### PR TITLE
Fix building without RTLSDR library

### DIFF
--- a/apps/dsd-cli/main.c
+++ b/apps/dsd-cli/main.c
@@ -37,9 +37,10 @@
 #include <signal.h>
 #include <stdlib.h>
 
+#include <dsd-neo/io/udp_input.h>
+
 #ifdef USE_RTLSDR
 #include <dsd-neo/io/rtl_stream_c.h>
-#include <dsd-neo/io/udp_input.h>
 #include <rtl-sdr.h>
 #endif
 

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -534,6 +534,7 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
             /* When DMR/dPMR/NXDN are enabled targets, proactively disable FM AGC/limiter which can
              * distort 2-level/FSK symbol envelopes and elevate early audio errors under marginal SNR.
              * Also force FLL/TED off for FSK paths. */
+#ifdef USE_RTLSDR
             if ((opts->frame_dmr == 1 || opts->frame_dpmr == 1 || opts->frame_nxdn48 == 1 || opts->frame_nxdn96 == 1)) {
                 extern void rtl_stream_set_fm_agc(int onoff);
                 extern void rtl_stream_set_fm_limiter(int onoff);
@@ -546,6 +547,7 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
                 rtl_stream_toggle_fll(0);
                 rtl_stream_toggle_ted(0);
             }
+#endif
             if (opts->frame_x2tdma == 1) {
                 if ((strcmp(synctest, X2TDMA_BS_DATA_SYNC) == 0) || (strcmp(synctest, X2TDMA_MS_DATA_SYNC) == 0)) {
                     state->carrier = 1;

--- a/src/protocol/m17/m17.c
+++ b/src/protocol/m17/m17.c
@@ -16,8 +16,8 @@
 #include <dsd-neo/runtime/log.h>
 #ifdef USE_RTLSDR
 #include <dsd-neo/io/rtl_stream_c.h>
-#include <dsd-neo/io/udp_input.h>
 #endif
+#include <dsd-neo/io/udp_input.h>
 
 //try to find a fancy lfsr or calculation for this and not an array if possible
 uint8_t m17_scramble[369] = {


### PR DESCRIPTION
if system doesn't have librtlsdr-dev build fails due to wrong set USE_RTLSDR macro. I've tried to fix that. 

```
-- Found PkgConfig: /usr/bin/pkg-config (found version "1.8.1")
-- Checking for module 'librtlsdr'
--   Package 'librtlsdr', required by 'virtual:world', not found
-- Could NOT find RTLSDR (missing: RTLSDR_LIBRARY RTLSDR_INCLUDE_DIR) 
-- Looking for wsyncup in /usr/lib/x86_64-linux-gnu/libcurses.so
```