### PR TITLE
NAC mismatch detection, false sync suppression, SPS hunt stabilization

### DIFF
--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -23,6 +23,16 @@ extern "C" {
 void dsd_frame_sync_reset_mod_state(void);
 
 /**
+ * @brief Return non-zero when alternate-protocol sync should be suppressed during active P25 trunking.
+ */
+int dsd_frame_sync_suppress_p25_alt_sync(const dsd_opts* opts, const dsd_state* state);
+
+/**
+ * @brief Return the number of no-sync buffer passes to dwell before SPS hunt advances.
+ */
+int dsd_frame_sync_sps_hunt_dwell_passes(const dsd_opts* opts, const dsd_state* state);
+
+/**
  * @brief Scan for a valid frame sync pattern and return its type.
  */
 int getFrameSync(dsd_opts* opts, dsd_state* state);

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -140,6 +140,11 @@ typedef struct {
     uint32_t grant_count;
     uint32_t cc_return_count;
 
+    // NAC mismatch tracking: counts consecutive frames where the decoded NAC
+    // differs from the expected CC NAC. After a threshold (3), triggers cc-lost
+    // to avoid dwelling on a wrong-NAC channel for seconds.
+    int nac_mismatch_count;
+
     // Initialized flag
     int initialized;
 } p25_sm_ctx_t;

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -141,8 +141,10 @@ typedef struct {
     uint32_t cc_return_count;
 
     // NAC mismatch tracking: counts consecutive frames where the decoded NAC
-    // differs from the expected CC NAC. After a threshold (3), triggers cc-lost
-    // to avoid dwelling on a wrong-NAC channel for seconds.
+    // differs from the expected CC NAC. After a threshold, triggers cc-lost
+    // to avoid dwelling on a wrong-NAC channel for seconds. Keep the expected
+    // NAC in the SM because state->p2_cc can be refreshed by each decoded P1 NID.
+    int expected_cc_nac;
     int nac_mismatch_count;
 
     // Initialized flag

--- a/src/dsp/CMakeLists.txt
+++ b/src/dsp/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(dsd-neo_dsp PRIVATE
 	  dsd_symbol.c
 	  p25p1_heuristics.c
 	  dsd_frame_sync.c
+	  frame_sync_policy.c
 	  sync_hamming.c
 	  dmr_sync.c
 	  sync_calibration.c

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -29,6 +29,7 @@
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/time_format.h>
 #include <dsd-neo/dsp/dmr_sync.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/dsp/symbol.h>
 #include <dsd-neo/dsp/sync_calibration.h>
 #include <dsd-neo/dsp/sync_hamming.h>
@@ -1079,11 +1080,11 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
             }
             //YSF sync
             strncpy(synctest20, (synctest_p - 19), 20);
-            /* Suppress YSF sync detection when already locked to a P25 signal.
+            /* Suppress YSF sync detection while P25 trunking is actively locked.
              * On noisy P25 frames, the 20-symbol YSF sync pattern can occasionally
              * match by chance, causing a brief false protocol switch that disrupts
-             * P25 decoding. Only check YSF when not currently tracking P25. */
-            if (opts->frame_ysf == 1 && !DSD_SYNC_IS_P25(state->lastsynctype)) {
+             * P25 decoding. */
+            if (opts->frame_ysf == 1 && !dsd_frame_sync_suppress_p25_alt_sync(opts, state)) {
                 if (strcmp(synctest20, FUSION_SYNC) == 0) {
                     printFrameSync(opts, state, "+YSF ", synctest_pos + 1, modulation);
                     state->carrier = 1;
@@ -1792,11 +1793,11 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
 
             }
 
-            /* Suppress D-STAR sync detection when already locked to a P25 signal.
+            /* Suppress D-STAR sync detection while P25 trunking is actively locked.
              * On noisy P25 frames, the 24-symbol D-STAR sync pattern can occasionally
              * match by chance, causing a brief false protocol switch that disrupts
-             * P25 decoding. Only check D-STAR when not currently tracking P25. */
-            else if (opts->frame_dstar == 1 && !DSD_SYNC_IS_P25(state->lastsynctype)) {
+             * P25 decoding. */
+            else if (opts->frame_dstar == 1 && !dsd_frame_sync_suppress_p25_alt_sync(opts, state)) {
                 if (strcmp(synctest, DSTAR_SYNC) == 0) {
                     state->carrier = 1;
                     state->offset = synctest_pos;
@@ -2027,15 +2028,11 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
                 /* Multi-rate SPS hunting: cycle through common symbol rates when no sync found.
                  * Tries 4800/2400/9600/6000 symbols/s (example SPS @48 kHz: 10/20/5/8).
                  * Only cycle if in auto mode and no carrier detected.
-                 * Uses a longer dwell (5 passes ≈ 0.8s) to give each rate more time to
-                 * acquire sync, reducing oscillation on marginal secondary CCs. */
+                 * Uses a longer P25 trunking CC dwell to reduce oscillation on marginal
+                 * secondary control channels without slowing other auto-detect modes. */
                 if (state->carrier == 0 && !opts->mod_cli_lock) {
                     state->sps_hunt_counter++;
-                    /* Cycle every ~5 buffer passes (~0.8 seconds at 4800 baud) to give
-                     * each symbol rate more time to acquire sync before switching. The
-                     * previous value of 3 (~0.5s) caused rapid oscillation on secondary
-                     * control channels with marginal signal. */
-                    if (state->sps_hunt_counter >= 5) {
+                    if (state->sps_hunt_counter >= dsd_frame_sync_sps_hunt_dwell_passes(opts, state)) {
                         state->sps_hunt_counter = 0;
                         /* Determine which protocols are enabled to decide SPS options */
                         int has_2400 = (opts->frame_nxdn48 == 1 || opts->frame_dpmr == 1);

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -1079,7 +1079,11 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
             }
             //YSF sync
             strncpy(synctest20, (synctest_p - 19), 20);
-            if (opts->frame_ysf == 1) {
+            /* Suppress YSF sync detection when already locked to a P25 signal.
+             * On noisy P25 frames, the 20-symbol YSF sync pattern can occasionally
+             * match by chance, causing a brief false protocol switch that disrupts
+             * P25 decoding. Only check YSF when not currently tracking P25. */
+            if (opts->frame_ysf == 1 && !DSD_SYNC_IS_P25(state->lastsynctype)) {
                 if (strcmp(synctest20, FUSION_SYNC) == 0) {
                     printFrameSync(opts, state, "+YSF ", synctest_pos + 1, modulation);
                     state->carrier = 1;
@@ -1788,7 +1792,11 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
 
             }
 
-            else if (opts->frame_dstar == 1) {
+            /* Suppress D-STAR sync detection when already locked to a P25 signal.
+             * On noisy P25 frames, the 24-symbol D-STAR sync pattern can occasionally
+             * match by chance, causing a brief false protocol switch that disrupts
+             * P25 decoding. Only check D-STAR when not currently tracking P25. */
+            else if (opts->frame_dstar == 1 && !DSD_SYNC_IS_P25(state->lastsynctype)) {
                 if (strcmp(synctest, DSTAR_SYNC) == 0) {
                     state->carrier = 1;
                     state->offset = synctest_pos;
@@ -2018,11 +2026,16 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
 
                 /* Multi-rate SPS hunting: cycle through common symbol rates when no sync found.
                  * Tries 4800/2400/9600/6000 symbols/s (example SPS @48 kHz: 10/20/5/8).
-                 * Only cycle if in auto mode and no carrier detected. */
+                 * Only cycle if in auto mode and no carrier detected.
+                 * Uses a longer dwell (5 passes ≈ 0.8s) to give each rate more time to
+                 * acquire sync, reducing oscillation on marginal secondary CCs. */
                 if (state->carrier == 0 && !opts->mod_cli_lock) {
                     state->sps_hunt_counter++;
-                    /* Cycle every ~3 buffer passes (~0.5 seconds at 4800 baud) */
-                    if (state->sps_hunt_counter >= 3) {
+                    /* Cycle every ~5 buffer passes (~0.8 seconds at 4800 baud) to give
+                     * each symbol rate more time to acquire sync before switching. The
+                     * previous value of 3 (~0.5s) caused rapid oscillation on secondary
+                     * control channels with marginal signal. */
+                    if (state->sps_hunt_counter >= 5) {
                         state->sps_hunt_counter = 0;
                         /* Determine which protocols are enabled to decide SPS options */
                         int has_2400 = (opts->frame_nxdn48 == 1 || opts->frame_dpmr == 1);

--- a/src/dsp/frame_sync_policy.c
+++ b/src/dsp/frame_sync_policy.c
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/frame_sync.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+int
+dsd_frame_sync_suppress_p25_alt_sync(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state) {
+        return 0;
+    }
+    return opts->p25_trunk == 1 && state->carrier == 1 && DSD_SYNC_IS_P25(state->lastsynctype);
+}
+
+int
+dsd_frame_sync_sps_hunt_dwell_passes(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state) {
+        return 3;
+    }
+    if (opts->p25_trunk == 1 && opts->p25_is_tuned == 0 && (opts->frame_p25p1 == 1 || opts->frame_p25p2 == 1)) {
+        return 5;
+    }
+    return 3;
+}

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -46,6 +46,61 @@ now_monotonic(void) {
     return dsd_time_now_monotonic_s();
 }
 
+static int
+p25_sm_valid_nac_int(int nac) {
+    return nac > 0 && nac != 0xFFF && nac <= 0xFFF;
+}
+
+static int
+p25_sm_valid_nac_ull(unsigned long long nac) {
+    return nac > 0 && nac != 0xFFFULL && nac <= 0xFFFULL;
+}
+
+static int
+p25_sm_current_cc_nac(const dsd_state* state) {
+    if (!state) {
+        return 0;
+    }
+    if (state->p2_hardset && p25_sm_valid_nac_ull(state->p2_cc)) {
+        return (int)state->p2_cc;
+    }
+    if (DSD_SYNC_IS_P25P2(state->lastsynctype) && p25_sm_valid_nac_ull(state->p2_cc)) {
+        return (int)state->p2_cc;
+    }
+    if (p25_sm_valid_nac_int(state->nac)) {
+        return state->nac;
+    }
+    if (p25_sm_valid_nac_ull(state->p2_cc)) {
+        return (int)state->p2_cc;
+    }
+    return 0;
+}
+
+static void
+p25_sm_set_expected_cc_nac(p25_sm_ctx_t* ctx, const dsd_state* state, int replace) {
+    if (!ctx || (!replace && p25_sm_valid_nac_int(ctx->expected_cc_nac))) {
+        return;
+    }
+    int nac = p25_sm_current_cc_nac(state);
+    if (p25_sm_valid_nac_int(nac)) {
+        ctx->expected_cc_nac = nac;
+        ctx->nac_mismatch_count = 0;
+    }
+}
+
+static void
+p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, const dsd_state* state, double tune_start_m) {
+    if (!ctx) {
+        return;
+    }
+    ctx->t_cc_sync_m = tune_start_m;
+    if (state && state->last_cc_sync_time_m > ctx->t_cc_sync_m) {
+        // CC retune hooks update this as tune metadata before any CC frame decodes.
+        // Absorb that timestamp now so the next watchdog tick does not relatch NAC from it.
+        ctx->t_cc_sync_m = state->last_cc_sync_time_m;
+    }
+}
+
 // Determine if channel is TDMA based on IDEN hints
 static inline int
 is_tdma_channel(const dsd_state* state, int channel) {
@@ -556,6 +611,7 @@ handle_cc_sync(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
         return;
     }
     ctx->t_cc_sync_m = now_monotonic();
+    p25_sm_set_expected_cc_nac(ctx, state, 1);
 
     if (ctx->state == P25_SM_IDLE || ctx->state == P25_SM_HUNTING) {
         set_state(ctx, opts, state, P25_SM_ON_CC, "cc-sync");
@@ -728,7 +784,9 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
     }
 
     // Return to CC
+    double tune_start_m = now_monotonic();
     dsd_trunk_tuning_hook_return_to_cc(opts, state);
+    p25_sm_start_cc_grace_after_tune(ctx, state, tune_start_m);
 
     // Transition to ON_CC state
     set_state(ctx, opts, state, P25_SM_ON_CC, "release->cc");
@@ -792,7 +850,7 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
         dsd_trunk_tuning_hook_tune_to_cc(opts, state, cand, sps);
         state->p25_cc_eval_freq = cand;
         state->p25_cc_eval_start_m = now_m;
-        ctx->t_cc_sync_m = now_m; // Reset grace timer
+        p25_sm_start_cc_grace_after_tune(ctx, state, now_m);
         set_state(ctx, opts, state, P25_SM_ON_CC, "hunt-cand");
         sm_log(opts, state, "hunt-cand-tune");
         return;
@@ -801,7 +859,7 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
     // Fall back to user-provided LCN list
     if (next_lcn_freq(state, &cand)) {
         dsd_trunk_tuning_hook_tune_to_cc(opts, state, cand, sps);
-        ctx->t_cc_sync_m = now_m; // Reset grace timer
+        p25_sm_start_cc_grace_after_tune(ctx, state, now_m);
         set_state(ctx, opts, state, P25_SM_ON_CC, "hunt-lcn");
         sm_log(opts, state, "hunt-lcn-tune");
         return;
@@ -871,6 +929,7 @@ p25_sm_init_ctx(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
             ctx->t_cc_sync_m = now_monotonic();
         }
         state->p25_sm_mode = DSD_P25_SM_MODE_ON_CC;
+        p25_sm_set_expected_cc_nac(ctx, state, 0);
     } else {
         ctx->state = P25_SM_IDLE;
         if (state) {
@@ -977,22 +1036,24 @@ p25_sm_tick_ctx(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
             // Sync CC timestamp from state if more recent
             if (state && state->last_cc_sync_time_m > ctx->t_cc_sync_m) {
                 ctx->t_cc_sync_m = state->last_cc_sync_time_m;
+                p25_sm_set_expected_cc_nac(ctx, state, 1);
+            } else {
+                p25_sm_set_expected_cc_nac(ctx, state, 0);
             }
-            // NAC mismatch detection: if we have a known CC NAC (from a
-            // previous Network Status Broadcast) and the current decoded NAC
-            // differs, treat it as cc-lost immediately rather than waiting for
-            // the grace timer. This handles the case where the decoder lands on
-            // a wrong frequency (e.g., adjacent traffic channel) and sees a
-            // different NAC. Ignore transient NAC values 0 and 0xFFF which
-            // appear during signal drops.
-            if (state && state->p2_cc != 0 && state->nac != 0
-                && state->nac != 0xFFF && state->nac != (int)state->p2_cc) {
+            // NAC mismatch detection: if we have a known CC NAC and the current
+            // decoded NAC differs, treat it as cc-lost immediately rather than
+            // waiting for the grace timer. This handles the case where the decoder
+            // lands on a wrong frequency (for example, an adjacent traffic channel).
+            // Ignore transient NAC values 0 and 0xFFF which appear during signal drops.
+            if (state && p25_sm_valid_nac_int(ctx->expected_cc_nac) && p25_sm_valid_nac_int(state->nac)
+                && state->nac != ctx->expected_cc_nac) {
                 ctx->nac_mismatch_count++;
                 if (ctx->nac_mismatch_count >= 3) {
-                    // 3 consecutive mismatches — this is a real wrong-channel situation
+                    // Three consecutive ticks is enough to distinguish a wrong channel
+                    // from a short transient without waiting for the full CC grace timer.
                     if (opts && opts->verbose > 0) {
                         fprintf(stderr, "\n[P25 SM] NAC mismatch: expected 0x%03llX, got 0x%03X (%d consecutive)\n",
-                                state->p2_cc, state->nac, ctx->nac_mismatch_count);
+                                (unsigned long long)ctx->expected_cc_nac, state->nac, ctx->nac_mismatch_count);
                     }
                     ctx->nac_mismatch_count = 0;
                     set_state(ctx, opts, state, P25_SM_HUNTING, "cc-lost-nac-mismatch");

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -978,6 +978,31 @@ p25_sm_tick_ctx(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
             if (state && state->last_cc_sync_time_m > ctx->t_cc_sync_m) {
                 ctx->t_cc_sync_m = state->last_cc_sync_time_m;
             }
+            // NAC mismatch detection: if we have a known CC NAC (from a
+            // previous Network Status Broadcast) and the current decoded NAC
+            // differs, treat it as cc-lost immediately rather than waiting for
+            // the grace timer. This handles the case where the decoder lands on
+            // a wrong frequency (e.g., adjacent traffic channel) and sees a
+            // different NAC. Ignore transient NAC values 0 and 0xFFF which
+            // appear during signal drops.
+            if (state && state->p2_cc != 0 && state->nac != 0
+                && state->nac != 0xFFF && state->nac != (int)state->p2_cc) {
+                ctx->nac_mismatch_count++;
+                if (ctx->nac_mismatch_count >= 3) {
+                    // 3 consecutive mismatches — this is a real wrong-channel situation
+                    if (opts && opts->verbose > 0) {
+                        fprintf(stderr, "\n[P25 SM] NAC mismatch: expected 0x%03llX, got 0x%03X (%d consecutive)\n",
+                                state->p2_cc, state->nac, ctx->nac_mismatch_count);
+                    }
+                    ctx->nac_mismatch_count = 0;
+                    set_state(ctx, opts, state, P25_SM_HUNTING, "cc-lost-nac-mismatch");
+                    ctx->t_hunt_try_m = now_m;
+                    try_next_cc(ctx, opts, state, now_m);
+                    break;
+                }
+            } else {
+                ctx->nac_mismatch_count = 0;
+            }
             // CC candidate evaluation cooldown: if we tuned to a candidate
             // and no CC activity appeared within the eval window, penalize
             if (state && state->p25_cc_eval_freq != 0) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1739,6 +1739,12 @@ target_include_directories(dsd-neo_test_dsp_sync_hamming PRIVATE ${PROJECT_SOURC
 target_link_libraries(dsd-neo_test_dsp_sync_hamming PRIVATE dsd-neo_dsp ${DSD_NEO_TEST_MATH_LIB})
 add_test(NAME DSP_SYNC_HAMMING COMMAND dsd-neo_test_dsp_sync_hamming)
 
+# Frame sync policy predicates for protocol suppression and SPS dwell.
+add_executable(dsd-neo_test_frame_sync_policy dsp/test_frame_sync_policy.c)
+target_include_directories(dsd-neo_test_frame_sync_policy PRIVATE ${PROJECT_SOURCE_DIR}/include)
+target_link_libraries(dsd-neo_test_frame_sync_policy PRIVATE dsd-neo_dsp ${DSD_NEO_TEST_MATH_LIB})
+add_test(NAME FRAME_SYNC_POLICY COMMAND dsd-neo_test_frame_sync_policy)
+
 # DMR sync warm start threshold initialization test
 add_executable(dsd-neo_test_sync_warm_start dsp/test_sync_warm_start.c)
 target_include_directories(dsd-neo_test_sync_warm_start PRIVATE ${PROJECT_SOURCE_DIR}/include)

--- a/tests/dsp/test_frame_sync_policy.c
+++ b/tests/dsp/test_frame_sync_policy.c
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static void
+reset(dsd_opts* opts, dsd_state* state) {
+    memset(opts, 0, sizeof(*opts));
+    memset(state, 0, sizeof(*state));
+}
+
+int
+main(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    state.lastsynctype = DSD_SYNC_P25P1_POS;
+    state.carrier = 1;
+    assert(dsd_frame_sync_suppress_p25_alt_sync(&opts, &state) == 0);
+
+    opts.p25_trunk = 1;
+    assert(dsd_frame_sync_suppress_p25_alt_sync(&opts, &state) == 1);
+
+    state.carrier = 0;
+    assert(dsd_frame_sync_suppress_p25_alt_sync(&opts, &state) == 0);
+
+    state.carrier = 1;
+    state.lastsynctype = DSD_SYNC_YSF_POS;
+    assert(dsd_frame_sync_suppress_p25_alt_sync(&opts, &state) == 0);
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) == 3);
+
+    opts.p25_trunk = 1;
+    assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) == 5);
+
+    opts.p25_is_tuned = 1;
+    assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) == 3);
+
+    opts.p25_is_tuned = 0;
+    opts.frame_p25p1 = 0;
+    opts.frame_p25p2 = 0;
+    assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) == 3);
+
+    return 0;
+}

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -22,6 +22,7 @@
 static long g_last_tuned_vc = 0;
 static long g_last_tuned_cc = 0;
 static int g_return_to_cc_called = 0;
+static int g_mark_cc_sync_on_cc_tune = 0;
 
 void
 trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
@@ -41,9 +42,11 @@ return_to_cc(dsd_opts* opts, dsd_state* state) {
 void
 trunk_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     (void)opts;
-    (void)state;
     (void)ted_sps;
     g_last_tuned_cc = freq;
+    if (g_mark_cc_sync_on_cc_tune) {
+        dsd_mark_cc_sync(state);
+    }
 }
 
 static void
@@ -128,6 +131,93 @@ main(void) {
         }
     }
     assert(found);
+
+    // 4) NAC mismatch uses the latched expected CC NAC, not mutable state->p2_cc.
+    static dsd_opts o5;
+    static dsd_state s5;
+    init_basic(&o5, &s5);
+    s5.p2_cc = 0x293;
+    s5.nac = 0x293;
+    s5.last_cc_sync_time_m = dsd_time_now_monotonic_s();
+
+    p25_sm_ctx_t ctx5;
+    p25_sm_init_ctx(&ctx5, &o5, &s5);
+    assert(ctx5.expected_cc_nac == 0x293);
+
+    (void)dsd_trunk_cc_candidates_add(&s5, 852000000, 0);
+    g_last_tuned_cc = 0;
+    s5.p2_cc = 0x123; // Simulate P1 NID refresh on the wrong channel.
+    s5.nac = 0x123;
+    p25_sm_tick_ctx(&ctx5, &o5, &s5);
+    assert(g_last_tuned_cc == 0);
+    assert(ctx5.nac_mismatch_count == 1);
+    assert(ctx5.expected_cc_nac == 0x293);
+
+    p25_sm_tick_ctx(&ctx5, &o5, &s5);
+    assert(g_last_tuned_cc == 0);
+    assert(ctx5.nac_mismatch_count == 2);
+
+    p25_sm_tick_ctx(&ctx5, &o5, &s5);
+    assert(g_last_tuned_cc == 852000000);
+    assert(ctx5.nac_mismatch_count == 0);
+    assert(ctx5.expected_cc_nac == 0x293);
+
+    // 5) A real CC activity timestamp advance may legitimately refresh the expected NAC.
+    static dsd_opts o6;
+    static dsd_state s6;
+    init_basic(&o6, &s6);
+    s6.p2_cc = 0x293;
+    s6.nac = 0x293;
+    s6.last_cc_sync_time_m = dsd_time_now_monotonic_s();
+
+    p25_sm_ctx_t ctx6;
+    p25_sm_init_ctx(&ctx6, &o6, &s6);
+    assert(ctx6.expected_cc_nac == 0x293);
+
+    s6.p2_cc = 0x321;
+    s6.nac = 0x321;
+    s6.last_cc_sync_time_m = ctx6.t_cc_sync_m + 1.0;
+    g_last_tuned_cc = 0;
+    p25_sm_tick_ctx(&ctx6, &o6, &s6);
+    assert(g_last_tuned_cc == 0);
+    assert(ctx6.nac_mismatch_count == 0);
+    assert(ctx6.expected_cc_nac == 0x321);
+
+    // 6) A CC retune hook timestamp must not relatch expected NAC before a decode.
+    static dsd_opts o7;
+    static dsd_state s7;
+    init_basic(&o7, &s7);
+    s7.p2_cc = 0x293;
+    s7.nac = 0x293;
+    s7.last_cc_sync_time_m = dsd_time_now_monotonic_s();
+
+    p25_sm_ctx_t ctx7;
+    p25_sm_init_ctx(&ctx7, &o7, &s7);
+    assert(ctx7.expected_cc_nac == 0x293);
+
+    (void)dsd_trunk_cc_candidates_add(&s7, 852000000, 0);
+    g_last_tuned_cc = 0;
+    g_mark_cc_sync_on_cc_tune = 1;
+    s7.p2_cc = 0x123;
+    s7.nac = 0x123;
+
+    p25_sm_tick_ctx(&ctx7, &o7, &s7);
+    assert(g_last_tuned_cc == 0);
+    assert(ctx7.nac_mismatch_count == 1);
+    p25_sm_tick_ctx(&ctx7, &o7, &s7);
+    assert(g_last_tuned_cc == 0);
+    assert(ctx7.nac_mismatch_count == 2);
+    p25_sm_tick_ctx(&ctx7, &o7, &s7);
+    assert(g_last_tuned_cc == 852000000);
+    assert(ctx7.nac_mismatch_count == 0);
+    assert(ctx7.expected_cc_nac == 0x293);
+
+    g_last_tuned_cc = 0;
+    p25_sm_tick_ctx(&ctx7, &o7, &s7);
+    assert(g_last_tuned_cc == 0);
+    assert(ctx7.nac_mismatch_count == 1);
+    assert(ctx7.expected_cc_nac == 0x293);
+    g_mark_cc_sync_on_cc_tune = 0;
 
     fprintf(stderr, "P25 SM core tests passed\n");
     return 0;


### PR DESCRIPTION
Three fixes for P25 trunked scanning stability, identified from debug logs on a Motorola P25 Phase 1 system with RTL-SDR R828D tuner.

**1. NAC mismatch detection in trunk state machine**
Files: p25_trunk_sm.c, p25_trunk_sm.h

When the decoder lands on a wrong frequency (e.g., adjacent traffic channel after a mis-tune), it sees a different NAC but the state machine only detects cc-lost via timestamp staleness after the full cc_grace window (5 seconds). During that time, every frame is duid:EE with frequent NID parity mismatches.

Added a nac_mismatch_count field to p25_sm_ctx_t and a check in the ON_CC tick handler that compares state->nac against state->p2_cc (the expected CC NAC from Network Status Broadcast). After 3 consecutive mismatches, triggers cc-lost-nac-mismatch and immediately hunts for the correct CC. Transient NAC values 0 and 0xFFF (which appear during signal drops) are ignored.

Reduces wrong-NAC dwell from ~7 seconds to under 1 second.

**2. False D-STAR/YSF sync suppression when locked to P25**
File: dsd_frame_sync.c

On noisy P25 frames, the 20-symbol YSF and 24-symbol D-STAR sync patterns occasionally match by chance, causing a brief false protocol switch that disrupts P25 decoding. Observed as Sync: +DSTAR VOICE and Sync: +YSF with garbage data in debug logs while actively tracking a P25 control channel.

Added !DSD_SYNC_IS_P25(state->lastsynctype) guards to both the YSF and D-STAR sync detection blocks. When the decoder is currently tracking a P25 signal, it skips YSF and D-STAR pattern matching entirely.

**3. SPS hunt cycle stabilization**
File: dsd_frame_sync.c

The multi-rate SPS hunting cycled every 3 buffer passes (~0.5 seconds), causing rapid oscillation between 4800 and 6000 sym/s on secondary control channels with marginal signal. This produced repeated ON_CC → HUNT → ON_CC cycles at startup (6+ cycles in 17 seconds observed).

Increased the cycle interval from 3 to 5 buffer passes (~0.8 seconds) to give each symbol rate more time to acquire sync before switching.

**Testing**
All three fixes validated on live air against the same Motorola P25 Phase 1 trunked system. Compared debug logs before and after across multiple sessions (~20 minutes total):

NAC mismatch episodes: eliminated (0 occurrences vs 1 sustained 7-second episode)
False D-STAR/YSF syncs: eliminated (0 vs 2 in previous logs)
SPS hunt cycles at startup: eliminated (1 normal cc-lost/hunt vs 6+ rapid oscillations)
Voice call grant/tune/decode/release cycle: working correctly throughout
No regressions in TSBK decoding, frequency mapping, or adjacent site tracking