### PR TITLE
Fix OpenSL ES audio resource leak in engine cleanup

### DIFF
--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -25,6 +25,7 @@
 #include <dsd-neo/io/rigctl_client.h>
 #include <dsd-neo/io/udp_input.h>
 #include <dsd-neo/io/udp_socket_connect.h>
+#include <dsd-neo/platform/audio.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/platform/timing.h>
@@ -1780,6 +1781,13 @@ dsd_engine_cleanup(dsd_opts* opts, dsd_state* state) {
     LOG_NOTICE("Total header errors: %i\n", state->debug_header_errors);
     LOG_NOTICE("Total irrecoverable header errors: %i\n", state->debug_header_critical_errors);
     LOG_NOTICE("Exiting.\n");
+
+    // Close audio streams so platform resources (OpenSL ES players, etc.) are freed.
+    // Without this, each engine run leaks player objects and eventually exhausts
+    // the OpenSL ES object pool ("Too many objects" / SL_RESULT_MEMORY_FAILURE).
+    closeAudioOutput(opts);
+    closeAudioInput(opts);
+    dsd_audio_cleanup();
 
     dsd_state_ext_free_all(state);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -695,6 +695,25 @@ else()
 endif()
 add_test(NAME ENGINE_NO_CARRIER_RESET COMMAND dsd-neo_test_engine_no_carrier_reset)
 
+add_executable(dsd-neo_test_engine_cleanup_audio engine/test_engine_cleanup_audio.c)
+target_include_directories(dsd-neo_test_engine_cleanup_audio PRIVATE ${PROJECT_SOURCE_DIR}/include)
+if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
+  target_link_libraries(dsd-neo_test_engine_cleanup_audio PRIVATE
+    "-Wl,--start-group"
+    dsd-neo_engine
+    "-Wl,--end-group"
+    ${LIBS}
+    dsd-neo_test_support
+  )
+else()
+  target_link_libraries(dsd-neo_test_engine_cleanup_audio PRIVATE
+    dsd-neo_engine
+    ${LIBS}
+    dsd-neo_test_support
+  )
+endif()
+add_test(NAME ENGINE_CLEANUP_AUDIO COMMAND dsd-neo_test_engine_cleanup_audio)
+
 add_executable(dsd-neo_test_runtime_config_user runtime/test_runtime_config_user.cpp)
 target_include_directories(dsd-neo_test_runtime_config_user PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(dsd-neo_test_runtime_config_user PRIVATE dsd-neo_runtime dsd-neo_test_support)

--- a/tests/engine/test_engine_cleanup_audio.c
+++ b/tests/engine/test_engine_cleanup_audio.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#define DSD_NEO_MAIN
+#include <dsd-neo/protocol/dmr/dmr_const.h>
+#include <dsd-neo/protocol/dstar/dstar_const.h>
+#include <dsd-neo/protocol/p25/p25p1_const.h>
+#include <dsd-neo/protocol/provoice/provoice_const.h>
+#include <dsd-neo/protocol/x2tdma/x2tdma_const.h>
+#undef DSD_NEO_MAIN
+
+#include <dsd-neo/core/init.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/engine/engine.h>
+#include <dsd-neo/platform/audio.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static int
+expect_true(const char* tag, int cond) {
+    if (!cond) {
+        fprintf(stderr, "%s failed\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+int
+ui_start(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    return 0;
+}
+
+void
+ui_stop(void) {}
+
+static int
+init_test_runtime(dsd_opts** opts_out, dsd_state** state_out) {
+    // dsd_state is multi-megabyte; keep it off the function stack.
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (opts == NULL || state == NULL) {
+        fprintf(stderr, "alloc-failed: runtime\n");
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    *opts_out = opts;
+    *state_out = state;
+    return 0;
+}
+
+static void
+free_test_runtime(dsd_opts* opts, dsd_state* state) {
+    if (state != NULL) {
+        freeState(state);
+    }
+    free(state);
+    free(opts);
+}
+
+int
+main(void) {
+    int rc = 0;
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+
+    // Test 1: audio stream pointers are NULL after cleanup.
+    // Allocate zeroed blocks to simulate open audio streams.
+    // dsd_audio_close() checks stream->handle before calling backend
+    // functions; a calloc'd block has handle==NULL so close() just free()s it.
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    opts->audio_out_stream = (dsd_audio_stream*)calloc(1, 64);
+    opts->audio_out_streamR = (dsd_audio_stream*)calloc(1, 64);
+    opts->audio_raw_out = (dsd_audio_stream*)calloc(1, 64);
+    opts->audio_in_stream = (dsd_audio_stream*)calloc(1, 64);
+
+    dsd_engine_cleanup(opts, state);
+
+    rc |= expect_true("audio_out_stream-null", opts->audio_out_stream == NULL);
+    rc |= expect_true("audio_out_streamR-null", opts->audio_out_streamR == NULL);
+    rc |= expect_true("audio_raw_out-null", opts->audio_raw_out == NULL);
+    rc |= expect_true("audio_in_stream-null", opts->audio_in_stream == NULL);
+
+    free_test_runtime(opts, state);
+    opts = NULL;
+    state = NULL;
+
+    // Test 2: cleanup with all-NULL audio pointers does not crash.
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    dsd_engine_cleanup(opts, state);
+
+    rc |= expect_true("null-safe-audio_out_stream", opts->audio_out_stream == NULL);
+    rc |= expect_true("null-safe-audio_out_streamR", opts->audio_out_streamR == NULL);
+    rc |= expect_true("null-safe-audio_raw_out", opts->audio_raw_out == NULL);
+    rc |= expect_true("null-safe-audio_in_stream", opts->audio_in_stream == NULL);
+
+    free_test_runtime(opts, state);
+    opts = NULL;
+    state = NULL;
+
+    // Test 3: double cleanup is idempotent (no crash or double-free).
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    dsd_engine_cleanup(opts, state);
+    dsd_engine_cleanup(opts, state);
+
+    rc |= expect_true("idempotent-audio_out_stream", opts->audio_out_stream == NULL);
+    rc |= expect_true("idempotent-audio_out_streamR", opts->audio_out_streamR == NULL);
+    rc |= expect_true("idempotent-audio_raw_out", opts->audio_raw_out == NULL);
+    rc |= expect_true("idempotent-audio_in_stream", opts->audio_in_stream == NULL);
+
+    free_test_runtime(opts, state);
+
+    if (rc == 0) {
+        printf("ENGINE_CLEANUP_AUDIO: OK\n");
+    }
+    return rc;
+}


### PR DESCRIPTION
### Summary

`dsd_engine_cleanup()` never closed audio streams or tore down the platform audio subsystem. On Android's OpenSL ES backend, each engine run leaked player objects until the fixed-size object pool was exhausted, causing `SL_RESULT_MEMORY_FAILURE` ("Too many objects") on subsequent runs.

### Root Cause

The function closes every other resource type (WAV files, sockets, RTL-SDR streams, MBE files) but was missing the audio stream teardown. On desktop backends (PulseAudio, PortAudio), leaked streams are reclaimed at process exit so the bug was invisible. OpenSL ES enforces a hard per-process object limit and does not reclaim objects until `SLObjectItf` is explicitly destroyed.

### Changes

**`src/engine/engine.c`**
- Added `closeAudioOutput(opts)`, `closeAudioInput(opts)`, and `dsd_audio_cleanup()` in `dsd_engine_cleanup()` after the final log messages and before `dsd_state_ext_free_all(state)`
- Added `#include <dsd-neo/platform/audio.h>` for `dsd_audio_cleanup()` declaration

**`tests/engine/test_engine_cleanup_audio.c`** (new)
- Stream pointers are NULL after cleanup (bug condition verification)
- Cleanup with all-NULL pointers does not crash (NULL-safety)
- Double cleanup is idempotent (no crash or double-free)

**`tests/CMakeLists.txt`**
- Registered `ENGINE_CLEANUP_AUDIO` test

### Testing

- `ENGINE_CLEANUP_AUDIO` passes all three test cases
- Full test suite: no regressions (273/274 pass; `FEC_BLOCK_CODES` failure is pre-existing)
Revert

