### PR TITLE
protocol(p25): handle queued and deny responses

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -656,6 +656,8 @@ struct dsd_state {
     unsigned int p25_sm_tune_count;      // number of VC tunes via SM
     unsigned int p25_sm_release_count;   // number of release requests via SM
     unsigned int p25_sm_cc_return_count; // number of actual returns to CC via SM
+    unsigned int p25_sm_queued_count;    ///< number of Queued Response (QUE_RSP) messages received
+    unsigned int p25_sm_deny_count;      ///< number of Deny Response (DENY_RSP) messages received
     // One-shot flag to force immediate return-to-CC on explicit MAC_END/IDLE
     // or policy events; cleared by the SM after handling
     int p25_sm_force_release;

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -380,7 +380,8 @@ void p25_sm_on_release(dsd_opts* opts, dsd_state* state);
 /**
  * @brief Notify the SM that a Queued Response (QUE_RSP) was received.
  *
- * If the SM is in TUNED state, triggers release with reason "queued-rsp".
+ * Requests a release with reason "queued-rsp"; the release path is idempotent
+ * unless the SM or legacy tune flags indicate a voice-channel tune is active.
  * Always increments the queued response telemetry counter.
  *
  * @param opts Decoder options.
@@ -394,7 +395,8 @@ void p25_sm_on_queued_response(dsd_opts* opts, dsd_state* state, int svc_type, i
 /**
  * @brief Notify the SM that a Deny Response (DENY_RSP) was received.
  *
- * If the SM is in TUNED state, triggers release with reason "deny-rsp".
+ * Requests a release with reason "deny-rsp"; the release path is idempotent
+ * unless the SM or legacy tune flags indicate a voice-channel tune is active.
  * Always increments the deny response telemetry counter.
  *
  * @param opts Decoder options.

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -378,6 +378,34 @@ void p25_sm_on_indiv_grant(dsd_opts* opts, dsd_state* state, int channel, int sv
 void p25_sm_on_release(dsd_opts* opts, dsd_state* state);
 
 /**
+ * @brief Notify the SM that a Queued Response (QUE_RSP) was received.
+ *
+ * If the SM is in TUNED state, triggers release with reason "queued-rsp".
+ * Always increments the queued response telemetry counter.
+ *
+ * @param opts Decoder options.
+ * @param state Decoder state.
+ * @param svc_type Service type from the QUE_RSP message.
+ * @param reason_code Reason code from the QUE_RSP message.
+ * @param target Target address from the QUE_RSP message.
+ */
+void p25_sm_on_queued_response(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target);
+
+/**
+ * @brief Notify the SM that a Deny Response (DENY_RSP) was received.
+ *
+ * If the SM is in TUNED state, triggers release with reason "deny-rsp".
+ * Always increments the deny response telemetry counter.
+ *
+ * @param opts Decoder options.
+ * @param state Decoder state.
+ * @param svc_type Service type from the DENY_RSP message.
+ * @param reason_code Reason code from the DENY_RSP message.
+ * @param target Target address from the DENY_RSP message.
+ */
+void p25_sm_on_deny_response(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target);
+
+/**
  * @brief Optional periodic heartbeat/tick for safety fallback.
  *
  * @param opts Decoder options.

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm_api.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm_api.h
@@ -20,6 +20,8 @@ typedef struct p25_sm_api {
     void (*on_neighbor_update)(dsd_opts* opts, dsd_state* state, const long* freqs, int count);
     int (*next_cc_candidate)(dsd_state* state, long* out_freq);
     void (*tick)(dsd_opts* opts, dsd_state* state);
+    void (*on_queued_response)(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target);
+    void (*on_deny_response)(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target);
 } p25_sm_api;
 
 void p25_sm_set_api(p25_sm_api api);

--- a/src/protocol/p25/p25_trunk_sm_wrappers.c
+++ b/src/protocol/p25/p25_trunk_sm_wrappers.c
@@ -11,6 +11,7 @@
  */
 
 #include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/state.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm_api.h>
@@ -156,4 +157,58 @@ p25_sm_tick(dsd_opts* opts, dsd_state* state) {
         return;
     }
     p25_sm_tick_default(opts, state);
+}
+
+/* ============================================================================
+ * Queued/Deny Response Wrappers
+ * ============================================================================ */
+
+static void
+p25_sm_on_queued_response_default(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target) {
+    (void)svc_type;
+    (void)reason_code;
+    (void)target;
+    if (!opts || !state) {
+        return;
+    }
+    state->p25_sm_queued_count++;
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    if (ctx && ctx->state == P25_SM_TUNED) {
+        p25_sm_release(ctx, opts, state, "queued-rsp");
+    }
+}
+
+void
+p25_sm_on_queued_response(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target) {
+    p25_sm_api api = p25_sm_get_api();
+    if (api.on_queued_response) {
+        api.on_queued_response(opts, state, svc_type, reason_code, target);
+        return;
+    }
+    p25_sm_on_queued_response_default(opts, state, svc_type, reason_code, target);
+}
+
+static void
+p25_sm_on_deny_response_default(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target) {
+    (void)svc_type;
+    (void)reason_code;
+    (void)target;
+    if (!opts || !state) {
+        return;
+    }
+    state->p25_sm_deny_count++;
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    if (ctx && ctx->state == P25_SM_TUNED) {
+        p25_sm_release(ctx, opts, state, "deny-rsp");
+    }
+}
+
+void
+p25_sm_on_deny_response(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target) {
+    p25_sm_api api = p25_sm_get_api();
+    if (api.on_deny_response) {
+        api.on_deny_response(opts, state, svc_type, reason_code, target);
+        return;
+    }
+    p25_sm_on_deny_response_default(opts, state, svc_type, reason_code, target);
 }

--- a/src/protocol/p25/p25_trunk_sm_wrappers.c
+++ b/src/protocol/p25/p25_trunk_sm_wrappers.c
@@ -172,10 +172,7 @@ p25_sm_on_queued_response_default(dsd_opts* opts, dsd_state* state, int svc_type
         return;
     }
     state->p25_sm_queued_count++;
-    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
-    if (ctx && ctx->state == P25_SM_TUNED) {
-        p25_sm_release(ctx, opts, state, "queued-rsp");
-    }
+    p25_sm_release(p25_sm_get_ctx(), opts, state, "queued-rsp");
 }
 
 void
@@ -197,10 +194,7 @@ p25_sm_on_deny_response_default(dsd_opts* opts, dsd_state* state, int svc_type, 
         return;
     }
     state->p25_sm_deny_count++;
-    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
-    if (ctx && ctx->state == P25_SM_TUNED) {
-        p25_sm_release(ctx, opts, state, "deny-rsp");
-    }
+    p25_sm_release(p25_sm_get_ctx(), opts, state, "deny-rsp");
 }
 
 void

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -44,44 +44,73 @@ static inline void dsd_append(char* dst, size_t dstsz, const char* src);
 /**
  * @brief Resolve a Queued Response reason code to a human-readable string.
  *
- * Reason codes are defined in TIA-102.AABC-B Annex C.
+ * Reason labels mirror sdrtrunk's QueuedResponseReason mapping.
  *
  * @param code The 8-bit reason code from octet 3.
- * @return Static string describing the reason, or NULL if unrecognized.
+ * @return Static string describing the reason.
  */
 static const char*
 p25_que_reason_str(uint8_t code) {
     switch (code) {
-        case 0x10: return "Requester Active";
-        case 0x20: return "Target Active";
-        case 0x2F: return "Target Queued";
-        case 0x30: return "Group Active";
-        case 0x40: return "No Channel Resources";
-        case 0x41: return "No Telephone Resources";
-        case 0x42: return "No Data Resources";
-        default: return NULL;
+        case 0x10: return "Requesting Unit Busy Other Service";
+        case 0x20: return "Target Unit Busy Other Service";
+        case 0x2F: return "Target Unit Queued This Call";
+        case 0x30: return "Target Group Currently Active";
+        case 0x40: return "Channel Resources Unavailable";
+        case 0x41: return "Telephone Resources Unavailable";
+        case 0x42: return "Data Resources Unavailable";
+        case 0x50: return "Superseding Service Currently Active";
+        default: break;
     }
+
+    if (code <= 0x7F) {
+        return "Reserved";
+    }
+
+    return "User/System Defined";
 }
 
 /**
  * @brief Resolve a Deny Response reason code to a human-readable string.
  *
- * Reason codes are defined in TIA-102.AABC-B Annex B.
+ * Reason labels mirror sdrtrunk's DenyReason mapping.
  *
  * @param code The 8-bit reason code from octet 3.
- * @return Static string describing the reason, or NULL if unrecognized.
+ * @return Static string describing the reason.
  */
 static const char*
 p25_deny_reason_str(uint8_t code) {
     switch (code) {
-        case 0x10: return "Requester Invalid";
-        case 0x20: return "Target Invalid";
-        case 0x2F: return "Target Refused";
-        case 0x30: return "Group Invalid";
-        case 0x60: return "Site Access Denied";
-        case 0xFF: return "Service Not Supported";
-        default: return NULL;
+        case 0x10: return "Requesting Unit Not Valid";
+        case 0x11: return "Requesting Unit Not Authorized";
+        case 0x20: return "Target Unit Not Valid";
+        case 0x21: return "Target Unit Not Authorized";
+        case 0x2F: return "Target Unit Refused Call";
+        case 0x30: return "Target Group Not Valid";
+        case 0x31: return "Target Group Not Authorized";
+        case 0x40: return "Invalid Dialing";
+        case 0x41: return "Telephone Number Not Authorized";
+        case 0x42: return "PSTN Not Valid";
+        case 0x50: return "Call Timeout";
+        case 0x51: return "Landline Terminated Call";
+        case 0x52: return "Subscriber Unit Terminated Call";
+        case 0x5F: return "Call Preempted";
+        case 0x60: return "Site Access Denial";
+        case 0x67: return "PTT Collide";
+        case 0x77: return "PTT Bonk";
+        case 0xF0: return "Call Options Not Valid For Service";
+        case 0xF1: return "Protection Service Option Not Valid";
+        case 0xF2: return "Duplex Service Option Not Valid";
+        case 0xF3: return "Circuit/Packet Mode Option Not Valid";
+        case 0xFF: return "System Does Not Support Service";
+        default: break;
     }
+
+    if (code <= 0x5E) {
+        return "Reserved";
+    }
+
+    return "User/System Defined";
 }
 
 /* Emit a compact JSON line for a P25 Phase 2 MAC PDU when enabled. */
@@ -2817,10 +2846,11 @@ process_MAC_VPDU(dsd_opts* opts, dsd_state* state, int type, unsigned long long 
             fprintf(stderr, "\n  Target Address: %d RF: 0x%X BER: 0x%X", ta, rf, ber);
         }
 
-        // Queued Response (MAC 0x61, TSBK 0x21) or Deny Response (MAC 0x67, TSBK 0x27)
-        // TIA-102.AABC-B §6.2.14 / §6.2.5
+        // Queued Response (MAC 0x61, TSBK 0x21) or Deny Response (MAC 0x67, TSBK 0x27).
+        // Field layout follows sdrtrunk's QueuedResponse/DenyResponse structures.
         if (MAC[1 + len_a] == 0x61 || MAC[1 + len_a] == 0x67) {
             int is_deny = (MAC[1 + len_a] == 0x67);
+            int has_addl_info = ((MAC[2 + len_a] & 0x80) != 0);
             int svc_type = (int)(MAC[2 + len_a] & 0x3F);
             int reason_code = (int)MAC[3 + len_a];
             int addl_info = (int)((MAC[4 + len_a] << 16) | (MAC[5 + len_a] << 8) | MAC[6 + len_a]);
@@ -2830,16 +2860,20 @@ process_MAC_VPDU(dsd_opts* opts, dsd_state* state, int type, unsigned long long 
                 is_deny ? p25_deny_reason_str((uint8_t)reason_code) : p25_que_reason_str((uint8_t)reason_code);
 
             fprintf(stderr, "\n %s Response", is_deny ? "Deny" : "Queued");
-            if (reason_str) {
-                fprintf(stderr, "\n  SVC [%02X] Reason [%s] Addl [%06X] Target [%d]", svc_type, reason_str, addl_info,
-                        target_addr);
-            } else {
-                fprintf(stderr, "\n  SVC [%02X] Reason [0x%02X] Addl [%06X] Target [%d]", svc_type, reason_code,
-                        addl_info, target_addr);
+            fprintf(stderr, "\n  SVC [%02X] Reason [%s]", svc_type, reason_str);
+            if (has_addl_info) {
+                fprintf(stderr, " Addl [%06X]", addl_info);
             }
+            fprintf(stderr, " Target [%d]", target_addr);
 
-            // Update active channel display
-            sprintf(state->active_channel[0], "%s Target: %d; ", is_deny ? "DENY" : "QUE", target_addr);
+            if (has_addl_info) {
+                snprintf(state->active_channel[0], sizeof state->active_channel[0],
+                         "%s Target: %d Reason: %s Info: %06X; ", is_deny ? "DENY" : "QUEUED", target_addr, reason_str,
+                         addl_info);
+            } else {
+                snprintf(state->active_channel[0], sizeof state->active_channel[0], "%s Target: %d Reason: %s; ",
+                         is_deny ? "DENY" : "QUEUED", target_addr, reason_str);
+            }
             state->last_active_time = time(NULL);
 
             // Notify the trunking state machine

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -41,6 +41,49 @@ static inline void dsd_append(char* dst, size_t dstsz, const char* src);
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 
+/**
+ * @brief Resolve a Queued Response reason code to a human-readable string.
+ *
+ * Reason codes are defined in TIA-102.AABC-B Annex C.
+ *
+ * @param code The 8-bit reason code from octet 3.
+ * @return Static string describing the reason, or NULL if unrecognized.
+ */
+static const char*
+p25_que_reason_str(uint8_t code) {
+    switch (code) {
+        case 0x10: return "Requester Active";
+        case 0x20: return "Target Active";
+        case 0x2F: return "Target Queued";
+        case 0x30: return "Group Active";
+        case 0x40: return "No Channel Resources";
+        case 0x41: return "No Telephone Resources";
+        case 0x42: return "No Data Resources";
+        default: return NULL;
+    }
+}
+
+/**
+ * @brief Resolve a Deny Response reason code to a human-readable string.
+ *
+ * Reason codes are defined in TIA-102.AABC-B Annex B.
+ *
+ * @param code The 8-bit reason code from octet 3.
+ * @return Static string describing the reason, or NULL if unrecognized.
+ */
+static const char*
+p25_deny_reason_str(uint8_t code) {
+    switch (code) {
+        case 0x10: return "Requester Invalid";
+        case 0x20: return "Target Invalid";
+        case 0x2F: return "Target Refused";
+        case 0x30: return "Group Invalid";
+        case 0x60: return "Site Access Denied";
+        case 0xFF: return "Service Not Supported";
+        default: return NULL;
+    }
+}
+
 /* Emit a compact JSON line for a P25 Phase 2 MAC PDU when enabled. */
 static void
 p25p2_emit_mac_json_if_enabled(dsd_state* state, int xch_type, uint8_t mfid, uint8_t opcode, int slot, int len_b,
@@ -2772,6 +2815,39 @@ process_MAC_VPDU(dsd_opts* opts, dsd_state* state, int type, unsigned long long 
             int ber = MAC[5 + len_a] & 0xF;
             fprintf(stderr, "\n Power Control Signal Quality");
             fprintf(stderr, "\n  Target Address: %d RF: 0x%X BER: 0x%X", ta, rf, ber);
+        }
+
+        // Queued Response (MAC 0x61, TSBK 0x21) or Deny Response (MAC 0x67, TSBK 0x27)
+        // TIA-102.AABC-B §6.2.14 / §6.2.5
+        if (MAC[1 + len_a] == 0x61 || MAC[1 + len_a] == 0x67) {
+            int is_deny = (MAC[1 + len_a] == 0x67);
+            int svc_type = (int)(MAC[2 + len_a] & 0x3F);
+            int reason_code = (int)MAC[3 + len_a];
+            int addl_info = (int)((MAC[4 + len_a] << 16) | (MAC[5 + len_a] << 8) | MAC[6 + len_a]);
+            int target_addr = (int)((MAC[7 + len_a] << 16) | (MAC[8 + len_a] << 8) | MAC[9 + len_a]);
+
+            const char* reason_str =
+                is_deny ? p25_deny_reason_str((uint8_t)reason_code) : p25_que_reason_str((uint8_t)reason_code);
+
+            fprintf(stderr, "\n %s Response", is_deny ? "Deny" : "Queued");
+            if (reason_str) {
+                fprintf(stderr, "\n  SVC [%02X] Reason [%s] Addl [%06X] Target [%d]", svc_type, reason_str, addl_info,
+                        target_addr);
+            } else {
+                fprintf(stderr, "\n  SVC [%02X] Reason [0x%02X] Addl [%06X] Target [%d]", svc_type, reason_code,
+                        addl_info, target_addr);
+            }
+
+            // Update active channel display
+            sprintf(state->active_channel[0], "%s Target: %d; ", is_deny ? "DENY" : "QUE", target_addr);
+            state->last_active_time = time(NULL);
+
+            // Notify the trunking state machine
+            if (is_deny) {
+                p25_sm_on_deny_response(opts, state, svc_type, reason_code, target_addr);
+            } else {
+                p25_sm_on_queued_response(opts, state, svc_type, reason_code, target_addr);
+            }
         }
 
     SKIPCALL:; //do nothing

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1879,6 +1879,12 @@ target_include_directories(dsd-neo_test_p25_p2_release_partial_audio PRIVATE ${P
 target_link_libraries(dsd-neo_test_p25_p2_release_partial_audio PRIVATE dsd-neo_proto_p25)
 add_test(NAME P25_P2_RELEASE_PARTIAL_AUDIO COMMAND dsd-neo_test_p25_p2_release_partial_audio)
 
+# P25 Queued/Deny Response decoding and SM notification
+add_executable(dsd-neo_test_p25_queued_deny_response protocol/p25/test_p25_queued_deny_response.c)
+target_include_directories(dsd-neo_test_p25_queued_deny_response PRIVATE ${PROJECT_SOURCE_DIR}/include)
+target_link_libraries(dsd-neo_test_p25_queued_deny_response PRIVATE dsd-neo_proto_p25 dsd-neo_test_support)
+add_test(NAME P25_QUEUED_DENY_RESPONSE COMMAND dsd-neo_test_p25_queued_deny_response)
+
 # Config system tests
 add_executable(dsd-neo_test_config_expand runtime/test_config_expand.cpp)
 target_include_directories(dsd-neo_test_config_expand PRIVATE ${PROJECT_SOURCE_DIR}/include)

--- a/tests/protocol/p25/test_p25_queued_deny_response.c
+++ b/tests/protocol/p25/test_p25_queued_deny_response.c
@@ -1,0 +1,707 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Unit tests for P25 Queued Response (0x61) and Deny Response (0x67) handling.
+ * Tests field extraction, reason code lookup, SM notification, and active
+ * channel display via the process_MAC_VPDU() entry point.
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm_api.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+struct RtlSdrContext;
+
+/* External entry point under test */
+void process_MAC_VPDU(dsd_opts* opts, dsd_state* state, int type, unsigned long long int MAC[24]);
+
+/* SM wrapper functions under test */
+void p25_sm_on_queued_response(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target);
+void p25_sm_on_deny_response(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target);
+
+/* Stubs for external hooks referenced by linked modules */
+bool
+SetFreq(int sockfd, long int freq) {
+    (void)sockfd;
+    (void)freq;
+    return false;
+}
+
+bool
+SetModulation(int sockfd, int bandwidth) {
+    (void)sockfd;
+    (void)bandwidth;
+    return false;
+}
+
+void
+return_to_cc(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+struct RtlSdrContext* g_rtl_ctx = 0;
+
+int
+rtl_stream_tune(struct RtlSdrContext* ctx, uint32_t center_freq_hz) {
+    (void)ctx;
+    (void)center_freq_hz;
+    return 0;
+}
+
+/* Alias decode helpers referenced by MAC VPDU handler */
+void
+unpack_byte_array_into_bit_array(uint8_t* input, uint8_t* output, int len) {
+    (void)input;
+    (void)output;
+    (void)len;
+}
+
+void
+apx_embedded_alias_header_phase2(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t* lc_bits) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)lc_bits;
+}
+
+void
+apx_embedded_alias_blocks_phase2(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t* lc_bits) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)lc_bits;
+}
+
+void
+l3h_embedded_alias_decode(dsd_opts* opts, dsd_state* state, uint8_t slot, int16_t len, uint8_t* input) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)len;
+    (void)input;
+}
+
+void
+nmea_harris(dsd_opts* opts, dsd_state* state, uint8_t* input, uint32_t src, int slot) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)src;
+    (void)slot;
+}
+
+/* ============================================================================
+ * SM API override tracking for tests
+ * ============================================================================ */
+
+static int g_queued_calls;
+static int g_deny_calls;
+static int g_last_svc_type;
+static int g_last_reason_code;
+static int g_last_target;
+
+static void
+fake_on_queued_response(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target) {
+    (void)opts;
+    (void)state;
+    g_queued_calls++;
+    g_last_svc_type = svc_type;
+    g_last_reason_code = reason_code;
+    g_last_target = target;
+}
+
+static void
+fake_on_deny_response(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target) {
+    (void)opts;
+    (void)state;
+    g_deny_calls++;
+    g_last_svc_type = svc_type;
+    g_last_reason_code = reason_code;
+    g_last_target = target;
+}
+
+static p25_sm_api
+sm_test_api(void) {
+    p25_sm_api api;
+    memset(&api, 0, sizeof(api));
+    api.on_queued_response = fake_on_queued_response;
+    api.on_deny_response = fake_on_deny_response;
+    return api;
+}
+
+static void
+reset_tracking(void) {
+    g_queued_calls = 0;
+    g_deny_calls = 0;
+    g_last_svc_type = -1;
+    g_last_reason_code = -1;
+    g_last_target = -1;
+}
+
+/* ============================================================================
+ * Helper: build a QUE/DENY MAC PDU
+ * ============================================================================ */
+
+static void
+build_que_deny_mac(unsigned long long MAC[24], int is_deny, int svc_type, int reason_code, int addl_info,
+                   int target_addr) {
+    memset(MAC, 0, 24 * sizeof(unsigned long long));
+    MAC[0] = 0x07;                                        // TSBK marker (len_b = 10)
+    MAC[1] = (unsigned long long)(is_deny ? 0x67 : 0x61); // opcode
+    MAC[2] = (unsigned long long)(svc_type & 0x3F);       // AIV=0, Service_Type
+    MAC[3] = (unsigned long long)(reason_code & 0xFF);
+    MAC[4] = (unsigned long long)((addl_info >> 16) & 0xFF);
+    MAC[5] = (unsigned long long)((addl_info >> 8) & 0xFF);
+    MAC[6] = (unsigned long long)(addl_info & 0xFF);
+    MAC[7] = (unsigned long long)((target_addr >> 16) & 0xFF);
+    MAC[8] = (unsigned long long)((target_addr >> 8) & 0xFF);
+    MAC[9] = (unsigned long long)(target_addr & 0xFF);
+}
+
+/* ============================================================================
+ * Test: QUE_RSP field extraction with known payload
+ * ============================================================================ */
+
+static int
+test_que_rsp_field_extraction_known_payload(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+
+    reset_tracking();
+    p25_sm_set_api(sm_test_api());
+
+    unsigned long long MAC[24];
+    // SVC=0x15, Reason=0x20, Addl=0x123456, Target=0xABCDEF (11259375)
+    build_que_deny_mac(MAC, 0, 0x15, 0x20, 0x123456, 0xABCDEF);
+
+    process_MAC_VPDU(&opts, &st, 0 /*FACCH*/, MAC);
+
+    int rc = 0;
+    if (g_queued_calls != 1) {
+        fprintf(stderr, "FAIL: test_que_rsp_field_extraction: expected 1 queued call, got %d\n", g_queued_calls);
+        rc = 1;
+    }
+    if (g_last_svc_type != 0x15) {
+        fprintf(stderr, "FAIL: test_que_rsp_field_extraction: svc_type expected 0x15, got 0x%02X\n", g_last_svc_type);
+        rc = 1;
+    }
+    if (g_last_reason_code != 0x20) {
+        fprintf(stderr, "FAIL: test_que_rsp_field_extraction: reason_code expected 0x20, got 0x%02X\n",
+                g_last_reason_code);
+        rc = 1;
+    }
+    if (g_last_target != 0xABCDEF) {
+        fprintf(stderr, "FAIL: test_que_rsp_field_extraction: target expected 0xABCDEF, got 0x%06X\n", g_last_target);
+        rc = 1;
+    }
+
+    p25_sm_reset_api();
+    return rc;
+}
+
+/* ============================================================================
+ * Test: DENY_RSP field extraction with known payload
+ * ============================================================================ */
+
+static int
+test_deny_rsp_field_extraction_known_payload(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+
+    reset_tracking();
+    p25_sm_set_api(sm_test_api());
+
+    unsigned long long MAC[24];
+    // SVC=0x3F, Reason=0xFF, Addl=0xFEDCBA, Target=0x000001
+    build_que_deny_mac(MAC, 1, 0x3F, 0xFF, 0xFEDCBA, 0x000001);
+
+    process_MAC_VPDU(&opts, &st, 0 /*FACCH*/, MAC);
+
+    int rc = 0;
+    if (g_deny_calls != 1) {
+        fprintf(stderr, "FAIL: test_deny_rsp_field_extraction: expected 1 deny call, got %d\n", g_deny_calls);
+        rc = 1;
+    }
+    if (g_last_svc_type != 0x3F) {
+        fprintf(stderr, "FAIL: test_deny_rsp_field_extraction: svc_type expected 0x3F, got 0x%02X\n", g_last_svc_type);
+        rc = 1;
+    }
+    if (g_last_reason_code != 0xFF) {
+        fprintf(stderr, "FAIL: test_deny_rsp_field_extraction: reason_code expected 0xFF, got 0x%02X\n",
+                g_last_reason_code);
+        rc = 1;
+    }
+    if (g_last_target != 0x000001) {
+        fprintf(stderr, "FAIL: test_deny_rsp_field_extraction: target expected 0x000001, got 0x%06X\n", g_last_target);
+        rc = 1;
+    }
+
+    p25_sm_reset_api();
+    return rc;
+}
+
+/* ============================================================================
+ * Test: Queued reason code lookup — all known codes
+ * ============================================================================ */
+
+static int
+test_que_reason_code_lookup_all_known(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    /* Test each known queued reason code by checking active_channel output */
+    struct {
+        int code;
+        const char* expected_substr;
+    } cases[] = {
+        {0x10, "Requester Active"},  {0x20, "Target Active"},        {0x2F, "Target Queued"},
+        {0x30, "Group Active"},      {0x40, "No Channel Resources"}, {0x41, "No Telephone Resources"},
+        {0x42, "No Data Resources"},
+    };
+
+    /* We verify reason codes by checking stderr output. Since we can't easily
+     * capture stderr in this test framework, we verify the SM callback receives
+     * the correct reason code value and that active_channel is set. */
+    for (int i = 0; i < (int)(sizeof(cases) / sizeof(cases[0])); i++) {
+        memset(&opts, 0, sizeof opts);
+        memset(&st, 0, sizeof st);
+        reset_tracking();
+        p25_sm_set_api(sm_test_api());
+
+        unsigned long long MAC[24];
+        build_que_deny_mac(MAC, 0, 0x01, cases[i].code, 0, 12345);
+        process_MAC_VPDU(&opts, &st, 0, MAC);
+
+        if (g_last_reason_code != cases[i].code) {
+            fprintf(stderr, "FAIL: test_que_reason_code[0x%02X]: reason_code mismatch got 0x%02X\n", cases[i].code,
+                    g_last_reason_code);
+            rc = 1;
+        }
+        /* Verify active_channel contains "QUE" */
+        if (strstr(st.active_channel[0], "QUE") == NULL) {
+            fprintf(stderr, "FAIL: test_que_reason_code[0x%02X]: active_channel missing 'QUE': '%s'\n", cases[i].code,
+                    st.active_channel[0]);
+            rc = 1;
+        }
+        p25_sm_reset_api();
+    }
+
+    return rc;
+}
+
+/* ============================================================================
+ * Test: Deny reason code lookup — all known codes
+ * ============================================================================ */
+
+static int
+test_deny_reason_code_lookup_all_known(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    struct {
+        int code;
+        const char* expected_substr;
+    } cases[] = {
+        {0x10, "Requester Invalid"}, {0x20, "Target Invalid"},     {0x2F, "Target Refused"},
+        {0x30, "Group Invalid"},     {0x60, "Site Access Denied"}, {0xFF, "Service Not Supported"},
+    };
+
+    for (int i = 0; i < (int)(sizeof(cases) / sizeof(cases[0])); i++) {
+        memset(&opts, 0, sizeof opts);
+        memset(&st, 0, sizeof st);
+        reset_tracking();
+        p25_sm_set_api(sm_test_api());
+
+        unsigned long long MAC[24];
+        build_que_deny_mac(MAC, 1, 0x02, cases[i].code, 0, 54321);
+        process_MAC_VPDU(&opts, &st, 0, MAC);
+
+        if (g_last_reason_code != cases[i].code) {
+            fprintf(stderr, "FAIL: test_deny_reason_code[0x%02X]: reason_code mismatch got 0x%02X\n", cases[i].code,
+                    g_last_reason_code);
+            rc = 1;
+        }
+        /* Verify active_channel contains "DENY" */
+        if (strstr(st.active_channel[0], "DENY") == NULL) {
+            fprintf(stderr, "FAIL: test_deny_reason_code[0x%02X]: active_channel missing 'DENY': '%s'\n", cases[i].code,
+                    st.active_channel[0]);
+            rc = 1;
+        }
+        p25_sm_reset_api();
+    }
+
+    return rc;
+}
+
+/* ============================================================================
+ * Test: Unrecognized queued reason code produces hex in active_channel
+ * ============================================================================ */
+
+static int
+test_que_rsp_unrecognized_reason_hex(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+    reset_tracking();
+    p25_sm_set_api(sm_test_api());
+
+    unsigned long long MAC[24];
+    // Use reason code 0xAB which is not in the queued lookup table
+    build_que_deny_mac(MAC, 0, 0x01, 0xAB, 0, 999);
+    process_MAC_VPDU(&opts, &st, 0, MAC);
+
+    int rc = 0;
+    if (g_last_reason_code != 0xAB) {
+        fprintf(stderr, "FAIL: test_que_rsp_unrecognized_reason: expected 0xAB, got 0x%02X\n", g_last_reason_code);
+        rc = 1;
+    }
+    /* The handler should still set active_channel with QUE */
+    if (strstr(st.active_channel[0], "QUE") == NULL) {
+        fprintf(stderr, "FAIL: test_que_rsp_unrecognized_reason: active_channel missing 'QUE': '%s'\n",
+                st.active_channel[0]);
+        rc = 1;
+    }
+
+    p25_sm_reset_api();
+    return rc;
+}
+
+/* ============================================================================
+ * Test: Unrecognized deny reason code produces hex in active_channel
+ * ============================================================================ */
+
+static int
+test_deny_rsp_unrecognized_reason_hex(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+    reset_tracking();
+    p25_sm_set_api(sm_test_api());
+
+    unsigned long long MAC[24];
+    // Use reason code 0x99 which is not in the deny lookup table
+    build_que_deny_mac(MAC, 1, 0x02, 0x99, 0, 888);
+    process_MAC_VPDU(&opts, &st, 0, MAC);
+
+    int rc = 0;
+    if (g_last_reason_code != 0x99) {
+        fprintf(stderr, "FAIL: test_deny_rsp_unrecognized_reason: expected 0x99, got 0x%02X\n", g_last_reason_code);
+        rc = 1;
+    }
+    if (strstr(st.active_channel[0], "DENY") == NULL) {
+        fprintf(stderr, "FAIL: test_deny_rsp_unrecognized_reason: active_channel missing 'DENY': '%s'\n",
+                st.active_channel[0]);
+        rc = 1;
+    }
+
+    p25_sm_reset_api();
+    return rc;
+}
+
+/* ============================================================================
+ * Test: SM queued response releases when TUNED
+ * ============================================================================ */
+
+static int
+test_sm_queued_releases_when_tuned(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+
+    /* Force SM into TUNED state */
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->state = P25_SM_TUNED;
+    ctx->initialized = 1;
+
+    /* Reset API to default (no override) so real SM logic runs */
+    p25_sm_reset_api();
+
+    p25_sm_on_queued_response(&opts, &st, 0x01, 0x20, 12345);
+
+    int rc = 0;
+    if (st.p25_sm_queued_count != 1) {
+        fprintf(stderr, "FAIL: test_sm_queued_releases_when_tuned: counter expected 1, got %u\n",
+                st.p25_sm_queued_count);
+        rc = 1;
+    }
+    /* After release, SM should be back to ON_CC (or IDLE depending on implementation) */
+    if (ctx->state == P25_SM_TUNED) {
+        fprintf(stderr, "FAIL: test_sm_queued_releases_when_tuned: SM still in TUNED state\n");
+        rc = 1;
+    }
+
+    return rc;
+}
+
+/* ============================================================================
+ * Test: SM deny response releases when TUNED
+ * ============================================================================ */
+
+static int
+test_sm_deny_releases_when_tuned(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->state = P25_SM_TUNED;
+    ctx->initialized = 1;
+
+    p25_sm_reset_api();
+
+    p25_sm_on_deny_response(&opts, &st, 0x02, 0xFF, 54321);
+
+    int rc = 0;
+    if (st.p25_sm_deny_count != 1) {
+        fprintf(stderr, "FAIL: test_sm_deny_releases_when_tuned: counter expected 1, got %u\n", st.p25_sm_deny_count);
+        rc = 1;
+    }
+    if (ctx->state == P25_SM_TUNED) {
+        fprintf(stderr, "FAIL: test_sm_deny_releases_when_tuned: SM still in TUNED state\n");
+        rc = 1;
+    }
+
+    return rc;
+}
+
+/* ============================================================================
+ * Test: SM queued response no-op when ON_CC
+ * ============================================================================ */
+
+static int
+test_sm_queued_noop_when_on_cc(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->state = P25_SM_ON_CC;
+    ctx->initialized = 1;
+
+    p25_sm_reset_api();
+
+    p25_sm_on_queued_response(&opts, &st, 0x01, 0x10, 100);
+
+    int rc = 0;
+    if (st.p25_sm_queued_count != 1) {
+        fprintf(stderr, "FAIL: test_sm_queued_noop_when_on_cc: counter expected 1, got %u\n", st.p25_sm_queued_count);
+        rc = 1;
+    }
+    if (ctx->state != P25_SM_ON_CC) {
+        fprintf(stderr, "FAIL: test_sm_queued_noop_when_on_cc: SM state changed from ON_CC\n");
+        rc = 1;
+    }
+
+    return rc;
+}
+
+/* ============================================================================
+ * Test: SM deny response no-op when ON_CC
+ * ============================================================================ */
+
+static int
+test_sm_deny_noop_when_on_cc(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->state = P25_SM_ON_CC;
+    ctx->initialized = 1;
+
+    p25_sm_reset_api();
+
+    p25_sm_on_deny_response(&opts, &st, 0x02, 0x60, 200);
+
+    int rc = 0;
+    if (st.p25_sm_deny_count != 1) {
+        fprintf(stderr, "FAIL: test_sm_deny_noop_when_on_cc: counter expected 1, got %u\n", st.p25_sm_deny_count);
+        rc = 1;
+    }
+    if (ctx->state != P25_SM_ON_CC) {
+        fprintf(stderr, "FAIL: test_sm_deny_noop_when_on_cc: SM state changed from ON_CC\n");
+        rc = 1;
+    }
+
+    return rc;
+}
+
+/* ============================================================================
+ * Test: SM queued counter increments regardless of state
+ * ============================================================================ */
+
+static int
+test_sm_queued_counter_increments(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->state = P25_SM_IDLE;
+    ctx->initialized = 1;
+
+    p25_sm_reset_api();
+
+    p25_sm_on_queued_response(&opts, &st, 0x01, 0x10, 100);
+    p25_sm_on_queued_response(&opts, &st, 0x01, 0x20, 200);
+    p25_sm_on_queued_response(&opts, &st, 0x01, 0x30, 300);
+
+    int rc = 0;
+    if (st.p25_sm_queued_count != 3) {
+        fprintf(stderr, "FAIL: test_sm_queued_counter_increments: expected 3, got %u\n", st.p25_sm_queued_count);
+        rc = 1;
+    }
+
+    return rc;
+}
+
+/* ============================================================================
+ * Test: SM deny counter increments regardless of state
+ * ============================================================================ */
+
+static int
+test_sm_deny_counter_increments(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->state = P25_SM_HUNTING;
+    ctx->initialized = 1;
+
+    p25_sm_reset_api();
+
+    p25_sm_on_deny_response(&opts, &st, 0x02, 0x20, 100);
+    p25_sm_on_deny_response(&opts, &st, 0x02, 0x60, 200);
+
+    int rc = 0;
+    if (st.p25_sm_deny_count != 2) {
+        fprintf(stderr, "FAIL: test_sm_deny_counter_increments: expected 2, got %u\n", st.p25_sm_deny_count);
+        rc = 1;
+    }
+
+    return rc;
+}
+
+/* ============================================================================
+ * Test: Active channel display contains "QUE" and target
+ * ============================================================================ */
+
+static int
+test_active_channel_que_format(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+    reset_tracking();
+    p25_sm_set_api(sm_test_api());
+
+    unsigned long long MAC[24];
+    build_que_deny_mac(MAC, 0, 0x01, 0x40, 0, 67890);
+    process_MAC_VPDU(&opts, &st, 0, MAC);
+
+    int rc = 0;
+    if (strstr(st.active_channel[0], "QUE") == NULL) {
+        fprintf(stderr, "FAIL: test_active_channel_que_format: missing 'QUE' in '%s'\n", st.active_channel[0]);
+        rc = 1;
+    }
+    if (strstr(st.active_channel[0], "67890") == NULL) {
+        fprintf(stderr, "FAIL: test_active_channel_que_format: missing '67890' in '%s'\n", st.active_channel[0]);
+        rc = 1;
+    }
+
+    p25_sm_reset_api();
+    return rc;
+}
+
+/* ============================================================================
+ * Test: Active channel display contains "DENY" and target
+ * ============================================================================ */
+
+static int
+test_active_channel_deny_format(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+    reset_tracking();
+    p25_sm_set_api(sm_test_api());
+
+    unsigned long long MAC[24];
+    build_que_deny_mac(MAC, 1, 0x02, 0x60, 0, 12345);
+    process_MAC_VPDU(&opts, &st, 0, MAC);
+
+    int rc = 0;
+    if (strstr(st.active_channel[0], "DENY") == NULL) {
+        fprintf(stderr, "FAIL: test_active_channel_deny_format: missing 'DENY' in '%s'\n", st.active_channel[0]);
+        rc = 1;
+    }
+    if (strstr(st.active_channel[0], "12345") == NULL) {
+        fprintf(stderr, "FAIL: test_active_channel_deny_format: missing '12345' in '%s'\n", st.active_channel[0]);
+        rc = 1;
+    }
+
+    p25_sm_reset_api();
+    return rc;
+}
+
+/* ============================================================================
+ * main
+ * ============================================================================ */
+
+int
+main(void) {
+    int rc = 0;
+
+    rc |= test_que_rsp_field_extraction_known_payload();
+    rc |= test_deny_rsp_field_extraction_known_payload();
+    rc |= test_que_reason_code_lookup_all_known();
+    rc |= test_deny_reason_code_lookup_all_known();
+    rc |= test_que_rsp_unrecognized_reason_hex();
+    rc |= test_deny_rsp_unrecognized_reason_hex();
+    rc |= test_sm_queued_releases_when_tuned();
+    rc |= test_sm_deny_releases_when_tuned();
+    rc |= test_sm_queued_noop_when_on_cc();
+    rc |= test_sm_deny_noop_when_on_cc();
+    rc |= test_sm_queued_counter_increments();
+    rc |= test_sm_deny_counter_increments();
+    rc |= test_active_channel_que_format();
+    rc |= test_active_channel_deny_format();
+
+    if (rc == 0) {
+        fprintf(stderr, "All P25 queued/deny response tests passed.\n");
+    }
+    return rc;
+}

--- a/tests/protocol/p25/test_p25_queued_deny_response.c
+++ b/tests/protocol/p25/test_p25_queued_deny_response.c
@@ -155,12 +155,12 @@ reset_tracking(void) {
  * ============================================================================ */
 
 static void
-build_que_deny_mac(unsigned long long MAC[24], int is_deny, int svc_type, int reason_code, int addl_info,
-                   int target_addr) {
+build_que_deny_mac_aii(unsigned long long MAC[24], int is_deny, int svc_type, int reason_code, int addl_info,
+                       int target_addr, int has_addl_info) {
     memset(MAC, 0, 24 * sizeof(unsigned long long));
-    MAC[0] = 0x07;                                        // TSBK marker (len_b = 10)
-    MAC[1] = (unsigned long long)(is_deny ? 0x67 : 0x61); // opcode
-    MAC[2] = (unsigned long long)(svc_type & 0x3F);       // AIV=0, Service_Type
+    MAC[0] = 0x07;                                                                 // TSBK marker
+    MAC[1] = (unsigned long long)(is_deny ? 0x67 : 0x61);                          // opcode
+    MAC[2] = (unsigned long long)((svc_type & 0x3F) | (has_addl_info ? 0x80 : 0)); // AII, Service_Type
     MAC[3] = (unsigned long long)(reason_code & 0xFF);
     MAC[4] = (unsigned long long)((addl_info >> 16) & 0xFF);
     MAC[5] = (unsigned long long)((addl_info >> 8) & 0xFF);
@@ -168,6 +168,12 @@ build_que_deny_mac(unsigned long long MAC[24], int is_deny, int svc_type, int re
     MAC[7] = (unsigned long long)((target_addr >> 16) & 0xFF);
     MAC[8] = (unsigned long long)((target_addr >> 8) & 0xFF);
     MAC[9] = (unsigned long long)(target_addr & 0xFF);
+}
+
+static void
+build_que_deny_mac(unsigned long long MAC[24], int is_deny, int svc_type, int reason_code, int addl_info,
+                   int target_addr) {
+    build_que_deny_mac_aii(MAC, is_deny, svc_type, reason_code, addl_info, target_addr, addl_info != 0);
 }
 
 /* ============================================================================
@@ -257,7 +263,7 @@ test_deny_rsp_field_extraction_known_payload(void) {
 }
 
 /* ============================================================================
- * Test: Queued reason code lookup — all known codes
+ * Test: Queued reason code lookup -- known codes and ranges
  * ============================================================================ */
 
 static int
@@ -266,19 +272,24 @@ test_que_reason_code_lookup_all_known(void) {
     static dsd_state st;
     int rc = 0;
 
-    /* Test each known queued reason code by checking active_channel output */
     struct {
         int code;
         const char* expected_substr;
     } cases[] = {
-        {0x10, "Requester Active"},  {0x20, "Target Active"},        {0x2F, "Target Queued"},
-        {0x30, "Group Active"},      {0x40, "No Channel Resources"}, {0x41, "No Telephone Resources"},
-        {0x42, "No Data Resources"},
+        {0x10, "Requesting Unit Busy Other Service"},
+        {0x20, "Target Unit Busy Other Service"},
+        {0x2F, "Target Unit Queued This Call"},
+        {0x30, "Target Group Currently Active"},
+        {0x40, "Channel Resources Unavailable"},
+        {0x41, "Telephone Resources Unavailable"},
+        {0x42, "Data Resources Unavailable"},
+        {0x50, "Superseding Service Currently Active"},
+        {0x00, "Reserved"},
+        {0x7F, "Reserved"},
+        {0x80, "User/System Defined"},
+        {0xAB, "User/System Defined"},
     };
 
-    /* We verify reason codes by checking stderr output. Since we can't easily
-     * capture stderr in this test framework, we verify the SM callback receives
-     * the correct reason code value and that active_channel is set. */
     for (int i = 0; i < (int)(sizeof(cases) / sizeof(cases[0])); i++) {
         memset(&opts, 0, sizeof opts);
         memset(&st, 0, sizeof st);
@@ -294,10 +305,14 @@ test_que_reason_code_lookup_all_known(void) {
                     g_last_reason_code);
             rc = 1;
         }
-        /* Verify active_channel contains "QUE" */
         if (strstr(st.active_channel[0], "QUE") == NULL) {
             fprintf(stderr, "FAIL: test_que_reason_code[0x%02X]: active_channel missing 'QUE': '%s'\n", cases[i].code,
                     st.active_channel[0]);
+            rc = 1;
+        }
+        if (strstr(st.active_channel[0], cases[i].expected_substr) == NULL) {
+            fprintf(stderr, "FAIL: test_que_reason_code[0x%02X]: active_channel missing '%s': '%s'\n", cases[i].code,
+                    cases[i].expected_substr, st.active_channel[0]);
             rc = 1;
         }
         p25_sm_reset_api();
@@ -307,7 +322,7 @@ test_que_reason_code_lookup_all_known(void) {
 }
 
 /* ============================================================================
- * Test: Deny reason code lookup — all known codes
+ * Test: Deny reason code lookup -- known codes and ranges
  * ============================================================================ */
 
 static int
@@ -320,8 +335,33 @@ test_deny_reason_code_lookup_all_known(void) {
         int code;
         const char* expected_substr;
     } cases[] = {
-        {0x10, "Requester Invalid"}, {0x20, "Target Invalid"},     {0x2F, "Target Refused"},
-        {0x30, "Group Invalid"},     {0x60, "Site Access Denied"}, {0xFF, "Service Not Supported"},
+        {0x10, "Requesting Unit Not Valid"},
+        {0x11, "Requesting Unit Not Authorized"},
+        {0x20, "Target Unit Not Valid"},
+        {0x21, "Target Unit Not Authorized"},
+        {0x2F, "Target Unit Refused Call"},
+        {0x30, "Target Group Not Valid"},
+        {0x31, "Target Group Not Authorized"},
+        {0x40, "Invalid Dialing"},
+        {0x41, "Telephone Number Not Authorized"},
+        {0x42, "PSTN Not Valid"},
+        {0x50, "Call Timeout"},
+        {0x51, "Landline Terminated Call"},
+        {0x52, "Subscriber Unit Terminated Call"},
+        {0x5F, "Call Preempted"},
+        {0x60, "Site Access Denial"},
+        {0x67, "PTT Collide"},
+        {0x77, "PTT Bonk"},
+        {0xF0, "Call Options Not Valid For Service"},
+        {0xF1, "Protection Service Option Not Valid"},
+        {0xF2, "Duplex Service Option Not Valid"},
+        {0xF3, "Circuit/Packet Mode Option Not Valid"},
+        {0xFF, "System Does Not Support Service"},
+        {0x00, "Reserved"},
+        {0x5E, "Reserved"},
+        {0x61, "User/System Defined"},
+        {0x99, "User/System Defined"},
+        {0xFE, "User/System Defined"},
     };
 
     for (int i = 0; i < (int)(sizeof(cases) / sizeof(cases[0])); i++) {
@@ -339,10 +379,14 @@ test_deny_reason_code_lookup_all_known(void) {
                     g_last_reason_code);
             rc = 1;
         }
-        /* Verify active_channel contains "DENY" */
         if (strstr(st.active_channel[0], "DENY") == NULL) {
             fprintf(stderr, "FAIL: test_deny_reason_code[0x%02X]: active_channel missing 'DENY': '%s'\n", cases[i].code,
                     st.active_channel[0]);
+            rc = 1;
+        }
+        if (strstr(st.active_channel[0], cases[i].expected_substr) == NULL) {
+            fprintf(stderr, "FAIL: test_deny_reason_code[0x%02X]: active_channel missing '%s': '%s'\n", cases[i].code,
+                    cases[i].expected_substr, st.active_channel[0]);
             rc = 1;
         }
         p25_sm_reset_api();
@@ -352,11 +396,11 @@ test_deny_reason_code_lookup_all_known(void) {
 }
 
 /* ============================================================================
- * Test: Unrecognized queued reason code produces hex in active_channel
+ * Test: Queued user/system reason range is labeled
  * ============================================================================ */
 
 static int
-test_que_rsp_unrecognized_reason_hex(void) {
+test_que_rsp_user_reason_range(void) {
     static dsd_opts opts;
     static dsd_state st;
     memset(&opts, 0, sizeof opts);
@@ -365,18 +409,21 @@ test_que_rsp_unrecognized_reason_hex(void) {
     p25_sm_set_api(sm_test_api());
 
     unsigned long long MAC[24];
-    // Use reason code 0xAB which is not in the queued lookup table
     build_que_deny_mac(MAC, 0, 0x01, 0xAB, 0, 999);
     process_MAC_VPDU(&opts, &st, 0, MAC);
 
     int rc = 0;
     if (g_last_reason_code != 0xAB) {
-        fprintf(stderr, "FAIL: test_que_rsp_unrecognized_reason: expected 0xAB, got 0x%02X\n", g_last_reason_code);
+        fprintf(stderr, "FAIL: test_que_rsp_user_reason_range: expected 0xAB, got 0x%02X\n", g_last_reason_code);
         rc = 1;
     }
-    /* The handler should still set active_channel with QUE */
     if (strstr(st.active_channel[0], "QUE") == NULL) {
-        fprintf(stderr, "FAIL: test_que_rsp_unrecognized_reason: active_channel missing 'QUE': '%s'\n",
+        fprintf(stderr, "FAIL: test_que_rsp_user_reason_range: active_channel missing 'QUE': '%s'\n",
+                st.active_channel[0]);
+        rc = 1;
+    }
+    if (strstr(st.active_channel[0], "User/System Defined") == NULL) {
+        fprintf(stderr, "FAIL: test_que_rsp_user_reason_range: active_channel missing user/system label: '%s'\n",
                 st.active_channel[0]);
         rc = 1;
     }
@@ -386,11 +433,11 @@ test_que_rsp_unrecognized_reason_hex(void) {
 }
 
 /* ============================================================================
- * Test: Unrecognized deny reason code produces hex in active_channel
+ * Test: Deny user/system reason range is labeled
  * ============================================================================ */
 
 static int
-test_deny_rsp_unrecognized_reason_hex(void) {
+test_deny_rsp_user_reason_range(void) {
     static dsd_opts opts;
     static dsd_state st;
     memset(&opts, 0, sizeof opts);
@@ -399,17 +446,21 @@ test_deny_rsp_unrecognized_reason_hex(void) {
     p25_sm_set_api(sm_test_api());
 
     unsigned long long MAC[24];
-    // Use reason code 0x99 which is not in the deny lookup table
     build_que_deny_mac(MAC, 1, 0x02, 0x99, 0, 888);
     process_MAC_VPDU(&opts, &st, 0, MAC);
 
     int rc = 0;
     if (g_last_reason_code != 0x99) {
-        fprintf(stderr, "FAIL: test_deny_rsp_unrecognized_reason: expected 0x99, got 0x%02X\n", g_last_reason_code);
+        fprintf(stderr, "FAIL: test_deny_rsp_user_reason_range: expected 0x99, got 0x%02X\n", g_last_reason_code);
         rc = 1;
     }
     if (strstr(st.active_channel[0], "DENY") == NULL) {
-        fprintf(stderr, "FAIL: test_deny_rsp_unrecognized_reason: active_channel missing 'DENY': '%s'\n",
+        fprintf(stderr, "FAIL: test_deny_rsp_user_reason_range: active_channel missing 'DENY': '%s'\n",
+                st.active_channel[0]);
+        rc = 1;
+    }
+    if (strstr(st.active_channel[0], "User/System Defined") == NULL) {
+        fprintf(stderr, "FAIL: test_deny_rsp_user_reason_range: active_channel missing user/system label: '%s'\n",
                 st.active_channel[0]);
         rc = 1;
     }
@@ -678,6 +729,43 @@ test_active_channel_deny_format(void) {
 }
 
 /* ============================================================================
+ * Test: Additional information is displayed only when AII is set
+ * ============================================================================ */
+
+static int
+test_additional_info_indicator_controls_display(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    reset_tracking();
+    p25_sm_set_api(sm_test_api());
+
+    unsigned long long MAC[24];
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+    build_que_deny_mac_aii(MAC, 0, 0x01, 0x40, 0x123456, 777, 0);
+    process_MAC_VPDU(&opts, &st, 0, MAC);
+    if (strstr(st.active_channel[0], "Info:") != NULL) {
+        fprintf(stderr, "FAIL: test_additional_info_indicator: displayed info without AII: '%s'\n",
+                st.active_channel[0]);
+        rc = 1;
+    }
+
+    memset(&opts, 0, sizeof opts);
+    memset(&st, 0, sizeof st);
+    build_que_deny_mac_aii(MAC, 0, 0x01, 0x40, 0x123456, 777, 1);
+    process_MAC_VPDU(&opts, &st, 0, MAC);
+    if (strstr(st.active_channel[0], "Info: 123456") == NULL) {
+        fprintf(stderr, "FAIL: test_additional_info_indicator: missing AII info: '%s'\n", st.active_channel[0]);
+        rc = 1;
+    }
+
+    p25_sm_reset_api();
+    return rc;
+}
+
+/* ============================================================================
  * main
  * ============================================================================ */
 
@@ -689,8 +777,8 @@ main(void) {
     rc |= test_deny_rsp_field_extraction_known_payload();
     rc |= test_que_reason_code_lookup_all_known();
     rc |= test_deny_reason_code_lookup_all_known();
-    rc |= test_que_rsp_unrecognized_reason_hex();
-    rc |= test_deny_rsp_unrecognized_reason_hex();
+    rc |= test_que_rsp_user_reason_range();
+    rc |= test_deny_rsp_user_reason_range();
     rc |= test_sm_queued_releases_when_tuned();
     rc |= test_sm_deny_releases_when_tuned();
     rc |= test_sm_queued_noop_when_on_cc();
@@ -699,6 +787,7 @@ main(void) {
     rc |= test_sm_deny_counter_increments();
     rc |= test_active_channel_que_format();
     rc |= test_active_channel_deny_format();
+    rc |= test_additional_info_indicator_controls_display();
 
     if (rc == 0) {
         fprintf(stderr, "All P25 queued/deny response tests passed.\n");


### PR DESCRIPTION
Split out from #78 for focused review.

This PR contains the queued/deny response slice:
- Decodes P25 Queued Response and Deny Response MAC/TSBK messages.
- Adds reason-code strings and active-channel display updates.
- Notifies the P25 trunking state machine so denied or queued calls release from `TUNED` back to `ON_CC`.
- Tracks queued/deny counters.

Review notes:
- This is a sensible standalone integration candidate because it fixes a concrete trunk-following state-machine hang condition without depending on the larger IDEN or PDU rewrites.

Validation:
- `cmake --preset dev-debug`
- `cmake --build --preset dev-debug -j --target dsd-neo_test_p25_queued_deny_response`
- `ctest --preset dev-debug --output-on-failure -R '^P25_QUEUED_DENY_RESPONSE$'`
- pre-push hook: clang-format, clang-tidy strict, cppcheck strict, IWYU strict, GCC analyzer strict, Semgrep