### PR TITLE
ci(codeql): add Python analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,8 @@ jobs:
             build-mode: manual
           - language: actions
             build-mode: ""
+          - language: python
+            build-mode: ""
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Adds Python to the CodeQL advanced setup matrix so the repository's Python helper script is included in CodeQL coverage.

## Root Cause

The repository contains a Python file, but the CodeQL workflow only initialized analysis for C/C++ and GitHub Actions. GitHub's CodeQL status page flags supported languages with zero scan coverage under advanced setup.

## Validation

- `tools/workflow_lint.sh .github/workflows/codeql.yml`
- Pre-push hook checks: scoped Semgrep, workflow lint, zizmor workflow security, and Lizard complexity