### PR TITLE
ci: tighten workflow token permissions

### DIFF
--- a/.github/workflows/linux-appimage.yaml
+++ b/.github/workflows/linux-appimage.yaml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-appimage:
     runs-on: ubuntu-latest
@@ -25,13 +28,14 @@ jobs:
       actions: read
       attestations: write
       artifact-metadata: write
-      contents: write
+      contents: read
       id-token: write
     strategy:
       fail-fast: false
       matrix:
         arch: [x86_64, aarch64]
     env:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       APPIMAGE_DEPS_DIR: ${{ github.workspace }}/.deps/appimage-${{ matrix.arch }}
       APPIMAGE_CCACHE_DIR: ${{ github.workspace }}/.ccache/appimage-${{ matrix.arch }}
     steps:
@@ -421,7 +425,7 @@ jobs:
           output-file: ${{ steps.names.outputs.OUT }}.spdx.json
           artifact-name: ${{ steps.names.outputs.ART }}.spdx.json
           upload-artifact: true
-          upload-release-assets: ${{ startsWith(github.ref, 'refs/tags/') }}
+          upload-release-assets: false
       - name: Attest artifact provenance
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
@@ -434,17 +438,20 @@ jobs:
           subject-path: ${{ steps.names.outputs.OUT }}
           sbom-path: ${{ steps.names.outputs.OUT }}.spdx.json
       - name: Upload release asset
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != ''
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
-          files: ${{ steps.names.outputs.OUT }}
+          files: |
+            ${{ steps.names.outputs.OUT }}
+            ${{ steps.names.outputs.OUT }}.spdx.json
           name: ${{ steps.release.outputs.release_title }}
           generate_release_notes: true
+          token: ${{ env.RELEASE_TOKEN }}
       - name: Upload nightly asset (overwrite)
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != '' }}
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ env.RELEASE_TOKEN }}
           tag: nightly
           prerelease: true
           file: ${{ steps.names.outputs.OUT }}

--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -497,15 +497,24 @@ jobs:
     needs: [build-linux]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    env:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
     permissions:
-      contents: write
+      contents: read
     steps:
+      - name: Skip nightly tag update
+        if: env.RELEASE_TOKEN == ''
+        run: echo "RELEASE_TOKEN is not configured; skipping nightly tag update."
+
       - name: Checkout repository
+        if: env.RELEASE_TOKEN != ''
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ env.RELEASE_TOKEN }}
 
       - name: Move nightly tag to current commit
+        if: env.RELEASE_TOKEN != ''
         run: |
           set -euxo pipefail
           git config user.name "github-actions[bot]"

--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-portable-dmg:
     runs-on: macos-latest
@@ -25,9 +28,10 @@ jobs:
       actions: read
       attestations: write
       artifact-metadata: write
-      contents: write
+      contents: read
       id-token: write
     env:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       HOMEBREW_NO_AUTO_UPDATE: "1"
       HOMEBREW_NO_INSTALL_CLEANUP: "1"
       HOMEBREW_NO_ANALYTICS: "1"
@@ -425,7 +429,7 @@ jobs:
           output-file: ${{ steps.dmg.outputs.DMG_PATH }}.spdx.json
           artifact-name: ${{ steps.dmg.outputs.ART_NAME }}.spdx.json
           upload-artifact: true
-          upload-release-assets: ${{ startsWith(github.ref, 'refs/tags/') }}
+          upload-release-assets: false
 
       - name: Attest artifact provenance
         if: startsWith(github.ref, 'refs/tags/')
@@ -441,18 +445,21 @@ jobs:
           sbom-path: ${{ steps.dmg.outputs.DMG_PATH }}.spdx.json
 
       - name: Upload release asset
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != ''
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
-          files: ${{ steps.dmg.outputs.DMG_PATH }}
+          files: |
+            ${{ steps.dmg.outputs.DMG_PATH }}
+            ${{ steps.dmg.outputs.DMG_PATH }}.spdx.json
           name: ${{ steps.release.outputs.release_title }}
           generate_release_notes: true
+          token: ${{ env.RELEASE_TOKEN }}
 
       - name: Upload nightly asset (overwrite)
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != '' }}
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ env.RELEASE_TOKEN }}
           tag: nightly
           prerelease: true
           file: ${{ steps.dmg.outputs.DMG_PATH }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,15 +12,21 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  checks: read
   contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
   scorecard:
     name: OpenSSF Scorecard
     runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
+      issues: read
       id-token: write
+      pull-requests: read
       security-events: write
     steps:
       - name: Checkout repository

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-native-msvc:
     runs-on: windows-latest
@@ -25,9 +28,10 @@ jobs:
       actions: read
       attestations: write
       artifact-metadata: write
-      contents: write
+      contents: read
       id-token: write
     env:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       # Use a release-only triplet to avoid building debug variants of vcpkg deps.
       VCPKG_DEFAULT_TRIPLET: x64-windows-dynamic-release
       VCPKG_TARGET_TRIPLET: x64-windows-dynamic-release
@@ -187,7 +191,7 @@ jobs:
           output-file: ${{ steps.zip.outputs.ZIP_PATH }}.spdx.json
           artifact-name: ${{ steps.zip.outputs.ART_NAME }}.spdx.json
           upload-artifact: true
-          upload-release-assets: ${{ startsWith(github.ref, 'refs/tags/') }}
+          upload-release-assets: false
 
       - name: Attest native MSVC provenance
         if: startsWith(github.ref, 'refs/tags/')
@@ -203,18 +207,21 @@ jobs:
           sbom-path: ${{ steps.zip.outputs.ZIP_PATH }}.spdx.json
 
       - name: Upload native MSVC release asset
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != ''
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
-          files: ${{ steps.zip.outputs.ZIP_PATH }}
+          files: |
+            ${{ steps.zip.outputs.ZIP_PATH }}
+            ${{ steps.zip.outputs.ZIP_PATH }}.spdx.json
           name: ${{ steps.release.outputs.release_title }}
           generate_release_notes: true
+          token: ${{ env.RELEASE_TOKEN }}
 
       - name: Upload native MSVC nightly asset (overwrite)
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != '' }}
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ env.RELEASE_TOKEN }}
           tag: nightly
           prerelease: true
           file: ${{ steps.zip.outputs.ZIP_PATH }}
@@ -227,9 +234,10 @@ jobs:
       actions: read
       attestations: write
       artifact-metadata: write
-      contents: write
+      contents: read
       id-token: write
     env:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       # Use a release-only triplet to avoid building debug variants of vcpkg deps.
       VCPKG_DEFAULT_TRIPLET: x64-mingw-dynamic-release
       VCPKG_TARGET_TRIPLET: x64-mingw-dynamic-release
@@ -420,7 +428,7 @@ jobs:
           output-file: ${{ steps.zip.outputs.ZIP_PATH }}.spdx.json
           artifact-name: ${{ steps.zip.outputs.ART_NAME }}.spdx.json
           upload-artifact: true
-          upload-release-assets: ${{ startsWith(github.ref, 'refs/tags/') }}
+          upload-release-assets: false
 
       - name: Attest native MinGW provenance
         if: startsWith(github.ref, 'refs/tags/')
@@ -436,18 +444,21 @@ jobs:
           sbom-path: ${{ steps.zip.outputs.ZIP_PATH }}.spdx.json
 
       - name: Upload native MinGW release asset
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != ''
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
-          files: ${{ steps.zip.outputs.ZIP_PATH }}
+          files: |
+            ${{ steps.zip.outputs.ZIP_PATH }}
+            ${{ steps.zip.outputs.ZIP_PATH }}.spdx.json
           name: ${{ steps.release.outputs.release_title }}
           generate_release_notes: true
+          token: ${{ env.RELEASE_TOKEN }}
 
       - name: Upload native MinGW nightly asset (overwrite)
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ !startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != '' }}
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ env.RELEASE_TOKEN }}
           tag: nightly
           prerelease: true
           file: ${{ steps.zip.outputs.ZIP_PATH }}

--- a/docs/openssf-baseline.md
+++ b/docs/openssf-baseline.md
@@ -28,9 +28,11 @@ enabled in GitHub.
   environment variables instead of directly interpolating them into shell
   scripts.
 - Pull request workflows use least-privilege `GITHUB_TOKEN` permissions. The
-  default GitHub Actions workflow permission for the repository is read-only.
-  Privileged publication credentials are only used in upstream non-PR release,
-  nightly, or AUR update paths.
+  default GitHub Actions workflow permission for the repository is read-only,
+  and workflows keep `GITHUB_TOKEN` read-only by default. GitHub Release and
+  nightly publication, when enabled, uses a maintainer-scoped `RELEASE_TOKEN`
+  secret only in trusted upstream non-PR release/nightly paths. AUR update
+  credentials are likewise restricted to upstream non-PR AUR update paths.
 - Official project channels and distribution channels are GitHub HTTPS URLs and
   AUR HTTPS URLs.
 - The project prevents accidental credential storage through contributor policy,

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -9,8 +9,9 @@ https://github.com/arancormonk/dsd-neo/releases
 Release tags use the form `vX.Y.Z`. The tag must match the project version
 declared by CMake, or the release workflow fails before packaging.
 
-Nightly assets are published from the moving `nightly` tag and are intended for
-testing rather than stable deployment.
+Nightly assets are published from the moving `nightly` tag when the maintainer
+publication token is configured. They are intended for testing rather than
+stable deployment.
 
 ## Source Tag Verification
 
@@ -39,6 +40,9 @@ git tag -v vX.Y.Z
 Release assets are distributed over GitHub HTTPS. Tag release workflows generate
 SBOMs and GitHub artifact attestations for packaged Linux AppImage, macOS DMG,
 and Windows ZIP assets when the corresponding workflow completes successfully.
+The workflows keep `GITHUB_TOKEN` read-only; uploading assets to GitHub Releases
+uses the maintainer-scoped `RELEASE_TOKEN` secret when it is configured. If that
+secret is not configured, publish reviewed workflow artifacts manually.
 
 Download assets from the release page, then verify an artifact attestation with
 GitHub CLI when available:


### PR DESCRIPTION
## Summary

- keep package workflows read-only by default for `GITHUB_TOKEN`
- route optional GitHub Release and nightly publication through `RELEASE_TOKEN`
- give Scorecard read access to checks, issues, and pull request metadata so CI test detection can see recent PR checks
- document the release publication token behavior

## Validation

- `tools/workflow_lint.sh`
- `tools/zizmor.sh`
- OpenSSF Scorecard `Token-Permissions` local check: `10 / 10`
- OpenSSF Scorecard `CI-Tests` repository check: `10 / 10`
- pre-push hook: Semgrep, workflow lint, zizmor, and lizard completed without blocking findings