### PR TITLE
ci: fix clang-format scope and no-radio builds

### DIFF
--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -1109,7 +1109,12 @@ jobs:
             if [[ "${{ github.event_name }}" == "pull_request" ]]; then
               mapfile -t files < .ci/changed-files/format_files.txt
             else
-              mapfile -t files < <(git ls-files "*.c" "*.cc" "*.cxx" "*.cpp" "*.h" "*.hpp" ":!:build/**")
+              mapfile -t files < <(
+                git ls-files \
+                  "*.c" "*.cc" "*.cxx" "*.cpp" "*.h" "*.hpp" \
+                  ":!:build/**" \
+                  ":!:src/third_party/**"
+              )
             fi
 
             clang-format --version

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -26,7 +26,6 @@
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/frame.h>
 #include <dsd-neo/core/opts.h>
-#include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/string_utils.h>
 #include <dsd-neo/core/sync_patterns.h>
@@ -43,7 +42,6 @@
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/exitflag.h>
 #include <dsd-neo/runtime/frame_sync_hooks.h>
-#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <dsd-neo/runtime/telemetry.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -56,6 +54,8 @@
 #include "dsd-neo/platform/timing.h"
 
 #ifdef USE_RADIO
+#include <dsd-neo/core/power.h>
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #endif
 
 static int
@@ -1669,6 +1669,8 @@ frame_sync_slice_cqpsk_dibit(const dsd_opts* opts, const dsd_state* state, float
             sym_max = -1000.0f;
         }
     }
+#else
+    UNUSED(opts);
 #endif
     return d;
 }
@@ -1697,6 +1699,9 @@ frame_sync_capture_symbol(dsd_opts* opts, dsd_state* state, int dibit, float sym
     if (!opts->symbol_out_f || dibit == 0) {
         return;
     }
+#ifndef USE_RADIO
+    UNUSED(cqpsk_4level);
+#endif
     int csymbol = 0;
 #ifdef USE_RADIO
     if (cqpsk_4level) {
@@ -2153,6 +2158,7 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
         demod_rate = dsd_opts_current_input_timing_rate(opts);
     }
 #else
+    UNUSED(levels_cycle);
     int demod_rate = dsd_opts_current_input_timing_rate(opts);
 #endif
 

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -36,8 +36,6 @@
 #include <dsd-neo/runtime/exitflag.h>
 #include <dsd-neo/runtime/log.h>
 #include <dsd-neo/runtime/net_audio_input_hooks.h>
-#include <dsd-neo/runtime/rtl_stream_io_hooks.h>
-#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <dsd-neo/runtime/udp_audio_hooks.h>
 #include <fcntl.h>
 #include <math.h>
@@ -58,6 +56,8 @@
 #endif
 
 #ifdef USE_RADIO
+#include <dsd-neo/runtime/rtl_stream_io_hooks.h>
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #endif
 #include <fcntl.h> // IWYU pragma: keep
 
@@ -483,15 +483,13 @@ symbol_accumulate_nxdn_window(const dsd_state* state, int i) {
     return state->samplesPerSymbol == 20 && i >= 7 && i <= 13;
 }
 
+#ifdef USE_RADIO
 static inline int
 symbol_accumulate_symbol_rate_override(const dsd_state* state, const symbol_work_ctx* work) {
     (void)state;
-#ifdef USE_RADIO
     return work->rtl_symbol_rate_output || work->cqpsk_symbol_rate;
-#else
-    return 0;
-#endif
 }
+#endif
 
 static inline int
 symbol_accumulate_sps5_window(const dsd_state* state, int i) {
@@ -947,6 +945,9 @@ symbol_scale_pcm_i16(short s, int input_volume_multiplier) {
 static inline unsigned int
 symbol_analog_block_size(const dsd_opts* opts, const dsd_state* state, unsigned int analog_out_cap) {
     unsigned int analog_block = analog_out_cap;
+#ifndef USE_RADIO
+    (void)state;
+#endif
     if (opts->audio_in_type == AUDIO_IN_RTL) {
 #ifdef USE_RADIO
         unsigned int Fs = 0;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -46,7 +46,6 @@
 #include <dsd-neo/runtime/input_spec.h>
 #include <dsd-neo/runtime/log.h>
 #include <dsd-neo/runtime/rdio_export.h>
-#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/ui/ui_async.h>
 #include <errno.h>
@@ -71,6 +70,7 @@
 struct CODEC2;
 #ifdef USE_RADIO
 #include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #endif
 #ifdef USE_RTLSDR
 #include <rtl-sdr.h>
@@ -776,6 +776,7 @@ dsd_engine_setup_parse_soapy_input(dsd_opts* opts) {
     opts->audio_in_type = AUDIO_IN_RTL;
 }
 
+#ifdef USE_RTLSDR
 static int
 dsd_engine_setup_parse_rtl_spec_tokens(dsd_opts* opts, char** saveptr) {
     const char* curr = dsd_strtok_r(NULL, ":", saveptr);
@@ -851,7 +852,6 @@ dsd_engine_setup_update_rtl_spec_with_selected_index(dsd_opts* opts) {
 
 static int
 dsd_engine_setup_enumerate_rtl_devices(const dsd_opts* opts, char* vendor, char* product, char* serial) {
-#ifdef USE_RTLSDR
     int device_count = 0;
 #if defined(_MSC_VER) && defined(_WIN32)
     __try {
@@ -890,14 +890,8 @@ dsd_engine_setup_enumerate_rtl_devices(const dsd_opts* opts, char* vendor, char*
         }
     }
     return device_count;
-#else
-    UNUSED(opts);
-    UNUSED(vendor);
-    UNUSED(product);
-    UNUSED(serial);
-    return 0;
-#endif
 }
+#endif
 
 static int
 dsd_engine_setup_configure_local_rtl(dsd_opts* opts, dsd_state* state, char* vendor, char* product, char* serial) {

--- a/src/protocol/edacs/edacs-fme.c
+++ b/src/protocol/edacs/edacs-fme.c
@@ -49,11 +49,9 @@
 #include <dsd-neo/runtime/log.h>
 #include <dsd-neo/runtime/net_audio_input_hooks.h>
 #include <dsd-neo/runtime/rigctl_query_hooks.h>
-#include <dsd-neo/runtime/rtl_stream_io_hooks.h>
 #include <dsd-neo/runtime/telemetry.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <dsd-neo/runtime/udp_audio_hooks.h>
-#include <math.h>
 #include <sndfile.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -64,6 +62,8 @@
 #include "dsd-neo/core/state_fwd.h"
 
 #ifdef USE_RADIO
+#include <dsd-neo/runtime/rtl_stream_io_hooks.h>
+#include <math.h>
 #endif
 
 static void
@@ -74,6 +74,7 @@ edacs_print_group_label(const dsd_state* state, uint32_t id) {
     }
 }
 
+#ifdef USE_RADIO
 static inline short
 clip_float_to_short(float v) {
     if (v > 32767.0f) {
@@ -84,6 +85,7 @@ clip_float_to_short(float v) {
     }
     return (short)lrintf(v);
 }
+#endif
 
 static int
 hamming_weight_u64(uint64_t v) {
@@ -293,9 +295,9 @@ edacs_fill_analog_block_udp(dsd_opts* opts, short* block) {
     }
 }
 
+#ifdef USE_RADIO
 static int
 edacs_fill_analog_block_rtl(dsd_opts* opts, dsd_state* state, short* block) {
-#ifdef USE_RADIO
     float rtl_sample = 0.0f;
     for (int i = 0; i < 960; i++) {
         if (!state->rtl_ctx) {
@@ -311,12 +313,8 @@ edacs_fill_analog_block_rtl(dsd_opts* opts, dsd_state* state, short* block) {
         block[i] = clip_float_to_short(rtl_sample);
     }
     return 1;
-#else
-    UNUSED(block);
-    cleanupAndExit(opts, state);
-    return 0;
-#endif
 }
+#endif
 
 static int
 edacs_collect_analog_triplet(dsd_opts* opts, dsd_state* state, short* analog1, short* analog2, short* analog3,

--- a/src/runtime/bootstrap/interactive.c
+++ b/src/runtime/bootstrap/interactive.c
@@ -154,6 +154,7 @@ interactive_configure_rtl_input(dsd_opts* opts, int* src) {
     DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "rtl:%d:%s:%d:%d:%d:%d:%d", dev, freq, gain, ppm, bw,
                  sql, vol);
 #else
+    (void)opts;
     LOG_WARNING("RTL-SDR support not enabled in this build.\n");
     *src = 1;
 #endif

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -23,25 +23,20 @@
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
-#include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/protocol/edacs/edacs_afs.h>
 #include <dsd-neo/protocol/p25/p25_callsign.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/telemetry.h>
-#include <dsd-neo/ui/keymap.h>
 #include <dsd-neo/ui/menu_core.h>
 #include <dsd-neo/ui/ncurses.h>
 #include <dsd-neo/ui/ncurses_dsp_display.h>
 #include <dsd-neo/ui/ncurses_internal.h>
 #include <dsd-neo/ui/ncurses_p25_display.h>
-#include <dsd-neo/ui/ncurses_snr.h>
 #include <dsd-neo/ui/ncurses_trunk_display.h>
-#include <dsd-neo/ui/ncurses_visualizers.h>
 #include <dsd-neo/ui/panels.h>
 #include <dsd-neo/ui/ui_async.h>
 #include <dsd-neo/ui/ui_history.h>
 #include <dsd-neo/ui/ui_prims.h>
-#include <math.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <string.h>
@@ -51,6 +46,11 @@
 #include "dsd-neo/core/state_fwd.h"
 
 #ifdef USE_RADIO
+#include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/ui/keymap.h>
+#include <dsd-neo/ui/ncurses_snr.h>
+#include <dsd-neo/ui/ncurses_visualizers.h>
+#include <math.h>
 #endif
 
 static int
@@ -850,6 +850,7 @@ ui_render_input_output_section(dsd_opts* opts, dsd_state* state) {
     ui_print_hr();
 }
 
+#ifdef USE_RADIO
 static void
 ui_print_rtl_visual_aids_controls(dsd_opts* opts, int nfft) {
     /* Controls/status line: only show controls relevant to active views */
@@ -888,6 +889,7 @@ ui_render_rtl_visual_aid_panels(dsd_opts* opts, dsd_state* state) {
         print_spectrum_view(opts);
     }
 }
+#endif
 
 static void
 ui_render_rtl_visual_aids(dsd_opts* opts, dsd_state* state) {
@@ -899,6 +901,9 @@ ui_render_rtl_visual_aids(dsd_opts* opts, dsd_state* state) {
         ui_print_rtl_visual_aids_controls(opts, nfft);
         ui_render_rtl_visual_aid_panels(opts, state);
     }
+#else
+    (void)opts;
+    (void)state;
 #endif
     /* Ensure our primary UI color remains active after visual aids */
     attron(COLOR_PAIR(4));

--- a/src/ui/terminal/ncurses_visualizers.c
+++ b/src/ui/terminal/ncurses_visualizers.c
@@ -9,22 +9,23 @@
 
 #include <curses.h>
 #include <dsd-neo/core/constants.h>
-#include <dsd-neo/core/opts.h>
-#include <dsd-neo/core/state.h>
-#include <dsd-neo/ui/ncurses_internal.h>
 #include <dsd-neo/ui/ncurses_visualizers.h>
 #include <dsd-neo/ui/ui_prims.h>
-#include <math.h>
-#include <stdint.h>
-#include <stdlib.h>
 #include "dsd-neo/core/opts_fwd.h"
-#include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
 #ifdef USE_RTLSDR
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
 #include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/ui/ncurses_internal.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "dsd-neo/core/safe_api.h"
 #endif
 
+#ifdef USE_RTLSDR
 static int
 clamp_int_local(int value, int lo, int hi) {
     if (value < lo) {
@@ -972,6 +973,7 @@ eye_estimate_snr_fallback(const float* buf, int n, int sps, int two_sps, int q1,
     }
     return snr_db;
 }
+#endif
 
 void
 print_constellation_view(dsd_opts* opts, dsd_state* state) {

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -1777,7 +1777,9 @@ test_iq_replay_long_options_parse(void) {
     }
 #endif
 
+#ifdef USE_RADIO
 out:
+#endif
     (void)remove(metadata_path);
     (void)remove(data_path);
     freeState(state);

--- a/tests/runtime/test_runtime_config_apply.cpp
+++ b/tests/runtime/test_runtime_config_apply.cpp
@@ -20,11 +20,9 @@
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_fwd.h>
-#include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/ui/ui_async.h>
 #include <dsd-neo/ui/ui_cmd.h>
-#include <dsd-neo/ui/ui_dsp_cmd.h>
 #include <math.h>
 #include <sndfile.h>
 #include <stdint.h>
@@ -35,6 +33,11 @@
 #include "dsd-neo/platform/file_compat.h"
 #include "dsd-neo/runtime/call_alert.h"
 #include "test_support.h"
+
+#ifdef USE_RADIO
+#include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/ui/ui_dsp_cmd.h>
+#endif
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -68,6 +71,7 @@ expect_float_ne(const char* label, float lhs, float rhs) {
     return 0;
 }
 
+#ifdef USE_RADIO
 static int
 expect_float_close(const char* label, float got, float want, float tol) {
     if (fabsf(got - want) > tol) {
@@ -76,6 +80,7 @@ expect_float_close(const char* label, float got, float want, float tol) {
     }
     return 0;
 }
+#endif
 
 static int g_tcp_connect_audio_calls = 0;
 static int g_tcp_connect_audio_result = 0;


### PR DESCRIPTION
## Summary
- exclude vendored third-party sources from the push-side clang-format file list
- gate radio and RTL-only helpers and includes so no-radio backend builds stay warning-clean
- keep radio-specific test helpers and cleanup labels behind matching feature guards

## Root cause
The CI formatting check excluded `src/third_party/` during the build job but not in the push-side file list. The no-radio backend matrix also exposed radio-only code paths to strict unused-symbol and include checks.

## Validation
- `git diff --check`
- `clang-format -n --Werror` on changed C/C++ files
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure` (324 passed)
- local pre-push hook checks