### PR TITLE
ci: harden workflow caching and release publishing

### DIFF
--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -71,6 +71,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
+          cache: pip
+          cache-dependency-path: .github/requirements/gersemi.txt
 
       - name: Install gersemi
         if: github.event_name != 'pull_request' || steps.changed.outputs.cmake_format_files != '0'
@@ -157,6 +159,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
+          cache: pip
+          cache-dependency-path: .github/requirements/zizmor.txt
 
       - name: Install zizmor
         if: github.event_name != 'pull_request' || steps.changed.outputs.workflow_security_targets != '0'

--- a/.github/workflows/linux-appimage.yaml
+++ b/.github/workflows/linux-appimage.yaml
@@ -119,6 +119,24 @@ jobs:
           restore-keys: |
             deps-appimage-${{ runner.os }}-${{ matrix.arch }}-
 
+      - name: Validate AppImage dependency cache
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mf="${APPIMAGE_DEPS_DIR}/.manifest"
+          if [ -d "${APPIMAGE_DEPS_DIR}" ]; then
+            if [ -f "$mf" ] &&
+               grep -Fxq "mbe_sha=${{ steps.dep-shas.outputs.mbe_sha }}" "$mf" &&
+               grep -Fxq "codec2_sha=${{ steps.dep-shas.outputs.codec2_sha }}" "$mf" &&
+               grep -Fxq "rtlsdr_sha=${{ steps.dep-shas.outputs.rtlsdr_sha }}" "$mf"; then
+              echo "AppImage dependency cache manifest matches requested SHAs"
+            else
+              echo "AppImage dependency cache manifest is missing or stale; clearing ${APPIMAGE_DEPS_DIR}"
+              rm -rf "${APPIMAGE_DEPS_DIR}"
+            fi
+          fi
+          mkdir -p "${APPIMAGE_DEPS_DIR}"
+
       - name: Restore AppImage ccache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/.github/workflows/linux-appimage.yaml
+++ b/.github/workflows/linux-appimage.yaml
@@ -8,10 +8,6 @@ on:
       - "v*.*.*"
     paths-ignore:
       - ".*"
-      - ".github/*.yml"
-      - ".github/*.yaml"
-      - ".github/**/*.yml"
-      - ".github/**/*.yaml"
       - "**/*.md"
 
 concurrency:
@@ -35,7 +31,6 @@ jobs:
       matrix:
         arch: [x86_64, aarch64]
     env:
-      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       APPIMAGE_DEPS_DIR: ${{ github.workspace }}/.deps/appimage-${{ matrix.arch }}
       APPIMAGE_CCACHE_DIR: ${{ github.workspace }}/.ccache/appimage-${{ matrix.arch }}
     steps:
@@ -455,23 +450,90 @@ jobs:
         with:
           subject-path: ${{ steps.names.outputs.OUT }}
           sbom-path: ${{ steps.names.outputs.OUT }}.spdx.json
+
+  publish-appimage:
+    name: Publish AppImage (${{ matrix.arch }})
+    needs: build-appimage
+    runs-on: ubuntu-latest
+    if: >-
+      github.repository == 'arancormonk/dsd-neo' &&
+      (startsWith(github.ref, 'refs/tags/v') ||
+      ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')))
+    permissions:
+      actions: read
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+    steps:
+      - name: Prepare artifact naming
+        id: names
+        shell: bash
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          arch='${{ matrix.arch }}'
+          if [ "$REF_TYPE" = 'tag' ] && [ -n "$REF_NAME" ]; then
+            out="dist/dsd-neo-linux-${arch}-portable-${REF_NAME}.AppImage"
+            art="dsd-neo-linux-${arch}-portable-${REF_NAME}"
+            title="dsd-neo ${REF_NAME#v}"
+          else
+            out="dist/dsd-neo-linux-${arch}-portable-nightly.AppImage"
+            art="dsd-neo-linux-${arch}-portable-nightly"
+            title="nightly"
+          fi
+          mkdir -p dist
+          {
+            echo "OUT=$out"
+            echo "ART=$art"
+            echo "RELEASE_TITLE=$title"
+          } >> "$GITHUB_OUTPUT"
+      - name: Download package artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ steps.names.outputs.ART }}
+          path: dist
+      - name: Download package SBOM artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ steps.names.outputs.ART }}.spdx.json
+          path: dist
+      - name: Verify downloaded release files
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f "${{ steps.names.outputs.OUT }}"
+          test -f "${{ steps.names.outputs.OUT }}.spdx.json"
       - name: Upload release asset
-        if: startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != ''
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           files: |
             ${{ steps.names.outputs.OUT }}
             ${{ steps.names.outputs.OUT }}.spdx.json
-          name: ${{ steps.release.outputs.release_title }}
+          name: ${{ steps.names.outputs.RELEASE_TITLE }}
           generate_release_notes: true
-          token: ${{ env.RELEASE_TOKEN }}
-      - name: Upload nightly asset (overwrite)
-        if: ${{ !startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != '' }}
-        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de
+          overwrite_files: true
+          fail_on_unmatched_files: true
+          token: ${{ github.token }}
+      - name: Upload nightly assets (overwrite)
+        if: >-
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+          (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
-          repo_token: ${{ env.RELEASE_TOKEN }}
-          tag: nightly
+          tag_name: nightly
+          name: nightly
           prerelease: true
-          file: ${{ steps.names.outputs.OUT }}
-          asset_name: ${{ steps.names.outputs.ART }}.AppImage
-          overwrite: true
+          make_latest: false
+          target_commitish: ${{ github.sha }}
+          files: |
+            ${{ steps.names.outputs.OUT }}
+            ${{ steps.names.outputs.OUT }}.spdx.json
+          overwrite_files: true
+          fail_on_unmatched_files: true
+          token: ${{ github.token }}

--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -517,25 +517,19 @@ jobs:
     name: Update nightly tag
     needs: [build-linux]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
-    env:
-      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+    if: >-
+      github.repository == 'arancormonk/dsd-neo' &&
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     permissions:
-      contents: read
+      contents: write
     steps:
-      - name: Skip nightly tag update
-        if: env.RELEASE_TOKEN == ''
-        run: echo "RELEASE_TOKEN is not configured; skipping nightly tag update."
-
       - name: Checkout repository
-        if: env.RELEASE_TOKEN != ''
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ env.RELEASE_TOKEN }}
 
       - name: Move nightly tag to current commit
-        if: env.RELEASE_TOKEN != ''
         run: |
           set -euxo pipefail
           git config user.name "github-actions[bot]"

--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -190,6 +190,23 @@ jobs:
           restore-keys: |
             deps-${{ runner.os }}-
 
+      - name: Validate dependency cache
+        run: |
+          set -euxo pipefail
+          mf="$DEPS_PREFIX/.manifest"
+          if [ -d "$DEPS_PREFIX" ]; then
+            if [ -f "$mf" ] &&
+               grep -Fxq "mbe_sha=${{ steps.dep-shas.outputs.mbe_sha }}" "$mf" &&
+               grep -Fxq "codec2_sha=${{ steps.dep-shas.outputs.codec2_sha }}" "$mf" &&
+               grep -Fxq "rtlsdr_sha=${{ steps.dep-shas.outputs.rtlsdr_sha }}" "$mf"; then
+              echo "Dependency cache manifest matches requested SHAs"
+            else
+              echo "Dependency cache manifest is missing or stale; clearing $DEPS_PREFIX"
+              rm -rf "$DEPS_PREFIX"
+            fi
+          fi
+          mkdir -p "$DEPS_PREFIX"
+
       - name: Install base build dependencies
         run: |
           sudo apt-get update
@@ -416,6 +433,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
+          cache: pip
+          cache-dependency-path: .github/requirements/semgrep.txt
 
       - name: Install Semgrep
         if: github.event_name != 'pull_request' || steps.changed.outputs.semgrep_targets != '0'
@@ -462,6 +481,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
+          cache: pip
+          cache-dependency-path: .github/requirements/lizard.txt
       - name: Install Lizard
         run: python -m pip install --require-hashes -r .github/requirements/lizard.txt
       - name: Run Lizard
@@ -911,6 +932,23 @@ jobs:
           restore-keys: |
             deps-${{ runner.os }}-
 
+      - name: Validate dependency cache
+        run: |
+          set -euxo pipefail
+          mf="$DEPS_PREFIX/.manifest"
+          if [ -d "$DEPS_PREFIX" ]; then
+            if [ -f "$mf" ] &&
+               grep -Fxq "mbe_sha=${{ steps.dep-shas.outputs.mbe_sha }}" "$mf" &&
+               grep -Fxq "codec2_sha=${{ steps.dep-shas.outputs.codec2_sha }}" "$mf" &&
+               grep -Fxq "rtlsdr_sha=${{ steps.dep-shas.outputs.rtlsdr_sha }}" "$mf"; then
+              echo "Dependency cache manifest matches requested SHAs"
+            else
+              echo "Dependency cache manifest is missing or stale; clearing $DEPS_PREFIX"
+              rm -rf "$DEPS_PREFIX"
+            fi
+          fi
+          mkdir -p "$DEPS_PREFIX"
+
       - name: Install base build dependencies
         run: |
           sudo apt-get update
@@ -1240,6 +1278,22 @@ jobs:
           key: arch-deps-${{ runner.os }}-${{ steps.dep-shas.outputs.mbe_sha }}
           restore-keys: |
             arch-deps-${{ runner.os }}-
+
+      - name: Validate dependency cache
+        if: github.event_name != 'pull_request' || steps.changed.outputs.analysis_tus != '0'
+        run: |
+          set -euxo pipefail
+          mf=".deps/.manifest"
+          if [ -d .deps ]; then
+            if [ -f "$mf" ] &&
+               grep -Fxq "mbe_sha=${{ steps.dep-shas.outputs.mbe_sha }}" "$mf"; then
+              echo "Dependency cache manifest matches requested SHAs"
+            else
+              echo "Dependency cache manifest is missing or stale; clearing .deps"
+              rm -rf .deps
+            fi
+          fi
+          mkdir -p .deps
 
       - name: Restore IWYU toolchain cache
         if: (github.event_name != 'pull_request' || steps.changed.outputs.analysis_tus != '0') && matrix.name == 'iwyu'

--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -8,10 +8,6 @@ on:
       - "v*.*.*"
     paths-ignore:
       - ".*"
-      - ".github/*.yml"
-      - ".github/*.yaml"
-      - ".github/**/*.yml"
-      - ".github/**/*.yaml"
       - "**/*.md"
 
 concurrency:
@@ -31,7 +27,6 @@ jobs:
       contents: read
       id-token: write
     env:
-      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       HOMEBREW_NO_AUTO_UPDATE: "1"
       HOMEBREW_NO_INSTALL_CLEANUP: "1"
       HOMEBREW_NO_ANALYTICS: "1"
@@ -462,24 +457,85 @@ jobs:
           subject-path: ${{ steps.dmg.outputs.DMG_PATH }}
           sbom-path: ${{ steps.dmg.outputs.DMG_PATH }}.spdx.json
 
+  publish-portable-dmg:
+    name: Publish portable DMG
+    needs: build-portable-dmg
+    runs-on: ubuntu-latest
+    if: >-
+      github.repository == 'arancormonk/dsd-neo' &&
+      (startsWith(github.ref, 'refs/tags/v') ||
+      ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')))
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Prepare artifact naming
+        id: names
+        shell: bash
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          arch='arm64'
+          if [ "$REF_TYPE" = 'tag' ] && [ -n "$REF_NAME" ]; then
+            dmg="dist/dsd-neo-macos-${arch}-portable-${REF_NAME}.dmg"
+            artName="dsd-neo-macos-${arch}-portable-${REF_NAME}"
+            title="dsd-neo ${REF_NAME#v}"
+          else
+            dmg="dist/dsd-neo-macos-${arch}-portable-nightly.dmg"
+            artName="dsd-neo-macos-${arch}-portable-nightly"
+            title="nightly"
+          fi
+          mkdir -p dist
+          {
+            echo "DMG_PATH=$dmg"
+            echo "ART_NAME=$artName"
+            echo "RELEASE_TITLE=$title"
+          } >> "$GITHUB_OUTPUT"
+      - name: Download package artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ steps.names.outputs.ART_NAME }}
+          path: dist
+      - name: Download package SBOM artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ steps.names.outputs.ART_NAME }}.spdx.json
+          path: dist
+      - name: Verify downloaded release files
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f "${{ steps.names.outputs.DMG_PATH }}"
+          test -f "${{ steps.names.outputs.DMG_PATH }}.spdx.json"
       - name: Upload release asset
-        if: startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != ''
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           files: |
-            ${{ steps.dmg.outputs.DMG_PATH }}
-            ${{ steps.dmg.outputs.DMG_PATH }}.spdx.json
-          name: ${{ steps.release.outputs.release_title }}
+            ${{ steps.names.outputs.DMG_PATH }}
+            ${{ steps.names.outputs.DMG_PATH }}.spdx.json
+          name: ${{ steps.names.outputs.RELEASE_TITLE }}
           generate_release_notes: true
-          token: ${{ env.RELEASE_TOKEN }}
-
-      - name: Upload nightly asset (overwrite)
-        if: ${{ !startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != '' }}
-        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de
+          overwrite_files: true
+          fail_on_unmatched_files: true
+          token: ${{ github.token }}
+      - name: Upload nightly assets (overwrite)
+        if: >-
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+          (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
-          repo_token: ${{ env.RELEASE_TOKEN }}
-          tag: nightly
+          tag_name: nightly
+          name: nightly
           prerelease: true
-          file: ${{ steps.dmg.outputs.DMG_PATH }}
-          asset_name: ${{ steps.dmg.outputs.ART_NAME }}.dmg
-          overwrite: true
+          make_latest: false
+          target_commitish: ${{ github.sha }}
+          files: |
+            ${{ steps.names.outputs.DMG_PATH }}
+            ${{ steps.names.outputs.DMG_PATH }}.spdx.json
+          overwrite_files: true
+          fail_on_unmatched_files: true
+          token: ${{ github.token }}

--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -79,6 +79,24 @@ jobs:
           restore-keys: |
             deps-${{ runner.os }}-
 
+      - name: Validate dependency cache
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mf="$DEPS_PREFIX/.manifest"
+          if [ -d "$DEPS_PREFIX" ]; then
+            if [ -f "$mf" ] &&
+               grep -Fxq "mbe_sha=${{ steps.dep-shas.outputs.mbe_sha }}" "$mf" &&
+               grep -Fxq "codec2_sha=${{ steps.dep-shas.outputs.codec2_sha }}" "$mf" &&
+               grep -Fxq "rtlsdr_sha=${{ steps.dep-shas.outputs.rtlsdr_sha }}" "$mf"; then
+              echo "Dependency cache manifest matches requested SHAs"
+            else
+              echo "Dependency cache manifest is missing or stale; clearing $DEPS_PREFIX"
+              rm -rf "$DEPS_PREFIX"
+            fi
+          fi
+          mkdir -p "$DEPS_PREFIX"
+
       - name: Install base toolchain + libs (Homebrew)
         shell: bash
         run: |

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -8,10 +8,6 @@ on:
       - "v*.*.*"
     paths-ignore:
       - ".*"
-      - ".github/*.yml"
-      - ".github/*.yaml"
-      - ".github/**/*.yml"
-      - ".github/**/*.yaml"
       - "**/*.md"
 
 concurrency:
@@ -32,7 +28,6 @@ jobs:
       id-token: write
       packages: write
     env:
-      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       # Use a release-only triplet to avoid building debug variants of vcpkg deps.
       VCPKG_DEFAULT_TRIPLET: x64-windows-dynamic-release
       VCPKG_TARGET_TRIPLET: x64-windows-dynamic-release
@@ -232,24 +227,84 @@ jobs:
           subject-path: ${{ steps.zip.outputs.ZIP_PATH }}
           sbom-path: ${{ steps.zip.outputs.ZIP_PATH }}.spdx.json
 
+  publish-native-msvc:
+    name: Publish native MSVC ZIP
+    needs: build-native-msvc
+    runs-on: ubuntu-latest
+    if: >-
+      github.repository == 'arancormonk/dsd-neo' &&
+      (startsWith(github.ref, 'refs/tags/v') ||
+      ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')))
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Prepare artifact naming
+        id: names
+        shell: bash
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "$REF_TYPE" = 'tag' ] && [ -n "$REF_NAME" ]; then
+            zip="dist/dsd-neo-msvc-x86_64-native-${REF_NAME}.zip"
+            artName="dsd-neo-msvc-x86_64-native-${REF_NAME}"
+            title="dsd-neo ${REF_NAME#v}"
+          else
+            zip="dist/dsd-neo-msvc-x86_64-native-nightly.zip"
+            artName="dsd-neo-msvc-x86_64-native-nightly"
+            title="nightly"
+          fi
+          mkdir -p dist
+          {
+            echo "ZIP_PATH=$zip"
+            echo "ART_NAME=$artName"
+            echo "RELEASE_TITLE=$title"
+          } >> "$GITHUB_OUTPUT"
+      - name: Download package artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ steps.names.outputs.ART_NAME }}
+          path: dist
+      - name: Download package SBOM artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ steps.names.outputs.ART_NAME }}.spdx.json
+          path: dist
+      - name: Verify downloaded release files
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f "${{ steps.names.outputs.ZIP_PATH }}"
+          test -f "${{ steps.names.outputs.ZIP_PATH }}.spdx.json"
       - name: Upload native MSVC release asset
-        if: startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != ''
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           files: |
-            ${{ steps.zip.outputs.ZIP_PATH }}
-            ${{ steps.zip.outputs.ZIP_PATH }}.spdx.json
-          name: ${{ steps.release.outputs.release_title }}
+            ${{ steps.names.outputs.ZIP_PATH }}
+            ${{ steps.names.outputs.ZIP_PATH }}.spdx.json
+          name: ${{ steps.names.outputs.RELEASE_TITLE }}
           generate_release_notes: true
-          token: ${{ env.RELEASE_TOKEN }}
-
-      - name: Upload native MSVC nightly asset (overwrite)
-        if: ${{ !startsWith(github.ref, 'refs/tags/') && env.RELEASE_TOKEN != '' }}
-        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de
+          overwrite_files: true
+          fail_on_unmatched_files: true
+          token: ${{ github.token }}
+      - name: Upload native MSVC nightly assets (overwrite)
+        if: >-
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+          (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
-          repo_token: ${{ env.RELEASE_TOKEN }}
-          tag: nightly
+          tag_name: nightly
+          name: nightly
           prerelease: true
-          file: ${{ steps.zip.outputs.ZIP_PATH }}
-          asset_name: dsd-neo-msvc-x86_64-native-nightly.zip
-          overwrite: true
+          make_latest: false
+          target_commitish: ${{ github.sha }}
+          files: |
+            ${{ steps.names.outputs.ZIP_PATH }}
+            ${{ steps.names.outputs.ZIP_PATH }}.spdx.json
+          overwrite_files: true
+          fail_on_unmatched_files: true
+          token: ${{ github.token }}

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -30,12 +30,18 @@ jobs:
       artifact-metadata: write
       contents: read
       id-token: write
+      packages: write
     env:
       RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       # Use a release-only triplet to avoid building debug variants of vcpkg deps.
       VCPKG_DEFAULT_TRIPLET: x64-windows-dynamic-release
       VCPKG_TARGET_TRIPLET: x64-windows-dynamic-release
       VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}\vcpkg-triplets
+      # vcpkg removed the GitHub Actions binary cache backend; use GitHub Packages via NuGet.
+      VCPKG_EXE: ${{ github.workspace }}/vcpkg/vcpkg.exe
+      VCPKG_NUGET_FEED: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+      VCPKG_NUGET_USER: ${{ github.repository_owner }}
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
       # Enable sccache GitHub Actions backend.
       SCCACHE_GHA_ENABLED: "true"
     steps:
@@ -67,6 +73,26 @@ jobs:
           # run-vcpkg v11.5 requires a full 40-char SHA1.
           # Keep this in sync with vcpkg.json's builtin-baseline.
           vcpkgGitCommitId: "56bb2411609227288b70117ead2c47585ba07713"
+
+      - name: Configure vcpkg binary cache
+        shell: pwsh
+        env:
+          VCPKG_NUGET_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $nuget = (& $env:VCPKG_EXE fetch nuget | Select-Object -Last 1)
+          if (-not $nuget) { throw "vcpkg fetch nuget did not return a path" }
+
+          & $nuget sources add `
+            -Source "$env:VCPKG_NUGET_FEED" `
+            -StorePasswordInClearText `
+            -Name GitHubPackages `
+            -UserName "$env:VCPKG_NUGET_USER" `
+            -Password "$env:VCPKG_NUGET_TOKEN" `
+            -NonInteractive
+
+          & $nuget setapikey "$env:VCPKG_NUGET_TOKEN" `
+            -Source "$env:VCPKG_NUGET_FEED" `
+            -NonInteractive
 
       - name: Install vcpkg dependencies (MSVC)
         shell: pwsh

--- a/docs/openssf-baseline.md
+++ b/docs/openssf-baseline.md
@@ -30,9 +30,10 @@ enabled in GitHub.
 - Pull request workflows use least-privilege `GITHUB_TOKEN` permissions. The
   default GitHub Actions workflow permission for the repository is read-only,
   and workflows keep `GITHUB_TOKEN` read-only by default. GitHub Release and
-  nightly publication, when enabled, uses a maintainer-scoped `RELEASE_TOKEN`
-  secret only in trusted upstream non-PR release/nightly paths. AUR update
-  credentials are likewise restricted to upstream non-PR AUR update paths.
+  nightly publication elevate `contents: write` only in trusted upstream non-PR
+  release/nightly paths and publish with the workflow `GITHUB_TOKEN`. AUR
+  update credentials are likewise restricted to upstream non-PR AUR update
+  paths.
 - Official project channels and distribution channels are GitHub HTTPS URLs and
   AUR HTTPS URLs.
 - The project prevents accidental credential storage through contributor policy,

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -9,9 +9,9 @@ https://github.com/arancormonk/dsd-neo/releases
 Release tags use the form `vX.Y.Z`. The tag must match the project version
 declared by CMake, or the release workflow fails before packaging.
 
-Nightly assets are published from the moving `nightly` tag when the maintainer
-publication token is configured. They are intended for testing rather than
-stable deployment.
+Nightly assets are published from the moving `nightly` tag on trusted upstream
+main-branch builds. They are intended for testing rather than stable
+deployment.
 
 ## Source Tag Verification
 
@@ -40,9 +40,8 @@ git tag -v vX.Y.Z
 Release assets are distributed over GitHub HTTPS. Tag release workflows generate
 SBOMs and GitHub artifact attestations for packaged Linux AppImage, macOS DMG,
 and Windows ZIP assets when the corresponding workflow completes successfully.
-The workflows keep `GITHUB_TOKEN` read-only; uploading assets to GitHub Releases
-uses the maintainer-scoped `RELEASE_TOKEN` secret when it is configured. If that
-secret is not configured, publish reviewed workflow artifacts manually.
+Release publication jobs use `contents: write` only in trusted upstream
+release/nightly paths and publish with the workflow `GITHUB_TOKEN`.
 
 Download assets from the release page, then verify an artifact attestation with
 GitHub CLI when available:


### PR DESCRIPTION
## Summary

- harden workflow caching and vcpkg cache handling already present on this branch
- publish tag and nightly release assets from scoped workflow publish jobs
- remove the unused `RELEASE_TOKEN` path and publish with `GITHUB_TOKEN`
- update release/security documentation for the new publication model

## Root Cause

Release package artifacts were being generated, but GitHub Release uploads were gated on an unused secret, so the upload steps were skipped and existing release assets stayed stale.

## Validation

- `actionlint`
- `git diff --check`
- `tools/zizmor.sh`
- pre-push hook: Semgrep strict, workflow lint, zizmor, lizard, install destination check

Note: pre-push scan-build full rebuild was skipped by the hook default.