### PR TITLE
ci: normalize release sbom filenames

### DIFF
--- a/.github/workflows/linux-appimage.yaml
+++ b/.github/workflows/linux-appimage.yaml
@@ -502,6 +502,11 @@ jobs:
         with:
           name: ${{ steps.names.outputs.ART }}.spdx.json
           path: dist
+      - name: Normalize downloaded SBOM filename
+        shell: bash
+        run: |
+          set -euo pipefail
+          mv -f "dist/${{ steps.names.outputs.ART }}.spdx.json" "${{ steps.names.outputs.OUT }}.spdx.json"
       - name: Verify downloaded release files
         shell: bash
         run: |

--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -504,6 +504,11 @@ jobs:
         with:
           name: ${{ steps.names.outputs.ART_NAME }}.spdx.json
           path: dist
+      - name: Normalize downloaded SBOM filename
+        shell: bash
+        run: |
+          set -euo pipefail
+          mv -f "dist/${{ steps.names.outputs.ART_NAME }}.spdx.json" "${{ steps.names.outputs.DMG_PATH }}.spdx.json"
       - name: Verify downloaded release files
         shell: bash
         run: |

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -273,6 +273,11 @@ jobs:
         with:
           name: ${{ steps.names.outputs.ART_NAME }}.spdx.json
           path: dist
+      - name: Normalize downloaded SBOM filename
+        shell: bash
+        run: |
+          set -euo pipefail
+          mv -f "dist/${{ steps.names.outputs.ART_NAME }}.spdx.json" "${{ steps.names.outputs.ZIP_PATH }}.spdx.json"
       - name: Verify downloaded release files
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- normalize downloaded SBOM artifact filenames in Linux AppImage, macOS DMG, and Windows ZIP publish jobs
- keep release upload paths as `<package filename>.spdx.json`
- fix publish verification after `actions/download-artifact` extracts SBOM artifacts by artifact name

## Root Cause

The build jobs generated SBOM files named after the packaged asset, but uploaded the workflow artifact under the shorter artifact name. Publish jobs downloaded the SBOM artifact successfully, then verified and uploaded the package-filename path, which did not exist until normalized.

## Validation

- `actionlint`
- `git diff --check`
- `tools/zizmor.sh`
- pre-push hook: Semgrep strict, workflow lint, zizmor, lizard, install destination check

Note: pre-push scan-build full rebuild was skipped by the hook default.