### PR TITLE
build(iwyu): include platform header for used attribute

### DIFF
--- a/src/protocol/dmr/dmr_block.c
+++ b/src/protocol/dmr/dmr_block.c
@@ -20,7 +20,6 @@
 #include <dsd-neo/crypto/aes.h>
 #include <dsd-neo/crypto/des.h>
 #include <dsd-neo/crypto/rc4.h>
-#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/protocol/dmr/dmr_utf8_text.h>
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
@@ -33,6 +32,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/platform.h"
 
 #define DMR_PDU_DECRYPTION //disable to skip attempting to decrypt DMR PDUs
 

--- a/src/protocol/dmr/dmr_pdu.c
+++ b/src/protocol/dmr/dmr_pdu.c
@@ -18,7 +18,6 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/time_format.h>
 #include <dsd-neo/platform/file_compat.h>
-#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/protocol/dmr/dmr_utf8_text.h>
 #include <dsd-neo/protocol/pdu.h>
@@ -32,6 +31,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/platform.h"
 
 static inline void dsd_append(char* dst, size_t dstsz, const char* src);
 

--- a/src/protocol/p25/phase1/p25p1_pdu_trunking.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_trunking.c
@@ -16,7 +16,6 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
-#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_frequency.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
@@ -29,6 +28,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/platform.h"
 
 static inline int
 p25_signed_offset_units(int sign_bit, int raw_offset) {

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -23,7 +23,6 @@
 #include <dsd-neo/core/time_format.h>
 #include <dsd-neo/core/vocoder.h>
 #include <dsd-neo/fec/ez.h>
-#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/protocol/p25/p25.h>
 #include <dsd-neo/protocol/p25/p25_lfsr.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
@@ -42,6 +41,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/platform.h"
 
 #ifdef USE_RADIO
 #endif

--- a/src/ui/terminal/dsd_ncurses_handler.c
+++ b/src/ui/terminal/dsd_ncurses_handler.c
@@ -13,7 +13,6 @@
 #include <curses.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
-#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/runtime/telemetry.h>
 #include <dsd-neo/ui/keymap.h>
 #include <dsd-neo/ui/menu_core.h>
@@ -26,6 +25,7 @@
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/platform.h"
 #ifdef USE_RTLSDR
 #include <dsd-neo/io/rtl_stream_c.h>
 #endif

--- a/src/ui/terminal/menu_prompts.c
+++ b/src/ui/terminal/menu_prompts.c
@@ -16,12 +16,12 @@
 #include <curses.h>
 #include <dsd-neo/core/string_utils.h>
 #include <dsd-neo/platform/curses_compat.h>
-#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/ui/keymap.h>
 #include <dsd-neo/ui/ui_prims.h>
 #include <stdlib.h>
 #include <string.h>
 #include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/platform/platform.h"
 #include "dsd-neo/ui/menu_core.h"
 #include "menu_internal.h"
 


### PR DESCRIPTION
## Summary

- Replace unnecessary `posix_compat.h` includes with `platform.h` in the IWYU-reported DMR, P25, and terminal UI translation units.
- Keep POSIX compatibility wrappers scoped to files that use the portability APIs.
- Resolve the strict IWYU findings for `DSD_ATTR_USED` without changing behavior.

## Validation

- `tools/iwyu.sh --strict --jobs 6 -- src/protocol/dmr/dmr_block.c src/protocol/dmr/dmr_pdu.c src/protocol/p25/phase1/p25p1_pdu_trunking.c src/protocol/p25/phase2/p25p2_frame.c src/ui/terminal/dsd_ncurses_handler.c src/ui/terminal/menu_prompts.c`
- `tools/iwyu.sh --strict --jobs 8`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- Pre-push hook completed changed-path checks: clang-format, clang-tidy, cppcheck, IWYU, GCC analyzer, Semgrep, and Lizard.