### PR TITLE
ci: keep scorecard publish job action-only

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   wait-for-linux-ci:
     name: Wait for Linux CI
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -72,7 +72,10 @@ jobs:
   scorecard:
     name: OpenSSF Scorecard
     needs: [wait-for-linux-ci]
-    if: always() && (github.event_name != 'push' || needs.wait-for-linux-ci.result == 'success')
+    if: >-
+      always() &&
+      github.ref_name == github.event.repository.default_branch &&
+      (github.event_name != 'push' || needs.wait-for-linux-ci.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       checks: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,25 +18,14 @@ permissions:
   pull-requests: read
 
 jobs:
-  scorecard:
-    name: OpenSSF Scorecard
+  wait-for-linux-ci:
+    name: Wait for Linux CI
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      checks: read
-      contents: read
-      issues: read
-      id-token: write
-      pull-requests: read
-      security-events: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
       - name: Wait for Linux CI checks
-        if: github.event_name == 'push'
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
@@ -60,8 +49,12 @@ jobs:
             if [ -n "$run_state" ]; then
               IFS=$'\t' read -r status conclusion <<< "$run_state"
               if [ "$status" = completed ]; then
-                echo "linux-ci completed with conclusion: ${conclusion:-unknown}"
-                break
+                if [ "$conclusion" = success ]; then
+                  echo "linux-ci completed with conclusion: success"
+                  break
+                fi
+                echo "linux-ci completed with non-success conclusion: ${conclusion:-unknown}" >&2
+                exit 1
               fi
               echo "linux-ci is $status; waiting before Scorecard..."
             else
@@ -75,6 +68,24 @@ jobs:
 
             sleep 30
           done
+
+  scorecard:
+    name: OpenSSF Scorecard
+    needs: [wait-for-linux-ci]
+    if: always() && (github.event_name != 'push' || needs.wait-for-linux-ci.result == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+      issues: read
+      id-token: write
+      pull-requests: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a


### PR DESCRIPTION
## Summary

- Move the Linux CI polling step into a separate prerequisite job.
- Keep the `OpenSSF Scorecard` job limited to action steps so `publish_results: true` can pass Scorecard workflow verification.
- Require the matching `linux-ci` push run to complete successfully before the Scorecard job runs on default-branch pushes.
- Skip Scorecard on non-default refs, because Scorecard publishing only supports the default branch.

## Root Cause

The failed post-merge Scorecard run completed the Linux CI wait step, then failed inside `ossf/scorecard-action` while publishing results:

`workflow verification failed: scorecard job must only have steps with uses`

The shell polling step was inside the same job as the Scorecard action. Scorecard's publishing verification rejects that job shape even though the polling itself succeeded.

## Validation

- `tools/workflow_lint.sh .github/workflows/scorecard.yml`
- `tools/zizmor.sh .github/workflows/scorecard.yml`
- pre-push checks: CMake install target check, Semgrep strict, workflow lint, zizmor, Lizard complexity
- Manual branch dispatch of `scorecard.yml` now skips on the non-default ref instead of failing Scorecard publishing