### PR TITLE
security: address CodeQL thread and UI alerts

### DIFF
--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -155,8 +155,6 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-latest
-    # Do not run this full Release build on pull_request; keep it for push/dispatch
-    if: github.event_name != 'pull_request'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -365,7 +363,7 @@ jobs:
 
       - name: Smoke test - show CLI help
         run: |
-          ./build/dev-release/apps/dsd-cli/dsd-neo -h || true
+          ./build/dev-release/apps/dsd-cli/dsd-neo -h
 
       - name: Show ccache stats
         if: always()
@@ -879,9 +877,6 @@ jobs:
   sanitize-linux:
     name: Linux • Debug • sanitizer (${{ matrix.name }})
     runs-on: ubuntu-latest
-    # Keep sanitizer coverage on push/manual runs. Pull requests get the
-    # non-sanitized debug build+ctest in backend-pr for faster feedback.
-    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -266,6 +266,7 @@ jobs:
           ./build/dev-release/apps/dsd-cli/dsd-neo -h || true
 
       - name: Stage portable tree
+        if: github.event_name != 'pull_request'
         id: stage
         shell: bash
         run: |
@@ -377,6 +378,7 @@ jobs:
           find "$STAGE/lib" -maxdepth 1 -type f -name '*.dylib' -exec basename {} \; | sort -f > "$STAGE/dylibs-manifest.txt"
 
       - name: Smoke test staged binary
+        if: github.event_name != 'pull_request'
         shell: bash
         run: |
           set -euo pipefail
@@ -385,6 +387,7 @@ jobs:
           "$STAGE/bin/dsd-neo" -h || true
 
       - name: Create DMG
+        if: github.event_name != 'pull_request'
         id: dmg
         shell: bash
         env:
@@ -416,6 +419,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Verify DMG contents (mount and run help)
+        if: github.event_name != 'pull_request'
         shell: bash
         run: |
           set -euxo pipefail
@@ -430,6 +434,7 @@ jobs:
           trap - EXIT
 
       - name: Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.dmg.outputs.ART_NAME }}
@@ -437,6 +442,7 @@ jobs:
           retention-days: 7
 
       - name: Generate artifact SBOM
+        if: github.event_name != 'pull_request'
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610
         with:
           file: ${{ steps.dmg.outputs.DMG_PATH }}

--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -9,6 +9,8 @@ on:
     paths-ignore:
       - ".*"
       - "**/*.md"
+  pull_request:
+    branches: [main, master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -115,6 +115,7 @@ jobs:
           & $env:SCCACHE_PATH --show-stats
 
       - name: Stage native MSVC tree
+        if: github.event_name != 'pull_request'
         id: stage
         shell: pwsh
         run: |
@@ -149,6 +150,7 @@ jobs:
           }
 
       - name: Smoke test staged binary (MSVC)
+        if: github.event_name != 'pull_request'
         shell: pwsh
         run: |
           $exe = 'dist/dsd-neo-msvc/bin/dsd-neo.exe'
@@ -161,6 +163,7 @@ jobs:
           & $exe -h
 
       - name: Archive native MSVC ZIP
+        if: github.event_name != 'pull_request'
         shell: pwsh
         env:
           REF_TYPE: ${{ github.ref_type }}
@@ -182,6 +185,7 @@ jobs:
         id: zip
 
       - name: Verify ZIP contents (extract and run help)
+        if: github.event_name != 'pull_request'
         shell: pwsh
         run: |
           $zip = '${{ steps.zip.outputs.ZIP_PATH }}'
@@ -200,6 +204,7 @@ jobs:
           & $exe -h
 
       - name: Upload native MSVC artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.zip.outputs.ART_NAME }}
@@ -207,6 +212,7 @@ jobs:
           retention-days: 7
 
       - name: Generate native MSVC SBOM
+        if: github.event_name != 'pull_request'
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610
         with:
           file: ${{ steps.zip.outputs.ZIP_PATH }}

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -9,6 +9,8 @@ on:
     paths-ignore:
       - ".*"
       - "**/*.md"
+  pull_request:
+    branches: [main, master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/include/dsd-neo/platform/threading.h
+++ b/include/dsd-neo/platform/threading.h
@@ -65,17 +65,27 @@ typedef void* (*dsd_thread_fn)(void*);
 /**
  * @brief Create and start a new thread.
  *
- * On POSIX C builds this expands to pthread_create at the call site so static
- * analysis can preserve the concrete thread entry/argument pairing. C++ builds
- * use the wrapper function to avoid -Waddress when passing named thread entry
- * functions.
+ * On POSIX C/C++ builds this expands to pthread_create at the call site so
+ * static analysis can preserve the concrete thread entry/argument pairing.
+ * The C++ form uses a lambda to keep the null checks without triggering
+ * -Waddress when passing named thread entry functions.
  *
  * @param thread    Pointer to thread handle (output).
  * @param func      Thread entry function.
  * @param arg       Argument passed to thread function.
  * @return 0 on success, non-zero error code on failure.
  */
-#if !DSD_PLATFORM_WIN_NATIVE && !defined(DSD_NEO_THREADING_NO_INLINE_CREATE) && !defined(__cplusplus)
+#if !DSD_PLATFORM_WIN_NATIVE && !defined(DSD_NEO_THREADING_NO_INLINE_CREATE) && defined(__cplusplus)
+#define dsd_thread_create(thread, func, arg)                                                                           \
+    ([&]() -> int {                                                                                                    \
+        dsd_thread_t* const dsd_thread_handle__ = (thread);                                                            \
+        dsd_thread_fn const dsd_thread_func__ = (func);                                                                \
+        void* const dsd_thread_arg__ = (arg);                                                                          \
+        return (!dsd_thread_handle__ || !dsd_thread_func__)                                                            \
+                   ? EINVAL                                                                                            \
+                   : pthread_create(dsd_thread_handle__, NULL, dsd_thread_func__, dsd_thread_arg__);                   \
+    }())
+#elif !DSD_PLATFORM_WIN_NATIVE && !defined(DSD_NEO_THREADING_NO_INLINE_CREATE)
 #define dsd_thread_create(thread, func, arg)                                                                           \
     (((thread) == NULL || (func) == NULL) ? EINVAL : pthread_create((thread), NULL, (func), (arg)))
 #else

--- a/src/ui/terminal/dsd_ncurses_handler.c
+++ b/src/ui/terminal/dsd_ncurses_handler.c
@@ -217,10 +217,10 @@ ncurses_input_handler(dsd_opts* opts, dsd_state* state, int c) {
 
     // If the nonblocking menu overlay is open, route keys to it first.
     if (ui_menu_is_open()) {
-        if (c != -1) {
-            ui_menu_handle_key(c, opts, state);
+        if (c == -1) {
+            return 1;
         }
-        return 1; // consume all keys while menu overlay is active
+        return (uint8_t)(ui_menu_handle_key(c, opts, state) || ui_menu_is_open());
     }
 
     if (ncurses_handle_escape_or_history(opts, state, c)) {

--- a/tests/ui/test_ui_hotkeys_regression.c
+++ b/tests/ui/test_ui_hotkeys_regression.c
@@ -42,6 +42,9 @@ static UiPostCapture g_cap;
 static int g_redraw_calls = 0;
 static int g_history_mode = 1;
 static int g_history_cycle_calls = 0;
+static int g_menu_open = 0;
+static int g_menu_handle_key_calls = 0;
+static int g_menu_last_key = ERR;
 
 int
 ui_post_cmd(int cmd_id, const void* payload, size_t payload_sz) { // NOLINT(misc-use-internal-linkage)
@@ -86,14 +89,15 @@ ui_history_cycle_mode(void) { // NOLINT(misc-use-internal-linkage)
 
 int
 ui_menu_is_open(void) { // NOLINT(misc-use-internal-linkage)
-    return 0;
+    return g_menu_open;
 }
 
 int
 ui_menu_handle_key(int ch, dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)ch;
     (void)opts;
     (void)state;
+    g_menu_handle_key_calls++;
+    g_menu_last_key = ch;
     return 0;
 }
 
@@ -122,6 +126,9 @@ cap_reset(void) {
     g_redraw_calls = 0;
     g_history_cycle_calls = 0;
     g_history_mode = 1;
+    g_menu_open = 0;
+    g_menu_handle_key_calls = 0;
+    g_menu_last_key = ERR;
 }
 
 static uint32_t
@@ -141,6 +148,15 @@ main(void) {
         free(opts);
         return 1;
     }
+
+    /* Open menu overlay should receive keys before hotkeys and keep input consumed. */
+    cap_reset();
+    g_menu_open = 1;
+    assert(ncurses_input_handler(opts, state, DSD_KEY_HISTORY) == 1);
+    assert(g_menu_handle_key_calls == 1);
+    assert(g_menu_last_key == DSD_KEY_HISTORY);
+    assert(g_history_cycle_calls == 0);
+    assert(g_cap.calls == 0);
 
     /* 'h' must cycle immediately in UI thread (no command queue dependency). */
     cap_reset();


### PR DESCRIPTION
## Summary

- expose POSIX C++ thread entry and argument pairs at the call site so CodeQL can follow each thread start without changing runtime behavior
- route ncurses overlay keys through the menu handler result instead of ignoring it
- add regression coverage for open-menu key consumption before normal hotkeys
- run macOS, Windows, Linux release, and Linux sanitizer checks on pull requests, and include them in the required PR gate
- keep PR platform jobs focused on compile/link validation by skipping release asset packaging on pull requests

## Required PR Gate Coverage

- Linux debug build plus full unit suite: `backend-pr (both)`
- Linux release compile/link: `build-linux`
- Linux sanitizer CTest runs: `Linux • Debug • sanitizer (asan-ubsan)`, `Linux • Debug • sanitizer (tsan)`
- macOS release compile/link: `build-portable-dmg`
- Windows MSVC release compile/link: `build-native-msvc`

## Validation

- `cmake --build --preset dev-debug -j`
- focused CTest run for threading, runtime ring/config, platform thread, UI hotkey, and RTL paths
- `ctest --preset dev-debug --output-on-failure` (`333/333` passed)
- pre-push strict checks for workflow-only changes: Semgrep, workflow lint, zizmor, and lizard
- latest `linux-ci` pull request run: https://github.com/arancormonk/dsd-neo/actions/runs/26457408295
- latest `macos-ci` pull request run: https://github.com/arancormonk/dsd-neo/actions/runs/26457408214
- latest `windows-ci` pull request run: https://github.com/arancormonk/dsd-neo/actions/runs/26457408451
- latest `codeql` pull request run: https://github.com/arancormonk/dsd-neo/actions/runs/26457408316
- latest `guardrails` pull request run: https://github.com/arancormonk/dsd-neo/actions/runs/26457408270
