### PR TITLE
security: fix event strings and code scanning findings

### DIFF
--- a/include/dsd-neo/core/file_io.h
+++ b/include/dsd-neo/core/file_io.h
@@ -18,6 +18,7 @@
 #include <dsd-neo/core/state_fwd.h>
 
 #include <sndfile.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -43,7 +44,7 @@ void openWavOutFile(dsd_opts* opts, dsd_state* state);
 void openWavOutFileL(dsd_opts* opts, dsd_state* state);
 void openWavOutFileR(dsd_opts* opts, dsd_state* state);
 void openWavOutFileLR(dsd_opts* opts, dsd_state* state);
-SNDFILE* open_wav_file(char* dir, char* temp_filename, uint16_t sample_rate, uint8_t ext);
+SNDFILE* open_wav_file(char* dir, char* temp_filename, size_t temp_filename_size, uint16_t sample_rate, uint8_t ext);
 void openWavOutFileRaw(dsd_opts* opts, dsd_state* state);
 void openSymbolOutFile(dsd_opts* opts, dsd_state* state);
 SNDFILE* close_wav_file(SNDFILE* wav_file);

--- a/include/dsd-neo/io/udp_control.h
+++ b/include/dsd-neo/io/udp_control.h
@@ -26,9 +26,8 @@ struct udp_control;
  * @brief Callback invoked on valid retune command.
  *
  * @param new_frequency_hz Parsed requested center frequency in Hz.
- * @param user_data Opaque pointer passed from the start function.
  */
-typedef void (*udp_control_retune_cb)(uint32_t new_frequency_hz, void* user_data);
+typedef void (*udp_control_retune_cb)(uint32_t new_frequency_hz);
 
 /**
  * @brief Start UDP control thread.
@@ -39,10 +38,9 @@ typedef void (*udp_control_retune_cb)(uint32_t new_frequency_hz, void* user_data
  *
  * @param udp_port UDP port to bind and listen on (0 disables/start no-op).
  * @param cb Callback invoked upon receiving a valid retune command.
- * @param user_data Opaque pointer passed to the callback.
  * @return Opaque handle on success; NULL on failure.
  */
-struct udp_control* udp_control_start(int udp_port, udp_control_retune_cb cb, void* user_data);
+struct udp_control* udp_control_start(int udp_port, udp_control_retune_cb cb);
 
 /**
  * @brief Start UDP control thread bound to a specific IPv4 address.
@@ -53,11 +51,9 @@ struct udp_control* udp_control_start(int udp_port, udp_control_retune_cb cb, vo
  * @param bindaddr Numeric IPv4 address to bind.
  * @param udp_port UDP port to bind and listen on (0 disables/start no-op).
  * @param cb Callback invoked upon receiving a valid retune command.
- * @param user_data Opaque pointer passed to the callback.
  * @return Opaque handle on success; NULL on failure.
  */
-struct udp_control* udp_control_start_bound(const char* bindaddr, int udp_port, udp_control_retune_cb cb,
-                                            void* user_data);
+struct udp_control* udp_control_start_bound(const char* bindaddr, int udp_port, udp_control_retune_cb cb);
 
 /**
  * @brief Stop UDP control thread and free resources.

--- a/include/dsd-neo/protocol/p25/p25_pdu.h
+++ b/include/dsd-neo/protocol/p25/p25_pdu.h
@@ -16,6 +16,7 @@
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -29,8 +30,8 @@ uint8_t p25_decode_es_header_2(const dsd_opts* opts, const dsd_state* state, uin
 void p25_decode_extended_address(dsd_opts* opts, dsd_state* state, const uint8_t* input, uint8_t* sap, int* ptr);
 void p25_decode_pdu_header(dsd_opts* opts, dsd_state* state, const uint8_t* input);
 void p25_decode_pdu_data(dsd_opts* opts, dsd_state* state, uint8_t* input, int len);
-void p25_decode_rsp(uint8_t C, uint8_t T, uint8_t S, char* rsp_string);
-void p25_decode_sap(uint8_t SAP, char* sap_string);
+void p25_decode_rsp(uint8_t C, uint8_t T, uint8_t S, char* rsp_string, size_t rsp_string_size);
+void p25_decode_sap(uint8_t SAP, char* sap_string, size_t sap_string_size);
 
 #ifdef __cplusplus
 }

--- a/semgrep/dsd-neo.yml
+++ b/semgrep/dsd-neo.yml
@@ -64,6 +64,33 @@ rules:
         - /src/third_party/**
     pattern: DSD_SPRINTF(...)
 
+  - id: dsd-neo.no-sizeof-function-parameter-in-dsd-snprintf
+    languages: [c, cpp]
+    severity: ERROR
+    message: Function parameters have pointer size in C; pass the explicit destination capacity to DSD_SNPRINTF.
+    paths:
+      include:
+        - /apps/**
+        - /include/**
+        - /src/**
+        - /tests/**
+      exclude:
+        - /include/dsd-neo/core/safe_api.h
+        - /src/third_party/**
+    pattern-either:
+      - patterns:
+          - pattern-inside: |
+              $RET $FUNC(..., $TYPE *$DST, ...) {
+                ...
+              }
+          - pattern: DSD_SNPRINTF($DST, sizeof($DST), ...)
+      - patterns:
+          - pattern-inside: |
+              $RET $FUNC(..., $TYPE $DST[$N], ...) {
+                ...
+              }
+          - pattern: DSD_SNPRINTF($DST, sizeof($DST), ...)
+
   - id: dsd-neo.no-direct-third-party-include
     languages: [c, cpp]
     severity: ERROR

--- a/src/core/file/dsd_file.c
+++ b/src/core/file/dsd_file.c
@@ -622,18 +622,28 @@ openMbeOutFileR(dsd_opts* opts, dsd_state* state) {
 
 //temp filename should not have the .wav extension, will be renamed with one after event is closed
 SNDFILE*
-open_wav_file(char* dir, char* temp_filename, uint16_t sample_rate, uint8_t ext) {
+open_wav_file(char* dir, char* temp_filename, size_t temp_filename_size, uint16_t sample_rate, uint8_t ext) {
+    if (temp_filename == NULL || temp_filename_size == 0) {
+        return NULL;
+    }
+
     uint16_t random_number = rand();
     char datestr[9];
     char timestr[7];
     getDate_buf(datestr);
     getTime_buf(timestr);
 
+    int written = 0;
     if (ext == 0) {
-        DSD_SNPRINTF(temp_filename, sizeof(temp_filename), "%s/TEMP_%s_%s_%04X", dir, datestr, timestr, random_number);
+        written =
+            DSD_SNPRINTF(temp_filename, temp_filename_size, "%s/TEMP_%s_%s_%04X", dir, datestr, timestr, random_number);
     } else {
-        DSD_SNPRINTF(temp_filename, sizeof(temp_filename), "%s/TEMP_%s_%s_%04X.wav", dir, datestr, timestr,
-                     random_number);
+        written = DSD_SNPRINTF(temp_filename, temp_filename_size, "%s/TEMP_%s_%s_%04X.wav", dir, datestr, timestr,
+                               random_number);
+    }
+    if (written < 0 || (size_t)written >= temp_filename_size) {
+        LOG_ERROR("Error - wav output temp filename is too long\n");
+        return NULL;
     }
 
     /* stack buffers; no free */

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -270,14 +270,14 @@ watchdog_event_rotate_wav_if_needed(dsd_opts* opts, const Event_History_I* event
     if (slot == 0 && opts->wav_out_f != NULL) {
         opts->wav_out_f =
             close_and_rename_wav_file(opts->wav_out_f, opts, opts->wav_out_file, opts->wav_out_dir, event_struct);
-        opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, 8000, 0);
+        opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, sizeof opts->wav_out_file, 8000, 0);
         return;
     }
 
     if (slot == 1 && opts->wav_out_fR != NULL) {
         opts->wav_out_fR =
             close_and_rename_wav_file(opts->wav_out_fR, opts, opts->wav_out_fileR, opts->wav_out_dir, event_struct);
-        opts->wav_out_fR = open_wav_file(opts->wav_out_dir, opts->wav_out_fileR, 8000, 0);
+        opts->wav_out_fR = open_wav_file(opts->wav_out_dir, opts->wav_out_fileR, sizeof opts->wav_out_fileR, 8000, 0);
     }
 }
 
@@ -792,10 +792,10 @@ watchdog_event_current_build_event_dmr(const dsd_state* state, uint8_t slot, con
                                        const char* datestr, const char* timestr, const char* sys_string,
                                        char* event_string, size_t event_size) {
     if (ctx->sys_id1) {
-        DSD_SNPRINTF(event_string, sizeof(event_string), "%s %s %s TGT: %08d; SRC: %08d; CC: %02d; SYS: %X; ", datestr,
-                     timestr, sys_string, ctx->target_id, ctx->source_id, ctx->sys_id2, ctx->sys_id1);
+        DSD_SNPRINTF(event_string, event_size, "%s %s %s TGT: %08d; SRC: %08d; CC: %02d; SYS: %X; ", datestr, timestr,
+                     sys_string, ctx->target_id, ctx->source_id, ctx->sys_id2, ctx->sys_id1);
     } else {
-        DSD_SNPRINTF(event_string, sizeof(event_string), "%s %s %s TGT: %08d; SRC: %08d; CC: %02d; ", datestr, timestr,
+        DSD_SNPRINTF(event_string, event_size, "%s %s %s TGT: %08d; SRC: %08d; CC: %02d; ", datestr, timestr,
                      sys_string, ctx->target_id, ctx->source_id, ctx->sys_id2);
     }
 
@@ -840,12 +840,11 @@ watchdog_event_current_build_event_p25(const dsd_state* state, uint8_t slot, con
                                        const char* datestr, const char* timestr, const char* sys_string,
                                        char* event_string, size_t event_size) {
     if (ctx->sys_id1) {
-        DSD_SNPRINTF(event_string, sizeof(event_string),
-                     "%s %s %s TGT: %08d; SRC: %08d; NAC: %03X; NET_STS: %05X:%03X:%d.%d; ", datestr, timestr,
-                     sys_string, ctx->target_id, ctx->source_id, ctx->sys_id3, ctx->sys_id1, ctx->sys_id2, ctx->sys_id4,
-                     ctx->sys_id5);
+        DSD_SNPRINTF(event_string, event_size, "%s %s %s TGT: %08d; SRC: %08d; NAC: %03X; NET_STS: %05X:%03X:%d.%d; ",
+                     datestr, timestr, sys_string, ctx->target_id, ctx->source_id, ctx->sys_id3, ctx->sys_id1,
+                     ctx->sys_id2, ctx->sys_id4, ctx->sys_id5);
     } else {
-        DSD_SNPRINTF(event_string, sizeof(event_string), "%s %s %s TGT: %08d; SRC: %08d; NAC: %03X; ", datestr, timestr,
+        DSD_SNPRINTF(event_string, event_size, "%s %s %s TGT: %08d; SRC: %08d; NAC: %03X; ", datestr, timestr,
                      sys_string, ctx->target_id, ctx->source_id, ctx->sys_id3);
     }
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -321,8 +321,8 @@ open_recording_outputs_if_needed(dsd_opts* opts, dsd_state* state) {
             LOG_NOTICE("Creating directory %s to save decoded wav files\n", wav_file_directory);
             dsd_mkdir(wav_file_directory, 0700);
         }
-        opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, 8000, 0);
-        opts->wav_out_fR = open_wav_file(opts->wav_out_dir, opts->wav_out_fileR, 8000, 0);
+        opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, sizeof opts->wav_out_file, 8000, 0);
+        opts->wav_out_fR = open_wav_file(opts->wav_out_dir, opts->wav_out_fileR, sizeof opts->wav_out_fileR, 8000, 0);
     } else if (opts->static_wav_file == 1 && opts->wav_out_f == NULL && opts->wav_out_file[0] != '\0') {
         openWavOutFileLR(opts, state);
     }

--- a/src/io/control/udp_control.cpp
+++ b/src/io/control/udp_control.cpp
@@ -36,7 +36,6 @@ struct udp_control {
     dsd_socket_t sockfd;
     dsd_thread_t thread;
     udp_control_retune_cb cb;
-    void* user_data;
     std::atomic<int> stop_flag;
 };
 
@@ -87,7 +86,7 @@ static DSD_THREAD_RETURN_TYPE
         if (n == 5 && buffer[0] == 0) {
             unsigned int new_freq = udp_chars_to_int(buffer);
             if (ctrl->cb) {
-                ctrl->cb(new_freq, ctrl->user_data);
+                ctrl->cb(new_freq);
             }
             LOG_INFO("\nTuning to: %u [Hz] \n", new_freq);
         }
@@ -103,16 +102,15 @@ static DSD_THREAD_RETURN_TYPE
  *
  * @param udp_port UDP port to bind and listen on (0 disables/start no-op).
  * @param cb Callback invoked upon receiving a valid retune command.
- * @param user_data Opaque pointer passed to the callback.
  * @return Opaque handle on success; NULL on failure.
  */
 extern "C" udp_control*
-udp_control_start(int udp_port, udp_control_retune_cb cb, void* user_data) {
-    return udp_control_start_bound("127.0.0.1", udp_port, cb, user_data);
+udp_control_start(int udp_port, udp_control_retune_cb cb) {
+    return udp_control_start_bound("127.0.0.1", udp_port, cb);
 }
 
 extern "C" udp_control*
-udp_control_start_bound(const char* bindaddr, int udp_port, udp_control_retune_cb cb, void* user_data) {
+udp_control_start_bound(const char* bindaddr, int udp_port, udp_control_retune_cb cb) {
     if (udp_port <= 0 || udp_port > 65535) {
         return NULL;
     }
@@ -155,7 +153,6 @@ udp_control_start_bound(const char* bindaddr, int udp_port, udp_control_retune_c
     ctrl->bindaddr[sizeof ctrl->bindaddr - 1] = '\0';
     ctrl->sockfd = sockfd;
     ctrl->cb = cb;
-    ctrl->user_data = user_data;
     ctrl->stop_flag.store(0);
     int rc = dsd_thread_create(&ctrl->thread, udp_thread_fn, ctrl);
     if (rc != 0) {

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -4478,13 +4478,10 @@ start_threads_and_async(void) {
         }
     }
     if (port != 0) {
-        g_udp_ctrl = udp_control_start_bound(
-            udp_control_bindaddr, port,
-            [](uint32_t new_freq_hz, void* /*user_data*/) {
-                /* Marshal onto controller thread: single programming path */
-                schedule_manual_retune(new_freq_hz);
-            },
-            NULL);
+        g_udp_ctrl = udp_control_start_bound(udp_control_bindaddr, port, [](uint32_t new_freq_hz) {
+            /* Marshal onto controller thread: single programming path */
+            schedule_manual_retune(new_freq_hz);
+        });
         if (!g_udp_ctrl) {
             LOG_ERROR("Failed to start RTL UDP retune control on %s:%u\n", udp_control_bindaddr, (unsigned)port);
         }
@@ -5494,9 +5491,8 @@ stream_open_start_rtltcp_pipeline(const dsd_opts* opts) {
         g_stream->demod_thread_started.store(1, std::memory_order_release);
     }
     if (port != 0) {
-        g_udp_ctrl = udp_control_start_bound(
-            udp_control_bindaddr, port,
-            [](uint32_t new_freq_hz, void* /*user_data*/) { schedule_manual_retune(new_freq_hz); }, NULL);
+        g_udp_ctrl = udp_control_start_bound(udp_control_bindaddr, port,
+                                             [](uint32_t new_freq_hz) { schedule_manual_retune(new_freq_hz); });
         if (!g_udp_ctrl) {
             LOG_ERROR("Failed to start RTL UDP retune control on %s:%u\n", udp_control_bindaddr, (unsigned)port);
         }

--- a/src/protocol/dmr/dmr_csbk.c
+++ b/src/protocol/dmr/dmr_csbk.c
@@ -2751,32 +2751,32 @@ dmr_syscode_decode_model(uint8_t model, uint8_t* cs_pdu_bits, uint16_t* net, uin
     *net = 0;
     *site = 0;
     *site_bits = 0;
-    DSD_SNPRINTF(model_str, sizeof(model_str), "%s", " ");
+    DSD_SNPRINTF(model_str, model_str_sz, "%s", " ");
 
     switch (model) {
         case 0:
             *net = (uint16_t)ConvertBitIntoBytes(&cs_pdu_bits[42], 9);
             *site = (uint16_t)ConvertBitIntoBytes(&cs_pdu_bits[51], 3);
             *site_bits = 3;
-            DSD_SNPRINTF(model_str, sizeof(model_str), "%s", "Tiny");
+            DSD_SNPRINTF(model_str, model_str_sz, "%s", "Tiny");
             break;
         case 1:
             *net = (uint16_t)ConvertBitIntoBytes(&cs_pdu_bits[42], 7);
             *site = (uint16_t)ConvertBitIntoBytes(&cs_pdu_bits[49], 5);
             *site_bits = 5;
-            DSD_SNPRINTF(model_str, sizeof(model_str), "%s", "Small");
+            DSD_SNPRINTF(model_str, model_str_sz, "%s", "Small");
             break;
         case 2:
             *net = (uint16_t)ConvertBitIntoBytes(&cs_pdu_bits[42], 4);
             *site = (uint16_t)ConvertBitIntoBytes(&cs_pdu_bits[46], 8);
             *site_bits = 8;
-            DSD_SNPRINTF(model_str, sizeof(model_str), "%s", "Large");
+            DSD_SNPRINTF(model_str, model_str_sz, "%s", "Large");
             break;
         default:
             *net = (uint16_t)ConvertBitIntoBytes(&cs_pdu_bits[42], 2);
             *site = (uint16_t)ConvertBitIntoBytes(&cs_pdu_bits[44], 10);
             *site_bits = 10;
-            DSD_SNPRINTF(model_str, sizeof(model_str), "%s", "Huge");
+            DSD_SNPRINTF(model_str, model_str_sz, "%s", "Huge");
             break;
     }
 }
@@ -2786,13 +2786,13 @@ dmr_syscode_set_partition_label(uint8_t par, char* par_str, size_t par_str_sz) {
     if (!par_str || par_str_sz == 0) {
         return;
     }
-    DSD_SNPRINTF(par_str, sizeof(par_str), "%s", "Res");
+    DSD_SNPRINTF(par_str, par_str_sz, "%s", "Res");
     if (par == 1) {
-        DSD_SNPRINTF(par_str, sizeof(par_str), "%s", "A");
+        DSD_SNPRINTF(par_str, par_str_sz, "%s", "A");
     } else if (par == 2) {
-        DSD_SNPRINTF(par_str, sizeof(par_str), "%s", "B");
+        DSD_SNPRINTF(par_str, par_str_sz, "%s", "B");
     } else if (par == 3) {
-        DSD_SNPRINTF(par_str, sizeof(par_str), "%s", "AB");
+        DSD_SNPRINTF(par_str, par_str_sz, "%s", "AB");
     }
 }
 

--- a/src/protocol/edacs/edacs-fme.c
+++ b/src/protocol/edacs/edacs-fme.c
@@ -560,7 +560,7 @@ edacs_prepare_voice_wav_output(dsd_opts* opts, dsd_state* state, int is_digital)
 
     opts->wav_out_f = close_and_rename_wav_file(opts->wav_out_f, opts, opts->wav_out_file, opts->wav_out_dir,
                                                 &state->event_history_s[0]);
-    opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, 48000, 0);
+    opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, sizeof opts->wav_out_file, 48000, 0);
 }
 
 static void
@@ -2124,7 +2124,7 @@ eot_cc(dsd_opts* opts, dsd_state* state) {
             opts->wav_out_f = close_and_rename_wav_file(opts->wav_out_f, opts, opts->wav_out_file, opts->wav_out_dir,
                                                         &state->event_history_s[0]);
         }
-        opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, 8000, 0);
+        opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, sizeof opts->wav_out_file, 8000, 0);
     }
 
     //set here so that when returning to the CC, it doesn't go into an immediate hunt if not immediately acquired

--- a/src/protocol/p25/phase1/p25p1_pdu_data.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_data.c
@@ -106,33 +106,36 @@ p25_parse_sap34_syscfg(dsd_opts* opts, dsd_state* state, const uint8_t* p, int p
 }
 
 void
-p25_decode_rsp(uint8_t C, uint8_t T, uint8_t S, char* rsp_string) {
+p25_decode_rsp(uint8_t C, uint8_t T, uint8_t S, char* rsp_string, size_t rsp_string_size) {
+    if (rsp_string == NULL || rsp_string_size == 0) {
+        return;
+    }
 
     if (C == 0) {
-        DSD_SNPRINTF(rsp_string, sizeof(rsp_string), " ACK (Success);");
+        DSD_SNPRINTF(rsp_string, rsp_string_size, " ACK (Success);");
     } else if (C == 2) {
-        DSD_SNPRINTF(rsp_string, sizeof(rsp_string), " SACK (Retry);");
+        DSD_SNPRINTF(rsp_string, rsp_string_size, " SACK (Retry);");
     } else if (C == 1) {
         if (T == 0) {
-            DSD_SNPRINTF(rsp_string, sizeof(rsp_string), " NACK (Illegal Format);");
+            DSD_SNPRINTF(rsp_string, rsp_string_size, " NACK (Illegal Format);");
         } else if (T == 1) {
-            DSD_SNPRINTF(rsp_string, sizeof(rsp_string), " NACK (CRC32 Failure);");
+            DSD_SNPRINTF(rsp_string, rsp_string_size, " NACK (CRC32 Failure);");
         } else if (T == 2) {
-            DSD_SNPRINTF(rsp_string, sizeof(rsp_string), " NACK (Memory Full);");
+            DSD_SNPRINTF(rsp_string, rsp_string_size, " NACK (Memory Full);");
         } else if (T == 3) {
-            DSD_SNPRINTF(rsp_string, sizeof(rsp_string), " NACK (FSN Sequence Error);");
+            DSD_SNPRINTF(rsp_string, rsp_string_size, " NACK (FSN Sequence Error);");
         } else if (T == 4) {
-            DSD_SNPRINTF(rsp_string, sizeof(rsp_string), " NACK (Undeliverable);");
+            DSD_SNPRINTF(rsp_string, rsp_string_size, " NACK (Undeliverable);");
         } else if (T == 5) {
-            DSD_SNPRINTF(rsp_string, sizeof(rsp_string), " NACK (NS/VR Sequence Error);"); //depreciated
+            DSD_SNPRINTF(rsp_string, rsp_string_size, " NACK (NS/VR Sequence Error);"); //depreciated
         } else if (T == 6) {
-            DSD_SNPRINTF(rsp_string, sizeof(rsp_string), " NACK (Invalid User on System);");
+            DSD_SNPRINTF(rsp_string, rsp_string_size, " NACK (Invalid User on System);");
         }
     }
 
     //catch all for everything else
     else {
-        DSD_SNPRINTF(rsp_string, sizeof(rsp_string), " Unknown RSP;");
+        DSD_SNPRINTF(rsp_string, rsp_string_size, " Unknown RSP;");
     }
 
     DSD_FPRINTF(stderr, " Response Packet:%s C: %X; T: %X; S: %X; ", rsp_string, C, T, S);
@@ -180,8 +183,12 @@ p25_sap_label(uint8_t sap) {
 }
 
 void
-p25_decode_sap(uint8_t SAP, char* sap_string) {
-    DSD_SNPRINTF(sap_string, sizeof(sap_string), "%s", p25_sap_label(SAP));
+p25_decode_sap(uint8_t SAP, char* sap_string, size_t sap_string_size) {
+    if (sap_string == NULL || sap_string_size == 0) {
+        return;
+    }
+
+    DSD_SNPRINTF(sap_string, sap_string_size, "%s", p25_sap_label(SAP));
 
     DSD_FPRINTF(stderr, "SAP: 0x%02X;%s ", SAP, sap_string);
 }
@@ -380,7 +387,7 @@ p25_decode_es_header(const dsd_opts* opts, dsd_state* state, uint8_t* input, uin
     uint8_t aux_sap =
         (uint8_t)ConvertBitIntoBytes(&bits[98], 6); //the SAP of the message that is encrypted immediately after
     char aux_sap_string[99];
-    p25_decode_sap(aux_sap, aux_sap_string);
+    p25_decode_sap(aux_sap, aux_sap_string, sizeof aux_sap_string);
     DSD_FPRINTF(stderr, "%s", KNRM);
     UNUSED(aux_res);
 
@@ -454,7 +461,7 @@ p25_decode_extended_address(dsd_opts* opts, dsd_state* state, const uint8_t* inp
     DSD_FPRINTF(stderr, "\n Extended Addressing Header; MFID: %02X; SRC LLID: %d; RES: %08X; CRC: %04X; ", ea_mfid,
                 ea_llid, ea_res, ea_crc);
     char ea_sap_string[99];
-    p25_decode_sap(ea_sap, ea_sap_string);
+    p25_decode_sap(ea_sap, ea_sap_string, sizeof ea_sap_string);
     UNUSED(ea_sap_string);
 
     //Print to Data Call String for Ncurses Terminal
@@ -513,13 +520,14 @@ p25_read_pdu_header_fields(const uint8_t* input) {
 }
 
 static void
-p25_decode_pdu_header_strings(const P25PduHeaderFields* h, char* sap_string, char* rsp_string) {
-    DSD_SNPRINTF(sap_string, sizeof(sap_string), "%s", " ");
-    DSD_SNPRINTF(rsp_string, sizeof(rsp_string), "%s", " ");
+p25_decode_pdu_header_strings(const P25PduHeaderFields* h, char* sap_string, size_t sap_string_size, char* rsp_string,
+                              size_t rsp_string_size) {
+    DSD_SNPRINTF(sap_string, sap_string_size, "%s", " ");
+    DSD_SNPRINTF(rsp_string, rsp_string_size, "%s", " ");
     if (h->fmt != 3) {
-        p25_decode_sap(h->sap, sap_string);
+        p25_decode_sap(h->sap, sap_string, sap_string_size);
     } else {
-        p25_decode_rsp(h->rsp_class, h->rsp_type, h->rsp_status, rsp_string);
+        p25_decode_rsp(h->rsp_class, h->rsp_type, h->rsp_status, rsp_string, rsp_string_size);
     }
 }
 
@@ -572,7 +580,7 @@ p25_decode_pdu_header(dsd_opts* opts, dsd_state* state, const uint8_t* input) {
     DSD_FPRINTF(stderr, " P25 Data - AN: %d; IO: %d; FMT: %02X; ", h.an, h.io, h.fmt);
     char sap_string[40];
     char rsp_string[40];
-    p25_decode_pdu_header_strings(&h, sap_string, rsp_string);
+    p25_decode_pdu_header_strings(&h, sap_string, sizeof sap_string, rsp_string, sizeof rsp_string);
     p25_log_pdu_header_fields(&h);
     p25_update_pdu_header_state(opts, state, &h, sap_string, rsp_string);
 }

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -1531,8 +1531,10 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                 dsd_mkdir(wav_file_directory, 0700);                                                                   \
             }                                                                                                          \
             LOG_NOTICE("Per Call Wav File Enabled.\n");                                                                \
-            opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, 8000, 0);                           \
-            opts->wav_out_fR = open_wav_file(opts->wav_out_dir, opts->wav_out_fileR, 8000, 0);                         \
+            opts->wav_out_f =                                                                                          \
+                open_wav_file(opts->wav_out_dir, opts->wav_out_file, sizeof opts->wav_out_file, 8000, 0);              \
+            opts->wav_out_fR =                                                                                         \
+                open_wav_file(opts->wav_out_dir, opts->wav_out_fileR, sizeof opts->wav_out_fileR, 8000, 0);            \
             opts->dmr_stereo_wav = 1;                                                                                  \
             break;                                                                                                     \
         case '7':                                                                                                      \

--- a/src/ui/terminal/menu_services.c
+++ b/src/ui/terminal/menu_services.c
@@ -80,8 +80,8 @@ svc_enable_per_call_wav(dsd_opts* opts, dsd_state* state) {
         dsd_mkdir(wav_file_directory, 0700);
     }
     DSD_FPRINTF(stderr, "\n Per Call Wav File Enabled to Directory: %s;.\n", opts->wav_out_dir);
-    opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, 8000, 0);
-    opts->wav_out_fR = open_wav_file(opts->wav_out_dir, opts->wav_out_fileR, 8000, 0);
+    opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, sizeof opts->wav_out_file, 8000, 0);
+    opts->wav_out_fR = open_wav_file(opts->wav_out_dir, opts->wav_out_fileR, sizeof opts->wav_out_fileR, 8000, 0);
     opts->dmr_stereo_wav = 1;
     return (opts->wav_out_f && opts->wav_out_fR) ? 0 : -1;
 }

--- a/src/ui/terminal/ui_cmd_queue.c
+++ b/src/ui/terminal/ui_cmd_queue.c
@@ -2499,8 +2499,8 @@ ui_cmd_handle_wav_start_legacy(dsd_opts* opts, dsd_state* state, const struct Ui
     }
     LOG_NOTICE("Per Call Wav File Enabled to Directory: %s\n", opts->wav_out_dir);
     srand(ui_cmd_rng_seed_now());
-    opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, 8000, 0);
-    opts->wav_out_fR = open_wav_file(opts->wav_out_dir, opts->wav_out_fileR, 8000, 0);
+    opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, sizeof opts->wav_out_file, 8000, 0);
+    opts->wav_out_fR = open_wav_file(opts->wav_out_dir, opts->wav_out_fileR, sizeof opts->wav_out_fileR, 8000, 0);
     opts->dmr_stereo_wav = 1;
     return 1;
 }

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -31,9 +31,10 @@ static int g_beeper_count;
 static int g_last_beeper_id;
 
 struct sf_private_tag*
-open_wav_file(char* dir, char* temp_filename, uint16_t sample_rate, uint8_t ext) {
+open_wav_file(char* dir, char* temp_filename, size_t temp_filename_size, uint16_t sample_rate, uint8_t ext) {
     UNUSED(dir);
     UNUSED(temp_filename);
+    UNUSED(temp_filename_size);
     UNUSED(sample_rate);
     UNUSED(ext);
     return NULL;
@@ -226,6 +227,59 @@ test_edacs_service_string_appends_past_pointer_size(void) {
     return rc;
 }
 
+static int
+test_dmr_event_string_keeps_full_prefix_after_sprintf_hardening(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.lastsrc = 123456U;
+    state.lasttg = 50061U;
+    state.gi[0] = 0;
+    state.dmr_color_code = 7U;
+    state.dmr_t3_syscode = 0xABCU;
+
+    watchdog_event_current(&opts, &state, 0);
+
+    const Event_History* item = &state.event_history_s[0].Event_History_Items[0];
+    int rc = 0;
+    rc |= expect_has_substr("dmr event date/time prefix", item->event_string, "2026-04-30 00:00:00");
+    rc |= expect_has_substr("dmr event voice prefix", item->event_string,
+                            "TEST TGT: 00050061; SRC: 00123456; CC: 07; SYS: ABC;");
+    rc |= expect_has_substr("dmr event call class", item->event_string, "Group;");
+    return rc;
+}
+
+static int
+test_p25_event_string_keeps_full_prefix_after_sprintf_hardening(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    state.lastsynctype = DSD_SYNC_P25P2_POS;
+    state.lastsrc = 5790062U;
+    state.lasttg = 50061U;
+    state.gi[0] = 0;
+    state.nac = 0x293;
+    state.p2_wacn = 0x45564U;
+    state.p2_sysid = 0x006U;
+    state.p2_rfssid = 10U;
+    state.p2_siteid = 10U;
+
+    watchdog_event_current(&opts, &state, 0);
+
+    const Event_History* item = &state.event_history_s[0].Event_History_Items[0];
+    int rc = 0;
+    rc |= expect_has_substr("p25 event date/time prefix", item->event_string, "2026-04-30 00:00:00");
+    rc |= expect_has_substr("p25 event voice prefix", item->event_string,
+                            "TEST TGT: 00050061; SRC: 05790062; NAC: 293; NET_STS: 45564:006:10.10;");
+    rc |= expect_has_substr("p25 event call class", item->event_string, "Group;");
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -235,6 +289,8 @@ main(void) {
     rc |= test_source_less_data_call_does_not_suppress_next_voice_start_alert();
     rc |= test_voice_end_alert_still_emits_for_voice_history();
     rc |= test_edacs_service_string_appends_past_pointer_size();
+    rc |= test_dmr_event_string_keeps_full_prefix_after_sprintf_hardening();
+    rc |= test_p25_event_string_keeps_full_prefix_after_sprintf_hardening();
 
     if (rc == 0) {
         printf("CORE_CALL_ALERT_HISTORY: OK\n");

--- a/tests/io/test_io_udp_control.c
+++ b/tests/io/test_io_udp_control.c
@@ -23,9 +23,11 @@ typedef struct callback_state {
     uint32_t freq;
 } callback_state;
 
+static callback_state g_callback_state;
+
 static void
-retune_cb(uint32_t new_frequency_hz, void* user_data) {
-    callback_state* state = (callback_state*)user_data;
+retune_cb(uint32_t new_frequency_hz) {
+    callback_state* state = &g_callback_state;
     dsd_mutex_lock(&state->mu);
     state->called = 1;
     state->freq = new_frequency_hz;
@@ -110,46 +112,45 @@ test_loopback_delivery(void) {
         return 1;
     }
 
-    callback_state state;
-    DSD_MEMSET(&state, 0, sizeof(state));
-    if (dsd_mutex_init(&state.mu) != 0 || dsd_cond_init(&state.cv) != 0) {
+    DSD_MEMSET(&g_callback_state, 0, sizeof(g_callback_state));
+    if (dsd_mutex_init(&g_callback_state.mu) != 0 || dsd_cond_init(&g_callback_state.cv) != 0) {
         DSD_FPRINTF(stderr, "failed to initialize callback synchronization\n");
         return 1;
     }
 
-    struct udp_control* ctrl = udp_control_start_bound("127.0.0.1", port, retune_cb, &state);
+    struct udp_control* ctrl = udp_control_start_bound("127.0.0.1", port, retune_cb);
     if (!ctrl) {
         DSD_FPRINTF(stderr, "udp_control_start_bound failed on 127.0.0.1:%d\n", port);
-        dsd_cond_destroy(&state.cv);
-        dsd_mutex_destroy(&state.mu);
+        dsd_cond_destroy(&g_callback_state.cv);
+        dsd_mutex_destroy(&g_callback_state.mu);
         return 1;
     }
 
     uint32_t expected = 851375000u;
     int test_rc = 0;
-    if (send_retune_packet(port, expected) != 0 || !wait_for_callback(&state, 2000)) {
+    if (send_retune_packet(port, expected) != 0 || !wait_for_callback(&g_callback_state, 2000)) {
         DSD_FPRINTF(stderr, "retune callback was not invoked\n");
         test_rc = 1;
-    } else if (state.freq != expected) {
-        DSD_FPRINTF(stderr, "expected callback frequency %u, got %u\n", expected, state.freq);
+    } else if (g_callback_state.freq != expected) {
+        DSD_FPRINTF(stderr, "expected callback frequency %u, got %u\n", expected, g_callback_state.freq);
         test_rc = 1;
     }
 
     udp_control_stop(ctrl);
-    dsd_cond_destroy(&state.cv);
-    dsd_mutex_destroy(&state.mu);
+    dsd_cond_destroy(&g_callback_state.cv);
+    dsd_mutex_destroy(&g_callback_state.mu);
     return test_rc;
 }
 
 static int
 test_invalid_bind_address_fails(void) {
-    struct udp_control* ctrl = udp_control_start_bound("localhost", 9911, retune_cb, NULL);
+    struct udp_control* ctrl = udp_control_start_bound("localhost", 9911, retune_cb);
     if (ctrl) {
         DSD_FPRINTF(stderr, "expected non-numeric bind address to fail\n");
         udp_control_stop(ctrl);
         return 1;
     }
-    ctrl = udp_control_start(0, retune_cb, NULL);
+    ctrl = udp_control_start(0, retune_cb);
     if (ctrl) {
         DSD_FPRINTF(stderr, "expected port 0 to disable UDP control\n");
         udp_control_stop(ctrl);

--- a/tests/runtime/test_runtime_config_env.cpp
+++ b/tests/runtime/test_runtime_config_env.cpp
@@ -1753,6 +1753,12 @@ test_tuner_autogain_env(void) {
 
 static int
 test_auto_ppm_env(void) {
+    /*
+     * Auto-PPM env parsing spans an enable flag, signal/power thresholds, zero-lock
+     * limits, and freeze behavior. This test reloads config snapshots for accepted
+     * values, range rejections, and malformed numeric input so the parser keeps
+     * rejecting unsafe values while preserving documented defaults.
+     */
     setenv("DSD_NEO_AUTO_PPM", "1", 1);
     setenv("DSD_NEO_AUTO_PPM_SNR_DB", "10.0", 1);
     setenv("DSD_NEO_AUTO_PPM_PWR_DB", "-50.0", 1);


### PR DESCRIPTION
## Summary

- Fix DMR/P25 event-history truncation caused by using `sizeof` on pointer parameters in hardened `DSD_SNPRINTF` call sites.
- Pass explicit destination buffer sizes through WAV rotation and P25 PDU helper APIs, and add a Semgrep guardrail for the unsafe pattern.
- Resolve the CodeQL findings by removing the unused UDP callback context that could store caller-owned stack addresses, and by documenting the long auto-PPM environment parser test.

## Root Cause

A recent hardening pass replaced formatting calls with bounded `DSD_SNPRINTF` calls, but a few helpers used `sizeof(parameter)` where the parameter had decayed to a pointer. That limited writes to pointer width and truncated event-history rows such as DMR and P25 entries.

The UDP control CodeQL warning was from the worker handle storing an opaque callback context supplied by the caller. Current production users did not need that context, so the API now invokes retune callbacks with only the parsed frequency and no longer persists caller-owned context.

## Validation

- `tools/format.sh include/dsd-neo/io/udp_control.h src/io/control/udp_control.cpp src/io/radio/rtl_sdr_fm.cpp tests/io/test_io_udp_control.c tests/runtime/test_runtime_config_env.cpp`
- `git diff --check`
- `tools/semgrep.sh --strict -- include/dsd-neo/io/udp_control.h src/io/control/udp_control.cpp src/io/radio/rtl_sdr_fm.cpp tests/io/test_io_udp_control.c tests/runtime/test_runtime_config_env.cpp`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug -R "IO_UDP_CONTROL|RUNTIME_CONFIG_ENV" --output-on-failure`
- `ctest --preset dev-debug --output-on-failure`
- pre-push guardrails: install destination check, secret/workflow/download/vcpkg pin guardrails, clang-format, strict clang-tidy, strict cppcheck, IWYU, lizard