### PR TITLE
vocoder: align mbelib-neo API usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,6 +552,8 @@ check_c_source_compiles(
 int main(void) {
     const mbe_soft_bit imbe_soft[8][23] = {{{0}}};
     const mbe_soft_bit ambe_soft[4][24] = {{{0}}};
+    const char imbe_fr[8][23] = {{0}};
+    const char imbe7100_fr[7][24] = {{0}};
     const char ambe_fr[4][24] = {{0}};
     char imbe_d[88] = {0};
     char ambe_d[49] = {0};
@@ -566,6 +568,9 @@ int main(void) {
     result.c0_errors = 0;
     result.total_errors = 0;
     result.flags = MBE_PROCESS_FLAG_SOFT_INPUT;
+    (void)mbe_decodeImbe7200x4400Frame(imbe_fr, imbe_d, &result);
+    (void)mbe_decodeImbe7100x4400Frame(imbe7100_fr, imbe_d, &result);
+    (void)mbe_decodeAmbe3600x2450Frame(ambe_fr, ambe_d, &result);
     (void)mbe_decodeImbe7200x4400SoftFrame(imbe_soft, imbe_d, &result);
     (void)mbe_decodeAmbe3600x2450SoftFrame(ambe_soft, ambe_d, &result);
     (void)mbe_processImbe4400Dataf(audio, &result, imbe_d, &cur, &prev, &prev_enhanced, 3);
@@ -573,6 +578,7 @@ int main(void) {
     (void)mbe_processAmbe2400Dataf(audio, &result, ambe_d, &cur, &prev, &prev_enhanced, 3);
     (void)mbe_processAmbe3600x2450Framef(audio, &result, ambe_fr, ambe_d, &cur, &prev, &prev_enhanced, 3);
     (void)mbe_processAmbe3600x2450SoftFramef(audio, &result, ambe_soft, ambe_d, &cur, &prev, &prev_enhanced, 3);
+    mbe_synthesizeSilencef(audio);
     mbe_formatProcessResult(err_str, sizeof(err_str), &result);
     return (int)(sizeof(mbe_soft_bit) + sizeof(mbe_process_result));
 }

--- a/include/dsd-neo/core/mbe_api.h
+++ b/include/dsd-neo/core/mbe_api.h
@@ -21,6 +21,13 @@ extern "C" {
 void dsd_mbe_init_result_from_errors(mbe_process_result* result, int errs, int errs2, unsigned flags);
 void dsd_mbe_store_result(int* errs, int* errs2, char* err_str, size_t err_str_size, const mbe_process_result* result);
 
+int dsd_mbe_decode_imbe7200_frame(int* errs, int* errs2, const char imbe_fr[8][23], char imbe_d[88],
+                                  mbe_process_result* result);
+int dsd_mbe_decode_imbe7100_frame(int* errs, int* errs2, const char imbe_fr[7][24], char imbe_d[88],
+                                  mbe_process_result* result);
+int dsd_mbe_decode_ambe2450_frame(int* errs, int* errs2, const char ambe_fr[4][24], char ambe_d[49],
+                                  mbe_process_result* result);
+
 int dsd_mbe_process_imbe4400_dataf(float* aout_buf, int* errs, int* errs2, char* err_str, size_t err_str_size,
                                    const char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp,
                                    mbe_parms* prev_mp_enhanced, int uvquality, mbe_process_result* result);

--- a/src/core/file/dsd_file.c
+++ b/src/core/file/dsd_file.c
@@ -1469,11 +1469,12 @@ ambe2_str_to_decode(dsd_opts* opts, dsd_state* state, const char* ambe_str, cons
 
     char ambe_d[49];
     DSD_MEMSET(ambe_d, 0, sizeof(ambe_d));
-    state->errs = mbe_eccAmbe3600x2450C0(ambe_fr);
-    state->errs2 = state->errs;
-    mbe_demodulateAmbe3600x2450Data(ambe_fr);
-    state->errs2 += mbe_eccAmbe3600x2450Data(ambe_fr, ambe_d);
-    state->debug_audio_errors += state->errs2;
+    mbe_process_result result;
+    int decode_ret =
+        dsd_mbe_decode_ambe2450_frame(&state->errs, &state->errs2, (const char (*)[24])ambe_fr, ambe_d, &result);
+    if (decode_ret >= 0) {
+        state->debug_audio_errors += state->errs2;
+    }
 
     ks_idx = sdrtrunk_apply_keystream(ambe_d, 49, ks, ks_idx);
 
@@ -1482,8 +1483,14 @@ ambe2_str_to_decode(dsd_opts* opts, dsd_state* state, const char* ambe_str, cons
         ks_idx += 7;
     }
 
-    mbe_process_result result;
-    dsd_mbe_init_result_from_errors(&result, state->errs, state->errs2, MBE_PROCESS_FLAG_C0_VALID);
+    if (decode_ret < 0) {
+        mbe_synthesizeSilencef(state->audio_out_temp_buf);
+        if (decode_audio_is_allowed(is_enc, ks_available)) {
+            run_decode_audio_output_path(opts, state);
+        }
+        return ks_idx;
+    }
+
     (void)dsd_mbe_process_ambe2450_dataf(state->audio_out_temp_buf, &state->errs, &state->errs2, state->err_str,
                                          sizeof(state->err_str), ambe_d, state->cur_mp, state->prev_mp,
                                          state->prev_mp_enhanced, opts->uvquality, &result);
@@ -1512,16 +1519,23 @@ imbe_str_to_decode(dsd_opts* opts, dsd_state* state, const char* imbe_str, const
 
     char imbe_d[88];
     DSD_MEMSET(imbe_d, 0, sizeof(imbe_d));
-    state->errs = mbe_eccImbe7200x4400C0(imbe_fr);
-    state->errs2 = state->errs;
-    mbe_demodulateImbe7200x4400Data(imbe_fr);
-    state->errs2 += mbe_eccImbe7200x4400Data(imbe_fr, imbe_d);
-    state->debug_audio_errors += state->errs2;
+    mbe_process_result result;
+    int decode_ret =
+        dsd_mbe_decode_imbe7200_frame(&state->errs, &state->errs2, (const char (*)[23])imbe_fr, imbe_d, &result);
+    if (decode_ret >= 0) {
+        state->debug_audio_errors += state->errs2;
+    }
 
     ks_idx = sdrtrunk_apply_keystream(imbe_d, 88, ks, ks_idx);
 
-    mbe_process_result result;
-    dsd_mbe_init_result_from_errors(&result, state->errs, state->errs2, MBE_PROCESS_FLAG_C0_VALID);
+    if (decode_ret < 0) {
+        mbe_synthesizeSilencef(state->audio_out_temp_buf);
+        if (decode_audio_is_allowed(is_enc, ks_available)) {
+            run_decode_audio_output_path(opts, state);
+        }
+        return ks_idx;
+    }
+
     (void)dsd_mbe_process_imbe4400_dataf(state->audio_out_temp_buf, &state->errs, &state->errs2, state->err_str,
                                          sizeof(state->err_str), imbe_d, state->cur_mp, state->prev_mp,
                                          state->prev_mp_enhanced, opts->uvquality, &result);

--- a/src/core/vocoder/dsd_mbe.c
+++ b/src/core/vocoder/dsd_mbe.c
@@ -139,6 +139,72 @@ dsd_mbe_store_result(int* errs, int* errs2, char* err_str, size_t err_str_size, 
     }
 }
 
+static void
+dsd_mbe_clear_status(int* errs, int* errs2, char* err_str, size_t err_str_size) {
+    if (errs) {
+        *errs = 0;
+    }
+    if (errs2) {
+        *errs2 = 0;
+    }
+    if (err_str && err_str_size > 0) {
+        err_str[0] = '\0';
+    }
+}
+
+static int
+dsd_mbe_store_decode_status(int ret, int* errs, int* errs2, const mbe_process_result* result) {
+    if (ret < 0) {
+        dsd_mbe_clear_status(errs, errs2, NULL, 0);
+        return ret;
+    }
+
+    dsd_mbe_store_result(errs, errs2, NULL, 0, result);
+    return ret;
+}
+
+static int
+dsd_mbe_store_process_status(int ret, float* aout_buf, int* errs, int* errs2, char* err_str, size_t err_str_size,
+                             const mbe_process_result* result) {
+    if (ret < 0) {
+        if (aout_buf) {
+            mbe_synthesizeSilencef(aout_buf);
+        }
+        dsd_mbe_clear_status(errs, errs2, err_str, err_str_size);
+        return ret;
+    }
+
+    dsd_mbe_store_result(errs, errs2, err_str, err_str_size, result);
+    return ret;
+}
+
+int
+dsd_mbe_decode_imbe7200_frame(int* errs, int* errs2, const char imbe_fr[8][23], char imbe_d[88],
+                              mbe_process_result* result) {
+    mbe_process_result local_result;
+    mbe_process_result* decode_result = result ? result : &local_result;
+    int ret = mbe_decodeImbe7200x4400Frame(imbe_fr, imbe_d, decode_result);
+    return dsd_mbe_store_decode_status(ret, errs, errs2, decode_result);
+}
+
+int
+dsd_mbe_decode_imbe7100_frame(int* errs, int* errs2, const char imbe_fr[7][24], char imbe_d[88],
+                              mbe_process_result* result) {
+    mbe_process_result local_result;
+    mbe_process_result* decode_result = result ? result : &local_result;
+    int ret = mbe_decodeImbe7100x4400Frame(imbe_fr, imbe_d, decode_result);
+    return dsd_mbe_store_decode_status(ret, errs, errs2, decode_result);
+}
+
+int
+dsd_mbe_decode_ambe2450_frame(int* errs, int* errs2, const char ambe_fr[4][24], char ambe_d[49],
+                              mbe_process_result* result) {
+    mbe_process_result local_result;
+    mbe_process_result* decode_result = result ? result : &local_result;
+    int ret = mbe_decodeAmbe3600x2450Frame(ambe_fr, ambe_d, decode_result);
+    return dsd_mbe_store_decode_status(ret, errs, errs2, decode_result);
+}
+
 int
 dsd_mbe_process_imbe4400_dataf(float* aout_buf, int* errs, int* errs2, char* err_str, size_t err_str_size,
                                const char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp,
@@ -151,8 +217,7 @@ dsd_mbe_process_imbe4400_dataf(float* aout_buf, int* errs, int* errs2, char* err
     }
 
     int ret = mbe_processImbe4400Dataf(aout_buf, process_result, imbe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
-    dsd_mbe_store_result(errs, errs2, err_str, err_str_size, process_result);
-    return ret;
+    return dsd_mbe_store_process_status(ret, aout_buf, errs, errs2, err_str, err_str_size, process_result);
 }
 
 int
@@ -167,8 +232,7 @@ dsd_mbe_process_ambe2450_dataf(float* aout_buf, int* errs, int* errs2, char* err
     }
 
     int ret = mbe_processAmbe2450Dataf(aout_buf, process_result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
-    dsd_mbe_store_result(errs, errs2, err_str, err_str_size, process_result);
-    return ret;
+    return dsd_mbe_store_process_status(ret, aout_buf, errs, errs2, err_str, err_str_size, process_result);
 }
 
 int
@@ -183,8 +247,7 @@ dsd_mbe_process_ambe2400_dataf(float* aout_buf, int* errs, int* errs2, char* err
     }
 
     int ret = mbe_processAmbe2400Dataf(aout_buf, process_result, ambe_d, cur_mp, prev_mp, prev_mp_enhanced, uvquality);
-    dsd_mbe_store_result(errs, errs2, err_str, err_str_size, process_result);
-    return ret;
+    return dsd_mbe_store_process_status(ret, aout_buf, errs, errs2, err_str, err_str_size, process_result);
 }
 
 int
@@ -194,8 +257,7 @@ dsd_mbe_process_ambe3600x2400_framef(float* aout_buf, int* errs, int* errs2, cha
     mbe_process_result result;
     int ret = mbe_processAmbe3600x2400Framef(aout_buf, &result, (const char (*)[24])ambe_fr, ambe_d, cur_mp, prev_mp,
                                              prev_mp_enhanced, uvquality);
-    dsd_mbe_store_result(errs, errs2, err_str, err_str_size, &result);
-    return ret;
+    return dsd_mbe_store_process_status(ret, aout_buf, errs, errs2, err_str, err_str_size, &result);
 }
 
 static int
@@ -205,16 +267,16 @@ decode_imbe7200_frame(dsd_state* state, char imbe_fr[8][23], dsd_vocoder_soft_bi
         mbe_soft_bit soft_fr[8][23];
 
         copy_imbe7200_soft_frame(imbe_soft_fr, soft_fr);
-        mbe_initProcessResult(result);
-        (void)mbe_decodeImbe7200x4400SoftFrame((const mbe_soft_bit(*)[23])soft_fr, imbe_d, result);
+        int ret = mbe_decodeImbe7200x4400SoftFrame((const mbe_soft_bit(*)[23])soft_fr, imbe_d, result);
+        if (ret < 0) {
+            dsd_mbe_clear_status(&state->errs, &state->errs2, NULL, 0);
+            return 0;
+        }
         dsd_mbe_store_result(&state->errs, &state->errs2, NULL, 0, result);
         return 1;
     }
 
-    mbe_initProcessResult(result);
-    (void)mbe_decodeImbe7200x4400Frame((const char (*)[23])imbe_fr, imbe_d, result);
-    dsd_mbe_store_result(&state->errs, &state->errs2, NULL, 0, result);
-    return 1;
+    return dsd_mbe_decode_imbe7200_frame(&state->errs, &state->errs2, (const char (*)[23])imbe_fr, imbe_d, result) >= 0;
 }
 
 static int
@@ -224,16 +286,16 @@ decode_ambe2450_frame(int* errs, int* errs2, char ambe_fr[4][24], dsd_vocoder_so
         mbe_soft_bit soft_fr[4][24];
 
         copy_ambe_soft_frame(ambe_soft_fr, soft_fr);
-        mbe_initProcessResult(result);
-        (void)mbe_decodeAmbe3600x2450SoftFrame((const mbe_soft_bit(*)[24])soft_fr, ambe_d, result);
+        int ret = mbe_decodeAmbe3600x2450SoftFrame((const mbe_soft_bit(*)[24])soft_fr, ambe_d, result);
+        if (ret < 0) {
+            dsd_mbe_clear_status(errs, errs2, NULL, 0);
+            return 0;
+        }
         dsd_mbe_store_result(errs, errs2, NULL, 0, result);
         return 1;
     }
 
-    mbe_initProcessResult(result);
-    (void)mbe_decodeAmbe3600x2450Frame((const char (*)[24])ambe_fr, ambe_d, result);
-    dsd_mbe_store_result(errs, errs2, NULL, 0, result);
-    return 1;
+    return dsd_mbe_decode_ambe2450_frame(errs, errs2, (const char (*)[24])ambe_fr, ambe_d, result) >= 0;
 }
 
 static void
@@ -569,6 +631,11 @@ mbe_process_p25p1(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], dsd_voc
                   mbe_frame_ctx_t* frame_ctx) {
     mbe_process_result imbe_result;
     int have_imbe_result = decode_imbe7200_frame(state, imbe_fr, imbe_soft_fr, frame_ctx->imbe_d, &imbe_result);
+    if (!have_imbe_result) {
+        dsd_mbe_store_process_status(MBE_STATUS_INVALID_BITS, state->audio_out_temp_buf, &state->errs, &state->errs2,
+                                     state->err_str, sizeof(state->err_str), NULL);
+        return;
+    }
 
     //P25p1 Multi Crypt Handler (DES1, DES3, DES-XL and AES)
     if (mbe_p25p1_multicrypt_enabled(state)) {
@@ -602,9 +669,13 @@ mbe_process_p25p1(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], dsd_voc
 static void
 mbe_process_provoice(dsd_opts* opts, dsd_state* state, char imbe7100_fr[7][24], mbe_frame_ctx_t* frame_ctx) {
     mbe_process_result imbe_result;
-    mbe_initProcessResult(&imbe_result);
-    (void)mbe_decodeImbe7100x4400Frame((const char (*)[24])imbe7100_fr, frame_ctx->imbe_d, &imbe_result);
-    dsd_mbe_store_result(&state->errs, &state->errs2, NULL, 0, &imbe_result);
+    if (dsd_mbe_decode_imbe7100_frame(&state->errs, &state->errs2, (const char (*)[24])imbe7100_fr, frame_ctx->imbe_d,
+                                      &imbe_result)
+        < 0) {
+        dsd_mbe_store_process_status(MBE_STATUS_INVALID_BITS, state->audio_out_temp_buf, &state->errs, &state->errs2,
+                                     state->err_str, sizeof(state->err_str), NULL);
+        return;
+    }
 
     if (dsd_frame_detail_enabled(opts)) {
         PrintIMBEData(opts, state, frame_ctx->imbe_d);
@@ -849,6 +920,11 @@ mbe_process_nxdn(dsd_opts* opts, dsd_state* state, char ambe_fr[4][24], dsd_voco
     mbe_process_result ambe_result;
     int have_ambe_result =
         decode_ambe2450_frame(&state->errs, &state->errs2, ambe_fr, ambe_soft_fr, frame_ctx->ambe_d, &ambe_result);
+    if (!have_ambe_result) {
+        dsd_mbe_store_process_status(MBE_STATUS_INVALID_BITS, state->audio_out_temp_buf, &state->errs, &state->errs2,
+                                     state->err_str, sizeof(state->err_str), NULL);
+        return;
+    }
 
     if ((state->nxdn_cipher_type == 0x01 && state->R != 0) || (state->M == 1 && state->R > 0)) {
         mbe_apply_nxdn_cipher1(state, frame_ctx->ambe_d);
@@ -1381,6 +1457,11 @@ mbeslot_process_left(dsd_opts* opts, dsd_state* state, char ambe_fr[4][24], dsd_
     mbe_process_result ambe_result;
     int have_ambe_result =
         decode_ambe2450_frame(&state->errs, &state->errs2, ambe_fr, ambe_soft_fr, frame_ctx->ambe_d, &ambe_result);
+    if (!have_ambe_result) {
+        dsd_mbe_store_process_status(MBE_STATUS_INVALID_BITS, state->audio_out_temp_buf, &state->errs, &state->errs2,
+                                     state->err_str, sizeof(state->err_str), NULL);
+        return;
+    }
 
     mbeslot_left_autoload_keys(opts, state);
     mbeslot_left_apply_basic_privacy(state, frame_ctx);
@@ -1400,6 +1481,11 @@ mbeslot_process_right(dsd_opts* opts, dsd_state* state, char ambe_fr[4][24], dsd
     mbe_process_result ambe_result;
     int have_ambe_result =
         decode_ambe2450_frame(&state->errsR, &state->errs2R, ambe_fr, ambe_soft_fr, frame_ctx->ambe_d, &ambe_result);
+    if (!have_ambe_result) {
+        dsd_mbe_store_process_status(MBE_STATUS_INVALID_BITS, state->audio_out_temp_bufR, &state->errsR, &state->errs2R,
+                                     state->err_strR, sizeof(state->err_strR), NULL);
+        return;
+    }
 
     mbeslot_right_autoload_keys(opts, state);
     mbeslot_right_apply_basic_privacy(state, frame_ctx);

--- a/src/core/vocoder/dsd_mbe2.c
+++ b/src/core/vocoder/dsd_mbe2.c
@@ -44,33 +44,43 @@ save_ambe2450_x2(dsd_opts* opts, dsd_state* state, char ambe_d[49]) {
     state->errs2 = saved_errs2;
 }
 
-//P25p1 IMBE 7200 or AMBE+2 EFR
 static void
-soft_demod_imbe7200(dsd_state* state, char imbe_fr7200[8][23], char imbe_d[88]) {
-    state->errs = mbe_eccImbe7200x4400C0(imbe_fr7200);
-    state->errs2 = state->errs;
-    mbe_demodulateImbe7200x4400Data(imbe_fr7200);
-    state->errs2 += mbe_eccImbe7200x4400Data(imbe_fr7200, imbe_d);
+stage_left_audio_for_output(const dsd_opts* opts, dsd_state* state) {
+    if (opts->floating_point == 1) {
+        DSD_MEMCPY(state->f_l, state->audio_out_temp_buf, sizeof(state->f_l));
+    } else {
+        processAudio(opts, state);
+    }
+}
+
+//P25p1 IMBE 7200 or AMBE+2 EFR
+static int
+soft_demod_imbe7200(dsd_state* state, char imbe_fr7200[8][23], char imbe_d[88], mbe_process_result* result) {
+    int ret =
+        dsd_mbe_decode_imbe7200_frame(&state->errs, &state->errs2, (const char (*)[23])imbe_fr7200, imbe_d, result);
+    if (ret < 0) {
+        return ret;
+    }
     state->debug_audio_errors += state->errs2;
+    return ret;
 }
 
 //ProVoice IMBE 7100
-static void
-soft_demod_imbe7100(dsd_state* state, char imbe_fr7100[7][24], char imbe_d[88]) {
-    state->errs = mbe_eccImbe7100x4400C0(imbe_fr7100);
-    state->errs2 = state->errs;
-    mbe_demodulateImbe7100x4400Data(imbe_fr7100);
-    state->errs2 += mbe_eccImbe7100x4400Data(imbe_fr7100, imbe_d);
+static int
+soft_demod_imbe7100(dsd_state* state, char imbe_fr7100[7][24], char imbe_d[88], mbe_process_result* result) {
+    int ret =
+        dsd_mbe_decode_imbe7100_frame(&state->errs, &state->errs2, (const char (*)[24])imbe_fr7100, imbe_d, result);
+    if (ret < 0) {
+        return ret;
+    }
     state->debug_audio_errors += state->errs2;
+    return ret;
 }
 
 //AMBE+2 EHR
-static void
-soft_demod_ambe2_ehr(dsd_state* state, char ambe2_ehr[4][24], char ambe_d[49]) {
-    state->errs = mbe_eccAmbe3600x2450C0(ambe2_ehr);
-    state->errs2 = state->errs;
-    mbe_demodulateAmbe3600x2450Data(ambe2_ehr);
-    state->errs2 += mbe_eccAmbe3600x2450Data(ambe2_ehr, ambe_d);
+static int
+soft_demod_ambe2_ehr(int* errs, int* errs2, char ambe2_ehr[4][24], char ambe_d[49], mbe_process_result* result) {
+    return dsd_mbe_decode_ambe2450_frame(errs, errs2, (const char (*)[24])ambe2_ehr, ambe_d, result);
 }
 
 //AMBE One Shot (DSTAR)
@@ -79,11 +89,7 @@ soft_demod_ambe_dstar(const dsd_opts* opts, dsd_state* state, char ambe_fr[4][24
     (void)dsd_mbe_process_ambe3600x2400_framef(state->audio_out_temp_buf, &state->errs, &state->errs2, state->err_str,
                                                sizeof(state->err_str), ambe_fr, ambe_d, state->cur_mp, state->prev_mp,
                                                state->prev_mp_enhanced, opts->uvquality);
-    if (opts->floating_point == 1) {
-        DSD_MEMCPY(state->f_l, state->audio_out_temp_buf, sizeof(state->f_l));
-    } else {
-        processAudio(opts, state);
-    }
+    stage_left_audio_for_output(opts, state);
 }
 
 //AMBE+2 One Shot (X2-TDMA)
@@ -105,20 +111,15 @@ soft_demod_ambe_x2(const dsd_opts* opts, dsd_state* state, char ambe_fr[4][24], 
         err_str = state->err_strR;
     }
 
-    *errs = mbe_eccAmbe3600x2450C0(ambe_fr);
-    *errs2 = *errs;
-    mbe_demodulateAmbe3600x2450Data(ambe_fr);
-    *errs2 += mbe_eccAmbe3600x2450Data(ambe_fr, ambe_d);
-
     mbe_process_result result;
-    dsd_mbe_init_result_from_errors(&result, *errs, *errs2, MBE_PROCESS_FLAG_C0_VALID);
+    if (dsd_mbe_decode_ambe2450_frame(errs, errs2, (const char (*)[24])ambe_fr, ambe_d, &result) < 0) {
+        mbe_synthesizeSilencef(state->audio_out_temp_buf);
+        stage_left_audio_for_output(opts, state);
+        return;
+    }
     (void)dsd_mbe_process_ambe2450_dataf(state->audio_out_temp_buf, errs, errs2, err_str, sizeof(state->err_str),
                                          ambe_d, cur_mp, prev_mp, prev_mp_enhanced, opts->uvquality, &result);
-    if (opts->floating_point == 1) {
-        DSD_MEMCPY(state->f_l, state->audio_out_temp_buf, sizeof(state->f_l));
-    } else {
-        processAudio(opts, state);
-    }
+    stage_left_audio_for_output(opts, state);
 }
 
 static void
@@ -165,9 +166,11 @@ play_synthesized_voice_by_output(dsd_opts* opts, dsd_state* state) {
 
 static void
 handle_soft_mbe_p25p1(const dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], char imbe_d[88]) {
-    soft_demod_imbe7200(state, imbe_fr, imbe_d);
     mbe_process_result result;
-    dsd_mbe_init_result_from_errors(&result, state->errs, state->errs2, MBE_PROCESS_FLAG_C0_VALID);
+    if (soft_demod_imbe7200(state, imbe_fr, imbe_d, &result) < 0) {
+        mbe_synthesizeSilencef(state->audio_out_temp_buf);
+        return;
+    }
     (void)dsd_mbe_process_imbe4400_dataf(state->audio_out_temp_buf, &state->errs, &state->errs2, state->err_str,
                                          sizeof(state->err_str), imbe_d, state->cur_mp, state->prev_mp,
                                          state->prev_mp_enhanced, opts->uvquality, &result);
@@ -176,10 +179,11 @@ handle_soft_mbe_p25p1(const dsd_opts* opts, dsd_state* state, char imbe_fr[8][23
 
 static void
 handle_soft_mbe_provoice(const dsd_opts* opts, dsd_state* state, char imbe7100_fr[7][24], char imbe_d[88]) {
-    soft_demod_imbe7100(state, imbe7100_fr, imbe_d);
-    mbe_convertImbe7100to7200(imbe_d);
     mbe_process_result result;
-    dsd_mbe_init_result_from_errors(&result, state->errs, state->errs2, MBE_PROCESS_FLAG_C0_VALID);
+    if (soft_demod_imbe7100(state, imbe7100_fr, imbe_d, &result) < 0) {
+        mbe_synthesizeSilencef(state->audio_out_temp_buf);
+        return;
+    }
     (void)dsd_mbe_process_imbe4400_dataf(state->audio_out_temp_buf, &state->errs, &state->errs2, state->err_str,
                                          sizeof(state->err_str), imbe_d, state->cur_mp, state->prev_mp,
                                          state->prev_mp_enhanced, opts->uvquality, &result);
@@ -223,20 +227,24 @@ handle_soft_mbe_x2(dsd_opts* opts, dsd_state* state, char ambe_fr[4][24], char a
 
 static void
 handle_soft_mbe_ambe2_ehr(dsd_opts* opts, dsd_state* state, char ambe_fr[4][24], char ambe_d[49]) {
-    soft_demod_ambe2_ehr(state, ambe_fr, ambe_d);
+    int* errs = state->currentslot == 1 ? &state->errsR : &state->errs;
+    int* errs2 = state->currentslot == 1 ? &state->errs2R : &state->errs2;
+    float* audio_buf = state->currentslot == 1 ? state->audio_out_temp_bufR : state->audio_out_temp_buf;
+
+    mbe_process_result result;
+    if (soft_demod_ambe2_ehr(errs, errs2, ambe_fr, ambe_d, &result) < 0) {
+        mbe_synthesizeSilencef(audio_buf);
+        return;
+    }
     if (dsd_frame_detail_enabled(opts)) {
         PrintAMBEData(opts, state, ambe_d);
     }
 
     if (state->currentslot == 0) {
-        mbe_process_result result;
-        dsd_mbe_init_result_from_errors(&result, state->errs, state->errs2, MBE_PROCESS_FLAG_C0_VALID);
         (void)dsd_mbe_process_ambe2450_dataf(state->audio_out_temp_buf, &state->errs, &state->errs2, state->err_str,
                                              sizeof(state->err_str), ambe_d, state->cur_mp, state->prev_mp,
                                              state->prev_mp_enhanced, opts->uvquality, &result);
     } else if (state->currentslot == 1) {
-        mbe_process_result result;
-        dsd_mbe_init_result_from_errors(&result, state->errsR, state->errs2R, MBE_PROCESS_FLAG_C0_VALID);
         (void)dsd_mbe_process_ambe2450_dataf(state->audio_out_temp_bufR, &state->errsR, &state->errs2R, state->err_strR,
                                              sizeof(state->err_strR), ambe_d, state->cur_mp2, state->prev_mp2,
                                              state->prev_mp_enhanced2, opts->uvquality, &result);


### PR DESCRIPTION
## Summary

- Route AMBE/IMBE frame decode paths through mbelib-neo decode APIs so process-result metadata is preserved for later vocoder processing.
- Handle negative mbelib status returns by synthesizing staged silence instead of processing invalid or stale parameter data.
- Expand the CMake mbelib-neo API probe for the decode and silence APIs used by the adapter.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: dependency / decoder.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `tools/format.sh CMakeLists.txt include/dsd-neo/core/mbe_api.h src/core/vocoder/dsd_mbe.c src/core/vocoder/dsd_mbe2.c src/core/file/dsd_file.c`
- [x] `cmake --preset dev-debug`
- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `cmake -S ../mbelib-neo -B /tmp/mbelib-neo-verify-build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/tmp/mbelib-neo-verify-prefix && cmake --build /tmp/mbelib-neo-verify-build -j && cmake --install /tmp/mbelib-neo-verify-build`
- [x] `cmake -S . -B /tmp/dsd-neo-verify-local-mbelib-build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/tmp/mbelib-neo-verify-prefix && cmake --build /tmp/dsd-neo-verify-local-mbelib-build -j`
- [x] `ctest --test-dir /tmp/dsd-neo-verify-local-mbelib-build --output-on-failure`
- [x] Pre-push hook: secret redaction, workflow pin, download pin, vcpkg overlay pin, clang-format, gersemi, clang-tidy strict, cppcheck strict, IWYU strict, GCC fanalyzer strict, Semgrep strict, Lizard complexity.
- [ ] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes

## Risk

- Security/dependency impact: dependency-facing vocoder API usage changed; no new dependency or permission surface added.
- CLI/UI behavior impact: no CLI or UI surface changes expected.
- Compatibility or packaging impact: CMake now probes for the mbelib-neo decode/silence APIs required by the adapter before enabling the integration.
