### PR TITLE
trunking: guard state on retune failures

### DIFF
--- a/include/dsd-neo/engine/trunk_tuning.h
+++ b/include/dsd-neo/engine/trunk_tuning.h
@@ -16,14 +16,15 @@
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
-void dsd_engine_trunk_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
-void dsd_engine_return_to_cc(dsd_opts* opts, dsd_state* state);
+dsd_trunk_tune_result dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
+dsd_trunk_tune_result dsd_engine_trunk_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
+dsd_trunk_tune_result dsd_engine_return_to_cc(dsd_opts* opts, dsd_state* state);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -41,6 +41,13 @@ typedef enum DSD_ATTR_PACKED rtl_stream_channel_profile {
     RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK = 5,
 } rtl_stream_channel_profile;
 
+typedef enum DSD_ATTR_PACKED rtl_stream_tune_result {
+    RTL_STREAM_TUNE_OK = 0,
+    RTL_STREAM_TUNE_DEFERRED = 1,
+    RTL_STREAM_TUNE_FAILED = -1,
+    RTL_STREAM_TUNE_TIMEOUT = -2,
+} rtl_stream_tune_result;
+
 /* Lifecycle */
 /**
  * @brief Create a new RTL-SDR stream context from an immutable options snapshot.
@@ -102,7 +109,7 @@ int rtl_stream_destroy(RtlSdrContext* ctx);
  * @brief Tune to a new center frequency.
  * @param ctx Stream context.
  * @param center_freq_hz New center frequency in Hz.
- * @return 0 on success; otherwise <0 on error.
+ * @return rtl_stream_tune_result: 0 on success, 1 when deferred, negative on error/timeout.
  */
 int rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz);
 /**
@@ -297,6 +304,13 @@ int rtl_stream_test_retune_output_pending(size_t queued_samples, int cached_symb
                                           int* out_cache_pending, int* out_drained);
 
 /**
+ * @brief Seed output/cache counts, apply tune-result drain policy, and report the result.
+ */
+int rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samples, int cached_symbols,
+                                             size_t* out_used_after, int* out_cache_pending_after,
+                                             uint32_t* out_generation_before, uint32_t* out_generation_after);
+
+/**
  * @brief Seed output/cache counts, clear output, and report the resulting state.
  */
 int rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size_t* out_used_after,
@@ -367,6 +381,13 @@ int rtl_stream_ted_bias(const RtlSdrContext* ctx);
  * @return Nominal SPS (>=2); 0 when unavailable.
  */
 int rtl_stream_get_ted_sps(void);
+
+/**
+ * @brief Get the pending Gardner TED samples-per-symbol override.
+ *
+ * @return Override SPS when set; 0 when normal rate-derived SPS is active.
+ */
+int rtl_stream_get_ted_sps_override(void);
 
 /**
  * @brief Set the Gardner TED samples-per-symbol.

--- a/include/dsd-neo/runtime/trunk_tuning_hooks.h
+++ b/include/dsd-neo/runtime/trunk_tuning_hooks.h
@@ -22,17 +22,35 @@
 extern "C" {
 #endif
 
+typedef enum {
+    DSD_TRUNK_TUNE_RESULT_OK = 0,
+    /* No hardware retune was scheduled yet; callers should retry without advancing state. */
+    DSD_TRUNK_TUNE_RESULT_DEFERRED = 1,
+    /* Retune was accepted but completion is asynchronous; callers should commit intended state. */
+    DSD_TRUNK_TUNE_RESULT_PENDING = 2,
+    DSD_TRUNK_TUNE_RESULT_FAILED = -1,
+    DSD_TRUNK_TUNE_RESULT_TIMEOUT = -2,
+} dsd_trunk_tune_result;
+
 typedef struct {
     void (*tune_to_freq)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
     void (*tune_to_cc)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
     void (*return_to_cc)(dsd_opts* opts, dsd_state* state);
+    dsd_trunk_tune_result (*tune_to_freq_result)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
+    dsd_trunk_tune_result (*tune_to_cc_result)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
+    dsd_trunk_tune_result (*return_to_cc_result)(dsd_opts* opts, dsd_state* state);
 } dsd_trunk_tuning_hooks;
 
 void dsd_trunk_tuning_hooks_set(dsd_trunk_tuning_hooks hooks);
 
-void dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
-void dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
-void dsd_trunk_tuning_hook_return_to_cc(dsd_opts* opts, dsd_state* state);
+dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
+dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
+dsd_trunk_tune_result dsd_trunk_tuning_hook_return_to_cc(dsd_opts* opts, dsd_state* state);
+
+static inline int
+dsd_trunk_tune_result_is_ok(dsd_trunk_tune_result result) {
+    return result == DSD_TRUNK_TUNE_RESULT_OK || result == DSD_TRUNK_TUNE_RESULT_PENDING;
+}
 
 #ifdef __cplusplus
 }

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -22,11 +22,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
-
-#ifdef USE_RADIO
-#endif
-#ifdef USE_RADIO
-#endif
+#include "dsd-neo/runtime/trunk_tuning_hooks.h"
 
 static int DSD_ATTR_USED
 dsd_engine_rtl_demod_rate(const dsd_state* state) {
@@ -107,6 +103,60 @@ dsd_engine_reset_return_to_cc_state(dsd_opts* opts, dsd_state* state) {
 }
 
 #ifdef USE_RADIO
+typedef struct {
+    int active;
+    int rf_mod;
+    int p25_vc_cqpsk_override;
+    int rtl_cqpsk_enable;
+    int rtl_symbol_rate_hz;
+    int rtl_symbol_levels;
+    int rtl_channel_profile;
+    int rtl_ted_sps;
+    int rtl_ted_sps_override;
+} dsd_engine_rtl_profile_snapshot;
+
+static void
+dsd_engine_rtl_profile_snapshot_capture(const dsd_opts* opts, const dsd_state* state,
+                                        dsd_engine_rtl_profile_snapshot* snapshot) {
+    if (!snapshot) {
+        return;
+    }
+    DSD_MEMSET(snapshot, 0, sizeof(*snapshot));
+    if (!opts || !state || opts->audio_in_type != AUDIO_IN_RTL) {
+        return;
+    }
+    snapshot->active = 1;
+    snapshot->rf_mod = state->rf_mod;
+    snapshot->p25_vc_cqpsk_override = state->p25_vc_cqpsk_override;
+    (void)rtl_stream_dsp_get(&snapshot->rtl_cqpsk_enable, NULL, NULL);
+    (void)rtl_stream_get_symbol_profile_full(&snapshot->rtl_symbol_rate_hz, &snapshot->rtl_symbol_levels,
+                                             &snapshot->rtl_channel_profile);
+    snapshot->rtl_ted_sps = rtl_stream_get_ted_sps();
+    snapshot->rtl_ted_sps_override = rtl_stream_get_ted_sps_override();
+}
+
+static void
+dsd_engine_rtl_profile_snapshot_restore(dsd_state* state, const dsd_engine_rtl_profile_snapshot* snapshot) {
+    if (!state || !snapshot || !snapshot->active) {
+        return;
+    }
+    state->rf_mod = snapshot->rf_mod;
+    state->p25_vc_cqpsk_override = snapshot->p25_vc_cqpsk_override;
+    rtl_stream_toggle_cqpsk(snapshot->rtl_cqpsk_enable);
+    if (snapshot->rtl_ted_sps > 0) {
+        rtl_stream_set_ted_sps_no_override(snapshot->rtl_ted_sps);
+    }
+    if (snapshot->rtl_ted_sps_override > 0) {
+        rtl_stream_set_ted_sps(snapshot->rtl_ted_sps_override);
+    } else {
+        rtl_stream_clear_ted_sps_override();
+    }
+    if (snapshot->rtl_symbol_rate_hz > 0 && (snapshot->rtl_symbol_levels == 2 || snapshot->rtl_symbol_levels == 4)) {
+        (void)rtl_stream_set_symbol_profile(snapshot->rtl_symbol_rate_hz, snapshot->rtl_symbol_levels,
+                                            snapshot->rtl_channel_profile);
+    }
+}
+
 static void
 dsd_engine_prepare_cc_rtl_chain(const dsd_opts* opts, dsd_state* state, int ted_sps) {
     if (opts->p25_trunk == 1) {
@@ -134,7 +184,15 @@ dsd_engine_prepare_cc_rtl_chain(const dsd_opts* opts, dsd_state* state, int ted_
 #endif
 
 static void
-dsd_engine_maybe_drain_audio(dsd_opts* opts) {
+dsd_engine_maybe_drain_audio(dsd_opts* opts, const dsd_state* state) {
+#ifdef USE_RADIO
+    if (opts && state && opts->audio_in_type == AUDIO_IN_RTL && opts->use_rigctl != 1 && state->rtl_ctx) {
+        return;
+    }
+#else
+    (void)state;
+#endif
+
     /* Avoid blocking drain when invoked from SM tick context. */
     if (!p25_sm_in_tick()) {
         dsd_drain_audio_output(opts);
@@ -157,7 +215,7 @@ dsd_engine_update_vc_tune_state(dsd_opts* opts, dsd_state* state, long int freq)
     state->p25_last_vc_tune_time_m = state->last_vc_sync_time_m;
 }
 
-static void
+static dsd_trunk_tune_result
 dsd_engine_tune_with_backend(const dsd_opts* opts, dsd_state* state, long int freq) {
     if (opts->use_rigctl == 1) {
         if (opts->setmod_bw != 0) {
@@ -165,18 +223,39 @@ dsd_engine_tune_with_backend(const dsd_opts* opts, dsd_state* state, long int fr
                 DSD_FPRINTF(stderr, "Rigctl modulation update failed for bandwidth %d.\n", opts->setmod_bw);
             }
         }
-        SetFreq(opts->rigctl_sockfd, freq);
-        return;
+        if (!SetFreq(opts->rigctl_sockfd, freq)) {
+            DSD_FPRINTF(stderr, "Rigctl frequency update failed for %ld Hz.\n", freq);
+            return DSD_TRUNK_TUNE_RESULT_FAILED;
+        }
+        return DSD_TRUNK_TUNE_RESULT_OK;
     }
     if (opts->audio_in_type != AUDIO_IN_RTL) {
-        return;
+        return DSD_TRUNK_TUNE_RESULT_OK;
     }
 #ifdef USE_RADIO
     if (state->rtl_ctx) {
-        rtl_stream_tune(state->rtl_ctx, (uint32_t)freq);
+        int rc = rtl_stream_tune(state->rtl_ctx, (uint32_t)freq);
+        if (rc == RTL_STREAM_TUNE_OK) {
+            return DSD_TRUNK_TUNE_RESULT_OK;
+        }
+        if (rc == RTL_STREAM_TUNE_DEFERRED) {
+            return DSD_TRUNK_TUNE_RESULT_DEFERRED;
+        }
+        if (rc == RTL_STREAM_TUNE_TIMEOUT) {
+            /*
+             * Live RTL retunes are owned by the controller thread. A timeout
+             * means the caller stopped waiting, not that the queued request was
+             * cancelled. Commit the requested DSP/trunk state as pending because
+             * hardware may still move to this frequency after this call returns.
+             */
+            return DSD_TRUNK_TUNE_RESULT_PENDING;
+        }
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
     }
+    return DSD_TRUNK_TUNE_RESULT_FAILED;
 #else
     (void)state;
+    return DSD_TRUNK_TUNE_RESULT_FAILED;
 #endif
 }
 
@@ -264,14 +343,13 @@ dsd_engine_maybe_apply_ted_override(const dsd_opts* opts, const dsd_state* state
  * @param opts Decoder options (tuning targets and sockets).
  * @param state Decoder state to reset.
  */
-void
+dsd_trunk_tune_result
 dsd_engine_return_to_cc(dsd_opts* opts, dsd_state* state) {
+    dsd_trunk_tune_result tune_result = DSD_TRUNK_TUNE_RESULT_OK;
     if (!opts || !state) {
-        return;
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
     }
     // Audio drain is handled by dsd_engine_trunk_tune_to_cc() before the hardware retune.
-
-    dsd_engine_reset_return_to_cc_state(opts, state);
 
     // Tune back to the control channel when known (best-effort). Prefer the
     // explicit CC when available; otherwise fall back to any tracked CC.
@@ -281,11 +359,17 @@ dsd_engine_return_to_cc(dsd_opts* opts, dsd_state* state) {
     const int trunk_enabled = (opts->trunk_enable == 1 || opts->p25_trunk == 1);
     if (trunk_enabled && cc != 0) {
         const int cc_sps = dsd_engine_compute_cc_sps(opts, state);
-        dsd_engine_trunk_tune_to_cc(opts, state, cc, cc_sps);
+        tune_result = dsd_engine_trunk_tune_to_cc(opts, state, cc, cc_sps);
+        if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+            return tune_result;
+        }
     }
+
+    dsd_engine_reset_return_to_cc_state(opts, state);
 
     /* Keep symbol timing aligned with the current control-channel mode. */
     dsd_engine_apply_cc_symbol_timing(opts, state);
+    return tune_result;
 }
 
 /**
@@ -299,10 +383,14 @@ dsd_engine_return_to_cc(dsd_opts* opts, dsd_state* state) {
  * @param freq Target frequency in Hz.
  * @param ted_sps TED samples-per-symbol to set (0 = no override).
  */
-void
+dsd_trunk_tune_result
 dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    dsd_trunk_tune_result result = DSD_TRUNK_TUNE_RESULT_OK;
+#ifdef USE_RADIO
+    dsd_engine_rtl_profile_snapshot rtl_snapshot;
+#endif
     if (!opts || !state || freq <= 0) {
-        return;
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
     }
 
     /* Trunking (P25): the SM sets state->rf_mod based on the grant (0=C4FM FDMA,
@@ -313,21 +401,9 @@ dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, i
      *
      * Respect explicit CQPSK forcing via runtime config/env (DSD_NEO_CQPSK). */
 #ifdef USE_RADIO
+    dsd_engine_rtl_profile_snapshot_capture(opts, state, &rtl_snapshot);
     dsd_engine_prepare_vc_rtl_chain(opts, state);
 #endif
-
-    // Reset modulation auto-detect state (ham tracking, vote counters) to ensure
-    // fresh acquisition on the new channel and avoid carrying stale decisions.
-    dsd_frame_sync_reset_mod_state();
-
-    // Reset P25P2 frame processing state when tuning to a voice channel.
-    // This is critical: without resetting the global bit buffers (p2bit, p2xbit),
-    // ESS buffers (ess_a, ess_b), and counters (vc_counter, ts_counter), the
-    // decoder will process new channel data using stale buffers from the previous
-    // channel, causing decode failures. The symptom is: first P25P2 tune works,
-    // but subsequent voice channel grants fail to lock with tanking EVM/SNR.
-    // Only reset for P25P2 (ted_sps matching the TDMA symbol rate), not P25P1 or other modes.
-    dsd_engine_maybe_reset_p25p2_state(opts, state, ted_sps);
 
     // NOTE: We intentionally do NOT call rtl_stream_reset_costas() here.
     //
@@ -354,9 +430,30 @@ dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, i
     dsd_engine_maybe_apply_ted_override(opts, state, freq, ted_sps);
 #endif
 
-    dsd_engine_maybe_drain_audio(opts);
-    dsd_engine_tune_with_backend(opts, state, freq);
+    dsd_engine_maybe_drain_audio(opts, state);
+    result = dsd_engine_tune_with_backend(opts, state, freq);
+    if (!dsd_trunk_tune_result_is_ok(result)) {
+#ifdef USE_RADIO
+        dsd_engine_rtl_profile_snapshot_restore(state, &rtl_snapshot);
+#endif
+        return result;
+    }
+
+    // Reset modulation auto-detect state (ham tracking, vote counters) after a
+    // confirmed tune so the decoder and tuner state do not diverge on failure.
+    dsd_frame_sync_reset_mod_state();
+
+    // Reset P25P2 frame processing state when tuning to a voice channel.
+    // This is critical: without resetting the global bit buffers (p2bit, p2xbit),
+    // ESS buffers (ess_a, ess_b), and counters (vc_counter, ts_counter), the
+    // decoder will process new channel data using stale buffers from the previous
+    // channel, causing decode failures. The symptom is: first P25P2 tune works,
+    // but subsequent voice channel grants fail to lock with tanking EVM/SNR.
+    // Only reset for P25P2 (ted_sps matching the TDMA symbol rate), not P25P1 or other modes.
+    dsd_engine_maybe_reset_p25p2_state(opts, state, ted_sps);
+
     dsd_engine_update_vc_tune_state(opts, state, freq);
+    return result;
 }
 
 /**
@@ -371,38 +468,42 @@ dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, i
  * @param ted_sps TED samples-per-symbol to set (0 = no change). Caller should
  *        pass the CC SPS (4 for P25P2 TDMA CC, 5 for P25P1 CC).
  */
-void
+dsd_trunk_tune_result
 dsd_engine_trunk_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    dsd_trunk_tune_result result = DSD_TRUNK_TUNE_RESULT_OK;
+#ifdef USE_RADIO
+    dsd_engine_rtl_profile_snapshot rtl_snapshot;
+#endif
     if (!opts || !state || freq <= 0) {
-        return;
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
     }
 #ifndef USE_RADIO
     (void)ted_sps;
+#else
+    dsd_engine_rtl_profile_snapshot_capture(opts, state, &rtl_snapshot);
 #endif
-    // Reset modulation auto-detect state for fresh acquisition.
-    dsd_frame_sync_reset_mod_state();
 
     // NOTE: Costas/TED reset is deferred to the controller thread after the hardware
     // retune completes. See dsd_engine_trunk_tune_to_freq for the full rationale.
 
-    dsd_engine_maybe_drain_audio(opts);
-    if (opts->use_rigctl == 1) {
-        if (opts->setmod_bw != 0) {
-            if (!SetModulation(opts->rigctl_sockfd, opts->setmod_bw)) {
-                DSD_FPRINTF(stderr, "Rigctl modulation update failed for bandwidth %d.\n", opts->setmod_bw);
-            }
-        }
-        SetFreq(opts->rigctl_sockfd, freq);
-    } else if (opts->audio_in_type == AUDIO_IN_RTL) {
+    dsd_engine_maybe_drain_audio(opts, state);
+    if (opts->audio_in_type == AUDIO_IN_RTL) {
 #ifdef USE_RADIO
         dsd_engine_prepare_cc_rtl_chain(opts, state, ted_sps);
-        if (state->rtl_ctx) {
-            rtl_stream_tune(state->rtl_ctx, (uint32_t)freq);
-        }
 #endif
     }
+    result = dsd_engine_tune_with_backend(opts, state, freq);
+    if (!dsd_trunk_tune_result_is_ok(result)) {
+#ifdef USE_RADIO
+        dsd_engine_rtl_profile_snapshot_restore(state, &rtl_snapshot);
+#endif
+        return result;
+    }
+    // Reset modulation auto-detect state for fresh acquisition after a confirmed tune.
+    dsd_frame_sync_reset_mod_state();
     // Do not set p25_is_tuned/trunk_is_tuned here; this is a CC hunt action.
     state->trunk_cc_freq = (long int)freq;
     state->last_cc_sync_time = time(NULL);
     state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
+    return result;
 }

--- a/src/engine/trunk_tuning_hooks_install.c
+++ b/src/engine/trunk_tuning_hooks_install.c
@@ -11,8 +11,8 @@
 void
 dsd_engine_trunk_tuning_hooks_install(void) {
     dsd_trunk_tuning_hooks hooks = {0};
-    hooks.tune_to_freq = dsd_engine_trunk_tune_to_freq;
-    hooks.tune_to_cc = dsd_engine_trunk_tune_to_cc;
-    hooks.return_to_cc = dsd_engine_return_to_cc;
+    hooks.tune_to_freq_result = dsd_engine_trunk_tune_to_freq;
+    hooks.tune_to_cc_result = dsd_engine_trunk_tune_to_cc;
+    hooks.return_to_cc_result = dsd_engine_return_to_cc;
     dsd_trunk_tuning_hooks_set(hooks);
 }

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -709,7 +709,7 @@ rtl_handle_u8_ring_generation_stale(const struct rtl_device* s, const unsigned c
 }
 
 static inline void
-rtl_finalize_u8_ring_write(struct rtl_device* s, const unsigned char* src, size_t done, size_t need,
+rtl_finalize_u8_ring_write(struct rtl_device* s, const unsigned char* src, size_t len, size_t done, size_t need,
                            struct rtl_capture_u8_byte_carry* carry, int* phase, int fs4_shift_active,
                            int count_full_reserve, int ring_exhausted, int generation_stale) {
     if (!s || !src || !carry || !phase) {
@@ -724,7 +724,7 @@ rtl_finalize_u8_ring_write(struct rtl_device* s, const unsigned char* src, size_
         if (count_full_reserve) {
             s->reserve_full_events++;
         }
-    } else if (need == 1U && !carry->valid) {
+    } else if (need == 1U && done < len && !carry->valid) {
         rtl_capture_u8_byte_carry_save(carry, src[done]);
     }
 
@@ -786,8 +786,8 @@ rtl_write_u8_to_ring(struct rtl_device* s, unsigned char* src, size_t len, int f
         input_ring_commit(s->input_ring, produced);
     }
 
-    rtl_finalize_u8_ring_write(s, src, done, need, &carry, &phase, fs4_shift_active, count_full_reserve, ring_exhausted,
-                               generation_stale);
+    rtl_finalize_u8_ring_write(s, src, len, done, need, &carry, &phase, fs4_shift_active, count_full_reserve,
+                               ring_exhausted, generation_stale);
     if (perf_on) {
         uint64_t drops_after = s->input_ring->producer_drops.load(std::memory_order_relaxed);
         uint64_t drops_delta = (drops_after >= perf_drops_before) ? (drops_after - perf_drops_before) : 0ULL;
@@ -5221,7 +5221,7 @@ rtl_device_set_iq_capture_writer(struct rtl_device* dev, struct dsd_iq_capture_w
 
 void
 rtl_device_begin_capture_reconfigure(struct rtl_device* dev) {
-    if (!dev || !dev->iq_capture_writer) {
+    if (!dev) {
         return;
     }
     dev->capture_reconfigure_hold.store(RTL_CAPTURE_RECONFIGURE_ACTIVE, std::memory_order_release);
@@ -5261,6 +5261,50 @@ rtl_device_test_end_capture_reconfigure_with_odd_carry(int* out_hold, int* out_m
     if (out_mute_byte_phase) {
         *out_mute_byte_phase = dev.mute_byte_phase.load(std::memory_order_acquire);
     }
+}
+
+extern "C" int
+rtl_device_test_begin_capture_reconfigure_without_writer(int* out_hold) {
+    rtl_device dev{};
+    rtl_device_init_common_state(&dev);
+    rtl_device_begin_capture_reconfigure(&dev);
+    if (out_hold) {
+        *out_hold = dev.capture_reconfigure_hold.load(std::memory_order_acquire);
+    }
+    rtl_device_cleanup_common_state(&dev);
+    return 0;
+}
+
+extern "C" int
+rtl_device_test_usb_reconfigure_discards_samples(size_t input_bytes, size_t* out_ring_used) {
+    if (!out_ring_used || input_bytes == 0U || input_bytes > 256U) {
+        return -1;
+    }
+    input_ring_state ring{};
+    if (input_ring_init(&ring, 512U) != 0) {
+        return -2;
+    }
+    unsigned char* buf = static_cast<unsigned char*>(calloc(input_bytes, sizeof(unsigned char)));
+    if (!buf) {
+        input_ring_destroy(&ring);
+        return -3;
+    }
+    for (size_t i = 0; i < input_bytes; i++) {
+        buf[i] = (unsigned char)(127U + (i & 1U));
+    }
+
+    rtl_device dev{};
+    rtl_device_init_common_state(&dev);
+    dev.input_ring = &ring;
+    dev.backend = RTL_BACKEND_USB;
+    rtl_device_begin_capture_reconfigure(&dev);
+    rtlsdr_callback(buf, (uint32_t)input_bytes, &dev);
+    *out_ring_used = input_ring_used(&ring);
+    rtl_device_end_capture_reconfigure(&dev);
+    rtl_device_cleanup_common_state(&dev);
+    free(buf);
+    input_ring_destroy(&ring);
+    return 0;
 }
 #endif
 

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -282,6 +282,8 @@ static uint32_t rtl_stream_bump_output_generation(void);
 static void rtl_fsk_metrics_reset_snapshot(void);
 static void rtl_decode_health_reset(void);
 static void rtl_publish_fsk_metrics_from_demod(const struct demod_state* d);
+static void rtl_stream_signal_output_waiters(struct output_state* outp);
+static void rtl_stream_clear_output_ring(struct output_state* outp, int bump_generation);
 /*
  * The controller already purges stale samples and applies a time-based hardware
  * mute after retunes. Do not additionally drop whole demod blocks here: at RTL
@@ -2966,6 +2968,75 @@ demod_maybe_signal_squelch_hop(struct demod_state* d) {
     }
 }
 
+static int
+demod_output_write_cancelled(void) {
+    return (exitflag || controller.retune_in_progress.load(std::memory_order_acquire)) ? 1 : 0;
+}
+
+static int
+demod_wait_for_output_space(struct output_state* o) {
+    dsd_mutex_lock(&o->ready_m);
+    int ret = dsd_cond_timedwait(&o->space, &o->ready_m, 10);
+    dsd_mutex_unlock(&o->ready_m);
+    if (ret == 0) {
+        return 1;
+    }
+    if (exitflag) {
+        return 0;
+    }
+    o->write_timeouts.fetch_add(1);
+    return 1;
+}
+
+static size_t
+demod_copy_output_chunk(struct output_state* o, const float* data, size_t count, size_t free_sp) {
+    size_t write_now = (count < free_sp) ? count : free_sp;
+    size_t h = o->head.load();
+    size_t to_end = o->capacity - h;
+    if (to_end >= write_now) {
+        DSD_MEMCPY(o->buffer + h, data, write_now * sizeof(float));
+        h += write_now;
+        if (h >= o->capacity) {
+            h = 0U;
+        }
+        o->head.store(h);
+        return write_now;
+    }
+    if (to_end > 0U) {
+        DSD_MEMCPY(o->buffer + h, data, to_end * sizeof(float));
+    }
+    size_t remaining = write_now - to_end;
+    DSD_MEMCPY(o->buffer, data + to_end, remaining * sizeof(float));
+    o->head.store(remaining);
+    return write_now;
+}
+
+static size_t
+demod_write_output_samples_interruptible(struct output_state* o, const float* data, size_t count) {
+    if (!o || !o->buffer || !data || count == 0U) {
+        return 0U;
+    }
+    int need_signal = ring_is_empty(o);
+    size_t written = 0U;
+    while (count > 0U && !demod_output_write_cancelled()) {
+        size_t free_sp = ring_free(o);
+        if (free_sp == 0U) {
+            if (!demod_wait_for_output_space(o)) {
+                break;
+            }
+            continue;
+        }
+        size_t write_now = demod_copy_output_chunk(o, data, count, free_sp);
+        data += write_now;
+        count -= write_now;
+        written += write_now;
+    }
+    if (need_signal && written > 0U) {
+        safe_cond_signal(&o->ready, &o->ready_m);
+    }
+    return written;
+}
+
 static size_t
 demod_write_output_block(struct demod_state* d, struct output_state* o) {
     if (!d || !o) {
@@ -2973,8 +3044,7 @@ demod_write_output_block(struct demod_state* d, struct output_state* o) {
     }
     if (d->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK || d->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK) {
         if (d->result_len > 0) {
-            ring_write_signal_on_empty_transition(o, d->result, (size_t)d->result_len);
-            return (size_t)d->result_len;
+            return demod_write_output_samples_interruptible(o, d->result, (size_t)d->result_len);
         }
         return 0U;
     }
@@ -2982,15 +3052,13 @@ demod_write_output_block(struct demod_state* d, struct output_state* o) {
         int out_n = resamp_process_block(d, d->result, d->result_len, d->resamp_outbuf);
         if (out_n > 0) {
             apply_output_scale(d, d->resamp_outbuf, out_n);
-            ring_write_signal_on_empty_transition(o, d->resamp_outbuf, (size_t)out_n);
-            return (size_t)out_n;
+            return demod_write_output_samples_interruptible(o, d->resamp_outbuf, (size_t)out_n);
         }
         return 0U;
     }
     if (d->result_len > 0) {
         apply_output_scale(d, d->result, d->result_len);
-        ring_write_signal_on_empty_transition(o, d->result, (size_t)d->result_len);
-        return (size_t)d->result_len;
+        return demod_write_output_samples_interruptible(o, d->result, (size_t)d->result_len);
     }
     return 0U;
 }
@@ -3121,7 +3189,8 @@ static DSD_THREAD_RETURN_TYPE
         }
         demod_maybe_signal_squelch_hop(d);
         uint64_t perf_output_start_ns = perf_on ? rtl_perf_now_ns() : 0ULL;
-        size_t perf_output_samples = demod_write_output_block(d, o);
+        size_t perf_output_samples =
+            controller.retune_in_progress.load(std::memory_order_acquire) ? 0U : demod_write_output_block(d, o);
         demod_perf_log_block(perf_on, perf_output_start_ns, perf_full_demod_ns, perf_metrics_ns, span.got,
                              perf_output_samples, d);
         demod_leave_processing_block(&controller);
@@ -3356,7 +3425,9 @@ controller_enter_reconfigure_gate(struct controller_state* s) {
         return;
     }
     s->retune_in_progress.store(1, std::memory_order_release);
+    rtl_stream_signal_output_waiters(g_stream && g_stream->output ? g_stream->output : &output);
     controller_wait_for_demod_idle(s);
+    rtl_stream_clear_output_ring(g_stream && g_stream->output ? g_stream->output : &output, 1);
     g_retune_settle_blocks_remaining.store(0, std::memory_order_release);
     g_retune_diag_blocks_remaining.store(0, std::memory_order_release);
 }
@@ -6167,6 +6238,11 @@ dsd_rtl_stream_get_ted_sps(void) {
 }
 
 extern "C" int
+dsd_rtl_stream_get_ted_sps_override(void) {
+    return demod.ted_sps_override;
+}
+
+extern "C" int
 dsd_rtl_stream_get_output_kind(void) {
     return demod.output_kind;
 }
@@ -6961,27 +7037,68 @@ dsd_rtl_stream_reset_cqpsk_eq(void) {
  *
  * @param opts      Decoder options.
  * @param frequency Target center frequency in Hz.
- * @return 0 on success, -1 on timeout.
+ * @return rtl_stream_tune_result: 0 on success, 1 when deferred, negative on error/timeout.
  */
+static const char*
+rtl_stream_backend_name(void) {
+    if (stream_is_replay_active()) {
+        return "iq-replay";
+    }
+    if (g_stream && g_stream->opts) {
+        if (g_stream->opts->rtltcp_enabled) {
+            return "rtl_tcp";
+        }
+        if (dsd_opts_audio_in_dev_is_soapy_spec(g_stream->opts->audio_in_dev)) {
+            return "soapy";
+        }
+    }
+    return "rtl";
+}
+
+static void
+rtl_stream_log_tune_warning(uint32_t requested_freq, const char* reason) {
+    uint32_t current_freq = controller.last_applied_freq_hz.load(std::memory_order_acquire);
+    if (current_freq == 0U) {
+        current_freq = load_dongle_frequency();
+    }
+    LOG_NOTICE("RTL retune warning: requested=%u Hz current=%u Hz backend=%s reason=%s\n", requested_freq, current_freq,
+               rtl_stream_backend_name(), reason ? reason : "unknown");
+}
+
 static int
-rtl_stream_tune_wait_for_completion(uint32_t request_id) {
-    int rc = 0;
+rtl_stream_tune_wait_for_completion(uint32_t request_id, uint32_t requested_freq) {
+    int rc = RTL_STREAM_TUNE_OK;
+    const uint64_t deadline_ns = dsd_time_monotonic_ns() + 500000000ULL;
     dsd_mutex_lock(&controller.retune_done_m);
     while (controller.retune_complete_id.load(std::memory_order_acquire) < request_id) {
-        int wait_rc = dsd_cond_timedwait(&controller.retune_done_cond, &controller.retune_done_m, 500);
-        if (wait_rc != 0) {
-            LOG_NOTICE("Retune wait timeout (request %u, complete %u) - continuing.\n", request_id,
-                       controller.retune_complete_id.load(std::memory_order_relaxed));
-            rc = -1;
+        uint64_t now_ns = dsd_time_monotonic_ns();
+        if (now_ns >= deadline_ns) {
+            rtl_stream_log_tune_warning(requested_freq, "timeout");
+            rc = RTL_STREAM_TUNE_TIMEOUT;
             break;
         }
+        uint64_t remaining_ms = (deadline_ns - now_ns + 999999ULL) / 1000000ULL;
+        int wait_ms = (remaining_ms > 25ULL) ? 25 : (int)remaining_ms;
+        if (wait_ms <= 0) {
+            wait_ms = 1;
+        }
+        int wait_rc = dsd_cond_timedwait(&controller.retune_done_cond, &controller.retune_done_m, wait_ms);
+        if (wait_rc != 0) {
+            continue;
+        }
         if (exitflag || (g_stream && g_stream->should_exit.load(std::memory_order_relaxed))) {
-            rc = -1;
+            rtl_stream_log_tune_warning(requested_freq, "shutdown");
+            rc = RTL_STREAM_TUNE_FAILED;
             break;
         }
     }
     dsd_mutex_unlock(&controller.retune_done_m);
     return rc;
+}
+
+static int
+rtl_stream_tune_result_needs_output_drain(int rc) {
+    return rc == RTL_STREAM_TUNE_OK || rc == RTL_STREAM_TUNE_TIMEOUT;
 }
 
 static void
@@ -7007,11 +7124,11 @@ dsd_rtl_stream_tune(dsd_opts* opts, long int frequency) {
             s_last_notice_ns.store(now_ns, std::memory_order_release);
             LOG_NOTICE("Retune ignored during IQ replay.\n");
         }
-        return 0;
+        return RTL_STREAM_TUNE_DEFERRED;
     }
     if (auto_ppm_should_freeze_retunes() && dsd_rtl_stream_auto_ppm_training_active()) {
-        LOG_NOTICE("Retune deferred: auto-PPM training active.\n");
-        return 0;
+        rtl_stream_log_tune_warning((uint32_t)frequency, "auto_ppm_training");
+        return RTL_STREAM_TUNE_DEFERRED;
     }
     if (opts->payload == 1) {
         LOG_INFO("\nTuning to %ld Hz.", frequency);
@@ -7028,14 +7145,15 @@ dsd_rtl_stream_tune(dsd_opts* opts, long int frequency) {
         LOG_INFO(" (Center Frequency: %u Hz.) \n", requested_freq);
     }
 
-    int rc = rtl_stream_tune_wait_for_completion(my_request_id);
+    int rc = rtl_stream_tune_wait_for_completion(my_request_id, requested_freq);
 
-    if (rc == 0) {
+    if (rc == RTL_STREAM_TUNE_OK) {
         rtl_stream_tune_reconcile_applied_frequency(opts, requested_freq);
     }
-
-    /* Honor drain/clear policy for API-triggered tunes as well */
-    drain_output_on_retune();
+    if (rtl_stream_tune_result_needs_output_drain(rc)) {
+        /* Honor drain/clear policy for API-triggered tunes and accepted-but-pending timeout paths. */
+        drain_output_on_retune();
+    }
     return rc;
 }
 
@@ -7111,7 +7229,9 @@ dsd_rtl_stream_test_prepare_reconfigure_input(size_t queued_samples, size_t* out
     output.head.store(queued_samples);
 
     *out_generation_before = dsd_rtl_stream_output_generation();
+    controller_enter_reconfigure_gate(&controller);
     controller_prepare_reconfigure_input();
+    controller_end_reconfigure(&controller);
     *out_generation_after = dsd_rtl_stream_output_generation();
     *out_used_after = ring_used(&output);
 
@@ -7155,6 +7275,55 @@ dsd_rtl_stream_test_retune_output_pending(size_t queued_samples, int cached_symb
 
     retune_output_pending(&output, out_ring_pending, out_cache_pending);
     *out_drained = retune_output_drained(&output);
+
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+    ring_clear(&output);
+    if (initialized_output) {
+        output_cleanup(&output);
+    }
+    return 0;
+}
+
+extern "C" int
+dsd_rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samples, int cached_symbols,
+                                             size_t* out_used_after, int* out_cache_pending_after,
+                                             uint32_t* out_generation_before, uint32_t* out_generation_after) {
+    if (!out_used_after || !out_cache_pending_after || !out_generation_before || !out_generation_after
+        || cached_symbols < 0) {
+        return -1;
+    }
+
+    int initialized_output = 0;
+    if (!output.buffer) {
+        output_init(&output);
+        initialized_output = 1;
+    }
+    if (!output.buffer || output.capacity == 0U) {
+        if (initialized_output) {
+            output_cleanup(&output);
+        }
+        return -2;
+    }
+    if (queued_samples >= output.capacity) {
+        if (initialized_output) {
+            output_cleanup(&output);
+        }
+        return -3;
+    }
+
+    ring_clear(&output);
+    output.tail.store(0);
+    output.head.store(queued_samples);
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_delta(cached_symbols);
+
+    *out_generation_before = dsd_rtl_stream_output_generation();
+    if (rtl_stream_tune_result_needs_output_drain(tune_result)) {
+        drain_output_on_retune();
+    }
+    *out_generation_after = dsd_rtl_stream_output_generation();
+    *out_used_after = ring_used(&output);
+    *out_cache_pending_after = dsd_rtl_stream_metrics_hook_symbol_cache_pending();
 
     dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
     ring_clear(&output);
@@ -7379,19 +7548,39 @@ dsd_rtl_stream_set_channel_squelch(float level) {
 /**
  * @brief Clear the output ring buffer and wake any waiting producer.
  */
+static void
+rtl_stream_signal_output_waiters(struct output_state* outp) {
+    if (!outp || !outp->buffer) {
+        return;
+    }
+    dsd_mutex_lock(&outp->ready_m);
+    dsd_cond_broadcast(&outp->space);
+    dsd_cond_broadcast(&outp->ready);
+    dsd_mutex_unlock(&outp->ready_m);
+}
+
+static void
+rtl_stream_clear_output_ring(struct output_state* outp, int bump_generation) {
+    if (!outp || !outp->buffer) {
+        return;
+    }
+    if (bump_generation) {
+        /* Invalidate decoder-owned cached symbols before clearing the shared output. */
+        rtl_stream_bump_output_generation();
+    }
+    /* Clear the entire ring to prevent sample 'lag' */
+    ring_clear(outp);
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+    rtl_stream_signal_output_waiters(outp);
+}
+
 extern "C" void
 dsd_rtl_stream_clear_output(void) {
     struct output_state* outp = &output;
     if (g_stream && g_stream->output) {
         outp = g_stream->output;
     }
-    /* Invalidate decoder-owned cached symbols before clearing the shared output. */
-    rtl_stream_bump_output_generation();
-    /* Clear the entire ring to prevent sample 'lag' */
-    ring_clear(outp);
-    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
-    /* Wake producer waiting for space */
-    safe_cond_signal(&outp->space, &outp->ready_m);
+    rtl_stream_clear_output_ring(outp, 1);
 }
 
 extern "C" int

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -2073,6 +2073,17 @@ demod_input_span_commit_direct(DemodInputSpan* span) {
         return;
     }
     input_ring_read_commit(&input_ring, span->reserved_count);
+    span->reserved_count = 0U;
+    span->direct_input_span = 0;
+}
+
+static void
+demod_input_span_commit_reserved(DemodInputSpan* span) {
+    if (!span || span->reserved_count == 0U) {
+        return;
+    }
+    input_ring_read_commit(&input_ring, span->reserved_count);
+    span->reserved_count = 0U;
     span->direct_input_span = 0;
 }
 
@@ -2125,7 +2136,7 @@ demod_copy_wrapped_input_block(struct demod_state* d, const DemodInputSpan* span
 }
 
 static int
-demod_read_input_block(struct demod_state* d, DemodInputSpan* span) {
+demod_read_input_block(const struct demod_state* d, DemodInputSpan* span) {
     demod_input_span_init(span);
     if (!d || !span) {
         return 0;
@@ -2138,9 +2149,17 @@ demod_read_input_block(struct demod_state* d, DemodInputSpan* span) {
     span->direct_input_span =
         (span->ring_p1 && span->ring_n1 == (size_t)span->got && (!span->ring_p2 || span->ring_n2 == 0)) ? 1 : 0;
     span->reserved_count = (size_t)span->got;
+    return 1;
+}
+
+static int
+demod_prepare_input_block(struct demod_state* d, DemodInputSpan* span) {
+    if (!d || !span) {
+        return 0;
+    }
     if (!span->direct_input_span) {
         int copied = demod_copy_wrapped_input_block(d, span);
-        input_ring_read_commit(&input_ring, span->reserved_count);
+        demod_input_span_commit_reserved(span);
         span->got = copied;
         if (span->got <= 0) {
             return 0;
@@ -3107,9 +3126,18 @@ demod_prepare_iteration_input(struct demod_state* d, int is_rtltcp_input, DemodI
     if (!demod_read_input_block(d, span)) {
         return 0;
     }
+    if (!demod_enter_processing_block(&controller)) {
+        demod_input_span_commit_reserved(span);
+        return 0;
+    }
+    if (!demod_prepare_input_block(d, span)) {
+        demod_leave_processing_block(&controller);
+        return 0;
+    }
     if (controller.retune_in_progress.load(std::memory_order_acquire)
         || g_ring_purge_pending.load(std::memory_order_acquire)) {
         demod_input_span_commit_direct(span);
+        demod_leave_processing_block(&controller);
         return 0;
     }
     int input_pairs = 0;
@@ -3118,25 +3146,28 @@ demod_prepare_iteration_input(struct demod_state* d, int is_rtltcp_input, DemodI
     iq_block_abs_stats(span->input_block, span->got, &input_mean_abs, &input_max_abs, &input_pairs);
     if (retune_settle_should_discard(d, input_mean_abs, input_max_abs, input_pairs)) {
         demod_input_span_commit_direct(span);
+        demod_leave_processing_block(&controller);
         return 0;
     }
     *retune_diag = demod_capture_retune_diag(input_mean_abs, input_max_abs, input_pairs);
     demod_autogain_update(d, input_mean_abs, input_max_abs);
-    d->lowpassed = span->input_block;
-    d->lp_len = span->got;
     if (!controller.cold_start_ready.load(std::memory_order_acquire)) {
-        demod_input_span_release_direct(d, span);
+        demod_input_span_commit_direct(span);
+        demod_leave_processing_block(&controller);
         return 0;
     }
     if (controller.retune_in_progress.load(std::memory_order_acquire)) {
-        demod_input_span_release_direct(d, span);
+        demod_input_span_commit_direct(span);
+        demod_leave_processing_block(&controller);
         return 0;
     }
+    d->lowpassed = span->input_block;
+    d->lp_len = span->got;
     return 1;
 }
 
 static int
-demod_prepare_iteration_processing(struct demod_state* d, DemodInputSpan* span, int* replay_active,
+demod_prepare_iteration_processing(const struct demod_state* d, const DemodInputSpan* span, int* replay_active,
                                    uint64_t* consumed_gen) {
     if (!d || !span || !replay_active || !consumed_gen) {
         return 0;
@@ -3145,10 +3176,6 @@ demod_prepare_iteration_processing(struct demod_state* d, DemodInputSpan* span, 
     *replay_active = stream_is_replay_active();
     if (*replay_active && g_stream) {
         *consumed_gen = g_stream->replay_last_submit_gen.load(std::memory_order_acquire);
-    }
-    if (!demod_enter_processing_block(&controller)) {
-        demod_input_span_release_direct(d, span);
-        return 0;
     }
     return 1;
 }
@@ -3171,6 +3198,8 @@ static DSD_THREAD_RETURN_TYPE
         int replay_active = 0;
         uint64_t consumed_gen = 0ULL;
         if (!demod_prepare_iteration_processing(d, &span, &replay_active, &consumed_gen)) {
+            demod_input_span_release_direct(d, &span);
+            demod_leave_processing_block(&controller);
             continue;
         }
         int perf_on = rtl_perf_enabled();

--- a/src/io/radio/rtl_stream.cpp
+++ b/src/io/radio/rtl_stream.cpp
@@ -149,7 +149,7 @@ RtlSdrOrchestrator::tune(uint32_t center_freq_hz) {
         return last_error_code_;
     }
     int rc = dsd_rtl_stream_tune(opts_, (long int)center_freq_hz);
-    if (rc < 0) {
+    if (rc != 0) {
         last_error_code_ = rc;
         return rc;
     }

--- a/src/io/radio/rtl_stream_c.cpp
+++ b/src/io/radio/rtl_stream_c.cpp
@@ -37,6 +37,7 @@ int dsd_rtl_stream_monitor_read(float* out, size_t count, int* out_got);
 unsigned int dsd_rtl_stream_monitor_rate(void);
 void dsd_rtl_stream_set_resampler_target(int target_hz);
 int dsd_rtl_stream_get_ted_sps(void);
+int dsd_rtl_stream_get_ted_sps_override(void);
 void dsd_rtl_stream_set_ted_sps(int sps);
 void dsd_rtl_stream_clear_ted_sps_override(void);
 void dsd_rtl_stream_set_ted_sps_no_override(int sps);
@@ -87,6 +88,9 @@ int dsd_rtl_stream_test_prepare_reconfigure_input(size_t queued_samples, size_t*
                                                   uint32_t* out_generation_before, uint32_t* out_generation_after);
 int dsd_rtl_stream_test_retune_output_pending(size_t queued_samples, int cached_symbols, size_t* out_ring_pending,
                                               int* out_cache_pending, int* out_drained);
+int dsd_rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samples, int cached_symbols,
+                                                 size_t* out_used_after, int* out_cache_pending_after,
+                                                 uint32_t* out_generation_before, uint32_t* out_generation_after);
 int dsd_rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size_t* out_used_after,
                                      int* out_cache_pending_after, uint32_t* out_generation_before,
                                      uint32_t* out_generation_after);
@@ -212,7 +216,7 @@ rtl_stream_destroy(RtlSdrContext* ctx) {
  *
  * @param ctx Stream context.
  * @param center_freq_hz New center frequency in Hz.
- * @return 0 on success; otherwise <0 on error.
+ * @return rtl_stream_tune_result: 0 on success, 1 when deferred, negative on error/timeout.
  */
 extern "C" int
 rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz) {
@@ -243,6 +247,15 @@ rtl_stream_test_retune_output_pending(size_t queued_samples, int cached_symbols,
                                       int* out_cache_pending, int* out_drained) {
     return dsd_rtl_stream_test_retune_output_pending(queued_samples, cached_symbols, out_ring_pending,
                                                      out_cache_pending, out_drained);
+}
+
+extern "C" int
+rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samples, int cached_symbols,
+                                         size_t* out_used_after, int* out_cache_pending_after,
+                                         uint32_t* out_generation_before, uint32_t* out_generation_after) {
+    return dsd_rtl_stream_test_tune_result_output_drain(tune_result, queued_samples, cached_symbols, out_used_after,
+                                                        out_cache_pending_after, out_generation_before,
+                                                        out_generation_after);
 }
 
 extern "C" int
@@ -413,6 +426,11 @@ rtl_stream_set_resampler_target(int target_hz) {
 extern "C" int
 rtl_stream_get_ted_sps(void) {
     return dsd_rtl_stream_get_ted_sps();
+}
+
+extern "C" int
+rtl_stream_get_ted_sps_override(void) {
+    return dsd_rtl_stream_get_ted_sps_override();
 }
 
 extern "C" void

--- a/src/protocol/dmr/dmr_csbk.c
+++ b/src/protocol/dmr/dmr_csbk.c
@@ -1360,8 +1360,13 @@ dmr_cspdu_pf0_c_bcast_try_switch_tscc(dsd_opts* opts, dsd_state* state, long f1,
     }
 
     if (next > 0 && next != cur) {
+        const long previous_cc = state->trunk_cc_freq;
         state->trunk_cc_freq = next;
-        dsd_trunk_tuning_hook_return_to_cc(opts, state);
+        dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_return_to_cc(opts, state);
+        if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+            state->trunk_cc_freq = previous_cc;
+            return;
+        }
         DSD_FPRINTF(stderr, "\n Switched to announced TSCC: %.6lf MHz\n", (double)next / 1000000.0);
     }
 }
@@ -2019,6 +2024,12 @@ dmr_cspdu_cap_plus_3e_try_tune_grants(dsd_opts* opts, dsd_state* state, const dm
             continue;
         }
 
+        const long int grant_freq = state->trunk_chan_map[j + 1];
+        const uint32_t old_rtl_center_freq = opts->rtlsdr_center_freq;
+        dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_freq(opts, state, grant_freq, 0);
+        if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+            break;
+        }
         if (state->tg_hold != 0) {
             if ((j & 1) == 0) {
                 state->lasttg = ctx->t_tg[j];
@@ -2026,10 +2037,9 @@ dmr_cspdu_cap_plus_3e_try_tune_grants(dsd_opts* opts, dsd_state* state, const dm
                 state->lasttgR = ctx->t_tg[j];
             }
         }
-        if (opts->rtlsdr_center_freq != (uint32_t)state->trunk_chan_map[j + 1]) {
+        if (old_rtl_center_freq != (uint32_t)grant_freq) {
             dmr_reset_blocks(opts, state);
         }
-        dsd_trunk_tuning_hook_tune_to_freq(opts, state, state->trunk_chan_map[j + 1], 0);
         break;
     }
 }
@@ -2285,6 +2295,9 @@ dmr_cspdu_con_plus_handle_data(dsd_opts* opts, dsd_state* state, const uint8_t c
     dsd_tg_policy_decision policy_decision;
     int policy_allowed;
     char suf[24];
+    char prev_active_channel[sizeof state->active_channel[0]];
+    time_t prev_last_active_time;
+    time_t now;
 
     if (csbk_o != 0x06) {
         return;
@@ -2304,23 +2317,33 @@ dmr_cspdu_con_plus_handle_data(dsd_opts* opts, dsd_state* state, const uint8_t c
     }
 
     dmr_format_chan_suffix(tslot, suf, sizeof suf);
+    DSD_SNPRINTF(prev_active_channel, sizeof prev_active_channel, "%s", state->active_channel[tslot]);
+    prev_last_active_time = state->last_active_time;
+    now = time(NULL);
     DSD_SNPRINTF(state->active_channel[tslot], sizeof(state->active_channel[tslot]), "Active Ch: %04X%s TG: %d; ", lcn,
                  suf, dtarget);
-    state->last_active_time = time(NULL);
+    state->last_active_time = now;
     if (opts->trunk_enable == 0 && state->trunk_chan_map[lcn] != 0) {
         state->trunk_vc_freq[0] = state->trunk_chan_map[lcn];
         state->trunk_vc_freq[1] = state->trunk_chan_map[lcn];
     }
 
     dmr_csbk_print_group_label(state, dtarget);
-    if (opts->trunk_tune_data_calls != 1 || (time(NULL) - state->last_vc_sync_time <= 2)) {
+    if (opts->trunk_tune_data_calls != 1 || (now - state->last_vc_sync_time <= 2)) {
         return;
     }
 
     policy_allowed = dmr_policy_tune_allowed(opts, state, dtarget, 0, 0, 1, &policy_decision);
     if (state->trunk_cc_freq != 0 && opts->trunk_enable == 1 && policy_allowed) {
         if (state->trunk_chan_map[lcn] != 0) {
-            dsd_trunk_tuning_hook_tune_to_freq(opts, state, state->trunk_chan_map[lcn], 0);
+            dsd_trunk_tune_result tune_result =
+                dsd_trunk_tuning_hook_tune_to_freq(opts, state, state->trunk_chan_map[lcn], 0);
+            if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+                DSD_SNPRINTF(state->active_channel[tslot], sizeof(state->active_channel[tslot]), "%s",
+                             prev_active_channel);
+                state->last_active_time = prev_last_active_time;
+                return;
+            }
             state->is_con_plus = 1;
             dmr_reset_blocks(opts, state);
         }

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -1128,7 +1128,10 @@ dmr_slco_tune_and_reset(dsd_opts* opts, dsd_state* state) {
     if (state->trunk_cc_freq == 0) {
         return;
     }
-    dsd_trunk_tuning_hook_tune_to_cc(opts, state, state->trunk_cc_freq, 0);
+    dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, state->trunk_cc_freq, 0);
+    if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+        return;
+    }
     opts->p25_is_tuned = 0;
     opts->trunk_is_tuned = 0;
     state->p25_vc_freq[0] = state->p25_vc_freq[1] = 0;

--- a/src/protocol/dmr/dmr_trunk_sm.c
+++ b/src/protocol/dmr/dmr_trunk_sm.c
@@ -84,11 +84,26 @@ set_state(dmr_sm_ctx_t* ctx, const dsd_opts* opts, dmr_sm_state_e new_state, con
 
 static void
 do_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason) {
+    int had_force_release = 0;
     if (!ctx) {
         return;
     }
 
+    if (state) {
+        had_force_release = (state->trunk_sm_force_release != 0) ? 1 : 0;
+        state->trunk_sm_force_release = 0;
+    }
+
     sm_log(opts, reason);
+
+    dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_return_to_cc(opts, state);
+    if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+        sm_log(opts, "release-tune-deferred");
+        if (state && had_force_release) {
+            state->trunk_sm_force_release = 1;
+        }
+        return;
+    }
 
     for (int s = 0; s < 2; s++) {
         ctx->slots[s].voice_active = 0;
@@ -112,9 +127,33 @@ do_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
         state->p25_sm_release_count++;
     }
 
-    dsd_trunk_tuning_hook_return_to_cc(opts, state);
-
     set_state(ctx, opts, DMR_SM_ON_CC, reason);
+}
+
+static int
+dmr_sm_resolve_tunable_grant(const dmr_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, const dmr_sm_event_t* ev,
+                             long* out_freq) {
+    if (opts->trunk_enable != 1 || state->trunk_cc_freq == 0) {
+        return 0;
+    }
+
+    long freq = resolve_freq(state, ev->freq_hz, ev->lpcn);
+    if (freq <= 0) {
+        sm_log(opts, "grant-no-freq");
+        return 0;
+    }
+
+    if (ev->freq_hz <= 0 && ev->lpcn > 0 && !lpcn_is_trusted(opts, state, ev->lpcn)) {
+        return 0;
+    }
+
+    if (ctx->state == DMR_SM_TUNED && ctx->vc_freq_hz == freq) {
+        sm_log(opts, "grant-same-freq");
+        return 0;
+    }
+
+    *out_freq = freq;
+    return 1;
 }
 
 /* ============================================================================
@@ -127,31 +166,19 @@ handle_grant(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const dmr_sm_e
         return;
     }
 
-    if (opts->trunk_enable != 1) {
-        return;
-    }
-    if (state->trunk_cc_freq == 0) {
-        return;
-    }
-
-    long freq = resolve_freq(state, ev->freq_hz, ev->lpcn);
-    if (freq <= 0) {
-        sm_log(opts, "grant-no-freq");
-        return;
-    }
-
-    if (ev->freq_hz <= 0 && ev->lpcn > 0) {
-        if (!lpcn_is_trusted(opts, state, ev->lpcn)) {
-            return;
-        }
-    }
-
-    if (ctx->state == DMR_SM_TUNED && ctx->vc_freq_hz == freq) {
-        sm_log(opts, "grant-same-freq");
+    long freq = 0;
+    if (!dmr_sm_resolve_tunable_grant(ctx, opts, state, ev, &freq)) {
         return;
     }
 
     double now_m = now_monotonic();
+
+    dsd_trunk_tune_result tune_result =
+        dsd_trunk_tuning_hook_tune_to_freq(opts, state, freq, 0); // DMR: no TED SPS override
+    if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+        sm_log(opts, "grant-tune-deferred");
+        return;
+    }
 
     ctx->vc_freq_hz = freq;
     ctx->vc_lpcn = ev->lpcn;
@@ -167,7 +194,6 @@ handle_grant(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const dmr_sm_e
     }
 
     dmr_reset_blocks(opts, state);
-    dsd_trunk_tuning_hook_tune_to_freq(opts, state, freq, 0); // DMR: no TED SPS override
 
     state->last_t3_tune_time_m = now_m;
     state->p25_sm_tune_count++;
@@ -233,7 +259,6 @@ handle_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot) {
     }
 
     if (state && state->trunk_sm_force_release != 0) {
-        state->trunk_sm_force_release = 0;
         do_release(ctx, opts, state, "release-forced");
         return;
     }
@@ -309,6 +334,11 @@ grant_timeout_expired(const dmr_sm_ctx_t* ctx, double now_m, double grant_timeou
 
 static void
 tick_tuned(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m, double hangtime, double grant_timeout) {
+    if (state && state->trunk_sm_force_release != 0) {
+        do_release(ctx, opts, state, "release-forced");
+        return;
+    }
+
     clear_stale_voice_slots(ctx, now_m);
 
     if (has_voice_activity(ctx)) {

--- a/src/protocol/edacs/edacs-fme.c
+++ b/src/protocol/edacs/edacs-fme.c
@@ -563,11 +563,16 @@ edacs_prepare_voice_wav_output(dsd_opts* opts, dsd_state* state, int is_digital)
     opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, sizeof opts->wav_out_file, 48000, 0);
 }
 
-static void
+static int
 edacs_tune_to_lcn(dsd_opts* opts, dsd_state* state, int lcn) {
     // LCN index is zero-based in trunk_lcn_freq[].
-    dsd_trunk_tuning_hook_tune_to_freq(opts, state, state->trunk_lcn_freq[lcn - 1], 0);
+    dsd_trunk_tune_result tune_result =
+        dsd_trunk_tuning_hook_tune_to_freq(opts, state, state->trunk_lcn_freq[lcn - 1], 0);
+    if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+        return 0;
+    }
     state->edacs_tuned_lcn = lcn;
+    return 1;
 }
 
 static void
@@ -577,8 +582,10 @@ edacs_try_tune_voice_call(dsd_opts* opts, dsd_state* state, int lcn, int is_digi
         return;
     }
 
+    if (!edacs_tune_to_lcn(opts, state, lcn)) {
+        return;
+    }
     edacs_prepare_voice_wav_output(opts, state, is_digital);
-    edacs_tune_to_lcn(opts, state, lcn);
     if (is_digital == 0) {
         edacs_analog(opts, state, call_target, (unsigned char)lcn);
     }
@@ -2127,18 +2134,15 @@ eot_cc(dsd_opts* opts, dsd_state* state) {
         opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, sizeof opts->wav_out_file, 8000, 0);
     }
 
-    //set here so that when returning to the CC, it doesn't go into an immediate hunt if not immediately acquired
-    state->last_cc_sync_time = now;
-    state->last_vc_sync_time = now;
-    state->last_cc_sync_time_m = nowm;
-    state->last_vc_sync_time_m = nowm;
-
     //jump back to CC here
     long int cc = (state->trunk_cc_freq != 0) ? state->trunk_cc_freq : state->p25_cc_freq;
     if ((opts->trunk_enable == 1 || opts->p25_trunk == 1) && cc != 0
         && (opts->trunk_is_tuned == 1 || opts->p25_is_tuned == 1)) {
         // Use centralized io/control tuning API
-        dsd_trunk_tuning_hook_tune_to_cc(opts, state, cc, 0);
+        dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, cc, 0);
+        if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+            return;
+        }
         opts->p25_is_tuned = 0;
         opts->trunk_is_tuned = 0;
 
@@ -2155,4 +2159,10 @@ eot_cc(dsd_opts* opts, dsd_state* state) {
         state->p25_vc_freq[0] = state->p25_vc_freq[1] = 0;
         state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = 0;
     }
+
+    //set here so that when returning to the CC, it doesn't go into an immediate hunt if not immediately acquired
+    state->last_cc_sync_time = now;
+    state->last_vc_sync_time = now;
+    state->last_cc_sync_time_m = nowm;
+    state->last_vc_sync_time_m = nowm;
 }

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -309,7 +309,10 @@ nxdn_element_handle_disc(dsd_opts* opts, dsd_state* state, const uint8_t* elemen
 
     if ((opts->trunk_enable == 1 || opts->p25_trunk == 1) && state->p25_cc_freq != 0
         && (opts->trunk_is_tuned == 1 || opts->p25_is_tuned == 1)) {
-        dsd_trunk_tuning_hook_tune_to_cc(opts, state, state->p25_cc_freq, 0);
+        dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, state->p25_cc_freq, 0);
+        if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+            return;
+        }
         opts->p25_is_tuned = 0;
         opts->trunk_is_tuned = 0;
 
@@ -1487,10 +1490,13 @@ nxdn_vcall_assgn_frequency(dsd_opts* opts, dsd_state* state, const struct nxdn_v
     return 0;
 }
 
-static void
+static int
 nxdn_vcall_assgn_setup_tuned_call(dsd_opts* opts, dsd_state* state, const struct nxdn_vcall_assgn_info* info,
                                   long int freq) {
-    dsd_trunk_tuning_hook_tune_to_freq(opts, state, freq, 0);
+    dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_freq(opts, state, freq, 0);
+    if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+        return 0;
+    }
     DSD_MEMSET(state->nxdn_sacch_frame_segment, 1, sizeof(state->nxdn_sacch_frame_segment));
     DSD_MEMSET(state->nxdn_sacch_frame_segcrc, 1, sizeof(state->nxdn_sacch_frame_segcrc));
     state->lastsynctype = DSD_SYNC_NONE;
@@ -1499,6 +1505,7 @@ nxdn_vcall_assgn_setup_tuned_call(dsd_opts* opts, dsd_state* state, const struct
     if (info->cc_option & 0x80U) {
         dsd_append(state->call_string[0], sizeof state->call_string[0], " Emergency");
     }
+    return 1;
 }
 
 static void
@@ -1514,23 +1521,31 @@ nxdn_vcall_assgn_load_scrambler_key(dsd_state* state, const struct nxdn_vcall_as
     }
 }
 
+static int
+nxdn_vcall_assgn_can_tune(const dsd_opts* opts, const dsd_state* state, int policy_allowed, int hold_matches,
+                          long int freq) {
+    if (!opts || !state || opts->p25_trunk != 1 || !policy_allowed || state->p25_cc_freq == 0 || freq == 0) {
+        return 0;
+    }
+    return (opts->p25_is_tuned == 0 || hold_matches) ? 1 : 0;
+}
+
 static void
 nxdn_vcall_assgn_apply_tune(dsd_opts* opts, dsd_state* state, const struct nxdn_vcall_assgn_info* info, long int freq) {
     nxdn_print_group_label(state, info->destination_id != 0U ? info->destination_id : info->source_unit_id);
     if (info->destination_id != 0U) {
         nxdn_print_group_label(state, info->source_unit_id);
     }
-    if (state->tg_hold != 0 && state->tg_hold == info->destination_id) {
-        opts->p25_is_tuned = 0;
-    }
-
     const int is_private_call = (info->call_type == 4U) ? 1 : 0;
     const int data_call = (info->message_type == 0x0DU || info->message_type == 0x0EU) ? 1 : 0;
+    const int hold_matches = (state->tg_hold != 0 && state->tg_hold == info->destination_id) ? 1 : 0;
     dsd_tg_policy_decision policy_decision;
     const int policy_allowed = nxdn_policy_tune_allowed(opts, state, info->destination_id, info->source_unit_id,
                                                         is_private_call, data_call, 1, &policy_decision);
-    if (opts->p25_trunk == 1 && policy_allowed && state->p25_cc_freq != 0 && opts->p25_is_tuned == 0 && freq != 0) {
-        nxdn_vcall_assgn_setup_tuned_call(opts, state, info, freq);
+    if (nxdn_vcall_assgn_can_tune(opts, state, policy_allowed, hold_matches, freq)) {
+        if (!nxdn_vcall_assgn_setup_tuned_call(opts, state, info, freq)) {
+            return;
+        }
         nxdn_vcall_assgn_load_scrambler_key(state, info);
     } else if (opts->p25_trunk == 1) {
         nxdn_policy_log_block(opts, is_private_call, info->destination_id, info->source_unit_id, &policy_decision);
@@ -2334,9 +2349,6 @@ nxdn_scch_apply_busy_tune(dsd_opts* opts, dsd_state* state, const struct nxdn_sc
 
     nxdn_scch_update_control_channel_from_map(state, info);
     nxdn_print_group_label(state, info->id);
-    if (state->tg_hold != 0 && state->tg_hold == info->id) {
-        opts->p25_is_tuned = 0;
-    }
 
     const long int freq = nxdn_channel_to_frequency(opts, state, info->rep1);
     if (freq == 0) {
@@ -2349,7 +2361,10 @@ nxdn_scch_apply_busy_tune(dsd_opts* opts, dsd_state* state, const struct nxdn_sc
         nxdn_policy_tune_allowed(opts, state, info->id, 0, is_private_call, 0, 0, &policy_decision);
     if (opts->p25_trunk == 1 && policy_allowed && state->p25_cc_freq != 0
         && ((info->now - state->last_vc_sync_time) > 1) && freq != 0) {
-        dsd_trunk_tuning_hook_tune_to_freq(opts, state, freq, 0);
+        dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_freq(opts, state, freq, 0);
+        if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+            return;
+        }
         DSD_MEMSET(state->nxdn_sacch_frame_segment, 1, sizeof(state->nxdn_sacch_frame_segment));
         DSD_MEMSET(state->nxdn_sacch_frame_segcrc, 1, sizeof(state->nxdn_sacch_frame_segcrc));
         state->lastsynctype = DSD_SYNC_NONE;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -527,12 +527,12 @@ p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_eve
 }
 
 static int
-p25_grant_configure_channel_profile(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, int slot) {
+p25_grant_configure_channel_profile_for_tdma(int vc_is_tdma, const dsd_opts* opts, dsd_state* state, int slot) {
     int ted_sps = p25_ted_sps_for_bw(opts, 4800);
-    if (!ctx || !state) {
+    if (!state) {
         return ted_sps;
     }
-    if (ctx->vc_is_tdma) {
+    if (vc_is_tdma) {
         ted_sps = p25_ted_sps_for_bw(opts, 6000);
         state->p25_p2_active_slot = slot;
         // P25P2 TDMA always uses CQPSK modulation.
@@ -543,6 +543,57 @@ p25_grant_configure_channel_profile(const p25_sm_ctx_t* ctx, const dsd_opts* opt
     state->samplesPerSymbol = ted_sps;
     state->symbolCenter = dsd_opts_symbol_center(ted_sps);
     return ted_sps;
+}
+
+typedef struct {
+    int p25_p2_active_slot;
+    int rf_mod;
+    int samples_per_symbol;
+    int symbol_center;
+    int vc_cqpsk_override;
+} p25_grant_profile_snapshot_t;
+
+static p25_grant_profile_snapshot_t
+p25_grant_profile_snapshot_capture(const dsd_state* state) {
+    p25_grant_profile_snapshot_t snapshot = {-1, 0, 0, 0, -1};
+    if (!state) {
+        return snapshot;
+    }
+    snapshot.p25_p2_active_slot = state->p25_p2_active_slot;
+    snapshot.rf_mod = state->rf_mod;
+    snapshot.samples_per_symbol = state->samplesPerSymbol;
+    snapshot.symbol_center = state->symbolCenter;
+    snapshot.vc_cqpsk_override = state->p25_vc_cqpsk_override;
+    return snapshot;
+}
+
+static void
+p25_grant_profile_snapshot_restore(dsd_state* state, const p25_grant_profile_snapshot_t* snapshot) {
+    if (!state || !snapshot) {
+        return;
+    }
+    state->p25_p2_active_slot = snapshot->p25_p2_active_slot;
+    state->rf_mod = snapshot->rf_mod;
+    state->samplesPerSymbol = snapshot->samples_per_symbol;
+    state->symbolCenter = snapshot->symbol_center;
+    state->p25_vc_cqpsk_override = snapshot->vc_cqpsk_override;
+}
+
+static int
+p25_grant_try_tune_vc(const p25_sm_event_t* ev, dsd_opts* opts, dsd_state* state, long freq, int slot,
+                      int* out_ted_sps) {
+    const int vc_is_tdma = is_tdma_channel(state, ev->channel);
+    p25_grant_profile_snapshot_t snapshot = p25_grant_profile_snapshot_capture(state);
+    const int ted_sps = p25_grant_configure_channel_profile_for_tdma(vc_is_tdma, opts, state, slot);
+    dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_freq(opts, state, freq, ted_sps);
+    if (dsd_trunk_tune_result_is_ok(tune_result)) {
+        *out_ted_sps = ted_sps;
+        return 1;
+    }
+
+    p25_grant_profile_snapshot_restore(state, &snapshot);
+    sm_log(opts, state, tune_result == DSD_TRUNK_TUNE_RESULT_DEFERRED ? "grant-tune-deferred" : "grant-tune-failed");
+    return 0;
 }
 
 static void
@@ -561,6 +612,18 @@ p25_grant_debug_log_tdma(const dsd_opts* opts, const dsd_state* state, const p25
                 "tune_count=%u grant_count=%u\n",
                 ev->channel & 0xFFFF, freq, state->p25_p2_active_slot, state->rf_mod, state->samplesPerSymbol,
                 state->symbolCenter, ted_sps, ctx->tune_count, ctx->grant_count);
+}
+
+static int
+p25_grant_handle_duplicate(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state,
+                           const dsd_tg_policy_call_route* route, const dsd_tg_policy_decision* decision, long freq,
+                           int target_id, double now_m) {
+    if (ctx->state != P25_SM_TUNED || ctx->vc_freq_hz != freq || ctx->vc_tg != target_id) {
+        return 0;
+    }
+    (void)dsd_tg_policy_note_active_call(state, route, decision, now_m);
+    sm_log(opts, state, "grant-same-freq");
+    return 1;
 }
 
 /* ============================================================================
@@ -600,9 +663,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
 
     // Skip if already tuned to same frequency AND same TG (avoid bounce on duplicate grants)
     // Different TG/call type should still trigger a new tune
-    if (ctx->state == P25_SM_TUNED && ctx->vc_freq_hz == freq && ctx->vc_tg == target_id) {
-        (void)dsd_tg_policy_note_active_call(state, &route, &decision, now_m);
-        sm_log(opts, state, "grant-same-freq");
+    if (p25_grant_handle_duplicate(ctx, opts, state, &route, &decision, freq, target_id, now_m)) {
         return;
     }
 
@@ -610,11 +671,11 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
         return;
     }
 
+    if (!p25_grant_try_tune_vc(ev, opts, state, freq, slot, &ted_sps)) {
+        return;
+    }
     p25_grant_store_vc_context(ctx, state, ev, freq, target_id, now_m);
     p25_grant_clear_slot_state(ctx);
-    ted_sps = p25_grant_configure_channel_profile(ctx, opts, state, slot);
-
-    dsd_trunk_tuning_hook_tune_to_freq(opts, state, freq, ted_sps);
     ctx->tune_count++;
     ctx->grant_count++;
     p25_grant_debug_log_tdma(opts, state, ctx, ev, freq, ted_sps);
@@ -816,10 +877,74 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
  * Release to CC
  * ============================================================================ */
 
+static int
+p25_release_should_return_to_cc(const p25_sm_ctx_t* ctx, const dsd_opts* opts) {
+    const int opts_tuned = (opts && (opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1)) ? 1 : 0;
+    return (ctx && (ctx->state == P25_SM_TUNED || opts_tuned)) ? 1 : 0;
+}
+
+static int
+p25_release_return_to_cc_accepted(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int had_force_release,
+                                  double* out_tune_start_m) {
+    if (ctx->vc_is_tdma && opts && state) {
+        dsd_p25_optional_hook_p25p2_flush_partial_audio(opts, state);
+    }
+
+    *out_tune_start_m = now_monotonic();
+    dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_return_to_cc(opts, state);
+    if (dsd_trunk_tune_result_is_ok(tune_result)) {
+        return 1;
+    }
+
+    sm_log(opts, state, tune_result == DSD_TRUNK_TUNE_RESULT_DEFERRED ? "release-cc-deferred" : "release-cc-failed");
+    if (state && had_force_release) {
+        state->p25_sm_force_release = 1;
+    }
+    return 0;
+}
+
+static void
+p25_release_clear_context(p25_sm_ctx_t* ctx) {
+    p25_grant_clear_slot_state(ctx);
+    ctx->vc_freq_hz = 0;
+    ctx->vc_channel = 0;
+    ctx->vc_tg = 0;
+    ctx->vc_src = 0;
+    ctx->t_tune_m = 0.0;
+    ctx->t_voice_m = 0.0;
+    ctx->release_count++;
+    ctx->cc_return_count++;
+}
+
+static void
+p25_release_clear_decoder_state(dsd_opts* opts, dsd_state* state) {
+    if (state) {
+        (void)dsd_tg_policy_clear_active_call(state, -1);
+        state->p25_p2_audio_allowed[0] = 0;
+        state->p25_p2_audio_allowed[1] = 0;
+        state->p25_p2_active_slot = -1;
+        state->p25_vc_freq[0] = 0;
+        state->p25_vc_freq[1] = 0;
+        state->trunk_vc_freq[0] = 0;
+        state->trunk_vc_freq[1] = 0;
+        state->payload_algid = 0;
+        state->payload_algidR = 0;
+        state->payload_keyid = 0;
+        state->payload_keyidR = 0;
+        state->payload_miP = 0;
+        state->payload_miN = 0;
+        state->p25_sm_release_count++;
+    }
+    if (opts) {
+        opts->p25_is_tuned = 0;
+        opts->trunk_is_tuned = 0;
+    }
+}
+
 static void
 do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason) {
     double tune_start_m = 0.0;
-    int opts_tuned = 0;
+    int had_force_release = 0;
     if (!ctx) {
         return;
     }
@@ -832,64 +957,27 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
     }
 
     if (state) {
+        had_force_release = (state->p25_sm_force_release != 0) ? 1 : 0;
         // Clear any pending forced-release request; we're handling teardown now.
         state->p25_sm_force_release = 0;
     }
 
-    // Only do a hardware return-to-CC when we are (or believe we are) tuned to
-    // a voice channel. This makes repeated release requests idempotent.
-    opts_tuned = (opts && (opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1)) ? 1 : 0;
-    if (ctx->state != P25_SM_TUNED && !opts_tuned) {
+    if (!p25_release_should_return_to_cc(ctx, opts)) {
         atomic_store(&g_p25_sm_release_lock, 0);
         return;
     }
 
     sm_log(opts, state, reason);
 
-    p25_grant_clear_slot_state(ctx);
-    ctx->vc_freq_hz = 0;
-    ctx->vc_channel = 0;
-    ctx->vc_tg = 0;
-    ctx->vc_src = 0;
-    ctx->t_tune_m = 0.0;
-    ctx->t_voice_m = 0.0;
-
-    ctx->release_count++;
-    ctx->cc_return_count++;
-    if (state) {
-        (void)dsd_tg_policy_clear_active_call(state, -1);
+    // Return to CC. On failure/defer, leave VC state untouched so the watchdog
+    // can retry through the same state machine instead of pretending the tuner moved.
+    if (!p25_release_return_to_cc_accepted(ctx, opts, state, had_force_release, &tune_start_m)) {
+        atomic_store(&g_p25_sm_release_lock, 0);
+        return;
     }
 
-    // P25p2 short-call robustness: flush any partially buffered audio before
-    // clearing slot gates and retuning, so short transmissions that end before
-    // a full superframe still produce audible output.
-    if (ctx->vc_is_tdma && opts && state) {
-        dsd_p25_optional_hook_p25p2_flush_partial_audio(opts, state);
-    }
-
-    // Clear legacy state fields
-    if (state) {
-        state->p25_p2_audio_allowed[0] = 0;
-        state->p25_p2_audio_allowed[1] = 0;
-        state->p25_p2_active_slot = -1;
-        state->p25_vc_freq[0] = 0;
-        state->p25_vc_freq[1] = 0;
-        state->trunk_vc_freq[0] = 0;
-        state->trunk_vc_freq[1] = 0;
-        // Clear encryption state
-        state->payload_algid = 0;
-        state->payload_algidR = 0;
-        state->payload_keyid = 0;
-        state->payload_keyidR = 0;
-        state->payload_miP = 0;
-        state->payload_miN = 0;
-        // Update release counter
-        state->p25_sm_release_count++;
-    }
-
-    // Return to CC
-    tune_start_m = now_monotonic();
-    dsd_trunk_tuning_hook_return_to_cc(opts, state);
+    p25_release_clear_context(ctx);
+    p25_release_clear_decoder_state(opts, state);
     p25_sm_start_cc_grace_after_tune(ctx, state, tune_start_m);
 
     // Transition to ON_CC state
@@ -966,7 +1054,12 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
 
     // First try discovered CC candidates (if preference enabled)
     if (opts && opts->p25_prefer_candidates == 1 && next_cc_candidate(state, &cand, now_m)) {
-        dsd_trunk_tuning_hook_tune_to_cc(opts, state, cand, sps);
+        dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, cand, sps);
+        if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+            sm_log(opts, state,
+                   tune_result == DSD_TRUNK_TUNE_RESULT_DEFERRED ? "hunt-cand-deferred" : "hunt-cand-failed");
+            return;
+        }
         state->p25_cc_eval_freq = cand;
         state->p25_cc_eval_start_m = now_m;
         p25_sm_start_cc_grace_after_tune(ctx, state, now_m);
@@ -977,7 +1070,12 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
 
     // Fall back to user-provided LCN list
     if (next_lcn_freq(state, &cand)) {
-        dsd_trunk_tuning_hook_tune_to_cc(opts, state, cand, sps);
+        dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, cand, sps);
+        if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+            sm_log(opts, state,
+                   tune_result == DSD_TRUNK_TUNE_RESULT_DEFERRED ? "hunt-lcn-deferred" : "hunt-lcn-failed");
+            return;
+        }
         p25_sm_start_cc_grace_after_tune(ctx, state, now_m);
         set_state(ctx, opts, state, P25_SM_ON_CC, "hunt-lcn");
         sm_log(opts, state, "hunt-lcn-tune");
@@ -1157,9 +1255,10 @@ p25_sm_tick_handle_forced_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* 
     if (!ctx || !state || state->p25_sm_force_release == 0) {
         return 0;
     }
-    state->p25_sm_force_release = 0;
     if (ctx->state == P25_SM_TUNED) {
         do_release(ctx, opts, state, "release-forced");
+    } else {
+        state->p25_sm_force_release = 0;
     }
     return 1;
 }
@@ -1297,39 +1396,79 @@ p25_sm_tick_tuned_check_hangtime(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
     }
 }
 
-static void
-p25_sm_tick_try_cqpsk_retry(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m, double dt_tune) {
 #ifdef USE_RADIO
-    if (!(opts && state && opts->audio_in_type == AUDIO_IN_RTL && ctx->vc_is_tdma && !ctx->vc_cqpsk_retry_done
-          && dt_tune >= 0.8 && state->p25_vc_cqpsk_pref != 1)) {
-        return;
+static int
+p25_cqpsk_retry_candidate(const p25_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state, double dt_tune) {
+    if (!ctx || !opts || !state || opts->audio_in_type != AUDIO_IN_RTL) {
+        return 0;
     }
+    if (!ctx->vc_is_tdma || ctx->vc_cqpsk_retry_done || dt_tune < 0.8 || state->p25_vc_cqpsk_pref == 1) {
+        return 0;
+    }
+    return 1;
+}
+
+static int
+p25_cqpsk_retry_runtime_allowed(p25_sm_ctx_t* ctx, const dsd_opts* opts, long vc_freq_hz) {
     const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
     if (!cfg) {
         dsd_neo_config_init(opts);
         cfg = dsd_neo_get_config();
     }
-    if ((cfg && cfg->cqpsk_is_set) || ctx->vc_freq_hz <= 0) {
-        return;
+    if ((cfg && cfg->cqpsk_is_set) || vc_freq_hz <= 0) {
+        return 0;
     }
 
     int cqpsk = 0, fll = 0, ted = 0;
     dsd_rtl_stream_metrics_hook_dsp_get(&cqpsk, &fll, &ted);
-    if (cqpsk) {
-        ctx->vc_cqpsk_retry_done = 1;
+    if (!cqpsk) {
+        return 1;
+    }
+    ctx->vc_cqpsk_retry_done = 1;
+    return 0;
+}
+
+static int
+p25_cqpsk_retry_tune(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int ted_sps) {
+    int prev_override = state->p25_vc_cqpsk_override;
+    int prev_sps = state->samplesPerSymbol;
+    int prev_center = state->symbolCenter;
+    state->p25_vc_cqpsk_override = 1;
+    state->samplesPerSymbol = ted_sps;
+    state->symbolCenter = dsd_opts_symbol_center(ted_sps);
+    dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_freq(opts, state, ctx->vc_freq_hz, ted_sps);
+    if (dsd_trunk_tune_result_is_ok(tune_result)) {
+        return 1;
+    }
+
+    state->p25_vc_cqpsk_override = prev_override;
+    state->samplesPerSymbol = prev_sps;
+    state->symbolCenter = prev_center;
+    sm_log(opts, state, tune_result == DSD_TRUNK_TUNE_RESULT_DEFERRED ? "cqpsk-retry-deferred" : "cqpsk-retry-failed");
+    return 0;
+}
+#endif
+
+static void
+p25_sm_tick_try_cqpsk_retry(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m, double dt_tune) {
+#ifdef USE_RADIO
+    if (!p25_cqpsk_retry_candidate(ctx, opts, state, dt_tune)) {
         return;
     }
 
-    state->p25_vc_cqpsk_override = 1;
+    if (!p25_cqpsk_retry_runtime_allowed(ctx, opts, ctx->vc_freq_hz)) {
+        return;
+    }
+
+    int ted_sps = p25_ted_sps_for_bw(opts, 6000);
+    if (!p25_cqpsk_retry_tune(ctx, opts, state, ted_sps)) {
+        return;
+    }
     ctx->vc_cqpsk_retry_done = 1;
     // Restart the tune timer for retry to avoid immediate timeout from the new attempt.
     ctx->t_tune_m = now_m;
     ctx->t_voice_m = 0.0;
     p25_sm_clear_slot_activity(ctx);
-    int ted_sps = p25_ted_sps_for_bw(opts, 6000);
-    state->samplesPerSymbol = ted_sps;
-    state->symbolCenter = dsd_opts_symbol_center(ted_sps);
-    dsd_trunk_tuning_hook_tune_to_freq(opts, state, ctx->vc_freq_hz, ted_sps);
     sm_log(opts, state, "cqpsk-retry-on");
 #else
     (void)ctx;

--- a/src/runtime/trunk_tuning_hooks.c
+++ b/src/runtime/trunk_tuning_hooks.c
@@ -14,11 +14,11 @@
 
 static dsd_trunk_tuning_hooks g_trunk_tuning_hooks = {0};
 
-static void
+static dsd_trunk_tune_result
 dsd_trunk_tuning_fallback_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     (void)ted_sps;
     if (!opts || !state || freq <= 0) {
-        return;
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
     }
 
     state->p25_vc_freq[0] = state->p25_vc_freq[1] = freq;
@@ -31,9 +31,10 @@ dsd_trunk_tuning_fallback_tune_to_freq(dsd_opts* opts, dsd_state* state, long in
     state->p25_last_vc_tune_time = state->last_vc_sync_time;
     state->last_vc_sync_time_m = nowm;
     state->p25_last_vc_tune_time_m = nowm;
+    return DSD_TRUNK_TUNE_RESULT_OK;
 }
 
-static void
+static dsd_trunk_tune_result
 dsd_trunk_tuning_fallback_return_to_cc(dsd_opts* opts, dsd_state* state) {
     if (opts) {
         opts->p25_is_tuned = 0;
@@ -45,18 +46,20 @@ dsd_trunk_tuning_fallback_return_to_cc(dsd_opts* opts, dsd_state* state) {
         state->last_vc_sync_time = 0;
         state->last_vc_sync_time_m = 0.0;
     }
+    return DSD_TRUNK_TUNE_RESULT_OK;
 }
 
-static void
+static dsd_trunk_tune_result
 dsd_trunk_tuning_fallback_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     (void)opts;
     (void)ted_sps;
     if (!state || freq <= 0) {
-        return;
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
     }
     state->trunk_cc_freq = freq;
     state->last_cc_sync_time = time(NULL);
     state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
+    return DSD_TRUNK_TUNE_RESULT_OK;
 }
 
 void
@@ -64,29 +67,38 @@ dsd_trunk_tuning_hooks_set(dsd_trunk_tuning_hooks hooks) {
     g_trunk_tuning_hooks = hooks;
 }
 
-void
+dsd_trunk_tune_result
 dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    if (g_trunk_tuning_hooks.tune_to_freq_result) {
+        return g_trunk_tuning_hooks.tune_to_freq_result(opts, state, freq, ted_sps);
+    }
     if (g_trunk_tuning_hooks.tune_to_freq) {
         g_trunk_tuning_hooks.tune_to_freq(opts, state, freq, ted_sps);
-        return;
+        return DSD_TRUNK_TUNE_RESULT_OK;
     }
-    dsd_trunk_tuning_fallback_tune_to_freq(opts, state, freq, ted_sps);
+    return dsd_trunk_tuning_fallback_tune_to_freq(opts, state, freq, ted_sps);
 }
 
-void
+dsd_trunk_tune_result
 dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    if (g_trunk_tuning_hooks.tune_to_cc_result) {
+        return g_trunk_tuning_hooks.tune_to_cc_result(opts, state, freq, ted_sps);
+    }
     if (g_trunk_tuning_hooks.tune_to_cc) {
         g_trunk_tuning_hooks.tune_to_cc(opts, state, freq, ted_sps);
-        return;
+        return DSD_TRUNK_TUNE_RESULT_OK;
     }
-    dsd_trunk_tuning_fallback_tune_to_cc(opts, state, freq, ted_sps);
+    return dsd_trunk_tuning_fallback_tune_to_cc(opts, state, freq, ted_sps);
 }
 
-void
+dsd_trunk_tune_result
 dsd_trunk_tuning_hook_return_to_cc(dsd_opts* opts, dsd_state* state) {
+    if (g_trunk_tuning_hooks.return_to_cc_result) {
+        return g_trunk_tuning_hooks.return_to_cc_result(opts, state);
+    }
     if (g_trunk_tuning_hooks.return_to_cc) {
         g_trunk_tuning_hooks.return_to_cc(opts, state);
-        return;
+        return DSD_TRUNK_TUNE_RESULT_OK;
     }
-    dsd_trunk_tuning_fallback_return_to_cc(opts, state);
+    return dsd_trunk_tuning_fallback_return_to_cc(opts, state);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2933,6 +2933,31 @@ target_link_libraries(
 )
 add_test(NAME DMR_T3_MOVE_RELEASE COMMAND dsd-neo_test_dmr_t3_move_release)
 
+# DMR Tier III Ann_WD_TSCC switch must preserve return-to-CC cleanup
+add_executable(
+    dsd-neo_test_dmr_t3_ann_wd_tscc
+    protocol/dmr/test_dmr_t3_ann_wd_tscc.c
+    ${PROJECT_SOURCE_DIR}/src/core/time/dsd_time_state.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/talkgroup_policy.c
+    ${PROJECT_SOURCE_DIR}/tests/test_support/csv_import_stub.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_trunk_sm.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_csbk.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_csbk_parse.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_csbk_tables.c
+)
+target_include_directories(
+    dsd-neo_test_dmr_t3_ann_wd_tscc
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/tests/protocol/dmr
+        ${PROJECT_SOURCE_DIR}/src/protocol/dmr
+)
+target_link_libraries(
+    dsd-neo_test_dmr_t3_ann_wd_tscc
+    PRIVATE dsd-neo_platform dsd-neo_runtime ${DSD_NEO_TEST_MATH_LIB}
+)
+add_test(NAME DMR_T3_ANN_WD_TSCC COMMAND dsd-neo_test_dmr_t3_ann_wd_tscc)
+
 # DMR Tier III regression: return-to-CC must work with trunk_enable only
 add_executable(
     dsd-neo_test_dmr_t3_return_to_cc_regression
@@ -2942,6 +2967,10 @@ add_executable(
 target_include_directories(
     dsd-neo_test_dmr_t3_return_to_cc_regression
     PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_dmr_t3_return_to_cc_regression
+    PRIVATE dsd-neo_feature_radio
 )
 add_test(
     NAME DMR_T3_RETURN_TO_CC_REGRESSION

--- a/tests/io/test_io_rtl_replay_retune_reject.cpp
+++ b/tests/io/test_io_rtl_replay_retune_reject.cpp
@@ -159,6 +159,13 @@ test_replay_retune_rejected_quickly(void) {
     rc |= expect_int_eq("retune rejected during replay", retune_rc, -1);
     rc |= expect_true("retune call returned quickly", elapsed_ms < 100ULL);
 
+    t0 = dsd_time_monotonic_ns();
+    retune_rc = rtl_stream_tune(ctx, 851625000U);
+    elapsed_ns = dsd_time_monotonic_ns() - t0;
+    elapsed_ms = elapsed_ns / 1000000ULL;
+    rc |= expect_int_eq("rtl_stream_tune reports deferred replay retune", retune_rc, RTL_STREAM_TUNE_DEFERRED);
+    rc |= expect_true("rtl_stream_tune deferred quickly", elapsed_ms < 100ULL);
+
     rc |= expect_int_eq("rtl_stream_stop", rtl_stream_stop(ctx), 0);
     rc |= expect_int_eq("rtl_stream_destroy", rtl_stream_destroy(ctx), 0);
     return rc;

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -17,6 +17,8 @@ extern "C" uint64_t rtl_device_test_coalesce_capture_mute_duration(uint64_t* pen
 extern "C" int rtl_device_test_complete_fragmented_capture_discard(int byte_count, unsigned int partial_byte_count);
 extern "C" void rtl_device_test_end_capture_reconfigure_with_odd_carry(int* out_hold, int* out_mute,
                                                                        int* out_mute_byte_phase);
+extern "C" int rtl_device_test_begin_capture_reconfigure_without_writer(int* out_hold);
+extern "C" int rtl_device_test_usb_reconfigure_discards_samples(size_t input_bytes, size_t* out_ring_used);
 extern "C" void rtl_device_test_replay_dispatch_reset_event_state(int* phase, int* have_carry, uint8_t* carry_byte);
 extern "C" int rtl_device_test_replay_event_boundary_drained(size_t ring_used, uint64_t submitted_gen,
                                                              uint64_t consumed_gen);
@@ -75,8 +77,8 @@ main(void) {
 
     int failed = 0;
     failed |= expect_int_eq("prepare reconfigure input rc", rc, 0);
-    failed |= expect_size_eq("queued output preserved for drain policy", used_after, 8U);
-    failed |= expect_generation_eq("output generation left for drain policy", generation_before, generation_after);
+    failed |= expect_size_eq("retune gate clears queued output", used_after, 0U);
+    failed |= expect_generation_changed("retune gate bumps output generation", generation_before, generation_after);
 
     rc = rtl_stream_test_retune_output_pending(0U, 3, &ring_pending, &cache_pending, &drained);
     failed |= expect_int_eq("retune pending helper rc", rc, 0);
@@ -95,6 +97,22 @@ main(void) {
     failed |= expect_size_eq("retune drain sees drained ring", ring_pending, 0U);
     failed |= expect_int_eq("retune drain sees drained cache", cache_pending, 0);
     failed |= expect_int_eq("retune drain reports drained", drained, 1);
+
+    cache_pending = -1;
+    rc = rtl_stream_test_tune_result_output_drain(RTL_STREAM_TUNE_TIMEOUT, 5U, 3, &used_after, &cache_pending,
+                                                  &generation_before, &generation_after);
+    failed |= expect_int_eq("timeout tune drain helper rc", rc, 0);
+    failed |= expect_size_eq("timeout tune drains queued output", used_after, 0U);
+    failed |= expect_int_eq("timeout tune clears cached symbols", cache_pending, 0);
+    failed |= expect_generation_changed("timeout tune bumps output generation", generation_before, generation_after);
+
+    cache_pending = -1;
+    rc = rtl_stream_test_tune_result_output_drain(RTL_STREAM_TUNE_DEFERRED, 5U, 3, &used_after, &cache_pending,
+                                                  &generation_before, &generation_after);
+    failed |= expect_int_eq("deferred tune drain helper rc", rc, 0);
+    failed |= expect_size_eq("deferred tune leaves queued output", used_after, 5U);
+    failed |= expect_int_eq("deferred tune leaves cached symbols", cache_pending, 3);
+    failed |= expect_generation_eq("deferred tune keeps output generation", generation_before, generation_after);
 
     cache_pending = -1;
     rc = rtl_stream_test_clear_output(7U, 3, &used_after, &cache_pending, &generation_before, &generation_after);
@@ -158,6 +176,16 @@ main(void) {
     failed |= expect_int_eq("end reconfigure clears hold after completion", hold, 0);
     failed |= expect_int_eq("end reconfigure schedules odd carry mute byte", mute, 1);
     failed |= expect_int_eq("end reconfigure preserves carry until scheduled mute drains", mute_byte_phase, 1);
+
+    hold = -1;
+    failed |= expect_int_eq("begin reconfigure without writer helper",
+                            rtl_device_test_begin_capture_reconfigure_without_writer(&hold), 0);
+    failed |= expect_int_eq("begin reconfigure without writer activates hold", hold, 1);
+
+    size_t held_ring_used = 99U;
+    failed |= expect_int_eq("usb reconfigure discard helper",
+                            rtl_device_test_usb_reconfigure_discards_samples(16U, &held_ring_used), 0);
+    failed |= expect_size_eq("usb reconfigure discards samples", held_ring_used, 0U);
 
     // Replay RESET events clear phase/carry state only after pending output drains.
     int replay_phase = 3;

--- a/tests/protocol/dmr/test_dmr_grant_policy.c
+++ b/tests/protocol/dmr/test_dmr_grant_policy.c
@@ -16,6 +16,7 @@
 #include <dsd-neo/io/rigctl_client.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -111,6 +112,8 @@ GetCurrentFreq(dsd_socket_t sockfd) {
 struct RtlSdrContext;
 
 struct RtlSdrContext* g_rtl_ctx = 0; // NOLINT(misc-use-internal-linkage)
+static int g_dmr_reset_blocks_calls = 0;
+static int g_result_tune_to_freq_calls = 0;
 
 int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -151,6 +154,7 @@ void
 dmr_reset_blocks(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_dmr_reset_blocks_calls++;
 }
 
 uint8_t
@@ -198,6 +202,31 @@ build_grant(uint8_t* bits, uint8_t* bytes, uint8_t opcode, uint16_t lpcn, uint32
     bits[28] = (uint8_t)(slot & 1U);
     write_bits_u32(bits, 32U, target & 0x00FFFFFFU, 24U);
     write_bits_u32(bits, 56U, source & 0x00FFFFFFU, 24U);
+}
+
+static void
+build_cap_plus_3e_single_group(uint8_t* bits, uint8_t* bytes, uint8_t rest_lsn, uint8_t active_lsn, uint8_t target) {
+    DSD_MEMSET(bits, 0, 256);
+    DSD_MEMSET(bytes, 0, 48);
+    bytes[0] = 0x3EU;
+    bytes[1] = 0x10U;
+
+    write_bits_u32(bits, 16U, 3U, 2U); // single-block Cap+ channel status
+    bits[18] = 0U;                     // TS1 status bank
+    write_bits_u32(bits, 20U, rest_lsn & 0x0FU, 4U);
+    bits[24U + (active_lsn - 1U)] = 1U; // bank-one active group bitmap
+    write_bits_u32(bits, 32U, target, 8U);
+}
+
+static dsd_trunk_tune_result
+cap_plus_result_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    (void)ted_sps;
+    g_result_tune_to_freq_calls++;
+    opts->rtlsdr_center_freq = freq;
+    opts->trunk_is_tuned = 1;
+    state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = freq;
+    state->last_vc_sync_time = time(NULL);
+    return DSD_TRUNK_TUNE_RESULT_OK;
 }
 
 static int
@@ -251,6 +280,27 @@ main(void) {
     rc |= expect_true("seed private allow source", seed_exact(st, 9002U, "A", "ALLOW-SRC") == 0);
     dmr_cspdu(opts, st, bits, bytes, 1U, 0U);
     rc |= expect_true("private known source allowed", opts->trunk_is_tuned == 1 && st->trunk_vc_freq[0] == freq);
+
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
+        .tune_to_freq_result = cap_plus_result_tune_to_freq,
+    });
+    static dsd_opts cap_opts;
+    static dsd_state cap_st;
+    init_env(&cap_opts, &cap_st);
+    const long cap_old_freq = 851000000L;
+    const long cap_grant_freq = 853000000L;
+    cap_opts.rtlsdr_center_freq = cap_old_freq;
+    cap_st.trunk_cc_freq = cap_old_freq;
+    cap_st.trunk_chan_map[1] = cap_grant_freq;
+    cap_st.last_vc_sync_time = time(NULL) - 10;
+    g_dmr_reset_blocks_calls = 0;
+    g_result_tune_to_freq_calls = 0;
+    build_cap_plus_3e_single_group(bits, bytes, 1U, 1U, 42U);
+    dmr_cspdu(&cap_opts, &cap_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("cap+ 3e tune hook called", g_result_tune_to_freq_calls == 1);
+    rc |= expect_true("cap+ 3e tune updates rtl center", cap_opts.rtlsdr_center_freq == cap_grant_freq);
+    rc |= expect_true("cap+ 3e reset uses pre-tune center", g_dmr_reset_blocks_calls == 1);
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
 
     if (rc == 0) {
         printf("DMR_GRANT_POLICY: OK\n");

--- a/tests/protocol/dmr/test_dmr_t3_ann_wd_tscc.c
+++ b/tests/protocol/dmr/test_dmr_t3_ann_wd_tscc.c
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Ann_WD_TSCC switches while already on the CC must keep the return-to-CC
+ * cleanup semantics, and deferred switches must not advance the CC anchor.
+ */
+
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/io/rigctl_client.h>
+#include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/sockets.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+static int g_return_to_cc_calls = 0;
+static int g_dmr_reset_blocks_calls = 0;
+static dsd_trunk_tune_result g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+
+static int
+expect_true(const char* tag, int cond) {
+    if (!cond) {
+        DSD_FPRINTF(stderr, "FAIL: %s\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+uint64_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ConvertBitIntoBytes(const uint8_t* BufferIn, uint32_t BitLength) {
+    uint64_t v = 0ULL;
+    for (uint32_t i = 0; i < BitLength; i++) {
+        v = (v << 1) | (uint64_t)(BufferIn[i] & 1U);
+    }
+    return v;
+}
+
+void
+watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+watchdog_event_datacall(dsd_opts* opts, dsd_state* state, uint32_t src, uint32_t dst, char* data_string, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    (void)src;
+    (void)dst;
+    (void)data_string;
+    (void)slot;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+rotate_symbol_out_file(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+bool
+SetFreq(dsd_socket_t sockfd, long int freq) {
+    (void)sockfd;
+    (void)freq;
+    return false;
+}
+
+bool
+SetModulation(dsd_socket_t sockfd, int bandwidth) {
+    (void)sockfd;
+    (void)bandwidth;
+    return false;
+}
+
+long int
+GetCurrentFreq(dsd_socket_t sockfd) {
+    (void)sockfd;
+    return 0;
+}
+
+struct RtlSdrContext;
+
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+struct RtlSdrContext* g_rtl_ctx = 0;
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+rtl_stream_tune(struct RtlSdrContext* ctx, uint32_t center_freq_hz) {
+    (void)ctx;
+    (void)center_freq_hz;
+    return 0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_reset_blocks(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_dmr_reset_blocks_calls++;
+}
+
+uint8_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+crc8(uint8_t bits[], unsigned int len) {
+    (void)bits;
+    (void)len;
+    return 0xFF;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_drain_audio_output(dsd_opts* opts) {
+    (void)opts;
+}
+
+static dsd_trunk_tune_result
+test_return_to_cc(dsd_opts* opts, dsd_state* state) {
+    g_return_to_cc_calls++;
+    if (g_return_to_cc_result != DSD_TRUNK_TUNE_RESULT_OK) {
+        return g_return_to_cc_result;
+    }
+
+    if (opts) {
+        opts->p25_is_tuned = 0;
+        opts->trunk_is_tuned = 0;
+    }
+    if (state) {
+        DSD_MEMSET(state->active_channel, 0, sizeof(state->active_channel));
+        state->trunk_vc_freq[0] = 0;
+        state->trunk_vc_freq[1] = 0;
+        state->lasttg = 0;
+        state->lasttgR = 0;
+        state->lastsrc = 0;
+        state->lastsrcR = 0;
+    }
+    dmr_reset_blocks(opts, state);
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static void
+init_env(dsd_opts* opts, dsd_state* state) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 0;
+    state->trunk_cc_freq = 851000000L;
+    dmr_sm_init(opts, state);
+}
+
+static void
+write_bits_u32(uint8_t* bits, size_t start, uint32_t value, size_t nbits) {
+    for (size_t i = 0; i < nbits; i++) {
+        size_t shift = (nbits - 1U) - i;
+        bits[start + i] = (uint8_t)((value >> shift) & 1U);
+    }
+}
+
+static void
+build_ann_wd_tscc(uint8_t* bits, uint8_t* bytes, uint16_t ch1, uint16_t ch2, uint8_t ch1_flag, uint8_t ch2_flag) {
+    DSD_MEMSET(bits, 0, 256);
+    DSD_MEMSET(bytes, 0, 48);
+    bytes[0] = 40U; /* C_BCAST */
+    write_bits_u32(bits, 25U, 1U, 4U);
+    write_bits_u32(bits, 29U, 2U, 4U);
+    bits[33] = (uint8_t)(ch1_flag & 1U);
+    bits[34] = (uint8_t)(ch2_flag & 1U);
+    write_bits_u32(bits, 56U, ch1 & 0x0FFFU, 12U);
+    write_bits_u32(bits, 68U, ch2 & 0x0FFFU, 12U);
+}
+
+extern void dmr_cspdu(dsd_opts*, dsd_state*, uint8_t*, uint8_t*, uint32_t, uint32_t);
+
+int
+main(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[256];
+    uint8_t bytes[48];
+    const uint16_t old_ch = 10U;
+    const uint16_t next_ch = 11U;
+    const long old_cc = 851000000L;
+    const long next_cc = 852000000L;
+
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
+        .return_to_cc_result = test_return_to_cc,
+    });
+
+    init_env(&opts, &state);
+    state.trunk_chan_map[old_ch] = old_cc;
+    state.trunk_chan_map[next_ch] = next_cc;
+    state.trunk_vc_freq[0] = 853000000L;
+    state.trunk_vc_freq[1] = 853000000L;
+    state.lasttg = 1001;
+    state.lastsrc = 2002;
+    DSD_SNPRINTF(state.active_channel[0], sizeof(state.active_channel[0]), "%s", "stale");
+    g_return_to_cc_calls = 0;
+    g_dmr_reset_blocks_calls = 0;
+    g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+
+    build_ann_wd_tscc(bits, bytes, old_ch, next_ch, 1U, 0U);
+    dmr_cspdu(&opts, &state, bits, bytes, 1U, 0U);
+    rc |= expect_true("tscc switch uses return-to-cc hook", g_return_to_cc_calls == 1);
+    rc |= expect_true("tscc switch resets DMR blocks", g_dmr_reset_blocks_calls == 1);
+    rc |= expect_true("tscc switch advances CC", state.trunk_cc_freq == next_cc);
+    rc |= expect_true("tscc switch clears stale VC", state.trunk_vc_freq[0] == 0 && state.trunk_vc_freq[1] == 0);
+    rc |= expect_true("tscc switch clears active channel", state.active_channel[0][0] == '\0');
+    rc |= expect_true("tscc switch clears last call", state.lasttg == 0 && state.lastsrc == 0);
+
+    init_env(&opts, &state);
+    state.trunk_chan_map[old_ch] = old_cc;
+    state.trunk_chan_map[next_ch] = next_cc;
+    g_return_to_cc_calls = 0;
+    g_dmr_reset_blocks_calls = 0;
+    g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+
+    build_ann_wd_tscc(bits, bytes, old_ch, next_ch, 1U, 0U);
+    dmr_cspdu(&opts, &state, bits, bytes, 1U, 0U);
+    rc |= expect_true("deferred tscc switch calls return-to-cc", g_return_to_cc_calls == 1);
+    rc |= expect_true("deferred tscc switch does not reset", g_dmr_reset_blocks_calls == 0);
+    rc |= expect_true("deferred tscc switch restores old CC", state.trunk_cc_freq == old_cc);
+
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    if (rc == 0) {
+        printf("DMR_T3_ANN_WD_TSCC: OK\n");
+    }
+    return rc;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/protocol/dmr/test_dmr_t3_ann_wd_tscc.c
+++ b/tests/protocol/dmr/test_dmr_t3_ann_wd_tscc.c
@@ -11,6 +11,7 @@
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/io/rigctl_client.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
@@ -230,6 +231,7 @@ main(void) {
     rc |= expect_true("tscc switch clears active channel", state.active_channel[0][0] == '\0');
     rc |= expect_true("tscc switch clears last call", state.lasttg == 0 && state.lastsrc == 0);
 
+    dsd_state_ext_free_all(&state);
     init_env(&opts, &state);
     state.trunk_chan_map[old_ch] = old_cc;
     state.trunk_chan_map[next_ch] = next_cc;
@@ -244,6 +246,7 @@ main(void) {
     rc |= expect_true("deferred tscc switch restores old CC", state.trunk_cc_freq == old_cc);
 
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    dsd_state_ext_free_all(&state);
     if (rc == 0) {
         printf("DMR_T3_ANN_WD_TSCC: OK\n");
     }

--- a/tests/protocol/dmr/test_dmr_t3_return_to_cc_regression.c
+++ b/tests/protocol/dmr/test_dmr_t3_return_to_cc_regression.c
@@ -25,6 +25,7 @@
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/io/rtl_stream_fwd.h"
 #include "dsd-neo/platform/sockets.h"
+#include "dsd-neo/runtime/trunk_tuning_hooks.h"
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -37,6 +38,19 @@
  */
 static int g_setfreq_calls = 0;
 static long int g_last_setfreq_hz = 0;
+static bool g_setfreq_result = true;
+static bool g_setmod_result = true;
+static int g_frame_sync_reset_calls = 0;
+static int g_p25p2_frame_reset_calls = 0;
+static int g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+static int g_rtl_cqpsk_enable = 0;
+static int g_rtl_symbol_rate_hz = 4800;
+static int g_rtl_symbol_levels = 4;
+static int g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+static int g_rtl_ted_sps = 5;
+static int g_rtl_ted_sps_override = 0;
+static int g_drain_audio_calls = 0;
+static int g_rtl_tune_calls = 0;
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -47,11 +61,15 @@ dmr_reset_blocks(dsd_opts* opts, dsd_state* state) {
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-dsd_frame_sync_reset_mod_state(void) {}
+dsd_frame_sync_reset_mod_state(void) {
+    g_frame_sync_reset_calls++;
+}
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-p25_p2_frame_reset(void) {}
+p25_p2_frame_reset(void) {
+    g_p25p2_frame_reset_calls++;
+}
 
 int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -63,6 +81,7 @@ void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_drain_audio_output(dsd_opts* opts) {
     (void)opts;
+    g_drain_audio_calls++;
 }
 
 bool
@@ -70,53 +89,97 @@ SetFreq(dsd_socket_t sockfd, long int freq) {
     (void)sockfd;
     g_setfreq_calls++;
     g_last_setfreq_hz = freq;
-    return true;
+    return g_setfreq_result;
 }
 
 bool
 SetModulation(dsd_socket_t sockfd, int bandwidth) {
     (void)sockfd;
     (void)bandwidth;
-    return true;
+    return g_setmod_result;
 }
 
 uint32_t
 rtl_stream_output_rate(const RtlSdrContext* ctx) {
     (void)ctx;
-    return 0;
+    return 48000;
 }
 
 int
 rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz) {
     (void)ctx;
     (void)center_freq_hz;
-    return 0;
+    g_rtl_tune_calls++;
+    return g_rtl_tune_result;
 }
 
 void
 rtl_stream_toggle_cqpsk(int onoff) {
-    (void)onoff;
+    g_rtl_cqpsk_enable = onoff ? 1 : 0;
+    if (g_rtl_cqpsk_enable) {
+        g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
+    }
+}
+
+int
+rtl_stream_dsp_get(int* cqpsk_enable, int* fll_enable, int* ted_enable) {
+    if (cqpsk_enable) {
+        *cqpsk_enable = g_rtl_cqpsk_enable;
+    }
+    if (fll_enable) {
+        *fll_enable = 0;
+    }
+    if (ted_enable) {
+        *ted_enable = 0;
+    }
+    return 0;
+}
+
+int
+rtl_stream_get_symbol_profile_full(int* out_symbol_rate_hz, int* out_levels, int* out_channel_profile) {
+    if (out_symbol_rate_hz) {
+        *out_symbol_rate_hz = g_rtl_symbol_rate_hz;
+    }
+    if (out_levels) {
+        *out_levels = g_rtl_symbol_levels;
+    }
+    if (out_channel_profile) {
+        *out_channel_profile = g_rtl_channel_profile;
+    }
+    return 0;
 }
 
 int
 rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profile) {
-    (void)symbol_rate_hz;
-    (void)levels;
-    (void)channel_profile;
+    g_rtl_symbol_rate_hz = symbol_rate_hz;
+    g_rtl_symbol_levels = levels;
+    g_rtl_channel_profile = channel_profile;
     return 0;
+}
+
+int
+rtl_stream_get_ted_sps(void) {
+    return g_rtl_ted_sps;
+}
+
+int
+rtl_stream_get_ted_sps_override(void) {
+    return g_rtl_ted_sps_override;
 }
 
 void
 rtl_stream_set_ted_sps(int sps) {
-    (void)sps;
+    g_rtl_ted_sps_override = sps;
 }
 
 void
-rtl_stream_clear_ted_sps_override(void) {}
+rtl_stream_clear_ted_sps_override(void) {
+    g_rtl_ted_sps_override = 0;
+}
 
 void
 rtl_stream_set_ted_sps_no_override(int sps) {
-    (void)sps;
+    g_rtl_ted_sps = sps;
 }
 
 uint64_t
@@ -190,6 +253,162 @@ main(void) {
     assert(state->samplesPerSymbol == 17);
     assert(state->symbolCenter == 8);
     assert(state->rf_mod == 2);
+
+    /* Rigctl modulation remains best-effort: a modulation failure must not
+     * report tune failure after the frequency command succeeds. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    opts->use_rigctl = 1;
+    opts->setmod_bw = 12500;
+    g_setfreq_calls = 0;
+    g_last_setfreq_hz = 0;
+    g_setmod_result = false;
+    g_setfreq_result = true;
+    g_frame_sync_reset_calls = 0;
+    assert(dsd_engine_trunk_tune_to_freq(opts, state, 853000000, 0) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_setfreq_calls == 1);
+    assert(g_last_setfreq_hz == 853000000);
+    assert(opts->trunk_is_tuned == 1);
+    assert(state->trunk_vc_freq[0] == 853000000);
+    assert(g_frame_sync_reset_calls == 1);
+
+    /* RTL input driven by rigctl still needs the generic output drain because
+     * the RTL stream backend will not run its retune drain policy. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->use_rigctl = 1;
+    g_setfreq_calls = 0;
+    g_last_setfreq_hz = 0;
+    g_setfreq_result = true;
+    g_drain_audio_calls = 0;
+    g_rtl_tune_calls = 0;
+    assert(dsd_engine_trunk_tune_to_freq(opts, state, 853500000, 0) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_drain_audio_calls == 1);
+    assert(g_setfreq_calls == 1);
+    assert(g_last_setfreq_hz == 853500000);
+    assert(g_rtl_tune_calls == 0);
+
+    /* If the frequency command itself fails, the decoder must not advance state
+     * or reset DSP acquisition state for a channel it did not tune to. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    opts->use_rigctl = 1;
+    opts->setmod_bw = 12500;
+    g_setmod_result = false;
+    g_setfreq_result = false;
+    g_frame_sync_reset_calls = 0;
+    assert(dsd_engine_trunk_tune_to_freq(opts, state, 854000000, 0) == DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(opts->trunk_is_tuned == 0);
+    assert(state->trunk_vc_freq[0] == 0);
+    assert(g_frame_sync_reset_calls == 0);
+
+#ifdef USE_RADIO
+    /* Native RTL stream retunes keep relying on rtl_stream_tune() for
+     * hardware-side drain/clear behavior instead of also draining here. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_drain_audio_calls = 0;
+    g_rtl_tune_calls = 0;
+    assert(dsd_engine_trunk_tune_to_freq(opts, state, 854500000, 0) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_drain_audio_calls == 0);
+    assert(g_rtl_tune_calls == 1);
+
+    /* Deferred RTL voice retunes must roll back the demod profile/TED changes
+     * prepared for the requested channel. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 1;
+    state->p25_p2_active_slot = 0;
+    state->p25_vc_cqpsk_override = 1;
+    g_rtl_tune_result = RTL_STREAM_TUNE_DEFERRED;
+    g_rtl_cqpsk_enable = 0;
+    g_rtl_symbol_rate_hz = 4800;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+    g_rtl_ted_sps = 5;
+    g_rtl_ted_sps_override = 0;
+    g_frame_sync_reset_calls = 0;
+    g_p25p2_frame_reset_calls = 0;
+    assert(dsd_engine_trunk_tune_to_freq(opts, state, 855000000, 4) == DSD_TRUNK_TUNE_RESULT_DEFERRED);
+    assert(opts->trunk_is_tuned == 0);
+    assert(state->trunk_vc_freq[0] == 0);
+    assert(state->p25_vc_cqpsk_override == 1);
+    assert(g_rtl_cqpsk_enable == 0);
+    assert(g_rtl_symbol_rate_hz == 4800);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
+    assert(g_rtl_ted_sps == 5);
+    assert(g_rtl_ted_sps_override == 0);
+    assert(g_frame_sync_reset_calls == 0);
+    assert(g_p25p2_frame_reset_calls == 0);
+
+    /* Pending RTL retunes keep the requested demod profile and trunk state
+     * because the queued controller request may still complete after timeout. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 1;
+    state->p25_p2_active_slot = 0;
+    state->p25_vc_cqpsk_override = 1;
+    g_rtl_tune_result = RTL_STREAM_TUNE_TIMEOUT;
+    g_rtl_cqpsk_enable = 0;
+    g_rtl_symbol_rate_hz = 4800;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+    g_rtl_ted_sps = 5;
+    g_rtl_ted_sps_override = 0;
+    g_frame_sync_reset_calls = 0;
+    g_p25p2_frame_reset_calls = 0;
+    assert(dsd_engine_trunk_tune_to_freq(opts, state, 855000000, 8) == DSD_TRUNK_TUNE_RESULT_PENDING);
+    assert(opts->trunk_is_tuned == 1);
+    assert(state->trunk_vc_freq[0] == 855000000);
+    assert(state->p25_vc_cqpsk_override == -1);
+    assert(g_rtl_cqpsk_enable == 1);
+    assert(g_rtl_symbol_rate_hz == 6000);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    assert(g_rtl_ted_sps == 5);
+    assert(g_rtl_ted_sps_override == 8);
+    assert(g_frame_sync_reset_calls == 1);
+    assert(g_p25p2_frame_reset_calls == 1);
+
+    /* Pending RTL CC retunes likewise keep the requested CC profile and tracked
+     * CC state aligned with the queued hardware request. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 0;
+    state->p25_cc_is_tdma = 1;
+    state->trunk_cc_freq = 851000000;
+    g_rtl_tune_result = RTL_STREAM_TUNE_TIMEOUT;
+    g_rtl_cqpsk_enable = 0;
+    g_rtl_symbol_rate_hz = 4800;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+    g_rtl_ted_sps = 5;
+    g_rtl_ted_sps_override = 0;
+    g_frame_sync_reset_calls = 0;
+    assert(dsd_engine_trunk_tune_to_cc(opts, state, 852000000, 4) == DSD_TRUNK_TUNE_RESULT_PENDING);
+    assert(state->rf_mod == 1);
+    assert(state->trunk_cc_freq == 852000000);
+    assert(g_rtl_cqpsk_enable == 1);
+    assert(g_rtl_symbol_rate_hz == 6000);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    assert(g_rtl_ted_sps == 4);
+    assert(g_rtl_ted_sps_override == 0);
+    assert(g_frame_sync_reset_calls == 1);
+#endif
 
     printf("DMR_T3_RETURN_TO_CC_REGRESSION: OK\n");
     free(state);

--- a/tests/protocol/dmr/test_dmr_t3_sm_release.c
+++ b/tests/protocol/dmr/test_dmr_t3_sm_release.c
@@ -9,6 +9,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdio.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -19,21 +20,31 @@
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #endif
 
-// Stubs
-void
-trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) { // NOLINT(misc-use-internal-linkage)
-    (void)freq;
+static dsd_trunk_tune_result g_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+static dsd_trunk_tune_result g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+static int g_return_to_cc_calls = 0;
+
+static dsd_trunk_tune_result
+test_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     (void)ted_sps;
+    if (g_tune_to_freq_result != DSD_TRUNK_TUNE_RESULT_OK) {
+        return g_tune_to_freq_result;
+    }
     if (opts) {
         opts->trunk_is_tuned = 1;
     }
     if (state) {
         state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = freq;
     }
+    return DSD_TRUNK_TUNE_RESULT_OK;
 }
 
-void
-return_to_cc(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+static dsd_trunk_tune_result
+test_return_to_cc(dsd_opts* opts, dsd_state* state) {
+    g_return_to_cc_calls++;
+    if (g_return_to_cc_result != DSD_TRUNK_TUNE_RESULT_OK) {
+        return g_return_to_cc_result;
+    }
     if (opts) {
         opts->trunk_is_tuned = 0;
     }
@@ -41,6 +52,7 @@ return_to_cc(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-lin
         state->trunk_vc_freq[0] = 0;
         state->trunk_vc_freq[1] = 0;
     }
+    return DSD_TRUNK_TUNE_RESULT_OK;
 }
 
 void
@@ -60,6 +72,10 @@ main(int argc, char** argv) {
     opts.trunk_enable = 1;
     opts.trunk_hangtime = 0.5f;
     state.trunk_cc_freq = 851000000;
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
+        .tune_to_freq_result = test_tune_to_freq,
+        .return_to_cc_result = test_return_to_cc,
+    });
 
     // Initialize and get context
     dmr_sm_init(&opts, &state);
@@ -67,7 +83,15 @@ main(int argc, char** argv) {
     assert(ctx != NULL);
     assert(ctx->state == DMR_SM_ON_CC);
 
+    // Deferred grants must not advance the DMR SM or shared tuned state.
+    g_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    dmr_sm_emit_group_grant(&opts, &state, 852000000, 0, 100, 1234);
+    assert(opts.trunk_is_tuned == 0);
+    assert(state.trunk_vc_freq[0] == 0);
+    assert(ctx->state == DMR_SM_ON_CC);
+
     // Grant to tune to VC
+    g_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
     long vc = 852000000;
     dmr_sm_emit_group_grant(&opts, &state, vc, 0, 100, 1234);
     assert(opts.trunk_is_tuned == 1);
@@ -95,8 +119,39 @@ main(int argc, char** argv) {
     double now_m = ctx->t_voice_m; // Get current monotonic time reference
     ctx->t_voice_m = now_m - 10.0; // 10 seconds ago, well past hangtime
 
-    // Tick should now release
+    // A deferred return-to-CC must leave the VC state untouched for retry.
+    g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
     dmr_sm_tick(&opts, &state);
+    assert(opts.trunk_is_tuned == 1);
+    assert(state.trunk_vc_freq[0] == vc);
+    assert(ctx->state == DMR_SM_TUNED);
+
+    // Tick should now release once return-to-CC succeeds.
+    g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    dmr_sm_tick(&opts, &state);
+    assert(opts.trunk_is_tuned == 0);
+    assert(ctx->state == DMR_SM_ON_CC);
+
+    // Forced releases must retry after a deferred CC retune even if voice stays active.
+    dmr_sm_emit_group_grant(&opts, &state, vc, 0, 100, 1234);
+    assert(opts.trunk_is_tuned == 1);
+    assert(ctx->state == DMR_SM_TUNED);
+    dmr_sm_emit_voice_sync(&opts, &state, 0);
+    assert(ctx->slots[0].voice_active == 1);
+
+    state.trunk_sm_force_release = 1;
+    g_return_to_cc_calls = 0;
+    g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    dmr_sm_emit_release(&opts, &state, 0);
+    assert(g_return_to_cc_calls == 1);
+    assert(state.trunk_sm_force_release == 1);
+    assert(opts.trunk_is_tuned == 1);
+    assert(ctx->state == DMR_SM_TUNED);
+
+    g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    dmr_sm_tick(&opts, &state);
+    assert(g_return_to_cc_calls == 2);
+    assert(state.trunk_sm_force_release == 0);
     assert(opts.trunk_is_tuned == 0);
     assert(ctx->state == DMR_SM_ON_CC);
 

--- a/tests/protocol/nxdn/test_nxdn_element_bounds.c
+++ b/tests/protocol/nxdn/test_nxdn_element_bounds.c
@@ -9,6 +9,7 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -207,22 +208,24 @@ dsd_time_monotonic_ns(void) {
     return 0ULL;
 }
 
-void
+dsd_trunk_tune_result
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     (void)opts;
     (void)state;
     (void)freq;
     (void)ted_sps;
+    return DSD_TRUNK_TUNE_RESULT_OK;
 }
 
-void
+dsd_trunk_tune_result
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     (void)opts;
     (void)state;
     (void)freq;
     (void)ted_sps;
+    return DSD_TRUNK_TUNE_RESULT_OK;
 }
 
 static void

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -331,7 +331,8 @@ main(void) {
     s10.p25_cc_freq = 851000000;
     s10.trunk_cc_freq = 851000000;
     s10.last_cc_sync_time_m = dsd_time_now_monotonic_s() - 10.0;
-    double old_cc_sync_m = s10.last_cc_sync_time_m;
+    const double old_cc_sync_m = s10.last_cc_sync_time_m;
+    const double cc_sync_epsilon_s = 1.0e-9;
     (void)dsd_trunk_cc_candidates_add(&s10, 852000000, 0);
     p25_sm_ctx_t ctx10;
     p25_sm_init_ctx(&ctx10, &o10, &s10);
@@ -340,7 +341,8 @@ main(void) {
     p25_sm_tick_ctx(&ctx10, &o10, &s10);
     assert(g_result_tune_to_cc_calls == 1);
     assert(s10.trunk_cc_freq == 851000000);
-    assert(s10.last_cc_sync_time_m == old_cc_sync_m);
+    assert((s10.last_cc_sync_time_m - old_cc_sync_m) <= cc_sync_epsilon_s);
+    assert((old_cc_sync_m - s10.last_cc_sync_time_m) <= cc_sync_epsilon_s);
     assert(s10.p25_cc_eval_freq == 0);
     assert(ctx10.state == P25_SM_HUNTING);
 

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -29,6 +29,12 @@ static long g_last_tuned_vc = 0;
 static long g_last_tuned_cc = 0;
 static int g_return_to_cc_called = 0;
 static int g_mark_cc_sync_on_cc_tune = 0;
+static dsd_trunk_tune_result g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+static dsd_trunk_tune_result g_result_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+static dsd_trunk_tune_result g_result_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+static int g_result_tune_to_freq_calls = 0;
+static int g_result_tune_to_cc_calls = 0;
+static int g_result_return_to_cc_calls = 0;
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -64,6 +70,54 @@ install_trunk_tuning_hooks(void) {
     hooks.tune_to_freq = trunk_tune_to_freq;
     hooks.tune_to_cc = trunk_tune_to_cc;
     hooks.return_to_cc = return_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+}
+
+static dsd_trunk_tune_result
+trunk_tune_to_freq_result(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    (void)ted_sps;
+    g_result_tune_to_freq_calls++;
+    g_last_tuned_vc = freq;
+    if (g_result_tune_to_freq_result == DSD_TRUNK_TUNE_RESULT_OK) {
+        if (opts) {
+            opts->p25_is_tuned = 1;
+            opts->trunk_is_tuned = 1;
+        }
+        if (state) {
+            state->p25_vc_freq[0] = state->p25_vc_freq[1] = freq;
+            state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = freq;
+        }
+    }
+    return g_result_tune_to_freq_result;
+}
+
+static dsd_trunk_tune_result
+trunk_tune_to_cc_result(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    (void)opts;
+    (void)ted_sps;
+    g_result_tune_to_cc_calls++;
+    g_last_tuned_cc = freq;
+    if (g_result_tune_to_cc_result == DSD_TRUNK_TUNE_RESULT_OK && state) {
+        state->trunk_cc_freq = freq;
+        dsd_mark_cc_sync(state);
+    }
+    return g_result_tune_to_cc_result;
+}
+
+static dsd_trunk_tune_result
+return_to_cc_result(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_result_return_to_cc_calls++;
+    return g_result_return_to_cc_result;
+}
+
+static void
+install_result_tuning_hooks(void) {
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_freq_result = trunk_tune_to_freq_result;
+    hooks.tune_to_cc_result = trunk_tune_to_cc_result;
+    hooks.return_to_cc_result = return_to_cc_result;
     dsd_trunk_tuning_hooks_set(hooks);
 }
 
@@ -229,6 +283,134 @@ main(void) {
     g_last_tuned_cc = 0;
     p25_sm_tick_ctx(&ctx8, &o8, &s8);
     assert(g_last_tuned_cc == 851000000);
+
+    // 8) A failed VC tune must not advance P25 tuned state or counters.
+    install_result_tuning_hooks();
+    static dsd_opts o9;
+    static dsd_state s9;
+    DSD_MEMSET(&o9, 0, sizeof(o9));
+    DSD_MEMSET(&s9, 0, sizeof(s9));
+    o9.p25_trunk = 1;
+    o9.trunk_tune_group_calls = 1;
+    s9.p25_cc_freq = 851000000;
+    int id9 = 1;
+    s9.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s9.p25_iden_fdma[id9].chan_type = 1;
+    s9.p25_iden_fdma[id9].chan_spac = 100;
+    s9.p25_iden_fdma[id9].trust = 2;
+    s9.p25_iden_fdma[id9].populated = 1;
+    s9.p25_chan_tdma_explicit[id9] = 1;
+    int ch9 = (id9 << 12) | 0x000A;
+    p25_sm_ctx_t ctx9;
+    p25_sm_init_ctx(&ctx9, &o9, &s9);
+    p25_sm_event_t ev9;
+    DSD_MEMSET(&ev9, 0, sizeof(ev9));
+    ev9.type = P25_SM_EV_GRANT;
+    ev9.channel = ch9;
+    ev9.tg = 1234;
+    ev9.src = 42;
+    ev9.is_group = 1;
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    g_result_tune_to_freq_calls = 0;
+    p25_sm_event(&ctx9, &o9, &s9, &ev9);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(o9.p25_is_tuned == 0);
+    assert(o9.trunk_is_tuned == 0);
+    assert(s9.p25_vc_freq[0] == 0);
+    assert(s9.trunk_vc_freq[0] == 0);
+    assert(s9.p25_sm_tune_count == 0);
+    assert(ctx9.state == P25_SM_ON_CC);
+
+    // 9) A failed CC retune must not update the tracked CC frequency or sync timestamp.
+    static dsd_opts o10;
+    static dsd_state s10;
+    DSD_MEMSET(&o10, 0, sizeof(o10));
+    DSD_MEMSET(&s10, 0, sizeof(s10));
+    o10.p25_trunk = 1;
+    o10.p25_prefer_candidates = 1;
+    s10.p25_cc_freq = 851000000;
+    s10.trunk_cc_freq = 851000000;
+    s10.last_cc_sync_time_m = dsd_time_now_monotonic_s() - 10.0;
+    double old_cc_sync_m = s10.last_cc_sync_time_m;
+    (void)dsd_trunk_cc_candidates_add(&s10, 852000000, 0);
+    p25_sm_ctx_t ctx10;
+    p25_sm_init_ctx(&ctx10, &o10, &s10);
+    g_result_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_TIMEOUT;
+    g_result_tune_to_cc_calls = 0;
+    p25_sm_tick_ctx(&ctx10, &o10, &s10);
+    assert(g_result_tune_to_cc_calls == 1);
+    assert(s10.trunk_cc_freq == 851000000);
+    assert(s10.last_cc_sync_time_m == old_cc_sync_m);
+    assert(s10.p25_cc_eval_freq == 0);
+    assert(ctx10.state == P25_SM_HUNTING);
+
+    // 10) Deferred VC tunes leave state unchanged and can be retried by a later grant.
+    static dsd_opts o11;
+    static dsd_state s11;
+    DSD_MEMSET(&o11, 0, sizeof(o11));
+    DSD_MEMSET(&s11, 0, sizeof(s11));
+    o11.p25_trunk = 1;
+    o11.trunk_tune_group_calls = 1;
+    s11.p25_cc_freq = 851000000;
+    s11.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s11.p25_iden_fdma[id9].chan_type = 1;
+    s11.p25_iden_fdma[id9].chan_spac = 100;
+    s11.p25_iden_fdma[id9].trust = 2;
+    s11.p25_iden_fdma[id9].populated = 1;
+    s11.p25_chan_tdma_explicit[id9] = 1;
+    p25_sm_ctx_t ctx11;
+    p25_sm_init_ctx(&ctx11, &o11, &s11);
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    g_result_tune_to_freq_calls = 0;
+    p25_sm_event(&ctx11, &o11, &s11, &ev9);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(o11.p25_is_tuned == 0);
+    assert(s11.p25_sm_tune_count == 0);
+    assert(ctx11.state == P25_SM_ON_CC);
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+    p25_sm_event(&ctx11, &o11, &s11, &ev9);
+    assert(g_result_tune_to_freq_calls == 2);
+    assert(o11.p25_is_tuned == 1);
+    assert(o11.trunk_is_tuned == 1);
+    assert(s11.p25_sm_tune_count == 1);
+    assert(ctx11.state == P25_SM_TUNED);
+
+    // 11) A forced release must survive deferred return-to-CC and retry even while voice remains active.
+    static dsd_opts o12;
+    static dsd_state s12;
+    DSD_MEMSET(&o12, 0, sizeof(o12));
+    DSD_MEMSET(&s12, 0, sizeof(s12));
+    o12.p25_trunk = 1;
+    o12.p25_is_tuned = 1;
+    o12.trunk_is_tuned = 1;
+    o12.trunk_hangtime = 0.2f;
+    s12.p25_cc_freq = 851000000;
+    s12.trunk_cc_freq = 851000000;
+    s12.p25_vc_freq[0] = 852000000;
+    s12.trunk_vc_freq[0] = 852000000;
+    p25_sm_ctx_t ctx12;
+    p25_sm_init_ctx(&ctx12, &o12, &s12);
+    ctx12.state = P25_SM_TUNED;
+    ctx12.vc_freq_hz = 852000000;
+    ctx12.slots[0].voice_active = 1;
+    s12.p25_sm_force_release = 1;
+    g_result_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    g_result_return_to_cc_calls = 0;
+    p25_sm_release(&ctx12, &o12, &s12, "release-forced");
+    assert(g_result_return_to_cc_calls == 1);
+    assert(s12.p25_sm_force_release == 1);
+    assert(o12.p25_is_tuned == 1);
+    assert(ctx12.state == P25_SM_TUNED);
+
+    g_result_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    p25_sm_tick_ctx(&ctx12, &o12, &s12);
+    assert(g_result_return_to_cc_calls == 2);
+    assert(s12.p25_sm_force_release == 0);
+    assert(o12.p25_is_tuned == 0);
+    assert(o12.trunk_is_tuned == 0);
+    assert(ctx12.state == P25_SM_ON_CC);
+
+    install_trunk_tuning_hooks();
 
     DSD_FPRINTF(stderr, "P25 SM core tests passed\n");
     return 0;

--- a/tests/runtime/test_runtime_trunk_tuning_hooks.c
+++ b/tests/runtime/test_runtime_trunk_tuning_hooks.c
@@ -63,17 +63,17 @@ main(void) {
     g_last_cc_freq = 0;
     g_last_ted_sps = -1;
 
-    dsd_trunk_tuning_hook_tune_to_freq(&opts, &state, 852000000, 123);
+    assert(dsd_trunk_tuning_hook_tune_to_freq(&opts, &state, 852000000, 123) == DSD_TRUNK_TUNE_RESULT_OK);
     assert(g_tune_to_freq_calls == 1);
     assert(g_last_freq == 852000000);
     assert(g_last_ted_sps == 123);
 
-    dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851000000, 456);
+    assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851000000, 456) == DSD_TRUNK_TUNE_RESULT_OK);
     assert(g_tune_to_cc_calls == 1);
     assert(g_last_cc_freq == 851000000);
     assert(g_last_ted_sps == 456);
 
-    dsd_trunk_tuning_hook_return_to_cc(&opts, &state);
+    assert(dsd_trunk_tuning_hook_return_to_cc(&opts, &state) == DSD_TRUNK_TUNE_RESULT_OK);
     assert(g_return_to_cc_calls == 1);
 
     // Verify fallback behavior when hooks are not installed
@@ -81,20 +81,26 @@ main(void) {
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
 
-    dsd_trunk_tuning_hook_tune_to_freq(&opts, &state, 853000000, 0);
+    assert(dsd_trunk_tuning_hook_tune_to_freq(&opts, &state, 853000000, 0) == DSD_TRUNK_TUNE_RESULT_OK);
     assert(opts.p25_is_tuned == 1);
     assert(opts.trunk_is_tuned == 1);
     assert(state.p25_vc_freq[0] == 853000000);
     assert(state.trunk_vc_freq[0] == 853000000);
 
-    dsd_trunk_tuning_hook_return_to_cc(&opts, &state);
+    assert(dsd_trunk_tuning_hook_return_to_cc(&opts, &state) == DSD_TRUNK_TUNE_RESULT_OK);
     assert(opts.p25_is_tuned == 0);
     assert(opts.trunk_is_tuned == 0);
     assert(state.p25_vc_freq[0] == 0);
     assert(state.trunk_vc_freq[0] == 0);
 
-    dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851500000, 0);
+    assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851500000, 0) == DSD_TRUNK_TUNE_RESULT_OK);
     assert(state.trunk_cc_freq == 851500000);
+    assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 0, 0) == DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_OK));
+    assert(dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_PENDING));
+    assert(!dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_DEFERRED));
+    assert(!dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_TIMEOUT));
+    assert(!dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_FAILED));
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- return explicit trunk tune results from the engine and runtime hook layer so callers can distinguish accepted, pending, deferred, failed, and timed-out retunes
- gate DMR, P25, NXDN, and EDACS state transitions on accepted or pending retunes so decoder state does not advance when hardware does not move
- tighten RTL retune output handling and add regression coverage for replay deferral, timeout, forced-release retry, and TSCC announcement paths

## Validation
- `tools/format.sh`
- `tools/cmake_format_check.sh`
- `cmake --preset dev-debug`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure -R "DMR_T3_(RETURN_TO_CC_REGRESSION|ANN_WD_TSCC|SM_RELEASE)|DMR_GRANT_POLICY|P25_SM_CORE|NXDN_ELEMENT_BOUNDS|RUNTIME_TRUNK_TUNING_HOOKS|IO_RTL_(RETUNE_PREPARE|REPLAY_RETUNE_REJECT)"`
- `tools/preflight_ci.sh`