### PR TITLE
test: fix p25 trunk sm fixture on windows

### DIFF
--- a/tests/protocol/p25/test_p25_p1_trunk_sm.c
+++ b/tests/protocol/p25/test_p25_p1_trunk_sm.c
@@ -128,9 +128,9 @@ main(int argc, char** argv) {
     // Mark IDEN 1 as TDMA to exercise slot detection; choose odd channel number => slot 1
     int iden = 1;
     // Populate new dual-array
-    state.p25_iden_tdma[iden].base_freq = 851000000;
-    state.p25_iden_tdma[iden].chan_type = 1;
-    state.p25_iden_tdma[iden].chan_spac = 1250;
+    state.p25_iden_tdma[iden].base_freq = 851000000L / 5L;
+    state.p25_iden_tdma[iden].chan_type = 3;
+    state.p25_iden_tdma[iden].chan_spac = 100;
     state.p25_iden_tdma[iden].trust = 2;
     state.p25_iden_tdma[iden].populated = 1;
     state.p25_chan_tdma_explicit[iden] = 2; // TDMA known
@@ -143,6 +143,7 @@ main(int argc, char** argv) {
     // Expect one tune and active slot set to 1 for TDMA
     rc |= expect_eq("tune_count after grant", state.p25_sm_tune_count, 1);
     rc |= expect_eq("active slot", state.p25_p2_active_slot, 1);
+    rc |= expect_eq("vc freq", state.p25_vc_freq[0], 851000000);
 
     // Release path: ensure it increments release count. Force no active slots to avoid deferral.
     state.p25_p2_audio_allowed[0] = 0;


### PR DESCRIPTION
## Summary

Fixes the P25 Phase 1 trunk state-machine unit test fixture so its TDMA IDEN data uses the same encoded units as production state.

## Root Cause

`p25_iden_entry_t::base_freq` stores the IDEN base frequency in 5 Hz units. The test populated it with a Hz value, which could remain positive on 64-bit Linux but overflowed 32-bit `long` on MSVC. That produced a negative resolved grant frequency on Windows and skipped the tune/release assertions.

## Changes

- Store the test TDMA base frequency as `851000000 / 5`.
- Use a real TDMA channel type and 12.5 kHz-equivalent spacing for the fixture.
- Assert the resolved voice-channel frequency so the fixture cannot silently regress on 64-bit platforms.

## Validation

- `ctest --preset dev-debug -R '^P25_P1_TRUNK_SM$' --output-on-failure`
- `ctest --preset dev-debug -R '^(P25_P1_TRUNK_SM|P25_IDEN_DUAL_ARRAY|P25_FREQ_FALLBACK_TDMA|P25_TRUNK_SM_TIMING)$' --output-on-failure`
- Pre-push checks for the touched translation unit: clang-format, clang-tidy strict, IWYU strict, GCC analyzer strict, Semgrep strict, and Lizard complexity