### PR TITLE
protocol: decode Atlas and P25 control messages

### DIFF
--- a/src/protocol/dmr/dmr_pdu.c
+++ b/src/protocol/dmr/dmr_pdu.c
@@ -505,6 +505,12 @@ decode_ip_pdu_handle_udp_service_ext(const dsd_opts* opts, dsd_state* state, uin
             lip_protocol_decoder(opts, state, bits);
             return 1;
         }
+        case 9361:
+            DSD_SNPRINTF(state->dmr_lrrp_gps[slot], sizeof(state->dmr_lrrp_gps[slot]),
+                         "P25 Atlas SRC(IP): %d.%d.%d.%d; DST(IP): %d.%d.%d.%d; ", input[12], input[13], input[14],
+                         input[15], input[16], input[17], input[18], input[19]);
+            DSD_FPRINTF(stderr, "Atlas Data Registration Server;");
+            return 1;
         case 49198:
             DSD_SNPRINTF(state->dmr_lrrp_gps[slot], sizeof(state->dmr_lrrp_gps[slot]),
                          "P25 Tier 2 LOCN SRC(IP): %d.%d.%d.%d; DST(IP): %d.%d.%d.%d; ", input[12], input[13],

--- a/src/protocol/p25/CMakeLists.txt
+++ b/src/protocol/p25/CMakeLists.txt
@@ -12,6 +12,8 @@ target_sources(
         p25_trunk_sm_api.c
         p25_trunk_sm_wrappers.c
         p25_cc_candidates.c
+        p25_extended_function.c
+        p25_mfid90_utils.c
         p25_sm_ui.c
         p25_sm_watchdog.c
         p25_patch.c

--- a/src/protocol/p25/p25_extended_function.c
+++ b/src/protocol/p25/p25_extended_function.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: ISC
+#include "p25_extended_function.h"
+
+const char*
+p25_extended_function_class0_operand_label(uint8_t operand) {
+    switch (operand & 0x7Fu) {
+        case 0x00: return "Radio Check";
+        case 0x7D: return "Radio Detach";
+        case 0x7E: return "Radio Uninhibit";
+        case 0x7F: return "Radio Inhibit";
+        default: return "Reserved";
+    }
+}
+
+int
+p25_extended_function_operand_is_ack(uint8_t operand) {
+    return (operand & 0x80u) != 0u;
+}

--- a/src/protocol/p25/p25_extended_function.h
+++ b/src/protocol/p25/p25_extended_function.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: ISC
+#ifndef DSD_NEO_PROTOCOL_P25_EXTENDED_FUNCTION_H
+#define DSD_NEO_PROTOCOL_P25_EXTENDED_FUNCTION_H
+
+#include <stdint.h>
+
+const char* p25_extended_function_class0_operand_label(uint8_t operand);
+int p25_extended_function_operand_is_ack(uint8_t operand);
+
+#endif // DSD_NEO_PROTOCOL_P25_EXTENDED_FUNCTION_H

--- a/src/protocol/p25/p25_mfid90_utils.c
+++ b/src/protocol/p25/p25_mfid90_utils.c
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: ISC
+#include "p25_mfid90_utils.h"
+
+int
+p25_mfid90_base_station_id_decode(const uint8_t tsbk_byte[12], char* cwid, size_t cwid_size, uint16_t* channel) {
+    if (!tsbk_byte) {
+        return -1;
+    }
+
+    if (channel) {
+        *channel = (uint16_t)((tsbk_byte[8] << 8) | tsbk_byte[9]);
+    }
+
+    if (cwid && cwid_size > 0) {
+        size_t out = 0;
+        cwid[0] = '\0';
+        for (int field = 0; field < 8; field++) {
+            uint8_t value = 0;
+            int bit_start = field * 6;
+            for (int bit = 0; bit < 6; bit++) {
+                int bit_index = bit_start + bit;
+                uint8_t octet = tsbk_byte[2 + (bit_index / 8)];
+                int shift = 7 - (bit_index % 8);
+                value = (uint8_t)((value << 1) | ((octet >> shift) & 1u));
+            }
+            if (value == 0) {
+                continue;
+            }
+            if (out + 1u < cwid_size) {
+                cwid[out++] = (char)(value + 43u);
+            }
+        }
+        cwid[out] = '\0';
+        return (int)out;
+    }
+
+    return 0;
+}

--- a/src/protocol/p25/p25_mfid90_utils.h
+++ b/src/protocol/p25/p25_mfid90_utils.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: ISC
+#ifndef DSD_NEO_PROTOCOL_P25_MFID90_UTILS_H
+#define DSD_NEO_PROTOCOL_P25_MFID90_UTILS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+int p25_mfid90_base_station_id_decode(const uint8_t tsbk_byte[12], char* cwid, size_t cwid_size, uint16_t* channel);
+
+#endif // DSD_NEO_PROTOCOL_P25_MFID90_UTILS_H

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <time.h>
+#include "../p25_mfid90_utils.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -400,15 +401,31 @@ tsbk_handle_mfid90_emergency(const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK]) {
 }
 
 static void
-tsbk_handle_mfid90_system_info(const dsd_opts* opts, const dsd_state* state,
-                               const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK]) {
-    DSD_FPRINTF(stderr, "\n MFID90 (Moto) System Information (BSI)\n");
-    DSD_FPRINTF(stderr, "  Data: %02X %02X %02X %02X %02X %02X %02X %02X", tsbk_byte[2], tsbk_byte[3], tsbk_byte[4],
-                tsbk_byte[5], tsbk_byte[6], tsbk_byte[7], tsbk_byte[8], tsbk_byte[9]);
-    if (opts->show_p25_callsign_decode && (state->p2_wacn != 0 || state->p2_sysid != 0)) {
+tsbk_handle_mfid90_base_station_id(const dsd_opts* opts, const dsd_state* state,
+                                   const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK]) {
+    char cwid[9];
+    uint16_t channel = 0;
+    (void)p25_mfid90_base_station_id_decode(tsbk_byte, cwid, sizeof cwid, &channel);
+
+    DSD_FPRINTF(stderr, "\n MFID90 (Moto) Control Channel Base Station ID\n");
+    DSD_FPRINTF(stderr, "  CHAN [%04X]", channel);
+    if (channel != 0) {
+        char suf[32];
+        p25_format_chan_suffix(state, channel, -1, suf, sizeof suf);
+        DSD_FPRINTF(stderr, "%s", suf);
+        if (state && channel < DSD_TRUNK_CHAN_MAP_SIZE && state->trunk_chan_map[channel] > 0) {
+            DSD_FPRINTF(stderr, " Freq: %.6lf MHz", (double)state->trunk_chan_map[channel] / 1000000.0);
+        }
+    }
+    if (cwid[0] != '\0') {
+        DSD_FPRINTF(stderr, " CWID: %s", cwid);
+    } else {
+        DSD_FPRINTF(stderr, " CWID: none");
+    }
+    if (opts && state && opts->show_p25_callsign_decode && (state->p2_wacn != 0 || state->p2_sysid != 0)) {
         char callsign[7];
         p25_wacn_sysid_to_callsign((uint32_t)state->p2_wacn, (uint16_t)state->p2_sysid, callsign);
-        DSD_FPRINTF(stderr, " [Callsign: %s]", callsign);
+        DSD_FPRINTF(stderr, " Network Callsign: %s", callsign);
     }
     DSD_FPRINTF(stderr, "\n");
 }
@@ -424,7 +441,7 @@ tsbk_handle_mfid90(dsd_opts* opts, dsd_state* state, const uint8_t tsbk_byte[TSB
         case 0x03: tsbk_handle_mfid90_grant_update(opts, state, tsbk_byte); break;
         case 0x09: tsbk_handle_mfid90_scan_marker(tsbk_byte); break;
         case 0x0A: tsbk_handle_mfid90_emergency(tsbk_byte); break;
-        case 0x0B: tsbk_handle_mfid90_system_info(opts, state, tsbk_byte); break;
+        case 0x0B: tsbk_handle_mfid90_base_station_id(opts, state, tsbk_byte); break;
         default: break;
     }
     DSD_FPRINTF(stderr, "%s", KNRM);

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include "../p25_extended_function.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -3746,6 +3747,26 @@ p25p2_vpdu_iter_block_53(p25p2_vpdu_ctx* ctx) {
     int slot VPDU_MAYBE_UNUSED = ctx->slot;
     int i = ctx->iter_idx;
     UNUSED4(type, mac_res, len_c, slot);
+
+    if (MAC[1 + len_a] == 0x64) {
+        uint8_t class_id = (uint8_t)MAC[2 + len_a];
+        uint8_t operand = (uint8_t)MAC[3 + len_a];
+        uint32_t argument = (uint32_t)((MAC[4 + len_a] << 16) | (MAC[5 + len_a] << 8) | MAC[6 + len_a]);
+        uint32_t target = (uint32_t)((MAC[7 + len_a] << 16) | (MAC[8 + len_a] << 8) | MAC[9 + len_a]);
+
+        DSD_FPRINTF(stderr, "\n Extended Function Command - Abbreviated");
+        DSD_FPRINTF(stderr, "\n  Class: %02X Operand: %02X Arg/Src: %06X Target: %u", class_id, operand, argument,
+                    target);
+        if (class_id == 0) {
+            DSD_FPRINTF(stderr, " %s", p25_extended_function_class0_operand_label(operand));
+            if (p25_extended_function_operand_is_ack(operand)) {
+                DSD_FPRINTF(stderr, " Ack");
+            }
+        } else {
+            DSD_FPRINTF(stderr, " Other Command");
+        }
+        DSD_FPRINTF(stderr, ";");
+    }
 
     if (MAC[1 + len_a] == 0x69) {
         int rfssid = MAC[2 + len_a];

--- a/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
@@ -251,6 +251,43 @@ build_ipv4_udp_vertex_tms(uint8_t* out, size_t cap, uint8_t ihl_words) {
     return ip_total_len;
 }
 
+static size_t
+build_ipv4_udp_empty_payload(uint8_t* out, size_t cap, uint16_t dst_port) {
+    DSD_MEMSET(out, 0, cap);
+
+    const size_t ip_header_len = 20u;
+    const size_t udp_len = 8u;
+    const size_t ip_total_len = ip_header_len + udp_len;
+    if (cap < ip_total_len) {
+        return 0;
+    }
+
+    out[0] = (uint8_t)((4u << 4) | 5u);
+    out[2] = (uint8_t)((ip_total_len >> 8) & 0xFFu);
+    out[3] = (uint8_t)(ip_total_len & 0xFFu);
+    out[8] = 0x40;
+    out[9] = 0x11;
+
+    out[12] = 1;
+    out[13] = 2;
+    out[14] = 3;
+    out[15] = 4;
+    out[16] = 5;
+    out[17] = 6;
+    out[18] = 7;
+    out[19] = 8;
+
+    const size_t udp_off = ip_header_len;
+    out[udp_off + 0] = 0x30;
+    out[udp_off + 1] = 0x39;
+    out[udp_off + 2] = (uint8_t)((dst_port >> 8) & 0xFFu);
+    out[udp_off + 3] = (uint8_t)(dst_port & 0xFFu);
+    out[udp_off + 4] = (uint8_t)((udp_len >> 8) & 0xFFu);
+    out[udp_off + 5] = (uint8_t)(udp_len & 0xFFu);
+
+    return ip_total_len;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -296,6 +333,14 @@ main(void) {
         decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
         rc |= expect_has_substr(st.dmr_lrrp_gps[0], "VTX TMS SRC:", "vtx5007 label");
         rc |= expect_has_substr(st.event_history_s[0].Event_History_Items[0].text_message, "HI", "vtx5007 text");
+    }
+
+    // Case 4: EF Johnson Atlas Data Registration Server on UDP/9361 should be labeled.
+    {
+        size_t plen = build_ipv4_udp_empty_payload(pkt, sizeof pkt, 9361);
+        st.dmr_lrrp_gps[0][0] = '\0';
+        decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
+        rc |= expect_has_substr(st.dmr_lrrp_gps[0], "P25 Atlas SRC(IP): 1.2.3.4; DST(IP): 5.6.7.8;", "atlas9361 label");
     }
 
     free(st.event_history_s);

--- a/tests/protocol/p25/test_p25_mfid90_grg.c
+++ b/tests/protocol/p25/test_p25_mfid90_grg.c
@@ -16,6 +16,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -71,12 +72,39 @@ expect_eq(const char* tag, int got, int want) {
 }
 
 static int
+expect_str(const char* tag, const char* got, const char* want) {
+    if (!got || strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got ? got : "(null)", want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 expect_true(const char* tag, int cond) {
     if (!cond) {
         DSD_FPRINTF(stderr, "%s: expected true\n", tag);
         return 1;
     }
     return 0;
+}
+
+int p25_mfid90_base_station_id_decode(const uint8_t tsbk_byte[12], char* cwid, size_t cwid_size, uint16_t* channel);
+
+static void
+pack_mfid90_cwid_values(uint8_t tsbk[12], const uint8_t values[8]) {
+    for (int field = 0; field < 8; field++) {
+        uint8_t value = (uint8_t)(values[field] & 0x3Fu);
+        int bit_start = field * 6;
+        for (int bit = 0; bit < 6; bit++) {
+            int bit_index = bit_start + bit;
+            int byte = 2 + (bit_index / 8);
+            int shift = 7 - (bit_index % 8);
+            if (((value >> (5 - bit)) & 1u) != 0u) {
+                tsbk[byte] = (uint8_t)(tsbk[byte] | (uint8_t)(1u << shift));
+            }
+        }
+    }
 }
 
 static int
@@ -107,6 +135,41 @@ main(void) {
     int rc = 0;
     static dsd_state st;
     DSD_MEMSET(&st, 0, sizeof st);
+
+    // Test 0: MFID90 Base Station ID decodes eight 6-bit CWID chars and channel.
+    {
+        uint8_t tsbk[12];
+        DSD_MEMSET(tsbk, 0, sizeof tsbk);
+        uint8_t values[8] = {
+            (uint8_t)('A' - 43), (uint8_t)('B' - 43), (uint8_t)('C' - 43), (uint8_t)('D' - 43),
+            (uint8_t)('E' - 43), (uint8_t)('F' - 43), (uint8_t)('G' - 43), (uint8_t)('H' - 43),
+        };
+        pack_mfid90_cwid_values(tsbk, values);
+        tsbk[8] = 0x1A;
+        tsbk[9] = 0xBC;
+
+        char cwid[9];
+        uint16_t channel = 0;
+        int count = p25_mfid90_base_station_id_decode(tsbk, cwid, sizeof cwid, &channel);
+        rc |= expect_eq("BSI cwid count", count, 8);
+        rc |= expect_str("BSI cwid", cwid, "ABCDEFGH");
+        rc |= expect_eq("BSI channel", channel, 0x1ABC);
+    }
+
+    // Test 0b: zero-valued CWID fields are omitted, matching sdrtrunk semantics.
+    {
+        uint8_t tsbk[12];
+        DSD_MEMSET(tsbk, 0, sizeof tsbk);
+        uint8_t values[8] = {(uint8_t)('A' - 43), 0, (uint8_t)('C' - 43), 0, 0, 0, 0, 0};
+        pack_mfid90_cwid_values(tsbk, values);
+
+        char cwid[9];
+        uint16_t channel = 0;
+        int count = p25_mfid90_base_station_id_decode(tsbk, cwid, sizeof cwid, &channel);
+        rc |= expect_eq("BSI zero cwid count", count, 2);
+        rc |= expect_str("BSI zero cwid", cwid, "AC");
+        rc |= expect_eq("BSI zero channel", channel, 0);
+    }
 
     // Test 1: MFID90 GRG Add Command pattern (sg=100, ga1=200, ga2=300, ga3=400)
     // Simulates the field extraction from p25p1_tsbk.c opcode 0x00 handler

--- a/tests/protocol/p25/test_p25_p1_tsbk_vpdu.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_vpdu.c
@@ -13,12 +13,15 @@
  */
 
 #include <dsd-neo/protocol/p25/p25_trunk_sm_api.h>
+#include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "test_support.h"
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -189,9 +192,69 @@ expect_eq(const char* tag, long got, long want) {
     return 0;
 }
 
+static int
+expect_str_has(const char* tag, const char* haystack, const char* needle) {
+    if (!haystack || !strstr(haystack, needle)) {
+        DSD_FPRINTF(stderr, "%s: missing '%s' in '%s'\n", tag, needle, haystack ? haystack : "(null)");
+        return 1;
+    }
+    return 0;
+}
+
 // Test shim entry (implemented in src/protocol/p25/p25_test_shim.c)
 void p25_test_invoke_mac_vpdu_with_state(const unsigned char* mac_bytes, int mac_len, int p25_trunk, long p25_cc_freq,
                                          int iden, int type, int tdma, long base, int spac);
+void p25_test_process_mac_vpdu(int type, const unsigned char* mac_bytes, int mac_len);
+const char* p25_extended_function_class0_operand_label(uint8_t operand);
+int p25_extended_function_operand_is_ack(uint8_t operand);
+
+static int
+test_extended_function_command_abbreviated(void) {
+    int rc = 0;
+
+    rc |= expect_str_has("extfn label inhibit", p25_extended_function_class0_operand_label(0x7F), "Radio Inhibit");
+    rc |= expect_str_has("extfn label detach", p25_extended_function_class0_operand_label(0x7D), "Radio Detach");
+    rc |= expect_eq("extfn ack bit", p25_extended_function_operand_is_ack(0xFF), 1);
+    rc |= expect_eq("extfn no ack bit", p25_extended_function_operand_is_ack(0x7F), 0);
+
+    unsigned char mac[24] = {0};
+    mac[0] = 0x01;
+    mac[1] = 0x64;
+    mac[2] = 0x00;
+    mac[3] = 0xFF;
+    mac[4] = 0x12;
+    mac[5] = 0x34;
+    mac[6] = 0x56;
+    mac[7] = 0xAB;
+    mac[8] = 0xCD;
+    mac[9] = 0xEF;
+
+    dsd_test_capture_stderr cap;
+    if (dsd_test_capture_stderr_begin(&cap, "p25_ext_fn_0x64") != 0) {
+        DSD_FPRINTF(stderr, "capture stderr begin failed: %s\n", strerror(errno));
+        return rc | 100;
+    }
+    p25_test_process_mac_vpdu(0, mac, 10);
+    dsd_test_capture_stderr_end(&cap);
+
+    FILE* f = fopen(cap.path, "r");
+    if (!f) {
+        DSD_FPRINTF(stderr, "open capture failed: %s\n", strerror(errno));
+        return rc | 101;
+    }
+    char buf[1024];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    fclose(f);
+    buf[n] = '\0';
+
+    rc |= expect_str_has("extfn output title", buf, "Extended Function Command - Abbreviated");
+    rc |= expect_str_has("extfn output class operand", buf, "Class: 00 Operand: FF");
+    rc |= expect_str_has("extfn output argument", buf, "Arg/Src: 123456");
+    rc |= expect_str_has("extfn output target", buf, "Target: 11259375");
+    rc |= expect_str_has("extfn output label", buf, "Radio Inhibit Ack");
+
+    return rc;
+}
 
 int
 main(void) {
@@ -246,6 +309,8 @@ main(void) {
     rc |= expect_eq("grant2 called", g_called, 1);
     rc |= expect_eq("grant2 svc", g_svc, 0x87);
     rc |= expect_eq("grant2 channel", g_channel, 0x100A);
+
+    rc |= test_extended_function_command_abbreviated();
 
     return rc;
 }


### PR DESCRIPTION
## Summary

- Label DMR UDP/9361 Atlas data registration traffic with source and destination IPs.
- Decode Motorola MFID90 Base Station ID CWID and channel fields without treating the message as a grant.
- Decode standard P25 Extended Function Command abbreviated messages and add focused regression coverage.

## Impact

This improves diagnostic output for known DMR/P25 control traffic while keeping the new decode paths passive. No tuning or grant behavior is added for these messages.

## Validation

- `tools/format.sh`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure -R '^(DMR_LRRP_IP_UDP_LENGTHS|P25_MFID90_GRG|P25_P1_TSBK_VPDU|P25_P1_TSBK_CLAMP|P25_QUEUED_DENY_RESPONSE|PROTOCOL_P25_TIER3_CONFORMANCE)$'`
- `ctest --preset dev-debug --output-on-failure`
- pre-push checks: clang-format, CMake format, clang-tidy strict, cppcheck strict, IWYU strict, GCC analyzer strict, Semgrep strict, Lizard