### PR TITLE
quality: enforce tightened strict checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,7 +371,12 @@ if(DSD_ENABLE_WARNINGS)
                 -Wunused-parameter
                 -Wempty-body
                 -Wunused-label
+                -Wformat=2
+                -Wvla
                 $<$<COMPILE_LANGUAGE:C>:-Wpointer-sign>
+                $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>
+                $<$<COMPILE_LANGUAGE:C>:-Wmissing-prototypes>
+                $<$<COMPILE_LANGUAGE:C>:-Wold-style-definition>
                 -Wmisleading-indentation
                 -Wparentheses
                 -Wunused-value

--- a/include/dsd-neo/core/file_io.h
+++ b/include/dsd-neo/core/file_io.h
@@ -16,6 +16,7 @@
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/platform/platform.h>
 #include <dsd-neo/platform/sndfile_fwd.h>
 
 #include <stddef.h>
@@ -30,7 +31,7 @@ void saveAmbe2450Data(dsd_opts* opts, const dsd_state* state, const char* ambe_d
 void saveAmbe2450DataR(dsd_opts* opts, const dsd_state* state, const char* ambe_d);
 int dsd_frame_log_enabled(const dsd_opts* opts);
 int dsd_frame_detail_enabled(const dsd_opts* opts);
-void dsd_frame_logf(dsd_opts* opts, const char* format, ...);
+void dsd_frame_logf(dsd_opts* opts, const char* format, ...) DSD_ATTR_FORMAT(printf, 2, 3);
 void dsd_frame_log_close(dsd_opts* opts);
 void PrintAMBEData(dsd_opts* opts, const dsd_state* state, const char* ambe_d);
 void PrintIMBEData(dsd_opts* opts, const dsd_state* state, const char* imbe_d);

--- a/include/dsd-neo/core/parse.h
+++ b/include/dsd-neo/core/parse.h
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_CORE_PARSE_H
+#define DSD_NEO_INCLUDE_DSD_NEO_CORE_PARSE_H
+
+/**
+ * @file
+ * @brief Strict scalar parsing helpers for project-owned input handling.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+static inline int
+dsd_parse_base_is_valid(int base) {
+    return base == 0 || (base >= 2 && base <= 36);
+}
+
+static inline int
+dsd_parse_long_strict(const char* text, int base, long min_value, long max_value, long* out) {
+    if (!text || !out || text[0] == '\0' || min_value > max_value || !dsd_parse_base_is_valid(base)) {
+        return -1;
+    }
+
+    errno = 0;
+    char* end = NULL;
+    long value = strtol(text, &end, base);
+    if (errno != 0 || end == text || !end || *end != '\0' || value < min_value || value > max_value) {
+        return -1;
+    }
+
+    *out = value;
+    return 0;
+}
+
+static inline int
+dsd_parse_int_strict(const char* text, int base, int min_value, int max_value, int* out) {
+    if (!out || min_value > max_value) {
+        return -1;
+    }
+
+    long parsed = 0;
+    if (dsd_parse_long_strict(text, base, (long)min_value, (long)max_value, &parsed) != 0) {
+        return -1;
+    }
+    *out = (int)parsed;
+    return 0;
+}
+
+static inline int
+dsd_parse_uint64_strict(const char* text, int base, uint64_t max_value, uint64_t* out) {
+    if (!text || !out || text[0] == '\0' || text[0] == '-' || !dsd_parse_base_is_valid(base)) {
+        return -1;
+    }
+
+    errno = 0;
+    char* end = NULL;
+    unsigned long long value = strtoull(text, &end, base);
+    if (errno != 0 || end == text || !end || *end != '\0' || (uint64_t)value > max_value) {
+        return -1;
+    }
+
+    *out = (uint64_t)value;
+    return 0;
+}
+
+static inline int
+dsd_parse_uint32_strict(const char* text, int base, uint32_t max_value, uint32_t* out) {
+    if (!out) {
+        return -1;
+    }
+
+    uint64_t parsed = 0;
+    if (dsd_parse_uint64_strict(text, base, (uint64_t)max_value, &parsed) != 0) {
+        return -1;
+    }
+    *out = (uint32_t)parsed;
+    return 0;
+}
+
+static inline int
+dsd_parse_uint16_strict(const char* text, int base, uint16_t max_value, uint16_t* out) {
+    if (!out) {
+        return -1;
+    }
+
+    uint64_t parsed = 0;
+    if (dsd_parse_uint64_strict(text, base, (uint64_t)max_value, &parsed) != 0) {
+        return -1;
+    }
+    *out = (uint16_t)parsed;
+    return 0;
+}
+
+static inline int
+dsd_parse_uint8_strict(const char* text, int base, uint8_t max_value, uint8_t* out) {
+    if (!out) {
+        return -1;
+    }
+
+    uint64_t parsed = 0;
+    if (dsd_parse_uint64_strict(text, base, (uint64_t)max_value, &parsed) != 0) {
+        return -1;
+    }
+    *out = (uint8_t)parsed;
+    return 0;
+}
+
+static inline int
+dsd_parse_double_strict(const char* text, double min_value, double max_value, double* out) {
+    if (!text || !out || text[0] == '\0' || min_value > max_value) {
+        return -1;
+    }
+
+    errno = 0;
+    char* end = NULL;
+    double value = strtod(text, &end);
+    if (errno != 0 || end == text || !end || *end != '\0' || value < min_value || value > max_value) {
+        return -1;
+    }
+
+    *out = value;
+    return 0;
+}
+
+static inline int
+dsd_parse_binary_u64_n(const char* bits, size_t bit_count, uint64_t* out) {
+    if (!bits || !out || bit_count == 0 || bit_count > 64) {
+        return -1;
+    }
+
+    uint64_t value = 0;
+    for (size_t i = 0; i < bit_count; i++) {
+        unsigned int bit = 0;
+        if (bits[i] == '0' || bits[i] == 0) {
+            bit = 0;
+        } else if (bits[i] == '1' || bits[i] == 1) {
+            bit = 1;
+        } else {
+            return -1;
+        }
+        value = (value << 1U) | (uint64_t)bit;
+    }
+
+    *out = value;
+    return 0;
+}
+
+static inline int
+dsd_parse_binary_u32_n(const char* bits, size_t bit_count, uint32_t* out) {
+    if (!out || bit_count > 32) {
+        return -1;
+    }
+
+    uint64_t parsed = 0;
+    if (dsd_parse_binary_u64_n(bits, bit_count, &parsed) != 0) {
+        return -1;
+    }
+    *out = (uint32_t)parsed;
+    return 0;
+}
+
+#endif /* DSD_NEO_INCLUDE_DSD_NEO_CORE_PARSE_H */

--- a/include/dsd-neo/core/safe_api.h
+++ b/include/dsd-neo/core/safe_api.h
@@ -163,6 +163,8 @@ dsd_safe_memset_impl(void* dst, size_t dst_size, int value, size_t count) {
 #endif
 }
 
+static inline int dsd_safe_vfprintf(FILE* stream, const char* fmt, va_list ap) DSD_NEO_PRINTF_FORMAT(2, 0);
+
 static inline int
 dsd_safe_vfprintf(FILE* stream, const char* fmt, va_list ap) {
     if (stream == NULL || fmt == NULL) {
@@ -194,6 +196,9 @@ dsd_safe_fprintf(FILE* stream, const char* fmt, ...) {
     return rc;
 }
 
+static inline int dsd_safe_vsnprintf(char* dst, size_t dst_size, const char* fmt, va_list ap)
+    DSD_NEO_PRINTF_FORMAT(3, 0);
+
 static inline int
 dsd_safe_vsnprintf(char* dst, size_t dst_size, const char* fmt, va_list ap) {
     if (dst == NULL || dst_size == 0U || fmt == NULL) {
@@ -222,6 +227,9 @@ dsd_safe_snprintf(char* dst, size_t dst_size, const char* fmt, ...) {
     return rc;
 }
 
+static inline int dsd_safe_vsprintf_impl(char* dst, size_t dst_size, const char* fmt, va_list ap)
+    DSD_NEO_PRINTF_FORMAT(3, 0);
+
 static inline int
 dsd_safe_vsprintf_impl(char* dst, size_t dst_size, const char* fmt, va_list ap) {
     if (dst == NULL || fmt == NULL) {
@@ -245,6 +253,8 @@ dsd_safe_sprintf_impl(char* dst, size_t dst_size, const char* fmt, ...) {
     va_end(ap);
     return rc;
 }
+
+static inline int dsd_safe_vsscanf(const char* src, const char* fmt, va_list ap) DSD_NEO_SCANF_FORMAT(2, 0);
 
 static inline int
 dsd_safe_vsscanf(const char* src, const char* fmt, va_list ap) {

--- a/include/dsd-neo/core/talkgroup_policy.h
+++ b/include/dsd-neo/core/talkgroup_policy.h
@@ -132,6 +132,11 @@ int dsd_tg_policy_append_exact(dsd_state* state, const dsd_tg_policy_entry* entr
 int dsd_tg_policy_upsert_exact(dsd_state* state, const dsd_tg_policy_entry* entry, dsd_tg_policy_upsert_mode mode);
 int dsd_tg_policy_append_group_file_row(const dsd_opts* opts, const dsd_tg_policy_entry* entry, const char* metadata);
 
+#ifdef DSD_NEO_TEST_HOOKS
+void dsd_tg_policy_test_alloc_reset(void);
+void dsd_tg_policy_test_alloc_fail_after(long fail_after);
+#endif
+
 int dsd_tg_policy_should_preempt(const dsd_opts* opts, const dsd_state* state,
                                  const dsd_tg_policy_call_route* candidate_route,
                                  const dsd_tg_policy_decision* candidate, double now_mono_s);

--- a/include/dsd-neo/fec/Golay24.hpp
+++ b/include/dsd-neo/fec/Golay24.hpp
@@ -10,8 +10,6 @@
  * because it matches expected P25 outputs where ITPP did not.
  */
 
-#include <assert.h>
-
 #define POLY 0xAE3
 
 class Golay24 {
@@ -255,21 +253,54 @@ class Golay24 {
  */
 class DSDGolay24 : public Golay24 {
   public:
+    static bool
+    bit_is_valid(char bit) {
+        return bit == 0 || bit == 1;
+    }
+
+    static bool
+    word_bits_are_valid(const char* word, unsigned int length) {
+        if (!word || length > 12) {
+            return false;
+        }
+        for (unsigned int i = 0; i < length; i++) {
+            if (!bit_is_valid(word[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool
+    parity_bits_are_valid(const char* parity) {
+        if (!parity) {
+            return false;
+        }
+        for (unsigned int i = 0; i < 12; i++) {
+            if (!bit_is_valid(parity[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     static unsigned int
     adapt_to_codeword(const char* word, unsigned int length, const char* parity) {
+        if (!word_bits_are_valid(word, length) || !parity_bits_are_valid(parity)) {
+            return 0;
+        }
+
         unsigned int codeword = 0;
 
         // Data needs to be packed with the 12 bits of parity as the most significant
         // bits and 12 bits of data as the less significant. All these discovered by trial and error.
         for (unsigned int i = 0; i < 12; i++) {
             unsigned int pbit = (unsigned int)(unsigned char)parity[11 - i];
-            assert(pbit == 0 || pbit == 1);
             codeword <<= 1;
             codeword |= pbit;
         }
         for (unsigned int i = 0; i < length; i++) {
             unsigned int bit = (unsigned int)(unsigned char)word[length - 1 - i];
-            assert(bit == 0 || bit == 1);
             codeword <<= 1;
             codeword |= bit;
         }
@@ -283,6 +314,10 @@ class DSDGolay24 : public Golay24 {
 
     static void
     adapt_to_word(unsigned int codeword, char* word, unsigned int length) {
+        if (!word || length > 12) {
+            return;
+        }
+
         // put back in word the bits from codeword
         for (unsigned int i = 0, mask = 1 << (12 - length); i < length; i++, mask <<= 1) {
             word[i] = (codeword & mask) != 0 ? 1 : 0;
@@ -291,12 +326,15 @@ class DSDGolay24 : public Golay24 {
 
     static unsigned int
     adapt_from_word(const char* word, unsigned int length) {
+        if (!word_bits_are_valid(word, length)) {
+            return 0;
+        }
+
         unsigned int codeword = 0;
 
         // encode the hex bits into a codeword
         for (unsigned int i = 0; i < length; i++) {
             unsigned int bit = (unsigned int)(unsigned char)word[length - 1 - i];
-            assert(bit == 0 || bit == 1);
             codeword <<= 1;
             codeword |= bit;
         }
@@ -321,6 +359,13 @@ class DSDGolay24 : public Golay24 {
      */
     static int
     decode_6(char* hex, const char* parity, int* fixed_errors) {
+        if (fixed_errors) {
+            *fixed_errors = 0;
+        }
+        if (!fixed_errors || !word_bits_are_valid(hex, 6) || !parity_bits_are_valid(parity)) {
+            return 1;
+        }
+
         unsigned int codeword = adapt_to_codeword(hex, 6, parity);
         // codeword now contains:
         // bits  0- 5: zeros
@@ -350,6 +395,13 @@ class DSDGolay24 : public Golay24 {
 
     static int
     decode_12(char* dodeca, const char* parity, int* fixed_errors) {
+        if (fixed_errors) {
+            *fixed_errors = 0;
+        }
+        if (!fixed_errors || !word_bits_are_valid(dodeca, 12) || !parity_bits_are_valid(parity)) {
+            return 1;
+        }
+
         unsigned int codeword = adapt_to_codeword(dodeca, 12, parity);
         // codeword contains:
         // bits  0-11: dodeca bits
@@ -378,6 +430,10 @@ class DSDGolay24 : public Golay24 {
 
     static void
     encode_6(const char* hex, char* out_parity) {
+        if (!out_parity || !word_bits_are_valid(hex, 6)) {
+            return;
+        }
+
         unsigned int data = adapt_from_word(hex, 6);
         unsigned int codeword = Golay24::encode(data);
 
@@ -389,6 +445,10 @@ class DSDGolay24 : public Golay24 {
 
     static void
     encode_12(const char* dodeca, char* out_parity) {
+        if (!out_parity || !word_bits_are_valid(dodeca, 12)) {
+            return;
+        }
+
         unsigned int data = adapt_from_word(dodeca, 12);
         unsigned int codeword = Golay24::encode(data);
 

--- a/include/dsd-neo/fec/Hamming.hpp
+++ b/include/dsd-neo/fec/Hamming.hpp
@@ -2,7 +2,6 @@
 #ifndef HAMMING_HPP_e7123c3795b94d14b5774d5d8f016a04
 #define HAMMING_HPP_e7123c3795b94d14b5774d5d8f016a04
 
-#include <assert.h>
 #include <bitset>
 #include <string>
 
@@ -133,7 +132,12 @@ class Hamming_10_6_3 : public Hamming_Inteface {
 
     int
     decode(int input, int* output) override {
-        assert(input < 1024 && input >= 0);
+        if (!output || input < 0 || input >= 1024) {
+            if (output) {
+                *output = 0;
+            }
+            return 2;
+        }
 
         std::bitset<10> bitset_input(input);
         int error_count = decode(bitset_input);
@@ -153,6 +157,10 @@ class Hamming_10_6_3 : public Hamming_Inteface {
 
     int
     decode(char* hex, char* parity) override {
+        if (!hex || !parity) {
+            return 2;
+        }
+
         // Make a bitset from hex and parity
         std::bitset<10> value;
         // in the bitset 9 is the left-most and 0 is the right-most
@@ -181,7 +189,9 @@ class Hamming_10_6_3 : public Hamming_Inteface {
 
     int
     encode(int input) override {
-        assert(input < 64 && input >= 0);
+        if (input < 0 || input >= 64) {
+            return 0;
+        }
 
         std::bitset<6> bitset_input(input);
 
@@ -190,6 +200,10 @@ class Hamming_10_6_3 : public Hamming_Inteface {
 
     void
     encode(char* hex, char* out_parity) override {
+        if (!hex || !out_parity) {
+            return;
+        }
+
         // Make a bitset from hex
         std::bitset<6> value;
         // in the bitset 5 is the left-most and 0 is the right-most
@@ -250,11 +264,17 @@ class Hamming_10_6_3_TableImpl : public Hamming_Inteface {
 
     static int
     convert_hex_to_int(const char* hex) {
+        if (!hex) {
+            return -1;
+        }
+
         // Make an int from hex
         int value = 0;
         // in the bitset 9 is the left-most and 0 is the right-most
         for (unsigned int i = 0; i < 6; i++) {
-            assert(hex[i] == 0 || hex[i] == 1);
+            if (hex[i] != 0 && hex[i] != 1) {
+                return -1;
+            }
             value <<= 1;
             value |= hex[i];
         }
@@ -264,16 +284,24 @@ class Hamming_10_6_3_TableImpl : public Hamming_Inteface {
 
     static int
     convert_hex_parity_to_int(const char* hex, const char* parity) {
+        if (!hex || !parity) {
+            return -1;
+        }
+
         // Make an int from hex and parity
         int value = 0;
         // in the bitset 9 is the left-most and 0 is the right-most
         for (unsigned int i = 0; i < 6; i++) {
-            assert(hex[i] == 0 || hex[i] == 1);
+            if (hex[i] != 0 && hex[i] != 1) {
+                return -1;
+            }
             value <<= 1;
             value |= hex[i];
         }
         for (unsigned int i = 0; i < 4; i++) {
-            assert(parity[i] == 0 || parity[i] == 1);
+            if (parity[i] != 0 && parity[i] != 1) {
+                return -1;
+            }
             value <<= 1;
             value |= parity[i];
         }
@@ -283,6 +311,9 @@ class Hamming_10_6_3_TableImpl : public Hamming_Inteface {
 
     static void
     convert_int_to_hex(int value, char* hex) {
+        if (!hex || value < 0) {
+            return;
+        }
         unsigned int v = value;
         for (unsigned int i = 0; i < 6; i++) {
             hex[5 - i] = v & 1;
@@ -293,6 +324,9 @@ class Hamming_10_6_3_TableImpl : public Hamming_Inteface {
     int
     decode(char* hex, char* parity) override {
         int value = convert_hex_parity_to_int(hex, parity);
+        if (value < 0) {
+            return 2;
+        }
         int fixed;
         int error_count = decode(value, &fixed);
 
@@ -311,6 +345,9 @@ class Hamming_10_6_3_TableImpl : public Hamming_Inteface {
     void
     encode(char* hex, char* out_parity) override {
         int value = convert_hex_to_int(hex);
+        if (value < 0 || !out_parity) {
+            return;
+        }
         int parity = encode(value);
 
         // Put the calculated parity in the form of a char array

--- a/include/dsd-neo/platform/file_compat.h
+++ b/include/dsd-neo/platform/file_compat.h
@@ -184,6 +184,19 @@ int dsd_resolve_existing_local_file(const char* requested, char* out, size_t out
 FILE* dsd_fopen_existing_local_file(const char* requested, char* out, size_t out_size);
 
 /**
+ * @brief Open an existing regular file by path for read-only access.
+ *
+ * The final path is opened without following symlinks/reparse points where the
+ * platform exposes that protection. Only read modes such as "r" and "rb" are
+ * accepted.
+ *
+ * @param path  Existing file path.
+ * @param mode  fopen-compatible read-only mode.
+ * @return Read stream for the existing regular file, or NULL with errno set.
+ */
+FILE* dsd_fopen_existing_regular_file(const char* path, const char* mode);
+
+/**
  * @brief Read from a file descriptor.
  *
  * @param fd        File descriptor.

--- a/include/dsd-neo/platform/nonce.h
+++ b/include/dsd-neo/platform/nonce.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_PLATFORM_NONCE_H
+#define DSD_NEO_INCLUDE_DSD_NEO_PLATFORM_NONCE_H
+
+/**
+ * @file
+ * @brief Non-cryptographic nonce helpers for filenames and protocol stream IDs.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void dsd_nonce_fill(void* out, size_t size);
+uint16_t dsd_nonce_u16(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_INCLUDE_DSD_NEO_PLATFORM_NONCE_H */

--- a/include/dsd-neo/platform/posix_compat.h
+++ b/include/dsd-neo/platform/posix_compat.h
@@ -92,6 +92,14 @@ int getopt(int argc, char* const argv[], const char* optstring);
  */
 int dsd_mkdir(const char* path, int mode);
 
+/**
+ * @brief Open a serial/control device for write-only output.
+ *
+ * @param path Device path selected by the user.
+ * @return File descriptor on success, -1 on error.
+ */
+int dsd_open_serial_write(const char* path);
+
 /* ============================================================================
  * Aligned Memory Allocation
  * ============================================================================ */

--- a/include/dsd-neo/protocol/p25/p25p2_frame.h
+++ b/include/dsd-neo/protocol/p25/p25p2_frame.h
@@ -14,6 +14,10 @@
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 
+#if defined(DSD_NEO_P25P2_TEST_STUB)
+#include <stdint.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -21,6 +25,10 @@ extern "C" {
 void p25_p2_frame_reset(void);
 void process_ESS(dsd_opts* opts, dsd_state* state);
 void process_2V(dsd_opts* opts, dsd_state* state);
+
+#if defined(DSD_NEO_P25P2_TEST_STUB)
+int p25p2_duid_lookup_soft_test(uint8_t received, const uint8_t reliab8[8]);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/runtime/log.h
+++ b/include/dsd-neo/runtime/log.h
@@ -44,7 +44,7 @@ typedef enum DSD_ATTR_PACKED {
 #ifdef __cplusplus
 extern "C" {
 #endif
-void dsd_neo_log_write(dsd_neo_log_level_t level, const char* format, ...);
+void dsd_neo_log_write(dsd_neo_log_level_t level, const char* format, ...) DSD_ATTR_FORMAT(printf, 2, 3);
 #ifdef __cplusplus
 }
 #endif

--- a/include/dsd-neo/ui/ui_prims.h
+++ b/include/dsd-neo/ui/ui_prims.h
@@ -14,6 +14,8 @@
 #ifndef DSD_NEO_INCLUDE_DSD_NEO_UI_UI_PRIMS_H_
 #define DSD_NEO_INCLUDE_DSD_NEO_UI_UI_PRIMS_H_
 
+#include <dsd-neo/platform/platform.h>
+
 #include <curses.h>
 #include <stddef.h>
 #include <time.h>
@@ -31,7 +33,7 @@ void ui_destroy_window(WINDOW** win);
 void ui_commit_frame(void);
 
 /** @brief Set a transient status/footer message (printf-style). */
-void ui_statusf(const char* fmt, ...);
+void ui_statusf(const char* fmt, ...) DSD_ATTR_FORMAT(printf, 1, 2);
 /** @brief Copy active status into buf when not expired at `now`; returns 1 if copied. */
 int ui_status_peek(char* buf, size_t n, time_t now);
 /** @brief Clear status when expired at `now` (no-op if still active). */

--- a/semgrep/dsd-neo.yml
+++ b/semgrep/dsd-neo.yml
@@ -49,6 +49,122 @@ rules:
       - pattern: posix_spawn(...)
       - pattern: posix_spawnp(...)
 
+  - id: dsd-neo.no-production-assert
+    languages: [c, cpp]
+    severity: ERROR
+    message: >
+      Use explicit runtime validation or unreachable handling in production code instead of assert(), which can compile
+      out under NDEBUG.
+    paths:
+      include:
+        - /apps/**
+        - /include/**
+        - /src/**
+      exclude:
+        - /src/third_party/**
+    pattern: assert(...)
+
+  - id: dsd-neo.no-weak-process-rng
+    languages: [c, cpp]
+    severity: ERROR
+    message: >
+      Do not use process-global rand()/srand(); use a purpose-specific RNG, nonce, or unique-name helper.
+    paths:
+      include:
+        - /apps/**
+        - /include/**
+        - /src/**
+      exclude:
+        - /src/third_party/**
+    pattern-either:
+      - pattern: rand(...)
+      - pattern: srand(...)
+
+  - id: dsd-neo.no-atoi-family
+    languages: [c, cpp]
+    severity: ERROR
+    message: Use checked strto* parsing or a project parse helper instead of atoi/atol/atoll/atof.
+    paths:
+      include:
+        - /apps/**
+        - /include/**
+        - /src/**
+      exclude:
+        - /src/third_party/**
+    pattern-either:
+      - pattern: atoi(...)
+      - pattern: atol(...)
+      - pattern: atoll(...)
+      - pattern: atof(...)
+      - pattern: std::atoi(...)
+      - pattern: std::atol(...)
+      - pattern: std::atoll(...)
+      - pattern: std::atof(...)
+
+  - id: dsd-neo.no-unchecked-strto-endptr
+    languages: [c, cpp]
+    severity: ERROR
+    message: Check the strto* end pointer and range instead of passing NULL for endptr.
+    paths:
+      include:
+        - /apps/**
+        - /include/**
+        - /src/**
+      exclude:
+        - /src/third_party/**
+    pattern-either:
+      - pattern: strtol($S, NULL, $B)
+      - pattern: strtoul($S, NULL, $B)
+      - pattern: strtoll($S, NULL, $B)
+      - pattern: strtoull($S, NULL, $B)
+      - pattern: strtod($S, NULL)
+      - pattern: strtof($S, NULL)
+      - pattern: strtol($S, nullptr, $B)
+      - pattern: strtoul($S, nullptr, $B)
+      - pattern: strtoll($S, nullptr, $B)
+      - pattern: strtoull($S, nullptr, $B)
+      - pattern: strtod($S, nullptr)
+      - pattern: strtof($S, nullptr)
+      - pattern: std::strtol($S, NULL, $B)
+      - pattern: std::strtoul($S, NULL, $B)
+      - pattern: std::strtoll($S, NULL, $B)
+      - pattern: std::strtoull($S, NULL, $B)
+      - pattern: std::strtod($S, NULL)
+      - pattern: std::strtof($S, NULL)
+      - pattern: std::strtol($S, nullptr, $B)
+      - pattern: std::strtoul($S, nullptr, $B)
+      - pattern: std::strtoll($S, nullptr, $B)
+      - pattern: std::strtoull($S, nullptr, $B)
+      - pattern: std::strtod($S, nullptr)
+      - pattern: std::strtof($S, nullptr)
+
+  - id: dsd-neo.no-raw-file-open
+    languages: [c, cpp]
+    severity: ERROR
+    message: Use project file/path compatibility helpers instead of raw file open/temp APIs in project-owned code.
+    paths:
+      include:
+        - /apps/**
+        - /include/**
+        - /src/**
+      exclude:
+        - /src/third_party/**
+        - /src/platform/file_compat_posix.c
+        - /src/platform/file_compat_win32.c
+        - /src/platform/posix_compat_posix.c
+        - /src/platform/posix_compat_win32.c
+        - /src/runtime/path_policy.c
+    pattern-either:
+      - pattern: fopen(...)
+      - pattern: freopen(...)
+      - pattern: open(...)
+      - pattern: creat(...)
+      - pattern: tmpfile(...)
+      - pattern: tmpnam(...)
+      - pattern: mktemp(...)
+      - pattern: mkstemp(...)
+      - pattern: mkstemps(...)
+
   - id: dsd-neo.no-deprecated-dsd-sprintf
     languages: [c, cpp]
     severity: ERROR

--- a/src/core/audio/dsd_audio.c
+++ b/src/core/audio/dsd_audio.c
@@ -55,7 +55,7 @@ dsd_audio_file_has_wav_family_header(const char* path) {
         return 0;
     }
 
-    FILE* fp = fopen(path, "rb");
+    FILE* fp = dsd_fopen_existing_regular_file(path, "rb");
     if (!fp) {
         return 0;
     }
@@ -1052,7 +1052,7 @@ dsd_audio_open_symbol_input(dsd_opts* opts, dsd_state* state, int symbol_type, c
         return 0;
     }
 
-    opts->symbolfile = fopen(opts->audio_in_dev, "rb");
+    opts->symbolfile = dsd_fopen_existing_regular_file(opts->audio_in_dev, "rb");
     if (opts->symbolfile == NULL) {
         LOG_ERROR("Error, couldn't open %s file %s\n", label, opts->audio_in_dev);
         return -1;

--- a/src/core/file/dsd_file.c
+++ b/src/core/file/dsd_file.c
@@ -27,6 +27,7 @@
 #include <dsd-neo/core/keyring.h>
 #include <dsd-neo/core/mbe_api.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/parse.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/string_utils.h>
 #include <dsd-neo/core/synctype_ids.h>
@@ -35,6 +36,7 @@
 #include <dsd-neo/crypto/des.h>
 #include <dsd-neo/crypto/rc4.h>
 #include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/nonce.h>
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/protocol/dmr/dmr_const.h>
 #include <dsd-neo/protocol/p25/p25p1_const.h>
@@ -431,7 +433,7 @@ openMbeInFile(dsd_opts* opts, dsd_state* state) {
     char cookie[5];
     state->mbe_file_type = -1;
 
-    opts->mbe_in_f = fopen(opts->mbe_in_file, "rb");
+    opts->mbe_in_f = dsd_fopen_existing_regular_file(opts->mbe_in_file, "rb");
     if (opts->mbe_in_f == NULL) {
         LOG_ERROR("Error: could not open %s\n", opts->mbe_in_file);
         return;
@@ -520,7 +522,7 @@ openMbeOutFile(dsd_opts* opts, dsd_state* state) {
     char datestr[9]; //stack buffer for date string
 
     //random element of filename, so two files won't overwrite one another
-    uint16_t random_number = rand() & 0xFFFF;
+    uint16_t random_number = dsd_nonce_u16();
 
     getTime_buf(timestr);
     getDate_buf(datestr);
@@ -575,7 +577,7 @@ openMbeOutFileR(dsd_opts* opts, dsd_state* state) {
     char datestr[9]; //stack buffer for date string
 
     //random element of filename, so two files won't overwrite one another
-    uint16_t random_number = rand() & 0xFFFF;
+    uint16_t random_number = dsd_nonce_u16();
 
     getTime_buf(timestr);
     getDate_buf(datestr);
@@ -628,7 +630,7 @@ open_wav_file(char* dir, char* temp_filename, size_t temp_filename_size, uint16_
         return NULL;
     }
 
-    uint16_t random_number = rand();
+    uint16_t random_number = dsd_nonce_u16();
     char datestr[9];
     char timestr[7];
     getDate_buf(datestr);
@@ -704,7 +706,7 @@ wav_rename_build_metadata(const Event_History* event_item, wav_rename_metadata* 
     }
     getDateF_buf(event_time, metadata->datestr);
     getTimeF_buf(event_time, metadata->timestr);
-    metadata->random_number = rand();
+    metadata->random_number = dsd_nonce_u16();
     metadata->source_id = event_item ? event_item->source_id : 0U;
     metadata->target_id = event_item ? event_item->target_id : 0U;
     DSD_MEMSET(metadata->sys_str, 0, sizeof(metadata->sys_str));
@@ -748,7 +750,7 @@ wav_file_get_size_or_negative(const char* filename) {
         return -1;
     }
 
-    FILE* file = fopen(filename, "r");
+    FILE* file = dsd_fopen_existing_regular_file(filename, "r");
     if (file == NULL) {
         return -1;
     }
@@ -1650,7 +1652,10 @@ sdrtrunk_json_handle_version(const dsd_opts* opts, const char* token, char** str
     if (!value) {
         return 1;
     }
-    ctx->version = (uint16_t)strtol(value, NULL, 10);
+    uint16_t version = 0;
+    if (dsd_parse_uint16_strict(value, 10, UINT16_MAX, &version) == 0) {
+        ctx->version = version;
+    }
     if (opts->payload == 1) {
         DSD_FPRINTF(stderr, "\n Version: %d;", ctx->version);
     }
@@ -1713,7 +1718,8 @@ sdrtrunk_json_handle_to_from(dsd_state* state, const char* token, char** str_sav
     if (strncmp("to", token, 2) == 0) {
         char* value = sdrtrunk_json_next_value(str_saveptr);
         if (value) {
-            state->lasttg = (uint32_t)strtol(value, NULL, 10);
+            uint32_t parsed = 0;
+            state->lasttg = (dsd_parse_uint32_strict(value, 10, UINT32_MAX, &parsed) == 0) ? parsed : 0U;
             DSD_FPRINTF(stderr, "\n To: %s", value);
         }
         return 1;
@@ -1721,7 +1727,8 @@ sdrtrunk_json_handle_to_from(dsd_state* state, const char* token, char** str_sav
     if (strncmp("from", token, 4) == 0) {
         char* value = sdrtrunk_json_next_value(str_saveptr);
         if (value) {
-            state->lastsrc = (uint32_t)strtol(value, NULL, 10);
+            uint32_t parsed = 0;
+            state->lastsrc = (dsd_parse_uint32_strict(value, 10, UINT32_MAX, &parsed) == 0) ? parsed : 0U;
             DSD_FPRINTF(stderr, "\n From: %s", value);
         }
         return 1;
@@ -1739,7 +1746,10 @@ sdrtrunk_json_handle_alg(const dsd_opts* opts, const char* token, char** str_sav
     if (!value) {
         return 1;
     }
-    ctx->alg_id = (uint8_t)strtol(value, NULL, 10);
+    uint8_t alg_id = 0;
+    if (dsd_parse_uint8_strict(value, 10, UINT8_MAX, &alg_id) == 0) {
+        ctx->alg_id = alg_id;
+    }
     if (opts->payload == 1) {
         DSD_FPRINTF(stderr, "\n Alg ID: %02X;", ctx->alg_id);
     }
@@ -1757,7 +1767,10 @@ sdrtrunk_json_handle_key_id(const dsd_opts* opts, const char* token, char** str_
     if (!value) {
         return 1;
     }
-    ctx->key_id = (uint16_t)strtol(value, NULL, 10);
+    uint16_t key_id = 0;
+    if (dsd_parse_uint16_strict(value, 10, UINT16_MAX, &key_id) == 0) {
+        ctx->key_id = key_id;
+    }
     if (opts->payload == 1) {
         DSD_FPRINTF(stderr, "\n Key ID: %04X;", ctx->key_id);
     }
@@ -1831,7 +1844,9 @@ sdrtrunk_json_handle_mi(dsd_opts* opts, dsd_state* state, const char* token, cha
 
     char iv_str[20];
     sdrtrunk_json_extract_iv(value, iv_str);
-    unsigned long long int iv_hex = strtoull(iv_str, NULL, 16);
+    uint64_t iv_parsed = 0;
+    unsigned long long int iv_hex =
+        (dsd_parse_uint64_strict(iv_str, 16, UINT64_MAX, &iv_parsed) == 0) ? (unsigned long long int)iv_parsed : 0ULL;
     if (opts->payload == 1) {
         DSD_FPRINTF(stderr, "\n IV: %016llX;", iv_hex);
     }
@@ -1912,7 +1927,9 @@ sdrtrunk_json_handle_time(const char* token, char** str_saveptr, dsd_state* stat
     char time_str[20];
     DSD_MEMSET(time_str, 0, sizeof(time_str));
     DSD_STRNCPY(time_str, value, 10);
-    time_t event_time = (time_t)strtol(time_str, NULL, 10);
+    long event_seconds = 0;
+    (void)dsd_parse_long_strict(time_str, 10, 0L, LONG_MAX, &event_seconds);
+    time_t event_time = (time_t)event_seconds;
     state->event_history_s[0].Event_History_Items[0].event_time = event_time;
 
     char timestr[9];

--- a/src/core/frames/dsd_dibit.c
+++ b/src/core/frames/dsd_dibit.c
@@ -19,7 +19,6 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <assert.h>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/dibit.h>
 #include <dsd-neo/core/opts.h>
@@ -317,8 +316,6 @@ invert_dibit(int dibit) {
         default: break;
     }
 
-    // Error, shouldn't be here
-    assert(0);
     return -1;
 }
 

--- a/src/core/gps/dsd_gps.c
+++ b/src/core/gps/dsd_gps.c
@@ -129,18 +129,35 @@ nmea_harris_print_src_prefix(uint16_t header, uint32_t src, int slot) {
     }
 }
 
+typedef struct {
+    uint8_t add_hash;
+    double latitude;
+    double longitude;
+    unsigned int position_error;
+    uint8_t pos_err;
+    int speed_kph;
+    int direction_deg;
+    const char* deg_glyph;
+    const char* latstr;
+    const char* lonstr;
+} lip_state_strings;
+
 static void DSD_ATTR_USED
-lip_store_state_strings(dsd_state* state, int slot, uint8_t add_hash, double latitude, double longitude,
-                        unsigned int position_error, uint8_t pos_err, int speed_kph, int direction_deg,
-                        const char* deg_glyph, const char* latstr, const char* lonstr) {
-    if (pos_err != 0x7U) {
+lip_store_state_strings(dsd_state* state, int slot, const lip_state_strings* gps) {
+    if (!state || !gps) {
+        return;
+    }
+
+    if (gps->pos_err != 0x7U) {
         DSD_SNPRINTF(state->dmr_embedded_gps[slot], sizeof state->dmr_embedded_gps[slot],
-                     "%03d; LIP: %.5lf%s%s %.5lf%s%s; Err: %dm; Spd: %d km/h; Dir: %d%s", add_hash, latitude, deg_glyph,
-                     latstr, longitude, deg_glyph, lonstr, position_error, speed_kph, direction_deg, deg_glyph);
+                     "%03d; LIP: %.5lf%s%s %.5lf%s%s; Err: %dm; Spd: %d km/h; Dir: %d%s", gps->add_hash, gps->latitude,
+                     gps->deg_glyph, gps->latstr, gps->longitude, gps->deg_glyph, gps->lonstr, gps->position_error,
+                     gps->speed_kph, gps->direction_deg, gps->deg_glyph);
     } else {
         DSD_SNPRINTF(state->dmr_embedded_gps[slot], sizeof state->dmr_embedded_gps[slot],
-                     "%03d; LIP: %.5lf%s%s %.5lf%s%s Unknown Pos Err; Spd: %d km/h; Dir %d%s", add_hash, latitude,
-                     deg_glyph, latstr, longitude, deg_glyph, lonstr, speed_kph, direction_deg, deg_glyph);
+                     "%03d; LIP: %.5lf%s%s %.5lf%s%s Unknown Pos Err; Spd: %d km/h; Dir %d%s", gps->add_hash,
+                     gps->latitude, gps->deg_glyph, gps->latstr, gps->longitude, gps->deg_glyph, gps->lonstr,
+                     gps->speed_kph, gps->direction_deg, gps->deg_glyph);
     }
 
     DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].gps_s,
@@ -148,6 +165,27 @@ lip_store_state_strings(dsd_state* state, int slot, uint8_t add_hash, double lat
 }
 
 static int nmea_hex_nibble(uint8_t c);
+
+static void DSD_ATTR_USED
+lip_emit_position_metadata(const dsd_opts* opts, dsd_state* state, int slot, const lip_state_strings* gps,
+                           double lat_sf, double lon_sf, uint8_t reason, uint8_t time_elapsed) {
+    if (gps->pos_err == 0x7U) {
+        DSD_FPRINTF(stderr, "\n  Position Error: Unknown or Invalid;");
+    } else {
+        DSD_FPRINTF(stderr, "\n  Position Error: Less than %dm;", gps->position_error);
+    }
+
+    if (reason != 0U) {
+        DSD_FPRINTF(stderr, " Reserved: %d;", reason);
+    } else {
+        DSD_FPRINTF(stderr, " Request Response; ");
+    }
+
+    lip_print_time_elapsed(time_elapsed);
+    lip_store_state_strings(state, slot, gps);
+    gps_write_lrrp_compact(opts, gps->add_hash, lat_sf * gps->latitude, lon_sf * gps->longitude, gps->speed_kph,
+                           gps->direction_deg);
+}
 
 static uint8_t
 nmea_validate_checksum(const uint8_t* input, int len_bytes, uint8_t* end_value, uint8_t* checksum_calc,
@@ -303,31 +341,26 @@ lip_protocol_decoder(const dsd_opts* opts, dsd_state* state, const uint8_t* inpu
         //6.3.63 Position Error (2 * 10^pos_err) via tiny LUT
         static const uint32_t pow10_lut[8] = {1u, 10u, 100u, 1000u, 10000u, 100000u, 1000000u, 10000000u};
         unsigned int position_error = (unsigned int)(2u * pow10_lut[pos_err & 7U]);
-        if (pos_err == 0x7U) {
-            DSD_FPRINTF(stderr, "\n  Position Error: Unknown or Invalid;");
-        } else {
-            DSD_FPRINTF(stderr, "\n  Position Error: Less than %dm;", position_error);
-        }
-
-        //Reason For Sending 6.6.11.3.3 Table 6.80
-        if (reason != 0U) {
-            DSD_FPRINTF(stderr, " Reserved: %d;", reason);
-        } else {
-            DSD_FPRINTF(stderr, " Request Response; ");
-        }
-
-        //6.3.78 Time elapsed
-        lip_print_time_elapsed(time_elapsed);
-
-        lip_store_state_strings(state, slot, add_hash, latitude, longitude, position_error, pos_err, vt, dt, deg_glyph,
-                                latstr, lonstr);
-
-        //save to LRRP report for mapping/logging
-        gps_write_lrrp_compact(opts, add_hash, lat_sf * latitude, lon_sf * longitude, vt, dt);
-
+        lip_state_strings gps = {add_hash, latitude, longitude, position_error, pos_err,
+                                 vt,       dt,       deg_glyph, latstr,         lonstr};
+        lip_emit_position_metadata(opts, state, slot, &gps, lat_sf, lon_sf, reason, time_elapsed);
     } else {
         DSD_FPRINTF(stderr, " Position Calculation Error;");
     }
+}
+
+static void DSD_ATTR_USED
+nmea_store_and_report(const dsd_opts* opts, dsd_state* state, int slot, uint32_t src, float latitude, float longitude,
+                      float speed_kph, uint16_t cog, int type, const char* deg_glyph) {
+    DSD_SNPRINTF(state->dmr_embedded_gps[slot], sizeof state->dmr_embedded_gps[slot], "GPS: (%f%s, %f%s)", latitude,
+                 deg_glyph, longitude, deg_glyph);
+    DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].gps_s,
+                 sizeof state->event_history_s[slot].Event_History_Items[0].gps_s, "(%f%s, %f%s)", latitude, deg_glyph,
+                 longitude, deg_glyph);
+
+    int speed_int = (int)speed_kph;
+    int azimuth = (type == 2) ? (int)cog : 0;
+    gps_write_lrrp_compact(opts, src, latitude, longitude, speed_int, azimuth);
 }
 
 void
@@ -419,19 +452,7 @@ nmea_iec_61162_1(const dsd_opts* opts, dsd_state* state, const uint8_t* input, u
         default: break;
     }
 
-    //save to ncurses string
-    DSD_SNPRINTF(state->dmr_embedded_gps[slot], sizeof state->dmr_embedded_gps[slot], "GPS: (%f%s, %f%s)", latitude,
-                 deg_glyph, longitude, deg_glyph);
-
-    //save to event history string
-    DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].gps_s,
-                 sizeof state->event_history_s[slot].Event_History_Items[0].gps_s, "(%f%s, %f%s)", latitude, deg_glyph,
-                 longitude, deg_glyph);
-
-    //save to LRRP report for mapping/logging
-    int speed_kph = (int)fkph;                     //rounded integer format for log reports
-    int azimuth = (type == 2) ? (int)nmea_cog : 0; //long format only
-    gps_write_lrrp_compact(opts, src, latitude, longitude, speed_kph, azimuth);
+    nmea_store_and_report(opts, state, slot, src, latitude, longitude, fkph, nmea_cog, type, deg_glyph);
 }
 
 //restructured the Harris GPS to flow more like the DMR UDT NMEA Format when possible
@@ -526,6 +547,15 @@ nmea_harris(const dsd_opts* opts, dsd_state* state, const uint8_t* input, uint32
 }
 
 //fallback version (if desired/required)
+static void DSD_ATTR_USED
+harris_gps_store_and_report(const dsd_opts* opts, dsd_state* state, int slot, uint32_t src, float lat_dec,
+                            float lon_dec, int speed_kph, int azimuth, const char* deg_glyph) {
+    uint8_t slot_idx = (slot >= 2) ? 1 : (uint8_t)slot;
+    DSD_SNPRINTF(state->dmr_embedded_gps[slot_idx], sizeof state->dmr_embedded_gps[slot_idx], "GPS: (%f%s, %f%s)",
+                 lat_dec, deg_glyph, lon_dec, deg_glyph);
+    gps_write_lrrp_compact(opts, src, lat_dec, lon_dec, speed_kph, azimuth);
+}
+
 void
 harris_gps(const dsd_opts* opts, dsd_state* state, int slot, const uint8_t* input) {
 
@@ -617,15 +647,7 @@ harris_gps(const dsd_opts* opts, dsd_state* state, int slot, const uint8_t* inpu
     //speed and direction
     DSD_FPRINTF(stderr, " DIR: %03d%s;", a, deg_glyph);
 
-    //save to array for ncurses (guard slot index)
-    {
-        uint8_t slot_idx = (slot >= 2) ? 1 : slot;
-        DSD_SNPRINTF(state->dmr_embedded_gps[slot_idx], sizeof state->dmr_embedded_gps[slot_idx], "GPS: (%f%s, %f%s)",
-                     lat_dec, deg_glyph, lon_dec, deg_glyph);
-    }
-
-    //save to LRRP report for mapping/logging
-    gps_write_lrrp_compact(opts, (uint32_t)src, lat_dec, lon_dec, s, a);
+    harris_gps_store_and_report(opts, state, slot, (uint32_t)src, lat_dec, lon_dec, s, a, deg_glyph);
 
     //NOTE: Thanks to DSheirer (SDRTrunk) for helping me work out a few of the things in here
     //not entirely convinced on some of these calcs (speed, angle, and TS) but sure these bits
@@ -633,13 +655,50 @@ harris_gps(const dsd_opts* opts, dsd_state* state, int slot, const uint8_t* inpu
 }
 
 //externalize embedded GPS - Confirmed working now on NE, NW, SE, and SW coordinates
+typedef struct {
+    double latitude;
+    double longitude;
+    double lat_sf;
+    double lon_sf;
+    unsigned int position_error;
+    uint8_t pos_err;
+    const char* deg_glyph;
+    const char* latstr;
+    const char* lonstr;
+} dmr_embedded_gps_fix;
+
+static void
+dmr_embedded_gps_store_clear_fix(const dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                 const dmr_embedded_gps_fix* fix) {
+    if (fix->pos_err <= 0x5) {
+        DSD_SNPRINTF(state->dmr_embedded_gps[slot], sizeof state->dmr_embedded_gps[slot],
+                     "GPS: %.5lf%s%s %.5lf%s%s Err: %dm", fix->latitude, fix->deg_glyph, fix->latstr, fix->longitude,
+                     fix->deg_glyph, fix->lonstr, fix->position_error);
+    } else if (fix->pos_err == 0x6) {
+        DSD_SNPRINTF(state->dmr_embedded_gps[slot], sizeof state->dmr_embedded_gps[slot],
+                     "GPS: %.5lf%s%s %.5lf%s%s Err: >200km", fix->latitude, fix->deg_glyph, fix->latstr, fix->longitude,
+                     fix->deg_glyph, fix->lonstr);
+    } else {
+        DSD_SNPRINTF(state->dmr_embedded_gps[slot], sizeof state->dmr_embedded_gps[slot],
+                     "GPS: %.5lf%s%s %.5lf%s%s Unknown Pos Err", fix->latitude, fix->deg_glyph, fix->latstr,
+                     fix->longitude, fix->deg_glyph, fix->lonstr);
+    }
+
+    uint32_t src = (slot == 0U) ? (uint32_t)state->lasttg : ((slot == 1U) ? (uint32_t)state->lasttgR : 0U);
+    if (state->event_history_s[slot].Event_History_Items[0].source_id == src) {
+        DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].gps_s,
+                     sizeof state->event_history_s[slot].Event_History_Items[0].gps_s, "%s",
+                     state->dmr_embedded_gps[slot]);
+    }
+    gps_write_lrrp_compact(opts, src, fix->lat_sf * fix->latitude, fix->lon_sf * fix->longitude, 0, 0);
+}
+
 void
 dmr_embedded_gps(const dsd_opts* opts, dsd_state* state, const uint8_t lc_bits[]) {
     UNUSED(opts);
 
     DSD_FPRINTF(stderr, "%s", KYEL);
     DSD_FPRINTF(stderr, " Embedded GPS:");
-    uint8_t slot = state->currentslot;
     uint8_t pf = lc_bits[0];
     uint8_t res_a = lc_bits[1];
     uint8_t res_b = (uint8_t)ConvertBitIntoBytes(&lc_bits[16], 4);
@@ -705,37 +764,10 @@ dmr_embedded_gps(const dsd_opts* opts, dsd_state* state, const uint8_t lc_bits[]
                 DSD_FPRINTF(stderr, "\n  Position Error: Less than %dm", position_error);
             }
 
-            //save to array for ncurses
-            if (pos_err <= 0x5) {
-                DSD_SNPRINTF(state->dmr_embedded_gps[slot], sizeof state->dmr_embedded_gps[slot],
-                             "GPS: %.5lf%s%s %.5lf%s%s Err: %dm", latitude, deg_glyph, latstr, longitude, deg_glyph,
-                             lonstr, position_error);
-            } else if (pos_err == 0x6) {
-                DSD_SNPRINTF(state->dmr_embedded_gps[slot], sizeof state->dmr_embedded_gps[slot],
-                             "GPS: %.5lf%s%s %.5lf%s%s Err: >200km", latitude, deg_glyph, latstr, longitude, deg_glyph,
-                             lonstr);
-            } else {
-                DSD_SNPRINTF(state->dmr_embedded_gps[slot], sizeof state->dmr_embedded_gps[slot],
-                             "GPS: %.5lf%s%s %.5lf%s%s Unknown Pos Err", latitude, deg_glyph, latstr, longitude,
-                             deg_glyph, lonstr);
-            }
-
-            uint32_t src = 0U;
-            if (slot == 0U) {
-                src = state->lasttg;
-            } else if (slot == 1U) {
-                src = state->lasttgR;
-            }
-
-            //save to event history string
-            if (state->event_history_s[slot].Event_History_Items[0].source_id == src) {
-                DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].gps_s,
-                             sizeof state->event_history_s[slot].Event_History_Items[0].gps_s, "%s",
-                             state->dmr_embedded_gps[slot]);
-            }
-
-            //save to LRRP report for mapping/logging
-            gps_write_lrrp_compact(opts, src, lat_sf * latitude, lon_sf * longitude, 0, 0);
+            dmr_embedded_gps_fix fix = {latitude, longitude, lat_sf, lon_sf, position_error,
+                                        pos_err,  deg_glyph, latstr, lonstr};
+            uint8_t slot = state->currentslot;
+            dmr_embedded_gps_store_clear_fix(opts, state, slot, &fix);
         }
     }
 

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -629,6 +629,49 @@ init_state_mbe_contexts(dsd_state* state) {
 }
 
 static void
+init_state_vendor_crypto_defaults(dsd_state* state) {
+    state->tyt_ap = 0;
+    state->tyt_bp = 0;
+    state->tyt_ep = 0;
+    state->baofeng_ap = 0;
+    state->csi_ee = 0;
+    DSD_MEMSET(state->csi_ee_key, 0, sizeof(state->csi_ee_key));
+    state->retevis_ap = 0;
+
+    state->ken_sc = 0;
+    state->any_bp = 0;
+    state->straight_ks = 0;
+    state->straight_mod = 0;
+    state->straight_frame_mode = 0;
+    state->straight_frame_off = 0;
+    state->straight_frame_step = 0;
+
+    DSD_MEMSET(state->ks_octetL, 0, sizeof(state->ks_octetL));
+    DSD_MEMSET(state->ks_octetR, 0, sizeof(state->ks_octetR));
+    DSD_MEMSET(state->ks_bitstreamL, 0, sizeof(state->ks_bitstreamL));
+    DSD_MEMSET(state->ks_bitstreamR, 0, sizeof(state->ks_bitstreamR));
+    state->octet_counter = 0;
+    state->bit_counterL = 0;
+    state->bit_counterR = 0;
+
+    DSD_MEMSET(state->static_ks_bits, 0, sizeof(state->static_ks_bits));
+    DSD_MEMSET(state->static_ks_counter, 0, sizeof(state->static_ks_counter));
+    DSD_MEMSET(state->vertex_ks_key, 0, sizeof(state->vertex_ks_key));
+    DSD_MEMSET(state->vertex_ks_bits, 0, sizeof(state->vertex_ks_bits));
+    DSD_MEMSET(state->vertex_ks_mod, 0, sizeof(state->vertex_ks_mod));
+    DSD_MEMSET(state->vertex_ks_frame_mode, 0, sizeof(state->vertex_ks_frame_mode));
+    DSD_MEMSET(state->vertex_ks_frame_off, 0, sizeof(state->vertex_ks_frame_off));
+    DSD_MEMSET(state->vertex_ks_frame_step, 0, sizeof(state->vertex_ks_frame_step));
+    state->vertex_ks_count = 0;
+    state->vertex_ks_active_idx[0] = -1;
+    state->vertex_ks_active_idx[1] = -1;
+    state->vertex_ks_counter[0] = 0;
+    state->vertex_ks_counter[1] = 0;
+    state->vertex_ks_warned[0] = 0;
+    state->vertex_ks_warned[1] = 0;
+}
+
+static void
 init_state_protocol_defaults_a(dsd_state* state) {
     // Initialize P25 neighbor/candidate UI helpers
     state->p25_nb_count = 0;
@@ -708,46 +751,7 @@ init_state_protocol_defaults_a(dsd_state* state) {
     state->dropL = 256;
     state->dropR = 256;
 
-    state->tyt_ap = 0;
-    state->tyt_bp = 0;
-    state->tyt_ep = 0;
-    state->baofeng_ap = 0;
-    state->csi_ee = 0;
-    DSD_MEMSET(state->csi_ee_key, 0, sizeof(state->csi_ee_key));
-    state->retevis_ap = 0;
-
-    state->ken_sc = 0;
-    state->any_bp = 0;
-    state->straight_ks = 0;
-    state->straight_mod = 0;
-    state->straight_frame_mode = 0;
-    state->straight_frame_off = 0;
-    state->straight_frame_step = 0;
-
-    //ks array storage and counters
-    DSD_MEMSET(state->ks_octetL, 0, sizeof(state->ks_octetL));
-    DSD_MEMSET(state->ks_octetR, 0, sizeof(state->ks_octetR));
-    DSD_MEMSET(state->ks_bitstreamL, 0, sizeof(state->ks_bitstreamL));
-    DSD_MEMSET(state->ks_bitstreamR, 0, sizeof(state->ks_bitstreamR));
-    state->octet_counter = 0;
-    state->bit_counterL = 0;
-    state->bit_counterR = 0;
-
-    DSD_MEMSET(state->static_ks_bits, 0, sizeof(state->static_ks_bits));
-    DSD_MEMSET(state->static_ks_counter, 0, sizeof(state->static_ks_counter));
-    DSD_MEMSET(state->vertex_ks_key, 0, sizeof(state->vertex_ks_key));
-    DSD_MEMSET(state->vertex_ks_bits, 0, sizeof(state->vertex_ks_bits));
-    DSD_MEMSET(state->vertex_ks_mod, 0, sizeof(state->vertex_ks_mod));
-    DSD_MEMSET(state->vertex_ks_frame_mode, 0, sizeof(state->vertex_ks_frame_mode));
-    DSD_MEMSET(state->vertex_ks_frame_off, 0, sizeof(state->vertex_ks_frame_off));
-    DSD_MEMSET(state->vertex_ks_frame_step, 0, sizeof(state->vertex_ks_frame_step));
-    state->vertex_ks_count = 0;
-    state->vertex_ks_active_idx[0] = -1;
-    state->vertex_ks_active_idx[1] = -1;
-    state->vertex_ks_counter[0] = 0;
-    state->vertex_ks_counter[1] = 0;
-    state->vertex_ks_warned[0] = 0;
-    state->vertex_ks_warned[1] = 0;
+    init_state_vendor_crypto_defaults(state);
 }
 
 static void
@@ -805,6 +809,26 @@ init_state_protocol_defaults_b(dsd_state* state) {
 }
 
 static void
+init_state_p25_patch_defaults(dsd_state* state) {
+    state->p25_patch_count = 0;
+    for (int p = 0; p < 8; p++) {
+        state->p25_patch_sgid[p] = 0;
+        state->p25_patch_is_patch[p] = 0;
+        state->p25_patch_active[p] = 0;
+        state->p25_patch_last_update[p] = 0;
+        state->p25_patch_wgid_count[p] = 0;
+        state->p25_patch_wuid_count[p] = 0;
+        for (int q = 0; q < 8; q++) {
+            state->p25_patch_wgid[p][q] = 0;
+            state->p25_patch_wuid[p][q] = 0;
+        }
+        state->p25_patch_key[p] = 0;
+        state->p25_patch_alg[p] = 0;
+        state->p25_patch_ssn[p] = 0;
+    }
+}
+
+static void
 init_state_p25_and_trunk_defaults(dsd_state* state) {
     //P2 variables
     state->p2_wacn = 0;
@@ -858,23 +882,7 @@ init_state_p25_and_trunk_defaults(dsd_state* state) {
     state->p25_vc_freq[0] = 0;
     state->p25_vc_freq[1] = 0;
 
-    // Initialize P25 regroup/patch tracking
-    state->p25_patch_count = 0;
-    for (int p = 0; p < 8; p++) {
-        state->p25_patch_sgid[p] = 0;
-        state->p25_patch_is_patch[p] = 0;
-        state->p25_patch_active[p] = 0;
-        state->p25_patch_last_update[p] = 0;
-        state->p25_patch_wgid_count[p] = 0;
-        state->p25_patch_wuid_count[p] = 0;
-        for (int q = 0; q < 8; q++) {
-            state->p25_patch_wgid[p][q] = 0;
-            state->p25_patch_wuid[p][q] = 0;
-        }
-        state->p25_patch_key[p] = 0;
-        state->p25_patch_alg[p] = 0;
-        state->p25_patch_ssn[p] = 0;
-    }
+    init_state_p25_patch_defaults(state);
 
     //edacs - may need to make these user configurable instead for stability on non-ea systems
     state->ea_mode = -1; //init on -1, 0 is standard, 1 is ea

--- a/src/core/util/talkgroup_policy.c
+++ b/src/core/util/talkgroup_policy.c
@@ -1079,7 +1079,7 @@ tg_policy_probe_group_file(const char* path, int* has_existing_header, int* exis
         return;
     }
 
-    rf = fopen(path, "r");
+    rf = dsd_fopen_existing_regular_file(path, "r");
     if (!rf) {
         *file_missing_or_empty = 1;
         return;

--- a/src/core/vocoder/dsd_mbe.c
+++ b/src/core/vocoder/dsd_mbe.c
@@ -299,20 +299,31 @@ decode_ambe2450_frame(int* errs, int* errs2, char ambe_fr[4][24], dsd_vocoder_so
     return dsd_mbe_decode_ambe2450_frame(errs, errs2, (const char (*)[24])ambe_fr, ambe_d, result) >= 0;
 }
 
+typedef struct {
+    float* aout_buf;
+    int* errs;
+    int* errs2;
+    char* err_str;
+    size_t err_str_size;
+    mbe_parms* cur_mp;
+    mbe_parms* prev_mp;
+    mbe_parms* prev_mp_enhanced;
+} mbe_process_params;
+
 static void
-process_imbe4400_params(float* aout_buf, int* errs, int* errs2, char* err_str, size_t err_str_size,
-                        const char imbe_d[88], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced,
-                        int uvquality, mbe_process_result* result, int have_result) {
-    (void)dsd_mbe_process_imbe4400_dataf(aout_buf, errs, errs2, err_str, err_str_size, imbe_d, cur_mp, prev_mp,
-                                         prev_mp_enhanced, uvquality, have_result ? result : NULL);
+process_imbe4400_params(const mbe_process_params* params, const char imbe_d[88], int uvquality,
+                        mbe_process_result* result, int have_result) {
+    (void)dsd_mbe_process_imbe4400_dataf(params->aout_buf, params->errs, params->errs2, params->err_str,
+                                         params->err_str_size, imbe_d, params->cur_mp, params->prev_mp,
+                                         params->prev_mp_enhanced, uvquality, have_result ? result : NULL);
 }
 
 static void
-process_ambe2450_params(float* aout_buf, int* errs, int* errs2, char* err_str, size_t err_str_size,
-                        const char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp, mbe_parms* prev_mp_enhanced,
-                        int uvquality, mbe_process_result* result, int have_result) {
-    (void)dsd_mbe_process_ambe2450_dataf(aout_buf, errs, errs2, err_str, err_str_size, ambe_d, cur_mp, prev_mp,
-                                         prev_mp_enhanced, uvquality, have_result ? result : NULL);
+process_ambe2450_params(const mbe_process_params* params, const char ambe_d[49], int uvquality,
+                        mbe_process_result* result, int have_result) {
+    (void)dsd_mbe_process_ambe2450_dataf(params->aout_buf, params->errs, params->errs2, params->err_str,
+                                         params->err_str_size, ambe_d, params->cur_mp, params->prev_mp,
+                                         params->prev_mp_enhanced, uvquality, have_result ? result : NULL);
 }
 
 void
@@ -653,9 +664,9 @@ mbe_process_p25p1(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], dsd_voc
 
     (void)dsd_mbe_strip_imbe_context_if_changed(decoded_imbe_d, frame_ctx->imbe_d, &imbe_result);
 
-    process_imbe4400_params(state->audio_out_temp_buf, &state->errs, &state->errs2, state->err_str,
-                            sizeof(state->err_str), frame_ctx->imbe_d, state->cur_mp, state->prev_mp,
-                            state->prev_mp_enhanced, opts->uvquality, &imbe_result, have_imbe_result);
+    mbe_process_params process = {state->audio_out_temp_buf, &state->errs,  &state->errs2,  state->err_str,
+                                  sizeof(state->err_str),    state->cur_mp, state->prev_mp, state->prev_mp_enhanced};
+    process_imbe4400_params(&process, frame_ctx->imbe_d, opts->uvquality, &imbe_result, have_imbe_result);
     update_p25_p1_voice_err_hist(state);
 
     if (dsd_frame_detail_enabled(opts)) {
@@ -690,9 +701,9 @@ mbe_process_provoice(dsd_opts* opts, dsd_state* state, char imbe7100_fr[7][24], 
         }
     }
 
-    process_imbe4400_params(state->audio_out_temp_buf, &state->errs, &state->errs2, state->err_str,
-                            sizeof(state->err_str), frame_ctx->imbe_d, state->cur_mp, state->prev_mp,
-                            state->prev_mp_enhanced, opts->uvquality, &imbe_result, 1);
+    mbe_process_params process = {state->audio_out_temp_buf, &state->errs,  &state->errs2,  state->err_str,
+                                  sizeof(state->err_str),    state->cur_mp, state->prev_mp, state->prev_mp_enhanced};
+    process_imbe4400_params(&process, frame_ctx->imbe_d, opts->uvquality, &imbe_result, 1);
     if (DSD_SYNC_IS_P25P1(state->synctype)) {
         update_p25_p1_voice_err_hist(state);
     }
@@ -893,9 +904,9 @@ mbe_slot_apply_straight_ks_right(dsd_state* state, char ambe_d[49]) {
 static void
 mbe_finalize_slot_left(dsd_opts* opts, dsd_state* state, char ambe_d[49], mbe_process_result* ambe_result,
                        int have_ambe_result) {
-    process_ambe2450_params(state->audio_out_temp_buf, &state->errs, &state->errs2, state->err_str,
-                            sizeof(state->err_str), ambe_d, state->cur_mp, state->prev_mp, state->prev_mp_enhanced,
-                            opts->uvquality, ambe_result, have_ambe_result);
+    mbe_process_params process = {state->audio_out_temp_buf, &state->errs,  &state->errs2,  state->err_str,
+                                  sizeof(state->err_str),    state->cur_mp, state->prev_mp, state->prev_mp_enhanced};
+    process_ambe2450_params(&process, ambe_d, opts->uvquality, ambe_result, have_ambe_result);
     p25p2_record_voice_err(state, state->errs2);
     if (dsd_frame_detail_enabled(opts)) {
         PrintAMBEData(opts, state, ambe_d);
@@ -908,9 +919,10 @@ mbe_finalize_slot_left(dsd_opts* opts, dsd_state* state, char ambe_d[49], mbe_pr
 static void
 mbe_finalize_slot_right(dsd_opts* opts, dsd_state* state, char ambe_d[49], mbe_process_result* ambe_result,
                         int have_ambe_result) {
-    process_ambe2450_params(state->audio_out_temp_bufR, &state->errsR, &state->errs2R, state->err_strR,
-                            sizeof(state->err_strR), ambe_d, state->cur_mp2, state->prev_mp2, state->prev_mp_enhanced2,
-                            opts->uvquality, ambe_result, have_ambe_result);
+    mbe_process_params process = {
+        state->audio_out_temp_bufR, &state->errsR,  &state->errs2R,  state->err_strR,
+        sizeof(state->err_strR),    state->cur_mp2, state->prev_mp2, state->prev_mp_enhanced2};
+    process_ambe2450_params(&process, ambe_d, opts->uvquality, ambe_result, have_ambe_result);
     p25p2_record_voice_err(state, state->errs2R);
     if (dsd_frame_detail_enabled(opts)) {
         PrintAMBEData(opts, state, ambe_d);
@@ -947,9 +959,9 @@ mbe_process_nxdn(dsd_opts* opts, dsd_state* state, char ambe_fr[4][24], dsd_voco
 
     (void)dsd_mbe_strip_ambe_context_if_changed(decoded_ambe_d, frame_ctx->ambe_d, &ambe_result);
 
-    process_ambe2450_params(state->audio_out_temp_buf, &state->errs, &state->errs2, state->err_str,
-                            sizeof(state->err_str), frame_ctx->ambe_d, state->cur_mp, state->prev_mp,
-                            state->prev_mp_enhanced, opts->uvquality, &ambe_result, have_ambe_result);
+    mbe_process_params process = {state->audio_out_temp_buf, &state->errs,  &state->errs2,  state->err_str,
+                                  sizeof(state->err_str),    state->cur_mp, state->prev_mp, state->prev_mp_enhanced};
+    process_ambe2450_params(&process, frame_ctx->ambe_d, opts->uvquality, &ambe_result, have_ambe_result);
     p25p2_record_voice_err(state, state->errs2);
 
     if (dsd_frame_detail_enabled(opts)) {

--- a/src/crypto/crypt-des.c
+++ b/src/crypto/crypt-des.c
@@ -142,6 +142,34 @@ rotate_sub_keys(uint8_t* Kc, uint8_t* Kd, uint8_t shift_size, uint8_t shift_byte
 }
 
 static void
+des_prepare_round_keys(const uint8_t* main_key, uint8_t Ks[16][7]) {
+    uint8_t Kc[4];
+    DSD_MEMSET(Kc, 0, sizeof(Kc));
+    uint8_t Kd[4];
+    DSD_MEMSET(Kd, 0, sizeof(Kd));
+
+    permute(main_key, Ks[0], pc1_key_permutation, 0, 56);
+    for (uint8_t i = 0; i < 3; i++) {
+        Kc[i] = Ks[0][i];
+    }
+    Kc[3] = Ks[0][3] & 0xF0;
+    for (uint8_t i = 0; i < 3; i++) {
+        Kd[i] = (Ks[0][i + 3] & 0x0F) << 4;
+        Kd[i] |= (Ks[0][i + 4] & 0xF0) >> 4;
+    }
+    Kd[3] = (Ks[0][6] & 0x0F) << 4;
+
+    DSD_MEMSET(Ks, 0, (size_t)16U * 7U * sizeof(uint8_t));
+    for (uint8_t i = 0; i < 16; i++) {
+        uint8_t shift_size = key_shift_sizes[i + 1];
+        uint8_t shift_byte = key_shift_bytes[i + 1];
+        rotate_sub_keys(Kc, Kd, shift_size, shift_byte);
+        permute(Kc, Ks[i], pc2_key_permutation, 0, 24);
+        permute(Kd, Ks[i], pc2_key_permutation, 24, 48);
+    }
+}
+
+static void
 des_cipher(const uint8_t* main_key, const uint8_t* input_register, uint8_t* output_register, uint8_t de) {
 
     //starting and ending permutations
@@ -165,34 +193,8 @@ des_cipher(const uint8_t* main_key, const uint8_t* input_register, uint8_t* outp
     //key sets
     uint8_t Ks[16][7];
     DSD_MEMSET(Ks, 0, sizeof(Ks));
-    uint8_t Kc[4];
-    DSD_MEMSET(Kc, 0, sizeof(Kc));
-    uint8_t Kd[4];
-    DSD_MEMSET(Kd, 0, sizeof(Kd));
-
-    //initial Ks permutation and shuffle to Kc and Kd
-    permute(main_key, Ks[0], pc1_key_permutation, 0, 56);
-    for (uint8_t i = 0; i < 3; i++) {
-        Kc[i] = Ks[0][i];
-    }
-    Kc[3] = Ks[0][3] & 0xF0;
-    for (uint8_t i = 0; i < 3; i++) {
-        Kd[i] = (Ks[0][i + 3] & 0x0F) << 4;
-        Kd[i] |= (Ks[0][i + 4] & 0xF0) >> 4;
-    }
-    Kd[3] = (Ks[0][6] & 0x0F) << 4;
-
-    //reset Ks
-    DSD_MEMSET(Ks, 0, sizeof(Ks));
-
-    //create the 16 Ks rounds
-    for (uint8_t i = 0; i < 16; i++) {
-        uint8_t shift_size = key_shift_sizes[i + 1];
-        uint8_t shift_byte = key_shift_bytes[i + 1];
-        rotate_sub_keys(Kc, Kd, shift_size, shift_byte);
-        permute(Kc, Ks[i], pc2_key_permutation, 0, 24);
-        permute(Kd, Ks[i], pc2_key_permutation, 24, 48);
-    }
+    // codeql[cpp/weak-cryptographic-algorithm] DES/TDEA is required for legacy radio protocol interoperability.
+    des_prepare_round_keys(main_key, Ks);
 
     //permute the input_register with the ip (initial_register_permutation) table
     permute(input_register, initial_permutation, initial_register_permutation, 0, 64);
@@ -277,6 +279,7 @@ des56_ofb_keystream_output(const uint8_t* main_key, const uint8_t* iv, uint8_t* 
     //execute the des_cipher in output feedback mode
     for (int16_t i = 0; i < nblocks; i++) {
         //de should be 1 here for encryption mode
+        // codeql[cpp/weak-cryptographic-algorithm] DES OFB is required for legacy radio protocol interoperability.
         des_cipher(main_key, input_register, output_register, de);
         DSD_MEMCPY(input_register, output_register,
                    sizeof(output_register)); //recycle output_register back into input register
@@ -303,6 +306,7 @@ tdea_tofb_keystream_output(const uint8_t* K1, const uint8_t* K2, const uint8_t* 
     //execute the des_cipher in output feedback mode 3 times using each key and transferring output to input each time
     for (int16_t i = 0; i < nblocks; i++) {
         //K1
+        // codeql[cpp/weak-cryptographic-algorithm] TDEA is required for legacy radio protocol interoperability.
         des_cipher(K1, input_register, output_register, de);
         DSD_MEMCPY(input_register, output_register,
                    sizeof(output_register));                     //recycle output_register back into input_register
@@ -310,6 +314,7 @@ tdea_tofb_keystream_output(const uint8_t* K1, const uint8_t* K2, const uint8_t* 
 
         //K2
         de = (de ^ 1) & 1; //flip the de bit
+        // codeql[cpp/weak-cryptographic-algorithm] TDEA is required for legacy radio protocol interoperability.
         des_cipher(K2, input_register, output_register, de);
         DSD_MEMCPY(input_register, output_register,
                    sizeof(output_register));                     //recycle output_register back into input_register
@@ -317,6 +322,7 @@ tdea_tofb_keystream_output(const uint8_t* K1, const uint8_t* K2, const uint8_t* 
 
         //K3
         de = (de ^ 1) & 1; //flip the de bit back
+        // codeql[cpp/weak-cryptographic-algorithm] TDEA is required for legacy radio protocol interoperability.
         des_cipher(K3, input_register, output_register, de);
         DSD_MEMCPY(input_register, output_register,
                    sizeof(output_register)); //recycle output_register back into input_register
@@ -375,6 +381,7 @@ des56_ca_keystream_output(const uint8_t* main_key, const uint8_t* iv, uint8_t* k
     for (int16_t i = 0; i < nbits; i++) {
 
         //de should be 1 here for encryption mode
+        // codeql[cpp/weak-cryptographic-algorithm] DES-XL is required for legacy radio protocol interoperability.
         des_cipher(main_key, input_register, output_register, de);
 
         //keystream accumulation, shift current byte and append

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -31,6 +31,7 @@
 #include <dsd-neo/dsp/symbol.h>
 #include <dsd-neo/dsp/symbol_levels.h>
 #include <dsd-neo/platform/audio.h>
+#include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/platform/timing.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/exitflag.h>
@@ -1507,7 +1508,7 @@ symbol_process_symbol_bin_input(dsd_opts* opts, dsd_state* state, float* symbol_
         opts->symbolfile = NULL;
         DSD_FPRINTF(stderr, "\nEnd of %s\n", opts->audio_in_dev);
         if (state->debug_mode == 1) {
-            opts->symbolfile = fopen(opts->audio_in_dev, "rb");
+            opts->symbolfile = dsd_fopen_existing_regular_file(opts->audio_in_dev, "rb");
             opts->audio_in_type = AUDIO_IN_SYMBOL_BIN;
             state->symbol_replay_format = DSD_SYMBOL_REPLAY_FORMAT_UNKNOWN;
             state->symbol_replay_header_checked = 0;

--- a/src/dsp/simd_fir_avx2.cpp
+++ b/src/dsp/simd_fir_avx2.cpp
@@ -192,6 +192,27 @@ hb_complex_accumulate_scalar(const float* scratch, const float* taps, int left_l
     return acc;
 }
 
+static inline float
+load_real(const float* scratch, int idx) {
+    return scratch[idx];
+}
+
+static inline float
+hb_real_accumulate_scalar(const float* scratch, const float* taps, int hist_len, int center, int n) {
+    const int center_idx = hist_len + (n << 1);
+    float acc = taps[center] * load_real(scratch, center_idx);
+
+    for (int e = 0; e < center; e += 2) {
+        const float ce = taps[e];
+        if (ce == 0.0f) {
+            continue;
+        }
+        const int d = center - e;
+        acc += ce * (load_real(scratch, center_idx - d) + load_real(scratch, center_idx + d));
+    }
+    return acc;
+}
+
 static inline void
 update_iq_history(const float* in, int sample_count, float* hist_i, float* hist_q, int hist_len) {
     if (sample_count >= hist_len) {
@@ -211,6 +232,18 @@ update_iq_history(const float* in, int sample_count, float* hist_i, float* hist_
         hist_i[keep + k] = in[k << 1];
         hist_q[keep + k] = in[(k << 1) + 1];
     }
+}
+
+static inline void
+update_real_history(const float* in, int in_len, float* hist, int hist_len) {
+    if (in_len >= hist_len) {
+        DSD_MEMCPY(hist, in + (in_len - hist_len), (size_t)hist_len * sizeof(float));
+        return;
+    }
+
+    const int keep = hist_len - in_len;
+    DSD_MEMMOVE(hist, hist + in_len, (size_t)keep * sizeof(float));
+    DSD_MEMCPY(hist + keep, in, (size_t)in_len * sizeof(float));
 }
 
 } // namespace
@@ -350,16 +383,12 @@ simd_hb_decim2_real_avx2(const float* in, int in_len, float* out, float* hist, c
     const int pad = center + 1; /* stride-2 centers, 8-output vectorization */
     const int scratch_len = total_len + pad;
 
-    /* Resize thread-local buffer if needed (amortized O(1)) */
     if (tls_scratch_real.size() < (size_t)scratch_len) {
         tls_scratch_real.resize((size_t)scratch_len);
     }
     float* scratch = tls_scratch_real.data();
 
-    /* Copy history */
     DSD_MEMCPY(scratch, hist, (size_t)hist_len * sizeof(float));
-
-    /* Copy input */
     DSD_MEMCPY(scratch + hist_len, in, (size_t)in_len * sizeof(float));
 
     /* Tail padding to preserve last sample behavior */
@@ -367,9 +396,6 @@ simd_hb_decim2_real_avx2(const float* in, int in_len, float* out, float* hist, c
     for (int k = 0; k < pad; k++) {
         scratch[hist_len + in_len + k] = last;
     }
-
-    /* Branch-free sample access (index is always valid due to padding) */
-    auto get_sample = [&](int idx) -> float { return scratch[idx]; };
 
     /* Process 8 output samples at a time */
     int n = 0;
@@ -389,8 +415,9 @@ simd_hb_decim2_real_avx2(const float* in, int in_len, float* out, float* hist, c
         int ci6 = hist_len + ((n + 6) << 1);
         int ci7 = hist_len + ((n + 7) << 1);
 
-        __m256 center_val = _mm256_set_ps(get_sample(ci7), get_sample(ci6), get_sample(ci5), get_sample(ci4),
-                                          get_sample(ci3), get_sample(ci2), get_sample(ci1), get_sample(ci0));
+        __m256 center_val = _mm256_set_ps(load_real(scratch, ci7), load_real(scratch, ci6), load_real(scratch, ci5),
+                                          load_real(scratch, ci4), load_real(scratch, ci3), load_real(scratch, ci2),
+                                          load_real(scratch, ci1), load_real(scratch, ci0));
         acc = _mm256_fmadd_ps(tap_c, center_val, acc);
 
         /* Half-band: only even indices */
@@ -403,11 +430,13 @@ simd_hb_decim2_real_avx2(const float* in, int in_len, float* out, float* hist, c
             __m256 tap_e = _mm256_set1_ps(ce);
 
             __m256 sum_m =
-                _mm256_set_ps(get_sample(ci7 - d), get_sample(ci6 - d), get_sample(ci5 - d), get_sample(ci4 - d),
-                              get_sample(ci3 - d), get_sample(ci2 - d), get_sample(ci1 - d), get_sample(ci0 - d));
+                _mm256_set_ps(load_real(scratch, ci7 - d), load_real(scratch, ci6 - d), load_real(scratch, ci5 - d),
+                              load_real(scratch, ci4 - d), load_real(scratch, ci3 - d), load_real(scratch, ci2 - d),
+                              load_real(scratch, ci1 - d), load_real(scratch, ci0 - d));
             __m256 sum_p =
-                _mm256_set_ps(get_sample(ci7 + d), get_sample(ci6 + d), get_sample(ci5 + d), get_sample(ci4 + d),
-                              get_sample(ci3 + d), get_sample(ci2 + d), get_sample(ci1 + d), get_sample(ci0 + d));
+                _mm256_set_ps(load_real(scratch, ci7 + d), load_real(scratch, ci6 + d), load_real(scratch, ci5 + d),
+                              load_real(scratch, ci4 + d), load_real(scratch, ci3 + d), load_real(scratch, ci2 + d),
+                              load_real(scratch, ci1 + d), load_real(scratch, ci0 + d));
             __m256 sum = _mm256_add_ps(sum_m, sum_p);
             acc = _mm256_fmadd_ps(tap_e, sum, acc);
         }
@@ -417,31 +446,10 @@ simd_hb_decim2_real_avx2(const float* in, int in_len, float* out, float* hist, c
 
     /* Scalar epilogue */
     for (; n < out_len; n++) {
-        int center_idx = hist_len + (n << 1);
-        float acc = 0.0f;
-
-        acc += taps[center] * get_sample(center_idx);
-
-        for (int e = 0; e < center; e += 2) {
-            float ce = taps[e];
-            if (ce == 0.0f) {
-                continue;
-            }
-            int d = center - e;
-            acc += ce * (get_sample(center_idx - d) + get_sample(center_idx + d));
-        }
-
-        out[n] = acc;
+        out[n] = hb_real_accumulate_scalar(scratch, taps, hist_len, center, n);
     }
 
-    /* Update history: read from original `in` buffer, not scratch */
-    if (in_len >= hist_len) {
-        DSD_MEMCPY(hist, in + (in_len - hist_len), (size_t)hist_len * sizeof(float));
-    } else {
-        int need = hist_len - in_len;
-        DSD_MEMMOVE(hist, hist + in_len, (size_t)need * sizeof(float));
-        DSD_MEMCPY(hist + need, in, (size_t)in_len * sizeof(float));
-    }
+    update_real_history(in, in_len, hist, hist_len);
 
     _mm256_zeroupper();
     return out_len;

--- a/src/dsp/simd_fir_neon.cpp
+++ b/src/dsp/simd_fir_neon.cpp
@@ -221,7 +221,6 @@ simd_hb_decim2_complex_neon(const float* in, int in_len, float* out, float* hist
         xq = scratch[2 * ii + 1];
     };
 
-    /* Process 2 output samples at a time */
     int n = 0;
     for (; n + 1 < out_ch_len; n += 2) {
         float32x4_t acc = vdupq_n_f32(0.0f);
@@ -239,7 +238,6 @@ simd_hb_decim2_complex_neon(const float* in, int in_len, float* out, float* hist
         float32x4_t center_val = vld1q_f32(center_arr);
         acc = vfmaq_f32(acc, tap_c, center_val);
 
-        /* Half-band: only even tap indices */
         for (int e = 0; e < center; e += 2) {
             float ce = taps[e];
             if (ce == 0.0f) {
@@ -267,7 +265,6 @@ simd_hb_decim2_complex_neon(const float* in, int in_len, float* out, float* hist
         vst1q_f32(out + (n << 1), acc);
     }
 
-    /* Scalar epilogue */
     for (; n < out_ch_len; n++) {
         int center_idx = left_len + (n << 1);
         float accI = 0.0f;

--- a/src/dsp/simd_fir_sse2.cpp
+++ b/src/dsp/simd_fir_sse2.cpp
@@ -224,17 +224,13 @@ simd_hb_decim2_complex_sse2(const float* in, int in_len, float* out, float* hist
         xq = scratch[2 * ii + 1];
     };
 
-    /* Process 2 output samples at a time */
     int n = 0;
     for (; n + 1 < out_ch_len; n += 2) {
         __m128 acc = _mm_setzero_ps();
 
-        /* Center tap */
         float cc = taps[center];
         __m128 tap_c = _mm_set1_ps(cc);
 
-        /* Output n: input index = 2*n, center_idx = left_len + 2*n */
-        /* Output n+1: input index = 2*(n+1), center_idx = left_len + 2*(n+1) */
         int center_idx0 = left_len + (n << 1);
         int center_idx1 = left_len + ((n + 1) << 1);
 

--- a/src/fec/Hamming.cpp
+++ b/src/fec/Hamming.cpp
@@ -85,7 +85,12 @@ Hamming_10_6_3::encode(const std::bitset<6>& input) {
 
 int
 Hamming_10_6_3_TableImpl::decode(int input, int* output) {
-    assert(input < 1024 && input >= 0);
+    if (!output || input < 0 || input >= 1024) {
+        if (output) {
+            *output = 0;
+        }
+        return 2;
+    }
 
     // Making use of a table...
     Hamming_10_6_3_TableImpl_data* table = data();
@@ -101,7 +106,9 @@ Hamming_10_6_3_TableImpl::decode(int input, int* output) {
 
 int
 Hamming_10_6_3_TableImpl::encode(int input) {
-    assert(input < 64 && input >= 0);
+    if (input < 0 || input >= 64) {
+        return 0;
+    }
 
     // Making use of a table...
     Hamming_10_6_3_TableImpl_data* table = data();

--- a/src/io/control/dsd_serial.c
+++ b/src/io/control/dsd_serial.c
@@ -3,11 +3,10 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/io/control.h>
+#include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/platform/platform.h>
+#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/runtime/log.h>
-#if !DSD_PLATFORM_WIN_NATIVE
-#include <fcntl.h>
-#endif
 #include <stdio.h>
 #include <sys/types.h>
 #if !DSD_PLATFORM_WIN_NATIVE
@@ -77,7 +76,7 @@ openSerial(dsd_opts* opts, dsd_state* state) {
 
     DSD_FPRINTF(stderr, "Opening serial port %s and setting baud to %i\n", opts->serial_dev, opts->serial_baud);
     opts->serial_fd = -1;
-    int fd = open(opts->serial_dev, O_WRONLY);
+    int fd = dsd_open_serial_write(opts->serial_dev);
     if (fd == -1) {
         LOG_ERROR("Error, couldn't open %s\n", opts->serial_dev);
         return;
@@ -136,7 +135,7 @@ resumeScan(dsd_opts* opts, dsd_state* state) {
     if (opts->serial_fd > 0) {
         char cmd[16];
         DSD_SNPRINTF(cmd, sizeof cmd, "\rKEY00\r");
-        ssize_t written = write(opts->serial_fd, cmd, 7);
+        ssize_t written = dsd_write(opts->serial_fd, cmd, 7);
         if (written != 7) {
             LOG_WARN("resumeScan: sent %zd/7 bytes on serial FD", written);
         }

--- a/src/io/iq/iq_capture.c
+++ b/src/io/iq/iq_capture.c
@@ -80,6 +80,8 @@ static DSD_THREAD_RETURN_TYPE
 #endif
     writer_thread_fn(void* arg);
 
+static void set_error(char* err_buf, size_t err_buf_size, const char* fmt, ...) DSD_ATTR_FORMAT(printf, 3, 4);
+
 static void
 set_error(char* err_buf, size_t err_buf_size, const char* fmt, ...) {
     if (!err_buf || err_buf_size == 0 || !fmt) {

--- a/src/io/iq/iq_replay.c
+++ b/src/io/iq/iq_replay.c
@@ -14,12 +14,15 @@
 #include <string.h>
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/io/iq_types.h"
+#include "dsd-neo/platform/platform.h"
 
 struct dsd_iq_replay_source {
     FILE* fp;
     uint64_t total_bytes;
     uint64_t remaining_bytes;
 };
+
+static void set_error(char* err_buf, size_t err_buf_size, const char* fmt, ...) DSD_ATTR_FORMAT(printf, 3, 4);
 
 static void
 set_error(char* err_buf, size_t err_buf_size, const char* fmt, ...) {
@@ -110,7 +113,7 @@ read_file_all(const char* path, char** out_data, size_t* out_size, char* err_buf
     *out_data = NULL;
     *out_size = 0;
 
-    FILE* fp = fopen(path, "rb");
+    FILE* fp = dsd_fopen_existing_regular_file(path, "rb");
     if (!fp) {
         set_error(err_buf, err_buf_size, "failed to open metadata file '%s': %s", path, strerror(errno));
         return DSD_IQ_ERR_IO;
@@ -1999,7 +2002,7 @@ dsd_iq_replay_open(const char* path, dsd_iq_replay_config* out_cfg, dsd_iq_repla
         dsd_iq_replay_config_clear(&cfg);
         return DSD_IQ_ERR_ALLOC;
     }
-    src->fp = fopen(cfg.data_path, "rb");
+    src->fp = dsd_fopen_existing_regular_file(cfg.data_path, "rb");
     if (!src->fp) {
         set_error(err_buf, err_buf_size, "failed to open replay data '%s': %s", cfg.data_path, strerror(errno));
         free(src);

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -109,7 +109,10 @@ static int
 rtlsdr_stub_status(void) {
     const char* env = getenv("DSD_NEO_RTLSDR_STUB_STATUS");
     if (env && *env != '\0') {
-        return atoi(env);
+        int parsed = 0;
+        if (dsd_parse_int_strict(env, 10, INT_MIN, INT_MAX, &parsed) == 0) {
+            return parsed;
+        }
     }
     return -1;
 }
@@ -118,9 +121,9 @@ static uint32_t
 rtlsdr_stub_sample_rate(void) {
     const char* env = getenv("DSD_NEO_RTLSDR_STUB_SAMPLE_RATE_HZ");
     if (env && *env != '\0') {
-        long parsed = strtol(env, NULL, 10);
-        if (parsed > 0L) {
-            return (uint32_t)parsed;
+        uint32_t parsed = 0;
+        if (dsd_parse_uint32_strict(env, 10, UINT32_MAX, &parsed) == 0 && parsed > 0U) {
+            return parsed;
         }
     }
     return 0U;
@@ -130,7 +133,10 @@ static int
 rtlsdr_stub_tuner_type(void) {
     const char* env = getenv("DSD_NEO_RTLSDR_STUB_TUNER_TYPE");
     if (env && *env != '\0') {
-        return atoi(env);
+        int parsed = RTLSDR_TUNER_UNKNOWN;
+        if (dsd_parse_int_strict(env, 10, INT_MIN, INT_MAX, &parsed) == 0) {
+            return parsed;
+        }
     }
     return RTLSDR_TUNER_UNKNOWN;
 }
@@ -670,29 +676,46 @@ rtl_accumulate_ring_drops(struct input_ring_state* ring, size_t dropped) {
     ring->producer_drops.fetch_add((uint64_t)dropped);
 }
 
+namespace {
+
+struct rtl_u8_write_cursor {
+    unsigned char* src;
+    size_t* done;
+    size_t* need;
+    struct rtl_capture_u8_byte_carry* carry;
+    int* phase;
+    int fs4_shift_active;
+    int combine_rotate_active;
+    int use_two_pass;
+};
+
+} // namespace
+
 static inline void
-rtl_write_u8_reserved_segment(const struct rtl_device* s, unsigned char* src, size_t* io_done, size_t* io_need,
-                              struct rtl_capture_u8_byte_carry* carry, float* dst, size_t produced_bytes,
-                              int fs4_shift_active, int combine_rotate_active, int use_two_pass, int* phase) {
-    if (!s || !src || !io_done || !io_need || !carry || !dst || !phase || produced_bytes == 0U) {
+rtl_write_u8_reserved_segment(const struct rtl_device* s, const rtl_u8_write_cursor* cursor, float* dst,
+                              size_t produced_bytes) {
+    if (!s || !cursor || !cursor->src || !cursor->done || !cursor->need || !cursor->carry || !dst || !cursor->phase
+        || produced_bytes == 0U) {
         return;
     }
 
     unsigned char pair[2];
-    size_t prefix = rtl_capture_u8_byte_carry_consume_prefix(src + *io_done, *io_need, carry, pair);
+    size_t prefix =
+        rtl_capture_u8_byte_carry_consume_prefix(cursor->src + *cursor->done, *cursor->need, cursor->carry, pair);
     size_t from_prefix = 0U;
     if (prefix != 0U) {
-        rtl_process_u8_chunk(s, pair, dst, 2U, fs4_shift_active, combine_rotate_active, use_two_pass, phase);
-        *io_done += prefix;
-        *io_need -= prefix;
+        rtl_process_u8_chunk(s, pair, dst, 2U, cursor->fs4_shift_active, cursor->combine_rotate_active,
+                             cursor->use_two_pass, cursor->phase);
+        *cursor->done += prefix;
+        *cursor->need -= prefix;
         from_prefix = 2U;
     }
     if (produced_bytes > from_prefix) {
         size_t body = produced_bytes - from_prefix;
-        rtl_process_u8_chunk(s, src + *io_done, dst + from_prefix, body, fs4_shift_active, combine_rotate_active,
-                             use_two_pass, phase);
-        *io_done += body;
-        *io_need -= body;
+        rtl_process_u8_chunk(s, cursor->src + *cursor->done, dst + from_prefix, body, cursor->fs4_shift_active,
+                             cursor->combine_rotate_active, cursor->use_two_pass, cursor->phase);
+        *cursor->done += body;
+        *cursor->need -= body;
     }
 }
 
@@ -708,30 +731,47 @@ rtl_handle_u8_ring_generation_stale(const struct rtl_device* s, const unsigned c
     return 1;
 }
 
+namespace {
+
+struct rtl_u8_finalize_state {
+    const unsigned char* src;
+    size_t len;
+    size_t done;
+    size_t need;
+    struct rtl_capture_u8_byte_carry* carry;
+    int* phase;
+    int fs4_shift_active;
+    int count_full_reserve;
+    int ring_exhausted;
+    int generation_stale;
+};
+
+} // namespace
+
 static inline void
-rtl_finalize_u8_ring_write(struct rtl_device* s, const unsigned char* src, size_t len, size_t done, size_t need,
-                           struct rtl_capture_u8_byte_carry* carry, int* phase, int fs4_shift_active,
-                           int count_full_reserve, int ring_exhausted, int generation_stale) {
-    if (!s || !src || !carry || !phase) {
+rtl_finalize_u8_ring_write(struct rtl_device* s, const rtl_u8_finalize_state* final_state) {
+    if (!s || !final_state || !final_state->src || !final_state->carry || !final_state->phase) {
         return;
     }
 
-    if (generation_stale) {
-        rtl_clear_capture_alignment_after_discard(s, carry);
-    } else if (ring_exhausted) {
-        size_t dropped = rtl_drop_u8_bytes_preserve_alignment(src + done, need, carry, phase, fs4_shift_active);
+    if (final_state->generation_stale) {
+        rtl_clear_capture_alignment_after_discard(s, final_state->carry);
+    } else if (final_state->ring_exhausted) {
+        size_t dropped =
+            rtl_drop_u8_bytes_preserve_alignment(final_state->src + final_state->done, final_state->need,
+                                                 final_state->carry, final_state->phase, final_state->fs4_shift_active);
         rtl_accumulate_ring_drops(s->input_ring, dropped);
-        if (count_full_reserve) {
+        if (final_state->count_full_reserve) {
             s->reserve_full_events++;
         }
-    } else if (need == 1U && done < len && !carry->valid) {
-        rtl_capture_u8_byte_carry_save(carry, src[done]);
+    } else if (final_state->need == 1U && final_state->done < final_state->len && !final_state->carry->valid) {
+        rtl_capture_u8_byte_carry_save(final_state->carry, final_state->src[final_state->done]);
     }
 
-    if (!generation_stale) {
-        s->iq_byte_carry = *carry;
-        if (fs4_shift_active) {
-            s->rot_phase = *phase;
+    if (!final_state->generation_stale) {
+        s->iq_byte_carry = *final_state->carry;
+        if (final_state->fs4_shift_active) {
+            s->rot_phase = *final_state->phase;
         }
     }
 }
@@ -773,10 +813,10 @@ rtl_write_u8_to_ring(struct rtl_device* s, unsigned char* src, size_t len, int f
             break;
         }
 
-        rtl_write_u8_reserved_segment(s, src, &done, &need, &carry, p1, w1, fs4_shift_active, combine_rotate_active,
-                                      use_two_pass, &phase);
-        rtl_write_u8_reserved_segment(s, src, &done, &need, &carry, p2, w2, fs4_shift_active, combine_rotate_active,
-                                      use_two_pass, &phase);
+        rtl_u8_write_cursor cursor = {
+            src, &done, &need, &carry, &phase, fs4_shift_active, combine_rotate_active, use_two_pass};
+        rtl_write_u8_reserved_segment(s, &cursor, p1, w1);
+        rtl_write_u8_reserved_segment(s, &cursor, p2, w2);
 
         if (!input_ring_discard_generation_matches(s->input_ring, discard_generation)) {
             generation_stale =
@@ -786,8 +826,9 @@ rtl_write_u8_to_ring(struct rtl_device* s, unsigned char* src, size_t len, int f
         input_ring_commit(s->input_ring, produced);
     }
 
-    rtl_finalize_u8_ring_write(s, src, len, done, need, &carry, &phase, fs4_shift_active, count_full_reserve,
-                               ring_exhausted, generation_stale);
+    rtl_u8_finalize_state final_state = {
+        src, len, done, need, &carry, &phase, fs4_shift_active, count_full_reserve, ring_exhausted, generation_stale};
+    rtl_finalize_u8_ring_write(s, &final_state);
     if (perf_on) {
         uint64_t drops_after = s->input_ring->producer_drops.load(std::memory_order_relaxed);
         uint64_t drops_delta = (drops_after >= perf_drops_before) ? (drops_after - perf_drops_before) : 0ULL;
@@ -1391,18 +1432,31 @@ replay_reserve_and_submit_chunk(struct rtl_device* s, const float* src, size_t s
     return 0;
 }
 
+namespace {
+
+struct replay_thread_io_state {
+    int* phase;
+    int* have_carry;
+    uint8_t* carry_byte;
+    uint64_t* complex_written;
+    uint64_t* data_offset;
+    uint32_t* event_cursor;
+    uint64_t* start_ns;
+    int realtime;
+};
+
+} // namespace
+
 static inline int
 replay_thread_process_inputs_valid(const struct rtl_device* s, const uint8_t* raw_block, const float* f32_block,
-                                   const int* phase, const int* have_carry, const uint8_t* carry_byte,
-                                   const uint64_t* complex_written, const uint64_t* data_offset,
-                                   const uint32_t* event_cursor, const uint64_t* start_ns) {
+                                   const replay_thread_io_state* io) {
     if (!s || !raw_block || !f32_block) {
         return 0;
     }
-    if (!phase || !have_carry || !carry_byte) {
+    if (!io || !io->phase || !io->have_carry || !io->carry_byte) {
         return 0;
     }
-    if (!complex_written || !data_offset || !event_cursor || !start_ns) {
+    if (!io->complex_written || !io->data_offset || !io->event_cursor || !io->start_ns) {
         return 0;
     }
     return 1;
@@ -1410,11 +1464,9 @@ replay_thread_process_inputs_valid(const struct rtl_device* s, const uint8_t* ra
 
 static inline int
 replay_thread_read_or_handle_empty(struct rtl_device* s, uint8_t* raw_block, size_t read_limit,
-                                   uint64_t* io_data_offset, uint64_t* io_complex_written, uint64_t* io_start_ns,
-                                   int realtime, int* io_phase, int* io_have_carry, uint8_t* io_carry_byte,
-                                   uint32_t* io_event_cursor, size_t* out_bytes) {
-    if (!s || !raw_block || !io_data_offset || !io_complex_written || !io_start_ns || !io_phase || !io_have_carry
-        || !io_carry_byte || !io_event_cursor || !out_bytes) {
+                                   replay_thread_io_state* io, size_t* out_bytes) {
+    if (!s || !raw_block || !io || !io->data_offset || !io->complex_written || !io->start_ns || !io->phase
+        || !io->have_carry || !io->carry_byte || !io->event_cursor || !out_bytes) {
         return 0;
     }
     *out_bytes = 0U;
@@ -1423,39 +1475,35 @@ replay_thread_read_or_handle_empty(struct rtl_device* s, uint8_t* raw_block, siz
         return 0;
     }
     if (*out_bytes == 0U) {
-        if (!replay_handle_empty_read(s, io_complex_written, io_start_ns, realtime, io_phase, io_have_carry,
-                                      io_carry_byte, io_data_offset, io_event_cursor)) {
+        if (!replay_handle_empty_read(s, io->complex_written, io->start_ns, io->realtime, io->phase, io->have_carry,
+                                      io->carry_byte, io->data_offset, io->event_cursor)) {
             return 0;
         }
         return 2;
     }
-    *io_data_offset += (uint64_t)(*out_bytes);
+    *io->data_offset += (uint64_t)(*out_bytes);
     return 1;
 }
 
 static int
 replay_thread_process_block(struct rtl_device* s, uint8_t* raw_block, size_t raw_block_bytes, float* f32_block,
-                            int* io_phase, int* io_have_carry, uint8_t* io_carry_byte, uint64_t* io_complex_written,
-                            uint64_t* io_data_offset, uint32_t* io_event_cursor, uint64_t* io_start_ns, int realtime) {
-    if (!replay_thread_process_inputs_valid(s, raw_block, f32_block, io_phase, io_have_carry, io_carry_byte,
-                                            io_complex_written, io_data_offset, io_event_cursor, io_start_ns)) {
+                            replay_thread_io_state* io) {
+    if (!replay_thread_process_inputs_valid(s, raw_block, f32_block, io)) {
         return 0;
     }
 
-    if (!replay_dispatch_pending_events(s, io_event_cursor, *io_data_offset, io_phase, io_have_carry, io_carry_byte,
-                                        io_complex_written)) {
+    if (!replay_dispatch_pending_events(s, io->event_cursor, *io->data_offset, io->phase, io->have_carry,
+                                        io->carry_byte, io->complex_written)) {
         return 0;
     }
 
-    size_t read_limit = replay_next_read_limit(s, *io_data_offset, *io_event_cursor, raw_block_bytes);
+    size_t read_limit = replay_next_read_limit(s, *io->data_offset, *io->event_cursor, raw_block_bytes);
     if (read_limit == 0U) {
         return 2;
     }
 
     size_t out_bytes = 0U;
-    int read_status = replay_thread_read_or_handle_empty(s, raw_block, read_limit, io_data_offset, io_complex_written,
-                                                         io_start_ns, realtime, io_phase, io_have_carry, io_carry_byte,
-                                                         io_event_cursor, &out_bytes);
+    int read_status = replay_thread_read_or_handle_empty(s, raw_block, read_limit, io, &out_bytes);
     if (read_status == 0) {
         return 0;
     }
@@ -1463,13 +1511,14 @@ replay_thread_process_block(struct rtl_device* s, uint8_t* raw_block, size_t raw
         return 2;
     }
 
-    int produced = replay_convert_block_to_f32(s, raw_block, out_bytes, f32_block, raw_block_bytes, io_phase,
-                                               io_have_carry, io_carry_byte);
+    int produced = replay_convert_block_to_f32(s, raw_block, out_bytes, f32_block, raw_block_bytes, io->phase,
+                                               io->have_carry, io->carry_byte);
     if (produced <= 0) {
         return 2;
     }
 
-    if (replay_enqueue_f32_no_drop(s, f32_block, (size_t)produced, io_complex_written, *io_start_ns, realtime) != 0) {
+    if (replay_enqueue_f32_no_drop(s, f32_block, (size_t)produced, io->complex_written, *io->start_ns, io->realtime)
+        != 0) {
         return 0;
     }
     return 1;
@@ -1939,9 +1988,9 @@ static DSD_THREAD_RETURN_TYPE
     int realtime = s->replay_cfg.realtime ? 1 : 0;
 
     while (!replay_forced_stop_requested(s)) {
-        int step =
-            replay_thread_process_block(s, raw_block, raw_block_bytes, f32_block, &phase, &have_carry, &carry_byte,
-                                        &complex_written, &data_offset, &event_cursor, &start_ns, realtime);
+        replay_thread_io_state io = {&phase,       &have_carry,   &carry_byte, &complex_written,
+                                     &data_offset, &event_cursor, &start_ns,   realtime};
+        int step = replay_thread_process_block(s, raw_block, raw_block_bytes, f32_block, &io);
         if (step == 0) {
             break;
         }
@@ -3914,11 +3963,8 @@ rtl_device_create_tcp(const char* host, int port, struct input_ring_state* input
     return dev;
 }
 
-struct rtl_device*
-rtl_device_create_soapy(const char* soapy_args, struct input_ring_state* input_ring, int combine_rotate_enabled) {
-    if (!input_ring) {
-        return NULL;
-    }
+static struct rtl_device*
+rtl_device_alloc_soapy_base(struct input_ring_state* input_ring, int combine_rotate_enabled) {
     struct rtl_device* dev = static_cast<rtl_device*>(calloc(1, sizeof(struct rtl_device)));
     if (!dev) {
         return NULL;
@@ -3927,22 +3973,34 @@ rtl_device_create_soapy(const char* soapy_args, struct input_ring_state* input_r
     dev->dev = NULL;
     dev->dev_index = -1;
     dev->input_ring = input_ring;
-    dev->thread_started = 0;
-    dev->mute = 0;
-    dev->mute_byte_phase = 0;
     dev->combine_rotate_enabled = combine_rotate_enabled;
     dev->backend = RTL_BACKEND_SOAPY;
-    dev->soapy_dev = NULL;
-    dev->soapy_stream = NULL;
     dev->soapy_format = SOAPY_FMT_NONE;
-    dev->soapy_mtu_elems = 0;
-    dev->rot_phase = 0;
     rtl_capture_u8_byte_carry_clear(&dev->iq_byte_carry);
     dev->sockfd = DSD_INVALID_SOCKET;
     dev->host[0] = '\0';
-    dev->port = 0;
     dev->run.store(0);
     dev->agc_mode = 1;
+    return dev;
+}
+
+struct rtl_device*
+rtl_device_create_soapy(const char* soapy_args, struct input_ring_state* input_ring, int combine_rotate_enabled) {
+    if (!input_ring) {
+        return NULL;
+    }
+    struct rtl_device* dev = rtl_device_alloc_soapy_base(input_ring, combine_rotate_enabled);
+    if (!dev) {
+        return NULL;
+    }
+    dev->thread_started = 0;
+    dev->mute = 0;
+    dev->mute_byte_phase = 0;
+    dev->soapy_dev = NULL;
+    dev->soapy_stream = NULL;
+    dev->soapy_mtu_elems = 0;
+    dev->rot_phase = 0;
+    dev->port = 0;
     dev->offset_tuning = 0;
     dev->testmode_on = 0;
     dev->rtl_xtal_hz = 0;

--- a/src/io/radio/rtl_perf.cpp
+++ b/src/io/radio/rtl_perf.cpp
@@ -174,10 +174,8 @@ rtl_perf_record_consumer_read(uint64_t elapsed_ns, size_t output_samples) {
 }
 
 extern "C" void
-rtl_perf_maybe_log(const char* source, uint32_t sample_rate_hz, int output_kind, size_t input_used,
-                   size_t input_capacity, uint64_t input_drops, size_t output_used, size_t output_capacity,
-                   int symbol_cache_pending, double snr_db, double cfo_hz, int carrier_lock) {
-    if (!rtl_perf_enabled()) {
+rtl_perf_maybe_log(const rtl_perf_log_snapshot* snapshot) {
+    if (!snapshot || !rtl_perf_enabled()) {
         return;
     }
 
@@ -213,11 +211,12 @@ rtl_perf_maybe_log(const char* source, uint32_t sample_rate_hz, int output_kind,
                 "%" PRIu64 ",%s,%" PRIu32 ",%d,%zu,%zu,%" PRIu64 ",%zu,%zu,%d,%" PRIu64 ",%" PRIu64 ",%" PRIu64
                 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64
                 ",%" PRIu64 ",%" PRIu64 ",%.3f,%.3f,%d\n",
-                (uint64_t)(now_ns / 1000000ULL), source ? source : "unknown", sample_rate_hz, output_kind, input_used,
-                input_capacity, input_drops, output_used, output_capacity, symbol_cache_pending, ingest_blocks,
-                ingest_samples, ingest_drops, ingest_ns, demod_blocks, demod_input_samples, demod_output_samples,
-                full_demod_ns, post_metrics_ns, output_write_ns, consumer_reads, consumer_samples, consumer_read_ns,
-                snr_db, cfo_hz, carrier_lock);
+                (uint64_t)(now_ns / 1000000ULL), snapshot->source ? snapshot->source : "unknown",
+                snapshot->sample_rate_hz, snapshot->output_kind, snapshot->input_used, snapshot->input_capacity,
+                snapshot->input_drops, snapshot->output_used, snapshot->output_capacity, snapshot->symbol_cache_pending,
+                ingest_blocks, ingest_samples, ingest_drops, ingest_ns, demod_blocks, demod_input_samples,
+                demod_output_samples, full_demod_ns, post_metrics_ns, output_write_ns, consumer_reads, consumer_samples,
+                consumer_read_ns, snapshot->snr_db, snapshot->cfo_hz, snapshot->carrier_lock);
     fflush(g_perf_file);
     g_perf_next_log_ns = now_ns + g_perf_interval_ns;
 }

--- a/src/io/radio/rtl_perf.h
+++ b/src/io/radio/rtl_perf.h
@@ -21,9 +21,22 @@ void rtl_perf_record_demod_block(uint64_t full_demod_ns, uint64_t post_metrics_n
                                  size_t input_samples, size_t output_samples);
 void rtl_perf_record_consumer_read(uint64_t elapsed_ns, size_t output_samples);
 
-void rtl_perf_maybe_log(const char* source, uint32_t sample_rate_hz, int output_kind, size_t input_used,
-                        size_t input_capacity, uint64_t input_drops, size_t output_used, size_t output_capacity,
-                        int symbol_cache_pending, double snr_db, double cfo_hz, int carrier_lock);
+typedef struct {
+    const char* source;
+    uint32_t sample_rate_hz;
+    int output_kind;
+    size_t input_used;
+    size_t input_capacity;
+    uint64_t input_drops;
+    size_t output_used;
+    size_t output_capacity;
+    int symbol_cache_pending;
+    double snr_db;
+    double cfo_hz;
+    int carrier_lock;
+} rtl_perf_log_snapshot;
+
+void rtl_perf_maybe_log(const rtl_perf_log_snapshot* snapshot);
 void rtl_perf_shutdown(void);
 
 #ifdef __cplusplus

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -3108,10 +3108,21 @@ demod_perf_log_block(int perf_on, uint64_t perf_output_start_ns, uint64_t perf_f
     rtl_perf_record_demod_block(perf_full_demod_ns, perf_metrics_ns, perf_output_write_ns, (size_t)got,
                                 perf_output_samples);
     double snr_db = demod_perf_pick_snr_db(d);
-    rtl_perf_maybe_log(rtl_perf_source_name(), load_dongle_rate(), d->output_kind, input_ring_used(&input_ring),
-                       input_ring.capacity, input_ring.producer_drops.load(std::memory_order_relaxed),
-                       ring_used(&output), output.capacity, -1, snr_db, dsd_rtl_stream_get_cfo_hz(),
-                       dsd_rtl_stream_get_carrier_lock());
+    rtl_perf_log_snapshot snapshot = {
+        rtl_perf_source_name(),
+        load_dongle_rate(),
+        d->output_kind,
+        input_ring_used(&input_ring),
+        input_ring.capacity,
+        input_ring.producer_drops.load(std::memory_order_relaxed),
+        ring_used(&output),
+        output.capacity,
+        -1,
+        snr_db,
+        dsd_rtl_stream_get_cfo_hz(),
+        dsd_rtl_stream_get_carrier_lock(),
+    };
+    rtl_perf_maybe_log(&snapshot);
 }
 
 static int
@@ -4153,28 +4164,50 @@ snr_qpsk_error_diag(const float* xy, int n, double aD) {
     return e2;
 }
 
+namespace {
+
+struct snr_eye_gfsk_window {
+    int two_sps;
+    int c1;
+    int c2;
+    int win;
+    float q2;
+};
+
+} // namespace
+
+namespace {
+
+struct snr_eye_gfsk_sums {
+    double sumL;
+    double sumH;
+    int cntL;
+    int cntH;
+};
+
+} // namespace
+
 static int
-snr_eye_gfsk_collect_binary(const float* eb, int nfb, int two_sps, int c1, int c2, int win, float q2, double* sumL,
-                            double* sumH, int* cntL, int* cntH) {
-    *sumL = 0.0;
-    *sumH = 0.0;
-    *cntL = 0;
-    *cntH = 0;
+snr_eye_gfsk_collect_binary(const float* eb, int nfb, const snr_eye_gfsk_window* window, snr_eye_gfsk_sums* sums) {
+    sums->sumL = 0.0;
+    sums->sumH = 0.0;
+    sums->cntL = 0;
+    sums->cntH = 0;
     for (int i = 0; i < nfb; i++) {
-        int phase = i % two_sps;
-        if (!snr_eye_phase_in_window(phase, c1, c2, win)) {
+        int phase = i % window->two_sps;
+        if (!snr_eye_phase_in_window(phase, window->c1, window->c2, window->win)) {
             continue;
         }
         float v = eb[i];
-        if (v <= q2) {
-            *sumL += v;
-            (*cntL)++;
+        if (v <= window->q2) {
+            sums->sumL += v;
+            sums->cntL++;
         } else {
-            *sumH += v;
-            (*cntH)++;
+            sums->sumH += v;
+            sums->cntH++;
         }
     }
-    return (*cntL > 0 && *cntH > 0) ? 1 : 0;
+    return (sums->cntL > 0 && sums->cntH > 0) ? 1 : 0;
 }
 
 static double
@@ -4302,21 +4335,20 @@ dsd_rtl_stream_estimate_snr_gfsk_eye(void) {
     if (!snr_eye_median(qv, mct, &q2)) {
         return -100.0;
     }
-    double sumL = 0.0;
-    double sumH = 0.0;
-    int cntL = 0;
-    int cntH = 0;
-    if (!snr_eye_gfsk_collect_binary(eb, nfb, two_sps, c1, c2, win, q2, &sumL, &sumH, &cntL, &cntH)) {
+    snr_eye_gfsk_window window = {two_sps, c1, c2, win, q2};
+    snr_eye_gfsk_sums sums;
+    if (!snr_eye_gfsk_collect_binary(eb, nfb, &window, &sums)) {
         return -100.0;
     }
-    double muL = sumL / (double)cntL, muH = sumH / (double)cntH;
-    int total = cntL + cntH;
+    double muL = sums.sumL / (double)sums.cntL, muH = sums.sumH / (double)sums.cntH;
+    int total = sums.cntL + sums.cntH;
     double noise_var = snr_eye_gfsk_noise_variance(eb, nfb, two_sps, c1, c2, win, q2, muL, muH, total);
     if (noise_var <= 1e-9) {
         return -100.0;
     }
-    double mu_all = (muL * (double)cntL + muH * (double)cntH) / (double)total;
-    double ssum = (double)cntL * (muL - mu_all) * (muL - mu_all) + (double)cntH * (muH - mu_all) * (muH - mu_all);
+    double mu_all = (muL * (double)sums.cntL + muH * (double)sums.cntH) / (double)total;
+    double ssum =
+        (double)sums.cntL * (muL - mu_all) * (muL - mu_all) + (double)sums.cntH * (muH - mu_all) * (muH - mu_all);
     double sig_var = ssum / (double)total;
     if (sig_var <= 1e-9) {
         return -100.0;

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(
     dsd-neo_platform
     PRIVATE
         audio_concealment.c
+        nonce.c
         ${PROJECT_SOURCE_DIR}/src/io/radio/tcp_quality_metrics.cpp
         ${PROJECT_SOURCE_DIR}/src/runtime/input_ring_watermark.cpp
 )

--- a/src/platform/file_compat_posix.c
+++ b/src/platform/file_compat_posix.c
@@ -115,6 +115,47 @@ dsd_fopen_private(const char* path, const char* mode) {
     return fp;
 }
 
+FILE*
+dsd_fopen_existing_regular_file(const char* path, const char* mode) {
+    if (!path || path[0] == '\0' || !mode || mode[0] != 'r' || strchr(mode, '+') != NULL) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    int flags = O_RDONLY;
+#ifdef O_NOFOLLOW
+    flags |= O_NOFOLLOW;
+#endif
+#ifdef O_CLOEXEC
+    flags |= O_CLOEXEC;
+#endif
+    int fd = open(path, flags);
+    if (fd < 0) {
+        return NULL;
+    }
+
+    dsd_stat_t st;
+    if (fstat(fd, &st) != 0) {
+        int saved_errno = errno ? errno : EINVAL;
+        close(fd);
+        errno = saved_errno;
+        return NULL;
+    }
+    if (!dsd_stat_is_regular(&st)) {
+        close(fd);
+        errno = EINVAL;
+        return NULL;
+    }
+
+    FILE* fp = fdopen(fd, mode);
+    if (!fp) {
+        int saved_errno = errno ? errno : EINVAL;
+        close(fd);
+        errno = saved_errno;
+    }
+    return fp;
+}
+
 static void
 dsd_set_cloexec_best_effort(int fd) {
 #ifdef FD_CLOEXEC

--- a/src/platform/file_compat_win32.c
+++ b/src/platform/file_compat_win32.c
@@ -115,6 +115,77 @@ dsd_fopen_private(const char* path, const char* mode) {
     return fp;
 }
 
+static int
+dsd_existing_regular_mode_flags(const char* mode, int* out_flags) {
+    if (!mode || mode[0] != 'r' || strchr(mode, '+') != NULL || !out_flags) {
+        errno = EINVAL;
+        return -1;
+    }
+    *out_flags = _O_RDONLY | _O_NOINHERIT | ((strchr(mode, 'b') != NULL) ? _O_BINARY : _O_TEXT);
+    return 0;
+}
+
+static int
+dsd_existing_regular_attrs_ok(const char* path) {
+    DWORD attrs = GetFileAttributesA(path);
+    if (attrs == INVALID_FILE_ATTRIBUTES || (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0
+        || (attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+static int
+dsd_open_existing_regular_fd_win32(const char* path, const char* mode) {
+    if (!path || path[0] == '\0' || !mode || mode[0] != 'r' || strchr(mode, '+') != NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (dsd_existing_regular_attrs_ok(path) != 0) {
+        return -1;
+    }
+
+    int flags = 0;
+    if (dsd_existing_regular_mode_flags(mode, &flags) != 0) {
+        return -1;
+    }
+    int fd = _open(path, flags);
+    if (fd < 0) {
+        return -1;
+    }
+
+    dsd_stat_t st;
+    if (_fstat(fd, &st) != 0) {
+        int saved_errno = errno ? errno : EINVAL;
+        _close(fd);
+        errno = saved_errno;
+        return -1;
+    }
+    if (!dsd_stat_is_regular(&st)) {
+        _close(fd);
+        errno = EINVAL;
+        return -1;
+    }
+    return fd;
+}
+
+FILE*
+dsd_fopen_existing_regular_file(const char* path, const char* mode) {
+    int fd = dsd_open_existing_regular_fd_win32(path, mode);
+    if (fd < 0) {
+        return NULL;
+    }
+
+    FILE* fp = _fdopen(fd, mode);
+    if (!fp) {
+        int saved_errno = errno ? errno : EINVAL;
+        _close(fd);
+        errno = saved_errno;
+    }
+    return fp;
+}
+
 FILE*
 dsd_fopen_private_temp_for_replace(const char* final_path, char* tmp_path, size_t tmp_path_size, const char* mode) {
     if (!final_path || final_path[0] == '\0' || !tmp_path || tmp_path_size == 0 || !mode || mode[0] == 'r') {

--- a/src/platform/nonce.c
+++ b/src/platform/nonce.c
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/platform/atomic_compat.h>
+#include <dsd-neo/platform/nonce.h>
+#include <dsd-neo/platform/timing.h>
+#include <stddef.h>
+#include <stdint.h>
+
+static dsd_atomic_u64 g_nonce_counter = {0x9E3779B97F4A7C15ULL};
+
+static uint64_t
+nonce_mix64(uint64_t x) {
+    x ^= x >> 30U;
+    x *= 0xBF58476D1CE4E5B9ULL;
+    x ^= x >> 27U;
+    x *= 0x94D049BB133111EBULL;
+    x ^= x >> 31U;
+    return x;
+}
+
+void
+dsd_nonce_fill(void* out, size_t size) {
+    if (!out || size == 0) {
+        return;
+    }
+
+    unsigned char* dst = (unsigned char*)out;
+    uintptr_t addr = (uintptr_t)&dst;
+    uint64_t seed = dsd_time_monotonic_ns() ^ ((uint64_t)addr << 1U);
+    seed ^= dsd_atomic_u64_fetch_add_relaxed(&g_nonce_counter, 0x9E3779B97F4A7C15ULL);
+
+    while (size > 0) {
+        seed = nonce_mix64(seed + 0xD1B54A32D192ED03ULL);
+        unsigned char block[sizeof(seed)];
+        DSD_MEMCPY(block, &seed, sizeof(block));
+        size_t n = (size < sizeof(block)) ? size : sizeof(block);
+        DSD_MEMCPY(dst, block, n);
+        dst += n;
+        size -= n;
+    }
+}
+
+uint16_t
+dsd_nonce_u16(void) {
+    uint16_t value = 0;
+    dsd_nonce_fill(&value, sizeof(value));
+    return value;
+}

--- a/src/platform/posix_compat_posix.c
+++ b/src/platform/posix_compat_posix.c
@@ -9,6 +9,8 @@
 #endif
 
 #include <dsd-neo/platform/posix_compat.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -38,6 +40,15 @@ dsd_unsetenv(const char* name) {
 int
 dsd_mkdir(const char* path, int mode) {
     return mkdir(path, (mode_t)mode);
+}
+
+int
+dsd_open_serial_write(const char* path) {
+    if (!path || path[0] == '\0') {
+        errno = EINVAL;
+        return -1;
+    }
+    return open(path, O_WRONLY | O_NOCTTY);
 }
 
 void*

--- a/src/platform/posix_compat_win32.c
+++ b/src/platform/posix_compat_win32.c
@@ -170,6 +170,13 @@ dsd_mkdir(const char* path, int mode) {
     return _mkdir(path);
 }
 
+int
+dsd_open_serial_write(const char* path) {
+    (void)path;
+    errno = ENOSYS;
+    return -1;
+}
+
 void*
 dsd_aligned_alloc(size_t alignment, size_t size) {
     return _aligned_malloc(size, alignment);

--- a/src/protocol/dmr/dmr_pdu.c
+++ b/src/protocol/dmr/dmr_pdu.c
@@ -563,10 +563,22 @@ decode_ip_pdu_handle_udp(dsd_opts* opts, dsd_state* state, uint8_t slot, uint32_
     decode_ip_pdu_handle_udp_service(opts, state, slot, src24, dst24, dst_port, payload_len, payload, input);
 }
 
+typedef struct {
+    uint8_t version;
+    uint8_t ihl;
+    uint8_t tos;
+    uint16_t tlen;
+    uint16_t iden;
+    uint8_t ipf;
+    uint16_t offset;
+    uint8_t ttl;
+    uint8_t prot;
+    uint16_t hsum;
+    uint16_t len;
+} dmr_ip_pdu_header;
+
 static void DSD_ATTR_USED
-decode_ip_pdu_print_header(const dsd_opts* opts, uint8_t version, uint8_t ihl, uint8_t tos, uint16_t tlen,
-                           uint16_t iden, uint8_t ipf, uint16_t offset, uint8_t ttl, uint8_t prot, uint16_t hsum,
-                           uint16_t len) {
+decode_ip_pdu_print_header(const dsd_opts* opts, const dmr_ip_pdu_header* hdr) {
     if (opts->payload != 1) {
         return;
     }
@@ -574,7 +586,8 @@ decode_ip_pdu_print_header(const dsd_opts* opts, uint8_t version, uint8_t ihl, u
         stderr,
         "\n IPv%d; IHL: %d; Type of Service: %d; Total Len: %d; IP ID: %04X; Flags: %X;\n Fragment Offset: %d; TTL: "
         "%d; Protocol: 0x%02X; Checksum: %04X; PDU Len: %d;",
-        version, ihl, tos, tlen, iden, ipf, offset, ttl, prot, hsum, len);
+        hdr->version, hdr->ihl, hdr->tos, hdr->tlen, hdr->iden, hdr->ipf, hdr->offset, hdr->ttl, hdr->prot, hdr->hsum,
+        hdr->len);
 }
 
 static void
@@ -653,7 +666,8 @@ decode_ip_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, uint8_t* input) {
             effective_len = (size_t)tlen;
         }
     }
-    decode_ip_pdu_print_header(opts, version, ihl, tos, tlen, iden, ipf, offset, ttl, prot, hsum, len);
+    dmr_ip_pdu_header hdr = {version, ihl, tos, tlen, iden, ipf, offset, ttl, prot, hsum, len};
+    decode_ip_pdu_print_header(opts, &hdr);
 
     uint32_t src24 = (uint32_t)((input[13] << 16) | (input[14] << 8) | input[15]);
     uint32_t dst24 = (uint32_t)((input[17] << 16) | (input[18] << 8) | input[19]);
@@ -1149,20 +1163,27 @@ dmr_lrrp_build_summary(char* out, size_t out_sz, const dmr_lrrp_parse_result* be
     }
 }
 
+typedef struct {
+    uint32_t source;
+    uint32_t dest;
+    uint8_t is_request;
+    uint8_t is_response;
+    uint8_t lrrp_type;
+} dmr_lrrp_emit_context;
+
 static void
 dmr_lrrp_emit_payload(const dsd_opts* opts, dsd_state* state, uint8_t slot, const dmr_lrrp_parse_result* best,
-                      uint8_t payload_len, uint8_t pdu_crc_ok, uint32_t source, uint32_t dest, uint8_t is_request,
-                      uint8_t is_response, uint8_t lrrp_type) {
+                      uint8_t payload_len, uint8_t pdu_crc_ok, const dmr_lrrp_emit_context* ctx) {
     if (payload_len == 0) {
         DSD_SNPRINTF(state->dmr_lrrp_gps[slot], sizeof state->dmr_lrrp_gps[slot],
-                     "LRRP SRC: %0d; Unknown Format %02X; TGT: %d;", source, lrrp_type, dest);
+                     "LRRP SRC: %0d; Unknown Format %02X; TGT: %d;", ctx->source, ctx->lrrp_type, ctx->dest);
         DSD_FPRINTF(stderr, "\n %s", state->dmr_lrrp_gps[slot]);
         return;
     }
     dmr_lrrp_scaled s = dmr_lrrp_compute_scaled(best);
     DSD_FPRINTF(stderr, "%s", KYEL);
     dmr_lrrp_print_details(best, &s, pdu_crc_ok);
-    dmr_lrrp_write_file_if_needed(opts, best, &s, pdu_crc_ok, source);
+    dmr_lrrp_write_file_if_needed(opts, best, &s, pdu_crc_ok, ctx->source);
 
     char lrrpstr[100];
     char velstr[20];
@@ -1170,8 +1191,8 @@ dmr_lrrp_emit_payload(const dsd_opts* opts, dsd_state* state, uint8_t slot, cons
     lrrpstr[0] = '\0';
     velstr[0] = '\0';
     degstr[0] = '\0';
-    dmr_lrrp_build_summary(lrrpstr, sizeof lrrpstr, best, &s, source, dest, is_request, is_response, lrrp_type,
-                           pdu_crc_ok);
+    dmr_lrrp_build_summary(lrrpstr, sizeof lrrpstr, best, &s, ctx->source, ctx->dest, ctx->is_request, ctx->is_response,
+                           ctx->lrrp_type, pdu_crc_ok);
     if (best->vel_set) {
         DSD_SNPRINTF(velstr, sizeof velstr, " %.2lf km/h", best->velocity_mph * 1.60934);
     }
@@ -1217,8 +1238,8 @@ dmr_lrrp(const dsd_opts* opts, dsd_state* state, uint16_t len, uint32_t source, 
     if (!source) {
         source = (uint32_t)state->dmr_lrrp_source[state->currentslot];
     }
-    dmr_lrrp_emit_payload(opts, state, slot, &best, payload_len, pdu_crc_ok, source, dest, is_request, is_response,
-                          lrrp_type);
+    dmr_lrrp_emit_context emit_ctx = {source, dest, is_request, is_response, lrrp_type};
+    dmr_lrrp_emit_payload(opts, state, slot, &best, payload_len, pdu_crc_ok, &emit_ctx);
     DSD_FPRINTF(stderr, "%s", KNRM);
 }
 

--- a/src/protocol/m17/m17.c
+++ b/src/protocol/m17/m17.c
@@ -26,6 +26,7 @@
 #include <dsd-neo/fec/viterbi.h>
 #include <dsd-neo/platform/audio.h>
 #include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/nonce.h>
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
 #include <dsd-neo/protocol/m17/m17.h>
 #include <dsd-neo/protocol/m17/m17_parse.h>
@@ -80,15 +81,9 @@ clip_float_to_short(float v) {
     return (short)lrintf(v);
 }
 
-static unsigned int
-m17_seed_now(void) {
-    const time_t now = time(NULL);
-    const uintptr_t addr = (uintptr_t)&now;
-    const clock_t ticks = clock();
-    unsigned int seed = (unsigned int)now;
-    seed ^= (unsigned int)(addr >> 4);
-    seed ^= (unsigned int)ticks;
-    return seed;
+static void
+m17_assign_stream_id(uint8_t sid[2]) {
+    dsd_nonce_fill(sid, 2);
 }
 
 //from M17_Implementations / libM17 -- sp5wwp -- should have just looked here to begin with
@@ -2006,9 +2001,7 @@ m17_str_reset_tx_idle_state(m17_str_ctx* ctx) {
     ctx->state->carrier = 0;
     ctx->state->synctype = DSD_SYNC_NONE;
 
-    srand(m17_seed_now());
-    ctx->sid[0] = rand() & 0xFF;
-    ctx->sid[1] = rand() & 0xFF;
+    m17_assign_stream_id(ctx->sid);
 
     m17_attach_lsf_crc(ctx->m17_lsf, ctx->lsf_packed, &ctx->crc_cmp);
     m17_encode_lsf_for_rf(ctx->m17_lsf, ctx->m17_lsfs);
@@ -2133,9 +2126,7 @@ m17_str_init(m17_str_ctx* ctx, dsd_opts* opts, dsd_state* state) {
     m17_send_dead_air_frames(opts, state, ctx->nil, 25);
     ctx->use_ip = m17_open_udp_if_enabled(opts, state);
 
-    srand(m17_seed_now());
-    ctx->sid[0] = rand() & 0xFF;
-    ctx->sid[1] = rand() & 0xFF;
+    m17_assign_stream_id(ctx->sid);
 
 #ifdef USE_CODEC2
     if (ctx->st == 2) {
@@ -2453,9 +2444,7 @@ m17_pkt_send_mpkt_if_enabled(m17_pkt_ctx* ctx) {
         }
     }
 
-    srand(m17_seed_now());
-    ctx->sid[0] = rand() & 0xFF;
-    ctx->sid[1] = rand() & 0xFF;
+    m17_assign_stream_id(ctx->sid);
     for (int j = 0; j < 2; j++) {
         for (int i = 0; i < 8; i++) {
             ctx->m17_ip_frame[k++] = (ctx->sid[j] >> (7 - i)) & 1;

--- a/src/protocol/p25/p25_cc_candidates.c
+++ b/src/protocol/p25/p25_cc_candidates.c
@@ -81,7 +81,7 @@ p25_cc_try_load_cache(const dsd_opts* opts, dsd_state* state) {
     if (!p25_cc_build_cache_path(state, fpath, sizeof(fpath))) {
         return;
     }
-    FILE* fp = fopen(fpath, "r");
+    FILE* fp = dsd_fopen_existing_regular_file(fpath, "r");
     if (!fp) {
         state->p25_cc_cache_loaded = 1;
         return;

--- a/src/protocol/p25/p25_patch.c
+++ b/src/protocol/p25/p25_patch.c
@@ -14,6 +14,7 @@
 #include <time.h>
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/platform.h"
 
 #define P25_PATCH_TTL_SECONDS 20
 
@@ -198,6 +199,8 @@ p25_patch_add_wuid(dsd_state* state, int sgid, uint32_t wuid) {
         state->p25_patch_wuid_count[idx] = cnt + 1;
     }
 }
+
+static void p25_patch_append(char* out, size_t cap, int* n, const char* fmt, ...) DSD_ATTR_FORMAT(printf, 4, 5);
 
 static void
 p25_patch_append(char* out, size_t cap, int* n, const char* fmt, ...) {

--- a/src/protocol/p25/p25_test_shim.c
+++ b/src/protocol/p25/p25_test_shim.c
@@ -33,6 +33,72 @@ p25_test_free_state(dsd_state* state) {
     free(state);
 }
 
+static int
+p25_test_alloc_decode_context(dsd_opts** opts, dsd_state** state) {
+    if (!opts || !state) {
+        return -1;
+    }
+    *opts = (dsd_opts*)calloc(1, sizeof(**opts));
+    *state = (dsd_state*)calloc(1, sizeof(**state));
+    if (!*opts || !*state) {
+        free(*opts);
+        p25_test_free_state(*state);
+        *opts = NULL;
+        *state = NULL;
+        return -1;
+    }
+    return 0;
+}
+
+static int
+p25_test_seed_iden_config(dsd_state* state, const p25_test_iden_config* iden_cfg) {
+    if (!state || !iden_cfg || iden_cfg->iden < 0 || iden_cfg->iden > 15) {
+        return -1;
+    }
+
+    int iden = iden_cfg->iden;
+    state->p25_chan_iden = iden & 0xF;
+    if (iden_cfg->tdma) {
+        state->p25_iden_tdma[iden].base_freq = iden_cfg->base;
+        state->p25_iden_tdma[iden].chan_type = iden_cfg->type & 0xF;
+        state->p25_iden_tdma[iden].chan_spac = iden_cfg->spac;
+        state->p25_iden_tdma[iden].populated = 1;
+        state->p25_chan_tdma_explicit[iden] |= 2;
+        return 0;
+    }
+
+    state->p25_iden_fdma[iden].base_freq = iden_cfg->base;
+    state->p25_iden_fdma[iden].chan_type = iden_cfg->type & 0xF;
+    state->p25_iden_fdma[iden].chan_spac = iden_cfg->spac;
+    state->p25_iden_fdma[iden].populated = 1;
+    state->p25_chan_tdma_explicit[iden] |= 1;
+    return 0;
+}
+
+static void
+p25_test_copy_mbt_outputs(const dsd_state* state, const p25_test_mbt_outputs* outputs) {
+    if (!state || !outputs) {
+        return;
+    }
+    if (outputs->cc) {
+        *outputs->cc = state->p25_cc_freq;
+    }
+    if (outputs->wacn) {
+        *outputs->wacn = (long)state->p2_wacn;
+    }
+    if (outputs->sysid) {
+        *outputs->sysid = state->p2_sysid;
+    }
+    if (outputs->nb_count) {
+        *outputs->nb_count = state->p25_nb_count;
+    }
+    if (outputs->nb_freqs) {
+        for (int i = 0; i < state->p25_nb_count && i < P25_NB_MAX; i++) {
+            outputs->nb_freqs[i] = state->p25_nb_entries[i].freq;
+        }
+    }
+}
+
 // Invoke the P25p1 MBT -> MAC Identifier Update bridge and report key state.
 // Returns 0 on success.
 int
@@ -154,60 +220,23 @@ p25_test_decode_mbt_with_iden(const unsigned char* mbt, int mbt_len, int iden, i
 // out_nb_count: number of neighbor entries populated
 // out_nb_freqs: array of at least P25_NB_MAX longs to receive neighbor frequencies
 int
-p25_test_decode_mbt_with_iden_nb(const unsigned char* mbt, int mbt_len, int iden, int type, int tdma, long base,
-                                 int spac, long* out_cc, long* out_wacn, int* out_sysid, int* out_nb_count,
-                                 long* out_nb_freqs) {
+p25_test_decode_mbt_with_iden_nb(const unsigned char* mbt, int mbt_len, const p25_test_iden_config* iden_cfg,
+                                 const p25_test_mbt_outputs* outputs) {
     (void)mbt_len;
-
-    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
-    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
-    if (!opts || !state) {
-        free(opts);
-        p25_test_free_state(state);
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    if (p25_test_alloc_decode_context(&opts, &state) != 0) {
         return -1;
     }
 
-    if (iden < 0 || iden > 15) {
+    if (p25_test_seed_iden_config(state, iden_cfg) != 0) {
         free(opts);
         p25_test_free_state(state);
         return -2;
     }
-    state->p25_chan_iden = iden & 0xF;
-
-    // Populate new dual-array entries (process_channel_to_freq reads from these)
-    if (tdma) {
-        state->p25_iden_tdma[iden].base_freq = base;
-        state->p25_iden_tdma[iden].chan_type = type & 0xF;
-        state->p25_iden_tdma[iden].chan_spac = spac;
-        state->p25_iden_tdma[iden].populated = 1;
-        state->p25_chan_tdma_explicit[iden] |= 2;
-    } else {
-        state->p25_iden_fdma[iden].base_freq = base;
-        state->p25_iden_fdma[iden].chan_type = type & 0xF;
-        state->p25_iden_fdma[iden].chan_spac = spac;
-        state->p25_iden_fdma[iden].populated = 1;
-        state->p25_chan_tdma_explicit[iden] |= 1;
-    }
 
     p25_decode_pdu_trunking(opts, state, (unsigned char*)mbt);
-
-    if (out_cc) {
-        *out_cc = state->p25_cc_freq;
-    }
-    if (out_wacn) {
-        *out_wacn = (long)state->p2_wacn;
-    }
-    if (out_sysid) {
-        *out_sysid = state->p2_sysid;
-    }
-    if (out_nb_count) {
-        *out_nb_count = state->p25_nb_count;
-    }
-    if (out_nb_freqs) {
-        for (int i = 0; i < state->p25_nb_count && i < P25_NB_MAX; i++) {
-            out_nb_freqs[i] = state->p25_nb_entries[i].freq;
-        }
-    }
+    p25_test_copy_mbt_outputs(state, outputs);
     free(opts);
     p25_test_free_state(state);
     return 0;
@@ -404,8 +433,8 @@ p25_test_invoke_mac_vpdu_with_state(const unsigned char* mac_bytes, int mac_len,
 
 // Invoke MAC VPDU and capture tuned flag and VC frequency for assertions.
 void
-p25_test_invoke_mac_vpdu_capture(const unsigned char* mac_bytes, int mac_len, int p25_trunk, long p25_cc_freq, int iden,
-                                 int type, int tdma, long base, int spac, long* out_vc0, int* out_tuned) {
+p25_test_invoke_mac_vpdu_capture(const unsigned char* mac_bytes, int mac_len, int p25_trunk, long p25_cc_freq,
+                                 const p25_test_iden_config* iden_cfg, long* out_vc0, int* out_tuned) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
     if (!opts || !state) {
@@ -429,20 +458,21 @@ p25_test_invoke_mac_vpdu_capture(const unsigned char* mac_bytes, int mac_len, in
     // do not get conservatively gated.
     opts->trunk_tune_enc_calls = 1;
     state->p25_cc_freq = p25_cc_freq;
+    int iden = iden_cfg ? iden_cfg->iden : 0;
     state->p25_chan_iden = iden & 0xF;
 
     // Populate new dual-array entries (process_channel_to_freq reads from these)
-    if (tdma) {
-        state->p25_iden_tdma[state->p25_chan_iden].base_freq = base;
-        state->p25_iden_tdma[state->p25_chan_iden].chan_type = type & 0xF;
-        state->p25_iden_tdma[state->p25_chan_iden].chan_spac = spac;
+    if (iden_cfg && iden_cfg->tdma) {
+        state->p25_iden_tdma[state->p25_chan_iden].base_freq = iden_cfg->base;
+        state->p25_iden_tdma[state->p25_chan_iden].chan_type = iden_cfg->type & 0xF;
+        state->p25_iden_tdma[state->p25_chan_iden].chan_spac = iden_cfg->spac;
         state->p25_iden_tdma[state->p25_chan_iden].trust = 2;
         state->p25_iden_tdma[state->p25_chan_iden].populated = 1;
         state->p25_chan_tdma_explicit[state->p25_chan_iden] |= 2;
-    } else {
-        state->p25_iden_fdma[state->p25_chan_iden].base_freq = base;
-        state->p25_iden_fdma[state->p25_chan_iden].chan_type = type & 0xF;
-        state->p25_iden_fdma[state->p25_chan_iden].chan_spac = spac;
+    } else if (iden_cfg) {
+        state->p25_iden_fdma[state->p25_chan_iden].base_freq = iden_cfg->base;
+        state->p25_iden_fdma[state->p25_chan_iden].chan_type = iden_cfg->type & 0xF;
+        state->p25_iden_fdma[state->p25_chan_iden].chan_spac = iden_cfg->spac;
         state->p25_iden_fdma[state->p25_chan_iden].trust = 2;
         state->p25_iden_fdma[state->p25_chan_iden].populated = 1;
         state->p25_chan_tdma_explicit[state->p25_chan_iden] |= 1;

--- a/src/protocol/p25/p25_test_shim.h
+++ b/src/protocol/p25/p25_test_shim.h
@@ -17,9 +17,25 @@ int p25_test_mbt_iden_bridge(const unsigned char* mbt, int mbt_len, long* out_ba
                              int* out_tdma, long* out_freq);
 int p25_test_decode_mbt_with_iden(const unsigned char* mbt, int mbt_len, int iden, int type, int tdma, long base,
                                   int spac, long* out_cc, long* out_wacn, int* out_sysid);
-int p25_test_decode_mbt_with_iden_nb(const unsigned char* mbt, int mbt_len, int iden, int type, int tdma, long base,
-                                     int spac, long* out_cc, long* out_wacn, int* out_sysid, int* out_nb_count,
-                                     long* out_nb_freqs);
+
+typedef struct {
+    int iden;
+    int type;
+    int tdma;
+    long base;
+    int spac;
+} p25_test_iden_config;
+
+typedef struct {
+    long* cc;
+    long* wacn;
+    int* sysid;
+    int* nb_count;
+    long* nb_freqs;
+} p25_test_mbt_outputs;
+
+int p25_test_decode_mbt_with_iden_nb(const unsigned char* mbt, int mbt_len, const p25_test_iden_config* iden_cfg,
+                                     const p25_test_mbt_outputs* outputs);
 void p25_test_process_mac_vpdu(int type, const unsigned char* mac_bytes, int mac_len);
 int p25_test_p1_ldu_gate(int algid, unsigned long long R, int aes_loaded);
 int p25_test_p2_gate(int algid, unsigned long long key, int aes_loaded);
@@ -29,7 +45,7 @@ void p25_test_process_mac_vpdu_ex(int type, const unsigned char* mac_bytes, int 
 void p25_test_invoke_mac_vpdu_with_state(const unsigned char* mac_bytes, int mac_len, int p25_trunk, long p25_cc_freq,
                                          int iden, int type, int tdma, long base, int spac);
 void p25_test_invoke_mac_vpdu_capture(const unsigned char* mac_bytes, int mac_len, int p25_trunk, long p25_cc_freq,
-                                      int iden, int type, int tdma, long base, int spac, long* out_vc0, int* out_tuned);
+                                      const p25_test_iden_config* iden_cfg, long* out_vc0, int* out_tuned);
 int p25_test_p2_early_enc_handle(dsd_opts* opts, dsd_state* state, int slot);
 
 #ifdef __cplusplus

--- a/src/protocol/p25/phase1/p25p1_hdu.c
+++ b/src/protocol/p25/phase1/p25p1_hdu.c
@@ -22,6 +22,7 @@
 #include <dsd-neo/core/dibit.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/parse.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
@@ -39,7 +40,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -611,11 +611,13 @@ processHDU(dsd_opts* opts, dsd_state* state) {
 
     hdu_extract_mi_algid_kid((const char (*)[6])hex_data, mi, algid, kid);
 
-    state->p25kid = strtol(kid, NULL, 2);
+    uint32_t kid_parsed = 0;
+    state->p25kid = (dsd_parse_binary_u32_n(kid, 16, &kid_parsed) == 0) ? (int)kid_parsed : 0;
     hdu_consume_trailing_dibits_and_status(opts, state);
 
-    algidhex = strtol(algid, NULL, 2);
-    kidhex = strtol(kid, NULL, 2);
+    uint32_t algid_parsed = 0;
+    algidhex = (dsd_parse_binary_u32_n(algid, 8, &algid_parsed) == 0) ? (int)algid_parsed : 0;
+    kidhex = (dsd_parse_binary_u32_n(kid, 16, &kid_parsed) == 0) ? (int)kid_parsed : 0;
     mihex1 = (unsigned long long int)ConvertBitIntoBytes(&mi[0], 32);
     mihex2 = (unsigned long long int)ConvertBitIntoBytes(&mi[32], 32);
     mihex3 = (unsigned long long int)ConvertBitIntoBytes(&mi[64], 8);

--- a/src/protocol/p25/phase1/p25p1_ldu2.c
+++ b/src/protocol/p25/phase1/p25p1_ldu2.c
@@ -23,6 +23,7 @@
 #include <dsd-neo/core/dibit.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/parse.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
@@ -40,7 +41,6 @@
 #include <dsd-neo/runtime/p25_optional_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -183,7 +183,8 @@ ldu2_maybe_apply_early_unmute(dsd_opts* opts, const dsd_state* state, const char
     char algid_bits[9];
     char kid_bits[17];
     ldu2_extract_ess_fields(hex_data, mi_bits, algid_bits, kid_bits);
-    int algid_early = (int)strtol(algid_bits, NULL, 2);
+    uint32_t algid_early_bits = 0;
+    int algid_early = (dsd_parse_binary_u32_n(algid_bits, 8, &algid_early_bits) == 0) ? (int)algid_early_bits : 0;
 
     if (state->R != 0 && (algid_early == 0xAA || algid_early == 0x81 || algid_early == 0x9F)) {
         opts->unmute_encrypted_p25 = 1;
@@ -325,8 +326,10 @@ ldu2_run_fec_and_heuristics(dsd_state* state, P25Heuristics* heur, char hex_data
 static void
 ldu2_decode_post_fec_fields(const dsd_state* state, Ldu2Frame* frame) {
     ldu2_extract_ess_fields((const char (*)[6])frame->hex_data, frame->mi, frame->algid, frame->kid);
-    frame->algidhex = (int)strtol(frame->algid, NULL, 2);
-    frame->kidhex = (int)strtol(frame->kid, NULL, 2);
+    uint32_t algidhex = 0;
+    uint32_t kidhex = 0;
+    frame->algidhex = (dsd_parse_binary_u32_n(frame->algid, 8, &algidhex) == 0) ? (int)algidhex : 0;
+    frame->kidhex = (dsd_parse_binary_u32_n(frame->kid, 16, &kidhex) == 0) ? (int)kidhex : 0;
     frame->mihex1 = (unsigned long long)ConvertBitIntoBytes(&frame->mi[0], 32);
     frame->mihex2 = (unsigned long long)ConvertBitIntoBytes(&frame->mi[32], 32);
     frame->mihex3 = (unsigned long long)ConvertBitIntoBytes(&frame->mi[64], 8);

--- a/src/protocol/p25/phase1/p25p1_pdu_data.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_data.c
@@ -45,26 +45,39 @@ dsd_append(char* dst, size_t dstsz, const char* src) {
     DSD_SNPRINTF(dst + len, dstsz - len, "%s", src);
 }
 
+typedef struct {
+    uint8_t fmt;
+    uint8_t sap;
+    uint8_t mfid;
+    uint8_t io;
+    uint32_t llid;
+    uint8_t blks;
+    uint8_t pad;
+    uint8_t offset;
+    int payload_len;
+    int encrypted;
+    const char* summary;
+} p25_pdu_json_fields;
+
 static void
-p25_emit_pdu_json_if_enabled(uint8_t fmt, uint8_t sap, uint8_t mfid, uint8_t io, uint32_t llid, uint8_t blks,
-                             uint8_t pad, uint8_t offset, int payload_len, int encrypted, const char* summary) {
+p25_emit_pdu_json_if_enabled(const p25_pdu_json_fields* fields) {
     const dsdneoRuntimeConfig* rc = dsd_neo_get_config();
-    if (!rc || !rc->pdu_json_enable) {
+    if (!fields || !rc || !rc->pdu_json_enable) {
         return;
     }
 
     /* Skip trunking control SAPs to reduce noise unless explicitly desired later */
-    if (sap == 61 || sap == 63) {
+    if (fields->sap == 61 || fields->sap == 63) {
         return;
     }
 
     time_t ts = time(NULL);
     char sum[160];
-    if (summary && summary[0] != '\0') {
+    if (fields->summary && fields->summary[0] != '\0') {
         /* ensure no embedded quotes break JSON (very minimal escape) */
         int j = 0;
-        for (int i = 0; summary[i] != '\0' && j < (int)sizeof(sum) - 1; i++) {
-            char ch = summary[i];
+        for (int i = 0; fields->summary[i] != '\0' && j < (int)sizeof(sum) - 1; i++) {
+            char ch = fields->summary[i];
             if (ch == '"') {
                 continue; /* drop quotes */
             }
@@ -80,7 +93,8 @@ p25_emit_pdu_json_if_enabled(uint8_t fmt, uint8_t sap, uint8_t mfid, uint8_t io,
     DSD_FPRINTF(stderr,
                 "{\"ts\":%ld,\"proto\":\"p25\",\"fmt\":%u,\"sap\":%u,\"mfid\":%u,\"io\":%u,\"llid\":%u,"
                 "\"blks\":%u,\"pad\":%u,\"offset\":%u,\"len\":%d,\"enc\":%d,\"summary\":\"%s\"}",
-                (long)ts, fmt, sap, mfid, io, llid, blks, pad, offset, payload_len, encrypted ? 1 : 0, sum);
+                (long)ts, fields->fmt, fields->sap, fields->mfid, fields->io, fields->llid, fields->blks, fields->pad,
+                fields->offset, fields->payload_len, fields->encrypted ? 1 : 0, sum);
 }
 
 static void
@@ -626,8 +640,9 @@ p25_pdu_payload_span(int len, int ptr) {
 
 static void
 p25_emit_pdu_json_for_fields(const P25PduDataFields* pdu, int len, int encrypted, const char* summary) {
-    p25_emit_pdu_json_if_enabled(pdu->fmt, pdu->sap, pdu->mfid, pdu->io, pdu->llid, pdu->blks, pdu->pad, pdu->offset,
-                                 len, encrypted, summary);
+    p25_pdu_json_fields fields = {pdu->fmt, pdu->sap,    pdu->mfid, pdu->io,   pdu->llid, pdu->blks,
+                                  pdu->pad, pdu->offset, len,       encrypted, summary};
+    p25_emit_pdu_json_if_enabled(&fields);
 }
 
 static void

--- a/src/protocol/p25/phase1/p25p1_soft.cpp
+++ b/src/protocol/p25/phase1/p25p1_soft.cpp
@@ -336,24 +336,38 @@ p25p1_hamming_search_masked_candidates(const char* bits, const int* reliab, cons
     }
 }
 
+namespace {
+
+struct p25p1_golay_seed_result {
+    int* best_penalty;
+    int* best_fixed;
+    char* best_data;
+    int* found_valid;
+    char* hard_data;
+    int* hard_valid;
+    int* hard_corrected;
+    int* hard_penalty;
+};
+
+} // namespace
+
 static void
 p25p1_golay6_seed_hard(const char* orig, const int* reliab, const DSDGolay24* golay, const char* hex_copy,
-                       int hard_fixed, int* best_penalty, int* best_fixed, char best_data[6], int* found_valid,
-                       char hard_data[6], int* hard_valid, int* hard_corrected, int* hard_penalty) {
+                       int hard_fixed, const p25p1_golay_seed_result* out) {
     char decoded[18];
     DSD_MEMCPY(decoded, hex_copy, 6);
     char enc_parity[12];
     golay->encode_6(hex_copy, enc_parity);
     DSD_MEMCPY(decoded + 6, enc_parity, 12);
 
-    *hard_valid = 1;
-    *hard_corrected = (hard_fixed > 0);
-    *hard_penalty = compute_penalty(orig, decoded, reliab, 18);
-    *best_penalty = *hard_penalty;
-    *best_fixed = count_differences(orig, decoded, 18);
-    DSD_MEMCPY(hard_data, hex_copy, 6);
-    DSD_MEMCPY(best_data, hex_copy, 6);
-    *found_valid = 1;
+    *out->hard_valid = 1;
+    *out->hard_corrected = (hard_fixed > 0);
+    *out->hard_penalty = compute_penalty(orig, decoded, reliab, 18);
+    *out->best_penalty = *out->hard_penalty;
+    *out->best_fixed = count_differences(orig, decoded, 18);
+    DSD_MEMCPY(out->hard_data, hex_copy, 6);
+    DSD_MEMCPY(out->best_data, hex_copy, 6);
+    *out->found_valid = 1;
 }
 
 static void
@@ -400,22 +414,21 @@ p25p1_golay6_search(const char* orig, const int* reliab, const int* least_rel, D
 
 static void
 p25p1_golay12_seed_hard(const char* orig, const int* reliab, const DSDGolay24* golay, const char* dodeca_copy,
-                        int hard_fixed, int* best_penalty, int* best_fixed, char best_data[12], int* found_valid,
-                        char hard_data[12], int* hard_valid, int* hard_corrected, int* hard_penalty) {
+                        int hard_fixed, const p25p1_golay_seed_result* out) {
     char decoded[24];
     DSD_MEMCPY(decoded, dodeca_copy, 12);
     char enc_parity[12];
     golay->encode_12(dodeca_copy, enc_parity);
     DSD_MEMCPY(decoded + 12, enc_parity, 12);
 
-    *hard_valid = 1;
-    *hard_corrected = (hard_fixed > 0);
-    *hard_penalty = compute_penalty(orig, decoded, reliab, 24);
-    *best_penalty = *hard_penalty;
-    *best_fixed = count_differences(orig, decoded, 24);
-    DSD_MEMCPY(hard_data, dodeca_copy, 12);
-    DSD_MEMCPY(best_data, dodeca_copy, 12);
-    *found_valid = 1;
+    *out->hard_valid = 1;
+    *out->hard_corrected = (hard_fixed > 0);
+    *out->hard_penalty = compute_penalty(orig, decoded, reliab, 24);
+    *out->best_penalty = *out->hard_penalty;
+    *out->best_fixed = count_differences(orig, decoded, 24);
+    DSD_MEMCPY(out->hard_data, dodeca_copy, 12);
+    DSD_MEMCPY(out->best_data, dodeca_copy, 12);
+    *out->found_valid = 1;
 }
 
 static void
@@ -526,8 +539,9 @@ check_and_fix_golay_24_6_soft(char* data, const char* parity, const int* reliab,
     int hard_penalty = 999999;
 
     if (hard_result == 0) {
-        p25p1_golay6_seed_hard(orig, reliab, &golay, hex_copy, hard_fixed, &best_penalty, &best_fixed, best_data,
-                               &found_valid, hard_data, &hard_valid, &hard_corrected, &hard_penalty);
+        p25p1_golay_seed_result seed = {&best_penalty, &best_fixed, best_data,       &found_valid,
+                                        hard_data,     &hard_valid, &hard_corrected, &hard_penalty};
+        p25p1_golay6_seed_hard(orig, reliab, &golay, hex_copy, hard_fixed, &seed);
     }
 
     int least_rel[8];
@@ -584,8 +598,9 @@ check_and_fix_golay_24_12_soft(char* data, const char* parity, const int* reliab
     int hard_penalty = 999999;
 
     if (hard_result == 0) {
-        p25p1_golay12_seed_hard(orig, reliab, &golay, dodeca_copy, hard_fixed, &best_penalty, &best_fixed, best_data,
-                                &found_valid, hard_data, &hard_valid, &hard_corrected, &hard_penalty);
+        p25p1_golay_seed_result seed = {&best_penalty, &best_fixed, best_data,       &found_valid,
+                                        hard_data,     &hard_valid, &hard_corrected, &hard_penalty};
+        p25p1_golay12_seed_hard(orig, reliab, &golay, dodeca_copy, hard_fixed, &seed);
     }
 
     int least_rel[8];

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -709,18 +709,31 @@ p25p2_vpdu_set_active_group_triple(dsd_state* state, int channel1, int group1, i
     state->last_active_time = time(NULL);
 }
 
+typedef struct {
+    int channel;
+    int group;
+    long int freq;
+    int svc_bits;
+} p25p2_vpdu_group_candidate;
+
+typedef struct {
+    int policy_encrypted_override;
+    int policy_data_override;
+    int emit_enc_lockout;
+    int stop_on_tune;
+} p25p2_vpdu_candidate_policy;
+
 static int
-p25p2_vpdu_try_group_candidate(const struct p25p2_mac_result* mac_res, dsd_opts* opts, dsd_state* state, int channel,
-                               int group, long int freq, int svc_bits, int policy_encrypted_override,
-                               int policy_data_override, int emit_enc_lockout, int stop_on_tune) {
+p25p2_vpdu_try_group_candidate(const struct p25p2_mac_result* mac_res, dsd_opts* opts, dsd_state* state,
+                               const p25p2_vpdu_group_candidate* candidate, const p25p2_vpdu_candidate_policy* policy) {
     int tuned = 0;
-    p25p2_vpdu_print_group_label(state, (uint32_t)group);
-    if (p25p2_vpdu_can_tune(opts, state, freq)) {
-        p25p2_mac_handle(mac_res, opts, state, channel, svc_bits, group, /*src*/ 0, policy_encrypted_override,
-                         policy_data_override, emit_enc_lockout);
-        tuned = (stop_on_tune && opts->p25_is_tuned != 0) ? 1 : 0;
+    p25p2_vpdu_print_group_label(state, (uint32_t)candidate->group);
+    if (p25p2_vpdu_can_tune(opts, state, candidate->freq)) {
+        p25p2_mac_handle(mac_res, opts, state, candidate->channel, candidate->svc_bits, candidate->group, /*src*/ 0,
+                         policy->policy_encrypted_override, policy->policy_data_override, policy->emit_enc_lockout);
+        tuned = (policy->stop_on_tune && opts->p25_is_tuned != 0) ? 1 : 0;
     }
-    p25p2_vpdu_update_playback_if_match(opts, state, group, freq);
+    p25p2_vpdu_update_playback_if_match(opts, state, candidate->group, candidate->freq);
     return tuned;
 }
 
@@ -968,18 +981,12 @@ p25p2_vpdu_block07_enc_blocked(const dsd_opts* opts, const dsd_state* state, int
 
 static void
 p25p2_vpdu_block07_try_candidates(const struct p25p2_mac_result* mac_res, dsd_opts* opts, dsd_state* state,
-                                  int channel1, int group1, long int freq1, int svc1, int channel2, int group2,
-                                  long int freq2, int svc2) {
-    int loop = (channel1 == channel2) ? 1 : 2;
-    const int channels[2] = {channel1, channel2};
-    const int groups[2] = {group1, group2};
-    const long int freqs[2] = {freq1, freq2};
-    const int svcs[2] = {svc1, svc2};
+                                  const p25p2_vpdu_group_candidate candidates[2]) {
+    int loop = (candidates[0].channel == candidates[1].channel) ? 1 : 2;
+    const p25p2_vpdu_candidate_policy policy = {-1, -1, 1, 0};
 
     for (int j = 0; j < loop; j++) {
-        (void)p25p2_vpdu_try_group_candidate(mac_res, opts, state, channels[j], groups[j], freqs[j], svcs[j],
-                                             /*policy_encrypted*/ -1, /*policy_data*/ -1, /*emit_enc_lockout*/ 1,
-                                             /*stop_on_tune*/ 0);
+        (void)p25p2_vpdu_try_group_candidate(mac_res, opts, state, &candidates[j], &policy);
     }
 }
 
@@ -1005,9 +1012,9 @@ static void
 p25p2_vpdu_block08_try_candidates(const struct p25p2_mac_result* mac_res, dsd_opts* opts, dsd_state* state,
                                   const int* channels, const int* groups, const long int* freqs, const int* svcs) {
     for (int j = 0; j < 3; j++) {
-        int tuned = p25p2_vpdu_try_group_candidate(mac_res, opts, state, channels[j], groups[j], freqs[j], svcs[j],
-                                                   /*policy_encrypted*/ -1, /*policy_data*/ -1,
-                                                   /*emit_enc_lockout*/ 1, /*stop_on_tune*/ 1);
+        p25p2_vpdu_group_candidate candidate = {channels[j], groups[j], freqs[j], svcs[j]};
+        const p25p2_vpdu_candidate_policy policy = {-1, -1, 1, 1};
+        int tuned = p25p2_vpdu_try_group_candidate(mac_res, opts, state, &candidate, &policy);
         if (tuned) {
             break;
         }
@@ -1168,9 +1175,9 @@ p25p2_vpdu_iter_block_03(p25p2_vpdu_ctx* ctx) {
             int tunable_group = (j == 0) ? group1 : group2;
             long int tunable_freq = (j == 0) ? freq1 : freq2;
             int policy_encrypted = p25_mfid90_enc_lockout_blocks(opts, state, tunable_group) ? 1 : 0;
-            int tuned = p25p2_vpdu_try_group_candidate(&mac_res, opts, state, tunable_chan, tunable_group, tunable_freq,
-                                                       /*svc_bits*/ 0, policy_encrypted,
-                                                       /*policy_data*/ 0, /*emit_enc_lockout*/ 0, /*stop_on_tune*/ 1);
+            p25p2_vpdu_group_candidate candidate = {tunable_chan, tunable_group, tunable_freq, 0};
+            p25p2_vpdu_candidate_policy policy = {policy_encrypted, 0, 0, 1};
+            int tuned = p25p2_vpdu_try_group_candidate(&mac_res, opts, state, &candidate, &policy);
             if (tuned) {
                 break;
             }
@@ -1423,8 +1430,9 @@ p25p2_vpdu_iter_block_07(p25p2_vpdu_ctx* ctx) {
             ctx->skip_rest = 1;
             goto BLOCK_END;
         }
-        p25p2_vpdu_block07_try_candidates(&mac_res, opts, state, channelt1, group1, freq1t, svc1, channelt2, group2,
-                                          freq2t, svc2);
+        p25p2_vpdu_group_candidate candidates[2] = {{channelt1, group1, freq1t, svc1},
+                                                    {channelt2, group2, freq2t, svc2}};
+        p25p2_vpdu_block07_try_candidates(&mac_res, opts, state, candidates);
     }
 
     if (len_b < 0) {
@@ -1543,9 +1551,9 @@ p25p2_vpdu_iter_block_09(p25p2_vpdu_ctx* ctx) {
             int tunable_chan = (j == 0) ? channel1 : channel2;
             int tunable_group = (j == 0) ? group1 : group2;
             long int tunable_freq = (j == 0) ? freq1 : freq2;
-            int tuned = p25p2_vpdu_try_group_candidate(&mac_res, opts, state, tunable_chan, tunable_group, tunable_freq,
-                                                       /*svc_bits*/ 0, /*policy_encrypted*/ 0,
-                                                       /*policy_data*/ 0, /*emit_enc_lockout*/ 0, /*stop_on_tune*/ 1);
+            p25p2_vpdu_group_candidate candidate = {tunable_chan, tunable_group, tunable_freq, 0};
+            const p25p2_vpdu_candidate_policy policy = {0, 0, 0, 1};
+            int tuned = p25p2_vpdu_try_group_candidate(&mac_res, opts, state, &candidate, &policy);
             if (tuned) {
                 break;
             }

--- a/src/protocol/x2tdma/x2tdma_voice.c
+++ b/src/protocol/x2tdma/x2tdma_voice.c
@@ -18,13 +18,14 @@
 
 #include <dsd-neo/core/dibit.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/parse.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/vocoder.h>
 #include <dsd-neo/protocol/x2tdma/x2tdma.h>
 #include <dsd-neo/protocol/x2tdma/x2tdma_const.h>
+#include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -548,8 +549,10 @@ processX2TDMAvoice(dsd_opts* opts, dsd_state* state) {
 
     if (ctx.mutecurrentslot == 0) {
         if (opts->p25enc == 1) {
-            int algidhex = strtol(state->algid, NULL, 2);
-            int kidhex = strtol(state->keyid, NULL, 2);
+            uint32_t algidbits = 0;
+            uint32_t kidbits = 0;
+            int algidhex = (dsd_parse_binary_u32_n(state->algid, 8, &algidbits) == 0) ? (int)algidbits : 0;
+            int kidhex = (dsd_parse_binary_u32_n(state->keyid, 16, &kidbits) == 0) ? (int)kidbits : 0;
             DSD_FPRINTF(stderr, "mi: %s algid: $%x kid: $%x\n", ctx.mi, algidhex, kidhex);
         }
     }

--- a/src/protocol/ysf/ysf.c
+++ b/src/protocol/ysf/ysf.c
@@ -183,117 +183,60 @@ ysf_dch_decode(dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft,
 }
 
 static void
+ysf_copy_text_field(char* dst, const char* src, size_t len) {
+    DSD_MEMCPY(dst, src, len);
+    dst[len] = '\0';
+}
+
+static void
+ysf_print_text_field(const char* label, const char* src, size_t len, const char* suffix) {
+    char text[11];
+    ysf_copy_text_field(text, src, len);
+    DSD_FPRINTF(stderr, "%s", label);
+    DSD_FPRINTF(stderr, "%s%s", text, suffix);
+}
+
+static void
+ysf_store_text_field(const char* label, const char* src, size_t len, char* dst, const char* suffix) {
+    ysf_print_text_field(label, src, len, suffix);
+    ysf_copy_text_field(dst, src, len);
+}
+
+static void
+ysf_dch_decode2_destination(dsd_state* state, const char dch_bytes[20], uint8_t cm) {
+    if (cm != 1) {
+        ysf_print_text_field("DST: ", dch_bytes, 10, " ");
+    } else {
+        ysf_print_text_field("DST RID: ", dch_bytes, 5, " ");
+        ysf_print_text_field("SRC RID: ", dch_bytes + 5, 5, " ");
+    }
+    ysf_copy_text_field(state->ysf_tgt, dch_bytes, 10);
+}
+
+static void
+ysf_dch_decode2_remarks(const char* label1, char* dst1, const char* label2, char* dst2, const char dch_bytes[20]) {
+    ysf_store_text_field(label1, dch_bytes, 5, dst1, " ");
+    ysf_store_text_field(label2, dch_bytes + 5, 5, dst2, " ");
+}
+
+static void
 ysf_dch_decode2(dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, uint8_t cm, uint8_t input[]) {
-    //TODO: Per Call WAV files using these strings
-    int i;
     char dch_bytes[20];
     DSD_MEMSET(dch_bytes, 0, sizeof(dch_bytes));
-    char string[11];
-    char rem1[6];
-    char rem2[6];
 
-    UNUSED4(bn, bt, fn, ft);
+    UNUSED3(bn, bt, ft);
 
-    for (i = 0; i < 10; i++) {
+    for (int i = 0; i < 10; i++) {
         dch_bytes[i] = (char)ConvertBitIntoBytes(&input[(size_t)i * 8u], 8);
     }
 
     switch (fn) {
-        case 0:
-            //Destination / Target
-            if (cm != 1) {
-                DSD_MEMCPY(string, dch_bytes, 10);
-                string[10] = '\0';
-                DSD_FPRINTF(stderr, "DST: ");
-                DSD_FPRINTF(stderr, "%s ", string);
-            } else //Radio ID Mode -- updated in the 1V02 spec manual
-            {
-                DSD_MEMCPY(rem1, dch_bytes, 5);
-                rem1[5] = '\0';
-                DSD_FPRINTF(stderr, "DST RID: ");
-                DSD_FPRINTF(stderr, "%s ", rem1);
-
-                DSD_MEMCPY(rem2, dch_bytes + 5, 5);
-                rem2[5] = '\0';
-                DSD_FPRINTF(stderr, "SRC RID: ");
-                DSD_FPRINTF(stderr, "%s ", rem2);
-            }
-
-            DSD_MEMCPY(state->ysf_tgt, dch_bytes, 10);
-            state->ysf_tgt[10] = '\0';
-
-            break;
-        case 1:
-            //Source
-            DSD_MEMCPY(string, dch_bytes, 10);
-            string[10] = '\0';
-            DSD_FPRINTF(stderr, "SRC: ");
-            DSD_FPRINTF(stderr, "%s", string);
-
-            DSD_MEMCPY(state->ysf_src, dch_bytes, 10);
-            state->ysf_src[10] = '\0';
-
-            break;
-        case 2:
-            //Uplink
-            DSD_MEMCPY(string, dch_bytes, 10);
-            string[10] = '\0';
-            DSD_FPRINTF(stderr, "U/L: ");
-            DSD_FPRINTF(stderr, "%s", string);
-
-            DSD_MEMCPY(state->ysf_upl, dch_bytes, 10);
-            state->ysf_upl[10] = '\0';
-
-            break;
-        case 3:
-            //Downlink
-            DSD_MEMCPY(string, dch_bytes, 10);
-            string[10] = '\0';
-            DSD_FPRINTF(stderr, "D/L: ");
-            DSD_FPRINTF(stderr, "%s", string);
-
-            state->ysf_dnl[10] = '\0';
-            DSD_MEMCPY(state->ysf_dnl, dch_bytes, 10);
-
-            break;
-        case 4:
-            //Remarks 1 and 2
-            DSD_MEMCPY(rem1, dch_bytes, 5);
-            rem1[5] = '\0';
-            DSD_FPRINTF(stderr, "RM1: ");
-            DSD_FPRINTF(stderr, "%s ", rem1);
-
-            DSD_MEMCPY(rem2, dch_bytes + 5, 5);
-            rem2[5] = '\0';
-            DSD_FPRINTF(stderr, "RM2: ");
-            DSD_FPRINTF(stderr, "%s ", rem2);
-
-            DSD_MEMCPY(state->ysf_rm1, dch_bytes, 5);
-            state->ysf_rm1[5] = '\0';
-
-            DSD_MEMCPY(state->ysf_rm2, dch_bytes + 5, 5);
-            state->ysf_rm2[5] = '\0';
-
-            break;
-        case 5:
-            //Remarks 3 and 4
-            DSD_MEMCPY(rem1, dch_bytes, 5);
-            rem1[5] = '\0';
-            DSD_FPRINTF(stderr, "RM3: ");
-            DSD_FPRINTF(stderr, "%s ", rem1);
-
-            DSD_MEMCPY(rem2, dch_bytes + 5, 5);
-            rem2[5] = '\0';
-            DSD_FPRINTF(stderr, "RM4: ");
-            DSD_FPRINTF(stderr, "%s ", rem2);
-
-            DSD_MEMCPY(state->ysf_rm3, dch_bytes, 5);
-            state->ysf_rm3[5] = '\0';
-
-            DSD_MEMCPY(state->ysf_rm4, dch_bytes + 5, 5);
-            state->ysf_rm4[5] = '\0';
-            break;
-
+        case 0: ysf_dch_decode2_destination(state, dch_bytes, cm); break;
+        case 1: ysf_store_text_field("SRC: ", dch_bytes, 10, state->ysf_src, ""); break;
+        case 2: ysf_store_text_field("U/L: ", dch_bytes, 10, state->ysf_upl, ""); break;
+        case 3: ysf_store_text_field("D/L: ", dch_bytes, 10, state->ysf_dnl, ""); break;
+        case 4: ysf_dch_decode2_remarks("RM1: ", state->ysf_rm1, "RM2: ", state->ysf_rm2, dch_bytes); break;
+        case 5: ysf_dch_decode2_remarks("RM3: ", state->ysf_rm3, "RM4: ", state->ysf_rm4, dch_bytes); break;
         default: break;
     }
 }

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -2210,7 +2210,7 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                 state->p2_wacn = w & 0xFFFFF;                                                                          \
                 state->p2_sysid = sy & 0xFFF;                                                                          \
                 state->p2_cc = na & 0xFFF;                                                                             \
-                LOG_NOTICE("P25p2 manual WACN/SYSID/NAC set: %05lX/%03lX/%03lX\n", state->p2_wacn, state->p2_sysid,    \
+                LOG_NOTICE("P25p2 manual WACN/SYSID/NAC set: %05llX/%03llX/%03llX\n", state->p2_wacn, state->p2_sysid, \
                            state->p2_cc);                                                                              \
             } else {                                                                                                   \
                 LOG_ERROR("-X expects exactly 11 hex chars (WACN[5]+SYSID[3]+NAC[3]), e.g., BEE00ABC123\n");           \

--- a/src/runtime/cli/compact.c
+++ b/src/runtime/cli/compact.c
@@ -38,83 +38,78 @@ compact_has_next_non_option(int i, int argc, char** argv) {
     return (i + 1 < argc && argv[i + 1] != NULL && argv[i + 1][0] != '-');
 }
 
+static const char* const k_skip_exact_no_arg[] = {
+    "--auto-ppm",          "--rtltcp-autotune",      "--iq-loop",       "--rdio-api-delete-after-upload",
+    "--enc-lockout",       "--enc-follow",           "--no-config",     "--print-config",
+    "--interactive-setup", "--dump-config-template", "--strict-config", "--list-profiles",
+};
+
+static const char* const k_skip_exact_next_any[] = {
+    "--input-volume",
+    "--input-level-warn-db",
+    "--frame-log",
+    "--rdio-mode",
+    "--rdio-system-id",
+    "--rdio-api-url",
+    "--rdio-api-key",
+    "--rdio-upload-timeout-ms",
+    "--rdio-upload-retries",
+    "--dmr-baofeng-pc5",
+    "--dmr-csi-ee72",
+    "--dmr-vertex-ks-csv",
+    "--auto-ppm-snr",
+    "--profile",
+    "--p25-vc-grace",
+    "--p25-min-follow-dwell",
+    "--p25-grant-voice-timeout",
+    "--p25-retune-backoff",
+    "--p25-mac-hold",
+    "--p25-ring-hold",
+    "--p25-cc-grace",
+    "--p25-force-release-extra",
+    "--p25-force-release-margin",
+    "--p25-p1-err-hold-pct",
+    "--p25-p1-err-hold-sec",
+    "--calc-lcn",
+    "--calc-step",
+    "--calc-cc-freq",
+    "--calc-cc-lcn",
+    "--calc-start-lcn",
+};
+
+static const char* const k_skip_exact_next_nonnull[] = {
+    "--iq-capture", "--iq-capture-format", "--iq-capture-max-mb", "--symbol-capture-format",
+    "--iq-replay",  "--iq-replay-rate",    "--iq-info",
+};
+
+static const char* const k_skip_exact_next_nonopt[] = {
+    "--rtl-udp-control",
+    "--rtl-udp-control-bind",
+    "--config",
+    "--validate-config",
+};
+
+static const char* const k_skip_prefix[] = {
+    "--rtl-udp-control=",
+    "--rtl-udp-control-bind=",
+    "--iq-capture=",
+    "--iq-capture-format=",
+    "--iq-capture-max-mb=",
+    "--symbol-capture-format=",
+    "--iq-replay=",
+    "--iq-replay-rate=",
+    "--iq-info=",
+    "--dmr-baofeng-pc5=",
+    "--dmr-csi-ee72=",
+    "--dmr-vertex-ks-csv=",
+    "--config=",
+};
+
 int
 dsd_cli_compact_args(int argc, char** argv) {
     if (argc <= 0 || argv == NULL) {
         return 0;
     }
-
-    /*
-     * These buckets mirror the long-option parser by operand shape.
-     * The compact pass strips only options that getopt() cannot process later.
-     * Each list keeps the skip rule explicit so optional operands stay visible.
-     */
-    static const char* const k_skip_exact_no_arg[] = {
-        "--auto-ppm",          "--rtltcp-autotune",      "--iq-loop",       "--rdio-api-delete-after-upload",
-        "--enc-lockout",       "--enc-follow",           "--no-config",     "--print-config",
-        "--interactive-setup", "--dump-config-template", "--strict-config", "--list-profiles",
-    };
-
-    static const char* const k_skip_exact_next_any[] = {
-        "--input-volume",
-        "--input-level-warn-db",
-        "--frame-log",
-        "--rdio-mode",
-        "--rdio-system-id",
-        "--rdio-api-url",
-        "--rdio-api-key",
-        "--rdio-upload-timeout-ms",
-        "--rdio-upload-retries",
-        "--dmr-baofeng-pc5",
-        "--dmr-csi-ee72",
-        "--dmr-vertex-ks-csv",
-        "--auto-ppm-snr",
-        "--profile",
-        "--p25-vc-grace",
-        "--p25-min-follow-dwell",
-        "--p25-grant-voice-timeout",
-        "--p25-retune-backoff",
-        "--p25-mac-hold",
-        "--p25-ring-hold",
-        "--p25-cc-grace",
-        "--p25-force-release-extra",
-        "--p25-force-release-margin",
-        "--p25-p1-err-hold-pct",
-        "--p25-p1-err-hold-sec",
-        "--calc-lcn",
-        "--calc-step",
-        "--calc-cc-freq",
-        "--calc-cc-lcn",
-        "--calc-start-lcn",
-    };
-
-    static const char* const k_skip_exact_next_nonnull[] = {
-        "--iq-capture", "--iq-capture-format", "--iq-capture-max-mb", "--symbol-capture-format",
-        "--iq-replay",  "--iq-replay-rate",    "--iq-info",
-    };
-
-    static const char* const k_skip_exact_next_nonopt[] = {
-        "--rtl-udp-control",
-        "--rtl-udp-control-bind",
-        "--config",
-        "--validate-config",
-    };
-
-    static const char* const k_skip_prefix[] = {
-        "--rtl-udp-control=",
-        "--rtl-udp-control-bind=",
-        "--iq-capture=",
-        "--iq-capture-format=",
-        "--iq-capture-max-mb=",
-        "--symbol-capture-format=",
-        "--iq-replay=",
-        "--iq-replay-rate=",
-        "--iq-info=",
-        "--dmr-baofeng-pc5=",
-        "--dmr-csi-ee72=",
-        "--dmr-vertex-ks-csv=",
-        "--config=",
-    };
 
     // Remove recognized long options so short-option getopt() sees remaining tokens.
     // Keep argv[0] as the program name and compact in place for legacy callers.

--- a/src/runtime/rdio_export.c
+++ b/src/runtime/rdio_export.c
@@ -483,7 +483,7 @@ dsd_rdio_wav_duration_s(const char* wav_path) {
         return 0;
     }
 
-    FILE* fp = fopen(wav_path, "rb");
+    FILE* fp = dsd_fopen_existing_regular_file(wav_path, "rb");
     if (!fp) {
         return 0;
     }

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -45,6 +45,7 @@
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/secret_redaction.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/platform.h"
 
 #ifdef USE_RADIO
 #include <dsd-neo/io/rtl_stream_c.h>
@@ -90,6 +91,8 @@ ui_print_label_pad(const char* label) {
         addch(' ');
     }
 }
+
+static void ui_print_kv_line(const char* label, const char* fmt, ...) DSD_ATTR_FORMAT(printf, 2, 3);
 
 static void
 ui_print_kv_line(const char* label, const char* fmt, ...) {

--- a/src/ui/terminal/menu_services.c
+++ b/src/ui/terminal/menu_services.c
@@ -102,7 +102,7 @@ svc_open_symbol_in(dsd_opts* opts, dsd_state* state, const char* filename) {
     if (!opts || !filename || !*filename) {
         return -1;
     }
-    opts->symbolfile = fopen(filename, "rb");
+    opts->symbolfile = dsd_fopen_existing_regular_file(filename, "rb");
     if (!opts->symbolfile) {
         LOG_ERROR("Error, couldn't open %s\n", filename);
         return -1;
@@ -136,7 +136,7 @@ svc_replay_last_symbol(dsd_opts* opts, dsd_state* state) {
     if (!opts) {
         return -1;
     }
-    opts->symbolfile = fopen(opts->audio_in_dev, "rb");
+    opts->symbolfile = dsd_fopen_existing_regular_file(opts->audio_in_dev, "rb");
     if (!opts->symbolfile) {
         LOG_ERROR("Error, couldn't open %s\n", opts->audio_in_dev);
         return -1;

--- a/src/ui/terminal/ncurses_dsp_display.c
+++ b/src/ui/terminal/ncurses_dsp_display.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/platform.h"
 
 #ifdef USE_RTLSDR
 
@@ -41,6 +42,8 @@ ui_print_label_pad(const char* label) {
         addch(' ');
     }
 }
+
+static void ui_print_kv_line(const char* label, const char* fmt, ...) DSD_ATTR_FORMAT(printf, 2, 3);
 
 static void
 ui_print_kv_line(const char* label, const char* fmt, ...) {

--- a/src/ui/terminal/ui_cmd_queue.c
+++ b/src/ui/terminal/ui_cmd_queue.c
@@ -50,7 +50,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
-#include "dsd-neo/platform/timing.h"
+#include "dsd-neo/platform/platform.h"
 #include "dsd-neo/runtime/call_alert.h"
 
 #ifdef USE_RADIO
@@ -68,15 +68,6 @@ static dsd_mutex_t g_mu;
 static atomic_int g_mu_init = 0;
 static atomic_int g_overflow = 0;
 static atomic_int g_overflow_warn_gate = 0;
-
-static unsigned int
-ui_cmd_rng_seed_now(void) {
-    uint64_t now_ns = dsd_time_monotonic_ns();
-    uintptr_t addr = (uintptr_t)&now_ns;
-    unsigned int seed = (unsigned int)(now_ns ^ (now_ns >> 32));
-    seed ^= (unsigned int)(addr >> 4);
-    return seed ? seed : 1U;
-}
 
 static void
 ensure_mu_init(void) {
@@ -109,6 +100,8 @@ static inline int
 q_is_empty_unlocked(void) {
     return g_head == g_tail;
 }
+
+static void ui_set_toast(dsd_state* state, int ttl_s, const char* fmt, ...) DSD_ATTR_FORMAT(printf, 3, 4);
 
 static void
 ui_set_toast(dsd_state* state, int ttl_s, const char* fmt, ...) {
@@ -2474,7 +2467,7 @@ ui_cmd_handle_replay_last_legacy(dsd_opts* opts, dsd_state* state, const struct 
         return 1;
     }
     if (dsd_stat_is_regular(&sb)) {
-        opts->symbolfile = fopen(opts->audio_in_dev, "rb");
+        opts->symbolfile = dsd_fopen_existing_regular_file(opts->audio_in_dev, "rb");
         if (opts->symbolfile) {
             opts->audio_in_type = AUDIO_IN_SYMBOL_BIN;
             state->symbol_replay_format = DSD_SYMBOL_REPLAY_FORMAT_UNKNOWN;
@@ -2498,7 +2491,6 @@ ui_cmd_handle_wav_start_legacy(dsd_opts* opts, dsd_state* state, const struct Ui
         dsd_mkdir(wav_file_directory, 0700);
     }
     LOG_NOTICE("Per Call Wav File Enabled to Directory: %s\n", opts->wav_out_dir);
-    srand(ui_cmd_rng_seed_now());
     opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, sizeof opts->wav_out_file, 8000, 0);
     opts->wav_out_fR = open_wav_file(opts->wav_out_dir, opts->wav_out_fileR, sizeof opts->wav_out_fileR, 8000, 0);
     opts->dmr_stereo_wav = 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2023,7 +2023,7 @@ add_executable(
 )
 target_include_directories(
     dsd-neo_test_p25_mbt_adj_rfss
-    PRIVATE ${PROJECT_SOURCE_DIR}/include
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/protocol/p25
 )
 target_link_libraries(
     dsd-neo_test_p25_mbt_adj_rfss
@@ -2262,6 +2262,7 @@ target_include_directories(
     dsd-neo_test_p25_p1_tsbk_clamp
     PRIVATE
         ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/protocol/p25
         ${PROJECT_SOURCE_DIR}/tests/protocol/p25
 )
 target_link_libraries(
@@ -2398,6 +2399,7 @@ target_include_directories(
     dsd-neo_test_p25_p2_vpdu_grants
     PRIVATE
         ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/protocol/p25
         ${PROJECT_SOURCE_DIR}/tests/protocol/p25
 )
 target_link_libraries(dsd-neo_test_p25_p2_vpdu_grants PRIVATE dsd-neo_proto_p25)

--- a/tests/core/test_core_tg_policy_alloc_fail.c
+++ b/tests/core/test_core_tg_policy_alloc_fail.c
@@ -14,9 +14,6 @@
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
-extern void dsd_tg_policy_test_alloc_reset(void);
-extern void dsd_tg_policy_test_alloc_fail_after(long fail_after);
-
 static int
 expect_true(const char* tag, int cond) {
     if (!cond) {

--- a/tests/fuzz/fuzz_protocol_m17_lsf.c
+++ b/tests/fuzz/fuzz_protocol_m17_lsf.c
@@ -7,6 +7,8 @@
 
 #include "fuzz_support.h"
 
+uint64_t ConvertBitIntoBytes(const uint8_t* bits, uint32_t n);
+
 uint64_t
 ConvertBitIntoBytes(const uint8_t* bits, uint32_t n) {
     uint64_t value = 0ULL;

--- a/tests/fuzz/fuzz_support.h
+++ b/tests/fuzz/fuzz_support.h
@@ -11,10 +11,21 @@
 #include "test_support.h"
 
 #include <errno.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 
 #define DSD_NEO_FUZZ_MAX_INPUT 65536U
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
 
 static inline size_t
 dsd_fuzz_bounded_size(size_t size) {

--- a/tests/protocol/p25/test_p25_mbt_adj_rfss.c
+++ b/tests/protocol/p25/test_p25_mbt_adj_rfss.c
@@ -23,14 +23,11 @@
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #endif
 
+#include "p25_test_shim.h"
+
 // Shim: decode an MBT with pre-seeded iden tables
 int p25_test_decode_mbt_with_iden(const unsigned char* mbt, int mbt_len, int iden, int type, int tdma, long base,
                                   int spac, long* out_cc, long* out_wacn, int* out_sysid);
-
-// Extended shim: also returns neighbor table entries after decode
-int p25_test_decode_mbt_with_iden_nb(const unsigned char* mbt, int mbt_len, int iden, int type, int tdma, long base,
-                                     int spac, long* out_cc, long* out_wacn, int* out_sysid, int* out_nb_count,
-                                     long* out_nb_freqs);
 
 static void
 sm_noop_init(dsd_opts* opts, dsd_state* state) {
@@ -281,8 +278,9 @@ main(void) {
         (void)cc;
         (void)w;
         (void)sid;
-        int sh = p25_test_decode_mbt_with_iden_nb(mbt, (int)sizeof(mbt), iden, type, tdma, base5, spac125, &cc, &w,
-                                                  &sid, &nb_count, nb_freqs);
+        p25_test_iden_config cfg = {iden, type, tdma, base5, spac125};
+        p25_test_mbt_outputs outputs = {&cc, &w, &sid, &nb_count, nb_freqs};
+        int sh = p25_test_decode_mbt_with_iden_nb(mbt, (int)sizeof(mbt), &cfg, &outputs);
         if (sh != 0) {
             return 30;
         }

--- a/tests/protocol/p25/test_p25_p1_tsbk_clamp.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_clamp.c
@@ -167,9 +167,7 @@ sm_noop_api(void) {
     return api;
 }
 
-// Shim to invoke VPDU and capture tuned flag and vc0
-void p25_test_invoke_mac_vpdu_capture(const unsigned char* mac_bytes, int mac_len, int p25_trunk, long p25_cc_freq,
-                                      int iden, int type, int tdma, long base, int spac, long* out_vc0, int* out_tuned);
+#include "p25_test_shim.h"
 
 static int
 expect_true(const char* tag, int cond) {
@@ -203,9 +201,8 @@ main(void) {
     long vc0 = -1;
     int tuned = -1;
     // Seed only iden=0 (not matching channel’s iden=1). Expect no tuning and vc0 remains 0.
-    p25_test_invoke_mac_vpdu_capture(mac, 10, /*trunk*/ 1, /*cc*/ 851000000,
-                                     /*iden*/ 0, /*type*/ 1, /*tdma*/ 0, /*base*/ 851000000 / 5, /*spac*/ 100, &vc0,
-                                     &tuned);
+    p25_test_iden_config cfg = {/*iden*/ 0, /*type*/ 1, /*tdma*/ 0, /*base*/ 851000000 / 5, /*spac*/ 100};
+    p25_test_invoke_mac_vpdu_capture(mac, 10, /*trunk*/ 1, /*cc*/ 851000000, &cfg, &vc0, &tuned);
     rc |= expect_true("not tuned", tuned == 0);
     rc |= expect_true("vc0 not set", vc0 == 0);
     return rc;

--- a/tests/protocol/p25/test_p25_p2_reliability.c
+++ b/tests/protocol/p25/test_p25_p2_reliability.c
@@ -20,6 +20,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/vocoder.h>
 #include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/protocol/p25/p25p2_frame.h>
 #include <dsd-neo/runtime/config.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -43,7 +44,6 @@ extern int ess_a[2][168];
 extern int16_t ess_a_llr[2][168];
 extern void p25_p2_frame_reset(void);
 extern void process_ESS(dsd_opts* opts, dsd_state* state);
-extern int p25p2_duid_lookup_soft_test(uint8_t received, const uint8_t reliab8[8]);
 
 static int g_ess_hard_rc = 0;
 static int g_ess_soft_min_success = -1;

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -11,20 +11,16 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #endif
 
-// Test shim wrapper
-void p25_test_invoke_mac_vpdu_capture(const unsigned char* mac_bytes, int mac_len, int p25_trunk, long p25_cc_freq,
-                                      int iden, int type, int tdma, long base, int spac, long* out_vc0, int* out_tuned);
-
-// Stubs for alias helpers and rigctl referenced along the path
-typedef struct dsd_opts dsd_opts;
-typedef struct dsd_state dsd_state;
+#include "p25_test_shim.h"
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -146,7 +142,8 @@ main(void) {
         mac[8] = 0x67; // group id (arbitrary)
         long vc = 0;
         int tuned = 0;
-        p25_test_invoke_mac_vpdu_capture(mac, 24, 1, cc, iden, type, tdma, base, spac, &vc, &tuned);
+        p25_test_iden_config cfg = {iden, type, tdma, base, spac};
+        p25_test_invoke_mac_vpdu_capture(mac, 24, 1, cc, &cfg, &vc, &tuned);
         rc |= expect_true("A3 tuned", tuned == 1);
         rc |= expect_eq_long("A3 vc", vc, 851125000);
     }
@@ -167,7 +164,8 @@ main(void) {
         mac[9] = 0x02; // source
         long vc = 0;
         int tuned = 0;
-        p25_test_invoke_mac_vpdu_capture(mac, 24, 1, cc, iden, type, tdma, base, spac, &vc, &tuned);
+        p25_test_iden_config cfg = {iden, type, tdma, base, spac};
+        p25_test_invoke_mac_vpdu_capture(mac, 24, 1, cc, &cfg, &vc, &tuned);
         rc |= expect_true("UU tuned", tuned == 1);
         rc |= expect_eq_long("UU vc", vc, 851125000);
     }

--- a/tests/protocol/p25/test_p25p1_soft_golay.cpp
+++ b/tests/protocol/p25/test_p25p1_soft_golay.cpp
@@ -74,8 +74,8 @@ static void
 test_golay_6_two_errors() {
     DSDGolay24 golay;
     char orig_data[6] = {1, 1, 0, 0, 1, 1};
-    char data[6];
-    char parity[12];
+    char data[6] = {0};
+    char parity[12] = {0};
 
     DSD_MEMCPY(data, orig_data, 6);
     golay.encode_6(data, parity);
@@ -122,8 +122,8 @@ static void
 test_golay_12_two_errors() {
     DSDGolay24 golay;
     char orig_data[12] = {0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 1};
-    char data[12];
-    char parity[12];
+    char data[12] = {0};
+    char parity[12] = {0};
 
     DSD_MEMCPY(data, orig_data, 12);
     golay.encode_12(data, parity);
@@ -151,8 +151,8 @@ test_golay_12_three_errors() {
     /* Test 3 errors - within Golay(24,12) hard decode capability */
     DSDGolay24 golay;
     char orig_data[12] = {1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 1, 0};
-    char data[12];
-    char parity[12];
+    char data[12] = {0};
+    char parity[12] = {0};
 
     DSD_MEMCPY(data, orig_data, 12);
     golay.encode_12(data, parity);

--- a/tools/lizard.sh
+++ b/tools/lizard.sh
@@ -14,8 +14,8 @@ Usage: tools/lizard.sh [--strict] [--ccn N] [--length N] [--arguments N] [--] [p
 Options:
   --strict       Fail when threshold warnings are emitted.
   --ccn N        Cyclomatic complexity warning threshold (default: 15).
-  --length N     Function length warning threshold (default: 1000; strict: 120).
-  --arguments N  Parameter count warning threshold (default: 100; strict: 13).
+  --length N     Function length warning threshold (default: 1000; strict: 100).
+  --arguments N  Parameter count warning threshold (default: 100; strict: 10).
 
 Arguments:
   paths...       Optional paths to scan. Default: src include apps
@@ -89,8 +89,8 @@ if [[ $STRICT -eq 1 ]]; then
   # Keep the current maximum CCN as the strict ceiling, but make length and
   # parameter-count budgets useful enough to catch future growth.
   [[ $CCN_SET -eq 0 ]] && CCN=15
-  [[ $LENGTH_SET -eq 0 ]] && LENGTH=120
-  [[ $ARGUMENTS_SET -eq 0 ]] && ARGUMENTS=13
+  [[ $LENGTH_SET -eq 0 ]] && LENGTH=100
+  [[ $ARGUMENTS_SET -eq 0 ]] && ARGUMENTS=10
 fi
 
 if ! command -v lizard > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Tighten strict rule enforcement around unsafe parsing, raw file opens, non-deterministic nonce generation, production asserts, complexity, length, and parameter count.
- Add shared strict parsing, nonce, regular-file, and serial-open helpers, then migrate legacy call sites to use them.
- Refactor strict-threshold offenders and clean include ownership surfaced by the stricter checks.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / parser / crypto / network input.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j` (run locally as `-j 2`)
- [x] `ctest --preset dev-debug --output-on-failure`
- [ ] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes

Additional local checks:

- [x] `tools/format.sh`
- [x] `tools/iwyu.sh --strict`
- [x] `tools/lizard.sh --strict`
- [x] `semgrep --metrics=off --disable-version-check --no-git-ignore --config semgrep/dsd-neo.yml src include apps`
- [x] Pre-push hook via `git push` (clang-format, gersemi, clang-tidy strict, cppcheck strict, IWYU strict, Lizard strict, guardrails)

## Risk

- Security/dependency impact: strengthens strict checks and replaces legacy unsafe patterns; no dependency changes.
- CLI/UI behavior impact: no intended user-visible behavior changes.
- Compatibility or packaging impact: no API compatibility retained by design for this cleanup; no packaging changes.
