### PR TITLE
engine: defer rtl trunk profile changes until retune

### DIFF
--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -201,6 +201,66 @@ int rtl_stream_get_symbol_profile_full(int* out_symbol_rate_hz, int* out_levels,
 int rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profile);
 
 /**
+ * @brief Queue a symbol/CQPSK/TED profile to apply at the next RTL retune boundary.
+ *
+ * Trunking code may know the destination channel profile before the controller
+ * thread has actually programmed the tuner. This helper records that profile
+ * without mutating the active demodulator; the controller applies it after the
+ * hardware frequency change and before retune DSP state reset.
+ *
+ * @param cqpsk_enable 0/1 to force CQPSK off/on, negative to leave unchanged.
+ * @param symbol_rate_hz Symbol rate in Hz, e.g. 4800 or 6000.
+ * @param levels Number of symbol levels, 2 or 4.
+ * @param channel_profile rtl_stream_channel_profile profile id.
+ * @param ted_sps TED samples-per-symbol to apply; <=0 leaves TED SPS unchanged.
+ * @param persist_ted_override Non-zero keeps ted_sps as an override after retune.
+ */
+void rtl_stream_prepare_retune_profile(int cqpsk_enable, int symbol_rate_hz, int levels, int channel_profile,
+                                       int ted_sps, int persist_ted_override);
+
+/**
+ * @brief Queue a symbol/CQPSK/TED profile for a specific RTL retune target.
+ *
+ * This is the preferred trunking helper when the destination frequency is
+ * already known. The native RTL controller consumes the profile only for a
+ * matching target frequency, so unrelated retunes cannot steal the queued
+ * demodulator settings before the intended tune request is scheduled.
+ *
+ * @param target_freq_hz Intended center frequency in Hz; zero leaves the profile unbound.
+ * @param cqpsk_enable 0/1 to force CQPSK off/on, negative to leave unchanged.
+ * @param symbol_rate_hz Symbol rate in Hz, e.g. 4800 or 6000.
+ * @param levels Number of symbol levels, 2 or 4.
+ * @param channel_profile rtl_stream_channel_profile profile id.
+ * @param ted_sps TED samples-per-symbol to apply; <=0 leaves TED SPS unchanged.
+ * @param persist_ted_override Non-zero keeps ted_sps as an override after retune.
+ */
+void rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz,
+                                                  int levels, int channel_profile, int ted_sps,
+                                                  int persist_ted_override);
+
+/**
+ * @brief Apply and clear the queued retune profile immediately.
+ *
+ * Use this when RTL audio is retuned by an external backend rather than the
+ * native RTL controller, so there is no controller retune boundary to consume
+ * the queued profile.
+ */
+void rtl_stream_apply_pending_retune_profile(void);
+
+/**
+ * @brief Apply and clear a queued retune profile for a specific external retune target.
+ *
+ * Use this when an external backend, such as rigctl, has completed a frequency
+ * change and the queued profile was bound to that target.
+ */
+void rtl_stream_apply_pending_retune_profile_for_target(uint32_t target_freq_hz);
+
+/**
+ * @brief Clear any queued retune profile that has not yet been consumed.
+ */
+void rtl_stream_clear_pending_retune_profile(void);
+
+/**
  * @brief Request fresh acquisition for the active RTL FSK symbol modem.
  *
  * The request is consumed by the demod thread before the next FSK block so the
@@ -323,6 +383,20 @@ int rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size
 int rtl_stream_test_fsk_reacquire(int output_kind, size_t queued_samples, int cached_symbols, size_t* out_used_after,
                                   int* out_cache_pending_after, uint32_t* out_generation_before,
                                   uint32_t* out_generation_after, int* out_request_rc, int* out_consumed);
+
+/**
+ * @brief Verify queued retune profiles are copied onto their scheduled requests.
+ */
+int rtl_stream_test_retune_profile_request_binding(int* out_first_profile, int* out_second_profile,
+                                                   uint32_t* out_first_freq_hz, uint32_t* out_second_freq_hz,
+                                                   uint32_t* out_first_request_id, uint32_t* out_second_request_id);
+
+/**
+ * @brief Verify a coalesced no-profile retune preserves an already-bound profile.
+ */
+int rtl_stream_test_retune_profile_coalesced_no_profile(int* out_profile, uint32_t* out_profile_freq_hz,
+                                                        uint32_t* out_manual_freq_hz, uint32_t* out_request_id,
+                                                        uint32_t* out_coalesced_request_id);
 
 typedef struct rtl_stream_test_replay_state {
     int replay_input_eof;

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -140,6 +140,7 @@ dsd_engine_rtl_profile_snapshot_restore(dsd_state* state, const dsd_engine_rtl_p
     if (!state || !snapshot || !snapshot->active) {
         return;
     }
+    rtl_stream_clear_pending_retune_profile();
     state->rf_mod = snapshot->rf_mod;
     state->p25_vc_cqpsk_override = snapshot->p25_vc_cqpsk_override;
     rtl_stream_toggle_cqpsk(snapshot->rtl_cqpsk_enable);
@@ -158,7 +159,10 @@ dsd_engine_rtl_profile_snapshot_restore(dsd_state* state, const dsd_engine_rtl_p
 }
 
 static void
-dsd_engine_prepare_cc_rtl_chain(const dsd_opts* opts, dsd_state* state, int ted_sps) {
+dsd_engine_prepare_cc_rtl_chain(const dsd_opts* opts, dsd_state* state, long int target_freq_hz, int ted_sps) {
+    if (!opts || !state || opts->audio_in_type != AUDIO_IN_RTL) {
+        return;
+    }
     if (opts->p25_trunk == 1) {
         const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
         if (!cfg) {
@@ -167,18 +171,22 @@ dsd_engine_prepare_cc_rtl_chain(const dsd_opts* opts, dsd_state* state, int ted_
         }
         const int want_cqpsk = (state->p25_cc_is_tdma == 1 || opts->mod_qpsk == 1) ? 1 : 0;
         state->rf_mod = want_cqpsk ? 1 : 0;
-        if (!(cfg && cfg->cqpsk_is_set)) {
-            rtl_stream_toggle_cqpsk(want_cqpsk);
-        }
-        {
-            const int sym_rate = (state->p25_cc_is_tdma == 1) ? 6000 : 4800;
-            const int profile = want_cqpsk ? RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK : RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
-            (void)rtl_stream_set_symbol_profile(sym_rate, 4, profile);
-        }
+        const int cqpsk_request = (cfg && cfg->cqpsk_is_set) ? -1 : want_cqpsk;
+        const int sym_rate = (state->p25_cc_is_tdma == 1) ? 6000 : 4800;
+        const int profile = want_cqpsk ? RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK : RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+        rtl_stream_prepare_retune_profile_for_target((uint32_t)target_freq_hz, cqpsk_request, sym_rate, 4, profile,
+                                                     ted_sps, 0);
+        return;
     }
     if (ted_sps > 0) {
-        rtl_stream_clear_ted_sps_override();
-        rtl_stream_set_ted_sps_no_override(ted_sps);
+        int symbol_rate_hz = 0;
+        int levels = 0;
+        int channel_profile = RTL_STREAM_CHANNEL_PROFILE_WIDE;
+        (void)rtl_stream_get_symbol_profile_full(&symbol_rate_hz, &levels, &channel_profile);
+        rtl_stream_prepare_retune_profile_for_target((uint32_t)target_freq_hz, -1, symbol_rate_hz, levels,
+                                                     channel_profile, ted_sps, 0);
+    } else {
+        rtl_stream_clear_pending_retune_profile();
     }
 }
 #endif
@@ -227,6 +235,11 @@ dsd_engine_tune_with_backend(const dsd_opts* opts, dsd_state* state, long int fr
             DSD_FPRINTF(stderr, "Rigctl frequency update failed for %ld Hz.\n", freq);
             return DSD_TRUNK_TUNE_RESULT_FAILED;
         }
+#ifdef USE_RADIO
+        if (opts->audio_in_type == AUDIO_IN_RTL) {
+            rtl_stream_apply_pending_retune_profile_for_target((uint32_t)freq);
+        }
+#endif
         return DSD_TRUNK_TUNE_RESULT_OK;
     }
     if (opts->audio_in_type != AUDIO_IN_RTL) {
@@ -292,8 +305,12 @@ dsd_engine_resolve_vc_cqpsk(const dsd_state* state, int rf_mod) {
 }
 
 static void
-dsd_engine_prepare_vc_rtl_chain(const dsd_opts* opts, dsd_state* state) {
-    if (opts->audio_in_type != AUDIO_IN_RTL || opts->p25_trunk != 1) {
+dsd_engine_prepare_vc_rtl_chain(const dsd_opts* opts, dsd_state* state, long int target_freq_hz, int ted_sps) {
+    if (opts->audio_in_type != AUDIO_IN_RTL) {
+        return;
+    }
+    if (opts->p25_trunk != 1) {
+        rtl_stream_clear_pending_retune_profile();
         return;
     }
 
@@ -304,24 +321,21 @@ dsd_engine_prepare_vc_rtl_chain(const dsd_opts* opts, dsd_state* state) {
     }
 
     int want_cqpsk = dsd_engine_resolve_vc_cqpsk(state, state->rf_mod);
-    if (!(cfg && cfg->cqpsk_is_set)) {
-        rtl_stream_toggle_cqpsk(want_cqpsk);
-    }
-
-    int sym_rate = (state->p25_p2_active_slot != -1) ? 6000 : 4800;
-    int profile = want_cqpsk ? RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK : RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
-    (void)rtl_stream_set_symbol_profile(sym_rate, 4, profile);
+    int cqpsk_request = (cfg && cfg->cqpsk_is_set) ? -1 : want_cqpsk;
+    const int sym_rate = (state->p25_p2_active_slot != -1) ? 6000 : 4800;
+    const int profile = want_cqpsk ? RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK : RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+    rtl_stream_prepare_retune_profile_for_target((uint32_t)target_freq_hz, cqpsk_request, sym_rate, 4, profile, ted_sps,
+                                                 ted_sps > 0 ? 1 : 0);
 
     /* One-shot override is consumed by this tune attempt. */
     state->p25_vc_cqpsk_override = -1;
 }
 
 static void
-dsd_engine_maybe_apply_ted_override(const dsd_opts* opts, const dsd_state* state, long int freq, int ted_sps) {
+dsd_engine_log_queued_ted_override(const dsd_opts* opts, const dsd_state* state, long int freq, int ted_sps) {
     if (opts->audio_in_type != AUDIO_IN_RTL || ted_sps <= 0) {
         return;
     }
-    rtl_stream_set_ted_sps(ted_sps);
     const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
     if (!cfg) {
         dsd_neo_config_init(NULL);
@@ -402,7 +416,7 @@ dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, i
      * Respect explicit CQPSK forcing via runtime config/env (DSD_NEO_CQPSK). */
 #ifdef USE_RADIO
     dsd_engine_rtl_profile_snapshot_capture(opts, state, &rtl_snapshot);
-    dsd_engine_prepare_vc_rtl_chain(opts, state);
+    dsd_engine_prepare_vc_rtl_chain(opts, state, freq, ted_sps);
 #endif
 
     // NOTE: We intentionally do NOT call rtl_stream_reset_costas() here.
@@ -423,11 +437,11 @@ dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, i
     // This matches OP25's architecture where configure_tdma/set_omega are called
     // synchronously with the frequency change, not asynchronously before it.
 
-    // Set TED samples-per-symbol override if provided by caller.
-    // The state machine determines the correct SPS for the current DSP rate and channel type
-    // and passes it directly.
+    // TED samples-per-symbol, CQPSK mode, and symbol profile changes were queued
+    // with the RTL controller above. They are applied after the hardware retune
+    // completes so old-frequency samples are never processed with new-channel timing.
 #ifdef USE_RADIO
-    dsd_engine_maybe_apply_ted_override(opts, state, freq, ted_sps);
+    dsd_engine_log_queued_ted_override(opts, state, freq, ted_sps);
 #endif
 
     dsd_engine_maybe_drain_audio(opts, state);
@@ -489,7 +503,7 @@ dsd_engine_trunk_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int
     dsd_engine_maybe_drain_audio(opts, state);
     if (opts->audio_in_type == AUDIO_IN_RTL) {
 #ifdef USE_RADIO
-        dsd_engine_prepare_cc_rtl_chain(opts, state, ted_sps);
+        dsd_engine_prepare_cc_rtl_chain(opts, state, freq, ted_sps);
 #endif
     }
     result = dsd_engine_tune_with_backend(opts, state, freq);

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -79,6 +79,7 @@ unsigned int dsd_rtl_stream_output_rate(void);
 int dsd_rtl_stream_ted_bias(void);
 int dsd_rtl_stream_set_rtltcp_autotune(int onoff);
 int dsd_rtl_stream_get_rtltcp_autotune(void);
+void dsd_rtl_stream_apply_pending_retune_profile_for_target(uint32_t target_freq_hz);
 #ifdef __cplusplus
 }
 #endif
@@ -174,6 +175,18 @@ static char udp_control_bindaddr[64] = "127.0.0.1";
 
 namespace {
 
+struct RtlRetuneProfile {
+    int active;
+    int cqpsk_enable;
+    int symbol_rate_hz;
+    int levels;
+    int channel_profile;
+    int ted_sps;
+    int ted_override;
+    uint32_t request_id;
+    uint32_t target_freq_hz;
+};
+
 struct dongle_state {
     dsd_thread_t thread;
     int dev_index;
@@ -201,6 +214,7 @@ struct controller_state {
     /* Marshalled retune request from external threads (UDP/API). */
     std::atomic<int> manual_retune_pending;
     uint32_t manual_retune_freq;
+    RtlRetuneProfile manual_retune_profile;
     /* Marshalled PPM correction updates stay on the controller thread so
      * device controls remain serialized with retunes/hops. */
     std::atomic<int> ppm_change_pending;
@@ -265,6 +279,8 @@ static std::atomic<uint32_t> g_retune_settle_seq{0};
 static std::atomic<int> g_retune_settle_blocks_remaining{0};
 static std::atomic<uint32_t> g_rtl_output_generation{1};
 static std::atomic<int> g_fsk_reacquire_pending{0};
+static std::mutex g_pending_retune_profile_mutex;
+static RtlRetuneProfile g_pending_retune_profile;
 static std::atomic<uint32_t> g_replay_event_retune_count{0};
 static std::atomic<uint32_t> g_replay_event_mute_count{0};
 static std::atomic<uint32_t> g_replay_event_reset_count{0};
@@ -279,6 +295,13 @@ static int controller_apply_replay_settings(struct controller_state* s, const ds
                                             const dsd_iq_replay_config* cfg);
 static const int kRetuneDiagBlocks = 20;
 static uint32_t rtl_stream_bump_output_generation(void);
+static void rtl_stream_clear_retune_profile(RtlRetuneProfile* profile);
+static int rtl_stream_take_pending_retune_profile(RtlRetuneProfile* out_profile, uint32_t request_id,
+                                                  uint32_t target_freq_hz);
+static void rtl_stream_store_pending_retune_profile(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz,
+                                                    int levels, int channel_profile, int ted_sps,
+                                                    int persist_ted_override);
+static void rtl_stream_apply_retune_profile(const RtlRetuneProfile* profile, uint32_t center_freq_hz);
 static void rtl_fsk_metrics_reset_snapshot(void);
 static void rtl_decode_health_reset(void);
 static void rtl_publish_fsk_metrics_from_demod(const struct demod_state* d);
@@ -3426,12 +3449,14 @@ rtl_stream_consume_fsk_reacquire_pending(struct demod_state* d) {
 static void
 controller_finalize_rate_chain(struct controller_state* s, const dsd_opts* opts, uint32_t center_freq_hz,
                                int mark_reconfigure, DemodRetuneResetReason reset_reason,
-                               uint32_t previous_center_freq_hz, int previous_rate_out_hz) {
+                               uint32_t previous_center_freq_hz, int previous_rate_out_hz,
+                               const RtlRetuneProfile* retune_profile) {
     if (!s || center_freq_hz == 0) {
         return;
     }
     s->last_applied_freq_hz.store(center_freq_hz, std::memory_order_release);
     rtl_demod_maybe_refresh_ted_sps_after_rate_change(&demod, opts, &output);
+    rtl_stream_apply_retune_profile(retune_profile, center_freq_hz);
     rtl_demod_maybe_update_resampler_after_rate_change(&demod, &output, rtl_dsp_bw_hz);
     DemodRetuneResetPlan reset_plan = demod_retune_reset_plan(reset_reason, previous_center_freq_hz, center_freq_hz,
                                                               previous_rate_out_hz, demod.rate_out);
@@ -3454,9 +3479,9 @@ controller_finalize_rate_chain(struct controller_state* s, const dsd_opts* opts,
 static void
 controller_finalize_reconfigure(struct controller_state* s, const dsd_opts* opts, uint32_t center_freq_hz,
                                 DemodRetuneResetReason reset_reason, uint32_t previous_center_freq_hz,
-                                int previous_rate_out_hz) {
+                                int previous_rate_out_hz, const RtlRetuneProfile* retune_profile) {
     controller_finalize_rate_chain(s, opts, center_freq_hz, 1, reset_reason, previous_center_freq_hz,
-                                   previous_rate_out_hz);
+                                   previous_rate_out_hz, retune_profile);
 }
 
 static inline void
@@ -3507,13 +3532,14 @@ controller_reconfigure_active_stream_locked(struct controller_state* s, uint32_t
     rtl_device_record_capture_retune(rtl_device_handle, center_freq_hz, load_dongle_frequency(), load_dongle_rate(),
                                      retune_reset_reason_name(reset_reason));
     controller_finalize_reconfigure(s, g_stream ? g_stream->opts : NULL, center_freq_hz, reset_reason,
-                                    previous_center_freq_hz, previous_rate_out_hz);
+                                    previous_center_freq_hz, previous_rate_out_hz, NULL);
     controller_arm_retune_mute("post-reset");
     rtl_device_end_capture_reconfigure(rtl_device_handle);
 }
 
 static int
-controller_apply_reconfigure(struct controller_state* s, uint32_t center_freq_hz, int ppm_error) {
+controller_apply_reconfigure(struct controller_state* s, uint32_t center_freq_hz, int ppm_error,
+                             const RtlRetuneProfile* retune_profile) {
     if (!s || center_freq_hz == 0) {
         return -1;
     }
@@ -3532,7 +3558,7 @@ controller_apply_reconfigure(struct controller_state* s, uint32_t center_freq_hz
     rtl_device_record_capture_retune(rtl_device_handle, center_freq_hz, load_dongle_frequency(), load_dongle_rate(),
                                      retune_reset_reason_name(reset_reason));
     controller_finalize_reconfigure(s, g_stream ? g_stream->opts : NULL, center_freq_hz, reset_reason,
-                                    previous_center_freq_hz, previous_rate_out_hz);
+                                    previous_center_freq_hz, previous_rate_out_hz, retune_profile);
     controller_arm_retune_mute("post-reset");
     rtl_device_end_capture_reconfigure(rtl_device_handle);
     controller_end_reconfigure(s);
@@ -3592,7 +3618,7 @@ rtl_replay_on_reset_event(const dsd_iq_event* event, void* user) {
     controller_enter_reconfigure_gate(&controller);
     controller_request_input_purge();
     controller_finalize_reconfigure(&controller, g_stream ? g_stream->opts : NULL, center_hz, reset_reason,
-                                    previous_center_hz, previous_rate_out_hz);
+                                    previous_center_hz, previous_rate_out_hz, NULL);
     controller_end_reconfigure(&controller);
     replay_wait_for_input_purge_applied();
     drain_output_on_retune();
@@ -3693,7 +3719,7 @@ controller_apply_initial_settings(struct controller_state* s, const dsd_opts* op
         return -1;
     }
 
-    controller_finalize_rate_chain(s, opts, (uint32_t)s->freqs[0], 0, DemodRetuneResetReason::FreshStream, 0U, 0);
+    controller_finalize_rate_chain(s, opts, (uint32_t)s->freqs[0], 0, DemodRetuneResetReason::FreshStream, 0U, 0, NULL);
     s->cold_start_ready.store(1, std::memory_order_release);
     return 0;
 }
@@ -3731,7 +3757,7 @@ controller_apply_replay_settings(struct controller_state* s, const dsd_opts* opt
 
     uint32_t center_hz =
         (uint32_t)((cfg->center_frequency_hz > 0) ? cfg->center_frequency_hz : cfg->capture_center_frequency_hz);
-    controller_finalize_rate_chain(s, opts, center_hz, 0, DemodRetuneResetReason::FreshStream, 0U, 0);
+    controller_finalize_rate_chain(s, opts, center_hz, 0, DemodRetuneResetReason::FreshStream, 0U, 0, NULL);
     s->cold_start_ready.store(1, std::memory_order_release);
     return 0;
 }
@@ -3744,6 +3770,9 @@ controller_apply_replay_settings(struct controller_state* s, const dsd_opts* opt
  */
 namespace {
 struct ControllerRetuneWork {
+    int manual_pending;
+    uint32_t manual_freq_hz;
+    RtlRetuneProfile manual_profile;
     int requested_ppm;
     uint32_t requested_ppm_request_id;
     int ppm_pending;
@@ -3767,6 +3796,9 @@ controller_wait_for_retune_work(struct controller_state* s, ControllerRetuneWork
     if (!s || !work) {
         return 0;
     }
+    work->manual_pending = 0;
+    work->manual_freq_hz = 0;
+    rtl_stream_clear_retune_profile(&work->manual_profile);
     dsd_mutex_lock(&s->hop_m);
     while (!s->manual_retune_pending.load(std::memory_order_acquire)
            && !s->ppm_change_pending.load(std::memory_order_acquire) && !exitflag
@@ -3776,6 +3808,12 @@ controller_wait_for_retune_work(struct controller_state* s, ControllerRetuneWork
     if (exitflag || (g_stream && g_stream->should_exit.load())) {
         dsd_mutex_unlock(&s->hop_m);
         return 0;
+    }
+    work->manual_pending = s->manual_retune_pending.exchange(0, std::memory_order_acq_rel);
+    if (work->manual_pending) {
+        work->manual_freq_hz = s->manual_retune_freq;
+        work->manual_profile = s->manual_retune_profile;
+        rtl_stream_clear_retune_profile(&s->manual_retune_profile);
     }
     work->requested_ppm = s->pending_ppm_error.load(std::memory_order_acquire);
     work->requested_ppm_request_id = s->pending_ppm_request_seq.load(std::memory_order_acquire);
@@ -3801,13 +3839,12 @@ controller_signal_manual_retune_complete(struct controller_state* s) {
 
 static int
 controller_process_manual_retune(struct controller_state* s, const ControllerRetuneWork* work) {
-    if (!s || !work || !s->manual_retune_pending.load(std::memory_order_acquire)) {
+    if (!s || !work || !work->manual_pending) {
         return 0;
     }
-    uint32_t target_hz = s->manual_retune_freq;
-    s->manual_retune_pending.store(0, std::memory_order_release);
+    uint32_t target_hz = work->manual_freq_hz;
     int target_ppm = work->ppm_changed ? work->requested_ppm : work->current_ppm;
-    int ppm_rc = controller_apply_reconfigure(s, target_hz, target_ppm);
+    int ppm_rc = controller_apply_reconfigure(s, target_hz, target_ppm, &work->manual_profile);
     if (work->ppm_changed && ppm_rc != 0) {
         note_failed_ppm_request(work->requested_ppm, work->requested_ppm_request_id, work->current_ppm, ppm_rc);
     }
@@ -3891,7 +3928,7 @@ static DSD_THREAD_RETURN_TYPE
             continue;
         }
         s->freq_now = (s->freq_now + 1) % s->freq_len;
-        controller_apply_reconfigure(s, (uint32_t)s->freqs[s->freq_now], work.current_ppm);
+        controller_apply_reconfigure(s, (uint32_t)s->freqs[s->freq_now], work.current_ppm, NULL);
         drain_output_on_retune();
     }
     DSD_THREAD_RETURN;
@@ -4435,6 +4472,7 @@ controller_init(struct controller_state* s) {
     dsd_mutex_init(&s->hop_m);
     s->manual_retune_pending.store(0);
     s->manual_retune_freq = 0;
+    rtl_stream_clear_retune_profile(&s->manual_retune_profile);
     s->ppm_change_pending.store(0);
     s->pending_ppm_error.store(0);
     s->ppm_request_publish_seq.store(0);
@@ -4550,19 +4588,29 @@ setup_initial_freq_and_rate(dsd_opts* opts) {
  * @return Request ID that will be completed once the queued retune finishes.
  */
 static uint32_t
-schedule_manual_retune(uint32_t target_freq_hz) {
-    dsd_mutex_lock(&controller.hop_m);
-    uint32_t request_id = controller.retune_request_id.load(std::memory_order_acquire);
-    int pending = controller.manual_retune_pending.load(std::memory_order_acquire);
+schedule_manual_retune_on_controller(struct controller_state* s, uint32_t target_freq_hz) {
+    if (!s) {
+        return 0U;
+    }
+    dsd_mutex_lock(&s->hop_m);
+    uint32_t request_id = s->retune_request_id.load(std::memory_order_acquire);
+    int pending = s->manual_retune_pending.load(std::memory_order_acquire);
     if (!pending) {
-        request_id = controller.retune_request_id.fetch_add(1, std::memory_order_acq_rel) + 1;
-        controller.manual_retune_pending.store(1, std::memory_order_release);
+        request_id = s->retune_request_id.fetch_add(1, std::memory_order_acq_rel) + 1;
+        s->manual_retune_pending.store(1, std::memory_order_release);
+        rtl_stream_clear_retune_profile(&s->manual_retune_profile);
     }
     /* Update/override target frequency even when coalescing into an existing pending retune. */
-    controller.manual_retune_freq = target_freq_hz;
-    dsd_cond_signal(&controller.hop);
-    dsd_mutex_unlock(&controller.hop_m);
+    s->manual_retune_freq = target_freq_hz;
+    (void)rtl_stream_take_pending_retune_profile(&s->manual_retune_profile, request_id, target_freq_hz);
+    dsd_cond_signal(&s->hop);
+    dsd_mutex_unlock(&s->hop_m);
     return request_id;
+}
+
+static uint32_t
+schedule_manual_retune(uint32_t target_freq_hz) {
+    return schedule_manual_retune_on_controller(&controller, target_freq_hz);
 }
 
 static void
@@ -6936,6 +6984,151 @@ rtl_stream_toggle_cqpsk(int onoff) {
     }
 }
 
+static int
+rtl_stream_clamp_retune_ted_sps(int sps) {
+    if (sps < 2) {
+        return 2;
+    }
+    if (sps > 64) {
+        return 64;
+    }
+    return sps;
+}
+
+static void
+rtl_stream_clear_retune_profile(RtlRetuneProfile* profile) {
+    if (profile) {
+        *profile = RtlRetuneProfile{};
+    }
+}
+
+static int
+rtl_stream_retune_profile_matches_target(const RtlRetuneProfile* profile, uint32_t target_freq_hz) {
+    if (!profile || !profile->active) {
+        return 0;
+    }
+    if (profile->target_freq_hz == 0U) {
+        return 1;
+    }
+    if (target_freq_hz == 0U) {
+        return 0;
+    }
+    return profile->target_freq_hz == target_freq_hz;
+}
+
+static int
+rtl_stream_take_pending_retune_profile(RtlRetuneProfile* out_profile, uint32_t request_id, uint32_t target_freq_hz) {
+    if (!out_profile) {
+        return 0;
+    }
+    std::lock_guard<std::mutex> lock(g_pending_retune_profile_mutex);
+    if (!rtl_stream_retune_profile_matches_target(&g_pending_retune_profile, target_freq_hz)) {
+        return 0;
+    }
+
+    rtl_stream_clear_retune_profile(out_profile);
+    *out_profile = g_pending_retune_profile;
+    out_profile->active = 1;
+    out_profile->request_id = request_id;
+    if (out_profile->target_freq_hz == 0U) {
+        out_profile->target_freq_hz = target_freq_hz;
+    }
+    rtl_stream_clear_retune_profile(&g_pending_retune_profile);
+    return 1;
+}
+
+static void
+rtl_stream_store_pending_retune_profile(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz, int levels,
+                                        int channel_profile, int ted_sps, int persist_ted_override) {
+    if (levels != 2 && levels != 4) {
+        levels = 4;
+    }
+    if (ted_sps > 0) {
+        ted_sps = rtl_stream_clamp_retune_ted_sps(ted_sps);
+    }
+
+    RtlRetuneProfile profile{};
+    profile.active = 1;
+    profile.cqpsk_enable = cqpsk_enable;
+    profile.symbol_rate_hz = symbol_rate_hz;
+    profile.levels = levels;
+    profile.channel_profile = channel_profile;
+    profile.ted_sps = ted_sps;
+    profile.ted_override = persist_ted_override ? 1 : 0;
+    profile.target_freq_hz = target_freq_hz;
+
+    std::lock_guard<std::mutex> lock(g_pending_retune_profile_mutex);
+    g_pending_retune_profile = profile;
+}
+
+extern "C" void
+dsd_rtl_stream_prepare_retune_profile(int cqpsk_enable, int symbol_rate_hz, int levels, int channel_profile,
+                                      int ted_sps, int persist_ted_override) {
+    rtl_stream_store_pending_retune_profile(0U, cqpsk_enable, symbol_rate_hz, levels, channel_profile, ted_sps,
+                                            persist_ted_override);
+}
+
+extern "C" void
+dsd_rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz,
+                                                 int levels, int channel_profile, int ted_sps,
+                                                 int persist_ted_override) {
+    rtl_stream_store_pending_retune_profile(target_freq_hz, cqpsk_enable, symbol_rate_hz, levels, channel_profile,
+                                            ted_sps, persist_ted_override);
+}
+
+extern "C" void
+dsd_rtl_stream_clear_pending_retune_profile(void) {
+    std::lock_guard<std::mutex> lock(g_pending_retune_profile_mutex);
+    rtl_stream_clear_retune_profile(&g_pending_retune_profile);
+}
+
+static void
+rtl_stream_apply_retune_profile(const RtlRetuneProfile* profile, uint32_t center_freq_hz) {
+    if (!profile || !profile->active) {
+        return;
+    }
+    if (profile->target_freq_hz != 0U) {
+        if (center_freq_hz == 0U || profile->target_freq_hz != center_freq_hz) {
+            return;
+        }
+    }
+
+    int cqpsk = profile->cqpsk_enable;
+    if (cqpsk >= 0) {
+        rtl_stream_toggle_cqpsk(cqpsk);
+    }
+
+    int symbol_rate_hz = profile->symbol_rate_hz;
+    int levels = profile->levels;
+    int channel_profile = profile->channel_profile;
+    if (symbol_rate_hz > 0 && (levels == 2 || levels == 4)) {
+        (void)dsd_rtl_stream_set_symbol_profile(symbol_rate_hz, levels, channel_profile);
+    }
+
+    int ted_sps = profile->ted_sps;
+    if (ted_sps <= 0) {
+        return;
+    }
+    ted_sps = rtl_stream_clamp_retune_ted_sps(ted_sps);
+    if (ted_sps != demod.ted_sps) {
+        demod.costas_reset_pending = 1;
+    }
+    demod.ted_sps = ted_sps;
+    demod.ted_sps_override = profile->ted_override ? ted_sps : 0;
+}
+
+extern "C" void
+dsd_rtl_stream_apply_pending_retune_profile(void) {
+    dsd_rtl_stream_apply_pending_retune_profile_for_target(0U);
+}
+
+extern "C" void
+dsd_rtl_stream_apply_pending_retune_profile_for_target(uint32_t target_freq_hz) {
+    RtlRetuneProfile profile{};
+    (void)rtl_stream_take_pending_retune_profile(&profile, 0U, target_freq_hz);
+    rtl_stream_apply_retune_profile(&profile, target_freq_hz);
+}
+
 extern "C" void
 rtl_stream_toggle_fll(int onoff) {
     if (rtl_stream_symbol_output_active()) {
@@ -7536,6 +7729,98 @@ dsd_rtl_stream_test_fsk_reacquire(int output_kind, size_t queued_samples, int ca
     g_fsk_reacquire_pending.store(0, std::memory_order_release);
     fsk_reacquire_test_reset_output_state();
     fsk_reacquire_test_cleanup_output_ring(initialized_output);
+    return 0;
+}
+
+extern "C" int
+dsd_rtl_stream_test_retune_profile_request_binding(int* out_first_profile, int* out_second_profile,
+                                                   uint32_t* out_first_freq_hz, uint32_t* out_second_freq_hz,
+                                                   uint32_t* out_first_request_id, uint32_t* out_second_request_id) {
+    if (!out_first_profile || !out_second_profile || !out_first_freq_hz || !out_second_freq_hz || !out_first_request_id
+        || !out_second_request_id) {
+        return -1;
+    }
+    *out_first_profile = -1;
+    *out_second_profile = -1;
+    *out_first_freq_hz = 0U;
+    *out_second_freq_hz = 0U;
+    *out_first_request_id = 0U;
+    *out_second_request_id = 0U;
+
+    controller_state test_controller = {};
+    controller_init(&test_controller);
+    dsd_rtl_stream_clear_pending_retune_profile();
+
+    dsd_rtl_stream_prepare_retune_profile_for_target(855000000U, 1, 6000, 4, RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK, 8,
+                                                     1);
+    uint32_t unrelated_request_id = schedule_manual_retune_on_controller(&test_controller, 851000000U);
+    uint32_t first_request_id = schedule_manual_retune_on_controller(&test_controller, 855000000U);
+    ControllerRetuneWork first = {};
+    if (!controller_wait_for_retune_work(&test_controller, &first) || !first.manual_pending) {
+        controller_cleanup(&test_controller);
+        return -2;
+    }
+
+    dsd_rtl_stream_prepare_retune_profile_for_target(851000000U, 0, 4800, 4, RTL_STREAM_CHANNEL_PROFILE_P25_C4FM, 5, 0);
+    uint32_t second_request_id = schedule_manual_retune_on_controller(&test_controller, 851000000U);
+    ControllerRetuneWork second = {};
+    if (!controller_wait_for_retune_work(&test_controller, &second) || !second.manual_pending) {
+        controller_cleanup(&test_controller);
+        return -3;
+    }
+
+    *out_first_profile = first.manual_profile.channel_profile;
+    *out_second_profile = second.manual_profile.channel_profile;
+    *out_first_freq_hz = first.manual_profile.target_freq_hz;
+    *out_second_freq_hz = second.manual_profile.target_freq_hz;
+    *out_first_request_id = first.manual_profile.request_id;
+    *out_second_request_id = second.manual_profile.request_id;
+
+    controller_cleanup(&test_controller);
+    if (unrelated_request_id != first_request_id || *out_first_request_id != first_request_id
+        || *out_second_request_id != second_request_id) {
+        return -4;
+    }
+    return 0;
+}
+
+extern "C" int
+dsd_rtl_stream_test_retune_profile_coalesced_no_profile(int* out_profile, uint32_t* out_profile_freq_hz,
+                                                        uint32_t* out_manual_freq_hz, uint32_t* out_request_id,
+                                                        uint32_t* out_coalesced_request_id) {
+    if (!out_profile || !out_profile_freq_hz || !out_manual_freq_hz || !out_request_id || !out_coalesced_request_id) {
+        return -1;
+    }
+    *out_profile = -1;
+    *out_profile_freq_hz = 0U;
+    *out_manual_freq_hz = 0U;
+    *out_request_id = 0U;
+    *out_coalesced_request_id = 0U;
+
+    controller_state test_controller = {};
+    controller_init(&test_controller);
+    dsd_rtl_stream_clear_pending_retune_profile();
+
+    dsd_rtl_stream_prepare_retune_profile_for_target(855000000U, 1, 6000, 4, RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK, 8,
+                                                     1);
+    uint32_t first_request_id = schedule_manual_retune_on_controller(&test_controller, 855000000U);
+    uint32_t second_request_id = schedule_manual_retune_on_controller(&test_controller, 855000000U);
+    ControllerRetuneWork work = {};
+    if (!controller_wait_for_retune_work(&test_controller, &work) || !work.manual_pending) {
+        controller_cleanup(&test_controller);
+        return -2;
+    }
+
+    *out_profile = work.manual_profile.channel_profile;
+    *out_profile_freq_hz = work.manual_profile.target_freq_hz;
+    *out_manual_freq_hz = work.manual_freq_hz;
+    *out_request_id = work.manual_profile.request_id;
+    *out_coalesced_request_id = second_request_id;
+
+    controller_cleanup(&test_controller);
+    if (second_request_id != first_request_id) {
+        return -3;
+    }
     return 0;
 }
 

--- a/src/io/radio/rtl_stream_c.cpp
+++ b/src/io/radio/rtl_stream_c.cpp
@@ -31,6 +31,14 @@ int dsd_rtl_stream_get_output_kind(void);
 int dsd_rtl_stream_get_symbol_profile(int* out_symbol_rate_hz, int* out_levels);
 int dsd_rtl_stream_get_symbol_profile_full(int* out_symbol_rate_hz, int* out_levels, int* out_channel_profile);
 int dsd_rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profile);
+void dsd_rtl_stream_prepare_retune_profile(int cqpsk_enable, int symbol_rate_hz, int levels, int channel_profile,
+                                           int ted_sps, int persist_ted_override);
+void dsd_rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz,
+                                                      int levels, int channel_profile, int ted_sps,
+                                                      int persist_ted_override);
+void dsd_rtl_stream_apply_pending_retune_profile(void);
+void dsd_rtl_stream_apply_pending_retune_profile_for_target(uint32_t target_freq_hz);
+void dsd_rtl_stream_clear_pending_retune_profile(void);
 int dsd_rtl_stream_request_fsk_reacquire(void);
 uint32_t dsd_rtl_stream_output_generation(void);
 int dsd_rtl_stream_monitor_read(float* out, size_t count, int* out_got);
@@ -98,6 +106,12 @@ int dsd_rtl_stream_test_fsk_reacquire(int output_kind, size_t queued_samples, in
                                       size_t* out_used_after, int* out_cache_pending_after,
                                       uint32_t* out_generation_before, uint32_t* out_generation_after,
                                       int* out_request_rc, int* out_consumed);
+int dsd_rtl_stream_test_retune_profile_request_binding(int* out_first_profile, int* out_second_profile,
+                                                       uint32_t* out_first_freq_hz, uint32_t* out_second_freq_hz,
+                                                       uint32_t* out_first_request_id, uint32_t* out_second_request_id);
+int dsd_rtl_stream_test_retune_profile_coalesced_no_profile(int* out_profile, uint32_t* out_profile_freq_hz,
+                                                            uint32_t* out_manual_freq_hz, uint32_t* out_request_id,
+                                                            uint32_t* out_coalesced_request_id);
 int dsd_rtl_stream_test_get_replay_state(rtl_stream_test_replay_state* out_state);
 int dsd_rtl_stream_test_steady_state_watermark_enabled(const char* audio_in_dev);
 #endif
@@ -276,6 +290,23 @@ rtl_stream_test_fsk_reacquire(int output_kind, size_t queued_samples, int cached
 }
 
 extern "C" int
+rtl_stream_test_retune_profile_request_binding(int* out_first_profile, int* out_second_profile,
+                                               uint32_t* out_first_freq_hz, uint32_t* out_second_freq_hz,
+                                               uint32_t* out_first_request_id, uint32_t* out_second_request_id) {
+    return dsd_rtl_stream_test_retune_profile_request_binding(out_first_profile, out_second_profile, out_first_freq_hz,
+                                                              out_second_freq_hz, out_first_request_id,
+                                                              out_second_request_id);
+}
+
+extern "C" int
+rtl_stream_test_retune_profile_coalesced_no_profile(int* out_profile, uint32_t* out_profile_freq_hz,
+                                                    uint32_t* out_manual_freq_hz, uint32_t* out_request_id,
+                                                    uint32_t* out_coalesced_request_id) {
+    return dsd_rtl_stream_test_retune_profile_coalesced_no_profile(out_profile, out_profile_freq_hz, out_manual_freq_hz,
+                                                                   out_request_id, out_coalesced_request_id);
+}
+
+extern "C" int
 rtl_stream_test_get_replay_state(const RtlSdrContext* ctx, rtl_stream_test_replay_state* out_state) {
     if (!ctx || !ctx->stream || !out_state) {
         return -2;
@@ -364,6 +395,35 @@ rtl_stream_get_symbol_profile_full(int* out_symbol_rate_hz, int* out_levels, int
 extern "C" int
 rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profile) {
     return dsd_rtl_stream_set_symbol_profile(symbol_rate_hz, levels, channel_profile);
+}
+
+extern "C" void
+rtl_stream_prepare_retune_profile(int cqpsk_enable, int symbol_rate_hz, int levels, int channel_profile, int ted_sps,
+                                  int persist_ted_override) {
+    dsd_rtl_stream_prepare_retune_profile(cqpsk_enable, symbol_rate_hz, levels, channel_profile, ted_sps,
+                                          persist_ted_override);
+}
+
+extern "C" void
+rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz, int levels,
+                                             int channel_profile, int ted_sps, int persist_ted_override) {
+    dsd_rtl_stream_prepare_retune_profile_for_target(target_freq_hz, cqpsk_enable, symbol_rate_hz, levels,
+                                                     channel_profile, ted_sps, persist_ted_override);
+}
+
+extern "C" void
+rtl_stream_apply_pending_retune_profile(void) {
+    dsd_rtl_stream_apply_pending_retune_profile();
+}
+
+extern "C" void
+rtl_stream_apply_pending_retune_profile_for_target(uint32_t target_freq_hz) {
+    dsd_rtl_stream_apply_pending_retune_profile_for_target(target_freq_hz);
+}
+
+extern "C" void
+rtl_stream_clear_pending_retune_profile(void) {
+    dsd_rtl_stream_clear_pending_retune_profile();
 }
 
 extern "C" int

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1463,6 +1463,24 @@ endif()
 add_test(NAME ENGINE_CLEANUP_AUDIO COMMAND dsd-neo_test_engine_cleanup_audio)
 
 add_executable(
+    dsd-neo_test_engine_trunk_retune_regression
+    engine/test_engine_trunk_retune_regression.c
+    ${PROJECT_SOURCE_DIR}/src/engine/trunk_tuning.c
+)
+target_include_directories(
+    dsd-neo_test_engine_trunk_retune_regression
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_engine_trunk_retune_regression
+    PRIVATE dsd-neo_feature_radio
+)
+add_test(
+    NAME ENGINE_TRUNK_RETUNE_REGRESSION
+    COMMAND dsd-neo_test_engine_trunk_retune_regression
+)
+
+add_executable(
     dsd-neo_test_runtime_config_user
     runtime/test_runtime_config_user.cpp
 )
@@ -2982,25 +3000,6 @@ target_link_libraries(
     PRIVATE dsd-neo_platform dsd-neo_runtime ${DSD_NEO_TEST_MATH_LIB}
 )
 add_test(NAME DMR_T3_ANN_WD_TSCC COMMAND dsd-neo_test_dmr_t3_ann_wd_tscc)
-
-# DMR Tier III regression: return-to-CC must work with trunk_enable only
-add_executable(
-    dsd-neo_test_dmr_t3_return_to_cc_regression
-    protocol/dmr/test_dmr_t3_return_to_cc_regression.c
-    ${PROJECT_SOURCE_DIR}/src/engine/trunk_tuning.c
-)
-target_include_directories(
-    dsd-neo_test_dmr_t3_return_to_cc_regression
-    PRIVATE ${PROJECT_SOURCE_DIR}/include
-)
-target_link_libraries(
-    dsd-neo_test_dmr_t3_return_to_cc_regression
-    PRIVATE dsd-neo_feature_radio
-)
-add_test(
-    NAME DMR_T3_RETURN_TO_CC_REGRESSION
-    COMMAND dsd-neo_test_dmr_t3_return_to_cc_regression
-)
 
 # DSP block tests
 add_executable(dsd-neo_test_dsp_halfband dsp/test_dsp_halfband.cpp)

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -4,9 +4,11 @@
  */
 
 /*
- * Regression: DMR Tier III return-to-CC must retune even when only
- * trunk_enable is set (p25_trunk disabled), and must not apply P25-only
- * CC symbol/modulation overrides when no P25 CC is active.
+ * Regression coverage for trunk retune edge cases:
+ * - protocol-agnostic return-to-CC must retune when only trunk_enable is set
+ * - non-P25 trunking must not apply P25-only CC symbol/modulation overrides
+ * - RTL P25 voice/CC retunes must queue demod profile changes until the
+ *   controller reaches the hardware retune boundary
  */
 
 #include <assert.h>
@@ -51,6 +53,14 @@ static int g_rtl_ted_sps = 5;
 static int g_rtl_ted_sps_override = 0;
 static int g_drain_audio_calls = 0;
 static int g_rtl_tune_calls = 0;
+static int g_rtl_pending_active = 0;
+static int g_rtl_pending_cqpsk = -1;
+static int g_rtl_pending_symbol_rate_hz = 0;
+static int g_rtl_pending_symbol_levels = 0;
+static int g_rtl_pending_channel_profile = -1;
+static int g_rtl_pending_ted_sps = 0;
+static int g_rtl_pending_ted_override = 0;
+static uint32_t g_rtl_pending_target_freq_hz = 0;
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -105,11 +115,39 @@ rtl_stream_output_rate(const RtlSdrContext* ctx) {
     return 48000;
 }
 
+static void
+apply_pending_retune_profile(uint32_t target_freq_hz) {
+    if (!g_rtl_pending_active) {
+        return;
+    }
+    if (g_rtl_pending_target_freq_hz != 0) {
+        if (target_freq_hz == 0 || g_rtl_pending_target_freq_hz != target_freq_hz) {
+            return;
+        }
+    }
+    if (g_rtl_pending_cqpsk >= 0) {
+        g_rtl_cqpsk_enable = g_rtl_pending_cqpsk ? 1 : 0;
+    }
+    if (g_rtl_pending_symbol_rate_hz > 0 && (g_rtl_pending_symbol_levels == 2 || g_rtl_pending_symbol_levels == 4)) {
+        g_rtl_symbol_rate_hz = g_rtl_pending_symbol_rate_hz;
+        g_rtl_symbol_levels = g_rtl_pending_symbol_levels;
+        g_rtl_channel_profile = g_rtl_pending_channel_profile;
+    }
+    if (g_rtl_pending_ted_sps > 0) {
+        g_rtl_ted_sps = g_rtl_pending_ted_sps;
+        g_rtl_ted_sps_override = g_rtl_pending_ted_override ? g_rtl_pending_ted_sps : 0;
+    }
+    g_rtl_pending_active = 0;
+    g_rtl_pending_target_freq_hz = 0;
+}
+
 int
 rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz) {
     (void)ctx;
-    (void)center_freq_hz;
     g_rtl_tune_calls++;
+    if (g_rtl_tune_result == RTL_STREAM_TUNE_OK) {
+        apply_pending_retune_profile(center_freq_hz);
+    }
     return g_rtl_tune_result;
 }
 
@@ -155,6 +193,42 @@ rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profil
     g_rtl_symbol_levels = levels;
     g_rtl_channel_profile = channel_profile;
     return 0;
+}
+
+void
+rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz, int levels,
+                                             int channel_profile, int ted_sps, int persist_ted_override) {
+    g_rtl_pending_cqpsk = cqpsk_enable;
+    g_rtl_pending_symbol_rate_hz = symbol_rate_hz;
+    g_rtl_pending_symbol_levels = levels;
+    g_rtl_pending_channel_profile = channel_profile;
+    g_rtl_pending_ted_sps = ted_sps;
+    g_rtl_pending_ted_override = persist_ted_override ? 1 : 0;
+    g_rtl_pending_target_freq_hz = target_freq_hz;
+    g_rtl_pending_active = 1;
+}
+
+void
+rtl_stream_prepare_retune_profile(int cqpsk_enable, int symbol_rate_hz, int levels, int channel_profile, int ted_sps,
+                                  int persist_ted_override) {
+    rtl_stream_prepare_retune_profile_for_target(0, cqpsk_enable, symbol_rate_hz, levels, channel_profile, ted_sps,
+                                                 persist_ted_override);
+}
+
+void
+rtl_stream_apply_pending_retune_profile(void) {
+    apply_pending_retune_profile(0);
+}
+
+void
+rtl_stream_apply_pending_retune_profile_for_target(uint32_t target_freq_hz) {
+    apply_pending_retune_profile(target_freq_hz);
+}
+
+void
+rtl_stream_clear_pending_retune_profile(void) {
+    g_rtl_pending_active = 0;
+    g_rtl_pending_target_freq_hz = 0;
 }
 
 int
@@ -290,6 +364,39 @@ main(void) {
     assert(g_last_setfreq_hz == 853500000);
     assert(g_rtl_tune_calls == 0);
 
+    /* RTL audio retuned by rigctl has no native RTL controller boundary, so the
+     * queued P25 VC demod profile must be applied after SetFreq succeeds. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->use_rigctl = 1;
+    opts->p25_trunk = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 1;
+    state->p25_p2_active_slot = 0;
+    state->p25_vc_cqpsk_override = 1;
+    g_setfreq_calls = 0;
+    g_last_setfreq_hz = 0;
+    g_setfreq_result = true;
+    g_rtl_tune_calls = 0;
+    g_rtl_cqpsk_enable = 0;
+    g_rtl_symbol_rate_hz = 4800;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+    g_rtl_ted_sps = 5;
+    g_rtl_ted_sps_override = 0;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_trunk_tune_to_freq(opts, state, 853750000, 8) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_setfreq_calls == 1);
+    assert(g_last_setfreq_hz == 853750000);
+    assert(g_rtl_tune_calls == 0);
+    assert(g_rtl_pending_active == 0);
+    assert(g_rtl_cqpsk_enable == 1);
+    assert(g_rtl_symbol_rate_hz == 6000);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    assert(g_rtl_ted_sps == 8);
+    assert(g_rtl_ted_sps_override == 8);
+
     /* If the frequency command itself fails, the decoder must not advance state
      * or reset DSP acquisition state for a channel it did not tune to. */
     DSD_MEMSET(opts, 0, sizeof(*opts));
@@ -336,6 +443,7 @@ main(void) {
     g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
     g_rtl_ted_sps = 5;
     g_rtl_ted_sps_override = 0;
+    g_rtl_pending_active = 0;
     g_frame_sync_reset_calls = 0;
     g_p25p2_frame_reset_calls = 0;
     assert(dsd_engine_trunk_tune_to_freq(opts, state, 855000000, 4) == DSD_TRUNK_TUNE_RESULT_DEFERRED);
@@ -347,11 +455,13 @@ main(void) {
     assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
     assert(g_rtl_ted_sps == 5);
     assert(g_rtl_ted_sps_override == 0);
+    assert(g_rtl_pending_active == 0);
     assert(g_frame_sync_reset_calls == 0);
     assert(g_p25p2_frame_reset_calls == 0);
 
-    /* Pending RTL retunes keep the requested demod profile and trunk state
-     * because the queued controller request may still complete after timeout. */
+    /* Pending RTL retunes keep active demod settings unchanged until the
+     * controller reaches the retune boundary, while preserving the requested
+     * profile for that queued hardware request. */
     DSD_MEMSET(opts, 0, sizeof(*opts));
     DSD_MEMSET(state, 0, sizeof(*state));
     opts->audio_in_type = AUDIO_IN_RTL;
@@ -367,22 +477,29 @@ main(void) {
     g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
     g_rtl_ted_sps = 5;
     g_rtl_ted_sps_override = 0;
+    g_rtl_pending_active = 0;
     g_frame_sync_reset_calls = 0;
     g_p25p2_frame_reset_calls = 0;
     assert(dsd_engine_trunk_tune_to_freq(opts, state, 855000000, 8) == DSD_TRUNK_TUNE_RESULT_PENDING);
     assert(opts->trunk_is_tuned == 1);
     assert(state->trunk_vc_freq[0] == 855000000);
     assert(state->p25_vc_cqpsk_override == -1);
-    assert(g_rtl_cqpsk_enable == 1);
-    assert(g_rtl_symbol_rate_hz == 6000);
-    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    assert(g_rtl_cqpsk_enable == 0);
+    assert(g_rtl_symbol_rate_hz == 4800);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
     assert(g_rtl_ted_sps == 5);
-    assert(g_rtl_ted_sps_override == 8);
+    assert(g_rtl_ted_sps_override == 0);
+    assert(g_rtl_pending_active == 1);
+    assert(g_rtl_pending_cqpsk == 1);
+    assert(g_rtl_pending_symbol_rate_hz == 6000);
+    assert(g_rtl_pending_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    assert(g_rtl_pending_ted_sps == 8);
+    assert(g_rtl_pending_ted_override == 1);
     assert(g_frame_sync_reset_calls == 1);
     assert(g_p25p2_frame_reset_calls == 1);
 
-    /* Pending RTL CC retunes likewise keep the requested CC profile and tracked
-     * CC state aligned with the queued hardware request. */
+    /* Pending RTL CC retunes likewise leave the active demod settings alone
+     * until the controller applies the queued control-channel profile. */
     DSD_MEMSET(opts, 0, sizeof(*opts));
     DSD_MEMSET(state, 0, sizeof(*state));
     opts->audio_in_type = AUDIO_IN_RTL;
@@ -398,19 +515,64 @@ main(void) {
     g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
     g_rtl_ted_sps = 5;
     g_rtl_ted_sps_override = 0;
+    g_rtl_pending_active = 0;
     g_frame_sync_reset_calls = 0;
     assert(dsd_engine_trunk_tune_to_cc(opts, state, 852000000, 4) == DSD_TRUNK_TUNE_RESULT_PENDING);
     assert(state->rf_mod == 1);
     assert(state->trunk_cc_freq == 852000000);
+    assert(g_rtl_cqpsk_enable == 0);
+    assert(g_rtl_symbol_rate_hz == 4800);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
+    assert(g_rtl_ted_sps == 5);
+    assert(g_rtl_ted_sps_override == 0);
+    assert(g_rtl_pending_active == 1);
+    assert(g_rtl_pending_cqpsk == 1);
+    assert(g_rtl_pending_symbol_rate_hz == 6000);
+    assert(g_rtl_pending_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    assert(g_rtl_pending_ted_sps == 4);
+    assert(g_rtl_pending_ted_override == 0);
+    assert(g_frame_sync_reset_calls == 1);
+
+    /* Simulcast P25P2 voice return to a P25P1 CQPSK control channel applies
+     * the 4800 sps CQPSK profile only after the RTL retune succeeds. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    opts->mod_qpsk = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 851000000;
+    state->trunk_cc_freq = 851000000;
+    state->p25_cc_is_tdma = 0;
+    state->p25_p2_active_slot = 0;
+    state->rf_mod = 1;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_cqpsk_enable = 1;
+    g_rtl_symbol_rate_hz = 6000;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
+    g_rtl_ted_sps = 8;
+    g_rtl_ted_sps_override = 8;
+    g_rtl_pending_active = 0;
+    g_frame_sync_reset_calls = 0;
+    assert(dsd_engine_return_to_cc(opts, state) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(opts->trunk_is_tuned == 0);
+    assert(opts->p25_is_tuned == 0);
+    assert(state->rf_mod == 1);
+    assert(state->samplesPerSymbol == 10);
+    assert(g_rtl_pending_active == 0);
     assert(g_rtl_cqpsk_enable == 1);
-    assert(g_rtl_symbol_rate_hz == 6000);
+    assert(g_rtl_symbol_rate_hz == 4800);
     assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
-    assert(g_rtl_ted_sps == 4);
+    assert(g_rtl_ted_sps == 10);
     assert(g_rtl_ted_sps_override == 0);
     assert(g_frame_sync_reset_calls == 1);
 #endif
 
-    printf("DMR_T3_RETURN_TO_CC_REGRESSION: OK\n");
+    printf("ENGINE_TRUNK_RETUNE_REGRESSION: OK\n");
     free(state);
     free(opts);
     return 0;

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -145,6 +145,41 @@ main(void) {
     failed |= expect_size_eq("inactive fsk reacquire leaves queued ring", used_after, 9U);
     failed |= expect_int_eq("inactive fsk reacquire leaves cached symbols", cache_pending, 4);
 
+    int first_profile = -1;
+    int second_profile = -1;
+    uint32_t first_freq_hz = 0U;
+    uint32_t second_freq_hz = 0U;
+    uint32_t first_request_id = 0U;
+    uint32_t second_request_id = 0U;
+    rc = rtl_stream_test_retune_profile_request_binding(&first_profile, &second_profile, &first_freq_hz,
+                                                        &second_freq_hz, &first_request_id, &second_request_id);
+    failed |= expect_int_eq("retune profile request binding helper rc", rc, 0);
+    failed |= expect_int_eq("first retune keeps CQPSK profile", first_profile, RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    failed |= expect_int_eq("second retune keeps C4FM profile", second_profile, RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
+    failed |= expect_int_eq("first retune profile keeps frequency", (int)first_freq_hz, 855000000);
+    failed |= expect_int_eq("second retune profile keeps frequency", (int)second_freq_hz, 851000000);
+    failed |= expect_int_eq("first retune profile keeps request id", (int)first_request_id, 1);
+    failed |= expect_int_eq("second retune profile keeps request id", (int)second_request_id, 2);
+
+    int coalesced_profile = -1;
+    uint32_t coalesced_profile_freq_hz = 0U;
+    uint32_t coalesced_manual_freq_hz = 0U;
+    uint32_t coalesced_request_id = 0U;
+    uint32_t coalesced_returned_request_id = 0U;
+    rc = rtl_stream_test_retune_profile_coalesced_no_profile(&coalesced_profile, &coalesced_profile_freq_hz,
+                                                             &coalesced_manual_freq_hz, &coalesced_request_id,
+                                                             &coalesced_returned_request_id);
+    failed |= expect_int_eq("coalesced retune profile helper rc", rc, 0);
+    failed |= expect_int_eq("coalesced no-profile retune keeps profile", coalesced_profile,
+                            RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    failed |=
+        expect_int_eq("coalesced no-profile retune keeps profile frequency", (int)coalesced_profile_freq_hz, 855000000);
+    failed |=
+        expect_int_eq("coalesced no-profile retune keeps manual frequency", (int)coalesced_manual_freq_hz, 855000000);
+    failed |= expect_int_eq("coalesced no-profile retune keeps request id", (int)coalesced_request_id, 1);
+    failed |= expect_int_eq("coalesced no-profile retune returns coalesced request id",
+                            (int)coalesced_returned_request_id, 1);
+
     // Fragmented mute spans are coalesced so capture metadata stays IQ-pair aligned.
     uint64_t pending_mute = 0U;
     uint64_t emitted = rtl_device_test_coalesce_capture_mute_duration(&pending_mute, 1U, 2U);


### PR DESCRIPTION
## Summary

- Queue RTL demod profile changes against the intended retune target, then apply CQPSK, symbol-rate, and TED settings at the native controller or external rigctl retune boundary.
- Prevent stale P25P2 voice-channel samples from training the demodulator with a P25P1 CQPSK control-channel profile during return-to-CC.
- Move the mixed return-to-CC regression into engine coverage and add RTL retune-profile binding tests.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / none. Marked area: radio input.
- [x] Outside review was requested when available, or unavailability is documented. Local review cleanups were incorporated before submission.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. No new suppressions.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [x] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes
- [x] `tools/zizmor.sh` for workflow changes
- [x] `tools/osv_scan.sh` for dependency input changes
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes

Additional checks run:
- `tools/format.sh`
- `ctest --preset dev-debug --output-on-failure -R "ENGINE_TRUNK_RETUNE_REGRESSION|IO_RTL_DEMOD_CONFIG|RTL_SYMBOL_CACHE_GENERATION|IO_RTL_RETUNE_PREPARE|P25_P1_TRUNK_SM|P25_TRUNK_SM_TIMING|P25_SM_UNIFIED_CORE|P25_SM_CORE"`
- Pre-push guardrails ran clang-format, gersemi, clang-tidy strict, cppcheck strict, IWYU strict, GCC fanalyzer strict, Semgrep strict, and Lizard complexity.

## Risk

- Security/dependency impact: none expected.
- CLI/UI behavior impact: none expected.
- Compatibility or packaging impact: low; adds RTL retune profile helper API and keeps existing helper behavior available.
