### PR TITLE
security: make protocol dispatch statically visible

### DIFF
--- a/src/engine/dispatch/protocol_dispatch.c
+++ b/src/engine/dispatch/protocol_dispatch.c
@@ -6,28 +6,63 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/protocol_dispatch.h>
-#include <string.h>
+
+#include <stddef.h>
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "protocol_dispatch_impl.h"
 
-static const dsd_protocol_handler*
-dsd_find_protocol_handler(int synctype) {
-    const dsd_protocol_handler* handler = dsd_protocol_handlers;
-    const dsd_protocol_handler* fallback = NULL;
+static int
+dsd_dispatch_known_frame(dsd_opts* opts, dsd_state* state) {
+    const int synctype = state->synctype;
 
-    while (handler->name != NULL) {
-        if (handler->matches_synctype != NULL && handler->matches_synctype(synctype)) {
-            return handler;
-        }
-        if (fallback == NULL && strcmp(handler->name, "P25P1") == 0) {
-            fallback = handler;
-        }
-        handler++;
+    if (dsd_dispatch_matches_nxdn(synctype)) {
+        dsd_dispatch_handle_nxdn(opts, state);
+        return 1;
+    }
+    if (dsd_dispatch_matches_dstar(synctype)) {
+        dsd_dispatch_handle_dstar(opts, state);
+        return 1;
+    }
+    if (dsd_dispatch_matches_dmr(synctype)) {
+        dsd_dispatch_handle_dmr(opts, state);
+        return 1;
+    }
+    if (dsd_dispatch_matches_x2tdma(synctype)) {
+        dsd_dispatch_handle_x2tdma(opts, state);
+        return 1;
+    }
+    if (dsd_dispatch_matches_provoice(synctype)) {
+        dsd_dispatch_handle_provoice(opts, state);
+        return 1;
+    }
+    if (dsd_dispatch_matches_edacs(synctype)) {
+        dsd_dispatch_handle_edacs(opts, state);
+        return 1;
+    }
+    if (dsd_dispatch_matches_ysf(synctype)) {
+        dsd_dispatch_handle_ysf(opts, state);
+        return 1;
+    }
+    if (dsd_dispatch_matches_m17(synctype)) {
+        dsd_dispatch_handle_m17(opts, state);
+        return 1;
+    }
+    if (dsd_dispatch_matches_p25p2(synctype)) {
+        dsd_dispatch_handle_p25p2(opts, state);
+        return 1;
+    }
+    if (dsd_dispatch_matches_dpmr(synctype)) {
+        dsd_dispatch_handle_dpmr(opts, state);
+        return 1;
+    }
+    if (dsd_dispatch_matches_p25p1(synctype)) {
+        dsd_dispatch_handle_p25p1(opts, state);
+        return 1;
     }
 
-    return fallback;
+    return 0;
 }
 
 void
@@ -41,10 +76,11 @@ processFrame(dsd_opts* opts, dsd_state* state) {
         state->minref = state->min;
     }
 
-    const dsd_protocol_handler* handler = dsd_find_protocol_handler(state->synctype);
-    if (handler != NULL && handler->handle_frame != NULL) {
-        handler->handle_frame(opts, state);
+    if (dsd_dispatch_known_frame(opts, state)) {
+        return;
     }
+
+    dsd_dispatch_handle_p25p1(opts, state);
 }
 
 const dsd_protocol_handler dsd_protocol_handlers[] = {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1640,6 +1640,22 @@ endif()
 add_test(NAME CORE_INIT_STATE COMMAND dsd-neo_test_core_init_state)
 
 add_executable(
+    dsd-neo_test_engine_protocol_dispatch
+    engine/test_engine_protocol_dispatch.c
+    ${PROJECT_SOURCE_DIR}/src/engine/dispatch/protocol_dispatch.c
+)
+target_include_directories(
+    dsd-neo_test_engine_protocol_dispatch
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/engine/dispatch
+)
+add_test(
+    NAME ENGINE_PROTOCOL_DISPATCH
+    COMMAND dsd-neo_test_engine_protocol_dispatch
+)
+
+add_executable(
     dsd-neo_test_engine_no_carrier_reset
     engine/test_engine_no_carrier_reset.c
 )

--- a/tests/core/test_core_hytera_bp_silence.c
+++ b/tests/core/test_core_hytera_bp_silence.c
@@ -87,12 +87,10 @@ legacy_hytera_bp_apply(unsigned long long k1, unsigned long long k2, unsigned lo
     }
 }
 
-int
-main(void) {
+static int
+test_silence_detection(const char silence[49]) {
     int rc = 0;
 
-    char silence[49] = {0};
-    fill_default_silence(silence);
     rc |= expect_eq_int("silence-detected", dmr_ambe49_is_default_silence(silence), 1);
 
     char not_silence[49];
@@ -111,102 +109,142 @@ main(void) {
         rc |= expect_eq_int("voice-stream-keep-active", dmr_ambe49_should_skip_voice_stream(active), 0);
     }
 
-    {
-        uint8_t ks_bits[128] = {0};
-        for (int i = 0; i < 128; i++) {
-            ks_bits[i] = (uint8_t)(i & 1);
-        }
+    return rc;
+}
 
-        char frame[49];
-        char expected[49];
-        for (int i = 0; i < 49; i++) {
-            frame[i] = (char)((i + 1) & 1);
-            expected[i] = (char)(frame[i] ^ (char)(ks_bits[i] & 1U));
-        }
-        frame[24] = 1;
-        expected[24] = (char)(frame[24] ^ (char)(ks_bits[24] & 1U));
-
-        long int bit_counter = 0;
-        int applied = dmr_voice_stream_apply_frame49(ks_bits, &bit_counter, 0x24, frame);
-        rc |= expect_eq_int("voice-stream-applied", applied, 1);
-        rc |= expect_eq_int("voice-stream-aes-counter", (int)bit_counter, 56);
-        rc |= expect_eq_frame("voice-stream-aes-frame", frame, expected);
+static int
+test_voice_stream_aes_keystream(void) {
+    uint8_t ks_bits[128] = {0};
+    for (int i = 0; i < 128; i++) {
+        ks_bits[i] = (uint8_t)(i & 1);
     }
 
-    {
-        uint8_t ks_bits[128] = {1};
-        char frame[49];
-        char original[49];
-        DSD_MEMCPY(frame, silence, sizeof(frame));
-        DSD_MEMCPY(original, silence, sizeof(original));
-        long int bit_counter = 0;
-        int applied = dmr_voice_stream_apply_frame49(ks_bits, &bit_counter, 0x24, frame);
-        rc |= expect_eq_int("voice-stream-silence-skipped", applied, 0);
-        rc |= expect_eq_int("voice-stream-silence-aes-counter", (int)bit_counter, 56);
-        rc |= expect_eq_frame("voice-stream-silence-frame", frame, original);
-
-        bit_counter = 0;
-        applied = dmr_voice_stream_apply_frame49(ks_bits, &bit_counter, 0x02, frame);
-        rc |= expect_eq_int("voice-stream-hytera-silence-skipped", applied, 0);
-        rc |= expect_eq_int("voice-stream-hytera-counter", (int)bit_counter, 49);
-        rc |= expect_eq_frame("voice-stream-hytera-frame", frame, original);
+    char frame[49];
+    char expected[49];
+    for (int i = 0; i < 49; i++) {
+        frame[i] = (char)((i + 1) & 1);
+        expected[i] = (char)(frame[i] ^ (char)(ks_bits[i] & 1U));
     }
+    frame[24] = 1;
+    expected[24] = (char)(frame[24] ^ (char)(ks_bits[24] & 1U));
 
-    {
-        char frame[49] = {0};
-        char expected[49] = {0};
-        int applied = dmr_basic_privacy_apply_frame49(42ULL, frame);
-        legacy_basic_privacy_apply(42ULL, expected);
-        rc |= expect_eq_int("bp-applied", applied, 1);
-        rc |= expect_eq_frame("bp-bits", frame, expected);
-    }
+    int rc = 0;
+    long int bit_counter = 0;
+    int applied = dmr_voice_stream_apply_frame49(ks_bits, &bit_counter, 0x24, frame);
+    rc |= expect_eq_int("voice-stream-applied", applied, 1);
+    rc |= expect_eq_int("voice-stream-aes-counter", (int)bit_counter, 56);
+    rc |= expect_eq_frame("voice-stream-aes-frame", frame, expected);
+    return rc;
+}
 
-    {
-        char frame[49] = {0};
-        char expected[49] = {0};
-        frame[0] = expected[0] = 1;
-        int applied = dmr_basic_privacy_apply_frame49(0ULL, frame);
-        rc |= expect_eq_int("bp-zero-rejected", applied, 0);
-        rc |= expect_eq_frame("bp-zero-unchanged", frame, expected);
+static int
+test_voice_stream_silence_skip(const char silence[49]) {
+    uint8_t ks_bits[128] = {1};
+    char frame[49];
+    char original[49];
+    DSD_MEMCPY(frame, silence, sizeof(frame));
+    DSD_MEMCPY(original, silence, sizeof(original));
 
-        applied = dmr_basic_privacy_apply_frame49(256ULL, frame);
-        rc |= expect_eq_int("bp-oob-rejected", applied, 0);
-        rc |= expect_eq_frame("bp-oob-unchanged", frame, expected);
-    }
+    int rc = 0;
+    long int bit_counter = 0;
+    int applied = dmr_voice_stream_apply_frame49(ks_bits, &bit_counter, 0x24, frame);
+    rc |= expect_eq_int("voice-stream-silence-skipped", applied, 0);
+    rc |= expect_eq_int("voice-stream-silence-aes-counter", (int)bit_counter, 56);
+    rc |= expect_eq_frame("voice-stream-silence-frame", frame, original);
 
-    {
-        char frame[49];
-        char original[49];
-        DSD_MEMCPY(frame, silence, sizeof(frame));
-        DSD_MEMCPY(original, silence, sizeof(original));
-        int frame_counter = 0;
-        int applied = hytera_bp_apply_frame49(0x0123456789ULL, 0ULL, 0ULL, 0ULL, &frame_counter, frame);
-        rc |= expect_eq_int("skip-silence-applied", applied, 0);
-        rc |= expect_eq_int("skip-silence-counter", frame_counter, 1);
-        rc |= expect_eq_frame("skip-silence-frame", frame, original);
-    }
+    bit_counter = 0;
+    applied = dmr_voice_stream_apply_frame49(ks_bits, &bit_counter, 0x02, frame);
+    rc |= expect_eq_int("voice-stream-hytera-silence-skipped", applied, 0);
+    rc |= expect_eq_int("voice-stream-hytera-counter", (int)bit_counter, 49);
+    rc |= expect_eq_frame("voice-stream-hytera-frame", frame, original);
+    return rc;
+}
 
-    {
-        char frame[49] = {0};
-        char expected[49] = {0};
-        int frame_counter = 1;
-        int applied = hytera_bp_apply_frame49(0x0123456789ULL, 0ULL, 0ULL, 0ULL, &frame_counter, frame);
-        legacy_hytera_bp_apply(0x0123456789ULL, 0ULL, 0ULL, 0ULL, 1, expected);
-        rc |= expect_eq_int("apply-frame-applied", applied, 1);
-        rc |= expect_eq_int("apply-frame-counter", frame_counter, 2);
-        rc |= expect_eq_frame("apply-frame-bits", frame, expected);
-    }
+static int
+test_basic_privacy(void) {
+    int rc = 0;
+    char frame[49] = {0};
+    char expected[49] = {0};
+    int applied = dmr_basic_privacy_apply_frame49(42ULL, frame);
+    legacy_basic_privacy_apply(42ULL, expected);
+    rc |= expect_eq_int("bp-applied", applied, 1);
+    rc |= expect_eq_frame("bp-bits", frame, expected);
+    return rc;
+}
 
-    {
-        char frame[49] = {0};
-        char expected[49] = {0};
-        int frame_counter = 99;
-        int applied = hytera_bp_apply_frame49(0x0123456789ULL, 0ULL, 0ULL, 0ULL, &frame_counter, frame);
-        legacy_hytera_bp_apply(0x0123456789ULL, 0ULL, 0ULL, 0ULL, 17, expected);
-        rc |= expect_eq_int("clamp-applied", applied, 1);
-        rc |= expect_eq_int("clamp-counter", frame_counter, 18);
-        rc |= expect_eq_frame("clamp-bits", frame, expected);
-    }
+static int
+test_basic_privacy_rejects_invalid_keys(void) {
+    int rc = 0;
+    char frame[49] = {0};
+    char expected[49] = {0};
+    frame[0] = expected[0] = 1;
+    int applied = dmr_basic_privacy_apply_frame49(0ULL, frame);
+    rc |= expect_eq_int("bp-zero-rejected", applied, 0);
+    rc |= expect_eq_frame("bp-zero-unchanged", frame, expected);
+
+    applied = dmr_basic_privacy_apply_frame49(256ULL, frame);
+    rc |= expect_eq_int("bp-oob-rejected", applied, 0);
+    rc |= expect_eq_frame("bp-oob-unchanged", frame, expected);
+    return rc;
+}
+
+static int
+test_hytera_bp_silence_skip(const char silence[49]) {
+    int rc = 0;
+    char frame[49];
+    char original[49];
+    DSD_MEMCPY(frame, silence, sizeof(frame));
+    DSD_MEMCPY(original, silence, sizeof(original));
+    int frame_counter = 0;
+    int applied = hytera_bp_apply_frame49(0x0123456789ULL, 0ULL, 0ULL, 0ULL, &frame_counter, frame);
+    rc |= expect_eq_int("skip-silence-applied", applied, 0);
+    rc |= expect_eq_int("skip-silence-counter", frame_counter, 1);
+    rc |= expect_eq_frame("skip-silence-frame", frame, original);
+    return rc;
+}
+
+static int
+test_hytera_bp_frame_apply(void) {
+    int rc = 0;
+    char frame[49] = {0};
+    char expected[49] = {0};
+    int frame_counter = 1;
+    int applied = hytera_bp_apply_frame49(0x0123456789ULL, 0ULL, 0ULL, 0ULL, &frame_counter, frame);
+    legacy_hytera_bp_apply(0x0123456789ULL, 0ULL, 0ULL, 0ULL, 1, expected);
+    rc |= expect_eq_int("apply-frame-applied", applied, 1);
+    rc |= expect_eq_int("apply-frame-counter", frame_counter, 2);
+    rc |= expect_eq_frame("apply-frame-bits", frame, expected);
+    return rc;
+}
+
+static int
+test_hytera_bp_frame_counter_clamp(void) {
+    int rc = 0;
+    char frame[49] = {0};
+    char expected[49] = {0};
+    int frame_counter = 99;
+    int applied = hytera_bp_apply_frame49(0x0123456789ULL, 0ULL, 0ULL, 0ULL, &frame_counter, frame);
+    legacy_hytera_bp_apply(0x0123456789ULL, 0ULL, 0ULL, 0ULL, 17, expected);
+    rc |= expect_eq_int("clamp-applied", applied, 1);
+    rc |= expect_eq_int("clamp-counter", frame_counter, 18);
+    rc |= expect_eq_frame("clamp-bits", frame, expected);
+    return rc;
+}
+
+int
+main(void) {
+    char silence[49] = {0};
+    fill_default_silence(silence);
+
+    int rc = 0;
+    rc |= test_silence_detection(silence);
+    rc |= test_voice_stream_aes_keystream();
+    rc |= test_voice_stream_silence_skip(silence);
+    rc |= test_basic_privacy();
+    rc |= test_basic_privacy_rejects_invalid_keys();
+    rc |= test_hytera_bp_silence_skip(silence);
+    rc |= test_hytera_bp_frame_apply();
+    rc |= test_hytera_bp_frame_counter_clamp();
 
     if (rc == 0) {
         printf("CORE_HYTERA_BP_SILENCE: OK\n");

--- a/tests/engine/test_engine_protocol_dispatch.c
+++ b/tests/engine/test_engine_protocol_dispatch.c
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/frame_processing.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "protocol_dispatch_impl.h"
+
+enum {
+    TEST_HANDLER_NONE = 0,
+    TEST_HANDLER_NXDN,
+    TEST_HANDLER_DSTAR,
+    TEST_HANDLER_DMR,
+    TEST_HANDLER_X2TDMA,
+    TEST_HANDLER_PROVOICE,
+    TEST_HANDLER_EDACS,
+    TEST_HANDLER_YSF,
+    TEST_HANDLER_M17,
+    TEST_HANDLER_P25P2,
+    TEST_HANDLER_DPMR,
+    TEST_HANDLER_P25P1,
+};
+
+static int g_called_handler = TEST_HANDLER_NONE;
+
+static void
+record_handler(int handler_id) {
+    assert(g_called_handler == TEST_HANDLER_NONE);
+    g_called_handler = handler_id;
+}
+
+int
+dsd_dispatch_matches_nxdn(int synctype) {
+    return DSD_SYNC_IS_NXDN(synctype);
+}
+
+void
+dsd_dispatch_handle_nxdn(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    record_handler(TEST_HANDLER_NXDN);
+}
+
+int
+dsd_dispatch_matches_dstar(int synctype) {
+    return DSD_SYNC_IS_DSTAR(synctype);
+}
+
+void
+dsd_dispatch_handle_dstar(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    record_handler(TEST_HANDLER_DSTAR);
+}
+
+int
+dsd_dispatch_matches_dmr(int synctype) {
+    return DSD_SYNC_IS_DMR(synctype);
+}
+
+void
+dsd_dispatch_handle_dmr(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    record_handler(TEST_HANDLER_DMR);
+}
+
+int
+dsd_dispatch_matches_x2tdma(int synctype) {
+    return DSD_SYNC_IS_X2TDMA(synctype);
+}
+
+void
+dsd_dispatch_handle_x2tdma(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    record_handler(TEST_HANDLER_X2TDMA);
+}
+
+int
+dsd_dispatch_matches_provoice(int synctype) {
+    return DSD_SYNC_IS_PROVOICE(synctype);
+}
+
+void
+dsd_dispatch_handle_provoice(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    record_handler(TEST_HANDLER_PROVOICE);
+}
+
+int
+dsd_dispatch_matches_edacs(int synctype) {
+    return DSD_SYNC_IS_EDACS(synctype);
+}
+
+void
+dsd_dispatch_handle_edacs(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    record_handler(TEST_HANDLER_EDACS);
+}
+
+int
+dsd_dispatch_matches_ysf(int synctype) {
+    return DSD_SYNC_IS_YSF(synctype);
+}
+
+void
+dsd_dispatch_handle_ysf(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    record_handler(TEST_HANDLER_YSF);
+}
+
+int
+dsd_dispatch_matches_m17(int synctype) {
+    return DSD_SYNC_IS_M17(synctype);
+}
+
+void
+dsd_dispatch_handle_m17(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    record_handler(TEST_HANDLER_M17);
+}
+
+int
+dsd_dispatch_matches_p25p2(int synctype) {
+    return DSD_SYNC_IS_P25P2(synctype);
+}
+
+void
+dsd_dispatch_handle_p25p2(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    record_handler(TEST_HANDLER_P25P2);
+}
+
+int
+dsd_dispatch_matches_dpmr(int synctype) {
+    return DSD_SYNC_IS_DPMR(synctype);
+}
+
+void
+dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    record_handler(TEST_HANDLER_DPMR);
+}
+
+int
+dsd_dispatch_matches_p25p1(int synctype) {
+    return DSD_SYNC_IS_P25P1(synctype);
+}
+
+void
+dsd_dispatch_handle_p25p1(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    record_handler(TEST_HANDLER_P25P1);
+}
+
+static void
+run_dispatch_case(int synctype, int expected_handler) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+    state->synctype = synctype;
+    state->rf_mod = 1;
+    state->max = 100.0F;
+    state->min = -50.0F;
+    g_called_handler = TEST_HANDLER_NONE;
+
+    processFrame(opts, state);
+
+    assert(g_called_handler == expected_handler);
+    assert(state->maxref == 80.0F);
+    assert(state->minref == -40.0F);
+    free(state);
+    free(opts);
+}
+
+static void
+check_public_handler_table(void) {
+    assert(strcmp(dsd_protocol_handlers[0].name, "NXDN") == 0);
+    assert(strcmp(dsd_protocol_handlers[1].name, "D-STAR") == 0);
+    assert(strcmp(dsd_protocol_handlers[2].name, "DMR") == 0);
+    assert(strcmp(dsd_protocol_handlers[9].name, "dPMR") == 0);
+    assert(strcmp(dsd_protocol_handlers[10].name, "P25P1") == 0);
+    assert(dsd_protocol_handlers[11].name == NULL);
+}
+
+int
+main(void) {
+    check_public_handler_table();
+    run_dispatch_case(DSD_SYNC_DMR_BS_VOICE_POS, TEST_HANDLER_DMR);
+    run_dispatch_case(DSD_SYNC_DPMR_FS1_POS, TEST_HANDLER_DPMR);
+    run_dispatch_case(DSD_SYNC_P25P1_POS, TEST_HANDLER_P25P1);
+    run_dispatch_case(-1, TEST_HANDLER_P25P1);
+
+    printf("ENGINE_PROTOCOL_DISPATCH: OK\n");
+    return 0;
+}

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -10,6 +10,9 @@ BUILD_DIR="$ROOT_DIR/build/coverage-debug"
 BUILD_PRESET=${BUILD_PRESET:-coverage-debug-clean}
 TEST_PRESET=${TEST_PRESET:-coverage-debug}
 COVERAGE_SCOPE=${COVERAGE_SCOPE:-src}
+LCOV_IGNORE_ERRORS=(--ignore-errors "negative,inconsistent,unused")
+GENHTML_IGNORE_ERRORS=(--ignore-errors inconsistent)
+THIRD_PARTY_EXCLUDES=("${ROOT_DIR}/src/third_party/*")
 
 cmake --preset coverage-debug > /dev/null
 cmake --build --preset "$BUILD_PRESET" -j > /dev/null
@@ -23,14 +26,18 @@ fi
 
 echo "Generating lcov report..."
 pushd "$BUILD_DIR" > /dev/null
-lcov --capture --directory . --output-file coverage.info > /dev/null
+
+# GCC/lcov can emit malformed negative or inconsistent counters for some
+# optimized/generated paths even when CTest passes. Keep the report generation
+# tolerant of those counters while still surfacing lcov warnings on stderr.
+lcov --capture --directory . --output-file coverage.info "${LCOV_IGNORE_ERRORS[@]}" > /dev/null
 
 case "$COVERAGE_SCOPE" in
   src | project)
     REPORT_NAME="coverage.src.info"
     REPORT_DIR="coverage_html"
-    REPORT_LABEL="project src/"
-    lcov --extract coverage.info "${ROOT_DIR}/src/*" -o "$REPORT_NAME" > /dev/null
+    REPORT_LABEL="project src/ excluding src/third_party"
+    lcov --extract coverage.info "${ROOT_DIR}/src/*" -o "$REPORT_NAME" "${LCOV_IGNORE_ERRORS[@]}" > /dev/null
     ;;
   protocol)
     REPORT_NAME="coverage.protocol.info"
@@ -42,7 +49,7 @@ case "$COVERAGE_SCOPE" in
       EXTRACT_ARGS+=("${ROOT_DIR}/src/protocol/${proto}/*")
     done
     EXTRACT_ARGS+=("${ROOT_DIR}/src/fec/*")
-    lcov --extract coverage.info "${EXTRACT_ARGS[@]}" -o "$REPORT_NAME" > /dev/null
+    lcov --extract coverage.info "${EXTRACT_ARGS[@]}" -o "$REPORT_NAME" "${LCOV_IGNORE_ERRORS[@]}" > /dev/null
     ;;
   *)
     echo "Unknown COVERAGE_SCOPE: $COVERAGE_SCOPE" >&2
@@ -51,7 +58,12 @@ case "$COVERAGE_SCOPE" in
     ;;
 esac
 
-genhtml "$REPORT_NAME" --output-directory "$REPORT_DIR" > /dev/null
+FILTERED_REPORT="${REPORT_NAME%.info}.filtered.info"
+lcov --remove "$REPORT_NAME" "${THIRD_PARTY_EXCLUDES[@]}" -o "$FILTERED_REPORT" "${LCOV_IGNORE_ERRORS[@]}" > /dev/null
+mv "$FILTERED_REPORT" "$REPORT_NAME"
+
+rm -rf -- "$REPORT_DIR"
+genhtml "$REPORT_NAME" --output-directory "$REPORT_DIR" "${GENHTML_IGNORE_ERRORS[@]}" > /dev/null
 printf 'Coverage summary (%s)\n' "$REPORT_LABEL"
 lcov --summary "$REPORT_NAME"
 popd > /dev/null


### PR DESCRIPTION
## Summary
- route `processFrame` through direct protocol handler calls while keeping the public handler metadata table intact
- split the Hytera BP silence regression into focused helper tests
- add dispatch regression coverage for DMR, dPMR, P25 P1, P25 fallback, and `rf_mod` reference scaling
- include the existing coverage reporting script fix already on this branch

## Validation
- `tools/format.sh`
- `tools/cmake_format_check.sh`
- `cmake --preset dev-debug`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure -R '^(ENGINE_PROTOCOL_DISPATCH|CORE_HYTERA_BP_SILENCE|P25_P1_SYNC_DISPATCH|DMR_SYNC_DISPATCH|DPMR_SYNC_DISPATCH|DMR_BS_SYNC_TIMES|DPMR_VOICE_BRIDGE)$'`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh --base origin/main`
- `tools/quality_preflight.sh`
- pre-push guardrails

## Notes
- Expected remaining security notices after CodeQL reruns are the single-maintainer Scorecard Code-Review and Branch-Protection findings.