### PR TITLE
security: annotate static helper roots for CodeQL

### DIFF
--- a/src/engine/dispatch/dispatch_p25p1.c
+++ b/src/engine/dispatch/dispatch_p25p1.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/io/control.h>
+#include <dsd-neo/platform/platform.h>
 #include <dsd-neo/protocol/p25/p25.h>
 #include <dsd-neo/protocol/p25/p25_status_symbol.h>
 #include <dsd-neo/protocol/p25/p25p1_check_nid.h>
@@ -187,7 +188,11 @@ p25p1_handle_nid_decode_failure(const dsd_opts* opts, dsd_state* state, char dui
     state->debug_header_critical_errors++;
 }
 
-static void
+/*
+ * Mark the static helper roots used by the public dispatch entrypoint. CodeQL's
+ * manual C/C++ database can miss this local call chain and report all children.
+ */
+static void DSD_ATTR_USED
 p25p1_decode_nid_and_duid(dsd_opts* opts, dsd_state* state, char duid[3]) {
     char bch_code[63];
     uint8_t bch_reliab[63];
@@ -406,7 +411,7 @@ p25p1_handle_unknown_duid(dsd_opts* opts, dsd_state* state, const char duid[3]) 
     p25_status_accum_classify(state, opts);
 }
 
-static void
+static void DSD_ATTR_USED
 p25p1_dispatch_by_duid(dsd_opts* opts, dsd_state* state, const char duid[3]) {
     if (strcmp(duid, "00") == 0) {
         p25p1_handle_hdu(opts, state);

--- a/src/engine/dispatch/protocol_dispatch.c
+++ b/src/engine/dispatch/protocol_dispatch.c
@@ -6,63 +6,28 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/protocol_dispatch.h>
-
-#include <stddef.h>
+#include <string.h>
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "protocol_dispatch_impl.h"
 
-static int
-dsd_dispatch_known_frame(dsd_opts* opts, dsd_state* state) {
-    const int synctype = state->synctype;
+static const dsd_protocol_handler*
+dsd_find_protocol_handler(int synctype) {
+    const dsd_protocol_handler* handler = dsd_protocol_handlers;
+    const dsd_protocol_handler* fallback = NULL;
 
-    if (dsd_dispatch_matches_nxdn(synctype)) {
-        dsd_dispatch_handle_nxdn(opts, state);
-        return 1;
-    }
-    if (dsd_dispatch_matches_dstar(synctype)) {
-        dsd_dispatch_handle_dstar(opts, state);
-        return 1;
-    }
-    if (dsd_dispatch_matches_dmr(synctype)) {
-        dsd_dispatch_handle_dmr(opts, state);
-        return 1;
-    }
-    if (dsd_dispatch_matches_x2tdma(synctype)) {
-        dsd_dispatch_handle_x2tdma(opts, state);
-        return 1;
-    }
-    if (dsd_dispatch_matches_provoice(synctype)) {
-        dsd_dispatch_handle_provoice(opts, state);
-        return 1;
-    }
-    if (dsd_dispatch_matches_edacs(synctype)) {
-        dsd_dispatch_handle_edacs(opts, state);
-        return 1;
-    }
-    if (dsd_dispatch_matches_ysf(synctype)) {
-        dsd_dispatch_handle_ysf(opts, state);
-        return 1;
-    }
-    if (dsd_dispatch_matches_m17(synctype)) {
-        dsd_dispatch_handle_m17(opts, state);
-        return 1;
-    }
-    if (dsd_dispatch_matches_p25p2(synctype)) {
-        dsd_dispatch_handle_p25p2(opts, state);
-        return 1;
-    }
-    if (dsd_dispatch_matches_dpmr(synctype)) {
-        dsd_dispatch_handle_dpmr(opts, state);
-        return 1;
-    }
-    if (dsd_dispatch_matches_p25p1(synctype)) {
-        dsd_dispatch_handle_p25p1(opts, state);
-        return 1;
+    while (handler->name != NULL) {
+        if (handler->matches_synctype != NULL && handler->matches_synctype(synctype)) {
+            return handler;
+        }
+        if (fallback == NULL && strcmp(handler->name, "P25P1") == 0) {
+            fallback = handler;
+        }
+        handler++;
     }
 
-    return 0;
+    return fallback;
 }
 
 void
@@ -76,11 +41,10 @@ processFrame(dsd_opts* opts, dsd_state* state) {
         state->minref = state->min;
     }
 
-    if (dsd_dispatch_known_frame(opts, state)) {
-        return;
+    const dsd_protocol_handler* handler = dsd_find_protocol_handler(state->synctype);
+    if (handler != NULL && handler->handle_frame != NULL) {
+        handler->handle_frame(opts, state);
     }
-
-    dsd_dispatch_handle_p25p1(opts, state);
 }
 
 const dsd_protocol_handler dsd_protocol_handlers[] = {

--- a/src/protocol/dmr/dmr_bs.c
+++ b/src/protocol/dmr/dmr_bs.c
@@ -24,6 +24,7 @@
 #include <dsd-neo/crypto/dmr_keystream.h>
 #include <dsd-neo/fec/block_codes.h>
 #include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/platform.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/protocol/dmr/dmr_const.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
@@ -91,7 +92,11 @@ typedef struct {
     char timestr[9];
 } dmr_bs_bootstrap_ctx;
 
-static void
+/*
+ * Mark dmrBS helper roots used by the public decoder entrypoint. CodeQL's
+ * manual C/C++ database can miss this local call chain and report all children.
+ */
+static void DSD_ATTR_USED
 init_dmr_bs_ctx(const dsd_state* state, dmr_bs_ctx* ctx) {
     DSD_MEMSET(ctx, 0, sizeof(*ctx));
     ctx->cc = 25;
@@ -709,7 +714,7 @@ run_dmr_bs_post_skip(dsd_opts* opts, dsd_state* state, dmr_bs_ctx* ctx) {
     return DMR_BS_ACTION_CONTINUE;
 }
 
-static void
+static void DSD_ATTR_USED
 finalize_dmr_bs(dsd_opts* opts, dsd_state* state, const dmr_bs_ctx* ctx) {
     state->dmr_stereo = 0;
     state->errs = 0;
@@ -893,7 +898,7 @@ process_dmr_bs_bootstrap_voice_if_open(dsd_opts* opts, dsd_state* state, dmr_bs_
     }
 }
 
-static dmr_bs_action
+static dmr_bs_action DSD_ATTR_USED
 process_dmr_bs_iteration(dsd_opts* opts, dsd_state* state, dmr_bs_ctx* ctx) {
     getTimeC_buf(ctx->timestr);
     reset_dmr_bs_loop_buffers(ctx);

--- a/src/protocol/dpmr/dpmr_voice.c
+++ b/src/protocol/dpmr/dpmr_voice.c
@@ -25,6 +25,7 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/vocoder.h>
 #include <dsd-neo/fec/block_codes.h>
+#include <dsd-neo/platform/platform.h>
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
 #include <dsd-neo/protocol/dpmr/dpmr_const.h>
 #include <dsd-neo/protocol/dpmr/dpmr_data.h>
@@ -75,7 +76,11 @@ dpmr_read_dibit(dsd_opts* opts, dsd_state* state) {
     return dibit;
 }
 
-static void
+/*
+ * Mark processdPMRvoice helper roots used by the public decoder entrypoint.
+ * CodeQL's manual C/C++ database can miss this local call chain.
+ */
+static void DSD_ATTR_USED
 dpmr_read_first_cch(dsd_opts* opts, dsd_state* state, dpmr_voice_ctx_t* ctx) {
     for (uint32_t i = 0; i < 36; i++) {
         uint32_t dibit = dpmr_read_dibit(opts, state);
@@ -84,7 +89,7 @@ dpmr_read_first_cch(dsd_opts* opts, dsd_state* state, dpmr_voice_ctx_t* ctx) {
     }
 }
 
-static void
+static void DSD_ATTR_USED
 dpmr_read_tch_group(dsd_opts* opts, dsd_state* state, dpmr_voice_ctx_t* ctx, uint32_t frame_base) {
     for (uint32_t j = 0; j < 4; j++) {
         const int* w = dpmr_ambe_interleave_w;
@@ -107,7 +112,7 @@ dpmr_read_tch_group(dsd_opts* opts, dsd_state* state, dpmr_voice_ctx_t* ctx, uin
     }
 }
 
-static void
+static void DSD_ATTR_USED
 dpmr_read_first_cc(dsd_opts* opts, dsd_state* state, dpmr_voice_ctx_t* ctx) {
     uint32_t k = 0;
     for (uint32_t i = 0; i < 12; i++) {
@@ -118,7 +123,7 @@ dpmr_read_first_cc(dsd_opts* opts, dsd_state* state, dpmr_voice_ctx_t* ctx) {
     state->dPMRVoiceFS2Frame.ColorCode[0] = (unsigned int)GetdPmrColorCode(ctx->CC[0]);
 }
 
-static void
+static void DSD_ATTR_USED
 dpmr_read_second_cch(dsd_opts* opts, dsd_state* state, dpmr_voice_ctx_t* ctx) {
     uint32_t k = 0;
     for (uint32_t i = 0; i < 36; i++) {
@@ -141,7 +146,7 @@ dpmr_extract_cch_crc(const uint8_t cch_bits[48]) {
     return crc;
 }
 
-static void
+static void DSD_ATTR_USED
 dpmr_decode_cch_frames(dsd_state* state, dpmr_voice_ctx_t* ctx) {
     for (uint32_t i = 0; i < NB_OF_DPMR_VOICE_FRAME_TO_DECODE; i++) {
         uint32_t scrambler_lfsr = 0x1FF;
@@ -184,7 +189,7 @@ dpmr_decode_cch_frames(dsd_state* state, dpmr_voice_ctx_t* ctx) {
     }
 }
 
-static void
+static void DSD_ATTR_USED
 dpmr_extract_previous_ids(const dsd_state* state, char called_id[8], char calling_id[8]) {
     dsd_strncpy_s(called_id, 8, (const char*)state->dPMRVoiceFS2Frame.CalledID, 7);
     called_id[7] = '\0';
@@ -241,7 +246,7 @@ dpmr_mark_unknown_superframe_part(dsd_opts* opts, dsd_state* state) {
     }
 }
 
-static void
+static void DSD_ATTR_USED
 dpmr_update_superframe_part(dpmr_voice_ctx_t* ctx, dsd_opts* opts, dsd_state* state, char called_id[8],
                             char calling_id[8]) {
     if (((ctx->CrcOk[0] || ctx->HammingCorrectable[0][0]) && (ctx->CCH_FrameNumber[0] == 0))
@@ -257,7 +262,7 @@ dpmr_update_superframe_part(dpmr_voice_ctx_t* ctx, dsd_opts* opts, dsd_state* st
     dpmr_mark_unknown_superframe_part(opts, state);
 }
 
-static void
+static void DSD_ATTR_USED
 dpmr_print_ids(dsd_state* state, char called_id[8], char calling_id[8]) {
     DSD_FPRINTF(stderr, "\n");
     if (state->dPMRVoiceFS2Frame.CalledIDOk) {
@@ -293,7 +298,7 @@ dpmr_print_ids(dsd_state* state, char called_id[8], char calling_id[8]) {
     }
 }
 
-static void
+static void DSD_ATTR_USED
 dpmr_print_scrambler_state(const dsd_state* state) {
     if (state->dPMRVoiceFS2Frame.Version[0] != 3) {
         return;


### PR DESCRIPTION
## Summary
- Mark static helper roots in P25 P1 dispatch, DMR BS, and dPMR voice with `DSD_ATTR_USED` so CodeQL can keep the local helper chains reachable without disabling or excluding the query.
- Restore protocol dispatch to the table-driven lookup; the previous direct-call dispatcher did not address the helper-chain alerts and was not the right long-term shape.
- Leave the two open Scorecard notifications unchanged because they are legitimate and cannot be resolved yet.

## Root Cause
CodeQL's manual C/C++ database can miss these local static helper chains even though they are reached from public decoder and dispatch entrypoints. The project already has `DSD_ATTR_USED` for this analyzer-visible-root case, so this applies that existing local convention narrowly at the roots of the affected chains.

## Validation
- `tools/format.sh`
- `cmake --preset dev-debug`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure -R "ENGINE_PROTOCOL_DISPATCH|P25_P1_SYNC_DISPATCH|DMR_BS_SYNC_TIMES|DPMR_VOICE_BRIDGE|DPMR_SYNC_DISPATCH|DMR_SYNC_DISPATCH"`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh`
- `git push -u origin security/codeql-static-helper-roots` (pre-push guardrails reran)

`tools/preflight_ci.sh` and the pre-push hook both skipped the optional scan-build full rebuild because `DSD_HOOK_RUN_SCAN_BUILD=1` was not set.