### PR TITLE
engine: reset RTL profile on no-carrier CC return

### DIFF
--- a/.github/workflows/linux-appimage.yaml
+++ b/.github/workflows/linux-appimage.yaml
@@ -513,6 +513,13 @@ jobs:
       matrix:
         arch: [x86_64, aarch64]
     steps:
+      - name: Checkout release helpers
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Prepare artifact naming
         id: names
         shell: bash
@@ -558,18 +565,30 @@ jobs:
           set -euo pipefail
           test -f "${{ steps.names.outputs.OUT }}"
           test -f "${{ steps.names.outputs.OUT }}.spdx.json"
-      - name: Upload release asset
+      - name: Wait for release metadata
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
-        with:
-          files: |
-            ${{ steps.names.outputs.OUT }}
-            ${{ steps.names.outputs.OUT }}.spdx.json
-          name: ${{ steps.names.outputs.RELEASE_TITLE }}
-          generate_release_notes: true
-          overwrite_files: true
-          fail_on_unmatched_files: true
-          token: ${{ github.token }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: tools/ci_wait_for_release.sh
+      - name: Upload release assets
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          APPIMAGE_PATH: ${{ steps.names.outputs.OUT }}
+          SBOM_PATH: ${{ steps.names.outputs.OUT }}.spdx.json
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" \
+            "${APPIMAGE_PATH}" \
+            "${SBOM_PATH}" \
+            --repo "${RELEASE_REPOSITORY}" \
+            --clobber
       - name: Upload nightly assets (overwrite)
         if: >-
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&

--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -719,6 +719,13 @@ jobs:
       actions: read
       contents: write
     steps:
+      - name: Checkout release helpers
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Prepare artifact naming
         id: names
         shell: bash
@@ -764,18 +771,30 @@ jobs:
           set -euo pipefail
           test -f "${{ steps.names.outputs.DMG_PATH }}"
           test -f "${{ steps.names.outputs.DMG_PATH }}.spdx.json"
-      - name: Upload release asset
+      - name: Wait for release metadata
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
-        with:
-          files: |
-            ${{ steps.names.outputs.DMG_PATH }}
-            ${{ steps.names.outputs.DMG_PATH }}.spdx.json
-          name: ${{ steps.names.outputs.RELEASE_TITLE }}
-          generate_release_notes: true
-          overwrite_files: true
-          fail_on_unmatched_files: true
-          token: ${{ github.token }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: tools/ci_wait_for_release.sh
+      - name: Upload release assets
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          DMG_PATH: ${{ steps.names.outputs.DMG_PATH }}
+          SBOM_PATH: ${{ steps.names.outputs.DMG_PATH }}.spdx.json
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" \
+            "${DMG_PATH}" \
+            "${SBOM_PATH}" \
+            --repo "${RELEASE_REPOSITORY}" \
+            --clobber
       - name: Upload nightly assets (overwrite)
         if: >-
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  create-release-metadata:
+    name: Create release metadata
+    runs-on: ubuntu-latest
+    if: github.repository == 'arancormonk/dsd-neo'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate release tag
+        id: release
+        shell: bash
+        env:
+          RELEASE_TAG_CREATED: ${{ github.event.created }}
+        run: tools/ci_validate_release_tag.sh
+
+      - name: Create release notes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TITLE: ${{ steps.release.outputs.release_title }}
+        run: tools/ci_create_release_metadata.sh

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -338,6 +338,13 @@ jobs:
       actions: read
       contents: write
     steps:
+      - name: Checkout release helpers
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Prepare artifact naming
         id: names
         shell: bash
@@ -382,18 +389,30 @@ jobs:
           set -euo pipefail
           test -f "${{ steps.names.outputs.ZIP_PATH }}"
           test -f "${{ steps.names.outputs.ZIP_PATH }}.spdx.json"
-      - name: Upload native MSVC release asset
+      - name: Wait for release metadata
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
-        with:
-          files: |
-            ${{ steps.names.outputs.ZIP_PATH }}
-            ${{ steps.names.outputs.ZIP_PATH }}.spdx.json
-          name: ${{ steps.names.outputs.RELEASE_TITLE }}
-          generate_release_notes: true
-          overwrite_files: true
-          fail_on_unmatched_files: true
-          token: ${{ github.token }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: tools/ci_wait_for_release.sh
+      - name: Upload native MSVC release assets
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          ZIP_PATH: ${{ steps.names.outputs.ZIP_PATH }}
+          SBOM_PATH: ${{ steps.names.outputs.ZIP_PATH }}.spdx.json
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" \
+            "${ZIP_PATH}" \
+            "${SBOM_PATH}" \
+            --repo "${RELEASE_REPOSITORY}" \
+            --clobber
       - name: Upload native MSVC nightly assets (overwrite)
         if: >-
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -4,6 +4,10 @@ Official releases are published through GitHub Releases:
 
 https://github.com/arancormonk/dsd-neo/releases
 
+The `release` workflow owns release metadata for version tags and creates the
+generated release notes exactly once. Platform packaging workflows wait for that
+release to exist, then upload their assets without rewriting the release body.
+
 ## Release Identifiers
 
 Release tags use the form `vX.Y.Z`. The tag must match the project version

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -866,6 +866,7 @@ init_state_p25_and_trunk_defaults(dsd_state* state) {
     state->p25_p2_enc_pending[1] = 0;
     state->p25_p2_enc_pending_ttg[0] = 0;
     state->p25_p2_enc_pending_ttg[1] = 0;
+    state->p25_p2_active_slot = -1;
     state->p25_cc_is_tdma =
         2; //init on 2, TSBK NET_STS will set 0, TDMA NET_STS will set 1. //used to determine if we need to change symbol rate when cc hunting
     state->p25_sys_is_tdma = 0;

--- a/src/core/util/dsd_reset.c
+++ b/src/core/util/dsd_reset.c
@@ -261,8 +261,9 @@ reset_p25_tables_and_hints(dsd_state* state) {
     DSD_MEMSET(state->p25_aff_last_seen, 0, sizeof(state->p25_aff_last_seen));
 
     // Reset P25 CC/system TDMA hints
-    state->p25_cc_is_tdma = 0;
+    state->p25_cc_is_tdma = 2;
     state->p25_sys_is_tdma = 0;
+    state->p25_p2_active_slot = -1;
     state->p25_vc_cqpsk_pref = -1;
     state->p25_vc_cqpsk_override = -1;
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1317,35 +1317,11 @@ no_carrier_p25_frames_enabled(const dsd_opts* opts) {
 }
 
 static int
-no_carrier_generic_trunk_frames_enabled(const dsd_opts* opts) {
-    return (opts->frame_x2tdma == 1 || opts->frame_nxdn48 == 1 || opts->frame_nxdn96 == 1 || opts->frame_dmr == 1
-            || opts->frame_provoice == 1)
-               ? 1
-               : 0;
-}
-
-static int
-no_carrier_p25_only_frames_enabled(const dsd_opts* opts) {
-    return (no_carrier_p25_frames_enabled(opts) && !no_carrier_generic_trunk_frames_enabled(opts)) ? 1 : 0;
-}
-
-static int
 no_carrier_generic_trunk_synctype(int synctype) {
     if (DSD_SYNC_IS_DMR(synctype) || DSD_SYNC_IS_NXDN(synctype) || DSD_SYNC_IS_EDACS(synctype)) {
         return 1;
     }
     return DSD_SYNC_IS_X2TDMA(synctype) ? 1 : 0;
-}
-
-static int
-no_carrier_has_p25_cc_identity(const dsd_state* state) {
-    if (state->p2_cc != 0 || state->p2_wacn != 0 || state->p2_sysid != 0) {
-        return 1;
-    }
-    if (state->p2_rfssid != 0 || state->p2_siteid != 0) {
-        return 1;
-    }
-    return (state->p25_sys_is_tdma == 1) ? 1 : 0;
 }
 
 static int
@@ -1361,20 +1337,37 @@ no_carrier_has_active_p25_voice_state(const dsd_opts* opts, const dsd_state* sta
 }
 
 static int
-no_carrier_selected_cc_has_p25_identity(const dsd_state* state, long cc) {
-    if (cc == 0 || state->p25_cc_freq == 0 || cc != state->p25_cc_freq) {
-        return 0;
-    }
-    return no_carrier_has_p25_cc_identity(state);
-}
-
-static int
 no_carrier_has_selectable_control_channel(const dsd_state* state) {
     return (state->trunk_cc_freq != 0 || state->p25_cc_freq != 0) ? 1 : 0;
 }
 
+static void
+no_carrier_clear_stale_p25_return_hints_after_generic_activity(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
+        return;
+    }
+    if (opts->p25_trunk != 1 && opts->trunk_enable != 1) {
+        return;
+    }
+    if (!no_carrier_generic_trunk_synctype(state->lastsynctype)
+        && !no_carrier_generic_trunk_synctype(state->synctype)) {
+        return;
+    }
+
+    state->p2_cc = 0;
+    state->p2_wacn = 0;
+    state->p2_sysid = 0;
+    state->p2_rfssid = 0;
+    state->p2_siteid = 0;
+    state->p25_sys_is_tdma = 0;
+    state->p25_vc_freq[0] = 0;
+    state->p25_vc_freq[1] = 0;
+    state->p25_p2_active_slot = -1;
+    opts->p25_is_tuned = 0;
+}
+
 static int
-no_carrier_is_p25_trunk_return(const dsd_opts* opts, const dsd_state* state, long cc) {
+no_carrier_is_p25_trunk_return(const dsd_opts* opts, const dsd_state* state) {
     if (!opts || !state || opts->p25_trunk != 1 || !no_carrier_p25_frames_enabled(opts)) {
         return 0;
     }
@@ -1385,15 +1378,6 @@ no_carrier_is_p25_trunk_return(const dsd_opts* opts, const dsd_state* state, lon
         return 1;
     }
     if (no_carrier_generic_trunk_synctype(state->lastsynctype) || no_carrier_generic_trunk_synctype(state->synctype)) {
-        return 0;
-    }
-    if (no_carrier_selected_cc_has_p25_identity(state, cc)) {
-        return 1;
-    }
-    if (no_carrier_has_p25_cc_identity(state) && no_carrier_has_active_p25_voice_state(opts, state)) {
-        return 1;
-    }
-    if (!no_carrier_p25_only_frames_enabled(opts)) {
         return 0;
     }
     return no_carrier_has_active_p25_voice_state(opts, state);
@@ -1554,7 +1538,7 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
     }
 
     long cc = no_carrier_select_control_channel(state);
-    const int p25_return = no_carrier_is_p25_trunk_return(opts, state, cc);
+    const int p25_return = no_carrier_is_p25_trunk_return(opts, state);
     const int clear_generic_p25_alias = no_carrier_should_clear_generic_p25_alias(state, cc, p25_return);
     int accepted_cc_return = 0;
     int clear_failed_helper_state = 0;
@@ -1987,6 +1971,7 @@ noCarrier(dsd_opts* opts, dsd_state* state) {
 
     no_carrier_step_scanner_mode_if_needed(opts, state, now);
     no_carrier_return_to_control_channel_if_needed(opts, state, now);
+    no_carrier_clear_stale_p25_return_hints_after_generic_activity(opts, state);
     no_carrier_reset_dibit_and_dmr_buffers(state);
     no_carrier_close_mbe_outputs_if_needed(opts, state);
     const int preserve_scan_state = opts && opts->trunk_scan_enabled == 1;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -24,6 +24,7 @@
 #include <dsd-neo/engine/engine.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/trunk_scan.h>
+#include <dsd-neo/engine/trunk_tuning.h>
 #include <dsd-neo/fec/block_codes.h>
 #include <dsd-neo/io/control.h>
 #include <dsd-neo/io/rigctl_client.h>
@@ -66,6 +67,7 @@
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/dsp/p25p1_heuristics.h"
 #include "dsd-neo/platform/sockets.h"
+#include "dsd-neo/runtime/trunk_tuning_hooks.h"
 #include "engine_hooks_install.h"
 
 struct CODEC2;
@@ -1323,23 +1325,36 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
     }
 
     long cc = no_carrier_select_control_channel(state);
+    int used_trunk_helper = 0;
+    int legacy_clear_state = 0;
     if (cc != 0) {
-        if (opts->use_rigctl == 1) {
+        dsd_trunk_tune_result tune_result = dsd_engine_return_to_cc(opts, state);
+        if (dsd_trunk_tune_result_is_ok(tune_result)) {
+            used_trunk_helper = 1;
+            state->edacs_tuned_lcn = -1;
+        } else if (opts->use_rigctl == 1) {
             no_carrier_tune_rigctl_if_needed(opts, cc);
             state->dmr_rest_channel = -1;
+            legacy_clear_state = 1;
         } else if (opts->audio_in_type == AUDIO_IN_RTL) {
-            no_carrier_tune_rtl_if_needed(opts, state, (uint32_t)cc);
+            if (!state->rtl_ctx) {
+                legacy_clear_state = 1;
+            }
 #ifdef USE_RADIO
             state->dmr_rest_channel = -1;
 #endif
+        } else {
+            legacy_clear_state = 1;
         }
 
-        opts->p25_is_tuned = 0;
-        opts->trunk_is_tuned = 0;
-        state->edacs_tuned_lcn = -1;
-        state->last_cc_sync_time = now;
-        state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
-        no_carrier_apply_p25_cc_symbolrate(opts, state);
+        if (!used_trunk_helper && legacy_clear_state) {
+            opts->p25_is_tuned = 0;
+            opts->trunk_is_tuned = 0;
+            state->edacs_tuned_lcn = -1;
+            state->last_cc_sync_time = now;
+            state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
+            no_carrier_apply_p25_cc_symbolrate(opts, state);
+        }
     }
 
     state->p25_vc_freq[0] = 0;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1339,11 +1339,8 @@ no_carrier_selected_cc_is_p25_alias(const dsd_state* state, long cc) {
 }
 
 static int
-no_carrier_has_known_control_channel(const dsd_state* state) {
-    if (state->trunk_cc_freq != 0 || state->p25_cc_freq != 0) {
-        return 1;
-    }
-    return (state->dmr_rest_channel != -1 && state->trunk_chan_map[state->dmr_rest_channel] != 0) ? 1 : 0;
+no_carrier_has_selectable_control_channel(const dsd_state* state) {
+    return (state->trunk_cc_freq != 0 || state->p25_cc_freq != 0) ? 1 : 0;
 }
 
 static int
@@ -1787,7 +1784,7 @@ no_carrier_clear_stale_follow_state_if_needed(dsd_opts* opts, dsd_state* state, 
     const int trunking_enabled = (opts->p25_trunk == 1 || opts->trunk_enable == 1) ? 1 : 0;
     const int voice_tuned = (opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1) ? 1 : 0;
     const int vc_recent = (state->last_vc_sync_time != 0 && (now - state->last_vc_sync_time) <= 10) ? 1 : 0;
-    const int retryable_cc_return = no_carrier_has_known_control_channel(state);
+    const int retryable_cc_return = no_carrier_has_selectable_control_channel(state);
     const int preserve_voice_state = (trunking_enabled && voice_tuned && (vc_recent || retryable_cc_return)) ? 1 : 0;
 
     if (now - state->last_cc_sync_time > 10 && !preserve_voice_state) {

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1317,15 +1317,26 @@ no_carrier_generic_trunk_synctype(int synctype) {
 }
 
 static int
-no_carrier_generic_trunk_frames_enabled(const dsd_opts* opts) {
-    if (opts->frame_dmr == 1 || opts->frame_nxdn48 == 1 || opts->frame_nxdn96 == 1) {
+no_carrier_has_p25_cc_identity(const dsd_state* state) {
+    if (state->p2_cc != 0 || state->p2_wacn != 0 || state->p2_sysid != 0) {
         return 1;
     }
-    return (opts->frame_provoice == 1 || opts->frame_x2tdma == 1) ? 1 : 0;
+    if (state->p2_rfssid != 0 || state->p2_siteid != 0) {
+        return 1;
+    }
+    return (state->p25_cc_is_tdma == 1 || state->p25_sys_is_tdma == 1 || state->p25_p2_active_slot != -1) ? 1 : 0;
 }
 
 static int
-no_carrier_is_p25_trunk_return(const dsd_opts* opts, const dsd_state* state) {
+no_carrier_has_known_control_channel(const dsd_state* state) {
+    if (state->trunk_cc_freq != 0 || state->p25_cc_freq != 0) {
+        return 1;
+    }
+    return (state->dmr_rest_channel != -1 && state->trunk_chan_map[state->dmr_rest_channel] != 0) ? 1 : 0;
+}
+
+static int
+no_carrier_is_p25_trunk_return(const dsd_opts* opts, const dsd_state* state, long cc) {
     if (!opts || !state || opts->p25_trunk != 1 || !no_carrier_p25_frames_enabled(opts)) {
         return 0;
     }
@@ -1335,10 +1346,13 @@ no_carrier_is_p25_trunk_return(const dsd_opts* opts, const dsd_state* state) {
     if (DSD_SYNC_IS_P25(state->lastsynctype) || DSD_SYNC_IS_P25(state->synctype)) {
         return 1;
     }
-    if (no_carrier_generic_trunk_synctype(state->lastsynctype)) {
+    if (no_carrier_generic_trunk_synctype(state->lastsynctype) || no_carrier_generic_trunk_synctype(state->synctype)) {
         return 0;
     }
-    return no_carrier_generic_trunk_frames_enabled(opts) ? 0 : 1;
+    if (cc != 0 && state->p25_cc_freq != 0 && cc == state->p25_cc_freq && no_carrier_has_p25_cc_identity(state)) {
+        return 1;
+    }
+    return 0;
 }
 
 static void
@@ -1444,12 +1458,15 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
     }
 
     long cc = no_carrier_select_control_channel(state);
-    const int p25_return = no_carrier_is_p25_trunk_return(opts, state);
+    const int p25_return = no_carrier_is_p25_trunk_return(opts, state, cc);
+    int accepted_cc_return = 0;
     if (cc != 0) {
         int p25_helper_attempted = 0;
         no_carrier_sync_selected_control_channel(state, cc, p25_return);
-        if (!no_carrier_try_helper_return_to_cc(opts, state, cc, p25_return, &p25_helper_attempted)
-            && no_carrier_apply_legacy_cc_return(opts, state, cc, p25_helper_attempted)) {
+        if (no_carrier_try_helper_return_to_cc(opts, state, cc, p25_return, &p25_helper_attempted)) {
+            accepted_cc_return = 1;
+        } else if (no_carrier_apply_legacy_cc_return(opts, state, cc, p25_helper_attempted)) {
+            accepted_cc_return = 1;
             state->edacs_tuned_lcn = -1;
             state->last_cc_sync_time = now;
             state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
@@ -1459,9 +1476,11 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
         }
     }
 
-    no_carrier_clear_voice_tune_state(opts, state);
-    DSD_MEMSET(state->active_channel, 0, sizeof(state->active_channel));
-    state->is_con_plus = 0;
+    if (accepted_cc_return) {
+        no_carrier_clear_voice_tune_state(opts, state);
+        DSD_MEMSET(state->active_channel, 0, sizeof(state->active_channel));
+        state->is_con_plus = 0;
+    }
 }
 
 static void
@@ -1734,11 +1753,13 @@ no_carrier_reset_p25_metrics_and_cache(dsd_state* state) {
 
 static void
 no_carrier_clear_stale_follow_state_if_needed(dsd_opts* opts, dsd_state* state, time_t now) {
-    const int p25_voice_tuned =
-        (opts->p25_trunk == 1 && (opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1)) ? 1 : 0;
-    const int p25_vc_recent = (state->last_vc_sync_time != 0 && (now - state->last_vc_sync_time) <= 10) ? 1 : 0;
+    const int trunking_enabled = (opts->p25_trunk == 1 || opts->trunk_enable == 1) ? 1 : 0;
+    const int voice_tuned = (opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1) ? 1 : 0;
+    const int vc_recent = (state->last_vc_sync_time != 0 && (now - state->last_vc_sync_time) <= 10) ? 1 : 0;
+    const int retryable_cc_return = no_carrier_has_known_control_channel(state);
+    const int preserve_voice_state = (trunking_enabled && voice_tuned && (vc_recent || retryable_cc_return)) ? 1 : 0;
 
-    if (now - state->last_cc_sync_time > 10 && !(p25_voice_tuned && p25_vc_recent)) {
+    if (now - state->last_cc_sync_time > 10 && !preserve_voice_state) {
         state->dmr_rest_channel = -1;
         state->p25_vc_freq[0] = 0;
         state->p25_vc_freq[1] = 0;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1304,6 +1304,16 @@ no_carrier_select_control_channel(dsd_state* state) {
 }
 
 static void
+no_carrier_sync_selected_control_channel(const dsd_opts* opts, dsd_state* state, long cc) {
+    if (cc == 0) {
+        return;
+    }
+
+    state->trunk_cc_freq = cc;
+    state->p25_cc_freq = (opts->p25_trunk == 1) ? cc : 0;
+}
+
+static void
 no_carrier_apply_p25_cc_symbolrate(dsd_opts* opts, dsd_state* state) {
     if (state->p25_cc_is_tdma == 0) {
         state->samplesPerSymbol = 10;
@@ -1328,10 +1338,12 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
     int used_trunk_helper = 0;
     int legacy_clear_state = 0;
     if (cc != 0) {
+        no_carrier_sync_selected_control_channel(opts, state, cc);
         dsd_trunk_tune_result tune_result = dsd_engine_return_to_cc(opts, state);
         if (dsd_trunk_tune_result_is_ok(tune_result)) {
             used_trunk_helper = 1;
             state->edacs_tuned_lcn = -1;
+            state->dmr_rest_channel = -1;
         } else if (opts->use_rigctl == 1) {
             no_carrier_tune_rigctl_if_needed(opts, cc);
             state->dmr_rest_channel = -1;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1289,13 +1289,21 @@ no_carrier_is_cc_return_due(const dsd_opts* opts, const dsd_state* state, time_t
     return dt > opts->trunk_hangtime;
 }
 
+static int
+no_carrier_has_mapped_dmr_rest_channel(const dsd_state* state) {
+    if (state->dmr_rest_channel < 0 || state->dmr_rest_channel >= DSD_TRUNK_CHAN_MAP_SIZE) {
+        return 0;
+    }
+    return (state->trunk_chan_map[state->dmr_rest_channel] != 0) ? 1 : 0;
+}
+
 static long
 no_carrier_select_control_channel(dsd_state* state) {
     long cc = (state->trunk_cc_freq != 0) ? state->trunk_cc_freq : state->p25_cc_freq;
     if (cc == 0) {
         return 0;
     }
-    if (state->dmr_rest_channel != -1 && state->trunk_chan_map[state->dmr_rest_channel] != 0) {
+    if (no_carrier_has_mapped_dmr_rest_channel(state)) {
         cc = state->trunk_chan_map[state->dmr_rest_channel];
         state->p25_cc_freq = cc;
         state->trunk_cc_freq = cc;
@@ -1332,10 +1340,7 @@ no_carrier_selected_cc_is_p25_alias(const dsd_state* state, long cc) {
     if (cc == 0 || state->p25_cc_freq == 0 || !no_carrier_has_p25_cc_identity(state)) {
         return 0;
     }
-    if (cc == state->p25_cc_freq) {
-        return 1;
-    }
-    return (state->trunk_cc_freq != 0 && cc == state->trunk_cc_freq) ? 1 : 0;
+    return (cc == state->p25_cc_freq) ? 1 : 0;
 }
 
 static int
@@ -1348,7 +1353,7 @@ no_carrier_is_p25_trunk_return(const dsd_opts* opts, const dsd_state* state, lon
     if (!opts || !state || opts->p25_trunk != 1 || !no_carrier_p25_frames_enabled(opts)) {
         return 0;
     }
-    if (state->dmr_rest_channel != -1) {
+    if (no_carrier_has_mapped_dmr_rest_channel(state)) {
         return 0;
     }
     if (DSD_SYNC_IS_P25(state->lastsynctype) || DSD_SYNC_IS_P25(state->synctype)) {
@@ -1365,7 +1370,7 @@ no_carrier_should_clear_generic_p25_alias(const dsd_state* state, long cc, int i
     if (is_p25_return) {
         return 0;
     }
-    if (state->dmr_rest_channel != -1 && state->trunk_chan_map[state->dmr_rest_channel] != 0) {
+    if (no_carrier_has_mapped_dmr_rest_channel(state)) {
         return 1;
     }
     return (state->p25_cc_freq != 0 && state->trunk_cc_freq != 0 && state->p25_cc_freq != state->trunk_cc_freq
@@ -1416,7 +1421,11 @@ no_carrier_clear_voice_tune_state(dsd_opts* opts, dsd_state* state) {
 
 static int
 no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, int p25_return,
-                                   int clear_generic_p25_alias, int* helper_attempted) {
+                                   int clear_generic_p25_alias, int* helper_attempted,
+                                   dsd_trunk_tune_result* helper_result) {
+    if (helper_result) {
+        *helper_result = DSD_TRUNK_TUNE_RESULT_OK;
+    }
     if (!p25_return) {
         return 0;
     }
@@ -1427,6 +1436,9 @@ no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, in
     no_carrier_sync_selected_control_channel(state, cc, p25_return, clear_generic_p25_alias);
 
     dsd_trunk_tune_result tune_result = dsd_engine_return_to_cc(opts, state);
+    if (helper_result) {
+        *helper_result = tune_result;
+    }
     if (!dsd_trunk_tune_result_is_ok(tune_result)) {
         state->p25_cc_freq = old_p25_cc_freq;
         state->trunk_cc_freq = old_trunk_cc_freq;
@@ -1437,6 +1449,11 @@ no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, in
     state->edacs_tuned_lcn = -1;
     state->dmr_rest_channel = -1;
     return 1;
+}
+
+static int
+no_carrier_helper_result_is_deferred(int helper_attempted, dsd_trunk_tune_result helper_result) {
+    return (helper_attempted && helper_result == DSD_TRUNK_TUNE_RESULT_DEFERRED) ? 1 : 0;
 }
 
 static int
@@ -1487,10 +1504,12 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
     const int p25_return = no_carrier_is_p25_trunk_return(opts, state, cc);
     const int clear_generic_p25_alias = no_carrier_should_clear_generic_p25_alias(state, cc, p25_return);
     int accepted_cc_return = 0;
+    int clear_failed_helper_state = 0;
     if (cc != 0) {
         int p25_helper_attempted = 0;
+        dsd_trunk_tune_result p25_helper_result = DSD_TRUNK_TUNE_RESULT_OK;
         if (no_carrier_try_helper_return_to_cc(opts, state, cc, p25_return, clear_generic_p25_alias,
-                                               &p25_helper_attempted)) {
+                                               &p25_helper_attempted, &p25_helper_result)) {
             accepted_cc_return = 1;
         } else if (no_carrier_apply_legacy_cc_return(opts, state, cc, p25_helper_attempted)) {
             no_carrier_sync_selected_control_channel(state, cc, p25_return, clear_generic_p25_alias);
@@ -1501,10 +1520,13 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
             if (p25_return) {
                 no_carrier_apply_p25_cc_symbolrate(opts, state);
             }
+        } else if (p25_helper_attempted
+                   && !no_carrier_helper_result_is_deferred(p25_helper_attempted, p25_helper_result)) {
+            clear_failed_helper_state = 1;
         }
     }
 
-    if (accepted_cc_return) {
+    if (accepted_cc_return || clear_failed_helper_state) {
         no_carrier_clear_voice_tune_state(opts, state);
         DSD_MEMSET(state->active_channel, 0, sizeof(state->active_channel));
         state->is_con_plus = 0;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1317,6 +1317,19 @@ no_carrier_p25_frames_enabled(const dsd_opts* opts) {
 }
 
 static int
+no_carrier_generic_trunk_frames_enabled(const dsd_opts* opts) {
+    return (opts->frame_x2tdma == 1 || opts->frame_nxdn48 == 1 || opts->frame_nxdn96 == 1 || opts->frame_dmr == 1
+            || opts->frame_provoice == 1)
+               ? 1
+               : 0;
+}
+
+static int
+no_carrier_p25_only_frames_enabled(const dsd_opts* opts) {
+    return (no_carrier_p25_frames_enabled(opts) && !no_carrier_generic_trunk_frames_enabled(opts)) ? 1 : 0;
+}
+
+static int
 no_carrier_generic_trunk_synctype(int synctype) {
     if (DSD_SYNC_IS_DMR(synctype) || DSD_SYNC_IS_NXDN(synctype) || DSD_SYNC_IS_EDACS(synctype)) {
         return 1;
@@ -1332,7 +1345,7 @@ no_carrier_has_p25_cc_identity(const dsd_state* state) {
     if (state->p2_rfssid != 0 || state->p2_siteid != 0) {
         return 1;
     }
-    return (state->p25_cc_is_tdma == 0 || state->p25_cc_is_tdma == 1 || state->p25_sys_is_tdma == 1) ? 1 : 0;
+    return (state->p25_sys_is_tdma == 1) ? 1 : 0;
 }
 
 static int
@@ -1348,11 +1361,11 @@ no_carrier_has_active_p25_voice_state(const dsd_opts* opts, const dsd_state* sta
 }
 
 static int
-no_carrier_selected_cc_is_p25_alias(const dsd_state* state, long cc) {
-    if (cc == 0 || state->p25_cc_freq == 0 || !no_carrier_has_p25_cc_identity(state)) {
+no_carrier_selected_cc_has_p25_identity(const dsd_state* state, long cc) {
+    if (cc == 0 || state->p25_cc_freq == 0 || cc != state->p25_cc_freq) {
         return 0;
     }
-    return (cc == state->p25_cc_freq) ? 1 : 0;
+    return no_carrier_has_p25_cc_identity(state);
 }
 
 static int
@@ -1374,10 +1387,16 @@ no_carrier_is_p25_trunk_return(const dsd_opts* opts, const dsd_state* state, lon
     if (no_carrier_generic_trunk_synctype(state->lastsynctype) || no_carrier_generic_trunk_synctype(state->synctype)) {
         return 0;
     }
-    if (no_carrier_has_active_p25_voice_state(opts, state)) {
+    if (no_carrier_selected_cc_has_p25_identity(state, cc)) {
         return 1;
     }
-    return no_carrier_selected_cc_is_p25_alias(state, cc);
+    if (no_carrier_has_p25_cc_identity(state) && no_carrier_has_active_p25_voice_state(opts, state)) {
+        return 1;
+    }
+    if (!no_carrier_p25_only_frames_enabled(opts)) {
+        return 0;
+    }
+    return no_carrier_has_active_p25_voice_state(opts, state);
 }
 
 static int
@@ -1437,6 +1456,7 @@ no_carrier_clear_voice_tune_state(dsd_opts* opts, dsd_state* state) {
     state->p25_vc_freq[1] = 0;
     state->trunk_vc_freq[0] = 0;
     state->trunk_vc_freq[1] = 0;
+    state->p25_p2_active_slot = -1;
 }
 
 static int

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1336,6 +1336,14 @@ no_carrier_has_p25_cc_identity(const dsd_state* state) {
 }
 
 static int
+no_carrier_has_active_p25_voice_state(const dsd_opts* opts, const dsd_state* state) {
+    if (opts->p25_is_tuned != 1 || !no_carrier_has_p25_cc_identity(state)) {
+        return 0;
+    }
+    return (state->p25_vc_freq[0] != 0 || state->p25_vc_freq[1] != 0) ? 1 : 0;
+}
+
+static int
 no_carrier_selected_cc_is_p25_alias(const dsd_state* state, long cc) {
     if (cc == 0 || state->p25_cc_freq == 0 || !no_carrier_has_p25_cc_identity(state)) {
         return 0;
@@ -1361,6 +1369,9 @@ no_carrier_is_p25_trunk_return(const dsd_opts* opts, const dsd_state* state, lon
     }
     if (no_carrier_generic_trunk_synctype(state->lastsynctype) || no_carrier_generic_trunk_synctype(state->synctype)) {
         return 0;
+    }
+    if (no_carrier_has_active_p25_voice_state(opts, state)) {
+        return 1;
     }
     return no_carrier_selected_cc_is_p25_alias(state, cc);
 }
@@ -1523,6 +1534,7 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
     const int clear_generic_p25_alias = no_carrier_should_clear_generic_p25_alias(state, cc, p25_return);
     int accepted_cc_return = 0;
     int clear_failed_helper_state = 0;
+    int clear_unreturnable_voice_state = 0;
     if (cc != 0) {
         int p25_helper_attempted = 0;
         dsd_trunk_tune_result p25_helper_result = DSD_TRUNK_TUNE_RESULT_OK;
@@ -1543,9 +1555,11 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
                    && !no_carrier_helper_result_is_deferred(p25_helper_attempted, p25_helper_result)) {
             clear_failed_helper_state = 1;
         }
+    } else {
+        clear_unreturnable_voice_state = 1;
     }
 
-    if (accepted_cc_return || clear_failed_helper_state) {
+    if (accepted_cc_return || clear_failed_helper_state || clear_unreturnable_voice_state) {
         no_carrier_clear_voice_tune_state(opts, state);
         DSD_MEMSET(state->active_channel, 0, sizeof(state->active_channel));
         state->is_con_plus = 0;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1445,8 +1445,10 @@ no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, in
         *helper_result = tune_result;
     }
     if (!dsd_trunk_tune_result_is_ok(tune_result)) {
-        state->p25_cc_freq = old_p25_cc_freq;
-        state->trunk_cc_freq = old_trunk_cc_freq;
+        if (tune_result != DSD_TRUNK_TUNE_RESULT_DEFERRED) {
+            state->p25_cc_freq = old_p25_cc_freq;
+            state->trunk_cc_freq = old_trunk_cc_freq;
+        }
         return 0;
     }
 
@@ -1485,17 +1487,28 @@ no_carrier_apply_legacy_cc_return(const dsd_opts* opts, dsd_state* state, long c
 }
 
 static void
+no_carrier_enable_p25_cc_slots(dsd_opts* opts) {
+    opts->slot1_on = 1;
+    opts->slot2_on = 1;
+}
+
+static void
+no_carrier_enable_p25_cc_slots_if_known(dsd_opts* opts, const dsd_state* state) {
+    if (state->p25_cc_is_tdma == 0 || state->p25_cc_is_tdma == 1) {
+        no_carrier_enable_p25_cc_slots(opts);
+    }
+}
+
+static void
 no_carrier_apply_p25_cc_symbolrate(dsd_opts* opts, dsd_state* state) {
     if (state->p25_cc_is_tdma == 0) {
         state->samplesPerSymbol = 10;
         state->symbolCenter = 4;
-        opts->slot1_on = 1;
-        opts->slot2_on = 1;
+        no_carrier_enable_p25_cc_slots(opts);
     } else if (state->p25_cc_is_tdma == 1) {
         state->samplesPerSymbol = 8;
         state->symbolCenter = 3;
-        opts->slot1_on = 1;
-        opts->slot2_on = 1;
+        no_carrier_enable_p25_cc_slots(opts);
     }
 }
 
@@ -1515,7 +1528,7 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
         dsd_trunk_tune_result p25_helper_result = DSD_TRUNK_TUNE_RESULT_OK;
         if (no_carrier_try_helper_return_to_cc(opts, state, cc, p25_return, clear_generic_p25_alias,
                                                &p25_helper_attempted, &p25_helper_result)) {
-            no_carrier_apply_p25_cc_symbolrate(opts, state);
+            no_carrier_enable_p25_cc_slots_if_known(opts, state);
             accepted_cc_return = 1;
         } else if (no_carrier_apply_legacy_cc_return(opts, state, cc, p25_helper_attempted)) {
             no_carrier_sync_selected_control_channel(state, cc, p25_return, clear_generic_p25_alias);

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1337,9 +1337,13 @@ no_carrier_has_p25_cc_identity(const dsd_state* state) {
 
 static int
 no_carrier_has_active_p25_voice_state(const dsd_opts* opts, const dsd_state* state) {
-    if (opts->p25_is_tuned != 1 || !no_carrier_has_p25_cc_identity(state)) {
+    if (opts->p25_is_tuned != 1) {
         return 0;
     }
+    /*
+     * Configured P25 follows can tune a voice channel before CC identity hints
+     * are decoded; p25_is_tuned plus a tracked P25 VC is still a P25 return hint.
+     */
     return (state->p25_vc_freq[0] != 0 || state->p25_vc_freq[1] != 0) ? 1 : 0;
 }
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1363,6 +1363,10 @@ no_carrier_clear_stale_p25_return_hints_after_generic_activity(dsd_opts* opts, d
     state->p25_vc_freq[0] = 0;
     state->p25_vc_freq[1] = 0;
     state->p25_p2_active_slot = -1;
+    state->p25_p2_audio_allowed[0] = 0;
+    state->p25_p2_audio_allowed[1] = 0;
+    state->p25_call_is_packet[0] = 0;
+    state->p25_call_is_packet[1] = 0;
     opts->p25_is_tuned = 0;
 }
 
@@ -1441,6 +1445,10 @@ no_carrier_clear_voice_tune_state(dsd_opts* opts, dsd_state* state) {
     state->trunk_vc_freq[0] = 0;
     state->trunk_vc_freq[1] = 0;
     state->p25_p2_active_slot = -1;
+    state->p25_p2_audio_allowed[0] = 0;
+    state->p25_p2_audio_allowed[1] = 0;
+    state->p25_call_is_packet[0] = 0;
+    state->p25_call_is_packet[1] = 0;
 }
 
 static int
@@ -1502,6 +1510,7 @@ no_carrier_apply_legacy_cc_return(const dsd_opts* opts, dsd_state* state, long c
 #endif
         return state->rtl_ctx ? 0 : 1;
     }
+    state->dmr_rest_channel = -1;
     return 1;
 }
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1385,8 +1385,13 @@ no_carrier_sync_selected_control_channel(dsd_state* state, long cc, int is_p25_r
         return;
     }
 
+    const int selected_existing_p25_alias = (state->p25_cc_freq == cc) ? 1 : 0;
     state->trunk_cc_freq = cc;
-    state->p25_cc_freq = (is_p25_return || !clear_generic_p25_alias) ? cc : 0;
+    if (is_p25_return) {
+        state->p25_cc_freq = cc;
+    } else if (clear_generic_p25_alias || !selected_existing_p25_alias) {
+        state->p25_cc_freq = 0;
+    }
 }
 
 static void
@@ -1510,6 +1515,7 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
         dsd_trunk_tune_result p25_helper_result = DSD_TRUNK_TUNE_RESULT_OK;
         if (no_carrier_try_helper_return_to_cc(opts, state, cc, p25_return, clear_generic_p25_alias,
                                                &p25_helper_attempted, &p25_helper_result)) {
+            no_carrier_apply_p25_cc_symbolrate(opts, state);
             accepted_cc_return = 1;
         } else if (no_carrier_apply_legacy_cc_return(opts, state, cc, p25_helper_attempted)) {
             no_carrier_sync_selected_control_channel(state, cc, p25_return, clear_generic_p25_alias);

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1324,7 +1324,18 @@ no_carrier_has_p25_cc_identity(const dsd_state* state) {
     if (state->p2_rfssid != 0 || state->p2_siteid != 0) {
         return 1;
     }
-    return (state->p25_cc_is_tdma == 1 || state->p25_sys_is_tdma == 1 || state->p25_p2_active_slot != -1) ? 1 : 0;
+    return (state->p25_cc_is_tdma == 0 || state->p25_cc_is_tdma == 1 || state->p25_sys_is_tdma == 1) ? 1 : 0;
+}
+
+static int
+no_carrier_selected_cc_is_p25_alias(const dsd_state* state, long cc) {
+    if (cc == 0 || state->p25_cc_freq == 0 || !no_carrier_has_p25_cc_identity(state)) {
+        return 0;
+    }
+    if (cc == state->p25_cc_freq) {
+        return 1;
+    }
+    return (state->trunk_cc_freq != 0 && cc == state->trunk_cc_freq) ? 1 : 0;
 }
 
 static int
@@ -1349,20 +1360,31 @@ no_carrier_is_p25_trunk_return(const dsd_opts* opts, const dsd_state* state, lon
     if (no_carrier_generic_trunk_synctype(state->lastsynctype) || no_carrier_generic_trunk_synctype(state->synctype)) {
         return 0;
     }
-    if (cc != 0 && state->p25_cc_freq != 0 && cc == state->p25_cc_freq && no_carrier_has_p25_cc_identity(state)) {
+    return no_carrier_selected_cc_is_p25_alias(state, cc);
+}
+
+static int
+no_carrier_should_clear_generic_p25_alias(const dsd_state* state, long cc, int is_p25_return) {
+    if (is_p25_return) {
+        return 0;
+    }
+    if (state->dmr_rest_channel != -1 && state->trunk_chan_map[state->dmr_rest_channel] != 0) {
         return 1;
     }
-    return 0;
+    return (state->p25_cc_freq != 0 && state->trunk_cc_freq != 0 && state->p25_cc_freq != state->trunk_cc_freq
+            && state->p25_cc_freq != cc)
+               ? 1
+               : 0;
 }
 
 static void
-no_carrier_sync_selected_control_channel(dsd_state* state, long cc, int is_p25_return) {
+no_carrier_sync_selected_control_channel(dsd_state* state, long cc, int is_p25_return, int clear_generic_p25_alias) {
     if (cc == 0) {
         return;
     }
 
     state->trunk_cc_freq = cc;
-    state->p25_cc_freq = is_p25_return ? cc : 0;
+    state->p25_cc_freq = (is_p25_return || !clear_generic_p25_alias) ? cc : 0;
 }
 
 static void
@@ -1396,14 +1418,21 @@ no_carrier_clear_voice_tune_state(dsd_opts* opts, dsd_state* state) {
 }
 
 static int
-no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, int p25_return, int* helper_attempted) {
+no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, int p25_return,
+                                   int clear_generic_p25_alias, int* helper_attempted) {
     if (!p25_return) {
         return 0;
     }
 
     *helper_attempted = 1;
+    const long old_p25_cc_freq = state->p25_cc_freq;
+    const long old_trunk_cc_freq = state->trunk_cc_freq;
+    no_carrier_sync_selected_control_channel(state, cc, p25_return, clear_generic_p25_alias);
+
     dsd_trunk_tune_result tune_result = dsd_engine_return_to_cc(opts, state);
     if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+        state->p25_cc_freq = old_p25_cc_freq;
+        state->trunk_cc_freq = old_trunk_cc_freq;
         return 0;
     }
 
@@ -1459,13 +1488,15 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
 
     long cc = no_carrier_select_control_channel(state);
     const int p25_return = no_carrier_is_p25_trunk_return(opts, state, cc);
+    const int clear_generic_p25_alias = no_carrier_should_clear_generic_p25_alias(state, cc, p25_return);
     int accepted_cc_return = 0;
     if (cc != 0) {
         int p25_helper_attempted = 0;
-        no_carrier_sync_selected_control_channel(state, cc, p25_return);
-        if (no_carrier_try_helper_return_to_cc(opts, state, cc, p25_return, &p25_helper_attempted)) {
+        if (no_carrier_try_helper_return_to_cc(opts, state, cc, p25_return, clear_generic_p25_alias,
+                                               &p25_helper_attempted)) {
             accepted_cc_return = 1;
         } else if (no_carrier_apply_legacy_cc_return(opts, state, cc, p25_helper_attempted)) {
+            no_carrier_sync_selected_control_channel(state, cc, p25_return, clear_generic_p25_alias);
             accepted_cc_return = 1;
             state->edacs_tuned_lcn = -1;
             state->last_cc_sync_time = now;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1303,14 +1303,123 @@ no_carrier_select_control_channel(dsd_state* state) {
     return cc;
 }
 
+static int
+no_carrier_p25_frames_enabled(const dsd_opts* opts) {
+    return (opts->frame_p25p1 == 1 || opts->frame_p25p2 == 1) ? 1 : 0;
+}
+
+static int
+no_carrier_generic_trunk_synctype(int synctype) {
+    if (DSD_SYNC_IS_DMR(synctype) || DSD_SYNC_IS_NXDN(synctype) || DSD_SYNC_IS_EDACS(synctype)) {
+        return 1;
+    }
+    return DSD_SYNC_IS_X2TDMA(synctype) ? 1 : 0;
+}
+
+static int
+no_carrier_generic_trunk_frames_enabled(const dsd_opts* opts) {
+    if (opts->frame_dmr == 1 || opts->frame_nxdn48 == 1 || opts->frame_nxdn96 == 1) {
+        return 1;
+    }
+    return (opts->frame_provoice == 1 || opts->frame_x2tdma == 1) ? 1 : 0;
+}
+
+static int
+no_carrier_is_p25_trunk_return(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state || opts->p25_trunk != 1 || !no_carrier_p25_frames_enabled(opts)) {
+        return 0;
+    }
+    if (state->dmr_rest_channel != -1) {
+        return 0;
+    }
+    if (DSD_SYNC_IS_P25(state->lastsynctype) || DSD_SYNC_IS_P25(state->synctype)) {
+        return 1;
+    }
+    if (no_carrier_generic_trunk_synctype(state->lastsynctype)) {
+        return 0;
+    }
+    return no_carrier_generic_trunk_frames_enabled(opts) ? 0 : 1;
+}
+
 static void
-no_carrier_sync_selected_control_channel(const dsd_opts* opts, dsd_state* state, long cc) {
+no_carrier_sync_selected_control_channel(dsd_state* state, long cc, int is_p25_return) {
     if (cc == 0) {
         return;
     }
 
     state->trunk_cc_freq = cc;
-    state->p25_cc_freq = (opts->p25_trunk == 1) ? cc : 0;
+    state->p25_cc_freq = is_p25_return ? cc : 0;
+}
+
+static void
+no_carrier_sync_helper_tune_cache(const dsd_opts* opts, const dsd_state* state, long cc) {
+    if (cc == 0) {
+        return;
+    }
+    if (opts->use_rigctl == 1) {
+        s_last_rigctl_freq = cc;
+        if (opts->setmod_bw != 0) {
+            s_last_rigctl_bw = opts->setmod_bw;
+        }
+    }
+#ifdef USE_RADIO
+    if (opts->audio_in_type == AUDIO_IN_RTL && state->rtl_ctx) {
+        s_last_rtl_freq = (uint32_t)cc;
+    }
+#else
+    UNUSED(state);
+#endif
+}
+
+static void
+no_carrier_clear_voice_tune_state(dsd_opts* opts, dsd_state* state) {
+    opts->p25_is_tuned = 0;
+    opts->trunk_is_tuned = 0;
+    state->p25_vc_freq[0] = 0;
+    state->p25_vc_freq[1] = 0;
+    state->trunk_vc_freq[0] = 0;
+    state->trunk_vc_freq[1] = 0;
+}
+
+static int
+no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, int p25_return, int* helper_attempted) {
+    if (!p25_return) {
+        return 0;
+    }
+
+    *helper_attempted = 1;
+    dsd_trunk_tune_result tune_result = dsd_engine_return_to_cc(opts, state);
+    if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+        return 0;
+    }
+
+    no_carrier_sync_helper_tune_cache(opts, state, cc);
+    state->edacs_tuned_lcn = -1;
+    state->dmr_rest_channel = -1;
+    return 1;
+}
+
+static int
+no_carrier_apply_legacy_cc_return(const dsd_opts* opts, dsd_state* state, long cc, int helper_attempted) {
+    if (opts->use_rigctl == 1) {
+        no_carrier_tune_rigctl_if_needed(opts, cc);
+        state->dmr_rest_channel = -1;
+        return 1;
+    }
+    if (opts->audio_in_type == AUDIO_IN_RTL) {
+        if (!helper_attempted) {
+            no_carrier_tune_rtl_if_needed(opts, state, (uint32_t)cc);
+#ifdef USE_RADIO
+            state->dmr_rest_channel = -1;
+#endif
+            return 1;
+        }
+#ifdef USE_RADIO
+        state->dmr_rest_channel = -1;
+#endif
+        return state->rtl_ctx ? 0 : 1;
+    }
+    return 1;
 }
 
 static void
@@ -1335,42 +1444,22 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
     }
 
     long cc = no_carrier_select_control_channel(state);
-    int used_trunk_helper = 0;
-    int legacy_clear_state = 0;
+    const int p25_return = no_carrier_is_p25_trunk_return(opts, state);
     if (cc != 0) {
-        no_carrier_sync_selected_control_channel(opts, state, cc);
-        dsd_trunk_tune_result tune_result = dsd_engine_return_to_cc(opts, state);
-        if (dsd_trunk_tune_result_is_ok(tune_result)) {
-            used_trunk_helper = 1;
-            state->edacs_tuned_lcn = -1;
-            state->dmr_rest_channel = -1;
-        } else if (opts->use_rigctl == 1) {
-            no_carrier_tune_rigctl_if_needed(opts, cc);
-            state->dmr_rest_channel = -1;
-            legacy_clear_state = 1;
-        } else if (opts->audio_in_type == AUDIO_IN_RTL) {
-            if (!state->rtl_ctx) {
-                legacy_clear_state = 1;
-            }
-#ifdef USE_RADIO
-            state->dmr_rest_channel = -1;
-#endif
-        } else {
-            legacy_clear_state = 1;
-        }
-
-        if (!used_trunk_helper && legacy_clear_state) {
-            opts->p25_is_tuned = 0;
-            opts->trunk_is_tuned = 0;
+        int p25_helper_attempted = 0;
+        no_carrier_sync_selected_control_channel(state, cc, p25_return);
+        if (!no_carrier_try_helper_return_to_cc(opts, state, cc, p25_return, &p25_helper_attempted)
+            && no_carrier_apply_legacy_cc_return(opts, state, cc, p25_helper_attempted)) {
             state->edacs_tuned_lcn = -1;
             state->last_cc_sync_time = now;
             state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
-            no_carrier_apply_p25_cc_symbolrate(opts, state);
+            if (p25_return) {
+                no_carrier_apply_p25_cc_symbolrate(opts, state);
+            }
         }
     }
 
-    state->p25_vc_freq[0] = 0;
-    state->p25_vc_freq[1] = 0;
+    no_carrier_clear_voice_tune_state(opts, state);
     DSD_MEMSET(state->active_channel, 0, sizeof(state->active_channel));
     state->is_con_plus = 0;
 }
@@ -1653,11 +1742,14 @@ no_carrier_clear_stale_follow_state_if_needed(dsd_opts* opts, dsd_state* state, 
         state->dmr_rest_channel = -1;
         state->p25_vc_freq[0] = 0;
         state->p25_vc_freq[1] = 0;
+        state->trunk_vc_freq[0] = 0;
+        state->trunk_vc_freq[1] = 0;
         state->dmr_mfid = -1;
         state->dmr_branding_sub[0] = '\0';
         state->dmr_branding[0] = '\0';
         state->dmr_site_parms[0] = '\0';
         opts->p25_is_tuned = 0;
+        opts->trunk_is_tuned = 0;
         DSD_MEMSET(state->active_channel, 0, sizeof(state->active_channel));
     }
 }

--- a/src/protocol/edacs/edacs-fme.c
+++ b/src/protocol/edacs/edacs-fme.c
@@ -65,6 +65,12 @@
 #include <math.h>
 #endif
 
+#ifdef DSD_NEO_TEST_HOOKS
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void dsd_neo_edacs_test_process_valid_frame(dsd_opts* opts, dsd_state* state, unsigned long long int msg_1,
+                                            unsigned long long int msg_2);
+#endif
+
 static void
 edacs_print_group_label(const dsd_state* state, uint32_t id) {
     char name[50];
@@ -1973,6 +1979,16 @@ edacs_process_valid_frame(dsd_opts* opts, dsd_state* state, unsigned long long i
     edacs_print_mode_selection_hint(msg_1, msg_2);
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_process_valid_frame(dsd_opts* opts, dsd_state* state, unsigned long long int msg_1,
+                                       unsigned long long int msg_2) {
+    edacs_init_afs_layout(state);
+    edacs_process_valid_frame(opts, state, msg_1, msg_2);
+}
+#endif
+
 void
 edacs(dsd_opts* opts, dsd_state* state) {
     edacs_init_afs_layout(state);
@@ -2079,6 +2095,7 @@ eot_cc(dsd_opts* opts, dsd_state* state) {
         DSD_SNPRINTF(state->call_string[1], sizeof state->call_string[1], "%s", "                     "); //21 spaces
         DSD_SNPRINTF(state->active_channel[0], sizeof state->active_channel[0], "%s", "");
         DSD_SNPRINTF(state->active_channel[1], sizeof state->active_channel[1], "%s", "");
+        state->edacs_tuned_lcn = -1;
         state->p25_vc_freq[0] = state->p25_vc_freq[1] = 0;
         state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = 0;
     }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -846,6 +846,7 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
 
     // Clear voice activity indicator to prevent audio routing logic from
     // treating this locked-out slot as having active voice
+    ctx->slots[slot].voice_active = 0;
     if (slot == 0) {
         state->dmrburstL = 0;
         // Reset voice counters to prevent stale state from affecting later calls

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4259,6 +4259,24 @@ target_include_directories(
 target_link_libraries(dsd-neo_test_p25_sm_core PRIVATE dsd-neo_proto_p25)
 add_test(NAME P25_SM_CORE COMMAND dsd-neo_test_p25_sm_core)
 
+# P25 return-to-control-channel stress matrix
+add_executable(
+    dsd-neo_test_p25_sm_return_to_cc_matrix
+    protocol/p25/test_p25_sm_return_to_cc_matrix.c
+)
+target_include_directories(
+    dsd-neo_test_p25_sm_return_to_cc_matrix
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_p25_sm_return_to_cc_matrix
+    PRIVATE dsd-neo_proto_p25
+)
+add_test(
+    NAME P25_SM_RETURN_TO_CC_MATRIX
+    COMMAND dsd-neo_test_p25_sm_return_to_cc_matrix
+)
+
 # P25 SM candidate cooldown
 add_executable(
     dsd-neo_test_p25_sm_cand_cooldown

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1683,6 +1683,7 @@ if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
             "-Wl,--start-group"
             dsd-neo_engine
             "-Wl,--end-group"
+            "-Wl,--wrap=rtl_stream_clear_pending_retune_profile"
             "-Wl,--wrap=rtl_stream_dsp_get"
             "-Wl,--wrap=rtl_stream_get_symbol_profile_full"
             "-Wl,--wrap=rtl_stream_get_ted_sps"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1673,6 +1673,10 @@ target_include_directories(
     PRIVATE ${PROJECT_SOURCE_DIR}/include
 )
 if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
+    target_compile_definitions(
+        dsd-neo_test_engine_no_carrier_reset
+        PRIVATE DSD_NEO_TEST_RTL_WRAP=1
+    )
     target_link_libraries(
         dsd-neo_test_engine_no_carrier_reset
         PRIVATE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1679,6 +1679,13 @@ if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
             "-Wl,--start-group"
             dsd-neo_engine
             "-Wl,--end-group"
+            "-Wl,--wrap=rtl_stream_dsp_get"
+            "-Wl,--wrap=rtl_stream_get_symbol_profile_full"
+            "-Wl,--wrap=rtl_stream_get_ted_sps"
+            "-Wl,--wrap=rtl_stream_get_ted_sps_override"
+            "-Wl,--wrap=rtl_stream_output_rate"
+            "-Wl,--wrap=rtl_stream_prepare_retune_profile_for_target"
+            "-Wl,--wrap=rtl_stream_tune"
             ${LIBS}
             dsd-neo_feature_radio
             dsd-neo_test_support

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1711,6 +1711,40 @@ add_test(
 )
 
 add_executable(
+    dsd-neo_test_engine_generic_trunk_return_matrix
+    engine/test_engine_generic_trunk_return_matrix.c
+)
+target_include_directories(
+    dsd-neo_test_engine_generic_trunk_return_matrix
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
+    target_link_libraries(
+        dsd-neo_test_engine_generic_trunk_return_matrix
+        PRIVATE
+            "-Wl,--start-group"
+            dsd-neo_engine
+            "-Wl,--end-group"
+            ${LIBS}
+            dsd-neo_feature_radio
+            dsd-neo_test_support
+    )
+else()
+    target_link_libraries(
+        dsd-neo_test_engine_generic_trunk_return_matrix
+        PRIVATE
+            dsd-neo_engine
+            ${LIBS}
+            dsd-neo_feature_radio
+            dsd-neo_test_support
+    )
+endif()
+add_test(
+    NAME ENGINE_GENERIC_TRUNK_RETURN_MATRIX
+    COMMAND dsd-neo_test_engine_generic_trunk_return_matrix
+)
+
+add_executable(
     dsd-neo_test_engine_cleanup_audio
     engine/test_engine_cleanup_audio.c
 )
@@ -3296,6 +3330,27 @@ target_link_libraries(
 )
 add_test(NAME DMR_T3_SM_RELEASE COMMAND dsd-neo_test_dmr_t3_sm_release)
 
+add_executable(
+    dsd-neo_test_dmr_t3_sm_return_to_cc_matrix
+    protocol/dmr/test_dmr_t3_sm_return_to_cc_matrix.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_trunk_sm.c
+)
+target_include_directories(
+    dsd-neo_test_dmr_t3_sm_return_to_cc_matrix
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/tests/protocol/dmr
+        ${PROJECT_SOURCE_DIR}/src/protocol/dmr
+)
+target_link_libraries(
+    dsd-neo_test_dmr_t3_sm_return_to_cc_matrix
+    PRIVATE dsd-neo_platform dsd-neo_runtime
+)
+add_test(
+    NAME DMR_T3_SM_RETURN_TO_CC_MATRIX
+    COMMAND dsd-neo_test_dmr_t3_sm_return_to_cc_matrix
+)
+
 # DMR Tier III end-to-end shim (neighbor → grant → release)
 add_executable(
     dsd-neo_test_dmr_t3_shim
@@ -4435,6 +4490,23 @@ target_link_libraries(dsd-neo_test_nxdn_grant_policy PRIVATE dsd-neo_proto_nxdn)
 add_test(NAME NXDN_GRANT_POLICY COMMAND dsd-neo_test_nxdn_grant_policy)
 
 add_executable(
+    dsd-neo_test_nxdn_grant_tune_matrix
+    protocol/nxdn/test_nxdn_grant_tune_matrix.c
+)
+target_include_directories(
+    dsd-neo_test_nxdn_grant_tune_matrix
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_nxdn_grant_tune_matrix
+    PRIVATE dsd-neo_proto_nxdn
+)
+add_test(
+    NAME NXDN_GRANT_TUNE_MATRIX
+    COMMAND dsd-neo_test_nxdn_grant_tune_matrix
+)
+
+add_executable(
     dsd-neo_test_edacs_bch
     protocol/edacs/test_edacs_bch.c
     ${PROJECT_SOURCE_DIR}/src/protocol/edacs/edacs-bch3.c
@@ -4478,6 +4550,39 @@ target_include_directories(
 )
 target_link_libraries(dsd-neo_test_edacs_grant_policy PRIVATE dsd-neo_core)
 add_test(NAME EDACS_GRANT_POLICY COMMAND dsd-neo_test_edacs_grant_policy)
+
+# This matrix drives eot_cc(); it must not call real skipDibit from the unit-test fixture.
+if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
+    target_compile_definitions(dsd-neo_proto_edacs PRIVATE DSD_NEO_TEST_HOOKS)
+    add_executable(
+        dsd-neo_test_edacs_grant_tune_matrix
+        protocol/edacs/test_edacs_grant_tune_matrix.c
+    )
+    target_include_directories(
+        dsd-neo_test_edacs_grant_tune_matrix
+        PRIVATE ${PROJECT_SOURCE_DIR}/include
+    )
+    target_link_libraries(
+        dsd-neo_test_edacs_grant_tune_matrix
+        PRIVATE
+            "-Wl,--start-group"
+            ${_DSD_RUNTIME_CLI_PARSE_LIBS}
+            "-Wl,--end-group"
+            ${LIBS}
+            dsd-neo_test_support
+    )
+    target_link_options(
+        dsd-neo_test_edacs_grant_tune_matrix
+        PRIVATE
+            "-Wl,--wrap=skipDibit"
+            "-Wl,--wrap=watchdog_event_current"
+            "-Wl,--wrap=watchdog_event_history"
+    )
+    add_test(
+        NAME EDACS_GRANT_TUNE_MATRIX
+        COMMAND dsd-neo_test_edacs_grant_tune_matrix
+    )
+endif()
 
 # CQPSK reliability metric unit test
 # Note: compiles its own test stub rather than linking dsd-neo_core to avoid

--- a/tests/engine/test_engine_generic_trunk_return_matrix.c
+++ b/tests/engine/test_engine_generic_trunk_return_matrix.c
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Protocol-generic noCarrier() trunk return matrix.
+ *
+ * Covers non-P25 trunk sync families that share the generic return path rather
+ * than the P25 trunk state machine helper.
+ */
+
+#include <dsd-neo/core/init.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/frame_processing.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+typedef struct {
+    const char* name;
+    int synctype;
+} generic_return_case;
+
+enum {
+    GENERIC_TRUNK_CC_HZ = 851012500,
+    GENERIC_TRUNK_VC_HZ = 852012500,
+    GENERIC_P25_CC_HZ = 769868750,
+    GENERIC_P25_VC_HZ = 771056250,
+    GENERIC_REST_CC_HZ = 853012500,
+};
+
+static int g_return_to_cc_calls = 0;
+
+int
+ui_start(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    return 0;
+}
+
+void
+ui_stop(void) { // NOLINT(misc-use-internal-linkage)
+}
+
+static dsd_trunk_tune_result
+generic_return_to_cc_guard(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_return_to_cc_calls++;
+    return DSD_TRUNK_TUNE_RESULT_FAILED;
+}
+
+static void
+install_return_to_cc_guard(void) {
+    g_return_to_cc_calls = 0;
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.return_to_cc_result = generic_return_to_cc_guard;
+    dsd_trunk_tuning_hooks_set(hooks);
+}
+
+static void
+clear_return_to_cc_guard(void) {
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    g_return_to_cc_calls = 0;
+}
+
+static int
+expect_true(const char* protocol, const char* scenario, const char* check, int cond) {
+    if (cond) {
+        return 0;
+    }
+    DSD_FPRINTF(stderr, "FAIL protocol=%s scenario=%s check=%s\n", protocol, scenario, check);
+    return 1;
+}
+
+static int
+init_test_runtime(dsd_opts** opts_out, dsd_state** state_out) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: runtime\n");
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+    *opts_out = opts;
+    *state_out = state;
+    return 0;
+}
+
+static void
+free_test_runtime(dsd_opts* opts, dsd_state* state) {
+    if (state) {
+        freeState(state);
+    }
+    free(state);
+    free(opts);
+}
+
+static int
+setup_generic_fixture(dsd_opts** opts_out, dsd_state** state_out, const generic_return_case* test_case,
+                      const char* scenario, int recent_vc, int with_cc) {
+    if (init_test_runtime(opts_out, state_out) != 0) {
+        return 1;
+    }
+
+    dsd_opts* opts = *opts_out;
+    dsd_state* state = *state_out;
+    const time_t now = time(NULL);
+
+    opts->trunk_enable = 1;
+    opts->p25_trunk = 0;
+    opts->trunk_hangtime = 1.0f;
+    opts->trunk_is_tuned = 1;
+    opts->p25_is_tuned = 1;
+    opts->audio_in_type = AUDIO_IN_PULSE;
+
+    state->synctype = test_case->synctype;
+    state->lastsynctype = test_case->synctype;
+    state->last_cc_sync_time = now - 11;
+    state->last_vc_sync_time = recent_vc ? now : (now - 11);
+    state->trunk_cc_freq = with_cc ? GENERIC_TRUNK_CC_HZ : 0L;
+    state->p25_cc_freq = with_cc ? GENERIC_P25_CC_HZ : 0L;
+    state->trunk_vc_freq[0] = GENERIC_TRUNK_VC_HZ;
+    state->trunk_vc_freq[1] = GENERIC_TRUNK_VC_HZ;
+    state->p25_vc_freq[0] = GENERIC_P25_VC_HZ;
+    state->p25_vc_freq[1] = GENERIC_P25_VC_HZ;
+    state->p2_cc = 0x293;
+    state->p2_wacn = 0xABCDE;
+    state->p2_sysid = 0x123;
+    state->p2_rfssid = 2;
+    state->p2_siteid = 3;
+    state->p25_sys_is_tdma = 1;
+    state->p25_p2_active_slot = 1;
+    state->p25_p2_audio_allowed[0] = 1;
+    state->p25_p2_audio_allowed[1] = 1;
+    state->p25_call_is_packet[0] = 1;
+    state->p25_call_is_packet[1] = 1;
+    DSD_SNPRINTF(state->active_channel[0], sizeof(state->active_channel[0]), "%s", scenario);
+    return 0;
+}
+
+static int
+run_recent_vc_case(const generic_return_case* test_case) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    int rc = setup_generic_fixture(&opts, &state, test_case, "recent-vc", 1, 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    noCarrier(opts, state);
+
+    rc |= expect_true(test_case->name, "recent-vc", "generic tuned flag preserved", opts->trunk_is_tuned == 1);
+    rc |= expect_true(test_case->name, "recent-vc", "p25 alias tuned flag cleared", opts->p25_is_tuned == 0);
+    rc |= expect_true(test_case->name, "recent-vc", "generic VC frequency preserved",
+                      state->trunk_vc_freq[0] == GENERIC_TRUNK_VC_HZ && state->trunk_vc_freq[1] == GENERIC_TRUNK_VC_HZ);
+    rc |= expect_true(test_case->name, "recent-vc", "p25 VC alias cleared",
+                      state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0);
+    rc |= expect_true(test_case->name, "recent-vc", "p25 identity aliases cleared",
+                      state->p2_cc == 0 && state->p2_wacn == 0 && state->p2_sysid == 0 && state->p2_rfssid == 0
+                          && state->p2_siteid == 0 && state->p25_sys_is_tdma == 0);
+    rc |= expect_true(test_case->name, "recent-vc", "p25 slot and audio aliases cleared",
+                      state->p25_p2_active_slot == -1 && state->p25_p2_audio_allowed[0] == 0
+                          && state->p25_p2_audio_allowed[1] == 0 && state->p25_call_is_packet[0] == 0
+                          && state->p25_call_is_packet[1] == 0);
+
+    free_test_runtime(opts, state);
+    return rc;
+}
+
+static int
+run_stale_vc_with_cc_case(const generic_return_case* test_case) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    int rc = setup_generic_fixture(&opts, &state, test_case, "stale-vc-with-cc", 0, 1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    noCarrier(opts, state);
+
+    rc |= expect_true(test_case->name, "stale-vc-with-cc", "tuned flags cleared",
+                      opts->trunk_is_tuned == 0 && opts->p25_is_tuned == 0);
+    rc |= expect_true(test_case->name, "stale-vc-with-cc", "generic VC frequencies cleared",
+                      state->trunk_vc_freq[0] == 0 && state->trunk_vc_freq[1] == 0);
+    rc |= expect_true(test_case->name, "stale-vc-with-cc", "p25 VC aliases cleared",
+                      state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0);
+    rc |= expect_true(test_case->name, "stale-vc-with-cc", "generic CC retained",
+                      state->trunk_cc_freq == GENERIC_TRUNK_CC_HZ);
+    rc |= expect_true(test_case->name, "stale-vc-with-cc", "stale p25 CC alias cleared", state->p25_cc_freq == 0);
+    rc |= expect_true(test_case->name, "stale-vc-with-cc", "p25 identity aliases cleared",
+                      state->p2_cc == 0 && state->p2_wacn == 0 && state->p2_sysid == 0 && state->p25_sys_is_tdma == 0);
+    rc |= expect_true(test_case->name, "stale-vc-with-cc", "p25 slot and audio aliases cleared",
+                      state->p25_p2_active_slot == -1 && state->p25_p2_audio_allowed[0] == 0
+                          && state->p25_p2_audio_allowed[1] == 0 && state->p25_call_is_packet[0] == 0
+                          && state->p25_call_is_packet[1] == 0);
+    rc |=
+        expect_true(test_case->name, "stale-vc-with-cc", "active display cleared", state->active_channel[0][0] == '\0');
+
+    free_test_runtime(opts, state);
+    return rc;
+}
+
+static int
+run_stale_vc_without_cc_case(const generic_return_case* test_case) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    int rc = setup_generic_fixture(&opts, &state, test_case, "stale-vc-without-cc", 0, 0);
+    if (rc != 0) {
+        return rc;
+    }
+
+    noCarrier(opts, state);
+
+    rc |= expect_true(test_case->name, "stale-vc-without-cc", "unreturnable tuned flags cleared",
+                      opts->trunk_is_tuned == 0 && opts->p25_is_tuned == 0);
+    rc |= expect_true(test_case->name, "stale-vc-without-cc", "unreturnable generic VC cleared",
+                      state->trunk_vc_freq[0] == 0 && state->trunk_vc_freq[1] == 0);
+    rc |= expect_true(test_case->name, "stale-vc-without-cc", "control channels remain empty",
+                      state->trunk_cc_freq == 0 && state->p25_cc_freq == 0);
+    rc |= expect_true(test_case->name, "stale-vc-without-cc", "p25 aliases cleared",
+                      state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0 && state->p2_cc == 0
+                          && state->p2_wacn == 0 && state->p2_sysid == 0);
+    rc |= expect_true(test_case->name, "stale-vc-without-cc", "p25 slot and audio aliases cleared",
+                      state->p25_p2_active_slot == -1 && state->p25_p2_audio_allowed[0] == 0
+                          && state->p25_p2_audio_allowed[1] == 0 && state->p25_call_is_packet[0] == 0
+                          && state->p25_call_is_packet[1] == 0);
+
+    free_test_runtime(opts, state);
+    return rc;
+}
+
+static int
+run_stale_vc_with_matching_p25_cc_alias_case(const generic_return_case* test_case) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    int rc = setup_generic_fixture(&opts, &state, test_case, "stale-vc-matching-p25-cc", 0, 1);
+    if (rc != 0) {
+        return rc;
+    }
+    state->p25_cc_freq = state->trunk_cc_freq;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true(test_case->name, "stale-vc-matching-p25-cc", "matching p25 CC alias retained",
+                      state->trunk_cc_freq == GENERIC_TRUNK_CC_HZ && state->p25_cc_freq == GENERIC_TRUNK_CC_HZ);
+    rc |= expect_true(test_case->name, "stale-vc-matching-p25-cc", "voice state cleared",
+                      opts->trunk_is_tuned == 0 && opts->p25_is_tuned == 0 && state->trunk_vc_freq[0] == 0
+                          && state->p25_vc_freq[0] == 0);
+
+    free_test_runtime(opts, state);
+    return rc;
+}
+
+static int
+run_mapped_rest_channel_case(const generic_return_case* test_case) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    int rc = setup_generic_fixture(&opts, &state, test_case, "mapped-rest-channel", 0, 1);
+    if (rc != 0) {
+        return rc;
+    }
+    state->dmr_rest_channel = 7;
+    state->trunk_chan_map[7] = GENERIC_REST_CC_HZ;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true(test_case->name, "mapped-rest-channel", "mapped rest channel selected",
+                      state->trunk_cc_freq == GENERIC_REST_CC_HZ);
+    rc |= expect_true(test_case->name, "mapped-rest-channel", "mapped rest channel clears stale p25 cc alias",
+                      state->p25_cc_freq == 0);
+    rc |= expect_true(test_case->name, "mapped-rest-channel", "mapped rest channel consumed",
+                      state->dmr_rest_channel == -1);
+    rc |= expect_true(test_case->name, "mapped-rest-channel", "voice state cleared",
+                      opts->trunk_is_tuned == 0 && opts->p25_is_tuned == 0 && state->trunk_vc_freq[0] == 0
+                          && state->p25_vc_freq[0] == 0);
+
+    free_test_runtime(opts, state);
+    return rc;
+}
+
+static int
+run_generic_overrides_p25_helper_case(const generic_return_case* test_case) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    int rc = setup_generic_fixture(&opts, &state, test_case, "generic-overrides-p25-helper", 0, 1);
+    if (rc != 0) {
+        return rc;
+    }
+    opts->p25_trunk = 1;
+    opts->p25_is_tuned = 1;
+    install_return_to_cc_guard();
+
+    noCarrier(opts, state);
+
+    rc |= expect_true(test_case->name, "generic-overrides-p25-helper", "p25 helper not called",
+                      g_return_to_cc_calls == 0);
+    rc |= expect_true(test_case->name, "generic-overrides-p25-helper", "generic legacy return accepted",
+                      opts->trunk_is_tuned == 0 && opts->p25_is_tuned == 0
+                          && state->trunk_cc_freq == GENERIC_TRUNK_CC_HZ && state->p25_cc_freq == 0);
+    rc |= expect_true(test_case->name, "generic-overrides-p25-helper", "p25 hints cleared",
+                      state->p25_vc_freq[0] == 0 && state->p2_cc == 0 && state->p25_sys_is_tdma == 0);
+
+    clear_return_to_cc_guard();
+    free_test_runtime(opts, state);
+    return rc;
+}
+
+static int
+run_sync_source_case(const generic_return_case* test_case, int current_only) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    const char* scenario = current_only ? "current-sync-only" : "last-sync-only";
+    int rc = setup_generic_fixture(&opts, &state, test_case, scenario, 0, 1);
+    if (rc != 0) {
+        return rc;
+    }
+    if (current_only) {
+        state->lastsynctype = DSD_SYNC_NONE;
+    } else {
+        state->synctype = DSD_SYNC_NONE;
+    }
+
+    noCarrier(opts, state);
+
+    rc |= expect_true(test_case->name, scenario, "generic sync source selected generic path",
+                      opts->trunk_is_tuned == 0 && opts->p25_is_tuned == 0
+                          && state->trunk_cc_freq == GENERIC_TRUNK_CC_HZ && state->p25_cc_freq == 0);
+    rc |= expect_true(test_case->name, scenario, "p25 aliases cleared",
+                      state->p25_vc_freq[0] == 0 && state->p2_cc == 0 && state->p25_p2_active_slot == -1);
+
+    free_test_runtime(opts, state);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    static const generic_return_case cases[] = {
+        {"dmr-bs-data-pos", DSD_SYNC_DMR_BS_DATA_POS},
+        {"dmr-bs-voice-neg", DSD_SYNC_DMR_BS_VOICE_NEG},
+        {"dmr-bs-voice-pos", DSD_SYNC_DMR_BS_VOICE_POS},
+        {"dmr-bs-data-neg", DSD_SYNC_DMR_BS_DATA_NEG},
+        {"dmr-ms-voice", DSD_SYNC_DMR_MS_VOICE},
+        {"dmr-ms-data", DSD_SYNC_DMR_MS_DATA},
+        {"dmr-rc-data", DSD_SYNC_DMR_RC_DATA},
+        {"nxdn-pos", DSD_SYNC_NXDN_POS},
+        {"nxdn-neg", DSD_SYNC_NXDN_NEG},
+        {"edacs-pos", DSD_SYNC_EDACS_POS},
+        {"edacs-neg", DSD_SYNC_EDACS_NEG},
+        {"provoice-pos", DSD_SYNC_PROVOICE_POS},
+        {"provoice-neg", DSD_SYNC_PROVOICE_NEG},
+        {"x2tdma-data-pos", DSD_SYNC_X2TDMA_DATA_POS},
+        {"x2tdma-voice-neg", DSD_SYNC_X2TDMA_VOICE_NEG},
+        {"x2tdma-voice-pos", DSD_SYNC_X2TDMA_VOICE_POS},
+        {"x2tdma-data-neg", DSD_SYNC_X2TDMA_DATA_NEG},
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        rc |= run_recent_vc_case(&cases[i]);
+        rc |= run_stale_vc_with_cc_case(&cases[i]);
+        rc |= run_stale_vc_without_cc_case(&cases[i]);
+        rc |= run_stale_vc_with_matching_p25_cc_alias_case(&cases[i]);
+        rc |= run_sync_source_case(&cases[i], 1);
+        rc |= run_sync_source_case(&cases[i], 0);
+    }
+
+    rc |= run_mapped_rest_channel_case(&(generic_return_case){"dmr-rest", DSD_SYNC_DMR_BS_VOICE_POS});
+    rc |= run_generic_overrides_p25_helper_case(&(generic_return_case){"dmr-p25-helper", DSD_SYNC_DMR_BS_VOICE_POS});
+    rc |= run_generic_overrides_p25_helper_case(&(generic_return_case){"nxdn-p25-helper", DSD_SYNC_NXDN_POS});
+    clear_return_to_cc_guard();
+
+    if (rc == 0) {
+        printf("ENGINE_GENERIC_TRUNK_RETURN_MATRIX: OK\n");
+    }
+    return rc;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -40,7 +40,9 @@ static int
 fake_rtl_fsk_output_kind(void) {
     return RTL_STREAM_OUTPUT_SYMBOL_FSK;
 }
+#endif
 
+#if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
 static int g_rtl_tune_calls = 0;
 static uint32_t g_rtl_tune_freq = 0;
 static int g_rtl_output_rate = 48000;
@@ -300,7 +302,7 @@ main(void) {
     rc |= expect_true("p25-stale-vc-clears-tuned", opts->p25_is_tuned == 0);
     rc |= expect_true("p25-stale-vc-clears-freq", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0);
 
-#ifdef USE_RADIO
+#if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {
         return 1;
@@ -315,7 +317,7 @@ main(void) {
     opts->mod_qpsk = 1;
     state->rtl_ctx = (RtlSdrContext*)state;
     state->p25_cc_freq = 769768750;
-    state->trunk_cc_freq = 769768750;
+    state->trunk_cc_freq = 769868750;
     state->p25_cc_is_tdma = 0;
     state->p25_p2_active_slot = 0;
     state->last_cc_sync_time = time(NULL) - 11;
@@ -328,12 +330,43 @@ main(void) {
 
     noCarrier(opts, state);
 
-    rc |= expect_true("p25-rtl-nocarrier-cc-retune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769768750U);
+    rc |= expect_true("p25-rtl-nocarrier-cc-retune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769868750U);
+    rc |= expect_true("p25-rtl-nocarrier-syncs-selected-cc",
+                      state->p25_cc_freq == 769868750 && state->trunk_cc_freq == 769868750);
     rc |= expect_true("p25-rtl-nocarrier-cc-profile-rate", g_rtl_symbol_rate_hz == 4800);
     rc |= expect_true("p25-rtl-nocarrier-cc-profile-cqpsk", g_rtl_cqpsk_enable == 1);
     rc |= expect_true("p25-rtl-nocarrier-cc-profile-ted", g_rtl_ted_sps == 10 && g_rtl_ted_sps_override == 0);
     rc |= expect_true("p25-rtl-nocarrier-clear-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
     rc |= expect_true("p25-rtl-nocarrier-clear-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    reset_rtl_profile_fakes();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 852012500;
+    state->trunk_cc_freq = 851012500;
+    state->dmr_rest_channel = 7;
+    state->trunk_chan_map[7] = 853012500;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("dmr-rtl-nocarrier-rest-cc-retune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 853012500U);
+    rc |= expect_true("dmr-rtl-nocarrier-clears-rest", state->dmr_rest_channel == -1);
+    rc |= expect_true("dmr-rtl-nocarrier-clears-stale-p25-cc",
+                      state->trunk_cc_freq == 853012500 && state->p25_cc_freq == 0);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
 #endif
 
     // Trunk scan keeps long-lived discovery state across carrier gaps. The test

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -471,7 +471,7 @@ main(void) {
     opts->trunk_is_tuned = 1;
     opts->mod_qpsk = 1;
     state->rtl_ctx = (RtlSdrContext*)state;
-    state->p25_cc_freq = 769768750;
+    state->p25_cc_freq = 769868750;
     state->trunk_cc_freq = 769868750;
     state->p25_cc_is_tdma = 0;
     state->p2_cc = 0x293;
@@ -493,7 +493,7 @@ main(void) {
                       state->p25_vc_freq[0] == 771056250 && state->p25_vc_freq[1] == 771056250
                           && state->trunk_vc_freq[0] == 771056250 && state->trunk_vc_freq[1] == 771056250);
     rc |= expect_true("p25-rtl-nocarrier-deferred-restores-cc",
-                      state->p25_cc_freq == 769768750 && state->trunk_cc_freq == 769868750);
+                      state->p25_cc_freq == 769868750 && state->trunk_cc_freq == 769868750);
 
     g_rtl_tune_result = RTL_STREAM_TUNE_OK;
     noCarrier(opts, state);
@@ -505,6 +505,40 @@ main(void) {
     rc |= expect_true("p25-rtl-nocarrier-retry-clears-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0
                                                                && state->trunk_vc_freq[0] == 0
                                                                && state->trunk_vc_freq[1] == 0);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    reset_rtl_profile_fakes();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 769868750;
+    state->trunk_cc_freq = 769868750;
+    state->p25_cc_is_tdma = 0;
+    state->p2_cc = 0x293;
+    state->synctype = DSD_SYNC_NONE;
+    state->lastsynctype = DSD_SYNC_NONE;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->p25_vc_freq[0] = 771056250;
+    state->p25_vc_freq[1] = 771056250;
+    state->trunk_vc_freq[0] = 771056250;
+    state->trunk_vc_freq[1] = 771056250;
+    g_rtl_tune_result = RTL_STREAM_TUNE_FAILED;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("p25-rtl-nocarrier-failed-tune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769868750U);
+    rc |= expect_true("p25-rtl-nocarrier-failed-clears-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
+    rc |= expect_true("p25-rtl-nocarrier-failed-clears-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0
+                                                                && state->trunk_vc_freq[0] == 0
+                                                                && state->trunk_vc_freq[1] == 0);
 
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {
@@ -535,6 +569,71 @@ main(void) {
                       state->p25_cc_freq == 935000000 && state->trunk_cc_freq == 935000000);
     rc |= expect_true("generic-rtl-nocarrier-keeps-profile",
                       g_rtl_symbol_rate_hz == 6000 && g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_WIDE);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    reset_rtl_profile_fakes();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 0;
+    opts->trunk_is_tuned = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 769868750;
+    state->trunk_cc_freq = 936000000;
+    state->p25_cc_is_tdma = 0;
+    state->p2_cc = 0x293;
+    state->synctype = DSD_SYNC_NONE;
+    state->lastsynctype = DSD_SYNC_NONE;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->trunk_vc_freq[0] = 936500000;
+    state->trunk_vc_freq[1] = 936500000;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_WIDE;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("generic-rtl-nocarrier-stale-p25-alias-retune",
+                      g_rtl_tune_calls == 1 && g_rtl_tune_freq == 936000000U);
+    rc |= expect_true("generic-rtl-nocarrier-stale-p25-alias-cleared",
+                      state->p25_cc_freq == 0 && state->trunk_cc_freq == 936000000);
+    rc |= expect_true("generic-rtl-nocarrier-stale-p25-keeps-profile",
+                      g_rtl_symbol_rate_hz == 6000 && g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_WIDE);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    reset_rtl_profile_fakes();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    opts->mod_qpsk = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 770168750;
+    state->trunk_cc_freq = 770168750;
+    state->p25_cc_is_tdma = 0;
+    state->p2_cc = 0x293;
+    state->dmr_rest_channel = 7;
+    state->trunk_chan_map[7] = 0;
+    state->synctype = DSD_SYNC_NONE;
+    state->lastsynctype = DSD_SYNC_NONE;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->p25_vc_freq[0] = 771056250;
+    state->p25_vc_freq[1] = 771056250;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("p25-rtl-nocarrier-unmapped-rest-retune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 770168750U);
+    rc |= expect_true("p25-rtl-nocarrier-unmapped-rest-profile", g_rtl_symbol_rate_hz == 4800);
+    rc |= expect_true("p25-rtl-nocarrier-unmapped-rest-clears", state->dmr_rest_channel == -1);
 
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -45,6 +45,7 @@ fake_rtl_fsk_output_kind(void) {
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
 static int g_rtl_tune_calls = 0;
 static uint32_t g_rtl_tune_freq = 0;
+static int g_rtl_tune_result = RTL_STREAM_TUNE_OK;
 static int g_rtl_output_rate = 48000;
 static int g_rtl_cqpsk_enable = 0;
 static int g_rtl_symbol_rate_hz = 6000;
@@ -65,6 +66,7 @@ static void
 reset_rtl_profile_fakes(void) {
     g_rtl_tune_calls = 0;
     g_rtl_tune_freq = 0;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
     g_rtl_output_rate = 48000;
     g_rtl_cqpsk_enable = 1;
     g_rtl_symbol_rate_hz = 6000;
@@ -171,8 +173,10 @@ __wrap_rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz) {
     (void)ctx;
     g_rtl_tune_calls++;
     g_rtl_tune_freq = center_freq_hz;
-    apply_pending_profile(center_freq_hz);
-    return RTL_STREAM_TUNE_OK;
+    if (g_rtl_tune_result == RTL_STREAM_TUNE_OK) {
+        apply_pending_profile(center_freq_hz);
+    }
+    return g_rtl_tune_result;
 }
 
 // NOLINTEND(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
@@ -320,6 +324,7 @@ main(void) {
     state->trunk_cc_freq = 769868750;
     state->p25_cc_is_tdma = 0;
     state->p25_p2_active_slot = 0;
+    state->lastsynctype = DSD_SYNC_P25P1_POS;
     state->last_cc_sync_time = time(NULL) - 11;
     state->last_vc_sync_time = time(NULL) - 11;
     state->p25_vc_freq[0] = 771056250;
@@ -346,15 +351,88 @@ main(void) {
 
     reset_rtl_profile_fakes();
     opts->audio_in_type = AUDIO_IN_RTL;
+    opts->scanner_mode = 1;
+    opts->p25_trunk = 1;
     opts->trunk_enable = 1;
+    opts->p25_is_tuned = 1;
     opts->trunk_is_tuned = 1;
+    opts->mod_qpsk = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->trunk_lcn_freq[0] = 771156250;
+    state->lcn_freq_count = 1;
+    state->p25_cc_freq = 769868750;
+    state->trunk_cc_freq = 769868750;
+    state->lastsynctype = DSD_SYNC_P25P1_POS;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("p25-rtl-nocarrier-cache-prime", g_rtl_tune_calls == 2 && g_rtl_tune_freq == 769868750U);
+
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->lcn_freq_roll = 0;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("p25-rtl-nocarrier-cache-allows-scan-retune",
+                      g_rtl_tune_calls == 3 && g_rtl_tune_freq == 771156250U);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    reset_rtl_profile_fakes();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    opts->mod_qpsk = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 769868750;
+    state->trunk_cc_freq = 769868750;
+    state->lastsynctype = DSD_SYNC_P25P1_POS;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->p25_vc_freq[0] = 771056250;
+    state->p25_vc_freq[1] = 771056250;
+    state->trunk_vc_freq[0] = 771056250;
+    state->trunk_vc_freq[1] = 771056250;
+    g_rtl_tune_result = RTL_STREAM_TUNE_DEFERRED;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("p25-rtl-nocarrier-deferred-tune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769868750U);
+    rc |= expect_true("p25-rtl-nocarrier-deferred-clears-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
+    rc |= expect_true("p25-rtl-nocarrier-deferred-clears-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0
+                                                                  && state->trunk_vc_freq[0] == 0
+                                                                  && state->trunk_vc_freq[1] == 0);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    reset_rtl_profile_fakes();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    opts->frame_p25p1 = 0;
+    opts->frame_p25p2 = 0;
+    opts->frame_dmr = 1;
     state->rtl_ctx = (RtlSdrContext*)state;
     state->p25_cc_freq = 852012500;
     state->trunk_cc_freq = 851012500;
     state->dmr_rest_channel = 7;
     state->trunk_chan_map[7] = 853012500;
+    state->lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
     state->last_cc_sync_time = time(NULL) - 11;
     state->last_vc_sync_time = time(NULL) - 11;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_WIDE;
 
     noCarrier(opts, state);
 
@@ -362,6 +440,8 @@ main(void) {
     rc |= expect_true("dmr-rtl-nocarrier-clears-rest", state->dmr_rest_channel == -1);
     rc |= expect_true("dmr-rtl-nocarrier-clears-stale-p25-cc",
                       state->trunk_cc_freq == 853012500 && state->p25_cc_freq == 0);
+    rc |= expect_true("dmr-rtl-nocarrier-keeps-generic-profile",
+                      g_rtl_symbol_rate_hz == 6000 && g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_WIDE);
 
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -355,6 +355,29 @@ main(void) {
         return 1;
     }
 
+    opts->trunk_enable = 1;
+    opts->p25_trunk = 0;
+    opts->p25_is_tuned = 0;
+    opts->trunk_is_tuned = 1;
+    state->p25_cc_freq = 0;
+    state->trunk_cc_freq = 936000000;
+    state->lastsynctype = DSD_SYNC_NXDN_POS;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->trunk_vc_freq[0] = 936500000;
+    state->trunk_vc_freq[1] = 936500000;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("generic-trunk-cc-only-keeps-p25-empty",
+                      state->p25_cc_freq == 0 && state->trunk_cc_freq == 936000000);
+    rc |= expect_true("generic-trunk-cc-only-clears-vc", state->trunk_vc_freq[0] == 0 && state->trunk_vc_freq[1] == 0);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {
@@ -368,6 +391,8 @@ main(void) {
     opts->p25_is_tuned = 1;
     opts->trunk_is_tuned = 1;
     opts->mod_qpsk = 1;
+    opts->slot1_on = 0;
+    opts->slot2_on = 0;
     state->rtl_ctx = (RtlSdrContext*)state;
     state->p25_cc_freq = 769768750;
     state->trunk_cc_freq = 769868750;
@@ -390,6 +415,7 @@ main(void) {
     rc |= expect_true("p25-rtl-nocarrier-cc-profile-rate", g_rtl_symbol_rate_hz == 4800);
     rc |= expect_true("p25-rtl-nocarrier-cc-profile-cqpsk", g_rtl_cqpsk_enable == 1);
     rc |= expect_true("p25-rtl-nocarrier-cc-profile-ted", g_rtl_ted_sps == 10 && g_rtl_ted_sps_override == 0);
+    rc |= expect_true("p25-rtl-nocarrier-reenables-slots", opts->slot1_on == 1 && opts->slot2_on == 1);
     rc |= expect_true("p25-rtl-nocarrier-clear-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
     rc |= expect_true("p25-rtl-nocarrier-clear-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0);
 

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -306,6 +306,32 @@ main(void) {
     rc |= expect_true("p25-stale-vc-clears-tuned", opts->p25_is_tuned == 0);
     rc |= expect_true("p25-stale-vc-clears-freq", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0);
 
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    opts->trunk_enable = 1;
+    opts->p25_trunk = 0;
+    opts->p25_is_tuned = 0;
+    opts->trunk_is_tuned = 1;
+    state->trunk_cc_freq = 851012500;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL);
+    state->trunk_vc_freq[0] = 852012500;
+    state->trunk_vc_freq[1] = 852012500;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("generic-vc-sync-preserves-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 1);
+    rc |= expect_true("generic-vc-sync-preserves-freq",
+                      state->trunk_vc_freq[0] == 852012500 && state->trunk_vc_freq[1] == 852012500);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {
@@ -393,6 +419,39 @@ main(void) {
     state->rtl_ctx = (RtlSdrContext*)state;
     state->p25_cc_freq = 769868750;
     state->trunk_cc_freq = 769868750;
+    state->p25_cc_is_tdma = 0;
+    state->p2_cc = 0x293;
+    state->synctype = DSD_SYNC_NONE;
+    state->lastsynctype = DSD_SYNC_NONE;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->p25_vc_freq[0] = 771056250;
+    state->p25_vc_freq[1] = 771056250;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("p25-rtl-nocarrier-auto-delayed-retune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769868750U);
+    rc |= expect_true("p25-rtl-nocarrier-auto-delayed-keeps-p25-cc",
+                      state->p25_cc_freq == 769868750 && state->trunk_cc_freq == 769868750);
+    rc |= expect_true("p25-rtl-nocarrier-auto-delayed-profile", g_rtl_symbol_rate_hz == 4800);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    reset_rtl_profile_fakes();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    opts->mod_qpsk = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 769868750;
+    state->trunk_cc_freq = 769868750;
+    state->p25_cc_is_tdma = 0;
+    state->p2_cc = 0x293;
     state->lastsynctype = DSD_SYNC_P25P1_POS;
     state->last_cc_sync_time = time(NULL) - 11;
     state->last_vc_sync_time = time(NULL) - 11;
@@ -405,10 +464,20 @@ main(void) {
     noCarrier(opts, state);
 
     rc |= expect_true("p25-rtl-nocarrier-deferred-tune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769868750U);
-    rc |= expect_true("p25-rtl-nocarrier-deferred-clears-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
-    rc |= expect_true("p25-rtl-nocarrier-deferred-clears-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0
-                                                                  && state->trunk_vc_freq[0] == 0
-                                                                  && state->trunk_vc_freq[1] == 0);
+    rc |=
+        expect_true("p25-rtl-nocarrier-deferred-preserves-tuned", opts->p25_is_tuned == 1 && opts->trunk_is_tuned == 1);
+    rc |= expect_true("p25-rtl-nocarrier-deferred-preserves-vc",
+                      state->p25_vc_freq[0] == 771056250 && state->p25_vc_freq[1] == 771056250
+                          && state->trunk_vc_freq[0] == 771056250 && state->trunk_vc_freq[1] == 771056250);
+
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    noCarrier(opts, state);
+
+    rc |= expect_true("p25-rtl-nocarrier-deferred-retries", g_rtl_tune_calls == 2 && g_rtl_tune_freq == 769868750U);
+    rc |= expect_true("p25-rtl-nocarrier-retry-clears-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
+    rc |= expect_true("p25-rtl-nocarrier-retry-clears-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0
+                                                               && state->trunk_vc_freq[0] == 0
+                                                               && state->trunk_vc_freq[1] == 0);
 
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -323,6 +323,30 @@ main(void) {
         return 1;
     }
 
+    opts->p25_trunk = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    state->last_cc_sync_time = time(NULL);
+    state->last_vc_sync_time = time(NULL) - 3;
+    state->p25_vc_freq[0] = 851012500;
+    state->p25_vc_freq[1] = 851012500;
+    state->trunk_vc_freq[0] = 851012500;
+    state->trunk_vc_freq[1] = 851012500;
+    DSD_SNPRINTF(state->active_channel[0], sizeof(state->active_channel[0]), "Active Ch: stale");
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("p25-no-cc-hangtime-clears-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
+    rc |= expect_true("p25-no-cc-hangtime-clears-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0
+                                                          && state->trunk_vc_freq[0] == 0
+                                                          && state->trunk_vc_freq[1] == 0);
+    rc |= expect_true("p25-no-cc-hangtime-clears-active", state->active_channel[0][0] == '\0');
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
     opts->trunk_enable = 1;
     opts->p25_trunk = 0;
     opts->p25_is_tuned = 0;
@@ -498,6 +522,38 @@ main(void) {
     rc |= expect_true("p25-rtl-nocarrier-auto-delayed-keeps-p25-cc",
                       state->p25_cc_freq == 769868750 && state->trunk_cc_freq == 769868750);
     rc |= expect_true("p25-rtl-nocarrier-auto-delayed-profile", g_rtl_symbol_rate_hz == 4800);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    reset_rtl_profile_fakes();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    opts->mod_qpsk = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 769768750;
+    state->trunk_cc_freq = 769868750;
+    state->p25_cc_is_tdma = 0;
+    state->p2_cc = 0x293;
+    state->synctype = DSD_SYNC_NONE;
+    state->lastsynctype = DSD_SYNC_NONE;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->p25_vc_freq[0] = 771056250;
+    state->p25_vc_freq[1] = 771056250;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("p25-rtl-nocarrier-delayed-selected-cc-retune",
+                      g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769868750U);
+    rc |= expect_true("p25-rtl-nocarrier-delayed-selected-cc-profile", g_rtl_symbol_rate_hz == 4800);
+    rc |= expect_true("p25-rtl-nocarrier-delayed-selected-cc-sync",
+                      state->p25_cc_freq == 769868750 && state->trunk_cc_freq == 769868750);
 
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -332,6 +332,7 @@ main(void) {
     state->p25_vc_freq[1] = 851012500;
     state->trunk_vc_freq[0] = 851012500;
     state->trunk_vc_freq[1] = 851012500;
+    state->p25_p2_active_slot = 0;
     DSD_SNPRINTF(state->active_channel[0], sizeof(state->active_channel[0]), "Active Ch: stale");
 
     noCarrier(opts, state);
@@ -340,6 +341,7 @@ main(void) {
     rc |= expect_true("p25-no-cc-hangtime-clears-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0
                                                           && state->trunk_vc_freq[0] == 0
                                                           && state->trunk_vc_freq[1] == 0);
+    rc |= expect_true("p25-no-cc-hangtime-clears-active-slot", state->p25_p2_active_slot == -1);
     rc |= expect_true("p25-no-cc-hangtime-clears-active", state->active_channel[0][0] == '\0');
 
     free_test_runtime(opts, state);
@@ -535,6 +537,8 @@ main(void) {
     opts->p25_is_tuned = 1;
     opts->trunk_is_tuned = 1;
     opts->mod_qpsk = 1;
+    opts->frame_x2tdma = 0;
+    opts->frame_dmr = 0;
     state->rtl_ctx = (RtlSdrContext*)state;
     state->p25_cc_freq = 769868750;
     state->trunk_cc_freq = 769868750;
@@ -662,6 +666,7 @@ main(void) {
     state->p25_vc_freq[1] = 771056250;
     state->trunk_vc_freq[0] = 771056250;
     state->trunk_vc_freq[1] = 771056250;
+    state->p25_p2_active_slot = 1;
     g_rtl_tune_result = RTL_STREAM_TUNE_FAILED;
 
     noCarrier(opts, state);
@@ -671,6 +676,7 @@ main(void) {
     rc |= expect_true("p25-rtl-nocarrier-failed-clears-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0
                                                                 && state->trunk_vc_freq[0] == 0
                                                                 && state->trunk_vc_freq[1] == 0);
+    rc |= expect_true("p25-rtl-nocarrier-failed-clears-active-slot", state->p25_p2_active_slot == -1);
 
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {
@@ -734,6 +740,46 @@ main(void) {
                       state->p25_cc_freq == 0 && state->trunk_cc_freq == 936000000);
     rc |= expect_true("generic-rtl-nocarrier-stale-p25-keeps-profile",
                       g_rtl_symbol_rate_hz == 6000 && g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_WIDE);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    reset_rtl_profile_fakes();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 938000000;
+    state->trunk_cc_freq = 938000000;
+    state->p25_cc_is_tdma = 0;
+    state->lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL);
+    state->p25_vc_freq[0] = 938500000;
+    state->p25_vc_freq[1] = 938500000;
+    state->trunk_vc_freq[0] = 938500000;
+    state->trunk_vc_freq[1] = 938500000;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_WIDE;
+
+    noCarrier(opts, state);
+
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+
+    noCarrier(opts, state);
+
+    rc |=
+        expect_true("generic-rtl-repeated-nocarrier-cc-retune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 938000000U);
+    rc |= expect_true("generic-rtl-repeated-nocarrier-preserves-cc-alias",
+                      state->p25_cc_freq == 938000000 && state->trunk_cc_freq == 938000000);
+    rc |= expect_true("generic-rtl-repeated-nocarrier-keeps-profile",
+                      g_rtl_symbol_rate_hz == 6000 && g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_WIDE);
+    rc |= expect_true("generic-rtl-repeated-nocarrier-clears-tuned",
+                      opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
 
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -144,6 +144,18 @@ __wrap_rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int
     g_pending_ted_override = persist_ted_override ? 1 : 0;
 }
 
+void
+__wrap_rtl_stream_clear_pending_retune_profile(void) {
+    g_pending_active = 0;
+    g_pending_target_freq_hz = 0;
+    g_pending_cqpsk = -1;
+    g_pending_symbol_rate_hz = 0;
+    g_pending_symbol_levels = 0;
+    g_pending_channel_profile = 0;
+    g_pending_ted_sps = 0;
+    g_pending_ted_override = 0;
+}
+
 static void
 apply_pending_profile(uint32_t target_freq_hz) {
     if (!g_pending_active) {
@@ -385,6 +397,7 @@ main(void) {
     }
 
     reset_rtl_profile_fakes();
+    g_rtl_output_rate = 96000;
     opts->audio_in_type = AUDIO_IN_RTL;
     opts->p25_trunk = 1;
     opts->trunk_enable = 1;
@@ -414,7 +427,9 @@ main(void) {
                       state->p25_cc_freq == 769868750 && state->trunk_cc_freq == 769868750);
     rc |= expect_true("p25-rtl-nocarrier-cc-profile-rate", g_rtl_symbol_rate_hz == 4800);
     rc |= expect_true("p25-rtl-nocarrier-cc-profile-cqpsk", g_rtl_cqpsk_enable == 1);
-    rc |= expect_true("p25-rtl-nocarrier-cc-profile-ted", g_rtl_ted_sps == 10 && g_rtl_ted_sps_override == 0);
+    rc |= expect_true("p25-rtl-nocarrier-cc-profile-ted", g_rtl_ted_sps == 20 && g_rtl_ted_sps_override == 0);
+    rc |= expect_true("p25-rtl-nocarrier-dynamic-symbol-timing",
+                      state->samplesPerSymbol == 20 && state->symbolCenter == 9);
     rc |= expect_true("p25-rtl-nocarrier-reenables-slots", opts->slot1_on == 1 && opts->slot2_on == 1);
     rc |= expect_true("p25-rtl-nocarrier-clear-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
     rc |= expect_true("p25-rtl-nocarrier-clear-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0);
@@ -497,7 +512,7 @@ main(void) {
     opts->trunk_is_tuned = 1;
     opts->mod_qpsk = 1;
     state->rtl_ctx = (RtlSdrContext*)state;
-    state->p25_cc_freq = 769868750;
+    state->p25_cc_freq = 769768750;
     state->trunk_cc_freq = 769868750;
     state->p25_cc_is_tdma = 0;
     state->p2_cc = 0x293;
@@ -518,13 +533,15 @@ main(void) {
     rc |= expect_true("p25-rtl-nocarrier-deferred-preserves-vc",
                       state->p25_vc_freq[0] == 771056250 && state->p25_vc_freq[1] == 771056250
                           && state->trunk_vc_freq[0] == 771056250 && state->trunk_vc_freq[1] == 771056250);
-    rc |= expect_true("p25-rtl-nocarrier-deferred-restores-cc",
+    rc |= expect_true("p25-rtl-nocarrier-deferred-preserves-selected-cc",
                       state->p25_cc_freq == 769868750 && state->trunk_cc_freq == 769868750);
 
     g_rtl_tune_result = RTL_STREAM_TUNE_OK;
     noCarrier(opts, state);
 
     rc |= expect_true("p25-rtl-nocarrier-deferred-retries", g_rtl_tune_calls == 2 && g_rtl_tune_freq == 769868750U);
+    rc |= expect_true("p25-rtl-nocarrier-deferred-retry-profile",
+                      g_rtl_symbol_rate_hz == 4800 && g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
     rc |= expect_true("p25-rtl-nocarrier-retry-syncs-cc",
                       state->p25_cc_freq == 769868750 && state->trunk_cc_freq == 769868750);
     rc |= expect_true("p25-rtl-nocarrier-retry-clears-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -536,6 +536,39 @@ main(void) {
     opts->trunk_is_tuned = 1;
     opts->mod_qpsk = 1;
     state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 769868750;
+    state->trunk_cc_freq = 769868750;
+    state->p25_cc_is_tdma = 2;
+    state->synctype = DSD_SYNC_NONE;
+    state->lastsynctype = DSD_SYNC_NONE;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->p25_vc_freq[0] = 771056250;
+    state->p25_vc_freq[1] = 771056250;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("p25-rtl-nocarrier-no-identity-retune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769868750U);
+    rc |= expect_true("p25-rtl-nocarrier-no-identity-profile",
+                      g_rtl_symbol_rate_hz == 4800 && g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    rc |= expect_true("p25-rtl-nocarrier-no-identity-sync",
+                      state->p25_cc_freq == 769868750 && state->trunk_cc_freq == 769868750);
+    rc |=
+        expect_true("p25-rtl-nocarrier-no-identity-clears-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    reset_rtl_profile_fakes();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    opts->mod_qpsk = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
     state->p25_cc_freq = 769768750;
     state->trunk_cc_freq = 769868750;
     state->p25_cc_is_tdma = 0;

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -12,12 +12,14 @@
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/io/rtl_stream_fwd.h"
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -38,6 +40,140 @@ static int
 fake_rtl_fsk_output_kind(void) {
     return RTL_STREAM_OUTPUT_SYMBOL_FSK;
 }
+
+static int g_rtl_tune_calls = 0;
+static uint32_t g_rtl_tune_freq = 0;
+static int g_rtl_output_rate = 48000;
+static int g_rtl_cqpsk_enable = 0;
+static int g_rtl_symbol_rate_hz = 6000;
+static int g_rtl_symbol_levels = 4;
+static int g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
+static int g_rtl_ted_sps = 8;
+static int g_rtl_ted_sps_override = 8;
+static int g_pending_active = 0;
+static uint32_t g_pending_target_freq_hz = 0;
+static int g_pending_cqpsk = -1;
+static int g_pending_symbol_rate_hz = 0;
+static int g_pending_symbol_levels = 0;
+static int g_pending_channel_profile = 0;
+static int g_pending_ted_sps = 0;
+static int g_pending_ted_override = 0;
+
+static void
+reset_rtl_profile_fakes(void) {
+    g_rtl_tune_calls = 0;
+    g_rtl_tune_freq = 0;
+    g_rtl_output_rate = 48000;
+    g_rtl_cqpsk_enable = 1;
+    g_rtl_symbol_rate_hz = 6000;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
+    g_rtl_ted_sps = 8;
+    g_rtl_ted_sps_override = 8;
+    g_pending_active = 0;
+    g_pending_target_freq_hz = 0;
+    g_pending_cqpsk = -1;
+    g_pending_symbol_rate_hz = 0;
+    g_pending_symbol_levels = 0;
+    g_pending_channel_profile = 0;
+    g_pending_ted_sps = 0;
+    g_pending_ted_override = 0;
+}
+
+// GNU ld --wrap entry points must keep the reserved __wrap_* symbol names.
+// NOLINTBEGIN(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+uint32_t
+__wrap_rtl_stream_output_rate(const RtlSdrContext* ctx) {
+    (void)ctx;
+    return (uint32_t)g_rtl_output_rate;
+}
+
+int
+__wrap_rtl_stream_dsp_get(int* cqpsk_enable, int* fll_enable, int* ted_enable) {
+    if (cqpsk_enable) {
+        *cqpsk_enable = g_rtl_cqpsk_enable;
+    }
+    if (fll_enable) {
+        *fll_enable = 0;
+    }
+    if (ted_enable) {
+        *ted_enable = 1;
+    }
+    return 0;
+}
+
+int
+__wrap_rtl_stream_get_symbol_profile_full(int* out_symbol_rate_hz, int* out_levels, int* out_channel_profile) {
+    if (out_symbol_rate_hz) {
+        *out_symbol_rate_hz = g_rtl_symbol_rate_hz;
+    }
+    if (out_levels) {
+        *out_levels = g_rtl_symbol_levels;
+    }
+    if (out_channel_profile) {
+        *out_channel_profile = g_rtl_channel_profile;
+    }
+    return 0;
+}
+
+int
+__wrap_rtl_stream_get_ted_sps(void) {
+    return g_rtl_ted_sps;
+}
+
+int
+__wrap_rtl_stream_get_ted_sps_override(void) {
+    return g_rtl_ted_sps_override;
+}
+
+void
+__wrap_rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz,
+                                                    int levels, int channel_profile, int ted_sps,
+                                                    int persist_ted_override) {
+    g_pending_active = 1;
+    g_pending_target_freq_hz = target_freq_hz;
+    g_pending_cqpsk = cqpsk_enable;
+    g_pending_symbol_rate_hz = symbol_rate_hz;
+    g_pending_symbol_levels = levels;
+    g_pending_channel_profile = channel_profile;
+    g_pending_ted_sps = ted_sps;
+    g_pending_ted_override = persist_ted_override ? 1 : 0;
+}
+
+static void
+apply_pending_profile(uint32_t target_freq_hz) {
+    if (!g_pending_active) {
+        return;
+    }
+    if (g_pending_target_freq_hz != 0 && g_pending_target_freq_hz != target_freq_hz) {
+        return;
+    }
+    if (g_pending_cqpsk >= 0) {
+        g_rtl_cqpsk_enable = g_pending_cqpsk ? 1 : 0;
+    }
+    if (g_pending_symbol_rate_hz > 0) {
+        g_rtl_symbol_rate_hz = g_pending_symbol_rate_hz;
+        g_rtl_symbol_levels = g_pending_symbol_levels;
+        g_rtl_channel_profile = g_pending_channel_profile;
+    }
+    if (g_pending_ted_sps > 0) {
+        g_rtl_ted_sps = g_pending_ted_sps;
+        g_rtl_ted_sps_override = g_pending_ted_override ? g_pending_ted_sps : 0;
+    }
+    g_pending_active = 0;
+    g_pending_target_freq_hz = 0;
+}
+
+int
+__wrap_rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz) {
+    (void)ctx;
+    g_rtl_tune_calls++;
+    g_rtl_tune_freq = center_freq_hz;
+    apply_pending_profile(center_freq_hz);
+    return RTL_STREAM_TUNE_OK;
+}
+
+// NOLINTEND(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
 #endif
 
 int
@@ -163,6 +299,42 @@ main(void) {
 
     rc |= expect_true("p25-stale-vc-clears-tuned", opts->p25_is_tuned == 0);
     rc |= expect_true("p25-stale-vc-clears-freq", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0);
+
+#ifdef USE_RADIO
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    reset_rtl_profile_fakes();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    opts->mod_qpsk = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 769768750;
+    state->trunk_cc_freq = 769768750;
+    state->p25_cc_is_tdma = 0;
+    state->p25_p2_active_slot = 0;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->p25_vc_freq[0] = 771056250;
+    state->p25_vc_freq[1] = 771056250;
+    state->samplesPerSymbol = 8;
+    state->symbolCenter = 3;
+    state->rf_mod = 1;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("p25-rtl-nocarrier-cc-retune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769768750U);
+    rc |= expect_true("p25-rtl-nocarrier-cc-profile-rate", g_rtl_symbol_rate_hz == 4800);
+    rc |= expect_true("p25-rtl-nocarrier-cc-profile-cqpsk", g_rtl_cqpsk_enable == 1);
+    rc |= expect_true("p25-rtl-nocarrier-cc-profile-ted", g_rtl_ted_sps == 10 && g_rtl_ted_sps_override == 0);
+    rc |= expect_true("p25-rtl-nocarrier-clear-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
+    rc |= expect_true("p25-rtl-nocarrier-clear-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0);
+#endif
 
     // Trunk scan keeps long-lived discovery state across carrier gaps. The test
     // keeps DMR confidence and P25 control-channel candidates populated while

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -332,6 +332,29 @@ main(void) {
         return 1;
     }
 
+    opts->trunk_enable = 1;
+    opts->p25_trunk = 0;
+    opts->p25_is_tuned = 0;
+    opts->trunk_is_tuned = 1;
+    state->dmr_rest_channel = 4;
+    state->trunk_chan_map[4] = 851012500;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->trunk_vc_freq[0] = 852012500;
+    state->trunk_vc_freq[1] = 852012500;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("dmr-rest-only-stale-clears-rest", state->dmr_rest_channel == -1);
+    rc |= expect_true("dmr-rest-only-stale-clears-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
+    rc |= expect_true("dmr-rest-only-stale-clears-vc", state->trunk_vc_freq[0] == 0 && state->trunk_vc_freq[1] == 0);
+    rc |= expect_true("dmr-rest-only-stale-keeps-cc-empty", state->p25_cc_freq == 0 && state->trunk_cc_freq == 0);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -537,8 +537,6 @@ main(void) {
     opts->p25_is_tuned = 1;
     opts->trunk_is_tuned = 1;
     opts->mod_qpsk = 1;
-    opts->frame_x2tdma = 0;
-    opts->frame_dmr = 0;
     state->rtl_ctx = (RtlSdrContext*)state;
     state->p25_cc_freq = 769868750;
     state->trunk_cc_freq = 769868750;
@@ -552,13 +550,14 @@ main(void) {
 
     noCarrier(opts, state);
 
-    rc |= expect_true("p25-rtl-nocarrier-no-identity-retune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769868750U);
-    rc |= expect_true("p25-rtl-nocarrier-no-identity-profile",
+    rc |= expect_true("p25-rtl-nocarrier-mixed-no-identity-retune",
+                      g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769868750U);
+    rc |= expect_true("p25-rtl-nocarrier-mixed-no-identity-profile",
                       g_rtl_symbol_rate_hz == 4800 && g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
-    rc |= expect_true("p25-rtl-nocarrier-no-identity-sync",
+    rc |= expect_true("p25-rtl-nocarrier-mixed-no-identity-sync",
                       state->p25_cc_freq == 769868750 && state->trunk_cc_freq == 769868750);
-    rc |=
-        expect_true("p25-rtl-nocarrier-no-identity-clears-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
+    rc |= expect_true("p25-rtl-nocarrier-mixed-no-identity-clears-tuned",
+                      opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
 
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {
@@ -756,6 +755,8 @@ main(void) {
     state->p25_cc_freq = 938000000;
     state->trunk_cc_freq = 938000000;
     state->p25_cc_is_tdma = 0;
+    state->p2_cc = 0x293;
+    state->p25_sys_is_tdma = 1;
     state->lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
     state->last_cc_sync_time = time(NULL) - 11;
     state->last_vc_sync_time = time(NULL);

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -448,7 +448,7 @@ main(void) {
     opts->trunk_is_tuned = 1;
     opts->mod_qpsk = 1;
     state->rtl_ctx = (RtlSdrContext*)state;
-    state->p25_cc_freq = 769868750;
+    state->p25_cc_freq = 769768750;
     state->trunk_cc_freq = 769868750;
     state->p25_cc_is_tdma = 0;
     state->p2_cc = 0x293;
@@ -469,15 +469,49 @@ main(void) {
     rc |= expect_true("p25-rtl-nocarrier-deferred-preserves-vc",
                       state->p25_vc_freq[0] == 771056250 && state->p25_vc_freq[1] == 771056250
                           && state->trunk_vc_freq[0] == 771056250 && state->trunk_vc_freq[1] == 771056250);
+    rc |= expect_true("p25-rtl-nocarrier-deferred-restores-cc",
+                      state->p25_cc_freq == 769768750 && state->trunk_cc_freq == 769868750);
 
     g_rtl_tune_result = RTL_STREAM_TUNE_OK;
     noCarrier(opts, state);
 
     rc |= expect_true("p25-rtl-nocarrier-deferred-retries", g_rtl_tune_calls == 2 && g_rtl_tune_freq == 769868750U);
+    rc |= expect_true("p25-rtl-nocarrier-retry-syncs-cc",
+                      state->p25_cc_freq == 769868750 && state->trunk_cc_freq == 769868750);
     rc |= expect_true("p25-rtl-nocarrier-retry-clears-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
     rc |= expect_true("p25-rtl-nocarrier-retry-clears-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0
                                                                && state->trunk_vc_freq[0] == 0
                                                                && state->trunk_vc_freq[1] == 0);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    reset_rtl_profile_fakes();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 0;
+    opts->trunk_is_tuned = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 935000000;
+    state->trunk_cc_freq = 935000000;
+    state->p25_cc_is_tdma = 2;
+    state->p25_p2_active_slot = 0;
+    state->synctype = DSD_SYNC_NONE;
+    state->lastsynctype = DSD_SYNC_NONE;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_WIDE;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("generic-rtl-nocarrier-slot-zero-retune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 935000000U);
+    rc |= expect_true("generic-rtl-nocarrier-preserves-cc-alias",
+                      state->p25_cc_freq == 935000000 && state->trunk_cc_freq == 935000000);
+    rc |= expect_true("generic-rtl-nocarrier-keeps-profile",
+                      g_rtl_symbol_rate_hz == 6000 && g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_WIDE);
 
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {

--- a/tests/protocol/dmr/test_dmr_t3_sm_return_to_cc_matrix.c
+++ b/tests/protocol/dmr/test_dmr_t3_sm_return_to_cc_matrix.c
@@ -1,0 +1,627 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Bounded DMR Tier III return-to-control-channel matrix.
+ *
+ * The harness drives the DMR trunking state machine directly and injects
+ * result-returning trunk tune hooks. It covers accepted asynchronous retunes,
+ * rejected voice-channel tunes, and retryable CC returns without depending on
+ * radio or rigctl backends.
+ */
+
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+typedef struct {
+    const char* name;
+    long freq_hz;
+    int lpcn;
+    int trust;
+    long mapped_freq_hz;
+} dmr_grant_case;
+
+typedef enum {
+    DMR_FLOW_GRANT_TIMEOUT = 0,
+    DMR_FLOW_VOICE_HANGTIME,
+    DMR_FLOW_DATA_HANGTIME,
+    DMR_FLOW_EXPLICIT_RELEASE,
+    DMR_FLOW_DUAL_SLOT_PARTIAL_RELEASE,
+    DMR_FLOW_FORCED_RELEASE,
+} dmr_flow_kind;
+
+typedef struct {
+    const char* name;
+    dmr_flow_kind kind;
+} dmr_flow_case;
+
+typedef struct {
+    const char* name;
+    dsd_trunk_tune_result results[2];
+    int count;
+} dmr_return_script;
+
+typedef struct {
+    dsd_trunk_tune_result tune_results[4];
+    int tune_count;
+    int tune_pos;
+    dsd_trunk_tune_result return_results[4];
+    int return_count;
+    int return_pos;
+    int tune_calls;
+    int return_calls;
+    long last_tune_freq;
+} dmr_hook_state;
+
+static dmr_hook_state g_hooks;
+static dsd_opts g_opts;
+static dsd_state g_state;
+static dmr_sm_ctx_t g_ctx;
+
+static const dmr_grant_case g_grants[] = {
+    {"explicit-frequency", 852012500L, 0, 0, 0},
+    {"trusted-lpcn", 0, 33, 2, 852512500L},
+    {"untrusted-lpcn-on-cc", 0, 34, 0, 853012500L},
+};
+
+static const dmr_flow_case g_flows[] = {
+    {"grant-timeout", DMR_FLOW_GRANT_TIMEOUT},
+    {"voice-hangtime", DMR_FLOW_VOICE_HANGTIME},
+    {"data-hangtime", DMR_FLOW_DATA_HANGTIME},
+    {"explicit-release", DMR_FLOW_EXPLICIT_RELEASE},
+    {"dual-slot-partial-release", DMR_FLOW_DUAL_SLOT_PARTIAL_RELEASE},
+    {"forced-release", DMR_FLOW_FORCED_RELEASE},
+};
+
+static const dmr_return_script g_return_scripts[] = {
+    {"ok", {DSD_TRUNK_TUNE_RESULT_OK, DSD_TRUNK_TUNE_RESULT_OK}, 1},
+    {"pending", {DSD_TRUNK_TUNE_RESULT_PENDING, DSD_TRUNK_TUNE_RESULT_OK}, 1},
+    {"deferred-then-ok", {DSD_TRUNK_TUNE_RESULT_DEFERRED, DSD_TRUNK_TUNE_RESULT_OK}, 2},
+    {"failed-then-ok", {DSD_TRUNK_TUNE_RESULT_FAILED, DSD_TRUNK_TUNE_RESULT_OK}, 2},
+    {"timeout-then-ok", {DSD_TRUNK_TUNE_RESULT_TIMEOUT, DSD_TRUNK_TUNE_RESULT_OK}, 2},
+};
+
+void
+dmr_reset_blocks(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+static long
+dmr_case_expected_freq(const dmr_grant_case* grant) {
+    return (grant->freq_hz > 0) ? grant->freq_hz : grant->mapped_freq_hz;
+}
+
+static dsd_trunk_tune_result
+dmr_pop_result(const dsd_trunk_tune_result* results, int count, int* pos) {
+    if (!results || !pos || count <= 0) {
+        return DSD_TRUNK_TUNE_RESULT_OK;
+    }
+    int idx = (*pos < count) ? *pos : (count - 1);
+    (*pos)++;
+    return results[idx];
+}
+
+static dsd_trunk_tune_result
+dmr_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    (void)ted_sps;
+    dsd_trunk_tune_result result = dmr_pop_result(g_hooks.tune_results, g_hooks.tune_count, &g_hooks.tune_pos);
+    g_hooks.tune_calls++;
+    g_hooks.last_tune_freq = freq;
+
+    if (dsd_trunk_tune_result_is_ok(result)) {
+        if (opts) {
+            opts->trunk_is_tuned = 1;
+        }
+        if (state) {
+            state->trunk_vc_freq[0] = freq;
+            state->trunk_vc_freq[1] = freq;
+            state->last_vc_sync_time = time(NULL);
+            state->last_vc_sync_time_m = dsd_time_now_monotonic_s();
+        }
+    }
+    return result;
+}
+
+static dsd_trunk_tune_result
+dmr_hook_return_to_cc(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_hooks.return_calls++;
+    return dmr_pop_result(g_hooks.return_results, g_hooks.return_count, &g_hooks.return_pos);
+}
+
+static void
+dmr_install_hooks(void) {
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_freq_result = dmr_hook_tune_to_freq;
+    hooks.return_to_cc_result = dmr_hook_return_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+}
+
+static void
+dmr_reset_hooks(void) {
+    DSD_MEMSET(&g_hooks, 0, sizeof(g_hooks));
+}
+
+static int
+dmr_expect(int cond, const char* grant, const char* flow, const char* script, const char* check) {
+    if (cond) {
+        return 0;
+    }
+    DSD_FPRINTF(stderr, "FAIL grant=%s flow=%s script=%s check=%s\n", grant, flow, script, check);
+    return 1;
+}
+
+static void
+dmr_setup_fixture(const dmr_grant_case* grant) {
+    DSD_MEMSET(&g_opts, 0, sizeof(g_opts));
+    DSD_MEMSET(&g_state, 0, sizeof(g_state));
+    DSD_MEMSET(&g_ctx, 0, sizeof(g_ctx));
+
+    g_opts.trunk_enable = 1;
+    g_opts.trunk_hangtime = 0.1f;
+    g_opts.trunk_tune_data_calls = 1;
+    g_state.trunk_cc_freq = 851012500L;
+    g_state.dmr_rest_channel = -1;
+
+    if (grant->lpcn > 0) {
+        g_state.trunk_chan_map[grant->lpcn] = grant->mapped_freq_hz;
+        g_state.dmr_lcn_trust[grant->lpcn] = (uint8_t)grant->trust;
+    }
+
+    dmr_sm_init_ctx(&g_ctx, &g_opts, &g_state);
+    g_ctx.hangtime_s = 0.1;
+    g_ctx.grant_timeout_s = 0.1;
+    g_ctx.cc_grace_s = 0.1;
+}
+
+static void
+dmr_age_grant_timeout(void) {
+    g_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    g_ctx.t_voice_m = 0.0;
+}
+
+static void
+dmr_age_hangtime(void) {
+    double old_m = dsd_time_now_monotonic_s() - 1.0;
+    g_ctx.t_tune_m = old_m;
+    g_ctx.t_voice_m = old_m;
+    g_ctx.slots[0].last_active_m = old_m;
+    g_ctx.slots[1].last_active_m = old_m;
+    g_state.last_vc_sync_time = time(NULL) - 1;
+    g_state.last_vc_sync_time_m = old_m;
+}
+
+static dmr_sm_event_t
+dmr_case_grant_event(const dmr_grant_case* grant, int id, int use_indiv) {
+    return use_indiv ? dmr_sm_ev_indiv_grant(grant->freq_hz, grant->lpcn, id, 7000 + id)
+                     : dmr_sm_ev_group_grant(grant->freq_hz, grant->lpcn, id, 7000 + id);
+}
+
+static int
+dmr_send_initial_grant(const dmr_grant_case* grant, int use_indiv, const char* flow, const char* script) {
+    const int grant_id = 1201;
+    dmr_sm_event_t ev = dmr_case_grant_event(grant, grant_id, use_indiv);
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+
+    long expected_freq = dmr_case_expected_freq(grant);
+    int expected_tg = use_indiv ? 0 : grant_id;
+    int rc = 0;
+    rc |= dmr_expect(g_hooks.tune_calls == 1, grant->name, flow, script, "initial tune attempted once");
+    rc |= dmr_expect(g_hooks.last_tune_freq == expected_freq, grant->name, flow, script, "initial tune frequency");
+    rc |= dmr_expect(g_ctx.state == DMR_SM_TUNED, grant->name, flow, script, "initial grant reached TUNED");
+    rc |= dmr_expect(g_ctx.vc_freq_hz == expected_freq, grant->name, flow, script, "ctx voice frequency committed");
+    rc |= dmr_expect(g_ctx.vc_tg == expected_tg && g_ctx.vc_src == 7000 + grant_id, grant->name, flow, script,
+                     use_indiv ? "individual grant metadata committed" : "group grant metadata committed");
+    rc |= dmr_expect(g_opts.trunk_is_tuned == 1, grant->name, flow, script, "generic tuned flag committed");
+    rc |= dmr_expect(g_state.trunk_vc_freq[0] == expected_freq && g_state.trunk_vc_freq[1] == expected_freq,
+                     grant->name, flow, script, "voice frequencies committed");
+    rc |= dmr_expect(g_state.p25_sm_tune_count == 1, grant->name, flow, script, "tune counter incremented");
+    return rc;
+}
+
+static int
+dmr_drive_to_cc(const dmr_grant_case* grant, const dmr_flow_case* flow, const dmr_return_script* script) {
+    for (int i = 0; i < 4 && g_ctx.state != DMR_SM_ON_CC; i++) {
+        dmr_age_hangtime();
+        dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+    }
+
+    int rc = 0;
+    rc |= dmr_expect(g_ctx.state == DMR_SM_ON_CC, grant->name, flow->name, script->name, "returned to ON_CC");
+    rc |= dmr_expect(g_opts.trunk_is_tuned == 0, grant->name, flow->name, script->name, "tuned flag cleared");
+    rc |= dmr_expect(g_state.trunk_vc_freq[0] == 0 && g_state.trunk_vc_freq[1] == 0, grant->name, flow->name,
+                     script->name, "voice frequencies cleared");
+    rc |= dmr_expect(g_ctx.vc_freq_hz == 0 && g_ctx.vc_lpcn == 0 && g_ctx.vc_tg == 0, grant->name, flow->name,
+                     script->name, "ctx voice grant state cleared");
+    rc |= dmr_expect(g_ctx.slots[0].voice_active == 0 && g_ctx.slots[1].voice_active == 0, grant->name, flow->name,
+                     script->name, "slot activity cleared");
+    rc |= dmr_expect(g_state.p25_sm_release_count == 1, grant->name, flow->name, script->name,
+                     "release counter incremented once");
+    rc |= dmr_expect(g_hooks.return_calls == script->count, grant->name, flow->name, script->name,
+                     "return calls match script");
+    return rc;
+}
+
+static int
+dmr_expect_rejected_return_preserved(const dmr_grant_case* grant, const dmr_flow_case* flow,
+                                     const dmr_return_script* script) {
+    if (dsd_trunk_tune_result_is_ok(script->results[0])) {
+        return 0;
+    }
+
+    long expected_freq = dmr_case_expected_freq(grant);
+    int rc = 0;
+    rc |= dmr_expect(g_hooks.return_calls == 1, grant->name, flow->name, script->name,
+                     "rejected return attempted once before retry");
+    rc |= dmr_expect(g_ctx.state == DMR_SM_TUNED, grant->name, flow->name, script->name,
+                     "rejected return preserved tuned state");
+    rc |= dmr_expect(g_opts.trunk_is_tuned == 1, grant->name, flow->name, script->name,
+                     "rejected return preserved tuned flag");
+    rc |= dmr_expect(g_state.trunk_vc_freq[0] == expected_freq && g_state.trunk_vc_freq[1] == expected_freq,
+                     grant->name, flow->name, script->name, "rejected return preserved voice frequencies");
+    rc |= dmr_expect(g_ctx.vc_freq_hz == expected_freq, grant->name, flow->name, script->name,
+                     "rejected return preserved ctx voice frequency");
+    rc |= dmr_expect(g_state.p25_sm_release_count == 0, grant->name, flow->name, script->name,
+                     "rejected return did not count release");
+    rc |= dmr_expect(g_state.trunk_sm_force_release == (flow->kind == DMR_FLOW_FORCED_RELEASE ? 1 : 0), grant->name,
+                     flow->name, script->name, "rejected return force latch state");
+    return rc;
+}
+
+static int
+dmr_apply_terminal_flow(const dmr_grant_case* grant, const dmr_flow_case* flow, const dmr_return_script* script) {
+    dmr_sm_event_t ev;
+    int rc = 0;
+
+    switch (flow->kind) {
+        case DMR_FLOW_GRANT_TIMEOUT:
+            dmr_age_grant_timeout();
+            dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+            break;
+
+        case DMR_FLOW_VOICE_HANGTIME:
+            ev = dmr_sm_ev_voice_sync(0);
+            dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+            g_ctx.slots[0].voice_active = 0;
+            dmr_age_hangtime();
+            dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+            break;
+
+        case DMR_FLOW_DATA_HANGTIME:
+            ev = dmr_sm_ev_data_sync(1);
+            dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+            dmr_age_hangtime();
+            dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+            break;
+
+        case DMR_FLOW_EXPLICIT_RELEASE:
+            ev = dmr_sm_ev_voice_sync(0);
+            dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+            ev = dmr_sm_ev_release(-1);
+            dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+            dmr_age_hangtime();
+            dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+            break;
+
+        case DMR_FLOW_DUAL_SLOT_PARTIAL_RELEASE:
+            ev = dmr_sm_ev_voice_sync(0);
+            dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+            ev = dmr_sm_ev_voice_sync(1);
+            dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+            ev = dmr_sm_ev_release(0);
+            dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+            g_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+            dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+            rc |= dmr_expect(g_ctx.state == DMR_SM_TUNED, grant->name, flow->name, script->name,
+                             "partial slot release remains tuned");
+            rc |= dmr_expect(g_hooks.return_calls == 0, grant->name, flow->name, script->name,
+                             "partial slot release does not return");
+            ev = dmr_sm_ev_release(1);
+            dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+            dmr_age_hangtime();
+            dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+            break;
+
+        case DMR_FLOW_FORCED_RELEASE:
+            ev = dmr_sm_ev_voice_sync(0);
+            dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+            g_state.trunk_sm_force_release = 1;
+            dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+            break;
+    }
+
+    rc |= dmr_expect_rejected_return_preserved(grant, flow, script);
+    rc |= dmr_drive_to_cc(grant, flow, script);
+    rc |= dmr_expect(g_state.trunk_sm_force_release == 0, grant->name, flow->name, script->name,
+                     "force release latch cleared");
+    return rc;
+}
+
+static int
+dmr_run_initial_tune_case(const dmr_grant_case* grant, dsd_trunk_tune_result result, const char* result_name) {
+    dmr_reset_hooks();
+    g_hooks.tune_results[0] = result;
+    g_hooks.tune_count = 1;
+    dmr_install_hooks();
+    dmr_setup_fixture(grant);
+
+    dmr_sm_event_t ev = dmr_case_grant_event(grant, 1201, 0);
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+
+    int accepted = dsd_trunk_tune_result_is_ok(result);
+    int rc = 0;
+    rc |= dmr_expect(g_hooks.tune_calls == 1, grant->name, "initial-tune", result_name, "tune attempted");
+    if (accepted) {
+        rc |= dmr_expect(g_ctx.state == DMR_SM_TUNED, grant->name, "initial-tune", result_name,
+                         "accepted tune reached TUNED");
+        rc |= dmr_expect(g_opts.trunk_is_tuned == 1, grant->name, "initial-tune", result_name,
+                         "accepted tune set tuned flag");
+        rc |= dmr_expect(g_state.trunk_vc_freq[0] == dmr_case_expected_freq(grant), grant->name, "initial-tune",
+                         result_name, "accepted tune set voice frequency");
+        rc |= dmr_expect(g_state.p25_sm_tune_count == 1, grant->name, "initial-tune", result_name,
+                         "accepted tune counted");
+    } else {
+        rc |= dmr_expect(g_ctx.state == DMR_SM_ON_CC, grant->name, "initial-tune", result_name,
+                         "rejected tune stayed ON_CC");
+        rc |= dmr_expect(g_opts.trunk_is_tuned == 0, grant->name, "initial-tune", result_name,
+                         "rejected tune left tuned flag clear");
+        rc |= dmr_expect(g_state.trunk_vc_freq[0] == 0 && g_state.trunk_vc_freq[1] == 0, grant->name, "initial-tune",
+                         result_name, "rejected tune left voice frequencies clear");
+        rc |= dmr_expect(g_state.p25_sm_tune_count == 0, grant->name, "initial-tune", result_name,
+                         "rejected tune not counted");
+    }
+    return rc;
+}
+
+static int
+dmr_run_terminal_case(const dmr_grant_case* grant, const dmr_flow_case* flow, const dmr_return_script* script) {
+    dmr_reset_hooks();
+    g_hooks.tune_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.tune_count = 1;
+    for (int i = 0; i < script->count; i++) {
+        g_hooks.return_results[i] = script->results[i];
+    }
+    g_hooks.return_count = script->count;
+    dmr_install_hooks();
+    dmr_setup_fixture(grant);
+
+    int rc = dmr_send_initial_grant(grant, 0, flow->name, script->name);
+    if (rc != 0) {
+        return rc;
+    }
+    return dmr_apply_terminal_flow(grant, flow, script);
+}
+
+static int
+dmr_run_active_without_terminal_case(const dmr_grant_case* grant) {
+    const char* flow = "active-without-terminal";
+    dmr_reset_hooks();
+    g_hooks.tune_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.tune_count = 1;
+    g_hooks.return_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.return_count = 1;
+    dmr_install_hooks();
+    dmr_setup_fixture(grant);
+
+    int rc = dmr_send_initial_grant(grant, 0, flow, "no-return");
+    if (rc != 0) {
+        return rc;
+    }
+
+    dmr_sm_event_t ev = dmr_sm_ev_voice_sync(0);
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+    g_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+
+    rc |= dmr_expect(g_ctx.state == DMR_SM_TUNED, grant->name, flow, "no-return", "active voice remains tuned");
+    rc |= dmr_expect(g_opts.trunk_is_tuned == 1, grant->name, flow, "no-return", "active voice keeps tuned flag");
+    rc |= dmr_expect(g_hooks.return_calls == 0, grant->name, flow, "no-return", "no return attempted");
+    return rc;
+}
+
+static int
+dmr_run_duplicate_grant_case(const dmr_grant_case* grant) {
+    dmr_reset_hooks();
+    g_hooks.tune_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.tune_results[1] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.tune_count = 2;
+    g_hooks.return_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.return_count = 1;
+    dmr_install_hooks();
+    dmr_setup_fixture(grant);
+
+    int rc = dmr_send_initial_grant(grant, 0, "duplicate-grant", "ok");
+    if (rc != 0) {
+        return rc;
+    }
+
+    dmr_sm_event_t ev = dmr_case_grant_event(grant, 1201, 0);
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+    rc |= dmr_expect(g_hooks.tune_calls == 1, grant->name, "duplicate-grant", "ok", "duplicate grant did not retune");
+    rc |=
+        dmr_expect(g_ctx.state == DMR_SM_TUNED, grant->name, "duplicate-grant", "ok", "duplicate grant remained tuned");
+
+    ev = dmr_sm_ev_release(-1);
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+    dmr_age_hangtime();
+    dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+    rc |= dmr_drive_to_cc(grant, &(dmr_flow_case){"duplicate-grant", DMR_FLOW_EXPLICIT_RELEASE},
+                          &(dmr_return_script){"ok", {DSD_TRUNK_TUNE_RESULT_OK, DSD_TRUNK_TUNE_RESULT_OK}, 1});
+    return rc;
+}
+
+static int
+dmr_run_retune_after_release_case(const dmr_grant_case* grant) {
+    dmr_return_script script = {"ok", {DSD_TRUNK_TUNE_RESULT_OK, DSD_TRUNK_TUNE_RESULT_OK}, 1};
+    dmr_flow_case flow = {"retune-after-release", DMR_FLOW_GRANT_TIMEOUT};
+
+    dmr_reset_hooks();
+    g_hooks.tune_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.tune_results[1] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.tune_count = 2;
+    g_hooks.return_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.return_count = 1;
+    dmr_install_hooks();
+    dmr_setup_fixture(grant);
+
+    int rc = dmr_send_initial_grant(grant, 1, flow.name, script.name);
+    if (rc != 0) {
+        return rc;
+    }
+    dmr_age_grant_timeout();
+    dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+    rc |= dmr_drive_to_cc(grant, &flow, &script);
+    if (rc != 0) {
+        return rc;
+    }
+
+    dmr_sm_event_t ev = dmr_case_grant_event(grant, 1301, 0);
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+    rc |= dmr_expect(g_hooks.tune_calls == 2, grant->name, flow.name, "second-grant", "second grant retuned");
+    rc |= dmr_expect(g_ctx.state == DMR_SM_TUNED, grant->name, flow.name, "second-grant", "second grant reached TUNED");
+    return rc;
+}
+
+static int
+dmr_run_untrusted_off_cc_reject_case(void) {
+    dmr_grant_case grant = {"untrusted-off-cc", 852012500L, 0, 0, 0};
+    dmr_reset_hooks();
+    g_hooks.tune_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.tune_results[1] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.tune_count = 2;
+    dmr_install_hooks();
+    dmr_setup_fixture(&grant);
+
+    int rc = dmr_send_initial_grant(&grant, 0, "untrusted-off-cc", "reject");
+    if (rc != 0) {
+        return rc;
+    }
+
+    g_state.trunk_chan_map[40] = 854012500L;
+    g_state.dmr_lcn_trust[40] = 0;
+    dmr_sm_event_t ev = dmr_sm_ev_group_grant(0, 40, 1401, 8401);
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+
+    rc |= dmr_expect(g_hooks.tune_calls == 1, grant.name, "untrusted-off-cc", "reject",
+                     "untrusted off-CC LPCN did not retune");
+    rc |= dmr_expect(g_ctx.vc_freq_hz == 852012500L && g_state.trunk_vc_freq[0] == 852012500L, grant.name,
+                     "untrusted-off-cc", "reject", "original tuned state preserved");
+    return rc;
+}
+
+static int
+dmr_run_data_sync_disabled_case(const dmr_grant_case* grant) {
+    dmr_return_script script = {"ok", {DSD_TRUNK_TUNE_RESULT_OK, DSD_TRUNK_TUNE_RESULT_OK}, 1};
+    dmr_flow_case flow = {"data-sync-disabled", DMR_FLOW_GRANT_TIMEOUT};
+
+    dmr_reset_hooks();
+    g_hooks.tune_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.tune_count = 1;
+    g_hooks.return_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.return_count = 1;
+    dmr_install_hooks();
+    dmr_setup_fixture(grant);
+    g_opts.trunk_tune_data_calls = 0;
+
+    int rc = dmr_send_initial_grant(grant, 0, flow.name, script.name);
+    if (rc != 0) {
+        return rc;
+    }
+
+    dmr_sm_event_t ev = dmr_sm_ev_data_sync(1);
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+    rc |= dmr_expect(g_ctx.t_voice_m == 0.0, grant->name, flow.name, script.name,
+                     "disabled data sync did not arm hangtime");
+
+    dmr_age_grant_timeout();
+    dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+    rc |= dmr_drive_to_cc(grant, &flow, &script);
+    return rc;
+}
+
+static int
+dmr_run_cc_loss_reacquire_case(void) {
+    const char* flow = "cc-loss-reacquire";
+    const char* script = "sync";
+    dmr_grant_case grant = {"control-channel", 0, 0, 0, 0};
+
+    dmr_reset_hooks();
+    dmr_install_hooks();
+    dmr_setup_fixture(&grant);
+
+    g_ctx.t_cc_sync_m = dsd_time_now_monotonic_s() - 1.0;
+    dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+
+    int rc = 0;
+    rc |= dmr_expect(g_ctx.state == DMR_SM_HUNTING, grant.name, flow, script, "stale CC enters HUNTING");
+    rc |= dmr_expect(g_hooks.tune_calls == 0 && g_hooks.return_calls == 0, grant.name, flow, script,
+                     "cc loss does not invoke VC return hooks");
+
+    dmr_sm_event_t ev = dmr_sm_ev_cc_sync();
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+    rc |= dmr_expect(g_ctx.state == DMR_SM_ON_CC, grant.name, flow, script, "cc sync returns ON_CC");
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+
+    static const struct {
+        const char* name;
+        dsd_trunk_tune_result result;
+    } initial_results[] = {
+        {"ok", DSD_TRUNK_TUNE_RESULT_OK},
+        {"pending", DSD_TRUNK_TUNE_RESULT_PENDING},
+        {"deferred", DSD_TRUNK_TUNE_RESULT_DEFERRED},
+        {"failed", DSD_TRUNK_TUNE_RESULT_FAILED},
+        {"timeout", DSD_TRUNK_TUNE_RESULT_TIMEOUT},
+    };
+
+    for (size_t g = 0; g < sizeof(g_grants) / sizeof(g_grants[0]); g++) {
+        for (size_t r = 0; r < sizeof(initial_results) / sizeof(initial_results[0]); r++) {
+            rc |= dmr_run_initial_tune_case(&g_grants[g], initial_results[r].result, initial_results[r].name);
+        }
+        rc |= dmr_run_active_without_terminal_case(&g_grants[g]);
+        rc |= dmr_run_duplicate_grant_case(&g_grants[g]);
+        rc |= dmr_run_retune_after_release_case(&g_grants[g]);
+        rc |= dmr_run_data_sync_disabled_case(&g_grants[g]);
+
+        for (size_t f = 0; f < sizeof(g_flows) / sizeof(g_flows[0]); f++) {
+            for (size_t s = 0; s < sizeof(g_return_scripts) / sizeof(g_return_scripts[0]); s++) {
+                rc |= dmr_run_terminal_case(&g_grants[g], &g_flows[f], &g_return_scripts[s]);
+            }
+        }
+    }
+
+    rc |= dmr_run_untrusted_off_cc_reject_case();
+    rc |= dmr_run_cc_loss_reacquire_case();
+
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    if (rc == 0) {
+        printf("DMR_T3_SM_RETURN_TO_CC_MATRIX: OK\n");
+    }
+    return rc;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/protocol/edacs/test_edacs_grant_tune_matrix.c
+++ b/tests/protocol/edacs/test_edacs_grant_tune_matrix.c
@@ -1,0 +1,540 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * EDACS/ProVoice grant tune matrix.
+ *
+ * Uses the DSD_NEO_TEST_HOOKS valid-frame shim to drive the real EDACS grant
+ * dispatcher with already-decoded 28-bit message words. Grant cases are
+ * intentionally digital so the shared tune path is exercised without entering
+ * the analog audio loop.
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/sync_patterns.h>
+#include <dsd-neo/protocol/edacs/edacs.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+void dsd_neo_edacs_test_process_valid_frame(dsd_opts* opts, dsd_state* state, unsigned long long int msg_1,
+                                            unsigned long long int msg_2);
+
+typedef struct {
+    const char* name;
+    unsigned long long int msg_1;
+    unsigned long long int msg_2;
+    long freq_hz;
+    int ea_mode;
+    int lcn;
+    int expected_flags;
+    int expected_lasttg;
+    int expected_lastsrc;
+} edacs_grant_case;
+
+typedef enum {
+    EDACS_GUARD_GROUP_DISABLED = 0,
+    EDACS_GUARD_PRIVATE_DISABLED,
+    EDACS_GUARD_ALLOWLIST_BLOCK,
+    EDACS_GUARD_MISSING_FREQUENCY,
+    EDACS_GUARD_MISSING_CC_LCN,
+    EDACS_GUARD_P25_TRUNK_DISABLED,
+} edacs_no_tune_guard;
+
+static dsd_opts g_opts;
+static dsd_state g_state;
+static dsd_trunk_tune_result g_vc_result = DSD_TRUNK_TUNE_RESULT_OK;
+static dsd_trunk_tune_result g_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+static int g_vc_tune_count = 0;
+static int g_cc_tune_count = 0;
+static int g_skip_dibit_count = 0;
+static long g_last_vc_freq = 0;
+static long g_last_cc_freq = 0;
+
+void
+// NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+__wrap_skipDibit(dsd_opts* opts, dsd_state* state, int count) {
+    (void)opts;
+    (void)state;
+    g_skip_dibit_count += count;
+}
+
+void
+// NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+__wrap_watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+// NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+__wrap_watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+static dsd_trunk_tune_result
+edacs_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    (void)ted_sps;
+    g_vc_tune_count++;
+    g_last_vc_freq = freq;
+    if (dsd_trunk_tune_result_is_ok(g_vc_result)) {
+        if (opts) {
+            opts->p25_is_tuned = 1;
+            opts->trunk_is_tuned = 1;
+        }
+        if (state) {
+            state->p25_vc_freq[0] = freq;
+            state->p25_vc_freq[1] = freq;
+            state->trunk_vc_freq[0] = freq;
+            state->trunk_vc_freq[1] = freq;
+        }
+    }
+    return g_vc_result;
+}
+
+static dsd_trunk_tune_result
+edacs_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    (void)opts;
+    (void)ted_sps;
+    g_cc_tune_count++;
+    g_last_cc_freq = freq;
+    if (dsd_trunk_tune_result_is_ok(g_cc_result) && state) {
+        state->trunk_cc_freq = freq;
+    }
+    return g_cc_result;
+}
+
+static void
+edacs_install_hooks(void) {
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_freq_result = edacs_hook_tune_to_freq;
+    hooks.tune_to_cc_result = edacs_hook_tune_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+}
+
+static int
+edacs_expect(int cond, const char* test_case, const char* result_name, const char* check) {
+    if (cond) {
+        return 0;
+    }
+    DSD_FPRINTF(stderr, "FAIL case=%s result=%s check=%s\n", test_case, result_name, check);
+    return 1;
+}
+
+static unsigned long long int
+edacs_standard_group_msg1(int mt_a, int lcn, int group, int source_lid) {
+    unsigned long long int msg = ((unsigned long long int)(mt_a & 0x7) << 25U);
+    msg |= ((unsigned long long int)(source_lid & 0x3F80) << 11U);
+    msg |= ((unsigned long long int)(lcn & 0x1F) << 12U);
+    msg |= (1ULL << 11U);
+    msg |= (unsigned long long int)(group & 0x7FF);
+    return msg;
+}
+
+static unsigned long long int
+edacs_standard_group_msg2(int source_lid) {
+    return (unsigned long long int)(source_lid & 0x7F) << 17U;
+}
+
+static unsigned long long int
+edacs_standard_individual_msg1(int lcn, int target, int is_digital) {
+    unsigned long long int msg = (7ULL << 25U) | (5ULL << 22U);
+    msg |= 1ULL << 21U;
+    msg |= (unsigned long long int)(lcn & 0x1F) << 15U;
+    msg |= (unsigned long long int)(is_digital ? 1U : 0U) << 14U;
+    msg |= (unsigned long long int)(target & 0x3FFF);
+    return msg;
+}
+
+static unsigned long long int
+edacs_extended_group_msg1(int mt1, int lcn, int group) {
+    unsigned long long int msg = (unsigned long long int)(mt1 & 0x1F) << 23U;
+    msg |= (unsigned long long int)(lcn & 0x1F) << 17U;
+    msg |= (unsigned long long int)(group & 0xFFFF);
+    return msg;
+}
+
+static unsigned long long int
+edacs_extended_icall_msg1(int target) {
+    unsigned long long int msg = 0x10ULL << 23U;
+    msg |= 1ULL << 21U;
+    msg |= (unsigned long long int)(target & 0xFFFFF);
+    return msg;
+}
+
+static unsigned long long int
+edacs_extended_icall_msg2(int lcn, int source) {
+    unsigned long long int msg = (unsigned long long int)(lcn & 0x1F) << 20U;
+    msg |= (unsigned long long int)(source & 0xFFFFF);
+    return msg;
+}
+
+static void
+edacs_setup_fixture(const edacs_grant_case* test_case) {
+    DSD_MEMSET(&g_opts, 0, sizeof(g_opts));
+    DSD_MEMSET(&g_state, 0, sizeof(g_state));
+
+    g_opts.p25_trunk = 1;
+    g_opts.trunk_enable = 1;
+    g_opts.trunk_tune_group_calls = 1;
+    g_opts.trunk_tune_private_calls = 1;
+    g_opts.trunk_hangtime = 1.0f;
+    g_state.ea_mode = test_case->ea_mode;
+    g_state.edacs_cc_lcn = 1;
+    g_state.edacs_tuned_lcn = -1;
+    g_state.trunk_lcn_freq[0] = 851012500L;
+    g_state.p25_cc_freq = g_state.trunk_lcn_freq[0];
+    g_state.trunk_cc_freq = g_state.trunk_lcn_freq[0];
+    g_state.trunk_lcn_freq[test_case->lcn - 1] = test_case->freq_hz;
+
+    g_vc_tune_count = 0;
+    g_cc_tune_count = 0;
+    g_skip_dibit_count = 0;
+    g_last_vc_freq = 0;
+    g_last_cc_freq = 0;
+}
+
+static int
+edacs_run_grant_result_case(const edacs_grant_case* test_case, dsd_trunk_tune_result result, const char* result_name) {
+    g_vc_result = result;
+    g_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    edacs_setup_fixture(test_case);
+    edacs_install_hooks();
+
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, test_case->msg_1, test_case->msg_2);
+
+    const int accepted = dsd_trunk_tune_result_is_ok(result);
+    int rc = 0;
+    rc |= edacs_expect(g_vc_tune_count == 1, test_case->name, result_name, "voice tune attempted once");
+    rc |= edacs_expect(g_last_vc_freq == test_case->freq_hz, test_case->name, result_name,
+                       "voice tune frequency matches LCN map");
+    rc |= edacs_expect(g_state.edacs_vc_lcn == test_case->lcn, test_case->name, result_name, "grant tracked VC LCN");
+    rc |= edacs_expect(g_state.lasttg == test_case->expected_lasttg && g_state.lastsrc == test_case->expected_lastsrc,
+                       test_case->name, result_name, "grant tracked target/source");
+    rc |= edacs_expect((g_state.edacs_vc_call_type & test_case->expected_flags) == test_case->expected_flags,
+                       test_case->name, result_name, "grant call flags");
+
+    if (accepted) {
+        rc |= edacs_expect(g_state.edacs_tuned_lcn == test_case->lcn, test_case->name, result_name,
+                           "accepted tune set tuned LCN");
+        rc |= edacs_expect(g_opts.p25_is_tuned == 1 && g_opts.trunk_is_tuned == 1, test_case->name, result_name,
+                           "accepted tune set tuned flags");
+        rc |=
+            edacs_expect(g_state.trunk_vc_freq[0] == test_case->freq_hz && g_state.p25_vc_freq[0] == test_case->freq_hz,
+                         test_case->name, result_name, "accepted tune set VC frequencies");
+    } else {
+        rc |= edacs_expect(g_state.edacs_tuned_lcn == -1, test_case->name, result_name,
+                           "rejected tune left tuned LCN clear");
+        rc |= edacs_expect(g_opts.p25_is_tuned == 0 && g_opts.trunk_is_tuned == 0, test_case->name, result_name,
+                           "rejected tune left tuned flags clear");
+        rc |= edacs_expect(g_state.trunk_vc_freq[0] == 0 && g_state.p25_vc_freq[0] == 0, test_case->name, result_name,
+                           "rejected tune left VC frequencies clear");
+    }
+    return rc;
+}
+
+static void
+edacs_apply_no_tune_guard(const edacs_grant_case* test_case, edacs_no_tune_guard guard) {
+    switch (guard) {
+        case EDACS_GUARD_GROUP_DISABLED: g_opts.trunk_tune_group_calls = 0; break;
+        case EDACS_GUARD_PRIVATE_DISABLED: g_opts.trunk_tune_private_calls = 0; break;
+        case EDACS_GUARD_ALLOWLIST_BLOCK: g_opts.trunk_use_allow_list = 1; break;
+        case EDACS_GUARD_MISSING_FREQUENCY: g_state.trunk_lcn_freq[test_case->lcn - 1] = 0; break;
+        case EDACS_GUARD_MISSING_CC_LCN: g_state.edacs_cc_lcn = 0; break;
+        case EDACS_GUARD_P25_TRUNK_DISABLED: g_opts.p25_trunk = 0; break;
+    }
+}
+
+static int
+edacs_run_no_tune_guard_case(const edacs_grant_case* test_case, edacs_no_tune_guard guard, const char* guard_name) {
+    g_vc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    edacs_setup_fixture(test_case);
+    edacs_apply_no_tune_guard(test_case, guard);
+    edacs_install_hooks();
+
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, test_case->msg_1, test_case->msg_2);
+
+    int rc = 0;
+    rc |= edacs_expect(g_vc_tune_count == 0, test_case->name, guard_name, "guard did not attempt tune");
+    rc |= edacs_expect(g_last_vc_freq == 0, test_case->name, guard_name, "guard left tune frequency clear");
+    rc |= edacs_expect(g_state.edacs_vc_lcn == test_case->lcn, test_case->name, guard_name,
+                       "guard still tracked parsed VC LCN");
+    rc |= edacs_expect(g_state.edacs_tuned_lcn == -1, test_case->name, guard_name, "guard left tuned LCN clear");
+    rc |= edacs_expect(g_opts.p25_is_tuned == 0 && g_opts.trunk_is_tuned == 0, test_case->name, guard_name,
+                       "guard left tuned flags clear");
+    rc |= edacs_expect(g_state.trunk_vc_freq[0] == 0 && g_state.p25_vc_freq[0] == 0, test_case->name, guard_name,
+                       "guard left VC frequencies clear");
+    rc |= edacs_expect(g_state.lasttg == test_case->expected_lasttg && g_state.lastsrc == test_case->expected_lastsrc,
+                       test_case->name, guard_name, "guard preserved parsed target/source");
+    rc |= edacs_expect((g_state.edacs_vc_call_type & test_case->expected_flags) == test_case->expected_flags,
+                       test_case->name, guard_name, "guard preserved parsed call flags");
+    return rc;
+}
+
+static int
+edacs_run_retry_after_reject_case(const edacs_grant_case* test_case, dsd_trunk_tune_result first_result,
+                                  const char* result_name) {
+    g_vc_result = first_result;
+    g_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    edacs_setup_fixture(test_case);
+    edacs_install_hooks();
+
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, test_case->msg_1, test_case->msg_2);
+
+    int rc = 0;
+    rc |= edacs_expect(g_vc_tune_count == 1, test_case->name, result_name, "rejected tune attempted once");
+    rc |=
+        edacs_expect(g_state.edacs_tuned_lcn == -1, test_case->name, result_name, "rejected tune left tuned LCN clear");
+    rc |= edacs_expect(g_opts.p25_is_tuned == 0 && g_opts.trunk_is_tuned == 0, test_case->name, result_name,
+                       "rejected tune left tuned flags clear");
+
+    g_vc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, test_case->msg_1, test_case->msg_2);
+
+    rc |= edacs_expect(g_vc_tune_count == 2, test_case->name, result_name, "later grant retried tune");
+    rc |= edacs_expect(g_last_vc_freq == test_case->freq_hz, test_case->name, result_name,
+                       "retried tune frequency matches LCN map");
+    rc |= edacs_expect(g_state.edacs_tuned_lcn == test_case->lcn, test_case->name, result_name,
+                       "retried tune set tuned LCN");
+    rc |= edacs_expect(g_opts.p25_is_tuned == 1 && g_opts.trunk_is_tuned == 1, test_case->name, result_name,
+                       "retried tune set tuned flags");
+    rc |= edacs_expect(g_state.trunk_vc_freq[0] == test_case->freq_hz && g_state.p25_vc_freq[0] == test_case->freq_hz,
+                       test_case->name, result_name, "retried tune set VC frequencies");
+    return rc;
+}
+
+static void
+edacs_setup_eot_fixture(void) {
+    DSD_MEMSET(&g_opts, 0, sizeof(g_opts));
+    DSD_MEMSET(&g_state, 0, sizeof(g_state));
+
+    g_opts.p25_trunk = 1;
+    g_opts.trunk_enable = 1;
+    g_opts.p25_is_tuned = 1;
+    g_opts.trunk_is_tuned = 1;
+    g_state.p25_cc_freq = 851012500L;
+    g_state.trunk_cc_freq = 851012500L;
+    g_state.p25_vc_freq[0] = 852012500L;
+    g_state.p25_vc_freq[1] = 852012500L;
+    g_state.trunk_vc_freq[0] = 852012500L;
+    g_state.trunk_vc_freq[1] = 852012500L;
+    g_state.edacs_tuned_lcn = 5;
+    g_state.lasttg = 1201;
+    g_state.lastsrc = 42001;
+    g_state.payload_algid = 0x84;
+    g_state.payload_keyid = 0x1234;
+    g_state.payload_miP = 0x5678;
+    DSD_SNPRINTF(g_state.call_string[0], sizeof(g_state.call_string[0]), "%s", "edacs active");
+    DSD_SNPRINTF(g_state.active_channel[0], sizeof(g_state.active_channel[0]), "%s", "active");
+
+    g_vc_tune_count = 0;
+    g_cc_tune_count = 0;
+    g_skip_dibit_count = 0;
+    g_last_vc_freq = 0;
+    g_last_cc_freq = 0;
+}
+
+static int
+edacs_run_eot_result_case(dsd_trunk_tune_result result, const char* result_name) {
+    g_vc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_cc_result = result;
+    edacs_setup_eot_fixture();
+    edacs_install_hooks();
+
+    eot_cc(&g_opts, &g_state);
+
+    const int accepted = dsd_trunk_tune_result_is_ok(result);
+    int rc = 0;
+    rc |= edacs_expect(g_cc_tune_count == 1, "eot-cc", result_name, "CC tune attempted once");
+    rc |= edacs_expect(g_last_cc_freq == 851012500L, "eot-cc", result_name, "CC tune frequency");
+    rc |= edacs_expect(g_skip_dibit_count == (240 * 8), "eot-cc", result_name, "EOT dibit skip was bounded");
+
+    if (accepted) {
+        rc |= edacs_expect(g_opts.p25_is_tuned == 0 && g_opts.trunk_is_tuned == 0, "eot-cc", result_name,
+                           "accepted CC return cleared tuned flags");
+        rc |=
+            edacs_expect(g_state.edacs_tuned_lcn == -1, "eot-cc", result_name, "accepted CC return cleared tuned LCN");
+        rc |= edacs_expect(g_state.p25_vc_freq[0] == 0 && g_state.trunk_vc_freq[0] == 0, "eot-cc", result_name,
+                           "accepted CC return cleared VC frequencies");
+        rc |= edacs_expect(g_state.lasttg == 0 && g_state.lastsrc == 0, "eot-cc", result_name,
+                           "accepted CC return cleared call ids");
+        rc |= edacs_expect(g_state.payload_algid == 0 && g_state.payload_keyid == 0 && g_state.payload_miP == 0,
+                           "eot-cc", result_name, "accepted CC return cleared payload metadata");
+        rc |= edacs_expect(g_state.active_channel[0][0] == '\0', "eot-cc", result_name,
+                           "accepted CC return cleared active display");
+    } else {
+        rc |= edacs_expect(g_opts.p25_is_tuned == 1 && g_opts.trunk_is_tuned == 1, "eot-cc", result_name,
+                           "rejected CC return preserved tuned flags");
+        rc |=
+            edacs_expect(g_state.edacs_tuned_lcn == 5, "eot-cc", result_name, "rejected CC return preserved tuned LCN");
+        rc |= edacs_expect(g_state.p25_vc_freq[0] == 852012500L && g_state.trunk_vc_freq[0] == 852012500L, "eot-cc",
+                           result_name, "rejected CC return preserved VC frequencies");
+        rc |= edacs_expect(g_state.lasttg == 1201 && g_state.lastsrc == 42001, "eot-cc", result_name,
+                           "rejected CC return preserved call ids");
+        rc |= edacs_expect(g_state.payload_algid == 0x84 && g_state.payload_keyid == 0x1234
+                               && g_state.payload_miP == 0x5678,
+                           "eot-cc", result_name, "rejected CC return preserved payload metadata");
+    }
+    return rc;
+}
+
+static int
+edacs_run_eot_retry_after_reject_case(dsd_trunk_tune_result first_result, const char* result_name) {
+    g_vc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_cc_result = first_result;
+    edacs_setup_eot_fixture();
+    edacs_install_hooks();
+
+    eot_cc(&g_opts, &g_state);
+
+    int rc = 0;
+    rc |= edacs_expect(g_cc_tune_count == 1, "eot-retry", result_name, "rejected CC tune attempted once");
+    rc |= edacs_expect(g_opts.p25_is_tuned == 1 && g_opts.trunk_is_tuned == 1, "eot-retry", result_name,
+                       "rejected CC tune preserved tuned flags");
+    rc |= edacs_expect(g_state.edacs_tuned_lcn == 5, "eot-retry", result_name, "rejected CC tune preserved tuned LCN");
+
+    g_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    eot_cc(&g_opts, &g_state);
+
+    rc |= edacs_expect(g_cc_tune_count == 2, "eot-retry", result_name, "later EOT retried CC tune");
+    rc |= edacs_expect(g_opts.p25_is_tuned == 0 && g_opts.trunk_is_tuned == 0, "eot-retry", result_name,
+                       "retried CC tune cleared tuned flags");
+    rc |= edacs_expect(g_state.edacs_tuned_lcn == -1, "eot-retry", result_name, "retried CC tune cleared tuned LCN");
+    rc |= edacs_expect(g_state.p25_vc_freq[0] == 0 && g_state.trunk_vc_freq[0] == 0, "eot-retry", result_name,
+                       "retried CC tune cleared VC frequencies");
+    return rc;
+}
+
+static int
+edacs_run_retune_after_eot_case(const edacs_grant_case* test_case) {
+    g_vc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    edacs_setup_fixture(test_case);
+    edacs_install_hooks();
+
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, test_case->msg_1, test_case->msg_2);
+
+    int rc = 0;
+    rc |= edacs_expect(g_vc_tune_count == 1, test_case->name, "retune-after-eot", "initial grant tuned once");
+    rc |= edacs_expect(g_state.edacs_tuned_lcn == test_case->lcn, test_case->name, "retune-after-eot",
+                       "initial grant set tuned LCN");
+
+    eot_cc(&g_opts, &g_state);
+    rc |= edacs_expect(g_cc_tune_count == 1, test_case->name, "retune-after-eot", "EOT returned to CC once");
+    rc |= edacs_expect(g_opts.p25_is_tuned == 0 && g_opts.trunk_is_tuned == 0, test_case->name, "retune-after-eot",
+                       "EOT cleared tuned flags");
+    rc |= edacs_expect(g_state.edacs_tuned_lcn == -1, test_case->name, "retune-after-eot", "EOT cleared tuned LCN");
+
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, test_case->msg_1, test_case->msg_2);
+    rc |= edacs_expect(g_vc_tune_count == 2, test_case->name, "retune-after-eot", "post-EOT grant retuned");
+    rc |= edacs_expect(g_last_vc_freq == test_case->freq_hz, test_case->name, "retune-after-eot",
+                       "post-EOT tune frequency matches LCN map");
+    rc |= edacs_expect(g_opts.p25_is_tuned == 1 && g_opts.trunk_is_tuned == 1, test_case->name, "retune-after-eot",
+                       "post-EOT grant set tuned flags");
+    rc |= edacs_expect(g_state.edacs_tuned_lcn == test_case->lcn, test_case->name, "retune-after-eot",
+                       "post-EOT grant set tuned LCN");
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    const int std_group = 321;
+    const int std_group_src = 1234;
+    const int std_indiv_target = 4321;
+    const int std_indiv_src = 2345;
+    const int ea_group = 54321;
+    const int ea_group_src = 34567;
+    const int ea_icall_target = 654321;
+    const int ea_icall_src = 45678;
+
+    static const struct {
+        const char* name;
+        dsd_trunk_tune_result result;
+    } results[] = {
+        {"ok", DSD_TRUNK_TUNE_RESULT_OK},
+        {"pending", DSD_TRUNK_TUNE_RESULT_PENDING},
+        {"deferred", DSD_TRUNK_TUNE_RESULT_DEFERRED},
+        {"failed", DSD_TRUNK_TUNE_RESULT_FAILED},
+        {"timeout", DSD_TRUNK_TUNE_RESULT_TIMEOUT},
+    };
+
+    const edacs_grant_case cases[] = {
+        {"standard-digital-group", edacs_standard_group_msg1(2, 5, std_group, std_group_src),
+         edacs_standard_group_msg2(std_group_src), 852012500L, 0, 5, EDACS_IS_VOICE | EDACS_IS_DIGITAL | EDACS_IS_GROUP,
+         std_group, std_group_src},
+        {"standard-digital-individual", edacs_standard_individual_msg1(6, std_indiv_target, 1),
+         (unsigned long long int)std_indiv_src, 852512500L, 0, 6,
+         EDACS_IS_VOICE | EDACS_IS_DIGITAL | EDACS_IS_INDIVIDUAL, std_indiv_target, std_indiv_src},
+        {"ea-digital-group", edacs_extended_group_msg1(3, 7, ea_group), (unsigned long long int)ea_group_src,
+         853012500L, 1, 7, EDACS_IS_VOICE | EDACS_IS_DIGITAL | EDACS_IS_GROUP, ea_group, ea_group_src},
+        {"ea-digital-icall", edacs_extended_icall_msg1(ea_icall_target), edacs_extended_icall_msg2(8, ea_icall_src),
+         853512500L, 1, 8, EDACS_IS_VOICE | EDACS_IS_DIGITAL | EDACS_IS_INDIVIDUAL, ea_icall_target, ea_icall_src},
+    };
+
+    for (size_t c = 0; c < sizeof(cases) / sizeof(cases[0]); c++) {
+        for (size_t r = 0; r < sizeof(results) / sizeof(results[0]); r++) {
+            rc |= edacs_run_grant_result_case(&cases[c], results[r].result, results[r].name);
+        }
+    }
+
+    static const struct {
+        size_t case_index;
+        edacs_no_tune_guard guard;
+        const char* name;
+    } guard_cases[] = {
+        {0U, EDACS_GUARD_GROUP_DISABLED, "group-disabled"},
+        {1U, EDACS_GUARD_PRIVATE_DISABLED, "private-disabled"},
+        {2U, EDACS_GUARD_GROUP_DISABLED, "ea-group-disabled"},
+        {3U, EDACS_GUARD_PRIVATE_DISABLED, "ea-private-disabled"},
+        {0U, EDACS_GUARD_ALLOWLIST_BLOCK, "group-allowlist-block"},
+        {1U, EDACS_GUARD_ALLOWLIST_BLOCK, "private-allowlist-block"},
+        {2U, EDACS_GUARD_ALLOWLIST_BLOCK, "ea-group-allowlist-block"},
+        {3U, EDACS_GUARD_ALLOWLIST_BLOCK, "ea-private-allowlist-block"},
+        {2U, EDACS_GUARD_MISSING_FREQUENCY, "missing-frequency"},
+        {2U, EDACS_GUARD_MISSING_CC_LCN, "missing-cc-lcn"},
+        {3U, EDACS_GUARD_P25_TRUNK_DISABLED, "p25-trunk-disabled"},
+    };
+
+    for (size_t g = 0; g < sizeof(guard_cases) / sizeof(guard_cases[0]); g++) {
+        rc |=
+            edacs_run_no_tune_guard_case(&cases[guard_cases[g].case_index], guard_cases[g].guard, guard_cases[g].name);
+    }
+
+    rc |= edacs_run_retry_after_reject_case(&cases[0], DSD_TRUNK_TUNE_RESULT_DEFERRED, "retry-after-deferred");
+    rc |= edacs_run_retry_after_reject_case(&cases[1], DSD_TRUNK_TUNE_RESULT_FAILED, "retry-after-failed");
+    rc |= edacs_run_retry_after_reject_case(&cases[2], DSD_TRUNK_TUNE_RESULT_TIMEOUT, "retry-after-timeout");
+
+    for (size_t r = 0; r < sizeof(results) / sizeof(results[0]); r++) {
+        rc |= edacs_run_eot_result_case(results[r].result, results[r].name);
+    }
+    rc |= edacs_run_eot_retry_after_reject_case(DSD_TRUNK_TUNE_RESULT_DEFERRED, "deferred-then-ok");
+    rc |= edacs_run_eot_retry_after_reject_case(DSD_TRUNK_TUNE_RESULT_FAILED, "failed-then-ok");
+    rc |= edacs_run_eot_retry_after_reject_case(DSD_TRUNK_TUNE_RESULT_TIMEOUT, "timeout-then-ok");
+    rc |= edacs_run_retune_after_eot_case(&cases[3]);
+
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    if (rc == 0) {
+        printf("EDACS_GRANT_TUNE_MATRIX: OK\n");
+    }
+    return rc;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/protocol/nxdn/test_nxdn_grant_tune_matrix.c
+++ b/tests/protocol/nxdn/test_nxdn_grant_tune_matrix.c
@@ -1,0 +1,656 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * NXDN grant tune matrix.
+ *
+ * Drives Type-C VCALL_ASSGN and Type-D SCCH busy grant paths with
+ * result-returning trunk hooks. OK/PENDING must commit tuned state; rejected
+ * results must leave voice-channel tune state untouched.
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+void NXDN_decode_VCALL_ASSGN(dsd_opts* opts, dsd_state* state, const uint8_t* Message);
+void NXDN_decode_scch(dsd_opts* opts, dsd_state* state, const uint8_t* Message, uint8_t direction);
+
+typedef enum {
+    NXDN_MATRIX_TYPE_C = 0,
+    NXDN_MATRIX_TYPE_D,
+} nxdn_matrix_path;
+
+typedef enum {
+    NXDN_GUARD_GROUP_DISABLED = 0,
+    NXDN_GUARD_PRIVATE_DISABLED,
+    NXDN_GUARD_DATA_DISABLED,
+    NXDN_GUARD_ALLOWLIST_BLOCK,
+    NXDN_GUARD_MISSING_FREQ,
+    NXDN_GUARD_MISSING_CC,
+    NXDN_GUARD_SCCH_RECENT_ACTIVE,
+    NXDN_GUARD_SCCH_REPEATER_ZERO,
+} nxdn_guard_kind;
+
+typedef struct {
+    const char* name;
+    nxdn_matrix_path path;
+    uint8_t message_type;
+    uint8_t call_type;
+    uint16_t source;
+    uint16_t target;
+    uint16_t channel;
+    int use_dfa;
+    uint16_t ofn;
+    uint8_t scch_gu;
+    uint8_t scch_rep1;
+    uint8_t scch_rep2;
+    uint16_t scch_id;
+    long expected_freq;
+} nxdn_case;
+
+static dsd_opts g_opts;
+static dsd_state g_state;
+static dsd_trunk_tune_result g_tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+static int g_tune_count = 0;
+static long g_last_tune_freq = 0;
+
+/*
+ * Link stubs:
+ * Pulling focused grant handlers from nxdn_element.c requires auxiliary
+ * symbols that are irrelevant to this matrix.
+ */
+uint64_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ConvertBitIntoBytes(const uint8_t* bits, uint32_t n) {
+    uint64_t v = 0ULL;
+    for (uint32_t i = 0U; i < n; i++) {
+        v = (v << 1U) | (uint64_t)(bits[i] & 1U);
+    }
+    return v;
+}
+
+uint64_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+convert_bits_into_output(const uint8_t* input, int len) {
+    if (!input || len <= 0) {
+        return 0ULL;
+    }
+    return ConvertBitIntoBytes(input, (uint32_t)len);
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+unpack_byte_array_into_bit_array(const uint8_t* input, uint8_t* output, int len) {
+    if (!input || !output || len <= 0) {
+        return;
+    }
+    DSD_MEMSET(output, 0, (size_t)len * sizeof(uint8_t));
+    for (int i = 0; i < len; i++) {
+        output[i] = (uint8_t)((input[i / 8] >> (7 - (i % 8))) & 1U);
+    }
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_message_type(const dsd_opts* opts, dsd_state* state, uint8_t MessageType) {
+    (void)opts;
+    (void)state;
+    (void)MessageType;
+}
+
+uint32_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_message_crc32(const uint8_t* input, int len) {
+    (void)input;
+    (void)len;
+    return 0U;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_alias_decode_arib(dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+    (void)opts;
+    (void)state;
+    (void)message_bits;
+    (void)crc_ok;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_alias_decode_prop(dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+    (void)opts;
+    (void)state;
+    (void)message_bits;
+    (void)crc_ok;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_alias_reset(dsd_state* state) {
+    (void)state;
+}
+
+long int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_channel_to_frequency(dsd_opts* opts, dsd_state* state, uint16_t channel) {
+    (void)opts;
+    if (!state || channel >= (uint16_t)(sizeof(state->trunk_chan_map) / sizeof(state->trunk_chan_map[0]))) {
+        return 0;
+    }
+    return state->trunk_chan_map[channel];
+}
+
+long int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_channel_to_frequency_quiet(dsd_state* state, uint16_t channel) {
+    if (!state || channel >= (uint16_t)(sizeof(state->trunk_chan_map) / sizeof(state->trunk_chan_map[0]))) {
+        return 0;
+    }
+    return state->trunk_chan_map[channel];
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_gps_report(dsd_opts* opts, dsd_state* state, uint8_t* input, uint32_t src) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)src;
+}
+
+uint8_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nmea_sentence_checker(dsd_opts* opts, dsd_state* state, uint8_t* input, uint8_t slot, int len_bytes) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)slot;
+    (void)len_bytes;
+    return 0U;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_trunk_diag_log_missing_channel_once(const dsd_opts* opts, dsd_state* state, uint16_t channel,
+                                         const char* context) {
+    (void)opts;
+    (void)state;
+    (void)channel;
+    (void)context;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+watchdog_event_current(dsd_opts* opts, dsd_state* state, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+watchdog_event_datacall(dsd_opts* opts, dsd_state* state, uint32_t src, uint32_t dst, char* data_string, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    (void)src;
+    (void)dst;
+    (void)data_string;
+    (void)slot;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+LFSR128n(dsd_state* state) {
+    (void)state;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+des_multi_keystream_output(unsigned long long int mi, unsigned long long int key_ulli, uint8_t* output, int type,
+                           int len) {
+    (void)mi;
+    (void)key_ulli;
+    (void)output;
+    (void)type;
+    (void)len;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+aes_ofb_keystream_output(const uint8_t* iv, const uint8_t* key, uint8_t* output, int type, int nblocks) {
+    (void)iv;
+    (void)key;
+    (void)output;
+    (void)type;
+    (void)nblocks;
+}
+
+long int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_rigctl_query_hook_get_current_freq_hz(const dsd_opts* opts) {
+    (void)opts;
+    return 0;
+}
+
+uint64_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_time_monotonic_ns(void) {
+    return 1000000000ULL;
+}
+
+static dsd_trunk_tune_result
+nxdn_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    (void)ted_sps;
+    g_tune_count++;
+    g_last_tune_freq = freq;
+    if (dsd_trunk_tune_result_is_ok(g_tune_result)) {
+        if (opts) {
+            opts->p25_is_tuned = 1;
+            opts->trunk_is_tuned = 1;
+        }
+        if (state) {
+            state->p25_vc_freq[0] = freq;
+            state->p25_vc_freq[1] = freq;
+            state->trunk_vc_freq[0] = freq;
+            state->trunk_vc_freq[1] = freq;
+        }
+    }
+    return g_tune_result;
+}
+
+static void
+nxdn_install_hooks(void) {
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_freq_result = nxdn_hook_tune_to_freq;
+    dsd_trunk_tuning_hooks_set(hooks);
+}
+
+static int
+nxdn_expect(int cond, const char* test_case, const char* result_name, const char* check) {
+    if (cond) {
+        return 0;
+    }
+    DSD_FPRINTF(stderr, "FAIL case=%s result=%s check=%s\n", test_case, result_name, check);
+    return 1;
+}
+
+static void
+write_bits_u32(uint8_t* bits, size_t start, uint32_t value, size_t nbits) {
+    for (size_t i = 0; i < nbits; i++) {
+        size_t shift = (nbits - 1U) - i;
+        bits[start + i] = (uint8_t)((value >> shift) & 1U);
+    }
+}
+
+static void
+set_message_type(uint8_t* bits, uint8_t type) {
+    bits[2] = (uint8_t)((type >> 5U) & 1U);
+    bits[3] = (uint8_t)((type >> 4U) & 1U);
+    bits[4] = (uint8_t)((type >> 3U) & 1U);
+    bits[5] = (uint8_t)((type >> 2U) & 1U);
+    bits[6] = (uint8_t)((type >> 1U) & 1U);
+    bits[7] = (uint8_t)(type & 1U);
+}
+
+static void
+build_vcall_assgn(uint8_t* message_bits, const nxdn_case* test_case) {
+    DSD_MEMSET(message_bits, 0, 128);
+    set_message_type(message_bits, test_case->message_type);
+    write_bits_u32(message_bits, 16U, test_case->call_type & 0x7U, 3U);
+    write_bits_u32(message_bits, 24U, test_case->source, 16U);
+    write_bits_u32(message_bits, 40U, test_case->target, 16U);
+    write_bits_u32(message_bits, 62U, test_case->channel & 0x03FFU, 10U);
+    if (test_case->use_dfa) {
+        write_bits_u32(message_bits, 64U, test_case->ofn, 16U);
+    }
+}
+
+static void
+build_scch(uint8_t* message_bits, const nxdn_case* test_case) {
+    DSD_MEMSET(message_bits, 0, 32);
+    write_bits_u32(message_bits, 0U, 0U, 2U);
+    write_bits_u32(message_bits, 3U, test_case->scch_rep1, 5U);
+    write_bits_u32(message_bits, 8U, test_case->scch_rep2, 5U);
+    write_bits_u32(message_bits, 13U, test_case->scch_id, 11U);
+    message_bits[24] = test_case->scch_gu ? 1U : 0U;
+}
+
+static void
+nxdn_setup_fixture(const nxdn_case* test_case) {
+    DSD_MEMSET(&g_opts, 0, sizeof(g_opts));
+    DSD_MEMSET(&g_state, 0, sizeof(g_state));
+
+    g_opts.p25_trunk = 1;
+    g_opts.trunk_enable = 1;
+    g_opts.trunk_tune_group_calls = 1;
+    g_opts.trunk_tune_private_calls = 1;
+    g_opts.trunk_tune_data_calls = 1;
+    g_opts.trunk_hangtime = 1.0f;
+
+    g_state.p25_cc_freq = 935000000L;
+    g_state.trunk_cc_freq = 935000000L;
+    g_state.lastsynctype = DSD_SYNC_NXDN_POS;
+    g_state.last_vc_sync_time = time(NULL) - 4;
+    g_state.nxdn_rcn = test_case->use_dfa ? 1 : 0;
+
+    if (test_case->path == NXDN_MATRIX_TYPE_C) {
+        uint16_t map_channel = test_case->use_dfa ? test_case->ofn : test_case->channel;
+        g_state.trunk_chan_map[map_channel] = test_case->expected_freq;
+    } else {
+        g_state.trunk_chan_map[31] = g_state.p25_cc_freq;
+        g_state.trunk_chan_map[test_case->scch_rep1] = test_case->expected_freq;
+        g_state.trunk_chan_map[test_case->scch_rep2] = g_state.p25_cc_freq;
+    }
+
+    g_tune_count = 0;
+    g_last_tune_freq = 0;
+}
+
+static void
+nxdn_run_case_decode(const nxdn_case* test_case) {
+    uint8_t message[128];
+    if (test_case->path == NXDN_MATRIX_TYPE_C) {
+        build_vcall_assgn(message, test_case);
+        NXDN_decode_VCALL_ASSGN(&g_opts, &g_state, message);
+    } else {
+        build_scch(message, test_case);
+        NXDN_decode_scch(&g_opts, &g_state, message, 1);
+    }
+}
+
+static int
+nxdn_run_tune_result_case(const nxdn_case* test_case, dsd_trunk_tune_result result, const char* result_name) {
+    g_tune_result = result;
+    nxdn_setup_fixture(test_case);
+    nxdn_install_hooks();
+
+    nxdn_run_case_decode(test_case);
+
+    const int accepted = dsd_trunk_tune_result_is_ok(result);
+    int rc = 0;
+    rc |= nxdn_expect(g_tune_count == 1, test_case->name, result_name, "tune attempted once");
+    rc |= nxdn_expect(g_last_tune_freq == test_case->expected_freq, test_case->name, result_name,
+                      "tune frequency matches map");
+
+    if (accepted) {
+        rc |= nxdn_expect(g_opts.p25_is_tuned == 1 && g_opts.trunk_is_tuned == 1, test_case->name, result_name,
+                          "accepted tune set tuned flags");
+        rc |= nxdn_expect(g_state.p25_vc_freq[0] == test_case->expected_freq
+                              && g_state.trunk_vc_freq[0] == test_case->expected_freq,
+                          test_case->name, result_name, "accepted tune set VC frequency state");
+        rc |= nxdn_expect(g_state.lastsynctype == DSD_SYNC_NONE, test_case->name, result_name,
+                          "accepted tune reset last sync");
+        rc |= nxdn_expect(g_state.nxdn_sacch_frame_segment[0][0] == 1, test_case->name, result_name,
+                          "accepted tune reset SACCH segments");
+    } else {
+        rc |= nxdn_expect(g_opts.p25_is_tuned == 0 && g_opts.trunk_is_tuned == 0, test_case->name, result_name,
+                          "rejected tune left tuned flags clear");
+        rc |= nxdn_expect(g_state.p25_vc_freq[0] == 0 && g_state.trunk_vc_freq[0] == 0, test_case->name, result_name,
+                          "rejected tune left VC frequency state clear");
+        rc |= nxdn_expect(g_state.lastsynctype == DSD_SYNC_NXDN_POS, test_case->name, result_name,
+                          "rejected tune preserved last sync");
+        rc |= nxdn_expect(g_state.nxdn_sacch_frame_segment[0][0] == 0, test_case->name, result_name,
+                          "rejected tune did not reset SACCH segments");
+    }
+    return rc;
+}
+
+static uint16_t
+nxdn_case_map_channel(const nxdn_case* test_case) {
+    if (test_case->path == NXDN_MATRIX_TYPE_C) {
+        return test_case->use_dfa ? test_case->ofn : test_case->channel;
+    }
+    return test_case->scch_rep1;
+}
+
+static void
+nxdn_apply_no_tune_guard(nxdn_case* test_case, nxdn_guard_kind guard) {
+    switch (guard) {
+        case NXDN_GUARD_GROUP_DISABLED: g_opts.trunk_tune_group_calls = 0; break;
+        case NXDN_GUARD_PRIVATE_DISABLED: g_opts.trunk_tune_private_calls = 0; break;
+        case NXDN_GUARD_DATA_DISABLED: g_opts.trunk_tune_data_calls = 0; break;
+        case NXDN_GUARD_ALLOWLIST_BLOCK: g_opts.trunk_use_allow_list = 1; break;
+        case NXDN_GUARD_MISSING_FREQ: g_state.trunk_chan_map[nxdn_case_map_channel(test_case)] = 0; break;
+        case NXDN_GUARD_MISSING_CC:
+            g_state.p25_cc_freq = 0;
+            g_state.trunk_cc_freq = 0;
+            if (test_case->path == NXDN_MATRIX_TYPE_D) {
+                g_state.trunk_chan_map[31] = 0;
+                g_state.trunk_chan_map[test_case->scch_rep2] = 0;
+            }
+            break;
+        case NXDN_GUARD_SCCH_RECENT_ACTIVE: g_state.last_vc_sync_time = time(NULL); break;
+        case NXDN_GUARD_SCCH_REPEATER_ZERO:
+            test_case->scch_rep1 = 0U;
+            g_state.trunk_chan_map[nxdn_case_map_channel(test_case)] = 0;
+            break;
+    }
+}
+
+static int
+nxdn_run_no_tune_guard_case(const nxdn_case* base_case, nxdn_guard_kind guard, const char* guard_name) {
+    nxdn_case test_case = *base_case;
+    g_tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    nxdn_setup_fixture(&test_case);
+    nxdn_apply_no_tune_guard(&test_case, guard);
+    nxdn_install_hooks();
+
+    nxdn_run_case_decode(&test_case);
+
+    int rc = 0;
+    rc |= nxdn_expect(g_tune_count == 0, test_case.name, guard_name, "guard did not attempt tune");
+    rc |= nxdn_expect(g_last_tune_freq == 0, test_case.name, guard_name, "guard left tune frequency clear");
+    rc |= nxdn_expect(g_opts.p25_is_tuned == 0 && g_opts.trunk_is_tuned == 0, test_case.name, guard_name,
+                      "guard left tuned flags clear");
+    rc |= nxdn_expect(g_state.p25_vc_freq[0] == 0 && g_state.trunk_vc_freq[0] == 0, test_case.name, guard_name,
+                      "guard left VC frequency state clear");
+    rc |=
+        nxdn_expect(g_state.lastsynctype == DSD_SYNC_NXDN_POS, test_case.name, guard_name, "guard preserved last sync");
+    rc |= nxdn_expect(g_state.nxdn_sacch_frame_segment[0][0] == 0, test_case.name, guard_name,
+                      "guard did not reset SACCH segments");
+    return rc;
+}
+
+static int
+nxdn_run_retry_after_reject_case(const nxdn_case* test_case) {
+    g_tune_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    nxdn_setup_fixture(test_case);
+    nxdn_install_hooks();
+
+    nxdn_run_case_decode(test_case);
+
+    int rc = 0;
+    rc |= nxdn_expect(g_tune_count == 1, test_case->name, "retry-after-deferred", "deferred tune attempted");
+    rc |= nxdn_expect(g_opts.p25_is_tuned == 0 && g_state.trunk_vc_freq[0] == 0, test_case->name,
+                      "retry-after-deferred", "deferred tune left state clear");
+
+    g_tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    nxdn_run_case_decode(test_case);
+
+    rc |= nxdn_expect(g_tune_count == 2, test_case->name, "retry-after-deferred", "later grant retried tune");
+    rc |= nxdn_expect(g_last_tune_freq == test_case->expected_freq, test_case->name, "retry-after-deferred",
+                      "retried tune frequency matches map");
+    rc |= nxdn_expect(g_opts.p25_is_tuned == 1 && g_opts.trunk_is_tuned == 1, test_case->name, "retry-after-deferred",
+                      "retried tune set tuned flags");
+    rc |= nxdn_expect(g_state.p25_vc_freq[0] == test_case->expected_freq
+                          && g_state.trunk_vc_freq[0] == test_case->expected_freq,
+                      test_case->name, "retry-after-deferred", "retried tune set VC frequency state");
+    return rc;
+}
+
+static int
+nxdn_run_duplicate_no_tune_case(void) {
+    nxdn_case duplicate = {
+        "type-c-duplicate-no-tune", NXDN_MATRIX_TYPE_C, 0x05U, 1U, 2100U, 1100U, 16U, 0, 0, 0, 0, 0, 0, 936012500L,
+    };
+    g_tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    nxdn_setup_fixture(&duplicate);
+    g_opts.p25_is_tuned = 1;
+    g_opts.trunk_is_tuned = 1;
+    g_state.last_vc_sync_time = time(NULL);
+    g_state.p25_vc_freq[0] = duplicate.expected_freq;
+    g_state.trunk_vc_freq[0] = duplicate.expected_freq;
+
+    nxdn_install_hooks();
+
+    nxdn_run_case_decode(&duplicate);
+
+    int rc = 0;
+    rc |= nxdn_expect(g_tune_count == 0, duplicate.name, "duplicate", "duplicate grant did not tune");
+    rc |= nxdn_expect(g_opts.p25_is_tuned == 1 && g_opts.trunk_is_tuned == 1, duplicate.name, "duplicate",
+                      "duplicate grant preserved tuned flags");
+    rc |= nxdn_expect(g_state.p25_vc_freq[0] == duplicate.expected_freq, duplicate.name, "duplicate",
+                      "duplicate grant preserved existing VC frequency");
+    return rc;
+}
+
+static int
+nxdn_run_active_other_tg_no_tune_case(void) {
+    nxdn_case active = {
+        "type-c-active-other-tg-no-tune",
+        NXDN_MATRIX_TYPE_C,
+        0x04U,
+        1U,
+        2100U,
+        1100U,
+        16U,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        936012500L,
+    };
+    const long existing_freq = 936912500L;
+    g_tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    nxdn_setup_fixture(&active);
+    g_opts.p25_is_tuned = 1;
+    g_opts.trunk_is_tuned = 1;
+    g_state.p25_vc_freq[0] = existing_freq;
+    g_state.trunk_vc_freq[0] = existing_freq;
+    nxdn_install_hooks();
+
+    nxdn_run_case_decode(&active);
+
+    int rc = 0;
+    rc |= nxdn_expect(g_tune_count == 0, active.name, "active-other-tg", "active non-held call did not retune");
+    rc |= nxdn_expect(g_opts.p25_is_tuned == 1 && g_opts.trunk_is_tuned == 1, active.name, "active-other-tg",
+                      "active non-held call preserved tuned flags");
+    rc |= nxdn_expect(g_state.p25_vc_freq[0] == existing_freq && g_state.trunk_vc_freq[0] == existing_freq, active.name,
+                      "active-other-tg", "active non-held call preserved VC frequency");
+    return rc;
+}
+
+static int
+nxdn_run_hold_match_retune_case(void) {
+    nxdn_case hold = {
+        "type-c-hold-match-retune", NXDN_MATRIX_TYPE_C, 0x05U, 1U, 2100U, 1100U, 16U, 0, 0, 0, 0, 0, 0, 936012500L,
+    };
+    const long existing_freq = 936912500L;
+    g_tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    nxdn_setup_fixture(&hold);
+    g_opts.p25_is_tuned = 1;
+    g_opts.trunk_is_tuned = 1;
+    g_state.tg_hold = hold.target;
+    g_state.last_vc_sync_time = time(NULL);
+    g_state.p25_vc_freq[0] = existing_freq;
+    g_state.trunk_vc_freq[0] = existing_freq;
+    nxdn_install_hooks();
+
+    nxdn_run_case_decode(&hold);
+
+    int rc = 0;
+    rc |= nxdn_expect(g_tune_count == 1, hold.name, "hold-match", "held duplicate grant retuned");
+    rc |= nxdn_expect(g_last_tune_freq == hold.expected_freq, hold.name, "hold-match",
+                      "held duplicate tune frequency matches map");
+    rc |= nxdn_expect(g_state.p25_vc_freq[0] == hold.expected_freq && g_state.trunk_vc_freq[0] == hold.expected_freq,
+                      hold.name, "hold-match", "held duplicate updated VC frequency");
+    rc |= nxdn_expect(g_state.lastsynctype == DSD_SYNC_NONE, hold.name, "hold-match", "held duplicate reset last sync");
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    static const nxdn_case cases[] = {
+        {"type-c-group-normal-map", NXDN_MATRIX_TYPE_C, 0x04U, 1U, 2100U, 1100U, 16U, 0, 0, 0, 0, 0, 0, 936012500L},
+        {"type-c-private-normal-map", NXDN_MATRIX_TYPE_C, 0x04U, 4U, 9002U, 9001U, 17U, 0, 0, 0, 0, 0, 0, 936512500L},
+        {"type-c-data-normal-map", NXDN_MATRIX_TYPE_C, 0x0DU, 1U, 2200U, 1200U, 18U, 0, 0, 0, 0, 0, 0, 937012500L},
+        {"type-c-group-dfa-ofn-map", NXDN_MATRIX_TYPE_C, 0x04U, 1U, 2300U, 1300U, 0U, 1, 0x120U, 0, 0, 0, 0,
+         937512500L},
+        {"type-d-scch-group", NXDN_MATRIX_TYPE_D, 0U, 0U, 0U, 0U, 0U, 0, 0, 0, 6, 3, 1400U, 938012500L},
+        {"type-d-scch-private", NXDN_MATRIX_TYPE_D, 0U, 0U, 0U, 0U, 0U, 0, 0, 1, 7, 3, 1500U, 938512500L},
+    };
+
+    static const struct {
+        const char* name;
+        dsd_trunk_tune_result result;
+    } results[] = {
+        {"ok", DSD_TRUNK_TUNE_RESULT_OK},
+        {"pending", DSD_TRUNK_TUNE_RESULT_PENDING},
+        {"deferred", DSD_TRUNK_TUNE_RESULT_DEFERRED},
+        {"failed", DSD_TRUNK_TUNE_RESULT_FAILED},
+        {"timeout", DSD_TRUNK_TUNE_RESULT_TIMEOUT},
+    };
+
+    for (size_t c = 0; c < sizeof(cases) / sizeof(cases[0]); c++) {
+        for (size_t r = 0; r < sizeof(results) / sizeof(results[0]); r++) {
+            rc |= nxdn_run_tune_result_case(&cases[c], results[r].result, results[r].name);
+        }
+    }
+
+    static const struct {
+        size_t case_index;
+        nxdn_guard_kind guard;
+        const char* name;
+    } guard_cases[] = {
+        {0U, NXDN_GUARD_GROUP_DISABLED, "group-disabled"},
+        {1U, NXDN_GUARD_PRIVATE_DISABLED, "private-disabled"},
+        {2U, NXDN_GUARD_DATA_DISABLED, "data-disabled"},
+        {0U, NXDN_GUARD_ALLOWLIST_BLOCK, "allowlist-block"},
+        {0U, NXDN_GUARD_MISSING_FREQ, "missing-frequency"},
+        {0U, NXDN_GUARD_MISSING_CC, "missing-control-channel"},
+        {4U, NXDN_GUARD_GROUP_DISABLED, "scch-group-disabled"},
+        {5U, NXDN_GUARD_PRIVATE_DISABLED, "scch-private-disabled"},
+        {4U, NXDN_GUARD_ALLOWLIST_BLOCK, "scch-allowlist-block"},
+        {4U, NXDN_GUARD_MISSING_FREQ, "scch-missing-frequency"},
+        {4U, NXDN_GUARD_MISSING_CC, "scch-missing-control-channel"},
+        {4U, NXDN_GUARD_SCCH_RECENT_ACTIVE, "scch-recent-active"},
+        {4U, NXDN_GUARD_SCCH_REPEATER_ZERO, "scch-repeater-zero"},
+    };
+
+    for (size_t g = 0; g < sizeof(guard_cases) / sizeof(guard_cases[0]); g++) {
+        rc |= nxdn_run_no_tune_guard_case(&cases[guard_cases[g].case_index], guard_cases[g].guard, guard_cases[g].name);
+    }
+    rc |= nxdn_run_retry_after_reject_case(&cases[0]);
+    rc |= nxdn_run_retry_after_reject_case(&cases[4]);
+    rc |= nxdn_run_duplicate_no_tune_case();
+    rc |= nxdn_run_active_other_tg_no_tune_case();
+    rc |= nxdn_run_hold_match_retune_case();
+
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    if (rc == 0) {
+        printf("NXDN_GRANT_TUNE_MATRIX: OK\n");
+    }
+    return rc;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
+++ b/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
@@ -15,6 +15,7 @@
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
@@ -265,6 +266,7 @@ static void
 matrix_setup_fixture(matrix_fixture* fixture, const matrix_mode_case* mode) {
     double now_m = dsd_time_now_monotonic_s();
     DSD_MEMSET(fixture->opts, 0, sizeof(*fixture->opts));
+    dsd_state_ext_free_all(fixture->state);
     DSD_MEMSET(fixture->state, 0, sizeof(*fixture->state));
     DSD_MEMSET(&fixture->ctx, 0, sizeof(fixture->ctx));
 
@@ -736,6 +738,7 @@ main(void) {
     }
 
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    dsd_state_ext_free_all(g_fixture.state);
     if (rc != 0) {
         return 1;
     }

--- a/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
+++ b/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
@@ -393,111 +393,124 @@ matrix_drive_to_cc(matrix_fixture* fixture, const matrix_mode_case* mode, const 
     return rc;
 }
 
+static void
+matrix_send_event(matrix_fixture* fixture, const p25_sm_event_t* ev) {
+    p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, ev);
+}
+
+static void
+matrix_tick_expired_voice(matrix_fixture* fixture) {
+    matrix_age_tuned_timers(fixture);
+    p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+}
+
+static void
+matrix_flow_grant_timeout(matrix_fixture* fixture) {
+    matrix_age_tuned_timers(fixture);
+    fixture->ctx.t_voice_m = 0.0;
+    p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+}
+
+static void
+matrix_flow_vc_sync_hang(matrix_fixture* fixture, int event_slot) {
+    p25_sm_event_t ev = {0};
+    ev.type = P25_SM_EV_VC_SYNC;
+    ev.slot = event_slot;
+    matrix_send_event(fixture, &ev);
+    matrix_tick_expired_voice(fixture);
+}
+
+static void
+matrix_flow_idle_hang(matrix_fixture* fixture, int event_slot, int use_active) {
+    p25_sm_event_t ev = use_active ? p25_sm_ev_active(event_slot) : p25_sm_ev_ptt(event_slot);
+    matrix_send_event(fixture, &ev);
+    fixture->state->p25_p2_audio_allowed[event_slot] = 1;
+    ev = p25_sm_ev_idle(event_slot);
+    matrix_send_event(fixture, &ev);
+    fixture->state->p25_p2_audio_allowed[event_slot] = 0;
+    matrix_tick_expired_voice(fixture);
+}
+
+static void
+matrix_flow_explicit_end(matrix_fixture* fixture, int event_slot) {
+    p25_sm_event_t ev = p25_sm_ev_ptt(event_slot);
+    matrix_send_event(fixture, &ev);
+    fixture->state->p25_p2_audio_allowed[event_slot] = 1;
+    fixture->state->p25_p2_audio_ring_count[event_slot] = 3;
+    ev = p25_sm_ev_end(event_slot);
+    matrix_send_event(fixture, &ev);
+}
+
+static void
+matrix_flow_tdu(matrix_fixture* fixture) {
+    p25_sm_event_t ev = p25_sm_ev_ptt(0);
+    matrix_send_event(fixture, &ev);
+    fixture->state->p25_p2_audio_allowed[0] = 1;
+    ev = p25_sm_ev_tdu();
+    matrix_send_event(fixture, &ev);
+}
+
+static int
+matrix_flow_dual_partial_end(matrix_fixture* fixture, const matrix_mode_case* mode, const matrix_flow_case* flow,
+                             const matrix_return_script* script) {
+    p25_sm_event_t ev = p25_sm_ev_ptt(0);
+    matrix_send_event(fixture, &ev);
+    ev = p25_sm_ev_ptt(1);
+    matrix_send_event(fixture, &ev);
+    fixture->state->p25_p2_audio_allowed[0] = 1;
+    fixture->state->p25_p2_audio_allowed[1] = 1;
+
+    ev = p25_sm_ev_end(0);
+    matrix_send_event(fixture, &ev);
+
+    int rc = 0;
+    rc |= matrix_expect(fixture->ctx.state == P25_SM_TUNED, mode->name, flow->name, script->name,
+                        "partial dual-slot end remains tuned");
+    rc |= matrix_expect(g_hooks.return_calls == 0, mode->name, flow->name, script->name,
+                        "partial dual-slot end does not return");
+
+    fixture->state->p25_p2_audio_allowed[1] = 0;
+    ev = p25_sm_ev_end(1);
+    matrix_send_event(fixture, &ev);
+    return rc;
+}
+
+static void
+matrix_flow_force_release(matrix_fixture* fixture, int event_slot) {
+    p25_sm_event_t ev = p25_sm_ev_ptt(event_slot);
+    matrix_send_event(fixture, &ev);
+    fixture->state->p25_p2_audio_allowed[event_slot] = 1;
+    fixture->state->p25_sm_force_release = 1;
+    p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+}
+
+static void
+matrix_flow_enc_lockout(matrix_fixture* fixture, int event_slot) {
+    fixture->opts->trunk_tune_enc_calls = 0;
+    p25_sm_event_t ev = p25_sm_ev_ptt(event_slot);
+    matrix_send_event(fixture, &ev);
+    fixture->state->p25_p2_audio_allowed[event_slot] = 1;
+    ev = p25_sm_ev_enc(event_slot, 0x84, 0x1234, 2000);
+    matrix_send_event(fixture, &ev);
+}
+
 static int
 matrix_apply_terminal_flow(matrix_fixture* fixture, const matrix_mode_case* mode, const matrix_flow_case* flow,
                            const matrix_return_script* script) {
     int slot = matrix_expected_slot(mode);
     int event_slot = (slot >= 0) ? slot : 0;
-    p25_sm_event_t ev;
     int rc = 0;
 
     switch (flow->kind) {
-        case MATRIX_FLOW_GRANT_TIMEOUT:
-            matrix_age_tuned_timers(fixture);
-            fixture->ctx.t_voice_m = 0.0;
-            p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
-            break;
-
-        case MATRIX_FLOW_VC_SYNC_HANG:
-            ev.type = P25_SM_EV_VC_SYNC;
-            ev.slot = event_slot;
-            ev.channel = 0;
-            ev.freq_hz = 0;
-            ev.tg = 0;
-            ev.src = 0;
-            ev.dst = 0;
-            ev.svc_bits = 0;
-            ev.is_group = 0;
-            ev.algid = 0;
-            ev.keyid = 0;
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            matrix_age_tuned_timers(fixture);
-            p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
-            break;
-
-        case MATRIX_FLOW_PTT_IDLE_HANG:
-            ev = p25_sm_ev_ptt(event_slot);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            fixture->state->p25_p2_audio_allowed[event_slot] = 1;
-            ev = p25_sm_ev_idle(event_slot);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            fixture->state->p25_p2_audio_allowed[event_slot] = 0;
-            matrix_age_tuned_timers(fixture);
-            p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
-            break;
-
-        case MATRIX_FLOW_ACTIVE_IDLE_HANG:
-            ev = p25_sm_ev_active(event_slot);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            fixture->state->p25_p2_audio_allowed[event_slot] = 1;
-            ev = p25_sm_ev_idle(event_slot);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            fixture->state->p25_p2_audio_allowed[event_slot] = 0;
-            matrix_age_tuned_timers(fixture);
-            p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
-            break;
-
-        case MATRIX_FLOW_EXPLICIT_END:
-            ev = p25_sm_ev_ptt(event_slot);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            fixture->state->p25_p2_audio_allowed[event_slot] = 1;
-            fixture->state->p25_p2_audio_ring_count[event_slot] = 3;
-            ev = p25_sm_ev_end(event_slot);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            break;
-
-        case MATRIX_FLOW_TDU:
-            ev = p25_sm_ev_ptt(0);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            fixture->state->p25_p2_audio_allowed[0] = 1;
-            ev = p25_sm_ev_tdu();
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            break;
-
-        case MATRIX_FLOW_DUAL_PARTIAL_END:
-            ev = p25_sm_ev_ptt(0);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            ev = p25_sm_ev_ptt(1);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            fixture->state->p25_p2_audio_allowed[0] = 1;
-            fixture->state->p25_p2_audio_allowed[1] = 1;
-            ev = p25_sm_ev_end(0);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            rc |= matrix_expect(fixture->ctx.state == P25_SM_TUNED, mode->name, flow->name, script->name,
-                                "partial dual-slot end remains tuned");
-            rc |= matrix_expect(g_hooks.return_calls == 0, mode->name, flow->name, script->name,
-                                "partial dual-slot end does not return");
-            fixture->state->p25_p2_audio_allowed[1] = 0;
-            ev = p25_sm_ev_end(1);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            break;
-
-        case MATRIX_FLOW_FORCE_RELEASE:
-            ev = p25_sm_ev_ptt(event_slot);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            fixture->state->p25_p2_audio_allowed[event_slot] = 1;
-            fixture->state->p25_sm_force_release = 1;
-            p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
-            break;
-
-        case MATRIX_FLOW_ENC_LOCKOUT:
-            fixture->opts->trunk_tune_enc_calls = 0;
-            ev = p25_sm_ev_ptt(event_slot);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            fixture->state->p25_p2_audio_allowed[event_slot] = 1;
-            ev = p25_sm_ev_enc(event_slot, 0x84, 0x1234, 2000);
-            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
-            break;
+        case MATRIX_FLOW_GRANT_TIMEOUT: matrix_flow_grant_timeout(fixture); break;
+        case MATRIX_FLOW_VC_SYNC_HANG: matrix_flow_vc_sync_hang(fixture, event_slot); break;
+        case MATRIX_FLOW_PTT_IDLE_HANG: matrix_flow_idle_hang(fixture, event_slot, 0); break;
+        case MATRIX_FLOW_ACTIVE_IDLE_HANG: matrix_flow_idle_hang(fixture, event_slot, 1); break;
+        case MATRIX_FLOW_EXPLICIT_END: matrix_flow_explicit_end(fixture, event_slot); break;
+        case MATRIX_FLOW_TDU: matrix_flow_tdu(fixture); break;
+        case MATRIX_FLOW_DUAL_PARTIAL_END: rc |= matrix_flow_dual_partial_end(fixture, mode, flow, script); break;
+        case MATRIX_FLOW_FORCE_RELEASE: matrix_flow_force_release(fixture, event_slot); break;
+        case MATRIX_FLOW_ENC_LOCKOUT: matrix_flow_enc_lockout(fixture, event_slot); break;
     }
 
     rc |= matrix_drive_to_cc(fixture, mode, flow, script);

--- a/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
+++ b/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
@@ -1,0 +1,748 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Bounded return-to-control-channel stress matrix for the unified P25 trunk SM.
+ *
+ * The harness drives p25_sm_event()/p25_sm_tick_ctx() directly and injects
+ * tune outcomes through runtime trunk-tuning hooks. It keeps the matrix small
+ * enough for normal CTest while exercising the mode, terminal-event, and
+ * retune-result combinations that can wedge CC return.
+ */
+
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/trunk_cc_candidates.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdio.h>
+#include <time.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+enum {
+    MATRIX_BASE_CC_HZ = 851000000,
+    MATRIX_IDEN_FDMA_C4FM = 1,
+    MATRIX_IDEN_FDMA_QPSK = 2,
+    MATRIX_IDEN_MIXED_P1CC_P2VC = 3,
+    MATRIX_IDEN_P2CC_P2VC = 4,
+    MATRIX_IDEN_AMBIG_P1 = 5,
+    MATRIX_IDEN_AMBIG_P2 = 6,
+};
+
+typedef struct {
+    const char* name;
+    int iden;
+    int low_channel;
+    int synctype;
+    int cc_is_tdma;
+    int sys_is_tdma;
+    int tdma_hint;
+    int populate_fdma;
+    int populate_tdma;
+    int initial_rf_mod;
+    int mod_qpsk;
+    int expect_tdma;
+} matrix_mode_case;
+
+typedef enum {
+    MATRIX_FLOW_GRANT_TIMEOUT = 0,
+    MATRIX_FLOW_VC_SYNC_HANG,
+    MATRIX_FLOW_PTT_IDLE_HANG,
+    MATRIX_FLOW_ACTIVE_IDLE_HANG,
+    MATRIX_FLOW_EXPLICIT_END,
+    MATRIX_FLOW_TDU,
+    MATRIX_FLOW_DUAL_PARTIAL_END,
+    MATRIX_FLOW_FORCE_RELEASE,
+    MATRIX_FLOW_ENC_LOCKOUT,
+} matrix_flow_kind;
+
+typedef struct {
+    const char* name;
+    matrix_flow_kind kind;
+    int tdma_only;
+    int fdma_only;
+} matrix_flow_case;
+
+typedef struct {
+    const char* name;
+    dsd_trunk_tune_result results[2];
+    int count;
+} matrix_return_script;
+
+typedef struct {
+    dsd_opts* opts;
+    dsd_state* state;
+    p25_sm_ctx_t ctx;
+} matrix_fixture;
+
+typedef struct {
+    dsd_trunk_tune_result vc_results[4];
+    int vc_count;
+    int vc_pos;
+    dsd_trunk_tune_result return_results[4];
+    int return_count;
+    int return_pos;
+    dsd_trunk_tune_result cc_results[4];
+    int cc_count;
+    int cc_pos;
+    int vc_calls;
+    int return_calls;
+    int cc_calls;
+    long last_vc_freq;
+    long last_cc_freq;
+    int last_vc_sps;
+    int last_cc_sps;
+} matrix_hook_state;
+
+static matrix_hook_state g_hooks;
+static dsd_opts g_fixture_opts;
+static dsd_state g_fixture_state;
+static matrix_fixture g_fixture = {&g_fixture_opts, &g_fixture_state, {0}};
+
+static const matrix_mode_case g_modes[] = {
+    {"p1-fdma-c4fm", MATRIX_IDEN_FDMA_C4FM, 10, DSD_SYNC_P25P1_POS, 0, 0, 0x01, 1, 0, 0, 0, 0},
+    {"p1-fdma-qpsk", MATRIX_IDEN_FDMA_QPSK, 11, DSD_SYNC_P25P1_POS, 0, 0, 0x01, 1, 0, 1, 1, 0},
+    {"mixed-p1cc-p2vc", MATRIX_IDEN_MIXED_P1CC_P2VC, 3, DSD_SYNC_P25P1_POS, 0, 1, 0x02, 0, 1, 0, 0, 1},
+    {"p2cc-p2vc", MATRIX_IDEN_P2CC_P2VC, 3, DSD_SYNC_P25P2_POS, 1, 1, 0x02, 0, 1, 1, 1, 1},
+    {"ambig-p1-context", MATRIX_IDEN_AMBIG_P1, 13, DSD_SYNC_P25P1_POS, 0, 0, 0x03, 1, 1, 0, 0, 0},
+    {"ambig-p2-context", MATRIX_IDEN_AMBIG_P2, 3, DSD_SYNC_P25P2_POS, 1, 1, 0x03, 1, 1, 1, 1, 1},
+};
+
+static const matrix_flow_case g_flows[] = {
+    {"grant-timeout", MATRIX_FLOW_GRANT_TIMEOUT, 0, 0},
+    {"vc-sync-hang", MATRIX_FLOW_VC_SYNC_HANG, 0, 0},
+    {"ptt-idle-hang", MATRIX_FLOW_PTT_IDLE_HANG, 0, 0},
+    {"active-idle-hang", MATRIX_FLOW_ACTIVE_IDLE_HANG, 0, 0},
+    {"explicit-end", MATRIX_FLOW_EXPLICIT_END, 0, 0},
+    {"p1-tdu", MATRIX_FLOW_TDU, 0, 1},
+    {"dual-slot-partial-end", MATRIX_FLOW_DUAL_PARTIAL_END, 1, 0},
+    {"forced-release", MATRIX_FLOW_FORCE_RELEASE, 0, 0},
+    {"enc-lockout", MATRIX_FLOW_ENC_LOCKOUT, 0, 0},
+};
+
+static const matrix_return_script g_return_scripts[] = {
+    {"ok", {DSD_TRUNK_TUNE_RESULT_OK, DSD_TRUNK_TUNE_RESULT_OK}, 1},
+    {"pending", {DSD_TRUNK_TUNE_RESULT_PENDING, DSD_TRUNK_TUNE_RESULT_OK}, 1},
+    {"deferred-then-ok", {DSD_TRUNK_TUNE_RESULT_DEFERRED, DSD_TRUNK_TUNE_RESULT_OK}, 2},
+    {"failed-then-ok", {DSD_TRUNK_TUNE_RESULT_FAILED, DSD_TRUNK_TUNE_RESULT_OK}, 2},
+    {"timeout-then-ok", {DSD_TRUNK_TUNE_RESULT_TIMEOUT, DSD_TRUNK_TUNE_RESULT_OK}, 2},
+};
+
+static void
+matrix_hook_reset(void) {
+    DSD_MEMSET(&g_hooks, 0, sizeof(g_hooks));
+}
+
+static dsd_trunk_tune_result
+matrix_pop_result(dsd_trunk_tune_result* results, int count, int* pos) {
+    if (!results || !pos || count <= 0) {
+        return DSD_TRUNK_TUNE_RESULT_OK;
+    }
+    int idx = (*pos < count) ? *pos : (count - 1);
+    (*pos)++;
+    return results[idx];
+}
+
+static dsd_trunk_tune_result
+matrix_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    dsd_trunk_tune_result result = matrix_pop_result(g_hooks.vc_results, g_hooks.vc_count, &g_hooks.vc_pos);
+    g_hooks.vc_calls++;
+    g_hooks.last_vc_freq = freq;
+    g_hooks.last_vc_sps = ted_sps;
+
+    if (dsd_trunk_tune_result_is_ok(result)) {
+        double now_m = dsd_time_now_monotonic_s();
+        if (opts) {
+            opts->p25_is_tuned = 1;
+            opts->trunk_is_tuned = 1;
+        }
+        if (state) {
+            state->p25_vc_freq[0] = freq;
+            state->p25_vc_freq[1] = freq;
+            state->trunk_vc_freq[0] = freq;
+            state->trunk_vc_freq[1] = freq;
+            state->last_vc_sync_time = time(NULL);
+            state->last_vc_sync_time_m = now_m;
+            state->p25_last_vc_tune_time = state->last_vc_sync_time;
+            state->p25_last_vc_tune_time_m = now_m;
+        }
+    }
+    return result;
+}
+
+static dsd_trunk_tune_result
+matrix_return_to_cc(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_hooks.return_calls++;
+    return matrix_pop_result(g_hooks.return_results, g_hooks.return_count, &g_hooks.return_pos);
+}
+
+static dsd_trunk_tune_result
+matrix_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    (void)opts;
+    dsd_trunk_tune_result result = matrix_pop_result(g_hooks.cc_results, g_hooks.cc_count, &g_hooks.cc_pos);
+    g_hooks.cc_calls++;
+    g_hooks.last_cc_freq = freq;
+    g_hooks.last_cc_sps = ted_sps;
+
+    if (dsd_trunk_tune_result_is_ok(result) && state) {
+        state->trunk_cc_freq = freq;
+        state->last_cc_sync_time = time(NULL);
+        state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
+    }
+    return result;
+}
+
+static void
+matrix_install_hooks(void) {
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_freq_result = matrix_tune_to_freq;
+    hooks.return_to_cc_result = matrix_return_to_cc;
+    hooks.tune_to_cc_result = matrix_tune_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+}
+
+static int
+matrix_expect(int cond, const char* mode, const char* flow, const char* script, const char* check) {
+    if (cond) {
+        return 0;
+    }
+    DSD_FPRINTF(stderr, "FAIL mode=%s flow=%s script=%s check=%s\n", mode, flow, script, check);
+    return 1;
+}
+
+static void
+matrix_seed_fdma(dsd_state* state, int iden) {
+    state->p25_iden_fdma[iden].base_freq = MATRIX_BASE_CC_HZ / 5;
+    state->p25_iden_fdma[iden].chan_type = 1;
+    state->p25_iden_fdma[iden].chan_spac = 100;
+    state->p25_iden_fdma[iden].trust = 2;
+    state->p25_iden_fdma[iden].populated = 1;
+}
+
+static void
+matrix_seed_tdma(dsd_state* state, int iden) {
+    state->p25_iden_tdma[iden].base_freq = MATRIX_BASE_CC_HZ / 5;
+    state->p25_iden_tdma[iden].chan_type = 3;
+    state->p25_iden_tdma[iden].chan_spac = 100;
+    state->p25_iden_tdma[iden].trust = 2;
+    state->p25_iden_tdma[iden].populated = 1;
+}
+
+static int
+matrix_channel(const matrix_mode_case* mode) {
+    return (mode->iden << 12) | (mode->low_channel & 0x0FFF);
+}
+
+static int
+matrix_expected_slot(const matrix_mode_case* mode) {
+    return mode->expect_tdma ? (mode->low_channel & 1) : -1;
+}
+
+static int
+matrix_expected_sps(const matrix_fixture* fixture, const matrix_mode_case* mode) {
+    return dsd_opts_compute_sps_rate(fixture->opts, mode->expect_tdma ? 6000 : 4800, 0);
+}
+
+static int
+matrix_expected_cc_sps(const matrix_fixture* fixture, const matrix_mode_case* mode) {
+    return dsd_opts_compute_sps_rate(fixture->opts, mode->cc_is_tdma == 1 ? 6000 : 4800, 0);
+}
+
+static void
+matrix_setup_fixture(matrix_fixture* fixture, const matrix_mode_case* mode) {
+    double now_m = dsd_time_now_monotonic_s();
+    DSD_MEMSET(fixture->opts, 0, sizeof(*fixture->opts));
+    DSD_MEMSET(fixture->state, 0, sizeof(*fixture->state));
+    DSD_MEMSET(&fixture->ctx, 0, sizeof(fixture->ctx));
+
+    fixture->opts->p25_trunk = 1;
+    fixture->opts->trunk_enable = 1;
+    fixture->opts->trunk_tune_group_calls = 1;
+    fixture->opts->trunk_tune_private_calls = 1;
+    fixture->opts->trunk_tune_enc_calls = 1;
+    fixture->opts->p25_prefer_candidates = 1;
+    fixture->opts->trunk_hangtime = 0.2f;
+    fixture->opts->p25_grant_voice_to_s = 0.2;
+    fixture->opts->mod_qpsk = mode->mod_qpsk;
+    fixture->opts->verbose = 0;
+
+    fixture->state->p25_cc_freq = MATRIX_BASE_CC_HZ;
+    fixture->state->trunk_cc_freq = MATRIX_BASE_CC_HZ;
+    fixture->state->last_cc_sync_time = time(NULL);
+    fixture->state->last_cc_sync_time_m = now_m;
+    fixture->state->nac = 0x293;
+    fixture->state->p2_cc = 0x293;
+    fixture->state->synctype = mode->synctype;
+    fixture->state->lastsynctype = mode->synctype;
+    fixture->state->p25_cc_is_tdma = mode->cc_is_tdma;
+    fixture->state->p25_sys_is_tdma = mode->sys_is_tdma;
+    fixture->state->p25_chan_tdma_explicit[mode->iden] = mode->tdma_hint;
+    fixture->state->p25_vc_cqpsk_pref = -1;
+    fixture->state->p25_vc_cqpsk_override = -1;
+    fixture->state->rf_mod = mode->initial_rf_mod;
+    fixture->state->p25_p2_active_slot = -1;
+
+    if (mode->populate_fdma) {
+        matrix_seed_fdma(fixture->state, mode->iden);
+    }
+    if (mode->populate_tdma) {
+        matrix_seed_tdma(fixture->state, mode->iden);
+    }
+
+    p25_sm_init_ctx(&fixture->ctx, fixture->opts, fixture->state);
+    fixture->ctx.config.hangtime_s = 0.2;
+    fixture->ctx.config.grant_timeout_s = 0.2;
+    fixture->ctx.config.cc_grace_s = 0.2;
+}
+
+static matrix_fixture*
+matrix_reset_fixture(const matrix_mode_case* mode) {
+    g_fixture.opts = &g_fixture_opts;
+    g_fixture.state = &g_fixture_state;
+    matrix_setup_fixture(&g_fixture, mode);
+    return &g_fixture;
+}
+
+static p25_sm_event_t
+matrix_group_grant(const matrix_mode_case* mode, int tg) {
+    return p25_sm_ev_group_grant(matrix_channel(mode), 0, tg, 1000 + tg, 0);
+}
+
+static p25_sm_event_t
+matrix_indiv_grant(const matrix_mode_case* mode, int dst) {
+    return p25_sm_ev_indiv_grant(matrix_channel(mode), 0, dst, 7000 + dst, 0);
+}
+
+static int
+matrix_send_initial_grant(matrix_fixture* fixture, const matrix_mode_case* mode, int use_indiv, const char* flow,
+                          const char* script) {
+    p25_sm_event_t ev = use_indiv ? matrix_indiv_grant(mode, 3000) : matrix_group_grant(mode, 2000);
+    p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+
+    int rc = 0;
+    rc |= matrix_expect(g_hooks.vc_calls == 1, mode->name, flow, script, "initial grant called tune once");
+    rc |= matrix_expect(fixture->ctx.state == P25_SM_TUNED, mode->name, flow, script, "grant reached TUNED");
+    rc |= matrix_expect(fixture->opts->p25_is_tuned == 1 && fixture->opts->trunk_is_tuned == 1, mode->name, flow,
+                        script, "grant set tuned flags");
+    rc |= matrix_expect(g_hooks.last_vc_sps == matrix_expected_sps(fixture, mode), mode->name, flow, script,
+                        "grant sps matches mode");
+    rc |= matrix_expect(fixture->state->samplesPerSymbol == matrix_expected_sps(fixture, mode), mode->name, flow,
+                        script, "state sps matches mode");
+    rc |= matrix_expect(fixture->state->symbolCenter == dsd_opts_symbol_center(matrix_expected_sps(fixture, mode)),
+                        mode->name, flow, script, "state symbol center matches mode");
+    rc |= matrix_expect(fixture->state->p25_p2_active_slot == matrix_expected_slot(mode), mode->name, flow, script,
+                        "active slot matches mode");
+    rc |= matrix_expect(fixture->ctx.vc_is_tdma == mode->expect_tdma, mode->name, flow, script,
+                        "ctx tdma flag matches mode");
+    rc |= matrix_expect(fixture->state->rf_mod == (mode->expect_tdma ? 1 : mode->initial_rf_mod), mode->name, flow,
+                        script, "rf_mod matches mode");
+    return rc;
+}
+
+static void
+matrix_age_tuned_timers(matrix_fixture* fixture) {
+    double now_m = dsd_time_now_monotonic_s();
+    fixture->ctx.t_tune_m = now_m - 1.0;
+    fixture->ctx.t_voice_m = now_m - 1.0;
+    fixture->state->last_vc_sync_time = time(NULL) - 1;
+    fixture->state->last_vc_sync_time_m = now_m - 1.0;
+    fixture->state->p25_last_vc_tune_time = time(NULL) - 1;
+    fixture->state->p25_last_vc_tune_time_m = now_m - 1.0;
+}
+
+static int
+matrix_drive_to_cc(matrix_fixture* fixture, const matrix_mode_case* mode, const matrix_flow_case* flow,
+                   const matrix_return_script* script) {
+    for (int i = 0; i < 4 && fixture->ctx.state != P25_SM_ON_CC; i++) {
+        matrix_age_tuned_timers(fixture);
+        p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+    }
+
+    int rc = 0;
+    rc |= matrix_expect(fixture->ctx.state == P25_SM_ON_CC, mode->name, flow->name, script->name, "returned to ON_CC");
+    rc |= matrix_expect(fixture->opts->p25_is_tuned == 0 && fixture->opts->trunk_is_tuned == 0, mode->name, flow->name,
+                        script->name, "tuned flags cleared");
+    rc |= matrix_expect(fixture->state->p25_vc_freq[0] == 0 && fixture->state->p25_vc_freq[1] == 0, mode->name,
+                        flow->name, script->name, "p25 vc frequencies cleared");
+    rc |= matrix_expect(fixture->state->trunk_vc_freq[0] == 0 && fixture->state->trunk_vc_freq[1] == 0, mode->name,
+                        flow->name, script->name, "trunk vc frequencies cleared");
+    rc |= matrix_expect(fixture->state->p25_p2_active_slot == -1, mode->name, flow->name, script->name,
+                        "active slot reset");
+    rc |= matrix_expect(fixture->state->p25_p2_audio_allowed[0] == 0 && fixture->state->p25_p2_audio_allowed[1] == 0,
+                        mode->name, flow->name, script->name, "audio gates cleared");
+    rc |= matrix_expect(fixture->ctx.vc_freq_hz == 0 && fixture->ctx.slots[0].voice_active == 0
+                            && fixture->ctx.slots[1].voice_active == 0,
+                        mode->name, flow->name, script->name, "ctx vc state cleared");
+    rc |= matrix_expect(g_hooks.return_calls == script->count, mode->name, flow->name, script->name,
+                        "return-to-cc call count matches script");
+    return rc;
+}
+
+static int
+matrix_apply_terminal_flow(matrix_fixture* fixture, const matrix_mode_case* mode, const matrix_flow_case* flow,
+                           const matrix_return_script* script) {
+    int slot = matrix_expected_slot(mode);
+    int event_slot = (slot >= 0) ? slot : 0;
+    p25_sm_event_t ev;
+    int rc = 0;
+
+    switch (flow->kind) {
+        case MATRIX_FLOW_GRANT_TIMEOUT:
+            matrix_age_tuned_timers(fixture);
+            fixture->ctx.t_voice_m = 0.0;
+            p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+            break;
+
+        case MATRIX_FLOW_VC_SYNC_HANG:
+            ev.type = P25_SM_EV_VC_SYNC;
+            ev.slot = event_slot;
+            ev.channel = 0;
+            ev.freq_hz = 0;
+            ev.tg = 0;
+            ev.src = 0;
+            ev.dst = 0;
+            ev.svc_bits = 0;
+            ev.is_group = 0;
+            ev.algid = 0;
+            ev.keyid = 0;
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            matrix_age_tuned_timers(fixture);
+            p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+            break;
+
+        case MATRIX_FLOW_PTT_IDLE_HANG:
+            ev = p25_sm_ev_ptt(event_slot);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            fixture->state->p25_p2_audio_allowed[event_slot] = 1;
+            ev = p25_sm_ev_idle(event_slot);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            fixture->state->p25_p2_audio_allowed[event_slot] = 0;
+            matrix_age_tuned_timers(fixture);
+            p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+            break;
+
+        case MATRIX_FLOW_ACTIVE_IDLE_HANG:
+            ev = p25_sm_ev_active(event_slot);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            fixture->state->p25_p2_audio_allowed[event_slot] = 1;
+            ev = p25_sm_ev_idle(event_slot);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            fixture->state->p25_p2_audio_allowed[event_slot] = 0;
+            matrix_age_tuned_timers(fixture);
+            p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+            break;
+
+        case MATRIX_FLOW_EXPLICIT_END:
+            ev = p25_sm_ev_ptt(event_slot);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            fixture->state->p25_p2_audio_allowed[event_slot] = 1;
+            fixture->state->p25_p2_audio_ring_count[event_slot] = 3;
+            ev = p25_sm_ev_end(event_slot);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            break;
+
+        case MATRIX_FLOW_TDU:
+            ev = p25_sm_ev_ptt(0);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            fixture->state->p25_p2_audio_allowed[0] = 1;
+            ev = p25_sm_ev_tdu();
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            break;
+
+        case MATRIX_FLOW_DUAL_PARTIAL_END:
+            ev = p25_sm_ev_ptt(0);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            ev = p25_sm_ev_ptt(1);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            fixture->state->p25_p2_audio_allowed[0] = 1;
+            fixture->state->p25_p2_audio_allowed[1] = 1;
+            ev = p25_sm_ev_end(0);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            rc |= matrix_expect(fixture->ctx.state == P25_SM_TUNED, mode->name, flow->name, script->name,
+                                "partial dual-slot end remains tuned");
+            rc |= matrix_expect(g_hooks.return_calls == 0, mode->name, flow->name, script->name,
+                                "partial dual-slot end does not return");
+            fixture->state->p25_p2_audio_allowed[1] = 0;
+            ev = p25_sm_ev_end(1);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            break;
+
+        case MATRIX_FLOW_FORCE_RELEASE:
+            ev = p25_sm_ev_ptt(event_slot);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            fixture->state->p25_p2_audio_allowed[event_slot] = 1;
+            fixture->state->p25_sm_force_release = 1;
+            p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+            break;
+
+        case MATRIX_FLOW_ENC_LOCKOUT:
+            fixture->opts->trunk_tune_enc_calls = 0;
+            ev = p25_sm_ev_ptt(event_slot);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            fixture->state->p25_p2_audio_allowed[event_slot] = 1;
+            ev = p25_sm_ev_enc(event_slot, 0x84, 0x1234, 2000);
+            p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+            break;
+    }
+
+    rc |= matrix_drive_to_cc(fixture, mode, flow, script);
+    return rc;
+}
+
+static int
+matrix_run_terminal_case(const matrix_mode_case* mode, const matrix_flow_case* flow,
+                         const matrix_return_script* script) {
+    if ((flow->tdma_only && !mode->expect_tdma) || (flow->fdma_only && mode->expect_tdma)) {
+        return 0;
+    }
+
+    matrix_fixture* fixture;
+    matrix_hook_reset();
+    g_hooks.vc_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.vc_count = 1;
+    for (int i = 0; i < script->count; i++) {
+        g_hooks.return_results[i] = script->results[i];
+    }
+    g_hooks.return_count = script->count;
+    matrix_install_hooks();
+    fixture = matrix_reset_fixture(mode);
+
+    int rc = matrix_send_initial_grant(fixture, mode, 0, flow->name, script->name);
+    if (rc != 0) {
+        return rc;
+    }
+    return matrix_apply_terminal_flow(fixture, mode, flow, script);
+}
+
+static int
+matrix_run_initial_tune_reject_case(const matrix_mode_case* mode, dsd_trunk_tune_result result, const char* name) {
+    matrix_fixture* fixture;
+    matrix_hook_reset();
+    g_hooks.vc_results[0] = result;
+    g_hooks.vc_count = 1;
+    matrix_install_hooks();
+    fixture = matrix_reset_fixture(mode);
+
+    p25_sm_event_t ev = matrix_group_grant(mode, 2200);
+    p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+
+    int rc = 0;
+    rc |= matrix_expect(g_hooks.vc_calls == 1, mode->name, "initial-tune", name, "vc tune attempted");
+    rc |= matrix_expect(fixture->ctx.state == P25_SM_ON_CC, mode->name, "initial-tune", name,
+                        "failed/deferred vc tune stays ON_CC");
+    rc |= matrix_expect(fixture->opts->p25_is_tuned == 0 && fixture->opts->trunk_is_tuned == 0, mode->name,
+                        "initial-tune", name, "failed/deferred vc tune leaves tuned flags clear");
+    rc |= matrix_expect(fixture->state->p25_vc_freq[0] == 0 && fixture->state->trunk_vc_freq[0] == 0, mode->name,
+                        "initial-tune", name, "failed/deferred vc tune leaves vc frequencies clear");
+    rc |= matrix_expect(fixture->state->p25_sm_tune_count == 0, mode->name, "initial-tune", name,
+                        "failed/deferred vc tune does not increment counter");
+    rc |= matrix_expect(fixture->state->p25_p2_active_slot == -1, mode->name, "initial-tune", name,
+                        "failed/deferred vc tune restores active slot");
+    rc |= matrix_expect(fixture->state->rf_mod == mode->initial_rf_mod, mode->name, "initial-tune", name,
+                        "failed/deferred vc tune restores rf_mod");
+    return rc;
+}
+
+static int
+matrix_run_active_no_terminal_case(const matrix_mode_case* mode) {
+    matrix_fixture* fixture;
+    const char* flow = "active-no-terminal";
+    matrix_hook_reset();
+    g_hooks.vc_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.vc_count = 1;
+    g_hooks.return_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.return_count = 1;
+    matrix_install_hooks();
+    fixture = matrix_reset_fixture(mode);
+
+    int rc = matrix_send_initial_grant(fixture, mode, 0, flow, "no-return");
+    if (rc != 0) {
+        return rc;
+    }
+    int slot = matrix_expected_slot(mode);
+    int event_slot = (slot >= 0) ? slot : 0;
+    p25_sm_event_t ev = p25_sm_ev_ptt(event_slot);
+    p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+    matrix_age_tuned_timers(fixture);
+    p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+
+    rc |= matrix_expect(fixture->ctx.state == P25_SM_TUNED, mode->name, flow, "no-return",
+                        "active call remains tuned without terminal signal");
+    rc |= matrix_expect(fixture->opts->p25_is_tuned == 1 && g_hooks.return_calls == 0, mode->name, flow, "no-return",
+                        "active call did not spuriously return");
+    return rc;
+}
+
+static int
+matrix_run_duplicate_grant_case(const matrix_mode_case* mode) {
+    matrix_fixture* fixture;
+    matrix_hook_reset();
+    g_hooks.vc_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.vc_results[1] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.vc_count = 2;
+    g_hooks.return_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.return_count = 1;
+    matrix_install_hooks();
+    fixture = matrix_reset_fixture(mode);
+
+    int rc = matrix_send_initial_grant(fixture, mode, 0, "duplicate-grant", "ok");
+    if (rc != 0) {
+        return rc;
+    }
+    p25_sm_event_t ev = matrix_group_grant(mode, 2000);
+    p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+    rc |= matrix_expect(g_hooks.vc_calls == 1, mode->name, "duplicate-grant", "ok", "duplicate grant did not retune");
+
+    ev = p25_sm_ev_end((matrix_expected_slot(mode) >= 0) ? matrix_expected_slot(mode) : 0);
+    p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+    rc |= matrix_drive_to_cc(fixture, mode, &(matrix_flow_case){"duplicate-grant", MATRIX_FLOW_EXPLICIT_END, 0, 0},
+                             &(matrix_return_script){"ok", {DSD_TRUNK_TUNE_RESULT_OK, DSD_TRUNK_TUNE_RESULT_OK}, 1});
+    return rc;
+}
+
+static int
+matrix_run_retune_after_release_case(const matrix_mode_case* mode) {
+    matrix_fixture* fixture;
+    matrix_hook_reset();
+    g_hooks.vc_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.vc_results[1] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.vc_count = 2;
+    g_hooks.return_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.return_count = 1;
+    matrix_install_hooks();
+    fixture = matrix_reset_fixture(mode);
+
+    matrix_flow_case flow = {"retune-after-release", MATRIX_FLOW_EXPLICIT_END, 0, 0};
+    matrix_return_script script = {"ok", {DSD_TRUNK_TUNE_RESULT_OK, DSD_TRUNK_TUNE_RESULT_OK}, 1};
+    int rc = matrix_send_initial_grant(fixture, mode, 1, flow.name, script.name);
+    if (rc != 0) {
+        return rc;
+    }
+    p25_sm_event_t ev = p25_sm_ev_end((matrix_expected_slot(mode) >= 0) ? matrix_expected_slot(mode) : 0);
+    p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+    rc |= matrix_drive_to_cc(fixture, mode, &flow, &script);
+    if (rc != 0) {
+        return rc;
+    }
+
+    ev = matrix_group_grant(mode, 2400);
+    p25_sm_event(&fixture->ctx, fixture->opts, fixture->state, &ev);
+    rc |= matrix_expect(g_hooks.vc_calls == 2, mode->name, flow.name, "second-grant", "second grant retuned");
+    rc |= matrix_expect(fixture->ctx.state == P25_SM_TUNED, mode->name, flow.name, "second-grant",
+                        "second grant reached TUNED");
+    return rc;
+}
+
+static int
+matrix_run_cc_hunt_case(const matrix_mode_case* mode, dsd_trunk_tune_result first_result, const char* result_name) {
+    matrix_fixture* fixture;
+    matrix_hook_reset();
+    g_hooks.cc_results[0] = first_result;
+    g_hooks.cc_results[1] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.cc_count = 2;
+    matrix_install_hooks();
+    fixture = matrix_reset_fixture(mode);
+
+    long candidate = MATRIX_BASE_CC_HZ + 1000000;
+    double now_m = dsd_time_now_monotonic_s();
+    (void)dsd_trunk_cc_candidates_add(fixture->state, candidate, 0);
+    fixture->state->last_cc_sync_time = time(NULL) - 10;
+    fixture->state->last_cc_sync_time_m = now_m - 10.0;
+    fixture->ctx.t_cc_sync_m = now_m - 10.0;
+
+    p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+    int rc = 0;
+    rc |= matrix_expect(g_hooks.cc_calls == 1, mode->name, "cc-hunt", result_name, "cc tune attempted");
+    rc |= matrix_expect(g_hooks.last_cc_sps == matrix_expected_cc_sps(fixture, mode), mode->name, "cc-hunt",
+                        result_name, "cc hunt sps matches cc mode");
+
+    if (dsd_trunk_tune_result_is_ok(first_result)) {
+        rc |= matrix_expect(fixture->ctx.state == P25_SM_ON_CC, mode->name, "cc-hunt", result_name,
+                            "accepted cc hunt returns ON_CC");
+        rc |= matrix_expect(fixture->state->p25_cc_eval_freq == candidate, mode->name, "cc-hunt", result_name,
+                            "accepted candidate is under evaluation");
+        return rc;
+    }
+
+    rc |= matrix_expect(fixture->ctx.state == P25_SM_HUNTING, mode->name, "cc-hunt", result_name,
+                        "failed/deferred cc hunt stays HUNTING");
+    rc |= matrix_expect(fixture->state->trunk_cc_freq == MATRIX_BASE_CC_HZ, mode->name, "cc-hunt", result_name,
+                        "failed/deferred cc hunt preserves tracked cc");
+    rc |= matrix_expect(fixture->state->p25_cc_eval_freq == 0, mode->name, "cc-hunt", result_name,
+                        "failed/deferred cc hunt does not enter eval");
+
+    fixture->ctx.t_hunt_try_m = dsd_time_now_monotonic_s() - 6.0;
+    p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+    rc |= matrix_expect(g_hooks.cc_calls == 2, mode->name, "cc-hunt", result_name, "cc hunt retried");
+    rc |= matrix_expect(fixture->ctx.state == P25_SM_ON_CC, mode->name, "cc-hunt", result_name,
+                        "cc hunt recovered on retry");
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+
+    static const struct {
+        const char* name;
+        dsd_trunk_tune_result result;
+    } tune_rejects[] = {
+        {"deferred", DSD_TRUNK_TUNE_RESULT_DEFERRED},
+        {"failed", DSD_TRUNK_TUNE_RESULT_FAILED},
+        {"timeout", DSD_TRUNK_TUNE_RESULT_TIMEOUT},
+    };
+
+    static const struct {
+        const char* name;
+        dsd_trunk_tune_result result;
+    } cc_results[] = {
+        {"ok", DSD_TRUNK_TUNE_RESULT_OK},
+        {"pending", DSD_TRUNK_TUNE_RESULT_PENDING},
+        {"deferred", DSD_TRUNK_TUNE_RESULT_DEFERRED},
+        {"failed", DSD_TRUNK_TUNE_RESULT_FAILED},
+        {"timeout", DSD_TRUNK_TUNE_RESULT_TIMEOUT},
+    };
+
+    for (size_t m = 0; m < sizeof(g_modes) / sizeof(g_modes[0]); m++) {
+        for (size_t r = 0; r < sizeof(tune_rejects) / sizeof(tune_rejects[0]); r++) {
+            rc |= matrix_run_initial_tune_reject_case(&g_modes[m], tune_rejects[r].result, tune_rejects[r].name);
+        }
+        rc |= matrix_run_active_no_terminal_case(&g_modes[m]);
+        rc |= matrix_run_duplicate_grant_case(&g_modes[m]);
+        rc |= matrix_run_retune_after_release_case(&g_modes[m]);
+
+        for (size_t f = 0; f < sizeof(g_flows) / sizeof(g_flows[0]); f++) {
+            for (size_t s = 0; s < sizeof(g_return_scripts) / sizeof(g_return_scripts[0]); s++) {
+                rc |= matrix_run_terminal_case(&g_modes[m], &g_flows[f], &g_return_scripts[s]);
+            }
+        }
+
+        for (size_t c = 0; c < sizeof(cc_results) / sizeof(cc_results[0]); c++) {
+            rc |= matrix_run_cc_hunt_case(&g_modes[m], cc_results[c].result, cc_results[c].name);
+        }
+    }
+
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    if (rc != 0) {
+        return 1;
+    }
+    DSD_FPRINTF(stderr, "P25 return-to-CC matrix passed\n");
+    return 0;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif

--- a/tools/ci_create_release_metadata.sh
+++ b/tools/ci_create_release_metadata.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${RELEASE_TAG:-${GITHUB_REF_NAME:-}}"
+repo="${RELEASE_REPOSITORY:-${GITHUB_REPOSITORY:-}}"
+title="${RELEASE_TITLE:-}"
+auth_token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+
+if [[ -z "${tag}" ]]; then
+  echo "RELEASE_TAG or GITHUB_REF_NAME is required." >&2
+  exit 2
+fi
+if [[ -z "${repo}" ]]; then
+  echo "RELEASE_REPOSITORY or GITHUB_REPOSITORY is required." >&2
+  exit 2
+fi
+if [[ -z "${title}" ]]; then
+  echo "RELEASE_TITLE is required." >&2
+  exit 2
+fi
+if [[ -z "${auth_token}" ]]; then
+  echo "GH_TOKEN or GITHUB_TOKEN is required." >&2
+  exit 2
+fi
+if ! command -v gh > /dev/null 2>&1; then
+  echo "GitHub CLI (gh) is required to create release metadata." >&2
+  exit 2
+fi
+
+export GH_TOKEN="${auth_token}"
+
+if gh release view "${tag}" --repo "${repo}" > /dev/null 2>&1; then
+  echo "Release ${tag} already exists; leaving existing release notes unchanged."
+  exit 0
+fi
+
+set +e
+create_output="$(
+  gh release create "${tag}" \
+    --repo "${repo}" \
+    --title "${title}" \
+    --generate-notes \
+    --verify-tag 2>&1
+)"
+create_rc=$?
+set -e
+
+if [[ ${create_rc} -eq 0 ]]; then
+  printf '%s\n' "${create_output}"
+  echo "Created release metadata for ${tag}."
+  exit 0
+fi
+
+if gh release view "${tag}" --repo "${repo}" > /dev/null 2>&1; then
+  echo "Release ${tag} was created concurrently; leaving existing release notes unchanged."
+  exit 0
+fi
+
+printf '%s\n' "${create_output}" >&2
+exit "${create_rc}"

--- a/tools/ci_wait_for_release.sh
+++ b/tools/ci_wait_for_release.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${RELEASE_TAG:-${GITHUB_REF_NAME:-}}"
+repo="${RELEASE_REPOSITORY:-${GITHUB_REPOSITORY:-}}"
+auth_token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+timeout_seconds="${RELEASE_WAIT_TIMEOUT_SECONDS:-600}"
+interval_seconds="${RELEASE_WAIT_INTERVAL_SECONDS:-5}"
+
+if [[ -z "${tag}" ]]; then
+  echo "RELEASE_TAG or GITHUB_REF_NAME is required." >&2
+  exit 2
+fi
+if [[ -z "${repo}" ]]; then
+  echo "RELEASE_REPOSITORY or GITHUB_REPOSITORY is required." >&2
+  exit 2
+fi
+if [[ -z "${auth_token}" ]]; then
+  echo "GH_TOKEN or GITHUB_TOKEN is required." >&2
+  exit 2
+fi
+if [[ ! "${timeout_seconds}" =~ ^[0-9]+$ ]] || [[ "${timeout_seconds}" -le 0 ]]; then
+  echo "RELEASE_WAIT_TIMEOUT_SECONDS must be a positive integer." >&2
+  exit 2
+fi
+if [[ ! "${interval_seconds}" =~ ^[0-9]+$ ]] || [[ "${interval_seconds}" -le 0 ]]; then
+  echo "RELEASE_WAIT_INTERVAL_SECONDS must be a positive integer." >&2
+  exit 2
+fi
+if ! command -v gh > /dev/null 2>&1; then
+  echo "GitHub CLI (gh) is required to wait for release metadata." >&2
+  exit 2
+fi
+
+export GH_TOKEN="${auth_token}"
+
+deadline=$((SECONDS + timeout_seconds))
+while ((SECONDS <= deadline)); do
+  if gh release view "${tag}" --repo "${repo}" > /dev/null 2>&1; then
+    echo "Release ${tag} is available."
+    exit 0
+  fi
+
+  if ((SECONDS + interval_seconds > deadline)); then
+    break
+  fi
+  sleep "${interval_seconds}"
+done
+
+echo "Timed out waiting for release ${tag} in ${repo}." >&2
+exit 1


### PR DESCRIPTION
## Summary

Fixes a P25 trunking recovery path where stale voice-channel no-carrier handling could return RTL tuning to the control-channel frequency without applying the normal control-channel demodulator profile reset.

## Root Cause

The explicit P25 state-machine release path already used the trunk retune helper, which prepares the RTL demodulator profile before retuning back to the control channel. The stale voice-channel `noCarrier()` path had a separate direct RTL retune fallback. That could leave the symbol/TED profile in a stale voice-channel configuration even though the hardware had returned to the control-channel frequency. In practice this can present as high SNR on the control channel while TSBK/control-channel decode is delayed until the pipeline eventually recovers.

## Resolution

- Route no-carrier control-channel returns through `dsd_engine_return_to_cc()` so RTL profile preparation and TED override clearing happen consistently.
- Keep legacy clear-state fallback behavior for rigctl/non-RTL cases and inactive RTL contexts.
- Add regression coverage for returning from a stale P25 RTL voice profile to a P25 control-channel profile.
- Add the required test linker wraps for RTL profile/tune fakes.

## Validation

- `tools/format.sh`
- `tools/cmake_format_check.sh`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh`
- `tools/quality_preflight.sh`
- pre-push guardrails during `git push -u origin fix/p25-no-carrier-cc-retune`