### PR TITLE
release: prepare 2.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(dsd-neo VERSION 2.0.0 LANGUAGES C CXX)
+project(dsd-neo VERSION 2.0.1 LANGUAGES C CXX)
 if(POLICY CMP0083)
     cmake_policy(SET CMP0083 NEW)
 endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "dsd-neo",
-  "version-string": "2.0.0",
+  "version-string": "2.0.1",
   "builtin-baseline": "d015e31e90838a4c9dfa3eed45979bc70d9357fc",
   "description": "Digital Speech Decoder: DSD-neo",
   "homepage": "https://github.com/arancormonk/dsd-neo",


### PR DESCRIPTION
## Summary

- Update the DSD-neo project version to 2.0.1 in CMake metadata.
- Update the package manifest version string to 2.0.1.

## Review

- [x] Changes were reviewed against the release workflow and version/tag validation requirements.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: release.
- [x] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests, or do not apply.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope, or do not apply.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `tools/cmake_format_check.sh`
- [x] `cmake --preset dev-debug`
- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [x] `tools/quality_preflight.sh`

## Risk

- Security/dependency impact: package version metadata only; no dependency pins changed.
- CLI/UI behavior impact: none.
- Compatibility or packaging impact: enables the `v2.0.1` release tag to match project metadata.

No regression test was added because this change only updates release metadata.