### PR TITLE
ui: refine snr readout handling

### DIFF
--- a/src/ui/terminal/CMakeLists.txt
+++ b/src/ui/terminal/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(
         dsd_ncurses_printer.c
         ncurses_utils.c
         ncurses_snr.c
+        ui_snr_readout.c
         ncurses_init.c
         ncurses_dsp_display.c
         ncurses_visualizers.c

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -47,13 +47,13 @@
 #include "dsd-neo/core/secret_redaction.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/platform/platform.h"
+#include "ui_snr_readout.h"
 
 #ifdef USE_RADIO
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/ui/keymap.h>
 #include <dsd-neo/ui/ncurses_snr.h>
 #include <dsd-neo/ui/ncurses_visualizers.h>
-#include <math.h>
 #endif
 
 static int
@@ -976,136 +976,6 @@ ui_render_audio_decode_header_fields(dsd_opts* opts, const dsd_state* state) {
     }
 }
 
-#ifdef USE_RADIO
-enum {
-    UI_SNR_INVALID_DB = -50,
-    UI_SNR_STALE_THRESHOLD_CDB = 5, /* 0.05 dB in centi-dB */
-    UI_SNR_STALE_LIMIT = 40
-};
-
-static double
-ui_snr_get_c4fm_value(void) {
-    static double last_c4_snr = -999.0;
-    static int last_c4_stable = 0;
-
-    double snr = rtl_stream_get_snr_c4fm();
-    if (snr <= (double)UI_SNR_INVALID_DB) {
-        double fb = rtl_stream_estimate_snr_c4fm_eye();
-        if (fb > (double)UI_SNR_INVALID_DB) {
-            snr = fb;
-            last_c4_stable = 0;
-        }
-        return snr;
-    }
-
-    int delta_cdb = (int)(fabs(snr - last_c4_snr) * 100.0);
-    if (delta_cdb < UI_SNR_STALE_THRESHOLD_CDB) {
-        if (++last_c4_stable >= UI_SNR_STALE_LIMIT) {
-            double fb = rtl_stream_estimate_snr_c4fm_eye();
-            if (fb > (double)UI_SNR_INVALID_DB) {
-                snr = fb;
-            }
-            last_c4_stable = 0;
-        }
-    } else {
-        last_c4_stable = 0;
-    }
-    last_c4_snr = snr;
-    return snr;
-}
-
-static double
-ui_snr_get_qpsk_value(void) {
-    static double last_qp_snr = -999.0;
-    static int last_qp_stable = 0;
-
-    double snr = rtl_stream_get_snr_cqpsk();
-    if (snr <= (double)UI_SNR_INVALID_DB) {
-        double fb = rtl_stream_estimate_snr_qpsk_const();
-        if (fb > (double)UI_SNR_INVALID_DB) {
-            snr = fb;
-            last_qp_stable = 0;
-        } else {
-            double snr_c = rtl_stream_get_snr_c4fm();
-            double snr_g = rtl_stream_get_snr_gfsk();
-            double snr_fb = (snr_c > snr_g) ? snr_c : snr_g;
-            if (snr_fb > (double)UI_SNR_INVALID_DB) {
-                snr = snr_fb;
-            }
-        }
-        return snr;
-    }
-
-    int delta_cdb = (int)(fabs(snr - last_qp_snr) * 100.0);
-    if (delta_cdb < UI_SNR_STALE_THRESHOLD_CDB) {
-        if (++last_qp_stable >= UI_SNR_STALE_LIMIT) {
-            double fb = rtl_stream_estimate_snr_qpsk_const();
-            if (fb > (double)UI_SNR_INVALID_DB) {
-                snr = fb;
-            }
-            last_qp_stable = 0;
-        }
-    } else {
-        last_qp_stable = 0;
-    }
-    last_qp_snr = snr;
-    return snr;
-}
-
-static double
-ui_snr_get_gfsk_value(void) {
-    static double last_gf_snr = -999.0;
-    static int last_gf_stable = 0;
-
-    double snr = rtl_stream_get_snr_gfsk();
-    if (snr <= (double)UI_SNR_INVALID_DB) {
-        double fb = rtl_stream_estimate_snr_gfsk_eye();
-        if (fb > (double)UI_SNR_INVALID_DB) {
-            snr = fb;
-            last_gf_stable = 0;
-        }
-        return snr;
-    }
-
-    int delta_cdb = (int)(fabs(snr - last_gf_snr) * 100.0);
-    if (delta_cdb < UI_SNR_STALE_THRESHOLD_CDB) {
-        if (++last_gf_stable >= UI_SNR_STALE_LIMIT) {
-            double fb = rtl_stream_estimate_snr_gfsk_eye();
-            if (fb > (double)UI_SNR_INVALID_DB) {
-                snr = fb;
-            }
-            last_gf_stable = 0;
-        }
-    } else {
-        last_gf_stable = 0;
-    }
-    last_gf_snr = snr;
-    return snr;
-}
-
-static const char*
-ui_snr_mod_label(int rf_mod) {
-    if (rf_mod == 1) {
-        return "QPSK";
-    }
-    if (rf_mod == 2) {
-        return "GFSK";
-    }
-    return "C4FM";
-}
-
-static double
-ui_snr_value_for_mod(int rf_mod) {
-    if (rf_mod == 1) {
-        return ui_snr_get_qpsk_value();
-    }
-    if (rf_mod == 2) {
-        return ui_snr_get_gfsk_value();
-    }
-    return ui_snr_get_c4fm_value();
-}
-#endif
-
 static void
 ui_render_demod_snr_line(const dsd_opts* opts, const dsd_state* state) {
     if (opts == NULL || state == NULL) {
@@ -1116,18 +986,18 @@ ui_render_demod_snr_line(const dsd_opts* opts, const dsd_state* state) {
     /* Demod SNR (per modulation) */
 #ifdef USE_RADIO
     {
-        double snr = ui_snr_value_for_mod(state->rf_mod);
-        const char* m = ui_snr_mod_label(state->rf_mod);
-        if (snr > (double)UI_SNR_INVALID_DB) {
+        ui_snr_readout snr = ui_snr_readout_for_mod(state->rf_mod);
+        const char* m = snr.mod_label;
+        if (snr.valid) {
             /* Show current SNR as a compact, colorized meter */
             char snr_value[16];
-            if (DSD_SNPRINTF(snr_value, sizeof(snr_value), "%.1f", snr) < 0) {
+            if (DSD_SNPRINTF(snr_value, sizeof(snr_value), "%.1f", snr.snr_db) < 0) {
                 snr_value[0] = '\0';
             }
             ui_print_snr_db_field(snr_value);
             addch(' ');
             /* Pass current modulation for per-mod color bands */
-            print_snr_meter(opts, snr, state->rf_mod);
+            print_snr_meter(opts, snr.snr_db, state->rf_mod);
             printw(" (%s)", m);
         } else {
             /* Show placeholder so users can see the field even when no estimate */

--- a/src/ui/terminal/ncurses_init.c
+++ b/src/ui/terminal/ncurses_init.c
@@ -57,10 +57,10 @@ ncursesOpen(dsd_opts* opts, dsd_state* state) {
         init_pair(8, COLOR_BLACK, COLOR_WHITE);   // Black on White
         init_pair(9, COLOR_RED, COLOR_WHITE);     // Red on White
         init_pair(10, COLOR_BLUE, COLOR_WHITE);   // Blue on White
-        /* Quality bands for SNR sparkline */
-        init_pair(11, COLOR_GREEN, COLOR_BLACK);  // good
-        init_pair(12, COLOR_YELLOW, COLOR_BLACK); // moderate
-        init_pair(13, COLOR_RED, COLOR_BLACK);    // poor
+        /* Quality bands for SNR sparkline and RTL spectrum visualizers */
+        init_pair(11, COLOR_GREEN, COLOR_BLACK);  // good/high
+        init_pair(12, COLOR_YELLOW, COLOR_BLACK); // moderate/mid
+        init_pair(13, COLOR_RED, COLOR_BLACK);    // poor/low
         init_pair(14, COLOR_YELLOW, COLOR_BLACK); // DSP status (explicit yellow)
         /* IDEN color palette (per-bandplan); 8 slots, wrap IDEN nibble modulo 8 */
         init_pair(21, COLOR_YELLOW, COLOR_BLACK);

--- a/src/ui/terminal/ncurses_snr.c
+++ b/src/ui/terminal/ncurses_snr.c
@@ -75,6 +75,8 @@ snr_meter_bar_count(double snr_db) {
 }
 
 #ifdef PRETTY_COLORS
+enum { SNR_METER_COLOR_PAIR = 6 };
+
 static short
 snr_quality_color_pair(double snr_db, int mod) {
     const short C_GOOD = 11, C_MOD = 12, C_POOR = 13;
@@ -277,6 +279,7 @@ print_snr_sparkline(const dsd_opts* opts, int mod) {
 /* Render a compact ascending signal-bar meter for current SNR. */
 void
 print_snr_meter(const dsd_opts* opts, double snr_db, int mod) {
+    (void)mod;
     /* Preserve the current color pair so our temporary colors don't clear it */
 #ifdef PRETTY_COLORS
     attr_t saved_attrs = 0;
@@ -286,9 +289,7 @@ print_snr_meter(const dsd_opts* opts, double snr_db, int mod) {
     const int bars = snr_meter_bar_count(snr_db);
     int use_unicode = SNR_USE_UNICODE(opts && opts->eye_unicode, ui_unicode_supported());
 #ifdef PRETTY_COLORS
-    short cp = snr_quality_color_pair(snr_db, mod);
-#else
-    (void)mod;
+    short cp = SNR_METER_COLOR_PAIR;
 #endif
     for (int i = 0; i < SNR_METER_BARS; i++) {
         if (i > 0) {

--- a/src/ui/terminal/ui_snr_readout.c
+++ b/src/ui/terminal/ui_snr_readout.c
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "ui_snr_readout.h"
+
+#ifdef USE_RADIO
+#include <dsd-neo/io/rtl_stream_c.h>
+#include <math.h>
+#endif
+
+enum { UI_SNR_INVALID_DB = -50 };
+
+static const char*
+ui_snr_mod_label(int rf_mod) {
+    if (rf_mod == 1) {
+        return "QPSK";
+    }
+    if (rf_mod == 2) {
+        return "GFSK";
+    }
+    return "C4FM";
+}
+
+static int
+ui_snr_value_is_valid(double snr) {
+    return snr > (double)UI_SNR_INVALID_DB;
+}
+
+#ifdef USE_RADIO
+enum {
+    UI_SNR_STALE_THRESHOLD_CDB = 5, /* 0.05 dB in centi-dB */
+    UI_SNR_STALE_LIMIT = 40
+};
+
+typedef struct ui_snr_stale_state {
+    double last_snr;
+    int stable_count;
+} ui_snr_stale_state;
+
+static ui_snr_stale_state g_c4fm_stale = {-999.0, 0};
+static ui_snr_stale_state g_qpsk_stale = {-999.0, 0};
+static ui_snr_stale_state g_gfsk_stale = {-999.0, 0};
+
+static double
+ui_snr_maybe_replace_stale(double snr, ui_snr_stale_state* state, double (*fallback_fn)(void)) {
+    if (!state || !fallback_fn) {
+        return snr;
+    }
+
+    int delta_cdb = (int)(fabs(snr - state->last_snr) * 100.0);
+    if (delta_cdb < UI_SNR_STALE_THRESHOLD_CDB) {
+        if (++state->stable_count >= UI_SNR_STALE_LIMIT) {
+            double fb = fallback_fn();
+            if (ui_snr_value_is_valid(fb)) {
+                snr = fb;
+            }
+            state->stable_count = 0;
+        }
+    } else {
+        state->stable_count = 0;
+    }
+    state->last_snr = snr;
+    return snr;
+}
+
+#ifdef DSD_NEO_TEST_HOOKS
+static void
+ui_snr_stale_reset(ui_snr_stale_state* state) {
+    if (!state) {
+        return;
+    }
+    state->last_snr = -999.0;
+    state->stable_count = 0;
+}
+#endif
+
+static double
+ui_snr_get_c4fm_value(void) {
+    double snr = rtl_stream_get_snr_c4fm();
+    if (!ui_snr_value_is_valid(snr)) {
+        double fb = rtl_stream_estimate_snr_c4fm_eye();
+        if (ui_snr_value_is_valid(fb)) {
+            snr = fb;
+            g_c4fm_stale.stable_count = 0;
+        }
+        return snr;
+    }
+
+    return ui_snr_maybe_replace_stale(snr, &g_c4fm_stale, rtl_stream_estimate_snr_c4fm_eye);
+}
+
+static double
+ui_snr_get_qpsk_value(void) {
+    double snr = rtl_stream_get_snr_cqpsk();
+    if (!ui_snr_value_is_valid(snr)) {
+        double fb = rtl_stream_estimate_snr_qpsk_const();
+        if (ui_snr_value_is_valid(fb)) {
+            snr = fb;
+            g_qpsk_stale.stable_count = 0;
+        } else {
+            double snr_c = rtl_stream_get_snr_c4fm();
+            double snr_g = rtl_stream_get_snr_gfsk();
+            double snr_fb = (snr_c > snr_g) ? snr_c : snr_g;
+            if (ui_snr_value_is_valid(snr_fb)) {
+                snr = snr_fb;
+            }
+        }
+        return snr;
+    }
+
+    return ui_snr_maybe_replace_stale(snr, &g_qpsk_stale, rtl_stream_estimate_snr_qpsk_const);
+}
+
+static double
+ui_snr_get_gfsk_value(void) {
+    double snr = rtl_stream_get_snr_gfsk();
+    if (!ui_snr_value_is_valid(snr)) {
+        double fb = rtl_stream_estimate_snr_gfsk_eye();
+        if (ui_snr_value_is_valid(fb)) {
+            snr = fb;
+            g_gfsk_stale.stable_count = 0;
+        }
+        return snr;
+    }
+
+    return ui_snr_maybe_replace_stale(snr, &g_gfsk_stale, rtl_stream_estimate_snr_gfsk_eye);
+}
+
+static int
+ui_snr_try_fsk_soft_value(double* out_snr) {
+    if (!out_snr) {
+        return 0;
+    }
+
+    rtl_stream_fsk_metrics metrics;
+    if (rtl_stream_get_fsk_metrics(&metrics) != 0 || !metrics.valid || !ui_snr_value_is_valid(metrics.evm_snr_db)) {
+        return 0;
+    }
+
+    *out_snr = (double)metrics.evm_snr_db;
+    return 1;
+}
+#endif
+
+ui_snr_readout
+ui_snr_readout_for_mod(int rf_mod) {
+    ui_snr_readout out;
+    out.mod_label = ui_snr_mod_label(rf_mod);
+
+#ifdef USE_RADIO
+    double snr = (double)UI_SNR_INVALID_DB;
+    if (rf_mod == 1) {
+        snr = ui_snr_get_qpsk_value();
+    } else if (!ui_snr_try_fsk_soft_value(&snr)) {
+        snr = (rf_mod == 2) ? ui_snr_get_gfsk_value() : ui_snr_get_c4fm_value();
+    }
+    out.snr_db = snr;
+    out.valid = ui_snr_value_is_valid(snr);
+#else
+    out.valid = 0;
+    out.snr_db = (double)UI_SNR_INVALID_DB;
+#endif
+
+    return out;
+}
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+ui_snr_readout_reset_for_test(void) {
+#ifdef USE_RADIO
+    ui_snr_stale_reset(&g_c4fm_stale);
+    ui_snr_stale_reset(&g_qpsk_stale);
+    ui_snr_stale_reset(&g_gfsk_stale);
+#endif
+}
+#endif

--- a/src/ui/terminal/ui_snr_readout.h
+++ b/src/ui/terminal/ui_snr_readout.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef DSD_NEO_SRC_UI_TERMINAL_UI_SNR_READOUT_H_
+#define DSD_NEO_SRC_UI_TERMINAL_UI_SNR_READOUT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ui_snr_readout {
+    int valid;
+    double snr_db;
+    const char* mod_label;
+} ui_snr_readout;
+
+ui_snr_readout ui_snr_readout_for_mod(int rf_mod);
+
+#ifdef DSD_NEO_TEST_HOOKS
+void ui_snr_readout_reset_for_test(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_SRC_UI_TERMINAL_UI_SNR_READOUT_H_ */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -926,6 +926,25 @@ target_link_libraries(
 )
 add_test(NAME UI_SNR_METER COMMAND dsd-neo_test_ui_snr_meter)
 
+add_executable(
+    dsd-neo_test_ui_snr_readout
+    ui/test_ui_snr_readout.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_snr_readout.c
+)
+target_include_directories(
+    dsd-neo_test_ui_snr_readout
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
+)
+target_compile_definitions(
+    dsd-neo_test_ui_snr_readout
+    PRIVATE DSD_NEO_TEST_HOOKS USE_RADIO
+)
+target_link_libraries(
+    dsd-neo_test_ui_snr_readout
+    PRIVATE ${DSD_NEO_TEST_MATH_LIB}
+)
+add_test(NAME UI_SNR_READOUT COMMAND dsd-neo_test_ui_snr_readout)
+
 if(NOT DSD_HAS_PDCURSES_WIDE_API)
     add_executable(
         dsd-neo_test_ui_snr_meter_pdc_wide_no_api

--- a/tests/ui/test_ui_snr_readout.c
+++ b/tests/ui/test_ui_snr_readout.c
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "ui_snr_readout.h"
+
+#include <assert.h>
+#include <dsd-neo/io/rtl_stream_c.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include "dsd-neo/core/safe_api.h"
+
+static rtl_stream_fsk_metrics g_fsk_metrics;
+static int g_fsk_result = 0;
+static int g_fsk_calls = 0;
+static int g_snr_c4fm_calls = 0;
+static int g_snr_c4fm_eye_calls = 0;
+static int g_snr_cqpsk_calls = 0;
+static int g_snr_gfsk_calls = 0;
+static int g_snr_gfsk_eye_calls = 0;
+static int g_snr_qpsk_const_calls = 0;
+static double g_snr_c4fm = -100.0;
+static double g_snr_c4fm_eye = -100.0;
+static double g_snr_cqpsk = -100.0;
+static double g_snr_gfsk = -100.0;
+static double g_snr_gfsk_eye = -100.0;
+static double g_snr_qpsk_const = -100.0;
+
+int
+rtl_stream_get_fsk_metrics(rtl_stream_fsk_metrics* out) {
+    g_fsk_calls++;
+    if (out) {
+        *out = g_fsk_metrics;
+    }
+    return g_fsk_result;
+}
+
+double
+rtl_stream_get_snr_c4fm(void) {
+    g_snr_c4fm_calls++;
+    return g_snr_c4fm;
+}
+
+double
+rtl_stream_estimate_snr_c4fm_eye(void) {
+    g_snr_c4fm_eye_calls++;
+    return g_snr_c4fm_eye;
+}
+
+double
+rtl_stream_get_snr_cqpsk(void) {
+    g_snr_cqpsk_calls++;
+    return g_snr_cqpsk;
+}
+
+double
+rtl_stream_get_snr_gfsk(void) {
+    g_snr_gfsk_calls++;
+    return g_snr_gfsk;
+}
+
+double
+rtl_stream_estimate_snr_gfsk_eye(void) {
+    g_snr_gfsk_eye_calls++;
+    return g_snr_gfsk_eye;
+}
+
+double
+rtl_stream_estimate_snr_qpsk_const(void) {
+    g_snr_qpsk_const_calls++;
+    return g_snr_qpsk_const;
+}
+
+static void
+reset_fakes(void) {
+    ui_snr_readout_reset_for_test();
+    DSD_MEMSET(&g_fsk_metrics, 0, sizeof(g_fsk_metrics));
+    g_fsk_result = 0;
+    g_fsk_calls = 0;
+    g_snr_c4fm_calls = 0;
+    g_snr_c4fm_eye_calls = 0;
+    g_snr_cqpsk_calls = 0;
+    g_snr_gfsk_calls = 0;
+    g_snr_gfsk_eye_calls = 0;
+    g_snr_qpsk_const_calls = 0;
+    g_snr_c4fm = -100.0;
+    g_snr_c4fm_eye = -100.0;
+    g_snr_cqpsk = -100.0;
+    g_snr_gfsk = -100.0;
+    g_snr_gfsk_eye = -100.0;
+    g_snr_qpsk_const = -100.0;
+}
+
+static void
+expect_readout(const char* name, int rf_mod, double expected_snr, const char* expected_label) {
+    ui_snr_readout got = ui_snr_readout_for_mod(rf_mod);
+    const char* actual_label = got.mod_label ? got.mod_label : "";
+    if (!got.valid || fabs(got.snr_db - expected_snr) > 1e-6 || strcmp(actual_label, expected_label) != 0) {
+        (void)DSD_FPRINTF(stderr, "%s: valid=%d snr=%.6f label=%s\n", name, got.valid, got.snr_db,
+                          actual_label[0] ? actual_label : "(null)");
+    }
+    assert(got.valid == 1);
+    assert(fabs(got.snr_db - expected_snr) <= 1e-6);
+    assert(strcmp(actual_label, expected_label) == 0);
+}
+
+static void
+test_c4fm_prefers_valid_fsk_soft_snr(void) {
+    reset_fakes();
+    g_fsk_metrics.valid = 1;
+    g_fsk_metrics.evm_snr_db = 18.25f;
+    g_snr_c4fm = 4.0;
+
+    expect_readout("c4fm-soft", 0, 18.25, "C4FM");
+    assert(g_fsk_calls == 1);
+    assert(g_snr_c4fm_calls == 0);
+}
+
+static void
+test_gfsk_prefers_valid_fsk_soft_snr(void) {
+    reset_fakes();
+    g_fsk_metrics.valid = 1;
+    g_fsk_metrics.evm_snr_db = 21.5f;
+    g_snr_gfsk = 6.0;
+
+    expect_readout("gfsk-soft", 2, 21.5, "GFSK");
+    assert(g_fsk_calls == 1);
+    assert(g_snr_gfsk_calls == 0);
+}
+
+static void
+test_gfsk_falls_back_when_fsk_metrics_invalid(void) {
+    reset_fakes();
+    g_fsk_metrics.valid = 0;
+    g_snr_gfsk = -100.0;
+    g_snr_gfsk_eye = 7.25;
+
+    expect_readout("gfsk-fallback", 2, 7.25, "GFSK");
+    assert(g_fsk_calls == 1);
+    assert(g_snr_gfsk_calls == 1);
+    assert(g_snr_gfsk_eye_calls == 1);
+}
+
+static void
+test_fsk_soft_snr_at_invalid_threshold_falls_back(void) {
+    reset_fakes();
+    g_fsk_metrics.valid = 1;
+    g_fsk_metrics.evm_snr_db = -50.0f;
+    g_snr_c4fm = 5.5;
+
+    expect_readout("c4fm-threshold-fallback", 0, 5.5, "C4FM");
+    assert(g_fsk_calls == 1);
+    assert(g_snr_c4fm_calls == 1);
+}
+
+static void
+test_qpsk_ignores_fsk_soft_snr(void) {
+    reset_fakes();
+    g_fsk_metrics.valid = 1;
+    g_fsk_metrics.evm_snr_db = 44.0f;
+    g_snr_cqpsk = 12.75;
+
+    expect_readout("qpsk-no-fsk", 1, 12.75, "QPSK");
+    assert(g_fsk_calls == 0);
+    assert(g_snr_cqpsk_calls == 1);
+}
+
+int
+main(void) {
+    test_c4fm_prefers_valid_fsk_soft_snr();
+    test_gfsk_prefers_valid_fsk_soft_snr();
+    test_gfsk_falls_back_when_fsk_metrics_invalid();
+    test_fsk_soft_snr_at_invalid_threshold_falls_back();
+    test_qpsk_ignores_fsk_soft_snr();
+    printf("UI_SNR_READOUT: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Prefer the FSK modem EVM SNR for the main C4FM/GFSK SNR readout when that metric is valid, while keeping QPSK and Auto PPM behavior unchanged.
- Move demod SNR readout selection into a small terminal UI helper with focused regression coverage.
- Keep the compact SNR meter white without changing the shared RTL spectrum low/mid/high color pairs.

## Testing
- `tools/format.sh`
- `tools/cmake_format_check.sh`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug -R 'UI_SNR_READOUT|UI_SNR_METER' --output-on-failure`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh`
- `git push -u origin ui/snr-readout-fsk-meter` pre-push guardrail