### PR TITLE
dmr: add synced debug burst dump

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,7 +7,7 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 - Help: `dsd-neo -h` | UI/logs: `-N`, `-Z` | List devices: `-O`
 - Inputs: `-i pulse | file.wav | rtl[:...] | rtltcp[:...] | soapy[:args[:freq[:gain[:ppm[:bw[:sql[:vol]]]]]]] | tcp[:host[:port]] | udp[:bind_addr[:port]] | m17udp[:bind_addr[:port]] | -`
 - Outputs: `-o pulse | null | udp[:host[:port]] | m17udp[:host[:port]] | -`
-- Record/Logs: `-6 file.wav`, `-w file.wav`, `-P`, `-7 ./calls`, `-d ./mbe`, `-J events.log`, `--frame-log frames.log`, `-L lrrp.log`, `-Q dsp.bin`, `-c symbols.bin`, `-r *.mbe`
+- Record/Logs/Debug: `-6 file.wav`, `-w file.wav`, `-P`, `-7 ./calls`, `-d ./mbe`, `-J events.log`, `--frame-log frames.log`, `-L lrrp.log`, `-Q dsp.bin`, `-c symbols.bin`, `-r *.mbe`, `--dmr-debug-burst`
 - IQ capture/replay: `--iq-capture <path>`, `--iq-capture-format cu8|cf32`, `--iq-capture-max-mb <n>`, `--iq-replay <path>`, `--iq-replay-rate fast|realtime`, `--iq-loop`, `--iq-info <path>`
 - Levels/Audio: `-g 0|1..50`, `-n 0..100`, `-8`, `-V 0|1|2|3`, `-z 0|1|2`, `-y`, `-v 0xF`, `-nm`
 - Modes: `-fa | -fs | -f1 | -f2 | -fd | -fx | -fy | -fz | -fU | -fi | -fn | -fp | -fh | -fH | -fe | -fE | -fm`
@@ -116,6 +116,43 @@ Tip: If paths or names contain spaces, wrap them in single quotes.
 - `--p25-force-release-margin <s>` safety‑net hard margin seconds beyond extra
 - `--p25-p1-err-hold-pct <pct>` P25p1 IMBE error percentage threshold to extend hang
 - `--p25-p1-err-hold-sec <s>` additional seconds to hold when threshold exceeded
+
+## DMR Burst Debugging
+
+`--dmr-debug-burst` emits one console line to stderr for each synced, fully assembled DMR burst. Use it when
+troubleshooting live DMR decode and you need bracketed post-demod no-CACH payload bytes without enabling verbose `-Z`
+payload logging or changing `-Q` OK-DMRlib structured output.
+
+Example:
+
+```sh
+dsd-neo -fs -i rtl:0:450M:26:-2:48:0:2 --dmr-debug-burst
+```
+
+Output format:
+
+```text
+Debug Demod +Sync slot=<1|2> type=0xNN: [AA][BB]...[CC]
+```
+
+Notes:
+
+- The dump is DMR-only and only runs for synced 144-dibit bursts.
+- The byte stream is the 33-byte no-CACH payload range also used by `-Q` DMR output.
+- Voice bursts report `type=0x10`; data bursts use the decoded DMR data burst type.
+- The option writes to stderr only. It does not imply `-Q`, `-Z`, symbol capture, or payload file logging.
+
+Windows console runs:
+
+- A no-argument run still starts the interactive setup when no config is loaded.
+- For a console debug run, pass explicit CLI arguments, for example:
+  `dsd-neo.exe -fs -i tcp --dmr-debug-burst`.
+- To suppress the interactive setup in `cmd.exe`, run `set DSD_NEO_NO_BOOTSTRAP=1` before starting `dsd-neo.exe`.
+- To suppress it in PowerShell, run `$env:DSD_NEO_NO_BOOTSTRAP = "1"` before starting `dsd-neo.exe`.
+- To reuse a saved config, pass `--config "%APPDATA%\dsd-neo\config.ini"` or set
+  `DSD_NEO_CONFIG=%APPDATA%\dsd-neo\config.ini` in `cmd.exe`.
+- In PowerShell, the equivalent config environment variable is
+  `$env:DSD_NEO_CONFIG = "$env:APPDATA\dsd-neo\config.ini"`.
 
 ## Recording & Files
 

--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -228,6 +228,7 @@ struct dsd_opts {
     /* DMR: when set, relax CRC gating (ignore final CRC when no irrecoverable errors).
        Off by default; enabled via -F like other protocols. */
     uint8_t dmr_crc_relaxed_default;
+    uint8_t dmr_debug_burst;
     uint8_t call_alert_events;
     int frame_ysf;
     int inverted_ysf;

--- a/include/dsd-neo/protocol/dmr/dmr.h
+++ b/include/dsd-neo/protocol/dmr/dmr.h
@@ -16,6 +16,7 @@
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -47,6 +48,11 @@ void dmr_block_assembler(dsd_opts* opts, dsd_state* state, uint8_t block_bytes[]
                          uint8_t type);
 void dmr_reset_blocks(dsd_opts* opts, dsd_state* state);
 void dmr_confidence_reset(dsd_state* state);
+size_t dmr_debug_format_burst(char* out, size_t out_size, const dsd_state* state, uint8_t slot_index,
+                              uint8_t burst_type);
+size_t dmr_debug_format_burst_payload(char* out, size_t out_size, const int payload[144], uint8_t slot_index,
+                                      uint8_t burst_type);
+void dmr_debug_dump_burst(const dsd_opts* opts, const dsd_state* state, uint8_t slot_index, uint8_t burst_type);
 
 void dmr_sd_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* DMR_PDU);
 void dmr_udp_comp_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* DMR_PDU);

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -237,6 +237,7 @@ init_opts_runtime_and_network_defaults(dsd_opts* opts) {
     opts->aggressive_framesync = 1;
     /* DMR: strict CRC gating by default (use -F to relax, like other protocols). */
     opts->dmr_crc_relaxed_default = 0;
+    opts->dmr_debug_burst = 0;
     opts->iq_capture_requested = 0;
     opts->iq_replay_requested = 0;
     opts->iq_replay_loop = 0;

--- a/src/protocol/dmr/dmr_bs.c
+++ b/src/protocol/dmr/dmr_bs.c
@@ -567,6 +567,7 @@ process_dmr_bs_voice_burst(dsd_opts* opts, dsd_state* state, dmr_bs_ctx* ctx) {
         return action;
     }
 
+    dmr_debug_dump_burst(opts, state, ctx->internalslot, 0x10);
     ctx->skipcount = 0;
     DSD_FPRINTF(stderr, "%s ", ctx->timestr);
 
@@ -1006,6 +1007,7 @@ dmrBSBootstrap(dsd_opts* opts, dsd_state* state) {
         write_dmr_bs_dsp_output(opts, state, ctx.internalslot);
     }
 
+    dmr_debug_dump_burst(opts, state, ctx.internalslot, 0x10);
     process_dmr_bs_bootstrap_voice_if_open(opts, state, &ctx);
     dmrBS(opts, state);
 

--- a/src/protocol/dmr/dmr_data.c
+++ b/src/protocol/dmr/dmr_data.c
@@ -407,6 +407,8 @@ void
 dmr_data_sync(dsd_opts* opts, dsd_state* state) {
     dmr_data_sync_ctx ctx;
     dmr_data_sync_init_ctx(&ctx, opts, state);
+    char debug_line[192];
+    debug_line[0] = '\0';
 
     if (dmr_data_collect_cach(&ctx)) {
         dmr_data_collect_first_half(&ctx);
@@ -414,9 +416,15 @@ dmr_data_sync(dsd_opts* opts, dsd_state* state) {
         dmr_data_collect_sync(&ctx);
         if (dmr_data_collect_slot_type_suffix(&ctx)) {
             dmr_data_collect_second_half(&ctx);
+            if (opts->dmr_debug_burst != 0) {
+                (void)dmr_debug_format_burst(debug_line, sizeof(debug_line), state, state->currentslot, ctx.burst);
+            }
             dmr_data_dispatch_burst(&ctx);
         }
     }
 
     dmr_data_finalize(opts, state, ctx.SlotTypeOk, ctx.cach_okay);
+    if (debug_line[0] != '\0') {
+        DSD_FPRINTF(stderr, "%s\n", debug_line);
+    }
 }

--- a/src/protocol/dmr/dmr_ms.c
+++ b/src/protocol/dmr/dmr_ms.c
@@ -300,6 +300,25 @@ dmr_ms_decode_bootstrap_voice(dsd_opts* opts, dsd_state* state, dmr_ms_voice_fra
 }
 
 static void
+dmr_ms_dump_bootstrap_debug_burst(const dsd_opts* opts, const dsd_state* state) {
+    if (opts == NULL || state == NULL || opts->dmr_debug_burst == 0) {
+        return;
+    }
+
+    int debug_payload[144];
+    DSD_MEMCPY(debug_payload, state->dmr_stereo_payload, sizeof(debug_payload));
+    for (int i = 48; i < 90; i++) {
+        debug_payload[i] = dmr_ms_apply_inversion(opts, debug_payload[i], 1);
+    }
+
+    char line[192];
+    if (dmr_debug_format_burst_payload(line, sizeof(line), debug_payload, (uint8_t)state->currentslot, 0x10) == 0U) {
+        return;
+    }
+    DSD_FPRINTF(stderr, "%s\n", line);
+}
+
+static void
 dmr_ms_print_bootstrap_sync(const dsd_opts* opts, dsd_state* state, const char timestr[9]) {
     const char* sign = (opts->inverted_dmr == 0) ? "+" : "-";
     if (state->dmr_color_code != 16) {
@@ -345,6 +364,7 @@ dmrMS(dsd_opts* opts, dsd_state* state) {
         uint8_t power = dmr_ms_decode_embedded_color_code(state, syncdata, emb_pdu);
         dmr_ms_fill_ambe_from_stream(opts, state, frames.ambe_fr2, 90, 18, 18);
         dmr_ms_fill_ambe_from_stream(opts, state, frames.ambe_fr3, 108, 36, 0);
+        dmr_debug_dump_burst(opts, state, state->currentslot, 0x10);
         dmr_ms_dump_dsp_output(opts, state);
 
         state->dmr_ms_mode = 1;
@@ -389,6 +409,7 @@ dmrMSBootstrap(dsd_opts* opts, dsd_state* state) {
     dmr_ms_prepare_bootstrap_payload(state);
     dmr_ms_collect_bootstrap_cach(opts, state, cachdata);
     dmr_ms_decode_bootstrap_voice(opts, state, &frames);
+    dmr_ms_dump_bootstrap_debug_burst(opts, state);
     dmr_ms_dump_dsp_output(opts, state);
     dmr_ms_print_bootstrap_sync(opts, state, timestr);
 

--- a/src/protocol/dmr/dmr_utils.c
+++ b/src/protocol/dmr/dmr_utils.c
@@ -12,11 +12,17 @@
 //Hamming17123, crc7, crc8, crc8ok functions
 //Original Souce - https://github.com/boatbod/op25
 
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
 #include <dsd-neo/fec/rs_12_9.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
+#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
 
 typedef struct {
     uint8_t syndrome;
@@ -39,6 +45,75 @@ dmr_hamming17123_apply_correction(uint8_t* d, uint8_t syndrome) {
         }
     }
     return false;
+}
+
+static uint8_t
+dmr_debug_payload_nibble(const int payload[144], size_t no_cach_nibble_index) {
+    const size_t dibit_pair_index = 6U + no_cach_nibble_index;
+    const size_t payload_index = dibit_pair_index * 2U;
+    const uint8_t hi = (uint8_t)(payload[payload_index] & 0x03);
+    const uint8_t lo = (uint8_t)(payload[payload_index + 1U] & 0x03);
+    return (uint8_t)((hi << 2U) | lo);
+}
+
+size_t
+dmr_debug_format_burst_payload(char* out, size_t out_size, const int payload[144], uint8_t slot_index,
+                               uint8_t burst_type) {
+    if (out == NULL || out_size == 0U || payload == NULL || slot_index > 1U) {
+        return 0U;
+    }
+
+    int n = DSD_SNPRINTF(out, out_size, "Debug Demod +Sync slot=%u type=0x%02X: ", (unsigned int)slot_index + 1U,
+                         (unsigned int)burst_type);
+    if (n < 0) {
+        out[0] = '\0';
+        return 0U;
+    }
+
+    size_t pos = (size_t)n;
+    if (pos >= out_size) {
+        out[out_size - 1U] = '\0';
+        return pos;
+    }
+
+    for (size_t byte_index = 0; byte_index < 33U; byte_index++) {
+        const uint8_t hi = dmr_debug_payload_nibble(payload, byte_index * 2U);
+        const uint8_t lo = dmr_debug_payload_nibble(payload, (byte_index * 2U) + 1U);
+        const uint8_t byte = (uint8_t)((hi << 4U) | lo);
+        n = DSD_SNPRINTF(out + pos, out_size - pos, "[%02X]", (unsigned int)byte);
+        if (n < 0) {
+            out[pos] = '\0';
+            return pos;
+        }
+        pos += (size_t)n;
+        if (pos >= out_size) {
+            out[out_size - 1U] = '\0';
+            return pos;
+        }
+    }
+
+    return pos;
+}
+
+size_t
+dmr_debug_format_burst(char* out, size_t out_size, const dsd_state* state, uint8_t slot_index, uint8_t burst_type) {
+    if (state == NULL) {
+        return 0U;
+    }
+    return dmr_debug_format_burst_payload(out, out_size, state->dmr_stereo_payload, slot_index, burst_type);
+}
+
+void
+dmr_debug_dump_burst(const dsd_opts* opts, const dsd_state* state, uint8_t slot_index, uint8_t burst_type) {
+    if (opts == NULL || state == NULL || opts->dmr_debug_burst == 0 || slot_index > 1U) {
+        return;
+    }
+
+    char line[192];
+    if (dmr_debug_format_burst(line, sizeof(line), state, slot_index, burst_type) == 0U) {
+        return;
+    }
+    DSD_FPRINTF(stderr, "%s\n", line);
 }
 
 uint16_t

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -863,6 +863,10 @@ cli_next_arg(char** argv, int i, int* arg_advance) {
             rdio_api_delete_after_upload_cli = 1;                                                                      \
             continue;                                                                                                  \
         }                                                                                                              \
+        if (strcmp(argv[i], "--dmr-debug-burst") == 0) {                                                               \
+            opts->dmr_debug_burst = 1;                                                                                 \
+            continue;                                                                                                  \
+        }                                                                                                              \
         if (strcmp(argv[i], "--dmr-baofeng-pc5") == 0) {                                                               \
             if (i + 1 >= argc) {                                                                                       \
                 LOG_ERROR("--dmr-baofeng-pc5 requires a hex key value\n");                                             \

--- a/src/runtime/cli/compact.c
+++ b/src/runtime/cli/compact.c
@@ -42,6 +42,7 @@ static const char* const k_skip_exact_no_arg[] = {
     "--auto-ppm",          "--rtltcp-autotune",      "--iq-loop",       "--rdio-api-delete-after-upload",
     "--enc-lockout",       "--enc-follow",           "--no-config",     "--print-config",
     "--interactive-setup", "--dump-config-template", "--strict-config", "--list-profiles",
+    "--dmr-debug-burst",
 };
 
 static const char* const k_skip_exact_next_any[] = {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3802,6 +3802,14 @@ target_include_directories(
 target_link_libraries(dsd-neo_test_dmr_bit_utils PRIVATE dsd-neo_proto_dmr)
 add_test(NAME DMR_BIT_UTILS COMMAND dsd-neo_test_dmr_bit_utils)
 
+add_executable(dsd-neo_test_dmr_debug_burst protocol/dmr/test_dmr_debug_burst.c)
+target_include_directories(
+    dsd-neo_test_dmr_debug_burst
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(dsd-neo_test_dmr_debug_burst PRIVATE dsd-neo_proto_dmr)
+add_test(NAME DMR_DEBUG_BURST COMMAND dsd-neo_test_dmr_debug_burst)
+
 add_executable(
     dsd-neo_test_dmr_confirmed_crc9
     protocol/dmr/test_dmr_confirmed_crc9.c

--- a/tests/protocol/dmr/test_dmr_bs_sync_times.c
+++ b/tests/protocol/dmr/test_dmr_bs_sync_times.c
@@ -187,6 +187,14 @@ dmr_data_burst_handler(dsd_opts* opts, dsd_state* state, uint8_t info[196], uint
     (void)databurst;
 }
 
+void
+dmr_debug_dump_burst(const dsd_opts* opts, const dsd_state* state, uint8_t slot_index, uint8_t burst_type) {
+    (void)opts;
+    (void)state;
+    (void)slot_index;
+    (void)burst_type;
+}
+
 uint8_t
 dmr_cach(dsd_opts* opts, dsd_state* state, uint8_t cach_bits[25]) {
     (void)opts;

--- a/tests/protocol/dmr/test_dmr_debug_burst.c
+++ b/tests/protocol/dmr/test_dmr_debug_burst.c
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static void
+set_no_cach_nibble(dsd_state* state, size_t no_cach_nibble_index, uint8_t value) {
+    const size_t dibit_pair_index = 6U + no_cach_nibble_index;
+    const size_t payload_index = dibit_pair_index * 2U;
+    state->dmr_stereo_payload[payload_index] = (value >> 2U) & 0x03;
+    state->dmr_stereo_payload[payload_index + 1U] = value & 0x03;
+}
+
+static void
+append_expected_byte(char* out, size_t out_size, uint8_t value) {
+    const size_t len = strlen(out);
+    if (len >= out_size) {
+        return;
+    }
+    DSD_SNPRINTF(out + len, out_size - len, "[%02X]", (unsigned int)value);
+}
+
+static void
+build_expected(char* expected, size_t expected_size) {
+    DSD_SNPRINTF(expected, expected_size, "Debug Demod +Sync slot=2 type=0x0A: ");
+    for (uint8_t byte = 0; byte < 33U; byte++) {
+        append_expected_byte(expected, expected_size, byte);
+    }
+}
+
+static int
+expect_debug_burst_line(const char* label, const char* actual, const char* expected) {
+    if (strcmp(actual, expected) != 0) {
+        DSD_FPRINTF(stderr, "unexpected %s debug burst\nexpected: %s\nactual:   %s\n", label, expected, actual);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_state_formatter(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    char expected[192];
+    build_expected(expected, sizeof(expected));
+    for (uint8_t byte = 0; byte < 33U; byte++) {
+        set_no_cach_nibble(&state, (size_t)byte * 2U, (uint8_t)(byte >> 4U));
+        set_no_cach_nibble(&state, ((size_t)byte * 2U) + 1U, (uint8_t)(byte & 0x0FU));
+    }
+
+    char actual[192];
+    size_t n = dmr_debug_format_burst(actual, sizeof(actual), &state, 1, 0x0A);
+    if (n == 0U) {
+        DSD_FPRINTF(stderr, "dmr_debug_format_burst returned zero\n");
+        return 1;
+    }
+    return expect_debug_burst_line("state", actual, expected);
+}
+
+static int
+test_payload_formatter(void) {
+    int payload[144];
+    DSD_MEMSET(payload, 0, sizeof(payload));
+
+    char expected[192];
+    build_expected(expected, sizeof(expected));
+    for (uint8_t byte = 0; byte < 33U; byte++) {
+        const size_t hi_index = (6U + ((size_t)byte * 2U)) * 2U;
+        const size_t lo_index = (6U + (((size_t)byte * 2U) + 1U)) * 2U;
+        payload[hi_index] = (byte >> 6U) & 0x03;
+        payload[hi_index + 1U] = (byte >> 4U) & 0x03;
+        payload[lo_index] = (byte >> 2U) & 0x03;
+        payload[lo_index + 1U] = byte & 0x03;
+    }
+
+    char actual[192];
+    size_t n = dmr_debug_format_burst_payload(actual, sizeof(actual), payload, 1, 0x0A);
+    if (n == 0U) {
+        DSD_FPRINTF(stderr, "dmr_debug_format_burst_payload returned zero\n");
+        return 1;
+    }
+    return expect_debug_burst_line("payload", actual, expected);
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_state_formatter();
+    rc |= test_payload_formatter();
+    return rc;
+}

--- a/tests/runtime/test_runtime_cli_compact.c
+++ b/tests/runtime/test_runtime_cli_compact.c
@@ -113,6 +113,25 @@ test_vendor_privacy_long_opts_are_removed(void) {
 }
 
 static int
+test_dmr_debug_burst_long_option_is_removed(void) {
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--dmr-debug-burst";
+    char arg2[] = "-fi";
+    char* argv[] = {arg0, arg1, arg2, NULL};
+
+    int new_argc = dsd_cli_compact_args(3, argv);
+    if (new_argc != 2) {
+        DSD_FPRINTF(stderr, "expected new_argc=2, got %d\n", new_argc);
+        return 1;
+    }
+    if (argv[1] == NULL || strcmp(argv[1], "-fi") != 0) {
+        DSD_FPRINTF(stderr, "expected argv[1] to be \"-fi\", got \"%s\"\n", argv[1] ? argv[1] : "(null)");
+        return 1;
+    }
+    return 0;
+}
+
+static int
 test_rtl_udp_control_consumes_port_and_leaves_short_opts(void) {
     char arg0[] = "dsd-neo";
     char arg1[] = "--rtl-udp-control";
@@ -283,6 +302,7 @@ main(void) {
     rc |= test_config_equals_form_is_removed();
     rc |= test_frame_log_consumes_path_and_leaves_short_opts();
     rc |= test_vendor_privacy_long_opts_are_removed();
+    rc |= test_dmr_debug_burst_long_option_is_removed();
     rc |= test_rtl_udp_control_consumes_port_and_leaves_short_opts();
     rc |= test_rtl_udp_control_missing_port_does_not_consume_next_option();
     rc |= test_rtl_udp_control_bind_consumes_address_and_leaves_short_opts();

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -2503,6 +2503,60 @@ test_frame_log_long_option_parse(void) {
 }
 
 static int
+test_dmr_debug_burst_long_option_parse(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--dmr-debug-burst";
+    char* argv[] = {arg0, arg1, NULL};
+
+    int argc_effective = 0;
+    int exit_rc = -1;
+    int rc = dsd_parse_args(2, argv, opts, state, &argc_effective, &exit_rc);
+    if (rc != DSD_PARSE_CONTINUE) {
+        DSD_FPRINTF(stderr, "expected rc=%d, got %d (exit_rc=%d)\n", DSD_PARSE_CONTINUE, rc, exit_rc);
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    int test_rc = 0;
+    if (opts->dmr_debug_burst != 1) {
+        DSD_FPRINTF(stderr, "expected dmr_debug_burst=1, got %u\n", (unsigned int)opts->dmr_debug_burst);
+        test_rc = 1;
+    }
+    if (opts->payload != 0) {
+        DSD_FPRINTF(stderr, "expected payload to remain off, got %d\n", opts->payload);
+        test_rc = 1;
+    }
+    if (opts->use_dsp_output != 0 || opts->dsp_out_file[0] != '\0') {
+        DSD_FPRINTF(stderr, "expected -Q output to remain off, got use_dsp_output=%d path=\"%s\"\n",
+                    opts->use_dsp_output, opts->dsp_out_file);
+        test_rc = 1;
+    }
+    if (argc_effective != 1) {
+        DSD_FPRINTF(stderr, "expected compacted argc=1, got %d\n", argc_effective);
+        test_rc = 1;
+    }
+
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
 test_input_source_arg_roundtrip(const char* input_spec) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
@@ -4905,6 +4959,7 @@ main(void) {
     rc |= test_sdrtrunk_json_forced_dmr_algid_uses_talkgroup_key();
     rc |= test_rdio_long_options_parse();
     rc |= test_frame_log_long_option_parse();
+    rc |= test_dmr_debug_burst_long_option_parse();
     rc |= test_input_source_soapy_roundtrip();
     rc |= test_input_source_soapy_args_roundtrip();
     rc |= test_input_source_rtl_roundtrip();


### PR DESCRIPTION
## Summary
- add `--dmr-debug-burst` for synced DMR burst dumps to stderr
- share no-CACH burst formatting across BS, MS/DM, and data paths
- document the debug option plus Windows console/config startup usage

## Notes
- voice bursts report `type=0x10`; data bursts use the decoded DMR data burst type
- `-Q` OK-DMRlib output and `-Z` payload logging remain independent
- MS bootstrap debug uses a normalized temporary payload copy for inverted DMR
- data debug output is printed after the normal status line to preserve console formatting

## Validation
- `tools/format.sh`
- `tools/iwyu.sh --strict -- src/protocol/dmr/dmr_utils.c tests/protocol/dmr/test_dmr_debug_burst.c`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug -R '^(DMR_DEBUG_BURST|RUNTIME_CLI_PARSE|RUNTIME_CLI_COMPACT)$' --output-on-failure`
- `ctest --preset dev-debug --output-on-failure`
- `git push -u origin issue-142-dmr-debug-burst` pre-push hook passed: install destination guard, secret/workflow/vcpkg pin guards, clang-format, gersemi, clang-tidy, cppcheck, IWYU, GCC analyzer, Semgrep, and Lizard; scan-build was skipped by the hook default