### PR TITLE
ui: fix no-radio snr readout build

### DIFF
--- a/src/ui/terminal/ui_snr_readout.c
+++ b/src/ui/terminal/ui_snr_readout.c
@@ -23,12 +23,12 @@ ui_snr_mod_label(int rf_mod) {
     return "C4FM";
 }
 
+#ifdef USE_RADIO
 static int
 ui_snr_value_is_valid(double snr) {
     return snr > (double)UI_SNR_INVALID_DB;
 }
 
-#ifdef USE_RADIO
 enum {
     UI_SNR_STALE_THRESHOLD_CDB = 5, /* 0.05 dB in centi-dB */
     UI_SNR_STALE_LIMIT = 40

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -945,6 +945,20 @@ target_link_libraries(
 )
 add_test(NAME UI_SNR_READOUT COMMAND dsd-neo_test_ui_snr_readout)
 
+add_executable(
+    dsd-neo_test_ui_snr_readout_no_radio
+    ui/test_ui_snr_readout_no_radio.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_snr_readout.c
+)
+target_include_directories(
+    dsd-neo_test_ui_snr_readout_no_radio
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
+)
+add_test(
+    NAME UI_SNR_READOUT_NO_RADIO
+    COMMAND dsd-neo_test_ui_snr_readout_no_radio
+)
+
 if(NOT DSD_HAS_PDCURSES_WIDE_API)
     add_executable(
         dsd-neo_test_ui_snr_meter_pdc_wide_no_api

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -373,6 +373,7 @@ main(void) {
     assert(g_last_setfreq_hz == 853500000);
     assert(g_rtl_tune_calls == 0);
 
+#ifdef USE_RADIO
     /* RTL audio retuned by rigctl has no native RTL controller boundary, so the
      * queued P25 VC demod profile must be applied after SetFreq succeeds. */
     DSD_MEMSET(opts, 0, sizeof(*opts));
@@ -405,6 +406,7 @@ main(void) {
     assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
     assert(g_rtl_ted_sps == 8);
     assert(g_rtl_ted_sps_override == 8);
+#endif
 
     /* If the frequency command itself fails, the decoder must not advance state
      * or reset DSP acquisition state for a channel it did not tune to. */

--- a/tests/ui/test_ui_snr_readout_no_radio.c
+++ b/tests/ui/test_ui_snr_readout_no_radio.c
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "ui_snr_readout.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static void
+expect_no_radio_readout(int rf_mod, const char* expected_label) {
+    ui_snr_readout got = ui_snr_readout_for_mod(rf_mod);
+    const char* actual_label = got.mod_label ? got.mod_label : "";
+
+    assert(got.valid == 0);
+    assert(got.snr_db == -50.0);
+    assert(strcmp(actual_label, expected_label) == 0);
+}
+
+int
+main(void) {
+    expect_no_radio_readout(0, "C4FM");
+    expect_no_radio_readout(1, "QPSK");
+    expect_no_radio_readout(2, "GFSK");
+
+    printf("UI_SNR_READOUT_NO_RADIO: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Keep the SNR validity helper behind `USE_RADIO` so no-radio builds do not fail `-Werror=unused-function`.
- Add no-radio SNR readout regression coverage for unavailable SNR values and modulation labels.
- Gate the RTL demod-profile trunk retune assertion behind `USE_RADIO` while leaving the generic rigctl and drain checks active in no-radio builds.

## Root Cause
The `backend-matrix (neither)` CI variant compiles `ui_snr_readout.c` without radio support. That disables the RTL-dependent readout call sites, leaving `ui_snr_value_is_valid()` unused under warnings-as-errors.

## Validation
- `tools/format.sh`
- `tools/cmake_format_check.sh`
- `cmake --preset dev-debug -DDSD_ENABLE_RTLSDR=OFF -DDSD_ENABLE_SOAPYSDR=OFF`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure` (no-radio, 377/377 passed)
- `cmake --preset dev-debug -DDSD_ENABLE_RTLSDR=ON -DDSD_ENABLE_SOAPYSDR=ON`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure` (radio-enabled, 387/387 passed)
- `tools/preflight_ci.sh`