### PR TITLE
p25: fix enc lockout gating and cc hunting

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -633,6 +633,8 @@ struct dsd_state {
     int p2_is_lcch;       //flag to tell us when a frame is lcch and not sacch
     // P25p2 per-slot audio gating (set on MAC_PTT/ACTIVE, cleared on MAC_END/IDLE/SIGNAL)
     int p25_p2_audio_allowed[2];
+    // P25p2 per-slot encrypted lockout mute marker for mixer suppression after service bits are cleared.
+    uint8_t p25_p2_enc_lockout_muted[2];
     // P25p2 small output jitter buffers (per-slot ring of decoded 20 ms frames)
     // Depth DSD_P25_P2_AUDIO_RING_DEPTH to match drain behavior (~80 ms max at depth=4)
     float p25_p2_audio_ring[2][DSD_P25_P2_AUDIO_RING_DEPTH][160];

--- a/include/dsd-neo/protocol/p25/p25_cc_candidates.h
+++ b/include/dsd-neo/protocol/p25/p25_cc_candidates.h
@@ -10,7 +10,7 @@
 /*
  * Control-channel candidates and neighbor list helpers for P25.
  * Provides small utilities to track announced neighbors, load/persist a
- * per-system candidate list, and expire stale entries.
+ * per-system current-site candidate list, and expire stale entries.
  */
 
 #ifndef DSD_NEO_INCLUDE_DSD_NEO_PROTOCOL_P25_P25_CC_CANDIDATES_H_H
@@ -56,7 +56,7 @@ typedef struct {
 int p25_cc_build_cache_path(const dsd_state* state, char* out, size_t out_len);
 
 /**
- * @brief Add a control channel candidate (Hz) with deduplication and FIFO rollover.
+ * @brief Add a validated current-site control channel candidate (Hz).
  *
  * @param state Decoder state containing candidate list.
  * @param freq_hz Candidate control channel frequency in Hz.

--- a/include/dsd-neo/runtime/trunk_cc_candidates.h
+++ b/include/dsd-neo/runtime/trunk_cc_candidates.h
@@ -7,8 +7,8 @@
  * @file
  * @brief Shared trunking control-channel candidate tracking.
  *
- * Stores CC candidate frequencies (discovered from neighbors/adjacent/network
- * messages) in a small struct attached to `dsd_state` via `dsd_state_ext`.
+ * Stores validated CC candidate frequencies in a small struct attached to
+ * `dsd_state` via `dsd_state_ext`.
  *
  * This keeps protocol libraries from expanding the core `dsd_state` struct with
  * protocol-specific fields while preserving existing candidate list behavior.
@@ -17,6 +17,7 @@
 #define DSD_NEO_INCLUDE_DSD_NEO_RUNTIME_TRUNK_CC_CANDIDATES_H_H
 
 #include <dsd-neo/core/state_fwd.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,8 +25,13 @@ extern "C" {
 
 enum { DSD_TRUNK_CC_CANDIDATES_MAX = 16 };
 
+enum {
+    DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE = 0x01,
+};
+
 typedef struct {
     long candidates[DSD_TRUNK_CC_CANDIDATES_MAX];
+    uint8_t flags[DSD_TRUNK_CC_CANDIDATES_MAX];
     int count;
     int idx;
     double cool_until[DSD_TRUNK_CC_CANDIDATES_MAX];
@@ -39,7 +45,12 @@ const dsd_trunk_cc_candidates* dsd_trunk_cc_candidates_peek(const dsd_state* sta
 
 int dsd_trunk_cc_candidates_add(dsd_state* state, long freq_hz, int bump_added);
 
+int dsd_trunk_cc_candidates_add_with_flags(dsd_state* state, long freq_hz, int bump_added, uint8_t flags);
+
 int dsd_trunk_cc_candidates_next(dsd_state* state, double now_monotonic_s, long* out_freq_hz);
+
+int dsd_trunk_cc_candidates_next_with_flags(dsd_state* state, double now_monotonic_s, uint8_t required_flags,
+                                            long* out_freq_hz);
 
 void dsd_trunk_cc_candidates_set_cooldown(const dsd_state* state, long freq_hz, double until_monotonic_s);
 

--- a/include/dsd-neo/ui/ui_history.h
+++ b/include/dsd-neo/ui/ui_history.h
@@ -15,6 +15,7 @@
 #define DSD_NEO_INCLUDE_DSD_NEO_UI_UI_HISTORY_H_
 
 #include <stddef.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,6 +44,15 @@ int ui_history_cycle_mode(void);
  * @return Number of characters written to @p out (excluding NUL).
  */
 size_t ui_history_compact_event_text(char* out, size_t out_size, const char* event_text, int mode);
+
+/**
+ * @brief Return the timestamp used for event-history ordering.
+ *
+ * Canonical event strings start with `YYYY-MM-DD HH:MM:SS `. When present,
+ * that displayed timestamp is authoritative so ordering matches what the UI
+ * prints. Noncanonical strings use @p fallback_time.
+ */
+time_t ui_history_event_sort_time(const char* event_text, time_t fallback_time);
 
 #ifdef __cplusplus
 }

--- a/src/core/audio/dsd_audio2.c
+++ b/src/core/audio/dsd_audio2.c
@@ -343,9 +343,58 @@ dsd_apply_dual_tg_audio_gate(const dsd_opts* opts, const dsd_state* state, int* 
     (void)dsd_audio_group_gate_dual(opts, state, TGL, TGR, *encL, *encR, encL, encR);
 }
 
+static int
+dsd_p25p2_slot_marked_encrypted(const dsd_state* state, int slot) {
+    int algid = (slot == 0) ? state->payload_algid : state->payload_algidR;
+    if (algid == 0x80) {
+        return 0;
+    }
+    if (algid != 0) {
+        return 1;
+    }
+    int svc = (slot == 0) ? state->dmr_so : state->dmr_soR;
+    return (svc & 0x40) != 0;
+}
+
+static int
+dsd_p25p2_slot_has_decrypt_key(const dsd_state* state, int slot) {
+    if (!state || slot < 0 || slot > 1) {
+        return 0;
+    }
+
+    int algid = (slot == 0) ? state->payload_algid : state->payload_algidR;
+    if (algid == 0 || algid == 0x80) {
+        return 0;
+    }
+
+    unsigned long long key = (slot == 0) ? state->R : state->RR;
+    if ((algid == 0xAA || algid == 0x81 || algid == 0x9F) && key != 0ULL) {
+        return 1;
+    }
+    if ((algid == 0x84 || algid == 0x89) && state->aes_key_loaded[slot] == 1) {
+        return 1;
+    }
+    return 0;
+}
+
+static int
+dsd_p25p2_encrypted_lockout_slot_muted(const dsd_opts* opts, const dsd_state* state, int slot, int muted) {
+    if (!opts || !state || slot < 0 || slot > 1 || !muted || opts->trunk_tune_enc_calls != 0) {
+        return 0;
+    }
+    if (state->p25_p2_enc_lockout_muted[slot] != 0) {
+        return 1;
+    }
+    return dsd_p25p2_slot_marked_encrypted(state, slot) && !dsd_p25p2_slot_has_decrypt_key(state, slot);
+}
+
 static void
-dsd_duplicate_active_float_quad_to_stereo(float stereo[4][320], int* encL, int* encR) {
+dsd_duplicate_active_float_quad_to_stereo(const dsd_opts* opts, const dsd_state* state, float stereo[4][320], int* encL,
+                                          int* encR) {
     if (!*encL && *encR) {
+        if (dsd_p25p2_encrypted_lockout_slot_muted(opts, state, 1, *encR)) {
+            return;
+        }
         for (int j = 0; j < 4; j++) {
             for (int i = 0; i < 320; i += 2) {
                 stereo[j][i + 1] = stereo[j][i + 0];
@@ -355,6 +404,9 @@ dsd_duplicate_active_float_quad_to_stereo(float stereo[4][320], int* encL, int* 
         return;
     }
     if (*encL && !*encR) {
+        if (dsd_p25p2_encrypted_lockout_slot_muted(opts, state, 0, *encL)) {
+            return;
+        }
         for (int j = 0; j < 4; j++) {
             for (int i = 0; i < 320; i += 2) {
                 stereo[j][i + 0] = stereo[j][i + 1];
@@ -568,8 +620,11 @@ dsd_p25p2_apply_slot_preference_ss18(dsd_opts* opts, const dsd_state* state, uns
 }
 
 static int
-dsd_ss18_should_copy_right_to_left(const dsd_opts* opts, const dsd_state* state, int encR) {
+dsd_ss18_should_copy_right_to_left(const dsd_opts* opts, const dsd_state* state, int encL, int encR) {
     if (encR != 0) {
+        return 0;
+    }
+    if (dsd_p25p2_encrypted_lockout_slot_muted(opts, state, 0, encL)) {
         return 0;
     }
     if (opts->slot1_on == 0 && opts->slot2_on == 1) {
@@ -585,8 +640,11 @@ dsd_ss18_should_copy_right_to_left(const dsd_opts* opts, const dsd_state* state,
 }
 
 static int
-dsd_ss18_should_copy_left_to_right(const dsd_opts* opts, const dsd_state* state, int encL) {
+dsd_ss18_should_copy_left_to_right(const dsd_opts* opts, const dsd_state* state, int encL, int encR) {
     if (encL != 0) {
+        return 0;
+    }
+    if (dsd_p25p2_encrypted_lockout_slot_muted(opts, state, 1, encR)) {
         return 0;
     }
     if (opts->slot1_on == 1 && opts->slot2_on == 0) {
@@ -609,9 +667,9 @@ dsd_p25p2_apply_stereo_output_policy_ss18(const dsd_opts* opts, dsd_state* state
     if (encR) {
         DSD_MEMSET(state->s_r4, 0, sizeof(state->s_r4));
     }
-    if (dsd_ss18_should_copy_right_to_left(opts, state, encR)) {
+    if (dsd_ss18_should_copy_right_to_left(opts, state, encL, encR)) {
         DSD_MEMCPY(state->s_l4, state->s_r4, sizeof(state->s_l4));
-    } else if (dsd_ss18_should_copy_left_to_right(opts, state, encL)) {
+    } else if (dsd_ss18_should_copy_left_to_right(opts, state, encL, encR)) {
         DSD_MEMCPY(state->s_r4, state->s_l4, sizeof(state->s_r4));
     }
 }
@@ -772,7 +830,7 @@ playSynthesizedVoiceFS4(dsd_opts* opts, dsd_state* state) {
 
     dsd_fs4_pop_gain_frames(opts, state, lf, rf, l_ok, r_ok);
     dsd_fs4_mix_interleaved_frames(lf, rf, encL, encR, l_ok, r_ok, stereo);
-    dsd_duplicate_active_float_quad_to_stereo(stereo, &encL, &encR);
+    dsd_duplicate_active_float_quad_to_stereo(opts, state, stereo, &encL, &encR);
 
     if (encL && encR) {
         goto END_FS4;

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -187,6 +187,15 @@ watchdog_event_should_write_slot(const dsd_state* state) {
 }
 
 static int
+watchdog_event_item_has_content(const Event_History* item) {
+    if (item == NULL) {
+        return 0;
+    }
+    return item->event_string[0] != '\0' || item->text_message[0] != '\0' || item->alias[0] != '\0'
+           || item->gps_s[0] != '\0' || item->internal_str[0] != '\0';
+}
+
+static int
 watchdog_event_is_m17_sync(int synctype) {
     return (synctype == DSD_SYNC_M17_STR_POS || synctype == DSD_SYNC_M17_STR_NEG || synctype == DSD_SYNC_M17_LSF_POS
             || synctype == DSD_SYNC_M17_LSF_NEG);
@@ -320,12 +329,18 @@ watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot) {
     uint8_t swrite = watchdog_event_should_write_slot(state);
     uint32_t last_source_id = event_struct->Event_History_Items[0].source_id;
     int last_event_is_data = event_struct->Event_History_Items[0].subtype == DSD_EVENT_SUBTYPE_DATA;
+    int last_event_has_content = watchdog_event_item_has_content(&event_struct->Event_History_Items[0]);
     uint32_t source_id = watchdog_event_source_id(opts, state, slot);
 
     //call alert beep when new call detected
     if (last_source_id == 0 && source_id != 0
         && dsd_call_alert_event_enabled(opts->call_alert, opts->call_alert_events, DSD_CALL_ALERT_EVENT_VOICE_START)) {
         beeper(opts, state, slot, 40, 86, 3);
+    }
+
+    if (last_event_is_data && last_event_has_content) {
+        watchdog_event_handle_source_transition(opts, state, event_struct, slot, swrite, last_event_is_data);
+        return;
     }
 
     if (source_id != last_source_id && last_source_id != 0) {
@@ -672,10 +687,6 @@ watchdog_event_current_load_labels(const dsd_state* state, watchdog_event_curren
 static void
 watchdog_event_current_update_item(const dsd_opts* opts, dsd_state* state, uint8_t slot, Event_History_I* event_struct,
                                    const watchdog_event_current_ctx* ctx) {
-    if (ctx->source_id == 0) {
-        return;
-    }
-
     event_struct->Event_History_Items[0].write = 0;
     state->event_history_s[slot].Event_History_Items[0].color_pair = ctx->color_pair;
     if (state->lastsynctype != DSD_SYNC_NONE) {

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -727,6 +727,8 @@ init_state_protocol_defaults_a(dsd_state* state) {
     state->fourv_counter[1] = 0;
     state->voice_counter[0] = 0;
     state->voice_counter[1] = 0;
+    state->p25_p2_enc_lockout_muted[0] = 0;
+    state->p25_p2_enc_lockout_muted[1] = 0;
 
     state->K = 0;
     state->R = 0;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1365,6 +1365,8 @@ no_carrier_clear_stale_p25_return_hints_after_generic_activity(dsd_opts* opts, d
     state->p25_p2_active_slot = -1;
     state->p25_p2_audio_allowed[0] = 0;
     state->p25_p2_audio_allowed[1] = 0;
+    state->p25_p2_enc_lockout_muted[0] = 0;
+    state->p25_p2_enc_lockout_muted[1] = 0;
     state->p25_call_is_packet[0] = 0;
     state->p25_call_is_packet[1] = 0;
     opts->p25_is_tuned = 0;
@@ -1447,6 +1449,8 @@ no_carrier_clear_voice_tune_state(dsd_opts* opts, dsd_state* state) {
     state->p25_p2_active_slot = -1;
     state->p25_p2_audio_allowed[0] = 0;
     state->p25_p2_audio_allowed[1] = 0;
+    state->p25_p2_enc_lockout_muted[0] = 0;
+    state->p25_p2_enc_lockout_muted[1] = 0;
     state->p25_call_is_packet[0] = 0;
     state->p25_call_is_packet[1] = 0;
 }

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -95,6 +95,8 @@ dsd_engine_reset_return_to_cc_state(dsd_opts* opts, dsd_state* state) {
     state->trunk_vc_freq[1] = 0;
     state->p25_p2_audio_allowed[0] = 0;
     state->p25_p2_audio_allowed[1] = 0;
+    state->p25_p2_enc_lockout_muted[0] = 0;
+    state->p25_p2_enc_lockout_muted[1] = 0;
     state->p25_call_is_packet[0] = 0;
     state->p25_call_is_packet[1] = 0;
     state->p25_p2_active_slot = -1;

--- a/src/protocol/p25/p25_cc_candidates.c
+++ b/src/protocol/p25/p25_cc_candidates.c
@@ -33,7 +33,7 @@ p25_cc_add_candidate(dsd_state* state, long freq_hz, int bump_added) {
     if (freq_hz == state->p25_cc_freq) {
         return 0;
     }
-    return dsd_trunk_cc_candidates_add(state, freq_hz, bump_added);
+    return dsd_trunk_cc_candidates_add_with_flags(state, freq_hz, bump_added, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE);
 }
 
 int
@@ -65,14 +65,80 @@ p25_cc_build_cache_path(const dsd_state* state, char* out, size_t out_len) {
     return (n > 0 && (size_t)n < out_len);
 }
 
+static int
+p25_cc_cache_enabled(void) {
+    const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
+    return cfg ? cfg->cc_cache_enable : 1;
+}
+
+static char*
+p25_cc_cache_skip_ws(char* p) {
+    while (*p == ' ' || *p == '\t') {
+        p++;
+    }
+    return p;
+}
+
+static const char*
+p25_cc_cache_line_payload(char* line) {
+    char* p = p25_cc_cache_skip_ws(line);
+    if (p[0] != 'c' || p[1] != 'c' || (p[2] != ' ' && p[2] != '\t')) {
+        return NULL;
+    }
+    return p25_cc_cache_skip_ws(p + 2);
+}
+
+static int
+p25_cc_parse_cache_line(char* line, long* out_freq_hz) {
+    char* end = NULL;
+    const char* p = p25_cc_cache_line_payload(line);
+    if (!p) {
+        return 0;
+    }
+
+    long freq_hz = strtol(p, &end, 10);
+    if (end == p || freq_hz <= 0) {
+        return 0;
+    }
+
+    *out_freq_hz = freq_hz;
+    return 1;
+}
+
+static void
+p25_cc_load_cache_lines(FILE* fp, dsd_state* state) {
+    char line[256];
+    while (fgets(line, sizeof(line), fp)) {
+        long freq_hz = 0;
+        if (p25_cc_parse_cache_line(line, &freq_hz)) {
+            (void)p25_cc_add_candidate(state, freq_hz, 0);
+        }
+    }
+}
+
+static int
+p25_cc_loaded_candidate_count(const dsd_state* state) {
+    const dsd_trunk_cc_candidates* cc = dsd_trunk_cc_candidates_peek(state);
+    if (!cc || cc->count <= 0 || cc->count > DSD_TRUNK_CC_CANDIDATES_MAX) {
+        return 0;
+    }
+    return cc->count;
+}
+
+static void
+p25_cc_log_cache_load(const dsd_opts* opts, const dsd_state* state) {
+    const int count = p25_cc_loaded_candidate_count(state);
+    if (opts && opts->verbose > 0 && count > 0) {
+        DSD_FPRINTF(stderr, "\n  P25 SM: Loaded %d CC candidates from cache\n", count);
+    }
+}
+
 void
 p25_cc_try_load_cache(const dsd_opts* opts, dsd_state* state) {
     if (!state || state->p25_cc_cache_loaded) {
         return;
     }
-    const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
-    int enable = cfg ? cfg->cc_cache_enable : 1;
-    if (!enable) {
+    if (!p25_cc_cache_enabled()) {
         state->p25_cc_cache_loaded = 1;
         return;
     }
@@ -87,23 +153,10 @@ p25_cc_try_load_cache(const dsd_opts* opts, dsd_state* state) {
         return;
     }
 
-    char line[256];
-    while (fgets(line, sizeof(line), fp)) {
-        char* end = NULL;
-        long f = strtol(line, &end, 10);
-        if (end == line) {
-            continue;
-        }
-        (void)p25_cc_add_candidate(state, f, 0);
-    }
+    p25_cc_load_cache_lines(fp, state);
     fclose(fp);
     state->p25_cc_cache_loaded = 1;
-
-    const dsd_trunk_cc_candidates* cc = dsd_trunk_cc_candidates_peek(state);
-    const int count = (cc && cc->count > 0 && cc->count <= DSD_TRUNK_CC_CANDIDATES_MAX) ? cc->count : 0;
-    if (opts && opts->verbose > 0 && count > 0) {
-        DSD_FPRINTF(stderr, "\n  P25 SM: Loaded %d CC candidates from cache\n", count);
-    }
+    p25_cc_log_cache_load(opts, state);
 }
 
 void
@@ -111,9 +164,7 @@ p25_cc_persist_cache(const dsd_opts* opts, const dsd_state* state) {
     if (!state) {
         return;
     }
-    const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
-    int enable = cfg ? cfg->cc_cache_enable : 1;
-    if (!enable) {
+    if (!p25_cc_cache_enabled()) {
         return;
     }
 
@@ -132,8 +183,8 @@ p25_cc_persist_cache(const dsd_opts* opts, const dsd_state* state) {
     const dsd_trunk_cc_candidates* cc = dsd_trunk_cc_candidates_peek(state);
     const int count = (cc && cc->count > 0 && cc->count <= DSD_TRUNK_CC_CANDIDATES_MAX) ? cc->count : 0;
     for (int i = 0; i < count; i++) {
-        if (cc->candidates[i] != 0) {
-            DSD_FPRINTF(fp, "%ld\n", cc->candidates[i]);
+        if (cc->candidates[i] != 0 && (cc->flags[i] & DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE) != 0) {
+            DSD_FPRINTF(fp, "cc %ld\n", cc->candidates[i]);
         }
     }
     fclose(fp);

--- a/src/protocol/p25/p25_test_shim.c
+++ b/src/protocol/p25/p25_test_shim.c
@@ -601,6 +601,7 @@ p25_test_p2_early_enc_handle(dsd_opts* opts, dsd_state* state, int slot) {
     int eslot = slot & 1;
     int other_audio = state->p25_p2_audio_allowed[eslot ^ 1];
     state->p25_p2_audio_allowed[eslot] = 0;
+    state->p25_p2_enc_lockout_muted[eslot] = 1;
     // Mirror production behavior: flush any queued audio for this slot so
     // residual samples do not bleed into playback after gating.
     p25_p2_audio_ring_reset(state, eslot);

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -818,6 +818,7 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
         // Even when encrypted calls are permitted, keep the gate aligned with
         // the current media policy so allow-list/TG-hold blocks are not reopened.
         state->p25_p2_audio_allowed[slot] = allow_audio;
+        state->p25_p2_enc_lockout_muted[slot] = 0;
         return;
     }
 
@@ -830,6 +831,7 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
     // policy; do not reopen slots that the caller already blocked.
     if (can_decrypt) {
         state->p25_p2_audio_allowed[slot] = allow_audio;
+        state->p25_p2_enc_lockout_muted[slot] = 0;
         return;
     }
 
@@ -842,6 +844,7 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
 
     // Gate audio for this slot
     state->p25_p2_audio_allowed[slot] = 0;
+    state->p25_p2_enc_lockout_muted[slot] = 1;
     p25_p2_audio_ring_reset(state, slot);
 
     // Clear voice activity indicator to prevent audio routing logic from
@@ -935,6 +938,8 @@ p25_release_clear_decoder_state(dsd_opts* opts, dsd_state* state) {
         state->payload_keyidR = 0;
         state->payload_miP = 0;
         state->payload_miN = 0;
+        state->p25_p2_enc_lockout_muted[0] = 0;
+        state->p25_p2_enc_lockout_muted[1] = 0;
         state->p25_sm_release_count++;
     }
     if (opts) {
@@ -998,7 +1003,7 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
 // Get next CC candidate (with cooldown check)
 static int
 next_cc_candidate(dsd_state* state, long* out_freq, double now_m) {
-    return dsd_trunk_cc_candidates_next(state, now_m, out_freq);
+    return dsd_trunk_cc_candidates_next_with_flags(state, now_m, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE, out_freq);
 }
 
 // Get next LCN frequency from user-provided list
@@ -1690,6 +1695,9 @@ p25_sm_update_audio_gate(p25_sm_ctx_t* ctx, dsd_state* state, int slot, int algi
 
     // Update audio gating in state (single source of truth)
     state->p25_p2_audio_allowed[s] = slot_can_decrypt(state, s, algid) ? 1 : 0;
+    if (state->p25_p2_audio_allowed[s] != 0) {
+        state->p25_p2_enc_lockout_muted[s] = 0;
+    }
 }
 
 /* ============================================================================

--- a/src/protocol/p25/p25_trunk_sm_wrappers.c
+++ b/src/protocol/p25/p25_trunk_sm_wrappers.c
@@ -50,8 +50,11 @@ p25_sm_on_neighbor_update_default(const dsd_opts* opts, dsd_state* state, const 
         }
         // Track neighbor list for UI
         p25_nb_add(state, f);
-        // Add to candidate list (dedup + FIFO rollover)
-        (void)p25_cc_add_candidate(state, f, 1);
+        /*
+         * Do not promote generic neighbor/RFSS updates to CC hunt candidates.
+         * Current-site secondary CC broadcasts call p25_cc_add_candidate()
+         * directly after site validation.
+         */
     }
 }
 
@@ -71,7 +74,7 @@ p25_sm_next_cc_candidate_default(dsd_state* state, long* out_freq) {
         return 0;
     }
     double nowm = now_monotonic();
-    return dsd_trunk_cc_candidates_next(state, nowm, out_freq);
+    return dsd_trunk_cc_candidates_next_with_flags(state, nowm, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE, out_freq);
 }
 
 int

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -55,7 +55,44 @@ extern int16_t ess_a_llr[2][168];
 
 #if defined(DSD_NEO_P25P2_TEST_STUB)
 #define p25_sm_emit_active(opts, state, slot) ((void)(opts), (void)(state), (void)(slot))
+#define p25_sm_emit_idle(opts, state, slot)   ((void)(opts), (void)(state), (void)(slot))
 #define p25_sm_on_release(opts, state)        ((void)(opts), (void)(state))
+#endif
+
+static int p25p2_ess_other_slot_active(const dsd_state* state, int other);
+static int p25p2_ess_have_decrypt_key(int alg, unsigned long long int key, int aes_loaded);
+static void p25p2_ess_release_or_defer_cc(dsd_opts* opts, dsd_state* state);
+static void p25p2_ess_clear_call_banner(dsd_state* state, int slot);
+
+#if defined(DSD_NEO_P25P2_TEST_STUB)
+static int
+p25p2_frame_test_stub_media_allowed(const dsd_opts* opts, const dsd_state* state, int slot) {
+    if (!opts || opts->trunk_use_allow_list != 1) {
+        return 1;
+    }
+    int target = (slot == 0) ? state->lasttg : state->lasttgR;
+    return (target > 0 && state->tg_hold == (unsigned long)target) ? 1 : 0;
+}
+
+static int
+p25p2_frame_test_stub_can_decrypt(const dsd_state* state, int slot, int alg) {
+    if (!state || slot < 0 || slot > 1) {
+        return 0;
+    }
+    if (alg == 0 || alg == 0x80) {
+        return 1;
+    }
+    unsigned long long key = (slot == 0) ? state->R : state->RR;
+    if ((alg == 0xAA || alg == 0x81 || alg == 0x9F) && key != 0ULL) {
+        return 1;
+    }
+    if ((alg == 0x84 || alg == 0x89) && state->aes_key_loaded[slot] == 1) {
+        return 1;
+    }
+    return 0;
+}
+
+void p25p2_test_decode_voice_frame_for_lockout(dsd_opts* opts, dsd_state* state);
 #endif
 
 static int
@@ -73,26 +110,112 @@ p25_p2_s16_frames_have_audio(short frames[18][160]) {
 static int DSD_ATTR_USED
 p25p2_frame_slot_audio_allowed(const dsd_opts* opts, const dsd_state* state, int slot, int alg) {
 #if defined(DSD_NEO_P25P2_TEST_STUB)
-    unsigned long long key = 0;
-    (void)opts;
-
-    if (!state || slot < 0 || slot > 1) {
-        return 0;
-    }
-    if (alg == 0 || alg == 0x80) {
-        return 1;
-    }
-    key = (slot == 0) ? state->R : state->RR;
-    if ((alg == 0xAA || alg == 0x81 || alg == 0x9F) && key != 0ULL) {
-        return 1;
-    }
-    if ((alg == 0x84 || alg == 0x89) && state->aes_key_loaded[slot] == 1) {
-        return 1;
-    }
-    return 0;
+    return p25p2_frame_test_stub_can_decrypt(state, slot, alg)
+           && p25p2_frame_test_stub_media_allowed(opts, state, slot);
 #else
     return dsd_p25p2_decode_audio_allowed(opts, state, slot, alg);
 #endif
+}
+
+static int
+p25p2_frame_slot_service_options(const dsd_state* state, int slot) {
+    return (slot == 0) ? state->dmr_so : state->dmr_soR;
+}
+
+static int
+p25p2_frame_slot_algid(const dsd_state* state, int slot) {
+    return (slot == 0) ? state->payload_algid : state->payload_algidR;
+}
+
+static int
+p25p2_frame_slot_has_decrypt_key(const dsd_state* state, int slot, int alg) {
+    if (!state || slot < 0 || slot > 1 || alg == 0 || alg == 0x80) {
+        return 0;
+    }
+
+    unsigned long long int key = (slot == 0) ? state->R : state->RR;
+    return p25p2_ess_have_decrypt_key(alg, key, state->aes_key_loaded[slot]);
+}
+
+static int
+p25p2_frame_slot_marked_encrypted(const dsd_state* state, int slot, int alg) {
+    if (alg == 0x80) {
+        return 0;
+    }
+    if (alg != 0) {
+        return 1;
+    }
+    int svc = p25p2_frame_slot_service_options(state, slot);
+    return (svc & 0x40) != 0;
+}
+
+static int
+p25p2_frame_encrypted_lockout_blocks_voice(const dsd_opts* opts, const dsd_state* state, int slot) {
+    if (!opts || !state || slot < 0 || slot > 1 || opts->trunk_tune_enc_calls != 0) {
+        return 0;
+    }
+
+    int alg = p25p2_frame_slot_algid(state, slot);
+    if (!p25p2_frame_slot_marked_encrypted(state, slot, alg)) {
+        return 0;
+    }
+    if (p25p2_frame_slot_has_decrypt_key(state, slot, alg)) {
+        return 0;
+    }
+    return 1;
+}
+
+static void
+p25p2_frame_clear_locked_slot_state(dsd_state* state, int slot) {
+    if (!state || slot < 0 || slot > 1) {
+        return;
+    }
+    if (slot == 0) {
+        state->payload_algid = 0;
+        state->payload_keyid = 0;
+        state->payload_miP = 0ULL;
+        state->dmrburstL = 0;
+        state->fourv_counter[0] = 0;
+        state->voice_counter[0] = 0;
+        state->DMRvcL = 0;
+        state->dropL = 256;
+        return;
+    }
+    state->payload_algidR = 0;
+    state->payload_keyidR = 0;
+    state->payload_miN = 0ULL;
+    state->dmrburstR = 0;
+    state->fourv_counter[1] = 0;
+    state->voice_counter[1] = 0;
+    state->DMRvcR = 0;
+    state->dropR = 256;
+}
+
+static void
+p25p2_frame_set_enc_lockout_marker(dsd_state* state, int slot, int muted) {
+    if (!state || slot < 0 || slot > 1) {
+        return;
+    }
+    state->p25_p2_enc_lockout_muted[slot] = (uint8_t)(muted ? 1U : 0U);
+}
+
+static void
+p25p2_frame_apply_encrypted_lockout(dsd_opts* opts, dsd_state* state, int slot) {
+    if (!opts || !state || slot < 0 || slot > 1) {
+        return;
+    }
+
+    p25_sm_emit_idle(opts, state, slot);
+    p25p2_frame_set_enc_lockout_marker(state, slot, 1);
+    p25p2_frame_clear_locked_slot_state(state, slot);
+
+    int other = slot ^ 1;
+    if (opts->p25_trunk == 1 && opts->p25_is_tuned == 1 && !p25p2_ess_other_slot_active(state, other)) {
+        p25p2_ess_release_or_defer_cc(opts, state);
+        return;
+    }
+
+    p25p2_ess_clear_call_banner(state, slot);
 }
 
 static int
@@ -131,6 +254,8 @@ p25_p2_teardown_call(dsd_opts* opts, dsd_state* state) {
 
     state->p25_p2_audio_allowed[0] = 0;
     state->p25_p2_audio_allowed[1] = 0;
+    p25p2_frame_set_enc_lockout_marker(state, 0, 0);
+    p25p2_frame_set_enc_lockout_marker(state, 1, 0);
     p25_p2_audio_ring_reset(state, -1);
     // Clear buffered short audio frames to avoid replaying stale samples on
     // subsequent short calls that never reach the normal SS18 playback path.
@@ -938,6 +1063,16 @@ p25p2_decode_and_store_voice_frame(dsd_opts* opts, dsd_state* state, dsd_vocoder
         p25p2_zero_voice_frame(state, frame_index);
         return;
     }
+    if (p25p2_frame_encrypted_lockout_blocks_voice(opts, state, slot)) {
+        int alg = p25p2_frame_slot_algid(state, slot);
+        state->p25_p2_audio_allowed[slot] = 0;
+        p25_p2_audio_ring_reset(state, slot);
+        p25p2_zero_voice_frame(state, frame_index);
+        if (alg != 0 && alg != 0x80) {
+            p25p2_frame_apply_encrypted_lockout(opts, state, slot);
+        }
+        return;
+    }
     if (!state->p25_p2_audio_allowed[slot]) {
         p25p2_zero_voice_frame(state, frame_index);
         return;
@@ -945,6 +1080,14 @@ p25p2_decode_and_store_voice_frame(dsd_opts* opts, dsd_state* state, dsd_vocoder
     processMbeFrameSoft(opts, state, NULL, ambe_soft, NULL);
     p25p2_store_decoded_voice_frame(state, frame_index, push_ring);
 }
+
+#if defined(DSD_NEO_P25P2_TEST_STUB)
+void
+p25p2_test_decode_voice_frame_for_lockout(dsd_opts* opts, dsd_state* state) {
+    dsd_vocoder_soft_bit ambe_soft[4][24] = {{{0}}};
+    p25p2_decode_and_store_voice_frame(opts, state, ambe_soft, 0, 0);
+}
+#endif
 
 static void
 process_4V(dsd_opts* opts, dsd_state* state) {
@@ -1059,12 +1202,14 @@ p25p2_frame_vc_grace_s(const dsd_state* state, double fallback) {
 static void
 p25p2_ess_maybe_enable_audio_slot(const dsd_opts* opts, dsd_state* state, int slot, int alg, int burst) {
     if (state->p25_p2_audio_allowed[slot] != 0) {
+        p25p2_frame_set_enc_lockout_marker(state, slot, 0);
         return;
     }
     int in_call = ((burst >= 20 && burst <= 22) || voice);
     int allow = in_call && p25p2_frame_slot_audio_allowed(opts, state, slot, alg);
     if (allow) {
         state->p25_p2_audio_allowed[slot] = 1;
+        p25p2_frame_set_enc_lockout_marker(state, slot, 0);
     }
 }
 
@@ -1077,6 +1222,7 @@ p25p2_ess_apply_slot0(const dsd_opts* opts, dsd_state* state, unsigned long long
     p25p2_ess_maybe_enable_audio_slot(opts, state, 0, state->payload_algid, state->dmrburstL);
 
     if (state->payload_algid == 0x80 || state->payload_algid == 0x0) {
+        p25p2_frame_set_enc_lockout_marker(state, 0, 0);
         return;
     }
 
@@ -1112,6 +1258,7 @@ p25p2_ess_apply_slot1(const dsd_opts* opts, dsd_state* state, unsigned long long
     p25p2_ess_maybe_enable_audio_slot(opts, state, 1, state->payload_algidR, state->dmrburstR);
 
     if (state->payload_algidR == 0x80 || state->payload_algidR == 0x0) {
+        p25p2_frame_set_enc_lockout_marker(state, 1, 0);
         return;
     }
 
@@ -1221,6 +1368,8 @@ p25p2_ess_apply_enc_lockout(dsd_opts* opts, dsd_state* state) {
     p25_emit_enc_lockout_once(opts, state, (uint8_t)eslot, ttg, /*svc_bits*/ 0);
     state->p25_p2_audio_allowed[eslot] = 0;
     p25_p2_audio_ring_reset(state, eslot);
+    p25p2_frame_set_enc_lockout_marker(state, eslot, 1);
+    p25p2_frame_clear_locked_slot_state(state, eslot);
 
     int other = eslot ^ 1;
     if (!p25p2_ess_other_slot_active(state, other)) {
@@ -1545,6 +1694,8 @@ p25p2_duid_should_abort(dsd_state* state, int err_counter) {
     state->payload_algidR = 0;
     state->payload_keyidR = 0;
     state->p2_is_lcch = 0;
+    p25p2_frame_set_enc_lockout_marker(state, 0, 0);
+    p25p2_frame_set_enc_lockout_marker(state, 1, 0);
     state->fourv_counter[0] = 0;
     state->fourv_counter[1] = 0;
     state->voice_counter[0] = 0;

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -199,7 +199,8 @@ p25p2_frame_set_enc_lockout_marker(dsd_state* state, int slot, int muted) {
     state->p25_p2_enc_lockout_muted[slot] = (uint8_t)(muted ? 1U : 0U);
 }
 
-static void
+// Reached through 2V/4V voice-frame dispatch; keep visible to analyzer builds.
+static void DSD_ATTR_USED
 p25p2_frame_apply_encrypted_lockout(dsd_opts* opts, dsd_state* state, int slot) {
     if (!opts || !state || slot < 0 || slot > 1) {
         return;

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -95,6 +95,12 @@ p25p2_add_secondary_cc_candidates(dsd_opts* opts, dsd_state* state, int rfssid, 
         return;
     }
 
+    /*
+     * Load persisted candidates before direct SCCB promotion so a full cache
+     * cannot evict the freshly validated current-site frequency.
+     */
+    p25_cc_try_load_cache(opts, state);
+
     long notify[2] = {0, 0};
     int notify_count = 0;
     for (int i = 0; i < count && i < 2; i++) {
@@ -836,6 +842,7 @@ p25p2_vpdu_mark_enc_lockout(dsd_opts* opts, dsd_state* state, int slot, int talk
         return;
     }
     p25_emit_enc_lockout_once(opts, state, (uint8_t)slot, talkgroup, /*svc_bits*/ 0);
+    state->p25_p2_enc_lockout_muted[slot & 1] = 1;
 }
 
 static void
@@ -3264,6 +3271,7 @@ p25p2_vpdu_iter_block_44(p25p2_vpdu_ctx* ctx) {
         DSD_FPRINTF(stderr, "CC: %03X; ", cc);
 
         p25p2_vpdu_gate_slot_audio(state, eslot);
+        state->p25_p2_enc_lockout_muted[eslot & 1] = 0;
         other_audio = p25p2_vpdu_other_slot_audio_with_history(state, eslot, mac_hold, voice_hold);
         if (!other_audio) {
             (void)p25p2_vpdu_force_release_after_grace(opts, state);

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -43,6 +43,9 @@ p25p2_xcch_set_slot_audio_allowed(dsd_state* state, int slot, int allow_audio) {
         return;
     }
     state->p25_p2_audio_allowed[slot] = allow_audio;
+    if (allow_audio != 0) {
+        state->p25_p2_enc_lockout_muted[slot] = 0;
+    }
 }
 
 static int
@@ -337,6 +340,7 @@ p25p2_xcch_emit_enc_if_encrypted(dsd_opts* opts, dsd_state* state, int slot) {
 
 static void
 p25p2_xcch_reset_ptt_slot_state(dsd_state* state, int slot) {
+    state->p25_p2_enc_lockout_muted[slot] = 0;
     state->fourv_counter[slot] = 0;
     state->voice_counter[slot] = 0;
     p25p2_xcch_set_slot_drop(state, slot, 256);
@@ -375,6 +379,7 @@ p25p2_xcch_handle_ptt_slot(dsd_opts* opts, dsd_state* state, const unsigned long
 
 static void
 p25p2_xcch_handle_end_slot(dsd_opts* opts, dsd_state* state, int slot, int clear_call_string) {
+    state->p25_p2_enc_lockout_muted[slot] = 0;
     state->fourv_counter[slot] = 0;
     state->voice_counter[slot] = 0;
     p25p2_xcch_set_slot_drop(state, slot, 256);
@@ -427,6 +432,7 @@ p25p2_xcch_reset_ptt_voice_counter_facch(dsd_state* state) {
 
 static void
 p25p2_xcch_reset_idle_slot_facch(dsd_state* state, int slot) {
+    state->p25_p2_enc_lockout_muted[slot] = 0;
     p25p2_xcch_set_slot_algid(state, slot, 0);
     p25p2_xcch_set_slot_keyid(state, slot, 0);
     p25p2_xcch_set_slot_burst(state, slot, 24);
@@ -550,6 +556,7 @@ p25p2_xcch_handle_sacch_mac_idle(dsd_opts* opts, dsd_state* state, uint8_t slot,
     DSD_FPRINTF(stderr, "%s", KNRM);
 
     p25_sm_emit_idle(opts, state, slot);
+    state->p25_p2_enc_lockout_muted[slot] = 0;
     p25p2_xcch_blank_slot_call_string(state, slot);
     p25p2_xcch_set_slot_audio_allowed(state, slot, 0);
     state->p25_call_is_packet[slot] = 0;

--- a/src/runtime/trunk_cc_candidates.c
+++ b/src/runtime/trunk_cc_candidates.c
@@ -5,10 +5,63 @@
 
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #include "dsd-neo/core/state_ext.h"
 #include "dsd-neo/core/state_fwd.h"
+
+static void
+dsd_trunk_cc_candidates_clear(dsd_trunk_cc_candidates* cc) {
+    cc->count = 0;
+    cc->idx = 0;
+    for (int k = 0; k < DSD_TRUNK_CC_CANDIDATES_MAX; k++) {
+        cc->candidates[k] = 0;
+        cc->flags[k] = 0;
+        cc->cool_until[k] = 0.0;
+    }
+}
+
+static int
+dsd_trunk_cc_candidates_has_valid_count(dsd_trunk_cc_candidates* cc) {
+    if (cc->count >= 0 && cc->count <= DSD_TRUNK_CC_CANDIDATES_MAX) {
+        return 1;
+    }
+    dsd_trunk_cc_candidates_clear(cc);
+    return 0;
+}
+
+static void
+dsd_trunk_cc_candidates_drop_oldest(dsd_trunk_cc_candidates* cc) {
+    for (int k = 1; k < DSD_TRUNK_CC_CANDIDATES_MAX; k++) {
+        cc->candidates[k - 1] = cc->candidates[k];
+        cc->flags[k - 1] = cc->flags[k];
+        cc->cool_until[k - 1] = cc->cool_until[k];
+    }
+    if (cc->idx > 0) {
+        cc->idx--;
+    }
+}
+
+static int
+dsd_trunk_cc_candidate_is_allowed(const dsd_trunk_cc_candidates* cc, int idx, long skip_cc_freq, double now_monotonic_s,
+                                  uint8_t required_flags, long* out_freq_hz) {
+    const uint8_t flags = cc->flags[idx];
+    const long freq_hz = cc->candidates[idx];
+
+    if (required_flags != 0 && (uint8_t)(flags & required_flags) != required_flags) {
+        return 0;
+    }
+    if (freq_hz == 0 || freq_hz == skip_cc_freq) {
+        return 0;
+    }
+    if (cc->cool_until[idx] > 0.0 && now_monotonic_s < cc->cool_until[idx]) {
+        return 0;
+    }
+
+    *out_freq_hz = freq_hz;
+    return 1;
+}
 
 dsd_trunk_cc_candidates*
 dsd_trunk_cc_candidates_get(dsd_state* state) {
@@ -44,7 +97,7 @@ dsd_trunk_cc_candidates_peek(const dsd_state* state) {
 }
 
 int
-dsd_trunk_cc_candidates_add(dsd_state* state, long freq_hz, int bump_added) {
+dsd_trunk_cc_candidates_add_with_flags(dsd_state* state, long freq_hz, int bump_added, uint8_t flags) {
     if (!state || freq_hz == 0) {
         return 0;
     }
@@ -54,27 +107,27 @@ dsd_trunk_cc_candidates_add(dsd_state* state, long freq_hz, int bump_added) {
         return 0;
     }
 
-    if (cc->count < 0 || cc->count > DSD_TRUNK_CC_CANDIDATES_MAX) {
-        cc->count = 0;
-        cc->idx = 0;
+    if (!dsd_trunk_cc_candidates_has_valid_count(cc)) {
+        return 0;
     }
 
     for (int k = 0; k < cc->count; k++) {
         if (cc->candidates[k] == freq_hz) {
+            cc->flags[k] |= flags;
             return 0;
         }
     }
 
     if (cc->count < DSD_TRUNK_CC_CANDIDATES_MAX) {
-        cc->candidates[cc->count++] = freq_hz;
+        cc->candidates[cc->count] = freq_hz;
+        cc->flags[cc->count] = flags;
+        cc->cool_until[cc->count] = 0.0;
+        cc->count++;
     } else {
-        for (int k = 1; k < DSD_TRUNK_CC_CANDIDATES_MAX; k++) {
-            cc->candidates[k - 1] = cc->candidates[k];
-        }
+        dsd_trunk_cc_candidates_drop_oldest(cc);
         cc->candidates[DSD_TRUNK_CC_CANDIDATES_MAX - 1] = freq_hz;
-        if (cc->idx > 0) {
-            cc->idx--;
-        }
+        cc->flags[DSD_TRUNK_CC_CANDIDATES_MAX - 1] = flags;
+        cc->cool_until[DSD_TRUNK_CC_CANDIDATES_MAX - 1] = 0.0;
     }
 
     if (bump_added) {
@@ -84,7 +137,13 @@ dsd_trunk_cc_candidates_add(dsd_state* state, long freq_hz, int bump_added) {
 }
 
 int
-dsd_trunk_cc_candidates_next(dsd_state* state, double now_monotonic_s, long* out_freq_hz) {
+dsd_trunk_cc_candidates_add(dsd_state* state, long freq_hz, int bump_added) {
+    return dsd_trunk_cc_candidates_add_with_flags(state, freq_hz, bump_added, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE);
+}
+
+int
+dsd_trunk_cc_candidates_next_with_flags(dsd_state* state, double now_monotonic_s, uint8_t required_flags,
+                                        long* out_freq_hz) {
     if (!state || !out_freq_hz) {
         return 0;
     }
@@ -95,9 +154,7 @@ dsd_trunk_cc_candidates_next(dsd_state* state, double now_monotonic_s, long* out
         return 0;
     }
 
-    if (cc->count < 0 || cc->count > DSD_TRUNK_CC_CANDIDATES_MAX) {
-        cc->count = 0;
-        cc->idx = 0;
+    if (!dsd_trunk_cc_candidates_has_valid_count(cc)) {
         return 0;
     }
 
@@ -107,19 +164,18 @@ dsd_trunk_cc_candidates_next(dsd_state* state, double now_monotonic_s, long* out
         if (cc->idx >= cc->count) {
             cc->idx = 0;
         }
-        int idx = cc->idx++;
-        long f = cc->candidates[idx];
-        if (f != 0 && f != skip_cc_freq) {
-            double cool_until = (idx >= 0 && idx < DSD_TRUNK_CC_CANDIDATES_MAX) ? cc->cool_until[idx] : 0.0;
-            if (cool_until > 0.0 && now_monotonic_s < cool_until) {
-                continue;
-            }
-            *out_freq_hz = f;
+        const int idx = cc->idx++;
+        if (dsd_trunk_cc_candidate_is_allowed(cc, idx, skip_cc_freq, now_monotonic_s, required_flags, out_freq_hz)) {
             cc->used++;
             return 1;
         }
     }
     return 0;
+}
+
+int
+dsd_trunk_cc_candidates_next(dsd_state* state, double now_monotonic_s, long* out_freq_hz) {
+    return dsd_trunk_cc_candidates_next_with_flags(state, now_monotonic_s, 0, out_freq_hz);
 }
 
 void

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -40,6 +40,7 @@
 #include <dsd-neo/ui/ui_prims.h>
 #include <stdarg.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -1304,6 +1305,12 @@ typedef struct {
     uint16_t string_size;
 } ui_history_render_ctx;
 
+typedef struct {
+    uint8_t slot;
+    uint16_t idx;
+    time_t sort_time;
+} ui_history_item_ref;
+
 static void
 ui_history_render_header(const dsd_state* state, int history_mode) {
     int rows = 0;
@@ -1529,97 +1536,97 @@ ui_history_render_dual_slot_item(const Event_History* item, uint8_t slot, const 
     (void)ui_history_print_detail_line(ctx->history_stop_y, slot, "DSD-neo: ", item->internal_str);
 }
 
-static uint16_t
-ui_history_single_slot_start_index(const dsd_state* state, uint8_t slot, uint16_t skip) {
-    uint16_t idx = 1;
-    while (idx < 255 && skip > 0) {
-        const Event_History* item = &state->event_history_s[slot].Event_History_Items[idx];
-        if (ui_eh_item_has_content(item)) {
-            skip--;
-        }
-        idx++;
-    }
-    return idx;
-}
-
-static void
-ui_history_advance_dual_indices(const dsd_state* state, uint16_t* idx0, uint16_t* idx1) {
-    while (*idx0 < 255 && !ui_eh_item_has_content(&state->event_history_s[0].Event_History_Items[*idx0])) {
-        (*idx0)++;
-    }
-    while (*idx1 < 255 && !ui_eh_item_has_content(&state->event_history_s[1].Event_History_Items[*idx1])) {
-        (*idx1)++;
-    }
-}
-
 static int
-ui_history_take_latest_dual_item(const dsd_state* state, uint16_t* idx0, uint16_t* idx1, uint8_t* slot, uint16_t* idx) {
-    ui_history_advance_dual_indices(state, idx0, idx1);
-    if (*idx0 >= 255 && *idx1 >= 255) {
-        return 0;
-    }
+ui_history_item_ref_compare(const void* lhs, const void* rhs) {
+    const ui_history_item_ref* a = (const ui_history_item_ref*)lhs;
+    const ui_history_item_ref* b = (const ui_history_item_ref*)rhs;
 
-    time_t t0 = (*idx0 < 255) ? state->event_history_s[0].Event_History_Items[*idx0].event_time : 0;
-    time_t t1 = (*idx1 < 255) ? state->event_history_s[1].Event_History_Items[*idx1].event_time : 0;
-    if (*idx1 < 255 && (*idx0 >= 255 || t1 > t0)) {
-        *slot = 1;
-        *idx = *idx1;
-        (*idx1)++;
-    } else {
-        *slot = 0;
-        *idx = *idx0;
-        (*idx0)++;
+    if (a->sort_time > b->sort_time) {
+        return -1;
     }
-    return 1;
+    if (a->sort_time < b->sort_time) {
+        return 1;
+    }
+    if (a->idx < b->idx) {
+        return -1;
+    }
+    if (a->idx > b->idx) {
+        return 1;
+    }
+    if (a->slot < b->slot) {
+        return -1;
+    }
+    if (a->slot > b->slot) {
+        return 1;
+    }
+    return 0;
 }
 
-static void
-ui_history_skip_dual_items(const dsd_state* state, uint16_t skip, uint16_t* idx0, uint16_t* idx1) {
-    uint8_t slot = 0;
-    uint16_t idx = 0;
-    while (skip > 0 && ui_history_take_latest_dual_item(state, idx0, idx1, &slot, &idx)) {
-        (void)slot;
-        (void)idx;
-        skip--;
+static size_t
+ui_history_collect_slot_items(const dsd_state* state, uint8_t slot, ui_history_item_ref* refs, size_t count,
+                              size_t cap) {
+    if (state == NULL || state->event_history_s == NULL || refs == NULL || count >= cap || slot >= 2) {
+        return count;
     }
-}
 
-static void
-ui_history_render_single_slot(const dsd_state* state, const ui_history_render_ctx* ctx) {
-    uint8_t slot = state->eh_slot;
-    uint16_t idx = ui_history_single_slot_start_index(state, slot, state->eh_index);
-
-    for (int shown = 0; shown < ctx->events_to_show && idx < 255; idx++) {
-        if (!ui_history_has_room_for_line(ctx->history_stop_y)) {
-            break;
-        }
+    for (uint16_t idx = 1; idx < 255 && count < cap; idx++) {
         const Event_History* item = &state->event_history_s[slot].Event_History_Items[idx];
         if (!ui_eh_item_has_content(item)) {
             continue;
         }
+        refs[count].slot = slot;
+        refs[count].idx = idx;
+        refs[count].sort_time = ui_history_event_sort_time(item->event_string, item->event_time);
+        count++;
+    }
+    return count;
+}
+
+static size_t
+ui_history_collect_sorted_items(const dsd_state* state, uint8_t slot, ui_history_item_ref* refs, size_t cap) {
+    size_t count = 0;
+    if (slot < 2) {
+        count = ui_history_collect_slot_items(state, slot, refs, count, cap);
+    } else {
+        count = ui_history_collect_slot_items(state, 0, refs, count, cap);
+        count = ui_history_collect_slot_items(state, 1, refs, count, cap);
+    }
+
+    if (count > 1) {
+        qsort(refs, count, sizeof(refs[0]), ui_history_item_ref_compare);
+    }
+    return count;
+}
+
+static void
+ui_history_render_item_refs(const dsd_state* state, const ui_history_render_ctx* ctx, const ui_history_item_ref* refs,
+                            size_t count) {
+    size_t pos = state->eh_index;
+    if (pos > count) {
+        pos = count;
+    }
+
+    for (int shown = 0; shown < ctx->events_to_show && pos < count; pos++) {
+        if (!ui_history_has_room_for_line(ctx->history_stop_y)) {
+            break;
+        }
+        const uint8_t slot = refs[pos].slot;
+        const uint16_t idx = refs[pos].idx;
+        const Event_History* item = &state->event_history_s[slot].Event_History_Items[idx];
         shown++;
-        ui_history_render_single_slot_item(item, ctx);
+        if (state->eh_slot < 2) {
+            ui_history_render_single_slot_item(item, ctx);
+        } else {
+            ui_history_render_dual_slot_item(item, slot, ctx);
+        }
     }
 }
 
 static void
-ui_history_render_dual_slots(const dsd_state* state, const ui_history_render_ctx* ctx) {
-    uint16_t idx0 = 1;
-    uint16_t idx1 = 1;
-    ui_history_skip_dual_items(state, state->eh_index, &idx0, &idx1);
-
-    for (int shown = 0; shown < ctx->events_to_show; shown++) {
-        if (!ui_history_has_room_for_line(ctx->history_stop_y)) {
-            break;
-        }
-        uint8_t slot = 0;
-        uint16_t idx = 0;
-        if (!ui_history_take_latest_dual_item(state, &idx0, &idx1, &slot, &idx)) {
-            break;
-        }
-        const Event_History* item = &state->event_history_s[slot].Event_History_Items[idx];
-        ui_history_render_dual_slot_item(item, slot, ctx);
-    }
+ui_history_render_sorted_slot_items(const dsd_state* state, const ui_history_render_ctx* ctx, uint8_t slot) {
+    ui_history_item_ref refs[508];
+    size_t count = ui_history_collect_sorted_items(state, slot, refs, sizeof(refs) / sizeof(refs[0]));
+    ui_history_render_item_refs(state, ctx, refs, count);
 }
 
 static void
@@ -1634,9 +1641,9 @@ ui_render_event_history_section(const dsd_state* state) {
         ui_history_setup_render_ctx(history_mode, &history_draw_footer, &ctx);
         if (state->event_history_s != NULL) {
             if (state->eh_slot < 2) {
-                ui_history_render_single_slot(state, &ctx);
+                ui_history_render_sorted_slot_items(state, &ctx, state->eh_slot);
             } else {
-                ui_history_render_dual_slots(state, &ctx);
+                ui_history_render_sorted_slot_items(state, &ctx, 2);
             }
         }
     }

--- a/src/ui/terminal/ui_history.c
+++ b/src/ui/terminal/ui_history.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/platform/atomic_compat.h>
 #include <dsd-neo/ui/ui_history.h>
 #include <string.h>
+#include <time.h>
 #include "dsd-neo/core/safe_api.h"
 
 static atomic_int g_ui_history_mode = 1;
@@ -65,6 +66,22 @@ ui_history_has_full_datetime_prefix(const char* s) {
     return ui_history_has_canonical_timestamp_prefix(s);
 }
 
+static int
+ui_history_parse_2_digits(const char* s, size_t off) {
+    return ((s[off] - '0') * 10) + (s[off + 1] - '0');
+}
+
+static int
+ui_history_parse_4_digits(const char* s, size_t off) {
+    return ((s[off] - '0') * 1000) + ((s[off + 1] - '0') * 100) + ((s[off + 2] - '0') * 10) + (s[off + 3] - '0');
+}
+
+static int
+ui_history_datetime_fields_in_range(int year, int month, int day, int hour, int minute, int second) {
+    return year >= 1970 && month >= 1 && month <= 12 && day >= 1 && day <= 31 && hour >= 0 && hour <= 23 && minute >= 0
+           && minute <= 59 && second >= 0 && second <= 60;
+}
+
 int
 ui_history_get_mode(void) {
     return ui_history_normalize_mode(atomic_load(&g_ui_history_mode));
@@ -104,4 +121,37 @@ ui_history_compact_event_text(char* out, size_t out_size, const char* event_text
     DSD_MEMCPY(out, src, n);
     out[n] = '\0';
     return n;
+}
+
+time_t
+ui_history_event_sort_time(const char* event_text, time_t fallback_time) {
+    if (!ui_history_has_full_datetime_prefix(event_text)) {
+        return fallback_time;
+    }
+
+    int year = ui_history_parse_4_digits(event_text, 0);
+    int month = ui_history_parse_2_digits(event_text, 5);
+    int day = ui_history_parse_2_digits(event_text, 8);
+    int hour = ui_history_parse_2_digits(event_text, 11);
+    int minute = ui_history_parse_2_digits(event_text, 14);
+    int second = ui_history_parse_2_digits(event_text, 17);
+    if (!ui_history_datetime_fields_in_range(year, month, day, hour, minute, second)) {
+        return fallback_time;
+    }
+
+    struct tm tmv;
+    DSD_MEMSET(&tmv, 0, sizeof tmv);
+    tmv.tm_year = year - 1900;
+    tmv.tm_mon = month - 1;
+    tmv.tm_mday = day;
+    tmv.tm_hour = hour;
+    tmv.tm_min = minute;
+    tmv.tm_sec = second;
+    tmv.tm_isdst = -1;
+
+    time_t parsed = mktime(&tmv);
+    if (parsed == (time_t)-1) {
+        return fallback_time;
+    }
+    return parsed;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2976,6 +2976,24 @@ add_test(
     COMMAND dsd-neo_test_p25_p2_2v_first_frame_gate
 )
 
+# P25 P2 service-option lockout should not release before ESS resolves ALGID
+add_executable(
+    dsd-neo_test_p25_p2_frame_lockout_sm
+    protocol/p25/test_p25_p2_frame_lockout_sm.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p2_frame_lockout_sm
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${_PUBLIC_INCLUDES}
+)
+target_link_libraries(
+    dsd-neo_test_p25_p2_frame_lockout_sm
+    PRIVATE dsd-neo_proto_p25
+)
+add_test(
+    NAME P25_P2_FRAME_LOCKOUT_SM
+    COMMAND dsd-neo_test_p25_p2_frame_lockout_sm
+)
+
 # P25 P2 mid-call ENC flush behavior: ensure per-slot jitter buffer flush
 add_executable(
     dsd-neo_test_p25_p2_midcall_enc_flush

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -178,6 +178,25 @@ test_source_less_data_call_does_not_suppress_next_voice_start_alert(void) {
 }
 
 static int
+test_source_less_data_call_is_preserved_in_history(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    watchdog_event_datacall(&opts, &state, 0, 0, "MNIS ARS;", 0);
+    watchdog_event_history(&opts, &state, 0);
+
+    const Event_History* current = &state.event_history_s[0].Event_History_Items[0];
+    const Event_History* stored = &state.event_history_s[0].Event_History_Items[1];
+    int rc = 0;
+    rc |= expect_int("source-less data current should be cleared", current->event_string[0], '\0');
+    rc |= expect_int("source-less data source remains zero", (int)stored->source_id, 0);
+    rc |= expect_has_substr("source-less data should be stored", stored->event_string, "MNIS ARS;");
+    return rc;
+}
+
+static int
 test_voice_end_alert_still_emits_for_voice_history(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -280,6 +299,35 @@ test_p25_event_string_keeps_full_prefix_after_sprintf_hardening(void) {
     return rc;
 }
 
+static int
+test_source_less_current_event_updates_history_metadata(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    state.lastsynctype = DSD_SYNC_P25P2_POS;
+    state.lastsrc = 0U;
+    state.lasttg = 21001U;
+    state.gi[0] = 0;
+    state.nac = 0x006;
+    state.p2_wacn = 0x45564U;
+    state.p2_sysid = 0x006U;
+    state.p2_rfssid = 10U;
+    state.p2_siteid = 10U;
+
+    watchdog_event_current(&opts, &state, 0);
+
+    const Event_History* item = &state.event_history_s[0].Event_History_Items[0];
+    int rc = 0;
+    rc |= expect_int("source-less current source remains zero", (int)item->source_id, 0);
+    rc |= expect_int("source-less current target should update", (int)item->target_id, 21001);
+    rc |= expect_int("source-less current event time should update", item->event_time > 0 ? 1 : 0, 1);
+    rc |=
+        expect_has_substr("source-less current string should include source zero", item->event_string, "SRC: 00000000");
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -287,10 +335,12 @@ main(void) {
     rc |= test_end_only_data_call_does_not_emit_voice_end_alert();
     rc |= test_data_only_data_call_emits_one_data_alert();
     rc |= test_source_less_data_call_does_not_suppress_next_voice_start_alert();
+    rc |= test_source_less_data_call_is_preserved_in_history();
     rc |= test_voice_end_alert_still_emits_for_voice_history();
     rc |= test_edacs_service_string_appends_past_pointer_size();
     rc |= test_dmr_event_string_keeps_full_prefix_after_sprintf_hardening();
     rc |= test_p25_event_string_keeps_full_prefix_after_sprintf_hardening();
+    rc |= test_source_less_current_event_updates_history_metadata();
 
     if (rc == 0) {
         printf("CORE_CALL_ALERT_HISTORY: OK\n");

--- a/tests/core/test_core_init_state.c
+++ b/tests/core/test_core_init_state.c
@@ -81,6 +81,7 @@ main(void) {
     state->payload_algidR = 0x89;
     state->payload_keyid = 0x1234;
     state->payload_keyidR = 0x5678;
+    state->p25_p2_enc_lockout_muted[0] = 1U;
     state->dropL = 1;
     state->dropR = 2;
     state->nxdn_cipher_type = 3U;
@@ -133,7 +134,8 @@ main(void) {
     }
     if (state->payload_mi != 0ULL || state->payload_miR != 0ULL || state->payload_miN != 0ULL
         || state->payload_miP != 0ULL || state->payload_algid != 0 || state->payload_algidR != 0
-        || state->payload_keyid != 0 || state->payload_keyidR != 0) {
+        || state->payload_keyid != 0 || state->payload_keyidR != 0 || state->p25_p2_enc_lockout_muted[0] != 0U
+        || state->p25_p2_enc_lockout_muted[1] != 0U) {
         DSD_FPRINTF(stderr, "initState did not clear payload crypto metadata\n");
         freeState(state);
         free(state);

--- a/tests/engine/test_engine_generic_trunk_return_matrix.c
+++ b/tests/engine/test_engine_generic_trunk_return_matrix.c
@@ -149,10 +149,19 @@ setup_generic_fixture(dsd_opts** opts_out, dsd_state** state_out, const generic_
     state->p25_p2_active_slot = 1;
     state->p25_p2_audio_allowed[0] = 1;
     state->p25_p2_audio_allowed[1] = 1;
+    state->p25_p2_enc_lockout_muted[0] = 1;
+    state->p25_p2_enc_lockout_muted[1] = 1;
     state->p25_call_is_packet[0] = 1;
     state->p25_call_is_packet[1] = 1;
     DSD_SNPRINTF(state->active_channel[0], sizeof(state->active_channel[0]), "%s", scenario);
     return 0;
+}
+
+static int
+p25_p2_voice_aliases_cleared(const dsd_state* state) {
+    return state->p25_p2_active_slot == -1 && state->p25_p2_audio_allowed[0] == 0 && state->p25_p2_audio_allowed[1] == 0
+           && state->p25_p2_enc_lockout_muted[0] == 0 && state->p25_p2_enc_lockout_muted[1] == 0
+           && state->p25_call_is_packet[0] == 0 && state->p25_call_is_packet[1] == 0;
 }
 
 static int
@@ -176,9 +185,7 @@ run_recent_vc_case(const generic_return_case* test_case) {
                       state->p2_cc == 0 && state->p2_wacn == 0 && state->p2_sysid == 0 && state->p2_rfssid == 0
                           && state->p2_siteid == 0 && state->p25_sys_is_tdma == 0);
     rc |= expect_true(test_case->name, "recent-vc", "p25 slot and audio aliases cleared",
-                      state->p25_p2_active_slot == -1 && state->p25_p2_audio_allowed[0] == 0
-                          && state->p25_p2_audio_allowed[1] == 0 && state->p25_call_is_packet[0] == 0
-                          && state->p25_call_is_packet[1] == 0);
+                      p25_p2_voice_aliases_cleared(state));
 
     free_test_runtime(opts, state);
     return rc;
@@ -207,9 +214,7 @@ run_stale_vc_with_cc_case(const generic_return_case* test_case) {
     rc |= expect_true(test_case->name, "stale-vc-with-cc", "p25 identity aliases cleared",
                       state->p2_cc == 0 && state->p2_wacn == 0 && state->p2_sysid == 0 && state->p25_sys_is_tdma == 0);
     rc |= expect_true(test_case->name, "stale-vc-with-cc", "p25 slot and audio aliases cleared",
-                      state->p25_p2_active_slot == -1 && state->p25_p2_audio_allowed[0] == 0
-                          && state->p25_p2_audio_allowed[1] == 0 && state->p25_call_is_packet[0] == 0
-                          && state->p25_call_is_packet[1] == 0);
+                      p25_p2_voice_aliases_cleared(state));
     rc |=
         expect_true(test_case->name, "stale-vc-with-cc", "active display cleared", state->active_channel[0][0] == '\0');
 
@@ -238,9 +243,7 @@ run_stale_vc_without_cc_case(const generic_return_case* test_case) {
                       state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0 && state->p2_cc == 0
                           && state->p2_wacn == 0 && state->p2_sysid == 0);
     rc |= expect_true(test_case->name, "stale-vc-without-cc", "p25 slot and audio aliases cleared",
-                      state->p25_p2_active_slot == -1 && state->p25_p2_audio_allowed[0] == 0
-                          && state->p25_p2_audio_allowed[1] == 0 && state->p25_call_is_packet[0] == 0
-                          && state->p25_call_is_packet[1] == 0);
+                      p25_p2_voice_aliases_cleared(state));
 
     free_test_runtime(opts, state);
     return rc;
@@ -262,7 +265,7 @@ run_stale_vc_with_matching_p25_cc_alias_case(const generic_return_case* test_cas
                       state->trunk_cc_freq == GENERIC_TRUNK_CC_HZ && state->p25_cc_freq == GENERIC_TRUNK_CC_HZ);
     rc |= expect_true(test_case->name, "stale-vc-matching-p25-cc", "voice state cleared",
                       opts->trunk_is_tuned == 0 && opts->p25_is_tuned == 0 && state->trunk_vc_freq[0] == 0
-                          && state->p25_vc_freq[0] == 0);
+                          && state->p25_vc_freq[0] == 0 && p25_p2_voice_aliases_cleared(state));
 
     free_test_runtime(opts, state);
     return rc;
@@ -289,7 +292,7 @@ run_mapped_rest_channel_case(const generic_return_case* test_case) {
                       state->dmr_rest_channel == -1);
     rc |= expect_true(test_case->name, "mapped-rest-channel", "voice state cleared",
                       opts->trunk_is_tuned == 0 && opts->p25_is_tuned == 0 && state->trunk_vc_freq[0] == 0
-                          && state->p25_vc_freq[0] == 0);
+                          && state->p25_vc_freq[0] == 0 && p25_p2_voice_aliases_cleared(state));
 
     free_test_runtime(opts, state);
     return rc;
@@ -315,7 +318,8 @@ run_generic_overrides_p25_helper_case(const generic_return_case* test_case) {
                       opts->trunk_is_tuned == 0 && opts->p25_is_tuned == 0
                           && state->trunk_cc_freq == GENERIC_TRUNK_CC_HZ && state->p25_cc_freq == 0);
     rc |= expect_true(test_case->name, "generic-overrides-p25-helper", "p25 hints cleared",
-                      state->p25_vc_freq[0] == 0 && state->p2_cc == 0 && state->p25_sys_is_tdma == 0);
+                      state->p25_vc_freq[0] == 0 && state->p2_cc == 0 && state->p25_sys_is_tdma == 0
+                          && p25_p2_voice_aliases_cleared(state));
 
     clear_return_to_cc_guard();
     free_test_runtime(opts, state);
@@ -343,7 +347,7 @@ run_sync_source_case(const generic_return_case* test_case, int current_only) {
                       opts->trunk_is_tuned == 0 && opts->p25_is_tuned == 0
                           && state->trunk_cc_freq == GENERIC_TRUNK_CC_HZ && state->p25_cc_freq == 0);
     rc |= expect_true(test_case->name, scenario, "p25 aliases cleared",
-                      state->p25_vc_freq[0] == 0 && state->p2_cc == 0 && state->p25_p2_active_slot == -1);
+                      state->p25_vc_freq[0] == 0 && state->p2_cc == 0 && p25_p2_voice_aliases_cleared(state));
 
     free_test_runtime(opts, state);
     return rc;

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -297,6 +297,10 @@ main(void) {
     state->p25_cc_freq = 0;
     state->trunk_vc_freq[0] = 852000000;
     state->trunk_vc_freq[1] = 852000000;
+    state->p25_p2_audio_allowed[0] = 1;
+    state->p25_p2_audio_allowed[1] = 1;
+    state->p25_p2_enc_lockout_muted[0] = 1;
+    state->p25_p2_enc_lockout_muted[1] = 1;
     state->last_cc_sync_time = 0;
     state->last_cc_sync_time_m = 0.0;
     DSD_SNPRINTF(state->call_string[0], sizeof(state->call_string[0]), "%s", "left active");
@@ -319,6 +323,10 @@ main(void) {
     assert(opts->p25_is_tuned == 0);
     assert(state->trunk_vc_freq[0] == 0);
     assert(state->trunk_vc_freq[1] == 0);
+    assert(state->p25_p2_audio_allowed[0] == 0);
+    assert(state->p25_p2_audio_allowed[1] == 0);
+    assert(state->p25_p2_enc_lockout_muted[0] == 0);
+    assert(state->p25_p2_enc_lockout_muted[1] == 0);
     assert(strcmp(state->call_string[0], "                     ") == 0);
     assert(strcmp(state->call_string[1], "                     ") == 0);
     assert(state->active_channel[0][0] == '\0');

--- a/tests/protocol/p25/test_p25_cc_cache_path.c
+++ b/tests/protocol/p25/test_p25_cc_cache_path.c
@@ -7,12 +7,15 @@
  * Control-channel cache path formatting tests.
  */
 
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "test_support.h"
@@ -35,6 +38,30 @@ expect_eq_int(const char* tag, int got, int want) {
         return 1;
     }
     return 0;
+}
+
+static int
+expect_eq_long(const char* tag, long got, long want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %ld want %ld\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+write_cache_fixture(const char* path) {
+    FILE* fp = fopen(path, "w");
+    if (!fp) {
+        DSD_FPRINTF(stderr, "failed to write cache fixture: %s\n", strerror(errno));
+        return 0;
+    }
+    DSD_FPRINTF(fp, "851111111\n");
+    DSD_FPRINTF(fp, "cc 851222222\n");
+    DSD_FPRINTF(fp, "  cc\t851333333\n");
+    DSD_FPRINTF(fp, "notcc 851444444\n");
+    fclose(fp);
+    return 1;
 }
 
 int
@@ -75,6 +102,26 @@ main(void) {
     DSD_SNPRINTF(want2, sizeof want2, "%s/p25_cc_%05lX_%03lX_R%03llu_S%03llu.txt", dir, (unsigned long)st.p2_wacn,
                  (unsigned long)st.p2_sysid, st.p2_rfssid, st.p2_siteid);
     rc |= expect_eq_str("rfss/site path", out, want2);
+
+    if (!write_cache_fixture(out)) {
+        return 101;
+    }
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    p25_cc_try_load_cache(&opts, &st);
+
+    const dsd_trunk_cc_candidates* cc = dsd_trunk_cc_candidates_peek(&st);
+    rc |= expect_eq_int("marked cache loaded", st.p25_cc_cache_loaded, 1);
+    rc |= expect_eq_int("loaded marked candidates only", cc ? cc->count : 0, 2);
+    if (cc && cc->count == 2) {
+        rc |= expect_eq_long("loaded cache candidate 0", cc->candidates[0], 851222222L);
+        rc |= expect_eq_long("loaded cache candidate 1", cc->candidates[1], 851333333L);
+        rc |= expect_eq_int("loaded cache candidate 0 flag", (cc->flags[0] & DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE) != 0,
+                            1);
+        rc |= expect_eq_int("loaded cache candidate 1 flag", (cc->flags[1] & DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE) != 0,
+                            1);
+    }
 
     return rc;
 }

--- a/tests/protocol/p25/test_p25_cc_cache_path.c
+++ b/tests/protocol/p25/test_p25_cc_cache_path.c
@@ -9,6 +9,7 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
@@ -51,7 +52,7 @@ expect_eq_long(const char* tag, long got, long want) {
 
 static int
 write_cache_fixture(const char* path) {
-    FILE* fp = fopen(path, "w");
+    FILE* fp = dsd_fopen_private(path, "w");
     if (!fp) {
         DSD_FPRINTF(stderr, "failed to write cache fixture: %s\n", strerror(errno));
         return 0;

--- a/tests/protocol/p25/test_p25_mbt_adj_rfss.c
+++ b/tests/protocol/p25/test_p25_mbt_adj_rfss.c
@@ -247,8 +247,9 @@ main(void) {
     }
 
     // Case B: Adjacent Status Broadcast (0x3C)
-    // After Layer 2 enrichment, 0x3C calls p25_nb_add_ex() + p25_cc_add_candidate()
-    // directly instead of p25_sm_on_neighbor_update(). Verify via neighbor table.
+    // After Layer 2 enrichment, 0x3C records adjacent-site metadata via
+    // p25_nb_add_ex() without promoting the frequency to a tuneable current-site
+    // CC candidate. Verify via neighbor table.
     // CHAN-R is the uplink side of the explicit channel and must not become
     // a separate downlink CC candidate.
     {

--- a/tests/protocol/p25/test_p25_neighbor_spam.c
+++ b/tests/protocol/p25/test_p25_neighbor_spam.c
@@ -5,13 +5,13 @@
 
 /*
  * P25 neighbor update spam test: stress p25_sm_on_neighbor_update with
- * many updates and assert CC candidate list remains bounded and
- * iteration via p25_sm_next_cc_candidate stays consistent.
+ * many updates and assert neighbors do not become tuneable CC candidates.
  */
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/platform/timing.h>
+#include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
@@ -108,10 +108,7 @@ main(void) {
             }
         }
         p25_sm_on_neighbor_update(&opts, &st, f, n);
-        // Count should never exceed 16
-        const dsd_trunk_cc_candidates* cc = dsd_trunk_cc_candidates_peek(&st);
-        const int count = cc ? cc->count : 0;
-        rc |= expect_true("cand<=16", count >= 0 && count <= DSD_TRUNK_CC_CANDIDATES_MAX);
+        rc |= expect_true("neighbor<=max", st.p25_nb_count >= 0 && st.p25_nb_count <= P25_NB_MAX);
     }
 
     // Timing end and guard: ensure this remains snappy
@@ -124,28 +121,19 @@ main(void) {
     rc |= expect_true("neighbor-spam-fast", elapsed_ms < 200.0);
 #endif
 
-    // Next-candidate iteration should cycle through at most count entries and
-    // never return 0 or the current CC.
+    // Generic neighbor updates must not seed the CC hunt list. Only validated
+    // current-site candidates should be tuneable by p25_sm_next_cc_candidate().
     const dsd_trunk_cc_candidates* cc = dsd_trunk_cc_candidates_peek(&st);
     const int count = cc ? cc->count : 0;
-    if (count > 0) {
-        int seen_nonzero = 0;
-        long last = -1;
-        for (int i = 0; i < count * 3; i++) {
-            long out = 0;
-            int ok = p25_sm_next_cc_candidate(&st, &out);
-            rc |= expect_true("next->ok", ok == 1);
-            rc |= expect_true("next->nonzero", out != 0);
-            rc |= expect_true("next->neq-cc", out != st.p25_cc_freq);
-            // do a weak monotonicity sanity: not all calls must differ, but should
-            // make progress across multiple calls
-            if (last != out) {
-                seen_nonzero = 1;
-            }
-            last = out;
-        }
-        rc |= expect_true("progress", seen_nonzero);
-    }
+    rc |= expect_true("neighbor-not-candidates", count == 0);
+
+    long out = 0;
+    rc |= expect_true("neighbor-next-empty", p25_sm_next_cc_candidate(&st, &out) == 0);
+
+    (void)p25_cc_add_candidate(&st, 852500000L, 1);
+    out = 0;
+    rc |= expect_true("validated-next-ok", p25_sm_next_cc_candidate(&st, &out) == 1);
+    rc |= expect_true("validated-next-freq", out == 852500000L);
 
     return rc;
 }

--- a/tests/protocol/p25/test_p25_next_cc_candidate_edges.c
+++ b/tests/protocol/p25/test_p25_next_cc_candidate_edges.c
@@ -6,7 +6,7 @@
 /*
  * P25 next CC candidate edge cases.
  * - Returns 0 when empty list
- * - Returns 0 when only current CC or zeros present
+ * - Returns 0 when only current CC, zeros, or generic neighbors are present
  */
 
 #include <dsd-neo/core/opts.h>
@@ -82,6 +82,10 @@ main(void) {
     p25_sm_on_neighbor_update(&opts, &st, neigh, 4);
     rc |= expect_eq_int("cc-only", p25_sm_next_cc_candidate(&st, &out), 0);
     rc |= expect_eq_int("cc-only-lcn-count", st.lcn_freq_count, 1);
+
+    long neighbor_only[1] = {852000000};
+    p25_sm_on_neighbor_update(&opts, &st, neighbor_only, 1);
+    rc |= expect_eq_int("neighbor-only", p25_sm_next_cc_candidate(&st, &out), 0);
     return rc;
 }
 

--- a/tests/protocol/p25/test_p25_p1_trunk_sm.c
+++ b/tests/protocol/p25/test_p25_p1_trunk_sm.c
@@ -12,6 +12,7 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/config.h>
 #include <stdbool.h>
@@ -104,21 +105,22 @@ main(int argc, char** argv) {
     rc |= expect_eq("init tune_count", state.p25_sm_tune_count, 0);
     rc |= expect_eq("init release_count", state.p25_sm_release_count, 0);
 
-    // Neighbor update supplies two CC candidates
-    long neigh[3] = {851012500, 851537500, 0};
-    p25_sm_on_neighbor_update(&opts, &state, neigh, 2);
+    // Validated current-site updates supply two CC candidates.
+    long cc_candidates[3] = {851012500, 851537500, 0};
+    (void)p25_cc_add_candidate(&state, cc_candidates[0], 1);
+    (void)p25_cc_add_candidate(&state, cc_candidates[1], 1);
 
     // Iterate candidates (order preserved)
     long cand = 0;
     int ok1 = p25_sm_next_cc_candidate(&state, &cand);
     rc |= expect_eq("cand ok1", ok1, 1);
-    rc |= expect_eq("cand1", cand, neigh[0]);
+    rc |= expect_eq("cand1", cand, cc_candidates[0]);
     ok1 = p25_sm_next_cc_candidate(&state, &cand);
     rc |= expect_eq("cand ok2", ok1, 1);
-    rc |= expect_eq("cand2", cand, neigh[1]);
+    rc |= expect_eq("cand2", cand, cc_candidates[1]);
     ok1 = p25_sm_next_cc_candidate(&state, &cand);
     rc |= expect_eq("cand cycle ok3", ok1, 1);
-    rc |= expect_eq("cand3", cand, neigh[0]);
+    rc |= expect_eq("cand3", cand, cc_candidates[0]);
 
     // Simulate a group grant: enable trunking and a non-zero CC freq
     opts.p25_trunk = 1;

--- a/tests/protocol/p25/test_p25_p2_2v_first_frame_gate.c
+++ b/tests/protocol/p25/test_p25_p2_2v_first_frame_gate.c
@@ -25,6 +25,7 @@ struct RtlSdrContext;
 
 // Expose the P25p2 2V handler under test
 void process_2V(dsd_opts* opts, dsd_state* state);
+void p25p2_test_decode_voice_frame_for_lockout(dsd_opts* opts, dsd_state* state);
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 bool SetFreq(int sockfd, long int freq);
@@ -343,6 +344,13 @@ reset_mbe_calls(void) {
     g_mbe_soft_calls = 0;
 }
 
+static void
+set_ess_algid(dsd_state* st, int slot, uint8_t algid) {
+    for (int i = 0; i < 8; i++) {
+        st->ess_b[slot][i] = (algid >> (7 - i)) & 1;
+    }
+}
+
 int
 main(void) {
     int rc = 0;
@@ -388,6 +396,224 @@ main(void) {
     rc |= expect_eq("slot1 allowed: mbe calls", g_mbe_calls, 2);
     rc |= expect_eq("slot1 allowed: soft mbe calls", g_mbe_soft_calls, 2);
     rc |= expect_eq("slot1 allowed: hard mbe calls", g_mbe_hard_calls, 0);
+
+    // Slot 0: stale allowed gate, encrypted/no key, lockout enabled -> no decode.
+    reset_state(&opts, &st);
+    opts.trunk_tune_enc_calls = 0;
+    st.currentslot = 0;
+    st.p25_p2_audio_allowed[0] = 1;
+    st.dmr_so = 0x40;
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot0 encrypted lockout: mbe calls", g_mbe_calls, 0);
+    rc |= expect_eq("slot0 encrypted lockout: gate closed", st.p25_p2_audio_allowed[0], 0);
+    rc |= expect_eq("slot0 encrypted lockout: ring flushed", st.p25_p2_audio_ring_count[0], 0);
+
+    // Slot 0: service-option ENC before ESS completion mutes voice but must
+    // not reset ESS_B collection; ALGID may still resolve to a loaded key.
+    reset_state(&opts, &st);
+    opts.trunk_tune_enc_calls = 0;
+    st.currentslot = 0;
+    st.p25_p2_audio_allowed[0] = 1;
+    st.dmr_so = 0x40;
+    st.fourv_counter[0] = 2;
+    reset_mbe_calls();
+    p25p2_test_decode_voice_frame_for_lockout(&opts, &st);
+    rc |= expect_eq("slot0 pre-ess lockout: mbe calls", g_mbe_calls, 0);
+    rc |= expect_eq("slot0 pre-ess lockout: gate closed", st.p25_p2_audio_allowed[0], 0);
+    rc |= expect_eq("slot0 pre-ess lockout: fourv preserved", st.fourv_counter[0], 2);
+    rc |= expect_eq("slot0 pre-ess lockout: marker clear", st.p25_p2_enc_lockout_muted[0], 0);
+
+    // Slot 0: lockout must clear stale crypto metadata so later clear service
+    // options on this slot are not misclassified before the next ESS refresh.
+    reset_state(&opts, &st);
+    opts.p25_trunk = 1;
+    opts.p25_is_tuned = 1;
+    opts.trunk_is_tuned = 1;
+    opts.trunk_tune_enc_calls = 0;
+    st.currentslot = 0;
+    st.p25_p2_audio_allowed[0] = 1;
+    st.p25_p2_audio_allowed[1] = 1;
+    st.dmr_so = 0x40;
+    st.payload_algid = 0x84;
+    st.payload_keyid = 0x1234;
+    st.payload_miP = 0x1122334455667788ULL;
+    set_ess_algid(&st, 0, 0x84);
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot0 stale algid cleanup: encrypted mbe calls", g_mbe_calls, 0);
+    rc |= expect_eq("slot0 stale algid cleanup: algid cleared", st.payload_algid, 0);
+    rc |= expect_eq("slot0 stale algid cleanup: keyid cleared", st.payload_keyid, 0);
+    rc |= expect_eq("slot0 stale algid cleanup: mi cleared", st.payload_miP == 0ULL, 1);
+    rc |= expect_eq("slot0 stale algid cleanup: marker set", st.p25_p2_enc_lockout_muted[0], 1);
+    st.p25_p2_audio_allowed[0] = 1;
+    st.dmr_so = 0;
+    set_ess_algid(&st, 0, 0x80);
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot0 stale algid cleanup: clear mbe calls", g_mbe_calls, 2);
+    rc |= expect_eq("slot0 stale algid cleanup: clear gate open", st.p25_p2_audio_allowed[0], 1);
+    rc |= expect_eq("slot0 stale algid cleanup: marker cleared", st.p25_p2_enc_lockout_muted[0], 0);
+
+    // Slot 0: follow encrypted preserves prior behavior even without a key.
+    reset_state(&opts, &st);
+    opts.trunk_tune_enc_calls = 1;
+    st.currentslot = 0;
+    st.p25_p2_audio_allowed[0] = 1;
+    st.dmr_so = 0x40;
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot0 encrypted follow: mbe calls", g_mbe_calls, 2);
+
+    // Slot 0: encrypted lockout enabled but decryptable audio remains allowed.
+    reset_state(&opts, &st);
+    opts.trunk_tune_enc_calls = 0;
+    st.currentslot = 0;
+    st.p25_p2_audio_allowed[0] = 1;
+    st.dmr_so = 0x40;
+    st.aes_key_loaded[0] = 1;
+    set_ess_algid(&st, 0, 0x84);
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot0 encrypted decryptable: mbe calls", g_mbe_calls, 2);
+
+    // Slot 0: keyed encrypted call muted by media policy is not an encrypted lockout.
+    reset_state(&opts, &st);
+    opts.trunk_tune_enc_calls = 0;
+    opts.trunk_use_allow_list = 1;
+    st.currentslot = 0;
+    st.lasttg = 1234;
+    st.tg_hold = 4321;
+    st.p25_p2_audio_allowed[0] = 0;
+    st.dmr_so = 0x40;
+    st.dmrburstL = 21;
+    st.aes_key_loaded[0] = 1;
+    set_ess_algid(&st, 0, 0x84);
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot0 policy-muted decryptable: mbe calls", g_mbe_calls, 0);
+    rc |= expect_eq("slot0 policy-muted decryptable: gate stays closed", st.p25_p2_audio_allowed[0], 0);
+    rc |= expect_eq("slot0 policy-muted decryptable: burst preserved", st.dmrburstL, 21);
+
+    // Slot 0: decoded clear ALGID overrides a stale encrypted service bit.
+    reset_state(&opts, &st);
+    opts.trunk_tune_enc_calls = 0;
+    st.currentslot = 0;
+    st.p25_p2_audio_allowed[0] = 1;
+    st.dmr_so = 0x40;
+    set_ess_algid(&st, 0, 0x80);
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot0 clear algid overrides svc: mbe calls", g_mbe_calls, 2);
+    rc |= expect_eq("slot0 clear algid overrides svc: gate open", st.p25_p2_audio_allowed[0], 1);
+
+    // Slot 1: stale allowed gate, encrypted/no key, lockout enabled -> no decode.
+    reset_state(&opts, &st);
+    opts.trunk_tune_enc_calls = 0;
+    st.currentslot = 1;
+    st.p25_p2_audio_allowed[1] = 1;
+    st.dmr_soR = 0x40;
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot1 encrypted lockout: mbe calls", g_mbe_calls, 0);
+    rc |= expect_eq("slot1 encrypted lockout: gate closed", st.p25_p2_audio_allowed[1], 0);
+    rc |= expect_eq("slot1 encrypted lockout: ring flushed", st.p25_p2_audio_ring_count[1], 0);
+
+    // Slot 1: same pre-ESS service-option mute must preserve fragment index.
+    reset_state(&opts, &st);
+    opts.trunk_tune_enc_calls = 0;
+    st.currentslot = 1;
+    st.p25_p2_audio_allowed[1] = 1;
+    st.dmr_soR = 0x40;
+    st.fourv_counter[1] = 3;
+    reset_mbe_calls();
+    p25p2_test_decode_voice_frame_for_lockout(&opts, &st);
+    rc |= expect_eq("slot1 pre-ess lockout: mbe calls", g_mbe_calls, 0);
+    rc |= expect_eq("slot1 pre-ess lockout: gate closed", st.p25_p2_audio_allowed[1], 0);
+    rc |= expect_eq("slot1 pre-ess lockout: fourv preserved", st.fourv_counter[1], 3);
+    rc |= expect_eq("slot1 pre-ess lockout: marker clear", st.p25_p2_enc_lockout_muted[1], 0);
+
+    // Slot 1: same stale-ALGID cleanup as slot 0.
+    reset_state(&opts, &st);
+    opts.p25_trunk = 1;
+    opts.p25_is_tuned = 1;
+    opts.trunk_is_tuned = 1;
+    opts.trunk_tune_enc_calls = 0;
+    st.currentslot = 1;
+    st.p25_p2_audio_allowed[0] = 1;
+    st.p25_p2_audio_allowed[1] = 1;
+    st.dmr_soR = 0x40;
+    st.payload_algidR = 0x84;
+    st.payload_keyidR = 0x5678;
+    st.payload_miN = 0x8877665544332211ULL;
+    set_ess_algid(&st, 1, 0x84);
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot1 stale algid cleanup: encrypted mbe calls", g_mbe_calls, 0);
+    rc |= expect_eq("slot1 stale algid cleanup: algid cleared", st.payload_algidR, 0);
+    rc |= expect_eq("slot1 stale algid cleanup: keyid cleared", st.payload_keyidR, 0);
+    rc |= expect_eq("slot1 stale algid cleanup: mi cleared", st.payload_miN == 0ULL, 1);
+    rc |= expect_eq("slot1 stale algid cleanup: marker set", st.p25_p2_enc_lockout_muted[1], 1);
+    st.p25_p2_audio_allowed[1] = 1;
+    st.dmr_soR = 0;
+    set_ess_algid(&st, 1, 0x80);
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot1 stale algid cleanup: clear mbe calls", g_mbe_calls, 2);
+    rc |= expect_eq("slot1 stale algid cleanup: clear gate open", st.p25_p2_audio_allowed[1], 1);
+    rc |= expect_eq("slot1 stale algid cleanup: marker cleared", st.p25_p2_enc_lockout_muted[1], 0);
+
+    // Slot 1: follow encrypted preserves prior behavior even without a key.
+    reset_state(&opts, &st);
+    opts.trunk_tune_enc_calls = 1;
+    st.currentslot = 1;
+    st.p25_p2_audio_allowed[1] = 1;
+    st.dmr_soR = 0x40;
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot1 encrypted follow: mbe calls", g_mbe_calls, 2);
+
+    // Slot 1: encrypted lockout enabled but decryptable audio remains allowed.
+    reset_state(&opts, &st);
+    opts.trunk_tune_enc_calls = 0;
+    st.currentslot = 1;
+    st.p25_p2_audio_allowed[1] = 1;
+    st.dmr_soR = 0x40;
+    st.aes_key_loaded[1] = 1;
+    set_ess_algid(&st, 1, 0x84);
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot1 encrypted decryptable: mbe calls", g_mbe_calls, 2);
+
+    // Slot 1: keyed encrypted call muted by media policy is not an encrypted lockout.
+    reset_state(&opts, &st);
+    opts.trunk_tune_enc_calls = 0;
+    opts.trunk_use_allow_list = 1;
+    st.currentslot = 1;
+    st.lasttgR = 5678;
+    st.tg_hold = 8765;
+    st.p25_p2_audio_allowed[1] = 0;
+    st.dmr_soR = 0x40;
+    st.dmrburstR = 21;
+    st.aes_key_loaded[1] = 1;
+    set_ess_algid(&st, 1, 0x84);
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot1 policy-muted decryptable: mbe calls", g_mbe_calls, 0);
+    rc |= expect_eq("slot1 policy-muted decryptable: gate stays closed", st.p25_p2_audio_allowed[1], 0);
+    rc |= expect_eq("slot1 policy-muted decryptable: burst preserved", st.dmrburstR, 21);
+
+    // Slot 1: decoded clear ALGID overrides a stale encrypted service bit.
+    reset_state(&opts, &st);
+    opts.trunk_tune_enc_calls = 0;
+    st.currentslot = 1;
+    st.p25_p2_audio_allowed[1] = 1;
+    st.dmr_soR = 0x40;
+    set_ess_algid(&st, 1, 0x80);
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot1 clear algid overrides svc: mbe calls", g_mbe_calls, 2);
+    rc |= expect_eq("slot1 clear algid overrides svc: gate open", st.p25_p2_audio_allowed[1], 1);
 
     return rc;
 }

--- a/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
+++ b/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Validate the P25 Phase 2 frame-level service-option encrypted mute does not
+ * force trunk state-machine release before ESS has identified the ALGID.
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/platform/sockets.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+struct RtlSdrContext;
+
+void process_2V(dsd_opts* opts, dsd_state* state);
+
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+bool SetFreq(int sockfd, long int freq);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+bool SetModulation(int sockfd, int bandwidth);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+int rtl_stream_tune(struct RtlSdrContext* ctx, uint32_t center_freq_hz);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_socket_t Connect(char* hostname, int portno);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void apx_embedded_alias_header_phase2(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t* lc_bits);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void apx_embedded_alias_blocks_phase2(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t* lc_bits);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void l3h_embedded_alias_decode(dsd_opts* opts, dsd_state* state, uint8_t slot, int16_t len, uint8_t* input);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void nmea_harris(dsd_opts* opts, dsd_state* state, uint8_t* input, uint32_t src, int slot);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void LFSRN(const char* buffer_in, char* buffer_out, dsd_state* state);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+uint16_t ComputeCrcCCITT16d(const uint8_t* buf, uint32_t len);
+
+static int g_return_to_cc_called = 0;
+
+bool
+SetFreq(int sockfd, long int freq) {
+    (void)sockfd;
+    (void)freq;
+    return false;
+}
+
+bool
+SetModulation(int sockfd, int bandwidth) {
+    (void)sockfd;
+    (void)bandwidth;
+    return false;
+}
+
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+struct RtlSdrContext* g_rtl_ctx = 0;
+
+int
+rtl_stream_tune(struct RtlSdrContext* ctx, uint32_t center_freq_hz) {
+    (void)ctx;
+    (void)center_freq_hz;
+    return 0;
+}
+
+dsd_socket_t
+Connect(char* hostname, int portno) {
+    (void)hostname;
+    (void)portno;
+    return DSD_INVALID_SOCKET;
+}
+
+static dsd_trunk_tune_result
+return_to_cc_result(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_return_to_cc_called++;
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static void
+install_trunk_tuning_hooks(void) {
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.return_to_cc_result = return_to_cc_result;
+    dsd_trunk_tuning_hooks_set(hooks);
+}
+
+void
+apx_embedded_alias_header_phase2(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t* lc_bits) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)lc_bits;
+}
+
+void
+apx_embedded_alias_blocks_phase2(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t* lc_bits) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)lc_bits;
+}
+
+void
+l3h_embedded_alias_decode(dsd_opts* opts, dsd_state* state, uint8_t slot, int16_t len, uint8_t* input) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)len;
+    (void)input;
+}
+
+void
+nmea_harris(dsd_opts* opts, dsd_state* state, uint8_t* input, uint32_t src, int slot) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)src;
+    (void)slot;
+}
+
+void
+LFSRN(const char* buffer_in, char* buffer_out, dsd_state* state) {
+    (void)buffer_in;
+    (void)buffer_out;
+    (void)state;
+}
+
+uint16_t
+ComputeCrcCCITT16d(const uint8_t* buf, uint32_t len) {
+    (void)buf;
+    (void)len;
+    return 0;
+}
+
+static int
+expect_eq(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static void
+setup_tuned_tdma(dsd_opts* opts, dsd_state* state, p25_sm_ctx_t** ctx) {
+    DSD_MEMSET(opts, 0, sizeof *opts);
+    DSD_MEMSET(state, 0, sizeof *state);
+    opts->p25_trunk = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    opts->trunk_tune_enc_calls = 0;
+    state->currentslot = 0;
+    state->p25_vc_cqpsk_pref = -1;
+    state->p25_vc_cqpsk_override = -1;
+    state->lasttg = 1234;
+    state->lasttgR = 5678;
+
+    p25_sm_init(opts, state);
+    *ctx = p25_sm_get_ctx();
+    (*ctx)->state = P25_SM_TUNED;
+    (*ctx)->vc_is_tdma = 1;
+    (*ctx)->vc_freq_hz = 851000000;
+    (*ctx)->t_tune_m = 1.0;
+    (*ctx)->t_voice_m = 1.0;
+}
+
+static int
+test_pre_ess_single_slot_stays_tuned(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    setup_tuned_tdma(&opts, &state, &ctx);
+    state.currentslot = 0;
+    state.p25_p2_audio_allowed[0] = 1;
+    state.dmr_so = 0x40;
+    g_return_to_cc_called = 0;
+
+    process_2V(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_eq("pre-ess single slot: no return", g_return_to_cc_called, 0);
+    rc |= expect_eq("pre-ess single slot: still tuned", ctx->state == P25_SM_TUNED, 1);
+    rc |= expect_eq("pre-ess single slot: voice remains active", ctx->slots[0].voice_active, 1);
+    rc |= expect_eq("pre-ess single slot: gate closed", state.p25_p2_audio_allowed[0], 0);
+    rc |= expect_eq("pre-ess single slot: marker clear", state.p25_p2_enc_lockout_muted[0], 0);
+    return rc;
+}
+
+static int
+test_pre_ess_opposite_clear_slot_stays_tuned(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    setup_tuned_tdma(&opts, &state, &ctx);
+    state.currentslot = 1;
+    state.p25_p2_audio_allowed[0] = 1;
+    state.p25_p2_audio_allowed[1] = 1;
+    state.dmr_soR = 0x40;
+    p25_sm_emit_active(&opts, &state, 0);
+    g_return_to_cc_called = 0;
+
+    process_2V(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_eq("opposite clear slot: no return", g_return_to_cc_called, 0);
+    rc |= expect_eq("opposite clear slot: still tuned", ctx->state == P25_SM_TUNED, 1);
+    rc |= expect_eq("opposite clear slot: clear active", ctx->slots[0].voice_active, 1);
+    rc |= expect_eq("opposite clear slot: pending ess active", ctx->slots[1].voice_active, 1);
+    rc |= expect_eq("opposite clear slot: clear gate open", state.p25_p2_audio_allowed[0], 1);
+    rc |= expect_eq("opposite clear slot: locked gate closed", state.p25_p2_audio_allowed[1], 0);
+    rc |= expect_eq("opposite clear slot: marker clear", state.p25_p2_enc_lockout_muted[1], 0);
+    return rc;
+}
+
+int
+main(void) {
+    install_trunk_tuning_hooks();
+
+    int rc = 0;
+    rc |= test_pre_ess_single_slot_stays_tuned();
+    rc |= test_pre_ess_opposite_clear_slot_stays_tuned();
+    return rc;
+}

--- a/tests/protocol/p25/test_p25_p2_mixer_gate.c
+++ b/tests/protocol/p25/test_p25_p2_mixer_gate.c
@@ -9,10 +9,19 @@
  */
 
 #include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/runtime/p25_p2_audio_ring.h>
+#include <dsd-neo/runtime/udp_audio_hooks.h>
+#include <stdint.h>
 #include <stdio.h>
+#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+
+static unsigned char g_audio_capture[2048];
+static size_t g_audio_capture_bytes = 0;
+static int g_audio_capture_calls = 0;
 
 static int
 expect_eq(const char* tag, int got, int want) {
@@ -21,6 +30,258 @@ expect_eq(const char* tag, int got, int want) {
         return 1;
     }
     return 0;
+}
+
+static int
+expect_true(const char* tag, int cond) {
+    if (!cond) {
+        DSD_FPRINTF(stderr, "%s failed\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+copy_capture_bytes(const char* tag, void* out, size_t expected_bytes) {
+    if (g_audio_capture_bytes != expected_bytes) {
+        DSD_FPRINTF(stderr, "%s: got %zu want %zu\n", tag, g_audio_capture_bytes, expected_bytes);
+        return 1;
+    }
+    DSD_MEMCPY(out, g_audio_capture, expected_bytes);
+    return 0;
+}
+
+static void
+capture_blast(const dsd_opts* opts, dsd_state* state, size_t bytes, const void* data) {
+    (void)opts;
+    (void)state;
+    g_audio_capture_calls++;
+    if (g_audio_capture_calls == 1 && data && bytes <= sizeof(g_audio_capture)) {
+        DSD_MEMCPY(g_audio_capture, data, bytes);
+        g_audio_capture_bytes = bytes;
+    }
+}
+
+static void
+reset_capture(void) {
+    DSD_MEMSET(g_audio_capture, 0, sizeof(g_audio_capture));
+    g_audio_capture_bytes = 0;
+    g_audio_capture_calls = 0;
+}
+
+static void
+fill_f32_frame(float frame[160], float value) {
+    for (int i = 0; i < 160; i++) {
+        frame[i] = value;
+    }
+}
+
+static int
+run_fs4_left_active_case_ext(int enc_lockout_enabled, int expect_right_silent, int muted_slot_algid,
+                             int muted_slot_aes_loaded, unsigned long long muted_slot_key, int muted_slot_svc,
+                             int muted_slot_marker) {
+    static dsd_opts opts;
+    static dsd_state st;
+    float frame[160];
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.pulse_digi_out_channels = 2;
+    opts.slot1_on = 1;
+    opts.slot2_on = 1;
+    opts.trunk_tune_enc_calls = enc_lockout_enabled ? 0 : 1;
+    opts.audio_gain = 25;
+    st.aout_gain = 49.0f;
+    st.aout_gainR = 49.0f;
+    st.p25_p2_audio_allowed[0] = 1;
+    st.p25_p2_audio_allowed[1] = 0;
+    st.dmr_soR = muted_slot_svc;
+    st.payload_algidR = muted_slot_algid;
+    st.aes_key_loaded[1] = muted_slot_aes_loaded;
+    st.RR = muted_slot_key;
+    st.p25_p2_enc_lockout_muted[1] = (uint8_t)(muted_slot_marker ? 1U : 0U);
+
+    fill_f32_frame(frame, 384.0f);
+    rc |= expect_eq("fs4 push left", p25_p2_audio_ring_push(&st, 0, frame), 1);
+    playSynthesizedVoiceFS4(&opts, &st);
+
+    float out[160 * 2] = {0.0f};
+    const size_t expected_bytes = (size_t)160 * 2U * sizeof(out[0]);
+    rc |= expect_eq("fs4 captured calls", g_audio_capture_calls >= 1, 1);
+    int copied = copy_capture_bytes("fs4 captured bytes", out, expected_bytes);
+    rc |= copied;
+    if (copied == 0) {
+        rc |= expect_true("fs4 left audible", out[0] != 0.0f);
+        rc |= expect_eq("fs4 right state", out[1] == 0.0f, expect_right_silent);
+    }
+    return rc;
+}
+
+static int
+run_fs4_left_active_case(int enc_lockout_enabled, int expect_right_silent, int muted_slot_algid,
+                         int muted_slot_aes_loaded, unsigned long long muted_slot_key) {
+    return run_fs4_left_active_case_ext(enc_lockout_enabled, expect_right_silent, muted_slot_algid,
+                                        muted_slot_aes_loaded, muted_slot_key, 0x40, 0);
+}
+
+static int
+run_fs4_right_active_case_ext(int enc_lockout_enabled, int expect_left_silent, int muted_slot_algid,
+                              int muted_slot_aes_loaded, unsigned long long muted_slot_key, int muted_slot_svc,
+                              int muted_slot_marker) {
+    static dsd_opts opts;
+    static dsd_state st;
+    float frame[160];
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.pulse_digi_out_channels = 2;
+    opts.slot1_on = 1;
+    opts.slot2_on = 1;
+    opts.trunk_tune_enc_calls = enc_lockout_enabled ? 0 : 1;
+    opts.audio_gain = 25;
+    st.aout_gain = 49.0f;
+    st.aout_gainR = 49.0f;
+    st.p25_p2_audio_allowed[0] = 0;
+    st.p25_p2_audio_allowed[1] = 1;
+    st.dmr_so = muted_slot_svc;
+    st.payload_algid = muted_slot_algid;
+    st.aes_key_loaded[0] = muted_slot_aes_loaded;
+    st.R = muted_slot_key;
+    st.p25_p2_enc_lockout_muted[0] = (uint8_t)(muted_slot_marker ? 1U : 0U);
+
+    fill_f32_frame(frame, 384.0f);
+    rc |= expect_eq("fs4 push right", p25_p2_audio_ring_push(&st, 1, frame), 1);
+    playSynthesizedVoiceFS4(&opts, &st);
+
+    float out[160 * 2] = {0.0f};
+    const size_t expected_bytes = (size_t)160 * 2U * sizeof(out[0]);
+    rc |= expect_eq("fs4 right captured calls", g_audio_capture_calls >= 1, 1);
+    int copied = copy_capture_bytes("fs4 right captured bytes", out, expected_bytes);
+    rc |= copied;
+    if (copied == 0) {
+        rc |= expect_eq("fs4 left state", out[0] == 0.0f, expect_left_silent);
+        rc |= expect_true("fs4 right audible", out[1] != 0.0f);
+    }
+    return rc;
+}
+
+static int
+run_fs4_right_active_case(int enc_lockout_enabled, int expect_left_silent, int muted_slot_algid,
+                          int muted_slot_aes_loaded, unsigned long long muted_slot_key) {
+    return run_fs4_right_active_case_ext(enc_lockout_enabled, expect_left_silent, muted_slot_algid,
+                                         muted_slot_aes_loaded, muted_slot_key, 0x40, 0);
+}
+
+static int
+run_ss18_left_active_case_ext(int enc_lockout_enabled, int expect_right_silent, int muted_slot_algid,
+                              int muted_slot_aes_loaded, unsigned long long muted_slot_key, int muted_slot_svc,
+                              int muted_slot_marker) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.slot1_on = 1;
+    opts.slot2_on = 1;
+    opts.trunk_tune_enc_calls = enc_lockout_enabled ? 0 : 1;
+    st.p25_p2_audio_allowed[0] = 1;
+    st.p25_p2_audio_allowed[1] = 0;
+    st.dmrburstL = 21;
+    st.dmrburstR = 0;
+    st.dmr_soR = muted_slot_svc;
+    st.payload_algidR = muted_slot_algid;
+    st.aes_key_loaded[1] = muted_slot_aes_loaded;
+    st.RR = muted_slot_key;
+    st.p25_p2_enc_lockout_muted[1] = (uint8_t)(muted_slot_marker ? 1U : 0U);
+
+    for (int i = 0; i < 160; i++) {
+        st.s_l4[0][i] = 100;
+    }
+    playSynthesizedVoiceSS18(&opts, &st);
+
+    short out[160 * 2] = {0};
+    const size_t expected_bytes = (size_t)160 * 2U * sizeof(out[0]);
+    rc |= expect_eq("ss18 captured calls", g_audio_capture_calls >= 1, 1);
+    int copied = copy_capture_bytes("ss18 captured bytes", out, expected_bytes);
+    rc |= copied;
+    if (copied == 0) {
+        rc |= expect_eq("ss18 left audible", out[0], 100);
+        rc |= expect_eq("ss18 right state", out[1] == 0, expect_right_silent);
+    }
+    return rc;
+}
+
+static int
+run_ss18_left_active_case(int enc_lockout_enabled, int expect_right_silent, int muted_slot_algid,
+                          int muted_slot_aes_loaded, unsigned long long muted_slot_key) {
+    return run_ss18_left_active_case_ext(enc_lockout_enabled, expect_right_silent, muted_slot_algid,
+                                         muted_slot_aes_loaded, muted_slot_key, 0x40, 0);
+}
+
+static int
+run_ss18_right_active_case_ext(int enc_lockout_enabled, int expect_left_silent, int muted_slot_algid,
+                               int muted_slot_aes_loaded, unsigned long long muted_slot_key, int muted_slot_svc,
+                               int muted_slot_marker) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.slot1_on = 1;
+    opts.slot2_on = 1;
+    opts.trunk_tune_enc_calls = enc_lockout_enabled ? 0 : 1;
+    st.p25_p2_audio_allowed[0] = 0;
+    st.p25_p2_audio_allowed[1] = 1;
+    st.dmrburstL = 0;
+    st.dmrburstR = 21;
+    st.dmr_so = muted_slot_svc;
+    st.payload_algid = muted_slot_algid;
+    st.aes_key_loaded[0] = muted_slot_aes_loaded;
+    st.R = muted_slot_key;
+    st.p25_p2_enc_lockout_muted[0] = (uint8_t)(muted_slot_marker ? 1U : 0U);
+
+    for (int i = 0; i < 160; i++) {
+        st.s_r4[0][i] = 100;
+    }
+    playSynthesizedVoiceSS18(&opts, &st);
+
+    short out[160 * 2] = {0};
+    const size_t expected_bytes = (size_t)160 * 2U * sizeof(out[0]);
+    rc |= expect_eq("ss18 right captured calls", g_audio_capture_calls >= 1, 1);
+    int copied = copy_capture_bytes("ss18 right captured bytes", out, expected_bytes);
+    rc |= copied;
+    if (copied == 0) {
+        rc |= expect_eq("ss18 left state", out[0] == 0, expect_left_silent);
+        rc |= expect_eq("ss18 right audible", out[1], 100);
+    }
+    return rc;
+}
+
+static int
+run_ss18_right_active_case(int enc_lockout_enabled, int expect_left_silent, int muted_slot_algid,
+                           int muted_slot_aes_loaded, unsigned long long muted_slot_key) {
+    return run_ss18_right_active_case_ext(enc_lockout_enabled, expect_left_silent, muted_slot_algid,
+                                          muted_slot_aes_loaded, muted_slot_key, 0x40, 0);
 }
 
 int
@@ -58,6 +319,61 @@ main(void) {
     rc |= expect_eq("gate ret D", dsd_p25p2_mixer_gate(&st, &encL, &encR), 0);
     rc |= expect_eq("D encL", encL, 1);
     rc |= expect_eq("D encR", encR, 1);
+
+    dsd_udp_audio_hooks_set((dsd_udp_audio_hooks){.blast = capture_blast});
+    rc |= run_fs4_left_active_case(/*enc_lockout_enabled*/ 1, /*expect_right_silent*/ 1, /*muted_slot_algid*/ 0,
+                                   /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 0ULL);
+    rc |= run_fs4_left_active_case_ext(/*enc_lockout_enabled*/ 1, /*expect_right_silent*/ 1,
+                                       /*muted_slot_algid*/ 0, /*muted_slot_aes_loaded*/ 0,
+                                       /*muted_slot_key*/ 0ULL, /*muted_slot_svc*/ 0, /*muted_slot_marker*/ 1);
+    rc |= run_fs4_left_active_case(/*enc_lockout_enabled*/ 0, /*expect_right_silent*/ 0, /*muted_slot_algid*/ 0,
+                                   /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 0ULL);
+    rc |= run_fs4_left_active_case(/*enc_lockout_enabled*/ 1, /*expect_right_silent*/ 0, /*muted_slot_algid*/ 0x80,
+                                   /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 0ULL);
+    rc |= run_fs4_left_active_case(/*enc_lockout_enabled*/ 1, /*expect_right_silent*/ 0, /*muted_slot_algid*/ 0x84,
+                                   /*muted_slot_aes_loaded*/ 1, /*muted_slot_key*/ 0ULL);
+    rc |= run_fs4_left_active_case(/*enc_lockout_enabled*/ 1, /*expect_right_silent*/ 0, /*muted_slot_algid*/ 0x81,
+                                   /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 1ULL);
+    rc |= run_fs4_right_active_case(/*enc_lockout_enabled*/ 1, /*expect_left_silent*/ 1, /*muted_slot_algid*/ 0,
+                                    /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 0ULL);
+    rc |= run_fs4_right_active_case_ext(/*enc_lockout_enabled*/ 1, /*expect_left_silent*/ 1,
+                                        /*muted_slot_algid*/ 0, /*muted_slot_aes_loaded*/ 0,
+                                        /*muted_slot_key*/ 0ULL, /*muted_slot_svc*/ 0, /*muted_slot_marker*/ 1);
+    rc |= run_fs4_right_active_case(/*enc_lockout_enabled*/ 0, /*expect_left_silent*/ 0, /*muted_slot_algid*/ 0,
+                                    /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 0ULL);
+    rc |= run_fs4_right_active_case(/*enc_lockout_enabled*/ 1, /*expect_left_silent*/ 0, /*muted_slot_algid*/ 0x80,
+                                    /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 0ULL);
+    rc |= run_fs4_right_active_case(/*enc_lockout_enabled*/ 1, /*expect_left_silent*/ 0, /*muted_slot_algid*/ 0x84,
+                                    /*muted_slot_aes_loaded*/ 1, /*muted_slot_key*/ 0ULL);
+    rc |= run_fs4_right_active_case(/*enc_lockout_enabled*/ 1, /*expect_left_silent*/ 0, /*muted_slot_algid*/ 0x81,
+                                    /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 1ULL);
+    rc |= run_ss18_left_active_case(/*enc_lockout_enabled*/ 1, /*expect_right_silent*/ 1, /*muted_slot_algid*/ 0,
+                                    /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 0ULL);
+    rc |= run_ss18_left_active_case_ext(/*enc_lockout_enabled*/ 1, /*expect_right_silent*/ 1,
+                                        /*muted_slot_algid*/ 0, /*muted_slot_aes_loaded*/ 0,
+                                        /*muted_slot_key*/ 0ULL, /*muted_slot_svc*/ 0, /*muted_slot_marker*/ 1);
+    rc |= run_ss18_left_active_case(/*enc_lockout_enabled*/ 0, /*expect_right_silent*/ 0, /*muted_slot_algid*/ 0,
+                                    /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 0ULL);
+    rc |= run_ss18_left_active_case(/*enc_lockout_enabled*/ 1, /*expect_right_silent*/ 0, /*muted_slot_algid*/ 0x80,
+                                    /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 0ULL);
+    rc |= run_ss18_left_active_case(/*enc_lockout_enabled*/ 1, /*expect_right_silent*/ 0, /*muted_slot_algid*/ 0x84,
+                                    /*muted_slot_aes_loaded*/ 1, /*muted_slot_key*/ 0ULL);
+    rc |= run_ss18_left_active_case(/*enc_lockout_enabled*/ 1, /*expect_right_silent*/ 0, /*muted_slot_algid*/ 0x81,
+                                    /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 1ULL);
+    rc |= run_ss18_right_active_case(/*enc_lockout_enabled*/ 1, /*expect_left_silent*/ 1, /*muted_slot_algid*/ 0,
+                                     /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 0ULL);
+    rc |= run_ss18_right_active_case_ext(/*enc_lockout_enabled*/ 1, /*expect_left_silent*/ 1,
+                                         /*muted_slot_algid*/ 0, /*muted_slot_aes_loaded*/ 0,
+                                         /*muted_slot_key*/ 0ULL, /*muted_slot_svc*/ 0, /*muted_slot_marker*/ 1);
+    rc |= run_ss18_right_active_case(/*enc_lockout_enabled*/ 0, /*expect_left_silent*/ 0, /*muted_slot_algid*/ 0,
+                                     /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 0ULL);
+    rc |= run_ss18_right_active_case(/*enc_lockout_enabled*/ 1, /*expect_left_silent*/ 0, /*muted_slot_algid*/ 0x80,
+                                     /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 0ULL);
+    rc |= run_ss18_right_active_case(/*enc_lockout_enabled*/ 1, /*expect_left_silent*/ 0, /*muted_slot_algid*/ 0x84,
+                                     /*muted_slot_aes_loaded*/ 1, /*muted_slot_key*/ 0ULL);
+    rc |= run_ss18_right_active_case(/*enc_lockout_enabled*/ 1, /*expect_left_silent*/ 0, /*muted_slot_algid*/ 0x81,
+                                     /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 1ULL);
+    dsd_udp_audio_hooks_set((dsd_udp_audio_hooks){0});
 
     return rc;
 }

--- a/tests/protocol/p25/test_p25_p2_vpdu_core.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_core.c
@@ -11,6 +11,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_vpdu.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <errno.h>
@@ -135,6 +136,15 @@ expect_eq_long(const char* tag, long got, long want) {
 }
 
 static int
+expect_true(const char* tag, int cond) {
+    if (!cond) {
+        DSD_FPRINTF(stderr, "%s: failed\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 run_sccb_candidate_case(const unsigned char* mac_bytes, int current_rfss, int current_site, long* out_freqs,
                         int out_cap, int* out_rfss, int* out_site, int* out_lcn_count, long* out_lcn_freqs,
                         int out_lcn_cap) {
@@ -184,6 +194,98 @@ run_sccb_candidate_case(const unsigned char* mac_bytes, int current_rfss, int cu
     dsd_state_ext_free_all(state);
     free(state);
     return count;
+}
+
+static int
+write_full_sccb_cache_fixture(const char* path, long first_freq) {
+    FILE* fp = fopen(path, "w");
+    if (!fp) {
+        DSD_FPRINTF(stderr, "failed to write SCCB cache fixture: %s\n", strerror(errno));
+        return 0;
+    }
+    for (int i = 0; i < DSD_TRUNK_CC_CANDIDATES_MAX; i++) {
+        DSD_FPRINTF(fp, "cc %ld\n", first_freq + (long)i * 12500L);
+    }
+    fclose(fp);
+    return 1;
+}
+
+static int
+cc_candidates_contains(const dsd_trunk_cc_candidates* cc, long freq) {
+    if (!cc || cc->count <= 0 || cc->count > DSD_TRUNK_CC_CANDIDATES_MAX) {
+        return 0;
+    }
+    for (int i = 0; i < cc->count; i++) {
+        if (cc->candidates[i] == freq) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+run_sccb_full_cache_preservation_case(void) {
+    int rc = 0;
+    char dir[DSD_TEST_PATH_MAX];
+    if (!dsd_test_mkdtemp(dir, sizeof(dir), "dsdneo_p2_sccb_cache")) {
+        DSD_FPRINTF(stderr, "dsd_test_mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+    setenv("DSD_NEO_CACHE_DIR", dir, 1);
+    setenv("DSD_NEO_CC_CACHE", "1", 1);
+    dsd_neo_config_init(NULL);
+
+    static dsd_opts opts;
+    dsd_state* state = NULL;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!state) {
+        return 1;
+    }
+
+    const int iden = 1;
+    state->p25_iden_fdma[iden].chan_type = 1;
+    state->p25_iden_fdma[iden].chan_spac = 100;
+    state->p25_iden_fdma[iden].base_freq = 851000000 / 5;
+    state->p25_iden_fdma[iden].populated = 1;
+    state->p25_chan_tdma_explicit[iden] = 1;
+    state->p2_wacn = 0xABCDE;
+    state->p2_sysid = 0x123;
+    state->p2_rfssid = 0x02;
+    state->p2_siteid = 0x03;
+
+    char cache_path[1024];
+    if (!p25_cc_build_cache_path(state, cache_path, sizeof(cache_path))) {
+        dsd_state_ext_free_all(state);
+        free(state);
+        return 1;
+    }
+    if (!write_full_sccb_cache_fixture(cache_path, 852000000L)) {
+        dsd_state_ext_free_all(state);
+        free(state);
+        return 1;
+    }
+
+    unsigned long long int MAC[24] = {0};
+    MAC[1] = 0xE9;
+    MAC[2] = 0x02;
+    MAC[3] = 0x03;
+    MAC[4] = 0x10;
+    MAC[5] = 0x0A;
+    MAC[6] = 0x10;
+    MAC[7] = 0x05;
+    MAC[8] = 0x01;
+    process_MAC_VPDU(&opts, state, 0 /* FACCH */, MAC);
+
+    const long sccb_freq = 851000000 + 10 * 100 * 125;
+    const dsd_trunk_cc_candidates* cc = dsd_trunk_cc_candidates_peek(state);
+    rc |= expect_eq_long("p2_sccb_cache_loaded", state->p25_cc_cache_loaded, 1);
+    rc |= expect_eq_long("p2_sccb_full_cache_count", cc ? cc->count : 0, DSD_TRUNK_CC_CANDIDATES_MAX);
+    rc |= expect_true("p2_sccb_preserved_after_full_cache_load", cc_candidates_contains(cc, sccb_freq));
+
+    dsd_state_ext_free_all(state);
+    free(state);
+    return rc;
 }
 
 static int
@@ -376,7 +478,11 @@ run_cases(void) {
         rc |= expect_eq_long("p2_sccb_implicit_partial_iden_lcn_ch2", lcn_freqs[1], 851000000 + 5 * 100 * 125);
     }
 
-    // Case 12: extended private voice (0x22) derives source from the SUID tail.
+    // Case 12: a full persisted cache loaded during SCCB handling must not
+    // evict the freshly validated current-site SCCB candidate.
+    rc |= run_sccb_full_cache_preservation_case();
+
+    // Case 13: extended private voice (0x22) derives source from the SUID tail.
     {
         static dsd_opts opts;
         static dsd_state state;

--- a/tests/protocol/p25/test_p25_p2_vpdu_core.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_core.c
@@ -11,6 +11,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_vpdu.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
@@ -198,7 +199,7 @@ run_sccb_candidate_case(const unsigned char* mac_bytes, int current_rfss, int cu
 
 static int
 write_full_sccb_cache_fixture(const char* path, long first_freq) {
-    FILE* fp = fopen(path, "w");
+    FILE* fp = dsd_fopen_private(path, "w");
     if (!fp) {
         DSD_FPRINTF(stderr, "failed to write SCCB cache fixture: %s\n", strerror(errno));
         return 0;

--- a/tests/runtime/test_runtime_trunk_cc_candidates.c
+++ b/tests/runtime/test_runtime_trunk_cc_candidates.c
@@ -23,6 +23,7 @@ test_add_dedup_rollover(void) {
     assert(cc != NULL);
     assert(cc->count == 1);
     assert(cc->candidates[0] == 100);
+    assert((cc->flags[0] & DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE) != 0);
     assert(cc->added == 0);
 
     assert(dsd_trunk_cc_candidates_add(st, 100, 1) == 0);
@@ -32,6 +33,7 @@ test_add_dedup_rollover(void) {
     assert(cc->count == 2);
     assert(cc->candidates[0] == 100);
     assert(cc->candidates[1] == 200);
+    assert((cc->flags[1] & DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE) != 0);
     assert(cc->added == 1);
 
     dsd_state* st2 = calloc(1, sizeof(*st2));
@@ -55,6 +57,28 @@ test_add_dedup_rollover(void) {
 
     dsd_state_ext_free_all(st2);
     free(st2);
+    dsd_state_ext_free_all(st);
+    free(st);
+}
+
+static void
+test_filtered_iteration(void) {
+    dsd_state* st = calloc(1, sizeof(*st));
+    assert(st != NULL);
+
+    assert(dsd_trunk_cc_candidates_add_with_flags(st, 300, 0, 0) == 1);
+    long out = 0;
+    assert(dsd_trunk_cc_candidates_next_with_flags(st, 0.0, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE, &out) == 0);
+
+    out = 0;
+    assert(dsd_trunk_cc_candidates_next(st, 0.0, &out) == 1);
+    assert(out == 300);
+
+    assert(dsd_trunk_cc_candidates_add_with_flags(st, 300, 0, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE) == 0);
+    out = 0;
+    assert(dsd_trunk_cc_candidates_next_with_flags(st, 0.0, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE, &out) == 1);
+    assert(out == 300);
+
     dsd_state_ext_free_all(st);
     free(st);
 }
@@ -107,6 +131,7 @@ test_next_and_cooldown(void) {
 int
 main(void) {
     test_add_dedup_rollover();
+    test_filtered_iteration();
     test_next_and_cooldown();
     return 0;
 }

--- a/tests/ui/test_ui_history_compact.c
+++ b/tests/ui/test_ui_history_compact.c
@@ -6,6 +6,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 #include <dsd-neo/ui/ui_history.h>
 
@@ -35,6 +36,11 @@ main(void) {
     n = ui_history_compact_event_text(tiny, sizeof tiny, canonical, 1);
     assert(n == 4);
     assert(strcmp(tiny, "02:0") == 0);
+
+    time_t newer = ui_history_event_sort_time("2026-06-07 19:20:15 P25p2 TGT: 00050002;", (time_t)1);
+    time_t older = ui_history_event_sort_time("2026-06-07 19:20:07 P25p1 TGT: 00021001;", (time_t)2000000000);
+    assert(newer > older);
+    assert(ui_history_event_sort_time(noncanonical, (time_t)1234) == (time_t)1234);
 
     printf("UI_HISTORY_COMPACT: OK\n");
     return 0;


### PR DESCRIPTION
## Summary

- 

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / none.
- [x] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [ ] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [ ] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [x] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes
- [x] `tools/zizmor.sh` for workflow changes
- [x] `tools/osv_scan.sh` for dependency input changes
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes

## Risk

- Security/dependency impact:
- CLI/UI behavior impact:
- Compatibility or packaging impact:
