### PR TITLE
dsp: stop repeated wav eof notices

### DIFF
--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -1123,8 +1123,36 @@ symbol_read_sample_pulse(dsd_opts* opts, float* sample_out) {
     return 1;
 }
 
+static inline void
+symbol_close_audio_in_file(dsd_opts* opts) {
+    if (opts == NULL || opts->audio_in_file == NULL) {
+        return;
+    }
+    sf_close(opts->audio_in_file);
+    opts->audio_in_file = NULL;
+}
+
+static inline int
+symbol_stop_after_shutdown(float* sample_out) {
+    if (exitflag != 1) {
+        return 0;
+    }
+    if (sample_out != NULL) {
+        *sample_out = 0.0f;
+    }
+    return 1;
+}
+
 static inline int
 symbol_read_sample_stdin(dsd_opts* opts, dsd_state* state, float* sample_out) {
+    if (symbol_stop_after_shutdown(sample_out)) {
+        return 0;
+    }
+    if (opts->audio_in_file == NULL) {
+        cleanupAndExit(opts, state);
+        return 0;
+    }
+
     short s = 0;
     sf_count_t result = sf_read_short(opts->audio_in_file, &s, 1);
     s = symbol_scale_pcm_i16(s, opts->input_volume_multiplier);
@@ -1133,7 +1161,7 @@ symbol_read_sample_stdin(dsd_opts* opts, dsd_state* state, float* sample_out) {
         if (dsd_pcm_input_take_staged_tail_sample(opts, sample_out, 1)) {
             return 1;
         }
-        sf_close(opts->audio_in_file);
+        symbol_close_audio_in_file(opts);
         cleanupAndExit(opts, state);
         return 0;
     }
@@ -1146,6 +1174,14 @@ symbol_read_sample_stdin(dsd_opts* opts, dsd_state* state, float* sample_out) {
 
 static inline int
 symbol_read_sample_wav(dsd_opts* opts, dsd_state* state, float* sample_out) {
+    if (symbol_stop_after_shutdown(sample_out)) {
+        return 0;
+    }
+    if (opts->audio_in_file == NULL) {
+        cleanupAndExit(opts, state);
+        return 0;
+    }
+
     short s = 0;
     sf_count_t result = sf_read_short(opts->audio_in_file, &s, 1);
     s = symbol_scale_pcm_i16(s, opts->input_volume_multiplier);
@@ -1154,7 +1190,7 @@ symbol_read_sample_wav(dsd_opts* opts, dsd_state* state, float* sample_out) {
         if (dsd_pcm_input_take_staged_tail_sample(opts, sample_out, 1)) {
             return 1;
         }
-        sf_close(opts->audio_in_file);
+        symbol_close_audio_in_file(opts);
         DSD_FPRINTF(stderr, "\nEnd of %s\n", opts->audio_in_dev);
         if (opts->audio_out_type == 0 && opts->use_ncurses_terminal == 1) {
             opts->audio_in_type = AUDIO_IN_PULSE;
@@ -1299,6 +1335,9 @@ symbol_read_sample_udp(dsd_opts* opts, dsd_state* state, float* sample_out) {
 
 static int
 symbol_take_sample(dsd_opts* opts, dsd_state* state, symbol_work_ctx* work) {
+    if (symbol_stop_after_shutdown(&work->sample)) {
+        return 0;
+    }
     if (dsd_pcm_input_uses_staged_resampler(opts) && opts->input_upsample_pos < opts->input_upsample_len) {
         work->sample = opts->input_upsample_buf[opts->input_upsample_pos++];
         return 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1508,6 +1508,19 @@ target_include_directories(
 dsd_neo_link_dsp_test(dsd-neo_test_dsp_pcm_input_staging)
 add_test(NAME DSP_PCM_INPUT_STAGING COMMAND dsd-neo_test_dsp_pcm_input_staging)
 
+add_executable(dsd-neo_test_dsp_wav_input_eof dsp/test_dsp_wav_input_eof.c)
+target_include_directories(
+    dsd-neo_test_dsp_wav_input_eof
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+dsd_neo_link_dsp_test(
+    dsd-neo_test_dsp_wav_input_eof
+    dsd-neo_test_support
+    ${DSD_NEO_TEST_MATH_LIB}
+    ${LIBSNDFILE_LIBRARIES}
+)
+add_test(NAME DSP_WAV_INPUT_EOF COMMAND dsd-neo_test_dsp_wav_input_eof)
+
 add_executable(
     dsd-neo_test_core_dmr_voice_alg_gate
     core/test_core_dmr_voice_alg_gate.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1511,7 +1511,7 @@ add_test(NAME DSP_PCM_INPUT_STAGING COMMAND dsd-neo_test_dsp_pcm_input_staging)
 add_executable(dsd-neo_test_dsp_wav_input_eof dsp/test_dsp_wav_input_eof.c)
 target_include_directories(
     dsd-neo_test_dsp_wav_input_eof
-    PRIVATE ${PROJECT_SOURCE_DIR}/include
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${LIBSNDFILE_INCLUDE_DIR}
 )
 dsd_neo_link_dsp_test(
     dsd-neo_test_dsp_wav_input_eof

--- a/tests/dsp/test_dsp_wav_input_eof.c
+++ b/tests/dsp/test_dsp_wav_input_eof.c
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/audio_filters.h>
+#include <dsd-neo/core/cleanup.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/power.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/dsp/symbol.h>
+#include <dsd-neo/io/rigctl_client.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/sockets.h>
+#include <dsd-neo/runtime/exitflag.h>
+#include <sndfile.h>
+#include <stdio.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "test_support.h"
+
+static int g_cleanup_calls = 0;
+
+dsd_socket_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+Connect(char* hostname, int portno) {
+    (void)hostname;
+    (void)portno;
+    return (dsd_socket_t)0;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+openAudioInput(dsd_opts* opts) {
+    (void)opts;
+    return -1;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+cleanupAndExit(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_cleanup_calls++;
+    exitflag = 1;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_audio_rescale_symbol_timing(dsd_state* state, int old_rate_hz, int new_rate_hz) {
+    (void)state;
+    (void)old_rate_hz;
+    (void)new_rate_hz;
+}
+
+double
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+raw_pwr_f(const float* samples, int len, int step) {
+    (void)samples;
+    (void)len;
+    (void)step;
+    return 0.0;
+}
+
+double
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+pwr_to_dB(double mean_power) {
+    (void)mean_power;
+    return 0.0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+lpf_f(dsd_state* state, float* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+hpf_f(dsd_state* state, float* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+pbf_f(dsd_state* state, float* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+agsm_f(dsd_opts* opts, dsd_state* state, float* input, int len) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+static int
+create_one_sample_wav(char* out_path, size_t out_path_size) {
+    int fd = dsd_test_mkstemp(out_path, out_path_size, "dsdneo_wav_eof");
+    if (fd < 0) {
+        return -1;
+    }
+    dsd_close(fd);
+
+    SF_INFO info;
+    DSD_MEMSET(&info, 0, sizeof(info));
+    info.samplerate = 48000;
+    info.channels = 1;
+    info.format = SF_FORMAT_WAV | SF_FORMAT_PCM_16;
+
+    SNDFILE* wav = sf_open(out_path, SFM_WRITE, &info);
+    if (wav == NULL) {
+        return -1;
+    }
+
+    short sample = 1234;
+    int ok = sf_write_short(wav, &sample, 1) == 1;
+    sf_close(wav);
+    return ok ? 0 : -1;
+}
+
+int
+main(void) {
+    char wav_path[DSD_TEST_PATH_MAX];
+    assert(create_one_sample_wav(wav_path, sizeof(wav_path)) == 0);
+
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    SF_INFO info;
+    DSD_MEMSET(&info, 0, sizeof(info));
+    opts.audio_in_file = sf_open(wav_path, SFM_READ, &info);
+    assert(opts.audio_in_file != NULL);
+    opts.audio_in_file_info = &info;
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.audio_out_type = 1;
+    opts.input_volume_multiplier = 1;
+    opts.wav_sample_rate = 48000;
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "%s", wav_path);
+
+    state.samplesPerSymbol = 1;
+    state.symbolCenter = 0;
+    state.rf_mod = 0;
+    exitflag = 0;
+
+    assert(getSymbol(&opts, &state, 0) == 1234.0f);
+    assert(g_cleanup_calls == 0);
+
+    assert(getSymbol(&opts, &state, 0) == 0.0f);
+    assert(g_cleanup_calls == 1);
+    assert(exitflag == 1);
+    assert(opts.audio_in_file == NULL);
+
+    assert(getSymbol(&opts, &state, 0) == 0.0f);
+    assert(g_cleanup_calls == 1);
+    assert(opts.audio_in_file == NULL);
+
+    remove(wav_path);
+    return 0;
+}

--- a/tests/dsp/test_dsp_wav_input_eof.c
+++ b/tests/dsp/test_dsp_wav_input_eof.c
@@ -17,6 +17,7 @@
 #include <dsd-neo/runtime/exitflag.h>
 #include <sndfile.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -149,11 +150,10 @@ main(void) {
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
 
-    SF_INFO info;
-    DSD_MEMSET(&info, 0, sizeof(info));
-    opts.audio_in_file = sf_open(wav_path, SFM_READ, &info);
+    opts.audio_in_file_info = (SF_INFO*)calloc(1, sizeof(*opts.audio_in_file_info));
+    assert(opts.audio_in_file_info != NULL);
+    opts.audio_in_file = sf_open(wav_path, SFM_READ, opts.audio_in_file_info);
     assert(opts.audio_in_file != NULL);
-    opts.audio_in_file_info = &info;
     opts.audio_in_type = AUDIO_IN_WAV;
     opts.audio_out_type = 1;
     opts.input_volume_multiplier = 1;
@@ -177,6 +177,8 @@ main(void) {
     assert(g_cleanup_calls == 1);
     assert(opts.audio_in_file == NULL);
 
+    free(opts.audio_in_file_info);
+    opts.audio_in_file_info = NULL;
     remove(wav_path);
     return 0;
 }


### PR DESCRIPTION
## Summary
- make WAV/stdin EOF handling idempotent by closing and clearing the libsndfile input handle
- stop later symbol reads immediately once shutdown has been requested
- add a one-sample WAV regression test for the EOF path

## Root Cause
WAV EOF closed the libsndfile handle but left `opts->audio_in_file` pointing at the closed object. Frame processing can continue to ask for symbols while shutdown is pending, so later reads re-entered the WAV EOF path and repeated the `End of ...` notice.

## Tests
- `tools/format.sh`
- `tools/cmake_format_check.sh`
- `cmake --preset dev-debug`
- `cmake --build --preset dev-debug --target dsd-neo_test_dsp_wav_input_eof -j`
- `ctest --preset dev-debug -R 'DSP_WAV_INPUT_EOF|DSP_PCM_INPUT_STAGING' --output-on-failure`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `cmake --preset asan-ubsan-debug`
- `cmake --build --preset asan-ubsan-debug -j`
- `ctest --preset asan-ubsan-debug --output-on-failure`
- `git diff --check`
- `tools/preflight_ci.sh`
- `tools/quality_preflight.sh`

Fixes #155