### PR TITLE
tests: avoid libsndfile private typedef

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,29 @@ set(_DSD_PUBLIC_HEADER_TEST_DIR
 )
 file(MAKE_DIRECTORY "${_DSD_PUBLIC_HEADER_TEST_DIR}")
 
+set(_DSD_SNDFILE_ALT_TAG_INCLUDE_DIR
+    "${CMAKE_CURRENT_BINARY_DIR}/sndfile_alt_tag_include"
+)
+file(MAKE_DIRECTORY "${_DSD_SNDFILE_ALT_TAG_INCLUDE_DIR}")
+file(
+    WRITE "${_DSD_SNDFILE_ALT_TAG_INCLUDE_DIR}/sndfile.h"
+    "#ifndef SNDFILE_H\n"
+    "#define SNDFILE_H\n"
+    "\n"
+    "typedef long long sf_count_t;\n"
+    "typedef struct SNDFILE_tag SNDFILE;\n"
+    "typedef struct SF_INFO {\n"
+    "    sf_count_t frames;\n"
+    "    int samplerate;\n"
+    "    int channels;\n"
+    "    int format;\n"
+    "    int sections;\n"
+    "    int seekable;\n"
+    "} SF_INFO;\n"
+    "\n"
+    "#endif /* SNDFILE_H */\n"
+)
+
 function(
     dsd_neo_add_public_header_smoke_test
     target_name
@@ -1393,6 +1416,34 @@ if(NOT APPLE AND NOT WIN32 AND (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang"))
     add_test(
         NAME CORE_CALL_ALERT_HISTORY
         COMMAND dsd-neo_test_core_call_alert_history
+    )
+
+    add_executable(
+        dsd-neo_test_core_call_alert_history_sndfile_alt_tag
+        core/test_core_call_alert_history.c
+    )
+    target_include_directories(
+        dsd-neo_test_core_call_alert_history_sndfile_alt_tag
+        BEFORE
+        PRIVATE
+            ${_DSD_SNDFILE_ALT_TAG_INCLUDE_DIR}
+            ${PROJECT_SOURCE_DIR}/include
+    )
+    target_link_libraries(
+        dsd-neo_test_core_call_alert_history_sndfile_alt_tag
+        PRIVATE dsd-neo_core
+    )
+    target_link_options(
+        dsd-neo_test_core_call_alert_history_sndfile_alt_tag
+        PRIVATE "LINKER:--wrap=beeper"
+    )
+    set_property(
+        TARGET dsd-neo_test_core_call_alert_history_sndfile_alt_tag
+        PROPERTY EXPORT_COMPILE_COMMANDS OFF
+    )
+    add_test(
+        NAME CORE_CALL_ALERT_HISTORY_SNDFILE_ALT_TAG
+        COMMAND dsd-neo_test_core_call_alert_history_sndfile_alt_tag
     )
 endif()
 

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/time_format.h>
+#include <dsd-neo/platform/sndfile_fwd.h>
 #include <dsd-neo/protocol/edacs/edacs_afs.h>
 #include <dsd-neo/runtime/call_alert.h>
 #include <stdint.h>
@@ -25,12 +26,10 @@
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #endif
 
-struct sf_private_tag;
-
 static int g_beeper_count;
 static int g_last_beeper_id;
 
-struct sf_private_tag*
+SNDFILE*
 open_wav_file(char* dir, char* temp_filename, size_t temp_filename_size, uint16_t sample_rate, uint8_t ext) {
     UNUSED(dir);
     UNUSED(temp_filename);
@@ -40,9 +39,9 @@ open_wav_file(char* dir, char* temp_filename, size_t temp_filename_size, uint16_
     return NULL;
 }
 
-struct sf_private_tag*
-close_and_rename_wav_file(struct sf_private_tag* wav_file, const dsd_opts* opts, const char* wav_out_filename,
-                          const char* dir, const Event_History_I* event_struct) {
+SNDFILE*
+close_and_rename_wav_file(SNDFILE* wav_file, const dsd_opts* opts, const char* wav_out_filename, const char* dir,
+                          const Event_History_I* event_struct) {
     UNUSED(wav_file);
     UNUSED(opts);
     UNUSED(wav_out_filename);


### PR DESCRIPTION
## Summary

- Fixes #149 by changing the call-alert history stubs to use the public `SNDFILE` typedef through `sndfile_fwd.h` instead of libsndfile's private `struct sf_private_tag`.
- Adds an alternate-tag regression target that builds the same test source against a generated libsndfile header using `typedef struct SNDFILE_tag SNDFILE`.
- Verified targeted Linux distro builds in CentOS Stream 9, Fedora latest, Ubuntu 24.04, and Debian stable containers.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented. Not broad/high-risk.
- [x] High-risk areas touched are marked: none.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests. No such areas changed; focused regression coverage was added for the build issue.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny. Not touched.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. No suppressions added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `tools/format.sh`
- [x] `tools/cmake_format_check.sh`
- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes. Not run: change is a narrow test/build portability fix.
- [ ] `tools/zizmor.sh` for workflow changes. Not run: workflows were not changed.
- [ ] `tools/osv_scan.sh` for dependency input changes. Not run: dependency inputs were not changed.
- [ ] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes. Not run directly: workflows/releases were not changed; relevant pin/redaction guardrails ran through `tools/preflight_ci.sh`.

Targeted distro container checks built `dsd-neo_test_core_call_alert_history` and ran `ctest -R '^CORE_CALL_ALERT_HISTORY$'` with optional radio backends disabled:

- CentOS Stream 9, GCC 11.5.0, libsndfile 1.0.31
- Fedora latest, GCC 16.1.1, libsndfile 1.2.2
- Ubuntu 24.04, GCC 13.3.0, libsndfile 1.2.2
- Debian stable, GCC 14.2.0, libsndfile 1.2.2

## Risk

- Security/dependency impact: none; no dependency inputs changed.
- CLI/UI behavior impact: none.
- Compatibility or packaging impact: improves test build portability across libsndfile packages that use different opaque struct tags.