### PR TITLE
docs: clarify tcp lan input setup

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,6 +67,8 @@ Tip: If you run with no arguments and no config is loaded, `dsd-neo` starts the 
 - RTL‑TCP: `-i rtltcp[:host:port[:freq:gain:ppm:bw:sql:vol[:bias[=on|off]]]]`
 - SoapySDR: `-i soapy[:args[:freq[:gain[:ppm[:bw[:sql[:vol]]]]]]]`
 - TCP raw PCM16LE input (mono): `-i tcp[:host:port]` (bare `tcp` connects to `localhost:7355`; sample rate uses `-s`, default 48000)
+  For a LAN host, use the IPv4 address of the computer running the TCP audio producer, and make sure that producer is
+  listening on that LAN interface, not just on `localhost`.
 - UDP PCM16 input: `-i udp[:bind_addr:port]` (defaults 127.0.0.1:7355)
 - M17 UDP/IP frame input: `-i m17udp[:bind_addr:port]` (defaults `127.0.0.1:17000`; use `0.0.0.0` only when LAN access is intended; use with `-fU`)
 - stdin (raw PCM16LE mono): `-i -` (sample rate uses `-s`)
@@ -76,6 +78,8 @@ Tip: If you run with no arguments and no config is loaded, `dsd-neo` starts the 
 TCP/UDP PCM input format notes
 
 - Sample format is signed PCM16LE (little-endian), mono, headerless stream/datagrams.
+- With `-i tcp:<host>:<port> -U <rigctl_port>`, rigctl connects to the same `<host>` as the TCP audio input. For SDR++
+  on another PC, allow inbound TCP for both the audio port, commonly `7355`, and rigctl, commonly `4532`.
 - See `docs/network-audio.md` for practical send/receive examples and UDP output details.
 
 Other input options

--- a/docs/network-audio.md
+++ b/docs/network-audio.md
@@ -27,6 +27,11 @@ Notes:
   even byte count (whole `int16_t` samples).
 - If UDP bursts faster than the internal ring can drain, samples may be dropped. Prefer steady packet sizes (e.g., ~20ms
   of audio per datagram).
+- For TCP input, DSD-neo is the client. `tcp:<host>:<port>` must name the computer and port where the PCM producer is
+  listening. `localhost` only reaches a producer on the same computer. To use a LAN address, configure the producer to
+  listen on its LAN interface or `0.0.0.0`, and allow inbound TCP through the host firewall.
+- With rigctl enabled (`-U <port>`), a TCP input host is also used as the rigctl host. For SDR++ on another PC, allow
+  both the TCP audio port, commonly `7355`, and the rigctl port, commonly `4532`.
 
 ## UDP Audio Output (`-o udp`)
 
@@ -96,5 +101,7 @@ Do not feed `m17udp` into raw PCM tools such as `ffplay -f s16le`; use the `udp`
 
 ## Troubleshooting
 
+- `tcp:localhost:7355` works but `tcp:<LAN-IP>:7355` fails: the PCM producer is usually listening only on loopback, the
+  LAN IP is not the producer computer's IPv4 address, or the host firewall is blocking the port.
 - Garbled audio usually means the **wrong sample format** (mono vs stereo, `s16le` vs `f32le`, or wrong sample rate).
 - If you need a self-describing file format, prefer WAV output (`-w` / `-P`) rather than UDP/stdout.

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -69,8 +69,9 @@ dsd_cli_usage_section_io(void) {
     printf("                soapy for SoapySDR input (default device args)\n");
     printf("                soapy:driver=airspy[,serial=...] for SoapySDR input selection args\n");
     printf("                soapy[:args]:freq[:gain[:ppm[:bw[:sql[:vol]]]]] for Soapy args + RTL-style tuning\n");
-    printf("                tcp for TCP raw PCM16LE mono audio input (Port 7355)\n");
-    printf("                tcp:192.168.7.5:7355 for custom address and port\n");
+    printf("                tcp for TCP raw PCM16LE mono audio input (connects to localhost:7355)\n");
+    printf("                tcp:192.168.1.50:7355 for a TCP producer listening on another host\n");
+    printf("                When -U is used with tcp:host:port, rigctl connects to the same host.\n");
     printf("                udp for UDP direct audio input (default host 127.0.0.1; default port 7355)\n");
     printf("                udp:0.0.0.0:7355 to bind all interfaces for UDP input\n");
     printf("                m17udp for M17 UDP/IP frame input (default 127.0.0.1:17000)\n");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5089,6 +5089,23 @@ target_link_libraries(
 add_test(NAME PLATFORM_FILE_COMPAT COMMAND dsd-neo_test_platform_file_compat)
 
 add_executable(
+    dsd-neo_test_platform_socket_resolve
+    platform/test_platform_socket_resolve.c
+)
+target_include_directories(
+    dsd-neo_test_platform_socket_resolve
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_platform_socket_resolve
+    PRIVATE dsd-neo_platform
+)
+add_test(
+    NAME PLATFORM_SOCKET_RESOLVE
+    COMMAND dsd-neo_test_platform_socket_resolve
+)
+
+add_executable(
     dsd-neo_test_platform_monotonic_cond
     platform/test_platform_monotonic_cond.c
 )

--- a/tests/platform/test_platform_socket_resolve.c
+++ b/tests/platform/test_platform_socket_resolve.c
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/platform/platform.h>
+#include <dsd-neo/platform/sockets.h>
+#include <stdio.h>
+#include "dsd-neo/core/safe_api.h"
+
+#if DSD_PLATFORM_WIN_NATIVE
+#include <winsock2.h>
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#endif
+
+static int
+expect_numeric_ipv4_resolves(const char* host, int port) {
+    struct sockaddr_in addr;
+    DSD_MEMSET(&addr, 0, sizeof(addr));
+
+    if (dsd_socket_resolve(host, port, &addr) != 0) {
+        DSD_FPRINTF(stderr, "expected %s:%d to resolve\n", host, port);
+        return 1;
+    }
+    if (addr.sin_family != AF_INET) {
+        DSD_FPRINTF(stderr, "expected AF_INET for %s, got %d\n", host, (int)addr.sin_family);
+        return 1;
+    }
+    if (ntohs(addr.sin_port) != port) {
+        DSD_FPRINTF(stderr, "expected port %d for %s, got %d\n", port, host, (int)ntohs(addr.sin_port));
+        return 1;
+    }
+
+    unsigned long expected_addr = inet_addr(host);
+    if (expected_addr == INADDR_NONE) {
+        DSD_FPRINTF(stderr, "test host %s is not a valid IPv4 literal\n", host);
+        return 1;
+    }
+    if (addr.sin_addr.s_addr != expected_addr) {
+        DSD_FPRINTF(stderr, "resolved address mismatch for %s\n", host);
+        return 1;
+    }
+
+    return 0;
+}
+
+int
+main(void) {
+    int rc = 0;
+    if (dsd_socket_init() != 0) {
+        DSD_FPRINTF(stderr, "socket init failed\n");
+        return 1;
+    }
+
+    rc |= expect_numeric_ipv4_resolves("127.0.0.1", 7355);
+    rc |= expect_numeric_ipv4_resolves("192.168.1.50", 7355);
+
+    dsd_socket_cleanup();
+    return rc ? 1 : 0;
+}

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -2621,6 +2621,11 @@ test_input_source_rtltcp_roundtrip(void) {
 }
 
 static int
+test_input_source_tcp_ipv4_roundtrip(void) {
+    return test_input_source_arg_roundtrip("tcp:192.168.1.50:7355");
+}
+
+static int
 test_iq_capture_long_options_parse(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
@@ -4964,6 +4969,7 @@ main(void) {
     rc |= test_input_source_soapy_args_roundtrip();
     rc |= test_input_source_rtl_roundtrip();
     rc |= test_input_source_rtltcp_roundtrip();
+    rc |= test_input_source_tcp_ipv4_roundtrip();
     rc |= test_trunk_scan_long_options_parse();
     rc |= test_trunk_scan_conflicts_with_legacy_scanner();
     rc |= test_trunk_scan_rejects_global_channel_map();


### PR DESCRIPTION
## Summary

- Clarify that `tcp:<host>:<port>` connects to the TCP audio producer, and that LAN use requires the producer to listen on a reachable interface.
- Document that `-U` with TCP input uses the same host for rigctl, so both audio and rigctl ports must be reachable.
- Add regression coverage for TCP IPv4 input parsing and numeric IPv4 socket resolution.

## Root Cause

The TCP input path already accepts numeric IPv4 addresses. The reported `localhost` versus LAN IP failure is most likely caused by the producer listening only on loopback, using the wrong LAN address, or firewall rules blocking the relevant ports. The previous help text did not make those setup requirements clear.

## Manual Emulation

A TCP PCM16 test server was used to exercise the same DSD-neo TCP client path:

- Loopback-bound producer and loopback client: connected successfully.
- All-interface producer and LAN-IP client: connected successfully.
- LAN-interface-bound producer and LAN-IP client: connected successfully.
- Loopback-bound producer and LAN-IP client: did not connect, matching the expected loopback-only listener failure mode.

## Validation

- `tools/format.sh`
- `tools/cmake_format_check.sh --fix`
- `tools/cmake_format_check.sh`
- `cmake --preset dev-debug`
- `cmake --build --preset dev-debug --target dsd-neo_test_runtime_cli_parse dsd-neo_test_platform_socket_resolve -j`
- `ctest --preset dev-debug -R 'RUNTIME_CLI_PARSE|PLATFORM_SOCKET_RESOLVE' --output-on-failure`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh`
- pre-push hook guardrails