### PR TITLE
ui: fall back for unsupported block glyphs

### DIFF
--- a/include/dsd-neo/runtime/unicode.h
+++ b/include/dsd-neo/runtime/unicode.h
@@ -31,6 +31,15 @@ void dsd_unicode_init_locale(void);
 /** @brief Convenience helper to pick Unicode or ASCII string based on support. */
 const char* dsd_unicode_or_ascii(const char* unicode_str, const char* ascii_str);
 
+/**
+ * @brief Return 1 when dense UI glyphs such as block meters are safe to use.
+ *
+ * This is intentionally stricter than dsd_unicode_supported(): a terminal may
+ * accept UTF-8 or wide-character output while its active console font still
+ * cannot render block glyphs.
+ */
+int dsd_unicode_block_glyphs_supported(void);
+
 /** @brief Degree glyph string with ASCII fallback ("\xC2\xB0" vs " deg"). */
 const char* dsd_degrees_glyph(void);
 

--- a/include/dsd-neo/ui/ncurses_internal.h
+++ b/include/dsd-neo/ui/ncurses_internal.h
@@ -31,6 +31,7 @@ int cmp_int_asc(const void* a, const void* b);
 int compute_percentiles_u8(const uint8_t* src, int len, double* p50, double* p95);
 int ui_is_locked_from_label(const dsd_state* state, const char* label);
 int ui_unicode_supported(void);
+int ui_block_glyphs_supported(void);
 
 static inline int
 ui_burst_is_active_p25_call(int burst) {

--- a/include/dsd-neo/ui/ncurses_snr.h
+++ b/include/dsd-neo/ui/ncurses_snr.h
@@ -35,7 +35,7 @@ void print_snr_meter(const dsd_opts* opts, double snr_db, int mod);
 #ifdef DSD_NEO_TEST_HOOKS
 int dsd_ncurses_snr_meter_bar_count_for_test(double snr_db);
 void dsd_ncurses_snr_meter_ascii_for_test(double snr_db, char* out, size_t out_size);
-int dsd_ncurses_snr_use_unicode_for_test(int option_enabled, int unicode_supported);
+int dsd_ncurses_snr_use_unicode_for_test(int option_enabled, int block_glyphs_supported);
 #endif
 
 #ifdef __cplusplus

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -76,6 +76,9 @@ target_link_libraries(
         dsd-neo_feature_curl
 )
 target_link_libraries(dsd-neo_runtime PRIVATE dsd-neo_io_iq)
+if(WIN32)
+    target_link_libraries(dsd-neo_runtime PRIVATE gdi32)
+endif()
 
 target_link_libraries(dsd-neo_runtime PRIVATE dsd-neo_warnings)
 

--- a/src/runtime/unicode.cpp
+++ b/src/runtime/unicode.cpp
@@ -29,6 +29,10 @@
 static int g_unicode_cached = 0;
 static int g_unicode_supported = 0;
 static int g_locale_inited = 0;
+#if DSD_PLATFORM_WIN_NATIVE
+static int g_block_glyphs_cached = 0;
+static int g_block_glyphs_supported = 0;
+#endif
 
 static char g_cached_locale[128] = {0};
 #if DSD_PLATFORM_WIN_NATIVE
@@ -68,6 +72,125 @@ str_icontains(const char* haystack, const char* needle) {
     }
     return 0;
 }
+
+#if DSD_PLATFORM_WIN_NATIVE
+static int
+env_nonempty(const char* name) {
+    const char* v = getenv(name);
+    return v && *v;
+}
+
+static int
+wide_ascii_equal_ci(const wchar_t* a, const wchar_t* b) {
+    if (!a || !b) {
+        return 0;
+    }
+    while (*a && *b) {
+        wchar_t ca = *a++;
+        wchar_t cb = *b++;
+        if (ca >= L'A' && ca <= L'Z') {
+            ca = (wchar_t)(ca - L'A' + L'a');
+        }
+        if (cb >= L'A' && cb <= L'Z') {
+            cb = (wchar_t)(cb - L'A' + L'a');
+        }
+        if (ca != cb) {
+            return 0;
+        }
+    }
+    return *a == L'\0' && *b == L'\0';
+}
+
+static int
+windows_console_font_face(wchar_t face[LF_FACESIZE]) {
+    if (!face) {
+        return 0;
+    }
+    face[0] = L'\0';
+
+    HANDLE out = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (out == NULL || out == INVALID_HANDLE_VALUE) {
+        return 0;
+    }
+
+    CONSOLE_FONT_INFOEX info;
+    DSD_MEMSET(&info, 0, sizeof(info));
+    info.cbSize = sizeof(info);
+    if (!GetCurrentConsoleFontEx(out, FALSE, &info)) {
+        return 0;
+    }
+
+    size_t i = 0;
+    for (; i + 1 < LF_FACESIZE && info.FaceName[i] != L'\0'; i++) {
+        face[i] = info.FaceName[i];
+    }
+    face[i] = L'\0';
+    return face[0] != L'\0';
+}
+
+static int
+windows_font_has_block_glyphs(const wchar_t* face) {
+    if (!face || face[0] == L'\0') {
+        return 0;
+    }
+
+    if (wide_ascii_equal_ci(face, L"Terminal") || wide_ascii_equal_ci(face, L"Raster Fonts")) {
+        return 0;
+    }
+
+    static const wchar_t required[] = {
+        (wchar_t)0x2581, (wchar_t)0x2582, (wchar_t)0x2583, (wchar_t)0x2584,
+        (wchar_t)0x2585, (wchar_t)0x2586, (wchar_t)0x2587, (wchar_t)0x2588,
+    };
+    WORD glyphs[sizeof(required) / sizeof(required[0])];
+    DSD_MEMSET(glyphs, 0, sizeof(glyphs));
+
+    HDC dc = CreateCompatibleDC(NULL);
+    if (!dc) {
+        return 0;
+    }
+
+    HFONT font = CreateFontW(0, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS,
+                             CLIP_DEFAULT_PRECIS, DEFAULT_QUALITY, FIXED_PITCH | FF_DONTCARE, face);
+    if (!font) {
+        DeleteDC(dc);
+        return 0;
+    }
+
+    HGDIOBJ old_font = SelectObject(dc, font);
+    DWORD rc = GetGlyphIndicesW(dc, required, (int)(sizeof(required) / sizeof(required[0])), glyphs,
+                                GGI_MARK_NONEXISTING_GLYPHS);
+    int supported = (rc != GDI_ERROR);
+    if (supported) {
+        for (size_t i = 0; i < sizeof(glyphs) / sizeof(glyphs[0]); i++) {
+            if (glyphs[i] == 0xFFFFu) {
+                supported = 0;
+                break;
+            }
+        }
+    }
+
+    if (old_font) {
+        SelectObject(dc, old_font);
+    }
+    DeleteObject(font);
+    DeleteDC(dc);
+    return supported;
+}
+
+static int
+windows_console_block_glyphs_supported(void) {
+    if (env_nonempty("WT_SESSION")) {
+        return 1;
+    }
+
+    wchar_t face[LF_FACESIZE];
+    if (!windows_console_font_face(face)) {
+        return 0;
+    }
+    return windows_font_has_block_glyphs(face);
+}
+#endif
 
 static int
 locale_is_utf8(void) {
@@ -172,6 +295,30 @@ dsd_unicode_supported(void) {
 const char*
 dsd_unicode_or_ascii(const char* unicode_str, const char* ascii_str) {
     return dsd_unicode_supported() ? unicode_str : ascii_str;
+}
+
+int
+dsd_unicode_block_glyphs_supported(void) {
+    if (env_truthy("DSD_FORCE_ASCII")) {
+        return 0;
+    }
+    if (env_truthy("DSD_FORCE_UTF8")) {
+        return 1;
+    }
+    if (!dsd_unicode_supported()) {
+        return 0;
+    }
+
+#if DSD_PLATFORM_WIN_NATIVE
+    if (g_block_glyphs_cached) {
+        return g_block_glyphs_supported;
+    }
+    g_block_glyphs_supported = windows_console_block_glyphs_supported() ? 1 : 0;
+    g_block_glyphs_cached = 1;
+    return g_block_glyphs_supported;
+#else
+    return 1;
+#endif
 }
 
 const char*

--- a/src/ui/terminal/ncurses_snr.c
+++ b/src/ui/terminal/ncurses_snr.c
@@ -40,9 +40,10 @@ enum { SNR_METER_BARS = 5, SNR_METER_WIDTH = (SNR_METER_BARS * 2) - 1 };
 enum { SNR_BLOCK_LEVELS = 8 };
 
 #if defined(DSD_USE_PDCURSES) && !defined(DSD_HAS_PDCURSES_WIDE_API)
-#define SNR_USE_UNICODE(option_enabled, unicode_supported) ((void)(option_enabled), (void)(unicode_supported), 0)
+#define SNR_USE_UNICODE(option_enabled, block_glyphs_supported)                                                        \
+    ((void)(option_enabled), (void)(block_glyphs_supported), 0)
 #else
-#define SNR_USE_UNICODE(option_enabled, unicode_supported) ((option_enabled) && (unicode_supported))
+#define SNR_USE_UNICODE(option_enabled, block_glyphs_supported) ((option_enabled) && (block_glyphs_supported))
 #endif
 
 #if defined(DSD_USE_PDCURSES) && defined(DSD_HAS_PDCURSES_WIDE_API)
@@ -129,8 +130,8 @@ dsd_ncurses_snr_meter_ascii_for_test(double snr_db, char* out, size_t out_size) 
 }
 
 int
-dsd_ncurses_snr_use_unicode_for_test(int option_enabled, int unicode_supported) {
-    return SNR_USE_UNICODE(option_enabled, unicode_supported);
+dsd_ncurses_snr_use_unicode_for_test(int option_enabled, int block_glyphs_supported) {
+    return SNR_USE_UNICODE(option_enabled, block_glyphs_supported);
 }
 #endif
 
@@ -249,8 +250,8 @@ print_snr_sparkline(const dsd_opts* opts, int mod) {
 #endif
     /* Make the lowest ASCII level visible (no leading space) */
     static const char ascii8[] = ".:;-=+*#"; /* 8 levels */
-    /* Respect the UI toggle: only use Unicode blocks when enabled and locale supports it */
-    int use_unicode = SNR_USE_UNICODE(opts && opts->eye_unicode, ui_unicode_supported());
+    /* Respect the UI toggle and require renderable block glyphs, not just UTF-8 bytes. */
+    int use_unicode = SNR_USE_UNICODE(opts && opts->eye_unicode, ui_block_glyphs_supported());
     const int levels = SNR_BLOCK_LEVELS;
     const int W = 24;                             /* sparkline width */
     const double clip_lo = -15.0, clip_hi = 30.0; /* dB window (allow negatives) */
@@ -287,7 +288,7 @@ print_snr_meter(const dsd_opts* opts, double snr_db, int mod) {
     attr_get(&saved_attrs, &saved_pair, NULL);
 #endif
     const int bars = snr_meter_bar_count(snr_db);
-    int use_unicode = SNR_USE_UNICODE(opts && opts->eye_unicode, ui_unicode_supported());
+    int use_unicode = SNR_USE_UNICODE(opts && opts->eye_unicode, ui_block_glyphs_supported());
 #ifdef PRETTY_COLORS
     short cp = SNR_METER_COLOR_PAIR;
 #endif

--- a/src/ui/terminal/ncurses_utils.c
+++ b/src/ui/terminal/ncurses_utils.c
@@ -26,6 +26,11 @@ ui_unicode_supported(void) {
     return dsd_unicode_supported();
 }
 
+int
+ui_block_glyphs_supported(void) {
+    return dsd_unicode_block_glyphs_supported();
+}
+
 /* Quickselect helpers for int arrays (k-th smallest in O(n)) */
 
 void

--- a/src/ui/terminal/ncurses_visualizers.c
+++ b/src/ui/terminal/ncurses_visualizers.c
@@ -158,7 +158,7 @@ constellation_grid_size(int* W, int* H) {
 static constellation_style
 constellation_make_style(const dsd_opts* opts) {
     constellation_style style;
-    style.use_unicode = (opts && opts->eye_unicode && ui_unicode_supported());
+    style.use_unicode = (opts && opts->eye_unicode && ui_block_glyphs_supported());
     style.use_dots = 1;
     style.color_enabled = (opts && opts->eye_color && has_colors());
     style.ascii_len = (int)(sizeof(k_density_ascii_palette) - 1);
@@ -541,7 +541,7 @@ eye_effective_unicode_ui(const dsd_opts* opts) {
     static int s_unicode_ready = -1;
     static int s_unicode_warned = 0;
     if (s_unicode_ready < 0) {
-        s_unicode_ready = ui_unicode_supported() ? 1 : 0;
+        s_unicode_ready = ui_block_glyphs_supported() ? 1 : 0;
     }
     int use_unicode_ui = (opts && opts->eye_unicode && s_unicode_ready);
     if (opts && opts->eye_unicode && !s_unicode_ready && !s_unicode_warned) {
@@ -1529,7 +1529,7 @@ print_spectrum_view_rtlsdr(const dsd_opts* opts) {
     float span = 1.0f;
     spectrum_range(col, w, &vmin, &vmax, &span);
 
-    int use_unicode = (opts && opts->eye_unicode && ui_unicode_supported());
+    int use_unicode = (opts && opts->eye_unicode && ui_block_glyphs_supported());
     spectrum_draw_plot(opts, col, w, h, vmin, vmax, span, use_unicode);
     spectrum_print_legend(opts, rate, w, use_unicode, vmax, vmin);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -850,6 +850,23 @@ target_link_libraries(dsd-neo_test_runtime_rings PRIVATE dsd-neo_runtime)
 add_test(NAME RUNTIME_RINGS COMMAND dsd-neo_test_runtime_rings)
 
 add_executable(
+    dsd-neo_test_runtime_unicode_block_glyphs
+    runtime/test_runtime_unicode_block_glyphs.c
+)
+target_include_directories(
+    dsd-neo_test_runtime_unicode_block_glyphs
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_runtime_unicode_block_glyphs
+    PRIVATE dsd-neo_runtime
+)
+add_test(
+    NAME RUNTIME_UNICODE_BLOCK_GLYPHS
+    COMMAND dsd-neo_test_runtime_unicode_block_glyphs
+)
+
+add_executable(
     dsd-neo_test_runtime_input_ring_init
     runtime/test_runtime_input_ring_init.cpp
 )

--- a/tests/runtime/test_runtime_unicode_block_glyphs.c
+++ b/tests/runtime/test_runtime_unicode_block_glyphs.c
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/runtime/unicode.h>
+#include <stdio.h>
+
+static void
+set_env_flag(const char* name, const char* value) {
+    int rc = value ? dsd_setenv(name, value, 1) : dsd_unsetenv(name);
+    assert(rc == 0);
+}
+
+int
+main(void) {
+    set_env_flag("DSD_FORCE_ASCII", NULL);
+    set_env_flag("DSD_FORCE_UTF8", NULL);
+
+    set_env_flag("DSD_FORCE_ASCII", "1");
+    set_env_flag("DSD_FORCE_UTF8", "1");
+    assert(dsd_unicode_block_glyphs_supported() == 0);
+
+    set_env_flag("DSD_FORCE_ASCII", NULL);
+    set_env_flag("DSD_FORCE_UTF8", "1");
+    assert(dsd_unicode_block_glyphs_supported() == 1);
+
+    set_env_flag("DSD_FORCE_ASCII", NULL);
+    set_env_flag("DSD_FORCE_UTF8", NULL);
+
+    printf("RUNTIME_UNICODE_BLOCK_GLYPHS: OK\n");
+    return 0;
+}

--- a/tests/ui/test_ui_snr_meter.c
+++ b/tests/ui/test_ui_snr_meter.c
@@ -10,7 +10,8 @@
 #include <string.h>
 #include "dsd-neo/core/safe_api.h"
 
-int ui_unicode_supported(void); // NOLINT(misc-use-internal-linkage)
+int ui_unicode_supported(void);      // NOLINT(misc-use-internal-linkage)
+int ui_block_glyphs_supported(void); // NOLINT(misc-use-internal-linkage)
 
 #if defined(DSD_NEO_FAST_MATH) || defined(__FAST_MATH__) || defined(_M_FP_FAST)
 #define DSD_NEO_TEST_FAST_MATH 1
@@ -22,6 +23,11 @@ int ui_unicode_supported(void); // NOLINT(misc-use-internal-linkage)
 
 int
 ui_unicode_supported(void) { // NOLINT(misc-use-internal-linkage)
+    return 0;
+}
+
+int
+ui_block_glyphs_supported(void) { // NOLINT(misc-use-internal-linkage)
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- Add a stricter block-glyph capability check separate from general Unicode support.
- Fall back to ASCII SNR and visualizer glyphs when Windows console fonts cannot render block elements.
- Add regression coverage for block glyph override behavior and SNR Unicode gating.

## Root Cause
The Windows build can have PDCurses wide/UTF-8 support while the active legacy console font still lacks U+2581..U+2588 block glyphs. The UI treated UTF-8/wide output support as enough and rendered Unicode block meters, which showed as bad symbols in cmd.exe.

## Validation
- `tools/format.sh`
- `tools/cmake_format_check.sh`
- `cmake --preset dev-debug && cmake --build --preset dev-debug --target dsd-neo_test_ui_snr_meter dsd-neo_test_runtime_unicode_block_glyphs dsd-neo_ui_terminal -j`
- `ctest --preset dev-debug --output-on-failure -R 'UI_SNR_METER|RUNTIME_UNICODE_BLOCK_GLYPHS'`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `tools/iwyu.sh --strict src/runtime/unicode.cpp src/ui/terminal/ncurses_snr.c src/ui/terminal/ncurses_utils.c src/ui/terminal/ncurses_visualizers.c tests/runtime/test_runtime_unicode_block_glyphs.c tests/ui/test_ui_snr_meter.c`
- `tools/preflight_ci.sh`
- `git diff --check`