### PR TITLE
feat: add input level monitoring and user feedback

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -335,7 +335,6 @@ if [[ ${#cppcheck_sources[@]} -gt 0 ]]; then
   mapfile -t cppcheck_sources < <(printf '%s\n' "${cppcheck_sources[@]}" | sort -u)
 fi
 
-overall_rc=0
 missing_tools=()
 
 mark_missing_tool() {
@@ -344,7 +343,8 @@ mark_missing_tool() {
   echo "pre-push: skipping ${reason} (${tool} not found in PATH)." >&2
   missing_tools+=("$tool")
   if [[ "$FAIL_ON_MISSING_TOOLS" == "1" ]]; then
-    overall_rc=1
+    echo "pre-push: failing because DSD_HOOK_FAIL_ON_MISSING_TOOLS=1." >&2
+    exit 1
   fi
 }
 
@@ -357,8 +357,8 @@ run_check() {
   local rc=$?
   set -e
   if [[ $rc -ne 0 ]]; then
-    overall_rc=1
     echo "pre-push: ${label} failed." >&2
+    exit "$rc"
   fi
 }
 
@@ -496,13 +496,6 @@ fi
 if [[ ${#missing_tools[@]} -gt 0 ]]; then
   mapfile -t missing_tools < <(printf '%s\n' "${missing_tools[@]}" | sort -u)
   echo "pre-push: missing tools: ${missing_tools[*]}" >&2
-  if [[ "$FAIL_ON_MISSING_TOOLS" == "1" ]]; then
-    echo "pre-push: failing because DSD_HOOK_FAIL_ON_MISSING_TOOLS=1." >&2
-  fi
-fi
-
-if [[ $overall_rc -ne 0 ]]; then
-  exit 1
 fi
 
 exit 0

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -85,7 +85,8 @@ TCP/UDP PCM input format notes
 Other input options
 
 - `--input-volume <1..16>` scale non‑RTL input samples (file/UDP/TCP) by an integer factor.
-- `--input-level-warn-db <dB>` warn if input power falls below dBFS (default −40).
+- `--input-level-warn-db <dB>` low input-level advisory threshold in dBFS (default −40). This only affects LOW
+  advisories; DSD-neo never changes gain automatically.
 
 Tip: If paths or names contain spaces, wrap them in single quotes.
 
@@ -103,6 +104,9 @@ Tip: If paths or names contain spaces, wrap them in single quotes.
 - `-Z` Log MBE/PDU payloads to the console (verbose)
 - `--frame-log <file>` Append one-line timestamped frame traces (separate from event log)
 - `-O` List PulseAudio input sources and output sinks
+- The ncurses input section shows advisory `Input Level`/`RF Level` health when metrics are available. `LOW` uses
+  `--input-level-warn-db`; `HOT` means peak at or above `-1.0 dBFS`; `CLIP` means at least `0.1%` clipped or near-rail
+  samples. These advisories never adjust gain automatically.
 - UI hotkeys and menu navigation: `docs/ui-terminal.md`
 - `-j` P25: force-enable LCW explicit retune (format 0x44; enabled by default)
 - `-^` P25: prefer CC candidates during control channel hunt
@@ -529,7 +533,7 @@ Misc
 - `DSD_NEO_CPU_USB|DSD_NEO_CPU_DONGLE|DSD_NEO_CPU_DEMOD=<cpu>` — per-thread CPU affinity (only used when `DSD_NEO_RT_SCHED=1`)
 - `DSD_NEO_FTZ_DAZ=1` — enable SSE flush‑to‑zero / denormals‑are‑zero
 - `DSD_NEO_INPUT_VOLUME=<1..16>` — scale non‑RTL input samples (env alternative to `--input-volume`)
-- `DSD_NEO_INPUT_WARN_DB=<dB>` — warn if input power falls below dBFS (default −40)
+- `DSD_NEO_INPUT_WARN_DB=<dB>` — low input-level advisory threshold in dBFS (default −40)
 - `DSD_NEO_RIGCTL_RCVTIMEO=<ms>` — rigctl socket receive timeout
 - `DSD_NEO_TCPIN_BACKOFF_MS=<ms>` — TCP input read backoff
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,6 +107,8 @@ Tip: If paths or names contain spaces, wrap them in single quotes.
 - The ncurses input section shows advisory `Input Level`/`RF Level` health when metrics are available. `LOW` uses
   `--input-level-warn-db`; `HOT` means peak at or above `-1.0 dBFS`; `CLIP` means at least `0.1%` clipped or near-rail
   samples. These advisories never adjust gain automatically.
+- For RTL-family inputs, the optional DSP panel shows post-channel-filter `Squelch` power against the SQL threshold.
+  This is separate from the raw receiver `RF Level` health line.
 - UI hotkeys and menu navigation: `docs/ui-terminal.md`
 - `-j` P25: force-enable LCW explicit retune (format 0x44; enabled by default)
 - `-^` P25: prefer CC candidates during control channel hunt

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -41,6 +41,9 @@ Config profiles:
 The DSP status panel shows RTL DSP loop state when RTL input support is available. CQPSK mode reports FLL,
 carrier/Costas, NCO, and timing-recovery state for the active OP25-style chain.
 
+For RTL-family inputs, the optional DSP panel also shows `Squelch`, which compares post-channel-filter power against the
+configured SQL threshold. This is an advanced squelch diagnostic and is separate from the raw `RF Level` health line.
+
 ## Input Level Health
 
 The input section shows a persistent advisory line when recent input-level metrics are available:
@@ -53,6 +56,10 @@ The input section shows a persistent advisory line when recent input-level metri
 `Input Level` is used for PCM-like audio inputs. `RF Level` is used for RTL-SDR, rtl_tcp, and SoapySDR receiver
 samples measured before demodulation. The line is advisory only; DSD-neo never changes input volume, RF gain, AGC, or
 filtering automatically.
+
+The default RTL input line shows the SQL threshold but does not duplicate channel power. Enable the DSP panel when you
+need to inspect post-channel-filter squelch power. `RF Level` and `Squelch` are measured at different stages and are not
+expected to match exactly.
 
 The low-level threshold is controlled by `--input-level-warn-db` or `DSD_NEO_INPUT_WARN_DB` and defaults to `-40 dBFS`.
 Hot/clipping advisories use fixed v1 thresholds: peak at or above `-1.0 dBFS` is `HOT`, and at least `0.1%` clipped or

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -41,6 +41,25 @@ Config profiles:
 The DSP status panel shows RTL DSP loop state when RTL input support is available. CQPSK mode reports FLL,
 carrier/Costas, NCO, and timing-recovery state for the active OP25-style chain.
 
+## Input Level Health
+
+The input section shows a persistent advisory line when recent input-level metrics are available:
+
+```text
+| Input Level: OK rms -23.1 dBFS peak -5.4 dBFS clip 0.0%
+| RF Level: CLIP rms -6.0 dBFS peak 0.0 dBFS clip 0.3% lower RF gain or add filtering/attenuation
+```
+
+`Input Level` is used for PCM-like audio inputs. `RF Level` is used for RTL-SDR, rtl_tcp, and SoapySDR receiver
+samples measured before demodulation. The line is advisory only; DSD-neo never changes input volume, RF gain, AGC, or
+filtering automatically.
+
+The low-level threshold is controlled by `--input-level-warn-db` or `DSD_NEO_INPUT_WARN_DB` and defaults to `-40 dBFS`.
+Hot/clipping advisories use fixed v1 thresholds: peak at or above `-1.0 dBFS` is `HOT`, and at least `0.1%` clipped or
+near-rail samples is `CLIP`. Footer messages are rate-limited. RF low-level status remains persistent but does not
+produce repeated low-level footer messages because a quiet channel and too little RF gain are not reliably
+distinguishable from raw receiver samples alone.
+
 ## Hotkeys (Main Screen)
 
 Keys are case-sensitive. Some commands only make sense in specific modes (for example, trunking controls require

--- a/include/dsd-neo/core/input_level.h
+++ b/include/dsd-neo/core/input_level.h
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Advisory input-level health metrics and classification helpers.
+ */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_CORE_INPUT_LEVEL_H_
+#define DSD_NEO_INCLUDE_DSD_NEO_CORE_INPUT_LEVEL_H_
+
+#include <dsd-neo/platform/platform.h>
+
+#include <stdint.h>
+#include <time.h>
+
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_fwd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum DSD_ATTR_PACKED dsd_input_level_status {
+    DSD_INPUT_LEVEL_UNKNOWN = 0,
+    DSD_INPUT_LEVEL_OK = 1,
+    DSD_INPUT_LEVEL_LOW = 2,
+    DSD_INPUT_LEVEL_HOT = 3,
+    DSD_INPUT_LEVEL_CLIPPING = 4,
+} dsd_input_level_status;
+
+typedef enum DSD_ATTR_PACKED dsd_input_level_source {
+    DSD_INPUT_LEVEL_SOURCE_UNKNOWN = 0,
+    DSD_INPUT_LEVEL_SOURCE_PCM = 1,
+    DSD_INPUT_LEVEL_SOURCE_RTL_CU8 = 2,
+    DSD_INPUT_LEVEL_SOURCE_RTL_TCP_CU8 = 3,
+    DSD_INPUT_LEVEL_SOURCE_SOAPY_CS16 = 4,
+    DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32 = 5,
+    DSD_INPUT_LEVEL_SOURCE_FSK_SYMBOL = 6,
+} dsd_input_level_source;
+
+typedef struct dsd_input_level_snapshot {
+    dsd_input_level_status status;
+    dsd_input_level_source source;
+    double rms_dbfs;
+    double peak_dbfs;
+    double clip_pct;
+    uint64_t sample_count;
+    time_t updated;
+} dsd_input_level_snapshot;
+
+typedef enum DSD_ATTR_PACKED dsd_input_level_notify_mask {
+    DSD_INPUT_LEVEL_NOTIFY_LOW = 1U << 0U,
+    DSD_INPUT_LEVEL_NOTIFY_HOT = 1U << 1U,
+    DSD_INPUT_LEVEL_NOTIFY_CLIPPING = 1U << 2U,
+    DSD_INPUT_LEVEL_NOTIFY_ALL =
+        DSD_INPUT_LEVEL_NOTIFY_LOW | DSD_INPUT_LEVEL_NOTIFY_HOT | DSD_INPUT_LEVEL_NOTIFY_CLIPPING,
+    DSD_INPUT_LEVEL_NOTIFY_RF = DSD_INPUT_LEVEL_NOTIFY_HOT | DSD_INPUT_LEVEL_NOTIFY_CLIPPING,
+} dsd_input_level_notify_mask;
+
+const char* dsd_input_level_status_label(dsd_input_level_status status);
+const char* dsd_input_level_display_label(dsd_input_level_source source);
+int dsd_input_level_source_is_rf(dsd_input_level_source source);
+
+void dsd_input_level_classify(dsd_input_level_snapshot* snapshot, double low_warn_db);
+
+int dsd_input_level_metrics_from_pcm_i16(const int16_t* samples, size_t count, size_t step,
+                                         dsd_input_level_source source, dsd_input_level_snapshot* out);
+int dsd_input_level_metrics_from_pcm_f32_i16_scale(const float* samples, size_t count, size_t step,
+                                                   dsd_input_level_source source, dsd_input_level_snapshot* out);
+int dsd_input_level_metrics_from_cu8(const uint8_t* samples, size_t count, dsd_input_level_source source,
+                                     dsd_input_level_snapshot* out);
+int dsd_input_level_metrics_from_cs16(const int16_t* samples, size_t count, dsd_input_level_source source,
+                                      dsd_input_level_snapshot* out);
+int dsd_input_level_metrics_from_cf32(const float* samples, size_t count, dsd_input_level_source source,
+                                      dsd_input_level_snapshot* out);
+int dsd_input_level_metrics_from_fsk_clip(float clip_pct, uint64_t symbols, dsd_input_level_snapshot* out);
+
+int dsd_input_level_format_advisory(const dsd_input_level_snapshot* snapshot, char* out, size_t out_size);
+void dsd_input_level_publish(dsd_opts* opts, dsd_state* state, const dsd_input_level_snapshot* snapshot,
+                             unsigned int notify_mask);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_INCLUDE_DSD_NEO_CORE_INPUT_LEVEL_H_ */

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -16,6 +16,7 @@
 
 #include <dsd-neo/platform/platform.h>
 
+#include <dsd-neo/core/input_level.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/state_fwd.h>
 
@@ -1110,6 +1111,12 @@ struct dsd_state {
     int dmr_sample_history_size;  /**< Buffer size (DMR_SAMPLE_HISTORY_SIZE) */
     int dmr_sample_history_head;  /**< Write index into circular buffer */
     int dmr_sample_history_count; /**< Symbols written (for underflow check) */
+
+    // Advisory-only input level health for ncurses/status snapshots.
+    dsd_input_level_snapshot input_level;
+    time_t input_level_last_toast_time;
+    dsd_input_level_status input_level_last_toast_status;
+    dsd_input_level_source input_level_last_toast_source;
 
     // Transient UI message (shown briefly in ncurses printer)
     char ui_msg[128];

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -19,6 +19,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <dsd-neo/core/input_level.h>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/io/rtl_stream_fwd.h>
 
@@ -790,6 +791,19 @@ int rtl_stream_get_fsk_metrics(rtl_stream_fsk_metrics* out);
  * @return 0 on success; negative on invalid input.
  */
 int rtl_stream_get_decode_health(rtl_stream_decode_health* out);
+
+/**
+ * @brief Get recent raw receiver input-level health metrics.
+ *
+ * The snapshot observes backend-native samples before demodulation (CU8 for
+ * RTL/rtl_tcp, CS16 or CF32 for Soapy). When raw receiver metrics are not yet
+ * available, the RTL path may return an invalid/unknown snapshot or a
+ * soft-symbol clipping diagnostic.
+ *
+ * @param out [out] Input-level snapshot. Must not be NULL.
+ * @return 0 on success; negative on invalid input.
+ */
+int rtl_stream_get_input_level(dsd_input_level_snapshot* out);
 
 /**
  * @brief Set or disable the resampler target rate (applied on controller thread).

--- a/include/dsd-neo/runtime/rtl_stream_metrics_hooks.h
+++ b/include/dsd-neo/runtime/rtl_stream_metrics_hooks.h
@@ -19,6 +19,8 @@
 
 #include <stdint.h>
 
+#include <dsd-neo/core/input_level.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -40,6 +42,7 @@ typedef struct {
     void (*p25p1_ber_update)(int ok_delta, int err_delta);
     void (*p25p2_err_update)(int slot, int facch_ok, int facch_err, int sacch_ok, int sacch_err, int voice_err);
     int (*stream_active)(void);
+    int (*input_level)(dsd_input_level_snapshot* out);
 } dsd_rtl_stream_metrics_hooks;
 
 typedef enum DSD_ATTR_PACKED dsd_rtl_stream_channel_profile {
@@ -58,6 +61,7 @@ int dsd_rtl_stream_metrics_hook_output_kind(void);
 int dsd_rtl_stream_metrics_hook_symbol_profile(int* out_symbol_rate_hz, int* out_levels, int* out_channel_profile);
 uint32_t dsd_rtl_stream_metrics_hook_stream_generation(void);
 int dsd_rtl_stream_metrics_hook_stream_active(void);
+int dsd_rtl_stream_metrics_hook_input_level(dsd_input_level_snapshot* out);
 int dsd_rtl_stream_metrics_hook_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profile);
 int dsd_rtl_stream_metrics_hook_dsp_get(int* out_cqpsk_enable, int* out_fll_enable, int* out_ted_enable);
 int dsd_rtl_stream_metrics_hook_ted_bias(void);

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -22,8 +22,8 @@
 #include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/audio_filters.h>
 #include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/input_level.h>
 #include <dsd-neo/core/opts.h>
-#include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/dmr_sync.h>
@@ -982,20 +982,15 @@ symbol_convert_analog_block_to_i16(dsd_state* state, unsigned int analog_block) 
 }
 
 static inline void
-symbol_update_unsynced_input_power(dsd_opts* opts, const dsd_state* state, unsigned int analog_block) {
+symbol_update_unsynced_input_power(dsd_opts* opts, dsd_state* state, unsigned int analog_block) {
     if (opts->audio_in_type == AUDIO_IN_RTL) {
         return;
     }
-    opts->rtl_pwr = raw_pwr_f(state->analog_out_f, (int)analog_block, 1);
-    if (opts->input_warn_db < 0.0) {
-        double db = pwr_to_dB(opts->rtl_pwr);
-        time_t now = time(NULL);
-        if (db <= opts->input_warn_db
-            && (opts->last_input_warn_time == 0
-                || (int)(now - opts->last_input_warn_time) >= opts->input_warn_cooldown_sec)) {
-            LOG_WARNING("Input level low (%.1f dBFS). Consider raising sender gain or use --input-volume.\n", db);
-            opts->last_input_warn_time = now;
-        }
+    dsd_input_level_snapshot snapshot;
+    if (dsd_input_level_metrics_from_pcm_f32_i16_scale(state->analog_out_f, analog_block, 1U,
+                                                       DSD_INPUT_LEVEL_SOURCE_PCM, &snapshot)
+        == 0) {
+        dsd_input_level_publish(opts, state, &snapshot, DSD_INPUT_LEVEL_NOTIFY_ALL);
     }
 }
 
@@ -1211,6 +1206,20 @@ symbol_read_sample_wav(dsd_opts* opts, dsd_state* state, float* sample_out) {
 }
 
 #ifdef USE_RADIO
+static inline void
+symbol_maybe_publish_rtl_input_level(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state || opts->audio_in_type != AUDIO_IN_RTL) {
+        return;
+    }
+    if ((state->symbolcnt & 0x3FU) != 0) {
+        return;
+    }
+    dsd_input_level_snapshot snapshot;
+    if (dsd_rtl_stream_metrics_hook_input_level(&snapshot) == 0 && snapshot.sample_count > 0U) {
+        dsd_input_level_publish(opts, state, &snapshot, DSD_INPUT_LEVEL_NOTIFY_RF);
+    }
+}
+
 static inline int
 symbol_read_sample_rtl(dsd_opts* opts, dsd_state* state, float* sample_out, const symbol_work_ctx* work) {
     if (!state->rtl_ctx) {
@@ -1459,6 +1468,7 @@ symbol_try_rtl_symbol_rate_fast_path(dsd_opts* opts, dsd_state* state, symbol_wo
     state->lastsample = work->sample;
     dmr_sample_history_push(state, work->sample);
     state->symbolcnt++;
+    symbol_maybe_publish_rtl_input_level(opts, state);
     return 1;
 }
 
@@ -1669,7 +1679,7 @@ symbol_apply_replay_overrides(dsd_opts* opts, dsd_state* state, float* symbol) {
 }
 
 static inline float
-symbol_commit_symbol(const dsd_opts* opts, dsd_state* state, int have_sync, const symbol_work_ctx* work, float symbol) {
+symbol_commit_symbol(dsd_opts* opts, dsd_state* state, int have_sync, const symbol_work_ctx* work, float symbol) {
 #ifdef USE_RADIO
     if (work->clk_mode && state->rf_mod == 0) {
         maybe_c4fm_clock(opts, state, have_sync, work->clk_mode, work->clk_early, work->clk_mid, work->clk_late);
@@ -1681,6 +1691,9 @@ symbol_commit_symbol(const dsd_opts* opts, dsd_state* state, int have_sync, cons
 #endif
     dmr_sample_history_push(state, symbol);
     state->symbolcnt++;
+#ifdef USE_RADIO
+    symbol_maybe_publish_rtl_input_level(opts, state);
+#endif
     return symbol;
 }
 

--- a/src/engine/rtl_stream_metrics_hooks_install.c
+++ b/src/engine/rtl_stream_metrics_hooks_install.c
@@ -39,6 +39,7 @@ dsd_engine_rtl_stream_metrics_hooks_install(void) {
     hooks.p25p1_ber_update = rtl_stream_p25p1_ber_update;
     hooks.p25p2_err_update = rtl_stream_p25p2_err_update;
     hooks.stream_active = rtl_stream_is_active;
+    hooks.input_level = rtl_stream_get_input_level;
 #endif
     dsd_rtl_stream_metrics_hooks_set(&hooks);
 }

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -49,7 +49,7 @@ if(DSD_HAS_RADIO)
     )
     target_link_libraries(
         dsd-neo_io_radio
-        PRIVATE dsd-neo_io_iq dsd-neo_platform
+        PRIVATE dsd-neo_core dsd-neo_io_iq dsd-neo_platform
     )
     # SoapySDR exports C++-only warning flags; keep it private so they do not leak into C dependents.
     target_link_libraries(dsd-neo_io_radio PRIVATE dsd-neo_feature_soapy)

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -874,6 +874,7 @@ rtl_publish_cu8_input_level(const struct rtl_device* s, const uint8_t* samples, 
     }
 }
 
+#ifdef USE_SOAPYSDR
 static inline void
 rtl_publish_cs16_input_level(const int16_t* samples, size_t count) {
     dsd_input_level_snapshot snapshot;
@@ -895,6 +896,7 @@ rtl_publish_cf32_input_level(const float* samples, size_t count) {
         rtl_stream_input_level_publish(&snapshot);
     }
 }
+#endif
 
 static inline void
 rtl_copy_event_reason(char* dst, size_t dst_size, const char* reason) {

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -12,6 +12,8 @@
  * u8 I/Q samples into normalized float and feeds the `input_ring_state`.
  */
 
+#include "dsd-neo/core/input_level.h"
+
 #include <algorithm>
 #include <atomic>
 #include <cinttypes>
@@ -51,6 +53,7 @@
 #include "rtl_capture_phase.h"
 #include "rtl_perf.h"
 #include "rtl_replay_device.h"
+#include "rtl_stream_shared.hpp"
 #include "soapy_profile.h"
 
 #if defined(_MSC_VER) && DSD_PLATFORM_WIN_NATIVE
@@ -647,6 +650,7 @@ rtl_reset_capture_state_on_stream_boundary(struct rtl_device* s) {
     }
     rtl_capture_u8_byte_carry_clear(&s->iq_byte_carry);
     s->mute_byte_phase.store((int)carry, std::memory_order_relaxed);
+    rtl_stream_input_level_reset();
 }
 
 static inline void
@@ -852,6 +856,44 @@ rtl_submit_capture_bytes(struct rtl_device* s, const void* data, size_t bytes) {
         return;
     }
     (void)dsd_iq_capture_submit(s->iq_capture_writer, data, bytes);
+}
+
+static inline dsd_input_level_source
+rtl_u8_input_level_source(const struct rtl_device* s) {
+    return (s && s->backend == RTL_BACKEND_TCP) ? DSD_INPUT_LEVEL_SOURCE_RTL_TCP_CU8 : DSD_INPUT_LEVEL_SOURCE_RTL_CU8;
+}
+
+static inline void
+rtl_publish_cu8_input_level(const struct rtl_device* s, const uint8_t* samples, size_t count) {
+    dsd_input_level_snapshot snapshot;
+    if (!s || !samples || count == 0U) {
+        return;
+    }
+    if (dsd_input_level_metrics_from_cu8(samples, count, rtl_u8_input_level_source(s), &snapshot) == 0) {
+        rtl_stream_input_level_publish(&snapshot);
+    }
+}
+
+static inline void
+rtl_publish_cs16_input_level(const int16_t* samples, size_t count) {
+    dsd_input_level_snapshot snapshot;
+    if (!samples || count == 0U) {
+        return;
+    }
+    if (dsd_input_level_metrics_from_cs16(samples, count, DSD_INPUT_LEVEL_SOURCE_SOAPY_CS16, &snapshot) == 0) {
+        rtl_stream_input_level_publish(&snapshot);
+    }
+}
+
+static inline void
+rtl_publish_cf32_input_level(const float* samples, size_t count) {
+    dsd_input_level_snapshot snapshot;
+    if (!samples || count == 0U) {
+        return;
+    }
+    if (dsd_input_level_metrics_from_cf32(samples, count, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32, &snapshot) == 0) {
+        rtl_stream_input_level_publish(&snapshot);
+    }
 }
 
 static inline void
@@ -2096,6 +2138,7 @@ rtlsdr_callback(unsigned char* buf, uint32_t len, void* ctx) {
         return;
     }
     rtl_submit_capture_bytes(s, buf, len);
+    rtl_publish_cu8_input_level(s, buf, len);
     /* Convert incoming u8 I/Q and write directly into input ring without extra copy. */
     rtl_write_u8_to_ring(s, buf, len, fs4_shift_active, use_two_pass, combine_rotate_active, 0);
 }
@@ -2866,11 +2909,13 @@ soapy_submit_samples(struct rtl_device* dev, size_t drop_elems, size_t kept_elem
     if (dev->soapy_format == SOAPY_FMT_CF32) {
         const std::complex<float>* src = cf32_buf.data() + drop_elems;
         rtl_submit_capture_bytes(dev, src, kept_elems * sizeof(std::complex<float>));
+        rtl_publish_cf32_input_level(reinterpret_cast<const float*>(src), kept_elems * 2U);
         (void)soapy_write_cf32_to_ring(dev, src, kept_elems, apply_rot);
         return;
     }
     const int16_t* src = cs16_buf.data() + (drop_elems * 2U);
     rtl_submit_capture_bytes(dev, src, kept_elems * 2U * sizeof(int16_t));
+    rtl_publish_cs16_input_level(src, kept_elems * 2U);
     (void)soapy_write_cs16_to_ring(dev, src, kept_elems, apply_rot);
 }
 #endif
@@ -3691,6 +3736,7 @@ static DSD_THREAD_RETURN_TYPE
 
         rtl_tcp_account_input_stats(s, len);
         rtl_submit_capture_bytes(s, st.u8, len);
+        rtl_publish_cu8_input_level(s, st.u8, len);
         rtl_tcp_reassemble_and_submit(s, st.u8, len, &policy);
         rtl_tcp_metrics_update_ring_snapshot(s);
         rtl_tcp_periodic_maintenance(s, &st);

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -12,6 +12,8 @@
  * and exposes a consumer API for audio samples and tuning.
  */
 
+#include "dsd-neo/core/input_level.h"
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -57,6 +59,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -1634,6 +1637,15 @@ static std::atomic<double> g_fsk_metrics_abs_est{0.0};
 static std::atomic<double> g_fsk_metrics_dc_est{0.0};
 static std::atomic<double> g_fsk_metrics_last_symbol{0.0};
 
+static std::atomic<int> g_input_level_valid{0};
+static std::atomic<int> g_input_level_status{DSD_INPUT_LEVEL_UNKNOWN};
+static std::atomic<int> g_input_level_source{DSD_INPUT_LEVEL_SOURCE_UNKNOWN};
+static std::atomic<double> g_input_level_rms_dbfs{-120.0};
+static std::atomic<double> g_input_level_peak_dbfs{-120.0};
+static std::atomic<double> g_input_level_clip_pct{0.0};
+static std::atomic<uint64_t> g_input_level_sample_count{0U};
+static std::atomic<long long> g_input_level_updated{0};
+
 static std::atomic<int> g_decode_health_valid{0};
 static std::atomic<uint32_t> g_decode_health_generation{0};
 static std::atomic<unsigned int> g_decode_p25p1_fec_ok{0};
@@ -1666,6 +1678,35 @@ rtl_fsk_metrics_reset_snapshot(void) {
     g_fsk_metrics_abs_est.store(0.0, std::memory_order_relaxed);
     g_fsk_metrics_dc_est.store(0.0, std::memory_order_relaxed);
     g_fsk_metrics_last_symbol.store(0.0, std::memory_order_relaxed);
+}
+
+void
+rtl_stream_input_level_reset(void) {
+    g_input_level_valid.store(0, std::memory_order_release);
+    g_input_level_status.store(DSD_INPUT_LEVEL_UNKNOWN, std::memory_order_relaxed);
+    g_input_level_source.store(DSD_INPUT_LEVEL_SOURCE_UNKNOWN, std::memory_order_relaxed);
+    g_input_level_rms_dbfs.store(-120.0, std::memory_order_relaxed);
+    g_input_level_peak_dbfs.store(-120.0, std::memory_order_relaxed);
+    g_input_level_clip_pct.store(0.0, std::memory_order_relaxed);
+    g_input_level_sample_count.store(0U, std::memory_order_relaxed);
+    g_input_level_updated.store(0, std::memory_order_relaxed);
+}
+
+void
+rtl_stream_input_level_publish(const dsd_input_level_snapshot* snapshot) {
+    if (!snapshot || snapshot->sample_count == 0U) {
+        rtl_stream_input_level_reset();
+        return;
+    }
+    g_input_level_valid.store(0, std::memory_order_release);
+    g_input_level_status.store((int)snapshot->status, std::memory_order_relaxed);
+    g_input_level_source.store((int)snapshot->source, std::memory_order_relaxed);
+    g_input_level_rms_dbfs.store(snapshot->rms_dbfs, std::memory_order_relaxed);
+    g_input_level_peak_dbfs.store(snapshot->peak_dbfs, std::memory_order_relaxed);
+    g_input_level_clip_pct.store(snapshot->clip_pct, std::memory_order_relaxed);
+    g_input_level_sample_count.store(snapshot->sample_count, std::memory_order_relaxed);
+    g_input_level_updated.store((long long)snapshot->updated, std::memory_order_relaxed);
+    g_input_level_valid.store(1, std::memory_order_release);
 }
 
 static void
@@ -1742,6 +1783,7 @@ snr_ema_reset(void) {
     g_snr_gfsk_src.store(0, std::memory_order_relaxed);
     g_snr_qpsk_acc_reset.store(1, std::memory_order_relaxed);
     rtl_fsk_metrics_reset_snapshot();
+    rtl_stream_input_level_reset();
     rtl_decode_health_reset();
 }
 
@@ -6886,6 +6928,37 @@ dsd_rtl_stream_get_fsk_metrics(rtl_stream_fsk_metrics* out) {
     out->abs_est = (float)g_fsk_metrics_abs_est.load(std::memory_order_relaxed);
     out->dc_est = (float)g_fsk_metrics_dc_est.load(std::memory_order_relaxed);
     out->last_symbol = (float)g_fsk_metrics_last_symbol.load(std::memory_order_relaxed);
+    return 0;
+}
+
+extern "C" int
+dsd_rtl_stream_get_input_level(dsd_input_level_snapshot* out) {
+    if (!out) {
+        return -1;
+    }
+    *out = dsd_input_level_snapshot{};
+    if (!rtl_stream_context_active()) {
+        rtl_stream_input_level_reset();
+        return 0;
+    }
+    if (g_input_level_valid.load(std::memory_order_acquire)) {
+        out->status = (dsd_input_level_status)g_input_level_status.load(std::memory_order_relaxed);
+        out->source = (dsd_input_level_source)g_input_level_source.load(std::memory_order_relaxed);
+        out->rms_dbfs = g_input_level_rms_dbfs.load(std::memory_order_relaxed);
+        out->peak_dbfs = g_input_level_peak_dbfs.load(std::memory_order_relaxed);
+        out->clip_pct = g_input_level_clip_pct.load(std::memory_order_relaxed);
+        out->sample_count = g_input_level_sample_count.load(std::memory_order_relaxed);
+        out->updated = (time_t)g_input_level_updated.load(std::memory_order_relaxed);
+        return 0;
+    }
+
+    rtl_stream_fsk_metrics fsk{};
+    if (dsd_rtl_stream_get_fsk_metrics(&fsk) == 0 && fsk.valid && fsk.clip_pct > 0.0f) {
+        uint64_t symbols = fsk.window_symbols ? (uint64_t)fsk.window_symbols : fsk.symbols_total;
+        if (dsd_input_level_metrics_from_fsk_clip(fsk.clip_pct, symbols, out) == 0) {
+            return 0;
+        }
+    }
     return 0;
 }
 

--- a/src/io/radio/rtl_stream_c.cpp
+++ b/src/io/radio/rtl_stream_c.cpp
@@ -12,6 +12,8 @@
  * legacy C control paths while preserving behavior.
  */
 
+#include "dsd-neo/core/input_level.h"
+
 #include <new>
 #include <stdint.h>
 #include <stdlib.h>
@@ -84,6 +86,7 @@ int dsd_rtl_stream_get_tuner_autogain(void);
 void dsd_rtl_stream_set_tuner_autogain(int onoff);
 int dsd_rtl_stream_get_fsk_metrics(rtl_stream_fsk_metrics* out);
 int dsd_rtl_stream_get_decode_health(rtl_stream_decode_health* out);
+int dsd_rtl_stream_get_input_level(dsd_input_level_snapshot* out);
 void dsd_rtl_stream_set_channel_squelch(float level);
 void dsd_rtl_stream_toggle_iq_balance(int onoff);
 int dsd_rtl_stream_get_iq_balance(void);
@@ -621,6 +624,11 @@ rtl_stream_get_fsk_metrics(rtl_stream_fsk_metrics* out) {
 extern "C" int
 rtl_stream_get_decode_health(rtl_stream_decode_health* out) {
     return dsd_rtl_stream_get_decode_health(out);
+}
+
+extern "C" int
+rtl_stream_get_input_level(dsd_input_level_snapshot* out) {
+    return dsd_rtl_stream_get_input_level(out);
 }
 
 /* Auto-PPM status snapshot */

--- a/src/io/radio/rtl_stream_shared.hpp
+++ b/src/io/radio/rtl_stream_shared.hpp
@@ -15,6 +15,7 @@
 #define DSD_NEO_SRC_IO_RADIO_RTL_STREAM_SHARED_HPP_
 
 #include <atomic>
+#include <dsd-neo/core/input_level.h>
 #include <dsd-neo/dsp/demod_state.h>
 
 extern demod_state demod;
@@ -41,5 +42,8 @@ extern std::atomic<int> g_auto_ppm_cooldown;
 extern std::atomic<double> g_spec_peak_db;
 extern std::atomic<double> g_spec_snr_db;
 extern std::atomic<double> g_resid_cfo_phase_hz;
+
+void rtl_stream_input_level_publish(const dsd_input_level_snapshot* snapshot);
+void rtl_stream_input_level_reset(void);
 
 #endif /* DSD_NEO_SRC_IO_RADIO_RTL_STREAM_SHARED_HPP_ */

--- a/src/protocol/m17/m17.c
+++ b/src/protocol/m17/m17.c
@@ -16,6 +16,7 @@
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/dibit.h>
 #include <dsd-neo/core/events.h>
+#include <dsd-neo/core/input_level.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
@@ -37,6 +38,7 @@
 #include <dsd-neo/runtime/m17_udp_hooks.h>
 #include <dsd-neo/runtime/net_audio_input_hooks.h>
 #include <dsd-neo/runtime/rtl_stream_io_hooks.h>
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <dsd-neo/runtime/telemetry.h>
 #include <dsd-neo/runtime/udp_audio_hooks.h>
 #include <math.h>
@@ -46,7 +48,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
-#include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -1928,18 +1929,16 @@ m17_str_apply_monitor_side_state(m17_str_ctx* ctx) {
 
 static void
 m17_str_update_input_power(m17_str_ctx* ctx) {
-    if (ctx->opts->audio_in_type != 3) {
-        ctx->opts->rtl_pwr = raw_pwr(ctx->voice1, ctx->nsam, 1);
-        if (ctx->opts->input_warn_db < 0.0) {
-            const double db = pwr_to_dB(ctx->opts->rtl_pwr);
-            const time_t now = time(NULL);
-            if (db <= ctx->opts->input_warn_db
-                && (ctx->opts->last_input_warn_time == 0
-                    || (int)(now - ctx->opts->last_input_warn_time) >= ctx->opts->input_warn_cooldown_sec)) {
-                LOG_WARNING("Input level low (%.1f dBFS). Consider raising sender gain or use --input-volume.\n", db);
-                ctx->opts->last_input_warn_time = now;
-            }
+    dsd_input_level_snapshot snapshot;
+    if (ctx->opts->audio_in_type == AUDIO_IN_RTL) {
+        if (dsd_rtl_stream_metrics_hook_input_level(&snapshot) == 0 && snapshot.sample_count > 0U) {
+            dsd_input_level_publish(ctx->opts, ctx->state, &snapshot, DSD_INPUT_LEVEL_NOTIFY_RF);
         }
+        return;
+    }
+    if (dsd_input_level_metrics_from_pcm_i16(ctx->voice1, (size_t)ctx->nsam, 1U, DSD_INPUT_LEVEL_SOURCE_PCM, &snapshot)
+        == 0) {
+        dsd_input_level_publish(ctx->opts, ctx->state, &snapshot, DSD_INPUT_LEVEL_NOTIFY_ALL);
     }
 }
 

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(
         control_pump.c
         freq_parse.c
         input_spec.c
+        input_level.c
         path_policy.c
         frame_sync_hooks.c
         trunk_scan_hooks.c

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -83,7 +83,7 @@ dsd_cli_usage_section_io(void) {
     printf("                (Use single quotes '/directory/audio file.wav' when directories/spaces are present)\n");
     printf("  -s <rate>     Sample rate (Hz) for WAV/TCP/UDP inputs (e.g., 48000, 96000)\n");
     printf("      --input-volume <N>  Scale non-RTL input samples by N (integer 1..16).\n");
-    printf("      --input-level-warn-db <dB>  Warn if input power below dBFS (default -40).\n");
+    printf("      --input-level-warn-db <dB>  Low input-level advisory threshold in dBFS (default -40).\n");
     printf("  -o <device>   Audio output device (default is pulse)\n");
     printf("                pulse for pulse audio decoded voice or analog output\n");
     printf("                pulse:1 or pulse:alsa_output.pci-0000_0d_00.3.analog-stereo for pulse audio decoded voice "

--- a/src/runtime/input_level.c
+++ b/src/runtime/input_level.c
@@ -1,0 +1,472 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/input_level.h>
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/runtime/log.h>
+#include <math.h>
+
+enum {
+    DSD_INPUT_LEVEL_TOAST_TTL_SEC = 4,
+};
+
+static const double DSD_INPUT_LEVEL_CLIP_PCT = 0.1;
+static const double DSD_INPUT_LEVEL_HOT_PEAK_DBFS = -1.0;
+
+static double
+input_level_pwr_to_db(double mean_power) {
+    if (mean_power <= 0.0 || !isfinite(mean_power)) {
+        return -120.0;
+    }
+    double db = 10.0 * log10(mean_power);
+    if (db > 0.0) {
+        db = 0.0;
+    }
+    if (db < -120.0) {
+        db = -120.0;
+    }
+    return db;
+}
+
+static double
+input_level_db_to_pwr(double db) {
+    if (db >= 0.0) {
+        return 1.0;
+    }
+    if (db < -200.0 || !isfinite(db)) {
+        db = -200.0;
+    }
+    const double ln10_over_10 = 2.302585092994046 / 10.0;
+    double pwr = exp(db * ln10_over_10);
+    if (pwr < 0.0) {
+        pwr = 0.0;
+    }
+    return pwr;
+}
+
+const char*
+dsd_input_level_status_label(dsd_input_level_status status) {
+    switch (status) {
+        case DSD_INPUT_LEVEL_OK: return "OK";
+        case DSD_INPUT_LEVEL_LOW: return "LOW";
+        case DSD_INPUT_LEVEL_HOT: return "HOT";
+        case DSD_INPUT_LEVEL_CLIPPING: return "CLIP";
+        case DSD_INPUT_LEVEL_UNKNOWN:
+        default: return "UNKNOWN";
+    }
+}
+
+int
+dsd_input_level_source_is_rf(dsd_input_level_source source) {
+    switch (source) {
+        case DSD_INPUT_LEVEL_SOURCE_RTL_CU8:
+        case DSD_INPUT_LEVEL_SOURCE_RTL_TCP_CU8:
+        case DSD_INPUT_LEVEL_SOURCE_SOAPY_CS16:
+        case DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32:
+        case DSD_INPUT_LEVEL_SOURCE_FSK_SYMBOL: return 1;
+        case DSD_INPUT_LEVEL_SOURCE_PCM:
+        case DSD_INPUT_LEVEL_SOURCE_UNKNOWN:
+        default: return 0;
+    }
+}
+
+const char*
+dsd_input_level_display_label(dsd_input_level_source source) {
+    return dsd_input_level_source_is_rf(source) ? "RF Level" : "Input Level";
+}
+
+static double
+input_level_peak_to_dbfs(double peak) {
+    if (peak <= 0.0 || !isfinite(peak)) {
+        return -120.0;
+    }
+    double db = 20.0 * log10(peak);
+    if (db > 0.0) {
+        db = 0.0;
+    }
+    if (db < -120.0) {
+        db = -120.0;
+    }
+    return db;
+}
+
+static double
+input_level_safe_abs(double value) {
+    if (!isfinite(value)) {
+        return 1.0;
+    }
+    return fabs(value);
+}
+
+static void
+input_level_fill(dsd_input_level_snapshot* out, dsd_input_level_source source, double mean_power, double peak,
+                 uint64_t clipped, uint64_t count) {
+    if (!out) {
+        return;
+    }
+    out->status = DSD_INPUT_LEVEL_UNKNOWN;
+    out->source = source;
+    out->rms_dbfs = input_level_pwr_to_db(mean_power);
+    out->peak_dbfs = input_level_peak_to_dbfs(peak);
+    out->clip_pct = (count > 0U) ? ((double)clipped * 100.0 / (double)count) : 0.0;
+    out->sample_count = count;
+    out->updated = time(NULL);
+}
+
+static int
+input_level_count_valid(size_t count, size_t step) {
+    return count > 0U && step > 0U;
+}
+
+void
+dsd_input_level_classify(dsd_input_level_snapshot* snapshot, double low_warn_db) {
+    if (!snapshot || snapshot->sample_count == 0U || snapshot->source == DSD_INPUT_LEVEL_SOURCE_UNKNOWN) {
+        if (snapshot) {
+            snapshot->status = DSD_INPUT_LEVEL_UNKNOWN;
+        }
+        return;
+    }
+    if (snapshot->clip_pct >= DSD_INPUT_LEVEL_CLIP_PCT) {
+        snapshot->status = DSD_INPUT_LEVEL_CLIPPING;
+        return;
+    }
+    if (snapshot->source == DSD_INPUT_LEVEL_SOURCE_FSK_SYMBOL) {
+        snapshot->status = DSD_INPUT_LEVEL_UNKNOWN;
+        return;
+    }
+    if (snapshot->peak_dbfs >= DSD_INPUT_LEVEL_HOT_PEAK_DBFS) {
+        snapshot->status = DSD_INPUT_LEVEL_HOT;
+        return;
+    }
+    if (low_warn_db < 0.0 && snapshot->rms_dbfs <= low_warn_db) {
+        snapshot->status = DSD_INPUT_LEVEL_LOW;
+        return;
+    }
+    snapshot->status = DSD_INPUT_LEVEL_OK;
+}
+
+int
+dsd_input_level_metrics_from_pcm_i16(const int16_t* samples, size_t count, size_t step, dsd_input_level_source source,
+                                     dsd_input_level_snapshot* out) {
+    if (!out || !samples || !input_level_count_valid(count, step)) {
+        return -1;
+    }
+    double p = 0.0;
+    double t = 0.0;
+    double peak = 0.0;
+    uint64_t clipped = 0U;
+    uint64_t used = 0U;
+    const double scale = 1.0 / 32768.0;
+    for (size_t i = 0U; i < count; i += step) {
+        const int16_t sample = samples[i];
+        const double s = (double)sample * scale;
+        const double a = input_level_safe_abs(s);
+        if (a > peak) {
+            peak = a;
+        }
+        if (sample <= INT16_MIN || sample >= INT16_MAX) {
+            clipped++;
+        }
+        t += s;
+        p += s * s;
+        used++;
+    }
+    double mean_power = 0.0;
+    if (used > 0U) {
+        mean_power = p - ((t * t) / (double)used);
+        if (mean_power < 0.0) {
+            mean_power = 0.0;
+        }
+        mean_power /= (double)used;
+    }
+    input_level_fill(out, source, mean_power, peak, clipped, used);
+    return 0;
+}
+
+int
+dsd_input_level_metrics_from_pcm_f32_i16_scale(const float* samples, size_t count, size_t step,
+                                               dsd_input_level_source source, dsd_input_level_snapshot* out) {
+    if (!out || !samples || !input_level_count_valid(count, step)) {
+        return -1;
+    }
+    double p = 0.0;
+    double t = 0.0;
+    double peak = 0.0;
+    uint64_t clipped = 0U;
+    uint64_t used = 0U;
+    const double scale = 1.0 / 32768.0;
+    for (size_t i = 0U; i < count; i += step) {
+        double raw = (double)samples[i];
+        if (!isfinite(raw)) {
+            raw = (raw < 0.0) ? -32768.0 : 32767.0;
+        }
+        const double s = raw * scale;
+        const double a = input_level_safe_abs(s);
+        if (a > peak) {
+            peak = a;
+        }
+        if (raw <= -32768.0 || raw >= 32767.0) {
+            clipped++;
+        }
+        t += s;
+        p += s * s;
+        used++;
+    }
+    double mean_power = 0.0;
+    if (used > 0U) {
+        mean_power = p - ((t * t) / (double)used);
+        if (mean_power < 0.0) {
+            mean_power = 0.0;
+        }
+        mean_power /= (double)used;
+    }
+    input_level_fill(out, source, mean_power, peak, clipped, used);
+    return 0;
+}
+
+int
+dsd_input_level_metrics_from_cu8(const uint8_t* samples, size_t count, dsd_input_level_source source,
+                                 dsd_input_level_snapshot* out) {
+    if (!out || !samples || count == 0U) {
+        return -1;
+    }
+    double p = 0.0;
+    double t = 0.0;
+    double peak = 0.0;
+    uint64_t clipped = 0U;
+    const double scale = 1.0 / 127.5;
+    for (size_t i = 0U; i < count; i++) {
+        const uint8_t sample = samples[i];
+        const double s = ((double)sample - 127.5) * scale;
+        const double a = fabs(s);
+        if (a > peak) {
+            peak = a;
+        }
+        if (sample <= 1U || sample >= 254U) {
+            clipped++;
+        }
+        t += s;
+        p += s * s;
+    }
+    double mean_power = p - ((t * t) / (double)count);
+    if (mean_power < 0.0) {
+        mean_power = 0.0;
+    }
+    mean_power /= (double)count;
+    input_level_fill(out, source, mean_power, peak, clipped, (uint64_t)count);
+    return 0;
+}
+
+int
+dsd_input_level_metrics_from_cs16(const int16_t* samples, size_t count, dsd_input_level_source source,
+                                  dsd_input_level_snapshot* out) {
+    if (!out || !samples || count == 0U) {
+        return -1;
+    }
+    double p = 0.0;
+    double t = 0.0;
+    double peak = 0.0;
+    uint64_t clipped = 0U;
+    const double scale = 1.0 / 32768.0;
+    for (size_t i = 0U; i < count; i++) {
+        const int16_t sample = samples[i];
+        const double s = (double)sample * scale;
+        const double a = input_level_safe_abs(s);
+        if (a > peak) {
+            peak = a;
+        }
+        if (sample <= -32760 || sample >= 32760) {
+            clipped++;
+        }
+        t += s;
+        p += s * s;
+    }
+    double mean_power = p - ((t * t) / (double)count);
+    if (mean_power < 0.0) {
+        mean_power = 0.0;
+    }
+    mean_power /= (double)count;
+    input_level_fill(out, source, mean_power, peak, clipped, (uint64_t)count);
+    return 0;
+}
+
+int
+dsd_input_level_metrics_from_cf32(const float* samples, size_t count, dsd_input_level_source source,
+                                  dsd_input_level_snapshot* out) {
+    if (!out || !samples || count == 0U) {
+        return -1;
+    }
+    double p = 0.0;
+    double t = 0.0;
+    double peak = 0.0;
+    uint64_t clipped = 0U;
+    for (size_t i = 0U; i < count; i++) {
+        double s = (double)samples[i];
+        if (!isfinite(s)) {
+            s = (s < 0.0) ? -1.0 : 1.0;
+        }
+        const double a = fabs(s);
+        if (a > peak) {
+            peak = a;
+        }
+        if (a >= 0.98) {
+            clipped++;
+        }
+        t += s;
+        p += s * s;
+    }
+    double mean_power = p - ((t * t) / (double)count);
+    if (mean_power < 0.0) {
+        mean_power = 0.0;
+    }
+    mean_power /= (double)count;
+    input_level_fill(out, source, mean_power, peak, clipped, (uint64_t)count);
+    return 0;
+}
+
+int
+dsd_input_level_metrics_from_fsk_clip(float clip_pct, uint64_t symbols, dsd_input_level_snapshot* out) {
+    if (!out || symbols == 0U || !isfinite((double)clip_pct)) {
+        return -1;
+    }
+    out->status = DSD_INPUT_LEVEL_UNKNOWN;
+    out->source = DSD_INPUT_LEVEL_SOURCE_FSK_SYMBOL;
+    out->rms_dbfs = -120.0;
+    out->peak_dbfs = -120.0;
+    out->clip_pct = clip_pct < 0.0f ? 0.0 : (double)clip_pct;
+    out->sample_count = symbols;
+    out->updated = time(NULL);
+    return 0;
+}
+
+static unsigned int
+input_level_notify_bit(dsd_input_level_status status) {
+    switch (status) {
+        case DSD_INPUT_LEVEL_LOW: return DSD_INPUT_LEVEL_NOTIFY_LOW;
+        case DSD_INPUT_LEVEL_HOT: return DSD_INPUT_LEVEL_NOTIFY_HOT;
+        case DSD_INPUT_LEVEL_CLIPPING: return DSD_INPUT_LEVEL_NOTIFY_CLIPPING;
+        case DSD_INPUT_LEVEL_UNKNOWN:
+        case DSD_INPUT_LEVEL_OK:
+        default: return 0U;
+    }
+}
+
+static int
+input_level_status_notifies(dsd_input_level_status status) {
+    return input_level_notify_bit(status) != 0U;
+}
+
+static int
+input_level_status_severity(dsd_input_level_status status) {
+    switch (status) {
+        case DSD_INPUT_LEVEL_LOW: return 1;
+        case DSD_INPUT_LEVEL_HOT: return 2;
+        case DSD_INPUT_LEVEL_CLIPPING: return 3;
+        case DSD_INPUT_LEVEL_UNKNOWN:
+        case DSD_INPUT_LEVEL_OK:
+        default: return 0;
+    }
+}
+
+int
+dsd_input_level_format_advisory(const dsd_input_level_snapshot* snapshot, char* out, size_t out_size) {
+    if (!snapshot || !out || out_size == 0U) {
+        return -1;
+    }
+    const char* label = dsd_input_level_display_label(snapshot->source);
+    const char* status = dsd_input_level_status_label(snapshot->status);
+    const char* advice = dsd_input_level_source_is_rf(snapshot->source) ? "lower RF gain or add filtering/attenuation"
+                                                                        : "lower source/input volume";
+    if (snapshot->status == DSD_INPUT_LEVEL_LOW) {
+        advice = dsd_input_level_source_is_rf(snapshot->source) ? "raise RF gain if signal is present"
+                                                                : "raise source/input volume";
+        DSD_SNPRINTF(out, out_size, "%s %s %.1f dBFS: %s", label, status, snapshot->rms_dbfs, advice);
+        return 0;
+    }
+    if (snapshot->status == DSD_INPUT_LEVEL_HOT) {
+        DSD_SNPRINTF(out, out_size, "%s %s peak %.1f dBFS: %s", label, status, snapshot->peak_dbfs, advice);
+        return 0;
+    }
+    if (snapshot->status == DSD_INPUT_LEVEL_CLIPPING) {
+        DSD_SNPRINTF(out, out_size, "%s %s %.1f%%: %s", label, status, snapshot->clip_pct, advice);
+        return 0;
+    }
+    DSD_SNPRINTF(out, out_size, "%s %s", label, status);
+    return 0;
+}
+
+static int
+input_level_should_notify(const dsd_opts* opts, const dsd_state* state, const dsd_input_level_snapshot* snapshot,
+                          unsigned int notify_mask, time_t now) {
+    if (!state || !snapshot) {
+        return 0;
+    }
+    unsigned int bit = input_level_notify_bit(snapshot->status);
+    if (bit == 0U || (notify_mask & bit) == 0U) {
+        return 0;
+    }
+    int cooldown = opts ? opts->input_warn_cooldown_sec : 10;
+    if (cooldown <= 0) {
+        cooldown = 10;
+    }
+    if (state->input_level_last_toast_time == 0) {
+        return 1;
+    }
+    const dsd_input_level_status last_status = state->input_level_last_toast_status;
+    const dsd_input_level_source last_source = state->input_level_last_toast_source;
+    if (!input_level_status_notifies(last_status) || last_source == DSD_INPUT_LEVEL_SOURCE_UNKNOWN) {
+        return 1;
+    }
+    if ((last_status != snapshot->status || last_source != snapshot->source)
+        && input_level_status_severity(snapshot->status) > input_level_status_severity(last_status)) {
+        return 1;
+    }
+    return difftime(now, state->input_level_last_toast_time) >= (double)cooldown;
+}
+
+void
+dsd_input_level_publish(dsd_opts* opts, dsd_state* state, const dsd_input_level_snapshot* snapshot,
+                        unsigned int notify_mask) {
+    if (!snapshot) {
+        return;
+    }
+
+    dsd_input_level_snapshot next = *snapshot;
+    double low_warn_db = opts ? opts->input_warn_db : -40.0;
+    dsd_input_level_classify(&next, low_warn_db);
+
+    if (opts && next.source == DSD_INPUT_LEVEL_SOURCE_PCM && next.sample_count > 0U && next.rms_dbfs > -200.0) {
+        opts->rtl_pwr = input_level_db_to_pwr(next.rms_dbfs);
+    }
+    if (!state) {
+        return;
+    }
+
+    time_t now = next.updated != 0 ? next.updated : time(NULL);
+    int notify = input_level_should_notify(opts, state, &next, notify_mask, now);
+    state->input_level = next;
+    if (!notify) {
+        return;
+    }
+
+    char msg[sizeof(state->ui_msg)];
+    if (dsd_input_level_format_advisory(&next, msg, sizeof(msg)) != 0) {
+        return;
+    }
+    LOG_WARNING("%s\n", msg);
+    DSD_SNPRINTF(state->ui_msg, sizeof(state->ui_msg), "%s", msg);
+    state->ui_msg_expire = now + DSD_INPUT_LEVEL_TOAST_TTL_SEC;
+    state->input_level_last_toast_time = now;
+    state->input_level_last_toast_status = next.status;
+    state->input_level_last_toast_source = next.source;
+    if (opts) {
+        opts->last_input_warn_time = now;
+    }
+}

--- a/src/runtime/rtl_stream_metrics_hooks.c
+++ b/src/runtime/rtl_stream_metrics_hooks.c
@@ -3,6 +3,8 @@
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+#include "dsd-neo/core/input_level.h"
+
 #include <dsd-neo/platform/atomic_compat.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 
@@ -61,6 +63,17 @@ int
 dsd_rtl_stream_metrics_hook_stream_active(void) {
     if (g_rtl_stream_metrics_hooks.stream_active) {
         return g_rtl_stream_metrics_hooks.stream_active() ? 1 : 0;
+    }
+    return 0;
+}
+
+int
+dsd_rtl_stream_metrics_hook_input_level(dsd_input_level_snapshot* out) {
+    if (g_rtl_stream_metrics_hooks.input_level) {
+        return g_rtl_stream_metrics_hooks.input_level(out);
+    }
+    if (out) {
+        *out = (dsd_input_level_snapshot){0};
     }
     return 0;
 }

--- a/src/ui/terminal/CMakeLists.txt
+++ b/src/ui/terminal/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(
         ui_snr_readout.c
         ncurses_init.c
         ncurses_dsp_display.c
+        ncurses_dsp_status_format.c
         ncurses_visualizers.c
         ncurses_p25_display.c
         ncurses_trunk_display.c

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -386,7 +386,6 @@ ui_render_rtl_input_source(dsd_opts* opts, dsd_state* state) {
         printw(" Mon: %iX;", opts->rtl_volume_multiplier);
         ui_print_rtl_ppm_field(opts);
         printw(" SQL: %.1f dB;", pwr_to_dB(opts->rtl_squelch_level));
-        printw(" PWR: %.1f dB;", pwr_to_dB(opts->rtl_pwr));
         printw(" DSP-BW: %i kHz;", opts->rtl_dsp_bw_khz);
         printw(" FRQ: %i;", opts->rtlsdr_center_freq);
         ui_print_rtl_auto_ppm_status();

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -16,6 +16,8 @@
  * 2024-03 EDACS-FME display improvements
  *-----------------------------------------------------------------------------*/
 
+#include "dsd-neo/core/input_level.h"
+
 #include <curses.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/power.h>
@@ -401,9 +403,29 @@ ui_render_rtl_input_source(dsd_opts* opts, dsd_state* state) {
 }
 
 static void
+ui_render_input_level_status(const dsd_state* state) {
+    if (!state || state->input_level.source == DSD_INPUT_LEVEL_SOURCE_UNKNOWN
+        || state->input_level.sample_count == 0U) {
+        return;
+    }
+    const dsd_input_level_snapshot* level = &state->input_level;
+    printw("| %s: %s rms %.1f dBFS peak %.1f dBFS clip %.1f%%", dsd_input_level_display_label(level->source),
+           dsd_input_level_status_label(level->status), level->rms_dbfs, level->peak_dbfs, level->clip_pct);
+    if (level->status == DSD_INPUT_LEVEL_LOW) {
+        printw(" %s", dsd_input_level_source_is_rf(level->source) ? "raise RF gain if signal is present"
+                                                                  : "raise source/input volume");
+    } else if (level->status == DSD_INPUT_LEVEL_HOT || level->status == DSD_INPUT_LEVEL_CLIPPING) {
+        printw(" %s", dsd_input_level_source_is_rf(level->source) ? "lower RF gain or add filtering/attenuation"
+                                                                  : "lower source/input volume");
+    }
+    printw("\n");
+}
+
+static void
 ui_render_input_sources_block(dsd_opts* opts, dsd_state* state) {
     ui_render_basic_input_sources(opts);
     ui_render_rtl_input_source(opts, state);
+    ui_render_input_level_status(state);
 }
 
 static void

--- a/src/ui/terminal/ncurses_dsp_display.c
+++ b/src/ui/terminal/ncurses_dsp_display.c
@@ -8,9 +8,9 @@
  */
 
 #include <curses.h>
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state.h>
-#include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/ui/ncurses_dsp_display.h>
 #include <dsd-neo/ui/ui_prims.h>
 #include <stdarg.h>
@@ -18,8 +18,13 @@
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/platform/platform.h"
+#include "ncurses_dsp_status_format.h"
 
 #ifdef USE_RTLSDR
+#include <dsd-neo/io/rtl_stream_c.h>
+#endif
+
+#ifdef USE_RADIO
 
 /* Small helpers to align key/value fields to a consistent value column. */
 static inline void
@@ -54,6 +59,20 @@ ui_print_kv_line(const char* label, const char* fmt, ...) {
     va_end(ap);
     addch('\n');
 }
+
+static void
+dsp_status_print_squelch(const dsd_opts* opts) {
+    if (!opts) {
+        return;
+    }
+    char status[64];
+    if (ui_dsp_format_squelch_status(opts->rtl_pwr, opts->rtl_squelch_level, status, sizeof(status)) == 0) {
+        ui_print_kv_line("Squelch", "%s", status);
+    }
+}
+#endif
+
+#ifdef USE_RTLSDR
 
 typedef struct {
     int cq;
@@ -174,24 +193,32 @@ void
 print_dsp_status(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-#ifdef USE_RTLSDR
+#ifdef USE_RADIO
     /* Preserve current color pair so our colored header/HR won't force default */
 #ifdef PRETTY_COLORS
     attr_t saved_attrs = 0;
     short saved_pair = 0;
     attr_get(&saved_attrs, &saved_pair, NULL);
 #endif
+
+#ifdef USE_RTLSDR
     dsp_status_snapshot snap;
     dsp_status_capture(&snap, state);
+#endif
 
     ui_print_header("DSP");
     attron(COLOR_PAIR(14)); /* explicit yellow for DSP items */
+#ifdef USE_RTLSDR
     dsp_status_print_front_and_path(&snap);
+#endif
+    dsp_status_print_squelch(opts);
+#ifdef USE_RTLSDR
     if (snap.cq) {
         dsp_status_print_cqpsk_metrics();
     }
     dsp_status_print_fsk_metrics();
     dsp_status_print_mode_tail(&snap);
+#endif
     attroff(COLOR_PAIR(14));
     attron(COLOR_PAIR(4));
     ui_print_hr();

--- a/src/ui/terminal/ncurses_dsp_status_format.c
+++ b/src/ui/terminal/ncurses_dsp_status_format.c
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "ncurses_dsp_status_format.h"
+
+#include <dsd-neo/core/power.h>
+#include <dsd-neo/core/safe_api.h>
+
+int
+ui_dsp_format_squelch_status(double channel_power, double squelch_power, char* out, size_t out_size) {
+    if (!out || out_size == 0U) {
+        return -1;
+    }
+    const int gate_closed = (squelch_power > 0.0 && channel_power < squelch_power);
+    const char* gate = gate_closed ? "Closed" : "Open";
+    DSD_SNPRINTF(out, out_size, "%s ch:%.1f dB sql:%.1f dB", gate, pwr_to_dB(channel_power), pwr_to_dB(squelch_power));
+    return 0;
+}

--- a/src/ui/terminal/ncurses_dsp_status_format.h
+++ b/src/ui/terminal/ncurses_dsp_status_format.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef DSD_NEO_SRC_UI_TERMINAL_NCURSES_DSP_STATUS_FORMAT_H_
+#define DSD_NEO_SRC_UI_TERMINAL_NCURSES_DSP_STATUS_FORMAT_H_
+
+#include <stddef.h>
+
+int ui_dsp_format_squelch_status(double channel_power, double squelch_power, char* out, size_t out_size);
+
+#endif /* DSD_NEO_SRC_UI_TERMINAL_NCURSES_DSP_STATUS_FORMAT_H_ */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -391,6 +391,12 @@ dsd_neo_add_public_header_smoke_test(
   C
 )
 dsd_neo_add_public_header_smoke_test(
+  dsd-neo_test_headers_public_core_input_level
+  HEADERS_PUBLIC_CORE_INPUT_LEVEL
+  dsd-neo/core/input_level.h
+  C
+)
+dsd_neo_add_public_header_smoke_test(
   dsd-neo_test_headers_public_core_state_ext
   HEADERS_PUBLIC_CORE_STATE_EXT
   dsd-neo/core/state_ext.h
@@ -1471,6 +1477,14 @@ target_include_directories(
 )
 target_link_libraries(dsd-neo_test_core_state_ext PRIVATE dsd-neo_core)
 add_test(NAME CORE_STATE_EXT COMMAND dsd-neo_test_core_state_ext)
+
+add_executable(dsd-neo_test_core_input_level core/test_core_input_level.c)
+target_include_directories(
+    dsd-neo_test_core_input_level
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(dsd-neo_test_core_input_level PRIVATE dsd-neo_core)
+add_test(NAME CORE_INPUT_LEVEL COMMAND dsd-neo_test_core_input_level)
 
 add_executable(dsd-neo_test_core_dsd_time core/test_core_dsd_time.c)
 target_include_directories(
@@ -5068,6 +5082,20 @@ target_link_libraries(
     PRIVATE dsd-neo_io_iq dsd-neo_platform dsd-neo_test_support
 )
 add_test(NAME IO_IQ_CAPTURE_WRITER COMMAND dsd-neo_test_io_iq_capture_writer)
+
+add_executable(
+    dsd-neo_test_io_input_level_metrics
+    io/test_io_input_level_metrics.c
+)
+target_include_directories(
+    dsd-neo_test_io_input_level_metrics
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(dsd-neo_test_io_input_level_metrics PRIVATE dsd-neo_core)
+add_test(
+    NAME IO_INPUT_LEVEL_METRICS
+    COMMAND dsd-neo_test_io_input_level_metrics
+)
 
 add_executable(
     dsd-neo_test_io_soapy_profile

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -951,6 +951,47 @@ target_include_directories(
 add_test(NAME UI_BURST_ACTIVE_CALL COMMAND dsd-neo_test_ui_burst_active_call)
 
 add_executable(
+    dsd-neo_test_ui_dsp_squelch_status
+    ui/test_ui_dsp_squelch_status.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_dsp_status_format.c
+)
+target_include_directories(
+    dsd-neo_test_ui_dsp_squelch_status
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
+)
+target_link_libraries(
+    dsd-neo_test_ui_dsp_squelch_status
+    PRIVATE dsd-neo_core ${DSD_NEO_TEST_MATH_LIB}
+)
+add_test(NAME UI_DSP_SQUELCH_STATUS COMMAND dsd-neo_test_ui_dsp_squelch_status)
+
+add_executable(
+    dsd-neo_test_ui_dsp_display_radio_compile
+    ui/test_ui_dsp_display_radio_compile.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_dsp_display.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_prims.c
+)
+target_compile_definitions(
+    dsd-neo_test_ui_dsp_display_radio_compile
+    PRIVATE USE_RADIO
+)
+target_include_directories(
+    dsd-neo_test_ui_dsp_display_radio_compile
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal
+        ${_PUBLIC_INCLUDES}
+)
+target_link_libraries(
+    dsd-neo_test_ui_dsp_display_radio_compile
+    PRIVATE ${CURSES_LIBRARIES} ${DSD_NEO_TEST_MATH_LIB}
+)
+add_test(
+    NAME UI_DSP_DISPLAY_RADIO_COMPILE
+    COMMAND dsd-neo_test_ui_dsp_display_radio_compile
+)
+
+add_executable(
     dsd-neo_test_ui_snr_meter
     ui/test_ui_snr_meter.c
     ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_snr.c

--- a/tests/core/test_core_input_level.c
+++ b/tests/core/test_core_input_level.c
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/input_level.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+static dsd_input_level_snapshot
+snapshot_for(dsd_input_level_source source, double rms_dbfs, double peak_dbfs, double clip_pct, time_t updated) {
+    dsd_input_level_snapshot snapshot = {
+        .status = DSD_INPUT_LEVEL_UNKNOWN,
+        .source = source,
+        .rms_dbfs = rms_dbfs,
+        .peak_dbfs = peak_dbfs,
+        .clip_pct = clip_pct,
+        .sample_count = 1000U,
+        .updated = updated,
+    };
+    return snapshot;
+}
+
+static void
+test_classifier_thresholds(void) {
+    dsd_input_level_snapshot low = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -50.0, -20.0, 0.0, 1);
+    dsd_input_level_classify(&low, -40.0);
+    assert(low.status == DSD_INPUT_LEVEL_LOW);
+
+    dsd_input_level_snapshot hot = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -20.0, -0.5, 0.0, 1);
+    dsd_input_level_classify(&hot, -40.0);
+    assert(hot.status == DSD_INPUT_LEVEL_HOT);
+
+    dsd_input_level_snapshot clip = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -20.0, -0.5, 0.1, 1);
+    dsd_input_level_classify(&clip, -40.0);
+    assert(clip.status == DSD_INPUT_LEVEL_CLIPPING);
+
+    dsd_input_level_snapshot ok = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -25.0, -3.0, 0.0, 1);
+    dsd_input_level_classify(&ok, -40.0);
+    assert(ok.status == DSD_INPUT_LEVEL_OK);
+}
+
+static void
+test_pcm_publish_backfills_rtl_power_but_rf_publish_does_not(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+    opts->input_warn_db = -40.0;
+    opts->input_warn_cooldown_sec = 10;
+    opts->rtl_pwr = 0.125;
+
+    dsd_input_level_snapshot rf_clip = snapshot_for(DSD_INPUT_LEVEL_SOURCE_RTL_CU8, -6.0, -0.1, 0.2, 50);
+    dsd_input_level_publish(opts, state, &rf_clip, DSD_INPUT_LEVEL_NOTIFY_RF);
+    assert(opts->rtl_pwr == 0.125);
+    assert(state->input_level.source == DSD_INPUT_LEVEL_SOURCE_RTL_CU8);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_CLIPPING);
+
+    dsd_input_level_snapshot pcm_ok = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -20.0, -3.0, 0.0, 60);
+    dsd_input_level_publish(opts, state, &pcm_ok, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(fabs(opts->rtl_pwr - 0.01) < 0.000001);
+
+    free(state);
+    free(opts);
+}
+
+static void
+test_toast_throttle_and_transition(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+    opts->input_warn_db = -40.0;
+    opts->input_warn_cooldown_sec = 10;
+
+    dsd_input_level_snapshot low = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -50.0, -20.0, 0.0, 100);
+    dsd_input_level_publish(opts, state, &low, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_LOW);
+    assert(strstr(state->ui_msg, "Input Level LOW") != NULL);
+    assert(strstr(state->ui_msg, "raise source/input volume") != NULL);
+    assert(state->input_level_last_toast_time == 100);
+
+    DSD_SNPRINTF(state->ui_msg, sizeof(state->ui_msg), "%s", "sentinel");
+    low.updated = 105;
+    dsd_input_level_publish(opts, state, &low, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(strcmp(state->ui_msg, "sentinel") == 0);
+
+    low.updated = 111;
+    dsd_input_level_publish(opts, state, &low, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(strstr(state->ui_msg, "Input Level LOW") != NULL);
+    assert(state->input_level_last_toast_time == 111);
+
+    dsd_input_level_snapshot clip = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -20.0, -0.2, 0.2, 112);
+    dsd_input_level_publish(opts, state, &clip, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(strstr(state->ui_msg, "Input Level CLIP") != NULL);
+    assert(state->input_level_last_toast_time == 112);
+
+    free(state);
+    free(opts);
+}
+
+static void
+test_toast_cooldown_survives_ok_sample(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+    opts->input_warn_db = -40.0;
+    opts->input_warn_cooldown_sec = 10;
+
+    dsd_input_level_snapshot low = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -50.0, -20.0, 0.0, 100);
+    dsd_input_level_publish(opts, state, &low, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(strstr(state->ui_msg, "Input Level LOW") != NULL);
+    assert(state->input_level_last_toast_time == 100);
+
+    dsd_input_level_snapshot ok = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -30.0, -3.0, 0.0, 105);
+    dsd_input_level_publish(opts, state, &ok, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_OK);
+
+    DSD_SNPRINTF(state->ui_msg, sizeof(state->ui_msg), "%s", "sentinel");
+    low.updated = 106;
+    dsd_input_level_publish(opts, state, &low, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(strcmp(state->ui_msg, "sentinel") == 0);
+    assert(state->input_level_last_toast_time == 100);
+
+    low.updated = 111;
+    dsd_input_level_publish(opts, state, &low, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(strstr(state->ui_msg, "Input Level LOW") != NULL);
+    assert(state->input_level_last_toast_time == 111);
+
+    free(state);
+    free(opts);
+}
+
+static void
+test_toast_escalation_survives_ok_sample(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+    opts->input_warn_db = -40.0;
+    opts->input_warn_cooldown_sec = 10;
+
+    dsd_input_level_snapshot low = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -50.0, -20.0, 0.0, 100);
+    dsd_input_level_publish(opts, state, &low, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(strstr(state->ui_msg, "Input Level LOW") != NULL);
+    assert(state->input_level_last_toast_time == 100);
+
+    dsd_input_level_snapshot ok = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -30.0, -3.0, 0.0, 105);
+    dsd_input_level_publish(opts, state, &ok, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_OK);
+
+    dsd_input_level_snapshot clip = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -20.0, -0.2, 0.2, 106);
+    dsd_input_level_publish(opts, state, &clip, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(strstr(state->ui_msg, "Input Level CLIP") != NULL);
+    assert(state->input_level_last_toast_time == 106);
+    assert(state->input_level_last_toast_status == DSD_INPUT_LEVEL_CLIPPING);
+
+    free(state);
+    free(opts);
+}
+
+static void
+test_toast_cooldown_suppresses_hot_clip_oscillation(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+    opts->input_warn_db = -40.0;
+    opts->input_warn_cooldown_sec = 10;
+
+    dsd_input_level_snapshot hot = snapshot_for(DSD_INPUT_LEVEL_SOURCE_RTL_CU8, -15.0, -0.5, 0.0, 200);
+    dsd_input_level_publish(opts, state, &hot, DSD_INPUT_LEVEL_NOTIFY_RF);
+    assert(strstr(state->ui_msg, "RF Level HOT") != NULL);
+    assert(state->input_level_last_toast_time == 200);
+    assert(state->input_level_last_toast_status == DSD_INPUT_LEVEL_HOT);
+
+    dsd_input_level_snapshot clip = snapshot_for(DSD_INPUT_LEVEL_SOURCE_RTL_CU8, -15.0, -0.1, 0.2, 201);
+    dsd_input_level_publish(opts, state, &clip, DSD_INPUT_LEVEL_NOTIFY_RF);
+    assert(strstr(state->ui_msg, "RF Level CLIP") != NULL);
+    assert(state->input_level_last_toast_time == 201);
+    assert(state->input_level_last_toast_status == DSD_INPUT_LEVEL_CLIPPING);
+
+    DSD_SNPRINTF(state->ui_msg, sizeof(state->ui_msg), "%s", "sentinel");
+    hot.updated = 202;
+    dsd_input_level_publish(opts, state, &hot, DSD_INPUT_LEVEL_NOTIFY_RF);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_HOT);
+    assert(strcmp(state->ui_msg, "sentinel") == 0);
+    assert(state->input_level_last_toast_time == 201);
+
+    clip.updated = 203;
+    dsd_input_level_publish(opts, state, &clip, DSD_INPUT_LEVEL_NOTIFY_RF);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_CLIPPING);
+    assert(strcmp(state->ui_msg, "sentinel") == 0);
+    assert(state->input_level_last_toast_time == 201);
+
+    free(state);
+    free(opts);
+}
+
+static void
+test_rf_low_suppressed_but_clip_notifies(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+    opts->input_warn_db = -40.0;
+    opts->input_warn_cooldown_sec = 10;
+
+    dsd_input_level_snapshot low = snapshot_for(DSD_INPUT_LEVEL_SOURCE_RTL_CU8, -80.0, -20.0, 0.0, 200);
+    dsd_input_level_publish(opts, state, &low, DSD_INPUT_LEVEL_NOTIFY_RF);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_LOW);
+    assert(state->ui_msg[0] == '\0');
+
+    dsd_input_level_snapshot clip = snapshot_for(DSD_INPUT_LEVEL_SOURCE_RTL_CU8, -15.0, -0.1, 0.2, 201);
+    dsd_input_level_publish(opts, state, &clip, DSD_INPUT_LEVEL_NOTIFY_RF);
+    assert(strstr(state->ui_msg, "RF Level CLIP") != NULL);
+    assert(strstr(state->ui_msg, "lower RF gain or add filtering/attenuation") != NULL);
+
+    free(state);
+    free(opts);
+}
+
+static void
+test_advisory_text_selection(void) {
+    char msg[128];
+    dsd_input_level_snapshot pcm_low = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -55.0, -30.0, 0.0, 1);
+    dsd_input_level_classify(&pcm_low, -40.0);
+    assert(dsd_input_level_format_advisory(&pcm_low, msg, sizeof(msg)) == 0);
+    assert(strstr(msg, "raise source/input volume") != NULL);
+
+    dsd_input_level_snapshot rf_clip = snapshot_for(DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32, -5.0, -0.1, 0.2, 1);
+    dsd_input_level_classify(&rf_clip, -40.0);
+    assert(dsd_input_level_format_advisory(&rf_clip, msg, sizeof(msg)) == 0);
+    assert(strstr(msg, "lower RF gain or add filtering/attenuation") != NULL);
+}
+
+int
+main(void) {
+    test_classifier_thresholds();
+    test_pcm_publish_backfills_rtl_power_but_rf_publish_does_not();
+    test_toast_throttle_and_transition();
+    test_toast_cooldown_survives_ok_sample();
+    test_toast_escalation_survives_ok_sample();
+    test_toast_cooldown_suppresses_hot_clip_oscillation();
+    test_rf_low_suppressed_but_clip_notifies();
+    test_advisory_text_selection();
+    return 0;
+}

--- a/tests/io/test_io_input_level_metrics.c
+++ b/tests/io/test_io_input_level_metrics.c
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/input_level.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+
+static void
+classify(dsd_input_level_snapshot* snapshot) {
+    dsd_input_level_classify(snapshot, -40.0);
+}
+
+static void
+test_cu8_metrics(void) {
+    uint8_t normal[128];
+    for (size_t i = 0U; i < 128U; i++) {
+        normal[i] = (i & 1U) ? 136U : 119U;
+    }
+
+    dsd_input_level_snapshot snapshot;
+    assert(dsd_input_level_metrics_from_cu8(normal, 128U, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, &snapshot) == 0);
+    classify(&snapshot);
+    assert(snapshot.source == DSD_INPUT_LEVEL_SOURCE_RTL_CU8);
+    assert(snapshot.status == DSD_INPUT_LEVEL_OK);
+    assert(snapshot.sample_count == 128U);
+    assert(snapshot.clip_pct == 0.0);
+
+    uint8_t low[64];
+    for (size_t i = 0U; i < 64U; i++) {
+        low[i] = 128U;
+    }
+    assert(dsd_input_level_metrics_from_cu8(low, 64U, DSD_INPUT_LEVEL_SOURCE_RTL_TCP_CU8, &snapshot) == 0);
+    classify(&snapshot);
+    assert(snapshot.status == DSD_INPUT_LEVEL_LOW);
+
+    uint8_t clipped[1000];
+    for (size_t i = 0U; i < 1000U; i++) {
+        clipped[i] = 128U;
+    }
+    clipped[17] = 0U;
+    assert(dsd_input_level_metrics_from_cu8(clipped, 1000U, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, &snapshot) == 0);
+    classify(&snapshot);
+    assert(snapshot.status == DSD_INPUT_LEVEL_CLIPPING);
+    assert(fabs(snapshot.clip_pct - 0.1) < 1e-9);
+}
+
+static void
+test_cs16_metrics(void) {
+    int16_t hot[1000] = {0};
+    hot[10] = 32000;
+    dsd_input_level_snapshot snapshot;
+    assert(dsd_input_level_metrics_from_cs16(hot, 1000U, DSD_INPUT_LEVEL_SOURCE_SOAPY_CS16, &snapshot) == 0);
+    classify(&snapshot);
+    assert(snapshot.status == DSD_INPUT_LEVEL_HOT);
+    assert(snapshot.clip_pct == 0.0);
+
+    int16_t clipped[1000] = {0};
+    clipped[20] = -32760;
+    assert(dsd_input_level_metrics_from_cs16(clipped, 1000U, DSD_INPUT_LEVEL_SOURCE_SOAPY_CS16, &snapshot) == 0);
+    classify(&snapshot);
+    assert(snapshot.status == DSD_INPUT_LEVEL_CLIPPING);
+    assert(fabs(snapshot.clip_pct - 0.1) < 1e-9);
+}
+
+static void
+test_cf32_metrics(void) {
+    float hot[1000] = {0.0f};
+    hot[8] = 0.95f;
+    dsd_input_level_snapshot snapshot;
+    assert(dsd_input_level_metrics_from_cf32(hot, 1000U, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32, &snapshot) == 0);
+    classify(&snapshot);
+    assert(snapshot.status == DSD_INPUT_LEVEL_HOT);
+    assert(snapshot.clip_pct == 0.0);
+
+    float clipped[1000] = {0.0f};
+    clipped[9] = -0.98f;
+    assert(dsd_input_level_metrics_from_cf32(clipped, 1000U, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32, &snapshot) == 0);
+    classify(&snapshot);
+    assert(snapshot.status == DSD_INPUT_LEVEL_CLIPPING);
+    assert(fabs(snapshot.clip_pct - 0.1) < 1e-9);
+}
+
+int
+main(void) {
+    test_cu8_metrics();
+    test_cs16_metrics();
+    test_cf32_metrics();
+    return 0;
+}

--- a/tests/runtime/test_runtime_rtl_stream_metrics_hooks.c
+++ b/tests/runtime/test_runtime_rtl_stream_metrics_hooks.c
@@ -4,6 +4,7 @@
  */
 
 #include <assert.h>
+#include <dsd-neo/core/input_level.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -25,6 +26,7 @@ static int g_snr_gfsk_calls = 0;
 static int g_snr_qpsk_const_calls = 0;
 static int g_p25p1_ber_calls = 0;
 static int g_p25p2_err_calls = 0;
+static int g_input_level_calls = 0;
 
 static int g_p25p1_ok_delta = 0;
 static int g_p25p1_err_delta = 0;
@@ -164,6 +166,21 @@ fake_p25p2_err_update(int slot, int facch_ok_delta, int facch_err_delta, int sac
     g_p25p2_voice_err_delta = voice_err_delta;
 }
 
+static int
+fake_input_level(dsd_input_level_snapshot* out) {
+    g_input_level_calls++;
+    if (out) {
+        out->status = DSD_INPUT_LEVEL_HOT;
+        out->source = DSD_INPUT_LEVEL_SOURCE_RTL_CU8;
+        out->rms_dbfs = -18.0;
+        out->peak_dbfs = -0.5;
+        out->clip_pct = 0.0;
+        out->sample_count = 4096U;
+        out->updated = 12345;
+    }
+    return -9;
+}
+
 int
 main(void) {
     /*
@@ -187,6 +204,19 @@ main(void) {
     assert(channel_profile == 0);
     assert(dsd_rtl_stream_metrics_hook_stream_generation() == 0U);
     assert(dsd_rtl_stream_metrics_hook_stream_active() == 0);
+    dsd_input_level_snapshot input_level = {
+        .status = DSD_INPUT_LEVEL_CLIPPING,
+        .source = DSD_INPUT_LEVEL_SOURCE_RTL_CU8,
+        .rms_dbfs = -1.0,
+        .peak_dbfs = 0.0,
+        .clip_pct = 50.0,
+        .sample_count = 99U,
+        .updated = 77,
+    };
+    assert(dsd_rtl_stream_metrics_hook_input_level(&input_level) == 0);
+    assert(input_level.status == DSD_INPUT_LEVEL_UNKNOWN);
+    assert(input_level.source == DSD_INPUT_LEVEL_SOURCE_UNKNOWN);
+    assert(input_level.sample_count == 0U);
     assert(dsd_rtl_stream_metrics_hook_set_symbol_profile(2400, 2, 1) == 0);
 
     int cqpsk = -1;
@@ -236,6 +266,7 @@ main(void) {
     g_snr_qpsk_const_calls = 0;
     g_p25p1_ber_calls = 0;
     g_p25p2_err_calls = 0;
+    g_input_level_calls = 0;
     g_set_symbol_rate_hz = 0;
     g_set_symbol_levels = 0;
     g_set_symbol_channel_profile = 0;
@@ -257,6 +288,7 @@ main(void) {
     hooks.snr_qpsk_const_db = fake_snr_qpsk_const_db;
     hooks.p25p1_ber_update = fake_p25p1_ber_update;
     hooks.p25p2_err_update = fake_p25p2_err_update;
+    hooks.input_level = fake_input_level;
     dsd_rtl_stream_metrics_hooks_set(&hooks);
 
     assert(dsd_rtl_stream_metrics_hook_output_rate_hz() == 24000U);
@@ -276,6 +308,13 @@ main(void) {
     assert(g_stream_generation_calls == 1);
     assert(dsd_rtl_stream_metrics_hook_stream_active() == 1);
     assert(g_stream_active_calls == 1);
+    input_level = (dsd_input_level_snapshot){0};
+    assert(dsd_rtl_stream_metrics_hook_input_level(&input_level) == -9);
+    assert(g_input_level_calls == 1);
+    assert(input_level.status == DSD_INPUT_LEVEL_HOT);
+    assert(input_level.source == DSD_INPUT_LEVEL_SOURCE_RTL_CU8);
+    assert(input_level.sample_count == 4096U);
+    assert(input_level.updated == 12345);
 
     assert(dsd_rtl_stream_metrics_hook_set_symbol_profile(6000, 4, 5) == 6);
     assert(g_set_symbol_profile_calls == 1);

--- a/tests/ui/test_ui_dsp_display_radio_compile.c
+++ b/tests/ui/test_ui_dsp_display_radio_compile.c
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "ncurses_dsp_status_format.h"
+
+#include <stddef.h>
+
+#ifdef USE_RTLSDR
+#error "This regression guard must compile the DSP panel with USE_RADIO only."
+#endif
+
+#ifndef USE_RADIO
+#error "This regression guard must compile the DSP panel with USE_RADIO."
+#endif
+
+int
+ui_dsp_format_squelch_status(double channel_power, double squelch_power, char* out, size_t out_size) {
+    (void)channel_power;
+    (void)squelch_power;
+    (void)out;
+    (void)out_size;
+    return -1;
+}
+
+int
+main(void) {
+    return 0;
+}

--- a/tests/ui/test_ui_dsp_squelch_status.c
+++ b/tests/ui/test_ui_dsp_squelch_status.c
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/power.h>
+#include <string.h>
+#include "ncurses_dsp_status_format.h"
+
+static void
+test_squelch_status_open(void) {
+    char out[64];
+    assert(ui_dsp_format_squelch_status(dB_to_pwr(-28.4), dB_to_pwr(-120.0), out, sizeof(out)) == 0);
+    assert(strcmp(out, "Open ch:-28.4 dB sql:-120.0 dB") == 0);
+}
+
+static void
+test_squelch_status_closed(void) {
+    char out[64];
+    assert(ui_dsp_format_squelch_status(dB_to_pwr(-80.0), dB_to_pwr(-40.0), out, sizeof(out)) == 0);
+    assert(strcmp(out, "Closed ch:-80.0 dB sql:-40.0 dB") == 0);
+}
+
+static void
+test_squelch_status_open_when_disabled(void) {
+    char out[64];
+    assert(ui_dsp_format_squelch_status(0.0, 0.0, out, sizeof(out)) == 0);
+    assert(strcmp(out, "Open ch:-120.0 dB sql:-120.0 dB") == 0);
+}
+
+static void
+test_squelch_status_open_at_threshold(void) {
+    char out[64];
+    assert(ui_dsp_format_squelch_status(dB_to_pwr(-40.0), dB_to_pwr(-40.0), out, sizeof(out)) == 0);
+    assert(strcmp(out, "Open ch:-40.0 dB sql:-40.0 dB") == 0);
+}
+
+static void
+test_squelch_status_rejects_missing_output(void) {
+    assert(ui_dsp_format_squelch_status(dB_to_pwr(-20.0), dB_to_pwr(-30.0), NULL, 0U) != 0);
+}
+
+int
+main(void) {
+    test_squelch_status_open();
+    test_squelch_status_closed();
+    test_squelch_status_open_when_disabled();
+    test_squelch_status_open_at_threshold();
+    test_squelch_status_rejects_missing_output();
+    return 0;
+}

--- a/tests/ui/test_ui_snapshot_event_history.c
+++ b/tests/ui/test_ui_snapshot_event_history.c
@@ -4,6 +4,7 @@
  */
 
 #include <assert.h>
+#include <dsd-neo/core/input_level.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/talkgroup_policy.h>
@@ -38,6 +39,12 @@ assert_render_fields(const dsd_state* snap) {
     assert(lookup.match == DSD_TG_POLICY_MATCH_EXACT);
     assert(strcmp(lookup.entry.name, "DISPATCH") == 0);
     assert(strcmp(snap->ui_msg, "snapshot ready") == 0);
+    assert(snap->input_level.status == DSD_INPUT_LEVEL_CLIPPING);
+    assert(snap->input_level.source == DSD_INPUT_LEVEL_SOURCE_RTL_CU8);
+    assert(snap->input_level.sample_count == 2048U);
+    assert(snap->input_level_last_toast_time == 1234);
+    assert(snap->input_level_last_toast_status == DSD_INPUT_LEVEL_CLIPPING);
+    assert(snap->input_level_last_toast_source == DSD_INPUT_LEVEL_SOURCE_RTL_CU8);
     assert(snap->rkey_array[7] == 0ULL);
 }
 
@@ -71,6 +78,16 @@ main(void) {
     assert(dsd_tg_policy_make_exact_entry(321U, "A", "DISPATCH", DSD_TG_POLICY_SOURCE_IMPORTED, &entry) == 0);
     assert(dsd_tg_policy_append_exact(state, &entry) == 0);
     DSD_SNPRINTF(state->ui_msg, sizeof(state->ui_msg), "%s", "snapshot ready");
+    state->input_level.status = DSD_INPUT_LEVEL_CLIPPING;
+    state->input_level.source = DSD_INPUT_LEVEL_SOURCE_RTL_CU8;
+    state->input_level.rms_dbfs = -12.5;
+    state->input_level.peak_dbfs = -0.2;
+    state->input_level.clip_pct = 0.5;
+    state->input_level.sample_count = 2048U;
+    state->input_level.updated = 1200;
+    state->input_level_last_toast_time = 1234;
+    state->input_level_last_toast_status = DSD_INPUT_LEVEL_CLIPPING;
+    state->input_level_last_toast_source = DSD_INPUT_LEVEL_SOURCE_RTL_CU8;
     state->rkey_array[7] = 0x12345678ULL;
     assert(dsd_trunk_cc_candidates_add(state, 851006250L, 1) == 1);
     assert(dsd_trunk_cc_candidates_add(state, 852006250L, 1) == 1);


### PR DESCRIPTION
## Summary

- 

## Review

- [ ] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [ ] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / none.
- [ ] Outside review was requested when available, or unavailability is documented.
- [ ] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [ ] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [ ] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [ ] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [ ] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [ ] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [ ] `cmake --build --preset dev-debug -j`
- [ ] `ctest --preset dev-debug --output-on-failure`
- [ ] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes
- [ ] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes

## Risk

- Security/dependency impact:
- CLI/UI behavior impact:
- Compatibility or packaging impact:
