### PR TITLE
security: add show-keys opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ Quick examples
   - `tools/cmake_format_check.sh` (CMake formatting with gersemi; use `--fix` to rewrite).
   - `tools/gitleaks.sh` (secret scanning with SARIF output for GitHub code scanning).
 - Security guardrails:
-  - `tools/check_secret_redaction.sh` (blocks formatted key/keystream output without `DSD_SECRET_REDACTED`).
+  - `tools/check_secret_redaction.sh` (blocks formatted key/keystream output outside the redaction formatter helpers).
   - `tools/check_workflow_git_pins.sh` (blocks floating public GitHub source checkouts in workflows and CI helper scripts).
   - `tools/check_workflow_download_pins.sh` (blocks mutable release helper downloads and digestless AppImage container refs).
   - `tools/check_release_hardening.sh` (verifies Linux ELF PIE/RELRO/BIND_NOW, macOS Mach-O PIE/@rpath, and hardening compile flags).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,7 +18,7 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 - RTL retune control: `--rtl-udp-control <port>` binds to loopback by default; use
   `--rtl-udp-control-bind <ipv4>` for explicit remote exposure (see `docs/udp-control.md`)
 - M17 encode: `-fZ -M M17:CAN:SRC:DST[:RATE[:VOX]]`, `-fP`, `-fB`
-- Keys: `-b`, `-H '<hex...>'`, `-R`, `-1`, `-2`, `-! '<hex...>'`, `-@ '<hex...>'`, `-5 '<hex...>'`, `-9`, `-A`, `-S bits:hex[:offset[:step]]`, `-k keys.csv`, `-K keys_hex.csv`, `--dmr-baofeng-pc5 <hex>`, `--dmr-csi-ee72 <hex>`, `--dmr-vertex-ks-csv <file>`, `--dmr-force-algid <hex>`, `-4`, `-0`, `-3`
+- Keys: `-b`, `-H '<hex...>'`, `-R`, `-1`, `-2`, `-! '<hex...>'`, `-@ '<hex...>'`, `-5 '<hex...>'`, `-9`, `-A`, `-S bits:hex[:offset[:step]]`, `-k keys.csv`, `-K keys_hex.csv`, `--dmr-baofeng-pc5 <hex>`, `--dmr-csi-ee72 <hex>`, `--dmr-vertex-ks-csv <file>`, `--dmr-force-algid <hex>`, `--show-keys`, `-4`, `-0`, `-3`
 - Tools: `--calc-lcn file`, `--calc-cc-freq 451.2375`, `--calc-cc-lcn 50`, `--calc-step 12500`, `--calc-start-lcn 1`, `--auto-ppm`, `--auto-ppm-snr 6`, `--rtltcp-autotune`, `--rdio-mode off|dirwatch|api|both`
 
 ## Quick Start
@@ -387,6 +387,9 @@ Examples
 - `dsd-neo -fP -M M17:9:DSD-NEO:ARANCORMO -6 m17pkt.wav -8`
 
 ## Keys & Privacy (advanced)
+
+By default, DSD-neo redacts radio keys and keystream material in logs and terminal status. Add `--show-keys` to reveal
+those values for the current CLI run only.
 
 - Basic Privacy key (decimal): `-b <dec>`
 - Hytera 10/32/64‑char BP or AES‑128/256 key (hex, groups of 16): `-H '<hex…>'`

--- a/docs/code-quality-guardrails.md
+++ b/docs/code-quality-guardrails.md
@@ -49,6 +49,6 @@ The repository intentionally blocks or flags patterns that are easy to reintrodu
 - Keep workflow scripts defensive: pass untrusted context through environment variables or action inputs, not direct expression interpolation in `run:` blocks.
 - Keep vcpkg overlay ports pinned by immutable `REF` and `SHA512`.
 - Keep release helper downloads immutable: build AppImage helper tools from pinned source, pin container images by digest, and verify executable installers by SHA256 before running them.
-- Do not print radio keys, keystreams, API keys, or derived key material in logs, terminal UI, or test diagnostics. Use `DSD_SECRET_REDACTED` for successful secret-load messages.
+- Do not print radio keys, keystreams, API keys, or derived key material in logs, terminal UI, or test diagnostics except for intentional radio key/keystream reveal through the CLI-only `--show-keys` flag. Successful radio key/keystream messages must use the redaction formatter helpers; API keys and derived key material remain non-printable.
 - Keep CI GitHub source dependencies pinned through `tools/ci-dependency-pins.env` and `tools/fetch-pinned-git.sh`.
 - Keep analyzer and linter output actionable. Prefer fixing root causes over widening suppressions.

--- a/docs/security-requirements.md
+++ b/docs/security-requirements.md
@@ -119,7 +119,8 @@ The project applies the following controls:
   and MSVC targets, with release verification in CI
 - exclusive private sibling temp files for atomic user config, IQ metadata, and
   Rdio sidecar replacement
-- redaction guardrails for key/keystream output paths
+- redaction guardrails for key/keystream output paths, with intentional radio key/keystream reveal limited to the CLI-only
+  `--show-keys` flag and shared redaction formatter helpers
 - sanitizer CI for AddressSanitizer and UndefinedBehaviorSanitizer
 - ThreadSanitizer preset for threading-sensitive local validation
 - libFuzzer smoke targets for selected file, metadata, config, and protocol

--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -197,6 +197,7 @@ struct dsd_opts {
     uint8_t show_p25_affiliations;       //show P25 Affiliations (RID list) (0=hidden)
     uint8_t show_p25_group_affiliations; //show P25 Group Affiliation (RID↔TG) (0=hidden)
     uint8_t show_p25_callsign_decode;    //show P25 callsign decode from WACN/SysID (0=hidden)
+    uint8_t show_keys;                   //show radio key/keystream material in CLI/status output (0=redacted)
     /** Enable status-symbol-based P25 AFC suppression (0=advisory only [default], 1=enforce). */
     int p25_afc_status_gate_enable;
 

--- a/include/dsd-neo/core/secret_redaction.h
+++ b/include/dsd-neo/core/secret_redaction.h
@@ -3,6 +3,94 @@
 #ifndef DSD_NEO_CORE_SECRET_REDACTION_H
 #define DSD_NEO_CORE_SECRET_REDACTION_H
 
+#include <dsd-neo/core/safe_api.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
 #define DSD_SECRET_REDACTED "[redacted]"
+
+static inline const char*
+dsd_secret_format_decimal(char* out, size_t out_size, int show_keys, unsigned long long value, unsigned width) {
+    if (show_keys == 0 || out == NULL || out_size == 0U) {
+        return DSD_SECRET_REDACTED;
+    }
+    if (width > 0U) {
+        (void)DSD_SNPRINTF(out, out_size, "%0*llu", (int)width, value);
+    } else {
+        (void)DSD_SNPRINTF(out, out_size, "%llu", value);
+    }
+    return out;
+}
+
+static inline const char*
+dsd_secret_format_hex(char* out, size_t out_size, int show_keys, unsigned long long value, unsigned width,
+                      int with_prefix) {
+    if (show_keys == 0 || out == NULL || out_size == 0U) {
+        return DSD_SECRET_REDACTED;
+    }
+    if (with_prefix != 0) {
+        (void)DSD_SNPRINTF(out, out_size, "0x%0*llX", (int)width, value);
+    } else {
+        (void)DSD_SNPRINTF(out, out_size, "%0*llX", (int)width, value);
+    }
+    return out;
+}
+
+static inline const char*
+dsd_secret_format_u64_segments(char* out, size_t out_size, int show_keys, const unsigned long long* segments,
+                               size_t segment_count) {
+    if (show_keys == 0 || out == NULL || out_size == 0U || segments == NULL || segment_count == 0U) {
+        return DSD_SECRET_REDACTED;
+    }
+
+    size_t pos = 0U;
+    out[0] = '\0';
+    for (size_t i = 0U; i < segment_count; i++) {
+        int n = DSD_SNPRINTF(out + pos, out_size - pos, (i == 0U) ? "%016llX" : " %016llX", segments[i]);
+        if (n < 0) {
+            out[0] = '\0';
+            return out;
+        }
+        if ((size_t)n >= out_size - pos) {
+            out[out_size - 1U] = '\0';
+            return out;
+        }
+        pos += (size_t)n;
+    }
+    return out;
+}
+
+static inline const char*
+dsd_secret_format_byte_hex(char* out, size_t out_size, int show_keys, const uint8_t* bytes, size_t byte_count) {
+    if (show_keys == 0 || out == NULL || out_size == 0U || bytes == NULL) {
+        return DSD_SECRET_REDACTED;
+    }
+
+    size_t pos = 0U;
+    out[0] = '\0';
+    for (size_t i = 0U; i < byte_count; i++) {
+        int n = DSD_SNPRINTF(out + pos, out_size - pos, "%02X", bytes[i]);
+        if (n < 0) {
+            out[0] = '\0';
+            return out;
+        }
+        if ((size_t)n >= out_size - pos) {
+            out[out_size - 1U] = '\0';
+            return out;
+        }
+        pos += (size_t)n;
+    }
+    return out;
+}
+
+static inline const char*
+dsd_secret_format_string(char* out, size_t out_size, int show_keys, const char* value) {
+    if (show_keys == 0 || out == NULL || out_size == 0U || value == NULL) {
+        return DSD_SECRET_REDACTED;
+    }
+    (void)DSD_SNPRINTF(out, out_size, "%s", value);
+    return out;
+}
 
 #endif /* DSD_NEO_CORE_SECRET_REDACTION_H */

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -242,6 +242,7 @@ struct dsd_state {
     unsigned long long int K2;
     unsigned long long int K3;
     unsigned long long int K4;
+    uint8_t hytera_key_segments;
     unsigned long long int R;
     unsigned long long int RR;
     unsigned long long int H;

--- a/include/dsd-neo/crypto/dmr_keystream.h
+++ b/include/dsd-neo/crypto/dmr_keystream.h
@@ -22,20 +22,20 @@
 extern "C" {
 #endif
 
-void tyt_ep_aes_keystream_creation(dsd_state* state, char* input);
-void tyt_ap_pc4_keystream_creation(dsd_state* state, const char* input);
-void retevis_rc2_keystream_creation(dsd_state* state, const char* input);
+void tyt_ep_aes_keystream_creation(dsd_state* state, const char* input, int show_keys);
+void tyt_ap_pc4_keystream_creation(dsd_state* state, const char* input, int show_keys);
+void retevis_rc2_keystream_creation(dsd_state* state, const char* input, int show_keys);
 int retevis_rc2_apply_frame49(dsd_state* state, char ambe_d[49]);
-int baofeng_ap_pc5_keystream_creation(dsd_state* state, const char* input);
+int baofeng_ap_pc5_keystream_creation(dsd_state* state, const char* input, int show_keys);
 int baofeng_pc5_apply_frame49(const dsd_state* state, char ambe_d[49]);
-int connect_systems_ee72_key_creation(dsd_state* state, const char* input);
-void ken_dmr_scrambler_keystream_creation(dsd_state* state, char* input);
+int connect_systems_ee72_key_creation(dsd_state* state, const char* input, int show_keys);
+void ken_dmr_scrambler_keystream_creation(dsd_state* state, char* input, int show_keys);
 int ken_dmr_scrambler_apply_frame49(dsd_state* state, int slot, char ambe_d[49]);
-void anytone_bp_keystream_creation(dsd_state* state, char* input);
+void anytone_bp_keystream_creation(dsd_state* state, char* input, int show_keys);
 int anytone_bp_apply_frame49(dsd_state* state, int slot, char ambe_d[49]);
 int dmr_parse_static_keystream_spec(const char* input, uint8_t out_bits[882], int* out_mod, int* out_frame_mode,
                                     int* out_frame_off, int* out_frame_step, char* err, size_t err_cap);
-void straight_mod_xor_keystream_creation(dsd_state* state, const char* input);
+void straight_mod_xor_keystream_creation(dsd_state* state, const char* input, int show_keys);
 void straight_mod_xor_apply_frame49(dsd_state* state, int slot, char ambe_d[49]);
 int dmr_ambe49_is_default_silence(const char ambe_d[49]);
 int dmr_ambe49_has_zero_tail(const char ambe_d[49]);

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -919,7 +919,18 @@ csvKeyImportDec(const dsd_opts* opts, dsd_state* state) //multi-key support
             field = dsd_strtok_r(NULL, ",", &saveptr);
             field_count++;
         }
-        LOG_INFO("Key [%03lld] loaded: %s", keynumber, DSD_SECRET_REDACTED);
+        char key_id_text[32];
+        (void)DSD_SNPRINTF(key_id_text, sizeof key_id_text, "%03lld", keynumber);
+        char key_text[16];
+        if (opts->show_keys != 0) {
+            LOG_INFO("Key [%s] [%s]", key_id_text,
+                     dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, state->rkey_array[keynumber],
+                                               5U));
+        } else {
+            LOG_INFO("Key [%s] loaded: %s", key_id_text,
+                     dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, state->rkey_array[keynumber],
+                                               5U));
+        }
         LOG_INFO("\n");
     }
     fclose(fp);
@@ -944,21 +955,37 @@ csv_key_import_hex_store_value(dsd_state* state, unsigned long long keynumber, u
 }
 
 static void
-csv_key_import_hex_log_offsets(const dsd_state* state, unsigned long long keynumber) {
-    unsigned long long out1 = 0, out2 = 0, out3 = 0;
-    size_t idx1 = 0, idx2 = 0, idx3 = 0;
-    if (csv_rkey_index(keynumber, 0x101ULL, &idx1)) {
-        out1 = state->rkey_array[idx1];
+csv_key_import_hex_log_offsets(const dsd_state* state, unsigned long long keynumber, int show_keys) {
+    static const unsigned long long offsets[] = {0x101ULL, 0x201ULL, 0x301ULL};
+    unsigned long long values[3] = {0ULL, 0ULL, 0ULL};
+    unsigned char loaded[3] = {0U, 0U, 0U};
+    int any_loaded = 0;
+
+    for (size_t i = 0U; i < sizeof(offsets) / sizeof(offsets[0]); i++) {
+        size_t idx = 0U;
+        if (csv_rkey_index(keynumber, offsets[i], &idx) && state->rkey_array_loaded[idx] != 0U) {
+            values[i] = state->rkey_array[idx];
+            loaded[i] = 1U;
+            any_loaded = 1;
+        }
     }
-    if (csv_rkey_index(keynumber, 0x201ULL, &idx2)) {
-        out2 = state->rkey_array[idx2];
+
+    if (any_loaded == 0) {
+        return;
     }
-    if (csv_rkey_index(keynumber, 0x301ULL, &idx3)) {
-        out3 = state->rkey_array[idx3];
+
+    if (show_keys == 0) {
+        char seg[17];
+        LOG_INFO(" [additional key segments loaded: %s]",
+                 dsd_secret_format_hex(seg, sizeof seg, show_keys, 0ULL, 16U, 0));
+        return;
     }
-    // cppcheck-suppress knownConditionTrueFalse
-    if (out1 != 0 || out2 != 0 || out3 != 0) {
-        LOG_INFO(" [additional key segments loaded: %s]", DSD_SECRET_REDACTED);
+
+    for (size_t i = 0U; i < sizeof(values) / sizeof(values[0]); i++) {
+        if (loaded[i] != 0U) {
+            char seg[17];
+            LOG_INFO(" [%s]", dsd_secret_format_hex(seg, sizeof seg, show_keys, values[i], 16U, 0));
+        }
     }
 }
 
@@ -1105,11 +1132,24 @@ csvKeyImportHex(const dsd_opts* opts, dsd_state* state) //key import for hex key
         unsigned long long keynumber = csv_key_import_hex_parse_row(state, buffer);
         size_t key_index = 0;
         if (csv_rkey_index(keynumber, 0ULL, &key_index)) {
-            LOG_INFO("Key [%04llX] loaded: %s", keynumber, DSD_SECRET_REDACTED);
+            char key_id_text[32];
+            (void)DSD_SNPRINTF(key_id_text, sizeof key_id_text, "%04llX", keynumber);
+            char key_text[17];
+            if (opts->show_keys != 0) {
+                LOG_INFO("Key [%s] [%s]", key_id_text,
+                         dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->rkey_array[key_index],
+                                               16U, 0));
+            } else {
+                LOG_INFO("Key [%s] loaded: %s", key_id_text,
+                         dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->rkey_array[key_index],
+                                               16U, 0));
+            }
             // If longer key is loaded (or clash with the 0x101, 0x201, 0x301 offset), then print the full key listing.
-            csv_key_import_hex_log_offsets(state, keynumber);
+            csv_key_import_hex_log_offsets(state, keynumber, opts->show_keys);
         } else {
-            LOG_INFO("Key [%04llX] [out-of-range]", keynumber);
+            char key_id_text[32];
+            (void)DSD_SNPRINTF(key_id_text, sizeof key_id_text, "%04llX", keynumber);
+            LOG_INFO("Key [%s] [out-of-range]", key_id_text);
         }
 
         LOG_INFO("\n");

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -65,6 +65,7 @@ init_opts_display_and_audio_defaults(dsd_opts* opts) {
     opts->show_p25_iden_plan = 0;         // hide P25 IDEN Plan by default
     opts->show_p25_cc_candidates = 0;     // hide P25 CC Candidates by default
     opts->show_p25_callsign_decode = 0;   // hide P25 callsign decode by default (many false positives)
+    opts->show_keys = 0;                  // redact radio keys/keystreams unless CLI explicitly opts in
     opts->p25_afc_status_gate_enable = 0; // advisory by default; status-derived direction is not always reliable
     opts->show_channels = 0;              // hide Channels section by default
     opts->symboltiming = 0;
@@ -739,6 +740,7 @@ init_state_protocol_defaults_a(dsd_state* state) {
     state->K2 = 0;
     state->K3 = 0;
     state->K4 = 0;
+    state->hytera_key_segments = 0U;
     state->M = 0; // Force key priority over settings from fid/so
 
     state->dmr_stereo = 0; //1, or 0?

--- a/src/core/vocoder/dsd_mbe.c
+++ b/src/core/vocoder/dsd_mbe.c
@@ -945,6 +945,8 @@ mbeslot_left_autoload_keys(dsd_opts* opts, dsd_state* state) {
         if (state->rkey_array[hash] != 0) {
             state->K = state->rkey_array[hash] & 0xFF;                     //doesn't exceed 255
             state->K1 = state->H = state->rkey_array[hash] & 0xFFFFFFFFFF; //doesn't exceed 40-bit limit
+            state->K2 = state->K3 = state->K4 = 0ULL;
+            state->hytera_key_segments = 1U;
             opts->dmr_mute_encL = 0;
         }
     }
@@ -957,6 +959,8 @@ mbeslot_right_autoload_keys(dsd_opts* opts, dsd_state* state) {
         if (state->rkey_array[hash] != 0) {
             state->K = state->rkey_array[hash] & 0xFF;
             state->K1 = state->H = state->rkey_array[hash] & 0xFFFFFFFFFF;
+            state->K2 = state->K3 = state->K4 = 0ULL;
+            state->hytera_key_segments = 1U;
             opts->dmr_mute_encR = 0;
         }
     }

--- a/src/crypto/crypt-csi72.c
+++ b/src/crypto/crypt-csi72.c
@@ -5,6 +5,7 @@
 
 #include <ctype.h>
 #include <dsd-neo/core/bit_packing.h>
+#include <dsd-neo/core/secret_redaction.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/crypto/dmr_keystream.h>
 #include <dsd-neo/protocol/dmr/dmr_const.h>
@@ -85,7 +86,7 @@ csi_parse_hex_bytes(const char* hex, size_t nhex, uint8_t* out, size_t out_len) 
 }
 
 int
-connect_systems_ee72_key_creation(dsd_state* state, const char* input) {
+connect_systems_ee72_key_creation(dsd_state* state, const char* input, int show_keys) {
     if (!state || !input) {
         return -1;
     }
@@ -106,7 +107,9 @@ connect_systems_ee72_key_creation(dsd_state* state, const char* input) {
 
     DSD_MEMCPY(state->csi_ee_key, key, sizeof(key));
     state->csi_ee = 1;
-    DSD_FPRINTF(stderr, "DMR Connect Systems EE72 72-bit key with forced application\n");
+    char key_text[19];
+    DSD_FPRINTF(stderr, "DMR Connect Systems EE72 72-bit key with forced application: %s\n",
+                dsd_secret_format_byte_hex(key_text, sizeof key_text, show_keys, key, sizeof(key)));
     return 0;
 }
 

--- a/src/crypto/crypt-etc.c
+++ b/src/crypto/crypt-etc.c
@@ -358,7 +358,7 @@ dmr_parse_static_keystream_spec(const char* input, uint8_t out_bits[882], int* o
 }
 
 void
-ken_dmr_scrambler_keystream_creation(dsd_state* state, char* input) {
+ken_dmr_scrambler_keystream_creation(dsd_state* state, char* input, int show_keys) {
     /*
   SLOT 1 Protected LC  FLCO=0x00 FID=0x20 <--this link appears to indicate scrambler usage from Kenwood on DMR
   DMR PDU Payload [80][20][40][00][00][01][00][00][01] SB: 00000000000 - 000;
@@ -378,7 +378,9 @@ ken_dmr_scrambler_keystream_creation(dsd_state* state, char* input) {
             lfsr = (int)parsed;
         }
     }
-    DSD_FPRINTF(stderr, "DMR Kenwood 15-bit scrambler key loaded with forced application: %s\n", DSD_SECRET_REDACTED);
+    char key_text[16];
+    DSD_FPRINTF(stderr, "DMR Kenwood 15-bit scrambler key loaded with forced application: %s\n",
+                dsd_secret_format_decimal(key_text, sizeof key_text, show_keys, (unsigned long long)lfsr, 5U));
 
     for (int i = 0; i < 882; i++) {
         state->static_ks_bits[0][i] = lfsr & 0x1;
@@ -391,7 +393,7 @@ ken_dmr_scrambler_keystream_creation(dsd_state* state, char* input) {
 }
 
 void
-anytone_bp_keystream_creation(dsd_state* state, char* input) {
+anytone_bp_keystream_creation(dsd_state* state, char* input, int show_keys) {
     uint16_t key = 0;
     uint16_t kperm = 0;
 
@@ -426,12 +428,14 @@ anytone_bp_keystream_creation(dsd_state* state, char* input) {
         state->static_ks_bits[1][i] = (kperm >> (15 - i)) & 1;
     }
 
-    DSD_FPRINTF(stderr, "DMR Anytone Basic 16-bit key loaded with forced application: %s\n", DSD_SECRET_REDACTED);
+    char key_text[16];
+    DSD_FPRINTF(stderr, "DMR Anytone Basic 16-bit key loaded with forced application: %s\n",
+                dsd_secret_format_hex(key_text, sizeof key_text, show_keys, key, 4U, 1));
     state->any_bp = 1;
 }
 
 void
-straight_mod_xor_keystream_creation(dsd_state* state, const char* input) {
+straight_mod_xor_keystream_creation(dsd_state* state, const char* input, int show_keys) {
     if (state == NULL || input == NULL) {
         return;
     }
@@ -465,7 +469,29 @@ straight_mod_xor_keystream_creation(dsd_state* state, const char* input) {
         state->static_ks_bits[1][i] = parsed_bits[i];
     }
 
-    DSD_FPRINTF(stderr, "AMBE Straight XOR %d-bit keystream loaded: %s", parsed_mod, DSD_SECRET_REDACTED);
+    uint8_t packed_ks[111];
+    DSD_MEMSET(packed_ks, 0, sizeof(packed_ks));
+    int unpack_len = parsed_mod / 8;
+    if ((parsed_mod % 8) != 0) {
+        unpack_len++;
+    }
+    for (int byte_idx = 0; byte_idx < unpack_len; byte_idx++) {
+        uint8_t out = 0U;
+        for (int bit = 0; bit < 8; bit++) {
+            out <<= 1U;
+            int bi = (byte_idx * 8) + bit;
+            if (bi < parsed_mod) {
+                out |= (uint8_t)(parsed_bits[bi] & 1U);
+            }
+        }
+        packed_ks[byte_idx] = out;
+    }
+
+    char ks_text[223];
+    char mod_text[16];
+    (void)DSD_SNPRINTF(mod_text, sizeof mod_text, "%d", parsed_mod);
+    DSD_FPRINTF(stderr, "AMBE Straight XOR %s-bit keystream loaded: %s", mod_text,
+                dsd_secret_format_byte_hex(ks_text, sizeof ks_text, show_keys, packed_ks, (size_t)unpack_len));
     if (parsed_frame_mode == 1) {
         DSD_FPRINTF(stderr, " with Frame Align (offset=%d, step=%d)", parsed_frame_off, parsed_frame_step);
     }

--- a/src/crypto/crypt-pc5.c
+++ b/src/crypto/crypt-pc5.c
@@ -4,6 +4,7 @@
  */
 
 #include <ctype.h>
+#include <dsd-neo/core/secret_redaction.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/crypto/dmr_keystream.h>
 #include <dsd-neo/crypto/pc5.h>
@@ -528,7 +529,7 @@ baofeng_pc5_apply_frame49(const dsd_state* state, char ambe_d[49]) {
 }
 
 int
-baofeng_ap_pc5_keystream_creation(dsd_state* state, const char* input) {
+baofeng_ap_pc5_keystream_creation(dsd_state* state, const char* input, int show_keys) {
     if (!state || !input) {
         return -1;
     }
@@ -554,7 +555,9 @@ baofeng_ap_pc5_keystream_creation(dsd_state* state, const char* input) {
         }
         create_keys_pc5(&ctxpc5, reversed, sizeof(reversed));
         ctxpc5.rounds = PC5_NBROUND;
-        DSD_FPRINTF(stderr, "DMR Baofeng AP (PC5) 128-bit key with forced application\n");
+        char key_text[33];
+        DSD_FPRINTF(stderr, "DMR Baofeng AP (PC5) 128-bit key with forced application: %s\n",
+                    dsd_secret_format_byte_hex(key_text, sizeof key_text, show_keys, raw, sizeof(raw)));
         state->baofeng_ap = 1;
         return 0;
     }
@@ -567,7 +570,9 @@ baofeng_ap_pc5_keystream_creation(dsd_state* state, const char* input) {
          */
         create_keys_pc5(&ctxpc5, (const unsigned char*)hex, nhex);
         ctxpc5.rounds = PC5_NBROUND;
-        DSD_FPRINTF(stderr, "DMR Baofeng AP (PC5) 256-bit key with forced application\n");
+        char key_text[65];
+        DSD_FPRINTF(stderr, "DMR Baofeng AP (PC5) 256-bit key with forced application: %s\n",
+                    dsd_secret_format_string(key_text, sizeof key_text, show_keys, hex));
         state->baofeng_ap = 1;
         return 0;
     }

--- a/src/crypto/crypt-rc2.c
+++ b/src/crypto/crypt-rc2.c
@@ -341,7 +341,7 @@ retevis_rc2_apply_frame49(dsd_state* state, char ambe_d[49]) {
 
 /* Key creation for Retevis AP */
 void
-retevis_rc2_keystream_creation(dsd_state* state, const char* input) {
+retevis_rc2_keystream_creation(dsd_state* state, const char* input, int show_keys) {
     if (state == NULL || input == NULL) {
         return;
     }
@@ -360,8 +360,12 @@ retevis_rc2_keystream_creation(dsd_state* state, const char* input) {
     DSD_MEMSET(&rc2_ctx, 0, sizeof(rc2_ctx));
     if (parsed.nhex == 64U) {
         create_keys_rc2(&rc2_ctx, parsed.hex, parsed.nhex);
+        uint8_t key_bytes[32];
+        char key_text[65];
+        DSD_MEMSET(key_bytes, 0, sizeof(key_bytes));
+        (void)dsd_vendor_ap_key_hex_to_bytes(parsed.hex, parsed.nhex, key_bytes, sizeof(key_bytes));
         DSD_FPRINTF(stderr, "DMR RETEVIS AP (RC2) 256-bit key loaded with forced application: %s\n",
-                    DSD_SECRET_REDACTED);
+                    dsd_secret_format_byte_hex(key_text, sizeof key_text, show_keys, key_bytes, sizeof(key_bytes)));
     } else {
         unsigned char key1[16];
         DSD_MEMSET(key1, 0, sizeof(key1));
@@ -379,8 +383,9 @@ retevis_rc2_keystream_creation(dsd_state* state, const char* input) {
             key2[i] = key1[15 - i];
         }
         create_keys_rc2(&rc2_ctx, key2, 16);
+        char key_text[33];
         DSD_FPRINTF(stderr, "DMR RETEVIS AP (RC2) 128-bit key loaded with forced application: %s\n",
-                    DSD_SECRET_REDACTED);
+                    dsd_secret_format_byte_hex(key_text, sizeof key_text, show_keys, key1, sizeof(key1)));
     }
 
     // Store context in DSD state

--- a/src/crypto/crypt-tyt.c
+++ b/src/crypto/crypt-tyt.c
@@ -195,7 +195,7 @@ tyt16_ambe2_codeword_keystream(const dsd_state* state, char ambe_fr[4][24], int 
 }
 
 void
-tyt_ap_pc4_keystream_creation(dsd_state* state, const char* input) {
+tyt_ap_pc4_keystream_creation(dsd_state* state, const char* input, int show_keys) {
     if (state == NULL || input == NULL) {
         return;
     }
@@ -212,7 +212,12 @@ tyt_ap_pc4_keystream_creation(dsd_state* state, const char* input) {
         create_keys(&g_pc4_context, parsed.hex, parsed.nhex);
         g_pc4_context.rounds = nbround;
 
-        DSD_FPRINTF(stderr, "DMR TYT AP (PC4) 256-bit key loaded with forced application: %s\n", DSD_SECRET_REDACTED);
+        uint8_t key_bytes[32];
+        char key_text[65];
+        DSD_MEMSET(key_bytes, 0, sizeof(key_bytes));
+        (void)dsd_vendor_ap_key_hex_to_bytes(parsed.hex, parsed.nhex, key_bytes, sizeof(key_bytes));
+        DSD_FPRINTF(stderr, "DMR TYT AP (PC4) 256-bit key loaded with forced application: %s\n",
+                    dsd_secret_format_byte_hex(key_text, sizeof key_text, show_keys, key_bytes, sizeof(key_bytes)));
     } else {
         unsigned char key1[16];
         DSD_MEMSET(key1, 0, sizeof(key1));
@@ -231,13 +236,15 @@ tyt_ap_pc4_keystream_creation(dsd_state* state, const char* input) {
         create_keys(&g_pc4_context, key2, 16);
         g_pc4_context.rounds = nbround;
 
-        DSD_FPRINTF(stderr, "DMR TYT AP (PC4) 128-bit key loaded with forced application: %s\n", DSD_SECRET_REDACTED);
+        char key_text[33];
+        DSD_FPRINTF(stderr, "DMR TYT AP (PC4) 128-bit key loaded with forced application: %s\n",
+                    dsd_secret_format_byte_hex(key_text, sizeof key_text, show_keys, key1, sizeof(key1)));
     }
     state->tyt_ap = 1;
 }
 
 void
-tyt_ep_aes_keystream_creation(dsd_state* state, char* input) {
+tyt_ep_aes_keystream_creation(dsd_state* state, const char* input, int show_keys) {
     char buf[1024];
     DSD_SNPRINTF(buf, sizeof(buf), "%s", input);
 
@@ -299,7 +306,10 @@ tyt_ep_aes_keystream_creation(dsd_state* state, char* input) {
         g_pc4_context.bits[i] = ks_bits[i];
     }
 
-    DSD_FPRINTF(stderr, "DMR TYT EP (AES-128) key loaded with forced application: %s\n", DSD_SECRET_REDACTED);
+    const unsigned long long segments[2] = {K1, K2};
+    char key_text[34];
+    DSD_FPRINTF(stderr, "DMR TYT EP (AES-128) key loaded with forced application: %s\n",
+                dsd_secret_format_u64_segments(key_text, sizeof key_text, show_keys, segments, 2U));
     state->tyt_ep = 1;
 }
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1790,6 +1790,7 @@ no_carrier_unload_keys_if_needed(dsd_state* state) {
     state->K2 = 0;
     state->K3 = 0;
     state->K4 = 0;
+    state->hytera_key_segments = 0U;
     DSD_MEMSET(state->A1, 0, sizeof(state->A1));
     DSD_MEMSET(state->A2, 0, sizeof(state->A2));
     DSD_MEMSET(state->A3, 0, sizeof(state->A3));

--- a/src/protocol/dmr/dmr_block.c
+++ b/src/protocol/dmr/dmr_block.c
@@ -988,15 +988,17 @@ dmr_udt_decoder(dsd_opts* opts, dsd_state* state, const uint8_t* block_bytes, ui
 }
 
 static void DSD_ATTR_USED
-dmr_block_type1_decrypt_pdu(dsd_state* state, uint8_t slot, int blocks, uint8_t block_len, uint8_t* decrypted_pdu) {
+dmr_block_type1_decrypt_pdu(const dsd_opts* opts, dsd_state* state, uint8_t slot, int blocks, uint8_t block_len,
+                            uint8_t* decrypted_pdu) {
 #ifdef DMR_PDU_DECRYPTION
     dmr_block_crypto_ctx ctx;
 
     dmr_block_crypto_load_ctx(state, slot, blocks, block_len, &ctx);
-    dmr_block_crypto_print_info(&ctx);
+    dmr_block_crypto_print_info(&ctx, opts ? opts->show_keys : 0);
 
-    *decrypted_pdu = dmr_block_crypto_decrypt_payload(state, slot, &ctx);
+    *decrypted_pdu = dmr_block_crypto_decrypt_payload(state, slot, &ctx, opts ? opts->show_keys : 0);
 #else
+    UNUSED(opts);
     UNUSED(state);
     UNUSED(slot);
     UNUSED(blocks);
@@ -1302,7 +1304,7 @@ dmr_block_type1_process_payload(dmr_block_assembler_ctx* ctx, int offset) {
     uint8_t decrypted_pdu = enc_check ? 0 : 1;
 
     if (enc_check) {
-        dmr_block_type1_decrypt_pdu(ctx->state, ctx->slot, ctx->blocks, ctx->block_len, &decrypted_pdu);
+        dmr_block_type1_decrypt_pdu(ctx->opts, ctx->state, ctx->slot, ctx->blocks, ctx->block_len, &decrypted_pdu);
     }
     if (enc_check == 1 && decrypted_pdu == 0) {
         dmr_block_type1_handle_encrypted_notice(ctx);

--- a/src/protocol/dmr/dmr_block_crypto.c
+++ b/src/protocol/dmr/dmr_block_crypto.c
@@ -129,8 +129,36 @@ dmr_block_crypto_load_ctx(const dsd_state* state, uint8_t slot, int blocks, uint
     ctx->rc4_iv[8] = (uint8_t)((ctx->mi & 0xFFULL) >> 0U);
 }
 
+static const char*
+dmr_block_crypto_alg_label(int alg) {
+    switch (alg) {
+        case 0: return "Moto BP";
+        case 1: return "RC4";
+        case 2: return "DES";
+        case 4: return "AES128";
+        case 5: return "AES256";
+        case 7: return "VTX STD";
+        default: return NULL;
+    }
+}
+
+static void
+dmr_block_crypto_print_key(const dmr_block_crypto_ctx* ctx, int show_keys) {
+    if ((ctx->alg == 4 || ctx->alg == 5) && ctx->aes_key_loaded == 1) {
+        char key_text[65];
+        const size_t key_bytes = (ctx->alg == 5) ? 32U : 16U;
+        DSD_FPRINTF(stderr, " Key: %s;",
+                    dsd_secret_format_byte_hex(key_text, sizeof key_text, show_keys, ctx->aes_key, key_bytes));
+    } else if (ctx->rkey != 0ULL && ctx->alg != 0) {
+        char key_text[19];
+        const unsigned width = (ctx->alg == 2) ? 16U : 10U;
+        DSD_FPRINTF(stderr, " Key: %s;",
+                    dsd_secret_format_hex(key_text, sizeof key_text, show_keys, ctx->rkey, width, 0));
+    }
+}
+
 void
-dmr_block_crypto_print_info(const dmr_block_crypto_ctx* ctx) {
+dmr_block_crypto_print_info(const dmr_block_crypto_ctx* ctx, int show_keys) {
     if (ctx == NULL) {
         return;
     }
@@ -139,22 +167,11 @@ dmr_block_crypto_print_info(const dmr_block_crypto_ctx* ctx) {
     if (ctx->alg != 0 && ctx->mi != 0ULL) {
         DSD_FPRINTF(stderr, " MI(32): %08llX;", ctx->mi);
     }
-    if (ctx->alg == 0) {
-        DSD_FPRINTF(stderr, " Moto BP;");
-    } else if (ctx->alg == 1) {
-        DSD_FPRINTF(stderr, " RC4;");
-    } else if (ctx->alg == 2) {
-        DSD_FPRINTF(stderr, " DES;");
-    } else if (ctx->alg == 4) {
-        DSD_FPRINTF(stderr, " AES128;");
-    } else if (ctx->alg == 5) {
-        DSD_FPRINTF(stderr, " AES256;");
-    } else if (ctx->alg == 7) {
-        DSD_FPRINTF(stderr, " VTX STD;");
+    const char* alg_label = dmr_block_crypto_alg_label(ctx->alg);
+    if (alg_label != NULL) {
+        DSD_FPRINTF(stderr, " %s;", alg_label);
     }
-    if (ctx->rkey != 0ULL && ctx->alg != 0) {
-        DSD_FPRINTF(stderr, " Key: %s;", DSD_SECRET_REDACTED);
-    }
+    dmr_block_crypto_print_key(ctx, show_keys);
 }
 
 static void
@@ -218,13 +235,14 @@ dmr_block_crypto_apply_aes_ecb(const dsd_state* state, uint8_t* slot_payload, ui
 }
 
 static uint8_t
-dmr_block_crypto_apply_bp(dsd_state* state, uint8_t slot, const dmr_block_crypto_ctx* ctx) {
+dmr_block_crypto_apply_bp(dsd_state* state, uint8_t slot, const dmr_block_crypto_ctx* ctx, int show_keys) {
     if (ctx->alg != 0 || state->K == 0 || state->K > 0xFFULL) {
         return 0;
     }
 
     const uint16_t bp_key = BPK[state->K];
-    DSD_FPRINTF(stderr, " Key: %s;", DSD_SECRET_REDACTED);
+    char key_text[16];
+    DSD_FPRINTF(stderr, " Key: %s;", dsd_secret_format_decimal(key_text, sizeof key_text, show_keys, state->K, 0U));
     if (bp_key == 0U) {
         return 0;
     }
@@ -240,7 +258,7 @@ dmr_block_crypto_apply_bp(dsd_state* state, uint8_t slot, const dmr_block_crypto
 }
 
 uint8_t
-dmr_block_crypto_decrypt_payload(dsd_state* state, uint8_t slot, const dmr_block_crypto_ctx* ctx) {
+dmr_block_crypto_decrypt_payload(dsd_state* state, uint8_t slot, const dmr_block_crypto_ctx* ctx, int show_keys) {
     if (state == NULL || ctx == NULL || slot >= 2U) {
         return 0;
     }
@@ -280,5 +298,5 @@ dmr_block_crypto_decrypt_payload(dsd_state* state, uint8_t slot, const dmr_block
         return dmr_block_crypto_apply_aes_ofb(state, slot, ctx);
     }
 
-    return dmr_block_crypto_apply_bp(state, slot, ctx);
+    return dmr_block_crypto_apply_bp(state, slot, ctx, show_keys);
 }

--- a/src/protocol/dmr/dmr_block_crypto.h
+++ b/src/protocol/dmr/dmr_block_crypto.h
@@ -23,7 +23,8 @@ typedef struct {
 
 void dmr_block_crypto_load_ctx(const dsd_state* state, uint8_t slot, int blocks, uint8_t block_len,
                                dmr_block_crypto_ctx* ctx);
-void dmr_block_crypto_print_info(const dmr_block_crypto_ctx* ctx);
-uint8_t dmr_block_crypto_decrypt_payload(dsd_state* state, uint8_t slot, const dmr_block_crypto_ctx* ctx);
+void dmr_block_crypto_print_info(const dmr_block_crypto_ctx* ctx, int show_keys);
+uint8_t dmr_block_crypto_decrypt_payload(dsd_state* state, uint8_t slot, const dmr_block_crypto_ctx* ctx,
+                                         int show_keys);
 
 #endif /* DSD_NEO_SRC_PROTOCOL_DMR_DMR_BLOCK_CRYPTO_H_ */

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -95,6 +95,41 @@ typedef struct {
     int protected_lc;
 } dmr_flco_ctx;
 
+static int
+dmr_flco_show_keys(const dmr_flco_ctx* ctx) {
+    return (ctx != NULL && ctx->opts != NULL) ? ctx->opts->show_keys : 0;
+}
+
+static unsigned int
+dmr_flco_hytera_key_segment_count(const dmr_flco_ctx* ctx) {
+    const dsd_state* state = (ctx != NULL) ? ctx->state : NULL;
+    if (state == NULL || (state->K1 == 0ULL && state->K2 == 0ULL && state->K3 == 0ULL && state->K4 == 0ULL)) {
+        return 0U;
+    }
+    if (state->hytera_key_segments == 1U || state->hytera_key_segments == 2U || state->hytera_key_segments == 4U) {
+        return state->hytera_key_segments;
+    }
+    if (state->K3 != 0ULL || state->K4 != 0ULL) {
+        return 4U;
+    }
+    if (state->K2 != 0ULL) {
+        return 2U;
+    }
+    return 1U;
+}
+
+static const char*
+dmr_flco_format_hytera_basic_key(char* key_text, size_t key_text_size, const dmr_flco_ctx* ctx,
+                                 unsigned int segment_count) {
+    if (segment_count == 2U || segment_count == 4U) {
+        const unsigned long long segments[4] = {ctx->state->K1, ctx->state->K2, ctx->state->K3, ctx->state->K4};
+        return dsd_secret_format_u64_segments(key_text, key_text_size, dmr_flco_show_keys(ctx), segments,
+                                              segment_count);
+    }
+    return dsd_secret_format_hex(key_text, key_text_size, dmr_flco_show_keys(ctx), ctx->state->K1 & 0xFFFFFFFFFFULL,
+                                 10U, 0);
+}
+
 static void
 dmr_flco_print_type_color(uint8_t type, const char* type1_color, const char* type2_color, const char* type3_color) {
     if (type == 1) {
@@ -405,10 +440,14 @@ dmr_flco_handle_irrecoverable_hytera_enhanced(dmr_flco_ctx* ctx) {
     DSD_FPRINTF(stderr, " Hytera Enhanced; ");
 
     if (ctx->slot == 0 && ctx->state->R != 0) {
-        DSD_FPRINTF(stderr, "Key: %s; ", DSD_SECRET_REDACTED);
+        char key_text[17];
+        DSD_FPRINTF(stderr, "Key: %s; ",
+                    dsd_secret_format_hex(key_text, sizeof key_text, dmr_flco_show_keys(ctx), ctx->state->R, 10U, 0));
     }
     if (ctx->slot == 1 && ctx->state->RR != 0) {
-        DSD_FPRINTF(stderr, "Key: %s; ", DSD_SECRET_REDACTED);
+        char key_text[17];
+        DSD_FPRINTF(stderr, "Key: %s; ",
+                    dsd_secret_format_hex(key_text, sizeof key_text, dmr_flco_show_keys(ctx), ctx->state->RR, 10U, 0));
     }
 
     for (int i = 0; i < 8; i++) {
@@ -752,13 +791,17 @@ dmr_flco_print_dmr_basic_keys(const dmr_flco_ctx* ctx) {
     if (ctx->state->K != 0 && ctx->fid == 0x10 && (ctx->so & 0x40) && ctx->slot == 0
         && ctx->state->payload_algid == 0) {
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key %s ", DSD_SECRET_REDACTED);
+        char key_text[16];
+        DSD_FPRINTF(stderr, "Key %s ",
+                    dsd_secret_format_decimal(key_text, sizeof key_text, dmr_flco_show_keys(ctx), ctx->state->K, 0U));
         DSD_FPRINTF(stderr, "%s ", KNRM);
     }
     if (ctx->state->K != 0 && ctx->fid == 0x10 && (ctx->so & 0x40) && ctx->slot == 1
         && ctx->state->payload_algidR == 0) {
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key %s ", DSD_SECRET_REDACTED);
+        char key_text[16];
+        DSD_FPRINTF(stderr, "Key %s ",
+                    dsd_secret_format_decimal(key_text, sizeof key_text, dmr_flco_show_keys(ctx), ctx->state->K, 0U));
         DSD_FPRINTF(stderr, "%s ", KNRM);
     }
 }
@@ -767,11 +810,13 @@ static void
 dmr_flco_print_hytera_basic_key_slot0(const dmr_flco_ctx* ctx) {
     if (ctx->state->K1 != 0 && ctx->fid == 0x68 && (ctx->so & 0x40) && ctx->slot == 0
         && ctx->state->payload_algid == 0) {
-        if (ctx->state->K2 != 0) {
+        const unsigned int segment_count = dmr_flco_hytera_key_segment_count(ctx);
+        if (segment_count >= 2U) {
             DSD_FPRINTF(stderr, "\n ");
         }
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key %s ", DSD_SECRET_REDACTED);
+        char key_text[68];
+        DSD_FPRINTF(stderr, "Key %s ", dmr_flco_format_hytera_basic_key(key_text, sizeof key_text, ctx, segment_count));
         DSD_FPRINTF(stderr, "%s ", KNRM);
     }
 }
@@ -780,11 +825,13 @@ static void
 dmr_flco_print_hytera_basic_key_slot1(const dmr_flco_ctx* ctx) {
     if (ctx->state->K1 != 0 && ctx->fid == 0x68 && (ctx->so & 0x40) && ctx->slot == 1
         && ctx->state->payload_algidR == 0) {
-        if (ctx->state->K2 != 0) {
+        const unsigned int segment_count = dmr_flco_hytera_key_segment_count(ctx);
+        if (segment_count >= 2U) {
             DSD_FPRINTF(stderr, "\n ");
         }
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key %s ", DSD_SECRET_REDACTED);
+        char key_text[68];
+        DSD_FPRINTF(stderr, "Key %s ", dmr_flco_format_hytera_basic_key(key_text, sizeof key_text, ctx, segment_count));
         DSD_FPRINTF(stderr, "%s ", KNRM);
     }
 }
@@ -793,12 +840,16 @@ static void
 dmr_flco_print_alg21_keys(const dmr_flco_ctx* ctx) {
     if (ctx->slot == 0 && ctx->state->payload_algid == 0x21 && ctx->state->R != 0) {
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key %s ", DSD_SECRET_REDACTED);
+        char key_text[17];
+        DSD_FPRINTF(stderr, "Key %s ",
+                    dsd_secret_format_hex(key_text, sizeof key_text, dmr_flco_show_keys(ctx), ctx->state->R, 10U, 0));
         DSD_FPRINTF(stderr, "%s ", KNRM);
     }
     if (ctx->slot == 1 && ctx->state->payload_algidR == 0x21 && ctx->state->RR != 0) {
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key %s ", DSD_SECRET_REDACTED);
+        char key_text[17];
+        DSD_FPRINTF(stderr, "Key %s ",
+                    dsd_secret_format_hex(key_text, sizeof key_text, dmr_flco_show_keys(ctx), ctx->state->RR, 10U, 0));
         DSD_FPRINTF(stderr, "%s ", KNRM);
     }
 }
@@ -815,12 +866,16 @@ static void
 dmr_flco_print_alg02_keys(const dmr_flco_ctx* ctx) {
     if (ctx->slot == 0 && ctx->state->payload_algid == 0x02 && ctx->state->R != 0) {
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key: %s ", DSD_SECRET_REDACTED);
+        char key_text[17];
+        DSD_FPRINTF(stderr, "Key: %s ",
+                    dsd_secret_format_hex(key_text, sizeof key_text, dmr_flco_show_keys(ctx), ctx->state->R, 10U, 0));
         DSD_FPRINTF(stderr, "%s ", KNRM);
     }
     if (ctx->slot == 1 && ctx->state->payload_algidR == 0x02 && ctx->state->RR != 0) {
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key: %s ", DSD_SECRET_REDACTED);
+        char key_text[17];
+        DSD_FPRINTF(stderr, "Key: %s ",
+                    dsd_secret_format_hex(key_text, sizeof key_text, dmr_flco_show_keys(ctx), ctx->state->RR, 10U, 0));
         DSD_FPRINTF(stderr, "%s ", KNRM);
     }
 }
@@ -831,14 +886,24 @@ dmr_flco_print_aes_24_25_keys(const dmr_flco_ctx* ctx) {
         && ctx->state->aes_key_loaded[0] == 1) {
         DSD_FPRINTF(stderr, "\n ");
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key: %s ", DSD_SECRET_REDACTED);
+        const unsigned long long segments[4] = {ctx->state->A1[0], ctx->state->A2[0], ctx->state->A3[0],
+                                                ctx->state->A4[0]};
+        char key_text[68];
+        DSD_FPRINTF(stderr, "Key: %s ",
+                    dsd_secret_format_u64_segments(key_text, sizeof key_text, dmr_flco_show_keys(ctx), segments,
+                                                   (ctx->state->payload_algid == 0x25) ? 4U : 2U));
         DSD_FPRINTF(stderr, "%s ", KNRM);
     }
     if (ctx->slot == 1 && (ctx->state->payload_algidR == 0x25 || ctx->state->payload_algidR == 0x24)
         && ctx->state->aes_key_loaded[1] == 1) {
         DSD_FPRINTF(stderr, "\n ");
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key: %s ", DSD_SECRET_REDACTED);
+        const unsigned long long segments[4] = {ctx->state->A1[1], ctx->state->A2[1], ctx->state->A3[1],
+                                                ctx->state->A4[1]};
+        char key_text[68];
+        DSD_FPRINTF(stderr, "Key: %s ",
+                    dsd_secret_format_u64_segments(key_text, sizeof key_text, dmr_flco_show_keys(ctx), segments,
+                                                   (ctx->state->payload_algidR == 0x25) ? 4U : 2U));
         DSD_FPRINTF(stderr, "%s ", KNRM);
     }
 }
@@ -849,14 +914,22 @@ dmr_flco_print_aes_36_37_keys(const dmr_flco_ctx* ctx) {
         && ctx->state->aes_key_loaded[0] == 1) {
         DSD_FPRINTF(stderr, "\n ");
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key: %s", DSD_SECRET_REDACTED);
+        const unsigned long long segments[4] = {ctx->state->A1[0], ctx->state->A2[0], ctx->state->A3[0],
+                                                ctx->state->A4[0]};
+        char key_text[68];
+        DSD_FPRINTF(stderr, "Key: %s",
+                    dsd_secret_format_u64_segments(key_text, sizeof key_text, dmr_flco_show_keys(ctx), segments, 4U));
         DSD_FPRINTF(stderr, "%s ", KNRM);
     }
     if (ctx->slot == 1 && (ctx->state->payload_algidR == 0x36 || ctx->state->payload_algidR == 0x37)
         && ctx->state->aes_key_loaded[1] == 1) {
         DSD_FPRINTF(stderr, "\n ");
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key: %s", DSD_SECRET_REDACTED);
+        const unsigned long long segments[4] = {ctx->state->A1[1], ctx->state->A2[1], ctx->state->A3[1],
+                                                ctx->state->A4[1]};
+        char key_text[68];
+        DSD_FPRINTF(stderr, "Key: %s",
+                    dsd_secret_format_u64_segments(key_text, sizeof key_text, dmr_flco_show_keys(ctx), segments, 4U));
         DSD_FPRINTF(stderr, "%s ", KNRM);
     }
 }

--- a/src/protocol/dmr/dmr_pi.c
+++ b/src/protocol/dmr/dmr_pi.c
@@ -96,13 +96,16 @@ dmr_pi_hytera_checksum(const uint8_t pi_byte[]) {
 }
 
 static void
-dmr_pi_hytera_print_key(const dsd_state* state) {
+dmr_pi_hytera_print_key(const dsd_state* state, int show_keys) {
     if (state->currentslot == 0 && state->R != 0) {
-        DSD_FPRINTF(stderr, "Key: %s; ", DSD_SECRET_REDACTED);
+        char key_text[17];
+        DSD_FPRINTF(stderr, "Key: %s; ", dsd_secret_format_hex(key_text, sizeof key_text, show_keys, state->R, 10U, 0));
     }
 
     if (state->currentslot == 1 && state->RR != 0) {
-        DSD_FPRINTF(stderr, "Key: %s; ", DSD_SECRET_REDACTED);
+        char key_text[17];
+        DSD_FPRINTF(stderr, "Key: %s; ",
+                    dsd_secret_format_hex(key_text, sizeof key_text, show_keys, state->RR, 10U, 0));
     }
 }
 
@@ -127,7 +130,7 @@ dmr_pi_handle_hytera(dsd_opts* opts, dsd_state* state, const uint8_t pi_byte[]) 
 
     if (dmr_pi_hytera_checksum(pi_byte) == pi_byte[9]) {
         DSD_FPRINTF(stderr, " Hytera Enhanced; ");
-        dmr_pi_hytera_print_key(state);
+        dmr_pi_hytera_print_key(state, opts->show_keys);
 
         //disable late entry for DMRA (hopefully, there aren't any systems running both DMRA and Hytera Enhanced mixed together)
         opts->dmr_le = 2;

--- a/src/protocol/dpmr/dpmr_voice.c
+++ b/src/protocol/dpmr/dpmr_voice.c
@@ -299,7 +299,7 @@ dpmr_print_ids(dsd_state* state, char called_id[8], char calling_id[8]) {
 }
 
 static void DSD_ATTR_USED
-dpmr_print_scrambler_state(const dsd_state* state) {
+dpmr_print_scrambler_state(const dsd_opts* opts, const dsd_state* state) {
     if (state->dPMRVoiceFS2Frame.Version[0] != 3) {
         return;
     }
@@ -308,7 +308,9 @@ dpmr_print_scrambler_state(const dsd_state* state) {
     DSD_FPRINTF(stderr, "%s", KNRM);
     if (state->R != 0) {
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, " Key %s ", DSD_SECRET_REDACTED);
+        char key_text[16];
+        DSD_FPRINTF(stderr, " Key %s ",
+                    dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, state->R, 5U));
         DSD_FPRINTF(stderr, "%s", KNRM);
     }
 }
@@ -408,7 +410,7 @@ processdPMRvoice(dsd_opts* opts, dsd_state* state) {
     dpmr_extract_previous_ids(state, CalledID, CallingID);
     dpmr_update_superframe_part(&ctx, opts, state, CalledID, CallingID);
     dpmr_print_ids(state, CalledID, CallingID);
-    dpmr_print_scrambler_state(state);
+    dpmr_print_scrambler_state(opts, state);
     dpmr_play_voice_frames(opts, state, ctx.ambe_fr);
     DSD_FPRINTF(stderr, "\n");
 

--- a/src/protocol/nxdn/nxdn_deperm.c
+++ b/src/protocol/nxdn/nxdn_deperm.c
@@ -756,7 +756,8 @@ nxdn_update_sacch2_identity_state(dsd_state* state, const struct nxdn_sacch2_fie
 }
 
 static void
-nxdn_print_sacch2_complete_message(dsd_state* state, const struct nxdn_sacch2_fields* fields, uint8_t crc_sf_check) {
+nxdn_print_sacch2_complete_message(const dsd_opts* opts, dsd_state* state, const struct nxdn_sacch2_fields* fields,
+                                   uint8_t crc_sf_check) {
     const int single_frame_ok = fields->sf_fb && fields->sf_pof && nxdn_sacch2_crc_ok(fields);
     const int multi_frame_ok = fields->sf_num == 0 && crc_sf_check == 0;
     if (!single_frame_ok && !multi_frame_ok) {
@@ -770,7 +771,9 @@ nxdn_print_sacch2_complete_message(dsd_state* state, const struct nxdn_sacch2_fi
         DSD_FPRINTF(stderr, "Scrambler; ");
         state->nxdn_cipher_type = 1;
         if (state->R != 0) {
-            DSD_FPRINTF(stderr, "Key: %s; ", DSD_SECRET_REDACTED);
+            char key_text[24];
+            DSD_FPRINTF(stderr, "Key: %s; ",
+                        dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, state->R, 0U));
         }
     } else if (cipher != 0x00) {
         DSD_FPRINTF(stderr, "Reserved Comms: %d; ", cipher);
@@ -826,7 +829,7 @@ nxdn_handle_sacch2(const dsd_opts* opts, dsd_state* state, const uint8_t* trelli
     const uint8_t crc_sf_check = nxdn_update_sacch2_segment_crc(state, &fields);
     nxdn_store_sacch2_frame(state, trellis_buf, &fields);
     nxdn_update_sacch2_identity_state(state, &fields);
-    nxdn_print_sacch2_complete_message(state, &fields, crc_sf_check);
+    nxdn_print_sacch2_complete_message(opts, state, &fields, crc_sf_check);
     nxdn_print_sacch2_payload(opts, state, &fields, m_data);
     nxdn_reset_sacch2_if_done(state, &fields);
 }

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -93,7 +93,7 @@ static void nxdn_element_handle_vcall_iv(dsd_opts* opts, dsd_state* state, const
                                          size_t elements_bits);
 static void nxdn_pdu_scrambler_keystream_creation(uint8_t* ks, int lfsr, int len_bits);
 static void nxdn_lfsr128_expand_iv_from_mi64(uint64_t mi, uint8_t out[16]);
-static int nxdn_load_data_aes_key(const dsd_state* state, uint8_t key_id, uint8_t out_key[32], uint64_t* key_stub);
+static int nxdn_load_data_aes_key(const dsd_state* state, uint8_t key_id, uint8_t out_key[32]);
 static void nxdn_sdcall_header(dsd_opts* opts, dsd_state* state, const uint8_t* Message);
 static void nxdn_dcall_header(dsd_opts* opts, dsd_state* state, const uint8_t* Message, size_t message_bits);
 static void nxdn_sdcall_iv(dsd_opts* opts, dsd_state* state, const uint8_t* Message);
@@ -609,15 +609,12 @@ nxdn_lfsr128_expand_iv_from_mi64(uint64_t mi, uint8_t out[16]) {
 }
 
 static int
-nxdn_load_data_aes_key(const dsd_state* state, uint8_t key_id, uint8_t out_key[32], uint64_t* key_stub) {
+nxdn_load_data_aes_key(const dsd_state* state, uint8_t key_id, uint8_t out_key[32]) {
     if (state == NULL || out_key == NULL) {
         return 0;
     }
 
     DSD_MEMSET(out_key, 0, 32U);
-    if (key_stub != NULL) {
-        *key_stub = 0ULL;
-    }
 
     if (state->keyloader == 1) {
         for (int i = 0; i < 8; i++) {
@@ -626,18 +623,12 @@ nxdn_load_data_aes_key(const dsd_state* state, uint8_t key_id, uint8_t out_key[3
             out_key[i + 16] = (uint8_t)((state->rkey_array[key_id + 0x201] >> (56 - (i * 8))) & 0xFFU);
             out_key[i + 24] = (uint8_t)((state->rkey_array[key_id + 0x301] >> (56 - (i * 8))) & 0xFFU);
         }
-        if (key_stub != NULL) {
-            *key_stub = state->rkey_array[key_id + 0x301];
-        }
     } else {
         for (int i = 0; i < 8; i++) {
             out_key[i + 0] = (uint8_t)((state->K1 >> (56 - (i * 8))) & 0xFFU);
             out_key[i + 8] = (uint8_t)((state->K2 >> (56 - (i * 8))) & 0xFFU);
             out_key[i + 16] = (uint8_t)((state->K3 >> (56 - (i * 8))) & 0xFFU);
             out_key[i + 24] = (uint8_t)((state->K4 >> (56 - (i * 8))) & 0xFFU);
-        }
-        if (key_stub != NULL) {
-            *key_stub = state->K4;
         }
     }
 
@@ -1018,18 +1009,17 @@ nxdn_dcall_prepare(dsd_state* state, const uint8_t* Message, size_t message_bits
 }
 
 static void
-nxdn_dcall_apply_decryption(dsd_state* state, const struct nxdn_dcall_data_context* ctx) {
+nxdn_dcall_apply_decryption(const dsd_opts* opts, dsd_state* state, const struct nxdn_dcall_data_context* ctx) {
     uint8_t ks[NXDN_DCALL_MAX_BITS];
     uint8_t aes_key[32];
     DSD_MEMSET(ks, 0, sizeof(ks));
     DSD_MEMSET(aes_key, 0, sizeof(aes_key));
 
     uint64_t key = 0ULL;
-    uint64_t aes_key_stub = 0ULL;
     int aes_key_loaded = 0;
     if (state->payload_algid != 0) {
         if (state->payload_algid == 3) {
-            aes_key_loaded = nxdn_load_data_aes_key(state, (uint8_t)state->payload_keyid, aes_key, &aes_key_stub);
+            aes_key_loaded = nxdn_load_data_aes_key(state, (uint8_t)state->payload_keyid, aes_key);
         } else if (state->keyloader == 1) {
             key = state->rkey_array[state->payload_keyid];
         } else {
@@ -1043,10 +1033,14 @@ nxdn_dcall_apply_decryption(dsd_state* state, const struct nxdn_dcall_data_conte
     }
 
     if (state->payload_algid == 1 && key != 0ULL) {
-        DSD_FPRINTF(stderr, " Key: %s;", DSD_SECRET_REDACTED);
+        char key_text[16];
+        DSD_FPRINTF(stderr, " Key: %s;",
+                    dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, key, 5U));
         nxdn_pdu_scrambler_keystream_creation(ks, (int)(key & 0x7FFFU), ctx->total_bits);
     } else if (state->payload_algid == 2 && key != 0ULL) {
-        DSD_FPRINTF(stderr, " Key: %s;", DSD_SECRET_REDACTED);
+        char key_text[17];
+        DSD_FPRINTF(stderr, " Key: %s;",
+                    dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, key, 16U, 0));
         const int nblocks = (ctx->total_bytes + 7) / 8;
         uint8_t ks_bytes[NXDN_DCALL_MAX_BYTES];
         DSD_MEMSET(ks_bytes, 0, sizeof(ks_bytes));
@@ -1056,7 +1050,9 @@ nxdn_dcall_apply_decryption(dsd_state* state, const struct nxdn_dcall_data_conte
         if (state->payload_mi != 0ULL) {
             nxdn_lfsr128_expand_iv_from_mi64((uint64_t)state->payload_mi, state->aes_ivR);
         }
-        DSD_FPRINTF(stderr, " KS: %s;", DSD_SECRET_REDACTED);
+        char key_text[65];
+        DSD_FPRINTF(stderr, " Key: %s;",
+                    dsd_secret_format_byte_hex(key_text, sizeof key_text, opts->show_keys, aes_key, sizeof(aes_key)));
         const int nblocks = (ctx->total_bytes + 15) / 16;
         uint8_t ks_bytes[NXDN_DCALL_MAX_BYTES];
         DSD_MEMSET(ks_bytes, 0, sizeof(ks_bytes));
@@ -1165,7 +1161,7 @@ nxdn_dcall_data(dsd_opts* opts, dsd_state* state, int type, const uint8_t* Messa
         return 0;
     }
 
-    nxdn_dcall_apply_decryption(state, &ctx);
+    nxdn_dcall_apply_decryption(opts, state, &ctx);
     const int crc_offset_bits = ctx.total_bits - 32;
     const uint32_t crc_ext = (uint32_t)convert_bits_into_output(state->dmr_pdu_sf[0] + crc_offset_bits, 32);
     const uint32_t crc_chk = nxdn_message_crc32(state->dmr_pdu_sf[0], crc_offset_bits);
@@ -1612,11 +1608,14 @@ nxdn_vcall_assgn_setup_tuned_call(dsd_opts* opts, dsd_state* state, const struct
 }
 
 static void
-nxdn_vcall_assgn_load_scrambler_key(dsd_state* state, const struct nxdn_vcall_assgn_info* info) {
+nxdn_vcall_assgn_load_scrambler_key(const dsd_opts* opts, dsd_state* state, const struct nxdn_vcall_assgn_info* info) {
     if (state->rkey_array[info->destination_id] != 0) {
         state->R = state->rkey_array[info->destination_id];
         DSD_FPRINTF(stderr, " %s", KYEL);
-        DSD_FPRINTF(stderr, " Key Loaded: %s", DSD_SECRET_REDACTED);
+        char key_text[24];
+        DSD_FPRINTF(stderr, " Key Loaded: %s",
+                    dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys,
+                                              state->rkey_array[info->destination_id], 0U));
         state->payload_miN = state->R;
     }
     if (state->M == 1) {
@@ -1649,7 +1648,7 @@ nxdn_vcall_assgn_apply_tune(dsd_opts* opts, dsd_state* state, const struct nxdn_
         if (!nxdn_vcall_assgn_setup_tuned_call(opts, state, info, freq)) {
             return;
         }
-        nxdn_vcall_assgn_load_scrambler_key(state, info);
+        nxdn_vcall_assgn_load_scrambler_key(opts, state, info);
     } else if (opts->p25_trunk == 1) {
         nxdn_policy_log_block(opts, is_private_call, info->destination_id, info->source_unit_id, &policy_decision);
     }
@@ -2184,7 +2183,7 @@ nxdn_vcall_load_key(const dsd_opts* opts, dsd_state* state, const struct nxdn_vc
 }
 
 static void
-nxdn_vcall_print_cipher(const dsd_state* state, const struct nxdn_vcall_info* info) {
+nxdn_vcall_print_cipher(const dsd_opts* opts, const dsd_state* state, const struct nxdn_vcall_info* info) {
     if (info->cipher_type != 0U && info->message_type == 0x01U) {
         DSD_FPRINTF(stderr, "\n  %s", KYEL);
         DSD_FPRINTF(stderr, "%s - ", NXDN_Cipher_Type_To_Str(info->cipher_type));
@@ -2193,17 +2192,23 @@ nxdn_vcall_print_cipher(const dsd_state* state, const struct nxdn_vcall_info* in
     }
     if (info->cipher_type == 0x01U && state->R > 0) {
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Value: %s", DSD_SECRET_REDACTED);
+        char key_text[16];
+        DSD_FPRINTF(stderr, "Value: %s",
+                    dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, state->R, 5U));
         DSD_FPRINTF(stderr, "%s", KNRM);
     }
     if (info->cipher_type == 0x02U && state->R > 0) {
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Value: %s", DSD_SECRET_REDACTED);
+        char key_text[17];
+        DSD_FPRINTF(stderr, "Value: %s",
+                    dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->R, 16U, 0));
         DSD_FPRINTF(stderr, "%s", KNRM);
     }
     if (info->cipher_type == 0x03U && state->R > 0) {
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "KS: %s", DSD_SECRET_REDACTED);
+        char key_text[17];
+        DSD_FPRINTF(stderr, "KS: %s",
+                    dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->R, 16U, 0));
         DSD_FPRINTF(stderr, "%s", KNRM);
     }
 }
@@ -2289,7 +2294,7 @@ static void
 nxdn_vcall_process(dsd_opts* opts, dsd_state* state, const struct nxdn_vcall_info* info) {
     nxdn_vcall_print_summary(state, info);
     nxdn_vcall_load_key(opts, state, info);
-    nxdn_vcall_print_cipher(state, info);
+    nxdn_vcall_print_cipher(opts, state, info);
     nxdn_vcall_apply_state(state, info);
     nxdn_vcall_run_enc_lockout(opts, state, info);
 }

--- a/src/protocol/nxdn/nxdn_frame.c
+++ b/src/protocol/nxdn/nxdn_frame.c
@@ -466,7 +466,10 @@ nxdn_apply_limazulu_voice_tweak(const dsd_opts* opts, dsd_state* state, const nx
         DSD_FPRINTF(stderr, "\n Freq: %ld - Freq Hash: %d", freq, limazulu);
     }
     if (state->rkey_array[limazulu] != 0) {
-        DSD_FPRINTF(stderr, " - Key Loaded: %s", DSD_SECRET_REDACTED);
+        char key_text[24];
+        DSD_FPRINTF(
+            stderr, " - Key Loaded: %s",
+            dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, state->rkey_array[limazulu], 0U));
     }
     DSD_FPRINTF(stderr, "%s", KNRM);
 

--- a/src/protocol/p25/phase1/p25p1_hdu.c
+++ b/src/protocol/p25/phase1/p25p1_hdu.c
@@ -509,7 +509,10 @@ static void
 hdu_apply_unmute_policy(dsd_opts* opts, const dsd_state* state) {
     if (state->R != 0
         && (state->payload_algid == 0xAA || state->payload_algid == 0x81 || state->payload_algid == 0x9F)) {
-        DSD_FPRINTF(stderr, " Key: %s", DSD_SECRET_REDACTED);
+        const unsigned int key_width = (state->payload_algid == 0xAA) ? 10U : 16U;
+        char key_text[17];
+        DSD_FPRINTF(stderr, " Key: %s",
+                    dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->R, key_width, 0));
         opts->unmute_encrypted_p25 = 1;
         return;
     }
@@ -517,7 +520,11 @@ hdu_apply_unmute_policy(dsd_opts* opts, const dsd_state* state) {
     if ((state->payload_algid == 0x84 || state->payload_algid == 0x89) && state->aes_key_loaded[0] == 1) {
         DSD_FPRINTF(stderr, "\n ");
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key: %s ", DSD_SECRET_REDACTED);
+        const unsigned long long segments[4] = {state->A1[0], state->A2[0], state->A3[0], state->A4[0]};
+        char key_text[68];
+        DSD_FPRINTF(stderr, "Key: %s ",
+                    dsd_secret_format_u64_segments(key_text, sizeof key_text, opts->show_keys, segments,
+                                                   (state->payload_algid == 0x84) ? 4U : 2U));
         DSD_FPRINTF(stderr, "%s ", KNRM);
         opts->unmute_encrypted_p25 = 1;
         return;

--- a/src/protocol/p25/phase1/p25p1_ldu2.c
+++ b/src/protocol/p25/phase1/p25p1_ldu2.c
@@ -349,14 +349,21 @@ static void
 ldu2_apply_unmute_policy(dsd_opts* opts, const dsd_state* state) {
     if (state->R != 0
         && (state->payload_algid == 0xAA || state->payload_algid == 0x81 || state->payload_algid == 0x9F)) {
-        DSD_FPRINTF(stderr, " Key: %s", DSD_SECRET_REDACTED);
+        const unsigned int key_width = (state->payload_algid == 0xAA) ? 10U : 16U;
+        char key_text[17];
+        DSD_FPRINTF(stderr, " Key: %s",
+                    dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->R, key_width, 0));
         opts->unmute_encrypted_p25 = 1;
         return;
     }
     if ((state->payload_algid == 0x84 || state->payload_algid == 0x89) && state->aes_key_loaded[0] == 1) {
         DSD_FPRINTF(stderr, "\n ");
         DSD_FPRINTF(stderr, "%s", KYEL);
-        DSD_FPRINTF(stderr, "Key: %s ", DSD_SECRET_REDACTED);
+        const unsigned long long segments[4] = {state->A1[0], state->A2[0], state->A3[0], state->A4[0]};
+        char key_text[68];
+        DSD_FPRINTF(stderr, "Key: %s ",
+                    dsd_secret_format_u64_segments(key_text, sizeof key_text, opts->show_keys, segments,
+                                                   (state->payload_algid == 0x84) ? 4U : 2U));
         DSD_FPRINTF(stderr, "%s ", KNRM);
         opts->unmute_encrypted_p25 = 1;
         return;

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -1235,14 +1235,22 @@ p25p2_ess_apply_slot0(const dsd_opts* opts, dsd_state* state, unsigned long long
     DSD_FPRINTF(stderr, " ESSB");
 
     if (state->R != 0 && state->payload_algid == 0xAA) {
-        DSD_FPRINTF(stderr, " Key %s", DSD_SECRET_REDACTED);
+        char key_text[19];
+        DSD_FPRINTF(stderr, " Key %s",
+                    dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->R, 10U, 1));
     }
     if (state->R != 0 && state->payload_algid == 0x81) {
-        DSD_FPRINTF(stderr, " Key %s", DSD_SECRET_REDACTED);
+        char key_text[19];
+        DSD_FPRINTF(stderr, " Key %s",
+                    dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->R, 16U, 1));
     }
     if ((state->payload_algid == 0x84 || state->payload_algid == 0x89) && state->aes_key_loaded[0] == 1) {
         DSD_FPRINTF(stderr, "\n ");
-        DSD_FPRINTF(stderr, "Key: %s ", DSD_SECRET_REDACTED);
+        const unsigned long long segments[4] = {state->A1[0], state->A2[0], state->A3[0], state->A4[0]};
+        char key_text[68];
+        DSD_FPRINTF(stderr, "Key: %s ",
+                    dsd_secret_format_u64_segments(key_text, sizeof key_text, opts->show_keys, segments,
+                                                   (state->payload_algid == 0x84) ? 4U : 2U));
     }
 
     if (state->payload_algid == 0x84 || state->payload_algid == 0x89) {
@@ -1271,14 +1279,22 @@ p25p2_ess_apply_slot1(const dsd_opts* opts, dsd_state* state, unsigned long long
     DSD_FPRINTF(stderr, " ESSB");
 
     if (state->RR != 0 && state->payload_algidR == 0xAA) {
-        DSD_FPRINTF(stderr, " Key %s", DSD_SECRET_REDACTED);
+        char key_text[19];
+        DSD_FPRINTF(stderr, " Key %s",
+                    dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->RR, 10U, 1));
     }
     if (state->RR != 0 && state->payload_algidR == 0x81) {
-        DSD_FPRINTF(stderr, " Key %s", DSD_SECRET_REDACTED);
+        char key_text[19];
+        DSD_FPRINTF(stderr, " Key %s",
+                    dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->RR, 16U, 1));
     }
     if ((state->payload_algidR == 0x84 || state->payload_algidR == 0x89) && state->aes_key_loaded[1] == 1) {
         DSD_FPRINTF(stderr, "\n ");
-        DSD_FPRINTF(stderr, "Key: %s ", DSD_SECRET_REDACTED);
+        const unsigned long long segments[4] = {state->A1[1], state->A2[1], state->A3[1], state->A4[1]};
+        char key_text[68];
+        DSD_FPRINTF(stderr, "Key: %s ",
+                    dsd_secret_format_u64_segments(key_text, sizeof key_text, opts->show_keys, segments,
+                                                   (state->payload_algidR == 0x84) ? 4U : 2U));
     }
 
     if (state->payload_algidR == 0x84 || state->payload_algidR == 0x89) {

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -310,15 +310,21 @@ p25p2_xcch_log_slot_encryption(dsd_opts* opts, dsd_state* state, int slot) {
     DSD_FPRINTF(stderr, " MPTT");
 
     if (key != 0 && algid == 0xAA) {
-        DSD_FPRINTF(stderr, " Key %s", DSD_SECRET_REDACTED);
+        char key_text[19];
+        DSD_FPRINTF(stderr, " Key %s", dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, key, 10U, 1));
     }
     if (key != 0 && algid == 0x81) {
-        DSD_FPRINTF(stderr, " Key %s", DSD_SECRET_REDACTED);
+        char key_text[19];
+        DSD_FPRINTF(stderr, " Key %s", dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, key, 16U, 1));
     }
 
     if ((algid == 0x84 || algid == 0x89) && state->aes_key_loaded[slot] == 1) {
         DSD_FPRINTF(stderr, "\n ");
-        DSD_FPRINTF(stderr, "Key: %s ", DSD_SECRET_REDACTED);
+        const unsigned long long segments[4] = {state->A1[slot], state->A2[slot], state->A3[slot], state->A4[slot]};
+        char key_text[68];
+        DSD_FPRINTF(stderr, "Key: %s ",
+                    dsd_secret_format_u64_segments(key_text, sizeof key_text, opts->show_keys, segments,
+                                                   (algid == 0x84) ? 4U : 2U));
     }
 
     if (algid == 0x84 || algid == 0x89) {

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -230,6 +230,9 @@ cli_has_config_one_shot_arg(int argc, char** argv) {
         if (!arg) {
             break;
         }
+        if (strcmp(arg, "--") == 0) {
+            break;
+        }
         if (strcmp(arg, "--validate-config") == 0 || strncmp(arg, "--validate-config=", 18) == 0
             || strcmp(arg, "--print-config") == 0 || strcmp(arg, "--list-profiles") == 0
             || strcmp(arg, "--dump-config-template") == 0) {
@@ -468,6 +471,12 @@ cli_next_arg(char** argv, int i, int* arg_advance) {
 #define DSD_PARSE_ARGS_PRESCAN_BLOCK()                                                                                 \
     for (int i = 1, arg_advance = 1; i < argc; i += arg_advance) {                                                     \
         arg_advance = 1;                                                                                               \
+        if (argv[i] == NULL) {                                                                                         \
+            break;                                                                                                     \
+        }                                                                                                              \
+        if (strcmp(argv[i], "--") == 0) {                                                                              \
+            break;                                                                                                     \
+        }                                                                                                              \
         if (strcmp(argv[i], "--rtltcp-autotune") == 0) {                                                               \
             opts->rtltcp_autotune = 1;                                                                                 \
             dsd_setenv("DSD_NEO_TCP_AUTOTUNE", "1", 1);                                                                \
@@ -865,6 +874,10 @@ cli_next_arg(char** argv, int i, int* arg_advance) {
         }                                                                                                              \
         if (strcmp(argv[i], "--dmr-debug-burst") == 0) {                                                               \
             opts->dmr_debug_burst = 1;                                                                                 \
+            continue;                                                                                                  \
+        }                                                                                                              \
+        if (strcmp(argv[i], "--show-keys") == 0) {                                                                     \
+            opts->show_keys = 1;                                                                                       \
             continue;                                                                                                  \
         }                                                                                                              \
         if (strcmp(argv[i], "--dmr-baofeng-pc5") == 0) {                                                               \
@@ -1320,14 +1333,14 @@ cli_next_arg(char** argv, int i, int* arg_advance) {
     }                                                                                                                  \
                                                                                                                        \
     if (dmr_baofeng_pc5_cli) {                                                                                         \
-        if (baofeng_ap_pc5_keystream_creation(state, dmr_baofeng_pc5_cli) != 0) {                                      \
+        if (baofeng_ap_pc5_keystream_creation(state, dmr_baofeng_pc5_cli, opts->show_keys) != 0) {                     \
             LOG_ERROR("Invalid --dmr-baofeng-pc5 value\n");                                                            \
             cli_set_exit_rc(out_exit_rc, 1);                                                                           \
             return DSD_PARSE_ERROR;                                                                                    \
         }                                                                                                              \
     }                                                                                                                  \
     if (dmr_csi_ee72_cli) {                                                                                            \
-        if (connect_systems_ee72_key_creation(state, dmr_csi_ee72_cli) != 0) {                                         \
+        if (connect_systems_ee72_key_creation(state, dmr_csi_ee72_cli, opts->show_keys) != 0) {                        \
             LOG_ERROR("Invalid --dmr-csi-ee72 value\n");                                                               \
             cli_set_exit_rc(out_exit_rc, 1);                                                                           \
             return DSD_PARSE_ERROR;                                                                                    \
@@ -1525,7 +1538,9 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                 }                                                                                                      \
                 state->R = key;                                                                                        \
                 state->RR = key;                                                                                       \
-                LOG_NOTICE("RC4/DES encryption key loaded: %s\n", DSD_SECRET_REDACTED);                                \
+                char key_text[32];                                                                                     \
+                LOG_NOTICE("RC4/DES encryption key loaded: %s\n",                                                      \
+                           dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->R, 16U, 0));       \
                 opts->unmute_encrypted_p25 = 0;                                                                        \
                 state->keyloader = 0;                                                                                  \
             }                                                                                                          \
@@ -1548,14 +1563,16 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
             state->tyt_bp = 1;                                                                                         \
             DSD_CLI_PARSE_U64_OR_RETURN("-2", optarg, 16, state->H);                                                   \
             state->H = state->H & 0xFFFF;                                                                              \
-            LOG_NOTICE("DMR TYT Basic 16-bit key loaded with forced application: %s\n", DSD_SECRET_REDACTED);          \
+            char key_text[16];                                                                                         \
+            LOG_NOTICE("DMR TYT Basic 16-bit key loaded with forced application: %s\n",                                \
+                       dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->H, 4U, 1));            \
             break;                                                                                                     \
-        case '!': tyt_ap_pc4_keystream_creation(state, optarg); break;                                                 \
-        case '@': retevis_rc2_keystream_creation(state, optarg); break;                                                \
-        case '5': tyt_ep_aes_keystream_creation(state, optarg); break;                                                 \
-        case '9': ken_dmr_scrambler_keystream_creation(state, optarg); break;                                          \
-        case 'A': anytone_bp_keystream_creation(state, optarg); break;                                                 \
-        case 'S': straight_mod_xor_keystream_creation(state, optarg); break;                                           \
+        case '!': tyt_ap_pc4_keystream_creation(state, optarg, opts->show_keys); break;                                \
+        case '@': retevis_rc2_keystream_creation(state, optarg, opts->show_keys); break;                               \
+        case '5': tyt_ep_aes_keystream_creation(state, optarg, opts->show_keys); break;                                \
+        case '9': ken_dmr_scrambler_keystream_creation(state, optarg, opts->show_keys); break;                         \
+        case 'A': anytone_bp_keystream_creation(state, optarg, opts->show_keys); break;                                \
+        case 'S': straight_mod_xor_keystream_creation(state, optarg, opts->show_keys); break;                          \
         case '3':                                                                                                      \
             opts->dmr_le = 0;                                                                                          \
             LOG_NOTICE("DMRA Late Entry Encryption Identifiers Disabled\n");                                           \
@@ -1645,8 +1662,11 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                     state->H = k1 & 0xFFFFFFFFFFULL;                                                                   \
                     state->K1 = state->H;                                                                              \
                     state->K2 = state->K3 = state->K4 = 0ULL;                                                          \
+                    state->hytera_key_segments = (state->K1 != 0ULL) ? 1U : 0U;                                        \
                     state->aes_key_segments[0] = state->aes_key_segments[1] = 0U;                                      \
-                    LOG_NOTICE("Hytera BP key loaded (40-bit)\n");                                                     \
+                    char key_text[32];                                                                                 \
+                    LOG_NOTICE("Hytera BP key loaded (40-bit): %s\n",                                                  \
+                               dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->K1, 10U, 0));  \
                 } else if (nhex == 32) {                                                                               \
                     if (!cli_parse_hex_u64_n(hex + 0, 16, &k1) || !cli_parse_hex_u64_n(hex + 16, 16, &k2)) {           \
                         LOG_ERROR("-H failed to parse 32-hex key (2x16)\n");                                           \
@@ -1657,6 +1677,7 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                     state->K1 = k1;                                                                                    \
                     state->K2 = k2;                                                                                    \
                     state->K3 = state->K4 = 0ULL;                                                                      \
+                    state->hytera_key_segments = (k1 != 0ULL || k2 != 0ULL) ? 2U : 0U;                                 \
                                                                                                                        \
                     state->A1[0] = state->A1[1] = k1;                                                                  \
                     state->A2[0] = state->A2[1] = k2;                                                                  \
@@ -1670,7 +1691,11 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                         state->aes_key[i + 0] = (uint8_t)((state->A1[0] >> (56 - (i * 8))) & 0xFF);                    \
                         state->aes_key[i + 8] = (uint8_t)((state->A2[0] >> (56 - (i * 8))) & 0xFF);                    \
                     }                                                                                                  \
-                    LOG_NOTICE("AES-128 / Hytera 128-bit key loaded (2x64)\n");                                        \
+                    const unsigned long long segments[2] = {k1, k2};                                                   \
+                    char key_text[96];                                                                                 \
+                    LOG_NOTICE(                                                                                        \
+                        "AES-128 / Hytera 128-bit key loaded (2x64): %s\n",                                            \
+                        dsd_secret_format_u64_segments(key_text, sizeof key_text, opts->show_keys, segments, 2U));     \
                 } else if (nhex == 64) {                                                                               \
                     if (!cli_parse_hex_u64_n(hex + 0, 16, &k1) || !cli_parse_hex_u64_n(hex + 16, 16, &k2)              \
                         || !cli_parse_hex_u64_n(hex + 32, 16, &k3) || !cli_parse_hex_u64_n(hex + 48, 16, &k4)) {       \
@@ -1683,6 +1708,7 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                     state->K2 = k2;                                                                                    \
                     state->K3 = k3;                                                                                    \
                     state->K4 = k4;                                                                                    \
+                    state->hytera_key_segments = (k1 != 0ULL || k2 != 0ULL || k3 != 0ULL || k4 != 0ULL) ? 4U : 0U;     \
                                                                                                                        \
                     state->A1[0] = state->A1[1] = k1;                                                                  \
                     state->A2[0] = state->A2[1] = k2;                                                                  \
@@ -1699,7 +1725,11 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                         state->aes_key[i + 16] = (uint8_t)((state->A3[0] >> (56 - (i * 8))) & 0xFF);                   \
                         state->aes_key[i + 24] = (uint8_t)((state->A4[0] >> (56 - (i * 8))) & 0xFF);                   \
                     }                                                                                                  \
-                    LOG_NOTICE("AES-256 / Hytera 256-bit key loaded (4x64)\n");                                        \
+                    const unsigned long long segments[4] = {k1, k2, k3, k4};                                           \
+                    char key_text[96];                                                                                 \
+                    LOG_NOTICE(                                                                                        \
+                        "AES-256 / Hytera 256-bit key loaded (4x64): %s\n",                                            \
+                        dsd_secret_format_u64_segments(key_text, sizeof key_text, opts->show_keys, segments, 4U));     \
                 } else {                                                                                               \
                     LOG_ERROR("-H expects 10, 32, or 64 hex characters (spaces allowed)\n");                           \
                     cli_set_exit_rc(out_exit_rc, 1);                                                                   \
@@ -1976,7 +2006,9 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
             }                                                                                                          \
             state->R = (unsigned long long)key;                                                                        \
             state->keyloader = 0;                                                                                      \
-            LOG_NOTICE("NXDN/dPMR scrambler key loaded: %s\n", DSD_SECRET_REDACTED);                                   \
+            char key_text[16];                                                                                         \
+            LOG_NOTICE("NXDN/dPMR scrambler key loaded: %s\n",                                                         \
+                       dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, state->R, 5U));           \
             break;                                                                                                     \
         }                                                                                                              \
         case 'v': {                                                                                                    \
@@ -2478,7 +2510,9 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                 opts->dmr_mute_encL = 1;                                                                               \
                 opts->dmr_mute_encR = 1;                                                                               \
             }                                                                                                          \
-            LOG_NOTICE("Basic Privacy key loaded (forced priority): %s\n", DSD_SECRET_REDACTED);                       \
+            char key_text[16];                                                                                         \
+            LOG_NOTICE("Basic Privacy key loaded (forced priority): %s\n",                                             \
+                       dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, state->K, 0U));           \
             break;                                                                                                     \
         }                                                                                                              \
         case 'D': {                                                                                                    \

--- a/src/runtime/cli/compact.c
+++ b/src/runtime/cli/compact.c
@@ -38,11 +38,31 @@ compact_has_next_non_option(int i, int argc, char** argv) {
     return (i + 1 < argc && argv[i + 1] != NULL && argv[i + 1][0] != '-');
 }
 
+static int
+compact_copy_terminator_tail_or_stop(int start, int argc, char** argv, int* out_w) {
+    if (argv[start] == NULL) {
+        return 1;
+    }
+    if (strcmp(argv[start], "--") != 0) {
+        return 0;
+    }
+    for (int i = start; i < argc; ++i) {
+        if (argv[i] == NULL) {
+            break;
+        }
+        argv[(*out_w)++] = argv[i];
+    }
+    return 1;
+}
+
 static const char* const k_skip_exact_no_arg[] = {
-    "--auto-ppm",          "--rtltcp-autotune",      "--iq-loop",       "--rdio-api-delete-after-upload",
-    "--enc-lockout",       "--enc-follow",           "--no-config",     "--print-config",
-    "--interactive-setup", "--dump-config-template", "--strict-config", "--list-profiles",
-    "--dmr-debug-burst",
+    "--auto-ppm",          "--rtltcp-autotune",
+    "--iq-loop",           "--rdio-api-delete-after-upload",
+    "--enc-lockout",       "--enc-follow",
+    "--no-config",         "--print-config",
+    "--interactive-setup", "--dump-config-template",
+    "--strict-config",     "--list-profiles",
+    "--dmr-debug-burst",   "--show-keys",
 };
 
 static const char* const k_skip_exact_next_any[] = {
@@ -127,10 +147,10 @@ dsd_cli_compact_args(int argc, char** argv) {
     int w = 1;
     for (int i = 1, advance = 1; i < argc; i += advance) {
         advance = 1;
-        const char* arg = argv[i];
-        if (arg == NULL) {
+        if (compact_copy_terminator_tail_or_stop(i, argc, argv, &w)) {
             break;
         }
+        const char* arg = argv[i];
         if (compact_matches_prefix(arg, k_skip_prefix, sizeof(k_skip_prefix) / sizeof(k_skip_prefix[0]))) {
             continue;
         }

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -254,7 +254,7 @@ dsd_cli_usage_section_decode(void) {
 }
 
 static void
-dsd_cli_usage_section_advanced(void) {
+dsd_cli_usage_section_advanced_decoder_options(void) {
     printf("Advanced Decoder options:\n");
     printf("  -X <hex>      Manually Set P2 Parameters (WACN, SYSID, CC/NAC)\n");
     printf("                 (-X BEE00ABC123)\n");
@@ -275,6 +275,13 @@ dsd_cli_usage_section_advanced(void) {
     printf("  -F            Relax NXDN SACCH/FACCH/CAC/F2U CRC Pass/Fail\n");
     printf("  -F            Relax M17 LSF/PKT CRC Error Checking\n");
     printf("\n");
+    printf("      --show-keys  Reveal radio keys and keystream material in CLI/status output for this run.\n");
+    printf("                   Default output remains redacted.\n");
+    printf("\n");
+}
+
+static void
+dsd_cli_usage_section_advanced_key_options(void) {
     printf("  -b <dec>      Manually Enter Basic Privacy Key (Decimal Value of Key Number)\n");
     printf("                 (NOTE: This used to be the 'K' option!)\n");
     printf("\n");
@@ -353,6 +360,12 @@ dsd_cli_usage_section_advanced(void) {
     printf("  -3            Disable DMR Late Entry Encryption Identifiers (VC6 Single Burst)\n");
     printf("                  Note: Disable this if false positives on Voice ENC occur.\n");
     printf("\n");
+}
+
+static void
+dsd_cli_usage_section_advanced(void) {
+    dsd_cli_usage_section_advanced_decoder_options();
+    dsd_cli_usage_section_advanced_key_options();
 }
 
 static void

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -50,6 +50,7 @@
 #include "dsd-neo/core/secret_redaction.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/platform/platform.h"
+#include "ui_key_status.h"
 #include "ui_snr_readout.h"
 
 #ifdef USE_RADIO
@@ -779,60 +780,85 @@ ui_render_trunking_and_edacs_toggles(const dsd_opts* opts, dsd_state* state) {
     ui_render_edacs_mode_toggles(opts, state);
 }
 
-static void
-ui_render_hytera_loaded_key_status(const dsd_state* state) {
-    const char* label = (state->K2 == 0ULL && state->K3 == 0ULL && state->K4 == 0ULL)
-                            ? "Hytera BP Key Loaded (not forced)"
-                            : "Hytera Key Loaded (not forced)";
-    printw("| %s: %s \n", label, DSD_SECRET_REDACTED);
+static const char*
+ui_format_hytera_key(char* key_text, size_t key_text_size, const dsd_state* state, int show_keys,
+                     unsigned int segment_count) {
+    const unsigned long long segments[4] = {state->K1, state->K2, state->K3, state->K4};
+    if (segment_count == 2U || segment_count == 4U) {
+        return dsd_secret_format_u64_segments(key_text, key_text_size, show_keys, segments, segment_count);
+    }
+    return dsd_secret_format_hex(key_text, key_text_size, show_keys, state->K1 & 0xFFFFFFFFFFULL, 10U, 0);
 }
 
 static void
-ui_render_forced_key_status_dmr(const dsd_state* state) {
+ui_render_hytera_loaded_key_status(const dsd_state* state, int show_keys) {
+    unsigned int segment_count = ui_hytera_key_segment_count(state);
+    if (segment_count == 0U) {
+        return;
+    }
+
+    char key_text[68];
+    const char* label = (segment_count == 1U) ? "Hytera BP Key Loaded (not forced)" : "Hytera Key Loaded (not forced)";
+    printw("| %s: %s \n", label, ui_format_hytera_key(key_text, sizeof key_text, state, show_keys, segment_count));
+}
+
+static void
+ui_render_forced_key_status_dmr(const dsd_state* state, int show_keys) {
     if (state->R != 0) {
-        printw("| Forcing Key Priority -- NXDN Sc Key: %s \n", DSD_SECRET_REDACTED);
+        char key_text[16];
+        printw("| Forcing Key Priority -- NXDN Sc Key: %s \n",
+               dsd_secret_format_decimal(key_text, sizeof key_text, show_keys, state->R, 5U));
     }
     if (state->K != 0) {
-        printw("| Forcing Key Priority -- Moto BP Key: %s \n", DSD_SECRET_REDACTED);
+        char key_text[16];
+        printw("| Forcing Key Priority -- Moto BP Key: %s \n",
+               dsd_secret_format_decimal(key_text, sizeof key_text, show_keys, state->K, 3U));
     }
-    if (state->K1 != 0) {
-        printw("| Forcing Key Priority -- Hytera BP Key: %s \n", DSD_SECRET_REDACTED);
+    unsigned int hytera_segment_count = ui_hytera_key_segment_count(state);
+    if (hytera_segment_count != 0U) {
+        char key_text[68];
+        const char* label = (hytera_segment_count == 1U) ? "Hytera BP Key" : "Hytera Key";
+        printw("| Forcing Key Priority -- %s: %s \n", label,
+               ui_format_hytera_key(key_text, sizeof key_text, state, show_keys, hytera_segment_count));
     }
-    if (state->K != 0 && state->K1 != 0) {
+    if (state->K != 0 && hytera_segment_count != 0U) {
         printw("| Warning! Multiple DMR Key Types Loaded! \n"); //warning may not be required
     }
 }
 
 static void
-ui_render_forced_key_status_rc4(const dsd_state* state) {
+ui_render_forced_key_status_rc4(const dsd_state* state, int show_keys) {
     if (state->R != 0) {
-        printw("| Forcing Key Priority -- RC4 Key: %s \n", DSD_SECRET_REDACTED);
+        char key_text[17];
+        printw("| Forcing Key Priority -- RC4 Key: %s \n",
+               dsd_secret_format_hex(key_text, sizeof key_text, show_keys, state->R, 10U, 0));
     }
 }
 
 static void
-ui_render_forced_key_status_tyt(const dsd_state* state) {
-    (void)state;
-    printw("| Forcing Key Priority -- TYT 16-bit Key: %s \n", DSD_SECRET_REDACTED);
+ui_render_forced_key_status_tyt(const dsd_state* state, int show_keys) {
+    char key_text[16];
+    printw("| Forcing Key Priority -- TYT 16-bit Key: %s \n",
+           dsd_secret_format_hex(key_text, sizeof key_text, show_keys, state->H, 4U, 0));
 }
 
 static void
-ui_render_forced_key_status(const dsd_state* state) {
+ui_render_forced_key_status(const dsd_state* state, int show_keys) {
     if (state == NULL) {
         return;
     }
 
-    if (state->M != 1 && state->H != 0 && state->tyt_bp == 0) {
-        ui_render_hytera_loaded_key_status(state);
+    if (state->M != 1 && state->tyt_bp == 0 && ui_hytera_key_segment_count(state) != 0U) {
+        ui_render_hytera_loaded_key_status(state, show_keys);
     }
     if (state->M == 1) {
-        ui_render_forced_key_status_dmr(state);
+        ui_render_forced_key_status_dmr(state, show_keys);
     }
     if (state->M == 0x21) {
-        ui_render_forced_key_status_rc4(state);
+        ui_render_forced_key_status_rc4(state, show_keys);
     }
     if (state->M == 0x16) {
-        ui_render_forced_key_status_tyt(state);
+        ui_render_forced_key_status_tyt(state, show_keys);
     }
 }
 
@@ -854,7 +880,7 @@ ui_render_scanner_and_reverse_status(const dsd_opts* opts, const dsd_state* stat
 
 static void
 ui_render_crypto_key_and_scanner_status(const dsd_opts* opts, const dsd_state* state) {
-    ui_render_forced_key_status(state);
+    ui_render_forced_key_status(state, opts->show_keys);
     ui_render_scanner_and_reverse_status(opts, state);
 }
 
@@ -1968,7 +1994,7 @@ ui_render_nxdn_tgt_src_line(const dsd_state* state) {
 }
 
 static void
-ui_render_nxdn_encryption_line(const dsd_state* state) {
+ui_render_nxdn_encryption_line(const dsd_opts* opts, const dsd_state* state) {
     printw("\n|");
     if (state->nxdn_cipher_type > 0) {
         printw(" ALG: %d Key ID: %02d ", state->nxdn_cipher_type, state->nxdn_key);
@@ -1989,7 +2015,8 @@ ui_render_nxdn_encryption_line(const dsd_state* state) {
             if (state->R != 0) {
                 attron(COLOR_PAIR(1));
                 printw("Seed: %04llX ", state->payload_miN);
-                printw("Key: %s ", DSD_SECRET_REDACTED);
+                char key_text[16];
+                printw("Key: %s ", dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, state->R, 5U));
                 attron(COLOR_PAIR(3));
             }
             break;
@@ -1999,7 +2026,8 @@ ui_render_nxdn_encryption_line(const dsd_state* state) {
             attron(COLOR_PAIR(2));
             printw("DES1 ");
             if (state->R != 0) {
-                printw("Key: %s ", DSD_SECRET_REDACTED);
+                char key_text[17];
+                printw("Key: %s ", dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->R, 16U, 0));
             }
             attroff(COLOR_PAIR(2));
             attron(COLOR_PAIR(3));
@@ -2010,7 +2038,9 @@ ui_render_nxdn_encryption_line(const dsd_state* state) {
             attron(COLOR_PAIR(2));
             printw("AES-256 ");
             if (state->aes_key_loaded[0] == 1) {
-                printw("KS: %s", DSD_SECRET_REDACTED);
+                char key_text[17];
+                printw("KS: %s",
+                       dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->A4[0], 16U, 0));
             }
             attroff(COLOR_PAIR(2));
             attron(COLOR_PAIR(3));
@@ -2048,12 +2078,12 @@ ui_render_call_info_nxdn(const dsd_opts* opts, const dsd_state* state) {
     ui_render_nxdn_monitor_line(opts, state, idas);
     ui_render_nxdn_site_line(state, idas);
     ui_render_nxdn_tgt_src_line(state);
-    ui_render_nxdn_encryption_line(state);
+    ui_render_nxdn_encryption_line(opts, state);
     ui_render_nxdn_active_channels_and_tg_hold(opts, state);
 }
 
 static void
-ui_render_call_info_dpmr(dsd_state* state) {
+ui_render_call_info_dpmr(const dsd_opts* opts, dsd_state* state) {
     //dPMR
     if (DSD_SYNC_IS_DPMR(lls)) {
         printw("| DCC: [%i] ", state->dpmr_color_code);
@@ -2066,7 +2096,9 @@ ui_render_call_info_dpmr(dsd_state* state) {
             attron(COLOR_PAIR(3));
             if (state->R != 0) {
                 attron(COLOR_PAIR(1));
-                printw("KEY VALUE: [%s] ", DSD_SECRET_REDACTED);
+                char key_text[16];
+                printw("KEY VALUE: [%s] ",
+                       dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, state->R, 5U));
                 attron(COLOR_PAIR(3));
             }
         }
@@ -2584,12 +2616,13 @@ ui_render_slot_p25_dmr_alg_details(const ui_slot_view* slot, int show_p25_vxtra)
 }
 
 static int
-ui_render_slot_named_crypto_rc4_des(const ui_slot_view* slot) {
+ui_render_slot_named_crypto_rc4_des(const ui_slot_view* slot, int show_keys) {
     if (slot->payload_algid == 0xAA || slot->payload_algid == 0x21 || slot->payload_algid == 0x01) {
         attron(COLOR_PAIR(1));
         printw("RC4 ");
         if (slot->rc4_key != 0) {
-            printw("Key: %s ", DSD_SECRET_REDACTED);
+            char key_text[17];
+            printw("Key: %s ", dsd_secret_format_hex(key_text, sizeof key_text, show_keys, slot->rc4_key, 10U, 0));
         }
         attron(COLOR_PAIR(3));
         return 1;
@@ -2598,7 +2631,8 @@ ui_render_slot_named_crypto_rc4_des(const ui_slot_view* slot) {
         attron(COLOR_PAIR(1));
         printw("DES1 ");
         if (slot->rc4_key != 0) {
-            printw("Key: %s ", DSD_SECRET_REDACTED);
+            char key_text[17];
+            printw("Key: %s ", dsd_secret_format_hex(key_text, sizeof key_text, show_keys, slot->rc4_key, 16U, 0));
         }
         attron(COLOR_PAIR(3));
         return 1;
@@ -2607,7 +2641,8 @@ ui_render_slot_named_crypto_rc4_des(const ui_slot_view* slot) {
         attron(COLOR_PAIR(1));
         printw("DES-XL ");
         if (slot->rc4_key != 0) {
-            printw("Key: %s ", DSD_SECRET_REDACTED);
+            char key_text[17];
+            printw("Key: %s ", dsd_secret_format_hex(key_text, sizeof key_text, show_keys, slot->rc4_key, 16U, 0));
         }
         attron(COLOR_PAIR(3));
         return 1;
@@ -2628,12 +2663,13 @@ ui_render_slot_named_crypto_rc4_des(const ui_slot_view* slot) {
 }
 
 static int
-ui_render_slot_named_crypto_aes(const ui_slot_view* slot) {
+ui_render_slot_named_crypto_aes(const ui_slot_view* slot, int show_keys) {
     if (slot->payload_algid == 0x89 || slot->payload_algid == 0x24) {
         attron(COLOR_PAIR(1));
         printw("AES-128 ");
         if (slot->aes_loaded != 0) {
-            printw("KS: %s ", DSD_SECRET_REDACTED);
+            char key_text[17];
+            printw("KS: %s ", dsd_secret_format_hex(key_text, sizeof key_text, show_keys, slot->aes_a2, 16U, 0));
         }
         attron(COLOR_PAIR(3));
         return 1;
@@ -2642,7 +2678,8 @@ ui_render_slot_named_crypto_aes(const ui_slot_view* slot) {
         attron(COLOR_PAIR(1));
         printw("AES-256 ");
         if (slot->aes_loaded != 0) {
-            printw("KS: %s ", DSD_SECRET_REDACTED);
+            char key_text[17];
+            printw("KS: %s ", dsd_secret_format_hex(key_text, sizeof key_text, show_keys, slot->aes_a4, 16U, 0));
         }
         attron(COLOR_PAIR(3));
         return 1;
@@ -2651,12 +2688,13 @@ ui_render_slot_named_crypto_aes(const ui_slot_view* slot) {
 }
 
 static int
-ui_render_slot_named_crypto_vendor(const ui_slot_view* slot) {
+ui_render_slot_named_crypto_vendor(const ui_slot_view* slot, int show_keys) {
     if (slot->payload_algid == 0x02) {
         attron(COLOR_PAIR(1));
         printw("Hytera Enhanced");
         if (slot->rc4_key != 0) {
-            printw(" Key: %s", DSD_SECRET_REDACTED);
+            char key_text[17];
+            printw(" Key: %s", dsd_secret_format_hex(key_text, sizeof key_text, show_keys, slot->rc4_key, 10U, 0));
         }
         attron(COLOR_PAIR(3));
         return 1;
@@ -2671,7 +2709,8 @@ ui_render_slot_named_crypto_vendor(const ui_slot_view* slot) {
         attron(COLOR_PAIR(1));
         printw((slot->payload_algid == 0x36) ? "Kirisun Adv" : "Kirisun Uni");
         if (slot->aes_loaded != 0) {
-            printw(" KS: %s", DSD_SECRET_REDACTED);
+            char key_text[17];
+            printw(" KS: %s", dsd_secret_format_hex(key_text, sizeof key_text, show_keys, slot->aes_a4, 16U, 0));
         }
         attron(COLOR_PAIR(3));
         return 1;
@@ -2680,21 +2719,22 @@ ui_render_slot_named_crypto_vendor(const ui_slot_view* slot) {
 }
 
 static void
-ui_render_slot_named_crypto_details(const ui_slot_view* slot, int show_crypto_status) {
+ui_render_slot_named_crypto_details(const ui_slot_view* slot, int show_crypto_status, int show_keys) {
     if (!show_crypto_status) {
         return;
     }
-    if (ui_render_slot_named_crypto_rc4_des(slot)) {
+    if (ui_render_slot_named_crypto_rc4_des(slot, show_keys)) {
         return;
     }
-    if (ui_render_slot_named_crypto_aes(slot)) {
+    if (ui_render_slot_named_crypto_aes(slot, show_keys)) {
         return;
     }
-    (void)ui_render_slot_named_crypto_vendor(slot);
+    (void)ui_render_slot_named_crypto_vendor(slot, show_keys);
 }
 
 static void
-ui_render_slot_vxtra_line(const dsd_state* state, const ui_slot_view* slot, const ui_slot_render_flags* flags) {
+ui_render_slot_vxtra_line(const dsd_opts* opts, const dsd_state* state, const ui_slot_view* slot,
+                          const ui_slot_render_flags* flags) {
     printw("| V XTRA | ");
 
     if (slot->burst == 16 && slot->payload_algid == 0 && (slot->dmr_so & 0x40)) {
@@ -2706,20 +2746,23 @@ ui_render_slot_vxtra_line(const dsd_state* state, const ui_slot_view* slot, cons
     if (slot->burst == 16 && slot->payload_algid == 0 && state->K > 0 && slot->dmr_fid == 0x10
         && (slot->dmr_so & 0x40)) {
         attron(COLOR_PAIR(1));
-        printw("BP Key: %s ", DSD_SECRET_REDACTED);
+        char key_text[16];
+        printw("BP Key: %s ", dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, state->K, 3U));
         attroff(COLOR_PAIR(1));
         attron(COLOR_PAIR(3));
     }
     if (slot->burst == 16 && slot->payload_algid == 0 && state->H > 0 && slot->dmr_fid == 0x68
         && (slot->dmr_so & 0x40)) {
         attron(COLOR_PAIR(1));
-        printw("Hytera BP Key: %s ", DSD_SECRET_REDACTED);
+        char key_text[17];
+        printw("Hytera BP Key: %s ",
+               dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->H, 10U, 0));
         attroff(COLOR_PAIR(1));
         attron(COLOR_PAIR(3));
     }
 
     ui_render_slot_p25_dmr_alg_details(slot, flags->show_p25_vxtra);
-    ui_render_slot_named_crypto_details(slot, flags->show_crypto_status);
+    ui_render_slot_named_crypto_details(slot, flags->show_crypto_status, opts->show_keys);
     printw("\n");
 }
 
@@ -2775,10 +2818,10 @@ ui_render_slot_dxtra_line(const dsd_state* state, const ui_slot_view* slot, int 
 }
 
 static void
-ui_render_p25_dmr_slot_block(const dsd_state* state, const ui_slot_view* slot) {
+ui_render_p25_dmr_slot_block(const dsd_opts* opts, const dsd_state* state, const ui_slot_view* slot) {
     ui_slot_render_flags flags = {0};
     ui_render_slot_header_line(state, slot, &flags);
-    ui_render_slot_vxtra_line(state, slot, &flags);
+    ui_render_slot_vxtra_line(opts, state, slot, &flags);
     ui_render_slot_dxtra_line(state, slot, flags.show_ids);
 }
 
@@ -2825,8 +2868,8 @@ ui_render_call_info_p25_dmr(const dsd_opts* opts, dsd_state* state) {
 
     ui_slot_view left = ui_build_slot_view(state, 0);
     ui_slot_view right = ui_build_slot_view(state, 1);
-    ui_render_p25_dmr_slot_block(state, &left);
-    ui_render_p25_dmr_slot_block(state, &right);
+    ui_render_p25_dmr_slot_block(opts, state, &left);
+    ui_render_p25_dmr_slot_block(opts, state, &right);
     ui_render_p25_dmr_active_channels_line(opts, state);
     ui_render_p25_dmr_tuned_freq_line(opts, state);
 }
@@ -2845,7 +2888,7 @@ ui_render_call_info_and_history(const dsd_opts* opts, dsd_state* state) {
 
     ui_render_call_info_p25_dmr(opts, state);
 
-    ui_render_call_info_dpmr(state);
+    ui_render_call_info_dpmr(opts, state);
 
     ui_render_call_info_edacs(opts, state);
 

--- a/src/ui/terminal/menu_labels.c
+++ b/src/ui/terminal/menu_labels.c
@@ -25,6 +25,7 @@
 #include "menu_env.h"
 #include "menu_internal.h"
 #include "menu_items.h"
+#include "ui_key_status.h"
 
 #ifdef USE_RADIO
 #include <dsd-neo/io/rtl_stream_c.h>
@@ -910,14 +911,8 @@ lbl_key_hytera(const void* v, char* b, size_t n) {
         DSD_SNPRINTF(b, n, "Hytera Privacy (HEX)");
         return b;
     }
-    const char* kind;
-    if (s->K2 == 0ULL && s->K3 == 0ULL && s->K4 == 0ULL) {
-        kind = "40-bit";
-    } else if (s->K3 == 0ULL && s->K4 == 0ULL) {
-        kind = "128-bit";
-    } else {
-        kind = "256-bit";
-    }
+    const unsigned int segment_count = ui_hytera_key_segment_count(s);
+    const char* kind = (segment_count == 1U) ? "40-bit" : ((segment_count == 2U) ? "128-bit" : "256-bit");
     DSD_SNPRINTF(b, n, "Hytera Privacy (HEX) [%s]", kind);
     return b;
 }

--- a/src/ui/terminal/ui_cmd_queue.c
+++ b/src/ui/terminal/ui_cmd_queue.c
@@ -145,7 +145,7 @@ static int
 ui_apply_visibility_toggle(dsd_opts* opts, int cmd_id) {
     for (size_t i = 0; i < (sizeof k_ui_visibility_toggle_specs / sizeof k_ui_visibility_toggle_specs[0]); ++i) {
         if (k_ui_visibility_toggle_specs[i].cmd_id == cmd_id) {
-            int* field = (int*)((char*)opts + k_ui_visibility_toggle_specs[i].opts_offset);
+            uint8_t* field = (uint8_t*)((char*)opts + k_ui_visibility_toggle_specs[i].opts_offset);
             *field = *field ? 0 : 1;
             return 1;
         }
@@ -242,107 +242,120 @@ apply_cmd_key_management_basic(dsd_opts* opts, dsd_state* state, const struct Ui
 }
 
 static int
-apply_cmd_key_management_block_keys(dsd_opts* opts, dsd_state* state, const struct UiCmd* c) {
-    if (!opts || !state || !c) {
+apply_cmd_key_hytera_set(dsd_opts* opts, dsd_state* state, const struct UiCmd* c) {
+    if (!opts || !state || !c || c->n < (int)(sizeof(uint64_t) * 5)) {
         return 0;
     }
-    switch (c->id) {
-        case UI_CMD_KEY_HYTERA_SET: {
-            if (c->n >= (int)(sizeof(uint64_t) * 5)) {
-                struct {
-                    uint64_t H, K1, K2, K3, K4;
-                } p;
 
-                DSD_MEMCPY(&p, c->data, sizeof p);
-                state->H = p.H;
-                state->K1 = p.K1;
-                state->K2 = p.K2;
-                state->K3 = p.K3;
-                state->K4 = p.K4;
-                ui_cmd_reset_key_mute_state(opts, state);
-                DSD_SNPRINTF(state->ui_msg, sizeof state->ui_msg, "Hytera key loaded (%s)",
-                             (state->M == 1) ? "forced" : "not forced");
-                state->ui_msg_expire = time(NULL) + 5;
-            }
-            return 1;
-        }
-        case UI_CMD_KEY_AES_SET: {
-            if (c->n >= (int)(sizeof(uint64_t) * 4)) {
-                struct {
-                    uint64_t K1, K2, K3, K4;
-                } p;
+    struct {
+        uint64_t H, K1, K2, K3, K4;
+    } p;
 
-                DSD_MEMCPY(&p, c->data, sizeof p);
-                state->A1[0] = state->A1[1] = p.K1;
-                state->A2[0] = state->A2[1] = p.K2;
-                state->A3[0] = state->A3[1] = p.K3;
-                state->A4[0] = state->A4[1] = p.K4;
-                state->aes_key_loaded[0] = state->aes_key_loaded[1] =
-                    (p.K1 != 0ULL || p.K2 != 0ULL || p.K3 != 0ULL || p.K4 != 0ULL) ? 1 : 0;
-                state->aes_key_segments[0] = state->aes_key_segments[1] = 4U;
-                state->H = 0ULL;
-                state->K1 = 0ULL;
-                state->K2 = 0ULL;
-                state->K3 = 0ULL;
-                state->K4 = 0ULL;
-                ui_cmd_reset_key_mute_state(opts, state);
-            }
-            return 1;
-        }
-        default: return 0;
+    DSD_MEMCPY(&p, c->data, sizeof p);
+    state->H = p.H;
+    state->K1 = p.K1;
+    state->K2 = p.K2;
+    state->K3 = p.K3;
+    state->K4 = p.K4;
+    if (state->K1 == 0ULL && state->K2 == 0ULL && state->K3 == 0ULL && state->K4 == 0ULL) {
+        state->hytera_key_segments = 0U;
+    } else if (state->K3 != 0ULL || state->K4 != 0ULL) {
+        state->hytera_key_segments = 4U;
+    } else if (state->K2 != 0ULL) {
+        state->hytera_key_segments = 2U;
+    } else {
+        state->hytera_key_segments = 1U;
     }
+    ui_cmd_reset_key_mute_state(opts, state);
+    DSD_SNPRINTF(state->ui_msg, sizeof state->ui_msg, "Hytera key loaded (%s)",
+                 (state->M == 1) ? "forced" : "not forced");
+    state->ui_msg_expire = time(NULL) + 5;
+    return 1;
 }
 
 static int
-apply_cmd_key_management_stream_keys(dsd_state* state, const struct UiCmd* c) {
-    if (!state || !c) {
+apply_cmd_key_aes_set(dsd_opts* opts, dsd_state* state, const struct UiCmd* c) {
+    if (!opts || !state || !c || c->n < (int)(sizeof(uint64_t) * 4)) {
         return 0;
     }
-    switch (c->id) {
-        case UI_CMD_KEY_TYT_AP_SET: {
-            char s[256];
-            if (ui_cmd_copy_payload_string(c, s, sizeof s)) {
-                tyt_ap_pc4_keystream_creation(state, s);
-            }
-            return 1;
-        }
-        case UI_CMD_KEY_RETEVIS_RC2_SET: {
-            char s[256];
-            if (ui_cmd_copy_payload_string(c, s, sizeof s)) {
-                retevis_rc2_keystream_creation(state, s);
-            }
-            return 1;
-        }
-        case UI_CMD_KEY_TYT_EP_SET: {
-            char s[256];
-            if (ui_cmd_copy_payload_string(c, s, sizeof s)) {
-                tyt_ep_aes_keystream_creation(state, s);
-            }
-            return 1;
-        }
-        case UI_CMD_KEY_KEN_SCR_SET: {
-            char s[128];
-            if (ui_cmd_copy_payload_string(c, s, sizeof s)) {
-                ken_dmr_scrambler_keystream_creation(state, s);
-            }
-            return 1;
-        }
-        case UI_CMD_KEY_ANYTONE_BP_SET: {
-            char s[128];
-            if (ui_cmd_copy_payload_string(c, s, sizeof s)) {
-                anytone_bp_keystream_creation(state, s);
-            }
-            return 1;
-        }
-        case UI_CMD_KEY_XOR_SET: {
-            char s[256];
-            if (ui_cmd_copy_payload_string(c, s, sizeof s)) {
-                straight_mod_xor_keystream_creation(state, s);
-            }
-            return 1;
-        }
-        default: return 0;
+
+    struct {
+        uint64_t K1, K2, K3, K4;
+    } p;
+
+    DSD_MEMCPY(&p, c->data, sizeof p);
+    state->A1[0] = state->A1[1] = p.K1;
+    state->A2[0] = state->A2[1] = p.K2;
+    state->A3[0] = state->A3[1] = p.K3;
+    state->A4[0] = state->A4[1] = p.K4;
+    state->aes_key_loaded[0] = state->aes_key_loaded[1] =
+        (p.K1 != 0ULL || p.K2 != 0ULL || p.K3 != 0ULL || p.K4 != 0ULL) ? 1 : 0;
+    state->aes_key_segments[0] = state->aes_key_segments[1] = 4U;
+    state->H = 0ULL;
+    state->K1 = 0ULL;
+    state->K2 = 0ULL;
+    state->K3 = 0ULL;
+    state->K4 = 0ULL;
+    state->hytera_key_segments = 0U;
+    ui_cmd_reset_key_mute_state(opts, state);
+    return 1;
+}
+
+static int
+apply_cmd_key_management_block_keys(dsd_opts* opts, dsd_state* state, const struct UiCmd* c) {
+    static const struct UiCmdHandlerEntry entries[] = {
+        {UI_CMD_KEY_HYTERA_SET, apply_cmd_key_hytera_set},
+        {UI_CMD_KEY_AES_SET, apply_cmd_key_aes_set},
+    };
+    return ui_cmd_apply_handler_table(entries, sizeof entries / sizeof entries[0], opts, state, c);
+}
+
+typedef void (*UiStreamKeyLoaderFn)(dsd_state* state, const char* input, int show_keys);
+
+struct UiStreamKeyLoaderEntry {
+    int cmd_id;
+    size_t payload_cap;
+    UiStreamKeyLoaderFn fn;
+};
+
+static void
+ui_load_ken_scrambler_key(dsd_state* state, const char* input, int show_keys) {
+    char local[128];
+    DSD_SNPRINTF(local, sizeof local, "%s", input ? input : "");
+    ken_dmr_scrambler_keystream_creation(state, local, show_keys);
+}
+
+static void
+ui_load_anytone_bp_key(dsd_state* state, const char* input, int show_keys) {
+    char local[128];
+    DSD_SNPRINTF(local, sizeof local, "%s", input ? input : "");
+    anytone_bp_keystream_creation(state, local, show_keys);
+}
+
+static int
+apply_cmd_key_management_stream_keys(const dsd_opts* opts, dsd_state* state, const struct UiCmd* c) {
+    static const struct UiStreamKeyLoaderEntry entries[] = {
+        {UI_CMD_KEY_TYT_AP_SET, 256U, tyt_ap_pc4_keystream_creation},
+        {UI_CMD_KEY_RETEVIS_RC2_SET, 256U, retevis_rc2_keystream_creation},
+        {UI_CMD_KEY_TYT_EP_SET, 256U, tyt_ep_aes_keystream_creation},
+        {UI_CMD_KEY_KEN_SCR_SET, 128U, ui_load_ken_scrambler_key},
+        {UI_CMD_KEY_ANYTONE_BP_SET, 128U, ui_load_anytone_bp_key},
+        {UI_CMD_KEY_XOR_SET, 256U, straight_mod_xor_keystream_creation},
+    };
+    if (!opts || !state || !c) {
+        return 0;
     }
+
+    for (size_t i = 0U; i < sizeof entries / sizeof entries[0]; i++) {
+        if (entries[i].cmd_id == c->id) {
+            char s[256];
+            if (ui_cmd_copy_payload_string(c, s, entries[i].payload_cap)) {
+                entries[i].fn(state, s, opts->show_keys);
+            }
+            return 1;
+        }
+    }
+    return 0;
 }
 
 static int
@@ -369,7 +382,7 @@ apply_cmd_key_management(dsd_opts* opts, dsd_state* state, const struct UiCmd* c
     if (apply_cmd_key_management_block_keys(opts, state, c)) {
         return 1;
     }
-    if (apply_cmd_key_management_stream_keys(state, c)) {
+    if (apply_cmd_key_management_stream_keys(opts, state, c)) {
         return 1;
     }
     return apply_cmd_key_management_m17(state, c);

--- a/src/ui/terminal/ui_key_status.h
+++ b/src/ui/terminal/ui_key_status.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef DSD_NEO_UI_TERMINAL_UI_KEY_STATUS_H
+#define DSD_NEO_UI_TERMINAL_UI_KEY_STATUS_H
+
+#include <dsd-neo/core/state.h>
+#include <stddef.h>
+#include "dsd-neo/core/state_fwd.h"
+
+static inline unsigned int
+ui_hytera_key_segment_count(const dsd_state* state) {
+    if (state == NULL || (state->K1 == 0ULL && state->K2 == 0ULL && state->K3 == 0ULL && state->K4 == 0ULL)) {
+        return 0U;
+    }
+    if (state->hytera_key_segments == 2U || state->hytera_key_segments == 4U) {
+        return state->hytera_key_segments;
+    }
+    if (state->hytera_key_segments == 1U) {
+        return 1U;
+    }
+    if (state->K3 != 0ULL || state->K4 != 0ULL) {
+        return 4U;
+    }
+    if (state->K2 != 0ULL) {
+        return 2U;
+    }
+    return 1U;
+}
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -579,7 +579,10 @@ target_include_directories(
     dsd-neo_test_pc5_baofeng
     PRIVATE ${PROJECT_SOURCE_DIR}/include
 )
-target_link_libraries(dsd-neo_test_pc5_baofeng PRIVATE dsd-neo_crypto)
+target_link_libraries(
+    dsd-neo_test_pc5_baofeng
+    PRIVATE dsd-neo_crypto dsd-neo_test_support
+)
 
 add_test(NAME PC5_BAOFENG COMMAND dsd-neo_test_pc5_baofeng)
 
@@ -588,7 +591,10 @@ target_include_directories(
     dsd-neo_test_csi72
     PRIVATE ${PROJECT_SOURCE_DIR}/include
 )
-target_link_libraries(dsd-neo_test_csi72 PRIVATE dsd-neo_crypto)
+target_link_libraries(
+    dsd-neo_test_csi72
+    PRIVATE dsd-neo_crypto dsd-neo_test_support
+)
 
 add_test(NAME CSI72 COMMAND dsd-neo_test_csi72)
 
@@ -832,7 +838,7 @@ target_include_directories(
 )
 target_link_libraries(
     dsd-neo_test_nxdn_element_bounds
-    PRIVATE dsd-neo_proto_nxdn
+    PRIVATE dsd-neo_proto_nxdn dsd-neo_test_support
 )
 add_test(NAME NXDN_ELEMENT_BOUNDS COMMAND dsd-neo_test_nxdn_element_bounds)
 
@@ -1542,6 +1548,20 @@ target_include_directories(
 )
 target_link_libraries(dsd-neo_test_core_safe_api PRIVATE dsd-neo_safe_api)
 add_test(NAME CORE_SAFE_API COMMAND dsd-neo_test_core_safe_api)
+
+add_executable(
+    dsd-neo_test_core_secret_redaction
+    core/test_core_secret_redaction.c
+)
+target_include_directories(
+    dsd-neo_test_core_secret_redaction
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_core_secret_redaction
+    PRIVATE dsd-neo_safe_api
+)
+add_test(NAME CORE_SECRET_REDACTION COMMAND dsd-neo_test_core_secret_redaction)
 
 add_executable(dsd-neo_test_core_csv_import core/test_core_csv_import.c)
 target_include_directories(
@@ -4174,7 +4194,10 @@ target_include_directories(
     dsd-neo_test_dmr_block_crypto
     PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/protocol/dmr
 )
-target_link_libraries(dsd-neo_test_dmr_block_crypto PRIVATE dsd-neo_crypto)
+target_link_libraries(
+    dsd-neo_test_dmr_block_crypto
+    PRIVATE dsd-neo_crypto dsd-neo_test_support
+)
 add_test(NAME DMR_BLOCK_CRYPTO COMMAND dsd-neo_test_dmr_block_crypto)
 
 # DMR relaxed header acceptance for SAP=4 (IP-based)

--- a/tests/core/test_core_init_state.c
+++ b/tests/core/test_core_init_state.c
@@ -21,6 +21,10 @@ test_init_opts_clears_trunk_scan_targets_csv(void) {
         DSD_FPRINTF(stderr, "initOpts did not clear trunk_scan_targets_csv\n");
         return 20;
     }
+    if (opts.show_keys != 0U) {
+        DSD_FPRINTF(stderr, "initOpts did not default show_keys to redacted\n");
+        return 21;
+    }
     return 0;
 }
 
@@ -72,6 +76,7 @@ main(void) {
     state->K2 = 0x2222222222222222ULL;
     state->K3 = 0x3333333333333333ULL;
     state->K4 = 0x4444444444444444ULL;
+    state->hytera_key_segments = 4U;
     state->M = 0x21;
     state->payload_mi = 0x1111222233334444ULL;
     state->payload_miR = 0x5555666677778888ULL;
@@ -126,7 +131,8 @@ main(void) {
         return 2;
     }
     if (state->K != 0 || state->R != 0ULL || state->RR != 0ULL || state->H != 0ULL || state->K1 != 0ULL
-        || state->K2 != 0ULL || state->K3 != 0ULL || state->K4 != 0ULL || state->M != 0) {
+        || state->K2 != 0ULL || state->K3 != 0ULL || state->K4 != 0ULL || state->hytera_key_segments != 0U
+        || state->M != 0) {
         DSD_FPRINTF(stderr, "initState did not clear manual crypto key fields\n");
         freeState(state);
         free(state);

--- a/tests/core/test_core_secret_redaction.c
+++ b/tests/core/test_core_secret_redaction.c
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/secret_redaction.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "dsd-neo/core/safe_api.h"
+
+static int
+expect_str(const char* label, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: expected \"%s\", got \"%s\"\n", label, want, got);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_redacted_default(void) {
+    char buf[64];
+    uint8_t bytes[2] = {0x12U, 0xABU};
+    unsigned long long segments[2] = {0x1ULL, 0x2ULL};
+    int rc = 0;
+    rc |=
+        expect_str("redacted decimal", dsd_secret_format_decimal(buf, sizeof buf, 0, 123ULL, 5U), DSD_SECRET_REDACTED);
+    rc |= expect_str("redacted hex", dsd_secret_format_hex(buf, sizeof buf, 0, 0xABULL, 4U, 1), DSD_SECRET_REDACTED);
+    rc |= expect_str("redacted segments", dsd_secret_format_u64_segments(buf, sizeof buf, 0, segments, 2U),
+                     DSD_SECRET_REDACTED);
+    rc |= expect_str("redacted bytes", dsd_secret_format_byte_hex(buf, sizeof buf, 0, bytes, sizeof bytes),
+                     DSD_SECRET_REDACTED);
+    rc |= expect_str("redacted string", dsd_secret_format_string(buf, sizeof buf, 0, "ABCDEF"), DSD_SECRET_REDACTED);
+    return rc;
+}
+
+static int
+test_revealed_decimal_and_hex(void) {
+    char buf[64];
+    int rc = 0;
+    rc |= expect_str("decimal width", dsd_secret_format_decimal(buf, sizeof buf, 1, 42ULL, 5U), "00042");
+    rc |= expect_str("decimal no width", dsd_secret_format_decimal(buf, sizeof buf, 1, 42ULL, 0U), "42");
+    rc |= expect_str("hex width", dsd_secret_format_hex(buf, sizeof buf, 1, 0x1AULL, 4U, 0), "001A");
+    rc |= expect_str("hex prefix", dsd_secret_format_hex(buf, sizeof buf, 1, 0x1AULL, 4U, 1), "0x001A");
+    return rc;
+}
+
+static int
+test_revealed_segments_and_bytes(void) {
+    char buf[128];
+    unsigned long long segments[2] = {0x1122ULL, 0xAABBULL};
+    uint8_t bytes[3] = {0x12U, 0xABU, 0x00U};
+    int rc = 0;
+    rc |= expect_str("segments", dsd_secret_format_u64_segments(buf, sizeof buf, 1, segments, 2U),
+                     "0000000000001122 000000000000AABB");
+    rc |= expect_str("bytes", dsd_secret_format_byte_hex(buf, sizeof buf, 1, bytes, sizeof bytes), "12AB00");
+    rc |= expect_str("string", dsd_secret_format_string(buf, sizeof buf, 1, "ABCDEF"), "ABCDEF");
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_redacted_default();
+    rc |= test_revealed_decimal_and_hex();
+    rc |= test_revealed_segments_and_bytes();
+    return rc;
+}

--- a/tests/core/test_core_straight_keystream_validation.c
+++ b/tests/core/test_core_straight_keystream_validation.c
@@ -147,7 +147,7 @@ main(void) {
     {
         char arg[] = "0x12345";
         const uint16_t expect = anytone_expected_perm(0x2345U);
-        anytone_bp_keystream_creation(st, arg);
+        anytone_bp_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("anytone-enabled", st->any_bp, 1);
         rc |= expect_eq_u8("anytone-truncated-byte0", bits_to_u8(st->static_ks_bits[0], 0), (expect >> 8U) & 0xFFU);
         rc |= expect_eq_u8("anytone-truncated-byte1", bits_to_u8(st->static_ks_bits[0], 8), expect & 0xFFU);
@@ -180,7 +180,7 @@ main(void) {
     DSD_MEMSET(st->static_ks_bits, 0, sizeof(st->static_ks_bits));
     {
         char arg[] = "1";
-        ken_dmr_scrambler_keystream_creation(st, arg);
+        ken_dmr_scrambler_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("kenwood-enabled", st->ken_sc, 1);
         rc |= expect_eq_u8("kenwood-seed-byte0", bits_to_u8(st->static_ks_bits[0], 0), 0x80U);
         rc |= expect_eq_u8("kenwood-slot1-byte0", bits_to_u8(st->static_ks_bits[1], 0), 0x80U);
@@ -213,7 +213,7 @@ main(void) {
     st->straight_mod = 77;
     {
         char arg[] = "0:AA";
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("len-zero-disabled", st->straight_ks, 0);
         rc |= expect_eq_int("len-zero-mod", st->straight_mod, 0);
     }
@@ -222,7 +222,7 @@ main(void) {
     st->straight_mod = 55;
     {
         char arg[] = "999:AA";
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("len-too-large-disabled", st->straight_ks, 0);
         rc |= expect_eq_int("len-too-large-mod", st->straight_mod, 0);
     }
@@ -231,7 +231,7 @@ main(void) {
     st->straight_mod = 11;
     {
         char arg[] = "49";
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("malformed-disabled", st->straight_ks, 0);
         rc |= expect_eq_int("malformed-mod", st->straight_mod, 0);
     }
@@ -240,7 +240,7 @@ main(void) {
     st->straight_mod = 11;
     {
         char arg[] = "49x:F0";
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("len-partial-disabled", st->straight_ks, 0);
         rc |= expect_eq_int("len-partial-mod", st->straight_mod, 0);
     }
@@ -248,7 +248,7 @@ main(void) {
     DSD_MEMSET(st->static_ks_bits, 0, sizeof(st->static_ks_bits));
     {
         char arg[] = "49:123456789ABC80";
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("valid-enabled", st->straight_ks, 1);
         rc |= expect_eq_int("valid-mod", st->straight_mod, 49);
         rc |= expect_eq_u8("slot0-first-byte", bits_to_u8(st->static_ks_bits[0], 0), 0x12U);
@@ -261,7 +261,7 @@ main(void) {
     // Optional frame alignment parsing: explicit offset + step.
     {
         char arg[] = "8:F0:2:3";
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("frame-mode-enabled", st->straight_ks, 1);
         rc |= expect_eq_int("frame-mode-flag", st->straight_frame_mode, 1);
         rc |= expect_eq_int("frame-mode-off", st->straight_frame_off, 2);
@@ -271,7 +271,7 @@ main(void) {
     // Offset-only syntax defaults step to 49 bits per frame (then modulo len).
     {
         char arg[] = "8:F0:2";
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("frame-default-step-enabled", st->straight_ks, 1);
         rc |= expect_eq_int("frame-default-step-flag", st->straight_frame_mode, 1);
         rc |= expect_eq_int("frame-default-step-val", st->straight_frame_step, 1); // 49 % 8
@@ -282,7 +282,7 @@ main(void) {
     st->straight_mod = 8;
     {
         char arg[] = "8:F0:bad";
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("bad-offset-disabled", st->straight_ks, 0);
         rc |= expect_eq_int("bad-offset-mod", st->straight_mod, 0);
     }
@@ -290,7 +290,7 @@ main(void) {
     st->straight_mod = 8;
     {
         char arg[] = "8:F0:2x:3";
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("bad-offset-partial-disabled", st->straight_ks, 0);
         rc |= expect_eq_int("bad-offset-partial-mod", st->straight_mod, 0);
     }
@@ -298,7 +298,7 @@ main(void) {
     st->straight_mod = 8;
     {
         char arg[] = "8:F0:0x10:3";
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("bad-offset-hex-disabled", st->straight_ks, 0);
         rc |= expect_eq_int("bad-offset-hex-mod", st->straight_mod, 0);
     }
@@ -306,7 +306,7 @@ main(void) {
     st->straight_mod = 8;
     {
         char arg[] = "8:F0:2:3x";
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("bad-step-partial-disabled", st->straight_ks, 0);
         rc |= expect_eq_int("bad-step-partial-mod", st->straight_mod, 0);
     }
@@ -314,7 +314,7 @@ main(void) {
     st->straight_mod = 8;
     {
         char arg[] = "8:F0:1:2:3";
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         rc |= expect_eq_int("extra-fields-disabled", st->straight_ks, 0);
         rc |= expect_eq_int("extra-fields-mod", st->straight_mod, 0);
     }
@@ -328,7 +328,7 @@ main(void) {
         DSD_MEMSET(frame1, 0, sizeof(frame1));
         frame0[24] = 1;
         frame1[24] = 1;
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         straight_mod_xor_apply_frame49(st, 0, frame0);
         straight_mod_xor_apply_frame49(st, 0, frame1);
         rc |= expect_eq_u8("legacy-frame0-byte0", bits_to_u8((const uint8_t*)frame0, 0), 0xF0U);
@@ -359,7 +359,7 @@ main(void) {
         frame1[24] = 1;
         frame2[24] = 1;
         frame_slot1[24] = 1;
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         straight_mod_xor_apply_frame49(st, 0, frame0);
         straight_mod_xor_apply_frame49(st, 0, frame1);
         straight_mod_xor_apply_frame49(st, 0, frame2);
@@ -387,7 +387,7 @@ main(void) {
         char frame0[49];
         DSD_MEMSET(frame0, 0, sizeof(frame0));
         frame0[24] = 1;
-        straight_mod_xor_keystream_creation(st, arg);
+        straight_mod_xor_keystream_creation(st, arg, 0);
         st->static_ks_counter[0] = 1000000000;
         straight_mod_xor_apply_frame49(st, 0, frame0);
 

--- a/tests/crypto/test_csi72.c
+++ b/tests/crypto/test_csi72.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "test_support.h"
 
 void
 unpack_byte_array_into_bit_array(const uint8_t* input, uint8_t* output, int len) {
@@ -40,6 +41,28 @@ expect_bytes(const char* label, const uint8_t* got, const uint8_t* want, size_t 
 }
 
 static int
+expect_file_contains(const char* label, const char* path, const char* needle, int want_contains) {
+    FILE* fp = fopen(path, "rb");
+    if (!fp) {
+        DSD_FPRINTF(stderr, "%s: failed to open capture file\n", label);
+        return 1;
+    }
+
+    char buf[512];
+    size_t n = fread(buf, 1U, sizeof(buf) - 1U, fp);
+    fclose(fp);
+    buf[n] = '\0';
+
+    const int contains = strstr(buf, needle) != NULL;
+    if (contains != want_contains) {
+        DSD_FPRINTF(stderr, "%s: expected contains=%d for \"%s\", got %d in \"%s\"\n", label, want_contains, needle,
+                    contains, buf);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 expect_frame_string(const char* label, char frame[4][24], const char* want) {
     size_t pos = 0;
     for (int r = 0; r < 4; r++) {
@@ -61,7 +84,7 @@ test_ee72_key_parse(void) {
     static dsd_state state;
     DSD_MEMSET(&state, 0, sizeof(state));
 
-    int parse_rc = connect_systems_ee72_key_creation(&state, "0x11 22 33 44 55 66 77 88 99");
+    int parse_rc = connect_systems_ee72_key_creation(&state, "0x11 22 33 44 55 66 77 88 99", 0);
 
     int rc = 0;
     rc |= expect_int("ee72 parse", parse_rc, 0);
@@ -75,7 +98,7 @@ test_ee72_rejects_invalid_length(void) {
     static dsd_state state;
     DSD_MEMSET(&state, 0, sizeof(state));
 
-    int parse_rc = connect_systems_ee72_key_creation(&state, "1122334455667788");
+    int parse_rc = connect_systems_ee72_key_creation(&state, "1122334455667788", 0);
 
     int rc = 0;
     rc |= expect_int("ee72 invalid parse", parse_rc, -1);
@@ -105,11 +128,42 @@ test_csi72_frame_transform_vector(void) {
     return expect_frame_string("csi72 frame", frame, expect);
 }
 
+static int
+test_ee72_key_log_respects_show_keys(void) {
+    static dsd_state state;
+    int rc = 0;
+
+    dsd_test_capture_stderr cap;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    if (dsd_test_capture_stderr_begin(&cap, "ee72_redacted") != 0) {
+        DSD_FPRINTF(stderr, "failed to capture stderr for EE72 redacted log\n");
+        return 1;
+    }
+    rc |= expect_int("ee72 redacted parse", connect_systems_ee72_key_creation(&state, "112233445566778899", 0), 0);
+    rc |= dsd_test_capture_stderr_end(&cap);
+    rc |= expect_file_contains("ee72 redacted marker", cap.path, "[redacted]", 1);
+    rc |= expect_file_contains("ee72 redacted key", cap.path, "112233445566778899", 0);
+    (void)remove(cap.path);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    if (dsd_test_capture_stderr_begin(&cap, "ee72_revealed") != 0) {
+        DSD_FPRINTF(stderr, "failed to capture stderr for EE72 revealed log\n");
+        return 1;
+    }
+    rc |= expect_int("ee72 revealed parse", connect_systems_ee72_key_creation(&state, "112233445566778899", 1), 0);
+    rc |= dsd_test_capture_stderr_end(&cap);
+    rc |= expect_file_contains("ee72 revealed key", cap.path, "112233445566778899", 1);
+    (void)remove(cap.path);
+
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
     rc |= test_ee72_key_parse();
     rc |= test_ee72_rejects_invalid_length();
     rc |= test_csi72_frame_transform_vector();
+    rc |= test_ee72_key_log_respects_show_keys();
     return rc;
 }

--- a/tests/crypto/test_pc4_tyt.c
+++ b/tests/crypto/test_pc4_tyt.c
@@ -227,7 +227,7 @@ test_tyt_ap_128_key_schedule(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&g_pc4_context, 0, sizeof(g_pc4_context));
     char input[] = "736B9A9C5645288B 243AD5CB8701EF8A";
-    tyt_ap_pc4_keystream_creation(&state, input);
+    tyt_ap_pc4_keystream_creation(&state, input, 0);
 
     int rc = 0;
     rc |= expect_int("tyt ap 128 flag", state.tyt_ap, 1);
@@ -253,7 +253,7 @@ test_tyt_ap_256_key_schedule(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&g_pc4_context, 0, sizeof(g_pc4_context));
     char input[] = "0123456789ABCDEF FEDCBA9876543210 1111222233334444 5555666677778888";
-    tyt_ap_pc4_keystream_creation(&state, input);
+    tyt_ap_pc4_keystream_creation(&state, input, 0);
 
     int rc = 0;
     rc |= expect_int("tyt ap 256 flag", state.tyt_ap, 1);
@@ -279,7 +279,7 @@ test_tyt_ap_256_trailing_zero_chunks_key_schedule(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&g_pc4_context, 0, sizeof(g_pc4_context));
     char input[] = "0123456789ABCDEF FEDCBA9876543210 0000000000000000 0000000000000000";
-    tyt_ap_pc4_keystream_creation(&state, input);
+    tyt_ap_pc4_keystream_creation(&state, input, 0);
 
     int rc = 0;
     rc |= expect_int("tyt ap 256 zero chunks flag", state.tyt_ap, 1);
@@ -295,14 +295,14 @@ test_tyt_ap_rejects_malformed_keys(void) {
     DSD_MEMSET(&bad_char_state, 0, sizeof(bad_char_state));
     bad_char_state.tyt_ap = 1;
     char bad_char_input[] = "736B9A9C5645288B 243AD5CB8701EF8Z";
-    tyt_ap_pc4_keystream_creation(&bad_char_state, bad_char_input);
+    tyt_ap_pc4_keystream_creation(&bad_char_state, bad_char_input, 0);
     rc |= expect_int("tyt ap bad hex disables flag", bad_char_state.tyt_ap, 0);
 
     static dsd_state bad_length_state;
     DSD_MEMSET(&bad_length_state, 0, sizeof(bad_length_state));
     bad_length_state.tyt_ap = 1;
     char bad_length_input[] = "736B9A9C5645288B";
-    tyt_ap_pc4_keystream_creation(&bad_length_state, bad_length_input);
+    tyt_ap_pc4_keystream_creation(&bad_length_state, bad_length_input, 0);
     rc |= expect_int("tyt ap bad length disables flag", bad_length_state.tyt_ap, 0);
 
     return rc;
@@ -316,7 +316,7 @@ test_tyt_ep_aes_vector(void) {
     DSD_MEMSET(&g_pc4_context, 0, sizeof(g_pc4_context));
     char input[] = "736B9A9C5645288B 243AD5CB8701EF8A";
 
-    tyt_ep_aes_keystream_creation(&state, input);
+    tyt_ep_aes_keystream_creation(&state, input, 0);
 
     int rc = 0;
     rc |= expect_int("tyt ep flag", state.tyt_ep, 1);
@@ -353,7 +353,7 @@ test_tyt_ap_apply_decrypts_voice_frame(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&g_pc4_context, 0, sizeof(g_pc4_context));
     char input[] = "736B9A9C5645288B 243AD5CB8701EF8A";
-    tyt_ap_pc4_keystream_creation(&state, input);
+    tyt_ap_pc4_keystream_creation(&state, input, 0);
 
     char frame[49];
     short expected_input[49];
@@ -369,7 +369,7 @@ test_tyt_ap_apply_decrypts_voice_frame(void) {
     }
 
     DSD_MEMSET(&g_pc4_context, 0, sizeof(g_pc4_context));
-    tyt_ap_pc4_keystream_creation(&state, input);
+    tyt_ap_pc4_keystream_creation(&state, input, 0);
 
     int rc = 0;
     rc |= expect_int("tyt ap apply voice frame", tyt_ap_pc4_apply_frame49(&state, frame), 1);

--- a/tests/crypto/test_pc5_baofeng.c
+++ b/tests/crypto/test_pc5_baofeng.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "test_support.h"
 
 static int
 expect_int(const char* label, int got, int want) {
@@ -43,6 +44,28 @@ expect_char_frame(const char* label, const char got[49], const char want[49]) {
             DSD_FPRINTF(stderr, "%s: bit %d expected %d, got %d\n", label, i, want_bit, got_bit);
             return 1;
         }
+    }
+    return 0;
+}
+
+static int
+expect_file_contains(const char* label, const char* path, const char* needle, int want_contains) {
+    FILE* fp = fopen(path, "rb");
+    if (!fp) {
+        DSD_FPRINTF(stderr, "%s: failed to open capture file\n", label);
+        return 1;
+    }
+
+    char buf[512];
+    size_t n = fread(buf, 1U, sizeof(buf) - 1U, fp);
+    fclose(fp);
+    buf[n] = '\0';
+
+    const int contains = strstr(buf, needle) != NULL;
+    if (contains != want_contains) {
+        DSD_FPRINTF(stderr, "%s: expected contains=%d for \"%s\", got %d in \"%s\"\n", label, want_contains, needle,
+                    contains, buf);
+        return 1;
     }
     return 0;
 }
@@ -136,7 +159,7 @@ test_baofeng_128_key_schedule(void) {
     static dsd_state state;
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&ctxpc5, 0, sizeof(ctxpc5));
-    int parse_rc = baofeng_ap_pc5_keystream_creation(&state, "0123456789ABCDEF FEDCBA9876543210");
+    int parse_rc = baofeng_ap_pc5_keystream_creation(&state, "0123456789ABCDEF FEDCBA9876543210", 0);
 
     int rc = 0;
     rc |= expect_int("baofeng 128 parse", parse_rc, 0);
@@ -157,7 +180,7 @@ test_baofeng_256_key_schedule_uses_ascii_hex(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&ctxpc5, 0, sizeof(ctxpc5));
     int parse_rc = baofeng_ap_pc5_keystream_creation(
-        &state, "0001020304050607 08090A0B0C0D0E0F 1011121314151617 18191A1B1C1D1E1F");
+        &state, "0001020304050607 08090A0B0C0D0E0F 1011121314151617 18191A1B1C1D1E1F", 0);
 
     int rc = 0;
     rc |= expect_int("baofeng 256 parse", parse_rc, 0);
@@ -178,7 +201,7 @@ test_baofeng_256_key_schedule_preserves_ascii_case(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&ctxpc5, 0, sizeof(ctxpc5));
     int parse_rc = baofeng_ap_pc5_keystream_creation(
-        &state, "0001020304050607 08090a0b0c0d0e0f 1011121314151617 18191a1b1c1d1e1f");
+        &state, "0001020304050607 08090a0b0c0d0e0f 1011121314151617 18191a1b1c1d1e1f", 0);
 
     int rc = 0;
     rc |= expect_int("baofeng 256 lowercase parse", parse_rc, 0);
@@ -191,7 +214,7 @@ static int
 test_baofeng_rejects_invalid_hex(void) {
     static dsd_state state;
     DSD_MEMSET(&state, 0, sizeof(state));
-    int parse_rc = baofeng_ap_pc5_keystream_creation(&state, "0123456789ABCDEZ FEDCBA9876543210");
+    int parse_rc = baofeng_ap_pc5_keystream_creation(&state, "0123456789ABCDEZ FEDCBA9876543210", 0);
 
     int rc = 0;
     rc |= expect_int("baofeng invalid parse", parse_rc, -1);
@@ -204,7 +227,7 @@ test_baofeng_apply_skips_silence_and_zero_tail(void) {
     static dsd_state state;
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&ctxpc5, 0, sizeof(ctxpc5));
-    (void)baofeng_ap_pc5_keystream_creation(&state, "0123456789ABCDEF FEDCBA9876543210");
+    (void)baofeng_ap_pc5_keystream_creation(&state, "0123456789ABCDEF FEDCBA9876543210", 0);
 
     int rc = 0;
     char silence[49];
@@ -233,7 +256,7 @@ test_baofeng_apply_decrypts_voice_frame(void) {
     static dsd_state state;
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&ctxpc5, 0, sizeof(ctxpc5));
-    (void)baofeng_ap_pc5_keystream_creation(&state, "0123456789ABCDEF FEDCBA9876543210");
+    (void)baofeng_ap_pc5_keystream_creation(&state, "0123456789ABCDEF FEDCBA9876543210", 0);
 
     char frame[49];
     short expected[49];
@@ -249,6 +272,55 @@ test_baofeng_apply_decrypts_voice_frame(void) {
     return rc;
 }
 
+static int
+test_baofeng_key_log_respects_show_keys(void) {
+    static dsd_state state;
+    int rc = 0;
+
+    dsd_test_capture_stderr cap;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctxpc5, 0, sizeof(ctxpc5));
+    if (dsd_test_capture_stderr_begin(&cap, "pc5_redacted") != 0) {
+        DSD_FPRINTF(stderr, "failed to capture stderr for PC5 redacted log\n");
+        return 1;
+    }
+    rc |= expect_int("baofeng redacted parse",
+                     baofeng_ap_pc5_keystream_creation(&state, "0123456789ABCDEF FEDCBA9876543210", 0), 0);
+    rc |= dsd_test_capture_stderr_end(&cap);
+    rc |= expect_file_contains("baofeng redacted marker", cap.path, "[redacted]", 1);
+    rc |= expect_file_contains("baofeng redacted key", cap.path, "0123456789ABCDEFFEDCBA9876543210", 0);
+    (void)remove(cap.path);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctxpc5, 0, sizeof(ctxpc5));
+    if (dsd_test_capture_stderr_begin(&cap, "pc5_revealed") != 0) {
+        DSD_FPRINTF(stderr, "failed to capture stderr for PC5 revealed log\n");
+        return 1;
+    }
+    rc |= expect_int("baofeng revealed parse",
+                     baofeng_ap_pc5_keystream_creation(&state, "0123456789ABCDEF FEDCBA9876543210", 1), 0);
+    rc |= dsd_test_capture_stderr_end(&cap);
+    rc |= expect_file_contains("baofeng revealed key", cap.path, "0123456789ABCDEFFEDCBA9876543210", 1);
+    (void)remove(cap.path);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctxpc5, 0, sizeof(ctxpc5));
+    if (dsd_test_capture_stderr_begin(&cap, "pc5_256_revealed") != 0) {
+        DSD_FPRINTF(stderr, "failed to capture stderr for PC5-256 revealed log\n");
+        return 1;
+    }
+    rc |= expect_int("baofeng 256 revealed parse",
+                     baofeng_ap_pc5_keystream_creation(
+                         &state, "0001020304050607 08090A0B0C0D0E0F 1011121314151617 18191A1B1C1D1E1F", 1),
+                     0);
+    rc |= dsd_test_capture_stderr_end(&cap);
+    rc |= expect_file_contains("baofeng 256 revealed key", cap.path,
+                               "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F", 1);
+    (void)remove(cap.path);
+
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -259,5 +331,6 @@ main(void) {
     rc |= test_baofeng_rejects_invalid_hex();
     rc |= test_baofeng_apply_skips_silence_and_zero_tail();
     rc |= test_baofeng_apply_decrypts_voice_frame();
+    rc |= test_baofeng_key_log_respects_show_keys();
     return rc;
 }

--- a/tests/crypto/test_rc2_retevis.c
+++ b/tests/crypto/test_rc2_retevis.c
@@ -142,7 +142,7 @@ test_retevis_128_key_schedule(void) {
     static dsd_state state;
     DSD_MEMSET(&state, 0, sizeof(state));
     char input[] = "736B9A9C5645288B 243AD5CB8701EF8A";
-    retevis_rc2_keystream_creation(&state, input);
+    retevis_rc2_keystream_creation(&state, input, 0);
 
     int rc = 0;
     rc |= expect_int("retevis 128 flag", state.retevis_ap, 1);
@@ -167,7 +167,7 @@ test_retevis_256_key_schedule(void) {
     static dsd_state state;
     DSD_MEMSET(&state, 0, sizeof(state));
     char input[] = "1122334455667788 99AABBCCDDEEFF11 1122334455667788 99AABBCCDDEEFF11";
-    retevis_rc2_keystream_creation(&state, input);
+    retevis_rc2_keystream_creation(&state, input, 0);
 
     int rc = 0;
     rc |= expect_int("retevis 256 flag", state.retevis_ap, 1);
@@ -192,7 +192,7 @@ test_retevis_256_trailing_zero_chunks_key_schedule(void) {
     static dsd_state state;
     DSD_MEMSET(&state, 0, sizeof(state));
     char input[] = "1122334455667788 99AABBCCDDEEFF11 0000000000000000 0000000000000000";
-    retevis_rc2_keystream_creation(&state, input);
+    retevis_rc2_keystream_creation(&state, input, 0);
 
     int rc = 0;
     rc |= expect_int("retevis 256 zero chunks flag", state.retevis_ap, 1);
@@ -214,7 +214,7 @@ test_retevis_rejects_malformed_keys(void) {
         return 1;
     }
     char bad_char_input[] = "736B9A9C5645288B 243AD5CB8701EF8Z";
-    retevis_rc2_keystream_creation(&bad_char_state, bad_char_input);
+    retevis_rc2_keystream_creation(&bad_char_state, bad_char_input, 0);
     rc |= expect_int("retevis bad hex disables flag", bad_char_state.retevis_ap, 0);
     rc |= expect_int("retevis bad hex frees context", bad_char_state.rc2_context == NULL, 1);
 
@@ -227,7 +227,7 @@ test_retevis_rejects_malformed_keys(void) {
         return 1;
     }
     char bad_length_input[] = "736B9A9C5645288B";
-    retevis_rc2_keystream_creation(&bad_length_state, bad_length_input);
+    retevis_rc2_keystream_creation(&bad_length_state, bad_length_input, 0);
     rc |= expect_int("retevis bad length disables flag", bad_length_state.retevis_ap, 0);
     rc |= expect_int("retevis bad length frees context", bad_length_state.rc2_context == NULL, 1);
 
@@ -239,7 +239,7 @@ test_retevis_apply_skips_silence_and_zero_tail(void) {
     static dsd_state state;
     DSD_MEMSET(&state, 0, sizeof(state));
     char input[] = "736B9A9C5645288B 243AD5CB8701EF8A";
-    retevis_rc2_keystream_creation(&state, input);
+    retevis_rc2_keystream_creation(&state, input, 0);
 
     int rc = 0;
     char silence[49];
@@ -270,7 +270,7 @@ test_retevis_apply_decrypts_voice_frame(void) {
     static dsd_state state;
     DSD_MEMSET(&state, 0, sizeof(state));
     char input[] = "736B9A9C5645288B 243AD5CB8701EF8A";
-    retevis_rc2_keystream_creation(&state, input);
+    retevis_rc2_keystream_creation(&state, input, 0);
 
     char frame[49];
     uint8_t expected[49];

--- a/tests/protocol/dmr/test_dmr_block_crypto.c
+++ b/tests/protocol/dmr/test_dmr_block_crypto.c
@@ -15,6 +15,7 @@
 #include "dmr_block_crypto.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "test_support.h"
 
 static int g_lfsr_calls = 0;
 
@@ -54,6 +55,47 @@ expect_bytes(const char* label, const uint8_t* got, const uint8_t* want, size_t 
     return 0;
 }
 
+static int
+expect_contains(const char* label, const char* got, const char* needle) {
+    if (strstr(got, needle) == NULL) {
+        DSD_FPRINTF(stderr, "%s: expected output to contain \"%s\", got \"%s\"\n", label, needle, got);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+capture_print_info(const dmr_block_crypto_ctx* ctx, int show_keys, char* out, size_t out_size) {
+    dsd_test_capture_stderr cap;
+    if (out == NULL || out_size == 0U) {
+        return 1;
+    }
+    out[0] = '\0';
+    if (dsd_test_capture_stderr_begin(&cap, "dsdneo_dmr_block_crypto") != 0) {
+        DSD_FPRINTF(stderr, "capture stderr begin failed\n");
+        return 1;
+    }
+
+    dmr_block_crypto_print_info(ctx, show_keys);
+
+    if (dsd_test_capture_stderr_end(&cap) != 0) {
+        DSD_FPRINTF(stderr, "capture stderr end failed\n");
+        return 1;
+    }
+
+    FILE* fp = fopen(cap.path, "rb");
+    if (fp == NULL) {
+        DSD_FPRINTF(stderr, "capture read failed\n");
+        (void)remove(cap.path);
+        return 1;
+    }
+    size_t nread = fread(out, 1U, out_size - 1U, fp);
+    out[nread] = '\0';
+    (void)fclose(fp);
+    (void)remove(cap.path);
+    return 0;
+}
+
 static void
 seed_window(dsd_state* state, uint8_t slot, uint8_t start, uint8_t poc) {
     DSD_MEMSET(state, 0, sizeof(*state));
@@ -88,6 +130,54 @@ xor_stream_into_payload(dsd_state* state, uint8_t slot, int start, const uint8_t
 }
 
 static int
+test_print_info_reveals_full_aes128_key(void) {
+    static dsd_state state;
+    dmr_block_crypto_ctx ctx;
+    char output[256];
+    const uint8_t slot = 0;
+    const int kid = 0x23;
+    int rc = 0;
+
+    seed_window(&state, slot, 0, 28);
+    state.payload_algid = 4;
+    state.payload_keyid = kid;
+    seed_key_array(&state, kid, 0x0123456789ABCDEFULL, 0ULL, 0xDEADBEEFDEADBEEFULL, 0ULL);
+
+    dmr_block_crypto_load_ctx(&state, slot, 1, 24, &ctx);
+    rc |= expect_int("aes128 print key loaded", ctx.aes_key_loaded, 1);
+    if (capture_print_info(&ctx, 1, output, sizeof output) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("aes128 print full key", output, "AES128; Key: 0123456789ABCDEF0000000000000000;");
+    return rc;
+}
+
+static int
+test_print_info_reveals_full_aes256_key_when_first_segment_zero(void) {
+    static dsd_state state;
+    dmr_block_crypto_ctx ctx;
+    char output[256];
+    const uint8_t slot = 1;
+    const int kid = 0x24;
+    int rc = 0;
+
+    seed_window(&state, slot, 0, 28);
+    state.payload_algidR = 5;
+    state.payload_keyidR = kid;
+    seed_key_array(&state, kid, 0ULL, 0x1112131415161718ULL, 0x2122232425262728ULL, 0x3132333435363738ULL);
+
+    dmr_block_crypto_load_ctx(&state, slot, 1, 24, &ctx);
+    rc |= expect_int("aes256 print rkey zero", ctx.rkey == 0ULL, 1);
+    rc |= expect_int("aes256 print key loaded", ctx.aes_key_loaded, 1);
+    if (capture_print_info(&ctx, 1, output, sizeof output) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("aes256 print full key", output,
+                          "AES256; Key: 0000000000000000111213141516171821222324252627283132333435363738;");
+    return rc;
+}
+
+static int
 test_aes128_zero_mi_uses_reference_ecb_block_count(void) {
     static const uint8_t ciphertext[16] = {0x69, 0xC4, 0xE0, 0xD8, 0x6A, 0x7B, 0x04, 0x30,
                                            0xD8, 0xCD, 0xB7, 0x80, 0x70, 0xB4, 0xC5, 0x5A};
@@ -119,7 +209,7 @@ test_aes128_zero_mi_uses_reference_ecb_block_count(void) {
     rc |= expect_int("aes128 ctx start", ctx.start, start);
     rc |= expect_int("aes128 ctx end", ctx.end, 35);
     rc |= expect_int("aes128 key loaded", ctx.aes_key_loaded, 1);
-    rc |= expect_int("aes128 decrypt result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx), 1);
+    rc |= expect_int("aes128 decrypt result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx, 0), 1);
     rc |= expect_int("aes128 zero-mi skips lfsr", g_lfsr_calls, 0);
     rc |= expect_int("aes128 alg normalized", state.payload_algid, 0x24);
     rc |= expect_u8("aes128 prefix byte 0", state.dmr_pdu_sf[slot][0], 0xE0);
@@ -160,7 +250,7 @@ test_aes256_zero_mi_uses_reference_ecb_block_count_and_manual_key_fallback(void)
     g_lfsr_calls = 0;
     dmr_block_crypto_load_ctx(&state, slot, 1, 24, &ctx);
     rc |= expect_int("aes256 manual key loaded", ctx.aes_key_loaded, 1);
-    rc |= expect_int("aes256 decrypt result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx), 1);
+    rc |= expect_int("aes256 decrypt result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx, 0), 1);
     rc |= expect_int("aes256 zero-mi skips lfsr", g_lfsr_calls, 0);
     rc |= expect_int("aes256 alg normalized", state.payload_algidR, 0x25);
     rc |= expect_bytes("aes256 block 0", state.dmr_pdu_sf[slot] + start, plaintext, sizeof(plaintext));
@@ -195,7 +285,7 @@ test_aes_nonzero_mi_keeps_ofb_path(void) {
     aes_ofb_keystream_output(iv, ctx.aes_key, stream, /*AES-128*/ 0, 3);
 
     rc |= expect_int("aes ofb ctx end", ctx.end, 16);
-    rc |= expect_int("aes ofb decrypt result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx), 1);
+    rc |= expect_int("aes ofb decrypt result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx, 0), 1);
     rc |= expect_int("aes nonzero-mi calls lfsr", g_lfsr_calls, 1);
     rc |= expect_int("aes ofb alg normalized", state.payload_algid, 0x24);
     rc |= expect_bytes("aes ofb skips discard block", state.dmr_pdu_sf[slot], stream + 16, 16);
@@ -226,7 +316,7 @@ test_rc4_decrypts_window_with_key_id_lookup(void) {
     rc4_block_output(256, 9, ctx.end, ctx.rc4_iv, stream);
     xor_stream_into_payload(&state, slot, ctx.start, plaintext, stream, (size_t)ctx.end);
 
-    rc |= expect_int("rc4 decrypt result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx), 1);
+    rc |= expect_int("rc4 decrypt result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx, 0), 1);
     rc |= expect_bytes("rc4 plaintext", state.dmr_pdu_sf[slot] + ctx.start, plaintext, (size_t)ctx.end);
     return rc;
 }
@@ -255,7 +345,7 @@ test_des_decrypts_window_with_manual_key_fallback(void) {
     des_multi_keystream_output(ctx.mi, ctx.rkey, stream, 1, (ctx.end / 8) + 1);
     xor_stream_into_payload(&state, slot, ctx.start, plaintext, stream, (size_t)ctx.end);
 
-    rc |= expect_int("des decrypt result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx), 1);
+    rc |= expect_int("des decrypt result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx, 0), 1);
     rc |= expect_bytes("des plaintext", state.dmr_pdu_sf[slot] + ctx.start, plaintext, (size_t)ctx.end);
     return rc;
 }
@@ -282,7 +372,7 @@ test_basic_privacy_decrypts_window(void) {
         state.dmr_pdu_sf[slot][ctx.start + i] = (uint8_t)(plaintext[i] ^ stream[i % 2]);
     }
 
-    rc |= expect_int("bp decrypt result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx), 1);
+    rc |= expect_int("bp decrypt result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx, 0), 1);
     rc |= expect_bytes("bp plaintext", state.dmr_pdu_sf[slot] + ctx.start, plaintext, (size_t)ctx.end);
     return rc;
 }
@@ -301,7 +391,7 @@ test_aes_missing_key_still_normalizes_alg(void) {
 
     dmr_block_crypto_load_ctx(&state, slot, 1, 24, &ctx);
     rc |= expect_int("aes missing key not loaded", ctx.aes_key_loaded, 0);
-    rc |= expect_int("aes missing key result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx), 0);
+    rc |= expect_int("aes missing key result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx, 0), 0);
     rc |= expect_int("aes missing key alg normalized", state.payload_algidR, 0x25);
     return rc;
 }
@@ -312,6 +402,8 @@ main(void) {
     rc |= test_aes128_zero_mi_uses_reference_ecb_block_count();
     rc |= test_aes256_zero_mi_uses_reference_ecb_block_count_and_manual_key_fallback();
     rc |= test_aes_nonzero_mi_keeps_ofb_path();
+    rc |= test_print_info_reveals_full_aes128_key();
+    rc |= test_print_info_reveals_full_aes256_key_when_first_segment_zero();
     rc |= test_rc4_decrypts_window_with_key_id_lookup();
     rc |= test_des_decrypts_window_with_manual_key_fallback();
     rc |= test_basic_privacy_decrypts_window();

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -95,6 +95,27 @@ build_regular_flco(uint8_t* bits, uint8_t flco, uint8_t fid, uint8_t so, uint32_
 }
 
 static int
+read_file_to_buffer(const char* path, char* out, size_t out_size) {
+    if (path == NULL || out == NULL || out_size == 0U) {
+        return -1;
+    }
+    out[0] = '\0';
+
+    FILE* fp = fopen(path, "rb");
+    if (fp == NULL) {
+        return -1;
+    }
+    size_t nread = fread(out, 1, out_size - 1U, fp);
+    if (ferror(fp)) {
+        fclose(fp);
+        return -1;
+    }
+    out[nread] = '\0';
+    fclose(fp);
+    return 0;
+}
+
+static int
 capture_regular_flco(uint8_t type, char* out, size_t out_size) {
     if (out == NULL || out_size == 0U) {
         return -1;
@@ -122,21 +143,55 @@ capture_regular_flco(uint8_t type, char* out, size_t out_size) {
         return -1;
     }
 
-    FILE* fp = fopen(cap.path, "rb");
-    if (fp == NULL) {
-        (void)remove(cap.path);
-        return -1;
-    }
-    size_t nread = fread(out, 1, out_size - 1U, fp);
-    if (ferror(fp)) {
-        fclose(fp);
-        (void)remove(cap.path);
-        return -1;
-    }
-    out[nread] = '\0';
-    fclose(fp);
+    rc = read_file_to_buffer(cap.path, out, out_size);
     (void)remove(cap.path);
-    return 0;
+    return rc;
+}
+
+static int
+capture_hytera_basic_key_output(unsigned int slot, uint8_t segment_count, char* out, size_t out_size) {
+    if (out == NULL || out_size == 0U || slot > 1U) {
+        return -1;
+    }
+    out[0] = '\0';
+
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.show_keys = 1U;
+    state.currentslot = slot;
+    state.K1 = 0x0123456789ULL;
+    state.K2 = 0xABCDEF0123456789ULL;
+    state.K3 = 0x1111111111111111ULL;
+    state.K4 = 0x2222222222222222ULL;
+    state.hytera_key_segments = segment_count;
+    state.payload_algid = 0U;
+    state.payload_algidR = 0U;
+
+    dsd_test_capture_stderr cap;
+    if (dsd_test_capture_stderr_begin(&cap, "dmr_hytera_key_output") != 0) {
+        return -1;
+    }
+
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    build_regular_flco(bits, 0x00U, 0x68U, 0x40U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+
+    int rc = dsd_test_capture_stderr_end(&cap);
+    if (rc != 0) {
+        (void)remove(cap.path);
+        return -1;
+    }
+
+    rc = read_file_to_buffer(cap.path, out, out_size);
+    (void)remove(cap.path);
+    if (irr != 0U) {
+        return -1;
+    }
+    return rc;
 }
 
 static void
@@ -145,6 +200,35 @@ test_flco_output_uses_real_newlines(void) {
     assert(capture_regular_flco(1U, out, sizeof(out)) == 0);
     assert(strchr(out, '\n') != NULL);
     assert(strstr(out, "\\n") == NULL);
+}
+
+static void
+test_hytera_basic_key_output_uses_segment_count(void) {
+    char out[2048];
+
+    assert(capture_hytera_basic_key_output(0U, 1U, out, sizeof(out)) == 0);
+    assert(strstr(out, "0123456789") != NULL);
+    assert(strstr(out, "0000000123456789") == NULL);
+    assert(strstr(out, "ABCDEF0123456789") == NULL);
+
+    assert(capture_hytera_basic_key_output(1U, 1U, out, sizeof(out)) == 0);
+    assert(strstr(out, "0123456789") != NULL);
+    assert(strstr(out, "0000000123456789") == NULL);
+    assert(strstr(out, "ABCDEF0123456789") == NULL);
+
+    assert(capture_hytera_basic_key_output(0U, 2U, out, sizeof(out)) == 0);
+    assert(strstr(out, "0000000123456789 ABCDEF0123456789") != NULL);
+    assert(strstr(out, "1111111111111111") == NULL);
+
+    assert(capture_hytera_basic_key_output(1U, 2U, out, sizeof(out)) == 0);
+    assert(strstr(out, "0000000123456789 ABCDEF0123456789") != NULL);
+    assert(strstr(out, "1111111111111111") == NULL);
+
+    assert(capture_hytera_basic_key_output(0U, 4U, out, sizeof(out)) == 0);
+    assert(strstr(out, "0000000123456789 ABCDEF0123456789 1111111111111111 2222222222222222") != NULL);
+
+    assert(capture_hytera_basic_key_output(1U, 4U, out, sizeof(out)) == 0);
+    assert(strstr(out, "0000000123456789 ABCDEF0123456789 1111111111111111 2222222222222222") != NULL);
 }
 
 static void
@@ -261,6 +345,7 @@ test_hytera_flco_scan_hook_uses_final_call_type(void) {
 int
 main(void) {
     test_flco_output_uses_real_newlines();
+    test_hytera_basic_key_output_uses_segment_count();
     test_kirisun_flco_sets_late_entry_mode();
     test_hytera_enhanced_flco_uses_secondary_checksum();
     test_flco_scan_hook_reports_encrypted_service_option();

--- a/tests/protocol/nxdn/test_nxdn_element_bounds.c
+++ b/tests/protocol/nxdn/test_nxdn_element_bounds.c
@@ -17,6 +17,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "test_support.h"
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -413,6 +414,31 @@ expect_string(const char* tag, const char* got, const char* want) {
 }
 
 static int
+expect_contains(const char* tag, const char* got, const char* want) {
+    if (strstr(got, want) == NULL) {
+        DSD_FPRINTF(stderr, "%s: expected output to contain '%s', got '%s'\n", tag, want, got);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+read_capture_file(const char* path, char* out, size_t out_size) {
+    if (path == NULL || out == NULL || out_size == 0U) {
+        return 1;
+    }
+    out[0] = '\0';
+    FILE* fp = fopen(path, "rb");
+    if (fp == NULL) {
+        return 1;
+    }
+    size_t nread = fread(out, 1U, out_size - 1U, fp);
+    out[nread] = '\0';
+    (void)fclose(fp);
+    return 0;
+}
+
+static int
 test_sdcall_header_short_is_ignored(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
@@ -666,12 +692,14 @@ test_dcall_aes_data_decrypts_with_manual_key_and_iv(void) {
     uint8_t first_bits[80];
     uint8_t final_bits[80];
     uint8_t encrypted[16];
+    char output[512];
+    dsd_test_capture_stderr cap;
     static const uint8_t plain[16] = {
         0xABU, 0xCDU, 0x11U, 0x22U, 0x33U, 0x44U, 0x55U, 0x66U, 0x77U, 0x88U, 0x99U, 0xAAU, 0x00U, 0x00U, 0x00U, 0x00U,
     };
     static const uint8_t expected_key[32] = {
         0x01U, 0x02U, 0x03U, 0x04U, 0x05U, 0x06U, 0x07U, 0x08U, 0x11U, 0x12U, 0x13U, 0x14U, 0x15U, 0x16U, 0x17U, 0x18U,
-        0x21U, 0x22U, 0x23U, 0x24U, 0x25U, 0x26U, 0x27U, 0x28U, 0x31U, 0x32U, 0x33U, 0x34U, 0x35U, 0x36U, 0x37U, 0x38U,
+        0x21U, 0x22U, 0x23U, 0x24U, 0x25U, 0x26U, 0x27U, 0x28U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U,
     };
     const uint8_t key_id = 0x11U;
     const uint64_t iv = 0x0102030405060708ULL;
@@ -694,14 +722,22 @@ test_dcall_aes_data_decrypts_with_manual_key_and_iv(void) {
     reset_datacall_capture();
     reset_crypto_stub_capture();
     g_aes_fill_enabled = 1;
+    opts->show_keys = 1;
     state->keyloader = 0;
     state->K1 = 0x0102030405060708ULL;
     state->K2 = 0x1112131415161718ULL;
     state->K3 = 0x2122232425262728ULL;
-    state->K4 = 0x3132333435363738ULL;
+    state->K4 = 0ULL;
 
     write_data_call_header_fields(header_bits, 0x09U, 3U, key_id, 0x0201U, 0x0302U, 1U, 0U);
     write_bits_u64(header_bits, 88U, iv, 64U);
+    if (dsd_test_capture_stderr_begin(&cap, "dsdneo_nxdn_dcall_aes") != 0) {
+        DSD_FPRINTF(stderr, "capture stderr begin failed\n");
+        free(state->event_history_s);
+        free(state);
+        free(opts);
+        return 1;
+    }
     NXDN_Elements_Content_decode(opts, state, 1U, header_bits, sizeof(header_bits));
     state->data_header_format[0] = 3U;
 
@@ -710,6 +746,15 @@ test_dcall_aes_data_decrypts_with_manual_key_and_iv(void) {
     write_data_payload_frame(final_bits, 0x0BU, 0U, 0U, encrypted + 8U, 8U);
     NXDN_Elements_Content_decode(opts, state, 1U, first_bits, sizeof(first_bits));
     NXDN_Elements_Content_decode(opts, state, 1U, final_bits, sizeof(final_bits));
+    if (dsd_test_capture_stderr_end(&cap) != 0 || read_capture_file(cap.path, output, sizeof output) != 0) {
+        DSD_FPRINTF(stderr, "capture stderr read failed\n");
+        (void)remove(cap.path);
+        free(state->event_history_s);
+        free(state);
+        free(opts);
+        return 1;
+    }
+    (void)remove(cap.path);
 
     const uint8_t zero_iv[16] = {0};
     int rc = 0;
@@ -717,6 +762,8 @@ test_dcall_aes_data_decrypts_with_manual_key_and_iv(void) {
     rc |= expect_int("dcall-aes-type", g_aes_type, 2);
     rc |= expect_int("dcall-aes-blocks", g_aes_blocks, 1);
     rc |= expect_bytes("dcall-aes-key", g_aes_key, expected_key, sizeof(expected_key));
+    rc |= expect_contains("dcall-aes-reveal-full-key", output,
+                          "Key: 0102030405060708111213141516171821222324252627280000000000000000;");
     rc |= expect_string("dcall-aes-event", state->event_history_s[0].Event_History_Items[0].text_message,
                         "Unknown Data Call Format: ABCD;");
     rc |= expect_string("dcall-aes-watchdog", g_datacall_event, "DATA CALL SRC: 513; TGT: 770;");

--- a/tests/runtime/test_runtime_cli_compact.c
+++ b/tests/runtime/test_runtime_cli_compact.c
@@ -132,6 +132,53 @@ test_dmr_debug_burst_long_option_is_removed(void) {
 }
 
 static int
+test_show_keys_long_option_is_removed(void) {
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--show-keys";
+    char arg2[] = "-fi";
+    char* argv[] = {arg0, arg1, arg2, NULL};
+
+    int new_argc = dsd_cli_compact_args(3, argv);
+    if (new_argc != 2) {
+        DSD_FPRINTF(stderr, "expected new_argc=2, got %d\n", new_argc);
+        return 1;
+    }
+    if (argv[1] == NULL || strcmp(argv[1], "-fi") != 0) {
+        DSD_FPRINTF(stderr, "expected argv[1] to be \"-fi\", got \"%s\"\n", argv[1] ? argv[1] : "(null)");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_option_terminator_preserves_later_show_keys_argument(void) {
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--";
+    char arg2[] = "--show-keys";
+    char arg3[] = "-fi";
+    char* argv[] = {arg0, arg1, arg2, arg3, NULL};
+
+    int new_argc = dsd_cli_compact_args(4, argv);
+    if (new_argc != 4) {
+        DSD_FPRINTF(stderr, "expected new_argc=4, got %d\n", new_argc);
+        return 1;
+    }
+    if (argv[1] == NULL || strcmp(argv[1], "--") != 0) {
+        DSD_FPRINTF(stderr, "expected argv[1] to be \"--\", got \"%s\"\n", argv[1] ? argv[1] : "(null)");
+        return 1;
+    }
+    if (argv[2] == NULL || strcmp(argv[2], "--show-keys") != 0) {
+        DSD_FPRINTF(stderr, "expected argv[2] to be \"--show-keys\", got \"%s\"\n", argv[2] ? argv[2] : "(null)");
+        return 1;
+    }
+    if (argv[3] == NULL || strcmp(argv[3], "-fi") != 0) {
+        DSD_FPRINTF(stderr, "expected argv[3] to be \"-fi\", got \"%s\"\n", argv[3] ? argv[3] : "(null)");
+        return 1;
+    }
+    return 0;
+}
+
+static int
 test_rtl_udp_control_consumes_port_and_leaves_short_opts(void) {
     char arg0[] = "dsd-neo";
     char arg1[] = "--rtl-udp-control";
@@ -303,6 +350,8 @@ main(void) {
     rc |= test_frame_log_consumes_path_and_leaves_short_opts();
     rc |= test_vendor_privacy_long_opts_are_removed();
     rc |= test_dmr_debug_burst_long_option_is_removed();
+    rc |= test_show_keys_long_option_is_removed();
+    rc |= test_option_terminator_preserves_later_show_keys_argument();
     rc |= test_rtl_udp_control_consumes_port_and_leaves_short_opts();
     rc |= test_rtl_udp_control_missing_port_does_not_consume_next_option();
     rc |= test_rtl_udp_control_bind_consumes_address_and_leaves_short_opts();

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/init.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/secret_redaction.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/crypto/ecdsa.h>
 #include <dsd-neo/crypto/pc5.h>
@@ -62,6 +63,49 @@ test_redirect_stdout_to_null(void) {
 #else
     (void)freopen("/dev/null", "w", stdout);
 #endif
+}
+
+static int
+read_file_to_buffer(const char* path, char* out, size_t out_size) {
+    if (path == NULL || out == NULL || out_size == 0U) {
+        return -1;
+    }
+    out[0] = '\0';
+
+    FILE* fp = fopen(path, "rb");
+    if (fp == NULL) {
+        return -1;
+    }
+    size_t nread = fread(out, 1, out_size - 1U, fp);
+    if (ferror(fp)) {
+        fclose(fp);
+        return -1;
+    }
+    out[nread] = '\0';
+    fclose(fp);
+    return 0;
+}
+
+static int
+parse_args_capture_stderr(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* argc_effective, int* exit_rc,
+                          char* out, size_t out_size) {
+    dsd_test_capture_stderr cap;
+    if (dsd_test_capture_stderr_begin(&cap, "runtime_cli_parse") != 0) {
+        return DSD_PARSE_ERROR;
+    }
+
+    int rc = dsd_parse_args(argc, argv, opts, state, argc_effective, exit_rc);
+
+    if (dsd_test_capture_stderr_end(&cap) != 0) {
+        (void)remove(cap.path);
+        return DSD_PARSE_ERROR;
+    }
+    if (read_file_to_buffer(cap.path, out, out_size) != 0) {
+        (void)remove(cap.path);
+        return DSD_PARSE_ERROR;
+    }
+    (void)remove(cap.path);
+    return rc;
 }
 
 static int
@@ -384,6 +428,68 @@ test_H_zero_key_keeps_dmr_encrypted_audio_muted(void) {
     free(opts);
     free(state);
     return 0;
+}
+
+static int
+expect_H_log_key_material(const char* key_arg, int show_keys, const char* expected, const char* unexpected) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+    initOpts(opts);
+    initState(state);
+
+    char arg0[] = "dsd-neo";
+    char arg_show[] = "--show-keys";
+    char arg_h[] = "-H";
+    char key_buf[128];
+    DSD_SNPRINTF(key_buf, sizeof key_buf, "%s", key_arg);
+    key_buf[sizeof key_buf - 1U] = '\0';
+    char* argv_show[] = {arg0, arg_show, arg_h, key_buf, NULL};
+    char* argv_hidden[] = {arg0, arg_h, key_buf, NULL};
+    char** argv = show_keys ? argv_show : argv_hidden;
+    int argc = show_keys ? 4 : 3;
+
+    char output[2048];
+    int argc_effective = 0;
+    int exit_rc = -1;
+    int rc = parse_args_capture_stderr(argc, argv, opts, state, &argc_effective, &exit_rc, output, sizeof(output));
+
+    int test_rc = 0;
+    if (rc != DSD_PARSE_CONTINUE) {
+        DSD_FPRINTF(stderr, "expected rc=%d for -H %s, got %d (exit_rc=%d)\n", DSD_PARSE_CONTINUE, key_buf, rc,
+                    exit_rc);
+        test_rc = 1;
+    }
+    if (expected != NULL && strstr(output, expected) == NULL) {
+        DSD_FPRINTF(stderr, "expected -H log to contain \"%s\", got \"%s\"\n", expected, output);
+        test_rc = 1;
+    }
+    if (unexpected != NULL && strstr(output, unexpected) != NULL) {
+        DSD_FPRINTF(stderr, "expected -H log to hide \"%s\", got \"%s\"\n", unexpected, output);
+        test_rc = 1;
+    }
+
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
+test_H_show_keys_log_reveals_key_material(void) {
+    int rc = 0;
+    rc |= expect_H_log_key_material("0123456789", 1, "0123456789", DSD_SECRET_REDACTED);
+    rc |= expect_H_log_key_material("736B9A9C5645288B 243AD5CB8701EF8A", 1, "736B9A9C5645288B 243AD5CB8701EF8A",
+                                    DSD_SECRET_REDACTED);
+    rc |= expect_H_log_key_material("20029736A5D91042 C923EB0697484433 005EFC58A1905195 E28E9C7836AA2DB8", 1,
+                                    "E28E9C7836AA2DB8", DSD_SECRET_REDACTED);
+    rc |= expect_H_log_key_material("0123456789", 0, DSD_SECRET_REDACTED, "0123456789");
+    return rc;
 }
 
 static int
@@ -2547,6 +2653,101 @@ test_dmr_debug_burst_long_option_parse(void) {
     }
     if (argc_effective != 1) {
         DSD_FPRINTF(stderr, "expected compacted argc=1, got %d\n", argc_effective);
+        test_rc = 1;
+    }
+
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
+test_show_keys_long_option_parse(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--show-keys";
+    char* argv[] = {arg0, arg1, NULL};
+
+    int argc_effective = 0;
+    int exit_rc = -1;
+    int rc = dsd_parse_args(2, argv, opts, state, &argc_effective, &exit_rc);
+    if (rc != DSD_PARSE_CONTINUE) {
+        DSD_FPRINTF(stderr, "expected rc=%d, got %d (exit_rc=%d)\n", DSD_PARSE_CONTINUE, rc, exit_rc);
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    int test_rc = 0;
+    if (opts->show_keys != 1U) {
+        DSD_FPRINTF(stderr, "expected show_keys=1, got %u\n", (unsigned int)opts->show_keys);
+        test_rc = 1;
+    }
+    if (argc_effective != 1) {
+        DSD_FPRINTF(stderr, "expected compacted argc=1, got %d\n", argc_effective);
+        test_rc = 1;
+    }
+
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
+test_show_keys_after_option_terminator_remains_positional(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--";
+    char arg2[] = "--show-keys";
+    char* argv[] = {arg0, arg1, arg2, NULL};
+
+    int argc_effective = 0;
+    int exit_rc = -1;
+    int rc = dsd_parse_args(3, argv, opts, state, &argc_effective, &exit_rc);
+    if (rc != DSD_PARSE_CONTINUE) {
+        DSD_FPRINTF(stderr, "expected rc=%d, got %d (exit_rc=%d)\n", DSD_PARSE_CONTINUE, rc, exit_rc);
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    int test_rc = 0;
+    if (opts->show_keys != 0U) {
+        DSD_FPRINTF(stderr, "expected show_keys to remain redacted, got %u\n", (unsigned int)opts->show_keys);
+        test_rc = 1;
+    }
+    if (argc_effective != 3) {
+        DSD_FPRINTF(stderr, "expected compacted argc=3, got %d\n", argc_effective);
+        test_rc = 1;
+    }
+    if (argv[1] == NULL || strcmp(argv[1], "--") != 0 || argv[2] == NULL || strcmp(argv[2], "--show-keys") != 0) {
+        DSD_FPRINTF(stderr, "expected terminator and positional --show-keys to remain in argv\n");
         test_rc = 1;
     }
 
@@ -4936,6 +5137,7 @@ main(void) {
     rc |= test_numeric_options_reject_trailing_junk();
     rc |= test_H_loads_aes256_key_for_both_slots();
     rc |= test_H_zero_key_keeps_dmr_encrypted_audio_muted();
+    rc |= test_H_show_keys_log_reveals_key_material();
     rc |= test_b_loads_basic_privacy_key_and_unmutes_dmr();
     rc |= test_b_zero_key_keeps_dmr_encrypted_audio_muted();
     rc |= test_b_clamps_to_basic_privacy_table_max();
@@ -4965,6 +5167,8 @@ main(void) {
     rc |= test_rdio_long_options_parse();
     rc |= test_frame_log_long_option_parse();
     rc |= test_dmr_debug_burst_long_option_parse();
+    rc |= test_show_keys_long_option_parse();
+    rc |= test_show_keys_after_option_terminator_remains_positional();
     rc |= test_input_source_soapy_roundtrip();
     rc |= test_input_source_soapy_args_roundtrip();
     rc |= test_input_source_rtl_roundtrip();

--- a/tests/runtime/test_runtime_config_apply.cpp
+++ b/tests/runtime/test_runtime_config_apply.cpp
@@ -37,6 +37,7 @@
 #include "menu_callbacks.h"
 #include "menu_internal.h"
 #include "test_support.h"
+#include "ui_key_status.h"
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -584,6 +585,42 @@ test_call_alert_off_selection_survives_ui_command_path(void) {
 }
 
 static int
+test_ui_visibility_toggles_preserve_show_keys(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    const struct VisibilityCommand {
+        int cmd_id;
+        const char* label;
+    } commands[] = {
+        {UI_CMD_UI_SHOW_P25_AFFIL_TOGGLE, "P25 affiliations visibility toggle preserves show_keys"},
+        {UI_CMD_UI_SHOW_P25_CALLSIGN_TOGGLE, "P25 callsign visibility toggle preserves show_keys"},
+        {UI_CMD_P25_GA_TOGGLE, "P25 group affiliation toggle preserves show_keys"},
+        {UI_CMD_UI_SHOW_DSP_PANEL_TOGGLE, "DSP panel visibility toggle preserves show_keys"},
+        {UI_CMD_UI_SHOW_P25_METRICS_TOGGLE, "P25 metrics visibility toggle preserves show_keys"},
+        {UI_CMD_UI_SHOW_P25_NEIGHBORS_TOGGLE, "P25 neighbors visibility toggle preserves show_keys"},
+        {UI_CMD_UI_SHOW_P25_IDEN_TOGGLE, "P25 IDEN visibility toggle preserves show_keys"},
+        {UI_CMD_UI_SHOW_P25_CCC_TOGGLE, "P25 CC candidates visibility toggle preserves show_keys"},
+        {UI_CMD_UI_SHOW_CHANNELS_TOGGLE, "channels visibility toggle preserves show_keys"},
+    };
+
+    int rc = 0;
+    for (size_t i = 0U; i < sizeof commands / sizeof commands[0]; i++) {
+        opts->show_keys = 1U;
+        ui_post_cmd(commands[i].cmd_id, NULL, 0);
+        ui_drain_cmds(opts, state);
+        rc |= expect_int_eq(commands[i].label, (int)opts->show_keys, 1);
+    }
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
 test_ui_aes_key_command_clears_manual_hytera_fields(void) {
     test_runtime runtime;
     if (alloc_test_runtime(&runtime) != 0) {
@@ -633,11 +670,109 @@ test_ui_aes_key_command_clears_manual_hytera_fields(void) {
     rc |= expect_u64_eq("UI AES clears K2", state->K2, 0ULL);
     rc |= expect_u64_eq("UI AES clears K3", state->K3, 0ULL);
     rc |= expect_u64_eq("UI AES clears K4", state->K4, 0ULL);
+    rc |= expect_int_eq("UI AES clears Hytera segment count", (int)state->hytera_key_segments, 0);
     rc |= expect_int_eq("UI AES disables keyloader", state->keyloader, 0);
     rc |= expect_int_eq("UI AES clears slot 0 payload key ID", state->payload_keyid, 0);
     rc |= expect_int_eq("UI AES clears slot 1 payload key ID", state->payload_keyidR, 0);
     rc |= expect_int_eq("UI AES unmutes encrypted left", opts->dmr_mute_encL, 0);
     rc |= expect_int_eq("UI AES unmutes encrypted right", opts->dmr_mute_encR, 0);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_hytera_status_counts_k_fields_only(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_state* state = runtime.state;
+
+    state->H = 0x2345ULL;
+    state->aes_key_segments[0] = 4U;
+    state->aes_key_segments[1] = 2U;
+
+    int rc = 0;
+    rc |=
+        expect_int_eq("UI Hytera status ignores H-only stale AES metadata", (int)ui_hytera_key_segment_count(state), 0);
+
+    state->K1 = 0x0123456789ULL;
+    rc |= expect_int_eq("UI Hytera BP status ignores stale AES metadata", (int)ui_hytera_key_segment_count(state), 1);
+
+    state->hytera_key_segments = 2U;
+    rc |= expect_int_eq("UI Hytera 128-bit status preserves zero K2", (int)ui_hytera_key_segment_count(state), 2);
+    state->hytera_key_segments = 0U;
+
+    state->K2 = 0x1122334455667788ULL;
+    rc |= expect_int_eq("UI Hytera 128-bit status counts K fields", (int)ui_hytera_key_segment_count(state), 2);
+
+    state->K2 = 0ULL;
+    state->K4 = 0x8877665544332211ULL;
+    rc |= expect_int_eq("UI Hytera 256-bit status counts upper K fields", (int)ui_hytera_key_segment_count(state), 4);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_hytera_key_command_preserves_aes_metadata(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    state->A1[0] = 0x20029736A5D91042ULL;
+    state->A2[0] = 0xC923EB0697484433ULL;
+    state->A3[0] = 0x005EFC58A1905195ULL;
+    state->A4[0] = 0xE28E9C7836AA2DB8ULL;
+    state->A1[1] = 0x361097A53A529002ULL;
+    state->A2[1] = 0x3344489706EB23C9ULL;
+    state->A3[1] = 0x955190A158FC5E00ULL;
+    state->A4[1] = 0xB82DAA36789C8EE2ULL;
+    state->aes_key_loaded[0] = 1;
+    state->aes_key_loaded[1] = 1;
+    state->aes_key_segments[0] = 4U;
+    state->aes_key_segments[1] = 4U;
+
+    uint8_t expected_aes_key[32];
+    for (size_t i = 0U; i < sizeof expected_aes_key; i++) {
+        state->aes_key[i] = (uint8_t)(i + 1U);
+        expected_aes_key[i] = state->aes_key[i];
+    }
+
+    struct HyteraKeyPayload {
+        uint64_t H, K1, K2, K3, K4;
+    } p = {
+        0x0123456789ULL, 0x0123456789ULL, 0ULL, 0ULL, 0ULL,
+    };
+
+    ui_post_cmd(UI_CMD_KEY_HYTERA_SET, &p, sizeof p);
+    ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_u64_eq("UI Hytera command sets H", state->H, p.H);
+    rc |= expect_u64_eq("UI Hytera command sets K1", state->K1, p.K1);
+    rc |= expect_u64_eq("UI Hytera command sets K2", state->K2, p.K2);
+    rc |= expect_u64_eq("UI Hytera command sets K3", state->K3, p.K3);
+    rc |= expect_u64_eq("UI Hytera command sets K4", state->K4, p.K4);
+    rc |= expect_int_eq("UI Hytera command records BP segment count", (int)state->hytera_key_segments, 1);
+    rc |= expect_int_eq("UI Hytera preserves AES loaded slot 0", state->aes_key_loaded[0], 1);
+    rc |= expect_int_eq("UI Hytera preserves AES loaded slot 1", state->aes_key_loaded[1], 1);
+    rc |= expect_int_eq("UI Hytera preserves AES segment count slot 0", (int)state->aes_key_segments[0], 4);
+    rc |= expect_int_eq("UI Hytera preserves AES segment count slot 1", (int)state->aes_key_segments[1], 4);
+    rc |= expect_u64_eq("UI Hytera preserves AES A1 slot 0", state->A1[0], 0x20029736A5D91042ULL);
+    rc |= expect_u64_eq("UI Hytera preserves AES A2 slot 0", state->A2[0], 0xC923EB0697484433ULL);
+    rc |= expect_u64_eq("UI Hytera preserves AES A3 slot 0", state->A3[0], 0x005EFC58A1905195ULL);
+    rc |= expect_u64_eq("UI Hytera preserves AES A4 slot 0", state->A4[0], 0xE28E9C7836AA2DB8ULL);
+    rc |= expect_u64_eq("UI Hytera preserves AES A1 slot 1", state->A1[1], 0x361097A53A529002ULL);
+    rc |= expect_u64_eq("UI Hytera preserves AES A2 slot 1", state->A2[1], 0x3344489706EB23C9ULL);
+    rc |= expect_u64_eq("UI Hytera preserves AES A3 slot 1", state->A3[1], 0x955190A158FC5E00ULL);
+    rc |= expect_u64_eq("UI Hytera preserves AES A4 slot 1", state->A4[1], 0xB82DAA36789C8EE2ULL);
+    rc |= expect_true("UI Hytera preserves AES key bytes",
+                      memcmp(state->aes_key, expected_aes_key, sizeof expected_aes_key) == 0);
 
     free_test_runtime(&runtime);
     return rc;
@@ -1103,7 +1238,10 @@ main(void) {
     rc |= test_ui_profile_menu_no_profiles_does_not_apply_base_config();
     rc |= test_stereo_file_hot_swap_rolls_back_to_live_input();
     rc |= test_call_alert_off_selection_survives_ui_command_path();
+    rc |= test_ui_visibility_toggles_preserve_show_keys();
     rc |= test_ui_aes_key_command_clears_manual_hytera_fields();
+    rc |= test_ui_hytera_status_counts_k_fields_only();
+    rc |= test_ui_hytera_key_command_preserves_aes_metadata();
     rc |= test_return_cc_uses_pulse_rate_not_stale_file_rate();
     rc |= test_file_config_apply_keeps_live_pulse_timing();
     rc |= test_file_config_apply_keeps_live_socket_timing();

--- a/tools/check_secret_redaction.sh
+++ b/tools/check_secret_redaction.sh
@@ -13,7 +13,7 @@ secret_terms='[Kk]ey|KEY|KS|keystream|Scrambler|Encryption|Privacy|RC4|DES|AES|K
 format_spec='%[#0 +*.0-9-]*(ll|l|z|j)?[Xxdu]'
 output_call='LOG_[A-Z]+|DSD_FPRINTF|\b(f?printf|printw|mvprintw|wprintw)\s*\('
 
-violations=$(
+raw_print_violations=$(
   rg -n \
     -e "(${output_call}).*(${secret_terms}).*${format_spec}" \
     -e "(${output_call}).*${format_spec}.*(${secret_terms})" \
@@ -23,8 +23,20 @@ violations=$(
     true
 )
 
-if [[ -n "$violations" ]]; then
-  echo "Potential secret material is printed without DSD_SECRET_REDACTED:" >&2
-  printf '%s\n' "$violations" >&2
+literal_reveal_violations=$(
+  rg -n -P 'dsd_secret_format_[A-Za-z0-9_]+\s*\(\s*[^,\n]+,\s*[^,\n]+,\s*(1|true)\s*,' \
+    src include apps --glob '!src/third_party/**' ||
+    true
+)
+
+if [[ -n "$raw_print_violations" ]]; then
+  echo "Potential secret material is printed outside redaction formatter helpers:" >&2
+  printf '%s\n' "$raw_print_violations" >&2
+  exit 1
+fi
+
+if [[ -n "$literal_reveal_violations" ]]; then
+  echo "Potential secret material is formatted with an unconditional reveal flag:" >&2
+  printf '%s\n' "$literal_reveal_violations" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Adds a CLI-only `--show-keys` opt-in for revealing radio key and keystream status output during the current run. Default output remains redacted.

The change centralizes key and keystream display through redaction formatter helpers, threads the per-run opt-in through protocol and terminal status paths, and keeps config persistence/rendering unchanged.

## Testing

- `tools/format.sh`
- `tools/cmake_format_check.sh`
- `tools/shell_lint.sh`
- `tools/check_secret_redaction.sh`
- `git diff --check`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure` (399 tests)
- `tools/preflight_ci.sh`
- `git push` pre-push hook: secret redaction, workflow/vcpkg pin checks, clang-format, gersemi, clang-tidy, cppcheck, IWYU, lizard

Not completed: `tools/quality_preflight.sh` was interrupted before completion. The pre-push hook completed the overlapping static-analysis checks; scan-build remained skipped by hook default.