### PR TITLE
runtime: suppress tcp idle input warning

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,7 +86,8 @@ Other input options
 
 - `--input-volume <1..16>` scale non‑RTL input samples (file/UDP/TCP) by an integer factor.
 - `--input-level-warn-db <dB>` low input-level advisory threshold in dBFS (default −40). This only affects LOW
-  advisories; DSD-neo never changes gain automatically.
+  advisories; DSD-neo never changes gain automatically. TCP input suppresses repeated LOW warnings while the stream is
+  digital silence, but still shows the persistent LOW status and still warns for non-silent low-level audio.
 
 Tip: If paths or names contain spaces, wrap them in single quotes.
 
@@ -106,7 +107,7 @@ Tip: If paths or names contain spaces, wrap them in single quotes.
 - `-O` List PulseAudio input sources and output sinks
 - The ncurses input section shows advisory `Input Level`/`RF Level` health when metrics are available. `LOW` uses
   `--input-level-warn-db`; `HOT` means peak at or above `-1.0 dBFS`; `CLIP` means at least `0.1%` clipped or near-rail
-  samples. These advisories never adjust gain automatically.
+  samples. TCP digital silence does not produce repeated LOW messages. These advisories never adjust gain automatically.
 - For RTL-family inputs, the optional DSP panel shows post-channel-filter `Squelch` power against the SQL threshold.
   This is separate from the raw receiver `RF Level` health line.
 - UI hotkeys and menu navigation: `docs/ui-terminal.md`

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -65,7 +65,9 @@ The low-level threshold is controlled by `--input-level-warn-db` or `DSD_NEO_INP
 Hot/clipping advisories use fixed v1 thresholds: peak at or above `-1.0 dBFS` is `HOT`, and at least `0.1%` clipped or
 near-rail samples is `CLIP`. Footer messages are rate-limited. RF low-level status remains persistent but does not
 produce repeated low-level footer messages because a quiet channel and too little RF gain are not reliably
-distinguishable from raw receiver samples alone.
+distinguishable from raw receiver samples alone. TCP PCM input also suppresses repeated low-level footer messages when
+the stream is digital silence; the persistent `Input Level` line still shows `LOW`, and non-silent low-level audio still
+warns.
 
 ## Hotkeys (Main Screen)
 

--- a/src/runtime/input_level.c
+++ b/src/runtime/input_level.c
@@ -17,8 +17,10 @@ enum {
     DSD_INPUT_LEVEL_TOAST_TTL_SEC = 4,
 };
 
+static const double DSD_INPUT_LEVEL_SILENCE_FLOOR_DBFS = -120.0;
 static const double DSD_INPUT_LEVEL_CLIP_PCT = 0.1;
 static const double DSD_INPUT_LEVEL_HOT_PEAK_DBFS = -1.0;
+static const double DSD_INPUT_LEVEL_SILENCE_EPSILON_DB = 0.1;
 
 static double
 input_level_pwr_to_db(double mean_power) {
@@ -375,6 +377,19 @@ input_level_status_severity(dsd_input_level_status status) {
     }
 }
 
+static int
+input_level_is_digital_silence(const dsd_input_level_snapshot* snapshot) {
+    return snapshot && snapshot->sample_count > 0U
+           && snapshot->rms_dbfs <= DSD_INPUT_LEVEL_SILENCE_FLOOR_DBFS + DSD_INPUT_LEVEL_SILENCE_EPSILON_DB
+           && snapshot->peak_dbfs <= DSD_INPUT_LEVEL_SILENCE_FLOOR_DBFS + DSD_INPUT_LEVEL_SILENCE_EPSILON_DB;
+}
+
+static int
+input_level_should_suppress_idle_tcp_low(const dsd_opts* opts, const dsd_input_level_snapshot* snapshot) {
+    return opts && snapshot && opts->audio_in_type == AUDIO_IN_TCP && snapshot->source == DSD_INPUT_LEVEL_SOURCE_PCM
+           && snapshot->status == DSD_INPUT_LEVEL_LOW && input_level_is_digital_silence(snapshot);
+}
+
 int
 dsd_input_level_format_advisory(const dsd_input_level_snapshot* snapshot, char* out, size_t out_size) {
     if (!snapshot || !out || out_size == 0U) {
@@ -386,7 +401,7 @@ dsd_input_level_format_advisory(const dsd_input_level_snapshot* snapshot, char* 
                                                                         : "lower source/input volume";
     if (snapshot->status == DSD_INPUT_LEVEL_LOW) {
         advice = dsd_input_level_source_is_rf(snapshot->source) ? "raise RF gain if signal is present"
-                                                                : "raise source/input volume";
+                                                                : "raise source/input volume if signal is present";
         DSD_SNPRINTF(out, out_size, "%s %s %.1f dBFS: %s", label, status, snapshot->rms_dbfs, advice);
         return 0;
     }
@@ -450,7 +465,9 @@ dsd_input_level_publish(dsd_opts* opts, dsd_state* state, const dsd_input_level_
     }
 
     time_t now = next.updated != 0 ? next.updated : time(NULL);
-    int notify = input_level_should_notify(opts, state, &next, notify_mask, now);
+    int notify = input_level_should_suppress_idle_tcp_low(opts, &next)
+                     ? 0
+                     : input_level_should_notify(opts, state, &next, notify_mask, now);
     state->input_level = next;
     if (!notify) {
         return;

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -413,7 +413,7 @@ ui_render_input_level_status(const dsd_state* state) {
            dsd_input_level_status_label(level->status), level->rms_dbfs, level->peak_dbfs, level->clip_pct);
     if (level->status == DSD_INPUT_LEVEL_LOW) {
         printw(" %s", dsd_input_level_source_is_rf(level->source) ? "raise RF gain if signal is present"
-                                                                  : "raise source/input volume");
+                                                                  : "raise source/input volume if signal is present");
     } else if (level->status == DSD_INPUT_LEVEL_HOT || level->status == DSD_INPUT_LEVEL_CLIPPING) {
         printw(" %s", dsd_input_level_source_is_rf(level->source) ? "lower RF gain or add filtering/attenuation"
                                                                   : "lower source/input volume");

--- a/tests/core/test_core_input_level.c
+++ b/tests/core/test_core_input_level.c
@@ -230,6 +230,89 @@ test_rf_low_suppressed_but_clip_notifies(void) {
 }
 
 static void
+test_tcp_silence_low_updates_state_without_toast(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+    opts->audio_in_type = AUDIO_IN_TCP;
+    opts->input_warn_db = -40.0;
+    opts->input_warn_cooldown_sec = 10;
+
+    DSD_SNPRINTF(state->ui_msg, sizeof(state->ui_msg), "%s", "sentinel");
+    dsd_input_level_snapshot silent = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -120.0, -120.0, 0.0, 300);
+    dsd_input_level_publish(opts, state, &silent, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_LOW);
+    assert(state->input_level.source == DSD_INPUT_LEVEL_SOURCE_PCM);
+    assert(strcmp(state->ui_msg, "sentinel") == 0);
+    assert(state->input_level_last_toast_time == 0);
+
+    free(state);
+    free(opts);
+}
+
+static void
+test_tcp_low_non_silent_still_notifies(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+    opts->audio_in_type = AUDIO_IN_TCP;
+    opts->input_warn_db = -40.0;
+    opts->input_warn_cooldown_sec = 10;
+
+    dsd_input_level_snapshot quiet = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -55.0, -30.0, 0.0, 310);
+    dsd_input_level_publish(opts, state, &quiet, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_LOW);
+    assert(strstr(state->ui_msg, "Input Level LOW") != NULL);
+    assert(strstr(state->ui_msg, "if signal is present") != NULL);
+    assert(state->input_level_last_toast_time == 310);
+
+    free(state);
+    free(opts);
+}
+
+static void
+test_tcp_silence_clip_still_notifies(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+    opts->audio_in_type = AUDIO_IN_TCP;
+    opts->input_warn_db = -40.0;
+    opts->input_warn_cooldown_sec = 10;
+
+    dsd_input_level_snapshot clip = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -120.0, -120.0, 0.2, 320);
+    dsd_input_level_publish(opts, state, &clip, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_CLIPPING);
+    assert(strstr(state->ui_msg, "Input Level CLIP") != NULL);
+    assert(state->input_level_last_toast_time == 320);
+
+    free(state);
+    free(opts);
+}
+
+static void
+test_non_tcp_silence_low_still_notifies(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    opts->input_warn_db = -40.0;
+    opts->input_warn_cooldown_sec = 10;
+
+    dsd_input_level_snapshot silent = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -120.0, -120.0, 0.0, 330);
+    dsd_input_level_publish(opts, state, &silent, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_LOW);
+    assert(strstr(state->ui_msg, "Input Level LOW") != NULL);
+    assert(state->input_level_last_toast_time == 330);
+
+    free(state);
+    free(opts);
+}
+
+static void
 test_advisory_text_selection(void) {
     char msg[128];
     dsd_input_level_snapshot pcm_low = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -55.0, -30.0, 0.0, 1);
@@ -252,6 +335,10 @@ main(void) {
     test_toast_escalation_survives_ok_sample();
     test_toast_cooldown_suppresses_hot_clip_oscillation();
     test_rf_low_suppressed_but_clip_notifies();
+    test_tcp_silence_low_updates_state_without_toast();
+    test_tcp_low_non_silent_still_notifies();
+    test_tcp_silence_clip_still_notifies();
+    test_non_tcp_silence_low_still_notifies();
     test_advisory_text_selection();
     return 0;
 }


### PR DESCRIPTION
## Summary

- Suppress repeated LOW input-level warning toasts/logs for connected TCP PCM streams that are digital silence.
- Keep the persistent input-level state updated, and keep HOT/CLIP notifications unchanged.
- Update the ncurses advice text and docs to clarify that low input should be raised only when signal is present.
- Add focused input-level regression tests for TCP silence, non-silent low TCP audio, clipping, and non-TCP behavior.

## Validation

- `tools/format.sh`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug -R CORE_INPUT_LEVEL --output-on-failure`
- `ctest --preset dev-debug --output-on-failure` passed 399/399
- `tools/preflight_ci.sh`
- `git push` pre-push guardrails
- Live connected TCP silence emulation against `build/dev-debug/apps/dsd-cli/dsd-neo -f1 -i tcp:127.0.0.1:<port> -o null`, with no `Input Level LOW` warning emitted
