### PR TITLE
ci: allow windows pr dependency cache misses

### DIFF
--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -86,7 +86,6 @@ jobs:
           --triplet $env:VCPKG_DEFAULT_TRIPLET
           --overlay-triplets "$env:GITHUB_WORKSPACE\\vcpkg-triplets"
           --x-manifest-root "$env:GITHUB_WORKSPACE"
-          --only-binarycaching
 
       - name: Configure (MSVC Release)
         shell: pwsh


### PR DESCRIPTION
## Summary
- Remove `--only-binarycaching` from the Windows PR vcpkg install step.
- Keep PR jobs on read-only NuGet binary cache access.

## Root cause
Recent PR jobs failed when GitHub scheduled them on a Windows runner image/toolchain with vcpkg ABI keys that did not match the packages seeded by a recent `main` run. With `--only-binarycaching`, those cache misses were fatal even though PRs could safely build dependencies locally without publishing packages.

## Impact
Windows PR jobs still restore cached packages when ABI keys match. When GitHub-hosted runner image drift creates a cache miss, the PR job can build dependencies locally instead of failing before configuration.

## Validation
- `tools/workflow_lint.sh`
- `tools/zizmor.sh`
- `tools/check_workflow_git_pins.sh`
- `tools/check_workflow_download_pins.sh`
- pre-push hook: install destination guardrail, secret redaction guardrail, workflow Git pin guardrail, workflow download pin guardrail, vcpkg overlay pin guardrail, Semgrep strict, workflow lint, zizmor, Lizard complexity

No C/C++ build or test suite was run because this change is limited to GitHub Actions workflow metadata.