### PR TITLE
release: prepare 2.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(dsd-neo VERSION 2.0.1 LANGUAGES C CXX)
+project(dsd-neo VERSION 2.1.0 LANGUAGES C CXX)
 if(POLICY CMP0083)
     cmake_policy(SET CMP0083 NEW)
 endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "dsd-neo",
-  "version-string": "2.0.1",
+  "version-string": "2.1.0",
   "builtin-baseline": "f3e10653cc27d62a37a3763cd84b38bca07c6075",
   "description": "Digital Speech Decoder: DSD-neo",
   "homepage": "https://github.com/arancormonk/dsd-neo",


### PR DESCRIPTION
## Summary

Prepare the 2.1.0 release by updating the project version metadata.

## Changes

- Bump `project(dsd-neo VERSION ...)` from 2.0.1 to 2.1.0.
- Bump `vcpkg.json` `version-string` from 2.0.1 to 2.1.0.

## Validation

- `tools/cmake_format_check.sh`
- `tools/osv_scan.sh`
- `tools/check_install_runtime_destinations.sh`
- `cmake --preset dev-debug`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure` (399 tests passed)
- `cmake --preset dev-release`
- `cmake --build --preset dev-release -j`
- `build/dev-release/apps/dsd-cli/dsd-neo -h`
- `tools/check_release_hardening.sh build/dev-release/apps/dsd-cli/dsd-neo build/dev-release`
- `cmake --install build/dev-release --prefix /tmp/dsd-neo-install-2.1.0.IxCCwy`
- `tools/preflight_ci.sh --base origin/main`
- `git push -u origin release/2.1.0` (pre-push hook passed)

The optional full `scan-build` rebuild was not run; the pre-push hook reports it is disabled unless `DSD_HOOK_RUN_SCAN_BUILD=1` is set.