### PR TITLE
runtime: suppress tcp idle console noise

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,8 +86,8 @@ Other input options
 
 - `--input-volume <1..16>` scale non‑RTL input samples (file/UDP/TCP) by an integer factor.
 - `--input-level-warn-db <dB>` low input-level advisory threshold in dBFS (default −40). This only affects LOW
-  advisories; DSD-neo never changes gain automatically. TCP input suppresses repeated LOW warnings while the stream is
-  digital silence, but still shows the persistent LOW status and still warns for non-silent low-level audio.
+  advisories; DSD-neo never changes gain automatically. TCP PCM input keeps LOW/HOT/CLIP visible in the persistent
+  input status, but suppresses repeated console level warnings while the decoder is idle/searching.
 
 Tip: If paths or names contain spaces, wrap them in single quotes.
 
@@ -107,7 +107,8 @@ Tip: If paths or names contain spaces, wrap them in single quotes.
 - `-O` List PulseAudio input sources and output sinks
 - The ncurses input section shows advisory `Input Level`/`RF Level` health when metrics are available. `LOW` uses
   `--input-level-warn-db`; `HOT` means peak at or above `-1.0 dBFS`; `CLIP` means at least `0.1%` clipped or near-rail
-  samples. TCP digital silence does not produce repeated LOW messages. These advisories never adjust gain automatically.
+  samples. TCP PCM idle/search level advisories are status-only to avoid console spam. These advisories never adjust
+  gain automatically.
 - For RTL-family inputs, the optional DSP panel shows post-channel-filter `Squelch` power against the SQL threshold.
   This is separate from the raw receiver `RF Level` health line.
 - UI hotkeys and menu navigation: `docs/ui-terminal.md`
@@ -246,6 +247,8 @@ Notes
 Notes
 
 - All frame types are auto-detectable with `-fa` (multi-rate SPS hunting).
+- In TCP PCM mode, SPS hunting still runs when no signal is present, but repeated idle `Sync: no sync` and `SPS hunt`
+  console diagnostics are suppressed.
 - P25p2 on a single frequency may require `-X` (below) if MAC_SIGNAL is missing.
 
 ## Mode Tweaks & Advanced

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -65,9 +65,8 @@ The low-level threshold is controlled by `--input-level-warn-db` or `DSD_NEO_INP
 Hot/clipping advisories use fixed v1 thresholds: peak at or above `-1.0 dBFS` is `HOT`, and at least `0.1%` clipped or
 near-rail samples is `CLIP`. Footer messages are rate-limited. RF low-level status remains persistent but does not
 produce repeated low-level footer messages because a quiet channel and too little RF gain are not reliably
-distinguishable from raw receiver samples alone. TCP PCM input also suppresses repeated low-level footer messages when
-the stream is digital silence; the persistent `Input Level` line still shows `LOW`, and non-silent low-level audio still
-warns.
+distinguishable from raw receiver samples alone. TCP PCM input suppresses repeated LOW/HOT/CLIP footer messages while
+the decoder is idle/searching; the persistent `Input Level` line still shows the current status.
 
 ## Hotkeys (Main Screen)
 

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -29,6 +29,11 @@ void dsd_frame_sync_reset_mod_state(void);
 int dsd_frame_sync_suppress_p25_alt_sync(const dsd_opts* opts, const dsd_state* state);
 
 /**
+ * @brief Return non-zero when TCP no-signal diagnostics should stay off the console.
+ */
+int dsd_frame_sync_suppress_tcp_no_signal_console(const dsd_opts* opts, const dsd_state* state);
+
+/**
  * @brief Return the number of no-sync buffer passes to dwell before SPS hunt advances.
  */
 int dsd_frame_sync_sps_hunt_dwell_passes(const dsd_opts* opts, const dsd_state* state);

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -2228,7 +2228,7 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
 #ifdef USE_RADIO
     rtl_maybe_update_symbol_profile_with_hint(opts, state, sym_rate, levels_cycle[next_idx]);
 #endif
-    if (opts->verbose > 1) {
+    if (opts->verbose > 1 && !dsd_frame_sync_suppress_tcp_no_signal_console(opts, state)) {
         DSD_FPRINTF(stderr, "SPS hunt: trying %d sps (sym=%d, demod=%d)\n", state->samplesPerSymbol, sym_rate,
                     demod_rate);
     }
@@ -2317,7 +2317,8 @@ frame_sync_handle_no_sync_timeout(dsd_opts* opts, dsd_state* state, const frame_
         return 0;
     }
 
-    if ((opts->errorbars == 1) && (opts->verbose > 1) && (state->carrier == 1)) {
+    if ((opts->errorbars == 1) && (opts->verbose > 1) && (state->carrier == 1)
+        && !dsd_frame_sync_suppress_tcp_no_signal_console(opts, state)) {
         DSD_FPRINTF(stderr, "Sync: no sync\n");
     }
 

--- a/src/dsp/frame_sync_policy.c
+++ b/src/dsp/frame_sync_policy.c
@@ -20,6 +20,14 @@ dsd_frame_sync_suppress_p25_alt_sync(const dsd_opts* opts, const dsd_state* stat
 }
 
 int
+dsd_frame_sync_suppress_tcp_no_signal_console(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state) {
+        return 0;
+    }
+    return opts->audio_in_type == AUDIO_IN_TCP;
+}
+
+int
 dsd_frame_sync_sps_hunt_dwell_passes(const dsd_opts* opts, const dsd_state* state) {
     if (!opts || !state) {
         return 3;

--- a/src/runtime/input_level.c
+++ b/src/runtime/input_level.c
@@ -17,9 +17,9 @@ enum {
     DSD_INPUT_LEVEL_TOAST_TTL_SEC = 4,
 };
 
-static const double DSD_INPUT_LEVEL_SILENCE_FLOOR_DBFS = -120.0;
 static const double DSD_INPUT_LEVEL_CLIP_PCT = 0.1;
 static const double DSD_INPUT_LEVEL_HOT_PEAK_DBFS = -1.0;
+static const double DSD_INPUT_LEVEL_SILENCE_FLOOR_DBFS = -120.0;
 static const double DSD_INPUT_LEVEL_SILENCE_EPSILON_DB = 0.1;
 
 static double
@@ -378,6 +378,11 @@ input_level_status_severity(dsd_input_level_status status) {
 }
 
 static int
+input_level_m17_encoder_active(const dsd_opts* opts) {
+    return opts && (opts->m17encoder == 1 || opts->m17encoderbrt == 1 || opts->m17encoderpkt == 1);
+}
+
+static int
 input_level_is_digital_silence(const dsd_input_level_snapshot* snapshot) {
     return snapshot && snapshot->sample_count > 0U
            && snapshot->rms_dbfs <= DSD_INPUT_LEVEL_SILENCE_FLOOR_DBFS + DSD_INPUT_LEVEL_SILENCE_EPSILON_DB
@@ -385,9 +390,16 @@ input_level_is_digital_silence(const dsd_input_level_snapshot* snapshot) {
 }
 
 static int
-input_level_should_suppress_idle_tcp_low(const dsd_opts* opts, const dsd_input_level_snapshot* snapshot) {
-    return opts && snapshot && opts->audio_in_type == AUDIO_IN_TCP && snapshot->source == DSD_INPUT_LEVEL_SOURCE_PCM
-           && snapshot->status == DSD_INPUT_LEVEL_LOW && input_level_is_digital_silence(snapshot);
+input_level_should_suppress_tcp_pcm_toast(const dsd_opts* opts, const dsd_state* state,
+                                          const dsd_input_level_snapshot* snapshot) {
+    if (!opts || !state || !snapshot || opts->audio_in_type != AUDIO_IN_TCP
+        || snapshot->source != DSD_INPUT_LEVEL_SOURCE_PCM || input_level_m17_encoder_active(opts)
+        || !input_level_status_notifies(snapshot->status)) {
+        return 0;
+    }
+
+    /* state->carrier can lag immediately after sync loss, so digital silence is also an idle signal. */
+    return state->carrier == 0 || (snapshot->status == DSD_INPUT_LEVEL_LOW && input_level_is_digital_silence(snapshot));
 }
 
 int
@@ -465,7 +477,7 @@ dsd_input_level_publish(dsd_opts* opts, dsd_state* state, const dsd_input_level_
     }
 
     time_t now = next.updated != 0 ? next.updated : time(NULL);
-    int notify = input_level_should_suppress_idle_tcp_low(opts, &next)
+    int notify = input_level_should_suppress_tcp_pcm_toast(opts, state, &next)
                      ? 0
                      : input_level_should_notify(opts, state, &next, notify_mask, now);
     state->input_level = next;

--- a/tests/core/test_core_input_level.c
+++ b/tests/core/test_core_input_level.c
@@ -230,7 +230,7 @@ test_rf_low_suppressed_but_clip_notifies(void) {
 }
 
 static void
-test_tcp_silence_low_updates_state_without_toast(void) {
+test_tcp_pcm_idle_levels_update_state_without_toast(void) {
     dsd_opts* opts = calloc(1, sizeof(*opts));
     dsd_state* state = calloc(1, sizeof(*state));
     assert(opts != NULL);
@@ -238,9 +238,75 @@ test_tcp_silence_low_updates_state_without_toast(void) {
     opts->audio_in_type = AUDIO_IN_TCP;
     opts->input_warn_db = -40.0;
     opts->input_warn_cooldown_sec = 10;
+    state->carrier = 0;
 
     DSD_SNPRINTF(state->ui_msg, sizeof(state->ui_msg), "%s", "sentinel");
     dsd_input_level_snapshot silent = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -120.0, -120.0, 0.0, 300);
+    dsd_input_level_publish(opts, state, &silent, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_LOW);
+    assert(state->input_level.source == DSD_INPUT_LEVEL_SOURCE_PCM);
+    assert(strcmp(state->ui_msg, "sentinel") == 0);
+    assert(state->input_level_last_toast_time == 0);
+
+    dsd_input_level_snapshot hot = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -10.0, -0.5, 0.0, 310);
+    dsd_input_level_publish(opts, state, &hot, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_HOT);
+    assert(state->input_level.source == DSD_INPUT_LEVEL_SOURCE_PCM);
+    assert(strcmp(state->ui_msg, "sentinel") == 0);
+    assert(state->input_level_last_toast_time == 0);
+
+    dsd_input_level_snapshot clip = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -120.0, -120.0, 0.2, 320);
+    dsd_input_level_publish(opts, state, &clip, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_CLIPPING);
+    assert(state->input_level.source == DSD_INPUT_LEVEL_SOURCE_PCM);
+    assert(strcmp(state->ui_msg, "sentinel") == 0);
+    assert(state->input_level_last_toast_time == 0);
+
+    free(state);
+    free(opts);
+}
+
+static void
+test_tcp_pcm_active_decoder_levels_still_notify(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+    opts->audio_in_type = AUDIO_IN_TCP;
+    opts->input_warn_db = -40.0;
+    opts->input_warn_cooldown_sec = 10;
+    state->carrier = 1;
+
+    dsd_input_level_snapshot quiet = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -55.0, -30.0, 0.0, 325);
+    dsd_input_level_publish(opts, state, &quiet, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_LOW);
+    assert(strstr(state->ui_msg, "Input Level LOW") != NULL);
+    assert(strstr(state->ui_msg, "if signal is present") != NULL);
+    assert(state->input_level_last_toast_time == 325);
+
+    dsd_input_level_snapshot hot = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -10.0, -0.5, 0.0, 330);
+    dsd_input_level_publish(opts, state, &hot, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(state->input_level.status == DSD_INPUT_LEVEL_HOT);
+    assert(strstr(state->ui_msg, "Input Level HOT") != NULL);
+    assert(state->input_level_last_toast_time == 330);
+
+    free(state);
+    free(opts);
+}
+
+static void
+test_tcp_pcm_silence_suppressed_before_carrier_reset(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+    opts->audio_in_type = AUDIO_IN_TCP;
+    opts->input_warn_db = -40.0;
+    opts->input_warn_cooldown_sec = 10;
+    state->carrier = 1;
+
+    DSD_SNPRINTF(state->ui_msg, sizeof(state->ui_msg), "%s", "sentinel");
+    dsd_input_level_snapshot silent = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -120.0, -120.0, 0.0, 335);
     dsd_input_level_publish(opts, state, &silent, DSD_INPUT_LEVEL_NOTIFY_ALL);
     assert(state->input_level.status == DSD_INPUT_LEVEL_LOW);
     assert(state->input_level.source == DSD_INPUT_LEVEL_SOURCE_PCM);
@@ -252,41 +318,22 @@ test_tcp_silence_low_updates_state_without_toast(void) {
 }
 
 static void
-test_tcp_low_non_silent_still_notifies(void) {
+test_tcp_pcm_m17_encoder_levels_still_notify(void) {
     dsd_opts* opts = calloc(1, sizeof(*opts));
     dsd_state* state = calloc(1, sizeof(*state));
     assert(opts != NULL);
     assert(state != NULL);
     opts->audio_in_type = AUDIO_IN_TCP;
+    opts->m17encoder = 1;
     opts->input_warn_db = -40.0;
     opts->input_warn_cooldown_sec = 10;
+    state->carrier = 0;
 
-    dsd_input_level_snapshot quiet = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -55.0, -30.0, 0.0, 310);
-    dsd_input_level_publish(opts, state, &quiet, DSD_INPUT_LEVEL_NOTIFY_ALL);
-    assert(state->input_level.status == DSD_INPUT_LEVEL_LOW);
-    assert(strstr(state->ui_msg, "Input Level LOW") != NULL);
-    assert(strstr(state->ui_msg, "if signal is present") != NULL);
-    assert(state->input_level_last_toast_time == 310);
-
-    free(state);
-    free(opts);
-}
-
-static void
-test_tcp_silence_clip_still_notifies(void) {
-    dsd_opts* opts = calloc(1, sizeof(*opts));
-    dsd_state* state = calloc(1, sizeof(*state));
-    assert(opts != NULL);
-    assert(state != NULL);
-    opts->audio_in_type = AUDIO_IN_TCP;
-    opts->input_warn_db = -40.0;
-    opts->input_warn_cooldown_sec = 10;
-
-    dsd_input_level_snapshot clip = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -120.0, -120.0, 0.2, 320);
+    dsd_input_level_snapshot clip = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -10.0, -0.1, 0.2, 340);
     dsd_input_level_publish(opts, state, &clip, DSD_INPUT_LEVEL_NOTIFY_ALL);
     assert(state->input_level.status == DSD_INPUT_LEVEL_CLIPPING);
     assert(strstr(state->ui_msg, "Input Level CLIP") != NULL);
-    assert(state->input_level_last_toast_time == 320);
+    assert(state->input_level_last_toast_time == 340);
 
     free(state);
     free(opts);
@@ -335,9 +382,10 @@ main(void) {
     test_toast_escalation_survives_ok_sample();
     test_toast_cooldown_suppresses_hot_clip_oscillation();
     test_rf_low_suppressed_but_clip_notifies();
-    test_tcp_silence_low_updates_state_without_toast();
-    test_tcp_low_non_silent_still_notifies();
-    test_tcp_silence_clip_still_notifies();
+    test_tcp_pcm_idle_levels_update_state_without_toast();
+    test_tcp_pcm_active_decoder_levels_still_notify();
+    test_tcp_pcm_silence_suppressed_before_carrier_reset();
+    test_tcp_pcm_m17_encoder_levels_still_notify();
     test_non_tcp_silence_low_still_notifies();
     test_advisory_text_selection();
     return 0;

--- a/tests/dsp/test_frame_sync_policy.c
+++ b/tests/dsp/test_frame_sync_policy.c
@@ -8,6 +8,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/frame_sync.h>
+#include <stddef.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -37,6 +38,22 @@ main(void) {
     state.carrier = 1;
     state.lastsynctype = DSD_SYNC_YSF_POS;
     assert(dsd_frame_sync_suppress_p25_alt_sync(&opts, &state) == 0);
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_TCP;
+    assert(dsd_frame_sync_suppress_tcp_no_signal_console(&opts, &state) == 1);
+
+    opts.audio_in_type = AUDIO_IN_PULSE;
+    assert(dsd_frame_sync_suppress_tcp_no_signal_console(&opts, &state) == 0);
+
+    opts.audio_in_type = AUDIO_IN_UDP;
+    assert(dsd_frame_sync_suppress_tcp_no_signal_console(&opts, &state) == 0);
+
+    opts.audio_in_type = AUDIO_IN_RTL;
+    assert(dsd_frame_sync_suppress_tcp_no_signal_console(&opts, &state) == 0);
+
+    assert(dsd_frame_sync_suppress_tcp_no_signal_console(NULL, &state) == 0);
+    assert(dsd_frame_sync_suppress_tcp_no_signal_console(&opts, NULL) == 0);
 
     reset(&opts, &state);
     opts.frame_p25p1 = 1;

--- a/tools/semgrep.sh
+++ b/tools/semgrep.sh
@@ -11,10 +11,11 @@ cd "$ROOT_DIR"
 
 usage() {
   cat << 'USAGE'
-Usage: tools/semgrep.sh [--strict] [--config <config>] [--] [paths...]
+Usage: tools/semgrep.sh [--strict] [--jobs N] [--config <config>] [--] [paths...]
 
 Options:
   --strict          Fail on findings (--error).
+  --jobs N          Semgrep parallelism (default: DSD_SEMGREP_JOBS or 1).
   --config CONFIG   Semgrep config/rule pack (default: p/default; strict also
                     adds p/c, p/security-audit, and semgrep/dsd-neo.yml).
                     May be supplied multiple times.
@@ -23,6 +24,7 @@ Arguments:
   paths...          Optional paths to scan. Default: src include apps tests tools .github/workflows
 
 Environment:
+  DSD_SEMGREP_JOBS       Optional Semgrep parallelism override.
   DSD_SEMGREP_SARIF_OUT  Optional SARIF output path for GitHub code scanning.
 USAGE
 }
@@ -30,6 +32,7 @@ USAGE
 STRICT=0
 CONFIGS=("p/default")
 CUSTOM_CONFIGS=0
+SEMGREP_JOBS="${DSD_SEMGREP_JOBS:-1}"
 TARGETS=()
 
 while [[ $# -gt 0 ]]; do
@@ -37,6 +40,14 @@ while [[ $# -gt 0 ]]; do
     --strict)
       STRICT=1
       shift
+      ;;
+    --jobs)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --jobs" >&2
+        exit 2
+      fi
+      SEMGREP_JOBS="$2"
+      shift 2
       ;;
     --config)
       if [[ $# -lt 2 ]]; then
@@ -70,6 +81,11 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ ! "$SEMGREP_JOBS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid Semgrep jobs value: $SEMGREP_JOBS" >&2
+  exit 2
+fi
 
 if ! command -v semgrep > /dev/null 2>&1; then
   echo "semgrep not found. Install with: pipx install semgrep (or pip install semgrep)." >&2
@@ -106,6 +122,7 @@ fi
 LOG_FILE=".semgrep.local.out"
 
 ARGS=(
+  --jobs "$SEMGREP_JOBS"
   --metrics=off
   --disable-version-check
   --no-git-ignore


### PR DESCRIPTION
## Summary

- Suppress repeated TCP PCM idle/search console diagnostics for input-level warnings, `Sync: no sync`, and SPS hunt messages while preserving persistent input status.
- Keep active decoder and M17 encoder input-level warnings available when they can still be actionable.
- Add regression coverage for TCP idle/input-level policy and frame-sync suppression policy.
- Cap `tools/semgrep.sh` to one Semgrep worker by default, with `--jobs` and `DSD_SEMGREP_JOBS` overrides, to avoid Semgrep engine allocation failures on constrained runners.

## Root Cause

TCP PCM no-signal streams could repeatedly publish advisory console output while the decoder was searching for sync. Separately, Semgrep's default parallelism could overrun local or CI runner limits and fail before analysis with `io_uring_queue_init` allocation errors.

## Validation

- `tools/format.sh`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `tools/shell_lint.sh`
- `tools/semgrep.sh --strict -- docs/cli.md docs/ui-terminal.md include/dsd-neo/dsp/frame_sync.h src/dsp/dsd_frame_sync.c src/dsp/frame_sync_policy.c src/runtime/input_level.c tests/core/test_core_input_level.c tests/dsp/test_frame_sync_policy.c tools/semgrep.sh`
- `tools/semgrep.sh --jobs 0 -- src/runtime/input_level.c` rejected invalid jobs value as expected
- `tools/preflight_ci.sh`
- Fake TCP PCM loopback smoke test for silence and clipped PCM streams: no `Input Level`, `WARNING:`, `Sync: no sync`, `SPS hunt:`, or TCP disconnect spam while the server stayed open
- Pre-push hook on `git push -u origin fix/tcp-idle-console-noise`