### PR TITLE
Harden P25 failed VC retune backoff

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -31,6 +31,7 @@
 
 enum DSD_ATTR_PACKED {
     DSD_P25_P2_AUDIO_RING_DEPTH = 4,
+    DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH = 8,
     DSD_TRUNK_CHAN_MAP_SIZE = 0xFFFF,
     DSD_VERTEX_KS_MAP_MAX = 64,
     DSD_RTL_SYMBOL_CACHE_CAP = 512,
@@ -749,10 +750,14 @@ struct dsd_state {
     int p25_sm_mode;
 
     // Retune backoff bookkeeping
-    // Blocks immediate re-tune to same VC/slot after a recent return
+    // Blocks immediate re-tune to failed VC/slot pairs after recent no-voice returns
     time_t p25_retune_block_until;
     long p25_retune_block_freq;
     int p25_retune_block_slot; // -1 when N/A
+    unsigned int p25_retune_block_next;
+    time_t p25_retune_block_history_until[DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH];
+    long p25_retune_block_history_freq[DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH];
+    int p25_retune_block_history_slot[DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH]; // -1 when N/A
     // Cached P25 SM tunables (seconds), resolved once at p25_sm_init()
     double p25_cfg_vc_grace_s;
     double p25_cfg_grant_voice_to_s;

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -840,6 +840,19 @@ init_state_p25_patch_defaults(dsd_state* state) {
 }
 
 static void
+init_state_p25_retune_backoff_defaults(dsd_state* state) {
+    state->p25_retune_block_until = 0;
+    state->p25_retune_block_freq = 0;
+    state->p25_retune_block_slot = -1;
+    state->p25_retune_block_next = 0;
+    DSD_MEMSET(state->p25_retune_block_history_until, 0, sizeof(state->p25_retune_block_history_until));
+    DSD_MEMSET(state->p25_retune_block_history_freq, 0, sizeof(state->p25_retune_block_history_freq));
+    for (int i = 0; i < DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH; i++) {
+        state->p25_retune_block_history_slot[i] = -1;
+    }
+}
+
+static void
 init_state_p25_and_trunk_defaults(dsd_state* state) {
     //P2 variables
     state->p2_wacn = 0;
@@ -895,6 +908,7 @@ init_state_p25_and_trunk_defaults(dsd_state* state) {
     state->p25_vc_freq[1] = 0;
 
     init_state_p25_patch_defaults(state);
+    init_state_p25_retune_backoff_defaults(state);
 
     //edacs - may need to make these user configurable instead for stability on non-ea systems
     state->ea_mode = -1; //init on -1, 0 is standard, 1 is ea

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -64,17 +64,22 @@ typedef struct {
     long int p25_vc_freq[2];
     long int trunk_vc_freq[2];
     time_t p25_patch_last_update[8];
+    time_t p25_retune_block_until;
     long int trunk_lcn_freq[26];
+    long p25_retune_block_freq;
     dsd_trunk_cc_candidates cc_candidates;
     p25_nb_entry_t p25_nb_entries[P25_NB_MAX];
     p25_iden_entry_t p25_iden_fdma[16];
     p25_iden_entry_t p25_iden_tdma[16];
+    time_t p25_retune_block_history_until[DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH];
     time_t p25_aff_last_seen[256];
     time_t p25_ga_last_seen[512];
     long int trunk_chan_map[DSD_TRUNK_CHAN_MAP_SIZE];
     uint32_t trunk_chan_map_used_count;
+    unsigned int p25_retune_block_next;
     unsigned int dmr_color_code;
     int p25_chan_iden;
+    int p25_retune_block_slot;
     int p25_cc_is_tdma;
     int p25_sys_is_tdma;
     int p25_vc_cqpsk_pref;
@@ -117,6 +122,8 @@ typedef struct {
     uint16_t p25_patch_wgid[8][8];
     uint16_t p25_ga_tg[512];
     uint16_t trunk_chan_map_used[DSD_TRUNK_CHAN_MAP_SIZE];
+    long p25_retune_block_history_freq[DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH];
+    int p25_retune_block_history_slot[DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH];
     uint8_t p25_prot_valid;
     uint8_t p25_prot_algid;
     uint8_t p25_sys_time_valid;
@@ -511,6 +518,10 @@ trunk_scan_snapshot_clear(dsd_trunk_scan_snapshot* snapshot) {
     snapshot->dmr_confidence_color_code = 16;
     snapshot->dmr_confidence_candidate_cc = 16;
     snapshot->dmr_rest_channel = -1;
+    snapshot->p25_retune_block_slot = -1;
+    for (int i = 0; i < DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH; i++) {
+        snapshot->p25_retune_block_history_slot[i] = -1;
+    }
     snapshot->p25_cc_is_tdma = 2;
     snapshot->p25_vc_cqpsk_pref = -1;
     snapshot->p25_vc_cqpsk_override = -1;
@@ -575,6 +586,34 @@ trunk_scan_restore_call_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot
 }
 
 static void
+trunk_scan_save_p25_retune_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot* snapshot) {
+    snapshot->p25_retune_block_until = state->p25_retune_block_until;
+    snapshot->p25_retune_block_freq = state->p25_retune_block_freq;
+    snapshot->p25_retune_block_slot = state->p25_retune_block_slot;
+    snapshot->p25_retune_block_next = state->p25_retune_block_next;
+    DSD_MEMCPY(snapshot->p25_retune_block_history_until, state->p25_retune_block_history_until,
+               sizeof(snapshot->p25_retune_block_history_until));
+    DSD_MEMCPY(snapshot->p25_retune_block_history_freq, state->p25_retune_block_history_freq,
+               sizeof(snapshot->p25_retune_block_history_freq));
+    DSD_MEMCPY(snapshot->p25_retune_block_history_slot, state->p25_retune_block_history_slot,
+               sizeof(snapshot->p25_retune_block_history_slot));
+}
+
+static void
+trunk_scan_restore_p25_retune_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot* snapshot) {
+    state->p25_retune_block_until = snapshot->p25_retune_block_until;
+    state->p25_retune_block_freq = snapshot->p25_retune_block_freq;
+    state->p25_retune_block_slot = snapshot->p25_retune_block_slot;
+    state->p25_retune_block_next = snapshot->p25_retune_block_next;
+    DSD_MEMCPY(state->p25_retune_block_history_until, snapshot->p25_retune_block_history_until,
+               sizeof(state->p25_retune_block_history_until));
+    DSD_MEMCPY(state->p25_retune_block_history_freq, snapshot->p25_retune_block_history_freq,
+               sizeof(state->p25_retune_block_history_freq));
+    DSD_MEMCPY(state->p25_retune_block_history_slot, snapshot->p25_retune_block_history_slot,
+               sizeof(state->p25_retune_block_history_slot));
+}
+
+static void
 trunk_scan_save_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot* snapshot) {
     if (!state || !snapshot) {
         return;
@@ -588,6 +627,7 @@ trunk_scan_save_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot* snapsh
     snapshot->trunk_cc_freq = state->trunk_cc_freq;
     DSD_MEMCPY(snapshot->p25_vc_freq, state->p25_vc_freq, sizeof(snapshot->p25_vc_freq));
     DSD_MEMCPY(snapshot->trunk_vc_freq, state->trunk_vc_freq, sizeof(snapshot->trunk_vc_freq));
+    trunk_scan_save_p25_retune_snapshot(state, snapshot);
     DSD_MEMCPY(snapshot->trunk_lcn_freq, state->trunk_lcn_freq, sizeof(snapshot->trunk_lcn_freq));
     DSD_MEMCPY(snapshot->trunk_chan_map, state->trunk_chan_map, sizeof(snapshot->trunk_chan_map));
     DSD_MEMCPY(snapshot->trunk_chan_map_used, state->trunk_chan_map_used, sizeof(snapshot->trunk_chan_map_used));
@@ -688,6 +728,7 @@ trunk_scan_restore_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot* sna
     state->trunk_cc_freq = snapshot->trunk_cc_freq;
     DSD_MEMCPY(state->p25_vc_freq, snapshot->p25_vc_freq, sizeof(state->p25_vc_freq));
     DSD_MEMCPY(state->trunk_vc_freq, snapshot->trunk_vc_freq, sizeof(state->trunk_vc_freq));
+    trunk_scan_restore_p25_retune_snapshot(state, snapshot);
     DSD_MEMCPY(state->trunk_lcn_freq, snapshot->trunk_lcn_freq, sizeof(state->trunk_lcn_freq));
     DSD_MEMCPY(state->trunk_chan_map, snapshot->trunk_chan_map, sizeof(state->trunk_chan_map));
     DSD_MEMCPY(state->trunk_chan_map_used, snapshot->trunk_chan_map_used, sizeof(state->trunk_chan_map_used));

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -31,15 +31,49 @@
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
-static void do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason);
+static void do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason,
+                       int arm_failed_vc_backoff_on_accept);
 
 // Serialize release-to-CC operations to avoid duplicate retunes when multiple
 // threads (watchdog tick + decoder) request release concurrently.
 static atomic_int g_p25_sm_release_lock = 0;
 
+#define P25_FAILED_VC_RETUNE_BACKOFF_DEFAULT_S 10.0
+
 static inline double
 now_monotonic(void) {
     return dsd_time_now_monotonic_s();
+}
+
+static int
+p25_retune_backoff_explicitly_disabled(const dsdneoRuntimeConfig* cfg) {
+    return (cfg && cfg->p25_retune_backoff_is_set && cfg->p25_retune_backoff_s <= 0.0) ? 1 : 0;
+}
+
+static double
+p25_failed_vc_retune_backoff_s(const dsd_opts* opts) {
+    const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
+    if (p25_retune_backoff_explicitly_disabled(cfg)) {
+        return 0.0;
+    }
+    if (cfg && cfg->p25_retune_backoff_is_set && cfg->p25_retune_backoff_s > 0.0) {
+        return cfg->p25_retune_backoff_s;
+    }
+    if (opts && opts->p25_retune_backoff_s > 0.0) {
+        return opts->p25_retune_backoff_s;
+    }
+    return P25_FAILED_VC_RETUNE_BACKOFF_DEFAULT_S;
+}
+
+static time_t
+p25_backoff_wall_seconds(double backoff_s) {
+    if (backoff_s <= 0.0) {
+        return 0;
+    }
+    if (backoff_s < 1.0) {
+        return 1;
+    }
+    return (time_t)(backoff_s + 0.999);
 }
 
 static int
@@ -479,7 +513,7 @@ p25_grant_preempt_active_call_if_needed(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
     }
     log_preempt_decision(ctx, opts, state, route, decision, "policy-allow", 1);
     sm_log(opts, state, "grant-preempt-accept");
-    do_release(ctx, opts, state, "grant-preempt");
+    do_release(ctx, opts, state, "grant-preempt", 0);
     return 1;
 }
 
@@ -627,6 +661,74 @@ p25_grant_handle_duplicate(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_st
     return 1;
 }
 
+static int
+p25_retune_block_slot_matches(int blocked_slot, int grant_slot) {
+    return blocked_slot == grant_slot;
+}
+
+static void
+p25_retune_block_clear_history_entry(dsd_state* state, int idx) {
+    if (!state || idx < 0 || idx >= DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH) {
+        return;
+    }
+    state->p25_retune_block_history_until[idx] = 0;
+    state->p25_retune_block_history_freq[idx] = 0;
+    state->p25_retune_block_history_slot[idx] = -1;
+}
+
+static int
+p25_retune_block_log_match(const dsd_opts* opts, dsd_state* state, int channel, long freq, int slot, time_t until) {
+    sm_log(opts, state, "grant-vc-backoff");
+    if (opts && opts->verbose > 1) {
+        DSD_FPRINTF(stderr, "\n[P25 SM] grant-vc-backoff ch=0x%04X freq=%ld slot=%d until=%ld\n", channel & 0xFFFF,
+                    freq, slot, (long)until);
+    }
+    return 1;
+}
+
+static int
+p25_grant_retune_blocked(const dsd_opts* opts, dsd_state* state, long freq, int slot, int channel) {
+    if (!state || freq <= 0) {
+        return 0;
+    }
+
+    time_t now = time(NULL);
+    for (int i = 0; i < DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH; i++) {
+        time_t until = state->p25_retune_block_history_until[i];
+        if (until <= 0) {
+            continue;
+        }
+        if (now >= until) {
+            p25_retune_block_clear_history_entry(state, i);
+            continue;
+        }
+        if (state->p25_retune_block_history_freq[i] == freq
+            && p25_retune_block_slot_matches(state->p25_retune_block_history_slot[i], slot)) {
+            state->p25_retune_block_freq = state->p25_retune_block_history_freq[i];
+            state->p25_retune_block_slot = state->p25_retune_block_history_slot[i];
+            state->p25_retune_block_until = until;
+            return p25_retune_block_log_match(opts, state, channel, freq, slot, until);
+        }
+    }
+
+    if (state->p25_retune_block_until <= 0) {
+        return 0;
+    }
+
+    if (now >= state->p25_retune_block_until) {
+        state->p25_retune_block_until = 0;
+        state->p25_retune_block_freq = 0;
+        state->p25_retune_block_slot = -1;
+        return 0;
+    }
+
+    if (state->p25_retune_block_freq != freq || !p25_retune_block_slot_matches(state->p25_retune_block_slot, slot)) {
+        return 0;
+    }
+
+    return p25_retune_block_log_match(opts, state, channel, freq, slot, state->p25_retune_block_until);
+}
+
 /* ============================================================================
  * Event Handlers
  * ============================================================================ */
@@ -658,6 +760,9 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
 
     now_m = now_monotonic();
     slot = channel_slot(state, ev->channel);
+    if (p25_grant_retune_blocked(opts, state, freq, slot, ev->channel)) {
+        return;
+    }
     needs_retune = (ctx->state == P25_SM_TUNED && ctx->vc_freq_hz != 0 && ctx->vc_freq_hz != freq) ? 1 : 0;
     target_id = p25_grant_target_id(ev, &decision);
     p25_grant_fill_route(&route, ev, freq, slot, needs_retune, target_id);
@@ -776,7 +881,7 @@ handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, 
 
         if (can_release) {
             // All active slots terminated - release immediately like P25P1 Call Termination
-            do_release(ctx, opts, state, "call-end");
+            do_release(ctx, opts, state, "call-end", 0);
         }
     }
 }
@@ -872,7 +977,7 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
                        || (state->p25_p2_audio_ring_count[other] > 0);
 
     if (!other_active) {
-        do_release(ctx, opts, state, "enc-lockout");
+        do_release(ctx, opts, state, "enc-lockout", 0);
     } else {
         sm_log(opts, state, "enc-lockout-slot-only");
     }
@@ -922,6 +1027,60 @@ p25_release_clear_context(p25_sm_ctx_t* ctx) {
 }
 
 static void
+p25_retune_block_remember_failure(dsd_state* state, long freq, int slot, time_t until) {
+    int replace_idx = -1;
+    time_t now = time(NULL);
+    if (!state || freq <= 0 || until <= now) {
+        return;
+    }
+
+    for (int i = 0; i < DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH; i++) {
+        if (state->p25_retune_block_history_until[i] > 0 && state->p25_retune_block_history_freq[i] == freq
+            && p25_retune_block_slot_matches(state->p25_retune_block_history_slot[i], slot)) {
+            replace_idx = i;
+            break;
+        }
+        if (replace_idx < 0 && state->p25_retune_block_history_until[i] <= now) {
+            replace_idx = i;
+        }
+    }
+
+    if (replace_idx < 0) {
+        replace_idx = (int)(state->p25_retune_block_next % DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH);
+        state->p25_retune_block_next++;
+    }
+
+    state->p25_retune_block_history_freq[replace_idx] = freq;
+    state->p25_retune_block_history_slot[replace_idx] = slot;
+    state->p25_retune_block_history_until[replace_idx] = until;
+}
+
+static void
+p25_arm_failed_vc_retune_backoff(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
+    if (!ctx || !state || ctx->vc_freq_hz <= 0 || ctx->t_voice_m > 0.0 || ctx->slots[0].voice_active
+        || ctx->slots[1].voice_active) {
+        return;
+    }
+
+    double backoff_s = p25_failed_vc_retune_backoff_s(opts);
+    time_t backoff_wall = p25_backoff_wall_seconds(backoff_s);
+    if (backoff_wall <= 0) {
+        return;
+    }
+
+    time_t until = time(NULL) + backoff_wall;
+    state->p25_retune_block_freq = ctx->vc_freq_hz;
+    state->p25_retune_block_slot = channel_slot(state, ctx->vc_channel);
+    state->p25_retune_block_until = until;
+    p25_retune_block_remember_failure(state, ctx->vc_freq_hz, state->p25_retune_block_slot, until);
+    sm_log(opts, state, "grant-vc-backoff-arm");
+    if (opts && opts->verbose > 1) {
+        DSD_FPRINTF(stderr, "\n[P25 SM] grant-vc-backoff-arm ch=0x%04X freq=%ld slot=%d %.3fs\n",
+                    ctx->vc_channel & 0xFFFF, ctx->vc_freq_hz, state->p25_retune_block_slot, backoff_s);
+    }
+}
+
+static void
 p25_release_clear_decoder_state(dsd_opts* opts, dsd_state* state) {
     if (state) {
         (void)dsd_tg_policy_clear_active_call(state, -1);
@@ -949,7 +1108,8 @@ p25_release_clear_decoder_state(dsd_opts* opts, dsd_state* state) {
 }
 
 static void
-do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason) {
+do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason,
+           int arm_failed_vc_backoff_on_accept) {
     double tune_start_m = 0.0;
     int had_force_release = 0;
     if (!ctx) {
@@ -981,6 +1141,10 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
     if (!p25_release_return_to_cc_accepted(ctx, opts, state, had_force_release, &tune_start_m)) {
         atomic_store(&g_p25_sm_release_lock, 0);
         return;
+    }
+
+    if (had_force_release || arm_failed_vc_backoff_on_accept) {
+        p25_arm_failed_vc_retune_backoff(ctx, opts, state);
     }
 
     p25_release_clear_context(ctx);
@@ -1050,6 +1214,34 @@ next_lcn_freq(dsd_state* state, long* out_freq) {
     return 0;
 }
 
+static int
+p25_has_user_lcn_list(const dsd_opts* opts, const dsd_state* state) {
+    if (opts && opts->chan_in_file[0] != '\0') {
+        return 1;
+    }
+    if (!opts || !state || opts->trunk_scan_enabled != 1) {
+        return 0;
+    }
+
+    // Trunk-scan seeds entry 0 with the target CC. Additional entries mean a
+    // per-target chan_csv was imported; learned grant caches only populate the
+    // sparse channel map and must not disable current-site CC candidate hunts.
+    return (state->lcn_freq_count > 1) ? 1 : 0;
+}
+
+static int
+next_primary_cc_freq(dsd_state* state, long* out_freq) {
+    if (!state || !out_freq) {
+        return 0;
+    }
+    long cc = (state->p25_cc_freq != 0) ? state->p25_cc_freq : state->trunk_cc_freq;
+    if (cc <= 0) {
+        return 0;
+    }
+    *out_freq = cc;
+    return 1;
+}
+
 // Try tuning to next CC candidate or LCN freq
 static void
 try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
@@ -1059,8 +1251,11 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
     long cand = 0;
     int sps = cc_ted_sps(opts, state);
 
-    // First try discovered CC candidates (if preference enabled)
-    if (opts && opts->p25_prefer_candidates == 1 && next_cc_candidate(state, &cand, now_m)) {
+    const int has_user_lcn_list = p25_has_user_lcn_list(opts, state);
+
+    // In no-import operation, only explicit current-site candidates are eligible
+    // before falling back to the known primary CC.
+    if (((opts && opts->p25_prefer_candidates == 1) || !has_user_lcn_list) && next_cc_candidate(state, &cand, now_m)) {
         dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, cand, sps);
         if (!dsd_trunk_tune_result_is_ok(tune_result)) {
             sm_log(opts, state,
@@ -1075,8 +1270,8 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
         return;
     }
 
-    // Fall back to user-provided LCN list
-    if (next_lcn_freq(state, &cand)) {
+    // Fall back only to an explicit user channel map; otherwise return to the known primary CC.
+    if ((has_user_lcn_list ? next_lcn_freq(state, &cand) : next_primary_cc_freq(state, &cand))) {
         dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, cand, sps);
         if (!dsd_trunk_tune_result_is_ok(tune_result)) {
             sm_log(opts, state,
@@ -1263,7 +1458,7 @@ p25_sm_tick_handle_forced_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* 
         return 0;
     }
     if (ctx->state == P25_SM_TUNED) {
-        do_release(ctx, opts, state, "release-forced");
+        do_release(ctx, opts, state, "release-forced", 0);
     } else {
         state->p25_sm_force_release = 0;
     }
@@ -1399,7 +1594,7 @@ p25_sm_tick_tuned_check_hangtime(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
     dt_voice = now_m - ctx->t_voice_m;
     effective_hangtime = p25_sm_effective_hangtime(state, hangtime);
     if (dt_voice >= effective_hangtime) {
-        do_release(ctx, opts, state, "hangtime-expired");
+        do_release(ctx, opts, state, "hangtime-expired", 0);
     }
 }
 
@@ -1494,7 +1689,7 @@ p25_sm_tick_tuned_wait_voice(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state
     double dt_tune = now_m - ctx->t_tune_m;
     p25_sm_tick_try_cqpsk_retry(ctx, opts, state, now_m, dt_tune);
     if (dt_tune >= grant_timeout) {
-        do_release(ctx, opts, state, "grant-timeout");
+        do_release(ctx, opts, state, "grant-timeout", 1);
     }
 }
 
@@ -1659,7 +1854,7 @@ p25_sm_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* 
     if (!ctx) {
         ctx = p25_sm_get_ctx();
     }
-    do_release(ctx, opts, state, reason ? reason : "explicit-release");
+    do_release(ctx, opts, state, reason ? reason : "explicit-release", 0);
 }
 
 int

--- a/tests/core/test_core_init_state.c
+++ b/tests/core/test_core_init_state.c
@@ -54,6 +54,15 @@ main(void) {
     state->trunk_chan_map_used[0] = 0x0123U;
     state->trunk_chan_map_used_count = 1U;
     state->trunk_chan_map_seq = 99U;
+    state->p25_retune_block_until = 1234567890;
+    state->p25_retune_block_freq = 851125000L;
+    state->p25_retune_block_slot = 1;
+    state->p25_retune_block_next = 7U;
+    for (int i = 0; i < DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH; i++) {
+        state->p25_retune_block_history_until[i] = 1234567890 + i;
+        state->p25_retune_block_history_freq[i] = 851125000L + i;
+        state->p25_retune_block_history_slot[i] = i % 2;
+    }
     state->rtl_symbol_cache[0] = 1234.0f;
     state->rtl_symbol_cache[DSD_RTL_SYMBOL_CACHE_CAP - 1] = 5678.0f;
     state->rtl_symbol_cache_pos = 2;
@@ -222,6 +231,23 @@ main(void) {
         freeState(state);
         free(state);
         return 4;
+    }
+
+    if (state->p25_retune_block_until != 0 || state->p25_retune_block_freq != 0 || state->p25_retune_block_slot != -1
+        || state->p25_retune_block_next != 0U) {
+        DSD_FPRINTF(stderr, "initState did not reset P25 retune backoff state\n");
+        freeState(state);
+        free(state);
+        return 22;
+    }
+    for (int i = 0; i < DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH; i++) {
+        if (state->p25_retune_block_history_until[i] != 0 || state->p25_retune_block_history_freq[i] != 0
+            || state->p25_retune_block_history_slot[i] != -1) {
+            DSD_FPRINTF(stderr, "initState did not reset P25 retune backoff history\n");
+            freeState(state);
+            free(state);
+            return 23;
+        }
     }
 
     if (state->rtl_symbol_cache_pos != 0 || state->rtl_symbol_cache_len != 0 || state->rtl_symbol_cache_output_kind != 0

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -1710,6 +1711,90 @@ test_channel_map_sequence_advances_on_equal_count_target_switches(void) {
 }
 
 static int
+test_p25_retune_backoff_state_isolated_per_target(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,p25-trunk,851000000,,250,,\n"
+                             "b,p25-trunk,852000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    dsd_engine_trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "retune-backoff snapshot init failed rc=%d active=%zu err=%s\n", rc,
+                    dsd_engine_trunk_scan_active_index(&state), err);
+        test_rc = 1;
+    }
+
+    const time_t until0 = time(NULL) + 60;
+    state.p25_retune_block_until = until0;
+    state.p25_retune_block_freq = 851125000L;
+    state.p25_retune_block_slot = 1;
+    state.p25_retune_block_next = 5U;
+    state.p25_retune_block_history_until[0] = until0;
+    state.p25_retune_block_history_freq[0] = 851125000L;
+    state.p25_retune_block_history_slot[0] = 1;
+
+    dsd_engine_trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1 || state.p25_retune_block_until != 0
+        || state.p25_retune_block_freq != 0 || state.p25_retune_block_history_until[0] != 0) {
+        DSD_FPRINTF(stderr, "retune-backoff leaked into target 1 active=%zu until=%ld freq=%ld hist=%ld\n",
+                    dsd_engine_trunk_scan_active_index(&state), (long)state.p25_retune_block_until,
+                    state.p25_retune_block_freq, (long)state.p25_retune_block_history_until[0]);
+        test_rc = 1;
+    }
+
+    const time_t until1 = time(NULL) + 90;
+    state.p25_retune_block_until = until1;
+    state.p25_retune_block_freq = 852125000L;
+    state.p25_retune_block_slot = 0;
+    state.p25_retune_block_next = 7U;
+    state.p25_retune_block_history_until[0] = until1;
+    state.p25_retune_block_history_freq[0] = 852125000L;
+    state.p25_retune_block_history_slot[0] = 0;
+
+    dsd_engine_trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || state.p25_retune_block_until != until0
+        || state.p25_retune_block_freq != 851125000L || state.p25_retune_block_slot != 1
+        || state.p25_retune_block_next != 5U || state.p25_retune_block_history_until[0] != until0
+        || state.p25_retune_block_history_freq[0] != 851125000L || state.p25_retune_block_history_slot[0] != 1) {
+        DSD_FPRINTF(stderr, "retune-backoff target 0 restore failed active=%zu until=%ld freq=%ld slot=%d next=%u\n",
+                    dsd_engine_trunk_scan_active_index(&state), (long)state.p25_retune_block_until,
+                    state.p25_retune_block_freq, state.p25_retune_block_slot, state.p25_retune_block_next);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(0.78);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1 || state.p25_retune_block_until != until1
+        || state.p25_retune_block_freq != 852125000L || state.p25_retune_block_slot != 0
+        || state.p25_retune_block_next != 7U || state.p25_retune_block_history_until[0] != until1
+        || state.p25_retune_block_history_freq[0] != 852125000L || state.p25_retune_block_history_slot[0] != 0) {
+        DSD_FPRINTF(stderr, "retune-backoff target 1 restore failed active=%zu until=%ld freq=%ld slot=%d next=%u\n",
+                    dsd_engine_trunk_scan_active_index(&state), (long)state.p25_retune_block_until,
+                    state.p25_retune_block_freq, state.p25_retune_block_slot, state.p25_retune_block_next);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_engine_trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
 test_trunk_targets_reuse_restored_control_channel(void) {
     char dir[DSD_TEST_PATH_MAX];
     char target_path[DSD_TEST_PATH_MAX];
@@ -2318,6 +2403,7 @@ main(void) {
     rc |= test_p25_targets_pass_cc_sps_to_retune_paths();
     rc |= test_p25_targets_use_rtl_output_rate_for_retune_sps();
     rc |= test_channel_map_sequence_advances_on_equal_count_target_switches();
+    rc |= test_p25_retune_backoff_state_isolated_per_target();
     rc |= test_trunk_targets_reuse_restored_control_channel();
     rc |= test_locked_demod_mode_preserved_when_seeding_targets();
     rc |= test_scan_tick_skips_rotation_when_p25_guard_busy();

--- a/tests/protocol/p25/test_p25_p1_lcw_gating.c
+++ b/tests/protocol/p25/test_p25_p1_lcw_gating.c
@@ -15,6 +15,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -204,6 +205,17 @@ main(void) {
     g_tunes = 0;
     p25_lcw(&opts, &st, lcw, 0);
     rc |= expect_eq_int("clear->tune", g_tunes, 1);
+
+    // Failed-VC backoff must also apply to LCW 0x44 explicit grants.
+    st.p25_retune_block_freq = 851125000;
+    st.p25_retune_block_slot = -1;
+    st.p25_retune_block_until = time(NULL) + 60;
+    g_tunes = 0;
+    p25_lcw(&opts, &st, lcw, 0);
+    rc |= expect_eq_int("clear blocked by backoff", g_tunes, 0);
+    st.p25_retune_block_freq = 0;
+    st.p25_retune_block_slot = -1;
+    st.p25_retune_block_until = 0;
 
     // Packet bit set: tuning disabled by default policy (trunk_tune_data_calls=0)
     set_bits_msb(lcw, 16, 8, (unsigned)(svc | 0x10));

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -8,9 +8,14 @@
  * Asserts trunking tune side-effects via test shim capture.
  */
 
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/protocol/p25/p25_vpdu.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -21,6 +26,8 @@
 #endif
 
 #include "p25_test_shim.h"
+
+struct RtlSdrContext;
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -212,6 +219,80 @@ main(void) {
         p25_test_invoke_mac_vpdu_channel_cache(mac, 24, &cfg, 0x100A, 0x100B, &freq_t, &freq_r);
         rc |= expect_eq_long("0xD6 CHAN-T cache", freq_t, 851125000);
         rc |= expect_eq_long("0xD6 CHAN-R cache", freq_r, 851137500);
+    }
+
+    // Case E: a grant decoded through MAC VPDU must honor failed-VC retune backoff.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        state.p25_cc_freq = cc;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+        state.p25_retune_block_freq = 851125000;
+        state.p25_retune_block_slot = -1;
+        state.p25_retune_block_until = time(NULL) + 60;
+
+        MAC[1] = 0x40; // Group Voice Channel Grant
+        MAC[2] = 0x00; // svc
+        MAC[3] = 0x10;
+        MAC[4] = 0x0A; // channel 0x100A -> blocked 851.125 MHz
+        MAC[5] = 0x12;
+        MAC[6] = 0x34; // group
+        MAC[7] = 0x00;
+        MAC[8] = 0x00;
+        MAC[9] = 0x02; // source
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_true("0x40 blocked by backoff", opts.p25_is_tuned == 0);
+        rc |= expect_eq_long("0x40 blocked vc", state.p25_vc_freq[0], 0);
+    }
+
+    // Case F: compact grant-update paths must also honor failed-VC retune backoff.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        state.p25_cc_freq = cc;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+        state.p25_retune_block_freq = 851125000;
+        state.p25_retune_block_slot = -1;
+        state.p25_retune_block_until = time(NULL) + 60;
+
+        MAC[1] = 0x42; // Group Voice Channel Grant Update - Implicit
+        MAC[2] = 0x10;
+        MAC[3] = 0x0A; // channel1 0x100A -> blocked 851.125 MHz
+        MAC[4] = 0x12;
+        MAC[5] = 0x34; // group1
+        MAC[6] = 0x10;
+        MAC[7] = 0x0A; // channel2 same as channel1, so only one candidate is tried
+        MAC[8] = 0x12;
+        MAC[9] = 0x35; // group2
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_true("0x42 blocked by backoff", opts.p25_is_tuned == 0);
+        rc |= expect_eq_long("0x42 blocked vc", state.p25_vc_freq[0], 0);
     }
 
     return rc;

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -9,11 +9,16 @@
  *   is applied for the same RF frequency and slot.
  * - A subsequent grant to the opposite slot at the same RF is allowed
  *   immediately (no backoff).
+ * - Multiple failed VC/slot pairs remain blocked concurrently instead of the
+ *   newest failure replacing the previous one.
  */
 
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -49,6 +54,11 @@ SetModulation(int sockfd, int bandwidth) {
 
 struct RtlSdrContext* g_rtl_ctx = 0; // NOLINT(misc-use-internal-linkage)
 
+static long g_last_tuned_vc = 0;
+static int g_tune_to_freq_calls = 0;
+static int g_return_to_cc_calls = 0;
+static dsd_trunk_tune_result g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+
 int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 rtl_stream_tune(struct RtlSdrContext* ctx, uint32_t center_freq_hz) {
@@ -70,6 +80,40 @@ return_to_cc(dsd_opts* opts, dsd_state* state) {
     }
 }
 
+static dsd_trunk_tune_result
+tune_to_freq_result(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    (void)ted_sps;
+    g_tune_to_freq_calls++;
+    g_last_tuned_vc = freq;
+    if (opts) {
+        opts->p25_is_tuned = 1;
+        opts->trunk_is_tuned = 1;
+    }
+    if (state) {
+        state->p25_vc_freq[0] = state->p25_vc_freq[1] = freq;
+        state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = freq;
+    }
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static dsd_trunk_tune_result
+return_to_cc_result(dsd_opts* opts, dsd_state* state) {
+    g_return_to_cc_calls++;
+    if (!dsd_trunk_tune_result_is_ok(g_return_to_cc_result)) {
+        return g_return_to_cc_result;
+    }
+    return_to_cc(opts, state);
+    return g_return_to_cc_result;
+}
+
+static void
+install_tuning_hooks(void) {
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_freq_result = tune_to_freq_result;
+    hooks.return_to_cc_result = return_to_cc_result;
+    dsd_trunk_tuning_hooks_set(hooks);
+}
+
 static int
 expect_true(const char* tag, int cond) {
     if (!cond) {
@@ -86,6 +130,7 @@ main(void) {
     static dsd_state st;
     DSD_MEMSET(&opts, 0, sizeof opts);
     DSD_MEMSET(&st, 0, sizeof st);
+    install_tuning_hooks();
 
     // Enable trunking and seed a CC
     opts.p25_trunk = 1;
@@ -110,31 +155,136 @@ main(void) {
     int ch_slot0 = (id << 12) | 0x0002; // slot 0
     int ch_slot1 = (id << 12) | 0x0003; // slot 1 (same RF)
 
+    p25_sm_ctx_t ctx;
+    p25_sm_init_ctx(&ctx, &opts, &st);
+
     // 1) Grant on slot 1 -> tune
-    opts.p25_is_tuned = 0;
-    unsigned prev_tunes = st.p25_sm_tune_count;
-    p25_sm_on_group_grant(&opts, &st, ch_slot1, 0 /*svc*/, 1001, 2002);
-    rc |= expect_true("initial tune", st.p25_sm_tune_count == prev_tunes + 1 && opts.p25_is_tuned == 1);
+    p25_sm_event_t ev_slot1 = p25_sm_ev_group_grant(ch_slot1, 0, 1001, 2002, 0);
+    p25_sm_event(&ctx, &opts, &st, &ev_slot1);
+    rc |= expect_true("initial tune", st.p25_sm_tune_count == 1 && opts.p25_is_tuned == 1 && g_tune_to_freq_calls == 1);
 
-    // 2) Force a no-voice return so retune backoff is armed for this slot/freq
-    // Ensure no MAC since tune and dt_since_tune >= grant_voice_to
-    st.p25_p2_last_mac_active[0] = 0;
-    st.p25_p2_last_mac_active[1] = 0;
-    st.p25_p2_audio_allowed[0] = 0;
-    st.p25_p2_audio_allowed[1] = 0;
-    st.p25_p2_audio_ring_count[0] = 0;
-    st.p25_p2_audio_ring_count[1] = 0;
-    st.p25_last_vc_tune_time = time(NULL) - 1; // > 0.5s
-    st.p25_p2_active_slot = 1;                 // last active slot = 1
-    st.p25_sm_force_release = 1;               // force immediate return to CC
-    p25_sm_on_release(&opts, &st);
-    rc |= expect_true("returned", opts.p25_is_tuned == 0);
+    // 2) Let the grant timeout without any voice/VC sync; this arms backoff for slot 1.
+    ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    ctx.t_voice_m = 0.0;
+    p25_sm_tick_ctx(&ctx, &opts, &st);
+    rc |= expect_true("returned", opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1 && ctx.state == P25_SM_ON_CC);
+    rc |= expect_true("backoff armed", st.p25_retune_block_freq == g_last_tuned_vc && st.p25_retune_block_slot == 1
+                                           && st.p25_retune_block_until > time(NULL));
 
-    // 3) Opposite-slot grant on same RF should be allowed immediately
-    prev_tunes = st.p25_sm_tune_count;
-    opts.p25_is_tuned = 0;
-    p25_sm_on_group_grant(&opts, &st, ch_slot0, 0 /*svc*/, 1001, 2002);
-    rc |= expect_true("other-slot allowed", st.p25_sm_tune_count == prev_tunes + 1 && opts.p25_is_tuned == 1);
+    // 3) Same-slot repeat grant on the same RF should be blocked during backoff.
+    p25_sm_event(&ctx, &opts, &st, &ev_slot1);
+    rc |= expect_true("same-slot blocked", g_tune_to_freq_calls == 1 && opts.p25_is_tuned == 0);
+
+    // 4) Opposite-slot grant on the same RF should be allowed immediately.
+    p25_sm_event_t ev_slot0 = p25_sm_ev_group_grant(ch_slot0, 0, 1001, 2002, 0);
+    p25_sm_event(&ctx, &opts, &st, &ev_slot0);
+    rc |= expect_true("other-slot allowed", g_tune_to_freq_calls == 2 && opts.p25_is_tuned == 1);
+
+    // 5) When the second slot also fails before voice, both recent failures
+    // should remain blocked. This catches single-entry backoff regressions.
+    ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    ctx.t_voice_m = 0.0;
+    p25_sm_tick_ctx(&ctx, &opts, &st);
+    rc |= expect_true("second returned",
+                      opts.p25_is_tuned == 0 && g_return_to_cc_calls == 2 && ctx.state == P25_SM_ON_CC);
+    rc |=
+        expect_true("second backoff armed", st.p25_retune_block_freq == g_last_tuned_vc && st.p25_retune_block_slot == 0
+                                                && st.p25_retune_block_until > time(NULL));
+
+    p25_sm_event(&ctx, &opts, &st, &ev_slot1);
+    rc |= expect_true("first failed slot still blocked", g_tune_to_freq_calls == 2 && opts.p25_is_tuned == 0);
+    p25_sm_event(&ctx, &opts, &st, &ev_slot0);
+    rc |= expect_true("second failed slot blocked", g_tune_to_freq_calls == 2 && opts.p25_is_tuned == 0);
+
+    // 6) A decoder/frame-sync forced release before grant timeout still records
+    // the failed VC because no voice was observed.
+    static dsd_opts forced_opts;
+    static dsd_state forced_st;
+    DSD_MEMSET(&forced_opts, 0, sizeof forced_opts);
+    DSD_MEMSET(&forced_st, 0, sizeof forced_st);
+    forced_opts.p25_trunk = 1;
+    forced_opts.trunk_tune_group_calls = 1;
+    forced_opts.trunk_hangtime = 0.2f;
+    forced_opts.p25_grant_voice_to_s = 10.0;
+    forced_opts.p25_retune_backoff_s = 2.0;
+    forced_st.p25_cc_freq = 851000000;
+    forced_st.p25_chan_iden = id;
+    forced_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+    forced_st.p25_chan_tdma_explicit[id] = 2;
+
+    p25_sm_ctx_t forced_ctx;
+    p25_sm_init_ctx(&forced_ctx, &forced_opts, &forced_st);
+    g_last_tuned_vc = 0;
+    g_tune_to_freq_calls = 0;
+    g_return_to_cc_calls = 0;
+    p25_sm_event(&forced_ctx, &forced_opts, &forced_st, &ev_slot1);
+    rc |= expect_true("forced initial tune",
+                      forced_st.p25_sm_tune_count == 1 && forced_opts.p25_is_tuned == 1 && g_tune_to_freq_calls == 1);
+
+    forced_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    forced_ctx.t_voice_m = 0.0;
+    forced_st.p25_sm_force_release = 1;
+    p25_sm_release(&forced_ctx, &forced_opts, &forced_st, "explicit-release");
+    rc |= expect_true("forced returned",
+                      forced_opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1 && forced_ctx.state == P25_SM_ON_CC);
+    rc |= expect_true("forced backoff armed", forced_st.p25_retune_block_freq == g_last_tuned_vc
+                                                  && forced_st.p25_retune_block_slot == 1
+                                                  && forced_st.p25_retune_block_until > time(NULL));
+
+    // 7) A transient return-to-CC failure during grant timeout must not record
+    // a failed VC until the retry is accepted.
+    static const dsd_trunk_tune_result transient_returns[] = {
+        DSD_TRUNK_TUNE_RESULT_DEFERRED,
+        DSD_TRUNK_TUNE_RESULT_FAILED,
+    };
+
+    for (size_t i = 0; i < sizeof(transient_returns) / sizeof(transient_returns[0]); i++) {
+        static dsd_opts transient_opts;
+        static dsd_state transient_st;
+        DSD_MEMSET(&transient_opts, 0, sizeof transient_opts);
+        DSD_MEMSET(&transient_st, 0, sizeof transient_st);
+        transient_opts.p25_trunk = 1;
+        transient_opts.trunk_tune_group_calls = 1;
+        transient_opts.trunk_hangtime = 0.2f;
+        transient_opts.p25_grant_voice_to_s = 0.5;
+        transient_opts.p25_retune_backoff_s = 2.0;
+        transient_st.p25_cc_freq = 851000000;
+        transient_st.p25_chan_iden = id;
+        transient_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+        transient_st.p25_chan_tdma_explicit[id] = 2;
+
+        p25_sm_ctx_t transient_ctx;
+        p25_sm_init_ctx(&transient_ctx, &transient_opts, &transient_st);
+        g_last_tuned_vc = 0;
+        g_tune_to_freq_calls = 0;
+        g_return_to_cc_calls = 0;
+        g_return_to_cc_result = transient_returns[i];
+        p25_sm_event(&transient_ctx, &transient_opts, &transient_st, &ev_slot1);
+        rc |=
+            expect_true("transient initial tune", transient_st.p25_sm_tune_count == 1
+                                                      && transient_opts.p25_is_tuned == 1 && g_tune_to_freq_calls == 1);
+
+        transient_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+        transient_ctx.t_voice_m = 0.0;
+        p25_sm_tick_ctx(&transient_ctx, &transient_opts, &transient_st);
+        rc |= expect_true("transient return preserved vc", transient_opts.p25_is_tuned == 1 && g_return_to_cc_calls == 1
+                                                               && transient_ctx.state == P25_SM_TUNED);
+        rc |= expect_true("transient return did not arm backoff",
+                          transient_st.p25_retune_block_until == 0 && transient_st.p25_retune_block_freq == 0);
+
+        g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+        p25_sm_tick_ctx(&transient_ctx, &transient_opts, &transient_st);
+        rc |= expect_true("transient retry returned", transient_opts.p25_is_tuned == 0 && g_return_to_cc_calls == 2
+                                                          && transient_ctx.state == P25_SM_ON_CC);
+        rc |= expect_true("transient retry backoff armed", transient_st.p25_retune_block_freq == g_last_tuned_vc
+                                                               && transient_st.p25_retune_block_slot == 1
+                                                               && transient_st.p25_retune_block_until > time(NULL));
+        dsd_state_ext_free_all(&transient_st);
+    }
+    g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+
+    dsd_state_ext_free_all(&forced_st);
+    dsd_state_ext_free_all(&st);
 
     return rc;
 }

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -284,7 +284,84 @@ main(void) {
     p25_sm_tick_ctx(&ctx8, &o8, &s8);
     assert(g_last_tuned_cc == 851000000);
 
-    // 8) A failed VC tune must not advance P25 tuned state or counters.
+    // 8) In no-import operation, legacy LCN fallback must not cycle through
+    // voice/grant-derived frequencies as CC hunt targets.
+    static dsd_opts o8b;
+    static dsd_state s8b;
+    DSD_MEMSET(&o8b, 0, sizeof(o8b));
+    DSD_MEMSET(&s8b, 0, sizeof(s8b));
+    o8b.p25_trunk = 1;
+    o8b.trunk_hangtime = 0.2f;
+    s8b.p25_cc_freq = 851000000;
+    s8b.trunk_lcn_freq[0] = 851000000;
+    s8b.trunk_lcn_freq[1] = 889000000;
+    s8b.lcn_freq_count = 2;
+
+    p25_sm_ctx_t ctx8b;
+    p25_sm_init_ctx(&ctx8b, &o8b, &s8b);
+    ctx8b.state = P25_SM_HUNTING;
+    ctx8b.t_hunt_try_m = 0.0;
+    g_last_tuned_cc = 0;
+    p25_sm_tick_ctx(&ctx8b, &o8b, &s8b);
+    assert(g_last_tuned_cc == 851000000);
+
+    ctx8b.state = P25_SM_HUNTING;
+    ctx8b.t_hunt_try_m = dsd_time_now_monotonic_s() - 10.0;
+    g_last_tuned_cc = 0;
+    p25_sm_tick_ctx(&ctx8b, &o8b, &s8b);
+    assert(g_last_tuned_cc == 851000000);
+
+    // 9) Trunk-scan per-target channel maps are explicit user LCN lists even
+    // though the live opts->chan_in_file is empty.
+    static dsd_opts o8d;
+    static dsd_state s8d;
+    DSD_MEMSET(&o8d, 0, sizeof(o8d));
+    DSD_MEMSET(&s8d, 0, sizeof(s8d));
+    o8d.p25_trunk = 1;
+    o8d.trunk_scan_enabled = 1;
+    o8d.trunk_hangtime = 0.2f;
+    s8d.p25_cc_freq = 851000000;
+    s8d.trunk_lcn_freq[0] = 851000000;
+    s8d.trunk_lcn_freq[1] = 852000000;
+    s8d.lcn_freq_count = 2;
+    s8d.trunk_chan_map[101] = 852000000;
+    s8d.trunk_chan_map_used[0] = 101;
+    s8d.trunk_chan_map_used_count = 1U;
+
+    p25_sm_ctx_t ctx8d;
+    p25_sm_init_ctx(&ctx8d, &o8d, &s8d);
+    ctx8d.state = P25_SM_HUNTING;
+    ctx8d.t_hunt_try_m = 0.0;
+    g_last_tuned_cc = 0;
+    p25_sm_tick_ctx(&ctx8d, &o8d, &s8d);
+    assert(g_last_tuned_cc == 851000000);
+
+    ctx8d.state = P25_SM_HUNTING;
+    ctx8d.t_hunt_try_m = dsd_time_now_monotonic_s() - 10.0;
+    g_last_tuned_cc = 0;
+    p25_sm_tick_ctx(&ctx8d, &o8d, &s8d);
+    assert(g_last_tuned_cc == 852000000);
+
+    // 10) A current-site candidate is still eligible in no-import operation.
+    static dsd_opts o8c;
+    static dsd_state s8c;
+    DSD_MEMSET(&o8c, 0, sizeof(o8c));
+    DSD_MEMSET(&s8c, 0, sizeof(s8c));
+    o8c.p25_trunk = 1;
+    o8c.trunk_hangtime = 0.2f;
+    s8c.p25_cc_freq = 851000000;
+    s8c.last_cc_sync_time_m = dsd_time_now_monotonic_s() - 10.0;
+    dsd_state_set_trunk_chan_freq(&s8c, 101U, 889000000L);
+    assert(s8c.trunk_chan_map_used_count == 1U);
+    (void)dsd_trunk_cc_candidates_add(&s8c, 852000000, 0);
+
+    p25_sm_ctx_t ctx8c;
+    p25_sm_init_ctx(&ctx8c, &o8c, &s8c);
+    g_last_tuned_cc = 0;
+    p25_sm_tick_ctx(&ctx8c, &o8c, &s8c);
+    assert(g_last_tuned_cc == 852000000);
+
+    // 11) A failed VC tune must not advance P25 tuned state or counters.
     install_result_tuning_hooks();
     static dsd_opts o9;
     static dsd_state s9;
@@ -321,7 +398,7 @@ main(void) {
     assert(s9.p25_sm_tune_count == 0);
     assert(ctx9.state == P25_SM_ON_CC);
 
-    // 9) A failed CC retune must not update the tracked CC frequency or sync timestamp.
+    // 12) A failed CC retune must not update the tracked CC frequency or sync timestamp.
     static dsd_opts o10;
     static dsd_state s10;
     DSD_MEMSET(&o10, 0, sizeof(o10));
@@ -346,7 +423,7 @@ main(void) {
     assert(s10.p25_cc_eval_freq == 0);
     assert(ctx10.state == P25_SM_HUNTING);
 
-    // 10) Deferred VC tunes leave state unchanged and can be retried by a later grant.
+    // 13) Deferred VC tunes leave state unchanged and can be retried by a later grant.
     static dsd_opts o11;
     static dsd_state s11;
     DSD_MEMSET(&o11, 0, sizeof(o11));
@@ -377,7 +454,7 @@ main(void) {
     assert(s11.p25_sm_tune_count == 1);
     assert(ctx11.state == P25_SM_TUNED);
 
-    // 11) A forced release must survive deferred return-to-CC and retry even while voice remains active.
+    // 14) A forced release must survive deferred return-to-CC and retry even while voice remains active.
     static dsd_opts o12;
     static dsd_state s12;
     DSD_MEMSET(&o12, 0, sizeof(o12));
@@ -411,6 +488,7 @@ main(void) {
     assert(o12.p25_is_tuned == 0);
     assert(o12.trunk_is_tuned == 0);
     assert(ctx12.state == P25_SM_ON_CC);
+    assert(s12.p25_retune_block_until == 0);
 
     install_trunk_tuning_hooks();
 


### PR DESCRIPTION
## Summary

- Track failed P25 voice-channel retunes by RF frequency and TDMA slot so repeated no-voice failures cannot evict each other from the backoff window.
- Keep no-import P25 control-channel hunting on current-site candidates or the known primary control channel instead of falling through legacy LCN entries.
- Preserve/reset P25 retune backoff state through trunk-scan target switches and state initialization, with regressions for LCW, MAC VPDU, no-import CC hunt, and per-slot failed-retune history.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: protocol / radio input.
- [x] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions. No copied/generated bulk code added.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. No new suppressions added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [x] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes: not applicable, no CMake changes
- [ ] `tools/zizmor.sh` for workflow changes: not applicable, no workflow changes; also covered by `tools/quality_preflight.sh`
- [ ] `tools/osv_scan.sh` for dependency input changes: not applicable, no dependency input changes; also covered by `tools/quality_preflight.sh`
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes: no workflow/release changes; covered by preflight/quality gates

Additional validation:

- [x] `tools/format.sh`
- [x] `ctest --preset dev-debug -R 'CORE_INIT_STATE|ENGINE_TRUNK_SCAN|P25_(RETUNE_BACKOFF_SLOT|P1_LCW_GATING|P2_VPDU_GRANTS|SM_CORE|P2_VPDU_CORE|NEXT_CC_CANDIDATE_EDGES|NEIGHBOR_SPAM|SM_RETURN_TO_CC_MATRIX|SM_CAND_COOLDOWN|GRANT_TRUST_CLAMP|P1_TSBK_CLAMP|P1_MBTX_CLAMP)' --output-on-failure`
- [x] `git diff --check`
- [x] `cmake --preset asan-ubsan-debug`
- [x] `cmake --build --preset asan-ubsan-debug -j`
- [x] `ctest --preset asan-ubsan-debug --output-on-failure`
- [x] pre-push changed-path guardrails on the updated branch

## Risk

- Security/dependency impact: none expected; no dependency or secret-handling changes.
- CLI/UI behavior impact: none direct.
- Compatibility or packaging impact: none expected.