### PR TITLE
install: harden linux loader setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ cmake -S mbelib-neo -B mbelib-neo/build -DCMAKE_BUILD_TYPE=Release
 cmake --build mbelib-neo/build -j
 cmake --install mbelib-neo/build --prefix "$HOME/.local"
 
+# Linux: user-prefix installs need this when running installed binaries.
+export LD_LIBRARY_PATH="$HOME/.local/lib:$HOME/.local/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+# Linux: if you install mbelib-neo to /usr or /usr/local instead, run:
+# sudo ldconfig
+
 # Then configure dsd-neo (point CMake to the install prefix)
 cmake --preset dev-release -DCMAKE_PREFIX_PATH="$HOME/.local"
 ```
@@ -213,6 +218,7 @@ Notes
 - The CLI binary outputs to `build/<preset>/apps/dsd-cli/dsd-neo`.
 - `cmake --install <build_dir>` only works if you configured that build directory. If you're inside the build directory, use `cmake --install .`.
 - If `cmake --install build/dev-release` fails and `build/dev-release/` doesn't exist, you likely did a manual build (install from your actual build dir).
+- On Linux, installed binaries must be able to find `libmbe-neo.so.2`. For `/usr` or `/usr/local` installs, run `sudo ldconfig` after installing `mbelib-neo`; for `$HOME/.local`, export `LD_LIBRARY_PATH` as shown above.
 
 ## Install / Uninstall
 

--- a/docs/build-installation.md
+++ b/docs/build-installation.md
@@ -68,6 +68,16 @@ Install with CMake:
 cmake --install build/dev-release --prefix /usr/local
 ```
 
+On Linux, refresh the dynamic linker cache after installing source-built
+dependencies such as `mbelib-neo` into `/usr` or `/usr/local`:
+
+```sh
+sudo ldconfig
+```
+
+For user prefixes such as `$HOME/.local`, set `LD_LIBRARY_PATH` instead; see
+`docs/linux-installation.md`.
+
 On POSIX systems, staged packaging can use `DESTDIR`:
 
 ```sh

--- a/docs/linux-installation.md
+++ b/docs/linux-installation.md
@@ -36,6 +36,25 @@ build-local prefix under `--build-dir` so packaging checks do not install them
 into the live system. Pass `--deps-prefix` explicitly when validating a
 specific dependency prefix.
 
+## Runtime Loader Setup
+
+For `/usr` or `/usr/local` dependency installs, the script refreshes the Linux
+dynamic linker cache with `ldconfig`. If you install `mbelib-neo` manually into
+one of those prefixes and `dsd-neo` reports that `libmbe-neo.so.2` cannot be
+opened, run:
+
+```sh
+sudo ldconfig
+```
+
+For non-system prefixes such as `$HOME/.local`, use environment variables
+instead of `ldconfig`:
+
+```sh
+export PATH="$HOME/.local/bin:$PATH"
+export LD_LIBRARY_PATH="$HOME/.local/lib:$HOME/.local/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+```
+
 Useful options:
 
 - `--radio auto|required|off` controls RTL-SDR and SoapySDR package setup.
@@ -45,13 +64,6 @@ Useful options:
   pinned source fallback there.
 - `--build-dir DIR` chooses the CMake build directory.
 - `--dry-run` prints package, dependency, build, and install commands.
-
-If installing into a non-system prefix, the current shell may need:
-
-```sh
-export PATH="$HOME/.local/bin:$PATH"
-export LD_LIBRARY_PATH="$HOME/.local/lib:$HOME/.local/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-```
 
 ## Distro Coverage
 

--- a/tools/install_linux.sh
+++ b/tools/install_linux.sh
@@ -38,6 +38,12 @@ RADIO_MODE=auto
 CODEC2_MODE=auto
 ASSUME_YES=0
 DRY_RUN=0
+ORIGINAL_LD_LIBRARY_PATH=
+ORIGINAL_LD_LIBRARY_PATH_SET=0
+if [ "${LD_LIBRARY_PATH+x}" = x ]; then
+  ORIGINAL_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+  ORIGINAL_LD_LIBRARY_PATH_SET=1
+fi
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -420,6 +426,66 @@ refresh_system_linker_cache() {
   fi
 }
 
+installed_binary_path() {
+  if [ -n "$DESTDIR_VALUE" ]; then
+    printf '%s%s/bin/dsd-neo\n' "$DESTDIR_VALUE" "$PREFIX"
+  else
+    printf '%s/bin/dsd-neo\n' "$PREFIX"
+  fi
+}
+
+run_installed_dsd_neo_help() {
+  installed_binary=$1
+  if system_library_prefix "$DEPS_PREFIX"; then
+    if [ "$ORIGINAL_LD_LIBRARY_PATH_SET" -eq 1 ]; then
+      env "LD_LIBRARY_PATH=$ORIGINAL_LD_LIBRARY_PATH" "$installed_binary" -h > /dev/null
+    else
+      env LD_LIBRARY_PATH= "$installed_binary" -h > /dev/null
+    fi
+  else
+    "$installed_binary" -h > /dev/null
+  fi
+}
+
+print_loader_fix_hint() {
+  smoke_output=$1
+  case "$smoke_output" in
+    *libmbe-neo.so.2*)
+      if system_library_prefix "$DEPS_PREFIX"; then
+        echo "Installed dsd-neo could not load libmbe-neo.so.2; run sudo ldconfig and try again." >&2
+      else
+        cat >&2 << EOF
+Installed dsd-neo could not load libmbe-neo.so.2; update this shell before running it:
+  export LD_LIBRARY_PATH="$DEPS_PREFIX/lib:$DEPS_PREFIX/lib64\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}"
+EOF
+      fi
+      ;;
+  esac
+}
+
+validate_installed_dsd_neo() {
+  installed_binary=$(installed_binary_path)
+  if [ "$DRY_RUN" -eq 1 ]; then
+    if system_library_prefix "$DEPS_PREFIX"; then
+      if [ "$ORIGINAL_LD_LIBRARY_PATH_SET" -eq 1 ]; then
+        run env "LD_LIBRARY_PATH=$ORIGINAL_LD_LIBRARY_PATH" "$installed_binary" -h
+      else
+        run env LD_LIBRARY_PATH= "$installed_binary" -h
+      fi
+    else
+      run "$installed_binary" -h
+    fi
+    return 0
+  fi
+
+  if ! smoke_output=$(run_installed_dsd_neo_help "$installed_binary" 2>&1); then
+    printf '%s\n' "$smoke_output" >&2
+    echo "Installed dsd-neo smoke test failed: $installed_binary -h" >&2
+    print_loader_fix_hint "$smoke_output"
+    exit 1
+  fi
+}
+
 build_mbelib_neo() {
   # shellcheck source=tools/ci-dependency-pins.env
   # shellcheck disable=SC1091
@@ -505,6 +571,8 @@ configure_build_install_dsd_neo() {
   else
     run_for_prefix "$PREFIX" cmake --install "$BUILD_DIR" --prefix "$PREFIX"
   fi
+  refresh_system_linker_cache
+  validate_installed_dsd_neo
 }
 
 prompt_for_packages


### PR DESCRIPTION
## Summary

- document Linux runtime loader setup for `mbelib-neo` installs in the README and install docs
- validate the installed `dsd-neo -h` path after `tools/install_linux.sh` completes installation
- refresh `ldconfig` before the installed-binary smoke test and print targeted guidance when `libmbe-neo.so.2` cannot be loaded

## Root Cause

Linux source installs can place `libmbe-neo.so.2` under `/usr/local/lib` before the dynamic linker cache knows about it. Manual installs need `sudo ldconfig` for system prefixes, while user-prefix installs need `LD_LIBRARY_PATH`.

## Validation

- `tools/install_linux.sh --dry-run --prefix /usr/local --deps-prefix /usr/local --radio off --codec2 off --yes`
- `tools/install_linux.sh --dry-run --prefix "$HOME/.local" --radio off --codec2 off --yes`
- `tools/shell_lint.sh tools/install_linux.sh`
- `tools/shell_lint.sh`
- `git diff --check`
- `tools/docker_linux_install_matrix.sh --distro ubuntu-24.04`
- pre-push hook: install runtime destinations, secret redaction, workflow pin checks, vcpkg overlay pins, Semgrep strict, shell lint, and Lizard complexity