### PR TITLE
protocol: apply reviewed decoder fixes

### DIFF
--- a/src/core/vocoder/dsd_mbe.c
+++ b/src/core/vocoder/dsd_mbe.c
@@ -762,8 +762,11 @@ mbe_apply_nxdn_cipher1(dsd_state* state, char ambe_d[49]) {
     LFSRN(ambe_temp, ambe_d, state);
 }
 
-static void
-mbe_init_nxdn_cipher23_keystream(dsd_state* state) {
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void dsd_mbe_init_nxdn_cipher23_keystream(dsd_state* state);
+
+void
+dsd_mbe_init_nxdn_cipher23_keystream(dsd_state* state) {
     if (state->nxdn_cipher_type == 0x02 && state->nxdn_new_iv == 1 && state->nxdn_part_of_frame == 0) {
         DSD_MEMSET(state->ks_octetL, 0, sizeof(state->ks_octetL));
         DSD_MEMSET(state->ks_bitstreamL, 0, sizeof(state->ks_bitstreamL));
@@ -778,14 +781,14 @@ mbe_init_nxdn_cipher23_keystream(dsd_state* state) {
         DSD_MEMSET(state->ks_bitstreamL, 0, sizeof(state->ks_bitstreamL));
         aes_ofb_keystream_output(state->aes_iv, state->aes_key, state->ks_octetL, 2, 15);
         state->bit_counterL = 0;
-        unpack_byte_array_into_bit_array(state->ks_octetL + 8, state->ks_bitstreamL, 15 * 8);
+        unpack_byte_array_into_bit_array(state->ks_octetL + 16, state->ks_bitstreamL, 14 * 16);
         state->nxdn_new_iv = 0;
     }
 }
 
 static void
 mbe_apply_nxdn_cipher23(dsd_state* state, char ambe_d[49]) {
-    mbe_init_nxdn_cipher23_keystream(state);
+    dsd_mbe_init_nxdn_cipher23_keystream(state);
 
     //sanity check, don't exceed bit application counter
     if (state->bit_counterL > (1568 - 49)) {

--- a/src/protocol/dmr/dmr_block.c
+++ b/src/protocol/dmr/dmr_block.c
@@ -337,12 +337,13 @@ dmr_dheader_handle_response(uint8_t slot, const dmr_dheader_fields* f) {
 
 static void
 dmr_dheader_handle_unconfirmed_or_confirmed(dsd_state* state, uint8_t slot, const dmr_dheader_fields* f) {
+    const char* final_text = f->f ? " (FINAL)" : "";
     if (f->dpf == 2) {
-        DSD_FPRINTF(stderr, "\n  SAP %02d [%s] - FMF %d - BLOCKS %02d - PAD %02d - FSN %d", f->sap, f->sap_string, f->f,
-                    f->bf, f->poc, f->fsn);
+        DSD_FPRINTF(stderr, "\n  SAP %02d [%s] - FINAL %d%s - BLOCKS %02d - PAD %02d - FSN %d", f->sap, f->sap_string,
+                    f->f, final_text, f->bf, f->poc, f->fsn);
     } else {
-        DSD_FPRINTF(stderr, "\n  SAP %02d [%s] - FMF %d - BLOCKS %02d - PAD %02d - S %d - NS %d - FSN %d", f->sap,
-                    f->sap_string, f->f, f->bf, f->poc, f->s, f->ns, f->fsn);
+        DSD_FPRINTF(stderr, "\n  SAP %02d [%s] - FINAL %d%s - BLOCKS %02d - PAD %02d - S %d - NS %d - FSN %d", f->sap,
+                    f->sap_string, f->f, final_text, f->bf, f->poc, f->s, f->ns, f->fsn);
     }
     state->data_header_blocks[slot] = f->bf;
     if (f->dpf == 3) {

--- a/src/protocol/p25/p25_lcw.c
+++ b/src/protocol/p25/p25_lcw.c
@@ -730,6 +730,19 @@ p25_lcw_dispatch_mfid_d8(p25_lcw_ctx* ctx) {
         tait_iso7_embedded_alias_decode(ctx->opts, ctx->state, 0, 8, ctx->bits);
         return 1;
     }
+    if (ctx->lc_format == 0x01) {
+        uint32_t wacn = (uint32_t)ConvertBitIntoBytes(&ctx->bits[16], 20);
+        uint16_t sysid = (uint16_t)ConvertBitIntoBytes(&ctx->bits[36], 12);
+        uint32_t src = (uint32_t)ConvertBitIntoBytes(&ctx->bits[48], 24);
+        DSD_FPRINTF(stderr, " MFIDD8 (Tait) Subscriber FQ-SUID: %05X.%03X.%d", wacn, sysid, src);
+        if (wacn != 0) {
+            ctx->state->p25_src_nid = wacn;
+        }
+        if (src != 0) {
+            ctx->state->lastsrc = (int)src;
+        }
+        return 1;
+    }
     return 0;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -843,6 +843,23 @@ target_link_libraries(
 add_test(NAME NXDN_ELEMENT_BOUNDS COMMAND dsd-neo_test_nxdn_element_bounds)
 
 add_executable(
+    dsd-neo_test_nxdn_voice_aes_keystream
+    protocol/nxdn/test_nxdn_voice_aes_keystream.c
+)
+target_include_directories(
+    dsd-neo_test_nxdn_voice_aes_keystream
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_nxdn_voice_aes_keystream
+    PRIVATE dsd-neo_core dsd-neo_crypto
+)
+add_test(
+    NAME NXDN_VOICE_AES_KEYSTREAM
+    COMMAND dsd-neo_test_nxdn_voice_aes_keystream
+)
+
+add_executable(
     dsd-neo_test_nxdn_sync_dispatch
     protocol/nxdn/test_nxdn_sync_dispatch.c
     ${PROJECT_SOURCE_DIR}/src/engine/dispatch/dispatch_nxdn.c
@@ -4220,6 +4237,10 @@ target_include_directories(
 target_compile_definitions(
     dsd-neo_test_dmr_relaxed_header_ip
     PRIVATE MBELIB_NO_HEADERS=1
+)
+target_link_libraries(
+    dsd-neo_test_dmr_relaxed_header_ip
+    PRIVATE dsd-neo_test_support
 )
 add_test(NAME DMR_RELAXED_HEADER_IP COMMAND dsd-neo_test_dmr_relaxed_header_ip)
 

--- a/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
+++ b/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
@@ -12,11 +12,13 @@
 #include <dsd-neo/fec/rs_12_9.h>
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
 #include <dsd-neo/runtime/unicode.h>
-#include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "test_support.h"
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -33,6 +35,34 @@ extern void dmr_reset_blocks(dsd_opts* opts, dsd_state* state);
 static unsigned int g_decode_ip_calls;
 static uint16_t g_decode_ip_last_len;
 static uint8_t g_decode_ip_first_byte;
+
+static int
+read_file_to_buffer(const char* path, char* out, size_t out_size) {
+    if (path == NULL || out == NULL || out_size == 0U) {
+        return -1;
+    }
+    FILE* f = fopen(path, "rb");
+    if (f == NULL) {
+        return -1;
+    }
+    size_t n = fread(out, 1U, out_size - 1U, f);
+    int bad = ferror(f);
+    int close_rc = fclose(f);
+    if (bad || close_rc != 0) {
+        return -1;
+    }
+    out[n] = '\0';
+    return 0;
+}
+
+static int
+expect_contains(const char* tag, const char* got, const char* want) {
+    if (strstr(got, want) == NULL) {
+        DSD_FPRINTF(stderr, "%s: expected output to contain '%s', got '%s'\n", tag, want, got);
+        return 1;
+    }
+    return 0;
+}
 
 // Provide local stubs to avoid pulling full core/audio deps during link
 void
@@ -334,12 +364,66 @@ test_crc_valid_type1_pdu_dispatches_in_strict_mode(void) {
     assert(g_decode_ip_first_byte == 0x45U);
 }
 
+static int
+test_data_header_prints_fsn_and_final_flag(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t dheader[12];
+    uint8_t bits[196];
+    char output[2048];
+    dsd_test_capture_stderr cap;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(dheader, 0, sizeof(dheader));
+    state.currentslot = 0;
+    opts.aggressive_framesync = 1;
+
+    if (dsd_test_capture_stderr_begin(&cap, "dmr_header_fsn_final") != 0) {
+        return 1;
+    }
+
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    set_bits(bits, 4, 2U, 4); // DPF=2, unconfirmed delivery
+    set_bits(bits, 8, 4U, 4); // SAP=4, IP based
+    set_bits(bits, 16, 0x000123U, 24);
+    set_bits(bits, 40, 0x000456U, 24);
+    set_bits(bits, 64, 1U, 1); // final-fragment flag
+    set_bits(bits, 65, 3U, 7); // blocks to follow
+    set_bits(bits, 76, 9U, 4); // fragment sequence number
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
+
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    set_bits(bits, 4, 3U, 4); // DPF=3, confirmed delivery
+    set_bits(bits, 8, 4U, 4); // SAP=4, IP based
+    set_bits(bits, 16, 0x000123U, 24);
+    set_bits(bits, 40, 0x000456U, 24);
+    set_bits(bits, 64, 1U, 1);  // final-fragment flag
+    set_bits(bits, 65, 4U, 7);  // blocks to follow
+    set_bits(bits, 72, 1U, 1);  // send-sequence flag
+    set_bits(bits, 73, 5U, 3);  // send-sequence number
+    set_bits(bits, 76, 10U, 4); // fragment sequence number
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
+
+    if (dsd_test_capture_stderr_end(&cap) != 0 || read_file_to_buffer(cap.path, output, sizeof(output)) != 0) {
+        (void)remove(cap.path);
+        return 1;
+    }
+    (void)remove(cap.path);
+
+    rc |= expect_contains("unconfirmed-fsn-final", output, "FINAL 1 (FINAL) - BLOCKS 03 - PAD 00 - FSN 9");
+    rc |= expect_contains("confirmed-fsn-final", output, "FINAL 1 (FINAL) - BLOCKS 04 - PAD 00 - S 1 - NS 5 - FSN 10");
+    return rc;
+}
+
 int
 main(int argc, char** argv) {
     (void)argc;
     (void)argv;
     test_reset_blocks_restores_integer_defaults();
     test_crc_valid_type1_pdu_dispatches_in_strict_mode();
+    int rc = test_data_header_prints_fsn_and_final_flag();
 
     static dsd_opts opts;
     static dsd_state state;
@@ -445,7 +529,7 @@ main(int argc, char** argv) {
     assert(state.dmr_soR == 0x100);
     assert(state.data_ks_start[1] == 0);
 
-    return 0;
+    return rc;
 }
 
 #if defined(__GNUC__) && !defined(__cplusplus)

--- a/tests/protocol/nxdn/test_nxdn_voice_aes_keystream.c
+++ b/tests/protocol/nxdn/test_nxdn_voice_aes_keystream.c
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Regression coverage for NXDN cipher 3 voice AES-OFB keystream alignment.
+ */
+
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/crypto/aes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "dsd-neo/core/state_fwd.h"
+
+void dsd_mbe_init_nxdn_cipher23_keystream(dsd_state* state);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void LFSRN(const char* buffer_in, char* buffer_out, dsd_state* state);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+uint16_t ComputeCrcCCITT16d(const uint8_t* buf, uint32_t len);
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+LFSRN(const char* buffer_in, char* buffer_out, dsd_state* state) {
+    (void)buffer_in;
+    (void)buffer_out;
+    (void)state;
+}
+
+uint16_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ComputeCrcCCITT16d(const uint8_t* buf, uint32_t len) {
+    (void)buf;
+    (void)len;
+    return 0U;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static uint8_t
+bit_from_byte(const uint8_t* bytes, size_t bit) {
+    return (uint8_t)((bytes[bit / 8U] >> (7U - (bit % 8U))) & 1U);
+}
+
+static int
+expect_bits_match(const char* tag, const uint8_t* got, const uint8_t* bytes, size_t bits) {
+    for (size_t i = 0U; i < bits; i++) {
+        uint8_t want = bit_from_byte(bytes, i);
+        if (got[i] != want) {
+            DSD_FPRINTF(stderr, "%s: bit %zu got %u want %u\n", tag, i, (unsigned)got[i], (unsigned)want);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+expect_bits_differ(const char* tag, const uint8_t* got, const uint8_t* bytes, size_t bits) {
+    for (size_t i = 0U; i < bits; i++) {
+        if (got[i] != bit_from_byte(bytes, i)) {
+            return 0;
+        }
+    }
+    DSD_FPRINTF(stderr, "%s: bits unexpectedly matched\n", tag);
+    return 1;
+}
+
+int
+main(void) {
+    static dsd_state state;
+    uint8_t expected[15U * 16U];
+    int rc = 0;
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    for (size_t i = 0U; i < sizeof(state.aes_iv); i++) {
+        state.aes_iv[i] = (uint8_t)(0x10U + i);
+    }
+    for (size_t i = 0U; i < sizeof(state.aes_key); i++) {
+        state.aes_key[i] = (uint8_t)(0xA0U + (i * 3U));
+    }
+
+    state.nxdn_cipher_type = 0x03U;
+    state.nxdn_new_iv = 1U;
+    state.nxdn_part_of_frame = 0U;
+
+    DSD_MEMSET(expected, 0, sizeof(expected));
+    aes_ofb_keystream_output(state.aes_iv, state.aes_key, expected, 2, 15);
+
+    dsd_mbe_init_nxdn_cipher23_keystream(&state);
+
+    rc |= expect_int("aes-new-iv-cleared", (int)state.nxdn_new_iv, 0);
+    rc |= expect_int("aes-bit-counter-reset", (int)state.bit_counterL, 0);
+    rc |= expect_bits_match("aes-discard-16-byte-block", state.ks_bitstreamL, expected + 16U, 128U);
+    rc |= expect_bits_differ("aes-not-old-8-byte-offset", state.ks_bitstreamL, expected + 8U, 64U);
+
+    if (rc == 0) {
+        printf("NXDN_VOICE_AES_KEYSTREAM: OK\n");
+    }
+    return rc;
+}

--- a/tests/protocol/p25/test_p25_lcw_src_zero_guard.c
+++ b/tests/protocol/p25/test_p25_lcw_src_zero_guard.c
@@ -330,6 +330,29 @@ main(void) {
         rc |= expect_true("SrcIdExtension_radio_24bit_at_bit48", st.lastsrc == 0x456789);
     }
 
+    /*
+     * Tait MFID 0xD8 format 0x01 uses the same fully-qualified source layout:
+     * WACN[16..35], SYSTEM[36..47], RADIO[48..71].
+     */
+    {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&st, 0, sizeof st);
+        st.lastsrc = 222;
+
+        uint8_t lcw[96];
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x01);
+        set_bits_msb(lcw, 8, 8, 0xD8);
+        set_bits_msb(lcw, 16, 20, 0x54321);
+        set_bits_msb(lcw, 36, 12, 0x987);
+        set_bits_msb(lcw, 48, 24, 0x2468AC);
+
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+
+        rc |= expect_true("TaitD8Fmt01_WACN_20bit", st.p25_src_nid == 0x54321);
+        rc |= expect_true("TaitD8Fmt01_radio_24bit_at_bit48", st.lastsrc == 0x2468AC);
+    }
+
     return rc;
 }
 


### PR DESCRIPTION
## Summary

- Decode Tait P25 MFID 0xD8 format 0x01 fully-qualified source identifiers and preserve parsed source state.
- Align NXDN AES voice OFB keystream handling to discard the first 16-byte block before applying voice bits.
- Clarify DMR data-header output by labeling the final-fragment flag while preserving FSN reporting.
- Add focused regression coverage for the P25, NXDN, and DMR paths.

## Validation

- `tools/format.sh`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug -R "(P25_LCW_SRC_ZERO_GUARD|NXDN_VOICE_AES_KEYSTREAM|DMR_RELAXED_HEADER_IP|NXDN_ELEMENT_BOUNDS)" --output-on-failure`
- `tools/cmake_format_check.sh --fix && tools/cmake_format_check.sh`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh`
- `cmake --preset asan-ubsan-debug && cmake --build --preset asan-ubsan-debug -j`
- `ctest --preset asan-ubsan-debug --output-on-failure`
- `git diff --check`

## Notes

- The pre-push hook also reran the configured local guardrails and skipped only the optional scan-build rebuild because `DSD_HOOK_RUN_SCAN_BUILD=1` was not set.