### PR TITLE
Fix DMR data event history classification

### DIFF
--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -32,7 +32,8 @@
 #include "dsd-neo/runtime/call_alert.h"
 
 enum {
-    DSD_EVENT_SUBTYPE_DATA = 6,
+    DSD_EVENT_SUBTYPE_DMR_DATA_BURST = 6,
+    DSD_EVENT_SUBTYPE_EXPLICIT_DATA = INT8_MAX,
 };
 
 // Safe bounded copy helper that tolerates potential overlap
@@ -196,6 +197,24 @@ watchdog_event_item_has_content(const Event_History* item) {
 }
 
 static int
+watchdog_event_is_dmr_data_sync(int systype) {
+    return systype == DSD_SYNC_DMR_BS_DATA_POS || systype == DSD_SYNC_DMR_BS_DATA_NEG || systype == DSD_SYNC_DMR_MS_DATA
+           || systype == DSD_SYNC_DMR_RC_DATA;
+}
+
+static int
+watchdog_event_is_explicit_data_event(const Event_History* item) {
+    return item != NULL && item->subtype == DSD_EVENT_SUBTYPE_EXPLICIT_DATA;
+}
+
+static int
+watchdog_event_is_data_event(const Event_History* item) {
+    return watchdog_event_is_explicit_data_event(item)
+           || (item != NULL && watchdog_event_is_dmr_data_sync(item->systype)
+               && item->subtype == DSD_EVENT_SUBTYPE_DMR_DATA_BURST);
+}
+
+static int
 watchdog_event_is_m17_sync(int synctype) {
     return (synctype == DSD_SYNC_M17_STR_POS || synctype == DSD_SYNC_M17_STR_NEG || synctype == DSD_SYNC_M17_LSF_POS
             || synctype == DSD_SYNC_M17_LSF_NEG);
@@ -326,10 +345,12 @@ watchdog_event_handle_source_transition(dsd_opts* opts, dsd_state* state, Event_
 void
 watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot) {
     Event_History_I* event_struct = &state->event_history_s[slot];
+    const Event_History* last_event = &event_struct->Event_History_Items[0];
     uint8_t swrite = watchdog_event_should_write_slot(state);
-    uint32_t last_source_id = event_struct->Event_History_Items[0].source_id;
-    int last_event_is_data = event_struct->Event_History_Items[0].subtype == DSD_EVENT_SUBTYPE_DATA;
-    int last_event_has_content = watchdog_event_item_has_content(&event_struct->Event_History_Items[0]);
+    uint32_t last_source_id = last_event->source_id;
+    int last_event_forces_history = watchdog_event_is_explicit_data_event(last_event);
+    int last_event_is_data = watchdog_event_is_data_event(last_event);
+    int last_event_has_content = watchdog_event_item_has_content(last_event);
     uint32_t source_id = watchdog_event_source_id(opts, state, slot);
 
     //call alert beep when new call detected
@@ -338,7 +359,7 @@ watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot) {
         beeper(opts, state, slot, 40, 86, 3);
     }
 
-    if (last_event_is_data && last_event_has_content) {
+    if (last_event_forces_history && last_event_has_content) {
         watchdog_event_handle_source_transition(opts, state, event_struct, slot, swrite, last_event_is_data);
         return;
     }
@@ -995,7 +1016,7 @@ watchdog_event_datacall(dsd_opts* opts, dsd_state* state, uint32_t src, uint32_t
     state->event_history_s[slot].Event_History_Items[0].write = 0;
     state->event_history_s[slot].Event_History_Items[0].color_pair = 4; //default data color //you can change this one
     state->event_history_s[slot].Event_History_Items[0].systype = state->lastsynctype;
-    state->event_history_s[slot].Event_History_Items[0].subtype = DSD_EVENT_SUBTYPE_DATA;
+    state->event_history_s[slot].Event_History_Items[0].subtype = DSD_EVENT_SUBTYPE_EXPLICIT_DATA;
     state->event_history_s[slot].Event_History_Items[0].gi = state->gi[slot];
     state->event_history_s[slot].Event_History_Items[0].enc = 0;
     state->event_history_s[slot].Event_History_Items[0].enc_alg = 0;

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -29,6 +29,10 @@
 static int g_beeper_count;
 static int g_last_beeper_id;
 
+enum {
+    TEST_DMR_DATA_BURST = 6,
+};
+
 SNDFILE*
 open_wav_file(char* dir, char* temp_filename, size_t temp_filename_size, uint16_t sample_rate, uint8_t ext) {
     UNUSED(dir);
@@ -196,6 +200,77 @@ test_source_less_data_call_is_preserved_in_history(void) {
 }
 
 static int
+test_source_less_dmr_data_current_event_is_not_preserved_in_history(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    state.lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+    state.dmr_color_code = 1U;
+
+    state.dmrburstL = TEST_DMR_DATA_BURST;
+    watchdog_event_current(&opts, &state, 0);
+    watchdog_event_history(&opts, &state, 0);
+
+    state.dmrburstR = TEST_DMR_DATA_BURST;
+    watchdog_event_current(&opts, &state, 1);
+    watchdog_event_history(&opts, &state, 1);
+
+    int rc = 0;
+    rc |= expect_int("slot 1 source-less DMR current should remain current",
+                     state.event_history_s[0].Event_History_Items[0].event_string[0] != '\0', 1);
+    rc |= expect_int("slot 1 source-less DMR current should not be stored",
+                     state.event_history_s[0].Event_History_Items[1].event_string[0], '\0');
+    rc |= expect_int("slot 2 source-less DMR current should remain current",
+                     state.event_history_s[1].Event_History_Items[0].event_string[0] != '\0', 1);
+    rc |= expect_int("slot 2 source-less DMR current should not be stored",
+                     state.event_history_s[1].Event_History_Items[1].event_string[0], '\0');
+    return rc;
+}
+
+static int
+test_sourced_dmr_data_current_event_does_not_emit_voice_end_alert(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_END;
+
+    state.lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+    state.dmr_color_code = 1U;
+
+    state.lastsrc = 1234;
+    state.lasttg = 5678;
+    state.dmrburstL = TEST_DMR_DATA_BURST;
+    watchdog_event_current(&opts, &state, 0);
+    state.lastsrc = 0;
+    watchdog_event_history(&opts, &state, 0);
+
+    int rc = 0;
+    rc |= expect_int("slot 1 sourced DMR data end should not beep", g_beeper_count, 0);
+    rc |= expect_int("slot 1 sourced DMR data should be stored",
+                     state.event_history_s[0].Event_History_Items[1].event_string[0] != '\0', 1);
+
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_END;
+    state.lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+    state.dmr_color_code = 1U;
+
+    state.lastsrcR = 2345;
+    state.lasttgR = 6789;
+    state.dmrburstR = TEST_DMR_DATA_BURST;
+    watchdog_event_current(&opts, &state, 1);
+    state.lastsrcR = 0;
+    watchdog_event_history(&opts, &state, 1);
+
+    rc |= expect_int("slot 2 sourced DMR data end should not beep", g_beeper_count, 0);
+    rc |= expect_int("slot 2 sourced DMR data should be stored",
+                     state.event_history_s[1].Event_History_Items[1].event_string[0] != '\0', 1);
+    return rc;
+}
+
+static int
 test_voice_end_alert_still_emits_for_voice_history(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -335,6 +410,8 @@ main(void) {
     rc |= test_data_only_data_call_emits_one_data_alert();
     rc |= test_source_less_data_call_does_not_suppress_next_voice_start_alert();
     rc |= test_source_less_data_call_is_preserved_in_history();
+    rc |= test_source_less_dmr_data_current_event_is_not_preserved_in_history();
+    rc |= test_sourced_dmr_data_current_event_does_not_emit_voice_end_alert();
     rc |= test_voice_end_alert_still_emits_for_voice_history();
     rc |= test_edacs_service_string_appends_past_pointer_size();
     rc |= test_dmr_event_string_keeps_full_prefix_after_sprintf_hardening();


### PR DESCRIPTION
## Summary

- Separate explicit data-call history flushing from DMR data-burst classification.
- Preserve voice-end alert suppression for sourced DMR subtype-6 data events.
- Add regression coverage for source-less DMR data current rows and sourced DMR data end transitions on both slots.

## Root Cause

The history path used one subtype check for two different meanings: forcing explicit data calls into history immediately, and classifying data events so they do not emit voice-end alerts. Moving explicit data calls to a private sentinel fixed source-less DMR current rows being preserved as history, but it also meant sourced DMR subtype-6 data bursts were no longer treated as data for alert suppression.

This change splits those predicates so only explicit data calls force immediate history flushing, while DMR data sync events with subtype 6 still suppress voice-end tones.

## Validation

- `tools/format.sh`
- `cmake --build --preset dev-debug -j --target dsd-neo_test_core_call_alert_history`
- `ctest --preset dev-debug -R CORE_CALL_ALERT_HISTORY --output-on-failure`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh`
- `git diff --check`