### PR TITLE
engine: add per-target trunk scan tuning

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -277,6 +277,8 @@ Notes
     `docs/trunk-scan.md`.
   - Requires a live retuning path: RTL-family input opened by DSD-neo, or rigctl control such as `-U 4532`.
   - Use per-target `chan_csv` entries in the target CSV; global `-C` is rejected in this mode.
+  - Optional per-target `modulation` and `rtl_gain` columns can override demod hints and RTL-family tuner gain for the
+    active target.
   - Cannot be combined with legacy `-Y` or IQ replay.
   - Idle dwell: `--trunk-scan-dwell-ms <250..600000>` (default `3000`).
   - Conventional DMR activity hold: `--trunk-scan-activity-hold-ms <250..600000>` (default `1200`).

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -51,8 +51,9 @@ The header must start with this exact prefix:
 id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes
 ```
 
-- Extra columns are allowed after `notes`.
-- Every data row must contain all seven fields, even when optional values are empty.
+- Optional columns are allowed after `notes`; recognized optional columns are matched by header name.
+- Every data row must contain the first seven fields, even when optional values are empty. Missing trailing optional
+  fields are treated as empty.
 - Blank data rows are skipped.
 
 Columns:
@@ -66,6 +67,8 @@ Columns:
 | `dwell_ms` | No | Per-target idle dwell (`250..600000`). Empty uses `--trunk-scan-dwell-ms` or `[trunk_scan] idle_dwell_ms`. |
 | `activity_hold_ms` | No | Per-target conventional DMR activity hold (`250..600000`). Empty uses `--trunk-scan-activity-hold-ms` or `[trunk_scan] activity_hold_ms`. |
 | `notes` | No | Ignored. Use for local notes. |
+| `modulation` | No | Per-target demod hint. Empty preserves global/default handling. `auto` uses target defaults and overrides global `-m` locks for that target. P25 accepts `auto`, `c4fm`, `cqpsk`; DMR accepts `auto`, `gfsk`. |
+| `rtl_gain` | No | Per-target RTL-family tuner gain. Empty uses the global/default gain. `0` or `auto` requests device automatic gain. `1..49` requests manual dB gain. Ignored for non-RTL retuning paths. |
 
 Validation notes:
 
@@ -80,10 +83,10 @@ Validation notes:
 Example:
 
 ```csv
-id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes
-county-p25,p25-trunk,851012500,,3000,,primary P25 control channel
-city-dmr,dmr-trunk,452012500,dmr_channels.csv,3000,,DMR Tier III control channel
-plant,dmr-conventional,461112500,,1500,1200,one-frequency DMR
+id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gain
+county-p25,p25-trunk,851012500,,3000,,primary P25 control channel,cqpsk,18
+city-dmr,dmr-trunk,452012500,dmr_channels.csv,3000,,DMR Tier III control channel,auto,
+plant,dmr-conventional,461112500,,1500,1200,one-frequency DMR,gfsk,auto
 ```
 
 ## Group List CSV (`-G <file>` / `[trunking] group_csv`)

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -31,10 +31,10 @@ id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes
 Example:
 
 ```csv
-id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes
-county-p25,p25-trunk,851012500,,3000,,P25 control channel
-city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel
-plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR
+id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gain
+county-p25,p25-trunk,851012500,,3000,,P25 control channel,cqpsk,18
+city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel,auto,
+plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR,gfsk,auto
 ```
 
 The repository includes a starter file at `examples/trunk_scan_targets.csv`.
@@ -50,18 +50,24 @@ Column behavior:
 | `dwell_ms` | No | Idle dwell for this target. Empty uses the CLI/config default. Valid range: `250..600000`. |
 | `activity_hold_ms` | No | Conventional DMR activity hold for this target. Empty uses the CLI/config default. Valid range: `250..600000`. |
 | `notes` | No | Ignored by DSD-neo. Use it for local notes. |
+| `modulation` | No | Demod hint for this target. Empty preserves global/default handling. `auto` uses target defaults even when a global `-m` lock is set. P25 accepts `auto`, `c4fm`, `cqpsk`; DMR accepts `auto`, `gfsk`. |
+| `rtl_gain` | No | RTL-family tuner gain for this target. Empty uses the global/default gain. `0` or `auto` requests device automatic gain. `1..49` requests manual dB gain. |
 
 Target list limits and validation:
 
 - Maximum 32 targets.
 - Blank rows are skipped.
 - Every data row must contain the seven fields above.
-- The header may have extra columns after `notes`, but the first seven header names must match the required prefix.
+- The header may have optional columns after `notes`, but the first seven header names must match the required prefix.
+  Recognized optional columns are matched by header name; missing trailing optional data fields are treated as empty.
 - Frequency values must be at least `1`. Normal 64-bit builds accept values up to `4294967295`; 32-bit builds may reject
   values above `LONG_MAX`.
 - Duplicate `id` values are rejected.
 - Duplicate `(type, frequency_hz)` pairs are rejected.
 - `chan_csv` is only valid for `p25-trunk` and `dmr-trunk` targets.
+- `modulation` values are target-type specific: `cqpsk`/`c4fm` are P25-only, and `gfsk` is DMR-only.
+- `rtl_gain` only affects RTL-family inputs opened by DSD-neo. It is ignored when scan retuning is done through rigctl
+  against a non-RTL audio input.
 - The parser is intentionally small. It can handle a quoted `chan_csv` that contains a comma, but it is not a full CSV
   parser and does not support escaped quotes.
 
@@ -159,6 +165,9 @@ At startup DSD-neo:
 During scanning:
 
 - Idle targets rotate after their dwell time.
+- A non-empty target `modulation` value overrides global CLI/config modulation locks for that target only.
+- A target `rtl_gain` value is applied at the retune boundary. Manual per-target gain temporarily suspends supervisory
+  tuner autogain; `auto` and global-auto targets restore the saved autogain setting.
 - P25 and DMR trunk targets stay parked while their trunking state machine is following an active call.
 - Conventional DMR targets stay parked only after allowed activity is decoded. The allow/block list, private-call
   tuning, data-call tuning, and encrypted-call tuning controls all apply to that decision.
@@ -187,6 +196,16 @@ The first line must begin with `id,type,frequency_hz,chan_csv,dwell_ms,activity_
 
 Use decimal Hz only, for example `851012500`. Frequency suffixes such as `851.0125M` are valid in CLI/config tuning
 fields, but not in the target CSV.
+
+`row N has invalid modulation`
+
+Use `auto`, `c4fm`, or `cqpsk` for P25 targets. Use `auto` or `gfsk` for DMR targets. Leave the field empty to keep
+global/default modulation handling.
+
+`row N has invalid rtl_gain`
+
+Leave the field empty to inherit the global/default gain. Use `0` or `auto` for device automatic gain, or an integer
+from `1` to `49` for manual RTL-family gain in dB.
 
 `--trunk-scan cannot be combined with global -C/channel-map config`
 

--- a/examples/trunk_scan_targets.csv
+++ b/examples/trunk_scan_targets.csv
@@ -1,4 +1,4 @@
-id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes
-county-p25,p25-trunk,851012500,,3000,,P25 control channel; channels may be learned from control-channel data
-city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel using examples/dmr_t3_chan.csv
-plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR conventional channel
+id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gain
+county-p25,p25-trunk,851012500,,3000,,P25 control channel; channels may be learned from control-channel data,auto,
+city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel using examples/dmr_t3_chan.csv,auto,
+plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR conventional channel,gfsk,

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -34,6 +34,14 @@ typedef enum {
     DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL = 2,
 } dsd_trunk_scan_target_type;
 
+typedef enum {
+    DSD_TRUNK_SCAN_MODULATION_UNSET = 0,
+    DSD_TRUNK_SCAN_MODULATION_AUTO = 1,
+    DSD_TRUNK_SCAN_MODULATION_C4FM = 2,
+    DSD_TRUNK_SCAN_MODULATION_CQPSK = 3,
+    DSD_TRUNK_SCAN_MODULATION_GFSK = 4,
+} dsd_trunk_scan_modulation;
+
 typedef struct {
     char id[64];
     dsd_trunk_scan_target_type type;
@@ -41,6 +49,9 @@ typedef struct {
     char chan_csv[1024];
     int dwell_ms;
     int activity_hold_ms;
+    dsd_trunk_scan_modulation modulation;
+    int rtl_gain_is_set;
+    int rtl_gain_db;
 } dsd_trunk_scan_target;
 
 typedef struct {
@@ -60,6 +71,8 @@ void dsd_engine_trunk_scan_dmr_conventional_activity(const dsd_opts* opts, const
                                                      uint32_t source, int is_private, int encrypted, int data_call);
 size_t dsd_engine_trunk_scan_active_index(const dsd_state* state);
 size_t dsd_engine_trunk_scan_target_count(const dsd_state* state);
+int dsd_engine_trunk_scan_saved_tuner_autogain(const dsd_state* state, int* out_on);
+int dsd_engine_trunk_scan_active_p25_cqpsk_request(const dsd_state* state, int* out_enable);
 
 void dsd_engine_trunk_scan_test_set_now(double now_m);
 void dsd_engine_trunk_scan_test_clear_now(void);

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -239,6 +239,36 @@ void rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int c
                                                   int levels, int channel_profile, int ted_sps,
                                                   int persist_ted_override);
 
+typedef struct rtl_stream_retune_gain_profile {
+    int tuner_gain_is_set;
+    int tuner_gain_tenth_db;
+    int tuner_gain_is_auto;
+    int tuner_autogain_is_set;
+    int tuner_autogain_on;
+} rtl_stream_retune_gain_profile;
+
+/**
+ * @brief Queue a symbol/CQPSK/TED profile plus optional tuner gain for a retune target.
+ *
+ * Gain fields are consumed at the same retune boundary as the demodulator
+ * profile. Pass NULL or set tuner_gain_is_set to zero to leave tuner gain
+ * unchanged. When set, tuner_gain_is_auto requests device auto gain; otherwise
+ * tuner_gain_tenth_db is applied as nearest manual gain.
+ *
+ * @param target_freq_hz Intended center frequency in Hz; zero leaves the profile unbound.
+ * @param cqpsk_enable 0/1 to force CQPSK off/on, negative to leave unchanged.
+ * @param symbol_rate_hz Symbol rate in Hz, e.g. 4800 or 6000.
+ * @param levels Number of symbol levels, 2 or 4.
+ * @param channel_profile rtl_stream_channel_profile profile id.
+ * @param ted_sps TED samples-per-symbol to apply; <=0 leaves TED SPS unchanged.
+ * @param persist_ted_override Non-zero keeps ted_sps as an override after retune.
+ * @param gain_profile Optional tuner gain/autogain profile to apply at retune.
+ */
+void rtl_stream_prepare_retune_profile_for_target_with_gain(uint32_t target_freq_hz, int cqpsk_enable,
+                                                            int symbol_rate_hz, int levels, int channel_profile,
+                                                            int ted_sps, int persist_ted_override,
+                                                            const rtl_stream_retune_gain_profile* gain_profile);
+
 /**
  * @brief Apply and clear the queued retune profile immediately.
  *
@@ -398,6 +428,12 @@ int rtl_stream_test_retune_profile_request_binding(int* out_first_profile, int* 
 int rtl_stream_test_retune_profile_coalesced_no_profile(int* out_profile, uint32_t* out_profile_freq_hz,
                                                         uint32_t* out_manual_freq_hz, uint32_t* out_request_id,
                                                         uint32_t* out_coalesced_request_id);
+
+/**
+ * @brief Verify queued retune gain settings are copied onto their scheduled request.
+ */
+int rtl_stream_test_retune_profile_gain_binding(int* out_gain_is_set, int* out_gain_tenth_db, int* out_gain_is_auto,
+                                                int* out_autogain_is_set, int* out_autogain_on);
 
 typedef struct rtl_stream_test_replay_state {
     int replay_input_eof;

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -11,6 +11,9 @@
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/engine/trunk_scan.h>
+#ifdef USE_RADIO
+#include <dsd-neo/io/rtl_stream_c.h>
+#endif
 #include <dsd-neo/engine/trunk_tuning.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
@@ -172,6 +175,13 @@ typedef struct {
     int saved_trunk_enable;
     int saved_p25_is_tuned;
     int saved_trunk_is_tuned;
+    int saved_mod_c4fm;
+    int saved_mod_qpsk;
+    int saved_mod_gfsk;
+    int saved_mod_cli_lock;
+    int saved_rtl_gain_value;
+    int saved_tuner_autogain_on;
+    int saved_tuner_autogain_is_set;
     uint64_t last_trunk_chan_map_seq;
 } dsd_trunk_scan_coord;
 
@@ -179,6 +189,11 @@ static dsd_trunk_scan_coord* g_trunk_scan_coord;
 static int g_trunk_scan_now_override;
 static double g_trunk_scan_now_m;
 static const char k_trunk_scan_csv_header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes";
+
+enum {
+    DSD_TRUNK_SCAN_REQUIRED_CSV_FIELDS = 7,
+    DSD_TRUNK_SCAN_MAX_CSV_FIELDS = 32,
+};
 
 static double
 trunk_scan_now_m(void) {
@@ -301,9 +316,17 @@ scan_parse_type(const char* s, dsd_trunk_scan_target_type* out) {
 }
 
 static int
-scan_split_row(char* line, char* fields[7]) {
+scan_split_csv_fields(char* line, char** fields, size_t max_fields, size_t* out_count) {
+    if (!line || !fields || max_fields == 0 || !out_count) {
+        return -1;
+    }
     char* p = line;
-    for (int i = 0; i < 6; i++) {
+    size_t count = 0;
+    for (;;) {
+        if (count >= max_fields) {
+            return -1;
+        }
+        fields[count++] = p;
         char* comma = NULL;
         int in_quote = 0;
         for (char* q = p; *q; q++) {
@@ -315,13 +338,12 @@ scan_split_row(char* line, char* fields[7]) {
             }
         }
         if (!comma) {
-            return -1;
+            break;
         }
         *comma = '\0';
-        fields[i] = p;
         p = comma + 1;
     }
-    fields[6] = p;
+    *out_count = count;
     return 0;
 }
 
@@ -350,26 +372,78 @@ typedef struct {
     const char* resolved_path;
     int default_dwell_ms;
     int default_hold_ms;
+    int modulation_idx;
+    int rtl_gain_idx;
     unsigned int row;
     char* err;
     size_t err_sz;
 } dsd_trunk_scan_row_parse;
 
+static const char*
+scan_optional_field(char** fields, size_t field_count, int idx) {
+    if (idx < 0 || (size_t)idx >= field_count) {
+        return "";
+    }
+    return scan_unquote(fields[idx]);
+}
+
 static int
-scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_trunk_scan_row_parse* parse) {
-    char* fields[7] = {0};
-    if (scan_split_row(line, fields) != 0) {
-        scan_set_error(parse->err, parse->err_sz, "row %u must contain 7 CSV fields", parse->row);
+scan_parse_modulation(const char* s, dsd_trunk_scan_target_type type, dsd_trunk_scan_modulation* out) {
+    if (!s || !out) {
         return -1;
     }
+    *out = DSD_TRUNK_SCAN_MODULATION_UNSET;
+    if (s[0] == '\0') {
+        return 0;
+    }
+    if (strcmp(s, "auto") == 0) {
+        *out = DSD_TRUNK_SCAN_MODULATION_AUTO;
+        return 0;
+    }
+    if (strcmp(s, "c4fm") == 0 && type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
+        *out = DSD_TRUNK_SCAN_MODULATION_C4FM;
+        return 0;
+    }
+    if (strcmp(s, "cqpsk") == 0 && type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
+        *out = DSD_TRUNK_SCAN_MODULATION_CQPSK;
+        return 0;
+    }
+    if (strcmp(s, "gfsk") == 0
+        && (type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK || type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL)) {
+        *out = DSD_TRUNK_SCAN_MODULATION_GFSK;
+        return 0;
+    }
+    return -1;
+}
 
+static int
+scan_parse_rtl_gain_field(const char* s, dsd_trunk_scan_target* target) {
+    if (!target) {
+        return -1;
+    }
+    target->rtl_gain_is_set = 0;
+    target->rtl_gain_db = 0;
+    if (!s || s[0] == '\0') {
+        return 0;
+    }
+    if (strcmp(s, "auto") == 0) {
+        target->rtl_gain_is_set = 1;
+        return 0;
+    }
+    uint32_t parsed = 0;
+    if (scan_parse_u32_decimal(s, 0U, 49U, &parsed) != 0) {
+        return -1;
+    }
+    target->rtl_gain_is_set = 1;
+    target->rtl_gain_db = (int)parsed;
+    return 0;
+}
+
+static int
+scan_parse_target_base_fields(char** fields, const dsd_trunk_scan_target_list* parsed,
+                              const dsd_trunk_scan_row_parse* parse, dsd_trunk_scan_target* target,
+                              const char** out_chan_csv, const char** out_dwell_s, const char** out_hold_s) {
     const char* id = scan_unquote(fields[0]);
-    const char* type_s = scan_unquote(fields[1]);
-    const char* freq_s = scan_unquote(fields[2]);
-    const char* chan_csv = scan_unquote(fields[3]);
-    const char* dwell_s = scan_unquote(fields[4]);
-    const char* hold_s = scan_unquote(fields[5]);
-
     if (id[0] == '\0' || strlen(id) >= sizeof(parsed->targets[0].id)) {
         scan_set_error(parse->err, parse->err_sz, "row %u has an empty or too-long id", parse->row);
         return -1;
@@ -379,15 +453,62 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
         return -1;
     }
 
-    dsd_trunk_scan_target target;
-    DSD_MEMSET(&target, 0, sizeof(target));
-    DSD_SNPRINTF(target.id, sizeof target.id, "%s", id);
-    if (scan_parse_type(type_s, &target.type) != 0) {
+    DSD_SNPRINTF(target->id, sizeof target->id, "%s", id);
+    const char* type_s = scan_unquote(fields[1]);
+    if (scan_parse_type(type_s, &target->type) != 0) {
         scan_set_error(parse->err, parse->err_sz, "row %u has invalid target type '%s'", parse->row, type_s);
         return -1;
     }
-    if (scan_parse_u32_decimal(freq_s, 1U, DSD_TRUNK_SCAN_MAX_FREQUENCY_HZ, &target.frequency_hz) != 0) {
+
+    const char* freq_s = scan_unquote(fields[2]);
+    if (scan_parse_u32_decimal(freq_s, 1U, DSD_TRUNK_SCAN_MAX_FREQUENCY_HZ, &target->frequency_hz) != 0) {
         scan_set_error(parse->err, parse->err_sz, "row %u has invalid frequency_hz '%s'", parse->row, freq_s);
+        return -1;
+    }
+
+    *out_chan_csv = scan_unquote(fields[3]);
+    *out_dwell_s = scan_unquote(fields[4]);
+    *out_hold_s = scan_unquote(fields[5]);
+    return 0;
+}
+
+static int
+scan_parse_target_overrides(dsd_trunk_scan_target* target, const dsd_trunk_scan_row_parse* parse,
+                            const char* modulation_s, const char* rtl_gain_s) {
+    if (scan_parse_modulation(modulation_s, target->type, &target->modulation) != 0) {
+        scan_set_error(parse->err, parse->err_sz, "row %u has invalid modulation '%s'", parse->row, modulation_s);
+        return -1;
+    }
+    if (scan_parse_rtl_gain_field(rtl_gain_s, target) != 0) {
+        scan_set_error(parse->err, parse->err_sz, "row %u has invalid rtl_gain '%s'", parse->row, rtl_gain_s);
+        return -1;
+    }
+    return 0;
+}
+
+static int
+scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_trunk_scan_row_parse* parse) {
+    char* fields[DSD_TRUNK_SCAN_MAX_CSV_FIELDS] = {0};
+    size_t field_count = 0;
+    if (scan_split_csv_fields(line, fields, DSD_TRUNK_SCAN_MAX_CSV_FIELDS, &field_count) != 0) {
+        scan_set_error(parse->err, parse->err_sz, "row %u has too many CSV fields", parse->row);
+        return -1;
+    }
+    if (field_count < DSD_TRUNK_SCAN_REQUIRED_CSV_FIELDS) {
+        scan_set_error(parse->err, parse->err_sz, "row %u must contain at least 7 CSV fields", parse->row);
+        return -1;
+    }
+
+    const char* modulation_s = scan_optional_field(fields, field_count, parse->modulation_idx);
+    const char* rtl_gain_s = scan_optional_field(fields, field_count, parse->rtl_gain_idx);
+
+    dsd_trunk_scan_target target;
+    DSD_MEMSET(&target, 0, sizeof(target));
+    const char* chan_csv = "";
+    const char* dwell_s = "";
+    const char* hold_s = "";
+    if (scan_parse_target_base_fields(fields, parsed, parse, &target, &chan_csv, &dwell_s, &hold_s) != 0
+        || scan_parse_target_overrides(&target, parse, modulation_s, rtl_gain_s) != 0) {
         return -1;
     }
     if (scan_has_duplicate_type_freq(parsed, target.type, target.frequency_hz)) {
@@ -420,18 +541,64 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
 }
 
 static int
-scan_read_target_csv_header(FILE* fp, char* line, size_t line_sz, char* err, size_t err_sz) {
+scan_read_target_csv_header(FILE* fp, char* line, size_t line_sz, dsd_trunk_scan_row_parse* parse) {
     if (!fgets(line, line_sz, fp)) {
-        scan_set_error(err, err_sz, "trunk scan target CSV is empty");
+        scan_set_error(parse->err, parse->err_sz, "trunk scan target CSV is empty");
         return -1;
     }
     line[strcspn(line, "\r\n")] = '\0';
 
-    size_t header_len = strlen(k_trunk_scan_csv_header);
-    if (strncmp(line, k_trunk_scan_csv_header, header_len) != 0
-        || (line[header_len] != '\0' && line[header_len] != ',')) {
-        scan_set_error(err, err_sz, "trunk scan target CSV header must start with '%s'", k_trunk_scan_csv_header);
+    char* fields[DSD_TRUNK_SCAN_MAX_CSV_FIELDS] = {0};
+    size_t field_count = 0;
+    if (scan_split_csv_fields(line, fields, DSD_TRUNK_SCAN_MAX_CSV_FIELDS, &field_count) != 0
+        || field_count < DSD_TRUNK_SCAN_REQUIRED_CSV_FIELDS) {
+        scan_set_error(parse->err, parse->err_sz, "trunk scan target CSV header must start with '%s'",
+                       k_trunk_scan_csv_header);
         return -1;
+    }
+
+    static const char* const required[DSD_TRUNK_SCAN_REQUIRED_CSV_FIELDS] = {
+        "id", "type", "frequency_hz", "chan_csv", "dwell_ms", "activity_hold_ms", "notes",
+    };
+    for (size_t i = 0; i < DSD_TRUNK_SCAN_REQUIRED_CSV_FIELDS; i++) {
+        const char* name = scan_unquote(fields[i]);
+        if (strcmp(name, required[i]) != 0) {
+            scan_set_error(parse->err, parse->err_sz, "trunk scan target CSV header must start with '%s'",
+                           k_trunk_scan_csv_header);
+            return -1;
+        }
+    }
+
+    parse->modulation_idx = -1;
+    parse->rtl_gain_idx = -1;
+    for (size_t i = DSD_TRUNK_SCAN_REQUIRED_CSV_FIELDS; i < field_count; i++) {
+        const char* name = scan_unquote(fields[i]);
+        if (strcmp(name, "modulation") == 0) {
+            if (parse->modulation_idx >= 0) {
+                scan_set_error(parse->err, parse->err_sz, "trunk scan target CSV header duplicates 'modulation'");
+                return -1;
+            }
+            parse->modulation_idx = (int)i;
+        } else if (strcmp(name, "rtl_gain") == 0) {
+            if (parse->rtl_gain_idx >= 0) {
+                scan_set_error(parse->err, parse->err_sz, "trunk scan target CSV header duplicates 'rtl_gain'");
+                return -1;
+            }
+            parse->rtl_gain_idx = (int)i;
+        }
+    }
+    return 0;
+}
+
+static int
+scan_target_list_has_rtl_gain_override(const dsd_trunk_scan_target_list* list) {
+    if (!list) {
+        return 0;
+    }
+    for (size_t i = 0; i < list->count; i++) {
+        if (list->targets[i].rtl_gain_is_set) {
+            return 1;
+        }
     }
     return 0;
 }
@@ -483,11 +650,6 @@ dsd_trunk_scan_load_targets_csv(const char* path, const dsd_opts* opts, dsd_trun
     }
 
     char line[4096];
-    if (scan_read_target_csv_header(fp, line, sizeof line, err, err_sz) != 0) {
-        fclose(fp);
-        return -1;
-    }
-
     dsd_trunk_scan_row_parse parse;
     parse.resolved_path = resolved_path;
     parse.default_dwell_ms =
@@ -496,6 +658,13 @@ dsd_trunk_scan_load_targets_csv(const char* path, const dsd_opts* opts, dsd_trun
         scan_default_ms(opts ? opts->trunk_scan_activity_hold_ms : 0, DSD_TRUNK_SCAN_ACTIVITY_HOLD_DEFAULT_MS);
     parse.err = err;
     parse.err_sz = err_sz;
+    parse.modulation_idx = -1;
+    parse.rtl_gain_idx = -1;
+
+    if (scan_read_target_csv_header(fp, line, sizeof line, &parse) != 0) {
+        fclose(fp);
+        return -1;
+    }
 
     int rows_rc = scan_load_target_csv_rows(fp, line, sizeof line, &parsed, &parse);
     fclose(fp);
@@ -946,7 +1115,11 @@ trunk_scan_apply_target_demod(const dsd_opts* opts, dsd_state* state, const dsd_
         int p25_sps = trunk_scan_p25_cc_sps(opts, state);
         state->samplesPerSymbol = p25_sps;
         state->symbolCenter = dsd_opts_symbol_center(p25_sps);
-        if (!opts->mod_cli_lock) {
+        if (target->modulation == DSD_TRUNK_SCAN_MODULATION_CQPSK) {
+            state->rf_mod = 1;
+        } else if (target->modulation == DSD_TRUNK_SCAN_MODULATION_C4FM) {
+            state->rf_mod = 0;
+        } else if (target->modulation == DSD_TRUNK_SCAN_MODULATION_AUTO || !opts->mod_cli_lock) {
             state->rf_mod = (state->p25_cc_is_tdma == 1) ? 1 : 0;
         }
         return;
@@ -957,16 +1130,80 @@ trunk_scan_apply_target_demod(const dsd_opts* opts, dsd_state* state, const dsd_
     int dmr_sps = trunk_scan_dmr_sps(opts, state);
     state->samplesPerSymbol = dmr_sps;
     state->symbolCenter = dsd_opts_symbol_center(dmr_sps);
-    if (!opts->mod_cli_lock) {
+    if (target->modulation == DSD_TRUNK_SCAN_MODULATION_GFSK || target->modulation == DSD_TRUNK_SCAN_MODULATION_AUTO
+        || !opts->mod_cli_lock) {
         state->rf_mod = 2;
     }
 }
 
 static void
-trunk_scan_apply_target_opts(dsd_opts* opts, const dsd_trunk_scan_target* target) {
-    if (!opts || !target) {
+trunk_scan_restore_saved_mod_gain_opts(dsd_opts* opts, const dsd_trunk_scan_coord* coord) {
+    if (!opts || !coord) {
         return;
     }
+    opts->mod_c4fm = coord->saved_mod_c4fm;
+    opts->mod_qpsk = coord->saved_mod_qpsk;
+    opts->mod_gfsk = coord->saved_mod_gfsk;
+    opts->mod_cli_lock = coord->saved_mod_cli_lock;
+    opts->rtl_gain_value = coord->saved_rtl_gain_value;
+}
+
+static void
+trunk_scan_apply_target_mod_opts(dsd_opts* opts, const dsd_trunk_scan_target* target) {
+    if (!opts || !target || target->modulation == DSD_TRUNK_SCAN_MODULATION_UNSET) {
+        return;
+    }
+    switch (target->modulation) {
+        case DSD_TRUNK_SCAN_MODULATION_AUTO:
+            if (target->type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
+                opts->mod_c4fm = 1;
+                opts->mod_qpsk = 0;
+                opts->mod_gfsk = 0;
+            } else {
+                opts->mod_c4fm = 0;
+                opts->mod_qpsk = 0;
+                opts->mod_gfsk = 1;
+            }
+            opts->mod_cli_lock = 0;
+            break;
+        case DSD_TRUNK_SCAN_MODULATION_C4FM:
+            opts->mod_c4fm = 1;
+            opts->mod_qpsk = 0;
+            opts->mod_gfsk = 0;
+            opts->mod_cli_lock = 1;
+            break;
+        case DSD_TRUNK_SCAN_MODULATION_CQPSK:
+            opts->mod_c4fm = 0;
+            opts->mod_qpsk = 1;
+            opts->mod_gfsk = 0;
+            opts->mod_cli_lock = 1;
+            break;
+        case DSD_TRUNK_SCAN_MODULATION_GFSK:
+            opts->mod_c4fm = 0;
+            opts->mod_qpsk = 0;
+            opts->mod_gfsk = 1;
+            opts->mod_cli_lock = 1;
+            break;
+        case DSD_TRUNK_SCAN_MODULATION_UNSET: break;
+    }
+}
+
+static void
+trunk_scan_apply_target_gain_opts(dsd_opts* opts, const dsd_trunk_scan_target* target) {
+    if (!opts || !target || !target->rtl_gain_is_set) {
+        return;
+    }
+    opts->rtl_gain_value = target->rtl_gain_db;
+}
+
+static void
+trunk_scan_apply_target_opts(dsd_opts* opts, const dsd_trunk_scan_coord* coord, const dsd_trunk_scan_target* target) {
+    if (!opts || !coord || !target) {
+        return;
+    }
+    trunk_scan_restore_saved_mod_gain_opts(opts, coord);
+    trunk_scan_apply_target_mod_opts(opts, target);
+    trunk_scan_apply_target_gain_opts(opts, target);
     opts->p25_is_tuned = 0;
     opts->trunk_is_tuned = 0;
     switch (target->type) {
@@ -1060,7 +1297,7 @@ trunk_scan_build_target_runtime(dsd_trunk_scan_coord* coord, dsd_opts* opts, dsd
         dsd_trunk_scan_target_runtime* rt = &coord->targets[i];
         rt->target = list->targets[i];
         trunk_scan_restore_snapshot(state, empty_snapshot);
-        trunk_scan_apply_target_opts(opts, &rt->target);
+        trunk_scan_apply_target_opts(opts, coord, &rt->target);
         trunk_scan_apply_target_demod(opts, state, &rt->target);
         trunk_scan_seed_target_state(state, &rt->target, now_m);
         if (trunk_scan_import_target_chan_csv(opts, state, &rt->target, err, err_sz) != 0) {
@@ -1139,7 +1376,7 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
     coord->active = next;
     dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
     trunk_scan_restore_target_snapshot(coord, state, rt);
-    trunk_scan_apply_target_opts(opts, &rt->target);
+    trunk_scan_apply_target_opts(opts, coord, &rt->target);
     trunk_scan_apply_target_demod(opts, state, &rt->target);
     trunk_scan_sync_active_sm_mode(state, rt);
 
@@ -1189,7 +1426,7 @@ trunk_scan_advance(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord
 
     coord->active = original_active;
     trunk_scan_restore_snapshot(state, original_snapshot);
-    trunk_scan_apply_target_opts(opts, &coord->targets[coord->active].target);
+    trunk_scan_apply_target_opts(opts, coord, &coord->targets[coord->active].target);
     trunk_scan_apply_target_demod(opts, state, &coord->targets[coord->active].target);
     trunk_scan_sync_active_sm_mode(state, &coord->targets[coord->active]);
 }
@@ -1225,10 +1462,41 @@ trunk_scan_restore_saved_opts(dsd_opts* opts, const dsd_trunk_scan_coord* coord)
     if (!opts || !coord) {
         return;
     }
+    trunk_scan_restore_saved_mod_gain_opts(opts, coord);
     opts->p25_trunk = coord->saved_p25_trunk;
     opts->trunk_enable = coord->saved_trunk_enable;
     opts->p25_is_tuned = coord->saved_p25_is_tuned;
     opts->trunk_is_tuned = coord->saved_trunk_is_tuned;
+}
+
+static void
+trunk_scan_capture_saved_opts(dsd_trunk_scan_coord* coord, const dsd_opts* opts) {
+    if (!coord || !opts) {
+        return;
+    }
+    coord->saved_p25_trunk = opts->p25_trunk;
+    coord->saved_trunk_enable = opts->trunk_enable;
+    coord->saved_p25_is_tuned = opts->p25_is_tuned;
+    coord->saved_trunk_is_tuned = opts->trunk_is_tuned;
+    coord->saved_mod_c4fm = opts->mod_c4fm;
+    coord->saved_mod_qpsk = opts->mod_qpsk;
+    coord->saved_mod_gfsk = opts->mod_gfsk;
+    coord->saved_mod_cli_lock = opts->mod_cli_lock;
+    coord->saved_rtl_gain_value = opts->rtl_gain_value;
+#ifdef USE_RADIO
+    coord->saved_tuner_autogain_on = rtl_stream_get_tuner_autogain() ? 1 : 0;
+    coord->saved_tuner_autogain_is_set = 1;
+#endif
+}
+
+static void
+trunk_scan_warn_ignored_target_gain(const dsd_opts* opts, const dsd_state* state,
+                                    const dsd_trunk_scan_target_list* list) {
+    if (!opts || !state || trunk_scan_has_open_rtl_stream(opts, state)
+        || !scan_target_list_has_rtl_gain_override(list)) {
+        return;
+    }
+    LOG_WARNING("Trunk scan rtl_gain target overrides require RTL-family input; ignoring target gain settings\n");
 }
 
 static void
@@ -1383,6 +1651,7 @@ dsd_engine_trunk_scan_init(dsd_opts* opts, dsd_state* state, char* err, size_t e
     if (dsd_trunk_scan_load_targets_csv(opts->trunk_scan_targets_csv, opts, &list, err, err_sz) != 0) {
         return -1;
     }
+    trunk_scan_warn_ignored_target_gain(opts, state, &list);
 
     dsd_trunk_scan_coord* coord = (dsd_trunk_scan_coord*)calloc(1, sizeof(*coord));
     if (!coord) {
@@ -1390,10 +1659,7 @@ dsd_engine_trunk_scan_init(dsd_opts* opts, dsd_state* state, char* err, size_t e
         return -1;
     }
     coord->count = list.count;
-    coord->saved_p25_trunk = opts->p25_trunk;
-    coord->saved_trunk_enable = opts->trunk_enable;
-    coord->saved_p25_is_tuned = opts->p25_is_tuned;
-    coord->saved_trunk_is_tuned = opts->trunk_is_tuned;
+    trunk_scan_capture_saved_opts(coord, opts);
 
     if (trunk_scan_build_target_runtime(coord, opts, state, &list, err, err_sz) != 0) {
         trunk_scan_restore_saved_opts(opts, coord);
@@ -1436,4 +1702,47 @@ size_t
 dsd_engine_trunk_scan_target_count(const dsd_state* state) {
     const dsd_trunk_scan_coord* coord = trunk_scan_get_const(state);
     return coord ? coord->count : 0;
+}
+
+int
+dsd_engine_trunk_scan_active_p25_cqpsk_request(const dsd_state* state, int* out_enable) {
+    if (!state || !out_enable) {
+        return 0;
+    }
+    const dsd_trunk_scan_coord* coord = trunk_scan_get_const(state);
+    if (!coord || coord->active >= coord->count) {
+        return 0;
+    }
+    const dsd_trunk_scan_target* target = &coord->targets[coord->active].target;
+    if (target->type != DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
+        return 0;
+    }
+    if (target->modulation == DSD_TRUNK_SCAN_MODULATION_C4FM) {
+        *out_enable = 0;
+        return 1;
+    }
+    if (target->modulation == DSD_TRUNK_SCAN_MODULATION_CQPSK) {
+        *out_enable = 1;
+        return 1;
+    }
+    if (target->modulation == DSD_TRUNK_SCAN_MODULATION_AUTO) {
+        *out_enable = (state->p25_cc_is_tdma == 1) ? 1 : 0;
+        return 1;
+    }
+    return 0;
+}
+
+int
+dsd_engine_trunk_scan_saved_tuner_autogain(const dsd_state* state, int* out_on) {
+    const dsd_trunk_scan_coord* coord = trunk_scan_get_const(state);
+    if (out_on) {
+        *out_on = 0;
+    }
+    if (!coord || !coord->saved_tuner_autogain_is_set) {
+        return 0;
+    }
+    if (out_on) {
+        *out_on = coord->saved_tuner_autogain_on ? 1 : 0;
+    }
+    return 1;
 }

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -8,6 +8,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/engine/trunk_scan.h>
 #include <dsd-neo/engine/trunk_tuning.h>
 #include <dsd-neo/io/rigctl_client.h>
 #include <dsd-neo/io/rtl_stream_c.h>
@@ -119,6 +120,43 @@ typedef struct {
     int rtl_ted_sps_override;
 } dsd_engine_rtl_profile_snapshot;
 
+static rtl_stream_retune_gain_profile
+dsd_engine_trunk_scan_gain_profile(const dsd_opts* opts, const dsd_state* state) {
+    rtl_stream_retune_gain_profile profile;
+    DSD_MEMSET(&profile, 0, sizeof(profile));
+    if (!opts || !state || opts->trunk_scan_enabled != 1 || dsd_engine_trunk_scan_target_count(state) == 0) {
+        return profile;
+    }
+
+    profile.tuner_gain_is_set = 1;
+    if (opts->rtl_gain_value > 0) {
+        profile.tuner_gain_tenth_db = opts->rtl_gain_value * 10;
+        profile.tuner_gain_is_auto = 0;
+        profile.tuner_autogain_is_set = 1;
+        profile.tuner_autogain_on = 0;
+        return profile;
+    }
+
+    profile.tuner_gain_tenth_db = 0;
+    profile.tuner_gain_is_auto = 1;
+    int saved_autogain = 0;
+    if (dsd_engine_trunk_scan_saved_tuner_autogain(state, &saved_autogain)) {
+        profile.tuner_autogain_is_set = 1;
+        profile.tuner_autogain_on = saved_autogain ? 1 : 0;
+    }
+    return profile;
+}
+
+static void
+dsd_engine_prepare_retune_profile_for_target(const dsd_opts* opts, const dsd_state* state, uint32_t target_freq_hz,
+                                             int cqpsk_enable, int symbol_rate_hz, int levels, int channel_profile,
+                                             int ted_sps, int persist_ted_override) {
+    rtl_stream_retune_gain_profile gain_profile = dsd_engine_trunk_scan_gain_profile(opts, state);
+    rtl_stream_prepare_retune_profile_for_target_with_gain(target_freq_hz, cqpsk_enable, symbol_rate_hz, levels,
+                                                           channel_profile, ted_sps, persist_ted_override,
+                                                           &gain_profile);
+}
+
 static void
 dsd_engine_rtl_profile_snapshot_capture(const dsd_opts* opts, const dsd_state* state,
                                         dsd_engine_rtl_profile_snapshot* snapshot) {
@@ -170,13 +208,17 @@ dsd_engine_prepare_p25_cc_rtl_chain(const dsd_opts* opts, dsd_state* state, long
         cfg = dsd_neo_get_config();
     }
 
-    const int want_cqpsk = (state->p25_cc_is_tdma == 1 || opts->mod_qpsk == 1) ? 1 : 0;
+    const int default_cqpsk = (state->p25_cc_is_tdma == 1 || opts->mod_qpsk == 1) ? 1 : 0;
+    int trunk_scan_cqpsk_request = 0;
+    const int has_trunk_scan_cqpsk_request =
+        dsd_engine_trunk_scan_active_p25_cqpsk_request(state, &trunk_scan_cqpsk_request);
+    const int want_cqpsk = has_trunk_scan_cqpsk_request ? trunk_scan_cqpsk_request : default_cqpsk;
     state->rf_mod = want_cqpsk ? 1 : 0;
-    const int cqpsk_request = (cfg && cfg->cqpsk_is_set) ? -1 : want_cqpsk;
+    const int cqpsk_request = (has_trunk_scan_cqpsk_request || !cfg || !cfg->cqpsk_is_set) ? want_cqpsk : -1;
     const int sym_rate = (state->p25_cc_is_tdma == 1) ? 6000 : 4800;
     const int profile = want_cqpsk ? RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK : RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
-    rtl_stream_prepare_retune_profile_for_target((uint32_t)target_freq_hz, cqpsk_request, sym_rate, 4, profile, ted_sps,
-                                                 0);
+    dsd_engine_prepare_retune_profile_for_target(opts, state, (uint32_t)target_freq_hz, cqpsk_request, sym_rate, 4,
+                                                 profile, ted_sps, 0);
 }
 
 static void
@@ -186,18 +228,19 @@ dsd_engine_prepare_dmr_cc_rtl_chain(const dsd_opts* opts, const dsd_state* state
     if (state->rtl_ctx) {
         retune_ted_sps = dsd_opts_compute_sps_rate(opts, 4800, (int)rtl_stream_output_rate(state->rtl_ctx));
     }
-    rtl_stream_prepare_retune_profile_for_target((uint32_t)target_freq_hz, 0, 4800, 4, RTL_STREAM_CHANNEL_PROFILE_12K5,
-                                                 retune_ted_sps, 0);
+    dsd_engine_prepare_retune_profile_for_target(opts, state, (uint32_t)target_freq_hz, 0, 4800, 4,
+                                                 RTL_STREAM_CHANNEL_PROFILE_12K5, retune_ted_sps, 0);
 }
 
 static void
-dsd_engine_prepare_current_cc_rtl_chain(long int target_freq_hz, int ted_sps) {
+dsd_engine_prepare_current_cc_rtl_chain(const dsd_opts* opts, const dsd_state* state, long int target_freq_hz,
+                                        int ted_sps) {
     if (ted_sps > 0) {
         int symbol_rate_hz = 0;
         int levels = 0;
         int channel_profile = RTL_STREAM_CHANNEL_PROFILE_WIDE;
         (void)rtl_stream_get_symbol_profile_full(&symbol_rate_hz, &levels, &channel_profile);
-        rtl_stream_prepare_retune_profile_for_target((uint32_t)target_freq_hz, -1, symbol_rate_hz, levels,
+        dsd_engine_prepare_retune_profile_for_target(opts, state, (uint32_t)target_freq_hz, -1, symbol_rate_hz, levels,
                                                      channel_profile, ted_sps, 0);
     } else {
         rtl_stream_clear_pending_retune_profile();
@@ -217,7 +260,7 @@ dsd_engine_prepare_cc_rtl_chain(const dsd_opts* opts, dsd_state* state, long int
         dsd_engine_prepare_dmr_cc_rtl_chain(opts, state, target_freq_hz, ted_sps);
         return;
     }
-    dsd_engine_prepare_current_cc_rtl_chain(target_freq_hz, ted_sps);
+    dsd_engine_prepare_current_cc_rtl_chain(opts, state, target_freq_hz, ted_sps);
 }
 #endif
 
@@ -350,12 +393,16 @@ dsd_engine_prepare_vc_rtl_chain(const dsd_opts* opts, dsd_state* state, long int
         cfg = dsd_neo_get_config();
     }
 
+    int trunk_scan_cqpsk_request = 0;
+    const int has_trunk_scan_cqpsk_request =
+        dsd_engine_trunk_scan_active_p25_cqpsk_request(state, &trunk_scan_cqpsk_request);
+    /* The target request only bypasses the runtime lock; VC modulation still follows the grant/profile state. */
     int want_cqpsk = dsd_engine_resolve_vc_cqpsk(state, state->rf_mod);
-    int cqpsk_request = (cfg && cfg->cqpsk_is_set) ? -1 : want_cqpsk;
+    int cqpsk_request = (has_trunk_scan_cqpsk_request || !cfg || !cfg->cqpsk_is_set) ? want_cqpsk : -1;
     const int sym_rate = (state->p25_p2_active_slot != -1) ? 6000 : 4800;
     const int profile = want_cqpsk ? RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK : RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
-    rtl_stream_prepare_retune_profile_for_target((uint32_t)target_freq_hz, cqpsk_request, sym_rate, 4, profile, ted_sps,
-                                                 ted_sps > 0 ? 1 : 0);
+    dsd_engine_prepare_retune_profile_for_target(opts, state, (uint32_t)target_freq_hz, cqpsk_request, sym_rate, 4,
+                                                 profile, ted_sps, ted_sps > 0 ? 1 : 0);
 
     /* One-shot override is consumed by this tune attempt. */
     state->p25_vc_cqpsk_override = -1;

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -185,6 +185,11 @@ struct RtlRetuneProfile {
     int channel_profile = 0;
     int ted_sps = 0;
     int ted_override = 0;
+    int tuner_gain_is_set = 0;
+    int tuner_gain_tenth_db = 0;
+    int tuner_gain_is_auto = 0;
+    int tuner_autogain_is_set = 0;
+    int tuner_autogain_on = 0;
     uint32_t request_id = 0U;
     uint32_t target_freq_hz = 0U;
 };
@@ -302,7 +307,8 @@ static int rtl_stream_take_pending_retune_profile(RtlRetuneProfile* out_profile,
                                                   uint32_t target_freq_hz);
 static void rtl_stream_store_pending_retune_profile(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz,
                                                     int levels, int channel_profile, int ted_sps,
-                                                    int persist_ted_override);
+                                                    int persist_ted_override,
+                                                    const rtl_stream_retune_gain_profile* gain_profile);
 static void rtl_stream_apply_retune_profile(const RtlRetuneProfile* profile, uint32_t center_freq_hz);
 static void rtl_fsk_metrics_reset_snapshot(void);
 static void rtl_decode_health_reset(void);
@@ -7059,6 +7065,18 @@ rtl_stream_clear_retune_profile(RtlRetuneProfile* profile) {
     }
 }
 
+static void
+rtl_stream_copy_retune_gain_profile(RtlRetuneProfile* profile, const rtl_stream_retune_gain_profile* gain_profile) {
+    if (!profile || !gain_profile) {
+        return;
+    }
+    profile->tuner_gain_is_set = gain_profile->tuner_gain_is_set ? 1 : 0;
+    profile->tuner_gain_tenth_db = gain_profile->tuner_gain_tenth_db < 0 ? 0 : gain_profile->tuner_gain_tenth_db;
+    profile->tuner_gain_is_auto = gain_profile->tuner_gain_is_auto ? 1 : 0;
+    profile->tuner_autogain_is_set = gain_profile->tuner_autogain_is_set ? 1 : 0;
+    profile->tuner_autogain_on = gain_profile->tuner_autogain_on ? 1 : 0;
+}
+
 static int
 rtl_stream_retune_profile_matches_target(const RtlRetuneProfile* profile, uint32_t target_freq_hz) {
     if (!profile || !profile->active) {
@@ -7096,7 +7114,8 @@ rtl_stream_take_pending_retune_profile(RtlRetuneProfile* out_profile, uint32_t r
 
 static void
 rtl_stream_store_pending_retune_profile(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz, int levels,
-                                        int channel_profile, int ted_sps, int persist_ted_override) {
+                                        int channel_profile, int ted_sps, int persist_ted_override,
+                                        const rtl_stream_retune_gain_profile* gain_profile) {
     if (levels != 2 && levels != 4) {
         levels = 4;
     }
@@ -7112,6 +7131,7 @@ rtl_stream_store_pending_retune_profile(uint32_t target_freq_hz, int cqpsk_enabl
     profile.channel_profile = channel_profile;
     profile.ted_sps = ted_sps;
     profile.ted_override = persist_ted_override ? 1 : 0;
+    rtl_stream_copy_retune_gain_profile(&profile, gain_profile);
     profile.target_freq_hz = target_freq_hz;
 
     std::lock_guard<std::mutex> lock(g_pending_retune_profile_mutex);
@@ -7122,7 +7142,7 @@ extern "C" void
 dsd_rtl_stream_prepare_retune_profile(int cqpsk_enable, int symbol_rate_hz, int levels, int channel_profile,
                                       int ted_sps, int persist_ted_override) {
     rtl_stream_store_pending_retune_profile(0U, cqpsk_enable, symbol_rate_hz, levels, channel_profile, ted_sps,
-                                            persist_ted_override);
+                                            persist_ted_override, NULL);
 }
 
 extern "C" void
@@ -7130,13 +7150,69 @@ dsd_rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int cq
                                                  int levels, int channel_profile, int ted_sps,
                                                  int persist_ted_override) {
     rtl_stream_store_pending_retune_profile(target_freq_hz, cqpsk_enable, symbol_rate_hz, levels, channel_profile,
-                                            ted_sps, persist_ted_override);
+                                            ted_sps, persist_ted_override, NULL);
+}
+
+extern "C" void
+dsd_rtl_stream_prepare_retune_profile_for_target_with_gain(uint32_t target_freq_hz, int cqpsk_enable,
+                                                           int symbol_rate_hz, int levels, int channel_profile,
+                                                           int ted_sps, int persist_ted_override,
+                                                           const rtl_stream_retune_gain_profile* gain_profile) {
+    rtl_stream_store_pending_retune_profile(target_freq_hz, cqpsk_enable, symbol_rate_hz, levels, channel_profile,
+                                            ted_sps, persist_ted_override, gain_profile);
 }
 
 extern "C" void
 dsd_rtl_stream_clear_pending_retune_profile(void) {
     std::lock_guard<std::mutex> lock(g_pending_retune_profile_mutex);
     rtl_stream_clear_retune_profile(&g_pending_retune_profile);
+}
+
+static void
+rtl_stream_restore_retune_autogain(const RtlRetuneProfile* profile) {
+    if (profile && profile->tuner_autogain_is_set) {
+        g_tuner_autogain_on.store(profile->tuner_autogain_on ? 1 : 0, std::memory_order_relaxed);
+    }
+}
+
+static int
+rtl_stream_apply_auto_retune_gain(void) {
+    int rc = rtl_device_set_gain(rtl_device_handle, AUTO_GAIN);
+    if (rc == 0) {
+        dongle.gain = AUTO_GAIN;
+    }
+    return rc;
+}
+
+static int
+rtl_stream_apply_manual_retune_gain(int tuner_gain_tenth_db) {
+    int rc = rtl_device_set_gain_nearest(rtl_device_handle, tuner_gain_tenth_db);
+    if (rc == 0) {
+        int applied = rtl_device_get_tuner_gain(rtl_device_handle);
+        dongle.gain = applied >= 0 ? applied : tuner_gain_tenth_db;
+    }
+    return rc;
+}
+
+static void
+rtl_stream_apply_retune_gain_profile(const RtlRetuneProfile* profile) {
+    if (!profile || !profile->active) {
+        return;
+    }
+    int manual_gain = profile->tuner_gain_is_set && !profile->tuner_gain_is_auto;
+    if (manual_gain) {
+        rtl_stream_restore_retune_autogain(profile);
+    }
+    if (profile->tuner_gain_is_set) {
+        int rc = profile->tuner_gain_is_auto ? rtl_stream_apply_auto_retune_gain()
+                                             : rtl_stream_apply_manual_retune_gain(profile->tuner_gain_tenth_db);
+        if (rc != 0) {
+            LOG_WARNING("Retune tuner gain apply failed (rc=%d); continuing retune\n", rc);
+        }
+    }
+    if (!manual_gain) {
+        rtl_stream_restore_retune_autogain(profile);
+    }
 }
 
 static void
@@ -7149,6 +7225,8 @@ rtl_stream_apply_retune_profile(const RtlRetuneProfile* profile, uint32_t center
             return;
         }
     }
+
+    rtl_stream_apply_retune_gain_profile(profile);
 
     int cqpsk = profile->cqpsk_enable;
     if (cqpsk >= 0) {
@@ -7782,6 +7860,48 @@ dsd_rtl_stream_test_retune_profile_coalesced_no_profile(int* out_profile, uint32
 
     controller_cleanup(&test_controller);
     if (second_request_id != first_request_id) {
+        return -3;
+    }
+    return 0;
+}
+
+extern "C" int
+dsd_rtl_stream_test_retune_profile_gain_binding(int* out_gain_is_set, int* out_gain_tenth_db, int* out_gain_is_auto,
+                                                int* out_autogain_is_set, int* out_autogain_on) {
+    if (!out_gain_is_set || !out_gain_tenth_db || !out_gain_is_auto || !out_autogain_is_set || !out_autogain_on) {
+        return -1;
+    }
+    *out_gain_is_set = 0;
+    *out_gain_tenth_db = 0;
+    *out_gain_is_auto = 0;
+    *out_autogain_is_set = 0;
+    *out_autogain_on = 0;
+
+    controller_state test_controller = {};
+    controller_init(&test_controller);
+    dsd_rtl_stream_clear_pending_retune_profile();
+
+    rtl_stream_retune_gain_profile gain_profile{};
+    gain_profile.tuner_gain_is_set = 1;
+    gain_profile.tuner_gain_tenth_db = 270;
+    gain_profile.tuner_autogain_is_set = 1;
+    dsd_rtl_stream_prepare_retune_profile_for_target_with_gain(
+        855000000U, 1, 6000, 4, RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK, 8, 1, &gain_profile);
+    uint32_t request_id = schedule_manual_retune_on_controller(&test_controller, 855000000U);
+    ControllerRetuneWork work = {};
+    if (!controller_wait_for_retune_work(&test_controller, &work) || !work.manual_pending) {
+        controller_cleanup(&test_controller);
+        return -2;
+    }
+
+    *out_gain_is_set = work.manual_profile.tuner_gain_is_set;
+    *out_gain_tenth_db = work.manual_profile.tuner_gain_tenth_db;
+    *out_gain_is_auto = work.manual_profile.tuner_gain_is_auto;
+    *out_autogain_is_set = work.manual_profile.tuner_autogain_is_set;
+    *out_autogain_on = work.manual_profile.tuner_autogain_on;
+
+    controller_cleanup(&test_controller);
+    if (work.manual_profile.request_id != request_id || work.manual_profile.target_freq_hz != 855000000U) {
         return -3;
     }
     return 0;

--- a/src/io/radio/rtl_stream_c.cpp
+++ b/src/io/radio/rtl_stream_c.cpp
@@ -38,6 +38,10 @@ void dsd_rtl_stream_prepare_retune_profile(int cqpsk_enable, int symbol_rate_hz,
 void dsd_rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz,
                                                       int levels, int channel_profile, int ted_sps,
                                                       int persist_ted_override);
+void dsd_rtl_stream_prepare_retune_profile_for_target_with_gain(uint32_t target_freq_hz, int cqpsk_enable,
+                                                                int symbol_rate_hz, int levels, int channel_profile,
+                                                                int ted_sps, int persist_ted_override,
+                                                                const rtl_stream_retune_gain_profile* gain_profile);
 void dsd_rtl_stream_apply_pending_retune_profile(void);
 void dsd_rtl_stream_apply_pending_retune_profile_for_target(uint32_t target_freq_hz);
 void dsd_rtl_stream_clear_pending_retune_profile(void);
@@ -112,6 +116,8 @@ int dsd_rtl_stream_test_retune_profile_request_binding(int* out_first_profile, i
 int dsd_rtl_stream_test_retune_profile_coalesced_no_profile(int* out_profile, uint32_t* out_profile_freq_hz,
                                                             uint32_t* out_manual_freq_hz, uint32_t* out_request_id,
                                                             uint32_t* out_coalesced_request_id);
+int dsd_rtl_stream_test_retune_profile_gain_binding(int* out_gain_is_set, int* out_gain_tenth_db, int* out_gain_is_auto,
+                                                    int* out_autogain_is_set, int* out_autogain_on);
 int dsd_rtl_stream_test_get_replay_state(rtl_stream_test_replay_state* out_state);
 int dsd_rtl_stream_test_steady_state_watermark_enabled(const char* audio_in_dev);
 #endif
@@ -307,6 +313,13 @@ rtl_stream_test_retune_profile_coalesced_no_profile(int* out_profile, uint32_t* 
 }
 
 extern "C" int
+rtl_stream_test_retune_profile_gain_binding(int* out_gain_is_set, int* out_gain_tenth_db, int* out_gain_is_auto,
+                                            int* out_autogain_is_set, int* out_autogain_on) {
+    return dsd_rtl_stream_test_retune_profile_gain_binding(out_gain_is_set, out_gain_tenth_db, out_gain_is_auto,
+                                                           out_autogain_is_set, out_autogain_on);
+}
+
+extern "C" int
 rtl_stream_test_get_replay_state(const RtlSdrContext* ctx, rtl_stream_test_replay_state* out_state) {
     if (!ctx || !ctx->stream || !out_state) {
         return -2;
@@ -409,6 +422,16 @@ rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int cqpsk_
                                              int channel_profile, int ted_sps, int persist_ted_override) {
     dsd_rtl_stream_prepare_retune_profile_for_target(target_freq_hz, cqpsk_enable, symbol_rate_hz, levels,
                                                      channel_profile, ted_sps, persist_ted_override);
+}
+
+extern "C" void
+rtl_stream_prepare_retune_profile_for_target_with_gain(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz,
+                                                       int levels, int channel_profile, int ted_sps,
+                                                       int persist_ted_override,
+                                                       const rtl_stream_retune_gain_profile* gain_profile) {
+    dsd_rtl_stream_prepare_retune_profile_for_target_with_gain(target_freq_hz, cqpsk_enable, symbol_rate_hz, levels,
+                                                               channel_profile, ted_sps, persist_ted_override,
+                                                               gain_profile);
 }
 
 extern "C" void

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1896,6 +1896,7 @@ if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
             "-Wl,--wrap=rtl_stream_get_ted_sps_override"
             "-Wl,--wrap=rtl_stream_output_rate"
             "-Wl,--wrap=rtl_stream_prepare_retune_profile_for_target"
+            "-Wl,--wrap=rtl_stream_prepare_retune_profile_for_target_with_gain"
             "-Wl,--wrap=rtl_stream_tune"
             ${LIBS}
             dsd-neo_feature_radio

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -145,6 +145,16 @@ __wrap_rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int
 }
 
 void
+__wrap_rtl_stream_prepare_retune_profile_for_target_with_gain(uint32_t target_freq_hz, int cqpsk_enable,
+                                                              int symbol_rate_hz, int levels, int channel_profile,
+                                                              int ted_sps, int persist_ted_override,
+                                                              const rtl_stream_retune_gain_profile* gain_profile) {
+    (void)gain_profile;
+    __wrap_rtl_stream_prepare_retune_profile_for_target(target_freq_hz, cqpsk_enable, symbol_rate_hz, levels,
+                                                        channel_profile, ted_sps, persist_ted_override);
+}
+
+void
 __wrap_rtl_stream_clear_pending_retune_profile(void) {
     g_pending_active = 0;
     g_pending_target_freq_hz = 0;

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -61,7 +61,19 @@ static int g_rtl_pending_symbol_levels = 0;
 static int g_rtl_pending_channel_profile = -1;
 static int g_rtl_pending_ted_sps = 0;
 static int g_rtl_pending_ted_override = 0;
+static int g_rtl_pending_tuner_gain_is_set = 0;
+static int g_rtl_pending_tuner_gain_tenth_db = 0;
+static int g_rtl_pending_tuner_gain_is_auto = 0;
+static int g_rtl_pending_tuner_autogain_is_set = 0;
+static int g_rtl_pending_tuner_autogain_on = 0;
 static uint32_t g_rtl_pending_target_freq_hz = 0;
+static size_t g_trunk_scan_target_count = 0;
+static int g_trunk_scan_saved_autogain_is_set = 0;
+static int g_trunk_scan_saved_autogain_on = 0;
+static int g_trunk_scan_active_p25_cqpsk_is_set = 0;
+static int g_trunk_scan_active_p25_cqpsk_enable = 0;
+static int g_runtime_config_is_set = 0;
+static dsdneoRuntimeConfig g_runtime_config;
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -93,6 +105,34 @@ void
 dsd_drain_audio_output(dsd_opts* opts) {
     (void)opts;
     g_drain_audio_calls++;
+}
+
+size_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_engine_trunk_scan_target_count(const dsd_state* state) {
+    (void)state;
+    return g_trunk_scan_target_count;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_engine_trunk_scan_saved_tuner_autogain(const dsd_state* state, int* out_on) {
+    (void)state;
+    if (out_on) {
+        *out_on = g_trunk_scan_saved_autogain_on;
+    }
+    return g_trunk_scan_saved_autogain_is_set;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_engine_trunk_scan_active_p25_cqpsk_request(const dsd_state* state, int* out_enable) {
+    (void)state;
+    if (!out_enable || !g_trunk_scan_active_p25_cqpsk_is_set) {
+        return 0;
+    }
+    *out_enable = g_trunk_scan_active_p25_cqpsk_enable ? 1 : 0;
+    return 1;
 }
 
 bool
@@ -197,16 +237,30 @@ rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profil
 }
 
 void
-rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz, int levels,
-                                             int channel_profile, int ted_sps, int persist_ted_override) {
+rtl_stream_prepare_retune_profile_for_target_with_gain(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz,
+                                                       int levels, int channel_profile, int ted_sps,
+                                                       int persist_ted_override,
+                                                       const rtl_stream_retune_gain_profile* gain_profile) {
     g_rtl_pending_cqpsk = cqpsk_enable;
     g_rtl_pending_symbol_rate_hz = symbol_rate_hz;
     g_rtl_pending_symbol_levels = levels;
     g_rtl_pending_channel_profile = channel_profile;
     g_rtl_pending_ted_sps = ted_sps;
     g_rtl_pending_ted_override = persist_ted_override ? 1 : 0;
+    g_rtl_pending_tuner_gain_is_set = gain_profile ? gain_profile->tuner_gain_is_set : 0;
+    g_rtl_pending_tuner_gain_tenth_db = gain_profile ? gain_profile->tuner_gain_tenth_db : 0;
+    g_rtl_pending_tuner_gain_is_auto = gain_profile ? gain_profile->tuner_gain_is_auto : 0;
+    g_rtl_pending_tuner_autogain_is_set = gain_profile ? gain_profile->tuner_autogain_is_set : 0;
+    g_rtl_pending_tuner_autogain_on = gain_profile ? gain_profile->tuner_autogain_on : 0;
     g_rtl_pending_target_freq_hz = target_freq_hz;
     g_rtl_pending_active = 1;
+}
+
+void
+rtl_stream_prepare_retune_profile_for_target(uint32_t target_freq_hz, int cqpsk_enable, int symbol_rate_hz, int levels,
+                                             int channel_profile, int ted_sps, int persist_ted_override) {
+    rtl_stream_prepare_retune_profile_for_target_with_gain(target_freq_hz, cqpsk_enable, symbol_rate_hz, levels,
+                                                           channel_profile, ted_sps, persist_ted_override, NULL);
 }
 
 void
@@ -230,6 +284,11 @@ void
 rtl_stream_clear_pending_retune_profile(void) {
     g_rtl_pending_active = 0;
     g_rtl_pending_target_freq_hz = 0;
+    g_rtl_pending_tuner_gain_is_set = 0;
+    g_rtl_pending_tuner_gain_tenth_db = 0;
+    g_rtl_pending_tuner_gain_is_auto = 0;
+    g_rtl_pending_tuner_autogain_is_set = 0;
+    g_rtl_pending_tuner_autogain_on = 0;
 }
 
 int
@@ -270,7 +329,7 @@ dsd_neo_config_init(const dsd_opts* opts) {
 
 const dsdneoRuntimeConfig*
 dsd_neo_get_config(void) {
-    return NULL;
+    return g_runtime_config_is_set ? &g_runtime_config : NULL;
 }
 
 int
@@ -471,6 +530,53 @@ main(void) {
     assert(g_rtl_ted_sps == 10);
     assert(g_rtl_ted_sps_override == 0);
 
+    /* Trunk-scan RTL retunes queue the active target/global gain with the
+     * demod profile so gain changes happen at the retune boundary. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_enable = 1;
+    opts->trunk_scan_enabled = 1;
+    opts->rtl_gain_value = 27;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 2;
+    g_trunk_scan_target_count = 2;
+    g_trunk_scan_saved_autogain_is_set = 1;
+    g_trunk_scan_saved_autogain_on = 1;
+    g_rtl_tune_result = RTL_STREAM_TUNE_TIMEOUT;
+    rtl_stream_clear_pending_retune_profile();
+    assert(dsd_engine_trunk_tune_to_cc(opts, state, 453000000, 10) == DSD_TRUNK_TUNE_RESULT_PENDING);
+    assert(g_rtl_pending_active == 1);
+    assert(g_rtl_pending_tuner_gain_is_set == 1);
+    assert(g_rtl_pending_tuner_gain_tenth_db == 270);
+    assert(g_rtl_pending_tuner_gain_is_auto == 0);
+    assert(g_rtl_pending_tuner_autogain_is_set == 1);
+    assert(g_rtl_pending_tuner_autogain_on == 0);
+
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_enable = 1;
+    opts->trunk_scan_enabled = 1;
+    opts->rtl_gain_value = 0;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 2;
+    g_trunk_scan_target_count = 2;
+    g_trunk_scan_saved_autogain_is_set = 1;
+    g_trunk_scan_saved_autogain_on = 1;
+    g_rtl_tune_result = RTL_STREAM_TUNE_TIMEOUT;
+    rtl_stream_clear_pending_retune_profile();
+    assert(dsd_engine_trunk_tune_to_cc(opts, state, 453500000, 10) == DSD_TRUNK_TUNE_RESULT_PENDING);
+    assert(g_rtl_pending_active == 1);
+    assert(g_rtl_pending_tuner_gain_is_set == 1);
+    assert(g_rtl_pending_tuner_gain_is_auto == 1);
+    assert(g_rtl_pending_tuner_autogain_is_set == 1);
+    assert(g_rtl_pending_tuner_autogain_on == 1);
+    g_trunk_scan_target_count = 0;
+    g_trunk_scan_saved_autogain_is_set = 0;
+    g_trunk_scan_saved_autogain_on = 0;
+    rtl_stream_clear_pending_retune_profile();
+
     /* Deferred RTL voice retunes must roll back the demod profile/TED changes
      * prepared for the requested channel. */
     DSD_MEMSET(opts, 0, sizeof(*opts));
@@ -577,6 +683,115 @@ main(void) {
     assert(g_rtl_pending_ted_sps == 4);
     assert(g_rtl_pending_ted_override == 0);
     assert(g_frame_sync_reset_calls == 1);
+
+    /* Empty trunk-scan modulation preserves the explicit runtime CQPSK mode. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(&g_runtime_config, 0, sizeof(g_runtime_config));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_scan_enabled = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 0;
+    state->p25_cc_is_tdma = 0;
+    g_runtime_config_is_set = 1;
+    g_runtime_config.cqpsk_is_set = 1;
+    g_runtime_config.cqpsk_enable = 1;
+    g_trunk_scan_active_p25_cqpsk_is_set = 0;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_cqpsk_enable = 1;
+    g_rtl_symbol_rate_hz = 6000;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_trunk_tune_to_cc(opts, state, 852250000, 5) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_rtl_cqpsk_enable == 1);
+
+    /* Explicit target C4FM overrides a globally forced CQPSK runtime mode. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_scan_enabled = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 0;
+    state->p25_cc_is_tdma = 0;
+    g_runtime_config_is_set = 1;
+    g_runtime_config.cqpsk_is_set = 1;
+    g_runtime_config.cqpsk_enable = 1;
+    g_trunk_scan_active_p25_cqpsk_is_set = 1;
+    g_trunk_scan_active_p25_cqpsk_enable = 0;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_cqpsk_enable = 1;
+    g_rtl_symbol_rate_hz = 6000;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_trunk_tune_to_cc(opts, state, 852500000, 5) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(state->rf_mod == 0);
+    assert(g_rtl_cqpsk_enable == 0);
+    assert(g_rtl_symbol_rate_hz == 4800);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
+
+    /* Target modulation overrides must also apply to P25P2 voice retunes.
+     * A C4FM/auto CC target can still grant TDMA voice, which must switch the
+     * RTL demod chain to CQPSK even when runtime config explicitly set CQPSK. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(&g_runtime_config, 0, sizeof(g_runtime_config));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_scan_enabled = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 1;
+    state->p25_p2_active_slot = 0;
+    state->p25_vc_cqpsk_pref = -1;
+    state->p25_vc_cqpsk_override = -1;
+    g_runtime_config_is_set = 1;
+    g_runtime_config.cqpsk_is_set = 1;
+    g_runtime_config.cqpsk_enable = 1;
+    g_trunk_scan_active_p25_cqpsk_is_set = 1;
+    g_trunk_scan_active_p25_cqpsk_enable = 0;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_cqpsk_enable = 0;
+    g_rtl_symbol_rate_hz = 4800;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_trunk_tune_to_freq(opts, state, 853000000, 8) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_rtl_pending_active == 0);
+    assert(g_rtl_cqpsk_enable == 1);
+    assert(g_rtl_symbol_rate_hz == 6000);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+
+    /* Explicit target CQPSK overrides a globally disabled CQPSK runtime mode. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(&g_runtime_config, 0, sizeof(g_runtime_config));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->trunk_scan_enabled = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 0;
+    state->p25_cc_is_tdma = 0;
+    g_runtime_config_is_set = 1;
+    g_runtime_config.cqpsk_is_set = 1;
+    g_runtime_config.cqpsk_enable = 0;
+    g_trunk_scan_active_p25_cqpsk_is_set = 1;
+    g_trunk_scan_active_p25_cqpsk_enable = 1;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_cqpsk_enable = 0;
+    g_rtl_symbol_rate_hz = 4800;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_trunk_tune_to_cc(opts, state, 852750000, 5) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(state->rf_mod == 1);
+    assert(g_rtl_cqpsk_enable == 1);
+    assert(g_rtl_symbol_rate_hz == 4800);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    g_runtime_config_is_set = 0;
+    g_trunk_scan_active_p25_cqpsk_is_set = 0;
 
     /* Simulcast P25P2 voice return to a P25P1 CQPSK control channel applies
      * the 4800 sps CQPSK profile only after the RTL retune succeeds. */

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -11,6 +11,7 @@
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/engine/trunk_scan.h>
 #include <dsd-neo/engine/trunk_tuning.h>
+#include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
@@ -45,6 +46,11 @@ static unsigned int g_fake_rtl_output_rate_hz = 0;
 static unsigned int
 fake_rtl_output_rate_hz(void) {
     return g_fake_rtl_output_rate_hz;
+}
+
+int
+rtl_stream_get_tuner_autogain(void) {
+    return 1;
 }
 
 static int
@@ -231,16 +237,21 @@ make_temp_dir(char* dir, size_t dir_sz) {
 }
 
 static int
-write_targets_file(const char* dir, const char* body, char* out_path, size_t out_sz) {
+write_targets_file_with_header(const char* dir, const char* header, const char* body, char* out_path, size_t out_sz) {
     if (dsd_test_path_join(out_path, out_sz, dir, "targets.csv") != 0) {
         return -1;
     }
     char content[8192];
-    int n = DSD_SNPRINTF(content, sizeof content, "%s%s", k_header, body);
+    int n = DSD_SNPRINTF(content, sizeof content, "%s%s", header, body);
     if (n < 0 || (size_t)n >= sizeof content) {
         return -1;
     }
     return write_text_file(out_path, content);
+}
+
+static int
+write_targets_file(const char* dir, const char* body, char* out_path, size_t out_sz) {
+    return write_targets_file_with_header(dir, k_header, body, out_path, out_sz);
 }
 
 static void
@@ -366,6 +377,60 @@ test_parser_accepts_quoted_chan_csv_with_comma(void) {
 }
 
 static int
+test_parser_accepts_optional_modulation_and_gain_columns(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,rtl_gain,modulation\n";
+    if (write_targets_file_with_header(dir, header,
+                                       "p25,p25-trunk,851000000,,250,,primary,27,cqpsk\n"
+                                       "dmr,dmr-trunk,452000000,,250,,tier iii,auto,gfsk\n"
+                                       "plain,dmr-conventional,461000000,,250,,legacy row\n",
+                                       target_path, sizeof target_path)
+        != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.trunk_scan_idle_dwell_ms = 3000;
+    opts.trunk_scan_activity_hold_ms = 1200;
+    dsd_trunk_scan_target_list list;
+    char err[256] = {0};
+    int rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
+
+    int test_rc = 0;
+    if (rc != 0 || list.count != 3) {
+        DSD_FPRINTF(stderr, "optional parser rc=%d count=%zu err=%s\n", rc, list.count, err);
+        test_rc = 1;
+    }
+    if (test_rc == 0) {
+        if (list.targets[0].modulation != DSD_TRUNK_SCAN_MODULATION_CQPSK || list.targets[0].rtl_gain_is_set != 1
+            || list.targets[0].rtl_gain_db != 27) {
+            DSD_FPRINTF(stderr, "optional parser P25 fields mismatch mod=%d gain_set=%d gain=%d\n",
+                        list.targets[0].modulation, list.targets[0].rtl_gain_is_set, list.targets[0].rtl_gain_db);
+            test_rc = 1;
+        }
+        if (list.targets[1].modulation != DSD_TRUNK_SCAN_MODULATION_GFSK || list.targets[1].rtl_gain_is_set != 1
+            || list.targets[1].rtl_gain_db != 0) {
+            DSD_FPRINTF(stderr, "optional parser DMR fields mismatch mod=%d gain_set=%d gain=%d\n",
+                        list.targets[1].modulation, list.targets[1].rtl_gain_is_set, list.targets[1].rtl_gain_db);
+            test_rc = 1;
+        }
+        if (list.targets[2].modulation != DSD_TRUNK_SCAN_MODULATION_UNSET || list.targets[2].rtl_gain_is_set != 0) {
+            DSD_FPRINTF(stderr, "optional parser missing fields not treated as empty\n");
+            test_rc = 1;
+        }
+    }
+
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
 expect_parser_rejects(const char* name, const char* body) {
     char dir[DSD_TEST_PATH_MAX];
     if (make_temp_dir(dir, sizeof dir) != 0) {
@@ -402,6 +467,36 @@ expect_parser_rejects(const char* name, const char* body) {
 }
 
 static int
+expect_parser_rejects_with_header(const char* name, const char* header, const char* body) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    if (write_targets_file_with_header(dir, header, body, target_path, sizeof target_path) != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.trunk_scan_idle_dwell_ms = 3000;
+    opts.trunk_scan_activity_hold_ms = 1200;
+    dsd_trunk_scan_target_list list;
+    DSD_MEMSET(&list, 0, sizeof list);
+    char err[256] = {0};
+    int rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
+    int test_rc = 0;
+    if (rc == 0) {
+        DSD_FPRINTF(stderr, "%s should have been rejected\n", name);
+        test_rc = 1;
+    }
+
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
 test_parser_rejects_invalid_inputs(void) {
     int rc = 0;
     rc |= expect_parser_rejects("duplicate-id", "a,p25-trunk,851000000,,,,\n"
@@ -415,6 +510,19 @@ test_parser_rejects_invalid_inputs(void) {
 #endif
     rc |= expect_parser_rejects("invalid-dwell", "a,p25-trunk,851000000,,249,,\n");
     rc |= expect_parser_rejects("conventional-chan-csv", "a,dmr-conventional,461000000,chan.csv,,,\n");
+    rc |= expect_parser_rejects_with_header(
+        "duplicate-modulation-header",
+        "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,modulation\n",
+        "a,p25-trunk,851000000,,,,,auto,c4fm\n");
+    rc |= expect_parser_rejects_with_header(
+        "invalid-modulation", "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation\n",
+        "a,p25-trunk,851000000,,,,,wide\n");
+    rc |= expect_parser_rejects_with_header(
+        "unsupported-modulation", "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation\n",
+        "a,dmr-trunk,452000000,,,,,cqpsk\n");
+    rc |= expect_parser_rejects_with_header("invalid-rtl-gain",
+                                            "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,rtl_gain\n",
+                                            "a,p25-trunk,851000000,,,,,50\n");
     return rc;
 }
 
@@ -1942,6 +2050,203 @@ test_locked_demod_mode_preserved_when_seeding_targets(void) {
 }
 
 static int
+test_per_target_modulation_overrides_global_lock(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation\n";
+    if (make_temp_dir(dir, sizeof dir) != 0
+        || write_targets_file_with_header(dir, header,
+                                          "p25,p25-trunk,851000000,,250,,P25 auto,auto\n"
+                                          "dmr,dmr-trunk,452000000,,250,,DMR forced,gfsk\n",
+                                          target_path, sizeof target_path)
+               != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    opts.mod_cli_lock = 1;
+    opts.mod_qpsk = 1;
+    opts.mod_c4fm = 0;
+    opts.mod_gfsk = 0;
+    state.rf_mod = 1;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    dsd_engine_trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0 || state.rf_mod != 0 || opts.mod_cli_lock != 0) {
+        DSD_FPRINTF(stderr, "target auto modulation did not override global lock rc=%d active=%zu rf_mod=%d lock=%d\n",
+                    rc, dsd_engine_trunk_scan_active_index(&state), state.rf_mod, opts.mod_cli_lock);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1 || state.rf_mod != 2 || opts.mod_gfsk != 1
+        || opts.mod_cli_lock != 1) {
+        DSD_FPRINTF(stderr, "target GFSK modulation did not apply active=%zu rf_mod=%d gfsk=%d lock=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), state.rf_mod, opts.mod_gfsk, opts.mod_cli_lock);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    if (opts.mod_cli_lock != 1 || opts.mod_qpsk != 1 || opts.mod_gfsk != 0) {
+        DSD_FPRINTF(stderr, "shutdown did not restore saved modulation opts lock=%d qpsk=%d gfsk=%d\n",
+                    opts.mod_cli_lock, opts.mod_qpsk, opts.mod_gfsk);
+        test_rc = 1;
+    }
+    dsd_engine_trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_active_p25_cqpsk_request_tracks_target_modulation(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation\n";
+    if (make_temp_dir(dir, sizeof dir) != 0
+        || write_targets_file_with_header(dir, header,
+                                          "c4fm,p25-trunk,851000000,,250,,C4FM,c4fm\n"
+                                          "cqpsk,p25-trunk,852000000,,250,,CQPSK,cqpsk\n"
+                                          "auto,p25-trunk,853000000,,250,,Auto,auto\n"
+                                          "dmr,dmr-trunk,454000000,,250,,DMR,gfsk\n",
+                                          target_path, sizeof target_path)
+               != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_cc_result = counting_tune_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+    g_counting_tune_to_cc_calls = 0;
+    g_counting_tune_to_cc_failures_remaining = 0;
+
+    char err[256] = {0};
+    dsd_engine_trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    int cqpsk_enable = -1;
+    if (rc != 0 || !dsd_engine_trunk_scan_active_p25_cqpsk_request(&state, &cqpsk_enable) || cqpsk_enable != 0) {
+        DSD_FPRINTF(stderr, "active C4FM target did not request CQPSK off rc=%d active=%zu enable=%d err=%s\n", rc,
+                    dsd_engine_trunk_scan_active_index(&state), cqpsk_enable, err);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    cqpsk_enable = -1;
+    if (dsd_engine_trunk_scan_active_index(&state) != 1
+        || !dsd_engine_trunk_scan_active_p25_cqpsk_request(&state, &cqpsk_enable) || cqpsk_enable != 1) {
+        DSD_FPRINTF(stderr, "active CQPSK target did not request CQPSK on active=%zu enable=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), cqpsk_enable);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    state.p25_cc_is_tdma = 0;
+    cqpsk_enable = -1;
+    if (dsd_engine_trunk_scan_active_index(&state) != 2
+        || !dsd_engine_trunk_scan_active_p25_cqpsk_request(&state, &cqpsk_enable) || cqpsk_enable != 0) {
+        DSD_FPRINTF(stderr, "active auto P25 target did not request FDMA default active=%zu enable=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), cqpsk_enable);
+        test_rc = 1;
+    }
+    state.p25_cc_is_tdma = 1;
+    cqpsk_enable = -1;
+    if (!dsd_engine_trunk_scan_active_p25_cqpsk_request(&state, &cqpsk_enable) || cqpsk_enable != 1) {
+        DSD_FPRINTF(stderr, "active auto P25 target did not request TDMA default enable=%d\n", cqpsk_enable);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(0.78);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    cqpsk_enable = -1;
+    if (dsd_engine_trunk_scan_active_index(&state) != 3
+        || dsd_engine_trunk_scan_active_p25_cqpsk_request(&state, &cqpsk_enable) || cqpsk_enable != -1) {
+        DSD_FPRINTF(stderr, "active DMR target unexpectedly returned a P25 CQPSK request active=%zu enable=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), cqpsk_enable);
+        test_rc = 1;
+    }
+
+    DSD_MEMSET(&hooks, 0, sizeof hooks);
+    dsd_trunk_tuning_hooks_set(hooks);
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_engine_trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_per_target_rtl_gain_overrides_and_restores_global_default(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,rtl_gain\n";
+    if (make_temp_dir(dir, sizeof dir) != 0
+        || write_targets_file_with_header(dir, header,
+                                          "strong,p25-trunk,851000000,,250,,strong,10\n"
+                                          "default,dmr-trunk,452000000,,250,,default\n"
+                                          "auto,dmr-conventional,461000000,,250,,auto,auto\n",
+                                          target_path, sizeof target_path)
+               != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    opts.rtl_gain_value = 22;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    dsd_engine_trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0 || opts.rtl_gain_value != 10) {
+        DSD_FPRINTF(stderr, "target gain init mismatch rc=%d active=%zu gain=%d err=%s\n", rc,
+                    dsd_engine_trunk_scan_active_index(&state), opts.rtl_gain_value, err);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1 || opts.rtl_gain_value != 22) {
+        DSD_FPRINTF(stderr, "empty target did not restore global gain active=%zu gain=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), opts.rtl_gain_value);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 2 || opts.rtl_gain_value != 0) {
+        DSD_FPRINTF(stderr, "auto target did not request autogain active=%zu gain=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), opts.rtl_gain_value);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    if (opts.rtl_gain_value != 22) {
+        DSD_FPRINTF(stderr, "shutdown did not restore global gain=%d\n", opts.rtl_gain_value);
+        test_rc = 1;
+    }
+    dsd_engine_trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
 test_scan_tick_skips_rotation_when_p25_guard_busy(void) {
     char dir[DSD_TEST_PATH_MAX];
     char target_path[DSD_TEST_PATH_MAX];
@@ -2384,6 +2689,7 @@ main(void) {
     int rc = 0;
     rc |= test_parser_valid_mixed_targets_and_relative_chan_csv();
     rc |= test_parser_accepts_quoted_chan_csv_with_comma();
+    rc |= test_parser_accepts_optional_modulation_and_gain_columns();
     rc |= test_parser_rejects_invalid_inputs();
     rc |= test_parser_rejects_too_many_targets();
     rc |= test_coordinator_idle_rotation_and_state_restore();
@@ -2406,6 +2712,9 @@ main(void) {
     rc |= test_p25_retune_backoff_state_isolated_per_target();
     rc |= test_trunk_targets_reuse_restored_control_channel();
     rc |= test_locked_demod_mode_preserved_when_seeding_targets();
+    rc |= test_per_target_modulation_overrides_global_lock();
+    rc |= test_active_p25_cqpsk_request_tracks_target_modulation();
+    rc |= test_per_target_rtl_gain_overrides_and_restores_global_default();
     rc |= test_scan_tick_skips_rotation_when_p25_guard_busy();
     rc |= test_single_target_retune_failure_retries_after_cooldown();
     rc |= test_retune_failure_cooldown();

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -183,6 +183,20 @@ main(void) {
     failed |= expect_int_eq("coalesced no-profile retune returns coalesced request id",
                             (int)coalesced_returned_request_id, 1);
 
+    int gain_is_set = -1;
+    int gain_tenth_db = -1;
+    int gain_is_auto = -1;
+    int autogain_is_set = -1;
+    int autogain_on = -1;
+    rc = rtl_stream_test_retune_profile_gain_binding(&gain_is_set, &gain_tenth_db, &gain_is_auto, &autogain_is_set,
+                                                     &autogain_on);
+    failed |= expect_int_eq("retune gain profile helper rc", rc, 0);
+    failed |= expect_int_eq("retune gain profile keeps gain-is-set", gain_is_set, 1);
+    failed |= expect_int_eq("retune gain profile keeps manual gain", gain_tenth_db, 270);
+    failed |= expect_int_eq("retune gain profile keeps manual mode", gain_is_auto, 0);
+    failed |= expect_int_eq("retune gain profile keeps autogain-is-set", autogain_is_set, 1);
+    failed |= expect_int_eq("retune gain profile keeps autogain off", autogain_on, 0);
+
     int settings_seen = -1;
     failed |= expect_int_eq("legacy Soapy config settings visibility helper",
                             rtl_device_test_soapy_config_settings_visibility(RTL_SOAPY_CONFIG_LEGACY_SIZE,


### PR DESCRIPTION
## Summary

- Add optional trunk-scan target CSV columns for per-target `modulation` and `rtl_gain` overrides.
- Apply per-target modulation and RTL gain/autogain settings at trunk scan retune boundaries while preserving global defaults for targets without overrides.
- Update trunk scan CSV docs, CLI docs, examples, and regression tests for parsing, validation, and retune gain propagation.

Closes #179.

## Validation

- `tools/format.sh`
- `tools/cmake_format_check.sh`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure` passed, 400/400
- `cmake --build --preset asan-ubsan-debug -j`
- `ctest --preset asan-ubsan-debug --output-on-failure` passed, 400/400
- `tools/preflight_ci.sh`
- `tools/quality_preflight.sh`
- Push hook preflight passed; scan-build full rebuild was skipped there because `DSD_HOOK_RUN_SCAN_BUILD=1` was not set, but `tools/quality_preflight.sh` ran scan-build separately and reported 0 bugs.