### PR TITLE
io: retry verified RTL-SDR control applies

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -324,6 +324,8 @@ Advanced (env)
 - `DSD_NEO_RTL_XTAL_HZ` / `DSD_NEO_TUNER_XTAL_HZ` — Override crystal refs in Hz (optional).
 - `DSD_NEO_RTL_IF_GAINS="stage:gain[,stage:gain]..."` — Set IF gain(s); gain in dB (e.g., `10`) or 0.1 dB (`125`).
 - `DSD_NEO_RTL_TESTMODE=0|1` — Enable librtlsdr test mode (ramp) instead of I/Q (for diagnostics).
+- `DSD_NEO_RTL_VERIFY=0|1` — Retry and verify local USB RTL-SDR control applies (default on).
+- `DSD_NEO_RTL_VERIFY_ATTEMPTS=1..10` — Total local USB apply attempts when verification is enabled (default 10).
 - On rtl_tcp reconnects, these settings are automatically reapplied.
 
 ## SoapySDR details (`-i soapy`)
@@ -506,6 +508,7 @@ RTL‑SDR driver options
 - `DSD_NEO_RTL_IF_GAINS="stage:gain[,...]"` — IF stage gains (dB or 0.1 dB)
 - `DSD_NEO_RTL_TESTMODE=0|1` — test mode (ramp source)
 - `DSD_NEO_RTL_AGC=0|1` — RTL2832U AGC enable/disable (default on)
+- `DSD_NEO_RTL_VERIFY=0|1`, `DSD_NEO_RTL_VERIFY_ATTEMPTS=1..10` — local USB apply verification/retry controls
 - `DSD_NEO_TUNER_BW_HZ=<Hz|auto>` — override tuner bandwidth (`auto` or `0` = driver automatic)
 
 Tuner autogain (experimental)

--- a/include/dsd-neo/runtime/config.h
+++ b/include/dsd-neo/runtime/config.h
@@ -386,6 +386,10 @@ typedef struct dsdneoRuntimeConfig {
     int rtl_testmode_is_set;
     int rtl_testmode_enable;
     int rtl_if_gains_is_set;
+    int rtl_verify_is_set;
+    int rtl_verify_enable;
+    int rtl_verify_attempts_is_set;
+    int rtl_verify_attempts;
     int tuner_bw_hz_is_set;
     int tuner_bw_hz; /* 0=auto */
 

--- a/include/dsd-neo/runtime/exitflag.h
+++ b/include/dsd-neo/runtime/exitflag.h
@@ -23,6 +23,24 @@ extern "C" {
 
 extern volatile uint8_t exitflag;
 
+static inline uint8_t
+dsd_exitflag_load(void) {
+#if defined(__GNUC__) || defined(__clang__)
+    return __atomic_load_n(&exitflag, __ATOMIC_ACQUIRE);
+#else
+    return exitflag;
+#endif
+}
+
+static inline void
+dsd_exitflag_store(uint8_t value) {
+#if defined(__GNUC__) || defined(__clang__)
+    __atomic_store_n(&exitflag, value, __ATOMIC_RELEASE);
+#else
+    exitflag = value;
+#endif
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -3980,7 +3980,25 @@ rtl_usb_verify_manual_gain(void* opaque) {
 struct rtl_usb_auto_gain_apply_ctx {
     rtlsdr_dev_t* dev;
     int agc_want;
+    int agc_rc;
 };
+
+static int
+rtl_usb_apply_auto_gain_controls(void* dev, int agc_want, int* out_agc_rc, rtl_usb_int_control_fn set_gain_mode,
+                                 rtl_usb_int_control_fn set_agc_mode) {
+    if (!dev || !set_gain_mode || !set_agc_mode) {
+        return -1;
+    }
+    int r = set_gain_mode(dev, 0);
+    if (r != 0) {
+        return r;
+    }
+    int agc_rc = set_agc_mode(dev, agc_want);
+    if (agc_rc != 0 && out_agc_rc && *out_agc_rc == 0) {
+        *out_agc_rc = agc_rc;
+    }
+    return 0;
+}
 
 static int
 rtl_usb_apply_auto_gain(void* opaque) {
@@ -3988,11 +4006,8 @@ rtl_usb_apply_auto_gain(void* opaque) {
     if (!ctx || !ctx->dev) {
         return -1;
     }
-    int r = rtlsdr_set_tuner_gain_mode(ctx->dev, 0);
-    if (r != 0) {
-        return r;
-    }
-    return rtlsdr_set_agc_mode(ctx->dev, ctx->agc_want);
+    return rtl_usb_apply_auto_gain_controls(ctx->dev, ctx->agc_want, &ctx->agc_rc, rtl_usb_set_tuner_gain_mode_control,
+                                            rtl_usb_set_agc_mode_control);
 }
 
 struct rtl_usb_int_apply_ctx {
@@ -4105,6 +4120,35 @@ rtl_usb_manual_gain_test_gain(void* opaque, int value) {
     return ctx->gain_rc;
 }
 
+struct rtl_usb_auto_gain_test_ctx {
+    int agc_rc;
+    int gain_mode_rc;
+    int agc_calls;
+    int gain_mode_calls;
+};
+
+static int
+rtl_usb_auto_gain_test_agc(void* opaque, int value) {
+    UNUSED(value);
+    rtl_usb_auto_gain_test_ctx* ctx = static_cast<rtl_usb_auto_gain_test_ctx*>(opaque);
+    if (!ctx) {
+        return -1;
+    }
+    ctx->agc_calls++;
+    return ctx->agc_rc;
+}
+
+static int
+rtl_usb_auto_gain_test_mode(void* opaque, int value) {
+    UNUSED(value);
+    rtl_usb_auto_gain_test_ctx* ctx = static_cast<rtl_usb_auto_gain_test_ctx*>(opaque);
+    if (!ctx) {
+        return -1;
+    }
+    ctx->gain_mode_calls++;
+    return ctx->gain_mode_rc;
+}
+
 } // namespace
 
 extern "C" int
@@ -4145,6 +4189,24 @@ rtl_device_test_usb_manual_gain_controls(int agc_rc, int gain_mode_rc, int gain_
     *out_agc_calls = ctx.agc_calls;
     *out_gain_mode_calls = ctx.gain_mode_calls;
     *out_gain_calls = ctx.gain_calls;
+    *out_recorded_agc_rc = recorded_agc_rc;
+    return rc;
+}
+
+extern "C" int
+rtl_device_test_usb_auto_gain_controls(int agc_rc, int gain_mode_rc, int* out_agc_calls, int* out_gain_mode_calls,
+                                       int* out_recorded_agc_rc) {
+    if (!out_agc_calls || !out_gain_mode_calls || !out_recorded_agc_rc) {
+        return -100;
+    }
+    rtl_usb_auto_gain_test_ctx ctx{};
+    ctx.agc_rc = agc_rc;
+    ctx.gain_mode_rc = gain_mode_rc;
+    int recorded_agc_rc = 0;
+    int rc = rtl_usb_apply_auto_gain_controls(&ctx, 1, &recorded_agc_rc, rtl_usb_auto_gain_test_mode,
+                                              rtl_usb_auto_gain_test_agc);
+    *out_agc_calls = ctx.agc_calls;
+    *out_gain_mode_calls = ctx.gain_mode_calls;
     *out_recorded_agc_rc = recorded_agc_rc;
     return rc;
 }
@@ -4304,16 +4366,20 @@ verbose_auto_gain(rtlsdr_dev_t* dev) {
     /* Original plan: enable RTL digital AGC in auto mode by default.
        Allow override via env DSD_NEO_RTL_AGC=0 to disable. */
     int want = env_agc_want();
-    rtl_usb_auto_gain_apply_ctx ctx{dev, want};
+    rtl_usb_auto_gain_apply_ctx ctx{dev, want, 0};
     int attempts = 0;
     int r = rtl_usb_apply_with_runtime_retry(rtl_usb_apply_auto_gain, NULL, &ctx, &attempts);
     if (r != 0) {
-        DSD_FPRINTF(stderr, "WARNING: Failed to set automatic tuner gain or %s RTL AGC.\n",
-                    want ? "enable" : "disable");
+        DSD_FPRINTF(stderr, "WARNING: Failed to set automatic tuner gain.\n");
     } else {
         rtl_usb_log_retry_attempts("automatic gain apply", attempts);
         DSD_FPRINTF(stderr, "Tuner gain set to automatic.\n");
-        DSD_FPRINTF(stderr, "RTL AGC %s.\n", want ? "enabled" : "disabled");
+        if (ctx.agc_rc != 0) {
+            DSD_FPRINTF(stderr, "WARNING: Failed to %s RTL AGC for automatic gain (rc=%d); continuing.\n",
+                        want ? "enable" : "disable", ctx.agc_rc);
+        } else {
+            DSD_FPRINTF(stderr, "RTL AGC %s.\n", want ? "enabled" : "disabled");
+        }
     }
     return r;
 }

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -3899,11 +3899,8 @@ struct rtl_usb_sample_rate_apply_ctx {
 };
 
 static int
-rtl_usb_sample_rate_readback_matches(uint32_t requested_rate, uint32_t actual_rate) {
-    if (requested_rate == 0U || actual_rate == 0U) {
-        return 0;
-    }
-    return actual_rate == requested_rate;
+rtl_usb_sample_rate_readback_is_usable(uint32_t actual_rate) {
+    return actual_rate != 0U;
 }
 
 static int
@@ -3919,10 +3916,7 @@ rtl_usb_verify_sample_rate(void* opaque) {
         return -1;
     }
     uint32_t actual = rtlsdr_get_sample_rate(ctx->dev);
-    if (actual == 0U) {
-        return -1;
-    }
-    if (!rtl_usb_sample_rate_readback_matches(ctx->requested_rate, actual)) {
+    if (!rtl_usb_sample_rate_readback_is_usable(actual)) {
         return -1;
     }
     ctx->actual_rate = actual;
@@ -4189,8 +4183,9 @@ rtl_device_test_usb_sample_rate_readback(uint32_t requested_rate, uint32_t actua
     if (!out_actual_rate) {
         return -100;
     }
+    UNUSED(requested_rate);
     *out_actual_rate = 0U;
-    if (!rtl_usb_sample_rate_readback_matches(requested_rate, actual_rate)) {
+    if (!rtl_usb_sample_rate_readback_is_usable(actual_rate)) {
         return -1;
     }
     *out_actual_rate = actual_rate;

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -203,6 +203,12 @@ rtlsdr_set_center_freq(rtlsdr_dev_t* dev, uint32_t freq) {
     return rtlsdr_stub_status();
 }
 
+static uint32_t
+rtlsdr_get_center_freq(rtlsdr_dev_t* dev) {
+    (void)dev;
+    return (uint32_t)rtlsdr_stub_status();
+}
+
 static int
 rtlsdr_set_sample_rate(rtlsdr_dev_t* dev, uint32_t rate) {
     (void)dev;
@@ -3758,13 +3764,8 @@ static DSD_THREAD_RETURN_TYPE
  */
 static int
 nearest_gain(rtlsdr_dev_t* dev, int target_gain) {
-    int i, r, count, nearest;
+    int i, count, nearest;
     int* gains;
-    r = rtlsdr_set_tuner_gain_mode(dev, 1);
-    if (r < 0) {
-        DSD_FPRINTF(stderr, "WARNING: Failed to enable manual gain.\n");
-        return r;
-    }
     count = rtlsdr_get_tuner_gains(dev, NULL);
     if (count <= 0) {
         return 0;
@@ -3790,6 +3791,367 @@ nearest_gain(rtlsdr_dev_t* dev, int target_gain) {
     return nearest;
 }
 
+namespace {
+
+struct rtl_usb_apply_policy {
+    int verify_enabled;
+    int attempts;
+};
+
+typedef int (*rtl_usb_apply_fn)(void* ctx);
+typedef int (*rtl_usb_verify_fn)(void* ctx);
+
+static struct rtl_usb_apply_policy
+rtl_usb_apply_policy_from_runtime(void) {
+    const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
+    struct rtl_usb_apply_policy policy{};
+    policy.verify_enabled = (!cfg || cfg->rtl_verify_enable) ? 1 : 0;
+    policy.attempts = cfg ? cfg->rtl_verify_attempts : 10;
+    if (policy.attempts < 1) {
+        policy.attempts = 1;
+    }
+    if (policy.attempts > 10) {
+        policy.attempts = 10;
+    }
+    if (!policy.verify_enabled) {
+        policy.attempts = 1;
+    }
+    return policy;
+}
+
+static int
+rtl_usb_apply_with_retry(const struct rtl_usb_apply_policy* policy, rtl_usb_apply_fn apply, rtl_usb_verify_fn verify,
+                         void* ctx, int* out_attempts) {
+    if (!policy || !apply) {
+        return -1;
+    }
+    int attempts = policy->attempts;
+    if (attempts < 1) {
+        attempts = 1;
+    }
+    if (attempts > 10) {
+        attempts = 10;
+    }
+    if (!policy->verify_enabled) {
+        attempts = 1;
+    }
+
+    int last_rc = -1;
+    int used_attempts = 0;
+    for (int i = 0; i < attempts; i++) {
+        used_attempts = i + 1;
+        last_rc = apply(ctx);
+        if (last_rc != 0) {
+            continue;
+        }
+        if (!policy->verify_enabled || !verify || verify(ctx) == 0) {
+            if (out_attempts) {
+                *out_attempts = used_attempts;
+            }
+            return 0;
+        }
+        last_rc = -1;
+    }
+
+    if (out_attempts) {
+        *out_attempts = used_attempts;
+    }
+    return (last_rc < 0) ? last_rc : -1;
+}
+
+static int
+rtl_usb_apply_with_runtime_retry(rtl_usb_apply_fn apply, rtl_usb_verify_fn verify, void* ctx, int* out_attempts) {
+    struct rtl_usb_apply_policy policy = rtl_usb_apply_policy_from_runtime();
+    return rtl_usb_apply_with_retry(&policy, apply, verify, ctx, out_attempts);
+}
+
+static void
+rtl_usb_log_retry_attempts(const char* control, int attempts) {
+    if (attempts > 1) {
+        DSD_FPRINTF(stderr, "RTL-SDR %s took %d attempts.\n", control ? control : "control apply", attempts);
+    }
+}
+
+struct rtl_usb_frequency_apply_ctx {
+    rtlsdr_dev_t* dev;
+    uint32_t frequency;
+};
+
+static int
+rtl_usb_apply_center_freq(void* opaque) {
+    rtl_usb_frequency_apply_ctx* ctx = static_cast<rtl_usb_frequency_apply_ctx*>(opaque);
+    return (ctx && ctx->dev) ? rtlsdr_set_center_freq(ctx->dev, ctx->frequency) : -1;
+}
+
+static int
+rtl_usb_verify_center_freq(void* opaque) {
+    rtl_usb_frequency_apply_ctx* ctx = static_cast<rtl_usb_frequency_apply_ctx*>(opaque);
+    if (!ctx || !ctx->dev) {
+        return -1;
+    }
+    return (rtlsdr_get_center_freq(ctx->dev) == ctx->frequency) ? 0 : -1;
+}
+
+struct rtl_usb_sample_rate_apply_ctx {
+    rtlsdr_dev_t* dev;
+    uint32_t requested_rate;
+    uint32_t actual_rate;
+};
+
+static int
+rtl_usb_apply_sample_rate(void* opaque) {
+    rtl_usb_sample_rate_apply_ctx* ctx = static_cast<rtl_usb_sample_rate_apply_ctx*>(opaque);
+    return (ctx && ctx->dev) ? rtlsdr_set_sample_rate(ctx->dev, ctx->requested_rate) : -1;
+}
+
+static int
+rtl_usb_verify_sample_rate(void* opaque) {
+    rtl_usb_sample_rate_apply_ctx* ctx = static_cast<rtl_usb_sample_rate_apply_ctx*>(opaque);
+    if (!ctx || !ctx->dev) {
+        return -1;
+    }
+    uint32_t actual = rtlsdr_get_sample_rate(ctx->dev);
+    if (actual == 0U) {
+        return -1;
+    }
+    ctx->actual_rate = actual;
+    return 0;
+}
+
+struct rtl_usb_gain_apply_ctx {
+    rtlsdr_dev_t* dev;
+    int gain;
+    int agc_rc;
+};
+
+typedef int (*rtl_usb_int_control_fn)(void* dev, int value);
+
+static int
+rtl_usb_set_agc_mode_control(void* dev, int value) {
+    return rtlsdr_set_agc_mode(static_cast<rtlsdr_dev_t*>(dev), value);
+}
+
+static int
+rtl_usb_set_tuner_gain_mode_control(void* dev, int value) {
+    return rtlsdr_set_tuner_gain_mode(static_cast<rtlsdr_dev_t*>(dev), value);
+}
+
+static int
+rtl_usb_set_tuner_gain_control(void* dev, int value) {
+    return rtlsdr_set_tuner_gain(static_cast<rtlsdr_dev_t*>(dev), value);
+}
+
+static int
+rtl_usb_apply_manual_gain_controls(void* dev, int gain, int* out_agc_rc, rtl_usb_int_control_fn set_agc_mode,
+                                   rtl_usb_int_control_fn set_gain_mode, rtl_usb_int_control_fn set_tuner_gain) {
+    if (!dev || !set_agc_mode || !set_gain_mode || !set_tuner_gain) {
+        return -1;
+    }
+    int agc_rc = set_agc_mode(dev, 0);
+    if (agc_rc != 0 && out_agc_rc && *out_agc_rc == 0) {
+        *out_agc_rc = agc_rc;
+    }
+    int r = set_gain_mode(dev, 1);
+    if (r != 0) {
+        return r;
+    }
+    return set_tuner_gain(dev, gain);
+}
+
+static int
+rtl_usb_apply_manual_gain(void* opaque) {
+    rtl_usb_gain_apply_ctx* ctx = static_cast<rtl_usb_gain_apply_ctx*>(opaque);
+    if (!ctx || !ctx->dev) {
+        return -1;
+    }
+    return rtl_usb_apply_manual_gain_controls(ctx->dev, ctx->gain, &ctx->agc_rc, rtl_usb_set_agc_mode_control,
+                                              rtl_usb_set_tuner_gain_mode_control, rtl_usb_set_tuner_gain_control);
+}
+
+static int
+rtl_usb_verify_manual_gain(void* opaque) {
+    rtl_usb_gain_apply_ctx* ctx = static_cast<rtl_usb_gain_apply_ctx*>(opaque);
+    if (!ctx || !ctx->dev) {
+        return -1;
+    }
+    return (rtlsdr_get_tuner_gain(ctx->dev) == ctx->gain) ? 0 : -1;
+}
+
+struct rtl_usb_auto_gain_apply_ctx {
+    rtlsdr_dev_t* dev;
+    int agc_want;
+};
+
+static int
+rtl_usb_apply_auto_gain(void* opaque) {
+    rtl_usb_auto_gain_apply_ctx* ctx = static_cast<rtl_usb_auto_gain_apply_ctx*>(opaque);
+    if (!ctx || !ctx->dev) {
+        return -1;
+    }
+    int r = rtlsdr_set_tuner_gain_mode(ctx->dev, 0);
+    if (r != 0) {
+        return r;
+    }
+    return rtlsdr_set_agc_mode(ctx->dev, ctx->agc_want);
+}
+
+struct rtl_usb_int_apply_ctx {
+    rtlsdr_dev_t* dev;
+    int value;
+};
+
+static int
+rtl_usb_apply_direct_sampling(void* opaque) {
+    rtl_usb_int_apply_ctx* ctx = static_cast<rtl_usb_int_apply_ctx*>(opaque);
+    return (ctx && ctx->dev) ? rtlsdr_set_direct_sampling(ctx->dev, ctx->value) : -1;
+}
+
+static int
+rtl_usb_apply_ppm(void* opaque) {
+    rtl_usb_int_apply_ctx* ctx = static_cast<rtl_usb_int_apply_ctx*>(opaque);
+    return (ctx && ctx->dev) ? rtlsdr_set_freq_correction(ctx->dev, ctx->value) : -1;
+}
+
+static int
+rtl_usb_apply_offset_tuning(void* opaque) {
+    rtl_usb_int_apply_ctx* ctx = static_cast<rtl_usb_int_apply_ctx*>(opaque);
+    return (ctx && ctx->dev) ? rtlsdr_set_offset_tuning(ctx->dev, ctx->value ? 1 : 0) : -1;
+}
+
+static int
+rtl_usb_apply_testmode(void* opaque) {
+    rtl_usb_int_apply_ctx* ctx = static_cast<rtl_usb_int_apply_ctx*>(opaque);
+    return (ctx && ctx->dev) ? rtlsdr_set_testmode(ctx->dev, ctx->value ? 1 : 0) : -1;
+}
+
+struct rtl_usb_u32_apply_ctx {
+    rtlsdr_dev_t* dev;
+    uint32_t value;
+};
+
+static int
+rtl_usb_apply_tuner_bandwidth(void* opaque) {
+    rtl_usb_u32_apply_ctx* ctx = static_cast<rtl_usb_u32_apply_ctx*>(opaque);
+    return (ctx && ctx->dev) ? rtlsdr_set_tuner_bandwidth(ctx->dev, (int)ctx->value) : -1;
+}
+
+#ifdef DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS
+struct rtl_usb_retry_test_ctx {
+    int apply_calls;
+    int verify_calls;
+    int apply_success_after;
+    int verify_success_after;
+};
+
+static int
+rtl_usb_retry_test_apply(void* opaque) {
+    rtl_usb_retry_test_ctx* ctx = static_cast<rtl_usb_retry_test_ctx*>(opaque);
+    if (!ctx) {
+        return -1;
+    }
+    ctx->apply_calls++;
+    return (ctx->apply_calls >= ctx->apply_success_after) ? 0 : -1;
+}
+
+static int
+rtl_usb_retry_test_verify(void* opaque) {
+    rtl_usb_retry_test_ctx* ctx = static_cast<rtl_usb_retry_test_ctx*>(opaque);
+    if (!ctx) {
+        return -1;
+    }
+    ctx->verify_calls++;
+    return (ctx->verify_calls >= ctx->verify_success_after) ? 0 : -1;
+}
+
+struct rtl_usb_manual_gain_test_ctx {
+    int agc_rc;
+    int gain_mode_rc;
+    int gain_rc;
+    int agc_calls;
+    int gain_mode_calls;
+    int gain_calls;
+};
+
+static int
+rtl_usb_manual_gain_test_agc(void* opaque, int value) {
+    UNUSED(value);
+    rtl_usb_manual_gain_test_ctx* ctx = static_cast<rtl_usb_manual_gain_test_ctx*>(opaque);
+    if (!ctx) {
+        return -1;
+    }
+    ctx->agc_calls++;
+    return ctx->agc_rc;
+}
+
+static int
+rtl_usb_manual_gain_test_mode(void* opaque, int value) {
+    UNUSED(value);
+    rtl_usb_manual_gain_test_ctx* ctx = static_cast<rtl_usb_manual_gain_test_ctx*>(opaque);
+    if (!ctx) {
+        return -1;
+    }
+    ctx->gain_mode_calls++;
+    return ctx->gain_mode_rc;
+}
+
+static int
+rtl_usb_manual_gain_test_gain(void* opaque, int value) {
+    UNUSED(value);
+    rtl_usb_manual_gain_test_ctx* ctx = static_cast<rtl_usb_manual_gain_test_ctx*>(opaque);
+    if (!ctx) {
+        return -1;
+    }
+    ctx->gain_calls++;
+    return ctx->gain_rc;
+}
+
+} // namespace
+
+extern "C" int
+rtl_device_test_usb_apply_retry(int verify_enabled, int attempts, int apply_success_after, int verify_success_after,
+                                int* out_apply_calls, int* out_verify_calls, int* out_used_attempts) {
+    if (!out_apply_calls || !out_verify_calls || !out_used_attempts || apply_success_after < 1
+        || verify_success_after < 1) {
+        return -100;
+    }
+    rtl_usb_apply_policy policy{};
+    policy.verify_enabled = verify_enabled ? 1 : 0;
+    policy.attempts = attempts;
+    rtl_usb_retry_test_ctx ctx{};
+    ctx.apply_success_after = apply_success_after;
+    ctx.verify_success_after = verify_success_after;
+    int used_attempts = 0;
+    int rc =
+        rtl_usb_apply_with_retry(&policy, rtl_usb_retry_test_apply, rtl_usb_retry_test_verify, &ctx, &used_attempts);
+    *out_apply_calls = ctx.apply_calls;
+    *out_verify_calls = ctx.verify_calls;
+    *out_used_attempts = used_attempts;
+    return rc;
+}
+
+extern "C" int
+rtl_device_test_usb_manual_gain_controls(int agc_rc, int gain_mode_rc, int gain_rc, int* out_agc_calls,
+                                         int* out_gain_mode_calls, int* out_gain_calls, int* out_recorded_agc_rc) {
+    if (!out_agc_calls || !out_gain_mode_calls || !out_gain_calls || !out_recorded_agc_rc) {
+        return -100;
+    }
+    rtl_usb_manual_gain_test_ctx ctx{};
+    ctx.agc_rc = agc_rc;
+    ctx.gain_mode_rc = gain_mode_rc;
+    ctx.gain_rc = gain_rc;
+    int recorded_agc_rc = 0;
+    int rc = rtl_usb_apply_manual_gain_controls(&ctx, 270, &recorded_agc_rc, rtl_usb_manual_gain_test_agc,
+                                                rtl_usb_manual_gain_test_mode, rtl_usb_manual_gain_test_gain);
+    *out_agc_calls = ctx.agc_calls;
+    *out_gain_mode_calls = ctx.gain_mode_calls;
+    *out_gain_calls = ctx.gain_calls;
+    *out_recorded_agc_rc = recorded_agc_rc;
+    return rc;
+}
+#else
+} // namespace
+#endif
+
 /**
  * @brief Set RTL-SDR center frequency with a brief status message.
  *
@@ -3799,11 +4161,13 @@ nearest_gain(rtlsdr_dev_t* dev, int target_gain) {
  */
 static int
 verbose_set_frequency(rtlsdr_dev_t* dev, uint32_t frequency) {
-    int r;
-    r = rtlsdr_set_center_freq(dev, frequency);
+    rtl_usb_frequency_apply_ctx ctx{dev, frequency};
+    int attempts = 0;
+    int r = rtl_usb_apply_with_runtime_retry(rtl_usb_apply_center_freq, rtl_usb_verify_center_freq, &ctx, &attempts);
     if (r < 0) {
         DSD_FPRINTF(stderr, " (WARNING: Failed to set Center Frequency). \n");
     } else {
+        rtl_usb_log_retry_attempts("center frequency apply", attempts);
         DSD_FPRINTF(stderr, " (Center Frequency: %u Hz.) \n", frequency);
     }
     return r;
@@ -3817,12 +4181,23 @@ verbose_set_frequency(rtlsdr_dev_t* dev, uint32_t frequency) {
  * @return 0 on success or a negative error code.
  */
 static int
-verbose_set_sample_rate(rtlsdr_dev_t* dev, uint32_t samp_rate) {
-    int r;
-    r = rtlsdr_set_sample_rate(dev, samp_rate);
+verbose_set_sample_rate(rtlsdr_dev_t* dev, uint32_t samp_rate, uint32_t* out_actual_rate) {
+    rtl_usb_sample_rate_apply_ctx ctx{dev, samp_rate, 0U};
+    int attempts = 0;
+    int r = rtl_usb_apply_with_runtime_retry(rtl_usb_apply_sample_rate, rtl_usb_verify_sample_rate, &ctx, &attempts);
     if (r < 0) {
         DSD_FPRINTF(stderr, "WARNING: Failed to set sample rate.\n");
     } else {
+        if (ctx.actual_rate == 0U) {
+            ctx.actual_rate = rtlsdr_get_sample_rate(dev);
+        }
+        if (ctx.actual_rate == 0U) {
+            ctx.actual_rate = samp_rate;
+        }
+        if (out_actual_rate) {
+            *out_actual_rate = ctx.actual_rate;
+        }
+        rtl_usb_log_retry_attempts("sample rate apply", attempts);
         DSD_FPRINTF(stderr, "Sampling at %u S/s.\n", samp_rate);
     }
     return r;
@@ -3837,12 +4212,14 @@ verbose_set_sample_rate(rtlsdr_dev_t* dev, uint32_t samp_rate) {
  */
 static int
 verbose_direct_sampling(rtlsdr_dev_t* dev, int on) {
-    int r;
-    r = rtlsdr_set_direct_sampling(dev, on);
+    rtl_usb_int_apply_ctx ctx{dev, on};
+    int attempts = 0;
+    int r = rtl_usb_apply_with_runtime_retry(rtl_usb_apply_direct_sampling, NULL, &ctx, &attempts);
     if (r != 0) {
         DSD_FPRINTF(stderr, "WARNING: Failed to set direct sampling mode.\n");
         return r;
     }
+    rtl_usb_log_retry_attempts("direct sampling apply", attempts);
     if (on == 0) {
         DSD_FPRINTF(stderr, "Direct sampling mode disabled.\n");
     }
@@ -3900,10 +4277,13 @@ rtl_device_print_offset_capability(struct rtl_device* dev) {
 static int
 verbose_set_tuner_bandwidth(rtlsdr_dev_t* dev, uint32_t bw_hz) {
     /* Pass-through to librtlsdr; bw_hz == 0 lets driver choose an appropriate filter */
-    int r = rtlsdr_set_tuner_bandwidth(dev, (int)bw_hz);
+    rtl_usb_u32_apply_ctx ctx{dev, bw_hz};
+    int attempts = 0;
+    int r = rtl_usb_apply_with_runtime_retry(rtl_usb_apply_tuner_bandwidth, NULL, &ctx, &attempts);
     if (r != 0) {
         DSD_FPRINTF(stderr, "WARNING: Failed to set tuner bandwidth to %u Hz.\n", bw_hz);
     } else {
+        rtl_usb_log_retry_attempts("tuner bandwidth apply", attempts);
         if (bw_hz == 0) {
             DSD_FPRINTF(stderr, "Tuner bandwidth set to auto (driver).\n");
         } else {
@@ -3921,20 +4301,18 @@ verbose_set_tuner_bandwidth(rtlsdr_dev_t* dev, uint32_t bw_hz) {
  */
 static int
 verbose_auto_gain(rtlsdr_dev_t* dev) {
-    int r;
-    r = rtlsdr_set_tuner_gain_mode(dev, 0);
-    if (r != 0) {
-        DSD_FPRINTF(stderr, "WARNING: Failed to set tuner gain.\n");
-    } else {
-        DSD_FPRINTF(stderr, "Tuner gain set to automatic.\n");
-    }
     /* Original plan: enable RTL digital AGC in auto mode by default.
        Allow override via env DSD_NEO_RTL_AGC=0 to disable. */
     int want = env_agc_want();
-    int ra = rtlsdr_set_agc_mode(dev, want);
-    if (ra != 0) {
-        DSD_FPRINTF(stderr, "WARNING: Failed to %s RTL AGC.\n", want ? "enable" : "disable");
+    rtl_usb_auto_gain_apply_ctx ctx{dev, want};
+    int attempts = 0;
+    int r = rtl_usb_apply_with_runtime_retry(rtl_usb_apply_auto_gain, NULL, &ctx, &attempts);
+    if (r != 0) {
+        DSD_FPRINTF(stderr, "WARNING: Failed to set automatic tuner gain or %s RTL AGC.\n",
+                    want ? "enable" : "disable");
     } else {
+        rtl_usb_log_retry_attempts("automatic gain apply", attempts);
+        DSD_FPRINTF(stderr, "Tuner gain set to automatic.\n");
         DSD_FPRINTF(stderr, "RTL AGC %s.\n", want ? "enabled" : "disabled");
     }
     return r;
@@ -3949,18 +4327,17 @@ verbose_auto_gain(rtlsdr_dev_t* dev) {
  */
 static int
 verbose_gain_set(rtlsdr_dev_t* dev, int gain) {
-    int r;
-    /* Disable RTL digital AGC when setting manual tuner gain */
-    (void)rtlsdr_set_agc_mode(dev, 0);
-    r = rtlsdr_set_tuner_gain_mode(dev, 1);
-    if (r < 0) {
-        DSD_FPRINTF(stderr, "WARNING: Failed to enable manual gain.\n");
-        return r;
-    }
-    r = rtlsdr_set_tuner_gain(dev, gain);
+    rtl_usb_gain_apply_ctx ctx{dev, gain, 0};
+    int attempts = 0;
+    int r = rtl_usb_apply_with_runtime_retry(rtl_usb_apply_manual_gain, rtl_usb_verify_manual_gain, &ctx, &attempts);
     if (r != 0) {
         DSD_FPRINTF(stderr, "WARNING: Failed to set tuner gain.\n");
     } else {
+        if (ctx.agc_rc != 0) {
+            DSD_FPRINTF(stderr, "WARNING: Failed to disable RTL AGC before manual gain (rc=%d); continuing.\n",
+                        ctx.agc_rc);
+        }
+        rtl_usb_log_retry_attempts("manual gain apply", attempts);
         DSD_FPRINTF(stderr, "Tuner gain set to %0.2f dB.\n", gain / 10.0);
     }
     return r;
@@ -3975,11 +4352,13 @@ verbose_gain_set(rtlsdr_dev_t* dev, int gain) {
  */
 static int
 verbose_ppm_set(rtlsdr_dev_t* dev, int ppm_error) {
-    int r;
-    r = rtlsdr_set_freq_correction(dev, ppm_error);
+    rtl_usb_int_apply_ctx ctx{dev, ppm_error};
+    int attempts = 0;
+    int r = rtl_usb_apply_with_runtime_retry(rtl_usb_apply_ppm, NULL, &ctx, &attempts);
     if (r < 0) {
         DSD_FPRINTF(stderr, "WARNING: Failed to set ppm error.\n");
     } else {
+        rtl_usb_log_retry_attempts("PPM apply", attempts);
         DSD_FPRINTF(stderr, "Tuner error set to %i ppm.\n", ppm_error);
     }
     return r;
@@ -4633,36 +5012,38 @@ rtl_device_set_frequency(struct rtl_device* dev, uint32_t frequency) {
     if (!dev) {
         return -1;
     }
-    dev->freq = frequency;
-    if (dev->backend == RTL_BACKEND_USB || dev->backend == RTL_BACKEND_TCP) {
-        rtl_reset_capture_state_on_stream_boundary(dev);
-    }
+    int rc = -1;
     if (dev->backend == RTL_BACKEND_USB) {
         if (!dev->dev) {
             return -1;
         }
-        return verbose_set_frequency(dev->dev, frequency);
-    }
-    if (dev->backend == RTL_BACKEND_TCP) {
-        return rtl_tcp_send_cmd(dev->sockfd, 0x01, frequency);
-    }
-    if (dev->backend == RTL_BACKEND_IQ_REPLAY) {
+        rc = verbose_set_frequency(dev->dev, frequency);
+    } else if (dev->backend == RTL_BACKEND_TCP) {
+        rc = rtl_tcp_send_cmd(dev->sockfd, 0x01, frequency);
+    } else if (dev->backend == RTL_BACKEND_IQ_REPLAY) {
         if (dev->replay_cfg.capture_center_frequency_hz > 0
             && (uint64_t)frequency != dev->replay_cfg.capture_center_frequency_hz) {
             DSD_FPRINTF(stderr, "IQ replay: ignoring retune request to %u Hz (capture center is %" PRIu64 " Hz).\n",
                         frequency, dev->replay_cfg.capture_center_frequency_hz);
         }
-        return 0;
-    }
+        rc = 0;
+    } else {
 #ifdef USE_SOAPYSDR
-    if (dev->backend == RTL_BACKEND_SOAPY) {
-        return soapy_call_locked(dev, "setFrequency", [&]() -> int {
-            dev->soapy_dev->setFrequency(SOAPY_SDR_RX, 0, (double)frequency);
-            return 0;
-        });
-    }
+        if (dev->backend == RTL_BACKEND_SOAPY) {
+            rc = soapy_call_locked(dev, "setFrequency", [&]() -> int {
+                dev->soapy_dev->setFrequency(SOAPY_SDR_RX, 0, (double)frequency);
+                return 0;
+            });
+        }
 #endif
-    return -1;
+    }
+    if (rc == 0) {
+        dev->freq = frequency;
+        if (dev->backend == RTL_BACKEND_USB || dev->backend == RTL_BACKEND_TCP) {
+            rtl_reset_capture_state_on_stream_boundary(dev);
+        }
+    }
+    return rc;
 }
 
 /**
@@ -4677,51 +5058,54 @@ rtl_device_set_sample_rate(struct rtl_device* dev, uint32_t samp_rate) {
     if (!dev) {
         return -1;
     }
-    dev->rate = samp_rate;
+    int rc = -1;
+    uint32_t applied_rate = samp_rate;
     if (dev->backend == RTL_BACKEND_USB) {
         if (!dev->dev) {
             return -1;
         }
-        return verbose_set_sample_rate(dev->dev, samp_rate);
-    }
-    if (dev->backend == RTL_BACKEND_TCP) {
-        int rc = rtl_tcp_send_cmd(dev->sockfd, 0x02, samp_rate);
+        rc = verbose_set_sample_rate(dev->dev, samp_rate, &applied_rate);
+    } else if (dev->backend == RTL_BACKEND_TCP) {
+        rc = rtl_tcp_send_cmd(dev->sockfd, 0x02, samp_rate);
         if (rc == 0) {
             /* The TCP device is created before the final stream rate is known.
              * Reset the metric windows when the rate is programmed so startup
              * delay cannot count against the first watchdog interval. */
             rtl_tcp_metrics_reset_device(dev, samp_rate);
         }
-        return rc;
-    }
-    if (dev->backend == RTL_BACKEND_IQ_REPLAY) {
-        return 0;
-    }
+    } else if (dev->backend == RTL_BACKEND_IQ_REPLAY) {
+        rc = 0;
+    } else {
 #ifdef USE_SOAPYSDR
-    if (dev->backend == RTL_BACKEND_SOAPY) {
-        return soapy_call_locked(dev, "setSampleRate", [&]() -> int {
-            double requested = (double)samp_rate;
-            double applied = requested;
-            bool adjusted = false;
-            try {
-                std::vector<double> listed =
-                    soapy_valid_positive_rates(dev->soapy_dev->listSampleRates(SOAPY_SDR_RX, 0));
-                std::vector<dsdneo::SoapyRange> ranges =
-                    soapy_ranges_from_range_list(dev->soapy_dev->getSampleRateRange(SOAPY_SDR_RX, 0));
-                applied = dsdneo::soapy_nearest_sample_rate(requested, listed, ranges, &adjusted);
-            } catch (const std::exception&) {
-                applied = requested;
-            }
-            if (adjusted) {
-                DSD_FPRINTF(stderr, "SoapySDR: adjusted sample rate from %.0f Hz to %.0f Hz.\n", requested, applied);
-            }
-            dev->soapy_dev->setSampleRate(SOAPY_SDR_RX, 0, applied);
-            dev->rate = (uint32_t)std::lround(applied);
-            return 0;
-        });
-    }
+        if (dev->backend == RTL_BACKEND_SOAPY) {
+            rc = soapy_call_locked(dev, "setSampleRate", [&]() -> int {
+                double requested = (double)samp_rate;
+                double applied = requested;
+                bool adjusted = false;
+                try {
+                    std::vector<double> listed =
+                        soapy_valid_positive_rates(dev->soapy_dev->listSampleRates(SOAPY_SDR_RX, 0));
+                    std::vector<dsdneo::SoapyRange> ranges =
+                        soapy_ranges_from_range_list(dev->soapy_dev->getSampleRateRange(SOAPY_SDR_RX, 0));
+                    applied = dsdneo::soapy_nearest_sample_rate(requested, listed, ranges, &adjusted);
+                } catch (const std::exception&) {
+                    applied = requested;
+                }
+                if (adjusted) {
+                    DSD_FPRINTF(stderr, "SoapySDR: adjusted sample rate from %.0f Hz to %.0f Hz.\n", requested,
+                                applied);
+                }
+                dev->soapy_dev->setSampleRate(SOAPY_SDR_RX, 0, applied);
+                applied_rate = (uint32_t)std::lround(applied);
+                return 0;
+            });
+        }
 #endif
-    return -1;
+    }
+    if (rc == 0) {
+        dev->rate = applied_rate;
+    }
+    return rc;
 }
 
 /**
@@ -4739,7 +5123,11 @@ rtl_device_get_sample_rate(struct rtl_device* dev) {
         if (!dev->dev) {
             return -1;
         }
-        return (int)rtlsdr_get_sample_rate(dev->dev);
+        uint32_t actual = rtlsdr_get_sample_rate(dev->dev);
+        if (actual > 0U) {
+            dev->rate = actual;
+        }
+        return (int)actual;
     }
     if (dev->backend == RTL_BACKEND_IQ_REPLAY) {
         return (int)dev->replay_cfg.sample_rate_hz;
@@ -4763,15 +5151,23 @@ rtl_device_get_sample_rate(struct rtl_device* dev) {
 }
 
 static int
-rtl_device_set_gain_usb(struct rtl_device* dev, int gain) {
+rtl_device_set_gain_usb(struct rtl_device* dev, int gain, int* out_applied_gain) {
     if (!dev || !dev->dev) {
         return -1;
     }
     if (gain == RTL_AUTO_GAIN) {
-        return verbose_auto_gain(dev->dev);
+        int rc = verbose_auto_gain(dev->dev);
+        if (rc == 0 && out_applied_gain) {
+            *out_applied_gain = RTL_AUTO_GAIN;
+        }
+        return rc;
     }
     int nearest = nearest_gain(dev->dev, gain);
-    return verbose_gain_set(dev->dev, nearest);
+    int rc = verbose_gain_set(dev->dev, nearest);
+    if (rc == 0 && out_applied_gain) {
+        *out_applied_gain = nearest;
+    }
+    return rc;
 }
 
 static int
@@ -4854,23 +5250,29 @@ rtl_device_set_gain(struct rtl_device* dev, int gain) {
     if (!dev) {
         return -1;
     }
-    dev->gain = gain;
+    int rc = -1;
+    int applied_gain = gain;
     if (dev->backend == RTL_BACKEND_USB) {
-        return rtl_device_set_gain_usb(dev, gain);
-    }
-    if (dev->backend == RTL_BACKEND_IQ_REPLAY) {
+        rc = rtl_device_set_gain_usb(dev, gain, &applied_gain);
+        if (rc == 0) {
+            dev->agc_mode = (applied_gain == RTL_AUTO_GAIN) ? 1 : 0;
+        }
+    } else if (dev->backend == RTL_BACKEND_IQ_REPLAY) {
         dev->agc_mode = 0;
-        return 0;
-    }
-    if (dev->backend == RTL_BACKEND_TCP) {
-        return rtl_device_set_gain_tcp(dev, gain);
-    }
+        rc = 0;
+    } else if (dev->backend == RTL_BACKEND_TCP) {
+        rc = rtl_device_set_gain_tcp(dev, gain);
+    } else {
 #ifdef USE_SOAPYSDR
-    if (dev->backend == RTL_BACKEND_SOAPY) {
-        return rtl_device_set_gain_soapy(dev, gain);
-    }
+        if (dev->backend == RTL_BACKEND_SOAPY) {
+            rc = rtl_device_set_gain_soapy(dev, gain);
+        }
 #endif
-    return -1;
+    }
+    if (rc == 0) {
+        dev->gain = applied_gain;
+    }
+    return rc;
 }
 
 static int
@@ -4882,17 +5284,13 @@ rtl_device_set_gain_nearest_usb(struct rtl_device* dev, int target_tenth_db) {
     if (g < 0) {
         return g;
     }
-    int r = rtlsdr_set_tuner_gain_mode(dev->dev, 1);
-    if (r < 0) {
-        DSD_FPRINTF(stderr, "WARNING: Failed to enable manual gain.\n");
-        return r;
-    }
-    r = rtlsdr_set_tuner_gain(dev->dev, g);
+    int r = verbose_gain_set(dev->dev, g);
     if (r < 0) {
         DSD_FPRINTF(stderr, "WARNING: Failed to set tuner gain (nearest).\n");
         return r;
     }
     dev->gain = g;
+    dev->agc_mode = 0;
     DSD_FPRINTF(stderr, "Tuner manual gain (nearest): %0.1f dB.\n", (double)g / 10.0);
     return 0;
 }
@@ -5078,23 +5476,23 @@ rtl_device_set_direct_sampling(struct rtl_device* dev, int on) {
     if (!dev) {
         return -1;
     }
-    dev->direct_sampling = on;
+    int rc = -1;
     if (dev->backend == RTL_BACKEND_USB) {
         if (!dev->dev) {
             return -1;
         }
-        return verbose_direct_sampling(dev->dev, on);
+        rc = verbose_direct_sampling(dev->dev, on);
+    } else if (dev->backend == RTL_BACKEND_TCP) {
+        rc = rtl_tcp_send_cmd(dev->sockfd, 0x09, (uint32_t)on);
+    } else if (dev->backend == RTL_BACKEND_IQ_REPLAY) {
+        rc = 0;
+    } else if (dev->backend == RTL_BACKEND_SOAPY) {
+        rc = DSD_ERR_NOT_SUPPORTED;
     }
-    if (dev->backend == RTL_BACKEND_TCP) {
-        return rtl_tcp_send_cmd(dev->sockfd, 0x09, (uint32_t)on);
+    if (rc == 0) {
+        dev->direct_sampling = on;
     }
-    if (dev->backend == RTL_BACKEND_IQ_REPLAY) {
-        return 0;
-    }
-    if (dev->backend == RTL_BACKEND_SOAPY) {
-        return DSD_ERR_NOT_SUPPORTED;
-    }
-    return -1;
+    return rc;
 }
 
 /**
@@ -5110,8 +5508,11 @@ rtl_device_set_offset_tuning_enabled(struct rtl_device* dev, int on) {
         if (!dev->dev) {
             return -1;
         }
-        r = rtlsdr_set_offset_tuning(dev->dev, on ? 1 : 0);
+        rtl_usb_int_apply_ctx ctx{dev->dev, on ? 1 : 0};
+        int attempts = 0;
+        r = rtl_usb_apply_with_runtime_retry(rtl_usb_apply_offset_tuning, NULL, &ctx, &attempts);
         if (r == 0) {
+            rtl_usb_log_retry_attempts("offset tuning apply", attempts);
             DSD_FPRINTF(stderr, on ? "Offset tuning mode enabled.\n" : "Offset tuning mode disabled.\n");
         } else {
             int tuner_type = rtlsdr_get_tuner_type(dev->dev);
@@ -5355,33 +5756,47 @@ rtl_device_set_bias_tee(struct rtl_device* dev, int on) {
     if (!dev) {
         return -1;
     }
-    dev->bias_tee_on = on ? 1 : 0;
+    int requested = on ? 1 : 0;
+    int rc = -1;
     if (dev->backend == RTL_BACKEND_IQ_REPLAY) {
-        return 0;
-    }
-    if (dev->backend == RTL_BACKEND_TCP) {
+        rc = 0;
+    } else if (dev->backend == RTL_BACKEND_TCP) {
         /* rtl_tcp protocol command 0x0E toggles bias tee */
-        return rtl_tcp_send_cmd(dev->sockfd, 0x0E, (uint32_t)dev->bias_tee_on);
-    }
-    if (dev->backend == RTL_BACKEND_SOAPY) {
-        return DSD_ERR_NOT_SUPPORTED;
-    }
+        rc = rtl_tcp_send_cmd(dev->sockfd, 0x0E, (uint32_t)requested);
+    } else if (dev->backend == RTL_BACKEND_SOAPY) {
+        rc = DSD_ERR_NOT_SUPPORTED;
+    } else {
 #ifdef USE_RTLSDR_BIAS_TEE
-    if (!dev->dev) {
-        return -1;
-    }
-    int r = rtlsdr_set_bias_tee(dev->dev, dev->bias_tee_on);
-    if (r != 0) {
-        DSD_FPRINTF(stderr, "WARNING: Failed to %sable RTL-SDR bias tee.\n", dev->bias_tee_on ? "en" : "dis");
-        return -1;
-    }
-    DSD_FPRINTF(stderr, "RTL-SDR bias tee %s.\n", dev->bias_tee_on ? "enabled" : "disabled");
-    return 0;
+        if (!dev->dev) {
+            return -1;
+        }
+
+        struct rtl_usb_bias_tee_apply_ctx {
+            rtlsdr_dev_t* dev;
+            int value;
+        } ctx{dev->dev, requested};
+
+        auto apply_bias_tee = [](void* opaque) -> int {
+            rtl_usb_bias_tee_apply_ctx* bias_ctx = static_cast<rtl_usb_bias_tee_apply_ctx*>(opaque);
+            return (bias_ctx && bias_ctx->dev) ? rtlsdr_set_bias_tee(bias_ctx->dev, bias_ctx->value) : -1;
+        };
+        int attempts = 0;
+        rc = rtl_usb_apply_with_runtime_retry(apply_bias_tee, NULL, &ctx, &attempts);
+        if (rc != 0) {
+            DSD_FPRINTF(stderr, "WARNING: Failed to %sable RTL-SDR bias tee.\n", requested ? "en" : "dis");
+            return -1;
+        }
+        rtl_usb_log_retry_attempts("bias tee apply", attempts);
+        DSD_FPRINTF(stderr, "RTL-SDR bias tee %s.\n", requested ? "enabled" : "disabled");
 #else
-    (void)on;
-    DSD_FPRINTF(stderr, "NOTE: librtlsdr built without bias tee API; ignoring bias setting on USB.\n");
-    return DSD_ERR_NOT_SUPPORTED;
+        DSD_FPRINTF(stderr, "NOTE: librtlsdr built without bias tee API; ignoring bias setting on USB.\n");
+        rc = DSD_ERR_NOT_SUPPORTED;
 #endif
+    }
+    if (rc == 0) {
+        dev->bias_tee_on = requested;
+    }
+    return rc;
 }
 
 int
@@ -5457,29 +5872,35 @@ rtl_device_set_testmode(struct rtl_device* dev, int on) {
     if (!dev) {
         return -1;
     }
-    dev->testmode_on = on ? 1 : 0;
+    int requested = on ? 1 : 0;
+    int rc = -1;
     if (dev->backend == RTL_BACKEND_IQ_REPLAY) {
-        return 0;
-    }
-    if (dev->backend == RTL_BACKEND_TCP) {
+        rc = 0;
+    } else if (dev->backend == RTL_BACKEND_TCP) {
         if (dev->sockfd == DSD_INVALID_SOCKET) {
             return -1;
         }
-        return rtl_tcp_send_cmd(dev->sockfd, 0x07, (uint32_t)(on ? 1 : 0));
+        rc = rtl_tcp_send_cmd(dev->sockfd, 0x07, (uint32_t)requested);
+    } else if (dev->backend == RTL_BACKEND_SOAPY) {
+        rc = DSD_ERR_NOT_SUPPORTED;
+    } else {
+        if (!dev->dev) {
+            return -1;
+        }
+        rtl_usb_int_apply_ctx ctx{dev->dev, requested};
+        int attempts = 0;
+        rc = rtl_usb_apply_with_runtime_retry(rtl_usb_apply_testmode, NULL, &ctx, &attempts);
+        if (rc != 0) {
+            DSD_FPRINTF(stderr, "WARNING: Failed to %s RTL-SDR test mode.\n", on ? "enable" : "disable");
+            return -1;
+        }
+        rtl_usb_log_retry_attempts("test mode apply", attempts);
+        DSD_FPRINTF(stderr, "RTL-SDR test mode %s.\n", on ? "enabled" : "disabled");
     }
-    if (dev->backend == RTL_BACKEND_SOAPY) {
-        return DSD_ERR_NOT_SUPPORTED;
+    if (rc == 0) {
+        dev->testmode_on = requested;
     }
-    if (!dev->dev) {
-        return -1;
-    }
-    int r = rtlsdr_set_testmode(dev->dev, on ? 1 : 0);
-    if (r != 0) {
-        DSD_FPRINTF(stderr, "WARNING: Failed to %s RTL-SDR test mode.\n", on ? "enable" : "disable");
-        return -1;
-    }
-    DSD_FPRINTF(stderr, "RTL-SDR test mode %s.\n", on ? "enabled" : "disabled");
-    return 0;
+    return rc;
 }
 
 int

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -3899,6 +3899,14 @@ struct rtl_usb_sample_rate_apply_ctx {
 };
 
 static int
+rtl_usb_sample_rate_readback_matches(uint32_t requested_rate, uint32_t actual_rate) {
+    if (requested_rate == 0U || actual_rate == 0U) {
+        return 0;
+    }
+    return actual_rate == requested_rate;
+}
+
+static int
 rtl_usb_apply_sample_rate(void* opaque) {
     rtl_usb_sample_rate_apply_ctx* ctx = static_cast<rtl_usb_sample_rate_apply_ctx*>(opaque);
     return (ctx && ctx->dev) ? rtlsdr_set_sample_rate(ctx->dev, ctx->requested_rate) : -1;
@@ -3912,6 +3920,9 @@ rtl_usb_verify_sample_rate(void* opaque) {
     }
     uint32_t actual = rtlsdr_get_sample_rate(ctx->dev);
     if (actual == 0U) {
+        return -1;
+    }
+    if (!rtl_usb_sample_rate_readback_matches(ctx->requested_rate, actual)) {
         return -1;
     }
     ctx->actual_rate = actual;
@@ -4171,6 +4182,19 @@ rtl_device_test_usb_apply_retry(int verify_enabled, int attempts, int apply_succ
     *out_verify_calls = ctx.verify_calls;
     *out_used_attempts = used_attempts;
     return rc;
+}
+
+extern "C" int
+rtl_device_test_usb_sample_rate_readback(uint32_t requested_rate, uint32_t actual_rate, uint32_t* out_actual_rate) {
+    if (!out_actual_rate) {
+        return -100;
+    }
+    *out_actual_rate = 0U;
+    if (!rtl_usb_sample_rate_readback_matches(requested_rate, actual_rate)) {
+        return -1;
+    }
+    *out_actual_rate = actual_rate;
+    return 0;
 }
 
 extern "C" int

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -3658,6 +3658,26 @@ controller_end_reconfigure(struct controller_state* s) {
 }
 
 static int
+controller_reconfigure_requires_finalize(int apply_rc, int hardware_changed, int ppm_changed) {
+    return apply_rc == 0 || hardware_changed || ppm_changed;
+}
+
+static uint32_t
+controller_reconfigure_finalized_center(uint32_t requested_center_freq_hz, uint32_t previous_center_freq_hz,
+                                        int apply_rc, int hardware_changed) {
+    if (apply_rc != 0 && !hardware_changed && previous_center_freq_hz != 0U) {
+        return previous_center_freq_hz;
+    }
+    return requested_center_freq_hz;
+}
+
+static const RtlRetuneProfile*
+controller_reconfigure_finalized_profile(const RtlRetuneProfile* retune_profile, uint32_t requested_center_freq_hz,
+                                         uint32_t finalized_center_freq_hz) {
+    return (finalized_center_freq_hz == requested_center_freq_hz) ? retune_profile : NULL;
+}
+
+static int
 controller_reconfigure_active_stream_locked(struct controller_state* s, uint32_t center_freq_hz,
                                             DemodRetuneResetReason reset_reason, int* out_reconfigured) {
     if (out_reconfigured) {
@@ -3672,14 +3692,17 @@ controller_reconfigure_active_stream_locked(struct controller_state* s, uint32_t
     controller_arm_retune_mute("program");
     int hardware_changed = 0;
     int rc = program_capture_frequency_and_rate(center_freq_hz, &previous_capture, &hardware_changed);
-    if (rc != 0 && !hardware_changed) {
+    int ppm_changed = (reset_reason == DemodRetuneResetReason::PpmCorrection);
+    if (!controller_reconfigure_requires_finalize(rc, hardware_changed, ppm_changed)) {
         rtl_device_end_capture_reconfigure(rtl_device_handle);
         return rc;
     }
+    uint32_t finalized_center_freq_hz =
+        controller_reconfigure_finalized_center(center_freq_hz, previous_center_freq_hz, rc, hardware_changed);
     controller_arm_retune_mute("post");
-    rtl_device_record_capture_retune(rtl_device_handle, center_freq_hz, load_dongle_frequency(), load_dongle_rate(),
-                                     retune_reset_reason_name(reset_reason));
-    controller_finalize_reconfigure(s, g_stream ? g_stream->opts : NULL, center_freq_hz, reset_reason,
+    rtl_device_record_capture_retune(rtl_device_handle, finalized_center_freq_hz, load_dongle_frequency(),
+                                     load_dongle_rate(), retune_reset_reason_name(reset_reason));
+    controller_finalize_reconfigure(s, g_stream ? g_stream->opts : NULL, finalized_center_freq_hz, reset_reason,
                                     previous_center_freq_hz, previous_rate_out_hz, NULL);
     controller_arm_retune_mute("post-reset");
     rtl_device_end_capture_reconfigure(rtl_device_handle);
@@ -3709,21 +3732,25 @@ controller_apply_reconfigure(struct controller_state* s, uint32_t center_freq_hz
     if (out_ppm_rc) {
         *out_ppm_rc = ppm_rc;
     }
-    if (apply_rc != 0 && !hardware_changed) {
+    int ppm_changed = (ppm_rc == 0 && ppm_error != prev_ppm);
+    if (!controller_reconfigure_requires_finalize(apply_rc, hardware_changed, ppm_changed)) {
         store_dongle_ppm_error_if_applied(ppm_rc, ppm_error);
         rtl_device_end_capture_reconfigure(rtl_device_handle);
         controller_end_reconfigure(s);
         return apply_rc;
     }
+    uint32_t finalized_center_freq_hz =
+        controller_reconfigure_finalized_center(center_freq_hz, previous_center_freq_hz, apply_rc, hardware_changed);
+    const RtlRetuneProfile* finalized_profile =
+        controller_reconfigure_finalized_profile(retune_profile, center_freq_hz, finalized_center_freq_hz);
     controller_arm_retune_mute("post");
     store_dongle_ppm_error_if_applied(ppm_rc, ppm_error);
-    DemodRetuneResetReason reset_reason = (ppm_rc == 0 && ppm_error != prev_ppm)
-                                              ? DemodRetuneResetReason::PpmCorrection
-                                              : DemodRetuneResetReason::FrequencyRetune;
-    rtl_device_record_capture_retune(rtl_device_handle, center_freq_hz, load_dongle_frequency(), load_dongle_rate(),
-                                     retune_reset_reason_name(reset_reason));
-    controller_finalize_reconfigure(s, g_stream ? g_stream->opts : NULL, center_freq_hz, reset_reason,
-                                    previous_center_freq_hz, previous_rate_out_hz, retune_profile);
+    DemodRetuneResetReason reset_reason =
+        ppm_changed ? DemodRetuneResetReason::PpmCorrection : DemodRetuneResetReason::FrequencyRetune;
+    rtl_device_record_capture_retune(rtl_device_handle, finalized_center_freq_hz, load_dongle_frequency(),
+                                     load_dongle_rate(), retune_reset_reason_name(reset_reason));
+    controller_finalize_reconfigure(s, g_stream ? g_stream->opts : NULL, finalized_center_freq_hz, reset_reason,
+                                    previous_center_freq_hz, previous_rate_out_hz, finalized_profile);
     controller_arm_retune_mute("post-reset");
     rtl_device_end_capture_reconfigure(rtl_device_handle);
     controller_end_reconfigure(s);
@@ -4051,6 +4078,18 @@ controller_signal_manual_retune_complete(struct controller_state* s, int result)
 }
 
 static int
+controller_manual_retune_completion_result(int retune_rc, int reconfigured, uint32_t target_hz,
+                                           uint32_t applied_freq_hz) {
+    if (retune_rc == 0) {
+        return RTL_STREAM_TUNE_OK;
+    }
+    if (reconfigured && target_hz != 0U && applied_freq_hz == target_hz) {
+        return RTL_STREAM_TUNE_OK;
+    }
+    return RTL_STREAM_TUNE_FAILED;
+}
+
+static int
 controller_process_manual_retune(struct controller_state* s, const ControllerRetuneWork* work) {
     if (!s || !work || !work->manual_pending) {
         return 0;
@@ -4065,11 +4104,16 @@ controller_process_manual_retune(struct controller_state* s, const ControllerRet
         note_failed_ppm_request(work->requested_ppm, work->requested_ppm_request_id, work->current_ppm, ppm_rc);
     }
     controller_clear_active_ppm_request(s, work->ppm_pending);
-    controller_signal_manual_retune_complete(s, retune_rc == 0 ? RTL_STREAM_TUNE_OK : RTL_STREAM_TUNE_FAILED);
+    uint32_t applied_freq_hz = s->last_applied_freq_hz.load(std::memory_order_acquire);
+    int completion_result =
+        controller_manual_retune_completion_result(retune_rc, reconfigured, target_hz, applied_freq_hz);
+    controller_signal_manual_retune_complete(s, completion_result);
     if (retune_rc == 0 || reconfigured) {
         drain_output_on_retune();
     }
-    if (retune_rc != 0) {
+    if (retune_rc != 0 && completion_result == RTL_STREAM_TUNE_OK) {
+        LOG_NOTICE("Retune applied with warning: %u Hz (rc=%d).\n", target_hz, retune_rc);
+    } else if (retune_rc != 0) {
         LOG_NOTICE("Retune failed: %u Hz (rc=%d).\n", target_hz, retune_rc);
     } else if (work->ppm_changed && ppm_rc == 0) {
         LOG_INFO("Retune applied: %u Hz (PPM=%d).\n", target_hz, work->requested_ppm);
@@ -7603,15 +7647,36 @@ rtl_stream_tune_result_needs_output_drain(int rc) {
 }
 
 static void
-rtl_stream_tune_reconcile_applied_frequency(dsd_opts* opts, uint32_t requested_freq) {
+rtl_stream_store_capture_frequency_for_center(uint32_t center_freq_hz) {
+    if (center_freq_hz == 0U) {
+        return;
+    }
+    uint32_t capture_rate_hz = load_dongle_rate();
+    uint32_t capture_freq_hz =
+        (capture_rate_hz == 0U) ? center_freq_hz : capture_frequency_for_rate((int64_t)center_freq_hz, capture_rate_hz);
+    store_dongle_frequency(capture_freq_hz);
+}
+
+static void
+rtl_stream_tune_reconcile_applied_frequency(dsd_opts* opts, uint32_t requested_freq, const char* reason) {
     uint32_t applied_freq = controller.last_applied_freq_hz.load(std::memory_order_acquire);
     if (applied_freq == 0 || applied_freq == requested_freq) {
         return;
     }
-    LOG_NOTICE("Retune request %u Hz superseded by %u Hz (coalesced pending tune).\n", requested_freq, applied_freq);
-    store_dongle_frequency(applied_freq);
+    LOG_NOTICE("Retune request %u Hz reconciled to %u Hz (%s).\n", requested_freq, applied_freq,
+               reason ? reason : "applied-state");
+    rtl_stream_store_capture_frequency_for_center(applied_freq);
     if (opts) {
         opts->rtlsdr_center_freq = (long int)applied_freq;
+    }
+}
+
+static void
+rtl_stream_tune_reconcile_result(dsd_opts* opts, uint32_t requested_freq, int rc) {
+    if (rc == RTL_STREAM_TUNE_OK) {
+        rtl_stream_tune_reconcile_applied_frequency(opts, requested_freq, "coalesced pending tune");
+    } else if (rc == RTL_STREAM_TUNE_FAILED) {
+        rtl_stream_tune_reconcile_applied_frequency(opts, requested_freq, "apply failed");
     }
 }
 
@@ -7648,9 +7713,7 @@ dsd_rtl_stream_tune(dsd_opts* opts, long int frequency) {
 
     int rc = rtl_stream_tune_wait_for_completion(my_request_id, requested_freq);
 
-    if (rc == RTL_STREAM_TUNE_OK) {
-        rtl_stream_tune_reconcile_applied_frequency(opts, requested_freq);
-    }
+    rtl_stream_tune_reconcile_result(opts, requested_freq, rc);
     if (rtl_stream_tune_result_needs_output_drain(rc)) {
         /* Honor drain/clear policy for API-triggered tunes and accepted-but-pending timeout paths. */
         drain_output_on_retune();
@@ -7837,6 +7900,59 @@ dsd_rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samp
 extern "C" int
 dsd_rtl_stream_test_tune_completion_result(int wait_result, int completion_result) {
     return rtl_stream_tune_apply_completion_result(wait_result, completion_result, 851000000U);
+}
+
+extern "C" int
+dsd_rtl_stream_test_manual_retune_completion_result(int retune_rc, int reconfigured, uint32_t target_hz,
+                                                    uint32_t applied_freq_hz) {
+    return controller_manual_retune_completion_result(retune_rc, reconfigured, target_hz, applied_freq_hz);
+}
+
+extern "C" int
+dsd_rtl_stream_test_tune_failure_reconciles_applied(uint32_t requested_freq_hz, uint32_t applied_freq_hz,
+                                                    long int* out_opts_freq, uint32_t* out_capture_freq_hz) {
+    if (!out_opts_freq || !out_capture_freq_hz) {
+        return -1;
+    }
+
+    uint32_t outer_applied_freq_hz = controller.last_applied_freq_hz.load(std::memory_order_acquire);
+    CaptureSettingsSnapshot outer = capture_settings_snapshot();
+    int outer_offset_tuning = dongle.offset_tuning;
+    int outer_edge = controller.edge;
+    int outer_disable_fs4_shift = disable_fs4_shift;
+    int outer_rate_in = demod.rate_in;
+
+    dsd_opts* opts = static_cast<dsd_opts*>(calloc(1, sizeof(*opts)));
+    if (!opts) {
+        restore_capture_settings(&outer);
+        dongle.offset_tuning = outer_offset_tuning;
+        controller.edge = outer_edge;
+        disable_fs4_shift = outer_disable_fs4_shift;
+        demod.rate_in = outer_rate_in;
+        controller.last_applied_freq_hz.store(outer_applied_freq_hz, std::memory_order_release);
+        return -2;
+    }
+    opts->rtlsdr_center_freq = (long int)requested_freq_hz;
+    controller.last_applied_freq_hz.store(applied_freq_hz, std::memory_order_release);
+    dongle.offset_tuning = 0;
+    controller.edge = 0;
+    disable_fs4_shift = 0;
+    demod.rate_in = 48000;
+    store_dongle_rate(960000U);
+    store_dongle_frequency(requested_freq_hz);
+
+    rtl_stream_tune_reconcile_result(opts, requested_freq_hz, RTL_STREAM_TUNE_FAILED);
+    *out_opts_freq = opts->rtlsdr_center_freq;
+    *out_capture_freq_hz = load_dongle_frequency();
+    free(opts);
+
+    restore_capture_settings(&outer);
+    dongle.offset_tuning = outer_offset_tuning;
+    controller.edge = outer_edge;
+    disable_fs4_shift = outer_disable_fs4_shift;
+    demod.rate_in = outer_rate_in;
+    controller.last_applied_freq_hz.store(outer_applied_freq_hz, std::memory_order_release);
+    return 0;
 }
 
 extern "C" int

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -447,6 +447,15 @@ capture_settings_snapshot(void) {
     return snapshot;
 }
 
+static CaptureSettingsSnapshot
+capture_settings_snapshot_for_center(uint32_t center_freq_hz) {
+    CaptureSettingsSnapshot snapshot = capture_settings_snapshot();
+    if (center_freq_hz != 0U && snapshot.dongle_rate_hz != 0U) {
+        snapshot.dongle_frequency_hz = capture_frequency_for_rate((int64_t)center_freq_hz, snapshot.dongle_rate_hz);
+    }
+    return snapshot;
+}
+
 static void
 restore_capture_rate_settings(const CaptureSettingsSnapshot* snapshot) {
     if (!snapshot) {
@@ -979,6 +988,13 @@ load_dongle_ppm_error(void) {
 static inline void
 store_dongle_ppm_error(int ppm_error) {
     dongle.ppm_error.store(ppm_error, std::memory_order_release);
+}
+
+static inline void
+store_dongle_ppm_error_if_applied(int ppm_rc, int ppm_error) {
+    if (ppm_rc == 0) {
+        store_dongle_ppm_error(ppm_error);
+    }
 }
 
 static inline int
@@ -3436,11 +3452,13 @@ optimal_settings(int freq, int rate) {
  * @param center_freq_hz Desired RF center frequency in Hz.
  */
 static int
-program_capture_frequency_and_rate(uint32_t center_freq_hz, int* out_hardware_changed) {
+program_capture_frequency_and_rate(uint32_t center_freq_hz, const CaptureSettingsSnapshot* restore_on_frequency_failure,
+                                   int* out_hardware_changed) {
     if (out_hardware_changed) {
         *out_hardware_changed = 0;
     }
-    CaptureSettingsSnapshot previous = capture_settings_snapshot();
+    CaptureSettingsSnapshot previous =
+        restore_on_frequency_failure ? *restore_on_frequency_failure : capture_settings_snapshot();
     optimal_settings((int)center_freq_hz, demod.rate_in);
     uint32_t capture_freq_hz = load_dongle_frequency();
     uint32_t capture_rate_hz = load_dongle_rate();
@@ -3485,13 +3503,15 @@ program_capture_frequency_and_rate(uint32_t center_freq_hz, int* out_hardware_ch
  * @return Result from the PPM control apply attempt.
  */
 static int
-apply_capture_settings(uint32_t center_freq_hz, int ppm_error, int* out_ppm_rc, int* out_hardware_changed) {
+apply_capture_settings(uint32_t center_freq_hz, int ppm_error,
+                       const CaptureSettingsSnapshot* restore_on_frequency_failure, int* out_ppm_rc,
+                       int* out_hardware_changed) {
     int ppm_rc = apply_ppm_setting(ppm_error);
     if (out_ppm_rc) {
         *out_ppm_rc = ppm_rc;
     }
     controller_arm_retune_mute("program");
-    return program_capture_frequency_and_rate(center_freq_hz, out_hardware_changed);
+    return program_capture_frequency_and_rate(center_freq_hz, restore_on_frequency_failure, out_hardware_changed);
 }
 
 static int
@@ -3648,9 +3668,10 @@ controller_reconfigure_active_stream_locked(struct controller_state* s, uint32_t
     }
     uint32_t previous_center_freq_hz = s->last_applied_freq_hz.load(std::memory_order_acquire);
     int previous_rate_out_hz = demod.rate_out;
+    CaptureSettingsSnapshot previous_capture = capture_settings_snapshot_for_center(previous_center_freq_hz);
     controller_arm_retune_mute("program");
     int hardware_changed = 0;
-    int rc = program_capture_frequency_and_rate(center_freq_hz, &hardware_changed);
+    int rc = program_capture_frequency_and_rate(center_freq_hz, &previous_capture, &hardware_changed);
     if (rc != 0 && !hardware_changed) {
         rtl_device_end_capture_reconfigure(rtl_device_handle);
         return rc;
@@ -3680,22 +3701,22 @@ controller_apply_reconfigure(struct controller_state* s, uint32_t center_freq_hz
     int prev_ppm = load_dongle_ppm_error();
     uint32_t previous_center_freq_hz = s->last_applied_freq_hz.load(std::memory_order_acquire);
     int previous_rate_out_hz = demod.rate_out;
+    CaptureSettingsSnapshot previous_capture = capture_settings_snapshot_for_center(previous_center_freq_hz);
     controller_begin_reconfigure(s);
     int ppm_rc = 0;
     int hardware_changed = 0;
-    int apply_rc = apply_capture_settings(center_freq_hz, ppm_error, &ppm_rc, &hardware_changed);
+    int apply_rc = apply_capture_settings(center_freq_hz, ppm_error, &previous_capture, &ppm_rc, &hardware_changed);
     if (out_ppm_rc) {
         *out_ppm_rc = ppm_rc;
     }
     if (apply_rc != 0 && !hardware_changed) {
+        store_dongle_ppm_error_if_applied(ppm_rc, ppm_error);
         rtl_device_end_capture_reconfigure(rtl_device_handle);
         controller_end_reconfigure(s);
         return apply_rc;
     }
     controller_arm_retune_mute("post");
-    if (ppm_rc == 0) {
-        store_dongle_ppm_error(ppm_error);
-    }
+    store_dongle_ppm_error_if_applied(ppm_rc, ppm_error);
     DemodRetuneResetReason reset_reason = (ppm_rc == 0 && ppm_error != prev_ppm)
                                               ? DemodRetuneResetReason::PpmCorrection
                                               : DemodRetuneResetReason::FrequencyRetune;
@@ -4043,11 +4064,11 @@ controller_process_manual_retune(struct controller_state* s, const ControllerRet
     if (work->ppm_changed && ppm_rc != 0) {
         note_failed_ppm_request(work->requested_ppm, work->requested_ppm_request_id, work->current_ppm, ppm_rc);
     }
+    controller_clear_active_ppm_request(s, work->ppm_pending);
+    controller_signal_manual_retune_complete(s, retune_rc == 0 ? RTL_STREAM_TUNE_OK : RTL_STREAM_TUNE_FAILED);
     if (retune_rc == 0 || reconfigured) {
         drain_output_on_retune();
     }
-    controller_signal_manual_retune_complete(s, retune_rc == 0 ? RTL_STREAM_TUNE_OK : RTL_STREAM_TUNE_FAILED);
-    controller_clear_active_ppm_request(s, work->ppm_pending);
     if (retune_rc != 0) {
         LOG_NOTICE("Retune failed: %u Hz (rc=%d).\n", target_hz, retune_rc);
     } else if (work->ppm_changed && ppm_rc == 0) {
@@ -7842,10 +7863,10 @@ dsd_rtl_stream_test_capture_settings_failure_restore(uint32_t* out_full_freq_hz,
     dongle.offset_tuning = 1;
     controller.edge = 0;
     disable_fs4_shift = 1;
-    store_dongle_frequency(851000000U);
+    store_dongle_frequency(855000000U);
     store_dongle_rate(960000U);
 
-    CaptureSettingsSnapshot before = capture_settings_snapshot();
+    CaptureSettingsSnapshot before = capture_settings_snapshot_for_center(851000000U);
     optimal_settings(855000000, demod.rate_in);
     restore_capture_settings(&before);
     *out_full_freq_hz = load_dongle_frequency();
@@ -7864,6 +7885,19 @@ dsd_rtl_stream_test_capture_settings_failure_restore(uint32_t* out_full_freq_hz,
     dongle.offset_tuning = outer_offset_tuning;
     controller.edge = outer_edge;
     disable_fs4_shift = outer_disable_fs4_shift;
+    return 0;
+}
+
+extern "C" int
+dsd_rtl_stream_test_ppm_store_if_applied(int ppm_rc, int requested_ppm, int* out_ppm_error) {
+    if (!out_ppm_error) {
+        return -1;
+    }
+    int outer_ppm = load_dongle_ppm_error();
+    store_dongle_ppm_error(3);
+    store_dongle_ppm_error_if_applied(ppm_rc, requested_ppm);
+    *out_ppm_error = load_dongle_ppm_error();
+    store_dongle_ppm_error(outer_ppm);
     return 0;
 }
 

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -177,6 +177,8 @@ static char udp_control_bindaddr[64] = "127.0.0.1";
 
 namespace {
 
+static const size_t kRetuneCompletionResultSlots = 256U;
+
 struct RtlRetuneProfile {
     int active = 0;
     int cqpsk_enable = 0;
@@ -258,6 +260,8 @@ struct controller_state {
     /* Request ID for matching completion signals to requests (prevents stale wakeups) */
     std::atomic<uint32_t> retune_request_id{0U};
     std::atomic<uint32_t> retune_complete_id{0U};
+    uint32_t retune_complete_result_ids[kRetuneCompletionResultSlots]{};
+    int retune_complete_results[kRetuneCompletionResultSlots]{};
     /* Last center frequency successfully applied by the controller thread. */
     std::atomic<uint32_t> last_applied_freq_hz{0U};
     /* Completed capture reconfigure generation. This lets consumer-side
@@ -421,6 +425,49 @@ apply_actual_capture_rate(uint32_t center_freq_hz, uint32_t requested_capture_fr
              actual_capture_rate_hz, demod.rate_out);
     return actual_capture_rate_hz;
 }
+
+namespace {
+
+struct CaptureSettingsSnapshot {
+    int downsample_passes;
+    float output_scale;
+    int rate_out;
+    uint32_t dongle_frequency_hz;
+    uint32_t dongle_rate_hz;
+};
+
+static CaptureSettingsSnapshot
+capture_settings_snapshot(void) {
+    CaptureSettingsSnapshot snapshot{};
+    snapshot.downsample_passes = demod.downsample_passes;
+    snapshot.output_scale = demod.output_scale;
+    snapshot.rate_out = demod.rate_out;
+    snapshot.dongle_frequency_hz = load_dongle_frequency();
+    snapshot.dongle_rate_hz = load_dongle_rate();
+    return snapshot;
+}
+
+static void
+restore_capture_rate_settings(const CaptureSettingsSnapshot* snapshot) {
+    if (!snapshot) {
+        return;
+    }
+    demod.downsample_passes = snapshot->downsample_passes;
+    demod.output_scale = snapshot->output_scale;
+    demod.rate_out = snapshot->rate_out;
+    store_dongle_rate(snapshot->dongle_rate_hz);
+}
+
+static void
+restore_capture_settings(const CaptureSettingsSnapshot* snapshot) {
+    if (!snapshot) {
+        return;
+    }
+    restore_capture_rate_settings(snapshot);
+    store_dongle_frequency(snapshot->dongle_frequency_hz);
+}
+
+} // namespace
 
 static void
 controller_request_input_purge(void) {
@@ -3388,13 +3435,38 @@ optimal_settings(int freq, int rate) {
  *
  * @param center_freq_hz Desired RF center frequency in Hz.
  */
-static void
-program_capture_frequency_and_rate(uint32_t center_freq_hz) {
+static int
+program_capture_frequency_and_rate(uint32_t center_freq_hz, int* out_hardware_changed) {
+    if (out_hardware_changed) {
+        *out_hardware_changed = 0;
+    }
+    CaptureSettingsSnapshot previous = capture_settings_snapshot();
     optimal_settings((int)center_freq_hz, demod.rate_in);
     uint32_t capture_freq_hz = load_dongle_frequency();
     uint32_t capture_rate_hz = load_dongle_rate();
-    rtl_device_set_frequency(rtl_device_handle, capture_freq_hz);
-    rtl_device_set_sample_rate(rtl_device_handle, capture_rate_hz);
+    int rc = rtl_device_set_frequency(rtl_device_handle, capture_freq_hz);
+    if (rc != 0) {
+        restore_capture_settings(&previous);
+        LOG_ERROR("Failed to apply RTL-SDR center frequency %u Hz (rc=%d).\n", capture_freq_hz, rc);
+        return rc;
+    }
+    if (out_hardware_changed) {
+        *out_hardware_changed = 1;
+    }
+    rc = rtl_device_set_sample_rate(rtl_device_handle, capture_rate_hz);
+    if (rc != 0) {
+        LOG_ERROR("Failed to apply RTL-SDR sample rate %u Hz (rc=%d).\n", capture_rate_hz, rc);
+        int actual = rtl_device_get_sample_rate(rtl_device_handle);
+        if (actual > 0) {
+            if ((uint32_t)actual != capture_rate_hz) {
+                (void)apply_actual_capture_rate(center_freq_hz, capture_freq_hz, capture_rate_hz, (uint32_t)actual);
+            }
+        } else {
+            restore_capture_rate_settings(&previous);
+        }
+        stream_refresh_watermark_for_current_rate();
+        return rc;
+    }
     /* Sync to actual device rate (USB may quantize). If it changed, update rate_out. */
     int actual = rtl_device_get_sample_rate(rtl_device_handle);
     if (actual > 0 && (uint32_t)actual != capture_rate_hz) {
@@ -3403,6 +3475,7 @@ program_capture_frequency_and_rate(uint32_t center_freq_hz) {
     /* Use driver auto hardware bandwidth by default, or override via env */
     (void)apply_capture_tuner_bandwidth(capture_rate_hz, g_stream ? g_stream->opts : NULL, 0);
     stream_refresh_watermark_for_current_rate();
+    return 0;
 }
 
 /**
@@ -3412,11 +3485,13 @@ program_capture_frequency_and_rate(uint32_t center_freq_hz) {
  * @return Result from the PPM control apply attempt.
  */
 static int
-apply_capture_settings(uint32_t center_freq_hz, int ppm_error) {
+apply_capture_settings(uint32_t center_freq_hz, int ppm_error, int* out_ppm_rc, int* out_hardware_changed) {
     int ppm_rc = apply_ppm_setting(ppm_error);
+    if (out_ppm_rc) {
+        *out_ppm_rc = ppm_rc;
+    }
     controller_arm_retune_mute("program");
-    program_capture_frequency_and_rate(center_freq_hz);
-    return ppm_rc;
+    return program_capture_frequency_and_rate(center_freq_hz, out_hardware_changed);
 }
 
 static int
@@ -3562,16 +3637,24 @@ controller_end_reconfigure(struct controller_state* s) {
     s->retune_in_progress.store(0, std::memory_order_release);
 }
 
-static void
+static int
 controller_reconfigure_active_stream_locked(struct controller_state* s, uint32_t center_freq_hz,
-                                            DemodRetuneResetReason reset_reason) {
+                                            DemodRetuneResetReason reset_reason, int* out_reconfigured) {
+    if (out_reconfigured) {
+        *out_reconfigured = 0;
+    }
     if (!s || center_freq_hz == 0) {
-        return;
+        return -1;
     }
     uint32_t previous_center_freq_hz = s->last_applied_freq_hz.load(std::memory_order_acquire);
     int previous_rate_out_hz = demod.rate_out;
     controller_arm_retune_mute("program");
-    program_capture_frequency_and_rate(center_freq_hz);
+    int hardware_changed = 0;
+    int rc = program_capture_frequency_and_rate(center_freq_hz, &hardware_changed);
+    if (rc != 0 && !hardware_changed) {
+        rtl_device_end_capture_reconfigure(rtl_device_handle);
+        return rc;
+    }
     controller_arm_retune_mute("post");
     rtl_device_record_capture_retune(rtl_device_handle, center_freq_hz, load_dongle_frequency(), load_dongle_rate(),
                                      retune_reset_reason_name(reset_reason));
@@ -3579,11 +3662,18 @@ controller_reconfigure_active_stream_locked(struct controller_state* s, uint32_t
                                     previous_center_freq_hz, previous_rate_out_hz, NULL);
     controller_arm_retune_mute("post-reset");
     rtl_device_end_capture_reconfigure(rtl_device_handle);
+    if (out_reconfigured) {
+        *out_reconfigured = 1;
+    }
+    return rc;
 }
 
 static int
 controller_apply_reconfigure(struct controller_state* s, uint32_t center_freq_hz, int ppm_error,
-                             const RtlRetuneProfile* retune_profile) {
+                             const RtlRetuneProfile* retune_profile, int* out_ppm_rc, int* out_reconfigured) {
+    if (out_reconfigured) {
+        *out_reconfigured = 0;
+    }
     if (!s || center_freq_hz == 0) {
         return -1;
     }
@@ -3591,7 +3681,17 @@ controller_apply_reconfigure(struct controller_state* s, uint32_t center_freq_hz
     uint32_t previous_center_freq_hz = s->last_applied_freq_hz.load(std::memory_order_acquire);
     int previous_rate_out_hz = demod.rate_out;
     controller_begin_reconfigure(s);
-    int ppm_rc = apply_capture_settings(center_freq_hz, ppm_error);
+    int ppm_rc = 0;
+    int hardware_changed = 0;
+    int apply_rc = apply_capture_settings(center_freq_hz, ppm_error, &ppm_rc, &hardware_changed);
+    if (out_ppm_rc) {
+        *out_ppm_rc = ppm_rc;
+    }
+    if (apply_rc != 0 && !hardware_changed) {
+        rtl_device_end_capture_reconfigure(rtl_device_handle);
+        controller_end_reconfigure(s);
+        return apply_rc;
+    }
     controller_arm_retune_mute("post");
     if (ppm_rc == 0) {
         store_dongle_ppm_error(ppm_error);
@@ -3606,7 +3706,10 @@ controller_apply_reconfigure(struct controller_state* s, uint32_t center_freq_hz
     controller_arm_retune_mute("post-reset");
     rtl_device_end_capture_reconfigure(rtl_device_handle);
     controller_end_reconfigure(s);
-    return ppm_rc;
+    if (out_reconfigured) {
+        *out_reconfigured = 1;
+    }
+    return apply_rc;
 }
 
 static void
@@ -3731,11 +3834,19 @@ static int
 controller_program_initial_capture_settings(const struct controller_state* s, const dsd_opts* opts) {
     uint32_t capture_freq_hz = load_dongle_frequency();
     uint32_t capture_rate_hz = load_dongle_rate();
-    (void)rtl_device_set_frequency(rtl_device_handle, capture_freq_hz);
+    int rc = rtl_device_set_frequency(rtl_device_handle, capture_freq_hz);
+    if (rc != 0) {
+        LOG_ERROR("Failed to apply initial RTL-SDR center frequency %u Hz (rc=%d).\n", capture_freq_hz, rc);
+        return rc;
+    }
     LOG_INFO("Oversampling input by: %ix.\n", (demod.downsample_passes > 0) ? (1 << demod.downsample_passes) : 1);
     LOG_INFO("Oversampling output by: %ix.\n", demod.post_downsample);
     LOG_INFO("Buffer size: %0.2fms\n", 1000 * 0.5 * (float)ACTUAL_BUF_LENGTH / (float)capture_rate_hz);
-    (void)rtl_device_set_sample_rate(rtl_device_handle, capture_rate_hz);
+    rc = rtl_device_set_sample_rate(rtl_device_handle, capture_rate_hz);
+    if (rc != 0) {
+        LOG_ERROR("Failed to apply initial RTL-SDR sample rate %u Hz (rc=%d).\n", capture_rate_hz, rc);
+        return rc;
+    }
     capture_rate_hz = controller_sync_initial_capture_rate((uint32_t)s->freqs[0], capture_freq_hz, capture_rate_hz);
     if (apply_capture_tuner_bandwidth(capture_rate_hz, opts, 1) != 0) {
         return -1;
@@ -3874,9 +3985,46 @@ controller_wait_for_retune_work(struct controller_state* s, ControllerRetuneWork
 }
 
 static void
-controller_signal_manual_retune_complete(struct controller_state* s) {
+controller_clear_retune_completion_results(struct controller_state* s) {
+    if (!s) {
+        return;
+    }
+    for (size_t i = 0; i < kRetuneCompletionResultSlots; i++) {
+        s->retune_complete_result_ids[i] = 0U;
+        s->retune_complete_results[i] = RTL_STREAM_TUNE_OK;
+    }
+}
+
+static void
+controller_store_retune_completion_result_locked(struct controller_state* s, uint32_t request_id, int result) {
+    if (!s || request_id == 0U) {
+        return;
+    }
+    size_t slot = (size_t)(request_id % (uint32_t)kRetuneCompletionResultSlots);
+    s->retune_complete_result_ids[slot] = request_id;
+    s->retune_complete_results[slot] = result;
+}
+
+static int
+controller_load_retune_completion_result_locked(const struct controller_state* s, uint32_t request_id,
+                                                int* out_result) {
+    if (!s || !out_result || request_id == 0U) {
+        return 0;
+    }
+    size_t slot = (size_t)(request_id % (uint32_t)kRetuneCompletionResultSlots);
+    if (s->retune_complete_result_ids[slot] != request_id) {
+        return 0;
+    }
+    *out_result = s->retune_complete_results[slot];
+    return 1;
+}
+
+static void
+controller_signal_manual_retune_complete(struct controller_state* s, int result) {
     dsd_mutex_lock(&s->retune_done_m);
-    s->retune_complete_id.fetch_add(1, std::memory_order_release);
+    uint32_t request_id = s->retune_complete_id.load(std::memory_order_acquire) + 1U;
+    controller_store_retune_completion_result_locked(s, request_id, result);
+    s->retune_complete_id.store(request_id, std::memory_order_release);
     dsd_cond_broadcast(&s->retune_done_cond);
     dsd_mutex_unlock(&s->retune_done_m);
 }
@@ -3888,14 +4036,21 @@ controller_process_manual_retune(struct controller_state* s, const ControllerRet
     }
     uint32_t target_hz = work->manual_freq_hz;
     int target_ppm = work->ppm_changed ? work->requested_ppm : work->current_ppm;
-    int ppm_rc = controller_apply_reconfigure(s, target_hz, target_ppm, &work->manual_profile);
+    int ppm_rc = 0;
+    int reconfigured = 0;
+    int retune_rc =
+        controller_apply_reconfigure(s, target_hz, target_ppm, &work->manual_profile, &ppm_rc, &reconfigured);
     if (work->ppm_changed && ppm_rc != 0) {
         note_failed_ppm_request(work->requested_ppm, work->requested_ppm_request_id, work->current_ppm, ppm_rc);
     }
-    controller_signal_manual_retune_complete(s);
-    drain_output_on_retune();
+    if (retune_rc == 0 || reconfigured) {
+        drain_output_on_retune();
+    }
+    controller_signal_manual_retune_complete(s, retune_rc == 0 ? RTL_STREAM_TUNE_OK : RTL_STREAM_TUNE_FAILED);
     controller_clear_active_ppm_request(s, work->ppm_pending);
-    if (work->ppm_changed && ppm_rc == 0) {
+    if (retune_rc != 0) {
+        LOG_NOTICE("Retune failed: %u Hz (rc=%d).\n", target_hz, retune_rc);
+    } else if (work->ppm_changed && ppm_rc == 0) {
         LOG_INFO("Retune applied: %u Hz (PPM=%d).\n", target_hz, work->requested_ppm);
     } else {
         LOG_INFO("Retune applied: %u Hz.\n", target_hz);
@@ -3928,10 +4083,19 @@ controller_process_ppm_change(struct controller_state* s, const ControllerRetune
     if (dsd::io::radio::rtl_ppm_should_reconfigure_after_apply(ppm_plan, ppm_rc)) {
         controller_prepare_reconfigure_input();
         store_dongle_ppm_error(work->requested_ppm);
-        controller_reconfigure_active_stream_locked(s, ppm_plan.freq_hz, DemodRetuneResetReason::PpmCorrection);
+        int reconfigured = 0;
+        int retune_rc = controller_reconfigure_active_stream_locked(
+            s, ppm_plan.freq_hz, DemodRetuneResetReason::PpmCorrection, &reconfigured);
         controller_end_reconfigure(s);
-        drain_output_on_retune();
-        LOG_INFO("PPM correction applied: %d (reconfigured %u Hz).\n", work->requested_ppm, ppm_plan.freq_hz);
+        if (retune_rc == 0 || reconfigured) {
+            drain_output_on_retune();
+        }
+        if (retune_rc == 0) {
+            LOG_INFO("PPM correction applied: %d (reconfigured %u Hz).\n", work->requested_ppm, ppm_plan.freq_hz);
+        } else {
+            LOG_NOTICE("PPM correction applied but reconfigure to %u Hz failed (rc=%d).\n", ppm_plan.freq_hz,
+                       retune_rc);
+        }
         return;
     }
     if (ppm_rc == 0) {
@@ -3972,8 +4136,13 @@ static DSD_THREAD_RETURN_TYPE
             continue;
         }
         s->freq_now = (s->freq_now + 1) % s->freq_len;
-        controller_apply_reconfigure(s, (uint32_t)s->freqs[s->freq_now], work.current_ppm, NULL);
-        drain_output_on_retune();
+        int ppm_rc = 0;
+        int reconfigured = 0;
+        int retune_rc = controller_apply_reconfigure(s, (uint32_t)s->freqs[s->freq_now], work.current_ppm, NULL,
+                                                     &ppm_rc, &reconfigured);
+        if (retune_rc == 0 || reconfigured) {
+            drain_output_on_retune();
+        }
     }
     DSD_THREAD_RETURN;
 }
@@ -4536,6 +4705,7 @@ controller_init(struct controller_state* s) {
     s->retune_done_flag.store(0);
     s->retune_request_id.store(0);
     s->retune_complete_id.store(0);
+    controller_clear_retune_completion_results(s);
     s->last_applied_freq_hz.store(0, std::memory_order_release);
     s->reconfigure_seq.store(0, std::memory_order_release);
 }
@@ -7361,8 +7531,18 @@ rtl_stream_log_tune_warning(uint32_t requested_freq, const char* reason) {
 }
 
 static int
+rtl_stream_tune_apply_completion_result(int rc, int completion, uint32_t requested_freq) {
+    if (rc == RTL_STREAM_TUNE_OK && completion != RTL_STREAM_TUNE_OK) {
+        rtl_stream_log_tune_warning(requested_freq, "apply_failed");
+        return RTL_STREAM_TUNE_FAILED;
+    }
+    return rc;
+}
+
+static int
 rtl_stream_tune_wait_for_completion(uint32_t request_id, uint32_t requested_freq) {
     int rc = RTL_STREAM_TUNE_OK;
+    int completion = RTL_STREAM_TUNE_OK;
     const uint64_t deadline_ns = dsd_time_monotonic_ns() + 500000000ULL;
     dsd_mutex_lock(&controller.retune_done_m);
     while (controller.retune_complete_id.load(std::memory_order_acquire) < request_id) {
@@ -7387,8 +7567,13 @@ rtl_stream_tune_wait_for_completion(uint32_t request_id, uint32_t requested_freq
             break;
         }
     }
+    if (rc == RTL_STREAM_TUNE_OK
+        && !controller_load_retune_completion_result_locked(&controller, request_id, &completion)) {
+        rtl_stream_log_tune_warning(requested_freq, "completion_missing");
+        rc = RTL_STREAM_TUNE_FAILED;
+    }
     dsd_mutex_unlock(&controller.retune_done_m);
-    return rc;
+    return rtl_stream_tune_apply_completion_result(rc, completion, requested_freq);
 }
 
 static int
@@ -7626,6 +7811,82 @@ dsd_rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samp
         output_cleanup(&output);
     }
     return 0;
+}
+
+extern "C" int
+dsd_rtl_stream_test_tune_completion_result(int wait_result, int completion_result) {
+    return rtl_stream_tune_apply_completion_result(wait_result, completion_result, 851000000U);
+}
+
+extern "C" int
+dsd_rtl_stream_test_capture_settings_failure_restore(uint32_t* out_full_freq_hz, uint32_t* out_full_rate_hz,
+                                                     int* out_full_rate_out_hz, uint32_t* out_partial_freq_hz,
+                                                     uint32_t* out_partial_rate_hz, int* out_partial_rate_out_hz) {
+    if (!out_full_freq_hz || !out_full_rate_hz || !out_full_rate_out_hz || !out_partial_freq_hz || !out_partial_rate_hz
+        || !out_partial_rate_out_hz) {
+        return -1;
+    }
+
+    CaptureSettingsSnapshot outer = capture_settings_snapshot();
+    int outer_rate_in = demod.rate_in;
+    int outer_post_downsample = demod.post_downsample;
+    int outer_offset_tuning = dongle.offset_tuning;
+    int outer_edge = controller.edge;
+    int outer_disable_fs4_shift = disable_fs4_shift;
+
+    demod.rate_in = 48000;
+    demod.post_downsample = 1;
+    demod.downsample_passes = 0;
+    demod.output_scale = 0.5f;
+    demod.rate_out = 48000;
+    dongle.offset_tuning = 1;
+    controller.edge = 0;
+    disable_fs4_shift = 1;
+    store_dongle_frequency(851000000U);
+    store_dongle_rate(960000U);
+
+    CaptureSettingsSnapshot before = capture_settings_snapshot();
+    optimal_settings(855000000, demod.rate_in);
+    restore_capture_settings(&before);
+    *out_full_freq_hz = load_dongle_frequency();
+    *out_full_rate_hz = load_dongle_rate();
+    *out_full_rate_out_hz = demod.rate_out;
+
+    optimal_settings(855000000, demod.rate_in);
+    restore_capture_rate_settings(&before);
+    *out_partial_freq_hz = load_dongle_frequency();
+    *out_partial_rate_hz = load_dongle_rate();
+    *out_partial_rate_out_hz = demod.rate_out;
+
+    restore_capture_settings(&outer);
+    demod.rate_in = outer_rate_in;
+    demod.post_downsample = outer_post_downsample;
+    dongle.offset_tuning = outer_offset_tuning;
+    controller.edge = outer_edge;
+    disable_fs4_shift = outer_disable_fs4_shift;
+    return 0;
+}
+
+extern "C" int
+dsd_rtl_stream_test_retune_completion_result_binding(int* out_first_result, int* out_second_result) {
+    if (!out_first_result || !out_second_result) {
+        return -1;
+    }
+    *out_first_result = -1;
+    *out_second_result = -1;
+
+    controller_state test_controller = {};
+    controller_init(&test_controller);
+    controller_signal_manual_retune_complete(&test_controller, RTL_STREAM_TUNE_FAILED);
+    controller_signal_manual_retune_complete(&test_controller, RTL_STREAM_TUNE_OK);
+
+    dsd_mutex_lock(&test_controller.retune_done_m);
+    int first_found = controller_load_retune_completion_result_locked(&test_controller, 1U, out_first_result);
+    int second_found = controller_load_retune_completion_result_locked(&test_controller, 2U, out_second_result);
+    dsd_mutex_unlock(&test_controller.retune_done_m);
+
+    controller_cleanup(&test_controller);
+    return (first_found && second_found) ? 0 : -2;
 }
 
 extern "C" int

--- a/src/protocol/p25/p25_sm_watchdog.c
+++ b/src/protocol/p25/p25_sm_watchdog.c
@@ -61,7 +61,7 @@ static DSD_THREAD_RETURN_TYPE
 #endif
     p25_sm_watchdog_thread(void* arg) {
     (void)arg;
-    while (atomic_load(&g_p25_sm_wd_running) && !exitflag) {
+    while (atomic_load(&g_p25_sm_wd_running) && !dsd_exitflag_load()) {
         if (g_opts && g_state) {
             p25_sm_try_tick(g_opts, g_state);
         }

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -226,6 +226,10 @@ config_snapshot_equals_block_c(const dsdneoRuntimeConfig& lhs, const dsdneoRunti
     CONFIG_EQ_FIELD(rtl_testmode_is_set);
     CONFIG_EQ_FIELD(rtl_testmode_enable);
     CONFIG_EQ_FIELD(rtl_if_gains_is_set);
+    CONFIG_EQ_FIELD(rtl_verify_is_set);
+    CONFIG_EQ_FIELD(rtl_verify_enable);
+    CONFIG_EQ_FIELD(rtl_verify_attempts_is_set);
+    CONFIG_EQ_FIELD(rtl_verify_attempts);
     CONFIG_EQ_FIELD(tuner_bw_hz_is_set);
     CONFIG_EQ_FIELD(tuner_bw_hz);
     CONFIG_EQ_FIELD(tuner_autogain_is_set);
@@ -574,6 +578,8 @@ config_init_defaults(dsdneoRuntimeConfig& c) {
 
     c.rtl_agc_enable = 1;
     c.rtl_direct_mode = 0;
+    c.rtl_verify_enable = 1;
+    c.rtl_verify_attempts = 10;
 
     c.tuner_autogain_probe_ms = 3000;
     c.tuner_autogain_seed_db = 30.0;
@@ -937,6 +943,15 @@ config_init_rtl_if_gains_and_tuner_bw(dsdneoRuntimeConfig& c) {
     const char* rig = getenv("DSD_NEO_RTL_IF_GAINS");
     c.rtl_if_gains_is_set = env_is_set(rig);
     env_copy_str(c.rtl_if_gains, sizeof c.rtl_if_gains, rig);
+
+    const char* rv = getenv("DSD_NEO_RTL_VERIFY");
+    c.rtl_verify_is_set = env_is_set(rv);
+    if (c.rtl_verify_is_set) {
+        c.rtl_verify_enable = env_is_falsey(rv) ? 0 : 1;
+    }
+
+    const char* rva = getenv("DSD_NEO_RTL_VERIFY_ATTEMPTS");
+    c.rtl_verify_attempts_is_set = env_parse_int_range(rva, 1, 10, &c.rtl_verify_attempts);
 
     const char* tbw = getenv("DSD_NEO_TUNER_BW_HZ");
     c.tuner_bw_hz_is_set = 0;

--- a/tests/engine/test_engine_synced_trunk_scan_tick.c
+++ b/tests/engine/test_engine_synced_trunk_scan_tick.c
@@ -66,7 +66,7 @@ __wrap_getFrameSync(dsd_opts* opts, dsd_state* state) {
     if (g_get_frame_sync_calls <= 3) {
         return DSD_SYNC_P25P1_POS;
     }
-    exitflag = 1;
+    dsd_exitflag_store(1);
     return DSD_SYNC_NONE;
 }
 

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -31,11 +31,14 @@ extern "C" int rtl_device_test_usb_apply_retry(int verify_enabled, int attempts,
 extern "C" int rtl_device_test_usb_manual_gain_controls(int agc_rc, int gain_mode_rc, int gain_rc, int* out_agc_calls,
                                                         int* out_gain_mode_calls, int* out_gain_calls,
                                                         int* out_recorded_agc_rc);
+extern "C" int rtl_device_test_usb_auto_gain_controls(int agc_rc, int gain_mode_rc, int* out_agc_calls,
+                                                      int* out_gain_mode_calls, int* out_recorded_agc_rc);
 extern "C" int dsd_rtl_stream_test_tune_completion_result(int wait_result, int completion_result);
 extern "C" int
 dsd_rtl_stream_test_capture_settings_failure_restore(uint32_t* out_full_freq_hz, uint32_t* out_full_rate_hz,
                                                      int* out_full_rate_out_hz, uint32_t* out_partial_freq_hz,
                                                      uint32_t* out_partial_rate_hz, int* out_partial_rate_out_hz);
+extern "C" int dsd_rtl_stream_test_ppm_store_if_applied(int ppm_rc, int requested_ppm, int* out_ppm_error);
 extern "C" int dsd_rtl_stream_test_retune_completion_result_binding(int* out_first_result, int* out_second_result);
 
 static int
@@ -154,12 +157,20 @@ main(void) {
                                                               &full_restore_rate_out_hz, &partial_restore_freq_hz,
                                                               &partial_restore_rate_hz, &partial_restore_rate_out_hz);
     failed |= expect_int_eq("capture settings restore helper rc", rc, 0);
-    failed |= expect_int_eq("frequency failure restores staged frequency", (int)full_restore_freq_hz, 851000000);
+    failed |= expect_int_eq("frequency failure restores applied frequency", (int)full_restore_freq_hz, 851000000);
     failed |= expect_int_eq("frequency failure restores staged rate", (int)full_restore_rate_hz, 960000);
     failed |= expect_int_eq("frequency failure restores demod rate", full_restore_rate_out_hz, 48000);
     failed |= expect_int_eq("partial retune keeps applied frequency", (int)partial_restore_freq_hz, 855000000);
     failed |= expect_int_eq("partial retune restores prior rate", (int)partial_restore_rate_hz, 960000);
     failed |= expect_int_eq("partial retune restores demod rate", partial_restore_rate_out_hz, 48000);
+
+    int ppm_after_failure = 0;
+    failed |= expect_int_eq("accepted ppm store helper rc",
+                            dsd_rtl_stream_test_ppm_store_if_applied(0, -7, &ppm_after_failure), 0);
+    failed |= expect_int_eq("accepted ppm survives retune failure", ppm_after_failure, -7);
+    failed |= expect_int_eq("failed ppm store helper rc",
+                            dsd_rtl_stream_test_ppm_store_if_applied(-5, 11, &ppm_after_failure), 0);
+    failed |= expect_int_eq("failed ppm keeps previous runtime ppm", ppm_after_failure, 3);
 
     cache_pending = -1;
     rc = rtl_stream_test_clear_output(7U, 3, &used_after, &cache_pending, &generation_before, &generation_after);
@@ -296,6 +307,18 @@ main(void) {
     failed |= expect_int_eq("manual gain mode still applied", gain_mode_calls, 1);
     failed |= expect_int_eq("manual gain value still applied", gain_calls, 1);
     failed |= expect_int_eq("manual gain records AGC failure", recorded_agc_rc, -5);
+
+    rc = rtl_device_test_usb_auto_gain_controls(-6, 0, &agc_calls, &gain_mode_calls, &recorded_agc_rc);
+    failed |= expect_int_eq("auto gain ignores AGC failure rc", rc, 0);
+    failed |= expect_int_eq("auto gain AGC call count", agc_calls, 1);
+    failed |= expect_int_eq("auto gain mode still applied", gain_mode_calls, 1);
+    failed |= expect_int_eq("auto gain records AGC failure", recorded_agc_rc, -6);
+
+    rc = rtl_device_test_usb_auto_gain_controls(0, -7, &agc_calls, &gain_mode_calls, &recorded_agc_rc);
+    failed |= expect_int_eq("auto gain mode failure remains fatal", rc, -7);
+    failed |= expect_int_eq("auto gain mode failure call count", gain_mode_calls, 1);
+    failed |= expect_int_eq("auto gain skips AGC after mode failure", agc_calls, 0);
+    failed |= expect_int_eq("auto gain mode failure records no AGC failure", recorded_agc_rc, 0);
 
     // Fragmented mute spans are coalesced so capture metadata stays IQ-pair aligned.
     uint64_t pending_mute = 0U;

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -25,6 +25,18 @@ extern "C" int rtl_device_test_soapy_config_settings_visibility(size_t config_si
 extern "C" void rtl_device_test_replay_dispatch_reset_event_state(int* phase, int* have_carry, uint8_t* carry_byte);
 extern "C" int rtl_device_test_replay_event_boundary_drained(size_t ring_used, uint64_t submitted_gen,
                                                              uint64_t consumed_gen);
+extern "C" int rtl_device_test_usb_apply_retry(int verify_enabled, int attempts, int apply_success_after,
+                                               int verify_success_after, int* out_apply_calls, int* out_verify_calls,
+                                               int* out_used_attempts);
+extern "C" int rtl_device_test_usb_manual_gain_controls(int agc_rc, int gain_mode_rc, int gain_rc, int* out_agc_calls,
+                                                        int* out_gain_mode_calls, int* out_gain_calls,
+                                                        int* out_recorded_agc_rc);
+extern "C" int dsd_rtl_stream_test_tune_completion_result(int wait_result, int completion_result);
+extern "C" int
+dsd_rtl_stream_test_capture_settings_failure_restore(uint32_t* out_full_freq_hz, uint32_t* out_full_rate_hz,
+                                                     int* out_full_rate_out_hz, uint32_t* out_partial_freq_hz,
+                                                     uint32_t* out_partial_rate_hz, int* out_partial_rate_out_hz);
+extern "C" int dsd_rtl_stream_test_retune_completion_result_binding(int* out_first_result, int* out_second_result);
 
 static int
 expect_int_eq(const char* label, int got, int want) {
@@ -116,6 +128,38 @@ main(void) {
     failed |= expect_size_eq("deferred tune leaves queued output", used_after, 5U);
     failed |= expect_int_eq("deferred tune leaves cached symbols", cache_pending, 3);
     failed |= expect_generation_eq("deferred tune keeps output generation", generation_before, generation_after);
+    failed |= expect_int_eq("ok completion result keeps tune ok",
+                            dsd_rtl_stream_test_tune_completion_result(RTL_STREAM_TUNE_OK, RTL_STREAM_TUNE_OK),
+                            RTL_STREAM_TUNE_OK);
+    failed |= expect_int_eq("failed completion result maps tune failed",
+                            dsd_rtl_stream_test_tune_completion_result(RTL_STREAM_TUNE_OK, RTL_STREAM_TUNE_FAILED),
+                            RTL_STREAM_TUNE_FAILED);
+    failed |= expect_int_eq("timeout completion result keeps timeout",
+                            dsd_rtl_stream_test_tune_completion_result(RTL_STREAM_TUNE_TIMEOUT, RTL_STREAM_TUNE_FAILED),
+                            RTL_STREAM_TUNE_TIMEOUT);
+    int first_completion_result = -1;
+    int second_completion_result = -1;
+    rc = dsd_rtl_stream_test_retune_completion_result_binding(&first_completion_result, &second_completion_result);
+    failed |= expect_int_eq("retune completion result binding helper rc", rc, 0);
+    failed |= expect_int_eq("first completion keeps failed result", first_completion_result, RTL_STREAM_TUNE_FAILED);
+    failed |= expect_int_eq("second completion keeps ok result", second_completion_result, RTL_STREAM_TUNE_OK);
+
+    uint32_t full_restore_freq_hz = 0U;
+    uint32_t full_restore_rate_hz = 0U;
+    int full_restore_rate_out_hz = 0;
+    uint32_t partial_restore_freq_hz = 0U;
+    uint32_t partial_restore_rate_hz = 0U;
+    int partial_restore_rate_out_hz = 0;
+    rc = dsd_rtl_stream_test_capture_settings_failure_restore(&full_restore_freq_hz, &full_restore_rate_hz,
+                                                              &full_restore_rate_out_hz, &partial_restore_freq_hz,
+                                                              &partial_restore_rate_hz, &partial_restore_rate_out_hz);
+    failed |= expect_int_eq("capture settings restore helper rc", rc, 0);
+    failed |= expect_int_eq("frequency failure restores staged frequency", (int)full_restore_freq_hz, 851000000);
+    failed |= expect_int_eq("frequency failure restores staged rate", (int)full_restore_rate_hz, 960000);
+    failed |= expect_int_eq("frequency failure restores demod rate", full_restore_rate_out_hz, 48000);
+    failed |= expect_int_eq("partial retune keeps applied frequency", (int)partial_restore_freq_hz, 855000000);
+    failed |= expect_int_eq("partial retune restores prior rate", (int)partial_restore_rate_hz, 960000);
+    failed |= expect_int_eq("partial retune restores demod rate", partial_restore_rate_out_hz, 48000);
 
     cache_pending = -1;
     rc = rtl_stream_test_clear_output(7U, 3, &used_after, &cache_pending, &generation_before, &generation_after);
@@ -207,6 +251,51 @@ main(void) {
         "sized Soapy config settings visibility helper",
         rtl_device_test_soapy_config_settings_visibility(RTL_SOAPY_CONFIG_SIZE, "biasT_ctrl=false", &settings_seen), 0);
     failed |= expect_int_eq("sized Soapy config observes appended settings", settings_seen, 1);
+
+    int apply_calls = -1;
+    int verify_calls = -1;
+    int used_attempts = -1;
+    rc = rtl_device_test_usb_apply_retry(1, 10, 1, 1, &apply_calls, &verify_calls, &used_attempts);
+    failed |= expect_int_eq("rtl usb retry first-attempt rc", rc, 0);
+    failed |= expect_int_eq("rtl usb retry first-attempt apply calls", apply_calls, 1);
+    failed |= expect_int_eq("rtl usb retry first-attempt verify calls", verify_calls, 1);
+    failed |= expect_int_eq("rtl usb retry first-attempt used attempts", used_attempts, 1);
+
+    rc = rtl_device_test_usb_apply_retry(1, 10, 3, 1, &apply_calls, &verify_calls, &used_attempts);
+    failed |= expect_int_eq("rtl usb retry apply succeeds late rc", rc, 0);
+    failed |= expect_int_eq("rtl usb retry apply succeeds late apply calls", apply_calls, 3);
+    failed |= expect_int_eq("rtl usb retry apply succeeds late verify calls", verify_calls, 1);
+    failed |= expect_int_eq("rtl usb retry apply succeeds late used attempts", used_attempts, 3);
+
+    rc = rtl_device_test_usb_apply_retry(1, 10, 1, 3, &apply_calls, &verify_calls, &used_attempts);
+    failed |= expect_int_eq("rtl usb retry verify succeeds late rc", rc, 0);
+    failed |= expect_int_eq("rtl usb retry verify succeeds late apply calls", apply_calls, 3);
+    failed |= expect_int_eq("rtl usb retry verify succeeds late verify calls", verify_calls, 3);
+    failed |= expect_int_eq("rtl usb retry verify succeeds late used attempts", used_attempts, 3);
+
+    rc = rtl_device_test_usb_apply_retry(1, 10, 11, 1, &apply_calls, &verify_calls, &used_attempts);
+    failed |= expect_int_eq("rtl usb retry exhausted rc", rc, -1);
+    failed |= expect_int_eq("rtl usb retry exhausted apply calls", apply_calls, 10);
+    failed |= expect_int_eq("rtl usb retry exhausted verify calls", verify_calls, 0);
+    failed |= expect_int_eq("rtl usb retry exhausted used attempts", used_attempts, 10);
+
+    rc = rtl_device_test_usb_apply_retry(0, 10, 1, 10, &apply_calls, &verify_calls, &used_attempts);
+    failed |= expect_int_eq("rtl usb retry disabled rc", rc, 0);
+    failed |= expect_int_eq("rtl usb retry disabled apply calls", apply_calls, 1);
+    failed |= expect_int_eq("rtl usb retry disabled verify calls", verify_calls, 0);
+    failed |= expect_int_eq("rtl usb retry disabled used attempts", used_attempts, 1);
+
+    int agc_calls = -1;
+    int gain_mode_calls = -1;
+    int gain_calls = -1;
+    int recorded_agc_rc = 0;
+    rc =
+        rtl_device_test_usb_manual_gain_controls(-5, 0, 0, &agc_calls, &gain_mode_calls, &gain_calls, &recorded_agc_rc);
+    failed |= expect_int_eq("manual gain ignores AGC failure rc", rc, 0);
+    failed |= expect_int_eq("manual gain AGC call count", agc_calls, 1);
+    failed |= expect_int_eq("manual gain mode still applied", gain_mode_calls, 1);
+    failed |= expect_int_eq("manual gain value still applied", gain_calls, 1);
+    failed |= expect_int_eq("manual gain records AGC failure", recorded_agc_rc, -5);
 
     // Fragmented mute spans are coalesced so capture metadata stays IQ-pair aligned.
     uint64_t pending_mute = 0U;

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -327,8 +327,8 @@ main(void) {
     failed |= expect_int_eq("rtl sample-rate readback exact actual", (int)actual_rate, 960000);
     actual_rate = 99U;
     rc = rtl_device_test_usb_sample_rate_readback(1024000U, 960000U, &actual_rate);
-    failed |= expect_int_eq("rtl sample-rate readback rejects stale rc", rc, -1);
-    failed |= expect_int_eq("rtl sample-rate readback clears stale actual", (int)actual_rate, 0);
+    failed |= expect_int_eq("rtl sample-rate readback accepts quantized rc", rc, 0);
+    failed |= expect_int_eq("rtl sample-rate readback returns quantized actual", (int)actual_rate, 960000);
     rc = rtl_device_test_usb_sample_rate_readback(1024000U, 0U, &actual_rate);
     failed |= expect_int_eq("rtl sample-rate readback rejects zero rc", rc, -1);
 

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -28,12 +28,19 @@ extern "C" int rtl_device_test_replay_event_boundary_drained(size_t ring_used, u
 extern "C" int rtl_device_test_usb_apply_retry(int verify_enabled, int attempts, int apply_success_after,
                                                int verify_success_after, int* out_apply_calls, int* out_verify_calls,
                                                int* out_used_attempts);
+extern "C" int rtl_device_test_usb_sample_rate_readback(uint32_t requested_rate, uint32_t actual_rate,
+                                                        uint32_t* out_actual_rate);
 extern "C" int rtl_device_test_usb_manual_gain_controls(int agc_rc, int gain_mode_rc, int gain_rc, int* out_agc_calls,
                                                         int* out_gain_mode_calls, int* out_gain_calls,
                                                         int* out_recorded_agc_rc);
 extern "C" int rtl_device_test_usb_auto_gain_controls(int agc_rc, int gain_mode_rc, int* out_agc_calls,
                                                       int* out_gain_mode_calls, int* out_recorded_agc_rc);
 extern "C" int dsd_rtl_stream_test_tune_completion_result(int wait_result, int completion_result);
+extern "C" int dsd_rtl_stream_test_manual_retune_completion_result(int retune_rc, int reconfigured, uint32_t target_hz,
+                                                                   uint32_t applied_freq_hz);
+extern "C" int dsd_rtl_stream_test_tune_failure_reconciles_applied(uint32_t requested_freq_hz, uint32_t applied_freq_hz,
+                                                                   long int* out_opts_freq,
+                                                                   uint32_t* out_capture_freq_hz);
 extern "C" int
 dsd_rtl_stream_test_capture_settings_failure_restore(uint32_t* out_full_freq_hz, uint32_t* out_full_rate_hz,
                                                      int* out_full_rate_out_hz, uint32_t* out_partial_freq_hz,
@@ -140,6 +147,24 @@ main(void) {
     failed |= expect_int_eq("timeout completion result keeps timeout",
                             dsd_rtl_stream_test_tune_completion_result(RTL_STREAM_TUNE_TIMEOUT, RTL_STREAM_TUNE_FAILED),
                             RTL_STREAM_TUNE_TIMEOUT);
+    failed |= expect_int_eq("committed retune failure reports tune ok",
+                            dsd_rtl_stream_test_manual_retune_completion_result(-5, 1, 855000000U, 855000000U),
+                            RTL_STREAM_TUNE_OK);
+    failed |= expect_int_eq("uncommitted retune failure reports tune failed",
+                            dsd_rtl_stream_test_manual_retune_completion_result(-5, 1, 855000000U, 851000000U),
+                            RTL_STREAM_TUNE_FAILED);
+    failed |= expect_int_eq("failed retune without reconfigure reports tune failed",
+                            dsd_rtl_stream_test_manual_retune_completion_result(-5, 0, 855000000U, 855000000U),
+                            RTL_STREAM_TUNE_FAILED);
+
+    long int reconciled_opts_freq = 0;
+    uint32_t reconciled_capture_freq = 0U;
+    rc = dsd_rtl_stream_test_tune_failure_reconciles_applied(855000000U, 851000000U, &reconciled_opts_freq,
+                                                             &reconciled_capture_freq);
+    failed |= expect_int_eq("failed tune reconcile helper rc", rc, 0);
+    failed |= expect_int_eq("failed tune rolls caller freq back to applied", (int)reconciled_opts_freq, 851000000);
+    failed |= expect_int_eq("failed tune restores applied capture center", (int)reconciled_capture_freq, 851240000);
+
     int first_completion_result = -1;
     int second_completion_result = -1;
     rc = dsd_rtl_stream_test_retune_completion_result_binding(&first_completion_result, &second_completion_result);
@@ -295,6 +320,17 @@ main(void) {
     failed |= expect_int_eq("rtl usb retry disabled apply calls", apply_calls, 1);
     failed |= expect_int_eq("rtl usb retry disabled verify calls", verify_calls, 0);
     failed |= expect_int_eq("rtl usb retry disabled used attempts", used_attempts, 1);
+
+    uint32_t actual_rate = 0U;
+    rc = rtl_device_test_usb_sample_rate_readback(960000U, 960000U, &actual_rate);
+    failed |= expect_int_eq("rtl sample-rate readback exact rc", rc, 0);
+    failed |= expect_int_eq("rtl sample-rate readback exact actual", (int)actual_rate, 960000);
+    actual_rate = 99U;
+    rc = rtl_device_test_usb_sample_rate_readback(1024000U, 960000U, &actual_rate);
+    failed |= expect_int_eq("rtl sample-rate readback rejects stale rc", rc, -1);
+    failed |= expect_int_eq("rtl sample-rate readback clears stale actual", (int)actual_rate, 0);
+    rc = rtl_device_test_usb_sample_rate_readback(1024000U, 0U, &actual_rate);
+    failed |= expect_int_eq("rtl sample-rate readback rejects zero rc", rc, -1);
 
     int agc_calls = -1;
     int gain_mode_calls = -1;

--- a/tests/runtime/test_runtime_config_env.cpp
+++ b/tests/runtime/test_runtime_config_env.cpp
@@ -161,6 +161,8 @@ unset_all_runtime_env(void) {
         "DSD_NEO_RTL_IF_GAINS",
         "DSD_NEO_RTL_OFFSET_TUNING",
         "DSD_NEO_RTL_TESTMODE",
+        "DSD_NEO_RTL_VERIFY",
+        "DSD_NEO_RTL_VERIFY_ATTEMPTS",
         "DSD_NEO_RTL_XTAL_HZ",
         "DSD_NEO_RT_PRIO_DEMOD",
         "DSD_NEO_RT_PRIO_DONGLE",
@@ -1626,6 +1628,71 @@ test_rtl_misc_env(void) {
 }
 
 static int
+test_rtl_verify_env(void) {
+    unsetenv("DSD_NEO_RTL_VERIFY");
+    unsetenv("DSD_NEO_RTL_VERIFY_ATTEMPTS");
+    dsd_neo_config_init(NULL);
+    const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
+    int rc = expect(cfg != NULL, 1380, "cfg NULL");
+    if (rc != 0) {
+        return rc;
+    }
+    rc = expect_int_eq(cfg->rtl_verify_is_set, 0, 1381, "rtl_verify_is_set default");
+    if (rc != 0) {
+        return rc;
+    }
+    rc = expect_int_eq(cfg->rtl_verify_enable, 1, 1382, "rtl_verify_enable default");
+    if (rc != 0) {
+        return rc;
+    }
+    rc = expect_int_eq(cfg->rtl_verify_attempts_is_set, 0, 1383, "rtl_verify_attempts_is_set default");
+    if (rc != 0) {
+        return rc;
+    }
+    rc = expect_int_eq(cfg->rtl_verify_attempts, 10, 1384, "rtl_verify_attempts default");
+    if (rc != 0) {
+        return rc;
+    }
+
+    setenv("DSD_NEO_RTL_VERIFY", "0", 1);
+    setenv("DSD_NEO_RTL_VERIFY_ATTEMPTS", "4", 1);
+    dsd_neo_config_init(NULL);
+    cfg = dsd_neo_get_config();
+    rc = expect_int_eq(cfg->rtl_verify_is_set, 1, 1385, "rtl_verify_is_set disabled");
+    if (rc != 0) {
+        return rc;
+    }
+    rc = expect_int_eq(cfg->rtl_verify_enable, 0, 1386, "rtl_verify_enable disabled");
+    if (rc != 0) {
+        return rc;
+    }
+    rc = expect_int_eq(cfg->rtl_verify_attempts_is_set, 1, 1387, "rtl_verify_attempts_is_set 4");
+    if (rc != 0) {
+        return rc;
+    }
+    rc = expect_int_eq(cfg->rtl_verify_attempts, 4, 1388, "rtl_verify_attempts 4");
+    if (rc != 0) {
+        return rc;
+    }
+
+    setenv("DSD_NEO_RTL_VERIFY_ATTEMPTS", "11", 1);
+    dsd_neo_config_init(NULL);
+    cfg = dsd_neo_get_config();
+    rc = expect_int_eq(cfg->rtl_verify_attempts_is_set, 0, 1389, "rtl_verify_attempts_is_set 11");
+    if (rc != 0) {
+        return rc;
+    }
+    rc = expect_int_eq(cfg->rtl_verify_attempts, 10, 1390, "rtl_verify_attempts invalid defaults");
+    if (rc != 0) {
+        return rc;
+    }
+
+    unsetenv("DSD_NEO_RTL_VERIFY");
+    unsetenv("DSD_NEO_RTL_VERIFY_ATTEMPTS");
+    return 0;
+}
+
+static int
 test_tuner_autogain_env(void) {
     /*
      * Tuner auto-gain has an enable bit plus timing, seed, SNR, ratio, and step
@@ -2505,6 +2572,10 @@ main(void) {
         return rc;
     }
     rc = test_rtl_direct_mode();
+    if (rc != 0) {
+        return rc;
+    }
+    rc = test_rtl_verify_env();
     if (rc != 0) {
         return rc;
     }


### PR DESCRIPTION
## Summary

- Add bounded local USB RTL-SDR control apply retries, defaulting to ten attempts.
- Verify applied state where librtlsdr exposes useful getters, and retry return-code-only controls where no readback exists.
- Propagate failed initial tuning and manual retunes so cached radio state is not advanced after unsuccessful required applies.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: none from the listed set; radio input touched and extra guardrails run.
- [x] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `tools/format.sh`
- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure -R "(RUNTIME_CONFIG_ENV|IO_RTL_RETUNE_PREPARE)"`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [x] `tools/quality_preflight.sh`
- [x] `git diff --check`
- [x] pre-push hook: clang-format, clang-tidy, cppcheck, IWYU, lizard, and pin/redaction guardrails
- [ ] `tools/cmake_format_check.sh` for CMake changes: not run separately; no CMake files changed and covered by quality preflight.
- [ ] `tools/zizmor.sh` for workflow changes: not run separately; no workflow files changed and covered by quality preflight.
- [ ] `tools/osv_scan.sh` for dependency input changes: not run separately; no dependency inputs changed and covered by quality preflight.
- [ ] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes: not run separately; no workflow or release files changed, and the relevant guardrails ran through preflight/quality/pre-push.

## Risk

- Security/dependency impact: no dependency or secret-handling changes.
- CLI/UI behavior impact: adds `DSD_NEO_RTL_VERIFY` and `DSD_NEO_RTL_VERIFY_ATTEMPTS` runtime environment controls; default verification is enabled.
- Compatibility or packaging impact: no packaging changes; local USB RTL-SDR apply failures can now surface instead of silently updating cached state.
