### PR TITLE
p25: seed control channel before voice grants

### DIFF
--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -180,6 +180,22 @@ void p25_sm_init_ctx(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state);
 void p25_sm_event(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev);
 
 /**
+ * @brief Seed an unknown P25 control-channel frequency from known CC state.
+ *
+ * Control-channel grant decoders call this before gating on state->p25_cc_freq
+ * so the first live grant can establish the CC frequency for return-to-CC
+ * behavior. The generic trunk CC alias is preferred when it is already known.
+ * Otherwise the tuner is sampled only while legacy tune flags indicate the
+ * decoder is parked on the control channel; voice-channel tunes are ignored.
+ * Live P25 Phase 2 sync seeds a TDMA CC modulation hint; live P25 Phase 1 sync
+ * clears any stale TDMA CC hint.
+ *
+ * @param opts Decoder options.
+ * @param state Decoder state.
+ */
+void p25_sm_seed_cc_from_current_tuner_if_unknown(const dsd_opts* opts, dsd_state* state);
+
+/**
  * @brief Periodic tick for timeout-based transitions.
  *
  * Call at ~1-10 Hz. Handles:

--- a/src/protocol/p25/p25_lcw.c
+++ b/src/protocol/p25/p25_lcw.c
@@ -247,6 +247,52 @@ p25_lcw_handle_format_42(p25_lcw_ctx* ctx) {
     }
 }
 
+static int
+p25_lcw_trunk_cc_ready_for_grant(p25_lcw_ctx* ctx) {
+    if (ctx->opts->p25_trunk != 1) {
+        return 0;
+    }
+    return ctx->state->p25_cc_freq != 0 || ctx->state->trunk_cc_freq > 0;
+}
+
+static int
+p25_lcw_format_44_skip_grant(const p25_lcw_ctx* ctx, uint16_t group) {
+    if (ctx->state->tg_hold != 0 && ctx->state->tg_hold != group) {
+        return 1;
+    }
+    if ((ctx->lc_svcopt & 0x40) && ctx->opts->trunk_tune_enc_calls == 0
+        && !p25_patch_tg_key_is_clear(ctx->state, group)) {
+        return 1;
+    }
+    return 0;
+}
+
+static void
+p25_lcw_warn_format_44_retune_disabled(p25_lcw_ctx* ctx) {
+    if (ctx->state->p25_lcw_retune_disabled_warned != 0) {
+        return;
+    }
+    ctx->state->p25_lcw_retune_disabled_warned = 1;
+    DSD_FPRINTF(stderr,
+                " [WARN: P25 LCW explicit retune is disabled; 0x44 grants may not be followed. Enable with -j or "
+                "menu.] ");
+}
+
+static void
+p25_lcw_handle_format_44_trunking(p25_lcw_ctx* ctx, uint16_t channel, uint16_t group) {
+    if (!p25_lcw_trunk_cc_ready_for_grant(ctx)) {
+        return;
+    }
+    if (ctx->opts->p25_lcw_retune == 0) {
+        p25_lcw_warn_format_44_retune_disabled(ctx);
+        return;
+    }
+    if (ctx->opts->p25_lcw_retune == 1 && ctx->opts->trunk_tune_group_calls == 1
+        && !p25_lcw_format_44_skip_grant(ctx, group)) {
+        p25_sm_on_group_grant(ctx->opts, ctx->state, channel, ctx->lc_svcopt, group, (int)ctx->state->lastsrc);
+    }
+}
+
 static void
 p25_lcw_handle_format_44(p25_lcw_ctx* ctx) {
     DSD_FPRINTF(stderr, " Group Voice Channel Update %s Explicit", dsd_unicode_or_ascii("–", "-"));
@@ -256,28 +302,7 @@ p25_lcw_handle_format_44(p25_lcw_ctx* ctx) {
     DSD_FPRINTF(stderr, "Ch: %04X TG: %d; ", channelt, group1);
     UNUSED(channelr);
 
-    if (ctx->opts->p25_lcw_retune == 1 && ctx->opts->p25_trunk == 1 && ctx->state->p25_cc_freq != 0) {
-        if (ctx->opts->trunk_tune_group_calls == 1) {
-            int skip_grant = 0;
-            if (ctx->state->tg_hold != 0 && ctx->state->tg_hold != group1) {
-                skip_grant = 1;
-            }
-            if ((ctx->lc_svcopt & 0x40) && ctx->opts->trunk_tune_enc_calls == 0
-                && !p25_patch_tg_key_is_clear(ctx->state, group1)) {
-                skip_grant = 1;
-            }
-            if (!skip_grant) {
-                p25_sm_on_group_grant(ctx->opts, ctx->state, channelt, ctx->lc_svcopt, group1,
-                                      (int)ctx->state->lastsrc);
-            }
-        }
-    } else if (ctx->opts->p25_lcw_retune == 0 && ctx->opts->p25_trunk == 1 && ctx->state->p25_cc_freq != 0
-               && ctx->state->p25_lcw_retune_disabled_warned == 0) {
-        ctx->state->p25_lcw_retune_disabled_warned = 1;
-        DSD_FPRINTF(stderr,
-                    " [WARN: P25 LCW explicit retune is disabled; 0x44 grants may not be followed. Enable with -j or "
-                    "menu.] ");
-    }
+    p25_lcw_handle_format_44_trunking(ctx, channelt, group1);
 
     char suf[32];
     p25_format_chan_suffix(ctx->state, channelt, -1, suf, sizeof suf);

--- a/src/protocol/p25/p25_test_lcw_shim.c
+++ b/src/protocol/p25/p25_test_lcw_shim.c
@@ -18,7 +18,8 @@
 #include "p25_test_lcw_shim.h"
 
 static void
-p25_test_invoke_lcw_impl(const unsigned char* lcw_bits, int len, int enable_retune, long cc_freq, long lastsrc) {
+p25_test_invoke_lcw_impl(const unsigned char* lcw_bits, int len, int enable_retune, long cc_freq, long lastsrc,
+                         long tuner_freq) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
     if (!opts || !state) {
@@ -31,6 +32,10 @@ p25_test_invoke_lcw_impl(const unsigned char* lcw_bits, int len, int enable_retu
     opts->p25_lcw_retune = (enable_retune != 0) ? 1 : 0;
     opts->trunk_tune_group_calls = 1;
     opts->trunk_tune_enc_calls = 0;
+    if (tuner_freq > 0) {
+        opts->audio_in_type = AUDIO_IN_RTL;
+        opts->rtlsdr_center_freq = (uint32_t)tuner_freq;
+    }
 
     state->p25_cc_freq = cc_freq;
     state->lastsrc = lastsrc;
@@ -51,11 +56,17 @@ p25_test_invoke_lcw_impl(const unsigned char* lcw_bits, int len, int enable_retu
 
 void
 p25_test_invoke_lcw(const unsigned char* lcw_bits, int len, int enable_retune, long cc_freq) {
-    p25_test_invoke_lcw_impl(lcw_bits, len, enable_retune, cc_freq, 0);
+    p25_test_invoke_lcw_impl(lcw_bits, len, enable_retune, cc_freq, 0, 0);
 }
 
 void
 p25_test_invoke_lcw_with_lastsrc(const unsigned char* lcw_bits, int len, int enable_retune, long cc_freq,
                                  long lastsrc) {
-    p25_test_invoke_lcw_impl(lcw_bits, len, enable_retune, cc_freq, lastsrc);
+    p25_test_invoke_lcw_impl(lcw_bits, len, enable_retune, cc_freq, lastsrc, 0);
+}
+
+void
+p25_test_invoke_lcw_with_tuner(const unsigned char* lcw_bits, int len, int enable_retune, long cc_freq,
+                               long tuner_freq) {
+    p25_test_invoke_lcw_impl(lcw_bits, len, enable_retune, cc_freq, 0, tuner_freq);
 }

--- a/src/protocol/p25/p25_test_lcw_shim.h
+++ b/src/protocol/p25/p25_test_lcw_shim.h
@@ -13,6 +13,8 @@ extern "C" {
 void p25_test_invoke_lcw(const unsigned char* lcw_bits, int len, int enable_retune, long cc_freq);
 void p25_test_invoke_lcw_with_lastsrc(const unsigned char* lcw_bits, int len, int enable_retune, long cc_freq,
                                       long lastsrc);
+void p25_test_invoke_lcw_with_tuner(const unsigned char* lcw_bits, int len, int enable_retune, long cc_freq,
+                                    long tuner_freq);
 
 #ifdef __cplusplus
 }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -19,6 +19,7 @@
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/p25_optional_hooks.h>
 #include <dsd-neo/runtime/p25_p2_audio_ring.h>
+#include <dsd-neo/runtime/rigctl_query_hooks.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
@@ -86,6 +87,69 @@ p25_sm_valid_nac_ull(unsigned long long nac) {
     return nac > 0 && nac != 0xFFFULL && nac <= 0xFFFULL;
 }
 
+static long
+p25_sm_current_tuner_freq_hz(const dsd_opts* opts) {
+    if (!opts) {
+        return 0;
+    }
+    if (opts->use_rigctl == 1) {
+        long freq = dsd_rigctl_query_hook_get_current_freq_hz(opts);
+        return (freq > 0) ? freq : 0;
+    }
+    if (opts->audio_in_type == AUDIO_IN_RTL && opts->rtlsdr_center_freq > 0) {
+        return (long)opts->rtlsdr_center_freq;
+    }
+    return 0;
+}
+
+static void
+p25_sm_seed_cc_modulation_from_current_sync(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    if (DSD_SYNC_IS_P25P2(state->synctype)) {
+        state->p25_cc_is_tdma = 1;
+    } else if (DSD_SYNC_IS_P25P1(state->synctype)) {
+        state->p25_cc_is_tdma = 0;
+    }
+}
+
+static void
+p25_sm_seed_cc_from_known_trunk_alias_if_unknown(dsd_state* state) {
+    if (!state || state->p25_cc_freq != 0 || state->trunk_cc_freq <= 0) {
+        return;
+    }
+    state->p25_cc_freq = state->trunk_cc_freq;
+    p25_sm_seed_cc_modulation_from_current_sync(state);
+    if (state->trunk_lcn_freq[0] == 0) {
+        state->trunk_lcn_freq[0] = state->trunk_cc_freq;
+    }
+}
+
+void
+p25_sm_seed_cc_from_current_tuner_if_unknown(const dsd_opts* opts, dsd_state* state) {
+    if (!state || state->p25_cc_freq != 0) {
+        return;
+    }
+    p25_sm_seed_cc_from_known_trunk_alias_if_unknown(state);
+    if (state->p25_cc_freq != 0) {
+        return;
+    }
+    if (!opts || opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1) {
+        return;
+    }
+    long freq = p25_sm_current_tuner_freq_hz(opts);
+    if (freq <= 0) {
+        return;
+    }
+    state->p25_cc_freq = freq;
+    state->trunk_cc_freq = freq;
+    p25_sm_seed_cc_modulation_from_current_sync(state);
+    if (state->trunk_lcn_freq[0] == 0) {
+        state->trunk_lcn_freq[0] = freq;
+    }
+}
+
 static int
 p25_sm_current_cc_nac(const dsd_state* state) {
     if (!state) {
@@ -119,15 +183,21 @@ p25_sm_set_expected_cc_nac(p25_sm_ctx_t* ctx, const dsd_state* state, int replac
 }
 
 static void
-p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, const dsd_state* state, double tune_start_m) {
+p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, dsd_state* state, double tune_start_m) {
     if (!ctx) {
         return;
     }
     ctx->t_cc_sync_m = tune_start_m;
-    if (state && state->last_cc_sync_time_m > ctx->t_cc_sync_m) {
-        // CC retune hooks update this as tune metadata before any CC frame decodes.
-        // Absorb that timestamp now so the next watchdog tick does not relatch NAC from it.
-        ctx->t_cc_sync_m = state->last_cc_sync_time_m;
+    if (state) {
+        if (state->last_cc_sync_time_m <= 0.0 || state->last_cc_sync_time_m < tune_start_m) {
+            state->last_cc_sync_time = time(NULL);
+            state->last_cc_sync_time_m = tune_start_m;
+        }
+        if (state->last_cc_sync_time_m > ctx->t_cc_sync_m) {
+            // CC retune hooks update this as tune metadata before any CC frame decodes.
+            // Absorb that timestamp now so the next watchdog tick does not relatch NAC from it.
+            ctx->t_cc_sync_m = state->last_cc_sync_time_m;
+        }
     }
 }
 
@@ -729,6 +799,23 @@ p25_grant_retune_blocked(const dsd_opts* opts, dsd_state* state, long freq, int 
     return p25_retune_block_log_match(opts, state, channel, freq, slot, state->p25_retune_block_until);
 }
 
+static void
+p25_grant_seed_cc_before_vc_tune(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, double now_m) {
+    if (!ctx || !state) {
+        return;
+    }
+    if (state->p25_cc_freq == 0) {
+        p25_sm_seed_cc_from_known_trunk_alias_if_unknown(state);
+    }
+    if (state->p25_cc_freq == 0 || ctx->state != P25_SM_IDLE) {
+        return;
+    }
+
+    p25_sm_start_cc_grace_after_tune(ctx, state, now_m);
+    p25_sm_set_expected_cc_nac(ctx, state, 0);
+    set_state(ctx, opts, state, P25_SM_ON_CC, "grant-cc-seed");
+}
+
 /* ============================================================================
  * Event Handlers
  * ============================================================================ */
@@ -776,6 +863,8 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     if (!p25_grant_preempt_active_call_if_needed(ctx, opts, state, &route, &decision, now_m)) {
         return;
     }
+
+    p25_grant_seed_cc_before_vc_tune(ctx, opts, state, now_m);
 
     if (!p25_grant_try_tune_vc(ev, opts, state, freq, slot, &ted_sps)) {
         return;

--- a/src/protocol/p25/phase1/p25p1_pdu_trunking.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_trunking.c
@@ -83,6 +83,15 @@ p25_print_mbt_payload_hex(const uint8_t* mpdu_byte, int blks) {
     }
 }
 
+static int
+p25p1_pdu_can_tune_grant(const dsd_opts* opts, dsd_state* state, long int freq) {
+    if (!opts || !state || opts->p25_trunk != 1 || opts->p25_is_tuned != 0 || freq == 0) {
+        return 0;
+    }
+    p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
+    return state->p25_cc_freq != 0;
+}
+
 static void DSD_ATTR_USED
 p25_mbt_try_bridge_iden_updates(dsd_opts* opts, dsd_state* state, const uint8_t* mpdu_byte,
                                 const p25p1_mbt_fields* fields) {
@@ -338,7 +347,7 @@ p25_handle_mbt_group_voice_grant(dsd_opts* opts, dsd_state* state, const uint8_t
         return;
     }
 
-    if (opts->p25_trunk == 1 && state->p25_cc_freq != 0 && opts->p25_is_tuned == 0 && freq1 != 0) {
+    if (p25p1_pdu_can_tune_grant(opts, state, freq1)) {
         p25_sm_on_group_grant(opts, state, channelt, svc, group, (int)source);
     }
 }
@@ -386,7 +395,7 @@ p25_handle_mbt_unit_to_unit_voice_grant(dsd_opts* opts, dsd_state* state, const 
         return;
     }
 
-    if (opts->p25_trunk == 1 && state->p25_cc_freq != 0 && opts->p25_is_tuned == 0 && freq1 != 0) {
+    if (p25p1_pdu_can_tune_grant(opts, state, freq1)) {
         p25_sm_on_indiv_grant(opts, state, channelt, svc, (int)target, (int)source);
     }
 }
@@ -451,7 +460,7 @@ p25_handle_mbt_telephone_interconnect_grant(dsd_opts* opts, dsd_state* state, co
         return;
     }
 
-    if (opts->p25_trunk == 1 && state->p25_cc_freq != 0 && opts->p25_is_tuned == 0 && freq != 0) {
+    if (p25p1_pdu_can_tune_grant(opts, state, freq)) {
         p25_sm_on_indiv_grant(opts, state, channel, svc, (int)target, 0);
     }
 
@@ -513,7 +522,7 @@ p25_handle_mbt_mfid90_group_regroup(dsd_opts* opts, dsd_state* state, const uint
         return;
     }
 
-    if (opts->p25_trunk == 1 && state->p25_cc_freq != 0 && opts->p25_is_tuned == 0 && freq1 != 0) {
+    if (p25p1_pdu_can_tune_grant(opts, state, freq1)) {
         p25_sm_on_group_grant(opts, state, channelt, svc, group, (int)source);
     }
 }

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -234,6 +234,7 @@ tsbk_handle_mfid90_grant(dsd_opts* opts, dsd_state* state, const uint8_t tsbk_by
     state->last_active_time = time(NULL);
     DSD_FPRINTF(stderr, "\n");
     if (opts->p25_trunk == 1 && freq != 0) {
+        p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
         p25_sm_on_group_grant(opts, state, channel, /*svc*/ 0, sg, source);
     }
 }
@@ -256,9 +257,11 @@ tsbk_handle_mfid90_grant_update(dsd_opts* opts, dsd_state* state, const uint8_t 
     state->last_active_time = time(NULL);
     DSD_FPRINTF(stderr, "\n");
     if (opts->p25_trunk == 1 && ch1 != 0 && freq1 != 0) {
+        p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
         p25_sm_on_group_grant(opts, state, ch1, /*svc*/ 0, sg1, /*src*/ 0);
     }
     if (opts->p25_trunk == 1 && ch2 != 0 && freq2 != 0) {
+        p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
         p25_sm_on_group_grant(opts, state, ch2, /*svc*/ 0, sg2, /*src*/ 0);
     }
 }

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -600,8 +600,14 @@ p25p2_vpdu_channel_is_valid(int channel) {
 }
 
 static int
-p25p2_vpdu_can_tune(const dsd_opts* opts, const dsd_state* state, long int freq) {
-    return state->p25_cc_freq != 0 && opts->p25_is_tuned == 0 && freq != 0;
+p25p2_vpdu_can_tune(const dsd_opts* opts, dsd_state* state, long int freq) {
+    if (!opts || !state || opts->p25_trunk != 1 || opts->p25_is_tuned != 0 || freq == 0) {
+        return 0;
+    }
+    if (state->trunk_cc_freq > 0 || state->p2_is_lcch == 1 || DSD_SYNC_IS_P25P1(state->synctype)) {
+        p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
+    }
+    return state->p25_cc_freq != 0;
 }
 
 static void
@@ -1066,7 +1072,7 @@ p25p2_vpdu_iter_block_01(p25p2_vpdu_ctx* ctx) {
 
         p25p2_vpdu_print_group_label(state, (uint32_t)sgroup);
 
-        if (state->p25_cc_freq != 0 && opts->p25_is_tuned == 0 && freq != 0) {
+        if (p25p2_vpdu_can_tune(opts, state, freq)) {
             /* No SVC bits are carried here; use conservative ENC gating policy facts. */
             const int policy_encrypted = p25_mfid90_enc_lockout_blocks(opts, state, sgroup) ? 1 : 0;
             p25p2_mac_handle(&mac_res, opts, state, channel, /*svc_bits*/ 0, sgroup, /*src*/ 0, policy_encrypted,
@@ -1117,7 +1123,7 @@ p25p2_vpdu_iter_block_02(p25p2_vpdu_ctx* ctx) {
 
         p25p2_vpdu_print_group_label(state, (uint32_t)sgroup);
 
-        if (state->p25_cc_freq != 0 && opts->p25_is_tuned == 0 && freq != 0) {
+        if (p25p2_vpdu_can_tune(opts, state, freq)) {
             /* No SVC bits are carried here; use conservative ENC gating policy facts. */
             const int policy_encrypted = p25_mfid90_enc_lockout_blocks(opts, state, sgroup) ? 1 : 0;
             p25p2_mac_handle(&mac_res, opts, state, channel, /*svc_bits*/ 0, sgroup, /*src*/ 0, policy_encrypted,
@@ -1665,7 +1671,7 @@ p25p2_vpdu_iter_block_11(p25p2_vpdu_ctx* ctx) {
         }
         state->last_active_time = time(NULL);
 
-        if (state->p25_cc_freq != 0 && opts->p25_is_tuned == 0 && freq != 0) {
+        if (p25p2_vpdu_can_tune(opts, state, freq)) {
             const int policy_encrypted = (opts->trunk_tune_enc_calls == 0) ? 1 : 0;
             p25p2_mac_handle_indiv(&mac_res, opts, state, channelt, /*svc_bits*/ 0, (int)target, /*src*/ 0,
                                    policy_encrypted, /*policy_data*/ 1);

--- a/tests/protocol/p25/test_p25_p1_lcw_gating.c
+++ b/tests/protocol/p25/test_p25_p1_lcw_gating.c
@@ -229,6 +229,47 @@ main(void) {
     p25_lcw(&opts, &st, lcw, 0);
     rc |= expect_eq_int("enc->no-tune", g_tunes, 0);
 
+    // A 0x44 LCW decoded on a VC must not learn that VC as the control channel.
+    {
+        static dsd_opts vc_opts;
+        static dsd_state vc_st;
+        DSD_MEMSET(&vc_opts, 0, sizeof vc_opts);
+        DSD_MEMSET(&vc_st, 0, sizeof vc_st);
+        vc_opts.p25_trunk = 1;
+        vc_opts.p25_lcw_retune = 0;
+        vc_opts.p25_is_tuned = 1;
+        vc_opts.trunk_is_tuned = 1;
+        vc_opts.audio_in_type = AUDIO_IN_RTL;
+        vc_opts.rtlsdr_center_freq = 852112500U;
+        set_bits_msb(lcw, 16, 8, (unsigned)svc);
+
+        p25_lcw(&vc_opts, &vc_st, lcw, 0);
+        rc |= expect_eq_int("vc-lcw no p25 cc seed", (int)vc_st.p25_cc_freq, 0);
+        rc |= expect_eq_int("vc-lcw no trunk cc seed", (int)vc_st.trunk_cc_freq, 0);
+        rc |= expect_eq_int("vc-lcw no lcn0 seed", (int)vc_st.trunk_lcn_freq[0], 0);
+    }
+
+    // Some unmanaged VC monitoring paths have not set the tuned flags; LCW must
+    // still avoid treating the current tuner frequency as a control channel.
+    {
+        static dsd_opts vc_opts;
+        static dsd_state vc_st;
+        DSD_MEMSET(&vc_opts, 0, sizeof vc_opts);
+        DSD_MEMSET(&vc_st, 0, sizeof vc_st);
+        vc_opts.p25_trunk = 1;
+        vc_opts.p25_lcw_retune = 1;
+        vc_opts.trunk_tune_group_calls = 1;
+        vc_opts.audio_in_type = AUDIO_IN_RTL;
+        vc_opts.rtlsdr_center_freq = 852112500U;
+
+        g_tunes = 0;
+        p25_lcw(&vc_opts, &vc_st, lcw, 0);
+        rc |= expect_eq_int("unmanaged vc-lcw no tune", g_tunes, 0);
+        rc |= expect_eq_int("unmanaged vc-lcw no p25 cc seed", (int)vc_st.p25_cc_freq, 0);
+        rc |= expect_eq_int("unmanaged vc-lcw no trunk cc seed", (int)vc_st.trunk_cc_freq, 0);
+        rc |= expect_eq_int("unmanaged vc-lcw no lcn0 seed", (int)vc_st.trunk_lcn_freq[0], 0);
+    }
+
     return rc;
 }
 

--- a/tests/protocol/p25/test_p25_p1_lcw_sm.c
+++ b/tests/protocol/p25/test_p25_p1_lcw_sm.c
@@ -27,6 +27,8 @@
 void p25_test_invoke_lcw(const unsigned char* lcw_bits, int len, int enable_retune, long cc_freq);
 void p25_test_invoke_lcw_with_lastsrc(const unsigned char* lcw_bits, int len, int enable_retune, long cc_freq,
                                       long lastsrc);
+void p25_test_invoke_lcw_with_tuner(const unsigned char* lcw_bits, int len, int enable_retune, long cc_freq,
+                                    long tuner_freq);
 
 // Stubs referenced by LCW path (alias helpers and streaming/rigctl)
 void
@@ -264,6 +266,12 @@ main(void) {
     rc |= expect_eq_int("tg", g_last_tg, tg);
     // source may be 0 unless prior LCW set it
     rc |= expect_eq_int("src default", g_last_src, 0);
+
+    // Subcase C: LCW traffic frames must not infer a CC from live tuner metadata.
+    g_called = 0;
+    g_last_channel = g_last_svc = g_last_tg = g_last_src = -1;
+    p25_test_invoke_lcw_with_tuner(lcw, 72, /*enable_retune*/ 1, /*cc*/ 0, /*tuner_freq*/ 851012500);
+    rc |= expect_eq_int("no dispatch from tuner-only lcw", g_called, 0);
 
     // Gating cases are covered in a separate test without overriding
     // p25_sm_on_group_grant so the implementation’s gating logic runs.

--- a/tests/protocol/p25/test_p25_p1_pdu_private_allowlist.c
+++ b/tests/protocol/p25/test_p25_p1_pdu_private_allowlist.c
@@ -156,6 +156,13 @@ p25_emit_enc_lockout_once(dsd_opts* opts, dsd_state* state, uint8_t slot, int tg
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_sm_seed_cc_from_current_tuner_if_unknown(const dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 p25_sm_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
     (void)opts;
     (void)state;

--- a/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
@@ -204,6 +204,12 @@ p25_format_chan_suffix(const dsd_state* state, uint16_t chan, int slot_hint, cha
 }
 
 void
+p25_sm_seed_cc_from_current_tuner_if_unknown(const dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
 p25_sm_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
     (void)opts;
     (void)state;

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -10,6 +10,7 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/protocol/p25/p25_vpdu.h>
 #include <stdbool.h>
@@ -258,7 +259,122 @@ main(void) {
         rc |= expect_eq_long("0x40 blocked vc", state.p25_vc_freq[0], 0);
     }
 
-    // Case F: compact grant-update paths must also honor failed-VC retune backoff.
+    // Case F: first live VPDU grant seeds an unknown CC from the current RTL tuner.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        opts.audio_in_type = AUDIO_IN_RTL;
+        opts.rtlsdr_center_freq = (uint32_t)cc;
+        state.synctype = DSD_SYNC_P25P2_POS;
+        state.p2_is_lcch = 1;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+
+        MAC[1] = 0x40; // Group Voice Channel Grant
+        MAC[2] = 0x00; // svc
+        MAC[3] = 0x10;
+        MAC[4] = 0x0A; // channel 0x100A -> 851.125 MHz
+        MAC[5] = 0x12;
+        MAC[6] = 0x34; // group
+        MAC[7] = 0x00;
+        MAC[8] = 0x00;
+        MAC[9] = 0x02; // source
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_true("0x40 seeded CC tuned", opts.p25_is_tuned == 1);
+        rc |= expect_eq_long("0x40 seeded CC", state.p25_cc_freq, cc);
+        rc |= expect_eq_long("0x40 seeded trunk CC", state.trunk_cc_freq, cc);
+        rc |= expect_true("0x40 seeded TDMA CC hint", state.p25_cc_is_tdma == 1);
+        rc |= expect_eq_long("0x40 seeded vc", state.p25_vc_freq[0], 851125000);
+    }
+
+    // Case G: traffic-channel MACs must not learn the current VC tuner frequency as the CC.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        opts.audio_in_type = AUDIO_IN_RTL;
+        opts.rtlsdr_center_freq = 852000000U;
+        state.synctype = DSD_SYNC_P25P2_POS;
+        state.p2_is_lcch = 0;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+
+        MAC[1] = 0x40; // Group Voice Channel Grant carried on FACCH/SACCH traffic MAC
+        MAC[2] = 0x00; // svc
+        MAC[3] = 0x10;
+        MAC[4] = 0x0A; // channel 0x100A -> 851.125 MHz
+        MAC[5] = 0x12;
+        MAC[6] = 0x34; // group
+        MAC[7] = 0x00;
+        MAC[8] = 0x00;
+        MAC[9] = 0x02; // source
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_true("0x40 traffic MAC not tuned", opts.p25_is_tuned == 0);
+        rc |= expect_eq_long("0x40 traffic MAC no p25 CC seed", state.p25_cc_freq, 0);
+        rc |= expect_eq_long("0x40 traffic MAC no trunk CC seed", state.trunk_cc_freq, 0);
+        rc |= expect_eq_long("0x40 traffic MAC no vc", state.p25_vc_freq[0], 0);
+    }
+
+    // Case H: first live VPDU grant can use the generic trunk CC alias when the P25 alias is still unknown.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        state.trunk_cc_freq = cc;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+
+        MAC[1] = 0x40; // Group Voice Channel Grant
+        MAC[2] = 0x00; // svc
+        MAC[3] = 0x10;
+        MAC[4] = 0x0A; // channel 0x100A -> 851.125 MHz
+        MAC[5] = 0x12;
+        MAC[6] = 0x34; // group
+        MAC[7] = 0x00;
+        MAC[8] = 0x00;
+        MAC[9] = 0x02; // source
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_true("0x40 trunk alias CC tuned", opts.p25_is_tuned == 1);
+        rc |= expect_eq_long("0x40 trunk alias p25 CC", state.p25_cc_freq, cc);
+        rc |= expect_eq_long("0x40 trunk alias trunk CC", state.trunk_cc_freq, cc);
+        rc |= expect_eq_long("0x40 trunk alias vc", state.p25_vc_freq[0], 851125000);
+    }
+
+    // Case I: compact grant-update paths must also honor failed-VC retune backoff.
     {
         static dsd_opts opts;
         static dsd_state state;

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -9,12 +9,15 @@
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/rigctl_query_hooks.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -35,6 +38,7 @@ static dsd_trunk_tune_result g_result_return_to_cc_result = DSD_TRUNK_TUNE_RESUL
 static int g_result_tune_to_freq_calls = 0;
 static int g_result_tune_to_cc_calls = 0;
 static int g_result_return_to_cc_calls = 0;
+static long g_rigctl_current_freq = 0;
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -119,6 +123,12 @@ install_result_tuning_hooks(void) {
     hooks.tune_to_cc_result = trunk_tune_to_cc_result;
     hooks.return_to_cc_result = return_to_cc_result;
     dsd_trunk_tuning_hooks_set(hooks);
+}
+
+static long
+fake_get_current_freq_hz(const dsd_opts* opts) {
+    (void)opts;
+    return g_rigctl_current_freq;
 }
 
 static void
@@ -489,6 +499,244 @@ main(void) {
     assert(o12.trunk_is_tuned == 0);
     assert(ctx12.state == P25_SM_ON_CC);
     assert(s12.p25_retune_block_until == 0);
+
+    // 15) Verified CC callers seed an unknown CC from the live tuner before leaving the control channel.
+    static dsd_opts o13;
+    static dsd_state s13;
+    DSD_MEMSET(&o13, 0, sizeof(o13));
+    DSD_MEMSET(&s13, 0, sizeof(s13));
+    o13.p25_trunk = 1;
+    o13.trunk_tune_group_calls = 1;
+    o13.audio_in_type = AUDIO_IN_RTL;
+    o13.rtlsdr_center_freq = 851012500U;
+    s13.synctype = DSD_SYNC_P25P1_POS;
+    s13.p25_cc_is_tdma = 1;
+    s13.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s13.p25_iden_fdma[id9].chan_type = 1;
+    s13.p25_iden_fdma[id9].chan_spac = 100;
+    s13.p25_iden_fdma[id9].trust = 2;
+    s13.p25_iden_fdma[id9].populated = 1;
+    s13.p25_chan_tdma_explicit[id9] = 1;
+    p25_sm_ctx_t ctx13;
+    p25_sm_init_ctx(&ctx13, &o13, &s13);
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_result_tune_to_freq_calls = 0;
+    p25_sm_seed_cc_from_current_tuner_if_unknown(&o13, &s13);
+    p25_sm_event(&ctx13, &o13, &s13, &ev9);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(s13.p25_cc_freq == 851012500);
+    assert(s13.trunk_cc_freq == 851012500);
+    assert(s13.trunk_lcn_freq[0] == 851012500);
+    assert(s13.p25_cc_is_tdma == 0);
+    assert(ctx13.state == P25_SM_TUNED);
+
+    static dsd_opts o14;
+    static dsd_state s14;
+    DSD_MEMSET(&o14, 0, sizeof(o14));
+    DSD_MEMSET(&s14, 0, sizeof(s14));
+    o14.p25_trunk = 1;
+    o14.trunk_tune_group_calls = 1;
+    o14.audio_in_type = AUDIO_IN_TCP;
+    o14.use_rigctl = 1;
+    s14.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s14.p25_iden_fdma[id9].chan_type = 1;
+    s14.p25_iden_fdma[id9].chan_spac = 100;
+    s14.p25_iden_fdma[id9].trust = 2;
+    s14.p25_iden_fdma[id9].populated = 1;
+    s14.p25_chan_tdma_explicit[id9] = 1;
+    p25_sm_ctx_t ctx14;
+    p25_sm_init_ctx(&ctx14, &o14, &s14);
+    g_rigctl_current_freq = 851987500;
+    dsd_rigctl_query_hooks hooks = {0};
+    hooks.get_current_freq_hz = fake_get_current_freq_hz;
+    dsd_rigctl_query_hooks_set(hooks);
+    g_result_tune_to_freq_calls = 0;
+    p25_sm_seed_cc_from_current_tuner_if_unknown(&o14, &s14);
+    p25_sm_event(&ctx14, &o14, &s14, &ev9);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(s14.p25_cc_freq == 851987500);
+    assert(s14.trunk_cc_freq == 851987500);
+    assert(s14.trunk_lcn_freq[0] == 851987500);
+    assert(ctx14.state == P25_SM_TUNED);
+    dsd_rigctl_query_hooks_set((dsd_rigctl_query_hooks){0});
+    g_rigctl_current_freq = 0;
+
+    static dsd_opts o14b;
+    static dsd_state s14b;
+    DSD_MEMSET(&o14b, 0, sizeof(o14b));
+    DSD_MEMSET(&s14b, 0, sizeof(s14b));
+    o14b.p25_trunk = 1;
+    o14b.trunk_tune_group_calls = 1;
+    o14b.audio_in_type = AUDIO_IN_RTL;
+    o14b.rtlsdr_center_freq = 851012500U;
+    s14b.synctype = DSD_SYNC_P25P2_POS;
+    s14b.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s14b.p25_iden_fdma[id9].chan_type = 1;
+    s14b.p25_iden_fdma[id9].chan_spac = 100;
+    s14b.p25_iden_fdma[id9].trust = 2;
+    s14b.p25_iden_fdma[id9].populated = 1;
+    s14b.p25_chan_tdma_explicit[id9] = 1;
+    p25_sm_ctx_t ctx14b;
+    p25_sm_init_ctx(&ctx14b, &o14b, &s14b);
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    g_result_tune_to_freq_calls = 0;
+    p25_sm_seed_cc_from_current_tuner_if_unknown(&o14b, &s14b);
+    p25_sm_event(&ctx14b, &o14b, &s14b, &ev9);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(s14b.p25_cc_freq == 851012500);
+    assert(s14b.trunk_cc_freq == 851012500);
+    assert(s14b.trunk_lcn_freq[0] == 851012500);
+    assert(s14b.p25_cc_is_tdma == 1);
+    assert(o14b.p25_is_tuned == 0);
+    assert(s14b.p25_sm_tune_count == 0);
+    assert(ctx14b.state == P25_SM_ON_CC);
+    assert(s14b.last_cc_sync_time_m > 0.0);
+    int tune_cc_calls_before_tick = g_result_tune_to_cc_calls;
+    p25_sm_tick_ctx(&ctx14b, &o14b, &s14b);
+    assert(ctx14b.state == P25_SM_ON_CC);
+    assert(g_result_tune_to_cc_calls == tune_cc_calls_before_tick);
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+
+    static dsd_opts o14c;
+    static dsd_state s14c;
+    DSD_MEMSET(&o14c, 0, sizeof(o14c));
+    DSD_MEMSET(&s14c, 0, sizeof(s14c));
+    o14c.p25_trunk = 1;
+    o14c.trunk_tune_group_calls = 1;
+    s14c.p25_cc_freq = 851012500;
+    s14c.trunk_cc_freq = 851012500;
+    s14c.nac = 0x123;
+    s14c.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s14c.p25_iden_fdma[id9].chan_type = 1;
+    s14c.p25_iden_fdma[id9].chan_spac = 100;
+    s14c.p25_iden_fdma[id9].trust = 2;
+    s14c.p25_iden_fdma[id9].populated = 1;
+    s14c.p25_chan_tdma_explicit[id9] = 1;
+    p25_sm_ctx_t ctx14c;
+    p25_sm_init_ctx(&ctx14c, &o14c, &s14c);
+    ctx14c.state = P25_SM_IDLE;
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    g_result_tune_to_freq_calls = 0;
+    p25_sm_event(&ctx14c, &o14c, &s14c, &ev9);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(s14c.p25_cc_freq == 851012500);
+    assert(s14c.trunk_cc_freq == 851012500);
+    assert(o14c.p25_is_tuned == 0);
+    assert(s14c.p25_sm_tune_count == 0);
+    assert(ctx14c.state == P25_SM_ON_CC);
+    assert(ctx14c.expected_cc_nac == 0x123);
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+
+    // 16) A generic trunk CC alias is enough to seed the P25-specific alias.
+    static dsd_opts o15;
+    static dsd_state s15;
+    DSD_MEMSET(&o15, 0, sizeof(o15));
+    DSD_MEMSET(&s15, 0, sizeof(s15));
+    o15.p25_trunk = 1;
+    o15.trunk_tune_group_calls = 1;
+    s15.trunk_cc_freq = 851000000;
+    s15.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s15.p25_iden_fdma[id9].chan_type = 1;
+    s15.p25_iden_fdma[id9].chan_spac = 100;
+    s15.p25_iden_fdma[id9].trust = 2;
+    s15.p25_iden_fdma[id9].populated = 1;
+    s15.p25_chan_tdma_explicit[id9] = 1;
+    p25_sm_ctx_t ctx15;
+    p25_sm_init_ctx(&ctx15, &o15, &s15);
+    g_result_tune_to_freq_calls = 0;
+    p25_sm_event(&ctx15, &o15, &s15, &ev9);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(s15.p25_cc_freq == 851000000);
+    assert(s15.trunk_cc_freq == 851000000);
+    assert(s15.trunk_lcn_freq[0] == 851000000);
+    assert(ctx15.state == P25_SM_TUNED);
+
+    // 17) Never learn the CC from the current tuner while already voice-tuned.
+    static dsd_opts o16;
+    static dsd_state s16;
+    DSD_MEMSET(&o16, 0, sizeof(o16));
+    DSD_MEMSET(&s16, 0, sizeof(s16));
+    o16.p25_trunk = 1;
+    o16.p25_is_tuned = 1;
+    o16.trunk_is_tuned = 1;
+    o16.audio_in_type = AUDIO_IN_RTL;
+    o16.rtlsdr_center_freq = 852112500U;
+    p25_sm_seed_cc_from_current_tuner_if_unknown(&o16, &s16);
+    assert(s16.p25_cc_freq == 0);
+    assert(s16.trunk_cc_freq == 0);
+    assert(s16.trunk_lcn_freq[0] == 0);
+
+    // 18) Unguarded generic grant events must not sample the current tuner as a CC.
+    static dsd_opts o17;
+    static dsd_state s17;
+    DSD_MEMSET(&o17, 0, sizeof(o17));
+    DSD_MEMSET(&s17, 0, sizeof(s17));
+    o17.p25_trunk = 1;
+    o17.trunk_tune_group_calls = 1;
+    o17.audio_in_type = AUDIO_IN_RTL;
+    o17.rtlsdr_center_freq = 852112500U;
+    s17.synctype = DSD_SYNC_P25P2_POS;
+    s17.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s17.p25_iden_fdma[id9].chan_type = 1;
+    s17.p25_iden_fdma[id9].chan_spac = 100;
+    s17.p25_iden_fdma[id9].trust = 2;
+    s17.p25_iden_fdma[id9].populated = 1;
+    s17.p25_chan_tdma_explicit[id9] = 1;
+    p25_sm_ctx_t ctx17;
+    p25_sm_init_ctx(&ctx17, &o17, &s17);
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    g_result_tune_to_freq_calls = 0;
+    p25_sm_event(&ctx17, &o17, &s17, &ev9);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(s17.p25_cc_freq == 0);
+    assert(s17.trunk_cc_freq == 0);
+    assert(s17.trunk_lcn_freq[0] == 0);
+    assert(ctx17.state == P25_SM_IDLE);
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+
+    // 19) Return-to-CC after a seeded first grant must refresh stale CC sync metadata.
+    static dsd_opts o18;
+    static dsd_state s18;
+    DSD_MEMSET(&o18, 0, sizeof(o18));
+    DSD_MEMSET(&s18, 0, sizeof(s18));
+    o18.p25_trunk = 1;
+    o18.trunk_tune_group_calls = 1;
+    o18.p25_prefer_candidates = 1;
+    s18.trunk_cc_freq = 851012500;
+    s18.nac = 0x123;
+    s18.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s18.p25_iden_fdma[id9].chan_type = 1;
+    s18.p25_iden_fdma[id9].chan_spac = 100;
+    s18.p25_iden_fdma[id9].trust = 2;
+    s18.p25_iden_fdma[id9].populated = 1;
+    s18.p25_chan_tdma_explicit[id9] = 1;
+    (void)dsd_trunk_cc_candidates_add(&s18, 853000000, 0);
+    p25_sm_ctx_t ctx18;
+    p25_sm_init_ctx(&ctx18, &o18, &s18);
+    assert(ctx18.state == P25_SM_IDLE);
+    g_result_tune_to_freq_calls = 0;
+    g_result_return_to_cc_calls = 0;
+    p25_sm_event(&ctx18, &o18, &s18, &ev9);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(ctx18.state == P25_SM_TUNED);
+    assert(s18.p25_cc_freq == 851012500);
+    assert(s18.last_cc_sync_time_m > 0.0);
+
+    s18.last_cc_sync_time = time(NULL) - 10;
+    s18.last_cc_sync_time_m = dsd_time_now_monotonic_s() - 10.0;
+    ctx18.t_cc_sync_m = s18.last_cc_sync_time_m;
+    const double stale_seed_cc_sync_m = s18.last_cc_sync_time_m;
+    g_result_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    p25_sm_release(&ctx18, &o18, &s18, "seeded-release");
+    assert(g_result_return_to_cc_calls == 1);
+    assert(ctx18.state == P25_SM_ON_CC);
+    assert(o18.p25_is_tuned == 0);
+    assert(s18.last_cc_sync_time_m > stale_seed_cc_sync_m);
+
+    int cc_calls_before_seeded_release_tick = g_result_tune_to_cc_calls;
+    p25_sm_tick_ctx(&ctx18, &o18, &s18);
+    assert(ctx18.state == P25_SM_ON_CC);
+    assert(g_result_tune_to_cc_calls == cc_calls_before_seeded_release_tick);
 
     install_trunk_tuning_hooks();
 

--- a/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
+++ b/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
@@ -365,6 +365,14 @@ matrix_age_tuned_timers(matrix_fixture* fixture) {
     fixture->state->p25_last_vc_tune_time_m = now_m - 1.0;
 }
 
+static void
+matrix_stale_cc_timers(matrix_fixture* fixture) {
+    double now_m = dsd_time_now_monotonic_s();
+    fixture->ctx.t_cc_sync_m = now_m - 10.0;
+    fixture->state->last_cc_sync_time = time(NULL) - 10;
+    fixture->state->last_cc_sync_time_m = now_m - 10.0;
+}
+
 static int
 matrix_drive_to_cc(matrix_fixture* fixture, const matrix_mode_case* mode, const matrix_flow_case* flow,
                    const matrix_return_script* script) {
@@ -390,6 +398,12 @@ matrix_drive_to_cc(matrix_fixture* fixture, const matrix_mode_case* mode, const 
                         mode->name, flow->name, script->name, "ctx vc state cleared");
     rc |= matrix_expect(g_hooks.return_calls == script->count, mode->name, flow->name, script->name,
                         "return-to-cc call count matches script");
+    const int cc_calls_before_post_return_tick = g_hooks.cc_calls;
+    p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+    rc |= matrix_expect(fixture->ctx.state == P25_SM_ON_CC, mode->name, flow->name, script->name,
+                        "post-return tick remains ON_CC");
+    rc |= matrix_expect(g_hooks.cc_calls == cc_calls_before_post_return_tick, mode->name, flow->name, script->name,
+                        "post-return tick does not hunt CC");
     return rc;
 }
 
@@ -539,6 +553,7 @@ matrix_run_terminal_case(const matrix_mode_case* mode, const matrix_flow_case* f
     if (rc != 0) {
         return rc;
     }
+    matrix_stale_cc_timers(fixture);
     return matrix_apply_terminal_flow(fixture, mode, flow, script);
 }
 


### PR DESCRIPTION
## Summary

Fixes a P25 trunking return-to-control-channel failure where the state machine could leave a control channel for the first voice grant without a P25 control-channel frequency recorded.

In RTL mode, and in TCP + rigctl setups such as SDR++, that could leave the release path unable to retune cleanly after a voice call ended. The visible symptom was repeated `release->cc`, `cc-lost`, and `HUNT` transitions while the tuner stayed on a voice frequency until the control channel was selected manually.

## Root Cause

Some grant decoders gated voice-channel tuning on `state->p25_cc_freq`, but the first live grant could arrive while only the current tuner frequency or the generic `trunk_cc_freq` alias identified the active control channel. After tuning to a voice channel, return-to-CC then had incomplete P25 CC state and stale CC-sync timing, so the watchdog could immediately treat the CC as lost.

## Changes

- Seed an unknown P25 control-channel frequency from the generic trunk CC alias, live rigctl current frequency, or RTL center frequency before accepting verified control-channel grants.
- Promote the seeded CC into the P25 trunk state before the first VC tune and refresh CC grace metadata so a successful return does not immediately fall into `cc-lost`.
- Keep LCW and P25P2 traffic-channel paths from learning a voice-channel tuner frequency as the CC.
- Add regression coverage for RTL seeding, TCP/rigctl seeding, trunk alias promotion, deferred tune handling, false VC CC learning, and stale CC-sync refresh after release.

## Validation

- `git diff --check`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug -R '^(P25_SM_CORE|P25_P2_VPDU_GRANTS|P25_P1_LCW_GATING|P25_P1_LCW_SM|P25_P1_PDU_PRIVATE_ALLOWLIST|P25_P1_TSBK_SEQUENCE|P25_SM_RETURN_TO_CC_MATRIX|P25_RETUNE_BACKOFF_SLOT|RUNTIME_RIGCTL_QUERY_HOOKS|ENGINE_TRUNK_RETUNE_REGRESSION)$' --output-on-failure`
- `ctest --preset dev-debug -R '^P25_' --output-on-failure`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh --base origin/main`
- pre-push hook on `git push -u origin fix/p25-return-to-cc-after-vc`
