### PR TITLE
protocol: clear stale p25p1 data display state

### DIFF
--- a/src/engine/dispatch/dispatch_p25p1.c
+++ b/src/engine/dispatch/dispatch_p25p1.c
@@ -242,9 +242,8 @@ p25p1_close_mbe_out_pair_if_open(dsd_opts* opts, dsd_state* state) {
 }
 
 static void
-p25p1_clear_extra_display_text(dsd_state* state) {
-    /* P25p1 PDU summaries reuse the DMR GPS/LRRP display fields in the shared UI. */
-    state->dmr_embedded_gps[0][0] = '\0';
+p25p1_clear_pdu_summary_display(dsd_state* state) {
+    /* P25p1 PDU summaries reuse the DMR LRRP display field in the shared UI. */
     state->dmr_lrrp_gps[0][0] = '\0';
 }
 
@@ -412,7 +411,7 @@ p25p1_handle_unknown_duid(dsd_opts* opts, dsd_state* state, const char duid[3]) 
 
 static void DSD_ATTR_USED
 p25p1_dispatch_by_duid(dsd_opts* opts, dsd_state* state, const char duid[3]) {
-    p25p1_clear_extra_display_text(state);
+    p25p1_clear_pdu_summary_display(state);
 
     if (strcmp(duid, "00") == 0) {
         p25p1_handle_hdu(opts, state);

--- a/src/engine/dispatch/dispatch_p25p1.c
+++ b/src/engine/dispatch/dispatch_p25p1.c
@@ -242,7 +242,8 @@ p25p1_close_mbe_out_pair_if_open(dsd_opts* opts, dsd_state* state) {
 }
 
 static void
-p25p1_clear_call_termination_gps(dsd_state* state) {
+p25p1_clear_extra_display_text(dsd_state* state) {
+    /* P25p1 PDU summaries reuse the DMR GPS/LRRP display fields in the shared UI. */
     state->dmr_embedded_gps[0][0] = '\0';
     state->dmr_lrrp_gps[0][0] = '\0';
 }
@@ -323,7 +324,6 @@ p25p1_handle_tdulc(dsd_opts* opts, dsd_state* state) {
     state->lastp25type = 0;
     state->err_str[0] = 0;
     DSD_SNPRINTF(state->fsubtype, sizeof(state->fsubtype), " TDULC        ");
-    p25p1_clear_call_termination_gps(state);
     state->numtdulc++;
 
     if ((opts->resume > 0) && (state->numtdulc > opts->resume)) {
@@ -351,7 +351,6 @@ p25p1_handle_tdu(dsd_opts* opts, dsd_state* state) {
     state->lastp25type = 0;
     state->err_str[0] = 0;
     DSD_SNPRINTF(state->fsubtype, sizeof(state->fsubtype), " TDU          ");
-    p25p1_clear_call_termination_gps(state);
     processTDU(opts, state);
 }
 
@@ -413,6 +412,8 @@ p25p1_handle_unknown_duid(dsd_opts* opts, dsd_state* state, const char duid[3]) 
 
 static void DSD_ATTR_USED
 p25p1_dispatch_by_duid(dsd_opts* opts, dsd_state* state, const char duid[3]) {
+    p25p1_clear_extra_display_text(state);
+
     if (strcmp(duid, "00") == 0) {
         p25p1_handle_hdu(opts, state);
     } else if (strcmp(duid, "11") == 0) {

--- a/tests/protocol/p25/test_p25_p1_sync_dispatch.c
+++ b/tests/protocol/p25/test_p25_p1_sync_dispatch.c
@@ -208,11 +208,13 @@ test_simple_tdu_dispatch_defaults(void) {
     assert(strcmp(state.fsubtype, " TDU          ") == 0);
 }
 
+static const char k_valid_embedded_gps[] = "GPS: 41.12345N 087.12345W (41.12345, -87.12345) Current Fix";
+
 static void
 seed_stale_data_call_display(dsd_state* state) {
     state->lasttg = 393226;
     state->lastsrc = 0xFFFFFF;
-    DSD_SNPRINTF(state->dmr_embedded_gps[0], sizeof(state->dmr_embedded_gps[0]), "stale embedded");
+    DSD_SNPRINTF(state->dmr_embedded_gps[0], sizeof(state->dmr_embedded_gps[0]), "%s", k_valid_embedded_gps);
     DSD_SNPRINTF(state->dmr_lrrp_gps[0], sizeof(state->dmr_lrrp_gps[0]),
                  "Data Call: Mobile Radio Statistics; SAP:24; LLID: 393226; ");
 }
@@ -231,7 +233,7 @@ expect_stale_data_call_display_cleared(const char* duid, unsigned int expected_b
     dsd_dispatch_handle_p25p1(&opts, &state);
 
     assert(state.dmrburstL == expected_burst);
-    assert(state.dmr_embedded_gps[0][0] == '\0');
+    assert(strcmp(state.dmr_embedded_gps[0], k_valid_embedded_gps) == 0);
     assert(state.dmr_lrrp_gps[0][0] == '\0');
     assert(strcmp(state.fsubtype, expected_subtype) == 0);
 }

--- a/tests/protocol/p25/test_p25_p1_sync_dispatch.c
+++ b/tests/protocol/p25/test_p25_p1_sync_dispatch.c
@@ -27,6 +27,8 @@
 int dsd_dispatch_matches_p25p1(int synctype);
 void dsd_dispatch_handle_p25p1(dsd_opts* opts, dsd_state* state);
 
+static char g_test_duid[3] = "03";
+
 int
 getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
     (void)opts;
@@ -61,8 +63,8 @@ check_NID_with_observed_nac_soft(const char* bch_code, const uint8_t* reliab63, 
         *new_nac = 0x293;
     }
     if (new_duid != NULL) {
-        new_duid[0] = '0';
-        new_duid[1] = '3';
+        new_duid[0] = g_test_duid[0];
+        new_duid[1] = g_test_duid[1];
         new_duid[2] = '\0';
     }
     if (error_count != NULL) {
@@ -198,6 +200,7 @@ test_simple_tdu_dispatch_defaults(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
 
     state.synctype = DSD_SYNC_P25P1_POS;
+    DSD_SNPRINTF(g_test_duid, sizeof(g_test_duid), "03");
     dsd_dispatch_handle_p25p1(&opts, &state);
 
     assert(state.nac == 0x293);
@@ -205,11 +208,57 @@ test_simple_tdu_dispatch_defaults(void) {
     assert(strcmp(state.fsubtype, " TDU          ") == 0);
 }
 
+static void
+seed_stale_data_call_display(dsd_state* state) {
+    state->lasttg = 393226;
+    state->lastsrc = 0xFFFFFF;
+    DSD_SNPRINTF(state->dmr_embedded_gps[0], sizeof(state->dmr_embedded_gps[0]), "stale embedded");
+    DSD_SNPRINTF(state->dmr_lrrp_gps[0], sizeof(state->dmr_lrrp_gps[0]),
+                 "Data Call: Mobile Radio Statistics; SAP:24; LLID: 393226; ");
+}
+
+static void
+expect_stale_data_call_display_cleared(const char* duid, unsigned int expected_burst, const char* expected_subtype) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.synctype = DSD_SYNC_P25P1_POS;
+    seed_stale_data_call_display(&state);
+
+    DSD_SNPRINTF(g_test_duid, sizeof(g_test_duid), "%s", duid);
+    dsd_dispatch_handle_p25p1(&opts, &state);
+
+    assert(state.dmrburstL == expected_burst);
+    assert(state.dmr_embedded_gps[0][0] == '\0');
+    assert(state.dmr_lrrp_gps[0][0] == '\0');
+    assert(strcmp(state.fsubtype, expected_subtype) == 0);
+}
+
+static void
+test_p25p1_dispatch_clears_stale_data_call_display(void) {
+    static const struct {
+        const char* duid;
+        unsigned int expected_burst;
+        const char* expected_subtype;
+    } cases[] = {
+        {"00", 25, " HDU          "}, {"11", 26, " LDU1         "}, {"22", 27, " LDU2         "},
+        {"33", 28, " TDULC        "}, {"03", 28, " TDU          "}, {"13", 29, " TSBK         "},
+        {"30", 29, " MPDU         "}, {"44", 0, "              "},
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        expect_stale_data_call_display_cleared(cases[i].duid, cases[i].expected_burst, cases[i].expected_subtype);
+    }
+}
+
 int
 main(void) {
     test_sync_pattern_lengths();
     test_synctype_helpers();
     test_simple_tdu_dispatch_defaults();
+    test_p25p1_dispatch_clears_stale_data_call_display();
     printf("P25_P1_SYNC_DISPATCH: OK\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
- Clear P25p1 extra display text at the DUID dispatch boundary so stale PDU summaries do not persist into TSBK, voice, failed MPDU, or unknown frames.
- Keep successful MPDU/PDU decode behavior intact by clearing before dispatch and allowing the decoder to repopulate the display text.
- Expand P25p1 sync dispatch coverage across the current DUID branches.

## Issue
P25p1 PDU summaries reuse the shared DMR GPS/LRRP display fields that feed the extra call-info line in the UI. When a data-call summary populated those fields, later P25p1 frames could reset IDs or move back to the control channel without clearing the reused display text. That left messages such as a mobile radio statistics data call visible while idling on the control channel with data calls locked out.

## Resolution
The dispatch path now clears the reused extra display text once per P25p1 DUID dispatch before handing off to the specific frame handler. This covers the original control-channel idle path and the other latent transitions where stale PDU text could otherwise survive into voice, failed/partial MPDU, or unknown DUID handling. Successful PDU decode can still repopulate the fields after the boundary clear.

## Validation
- `tools/format.sh`
- `cmake --build --preset dev-debug -j --target dsd-neo_test_p25_p1_sync_dispatch`
- `ctest --preset dev-debug --output-on-failure -R '^P25_P1_SYNC_DISPATCH$'`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh`