### PR TITLE
io: fix rtl auto-ppm fsk correction

### DIFF
--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -159,9 +159,9 @@ struct dsd_opts {
     /* Mark when RTL-SDR stream must be destroyed/recreated to apply changes
        that cannot be updated live (e.g., device index, bandwidth, manual gain). */
     int rtl_needs_restart;
-    /* Spectrum-based RTL auto-PPM enable (0=off, 1=on). Mirrors DSD_NEO_AUTO_PPM. */
+    /* Carrier/tracking-based RTL auto-PPM enable (0=off, 1=on). Mirrors DSD_NEO_AUTO_PPM. */
     int rtl_auto_ppm;
-    /* Spectrum-based RTL auto-PPM SNR threshold in dB; <=0 means default. */
+    /* Carrier/tracking-based RTL auto-PPM SNR threshold in dB; <=0 means default. */
     float rtl_auto_ppm_snr_db;
     int monitor_input_audio;
     /* Warn when input level is below this dBFS threshold (e.g., -40). */

--- a/include/dsd-neo/runtime/config.h
+++ b/include/dsd-neo/runtime/config.h
@@ -182,7 +182,7 @@ typedef struct dsdneoRuntimeConfig {
     double tuner_autogain_inband_ratio;
     double tuner_autogain_up_step_db;
 
-    /* Auto-PPM (spectrum-based) knobs */
+    /* Auto-PPM (carrier/tracking-based) knobs */
     double auto_ppm_snr_db;
     double auto_ppm_pwr_db;
     double auto_ppm_zerolock_ppm;
@@ -352,7 +352,7 @@ typedef struct dsdneoRuntimeConfig {
     int tuner_autogain_up_persist_is_set;
     int tuner_autogain_up_persist;
 
-    /* Auto-PPM (spectrum-based) knobs */
+    /* Auto-PPM (carrier/tracking-based) knobs */
     int auto_ppm_is_set;
     int auto_ppm_enable;
     int auto_ppm_snr_db_is_set;

--- a/src/io/radio/rtl_auto_ppm.cpp
+++ b/src/io/radio/rtl_auto_ppm.cpp
@@ -42,9 +42,7 @@ clamp_ppm_step(int step, int limit) {
 
 static inline double
 estimate_snr_db(RtlAutoPpmSource source, const RtlAutoPpmInputs& inputs) {
-    if (source == RtlAutoPpmSource::SpectrumResidual) {
-        return inputs.spec_snr_db;
-    }
+    (void)source;
     return std::max(inputs.gate_snr_db, inputs.spec_snr_db);
 }
 
@@ -95,7 +93,6 @@ rtl_auto_ppm_source_max_step(RtlAutoPpmSource source, const RtlAutoPpmConfig& co
     switch (source) {
         case RtlAutoPpmSource::CarrierTotal: return config.max_step_carrier_ppm;
         case RtlAutoPpmSource::PhaseResidual: return config.max_step_phase_ppm;
-        case RtlAutoPpmSource::SpectrumResidual: return config.max_step_spectrum_ppm;
         case RtlAutoPpmSource::None:
         default: return 0;
     }
@@ -106,9 +103,8 @@ rtl_auto_ppm_source_observation_ms(RtlAutoPpmSource source, const RtlAutoPpmConf
     switch (source) {
         case RtlAutoPpmSource::CarrierTotal: return config.carrier_observation_ms;
         case RtlAutoPpmSource::PhaseResidual: return config.phase_observation_ms;
-        case RtlAutoPpmSource::SpectrumResidual: return config.spectrum_observation_ms;
         case RtlAutoPpmSource::None:
-        default: return config.phase_observation_ms;
+        default: return 0;
     }
 }
 
@@ -443,17 +439,30 @@ rtl_auto_ppm_try_apply_correction(const RtlAutoPpmConfig& config, const RtlAutoP
 RtlAutoPpmEstimate
 rtl_auto_ppm_select_estimate(const RtlAutoPpmSignalMetrics& metrics) {
     /* Tuner PPM is a device-wide calibration. Only CQPSK carrier recovery can
-     * export a stable total CFO; non-CQPSK FLL totals can include transmitter
-     * or channel offset and must not be folded into the dongle calibration. */
+     * export a stable total CFO; non-CQPSK totals can include transmitter or
+     * channel offset and must not be folded into the dongle calibration. */
     if (tracking_estimate_ready(metrics)) {
         return {RtlAutoPpmSource::CarrierTotal, metrics.nco_cfo_hz};
     }
 
-    if (metrics.spectrum_valid && finite_hz(metrics.spectrum_cfo_hz)) {
-        return {RtlAutoPpmSource::SpectrumResidual, metrics.spectrum_cfo_hz};
+    /* For non-CQPSK, tracking_enable means phase_cfo_hz has already been
+     * vetted by a mode-specific tracker such as the FSK modem DC estimator. */
+    if (!metrics.cqpsk_enable && metrics.tracking_enable && finite_hz(metrics.phase_cfo_hz)) {
+        return {RtlAutoPpmSource::PhaseResidual, metrics.phase_cfo_hz};
     }
 
     return {};
+}
+
+double
+rtl_auto_ppm_fsk_dc_est_to_cfo_hz(double dc_rad_per_sample, int sample_rate_hz) {
+    /* FSK dc_est is the discriminator-centering term subtracted inside the
+     * modem (`centered = freq - dc_est`), not the residual that remains after
+     * centering. Hardware tests with RTL-SDR frequency correction show that
+     * positive dc_est must request a negative PPM correction to reduce the
+     * observed symbol DC bias, so keep this conversion opposite the raw
+     * phase-delta sign. */
+    return -dc_rad_per_sample * static_cast<double>(sample_rate_hz) / 6.28318530717958647692;
 }
 
 void

--- a/src/io/radio/rtl_auto_ppm.h
+++ b/src/io/radio/rtl_auto_ppm.h
@@ -18,17 +18,14 @@ enum class RtlAutoPpmSource : uint8_t {
     None = 0,
     CarrierTotal = 1,
     PhaseResidual = 2,
-    SpectrumResidual = 3,
 };
 
 struct RtlAutoPpmSignalMetrics {
     int cqpsk_enable = 0;
     int tracking_enable = 0;
     int carrier_lock = 0;
-    int spectrum_valid = 0;
     double nco_cfo_hz = 0.0;
     double phase_cfo_hz = 0.0;
-    double spectrum_cfo_hz = 0.0;
 };
 
 struct RtlAutoPpmEstimate {
@@ -50,12 +47,10 @@ struct RtlAutoPpmConfig {
     double max_abs_ppm = 200.0;
     int carrier_observation_ms = 4000;
     int phase_observation_ms = 5000;
-    int spectrum_observation_ms = 8000;
     int settle_ms = 2500;
     int lock_hold_ms = 3000;
     int max_step_carrier_ppm = 25;
     int max_step_phase_ppm = 12;
-    int max_step_spectrum_ppm = 4;
 };
 
 struct RtlAutoPpmInputs {
@@ -88,6 +83,11 @@ struct RtlAutoPpmUpdate {
 };
 
 RtlAutoPpmEstimate rtl_auto_ppm_select_estimate(const RtlAutoPpmSignalMetrics& metrics);
+
+/* Convert the FSK modem's discriminator centering estimate into the RTL/Soapy
+ * frequency-correction sign used by auto-PPM. The result is intentionally
+ * opposite the raw dc_est phase-delta sign. */
+double rtl_auto_ppm_fsk_dc_est_to_cfo_hz(double dc_rad_per_sample, int sample_rate_hz);
 
 class RtlAutoPpmController {
   public:

--- a/src/io/radio/rtl_metrics.cpp
+++ b/src/io/radio/rtl_metrics.cpp
@@ -7,9 +7,8 @@
  * @file
  * @brief RTL-SDR metrics, spectrum diagnostics, and auto-PPM helpers.
  *
- * Houses spectrum/SNR-based auto-PPM supervision state, spectrum and
- * carrier diagnostics, and the public query/toggle helpers used by
- * the UI and protocol code.
+ * Houses auto-PPM supervision state, spectrum and carrier diagnostics, and the
+ * public query/toggle helpers used by the UI and protocol code.
  */
 
 #include <algorithm>

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/power.h>
@@ -52,7 +53,6 @@
 #include <dsd-neo/runtime/unicode.h>
 #include <errno.h>
 #include <limits.h>
-#include <math.h>
 #include <mutex>
 #include <stdint.h>
 #include <stdio.h>
@@ -6309,6 +6309,25 @@ auto_ppm_make_config(const dsd_opts* opts) {
 }
 
 static int
+auto_ppm_fsk_phase_cfo_hz(double* out_cfo_hz) {
+    if (!out_cfo_hz || demod.cqpsk_enable || demod.output_kind != DSD_DEMOD_OUTPUT_SYMBOL_FSK || demod.rate_out <= 0) {
+        return 0;
+    }
+    if (!g_fsk_metrics_valid.load(std::memory_order_acquire)
+        || !g_fsk_metrics_timing_acquired.load(std::memory_order_relaxed)) {
+        return 0;
+    }
+
+    double dc_rad_per_sample = g_fsk_metrics_dc_est.load(std::memory_order_relaxed);
+    if (!std::isfinite(dc_rad_per_sample)) {
+        return 0;
+    }
+
+    *out_cfo_hz = dsd::io::radio::rtl_auto_ppm_fsk_dc_est_to_cfo_hz(dc_rad_per_sample, demod.rate_out);
+    return 1;
+}
+
+static int
 auto_ppm_should_freeze_retunes(void) {
     const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
     if (!cfg) {
@@ -6349,10 +6368,14 @@ auto_ppm_maybe_adjust(dsd_opts* opts, const dsd_state* state) {
     metrics.cqpsk_enable = demod.cqpsk_enable ? 1 : 0;
     metrics.tracking_enable = demod.cqpsk_enable ? 1 : 0;
     metrics.carrier_lock = dsd_rtl_stream_get_carrier_lock();
-    metrics.spectrum_valid = (spec_snr_db > -99.0) ? 1 : 0;
     metrics.nco_cfo_hz = dsd_rtl_stream_get_cfo_hz();
-    metrics.phase_cfo_hz = g_resid_cfo_phase_hz.load(std::memory_order_relaxed);
-    metrics.spectrum_cfo_hz = dsd_rtl_stream_get_residual_cfo_hz();
+    double fsk_phase_cfo_hz = 0.0;
+    if (auto_ppm_fsk_phase_cfo_hz(&fsk_phase_cfo_hz)) {
+        metrics.tracking_enable = 1;
+        metrics.phase_cfo_hz = fsk_phase_cfo_hz;
+    } else {
+        metrics.phase_cfo_hz = g_resid_cfo_phase_hz.load(std::memory_order_relaxed);
+    }
 
     dsd::io::radio::RtlAutoPpmInputs inputs = {};
     inputs.now_ms = now_ms;

--- a/tests/io/test_io_rtl_auto_ppm.cpp
+++ b/tests/io/test_io_rtl_auto_ppm.cpp
@@ -10,6 +10,7 @@
 #include "rtl_auto_ppm.h"
 #include "rtl_ppm_request.h"
 
+using dsd::io::radio::rtl_auto_ppm_fsk_dc_est_to_cfo_hz;
 using dsd::io::radio::rtl_auto_ppm_select_estimate;
 using dsd::io::radio::RtlAutoPpmConfig;
 using dsd::io::radio::RtlAutoPpmController;
@@ -83,9 +84,7 @@ test_select_estimate_accepts_large_finite_cqpsk_nco(void) {
     metrics.cqpsk_enable = 1;
     metrics.tracking_enable = 1;
     metrics.carrier_lock = 1;
-    metrics.spectrum_valid = 1;
     metrics.nco_cfo_hz = -68000.0;
-    metrics.spectrum_cfo_hz = 1800.0;
 
     RtlAutoPpmEstimate estimate = select_estimate(metrics);
     rc |= expect_int_eq("large cqpsk nco source", static_cast<int>(estimate.source),
@@ -101,9 +100,7 @@ test_select_estimate_prefers_cqpsk_nco_after_lock(void) {
     metrics.cqpsk_enable = 1;
     metrics.tracking_enable = 1;
     metrics.carrier_lock = 1;
-    metrics.spectrum_valid = 1;
     metrics.nco_cfo_hz = 1200.0;
-    metrics.spectrum_cfo_hz = 75.0;
 
     RtlAutoPpmEstimate estimate = select_estimate(metrics);
     rc |= expect_int_eq("cqpsk carrier source", static_cast<int>(estimate.source),
@@ -113,30 +110,12 @@ test_select_estimate_prefers_cqpsk_nco_after_lock(void) {
 }
 
 static int
-test_select_estimate_uses_cqpsk_spectrum_before_lock(void) {
-    int rc = 0;
-    RtlAutoPpmSignalMetrics metrics = {};
-    metrics.cqpsk_enable = 1;
-    metrics.tracking_enable = 1;
-    metrics.spectrum_valid = 1;
-    metrics.nco_cfo_hz = 950.0;
-    metrics.spectrum_cfo_hz = 240.0;
-
-    RtlAutoPpmEstimate estimate = select_estimate(metrics);
-    rc |= expect_int_eq("cqpsk bootstrap source", static_cast<int>(estimate.source),
-                        static_cast<int>(RtlAutoPpmSource::SpectrumResidual));
-    rc |= expect_double_close("cqpsk bootstrap error", estimate.error_hz, 240.0, 1e-9);
-    return rc;
-}
-
-static int
-test_select_estimate_rejects_cqpsk_without_lock_or_spectrum(void) {
+test_select_estimate_rejects_cqpsk_without_lock(void) {
     int rc = 0;
     RtlAutoPpmSignalMetrics metrics = {};
     metrics.cqpsk_enable = 1;
     metrics.tracking_enable = 1;
     metrics.nco_cfo_hz = 950.0;
-    metrics.spectrum_cfo_hz = 240.0;
 
     RtlAutoPpmEstimate estimate = select_estimate(metrics);
     rc |= expect_int_eq("cqpsk no-lock source", static_cast<int>(estimate.source),
@@ -146,61 +125,39 @@ test_select_estimate_rejects_cqpsk_without_lock_or_spectrum(void) {
 }
 
 static int
-test_select_estimate_keeps_non_cqpsk_spectrum_with_tracking_enabled(void) {
-    int rc = 0;
-    RtlAutoPpmSignalMetrics metrics = {};
-    metrics.tracking_enable = 1;
-    metrics.spectrum_valid = 1;
-    metrics.nco_cfo_hz = -320.0;
-    metrics.phase_cfo_hz = -320.0;
-    metrics.spectrum_cfo_hz = 40.0;
-
-    RtlAutoPpmEstimate estimate = select_estimate(metrics);
-    rc |= expect_int_eq("non-cqpsk spectrum source", static_cast<int>(estimate.source),
-                        static_cast<int>(RtlAutoPpmSource::SpectrumResidual));
-    rc |= expect_double_close("non-cqpsk spectrum error", estimate.error_hz, 40.0, 1e-9);
-    return rc;
-}
-
-static int
-test_select_estimate_keeps_non_cqpsk_spectrum_for_large_offsets(void) {
-    int rc = 0;
-    RtlAutoPpmSignalMetrics metrics = {};
-    metrics.tracking_enable = 1;
-    metrics.spectrum_valid = 1;
-    metrics.nco_cfo_hz = 0.0;
-    metrics.phase_cfo_hz = -320.0;
-    metrics.spectrum_cfo_hz = 250.0;
-
-    RtlAutoPpmEstimate estimate = select_estimate(metrics);
-    rc |= expect_int_eq("fallback source", static_cast<int>(estimate.source),
-                        static_cast<int>(RtlAutoPpmSource::SpectrumResidual));
-    rc |= expect_double_close("fallback error", estimate.error_hz, 250.0, 1e-9);
-    return rc;
-}
-
-static int
-test_select_estimate_rejects_invalid_non_cqpsk_spectrum(void) {
+test_select_estimate_prefers_non_cqpsk_phase_tracking(void) {
     int rc = 0;
     RtlAutoPpmSignalMetrics metrics = {};
     metrics.tracking_enable = 1;
     metrics.nco_cfo_hz = -320.0;
     metrics.phase_cfo_hz = -320.0;
-    metrics.spectrum_cfo_hz = 90.0;
 
     RtlAutoPpmEstimate estimate = select_estimate(metrics);
-    rc |= expect_int_eq("invalid spectrum source", static_cast<int>(estimate.source),
-                        static_cast<int>(RtlAutoPpmSource::None));
-    rc |= expect_double_close("invalid spectrum error", estimate.error_hz, 0.0, 1e-9);
+    rc |= expect_int_eq("non-cqpsk phase source", static_cast<int>(estimate.source),
+                        static_cast<int>(RtlAutoPpmSource::PhaseResidual));
+    rc |= expect_double_close("non-cqpsk phase error", estimate.error_hz, -320.0, 1e-9);
     return rc;
 }
 
 static int
-test_select_estimate_rejects_phase_only_non_cqpsk(void) {
+test_select_estimate_uses_tracked_phase(void) {
+    int rc = 0;
+    RtlAutoPpmSignalMetrics metrics = {};
+    metrics.tracking_enable = 1;
+    metrics.phase_cfo_hz = 180.0;
+
+    RtlAutoPpmEstimate estimate = select_estimate(metrics);
+    rc |= expect_int_eq("tracked phase-only source", static_cast<int>(estimate.source),
+                        static_cast<int>(RtlAutoPpmSource::PhaseResidual));
+    rc |= expect_double_close("tracked phase-only error", estimate.error_hz, 180.0, 1e-9);
+    return rc;
+}
+
+static int
+test_select_estimate_rejects_untracked_phase_only_non_cqpsk(void) {
     int rc = 0;
     RtlAutoPpmSignalMetrics metrics = {};
     metrics.phase_cfo_hz = -320.0;
-    metrics.spectrum_cfo_hz = std::nan("");
 
     RtlAutoPpmEstimate estimate = select_estimate(metrics);
     rc |=
@@ -210,25 +167,30 @@ test_select_estimate_rejects_phase_only_non_cqpsk(void) {
 }
 
 static int
-test_spectrum_estimate_requires_valid_spectral_snr(void) {
+test_fsk_dc_estimate_uses_hardware_ppm_correction_sign(void) {
     int rc = 0;
+    const int sample_rate_hz = 48000;
+    const uint32_t tuned_freq_hz = 480000000U;
+    const double dc_rad_per_sample = (2.0 * std::acos(-1.0) * 960.0) / static_cast<double>(sample_rate_hz);
+
+    double cfo_hz = rtl_auto_ppm_fsk_dc_est_to_cfo_hz(dc_rad_per_sample, sample_rate_hz);
+    rc |= expect_double_close("positive fsk dc requests negative correction", cfo_hz, -960.0, 1e-9);
+    rc |= expect_double_close("negative fsk dc requests positive correction",
+                              rtl_auto_ppm_fsk_dc_est_to_cfo_hz(-dc_rad_per_sample, sample_rate_hz), 960.0, 1e-9);
+
     RtlAutoPpmController controller;
     RtlAutoPpmConfig config = {};
-    const uint32_t freq_hz = 460000000U;
+    controller.reset(0, tuned_freq_hz);
 
-    controller.reset(0, freq_hz);
-
-    RtlAutoPpmInputs inputs = make_inputs(0, 0, freq_hz, -6.0, RtlAutoPpmSource::SpectrumResidual);
-    inputs.gate_snr_db = 18.0;
-    inputs.spec_snr_db = -100.0;
-
-    (void)controller.update(config, inputs);
-    inputs.now_ms = 9000;
+    RtlAutoPpmInputs inputs = make_inputs(0, 0, tuned_freq_hz, 0.0, RtlAutoPpmSource::PhaseResidual);
+    inputs.estimate.error_hz = cfo_hz;
     RtlAutoPpmUpdate update = controller.update(config, inputs);
-    rc |= expect_int_eq("invalid spectrum does not apply", update.apply_ppm, 0);
-    rc |= expect_int_eq("invalid spectrum stays unlocked", update.locked, 0);
-    rc |= expect_int_eq("invalid spectrum is not training", update.training, 0);
-    rc |= expect_double_close("invalid spectrum uses spectral snr", update.snr_db, -100.0, 1e-9);
+    rc |= expect_int_eq("positive fsk dc waits for observation", update.apply_ppm, 0);
+
+    inputs.now_ms = 5001;
+    update = controller.update(config, inputs);
+    rc |= expect_int_eq("positive fsk dc decrements hardware ppm", update.apply_ppm, 1);
+    rc |= expect_int_eq("positive fsk dc correction step", update.new_ppm, -2);
     return rc;
 }
 
@@ -264,52 +226,6 @@ test_carrier_estimate_applies_direct_correction_then_locks(void) {
     rc |= expect_int_eq("stable zero locks", update.locked, 1);
     rc |= expect_int_eq("stable zero exits training", update.training, 0);
     rc |= expect_int_eq("lock stores corrected ppm", update.lock_ppm, -8);
-    return rc;
-}
-
-static int
-test_spectrum_fallback_clamps_large_steps(void) {
-    int rc = 0;
-    RtlAutoPpmController controller;
-    RtlAutoPpmConfig config = {};
-    const uint32_t freq_hz = 935000000U;
-
-    controller.reset(0, freq_hz);
-    (void)controller.update(config, make_inputs(0, 0, freq_hz, -20.0, RtlAutoPpmSource::SpectrumResidual));
-
-    RtlAutoPpmUpdate update =
-        controller.update(config, make_inputs(8000, 0, freq_hz, -20.0, RtlAutoPpmSource::SpectrumResidual));
-    rc |= expect_int_eq("spectrum fallback applies", update.apply_ppm, 1);
-    rc |= expect_int_eq("spectrum fallback clamps step", update.new_ppm, -4);
-    rc |= expect_int_eq("spectrum fallback remains in training", update.training, 1);
-    rc |= expect_int_eq("spectrum fallback stays unlocked", update.locked, 0);
-    return rc;
-}
-
-static int
-test_large_spectrum_residual_stays_bounded_across_windows(void) {
-    int rc = 0;
-    RtlAutoPpmController controller;
-    RtlAutoPpmConfig config = {};
-    const uint32_t freq_hz = 935000000U;
-
-    controller.reset(0, freq_hz);
-    (void)controller.update(config, make_inputs(0, 0, freq_hz, -60.0, RtlAutoPpmSource::SpectrumResidual));
-
-    RtlAutoPpmUpdate update =
-        controller.update(config, make_inputs(8000, 0, freq_hz, -60.0, RtlAutoPpmSource::SpectrumResidual));
-    rc |= expect_int_eq("bounded step applies", update.apply_ppm, 1);
-    rc |= expect_int_eq("bounded step clamps to spectrum max", update.new_ppm, -4);
-    rc |= expect_int_eq("bounded step keeps controller unlocked", update.locked, 0);
-    rc |= expect_int_eq("bounded step keeps training active", update.training, 1);
-
-    update = controller.update(config, make_inputs(10501, -4, freq_hz, -56.0, RtlAutoPpmSource::SpectrumResidual));
-    rc |= expect_int_eq("post-bounded settle does not reapply immediately", update.apply_ppm, 0);
-    rc |= expect_int_eq("post-bounded settle remains in training", update.training, 1);
-
-    update = controller.update(config, make_inputs(18502, -4, freq_hz, -56.0, RtlAutoPpmSource::SpectrumResidual));
-    rc |= expect_int_eq("residual can trigger another bounded step", update.apply_ppm, 1);
-    rc |= expect_int_eq("second bounded step continues converging", update.new_ppm, -8);
     return rc;
 }
 
@@ -671,88 +587,6 @@ test_sub_deadband_residual_locks_with_zero_lock_ppm_below_deadband_floor(void) {
 }
 
 static int
-test_spectrum_lock_revalidates_same_frequency_carrier_upgrade(void) {
-    int rc = 0;
-    RtlAutoPpmController controller;
-    RtlAutoPpmConfig config = {};
-    const uint32_t freq_hz = 851000000U;
-
-    controller.reset(0, freq_hz);
-
-    (void)controller.update(config, make_inputs(1000, 0, freq_hz, 0.02, RtlAutoPpmSource::SpectrumResidual));
-    RtlAutoPpmUpdate update =
-        controller.update(config, make_inputs(4000, 0, freq_hz, 0.02, RtlAutoPpmSource::SpectrumResidual));
-    rc |= expect_int_eq("spectrum provisional lock setup reaches lock", update.locked, 1);
-    rc |= expect_int_eq("spectrum provisional lock stores current ppm", update.lock_ppm, 0);
-
-    update = controller.update(config, make_inputs(5000, 0, freq_hz, -6.0, RtlAutoPpmSource::CarrierTotal));
-    rc |= expect_int_eq("same-frequency carrier upgrade clears provisional lock", update.locked, 0);
-    rc |= expect_int_eq("same-frequency carrier upgrade resumes training", update.training, 1);
-    rc |= expect_int_eq("same-frequency carrier upgrade does not apply immediately", update.apply_ppm, 0);
-    rc |= expect_int_eq("same-frequency carrier upgrade preserves lock snapshot", update.lock_ppm, 0);
-
-    update = controller.update(config, make_inputs(9000, 0, freq_hz, -6.0, RtlAutoPpmSource::CarrierTotal));
-    rc |= expect_int_eq("same-frequency carrier upgrade can correct after observation", update.apply_ppm, 1);
-    rc |= expect_int_eq("same-frequency carrier upgrade applies from current ppm", update.new_ppm, -6);
-    rc |= expect_int_eq("same-frequency carrier upgrade remains in training after step", update.training, 1);
-    rc |= expect_int_eq("same-frequency carrier upgrade stays unlocked after step", update.locked, 0);
-    return rc;
-}
-
-static int
-test_spectrum_lock_ignores_carrier_upgrade_after_frequency_change(void) {
-    int rc = 0;
-    RtlAutoPpmController controller;
-    RtlAutoPpmConfig config = {};
-    const uint32_t freq_a_hz = 851000000U;
-    const uint32_t freq_b_hz = 935000000U;
-
-    controller.reset(0, freq_a_hz);
-
-    (void)controller.update(config, make_inputs(1000, 0, freq_a_hz, 0.02, RtlAutoPpmSource::SpectrumResidual));
-    RtlAutoPpmUpdate update =
-        controller.update(config, make_inputs(4000, 0, freq_a_hz, 0.02, RtlAutoPpmSource::SpectrumResidual));
-    rc |= expect_int_eq("spectrum retune setup reaches lock", update.locked, 1);
-
-    update = controller.update(config, make_inputs(5000, 0, freq_b_hz, -6.0, RtlAutoPpmSource::CarrierTotal));
-    rc |= expect_int_eq("retuned carrier estimate keeps provisional lock", update.locked, 1);
-    rc |= expect_int_eq("retuned carrier estimate stays out of training", update.training, 0);
-    rc |= expect_int_eq("retuned carrier estimate does not apply", update.apply_ppm, 0);
-
-    update = controller.update(config, make_inputs(9000, 0, freq_b_hz, -6.0, RtlAutoPpmSource::CarrierTotal));
-    rc |= expect_int_eq("retuned carrier estimate still does not apply later", update.apply_ppm, 0);
-    rc |= expect_int_eq("retuned carrier estimate remains locked later", update.locked, 1);
-    rc |= expect_int_eq("retuned carrier estimate remains idle later", update.training, 0);
-    return rc;
-}
-
-static int
-test_spectrum_lock_promotes_on_same_frequency_carrier_zero_lock(void) {
-    int rc = 0;
-    RtlAutoPpmController controller;
-    RtlAutoPpmConfig config = {};
-    const uint32_t freq_hz = 851000000U;
-
-    controller.reset(0, freq_hz);
-
-    (void)controller.update(config, make_inputs(1000, 0, freq_hz, 0.02, RtlAutoPpmSource::SpectrumResidual));
-    RtlAutoPpmUpdate update =
-        controller.update(config, make_inputs(4000, 0, freq_hz, 0.02, RtlAutoPpmSource::SpectrumResidual));
-    rc |= expect_int_eq("spectrum carrier-zero setup reaches lock", update.locked, 1);
-
-    update = controller.update(config, make_inputs(5000, 0, freq_hz, 0.02, RtlAutoPpmSource::CarrierTotal));
-    rc |= expect_int_eq("same-frequency carrier zero keeps lock", update.locked, 1);
-    rc |= expect_int_eq("same-frequency carrier zero stays out of training", update.training, 0);
-    rc |= expect_int_eq("same-frequency carrier zero does not apply", update.apply_ppm, 0);
-
-    update = controller.update(config, make_inputs(9000, 0, freq_hz, -6.0, RtlAutoPpmSource::CarrierTotal));
-    rc |= expect_int_eq("carrier-validated lock ignores later drift", update.locked, 1);
-    rc |= expect_int_eq("carrier-validated lock stays out of training", update.training, 0);
-    rc |= expect_int_eq("carrier-validated lock does not apply later drift", update.apply_ppm, 0);
-    return rc;
-}
-
-static int
 test_frequency_change_during_training_restarts_observation(void) {
     int rc = 0;
     RtlAutoPpmController controller;
@@ -761,16 +595,16 @@ test_frequency_change_during_training_restarts_observation(void) {
     const uint32_t freq_b_hz = 935000000U;
 
     controller.reset(0, freq_a_hz);
-    (void)controller.update(config, make_inputs(0, 0, freq_a_hz, -8.0, RtlAutoPpmSource::SpectrumResidual));
+    (void)controller.update(config, make_inputs(0, 0, freq_a_hz, -8.0, RtlAutoPpmSource::PhaseResidual));
 
     RtlAutoPpmUpdate update =
-        controller.update(config, make_inputs(3000, 0, freq_b_hz, -8.0, RtlAutoPpmSource::SpectrumResidual));
+        controller.update(config, make_inputs(3000, 0, freq_b_hz, -8.0, RtlAutoPpmSource::PhaseResidual));
     rc |= expect_int_eq("retune during training does not apply immediately", update.apply_ppm, 0);
     rc |= expect_int_eq("retune during training keeps cooldown clear", update.cooldown_ticks, 0);
 
-    update = controller.update(config, make_inputs(11001, 0, freq_b_hz, -8.0, RtlAutoPpmSource::SpectrumResidual));
+    update = controller.update(config, make_inputs(11001, 0, freq_b_hz, -8.0, RtlAutoPpmSource::PhaseResidual));
     rc |= expect_int_eq("retune observation can apply on new channel", update.apply_ppm, 1);
-    rc |= expect_int_eq("retune observation applies from current ppm", update.new_ppm, -4);
+    rc |= expect_int_eq("retune observation applies from current ppm", update.new_ppm, -8);
     rc |= expect_int_eq("retune observation stays unlocked", update.locked, 0);
     rc |= expect_int_eq("retune observation keeps training active", update.training, 1);
     return rc;
@@ -864,16 +698,12 @@ main(void) {
     int rc = 0;
     rc |= test_select_estimate_accepts_large_finite_cqpsk_nco();
     rc |= test_select_estimate_prefers_cqpsk_nco_after_lock();
-    rc |= test_select_estimate_uses_cqpsk_spectrum_before_lock();
-    rc |= test_select_estimate_rejects_cqpsk_without_lock_or_spectrum();
-    rc |= test_select_estimate_keeps_non_cqpsk_spectrum_with_tracking_enabled();
-    rc |= test_select_estimate_keeps_non_cqpsk_spectrum_for_large_offsets();
-    rc |= test_select_estimate_rejects_invalid_non_cqpsk_spectrum();
-    rc |= test_select_estimate_rejects_phase_only_non_cqpsk();
-    rc |= test_spectrum_estimate_requires_valid_spectral_snr();
+    rc |= test_select_estimate_rejects_cqpsk_without_lock();
+    rc |= test_select_estimate_prefers_non_cqpsk_phase_tracking();
+    rc |= test_select_estimate_uses_tracked_phase();
+    rc |= test_select_estimate_rejects_untracked_phase_only_non_cqpsk();
+    rc |= test_fsk_dc_estimate_uses_hardware_ppm_correction_sign();
     rc |= test_carrier_estimate_applies_direct_correction_then_locks();
-    rc |= test_spectrum_fallback_clamps_large_steps();
-    rc |= test_large_spectrum_residual_stays_bounded_across_windows();
     rc |= test_external_ppm_change_resets_observation_window();
     rc |= test_async_ppm_waits_for_applied_snapshot_before_retraining();
     rc |= test_requested_ppm_change_blocks_retraining_until_applied();
@@ -886,9 +716,6 @@ main(void) {
     rc |= test_sub_deadband_residual_locks_without_dither_with_default_config();
     rc |= test_sub_deadband_residual_locks_with_zero_lock_hz_below_deadband_floor();
     rc |= test_sub_deadband_residual_locks_with_zero_lock_ppm_below_deadband_floor();
-    rc |= test_spectrum_lock_revalidates_same_frequency_carrier_upgrade();
-    rc |= test_spectrum_lock_ignores_carrier_upgrade_after_frequency_change();
-    rc |= test_spectrum_lock_promotes_on_same_frequency_carrier_zero_lock();
     rc |= test_frequency_change_during_training_restarts_observation();
     rc |= test_frequency_change_keeps_session_lock_after_lock_carry();
     rc |= test_locked_session_ignores_external_ppm_change();


### PR DESCRIPTION
## Summary

- Remove the invalid spectrum fallback from RTL auto-PPM source selection.
- Use vetted FSK timing/DC metrics as the non-CQPSK phase correction source.
- Invert FSK discriminator DC conversion so correction direction matches tuner PPM adjustment.
- Drop obsolete spectrum fallback tests and keep the active carrier/phase selection coverage.

## Root Cause

The old fallback could derive correction from spectrum peak behavior that is not a stable tuner calibration signal for FSK modes. On DMR, that allowed modulation or channel offset to drive the correction in the wrong direction. The FSK DC estimate also needed to be converted as a correction term, not preserved as the raw discriminator sign.

## Validation

- `tools/format.sh`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh`
- push hook preflight on `fix/rtl-auto-ppm-fsk-correction`