### PR TITLE
core: treat startup history as status events

### DIFF
--- a/include/dsd-neo/core/events.h
+++ b/include/dsd-neo/core/events.h
@@ -28,6 +28,7 @@ void push_event_history(Event_History_I* event_struct);
 void write_event_to_log_file(const dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite, char* event_string);
 void watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot);
 void watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot);
+void watchdog_event_status(dsd_state* state, const char* status_string, uint8_t slot);
 void watchdog_event_datacall(dsd_opts* opts, dsd_state* state, uint32_t src, uint32_t dst, char* data_string,
                              uint8_t slot);
 

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -1012,6 +1012,34 @@ watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) {
 }
 
 void
+watchdog_event_status(dsd_state* state, const char* status_string, uint8_t slot) {
+    if (state == NULL || state->event_history_s == NULL || status_string == NULL || slot >= 2) {
+        return;
+    }
+
+    Event_History_I* event_struct = &state->event_history_s[slot];
+    init_event_history(event_struct, 0, 1);
+
+    Event_History* item = &event_struct->Event_History_Items[0];
+    item->write = 0;
+    item->color_pair = 4;
+    item->systype = -1;
+    item->subtype = -1;
+    item->source_id = 0;
+    item->target_id = 0;
+
+    time_t now = time(NULL);
+    item->event_time = now;
+
+    char timestr[9];
+    char datestr[11];
+    getTimeN_buf(now, timestr);
+    getDateN_buf(now, datestr);
+
+    DSD_SNPRINTF(item->event_string, sizeof item->event_string, "%s %s %s", datestr, timestr, status_string);
+}
+
+void
 watchdog_event_datacall(dsd_opts* opts, dsd_state* state, uint32_t src, uint32_t dst, char* data_string, uint8_t slot) {
     state->event_history_s[slot].Event_History_Items[0].write = 0;
     state->event_history_s[slot].Event_History_Items[0].color_pair = 4; //default data color //you can change this one

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2071,13 +2071,15 @@ live_scanner_start_trunk_scan_if_needed(dsd_opts* opts, dsd_state* state) {
 }
 
 static void
-live_scanner_emit_start_history(dsd_opts* opts, dsd_state* state) {
-    state->event_history_s[0].Event_History_Items[0].color_pair = 4;
-    watchdog_event_datacall(opts, state, 0, 0, "Any decoded voice calls or data calls display here;", 0);
+live_scanner_emit_start_history(dsd_state* state) {
+    if (state == NULL || state->event_history_s == NULL) {
+        return;
+    }
+
+    watchdog_event_status(state, "Any decoded voice calls or data calls display here;", 0);
     push_event_history(&state->event_history_s[0]);
     init_event_history(&state->event_history_s[0], 0, 1);
-    state->event_history_s[0].Event_History_Items[0].color_pair = 4;
-    watchdog_event_datacall(opts, state, 0, 0, "DSD-neo Started and Event History Initialized;", 0);
+    watchdog_event_status(state, "DSD-neo Started and Event History Initialized;", 0);
     push_event_history(&state->event_history_s[0]);
     init_event_history(&state->event_history_s[0], 0, 1);
 }
@@ -2170,7 +2172,7 @@ liveScanner(dsd_opts* opts, dsd_state* state) {
         return -1;
     }
 
-    live_scanner_emit_start_history(opts, state);
+    live_scanner_emit_start_history(state);
     live_scanner_emit_start_log_if_enabled(opts, state);
     if (dsd_frame_log_enabled(opts)) {
         dsd_frame_logf(opts, "DSD-neo frame logging initialized");

--- a/src/ui/terminal/ui_cmd_queue.c
+++ b/src/ui/terminal/ui_cmd_queue.c
@@ -391,18 +391,13 @@ apply_cmd_key_management(dsd_opts* opts, dsd_state* state, const struct UiCmd* c
 #ifdef USE_RADIO
 static int
 apply_dsp_op_cqpsk_toggle(const UiDspPayload* p) {
-    if (!p) {
+    if (!p || p->op != UI_DSP_OP_TOGGLE_CQ) {
         return 0;
     }
-    switch (p->op) {
-        case UI_DSP_OP_TOGGLE_CQ: {
-            int cq = 0;
-            rtl_stream_get_cqpsk_status(&cq, NULL);
-            rtl_stream_toggle_cqpsk(cq ? 0 : 1);
-            return 1;
-        }
-        default: return 0;
-    }
+    int cq = 0;
+    rtl_stream_get_cqpsk_status(&cq, NULL);
+    rtl_stream_toggle_cqpsk(cq ? 0 : 1);
+    return 1;
 }
 
 static int

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -13,6 +13,7 @@
 #include <dsd-neo/platform/sndfile_fwd.h>
 #include <dsd-neo/protocol/edacs/edacs_afs.h>
 #include <dsd-neo/runtime/call_alert.h>
+#include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -28,6 +29,8 @@
 
 static int g_beeper_count;
 static int g_last_beeper_id;
+static int g_frame_log_count;
+static char g_last_frame_log[512];
 
 enum {
     TEST_DMR_DATA_BURST = 6,
@@ -57,7 +60,11 @@ close_and_rename_wav_file(SNDFILE* wav_file, const dsd_opts* opts, const char* w
 void
 dsd_frame_logf(dsd_opts* opts, const char* format, ...) {
     UNUSED(opts);
-    UNUSED(format);
+    g_frame_log_count++;
+    va_list ap;
+    va_start(ap, format);
+    (void)DSD_VSNPRINTF(g_last_frame_log, sizeof g_last_frame_log, format, ap);
+    va_end(ap);
 }
 
 const char*
@@ -107,6 +114,8 @@ reset_fixture(dsd_opts* opts, dsd_state* state, Event_History_I event_history[2]
     opts->call_alert = 1;
     g_beeper_count = 0;
     g_last_beeper_id = 0;
+    g_frame_log_count = 0;
+    g_last_frame_log[0] = '\0';
 }
 
 static int
@@ -156,6 +165,52 @@ test_data_only_data_call_emits_one_data_alert(void) {
     int rc = 0;
     rc |= expect_int("data-only data call should beep once", g_beeper_count, 1);
     rc |= expect_int("data-only data call should use data tone", g_last_beeper_id, 80);
+    return rc;
+}
+
+static int
+test_data_call_emits_frame_log_record(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    watchdog_event_datacall(&opts, &state, 1234, 5678, "MNIS ARS;", 0);
+
+    int rc = 0;
+    rc |= expect_int("data call should emit one frame log", g_frame_log_count, 1);
+    rc |= expect_has_substr("data call frame log should identify data", g_last_frame_log, "FRAME DATA slot=1");
+    rc |= expect_has_substr("data call frame log should keep source", g_last_frame_log, "src=1234");
+    rc |= expect_has_substr("data call frame log should keep target", g_last_frame_log, "dst=5678");
+    return rc;
+}
+
+static int
+test_status_event_is_not_data_call_or_frame_log(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_DATA;
+
+    watchdog_event_status(&state, "DSD-neo Started and Event History Initialized;", 0);
+
+    const Event_History* current = &state.event_history_s[0].Event_History_Items[0];
+    int rc = 0;
+    rc |= expect_has_substr("status current should include message", current->event_string, "DSD-neo Started");
+    rc |= expect_int("status source remains zero", (int)current->source_id, 0);
+    rc |= expect_int("status target remains zero", (int)current->target_id, 0);
+    rc |= expect_int("status subtype remains neutral", (int)current->subtype, -1);
+    rc |= expect_int("status systype remains neutral", (int)current->systype, -1);
+    rc |= expect_int("status event time should be set", current->event_time > 0 ? 1 : 0, 1);
+    rc |= expect_int("status should not emit frame log", g_frame_log_count, 0);
+    rc |= expect_int("status should not emit data alert", g_beeper_count, 0);
+
+    push_event_history(&state.event_history_s[0]);
+    init_event_history(&state.event_history_s[0], 0, 1);
+    const Event_History* stored = &state.event_history_s[0].Event_History_Items[1];
+    rc |= expect_has_substr("status can be stored in history", stored->event_string, "DSD-neo Started");
+    rc |= expect_int("stored status subtype remains neutral", (int)stored->subtype, -1);
     return rc;
 }
 
@@ -408,6 +463,8 @@ main(void) {
 
     rc |= test_end_only_data_call_does_not_emit_voice_end_alert();
     rc |= test_data_only_data_call_emits_one_data_alert();
+    rc |= test_data_call_emits_frame_log_record();
+    rc |= test_status_event_is_not_data_call_or_frame_log();
     rc |= test_source_less_data_call_does_not_suppress_next_voice_start_alert();
     rc |= test_source_less_data_call_is_preserved_in_history();
     rc |= test_source_less_dmr_data_current_event_is_not_preserved_in_history();


### PR DESCRIPTION
## Summary

- Add a neutral startup status-event path for event-history placeholders.
- Stop startup placeholders from emitting `FRAME DATA` records with `src=0` and `dst=0`.
- Add focused regression coverage for real data-call frame logs and non-data status events.
- Rewrite the CQPSK UI DSP command handler's one-case switch as an `if` for CodeQL alert 742.

## Issue

Discussion #152 reported confusing source/target zero entries while investigating the provided capture. The capture still points to decode quality as the likely audio issue, but the zero-ID `TGT/SRC` records are not decoded traffic. They were startup event-history placeholder strings routed through `watchdog_event_datacall()`, which made frame logging and history treat them like decoded data calls.

## Resolution

`live_scanner_emit_start_history()` now uses `watchdog_event_status()`, which records neutral event-history status text without data-call metadata, call alerts, or frame-log output. Real decoded data calls continue through `watchdog_event_datacall()` and retain existing frame-log behavior, covered by regression tests.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: none.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests. Not applicable to parser/input; focused event-history tests were added.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny. No protocol, crypto, workflow, dependency, or release behavior changed.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. No suppressions were added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `tools/format.sh`
- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes
- [ ] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes

## Risk

- Security/dependency impact: None. CodeQL alert 742 cleanup is a maintainability rewrite, not a security behavior change.
- CLI/UI behavior impact: Startup history placeholders remain visible, but no longer appear as decoded data-call frame-log records with zero source/target IDs. CQPSK toggle behavior is unchanged.
- Compatibility or packaging impact: None.
