### PR TITLE
dsp: preserve non-radio symbol timing

### DIFF
--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -242,10 +242,13 @@ dmr_set_symbol_timing(const dsd_opts* opts, dsd_state* state) {
         return;
     }
 
-    int demod_rate = 0;
+    int demod_rate = dsd_opts_current_input_timing_rate(opts);
 #ifdef USE_RADIO
     if (opts->audio_in_type == AUDIO_IN_RTL && state->rtl_ctx) {
-        demod_rate = (int)dsd_rtl_stream_metrics_hook_output_rate_hz();
+        int rtl_demod_rate = (int)dsd_rtl_stream_metrics_hook_output_rate_hz();
+        if (rtl_demod_rate > 0) {
+            demod_rate = rtl_demod_rate;
+        }
     }
 #endif
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1522,17 +1522,35 @@ no_carrier_enable_p25_cc_slots_if_known(dsd_opts* opts, const dsd_state* state) 
     }
 }
 
+static int
+no_carrier_current_demod_rate(const dsd_opts* opts, const dsd_state* state) {
+    int demod_rate = dsd_opts_current_input_timing_rate(opts);
+#ifdef USE_RADIO
+    if (opts && opts->audio_in_type == AUDIO_IN_RTL && state && state->rtl_ctx) {
+        uint32_t rtl_rate = rtl_stream_output_rate(state->rtl_ctx);
+        if (rtl_rate > 0) {
+            demod_rate = (int)rtl_rate;
+        }
+    }
+#else
+    (void)state;
+#endif
+    return demod_rate;
+}
+
 static void
 no_carrier_apply_p25_cc_symbolrate(dsd_opts* opts, dsd_state* state) {
+    int sym_rate = 0;
     if (state->p25_cc_is_tdma == 0) {
-        state->samplesPerSymbol = 10;
-        state->symbolCenter = 4;
-        no_carrier_enable_p25_cc_slots(opts);
+        sym_rate = 4800;
     } else if (state->p25_cc_is_tdma == 1) {
-        state->samplesPerSymbol = 8;
-        state->symbolCenter = 3;
-        no_carrier_enable_p25_cc_slots(opts);
+        sym_rate = 6000;
+    } else {
+        return;
     }
+    state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, sym_rate, no_carrier_current_demod_rate(opts, state));
+    state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
+    no_carrier_enable_p25_cc_slots(opts);
 }
 
 static void

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -26,11 +26,14 @@
 #include "dsd-neo/runtime/trunk_tuning_hooks.h"
 
 static int DSD_ATTR_USED
-dsd_engine_rtl_demod_rate(const dsd_state* state) {
-    int demod_rate = 0;
+dsd_engine_current_demod_rate(const dsd_opts* opts, const dsd_state* state) {
+    int demod_rate = dsd_opts_current_input_timing_rate(opts);
 #ifdef USE_RADIO
-    if (state && state->rtl_ctx) {
-        demod_rate = (int)rtl_stream_output_rate(state->rtl_ctx);
+    if (opts && opts->audio_in_type == AUDIO_IN_RTL && state && state->rtl_ctx) {
+        int rtl_rate = (int)rtl_stream_output_rate(state->rtl_ctx);
+        if (rtl_rate > 0) {
+            demod_rate = rtl_rate;
+        }
     }
 #else
     (void)state;
@@ -52,7 +55,7 @@ dsd_engine_compute_cc_sps(const dsd_opts* opts, const dsd_state* state) {
         return 0;
     }
     const int sym_rate = (state->p25_cc_is_tdma == 1) ? 6000 : 4800;
-    return dsd_opts_compute_sps_rate(opts, sym_rate, dsd_engine_rtl_demod_rate(state));
+    return dsd_opts_compute_sps_rate(opts, sym_rate, dsd_engine_current_demod_rate(opts, state));
 }
 
 static void DSD_ATTR_USED
@@ -61,7 +64,7 @@ dsd_engine_apply_cc_symbol_timing(const dsd_opts* opts, dsd_state* state) {
         return;
     }
     const int sym_rate = (state->p25_cc_is_tdma == 1) ? 6000 : 4800;
-    state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, sym_rate, dsd_engine_rtl_demod_rate(state));
+    state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, sym_rate, dsd_engine_current_demod_rate(opts, state));
     state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
     state->rf_mod = (state->p25_cc_is_tdma == 1) ? 1 : ((opts->mod_qpsk == 1) ? 1 : 0);
 }
@@ -347,15 +350,7 @@ dsd_engine_tune_with_backend(const dsd_opts* opts, dsd_state* state, long int fr
 
 static void
 dsd_engine_maybe_reset_p25p2_state(const dsd_opts* opts, const dsd_state* state, int ted_sps) {
-    int p25p2_demod_rate = 0;
-#ifdef USE_RADIO
-    if (state->rtl_ctx) {
-        p25p2_demod_rate = (int)rtl_stream_output_rate(state->rtl_ctx);
-    }
-#else
-    (void)state;
-#endif
-    int p25p2_sps = dsd_opts_compute_sps_rate(opts, 6000, p25p2_demod_rate);
+    int p25p2_sps = dsd_opts_compute_sps_rate(opts, 6000, dsd_engine_current_demod_rate(opts, state));
     if (ted_sps == p25p2_sps) {
         p25_p2_frame_reset();
     }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -395,12 +395,18 @@ channel_slot(const dsd_state* state, int channel) {
     return is_tdma_channel(state, channel) ? ((channel & 1) ? 1 : 0) : -1;
 }
 
-// Compute TED SPS based on actual demodulator output rate (accounts for resampler).
+// Compute TED SPS from the active input timing rate, using live RTL output when available.
 static inline int
 p25_ted_sps_for_bw(const dsd_opts* opts, int sym_rate_hz) {
-    /* Query actual demodulator output rate first (accounts for any active resampler).
-     * Falls back to rtl_dsp_bw_khz if RTL stream is unavailable or returns 0. */
-    int demod_rate = (int)dsd_rtl_stream_metrics_hook_output_rate_hz();
+    int demod_rate = dsd_opts_current_input_timing_rate(opts);
+#ifdef USE_RADIO
+    if (opts && opts->audio_in_type == AUDIO_IN_RTL) {
+        int rtl_rate = (int)dsd_rtl_stream_metrics_hook_output_rate_hz();
+        if (rtl_rate > 0) {
+            demod_rate = rtl_rate;
+        }
+    }
+#endif
     return dsd_opts_compute_sps_rate(opts, sym_rate_hz, demod_rate);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3893,6 +3893,23 @@ target_include_directories(
 dsd_neo_link_dsp_test(dsd-neo_test_rtl_symbol_pipeline ${DSD_NEO_TEST_MATH_LIB})
 add_test(NAME RTL_SYMBOL_PIPELINE COMMAND dsd-neo_test_rtl_symbol_pipeline)
 
+add_executable(
+    dsd-neo_test_frame_sync_dmr_wav_rate
+    dsp/test_frame_sync_dmr_wav_rate.c
+)
+target_include_directories(
+    dsd-neo_test_frame_sync_dmr_wav_rate
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+dsd_neo_link_dsp_test(dsd-neo_test_frame_sync_dmr_wav_rate
+  ${DSD_NEO_TEST_MATH_LIB}
+  ${LIBSNDFILE_LIBRARIES}
+)
+add_test(
+    NAME FRAME_SYNC_DMR_WAV_RATE
+    COMMAND dsd-neo_test_frame_sync_dmr_wav_rate
+)
+
 if(DSD_HAS_RADIO)
     add_executable(
         dsd-neo_test_rtl_symbol_cache_generation

--- a/tests/dsp/test_frame_sync_dmr_wav_rate.c
+++ b/tests/dsp/test_frame_sync_dmr_wav_rate.c
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/sync_patterns.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/dmr_sync.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/platform/sockets.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "dsd-neo/core/dibit.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+static size_t g_symbol_index;
+static const char* g_sync_pattern = DMR_BS_DATA_SYNC;
+
+dsd_socket_t
+Connect(char* hostname, int portno) { // NOLINT(misc-use-internal-linkage)
+    (void)hostname;
+    (void)portno;
+    return (dsd_socket_t)0;
+}
+
+int
+openAudioInput(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    return -1;
+}
+
+void
+cleanupAndExit(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_audio_rescale_symbol_timing(dsd_state* state, int old_rate_hz, int new_rate_hz) {
+    (void)state;
+    (void)old_rate_hz;
+    (void)new_rate_hz;
+}
+
+void
+getTimeC_buf(char out[9]) { // NOLINT(misc-use-internal-linkage)
+    if (out) {
+        DSD_SNPRINTF(out, 9, "%s", "00:00:00");
+    }
+}
+
+void
+printFrameInfo(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+void
+dsd_mark_cc_sync(dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+}
+
+void
+watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+write_symbol_capture_record(dsd_opts* opts, dsd_state* state, int dibit, float symbol) {
+    (void)opts;
+    (void)state;
+    (void)dibit;
+    (void)symbol;
+}
+
+uint8_t
+dmr_compute_reliability(const dsd_state* st, float sym) {
+    (void)st;
+    (void)sym;
+    return 255;
+}
+
+double
+raw_pwr_f(const float* samples, int len, int step) { // NOLINT(misc-use-internal-linkage)
+    (void)samples;
+    (void)len;
+    (void)step;
+    return 1.0;
+}
+
+double
+pwr_to_dB(double mean_power) { // NOLINT(misc-use-internal-linkage)
+    (void)mean_power;
+    return 0.0;
+}
+
+void
+lpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+hpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+pbf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+agsm_f(dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+static float
+symbol_level_for_dibit(char dibit) {
+    return (dibit == '3') ? -3.0f : 3.0f;
+}
+
+float
+getSymbol(dsd_opts* opts, dsd_state* state, int have_sync) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)have_sync;
+
+    const size_t pattern_len = strlen(g_sync_pattern);
+    char dibit = (g_symbol_index < pattern_len) ? g_sync_pattern[g_symbol_index] : '1';
+    g_symbol_index++;
+
+    float symbol = symbol_level_for_dibit(dibit);
+    dmr_sample_history_push(state, symbol);
+    return symbol;
+}
+
+static void
+free_state_buffers(dsd_state* state) {
+    free(state->dibit_buf);
+    free(state->dmr_payload_buf);
+    free(state->dmr_reliab_buf);
+    free(state->dmr_soft_buf);
+    dmr_sample_history_free(state);
+}
+
+static int
+init_state_buffers(dsd_state* state) {
+    state->dibit_buf = (int*)calloc(1000000U, sizeof(int));
+    state->dmr_payload_buf = (int*)calloc(1000000U, sizeof(int));
+    state->dmr_reliab_buf = (uint8_t*)calloc(1000000U, sizeof(uint8_t));
+    state->dmr_soft_buf = (dsd_dibit_soft_t*)calloc(1000000U, sizeof(dsd_dibit_soft_t));
+    if (dmr_sample_history_init(state) != 0 || !state->dibit_buf || !state->dmr_payload_buf || !state->dmr_reliab_buf
+        || !state->dmr_soft_buf) {
+        free_state_buffers(state);
+        return 0;
+    }
+    state->dibit_buf_p = state->dibit_buf + 200;
+    state->dmr_payload_p = state->dmr_payload_buf + 200;
+    state->dmr_reliab_p = state->dmr_reliab_buf + 200;
+    state->dmr_soft_p = state->dmr_soft_buf + 200;
+    return 1;
+}
+
+static int
+run_dmr_wav_rate_case(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "failed to allocate frame-sync state buffers\n");
+        return 1;
+    }
+
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 96000;
+    opts.wav_decimator = 48000;
+    opts.frame_dmr = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_gfsk = 1;
+    opts.msize = 1;
+    opts.ssize = 128;
+
+    state.rf_mod = 2;
+    state.samplesPerSymbol = 20;
+    state.symbolCenter = 9;
+    state.p25_p2_active_slot = -1;
+    state.center = 0.0f;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.lmid = -2.0f;
+    state.umid = 2.0f;
+    state.minref = -2.4f;
+    state.maxref = 2.4f;
+
+    g_symbol_index = 0U;
+    g_sync_pattern = DMR_BS_DATA_SYNC;
+    dsd_frame_sync_reset_mod_state();
+
+    int sync = getFrameSync(&opts, &state);
+    int rc = 0;
+    if (sync != DSD_SYNC_DMR_BS_DATA_POS) {
+        DSD_FPRINTF(stderr, "DMR WAV sync returned %d, expected %d\n", sync, DSD_SYNC_DMR_BS_DATA_POS);
+        rc = 1;
+    }
+    if (state.samplesPerSymbol != 20 || state.symbolCenter != 9) {
+        DSD_FPRINTF(stderr, "DMR WAV timing changed to sps=%d center=%d, expected 20/9\n", state.samplesPerSymbol,
+                    state.symbolCenter);
+        rc = 1;
+    }
+
+    free_state_buffers(&state);
+    return rc;
+}
+
+int
+main(void) {
+    return run_dmr_wav_rate_case();
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -437,6 +437,49 @@ main(void) {
     assert(g_last_setfreq_hz == 853500000);
     assert(g_rtl_tune_calls == 0);
 
+    /* Non-radio P25 return-to-CC timing must follow the active PCM input rate,
+     * not the RTL bandwidth fallback. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->wav_sample_rate = 96000;
+    opts->wav_decimator = 48000;
+    opts->use_rigctl = 1;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    state->p25_cc_freq = 851000000;
+    state->trunk_cc_freq = 851000000;
+    state->p25_cc_is_tdma = 1;
+    state->samplesPerSymbol = 8;
+    state->symbolCenter = 3;
+    g_setfreq_calls = 0;
+    g_last_setfreq_hz = 0;
+    g_setfreq_result = true;
+    assert(dsd_engine_return_to_cc(opts, state) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_setfreq_calls == 1);
+    assert(g_last_setfreq_hz == 851000000);
+    assert(state->samplesPerSymbol == 16);
+    assert(state->symbolCenter == 7);
+    assert(state->rf_mod == 1);
+
+    /* P25P2 reset detection uses the same non-radio timing rate on direct
+     * voice-channel tunes. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->wav_sample_rate = 96000;
+    opts->wav_decimator = 48000;
+    opts->use_rigctl = 1;
+    opts->p25_trunk = 1;
+    g_frame_sync_reset_calls = 0;
+    g_p25p2_frame_reset_calls = 0;
+    g_setfreq_result = true;
+    assert(dsd_engine_trunk_tune_to_freq(opts, state, 853600000, 16) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_frame_sync_reset_calls == 1);
+    assert(g_p25p2_frame_reset_calls == 1);
+
 #ifdef USE_RADIO
     /* RTL audio retuned by rigctl has no native RTL controller boundary, so the
      * queued P25 VC demod profile must be applied after SetFreq succeeds. */

--- a/tests/protocol/p25/test_p25_trunk_sm_timing.c
+++ b/tests/protocol/p25/test_p25_trunk_sm_timing.c
@@ -10,6 +10,7 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -63,52 +64,96 @@ expect_eq_int(const char* tag, int got, int want) {
     return 0;
 }
 
+static void
+setup_opts(dsd_opts* opts, int input_rate_hz) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    opts->p25_trunk = 1;
+    opts->trunk_tune_group_calls = 1;
+    if (input_rate_hz > 0) {
+        opts->audio_in_type = AUDIO_IN_WAV;
+        opts->wav_sample_rate = input_rate_hz;
+        opts->wav_decimator = 48000;
+    }
+}
+
+static void
+setup_tdma_grant(dsd_state* st, int* out_channel) {
+    // TDMA IDEN: id=2, type=3 => denom=2
+    int id_t = 2;
+    st->p25_chan_iden = id_t;
+    // Populate new dual-array
+    st->p25_iden_tdma[id_t].base_freq = 851000000 / 5;
+    st->p25_iden_tdma[id_t].chan_type = 3;
+    st->p25_iden_tdma[id_t].chan_spac = 100;
+    st->p25_iden_tdma[id_t].trust = 2;
+    st->p25_iden_tdma[id_t].populated = 1;
+    st->p25_chan_tdma_explicit[id_t] = 2; // TDMA known
+
+    // Odd channel low bit -> slot 1
+    *out_channel = (id_t << 12) | 0x0001;
+}
+
+static void
+setup_fdma_grant(dsd_state* st, int* out_channel) {
+    // FDMA IDEN: id=1, type=1 => denom=1
+    int id_f = 1;
+    st->p25_chan_iden = id_f;
+    // Populate new dual-array
+    st->p25_iden_fdma[id_f].base_freq = 851000000 / 5;
+    st->p25_iden_fdma[id_f].chan_type = 1;
+    st->p25_iden_fdma[id_f].chan_spac = 100;
+    st->p25_iden_fdma[id_f].trust = 2;
+    st->p25_iden_fdma[id_f].populated = 1;
+    st->p25_chan_tdma_explicit[id_f] = 1; // FDMA known
+    *out_channel = (id_f << 12) | 0x000A;
+}
+
+static int
+run_grant_case(const char* label, int input_rate_hz, int is_tdma, int expected_sps, int expected_slot) {
+    static dsd_opts opts;
+    static dsd_state st;
+    static p25_sm_ctx_t ctx;
+    int channel = 0;
+    int rc = 0;
+
+    setup_opts(&opts, input_rate_hz);
+    dsd_state_ext_free_all(&st);
+    DSD_MEMSET(&st, 0, sizeof st);
+    DSD_MEMSET(&ctx, 0, sizeof ctx);
+    st.p25_cc_freq = 851000000;
+    st.trunk_cc_freq = 851000000;
+
+    if (is_tdma) {
+        setup_tdma_grant(&st, &channel);
+    } else {
+        setup_fdma_grant(&st, &channel);
+    }
+
+    p25_sm_init_ctx(&ctx, &opts, &st);
+    p25_sm_event_t ev = p25_sm_ev_group_grant(channel, 0, 1234, 5678, 0);
+    p25_sm_event(&ctx, &opts, &st, &ev);
+
+    rc |= expect_eq_int(label, st.samplesPerSymbol, expected_sps);
+    rc |= expect_eq_int("symbol center", st.symbolCenter, dsd_opts_symbol_center(expected_sps));
+    rc |= expect_eq_int("active slot", st.p25_p2_active_slot, expected_slot);
+    dsd_state_ext_free_all(&st);
+    return rc;
+}
+
+static int
+run_timing_case(int input_rate_hz, int expected_tdma_sps, int expected_fdma_sps) {
+    int rc = 0;
+    rc |= run_grant_case("tdma sps", input_rate_hz, 1, expected_tdma_sps, 1);
+    rc |= run_grant_case("fdma sps", input_rate_hz, 0, expected_fdma_sps, -1);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
-    static dsd_opts opts;
-    static dsd_state st;
-    DSD_MEMSET(&opts, 0, sizeof opts);
-    DSD_MEMSET(&st, 0, sizeof st);
-    opts.p25_trunk = 1;
-    opts.trunk_tune_group_calls = 1;
-    st.p25_cc_freq = 851000000;
 
-    // TDMA IDEN: id=2, type=3 => denom=2
-    int id_t = 2;
-    st.p25_chan_iden = id_t;
-    // Populate new dual-array
-    st.p25_iden_tdma[id_t].base_freq = 851000000 / 5;
-    st.p25_iden_tdma[id_t].chan_type = 3;
-    st.p25_iden_tdma[id_t].chan_spac = 100;
-    st.p25_iden_tdma[id_t].trust = 2;
-    st.p25_iden_tdma[id_t].populated = 1;
-    st.p25_chan_tdma_explicit[id_t] = 2; // TDMA known
-
-    // Odd channel low bit -> slot 1
-    int ch_tdma = (id_t << 12) | 0x0001;
-    p25_sm_on_group_grant(&opts, &st, ch_tdma, 0, 1234, 5678);
-    rc |= expect_eq_int("tdma sps", st.samplesPerSymbol, 8);
-    rc |= expect_eq_int("tdma center", st.symbolCenter, 3);
-    rc |= expect_eq_int("tdma slot", st.p25_p2_active_slot, 1);
-    p25_sm_on_release(&opts, &st);
-    opts.p25_is_tuned = 0;
-
-    // FDMA IDEN: id=1, type=1 => denom=1
-    int id_f = 1;
-    st.p25_chan_iden = id_f;
-    // Populate new dual-array
-    st.p25_iden_fdma[id_f].base_freq = 851000000 / 5;
-    st.p25_iden_fdma[id_f].chan_type = 1;
-    st.p25_iden_fdma[id_f].chan_spac = 100;
-    st.p25_iden_fdma[id_f].trust = 2;
-    st.p25_iden_fdma[id_f].populated = 1;
-    st.p25_chan_tdma_explicit[id_f] = 1; // FDMA known
-    int ch_fdma = (id_f << 12) | 0x000A;
-    p25_sm_on_group_grant(&opts, &st, ch_fdma, 0, 555, 666);
-    rc |= expect_eq_int("fdma sps", st.samplesPerSymbol, 10);
-    rc |= expect_eq_int("fdma center", st.symbolCenter, 4);
-    rc |= expect_eq_int("fdma slot unset", st.p25_p2_active_slot, -1);
+    rc |= run_timing_case(0, 8, 10);
+    rc |= run_timing_case(96000, 16, 20);
 
     return rc;
 }


### PR DESCRIPTION
## Summary

- Preserve active non-radio input timing when DMR frame sync accepts a DMR frame, so 96 kHz WAV input keeps 20 samples per symbol instead of falling back to 48 kHz timing.
- Apply the same timing rule to adjacent P25 trunk paths: grant timing, return-to-control-channel timing, P25P2 reset detection, and the no-carrier P25 CC fallback.
- Keep RTL behavior intact by using live RTL demodulator output rate only for RTL input.
- Add regressions for 96 kHz WAV DMR sync and P25 trunk timing/return paths.
- Fix the PR's ASan/UBSan CI failure by releasing test-owned `dsd_state` extension allocations in the P25 trunk timing regression.

Root cause: DMR sync acceptance recalculated symbol timing from an RTL-oriented fallback instead of the active WAV sample rate. The direct sync accept paths for other protocols did not show the same reset pattern, but P25 trunk helpers had the same 48 kHz fallback class in non-radio timing paths, so those are fixed here too.

The ASan/UBSan CI failure was a LeakSanitizer report in `P25_TRUNK_SM_TIMING`: the test drove grant handling, allocated talkgroup-policy extension state, and then reused/exited the static `dsd_state` without cleanup. The test now calls `dsd_state_ext_free_all()` around those cases.

The reported `BP59.wav` capture now decodes sustained DMR color code 05, reports voice bursts, and writes a non-empty synthesized WAV.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: decoder / protocol timing.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

Notes: this is a focused decoder/protocol timing fix. Extra guardrails run through `tools/preflight_ci.sh`, the ASan/UBSan preset, and the pre-push hook; maintainer review is still needed before marking ready.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

Notes: test-only `NOLINT(misc-use-internal-linkage)` stubs follow existing linker-stub patterns.

## Tests And Guardrails

- [x] `tools/format.sh`
- [x] `tools/cmake_format_check.sh`
- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` (398 tests passed)
- [x] `cmake --preset asan-ubsan-debug`
- [x] `cmake --build --preset asan-ubsan-debug -j`
- [x] `ctest --preset asan-ubsan-debug --output-on-failure` (398 tests passed)
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] threading and fuzz gates
- [ ] workflow, dependency, release, and packaging guardrails beyond preflight

Additional validation:

- `ctest --test-dir build/dev-debug -R 'ENGINE_NO_CARRIER_RESET|ENGINE_TRUNK_RETUNE_REGRESSION|P25_TRUNK_SM_TIMING|FRAME_SYNC_DMR_WAV_RATE' --output-on-failure`
- `ctest --test-dir build/asan-ubsan-debug -R 'ENGINE_NO_CARRIER_RESET|ENGINE_TRUNK_RETUNE_REGRESSION|P25_TRUNK_SM_TIMING|FRAME_SYNC_DMR_WAV_RATE' --output-on-failure`
- BP59 WAV capture smoke test with `-s 96000 -b 59 -o null` and decoded WAV output enabled
  - 567 `Color Code=05` lines
  - 108 voice-related lines
  - generated decoded WAV as 16-bit stereo 8 kHz PCM, 426284 bytes
- `git push --force-with-lease origin fix/dmr-wav-input-timing` passed the pre-push guardrails.

Skipped gates: `tools/quality_preflight.sh`, threading, and fuzz gates were not run because the change is narrowly scoped to timing-rate selection and does not touch threading or fuzz targets; workflow, dependency, release, and packaging guardrails beyond preflight were not applicable.

## Risk

- Security/dependency impact: No dependency, crypto, workflow, or secret-handling changes.
- CLI/UI behavior impact: No option changes. Existing 96 kHz WAV DMR input should now retain correct DMR timing after sync acceptance.
- Protocol impact: DMR WAV timing is fixed; P25 trunk auxiliary timing paths now use the active non-radio input rate. Other direct protocol frame-sync accept paths were audited and did not use the DMR-style recalculation pattern.
- Compatibility or packaging impact: No packaging changes. RTL timing still prefers live RTL demodulator output rate when available.