### PR TITLE
rtl: improve fsk replay recovery

### DIFF
--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -450,8 +450,9 @@ version = 1
   gain, PPM correction, bandwidth, squelch, monitor gain, and auto-PPM.
   Omitted values use sensible defaults. To switch the input to RTL at
   startup, set at least `rtl_freq` (and optionally `rtl_device`).
-  Digital RTL decode runs in the symbol domain: the decoder receives one
-  normalized FSK or CQPSK symbol per decision, not discriminator audio.
+  Digital RTL decode uses direct DSP output: FSK feeds centered discriminator
+  samples into the sample-domain symbolizer, while CQPSK feeds symbol-rate
+  samples.
   `rtl_volume` affects only the separate monitor/non-symbol audio path.
 
 - **RTL-TCP (`source = "rtltcp"`)**: Uses `rtltcp_host`/`rtltcp_port`
@@ -465,8 +466,8 @@ version = 1
     `-i soapy[:args]:freq[:gain[:ppm[:bw[:sql[:vol]]]]]`.
   - Reuses existing `rtl_*` tuning keys (`rtl_freq`, `rtl_gain`, `rtl_ppm`, `rtl_bw_khz`, `rtl_sql`, `rtl_volume`)
     so trunking and retune behavior remains unchanged.
-  - Digital decode uses the same normalized symbol-domain stream as RTL USB, RTL-TCP, and IQ replay.
-  - `rtl_volume` remains a monitor/non-symbol gain key; it does not scale RTL-family digital symbols.
+  - Digital decode uses the same FSK discriminator and CQPSK symbol contracts as RTL USB, RTL-TCP, and IQ replay.
+  - `rtl_volume` remains a monitor/direct-output gain key; it does not scale RTL-family digital decode samples.
   - `rtl_device` and `rtltcp_*` endpoint keys are not used in Soapy mode.
   - Set `rtl_freq` explicitly for predictable startup frequency with non-RTL radios.
   - If frequency resolves to `0`, radio startup fails with `Please specify a frequency.`

--- a/docs/dsp-benchmarking.md
+++ b/docs/dsp-benchmarking.md
@@ -61,9 +61,9 @@ The benchmark target includes:
 
 - Input/output rings and RTL u8 widening/rotation.
 - SIMD FIR kernels, half-band decimators, and generated channel LPF plans.
-- FSK modem acquisition/steady-state cases.
+- FSK discriminator reset/steady-state cases.
 - CQPSK stage cases for band-edge FLL, Gardner, differential phasor, Costas, and full demod chains.
-- Full demod cases for C4FM audio monitor, FSK symbol output, and CQPSK P25P1/P25P2.
+- Full demod cases for C4FM audio monitor, FSK discriminator output, and CQPSK P25P1/P25P2.
 
 The RTL benchmark target includes:
 
@@ -71,7 +71,7 @@ The RTL benchmark target includes:
 - The legacy two-pass rotate+widen ingest path for comparison against the combined path.
 - CS16 ingest conversion for Soapy-style signed sample input.
 - Post-demod spectrum snapshot updates used by the UI/metrics path.
-- 512-sample symbol-output batch reads.
+- 512-sample direct-output batch reads.
 
 Channel LPF CSV rows include `rate_hz`, `profile`, `tap_count`, and `variant`
 metadata so tap-count and profile changes can be compared directly.

--- a/docs/rtl-demod-pipeline-audit.md
+++ b/docs/rtl-demod-pipeline-audit.md
@@ -1,9 +1,8 @@
 # RTL Demod Pipeline Audit
 
 This note documents the RTL-family digital demod path and the contracts that keep
-clean symbols flowing into the legacy slicers. It covers RTL USB, RTL-TCP,
-SoapySDR, and IQ replay; all four sources feed the same normalized symbol-output
-contract into the legacy slicers.
+clean samples and symbols flowing into the decoder. It covers RTL USB, RTL-TCP,
+SoapySDR, and IQ replay; all four sources feed the same direct-output contracts.
 
 ## Source-To-Slicer Path
 
@@ -16,38 +15,38 @@ contract into the legacy slicers.
    start configuration, and honors retune purge/mute gates before DSP state can
    train on new samples.
 3. `full_demod()` applies baseband processing.
-   - FSK symbol output runs the channel LPF, then `dsd_fsk_modem_process()` on
-     complex I/Q, producing one normalized float per symbol.
+   - FSK direct output runs the channel LPF, then converts complex I/Q into
+     centered PCM-like discriminator samples for `getSymbol()` sample-domain
+     timing and slicing.
    - CQPSK symbol output runs the OP25-style chain:
      AGC -> band-edge FLL -> Gardner -> differential phasor -> Costas ->
      phase symbol scaling.
-4. Symbol outputs are written to the RTL output ring without monitor volume,
+4. Direct outputs are written to the RTL output ring without monitor volume,
    audio resampling, deemphasis, audio LPF, DC-block audio filtering, or legacy
    scalar matched filters.
-5. `getSymbol()` detects RTL symbol output, forces `samplesPerSymbol = 1`, and
-   applies fixed RTL symbol thresholds.
+5. `getSymbol()` detects CQPSK symbol output and uses the symbol-rate fast path.
+   FSK discriminator output stays on the sample-domain timing/filter path.
 6. `digitize()` maps floats to dibits.
    - CQPSK uses fixed OP25-compatible thresholds at `-2, 0, +2` when the CQPSK
      DSP path is active for P25.
-   - FSK/GFSK modes use the existing legacy threshold path, with RTL-provided
-     symbol levels centered around `{-3,-1,+1,+3}` or `{-1,+1}`.
+   - FSK/GFSK modes use the existing sample-domain threshold path.
 
 ## Mode Matrix
 
 | Mode | RTL output | Symbol rate | Levels | Channel LPF |
 | --- | --- | ---: | ---: | --- |
-| P25 Phase 1 C4FM | FSK symbols | 4800 | 4 | P25 C4FM |
+| P25 Phase 1 C4FM | FSK discriminator | 4800 | 4 | P25 C4FM |
 | P25 Phase 1 CQPSK | CQPSK symbols | 4800 | 4 | P25 CQPSK |
 | P25 Phase 2 CQPSK | CQPSK symbols | 6000 | 4 | P25 CQPSK |
-| DMR | FSK symbols | 4800 | 4 | 12.5 kHz |
-| NXDN48 | FSK symbols | 2400 | 4 | 6.25 kHz |
-| NXDN96 | FSK symbols | 4800 | 4 | 12.5 kHz |
-| D-STAR | FSK symbols | 4800 | 2 | 6.25 kHz |
-| X2-TDMA | FSK symbols | 6000 | 4 | 12.5 kHz |
-| YSF | FSK symbols | 4800 | 4 | 12.5 kHz |
-| dPMR | FSK symbols | 2400 | 4 | 6.25 kHz |
-| M17 | FSK symbols | 4800 | 4 | 12.5 kHz |
-| ProVoice / EDACS | FSK symbols | 9600 | 2 | ProVoice |
+| DMR | FSK discriminator | 4800 | 4 | 12.5 kHz |
+| NXDN48 | FSK discriminator | 2400 | 4 | 6.25 kHz |
+| NXDN96 | FSK discriminator | 4800 | 4 | 12.5 kHz |
+| D-STAR | FSK discriminator | 4800 | 2 | 6.25 kHz |
+| X2-TDMA | FSK discriminator | 6000 | 4 | 12.5 kHz |
+| YSF | FSK discriminator | 4800 | 4 | 12.5 kHz |
+| dPMR | FSK discriminator | 2400 | 4 | 6.25 kHz |
+| M17 | FSK discriminator | 4800 | 4 | 12.5 kHz |
+| ProVoice / EDACS | FSK discriminator | 9600 | 2 | ProVoice |
 
 ## Filter And Rate Guardrails
 
@@ -58,21 +57,18 @@ contract into the legacy slicers.
 - CQPSK timing recovery requires the correct samples-per-symbol:
   - P25 Phase 1 CQPSK: 10 SPS at 48 kHz, 5 SPS at 24 kHz.
   - P25 Phase 2 CQPSK: 8 SPS at 48 kHz, 4 SPS at 24 kHz.
-- FSK symbol output uses the FSK modem clock directly, so it can handle
-  non-integer clocks such as 9600 symbols/s at 24 kHz. That path still needs
-  capture bandwidth wide enough to avoid shaving deviation energy.
+- FSK discriminator output uses `getSymbol()` sample-domain timing. That path
+  needs capture bandwidth wide enough to avoid shaving deviation energy.
 
 ## Regression Coverage
 
 - `IO_RTL_DEMOD_CONFIG` validates the full mode matrix at 48 kHz and key 24 kHz
   cases, including output kind, symbol rate, level count, LPF profile, and CQPSK
   TED SPS.
-- `RTL_SYMBOL_PIPELINE` synthesizes FSK and CQPSK symbols through `full_demod()`
-  and checks the symbol-output contract:
-  one float per symbol, expected 4-level decisions, and no audio-only
-  post-processing on symbol streams.
-- `DSP_FSK_MODEM` covers FSK modem normalization, 2-level and 4-level output,
-  2400/4800 symbol clocks, CFO/noise tolerance, and reconfigure reset behavior.
+- `RTL_SYMBOL_PIPELINE` synthesizes FSK discriminator samples and CQPSK symbols
+  through `full_demod()` and checks the direct-output contracts.
+- `DSP_FSK_MODEM` covers discriminator count, sign, centering, scale, and reset
+  behavior.
 - `DSP_DEMOD_MISC` checks channel LPF protected-edge gain for every LPF profile.
 
 Run the focused audit checks with:

--- a/docs/soapysdr.md
+++ b/docs/soapysdr.md
@@ -66,7 +66,8 @@ In Soapy mode, you can either:
 Trailing Soapy tuning fields map to the same shared controls used by RTL/RTL-TCP (`rtl_*` keys).
 If your Soapy args string itself contains `:`, prefer config (`soapy_args` + `rtl_*`) to avoid ambiguity.
 `--print-config` normalizes this shorthand before rendering, so effective output shows `soapy_args` plus `rtl_*` fields.
-For digital decode, SoapySDR uses the same normalized symbol-domain stream as RTL USB, RTL-TCP, and IQ replay.
+For digital decode, SoapySDR uses the same FSK discriminator and CQPSK symbol contracts as RTL USB, RTL-TCP, and IQ
+replay.
 
 Minimal config (recommended):
 

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -385,6 +385,9 @@ struct dsd_state {
     int rtl_symbol_cache_levels;
     uint32_t rtl_symbol_cache_generation;
     int rtl_symbol_cache_published_pending;
+    int rtl_fsk_sps_num;
+    int rtl_fsk_sps_den;
+    int rtl_fsk_sps_accum;
 
     /* C4FM timing assist (clock loop hinting). Lightweight EL/M&M error drives
        occasional ±1 nudges of symbolCenter; disabled by default. */

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -374,9 +374,8 @@ struct dsd_state {
     unsigned int symbol_replay_soft_records;
     unsigned int symbol_capture_soft_records;
 
-    /* RTL DSP symbol-output cache. The RTL demod thread already produces
-       symbol-rate floats in blocks; this lets legacy getSymbol() consume them
-       without one ring read per dibit. */
+    /* RTL DSP direct-output cache. The RTL demod thread produces direct FSK/CQPSK
+       blocks; this lets getSymbol() consume them without one ring read per sample. */
     float rtl_symbol_cache[DSD_RTL_SYMBOL_CACHE_CAP];
     int rtl_symbol_cache_pos;
     int rtl_symbol_cache_len;

--- a/include/dsd-neo/dsp/demod_state.h
+++ b/include/dsd-neo/dsp/demod_state.h
@@ -59,7 +59,7 @@ enum DSD_ATTR_PACKED {
 
 enum DSD_ATTR_PACKED dsd_demod_output_kind {
     DSD_DEMOD_OUTPUT_AUDIO_MONITOR = 0,
-    DSD_DEMOD_OUTPUT_SYMBOL_FSK = 1,
+    DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR = 1,
     DSD_DEMOD_OUTPUT_SYMBOL_CQPSK = 2,
 };
 
@@ -192,7 +192,7 @@ struct demod_state {
      * Total CFO for metrics = fll_band_edge_state.freq + costas_state.freq/sps */
     dsd_costas_loop_state_t costas_state;          /* Symbol-rate Costas loop */
     dsd_fll_band_edge_state_t fll_band_edge_state; /* Sample-rate FLL band-edge */
-    dsd_fsk_modem_state fsk_modem_state;           /* Symbol-rate FSK modem */
+    dsd_fsk_modem_state fsk_modem_state;           /* FSK discriminator state */
 
     /* Timing error detector (Gardner) - native float */
     int ted_enabled;
@@ -223,8 +223,8 @@ struct demod_state {
     /* CQPSK (H-DQPSK) path enable for P25 LSM/TDMA */
     int cqpsk_enable;
     int output_kind;    /* dsd_demod_output_kind */
-    int symbol_rate_hz; /* output symbol rate for SYMBOL_* paths */
-    int symbol_levels;  /* 2 or 4 for SYMBOL_FSK; 4 for SYMBOL_CQPSK */
+    int symbol_rate_hz; /* FSK/CQPSK protocol symbol rate */
+    int symbol_levels;  /* 2 or 4 for FSK; 4 for SYMBOL_CQPSK */
 
     /* CQPSK pre-Costas differential phasor history (previous raw sample) */
     float cqpsk_diff_prev_r;

--- a/include/dsd-neo/dsp/fsk_modem.h
+++ b/include/dsd-neo/dsp/fsk_modem.h
@@ -83,6 +83,7 @@ typedef struct dsd_fsk_modem_state {
     float track_last_score;
     uint64_t track_updates;
     uint64_t track_skips;
+    uint64_t track_consecutive_skips;
     float track_freq[DSD_FSK_MODEM_TRACK_MAX_SAMPLES];
     int pending_pos;
     int pending_len;

--- a/include/dsd-neo/dsp/fsk_modem.h
+++ b/include/dsd-neo/dsp/fsk_modem.h
@@ -81,6 +81,7 @@ typedef struct dsd_fsk_modem_state {
     float track_start_phase;
     float track_last_error;
     float track_last_score;
+    float track_signal_ref;
     uint64_t track_updates;
     uint64_t track_skips;
     uint64_t track_consecutive_skips;

--- a/include/dsd-neo/dsp/fsk_modem.h
+++ b/include/dsd-neo/dsp/fsk_modem.h
@@ -5,17 +5,15 @@
 
 /**
  * @file
- * @brief Symbol-rate FSK modem for complex RTL-family baseband.
+ * @brief FSK discriminator helper for complex RTL-family baseband.
  *
- * The modem consumes filtered complex baseband and emits one normalized float
- * per recovered symbol. It performs FM phase-difference detection internally;
- * callers never see or route a discriminator PCM stream for digital decode.
+ * The helper consumes filtered complex baseband and emits centered PCM-like
+ * discriminator samples. The core decoder's sample-domain symbolizer performs
+ * all FSK symbol timing and slicing.
  */
 
 #ifndef DSD_NEO_INCLUDE_DSD_NEO_DSP_FSK_MODEM_H_
 #define DSD_NEO_INCLUDE_DSD_NEO_DSP_FSK_MODEM_H_
-
-#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,79 +26,21 @@ typedef struct dsd_fsk_modem_config {
     int channel_profile; /* DSD_CH_LPF_PROFILE_* value for diagnostics/config */
 } dsd_fsk_modem_config;
 
-typedef struct dsd_fsk_modem_metrics {
-    int valid;
-    int levels;
-    int symbol_rate_hz;
-    uint64_t symbols_total;
-    unsigned int window_symbols;
-    unsigned int mean_reliability;
-    unsigned int min_reliability;
-    float rms_error;
-    float evm_snr_db;
-    float low_reliability_pct;
-    float clip_pct;
-    int timing_acquired;
-    float track_last_error;
-    float track_last_score;
-    uint64_t track_updates;
-    uint64_t track_skips;
-    float abs_est;
-    float dc_est;
-    float last_symbol;
-} dsd_fsk_modem_metrics;
-
-#define DSD_FSK_MODEM_ACQ_MAX_SAMPLES        2048
-#define DSD_FSK_MODEM_TRACK_MAX_SAMPLES      2048
-#define DSD_FSK_MODEM_PENDING_INLINE_SYMBOLS 2048
-
 typedef struct dsd_fsk_modem_state {
     dsd_fsk_modem_config cfg;
     float prev_i;
     float prev_q;
     int have_prev;
-    float symbol_clock;
-    float symbol_phase;
-    float symbol_accum;
-    int symbol_count;
     float dc_est;
-    float abs_est;
-    float last_symbol;
-    uint64_t symbols_emitted;
-    int timing_acquired;
-    dsd_fsk_modem_metrics metrics;
-    float metrics_rel_sum;
-    float metrics_err2_sum;
-    float metrics_ref2_sum;
-    unsigned int metrics_low_count;
-    unsigned int metrics_clip_count;
-    unsigned int metrics_min_reliability;
-    int acq_len;
-    float acq_freq[DSD_FSK_MODEM_ACQ_MAX_SAMPLES];
-    int track_len;
-    float track_start_phase;
-    float track_last_error;
-    float track_last_score;
-    float track_signal_ref;
-    uint64_t track_updates;
-    uint64_t track_skips;
-    uint64_t track_consecutive_skips;
-    float track_freq[DSD_FSK_MODEM_TRACK_MAX_SAMPLES];
-    int pending_pos;
-    int pending_len;
-    int pending_cap;
-    float* pending_heap;
-    float pending_symbols[DSD_FSK_MODEM_PENDING_INLINE_SYMBOLS];
+    float discriminator_peak_est;
 } dsd_fsk_modem_state;
 
 void dsd_fsk_modem_init(dsd_fsk_modem_state* st, const dsd_fsk_modem_config* cfg);
 void dsd_fsk_modem_reset(dsd_fsk_modem_state* st);
 void dsd_fsk_modem_configure(dsd_fsk_modem_state* st, const dsd_fsk_modem_config* cfg);
 void dsd_fsk_modem_release(dsd_fsk_modem_state* st);
-int dsd_fsk_modem_process(dsd_fsk_modem_state* st, const float* iq_interleaved, int len_interleaved, float* out_symbols,
-                          int max_symbols);
-int dsd_fsk_modem_zero_symbols(dsd_fsk_modem_state* st, int input_complex_samples, float* out_symbols, int max_symbols);
-int dsd_fsk_modem_get_metrics(const dsd_fsk_modem_state* st, dsd_fsk_modem_metrics* out);
+int dsd_fsk_modem_discriminator_process(dsd_fsk_modem_state* st, const float* iq_interleaved, int len_interleaved,
+                                        float* out_samples, int max_samples);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/dsp/snr_estimator.h
+++ b/include/dsd-neo/dsp/snr_estimator.h
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_DSP_SNR_ESTIMATOR_H_
+#define DSD_NEO_INCLUDE_DSD_NEO_DSP_SNR_ESTIMATOR_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Estimate 4-level FSK SNR from real sample-domain discriminator output.
+ *
+ * Scans all possible sample phases for the best eye opening, clusters samples
+ * into four rails, and returns 10*log10(signal variance / noise variance) minus
+ * the supplied estimator bias. Returns -100 dB when insufficient data is
+ * available.
+ */
+double dsd_snr_estimate_c4fm_real_db(const float* samples, int sample_count, int samples_per_symbol, int phase_window,
+                                     double bias_db);
+
+/**
+ * @brief Estimate binary FSK SNR from real sample-domain discriminator output.
+ *
+ * Scans all possible sample phases for the best eye opening, splits samples
+ * into two rails by median, and returns 10*log10(signal variance / noise
+ * variance) minus the supplied estimator bias. Returns -100 dB when
+ * insufficient data is available.
+ */
+double dsd_snr_estimate_gfsk_real_db(const float* samples, int sample_count, int samples_per_symbol, int phase_window,
+                                     double bias_db);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_INCLUDE_DSD_NEO_DSP_SNR_ESTIMATOR_H_ */

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -29,7 +29,7 @@ extern "C" {
 
 typedef enum DSD_ATTR_PACKED rtl_stream_output_kind {
     RTL_STREAM_OUTPUT_AUDIO_MONITOR = 0,
-    RTL_STREAM_OUTPUT_SYMBOL_FSK = 1,
+    RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR = 1,
     RTL_STREAM_OUTPUT_SYMBOL_CQPSK = 2,
 } rtl_stream_output_kind;
 
@@ -292,11 +292,11 @@ void rtl_stream_apply_pending_retune_profile_for_target(uint32_t target_freq_hz)
 void rtl_stream_clear_pending_retune_profile(void);
 
 /**
- * @brief Request fresh acquisition for the active RTL FSK symbol modem.
+ * @brief Request fresh acquisition for the active RTL FSK demod path.
  *
  * The request is consumed by the demod thread before the next FSK block so the
  * modem state is not mutated from decoder/control threads. Returns 1 when a
- * request was queued, 0 when FSK symbol output is inactive.
+ * request was queued, 0 when RTL FSK output is inactive.
  */
 int rtl_stream_request_fsk_reacquire(void);
 
@@ -562,8 +562,9 @@ int rtl_stream_eye_get(float* out, int max_samples, int* out_sps);
 /**
  * @brief Get smoothed demod SNR estimate in dB (post-filter, center-of-symbol).
  *
- * Computed on the demod thread for digital modes using I-channel samples near
- * symbol centers and a 4-level clustering heuristic for C4FM/FSK.
+ * Computed on the demod thread for digital modes using the active demodulation
+ * domain: discriminator samples for FSK output, and symbol/constellation-domain
+ * samples for CQPSK.
  * Returns a negative value when unavailable.
  *
  * @return SNR in dB, or negative when unavailable.
@@ -706,29 +707,6 @@ typedef struct rtl_stream_costas_metrics {
     int zero_conf_pct;
 } rtl_stream_costas_metrics;
 
-typedef struct rtl_stream_fsk_metrics {
-    int valid;
-    int levels;
-    int symbol_rate_hz;
-    uint64_t symbols_total;
-    unsigned int window_symbols;
-    unsigned int mean_reliability;
-    unsigned int min_reliability;
-    float rms_error;
-    float evm_snr_db;
-    float low_reliability_pct;
-    float clip_pct;
-    int timing_acquired;
-    float track_last_error;
-    float track_last_score;
-    uint64_t track_updates;
-    uint64_t track_skips;
-    float abs_est;
-    float dc_est;
-    float last_symbol;
-    uint32_t generation;
-} rtl_stream_fsk_metrics;
-
 typedef struct rtl_stream_decode_health {
     int valid;
     uint32_t generation;
@@ -755,18 +733,6 @@ void rtl_stream_toggle_cqpsk(int onoff);
  * @return 0 on success; negative on error.
  */
 int rtl_stream_get_cqpsk_status(int* cqpsk_enable, int* cqpsk_timing_active);
-
-/**
- * @brief Get recent soft-symbol quality metrics from the RTL FSK symbol modem.
- *
- * These metrics observe the current FSK symbol stream and do not affect slicer
- * decisions. The snapshot is invalidated on retune, output clear, or squelch
- * zero-symbol generation.
- *
- * @param out [out] FSK metrics snapshot. Must not be NULL.
- * @return 0 on success; negative on invalid input.
- */
-int rtl_stream_get_fsk_metrics(rtl_stream_fsk_metrics* out);
 
 /**
  * @brief Get RTL-path decode-health counters for the current output generation.

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -407,6 +407,10 @@ int rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samp
 int rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size_t* out_used_after,
                                  int* out_cache_pending_after, uint32_t* out_generation_before,
                                  uint32_t* out_generation_after);
+int rtl_stream_test_clear_output_fsk_reset(size_t queued_samples, int* out_have_prev_after_clear,
+                                           int* out_consumed_reset, int* out_have_prev_after_consume);
+int rtl_stream_test_fsk_cfo_snapshot(double dc_rad_per_sample, int rate_out_hz, double* out_cfo_hz,
+                                     int* out_after_reset_available);
 
 /**
  * @brief Seed output/cache state, request FSK reacquire, and consume pending reset.

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -409,6 +409,21 @@ int rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size
                                  uint32_t* out_generation_after);
 int rtl_stream_test_clear_output_fsk_reset(size_t queued_samples, int* out_have_prev_after_clear,
                                            int* out_consumed_reset, int* out_have_prev_after_consume);
+
+typedef struct rtl_stream_test_cqpsk_toggle_result {
+    size_t used_after;
+    int cache_pending_after;
+    uint32_t generation_before;
+    uint32_t generation_after;
+    int output_kind_after;
+    int fsk_reset_pending_after_toggle;
+    int reset_consumed;
+    int have_prev_after_consume;
+} rtl_stream_test_cqpsk_toggle_result;
+
+int rtl_stream_test_cqpsk_toggle_output_clear(int start_cqpsk, int target_cqpsk, int active_rtl_digital,
+                                              size_t queued_samples, int cached_symbols,
+                                              rtl_stream_test_cqpsk_toggle_result* out_result);
 int rtl_stream_test_fsk_cfo_snapshot(double dc_rad_per_sample, int rate_out_hz, double* out_cfo_hz,
                                      int* out_after_generation_bump_available, int* out_after_reset_available);
 int rtl_stream_test_fsk_snr_sps(int rate_out_hz, int symbol_rate_hz, int stale_ted_sps);

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -410,7 +410,10 @@ int rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size
 int rtl_stream_test_clear_output_fsk_reset(size_t queued_samples, int* out_have_prev_after_clear,
                                            int* out_consumed_reset, int* out_have_prev_after_consume);
 int rtl_stream_test_fsk_cfo_snapshot(double dc_rad_per_sample, int rate_out_hz, double* out_cfo_hz,
-                                     int* out_after_reset_available);
+                                     int* out_after_generation_bump_available, int* out_after_reset_available);
+int rtl_stream_test_fsk_snr_sps(int rate_out_hz, int symbol_rate_hz, int stale_ted_sps);
+int rtl_stream_test_direct_output_rate_after_open_update(int output_kind, int rate_out_hz, int resamp_target_hz,
+                                                         unsigned int* out_rate_hz, int* out_resamp_enabled);
 
 /**
  * @brief Seed output/cache state, request FSK reacquire, and consume pending reset.

--- a/src/core/frames/dsd_dibit.c
+++ b/src/core/frames/dsd_dibit.c
@@ -25,7 +25,6 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/symbol.h>
-#include <dsd-neo/dsp/symbol_levels.h>
 #include <dsd-neo/platform/platform.h>
 #include <dsd-neo/platform/timing.h>
 #include <dsd-neo/runtime/config.h>
@@ -438,7 +437,7 @@ apply_cqpsk_snr_weight(int rel) {
 #endif
 
 static int DSD_ATTR_USED
-fsk_soft_metric_available(int* out_levels) {
+rtl_fsk_discriminator_metric_context(int* out_levels) {
 #ifdef USE_RADIO
     int symbol_rate_hz = 0;
     int levels = 0;
@@ -510,9 +509,9 @@ c4fm_reliability_from_thresholds(const dsd_state* st, float sym) {
 
 #ifdef USE_RADIO
 static int
-apply_c4fm_snr_weight(int rel, int rtl_fsk_soft, int rtl_fsk_levels) {
+apply_c4fm_snr_weight(int rel, int rtl_fsk_context, int rtl_fsk_levels) {
     double snr_db = -100.0;
-    if (rtl_fsk_soft && rtl_fsk_levels == 2) {
+    if (rtl_fsk_context && rtl_fsk_levels == 2) {
         snr_db = dsd_rtl_stream_metrics_hook_snr_gfsk_db();
         if (snr_db < -50.0) {
             snr_db = dsd_rtl_stream_metrics_hook_snr_c4fm_db();
@@ -566,13 +565,10 @@ dmr_compute_reliability(const dsd_state* st, float sym) {
     int rel = c4fm_reliability_from_thresholds(st, sym);
 #ifdef USE_RADIO
     int rtl_fsk_levels = 4;
-    int rtl_fsk_soft = fsk_soft_metric_available(&rtl_fsk_levels);
-    if (rtl_fsk_soft) {
-        rel = (int)dsd_fsk_symbol_reliability(sym, rtl_fsk_levels);
-    }
+    int rtl_fsk_context = rtl_fsk_discriminator_metric_context(&rtl_fsk_levels);
 #endif
 #ifdef USE_RADIO
-    rel = apply_c4fm_snr_weight(rel, rtl_fsk_soft, rtl_fsk_levels);
+    rel = apply_c4fm_snr_weight(rel, rtl_fsk_context, rtl_fsk_levels);
 #endif
     return (uint8_t)rel;
 }

--- a/src/core/frames/dsd_dibit.c
+++ b/src/core/frames/dsd_dibit.c
@@ -45,7 +45,7 @@
 #endif
 
 #ifdef USE_RADIO
-#define DSD_RTL_OUTPUT_KIND_SYMBOL_FSK 1
+#define DSD_RTL_OUTPUT_KIND_FSK_DISCRIMINATOR 1
 #endif
 
 static void DSD_ATTR_USED
@@ -444,7 +444,7 @@ fsk_soft_metric_available(int* out_levels) {
     int levels = 0;
     int channel_profile = 0;
     if (dsd_rtl_stream_metrics_hook_stream_active()
-        && dsd_rtl_stream_metrics_hook_output_kind() == DSD_RTL_OUTPUT_KIND_SYMBOL_FSK
+        && dsd_rtl_stream_metrics_hook_output_kind() == DSD_RTL_OUTPUT_KIND_FSK_DISCRIMINATOR
         && dsd_rtl_stream_metrics_hook_symbol_profile(&symbol_rate_hz, &levels, &channel_profile) == 0) {
         (void)symbol_rate_hz;
         (void)channel_profile;

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -458,6 +458,9 @@ init_state_core_buffers(dsd_state* state) {
     state->rtl_symbol_cache_levels = 0;
     state->rtl_symbol_cache_generation = 0;
     state->rtl_symbol_cache_published_pending = 0;
+    state->rtl_fsk_sps_num = 0;
+    state->rtl_fsk_sps_den = 0;
+    state->rtl_fsk_sps_accum = 0;
     // Optional RC2 crypto context (allocated on demand by key setup path)
     state->rc2_context = NULL;
 

--- a/src/dsp/CMakeLists.txt
+++ b/src/dsp/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(
     PRIVATE
         demod_pipeline.cpp
         snr_bias.cpp
+        snr_estimator.cpp
         costas.cpp
         resampler.cpp
         halfband.cpp

--- a/src/dsp/demod_pipeline.cpp
+++ b/src/dsp/demod_pipeline.cpp
@@ -1148,9 +1148,9 @@ full_demod_run_non_cqpsk_chain(struct demod_state* d) {
     if (d->cqpsk_enable || d->channel_squelched) {
         return;
     }
-    int fsk_symbol_output = (d->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK);
+    int fsk_direct_output = (d->output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR);
     iq_dc_block(d);
-    if (fsk_symbol_output) {
+    if (fsk_direct_output) {
         return;
     }
 }
@@ -1199,15 +1199,19 @@ full_demod_apply_iq_balance(struct demod_state* d) {
 
 static int
 full_demod_handle_fsk_output(struct demod_state* d) {
-    if (d->output_kind != DSD_DEMOD_OUTPUT_SYMBOL_FSK) {
+    if (d->output_kind != DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
         return 0;
     }
     int in_pairs = d->lp_len >> 1;
     if (d->channel_squelched) {
-        d->result_len = dsd_fsk_modem_zero_symbols(&d->fsk_modem_state, in_pairs, d->result, MAXIMUM_BUF_LENGTH);
+        dsd_fsk_modem_reset(&d->fsk_modem_state);
+        d->result_len = in_pairs < MAXIMUM_BUF_LENGTH ? in_pairs : MAXIMUM_BUF_LENGTH;
+        for (int i = 0; i < d->result_len; i++) {
+            d->result[i] = 0.0f;
+        }
     } else {
-        d->result_len =
-            dsd_fsk_modem_process(&d->fsk_modem_state, d->lowpassed, d->lp_len, d->result, MAXIMUM_BUF_LENGTH);
+        d->result_len = dsd_fsk_modem_discriminator_process(&d->fsk_modem_state, d->lowpassed, d->lp_len, d->result,
+                                                            MAXIMUM_BUF_LENGTH);
     }
     return 1;
 }

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -1120,18 +1120,73 @@ symbol_refresh_rtl_profile(dsd_state* state, symbol_work_ctx* work) {
     return work->rtl_direct_output;
 }
 
+static inline int
+symbol_rtl_fsk_output_rate_hz(const dsd_opts* opts) {
+    unsigned int output_rate = dsd_rtl_stream_metrics_hook_output_rate_hz();
+    int output_rate_hz = output_rate > 0U ? (int)output_rate : dsd_opts_current_input_timing_rate(opts);
+    return output_rate_hz > 0 ? output_rate_hz : 48000;
+}
+
+static inline int
+symbol_rtl_fsk_symbol_rate_hz(const symbol_work_ctx* work) {
+    return work->rtl_symbol_rate_hz > 0 ? work->rtl_symbol_rate_hz : 4800;
+}
+
+static inline void
+symbol_reset_rtl_fsk_timing_if_needed(dsd_state* state, int output_rate_hz, int symbol_rate_hz,
+                                      const symbol_work_ctx* work) {
+    if (state->rtl_fsk_sps_num == output_rate_hz && state->rtl_fsk_sps_den == symbol_rate_hz
+        && !work->rtl_profile_changed) {
+        return;
+    }
+    state->rtl_fsk_sps_num = output_rate_hz;
+    state->rtl_fsk_sps_den = symbol_rate_hz;
+    state->rtl_fsk_sps_accum = 0;
+}
+
+static inline int
+symbol_rtl_fsk_whole_sps(int output_rate_hz, int symbol_rate_hz, int* rem_out) {
+    int whole = output_rate_hz / symbol_rate_hz;
+    int rem = output_rate_hz % symbol_rate_hz;
+    if (whole < 2) {
+        whole = 2;
+        rem = 0;
+    }
+    if (whole > 64) {
+        whole = 64;
+        rem = 0;
+    }
+    *rem_out = rem;
+    return whole;
+}
+
+static inline int
+symbol_rtl_fsk_next_sps(dsd_state* state, int output_rate_hz, int symbol_rate_hz) {
+    int rem = 0;
+    int sps = symbol_rtl_fsk_whole_sps(output_rate_hz, symbol_rate_hz, &rem);
+    if (rem <= 0 || state->rtl_fsk_sps_den <= 0) {
+        return sps;
+    }
+
+    int accum = state->rtl_fsk_sps_accum + rem;
+    if (accum >= state->rtl_fsk_sps_den) {
+        sps++;
+        accum -= state->rtl_fsk_sps_den;
+    }
+    state->rtl_fsk_sps_accum = accum;
+    return sps > 64 ? 64 : sps;
+}
+
 static inline void
 symbol_apply_rtl_fsk_discriminator_timing(const dsd_opts* opts, dsd_state* state, const symbol_work_ctx* work) {
     if (!opts || !state || !work) {
         return;
     }
-    unsigned int output_rate = dsd_rtl_stream_metrics_hook_output_rate_hz();
-    int output_rate_hz = output_rate > 0U ? (int)output_rate : dsd_opts_current_input_timing_rate(opts);
-    int symbol_rate_hz = work->rtl_symbol_rate_hz > 0 ? work->rtl_symbol_rate_hz : 4800;
-    if (output_rate_hz <= 0) {
-        output_rate_hz = 48000;
-    }
-    state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, symbol_rate_hz, output_rate_hz);
+    int output_rate_hz = symbol_rtl_fsk_output_rate_hz(opts);
+    int symbol_rate_hz = symbol_rtl_fsk_symbol_rate_hz(work);
+    symbol_reset_rtl_fsk_timing_if_needed(state, output_rate_hz, symbol_rate_hz, work);
+
+    state->samplesPerSymbol = symbol_rtl_fsk_next_sps(state, output_rate_hz, symbol_rate_hz);
     state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
     state->jitter = -1;
 }
@@ -1151,7 +1206,6 @@ symbol_read_cached_rtl_sample(dsd_opts* opts, dsd_state* state, float* sample_ou
         }
         symbol_refresh_rtl_profile(state, work);
         if (!work->rtl_fsk_discriminator_output) {
-            cleanupAndExit(opts, state);
             return 0;
         }
         if (work->rtl_profile_changed || state->samplesPerSymbol <= 1) {
@@ -1379,9 +1433,7 @@ symbol_try_rtl_symbol_rate_fast_path(dsd_opts* opts, dsd_state* state, symbol_wo
 
 static inline void
 symbol_prepare_rtl_fsk_discriminator_span(const dsd_opts* opts, dsd_state* state, const symbol_work_ctx* work) {
-    if (work->rtl_profile_changed || state->samplesPerSymbol <= 1) {
-        symbol_apply_rtl_fsk_discriminator_timing(opts, state, work);
-    }
+    symbol_apply_rtl_fsk_discriminator_timing(opts, state, work);
 }
 
 static inline void

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -455,6 +455,9 @@ symbol_adjust_timing_index(dsd_state* state, int have_sync, int symbol_span, int
     if (symbol_span <= 1 || *i != 0 || have_sync != 0) {
         return;
     }
+    if (state->jitter < 0) {
+        return;
+    }
     if (state->samplesPerSymbol == 20) {
         symbol_adjust_timing_nxdn(state, i);
     } else if (state->rf_mod == 1) {
@@ -1132,6 +1135,28 @@ symbol_rtl_fsk_symbol_rate_hz(const symbol_work_ctx* work) {
     return work->rtl_symbol_rate_hz > 0 ? work->rtl_symbol_rate_hz : 4800;
 }
 
+static inline void
+symbol_reset_rtl_fsk_discriminator_slicer(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+
+    state->center = 0.0f;
+    state->min = -30000.0f;
+    state->max = 30000.0f;
+    state->lmid = -20000.0f;
+    state->umid = 20000.0f;
+    state->minref = -24000.0f;
+    state->maxref = 24000.0f;
+    int minmax_cap = (int)(sizeof(state->minbuf) / sizeof(state->minbuf[0]));
+    for (int i = 0; i < minmax_cap; i++) {
+        state->minbuf[i] = state->min;
+        state->maxbuf[i] = state->max;
+    }
+    state->midx = 0;
+    dsd_state_invalidate_minmax_sums(state);
+}
+
 static inline int
 symbol_reset_rtl_fsk_timing_if_needed(dsd_state* state, int output_rate_hz, int symbol_rate_hz,
                                       const symbol_work_ctx* work) {
@@ -1143,6 +1168,7 @@ symbol_reset_rtl_fsk_timing_if_needed(dsd_state* state, int output_rate_hz, int 
     state->rtl_fsk_sps_den = symbol_rate_hz;
     state->rtl_fsk_sps_accum = 0;
     state->jitter = -1;
+    symbol_reset_rtl_fsk_discriminator_slicer(state);
     return 1;
 }
 

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -1132,16 +1132,18 @@ symbol_rtl_fsk_symbol_rate_hz(const symbol_work_ctx* work) {
     return work->rtl_symbol_rate_hz > 0 ? work->rtl_symbol_rate_hz : 4800;
 }
 
-static inline void
+static inline int
 symbol_reset_rtl_fsk_timing_if_needed(dsd_state* state, int output_rate_hz, int symbol_rate_hz,
                                       const symbol_work_ctx* work) {
     if (state->rtl_fsk_sps_num == output_rate_hz && state->rtl_fsk_sps_den == symbol_rate_hz
         && !work->rtl_profile_changed) {
-        return;
+        return 0;
     }
     state->rtl_fsk_sps_num = output_rate_hz;
     state->rtl_fsk_sps_den = symbol_rate_hz;
     state->rtl_fsk_sps_accum = 0;
+    state->jitter = -1;
+    return 1;
 }
 
 static inline int
@@ -1184,11 +1186,10 @@ symbol_apply_rtl_fsk_discriminator_timing(const dsd_opts* opts, dsd_state* state
     }
     int output_rate_hz = symbol_rtl_fsk_output_rate_hz(opts);
     int symbol_rate_hz = symbol_rtl_fsk_symbol_rate_hz(work);
-    symbol_reset_rtl_fsk_timing_if_needed(state, output_rate_hz, symbol_rate_hz, work);
+    (void)symbol_reset_rtl_fsk_timing_if_needed(state, output_rate_hz, symbol_rate_hz, work);
 
     state->samplesPerSymbol = symbol_rtl_fsk_next_sps(state, output_rate_hz, symbol_rate_hz);
     state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
-    state->jitter = -1;
 }
 
 static inline int

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -211,7 +211,10 @@ typedef struct {
     unsigned int analog_out_cap;
 #ifdef USE_RADIO
     int rtl_output_kind;
+    int rtl_direct_output;
     int rtl_symbol_rate_output;
+    int rtl_fsk_discriminator_output;
+    int rtl_profile_changed;
     int rtl_channel_profile;
     int rtl_symbol_rate_hz;
     int rtl_symbol_levels;
@@ -578,7 +581,7 @@ maybe_adjust_sps_for_output_rate(const dsd_opts* opts, dsd_state* state) {
 
 #ifdef USE_RADIO
 enum {
-    RTL_STREAM_OUTPUT_SYMBOL_FSK_LOCAL = 1,
+    RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR_LOCAL = 1,
     RTL_STREAM_OUTPUT_SYMBOL_CQPSK_LOCAL = 2,
 };
 
@@ -589,8 +592,19 @@ enum {
 };
 
 static inline int
-rtl_symbol_output_active(int output_kind) {
-    return output_kind == RTL_STREAM_OUTPUT_SYMBOL_FSK_LOCAL || output_kind == RTL_STREAM_OUTPUT_SYMBOL_CQPSK_LOCAL;
+rtl_direct_output_active(int output_kind) {
+    return output_kind == RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR_LOCAL
+           || output_kind == RTL_STREAM_OUTPUT_SYMBOL_CQPSK_LOCAL;
+}
+
+static inline int
+rtl_symbol_rate_output_active(int output_kind) {
+    return output_kind == RTL_STREAM_OUTPUT_SYMBOL_CQPSK_LOCAL;
+}
+
+static inline int
+rtl_fsk_discriminator_output_active(int output_kind) {
+    return output_kind == RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR_LOCAL;
 }
 
 static inline int
@@ -603,7 +617,7 @@ rtl_symbol_current_profile(int* output_kind, int* channel_profile, int* symbol_r
     if (generation) {
         *generation = dsd_rtl_stream_metrics_hook_stream_generation();
     }
-    if (!rtl_symbol_output_active(current_output_kind)) {
+    if (!rtl_direct_output_active(current_output_kind)) {
         if (channel_profile) {
             *channel_profile = 0;
         }
@@ -704,11 +718,11 @@ rtl_symbol_cache_pop(dsd_state* state, uint32_t generation, float* sample_out) {
     return RTL_SYMBOL_CACHE_READY;
 }
 
-static inline void
+static inline int
 rtl_symbol_cache_profile(dsd_state* state, int output_kind, int channel_profile, int symbol_rate_hz, int levels,
                          uint32_t generation) {
     if (!state) {
-        return;
+        return 0;
     }
     if (state->rtl_symbol_cache_output_kind != output_kind || state->rtl_symbol_cache_channel_profile != channel_profile
         || state->rtl_symbol_cache_symbol_rate_hz != symbol_rate_hz || state->rtl_symbol_cache_levels != levels
@@ -719,7 +733,9 @@ rtl_symbol_cache_profile(dsd_state* state, int output_kind, int channel_profile,
         state->rtl_symbol_cache_symbol_rate_hz = symbol_rate_hz;
         state->rtl_symbol_cache_levels = levels;
         state->rtl_symbol_cache_generation = generation;
+        return 1;
     }
+    return 0;
 }
 
 static inline void
@@ -1083,10 +1099,79 @@ symbol_maybe_publish_rtl_input_level(dsd_opts* opts, dsd_state* state) {
 }
 
 static inline int
-symbol_read_sample_rtl(dsd_opts* opts, dsd_state* state, float* sample_out, const symbol_work_ctx* work) {
+symbol_refresh_rtl_profile(dsd_state* state, symbol_work_ctx* work) {
+    if (!work) {
+        return 0;
+    }
+    work->rtl_direct_output =
+        rtl_symbol_current_profile(&work->rtl_output_kind, &work->rtl_channel_profile, &work->rtl_symbol_rate_hz,
+                                   &work->rtl_symbol_levels, &work->rtl_stream_generation);
+    work->rtl_symbol_rate_output =
+        (work->rtl_direct_output && rtl_symbol_rate_output_active(work->rtl_output_kind)) ? 1 : 0;
+    work->rtl_fsk_discriminator_output =
+        (work->rtl_direct_output && rtl_fsk_discriminator_output_active(work->rtl_output_kind)) ? 1 : 0;
+    if (work->rtl_direct_output) {
+        work->rtl_profile_changed |=
+            rtl_symbol_cache_profile(state, work->rtl_output_kind, work->rtl_channel_profile, work->rtl_symbol_rate_hz,
+                                     work->rtl_symbol_levels, work->rtl_stream_generation);
+    } else {
+        rtl_symbol_cache_clear(state);
+    }
+    return work->rtl_direct_output;
+}
+
+static inline void
+symbol_apply_rtl_fsk_discriminator_timing(const dsd_opts* opts, dsd_state* state, const symbol_work_ctx* work) {
+    if (!opts || !state || !work) {
+        return;
+    }
+    unsigned int output_rate = dsd_rtl_stream_metrics_hook_output_rate_hz();
+    int output_rate_hz = output_rate > 0U ? (int)output_rate : dsd_opts_current_input_timing_rate(opts);
+    int symbol_rate_hz = work->rtl_symbol_rate_hz > 0 ? work->rtl_symbol_rate_hz : 4800;
+    if (output_rate_hz <= 0) {
+        output_rate_hz = 48000;
+    }
+    state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, symbol_rate_hz, output_rate_hz);
+    state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
+    state->jitter = -1;
+}
+
+static inline int
+symbol_read_cached_rtl_sample(dsd_opts* opts, dsd_state* state, float* sample_out, symbol_work_ctx* work) {
+    for (;;) {
+        int cache_status =
+            rtl_symbol_cache_take(state, work->rtl_output_kind, work->rtl_channel_profile, work->rtl_symbol_rate_hz,
+                                  work->rtl_symbol_levels, &work->rtl_stream_generation, sample_out);
+        if (cache_status == RTL_SYMBOL_CACHE_READY) {
+            return 1;
+        }
+        if (cache_status != RTL_SYMBOL_CACHE_RETRY) {
+            cleanupAndExit(opts, state);
+            return 0;
+        }
+        symbol_refresh_rtl_profile(state, work);
+        if (!work->rtl_fsk_discriminator_output) {
+            cleanupAndExit(opts, state);
+            return 0;
+        }
+        if (work->rtl_profile_changed || state->samplesPerSymbol <= 1) {
+            symbol_apply_rtl_fsk_discriminator_timing(opts, state, work);
+        }
+    }
+}
+
+static inline int
+symbol_read_sample_rtl(dsd_opts* opts, dsd_state* state, float* sample_out, symbol_work_ctx* work) {
     if (!state->rtl_ctx) {
         cleanupAndExit(opts, state);
         return 0;
+    }
+    if (work->rtl_fsk_discriminator_output) {
+        if (!symbol_read_cached_rtl_sample(opts, state, sample_out, work)) {
+            return 0;
+        }
+        opts->rtl_pwr = dsd_rtl_stream_io_hook_return_pwr(state);
+        return 1;
     }
     int got = 0;
     if (dsd_rtl_stream_io_hook_read(state, sample_out, 1, &got) < 0 || got != 1) {
@@ -1094,7 +1179,7 @@ symbol_read_sample_rtl(dsd_opts* opts, dsd_state* state, float* sample_out, cons
         return 0;
     }
     opts->rtl_pwr = dsd_rtl_stream_io_hook_return_pwr(state);
-    if (!work->rtl_symbol_rate_output && !work->cqpsk_symbol_rate) {
+    if (!work->rtl_symbol_rate_output && !work->cqpsk_symbol_rate && !work->rtl_fsk_discriminator_output) {
         *sample_out *= opts->rtl_volume_multiplier;
     }
     return 1;
@@ -1242,16 +1327,9 @@ symbol_take_sample(dsd_opts* opts, dsd_state* state, symbol_work_ctx* work) {
 #ifdef USE_RADIO
 static inline void
 symbol_init_rtl_profile(const dsd_opts* opts, dsd_state* state, symbol_work_ctx* work) {
+    (void)opts;
     if (opts->audio_in_type == AUDIO_IN_RTL) {
-        work->rtl_symbol_rate_output =
-            rtl_symbol_current_profile(&work->rtl_output_kind, &work->rtl_channel_profile, &work->rtl_symbol_rate_hz,
-                                       &work->rtl_symbol_levels, &work->rtl_stream_generation);
-    }
-    if (work->rtl_symbol_rate_output) {
-        rtl_symbol_cache_profile(state, work->rtl_output_kind, work->rtl_channel_profile, work->rtl_symbol_rate_hz,
-                                 work->rtl_symbol_levels, work->rtl_stream_generation);
-    } else {
-        rtl_symbol_cache_clear(state);
+        (void)symbol_refresh_rtl_profile(state, work);
     }
 }
 
@@ -1282,15 +1360,10 @@ symbol_try_rtl_symbol_rate_fast_path(dsd_opts* opts, dsd_state* state, symbol_wo
             return -1;
         }
 
-        work->rtl_symbol_rate_output =
-            rtl_symbol_current_profile(&work->rtl_output_kind, &work->rtl_channel_profile, &work->rtl_symbol_rate_hz,
-                                       &work->rtl_symbol_levels, &work->rtl_stream_generation);
+        (void)symbol_refresh_rtl_profile(state, work);
         if (!work->rtl_symbol_rate_output) {
-            rtl_symbol_cache_clear(state);
             break;
         }
-        rtl_symbol_cache_profile(state, work->rtl_output_kind, work->rtl_channel_profile, work->rtl_symbol_rate_hz,
-                                 work->rtl_symbol_levels, work->rtl_stream_generation);
     }
 
     if (!work->rtl_symbol_rate_output) {
@@ -1305,8 +1378,17 @@ symbol_try_rtl_symbol_rate_fast_path(dsd_opts* opts, dsd_state* state, symbol_wo
 }
 
 static inline void
+symbol_prepare_rtl_fsk_discriminator_span(const dsd_opts* opts, dsd_state* state, const symbol_work_ctx* work) {
+    if (work->rtl_profile_changed || state->samplesPerSymbol <= 1) {
+        symbol_apply_rtl_fsk_discriminator_timing(opts, state, work);
+    }
+}
+
+static inline void
 symbol_prepare_span(const dsd_opts* opts, dsd_state* state, symbol_work_ctx* work, int have_sync) {
-    if (!work->rtl_symbol_rate_output) {
+    if (work->rtl_fsk_discriminator_output) {
+        symbol_prepare_rtl_fsk_discriminator_span(opts, state, work);
+    } else if (!work->rtl_symbol_rate_output) {
         maybe_auto_center(opts, state, have_sync);
         maybe_adjust_sps_for_output_rate(opts, state);
     } else {
@@ -1333,7 +1415,7 @@ symbol_prepare_span(const dsd_opts* opts, dsd_state* state, symbol_work_ctx* wor
     if (work->rtl_symbol_rate_output) {
         work->symbol_span = 1;
     }
-    if (!work->rtl_symbol_rate_output && opts->audio_in_type == AUDIO_IN_RTL && state->rf_mod == 1) {
+    if (!work->rtl_direct_output && opts->audio_in_type == AUDIO_IN_RTL && state->rf_mod == 1) {
         int dsp_cqpsk = 0;
         int dsp_timing = 0;
         dsd_rtl_stream_metrics_hook_cqpsk_status(&dsp_cqpsk, &dsp_timing);

--- a/src/dsp/fsk_modem.c
+++ b/src/dsp/fsk_modem.c
@@ -11,13 +11,17 @@
 #include <string.h>
 #include "dsd-neo/core/safe_api.h"
 
-#define DSD_FSK_TRACK_SYMBOLS        64
-#define DSD_FSK_TRACK_MIN_SCORE      1.0e-4f
-#define DSD_FSK_TRACK_MIN_RATIO      1.10f
-#define DSD_FSK_TRACK_GAIN           0.125f
-#define DSD_FSK_TRACK_MAX_CORRECTION 0.25f
-#define DSD_FSK_METRICS_WINDOW       256U
-#define DSD_FSK_LOW_RELIABILITY      128U
+#define DSD_FSK_TRACK_SYMBOLS             64
+#define DSD_FSK_TRACK_MIN_SCORE           1.0e-4f
+#define DSD_FSK_TRACK_MIN_RATIO           1.10f
+#define DSD_FSK_TRACK_SOFT_MIN_RATIO      1.02f
+#define DSD_FSK_TRACK_SOFT_MIN_CONFIDENCE 0.25f
+#define DSD_FSK_TRACK_GAIN                0.125f
+#define DSD_FSK_TRACK_MAX_CORRECTION      0.25f
+#define DSD_FSK_TRACK_SOFT_MAX_CORRECTION 0.125f
+#define DSD_FSK_TRACK_REACQUIRE_SKIPS     32ULL
+#define DSD_FSK_METRICS_WINDOW            256U
+#define DSD_FSK_LOW_RELIABILITY           128U
 
 static int
 clamp_levels(int levels) {
@@ -440,11 +444,6 @@ acquire_symbol_phase_scored(const float* freq, int n, int clock_i, float* out_sc
 }
 
 static int
-acquire_symbol_phase(const float* freq, int n, int clock_i, float* out_score) {
-    return acquire_symbol_phase_scored(freq, n, clock_i, out_score, NULL);
-}
-
-static int
 tracking_target_samples(int clock_i) {
     int target = clock_i * DSD_FSK_TRACK_SYMBOLS;
     if (target > DSD_FSK_MODEM_TRACK_MAX_SAMPLES) {
@@ -480,6 +479,7 @@ typedef struct {
     float best_score;
     float ratio;
     float err;
+    float confidence;
     int accept;
 } dsd_fsk_track_eval;
 
@@ -502,6 +502,19 @@ track_score_ratio(float best_score, float second_score) {
         return best_score / second_score;
     }
     return (best_score > 0.0f) ? 1000.0f : 0.0f;
+}
+
+static float
+track_correction_confidence(float ratio) {
+    if (ratio >= DSD_FSK_TRACK_MIN_RATIO) {
+        return 1.0f;
+    }
+    if (ratio <= DSD_FSK_TRACK_SOFT_MIN_RATIO) {
+        return DSD_FSK_TRACK_SOFT_MIN_CONFIDENCE;
+    }
+    float span = DSD_FSK_TRACK_MIN_RATIO - DSD_FSK_TRACK_SOFT_MIN_RATIO;
+    float scaled = (ratio - DSD_FSK_TRACK_SOFT_MIN_RATIO) / span;
+    return DSD_FSK_TRACK_SOFT_MIN_CONFIDENCE + scaled * (1.0f - DSD_FSK_TRACK_SOFT_MIN_CONFIDENCE);
 }
 
 static int
@@ -537,18 +550,21 @@ track_compute_eval(const dsd_fsk_modem_state* st, int clock_i) {
     eval.expected_phase = (clock_i - start_phase) % clock_i;
     eval.ratio = track_score_ratio(eval.best_score, second_score);
     eval.err = wrap_timing_error((float)(eval.best_phase - eval.expected_phase), clock_i);
-    eval.accept = (eval.best_score >= DSD_FSK_TRACK_MIN_SCORE && eval.ratio >= DSD_FSK_TRACK_MIN_RATIO
+    eval.confidence = track_correction_confidence(eval.ratio);
+    eval.accept = (eval.best_score >= DSD_FSK_TRACK_MIN_SCORE && eval.ratio >= DSD_FSK_TRACK_SOFT_MIN_RATIO
                    && fabsf(eval.err) <= 2.0f);
     return eval;
 }
 
 static float
-track_gain_correction(float err) {
-    float correction = err * DSD_FSK_TRACK_GAIN;
-    if (correction > DSD_FSK_TRACK_MAX_CORRECTION) {
-        correction = DSD_FSK_TRACK_MAX_CORRECTION;
-    } else if (correction < -DSD_FSK_TRACK_MAX_CORRECTION) {
-        correction = -DSD_FSK_TRACK_MAX_CORRECTION;
+track_gain_correction(float err, float confidence, float ratio) {
+    float correction = err * DSD_FSK_TRACK_GAIN * confidence;
+    float max_correction =
+        (ratio >= DSD_FSK_TRACK_MIN_RATIO) ? DSD_FSK_TRACK_MAX_CORRECTION : DSD_FSK_TRACK_SOFT_MAX_CORRECTION;
+    if (correction > max_correction) {
+        correction = max_correction;
+    } else if (correction < -max_correction) {
+        correction = -max_correction;
     }
     return correction;
 }
@@ -575,9 +591,10 @@ static void
 track_log_accept(const dsd_fsk_modem_state* st, int clock_i, const dsd_fsk_track_eval* eval, float correction) {
     if (debug_fsk_acq_enabled()) {
         DSD_FPRINTF(stderr,
-                    "[FSKTRACK] clock=%d best=%d expect=%d err=%.3f corr=%.3f score=%.5f ratio=%.3f updates=%llu\n",
+                    "[FSKTRACK] clock=%d best=%d expect=%d err=%.3f corr=%.3f score=%.5f ratio=%.3f conf=%.3f "
+                    "updates=%llu\n",
                     clock_i, eval->best_phase, eval->expected_phase, eval->err, correction, eval->best_score,
-                    eval->ratio, (unsigned long long)st->track_updates);
+                    eval->ratio, eval->confidence, (unsigned long long)st->track_updates);
     }
 }
 
@@ -587,6 +604,36 @@ track_log_skip(const dsd_fsk_modem_state* st, int clock_i, const dsd_fsk_track_e
         DSD_FPRINTF(stderr, "[FSKTRACK] skip clock=%d best=%d expect=%d score=%.5f ratio=%.3f skips=%llu\n", clock_i,
                     eval->best_phase, eval->expected_phase, eval->best_score, eval->ratio,
                     (unsigned long long)st->track_skips);
+    }
+}
+
+static void
+track_log_reacquire(const dsd_fsk_modem_state* st, int clock_i, const dsd_fsk_track_eval* eval) {
+    if (debug_fsk_acq_enabled()) {
+        DSD_FPRINTF(stderr, "[FSKREACQ] clock=%d best=%d expect=%d err=%.3f score=%.5f ratio=%.3f skips=%llu\n",
+                    clock_i, eval->best_phase, eval->expected_phase, eval->err, eval->best_score, eval->ratio,
+                    (unsigned long long)st->track_skips);
+    }
+}
+
+static void
+reset_symbol_timing_for_reacquisition(dsd_fsk_modem_state* st, float* phase_io) {
+    if (!st) {
+        return;
+    }
+    st->symbol_phase = 0.0f;
+    st->symbol_accum = 0.0f;
+    st->symbol_count = 0;
+    st->acq_len = 0;
+    st->track_consecutive_skips = 0;
+    st->track_last_error = 0.0f;
+    st->track_last_score = 0.0f;
+    clear_pending_symbols(st);
+    clear_tracking_window(st);
+    st->timing_acquired = modem_should_acquire_timing(&st->cfg, st->symbol_clock) ? 0 : 1;
+    reset_soft_metrics(st);
+    if (phase_io) {
+        *phase_io = st->symbol_phase;
     }
 }
 
@@ -627,36 +674,53 @@ track_boundary_phase_scored(const float* freq, int n, int clock_i, float* out_sc
     return best_phase;
 }
 
-static void
+static int
 maybe_track_symbol_timing(dsd_fsk_modem_state* st, float centered, int clock_i, float sample_phase, float* phase_io) {
     if (!track_timing_ready(st, phase_io, clock_i)) {
-        return;
+        return 0;
     }
     if (!track_push_sample(st, centered, sample_phase, tracking_target_samples(clock_i))) {
-        return;
+        return 0;
     }
 
     dsd_fsk_track_eval eval = track_compute_eval(st, clock_i);
     if (eval.accept) {
-        float correction = track_gain_correction(eval.err);
+        float correction = track_gain_correction(eval.err, eval.confidence, eval.ratio);
         correction = track_apply_correction(st, phase_io, correction);
         st->track_last_error = eval.err;
         st->track_last_score = eval.best_score;
         st->track_updates++;
+        st->track_consecutive_skips = 0;
         track_log_accept(st, clock_i, &eval, correction);
     } else {
         st->track_last_error = 0.0f;
         st->track_last_score = eval.best_score;
         st->track_skips++;
+        st->track_consecutive_skips++;
         track_log_skip(st, clock_i, &eval);
+        if (st->track_consecutive_skips >= DSD_FSK_TRACK_REACQUIRE_SKIPS) {
+            track_log_reacquire(st, clock_i, &eval);
+            reset_symbol_timing_for_reacquisition(st, phase_io);
+            return 1;
+        }
     }
     clear_tracking_window(st);
+    return 0;
 }
 
 static int
 emit_acquisition_symbols(dsd_fsk_modem_state* st, int clock_i, float* out_symbols, int out_count, int max_symbols) {
     float score = 0.0f;
-    int phase = acquire_symbol_phase(st->acq_freq, st->acq_len, clock_i, &score);
+    float second_score = 0.0f;
+    int phase = acquire_symbol_phase_scored(st->acq_freq, st->acq_len, clock_i, &score, &second_score);
+    float ratio = track_score_ratio(score, second_score);
+    if (score < DSD_FSK_TRACK_MIN_SCORE && st->acq_len < DSD_FSK_MODEM_ACQ_MAX_SAMPLES) {
+        if (debug_fsk_acq_enabled()) {
+            DSD_FPRINTF(stderr, "[FSKACQ] wait clock=%d phase=%d score=%.5f ratio=%.3f samples=%d\n", clock_i, phase,
+                        score, ratio, st->acq_len);
+        }
+        return out_count;
+    }
     if (phase < 0) {
         phase = 0;
     } else if (phase >= clock_i) {
@@ -693,8 +757,8 @@ emit_acquisition_symbols(dsd_fsk_modem_state* st, int clock_i, float* out_symbol
     clear_tracking_window(st);
 
     if (debug_fsk_acq_enabled()) {
-        DSD_FPRINTF(stderr, "[FSKACQ] clock=%d phase=%d score=%.5f lead=%d carry=%d emitted=%llu\n", clock_i, phase,
-                    score, emitted_leading, st->symbol_count, (unsigned long long)st->symbols_emitted);
+        DSD_FPRINTF(stderr, "[FSKACQ] clock=%d phase=%d score=%.5f ratio=%.3f lead=%d carry=%d emitted=%llu\n", clock_i,
+                    phase, score, ratio, emitted_leading, st->symbol_count, (unsigned long long)st->symbols_emitted);
     }
     return out_count;
 }
@@ -791,9 +855,11 @@ process_acquisition_window(dsd_fsk_modem_state* st, dsd_fsk_process_ctx* ctx, fl
     }
     if (st->acq_len >= ctx->acq_target) {
         *out_count = emit_acquisition_symbols(st, ctx->clock_i, out_symbols, *out_count, max_symbols);
-        ctx->phase = st->symbol_phase;
-        ctx->accum = st->symbol_accum;
-        ctx->accum_count = st->symbol_count;
+        if (st->timing_acquired) {
+            ctx->phase = st->symbol_phase;
+            ctx->accum = st->symbol_accum;
+            ctx->accum_count = st->symbol_count;
+        }
     }
     return 1;
 }
@@ -822,7 +888,11 @@ process_tracking_window(dsd_fsk_modem_state* st, dsd_fsk_process_ctx* ctx, float
         ctx->accum_count = 0;
         normalize_symbol_phase(&ctx->phase, ctx->clock);
     }
-    maybe_track_symbol_timing(st, centered, ctx->clock_i, sample_phase, &ctx->phase);
+    if (maybe_track_symbol_timing(st, centered, ctx->clock_i, sample_phase, &ctx->phase)) {
+        ctx->phase = st->symbol_phase;
+        ctx->accum = st->symbol_accum;
+        ctx->accum_count = st->symbol_count;
+    }
 }
 
 int
@@ -892,6 +962,7 @@ dsd_fsk_modem_zero_symbols(dsd_fsk_modem_state* st, int input_complex_samples, f
     clear_tracking_window(st);
     st->track_last_error = 0.0f;
     st->track_last_score = 0.0f;
+    st->track_consecutive_skips = 0;
     st->prev_i = 0.0f;
     st->prev_q = 0.0f;
     st->have_prev = 0;

--- a/src/dsp/fsk_modem.c
+++ b/src/dsp/fsk_modem.c
@@ -597,6 +597,15 @@ track_eval_has_signal_loss(const dsd_fsk_modem_state* st, const dsd_fsk_track_ev
 }
 
 static void
+clear_signal_level_reference(dsd_fsk_modem_state* st) {
+    if (!st) {
+        return;
+    }
+    st->track_signal_ref = 0.0f;
+    st->abs_est = 0.0f;
+}
+
+static void
 track_update_signal_ref(dsd_fsk_modem_state* st, float mean_abs) {
     if (!st || mean_abs < DSD_FSK_TRACK_MIN_SCORE) {
         return;
@@ -684,7 +693,7 @@ reset_symbol_timing_for_reacquisition(dsd_fsk_modem_state* st, float* phase_io) 
     st->track_consecutive_skips = 0;
     st->track_last_error = 0.0f;
     st->track_last_score = 0.0f;
-    clear_pending_symbols(st);
+    clear_signal_level_reference(st);
     clear_tracking_window(st);
     st->timing_acquired = modem_should_acquire_timing(&st->cfg, st->symbol_clock) ? 0 : 1;
     reset_soft_metrics(st);
@@ -1035,6 +1044,7 @@ dsd_fsk_modem_zero_symbols(dsd_fsk_modem_state* st, int input_complex_samples, f
     st->track_last_error = 0.0f;
     st->track_last_score = 0.0f;
     st->track_consecutive_skips = 0;
+    clear_signal_level_reference(st);
     st->prev_i = 0.0f;
     st->prev_q = 0.0f;
     st->have_prev = 0;

--- a/src/dsp/fsk_modem.c
+++ b/src/dsp/fsk_modem.c
@@ -13,12 +13,7 @@
 
 #define DSD_FSK_TRACK_SYMBOLS              64
 #define DSD_FSK_TRACK_MIN_SCORE            1.0e-4f
-#define DSD_FSK_TRACK_MIN_RATIO            1.10f
 #define DSD_FSK_TRACK_SOFT_MIN_RATIO       1.02f
-#define DSD_FSK_TRACK_SOFT_MIN_CONFIDENCE  0.25f
-#define DSD_FSK_TRACK_GAIN                 0.125f
-#define DSD_FSK_TRACK_MAX_CORRECTION       0.25f
-#define DSD_FSK_TRACK_SOFT_MAX_CORRECTION  0.125f
 #define DSD_FSK_TRACK_REACQUIRE_SKIPS      32ULL
 #define DSD_FSK_TRACK_SIGNAL_LOSS_FRACTION 0.20f
 #define DSD_FSK_METRICS_WINDOW             256U
@@ -480,7 +475,6 @@ typedef struct {
     float best_score;
     float ratio;
     float err;
-    float confidence;
     float mean_abs;
     int accept;
 } dsd_fsk_track_eval;
@@ -518,19 +512,6 @@ track_mean_abs_freq(const float* freq, int n) {
     return (float)(sum / (double)n);
 }
 
-static float
-track_correction_confidence(float ratio) {
-    if (ratio >= DSD_FSK_TRACK_MIN_RATIO) {
-        return 1.0f;
-    }
-    if (ratio <= DSD_FSK_TRACK_SOFT_MIN_RATIO) {
-        return DSD_FSK_TRACK_SOFT_MIN_CONFIDENCE;
-    }
-    float span = DSD_FSK_TRACK_MIN_RATIO - DSD_FSK_TRACK_SOFT_MIN_RATIO;
-    float scaled = (ratio - DSD_FSK_TRACK_SOFT_MIN_RATIO) / span;
-    return DSD_FSK_TRACK_SOFT_MIN_CONFIDENCE + scaled * (1.0f - DSD_FSK_TRACK_SOFT_MIN_CONFIDENCE);
-}
-
 static int
 track_timing_ready(const dsd_fsk_modem_state* st, const float* phase_io, int clock_i) {
     if (!st || !phase_io || clock_i < 4 || clock_i > 32 || !st->timing_acquired) {
@@ -564,16 +545,10 @@ track_compute_eval(const dsd_fsk_modem_state* st, int clock_i) {
     eval.expected_phase = (clock_i - start_phase) % clock_i;
     eval.ratio = track_score_ratio(eval.best_score, second_score);
     eval.err = wrap_timing_error((float)(eval.best_phase - eval.expected_phase), clock_i);
-    eval.confidence = track_correction_confidence(eval.ratio);
     eval.mean_abs = track_mean_abs_freq(st->track_freq, st->track_len);
     eval.accept = (eval.best_score >= DSD_FSK_TRACK_MIN_SCORE && eval.ratio >= DSD_FSK_TRACK_SOFT_MIN_RATIO
                    && fabsf(eval.err) <= 2.0f);
     return eval;
-}
-
-static int
-track_eval_is_hard_accept(const dsd_fsk_track_eval* eval) {
-    return eval && eval->accept && eval->ratio >= DSD_FSK_TRACK_MIN_RATIO;
 }
 
 static int
@@ -620,45 +595,14 @@ track_update_signal_ref(dsd_fsk_modem_state* st, float mean_abs) {
     st->track_signal_ref += 0.05f * (mean_abs - st->track_signal_ref);
 }
 
-static float
-track_gain_correction(float err, float confidence, float ratio) {
-    float correction = err * DSD_FSK_TRACK_GAIN * confidence;
-    float max_correction =
-        (ratio >= DSD_FSK_TRACK_MIN_RATIO) ? DSD_FSK_TRACK_MAX_CORRECTION : DSD_FSK_TRACK_SOFT_MAX_CORRECTION;
-    if (correction > max_correction) {
-        correction = max_correction;
-    } else if (correction < -max_correction) {
-        correction = -max_correction;
-    }
-    return correction;
-}
-
-static float
-track_apply_correction(const dsd_fsk_modem_state* st, float* phase_io, float correction) {
-    float corrected_phase = *phase_io - correction;
-    if (corrected_phase < 0.0f) {
-        correction = *phase_io;
-        corrected_phase = 0.0f;
-    } else if (corrected_phase >= st->symbol_clock) {
-        float phase_limit = st->symbol_clock - 1.0e-4f;
-        if (phase_limit < 0.0f) {
-            phase_limit = 0.0f;
-        }
-        correction = *phase_io - phase_limit;
-        corrected_phase = phase_limit;
-    }
-    *phase_io = corrected_phase;
-    return correction;
-}
-
 static void
-track_log_accept(const dsd_fsk_modem_state* st, int clock_i, const dsd_fsk_track_eval* eval, float correction) {
+track_log_accept(const dsd_fsk_modem_state* st, int clock_i, const dsd_fsk_track_eval* eval) {
     if (debug_fsk_acq_enabled()) {
         DSD_FPRINTF(stderr,
-                    "[FSKTRACK] clock=%d best=%d expect=%d err=%.3f corr=%.3f score=%.5f ratio=%.3f conf=%.3f "
+                    "[FSKTRACK] clock=%d best=%d expect=%d err=%.3f score=%.5f ratio=%.3f "
                     "mean=%.5f updates=%llu\n",
-                    clock_i, eval->best_phase, eval->expected_phase, eval->err, correction, eval->best_score,
-                    eval->ratio, eval->confidence, eval->mean_abs, (unsigned long long)st->track_updates);
+                    clock_i, eval->best_phase, eval->expected_phase, eval->err, eval->best_score, eval->ratio,
+                    eval->mean_abs, (unsigned long long)st->track_updates);
     }
 }
 
@@ -753,28 +697,17 @@ maybe_track_symbol_timing(dsd_fsk_modem_state* st, float centered, int clock_i, 
     if (!signal_loss) {
         track_update_signal_ref(st, eval.mean_abs);
     }
-    if (eval.accept) {
-        float correction = track_gain_correction(eval.err, eval.confidence, eval.ratio);
-        correction = track_apply_correction(st, phase_io, correction);
-        st->track_last_error = eval.err;
-        st->track_last_score = eval.best_score;
-        st->track_updates++;
-        if (track_eval_is_hard_accept(&eval) || !signal_loss) {
-            st->track_consecutive_skips = 0;
-        } else {
-            st->track_consecutive_skips++;
-        }
-        track_log_accept(st, clock_i, &eval, correction);
-    } else {
-        st->track_last_error = 0.0f;
-        st->track_last_score = eval.best_score;
+    st->track_last_error = eval.accept ? eval.err : 0.0f;
+    st->track_last_score = eval.best_score;
+    if (signal_loss) {
         st->track_skips++;
-        if (signal_loss) {
-            st->track_consecutive_skips++;
-        } else {
-            st->track_consecutive_skips = 0;
-        }
+        st->track_consecutive_skips++;
         track_log_skip(st, clock_i, &eval);
+    } else {
+        st->track_consecutive_skips = 0;
+        if (eval.accept) {
+            track_log_accept(st, clock_i, &eval);
+        }
     }
     if (signal_loss && st->track_consecutive_skips >= DSD_FSK_TRACK_REACQUIRE_SKIPS) {
         track_log_reacquire(st, clock_i, &eval);

--- a/src/dsp/fsk_modem.c
+++ b/src/dsp/fsk_modem.c
@@ -4,20 +4,11 @@
  */
 
 #include <dsd-neo/dsp/fsk_modem.h>
-#include <dsd-neo/dsp/symbol_levels.h>
 #include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include "dsd-neo/core/safe_api.h"
 
-#define DSD_FSK_TRACK_SYMBOLS              64
-#define DSD_FSK_TRACK_MIN_SCORE            1.0e-4f
-#define DSD_FSK_TRACK_SOFT_MIN_RATIO       1.02f
-#define DSD_FSK_TRACK_REACQUIRE_SKIPS      32ULL
-#define DSD_FSK_TRACK_SIGNAL_LOSS_FRACTION 0.20f
-#define DSD_FSK_METRICS_WINDOW             256U
-#define DSD_FSK_LOW_RELIABILITY            128U
+#define DSD_FSK_DISCRIMINATOR_TARGET   30000.0f
+#define DSD_FSK_DISCRIMINATOR_MIN_PEAK 1.0e-7f
 
 static int
 clamp_levels(int levels) {
@@ -27,63 +18,6 @@ clamp_levels(int levels) {
 static int
 valid_rate(int rate_hz, int fallback_hz) {
     return (rate_hz > 0) ? rate_hz : fallback_hz;
-}
-
-static float
-modem_symbol_clock(const dsd_fsk_modem_config* cfg) {
-    int sample_rate = valid_rate(cfg ? cfg->sample_rate_hz : 0, 48000);
-    int symbol_rate = valid_rate(cfg ? cfg->symbol_rate_hz : 0, 4800);
-    float clock = (float)sample_rate / (float)symbol_rate;
-    if (clock < 1.0f) {
-        clock = 1.0f;
-    }
-    if (clock > 256.0f) {
-        clock = 256.0f;
-    }
-    return clock;
-}
-
-static int
-modem_clock_int(float clock) {
-    int ci = (int)(clock + 0.5f);
-    if (ci < 1) {
-        ci = 1;
-    }
-    if (fabsf(clock - (float)ci) > 0.01f) {
-        return 0;
-    }
-    return ci;
-}
-
-static int
-modem_should_acquire_timing(const dsd_fsk_modem_config* cfg, float clock) {
-    int ci = modem_clock_int(clock);
-    if (!cfg || ci < 4 || ci > 32) {
-        return 0;
-    }
-    return (cfg->levels == 2 || cfg->levels == 4) ? 1 : 0;
-}
-
-static int
-modem_acq_target_samples(int clock_i) {
-    int target = clock_i * 96;
-    if (target > DSD_FSK_MODEM_ACQ_MAX_SAMPLES) {
-        target = DSD_FSK_MODEM_ACQ_MAX_SAMPLES - (DSD_FSK_MODEM_ACQ_MAX_SAMPLES % clock_i);
-    }
-    if (target < clock_i * 12) {
-        target = clock_i * 12;
-    }
-    return target;
-}
-
-static int
-debug_fsk_acq_enabled(void) {
-    static int cached = -1;
-    if (cached < 0) {
-        const char* dbg = getenv("DSD_NEO_DEBUG_SYNC");
-        cached = (dbg && *dbg && strcmp(dbg, "0") != 0) ? 1 : 0;
-    }
-    return cached;
 }
 
 static inline float
@@ -114,27 +48,14 @@ normalized_config(const dsd_fsk_modem_config* cfg) {
     return out;
 }
 
-static void
-release_pending_storage(dsd_fsk_modem_state* st) {
-    if (st->pending_heap) {
-        free(st->pending_heap);
-        st->pending_heap = NULL;
-    }
-    st->pending_cap = 0;
-}
-
 void
 dsd_fsk_modem_reset(dsd_fsk_modem_state* st) {
     if (!st) {
         return;
     }
     dsd_fsk_modem_config cfg = st->cfg;
-    release_pending_storage(st);
     DSD_MEMSET(st, 0, sizeof(*st));
     st->cfg = normalized_config(&cfg);
-    st->symbol_clock = modem_symbol_clock(&st->cfg);
-    st->abs_est = 0.0f;
-    st->timing_acquired = modem_should_acquire_timing(&st->cfg, st->symbol_clock) ? 0 : 1;
 }
 
 void
@@ -146,7 +67,6 @@ dsd_fsk_modem_configure(dsd_fsk_modem_state* st, const dsd_fsk_modem_config* cfg
     int changed = (st->cfg.sample_rate_hz != next.sample_rate_hz || st->cfg.symbol_rate_hz != next.symbol_rate_hz
                    || st->cfg.levels != next.levels || st->cfg.channel_profile != next.channel_profile);
     st->cfg = next;
-    st->symbol_clock = modem_symbol_clock(&st->cfg);
     if (changed) {
         dsd_fsk_modem_reset(st);
     }
@@ -159,687 +79,11 @@ dsd_fsk_modem_init(dsd_fsk_modem_state* st, const dsd_fsk_modem_config* cfg) {
     }
     DSD_MEMSET(st, 0, sizeof(*st));
     st->cfg = normalized_config(cfg);
-    st->symbol_clock = modem_symbol_clock(&st->cfg);
-    st->timing_acquired = modem_should_acquire_timing(&st->cfg, st->symbol_clock) ? 0 : 1;
 }
 
 void
 dsd_fsk_modem_release(dsd_fsk_modem_state* st) {
-    if (!st) {
-        return;
-    }
-    release_pending_storage(st);
-    st->pending_pos = 0;
-    st->pending_len = 0;
-}
-
-static void
-reset_soft_metrics(dsd_fsk_modem_state* st) {
-    if (!st) {
-        return;
-    }
-    DSD_MEMSET(&st->metrics, 0, sizeof(st->metrics));
-    st->metrics_rel_sum = 0.0f;
-    st->metrics_err2_sum = 0.0f;
-    st->metrics_ref2_sum = 0.0f;
-    st->metrics_low_count = 0;
-    st->metrics_clip_count = 0;
-    st->metrics_min_reliability = 0;
-}
-
-static void
-refresh_soft_metrics_snapshot(dsd_fsk_modem_state* st) {
-    if (!st || st->metrics.window_symbols == 0U) {
-        if (st) {
-            st->metrics.valid = 0;
-        }
-        return;
-    }
-
-    const unsigned int n = st->metrics.window_symbols;
-    st->metrics.valid = 1;
-    st->metrics.levels = st->cfg.levels;
-    st->metrics.symbol_rate_hz = st->cfg.symbol_rate_hz;
-    st->metrics.mean_reliability = (unsigned int)((st->metrics_rel_sum / (float)n) + 0.5f);
-    if (st->metrics.mean_reliability > 255U) {
-        st->metrics.mean_reliability = 255U;
-    }
-    st->metrics.min_reliability = st->metrics_min_reliability;
-    st->metrics.rms_error = sqrtf(st->metrics_err2_sum / (float)n);
-    if (st->metrics_err2_sum > 1.0e-12f && st->metrics_ref2_sum > 1.0e-12f) {
-        st->metrics.evm_snr_db = 10.0f * log10f(st->metrics_ref2_sum / st->metrics_err2_sum);
-    } else if (st->metrics_ref2_sum > 1.0e-12f) {
-        st->metrics.evm_snr_db = 99.0f;
-    } else {
-        st->metrics.evm_snr_db = -100.0f;
-    }
-    st->metrics.low_reliability_pct = (100.0f * (float)st->metrics_low_count) / (float)n;
-    st->metrics.clip_pct = (100.0f * (float)st->metrics_clip_count) / (float)n;
-    st->metrics.timing_acquired = st->timing_acquired;
-    st->metrics.track_last_error = st->track_last_error;
-    st->metrics.track_last_score = st->track_last_score;
-    st->metrics.track_updates = st->track_updates;
-    st->metrics.track_skips = st->track_skips;
-    st->metrics.abs_est = st->abs_est;
-    st->metrics.dc_est = st->dc_est;
-    st->metrics.last_symbol = st->last_symbol;
-}
-
-static void
-update_soft_metrics(dsd_fsk_modem_state* st, float symbol) {
-    if (!st) {
-        return;
-    }
-    if (st->metrics.window_symbols >= DSD_FSK_METRICS_WINDOW) {
-        st->metrics.window_symbols = 0;
-        st->metrics_rel_sum = 0.0f;
-        st->metrics_err2_sum = 0.0f;
-        st->metrics_ref2_sum = 0.0f;
-        st->metrics_low_count = 0;
-        st->metrics_clip_count = 0;
-    }
-    if (st->metrics.window_symbols == 0U) {
-        st->metrics_min_reliability = 255U;
-    }
-
-    dsd_fsk_soft_symbol_metrics sm = dsd_fsk_soft_symbol_metrics_from_symbol(symbol, st->cfg.levels);
-    st->metrics.window_symbols++;
-    st->metrics.symbols_total++;
-    st->metrics_rel_sum += (float)sm.reliability;
-    st->metrics_err2_sum += sm.error * sm.error;
-    st->metrics_ref2_sum += sm.ideal * sm.ideal;
-    if ((unsigned int)sm.reliability < st->metrics_min_reliability) {
-        st->metrics_min_reliability = (unsigned int)sm.reliability;
-    }
-    if ((unsigned int)sm.reliability < DSD_FSK_LOW_RELIABILITY) {
-        st->metrics_low_count++;
-    }
-    if (sm.clipped) {
-        st->metrics_clip_count++;
-    }
-    refresh_soft_metrics_snapshot(st);
-}
-
-static float
-clamp_symbol(float sym, int levels) {
-    float limit = (levels == 2) ? 2.25f : 4.5f;
-    if (sym > limit) {
-        return limit;
-    }
-    if (sym < -limit) {
-        return -limit;
-    }
-    return sym;
-}
-
-static float
-normalize_symbol(dsd_fsk_modem_state* st, float raw_symbol) {
-    float abs_raw = fabsf(raw_symbol);
-    if (abs_raw > 1e-7f) {
-        if (st->abs_est <= 1e-7f) {
-            st->abs_est = abs_raw;
-        } else {
-            /* Track level slowly so short symbol runs do not pump the slicer. */
-            st->abs_est += 0.0125f * (abs_raw - st->abs_est);
-        }
-    }
-
-    float ref_abs = (st->cfg.levels == 2) ? 1.0f : 2.0f;
-    float denom = (st->abs_est > 1e-7f) ? st->abs_est : (abs_raw > 1e-7f ? abs_raw : ref_abs);
-    float sym = raw_symbol * (ref_abs / denom);
-    return clamp_symbol(sym, st->cfg.levels);
-}
-
-static const float*
-pending_symbol_data(const dsd_fsk_modem_state* st) {
-    return st->pending_heap ? st->pending_heap : st->pending_symbols;
-}
-
-static int
-pending_symbol_capacity(const dsd_fsk_modem_state* st) {
-    return st->pending_heap ? st->pending_cap : DSD_FSK_MODEM_PENDING_INLINE_SYMBOLS;
-}
-
-static void
-clear_pending_symbols(dsd_fsk_modem_state* st) {
-    st->pending_pos = 0;
-    st->pending_len = 0;
-    release_pending_storage(st);
-}
-
-static void
-compact_pending_symbols(dsd_fsk_modem_state* st) {
-    if (st->pending_pos <= 0) {
-        return;
-    }
-
-    int remaining = st->pending_len - st->pending_pos;
-    if (remaining > 0) {
-        float* pending = st->pending_heap ? st->pending_heap : st->pending_symbols;
-        DSD_MEMMOVE(pending, pending + st->pending_pos, (size_t)remaining * sizeof(float));
-    }
-    st->pending_pos = 0;
-    st->pending_len = remaining;
-}
-
-static int
-ensure_pending_capacity(dsd_fsk_modem_state* st, int needed) {
-    int cap = pending_symbol_capacity(st);
-    if (needed <= cap) {
-        return 1;
-    }
-
-    int new_cap = cap;
-    while (new_cap < needed) {
-        if (new_cap > 1073741823) {
-            return 0;
-        }
-        new_cap *= 2;
-    }
-
-    float* next = NULL;
-    if (st->pending_heap) {
-        next = (float*)realloc(st->pending_heap, (size_t)new_cap * sizeof(float));
-    } else {
-        next = (float*)malloc((size_t)new_cap * sizeof(float));
-        if (next) {
-            DSD_MEMCPY(next, st->pending_symbols, (size_t)st->pending_len * sizeof(float));
-        }
-    }
-    if (!next) {
-        return 0;
-    }
-
-    st->pending_heap = next;
-    st->pending_cap = new_cap;
-    return 1;
-}
-
-static int
-drain_pending_symbols(dsd_fsk_modem_state* st, float* out_symbols, int out_count, int max_symbols) {
-    const float* pending = pending_symbol_data(st);
-    while (st->pending_pos < st->pending_len && out_count < max_symbols) {
-        out_symbols[out_count++] = pending[st->pending_pos++];
-        st->symbols_emitted++;
-    }
-    if (st->pending_pos >= st->pending_len) {
-        clear_pending_symbols(st);
-    }
-    return out_count;
-}
-
-static int
-queue_pending_symbol(dsd_fsk_modem_state* st, float symbol) {
-    if (st->pending_pos > 0 && st->pending_len >= pending_symbol_capacity(st)) {
-        compact_pending_symbols(st);
-    }
-    if (!ensure_pending_capacity(st, st->pending_len + 1)) {
-        return 0;
-    }
-    float* pending = st->pending_heap ? st->pending_heap : st->pending_symbols;
-    pending[st->pending_len++] = symbol;
-    return 1;
-}
-
-static int
-emit_symbol(dsd_fsk_modem_state* st, float raw_symbol, float* out_symbols, int out_count, int max_symbols) {
-    float sym = normalize_symbol(st, raw_symbol);
-    st->last_symbol = sym;
-    update_soft_metrics(st, sym);
-    if (out_count < max_symbols) {
-        out_symbols[out_count++] = sym;
-        st->symbols_emitted++;
-    } else {
-        (void)queue_pending_symbol(st, sym);
-    }
-    return out_count;
-}
-
-static float
-sum_freq_window(const float* freq, int start, int len) {
-    float sum = 0.0f;
-    for (int i = 0; i < len; i++) {
-        sum += freq[start + i];
-    }
-    return sum;
-}
-
-static int
-acquire_symbol_phase_scored(const float* freq, int n, int clock_i, float* out_score, float* out_second_score) {
-    int best_phase = 0;
-    float best_score = -1.0f;
-    float second_score = -1.0f;
-
-    for (int phase = 0; phase < clock_i; phase++) {
-        double score = 0.0;
-        int count = 0;
-        for (int start = phase; start + clock_i <= n; start += clock_i) {
-            float sum = sum_freq_window(freq, start, clock_i);
-            score += fabs((double)sum / (double)clock_i);
-            count++;
-        }
-        if (count > 0) {
-            score /= (double)count;
-        }
-        if ((float)score > best_score) {
-            second_score = best_score;
-            best_score = (float)score;
-            best_phase = phase;
-        } else if ((float)score > second_score) {
-            second_score = (float)score;
-        }
-    }
-
-    if (out_score) {
-        *out_score = best_score;
-    }
-    if (out_second_score) {
-        *out_second_score = second_score;
-    }
-    return best_phase;
-}
-
-static int
-tracking_target_samples(int clock_i) {
-    int target = clock_i * DSD_FSK_TRACK_SYMBOLS;
-    if (target > DSD_FSK_MODEM_TRACK_MAX_SAMPLES) {
-        target = DSD_FSK_MODEM_TRACK_MAX_SAMPLES - (DSD_FSK_MODEM_TRACK_MAX_SAMPLES % clock_i);
-    }
-    if (target < clock_i * 12) {
-        target = clock_i * 12;
-    }
-    return target;
-}
-
-static void
-clear_tracking_window(dsd_fsk_modem_state* st) {
-    st->track_len = 0;
-    st->track_start_phase = 0.0f;
-}
-
-static float
-wrap_timing_error(float err, int clock_i) {
-    float half = (float)clock_i * 0.5f;
-    while (err > half) {
-        err -= (float)clock_i;
-    }
-    while (err < -half) {
-        err += (float)clock_i;
-    }
-    return err;
-}
-
-typedef struct {
-    int best_phase;
-    int expected_phase;
-    float best_score;
-    float ratio;
-    float err;
-    float mean_abs;
-    int accept;
-} dsd_fsk_track_eval;
-
-static int track_boundary_phase_scored(const float* freq, int n, int clock_i, float* out_score,
-                                       float* out_second_score);
-
-static int
-track_start_phase_mod(float start_phase, int clock_i) {
-    int phase = (int)floorf(start_phase);
-    phase %= clock_i;
-    if (phase < 0) {
-        phase += clock_i;
-    }
-    return phase;
-}
-
-static float
-track_score_ratio(float best_score, float second_score) {
-    if (second_score > 1.0e-12f) {
-        return best_score / second_score;
-    }
-    return (best_score > 0.0f) ? 1000.0f : 0.0f;
-}
-
-static float
-track_mean_abs_freq(const float* freq, int n) {
-    double sum = 0.0;
-    if (!freq || n <= 0) {
-        return 0.0f;
-    }
-    for (int i = 0; i < n; i++) {
-        sum += fabs((double)freq[i]);
-    }
-    return (float)(sum / (double)n);
-}
-
-static int
-track_timing_ready(const dsd_fsk_modem_state* st, const float* phase_io, int clock_i) {
-    if (!st || !phase_io || clock_i < 4 || clock_i > 32 || !st->timing_acquired) {
-        return 0;
-    }
-    return 1;
-}
-
-static int
-track_push_sample(dsd_fsk_modem_state* st, float centered, float sample_phase, int target) {
-    if (target <= 0) {
-        return 0;
-    }
-    if (st->track_len == 0) {
-        st->track_start_phase = sample_phase;
-    }
-    if (st->track_len < DSD_FSK_MODEM_TRACK_MAX_SAMPLES) {
-        st->track_freq[st->track_len++] = centered;
-    }
-    return (st->track_len >= target) ? 1 : 0;
-}
-
-static dsd_fsk_track_eval
-track_compute_eval(const dsd_fsk_modem_state* st, int clock_i) {
-    dsd_fsk_track_eval eval;
-    float second_score = 0.0f;
-    eval.best_score = 0.0f;
-    eval.best_phase =
-        track_boundary_phase_scored(st->track_freq, st->track_len, clock_i, &eval.best_score, &second_score);
-    int start_phase = track_start_phase_mod(st->track_start_phase, clock_i);
-    eval.expected_phase = (clock_i - start_phase) % clock_i;
-    eval.ratio = track_score_ratio(eval.best_score, second_score);
-    eval.err = wrap_timing_error((float)(eval.best_phase - eval.expected_phase), clock_i);
-    eval.mean_abs = track_mean_abs_freq(st->track_freq, st->track_len);
-    eval.accept = (eval.best_score >= DSD_FSK_TRACK_MIN_SCORE && eval.ratio >= DSD_FSK_TRACK_SOFT_MIN_RATIO
-                   && fabsf(eval.err) <= 2.0f);
-    return eval;
-}
-
-static int
-track_score_has_signal_loss(const dsd_fsk_modem_state* st, float score) {
-    if (!st) {
-        return 0;
-    }
-    float ref = (st->track_signal_ref > 1.0e-7f) ? st->track_signal_ref : st->abs_est;
-    if (ref <= 1.0e-7f) {
-        return score < DSD_FSK_TRACK_MIN_SCORE;
-    }
-    return score < (ref * DSD_FSK_TRACK_SIGNAL_LOSS_FRACTION);
-}
-
-static int
-track_eval_has_signal_loss(const dsd_fsk_modem_state* st, const dsd_fsk_track_eval* eval) {
-    if (!st || !eval) {
-        return 0;
-    }
-    return track_score_has_signal_loss(st, eval->mean_abs);
-}
-
-static void
-clear_signal_level_reference(dsd_fsk_modem_state* st) {
-    if (!st) {
-        return;
-    }
-    st->track_signal_ref = 0.0f;
-    st->abs_est = 0.0f;
-}
-
-static void
-track_update_signal_ref(dsd_fsk_modem_state* st, float mean_abs) {
-    if (!st || mean_abs < DSD_FSK_TRACK_MIN_SCORE) {
-        return;
-    }
-    if (st->track_signal_ref <= 1.0e-7f) {
-        st->track_signal_ref = mean_abs;
-        return;
-    }
-    if (mean_abs < (st->track_signal_ref * DSD_FSK_TRACK_SIGNAL_LOSS_FRACTION)) {
-        return;
-    }
-    st->track_signal_ref += 0.05f * (mean_abs - st->track_signal_ref);
-}
-
-static void
-track_log_accept(const dsd_fsk_modem_state* st, int clock_i, const dsd_fsk_track_eval* eval) {
-    if (debug_fsk_acq_enabled()) {
-        DSD_FPRINTF(stderr,
-                    "[FSKTRACK] clock=%d best=%d expect=%d err=%.3f score=%.5f ratio=%.3f "
-                    "mean=%.5f updates=%llu\n",
-                    clock_i, eval->best_phase, eval->expected_phase, eval->err, eval->best_score, eval->ratio,
-                    eval->mean_abs, (unsigned long long)st->track_updates);
-    }
-}
-
-static void
-track_log_skip(const dsd_fsk_modem_state* st, int clock_i, const dsd_fsk_track_eval* eval) {
-    if (debug_fsk_acq_enabled()) {
-        DSD_FPRINTF(stderr, "[FSKTRACK] skip clock=%d best=%d expect=%d score=%.5f ratio=%.3f mean=%.5f skips=%llu\n",
-                    clock_i, eval->best_phase, eval->expected_phase, eval->best_score, eval->ratio, eval->mean_abs,
-                    (unsigned long long)st->track_skips);
-    }
-}
-
-static void
-track_log_reacquire(const dsd_fsk_modem_state* st, int clock_i, const dsd_fsk_track_eval* eval) {
-    if (debug_fsk_acq_enabled()) {
-        DSD_FPRINTF(stderr,
-                    "[FSKREACQ] clock=%d best=%d expect=%d err=%.3f score=%.5f ratio=%.3f mean=%.5f skips=%llu\n",
-                    clock_i, eval->best_phase, eval->expected_phase, eval->err, eval->best_score, eval->ratio,
-                    eval->mean_abs, (unsigned long long)st->track_skips);
-    }
-}
-
-static void
-reset_symbol_timing_for_reacquisition(dsd_fsk_modem_state* st, float* phase_io) {
-    if (!st) {
-        return;
-    }
-    st->symbol_phase = 0.0f;
-    st->symbol_accum = 0.0f;
-    st->symbol_count = 0;
-    st->acq_len = 0;
-    st->track_consecutive_skips = 0;
-    st->track_last_error = 0.0f;
-    st->track_last_score = 0.0f;
-    clear_signal_level_reference(st);
-    clear_tracking_window(st);
-    st->timing_acquired = modem_should_acquire_timing(&st->cfg, st->symbol_clock) ? 0 : 1;
-    reset_soft_metrics(st);
-    if (phase_io) {
-        *phase_io = st->symbol_phase;
-    }
-}
-
-static int
-track_boundary_phase_scored(const float* freq, int n, int clock_i, float* out_score, float* out_second_score) {
-    int best_phase = 0;
-    float best_score = -1.0f;
-    float second_score = -1.0f;
-
-    for (int phase = 0; phase < clock_i; phase++) {
-        double score = 0.0;
-        int count = 0;
-        for (int pos = phase; pos < n; pos += clock_i) {
-            if (pos <= 0) {
-                continue;
-            }
-            score += fabs((double)freq[pos] - (double)freq[pos - 1]);
-            count++;
-        }
-        if (count > 0) {
-            score /= (double)count;
-        }
-        if ((float)score > best_score) {
-            second_score = best_score;
-            best_score = (float)score;
-            best_phase = phase;
-        } else if ((float)score > second_score) {
-            second_score = (float)score;
-        }
-    }
-
-    if (out_score) {
-        *out_score = best_score;
-    }
-    if (out_second_score) {
-        *out_second_score = second_score;
-    }
-    return best_phase;
-}
-
-static int
-maybe_track_symbol_timing(dsd_fsk_modem_state* st, float centered, int clock_i, float sample_phase, float* phase_io) {
-    if (!track_timing_ready(st, phase_io, clock_i)) {
-        return 0;
-    }
-    if (!track_push_sample(st, centered, sample_phase, tracking_target_samples(clock_i))) {
-        return 0;
-    }
-
-    dsd_fsk_track_eval eval = track_compute_eval(st, clock_i);
-    int signal_loss = track_eval_has_signal_loss(st, &eval);
-    if (!signal_loss) {
-        track_update_signal_ref(st, eval.mean_abs);
-    }
-    st->track_last_error = eval.accept ? eval.err : 0.0f;
-    st->track_last_score = eval.best_score;
-    if (signal_loss) {
-        st->track_skips++;
-        st->track_consecutive_skips++;
-        track_log_skip(st, clock_i, &eval);
-    } else {
-        st->track_consecutive_skips = 0;
-        if (eval.accept) {
-            track_log_accept(st, clock_i, &eval);
-        }
-    }
-    if (signal_loss && st->track_consecutive_skips >= DSD_FSK_TRACK_REACQUIRE_SKIPS) {
-        track_log_reacquire(st, clock_i, &eval);
-        reset_symbol_timing_for_reacquisition(st, phase_io);
-        return 1;
-    }
-    clear_tracking_window(st);
-    return 0;
-}
-
-static int
-emit_acquisition_symbols(dsd_fsk_modem_state* st, int clock_i, float* out_symbols, int out_count, int max_symbols) {
-    float score = 0.0f;
-    float second_score = 0.0f;
-    int phase = acquire_symbol_phase_scored(st->acq_freq, st->acq_len, clock_i, &score, &second_score);
-    float ratio = track_score_ratio(score, second_score);
-    if (track_score_has_signal_loss(st, score)) {
-        if (debug_fsk_acq_enabled()) {
-            DSD_FPRINTF(stderr, "[FSKACQ] wait clock=%d phase=%d score=%.5f ratio=%.3f samples=%d\n", clock_i, phase,
-                        score, ratio, st->acq_len);
-        }
-        if (st->acq_len >= DSD_FSK_MODEM_ACQ_MAX_SAMPLES) {
-            st->acq_len = 0;
-        }
-        return out_count;
-    }
-    if (phase < 0) {
-        phase = 0;
-    } else if (phase >= clock_i) {
-        phase = clock_i - 1;
-    }
-    int start = phase;
-    int emitted_leading = 0;
-
-    if (phase >= clock_i - 1 && phase > 0) {
-        float sum = sum_freq_window(st->acq_freq, 0, phase);
-        out_count = emit_symbol(st, sum / (float)phase, out_symbols, out_count, max_symbols);
-        emitted_leading = 1;
-    }
-
-    while (start + clock_i <= st->acq_len) {
-        float sum = sum_freq_window(st->acq_freq, start, clock_i);
-        out_count = emit_symbol(st, sum / (float)clock_i, out_symbols, out_count, max_symbols);
-        start += clock_i;
-    }
-
-    st->symbol_accum = 0.0f;
-    st->symbol_count = 0;
-    st->symbol_phase = 0.0f;
-    for (int i = start; i < st->acq_len; i++) {
-        st->symbol_accum += st->acq_freq[i];
-        st->symbol_count++;
-        st->symbol_phase += 1.0f;
-    }
-    if (st->symbol_phase >= st->symbol_clock) {
-        st->symbol_phase = fmodf(st->symbol_phase, st->symbol_clock);
-    }
-    st->acq_len = 0;
-    st->timing_acquired = 1;
-    track_update_signal_ref(st, score);
-    clear_tracking_window(st);
-
-    if (debug_fsk_acq_enabled()) {
-        DSD_FPRINTF(stderr, "[FSKACQ] clock=%d phase=%d score=%.5f ratio=%.3f lead=%d carry=%d emitted=%llu\n", clock_i,
-                    phase, score, ratio, emitted_leading, st->symbol_count, (unsigned long long)st->symbols_emitted);
-    }
-    return out_count;
-}
-
-typedef struct {
-    float prev_i;
-    float prev_q;
-    int have_prev;
-    float phase;
-    float accum;
-    int accum_count;
-    float dc;
-    float clock;
-    int clock_i;
-    int acq_target;
-} dsd_fsk_process_ctx;
-
-static float
-modem_clock_or_default(const dsd_fsk_modem_state* st) {
-    if (st->symbol_clock > 0.0f) {
-        return st->symbol_clock;
-    }
-    return modem_symbol_clock(&st->cfg);
-}
-
-static int
-modem_acquisition_target(int clock_i) {
-    if (clock_i <= 0) {
-        return 0;
-    }
-    return modem_acq_target_samples(clock_i);
-}
-
-static float
-symbol_average_or_zero(float accum, int count) {
-    if (count > 0) {
-        return accum / (float)count;
-    }
-    return 0.0f;
-}
-
-static dsd_fsk_process_ctx
-process_ctx_load(const dsd_fsk_modem_state* st) {
-    dsd_fsk_process_ctx ctx;
-    ctx.prev_i = st->prev_i;
-    ctx.prev_q = st->prev_q;
-    ctx.have_prev = st->have_prev;
-    ctx.phase = st->symbol_phase;
-    ctx.accum = st->symbol_accum;
-    ctx.accum_count = st->symbol_count;
-    ctx.dc = st->dc_est;
-    ctx.clock = modem_clock_or_default(st);
-    ctx.clock_i = modem_clock_int(ctx.clock);
-    ctx.acq_target = modem_acquisition_target(ctx.clock_i);
-    return ctx;
-}
-
-static void
-process_ctx_store(dsd_fsk_modem_state* st, const dsd_fsk_process_ctx* ctx) {
-    st->prev_i = ctx->prev_i;
-    st->prev_q = ctx->prev_q;
-    st->have_prev = ctx->have_prev;
-    st->symbol_phase = ctx->phase;
-    st->symbol_accum = ctx->accum;
-    st->symbol_count = ctx->accum_count;
-    st->dc_est = ctx->dc;
-    st->symbol_clock = ctx->clock;
+    (void)st;
 }
 
 static float
@@ -858,154 +102,63 @@ update_centered_frequency(float* dc_io, float freq) {
     return freq - *dc_io;
 }
 
-static int
-process_acquisition_window(dsd_fsk_modem_state* st, dsd_fsk_process_ctx* ctx, float centered, float* out_symbols,
-                           int* out_count, int max_symbols) {
-    if (st->timing_acquired || ctx->clock_i <= 0) {
-        return 0;
+static float
+clip_pcm_float(float sample) {
+    if (sample > 32767.0f) {
+        return 32767.0f;
     }
-    if (st->acq_len < DSD_FSK_MODEM_ACQ_MAX_SAMPLES) {
-        st->acq_freq[st->acq_len++] = centered;
+    if (sample < -32768.0f) {
+        return -32768.0f;
     }
-    if (st->acq_len >= ctx->acq_target) {
-        *out_count = emit_acquisition_symbols(st, ctx->clock_i, out_symbols, *out_count, max_symbols);
-        if (st->timing_acquired) {
-            ctx->phase = st->symbol_phase;
-            ctx->accum = st->symbol_accum;
-            ctx->accum_count = st->symbol_count;
-        }
-    }
-    return 1;
+    return sample;
 }
 
-static void
-normalize_symbol_phase(float* phase_io, float clock) {
-    if (*phase_io >= clock) {
-        *phase_io -= clock;
-        if (*phase_io >= clock) {
-            *phase_io = fmodf(*phase_io, clock);
+static float
+scale_discriminator_sample(dsd_fsk_modem_state* st, float centered) {
+    float mag = fabsf(centered);
+    if (mag > DSD_FSK_DISCRIMINATOR_MIN_PEAK) {
+        if (st->discriminator_peak_est <= DSD_FSK_DISCRIMINATOR_MIN_PEAK) {
+            st->discriminator_peak_est = mag;
+        } else if (mag > st->discriminator_peak_est) {
+            st->discriminator_peak_est += 0.125f * (mag - st->discriminator_peak_est);
+        } else {
+            st->discriminator_peak_est += 0.00005f * (mag - st->discriminator_peak_est);
         }
     }
-}
-
-static void
-process_tracking_window(dsd_fsk_modem_state* st, dsd_fsk_process_ctx* ctx, float centered, float* out_symbols,
-                        int* out_count, int max_symbols) {
-    float sample_phase = ctx->phase;
-    ctx->accum += centered;
-    ctx->accum_count++;
-    ctx->phase += 1.0f;
-    if (ctx->phase >= ctx->clock) {
-        float raw_symbol = symbol_average_or_zero(ctx->accum, ctx->accum_count);
-        *out_count = emit_symbol(st, raw_symbol, out_symbols, *out_count, max_symbols);
-        ctx->accum = 0.0f;
-        ctx->accum_count = 0;
-        normalize_symbol_phase(&ctx->phase, ctx->clock);
+    float peak = st->discriminator_peak_est;
+    if (peak <= DSD_FSK_DISCRIMINATOR_MIN_PEAK) {
+        peak = 1.0f;
     }
-    if (maybe_track_symbol_timing(st, centered, ctx->clock_i, sample_phase, &ctx->phase)) {
-        ctx->phase = st->symbol_phase;
-        ctx->accum = st->symbol_accum;
-        ctx->accum_count = st->symbol_count;
-    }
+    return clip_pcm_float(centered * (DSD_FSK_DISCRIMINATOR_TARGET / peak));
 }
 
 int
-dsd_fsk_modem_process(dsd_fsk_modem_state* st, const float* iq_interleaved, int len_interleaved, float* out_symbols,
-                      int max_symbols) {
-    if (!st || !out_symbols || max_symbols <= 0) {
+dsd_fsk_modem_discriminator_process(dsd_fsk_modem_state* st, const float* iq_interleaved, int len_interleaved,
+                                    float* out_samples, int max_samples) {
+    if (!st || !out_samples || max_samples <= 0 || !iq_interleaved || len_interleaved < 2) {
         return 0;
     }
 
-    int out_count = drain_pending_symbols(st, out_symbols, 0, max_symbols);
-    if (!iq_interleaved || len_interleaved < 2) {
-        return out_count;
-    }
-
-    dsd_fsk_process_ctx ctx = process_ctx_load(st);
     int pairs = len_interleaved >> 1;
-    for (int n = 0; n < pairs; n++) {
+    int out_count = 0;
+    for (int n = 0; n < pairs && out_count < max_samples; n++) {
         float cur_i = iq_interleaved[(n << 1) + 0];
         float cur_q = iq_interleaved[(n << 1) + 1];
 
-        if (!ctx.have_prev) {
-            ctx.prev_i = cur_i;
-            ctx.prev_q = cur_q;
-            ctx.have_prev = 1;
+        if (!st->have_prev) {
+            st->prev_i = cur_i;
+            st->prev_q = cur_q;
+            st->have_prev = 1;
+            out_samples[out_count++] = 0.0f;
             continue;
         }
 
-        float freq = discriminator_frequency(cur_i, cur_q, ctx.prev_i, ctx.prev_q);
-        float centered = update_centered_frequency(&ctx.dc, freq);
-
-        if (process_acquisition_window(st, &ctx, centered, out_symbols, &out_count, max_symbols)) {
-            ctx.prev_i = cur_i;
-            ctx.prev_q = cur_q;
-            continue;
-        }
-
-        process_tracking_window(st, &ctx, centered, out_symbols, &out_count, max_symbols);
-        ctx.prev_i = cur_i;
-        ctx.prev_q = cur_q;
+        float freq = discriminator_frequency(cur_i, cur_q, st->prev_i, st->prev_q);
+        float centered = update_centered_frequency(&st->dc_est, freq);
+        out_samples[out_count++] = scale_discriminator_sample(st, centered);
+        st->prev_i = cur_i;
+        st->prev_q = cur_q;
     }
 
-    process_ctx_store(st, &ctx);
     return out_count;
-}
-
-int
-dsd_fsk_modem_zero_symbols(dsd_fsk_modem_state* st, int input_complex_samples, float* out_symbols, int max_symbols) {
-    if (!st || !out_symbols || input_complex_samples <= 0 || max_symbols <= 0) {
-        return 0;
-    }
-    float clock = st->symbol_clock > 0.0f ? st->symbol_clock : modem_symbol_clock(&st->cfg);
-    int n = (int)ceilf((float)input_complex_samples / clock);
-    if (n < 1) {
-        n = 1;
-    }
-    if (n > max_symbols) {
-        n = max_symbols;
-    }
-    for (int i = 0; i < n; i++) {
-        out_symbols[i] = 0.0f;
-    }
-    st->symbol_phase = 0.0f;
-    st->symbol_accum = 0.0f;
-    st->symbol_count = 0;
-    st->last_symbol = 0.0f;
-    clear_pending_symbols(st);
-    clear_tracking_window(st);
-    st->track_last_error = 0.0f;
-    st->track_last_score = 0.0f;
-    st->track_consecutive_skips = 0;
-    clear_signal_level_reference(st);
-    st->prev_i = 0.0f;
-    st->prev_q = 0.0f;
-    st->have_prev = 0;
-    st->acq_len = 0;
-    st->timing_acquired = modem_should_acquire_timing(&st->cfg, clock) ? 0 : 1;
-    reset_soft_metrics(st);
-    st->symbols_emitted += (uint64_t)n;
-    return n;
-}
-
-int
-dsd_fsk_modem_get_metrics(const dsd_fsk_modem_state* st, dsd_fsk_modem_metrics* out) {
-    if (!st || !out) {
-        return -1;
-    }
-    *out = st->metrics;
-    out->levels = st->cfg.levels;
-    out->symbol_rate_hz = st->cfg.symbol_rate_hz;
-    out->timing_acquired = st->timing_acquired;
-    out->track_last_error = st->track_last_error;
-    out->track_last_score = st->track_last_score;
-    out->track_updates = st->track_updates;
-    out->track_skips = st->track_skips;
-    out->abs_est = st->abs_est;
-    out->dc_est = st->dc_est;
-    out->last_symbol = st->last_symbol;
-    if (out->window_symbols == 0U) {
-        out->valid = 0;
-    }
-    return 0;
 }

--- a/src/dsp/fsk_modem.c
+++ b/src/dsp/fsk_modem.c
@@ -11,17 +11,18 @@
 #include <string.h>
 #include "dsd-neo/core/safe_api.h"
 
-#define DSD_FSK_TRACK_SYMBOLS             64
-#define DSD_FSK_TRACK_MIN_SCORE           1.0e-4f
-#define DSD_FSK_TRACK_MIN_RATIO           1.10f
-#define DSD_FSK_TRACK_SOFT_MIN_RATIO      1.02f
-#define DSD_FSK_TRACK_SOFT_MIN_CONFIDENCE 0.25f
-#define DSD_FSK_TRACK_GAIN                0.125f
-#define DSD_FSK_TRACK_MAX_CORRECTION      0.25f
-#define DSD_FSK_TRACK_SOFT_MAX_CORRECTION 0.125f
-#define DSD_FSK_TRACK_REACQUIRE_SKIPS     32ULL
-#define DSD_FSK_METRICS_WINDOW            256U
-#define DSD_FSK_LOW_RELIABILITY           128U
+#define DSD_FSK_TRACK_SYMBOLS              64
+#define DSD_FSK_TRACK_MIN_SCORE            1.0e-4f
+#define DSD_FSK_TRACK_MIN_RATIO            1.10f
+#define DSD_FSK_TRACK_SOFT_MIN_RATIO       1.02f
+#define DSD_FSK_TRACK_SOFT_MIN_CONFIDENCE  0.25f
+#define DSD_FSK_TRACK_GAIN                 0.125f
+#define DSD_FSK_TRACK_MAX_CORRECTION       0.25f
+#define DSD_FSK_TRACK_SOFT_MAX_CORRECTION  0.125f
+#define DSD_FSK_TRACK_REACQUIRE_SKIPS      32ULL
+#define DSD_FSK_TRACK_SIGNAL_LOSS_FRACTION 0.20f
+#define DSD_FSK_METRICS_WINDOW             256U
+#define DSD_FSK_LOW_RELIABILITY            128U
 
 static int
 clamp_levels(int levels) {
@@ -480,6 +481,7 @@ typedef struct {
     float ratio;
     float err;
     float confidence;
+    float mean_abs;
     int accept;
 } dsd_fsk_track_eval;
 
@@ -502,6 +504,18 @@ track_score_ratio(float best_score, float second_score) {
         return best_score / second_score;
     }
     return (best_score > 0.0f) ? 1000.0f : 0.0f;
+}
+
+static float
+track_mean_abs_freq(const float* freq, int n) {
+    double sum = 0.0;
+    if (!freq || n <= 0) {
+        return 0.0f;
+    }
+    for (int i = 0; i < n; i++) {
+        sum += fabs((double)freq[i]);
+    }
+    return (float)(sum / (double)n);
 }
 
 static float
@@ -551,9 +565,50 @@ track_compute_eval(const dsd_fsk_modem_state* st, int clock_i) {
     eval.ratio = track_score_ratio(eval.best_score, second_score);
     eval.err = wrap_timing_error((float)(eval.best_phase - eval.expected_phase), clock_i);
     eval.confidence = track_correction_confidence(eval.ratio);
+    eval.mean_abs = track_mean_abs_freq(st->track_freq, st->track_len);
     eval.accept = (eval.best_score >= DSD_FSK_TRACK_MIN_SCORE && eval.ratio >= DSD_FSK_TRACK_SOFT_MIN_RATIO
                    && fabsf(eval.err) <= 2.0f);
     return eval;
+}
+
+static int
+track_eval_is_hard_accept(const dsd_fsk_track_eval* eval) {
+    return eval && eval->accept && eval->ratio >= DSD_FSK_TRACK_MIN_RATIO;
+}
+
+static int
+track_score_has_signal_loss(const dsd_fsk_modem_state* st, float score) {
+    if (!st) {
+        return 0;
+    }
+    float ref = (st->track_signal_ref > 1.0e-7f) ? st->track_signal_ref : st->abs_est;
+    if (ref <= 1.0e-7f) {
+        return score < DSD_FSK_TRACK_MIN_SCORE;
+    }
+    return score < (ref * DSD_FSK_TRACK_SIGNAL_LOSS_FRACTION);
+}
+
+static int
+track_eval_has_signal_loss(const dsd_fsk_modem_state* st, const dsd_fsk_track_eval* eval) {
+    if (!st || !eval) {
+        return 0;
+    }
+    return track_score_has_signal_loss(st, eval->mean_abs);
+}
+
+static void
+track_update_signal_ref(dsd_fsk_modem_state* st, float mean_abs) {
+    if (!st || mean_abs < DSD_FSK_TRACK_MIN_SCORE) {
+        return;
+    }
+    if (st->track_signal_ref <= 1.0e-7f) {
+        st->track_signal_ref = mean_abs;
+        return;
+    }
+    if (mean_abs < (st->track_signal_ref * DSD_FSK_TRACK_SIGNAL_LOSS_FRACTION)) {
+        return;
+    }
+    st->track_signal_ref += 0.05f * (mean_abs - st->track_signal_ref);
 }
 
 static float
@@ -592,17 +647,17 @@ track_log_accept(const dsd_fsk_modem_state* st, int clock_i, const dsd_fsk_track
     if (debug_fsk_acq_enabled()) {
         DSD_FPRINTF(stderr,
                     "[FSKTRACK] clock=%d best=%d expect=%d err=%.3f corr=%.3f score=%.5f ratio=%.3f conf=%.3f "
-                    "updates=%llu\n",
+                    "mean=%.5f updates=%llu\n",
                     clock_i, eval->best_phase, eval->expected_phase, eval->err, correction, eval->best_score,
-                    eval->ratio, eval->confidence, (unsigned long long)st->track_updates);
+                    eval->ratio, eval->confidence, eval->mean_abs, (unsigned long long)st->track_updates);
     }
 }
 
 static void
 track_log_skip(const dsd_fsk_modem_state* st, int clock_i, const dsd_fsk_track_eval* eval) {
     if (debug_fsk_acq_enabled()) {
-        DSD_FPRINTF(stderr, "[FSKTRACK] skip clock=%d best=%d expect=%d score=%.5f ratio=%.3f skips=%llu\n", clock_i,
-                    eval->best_phase, eval->expected_phase, eval->best_score, eval->ratio,
+        DSD_FPRINTF(stderr, "[FSKTRACK] skip clock=%d best=%d expect=%d score=%.5f ratio=%.3f mean=%.5f skips=%llu\n",
+                    clock_i, eval->best_phase, eval->expected_phase, eval->best_score, eval->ratio, eval->mean_abs,
                     (unsigned long long)st->track_skips);
     }
 }
@@ -610,9 +665,10 @@ track_log_skip(const dsd_fsk_modem_state* st, int clock_i, const dsd_fsk_track_e
 static void
 track_log_reacquire(const dsd_fsk_modem_state* st, int clock_i, const dsd_fsk_track_eval* eval) {
     if (debug_fsk_acq_enabled()) {
-        DSD_FPRINTF(stderr, "[FSKREACQ] clock=%d best=%d expect=%d err=%.3f score=%.5f ratio=%.3f skips=%llu\n",
+        DSD_FPRINTF(stderr,
+                    "[FSKREACQ] clock=%d best=%d expect=%d err=%.3f score=%.5f ratio=%.3f mean=%.5f skips=%llu\n",
                     clock_i, eval->best_phase, eval->expected_phase, eval->err, eval->best_score, eval->ratio,
-                    (unsigned long long)st->track_skips);
+                    eval->mean_abs, (unsigned long long)st->track_skips);
     }
 }
 
@@ -684,25 +740,37 @@ maybe_track_symbol_timing(dsd_fsk_modem_state* st, float centered, int clock_i, 
     }
 
     dsd_fsk_track_eval eval = track_compute_eval(st, clock_i);
+    int signal_loss = track_eval_has_signal_loss(st, &eval);
+    if (!signal_loss) {
+        track_update_signal_ref(st, eval.mean_abs);
+    }
     if (eval.accept) {
         float correction = track_gain_correction(eval.err, eval.confidence, eval.ratio);
         correction = track_apply_correction(st, phase_io, correction);
         st->track_last_error = eval.err;
         st->track_last_score = eval.best_score;
         st->track_updates++;
-        st->track_consecutive_skips = 0;
+        if (track_eval_is_hard_accept(&eval) || !signal_loss) {
+            st->track_consecutive_skips = 0;
+        } else {
+            st->track_consecutive_skips++;
+        }
         track_log_accept(st, clock_i, &eval, correction);
     } else {
         st->track_last_error = 0.0f;
         st->track_last_score = eval.best_score;
         st->track_skips++;
-        st->track_consecutive_skips++;
-        track_log_skip(st, clock_i, &eval);
-        if (st->track_consecutive_skips >= DSD_FSK_TRACK_REACQUIRE_SKIPS) {
-            track_log_reacquire(st, clock_i, &eval);
-            reset_symbol_timing_for_reacquisition(st, phase_io);
-            return 1;
+        if (signal_loss) {
+            st->track_consecutive_skips++;
+        } else {
+            st->track_consecutive_skips = 0;
         }
+        track_log_skip(st, clock_i, &eval);
+    }
+    if (signal_loss && st->track_consecutive_skips >= DSD_FSK_TRACK_REACQUIRE_SKIPS) {
+        track_log_reacquire(st, clock_i, &eval);
+        reset_symbol_timing_for_reacquisition(st, phase_io);
+        return 1;
     }
     clear_tracking_window(st);
     return 0;
@@ -714,10 +782,13 @@ emit_acquisition_symbols(dsd_fsk_modem_state* st, int clock_i, float* out_symbol
     float second_score = 0.0f;
     int phase = acquire_symbol_phase_scored(st->acq_freq, st->acq_len, clock_i, &score, &second_score);
     float ratio = track_score_ratio(score, second_score);
-    if (score < DSD_FSK_TRACK_MIN_SCORE && st->acq_len < DSD_FSK_MODEM_ACQ_MAX_SAMPLES) {
+    if (track_score_has_signal_loss(st, score)) {
         if (debug_fsk_acq_enabled()) {
             DSD_FPRINTF(stderr, "[FSKACQ] wait clock=%d phase=%d score=%.5f ratio=%.3f samples=%d\n", clock_i, phase,
                         score, ratio, st->acq_len);
+        }
+        if (st->acq_len >= DSD_FSK_MODEM_ACQ_MAX_SAMPLES) {
+            st->acq_len = 0;
         }
         return out_count;
     }
@@ -754,6 +825,7 @@ emit_acquisition_symbols(dsd_fsk_modem_state* st, int clock_i, float* out_symbol
     }
     st->acq_len = 0;
     st->timing_acquired = 1;
+    track_update_signal_ref(st, score);
     clear_tracking_window(st);
 
     if (debug_fsk_acq_enabled()) {

--- a/src/dsp/snr_estimator.cpp
+++ b/src/dsp/snr_estimator.cpp
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/dsp/snr_estimator.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <stdlib.h>
+
+namespace {
+
+constexpr double kInvalidSnrDb = -100.0;
+constexpr int kMaxSnrSamples = 8192;
+
+int
+valid_sps(int samples_per_symbol) {
+    return samples_per_symbol >= 1 && samples_per_symbol <= 64;
+}
+
+int
+normalized_phase_window(int samples_per_symbol, int phase_window) {
+    int win = phase_window;
+    if (win < 0) {
+        win = samples_per_symbol / 10;
+    }
+    if (samples_per_symbol > 1 && win < 1) {
+        win = 1;
+    }
+    int max_win = samples_per_symbol / 2;
+    if (win > max_win) {
+        win = max_win;
+    }
+    return win;
+}
+
+int
+circular_phase_distance(int a, int b, int samples_per_symbol) {
+    int d = std::abs(a - b);
+    int wrapped = samples_per_symbol - d;
+    return (d < wrapped) ? d : wrapped;
+}
+
+int
+collect_phase_samples(const float* samples, int sample_count, int samples_per_symbol, int phase, int phase_window,
+                      float* vals, int max_vals) {
+    int count = 0;
+    for (int i = 0; i < sample_count && count < max_vals; i++) {
+        if (samples_per_symbol > 1) {
+            int sample_phase = i % samples_per_symbol;
+            if (circular_phase_distance(sample_phase, phase, samples_per_symbol) > phase_window) {
+                continue;
+            }
+        }
+        float v = samples[i];
+        if (std::isfinite(v)) {
+            vals[count++] = v;
+        }
+    }
+    return count;
+}
+
+double
+percentile_value(float* vals, int count, int index) {
+    if (index < 0) {
+        index = 0;
+    } else if (index >= count) {
+        index = count - 1;
+    }
+    std::nth_element(vals, vals + index, vals + count);
+    return vals[index];
+}
+
+template <int Levels>
+int
+nearest_center(double sample, const double (&centers)[Levels]) {
+    int best = 0;
+    double best_dist = std::abs(sample - centers[0]);
+    for (int i = 1; i < Levels; i++) {
+        double dist = std::abs(sample - centers[i]);
+        if (dist < best_dist) {
+            best = i;
+            best_dist = dist;
+        }
+    }
+    return best;
+}
+
+template <int Levels>
+int
+kmeans_assign(const float* vals, int count, const double (&centers)[Levels], int* assignments, double (&sum)[Levels],
+              int (&cnt)[Levels]) {
+    for (int i = 0; i < Levels; i++) {
+        sum[i] = 0.0;
+        cnt[i] = 0;
+    }
+    for (int i = 0; i < count; i++) {
+        int b = nearest_center((double)vals[i], centers);
+        assignments[i] = b;
+        sum[b] += vals[i];
+        cnt[b]++;
+    }
+    for (int i = 0; i < Levels; i++) {
+        if (cnt[i] <= 0) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+template <int Levels>
+int
+kmeans_refine(const float* vals, int count, double (&centers)[Levels], int* assignments, int (&cnt)[Levels]) {
+    double sum[Levels];
+    for (int iter = 0; iter < 8; iter++) {
+        if (!kmeans_assign(vals, count, centers, assignments, sum, cnt)) {
+            return 0;
+        }
+        for (int i = 0; i < Levels; i++) {
+            centers[i] = sum[i] / (double)cnt[i];
+        }
+        std::sort(centers, centers + Levels);
+    }
+    return kmeans_assign(vals, count, centers, assignments, sum, cnt);
+}
+
+template <int Levels>
+double
+signal_variance(const double (&mu)[Levels], const int (&cnt)[Levels], int total) {
+    double mean = 0.0;
+    for (int b = 0; b < Levels; b++) {
+        mean += mu[b] * (double)cnt[b] / (double)total;
+    }
+
+    double signal = 0.0;
+    for (int b = 0; b < Levels; b++) {
+        double d = mu[b] - mean;
+        signal += (double)cnt[b] * d * d;
+    }
+    return signal / (double)total;
+}
+
+double
+estimate_c4fm_values_db(float* vals, int count, double bias_db) {
+    if (!vals || count <= 32) {
+        return kInvalidSnrDb;
+    }
+
+    double mu[4] = {percentile_value(vals, count, count / 8), percentile_value(vals, count, (3 * count) / 8),
+                    percentile_value(vals, count, (5 * count) / 8), percentile_value(vals, count, (7 * count) / 8)};
+    std::sort(mu, mu + 4);
+    std::array<int, kMaxSnrSamples> assignments{};
+    int cnt[4] = {0, 0, 0, 0};
+    if (!kmeans_refine(vals, count, mu, assignments.data(), cnt)) {
+        return kInvalidSnrDb;
+    }
+
+    double noise = 0.0;
+    for (int i = 0; i < count; i++) {
+        double e = (double)vals[i] - mu[assignments[(size_t)i]];
+        noise += e * e;
+    }
+    int total = cnt[0] + cnt[1] + cnt[2] + cnt[3];
+    double noise_var = noise / (double)total;
+    double sig_var = signal_variance(mu, cnt, total);
+    if (!(noise_var > 1e-9 && sig_var > 1e-9)) {
+        return kInvalidSnrDb;
+    }
+    return 10.0 * std::log10(sig_var / noise_var) - bias_db;
+}
+
+double
+estimate_gfsk_values_db(float* vals, int count, double bias_db) {
+    if (!vals || count <= 32) {
+        return kInvalidSnrDb;
+    }
+
+    double mu[2] = {percentile_value(vals, count, count / 4), percentile_value(vals, count, (3 * count) / 4)};
+    std::sort(mu, mu + 2);
+    std::array<int, kMaxSnrSamples> assignments{};
+    int cnt[2] = {0, 0};
+    if (!kmeans_refine(vals, count, mu, assignments.data(), cnt)) {
+        return kInvalidSnrDb;
+    }
+
+    double noise = 0.0;
+    for (int i = 0; i < count; i++) {
+        double e = (double)vals[i] - mu[assignments[(size_t)i]];
+        noise += e * e;
+    }
+    int total = cnt[0] + cnt[1];
+    double noise_var = noise / (double)total;
+    double sig_var = signal_variance(mu, cnt, total);
+    if (!(noise_var > 1e-9 && sig_var > 1e-9)) {
+        return kInvalidSnrDb;
+    }
+    return 10.0 * std::log10(sig_var / noise_var) - bias_db;
+}
+
+template <typename EstimateFn>
+double
+estimate_best_phase_db(const float* samples, int sample_count, int samples_per_symbol, int phase_window, double bias_db,
+                       EstimateFn estimate_fn) {
+    if (!samples || sample_count <= 64 || !valid_sps(samples_per_symbol) || !std::isfinite(bias_db)) {
+        return kInvalidSnrDb;
+    }
+
+    int win = normalized_phase_window(samples_per_symbol, phase_window);
+    int phases = samples_per_symbol;
+    std::array<float, kMaxSnrSamples> vals{};
+    double best = kInvalidSnrDb;
+    for (int phase = 0; phase < phases; phase++) {
+        int count =
+            collect_phase_samples(samples, sample_count, samples_per_symbol, phase, win, vals.data(), (int)vals.size());
+        if (count <= 32) {
+            continue;
+        }
+        double snr = estimate_fn(vals.data(), count, bias_db);
+        if (snr > best) {
+            best = snr;
+        }
+    }
+    return best;
+}
+
+} // namespace
+
+extern "C" double
+dsd_snr_estimate_c4fm_real_db(const float* samples, int sample_count, int samples_per_symbol, int phase_window,
+                              double bias_db) {
+    return estimate_best_phase_db(samples, sample_count, samples_per_symbol, phase_window, bias_db,
+                                  estimate_c4fm_values_db);
+}
+
+extern "C" double
+dsd_snr_estimate_gfsk_real_db(const float* samples, int sample_count, int samples_per_symbol, int phase_window,
+                              double bias_db) {
+    return estimate_best_phase_db(samples, sample_count, samples_per_symbol, phase_window, bias_db,
+                                  estimate_gfsk_values_db);
+}

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -131,6 +131,14 @@ dsd_parse_double_arg(const char* token, double* out) {
 }
 
 #ifdef USE_RADIO
+/*
+ * The RTL FSK modem handles normal timing reacquisition locally. This fallback
+ * clears queued RTL output, so keep it as a last-resort watchdog for sustained
+ * no-sync periods instead of firing inside short DMR call gaps.
+ */
+static const double RTL_FSK_NO_SYNC_REACQUIRE_GAP_S = 10.000;
+static const double RTL_FSK_NO_SYNC_REACQUIRE_COOLDOWN_S = 0.750;
+
 static time_t
 max_time_t(time_t a, time_t b) {
     return (a > b) ? a : b;
@@ -197,9 +205,6 @@ rtl_fsk_reacquire_gap_ready(const dsd_state* state, double nowm, double gap_s, d
 
 static void
 maybe_request_rtl_fsk_reacquire_on_no_sync(const dsd_opts* opts, dsd_state* state, time_t now) {
-    const double gap_s = 0.300;
-    const double cooldown_s = 0.750;
-
     if (!opts || !state || opts->audio_in_type != AUDIO_IN_RTL || !state->rtl_ctx) {
         return;
     }
@@ -229,7 +234,8 @@ maybe_request_rtl_fsk_reacquire_on_no_sync(const dsd_opts* opts, dsd_state* stat
         state->rtl_fsk_reacquire_gap_start_m = nowm;
         return;
     }
-    if (!rtl_fsk_reacquire_gap_ready(state, nowm, gap_s, cooldown_s)) {
+    if (!rtl_fsk_reacquire_gap_ready(state, nowm, RTL_FSK_NO_SYNC_REACQUIRE_GAP_S,
+                                     RTL_FSK_NO_SYNC_REACQUIRE_COOLDOWN_S)) {
         return;
     }
     if (rtl_stream_request_fsk_reacquire() > 0) {

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1637,6 +1637,9 @@ no_carrier_reset_decode_state(dsd_state* state, int preserve_dmr_confidence) {
     state->max = 15000;
     state->min = -15000;
     state->center = 0;
+    state->rtl_fsk_sps_num = 0;
+    state->rtl_fsk_sps_den = 0;
+    state->rtl_fsk_sps_accum = 0;
     state->m17_polarity = 0;
     state->err_str[0] = '\0';
     state->err_strR[0] = '\0';

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -155,7 +155,7 @@ rtl_fsk_reacquire_output_is_fsk(void) {
     if (output_kind == 0) {
         output_kind = rtl_stream_get_output_kind();
     }
-    return output_kind == RTL_STREAM_OUTPUT_SYMBOL_FSK;
+    return output_kind == RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
 }
 
 static void

--- a/src/io/radio/rtl_demod_config.cpp
+++ b/src/io/radio/rtl_demod_config.cpp
@@ -274,10 +274,10 @@ demod_apply_output_kind(struct demod_state* s, const dsd_opts* opts) {
         s->output_kind = DSD_DEMOD_OUTPUT_SYMBOL_CQPSK;
         s->symbol_levels = 4;
     } else {
-        s->output_kind = DSD_DEMOD_OUTPUT_SYMBOL_FSK;
+        s->output_kind = DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
     }
 
-    if (s->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK) {
+    if (s->output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
         s->cqpsk_enable = 0;
         s->ted_enabled = 0;
     } else if (s->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK) {
@@ -548,7 +548,7 @@ demod_apply_channel_lpf_defaults(struct demod_state* demod, const dsd_opts* opts
 static void
 demod_finalize_runtime_profile(struct demod_state* demod, const dsd_opts* opts) {
     demod->channel_squelch_level = (float)opts->rtl_squelch_level;
-    if (demod->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK) {
+    if (demod->output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
         demod->ted_enabled = 0;
     }
     fsk_modem_apply_config(demod);
@@ -702,7 +702,8 @@ rtl_demod_disable_resampler(struct demod_state* demod, int reset_ratio) {
 
 static int
 rtl_demod_should_skip_resampler(const struct demod_state* demod) {
-    return (demod->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK || demod->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK);
+    return (demod->output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR
+            || demod->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK);
 }
 
 static void

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -880,6 +880,7 @@ rtl_publish_cu8_input_level(const struct rtl_device* s, const uint8_t* samples, 
     }
 }
 
+#ifdef USE_SOAPYSDR
 static inline void
 rtl_publish_cf32_input_level_source(const float* samples, size_t count, dsd_input_level_source source) {
     dsd_input_level_snapshot snapshot;
@@ -891,7 +892,6 @@ rtl_publish_cf32_input_level_source(const float* samples, size_t count, dsd_inpu
     }
 }
 
-#ifdef USE_SOAPYSDR
 static inline void
 rtl_publish_cs16_input_level(const int16_t* samples, size_t count) {
     dsd_input_level_snapshot snapshot;

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -909,19 +909,28 @@ rtl_publish_cf32_input_level(const float* samples, size_t count) {
 }
 #endif
 
-static inline void
-rtl_publish_replay_input_level(const struct rtl_device* s, const uint8_t* raw_block, size_t raw_bytes,
-                               const float* f32_block, int f32_count) {
-    if (!s) {
-        return;
+static inline int
+rtl_prepare_replay_input_level_snapshot(const struct rtl_device* s, const uint8_t* raw_block, size_t raw_bytes,
+                                        float* scratch_f32, size_t scratch_cap_f32, dsd_input_level_snapshot* out) {
+    if (!s || !raw_block || raw_bytes == 0U || !out) {
+        return -1;
     }
     if (s->replay_cfg.format == DSD_IQ_FORMAT_CU8) {
-        rtl_publish_cu8_input_level(s, raw_block, raw_bytes);
-        return;
+        return dsd_input_level_metrics_from_cu8(raw_block, raw_bytes, rtl_u8_input_level_source(s), out);
     }
-    if (s->replay_cfg.format == DSD_IQ_FORMAT_CF32 && f32_count > 0) {
-        rtl_publish_cf32_input_level_source(f32_block, (size_t)f32_count, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32);
+    if (s->replay_cfg.format == DSD_IQ_FORMAT_CF32) {
+        if (!scratch_f32 || (raw_bytes & 7U) != 0U
+            || strcmp(s->replay_cfg.capture_stage, "post_driver_cf32_pre_ring") != 0) {
+            return -1;
+        }
+        size_t float_count = raw_bytes / sizeof(float);
+        if (float_count == 0U || float_count > scratch_cap_f32) {
+            return -1;
+        }
+        DSD_MEMCPY(scratch_f32, raw_block, float_count * sizeof(float));
+        return dsd_input_level_metrics_from_cf32(scratch_f32, float_count, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32, out);
     }
+    return -1;
 }
 
 static inline void
@@ -1590,12 +1599,20 @@ replay_thread_process_block(struct rtl_device* s, uint8_t* raw_block, size_t raw
         return 2;
     }
 
+    dsd_input_level_snapshot input_level;
+    DSD_MEMSET(&input_level, 0, sizeof(input_level));
+    int have_input_level =
+        (rtl_prepare_replay_input_level_snapshot(s, raw_block, out_bytes, f32_block, raw_block_bytes, &input_level)
+         == 0);
+
     int produced = replay_convert_block_to_f32(s, raw_block, out_bytes, f32_block, raw_block_bytes, io->phase,
                                                io->have_carry, io->carry_byte);
     if (produced <= 0) {
         return 2;
     }
-    rtl_publish_replay_input_level(s, raw_block, out_bytes, f32_block, produced);
+    if (have_input_level) {
+        rtl_stream_input_level_publish(&input_level);
+    }
 
     if (replay_enqueue_f32_no_drop(s, f32_block, (size_t)produced, io->complex_written, *io->start_ns, io->realtime)
         != 0) {

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -880,6 +880,17 @@ rtl_publish_cu8_input_level(const struct rtl_device* s, const uint8_t* samples, 
     }
 }
 
+static inline void
+rtl_publish_cf32_input_level_source(const float* samples, size_t count, dsd_input_level_source source) {
+    dsd_input_level_snapshot snapshot;
+    if (!samples || count == 0U) {
+        return;
+    }
+    if (dsd_input_level_metrics_from_cf32(samples, count, source, &snapshot) == 0) {
+        rtl_stream_input_level_publish(&snapshot);
+    }
+}
+
 #ifdef USE_SOAPYSDR
 static inline void
 rtl_publish_cs16_input_level(const int16_t* samples, size_t count) {
@@ -894,15 +905,24 @@ rtl_publish_cs16_input_level(const int16_t* samples, size_t count) {
 
 static inline void
 rtl_publish_cf32_input_level(const float* samples, size_t count) {
-    dsd_input_level_snapshot snapshot;
-    if (!samples || count == 0U) {
-        return;
-    }
-    if (dsd_input_level_metrics_from_cf32(samples, count, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32, &snapshot) == 0) {
-        rtl_stream_input_level_publish(&snapshot);
-    }
+    rtl_publish_cf32_input_level_source(samples, count, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32);
 }
 #endif
+
+static inline void
+rtl_publish_replay_input_level(const struct rtl_device* s, const uint8_t* raw_block, size_t raw_bytes,
+                               const float* f32_block, int f32_count) {
+    if (!s) {
+        return;
+    }
+    if (s->replay_cfg.format == DSD_IQ_FORMAT_CU8) {
+        rtl_publish_cu8_input_level(s, raw_block, raw_bytes);
+        return;
+    }
+    if (s->replay_cfg.format == DSD_IQ_FORMAT_CF32 && f32_count > 0) {
+        rtl_publish_cf32_input_level_source(f32_block, (size_t)f32_count, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32);
+    }
+}
 
 static inline void
 rtl_copy_event_reason(char* dst, size_t dst_size, const char* reason) {
@@ -1575,6 +1595,7 @@ replay_thread_process_block(struct rtl_device* s, uint8_t* raw_block, size_t raw
     if (produced <= 0) {
         return 2;
     }
+    rtl_publish_replay_input_level(s, raw_block, out_bytes, f32_block, produced);
 
     if (replay_enqueue_f32_no_drop(s, f32_block, (size_t)produced, io->complex_written, *io->start_ns, io->realtime)
         != 0) {

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -319,6 +319,7 @@ static int controller_apply_replay_settings(struct controller_state* s, const ds
                                             const dsd_iq_replay_config* cfg);
 static const int kRetuneDiagBlocks = 20;
 static uint32_t rtl_stream_bump_output_generation(void);
+static void rtl_stream_signal_output_waiters(struct output_state* outp);
 static void rtl_stream_clear_retune_profile(RtlRetuneProfile* profile);
 static int rtl_stream_take_pending_retune_profile(RtlRetuneProfile* out_profile, uint32_t request_id,
                                                   uint32_t target_freq_hz);
@@ -7164,10 +7165,52 @@ rtl_stream_disable_cqpsk_mode(void) {
     }
 }
 
+static void
+rtl_stream_clear_output_for_demod_family_switch(void) {
+    struct output_state* outp = &output;
+    if (g_stream && g_stream->output) {
+        outp = g_stream->output;
+    }
+    rtl_stream_clear_output_ring(outp, 1);
+    if (demod.output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
+        rtl_stream_queue_fsk_modem_reset();
+    }
+}
+
+static int
+rtl_stream_enter_demod_family_switch_gate(void) {
+    if (!g_stream) {
+        return 0;
+    }
+    int expected = 0;
+    if (!controller.retune_in_progress.compare_exchange_strong(expected, 1, std::memory_order_acq_rel,
+                                                               std::memory_order_acquire)) {
+        controller_wait_for_demod_idle(&controller);
+        return 0;
+    }
+    rtl_stream_signal_output_waiters(g_stream && g_stream->output ? g_stream->output : &output);
+    controller_wait_for_demod_idle(&controller);
+    return 1;
+}
+
+static void
+rtl_stream_leave_demod_family_switch_gate(int gate_armed) {
+    if (!gate_armed) {
+        return;
+    }
+    controller.retune_in_progress.store(0, std::memory_order_release);
+    if (input_ring.buffer && input_ring.capacity > 0U) {
+        safe_cond_signal(&input_ring.ready, &input_ring.ready_m);
+    }
+}
+
 extern "C" void
 rtl_stream_toggle_cqpsk(int onoff) {
     int was = demod.cqpsk_enable ? 1 : 0;
-    demod.cqpsk_enable = onoff ? 1 : 0;
+    int next = onoff ? 1 : 0;
+    int changed = (next != was) ? 1 : 0;
+    int gate_armed = changed ? rtl_stream_enter_demod_family_switch_gate() : 0;
+    demod.cqpsk_enable = next;
     if (demod.cqpsk_enable) {
         rtl_stream_enable_cqpsk_mode();
     } else {
@@ -7178,7 +7221,9 @@ rtl_stream_toggle_cqpsk(int onoff) {
      * This keeps loop state consistent when switching between FM and CQPSK paths. */
     if (demod.cqpsk_enable != was) {
         demod.costas_reset_pending = 1;
+        rtl_stream_clear_output_for_demod_family_switch();
     }
+    rtl_stream_leave_demod_family_switch_gate(gate_armed);
 }
 
 static int
@@ -7977,6 +8022,156 @@ dsd_rtl_stream_test_clear_output_fsk_reset(size_t queued_samples, int* out_have_
     demod.fsk_modem_state = prev_modem;
     g_fsk_modem_reset_pending.store(prev_reset_pending, std::memory_order_release);
     fsk_reacquire_test_reset_output_state();
+    fsk_reacquire_test_cleanup_output_ring(initialized_output);
+    return 0;
+}
+
+namespace {
+struct CqpskToggleTestSnapshot {
+    int cqpsk;
+    int output_kind;
+    int symbol_rate_hz;
+    int symbol_levels;
+    int ted_enabled;
+    int channel_lpf_profile;
+    int costas_reset_pending;
+    void (*mode_demod)(struct demod_state*);
+    float cqpsk_diff_prev_r;
+    float cqpsk_diff_prev_j;
+    dsd_fsk_modem_state modem;
+    struct RtlSdrInternals* stream;
+    int retune_in_progress;
+    int reset_pending;
+    int cache_pending;
+    size_t output_head;
+    size_t output_tail;
+};
+} // namespace
+
+static void
+cqpsk_toggle_test_save(CqpskToggleTestSnapshot* s) {
+    s->cqpsk = demod.cqpsk_enable;
+    s->output_kind = demod.output_kind;
+    s->symbol_rate_hz = demod.symbol_rate_hz;
+    s->symbol_levels = demod.symbol_levels;
+    s->ted_enabled = demod.ted_enabled;
+    s->channel_lpf_profile = demod.channel_lpf_profile;
+    s->costas_reset_pending = demod.costas_reset_pending;
+    s->mode_demod = demod.mode_demod;
+    s->cqpsk_diff_prev_r = demod.cqpsk_diff_prev_r;
+    s->cqpsk_diff_prev_j = demod.cqpsk_diff_prev_j;
+    s->modem = demod.fsk_modem_state;
+    s->stream = g_stream;
+    s->retune_in_progress = controller.retune_in_progress.exchange(0, std::memory_order_acq_rel);
+    s->reset_pending = g_fsk_modem_reset_pending.exchange(0, std::memory_order_acq_rel);
+    s->cache_pending = dsd_rtl_stream_metrics_hook_symbol_cache_pending();
+    s->output_head = output.head.load(std::memory_order_acquire);
+    s->output_tail = output.tail.load(std::memory_order_acquire);
+}
+
+static void
+cqpsk_toggle_test_restore(const CqpskToggleTestSnapshot* s, int initialized_output) {
+    demod.cqpsk_enable = s->cqpsk;
+    demod.output_kind = s->output_kind;
+    demod.symbol_rate_hz = s->symbol_rate_hz;
+    demod.symbol_levels = s->symbol_levels;
+    demod.ted_enabled = s->ted_enabled;
+    demod.channel_lpf_profile = s->channel_lpf_profile;
+    demod.costas_reset_pending = s->costas_reset_pending;
+    demod.mode_demod = s->mode_demod;
+    demod.cqpsk_diff_prev_r = s->cqpsk_diff_prev_r;
+    demod.cqpsk_diff_prev_j = s->cqpsk_diff_prev_j;
+    demod.fsk_modem_state = s->modem;
+    g_stream = s->stream;
+    controller.retune_in_progress.store(s->retune_in_progress, std::memory_order_release);
+    g_fsk_modem_reset_pending.store(s->reset_pending, std::memory_order_release);
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_delta(s->cache_pending);
+    if (initialized_output) {
+        ring_clear(&output);
+    } else {
+        output.head.store(s->output_head, std::memory_order_release);
+        output.tail.store(s->output_tail, std::memory_order_release);
+    }
+}
+
+static void
+cqpsk_toggle_test_configure_stream(int active_rtl_digital, RtlSdrInternals* test_stream) {
+    static dsd_opts test_opts;
+    DSD_MEMSET(&test_opts, 0, sizeof(test_opts));
+    if (!active_rtl_digital) {
+        g_stream = NULL;
+        return;
+    }
+    test_opts.frame_p25p1 = 1;
+    test_stream->output = &output;
+    test_stream->opts = &test_opts;
+    g_stream = test_stream;
+}
+
+static void
+cqpsk_toggle_test_configure_demod(int start_cqpsk) {
+    demod.cqpsk_enable = start_cqpsk ? 1 : 0;
+    demod.output_kind = start_cqpsk ? DSD_DEMOD_OUTPUT_SYMBOL_CQPSK : DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
+    demod.symbol_rate_hz = 4800;
+    demod.symbol_levels = 4;
+    demod.ted_enabled = start_cqpsk ? 1 : 0;
+    demod.channel_lpf_profile = start_cqpsk ? DSD_CH_LPF_PROFILE_P25_CQPSK : DSD_CH_LPF_PROFILE_P25_C4FM;
+    demod.costas_reset_pending = 0;
+    demod.mode_demod = start_cqpsk ? &qpsk_differential_demod : &dsd_fm_demod;
+    demod.cqpsk_diff_prev_r = start_cqpsk ? 0.25f : 1.0f;
+    demod.cqpsk_diff_prev_j = start_cqpsk ? -0.25f : 0.0f;
+    demod.fsk_modem_state.have_prev = 1;
+}
+
+static void
+cqpsk_toggle_test_seed_output(size_t queued_samples, int cached_symbols) {
+    ring_clear(&output);
+    output.tail.store(0, std::memory_order_release);
+    output.head.store(queued_samples, std::memory_order_release);
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_delta(cached_symbols);
+}
+
+static void
+cqpsk_toggle_test_collect(rtl_stream_test_cqpsk_toggle_result* out_result) {
+    out_result->generation_after = dsd_rtl_stream_output_generation();
+    out_result->used_after = ring_used(&output);
+    out_result->cache_pending_after = dsd_rtl_stream_metrics_hook_symbol_cache_pending();
+    out_result->output_kind_after = demod.output_kind;
+    out_result->fsk_reset_pending_after_toggle = g_fsk_modem_reset_pending.load(std::memory_order_acquire);
+    out_result->reset_consumed = rtl_stream_consume_fsk_modem_reset_pending(&demod);
+    out_result->have_prev_after_consume = demod.fsk_modem_state.have_prev;
+}
+
+extern "C" int
+dsd_rtl_stream_test_cqpsk_toggle_output_clear(int start_cqpsk, int target_cqpsk, int active_rtl_digital,
+                                              size_t queued_samples, int cached_symbols,
+                                              rtl_stream_test_cqpsk_toggle_result* out_result) {
+    if (!out_result || cached_symbols < 0) {
+        return -1;
+    }
+    *out_result = {};
+
+    int initialized_output = 0;
+    int prepare_rc = fsk_reacquire_test_prepare_output_ring(queued_samples, &initialized_output);
+    if (prepare_rc != 0) {
+        fsk_reacquire_test_cleanup_output_ring(initialized_output);
+        return prepare_rc;
+    }
+
+    CqpskToggleTestSnapshot snapshot = {};
+    cqpsk_toggle_test_save(&snapshot);
+    RtlSdrInternals test_stream = {};
+    cqpsk_toggle_test_configure_stream(active_rtl_digital, &test_stream);
+    cqpsk_toggle_test_configure_demod(start_cqpsk);
+    cqpsk_toggle_test_seed_output(queued_samples, cached_symbols);
+
+    out_result->generation_before = dsd_rtl_stream_output_generation();
+    rtl_stream_toggle_cqpsk(target_cqpsk ? 1 : 0);
+    cqpsk_toggle_test_collect(out_result);
+
+    cqpsk_toggle_test_restore(&snapshot, initialized_output);
     fsk_reacquire_test_cleanup_output_ring(initialized_output);
     return 0;
 }

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -533,6 +533,7 @@ struct RtlSdrInternals {
 } // namespace
 
 static struct RtlSdrInternals* g_stream = NULL;
+static struct RtlSdrInternals g_cqpsk_toggle_test_stream;
 static float g_monitor_fm_prev_r = 0.0f;
 static float g_monitor_fm_prev_j = 0.0f;
 static int g_monitor_fm_have_prev = 0;
@@ -8096,7 +8097,7 @@ cqpsk_toggle_test_restore(const CqpskToggleTestSnapshot* s, int initialized_outp
 }
 
 static void
-cqpsk_toggle_test_configure_stream(int active_rtl_digital, RtlSdrInternals* test_stream) {
+cqpsk_toggle_test_configure_stream(int active_rtl_digital) {
     static dsd_opts test_opts;
     DSD_MEMSET(&test_opts, 0, sizeof(test_opts));
     if (!active_rtl_digital) {
@@ -8104,9 +8105,13 @@ cqpsk_toggle_test_configure_stream(int active_rtl_digital, RtlSdrInternals* test
         return;
     }
     test_opts.frame_p25p1 = 1;
-    test_stream->output = &output;
-    test_stream->opts = &test_opts;
-    g_stream = test_stream;
+    g_cqpsk_toggle_test_stream.output = &output;
+    g_cqpsk_toggle_test_stream.opts = &test_opts;
+    g_cqpsk_toggle_test_stream.should_exit.store(0, std::memory_order_release);
+    g_cqpsk_toggle_test_stream.async_started.store(0, std::memory_order_release);
+    g_cqpsk_toggle_test_stream.demod_thread_started.store(0, std::memory_order_release);
+    g_cqpsk_toggle_test_stream.controller_thread_started.store(0, std::memory_order_release);
+    g_stream = &g_cqpsk_toggle_test_stream;
 }
 
 static void
@@ -8162,8 +8167,7 @@ dsd_rtl_stream_test_cqpsk_toggle_output_clear(int start_cqpsk, int target_cqpsk,
 
     CqpskToggleTestSnapshot snapshot = {};
     cqpsk_toggle_test_save(&snapshot);
-    RtlSdrInternals test_stream = {};
-    cqpsk_toggle_test_configure_stream(active_rtl_digital, &test_stream);
+    cqpsk_toggle_test_configure_stream(active_rtl_digital);
     cqpsk_toggle_test_configure_demod(start_cqpsk);
     cqpsk_toggle_test_seed_output(queued_samples, cached_symbols);
 

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -2907,9 +2907,20 @@ demod_snr_output_samples_per_symbol(const struct demod_state* d) {
     if (!d) {
         return 0;
     }
-    int sps = d->ted_sps;
-    if (sps <= 0 && d->rate_out > 0 && d->symbol_rate_hz > 0) {
+    int sps = 0;
+    if (d->output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR && d->rate_out > 0 && d->symbol_rate_hz > 0) {
         sps = (d->rate_out + (d->symbol_rate_hz / 2)) / d->symbol_rate_hz;
+    } else {
+        sps = d->ted_sps;
+        if (sps <= 0 && d->rate_out > 0 && d->symbol_rate_hz > 0) {
+            sps = (d->rate_out + (d->symbol_rate_hz / 2)) / d->symbol_rate_hz;
+        }
+    }
+    if (sps < 1) {
+        return 0;
+    }
+    if (sps > 64) {
+        return 64;
     }
     return sps;
 }
@@ -3560,6 +3571,7 @@ rtl_stream_bump_output_generation(void) {
         next = g_rtl_output_generation.fetch_add(1, std::memory_order_acq_rel) + 1U;
     }
     rtl_decode_health_reset();
+    rtl_stream_invalidate_fsk_phase_cfo_snapshot();
     return next;
 }
 
@@ -5838,6 +5850,15 @@ stream_open_apply_controller_settings(RadioSourceKind source_kind, const dsd_opt
 
 static void
 stream_open_configure_resampler_chain(void) {
+    const bool direct_symbol_output =
+        (demod.output_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK || demod.output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR);
+    if (direct_symbol_output) {
+        demod.resamp_enabled = 0;
+        demod.resamp_L = 1;
+        demod.resamp_M = 1;
+        demod.resamp_phase = 0;
+        return;
+    }
     if (demod.resamp_target_hz <= 0) {
         demod.resamp_enabled = 0;
         return;
@@ -5873,7 +5894,9 @@ stream_open_configure_resampler_chain(void) {
 
 static void
 stream_open_update_output_rates(void) {
-    if (demod.resamp_enabled && demod.resamp_target_hz > 0) {
+    const bool direct_symbol_output =
+        (demod.output_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK || demod.output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR);
+    if (!direct_symbol_output && demod.resamp_enabled && demod.resamp_target_hz > 0) {
         output.rate = demod.resamp_target_hz;
         LOG_INFO("Output rate set to %d Hz via resampler.\n", output.rate);
     } else {
@@ -6734,15 +6757,28 @@ dsd_rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_pr
     if (levels != 2 && levels != 4) {
         return -1;
     }
-    int changed = (demod.symbol_rate_hz != symbol_rate_hz || demod.symbol_levels != levels);
+    int next_channel_profile = demod.channel_lpf_profile;
+    if (channel_profile >= DSD_CH_LPF_PROFILE_WIDE && channel_profile <= DSD_CH_LPF_PROFILE_P25_CQPSK) {
+        next_channel_profile = channel_profile;
+    }
+    int changed = (demod.symbol_rate_hz != symbol_rate_hz || demod.symbol_levels != levels
+                   || demod.channel_lpf_profile != next_channel_profile);
     demod.symbol_rate_hz = symbol_rate_hz;
     demod.symbol_levels = levels;
-    if (channel_profile >= DSD_CH_LPF_PROFILE_WIDE && channel_profile <= DSD_CH_LPF_PROFILE_P25_CQPSK) {
-        demod.channel_lpf_profile = channel_profile;
+    demod.channel_lpf_profile = next_channel_profile;
+    if (demod.output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR && demod.rate_out > 0) {
+        int sps = (demod.rate_out + (symbol_rate_hz / 2)) / symbol_rate_hz;
+        if (sps < 1) {
+            sps = 1;
+        } else if (sps > 64) {
+            sps = 64;
+        }
+        demod.ted_sps = sps;
     }
     rtl_stream_queue_fsk_modem_config(demod.symbol_rate_hz, demod.symbol_levels, demod.channel_lpf_profile);
     if (changed) {
         demod.costas_reset_pending = 1;
+        rtl_stream_invalidate_fsk_phase_cfo_snapshot();
     }
     return 0;
 }
@@ -7947,8 +7983,8 @@ dsd_rtl_stream_test_clear_output_fsk_reset(size_t queued_samples, int* out_have_
 
 extern "C" int
 dsd_rtl_stream_test_fsk_cfo_snapshot(double dc_rad_per_sample, int rate_out_hz, double* out_cfo_hz,
-                                     int* out_after_reset_available) {
-    if (!out_cfo_hz || !out_after_reset_available) {
+                                     int* out_after_generation_bump_available, int* out_after_reset_available) {
+    if (!out_cfo_hz || !out_after_generation_bump_available || !out_after_reset_available) {
         return -1;
     }
 
@@ -7966,6 +8002,10 @@ dsd_rtl_stream_test_fsk_cfo_snapshot(double dc_rad_per_sample, int rate_out_hz, 
     rtl_stream_publish_fsk_phase_cfo_snapshot(&demod);
 
     int available_before = auto_ppm_fsk_phase_cfo_hz(out_cfo_hz);
+    double after_generation_bump_cfo_hz = 0.0;
+    (void)rtl_stream_bump_output_generation();
+    *out_after_generation_bump_available = auto_ppm_fsk_phase_cfo_hz(&after_generation_bump_cfo_hz);
+    rtl_stream_publish_fsk_phase_cfo_snapshot(&demod);
     rtl_stream_queue_fsk_modem_reset();
     (void)rtl_stream_consume_fsk_modem_reset_pending(&demod);
     double after_reset_cfo_hz = 0.0;
@@ -7978,6 +8018,61 @@ dsd_rtl_stream_test_fsk_cfo_snapshot(double dc_rad_per_sample, int rate_out_hz, 
     g_fsk_modem_reset_pending.store(prev_reset_pending, std::memory_order_release);
     rtl_stream_invalidate_fsk_phase_cfo_snapshot();
     return available_before ? 0 : -2;
+}
+
+extern "C" int
+dsd_rtl_stream_test_fsk_snr_sps(int rate_out_hz, int symbol_rate_hz, int stale_ted_sps) {
+    static demod_state d;
+    DSD_MEMSET(&d, 0, sizeof(d));
+    d.output_kind = DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
+    d.rate_out = rate_out_hz;
+    d.symbol_rate_hz = symbol_rate_hz;
+    d.ted_sps = stale_ted_sps;
+    return demod_snr_output_samples_per_symbol(&d);
+}
+
+extern "C" int
+dsd_rtl_stream_test_direct_output_rate_after_open_update(int output_kind, int rate_out_hz, int resamp_target_hz,
+                                                         unsigned int* out_rate_hz, int* out_resamp_enabled) {
+    if (!out_rate_hz || !out_resamp_enabled) {
+        return -1;
+    }
+    if (output_kind != DSD_DEMOD_OUTPUT_SYMBOL_CQPSK && output_kind != DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
+        return -2;
+    }
+
+    int prev_output_kind = demod.output_kind;
+    int prev_rate_out = demod.rate_out;
+    int prev_resamp_target_hz = demod.resamp_target_hz;
+    int prev_resamp_enabled = demod.resamp_enabled;
+    int prev_resamp_l = demod.resamp_L;
+    int prev_resamp_m = demod.resamp_M;
+    int prev_resamp_phase = demod.resamp_phase;
+    unsigned int prev_output_rate = output.rate;
+
+    demod.output_kind = output_kind;
+    demod.rate_out = rate_out_hz;
+    demod.resamp_target_hz = resamp_target_hz;
+    demod.resamp_enabled = 0;
+    demod.resamp_L = 1;
+    demod.resamp_M = 1;
+    demod.resamp_phase = 0;
+    output.rate = 0U;
+
+    stream_open_configure_resampler_chain();
+    stream_open_update_output_rates();
+    *out_rate_hz = output.rate;
+    *out_resamp_enabled = demod.resamp_enabled;
+
+    demod.output_kind = prev_output_kind;
+    demod.rate_out = prev_rate_out;
+    demod.resamp_target_hz = prev_resamp_target_hz;
+    demod.resamp_enabled = prev_resamp_enabled;
+    demod.resamp_L = prev_resamp_l;
+    demod.resamp_M = prev_resamp_m;
+    demod.resamp_phase = prev_resamp_phase;
+    output.rate = prev_output_rate;
+    return 0;
 }
 
 static void

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -290,6 +290,13 @@ static std::atomic<uint32_t> g_retune_settle_seq{0};
 static std::atomic<int> g_retune_settle_blocks_remaining{0};
 static std::atomic<uint32_t> g_rtl_output_generation{1};
 static std::atomic<int> g_fsk_reacquire_pending{0};
+static std::atomic<int> g_fsk_modem_reset_pending{0};
+static std::atomic<int> g_fsk_modem_config_pending{0};
+static std::atomic<int> g_fsk_modem_config_symbol_rate_hz{4800};
+static std::atomic<int> g_fsk_modem_config_levels{4};
+static std::atomic<int> g_fsk_modem_config_channel_profile{DSD_CH_LPF_PROFILE_WIDE};
+static std::atomic<int> g_fsk_phase_cfo_valid{0};
+static std::atomic<double> g_fsk_phase_cfo_hz{0.0};
 static std::mutex g_pending_retune_profile_mutex;
 static RtlRetuneProfile g_pending_retune_profile;
 static std::atomic<uint32_t> g_replay_event_retune_count{0};
@@ -302,6 +309,12 @@ static std::atomic<uint32_t> g_replay_loop_restart_count{0};
 static std::atomic<uint32_t> g_replay_loop_restart_last_frequency_hz{0};
 
 static int rtl_stream_consume_fsk_reacquire_pending(struct demod_state* d);
+static int rtl_stream_consume_fsk_modem_config_pending(struct demod_state* d);
+static int rtl_stream_consume_fsk_modem_reset_pending(struct demod_state* d);
+static void rtl_stream_invalidate_fsk_phase_cfo_snapshot(void);
+static void rtl_stream_publish_fsk_phase_cfo_snapshot(const struct demod_state* d);
+static void rtl_stream_queue_fsk_modem_config(int symbol_rate_hz, int levels, int channel_profile);
+static void rtl_stream_queue_fsk_modem_reset(void);
 static int controller_apply_replay_settings(struct controller_state* s, const dsd_opts* opts,
                                             const dsd_iq_replay_config* cfg);
 static const int kRetuneDiagBlocks = 20;
@@ -1620,6 +1633,7 @@ demod_reset_histories_for_output_mode(struct demod_state* s) {
     demod_reset_resampler_state(s);
     if (s->output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
         dsd_fsk_modem_reset(&s->fsk_modem_state);
+        rtl_stream_invalidate_fsk_phase_cfo_snapshot();
     }
     demod_reset_monitor_state();
 }
@@ -3321,8 +3335,13 @@ static DSD_THREAD_RETURN_TYPE
         }
         int perf_on = rtl_perf_enabled();
         uint64_t perf_full_start_ns = perf_on ? rtl_perf_now_ns() : 0ULL;
-        (void)rtl_stream_consume_fsk_reacquire_pending(d);
+        (void)rtl_stream_consume_fsk_modem_config_pending(d);
+        int consumed_fsk_reacquire = rtl_stream_consume_fsk_reacquire_pending(d);
+        if (!consumed_fsk_reacquire) {
+            (void)rtl_stream_consume_fsk_modem_reset_pending(d);
+        }
         full_demod(d);
+        rtl_stream_publish_fsk_phase_cfo_snapshot(d);
         uint64_t perf_full_demod_ns = perf_on ? (rtl_perf_now_ns() - perf_full_start_ns) : 0ULL;
         rtl_monitor_side_tap_process(d);
         demod_log_retune_diag_block(d, span.got, &retune_diag);
@@ -3544,14 +3563,93 @@ rtl_stream_bump_output_generation(void) {
     return next;
 }
 
+static void
+rtl_stream_invalidate_fsk_phase_cfo_snapshot(void) {
+    g_fsk_phase_cfo_valid.store(0, std::memory_order_release);
+}
+
+static void
+rtl_stream_publish_fsk_phase_cfo_snapshot(const struct demod_state* d) {
+    if (!d || d->cqpsk_enable || d->output_kind != DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR || d->rate_out <= 0
+        || !d->fsk_modem_state.have_prev) {
+        rtl_stream_invalidate_fsk_phase_cfo_snapshot();
+        return;
+    }
+
+    double dc_rad_per_sample = (double)d->fsk_modem_state.dc_est;
+    if (!std::isfinite(dc_rad_per_sample)) {
+        rtl_stream_invalidate_fsk_phase_cfo_snapshot();
+        return;
+    }
+
+    double cfo_hz = dsd::io::radio::rtl_auto_ppm_fsk_dc_est_to_cfo_hz(dc_rad_per_sample, d->rate_out);
+    if (!std::isfinite(cfo_hz)) {
+        rtl_stream_invalidate_fsk_phase_cfo_snapshot();
+        return;
+    }
+
+    g_fsk_phase_cfo_hz.store(cfo_hz, std::memory_order_relaxed);
+    g_fsk_phase_cfo_valid.store(1, std::memory_order_release);
+}
+
+static void
+rtl_stream_queue_fsk_modem_config(int symbol_rate_hz, int levels, int channel_profile) {
+    g_fsk_modem_config_symbol_rate_hz.store(symbol_rate_hz, std::memory_order_relaxed);
+    g_fsk_modem_config_levels.store(levels, std::memory_order_relaxed);
+    g_fsk_modem_config_channel_profile.store(channel_profile, std::memory_order_relaxed);
+    g_fsk_modem_config_pending.store(1, std::memory_order_release);
+}
+
+static void
+rtl_stream_queue_fsk_modem_reset(void) {
+    g_fsk_modem_reset_pending.store(1, std::memory_order_release);
+}
+
+static void
+rtl_stream_reset_fsk_modem_on_demod_thread(struct demod_state* d) {
+    if (!d) {
+        return;
+    }
+    dsd_fsk_modem_reset(&d->fsk_modem_state);
+    rtl_stream_invalidate_fsk_phase_cfo_snapshot();
+}
+
+static int
+rtl_stream_consume_fsk_modem_config_pending(struct demod_state* d) {
+    int pending = g_fsk_modem_config_pending.exchange(0, std::memory_order_acq_rel);
+    if (!pending || !d) {
+        return 0;
+    }
+
+    dsd_fsk_modem_config cfg = {};
+    cfg.sample_rate_hz = d->rate_out > 0 ? d->rate_out : d->rate_in;
+    cfg.symbol_rate_hz = g_fsk_modem_config_symbol_rate_hz.load(std::memory_order_relaxed);
+    cfg.levels = g_fsk_modem_config_levels.load(std::memory_order_relaxed);
+    cfg.channel_profile = g_fsk_modem_config_channel_profile.load(std::memory_order_relaxed);
+    dsd_fsk_modem_configure(&d->fsk_modem_state, &cfg);
+    rtl_stream_invalidate_fsk_phase_cfo_snapshot();
+    return 1;
+}
+
+static int
+rtl_stream_consume_fsk_modem_reset_pending(struct demod_state* d) {
+    int pending = g_fsk_modem_reset_pending.exchange(0, std::memory_order_acq_rel);
+    if (!pending || !d || d->output_kind != DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
+        return 0;
+    }
+    rtl_stream_reset_fsk_modem_on_demod_thread(d);
+    return 1;
+}
+
 static int
 rtl_stream_consume_fsk_reacquire_pending(struct demod_state* d) {
     int pending = g_fsk_reacquire_pending.exchange(0, std::memory_order_acq_rel);
     if (!pending || !d || d->output_kind != DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
         return 0;
     }
-    dsd_rtl_stream_clear_output();
-    dsd_fsk_modem_reset(&d->fsk_modem_state);
+    rtl_stream_clear_output_ring(g_stream && g_stream->output ? g_stream->output : &output, 1);
+    g_fsk_modem_reset_pending.store(0, std::memory_order_release);
+    rtl_stream_reset_fsk_modem_on_demod_thread(d);
     if (debug_sync_enabled()) {
         DSD_FPRINTF(stderr, "[FSKREACQ] consumed output_generation=%u\n",
                     g_rtl_output_generation.load(std::memory_order_acquire));
@@ -6291,16 +6389,15 @@ auto_ppm_make_config(const dsd_opts* opts) {
 
 static int
 auto_ppm_fsk_phase_cfo_hz(double* out_cfo_hz) {
-    if (!out_cfo_hz || demod.cqpsk_enable || demod.output_kind != DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR
-        || demod.rate_out <= 0 || !demod.fsk_modem_state.have_prev) {
+    if (!out_cfo_hz || !g_fsk_phase_cfo_valid.load(std::memory_order_acquire)) {
         return 0;
     }
-    double dc_rad_per_sample = (double)demod.fsk_modem_state.dc_est;
-    if (!std::isfinite(dc_rad_per_sample)) {
+    double cfo_hz = g_fsk_phase_cfo_hz.load(std::memory_order_relaxed);
+    if (!std::isfinite(cfo_hz)) {
         return 0;
     }
 
-    *out_cfo_hz = dsd::io::radio::rtl_auto_ppm_fsk_dc_est_to_cfo_hz(dc_rad_per_sample, demod.rate_out);
+    *out_cfo_hz = cfo_hz;
     return 1;
 }
 
@@ -6643,12 +6740,7 @@ dsd_rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_pr
     if (channel_profile >= DSD_CH_LPF_PROFILE_WIDE && channel_profile <= DSD_CH_LPF_PROFILE_P25_CQPSK) {
         demod.channel_lpf_profile = channel_profile;
     }
-    dsd_fsk_modem_config cfg = {};
-    cfg.sample_rate_hz = demod.rate_out > 0 ? demod.rate_out : demod.rate_in;
-    cfg.symbol_rate_hz = demod.symbol_rate_hz;
-    cfg.levels = demod.symbol_levels;
-    cfg.channel_profile = demod.channel_lpf_profile;
-    dsd_fsk_modem_configure(&demod.fsk_modem_state, &cfg);
+    rtl_stream_queue_fsk_modem_config(demod.symbol_rate_hz, demod.symbol_levels, demod.channel_lpf_profile);
     if (changed) {
         demod.costas_reset_pending = 1;
     }
@@ -7013,6 +7105,7 @@ dsd_rtl_stream_get_iq_balance(void) {
 static void
 rtl_stream_enable_cqpsk_mode(void) {
     demod.output_kind = DSD_DEMOD_OUTPUT_SYMBOL_CQPSK;
+    rtl_stream_invalidate_fsk_phase_cfo_snapshot();
     demod.symbol_levels = 4;
     demod.ted_enabled = 1;
     demod.mode_demod = &qpsk_differential_demod;
@@ -7031,6 +7124,7 @@ rtl_stream_disable_cqpsk_mode(void) {
         demod.output_kind = DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
     } else {
         demod.output_kind = DSD_DEMOD_OUTPUT_AUDIO_MONITOR;
+        rtl_stream_invalidate_fsk_phase_cfo_snapshot();
     }
 }
 
@@ -7761,6 +7855,10 @@ dsd_rtl_stream_test_retune_completion_result_binding(int* out_first_result, int*
     return (first_found && second_found) ? 0 : -2;
 }
 
+static void fsk_reacquire_test_cleanup_output_ring(int initialized_output);
+static int fsk_reacquire_test_prepare_output_ring(size_t queued_samples, int* initialized_output);
+static void fsk_reacquire_test_reset_output_state(void);
+
 extern "C" int
 dsd_rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size_t* out_used_after,
                                  int* out_cache_pending_after, uint32_t* out_generation_before,
@@ -7793,6 +7891,7 @@ dsd_rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size
     output.head.store(queued_samples);
     dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
     dsd_rtl_stream_metrics_hook_symbol_cache_pending_delta(cached_symbols);
+    int prev_reset_pending = g_fsk_modem_reset_pending.exchange(0, std::memory_order_acq_rel);
 
     *out_generation_before = dsd_rtl_stream_output_generation();
     dsd_rtl_stream_clear_output();
@@ -7802,10 +7901,83 @@ dsd_rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size
 
     ring_clear(&output);
     dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+    g_fsk_modem_reset_pending.store(prev_reset_pending, std::memory_order_release);
     if (initialized_output) {
         output_cleanup(&output);
     }
     return 0;
+}
+
+extern "C" int
+dsd_rtl_stream_test_clear_output_fsk_reset(size_t queued_samples, int* out_have_prev_after_clear,
+                                           int* out_consumed_reset, int* out_have_prev_after_consume) {
+    if (!out_have_prev_after_clear || !out_consumed_reset || !out_have_prev_after_consume) {
+        return -1;
+    }
+
+    int initialized_output = 0;
+    int prepare_rc = fsk_reacquire_test_prepare_output_ring(queued_samples, &initialized_output);
+    if (prepare_rc != 0) {
+        fsk_reacquire_test_cleanup_output_ring(initialized_output);
+        return prepare_rc;
+    }
+
+    int prev_output_kind = demod.output_kind;
+    dsd_fsk_modem_state prev_modem = demod.fsk_modem_state;
+    int prev_reset_pending = g_fsk_modem_reset_pending.exchange(0, std::memory_order_acq_rel);
+    demod.output_kind = DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
+    demod.fsk_modem_state.have_prev = 1;
+
+    ring_clear(&output);
+    output.tail.store(0);
+    output.head.store(queued_samples);
+
+    dsd_rtl_stream_clear_output();
+    *out_have_prev_after_clear = demod.fsk_modem_state.have_prev;
+    *out_consumed_reset = rtl_stream_consume_fsk_modem_reset_pending(&demod);
+    *out_have_prev_after_consume = demod.fsk_modem_state.have_prev;
+
+    demod.output_kind = prev_output_kind;
+    demod.fsk_modem_state = prev_modem;
+    g_fsk_modem_reset_pending.store(prev_reset_pending, std::memory_order_release);
+    fsk_reacquire_test_reset_output_state();
+    fsk_reacquire_test_cleanup_output_ring(initialized_output);
+    return 0;
+}
+
+extern "C" int
+dsd_rtl_stream_test_fsk_cfo_snapshot(double dc_rad_per_sample, int rate_out_hz, double* out_cfo_hz,
+                                     int* out_after_reset_available) {
+    if (!out_cfo_hz || !out_after_reset_available) {
+        return -1;
+    }
+
+    int prev_cqpsk = demod.cqpsk_enable;
+    int prev_output_kind = demod.output_kind;
+    int prev_rate_out = demod.rate_out;
+    dsd_fsk_modem_state prev_modem = demod.fsk_modem_state;
+    int prev_reset_pending = g_fsk_modem_reset_pending.exchange(0, std::memory_order_acq_rel);
+
+    demod.cqpsk_enable = 0;
+    demod.output_kind = DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
+    demod.rate_out = rate_out_hz;
+    demod.fsk_modem_state.have_prev = 1;
+    demod.fsk_modem_state.dc_est = (float)dc_rad_per_sample;
+    rtl_stream_publish_fsk_phase_cfo_snapshot(&demod);
+
+    int available_before = auto_ppm_fsk_phase_cfo_hz(out_cfo_hz);
+    rtl_stream_queue_fsk_modem_reset();
+    (void)rtl_stream_consume_fsk_modem_reset_pending(&demod);
+    double after_reset_cfo_hz = 0.0;
+    *out_after_reset_available = auto_ppm_fsk_phase_cfo_hz(&after_reset_cfo_hz);
+
+    demod.cqpsk_enable = prev_cqpsk;
+    demod.output_kind = prev_output_kind;
+    demod.rate_out = prev_rate_out;
+    demod.fsk_modem_state = prev_modem;
+    g_fsk_modem_reset_pending.store(prev_reset_pending, std::memory_order_release);
+    rtl_stream_invalidate_fsk_phase_cfo_snapshot();
+    return available_before ? 0 : -2;
 }
 
 static void
@@ -7868,7 +8040,8 @@ dsd_rtl_stream_test_fsk_reacquire(int output_kind, size_t queued_samples, int ca
     dsd_fsk_modem_state prev_modem = demod.fsk_modem_state;
     demod.output_kind = output_kind;
     demod.fsk_modem_state.have_prev = 1;
-    g_fsk_reacquire_pending.store(0, std::memory_order_release);
+    int prev_reacquire_pending = g_fsk_reacquire_pending.exchange(0, std::memory_order_acq_rel);
+    int prev_reset_pending = g_fsk_modem_reset_pending.exchange(0, std::memory_order_acq_rel);
 
     ring_clear(&output);
     output.tail.store(0);
@@ -7882,7 +8055,8 @@ dsd_rtl_stream_test_fsk_reacquire(int output_kind, size_t queued_samples, int ca
         && !fsk_reacquire_test_request_state_valid(queued_samples, cached_symbols, *out_generation_before)) {
         demod.output_kind = prev_output_kind;
         demod.fsk_modem_state = prev_modem;
-        g_fsk_reacquire_pending.store(0, std::memory_order_release);
+        g_fsk_reacquire_pending.store(prev_reacquire_pending, std::memory_order_release);
+        g_fsk_modem_reset_pending.store(prev_reset_pending, std::memory_order_release);
         fsk_reacquire_test_reset_output_state();
         fsk_reacquire_test_cleanup_output_ring(initialized_output);
         return -5;
@@ -7894,7 +8068,8 @@ dsd_rtl_stream_test_fsk_reacquire(int output_kind, size_t queued_samples, int ca
 
     demod.output_kind = prev_output_kind;
     demod.fsk_modem_state = prev_modem;
-    g_fsk_reacquire_pending.store(0, std::memory_order_release);
+    g_fsk_reacquire_pending.store(prev_reacquire_pending, std::memory_order_release);
+    g_fsk_modem_reset_pending.store(prev_reset_pending, std::memory_order_release);
     fsk_reacquire_test_reset_output_state();
     fsk_reacquire_test_cleanup_output_ring(initialized_output);
     return 0;
@@ -8134,9 +8309,7 @@ dsd_rtl_stream_clear_output(void) {
         outp = g_stream->output;
     }
     rtl_stream_clear_output_ring(outp, 1);
-    if (demod.output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
-        dsd_fsk_modem_reset(&demod.fsk_modem_state);
-    }
+    rtl_stream_queue_fsk_modem_reset();
 }
 
 extern "C" int

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -533,7 +533,9 @@ struct RtlSdrInternals {
 } // namespace
 
 static struct RtlSdrInternals* g_stream = NULL;
+#if defined(DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS)
 static struct RtlSdrInternals g_cqpsk_toggle_test_stream;
+#endif
 static float g_monitor_fm_prev_r = 0.0f;
 static float g_monitor_fm_prev_j = 0.0f;
 static int g_monitor_fm_have_prev = 0;

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -29,6 +29,7 @@
 #include <dsd-neo/dsp/math_utils.h>
 #include <dsd-neo/dsp/resampler.h>
 #include <dsd-neo/dsp/snr_bias.h>
+#include <dsd-neo/dsp/snr_estimator.h>
 #include <dsd-neo/dsp/ted.h>
 #include <dsd-neo/io/iq_capture.h>
 #include <dsd-neo/io/iq_replay.h>
@@ -313,9 +314,7 @@ static void rtl_stream_store_pending_retune_profile(uint32_t target_freq_hz, int
                                                     int persist_ted_override,
                                                     const rtl_stream_retune_gain_profile* gain_profile);
 static void rtl_stream_apply_retune_profile(const RtlRetuneProfile* profile, uint32_t center_freq_hz);
-static void rtl_fsk_metrics_reset_snapshot(void);
 static void rtl_decode_health_reset(void);
-static void rtl_publish_fsk_metrics_from_demod(const struct demod_state* d);
 static void rtl_stream_signal_output_waiters(struct output_state* outp);
 static void rtl_stream_clear_output_ring(struct output_state* outp, int bump_generation);
 /*
@@ -576,7 +575,7 @@ rtl_monitor_side_tap_active(const struct demod_state* d) {
     if (!d || !g_stream || !g_stream->opts) {
         return 0;
     }
-    if (d->output_kind != DSD_DEMOD_OUTPUT_SYMBOL_FSK && d->output_kind != DSD_DEMOD_OUTPUT_SYMBOL_CQPSK) {
+    if (d->output_kind != DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR && d->output_kind != DSD_DEMOD_OUTPUT_SYMBOL_CQPSK) {
         return 0;
     }
     return (g_stream->opts->monitor_input_audio == 1 || g_stream->opts->analog_only == 1) ? 1 : 0;
@@ -1614,12 +1613,12 @@ demod_reset_monitor_state(void) {
 
 static void
 demod_reset_histories_for_output_mode(struct demod_state* s) {
-    if (!(s->cqpsk_enable || s->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK)) {
+    if (!(s->cqpsk_enable || s->output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR)) {
         return;
     }
     demod_clear_filter_histories(s);
     demod_reset_resampler_state(s);
-    if (s->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK) {
+    if (s->output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
         dsd_fsk_modem_reset(&s->fsk_modem_state);
     }
     demod_reset_monitor_state();
@@ -1678,27 +1677,6 @@ static std::atomic<double> g_snr_ema_gfsk{-100.0};
 /* QPSK accumulator reset flag (actual buffer is in demod loop) */
 static std::atomic<int> g_snr_qpsk_acc_reset{0};
 
-static std::atomic<int> g_fsk_metrics_valid{0};
-static std::atomic<uint32_t> g_fsk_metrics_generation{0};
-static std::atomic<int> g_fsk_metrics_levels{0};
-static std::atomic<int> g_fsk_metrics_symbol_rate_hz{0};
-static std::atomic<uint64_t> g_fsk_metrics_symbols_total{0};
-static std::atomic<unsigned int> g_fsk_metrics_window_symbols{0};
-static std::atomic<unsigned int> g_fsk_metrics_mean_reliability{0};
-static std::atomic<unsigned int> g_fsk_metrics_min_reliability{0};
-static std::atomic<double> g_fsk_metrics_rms_error{0.0};
-static std::atomic<double> g_fsk_metrics_evm_snr_db{-100.0};
-static std::atomic<double> g_fsk_metrics_low_reliability_pct{0.0};
-static std::atomic<double> g_fsk_metrics_clip_pct{0.0};
-static std::atomic<int> g_fsk_metrics_timing_acquired{0};
-static std::atomic<double> g_fsk_metrics_track_last_error{0.0};
-static std::atomic<double> g_fsk_metrics_track_last_score{0.0};
-static std::atomic<uint64_t> g_fsk_metrics_track_updates{0};
-static std::atomic<uint64_t> g_fsk_metrics_track_skips{0};
-static std::atomic<double> g_fsk_metrics_abs_est{0.0};
-static std::atomic<double> g_fsk_metrics_dc_est{0.0};
-static std::atomic<double> g_fsk_metrics_last_symbol{0.0};
-
 static std::atomic<int> g_input_level_valid{0};
 static std::atomic<int> g_input_level_status{DSD_INPUT_LEVEL_UNKNOWN};
 static std::atomic<int> g_input_level_source{DSD_INPUT_LEVEL_SOURCE_UNKNOWN};
@@ -1717,30 +1695,6 @@ static std::atomic<unsigned int> g_decode_p25p2_facch_err{0};
 static std::atomic<unsigned int> g_decode_p25p2_sacch_ok{0};
 static std::atomic<unsigned int> g_decode_p25p2_sacch_err{0};
 static std::atomic<unsigned int> g_decode_p25p2_voice_err{0};
-
-static void
-rtl_fsk_metrics_reset_snapshot(void) {
-    g_fsk_metrics_valid.store(0, std::memory_order_release);
-    g_fsk_metrics_generation.store(g_rtl_output_generation.load(std::memory_order_acquire), std::memory_order_release);
-    g_fsk_metrics_levels.store(0, std::memory_order_relaxed);
-    g_fsk_metrics_symbol_rate_hz.store(0, std::memory_order_relaxed);
-    g_fsk_metrics_symbols_total.store(0, std::memory_order_relaxed);
-    g_fsk_metrics_window_symbols.store(0, std::memory_order_relaxed);
-    g_fsk_metrics_mean_reliability.store(0, std::memory_order_relaxed);
-    g_fsk_metrics_min_reliability.store(0, std::memory_order_relaxed);
-    g_fsk_metrics_rms_error.store(0.0, std::memory_order_relaxed);
-    g_fsk_metrics_evm_snr_db.store(-100.0, std::memory_order_relaxed);
-    g_fsk_metrics_low_reliability_pct.store(0.0, std::memory_order_relaxed);
-    g_fsk_metrics_clip_pct.store(0.0, std::memory_order_relaxed);
-    g_fsk_metrics_timing_acquired.store(0, std::memory_order_relaxed);
-    g_fsk_metrics_track_last_error.store(0.0, std::memory_order_relaxed);
-    g_fsk_metrics_track_last_score.store(0.0, std::memory_order_relaxed);
-    g_fsk_metrics_track_updates.store(0, std::memory_order_relaxed);
-    g_fsk_metrics_track_skips.store(0, std::memory_order_relaxed);
-    g_fsk_metrics_abs_est.store(0.0, std::memory_order_relaxed);
-    g_fsk_metrics_dc_est.store(0.0, std::memory_order_relaxed);
-    g_fsk_metrics_last_symbol.store(0.0, std::memory_order_relaxed);
-}
 
 void
 rtl_stream_input_level_reset(void) {
@@ -1800,39 +1754,6 @@ rtl_decode_health_prepare_update(void) {
 }
 
 static void
-rtl_publish_fsk_metrics_from_demod(const struct demod_state* d) {
-    dsd_fsk_modem_metrics m = {};
-    if (!d || d->output_kind != DSD_DEMOD_OUTPUT_SYMBOL_FSK || dsd_fsk_modem_get_metrics(&d->fsk_modem_state, &m) != 0
-        || !m.valid) {
-        rtl_fsk_metrics_reset_snapshot();
-        return;
-    }
-
-    uint32_t gen = g_rtl_output_generation.load(std::memory_order_acquire);
-    g_fsk_metrics_valid.store(0, std::memory_order_release);
-    g_fsk_metrics_generation.store(gen, std::memory_order_relaxed);
-    g_fsk_metrics_levels.store(m.levels, std::memory_order_relaxed);
-    g_fsk_metrics_symbol_rate_hz.store(m.symbol_rate_hz, std::memory_order_relaxed);
-    g_fsk_metrics_symbols_total.store(m.symbols_total, std::memory_order_relaxed);
-    g_fsk_metrics_window_symbols.store(m.window_symbols, std::memory_order_relaxed);
-    g_fsk_metrics_mean_reliability.store(m.mean_reliability, std::memory_order_relaxed);
-    g_fsk_metrics_min_reliability.store(m.min_reliability, std::memory_order_relaxed);
-    g_fsk_metrics_rms_error.store((double)m.rms_error, std::memory_order_relaxed);
-    g_fsk_metrics_evm_snr_db.store((double)m.evm_snr_db, std::memory_order_relaxed);
-    g_fsk_metrics_low_reliability_pct.store((double)m.low_reliability_pct, std::memory_order_relaxed);
-    g_fsk_metrics_clip_pct.store((double)m.clip_pct, std::memory_order_relaxed);
-    g_fsk_metrics_timing_acquired.store(m.timing_acquired, std::memory_order_relaxed);
-    g_fsk_metrics_track_last_error.store((double)m.track_last_error, std::memory_order_relaxed);
-    g_fsk_metrics_track_last_score.store((double)m.track_last_score, std::memory_order_relaxed);
-    g_fsk_metrics_track_updates.store(m.track_updates, std::memory_order_relaxed);
-    g_fsk_metrics_track_skips.store(m.track_skips, std::memory_order_relaxed);
-    g_fsk_metrics_abs_est.store((double)m.abs_est, std::memory_order_relaxed);
-    g_fsk_metrics_dc_est.store((double)m.dc_est, std::memory_order_relaxed);
-    g_fsk_metrics_last_symbol.store((double)m.last_symbol, std::memory_order_relaxed);
-    g_fsk_metrics_valid.store(1, std::memory_order_release);
-}
-
-static void
 snr_ema_reset(void) {
     g_snr_ema_c4fm.store(-100.0, std::memory_order_relaxed);
     g_snr_ema_qpsk.store(-100.0, std::memory_order_relaxed);
@@ -1844,7 +1765,6 @@ snr_ema_reset(void) {
     g_snr_qpsk_src.store(0, std::memory_order_relaxed);
     g_snr_gfsk_src.store(0, std::memory_order_relaxed);
     g_snr_qpsk_acc_reset.store(1, std::memory_order_relaxed);
-    rtl_fsk_metrics_reset_snapshot();
     rtl_stream_input_level_reset();
     rtl_decode_health_reset();
 }
@@ -2639,9 +2559,9 @@ demod_metrics_due_for_block(DemodMetricsState* st, const struct demod_state* d) 
     if (!st || !d) {
         return 0;
     }
-    const int rtl_symbol_output =
-        (d->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK || d->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK);
-    return (!rtl_symbol_output || ((++st->dsp_metrics_block & 1U) == 0U)) ? 1 : 0;
+    const int rtl_direct_output =
+        (d->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK || d->output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR);
+    return (!rtl_direct_output || ((++st->dsp_metrics_block & 1U) == 0U)) ? 1 : 0;
 }
 
 static void
@@ -2724,6 +2644,39 @@ demod_snr_qpsk_publish(const struct demod_state* d, double ratio, DemodSnrUpdate
     g_snr_qpsk_src.store(1, std::memory_order_relaxed);
     g_snr_qpsk_last_ms.store(demod_now_ms(), std::memory_order_relaxed);
     flags->qpsk_updated = true;
+}
+
+static int
+demod_snr_valid(double snr_db) {
+    return std::isfinite(snr_db) && snr_db > -50.0;
+}
+
+static void
+demod_snr_publish_c4fm_direct(double snr, DemodSnrUpdateFlags* flags) {
+    if (!flags || !demod_snr_valid(snr)) {
+        return;
+    }
+    double ema = g_snr_ema_c4fm.load(std::memory_order_relaxed);
+    ema = (ema < -50.0) ? snr : (0.5 * ema + 0.5 * snr);
+    g_snr_ema_c4fm.store(ema, std::memory_order_relaxed);
+    g_snr_c4fm_db.store(ema, std::memory_order_relaxed);
+    g_snr_c4fm_src.store(1, std::memory_order_relaxed);
+    g_snr_c4fm_last_ms.store(demod_now_ms(), std::memory_order_relaxed);
+    flags->c4fm_updated = true;
+}
+
+static void
+demod_snr_publish_gfsk_direct(double snr, DemodSnrUpdateFlags* flags) {
+    if (!flags || !demod_snr_valid(snr)) {
+        return;
+    }
+    double ema = g_snr_ema_gfsk.load(std::memory_order_relaxed);
+    ema = (ema < -50.0) ? snr : (0.5 * ema + 0.5 * snr);
+    g_snr_ema_gfsk.store(ema, std::memory_order_relaxed);
+    g_snr_gfsk_db.store(ema, std::memory_order_relaxed);
+    g_snr_gfsk_src.store(1, std::memory_order_relaxed);
+    g_snr_gfsk_last_ms.store(demod_now_ms(), std::memory_order_relaxed);
+    flags->gfsk_updated = true;
 }
 
 static void
@@ -2860,13 +2813,7 @@ demod_snr_update_c4fm_direct(const struct demod_state* d, const float* vals, int
     }
     double bias = dsd_snr_bias_c4fm_db(d->rate_out, d->ted_sps, d->channel_lpf_profile);
     double snr = 10.0 * log10(sig_var / noise_var) - bias;
-    double ema = g_snr_ema_c4fm.load(std::memory_order_relaxed);
-    ema = (ema < -50.0) ? snr : (0.5 * ema + 0.5 * snr);
-    g_snr_ema_c4fm.store(ema, std::memory_order_relaxed);
-    g_snr_c4fm_db.store(ema, std::memory_order_relaxed);
-    g_snr_c4fm_src.store(1, std::memory_order_relaxed);
-    g_snr_c4fm_last_ms.store(demod_now_ms(), std::memory_order_relaxed);
-    flags->c4fm_updated = true;
+    demod_snr_publish_c4fm_direct(snr, flags);
 }
 
 static void
@@ -2914,13 +2861,7 @@ demod_snr_update_gfsk_direct(const struct demod_state* d, const float* vals, int
     }
     double bias = dsd_snr_bias_evm_db(d->rate_out, d->ted_sps, d->channel_lpf_profile);
     double snr = 10.0 * log10(sig_var / noise_var) - bias;
-    double ema = g_snr_ema_gfsk.load(std::memory_order_relaxed);
-    ema = (ema < -50.0) ? snr : (0.5 * ema + 0.5 * snr);
-    g_snr_ema_gfsk.store(ema, std::memory_order_relaxed);
-    g_snr_gfsk_db.store(ema, std::memory_order_relaxed);
-    g_snr_gfsk_src.store(1, std::memory_order_relaxed);
-    g_snr_gfsk_last_ms.store(demod_now_ms(), std::memory_order_relaxed);
-    flags->gfsk_updated = true;
+    demod_snr_publish_gfsk_direct(snr, flags);
 }
 
 static void
@@ -2945,6 +2886,46 @@ demod_snr_update_fsk_direct(const struct demod_state* d, const float* iq, int pa
     }
     demod_snr_update_c4fm_direct(d, vals, m, q1, q2, q3, flags);
     demod_snr_update_gfsk_direct(d, vals, m, q2, flags);
+}
+
+static int
+demod_snr_output_samples_per_symbol(const struct demod_state* d) {
+    if (!d) {
+        return 0;
+    }
+    int sps = d->ted_sps;
+    if (sps <= 0 && d->rate_out > 0 && d->symbol_rate_hz > 0) {
+        sps = (d->rate_out + (d->symbol_rate_hz / 2)) / d->symbol_rate_hz;
+    }
+    return sps;
+}
+
+static void
+demod_snr_update_fsk_discriminator_direct(const struct demod_state* d, DemodSnrUpdateFlags* flags) {
+    if (!d || !flags || d->output_kind != DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR || d->result_len <= 64) {
+        return;
+    }
+
+    int sps = demod_snr_output_samples_per_symbol(d);
+    int win = sps / 10;
+    if (win < 1) {
+        win = 1;
+    }
+
+    double c4fm_bias = dsd_snr_bias_c4fm_db(d->rate_out, sps, d->channel_lpf_profile);
+    double c4fm_snr = dsd_snr_estimate_c4fm_real_db(d->result, d->result_len, sps, win, c4fm_bias);
+    if (demod_snr_valid(c4fm_snr)) {
+        demod_snr_publish_c4fm_direct(c4fm_snr, flags);
+        if (d->symbol_levels != 2) {
+            demod_snr_publish_gfsk_direct(c4fm_snr, flags);
+        }
+    }
+
+    if (d->symbol_levels == 2) {
+        double gfsk_bias = dsd_snr_bias_evm_db(d->rate_out, sps, d->channel_lpf_profile);
+        double gfsk_snr = dsd_snr_estimate_gfsk_real_db(d->result, d->result_len, sps, win, gfsk_bias);
+        demod_snr_publish_gfsk_direct(gfsk_snr, flags);
+    }
 }
 
 static void
@@ -3026,7 +3007,9 @@ demod_metrics_update_snr(const struct demod_state* d, DemodMetricsState* st) {
     const float* iq = d->lowpassed;
     const int n_iq = d->lp_len;
     const int sps = d->ted_sps;
-    if (iq && n_iq >= 4 && sps >= 2) {
+    if (d->output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
+        demod_snr_update_fsk_discriminator_direct(d, &flags);
+    } else if (iq && n_iq >= 4 && sps >= 2) {
         const int pairs = n_iq / 2;
         const int mid = sps / 2;
         int win = sps / 10;
@@ -3184,7 +3167,7 @@ demod_write_output_block(struct demod_state* d, struct output_state* o) {
     if (!d || !o) {
         return 0U;
     }
-    if (d->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK || d->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK) {
+    if (d->output_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK || d->output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
         if (d->result_len > 0) {
             return demod_write_output_samples_interruptible(o, d->result, (size_t)d->result_len);
         }
@@ -3340,7 +3323,6 @@ static DSD_THREAD_RETURN_TYPE
         uint64_t perf_full_start_ns = perf_on ? rtl_perf_now_ns() : 0ULL;
         (void)rtl_stream_consume_fsk_reacquire_pending(d);
         full_demod(d);
-        rtl_publish_fsk_metrics_from_demod(d);
         uint64_t perf_full_demod_ns = perf_on ? (rtl_perf_now_ns() - perf_full_start_ns) : 0ULL;
         rtl_monitor_side_tap_process(d);
         demod_log_retune_diag_block(d, span.got, &retune_diag);
@@ -3558,7 +3540,6 @@ rtl_stream_bump_output_generation(void) {
     if (next == 0U) {
         next = g_rtl_output_generation.fetch_add(1, std::memory_order_acq_rel) + 1U;
     }
-    rtl_fsk_metrics_reset_snapshot();
     rtl_decode_health_reset();
     return next;
 }
@@ -3566,7 +3547,7 @@ rtl_stream_bump_output_generation(void) {
 static int
 rtl_stream_consume_fsk_reacquire_pending(struct demod_state* d) {
     int pending = g_fsk_reacquire_pending.exchange(0, std::memory_order_acq_rel);
-    if (!pending || !d || d->output_kind != DSD_DEMOD_OUTPUT_SYMBOL_FSK) {
+    if (!pending || !d || d->output_kind != DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
         return 0;
     }
     dsd_rtl_stream_clear_output();
@@ -6310,15 +6291,11 @@ auto_ppm_make_config(const dsd_opts* opts) {
 
 static int
 auto_ppm_fsk_phase_cfo_hz(double* out_cfo_hz) {
-    if (!out_cfo_hz || demod.cqpsk_enable || demod.output_kind != DSD_DEMOD_OUTPUT_SYMBOL_FSK || demod.rate_out <= 0) {
+    if (!out_cfo_hz || demod.cqpsk_enable || demod.output_kind != DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR
+        || demod.rate_out <= 0 || !demod.fsk_modem_state.have_prev) {
         return 0;
     }
-    if (!g_fsk_metrics_valid.load(std::memory_order_acquire)
-        || !g_fsk_metrics_timing_acquired.load(std::memory_order_relaxed)) {
-        return 0;
-    }
-
-    double dc_rad_per_sample = g_fsk_metrics_dc_est.load(std::memory_order_relaxed);
+    double dc_rad_per_sample = (double)demod.fsk_modem_state.dc_est;
     if (!std::isfinite(dc_rad_per_sample)) {
         return 0;
     }
@@ -6673,7 +6650,6 @@ dsd_rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_pr
     cfg.channel_profile = demod.channel_lpf_profile;
     dsd_fsk_modem_configure(&demod.fsk_modem_state, &cfg);
     if (changed) {
-        rtl_fsk_metrics_reset_snapshot();
         demod.costas_reset_pending = 1;
     }
     return 0;
@@ -6681,7 +6657,7 @@ dsd_rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_pr
 
 extern "C" int
 dsd_rtl_stream_request_fsk_reacquire(void) {
-    if (demod.output_kind != DSD_DEMOD_OUTPUT_SYMBOL_FSK) {
+    if (demod.output_kind != DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
         return 0;
     }
     g_fsk_reacquire_pending.store(1, std::memory_order_release);
@@ -6814,8 +6790,8 @@ dsd_rtl_stream_get_ted_gain(void) {
 }
 
 static inline int
-rtl_stream_fsk_symbol_output_active(void) {
-    return demod.output_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK;
+rtl_stream_fsk_direct_output_active(void) {
+    return demod.output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
 }
 
 static inline int
@@ -6831,7 +6807,7 @@ rtl_stream_reset_ted_runtime_state(void) {
 
 static void
 rtl_stream_apply_symbol_timing_mode(void) {
-    if (rtl_stream_fsk_symbol_output_active()) {
+    if (rtl_stream_fsk_direct_output_active()) {
         if (demod.ted_enabled) {
             demod.ted_enabled = 0;
             rtl_stream_reset_ted_runtime_state();
@@ -6975,44 +6951,6 @@ rtl_stream_p25p1_ber_update(int fec_ok_delta, int fec_err_delta) {
 }
 
 extern "C" int
-dsd_rtl_stream_get_fsk_metrics(rtl_stream_fsk_metrics* out) {
-    if (!out) {
-        return -1;
-    }
-    *out = rtl_stream_fsk_metrics{};
-    uint32_t current_generation = g_rtl_output_generation.load(std::memory_order_acquire);
-    uint32_t snapshot_generation = g_fsk_metrics_generation.load(std::memory_order_acquire);
-    out->generation = current_generation;
-    if (!rtl_stream_context_active()) {
-        rtl_fsk_metrics_reset_snapshot();
-        return 0;
-    }
-    if (!g_fsk_metrics_valid.load(std::memory_order_acquire) || snapshot_generation != current_generation) {
-        return 0;
-    }
-    out->valid = 1;
-    out->levels = g_fsk_metrics_levels.load(std::memory_order_relaxed);
-    out->symbol_rate_hz = g_fsk_metrics_symbol_rate_hz.load(std::memory_order_relaxed);
-    out->symbols_total = g_fsk_metrics_symbols_total.load(std::memory_order_relaxed);
-    out->window_symbols = g_fsk_metrics_window_symbols.load(std::memory_order_relaxed);
-    out->mean_reliability = g_fsk_metrics_mean_reliability.load(std::memory_order_relaxed);
-    out->min_reliability = g_fsk_metrics_min_reliability.load(std::memory_order_relaxed);
-    out->rms_error = (float)g_fsk_metrics_rms_error.load(std::memory_order_relaxed);
-    out->evm_snr_db = (float)g_fsk_metrics_evm_snr_db.load(std::memory_order_relaxed);
-    out->low_reliability_pct = (float)g_fsk_metrics_low_reliability_pct.load(std::memory_order_relaxed);
-    out->clip_pct = (float)g_fsk_metrics_clip_pct.load(std::memory_order_relaxed);
-    out->timing_acquired = g_fsk_metrics_timing_acquired.load(std::memory_order_relaxed);
-    out->track_last_error = (float)g_fsk_metrics_track_last_error.load(std::memory_order_relaxed);
-    out->track_last_score = (float)g_fsk_metrics_track_last_score.load(std::memory_order_relaxed);
-    out->track_updates = g_fsk_metrics_track_updates.load(std::memory_order_relaxed);
-    out->track_skips = g_fsk_metrics_track_skips.load(std::memory_order_relaxed);
-    out->abs_est = (float)g_fsk_metrics_abs_est.load(std::memory_order_relaxed);
-    out->dc_est = (float)g_fsk_metrics_dc_est.load(std::memory_order_relaxed);
-    out->last_symbol = (float)g_fsk_metrics_last_symbol.load(std::memory_order_relaxed);
-    return 0;
-}
-
-extern "C" int
 dsd_rtl_stream_get_input_level(dsd_input_level_snapshot* out) {
     if (!out) {
         return -1;
@@ -7031,14 +6969,6 @@ dsd_rtl_stream_get_input_level(dsd_input_level_snapshot* out) {
         out->sample_count = g_input_level_sample_count.load(std::memory_order_relaxed);
         out->updated = (time_t)g_input_level_updated.load(std::memory_order_relaxed);
         return 0;
-    }
-
-    rtl_stream_fsk_metrics fsk{};
-    if (dsd_rtl_stream_get_fsk_metrics(&fsk) == 0 && fsk.valid && fsk.clip_pct > 0.0f) {
-        uint64_t symbols = fsk.window_symbols ? (uint64_t)fsk.window_symbols : fsk.symbols_total;
-        if (dsd_input_level_metrics_from_fsk_clip(fsk.clip_pct, symbols, out) == 0) {
-            return 0;
-        }
     }
     return 0;
 }
@@ -7098,7 +7028,7 @@ rtl_stream_disable_cqpsk_mode(void) {
         demod.channel_lpf_profile = rtl_stream_fsk_channel_profile_for_current_mode();
     }
     if (g_stream && opts_is_digital_mode(g_stream->opts) && radio_source_is_rtl_family(g_stream->opts)) {
-        demod.output_kind = DSD_DEMOD_OUTPUT_SYMBOL_FSK;
+        demod.output_kind = DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
     } else {
         demod.output_kind = DSD_DEMOD_OUTPUT_AUDIO_MONITOR;
     }
@@ -7935,15 +7865,9 @@ dsd_rtl_stream_test_fsk_reacquire(int output_kind, size_t queued_samples, int ca
     }
 
     int prev_output_kind = demod.output_kind;
-    if (demod.fsk_modem_state.pending_heap) {
-        fsk_reacquire_test_cleanup_output_ring(initialized_output);
-        return -4;
-    }
     dsd_fsk_modem_state prev_modem = demod.fsk_modem_state;
     demod.output_kind = output_kind;
     demod.fsk_modem_state.have_prev = 1;
-    demod.fsk_modem_state.timing_acquired = 1;
-    demod.fsk_modem_state.track_len = 9;
     g_fsk_reacquire_pending.store(0, std::memory_order_release);
 
     ring_clear(&output);
@@ -8210,6 +8134,9 @@ dsd_rtl_stream_clear_output(void) {
         outp = g_stream->output;
     }
     rtl_stream_clear_output_ring(outp, 1);
+    if (demod.output_kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR) {
+        dsd_fsk_modem_reset(&demod.fsk_modem_state);
+    }
 }
 
 extern "C" int

--- a/src/io/radio/rtl_stream_c.cpp
+++ b/src/io/radio/rtl_stream_c.cpp
@@ -103,6 +103,10 @@ int dsd_rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_
 int dsd_rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size_t* out_used_after,
                                      int* out_cache_pending_after, uint32_t* out_generation_before,
                                      uint32_t* out_generation_after);
+int dsd_rtl_stream_test_clear_output_fsk_reset(size_t queued_samples, int* out_have_prev_after_clear,
+                                               int* out_consumed_reset, int* out_have_prev_after_consume);
+int dsd_rtl_stream_test_fsk_cfo_snapshot(double dc_rad_per_sample, int rate_out_hz, double* out_cfo_hz,
+                                         int* out_after_reset_available);
 int dsd_rtl_stream_test_fsk_reacquire(int output_kind, size_t queued_samples, int cached_symbols,
                                       size_t* out_used_after, int* out_cache_pending_after,
                                       uint32_t* out_generation_before, uint32_t* out_generation_after,
@@ -281,6 +285,19 @@ rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size_t* 
                              uint32_t* out_generation_after) {
     return dsd_rtl_stream_test_clear_output(queued_samples, cached_symbols, out_used_after, out_cache_pending_after,
                                             out_generation_before, out_generation_after);
+}
+
+extern "C" int
+rtl_stream_test_clear_output_fsk_reset(size_t queued_samples, int* out_have_prev_after_clear, int* out_consumed_reset,
+                                       int* out_have_prev_after_consume) {
+    return dsd_rtl_stream_test_clear_output_fsk_reset(queued_samples, out_have_prev_after_clear, out_consumed_reset,
+                                                      out_have_prev_after_consume);
+}
+
+extern "C" int
+rtl_stream_test_fsk_cfo_snapshot(double dc_rad_per_sample, int rate_out_hz, double* out_cfo_hz,
+                                 int* out_after_reset_available) {
+    return dsd_rtl_stream_test_fsk_cfo_snapshot(dc_rad_per_sample, rate_out_hz, out_cfo_hz, out_after_reset_available);
 }
 
 extern "C" int

--- a/src/io/radio/rtl_stream_c.cpp
+++ b/src/io/radio/rtl_stream_c.cpp
@@ -86,7 +86,6 @@ double dsd_rtl_stream_get_snr_bias_evm(void);
 /* Tuner autogain */
 int dsd_rtl_stream_get_tuner_autogain(void);
 void dsd_rtl_stream_set_tuner_autogain(int onoff);
-int dsd_rtl_stream_get_fsk_metrics(rtl_stream_fsk_metrics* out);
 int dsd_rtl_stream_get_decode_health(rtl_stream_decode_health* out);
 int dsd_rtl_stream_get_input_level(dsd_input_level_snapshot* out);
 void dsd_rtl_stream_set_channel_squelch(float level);
@@ -625,11 +624,6 @@ extern "C" double dsd_rtl_stream_get_fll_band_edge_freq_hz(void);
 extern "C" double
 rtl_stream_get_fll_band_edge_freq_hz(void) {
     return dsd_rtl_stream_get_fll_band_edge_freq_hz();
-}
-
-extern "C" int
-rtl_stream_get_fsk_metrics(rtl_stream_fsk_metrics* out) {
-    return dsd_rtl_stream_get_fsk_metrics(out);
 }
 
 extern "C" int

--- a/src/io/radio/rtl_stream_c.cpp
+++ b/src/io/radio/rtl_stream_c.cpp
@@ -105,6 +105,9 @@ int dsd_rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, 
                                      uint32_t* out_generation_after);
 int dsd_rtl_stream_test_clear_output_fsk_reset(size_t queued_samples, int* out_have_prev_after_clear,
                                                int* out_consumed_reset, int* out_have_prev_after_consume);
+int dsd_rtl_stream_test_cqpsk_toggle_output_clear(int start_cqpsk, int target_cqpsk, int active_rtl_digital,
+                                                  size_t queued_samples, int cached_symbols,
+                                                  rtl_stream_test_cqpsk_toggle_result* out_result);
 int dsd_rtl_stream_test_fsk_cfo_snapshot(double dc_rad_per_sample, int rate_out_hz, double* out_cfo_hz,
                                          int* out_after_generation_bump_available, int* out_after_reset_available);
 int dsd_rtl_stream_test_fsk_snr_sps(int rate_out_hz, int symbol_rate_hz, int stale_ted_sps);
@@ -295,6 +298,14 @@ rtl_stream_test_clear_output_fsk_reset(size_t queued_samples, int* out_have_prev
                                        int* out_have_prev_after_consume) {
     return dsd_rtl_stream_test_clear_output_fsk_reset(queued_samples, out_have_prev_after_clear, out_consumed_reset,
                                                       out_have_prev_after_consume);
+}
+
+extern "C" int
+rtl_stream_test_cqpsk_toggle_output_clear(int start_cqpsk, int target_cqpsk, int active_rtl_digital,
+                                          size_t queued_samples, int cached_symbols,
+                                          rtl_stream_test_cqpsk_toggle_result* out_result) {
+    return dsd_rtl_stream_test_cqpsk_toggle_output_clear(start_cqpsk, target_cqpsk, active_rtl_digital, queued_samples,
+                                                         cached_symbols, out_result);
 }
 
 extern "C" int

--- a/src/io/radio/rtl_stream_c.cpp
+++ b/src/io/radio/rtl_stream_c.cpp
@@ -106,7 +106,10 @@ int dsd_rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, 
 int dsd_rtl_stream_test_clear_output_fsk_reset(size_t queued_samples, int* out_have_prev_after_clear,
                                                int* out_consumed_reset, int* out_have_prev_after_consume);
 int dsd_rtl_stream_test_fsk_cfo_snapshot(double dc_rad_per_sample, int rate_out_hz, double* out_cfo_hz,
-                                         int* out_after_reset_available);
+                                         int* out_after_generation_bump_available, int* out_after_reset_available);
+int dsd_rtl_stream_test_fsk_snr_sps(int rate_out_hz, int symbol_rate_hz, int stale_ted_sps);
+int dsd_rtl_stream_test_direct_output_rate_after_open_update(int output_kind, int rate_out_hz, int resamp_target_hz,
+                                                             unsigned int* out_rate_hz, int* out_resamp_enabled);
 int dsd_rtl_stream_test_fsk_reacquire(int output_kind, size_t queued_samples, int cached_symbols,
                                       size_t* out_used_after, int* out_cache_pending_after,
                                       uint32_t* out_generation_before, uint32_t* out_generation_after,
@@ -296,8 +299,21 @@ rtl_stream_test_clear_output_fsk_reset(size_t queued_samples, int* out_have_prev
 
 extern "C" int
 rtl_stream_test_fsk_cfo_snapshot(double dc_rad_per_sample, int rate_out_hz, double* out_cfo_hz,
-                                 int* out_after_reset_available) {
-    return dsd_rtl_stream_test_fsk_cfo_snapshot(dc_rad_per_sample, rate_out_hz, out_cfo_hz, out_after_reset_available);
+                                 int* out_after_generation_bump_available, int* out_after_reset_available) {
+    return dsd_rtl_stream_test_fsk_cfo_snapshot(dc_rad_per_sample, rate_out_hz, out_cfo_hz,
+                                                out_after_generation_bump_available, out_after_reset_available);
+}
+
+extern "C" int
+rtl_stream_test_fsk_snr_sps(int rate_out_hz, int symbol_rate_hz, int stale_ted_sps) {
+    return dsd_rtl_stream_test_fsk_snr_sps(rate_out_hz, symbol_rate_hz, stale_ted_sps);
+}
+
+extern "C" int
+rtl_stream_test_direct_output_rate_after_open_update(int output_kind, int rate_out_hz, int resamp_target_hz,
+                                                     unsigned int* out_rate_hz, int* out_resamp_enabled) {
+    return dsd_rtl_stream_test_direct_output_rate_after_open_update(output_kind, rate_out_hz, resamp_target_hz,
+                                                                    out_rate_hz, out_resamp_enabled);
 }
 
 extern "C" int

--- a/src/runtime/input_level.c
+++ b/src/runtime/input_level.c
@@ -71,8 +71,8 @@ dsd_input_level_source_is_rf(dsd_input_level_source source) {
         case DSD_INPUT_LEVEL_SOURCE_RTL_CU8:
         case DSD_INPUT_LEVEL_SOURCE_RTL_TCP_CU8:
         case DSD_INPUT_LEVEL_SOURCE_SOAPY_CS16:
-        case DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32:
-        case DSD_INPUT_LEVEL_SOURCE_FSK_SYMBOL: return 1;
+        case DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32: return 1;
+        case DSD_INPUT_LEVEL_SOURCE_FSK_SYMBOL:
         case DSD_INPUT_LEVEL_SOURCE_PCM:
         case DSD_INPUT_LEVEL_SOURCE_UNKNOWN:
         default: return 0;
@@ -135,12 +135,12 @@ dsd_input_level_classify(dsd_input_level_snapshot* snapshot, double low_warn_db)
         }
         return;
     }
-    if (snapshot->clip_pct >= DSD_INPUT_LEVEL_CLIP_PCT) {
-        snapshot->status = DSD_INPUT_LEVEL_CLIPPING;
-        return;
-    }
     if (snapshot->source == DSD_INPUT_LEVEL_SOURCE_FSK_SYMBOL) {
         snapshot->status = DSD_INPUT_LEVEL_UNKNOWN;
+        return;
+    }
+    if (snapshot->clip_pct >= DSD_INPUT_LEVEL_CLIP_PCT) {
+        snapshot->status = DSD_INPUT_LEVEL_CLIPPING;
         return;
     }
     if (snapshot->peak_dbfs >= DSD_INPUT_LEVEL_HOT_PEAK_DBFS) {

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -150,8 +150,8 @@ ui_demod_symbol_rate_hz(const dsd_opts* opts, const dsd_state* state) {
         int symbol_rate_hz = 0;
         int output_kind = rtl_stream_get_output_kind();
         /* RTL direct symbol paths feed one decoded symbol per sample; report the configured profile rate. */
-        if (output_kind == RTL_STREAM_OUTPUT_SYMBOL_CQPSK && rtl_stream_get_symbol_profile(&symbol_rate_hz, NULL) == 0
-            && symbol_rate_hz > 0) {
+        if ((output_kind == RTL_STREAM_OUTPUT_SYMBOL_CQPSK || output_kind == RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR)
+            && rtl_stream_get_symbol_profile(&symbol_rate_hz, NULL) == 0 && symbol_rate_hz > 0) {
             return symbol_rate_hz;
         }
 

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -149,10 +149,9 @@ ui_demod_symbol_rate_hz(const dsd_opts* opts, const dsd_state* state) {
     if (opts && state && opts->audio_in_type == AUDIO_IN_RTL && state->rtl_ctx) {
         int symbol_rate_hz = 0;
         int output_kind = rtl_stream_get_output_kind();
-        /* RTL symbol-output paths feed one sliced symbol per sample; report the configured profile rate. */
-        if ((output_kind == RTL_STREAM_OUTPUT_SYMBOL_FSK || output_kind == RTL_STREAM_OUTPUT_SYMBOL_CQPSK
-             || state->samplesPerSymbol <= 1)
-            && rtl_stream_get_symbol_profile(&symbol_rate_hz, NULL) == 0 && symbol_rate_hz > 0) {
+        /* RTL direct symbol paths feed one decoded symbol per sample; report the configured profile rate. */
+        if (output_kind == RTL_STREAM_OUTPUT_SYMBOL_CQPSK && rtl_stream_get_symbol_profile(&symbol_rate_hz, NULL) == 0
+            && symbol_rate_hz > 0) {
             return symbol_rate_hz;
         }
 

--- a/src/ui/terminal/menu_labels.c
+++ b/src/ui/terminal/menu_labels.c
@@ -61,7 +61,8 @@ io_rtl_active(const void* ctx) {
 #ifdef USE_RADIO
 static bool
 rtl_fsk_symbol_output_active_for_ui(void) {
-    return rtl_stream_get_output_kind() == RTL_STREAM_OUTPUT_SYMBOL_FSK;
+    int output_kind = rtl_stream_get_output_kind();
+    return output_kind == RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
 }
 
 bool

--- a/src/ui/terminal/ncurses_dsp_display.c
+++ b/src/ui/terminal/ncurses_dsp_display.c
@@ -144,20 +144,6 @@ dsp_status_print_cqpsk_metrics(void) {
                      (double)cm.confidence_avg_q14 / 16384.0, cm.zero_conf_pct, nco_q15, Fs);
 }
 
-static void
-dsp_status_print_fsk_metrics(void) {
-    rtl_stream_fsk_metrics fm;
-    DSD_MEMSET(&fm, 0, sizeof(fm));
-    if (rtl_stream_get_fsk_metrics(&fm) != 0 || !fm.valid) {
-        return;
-    }
-    ui_print_kv_line("FSK Soft", "rel:%u min:%u low:%4.1f%% clip:%4.1f%% err:%.3f snr:%4.1f dB", fm.mean_reliability,
-                     fm.min_reliability, fm.low_reliability_pct, fm.clip_pct, fm.rms_error, fm.evm_snr_db);
-    ui_print_kv_line("FSK Track", "acq:%s e:%.2f score:%.4f upd:%llu skip:%llu", fm.timing_acquired ? "Y" : "N",
-                     fm.track_last_error, fm.track_last_score, (unsigned long long)fm.track_updates,
-                     (unsigned long long)fm.track_skips);
-}
-
 #endif
 
 /* Print a compact DSP status summary (which blocks are active). */
@@ -188,7 +174,6 @@ print_dsp_status(dsd_opts* opts, dsd_state* state) {
     if (snap.cq) {
         dsp_status_print_cqpsk_metrics();
     }
-    dsp_status_print_fsk_metrics();
 #endif
     attroff(COLOR_PAIR(14));
     attron(COLOR_PAIR(4));

--- a/src/ui/terminal/ui_snr_readout.c
+++ b/src/ui/terminal/ui_snr_readout.c
@@ -7,7 +7,6 @@
 
 #ifdef USE_RADIO
 #include <dsd-neo/io/rtl_stream_c.h>
-#include <math.h>
 #endif
 
 enum { UI_SNR_INVALID_DB = -50 };
@@ -29,53 +28,6 @@ ui_snr_value_is_valid(double snr) {
     return snr > (double)UI_SNR_INVALID_DB;
 }
 
-enum {
-    UI_SNR_STALE_THRESHOLD_CDB = 5, /* 0.05 dB in centi-dB */
-    UI_SNR_STALE_LIMIT = 40
-};
-
-typedef struct ui_snr_stale_state {
-    double last_snr;
-    int stable_count;
-} ui_snr_stale_state;
-
-static ui_snr_stale_state g_c4fm_stale = {-999.0, 0};
-static ui_snr_stale_state g_qpsk_stale = {-999.0, 0};
-static ui_snr_stale_state g_gfsk_stale = {-999.0, 0};
-
-static double
-ui_snr_maybe_replace_stale(double snr, ui_snr_stale_state* state, double (*fallback_fn)(void)) {
-    if (!state || !fallback_fn) {
-        return snr;
-    }
-
-    int delta_cdb = (int)(fabs(snr - state->last_snr) * 100.0);
-    if (delta_cdb < UI_SNR_STALE_THRESHOLD_CDB) {
-        if (++state->stable_count >= UI_SNR_STALE_LIMIT) {
-            double fb = fallback_fn();
-            if (ui_snr_value_is_valid(fb)) {
-                snr = fb;
-            }
-            state->stable_count = 0;
-        }
-    } else {
-        state->stable_count = 0;
-    }
-    state->last_snr = snr;
-    return snr;
-}
-
-#ifdef DSD_NEO_TEST_HOOKS
-static void
-ui_snr_stale_reset(ui_snr_stale_state* state) {
-    if (!state) {
-        return;
-    }
-    state->last_snr = -999.0;
-    state->stable_count = 0;
-}
-#endif
-
 static double
 ui_snr_get_c4fm_value(void) {
     double snr = rtl_stream_get_snr_c4fm();
@@ -83,12 +35,9 @@ ui_snr_get_c4fm_value(void) {
         double fb = rtl_stream_estimate_snr_c4fm_eye();
         if (ui_snr_value_is_valid(fb)) {
             snr = fb;
-            g_c4fm_stale.stable_count = 0;
         }
-        return snr;
     }
-
-    return ui_snr_maybe_replace_stale(snr, &g_c4fm_stale, rtl_stream_estimate_snr_c4fm_eye);
+    return snr;
 }
 
 static double
@@ -98,7 +47,6 @@ ui_snr_get_qpsk_value(void) {
         double fb = rtl_stream_estimate_snr_qpsk_const();
         if (ui_snr_value_is_valid(fb)) {
             snr = fb;
-            g_qpsk_stale.stable_count = 0;
         } else {
             double snr_c = rtl_stream_get_snr_c4fm();
             double snr_g = rtl_stream_get_snr_gfsk();
@@ -107,10 +55,8 @@ ui_snr_get_qpsk_value(void) {
                 snr = snr_fb;
             }
         }
-        return snr;
     }
-
-    return ui_snr_maybe_replace_stale(snr, &g_qpsk_stale, rtl_stream_estimate_snr_qpsk_const);
+    return snr;
 }
 
 static double
@@ -120,28 +66,11 @@ ui_snr_get_gfsk_value(void) {
         double fb = rtl_stream_estimate_snr_gfsk_eye();
         if (ui_snr_value_is_valid(fb)) {
             snr = fb;
-            g_gfsk_stale.stable_count = 0;
         }
-        return snr;
     }
-
-    return ui_snr_maybe_replace_stale(snr, &g_gfsk_stale, rtl_stream_estimate_snr_gfsk_eye);
+    return snr;
 }
 
-static int
-ui_snr_try_fsk_soft_value(double* out_snr) {
-    if (!out_snr) {
-        return 0;
-    }
-
-    rtl_stream_fsk_metrics metrics;
-    if (rtl_stream_get_fsk_metrics(&metrics) != 0 || !metrics.valid || !ui_snr_value_is_valid(metrics.evm_snr_db)) {
-        return 0;
-    }
-
-    *out_snr = (double)metrics.evm_snr_db;
-    return 1;
-}
 #endif
 
 ui_snr_readout
@@ -153,7 +82,7 @@ ui_snr_readout_for_mod(int rf_mod) {
     double snr = (double)UI_SNR_INVALID_DB;
     if (rf_mod == 1) {
         snr = ui_snr_get_qpsk_value();
-    } else if (!ui_snr_try_fsk_soft_value(&snr)) {
+    } else {
         snr = (rf_mod == 2) ? ui_snr_get_gfsk_value() : ui_snr_get_c4fm_value();
     }
     out.snr_db = snr;
@@ -168,11 +97,5 @@ ui_snr_readout_for_mod(int rf_mod) {
 
 #ifdef DSD_NEO_TEST_HOOKS
 void
-ui_snr_readout_reset_for_test(void) {
-#ifdef USE_RADIO
-    ui_snr_stale_reset(&g_c4fm_stale);
-    ui_snr_stale_reset(&g_qpsk_stale);
-    ui_snr_stale_reset(&g_gfsk_stale);
-#endif
-}
+ui_snr_readout_reset_for_test(void) {}
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3860,6 +3860,14 @@ target_include_directories(
 dsd_neo_link_dsp_test(dsd-neo_test_dsp_snr_bias ${DSD_NEO_TEST_MATH_LIB})
 add_test(NAME DSP_SNR_BIAS COMMAND dsd-neo_test_dsp_snr_bias)
 
+add_executable(dsd-neo_test_dsp_snr_estimator dsp/test_dsp_snr_estimator.cpp)
+target_include_directories(
+    dsd-neo_test_dsp_snr_estimator
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+dsd_neo_link_dsp_test(dsd-neo_test_dsp_snr_estimator ${DSD_NEO_TEST_MATH_LIB})
+add_test(NAME DSP_SNR_ESTIMATOR COMMAND dsd-neo_test_dsp_snr_estimator)
+
 # Post-demod audio polyphase decimator (M>2) smoke test
 add_executable(
     dsd-neo_test_dsp_audio_polydecim

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4851,6 +4851,28 @@ target_link_libraries(
 )
 add_test(NAME DIBIT_SYMBOL_BIN_SOFT COMMAND dsd-neo_test_dibit_symbol_bin_soft)
 
+add_executable(
+    dsd-neo_test_dibit_rtl_fsk_reliability
+    core/test_dibit_rtl_fsk_reliability.c
+    ${PROJECT_SOURCE_DIR}/src/core/frames/dsd_dibit.c
+)
+target_compile_definitions(
+    dsd-neo_test_dibit_rtl_fsk_reliability
+    PRIVATE USE_RADIO
+)
+target_include_directories(
+    dsd-neo_test_dibit_rtl_fsk_reliability
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_dibit_rtl_fsk_reliability
+    PRIVATE dsd-neo_platform ${DSD_NEO_TEST_MATH_LIB}
+)
+add_test(
+    NAME DIBIT_RTL_FSK_RELIABILITY
+    COMMAND dsd-neo_test_dibit_rtl_fsk_reliability
+)
+
 # Sync hamming/remap helper unit test
 add_executable(dsd-neo_test_dsp_sync_hamming dsp/test_dsp_sync_hamming.c)
 target_include_directories(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1897,6 +1897,7 @@ if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
             "-Wl,--wrap=rtl_stream_output_rate"
             "-Wl,--wrap=rtl_stream_prepare_retune_profile_for_target"
             "-Wl,--wrap=rtl_stream_prepare_retune_profile_for_target_with_gain"
+            "-Wl,--wrap=rtl_stream_request_fsk_reacquire"
             "-Wl,--wrap=rtl_stream_tune"
             ${LIBS}
             dsd-neo_feature_radio

--- a/tests/core/test_core_init_state.c
+++ b/tests/core/test_core_init_state.c
@@ -73,6 +73,9 @@ main(void) {
     state->rtl_symbol_cache_levels = 4;
     state->rtl_symbol_cache_generation = 42U;
     state->rtl_symbol_cache_published_pending = 2;
+    state->rtl_fsk_sps_num = 24000;
+    state->rtl_fsk_sps_den = 9600;
+    state->rtl_fsk_sps_accum = 4800;
     state->ess_b[0][95] = 1;
     state->ess_b_llr[1][95] = 123;
     state->fourv_counter[0] = 2;
@@ -253,7 +256,8 @@ main(void) {
     if (state->rtl_symbol_cache_pos != 0 || state->rtl_symbol_cache_len != 0 || state->rtl_symbol_cache_output_kind != 0
         || state->rtl_symbol_cache_channel_profile != 0 || state->rtl_symbol_cache_symbol_rate_hz != 0
         || state->rtl_symbol_cache_levels != 0 || state->rtl_symbol_cache_generation != 0U
-        || state->rtl_symbol_cache_published_pending != 0 || state->rtl_symbol_cache[0] != 0.0f
+        || state->rtl_symbol_cache_published_pending != 0 || state->rtl_fsk_sps_num != 0 || state->rtl_fsk_sps_den != 0
+        || state->rtl_fsk_sps_accum != 0 || state->rtl_symbol_cache[0] != 0.0f
         || state->rtl_symbol_cache[DSD_RTL_SYMBOL_CACHE_CAP - 1] != 0.0f) {
         DSD_FPRINTF(stderr, "initState did not clear RTL symbol cache state\n");
         freeState(state);

--- a/tests/core/test_core_input_level.c
+++ b/tests/core/test_core_input_level.c
@@ -371,6 +371,14 @@ test_advisory_text_selection(void) {
     dsd_input_level_classify(&rf_clip, -40.0);
     assert(dsd_input_level_format_advisory(&rf_clip, msg, sizeof(msg)) == 0);
     assert(strstr(msg, "lower RF gain or add filtering/attenuation") != NULL);
+
+    dsd_input_level_snapshot fsk_clip = snapshot_for(DSD_INPUT_LEVEL_SOURCE_FSK_SYMBOL, -120.0, -120.0, 12.5, 1);
+    dsd_input_level_classify(&fsk_clip, -40.0);
+    assert(fsk_clip.status == DSD_INPUT_LEVEL_UNKNOWN);
+    assert(dsd_input_level_format_advisory(&fsk_clip, msg, sizeof(msg)) == 0);
+    assert(strstr(msg, "Input Level UNKNOWN") != NULL);
+    assert(strstr(msg, "RF Level") == NULL);
+    assert(strstr(msg, "lower RF gain") == NULL);
 }
 
 int

--- a/tests/core/test_dibit_rtl_fsk_reliability.c
+++ b/tests/core/test_dibit_rtl_fsk_reliability.c
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+float
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+getSymbol(dsd_opts* opts, dsd_state* state, int have_sync) {
+    (void)opts;
+    (void)state;
+    (void)have_sync;
+    return 0.0f;
+}
+
+uint64_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_time_monotonic_ns(void) {
+    return 0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_sleep_ms(unsigned int ms) {
+    (void)ms;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_sleep_ns(uint64_t ns) {
+    (void)ns;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_sleep_us(uint64_t us) {
+    (void)us;
+}
+
+void
+dsd_neo_config_init(const dsd_opts* opts) {
+    (void)opts;
+}
+
+const dsdneoRuntimeConfig*
+dsd_neo_get_config(void) {
+    static dsdneoRuntimeConfig cfg;
+    return &cfg;
+}
+
+int
+dsd_rtl_stream_metrics_hook_output_kind(void) {
+    return 1; /* RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR */
+}
+
+int
+dsd_rtl_stream_metrics_hook_symbol_profile(int* out_symbol_rate_hz, int* out_levels, int* out_channel_profile) {
+    if (out_symbol_rate_hz) {
+        *out_symbol_rate_hz = 4800;
+    }
+    if (out_levels) {
+        *out_levels = 4;
+    }
+    if (out_channel_profile) {
+        *out_channel_profile = 2;
+    }
+    return 0;
+}
+
+int
+dsd_rtl_stream_metrics_hook_stream_active(void) {
+    return 1;
+}
+
+double
+dsd_rtl_stream_metrics_hook_snr_c4fm_db(void) {
+    return 25.0;
+}
+
+double
+dsd_rtl_stream_metrics_hook_snr_c4fm_eye_db(void) {
+    return 25.0;
+}
+
+double
+dsd_rtl_stream_metrics_hook_snr_gfsk_db(void) {
+    return 25.0;
+}
+
+double
+dsd_rtl_stream_metrics_hook_snr_cqpsk_db(void) {
+    return 25.0;
+}
+
+int
+dsd_rtl_stream_metrics_hook_cqpsk_status(int* out_cqpsk_enable, int* out_cqpsk_timing_active) {
+    if (out_cqpsk_enable) {
+        *out_cqpsk_enable = 0;
+    }
+    if (out_cqpsk_timing_active) {
+        *out_cqpsk_timing_active = 0;
+    }
+    return 0;
+}
+
+int
+main(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.rf_mod = 0;
+    state.min = -30000.0f;
+    state.max = 30000.0f;
+    state.center = 0.0f;
+    state.lmid = -20000.0f;
+    state.umid = 20000.0f;
+
+    uint8_t reliability = dmr_compute_reliability(&state, 30000.0f);
+
+    if (reliability < 200U) {
+        DSD_FPRINTF(stderr, "RTL FSK discriminator reliability clipped to %u\n", reliability);
+        return 1;
+    }
+    return 0;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/dsp/bench_dsp.cpp
+++ b/tests/dsp/bench_dsp.cpp
@@ -625,8 +625,8 @@ bench_fir(const BenchOptions& opts) {
 }
 
 static int
-bench_one_fsk_modem_variant(const BenchOptions& opts, const char* name, int sample_rate, int symbol_rate, int levels,
-                            int reset_each_call) {
+bench_one_fsk_discriminator_variant(const BenchOptions& opts, const char* name, int sample_rate, int symbol_rate,
+                                    int levels, int reset_each_call) {
     const int sps = sample_rate / symbol_rate;
     constexpr int kPairs = 4096;
     constexpr int kInLen = kPairs * 2;
@@ -643,7 +643,8 @@ bench_one_fsk_modem_variant(const BenchOptions& opts, const char* name, int samp
     dsd_fsk_modem_init(&fsk_state, &fsk_cfg);
 
     if (!reset_each_call) {
-        (void)dsd_fsk_modem_process(&fsk_state, fsk_iq.data(), kInLen, fsk_out.data(), (int)fsk_out.size());
+        (void)dsd_fsk_modem_discriminator_process(&fsk_state, fsk_iq.data(), kInLen, fsk_out.data(),
+                                                  (int)fsk_out.size());
     }
 
     BenchMeta meta;
@@ -657,7 +658,8 @@ bench_one_fsk_modem_variant(const BenchOptions& opts, const char* name, int samp
             if (reset_each_call) {
                 dsd_fsk_modem_reset(&fsk_state);
             }
-            int got = dsd_fsk_modem_process(&fsk_state, fsk_iq.data(), kInLen, fsk_out.data(), (int)fsk_out.size());
+            int got = dsd_fsk_modem_discriminator_process(&fsk_state, fsk_iq.data(), kInLen, fsk_out.data(),
+                                                          (int)fsk_out.size());
             return fsk_out[0] + fsk_out[(got > 0) ? got - 1 : 0] + (float)got;
         },
         &meta);
@@ -669,14 +671,14 @@ bench_one_fsk_modem_variant(const BenchOptions& opts, const char* name, int samp
 static int
 bench_fsk_modem_variants(const BenchOptions& opts) {
     int ran = 0;
-    ran += bench_one_fsk_modem_variant(opts, "fsk_modem_4lvl_24k_acq", 24000, 4800, 4, 1);
-    ran += bench_one_fsk_modem_variant(opts, "fsk_modem_4lvl_24k_steady", 24000, 4800, 4, 0);
-    ran += bench_one_fsk_modem_variant(opts, "fsk_modem_4lvl_48k_acq", 48000, 4800, 4, 1);
-    ran += bench_one_fsk_modem_variant(opts, "fsk_modem_4lvl_48k_steady", 48000, 4800, 4, 0);
-    ran += bench_one_fsk_modem_variant(opts, "fsk_modem_2lvl_24k_acq", 24000, 2400, 2, 1);
-    ran += bench_one_fsk_modem_variant(opts, "fsk_modem_2lvl_24k_steady", 24000, 2400, 2, 0);
-    ran += bench_one_fsk_modem_variant(opts, "fsk_modem_2lvl_48k_acq", 48000, 2400, 2, 1);
-    ran += bench_one_fsk_modem_variant(opts, "fsk_modem_2lvl_48k_steady", 48000, 2400, 2, 0);
+    ran += bench_one_fsk_discriminator_variant(opts, "fsk_discriminator_4lvl_24k_reset", 24000, 4800, 4, 1);
+    ran += bench_one_fsk_discriminator_variant(opts, "fsk_discriminator_4lvl_24k_steady", 24000, 4800, 4, 0);
+    ran += bench_one_fsk_discriminator_variant(opts, "fsk_discriminator_4lvl_48k_reset", 48000, 4800, 4, 1);
+    ran += bench_one_fsk_discriminator_variant(opts, "fsk_discriminator_4lvl_48k_steady", 48000, 4800, 4, 0);
+    ran += bench_one_fsk_discriminator_variant(opts, "fsk_discriminator_2lvl_24k_reset", 24000, 2400, 2, 1);
+    ran += bench_one_fsk_discriminator_variant(opts, "fsk_discriminator_2lvl_24k_steady", 24000, 2400, 2, 0);
+    ran += bench_one_fsk_discriminator_variant(opts, "fsk_discriminator_2lvl_48k_reset", 48000, 2400, 2, 1);
+    ran += bench_one_fsk_discriminator_variant(opts, "fsk_discriminator_2lvl_48k_steady", 48000, 2400, 2, 0);
     return ran;
 }
 
@@ -726,8 +728,9 @@ bench_kernel_demods(const BenchOptions& opts) {
     fsk_cfg.levels = 4;
     fsk_cfg.channel_profile = DSD_CH_LPF_PROFILE_P25_C4FM;
     dsd_fsk_modem_init(&fsk_state, &fsk_cfg);
-    ran += run_case(opts, "dsd_fsk_modem_process", "pair", (double)kPairs, [&]() -> float {
-        int got = dsd_fsk_modem_process(&fsk_state, fsk_iq.data(), kInLen, fsk_out.data(), (int)fsk_out.size());
+    ran += run_case(opts, "dsd_fsk_modem_discriminator_process", "pair", (double)kPairs, [&]() -> float {
+        int got =
+            dsd_fsk_modem_discriminator_process(&fsk_state, fsk_iq.data(), kInLen, fsk_out.data(), (int)fsk_out.size());
         return fsk_out[0] + fsk_out[(got > 0) ? got - 1 : 0] + (float)got;
     });
     dsd_fsk_modem_release(&fsk_state);
@@ -911,7 +914,7 @@ configure_common_fsk_state(demod_state* s, int sample_rate, int symbol_rate, int
     s->rate_out2 = 0;
     s->lowpassed = s->input_cb_buf;
     s->mode_demod = &dsd_fm_demod;
-    s->output_kind = DSD_DEMOD_OUTPUT_SYMBOL_FSK;
+    s->output_kind = DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
     s->symbol_rate_hz = symbol_rate;
     s->symbol_levels = 4;
     s->ted_sps = sample_rate / symbol_rate;

--- a/tests/dsp/test_dsp_snr_estimator.cpp
+++ b/tests/dsp/test_dsp_snr_estimator.cpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/dsp/snr_estimator.h>
+
+#include <cstdint>
+#include <stdio.h>
+#include "dsd-neo/core/safe_api.h"
+
+namespace {
+
+enum : std::uint16_t { kSps = 10, kSymbols = 512, kSamples = kSps * kSymbols };
+
+float
+deterministic_noise(uint32_t* seed, float peak) {
+    *seed = (*seed * 1664525u) + 1013904223u;
+    int centered = (int)((*seed >> 16) & 0xffffu) - 32768;
+    return ((float)centered / 32768.0f) * peak;
+}
+
+void
+fill_four_level_discriminator(float* out) {
+    static const float levels[4] = {-30000.0f, -10000.0f, 10000.0f, 30000.0f};
+    uint32_t seed = 0x1234abcdU;
+    float prev = levels[0];
+    for (int sym = 0; sym < kSymbols; sym++) {
+        float level = levels[(sym + (sym / 7)) & 3];
+        for (int k = 0; k < kSps; k++) {
+            float v = (k == 0 && sym > 0) ? (0.5f * (prev + level)) : level;
+            out[(sym * kSps) + k] = v + deterministic_noise(&seed, 350.0f);
+        }
+        prev = level;
+    }
+}
+
+void
+fill_binary_discriminator(float* out) {
+    uint32_t seed = 0x4f1bbc2dU;
+    float prev = -22000.0f;
+    for (int sym = 0; sym < kSymbols; sym++) {
+        float level = (sym & 1) ? 22000.0f : -22000.0f;
+        for (int k = 0; k < kSps; k++) {
+            float v = (k == 0 && sym > 0) ? (0.5f * (prev + level)) : level;
+            out[(sym * kSps) + k] = v + deterministic_noise(&seed, 450.0f);
+        }
+        prev = level;
+    }
+}
+
+int
+expect_good_four_level_estimate(void) {
+    float samples[kSamples];
+    fill_four_level_discriminator(samples);
+
+    double c4fm = dsd_snr_estimate_c4fm_real_db(samples, kSamples, kSps, 1, 7.0);
+    double binary = dsd_snr_estimate_gfsk_real_db(samples, kSamples, kSps, 1, 3.0);
+    if (!(c4fm > 20.0 && c4fm > binary + 12.0)) {
+        DSD_FPRINTF(stderr, "four-level estimator c4fm=%.3f binary=%.3f\n", c4fm, binary);
+        return 1;
+    }
+    return 0;
+}
+
+int
+expect_good_binary_estimate(void) {
+    float samples[kSamples];
+    fill_binary_discriminator(samples);
+
+    double gfsk = dsd_snr_estimate_gfsk_real_db(samples, kSamples, kSps, 1, 3.0);
+    if (!(gfsk > 20.0)) {
+        DSD_FPRINTF(stderr, "binary estimator gfsk=%.3f\n", gfsk);
+        return 1;
+    }
+    return 0;
+}
+
+int
+expect_invalid_for_insufficient_data(void) {
+    float samples[16] = {};
+    double snr = dsd_snr_estimate_c4fm_real_db(samples, 16, kSps, 1, 0.0);
+    if (!(snr <= -50.0)) {
+        DSD_FPRINTF(stderr, "insufficient data estimator snr=%.3f\n", snr);
+        return 1;
+    }
+    return 0;
+}
+
+} // namespace
+
+int
+main(void) {
+    int rc = 0;
+    rc |= expect_good_four_level_estimate();
+    rc |= expect_good_binary_estimate();
+    rc |= expect_invalid_for_insufficient_data();
+    if (rc == 0) {
+        printf("DSP_SNR_ESTIMATOR: OK\n");
+    }
+    return rc;
+}

--- a/tests/dsp/test_frame_sync_m17.c
+++ b/tests/dsp/test_frame_sync_m17.c
@@ -26,7 +26,7 @@
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #endif
 
-static size_t g_symbol_index;
+static size_t g_sample_index;
 static const char* g_sync_pattern = M17_PRE;
 static char g_fill_symbol = '1';
 
@@ -168,10 +168,12 @@ fake_rtl_read(void* rtl_ctx, float* out, size_t count, int* out_got) {
     }
 
     const size_t pattern_len = strlen(g_sync_pattern);
+    const size_t samples_per_symbol = 10U;
     for (size_t i = 0; i < count; i++) {
-        char dibit = (g_symbol_index < pattern_len) ? g_sync_pattern[g_symbol_index] : g_fill_symbol;
+        size_t symbol_index = g_sample_index / samples_per_symbol;
+        char dibit = (symbol_index < pattern_len) ? g_sync_pattern[symbol_index] : g_fill_symbol;
         out[i] = symbol_level_for_m17(dibit);
-        g_symbol_index++;
+        g_sample_index++;
     }
     *out_got = (int)count;
     return 0;
@@ -185,7 +187,7 @@ fake_rtl_pwr(const void* rtl_ctx) {
 
 static int
 fake_output_kind(void) {
-    return RTL_STREAM_OUTPUT_SYMBOL_FSK;
+    return RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
 }
 
 static int
@@ -303,7 +305,7 @@ init_m17_sync_case(dsd_opts* opts, dsd_state* state, int* fake_rtl_context) {
 
 static int
 run_one_on_state(dsd_opts* opts, dsd_state* state, const char* pattern, int expected_sync, const char* label) {
-    g_symbol_index = 0U;
+    g_sample_index = 0U;
     g_sync_pattern = pattern;
     g_fill_symbol = (expected_sync < 0) ? '3' : '1';
     state->rtl_symbol_cache_pos = 0;

--- a/tests/dsp/test_fsk_modem.c
+++ b/tests/dsp/test_fsk_modem.c
@@ -938,6 +938,7 @@ test_local_reacquire_preserves_pending_symbols(void) {
     expect_4level_accuracy_best_shift("local-reacquire-preserves-pending", out, total, symbols, SYMBOLS, RUN, 160, 64,
                                       0.88f);
 
+    dsd_fsk_modem_release(&modem);
     free(out);
     free(iq);
     free(symbols);

--- a/tests/dsp/test_fsk_modem.c
+++ b/tests/dsp/test_fsk_modem.c
@@ -245,6 +245,17 @@ seed_tracking_boundary_window(dsd_fsk_modem_state* modem, int clock_i, int best_
 }
 
 static void
+seed_tracking_constant_window(dsd_fsk_modem_state* modem, int clock_i, float start_phase, float value) {
+    int target = clock_i * 64;
+    assert(target <= DSD_FSK_MODEM_TRACK_MAX_SAMPLES);
+    for (int i = 0; i < target - 1; i++) {
+        modem->track_freq[i] = value;
+    }
+    modem->track_len = target - 1;
+    modem->track_start_phase = start_phase;
+}
+
+static void
 test_p25_c4fm_4800_at_48000(void) {
     enum { SYMBOLS = 1600, SPS = 10, RUN = 12 };
 
@@ -702,6 +713,56 @@ test_timing_tracker_applies_bounded_soft_correction(void) {
 }
 
 static void
+test_timing_tracker_soft_accepts_do_not_mask_signal_loss(void) {
+    dsd_fsk_modem_state modem;
+    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
+    dsd_fsk_modem_init(&modem, &cfg);
+    modem.timing_acquired = 1;
+    modem.symbol_phase = 5.0f;
+    modem.abs_est = 10.0f;
+
+    float iq[] = {1.0f, 0.0f};
+    float out[8];
+    for (int i = 0; i < 32; i++) {
+        modem.have_prev = 1;
+        modem.prev_i = 1.0f;
+        modem.prev_q = 0.0f;
+        seed_tracking_boundary_window_scaled(&modem, 10, 2, 7, 8.0f, 1.05f, 1.0f);
+        (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
+    }
+
+    assert(modem.track_updates == 32);
+    assert(modem.track_skips == 0);
+    assert(modem.track_consecutive_skips == 0);
+    assert(modem.timing_acquired == 0);
+}
+
+static void
+test_timing_tracker_preserves_low_transition_signal(void) {
+    dsd_fsk_modem_state modem;
+    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
+    dsd_fsk_modem_init(&modem, &cfg);
+    modem.timing_acquired = 1;
+    modem.symbol_phase = 4.0f;
+    modem.abs_est = 0.05f;
+
+    float iq[] = {cosf(0.05f), sinf(0.05f)};
+    float out[8];
+    for (int i = 0; i < 40; i++) {
+        modem.have_prev = 1;
+        modem.prev_i = 1.0f;
+        modem.prev_q = 0.0f;
+        modem.dc_est = 0.0f;
+        seed_tracking_constant_window(&modem, 10, 0.0f, 0.05f);
+        (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
+        assert(modem.timing_acquired == 1);
+    }
+
+    assert(modem.track_skips == 40);
+    assert(modem.track_consecutive_skips == 0);
+}
+
+static void
 test_timing_tracker_reacquires_after_consecutive_skips(void) {
     dsd_fsk_modem_state modem;
     dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
@@ -727,6 +788,38 @@ test_timing_tracker_reacquires_after_consecutive_skips(void) {
     assert(modem.acq_len == 0);
     assert(modem.symbol_count == 0);
     assert(modem.pending_len == 0);
+}
+
+static void
+test_timing_reacquire_waits_through_long_silence(void) {
+    enum { SYMBOLS = 2200, SPS = 10, RUN = 16, GAP_COMPLEX = (33 * 64 * SPS) + DSD_FSK_MODEM_ACQ_MAX_SAMPLES + 500 };
+
+    static const float levels[] = {-3.0f, 3.0f, -1.0f, 1.0f, 3.0f, -3.0f};
+    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
+    float* first_iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
+    float* gap_iq = (float*)calloc((size_t)GAP_COMPLEX * 2U, sizeof(float));
+    float* out = (float*)calloc(SYMBOLS + 512, sizeof(float));
+    assert(symbols && first_iq && gap_iq && out);
+
+    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
+    synthesize_fsk(first_iq, symbols, SYMBOLS, SPS, 0.025f, 0.001f, 0.002f, 0);
+
+    dsd_fsk_modem_state modem;
+    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
+    dsd_fsk_modem_init(&modem, &cfg);
+    int produced = dsd_fsk_modem_process(&modem, first_iq, SYMBOLS * SPS * 2, out, SYMBOLS + 512);
+    assert(produced >= SYMBOLS - 24);
+    assert(modem.timing_acquired == 1);
+
+    (void)dsd_fsk_modem_process(&modem, gap_iq, GAP_COMPLEX * 2, out, SYMBOLS + 512);
+    assert(modem.timing_acquired == 0);
+    assert(modem.acq_len > 0);
+    assert(modem.acq_len < DSD_FSK_MODEM_ACQ_MAX_SAMPLES);
+
+    free(out);
+    free(gap_iq);
+    free(first_iq);
+    free(symbols);
 }
 
 static void
@@ -791,6 +884,7 @@ test_reconfigure_resets_state(void) {
     modem.track_start_phase = 3.0f;
     modem.track_last_error = 2.0f;
     modem.track_last_score = 0.5f;
+    modem.track_signal_ref = 0.25f;
     modem.track_updates = 7;
     modem.track_skips = 5;
     modem.track_consecutive_skips = 3;
@@ -808,6 +902,7 @@ test_reconfigure_resets_state(void) {
     assert(modem.track_start_phase == 0.0f);
     assert(modem.track_last_error == 0.0f);
     assert(modem.track_last_score == 0.0f);
+    assert(modem.track_signal_ref == 0.0f);
     assert(modem.track_updates == 0);
     assert(modem.track_skips == 0);
     assert(modem.track_consecutive_skips == 0);
@@ -836,7 +931,10 @@ main(void) {
     test_dmr_gfsk_tracks_fractional_symbol_clock();
     test_timing_tracker_skips_low_confidence_windows();
     test_timing_tracker_applies_bounded_soft_correction();
+    test_timing_tracker_soft_accepts_do_not_mask_signal_loss();
+    test_timing_tracker_preserves_low_transition_signal();
     test_timing_tracker_reacquires_after_consecutive_skips();
+    test_timing_reacquire_waits_through_long_silence();
     test_timing_tracker_recovers_after_gap();
     test_reconfigure_resets_state();
     return 0;

--- a/tests/dsp/test_fsk_modem.c
+++ b/tests/dsp/test_fsk_modem.c
@@ -569,7 +569,7 @@ test_nxdn48_2400_at_48000(void) {
 }
 
 static void
-test_timing_tracker_clamps_phase_underflow(void) {
+test_timing_tracker_does_not_nudge_wrapped_phase(void) {
     dsd_fsk_modem_state modem;
     dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
     dsd_fsk_modem_init(&modem, &cfg);
@@ -585,13 +585,14 @@ test_timing_tracker_clamps_phase_underflow(void) {
     float iq[] = {1.0f, 0.0f};
     float out[8];
     (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
-    assert(modem.track_updates > 0);
+    assert(modem.track_updates == 0);
+    assert(modem.track_skips == 0);
     assert(modem.symbol_phase >= 0.0f);
     assert(modem.symbol_phase < 1.0f);
 }
 
 static void
-test_timing_tracker_clamps_phase_overflow(void) {
+test_timing_tracker_does_not_nudge_high_phase(void) {
     dsd_fsk_modem_state modem;
     dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
     dsd_fsk_modem_init(&modem, &cfg);
@@ -605,7 +606,8 @@ test_timing_tracker_clamps_phase_overflow(void) {
     float iq[] = {1.0f, 0.0f};
     float out[8];
     (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
-    assert(modem.track_updates > 0);
+    assert(modem.track_updates == 0);
+    assert(modem.track_skips == 0);
     assert(modem.symbol_phase > 9.0f);
     assert(modem.symbol_phase < 10.0f);
 }
@@ -625,13 +627,13 @@ test_timing_tracker_uses_floor_for_fractional_start_phase(void) {
     float iq[] = {1.0f, 0.0f};
     float out[8];
     (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
-    assert(modem.track_updates > 0);
+    assert(modem.track_updates == 0);
     assert(fabsf(modem.track_last_error) < 1.0e-6f);
     assert(fabsf(modem.symbol_phase - 1.6f) < 1.0e-4f);
 }
 
 static void
-test_dmr_gfsk_tracks_fractional_symbol_clock(void) {
+test_dmr_gfsk_handles_fractional_symbol_clock_without_phase_nudges(void) {
     enum { SYMBOLS = 4200, RUN = 17 };
 
     const float actual_sps = 10.005f;
@@ -651,8 +653,8 @@ test_dmr_gfsk_tracks_fractional_symbol_clock(void) {
     dsd_fsk_modem_init(&modem, &cfg);
     int produced = dsd_fsk_modem_process(&modem, iq, sample_count * 2, out, SYMBOLS + 512);
     assert(produced >= SYMBOLS - 24);
-    assert(modem.track_updates > 0);
-    expect_4level_accuracy("dmr-gfsk-fractional-clock-tracking", out, produced, symbols, SYMBOLS, RUN, 900, 0.88f);
+    assert(modem.track_updates == 0);
+    expect_4level_accuracy("dmr-gfsk-fractional-clock-no-nudge", out, produced, symbols, SYMBOLS, RUN, 900, 0.88f);
 
     free(out);
     free(iq);
@@ -690,7 +692,7 @@ test_timing_tracker_skips_low_confidence_windows(void) {
 }
 
 static void
-test_timing_tracker_applies_bounded_soft_correction(void) {
+test_timing_tracker_accepts_without_phase_nudge(void) {
     dsd_fsk_modem_state modem;
     dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
     dsd_fsk_modem_init(&modem, &cfg);
@@ -705,11 +707,11 @@ test_timing_tracker_applies_bounded_soft_correction(void) {
     float iq[] = {1.0f, 0.0f};
     float out[8];
     (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
-    assert(modem.track_updates == 1);
+    assert(modem.track_updates == 0);
     assert(modem.track_skips == 0);
     assert(modem.track_consecutive_skips == 0);
-    assert(modem.symbol_phase < 6.0f);
-    assert(modem.symbol_phase > 5.86f);
+    assert(fabsf(modem.track_last_error - 2.0f) < 1.0e-6f);
+    assert(fabsf(modem.symbol_phase - 6.0f) < 1.0e-4f);
 }
 
 static void
@@ -731,8 +733,8 @@ test_timing_tracker_soft_accepts_do_not_mask_signal_loss(void) {
         (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
     }
 
-    assert(modem.track_updates == 32);
-    assert(modem.track_skips == 0);
+    assert(modem.track_updates == 0);
+    assert(modem.track_skips == 32);
     assert(modem.track_consecutive_skips == 0);
     assert(modem.timing_acquired == 0);
 }
@@ -758,7 +760,7 @@ test_timing_tracker_preserves_low_transition_signal(void) {
         assert(modem.timing_acquired == 1);
     }
 
-    assert(modem.track_skips == 40);
+    assert(modem.track_skips == 0);
     assert(modem.track_consecutive_skips == 0);
 }
 
@@ -1008,12 +1010,12 @@ main(void) {
     test_acquisition_preserves_backlog_with_small_output();
     test_binary_fsk_4800();
     test_nxdn48_2400_at_48000();
-    test_timing_tracker_clamps_phase_underflow();
-    test_timing_tracker_clamps_phase_overflow();
+    test_timing_tracker_does_not_nudge_wrapped_phase();
+    test_timing_tracker_does_not_nudge_high_phase();
     test_timing_tracker_uses_floor_for_fractional_start_phase();
-    test_dmr_gfsk_tracks_fractional_symbol_clock();
+    test_dmr_gfsk_handles_fractional_symbol_clock_without_phase_nudges();
     test_timing_tracker_skips_low_confidence_windows();
-    test_timing_tracker_applies_bounded_soft_correction();
+    test_timing_tracker_accepts_without_phase_nudge();
     test_timing_tracker_soft_accepts_do_not_mask_signal_loss();
     test_timing_tracker_preserves_low_transition_signal();
     test_timing_tracker_reacquires_after_consecutive_skips();

--- a/tests/dsp/test_fsk_modem.c
+++ b/tests/dsp/test_fsk_modem.c
@@ -149,6 +149,48 @@ expect_4level_accuracy(const char* name, const float* out, int out_count, const 
 }
 
 static void
+expect_4level_accuracy_best_shift(const char* name, const float* out, int out_count, const float* expected,
+                                  int expected_count, int run_len, int warmup, int max_abs_shift, float min_accuracy) {
+    float best_accuracy = 0.0f;
+    int best_ok = 0;
+    int best_checked = 0;
+    int best_shift = 0;
+    for (int shift = -max_abs_shift; shift <= max_abs_shift; shift++) {
+        int checked = 0;
+        int ok = 0;
+        int limit = out_count < expected_count ? out_count : expected_count;
+        for (int i = warmup; i < limit; i++) {
+            int expected_i = i + shift;
+            if (expected_i < 0 || expected_i >= expected_count) {
+                continue;
+            }
+            int pos = expected_i % run_len;
+            if (pos == 0 || pos >= run_len - 2) {
+                continue;
+            }
+            checked++;
+            if (classify4(out[i]) == (int)expected[expected_i]) {
+                ok++;
+            }
+        }
+        if (checked > 200) {
+            float accuracy = (float)ok / (float)checked;
+            if (accuracy > best_accuracy) {
+                best_accuracy = accuracy;
+                best_ok = ok;
+                best_checked = checked;
+                best_shift = shift;
+            }
+        }
+    }
+    if (best_accuracy < min_accuracy) {
+        DSD_FPRINTF(stderr, "%s: best shifted 4-level accuracy %.3f below %.3f shift=%d (%d/%d)\n", name, best_accuracy,
+                    min_accuracy, best_shift, best_ok, best_checked);
+        assert(0);
+    }
+}
+
+static void
 expect_2level_accuracy(const char* name, const float* out, int out_count, const float* expected, int expected_count,
                        int run_len, int warmup, float min_accuracy) {
     int checked = 0;
@@ -174,18 +216,32 @@ expect_2level_accuracy(const char* name, const float* out, int out_count, const 
 }
 
 static void
-seed_tracking_boundary_window(dsd_fsk_modem_state* modem, int clock_i, int best_phase, float start_phase) {
+seed_tracking_boundary_window_scaled(dsd_fsk_modem_state* modem, int clock_i, int best_phase, int second_phase,
+                                     float start_phase, float best_delta, float second_delta) {
     int target = clock_i * 64;
     assert(target <= DSD_FSK_MODEM_TRACK_MAX_SAMPLES);
     DSD_MEMSET(modem->track_freq, 0, sizeof(modem->track_freq));
     for (int pos = best_phase; pos < target - 1; pos += clock_i) {
         if (pos > 0) {
             modem->track_freq[pos - 1] = -1.0f;
-            modem->track_freq[pos] = 1.0f;
+            modem->track_freq[pos] = -1.0f + best_delta;
+        }
+    }
+    if (second_phase >= 0) {
+        for (int pos = second_phase; pos < target - 1; pos += clock_i) {
+            if (pos > 0) {
+                modem->track_freq[pos - 1] = -1.0f;
+                modem->track_freq[pos] = -1.0f + second_delta;
+            }
         }
     }
     modem->track_len = target - 1;
     modem->track_start_phase = start_phase;
+}
+
+static void
+seed_tracking_boundary_window(dsd_fsk_modem_state* modem, int clock_i, int best_phase, float start_phase) {
+    seed_tracking_boundary_window_scaled(modem, clock_i, best_phase, -1, start_phase, 2.0f, 0.0f);
 }
 
 static void
@@ -623,6 +679,96 @@ test_timing_tracker_skips_low_confidence_windows(void) {
 }
 
 static void
+test_timing_tracker_applies_bounded_soft_correction(void) {
+    dsd_fsk_modem_state modem;
+    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
+    dsd_fsk_modem_init(&modem, &cfg);
+    modem.timing_acquired = 1;
+    modem.have_prev = 1;
+    modem.prev_i = 1.0f;
+    modem.prev_q = 0.0f;
+    modem.symbol_phase = 5.0f;
+    modem.track_consecutive_skips = 4;
+    seed_tracking_boundary_window_scaled(&modem, 10, 2, 7, 0.0f, 1.05f, 1.0f);
+
+    float iq[] = {1.0f, 0.0f};
+    float out[8];
+    (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
+    assert(modem.track_updates == 1);
+    assert(modem.track_skips == 0);
+    assert(modem.track_consecutive_skips == 0);
+    assert(modem.symbol_phase < 6.0f);
+    assert(modem.symbol_phase > 5.86f);
+}
+
+static void
+test_timing_tracker_reacquires_after_consecutive_skips(void) {
+    dsd_fsk_modem_state modem;
+    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
+    dsd_fsk_modem_init(&modem, &cfg);
+    modem.timing_acquired = 1;
+    modem.have_prev = 1;
+    modem.prev_i = 1.0f;
+    modem.prev_q = 0.0f;
+    modem.symbol_phase = 4.0f;
+
+    float iq[] = {1.0f, 0.0f};
+    float out[8];
+    for (int i = 0; i < 32; i++) {
+        modem.track_len = 10 * 64 - 1;
+        modem.track_start_phase = 0.0f;
+        DSD_MEMSET(modem.track_freq, 0, sizeof(modem.track_freq));
+        (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
+    }
+
+    assert(modem.track_skips == 32);
+    assert(modem.track_consecutive_skips == 0);
+    assert(modem.timing_acquired == 0);
+    assert(modem.acq_len == 0);
+    assert(modem.symbol_count == 0);
+    assert(modem.pending_len == 0);
+}
+
+static void
+test_timing_tracker_recovers_after_gap(void) {
+    enum { SYMBOLS = 2200, SPS = 10, RUN = 16, GAP_COMPLEX = (33 * 64 * SPS) + 100 };
+
+    static const float levels[] = {-3.0f, 3.0f, -1.0f, 1.0f, 3.0f, -3.0f};
+    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
+    float* first_iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
+    float* gap_iq = (float*)calloc((size_t)GAP_COMPLEX * 2U, sizeof(float));
+    float* second_iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
+    float* out = (float*)calloc(SYMBOLS + 512, sizeof(float));
+    assert(symbols && first_iq && gap_iq && second_iq && out);
+
+    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
+    synthesize_fsk(first_iq, symbols, SYMBOLS, SPS, 0.025f, 0.001f, 0.002f, 0);
+    synthesize_fsk(second_iq, symbols, SYMBOLS, SPS, 0.025f, -0.001f, 0.002f, 7);
+
+    dsd_fsk_modem_state modem;
+    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
+    dsd_fsk_modem_init(&modem, &cfg);
+    int produced = dsd_fsk_modem_process(&modem, first_iq, SYMBOLS * SPS * 2, out, SYMBOLS + 512);
+    assert(produced >= SYMBOLS - 24);
+    assert(modem.timing_acquired == 1);
+
+    (void)dsd_fsk_modem_process(&modem, gap_iq, GAP_COMPLEX * 2, out, SYMBOLS + 512);
+    assert(modem.timing_acquired == 0);
+
+    produced = dsd_fsk_modem_process(&modem, second_iq, SYMBOLS * SPS * 2, out, SYMBOLS + 512);
+    assert(produced >= SYMBOLS - 256);
+    assert(modem.timing_acquired == 1);
+    expect_4level_accuracy_best_shift("dmr-gfsk-reacquire-after-gap", out, produced, symbols, SYMBOLS, RUN, 900, 64,
+                                      0.86f);
+
+    free(out);
+    free(second_iq);
+    free(gap_iq);
+    free(first_iq);
+    free(symbols);
+}
+
+static void
 test_reconfigure_resets_state(void) {
     dsd_fsk_modem_state modem;
     dsd_fsk_modem_config cfg = {48000, 4800, 4, 4};
@@ -647,6 +793,7 @@ test_reconfigure_resets_state(void) {
     modem.track_last_score = 0.5f;
     modem.track_updates = 7;
     modem.track_skips = 5;
+    modem.track_consecutive_skips = 3;
 
     dsd_fsk_modem_config next = {48000, 2400, 2, 1};
     dsd_fsk_modem_configure(&modem, &next);
@@ -663,6 +810,7 @@ test_reconfigure_resets_state(void) {
     assert(modem.track_last_score == 0.0f);
     assert(modem.track_updates == 0);
     assert(modem.track_skips == 0);
+    assert(modem.track_consecutive_skips == 0);
     assert(dsd_fsk_modem_get_metrics(&modem, &metrics) == 0);
     assert(metrics.valid == 0);
     assert(metrics.window_symbols == 0U);
@@ -687,6 +835,9 @@ main(void) {
     test_timing_tracker_uses_floor_for_fractional_start_phase();
     test_dmr_gfsk_tracks_fractional_symbol_clock();
     test_timing_tracker_skips_low_confidence_windows();
+    test_timing_tracker_applies_bounded_soft_correction();
+    test_timing_tracker_reacquires_after_consecutive_skips();
+    test_timing_tracker_recovers_after_gap();
     test_reconfigure_resets_state();
     return 0;
 }

--- a/tests/dsp/test_fsk_modem.c
+++ b/tests/dsp/test_fsk_modem.c
@@ -6,1023 +6,155 @@
 #include <assert.h>
 #include <dsd-neo/dsp/fsk_modem.h>
 #include <math.h>
-#include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include "dsd-neo/core/safe_api.h"
 
-#ifndef DSD_TEST_PI
-#define DSD_TEST_PI 3.14159265358979323846f
-#endif
-
-static uint32_t g_rng = 0x12345678u;
-
-static float
-test_rand_pm1(void) {
-    g_rng = g_rng * 1664525u + 1013904223u;
-    return ((float)((g_rng >> 8) & 0xFFFFu) / 32767.5f) - 1.0f;
-}
+enum { TEST_SAMPLE_RATE = 48000, TEST_SYMBOL_RATE = 4800, TEST_SPS = 10 };
 
 static void
-fill_run_pattern(float* symbols, int count, const float* levels, int level_count, int run_len) {
-    for (int i = 0; i < count; i++) {
-        int idx = (i / run_len) % level_count;
-        symbols[i] = levels[idx];
-    }
-}
-
-static void
-synthesize_fsk(float* iq, const float* symbols, int symbol_count, int sps, float deviation_per_level, float cfo,
-               float noise_amp, int timing_offset_samples) {
-    float phase = 0.37f;
-    int first_symbol = 0;
-    for (int k = 0; k < timing_offset_samples; k++) {
-        phase += cfo + deviation_per_level * symbols[first_symbol];
-        if (phase > DSD_TEST_PI) {
-            phase -= 2.0f * DSD_TEST_PI;
-        } else if (phase < -DSD_TEST_PI) {
-            phase += 2.0f * DSD_TEST_PI;
-        }
-    }
-
+synthesize_fsk_iq(float* out_iq, const float* symbols, int symbol_count, int sps, float deviation_per_level) {
+    float phase = 0.17f;
     int out = 0;
     for (int sym = 0; sym < symbol_count; sym++) {
         for (int k = 0; k < sps; k++) {
-            phase += cfo + deviation_per_level * symbols[sym];
-            if (phase > DSD_TEST_PI) {
-                phase -= 2.0f * DSD_TEST_PI;
-            } else if (phase < -DSD_TEST_PI) {
-                phase += 2.0f * DSD_TEST_PI;
+            phase += deviation_per_level * symbols[sym];
+            if (phase > 3.14159265358979323846f) {
+                phase -= 6.28318530717958647692f;
+            } else if (phase < -3.14159265358979323846f) {
+                phase += 6.28318530717958647692f;
             }
-            float amp = 0.72f + 0.36f * (float)((sym + k) % 29) / 28.0f;
-            iq[out++] = amp * cosf(phase) + noise_amp * test_rand_pm1();
-            iq[out++] = amp * sinf(phase) + noise_amp * test_rand_pm1();
+            out_iq[out++] = 0.85f * cosf(phase);
+            out_iq[out++] = 0.85f * sinf(phase);
         }
     }
 }
 
 static void
-synthesize_fsk_capture_offset(float* iq, const float* symbols, int sample_count, int sps, float deviation_per_level,
-                              int capture_offset_samples) {
-    float phase = 0.29f;
-    int out = 0;
-    for (int sample = 0; sample < sample_count; sample++) {
-        int absolute_sample = sample + capture_offset_samples;
-        int sym = absolute_sample / sps;
-        phase += deviation_per_level * symbols[sym];
-        if (phase > DSD_TEST_PI) {
-            phase -= 2.0f * DSD_TEST_PI;
-        } else if (phase < -DSD_TEST_PI) {
-            phase += 2.0f * DSD_TEST_PI;
-        }
-        iq[out++] = cosf(phase);
-        iq[out++] = sinf(phase);
-    }
-}
+expect_discriminator_count_sign_center_and_scale(void) {
+    enum { SYMBOLS = 160, SAMPLES = SYMBOLS * TEST_SPS };
 
-static void
-synthesize_fsk_fractional(float* iq, const float* symbols, int symbol_count, int sample_count, float actual_sps,
-                          float deviation_per_level, float cfo, float noise_amp) {
-    float phase = 0.41f;
-    int out = 0;
-    for (int sample = 0; sample < sample_count; sample++) {
-        int sym = (int)floorf((float)sample / actual_sps);
-        if (sym < 0) {
-            sym = 0;
-        } else if (sym >= symbol_count) {
-            sym = symbol_count - 1;
-        }
-        phase += cfo + deviation_per_level * symbols[sym];
-        if (phase > DSD_TEST_PI) {
-            phase -= 2.0f * DSD_TEST_PI;
-        } else if (phase < -DSD_TEST_PI) {
-            phase += 2.0f * DSD_TEST_PI;
-        }
-        float amp = 0.82f + 0.18f * (float)((sample / 3) % 19) / 18.0f;
-        iq[out++] = amp * cosf(phase) + noise_amp * test_rand_pm1();
-        iq[out++] = amp * sinf(phase) + noise_amp * test_rand_pm1();
-    }
-}
+    static const float cycle[] = {-3.0f, -1.0f, 1.0f, 3.0f};
+    float symbols[SYMBOLS];
+    float iq[SAMPLES * 2];
+    float out[SAMPLES];
 
-static int
-classify4(float sym) {
-    if (sym < -2.0f) {
-        return -3;
+    for (int i = 0; i < SYMBOLS; i++) {
+        symbols[i] = cycle[i & 3];
     }
-    if (sym < 0.0f) {
-        return -1;
-    }
-    if (sym < 2.0f) {
-        return 1;
-    }
-    return 3;
-}
+    synthesize_fsk_iq(iq, symbols, SYMBOLS, TEST_SPS, 0.026f);
 
-static int
-classify2(float sym) {
-    return sym >= 0.0f ? 1 : -1;
-}
+    dsd_fsk_modem_state modem;
+    dsd_fsk_modem_config cfg = {TEST_SAMPLE_RATE, TEST_SYMBOL_RATE, 4, 2};
+    dsd_fsk_modem_init(&modem, &cfg);
 
-static void
-expect_4level_accuracy(const char* name, const float* out, int out_count, const float* expected, int expected_count,
-                       int run_len, int warmup, float min_accuracy) {
+    int produced = dsd_fsk_modem_discriminator_process(&modem, iq, SAMPLES * 2, out, SAMPLES);
+    assert(produced == SAMPLES);
+    assert(out[0] == 0.0f);
+    assert(modem.have_prev == 1);
+    assert(modem.discriminator_peak_est > 0.0f);
+
     int checked = 0;
-    int ok = 0;
-    int limit = out_count < expected_count ? out_count : expected_count;
-    for (int i = warmup; i < limit; i++) {
-        int pos = i % run_len;
-        if (pos == 0 || pos >= run_len - 2) {
-            continue;
+    int correct_sign = 0;
+    float peak = 0.0f;
+    double mean = 0.0;
+    const int stable_start = TEST_SPS * 24;
+    for (int i = stable_start; i < produced; i++) {
+        int sym = i / TEST_SPS;
+        if (sym >= SYMBOLS) {
+            sym = SYMBOLS - 1;
         }
-        checked++;
-        if (classify4(out[i]) == (int)expected[i]) {
-            ok++;
+        float sample = out[i];
+        assert(sample >= -32768.0f);
+        assert(sample <= 32767.0f);
+        mean += (double)sample;
+        if (fabsf(sample) > peak) {
+            peak = fabsf(sample);
         }
-    }
-    assert(checked > 200);
-    float accuracy = (float)ok / (float)checked;
-    if (accuracy < min_accuracy) {
-        DSD_FPRINTF(stderr, "%s: 4-level accuracy %.3f below %.3f (%d/%d)\n", name, accuracy, min_accuracy, ok,
-                    checked);
-        assert(0);
-    }
-}
-
-static void
-expect_4level_accuracy_best_shift(const char* name, const float* out, int out_count, const float* expected,
-                                  int expected_count, int run_len, int warmup, int max_abs_shift, float min_accuracy) {
-    float best_accuracy = 0.0f;
-    int best_ok = 0;
-    int best_checked = 0;
-    int best_shift = 0;
-    for (int shift = -max_abs_shift; shift <= max_abs_shift; shift++) {
-        int checked = 0;
-        int ok = 0;
-        int limit = out_count < expected_count ? out_count : expected_count;
-        for (int i = warmup; i < limit; i++) {
-            int expected_i = i + shift;
-            if (expected_i < 0 || expected_i >= expected_count) {
-                continue;
-            }
-            int pos = expected_i % run_len;
-            if (pos == 0 || pos >= run_len - 2) {
-                continue;
-            }
+        if (fabsf(symbols[sym]) >= 2.0f) {
             checked++;
-            if (classify4(out[i]) == (int)expected[expected_i]) {
-                ok++;
-            }
-        }
-        if (checked > 200) {
-            float accuracy = (float)ok / (float)checked;
-            if (accuracy > best_accuracy) {
-                best_accuracy = accuracy;
-                best_ok = ok;
-                best_checked = checked;
-                best_shift = shift;
+            if ((sample > 0.0f) == (symbols[sym] > 0.0f)) {
+                correct_sign++;
             }
         }
     }
-    if (best_accuracy < min_accuracy) {
-        DSD_FPRINTF(stderr, "%s: best shifted 4-level accuracy %.3f below %.3f shift=%d (%d/%d)\n", name, best_accuracy,
-                    min_accuracy, best_shift, best_ok, best_checked);
-        assert(0);
-    }
+    mean /= (double)(produced - stable_start);
+    assert(checked > 400);
+    assert(correct_sign >= (checked * 95) / 100);
+    assert(peak > 25000.0f);
+    assert(fabs(mean) < 2500.0);
 }
 
 static void
-expect_2level_accuracy(const char* name, const float* out, int out_count, const float* expected, int expected_count,
-                       int run_len, int warmup, float min_accuracy) {
-    int checked = 0;
-    int ok = 0;
-    int limit = out_count < expected_count ? out_count : expected_count;
-    for (int i = warmup; i < limit; i++) {
-        int pos = i % run_len;
-        if (pos == 0 || pos >= run_len - 2) {
-            continue;
-        }
-        checked++;
-        if (classify2(out[i]) == (int)expected[i]) {
-            ok++;
-        }
-    }
-    assert(checked > 200);
-    float accuracy = (float)ok / (float)checked;
-    if (accuracy < min_accuracy) {
-        DSD_FPRINTF(stderr, "%s: 2-level accuracy %.3f below %.3f (%d/%d)\n", name, accuracy, min_accuracy, ok,
-                    checked);
-        assert(0);
-    }
-}
+expect_reset_clears_discriminator_history(void) {
+    enum { SYMBOLS = 24, SAMPLES = SYMBOLS * TEST_SPS };
 
-static void
-seed_tracking_boundary_window_scaled(dsd_fsk_modem_state* modem, int clock_i, int best_phase, int second_phase,
-                                     float start_phase, float best_delta, float second_delta) {
-    int target = clock_i * 64;
-    assert(target <= DSD_FSK_MODEM_TRACK_MAX_SAMPLES);
-    DSD_MEMSET(modem->track_freq, 0, sizeof(modem->track_freq));
-    for (int pos = best_phase; pos < target - 1; pos += clock_i) {
-        if (pos > 0) {
-            modem->track_freq[pos - 1] = -1.0f;
-            modem->track_freq[pos] = -1.0f + best_delta;
-        }
-    }
-    if (second_phase >= 0) {
-        for (int pos = second_phase; pos < target - 1; pos += clock_i) {
-            if (pos > 0) {
-                modem->track_freq[pos - 1] = -1.0f;
-                modem->track_freq[pos] = -1.0f + second_delta;
-            }
-        }
-    }
-    modem->track_len = target - 1;
-    modem->track_start_phase = start_phase;
-}
-
-static void
-seed_tracking_boundary_window(dsd_fsk_modem_state* modem, int clock_i, int best_phase, float start_phase) {
-    seed_tracking_boundary_window_scaled(modem, clock_i, best_phase, -1, start_phase, 2.0f, 0.0f);
-}
-
-static void
-seed_tracking_constant_window(dsd_fsk_modem_state* modem, int clock_i, float start_phase, float value) {
-    int target = clock_i * 64;
-    assert(target <= DSD_FSK_MODEM_TRACK_MAX_SAMPLES);
-    for (int i = 0; i < target - 1; i++) {
-        modem->track_freq[i] = value;
-    }
-    modem->track_len = target - 1;
-    modem->track_start_phase = start_phase;
-}
-
-static void
-test_p25_c4fm_4800_at_48000(void) {
-    enum { SYMBOLS = 1600, SPS = 10, RUN = 12 };
-
-    static const float levels[] = {-3.0f, -1.0f, 1.0f, 3.0f, 1.0f, -1.0f};
-    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
-    float* iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
-    float* out = (float*)calloc(SYMBOLS + 16, sizeof(float));
-    assert(symbols && iq && out);
-
-    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
-    synthesize_fsk(iq, symbols, SYMBOLS, SPS, 0.026f, 0.0f, 0.0f, 0);
-
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 4};
-    dsd_fsk_modem_init(&modem, &cfg);
-    int produced = dsd_fsk_modem_process(&modem, iq, SYMBOLS * SPS * 2, out, SYMBOLS + 16);
-    assert(produced >= SYMBOLS - 2);
-    expect_4level_accuracy("p25-c4fm-4800", out, produced, symbols, SYMBOLS, RUN, 160, 0.96f);
-
-    free(out);
-    free(iq);
-    free(symbols);
-}
-
-static void
-test_dmr_gfsk_4800_with_offsets_noise_and_cfo(void) {
-    enum { SYMBOLS = 2600, SPS = 10, RUN = 14 };
-
-    static const float levels[] = {-3.0f, 3.0f, -1.0f, 1.0f, 3.0f, -3.0f, 1.0f, -1.0f};
-    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
-    float* iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
-    float* out = (float*)calloc(SYMBOLS + 16, sizeof(float));
-    assert(symbols && iq && out);
-
-    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
-    synthesize_fsk(iq, symbols, SYMBOLS, SPS, 0.024f, 0.0025f, 0.004f, 3);
-
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
-    dsd_fsk_modem_init(&modem, &cfg);
-    int produced = dsd_fsk_modem_process(&modem, iq, SYMBOLS * SPS * 2, out, SYMBOLS + 16);
-    assert(produced >= SYMBOLS - 2);
-    expect_4level_accuracy("dmr-gfsk-offset-cfo-noise", out, produced, symbols, SYMBOLS, RUN, 500, 0.90f);
-
-    free(out);
-    free(iq);
-    free(symbols);
-}
-
-static void
-run_mid_symbol_start_case(const char* name, const float* levels, int level_count, int cfg_levels, int channel_profile,
-                          int symbol_rate, int sps, int offset, float deviation_per_level, int use_4level,
-                          float min_accuracy) {
-    enum { SYMBOLS = 1800 };
-
-    int expected_shift = offset > 0 ? 1 : 0;
-
-    float* symbols = (float*)calloc(SYMBOLS + expected_shift + 8, sizeof(float));
-    float* iq = (float*)calloc((size_t)SYMBOLS * (size_t)sps * 2U, sizeof(float));
-    float* out = (float*)calloc(SYMBOLS + 16, sizeof(float));
-    assert(symbols && iq && out);
-
-    for (int i = 0; i < SYMBOLS + expected_shift + 8; i++) {
-        g_rng = g_rng * 1664525u + 1013904223u;
-        symbols[i] = levels[(g_rng >> 29) % (uint32_t)level_count];
-    }
-    synthesize_fsk_capture_offset(iq, symbols, SYMBOLS * sps, sps, deviation_per_level, offset);
-
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, symbol_rate, cfg_levels, channel_profile};
-    dsd_fsk_modem_init(&modem, &cfg);
-    int produced = dsd_fsk_modem_process(&modem, iq, SYMBOLS * sps * 2, out, SYMBOLS + 16);
-    assert(produced >= SYMBOLS - 8);
-
-    int checked = 0;
-    int ok = 0;
-    int limit = produced < SYMBOLS - expected_shift ? produced : SYMBOLS - expected_shift;
-    for (int i = 220; i < limit; i++) {
-        checked++;
-        int got = use_4level ? classify4(out[i]) : classify2(out[i]);
-        if (got == (int)symbols[i + expected_shift]) {
-            ok++;
-        }
-    }
-    assert(checked > 500);
-    float accuracy = (float)ok / (float)checked;
-    if (accuracy < min_accuracy) {
-        DSD_FPRINTF(stderr, "%s accuracy %.3f below %.3f (%d/%d)\n", name, accuracy, min_accuracy, ok, checked);
-        assert(0);
-    }
-
-    free(out);
-    free(iq);
-    free(symbols);
-}
-
-static void
-test_dmr_gfsk_acquires_mid_symbol_start(void) {
-    static const float levels[] = {-3.0f, 3.0f, 1.0f, -1.0f};
-    run_mid_symbol_start_case("dmr-gfsk-mid-symbol-start", levels, 4, 4, 2, 4800, 10, 7, 0.026f, 1, 0.90f);
-}
-
-static void
-test_p25_c4fm_acquires_mid_symbol_start(void) {
-    static const float levels[] = {-3.0f, -1.0f, 1.0f, 3.0f};
-    run_mid_symbol_start_case("p25-c4fm-mid-symbol-start", levels, 4, 4, 4, 4800, 10, 6, 0.026f, 1, 0.90f);
-}
-
-static void
-test_binary_fsk_acquires_mid_symbol_start(void) {
-    static const float levels[] = {-1.0f, 1.0f};
-    run_mid_symbol_start_case("binary-fsk-mid-symbol-start", levels, 2, 2, 1, 4800, 10, 7, 0.035f, 0, 0.94f);
-}
-
-static void
-test_provoice_fsk_acquires_mid_symbol_start(void) {
-    static const float levels[] = {-1.0f, 1.0f};
-    run_mid_symbol_start_case("provoice-fsk-mid-symbol-start", levels, 2, 2, 3, 9600, 5, 3, 0.035f, 0, 0.94f);
-}
-
-static void
-test_squelch_clears_partial_acquisition(void) {
-    enum { SYMBOLS = 24, SPS = 10 };
-
-    static const float levels[] = {-3.0f, -1.0f, 1.0f, 3.0f};
+    static const float cycle[] = {-3.0f, 3.0f, -1.0f, 1.0f};
     float symbols[SYMBOLS];
-    float iq[SYMBOLS * SPS * 2];
-    float out[64];
+    float iq[SAMPLES * 2];
+    float out[SAMPLES];
 
     for (int i = 0; i < SYMBOLS; i++) {
-        symbols[i] = levels[i & 3];
+        symbols[i] = cycle[i & 3];
     }
-    synthesize_fsk(iq, symbols, SYMBOLS, SPS, 0.026f, 0.0f, 0.0f, 0);
+    synthesize_fsk_iq(iq, symbols, SYMBOLS, TEST_SPS, 0.03f);
 
     dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 4};
+    dsd_fsk_modem_config cfg = {TEST_SAMPLE_RATE, TEST_SYMBOL_RATE, 4, 4};
     dsd_fsk_modem_init(&modem, &cfg);
-    int produced = dsd_fsk_modem_process(&modem, iq, SYMBOLS * SPS * 2, out, 64);
-    assert(produced == 0);
-    assert(modem.acq_len > 0);
-    assert(modem.timing_acquired == 0);
+    assert(dsd_fsk_modem_discriminator_process(&modem, iq, SAMPLES * 2, out, SAMPLES) == SAMPLES);
     assert(modem.have_prev == 1);
+    assert(modem.discriminator_peak_est > 0.0f);
 
-    int zeros = dsd_fsk_modem_zero_symbols(&modem, SYMBOLS * SPS, out, 64);
-    assert(zeros > 0);
-    assert(modem.acq_len == 0);
-    assert(modem.timing_acquired == 0);
+    dsd_fsk_modem_reset(&modem);
     assert(modem.have_prev == 0);
+    assert(modem.dc_est == 0.0f);
+    assert(modem.discriminator_peak_est == 0.0f);
+    assert(modem.cfg.sample_rate_hz == TEST_SAMPLE_RATE);
+    assert(modem.cfg.symbol_rate_hz == TEST_SYMBOL_RATE);
+    assert(modem.cfg.levels == 4);
+
+    int produced = dsd_fsk_modem_discriminator_process(&modem, iq, SAMPLES * 2, out, SAMPLES);
+    assert(produced == SAMPLES);
+    assert(out[0] == 0.0f);
 }
 
 static void
-test_soft_metrics_track_clean_signal(void) {
-    enum { SYMBOLS = 1400, SPS = 10, RUN = 13 };
+expect_configure_preserves_or_resets_state(void) {
+    enum { SYMBOLS = 16, SAMPLES = SYMBOLS * TEST_SPS };
 
-    static const float levels[] = {1.0f, -1.0f, -1.0f, 1.0f};
-    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
-    float* iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
-    float* out = (float*)calloc(SYMBOLS + 16, sizeof(float));
-    assert(symbols && iq && out);
-
-    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
-    synthesize_fsk(iq, symbols, SYMBOLS, SPS, 0.035f, 0.0f, 0.0f, 0);
-
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 2, 1};
-    dsd_fsk_modem_init(&modem, &cfg);
-    int produced = dsd_fsk_modem_process(&modem, iq, SYMBOLS * SPS * 2, out, SYMBOLS + 16);
-    assert(produced >= SYMBOLS - 2);
-
-    dsd_fsk_modem_metrics metrics;
-    assert(dsd_fsk_modem_get_metrics(&modem, &metrics) == 0);
-    assert(metrics.valid == 1);
-    assert(metrics.levels == 2);
-    assert(metrics.symbol_rate_hz == 4800);
-    assert(metrics.window_symbols > 0);
-    assert(metrics.window_symbols <= 256U);
-    assert(metrics.symbols_total >= (uint64_t)(SYMBOLS - 2));
-    assert(metrics.mean_reliability > 128U);
-    assert(metrics.min_reliability <= metrics.mean_reliability);
-    assert(metrics.rms_error >= 0.0f && metrics.rms_error < 0.8f);
-    assert(metrics.evm_snr_db > 0.0f);
-    assert(metrics.low_reliability_pct < 50.0f);
-    assert(metrics.clip_pct == 0.0f);
-    assert(metrics.timing_acquired == modem.timing_acquired);
-    assert(metrics.track_updates == modem.track_updates);
-    assert(metrics.track_skips == modem.track_skips);
-
-    free(out);
-    free(iq);
-    free(symbols);
-}
-
-static void
-test_soft_metrics_invalidate_on_zero_symbols(void) {
-    enum { SYMBOLS = 240, SPS = 10 };
-
-    static const float levels[] = {-3.0f, -1.0f, 1.0f, 3.0f};
     float symbols[SYMBOLS];
-    float iq[SYMBOLS * SPS * 2];
-    float out[SYMBOLS + 32];
+    float iq[SAMPLES * 2];
+    float out[SAMPLES];
 
     for (int i = 0; i < SYMBOLS; i++) {
-        symbols[i] = levels[i & 3];
+        symbols[i] = (i & 1) ? 3.0f : -3.0f;
     }
-    synthesize_fsk(iq, symbols, SYMBOLS, SPS, 0.026f, 0.0f, 0.0f, 0);
+    synthesize_fsk_iq(iq, symbols, SYMBOLS, TEST_SPS, 0.025f);
 
     dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 4};
+    dsd_fsk_modem_config cfg = {TEST_SAMPLE_RATE, TEST_SYMBOL_RATE, 4, 2};
     dsd_fsk_modem_init(&modem, &cfg);
-    int produced = dsd_fsk_modem_process(&modem, iq, SYMBOLS * SPS * 2, out, SYMBOLS + 32);
-    assert(produced > 0);
-
-    dsd_fsk_modem_metrics metrics;
-    assert(dsd_fsk_modem_get_metrics(&modem, &metrics) == 0);
-    assert(metrics.valid == 1);
-
-    int zeros = dsd_fsk_modem_zero_symbols(&modem, SPS * 8, out, SYMBOLS + 32);
-    assert(zeros > 0);
-    assert(dsd_fsk_modem_get_metrics(&modem, &metrics) == 0);
-    assert(metrics.valid == 0);
-    assert(metrics.window_symbols == 0U);
-}
-
-static void
-test_acquisition_preserves_backlog_with_small_output(void) {
-    enum { SYMBOLS = 3600, SPS = 10, RUN = 13, CHUNK = 7 };
-
-    static const float levels[] = {-3.0f, -1.0f, 1.0f, 3.0f, 1.0f, -1.0f};
-    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
-    float* iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
-    float* out = (float*)calloc(SYMBOLS + 16, sizeof(float));
-    float chunk[CHUNK];
-    assert(symbols && iq && out);
-
-    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
-    synthesize_fsk(iq, symbols, SYMBOLS, SPS, 0.026f, 0.0f, 0.0f, 0);
-
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 4};
-    dsd_fsk_modem_init(&modem, &cfg);
-
-    int total = dsd_fsk_modem_process(&modem, iq, SYMBOLS * SPS * 2, out, CHUNK);
-    assert(total == CHUNK);
-    assert(modem.pending_heap != NULL);
-    assert(modem.pending_cap > DSD_FSK_MODEM_PENDING_INLINE_SYMBOLS);
-    while (total < SYMBOLS && modem.pending_pos < modem.pending_len) {
-        int produced = dsd_fsk_modem_process(&modem, NULL, 0, chunk, CHUNK);
-        assert(produced > 0);
-        for (int i = 0; i < produced; i++) {
-            out[total++] = chunk[i];
-        }
-    }
-
-    assert(total >= SYMBOLS - 2);
-    assert(modem.pending_heap == NULL);
-    expect_4level_accuracy("small-output-acquisition-backlog", out, total, symbols, SYMBOLS, RUN, 160, 0.96f);
-
-    free(out);
-    free(iq);
-    free(symbols);
-}
-
-static void
-test_binary_fsk_4800(void) {
-    enum { SYMBOLS = 1600, SPS = 10, RUN = 11 };
-
-    static const float levels[] = {1.0f, -1.0f, -1.0f, 1.0f};
-    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
-    float* iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
-    float* out = (float*)calloc(SYMBOLS + 16, sizeof(float));
-    assert(symbols && iq && out);
-
-    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
-    synthesize_fsk(iq, symbols, SYMBOLS, SPS, 0.035f, -0.001f, 0.001f, 2);
-
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 2, 1};
-    dsd_fsk_modem_init(&modem, &cfg);
-    int produced = dsd_fsk_modem_process(&modem, iq, SYMBOLS * SPS * 2, out, SYMBOLS + 16);
-    assert(produced >= SYMBOLS - 2);
-    expect_2level_accuracy("binary-fsk-4800", out, produced, symbols, SYMBOLS, RUN, 250, 0.94f);
-
-    free(out);
-    free(iq);
-    free(symbols);
-}
-
-static void
-test_nxdn48_2400_at_48000(void) {
-    enum { SYMBOLS = 1200, SPS = 20, RUN = 10 };
-
-    static const float levels[] = {-3.0f, -1.0f, 1.0f, 3.0f};
-    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
-    float* iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
-    float* out = (float*)calloc(SYMBOLS + 16, sizeof(float));
-    assert(symbols && iq && out);
-
-    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
-    synthesize_fsk(iq, symbols, SYMBOLS, SPS, 0.018f, 0.0f, 0.002f, 5);
-
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 2400, 4, 1};
-    dsd_fsk_modem_init(&modem, &cfg);
-    int produced = dsd_fsk_modem_process(&modem, iq, SYMBOLS * SPS * 2, out, SYMBOLS + 16);
-    assert(produced >= SYMBOLS - 2);
-    expect_4level_accuracy("nxdn48-2400", out, produced, symbols, SYMBOLS, RUN, 180, 0.94f);
-
-    free(out);
-    free(iq);
-    free(symbols);
-}
-
-static void
-test_timing_tracker_does_not_nudge_wrapped_phase(void) {
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
-    dsd_fsk_modem_init(&modem, &cfg);
-    modem.timing_acquired = 1;
-    modem.have_prev = 1;
-    modem.prev_i = 1.0f;
-    modem.prev_q = 0.0f;
-    modem.symbol_phase = 9.1f;
-    modem.symbol_accum = 0.1f;
-    modem.symbol_count = 9;
-    seed_tracking_boundary_window(&modem, 10, 2, 0.0f);
-
-    float iq[] = {1.0f, 0.0f};
-    float out[8];
-    (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
-    assert(modem.track_updates == 0);
-    assert(modem.track_skips == 0);
-    assert(modem.symbol_phase >= 0.0f);
-    assert(modem.symbol_phase < 1.0f);
-}
-
-static void
-test_timing_tracker_does_not_nudge_high_phase(void) {
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
-    dsd_fsk_modem_init(&modem, &cfg);
-    modem.timing_acquired = 1;
-    modem.have_prev = 1;
-    modem.prev_i = 1.0f;
-    modem.prev_q = 0.0f;
-    modem.symbol_phase = 8.95f;
-    seed_tracking_boundary_window(&modem, 10, 0, 8.0f);
-
-    float iq[] = {1.0f, 0.0f};
-    float out[8];
-    (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
-    assert(modem.track_updates == 0);
-    assert(modem.track_skips == 0);
-    assert(modem.symbol_phase > 9.0f);
-    assert(modem.symbol_phase < 10.0f);
-}
-
-static void
-test_timing_tracker_uses_floor_for_fractional_start_phase(void) {
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
-    dsd_fsk_modem_init(&modem, &cfg);
-    modem.timing_acquired = 1;
-    modem.have_prev = 1;
-    modem.prev_i = 1.0f;
-    modem.prev_q = 0.0f;
-    modem.symbol_phase = 0.6f;
-    seed_tracking_boundary_window(&modem, 10, 0, 0.6f);
-
-    float iq[] = {1.0f, 0.0f};
-    float out[8];
-    (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
-    assert(modem.track_updates == 0);
-    assert(fabsf(modem.track_last_error) < 1.0e-6f);
-    assert(fabsf(modem.symbol_phase - 1.6f) < 1.0e-4f);
-}
-
-static void
-test_dmr_gfsk_handles_fractional_symbol_clock_without_phase_nudges(void) {
-    enum { SYMBOLS = 4200, RUN = 17 };
-
-    const float actual_sps = 10.005f;
-    int sample_count = (int)((float)SYMBOLS * actual_sps);
-
-    static const float levels[] = {-3.0f, 3.0f, -1.0f, 1.0f, 3.0f, -3.0f};
-    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
-    float* iq = (float*)calloc((size_t)sample_count * 2U, sizeof(float));
-    float* out = (float*)calloc(SYMBOLS + 512, sizeof(float));
-    assert(symbols && iq && out);
-
-    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
-    synthesize_fsk_fractional(iq, symbols, SYMBOLS, sample_count, actual_sps, 0.025f, 0.0015f, 0.002f);
-
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
-    dsd_fsk_modem_init(&modem, &cfg);
-    int produced = dsd_fsk_modem_process(&modem, iq, sample_count * 2, out, SYMBOLS + 512);
-    assert(produced >= SYMBOLS - 24);
-    assert(modem.track_updates == 0);
-    expect_4level_accuracy("dmr-gfsk-fractional-clock-no-nudge", out, produced, symbols, SYMBOLS, RUN, 900, 0.88f);
-
-    free(out);
-    free(iq);
-    free(symbols);
-}
-
-static void
-test_timing_tracker_skips_low_confidence_windows(void) {
-    enum { SYMBOLS = 128, SPS = 10, ZERO_SAMPLES = SPS * 80 };
-
-    static const float levels[] = {-3.0f, -1.0f, 1.0f, 3.0f};
-    float symbols[SYMBOLS];
-    float iq[SYMBOLS * SPS * 2];
-    float zeros[ZERO_SAMPLES * 2];
-    float out[SYMBOLS + 128];
-
-    for (int i = 0; i < SYMBOLS; i++) {
-        symbols[i] = levels[i & 3];
-    }
-    synthesize_fsk(iq, symbols, SYMBOLS, SPS, 0.026f, 0.0f, 0.0f, 0);
-    DSD_MEMSET(zeros, 0, sizeof(zeros));
-
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 4};
-    dsd_fsk_modem_init(&modem, &cfg);
-    int produced = dsd_fsk_modem_process(&modem, iq, SYMBOLS * SPS * 2, out, SYMBOLS + 128);
-    assert(produced > 0);
-    assert(modem.timing_acquired == 1);
-
-    modem.track_len = 0;
-    modem.have_prev = 0;
-    uint64_t skips_before = modem.track_skips;
-    (void)dsd_fsk_modem_process(&modem, zeros, ZERO_SAMPLES * 2, out, SYMBOLS + 128);
-    assert(modem.track_skips > skips_before);
-}
-
-static void
-test_timing_tracker_accepts_without_phase_nudge(void) {
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
-    dsd_fsk_modem_init(&modem, &cfg);
-    modem.timing_acquired = 1;
-    modem.have_prev = 1;
-    modem.prev_i = 1.0f;
-    modem.prev_q = 0.0f;
-    modem.symbol_phase = 5.0f;
-    modem.track_consecutive_skips = 4;
-    seed_tracking_boundary_window_scaled(&modem, 10, 2, 7, 0.0f, 1.05f, 1.0f);
-
-    float iq[] = {1.0f, 0.0f};
-    float out[8];
-    (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
-    assert(modem.track_updates == 0);
-    assert(modem.track_skips == 0);
-    assert(modem.track_consecutive_skips == 0);
-    assert(fabsf(modem.track_last_error - 2.0f) < 1.0e-6f);
-    assert(fabsf(modem.symbol_phase - 6.0f) < 1.0e-4f);
-}
-
-static void
-test_timing_tracker_soft_accepts_do_not_mask_signal_loss(void) {
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
-    dsd_fsk_modem_init(&modem, &cfg);
-    modem.timing_acquired = 1;
-    modem.symbol_phase = 5.0f;
-    modem.abs_est = 10.0f;
-
-    float iq[] = {1.0f, 0.0f};
-    float out[8];
-    for (int i = 0; i < 32; i++) {
-        modem.have_prev = 1;
-        modem.prev_i = 1.0f;
-        modem.prev_q = 0.0f;
-        seed_tracking_boundary_window_scaled(&modem, 10, 2, 7, 8.0f, 1.05f, 1.0f);
-        (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
-    }
-
-    assert(modem.track_updates == 0);
-    assert(modem.track_skips == 32);
-    assert(modem.track_consecutive_skips == 0);
-    assert(modem.timing_acquired == 0);
-}
-
-static void
-test_timing_tracker_preserves_low_transition_signal(void) {
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
-    dsd_fsk_modem_init(&modem, &cfg);
-    modem.timing_acquired = 1;
-    modem.symbol_phase = 4.0f;
-    modem.abs_est = 0.05f;
-
-    float iq[] = {cosf(0.05f), sinf(0.05f)};
-    float out[8];
-    for (int i = 0; i < 40; i++) {
-        modem.have_prev = 1;
-        modem.prev_i = 1.0f;
-        modem.prev_q = 0.0f;
-        modem.dc_est = 0.0f;
-        seed_tracking_constant_window(&modem, 10, 0.0f, 0.05f);
-        (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
-        assert(modem.timing_acquired == 1);
-    }
-
-    assert(modem.track_skips == 0);
-    assert(modem.track_consecutive_skips == 0);
-}
-
-static void
-test_timing_tracker_reacquires_after_consecutive_skips(void) {
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
-    dsd_fsk_modem_init(&modem, &cfg);
-    modem.timing_acquired = 1;
-    modem.have_prev = 1;
-    modem.prev_i = 1.0f;
-    modem.prev_q = 0.0f;
-    modem.symbol_phase = 4.0f;
-
-    float iq[] = {1.0f, 0.0f};
-    float out[8];
-    for (int i = 0; i < 32; i++) {
-        modem.track_len = 10 * 64 - 1;
-        modem.track_start_phase = 0.0f;
-        DSD_MEMSET(modem.track_freq, 0, sizeof(modem.track_freq));
-        (void)dsd_fsk_modem_process(&modem, iq, 2, out, 8);
-    }
-
-    assert(modem.track_skips == 32);
-    assert(modem.track_consecutive_skips == 0);
-    assert(modem.timing_acquired == 0);
-    assert(modem.acq_len == 0);
-    assert(modem.symbol_count == 0);
-    assert(modem.pending_len == 0);
-}
-
-static void
-test_timing_reacquire_waits_through_long_silence(void) {
-    enum { SYMBOLS = 2200, SPS = 10, RUN = 16, GAP_COMPLEX = (33 * 64 * SPS) + DSD_FSK_MODEM_ACQ_MAX_SAMPLES + 500 };
-
-    static const float levels[] = {-3.0f, 3.0f, -1.0f, 1.0f, 3.0f, -3.0f};
-    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
-    float* first_iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
-    float* gap_iq = (float*)calloc((size_t)GAP_COMPLEX * 2U, sizeof(float));
-    float* out = (float*)calloc(SYMBOLS + 512, sizeof(float));
-    assert(symbols && first_iq && gap_iq && out);
-
-    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
-    synthesize_fsk(first_iq, symbols, SYMBOLS, SPS, 0.025f, 0.001f, 0.002f, 0);
-
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
-    dsd_fsk_modem_init(&modem, &cfg);
-    int produced = dsd_fsk_modem_process(&modem, first_iq, SYMBOLS * SPS * 2, out, SYMBOLS + 512);
-    assert(produced >= SYMBOLS - 24);
-    assert(modem.timing_acquired == 1);
-
-    (void)dsd_fsk_modem_process(&modem, gap_iq, GAP_COMPLEX * 2, out, SYMBOLS + 512);
-    assert(modem.timing_acquired == 0);
-    assert(modem.acq_len > 0);
-    assert(modem.acq_len < DSD_FSK_MODEM_ACQ_MAX_SAMPLES);
-
-    free(out);
-    free(gap_iq);
-    free(first_iq);
-    free(symbols);
-}
-
-static void
-test_timing_tracker_recovers_after_gap(void) {
-    enum { SYMBOLS = 2200, SPS = 10, RUN = 16, GAP_COMPLEX = (33 * 64 * SPS) + 100 };
-
-    static const float levels[] = {-3.0f, 3.0f, -1.0f, 1.0f, 3.0f, -3.0f};
-    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
-    float* first_iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
-    float* gap_iq = (float*)calloc((size_t)GAP_COMPLEX * 2U, sizeof(float));
-    float* second_iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
-    float* out = (float*)calloc(SYMBOLS + 512, sizeof(float));
-    assert(symbols && first_iq && gap_iq && second_iq && out);
-
-    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
-    synthesize_fsk(first_iq, symbols, SYMBOLS, SPS, 0.025f, 0.001f, 0.002f, 0);
-    synthesize_fsk(second_iq, symbols, SYMBOLS, SPS, 0.025f, -0.001f, 0.002f, 7);
-
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
-    dsd_fsk_modem_init(&modem, &cfg);
-    int produced = dsd_fsk_modem_process(&modem, first_iq, SYMBOLS * SPS * 2, out, SYMBOLS + 512);
-    assert(produced >= SYMBOLS - 24);
-    assert(modem.timing_acquired == 1);
-
-    (void)dsd_fsk_modem_process(&modem, gap_iq, GAP_COMPLEX * 2, out, SYMBOLS + 512);
-    assert(modem.timing_acquired == 0);
-
-    produced = dsd_fsk_modem_process(&modem, second_iq, SYMBOLS * SPS * 2, out, SYMBOLS + 512);
-    assert(produced >= SYMBOLS - 256);
-    assert(modem.timing_acquired == 1);
-    expect_4level_accuracy_best_shift("dmr-gfsk-reacquire-after-gap", out, produced, symbols, SYMBOLS, RUN, 900, 64,
-                                      0.86f);
-
-    free(out);
-    free(second_iq);
-    free(gap_iq);
-    free(first_iq);
-    free(symbols);
-}
-
-static void
-test_timing_tracker_recovers_lower_deviation_after_gap(void) {
-    enum { SYMBOLS = 2400, SPS = 10, RUN = 16, GAP_COMPLEX = (33 * 64 * SPS) + 100 };
-
-    static const float levels[] = {-3.0f, 3.0f, -1.0f, 1.0f, 3.0f, -3.0f};
-    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
-    float* first_iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
-    float* gap_iq = (float*)calloc((size_t)GAP_COMPLEX * 2U, sizeof(float));
-    float* second_iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
-    float* out = (float*)calloc(SYMBOLS + 512, sizeof(float));
-    assert(symbols && first_iq && gap_iq && second_iq && out);
-
-    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
-    synthesize_fsk(first_iq, symbols, SYMBOLS, SPS, 0.030f, 0.001f, 0.002f, 0);
-    synthesize_fsk(second_iq, symbols, SYMBOLS, SPS, 0.004f, -0.0005f, 0.0005f, 5);
-
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
-    dsd_fsk_modem_init(&modem, &cfg);
-    int produced = dsd_fsk_modem_process(&modem, first_iq, SYMBOLS * SPS * 2, out, SYMBOLS + 512);
-    assert(produced >= SYMBOLS - 24);
-    assert(modem.timing_acquired == 1);
-    assert(modem.track_signal_ref > 0.0f);
-    assert(modem.abs_est > 0.0f);
-
-    (void)dsd_fsk_modem_process(&modem, gap_iq, GAP_COMPLEX * 2, out, SYMBOLS + 512);
-    assert(modem.timing_acquired == 0);
-
-    produced = dsd_fsk_modem_process(&modem, second_iq, SYMBOLS * SPS * 2, out, SYMBOLS + 512);
-    assert(produced >= SYMBOLS - 320);
-    assert(modem.timing_acquired == 1);
-    expect_4level_accuracy_best_shift("dmr-gfsk-reacquire-lower-deviation", out, produced, symbols, SYMBOLS, RUN, 900,
-                                      96, 0.82f);
-
-    free(out);
-    free(second_iq);
-    free(gap_iq);
-    free(first_iq);
-    free(symbols);
-}
-
-static void
-test_local_reacquire_preserves_pending_symbols(void) {
-    enum { SYMBOLS = 2200, SPS = 10, RUN = 16, CHUNK = 7, DRAIN_TARGET = 1200 };
-
-    enum { GAP_COMPLEX = (33 * 64 * SPS) + 100 };
-
-    static const float levels[] = {-3.0f, 3.0f, -1.0f, 1.0f, 3.0f, -3.0f};
-    const int total_complex = (SYMBOLS * SPS) + GAP_COMPLEX;
-    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
-    float* iq = (float*)calloc((size_t)total_complex * 2U, sizeof(float));
-    float* out = (float*)calloc(SYMBOLS + 512, sizeof(float));
-    float chunk[CHUNK];
-    assert(symbols && iq && out);
-
-    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
-    synthesize_fsk(iq, symbols, SYMBOLS, SPS, 0.025f, 0.001f, 0.002f, 0);
-
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
-    dsd_fsk_modem_init(&modem, &cfg);
-    int total = dsd_fsk_modem_process(&modem, iq, total_complex * 2, out, CHUNK);
-    assert(total == CHUNK);
-    assert(modem.timing_acquired == 0);
-    assert(modem.pending_pos < modem.pending_len);
-
-    while (total < DRAIN_TARGET && modem.pending_pos < modem.pending_len) {
-        int produced = dsd_fsk_modem_process(&modem, NULL, 0, chunk, CHUNK);
-        assert(produced > 0);
-        for (int i = 0; i < produced; i++) {
-            out[total++] = chunk[i];
-        }
-    }
-    assert(total >= DRAIN_TARGET);
-    expect_4level_accuracy_best_shift("local-reacquire-preserves-pending", out, total, symbols, SYMBOLS, RUN, 160, 64,
-                                      0.88f);
-
-    dsd_fsk_modem_release(&modem);
-    free(out);
-    free(iq);
-    free(symbols);
-}
-
-static void
-test_reconfigure_resets_state(void) {
-    dsd_fsk_modem_state modem;
-    dsd_fsk_modem_config cfg = {48000, 4800, 4, 4};
-    dsd_fsk_modem_init(&modem, &cfg);
-
-    float iq[128 * 10 * 2];
-    float out[160];
-    float symbols[128];
-    for (int i = 0; i < 128; i++) {
-        symbols[i] = 3.0f;
-    }
-    synthesize_fsk(iq, symbols, 128, 10, 0.02f, 0.0f, 0.0f, 0);
-    (void)dsd_fsk_modem_process(&modem, iq, 128 * 10 * 2, out, 160);
+    assert(dsd_fsk_modem_discriminator_process(&modem, iq, SAMPLES * 2, out, SAMPLES) == SAMPLES);
     assert(modem.have_prev == 1);
-    assert(modem.symbols_emitted > 0);
-    dsd_fsk_modem_metrics metrics;
-    assert(dsd_fsk_modem_get_metrics(&modem, &metrics) == 0);
-    assert(metrics.valid == 1);
-    modem.track_len = 11;
-    modem.track_start_phase = 3.0f;
-    modem.track_last_error = 2.0f;
-    modem.track_last_score = 0.5f;
-    modem.track_signal_ref = 0.25f;
-    modem.track_updates = 7;
-    modem.track_skips = 5;
-    modem.track_consecutive_skips = 3;
 
-    dsd_fsk_modem_config next = {48000, 2400, 2, 1};
+    dsd_fsk_modem_configure(&modem, &cfg);
+    assert(modem.have_prev == 1);
+
+    dsd_fsk_modem_config next = {0, 0, 99, 1};
     dsd_fsk_modem_configure(&modem, &next);
-    assert(modem.cfg.sample_rate_hz == 48000);
-    assert(modem.cfg.symbol_rate_hz == 2400);
-    assert(modem.cfg.levels == 2);
+    assert(modem.cfg.sample_rate_hz == TEST_SAMPLE_RATE);
+    assert(modem.cfg.symbol_rate_hz == TEST_SYMBOL_RATE);
+    assert(modem.cfg.levels == 4);
     assert(modem.cfg.channel_profile == 1);
     assert(modem.have_prev == 0);
-    assert(modem.symbol_count == 0);
-    assert(modem.symbols_emitted == 0);
-    assert(modem.track_len == 0);
-    assert(modem.track_start_phase == 0.0f);
-    assert(modem.track_last_error == 0.0f);
-    assert(modem.track_last_score == 0.0f);
-    assert(modem.track_signal_ref == 0.0f);
-    assert(modem.track_updates == 0);
-    assert(modem.track_skips == 0);
-    assert(modem.track_consecutive_skips == 0);
-    assert(dsd_fsk_modem_get_metrics(&modem, &metrics) == 0);
-    assert(metrics.valid == 0);
-    assert(metrics.window_symbols == 0U);
+    assert(modem.dc_est == 0.0f);
+    assert(modem.discriminator_peak_est == 0.0f);
 }
 
 int
 main(void) {
-    test_p25_c4fm_4800_at_48000();
-    test_dmr_gfsk_4800_with_offsets_noise_and_cfo();
-    test_dmr_gfsk_acquires_mid_symbol_start();
-    test_p25_c4fm_acquires_mid_symbol_start();
-    test_binary_fsk_acquires_mid_symbol_start();
-    test_provoice_fsk_acquires_mid_symbol_start();
-    test_squelch_clears_partial_acquisition();
-    test_soft_metrics_track_clean_signal();
-    test_soft_metrics_invalidate_on_zero_symbols();
-    test_acquisition_preserves_backlog_with_small_output();
-    test_binary_fsk_4800();
-    test_nxdn48_2400_at_48000();
-    test_timing_tracker_does_not_nudge_wrapped_phase();
-    test_timing_tracker_does_not_nudge_high_phase();
-    test_timing_tracker_uses_floor_for_fractional_start_phase();
-    test_dmr_gfsk_handles_fractional_symbol_clock_without_phase_nudges();
-    test_timing_tracker_skips_low_confidence_windows();
-    test_timing_tracker_accepts_without_phase_nudge();
-    test_timing_tracker_soft_accepts_do_not_mask_signal_loss();
-    test_timing_tracker_preserves_low_transition_signal();
-    test_timing_tracker_reacquires_after_consecutive_skips();
-    test_timing_reacquire_waits_through_long_silence();
-    test_timing_tracker_recovers_after_gap();
-    test_timing_tracker_recovers_lower_deviation_after_gap();
-    test_local_reacquire_preserves_pending_symbols();
-    test_reconfigure_resets_state();
+    expect_discriminator_count_sign_center_and_scale();
+    expect_reset_clears_discriminator_history();
+    expect_configure_preserves_or_resets_state();
+    printf("DSP_FSK_MODEM: OK\n");
     return 0;
 }

--- a/tests/dsp/test_fsk_modem.c
+++ b/tests/dsp/test_fsk_modem.c
@@ -862,6 +862,88 @@ test_timing_tracker_recovers_after_gap(void) {
 }
 
 static void
+test_timing_tracker_recovers_lower_deviation_after_gap(void) {
+    enum { SYMBOLS = 2400, SPS = 10, RUN = 16, GAP_COMPLEX = (33 * 64 * SPS) + 100 };
+
+    static const float levels[] = {-3.0f, 3.0f, -1.0f, 1.0f, 3.0f, -3.0f};
+    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
+    float* first_iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
+    float* gap_iq = (float*)calloc((size_t)GAP_COMPLEX * 2U, sizeof(float));
+    float* second_iq = (float*)calloc((size_t)SYMBOLS * SPS * 2U, sizeof(float));
+    float* out = (float*)calloc(SYMBOLS + 512, sizeof(float));
+    assert(symbols && first_iq && gap_iq && second_iq && out);
+
+    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
+    synthesize_fsk(first_iq, symbols, SYMBOLS, SPS, 0.030f, 0.001f, 0.002f, 0);
+    synthesize_fsk(second_iq, symbols, SYMBOLS, SPS, 0.004f, -0.0005f, 0.0005f, 5);
+
+    dsd_fsk_modem_state modem;
+    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
+    dsd_fsk_modem_init(&modem, &cfg);
+    int produced = dsd_fsk_modem_process(&modem, first_iq, SYMBOLS * SPS * 2, out, SYMBOLS + 512);
+    assert(produced >= SYMBOLS - 24);
+    assert(modem.timing_acquired == 1);
+    assert(modem.track_signal_ref > 0.0f);
+    assert(modem.abs_est > 0.0f);
+
+    (void)dsd_fsk_modem_process(&modem, gap_iq, GAP_COMPLEX * 2, out, SYMBOLS + 512);
+    assert(modem.timing_acquired == 0);
+
+    produced = dsd_fsk_modem_process(&modem, second_iq, SYMBOLS * SPS * 2, out, SYMBOLS + 512);
+    assert(produced >= SYMBOLS - 320);
+    assert(modem.timing_acquired == 1);
+    expect_4level_accuracy_best_shift("dmr-gfsk-reacquire-lower-deviation", out, produced, symbols, SYMBOLS, RUN, 900,
+                                      96, 0.82f);
+
+    free(out);
+    free(second_iq);
+    free(gap_iq);
+    free(first_iq);
+    free(symbols);
+}
+
+static void
+test_local_reacquire_preserves_pending_symbols(void) {
+    enum { SYMBOLS = 2200, SPS = 10, RUN = 16, CHUNK = 7, DRAIN_TARGET = 1200 };
+
+    enum { GAP_COMPLEX = (33 * 64 * SPS) + 100 };
+
+    static const float levels[] = {-3.0f, 3.0f, -1.0f, 1.0f, 3.0f, -3.0f};
+    const int total_complex = (SYMBOLS * SPS) + GAP_COMPLEX;
+    float* symbols = (float*)calloc(SYMBOLS, sizeof(float));
+    float* iq = (float*)calloc((size_t)total_complex * 2U, sizeof(float));
+    float* out = (float*)calloc(SYMBOLS + 512, sizeof(float));
+    float chunk[CHUNK];
+    assert(symbols && iq && out);
+
+    fill_run_pattern(symbols, SYMBOLS, levels, (int)(sizeof(levels) / sizeof(levels[0])), RUN);
+    synthesize_fsk(iq, symbols, SYMBOLS, SPS, 0.025f, 0.001f, 0.002f, 0);
+
+    dsd_fsk_modem_state modem;
+    dsd_fsk_modem_config cfg = {48000, 4800, 4, 2};
+    dsd_fsk_modem_init(&modem, &cfg);
+    int total = dsd_fsk_modem_process(&modem, iq, total_complex * 2, out, CHUNK);
+    assert(total == CHUNK);
+    assert(modem.timing_acquired == 0);
+    assert(modem.pending_pos < modem.pending_len);
+
+    while (total < DRAIN_TARGET && modem.pending_pos < modem.pending_len) {
+        int produced = dsd_fsk_modem_process(&modem, NULL, 0, chunk, CHUNK);
+        assert(produced > 0);
+        for (int i = 0; i < produced; i++) {
+            out[total++] = chunk[i];
+        }
+    }
+    assert(total >= DRAIN_TARGET);
+    expect_4level_accuracy_best_shift("local-reacquire-preserves-pending", out, total, symbols, SYMBOLS, RUN, 160, 64,
+                                      0.88f);
+
+    free(out);
+    free(iq);
+    free(symbols);
+}
+
+static void
 test_reconfigure_resets_state(void) {
     dsd_fsk_modem_state modem;
     dsd_fsk_modem_config cfg = {48000, 4800, 4, 4};
@@ -936,6 +1018,8 @@ main(void) {
     test_timing_tracker_reacquires_after_consecutive_skips();
     test_timing_reacquire_waits_through_long_silence();
     test_timing_tracker_recovers_after_gap();
+    test_timing_tracker_recovers_lower_deviation_after_gap();
+    test_local_reacquire_preserves_pending_symbols();
     test_reconfigure_resets_state();
     return 0;
 }

--- a/tests/dsp/test_rtl_symbol_cache_generation.c
+++ b/tests/dsp/test_rtl_symbol_cache_generation.c
@@ -41,6 +41,7 @@ static int g_channel_profile_after_bump = -1;
 static int g_cleanup_calls = 0;
 static int g_fail_reads = 0;
 static int g_failed_read_calls = 0;
+static int g_max_read_calls = 0;
 
 dsd_socket_t
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -139,6 +140,11 @@ fake_rtl_read(void* rtl_ctx, float* out, size_t count, int* out_got) {
     assert(count >= 4U);
 
     g_read_calls++;
+    if (g_max_read_calls > 0 && g_read_calls > g_max_read_calls) {
+        DSD_FPRINTF(stderr, "RTL symbol cache exceeded read limit: calls=%d limit=%d\n", g_read_calls,
+                    g_max_read_calls);
+        exit(3);
+    }
     if (g_fail_reads) {
         g_failed_read_calls++;
         if (g_failed_read_calls > 4) {
@@ -231,6 +237,7 @@ reset_stream_fixture(void) {
     g_cleanup_calls = 0;
     g_fail_reads = 0;
     g_failed_read_calls = 0;
+    g_max_read_calls = 0;
     dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
 }
 
@@ -268,6 +275,40 @@ main(void) {
         .stream_generation = fake_stream_generation,
     };
     dsd_rtl_stream_metrics_hooks_set(&metrics_hooks);
+
+    reset_stream_fixture();
+    reset_decoder_fixture(&opts, &state, &fake_rtl_context);
+    g_output_kind = RTL_STREAM_OUTPUT_SYMBOL_CQPSK;
+    state.rf_mod = 1;
+    assert(getSymbol(&opts, &state, 1) == 1000.0f);
+    assert(state.min == -3.0f);
+    assert(state.max == 3.0f);
+    assert(state.lmid == -2.0f);
+    assert(state.umid == 2.0f);
+
+    g_output_kind = RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
+    g_stream_generation = 2U;
+    g_output_rate_hz = 48000U;
+    g_symbol_rate_hz = 4800;
+    g_symbol_levels = 4;
+    g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_12K5;
+    g_read_base = 30000.0f;
+    g_read_base_step = 4.0f;
+    state.rf_mod = 0;
+
+    (void)getSymbol(&opts, &state, 1);
+    assert(state.min == -30000.0f);
+    assert(state.max == 30000.0f);
+    assert(state.lmid == -20000.0f);
+    assert(state.umid == 20000.0f);
+    assert(state.minref == -24000.0f);
+    assert(state.maxref == 24000.0f);
+    assert(state.minbuf[0] == -30000.0f);
+    assert(state.maxbuf[0] == 30000.0f);
+    assert(state.minbuf[1023] == -30000.0f);
+    assert(state.maxbuf[1023] == 30000.0f);
+    assert(state.minmax_sum_window == 0);
+
     reset_stream_fixture();
     reset_decoder_fixture(&opts, &state, &fake_rtl_context);
 
@@ -278,6 +319,10 @@ main(void) {
     assert(getSymbol(&opts, &state, 1) == 1001.0f);
     assert(dsd_rtl_stream_metrics_hook_symbol_cache_pending() == 2);
     assert(g_read_calls == 1);
+    assert(state.min == -3.0f);
+    assert(state.max == 3.0f);
+    assert(state.lmid == -2.0f);
+    assert(state.umid == 2.0f);
 
     g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
     g_read_base = 1250.0f;
@@ -376,6 +421,17 @@ main(void) {
     g_read_base = 5000.0f;
     g_read_base_step = 4.0f;
 
+    g_max_read_calls = 2;
+    assert(getSymbol(&opts, &state, 0) == 5000.0f);
+    assert(state.samplesPerSymbol == 2);
+    assert(state.symbolCenter == dsd_opts_symbol_center(2));
+    assert(state.jitter == -1);
+    assert(g_read_calls == 1);
+    g_max_read_calls = 0;
+
+    g_read_base = 5000.0f;
+    g_read_base_step = 4.0f;
+    g_stream_generation++;
     assert(getSymbol(&opts, &state, 1) == 5000.0f);
     assert(state.samplesPerSymbol == 2);
     assert(state.symbolCenter == dsd_opts_symbol_center(2));

--- a/tests/dsp/test_rtl_symbol_cache_generation.c
+++ b/tests/dsp/test_rtl_symbol_cache_generation.c
@@ -34,6 +34,7 @@ static float g_read_base = 1000.0f;
 static float g_read_base_step = 0.0f;
 static int g_read_calls = 0;
 static int g_bump_generation_during_read = 0;
+static int g_output_kind_after_bump = -1;
 static int g_symbol_rate_hz_after_bump = 0;
 static int g_symbol_levels_after_bump = 0;
 static int g_channel_profile_after_bump = -1;
@@ -150,6 +151,10 @@ fake_rtl_read(void* rtl_ctx, float* out, size_t count, int* out_got) {
     float read_base = g_read_base;
     if (g_bump_generation_during_read) {
         g_stream_generation++;
+        if (g_output_kind_after_bump >= 0) {
+            g_output_kind = g_output_kind_after_bump;
+            g_output_kind_after_bump = -1;
+        }
         if (g_symbol_rate_hz_after_bump > 0) {
             g_symbol_rate_hz = g_symbol_rate_hz_after_bump;
             g_symbol_rate_hz_after_bump = 0;
@@ -219,6 +224,7 @@ reset_stream_fixture(void) {
     g_read_base_step = 0.0f;
     g_read_calls = 0;
     g_bump_generation_during_read = 0;
+    g_output_kind_after_bump = -1;
     g_symbol_rate_hz_after_bump = 0;
     g_symbol_levels_after_bump = 0;
     g_channel_profile_after_bump = -1;
@@ -360,6 +366,53 @@ main(void) {
     assert(state.rtl_symbol_cache_channel_profile == RTL_STREAM_CHANNEL_PROFILE_6K25);
     assert(state.rtl_symbol_cache_levels == 2);
 
+    reset_stream_fixture();
+    reset_decoder_fixture(&opts, &state, &fake_rtl_context);
+    g_output_kind = RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
+    g_output_rate_hz = 24000U;
+    g_symbol_rate_hz = 9600;
+    g_symbol_levels = 2;
+    g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_PROVOICE;
+    g_read_base = 5000.0f;
+    g_read_base_step = 4.0f;
+
+    assert(getSymbol(&opts, &state, 1) == 5000.0f);
+    assert(state.samplesPerSymbol == 2);
+    assert(state.symbolCenter == dsd_opts_symbol_center(2));
+    assert(state.rtl_fsk_sps_accum == 4800);
+    assert(getSymbol(&opts, &state, 1) == 5003.0f);
+    assert(state.samplesPerSymbol == 3);
+    assert(state.symbolCenter == dsd_opts_symbol_center(3));
+    assert(state.rtl_fsk_sps_accum == 0);
+    assert(getSymbol(&opts, &state, 1) == 5005.0f);
+    assert(state.samplesPerSymbol == 2);
+    assert(state.rtl_fsk_sps_accum == 4800);
+
+    reset_stream_fixture();
+    reset_decoder_fixture(&opts, &state, &fake_rtl_context);
+    g_output_kind = RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
+    g_output_rate_hz = 48000U;
+    g_symbol_rate_hz = 4800;
+    g_symbol_levels = 4;
+    g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_12K5;
+    g_read_base = 4000.0f;
+    g_read_base_step = 100.0f;
+    g_bump_generation_during_read = 1;
+    g_output_kind_after_bump = RTL_STREAM_OUTPUT_SYMBOL_CQPSK;
+    g_symbol_rate_hz_after_bump = 4800;
+    g_symbol_levels_after_bump = 4;
+    g_channel_profile_after_bump = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
+
+    assert(getSymbol(&opts, &state, 1) == 0.0f);
+    assert(g_cleanup_calls == 0);
+    assert(g_stream_generation == 2U);
+    assert(g_output_kind == RTL_STREAM_OUTPUT_SYMBOL_CQPSK);
+    state.rf_mod = 1;
+    assert(getSymbol(&opts, &state, 1) == 4100.0f);
+    assert(g_cleanup_calls == 0);
+
+    reset_stream_fixture();
+    reset_decoder_fixture(&opts, &state, &fake_rtl_context);
     g_fail_reads = 1;
     g_failed_read_calls = 0;
     assert(getSymbol(&opts, &state, 1) == 0.0f);

--- a/tests/dsp/test_rtl_symbol_cache_generation.c
+++ b/tests/dsp/test_rtl_symbol_cache_generation.c
@@ -395,6 +395,30 @@ main(void) {
     g_symbol_rate_hz = 4800;
     g_symbol_levels = 4;
     g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_12K5;
+    g_read_base = 7000.0f;
+    g_read_base_step = 4.0f;
+
+    assert(getSymbol(&opts, &state, 1) == 7004.0f);
+    assert(state.samplesPerSymbol == 10);
+    assert(state.symbolCenter == dsd_opts_symbol_center(10));
+    assert(dsd_rtl_stream_metrics_hook_symbol_cache_pending() == 2);
+    state.jitter = state.symbolCenter;
+    float shifted_symbol = getSymbol(&opts, &state, 0);
+    if (fabsf(shifted_symbol - 7015.0f) >= 0.01f) {
+        DSD_FPRINTF(stderr, "FSK discriminator jitter-adjusted symbol %.4f\n", shifted_symbol);
+    }
+    assert(fabsf(shifted_symbol - 7015.0f) < 0.01f);
+    assert(state.jitter == -1);
+    assert(g_read_calls == 6);
+    assert(dsd_rtl_stream_metrics_hook_symbol_cache_pending() == 3);
+
+    reset_stream_fixture();
+    reset_decoder_fixture(&opts, &state, &fake_rtl_context);
+    g_output_kind = RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
+    g_output_rate_hz = 48000U;
+    g_symbol_rate_hz = 4800;
+    g_symbol_levels = 4;
+    g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_12K5;
     g_read_base = 4000.0f;
     g_read_base_step = 100.0f;
     g_bump_generation_during_read = 1;

--- a/tests/dsp/test_rtl_symbol_cache_generation.c
+++ b/tests/dsp/test_rtl_symbol_cache_generation.c
@@ -13,6 +13,7 @@
 #include <dsd-neo/platform/sockets.h>
 #include <dsd-neo/runtime/rtl_stream_io_hooks.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,6 +25,8 @@
 #endif
 
 static uint32_t g_stream_generation = 1;
+static int g_output_kind = RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
+static unsigned int g_output_rate_hz = 48000U;
 static int g_symbol_rate_hz = 4800;
 static int g_symbol_levels = 4;
 static int g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
@@ -177,7 +180,7 @@ fake_rtl_pwr(const void* rtl_ctx) {
 
 static int
 fake_output_kind(void) {
-    return RTL_STREAM_OUTPUT_SYMBOL_FSK;
+    return g_output_kind;
 }
 
 static int
@@ -199,6 +202,42 @@ fake_stream_generation(void) {
     return g_stream_generation;
 }
 
+static unsigned int
+fake_output_rate_hz(void) {
+    return g_output_rate_hz;
+}
+
+static void
+reset_stream_fixture(void) {
+    g_stream_generation = 1U;
+    g_output_kind = RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
+    g_output_rate_hz = 48000U;
+    g_symbol_rate_hz = 4800;
+    g_symbol_levels = 4;
+    g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+    g_read_base = 1000.0f;
+    g_read_base_step = 0.0f;
+    g_read_calls = 0;
+    g_bump_generation_during_read = 0;
+    g_symbol_rate_hz_after_bump = 0;
+    g_symbol_levels_after_bump = 0;
+    g_channel_profile_after_bump = -1;
+    g_cleanup_calls = 0;
+    g_fail_reads = 0;
+    g_failed_read_calls = 0;
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+}
+
+static void
+reset_decoder_fixture(dsd_opts* opts, dsd_state* state, void* rtl_context) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->symboltiming = 0;
+    state->rf_mod = 2;
+    state->rtl_ctx = (struct RtlSdrContext*)rtl_context;
+}
+
 int
 main(void) {
     static dsd_opts opts;
@@ -218,12 +257,16 @@ main(void) {
     });
     dsd_rtl_stream_metrics_hooks metrics_hooks = {
         .output_kind = fake_output_kind,
+        .output_rate_hz = fake_output_rate_hz,
         .symbol_profile = fake_symbol_profile,
         .stream_generation = fake_stream_generation,
     };
     dsd_rtl_stream_metrics_hooks_set(&metrics_hooks);
-    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+    reset_stream_fixture();
+    reset_decoder_fixture(&opts, &state, &fake_rtl_context);
 
+    g_output_kind = RTL_STREAM_OUTPUT_SYMBOL_CQPSK;
+    state.rf_mod = 1;
     assert(getSymbol(&opts, &state, 1) == 1000.0f);
     assert(dsd_rtl_stream_metrics_hook_symbol_cache_pending() == 3);
     assert(getSymbol(&opts, &state, 1) == 1001.0f);
@@ -281,6 +324,41 @@ main(void) {
     assert(getSymbol(&opts, &state, 1) == 3103.0f);
     assert(dsd_rtl_stream_metrics_hook_symbol_cache_pending() == 0);
     assert(g_cleanup_calls == 0);
+
+    reset_stream_fixture();
+    reset_decoder_fixture(&opts, &state, &fake_rtl_context);
+    g_output_kind = RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
+    g_output_rate_hz = 48000U;
+    g_symbol_rate_hz = 4800;
+    g_symbol_levels = 4;
+    g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_12K5;
+    g_read_base = 1000.0f;
+    g_read_base_step = 4.0f;
+
+    assert(getSymbol(&opts, &state, 1) == 1004.0f);
+    assert(state.samplesPerSymbol == 10);
+    assert(state.symbolCenter == 4);
+    assert(state.jitter == -1);
+    assert(g_read_calls == 3);
+    assert(dsd_rtl_stream_metrics_hook_symbol_cache_pending() == 2);
+
+    g_stream_generation = 4U;
+    g_symbol_rate_hz = 2400;
+    g_symbol_levels = 2;
+    g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_6K25;
+    g_read_base = 2000.0f;
+    g_read_base_step = 4.0f;
+    float nxdn_symbol = getSymbol(&opts, &state, 1);
+    if (fabsf(nxdn_symbol - 2009.7778f) >= 0.01f) {
+        DSD_FPRINTF(stderr, "FSK discriminator generation-change symbol %.4f\n", nxdn_symbol);
+    }
+    assert(fabsf(nxdn_symbol - 2009.7778f) < 0.01f);
+    assert(state.samplesPerSymbol == 20);
+    assert(state.symbolCenter == dsd_opts_symbol_center(20));
+    assert(state.rtl_symbol_cache_generation == 4U);
+    assert(state.rtl_symbol_cache_symbol_rate_hz == 2400);
+    assert(state.rtl_symbol_cache_channel_profile == RTL_STREAM_CHANNEL_PROFILE_6K25);
+    assert(state.rtl_symbol_cache_levels == 2);
 
     g_fail_reads = 1;
     g_failed_read_calls = 0;

--- a/tests/dsp/test_rtl_symbol_pipeline.cpp
+++ b/tests/dsp/test_rtl_symbol_pipeline.cpp
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -31,20 +32,6 @@ reset_demod(demod_state* s) {
     s->channel_lpf_enable = 0;
 }
 
-static int
-classify4(float sym) {
-    if (sym < -2.0f) {
-        return -3;
-    }
-    if (sym < 0.0f) {
-        return -1;
-    }
-    if (sym < 2.0f) {
-        return 1;
-    }
-    return 3;
-}
-
 static void
 synthesize_fsk_iq(float* out_iq, const float* symbols, int symbol_count, int sps, float deviation_per_level) {
     float phase = 0.19f;
@@ -64,51 +51,71 @@ synthesize_fsk_iq(float* out_iq, const float* symbols, int symbol_count, int sps
 }
 
 static int
-check_fsk_symbol_output_contract(demod_state* s) {
-    enum : unsigned short { SYMBOLS = 512, SPS = 10 };
+check_fsk_discriminator_output_contract(demod_state* s) {
+    enum : unsigned short { SYMBOLS = 256, SPS = 10 };
 
-    static const float levels[] = {-3.0f, -1.0f, 1.0f, 3.0f, 1.0f, -1.0f};
+    static const float levels[] = {-3.0f, -1.0f, 1.0f, 3.0f};
     float expected[SYMBOLS];
 
     reset_demod(s);
-    s->output_kind = DSD_DEMOD_OUTPUT_SYMBOL_FSK;
+    s->output_kind = DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
     s->symbol_rate_hz = 4800;
     s->symbol_levels = 4;
     s->lp_len = SYMBOLS * SPS * 2;
 
     for (int i = 0; i < SYMBOLS; i++) {
-        expected[i] = levels[i % (int)(sizeof(levels) / sizeof(levels[0]))];
+        expected[i] = levels[(i / 8) & 3];
     }
-    synthesize_fsk_iq(s->input_cb_buf, expected, SYMBOLS, SPS, 0.028f);
+    synthesize_fsk_iq(s->input_cb_buf, expected, SYMBOLS, SPS, 0.026f);
 
     dsd_fsk_modem_config cfg = {};
     cfg.sample_rate_hz = s->rate_out;
     cfg.symbol_rate_hz = s->symbol_rate_hz;
     cfg.levels = s->symbol_levels;
-    cfg.channel_profile = DSD_CH_LPF_PROFILE_P25_C4FM;
+    cfg.channel_profile = DSD_CH_LPF_PROFILE_12K5;
     dsd_fsk_modem_init(&s->fsk_modem_state, &cfg);
 
     full_demod(s);
 
-    if (s->result_len < SYMBOLS - 2 || s->result_len > SYMBOLS + 2) {
-        DSD_FPRINTF(stderr, "FSK symbol path result_len=%d, expected about %d symbols\n", s->result_len, SYMBOLS);
+    if (s->result_len != SYMBOLS * SPS) {
+        DSD_FPRINTF(stderr, "FSK discriminator result_len=%d, expected %d samples\n", s->result_len, SYMBOLS * SPS);
+        return 1;
+    }
+    if (s->result[0] != 0.0f) {
+        DSD_FPRINTF(stderr, "FSK discriminator first sample %.3f, expected 0\n", s->result[0]);
         return 1;
     }
 
     int checked = 0;
     int ok = 0;
-    const int limit = (s->result_len < SYMBOLS) ? s->result_len : SYMBOLS;
-    for (int i = 80; i < limit; i++) {
-        checked++;
-        if (classify4(s->result[i]) == (int)expected[i]) {
-            ok++;
+    float peak = 0.0f;
+    double mean = 0.0;
+    const int stable_start = SPS * 32;
+    for (int i = stable_start; i < s->result_len; i++) {
+        int sym = i / SPS;
+        if (sym >= SYMBOLS) {
+            sym = SYMBOLS - 1;
+        }
+        float sample = s->result[i];
+        mean += (double)sample;
+        peak = std::max(peak, std::fabs(sample));
+        if (std::fabs(expected[sym]) >= 2.0f) {
+            checked++;
+            if ((sample > 0.0f) == (expected[sym] > 0.0f)) {
+                ok++;
+            }
+        }
+        if (sample < -32768.0f || sample > 32767.0f) {
+            DSD_FPRINTF(stderr, "FSK discriminator sample[%d]=%.1f outside PCM range\n", i, sample);
+            return 1;
         }
     }
-    if (checked < 200 || ((double)ok / (double)checked) < 0.95) {
-        DSD_FPRINTF(stderr, "FSK symbol path accuracy %.3f (%d/%d)\n", checked ? (double)ok / (double)checked : 0.0, ok,
-                    checked);
+    mean /= (double)(s->result_len - stable_start);
+    if (checked < 1000 || ok < (checked * 95) / 100 || peak < 25000.0f || std::fabs(mean) > 1500.0) {
+        DSD_FPRINTF(stderr, "FSK discriminator sign=%d/%d peak=%.1f mean=%.1f\n", ok, checked, peak, mean);
         return 1;
     }
+
     return 0;
 }
 
@@ -209,7 +216,7 @@ main(void) {
     }
 
     int rc = 0;
-    rc |= check_fsk_symbol_output_contract(s);
+    rc |= check_fsk_discriminator_output_contract(s);
     rc |= check_cqpsk_symbol_output_contract(s);
     rc |= check_cqpsk_phase_extractor_accuracy(s);
 

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -53,6 +53,7 @@ static int g_rtl_symbol_levels = 4;
 static int g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
 static int g_rtl_ted_sps = 8;
 static int g_rtl_ted_sps_override = 8;
+static int g_rtl_fsk_reacquire_requests = 0;
 static int g_pending_active = 0;
 static uint32_t g_pending_target_freq_hz = 0;
 static int g_pending_cqpsk = -1;
@@ -74,6 +75,7 @@ reset_rtl_profile_fakes(void) {
     g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
     g_rtl_ted_sps = 8;
     g_rtl_ted_sps_override = 8;
+    g_rtl_fsk_reacquire_requests = 0;
     g_pending_active = 0;
     g_pending_target_freq_hz = 0;
     g_pending_cqpsk = -1;
@@ -196,6 +198,12 @@ __wrap_rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz) {
         apply_pending_profile(center_freq_hz);
     }
     return g_rtl_tune_result;
+}
+
+int
+__wrap_rtl_stream_request_fsk_reacquire(void) {
+    g_rtl_fsk_reacquire_requests++;
+    return 1;
 }
 
 // NOLINTEND(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
@@ -914,6 +922,42 @@ main(void) {
     rc |= expect_true("rtl-fsk-recovered-sync-clears-gap", state->rtl_fsk_reacquire_gap_start_m == 0.0);
     rc |= expect_true("rtl-fsk-recovered-sync-refreshes-timer",
                       state->rtl_fsk_reacquire_last_sync_m > old_reacquire_sync_m);
+#if defined(DSD_NEO_TEST_RTL_WRAP)
+    g_rtl_fsk_reacquire_requests = 0;
+    double reacquire_now_m = dsd_time_now_monotonic_s();
+    time_t reacquire_now = time(NULL);
+    state->lastsynctype = DSD_SYNC_NONE;
+    state->last_cc_sync_time = reacquire_now - 1;
+    state->last_vc_sync_time = 0;
+    state->last_cc_sync_time_m = reacquire_now_m - 1.0;
+    state->last_vc_sync_time_m = 0.0;
+    state->rtl_fsk_reacquire_last_sync_time = reacquire_now - 1;
+    state->rtl_fsk_reacquire_last_sync_m = reacquire_now_m - 1.0;
+    state->rtl_fsk_reacquire_gap_start_m = reacquire_now_m - 1.0;
+    state->rtl_fsk_reacquire_last_request_m = 0.0;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("rtl-fsk-short-nosync-gap-does-not-reacquire", g_rtl_fsk_reacquire_requests == 0);
+
+    g_rtl_fsk_reacquire_requests = 0;
+    reacquire_now_m = dsd_time_now_monotonic_s();
+    reacquire_now = time(NULL);
+    state->lastsynctype = DSD_SYNC_NONE;
+    state->last_cc_sync_time = reacquire_now - 11;
+    state->last_vc_sync_time = 0;
+    state->last_cc_sync_time_m = reacquire_now_m - 11.0;
+    state->last_vc_sync_time_m = 0.0;
+    state->rtl_fsk_reacquire_last_sync_time = reacquire_now - 11;
+    state->rtl_fsk_reacquire_last_sync_m = reacquire_now_m - 11.0;
+    state->rtl_fsk_reacquire_gap_start_m = reacquire_now_m - 11.0;
+    state->rtl_fsk_reacquire_last_request_m = 0.0;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("rtl-fsk-long-nosync-gap-reacquires-once", g_rtl_fsk_reacquire_requests == 1);
+    rc |= expect_true("rtl-fsk-long-nosync-gap-records-request", state->rtl_fsk_reacquire_last_request_m > 0.0);
+#endif
     dsd_rtl_stream_metrics_hooks_set(NULL);
 #endif
 

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -38,7 +38,7 @@ expect_true(const char* tag, int cond) {
 #ifdef USE_RADIO
 static int
 fake_rtl_fsk_output_kind(void) {
-    return RTL_STREAM_OUTPUT_SYMBOL_FSK;
+    return RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
 }
 #endif
 

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -274,12 +274,17 @@ main(void) {
     if (state->dmr_reliab_buf != NULL) {
         state->dmr_reliab_p = state->dmr_reliab_buf + 321;
     }
+    state->rtl_fsk_sps_num = 48000;
+    state->rtl_fsk_sps_den = 4800;
+    state->rtl_fsk_sps_accum = 2400;
 
     noCarrier(opts, state);
 
     rc |= expect_true("dmr-payload-pointer-buffer", state->dmr_payload_p == state->dmr_payload_buf + 200);
     rc |= expect_true("dmr-payload-pointer-not-dibit", state->dmr_payload_p != state->dibit_buf + 200);
     rc |= expect_true("dibit-pointer-reset", state->dibit_buf_p == state->dibit_buf + 200);
+    rc |= expect_true("rtl-fsk-sps-cache-reset",
+                      state->rtl_fsk_sps_num == 0 && state->rtl_fsk_sps_den == 0 && state->rtl_fsk_sps_accum == 0);
 
     for (int i = 0; i < 200; i++) {
         if (state->dmr_payload_buf[i] != 0) {

--- a/tests/io/test_io_input_level_metrics.c
+++ b/tests/io/test_io_input_level_metrics.c
@@ -84,10 +84,23 @@ test_cf32_metrics(void) {
     assert(fabs(snapshot.clip_pct - 0.1) < 1e-9);
 }
 
+static void
+test_fsk_symbol_clip_metric_is_not_rf_clipping(void) {
+    dsd_input_level_snapshot snapshot;
+    assert(dsd_input_level_metrics_from_fsk_clip(12.5f, 256U, &snapshot) == 0);
+    classify(&snapshot);
+    assert(snapshot.source == DSD_INPUT_LEVEL_SOURCE_FSK_SYMBOL);
+    assert(snapshot.status == DSD_INPUT_LEVEL_UNKNOWN);
+    assert(dsd_input_level_source_is_rf(snapshot.source) == 0);
+    assert(snapshot.sample_count == 256U);
+    assert(fabs(snapshot.clip_pct - 12.5) < 1e-6);
+}
+
 int
 main(void) {
     test_cu8_metrics();
     test_cs16_metrics();
     test_cf32_metrics();
+    test_fsk_symbol_clip_metric_is_not_rf_clipping();
     return 0;
 }

--- a/tests/io/test_io_rtl_demod_config.cpp
+++ b/tests/io/test_io_rtl_demod_config.cpp
@@ -13,6 +13,7 @@
 #include <dsd-neo/io/rtl_metrics.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/runtime/ring.h>
+#include <stdint.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 
@@ -28,6 +29,33 @@ static int
 expect_int_eq(const char* label, int got, int want) {
     if (got != want) {
         DSD_FPRINTF(stderr, "%s: got=%d want=%d\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_size_eq(const char* label, size_t got, size_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got=%zu want=%zu\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_generation_eq(const char* label, uint32_t before, uint32_t after) {
+    if (before != after) {
+        DSD_FPRINTF(stderr, "%s: before=%u after=%u\n", label, before, after);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_generation_changed(const char* label, uint32_t before, uint32_t after) {
+    if (before == after) {
+        DSD_FPRINTF(stderr, "%s: before=%u after=%u\n", label, before, after);
         return 1;
     }
     return 0;
@@ -237,6 +265,52 @@ expect_live_symbol_status(void) {
     }
 
     return rc;
+}
+
+static int
+expect_cqpsk_toggle_clears_output_contract_backlog(void) {
+    int failed = 0;
+    rtl_stream_test_cqpsk_toggle_result result = {};
+
+    int rc = rtl_stream_test_cqpsk_toggle_output_clear(0, 1, 1, 11U, 5, &result);
+    failed |= expect_int_eq("FSK to CQPSK output clear helper rc", rc, 0);
+    failed |= expect_generation_changed("FSK to CQPSK bumps output generation", result.generation_before,
+                                        result.generation_after);
+    failed |= expect_size_eq("FSK to CQPSK clears queued output", result.used_after, 0U);
+    failed |= expect_int_eq("FSK to CQPSK clears cached symbols", result.cache_pending_after, 0);
+    failed |=
+        expect_int_eq("FSK to CQPSK selects CQPSK symbols", result.output_kind_after, RTL_STREAM_OUTPUT_SYMBOL_CQPSK);
+    failed |= expect_int_eq("FSK to CQPSK does not queue FSK reset", result.fsk_reset_pending_after_toggle, 0);
+    failed |= expect_int_eq("FSK to CQPSK reset not consumed", result.reset_consumed, 0);
+    failed |= expect_int_eq("FSK to CQPSK leaves FSK modem history untouched", result.have_prev_after_consume, 1);
+
+    result = {};
+    rc = rtl_stream_test_cqpsk_toggle_output_clear(1, 0, 1, 13U, 6, &result);
+    failed |= expect_int_eq("CQPSK to FSK output clear helper rc", rc, 0);
+    failed |= expect_generation_changed("CQPSK to FSK bumps output generation", result.generation_before,
+                                        result.generation_after);
+    failed |= expect_size_eq("CQPSK to FSK clears queued output", result.used_after, 0U);
+    failed |= expect_int_eq("CQPSK to FSK clears cached symbols", result.cache_pending_after, 0);
+    failed |= expect_int_eq("CQPSK to FSK selects FSK discriminator", result.output_kind_after,
+                            RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR);
+    failed |= expect_int_eq("CQPSK to FSK queues FSK reset", result.fsk_reset_pending_after_toggle, 1);
+    failed |= expect_int_eq("CQPSK to FSK reset consumed", result.reset_consumed, 1);
+    failed |= expect_int_eq("CQPSK to FSK clears FSK modem history", result.have_prev_after_consume, 0);
+
+    result = {};
+    rc = rtl_stream_test_cqpsk_toggle_output_clear(0, 0, 1, 7U, 3, &result);
+    failed |= expect_int_eq("FSK no-op CQPSK toggle helper rc", rc, 0);
+    failed |= expect_generation_eq("FSK no-op CQPSK toggle keeps output generation", result.generation_before,
+                                   result.generation_after);
+    failed |= expect_size_eq("FSK no-op CQPSK toggle leaves queued output", result.used_after, 7U);
+    failed |= expect_int_eq("FSK no-op CQPSK toggle leaves cached symbols", result.cache_pending_after, 3);
+    failed |= expect_int_eq("FSK no-op CQPSK toggle keeps FSK discriminator", result.output_kind_after,
+                            RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR);
+    failed |= expect_int_eq("FSK no-op CQPSK toggle leaves reset unqueued", result.fsk_reset_pending_after_toggle, 0);
+    failed |= expect_int_eq("FSK no-op CQPSK toggle reset not consumed", result.reset_consumed, 0);
+    failed |= expect_int_eq("FSK no-op CQPSK toggle keeps FSK modem history", result.have_prev_after_consume, 1);
+
+    return failed;
 }
 
 static int
@@ -534,6 +608,7 @@ main(void) {
                              4800, 4);
 
     rc |= expect_live_symbol_status();
+    rc |= expect_cqpsk_toggle_clears_output_contract_backlog();
     rc |= expect_cqpsk_toggle_restores_fsk_channel_profile();
     rc |= expect_rtl_metrics_do_not_nudge_cqpsk_bandedge();
     rc |= expect_fsk_snr_sps_uses_active_profile();

--- a/tests/io/test_io_rtl_demod_config.cpp
+++ b/tests/io/test_io_rtl_demod_config.cpp
@@ -20,6 +20,11 @@ extern demod_state demod;
 extern std::atomic<double> g_snr_qpsk_db;
 
 static int
+is_fsk_output_kind(int kind) {
+    return kind == DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
+}
+
+static int
 expect_sps(const char* label, const dsd_opts& opts, int rate_hz, int override_sps, int want_sps, int want_profile) {
     static demod_state demod;
     output_state output;
@@ -67,9 +72,9 @@ expect_output_kind(const char* label, const dsd_opts& opts, int want_kind, int w
         DSD_FPRINTF(stderr, "%s: got symbol_levels=%d want=%d\n", label, demod->symbol_levels, want_levels);
         rc = 1;
     }
-    if (want_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK) {
+    if (is_fsk_output_kind(want_kind)) {
         if (demod->cqpsk_enable != 0 || demod->ted_enabled != 0) {
-            DSD_FPRINTF(stderr, "%s: FSK symbol path left CQPSK timing enabled\n", label);
+            DSD_FPRINTF(stderr, "%s: FSK path left CQPSK timing enabled\n", label);
             rc = 1;
         }
     }
@@ -79,8 +84,7 @@ expect_output_kind(const char* label, const dsd_opts& opts, int want_kind, int w
     }
 
     rtl_demod_maybe_update_resampler_after_rate_change(demod, &output, 48000);
-    if ((want_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK || want_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK)
-        && output.rate != 48000U) {
+    if ((is_fsk_output_kind(want_kind) || want_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK) && output.rate != 48000U) {
         DSD_FPRINTF(stderr, "%s: symbol output changed public output rate to %u\n", label, output.rate);
         rc = 1;
     }
@@ -164,9 +168,9 @@ expect_configured_mode(const char* label, const dsd_opts& opts, int rtl_dsp_bw_h
                     want_profile);
         rc = 1;
     }
-    if (want_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK) {
+    if (is_fsk_output_kind(want_kind)) {
         if (demod->cqpsk_enable != 0 || demod->ted_enabled != 0) {
-            DSD_FPRINTF(stderr, "%s: FSK symbol path left CQPSK timing enabled\n", label);
+            DSD_FPRINTF(stderr, "%s: FSK path left CQPSK timing enabled\n", label);
             rc = 1;
         }
     }
@@ -174,8 +178,7 @@ expect_configured_mode(const char* label, const dsd_opts& opts, int rtl_dsp_bw_h
         DSD_FPRINTF(stderr, "%s: CQPSK symbol path did not force TED on\n", label);
         rc = 1;
     }
-    if ((want_kind == DSD_DEMOD_OUTPUT_SYMBOL_FSK || want_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK)
-        && output.rate != rtl_dsp_bw_hz) {
+    if ((is_fsk_output_kind(want_kind) || want_kind == DSD_DEMOD_OUTPUT_SYMBOL_CQPSK) && output.rate != rtl_dsp_bw_hz) {
         DSD_FPRINTF(stderr, "%s: symbol output changed public output rate to %u\n", label, output.rate);
         rc = 1;
     }
@@ -190,7 +193,7 @@ expect_live_symbol_status(void) {
     int rc = 0;
 
     DSD_MEMSET(&demod, 0, sizeof(demod));
-    demod.output_kind = DSD_DEMOD_OUTPUT_SYMBOL_FSK;
+    demod.output_kind = DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
     demod.symbol_rate_hz = 4800;
     demod.symbol_levels = 4;
 
@@ -198,7 +201,7 @@ expect_live_symbol_status(void) {
     int timing = -1;
     rtl_stream_get_cqpsk_status(&cq, &timing);
     if (cq != 0 || timing != 0 || demod.ted_enabled != 0) {
-        DSD_FPRINTF(stderr, "FSK symbol output reported CQPSK timing active\n");
+        DSD_FPRINTF(stderr, "FSK discriminator output reported CQPSK timing active\n");
         rc = 1;
     }
 
@@ -322,7 +325,6 @@ expect_rtl_metrics_do_not_nudge_cqpsk_bandedge(void) {
 int
 main(void) {
     int rc = 0;
-
     /*
      * Walk protocol families through the same demod configuration helper.
      * The assertions check symbol rate, output kind, and channel filter profile
@@ -353,11 +355,12 @@ main(void) {
     static dsd_opts p25_c4fm;
     DSD_MEMSET(&p25_c4fm, 0, sizeof(p25_c4fm));
     p25_c4fm.frame_p25p1 = 1;
-    rc |= expect_output_kind("P25 C4FM selects FSK symbols", p25_c4fm, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800, 4);
-    rc |= expect_configured_mode("P25 C4FM uses P25 C4FM LPF", p25_c4fm, 48000, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800, 4,
-                                 DSD_CH_LPF_PROFILE_P25_C4FM);
-    rc |= expect_configured_mode("P25 C4FM keeps profile at 24 kHz", p25_c4fm, 24000, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800,
-                                 4, DSD_CH_LPF_PROFILE_P25_C4FM);
+    rc |=
+        expect_output_kind("P25 C4FM selects FSK discriminator", p25_c4fm, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 4800, 4);
+    rc |= expect_configured_mode("P25 C4FM uses P25 C4FM LPF", p25_c4fm, 48000, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR,
+                                 4800, 4, DSD_CH_LPF_PROFILE_P25_C4FM);
+    rc |= expect_configured_mode("P25 C4FM keeps profile at 24 kHz", p25_c4fm, 24000,
+                                 DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 4800, 4, DSD_CH_LPF_PROFILE_P25_C4FM);
 
     rc |= expect_output_kind("P25 QPSK selects CQPSK symbols", p25p1_qpsk, DSD_DEMOD_OUTPUT_SYMBOL_CQPSK, 4800, 4);
     rc |= expect_configured_mode("P25 QPSK uses P25 CQPSK LPF", p25p1_qpsk, 48000, DSD_DEMOD_OUTPUT_SYMBOL_CQPSK, 4800,
@@ -373,24 +376,25 @@ main(void) {
     static dsd_opts nxdn48;
     DSD_MEMSET(&nxdn48, 0, sizeof(nxdn48));
     nxdn48.frame_nxdn48 = 1;
-    rc |= expect_output_kind("NXDN48 selects 2400-symbol FSK", nxdn48, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 2400, 4);
-    rc |= expect_configured_mode("NXDN48 uses 6.25 kHz LPF", nxdn48, 48000, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 2400, 4,
+    rc |= expect_output_kind("NXDN48 selects 2400 FSK discriminator", nxdn48, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 2400,
+                             4);
+    rc |= expect_configured_mode("NXDN48 uses 6.25 kHz LPF", nxdn48, 48000, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 2400, 4,
                                  DSD_CH_LPF_PROFILE_6K25);
-    rc |= expect_configured_mode("NXDN48 keeps 6.25 kHz LPF at 24 kHz", nxdn48, 24000, DSD_DEMOD_OUTPUT_SYMBOL_FSK,
-                                 2400, 4, DSD_CH_LPF_PROFILE_6K25);
+    rc |= expect_configured_mode("NXDN48 keeps 6.25 kHz LPF at 24 kHz", nxdn48, 24000,
+                                 DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 2400, 4, DSD_CH_LPF_PROFILE_6K25);
 
     static dsd_opts nxdn96;
     DSD_MEMSET(&nxdn96, 0, sizeof(nxdn96));
     nxdn96.frame_nxdn96 = 1;
-    rc |= expect_configured_mode("NXDN96 uses 12.5 kHz LPF", nxdn96, 48000, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800, 4,
+    rc |= expect_configured_mode("NXDN96 uses 12.5 kHz LPF", nxdn96, 48000, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 4800, 4,
                                  DSD_CH_LPF_PROFILE_12K5);
-    rc |= expect_configured_mode("NXDN96 keeps 12.5 kHz LPF at 24 kHz", nxdn96, 24000, DSD_DEMOD_OUTPUT_SYMBOL_FSK,
-                                 4800, 4, DSD_CH_LPF_PROFILE_12K5);
+    rc |= expect_configured_mode("NXDN96 keeps 12.5 kHz LPF at 24 kHz", nxdn96, 24000,
+                                 DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 4800, 4, DSD_CH_LPF_PROFILE_12K5);
 
     static dsd_opts dmr;
     DSD_MEMSET(&dmr, 0, sizeof(dmr));
     dmr.frame_dmr = 1;
-    rc |= expect_output_kind("DMR selects 4800-symbol FSK", dmr, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800, 4);
+    rc |= expect_output_kind("DMR selects 4800 FSK discriminator", dmr, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 4800, 4);
     rc |= expect_configured_channel_profile("DMR uses 12.5 kHz FSK channel LPF", dmr, 48000, DSD_CH_LPF_PROFILE_12K5);
     rc |= expect_configured_channel_profile("DMR keeps 12.5 kHz FSK channel LPF at 24 kHz", dmr, 24000,
                                             DSD_CH_LPF_PROFILE_12K5);
@@ -398,51 +402,52 @@ main(void) {
     static dsd_opts dstar;
     DSD_MEMSET(&dstar, 0, sizeof(dstar));
     dstar.frame_dstar = 1;
-    rc |= expect_output_kind("D-STAR selects binary FSK", dstar, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800, 2);
-    rc |= expect_configured_mode("D-STAR uses 6.25 kHz LPF", dstar, 48000, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800, 2,
+    rc |= expect_output_kind("D-STAR selects binary FSK discriminator", dstar, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 4800,
+                             2);
+    rc |= expect_configured_mode("D-STAR uses 6.25 kHz LPF", dstar, 48000, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 4800, 2,
                                  DSD_CH_LPF_PROFILE_6K25);
     rc |= expect_configured_mode("D-STAR keeps binary 6.25 kHz LPF at 24 kHz", dstar, 24000,
-                                 DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800, 2, DSD_CH_LPF_PROFILE_6K25);
+                                 DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 4800, 2, DSD_CH_LPF_PROFILE_6K25);
 
     static dsd_opts x2tdma;
     DSD_MEMSET(&x2tdma, 0, sizeof(x2tdma));
     x2tdma.frame_x2tdma = 1;
-    rc |= expect_configured_mode("X2-TDMA uses 6 ksps 12.5 kHz LPF", x2tdma, 48000, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 6000,
-                                 4, DSD_CH_LPF_PROFILE_12K5);
+    rc |= expect_configured_mode("X2-TDMA uses 6 ksps 12.5 kHz LPF", x2tdma, 48000, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR,
+                                 6000, 4, DSD_CH_LPF_PROFILE_12K5);
     rc |= expect_configured_mode("X2-TDMA keeps 6 ksps 12.5 kHz LPF at 24 kHz", x2tdma, 24000,
-                                 DSD_DEMOD_OUTPUT_SYMBOL_FSK, 6000, 4, DSD_CH_LPF_PROFILE_12K5);
+                                 DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 6000, 4, DSD_CH_LPF_PROFILE_12K5);
 
     static dsd_opts ysf;
     DSD_MEMSET(&ysf, 0, sizeof(ysf));
     ysf.frame_ysf = 1;
-    rc |= expect_configured_mode("YSF uses 12.5 kHz LPF", ysf, 48000, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800, 4,
+    rc |= expect_configured_mode("YSF uses 12.5 kHz LPF", ysf, 48000, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 4800, 4,
                                  DSD_CH_LPF_PROFILE_12K5);
-    rc |= expect_configured_mode("YSF keeps 12.5 kHz LPF at 24 kHz", ysf, 24000, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800, 4,
-                                 DSD_CH_LPF_PROFILE_12K5);
+    rc |= expect_configured_mode("YSF keeps 12.5 kHz LPF at 24 kHz", ysf, 24000, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR,
+                                 4800, 4, DSD_CH_LPF_PROFILE_12K5);
 
     static dsd_opts dpmr;
     DSD_MEMSET(&dpmr, 0, sizeof(dpmr));
     dpmr.frame_dpmr = 1;
-    rc |= expect_configured_mode("dPMR uses 6.25 kHz LPF", dpmr, 48000, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 2400, 4,
+    rc |= expect_configured_mode("dPMR uses 6.25 kHz LPF", dpmr, 48000, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 2400, 4,
                                  DSD_CH_LPF_PROFILE_6K25);
-    rc |= expect_configured_mode("dPMR keeps 6.25 kHz LPF at 24 kHz", dpmr, 24000, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 2400, 4,
-                                 DSD_CH_LPF_PROFILE_6K25);
+    rc |= expect_configured_mode("dPMR keeps 6.25 kHz LPF at 24 kHz", dpmr, 24000, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR,
+                                 2400, 4, DSD_CH_LPF_PROFILE_6K25);
 
     static dsd_opts m17;
     DSD_MEMSET(&m17, 0, sizeof(m17));
     m17.frame_m17 = 1;
-    rc |= expect_configured_mode("M17 uses 12.5 kHz LPF", m17, 48000, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800, 4,
+    rc |= expect_configured_mode("M17 uses 12.5 kHz LPF", m17, 48000, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 4800, 4,
                                  DSD_CH_LPF_PROFILE_12K5);
-    rc |= expect_configured_mode("M17 keeps 12.5 kHz LPF at 24 kHz", m17, 24000, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800, 4,
-                                 DSD_CH_LPF_PROFILE_12K5);
+    rc |= expect_configured_mode("M17 keeps 12.5 kHz LPF at 24 kHz", m17, 24000, DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR,
+                                 4800, 4, DSD_CH_LPF_PROFILE_12K5);
 
     static dsd_opts provoice;
     DSD_MEMSET(&provoice, 0, sizeof(provoice));
     provoice.frame_provoice = 1;
-    rc |= expect_configured_mode("ProVoice uses 9.6 ksps binary FSK", provoice, 48000, DSD_DEMOD_OUTPUT_SYMBOL_FSK,
-                                 9600, 2, DSD_CH_LPF_PROFILE_PROVOICE);
+    rc |= expect_configured_mode("ProVoice uses 9.6 ksps binary FSK", provoice, 48000,
+                                 DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 9600, 2, DSD_CH_LPF_PROFILE_PROVOICE);
     rc |= expect_configured_mode("ProVoice keeps 9.6 ksps binary FSK at 24 kHz", provoice, 24000,
-                                 DSD_DEMOD_OUTPUT_SYMBOL_FSK, 9600, 2, DSD_CH_LPF_PROFILE_PROVOICE);
+                                 DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 9600, 2, DSD_CH_LPF_PROFILE_PROVOICE);
 
     static dsd_opts auto_all;
     DSD_MEMSET(&auto_all, 0, sizeof(auto_all));
@@ -458,16 +463,16 @@ main(void) {
     auto_all.frame_provoice = 1;
     auto_all.frame_m17 = 1;
     rc |= expect_configured_mode("AUTO starts on 4.8 ksps wide 4FSK profile", auto_all, 48000,
-                                 DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800, 4, DSD_CH_LPF_PROFILE_12K5);
+                                 DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 4800, 4, DSD_CH_LPF_PROFILE_12K5);
 
     // Soapy inputs share tuning fields but must preserve the selected digital mode.
     static dsd_opts soapy_p25_c4fm;
     soapy_p25_c4fm = p25_c4fm;
     DSD_SNPRINTF(soapy_p25_c4fm.audio_in_dev, sizeof(soapy_p25_c4fm.audio_in_dev), "%s", "soapy");
-    rc |=
-        expect_output_kind("Soapy P25 C4FM selects FSK symbols", soapy_p25_c4fm, DSD_DEMOD_OUTPUT_SYMBOL_FSK, 4800, 4);
-    rc |= expect_configured_mode("Soapy P25 C4FM uses P25 C4FM LPF", soapy_p25_c4fm, 48000, DSD_DEMOD_OUTPUT_SYMBOL_FSK,
-                                 4800, 4, DSD_CH_LPF_PROFILE_P25_C4FM);
+    rc |= expect_output_kind("Soapy P25 C4FM selects FSK discriminator", soapy_p25_c4fm,
+                             DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 4800, 4);
+    rc |= expect_configured_mode("Soapy P25 C4FM uses P25 C4FM LPF", soapy_p25_c4fm, 48000,
+                                 DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 4800, 4, DSD_CH_LPF_PROFILE_P25_C4FM);
 
     static dsd_opts soapy_p25p1_qpsk;
     soapy_p25p1_qpsk = p25p1_qpsk;

--- a/tests/io/test_io_rtl_demod_config.cpp
+++ b/tests/io/test_io_rtl_demod_config.cpp
@@ -25,6 +25,15 @@ is_fsk_output_kind(int kind) {
 }
 
 static int
+expect_int_eq(const char* label, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got=%d want=%d\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 expect_sps(const char* label, const dsd_opts& opts, int rate_hz, int override_sps, int want_sps, int want_profile) {
     static demod_state demod;
     output_state output;
@@ -322,6 +331,37 @@ expect_rtl_metrics_do_not_nudge_cqpsk_bandedge(void) {
     return 0;
 }
 
+static int
+expect_fsk_snr_sps_uses_active_profile(void) {
+    int rc = 0;
+
+    rc |= expect_int_eq("FSK SNR ignores stale TED SPS for ProVoice", rtl_stream_test_fsk_snr_sps(24000, 9600, 10), 3);
+    rc |= expect_int_eq("FSK SNR ignores stale low TED SPS for 4.8k", rtl_stream_test_fsk_snr_sps(48000, 4800, 2), 10);
+    return rc;
+}
+
+static int
+expect_direct_output_open_rate_uses_demod_rate(void) {
+    int rc = 0;
+    unsigned int output_rate_hz = 0U;
+    int resamp_enabled = -1;
+
+    int helper_rc = rtl_stream_test_direct_output_rate_after_open_update(DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR, 24000,
+                                                                         48000, &output_rate_hz, &resamp_enabled);
+    rc |= expect_int_eq("FSK direct output rate helper rc", helper_rc, 0);
+    rc |= expect_int_eq("FSK direct output publishes demod rate", (int)output_rate_hz, 24000);
+    rc |= expect_int_eq("FSK direct output disables resampler", resamp_enabled, 0);
+
+    output_rate_hz = 0U;
+    resamp_enabled = -1;
+    helper_rc = rtl_stream_test_direct_output_rate_after_open_update(DSD_DEMOD_OUTPUT_SYMBOL_CQPSK, 24000, 48000,
+                                                                     &output_rate_hz, &resamp_enabled);
+    rc |= expect_int_eq("CQPSK direct output rate helper rc", helper_rc, 0);
+    rc |= expect_int_eq("CQPSK direct output publishes demod rate", (int)output_rate_hz, 24000);
+    rc |= expect_int_eq("CQPSK direct output disables resampler", resamp_enabled, 0);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -496,6 +536,8 @@ main(void) {
     rc |= expect_live_symbol_status();
     rc |= expect_cqpsk_toggle_restores_fsk_channel_profile();
     rc |= expect_rtl_metrics_do_not_nudge_cqpsk_bandedge();
+    rc |= expect_fsk_snr_sps_uses_active_profile();
+    rc |= expect_direct_output_open_rate_uses_demod_rate();
     rc |= expect_steady_state_watermark_disabled("rtl_tcp keeps demod watermark disabled", "rtltcp:127.0.0.1:1234");
     rc |= expect_steady_state_watermark_disabled("rtlsdr keeps demod watermark disabled", "rtl");
     rc |= expect_steady_state_watermark_disabled("soapy keeps demod watermark disabled", "soapy:driver=test");

--- a/tests/io/test_io_rtl_replay_eof_and_cf32.cpp
+++ b/tests/io/test_io_rtl_replay_eof_and_cf32.cpp
@@ -271,6 +271,108 @@ make_midrange_cu8_replay_fixture(char* out_metadata_path, size_t out_metadata_pa
 }
 
 static int
+make_constant_cu8_replay_fixture(char* out_metadata_path, size_t out_metadata_path_size, uint8_t sample,
+                                 int combine_rotate_enabled, size_t payload_bytes) {
+    if (!out_metadata_path || out_metadata_path_size == 0U) {
+        return 1;
+    }
+    if ((payload_bytes & 1U) != 0U) {
+        payload_bytes++;
+    }
+
+    char temp_dir[DSD_TEST_PATH_MAX];
+    if (!dsd_test_mkdtemp(temp_dir, sizeof(temp_dir), "dsdneo_replay_level_cu8")) {
+        DSD_FPRINTF(stderr, "FAIL: could not create CU8 input-level fixture directory\n");
+        return 1;
+    }
+
+    char data_path[DSD_TEST_PATH_MAX];
+    char metadata_path[DSD_TEST_PATH_MAX];
+    if (dsd_test_path_join(data_path, sizeof(data_path), temp_dir, "level_cu8.iq") != 0
+        || dsd_test_path_join(metadata_path, sizeof(metadata_path), temp_dir, "level_cu8.iq.json") != 0) {
+        return 1;
+    }
+
+    dsd_iq_capture_config cfg;
+    fill_capture_cfg(&cfg, data_path, metadata_path, DSD_IQ_FORMAT_CU8, "post_mute_pre_widen", 1);
+    cfg.combine_rotate_enabled = combine_rotate_enabled ? 1 : 0;
+
+    dsd_iq_capture_writer* writer = NULL;
+    char err_buf[256] = {0};
+    if (dsd_iq_capture_open(&cfg, &writer, err_buf, sizeof(err_buf)) != DSD_IQ_OK || !writer) {
+        DSD_FPRINTF(stderr, "FAIL: could not open CU8 input-level IQ capture writer: %s\n",
+                    err_buf[0] ? err_buf : "unknown");
+        return 1;
+    }
+
+    std::vector<uint8_t> payload(payload_bytes, sample);
+    if (dsd_iq_capture_submit(writer, payload.data(), payload.size()) != DSD_IQ_OK) {
+        dsd_iq_capture_abort(writer);
+        return 1;
+    }
+
+    dsd_iq_capture_final_stats stats;
+    DSD_MEMSET(&stats, 0, sizeof(stats));
+    dsd_iq_capture_close(writer, &stats);
+
+    if (DSD_SNPRINTF(out_metadata_path, out_metadata_path_size, "%s", metadata_path) >= (int)out_metadata_path_size) {
+        return 1;
+    }
+    return 0;
+}
+
+static int
+make_constant_cf32_replay_fixture(char* out_metadata_path, size_t out_metadata_path_size, float i_sample,
+                                  float q_sample, size_t complex_count) {
+    if (!out_metadata_path || out_metadata_path_size == 0U || complex_count == 0U) {
+        return 1;
+    }
+
+    char temp_dir[DSD_TEST_PATH_MAX];
+    if (!dsd_test_mkdtemp(temp_dir, sizeof(temp_dir), "dsdneo_replay_level_cf32")) {
+        DSD_FPRINTF(stderr, "FAIL: could not create CF32 input-level fixture directory\n");
+        return 1;
+    }
+
+    char data_path[DSD_TEST_PATH_MAX];
+    char metadata_path[DSD_TEST_PATH_MAX];
+    if (dsd_test_path_join(data_path, sizeof(data_path), temp_dir, "level_cf32.iq") != 0
+        || dsd_test_path_join(metadata_path, sizeof(metadata_path), temp_dir, "level_cf32.iq.json") != 0) {
+        return 1;
+    }
+
+    dsd_iq_capture_config cfg;
+    fill_capture_cfg(&cfg, data_path, metadata_path, DSD_IQ_FORMAT_CF32, "post_driver_cf32_pre_ring", 1);
+
+    dsd_iq_capture_writer* writer = NULL;
+    char err_buf[256] = {0};
+    if (dsd_iq_capture_open(&cfg, &writer, err_buf, sizeof(err_buf)) != DSD_IQ_OK || !writer) {
+        DSD_FPRINTF(stderr, "FAIL: could not open CF32 input-level IQ capture writer: %s\n",
+                    err_buf[0] ? err_buf : "unknown");
+        return 1;
+    }
+
+    std::vector<float> payload(complex_count * 2U);
+    for (size_t i = 0; i < complex_count; i++) {
+        payload[i * 2U + 0U] = i_sample;
+        payload[i * 2U + 1U] = q_sample;
+    }
+    if (dsd_iq_capture_submit(writer, payload.data(), payload.size() * sizeof(float)) != DSD_IQ_OK) {
+        dsd_iq_capture_abort(writer);
+        return 1;
+    }
+
+    dsd_iq_capture_final_stats stats;
+    DSD_MEMSET(&stats, 0, sizeof(stats));
+    dsd_iq_capture_close(writer, &stats);
+
+    if (DSD_SNPRINTF(out_metadata_path, out_metadata_path_size, "%s", metadata_path) >= (int)out_metadata_path_size) {
+        return 1;
+    }
+    return 0;
+}
+
+static int
 make_eventful_replay_fixture_with_reset_reason(char* out_metadata_path, size_t out_metadata_path_size,
                                                size_t payload_bytes, const char* reset_reason) {
     if (!out_metadata_path || out_metadata_path_size == 0U) {
@@ -554,6 +656,94 @@ test_cu8_replay_publishes_raw_input_level(void) {
         rc |= expect_int_eq("cu8 replay input level source", (int)level.source, (int)DSD_INPUT_LEVEL_SOURCE_RTL_CU8);
         rc |= expect_true("cu8 replay input level has samples", level.sample_count > 0U);
         rc |= expect_true("cu8 replay input level is unclipped", level.clip_pct == 0.0);
+    }
+
+    stop_and_destroy_stream(ctx);
+    return rc;
+}
+
+static int
+test_cu8_replay_legacy_fs4_level_uses_raw_block(void) {
+    int rc = 0;
+
+    char metadata_path[DSD_TEST_PATH_MAX];
+    rc |= make_constant_cu8_replay_fixture(metadata_path, sizeof(metadata_path), 96U, 0, 131072U);
+    if (rc != 0) {
+        return 1;
+    }
+
+    std::unique_ptr<dsd_opts> opts;
+    RtlSdrContext* ctx = NULL;
+    rc |= start_replay_stream_with_loop(metadata_path, 1, &opts, &ctx);
+    if (rc != 0) {
+        stop_and_destroy_stream(ctx);
+        return 1;
+    }
+
+    dsd_input_level_snapshot level;
+    DSD_MEMSET(&level, 0, sizeof(level));
+    int saw_level = 0;
+    uint64_t start_ns = dsd_time_monotonic_ns();
+    while (dsd_time_monotonic_ns() - start_ns < 3000ULL * 1000000ULL) {
+        rc |= expect_int_eq("legacy CU8 replay input level snapshot", rtl_stream_get_input_level(&level), 0);
+        if (rc != 0) {
+            break;
+        }
+        if (level.source == DSD_INPUT_LEVEL_SOURCE_RTL_CU8 && level.sample_count > 0U) {
+            saw_level = 1;
+            break;
+        }
+        dsd_sleep_ms(1U);
+    }
+
+    rc |= expect_true("legacy CU8 replay raw input level published", saw_level);
+    if (saw_level) {
+        rc |= expect_true("legacy CU8 replay raw DC level remains near zero RMS", level.rms_dbfs < -100.0);
+    }
+
+    stop_and_destroy_stream(ctx);
+    return rc;
+}
+
+static int
+test_cf32_replay_fs4_level_uses_raw_block(void) {
+    int rc = 0;
+
+    char metadata_path[DSD_TEST_PATH_MAX];
+    rc |= make_constant_cf32_replay_fixture(metadata_path, sizeof(metadata_path), 0.5f, 0.5f, 16384U);
+    if (rc != 0) {
+        return 1;
+    }
+
+    std::unique_ptr<dsd_opts> opts;
+    RtlSdrContext* ctx = NULL;
+    rc |= start_replay_stream_with_loop(metadata_path, 1, &opts, &ctx);
+    if (rc != 0) {
+        stop_and_destroy_stream(ctx);
+        return 1;
+    }
+
+    dsd_input_level_snapshot level;
+    DSD_MEMSET(&level, 0, sizeof(level));
+    int saw_level = 0;
+    uint64_t start_ns = dsd_time_monotonic_ns();
+    while (dsd_time_monotonic_ns() - start_ns < 3000ULL * 1000000ULL) {
+        rc |= expect_int_eq("CF32 replay input level snapshot", rtl_stream_get_input_level(&level), 0);
+        if (rc != 0) {
+            break;
+        }
+        if (level.source == DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32 && level.sample_count > 0U) {
+            saw_level = 1;
+            break;
+        }
+        dsd_sleep_ms(1U);
+    }
+
+    rc |= expect_true("CF32 replay raw input level published", saw_level);
+    if (saw_level) {
+        rc |= expect_true("CF32 replay raw DC level remains near zero RMS", level.rms_dbfs < -100.0);
+        rc |= expect_true("CF32 replay raw peak still reflects DC offset",
+                          level.peak_dbfs > -7.0 && level.peak_dbfs < -5.0);
     }
 
     stop_and_destroy_stream(ctx);
@@ -987,6 +1177,8 @@ int
 main(void) {
     int rc = 0;
     rc |= test_cu8_replay_publishes_raw_input_level();
+    rc |= test_cu8_replay_legacy_fs4_level_uses_raw_block();
+    rc |= test_cf32_replay_fs4_level_uses_raw_block();
     rc |= test_replay_eof_partial_block_drains_before_exit();
     rc |= test_replay_output_tail_available_after_demod_drain();
     rc |= test_eventful_replay_applies_scheduled_events();

--- a/tests/io/test_io_rtl_replay_eof_and_cf32.cpp
+++ b/tests/io/test_io_rtl_replay_eof_and_cf32.cpp
@@ -20,6 +20,7 @@
 #include <dsd-neo/platform/timing.h>
 #include <memory>
 #include <vector>
+#include "dsd-neo/core/input_level.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/io/iq_types.h"
@@ -212,6 +213,58 @@ make_replay_fixture(char* out_metadata_path, size_t out_metadata_path_size, dsd_
 
     if (DSD_SNPRINTF(out_metadata_path, out_metadata_path_size, "%s", metadata_path) >= (int)out_metadata_path_size) {
         DSD_FPRINTF(stderr, "FAIL: metadata path overflow\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+make_midrange_cu8_replay_fixture(char* out_metadata_path, size_t out_metadata_path_size, size_t payload_bytes) {
+    if (!out_metadata_path || out_metadata_path_size == 0U) {
+        return 1;
+    }
+    if ((payload_bytes & 1U) != 0U) {
+        payload_bytes++;
+    }
+
+    char temp_dir[DSD_TEST_PATH_MAX];
+    if (!dsd_test_mkdtemp(temp_dir, sizeof(temp_dir), "dsdneo_replay_level")) {
+        DSD_FPRINTF(stderr, "FAIL: could not create input-level fixture directory\n");
+        return 1;
+    }
+
+    char data_path[DSD_TEST_PATH_MAX];
+    char metadata_path[DSD_TEST_PATH_MAX];
+    if (dsd_test_path_join(data_path, sizeof(data_path), temp_dir, "level.iq") != 0
+        || dsd_test_path_join(metadata_path, sizeof(metadata_path), temp_dir, "level.iq.json") != 0) {
+        return 1;
+    }
+
+    dsd_iq_capture_config cfg;
+    fill_capture_cfg(&cfg, data_path, metadata_path, DSD_IQ_FORMAT_CU8, "post_mute_pre_widen", 1);
+
+    dsd_iq_capture_writer* writer = NULL;
+    char err_buf[256] = {0};
+    if (dsd_iq_capture_open(&cfg, &writer, err_buf, sizeof(err_buf)) != DSD_IQ_OK || !writer) {
+        DSD_FPRINTF(stderr, "FAIL: could not open input-level IQ capture writer: %s\n",
+                    err_buf[0] ? err_buf : "unknown");
+        return 1;
+    }
+
+    std::vector<uint8_t> payload(payload_bytes);
+    for (size_t i = 0; i < payload.size(); i++) {
+        payload[i] = static_cast<uint8_t>(96U + ((i * 17U) % 65U));
+    }
+    if (dsd_iq_capture_submit(writer, payload.data(), payload.size()) != DSD_IQ_OK) {
+        dsd_iq_capture_abort(writer);
+        return 1;
+    }
+
+    dsd_iq_capture_final_stats stats;
+    DSD_MEMSET(&stats, 0, sizeof(stats));
+    dsd_iq_capture_close(writer, &stats);
+
+    if (DSD_SNPRINTF(out_metadata_path, out_metadata_path_size, "%s", metadata_path) >= (int)out_metadata_path_size) {
         return 1;
     }
     return 0;
@@ -460,6 +513,51 @@ drain_stream_to_eof(RtlSdrContext* ctx, uint64_t timeout_ms, uint64_t* out_total
             return 1;
         }
     }
+}
+
+static int
+test_cu8_replay_publishes_raw_input_level(void) {
+    int rc = 0;
+
+    char metadata_path[DSD_TEST_PATH_MAX];
+    rc |= make_midrange_cu8_replay_fixture(metadata_path, sizeof(metadata_path), 131072U);
+    if (rc != 0) {
+        return 1;
+    }
+
+    std::unique_ptr<dsd_opts> opts;
+    RtlSdrContext* ctx = NULL;
+    rc |= start_replay_stream_with_loop(metadata_path, 1, &opts, &ctx);
+    if (rc != 0) {
+        stop_and_destroy_stream(ctx);
+        return 1;
+    }
+
+    dsd_input_level_snapshot level;
+    DSD_MEMSET(&level, 0, sizeof(level));
+    int saw_level = 0;
+    uint64_t start_ns = dsd_time_monotonic_ns();
+    while (dsd_time_monotonic_ns() - start_ns < 3000ULL * 1000000ULL) {
+        rc |= expect_int_eq("replay input level snapshot", rtl_stream_get_input_level(&level), 0);
+        if (rc != 0) {
+            break;
+        }
+        if (level.source == DSD_INPUT_LEVEL_SOURCE_RTL_CU8 && level.sample_count > 0U) {
+            saw_level = 1;
+            break;
+        }
+        dsd_sleep_ms(1U);
+    }
+
+    rc |= expect_true("cu8 replay raw input level published", saw_level);
+    if (saw_level) {
+        rc |= expect_int_eq("cu8 replay input level source", (int)level.source, (int)DSD_INPUT_LEVEL_SOURCE_RTL_CU8);
+        rc |= expect_true("cu8 replay input level has samples", level.sample_count > 0U);
+        rc |= expect_true("cu8 replay input level is unclipped", level.clip_pct == 0.0);
+    }
+
+    stop_and_destroy_stream(ctx);
+    return rc;
 }
 
 static int
@@ -888,6 +986,7 @@ test_cf32_unknown_capture_stage_rejected(void) {
 int
 main(void) {
     int rc = 0;
+    rc |= test_cu8_replay_publishes_raw_input_level();
     rc |= test_replay_eof_partial_block_drains_before_exit();
     rc |= test_replay_output_tail_available_after_demod_drain();
     rc |= test_eventful_replay_applies_scheduled_events();

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -224,13 +224,16 @@ main(void) {
     failed |= expect_int_eq("clear output fsk reset clears modem history", have_prev_after_consume, 0);
 
     double fsk_cfo_hz = 0.0;
+    int fsk_cfo_after_generation_bump = -1;
     int fsk_cfo_after_reset = -1;
     const double fsk_dc_rad_per_sample = 0.0125;
-    rc = rtl_stream_test_fsk_cfo_snapshot(fsk_dc_rad_per_sample, 48000, &fsk_cfo_hz, &fsk_cfo_after_reset);
+    rc = rtl_stream_test_fsk_cfo_snapshot(fsk_dc_rad_per_sample, 48000, &fsk_cfo_hz, &fsk_cfo_after_generation_bump,
+                                          &fsk_cfo_after_reset);
     failed |= expect_int_eq("fsk cfo snapshot helper rc", rc, 0);
     failed |= expect_double_near(
         "fsk cfo snapshot conversion", fsk_cfo_hz,
         -static_cast<double>(static_cast<float>(fsk_dc_rad_per_sample)) * 48000.0 / 6.28318530717958647692, 1e-6);
+    failed |= expect_int_eq("fsk cfo snapshot generation bump invalidates estimate", fsk_cfo_after_generation_bump, 0);
     failed |= expect_int_eq("fsk cfo snapshot reset invalidates estimate", fsk_cfo_after_reset, 0);
 
     int request_rc = -1;

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -207,14 +207,15 @@ main(void) {
     int request_rc = -1;
     int consumed = -1;
     cache_pending = -1;
-    rc = rtl_stream_test_fsk_reacquire(RTL_STREAM_OUTPUT_SYMBOL_FSK, 9U, 4, &used_after, &cache_pending,
+    rc = rtl_stream_test_fsk_reacquire(RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR, 9U, 4, &used_after, &cache_pending,
                                        &generation_before, &generation_after, &request_rc, &consumed);
-    failed |= expect_int_eq("fsk reacquire helper rc", rc, 0);
-    failed |= expect_int_eq("fsk reacquire request queued", request_rc, 1);
-    failed |= expect_int_eq("fsk reacquire consumed", consumed, 1);
-    failed |= expect_generation_changed("fsk reacquire bumps generation", generation_before, generation_after);
-    failed |= expect_size_eq("fsk reacquire clears queued ring", used_after, 0U);
-    failed |= expect_int_eq("fsk reacquire resets cached symbols", cache_pending, 0);
+    failed |= expect_int_eq("fsk discriminator reacquire helper rc", rc, 0);
+    failed |= expect_int_eq("fsk discriminator reacquire request queued", request_rc, 1);
+    failed |= expect_int_eq("fsk discriminator reacquire consumed", consumed, 1);
+    failed |=
+        expect_generation_changed("fsk discriminator reacquire bumps generation", generation_before, generation_after);
+    failed |= expect_size_eq("fsk discriminator reacquire clears queued ring", used_after, 0U);
+    failed |= expect_int_eq("fsk discriminator reacquire resets cached symbols", cache_pending, 0);
 
     request_rc = -1;
     consumed = -1;

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -7,6 +7,7 @@
 #error "DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS must be enabled for this test."
 #endif
 
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <dsd-neo/io/rtl_device.h>
@@ -79,6 +80,15 @@ static int
 expect_generation_changed(const char* label, uint32_t before, uint32_t after) {
     if (before == after) {
         DSD_FPRINTF(stderr, "FAIL: %s before=%u after=%u\n", label, before, after);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_double_near(const char* label, double got, double want, double tolerance) {
+    if (std::fabs(got - want) > tolerance) {
+        DSD_FPRINTF(stderr, "FAIL: %s got=%.9f want=%.9f tolerance=%.9f\n", label, got, want, tolerance);
         return 1;
     }
     return 0;
@@ -203,6 +213,25 @@ main(void) {
     failed |= expect_generation_changed("clear output bumps generation", generation_before, generation_after);
     failed |= expect_size_eq("clear output clears queued ring", used_after, 0U);
     failed |= expect_int_eq("clear output resets cached symbols", cache_pending, 0);
+
+    int have_prev_after_clear = -1;
+    int reset_consumed = -1;
+    int have_prev_after_consume = -1;
+    rc = rtl_stream_test_clear_output_fsk_reset(7U, &have_prev_after_clear, &reset_consumed, &have_prev_after_consume);
+    failed |= expect_int_eq("clear output fsk reset helper rc", rc, 0);
+    failed |= expect_int_eq("clear output leaves fsk modem for demod thread", have_prev_after_clear, 1);
+    failed |= expect_int_eq("clear output fsk reset consumed", reset_consumed, 1);
+    failed |= expect_int_eq("clear output fsk reset clears modem history", have_prev_after_consume, 0);
+
+    double fsk_cfo_hz = 0.0;
+    int fsk_cfo_after_reset = -1;
+    const double fsk_dc_rad_per_sample = 0.0125;
+    rc = rtl_stream_test_fsk_cfo_snapshot(fsk_dc_rad_per_sample, 48000, &fsk_cfo_hz, &fsk_cfo_after_reset);
+    failed |= expect_int_eq("fsk cfo snapshot helper rc", rc, 0);
+    failed |= expect_double_near(
+        "fsk cfo snapshot conversion", fsk_cfo_hz,
+        -static_cast<double>(static_cast<float>(fsk_dc_rad_per_sample)) * 48000.0 / 6.28318530717958647692, 1e-6);
+    failed |= expect_int_eq("fsk cfo snapshot reset invalidates estimate", fsk_cfo_after_reset, 0);
 
     int request_rc = -1;
     int consumed = -1;

--- a/tests/ui/test_ui_snr_readout.c
+++ b/tests/ui/test_ui_snr_readout.c
@@ -5,16 +5,14 @@
 
 #include "ui_snr_readout.h"
 
-#include <assert.h>
 #include <dsd-neo/io/rtl_stream_c.h>
+
+#include <assert.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
 #include "dsd-neo/core/safe_api.h"
 
-static rtl_stream_fsk_metrics g_fsk_metrics;
-static int g_fsk_result = 0;
-static int g_fsk_calls = 0;
 static int g_snr_c4fm_calls = 0;
 static int g_snr_c4fm_eye_calls = 0;
 static int g_snr_cqpsk_calls = 0;
@@ -27,15 +25,6 @@ static double g_snr_cqpsk = -100.0;
 static double g_snr_gfsk = -100.0;
 static double g_snr_gfsk_eye = -100.0;
 static double g_snr_qpsk_const = -100.0;
-
-int
-rtl_stream_get_fsk_metrics(rtl_stream_fsk_metrics* out) {
-    g_fsk_calls++;
-    if (out) {
-        *out = g_fsk_metrics;
-    }
-    return g_fsk_result;
-}
 
 double
 rtl_stream_get_snr_c4fm(void) {
@@ -76,9 +65,6 @@ rtl_stream_estimate_snr_qpsk_const(void) {
 static void
 reset_fakes(void) {
     ui_snr_readout_reset_for_test();
-    DSD_MEMSET(&g_fsk_metrics, 0, sizeof(g_fsk_metrics));
-    g_fsk_result = 0;
-    g_fsk_calls = 0;
     g_snr_c4fm_calls = 0;
     g_snr_c4fm_eye_calls = 0;
     g_snr_cqpsk_calls = 0;
@@ -107,73 +93,77 @@ expect_readout(const char* name, int rf_mod, double expected_snr, const char* ex
 }
 
 static void
-test_c4fm_prefers_valid_fsk_soft_snr(void) {
+test_c4fm_uses_direct_snr(void) {
     reset_fakes();
-    g_fsk_metrics.valid = 1;
-    g_fsk_metrics.evm_snr_db = 18.25f;
-    g_snr_c4fm = 4.0;
+    g_snr_c4fm = 18.25;
 
-    expect_readout("c4fm-soft", 0, 18.25, "C4FM");
-    assert(g_fsk_calls == 1);
-    assert(g_snr_c4fm_calls == 0);
+    expect_readout("c4fm-direct", 0, 18.25, "C4FM");
+    assert(g_snr_c4fm_calls == 1);
+    assert(g_snr_c4fm_eye_calls == 0);
 }
 
 static void
-test_gfsk_prefers_valid_fsk_soft_snr(void) {
+test_c4fm_keeps_stable_direct_snr(void) {
     reset_fakes();
-    g_fsk_metrics.valid = 1;
-    g_fsk_metrics.evm_snr_db = 21.5f;
-    g_snr_gfsk = 6.0;
+    g_snr_c4fm = 18.25;
+    g_snr_c4fm_eye = 4.0;
 
-    expect_readout("gfsk-soft", 2, 21.5, "GFSK");
-    assert(g_fsk_calls == 1);
-    assert(g_snr_gfsk_calls == 0);
+    for (int i = 0; i < 64; i++) {
+        expect_readout("c4fm-stable-direct", 0, 18.25, "C4FM");
+    }
+    assert(g_snr_c4fm_calls == 64);
+    assert(g_snr_c4fm_eye_calls == 0);
 }
 
 static void
-test_gfsk_falls_back_when_fsk_metrics_invalid(void) {
+test_gfsk_uses_direct_snr(void) {
     reset_fakes();
-    g_fsk_metrics.valid = 0;
+    g_snr_gfsk = 21.5;
+
+    expect_readout("gfsk-direct", 2, 21.5, "GFSK");
+    assert(g_snr_gfsk_calls == 1);
+    assert(g_snr_gfsk_eye_calls == 0);
+}
+
+static void
+test_gfsk_falls_back_when_direct_snr_invalid(void) {
+    reset_fakes();
     g_snr_gfsk = -100.0;
     g_snr_gfsk_eye = 7.25;
 
     expect_readout("gfsk-fallback", 2, 7.25, "GFSK");
-    assert(g_fsk_calls == 1);
     assert(g_snr_gfsk_calls == 1);
     assert(g_snr_gfsk_eye_calls == 1);
 }
 
 static void
-test_fsk_soft_snr_at_invalid_threshold_falls_back(void) {
+test_c4fm_snr_at_invalid_threshold_falls_back(void) {
     reset_fakes();
-    g_fsk_metrics.valid = 1;
-    g_fsk_metrics.evm_snr_db = -50.0f;
-    g_snr_c4fm = 5.5;
+    g_snr_c4fm = -50.0;
+    g_snr_c4fm_eye = 5.5;
 
     expect_readout("c4fm-threshold-fallback", 0, 5.5, "C4FM");
-    assert(g_fsk_calls == 1);
     assert(g_snr_c4fm_calls == 1);
+    assert(g_snr_c4fm_eye_calls == 1);
 }
 
 static void
-test_qpsk_ignores_fsk_soft_snr(void) {
+test_qpsk_uses_cqpsk_snr(void) {
     reset_fakes();
-    g_fsk_metrics.valid = 1;
-    g_fsk_metrics.evm_snr_db = 44.0f;
     g_snr_cqpsk = 12.75;
 
-    expect_readout("qpsk-no-fsk", 1, 12.75, "QPSK");
-    assert(g_fsk_calls == 0);
+    expect_readout("qpsk", 1, 12.75, "QPSK");
     assert(g_snr_cqpsk_calls == 1);
 }
 
 int
 main(void) {
-    test_c4fm_prefers_valid_fsk_soft_snr();
-    test_gfsk_prefers_valid_fsk_soft_snr();
-    test_gfsk_falls_back_when_fsk_metrics_invalid();
-    test_fsk_soft_snr_at_invalid_threshold_falls_back();
-    test_qpsk_ignores_fsk_soft_snr();
+    test_c4fm_uses_direct_snr();
+    test_c4fm_keeps_stable_direct_snr();
+    test_gfsk_uses_direct_snr();
+    test_gfsk_falls_back_when_direct_snr_invalid();
+    test_c4fm_snr_at_invalid_threshold_falls_back();
+    test_qpsk_uses_cqpsk_snr();
     printf("UI_SNR_READOUT: OK\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

- Publish raw input-level metrics for IQ replay so CU8 captures report true RF levels instead of falling back to symbol-derived clipping metrics.
- Make FSK timing tracking more tolerant of soft boundary confidence and reacquire locally after sustained tracking failures.
- Keep engine-level RTL FSK reacquire as a last-resort no-sync watchdog to avoid clearing queued symbol output during short DMR call gaps.
- Treat FSK symbol clipping metrics as non-RF diagnostics so they do not produce misleading RF gain advisories.

## Capture Replay

Tested with the supplied `broken-first-call.iq.json` capture from discussion #152.

- Baseline: 4505 total audio errors, 306 FEC errors, 63 valid `TGT=9/SRC=226` grants, false RF clipping warning.
- With this change: 2971 total audio errors, 261 FEC errors, 11 no-sync events, 77 valid `TGT=9/SRC=226` grants.
- No `RF Level`, `CLIP`, `TGT=0`, or `SRC=0` hits remained in the final replay log.

The capture still has residual decode errors, but this improves the RTL replay behavior and removes a misleading clipping diagnosis.

## Validation

- `tools/format.sh`
- `tools/cmake_format_check.sh`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh`
- `cmake --preset asan-ubsan-debug`
- `cmake --build --preset asan-ubsan-debug -j --target dsd-neo_test_dsp_fsk_modem dsd-neo_test_io_rtl_replay_eof_and_cf32 dsd-neo_test_io_input_level_metrics dsd-neo_test_core_input_level dsd-neo_test_engine_no_carrier_reset`
- `ctest --preset asan-ubsan-debug --output-on-failure -R '^(DSP_FSK_MODEM|IO_RTL_REPLAY_EOF_AND_CF32|IO_INPUT_LEVEL_METRICS|CORE_INPUT_LEVEL|ENGINE_NO_CARRIER_RESET)$'`
- Push pre-push hook passed.