### PR TITLE
p25: guard NSB control-channel updates

### DIFF
--- a/src/protocol/p25/p25_cc_update.h
+++ b/src/protocol/p25/p25_cc_update.h
@@ -22,9 +22,15 @@ p25_cc_update_primary_from_network_status(const dsd_opts* opts, dsd_state* state
         return 0;
     }
 
-    const long known_cc = (state->p25_cc_freq != 0) ? state->p25_cc_freq : state->trunk_cc_freq;
-    if (p25_cc_update_is_voice_tuned(opts) && known_cc > 0 && known_cc != freq_hz) {
-        return 0;
+    if (p25_cc_update_is_voice_tuned(opts)) {
+        /*
+         * During voice follow, trunk_cc_freq is the selected return alias when
+         * populated. Do not let a stale P25 alias replace it from an NSB.
+         */
+        const long selected_cc = (state->trunk_cc_freq != 0) ? state->trunk_cc_freq : state->p25_cc_freq;
+        if (selected_cc > 0 && selected_cc != freq_hz) {
+            return 0;
+        }
     }
 
     state->p25_cc_freq = freq_hz;

--- a/src/protocol/p25/p25_cc_update.h
+++ b/src/protocol/p25/p25_cc_update.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef DSD_NEO_SRC_PROTOCOL_P25_P25_CC_UPDATE_H_
+#define DSD_NEO_SRC_PROTOCOL_P25_P25_CC_UPDATE_H_
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+
+static inline int
+p25_cc_update_is_voice_tuned(const dsd_opts* opts) {
+    return opts && (opts->p25_is_tuned != 0 || opts->trunk_is_tuned != 0);
+}
+
+static inline int
+p25_cc_update_primary_from_network_status(const dsd_opts* opts, dsd_state* state, long freq_hz) {
+    if (!state || freq_hz <= 0) {
+        return 0;
+    }
+
+    const long known_cc = (state->p25_cc_freq != 0) ? state->p25_cc_freq : state->trunk_cc_freq;
+    if (p25_cc_update_is_voice_tuned(opts) && known_cc > 0 && known_cc != freq_hz) {
+        return 0;
+    }
+
+    state->p25_cc_freq = freq_hz;
+    state->trunk_cc_freq = freq_hz;
+    return 1;
+}
+
+#endif /* DSD_NEO_SRC_PROTOCOL_P25_P25_CC_UPDATE_H_ */

--- a/src/protocol/p25/phase1/p25p1_pdu_trunking.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_trunking.c
@@ -25,6 +25,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <time.h>
+#include "../p25_cc_update.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -176,8 +177,7 @@ p25_handle_mbt_net_sts_broadcast(dsd_opts* opts, dsd_state* state, const uint8_t
     long int cr_freq = process_channel_to_freq(opts, state, channelr);
     UNUSED(cr_freq);
 
-    if (ct_freq > 0) {
-        state->p25_cc_freq = ct_freq;
+    if (p25_cc_update_primary_from_network_status(opts, state, ct_freq)) {
         state->p25_cc_is_tdma = 0;
 
         if (state->trunk_lcn_freq[0] == 0 || state->trunk_lcn_freq[0] != state->p25_cc_freq) {
@@ -198,6 +198,8 @@ p25_handle_mbt_net_sts_broadcast(dsd_opts* opts, dsd_state* state, const uint8_t
         const long neigh[1] = {ct_freq};
         p25_sm_on_neighbor_update(opts, state, neigh, 1);
         p25_confirm_idens_for_current_site(state);
+    } else if (ct_freq > 0) {
+        DSD_FPRINTF(stderr, "\n  P25 MBT NET_STS: ignoring CC update while voice-tuned (freq=%ld)", ct_freq);
     } else {
         DSD_FPRINTF(stderr, "\n  P25 MBT NET_STS: ignoring invalid channel->freq (CHAN-T=%04X)", channelt);
     }

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -391,8 +391,11 @@ tsbk_handle_network_status(dsd_opts* opts, dsd_state* state, const uint8_t tsbk_
     }
     long int cc_freq = process_channel_to_freq(opts, state, channel);
     int accepted_cc = p25_cc_update_primary_from_network_status(opts, state, cc_freq);
-    state->p25_cc_is_tdma = 0;
-    if ((accepted_cc || !p25_cc_update_is_voice_tuned(opts)) && state->p2_hardset == 0) {
+    const int cc_metadata_allowed = accepted_cc || !p25_cc_update_is_voice_tuned(opts);
+    if (cc_metadata_allowed) {
+        state->p25_cc_is_tdma = 0;
+    }
+    if (cc_metadata_allowed && state->p2_hardset == 0) {
         state->p2_wacn = wacn;
         state->p2_sysid = sysid;
     }

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <time.h>
+#include "../p25_cc_update.h"
 #include "../p25_mfid90_utils.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -388,18 +389,24 @@ tsbk_handle_network_status(dsd_opts* opts, dsd_state* state, const uint8_t tsbk_
         p25_wacn_sysid_to_callsign((uint32_t)wacn, (uint16_t)sysid, callsign);
         DSD_FPRINTF(stderr, " [%s]", callsign);
     }
-    state->p25_cc_freq = process_channel_to_freq(opts, state, channel);
-    const long neigh[1] = {state->p25_cc_freq};
-    p25_sm_on_neighbor_update(opts, state, neigh, 1);
-    state->p25_cc_is_tdma = 0;
-    if (state->trunk_lcn_freq[0] == 0 || state->trunk_lcn_freq[0] != state->p25_cc_freq) {
-        state->trunk_lcn_freq[0] = state->p25_cc_freq;
+    long int cc_freq = process_channel_to_freq(opts, state, channel);
+    if (p25_cc_update_primary_from_network_status(opts, state, cc_freq)) {
+        const long neigh[1] = {state->p25_cc_freq};
+        p25_sm_on_neighbor_update(opts, state, neigh, 1);
+        state->p25_cc_is_tdma = 0;
+        if (state->trunk_lcn_freq[0] == 0 || state->trunk_lcn_freq[0] != state->p25_cc_freq) {
+            state->trunk_lcn_freq[0] = state->p25_cc_freq;
+        }
+        if (state->p2_hardset == 0) {
+            state->p2_wacn = wacn;
+            state->p2_sysid = sysid;
+        }
+        p25_confirm_idens_for_current_site(state);
+    } else if (cc_freq > 0) {
+        DSD_FPRINTF(stderr, "\n  P25 TSBK NET_STS: ignoring CC update while voice-tuned (freq=%ld)", cc_freq);
+    } else {
+        DSD_FPRINTF(stderr, "\n  P25 TSBK NET_STS: ignoring invalid channel->freq (CHAN-T=%04X)", channel);
     }
-    if (state->p2_hardset == 0) {
-        state->p2_wacn = wacn;
-        state->p2_sysid = sysid;
-    }
-    p25_confirm_idens_for_current_site(state);
 }
 
 static void

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -391,6 +391,7 @@ tsbk_handle_network_status(dsd_opts* opts, dsd_state* state, const uint8_t tsbk_
     }
     long int cc_freq = process_channel_to_freq(opts, state, channel);
     int accepted_cc = p25_cc_update_primary_from_network_status(opts, state, cc_freq);
+    state->p25_cc_is_tdma = 0;
     if ((accepted_cc || !p25_cc_update_is_voice_tuned(opts)) && state->p2_hardset == 0) {
         state->p2_wacn = wacn;
         state->p2_sysid = sysid;
@@ -398,7 +399,6 @@ tsbk_handle_network_status(dsd_opts* opts, dsd_state* state, const uint8_t tsbk_
     if (accepted_cc) {
         const long neigh[1] = {state->p25_cc_freq};
         p25_sm_on_neighbor_update(opts, state, neigh, 1);
-        state->p25_cc_is_tdma = 0;
         if (state->trunk_lcn_freq[0] == 0 || state->trunk_lcn_freq[0] != state->p25_cc_freq) {
             state->trunk_lcn_freq[0] = state->p25_cc_freq;
         }

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -390,16 +390,17 @@ tsbk_handle_network_status(dsd_opts* opts, dsd_state* state, const uint8_t tsbk_
         DSD_FPRINTF(stderr, " [%s]", callsign);
     }
     long int cc_freq = process_channel_to_freq(opts, state, channel);
-    if (p25_cc_update_primary_from_network_status(opts, state, cc_freq)) {
+    int accepted_cc = p25_cc_update_primary_from_network_status(opts, state, cc_freq);
+    if ((accepted_cc || !p25_cc_update_is_voice_tuned(opts)) && state->p2_hardset == 0) {
+        state->p2_wacn = wacn;
+        state->p2_sysid = sysid;
+    }
+    if (accepted_cc) {
         const long neigh[1] = {state->p25_cc_freq};
         p25_sm_on_neighbor_update(opts, state, neigh, 1);
         state->p25_cc_is_tdma = 0;
         if (state->trunk_lcn_freq[0] == 0 || state->trunk_lcn_freq[0] != state->p25_cc_freq) {
             state->trunk_lcn_freq[0] = state->p25_cc_freq;
-        }
-        if (state->p2_hardset == 0) {
-            state->p2_wacn = wacn;
-            state->p2_sysid = sysid;
         }
         p25_confirm_idens_for_current_site(state);
     } else if (cc_freq > 0) {

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -3427,11 +3427,18 @@ p25p2_vpdu_apply_nsb_identity(dsd_state* state, int lwacn, int lsysid, int lcolo
 }
 
 static void
+p25p2_vpdu_note_nsb_system_tdma(dsd_state* state) {
+    if (state) {
+        state->p25_sys_is_tdma = 1; // system carries Phase 2 voice (TDMA present)
+    }
+}
+
+static void
 p25p2_vpdu_accept_nsb_cc(dsd_opts* opts, dsd_state* state, int lwacn, int lsysid, int lcolorcode, int seed_lcn0) {
     const long neigh[1] = {state->p25_cc_freq};
     p25_sm_on_neighbor_update(opts, state, neigh, 1);
-    state->p25_sys_is_tdma = 1; // system carries Phase 2 voice (TDMA present)
-    state->p25_cc_is_tdma = 1;  // TDMA control channel (QPSK, 6000 sym/s)
+    p25p2_vpdu_note_nsb_system_tdma(state);
+    state->p25_cc_is_tdma = 1; // TDMA control channel (QPSK, 6000 sym/s)
 
     // Only update system identity and potentially reset IDEN tables when values
     // are sane (non-zero) and we have a valid frequency mapping.
@@ -3478,6 +3485,7 @@ p25p2_vpdu_iter_block_47(p25p2_vpdu_ctx* ctx) {
         DSD_FPRINTF(stderr, "  LRA [%02X] WACN [%05X] SYSID [%03X] NAC [%03X] CHAN-T [%04X]", lra, lwacn, lsysid,
                     lcolorcode, channel);
         long int cc_freq = process_channel_to_freq(opts, state, channel);
+        p25p2_vpdu_note_nsb_system_tdma(state);
         if (p25_cc_update_primary_from_network_status(opts, state, cc_freq)) {
             p25p2_vpdu_accept_nsb_cc(opts, state, lwacn, lsysid, lcolorcode, 1);
         } else {
@@ -3523,6 +3531,7 @@ p25p2_vpdu_iter_block_48(p25p2_vpdu_ctx* ctx) {
                     lsysid, lcolorcode, channelt, channelr);
         long int nf1 = process_channel_to_freq(opts, state, channelt);
         (void)process_channel_to_freq(opts, state, channelr);
+        p25p2_vpdu_note_nsb_system_tdma(state);
         if (p25_cc_update_primary_from_network_status(opts, state, nf1)) {
             p25p2_vpdu_accept_nsb_cc(opts, state, lwacn, lsysid, lcolorcode, 0);
         } else {

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include "../p25_cc_update.h"
 #include "../p25_extended_function.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -3409,6 +3410,49 @@ BLOCK_END:
 }
 
 static void
+p25p2_vpdu_apply_nsb_identity(dsd_state* state, int lwacn, int lsysid, int lcolorcode) {
+    if (!state || state->p2_hardset != 0) {
+        return;
+    }
+    if (lwacn == 0 && lsysid == 0) {
+        return;
+    }
+    if ((state->p2_wacn != 0 || state->p2_sysid != 0)
+        && (state->p2_wacn != (unsigned long long)lwacn || state->p2_sysid != (unsigned long long)lsysid)) {
+        p25_reset_iden_tables(state);
+    }
+    state->p2_wacn = lwacn;
+    state->p2_sysid = lsysid;
+    state->p2_cc = lcolorcode;
+}
+
+static void
+p25p2_vpdu_accept_nsb_cc(dsd_opts* opts, dsd_state* state, int lwacn, int lsysid, int lcolorcode, int seed_lcn0) {
+    const long neigh[1] = {state->p25_cc_freq};
+    p25_sm_on_neighbor_update(opts, state, neigh, 1);
+    state->p25_sys_is_tdma = 1; // system carries Phase 2 voice (TDMA present)
+    state->p25_cc_is_tdma = 1;  // TDMA control channel (QPSK, 6000 sym/s)
+
+    // Only update system identity and potentially reset IDEN tables when values
+    // are sane (non-zero) and we have a valid frequency mapping.
+    p25p2_vpdu_apply_nsb_identity(state, lwacn, lsysid, lcolorcode);
+
+    if (seed_lcn0 && (state->trunk_lcn_freq[0] == 0 || state->trunk_lcn_freq[0] != state->p25_cc_freq)) {
+        state->trunk_lcn_freq[0] = state->p25_cc_freq;
+    }
+    p25_confirm_idens_for_current_site(state);
+}
+
+static void
+p25p2_vpdu_log_rejected_nsb_cc(const char* label, long freq, int channel) {
+    if (freq > 0) {
+        DSD_FPRINTF(stderr, "\n  %s: ignoring CC update while voice-tuned (freq=%ld)", label, freq);
+    } else {
+        DSD_FPRINTF(stderr, "\n  %s: ignoring invalid channel->freq (CHAN-T=%04X)", label, channel);
+    }
+}
+
+static void
 p25p2_vpdu_iter_block_47(p25p2_vpdu_ctx* ctx) {
     dsd_opts* opts VPDU_MAYBE_UNUSED = ctx->opts;
     dsd_state* state VPDU_MAYBE_UNUSED = ctx->state;
@@ -3434,39 +3478,10 @@ p25p2_vpdu_iter_block_47(p25p2_vpdu_ctx* ctx) {
         DSD_FPRINTF(stderr, "  LRA [%02X] WACN [%05X] SYSID [%03X] NAC [%03X] CHAN-T [%04X]", lra, lwacn, lsysid,
                     lcolorcode, channel);
         long int cc_freq = process_channel_to_freq(opts, state, channel);
-        if (cc_freq > 0) {
-            state->p25_cc_freq = cc_freq;
-            const long neigh_a[1] = {state->p25_cc_freq};
-            p25_sm_on_neighbor_update(opts, state, neigh_a, 1);
-            state->p25_sys_is_tdma = 1; // system carries Phase 2 voice (TDMA present)
-            state->p25_cc_is_tdma = 1;  // TDMA control channel (QPSK, 6000 sym/s)
-
-            // Only update system identity and potentially reset IDEN tables when
-            // values are sane (non-zero) and we have a valid frequency mapping.
-            if (state->p2_hardset == 0) { // prevent bogus data from wiping tables
-                if ((lwacn != 0 || lsysid != 0)
-                    && ((state->p2_wacn != 0 || state->p2_sysid != 0)
-                        && (state->p2_wacn != (unsigned long long)lwacn
-                            || state->p2_sysid != (unsigned long long)lsysid))) {
-                    p25_reset_iden_tables(state);
-                }
-                if (lwacn != 0 || lsysid != 0) {
-                    state->p2_wacn = lwacn;
-                    state->p2_sysid = lsysid;
-                    state->p2_cc = lcolorcode;
-                }
-            }
-
-            //place the cc freq into the list at index 0 if 0 is empty, or not the same,
-            //so we can hunt for rotating CCs without user LCN list
-            if (state->trunk_lcn_freq[0] == 0 || state->trunk_lcn_freq[0] != state->p25_cc_freq) {
-                state->trunk_lcn_freq[0] = state->p25_cc_freq;
-            }
-            // Confirm any IDENs now that CC identity is known
-            p25_confirm_idens_for_current_site(state);
+        if (p25_cc_update_primary_from_network_status(opts, state, cc_freq)) {
+            p25p2_vpdu_accept_nsb_cc(opts, state, lwacn, lsysid, lcolorcode, 1);
         } else {
-            // Invalid/unknown channel mapping: ignore to avoid wiping IDEN tables from bogus frames
-            DSD_FPRINTF(stderr, "\n  P25 NSB: ignoring invalid channel->freq (CHAN-T=%04X)", channel);
+            p25p2_vpdu_log_rejected_nsb_cc("P25 NSB", cc_freq, channel);
         }
     }
 
@@ -3508,28 +3523,10 @@ p25p2_vpdu_iter_block_48(p25p2_vpdu_ctx* ctx) {
                     lsysid, lcolorcode, channelt, channelr);
         long int nf1 = process_channel_to_freq(opts, state, channelt);
         (void)process_channel_to_freq(opts, state, channelr);
-        if (nf1 > 0) {
-            state->p25_cc_freq = nf1;
-            const long neigh_b[1] = {nf1};
-            p25_sm_on_neighbor_update(opts, state, neigh_b, 1);
-            state->p25_sys_is_tdma = 1;   // system carries Phase 2 voice (TDMA present)
-            state->p25_cc_is_tdma = 1;    // TDMA control channel (QPSK, 6000 sym/s)
-            if (state->p2_hardset == 0) { // prevent bogus data from wiping tables
-                if ((lwacn != 0 || lsysid != 0)
-                    && ((state->p2_wacn != 0 || state->p2_sysid != 0)
-                        && (state->p2_wacn != (unsigned long long)lwacn
-                            || state->p2_sysid != (unsigned long long)lsysid))) {
-                    p25_reset_iden_tables(state);
-                }
-                if (lwacn != 0 || lsysid != 0) {
-                    state->p2_wacn = lwacn;
-                    state->p2_sysid = lsysid;
-                    state->p2_cc = lcolorcode;
-                }
-            }
-            p25_confirm_idens_for_current_site(state);
+        if (p25_cc_update_primary_from_network_status(opts, state, nf1)) {
+            p25p2_vpdu_accept_nsb_cc(opts, state, lwacn, lsysid, lcolorcode, 0);
         } else {
-            DSD_FPRINTF(stderr, "\n  P25 NSB-EXT: ignoring invalid channel->freq (CHAN-T=%04X)", channelt);
+            p25p2_vpdu_log_rejected_nsb_cc("P25 NSB-EXT", nf1, channelt);
         }
     }
 

--- a/tests/protocol/p25/test_p25_neighbor_table.c
+++ b/tests/protocol/p25/test_p25_neighbor_table.c
@@ -162,6 +162,48 @@ test_nsb_cc_update_accepts_same_freq_while_voice_tuned(void) {
     free(st);
 }
 
+/* A stale P25 alias must not replace the selected trunk return CC. */
+static void
+test_nsb_cc_update_rejects_stale_p25_alias_while_voice_tuned(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* st = calloc(1, sizeof(*st));
+    assert(opts != NULL);
+    assert(st != NULL);
+
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    st->p25_cc_freq = 769768750;
+    st->trunk_cc_freq = 769868750;
+
+    assert(!p25_cc_update_primary_from_network_status(opts, st, 769768750));
+    assert(st->p25_cc_freq == 769768750);
+    assert(st->trunk_cc_freq == 769868750);
+
+    free(opts);
+    free(st);
+}
+
+/* An NSB matching the selected trunk return CC can resync a stale P25 alias. */
+static void
+test_nsb_cc_update_accepts_trunk_alias_while_voice_tuned(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* st = calloc(1, sizeof(*st));
+    assert(opts != NULL);
+    assert(st != NULL);
+
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    st->p25_cc_freq = 769768750;
+    st->trunk_cc_freq = 769868750;
+
+    assert(p25_cc_update_primary_from_network_status(opts, st, 769868750));
+    assert(st->p25_cc_freq == 769868750);
+    assert(st->trunk_cc_freq == 769868750);
+
+    free(opts);
+    free(st);
+}
+
 /* On the control channel/acquisition path, NSB can still seed or rotate CC. */
 static void
 test_nsb_cc_update_accepts_new_freq_when_not_voice_tuned(void) {
@@ -301,6 +343,8 @@ main(void) {
     test_cc_rotation_accepts_old();
     test_nsb_cc_update_rejects_different_freq_while_voice_tuned();
     test_nsb_cc_update_accepts_same_freq_while_voice_tuned();
+    test_nsb_cc_update_rejects_stale_p25_alias_while_voice_tuned();
+    test_nsb_cc_update_accepts_trunk_alias_while_voice_tuned();
     test_nsb_cc_update_accepts_new_freq_when_not_voice_tuned();
     test_new_entry_fields();
     test_multiple_distinct_entries();

--- a/tests/protocol/p25/test_p25_neighbor_table.c
+++ b/tests/protocol/p25/test_p25_neighbor_table.c
@@ -7,11 +7,14 @@
  * CC rotation, LRU eviction, and input guards for p25_nb_add_ex(). */
 
 #include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <time.h>
+#include "../../../src/protocol/p25/p25_cc_update.h"
 #include "dsd-neo/core/state_fwd.h"
 
 /* --- Metadata preservation ------------------------------------------------ */
@@ -117,6 +120,64 @@ test_cc_rotation_accepts_old(void) {
     assert(st->p25_nb_entries[0].freq == 852312500);
     assert(st->p25_nb_entries[0].sysid == 0x100);
 
+    free(st);
+}
+
+/* Network Status Broadcasts seen on a VC must not clobber the return CC. */
+static void
+test_nsb_cc_update_rejects_different_freq_while_voice_tuned(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* st = calloc(1, sizeof(*st));
+    assert(opts != NULL);
+    assert(st != NULL);
+
+    opts->p25_is_tuned = 1;
+    st->p25_cc_freq = 769768750;
+    st->trunk_cc_freq = 769768750;
+
+    assert(!p25_cc_update_primary_from_network_status(opts, st, 863812500));
+    assert(st->p25_cc_freq == 769768750);
+    assert(st->trunk_cc_freq == 769768750);
+
+    free(opts);
+    free(st);
+}
+
+/* A matching NSB CC can refresh aliases even while voice-tuned. */
+static void
+test_nsb_cc_update_accepts_same_freq_while_voice_tuned(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* st = calloc(1, sizeof(*st));
+    assert(opts != NULL);
+    assert(st != NULL);
+
+    opts->trunk_is_tuned = 1;
+    st->p25_cc_freq = 769768750;
+
+    assert(p25_cc_update_primary_from_network_status(opts, st, 769768750));
+    assert(st->p25_cc_freq == 769768750);
+    assert(st->trunk_cc_freq == 769768750);
+
+    free(opts);
+    free(st);
+}
+
+/* On the control channel/acquisition path, NSB can still seed or rotate CC. */
+static void
+test_nsb_cc_update_accepts_new_freq_when_not_voice_tuned(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* st = calloc(1, sizeof(*st));
+    assert(opts != NULL);
+    assert(st != NULL);
+
+    st->p25_cc_freq = 769768750;
+    st->trunk_cc_freq = 769768750;
+
+    assert(p25_cc_update_primary_from_network_status(opts, st, 770018750));
+    assert(st->p25_cc_freq == 770018750);
+    assert(st->trunk_cc_freq == 770018750);
+
+    free(opts);
     free(st);
 }
 
@@ -238,6 +299,9 @@ main(void) {
     test_same_frequency_distinct_sites_remain_separate();
     test_self_entry_rejected();
     test_cc_rotation_accepts_old();
+    test_nsb_cc_update_rejects_different_freq_while_voice_tuned();
+    test_nsb_cc_update_accepts_same_freq_while_voice_tuned();
+    test_nsb_cc_update_accepts_new_freq_when_not_voice_tuned();
     test_new_entry_fields();
     test_multiple_distinct_entries();
     test_lru_eviction();

--- a/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
@@ -107,6 +107,20 @@ build_group_grant_tsbk(uint8_t out[12], uint8_t lb, uint16_t group, uint32_t sou
 }
 
 static void
+build_network_status_tsbk(uint8_t out[12], uint32_t wacn, uint16_t sysid, uint16_t channel) {
+    DSD_MEMSET(out, 0, 12);
+    out[0] = 0x80U | 0x3BU;
+    out[1] = 0x00;
+    out[3] = (uint8_t)((wacn >> 12) & 0xFFU);
+    out[4] = (uint8_t)((wacn >> 4) & 0xFFU);
+    out[5] = (uint8_t)(((wacn & 0x0FU) << 4) | ((sysid >> 8) & 0x0FU));
+    out[6] = (uint8_t)(sysid & 0xFFU);
+    out[7] = (uint8_t)(channel >> 8);
+    out[8] = (uint8_t)(channel & 0xFFU);
+    append_crc16(out);
+}
+
+static void
 append_tsbk_stream_block(const uint8_t dibits[98], int* skipdibit) {
     int valid_idx = 0;
     for (int i = 0; i < 101; i++) {
@@ -118,6 +132,18 @@ append_tsbk_stream_block(const uint8_t dibits[98], int* skipdibit) {
         }
         (*skipdibit)++;
     }
+}
+
+static void
+reset_decode_counters(void) {
+    g_mac_count = 0;
+    g_mac_group[0] = 0;
+    g_mac_group[1] = 0;
+    g_mac_group[2] = 0;
+    g_mac_source[0] = 0;
+    g_mac_source[1] = 0;
+    g_mac_source[2] = 0;
+    g_status_count = 0;
 }
 
 static void
@@ -135,6 +161,21 @@ build_two_block_stream(void) {
     append_tsbk_stream_block(dibits, &skipdibit);
 
     build_group_grant_tsbk(block, 1, 0x2222, 0x000202);
+    encode_12_to_dibits(block, dibits);
+    append_tsbk_stream_block(dibits, &skipdibit);
+}
+
+static void
+build_network_status_stream(void) {
+    uint8_t block[12];
+    uint8_t dibits[98];
+    int skipdibit = 36 - 14;
+
+    DSD_MEMSET(g_stream, 0, sizeof(g_stream));
+    g_stream_len = 0;
+    g_stream_pos = 0;
+
+    build_network_status_tsbk(block, 0xABCDE, 0x123, 0x8123);
     encode_12_to_dibits(block, dibits);
     append_tsbk_stream_block(dibits, &skipdibit);
 }
@@ -320,6 +361,7 @@ expect_eq_int(const char* tag, int got, int want) {
 int
 main(void) {
     build_two_block_stream();
+    reset_decode_counters();
 
     static dsd_opts opts;
     static dsd_state state;
@@ -338,6 +380,18 @@ main(void) {
     rc |= expect_eq_int("status symbols collected", g_status_count, 6);
     rc |= expect_eq_int("fec ok count", (int)state.p25_p1_fec_ok, 2);
     rc |= expect_eq_int("fec err count", (int)state.p25_p1_fec_err, 0);
+
+    build_network_status_stream();
+    reset_decode_counters();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    processTSBK(&opts, &state);
+
+    rc |= expect_eq_int("net-sts missing-iden stores wacn", (int)state.p2_wacn, 0xABCDE);
+    rc |= expect_eq_int("net-sts missing-iden stores sysid", (int)state.p2_sysid, 0x123);
+    rc |= expect_eq_int("net-sts missing-iden leaves p25 cc empty", (int)state.p25_cc_freq, 0);
+    rc |= expect_eq_int("net-sts missing-iden leaves trunk cc empty", (int)state.trunk_cc_freq, 0);
     return rc;
 }
 

--- a/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
@@ -385,11 +385,13 @@ main(void) {
     reset_decode_counters();
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
+    state.p25_cc_is_tdma = 2;
 
     processTSBK(&opts, &state);
 
     rc |= expect_eq_int("net-sts missing-iden stores wacn", (int)state.p2_wacn, 0xABCDE);
     rc |= expect_eq_int("net-sts missing-iden stores sysid", (int)state.p2_sysid, 0x123);
+    rc |= expect_eq_int("net-sts missing-iden marks p1 cc fdma", state.p25_cc_is_tdma, 0);
     rc |= expect_eq_int("net-sts missing-iden leaves p25 cc empty", (int)state.p25_cc_freq, 0);
     rc |= expect_eq_int("net-sts missing-iden leaves trunk cc empty", (int)state.trunk_cc_freq, 0);
     return rc;

--- a/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
@@ -45,6 +45,7 @@ static int g_mac_count = 0;
 static int g_mac_group[3] = {0};
 static int g_mac_source[3] = {0};
 static int g_status_count = 0;
+static long g_channel_freq = 0;
 
 static void
 bytes_to_tdibits(const uint8_t bytes[12], uint8_t tdibits[49]) {
@@ -231,7 +232,7 @@ process_channel_to_freq(const dsd_opts* opts, dsd_state* state, int channel) {
     (void)opts;
     (void)state;
     (void)channel;
-    return 0;
+    return g_channel_freq;
 }
 
 void
@@ -383,6 +384,7 @@ main(void) {
 
     build_network_status_stream();
     reset_decode_counters();
+    g_channel_freq = 0;
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
     state.p25_cc_is_tdma = 2;
@@ -394,6 +396,24 @@ main(void) {
     rc |= expect_eq_int("net-sts missing-iden marks p1 cc fdma", state.p25_cc_is_tdma, 0);
     rc |= expect_eq_int("net-sts missing-iden leaves p25 cc empty", (int)state.p25_cc_freq, 0);
     rc |= expect_eq_int("net-sts missing-iden leaves trunk cc empty", (int)state.trunk_cc_freq, 0);
+
+    build_network_status_stream();
+    reset_decode_counters();
+    g_channel_freq = 863812500;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.p25_is_tuned = 1;
+    state.p25_cc_freq = 851000000;
+    state.trunk_cc_freq = 851000000;
+    state.p25_cc_is_tdma = 1;
+
+    processTSBK(&opts, &state);
+
+    rc |= expect_eq_int("net-sts rejected voice preserves p25 cc", (int)state.p25_cc_freq, 851000000);
+    rc |= expect_eq_int("net-sts rejected voice preserves trunk cc", (int)state.trunk_cc_freq, 851000000);
+    rc |= expect_eq_int("net-sts rejected voice preserves tdma cc hint", state.p25_cc_is_tdma, 1);
+    rc |= expect_eq_int("net-sts rejected voice skips wacn", (int)state.p2_wacn, 0);
+    rc |= expect_eq_int("net-sts rejected voice skips sysid", (int)state.p2_sysid, 0);
     return rc;
 }
 

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -411,6 +411,46 @@ main(void) {
         rc |= expect_eq_long("0x42 blocked vc", state.p25_vc_freq[0], 0);
     }
 
+    // Case J: rejected P2 NSBs still prove the system carries TDMA voice without changing return CC metadata.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_is_tuned = 1;
+        state.p25_cc_freq = cc;
+        state.trunk_cc_freq = cc;
+        state.p25_cc_is_tdma = 0;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+
+        MAC[1] = 0x7B; // Network Status Broadcast - Abbreviated
+        MAC[2] = 0x01; // LRA
+        MAC[3] = 0xAB;
+        MAC[4] = 0xCD;
+        MAC[5] = 0xE1; // WACN 0xABCDE, SYSID high nibble 0x1
+        MAC[6] = 0x23; // SYSID low byte
+        MAC[7] = 0x10;
+        MAC[8] = 0x0A; // channel 0x100A -> 851.125 MHz, rejected while selected CC is 851 MHz
+        MAC[9] = 0x00; // sysclass
+        MAC[10] = 0x00;
+        MAC[11] = 0x55; // NAC
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_true("p2 rejected nsb sets system tdma hint", state.p25_sys_is_tdma == 1);
+        rc |= expect_true("p2 rejected nsb preserves cc modulation", state.p25_cc_is_tdma == 0);
+        rc |= expect_eq_long("p2 rejected nsb preserves p25 cc", state.p25_cc_freq, cc);
+        rc |= expect_eq_long("p2 rejected nsb preserves trunk cc", state.trunk_cc_freq, cc);
+        rc |= expect_true("p2 rejected nsb skips wacn", state.p2_wacn == 0);
+        rc |= expect_true("p2 rejected nsb skips sysid", state.p2_sysid == 0);
+    }
+
     return rc;
 }
 


### PR DESCRIPTION
## Summary
- Reject NSB-derived control-channel updates while voice-tuned when they differ from the known return control channel.
- Keep accepted NSB control-channel updates synchronized between P25 and trunk aliases.
- Add regression coverage for mid-call foreign control-channel updates.

## Root Cause
Network Status Broadcast handlers directly overwrote `state->p25_cc_freq` from CHAN-T mappings seen during voice follow. Return-to-CC selection prefers `p25_cc_freq`; the tune path then records that value into `trunk_cc_freq`, so a traffic-channel NSB could poison the primary return CC and LCN fallback.

`/tmp/p25-sm.log` shows the good CC `769768750` changing to `863812500` while still on voice frequency `773718750`, followed by release back to `863812500` and repeated failed ON_CC attempts. OP25 keeps NSB primary-channel data separate from the active return CC, which matches the guard added here.

## Validation
- `tools/format.sh`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure -R P25_NEIGHBOR_TABLE`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh`
- `git push -u origin fix/p25-nsb-cc-guard` (pre-push hook passed)