### PR TITLE
dsp: stabilize p25 cqpsk sync orientation

### DIFF
--- a/include/dsd-neo/core/p25_cqpsk_dibit.h
+++ b/include/dsd-neo/core/p25_cqpsk_dibit.h
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief OP25-compatible P25 CQPSK dibit orientation maps.
+ */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_CORE_P25_CQPSK_DIBIT_H_
+#define DSD_NEO_INCLUDE_DSD_NEO_CORE_P25_CQPSK_DIBIT_H_
+
+#include <stdint.h>
+
+#define DSD_P25_CQPSK_DIBIT_MAP_IDENTITY 0u
+#define DSD_P25_CQPSK_DIBIT_MAP_REV_P    1u
+#define DSD_P25_CQPSK_DIBIT_MAP_X2400    2u
+#define DSD_P25_CQPSK_DIBIT_MAP_N1200    3u
+#define DSD_P25_CQPSK_DIBIT_MAP_P1200    4u
+#define DSD_P25_CQPSK_DIBIT_MAP_COUNT    5u
+
+static inline uint8_t
+dsd_p25_cqpsk_dibit_map_index(uint8_t map_idx) {
+    return (map_idx < DSD_P25_CQPSK_DIBIT_MAP_COUNT) ? map_idx : DSD_P25_CQPSK_DIBIT_MAP_IDENTITY;
+}
+
+static inline uint8_t
+dsd_p25_cqpsk_correct_dibit(uint8_t map_idx, uint8_t dibit) {
+    static const uint8_t maps[DSD_P25_CQPSK_DIBIT_MAP_COUNT][4] = {
+        {0, 1, 2, 3}, /* normal */
+        {2, 3, 0, 1}, /* reverse polarity */
+        {3, 2, 1, 0}, /* OP25 X2400 */
+        {1, 3, 0, 2}, /* OP25 N1200 */
+        {2, 0, 3, 1}, /* OP25 P1200 */
+    };
+    return maps[dsd_p25_cqpsk_dibit_map_index(map_idx)][dibit & 0x3u];
+}
+
+static inline uint8_t
+dsd_p25_cqpsk_raw_dibit_for_corrected(uint8_t map_idx, uint8_t corrected_dibit) {
+    uint8_t wanted = corrected_dibit & 0x3u;
+    uint8_t idx = dsd_p25_cqpsk_dibit_map_index(map_idx);
+    for (uint8_t raw = 0; raw < 4u; raw++) {
+        if (dsd_p25_cqpsk_correct_dibit(idx, raw) == wanted) {
+            return raw;
+        }
+    }
+    return wanted;
+}
+
+#endif /* DSD_NEO_INCLUDE_DSD_NEO_CORE_P25_CQPSK_DIBIT_H_ */

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -474,6 +474,7 @@ struct dsd_state {
 
     // Last dibit read
     int last_dibit;
+    uint8_t p25_cqpsk_dibit_map_idx; // OP25-compatible CQPSK orientation map
 
     //input sample buffer for monitoring Input
     short input_sample_buffer;  //HERE HERE

--- a/src/core/frames/dsd_dibit.c
+++ b/src/core/frames/dsd_dibit.c
@@ -663,7 +663,7 @@ build_standard_dibit_ideals(const dsd_state* state, int inverted, float ideal[4]
 }
 
 static void DSD_ATTR_USED
-build_cqpsk_dibit_ideals(const dsd_state* state, float ideal[4]) {
+build_cqpsk_dibit_ideals(const dsd_state* state, int inverted, float ideal[4]) {
     const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
     if (!cfg) {
         dsd_neo_config_init(NULL);
@@ -675,19 +675,16 @@ build_cqpsk_dibit_ideals(const dsd_state* state, float ideal[4]) {
     const float base_ideal[4] = {1.0f, 3.0f, -1.0f, -3.0f};
 
     for (int dibit = 0; dibit < 4; dibit++) {
-        int mapped = dsd_p25_cqpsk_raw_dibit_for_corrected(state->p25_cqpsk_dibit_map_idx, (uint8_t)dibit);
+        int corrected = inverted ? invert_dibit(dibit) : dibit;
+        if (corrected < 0 || corrected >= 4) {
+            corrected = dibit;
+        }
+        int mapped = dsd_p25_cqpsk_raw_dibit_for_corrected(state->p25_cqpsk_dibit_map_idx, (uint8_t)corrected);
         int base = inv ? invert_dibit(mapped) : mapped;
         if (base < 0 || base >= 4) {
             base = 0;
         }
-        float level = 1.0f;
-        switch (base) {
-            case 0: level = base_ideal[0]; break;
-            case 1: level = base_ideal[1]; break;
-            case 2: level = base_ideal[2]; break;
-            case 3: level = base_ideal[3]; break;
-            default: level = base_ideal[0]; break;
-        }
+        float level = base_ideal[base];
         if (negate) {
             level = -level;
         }
@@ -705,7 +702,7 @@ compute_dibit_soft_metric(const dsd_state* state, float symbol, int dibit, int i
 
     float ideal[4];
     if (cqpsk_aligned) {
-        build_cqpsk_dibit_ideals(state, ideal);
+        build_cqpsk_dibit_ideals(state, inverted, ideal);
     } else {
         build_standard_dibit_ideals(state, inverted, ideal);
     }
@@ -1039,6 +1036,12 @@ select_four_level_dibit(const dsd_opts* opts, const dsd_state* state, float symb
     if (want_cqpsk_p25_slice(opts, state, is_negative)) {
         int dibit = cqpsk_slice_aligned(symbol - state->center);
         dibit = dsd_p25_cqpsk_correct_dibit(state->p25_cqpsk_dibit_map_idx, (uint8_t)dibit);
+        if (is_negative) {
+            dibit = invert_dibit(dibit);
+            if (dibit < 0) {
+                dibit = 0;
+            }
+        }
         if (used_cqpsk_slice) {
             *used_cqpsk_slice = 1;
         }
@@ -1088,7 +1091,7 @@ digitize(const dsd_opts* opts, dsd_state* state, float symbol) {
     int stored_dibit = is_negative ? invert_dibit(dibit) : dibit;
 
     dsd_dibit_soft_t soft;
-    compute_dibit_soft_metric(state, symbol, dibit, is_negative && !used_cqpsk_slice, used_cqpsk_slice, &soft);
+    compute_dibit_soft_metric(state, symbol, dibit, is_negative, used_cqpsk_slice, &soft);
     state->last_dibit = dibit;
     store_dibit_with_soft(state, stored_dibit, &soft);
     return dibit;

--- a/src/core/frames/dsd_dibit.c
+++ b/src/core/frames/dsd_dibit.c
@@ -22,6 +22,7 @@
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/dibit.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/p25_cqpsk_dibit.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/symbol.h>
@@ -674,7 +675,8 @@ build_cqpsk_dibit_ideals(const dsd_state* state, float ideal[4]) {
     const float base_ideal[4] = {1.0f, 3.0f, -1.0f, -3.0f};
 
     for (int dibit = 0; dibit < 4; dibit++) {
-        int base = inv ? invert_dibit(dibit) : dibit;
+        int mapped = dsd_p25_cqpsk_raw_dibit_for_corrected(state->p25_cqpsk_dibit_map_idx, (uint8_t)dibit);
+        int base = inv ? invert_dibit(mapped) : mapped;
         if (base < 0 || base >= 4) {
             base = 0;
         }
@@ -1036,6 +1038,7 @@ select_four_level_dibit(const dsd_opts* opts, const dsd_state* state, float symb
 #ifdef USE_RADIO
     if (want_cqpsk_p25_slice(opts, state, is_negative)) {
         int dibit = cqpsk_slice_aligned(symbol - state->center);
+        dibit = dsd_p25_cqpsk_correct_dibit(state->p25_cqpsk_dibit_map_idx, (uint8_t)dibit);
         if (used_cqpsk_slice) {
             *used_cqpsk_slice = 1;
         }

--- a/src/core/frames/dsd_dibit.c
+++ b/src/core/frames/dsd_dibit.c
@@ -994,18 +994,13 @@ store_two_level_dibit(dsd_state* state, float symbol, int high_symbol_return) {
 
 static int DSD_ATTR_USED
 want_cqpsk_p25_slice(const dsd_opts* opts, const dsd_state* state, int is_negative) {
-    int p25p1_sync = is_negative ? DSD_SYNC_P25P1_NEG : DSD_SYNC_P25P1_POS;
-    int p25p2_sync = is_negative ? DSD_SYNC_P25P2_NEG : DSD_SYNC_P25P2_POS;
+    UNUSED(is_negative);
 #ifdef USE_RADIO
     return is_cqpsk_active(opts) && state->rf_mod == 1
-           && (opts->frame_p25p1 == 1 || opts->frame_p25p2 == 1 || state->synctype == p25p1_sync
-               || state->synctype == p25p2_sync || state->lastsynctype == p25p1_sync
-               || state->lastsynctype == p25p2_sync);
+           && (DSD_SYNC_IS_P25(state->synctype) || DSD_SYNC_IS_P25(state->lastsynctype));
 #else
     UNUSED(opts);
     UNUSED(state);
-    UNUSED(p25p1_sync);
-    UNUSED(p25p2_sync);
     return 0;
 #endif
 }

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -6,6 +6,7 @@
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/init.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/p25_cqpsk_dibit.h>
 #include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
@@ -557,6 +558,7 @@ init_state_sync_and_stream_defaults(dsd_state* state) {
     state->symbol_capture_soft_records = 0;
     state->rf_mod = 0;
     state->lastsynctype = DSD_SYNC_NONE;
+    state->p25_cqpsk_dibit_map_idx = DSD_P25_CQPSK_DIBIT_MAP_IDENTITY;
     state->lastp25type = 0;
     state->offset = 0;
     state->carrier = 0;

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -412,6 +412,11 @@ typedef enum {
 } frame_sync_p25_center_mode_t;
 
 #ifdef USE_RADIO
+typedef struct {
+    float center;
+    float gain;
+} frame_sync_p25_cqpsk_raw_fit_t;
+
 static int
 frame_sync_cqpsk_raw_level_unit(uint8_t raw_dibit) {
     static const int units[4] = {1, 3, -1, -3};
@@ -435,7 +440,7 @@ frame_sync_accumulate_p25_cqpsk_raw_sync(const dsd_state* state, const char* raw
 }
 
 static dsd_warm_start_result_t
-frame_sync_fit_p25_cqpsk_raw_center(const float sum[4], const int count[4], float* out_center) {
+frame_sync_fit_p25_cqpsk_raw_levels(const float sum[4], const int count[4], frame_sync_p25_cqpsk_raw_fit_t* out_fit) {
     float sum_x = 0.0f;
     float sum_y = 0.0f;
     float sum_xx = 0.0f;
@@ -465,19 +470,24 @@ frame_sync_fit_p25_cqpsk_raw_center(const float sum[4], const int count[4], floa
     if (fabsf(gain) * 2.0f < DSD_WARM_START_MIN_SPAN) {
         return DSD_WARM_START_DEGENERATE;
     }
-    *out_center = (sum_y - (gain * sum_x)) / (float)n;
+    if (!out_fit) {
+        return DSD_WARM_START_NULL_STATE;
+    }
+    out_fit->center = (sum_y - (gain * sum_x)) / (float)n;
+    out_fit->gain = gain;
     return DSD_WARM_START_OK;
 }
 
 static dsd_warm_start_result_t
-frame_sync_warm_start_p25_cqpsk_center_from_raw_sync(frame_sync_match_ctx* ctx, const char* raw_window, int sync_len) {
+frame_sync_fit_p25_cqpsk_raw_sync(const frame_sync_match_ctx* ctx, const char* raw_window, int sync_len,
+                                  frame_sync_p25_cqpsk_raw_fit_t* out_fit) {
     if (!dsd_sync_warm_start_enabled()) {
         return DSD_WARM_START_DISABLED;
     }
     if (!ctx || !ctx->state || !raw_window) {
         return DSD_WARM_START_NULL_STATE;
     }
-    dsd_state* state = ctx->state;
+    const dsd_state* state = ctx->state;
     if (sync_len <= 1 || strlen(raw_window) < (size_t)sync_len) {
         return DSD_WARM_START_DEGENERATE;
     }
@@ -491,13 +501,50 @@ frame_sync_warm_start_p25_cqpsk_center_from_raw_sync(frame_sync_match_ctx* ctx, 
     if (result != DSD_WARM_START_OK) {
         return result;
     }
-    float center = 0.0f;
-    result = frame_sync_fit_p25_cqpsk_raw_center(sum, count, &center);
-    if (result != DSD_WARM_START_OK) {
-        return result;
+    return frame_sync_fit_p25_cqpsk_raw_levels(sum, count, out_fit);
+}
+
+static void
+frame_sync_seed_p25_cqpsk_level_windows(const dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
+        return;
     }
-    state->center = center;
-    return DSD_WARM_START_OK;
+
+    int minmax_count = dsd_state_minmax_window_size(opts->msize);
+    for (int i = 0; i < minmax_count; i++) {
+        state->minbuf[i] = state->min;
+        state->maxbuf[i] = state->max;
+    }
+    dsd_state_invalidate_minmax_sums(state);
+
+    int symbol_count = opts->ssize;
+    if (symbol_count < 0) {
+        symbol_count = 0;
+    }
+    if (symbol_count > (int)(sizeof(state->sbuf) / sizeof(state->sbuf[0]))) {
+        symbol_count = (int)(sizeof(state->sbuf) / sizeof(state->sbuf[0]));
+    }
+    for (int i = 0; i < symbol_count; i++) {
+        state->sbuf[i] = (i & 1) ? state->max : state->min;
+    }
+}
+
+static void
+frame_sync_apply_p25_cqpsk_raw_fit(frame_sync_match_ctx* ctx, const frame_sync_p25_cqpsk_raw_fit_t* fit) {
+    if (!ctx || !ctx->state || !fit) {
+        return;
+    }
+
+    dsd_state* state = ctx->state;
+    float half_span = fabsf(fit->gain) * 3.0f;
+    state->center = fit->center;
+    state->min = fit->center - half_span;
+    state->max = fit->center + half_span;
+    state->umid = state->center + (state->max - state->center) * DSD_WARM_START_MID_FRACTION;
+    state->lmid = state->center + (state->min - state->center) * DSD_WARM_START_MID_FRACTION;
+    state->maxref = state->max * 0.80f;
+    state->minref = state->min * 0.80f;
+    frame_sync_seed_p25_cqpsk_level_windows(ctx->opts, state);
 }
 
 static int
@@ -634,25 +681,31 @@ frame_sync_try_p25p1(frame_sync_match_ctx* ctx) {
     uint8_t map_idx = DSD_P25_CQPSK_DIBIT_MAP_IDENTITY;
     if (frame_sync_cqpsk_4level_enabled(opts, state)
         && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest, P25P1_SYNC, &map_idx)) {
-        dsd_warm_start_result_t center_result =
-            frame_sync_warm_start_p25_cqpsk_center_from_raw_sync(ctx, ctx->synctest, 24);
+        frame_sync_p25_cqpsk_raw_fit_t fit = {0.0f, 0.0f};
+        dsd_warm_start_result_t center_result = frame_sync_fit_p25_cqpsk_raw_sync(ctx, ctx->synctest, 24, &fit);
         if (frame_sync_p25_cqpsk_map_requires_center_fit(map_idx) && center_result != DSD_WARM_START_OK) {
             return DSD_SYNC_NONE;
         }
         frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
         frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_POS, "+P25p1", FRAME_SYNC_P25_CENTER_SKIP);
+        if (center_result == DSD_WARM_START_OK) {
+            frame_sync_apply_p25_cqpsk_raw_fit(ctx, &fit);
+        }
         return DSD_SYNC_P25P1_POS;
     }
 
     if (frame_sync_cqpsk_4level_enabled(opts, state)
         && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest, INV_P25P1_SYNC, &map_idx)) {
-        dsd_warm_start_result_t center_result =
-            frame_sync_warm_start_p25_cqpsk_center_from_raw_sync(ctx, ctx->synctest, 24);
+        frame_sync_p25_cqpsk_raw_fit_t fit = {0.0f, 0.0f};
+        dsd_warm_start_result_t center_result = frame_sync_fit_p25_cqpsk_raw_sync(ctx, ctx->synctest, 24, &fit);
         if (frame_sync_p25_cqpsk_map_requires_center_fit(map_idx) && center_result != DSD_WARM_START_OK) {
             return DSD_SYNC_NONE;
         }
         frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
         frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_NEG, "-P25p1 ", FRAME_SYNC_P25_CENTER_SKIP);
+        if (center_result == DSD_WARM_START_OK) {
+            frame_sync_apply_p25_cqpsk_raw_fit(ctx, &fit);
+        }
         return DSD_SYNC_P25P1_NEG;
     }
 #endif
@@ -770,25 +823,31 @@ frame_sync_try_p25p2(frame_sync_match_ctx* ctx) {
     uint8_t map_idx = DSD_P25_CQPSK_DIBIT_MAP_IDENTITY;
     if (frame_sync_cqpsk_4level_enabled(opts, state)
         && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest20, P25P2_SYNC, &map_idx)) {
-        dsd_warm_start_result_t center_result =
-            frame_sync_warm_start_p25_cqpsk_center_from_raw_sync(ctx, ctx->synctest20, 20);
+        frame_sync_p25_cqpsk_raw_fit_t fit = {0.0f, 0.0f};
+        dsd_warm_start_result_t center_result = frame_sync_fit_p25_cqpsk_raw_sync(ctx, ctx->synctest20, 20, &fit);
         if (frame_sync_p25_cqpsk_map_requires_center_fit(map_idx) && center_result != DSD_WARM_START_OK) {
             return DSD_SYNC_NONE;
         }
         frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
         frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_POS, 0, "+P25p2", 1, FRAME_SYNC_P25_CENTER_SKIP);
+        if (center_result == DSD_WARM_START_OK) {
+            frame_sync_apply_p25_cqpsk_raw_fit(ctx, &fit);
+        }
         return DSD_SYNC_P25P2_POS;
     }
 
     if (frame_sync_cqpsk_4level_enabled(opts, state)
         && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest20, INV_P25P2_SYNC, &map_idx)) {
-        dsd_warm_start_result_t center_result =
-            frame_sync_warm_start_p25_cqpsk_center_from_raw_sync(ctx, ctx->synctest20, 20);
+        frame_sync_p25_cqpsk_raw_fit_t fit = {0.0f, 0.0f};
+        dsd_warm_start_result_t center_result = frame_sync_fit_p25_cqpsk_raw_sync(ctx, ctx->synctest20, 20, &fit);
         if (frame_sync_p25_cqpsk_map_requires_center_fit(map_idx) && center_result != DSD_WARM_START_OK) {
             return DSD_SYNC_NONE;
         }
         frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
         frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_NEG, 1, "-P25p2", 0, FRAME_SYNC_P25_CENTER_SKIP);
+        if (center_result == DSD_WARM_START_OK) {
+            frame_sync_apply_p25_cqpsk_raw_fit(ctx, &fit);
+        }
         return DSD_SYNC_P25P2_NEG;
     }
 #endif

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -44,6 +44,7 @@
 #include <dsd-neo/runtime/exitflag.h>
 #include <dsd-neo/runtime/frame_sync_hooks.h>
 #include <dsd-neo/runtime/telemetry.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -328,16 +329,10 @@ dsd_frame_sync_reset_mod_state(void) {
 }
 
 /*
- * P25 CQPSK handling - matches OP25 exactly.
- *
- * OP25 does NOT use constellation permutation tables. It only uses:
- * 1. Normal sync detection (P25_FRAME_SYNC_MAGIC)
- * 2. Polarity reversal detection (reverse_p ^= 0x02)
- * 3. Tuning error detection (log only, no dibit remapping)
- *
- * The Costas loop handles legitimate 90° phase ambiguity via PT_45 rotation.
- * Tuning errors (±1200Hz, ±2400Hz) cannot be fixed by dibit remapping - they
- * require RF correction.
+ * P25 CQPSK handling follows OP25's frame-sync dibit maps. OP25 detects raw
+ * sync variants and applies the selected map at slicer output; dsd-neo also
+ * keeps a separate center estimate for RTL symbol streams, so rotated sync
+ * acceptance must calibrate that center from the raw symbol window.
  */
 
 void
@@ -410,7 +405,107 @@ frame_sync_set_p25_cqpsk_dibit_map(frame_sync_match_ctx* ctx, uint8_t map_idx) {
     ctx->state->p25_cqpsk_dibit_map_idx = dsd_p25_cqpsk_dibit_map_index(map_idx);
 }
 
+typedef enum {
+    FRAME_SYNC_P25_CENTER_AUTO = 0,
+    FRAME_SYNC_P25_CENTER_FORCE = 1,
+    FRAME_SYNC_P25_CENTER_SKIP = 2,
+} frame_sync_p25_center_mode_t;
+
 #ifdef USE_RADIO
+static int
+frame_sync_cqpsk_raw_level_unit(uint8_t raw_dibit) {
+    static const int units[4] = {1, 3, -1, -3};
+    return units[raw_dibit & 0x3u];
+}
+
+static dsd_warm_start_result_t
+frame_sync_accumulate_p25_cqpsk_raw_sync(const dsd_state* state, const char* raw_window, int sync_len, float sum[4],
+                                         int count[4]) {
+    for (int i = 0; i < sync_len; i++) {
+        char c = raw_window[i];
+        if (c < '0' || c > '3') {
+            return DSD_WARM_START_DEGENERATE;
+        }
+        int raw_dibit = c - '0';
+        int back = sync_len - 1 - i;
+        sum[raw_dibit] += dsd_symbol_history_get_back(state, back);
+        count[raw_dibit]++;
+    }
+    return DSD_WARM_START_OK;
+}
+
+static dsd_warm_start_result_t
+frame_sync_fit_p25_cqpsk_raw_center(const float sum[4], const int count[4], float* out_center) {
+    float sum_x = 0.0f;
+    float sum_y = 0.0f;
+    float sum_xx = 0.0f;
+    float sum_xy = 0.0f;
+    int n = 0;
+    for (uint8_t raw = 0; raw < 4u; raw++) {
+        if (count[raw] == 0) {
+            continue;
+        }
+        float x = (float)frame_sync_cqpsk_raw_level_unit(raw);
+        float y = sum[raw] / (float)count[raw];
+        sum_x += x;
+        sum_y += y;
+        sum_xx += x * x;
+        sum_xy += x * y;
+        n++;
+    }
+    if (n < 2) {
+        return DSD_WARM_START_DEGENERATE;
+    }
+
+    float denom = ((float)n * sum_xx) - (sum_x * sum_x);
+    if (fabsf(denom) < 1.0e-6f) {
+        return DSD_WARM_START_DEGENERATE;
+    }
+    float gain = (((float)n * sum_xy) - (sum_x * sum_y)) / denom;
+    if (fabsf(gain) * 2.0f < DSD_WARM_START_MIN_SPAN) {
+        return DSD_WARM_START_DEGENERATE;
+    }
+    *out_center = (sum_y - (gain * sum_x)) / (float)n;
+    return DSD_WARM_START_OK;
+}
+
+static dsd_warm_start_result_t
+frame_sync_warm_start_p25_cqpsk_center_from_raw_sync(frame_sync_match_ctx* ctx, const char* raw_window, int sync_len) {
+    if (!dsd_sync_warm_start_enabled()) {
+        return DSD_WARM_START_DISABLED;
+    }
+    if (!ctx || !ctx->state || !raw_window) {
+        return DSD_WARM_START_NULL_STATE;
+    }
+    dsd_state* state = ctx->state;
+    if (sync_len <= 1 || strlen(raw_window) < (size_t)sync_len) {
+        return DSD_WARM_START_DEGENERATE;
+    }
+    if (state->dmr_sample_history == NULL || dsd_symbol_history_count(state) < sync_len) {
+        return DSD_WARM_START_NO_HISTORY;
+    }
+
+    float sum[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    int count[4] = {0, 0, 0, 0};
+    dsd_warm_start_result_t result = frame_sync_accumulate_p25_cqpsk_raw_sync(state, raw_window, sync_len, sum, count);
+    if (result != DSD_WARM_START_OK) {
+        return result;
+    }
+    float center = 0.0f;
+    result = frame_sync_fit_p25_cqpsk_raw_center(sum, count, &center);
+    if (result != DSD_WARM_START_OK) {
+        return result;
+    }
+    state->center = center;
+    return DSD_WARM_START_OK;
+}
+
+static int
+frame_sync_p25_cqpsk_map_requires_center_fit(uint8_t map_idx) {
+    map_idx = dsd_p25_cqpsk_dibit_map_index(map_idx);
+    return map_idx == DSD_P25_CQPSK_DIBIT_MAP_N1200 || map_idx == DSD_P25_CQPSK_DIBIT_MAP_P1200;
+}
+
 static int
 frame_sync_cqpsk_window_matches_map(const char* raw_window, const char* expected, uint8_t map_idx) {
     if (!raw_window || !expected) {
@@ -458,7 +553,8 @@ frame_sync_maybe_force_dmr_gfsk(const dsd_opts* opts, dsd_state* state) {
 }
 
 static void
-frame_sync_accept_p25p1(frame_sync_match_ctx* ctx, int synctype, const char* label, int force_center_warm_start) {
+frame_sync_accept_p25p1(frame_sync_match_ctx* ctx, int synctype, const char* label,
+                        frame_sync_p25_center_mode_t center_mode) {
     dsd_opts* opts = ctx->opts;
     dsd_state* state = ctx->state;
     frame_sync_set_basic_lock(ctx);
@@ -471,7 +567,8 @@ frame_sync_accept_p25p1(frame_sync_match_ctx* ctx, int synctype, const char* lab
     }
     state->lastsynctype = synctype;
     frame_sync_note_cc_sync(ctx);
-    if (force_center_warm_start || state->rf_mod == 1) {
+    if (center_mode != FRAME_SYNC_P25_CENTER_SKIP
+        && (center_mode == FRAME_SYNC_P25_CENTER_FORCE || state->rf_mod == 1)) {
         dsd_sync_warm_start_center_outer_only(opts, state, 24);
     } else if (state->rf_mod == 0) {
         dsd_sync_warm_start_thresholds_outer_only(opts, state, 24);
@@ -491,7 +588,7 @@ frame_sync_report_p25p2_params(dsd_opts* opts, dsd_state* state) {
 
 static void
 frame_sync_accept_p25p2(frame_sync_match_ctx* ctx, int synctype, int inverted, const char* label,
-                        int set_last_before_info, int force_center_warm_start) {
+                        int set_last_before_info, frame_sync_p25_center_mode_t center_mode) {
     dsd_opts* opts = ctx->opts;
     dsd_state* state = ctx->state;
     frame_sync_set_basic_lock(ctx);
@@ -507,7 +604,8 @@ frame_sync_accept_p25p2(frame_sync_match_ctx* ctx, int synctype, int inverted, c
         state->lastsynctype = synctype;
     }
     p25p2_note_sync_activity(opts, state);
-    if (force_center_warm_start || state->rf_mod == 1) {
+    if (center_mode != FRAME_SYNC_P25_CENTER_SKIP
+        && (center_mode == FRAME_SYNC_P25_CENTER_FORCE || state->rf_mod == 1)) {
         dsd_sync_warm_start_center_outer_only(opts, state, 20);
     }
 }
@@ -520,13 +618,13 @@ frame_sync_try_p25p1(frame_sync_match_ctx* ctx) {
 
     if (strcmp(ctx->synctest, P25P1_SYNC) == 0) {
         frame_sync_set_p25_cqpsk_dibit_map(ctx, DSD_P25_CQPSK_DIBIT_MAP_IDENTITY);
-        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_POS, "+P25p1", 0);
+        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_POS, "+P25p1", FRAME_SYNC_P25_CENTER_AUTO);
         return DSD_SYNC_P25P1_POS;
     }
 
     if (strcmp(ctx->synctest, INV_P25P1_SYNC) == 0) {
         frame_sync_set_p25_cqpsk_dibit_map(ctx, DSD_P25_CQPSK_DIBIT_MAP_IDENTITY);
-        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_NEG, "-P25p1 ", 0);
+        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_NEG, "-P25p1 ", FRAME_SYNC_P25_CENTER_AUTO);
         return DSD_SYNC_P25P1_NEG;
     }
 
@@ -536,15 +634,25 @@ frame_sync_try_p25p1(frame_sync_match_ctx* ctx) {
     uint8_t map_idx = DSD_P25_CQPSK_DIBIT_MAP_IDENTITY;
     if (frame_sync_cqpsk_4level_enabled(opts, state)
         && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest, P25P1_SYNC, &map_idx)) {
+        dsd_warm_start_result_t center_result =
+            frame_sync_warm_start_p25_cqpsk_center_from_raw_sync(ctx, ctx->synctest, 24);
+        if (frame_sync_p25_cqpsk_map_requires_center_fit(map_idx) && center_result != DSD_WARM_START_OK) {
+            return DSD_SYNC_NONE;
+        }
         frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
-        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_POS, "+P25p1", 1);
+        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_POS, "+P25p1", FRAME_SYNC_P25_CENTER_SKIP);
         return DSD_SYNC_P25P1_POS;
     }
 
     if (frame_sync_cqpsk_4level_enabled(opts, state)
         && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest, INV_P25P1_SYNC, &map_idx)) {
+        dsd_warm_start_result_t center_result =
+            frame_sync_warm_start_p25_cqpsk_center_from_raw_sync(ctx, ctx->synctest, 24);
+        if (frame_sync_p25_cqpsk_map_requires_center_fit(map_idx) && center_result != DSD_WARM_START_OK) {
+            return DSD_SYNC_NONE;
+        }
         frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
-        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_NEG, "-P25p1 ", 1);
+        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_NEG, "-P25p1 ", FRAME_SYNC_P25_CENTER_SKIP);
         return DSD_SYNC_P25P1_NEG;
     }
 #endif
@@ -646,13 +754,13 @@ frame_sync_try_p25p2(frame_sync_match_ctx* ctx) {
 
     if (strcmp(ctx->synctest20, P25P2_SYNC) == 0) {
         frame_sync_set_p25_cqpsk_dibit_map(ctx, DSD_P25_CQPSK_DIBIT_MAP_IDENTITY);
-        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_POS, 0, "+P25p2", 1, 0);
+        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_POS, 0, "+P25p2", 1, FRAME_SYNC_P25_CENTER_AUTO);
         return DSD_SYNC_P25P2_POS;
     }
 
     if (strcmp(ctx->synctest20, INV_P25P2_SYNC) == 0) {
         frame_sync_set_p25_cqpsk_dibit_map(ctx, DSD_P25_CQPSK_DIBIT_MAP_IDENTITY);
-        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_NEG, 1, "-P25p2", 0, 0);
+        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_NEG, 1, "-P25p2", 0, FRAME_SYNC_P25_CENTER_AUTO);
         return DSD_SYNC_P25P2_NEG;
     }
 
@@ -662,15 +770,25 @@ frame_sync_try_p25p2(frame_sync_match_ctx* ctx) {
     uint8_t map_idx = DSD_P25_CQPSK_DIBIT_MAP_IDENTITY;
     if (frame_sync_cqpsk_4level_enabled(opts, state)
         && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest20, P25P2_SYNC, &map_idx)) {
+        dsd_warm_start_result_t center_result =
+            frame_sync_warm_start_p25_cqpsk_center_from_raw_sync(ctx, ctx->synctest20, 20);
+        if (frame_sync_p25_cqpsk_map_requires_center_fit(map_idx) && center_result != DSD_WARM_START_OK) {
+            return DSD_SYNC_NONE;
+        }
         frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
-        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_POS, 0, "+P25p2", 1, 1);
+        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_POS, 0, "+P25p2", 1, FRAME_SYNC_P25_CENTER_SKIP);
         return DSD_SYNC_P25P2_POS;
     }
 
     if (frame_sync_cqpsk_4level_enabled(opts, state)
         && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest20, INV_P25P2_SYNC, &map_idx)) {
+        dsd_warm_start_result_t center_result =
+            frame_sync_warm_start_p25_cqpsk_center_from_raw_sync(ctx, ctx->synctest20, 20);
+        if (frame_sync_p25_cqpsk_map_requires_center_fit(map_idx) && center_result != DSD_WARM_START_OK) {
+            return DSD_SYNC_NONE;
+        }
         frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
-        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_NEG, 1, "-P25p2", 0, 1);
+        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_NEG, 1, "-P25p2", 0, FRAME_SYNC_P25_CENTER_SKIP);
         return DSD_SYNC_P25P2_NEG;
     }
 #endif

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -410,6 +410,7 @@ frame_sync_set_p25_cqpsk_dibit_map(frame_sync_match_ctx* ctx, uint8_t map_idx) {
     ctx->state->p25_cqpsk_dibit_map_idx = dsd_p25_cqpsk_dibit_map_index(map_idx);
 }
 
+#ifdef USE_RADIO
 static int
 frame_sync_cqpsk_window_matches_map(const char* raw_window, const char* expected, uint8_t map_idx) {
     if (!raw_window || !expected) {
@@ -447,6 +448,7 @@ frame_sync_find_rotated_p25_cqpsk_map(const char* raw_window, const char* expect
     }
     return 0;
 }
+#endif
 
 static inline void
 frame_sync_maybe_force_dmr_gfsk(const dsd_opts* opts, dsd_state* state) {

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -26,6 +26,7 @@
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/frame.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/p25_cqpsk_dibit.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/string_utils.h>
 #include <dsd-neo/core/sync_patterns.h>
@@ -384,6 +385,8 @@ typedef struct {
     char* synctest48;
 } frame_sync_match_ctx;
 
+static int frame_sync_cqpsk_4level_enabled(const dsd_opts* opts, const dsd_state* state);
+
 static inline void
 frame_sync_set_basic_lock(frame_sync_match_ctx* ctx) {
     dsd_state* state = ctx->state;
@@ -399,6 +402,52 @@ frame_sync_note_cc_sync(frame_sync_match_ctx* ctx) {
     ctx->state->last_cc_sync_time_m = ctx->nowm;
 }
 
+static void
+frame_sync_set_p25_cqpsk_dibit_map(frame_sync_match_ctx* ctx, uint8_t map_idx) {
+    if (!ctx || !ctx->state) {
+        return;
+    }
+    ctx->state->p25_cqpsk_dibit_map_idx = dsd_p25_cqpsk_dibit_map_index(map_idx);
+}
+
+static int
+frame_sync_cqpsk_window_matches_map(const char* raw_window, const char* expected, uint8_t map_idx) {
+    if (!raw_window || !expected) {
+        return 0;
+    }
+
+    size_t expected_len = strlen(expected);
+    for (size_t i = 0; i < expected_len; i++) {
+        if (raw_window[i] < '0' || raw_window[i] > '3') {
+            return 0;
+        }
+        uint8_t raw_dibit = (uint8_t)(raw_window[i] - '0');
+        uint8_t corrected = dsd_p25_cqpsk_correct_dibit(map_idx, raw_dibit);
+        if ((char)('0' + corrected) != expected[i]) {
+            return 0;
+        }
+    }
+    return raw_window[expected_len] == '\0';
+}
+
+static int
+frame_sync_find_rotated_p25_cqpsk_map(const char* raw_window, const char* expected, uint8_t* out_map_idx) {
+    static const uint8_t rotation_maps[] = {
+        DSD_P25_CQPSK_DIBIT_MAP_X2400,
+        DSD_P25_CQPSK_DIBIT_MAP_N1200,
+        DSD_P25_CQPSK_DIBIT_MAP_P1200,
+    };
+    for (size_t i = 0; i < sizeof(rotation_maps) / sizeof(rotation_maps[0]); i++) {
+        if (frame_sync_cqpsk_window_matches_map(raw_window, expected, rotation_maps[i])) {
+            if (out_map_idx) {
+                *out_map_idx = rotation_maps[i];
+            }
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static inline void
 frame_sync_maybe_force_dmr_gfsk(const dsd_opts* opts, dsd_state* state) {
     if (!opts->mod_cli_lock || opts->mod_gfsk) {
@@ -406,51 +455,97 @@ frame_sync_maybe_force_dmr_gfsk(const dsd_opts* opts, dsd_state* state) {
     }
 }
 
-static int
-frame_sync_try_p25p1(frame_sync_match_ctx* ctx) {
+static void
+frame_sync_accept_p25p1(frame_sync_match_ctx* ctx, int synctype, const char* label, int force_center_warm_start) {
     dsd_opts* opts = ctx->opts;
     dsd_state* state = ctx->state;
-    if (opts->frame_p25p1 != 1) {
+    frame_sync_set_basic_lock(ctx);
+    state->dmrburstR = 17;
+    state->payload_algidR = 0;
+    state->dmr_stereo = 1;
+    DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "P25 Phase 1");
+    if (opts->errorbars == 1) {
+        printFrameSync(opts, state, label, ctx->synctest_pos + 1, ctx->modulation);
+    }
+    state->lastsynctype = synctype;
+    frame_sync_note_cc_sync(ctx);
+    if (force_center_warm_start || state->rf_mod == 1) {
+        dsd_sync_warm_start_center_outer_only(opts, state, 24);
+    } else if (state->rf_mod == 0) {
+        dsd_sync_warm_start_thresholds_outer_only(opts, state, 24);
+    }
+}
+
+static void
+frame_sync_report_p25p2_params(dsd_opts* opts, dsd_state* state) {
+    if (state->p2_wacn != 0 && state->p2_cc != 0 && state->p2_sysid != 0) {
+        printFrameInfo(opts, state);
+    } else {
+        DSD_FPRINTF(stderr, "%s", KRED);
+        DSD_FPRINTF(stderr, " P2 Missing Parameters            ");
+        DSD_FPRINTF(stderr, "%s", KNRM);
+    }
+}
+
+static void
+frame_sync_accept_p25p2(frame_sync_match_ctx* ctx, int synctype, int inverted, const char* label,
+                        int set_last_before_info, int force_center_warm_start) {
+    dsd_opts* opts = ctx->opts;
+    dsd_state* state = ctx->state;
+    frame_sync_set_basic_lock(ctx);
+    opts->inverted_p2 = inverted;
+    if (set_last_before_info) {
+        state->lastsynctype = synctype;
+    }
+    if (opts->errorbars == 1) {
+        printFrameSync(opts, state, label, ctx->synctest_pos + 1, ctx->modulation);
+    }
+    frame_sync_report_p25p2_params(opts, state);
+    if (!set_last_before_info) {
+        state->lastsynctype = synctype;
+    }
+    p25p2_note_sync_activity(opts, state);
+    if (force_center_warm_start || state->rf_mod == 1) {
+        dsd_sync_warm_start_center_outer_only(opts, state, 20);
+    }
+}
+
+static int
+frame_sync_try_p25p1(frame_sync_match_ctx* ctx) {
+    if (ctx->opts->frame_p25p1 != 1) {
         return DSD_SYNC_NONE;
     }
 
     if (strcmp(ctx->synctest, P25P1_SYNC) == 0) {
-        frame_sync_set_basic_lock(ctx);
-        state->dmrburstR = 17;
-        state->payload_algidR = 0;
-        state->dmr_stereo = 1;
-        DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "P25 Phase 1");
-        if (opts->errorbars == 1) {
-            printFrameSync(opts, state, "+P25p1", ctx->synctest_pos + 1, ctx->modulation);
-        }
-        state->lastsynctype = DSD_SYNC_P25P1_POS;
-        frame_sync_note_cc_sync(ctx);
-        if (state->rf_mod == 0) {
-            dsd_sync_warm_start_thresholds_outer_only(opts, state, 24);
-        } else if (state->rf_mod == 1) {
-            dsd_sync_warm_start_center_outer_only(opts, state, 24);
-        }
+        frame_sync_set_p25_cqpsk_dibit_map(ctx, DSD_P25_CQPSK_DIBIT_MAP_IDENTITY);
+        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_POS, "+P25p1", 0);
         return DSD_SYNC_P25P1_POS;
     }
 
     if (strcmp(ctx->synctest, INV_P25P1_SYNC) == 0) {
-        frame_sync_set_basic_lock(ctx);
-        state->dmrburstR = 17;
-        state->payload_algidR = 0;
-        state->dmr_stereo = 1;
-        DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "P25 Phase 1");
-        if (opts->errorbars == 1) {
-            printFrameSync(opts, state, "-P25p1 ", ctx->synctest_pos + 1, ctx->modulation);
-        }
-        state->lastsynctype = DSD_SYNC_P25P1_NEG;
-        frame_sync_note_cc_sync(ctx);
-        if (state->rf_mod == 0) {
-            dsd_sync_warm_start_thresholds_outer_only(opts, state, 24);
-        } else if (state->rf_mod == 1) {
-            dsd_sync_warm_start_center_outer_only(opts, state, 24);
-        }
+        frame_sync_set_p25_cqpsk_dibit_map(ctx, DSD_P25_CQPSK_DIBIT_MAP_IDENTITY);
+        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_NEG, "-P25p1 ", 0);
         return DSD_SYNC_P25P1_NEG;
     }
+
+#ifdef USE_RADIO
+    const dsd_opts* opts = ctx->opts;
+    const dsd_state* state = ctx->state;
+    uint8_t map_idx = DSD_P25_CQPSK_DIBIT_MAP_IDENTITY;
+    if (frame_sync_cqpsk_4level_enabled(opts, state)
+        && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest, P25P1_SYNC, &map_idx)) {
+        frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
+        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_POS, "+P25p1", 1);
+        return DSD_SYNC_P25P1_POS;
+    }
+
+    if (frame_sync_cqpsk_4level_enabled(opts, state)
+        && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest, INV_P25P1_SYNC, &map_idx)) {
+        frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
+        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_NEG, "-P25p1 ", 1);
+        return DSD_SYNC_P25P1_NEG;
+    }
+#endif
 
     return DSD_SYNC_NONE;
 }
@@ -542,54 +637,41 @@ frame_sync_try_ysf(frame_sync_match_ctx* ctx) {
 
 static int
 frame_sync_try_p25p2(frame_sync_match_ctx* ctx) {
-    dsd_opts* opts = ctx->opts;
-    dsd_state* state = ctx->state;
     dsd_strncpy_s(ctx->synctest20, 21, (ctx->synctest_p - 19), 20);
-    if (opts->frame_p25p2 != 1) {
+    if (ctx->opts->frame_p25p2 != 1) {
         return DSD_SYNC_NONE;
     }
 
     if (strcmp(ctx->synctest20, P25P2_SYNC) == 0) {
-        frame_sync_set_basic_lock(ctx);
-        opts->inverted_p2 = 0;
-        state->lastsynctype = DSD_SYNC_P25P2_POS;
-        if (opts->errorbars == 1) {
-            printFrameSync(opts, state, "+P25p2", ctx->synctest_pos + 1, ctx->modulation);
-        }
-        if (state->p2_wacn != 0 && state->p2_cc != 0 && state->p2_sysid != 0) {
-            printFrameInfo(opts, state);
-        } else {
-            DSD_FPRINTF(stderr, "%s", KRED);
-            DSD_FPRINTF(stderr, " P2 Missing Parameters            ");
-            DSD_FPRINTF(stderr, "%s", KNRM);
-        }
-        p25p2_note_sync_activity(opts, state);
-        if (state->rf_mod == 1) {
-            dsd_sync_warm_start_center_outer_only(opts, state, 20);
-        }
+        frame_sync_set_p25_cqpsk_dibit_map(ctx, DSD_P25_CQPSK_DIBIT_MAP_IDENTITY);
+        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_POS, 0, "+P25p2", 1, 0);
         return DSD_SYNC_P25P2_POS;
     }
 
     if (strcmp(ctx->synctest20, INV_P25P2_SYNC) == 0) {
-        frame_sync_set_basic_lock(ctx);
-        opts->inverted_p2 = 1;
-        if (opts->errorbars == 1) {
-            printFrameSync(opts, state, "-P25p2", ctx->synctest_pos + 1, ctx->modulation);
-        }
-        if (state->p2_wacn != 0 && state->p2_cc != 0 && state->p2_sysid != 0) {
-            printFrameInfo(opts, state);
-        } else {
-            DSD_FPRINTF(stderr, "%s", KRED);
-            DSD_FPRINTF(stderr, " P2 Missing Parameters            ");
-            DSD_FPRINTF(stderr, "%s", KNRM);
-        }
-        state->lastsynctype = DSD_SYNC_P25P2_NEG;
-        p25p2_note_sync_activity(opts, state);
-        if (state->rf_mod == 1) {
-            dsd_sync_warm_start_center_outer_only(opts, state, 20);
-        }
+        frame_sync_set_p25_cqpsk_dibit_map(ctx, DSD_P25_CQPSK_DIBIT_MAP_IDENTITY);
+        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_NEG, 1, "-P25p2", 0, 0);
         return DSD_SYNC_P25P2_NEG;
     }
+
+#ifdef USE_RADIO
+    const dsd_opts* opts = ctx->opts;
+    const dsd_state* state = ctx->state;
+    uint8_t map_idx = DSD_P25_CQPSK_DIBIT_MAP_IDENTITY;
+    if (frame_sync_cqpsk_4level_enabled(opts, state)
+        && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest20, P25P2_SYNC, &map_idx)) {
+        frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
+        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_POS, 0, "+P25p2", 1, 1);
+        return DSD_SYNC_P25P2_POS;
+    }
+
+    if (frame_sync_cqpsk_4level_enabled(opts, state)
+        && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest20, INV_P25P2_SYNC, &map_idx)) {
+        frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
+        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_NEG, 1, "-P25p2", 0, 1);
+        return DSD_SYNC_P25P2_NEG;
+    }
+#endif
 
     return DSD_SYNC_NONE;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3940,6 +3940,7 @@ if(DSD_HAS_RADIO)
     add_executable(
         dsd-neo_test_frame_sync_p25p2_rtl
         dsp/test_frame_sync_p25p2_rtl.c
+        ${PROJECT_SOURCE_DIR}/src/core/frames/dsd_dibit.c
     )
     target_include_directories(
         dsd-neo_test_frame_sync_p25p2_rtl

--- a/tests/core/test_core_init_state.c
+++ b/tests/core/test_core_init_state.c
@@ -5,6 +5,7 @@
 
 #include <dsd-neo/core/init.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/p25_cqpsk_dibit.h>
 #include <dsd-neo/core/state.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -76,6 +77,7 @@ main(void) {
     state->rtl_fsk_sps_num = 24000;
     state->rtl_fsk_sps_den = 9600;
     state->rtl_fsk_sps_accum = 4800;
+    state->p25_cqpsk_dibit_map_idx = DSD_P25_CQPSK_DIBIT_MAP_N1200;
     state->ess_b[0][95] = 1;
     state->ess_b_llr[1][95] = 123;
     state->fourv_counter[0] = 2;
@@ -257,8 +259,8 @@ main(void) {
         || state->rtl_symbol_cache_channel_profile != 0 || state->rtl_symbol_cache_symbol_rate_hz != 0
         || state->rtl_symbol_cache_levels != 0 || state->rtl_symbol_cache_generation != 0U
         || state->rtl_symbol_cache_published_pending != 0 || state->rtl_fsk_sps_num != 0 || state->rtl_fsk_sps_den != 0
-        || state->rtl_fsk_sps_accum != 0 || state->rtl_symbol_cache[0] != 0.0f
-        || state->rtl_symbol_cache[DSD_RTL_SYMBOL_CACHE_CAP - 1] != 0.0f) {
+        || state->rtl_fsk_sps_accum != 0 || state->p25_cqpsk_dibit_map_idx != DSD_P25_CQPSK_DIBIT_MAP_IDENTITY
+        || state->rtl_symbol_cache[0] != 0.0f || state->rtl_symbol_cache[DSD_RTL_SYMBOL_CACHE_CAP - 1] != 0.0f) {
         DSD_FPRINTF(stderr, "initState did not clear RTL symbol cache state\n");
         freeState(state);
         free(state);

--- a/tests/dsp/test_frame_sync_p25p2_rtl.c
+++ b/tests/dsp/test_frame_sync_p25p2_rtl.c
@@ -90,21 +90,6 @@ watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) { /
     (void)slot;
 }
 
-void
-write_symbol_capture_record(dsd_opts* opts, dsd_state* state, int dibit, float symbol) {
-    (void)opts;
-    (void)state;
-    (void)dibit;
-    (void)symbol;
-}
-
-uint8_t
-dmr_compute_reliability(const dsd_state* st, float sym) {
-    (void)st;
-    (void)sym;
-    return 255;
-}
-
 double
 raw_pwr_f(const float* samples, int len, int step) { // NOLINT(misc-use-internal-linkage)
     (void)samples;
@@ -225,6 +210,11 @@ build_raw_pattern_for_map(const char* corrected_pattern, uint8_t map_idx, char* 
     }
     out[len] = '\0';
     return 1;
+}
+
+static int
+llr_matches_bit(int16_t llr, int bit) {
+    return bit ? (llr > 0) : (llr < 0);
 }
 
 static uint32_t
@@ -350,6 +340,54 @@ run_p25p1_sync_case(const char* pattern, int expected_sync, uint8_t expected_map
     return run_p25_sync_case(pattern, 1, 0, expected_sync, expected_map, label);
 }
 
+static int
+test_negative_cqpsk_dibit_polarity(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "failed to allocate CQPSK dibit state buffers\n");
+        return 1;
+    }
+
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_p25p2 = 1;
+    state.rf_mod = 1;
+    state.synctype = DSD_SYNC_P25P2_NEG;
+    state.center = 0.0f;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.p25_cqpsk_dibit_map_idx = DSD_P25_CQPSK_DIBIT_MAP_X2400;
+
+    dsd_rtl_stream_metrics_hooks metrics_hooks = {
+        .output_kind = fake_output_kind,
+        .symbol_profile = fake_symbol_profile,
+        .stream_generation = fake_stream_generation,
+        .cqpsk_status = fake_cqpsk_status,
+        .stream_active = fake_stream_active,
+    };
+    dsd_rtl_stream_metrics_hooks_set(&metrics_hooks);
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+
+    int got = digitize(&opts, &state, 1.0f);
+    const dsd_dibit_soft_t soft = state.dmr_soft_p[-1];
+    int rc = 0;
+    if (got != 1) {
+        DSD_FPRINTF(stderr, "negative CQPSK rotated dibit returned %d, expected 1\n", got);
+        rc = 1;
+    }
+    if (!llr_matches_bit(soft.llr[0], 0) || !llr_matches_bit(soft.llr[1], 1)) {
+        DSD_FPRINTF(stderr, "negative CQPSK rotated soft signs mismatch (%d,%d)\n", soft.llr[0], soft.llr[1]);
+        rc = 1;
+    }
+
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+    free_state_buffers(&state);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -365,6 +403,12 @@ main(void) {
     }
     rc |=
         run_p25p2_sync_case(rotated, DSD_SYNC_P25P2_POS, DSD_P25_CQPSK_DIBIT_MAP_X2400, "P25P2 RTL X2400 rotated sync");
+
+    if (!build_raw_pattern_for_map(INV_P25P2_SYNC, DSD_P25_CQPSK_DIBIT_MAP_X2400, rotated, sizeof(rotated))) {
+        return 1;
+    }
+    rc |= run_p25p2_sync_case(rotated, DSD_SYNC_P25P2_NEG, DSD_P25_CQPSK_DIBIT_MAP_X2400,
+                              "P25P2 RTL X2400 rotated inverted sync");
 
     if (!build_raw_pattern_for_map(P25P2_SYNC, DSD_P25_CQPSK_DIBIT_MAP_N1200, rotated, sizeof(rotated))) {
         return 1;
@@ -383,6 +427,7 @@ main(void) {
     }
     rc |=
         run_p25p1_sync_case(rotated, DSD_SYNC_P25P1_POS, DSD_P25_CQPSK_DIBIT_MAP_X2400, "P25P1 RTL X2400 rotated sync");
+    rc |= test_negative_cqpsk_dibit_polarity();
     return rc;
 }
 

--- a/tests/dsp/test_frame_sync_p25p2_rtl.c
+++ b/tests/dsp/test_frame_sync_p25p2_rtl.c
@@ -219,6 +219,77 @@ llr_matches_bit(int16_t llr, int bit) {
     return bit ? (llr > 0) : (llr < 0);
 }
 
+static void
+test_symbol_window_extrema_avg2(const float* samples, int count, float* out_min, float* out_max) {
+    if (!samples || !out_min || !out_max || count < 2) {
+        if (out_min) {
+            *out_min = 0.0f;
+        }
+        if (out_max) {
+            *out_max = 0.0f;
+        }
+        return;
+    }
+
+    float min1 = samples[0];
+    float min2 = samples[1];
+    if (min2 < min1) {
+        float tmp = min1;
+        min1 = min2;
+        min2 = tmp;
+    }
+
+    float max1 = samples[0];
+    float max2 = samples[1];
+    if (max2 > max1) {
+        float tmp = max1;
+        max1 = max2;
+        max2 = tmp;
+    }
+
+    for (int i = 2; i < count; i++) {
+        float v = samples[i];
+        if (v < min1) {
+            min2 = min1;
+            min1 = v;
+        } else if (v < min2) {
+            min2 = v;
+        }
+
+        if (v > max1) {
+            max2 = max1;
+            max1 = v;
+        } else if (v > max2) {
+            max2 = v;
+        }
+    }
+
+    *out_min = (min1 + min2) * 0.5f;
+    *out_max = (max1 + max2) * 0.5f;
+}
+
+static void
+simulate_payload_threshold_update(const dsd_opts* opts, dsd_state* state, float payload_symbol) {
+    int cap = opts->ssize;
+    if (cap < 0) {
+        cap = 0;
+    }
+    if (cap > (int)(sizeof(state->sbuf) / sizeof(state->sbuf[0]))) {
+        cap = (int)(sizeof(state->sbuf) / sizeof(state->sbuf[0]));
+    }
+    if (cap > 0) {
+        state->sbuf[state->sidx] = payload_symbol;
+    }
+
+    float lmin = 0.0f;
+    float lmax = 0.0f;
+    test_symbol_window_extrema_avg2(state->sbuf, cap, &lmin, &lmax);
+    dsd_state_push_minmax_window(state, opts->msize, lmin, lmax);
+    state->center = (state->max + state->min) / 2.0f;
+    state->umid = (((state->max) - state->center) * 5.0f / 8.0f) + state->center;
+    state->lmid = (((state->min) - state->center) * 5.0f / 8.0f) + state->center;
+}
+
 static uint32_t
 fake_stream_generation(void) {
     return 1U;
@@ -296,6 +367,7 @@ run_p25_sync_case(const char* pattern, int frame_p25p1, int frame_p25p2, int exp
     opts.mod_qpsk = 1;
     opts.p25_trunk = 1;
     opts.msize = 1;
+    opts.ssize = 36;
 
     state.rf_mod = 1;
     state.p25_p2_active_slot = 1;
@@ -331,6 +403,16 @@ run_p25_sync_case(const char* pattern, int frame_p25p1, int frame_p25p2, int exp
     }
     if (fabsf(state.center - expected_center) > 0.001f) {
         DSD_FPRINTF(stderr, "%s center %.3f, expected %.3f\n", label, state.center, expected_center);
+        rc = 1;
+    }
+    float scanner_center = (state.max + state.min) / 2.0f;
+    if (fabsf(scanner_center - expected_center) > 0.001f) {
+        DSD_FPRINTF(stderr, "%s scanner center %.3f, expected %.3f\n", label, scanner_center, expected_center);
+        rc = 1;
+    }
+    simulate_payload_threshold_update(&opts, &state, symbol_level_for_dibit('1'));
+    if (fabsf(state.center - expected_center) > 0.001f) {
+        DSD_FPRINTF(stderr, "%s payload update center %.3f, expected %.3f\n", label, state.center, expected_center);
         rc = 1;
     }
 

--- a/tests/dsp/test_frame_sync_p25p2_rtl.c
+++ b/tests/dsp/test_frame_sync_p25p2_rtl.c
@@ -9,10 +9,12 @@
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/dsp/sync_calibration.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/sockets.h>
 #include <dsd-neo/runtime/rtl_stream_io_hooks.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -244,6 +246,7 @@ free_state_buffers(dsd_state* state) {
     free(state->dmr_payload_buf);
     free(state->dmr_reliab_buf);
     free(state->dmr_soft_buf);
+    dsd_symbol_history_free(state);
 }
 
 static int
@@ -260,12 +263,16 @@ init_state_buffers(dsd_state* state) {
     state->dmr_payload_p = state->dmr_payload_buf + 200;
     state->dmr_reliab_p = state->dmr_reliab_buf + 200;
     state->dmr_soft_p = state->dmr_soft_buf + 200;
+    if (dsd_symbol_history_init(state, DSD_SYMBOL_HISTORY_SIZE) != 0) {
+        free_state_buffers(state);
+        return 0;
+    }
     return 1;
 }
 
 static int
 run_p25_sync_case(const char* pattern, int frame_p25p1, int frame_p25p2, int expected_sync, uint8_t expected_map,
-                  const char* label) {
+                  float expected_center, const char* label) {
     static dsd_opts opts;
     static dsd_state state;
     static int fake_rtl_context;
@@ -322,6 +329,10 @@ run_p25_sync_case(const char* pattern, int frame_p25p1, int frame_p25p2, int exp
                     dsd_p25_cqpsk_dibit_map_index(expected_map));
         rc = 1;
     }
+    if (fabsf(state.center - expected_center) > 0.001f) {
+        DSD_FPRINTF(stderr, "%s center %.3f, expected %.3f\n", label, state.center, expected_center);
+        rc = 1;
+    }
 
     dsd_rtl_stream_io_hooks_set((dsd_rtl_stream_io_hooks){0});
     dsd_rtl_stream_metrics_hooks_set(NULL);
@@ -332,12 +343,12 @@ run_p25_sync_case(const char* pattern, int frame_p25p1, int frame_p25p2, int exp
 
 static int
 run_p25p2_sync_case(const char* pattern, int expected_sync, uint8_t expected_map, const char* label) {
-    return run_p25_sync_case(pattern, 0, 1, expected_sync, expected_map, label);
+    return run_p25_sync_case(pattern, 0, 1, expected_sync, expected_map, 0.0f, label);
 }
 
 static int
 run_p25p1_sync_case(const char* pattern, int expected_sync, uint8_t expected_map, const char* label) {
-    return run_p25_sync_case(pattern, 1, 0, expected_sync, expected_map, label);
+    return run_p25_sync_case(pattern, 1, 0, expected_sync, expected_map, 0.0f, label);
 }
 
 static int
@@ -388,6 +399,49 @@ test_negative_cqpsk_dibit_polarity(void) {
     return rc;
 }
 
+static int
+test_cqpsk_map_is_p25_scoped(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "failed to allocate non-P25 CQPSK state buffers\n");
+        return 1;
+    }
+
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    state.rf_mod = 1;
+    state.synctype = DSD_SYNC_X2TDMA_DATA_POS;
+    state.lastsynctype = DSD_SYNC_X2TDMA_DATA_POS;
+    state.center = 0.0f;
+    state.p25_cqpsk_dibit_map_idx = DSD_P25_CQPSK_DIBIT_MAP_X2400;
+
+    dsd_rtl_stream_metrics_hooks metrics_hooks = {
+        .output_kind = fake_output_kind,
+        .symbol_profile = fake_symbol_profile,
+        .stream_generation = fake_stream_generation,
+        .cqpsk_status = fake_cqpsk_status,
+        .stream_active = fake_stream_active,
+    };
+    dsd_rtl_stream_metrics_hooks_set(&metrics_hooks);
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+
+    int got = digitize(&opts, &state, 3.0f);
+    int rc = 0;
+    if (got != 1) {
+        DSD_FPRINTF(stderr, "non-P25 CQPSK dibit returned %d, expected raw threshold dibit 1\n", got);
+        rc = 1;
+    }
+
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+    free_state_buffers(&state);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -428,6 +482,7 @@ main(void) {
     rc |=
         run_p25p1_sync_case(rotated, DSD_SYNC_P25P1_POS, DSD_P25_CQPSK_DIBIT_MAP_X2400, "P25P1 RTL X2400 rotated sync");
     rc |= test_negative_cqpsk_dibit_polarity();
+    rc |= test_cqpsk_map_is_p25_scoped();
     return rc;
 }
 

--- a/tests/dsp/test_frame_sync_p25p2_rtl.c
+++ b/tests/dsp/test_frame_sync_p25p2_rtl.c
@@ -4,6 +4,7 @@
  */
 
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/p25_cqpsk_dibit.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
@@ -28,6 +29,7 @@
 
 static size_t g_symbol_index;
 static const char* g_sync_pattern = P25P2_SYNC;
+static int g_symbol_rate_hz = 6000;
 
 dsd_socket_t
 Connect(char* hostname, int portno) { // NOLINT(misc-use-internal-linkage)
@@ -197,7 +199,7 @@ fake_output_kind(void) {
 static int
 fake_symbol_profile(int* out_symbol_rate_hz, int* out_levels, int* out_channel_profile) {
     if (out_symbol_rate_hz) {
-        *out_symbol_rate_hz = 6000;
+        *out_symbol_rate_hz = g_symbol_rate_hz;
     }
     if (out_levels) {
         *out_levels = 4;
@@ -206,6 +208,23 @@ fake_symbol_profile(int* out_symbol_rate_hz, int* out_levels, int* out_channel_p
         *out_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
     }
     return 0;
+}
+
+static int
+build_raw_pattern_for_map(const char* corrected_pattern, uint8_t map_idx, char* out, size_t out_cap) {
+    size_t len = strlen(corrected_pattern);
+    if (!out || out_cap <= len) {
+        return 0;
+    }
+    for (size_t i = 0; i < len; i++) {
+        if (corrected_pattern[i] < '0' || corrected_pattern[i] > '3') {
+            return 0;
+        }
+        uint8_t corrected = (uint8_t)(corrected_pattern[i] - '0');
+        out[i] = (char)('0' + dsd_p25_cqpsk_raw_dibit_for_corrected(map_idx, corrected));
+    }
+    out[len] = '\0';
+    return 1;
 }
 
 static uint32_t
@@ -255,13 +274,15 @@ init_state_buffers(dsd_state* state) {
 }
 
 static int
-run_p25p2_sync_case(const char* pattern, int expected_sync, const char* label) {
+run_p25_sync_case(const char* pattern, int frame_p25p1, int frame_p25p2, int expected_sync, uint8_t expected_map,
+                  const char* label) {
     static dsd_opts opts;
     static dsd_state state;
     static int fake_rtl_context;
 
     g_symbol_index = 0U;
     g_sync_pattern = pattern;
+    g_symbol_rate_hz = frame_p25p2 ? 6000 : 4800;
     dsd_frame_sync_reset_mod_state();
 
     DSD_MEMSET(&opts, 0, sizeof(opts));
@@ -272,7 +293,8 @@ run_p25p2_sync_case(const char* pattern, int expected_sync, const char* label) {
     }
 
     opts.audio_in_type = AUDIO_IN_RTL;
-    opts.frame_p25p2 = 1;
+    opts.frame_p25p1 = frame_p25p1;
+    opts.frame_p25p2 = frame_p25p2;
     opts.mod_cli_lock = 1;
     opts.mod_qpsk = 1;
     opts.p25_trunk = 1;
@@ -305,6 +327,11 @@ run_p25p2_sync_case(const char* pattern, int expected_sync, const char* label) {
         DSD_FPRINTF(stderr, "%s returned %d, expected %d\n", label, sync, expected_sync);
         rc = 1;
     }
+    if (state.p25_cqpsk_dibit_map_idx != dsd_p25_cqpsk_dibit_map_index(expected_map)) {
+        DSD_FPRINTF(stderr, "%s selected map %u, expected %u\n", label, state.p25_cqpsk_dibit_map_idx,
+                    dsd_p25_cqpsk_dibit_map_index(expected_map));
+        rc = 1;
+    }
 
     dsd_rtl_stream_io_hooks_set((dsd_rtl_stream_io_hooks){0});
     dsd_rtl_stream_metrics_hooks_set(NULL);
@@ -313,11 +340,49 @@ run_p25p2_sync_case(const char* pattern, int expected_sync, const char* label) {
     return rc;
 }
 
+static int
+run_p25p2_sync_case(const char* pattern, int expected_sync, uint8_t expected_map, const char* label) {
+    return run_p25_sync_case(pattern, 0, 1, expected_sync, expected_map, label);
+}
+
+static int
+run_p25p1_sync_case(const char* pattern, int expected_sync, uint8_t expected_map, const char* label) {
+    return run_p25_sync_case(pattern, 1, 0, expected_sync, expected_map, label);
+}
+
 int
 main(void) {
     int rc = 0;
-    rc |= run_p25p2_sync_case(P25P2_SYNC, DSD_SYNC_P25P2_POS, "P25P2 RTL positive sync");
-    rc |= run_p25p2_sync_case(INV_P25P2_SYNC, DSD_SYNC_P25P2_NEG, "P25P2 RTL inverted sync");
+    char rotated[32];
+
+    rc |= run_p25p2_sync_case(P25P2_SYNC, DSD_SYNC_P25P2_POS, DSD_P25_CQPSK_DIBIT_MAP_IDENTITY,
+                              "P25P2 RTL positive sync");
+    rc |= run_p25p2_sync_case(INV_P25P2_SYNC, DSD_SYNC_P25P2_NEG, DSD_P25_CQPSK_DIBIT_MAP_IDENTITY,
+                              "P25P2 RTL inverted sync");
+
+    if (!build_raw_pattern_for_map(P25P2_SYNC, DSD_P25_CQPSK_DIBIT_MAP_X2400, rotated, sizeof(rotated))) {
+        return 1;
+    }
+    rc |=
+        run_p25p2_sync_case(rotated, DSD_SYNC_P25P2_POS, DSD_P25_CQPSK_DIBIT_MAP_X2400, "P25P2 RTL X2400 rotated sync");
+
+    if (!build_raw_pattern_for_map(P25P2_SYNC, DSD_P25_CQPSK_DIBIT_MAP_N1200, rotated, sizeof(rotated))) {
+        return 1;
+    }
+    rc |=
+        run_p25p2_sync_case(rotated, DSD_SYNC_P25P2_POS, DSD_P25_CQPSK_DIBIT_MAP_N1200, "P25P2 RTL N1200 rotated sync");
+
+    if (!build_raw_pattern_for_map(P25P2_SYNC, DSD_P25_CQPSK_DIBIT_MAP_P1200, rotated, sizeof(rotated))) {
+        return 1;
+    }
+    rc |=
+        run_p25p2_sync_case(rotated, DSD_SYNC_P25P2_POS, DSD_P25_CQPSK_DIBIT_MAP_P1200, "P25P2 RTL P1200 rotated sync");
+
+    if (!build_raw_pattern_for_map(P25P1_SYNC, DSD_P25_CQPSK_DIBIT_MAP_X2400, rotated, sizeof(rotated))) {
+        return 1;
+    }
+    rc |=
+        run_p25p1_sync_case(rotated, DSD_SYNC_P25P1_POS, DSD_P25_CQPSK_DIBIT_MAP_X2400, "P25P1 RTL X2400 rotated sync");
     return rc;
 }
 


### PR DESCRIPTION
## Summary
- add OP25-compatible P25 CQPSK dibit orientation maps
- detect rotated CQPSK sync windows for P25 Phase 1 and Phase 2 before frame lock
- apply the selected map in CQPSK dibit slicing and soft-symbol ideal selection
- add RTL frame-sync regression coverage for rotated P25 CQPSK mappings

## Root Cause
Startup could lock onto a valid CQPSK constellation orientation that produced high SNR but raw dibits in a rotated mapping. The frame-sync scanner only recognized the normal and inverted P25 sync strings, so rotated-but-correctable CQPSK windows never reached stable sync.

## Validation
- `tools/format.sh`
- `cmake --build --preset dev-debug --target dsd-neo_test_frame_sync_p25p2_rtl -j`
- `ctest --preset dev-debug --output-on-failure -R FRAME_SYNC_P25P2_RTL`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh`