### PR TITLE
tests: address codeql warnings

### DIFF
--- a/tests/dsp/test_frame_sync_p25p2_rtl.c
+++ b/tests/dsp/test_frame_sync_p25p2_rtl.c
@@ -349,7 +349,18 @@ run_p25_sync_case(const char* pattern, int frame_p25p1, int frame_p25p2, int exp
     static int fake_rtl_context;
 
     g_symbol_index = 0U;
-    g_sync_pattern = pattern;
+    if (!pattern) {
+        DSD_FPRINTF(stderr, "%s sync pattern is null\n", label ? label : "P25 sync");
+        return 1;
+    }
+    const size_t pattern_len = strlen(pattern);
+    char* sync_pattern_copy = (char*)malloc(pattern_len + 1U);
+    if (!sync_pattern_copy) {
+        DSD_FPRINTF(stderr, "%s sync pattern copy allocation failed\n", label ? label : "P25 sync");
+        return 1;
+    }
+    DSD_MEMCPY(sync_pattern_copy, pattern, pattern_len + 1U);
+    g_sync_pattern = sync_pattern_copy;
     g_symbol_rate_hz = frame_p25p2 ? 6000 : 4800;
     dsd_frame_sync_reset_mod_state();
 
@@ -357,6 +368,8 @@ run_p25_sync_case(const char* pattern, int frame_p25p1, int frame_p25p2, int exp
     DSD_MEMSET(&state, 0, sizeof(state));
     if (!init_state_buffers(&state)) {
         DSD_FPRINTF(stderr, "failed to allocate frame-sync state buffers\n");
+        g_sync_pattern = P25P2_SYNC;
+        free(sync_pattern_copy);
         return 1;
     }
 
@@ -420,6 +433,8 @@ run_p25_sync_case(const char* pattern, int frame_p25p1, int frame_p25p2, int exp
     dsd_rtl_stream_metrics_hooks_set(NULL);
     dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
     free_state_buffers(&state);
+    g_sync_pattern = P25P2_SYNC;
+    free(sync_pattern_copy);
     return rc;
 }
 

--- a/tests/dsp/test_rtl_symbol_cache_generation.c
+++ b/tests/dsp/test_rtl_symbol_cache_generation.c
@@ -276,6 +276,11 @@ main(void) {
     };
     dsd_rtl_stream_metrics_hooks_set(&metrics_hooks);
 
+    /*
+     * Symbol-path setup covers the direct CQPSK output path first, then the
+     * discriminator path that seeds min/max state from the active channel
+     * profile.
+     */
     reset_stream_fixture();
     reset_decoder_fixture(&opts, &state, &fake_rtl_context);
     g_output_kind = RTL_STREAM_OUTPUT_SYMBOL_CQPSK;
@@ -309,6 +314,11 @@ main(void) {
     assert(state.maxbuf[1023] == 30000.0f);
     assert(state.minmax_sum_window == 0);
 
+    /*
+     * Cached CQPSK symbols should be reused until the generation or channel
+     * profile changes. Mid-read generation bumps must refresh cached metadata
+     * without losing the samples returned by the read hook.
+     */
     reset_stream_fixture();
     reset_decoder_fixture(&opts, &state, &fake_rtl_context);
 
@@ -376,6 +386,11 @@ main(void) {
     assert(dsd_rtl_stream_metrics_hook_symbol_cache_pending() == 0);
     assert(g_cleanup_calls == 0);
 
+    /*
+     * FSK discriminator tests cover nominal sample-per-symbol choices, fractional
+     * accumulation for high-rate modes, jitter adjustment, and output-kind changes
+     * that happen while a read is in flight.
+     */
     reset_stream_fixture();
     reset_decoder_fixture(&opts, &state, &fake_rtl_context);
     g_output_kind = RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
@@ -491,6 +506,10 @@ main(void) {
     assert(getSymbol(&opts, &state, 1) == 4100.0f);
     assert(g_cleanup_calls == 0);
 
+    /*
+     * Read failures should surface as the existing empty-symbol path, trigger
+     * the legacy cleanup hook once, and leave global hooks reset for later tests.
+     */
     reset_stream_fixture();
     reset_decoder_fixture(&opts, &state, &fake_rtl_context);
     g_fail_reads = 1;

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -167,6 +167,11 @@ main(void) {
                             dsd_rtl_stream_test_manual_retune_completion_result(-5, 0, 855000000U, 855000000U),
                             RTL_STREAM_TUNE_FAILED);
 
+    /*
+     * Failed tune and capture-setting paths reconcile staged frequency/rate state
+     * back to the applied RTL configuration, while accepted PPM changes survive a
+     * later retune failure.
+     */
     long int reconciled_opts_freq = 0;
     uint32_t reconciled_capture_freq = 0U;
     rc = dsd_rtl_stream_test_tune_failure_reconciles_applied(855000000U, 851000000U, &reconciled_opts_freq,
@@ -207,6 +212,11 @@ main(void) {
                             dsd_rtl_stream_test_ppm_store_if_applied(-5, 11, &ppm_after_failure), 0);
     failed |= expect_int_eq("failed ppm keeps previous runtime ppm", ppm_after_failure, 3);
 
+    /*
+     * Clear-output and reacquire helpers coordinate the sample ring, cached
+     * symbol count, FSK modem history, and generation counters used by the
+     * demodulator thread.
+     */
     cache_pending = -1;
     rc = rtl_stream_test_clear_output(7U, 3, &used_after, &cache_pending, &generation_before, &generation_after);
     failed |= expect_int_eq("clear output helper rc", rc, 0);
@@ -277,6 +287,11 @@ main(void) {
     failed |= expect_int_eq("first retune profile keeps request id", (int)first_request_id, 1);
     failed |= expect_int_eq("second retune profile keeps request id", (int)second_request_id, 2);
 
+    /*
+     * Retune requests also preserve profile-specific gain, autogain, and Soapy
+     * settings fields so a coalesced manual retune cannot silently discard user
+     * capture preferences.
+     */
     int coalesced_profile = -1;
     uint32_t coalesced_profile_freq_hz = 0U;
     uint32_t coalesced_manual_freq_hz = 0U;
@@ -321,6 +336,11 @@ main(void) {
         rtl_device_test_soapy_config_settings_visibility(RTL_SOAPY_CONFIG_SIZE, "biasT_ctrl=false", &settings_seen), 0);
     failed |= expect_int_eq("sized Soapy config observes appended settings", settings_seen, 1);
 
+    /*
+     * USB apply/readback checks keep retry behavior explicit: apply failures are
+     * retried, readback failures are retried only when verification is enabled,
+     * and zero readback remains invalid.
+     */
     int apply_calls = -1;
     int verify_calls = -1;
     int used_attempts = -1;
@@ -365,6 +385,10 @@ main(void) {
     rc = rtl_device_test_usb_sample_rate_readback(1024000U, 0U, &actual_rate);
     failed |= expect_int_eq("rtl sample-rate readback rejects zero rc", rc, -1);
 
+    /*
+     * Gain setup intentionally records non-fatal AGC failures while still treating
+     * gain-mode failures as fatal, matching the live-device setup sequence.
+     */
     int agc_calls = -1;
     int gain_mode_calls = -1;
     int gain_calls = -1;

--- a/tests/runtime/test_runtime_config_user.cpp
+++ b/tests/runtime/test_runtime_config_user.cpp
@@ -979,6 +979,10 @@ test_apply_logging_retargets_frame_log_file(void) {
 
     dsd_apply_user_config_to_opts(&cfg, &opts, &state);
 
+    /*
+     * Retargeting to new frame-log paths must close existing handles, replace the
+     * remembered path strings, and clear sticky open/write error state.
+     */
     int rc = 0;
     if (opts.frame_log_f != NULL) {
         DSD_FPRINTF(stderr, "frame log handle should be closed after retarget\n");
@@ -1034,6 +1038,10 @@ test_apply_logging_retargets_frame_log_file(void) {
 
     dsd_apply_user_config_to_opts(&cfg, &opts, &state);
 
+    /*
+     * Clearing configured paths is the disable case: both handles close, paths
+     * become empty, and the same sticky error flags reset for future attempts.
+     */
     if (opts.frame_log_f != NULL) {
         DSD_FPRINTF(stderr, "frame log handle should be closed when disabling logging path\n");
         rc |= 1;


### PR DESCRIPTION
## Summary

- Own the P25 sync test pattern for each case so the test fixture no longer stores a caller stack address in global state.
- Add scenario-level comments to the large test functions flagged by CodeQL as under-documented.
- Keep the changes limited to tests and preserve existing test behavior.

## Validation

- `tools/format.sh`
- `cmake --build --preset dev-debug -j --target dsd-neo_test_frame_sync_p25p2_rtl dsd-neo_test_rtl_symbol_cache_generation dsd-neo_test_io_rtl_retune_prepare dsd-neo_test_runtime_config_user`
- `ctest --preset dev-debug --output-on-failure -R '^(DSP_FRAME_SYNC_P25P2_RTL|DSP_RTL_SYMBOL_CACHE_GENERATION|IO_RTL_RETUNE_PREPARE|RUNTIME_CONFIG_USER)$'` (matched runtime and IO entries only)
- `ctest --preset dev-debug --output-on-failure -R '^(RTL_SYMBOL_CACHE_GENERATION|FRAME_SYNC_P25P2_RTL)$'`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- `tools/preflight_ci.sh`
- pre-push hook during `git push -u origin fix/codeql-test-warnings`