### PR TITLE
release: prepare 2.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(dsd-neo VERSION 2.1.0 LANGUAGES C CXX)
+project(dsd-neo VERSION 2.2.0 LANGUAGES C CXX)
 if(POLICY CMP0083)
     cmake_policy(SET CMP0083 NEW)
 endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "dsd-neo",
-  "version-string": "2.1.0",
+  "version-string": "2.2.0",
   "builtin-baseline": "f3e10653cc27d62a37a3763cd84b38bca07c6075",
   "description": "Digital Speech Decoder: DSD-neo",
   "homepage": "https://github.com/arancormonk/dsd-neo",


### PR DESCRIPTION
## Summary

- Update the CMake project version to 2.2.0.
- Update the vcpkg manifest version string to 2.2.0.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: release.
- [x] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `tools/cmake_format_check.sh`
- [x] `cmake --preset dev-debug`
- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `cmake --preset dev-release`
- [x] `cmake --build --preset dev-release -j`
- [x] `tools/check_release_hardening.sh build/dev-release/apps/dsd-cli/dsd-neo build/dev-release`
- [x] `build/dev-release/apps/dsd-cli/dsd-neo -h`
- [x] `tools/preflight_ci.sh`

No focused regression test was added because this is a metadata-only release version bump.

## Risk

- Security/dependency impact: none; no dependency versions or workflow permissions changed.
- CLI/UI behavior impact: none expected.
- Compatibility or packaging impact: release metadata now targets 2.2.0.