### PR TITLE
test: expand source coverage follow-through

### DIFF
--- a/apps/dsd-cli/CMakeLists.txt
+++ b/apps/dsd-cli/CMakeLists.txt
@@ -28,6 +28,24 @@ target_compile_definitions(dsd-neo PRIVATE USE_MBELIB_NEO)
 
 target_link_libraries(dsd-neo PRIVATE dsd-neo_warnings)
 
+if(BUILD_TESTING)
+    add_test(
+        NAME CLI_HELP_SMOKE
+        COMMAND
+            ${CMAKE_COMMAND} -D DSD_NEO_CLI=$<TARGET_FILE:dsd-neo> -D
+            DSD_NEO_CLI_SMOKE_MODE=help -P
+            ${PROJECT_SOURCE_DIR}/tests/cmake/RunCliSmoke.cmake
+    )
+
+    add_test(
+        NAME CLI_INVALID_OPTION_SMOKE
+        COMMAND
+            ${CMAKE_COMMAND} -D DSD_NEO_CLI=$<TARGET_FILE:dsd-neo> -D
+            DSD_NEO_CLI_SMOKE_MODE=invalid-option -P
+            ${PROJECT_SOURCE_DIR}/tests/cmake/RunCliSmoke.cmake
+    )
+endif()
+
 ## Fast-math now configured globally when enabled
 
 ## LTO/IPO now configured globally for Release when enabled

--- a/include/dsd-neo/core/dsd_time.h
+++ b/include/dsd-neo/core/dsd_time.h
@@ -15,7 +15,7 @@
 #define DSD_NEO_INCLUDE_DSD_NEO_CORE_DSD_TIME_H_H
 
 #include <dsd-neo/core/state_fwd.h>
-#include <dsd-neo/platform/timing.h>
+#include <dsd-neo/platform/timing.h> // IWYU pragma: keep
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -13,6 +13,7 @@
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <time.h> // IWYU pragma: keep
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,6 +53,26 @@ int getFrameSync(dsd_opts* opts, dsd_state* state);
  */
 void printFrameSync(const dsd_opts* opts, const dsd_state* state, const char* frametype, int offset,
                     const char* modulation);
+
+#ifdef DSD_NEO_TEST_HOOKS
+int dsd_frame_sync_test_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* state, const int* sym_rate_cycle,
+                                            const int* levels_cycle, int cycle_count);
+void dsd_frame_sync_test_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx,
+                                                const int* sym_rate_cycle, const int* levels_cycle);
+double dsd_frame_sync_test_elapsed_seconds(double nowm, time_t now, double mono_stamp, time_t wall_stamp);
+void dsd_frame_sync_test_p25_slot_activity(const dsd_opts* opts, const dsd_state* state, time_t now, double nowm,
+                                           double mac_hold, double ring_hold, double dt, int* left_active,
+                                           int* right_active);
+int dsd_frame_sync_test_hamming_distance_pattern(const char* symbols, const char* pattern, int len);
+int dsd_frame_sync_test_best_ham_for_patterns(const char* symbols, const char* const patterns[], int pattern_count,
+                                              int pattern_len, int best_start);
+int dsd_frame_sync_test_best_nxdn_scaled_ham(const char* symbols10, int best_start);
+#ifdef USE_RADIO
+int dsd_frame_sync_test_rtl_profile_for_symbol_rate(const dsd_opts* opts, const dsd_state* state, int sym_rate_hz,
+                                                    int preferred_levels);
+int dsd_frame_sync_test_rtl_levels_for_symbol_rate(const dsd_opts* opts, int sym_rate_hz, int preferred_levels);
+#endif
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -67,6 +67,11 @@ int dsd_frame_sync_test_hamming_distance_pattern(const char* symbols, const char
 int dsd_frame_sync_test_best_ham_for_patterns(const char* symbols, const char* const patterns[], int pattern_count,
                                               int pattern_len, int best_start);
 int dsd_frame_sync_test_best_nxdn_scaled_ham(const char* symbols10, int best_start);
+void dsd_frame_sync_test_set_recent_hamming(int ham_c4fm, int ham_qpsk, int ham_gfsk);
+void dsd_frame_sync_test_get_mod_votes(int* out_c4fm, int* out_qpsk, int* out_gfsk);
+void dsd_frame_sync_test_auto_switch_modulation(const dsd_opts* opts, dsd_state* state, int t_max, int* lastt);
+void dsd_frame_sync_test_reset_p25_trunk_tick_state(void);
+void dsd_frame_sync_test_maybe_tick_p25_trunk_sm(dsd_opts* opts, dsd_state* state, time_t now);
 #ifdef USE_RADIO
 int dsd_frame_sync_test_rtl_profile_for_symbol_rate(const dsd_opts* opts, const dsd_state* state, int sym_rate_hz,
                                                     int preferred_levels);

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -429,6 +429,13 @@ int rtl_stream_test_fsk_cfo_snapshot(double dc_rad_per_sample, int rate_out_hz, 
 int rtl_stream_test_fsk_snr_sps(int rate_out_hz, int symbol_rate_hz, int stale_ted_sps);
 int rtl_stream_test_direct_output_rate_after_open_update(int output_kind, int rate_out_hz, int resamp_target_hz,
                                                          unsigned int* out_rate_hz, int* out_resamp_enabled);
+int rtl_stream_test_parse_compat_matrix(int* out_int_ok, int* out_int_values, size_t int_count, int* out_double_ok,
+                                        double* out_double_values, size_t double_count);
+int rtl_stream_test_source_policy_matrix(int* out_kind, int* out_rtltcp, int* out_soapy, int* out_replay,
+                                         int* out_family, size_t count, char* out_names, size_t names_size,
+                                         char* out_soapy_args, size_t args_size);
+int rtl_stream_test_mode_policy_matrix(int* out_values, size_t count);
+int rtl_stream_test_fsk_profile_policy_matrix(int* out_profiles, size_t count);
 
 /**
  * @brief Seed output/cache state, request FSK reacquire, and consume pending reset.

--- a/include/dsd-neo/protocol/dmr/dmr.h
+++ b/include/dsd-neo/protocol/dmr/dmr.h
@@ -33,6 +33,20 @@ void dmr_data_sync(dsd_opts* opts, dsd_state* state);
 void dmr_data_burst_handler(dsd_opts* opts, dsd_state* state, uint8_t info[196], uint8_t databurst);
 void dmr_data_burst_handler_ex(dsd_opts* opts, dsd_state* state, uint8_t info[196], uint8_t databurst,
                                const uint8_t* reliab98);
+#ifdef DSD_NEO_TEST_HOOKS
+typedef struct {
+    uint8_t pdu_len;
+    uint8_t pdu_start;
+    uint8_t crclen;
+    uint32_t crcmask;
+    uint8_t flags;
+    char subtype[8];
+    uint8_t data_p_head;
+} dsd_neo_dmr_test_dburst_profile_result;
+
+int dsd_neo_dmr_test_dburst_profile(dsd_opts* opts, dsd_state* state, uint8_t databurst, uint8_t slot,
+                                    dsd_neo_dmr_test_dburst_profile_result* result);
+#endif
 
 void dmr_pi(dsd_opts* opts, dsd_state* state, uint8_t PI_BYTE[], uint32_t CRCCorrect, uint32_t IrrecoverableErrors);
 void dmr_flco(dsd_opts* opts, dsd_state* state, uint8_t lc_bits[], uint32_t CRCCorrect, uint32_t* IrrecoverableErrors,

--- a/include/dsd-neo/protocol/m17/m17.h
+++ b/include/dsd-neo/protocol/m17/m17.h
@@ -14,6 +14,7 @@
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 #ifdef DSD_NEO_TEST_HOOKS
+#include <stddef.h>
 #include <stdint.h>
 #endif
 
@@ -45,6 +46,37 @@ enum dsd_neo_m17_test_stream_result {
 int dsd_neo_m17_test_apply_lsf_result(dsd_state* state, const struct m17_lsf_result* res);
 int dsd_neo_m17_test_dispatch_stream_payload(const dsd_opts* opts, dsd_state* state, const uint8_t payload[128],
                                              uint16_t frame_number, uint8_t processed_payload[128]);
+void dsd_neo_m17_test_process_bert_payload(const dsd_opts* opts, dsd_state* state, const uint8_t bert_bits[197]);
+void dsd_neo_m17_test_unpack_bytes_to_bits(const uint8_t* bytes, int byte_count, uint8_t* out_bits);
+void dsd_neo_m17_test_depuncture_p2_hard(const uint8_t punctured[368], uint8_t* depunc, int depunc_bits);
+void dsd_neo_m17_test_decode_bert_payload_bits(const uint8_t m17_bits[368], uint8_t bert_bits[197]);
+uint16_t dsd_neo_m17_test_compose_frame_info(uint16_t ps, uint16_t dt, uint16_t et, uint16_t es, uint16_t cn,
+                                             uint16_t signature, uint16_t reserved);
+unsigned long long dsd_neo_m17_test_read_ip_source(const uint8_t ip_frame[10]);
+void dsd_neo_m17_test_setup_conn_disc_eotx(unsigned long long src, uint8_t reflector_module, uint8_t conn[11],
+                                           uint8_t disc[10], uint8_t eotx[10]);
+void dsd_neo_m17_test_load_lsf_callsigns(uint8_t m17_lsf[240], unsigned long long dst, unsigned long long src);
+uint16_t dsd_neo_m17_test_attach_lsf_crc(uint8_t m17_lsf[240], uint8_t lsf_packed[30]);
+void dsd_neo_m17_test_apply_frame_prefix_dibits(int type, uint8_t output_dibits[192]);
+void dsd_neo_m17_test_load_payload_dibits(const uint8_t input[368], uint8_t output_dibits[192]);
+short dsd_neo_m17_test_clip_float_to_short(float value);
+void dsd_neo_m17_test_dibits_to_symbols(const uint8_t output_dibits[192], int output_symbols[192]);
+void dsd_neo_m17_test_upsample_symbols_10x(const int output_symbols[192], int output_up[1920]);
+void dsd_neo_m17_test_baseband_no_filter(const int output_up[1920], short baseband[1920]);
+void dsd_neo_m17_test_maybe_apply_dead_air(int type, uint8_t output_dibits[192], short baseband[1920]);
+void dsd_neo_m17_test_reverse_brt_bits(const uint8_t input[197], uint8_t output[208]);
+size_t dsd_neo_m17_test_strlen_limit(const char* text, size_t limit);
+int dsd_neo_m17_test_prepare_pkt_payload(const char* text, uint8_t* packed, uint8_t* full_bits, uint16_t* app_len,
+                                         int* block, uint8_t* lst, uint16_t* crc);
+int dsd_neo_m17_test_prepare_pkt_from_state(const dsd_state* input_state, uint8_t* lsf_bits, uint8_t* packed,
+                                            uint16_t* app_len, uint16_t* lsf_crc, uint8_t* can, unsigned long long* dst,
+                                            unsigned long long* src);
+int dsd_neo_m17_test_decode_pkt_should_report_encrypted(const dsd_state* state, uint32_t protocol);
+int dsd_neo_m17_test_pkt_ptr_clamped(int pbc_count);
+void dsd_neo_m17_test_dispatch_ip_frame(const dsd_opts* opts, dsd_state* state, const uint8_t* ip_frame, int len);
+int dsd_neo_m17_test_process_lich(dsd_state* state, const dsd_opts* opts, const uint8_t* lich_bits);
+void dsd_neo_m17_test_finalize_packet_eot(const dsd_opts* opts, dsd_state* state, uint16_t app_len, int end);
+size_t dsd_neo_m17_test_encode_packet_protocol_id(uint32_t identifier, uint8_t out[4]);
 #endif
 
 #ifdef __cplusplus

--- a/include/dsd-neo/protocol/m17/m17.h
+++ b/include/dsd-neo/protocol/m17/m17.h
@@ -13,6 +13,9 @@
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#ifdef DSD_NEO_TEST_HOOKS
+#include <stdint.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,6 +29,23 @@ void processM17IPF(dsd_opts* opts, dsd_state* state);
 void encodeM17STR(dsd_opts* opts, dsd_state* state);
 void encodeM17BRT(dsd_opts* opts, dsd_state* state);
 void encodeM17PKT(dsd_opts* opts, dsd_state* state);
+
+#ifdef DSD_NEO_TEST_HOOKS
+struct m17_lsf_result;
+
+enum dsd_neo_m17_test_stream_result {
+    DSD_NEO_M17_TEST_STREAM_INVALID = -1,
+    DSD_NEO_M17_TEST_STREAM_CAN_FILTERED = 0,
+    DSD_NEO_M17_TEST_STREAM_CLEAR_DISPATCHED = 1,
+    DSD_NEO_M17_TEST_STREAM_ENCRYPTED_LOCKED = 2,
+    DSD_NEO_M17_TEST_STREAM_ENCRYPTED_DISPATCHED = 3,
+    DSD_NEO_M17_TEST_STREAM_SIGNATURE_CONSUMED = 4,
+};
+
+int dsd_neo_m17_test_apply_lsf_result(dsd_state* state, const struct m17_lsf_result* res);
+int dsd_neo_m17_test_dispatch_stream_payload(const dsd_opts* opts, dsd_state* state, const uint8_t payload[128],
+                                             uint16_t frame_number, uint8_t processed_payload[128]);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/protocol/nxdn/nxdn.h
+++ b/include/dsd-neo/protocol/nxdn/nxdn.h
@@ -13,12 +13,20 @@
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#ifdef DSD_NEO_TEST_HOOKS
+#include <stdint.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void nxdn_frame(dsd_opts* opts, dsd_state* state);
+
+#ifdef DSD_NEO_TEST_HOOKS
+int dsd_neo_nxdn_test_route_decoded_lich(dsd_opts* opts, dsd_state* state, uint8_t lich, const uint8_t bits[364],
+                                         const uint8_t reliab[364]);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/protocol/nxdn/nxdn_deperm.h
+++ b/include/dsd-neo/protocol/nxdn/nxdn_deperm.h
@@ -83,6 +83,8 @@ void dsd_neo_nxdn_test_facch2_udch_state_update(dsd_opts* opts, dsd_state* state
 void dsd_neo_nxdn_test_facch3_udch2_state_update(dsd_opts* opts, dsd_state* state, const uint8_t bits[160],
                                                  const uint8_t bytes[24], uint16_t crc0, uint16_t check0, uint16_t crc1,
                                                  uint16_t check1, uint8_t type);
+void dsd_neo_nxdn_test_facch3_udch2_store_block(uint8_t bits[160], uint8_t bytes[24], size_t block,
+                                                const uint8_t trellis_buf[96], const uint8_t m_data[12]);
 #endif
 
 const char* nxdn_message_type_label(uint8_t message_type);

--- a/include/dsd-neo/protocol/nxdn/nxdn_deperm.h
+++ b/include/dsd-neo/protocol/nxdn/nxdn_deperm.h
@@ -47,6 +47,44 @@ void nxdn_deperm_scch_soft(dsd_opts* opts, dsd_state* state, uint8_t bits[60], c
 
 void nxdn_deperm_cac_soft(dsd_opts* opts, dsd_state* state, uint8_t bits[300], const uint8_t reliab[300]);
 
+#ifdef DSD_NEO_TEST_HOOKS
+void dsd_neo_nxdn_test_depermute_12_5(const uint8_t input[60], const uint8_t reliab[60], uint8_t deperm[60],
+                                      uint8_t deperm_rel[60]);
+void dsd_neo_nxdn_test_depermute_16_9(const uint8_t input[144], const uint8_t reliab[144], uint8_t deperm[144],
+                                      uint8_t deperm_rel[144]);
+void dsd_neo_nxdn_test_depermute_12_25(const uint8_t input[300], const uint8_t reliab[300], uint8_t deperm[300],
+                                       uint8_t deperm_rel[300]);
+void dsd_neo_nxdn_test_depermute_12_29(const uint8_t input[348], const uint8_t reliab[348], uint8_t deperm[348],
+                                       uint8_t deperm_rel[348]);
+void dsd_neo_nxdn_test_depuncture_12_5(const uint8_t deperm[60], const uint8_t deperm_rel[60], uint8_t depunc[72],
+                                       uint8_t depunc_rel[72]);
+void dsd_neo_nxdn_test_depuncture_16_9(const uint8_t deperm[144], const uint8_t deperm_rel[144], uint8_t depunc[192],
+                                       uint8_t depunc_rel[192]);
+void dsd_neo_nxdn_test_depuncture_12_group(const uint8_t* deperm, const uint8_t* deperm_rel, size_t groups,
+                                           uint8_t* depunc, uint8_t* depunc_rel);
+int dsd_neo_nxdn_test_dcr_is_sb0_message_type(uint8_t message_type);
+void dsd_neo_nxdn_test_unpack_bytes_msb(const uint8_t* bytes, size_t byte_count, uint8_t* bits);
+void dsd_neo_nxdn_test_pack_bits_msb(const uint8_t* bits, size_t byte_count, uint8_t* bytes);
+uint16_t dsd_neo_nxdn_test_bits_to_u16(const uint8_t* bits, int len);
+int dsd_neo_nxdn_test_sacch_part_of_frame(uint8_t sf);
+int dsd_neo_nxdn_test_ran_from_trellis(const uint8_t* trellis_buf);
+void dsd_neo_nxdn_test_reset_payload_seed_if_forced(dsd_state* state);
+void dsd_neo_nxdn_test_prepare_sacch_payload_seed(dsd_state* state, int part_of_frame);
+void dsd_neo_nxdn_test_sacch_state_update(dsd_opts* opts, dsd_state* state, const uint8_t trellis_buf[32],
+                                          const uint8_t m_data[5], uint8_t crc, uint8_t check);
+void dsd_neo_nxdn_test_sacch2_state_update(const dsd_opts* opts, dsd_state* state, const uint8_t trellis_buf[32],
+                                           const uint8_t m_data[5], uint8_t crc, uint8_t check);
+void dsd_neo_nxdn_test_cac_state_update(dsd_opts* opts, dsd_state* state, const uint8_t trellis_buf[176],
+                                        const uint8_t m_data[22], uint16_t crc);
+void dsd_neo_nxdn_test_pich_tch_state_update(const dsd_opts* opts, dsd_state* state, const uint8_t trellis_buf[96],
+                                             const uint8_t m_data[12], uint16_t crc, uint16_t check, uint8_t lich);
+void dsd_neo_nxdn_test_facch2_udch_state_update(dsd_opts* opts, dsd_state* state, const uint8_t trellis_buf[208],
+                                                const uint8_t m_data[26], uint16_t crc, uint16_t check, uint8_t type);
+void dsd_neo_nxdn_test_facch3_udch2_state_update(dsd_opts* opts, dsd_state* state, const uint8_t bits[160],
+                                                 const uint8_t bytes[24], uint16_t crc0, uint16_t check0, uint16_t crc1,
+                                                 uint16_t check1, uint8_t type);
+#endif
+
 const char* nxdn_message_type_label(uint8_t message_type);
 void nxdn_message_type(const dsd_opts* opts, dsd_state* state, uint8_t MessageType);
 

--- a/include/dsd-neo/protocol/p25/p25p2_frame.h
+++ b/include/dsd-neo/protocol/p25/p25p2_frame.h
@@ -28,6 +28,11 @@ void process_2V(dsd_opts* opts, dsd_state* state);
 
 #if defined(DSD_NEO_P25P2_TEST_STUB)
 int p25p2_duid_lookup_soft_test(uint8_t received, const uint8_t reliab8[8]);
+void p25p2_test_teardown_call(dsd_opts* opts, dsd_state* state);
+void p25p2_test_process_facchc(dsd_opts* opts, dsd_state* state, int timeslot_index);
+void p25p2_test_process_isch(dsd_opts* opts, dsd_state* state, int framing_index);
+void p25p2_test_process_p2_duid(dsd_opts* opts, dsd_state* state);
+void p25p2_test_process_sacchc(dsd_opts* opts, dsd_state* state, int timeslot_index);
 #endif
 
 #ifdef __cplusplus

--- a/include/dsd-neo/protocol/ysf/ysf.h
+++ b/include/dsd-neo/protocol/ysf/ysf.h
@@ -14,11 +14,29 @@
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 
+#ifdef DSD_NEO_TEST_HOOKS
+#include <stdint.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void processYSF(dsd_opts* opts, dsd_state* state);
+
+#ifdef DSD_NEO_TEST_HOOKS
+void dsd_neo_ysf_test_decode_dch(dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, uint8_t cm,
+                                 const uint8_t input[160]);
+void dsd_neo_ysf_test_decode_dch2(dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, uint8_t cm,
+                                  const uint8_t input[80]);
+uint16_t dsd_neo_ysf_test_crc16(const uint8_t* bits, int len);
+int dsd_neo_ysf_test_conv_fich(const uint8_t input[100], uint8_t dest[32], uint32_t* v_error_out);
+int dsd_neo_ysf_test_conv_dch(const dsd_opts* opts, dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft,
+                              uint8_t cm, uint8_t input[180]);
+int dsd_neo_ysf_test_conv_dch2(const dsd_opts* opts, dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft,
+                               uint8_t cm, uint8_t input[100]);
+void dsd_neo_ysf_test_build_type2_ambe(const uint8_t vech_bits[104], uint8_t temp[512], char ambe_d[49]);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/runtime/rt_sched.h
+++ b/include/dsd-neo/runtime/rt_sched.h
@@ -30,6 +30,13 @@ extern "C" {
  */
 void maybe_set_thread_realtime_and_affinity(const char* role);
 
+#ifdef DSD_NEO_TEST_HOOKS
+#include <dsd-neo/runtime/config.h>
+const char* dsd_neo_rt_sched_test_role_or_default(const char* role);
+int dsd_neo_rt_sched_test_resolve_role_rt_priority(const dsdneoRuntimeConfig* cfg, const char* role);
+int dsd_neo_rt_sched_test_resolve_role_cpu_affinity(const dsdneoRuntimeConfig* cfg, const char* role);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dsd-neo/ui/ncurses_snr.h
+++ b/include/dsd-neo/ui/ncurses_snr.h
@@ -17,6 +17,12 @@
 
 #ifdef DSD_NEO_TEST_HOOKS
 #include <stddef.h>
+
+typedef int (*dsd_ncurses_snr_emit_ch_fn)(unsigned long ch);
+typedef int (*dsd_ncurses_snr_emit_str_fn)(const char* text);
+typedef int (*dsd_ncurses_snr_emit_attr_fn)(unsigned long attrs);
+typedef int (*dsd_ncurses_snr_emit_attr_get_fn)(unsigned long* attrs, short* pair);
+typedef int (*dsd_ncurses_snr_emit_attr_set_fn)(unsigned long attrs, short pair);
 #endif
 
 #ifdef __cplusplus
@@ -36,6 +42,18 @@ void print_snr_meter(const dsd_opts* opts, double snr_db, int mod);
 int dsd_ncurses_snr_meter_bar_count_for_test(double snr_db);
 void dsd_ncurses_snr_meter_ascii_for_test(double snr_db, char* out, size_t out_size);
 int dsd_ncurses_snr_use_unicode_for_test(int option_enabled, int block_glyphs_supported);
+void dsd_ncurses_snr_hist_reset_for_test(void);
+int dsd_ncurses_snr_hist_len_for_test(int mod);
+int dsd_ncurses_snr_hist_head_for_test(int mod);
+double dsd_ncurses_snr_hist_value_for_test(int mod, int index);
+int dsd_ncurses_snr_hist_render_count_for_test(int len, int width);
+int dsd_ncurses_snr_hist_render_start_for_test(int head, int len, int count);
+int dsd_ncurses_snr_level_index_for_test(double value, double clip_lo, double span, int levels);
+void dsd_ncurses_snr_set_emit_hooks_for_test(dsd_ncurses_snr_emit_ch_fn emit_ch, dsd_ncurses_snr_emit_str_fn emit_str,
+                                             dsd_ncurses_snr_emit_attr_fn emit_attron,
+                                             dsd_ncurses_snr_emit_attr_fn emit_attroff,
+                                             dsd_ncurses_snr_emit_attr_get_fn emit_attr_get,
+                                             dsd_ncurses_snr_emit_attr_set_fn emit_attr_set);
 #endif
 
 #ifdef __cplusplus

--- a/include/dsd-neo/ui/ui_async.h
+++ b/include/dsd-neo/ui/ui_async.h
@@ -11,6 +11,9 @@
 #define DSD_NEO_INCLUDE_DSD_NEO_UI_UI_ASYNC_H_H
 
 #include <stddef.h>
+#ifdef DSD_NEO_TEST_HOOKS
+#include <stdint.h>
+#endif
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
@@ -48,6 +51,15 @@ int ui_drain_cmds(dsd_opts* opts, dsd_state* state);
  * publish snapshots.
  */
 int ui_is_thread_context(void);
+
+#ifdef DSD_NEO_TEST_HOOKS
+void dsd_neo_ui_async_test_set_context(dsd_opts* opts, dsd_state* state);
+const dsd_opts* dsd_neo_ui_async_test_opts_snapshot_or_default(void);
+int dsd_neo_ui_async_test_curses_is_active(const dsd_opts* opts);
+int dsd_neo_ui_async_test_read_key_nonblocking(const dsd_opts* opts);
+void dsd_neo_ui_async_test_process_input_frame(const dsd_opts* opts);
+void dsd_neo_ui_async_test_draw_if_needed(const dsd_opts* opts, uint64_t* last_draw_ns, uint64_t frame_ns);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/core/audio/dsd_audio.c
+++ b/src/core/audio/dsd_audio.c
@@ -92,6 +92,17 @@ dsd_audio_default_sample_rate_hz(int configured_sample_rate_hz) {
     return (configured_sample_rate_hz > 0) ? configured_sample_rate_hz : 48000;
 }
 
+static void
+dsd_audio_write_wav_short_block(SNDFILE* file, const short* samples, sf_count_t sample_count, const char* context) {
+    if (file == NULL || samples == NULL || sample_count <= 0) {
+        return;
+    }
+    sf_count_t written = sf_write_short(file, samples, sample_count);
+    if (written != sample_count) {
+        LOG_WARN("%s: wrote %lld/%lld samples to WAV output\n", context, (long long)written, (long long)sample_count);
+    }
+}
+
 static int
 dsd_audio_try_open_mono_wav_container(const char* path, SF_INFO* info, SNDFILE** out_file, int* out_sample_rate_hz) {
     if (!dsd_audio_path_is_wav_container(path) || !dsd_audio_file_has_wav_family_header(path)) {
@@ -694,7 +705,7 @@ writeSynthesizedVoice(dsd_opts* opts, dsd_state* state) {
         state->audio_out_temp_buf_p++;
     }
 
-    sf_write_short(opts->wav_out_f, aout_buf, 160);
+    dsd_audio_write_wav_short_block(opts->wav_out_f, aout_buf, 160, "writeSynthesizedVoice");
 }
 
 void
@@ -717,7 +728,7 @@ writeSynthesizedVoiceR(dsd_opts* opts, dsd_state* state) {
         state->audio_out_temp_buf_pR++;
     }
 
-    sf_write_short(opts->wav_out_fR, aout_buf, 160);
+    dsd_audio_write_wav_short_block(opts->wav_out_fR, aout_buf, 160, "writeSynthesizedVoiceR");
 }
 
 //short Mono to Stereo version for new static .wav files in stereo format for TDMA
@@ -747,7 +758,7 @@ writeSynthesizedVoiceMS(dsd_opts* opts, dsd_state* state) {
         ss[(n * 2) + 1] = aout_buf[n];
     }
 
-    sf_write_short(opts->wav_out_f, ss, 320);
+    dsd_audio_write_wav_short_block(opts->wav_out_f, ss, 320, "writeSynthesizedVoiceMS");
 }
 
 void

--- a/src/core/audio/dsd_audio2.c
+++ b/src/core/audio/dsd_audio2.c
@@ -19,6 +19,7 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/platform/audio.h>
 #include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/runtime/log.h>
 #include <dsd-neo/runtime/p25_p2_audio_ring.h>
 #include <dsd-neo/runtime/udp_audio_hooks.h>
 #include <math.h>
@@ -30,11 +31,23 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "dsd_audio2_internal.h"
 
 static void
 write_s16_audio(dsd_opts* opts, const int16_t* buf, size_t frames) {
     if (opts->audio_out_stream) {
         dsd_audio_write(opts->audio_out_stream, buf, frames);
+    }
+}
+
+static void
+dsd_audio2_write_wav_short_block(SNDFILE* file, const short* samples, sf_count_t sample_count, const char* context) {
+    if (file == NULL || samples == NULL || sample_count <= 0) {
+        return;
+    }
+    sf_count_t written = sf_write_short(file, samples, sample_count);
+    if (written != sample_count) {
+        LOG_WARN("%s: wrote %lld/%lld samples to WAV output\n", context, (long long)written, (long long)sample_count);
     }
 }
 
@@ -84,7 +97,7 @@ write_audio_out(int fd, const void* buf, size_t bytes) {
     (void)written;
 }
 
-static int
+DSD_AUDIO2_INTERNAL int
 dsd_is_all_zero_s16(const short* buf, size_t n) {
     if (!buf) {
         return 1;
@@ -97,7 +110,7 @@ dsd_is_all_zero_s16(const short* buf, size_t n) {
     return 1;
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_audio_maybe_reset_output_ring_left(dsd_state* state) {
     if (state->audio_out_idx2 >= 800000) {
         state->audio_out_float_buf_p = state->audio_out_float_buf + 100;
@@ -108,7 +121,7 @@ dsd_audio_maybe_reset_output_ring_left(dsd_state* state) {
     }
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_audio_maybe_reset_output_ring_right(dsd_state* state) {
     if (state->audio_out_idx2R >= 800000) {
         state->audio_out_float_buf_pR = state->audio_out_float_bufR + 100;
@@ -159,7 +172,7 @@ dsd_audio_reset_short_lr_working_state(dsd_state* state) {
     dsd_audio_maybe_reset_output_ring_right(state);
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_output_float_block(dsd_opts* opts, dsd_state* state, const float* samples, size_t frames, int channels) {
     if (opts->audio_out != 1 || !samples || frames == 0) {
         return;
@@ -173,7 +186,7 @@ dsd_output_float_block(dsd_opts* opts, dsd_state* state, const float* samples, s
     }
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_output_s16_block(dsd_opts* opts, dsd_state* state, const short* samples, size_t frames, int channels) {
     if (opts->audio_out != 1 || !samples || frames == 0) {
         return;
@@ -187,7 +200,7 @@ dsd_output_s16_block(dsd_opts* opts, dsd_state* state, const short* samples, siz
     }
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_output_float_blocks(dsd_opts* opts, dsd_state* state, const float* const* blocks, size_t block_count, size_t frames,
                         int channels, int skip_silent) {
     size_t samples_per_block = frames * (size_t)channels;
@@ -199,7 +212,7 @@ dsd_output_float_blocks(dsd_opts* opts, dsd_state* state, const float* const* bl
     }
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_output_s16_blocks(dsd_opts* opts, dsd_state* state, const short* const* blocks, size_t block_count, size_t frames,
                       int channels, int skip_silent) {
     size_t samples_per_block = frames * (size_t)channels;
@@ -244,15 +257,15 @@ dsd_write_static_wav_from_mono(dsd_opts* opts, const short* mono_samp, size_t le
             ss[(i * 2) + 1] = mono_samp[(size_t)i * 6];
         }
     }
-    sf_write_short(opts->wav_out_f, ss, 320);
+    dsd_audio2_write_wav_short_block(opts->wav_out_f, ss, 320, "dsd_write_static_wav_from_mono");
 }
 
-static int
+DSD_AUDIO2_INTERNAL int
 dsd_p25_algid_is_encrypted(const dsd_state* state) {
     return DSD_SYNC_IS_P25P1(state->synctype) && state->payload_algid != 0 && state->payload_algid != 0x80;
 }
 
-static int
+DSD_AUDIO2_INTERNAL int
 dsd_p25_algid_can_decrypt(const dsd_state* state) {
     int algid = state->payload_algid;
     if (algid == 0xAA || algid == 0x81 || algid == 0x9F) {
@@ -264,7 +277,7 @@ dsd_p25_algid_can_decrypt(const dsd_state* state) {
     return 0;
 }
 
-static int
+DSD_AUDIO2_INTERNAL int
 dsd_nxdn_can_decrypt(const dsd_state* state) {
     if (state->nxdn_cipher_type == 0x1 || state->nxdn_cipher_type == 0x2) {
         return state->R != 0;
@@ -292,7 +305,7 @@ dmr_forced_privacy_unmute_enabled(const dsd_state* state) {
     return state && ((state->baofeng_ap == 1) || (state->csi_ee == 1));
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_dmr_init_slot_mute_flags(const dsd_opts* opts, const dsd_state* state, int* encL, int* encR) {
     const int forced_dmr_privacy = dmr_forced_privacy_unmute_enabled(state);
     int l_is_enc = state->dmr_encL != 0;
@@ -301,7 +314,7 @@ dsd_dmr_init_slot_mute_flags(const dsd_opts* opts, const dsd_state* state, int* 
     *encR = (forced_dmr_privacy || !r_is_enc || opts->dmr_mute_encR == 0) ? 0 : 1;
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_duplicate_active_float_slot_to_stereo(float* a, float* b, float* c, int encL, int encR, int* outL, int* outR) {
     if (!encL && encR) {
         for (int i = 0; i < 320; i += 2) {
@@ -377,7 +390,7 @@ dsd_p25p2_slot_has_decrypt_key(const dsd_state* state, int slot) {
     return 0;
 }
 
-static int
+DSD_AUDIO2_INTERNAL int
 dsd_p25p2_encrypted_lockout_slot_muted(const dsd_opts* opts, const dsd_state* state, int slot, int muted) {
     if (!opts || !state || slot < 0 || slot > 1 || !muted || opts->trunk_tune_enc_calls != 0) {
         return 0;
@@ -450,7 +463,7 @@ dsd_fs4_mix_interleaved_frames(float lf[4][160], float rf[4][160], int encL, int
     }
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_fs4_mix_mono_frames(float lf[4][160], float rf[4][160], int encL, int encR, int l_ok[4], int r_ok[4],
                         float mono[4][160]) {
     for (int j = 0; j < 4; j++) {
@@ -505,11 +518,11 @@ dsd_write_s16_wav_18_blocks(dsd_opts* opts, short stereo_sf[18][320]) {
         return;
     }
     for (int j = 0; j < 18; j++) {
-        sf_write_short(opts->wav_out_f, stereo_sf[j], 320);
+        dsd_audio2_write_wav_short_block(opts->wav_out_f, stereo_sf[j], 320, "dsd_write_s16_wav_18_blocks");
     }
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_dmr_ss3_init_enc_flags(const dsd_state* state, int* encL, int* encR) {
     *encL = (state->dmr_so >> 6) & 0x1;
     *encR = (state->dmr_soR >> 6) & 0x1;
@@ -535,7 +548,7 @@ dsd_dmr_ss3_init_enc_flags(const dsd_state* state, int* encL, int* encR) {
     }
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_dmr_apply_tg_hold_and_slot_preference_ss3(dsd_opts* opts, const dsd_state* state, unsigned long TGL,
                                               unsigned long TGR, int* encL, int* encR) {
     if (state->tg_hold != 0 && state->tg_hold != TGL) {
@@ -591,7 +604,7 @@ dsd_ss3_should_copy_left_to_right(const dsd_opts* opts, const dsd_state* state, 
     return 0;
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_dmr_apply_stereo_output_policy_ss3(const dsd_opts* opts, dsd_state* state, int encL, int encR) {
     if (encL) {
         DSD_MEMSET(state->s_l4, 0, sizeof(state->s_l4));
@@ -606,7 +619,7 @@ dsd_dmr_apply_stereo_output_policy_ss3(const dsd_opts* opts, dsd_state* state, i
     }
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_p25p2_apply_slot_preference_ss18(dsd_opts* opts, const dsd_state* state, unsigned long TGL, unsigned long TGR) {
     if (state->tg_hold != 0 && state->tg_hold == TGL) {
         opts->slot1_on = 1;
@@ -659,7 +672,7 @@ dsd_ss18_should_copy_left_to_right(const dsd_opts* opts, const dsd_state* state,
     return 0;
 }
 
-static void
+DSD_AUDIO2_INTERNAL void
 dsd_p25p2_apply_stereo_output_policy_ss18(const dsd_opts* opts, dsd_state* state, int encL, int encR) {
     if (encL) {
         DSD_MEMSET(state->s_l4, 0, sizeof(state->s_l4));
@@ -956,7 +969,7 @@ playSynthesizedVoiceSS(dsd_opts* opts, dsd_state* state) {
     if (!encL) {
         dsd_output_s16_block(opts, state, stereo_samp1, 160, 2);
         if (opts->wav_out_f != NULL && opts->static_wav_file == 1) {
-            sf_write_short(opts->wav_out_f, stereo_samp1, 320);
+            dsd_audio2_write_wav_short_block(opts->wav_out_f, stereo_samp1, 320, "processAudioDMRslot");
         }
     }
     dsd_audio_reset_short_lr_working_state(state);
@@ -1010,9 +1023,9 @@ playSynthesizedVoiceSS3(dsd_opts* opts, dsd_state* state) {
     dsd_output_s16_blocks(opts, state, stereo_blocks, 3, 160, 2, 0);
 
     if (opts->wav_out_f != NULL && opts->static_wav_file == 1) {
-        sf_write_short(opts->wav_out_f, stereo_samp1, 320);
-        sf_write_short(opts->wav_out_f, stereo_samp2, 320);
-        sf_write_short(opts->wav_out_f, stereo_samp3, 320);
+        dsd_audio2_write_wav_short_block(opts->wav_out_f, stereo_samp1, 320, "processAudioDMRstereo3v2 block1");
+        dsd_audio2_write_wav_short_block(opts->wav_out_f, stereo_samp2, 320, "processAudioDMRstereo3v2 block2");
+        dsd_audio2_write_wav_short_block(opts->wav_out_f, stereo_samp3, 320, "processAudioDMRstereo3v2 block3");
     }
 
 SS3_END:

--- a/src/core/audio/dsd_audio2_internal.h
+++ b/src/core/audio/dsd_audio2_internal.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: ISC
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+/*
+ * Internal audio2 helper declarations for production-local helpers that have
+ * focused regression tests. Production builds keep these helpers file-local;
+ * the helper test target overrides DSD_AUDIO2_INTERNAL to link them directly.
+ */
+
+#ifndef DSD_NEO_SRC_CORE_AUDIO_DSD_AUDIO2_INTERNAL_H
+#define DSD_NEO_SRC_CORE_AUDIO_DSD_AUDIO2_INTERNAL_H
+
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_fwd.h>
+
+#include <stddef.h>
+
+#ifndef DSD_AUDIO2_INTERNAL
+#define DSD_AUDIO2_INTERNAL static
+#endif
+
+DSD_AUDIO2_INTERNAL int dsd_p25_algid_is_encrypted(const dsd_state* state);
+DSD_AUDIO2_INTERNAL int dsd_p25_algid_can_decrypt(const dsd_state* state);
+DSD_AUDIO2_INTERNAL int dsd_nxdn_can_decrypt(const dsd_state* state);
+DSD_AUDIO2_INTERNAL int dsd_is_all_zero_s16(const short* buf, size_t n);
+
+DSD_AUDIO2_INTERNAL void dsd_output_float_block(dsd_opts* opts, dsd_state* state, const float* samples, size_t frames,
+                                                int channels);
+DSD_AUDIO2_INTERNAL void dsd_output_s16_block(dsd_opts* opts, dsd_state* state, const short* samples, size_t frames,
+                                              int channels);
+DSD_AUDIO2_INTERNAL void dsd_output_float_blocks(dsd_opts* opts, dsd_state* state, const float* const* blocks,
+                                                 size_t block_count, size_t frames, int channels, int skip_silent);
+DSD_AUDIO2_INTERNAL void dsd_output_s16_blocks(dsd_opts* opts, dsd_state* state, const short* const* blocks,
+                                               size_t block_count, size_t frames, int channels, int skip_silent);
+
+DSD_AUDIO2_INTERNAL void dsd_audio_maybe_reset_output_ring_left(dsd_state* state);
+DSD_AUDIO2_INTERNAL void dsd_audio_maybe_reset_output_ring_right(dsd_state* state);
+DSD_AUDIO2_INTERNAL void dsd_dmr_init_slot_mute_flags(const dsd_opts* opts, const dsd_state* state, int* encL,
+                                                      int* encR);
+DSD_AUDIO2_INTERNAL void dsd_duplicate_active_float_slot_to_stereo(float* a, float* b, float* c, int encL, int encR,
+                                                                   int* outL, int* outR);
+DSD_AUDIO2_INTERNAL void dsd_dmr_ss3_init_enc_flags(const dsd_state* state, int* encL, int* encR);
+DSD_AUDIO2_INTERNAL void dsd_dmr_apply_tg_hold_and_slot_preference_ss3(dsd_opts* opts, const dsd_state* state,
+                                                                       unsigned long TGL, unsigned long TGR, int* encL,
+                                                                       int* encR);
+DSD_AUDIO2_INTERNAL void dsd_dmr_apply_stereo_output_policy_ss3(const dsd_opts* opts, dsd_state* state, int encL,
+                                                                int encR);
+DSD_AUDIO2_INTERNAL int dsd_p25p2_encrypted_lockout_slot_muted(const dsd_opts* opts, const dsd_state* state, int slot,
+                                                               int muted);
+DSD_AUDIO2_INTERNAL void dsd_p25p2_apply_slot_preference_ss18(dsd_opts* opts, const dsd_state* state, unsigned long TGL,
+                                                              unsigned long TGR);
+DSD_AUDIO2_INTERNAL void dsd_p25p2_apply_stereo_output_policy_ss18(const dsd_opts* opts, dsd_state* state, int encL,
+                                                                   int encR);
+DSD_AUDIO2_INTERNAL void dsd_fs4_mix_mono_frames(float lf[4][160], float rf[4][160], int encL, int encR, int l_ok[4],
+                                                 int r_ok[4], float mono[4][160]);
+
+#endif // DSD_NEO_SRC_CORE_AUDIO_DSD_AUDIO2_INTERNAL_H

--- a/src/core/file/dsd_file.c
+++ b/src/core/file/dsd_file.c
@@ -1105,10 +1105,8 @@ parse_raw_user_string(const char* input, uint8_t* output, size_t out_cap) {
         return 0;
     }
 
-    // If odd number of nibbles, we will logically pad one nibble (shift last)
-    int shift = 0;
+    // If odd number of nibbles, logically pad the missing low nibble with zero.
     if (in_len & 1U) {
-        shift = 1;
         in_len++; // treat as if one extra nibble was provided
     }
 
@@ -1140,11 +1138,6 @@ parse_raw_user_string(const char* input, uint8_t* output, size_t out_cap) {
         // Parse two nibbles into a byte
         output[i] = hex_pair_to_u8_or_zero(octet_char);
         k += 2;
-    }
-
-    // If we had an odd input nibble count, left shift the last written octet
-    if (shift && want_octets > 0) {
-        output[want_octets - 1] <<= 4;
     }
 
     return (uint16_t)want_octets;

--- a/src/core/file/dsd_file.c
+++ b/src/core/file/dsd_file.c
@@ -453,11 +453,29 @@ openMbeInFile(dsd_opts* opts, dsd_state* state) {
     //debug
 
     // read cookie
-    cookie[0] = fgetc(opts->mbe_in_f);
-    cookie[1] = fgetc(opts->mbe_in_f);
-    cookie[2] = fgetc(opts->mbe_in_f);
-    cookie[3] = fgetc(opts->mbe_in_f);
+    int cookie_ok = 1;
+    for (size_t i = 0; i < 4U; i++) {
+        int c = fgetc(opts->mbe_in_f);
+        if (c == EOF) {
+            cookie_ok = 0;
+            cookie[i] = '\0';
+        } else {
+            cookie[i] = (char)c;
+        }
+    }
     cookie[4] = 0;
+
+    if (cookie_ok == 0) {
+        if (strncmp(".mbe", ext, 4) == 0) {
+            state->mbe_file_type = 3;
+            return;
+        }
+        state->mbe_file_type = -1;
+        LOG_ERROR("Error - incomplete MBE file header\n");
+        fclose(opts->mbe_in_f);
+        opts->mbe_in_f = NULL;
+        return;
+    }
 
     //ambe+2
     if (strstr(cookie, ".amb") != NULL) {

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -773,6 +773,8 @@ csv_chan_import_apply_field(dsd_state* state, int field_count, const char* field
         long int parsed_chan = 0;
         if (parse_dec_long_strict(field, &parsed_chan)) {
             *chan_number = parsed_chan;
+        } else {
+            *chan_number = -1;
         }
         return;
     }
@@ -780,11 +782,13 @@ csv_chan_import_apply_field(dsd_state* state, int field_count, const char* field
         return;
     }
 
-    if (*chan_number >= 0 && *chan_number < 0xFFFF) {
-        long int freq = 0;
-        if (parse_dec_long_strict(field, &freq)) {
-            dsd_state_set_trunk_chan_freq(state, (uint32_t)*chan_number, freq);
-        }
+    if (*chan_number < 0 || *chan_number >= 0xFFFF) {
+        return;
+    }
+
+    long int freq = 0;
+    if (parse_dec_long_strict(field, &freq)) {
+        dsd_state_set_trunk_chan_freq(state, (uint32_t)*chan_number, freq);
     }
 
     if (state->lcn_freq_count < 0
@@ -792,7 +796,6 @@ csv_chan_import_apply_field(dsd_state* state, int field_count, const char* field
         return;
     }
 
-    long int freq = 0;
     if (parse_dec_long_strict(field, &freq)) {
         state->trunk_lcn_freq[state->lcn_freq_count] = freq;
     } else {
@@ -868,6 +871,7 @@ csvChanImport(const dsd_opts* opts, dsd_state* state) //channel map import
 
     while (fgets(buffer, BSIZE, fp)) {
         int field_count = 0;
+        chan_number = -1;
         row_count++;
         if (row_count == 1) {
             continue; //don't want labels

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -867,7 +867,7 @@ csvChanImport(const dsd_opts* opts, dsd_state* state) //channel map import
     }
     int row_count = 0;
 
-    long int chan_number = 0;
+    long int chan_number;
 
     while (fgets(buffer, BSIZE, fp)) {
         int field_count = 0;

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -1664,25 +1664,39 @@ frame_sync_try_protocol_matches(frame_sync_match_ctx* ctx) {
     return frame_sync_try_provoice_conventional(ctx);
 }
 
+static time_t g_p25_trunk_tick_last_tick = 0;
+static time_t g_p25_trunk_tick_last_p25_seen = 0;
+
 static void
 frame_sync_maybe_tick_p25_trunk_sm(dsd_opts* opts, dsd_state* state, time_t now) {
-    static time_t last_tick = 0;
-    static time_t last_p25_seen = 0;
-    if (now == last_tick) {
+    if (now == g_p25_trunk_tick_last_tick) {
         return;
     }
 
     int p25_by_sync = DSD_SYNC_IS_P25(state->lastsynctype) ? 1 : 0;
     if (p25_by_sync) {
-        last_p25_seen = now;
+        g_p25_trunk_tick_last_p25_seen = now;
     }
-    int p25_recent = (last_p25_seen != 0 && (now - last_p25_seen) <= 3) ? 1 : 0;
+    int p25_recent = (g_p25_trunk_tick_last_p25_seen != 0 && (now - g_p25_trunk_tick_last_p25_seen) <= 3) ? 1 : 0;
     int p25_active = p25_by_sync || p25_recent || (state->p25_p2_active_slot != -1);
     if (opts->p25_trunk == 1 && p25_active) {
         dsd_frame_sync_hook_p25_sm_try_tick(opts, state);
     }
-    last_tick = now;
+    g_p25_trunk_tick_last_tick = now;
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_frame_sync_test_reset_p25_trunk_tick_state(void) {
+    g_p25_trunk_tick_last_tick = 0;
+    g_p25_trunk_tick_last_p25_seen = 0;
+}
+
+void
+dsd_frame_sync_test_maybe_tick_p25_trunk_sm(dsd_opts* opts, dsd_state* state, time_t now) {
+    frame_sync_maybe_tick_p25_trunk_sm(opts, state, now);
+}
+#endif
 
 static inline void
 frame_sync_apply_cli_mod_lock(const dsd_opts* opts, dsd_state* state) {
@@ -1903,6 +1917,33 @@ frame_sync_maybe_auto_switch_modulation(const dsd_opts* opts, dsd_state* state, 
     frame_sync_update_mod_votes(want_mod);
     frame_sync_apply_mod_switch(state, frame_sync_decide_mod_switch(state, want_mod));
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_frame_sync_test_set_recent_hamming(int ham_c4fm, int ham_qpsk, int ham_gfsk) {
+    atomic_store(&g_ham_c4fm_recent, ham_c4fm);
+    atomic_store(&g_ham_qpsk_recent, ham_qpsk);
+    atomic_store(&g_ham_gfsk_recent, ham_gfsk);
+}
+
+void
+dsd_frame_sync_test_get_mod_votes(int* out_c4fm, int* out_qpsk, int* out_gfsk) {
+    if (out_c4fm) {
+        *out_c4fm = atomic_load(&g_vote_c4fm);
+    }
+    if (out_qpsk) {
+        *out_qpsk = atomic_load(&g_vote_qpsk);
+    }
+    if (out_gfsk) {
+        *out_gfsk = atomic_load(&g_vote_gfsk);
+    }
+}
+
+void
+dsd_frame_sync_test_auto_switch_modulation(const dsd_opts* opts, dsd_state* state, int t_max, int* lastt) {
+    frame_sync_maybe_auto_switch_modulation(opts, state, t_max, lastt);
+}
+#endif
 
 static void
 frame_sync_debug_symbol_stats(const dsd_opts* opts, float symbol) {

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -221,6 +221,19 @@ rtl_levels_for_symbol_rate(const dsd_opts* opts, int sym_rate_hz, int preferred_
     return 4;
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_frame_sync_test_rtl_profile_for_symbol_rate(const dsd_opts* opts, const dsd_state* state, int sym_rate_hz,
+                                                int preferred_levels) {
+    return rtl_profile_for_symbol_rate(opts, state, sym_rate_hz, preferred_levels);
+}
+
+int
+dsd_frame_sync_test_rtl_levels_for_symbol_rate(const dsd_opts* opts, int sym_rate_hz, int preferred_levels) {
+    return rtl_levels_for_symbol_rate(opts, sym_rate_hz, preferred_levels);
+}
+#endif
+
 static void
 rtl_maybe_update_symbol_profile_with_hint(const dsd_opts* opts, const dsd_state* state, int sym_rate_hz,
                                           int preferred_levels) {
@@ -2260,7 +2273,7 @@ frame_sync_update_qpsk_hamming(const dsd_opts* opts, const char* synctest, const
 }
 
 static int
-frame_sync_best_ham_for_patterns(const char* symbols, const char* patterns[], int pattern_count, int pattern_len,
+frame_sync_best_ham_for_patterns(const char* symbols, const char* const patterns[], int pattern_count, int pattern_len,
                                  int best_start) {
     int best = best_start;
     for (int p = 0; p < pattern_count; p++) {
@@ -2286,6 +2299,30 @@ frame_sync_best_nxdn_scaled_ham(frame_sync_runtime_ctx* rt, int best_start) {
     }
     return best;
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_frame_sync_test_hamming_distance_pattern(const char* symbols, const char* pattern, int len) {
+    return frame_sync_hamming_distance_pattern(symbols, pattern, len);
+}
+
+int
+dsd_frame_sync_test_best_ham_for_patterns(const char* symbols, const char* const patterns[], int pattern_count,
+                                          int pattern_len, int best_start) {
+    return frame_sync_best_ham_for_patterns(symbols, patterns, pattern_count, pattern_len, best_start);
+}
+
+int
+dsd_frame_sync_test_best_nxdn_scaled_ham(const char* symbols10, int best_start) {
+    frame_sync_runtime_ctx rt;
+    DSD_MEMSET(&rt, 0, sizeof(rt));
+    if (symbols10) {
+        DSD_STRNCPY(rt.synctest_buf, symbols10, 10);
+    }
+    rt.synctest_p = rt.synctest_buf + 9;
+    return frame_sync_best_nxdn_scaled_ham(&rt, best_start);
+}
+#endif
 
 static void
 frame_sync_update_gfsk_hamming(const dsd_opts* opts, frame_sync_runtime_ctx* rt) {
@@ -2466,6 +2503,14 @@ frame_sync_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* state, con
     return next_idx;
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_frame_sync_test_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* state, const int* sym_rate_cycle,
+                                        const int* levels_cycle, int cycle_count) {
+    return frame_sync_sps_hunt_next_index(opts, state, sym_rate_cycle, levels_cycle, cycle_count);
+}
+#endif
+
 static void
 frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx, const int* sym_rate_cycle,
                                   const int* levels_cycle) {
@@ -2499,6 +2544,14 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
     }
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_frame_sync_test_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx,
+                                           const int* sym_rate_cycle, const int* levels_cycle) {
+    frame_sync_apply_sps_hunt_profile(opts, state, next_idx, sym_rate_cycle, levels_cycle);
+}
+#endif
+
 static void
 frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
     if (!(state->carrier == 0 && !opts->mod_cli_lock)) {
@@ -2528,6 +2581,13 @@ frame_sync_elapsed_seconds(double nowm, time_t now, double mono_stamp, time_t wa
     return 1e9;
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+double
+dsd_frame_sync_test_elapsed_seconds(double nowm, time_t now, double mono_stamp, time_t wall_stamp) {
+    return frame_sync_elapsed_seconds(nowm, now, mono_stamp, wall_stamp);
+}
+#endif
+
 static void
 frame_sync_p25_slot_activity(const dsd_opts* opts, const dsd_state* state, time_t now, double nowm, double mac_hold,
                              double ring_hold, double dt, int* left_active, int* right_active) {
@@ -2546,6 +2606,15 @@ frame_sync_p25_slot_activity(const dsd_opts* opts, const dsd_state* state, time_
     *left_active = left_has_audio || (l_dmac <= mac_hold);
     *right_active = right_has_audio || (r_dmac <= mac_hold);
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_frame_sync_test_p25_slot_activity(const dsd_opts* opts, const dsd_state* state, time_t now, double nowm,
+                                      double mac_hold, double ring_hold, double dt, int* left_active,
+                                      int* right_active) {
+    frame_sync_p25_slot_activity(opts, state, now, nowm, mac_hold, ring_hold, dt, left_active, right_active);
+}
+#endif
 
 static void
 frame_sync_no_sync_try_p25_release(dsd_opts* opts, dsd_state* state, time_t now) {

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -65,6 +65,22 @@
 extern dsd_socket_t Connect(char* hostname, int portno);
 extern void cleanupAndExit(dsd_opts* opts, dsd_state* state);
 
+#ifdef DSD_NEO_TEST_HOOKS
+// Test-hook entry points are intentionally externally visible to focused fixtures.
+// NOLINTBEGIN(misc-use-internal-linkage)
+void dsd_symbol_test_select_window(int rf_mod, int synctype, int lastsynctype, int freeze_window, int* l_edge,
+                                   int* r_edge);
+int dsd_symbol_test_adjust_timing_index(int samples_per_symbol, int symbol_center, int rf_mod, int jitter,
+                                        int have_sync, int symbol_span, int start_i, int* jitter_after);
+int dsd_symbol_test_is_m17_sync(int lastsynctype);
+unsigned int dsd_symbol_test_convert_analog_block_to_i16(const float* input, short* output, unsigned int count);
+#ifdef USE_RADIO
+int dsd_symbol_test_rtl_cache_and_center_contract(int out_values[10]);
+int dsd_symbol_test_auto_center_step_direction(int e_ema, int deadband, int* run_dir, int* run_len, int* dir_out);
+#endif
+// NOLINTEND(misc-use-internal-linkage)
+#endif
+
 static inline short
 float_to_int16_clip(float v) {
     if (v > 32767.0f) {
@@ -74,6 +90,17 @@ float_to_int16_clip(float v) {
         return -32768;
     }
     return (short)lrintf(v);
+}
+
+static inline void
+symbol_write_wav_short_block(SNDFILE* file, const short* samples, sf_count_t sample_count, const char* context) {
+    if (file == NULL || samples == NULL || sample_count <= 0) {
+        return;
+    }
+    sf_count_t written = sf_write_short(file, samples, sample_count);
+    if (written != sample_count) {
+        LOG_WARN("%s: wrote %lld/%lld samples to WAV output\n", context, (long long)written, (long long)sample_count);
+    }
 }
 
 static int16_t
@@ -199,6 +226,7 @@ clamp_symbol_center_to_margin(int* center, int samples_per_symbol) {
         *center = max_c;
     }
 }
+
 #endif
 
 typedef struct {
@@ -469,6 +497,49 @@ symbol_adjust_timing_index(dsd_state* state, int have_sync, int symbol_span, int
     }
     state->jitter = -1;
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_symbol_test_select_window(int rf_mod, int synctype, int lastsynctype, int freeze_window, int* l_edge, int* r_edge) {
+    if (!l_edge || !r_edge) {
+        return;
+    }
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.rf_mod = rf_mod;
+    state.synctype = synctype;
+    state.lastsynctype = lastsynctype;
+    if (rf_mod == 0) {
+        select_window_c4fm(&state, l_edge, r_edge, freeze_window);
+    } else if (rf_mod == 1) {
+        select_window_qpsk(l_edge, r_edge, freeze_window);
+    } else {
+        select_window_gfsk(l_edge, r_edge, freeze_window);
+    }
+}
+
+int
+dsd_symbol_test_adjust_timing_index(int samples_per_symbol, int symbol_center, int rf_mod, int jitter, int have_sync,
+                                    int symbol_span, int start_i, int* jitter_after) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.samplesPerSymbol = samples_per_symbol;
+    state.symbolCenter = symbol_center;
+    state.rf_mod = rf_mod;
+    state.jitter = jitter;
+    int i = start_i;
+    symbol_adjust_timing_index(&state, have_sync, symbol_span, &i);
+    if (jitter_after) {
+        *jitter_after = state.jitter;
+    }
+    return i;
+}
+
+int
+dsd_symbol_test_is_m17_sync(int lastsynctype) {
+    return symbol_is_m17_sync(lastsynctype);
+}
+#endif
 
 #ifdef USE_RADIO
 /*
@@ -754,6 +825,50 @@ rtl_symbol_cache_clear(dsd_state* state) {
     state->rtl_symbol_cache_generation = 0;
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_symbol_test_auto_center_step_direction(int e_ema, int deadband, int* run_dir, int* run_len, int* dir_out) {
+    if (!run_dir || !run_len || !dir_out) {
+        return 0;
+    }
+    return maybe_auto_center_step_direction(e_ema, deadband, run_dir, run_len, dir_out);
+}
+
+int
+dsd_symbol_test_rtl_cache_and_center_contract(int out_values[10]) {
+    if (!out_values) {
+        return 0;
+    }
+
+    int center = -5;
+    clamp_symbol_center_to_margin(&center, 10);
+    out_values[0] = center;
+    center = 99;
+    clamp_symbol_center_to_margin(&center, 10);
+    out_values[1] = center;
+
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    out_values[2] = rtl_symbol_cache_profile(&state, RTL_STREAM_OUTPUT_SYMBOL_CQPSK_LOCAL, 3, 4800, 4, 0U);
+    out_values[3] = rtl_symbol_cache_profile(&state, RTL_STREAM_OUTPUT_SYMBOL_CQPSK_LOCAL, 3, 4800, 4, 0U);
+    out_values[4] = state.rtl_symbol_cache_output_kind;
+    out_values[5] = state.rtl_symbol_cache_symbol_rate_hz;
+
+    state.rtl_symbol_cache[0] = 1.25f;
+    state.rtl_symbol_cache[1] = -2.5f;
+    state.rtl_symbol_cache_len = 2;
+    state.rtl_symbol_cache_pos = 0;
+    state.rtl_symbol_cache_generation = 0U;
+    float sample = 0.0f;
+    out_values[6] = rtl_symbol_cache_pop(&state, 0U, &sample);
+    out_values[7] = (int)lrintf(sample * 100.0f);
+    out_values[8] = state.rtl_symbol_cache_pos;
+    rtl_symbol_cache_clear(&state);
+    out_values[9] = state.rtl_symbol_cache_len + state.rtl_symbol_cache_output_kind + state.rtl_symbol_cache_levels;
+    return 10;
+}
+#endif
+
 static int
 rtl_symbol_cache_refill(dsd_state* state, int output_kind, int channel_profile, int symbol_rate_hz, int levels,
                         uint32_t* generation, uint32_t expected_generation, float* sample_out) {
@@ -862,6 +977,27 @@ symbol_convert_analog_block_to_i16(dsd_state* state, unsigned int analog_block) 
     }
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+unsigned int
+dsd_symbol_test_convert_analog_block_to_i16(const float* input, short* output, unsigned int count) {
+    if (!input || !output) {
+        return 0U;
+    }
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    unsigned int cap = (unsigned int)(sizeof(state.analog_out_f) / sizeof(state.analog_out_f[0]));
+    unsigned int n = count < cap ? count : cap;
+    for (unsigned int i = 0; i < n; i++) {
+        state.analog_out_f[i] = input[i];
+    }
+    symbol_convert_analog_block_to_i16(&state, n);
+    for (unsigned int i = 0; i < n; i++) {
+        output[i] = state.analog_out[i];
+    }
+    return n;
+}
+#endif
+
 static inline void
 symbol_update_unsynced_input_power(dsd_opts* opts, dsd_state* state, unsigned int analog_block) {
     if (opts->audio_in_type == AUDIO_IN_RTL) {
@@ -880,7 +1016,7 @@ symbol_write_unsynced_raw_wav(dsd_opts* opts, dsd_state* state, unsigned int ana
     if (opts->wav_out_raw != NULL && opts->frame_nxdn48 == 0 && opts->frame_nxdn96 == 0 && opts->frame_dpmr == 0
         && opts->frame_m17 == 0) {
         symbol_convert_analog_block_to_i16(state, analog_block);
-        sf_write_short(opts->wav_out_raw, state->analog_out, analog_block);
+        symbol_write_wav_short_block(opts->wav_out_raw, state->analog_out, analog_block, "symbol raw WAV");
         sf_write_sync(opts->wav_out_raw);
     }
 }
@@ -967,7 +1103,7 @@ symbol_process_synced_analog(dsd_opts* opts, dsd_state* state, unsigned int anal
     if ((unsigned int)state->analog_sample_counter == analog_out_cap) {
         if (opts->wav_out_raw != NULL) {
             symbol_convert_analog_block_to_i16(state, analog_out_cap);
-            sf_write_short(opts->wav_out_raw, state->analog_out, analog_out_cap);
+            symbol_write_wav_short_block(opts->wav_out_raw, state->analog_out, analog_out_cap, "symbol raw WAV");
             sf_write_sync(opts->wav_out_raw);
         }
         symbol_reset_analog_buffers(state);

--- a/src/dsp/simd_widen.cpp
+++ b/src/dsp/simd_widen.cpp
@@ -82,6 +82,10 @@ extern "C" uint32_t widen_rotate90_u8_to_f32_bias127_phase_neon(const unsigned c
 
 static uint32_t widen_rotate90_u8_to_f32_bias127_phase_scalar(const unsigned char* src, float* dst, uint32_t len,
                                                               uint32_t phase);
+#ifdef DSD_NEO_TEST_HOOKS
+extern "C" uint32_t dsd_test_widen_rotate90_u8_to_f32_bias127_phase_scalar(const unsigned char* src, float* dst,
+                                                                           uint32_t len, uint32_t phase);
+#endif
 
 static widen_rot_phase_fn g_widen_rot_phase_impl = widen_rotate90_u8_to_f32_bias127_phase_scalar;
 static std::atomic<int> g_widen_init_done{0};
@@ -155,6 +159,14 @@ widen_rotate90_u8_to_f32_bias127_phase_scalar(const unsigned char* src, float* d
 
     return cur_phase;
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+extern "C" uint32_t
+dsd_test_widen_rotate90_u8_to_f32_bias127_phase_scalar(const unsigned char* src, float* dst, uint32_t len,
+                                                       uint32_t phase) {
+    return widen_rotate90_u8_to_f32_bias127_phase_scalar(src, dst, len, phase);
+}
+#endif
 
 uint32_t
 widen_rotate90_u8_to_f32_bias127_phase(const unsigned char* src, float* dst, uint32_t len, uint32_t phase) {

--- a/src/io/control/dsd_rigctl.c
+++ b/src/io/control/dsd_rigctl.c
@@ -62,6 +62,13 @@ static bool DSD_ATTR_UNUSED_FN GetSquelchLevel(dsd_socket_t sockfd, double* dB);
 static bool DSD_ATTR_UNUSED_FN SetSquelchLevel(dsd_socket_t sockfd, double dB);
 static bool DSD_ATTR_UNUSED_FN GetSignalLevelEx(dsd_socket_t sockfd, double* dB, int n_samp);
 static void DSD_ATTR_UNUSED_FN rtl_udp_tune(dsd_opts* opts, dsd_state* state, long int frequency);
+#if defined(DSD_NEO_TEST_HOOKS)
+bool dsd_rigctl_test_get_signal_level(dsd_socket_t sockfd, double* dB);
+bool dsd_rigctl_test_get_squelch_level(dsd_socket_t sockfd, double* dB);
+bool dsd_rigctl_test_set_squelch_level(dsd_socket_t sockfd, double dB);
+bool dsd_rigctl_test_get_signal_level_ex(dsd_socket_t sockfd, double* dB, int n_samp);
+void dsd_rigctl_test_rtl_udp_tune(dsd_opts* opts, dsd_state* state, long int frequency);
+#endif
 
 static bool
 parse_double_strict(const char* input, double* out) {
@@ -401,6 +408,28 @@ GetSignalLevelEx(dsd_socket_t sockfd, double* dB, int n_samp) {
     return true;
 }
 
+#if defined(DSD_NEO_TEST_HOOKS)
+bool
+dsd_rigctl_test_get_signal_level(dsd_socket_t sockfd, double* dB) {
+    return GetSignalLevel(sockfd, dB);
+}
+
+bool
+dsd_rigctl_test_get_squelch_level(dsd_socket_t sockfd, double* dB) {
+    return GetSquelchLevel(sockfd, dB);
+}
+
+bool
+dsd_rigctl_test_set_squelch_level(dsd_socket_t sockfd, double dB) {
+    return SetSquelchLevel(sockfd, dB);
+}
+
+bool
+dsd_rigctl_test_get_signal_level_ex(dsd_socket_t sockfd, double* dB, int n_samp) {
+    return GetSignalLevelEx(sockfd, dB, n_samp);
+}
+#endif
+
 //going to leave this function available, even if completely switched over to rtl_dev_tune now, may be useful in the future
 /**
  * @brief Tune RTL devices via legacy UDP command flow.
@@ -446,6 +475,13 @@ rtl_udp_tune(dsd_opts* opts, dsd_state* state, long int frequency) {
     dsd_socket_close(handle); //close socket after sending.
     s_last_udp_freq = frequency;
 }
+
+#if defined(DSD_NEO_TEST_HOOKS)
+void
+dsd_rigctl_test_rtl_udp_tune(dsd_opts* opts, dsd_state* state, long int frequency) {
+    rtl_udp_tune(opts, state, frequency);
+}
+#endif
 
 /**
  * @brief Set tuner frequency via io/control API (simple tune without trunking bookkeeping).

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -47,6 +47,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <string>
+#include <vector>
 #if !DSD_PLATFORM_WIN_NATIVE
 #include <sys/socket.h>
 #endif
@@ -917,6 +918,18 @@ rtl_prepare_replay_input_level_snapshot(const struct rtl_device* s, const uint8_
     }
     if (s->replay_cfg.format == DSD_IQ_FORMAT_CU8) {
         return dsd_input_level_metrics_from_cu8(raw_block, raw_bytes, rtl_u8_input_level_source(s), out);
+    }
+    if (s->replay_cfg.format == DSD_IQ_FORMAT_CS16) {
+        if ((raw_bytes & 3U) != 0U) {
+            return -1;
+        }
+        size_t sample_count = raw_bytes / sizeof(int16_t);
+        if (sample_count == 0U) {
+            return -1;
+        }
+        std::vector<int16_t> samples(sample_count);
+        DSD_MEMCPY(samples.data(), raw_block, sample_count * sizeof(int16_t));
+        return dsd_input_level_metrics_from_cs16(samples.data(), sample_count, DSD_INPUT_LEVEL_SOURCE_SOAPY_CS16, out);
     }
     if (s->replay_cfg.format == DSD_IQ_FORMAT_CF32) {
         if (!scratch_f32 || (raw_bytes & 7U) != 0U
@@ -1890,6 +1903,10 @@ rtl_device_test_replay_input_level_snapshot(int format, int backend, const char*
     }
     if (format == DSD_IQ_FORMAT_CF32) {
         const float samples[] = {0.25f, -0.25f, 0.50f, -0.50f};
+        size_t copy_bytes = raw_bytes < sizeof(samples) ? raw_bytes : sizeof(samples);
+        DSD_MEMCPY(raw, samples, copy_bytes);
+    } else if (format == DSD_IQ_FORMAT_CS16) {
+        const int16_t samples[] = {8192, -8192, 16384, -16384};
         size_t copy_bytes = raw_bytes < sizeof(samples) ? raw_bytes : sizeof(samples);
         DSD_MEMCPY(raw, samples, copy_bytes);
     }

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <cinttypes>
 #include <cmath>
 #include <dsd-neo/core/constants.h>
@@ -45,6 +46,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <string>
 #if !DSD_PLATFORM_WIN_NATIVE
 #include <sys/socket.h>
 #endif
@@ -77,10 +79,8 @@ enum : unsigned char {
 #include <SoapySDR/Errors.hpp>
 #include <SoapySDR/Formats.h>
 #include <SoapySDR/Types.hpp>
-#include <cctype>
 #include <complex>
 #include <exception>
-#include <string>
 #include <vector>
 
 namespace SoapySDR {
@@ -1870,6 +1870,37 @@ rtl_device_test_replay_dispatch_reset_event_state(int* phase, int* have_carry, u
     uint64_t complex_written = 0;
     replay_dispatch_event(&dev, &event, phase, have_carry, carry_byte, &complex_written);
 }
+
+extern "C" int
+rtl_device_test_replay_input_level_snapshot(int format, int backend, const char* capture_stage, size_t raw_bytes,
+                                            size_t scratch_cap_f32, int* out_rc, int* out_source, uint64_t* out_count) {
+    if (!out_rc || !out_source || !out_count || raw_bytes > 32U || scratch_cap_f32 > 8U) {
+        return -1;
+    }
+
+    rtl_device dev{};
+    dev.backend = backend;
+    dev.replay_cfg.format = (dsd_iq_sample_format)format;
+    DSD_SNPRINTF(dev.replay_cfg.capture_stage, sizeof(dev.replay_cfg.capture_stage), "%s",
+                 capture_stage ? capture_stage : "");
+
+    uint8_t raw[32] = {};
+    for (size_t i = 0U; i < sizeof(raw); i++) {
+        raw[i] = (i & 1U) ? 136U : 119U;
+    }
+    if (format == DSD_IQ_FORMAT_CF32) {
+        const float samples[] = {0.25f, -0.25f, 0.50f, -0.50f};
+        size_t copy_bytes = raw_bytes < sizeof(samples) ? raw_bytes : sizeof(samples);
+        DSD_MEMCPY(raw, samples, copy_bytes);
+    }
+
+    float scratch[8] = {};
+    dsd_input_level_snapshot snapshot{};
+    *out_rc = rtl_prepare_replay_input_level_snapshot(&dev, raw, raw_bytes, scratch, scratch_cap_f32, &snapshot);
+    *out_source = (*out_rc == 0) ? (int)snapshot.source : -1;
+    *out_count = (*out_rc == 0) ? snapshot.sample_count : 0U;
+    return 0;
+}
 #endif
 
 static void
@@ -2049,6 +2080,70 @@ replay_convert_block_to_f32(const struct rtl_device* s, const uint8_t* raw_block
     }
     return -1;
 }
+
+#ifdef DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS
+// Internal test hooks use a pointer-shaped C ABI; the request layout is mirrored by the test TU.
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+struct rtl_device_test_replay_convert_block_request {
+    int format;
+    const char* capture_stage;
+    int fs4_shift_enabled;
+    int combine_rotate_enabled;
+    const uint8_t* raw_block;
+    size_t raw_bytes;
+    size_t out_cap_f32;
+    int start_phase;
+    int start_have_carry;
+    uint8_t start_carry_byte;
+};
+
+static int
+rtl_device_test_replay_convert_block_request_valid(const rtl_device_test_replay_convert_block_request* request,
+                                                   const float* out_f32, size_t out_f32_count, const int* out_phase,
+                                                   const int* out_have_carry, const uint8_t* out_carry_byte) {
+    return request && request->raw_block && out_f32 && out_phase && out_have_carry && out_carry_byte
+           && request->raw_bytes <= 32U && request->out_cap_f32 <= out_f32_count;
+}
+
+static size_t
+rtl_device_test_replay_convert_copy_count(int rc, size_t out_f32_count, size_t scratch_count) {
+    size_t copy_count = (rc > 0 && (size_t)rc < out_f32_count) ? (size_t)rc : out_f32_count;
+    return (copy_count > scratch_count) ? scratch_count : copy_count;
+}
+
+extern "C" int
+rtl_device_test_replay_convert_block(const rtl_device_test_replay_convert_block_request* request, float* out_f32,
+                                     size_t out_f32_count, int* out_phase, int* out_have_carry,
+                                     uint8_t* out_carry_byte) {
+    if (!rtl_device_test_replay_convert_block_request_valid(request, out_f32, out_f32_count, out_phase, out_have_carry,
+                                                            out_carry_byte)) {
+        return -1;
+    }
+
+    rtl_device dev{};
+    dev.backend = RTL_BACKEND_IQ_REPLAY;
+    dev.replay_cfg.format = (dsd_iq_sample_format)request->format;
+    dev.replay_cfg.fs4_shift_enabled = request->fs4_shift_enabled ? 1 : 0;
+    dev.replay_fs4_shift_enabled = request->fs4_shift_enabled ? 1 : 0;
+    dev.replay_combine_rotate_enabled = request->combine_rotate_enabled ? 1 : 0;
+    DSD_SNPRINTF(dev.replay_cfg.capture_stage, sizeof(dev.replay_cfg.capture_stage), "%s",
+                 request->capture_stage ? request->capture_stage : "");
+
+    float scratch[8] = {};
+    int phase = request->start_phase;
+    int have_carry = request->start_have_carry;
+    uint8_t carry_byte = request->start_carry_byte;
+    int rc = replay_convert_block_to_f32(&dev, request->raw_block, request->raw_bytes, scratch, request->out_cap_f32,
+                                         &phase, &have_carry, &carry_byte);
+    size_t copy_count =
+        rtl_device_test_replay_convert_copy_count(rc, out_f32_count, sizeof(scratch) / sizeof(scratch[0]));
+    DSD_MEMCPY(out_f32, scratch, copy_count * sizeof(float));
+    *out_phase = phase;
+    *out_have_carry = have_carry;
+    *out_carry_byte = carry_byte;
+    return rc;
+}
+#endif
 
 static DSD_THREAD_RETURN_TYPE
 #if DSD_PLATFORM_WIN_NATIVE
@@ -2243,6 +2338,19 @@ rtl_soapy_config_field_available(const struct rtl_soapy_config* cfg, size_t conf
     rtl_soapy_config_field_available((cfg), (config_size), offsetof(struct rtl_soapy_config, field),                   \
                                      sizeof(((struct rtl_soapy_config*)0)->field))
 
+static std::string
+soapy_trim_copy(const std::string& value) {
+    size_t start = 0;
+    while (start < value.size() && std::isspace((unsigned char)value[start])) {
+        start++;
+    }
+    size_t end = value.size();
+    while (end > start && std::isspace((unsigned char)value[end - 1])) {
+        end--;
+    }
+    return value.substr(start, end - start);
+}
+
 #ifdef USE_SOAPYSDR
 template <typename Fn>
 static int
@@ -2400,19 +2508,6 @@ soapy_log_capability_summary_locked(struct rtl_device* dev) {
         dev->soapy_native_stream_format[0] ? dev->soapy_native_stream_format : "-",
         dsdneo::soapy_join_names(formats, 120).c_str(), dsdneo::soapy_join_names(gains, 120).c_str(),
         dsdneo::soapy_join_names(antennas, 80).c_str(), dsdneo::soapy_join_names(clocks, 80).c_str());
-}
-
-static std::string
-soapy_trim_copy(const std::string& value) {
-    size_t start = 0;
-    while (start < value.size() && isspace((unsigned char)value[start])) {
-        start++;
-    }
-    size_t end = value.size();
-    while (end > start && isspace((unsigned char)value[end - 1])) {
-        end--;
-    }
-    return value.substr(start, end - start);
 }
 
 static int
@@ -3180,6 +3275,35 @@ rtl_tcp_round_up_page(size_t n) {
     return (n + 4095U) & ~((size_t)4095U);
 }
 
+#ifdef DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS
+extern "C" int
+rtl_device_test_misc_string_helpers(char* tuner_labels, size_t tuner_labels_size, char* reason_small,
+                                    size_t reason_small_size, char* reason_null, size_t reason_null_size, char* trimmed,
+                                    size_t trimmed_size, size_t* rounded_pages, size_t rounded_pages_len) {
+    if (!tuner_labels || tuner_labels_size == 0U || !reason_small || reason_small_size == 0U || !reason_null
+        || reason_null_size == 0U || !trimmed || trimmed_size == 0U || !rounded_pages || rounded_pages_len < 4U) {
+        return -1;
+    }
+
+    DSD_SNPRINTF(tuner_labels, tuner_labels_size, "%s|%s|%s|%s|%s|%s|%s", rtl_tuner_type_name(RTLSDR_TUNER_E4000),
+                 rtl_tuner_type_name(RTLSDR_TUNER_FC0012), rtl_tuner_type_name(RTLSDR_TUNER_FC0013),
+                 rtl_tuner_type_name(RTLSDR_TUNER_FC2580), rtl_tuner_type_name(RTLSDR_TUNER_R820T),
+                 rtl_tuner_type_name(RTLSDR_TUNER_R828D), rtl_tuner_type_name(-1));
+
+    rtl_copy_event_reason(reason_small, reason_small_size, "capture-reconfigure");
+    rtl_copy_event_reason(reason_null, reason_null_size, NULL);
+
+    std::string t = soapy_trim_copy(" \t gain = 12.5 \n");
+    DSD_SNPRINTF(trimmed, trimmed_size, "%s", t.c_str());
+
+    rounded_pages[0] = rtl_tcp_round_up_page(0U);
+    rounded_pages[1] = rtl_tcp_round_up_page(1U);
+    rounded_pages[2] = rtl_tcp_round_up_page(4096U);
+    rounded_pages[3] = rtl_tcp_round_up_page(4097U);
+    return 0;
+}
+#endif
+
 static size_t
 rtl_tcp_default_bufsz(const struct rtl_device* s) {
     if (!s) {
@@ -3656,6 +3780,53 @@ static inline uint64_t
 rtl_tcp_counter_delta(uint64_t now, uint64_t prev) {
     return (now >= prev) ? (now - prev) : 0ULL;
 }
+
+#ifdef DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS
+extern "C" int
+rtl_device_test_tcp_policy_helpers(size_t* bufsz_out, size_t bufsz_count, int* waitall_out, size_t waitall_count,
+                                   uint64_t* delta_out, size_t delta_count, int* agc_out) {
+    if (!bufsz_out || bufsz_count < 8U || !waitall_out || waitall_count < 4U || !delta_out || delta_count < 2U
+        || !agc_out) {
+        return -1;
+    }
+
+    rtl_device dev{};
+    dsdneoRuntimeConfig cfg{};
+
+    bufsz_out[0] = rtl_tcp_default_bufsz(NULL);
+    dev.backend = RTL_BACKEND_TCP;
+    bufsz_out[1] = rtl_tcp_default_bufsz(&dev);
+    dev.backend = RTL_BACKEND_USB;
+    dev.rate = 0U;
+    bufsz_out[2] = rtl_tcp_default_bufsz(&dev);
+    dev.rate = 48000U;
+    bufsz_out[3] = rtl_tcp_default_bufsz(&dev);
+    dev.rate = 960000U;
+    bufsz_out[4] = rtl_tcp_default_bufsz(&dev);
+    dev.rate = 10000000U;
+    bufsz_out[5] = rtl_tcp_default_bufsz(&dev);
+    cfg.tcp_bufsz_is_set = 1;
+    cfg.tcp_bufsz_bytes = 12345;
+    bufsz_out[6] = rtl_tcp_cfg_bufsz(&dev, &cfg);
+    cfg.tcp_bufsz_bytes = 0;
+    bufsz_out[7] = rtl_tcp_cfg_bufsz(&dev, &cfg);
+
+    waitall_out[0] = rtl_tcp_cfg_waitall(NULL, NULL);
+    dev.backend = RTL_BACKEND_TCP;
+    waitall_out[1] = rtl_tcp_cfg_waitall(&dev, NULL);
+    cfg = {};
+    cfg.tcp_waitall_is_set = 1;
+    cfg.tcp_waitall_enable = 1;
+    waitall_out[2] = rtl_tcp_cfg_waitall(&dev, &cfg);
+    cfg.tcp_waitall_enable = 0;
+    waitall_out[3] = rtl_tcp_cfg_waitall(&dev, &cfg);
+
+    delta_out[0] = rtl_tcp_counter_delta(100U, 40U);
+    delta_out[1] = rtl_tcp_counter_delta(40U, 100U);
+    *agc_out = env_agc_want();
+    return 0;
+}
+#endif
 
 static inline void
 rtl_tcp_autotune_on_overflow(struct rtl_tcp_loop_state* st) {
@@ -6174,6 +6345,103 @@ rtl_device_test_usb_reconfigure_discards_samples(size_t input_bytes, size_t* out
 }
 
 extern "C" int
+rtl_device_test_u8_odd_carry_bridge(size_t* out_used, int* out_phase, int* out_carry_valid, uint8_t* out_carry_byte,
+                                    int* out_first_status, int* out_second_status) {
+    if (!out_used || !out_phase || !out_carry_valid || !out_carry_byte || !out_first_status || !out_second_status) {
+        return -1;
+    }
+    input_ring_state ring{};
+    if (input_ring_init(&ring, 16U) != 0) {
+        return -2;
+    }
+
+    rtl_device dev{};
+    dev.input_ring = &ring;
+    dev.backend = RTL_BACKEND_IQ_REPLAY;
+    dev.replay_fs4_shift_enabled = 1;
+    dev.replay_combine_rotate_enabled = 1;
+    dev.rot_phase = 0;
+
+    unsigned char first[] = {129U};
+    unsigned char second[] = {128U, 126U};
+    *out_first_status = rtl_write_u8_to_ring(&dev, first, sizeof(first), 1, 0, 1, 0);
+    *out_second_status = rtl_write_u8_to_ring(&dev, second, sizeof(second), 1, 0, 1, 0);
+    *out_used = input_ring_used(&ring);
+    *out_phase = dev.rot_phase;
+    *out_carry_valid = dev.iq_byte_carry.valid ? 1 : 0;
+    *out_carry_byte = dev.iq_byte_carry.byte;
+
+    input_ring_destroy(&ring);
+    return 0;
+}
+
+extern "C" int
+rtl_device_test_u8_full_ring_drop(size_t* out_used, uint64_t* out_drops, uint64_t* out_full_events, int* out_phase,
+                                  int* out_status) {
+    if (!out_used || !out_drops || !out_full_events || !out_phase || !out_status) {
+        return -1;
+    }
+    input_ring_state ring{};
+    if (input_ring_init(&ring, 3U) != 0) {
+        return -2;
+    }
+
+    rtl_device dev{};
+    dev.input_ring = &ring;
+    dev.backend = RTL_BACKEND_USB;
+    dev.offset_tuning = 0;
+    dev.combine_rotate_enabled = 0;
+    dev.rot_phase = 0;
+
+    unsigned char input[] = {130U, 127U, 129U, 126U, 128U, 125U};
+    *out_status = rtl_write_u8_to_ring(&dev, input, sizeof(input), 1, 1, 0, 1);
+    *out_used = input_ring_used(&ring);
+    *out_drops = ring.producer_drops.load(std::memory_order_acquire);
+    *out_full_events = dev.reserve_full_events;
+    *out_phase = dev.rot_phase;
+
+    input_ring_destroy(&ring);
+    return 0;
+}
+
+extern "C" int
+rtl_device_test_u8_generation_stale_drop(uint64_t* out_drops, int* out_phase, int* out_dev_carry_valid,
+                                         int* out_local_carry_valid, int* out_status) {
+    if (!out_drops || !out_phase || !out_dev_carry_valid || !out_local_carry_valid || !out_status) {
+        return -1;
+    }
+    input_ring_state ring{};
+    if (input_ring_init(&ring, 8U) != 0) {
+        return -2;
+    }
+
+    rtl_device dev{};
+    dev.input_ring = &ring;
+    dev.backend = RTL_BACKEND_USB;
+    dev.rot_phase = 3;
+    rtl_capture_u8_byte_carry_save(&dev.iq_byte_carry, 200U);
+
+    unsigned char input[] = {120U, 121U, 122U, 123U, 124U};
+    rtl_capture_u8_byte_carry carry = dev.iq_byte_carry;
+    int phase = dev.rot_phase;
+    size_t done = 1U;
+    size_t need = 4U;
+    size_t produced = 2U;
+    *out_status = rtl_handle_u8_ring_generation_stale(&dev, input, done, need, &carry, &phase, 1, produced);
+
+    rtl_u8_finalize_state final_state = {input, sizeof(input), done, need, &carry, &phase, 1, 0, 0, 1};
+    rtl_finalize_u8_ring_write(&dev, &final_state);
+
+    *out_drops = ring.producer_drops.load(std::memory_order_acquire);
+    *out_phase = phase;
+    *out_dev_carry_valid = dev.iq_byte_carry.valid ? 1 : 0;
+    *out_local_carry_valid = carry.valid ? 1 : 0;
+
+    input_ring_destroy(&ring);
+    return 0;
+}
+
+extern "C" int
 rtl_device_test_soapy_config_settings_visibility(size_t config_size, const char* settings, int* out_seen) {
     if (!out_seen) {
         return -1;
@@ -6277,3 +6545,47 @@ rtl_device_get_tcp_quality_snapshot(struct rtl_device* dev, struct tcp_quality_s
     rtl_tcp_metrics_unlock(dev);
     return 0;
 }
+
+#ifdef DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS
+extern "C" int
+rtl_device_test_public_capture_policy(int* out_formats, size_t out_formats_len, uint32_t* out_counts,
+                                      size_t out_counts_len) {
+    if (!out_formats || out_formats_len < 8U || !out_counts || out_counts_len < 5U) {
+        return -1;
+    }
+
+    rtl_device dev{};
+
+    out_formats[0] = rtl_device_get_native_sample_format(NULL);
+    dev.backend = RTL_BACKEND_USB;
+    out_formats[1] = rtl_device_get_native_sample_format(&dev);
+    dev.backend = RTL_BACKEND_TCP;
+    out_formats[2] = rtl_device_get_native_sample_format(&dev);
+    dev.backend = RTL_BACKEND_SOAPY;
+    dev.soapy_format = SOAPY_FMT_CF32;
+    out_formats[3] = rtl_device_get_native_sample_format(&dev);
+    dev.soapy_format = SOAPY_FMT_CS16;
+    out_formats[4] = rtl_device_get_native_sample_format(&dev);
+    dev.soapy_format = SOAPY_FMT_NONE;
+    out_formats[5] = rtl_device_get_native_sample_format(&dev);
+    dev.backend = RTL_BACKEND_IQ_REPLAY;
+    dev.replay_cfg.format = DSD_IQ_FORMAT_CS16;
+    out_formats[6] = rtl_device_get_native_sample_format(&dev);
+    dev.backend = 99;
+    out_formats[7] = rtl_device_get_native_sample_format(&dev);
+
+    out_counts[0] = rtl_device_get_capture_retune_count(NULL);
+    out_counts[1] = rtl_device_get_capture_retune_count(&dev);
+    rtl_device_note_capture_retune(&dev);
+    out_counts[2] = rtl_device_get_capture_retune_count(&dev);
+    // Opaque non-null sentinel used only to exercise pointer-presence accounting.
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    rtl_device_set_iq_capture_writer(&dev, reinterpret_cast<dsd_iq_capture_writer*>(static_cast<uintptr_t>(1U)));
+    rtl_device_note_capture_retune(&dev);
+    rtl_device_note_capture_retune(&dev);
+    out_counts[3] = rtl_device_get_capture_retune_count(&dev);
+    rtl_device_set_iq_capture_writer(&dev, NULL);
+    out_counts[4] = rtl_device_get_capture_retune_count(&dev);
+    return 0;
+}
+#endif

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -82,7 +82,6 @@ enum : unsigned char {
 #include <SoapySDR/Types.hpp>
 #include <complex>
 #include <exception>
-#include <vector>
 
 namespace SoapySDR {
 class Stream;

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -8405,7 +8405,8 @@ rtl_stream_test_source_policy_matrix(int* out_kind, int* out_rtltcp, int* out_so
         "rtl:0"};
 
     struct RtlSdrInternals* prev_stream = g_stream;
-    struct RtlSdrInternals test_stream = {};
+    static RtlSdrInternals test_stream;
+    DSD_MEMSET(&test_stream, 0, sizeof(test_stream));
     static dsd_opts opts;
     DSD_MEMSET(&opts, 0, sizeof(opts));
     test_stream.opts = &opts;
@@ -8527,7 +8528,8 @@ rtl_stream_test_fsk_profile_policy_matrix(int* out_profiles, size_t count) {
     out_profiles[17] = rtl_stream_fsk_profile_for_symbol_rate(1200, 4);
 
     struct RtlSdrInternals* prev_stream = g_stream;
-    struct RtlSdrInternals test_stream = {};
+    static RtlSdrInternals test_stream;
+    DSD_MEMSET(&test_stream, 0, sizeof(test_stream));
     int prev_symbol_rate = demod.symbol_rate_hz;
     int prev_symbol_levels = demod.symbol_levels;
 

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -8276,6 +8276,283 @@ dsd_rtl_stream_test_direct_output_rate_after_open_update(int output_kind, int ra
     return 0;
 }
 
+extern "C" int
+rtl_stream_test_parse_compat_matrix(int* out_int_ok, int* out_int_values, size_t int_count, int* out_double_ok,
+                                    double* out_double_values, size_t double_count) {
+    if (!out_int_ok || !out_int_values || int_count < 10U || !out_double_ok || !out_double_values
+        || double_count < 8U) {
+        return -1;
+    }
+
+    int iv = -999;
+    out_int_ok[0] = parse_int_atoi_compat(NULL, &iv);
+    out_int_values[0] = iv;
+    out_int_ok[1] = parse_int_atoi_compat("", &iv);
+    out_int_values[1] = iv;
+    out_int_ok[2] = parse_int_atoi_compat("7", NULL);
+    out_int_values[2] = iv;
+    out_int_ok[3] = parse_int_atoi_compat("42", &iv);
+    out_int_values[3] = iv;
+    out_int_ok[4] = parse_int_atoi_compat("-17", &iv);
+    out_int_values[4] = iv;
+    out_int_ok[5] = parse_int_atoi_compat("abc", &iv);
+    out_int_values[5] = iv;
+    out_int_ok[6] = parse_int_atoi_compat("12x", &iv);
+    out_int_values[6] = iv;
+    out_int_ok[7] = parse_int_atoi_compat("999999999999999999999999", &iv);
+    out_int_values[7] = iv;
+    out_int_ok[8] = parse_int_atoi_compat("2147483648", &iv);
+    out_int_values[8] = iv;
+    out_int_ok[9] = parse_int_atoi_compat("-2147483649", &iv);
+    out_int_values[9] = iv;
+
+    double dv = -999.0;
+    out_double_ok[0] = parse_double_atof_compat(NULL, &dv);
+    out_double_values[0] = dv;
+    out_double_ok[1] = parse_double_atof_compat("", &dv);
+    out_double_values[1] = dv;
+    out_double_ok[2] = parse_double_atof_compat("1.5", NULL);
+    out_double_values[2] = dv;
+    out_double_ok[3] = parse_double_atof_compat("3.25", &dv);
+    out_double_values[3] = dv;
+    out_double_ok[4] = parse_double_atof_compat("-2.5", &dv);
+    out_double_values[4] = dv;
+    out_double_ok[5] = parse_double_atof_compat("nanx", &dv);
+    out_double_values[5] = dv;
+    out_double_ok[6] = parse_double_atof_compat("abc", &dv);
+    out_double_values[6] = dv;
+    out_double_ok[7] = parse_double_atof_compat("1e9999", &dv);
+    out_double_values[7] = dv;
+    return 0;
+}
+
+namespace {
+struct RtlSourcePolicyMatrixOut {
+    int* kind;
+    int* rtltcp;
+    int* soapy;
+    int* replay;
+    int* family;
+    char* names;
+    size_t names_size;
+};
+} // namespace
+
+static int
+rtl_test_source_policy_args_valid(const RtlSourcePolicyMatrixOut* out, size_t count, const char* soapy_args,
+                                  size_t args_size) {
+    return out && out->kind && out->rtltcp && out->soapy && out->replay && out->family && count >= 8U && out->names
+           && out->names_size != 0U && soapy_args && args_size != 0U;
+}
+
+static void
+rtl_test_append_source_name(const RtlSourcePolicyMatrixOut* out) {
+    size_t used = strlen(out->names);
+    if (used + 1U < out->names_size) {
+        DSD_SNPRINTF(out->names + used, out->names_size - used, "%s%s", (used == 0U) ? "" : "|",
+                     rtl_perf_source_name());
+    }
+}
+
+static void
+rtl_test_source_policy_case(const RtlSourcePolicyMatrixOut* out, size_t index, const char* spec, dsd_opts* opts) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    if (spec) {
+        DSD_SNPRINTF(opts->audio_in_dev, sizeof(opts->audio_in_dev), "%s", spec);
+    }
+
+    const dsd_opts* detected_opts = spec ? opts : NULL;
+    const RadioSourceKind kind = detect_radio_source(detected_opts);
+    out->kind[index] = (int)kind;
+    out->rtltcp[index] = radio_source_is_rtltcp(detected_opts);
+    out->soapy[index] = radio_source_is_soapy(detected_opts);
+    out->replay[index] = radio_source_is_iq_replay(detected_opts);
+    out->family[index] = radio_source_is_rtl_family(detected_opts);
+    rtl_test_append_source_name(out);
+}
+
+static void
+rtl_test_write_soapy_args(char* out_soapy_args, size_t args_size) {
+    const char* args_null = radio_source_soapy_args(NULL);
+
+    static dsd_opts soapy_no_colon;
+    DSD_MEMSET(&soapy_no_colon, 0, sizeof(soapy_no_colon));
+    DSD_SNPRINTF(soapy_no_colon.audio_in_dev, sizeof(soapy_no_colon.audio_in_dev), "%s", "soapy");
+    const char* args_no_colon = radio_source_soapy_args(&soapy_no_colon);
+    static dsd_opts soapy_empty;
+    DSD_MEMSET(&soapy_empty, 0, sizeof(soapy_empty));
+    DSD_SNPRINTF(soapy_empty.audio_in_dev, sizeof(soapy_empty.audio_in_dev), "%s", "soapy:");
+    const char* args_empty = radio_source_soapy_args(&soapy_empty);
+    static dsd_opts soapy_args;
+    DSD_MEMSET(&soapy_args, 0, sizeof(soapy_args));
+    DSD_SNPRINTF(soapy_args.audio_in_dev, sizeof(soapy_args.audio_in_dev), "%s", "soapy:driver=rtlsdr");
+    const char* args_value = radio_source_soapy_args(&soapy_args);
+    DSD_SNPRINTF(out_soapy_args, args_size, "%s|%s|%s|%s", args_null ? args_null : "",
+                 args_no_colon ? args_no_colon : "", args_empty ? args_empty : "", args_value ? args_value : "");
+}
+
+extern "C" int
+rtl_stream_test_source_policy_matrix(int* out_kind, int* out_rtltcp, int* out_soapy, int* out_replay, int* out_family,
+                                     size_t count, char* out_names, size_t names_size, char* out_soapy_args,
+                                     size_t args_size) {
+    RtlSourcePolicyMatrixOut out = {out_kind, out_rtltcp, out_soapy, out_replay, out_family, out_names, names_size};
+    if (!rtl_test_source_policy_args_valid(&out, count, out_soapy_args, args_size)) {
+        return -1;
+    }
+
+    const char* specs[] = {
+        NULL,   "", "rtltcp", "rtltcp:127.0.0.1:1234", "soapy", "soapy:driver=rtlsdr", "iqreplay:/tmp/capture.iq.json",
+        "rtl:0"};
+
+    struct RtlSdrInternals* prev_stream = g_stream;
+    struct RtlSdrInternals test_stream = {};
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    test_stream.opts = &opts;
+    g_stream = &test_stream;
+
+    out_names[0] = '\0';
+    for (size_t i = 0U; i < sizeof specs / sizeof specs[0]; i++) {
+        rtl_test_source_policy_case(&out, i, specs[i], &opts);
+    }
+    rtl_test_write_soapy_args(out_soapy_args, args_size);
+
+    g_stream = prev_stream;
+    return 0;
+}
+
+static void
+rtl_test_set_single_mode(dsd_opts* opts, int index) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    switch (index) {
+        case 0: opts->frame_p25p1 = 1; break;
+        case 1: opts->frame_p25p2 = 1; break;
+        case 2: opts->frame_provoice = 1; break;
+        case 3: opts->frame_dmr = 1; break;
+        case 4: opts->frame_nxdn48 = 1; break;
+        case 5: opts->frame_nxdn96 = 1; break;
+        case 6: opts->frame_x2tdma = 1; break;
+        case 7: opts->frame_ysf = 1; break;
+        case 8: opts->frame_dstar = 1; break;
+        case 9: opts->frame_dpmr = 1; break;
+        case 10: opts->frame_m17 = 1; break;
+        case 11: opts->mod_qpsk = 1; break;
+        default: break;
+    }
+}
+
+extern "C" int
+rtl_stream_test_mode_policy_matrix(int* out_values, size_t count) {
+    if (!out_values || count < 32U) {
+        return -1;
+    }
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    size_t o = 0U;
+    out_values[o++] = opts_is_digital_mode(NULL);
+    for (int i = 0; i <= 10; i++) {
+        rtl_test_set_single_mode(&opts, i);
+        out_values[o++] = opts_is_digital_mode(&opts);
+    }
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    out_values[o++] = opts_is_digital_mode(&opts);
+
+    out_values[o++] = opts_has_4800_wide_four_level_mode(NULL);
+    const int wide_modes[] = {3, 5, 7, 10};
+    for (size_t i = 0U; i < sizeof(wide_modes) / sizeof(wide_modes[0]); i++) {
+        rtl_test_set_single_mode(&opts, wide_modes[i]);
+        out_values[o++] = opts_has_4800_wide_four_level_mode(&opts);
+    }
+    rtl_test_set_single_mode(&opts, 0);
+    out_values[o++] = opts_has_4800_wide_four_level_mode(&opts);
+
+    out_values[o++] = opts_has_12k5_or_cqpsk_bw_mode(NULL);
+    const int bw_modes[] = {0, 1, 2, 3, 5, 6, 7, 10, 11};
+    for (size_t i = 0U; i < sizeof(bw_modes) / sizeof(bw_modes[0]); i++) {
+        rtl_test_set_single_mode(&opts, bw_modes[i]);
+        out_values[o++] = opts_has_12k5_or_cqpsk_bw_mode(&opts);
+    }
+    rtl_test_set_single_mode(&opts, 4);
+    out_values[o++] = opts_has_12k5_or_cqpsk_bw_mode(&opts);
+    return 0;
+}
+
+extern "C" int
+rtl_stream_test_fsk_profile_policy_matrix(int* out_profiles, size_t count) {
+    if (!out_profiles || count < 21U) {
+        return -1;
+    }
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    out_profiles[0] = rtl_stream_fsk_profile_for_opts_by_sym_rate(NULL, 4800);
+    out_profiles[1] = rtl_stream_fsk_profile_for_opts_by_frame(NULL);
+    opts.frame_provoice = 1;
+    out_profiles[2] = rtl_stream_fsk_profile_for_opts_by_sym_rate(&opts, 9600);
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.frame_nxdn48 = 1;
+    out_profiles[3] = rtl_stream_fsk_profile_for_opts_by_sym_rate(&opts, 2400);
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.frame_dpmr = 1;
+    out_profiles[4] = rtl_stream_fsk_profile_for_opts_by_sym_rate(&opts, 2400);
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.frame_x2tdma = 1;
+    out_profiles[5] = rtl_stream_fsk_profile_for_opts_by_sym_rate(&opts, 6000);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.frame_dmr = 1;
+    out_profiles[6] = rtl_stream_fsk_profile_for_opts_by_frame(&opts);
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.frame_p25p1 = 1;
+    out_profiles[7] = rtl_stream_fsk_profile_for_opts_by_frame(&opts);
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.frame_p25p2 = 1;
+    out_profiles[8] = rtl_stream_fsk_profile_for_opts_by_frame(&opts);
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.frame_dstar = 1;
+    out_profiles[9] = rtl_stream_fsk_profile_for_opts_by_frame(&opts);
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.frame_x2tdma = 1;
+    out_profiles[10] = rtl_stream_fsk_profile_for_opts_by_frame(&opts);
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.frame_provoice = 1;
+    out_profiles[11] = rtl_stream_fsk_profile_for_opts_by_frame(&opts);
+
+    out_profiles[12] = rtl_stream_fsk_profile_for_symbol_rate(2400, 4);
+    out_profiles[13] = rtl_stream_fsk_profile_for_symbol_rate(9600, 4);
+    out_profiles[14] = rtl_stream_fsk_profile_for_symbol_rate(6000, 4);
+    out_profiles[15] = rtl_stream_fsk_profile_for_symbol_rate(4800, 2);
+    out_profiles[16] = rtl_stream_fsk_profile_for_symbol_rate(4800, 4);
+    out_profiles[17] = rtl_stream_fsk_profile_for_symbol_rate(1200, 4);
+
+    struct RtlSdrInternals* prev_stream = g_stream;
+    struct RtlSdrInternals test_stream = {};
+    int prev_symbol_rate = demod.symbol_rate_hz;
+    int prev_symbol_levels = demod.symbol_levels;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.frame_provoice = 1;
+    test_stream.opts = &opts;
+    g_stream = &test_stream;
+    demod.symbol_rate_hz = 9600;
+    demod.symbol_levels = 4;
+    out_profiles[18] = rtl_stream_fsk_channel_profile_for_current_mode();
+
+    g_stream = NULL;
+    demod.symbol_rate_hz = 4800;
+    demod.symbol_levels = 2;
+    out_profiles[19] = rtl_stream_fsk_channel_profile_for_current_mode();
+    demod.symbol_rate_hz = 0;
+    demod.symbol_levels = 0;
+    out_profiles[20] = rtl_stream_fsk_channel_profile_for_current_mode();
+
+    demod.symbol_rate_hz = prev_symbol_rate;
+    demod.symbol_levels = prev_symbol_levels;
+    g_stream = prev_stream;
+    return 0;
+}
+
 static void
 fsk_reacquire_test_cleanup_output_ring(int initialized_output) {
     if (initialized_output) {

--- a/src/protocol/dmr/dmr_dburst.c
+++ b/src/protocol/dmr/dmr_dburst.c
@@ -216,6 +216,39 @@ dmr_dburst_keeps_data_p_head(uint8_t databurst) {
     return databurst == 0x06 || databurst == 0x07 || databurst == 0x08 || databurst == 0x0A || databurst == 0x0B;
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_neo_dmr_test_dburst_profile(dsd_opts* opts, dsd_state* state, uint8_t databurst, uint8_t slot,
+                                dsd_neo_dmr_test_dburst_profile_result* result) {
+    uint8_t info[196];
+    dmr_data_burst_ctx ctx;
+    DSD_MEMSET(info, 0, sizeof(info));
+    if (opts == NULL || state == NULL || result == NULL || slot >= 2U) {
+        return 0;
+    }
+    DSD_MEMSET(result, 0, sizeof(*result));
+
+    state->currentslot = slot;
+    dmr_dburst_ctx_init(&ctx, opts, state, info, databurst, NULL);
+    dmr_dburst_apply_base_profile(&ctx);
+    dmr_dburst_apply_dynamic_profile(&ctx);
+    if (!dmr_dburst_keeps_data_p_head(ctx.databurst)) {
+        state->data_p_head[ctx.slot] = 0;
+    }
+
+    result->pdu_len = ctx.pdu_len;
+    result->pdu_start = ctx.pdu_start;
+    result->crclen = ctx.crclen;
+    result->crcmask = ctx.crcmask;
+    result->flags = (uint8_t)((ctx.is_bptc ? DMR_DBURST_F_BPTC : 0U) | (ctx.is_trellis ? DMR_DBURST_F_TRELLIS : 0U)
+                              | (ctx.is_emb ? DMR_DBURST_F_EMB : 0U) | (ctx.is_lc ? DMR_DBURST_F_LC : 0U)
+                              | (ctx.is_full ? DMR_DBURST_F_FULL : 0U) | (ctx.is_udt ? 0x80U : 0U));
+    DSD_SNPRINTF(result->subtype, sizeof(result->subtype), "%s", state->fsubtype);
+    result->data_p_head = state->data_p_head[ctx.slot];
+    return 1;
+}
+#endif
+
 static void
 dmr_dburst_print_header_and_dump(dmr_data_burst_ctx* ctx) {
     if (ctx->databurst == 0xEB) {

--- a/src/protocol/dpmr/dpmr_voice.c
+++ b/src/protocol/dpmr/dpmr_voice.c
@@ -44,6 +44,14 @@ static void ConvertAirInterfaceID(uint32_t AI_ID, char ID[8]);
 #ifdef DSD_NEO_TEST_HOOKS
 void dsd_test_dpmr_play_voice_frames(dsd_opts* opts, dsd_state* state,
                                      char ambe_fr[NB_OF_DPMR_VOICE_FRAME_TO_DECODE * 4][4][24]);
+void dsd_test_dpmr_deinterleave_6x12(const uint8_t* input, uint8_t* output);
+uint8_t dsd_test_dpmr_crc7(const uint8_t* input, uint32_t bit_length);
+void dsd_test_dpmr_convert_air_interface_id(uint32_t ai_id, char id[8]);
+uint8_t dsd_test_dpmr_extract_cch_crc(const uint8_t cch_bits[48]);
+void dsd_test_dpmr_update_superframe_part(dsd_opts* opts, dsd_state* state, uint32_t frame0, uint32_t frame1,
+                                          uint32_t id_value, bool crc0_ok, bool crc1_ok, bool hamming0_ok,
+                                          bool hamming1_ok);
+void dsd_test_dpmr_print_ids(dsd_state* state, const char called_id[8], const char calling_id[8]);
 #endif
 
 typedef struct {
@@ -363,6 +371,62 @@ void
 dsd_test_dpmr_play_voice_frames(dsd_opts* opts, dsd_state* state,
                                 char ambe_fr[NB_OF_DPMR_VOICE_FRAME_TO_DECODE * 4][4][24]) {
     dpmr_play_voice_frames(opts, state, ambe_fr);
+}
+
+void
+dsd_test_dpmr_deinterleave_6x12(const uint8_t* input, uint8_t* output) {
+    DeInterleave6x12DPmrBit(input, output);
+}
+
+uint8_t
+dsd_test_dpmr_crc7(const uint8_t* input, uint32_t bit_length) {
+    return CRC7BitdPMR(input, bit_length);
+}
+
+void
+dsd_test_dpmr_convert_air_interface_id(uint32_t ai_id, char id[8]) {
+    ConvertAirInterfaceID(ai_id, id);
+}
+
+uint8_t
+dsd_test_dpmr_extract_cch_crc(const uint8_t cch_bits[48]) {
+    return dpmr_extract_cch_crc(cch_bits);
+}
+
+void
+dsd_test_dpmr_update_superframe_part(dsd_opts* opts, dsd_state* state, uint32_t frame0, uint32_t frame1,
+                                     uint32_t id_value, bool crc0_ok, bool crc1_ok, bool hamming0_ok,
+                                     bool hamming1_ok) {
+    dpmr_voice_ctx_t ctx;
+    char called_id[8] = {0};
+    char calling_id[8] = {0};
+    uint32_t first_half = (id_value >> 12U) & 0xFFFU;
+    uint32_t second_half = id_value & 0xFFFU;
+
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    dpmr_extract_previous_ids(state, called_id, calling_id);
+    ctx.CCH_FrameNumber[0] = frame0;
+    ctx.CCH_FrameNumber[1] = frame1;
+    ctx.CrcOk[0] = crc0_ok ? 1U : 0U;
+    ctx.CrcOk[1] = crc1_ok ? 1U : 0U;
+    ctx.HammingCorrectable[0][0] = hamming0_ok;
+    ctx.HammingCorrectable[0][1] = hamming0_ok;
+    ctx.HammingCorrectable[1][0] = hamming1_ok;
+    ctx.HammingCorrectable[1][1] = hamming1_ok;
+    for (uint32_t i = 0; i < 12U; i++) {
+        ctx.CCHDataHammingCorrected[0][2U + i] = (uint8_t)((first_half >> (11U - i)) & 1U);
+        ctx.CCHDataHammingCorrected[1][2U + i] = (uint8_t)((second_half >> (11U - i)) & 1U);
+    }
+    dpmr_update_superframe_part(&ctx, opts, state, called_id, calling_id);
+}
+
+void
+dsd_test_dpmr_print_ids(dsd_state* state, const char called_id[8], const char calling_id[8]) {
+    char called_copy[8] = {0};
+    char calling_copy[8] = {0};
+    dsd_strncpy_s(called_copy, sizeof(called_copy), called_id, sizeof(called_copy) - 1U);
+    dsd_strncpy_s(calling_copy, sizeof(calling_copy), calling_id, sizeof(calling_copy) - 1U);
+    dpmr_print_ids(state, called_copy, calling_copy);
 }
 #endif
 

--- a/src/protocol/edacs/edacs-fme.c
+++ b/src/protocol/edacs/edacs-fme.c
@@ -104,6 +104,16 @@ unsigned long long int dsd_neo_edacs_test_build_symbol_register(const dsd_opts* 
                                                                 const short analog1[960]);
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 void dsd_neo_edacs_test_reset_digitize_overflow(dsd_state* state);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+int dsd_neo_edacs_test_collect_analog_triplet(dsd_opts* opts, dsd_state* state, short* analog1, short* analog2,
+                                              short* analog3, double* pwr);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void dsd_neo_edacs_test_emit_analog_audio(dsd_opts* opts, dsd_state* state, const short* analog1, const short* analog2,
+                                          const short* analog3);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+int dsd_neo_edacs_test_static_wav_downsample(const short* src, short* out, size_t out_count);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+double dsd_neo_edacs_test_no_sql_watchdog_window(double trunk_hangtime);
 #endif
 
 static void
@@ -410,13 +420,18 @@ edacs_emit_analog_audio(dsd_opts* opts, dsd_state* state, const short* analog1, 
 }
 
 static void
+edacs_build_static_wav_block(const short* src, short out[320]) {
+    for (int i = 0; i < 160; i++) {
+        out[((size_t)i * 2) + 0] = src[(size_t)i * 6];
+        out[((size_t)i * 2) + 1] = src[(size_t)i * 6];
+    }
+}
+
+static void
 edacs_write_static_wav_block(SNDFILE* wav, const short* src) {
     short ss[320];
     DSD_MEMSET(ss, 0, sizeof(ss));
-    for (int i = 0; i < 160; i++) {
-        ss[((size_t)i * 2) + 0] = src[(size_t)i * 6];
-        ss[((size_t)i * 2) + 1] = src[(size_t)i * 6];
-    }
+    edacs_build_static_wav_block(src, ss);
     edacs_write_wav_short_block(wav, ss, 320, "edacs static WAV");
 }
 
@@ -484,6 +499,17 @@ edacs_should_release_voice(unsigned long long int sr, int sql_disabled, time_t s
         return 1;
     }
     return 0;
+}
+
+static double
+edacs_no_sql_watchdog_window(double trunk_hangtime) {
+    double no_sql_watchdog_s = trunk_hangtime * 10.0;
+    if (no_sql_watchdog_s < 20.0) {
+        no_sql_watchdog_s = 20.0;
+    } else if (no_sql_watchdog_s > 60.0) {
+        no_sql_watchdog_s = 60.0;
+    }
+    return no_sql_watchdog_s;
 }
 
 static void
@@ -616,12 +642,7 @@ edacs_analog(dsd_opts* opts, dsd_state* state, int afs, unsigned char lcn) {
     double pwr = opts->rtl_squelch_level + 1e-3; // small offset for initial loop phase
     double sql = opts->rtl_squelch_level;
     const int sql_disabled = (sql <= 0.0);
-    double no_sql_watchdog_s = opts->trunk_hangtime * 10.0;
-    if (no_sql_watchdog_s < 20.0) {
-        no_sql_watchdog_s = 20.0;
-    } else if (no_sql_watchdog_s > 60.0) {
-        no_sql_watchdog_s = 60.0;
-    }
+    const double no_sql_watchdog_s = edacs_no_sql_watchdog_window(opts->trunk_hangtime);
 
     DSD_FPRINTF(stderr, "\n");
     if (sql_disabled) {
@@ -2089,6 +2110,45 @@ dsd_neo_edacs_test_reset_digitize_overflow(dsd_state* state) {
         return;
     }
     edacs_reset_digitize_overflow(state);
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_collect_analog_triplet(dsd_opts* opts, dsd_state* state, short* analog1, short* analog2,
+                                          short* analog3, double* pwr) {
+    if (opts == NULL || state == NULL || analog1 == NULL || analog2 == NULL || analog3 == NULL || pwr == NULL) {
+        return 0;
+    }
+    return edacs_collect_analog_triplet(opts, state, analog1, analog2, analog3, pwr);
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_emit_analog_audio(dsd_opts* opts, dsd_state* state, const short* analog1, const short* analog2,
+                                     const short* analog3) {
+    if (opts == NULL || state == NULL || analog1 == NULL || analog2 == NULL || analog3 == NULL) {
+        return;
+    }
+    edacs_emit_analog_audio(opts, state, analog1, analog2, analog3);
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_static_wav_downsample(const short* src, short* out, size_t out_count) {
+    if (src == NULL || out == NULL || out_count < 320U) {
+        return -1;
+    }
+    short block[320];
+    DSD_MEMSET(block, 0, sizeof(block));
+    edacs_build_static_wav_block(src, block);
+    DSD_MEMCPY(out, block, sizeof(block));
+    return 0;
+}
+
+double
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_no_sql_watchdog_window(double trunk_hangtime) {
+    return edacs_no_sql_watchdog_window(trunk_hangtime);
 }
 #endif
 

--- a/src/protocol/edacs/edacs-fme.c
+++ b/src/protocol/edacs/edacs-fme.c
@@ -65,10 +65,45 @@
 #include <math.h>
 #endif
 
+static void
+edacs_write_wav_short_block(SNDFILE* file, const short* samples, sf_count_t sample_count, const char* context) {
+    if (file == NULL || samples == NULL || sample_count <= 0) {
+        return;
+    }
+    sf_count_t written = sf_write_short(file, samples, sample_count);
+    if (written != sample_count) {
+        LOG_WARN("%s: wrote %lld/%lld samples to WAV output", context, (long long)written, (long long)sample_count);
+    }
+}
+
 #ifdef DSD_NEO_TEST_HOOKS
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 void dsd_neo_edacs_test_process_valid_frame(dsd_opts* opts, dsd_state* state, unsigned long long int msg_1,
                                             unsigned long long int msg_2);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+const char* dsd_neo_edacs_test_lcn_status_string(int lcn);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+short dsd_neo_edacs_test_apply_input_volume(int multiplier, short sample);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+unsigned long long int dsd_neo_edacs_test_vote_frames(unsigned long long int fr_1_4, unsigned long long int fr_2_5,
+                                                      unsigned long long int fr_3_6);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+int dsd_neo_edacs_test_update_squelch_count(double pwr, double sql, int count);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+int dsd_neo_edacs_test_should_release_voice(unsigned long long int sr, int sql_disabled, time_t start_time,
+                                            double no_sql_watchdog_s);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void dsd_neo_edacs_test_update_lcn_count(dsd_state* state, int lcn);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void dsd_neo_edacs_test_build_raw_frames(const int edacs_bit[241], unsigned long long int* fr_1,
+                                         unsigned long long int* fr_2, unsigned long long int* fr_3,
+                                         unsigned long long int* fr_4, unsigned long long int* fr_5,
+                                         unsigned long long int* fr_6);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+unsigned long long int dsd_neo_edacs_test_build_symbol_register(const dsd_opts* opts, dsd_state* state,
+                                                                const short analog1[960]);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void dsd_neo_edacs_test_reset_digitize_overflow(dsd_state* state);
 #endif
 
 static void
@@ -382,15 +417,15 @@ edacs_write_static_wav_block(SNDFILE* wav, const short* src) {
         ss[((size_t)i * 2) + 0] = src[(size_t)i * 6];
         ss[((size_t)i * 2) + 1] = src[(size_t)i * 6];
     }
-    sf_write_short(wav, ss, 320);
+    edacs_write_wav_short_block(wav, ss, 320, "edacs static WAV");
 }
 
 static void
-edacs_write_analog_wav(dsd_opts* opts, short* analog1, short* analog2, short* analog3) {
+edacs_write_analog_wav(dsd_opts* opts, const short* analog1, const short* analog2, const short* analog3) {
     if (opts->wav_out_f != NULL && opts->dmr_stereo_wav == 1) {
-        sf_write_short(opts->wav_out_f, analog1, 960);
-        sf_write_short(opts->wav_out_f, analog2, 960);
-        sf_write_short(opts->wav_out_f, analog3, 960);
+        edacs_write_wav_short_block(opts->wav_out_f, analog1, 960, "edacs WAV analog1");
+        edacs_write_wav_short_block(opts->wav_out_f, analog2, 960, "edacs WAV analog2");
+        edacs_write_wav_short_block(opts->wav_out_f, analog3, 960, "edacs WAV analog3");
     } else if (opts->wav_out_f != NULL && opts->static_wav_file == 1) {
         edacs_write_static_wav_block(opts->wav_out_f, analog1);
         edacs_write_static_wav_block(opts->wav_out_f, analog2);
@@ -1986,6 +2021,74 @@ dsd_neo_edacs_test_process_valid_frame(dsd_opts* opts, dsd_state* state, unsigne
                                        unsigned long long int msg_2) {
     edacs_init_afs_layout(state);
     edacs_process_valid_frame(opts, state, msg_1, msg_2);
+}
+
+const char*
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_lcn_status_string(int lcn) {
+    return getLcnStatusString(lcn);
+}
+
+short
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_apply_input_volume(int multiplier, short sample) {
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.input_volume_multiplier = multiplier;
+    return edacs_apply_input_volume(&opts, sample);
+}
+
+unsigned long long int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_vote_frames(unsigned long long int fr_1_4, unsigned long long int fr_2_5,
+                               unsigned long long int fr_3_6) {
+    return edacsVoteFr(fr_1_4, fr_2_5, fr_3_6);
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_update_squelch_count(double pwr, double sql, int count) {
+    return edacs_update_squelch_count(pwr, sql, count);
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_should_release_voice(unsigned long long int sr, int sql_disabled, time_t start_time,
+                                        double no_sql_watchdog_s) {
+    return edacs_should_release_voice(sr, sql_disabled, start_time, no_sql_watchdog_s);
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_update_lcn_count(dsd_state* state, int lcn) {
+    edacs_update_lcn_count(state, lcn);
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_build_raw_frames(const int edacs_bit[241], unsigned long long int* fr_1,
+                                    unsigned long long int* fr_2, unsigned long long int* fr_3,
+                                    unsigned long long int* fr_4, unsigned long long int* fr_5,
+                                    unsigned long long int* fr_6) {
+    edacs_build_raw_frames(edacs_bit, fr_1, fr_2, fr_3, fr_4, fr_5, fr_6);
+}
+
+unsigned long long int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_build_symbol_register(const dsd_opts* opts, dsd_state* state, const short analog1[960]) {
+    if (opts == NULL || state == NULL || analog1 == NULL) {
+        return 0ULL;
+    }
+    return edacs_build_symbol_register(opts, state, analog1);
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_neo_edacs_test_reset_digitize_overflow(dsd_state* state) {
+    if (state == NULL) {
+        return;
+    }
+    edacs_reset_digitize_overflow(state);
 }
 #endif
 

--- a/src/protocol/m17/m17.c
+++ b/src/protocol/m17/m17.c
@@ -70,6 +70,17 @@ static void M17decodeLSFMeta(dsd_state* state, const struct m17_lsf_result* res)
 static void M17logLSFTrailer(const dsd_state* state, const struct m17_lsf_result* res);
 static int m17_can_matches_state(const dsd_state* state);
 
+static void
+m17_write_wav_short_block(SNDFILE* file, const short* samples, sf_count_t sample_count, const char* context) {
+    if (file == NULL || samples == NULL || sample_count <= 0) {
+        return;
+    }
+    sf_count_t written = sf_write_short(file, samples, sample_count);
+    if (written != sample_count) {
+        LOG_WARN("%s: wrote %lld/%lld samples to WAV output", context, (long long)written, (long long)sample_count);
+    }
+}
+
 #ifdef USE_CODEC2
 #define M17_CODEC2_OPTS_PARAM  dsd_opts*
 #define M17_CODEC2_STATE_PARAM dsd_state*
@@ -99,6 +110,13 @@ clip_float_to_short(float v) {
     }
     return (short)lrintf(v);
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+short
+dsd_neo_m17_test_clip_float_to_short(float value) {
+    return clip_float_to_short(value);
+}
+#endif
 
 static void
 m17_assign_stream_id(uint8_t sid[2]) {
@@ -145,6 +163,14 @@ M17composeFrameInfo(uint16_t ps, uint16_t dt, uint16_t et, uint16_t es, uint16_t
     return (uint16_t)((ps & 0x1U) | ((dt & 0x3U) << 1) | ((et & 0x3U) << 3) | ((es & 0x3U) << 5) | ((cn & 0xFU) << 7)
                       | ((signature & 0x1U) << 11) | ((reserved & 0xFU) << 12));
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+uint16_t
+dsd_neo_m17_test_compose_frame_info(uint16_t ps, uint16_t dt, uint16_t et, uint16_t es, uint16_t cn, uint16_t signature,
+                                    uint16_t reserved) {
+    return M17composeFrameInfo(ps, dt, et, es, cn, signature, reserved);
+}
+#endif
 
 static void
 M17logDataType(uint8_t dt) {
@@ -205,6 +231,16 @@ M17readIpSource(const uint8_t* ip_frame) {
            + ((unsigned long long int)ip_frame[6] << 24ULL) + ((unsigned long long int)ip_frame[7] << 16ULL)
            + ((unsigned long long int)ip_frame[8] << 8ULL) + ((unsigned long long int)ip_frame[9] << 0ULL);
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+unsigned long long
+dsd_neo_m17_test_read_ip_source(const uint8_t ip_frame[10]) {
+    if (ip_frame == NULL) {
+        return 0ULL;
+    }
+    return M17readIpSource(ip_frame);
+}
+#endif
 
 static void
 M17printIpSource(unsigned long long int src) {
@@ -339,16 +375,54 @@ M17storeLSFMeta(dsd_state* state, const struct m17_lsf_result* res) {
     }
 }
 
+static size_t
+m17_encode_packet_protocol_id(uint32_t identifier, uint8_t out[4]) {
+    if (out == NULL || identifier > M17_PACKET_PROTOCOL_MAX) {
+        return 0U;
+    }
+
+    if (identifier < 0x80U) {
+        out[0] = (uint8_t)identifier;
+        return 1U;
+    }
+    if (identifier < 0x800U) {
+        out[0] = (uint8_t)(0xC0U | ((identifier >> 6U) & 0x1FU));
+        out[1] = (uint8_t)(0x80U | (identifier & 0x3FU));
+        return 2U;
+    }
+    if (identifier < 0x10000U) {
+        out[0] = (uint8_t)(0xE0U | ((identifier >> 12U) & 0x0FU));
+        out[1] = (uint8_t)(0x80U | ((identifier >> 6U) & 0x3FU));
+        out[2] = (uint8_t)(0x80U | (identifier & 0x3FU));
+        return 3U;
+    }
+
+    out[0] = (uint8_t)(0xF0U | ((identifier >> 18U) & 0x07U));
+    out[1] = (uint8_t)(0x80U | ((identifier >> 12U) & 0x3FU));
+    out[2] = (uint8_t)(0x80U | ((identifier >> 6U) & 0x3FU));
+    out[3] = (uint8_t)(0x80U | (identifier & 0x3FU));
+    return 4U;
+}
+
+#ifdef DSD_NEO_TEST_HOOKS
+size_t
+dsd_neo_m17_test_encode_packet_protocol_id(uint32_t identifier, uint8_t out[4]) {
+    return m17_encode_packet_protocol_id(identifier, out);
+}
+#endif
+
 static void
 M17decodeMetaPayload(dsd_state* state, uint8_t identifier) {
-    uint8_t meta[15];
-    meta[0] = identifier; //add identifier for pkt decoder
-    for (int i = 0; i < 14; i++) {
-        meta[i + 1] = state->m17_meta[i];
+    uint8_t meta[4U + M17_META_BYTES];
+    DSD_MEMSET(meta, 0, sizeof(meta));
+    const size_t protocol_len = m17_encode_packet_protocol_id(identifier, meta);
+    if (protocol_len == 0U) {
+        return;
     }
+    DSD_MEMCPY(meta + protocol_len, state->m17_meta, M17_META_BYTES);
     LOG_INFO("\n ");
     //Note: We don't have opts here, so in the future, if we need it, we will need to pass it here
-    decodeM17PKT(NULL, state, meta, 15); //decode META
+    decodeM17PKT(NULL, state, meta, (int)(protocol_len + M17_META_BYTES)); //decode META
 }
 
 static void
@@ -419,6 +493,16 @@ M17processLICH(dsd_state* state, const dsd_opts* opts, const uint8_t* lich_bits)
 
     return err;
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_neo_m17_test_process_lich(dsd_state* state, const dsd_opts* opts, const uint8_t* lich_bits) {
+    if (state == NULL || opts == NULL || lich_bits == NULL) {
+        return -1;
+    }
+    return M17processLICH(state, opts, lich_bits);
+}
+#endif
 
 static void
 m17_unpack_voice_octets(const uint8_t* payload, unsigned char* voice1, unsigned char* voice2) {
@@ -639,7 +723,7 @@ m17_write_static_stereo_wav(const short* mono, int count, SNDFILE* wav_out_f) {
         stereo[((size_t)i * 2) + 0] = mono[i];
         stereo[((size_t)i * 2) + 1] = mono[i];
     }
-    sf_write_short(wav_out_f, stereo, ((sf_count_t)count) * 2);
+    m17_write_wav_short_block(wav_out_f, stereo, ((sf_count_t)count) * 2, "M17 static stereo WAV");
 }
 
 static void
@@ -649,7 +733,7 @@ m17_maybe_write_wav_single(const dsd_opts* opts, const dsd_state* state, const s
     }
 
     if (opts->dmr_stereo_wav == 1) {
-        sf_write_short(opts->wav_out_f, samples, count);
+        m17_write_wav_short_block(opts->wav_out_f, samples, count, "M17 WAV single");
         return;
     }
 
@@ -666,8 +750,8 @@ m17_maybe_write_wav_pair(const dsd_opts* opts, const dsd_state* state, const sho
     }
 
     if (opts->dmr_stereo_wav == 1) {
-        sf_write_short(opts->wav_out_f, first, count);
-        sf_write_short(opts->wav_out_f, second, count);
+        m17_write_wav_short_block(opts->wav_out_f, first, count, "M17 WAV pair first");
+        m17_write_wav_short_block(opts->wav_out_f, second, count, "M17 WAV pair second");
         return;
     }
 
@@ -1252,6 +1336,37 @@ m17_process_bert_payload(const dsd_opts* opts, dsd_state* state, const uint8_t* 
     }
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_m17_test_process_bert_payload(const dsd_opts* opts, dsd_state* state, const uint8_t bert_bits[197]) {
+    if (opts == NULL || state == NULL || bert_bits == NULL) {
+        return;
+    }
+    m17_process_bert_payload(opts, state, bert_bits);
+}
+
+void
+dsd_neo_m17_test_unpack_bytes_to_bits(const uint8_t* bytes, int byte_count, uint8_t* out_bits) {
+    m17_unpack_bytes_to_bits(bytes, byte_count, out_bits);
+}
+
+void
+dsd_neo_m17_test_depuncture_p2_hard(const uint8_t punctured[368], uint8_t* depunc, int depunc_bits) {
+    if (punctured == NULL || depunc == NULL || depunc_bits < 0) {
+        return;
+    }
+    m17_depuncture_p2_hard(punctured, depunc, depunc_bits);
+}
+
+void
+dsd_neo_m17_test_decode_bert_payload_bits(const uint8_t m17_bits[368], uint8_t bert_bits[197]) {
+    if (m17_bits == NULL || bert_bits == NULL) {
+        return;
+    }
+    m17_decode_bert_payload_bits(m17_bits, bert_bits);
+}
+#endif
+
 void
 processM17BRT(dsd_opts* opts, dsd_state* state) {
     uint8_t m17_rnd_bits[M17_PAYLOAD_BITS];
@@ -1487,6 +1602,24 @@ m17_load_payload_dibits(const uint8_t* input, uint8_t* output_dibits) {
     }
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_m17_test_apply_frame_prefix_dibits(int type, uint8_t output_dibits[192]) {
+    if (output_dibits == NULL) {
+        return;
+    }
+    m17_apply_frame_prefix_dibits(type, output_dibits);
+}
+
+void
+dsd_neo_m17_test_load_payload_dibits(const uint8_t input[368], uint8_t output_dibits[192]) {
+    if (input == NULL || output_dibits == NULL) {
+        return;
+    }
+    m17_load_payload_dibits(input, output_dibits);
+}
+#endif
+
 static void
 m17_dibits_to_symbols(const uint8_t* output_dibits, int* output_symbols) {
     for (int i = 0; i < M17_FRAME_SYMBOLS; i++) {
@@ -1546,6 +1679,40 @@ m17_maybe_apply_dead_air(int type, uint8_t* output_dibits, short* baseband) {
     }
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_m17_test_dibits_to_symbols(const uint8_t output_dibits[192], int output_symbols[192]) {
+    if (output_dibits == NULL || output_symbols == NULL) {
+        return;
+    }
+    m17_dibits_to_symbols(output_dibits, output_symbols);
+}
+
+void
+dsd_neo_m17_test_upsample_symbols_10x(const int output_symbols[192], int output_up[1920]) {
+    if (output_symbols == NULL || output_up == NULL) {
+        return;
+    }
+    m17_upsample_symbols_10x(output_symbols, output_up);
+}
+
+void
+dsd_neo_m17_test_baseband_no_filter(const int output_up[1920], short baseband[1920]) {
+    if (output_up == NULL || baseband == NULL) {
+        return;
+    }
+    m17_baseband_no_filter(output_up, baseband);
+}
+
+void
+dsd_neo_m17_test_maybe_apply_dead_air(int type, uint8_t output_dibits[192], short baseband[1920]) {
+    if (output_dibits == NULL || baseband == NULL) {
+        return;
+    }
+    m17_maybe_apply_dead_air(type, output_dibits, baseband);
+}
+#endif
+
 static void
 m17_write_symbol_capture_if_enabled(dsd_opts* opts, dsd_state* state, const uint8_t* output_dibits,
                                     const int* output_symbols) {
@@ -1602,7 +1769,7 @@ m17_monitor_baseband_if_enabled(dsd_opts* opts, dsd_state* state, const short* b
 static void
 m17_write_baseband_wav_if_enabled(const dsd_opts* opts, const short* baseband) {
     if (opts->wav_out_raw != NULL) {
-        sf_write_short(opts->wav_out_raw, baseband, (sf_count_t)M17_BASEBAND_SAMPLES);
+        m17_write_wav_short_block(opts->wav_out_raw, baseband, (sf_count_t)M17_BASEBAND_SAMPLES, "M17 raw WAV");
         sf_write_sync(opts->wav_out_raw);
     }
 }
@@ -1614,6 +1781,16 @@ m17_reverse_brt_bits(const uint8_t* m17_b1, uint8_t* m17_b1r) {
         m17_b1r[i + 3] = m17_b1[(M17_BERT_PAYLOAD_BITS - 1) - i];
     }
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_m17_test_reverse_brt_bits(const uint8_t input[197], uint8_t output[208]) {
+    if (input == NULL || output == NULL) {
+        return;
+    }
+    m17_reverse_brt_bits(input, output);
+}
+#endif
 
 static void
 m17_print_brt_sequence(const uint8_t* m17_b1) {
@@ -1762,6 +1939,17 @@ m17_setup_conn_disc_eotx(unsigned long long int src, uint8_t reflector_module, u
     }
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_m17_test_setup_conn_disc_eotx(unsigned long long src, uint8_t reflector_module, uint8_t conn[11],
+                                      uint8_t disc[10], uint8_t eotx[10]) {
+    if (conn == NULL || disc == NULL || eotx == NULL) {
+        return;
+    }
+    m17_setup_conn_disc_eotx(src, reflector_module, conn, disc, eotx);
+}
+#endif
+
 static void
 m17_load_lsf_callsigns(uint8_t* m17_lsf, unsigned long long int dst, unsigned long long int src) {
     for (int i = 0; i < 48; i++) {
@@ -1783,6 +1971,26 @@ m17_attach_lsf_crc(uint8_t* m17_lsf, uint8_t* lsf_packed, uint16_t* crc_cmp) {
         m17_lsf[224 + i] = (*crc_cmp >> (15 - i)) & 1;
     }
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_m17_test_load_lsf_callsigns(uint8_t m17_lsf[240], unsigned long long dst, unsigned long long src) {
+    if (m17_lsf == NULL) {
+        return;
+    }
+    m17_load_lsf_callsigns(m17_lsf, dst, src);
+}
+
+uint16_t
+dsd_neo_m17_test_attach_lsf_crc(uint8_t m17_lsf[240], uint8_t lsf_packed[30]) {
+    if (m17_lsf == NULL || lsf_packed == NULL) {
+        return 0U;
+    }
+    uint16_t crc_cmp = 0U;
+    m17_attach_lsf_crc(m17_lsf, lsf_packed, &crc_cmp);
+    return crc_cmp;
+}
+#endif
 
 static void
 m17_encode_lsf_for_rf(const uint8_t m17_lsf[M17_LSF_TYPE1_BITS], uint8_t m17_lsfs[M17_PAYLOAD_BITS]) {
@@ -2584,6 +2792,16 @@ m17_strlen_limit(const char* text, size_t limit) {
     return len;
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+size_t
+dsd_neo_m17_test_strlen_limit(const char* text, size_t limit) {
+    if (text == NULL) {
+        return 0U;
+    }
+    return m17_strlen_limit(text, limit);
+}
+#endif
+
 static void
 m17_pkt_pack_bytes_to_bits(m17_pkt_ctx* ctx) {
     const int padded_bytes = ctx->block * M17_PACKET_CHUNK_BYTES;
@@ -2623,6 +2841,58 @@ m17_pkt_prepare_payload_layout(m17_pkt_ctx* ctx) {
     ctx->lst = last_frame_bytes;
     m17_pkt_pack_bytes_to_bits(ctx);
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_neo_m17_test_prepare_pkt_payload(const char* text, uint8_t* packed, uint8_t* full_bits, uint16_t* app_len,
+                                     int* block, uint8_t* lst, uint16_t* crc) {
+    if (!packed || !full_bits || !app_len || !block || !lst || !crc) {
+        return -1;
+    }
+
+    m17_pkt_ctx ctx;
+    m17_pkt_init_defaults(&ctx, NULL, NULL);
+    if (text != NULL) {
+        DSD_SNPRINTF(ctx.text, sizeof(ctx.text), "%s", text);
+    }
+    m17_pkt_prepare_payload_layout(&ctx);
+
+    DSD_MEMCPY(packed, ctx.m17_p1_packed, sizeof(ctx.m17_p1_packed));
+    DSD_MEMCPY(full_bits, ctx.m17_p1_full, sizeof(ctx.m17_p1_full));
+    *app_len = ctx.app_len;
+    *block = ctx.block;
+    *lst = ctx.lst;
+    *crc = ctx.crc_cmp;
+    return 0;
+}
+
+int
+dsd_neo_m17_test_prepare_pkt_from_state(const dsd_state* input_state, uint8_t* lsf_bits, uint8_t* packed,
+                                        uint16_t* app_len, uint16_t* lsf_crc, uint8_t* can, unsigned long long* dst,
+                                        unsigned long long* src) {
+    if (!input_state || !lsf_bits || !packed || !app_len || !lsf_crc || !can || !dst || !src) {
+        return -1;
+    }
+
+    static dsd_state state;
+    state = *input_state;
+    m17_pkt_ctx ctx;
+    m17_pkt_init_defaults(&ctx, NULL, &state);
+    m17_pkt_apply_cli_overrides(&ctx);
+    m17_pkt_prepare_lsf(&ctx);
+    const uint16_t prepared_lsf_crc = ctx.crc_cmp;
+    m17_pkt_prepare_payload_layout(&ctx);
+
+    DSD_MEMCPY(lsf_bits, ctx.m17_lsf, sizeof(ctx.m17_lsf));
+    DSD_MEMCPY(packed, ctx.m17_p1_packed, sizeof(ctx.m17_p1_packed));
+    *app_len = ctx.app_len;
+    *lsf_crc = prepared_lsf_crc;
+    *can = ctx.can;
+    *dst = ctx.dst;
+    *src = ctx.src;
+    return 0;
+}
+#endif
 
 static void
 m17_pkt_print_full_payload(const m17_pkt_ctx* ctx) {
@@ -2930,6 +3200,13 @@ m17_decode_pkt_should_report_encrypted(const dsd_state* state, uint32_t protocol
     return 1;
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_neo_m17_test_decode_pkt_should_report_encrypted(const dsd_state* state, uint32_t protocol) {
+    return m17_decode_pkt_should_report_encrypted(state, protocol);
+}
+#endif
+
 static void
 m17_decode_pkt_dispatch_payload(dsd_state* state, const uint8_t* input, int len, const uint8_t* payload,
                                 int payload_len, uint32_t protocol) {
@@ -3010,6 +3287,13 @@ m17_pkt_ptr_clamped(int pbc_count) {
     return ptr;
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_neo_m17_test_pkt_ptr_clamped(int pbc_count) {
+    return m17_pkt_ptr_clamped(pbc_count);
+}
+#endif
+
 static void
 m17_pkt_log_counter(int pbc_count, uint8_t counter, uint8_t eot) {
     if (eot == 0U) {
@@ -3066,6 +3350,16 @@ m17_pkt_finalize_eot(const dsd_opts* opts, dsd_state* state, uint16_t app_len, i
     DSD_MEMSET(state->m17_pkt, 0, sizeof(state->m17_pkt));
     state->m17_pbc_ct = 0;
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_m17_test_finalize_packet_eot(const dsd_opts* opts, dsd_state* state, uint16_t app_len, int end) {
+    if (opts == NULL || state == NULL) {
+        return;
+    }
+    m17_pkt_finalize_eot(opts, state, app_len, end);
+}
+#endif
 
 //WIP PKT decoder - soft symbol enhanced
 void
@@ -3330,6 +3624,16 @@ m17_ip_dispatch_frame(const dsd_opts* opts, dsd_state* state, const uint8_t* ip_
         }
     }
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_m17_test_dispatch_ip_frame(const dsd_opts* opts, dsd_state* state, const uint8_t* ip_frame, int len) {
+    if (opts == NULL || state == NULL || ip_frame == NULL) {
+        return;
+    }
+    m17_ip_dispatch_frame(opts, state, ip_frame, len);
+}
+#endif
 
 //Process Received IP Frames
 void

--- a/src/protocol/m17/m17.c
+++ b/src/protocol/m17/m17.c
@@ -897,6 +897,63 @@ M17dispatchStreamPayload(M17_CODEC2_OPTS_PARAM opts, dsd_state* state, const uin
     }
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_neo_m17_test_apply_lsf_result(dsd_state* state, const struct m17_lsf_result* res) {
+    if (state == NULL || res == NULL) {
+        return -1;
+    }
+    if (res->rs != 0U || res->type_reserved_valid == 0U || res->dst_is_valid == 0U || res->src_is_valid == 0U) {
+        return 0;
+    }
+
+    M17decodeLSFFields(state, res);
+    M17logLSFSummary(state, res);
+    M17storeLSFMeta(state, res);
+    M17decodeLSFMeta(state, res);
+    return 1;
+}
+
+int
+dsd_neo_m17_test_dispatch_stream_payload(const dsd_opts* opts, dsd_state* state, const uint8_t payload[128],
+                                         uint16_t frame_number, uint8_t processed_payload[128]) {
+    if (opts == NULL || state == NULL || payload == NULL || processed_payload == NULL) {
+        return DSD_NEO_M17_TEST_STREAM_INVALID;
+    }
+
+    uint8_t payload_bytes[M17_SIGNATURE_DIGEST_BYTES];
+    uint8_t trellis_buf[144];
+    DSD_MEMSET(payload_bytes, 0, sizeof(payload_bytes));
+    DSD_MEMSET(trellis_buf, 0, sizeof(trellis_buf));
+    DSD_MEMSET(processed_payload, 0, M17_STREAM_PAYLOAD_BITS);
+    m17_bits_to_bytes_msb(payload, payload_bytes, sizeof(payload_bytes));
+
+    if (M17collectSignaturePayload(state, payload_bytes, trellis_buf, frame_number) != 0) {
+        return DSD_NEO_M17_TEST_STREAM_SIGNATURE_CONSUMED;
+    }
+
+    const uint16_t payload_frame_number = (uint16_t)(frame_number & M17_STREAM_FRAME_COUNTER_MAX);
+    M17updateSignatureDigestIfNeeded(state, payload_bytes, payload_frame_number);
+
+    if (!m17_can_matches_state(state)) {
+        return DSD_NEO_M17_TEST_STREAM_CAN_FILTERED;
+    }
+
+    const int payload_ready = m17_decrypt_stream_payload(state, frame_number, payload, processed_payload);
+    if (payload_ready == 0) {
+        return DSD_NEO_M17_TEST_STREAM_ENCRYPTED_LOCKED;
+    }
+
+    const uint8_t old_payload_decrypted = state->m17_payload_decrypted;
+    state->m17_payload_decrypted = (state->m17_enc != 0U) ? 1U : 0U;
+    M17processStreamPayloadBits((M17_CODEC2_OPTS_PARAM)opts, state, processed_payload, payload_frame_number);
+    const int result = (state->m17_enc != 0U) ? DSD_NEO_M17_TEST_STREAM_ENCRYPTED_DISPATCHED
+                                              : DSD_NEO_M17_TEST_STREAM_CLEAR_DISPATCHED;
+    state->m17_payload_decrypted = old_payload_decrypted;
+    return result;
+}
+#endif
+
 static void
 M17prepareStream(M17_CODEC2_OPTS_PARAM opts, dsd_state* state, const uint8_t* m17_bits) {
 

--- a/src/protocol/nxdn/nxdn_deperm.c
+++ b/src/protocol/nxdn/nxdn_deperm.c
@@ -202,6 +202,90 @@ nxdn_depuncture_12_group_rel(const uint8_t* deperm, const uint8_t* deperm_rel, s
     }
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_nxdn_test_depermute_12_5(const uint8_t input[60], const uint8_t reliab[60], uint8_t deperm[60],
+                                 uint8_t deperm_rel[60]) {
+    nxdn_depermute_rel_u8(input, reliab, 60U, PERM_12_5, deperm, deperm_rel);
+}
+
+void
+dsd_neo_nxdn_test_depermute_16_9(const uint8_t input[144], const uint8_t reliab[144], uint8_t deperm[144],
+                                 uint8_t deperm_rel[144]) {
+    nxdn_depermute_rel_u8(input, reliab, 144U, PERM_16_9, deperm, deperm_rel);
+}
+
+void
+dsd_neo_nxdn_test_depermute_12_25(const uint8_t input[300], const uint8_t reliab[300], uint8_t deperm[300],
+                                  uint8_t deperm_rel[300]) {
+    nxdn_depermute_rel(input, reliab, 300U, PERM_12_25, deperm, deperm_rel);
+}
+
+void
+dsd_neo_nxdn_test_depermute_12_29(const uint8_t input[348], const uint8_t reliab[348], uint8_t deperm[348],
+                                  uint8_t deperm_rel[348]) {
+    nxdn_depermute_rel(input, reliab, 348U, PERM_12_29, deperm, deperm_rel);
+}
+
+void
+dsd_neo_nxdn_test_depuncture_12_5(const uint8_t deperm[60], const uint8_t deperm_rel[60], uint8_t depunc[72],
+                                  uint8_t depunc_rel[72]) {
+    nxdn_depuncture_12_5_rel(deperm, deperm_rel, depunc, depunc_rel);
+}
+
+void
+dsd_neo_nxdn_test_depuncture_16_9(const uint8_t deperm[144], const uint8_t deperm_rel[144], uint8_t depunc[192],
+                                  uint8_t depunc_rel[192]) {
+    nxdn_depuncture_16_9_rel(deperm, deperm_rel, depunc, depunc_rel);
+}
+
+void
+dsd_neo_nxdn_test_depuncture_12_group(const uint8_t* deperm, const uint8_t* deperm_rel, size_t groups, uint8_t* depunc,
+                                      uint8_t* depunc_rel) {
+    nxdn_depuncture_12_group_rel(deperm, deperm_rel, groups, depunc, depunc_rel);
+}
+
+int
+dsd_neo_nxdn_test_dcr_is_sb0_message_type(uint8_t message_type) {
+    return nxdn_dcr_is_sb0_message_type(message_type);
+}
+
+void
+dsd_neo_nxdn_test_unpack_bytes_msb(const uint8_t* bytes, size_t byte_count, uint8_t* bits) {
+    nxdn_unpack_bytes_msb(bytes, byte_count, bits);
+}
+
+void
+dsd_neo_nxdn_test_pack_bits_msb(const uint8_t* bits, size_t byte_count, uint8_t* bytes) {
+    nxdn_pack_bits_msb(bits, byte_count, bytes);
+}
+
+uint16_t
+dsd_neo_nxdn_test_bits_to_u16(const uint8_t* bits, int len) {
+    return nxdn_bits_to_u16(bits, len);
+}
+
+int
+dsd_neo_nxdn_test_sacch_part_of_frame(uint8_t sf) {
+    return nxdn_sacch_part_of_frame(sf);
+}
+
+int
+dsd_neo_nxdn_test_ran_from_trellis(const uint8_t* trellis_buf) {
+    return nxdn_ran_from_trellis(trellis_buf);
+}
+
+void
+dsd_neo_nxdn_test_reset_payload_seed_if_forced(dsd_state* state) {
+    nxdn_reset_payload_seed_if_forced(state);
+}
+
+void
+dsd_neo_nxdn_test_prepare_sacch_payload_seed(dsd_state* state, int part_of_frame) {
+    nxdn_prepare_sacch_payload_seed(state, part_of_frame);
+}
+#endif
+
 static void
 nxdn_conv_decode_soft(const uint8_t* depunc, const uint8_t* depunc_rel, size_t depunc_len, uint8_t* m_data,
                       int chainback_bits) {
@@ -360,6 +444,14 @@ nxdn_handle_sacch(dsd_opts* opts, dsd_state* state, const uint8_t* trellis_buf, 
     }
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_nxdn_test_sacch_state_update(dsd_opts* opts, dsd_state* state, const uint8_t trellis_buf[32],
+                                     const uint8_t m_data[5], uint8_t crc, uint8_t check) {
+    nxdn_handle_sacch(opts, state, trellis_buf, m_data, crc, check);
+}
+#endif
+
 static void
 nxdn_print_pich_tch_name(uint8_t lich) {
     if (lich == 0x08U) {
@@ -462,6 +554,14 @@ nxdn_handle_pich_tch(const dsd_opts* opts, dsd_state* state, const uint8_t* trel
     nxdn_print_pich_tch_payload(opts, m_data, crc, check, lich);
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_nxdn_test_pich_tch_state_update(const dsd_opts* opts, dsd_state* state, const uint8_t trellis_buf[96],
+                                        const uint8_t m_data[12], uint16_t crc, uint16_t check, uint8_t lich) {
+    nxdn_handle_pich_tch(opts, state, trellis_buf, m_data, crc, check, lich);
+}
+#endif
+
 static void
 nxdn_print_facch2_udch_name(uint8_t type) {
     if (type == 0) {
@@ -545,6 +645,14 @@ nxdn_handle_facch2_udch(dsd_opts* opts, dsd_state* state, const uint8_t* trellis
 
     nxdn_print_facch2_udch_payload(opts, m_data, crc, check, type);
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_nxdn_test_facch2_udch_state_update(dsd_opts* opts, dsd_state* state, const uint8_t trellis_buf[208],
+                                           const uint8_t m_data[26], uint16_t crc, uint16_t check, uint8_t type) {
+    nxdn_handle_facch2_udch(opts, state, trellis_buf, m_data, crc, check, type);
+}
+#endif
 
 static int cac_fail = 0;
 
@@ -649,6 +757,14 @@ nxdn_handle_cac(dsd_opts* opts, dsd_state* state, const uint8_t* trellis_buf, co
     nxdn_print_cac_payload(opts, m_data);
     rotate_symbol_out_file(opts, state);
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_nxdn_test_cac_state_update(dsd_opts* opts, dsd_state* state, const uint8_t trellis_buf[176],
+                                   const uint8_t m_data[22], uint16_t crc) {
+    nxdn_handle_cac(opts, state, trellis_buf, m_data, crc);
+}
+#endif
 
 struct nxdn_sacch2_fields {
     uint8_t sf_fb;
@@ -834,6 +950,14 @@ nxdn_handle_sacch2(const dsd_opts* opts, dsd_state* state, const uint8_t* trelli
     nxdn_reset_sacch2_if_done(state, &fields);
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_nxdn_test_sacch2_state_update(const dsd_opts* opts, dsd_state* state, const uint8_t trellis_buf[32],
+                                      const uint8_t m_data[5], uint8_t crc, uint8_t check) {
+    nxdn_handle_sacch2(opts, state, trellis_buf, m_data, crc, check);
+}
+#endif
+
 struct nxdn_facch3_udch2_message {
     uint8_t bits[160];
     uint8_t bytes[24];
@@ -992,6 +1116,23 @@ nxdn_handle_facch3_udch2_soft(dsd_opts* opts, dsd_state* state, const struct nxd
     }
     nxdn_print_facch3_udch2_payload_soft(opts, message, type);
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_nxdn_test_facch3_udch2_state_update(dsd_opts* opts, dsd_state* state, const uint8_t bits[160],
+                                            const uint8_t bytes[24], uint16_t crc0, uint16_t check0, uint16_t crc1,
+                                            uint16_t check1, uint8_t type) {
+    struct nxdn_facch3_udch2_message message;
+    DSD_MEMSET(&message, 0, sizeof(message));
+    DSD_MEMCPY(message.bits, bits, sizeof(message.bits));
+    DSD_MEMCPY(message.bytes, bytes, sizeof(message.bytes));
+    message.crc[0] = crc0;
+    message.check[0] = check0;
+    message.crc[1] = crc1;
+    message.check[1] = check1;
+    nxdn_handle_facch3_udch2_soft(opts, state, &message, type);
+}
+#endif
 
 struct nxdn_message_label {
     uint8_t type;

--- a/src/protocol/nxdn/nxdn_deperm.c
+++ b/src/protocol/nxdn/nxdn_deperm.c
@@ -1132,6 +1132,22 @@ dsd_neo_nxdn_test_facch3_udch2_state_update(dsd_opts* opts, dsd_state* state, co
     message.check[1] = check1;
     nxdn_handle_facch3_udch2_soft(opts, state, &message, type);
 }
+
+void
+dsd_neo_nxdn_test_facch3_udch2_store_block(uint8_t bits[160], uint8_t bytes[24], size_t block,
+                                           const uint8_t trellis_buf[96], const uint8_t m_data[12]) {
+    if (bits == NULL || bytes == NULL || trellis_buf == NULL || m_data == NULL || block > 1U) {
+        return;
+    }
+
+    struct nxdn_facch3_udch2_message message;
+    DSD_MEMSET(&message, 0, sizeof(message));
+    DSD_MEMCPY(message.bits, bits, sizeof(message.bits));
+    DSD_MEMCPY(message.bytes, bytes, sizeof(message.bytes));
+    nxdn_store_facch3_udch2_block(&message, block, trellis_buf, m_data);
+    DSD_MEMCPY(bits, message.bits, sizeof(message.bits));
+    DSD_MEMCPY(bytes, message.bytes, sizeof(message.bytes));
+}
 #endif
 
 struct nxdn_message_label {

--- a/src/protocol/nxdn/nxdn_frame.c
+++ b/src/protocol/nxdn/nxdn_frame.c
@@ -369,15 +369,7 @@ nxdn_print_sync_banner(const dsd_opts* opts, const dsd_state* state, const nxdn_
 }
 
 static void
-nxdn_collect_payload_and_unpack(dsd_opts* opts, dsd_state* state, nxdn_frame_ctx* ctx) {
-    for (int i = 0; i < 174; i++) {
-        uint8_t rel = 255;
-        ctx->dbuf[i + 8] = (uint8_t)getDibitWithReliability(opts, state, &rel);
-        ctx->dbuf_reliab[i + 8] = rel;
-    }
-
-    nxdn_descramble_with_seed(ctx->dbuf, 182, state->nxdn_pn95_seed);
-
+nxdn_unpack_payload_fields(nxdn_frame_ctx* ctx) {
     for (size_t i = 0; i < 182; i++) {
         size_t idx = i * 2;
         ctx->nxdn_bit_buffer[idx] = ctx->dbuf[i] >> 1;
@@ -412,6 +404,18 @@ nxdn_collect_payload_and_unpack(dsd_opts* opts, dsd_state* state, nxdn_frame_ctx
         ctx->facch3_bits[i] = (uint8_t)ctx->nxdn_bit_buffer[i + 16 + 60];
         ctx->facch3_reliab[i] = ctx->nxdn_reliab_buffer[i + 16 + 60];
     }
+}
+
+static void
+nxdn_collect_payload_and_unpack(dsd_opts* opts, dsd_state* state, nxdn_frame_ctx* ctx) {
+    for (int i = 0; i < 174; i++) {
+        uint8_t rel = 255;
+        ctx->dbuf[i + 8] = (uint8_t)getDibitWithReliability(opts, state, &rel);
+        ctx->dbuf_reliab[i + 8] = rel;
+    }
+
+    nxdn_descramble_with_seed(ctx->dbuf, 182, state->nxdn_pn95_seed);
+    nxdn_unpack_payload_fields(ctx);
 }
 
 static void
@@ -710,3 +714,52 @@ nxdn_frame(dsd_opts* opts, dsd_state* state) {
 END:
     nxdn_finalize_sync_reject(state);
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_neo_nxdn_test_route_decoded_lich(dsd_opts* opts, dsd_state* state, uint8_t lich, const uint8_t bits[364],
+                                     const uint8_t reliab[364]) {
+    if (opts == NULL || state == NULL || bits == NULL || reliab == NULL) {
+        return -1;
+    }
+
+    nxdn_frame_ctx ctx;
+    nxdn_frame_ctx_init(&ctx);
+    ctx.lich = lich;
+
+    if (!nxdn_validate_lich_direction(opts, state, &ctx)) {
+        goto END;
+    }
+    if (!nxdn_apply_lich_profile(opts, state, &ctx)) {
+        goto END;
+    }
+
+    nxdn_mark_carrier_sync_active(state);
+
+    for (size_t i = 0U; i < 182U; i++) {
+        const size_t idx = i * 2U;
+        ctx.dbuf[i] = (uint8_t)(((bits[idx] & 1U) << 1) | (bits[idx + 1U] & 1U));
+        ctx.dbuf_reliab[i] = reliab[idx];
+    }
+    nxdn_unpack_payload_fields(&ctx);
+
+    ctx.lich_rf = (ctx.lich >> 5) & 0x3;
+    ctx.direction = (ctx.lich % 2 == 0) ? 0 : 1;
+
+    nxdn_apply_limazulu_voice_tweak(opts, state, &ctx);
+    if (opts->scanner_mode == 1) {
+        state->last_cc_sync_time = time(NULL) + 2;
+    }
+
+    nxdn_print_voice_or_data_and_sync_lfsr(state, &ctx);
+    nxdn_update_sacch_mode(state, ctx.lich);
+    nxdn_decode_control_channels(opts, state, &ctx);
+    nxdn_process_voice_and_mbe(opts, state, &ctx);
+    nxdn_handle_post_voice_facch2_lfsr(state, &ctx);
+    return 1;
+
+END:
+    nxdn_finalize_sync_reject(state);
+    return 0;
+}
+#endif

--- a/src/protocol/nxdn/nxdn_frame.c
+++ b/src/protocol/nxdn/nxdn_frame.c
@@ -407,18 +407,6 @@ nxdn_unpack_payload_fields(nxdn_frame_ctx* ctx) {
 }
 
 static void
-nxdn_collect_payload_and_unpack(dsd_opts* opts, dsd_state* state, nxdn_frame_ctx* ctx) {
-    for (int i = 0; i < 174; i++) {
-        uint8_t rel = 255;
-        ctx->dbuf[i + 8] = (uint8_t)getDibitWithReliability(opts, state, &rel);
-        ctx->dbuf_reliab[i + 8] = rel;
-    }
-
-    nxdn_descramble_with_seed(ctx->dbuf, 182, state->nxdn_pn95_seed);
-    nxdn_unpack_payload_fields(ctx);
-}
-
-static void
 nxdn_print_rf_channel_type(const nxdn_frame_ctx* ctx) {
     if (ctx->sacch2 != 0) {
         return;
@@ -689,7 +677,14 @@ nxdn_frame(dsd_opts* opts, dsd_state* state) {
     nxdn_mark_carrier_sync_active(state);
     nxdn_print_sync_banner(opts, state, &ctx);
 
-    nxdn_collect_payload_and_unpack(opts, state, &ctx);
+    for (int i = 0; i < 174; i++) {
+        uint8_t rel = 255;
+        ctx.dbuf[i + 8] = (uint8_t)getDibitWithReliability(opts, state, &rel);
+        ctx.dbuf_reliab[i + 8] = rel;
+    }
+
+    nxdn_descramble_with_seed(ctx.dbuf, 182, state->nxdn_pn95_seed);
+    nxdn_unpack_payload_fields(&ctx);
 
     ctx.lich_rf = (ctx.lich >> 5) & 0x3;
     ctx.direction = (ctx.lich % 2 == 0) ? 0 : 1;

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -63,6 +63,7 @@ static int p25p2_ess_other_slot_active(const dsd_state* state, int other);
 static int p25p2_ess_have_decrypt_key(int alg, unsigned long long int key, int aes_loaded);
 static void p25p2_ess_release_or_defer_cc(dsd_opts* opts, dsd_state* state);
 static void p25p2_ess_clear_call_banner(dsd_state* state, int slot);
+static void process_P2_DUID(dsd_opts* opts, dsd_state* state);
 
 #if defined(DSD_NEO_P25P2_TEST_STUB)
 static int
@@ -93,6 +94,10 @@ p25p2_frame_test_stub_can_decrypt(const dsd_state* state, int slot, int alg) {
 }
 
 void p25p2_test_decode_voice_frame_for_lockout(dsd_opts* opts, dsd_state* state);
+void p25p2_test_teardown_call(dsd_opts* opts, dsd_state* state);
+void p25p2_test_process_facchc(dsd_opts* opts, dsd_state* state, int timeslot_index);
+void p25p2_test_process_isch(dsd_opts* opts, dsd_state* state, int framing_index);
+void p25p2_test_process_sacchc(dsd_opts* opts, dsd_state* state, int timeslot_index);
 #endif
 
 static int
@@ -281,6 +286,13 @@ p25_p2_teardown_call(dsd_opts* opts, dsd_state* state) {
     DSD_SNPRINTF(state->call_string[0], sizeof state->call_string[0], "%s", "                     ");
     DSD_SNPRINTF(state->call_string[1], sizeof state->call_string[1], "%s", "                     ");
 }
+
+#if defined(DSD_NEO_P25P2_TEST_STUB)
+void
+p25p2_test_teardown_call(dsd_opts* opts, dsd_state* state) {
+    p25_p2_teardown_call(opts, state);
+}
+#endif
 
 //DUID Look Up Table from OP25
 static const int16_t duid_lookup[256] =
@@ -879,6 +891,20 @@ process_SACCHs(dsd_opts* opts, dsd_state* state) {
     }
 }
 
+#if defined(DSD_NEO_P25P2_TEST_STUB)
+void
+p25p2_test_process_facchc(dsd_opts* opts, dsd_state* state, int timeslot_index) {
+    ts_counter = timeslot_index;
+    process_FACCHc(opts, state);
+}
+
+void
+p25p2_test_process_sacchc(dsd_opts* opts, dsd_state* state, int timeslot_index) {
+    ts_counter = timeslot_index;
+    process_SACCHc(opts, state);
+}
+#endif
+
 static void
 process_ISCH(dsd_opts* opts, dsd_state* state) {
     UNUSED(opts);
@@ -919,6 +945,14 @@ process_ISCH(dsd_opts* opts, dsd_state* state) {
 
     isch_decoded = -1; //reset to bad value after running
 }
+
+#if defined(DSD_NEO_P25P2_TEST_STUB)
+void
+p25p2_test_process_isch(dsd_opts* opts, dsd_state* state, int framing_index) {
+    framing_counter = framing_index;
+    process_ISCH(opts, state);
+}
+#endif
 
 static void DSD_ATTR_USED
 p25p2_emit_active_if_allowed(dsd_opts* opts, dsd_state* state) {
@@ -1797,6 +1831,13 @@ process_P2_DUID(dsd_opts* opts, dsd_state* state) {
 END:
     voice = 0;
 }
+
+#if defined(DSD_NEO_P25P2_TEST_STUB)
+void
+p25p2_test_process_p2_duid(dsd_opts* opts, dsd_state* state) {
+    process_P2_DUID(opts, state);
+}
+#endif
 
 void
 processP2(dsd_opts* opts, dsd_state* state) {

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -385,6 +385,9 @@ p25p2_xcch_handle_ptt_slot(dsd_opts* opts, dsd_state* state, const unsigned long
 
 static void
 p25p2_xcch_handle_end_slot(dsd_opts* opts, dsd_state* state, int slot, int clear_call_string) {
+    if (slot < 0 || slot >= 2) {
+        return;
+    }
     state->p25_p2_enc_lockout_muted[slot] = 0;
     state->fourv_counter[slot] = 0;
     state->voice_counter[slot] = 0;

--- a/src/protocol/ysf/ysf.c
+++ b/src/protocol/ysf/ysf.c
@@ -128,7 +128,7 @@ ysf_dch_decode_text(dsd_state* state, const char dch_bytes[20], uint8_t fn, uint
 }
 
 static void
-ysf_dch_decode(dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, uint8_t cm, uint8_t input[]) {
+ysf_dch_decode(dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, uint8_t cm, const uint8_t input[]) {
     //TODO: Per Call WAV files using these strings
     int i;
     char dch_bytes[20];
@@ -186,7 +186,7 @@ ysf_dch_decode2_remarks(const char* label1, char* dst1, const char* label2, char
 }
 
 static void
-ysf_dch_decode2(dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, uint8_t cm, uint8_t input[]) {
+ysf_dch_decode2(dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, uint8_t cm, const uint8_t input[]) {
     char dch_bytes[20];
     DSD_MEMSET(dch_bytes, 0, sizeof(dch_bytes));
 
@@ -221,6 +221,25 @@ crc16ysf(const uint8_t buf[], int len) {
     crc = crc ^ 0xffff;
     return crc & 0xffff;
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_ysf_test_decode_dch(dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, uint8_t cm,
+                            const uint8_t input[160]) {
+    ysf_dch_decode(state, bn, bt, fn, ft, cm, input);
+}
+
+void
+dsd_neo_ysf_test_decode_dch2(dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, uint8_t cm,
+                             const uint8_t input[80]) {
+    ysf_dch_decode2(state, bn, bt, fn, ft, cm, input);
+}
+
+uint16_t
+dsd_neo_ysf_test_crc16(const uint8_t* bits, int len) {
+    return crc16ysf(bits, len);
+}
+#endif
 
 //modified version of nxdn_deperm_facch1 -- this one for V/D Type 2 CC DCH (100 dibit version)
 static int
@@ -279,6 +298,14 @@ ysf_conv_dch2(const dsd_opts* opts, dsd_state* state, uint8_t bn, uint8_t bt, ui
     return err;
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_neo_ysf_test_conv_dch2(const dsd_opts* opts, dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft,
+                           uint8_t cm, uint8_t input[100]) {
+    return ysf_conv_dch2(opts, state, bn, bt, fn, ft, cm, input);
+}
+#endif
+
 //modified version of nxdn_deperm_facch1 -- this one for Full Rate, Type 1 CC, Headers and Terminators DCH (180 dibit version)
 static int
 ysf_conv_dch(const dsd_opts* opts, dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft, uint8_t cm,
@@ -335,9 +362,21 @@ ysf_conv_dch(const dsd_opts* opts, dsd_state* state, uint8_t bn, uint8_t bt, uin
     return err;
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_neo_ysf_test_conv_dch(const dsd_opts* opts, dsd_state* state, uint8_t bn, uint8_t bt, uint8_t fn, uint8_t ft,
+                          uint8_t cm, uint8_t input[180]) {
+    return ysf_conv_dch(opts, state, bn, bt, fn, ft, cm, input);
+}
+#endif
+
 //modified version of nxdn_deperm_facch1
 static int
-ysf_conv_fich(uint8_t input[], uint8_t dest[32], uint32_t* v_error_out) {
+ysf_conv_fich(const uint8_t input[100], uint8_t dest[32], uint32_t* v_error_out) {
+    if (input == NULL || dest == NULL) {
+        return -1;
+    }
+
     int i, j, err;
     uint8_t trellis_buf[100];
     uint8_t m_data[100];
@@ -398,6 +437,20 @@ ysf_conv_fich(uint8_t input[], uint8_t dest[32], uint32_t* v_error_out) {
     DSD_MEMCPY(dest, fich_bits, 32); //copy minus the crc16
     return err;
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_neo_ysf_test_conv_fich(const uint8_t input[100], uint8_t dest[32], uint32_t* v_error_out) {
+    if (input == NULL) {
+        return -1;
+    }
+    uint8_t local_input[100];
+    for (size_t i = 0; i < sizeof(local_input); i++) {
+        local_input[i] = (uint8_t)(input[i] & 0x03U);
+    }
+    return ysf_conv_fich(local_input, dest, v_error_out);
+}
+#endif
 
 static void
 ysf_ehr(dsd_opts* opts, dsd_state* state, uint8_t dbuf[180], int start, int stop) {
@@ -733,6 +786,13 @@ ysf_build_type2_ambe(const uint8_t vech_bits[104], uint8_t temp[512], char ambe_
         ambe_d[j] = (char)temp[j];
     }
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_ysf_test_build_type2_ambe(const uint8_t vech_bits[104], uint8_t temp[512], char ambe_d[49]) {
+    ysf_build_type2_ambe(vech_bits, temp, ambe_d);
+}
+#endif
 
 static void
 ysf_handle_vd_type2(dsd_opts* opts, dsd_state* state, const ysf_fich_info* info) {

--- a/src/runtime/rt_sched.cpp
+++ b/src/runtime/rt_sched.cpp
@@ -69,6 +69,23 @@ resolve_role_cpu_affinity(const dsdneoRuntimeConfig* cfg, const char* role) {
     return -1;
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+const char*
+dsd_neo_rt_sched_test_role_or_default(const char* role) {
+    return role_or_default(role);
+}
+
+int
+dsd_neo_rt_sched_test_resolve_role_rt_priority(const dsdneoRuntimeConfig* cfg, const char* role) {
+    return resolve_role_rt_priority(cfg, role);
+}
+
+int
+dsd_neo_rt_sched_test_resolve_role_cpu_affinity(const dsdneoRuntimeConfig* cfg, const char* role) {
+    return resolve_role_cpu_affinity(cfg, role);
+}
+#endif
+
 /**
  * @brief Optionally enable realtime scheduling and set CPU affinity for the current thread.
  *

--- a/src/runtime/worker_pool.cpp
+++ b/src/runtime/worker_pool.cpp
@@ -26,9 +26,17 @@
 namespace {
 
 /* Opaque handle keyed off demod_state* to avoid depending on its layout here */
+struct WorkerCtx;
+
+struct WorkerArg {
+    WorkerCtx* ctx = nullptr;
+    int id = 0;
+};
+
 struct WorkerCtx {
     bool enabled = false;
     dsd_thread_t threads[2] = {};
+    WorkerArg* args = nullptr;
     dsd_mutex_t lock = {};
     dsd_cond_t cv = {};
     dsd_cond_t done_cv = {};
@@ -38,11 +46,6 @@ struct WorkerCtx {
     int posted_count = 0;
 
     demod_mt_task tasks[2] = {};
-};
-
-struct WorkerArg {
-    WorkerCtx* ctx = nullptr;
-    int id = 0;
 };
 
 std::unordered_map<const void*, WorkerCtx*> g_ctx_map;
@@ -88,7 +91,8 @@ static DSD_THREAD_RETURN_TYPE
         local_epoch = ctx->epoch;
         void (*fn)(void*) = nullptr;
         void* fn_arg = nullptr;
-        if (id < ctx->posted_count) {
+        bool assigned = id < ctx->posted_count;
+        if (assigned) {
             fn = ctx->tasks[id].run;
             fn_arg = ctx->tasks[id].arg;
         }
@@ -97,9 +101,11 @@ static DSD_THREAD_RETURN_TYPE
             fn(fn_arg);
         }
         dsd_mutex_lock(&ctx->lock);
-        ctx->completed_in_epoch++;
-        if (ctx->completed_in_epoch >= ctx->posted_count) {
-            dsd_cond_signal(&ctx->done_cv);
+        if (assigned) {
+            ctx->completed_in_epoch++;
+            if (ctx->completed_in_epoch >= ctx->posted_count) {
+                dsd_cond_signal(&ctx->done_cv);
+            }
         }
         dsd_mutex_unlock(&ctx->lock);
     }
@@ -142,8 +148,8 @@ demod_mt_init(struct demod_state* s) {
     dsd_mutex_init(&ctx->lock);
     dsd_cond_init(&ctx->cv);
     dsd_cond_init(&ctx->done_cv);
-    WorkerArg* args = static_cast<WorkerArg*>(calloc(2, sizeof(WorkerArg)));
-    if (args == NULL) {
+    ctx->args = static_cast<WorkerArg*>(calloc(2, sizeof(WorkerArg)));
+    if (ctx->args == NULL) {
         DSD_FPRINTF(stderr, "Failed to allocate worker thread arguments\n");
         dsd_mutex_destroy(&ctx->lock);
         dsd_cond_destroy(&ctx->cv);
@@ -152,11 +158,10 @@ demod_mt_init(struct demod_state* s) {
         return;
     }
     for (int i = 0; i < 2; i++) {
-        args[i].ctx = ctx;
-        args[i].id = i;
-        dsd_thread_create(&ctx->threads[i], demod_mt_worker, static_cast<void*>(&args[i]));
+        ctx->args[i].ctx = ctx;
+        ctx->args[i].id = i;
+        dsd_thread_create(&ctx->threads[i], demod_mt_worker, static_cast<void*>(&ctx->args[i]));
     }
-    // Intentionally leak args array until threads exit to keep pointers valid; freed in destroy
     set_ctx(static_cast<const void*>(s), ctx);
     DSD_FPRINTF(stderr, "Intra-block multithreading enabled (DSD_NEO_MT=1), workers: 2.\n");
 }
@@ -184,8 +189,8 @@ demod_mt_destroy(struct demod_state* s) {
     dsd_cond_destroy(&ctx->done_cv);
     dsd_cond_destroy(&ctx->cv);
     dsd_mutex_destroy(&ctx->lock);
-    // Free leaked WorkerArg array: not tracked; threads have exited so it's safe to free if we had kept pointer.
-    // Since we didn't keep it, allow small leak to be reclaimed on process exit. Not critical during normal teardown.
+    free(ctx->args);
+    ctx->args = nullptr;
     delete ctx;
     set_ctx(static_cast<const void*>(s), nullptr);
 }

--- a/src/third_party/pffft/pffft.c
+++ b/src/third_party/pffft/pffft.c
@@ -285,15 +285,22 @@ typedef union v4sf_union {
 
 #define assertv4(v, f0, f1, f2, f3) assert(v.f[0] == (f0) && v.f[1] == (f1) && v.f[2] == (f2) && v.f[3] == (f3))
 
+static void
+pffft_copy4(float dst[4], const float src[4]) {
+    for (int i = 0; i < 4; i++) {
+        dst[i] = src[i];
+    }
+}
+
 /* detect bugs with the vector support macros */
 void
 validate_pffft_simd(void) {
     float f[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
     v4sf_union a0, a1, a2, a3, t, u;
-    memcpy(a0.f, f, 4 * sizeof(float));
-    memcpy(a1.f, f + 4, 4 * sizeof(float));
-    memcpy(a2.f, f + 8, 4 * sizeof(float));
-    memcpy(a3.f, f + 12, 4 * sizeof(float));
+    pffft_copy4(a0.f, f);
+    pffft_copy4(a1.f, f + 4);
+    pffft_copy4(a2.f, f + 8);
+    pffft_copy4(a3.f, f + 12);
 
     t = a0;
     u = a1;

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -343,29 +343,39 @@ ui_print_rtl_ppm_field(const dsd_opts* opts) {
 }
 
 static void
+ui_print_rtl_auto_ppm_status_values(int enabled, int locked, int locked_ppm, double snr_db, double df_hz,
+                                    int step_dir) {
+    if (!enabled) {
+        printw("\n| Auto PPM: Off");
+    } else if (locked) {
+        printw("\n| Auto PPM: Locked (PPM: %d)", locked_ppm);
+    } else {
+        printw("\n| Auto PPM: On; SNR: %.1f dB; df: %.1f Hz; step: %s;", snr_db, df_hz,
+               (step_dir > 0)   ? "+1"
+               : (step_dir < 0) ? "-1"
+                                : "hold");
+    }
+}
+
+static void
 ui_print_rtl_auto_ppm_status(void) {
 #ifndef USE_RADIO
-    printw("\n| Auto PPM: Off");
+    ui_print_rtl_auto_ppm_status_values(0, 0, 0, -100.0, 0.0, 0);
 #else
     /* Show carrier/error-based auto PPM status snapshot */
     int ap_en = 0, ap_dir = 0, ap_locked = 0;
     double ap_snr = -100.0, ap_df = 0.0;
     (void)rtl_stream_auto_ppm_get_status(&ap_en, &ap_snr, &ap_df, NULL, &ap_dir, NULL, &ap_locked);
-    if (!ap_en) {
-        printw("\n| Auto PPM: Off");
-    } else if (ap_locked) {
-        int lppm = 0;
+    if (ap_locked) {
+        int locked_ppm = 0;
         double lsnr = -100.0, ldf = 0.0;
-        (void)rtl_stream_auto_ppm_get_lock(&lppm, &lsnr, &ldf);
+        (void)rtl_stream_auto_ppm_get_lock(&locked_ppm, &lsnr, &ldf);
         (void)lsnr;
         (void)ldf;
-        printw("\n| Auto PPM: Locked (PPM: %d)", lppm);
-    } else {
-        printw("\n| Auto PPM: On; SNR: %.1f dB; df: %.1f Hz; step: %s;", ap_snr, ap_df,
-               (ap_dir > 0)   ? "+1"
-               : (ap_dir < 0) ? "-1"
-                              : "hold");
+        ui_print_rtl_auto_ppm_status_values(ap_en, ap_locked, locked_ppm, ap_snr, ap_df, ap_dir);
+        return;
     }
+    ui_print_rtl_auto_ppm_status_values(ap_en, ap_locked, 0, ap_snr, ap_df, ap_dir);
 #endif
 }
 

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -626,7 +626,7 @@ ui_render_encoder_and_file_outputs(const dsd_opts* opts, const dsd_state* state)
     ui_render_file_output_status(opts);
 }
 
-static void
+static void DSD_ATTR_UNUSED
 ui_render_trunking_call_filters_pretty(const dsd_opts* opts) {
     printw("| Trunking -");
     if (opts->trunk_tune_group_calls == 0) {

--- a/src/ui/terminal/menu_internal.h
+++ b/src/ui/terminal/menu_internal.h
@@ -181,6 +181,11 @@ int ui_visible_count_and_maxlab(const NcMenuItem* items, size_t n, const void* c
 
 #ifdef DSD_NEO_TEST_HOOKS
 const char* ui_menu_item_label_for_test(const NcMenuItem* it, const void* ctx, char* out, size_t out_size);
+int ui_overlay_cap_then_floor_for_test(int value, int max_value, int min_value);
+int ui_overlay_center_axis_for_test(int outer, int inner);
+int ui_overlay_compute_width_for_test(const UiMenuFrame* f, int maxlab);
+int ui_overlay_compute_height_for_test(int visible_items);
+void ui_overlay_layout_for_test(UiMenuFrame* f, const void* ctx, int term_h, int term_w);
 #endif
 
 // Chooser helpers are declared in menu_prompts.h

--- a/src/ui/terminal/menu_prompts.c
+++ b/src/ui/terminal/menu_prompts.c
@@ -1236,34 +1236,41 @@ ui_chooser_fit_height(int desired_height, int screen_height) {
 }
 
 static int
-ui_chooser_compute_window_rect(const char* title, const char* footer, int max_item, int* h, int* w, int* wy, int* wx) {
+ui_chooser_compute_window_rect_for_terminal(const char* title, const char* footer, int max_item, int count,
+                                            int screen_h, int screen_w, int* h, int* w, int* wy, int* wx) {
     if (!title || !footer || !h || !w || !wy || !wx) {
         return 0;
     }
     int local_w = ui_chooser_initial_width(title, footer, max_item);
-    int local_h = g_chooser.count + 5;
+    int local_h = count + 5;
     if (local_h < 7) {
         local_h = 7;
     }
 
-    int scr_h = 0, scr_w = 0;
-    getmaxyx(stdscr, scr_h, scr_w);
-    if (scr_h < 4 || scr_w < 8) {
+    if (screen_h < 4 || screen_w < 8) {
         return 0;
     }
-    local_w = ui_chooser_fit_width(local_w, scr_w);
-    local_h = ui_chooser_fit_height(local_h, scr_h);
+    local_w = ui_chooser_fit_width(local_w, screen_w);
+    local_h = ui_chooser_fit_height(local_h, screen_h);
     if (local_w <= 0 || local_h <= 0) {
         return 0;
     }
 
-    int local_wy = ui_center_axis(scr_h, local_h);
-    int local_wx = ui_center_axis(scr_w, local_w);
+    int local_wy = ui_center_axis(screen_h, local_h);
+    int local_wx = ui_center_axis(screen_w, local_w);
     *h = local_h;
     *w = local_w;
     *wy = local_wy;
     *wx = local_wx;
     return 1;
+}
+
+static int
+ui_chooser_compute_window_rect(const char* title, const char* footer, int max_item, int* h, int* w, int* wy, int* wx) {
+    int scr_h = 0, scr_w = 0;
+    getmaxyx(stdscr, scr_h, scr_w);
+    return ui_chooser_compute_window_rect_for_terminal(title, footer, max_item, g_chooser.count, scr_h, scr_w, h, w, wy,
+                                                       wx);
 }
 
 static void
@@ -1379,6 +1386,98 @@ ui_chooser_test_snapshot(void) {
     snapshot.sel = g_chooser.sel;
     snapshot.top = g_chooser.top;
     snapshot.page_rows = g_chooser.page_rows;
+    return snapshot;
+}
+
+void
+ui_help_test_set_metrics(int line_count, int page_rows, int scroll) {
+    if (line_count < 0) {
+        line_count = 0;
+    }
+    if (page_rows < 0) {
+        page_rows = 0;
+    }
+    g_help.line_count = line_count;
+    g_help.page_rows = page_rows;
+    g_help.scroll = scroll;
+    ui_help_clamp_scroll(ui_help_max_scroll());
+}
+
+UiHelpTestSnapshot
+ui_help_test_snapshot(void) {
+    UiHelpTestSnapshot snapshot;
+    snapshot.active = g_help.active;
+    snapshot.scroll = g_help.scroll;
+    snapshot.line_count = g_help.line_count;
+    snapshot.page_rows = g_help.page_rows;
+    return snapshot;
+}
+
+int
+ui_help_wrap_line_for_test(const char* text, int width, int index, char* out, size_t out_size) {
+    char lines[UI_HELP_MAX_LINES][UI_HELP_MAX_LINE_CHARS];
+    int count = ui_help_wrap_text(text, width, lines, UI_HELP_MAX_LINES);
+    if (out && out_size > 0) {
+        out[0] = '\0';
+        if (index >= 0 && index < count && index < UI_HELP_MAX_LINES) {
+            DSD_SNPRINTF(out, out_size, "%s", lines[index]);
+        }
+    }
+    return count;
+}
+
+int
+ui_chooser_max_item_width_for_test(const char* const* items, int count) {
+    const char* const* saved_items = g_chooser.items;
+    int saved_count = g_chooser.count;
+    g_chooser.items = items;
+    g_chooser.count = count;
+    int max_item = ui_chooser_max_item_width();
+    g_chooser.items = saved_items;
+    g_chooser.count = saved_count;
+    return max_item;
+}
+
+int
+ui_chooser_layout_for_test(const char* title, const char* footer, int max_item, int count, int screen_h, int screen_w,
+                           int* h, int* w, int* wy, int* wx) {
+    return ui_chooser_compute_window_rect_for_terminal(title, footer, max_item, count, screen_h, screen_w, h, w, wy,
+                                                       wx);
+}
+
+int
+ui_prompt_center_axis_for_test(int screen_extent, int window_extent) {
+    return ui_center_axis(screen_extent, window_extent);
+}
+
+int
+ui_prompt_fit_width_for_test(int desired_width, int screen_width) {
+    return ui_prompt_fit_width(desired_width, screen_width);
+}
+
+int
+ui_prompt_fit_height_for_test(int desired_height, int screen_height) {
+    return ui_prompt_fit_height(desired_height, screen_height);
+}
+
+void
+ui_prompt_rows_for_test(int height, int* title_y, int* input_y, int* footer_y) {
+    ui_prompt_compute_row_positions(height, title_y, input_y, footer_y);
+}
+
+void
+ui_prompt_field_geometry_for_test(int width, int* field_col, int* field_right, int* field_width) {
+    ui_prompt_compute_field_geometry(width, field_col, field_right, field_width);
+}
+
+UiPromptViewTestSnapshot
+ui_prompt_view_for_test(const char* text, size_t cursor, int field_col, int field_right, int field_width) {
+    UiPromptViewState view = ui_prompt_compute_view_state(text, cursor, field_width);
+    UiPromptViewTestSnapshot snapshot;
+    snapshot.start = view.start;
+    snapshot.cursor = view.cursor;
+    snapshot.show_left_ellipsis = view.show_left_ellipsis;
+    snapshot.cursor_x = ui_prompt_compute_cursor_x(field_col, field_right, &view);
     return snapshot;
 }
 #endif

--- a/src/ui/terminal/menu_prompts.h
+++ b/src/ui/terminal/menu_prompts.h
@@ -165,8 +165,35 @@ typedef struct {
     int page_rows;
 } UiChooserTestSnapshot;
 
+typedef struct {
+    int active;
+    int scroll;
+    int line_count;
+    int page_rows;
+} UiHelpTestSnapshot;
+
+typedef struct {
+    size_t start;
+    size_t cursor;
+    int show_left_ellipsis;
+    int cursor_x;
+} UiPromptViewTestSnapshot;
+
 void ui_chooser_test_set_page_rows(int page_rows);
 UiChooserTestSnapshot ui_chooser_test_snapshot(void);
+void ui_help_test_set_metrics(int line_count, int page_rows, int scroll);
+UiHelpTestSnapshot ui_help_test_snapshot(void);
+int ui_help_wrap_line_for_test(const char* text, int width, int index, char* out, size_t out_size);
+int ui_chooser_max_item_width_for_test(const char* const* items, int count);
+int ui_chooser_layout_for_test(const char* title, const char* footer, int max_item, int count, int screen_h,
+                               int screen_w, int* h, int* w, int* wy, int* wx);
+int ui_prompt_center_axis_for_test(int screen_extent, int window_extent);
+int ui_prompt_fit_width_for_test(int desired_width, int screen_width);
+int ui_prompt_fit_height_for_test(int desired_height, int screen_height);
+void ui_prompt_rows_for_test(int height, int* title_y, int* input_y, int* footer_y);
+void ui_prompt_field_geometry_for_test(int width, int* field_col, int* field_right, int* field_width);
+UiPromptViewTestSnapshot ui_prompt_view_for_test(const char* text, size_t cursor, int field_col, int field_right,
+                                                 int field_width);
 #endif
 
 #endif /* DSD_NEO_SRC_UI_TERMINAL_MENU_PROMPTS_H_ */

--- a/src/ui/terminal/menu_render.c
+++ b/src/ui/terminal/menu_render.c
@@ -158,6 +158,13 @@ ui_menu_item_label(const NcMenuItem* it, const void* ctx, char* out, size_t out_
     return lab;
 }
 
+static int
+ui_menu_item_label_len(const NcMenuItem* it, const void* ctx) {
+    char dyn[128];
+    const char* lab = ui_menu_item_label(it, ctx, dyn, sizeof dyn);
+    return (int)strlen(lab);
+}
+
 #ifdef DSD_NEO_TEST_HOOKS
 const char*
 ui_menu_item_label_for_test(const NcMenuItem* it, const void* ctx, char* out, size_t out_size) {
@@ -280,18 +287,7 @@ ui_visible_count_and_maxlab(const NcMenuItem* items, size_t n, const void* ctx, 
         if (!ui_is_enabled(&items[i], ctx)) {
             continue;
         }
-        const char* lab = items[i].label ? items[i].label : items[i].id;
-        if (items[i].label_fn) {
-            char dyn[128];
-            const char* got = items[i].label_fn(ctx, dyn, sizeof dyn);
-            if (got && *got) {
-                lab = got;
-            }
-        }
-        int L = (int)strlen(lab);
-        if (items[i].submenu && items[i].submenu_len > 0) {
-            L += 2; // " >" suffix
-        }
+        int L = ui_menu_item_label_len(&items[i], ctx);
         if (L > maxlab) {
             maxlab = L;
         }
@@ -345,8 +341,30 @@ ui_overlay_compute_height(int visible_items) {
     return (height < 9) ? 9 : height;
 }
 
-void
-ui_overlay_layout(UiMenuFrame* f, const void* ctx) {
+#ifdef DSD_NEO_TEST_HOOKS
+int
+ui_overlay_cap_then_floor_for_test(int value, int max_value, int min_value) {
+    return ui_overlay_cap_then_floor(value, max_value, min_value);
+}
+
+int
+ui_overlay_center_axis_for_test(int outer, int inner) {
+    return ui_overlay_center_axis(outer, inner);
+}
+
+int
+ui_overlay_compute_width_for_test(const UiMenuFrame* f, int maxlab) {
+    return ui_overlay_compute_width(f, maxlab);
+}
+
+int
+ui_overlay_compute_height_for_test(int visible_items) {
+    return ui_overlay_compute_height(visible_items);
+}
+#endif
+
+static void
+ui_overlay_layout_for_terminal(UiMenuFrame* f, const void* ctx, int term_h, int term_w) {
     if (!f || !f->items || f->n == 0) {
         return;
     }
@@ -354,15 +372,30 @@ ui_overlay_layout(UiMenuFrame* f, const void* ctx) {
     int vis = ui_visible_count_and_maxlab(f->items, f->n, ctx, &maxlab);
     int width = ui_overlay_compute_width(f, maxlab);
     int height = ui_overlay_compute_height(vis);
-    int term_h = 24;
-    int term_w = 80;
-    getmaxyx(stdscr, term_h, term_w);
     width = ui_overlay_cap_then_floor(width, term_w - 2, 10);
     height = ui_overlay_cap_then_floor(height, term_h - 2, 6);
     f->h = height;
     f->w = width;
     f->y = ui_overlay_center_axis(term_h, height);
     f->x = ui_overlay_center_axis(term_w, width);
+}
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+ui_overlay_layout_for_test(UiMenuFrame* f, const void* ctx, int term_h, int term_w) {
+    ui_overlay_layout_for_terminal(f, ctx, term_h, term_w);
+}
+#endif
+
+void
+ui_overlay_layout(UiMenuFrame* f, const void* ctx) {
+    if (!f || !f->items || f->n == 0) {
+        return;
+    }
+    int term_h = 24;
+    int term_w = 80;
+    getmaxyx(stdscr, term_h, term_w);
+    ui_overlay_layout_for_terminal(f, ctx, term_h, term_w);
 }
 
 void

--- a/src/ui/terminal/ncurses_snr.c
+++ b/src/ui/terminal/ncurses_snr.c
@@ -39,6 +39,103 @@ enum { SNR_METER_BARS = 5, SNR_METER_WIDTH = (SNR_METER_BARS * 2) - 1 };
 
 enum { SNR_BLOCK_LEVELS = 8 };
 
+#ifdef DSD_NEO_TEST_HOOKS
+struct snr_emit_hooks {
+    dsd_ncurses_snr_emit_ch_fn emit_ch;
+    dsd_ncurses_snr_emit_str_fn emit_str;
+    dsd_ncurses_snr_emit_attr_fn emit_attron;
+    dsd_ncurses_snr_emit_attr_fn emit_attroff;
+    dsd_ncurses_snr_emit_attr_get_fn emit_attr_get;
+    dsd_ncurses_snr_emit_attr_set_fn emit_attr_set;
+};
+
+static struct snr_emit_hooks g_snr_emit_hooks;
+
+// cppcheck-suppress-begin funcArgNamesDifferentUnnamed
+void
+dsd_ncurses_snr_set_emit_hooks_for_test(dsd_ncurses_snr_emit_ch_fn emit_ch, dsd_ncurses_snr_emit_str_fn emit_str,
+                                        dsd_ncurses_snr_emit_attr_fn emit_attron,
+                                        dsd_ncurses_snr_emit_attr_fn emit_attroff,
+                                        dsd_ncurses_snr_emit_attr_get_fn emit_attr_get,
+                                        dsd_ncurses_snr_emit_attr_set_fn emit_attr_set) {
+    g_snr_emit_hooks.emit_ch = emit_ch;
+    g_snr_emit_hooks.emit_str = emit_str;
+    g_snr_emit_hooks.emit_attron = emit_attron;
+    g_snr_emit_hooks.emit_attroff = emit_attroff;
+    g_snr_emit_hooks.emit_attr_get = emit_attr_get;
+    g_snr_emit_hooks.emit_attr_set = emit_attr_set;
+}
+
+// cppcheck-suppress-end funcArgNamesDifferentUnnamed
+#endif
+
+static int
+snr_emit_ch(chtype ch) {
+#ifdef DSD_NEO_TEST_HOOKS
+    if (g_snr_emit_hooks.emit_ch) {
+        return g_snr_emit_hooks.emit_ch((unsigned long)ch);
+    }
+#endif
+    return addch(ch);
+}
+
+static int
+snr_emit_str(const char* text) {
+#ifdef DSD_NEO_TEST_HOOKS
+    if (g_snr_emit_hooks.emit_str) {
+        return g_snr_emit_hooks.emit_str(text);
+    }
+#endif
+    return addstr(text);
+}
+
+#if defined(PRETTY_COLORS)
+static int
+snr_emit_attron(attr_t attrs) {
+#ifdef DSD_NEO_TEST_HOOKS
+    if (g_snr_emit_hooks.emit_attron) {
+        return g_snr_emit_hooks.emit_attron((unsigned long)attrs);
+    }
+#endif
+    return attron(attrs);
+}
+
+static int
+snr_emit_attroff(attr_t attrs) {
+#ifdef DSD_NEO_TEST_HOOKS
+    if (g_snr_emit_hooks.emit_attroff) {
+        return g_snr_emit_hooks.emit_attroff((unsigned long)attrs);
+    }
+#endif
+    return attroff(attrs);
+}
+
+static int
+snr_emit_attr_get(attr_t* attrs, short* pair) {
+#ifdef DSD_NEO_TEST_HOOKS
+    if (g_snr_emit_hooks.emit_attr_get) {
+        unsigned long tmp_attrs = 0;
+        int ret = g_snr_emit_hooks.emit_attr_get(&tmp_attrs, pair);
+        if (attrs) {
+            *attrs = (attr_t)tmp_attrs;
+        }
+        return ret;
+    }
+#endif
+    return attr_get(attrs, pair, NULL);
+}
+
+static int
+snr_emit_attr_set(attr_t attrs, short pair) {
+#ifdef DSD_NEO_TEST_HOOKS
+    if (g_snr_emit_hooks.emit_attr_set) {
+        return g_snr_emit_hooks.emit_attr_set((unsigned long)attrs, pair);
+    }
+#endif
+    return attr_set(attrs, pair, NULL);
+}
+#endif
+
 #if defined(DSD_USE_PDCURSES) && !defined(DSD_HAS_PDCURSES_WIDE_API)
 #define SNR_USE_UNICODE(option_enabled, block_glyphs_supported)                                                        \
     ((void)(option_enabled), (void)(block_glyphs_supported), 0)
@@ -217,11 +314,61 @@ snr_hist_level_index(double value, double clip_lo, double span, int levels) {
     return li;
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_ncurses_snr_hist_reset_for_test(void) {
+    for (int i = 0; i < SNR_HIST_N; i++) {
+        snr_hist_c4fm[i] = 0.0;
+        snr_hist_qpsk[i] = 0.0;
+        snr_hist_gfsk[i] = 0.0;
+    }
+    snr_hist_len_c4fm = 0;
+    snr_hist_head_c4fm = 0;
+    snr_hist_len_qpsk = 0;
+    snr_hist_head_qpsk = 0;
+    snr_hist_len_gfsk = 0;
+    snr_hist_head_gfsk = 0;
+}
+
+int
+dsd_ncurses_snr_hist_len_for_test(int mod) {
+    return snr_hist_view_for_mod(mod).len;
+}
+
+int
+dsd_ncurses_snr_hist_head_for_test(int mod) {
+    return snr_hist_view_for_mod(mod).head;
+}
+
+double
+dsd_ncurses_snr_hist_value_for_test(int mod, int index) {
+    if (index < 0 || index >= SNR_HIST_N) {
+        return 0.0;
+    }
+    return snr_hist_view_for_mod(mod).buf[index];
+}
+
+int
+dsd_ncurses_snr_hist_render_count_for_test(int len, int width) {
+    return snr_hist_render_count(len, width);
+}
+
+int
+dsd_ncurses_snr_hist_render_start_for_test(int head, int len, int count) {
+    return snr_hist_render_start(head, len, count);
+}
+
+int
+dsd_ncurses_snr_level_index_for_test(double value, double clip_lo, double span, int levels) {
+    return snr_hist_level_index(value, clip_lo, span, levels);
+}
+#endif
+
 static void
 snr_draw_level_glyph(double sample, int mod, int use_unicode, const char* ascii8, int li) {
 #ifdef PRETTY_COLORS
     short cp = snr_quality_color_pair(sample, mod);
-    attron(COLOR_PAIR(cp));
+    snr_emit_attron(COLOR_PAIR(cp));
 #else
     (void)sample;
     (void)mod;
@@ -230,13 +377,13 @@ snr_draw_level_glyph(double sample, int mod, int use_unicode, const char* ascii8
 #if defined(DSD_USE_PDCURSES) && defined(DSD_HAS_PDCURSES_WIDE_API)
         addwstr(snr_block_glyphs[li]);
 #else
-        addstr(snr_block_glyphs[li]);
+        snr_emit_str(snr_block_glyphs[li]);
 #endif
     } else {
-        addch(ascii8[li]);
+        snr_emit_ch(ascii8[li]);
     }
 #ifdef PRETTY_COLORS
-    attroff(COLOR_PAIR(cp));
+    snr_emit_attroff(COLOR_PAIR(cp));
 #endif
 }
 
@@ -246,7 +393,7 @@ print_snr_sparkline(const dsd_opts* opts, int mod) {
 #ifdef PRETTY_COLORS
     attr_t saved_attrs = 0;
     short saved_pair = 0;
-    attr_get(&saved_attrs, &saved_pair, NULL);
+    snr_emit_attr_get(&saved_attrs, &saved_pair);
 #endif
     /* Make the lowest ASCII level visible (no leading space) */
     static const char ascii8[] = ".:;-=+*#"; /* 8 levels */
@@ -273,7 +420,7 @@ print_snr_sparkline(const dsd_opts* opts, int mod) {
     }
 #ifdef PRETTY_COLORS
     /* Restore previously active color pair (e.g., green call banner) */
-    attr_set(saved_attrs, saved_pair, NULL);
+    snr_emit_attr_set(saved_attrs, saved_pair);
 #endif
 }
 
@@ -285,7 +432,7 @@ print_snr_meter(const dsd_opts* opts, double snr_db, int mod) {
 #ifdef PRETTY_COLORS
     attr_t saved_attrs = 0;
     short saved_pair = 0;
-    attr_get(&saved_attrs, &saved_pair, NULL);
+    snr_emit_attr_get(&saved_attrs, &saved_pair);
 #endif
     const int bars = snr_meter_bar_count(snr_db);
     int use_unicode = SNR_USE_UNICODE(opts && opts->eye_unicode, ui_block_glyphs_supported());
@@ -294,31 +441,31 @@ print_snr_meter(const dsd_opts* opts, double snr_db, int mod) {
 #endif
     for (int i = 0; i < SNR_METER_BARS; i++) {
         if (i > 0) {
-            addch(' ');
+            snr_emit_ch(' ');
         }
         if (i >= bars) {
-            addch(' ');
+            snr_emit_ch(' ');
             continue;
         }
 #ifdef PRETTY_COLORS
-        attron(COLOR_PAIR(cp));
+        snr_emit_attron(COLOR_PAIR(cp));
 #endif
         if (use_unicode) {
 #if defined(DSD_USE_PDCURSES) && defined(DSD_HAS_PDCURSES_WIDE_API)
             addwstr(snr_block_glyphs[i]);
 #else
-            addstr(snr_block_glyphs[i]);
+            snr_emit_str(snr_block_glyphs[i]);
 #endif
         } else {
-            addch('|');
+            snr_emit_ch('|');
         }
 #ifdef PRETTY_COLORS
-        attroff(COLOR_PAIR(cp));
-        attr_set(saved_attrs, saved_pair, NULL);
+        snr_emit_attroff(COLOR_PAIR(cp));
+        snr_emit_attr_set(saved_attrs, saved_pair);
 #endif
     }
 #ifdef PRETTY_COLORS
     /* Padding belongs to the caller's line styling, not the temporary SNR color. */
-    attr_set(saved_attrs, saved_pair, NULL);
+    snr_emit_attr_set(saved_attrs, saved_pair);
 #endif
 }

--- a/src/ui/terminal/ui_async.c
+++ b/src/ui/terminal/ui_async.c
@@ -140,6 +140,45 @@ ui_draw_if_needed(const dsd_opts* osnap, uint64_t* last_draw_ns, uint64_t frame_
     *last_draw_ns = now_ns;
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_neo_ui_async_test_set_context(dsd_opts* opts, dsd_state* state) {
+    g_ui_opts = opts;
+    g_ui_state = state;
+    g_ui_curses_cfg_done = 0;
+    atomic_store(&g_ui_dirty, 0);
+    atomic_store(&g_ui_in_context, 0);
+}
+
+const dsd_opts*
+dsd_neo_ui_async_test_opts_snapshot_or_default(void) {
+    return ui_get_opts_snapshot_or_default();
+}
+
+int
+dsd_neo_ui_async_test_curses_is_active(const dsd_opts* opts) {
+    return ui_curses_is_active(opts);
+}
+
+int
+dsd_neo_ui_async_test_read_key_nonblocking(const dsd_opts* opts) {
+    return ui_read_key_nonblocking(opts);
+}
+
+void
+dsd_neo_ui_async_test_process_input_frame(const dsd_opts* opts) {
+    ui_process_input_frame(opts);
+}
+
+void
+dsd_neo_ui_async_test_draw_if_needed(const dsd_opts* opts, uint64_t* last_draw_ns, uint64_t frame_ns) {
+    if (last_draw_ns == NULL) {
+        return;
+    }
+    ui_draw_if_needed(opts, last_draw_ns, frame_ns);
+}
+#endif
+
 static DSD_THREAD_RETURN_TYPE
 #if DSD_PLATFORM_WIN_NATIVE
     __stdcall

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -735,6 +735,21 @@ target_link_libraries(dsd-neo_test_ysf_frame PRIVATE ${LIBS})
 add_test(NAME YSF_FRAME COMMAND dsd-neo_test_ysf_frame)
 
 add_executable(
+    dsd-neo_test_p25_p2_ysf_sync_dispatch
+    protocol/p25/test_p25_p2_ysf_sync_dispatch.c
+    ${PROJECT_SOURCE_DIR}/src/engine/dispatch/dispatch_p25p2.c
+    ${PROJECT_SOURCE_DIR}/src/engine/dispatch/dispatch_ysf.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p2_ysf_sync_dispatch
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(
+    NAME P25_P2_YSF_SYNC_DISPATCH
+    COMMAND dsd-neo_test_p25_p2_ysf_sync_dispatch
+)
+
+add_executable(
     dsd-neo_test_x2tdma_frame
     protocol/x2tdma/test_x2tdma_frame.c
     ${PROJECT_SOURCE_DIR}/src/protocol/x2tdma/x2tdma_frame.c
@@ -858,6 +873,32 @@ add_test(
     NAME NXDN_VOICE_AES_KEYSTREAM
     COMMAND dsd-neo_test_nxdn_voice_aes_keystream
 )
+
+add_executable(
+    dsd-neo_test_nxdn_voice_mapping
+    protocol/nxdn/test_nxdn_voice_mapping.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/nxdn/nxdn_voice.c
+)
+target_include_directories(
+    dsd-neo_test_nxdn_voice_mapping
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME NXDN_VOICE_MAPPING COMMAND dsd-neo_test_nxdn_voice_mapping)
+
+add_executable(
+    dsd-neo_test_nxdn_frame_routing
+    protocol/nxdn/test_nxdn_frame_routing.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/nxdn/nxdn_frame.c
+)
+target_compile_definitions(
+    dsd-neo_test_nxdn_frame_routing
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
+target_include_directories(
+    dsd-neo_test_nxdn_frame_routing
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME NXDN_FRAME_ROUTING COMMAND dsd-neo_test_nxdn_frame_routing)
 
 add_executable(
     dsd-neo_test_nxdn_sync_dispatch
@@ -1170,6 +1211,21 @@ target_link_libraries(
 add_test(NAME UI_MENU_DYNAMIC_LABEL COMMAND dsd-neo_test_ui_menu_dynamic_label)
 
 add_executable(
+    dsd-neo_test_ui_menu_env
+    ui/test_ui_menu_env.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_env.c
+)
+target_include_directories(
+    dsd-neo_test_ui_menu_env
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
+)
+target_link_libraries(
+    dsd-neo_test_ui_menu_env
+    PRIVATE dsd-neo_runtime ${DSD_NEO_TEST_MATH_LIB}
+)
+add_test(NAME UI_MENU_ENV COMMAND dsd-neo_test_ui_menu_env)
+
+add_executable(
     dsd-neo_test_ui_chooser_navigation
     ui/test_ui_chooser_navigation.c
     ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_prompts.c
@@ -1260,6 +1316,18 @@ add_test(
 )
 
 add_executable(
+    dsd-neo_test_ui_opts_snapshot
+    ui/test_ui_opts_snapshot.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_opts_snapshot.c
+)
+target_include_directories(
+    dsd-neo_test_ui_opts_snapshot
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
+)
+target_link_libraries(dsd-neo_test_ui_opts_snapshot PRIVATE dsd-neo_platform)
+add_test(NAME UI_OPTS_SNAPSHOT COMMAND dsd-neo_test_ui_opts_snapshot)
+
+add_executable(
     dsd-neo_test_runtime_freq_parse
     runtime/test_runtime_freq_parse.c
 )
@@ -1269,6 +1337,23 @@ target_include_directories(
 )
 target_link_libraries(dsd-neo_test_runtime_freq_parse PRIVATE dsd-neo_runtime)
 add_test(NAME RUNTIME_FREQ_PARSE COMMAND dsd-neo_test_runtime_freq_parse)
+
+add_executable(
+    dsd-neo_test_runtime_dmr_t3_lcn_calc
+    runtime/test_runtime_dmr_t3_lcn_calc.c
+)
+target_include_directories(
+    dsd-neo_test_runtime_dmr_t3_lcn_calc
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_runtime_dmr_t3_lcn_calc
+    PRIVATE dsd-neo_runtime dsd-neo_test_support
+)
+add_test(
+    NAME RUNTIME_DMR_T3_LCN_CALC
+    COMMAND dsd-neo_test_runtime_dmr_t3_lcn_calc
+)
 
 add_executable(
     dsd-neo_test_runtime_input_spec
@@ -3502,6 +3587,22 @@ target_link_libraries(
 )
 add_test(NAME M17_REFERENCE_VECTORS COMMAND dsd-neo_test_m17_reference_vectors)
 
+target_compile_definitions(dsd-neo_proto_m17 PRIVATE DSD_NEO_TEST_HOOKS)
+add_executable(
+    dsd-neo_test_m17_state_dispatch
+    protocol/m17/test_m17_state_dispatch.c
+)
+target_compile_definitions(
+    dsd-neo_test_m17_state_dispatch
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
+target_include_directories(
+    dsd-neo_test_m17_state_dispatch
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(dsd-neo_test_m17_state_dispatch PRIVATE dsd-neo_proto_m17)
+add_test(NAME M17_STATE_DISPATCH COMMAND dsd-neo_test_m17_state_dispatch)
+
 add_executable(
     dsd-neo_test_dmr_t3_sm_clamp
     protocol/dmr/test_dmr_t3_sm_clamp.c
@@ -4002,6 +4103,43 @@ target_link_libraries(dsd-neo_test_dmr_debug_burst PRIVATE dsd-neo_proto_dmr)
 add_test(NAME DMR_DEBUG_BURST COMMAND dsd-neo_test_dmr_debug_burst)
 
 add_executable(
+    dsd-neo_test_dmr_dburst_profile
+    protocol/dmr/test_dmr_dburst_profile.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_dburst.c
+)
+target_compile_definitions(
+    dsd-neo_test_dmr_dburst_profile
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
+target_include_directories(
+    dsd-neo_test_dmr_dburst_profile
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME DMR_DBURST_PROFILE COMMAND dsd-neo_test_dmr_dburst_profile)
+
+add_executable(
+    dsd-neo_test_dmr_data_sync
+    protocol/dmr/test_dmr_data_sync.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_data.c
+)
+target_include_directories(
+    dsd-neo_test_dmr_data_sync
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/protocol/dmr
+)
+add_test(NAME DMR_DATA_SYNC COMMAND dsd-neo_test_dmr_data_sync)
+
+add_executable(
+    dsd-neo_test_dmr_ms_data
+    protocol/dmr/test_dmr_ms_data.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ms.c
+)
+target_include_directories(
+    dsd-neo_test_dmr_ms_data
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME DMR_MS_DATA COMMAND dsd-neo_test_dmr_ms_data)
+
+add_executable(
     dsd-neo_test_dmr_confirmed_crc9
     protocol/dmr/test_dmr_confirmed_crc9.c
 )
@@ -4128,6 +4266,18 @@ target_link_libraries(
     PRIVATE dsd-neo_proto_dmr
 )
 add_test(NAME DMR_CONFIDENCE_GATE COMMAND dsd-neo_test_dmr_confidence_gate)
+
+add_executable(
+    dsd-neo_test_dmr_csbk_helpers
+    protocol/dmr/test_dmr_csbk_helpers.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_csbk_parse.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_csbk_tables.c
+)
+target_include_directories(
+    dsd-neo_test_dmr_csbk_helpers
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME DMR_CSBK_HELPERS COMMAND dsd-neo_test_dmr_csbk_helpers)
 
 add_executable(dsd-neo_test_dmr_r34_stub protocol/dmr/test_dmr_r34_stub.c)
 target_include_directories(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2950,6 +2950,29 @@ else()
 endif()
 add_test(NAME RUNTIME_CONFIG_APPLY COMMAND dsd-neo_test_runtime_config_apply)
 
+add_executable(dsd-neo_test_ui_cmd_queue ui/test_ui_cmd_queue.c)
+target_include_directories(
+    dsd-neo_test_ui_cmd_queue
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${CURSES_INCLUDE_DIRS}
+)
+if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
+    target_link_libraries(
+        dsd-neo_test_ui_cmd_queue
+        PRIVATE
+            "-Wl,--start-group"
+            ${_DSD_RUNTIME_CONFIG_APPLY_LIBS}
+            "-Wl,--end-group"
+            ${LIBS}
+            dsd-neo_test_support
+    )
+else()
+    target_link_libraries(
+        dsd-neo_test_ui_cmd_queue
+        PRIVATE ${_DSD_RUNTIME_CONFIG_APPLY_LIBS} ${LIBS} dsd-neo_test_support
+    )
+endif()
+add_test(NAME UI_CMD_QUEUE COMMAND dsd-neo_test_ui_cmd_queue)
+
 set(_DSD_BOOTSTRAP_FIXTURE_DIR
     "${CMAKE_CURRENT_BINARY_DIR}/runtime_bootstrap_fixtures"
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -622,6 +622,17 @@ target_link_libraries(
 add_test(NAME DSTAR_HEADER_UTILS COMMAND dsd-neo_test_dstar_header_utils)
 
 add_executable(
+    dsd-neo_test_dstar_process
+    protocol/dstar/test_dstar_process.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dstar/dstar.c
+)
+target_include_directories(
+    dsd-neo_test_dstar_process
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME DSTAR_PROCESS COMMAND dsd-neo_test_dstar_process)
+
+add_executable(
     dsd-neo_test_dstar_sync_dispatch
     protocol/dstar/test_dstar_sync_dispatch.c
     ${PROJECT_SOURCE_DIR}/src/engine/dispatch/dispatch_dstar.c
@@ -647,6 +658,20 @@ target_link_libraries(
     PRIVATE dsd-neo_proto_provoice
 )
 add_test(NAME PROVOICE_FRAME COMMAND dsd-neo_test_provoice_frame)
+
+add_executable(
+    dsd-neo_test_provoice_process
+    protocol/provoice/test_provoice_process.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/provoice/provoice.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/provoice/provoice_frame.c
+)
+target_include_directories(
+    dsd-neo_test_provoice_process
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/protocol/provoice
+)
+add_test(NAME PROVOICE_PROCESS COMMAND dsd-neo_test_provoice_process)
 
 add_executable(
     dsd-neo_test_provoice_sync_dispatch
@@ -734,6 +759,34 @@ target_include_directories(
 target_link_libraries(dsd-neo_test_ysf_frame PRIVATE ${LIBS})
 add_test(NAME YSF_FRAME COMMAND dsd-neo_test_ysf_frame)
 
+target_compile_definitions(dsd-neo_proto_ysf PRIVATE DSD_NEO_TEST_HOOKS)
+add_executable(dsd-neo_test_ysf_dch_decode protocol/ysf/test_ysf_dch_decode.c)
+target_compile_definitions(
+    dsd-neo_test_ysf_dch_decode
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
+target_include_directories(
+    dsd-neo_test_ysf_dch_decode
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_ysf_dch_decode
+    PRIVATE
+        "-Wl,--start-group"
+        dsd-neo_proto_ysf
+        ${_DSD_RUNTIME_CLI_PARSE_LIBS}
+        "-Wl,--end-group"
+        ${LIBS}
+)
+target_link_options(
+    dsd-neo_test_ysf_dch_decode
+    PRIVATE
+        -Wl,--wrap=getDibit
+        -Wl,--wrap=processMbeFrame
+        -Wl,--wrap=dsd_mbe_process_ambe2450_dataf
+)
+add_test(NAME YSF_DCH_DECODE COMMAND dsd-neo_test_ysf_dch_decode)
+
 add_executable(
     dsd-neo_test_p25_p2_ysf_sync_dispatch
     protocol/p25/test_p25_p2_ysf_sync_dispatch.c
@@ -774,6 +827,33 @@ target_include_directories(
 add_test(NAME X2TDMA_SYNC_DISPATCH COMMAND dsd-neo_test_x2tdma_sync_dispatch)
 
 add_executable(
+    dsd-neo_test_x2tdma_data
+    protocol/x2tdma/test_x2tdma_data.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/x2tdma/x2tdma_data.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/x2tdma/x2tdma_frame.c
+)
+target_include_directories(
+    dsd-neo_test_x2tdma_data
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/protocol/x2tdma
+)
+add_test(NAME X2TDMA_DATA COMMAND dsd-neo_test_x2tdma_data)
+
+add_executable(
+    dsd-neo_test_x2tdma_voice_helpers
+    protocol/x2tdma/test_x2tdma_voice_helpers.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/x2tdma/x2tdma_frame.c
+)
+target_include_directories(
+    dsd-neo_test_x2tdma_voice_helpers
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/protocol/x2tdma
+)
+add_test(NAME X2TDMA_VOICE_HELPERS COMMAND dsd-neo_test_x2tdma_voice_helpers)
+
+add_executable(
     dsd-neo_test_nxdn_trunk_diag
     protocol/nxdn/test_nxdn_trunk_diag.c
 )
@@ -794,6 +874,21 @@ target_include_directories(
 )
 target_link_libraries(dsd-neo_test_nxdn_alias_decode PRIVATE dsd-neo_proto_nxdn)
 add_test(NAME NXDN_ALIAS_DECODE COMMAND dsd-neo_test_nxdn_alias_decode)
+
+add_executable(
+    dsd-neo_test_nxdn_alias_fallback
+    protocol/nxdn/test_nxdn_alias_fallback.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/nxdn/nxdn_alias_decode.c
+)
+target_compile_definitions(
+    dsd-neo_test_nxdn_alias_fallback
+    PRIVATE DSD_HAVE_ICONV=0
+)
+target_include_directories(
+    dsd-neo_test_nxdn_alias_fallback
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME NXDN_ALIAS_FALLBACK COMMAND dsd-neo_test_nxdn_alias_fallback)
 
 add_executable(
     dsd-neo_test_nxdn_dcr_utils
@@ -817,6 +912,46 @@ target_include_directories(
     PRIVATE ${PROJECT_SOURCE_DIR}/include
 )
 add_test(NAME NXDN_DEPERM_WINDOWS COMMAND dsd-neo_test_nxdn_deperm_windows)
+
+target_compile_definitions(dsd-neo_proto_nxdn PRIVATE DSD_NEO_TEST_HOOKS)
+add_executable(
+    dsd-neo_test_nxdn_deperm_primitives
+    protocol/nxdn/test_nxdn_deperm_primitives.c
+)
+target_compile_definitions(
+    dsd-neo_test_nxdn_deperm_primitives
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
+target_include_directories(
+    dsd-neo_test_nxdn_deperm_primitives
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_nxdn_deperm_primitives
+    PRIVATE
+        "-Wl,--start-group"
+        dsd-neo_proto_nxdn
+        dsd-neo_proto_dmr
+        dsd-neo_proto_p25
+        dsd-neo_core
+        "-Wl,--end-group"
+        ${LIBS}
+)
+add_test(
+    NAME NXDN_DEPERM_PRIMITIVES
+    COMMAND dsd-neo_test_nxdn_deperm_primitives
+)
+
+add_executable(
+    dsd-neo_test_nxdn_convolution
+    protocol/nxdn/test_nxdn_convolution.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/nxdn/nxdn_convolution.c
+)
+target_include_directories(
+    dsd-neo_test_nxdn_convolution
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME NXDN_CONVOLUTION COMMAND dsd-neo_test_nxdn_convolution)
 
 add_executable(
     dsd-neo_test_nxdn_lfsr
@@ -919,6 +1054,40 @@ target_include_directories(
 target_link_libraries(dsd-neo_test_runtime_rings PRIVATE dsd-neo_runtime)
 add_test(NAME RUNTIME_RINGS COMMAND dsd-neo_test_runtime_rings)
 
+add_executable(dsd-neo_test_runtime_mem runtime/test_runtime_mem.cpp)
+target_include_directories(
+    dsd-neo_test_runtime_mem
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(dsd-neo_test_runtime_mem PRIVATE dsd-neo_runtime)
+add_test(NAME RUNTIME_MEM COMMAND dsd-neo_test_runtime_mem)
+
+add_executable(
+    dsd-neo_test_runtime_worker_pool
+    runtime/test_runtime_worker_pool.cpp
+)
+target_include_directories(
+    dsd-neo_test_runtime_worker_pool
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(dsd-neo_test_runtime_worker_pool PRIVATE dsd-neo_runtime)
+add_test(NAME RUNTIME_WORKER_POOL COMMAND dsd-neo_test_runtime_worker_pool)
+
+add_executable(
+    dsd-neo_test_runtime_rt_sched
+    runtime/test_runtime_rt_sched.cpp
+    ${PROJECT_SOURCE_DIR}/src/runtime/rt_sched.cpp
+)
+target_compile_definitions(
+    dsd-neo_test_runtime_rt_sched
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
+target_include_directories(
+    dsd-neo_test_runtime_rt_sched
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME RUNTIME_RT_SCHED COMMAND dsd-neo_test_runtime_rt_sched)
+
 add_executable(
     dsd-neo_test_runtime_unicode_block_glyphs
     runtime/test_runtime_unicode_block_glyphs.c
@@ -936,6 +1105,14 @@ add_test(
     COMMAND dsd-neo_test_runtime_unicode_block_glyphs
 )
 
+add_executable(dsd-neo_test_runtime_log runtime/test_runtime_log.cpp)
+target_include_directories(
+    dsd-neo_test_runtime_log
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(dsd-neo_test_runtime_log PRIVATE dsd-neo_runtime)
+add_test(NAME RUNTIME_LOG COMMAND dsd-neo_test_runtime_log)
+
 add_executable(
     dsd-neo_test_runtime_input_ring_init
     runtime/test_runtime_input_ring_init.cpp
@@ -951,6 +1128,23 @@ target_link_libraries(
 add_test(
     NAME RUNTIME_INPUT_RING_INIT
     COMMAND dsd-neo_test_runtime_input_ring_init
+)
+
+add_executable(
+    dsd-neo_test_runtime_frame_sync_hooks
+    runtime/test_runtime_frame_sync_hooks.c
+)
+target_include_directories(
+    dsd-neo_test_runtime_frame_sync_hooks
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_runtime_frame_sync_hooks
+    PRIVATE dsd-neo_runtime
+)
+add_test(
+    NAME RUNTIME_FRAME_SYNC_HOOKS
+    COMMAND dsd-neo_test_runtime_frame_sync_hooks
 )
 
 add_executable(
@@ -980,6 +1174,255 @@ add_test(
     NAME RUNTIME_P25_P2_AUDIO_RING
     COMMAND dsd-neo_test_runtime_p25_p2_audio_ring
 )
+
+add_executable(
+    dsd-neo_test_ui_async_lifecycle
+    ui/test_ui_async_lifecycle.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_async.c
+)
+target_compile_definitions(
+    dsd-neo_test_ui_async_lifecycle
+    PRIVATE DSD_NEO_THREADING_NO_INLINE_CREATE DSD_NEO_TEST_HOOKS
+)
+target_include_directories(
+    dsd-neo_test_ui_async_lifecycle
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
+)
+add_test(NAME UI_ASYNC_LIFECYCLE COMMAND dsd-neo_test_ui_async_lifecycle)
+
+add_executable(
+    dsd-neo_test_ui_cmd_actions
+    ui/test_ui_cmd_actions.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/actions/actions_audio.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/actions/actions_radio.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/actions/actions_trunk.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/actions/actions_logging.c
+)
+target_include_directories(
+    dsd-neo_test_ui_cmd_actions
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME UI_CMD_ACTIONS COMMAND dsd-neo_test_ui_cmd_actions)
+
+add_executable(
+    dsd-neo_test_ui_menu_services
+    ui/test_ui_menu_services.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_services.c
+)
+target_include_directories(
+    dsd-neo_test_ui_menu_services
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
+)
+target_compile_definitions(dsd-neo_test_ui_menu_services PRIVATE USE_RADIO)
+add_test(NAME UI_MENU_SERVICES COMMAND dsd-neo_test_ui_menu_services)
+
+add_executable(
+    dsd-neo_test_ui_menu_labels
+    ui/test_ui_menu_labels.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_labels.c
+)
+target_include_directories(
+    dsd-neo_test_ui_menu_labels
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal
+        ${CURSES_INCLUDE_DIRS}
+)
+add_test(NAME UI_MENU_LABELS COMMAND dsd-neo_test_ui_menu_labels)
+
+add_executable(
+    dsd-neo_test_ui_menu_labels_radio
+    ui/test_ui_menu_labels_radio.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_labels.c
+)
+target_include_directories(
+    dsd-neo_test_ui_menu_labels_radio
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal
+        ${CURSES_INCLUDE_DIRS}
+)
+target_compile_definitions(dsd-neo_test_ui_menu_labels_radio PRIVATE USE_RADIO)
+add_test(NAME UI_MENU_LABELS_RADIO COMMAND dsd-neo_test_ui_menu_labels_radio)
+
+add_executable(
+    dsd-neo_test_ui_menu_render_helpers
+    ui/test_ui_menu_render_helpers.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_render.c
+)
+target_include_directories(
+    dsd-neo_test_ui_menu_render_helpers
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal
+        ${CURSES_INCLUDE_DIRS}
+)
+target_compile_definitions(
+    dsd-neo_test_ui_menu_render_helpers
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
+target_link_libraries(
+    dsd-neo_test_ui_menu_render_helpers
+    PRIVATE ${CURSES_LIBRARIES}
+)
+add_test(
+    NAME UI_MENU_RENDER_HELPERS
+    COMMAND dsd-neo_test_ui_menu_render_helpers
+)
+
+add_executable(
+    dsd-neo_test_ui_menu_defs
+    ui/test_ui_menu_defs.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menus/menu_defs.c
+)
+target_include_directories(
+    dsd-neo_test_ui_menu_defs
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
+)
+add_test(NAME UI_MENU_DEFS COMMAND dsd-neo_test_ui_menu_defs)
+
+add_executable(
+    dsd-neo_test_ui_panels_header_footer
+    ui/test_ui_panels_header_footer.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/panels/header.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/panels/footer.c
+)
+target_compile_definitions(
+    dsd-neo_test_ui_panels_header_footer
+    PRIVATE NCURSES_NOMACROS
+)
+target_include_directories(
+    dsd-neo_test_ui_panels_header_footer
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${CURSES_INCLUDE_DIRS}
+)
+target_link_libraries(
+    dsd-neo_test_ui_panels_header_footer
+    PRIVATE ${CURSES_LIBRARIES}
+)
+add_test(
+    NAME UI_PANELS_HEADER_FOOTER
+    COMMAND dsd-neo_test_ui_panels_header_footer
+)
+
+add_executable(
+    dsd-neo_test_ui_ncurses_visualizers_helpers
+    ui/test_ui_ncurses_visualizers_helpers.c
+)
+target_include_directories(
+    dsd-neo_test_ui_ncurses_visualizers_helpers
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal
+        ${CURSES_INCLUDE_DIRS}
+)
+target_link_libraries(
+    dsd-neo_test_ui_ncurses_visualizers_helpers
+    PRIVATE ${CURSES_LIBRARIES} ${DSD_NEO_TEST_MATH_LIB}
+)
+add_test(
+    NAME UI_NCURSES_VISUALIZERS_HELPERS
+    COMMAND dsd-neo_test_ui_ncurses_visualizers_helpers
+)
+
+add_executable(
+    dsd-neo_test_ui_telemetry_hooks_install
+    ui/test_ui_telemetry_hooks_install.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/telemetry_hooks_install.c
+)
+target_include_directories(
+    dsd-neo_test_ui_telemetry_hooks_install
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
+)
+add_test(
+    NAME UI_TELEMETRY_HOOKS_INSTALL
+    COMMAND dsd-neo_test_ui_telemetry_hooks_install
+)
+
+add_executable(
+    dsd-neo_test_ui_ncurses_trunk_display_helpers
+    ui/test_ui_ncurses_trunk_display_helpers.c
+)
+target_include_directories(
+    dsd-neo_test_ui_ncurses_trunk_display_helpers
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal
+        ${CURSES_INCLUDE_DIRS}
+)
+target_link_libraries(
+    dsd-neo_test_ui_ncurses_trunk_display_helpers
+    PRIVATE ${CURSES_LIBRARIES}
+)
+add_test(
+    NAME UI_NCURSES_TRUNK_DISPLAY_HELPERS
+    COMMAND dsd-neo_test_ui_ncurses_trunk_display_helpers
+)
+
+add_executable(
+    dsd-neo_test_ui_ncurses_p25_display_helpers
+    ui/test_ui_ncurses_p25_display_helpers.c
+)
+target_include_directories(
+    dsd-neo_test_ui_ncurses_p25_display_helpers
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal
+        ${CURSES_INCLUDE_DIRS}
+)
+target_link_libraries(
+    dsd-neo_test_ui_ncurses_p25_display_helpers
+    PRIVATE ${CURSES_LIBRARIES}
+)
+add_test(
+    NAME UI_NCURSES_P25_DISPLAY_HELPERS
+    COMMAND dsd-neo_test_ui_ncurses_p25_display_helpers
+)
+
+add_executable(
+    dsd-neo_test_ui_ncurses_printer_helpers
+    ui/test_ui_ncurses_printer_helpers.c
+)
+target_include_directories(
+    dsd-neo_test_ui_ncurses_printer_helpers
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal
+        ${CURSES_INCLUDE_DIRS}
+)
+target_compile_options(
+    dsd-neo_test_ui_ncurses_printer_helpers
+    PRIVATE -Wno-unused-function
+)
+target_link_libraries(
+    dsd-neo_test_ui_ncurses_printer_helpers
+    PRIVATE ${CURSES_LIBRARIES} ${DSD_NEO_TEST_MATH_LIB}
+)
+add_test(
+    NAME UI_NCURSES_PRINTER_HELPERS
+    COMMAND dsd-neo_test_ui_ncurses_printer_helpers
+)
+
+add_executable(
+    dsd-neo_test_ui_menu_callbacks
+    ui/test_ui_menu_callbacks.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_callbacks.c
+)
+target_include_directories(
+    dsd-neo_test_ui_menu_callbacks
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
+)
+add_test(NAME UI_MENU_CALLBACKS COMMAND dsd-neo_test_ui_menu_callbacks)
+
+add_executable(
+    dsd-neo_test_ui_menu_actions
+    ui/test_ui_menu_actions.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_actions.c
+)
+target_include_directories(
+    dsd-neo_test_ui_menu_actions
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
+)
+add_test(NAME UI_MENU_ACTIONS COMMAND dsd-neo_test_ui_menu_actions)
 
 add_executable(
     dsd-neo_test_ui_hotkeys_regression
@@ -1013,6 +1456,32 @@ target_include_directories(
     PRIVATE ${PROJECT_SOURCE_DIR}/include
 )
 add_test(NAME UI_BURST_ACTIVE_CALL COMMAND dsd-neo_test_ui_burst_active_call)
+
+add_executable(
+    dsd-neo_test_ui_ncurses_utils
+    ui/test_ui_ncurses_utils.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_utils.c
+)
+target_include_directories(
+    dsd-neo_test_ui_ncurses_utils
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_ui_ncurses_utils
+    PRIVATE dsd-neo_core dsd-neo_runtime ${DSD_NEO_TEST_MATH_LIB}
+)
+add_test(NAME UI_NCURSES_UTILS COMMAND dsd-neo_test_ui_ncurses_utils)
+
+add_executable(
+    dsd-neo_test_ui_ncurses_init
+    ui/test_ui_ncurses_init.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_init.c
+)
+target_include_directories(
+    dsd-neo_test_ui_ncurses_init
+    PRIVATE ${PROJECT_SOURCE_DIR}/tests/ui ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME UI_NCURSES_INIT COMMAND dsd-neo_test_ui_ncurses_init)
 
 add_executable(
     dsd-neo_test_ui_dsp_squelch_status
@@ -1056,6 +1525,20 @@ add_test(
 )
 
 add_executable(
+    dsd-neo_test_ui_prims_status_gamma
+    ui/test_ui_prims_status_gamma.c
+)
+target_include_directories(
+    dsd-neo_test_ui_prims_status_gamma
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${CURSES_INCLUDE_DIRS}
+)
+target_link_libraries(
+    dsd-neo_test_ui_prims_status_gamma
+    PRIVATE ${DSD_NEO_TEST_MATH_LIB}
+)
+add_test(NAME UI_PRIMS_STATUS_GAMMA COMMAND dsd-neo_test_ui_prims_status_gamma)
+
+add_executable(
     dsd-neo_test_ui_snr_meter
     ui/test_ui_snr_meter.c
     ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_snr.c
@@ -1064,7 +1547,10 @@ target_include_directories(
     dsd-neo_test_ui_snr_meter
     PRIVATE ${PROJECT_SOURCE_DIR}/include ${CURSES_INCLUDE_DIRS}
 )
-target_compile_definitions(dsd-neo_test_ui_snr_meter PRIVATE DSD_NEO_TEST_HOOKS)
+target_compile_definitions(
+    dsd-neo_test_ui_snr_meter
+    PRIVATE DSD_NEO_TEST_HOOKS PRETTY_COLORS
+)
 if(DSD_ENABLE_FAST_MATH)
     target_compile_definitions(
         dsd-neo_test_ui_snr_meter
@@ -1122,7 +1608,7 @@ if(NOT DSD_HAS_PDCURSES_WIDE_API)
     )
     target_compile_definitions(
         dsd-neo_test_ui_snr_meter_pdc_wide_no_api
-        PRIVATE DSD_NEO_TEST_HOOKS DSD_USE_PDCURSES PDC_WIDE
+        PRIVATE DSD_NEO_TEST_HOOKS DSD_USE_PDCURSES PDC_WIDE PRETTY_COLORS
     )
     if(DSD_ENABLE_FAST_MATH)
         target_compile_definitions(
@@ -1270,6 +1756,28 @@ target_link_libraries(
 add_test(NAME UI_PROMPT_CURSOR COMMAND dsd-neo_test_ui_prompt_cursor)
 
 add_executable(
+    dsd-neo_test_ui_prompt_validation
+    ui/test_ui_prompt_validation.c
+    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_prompts.c
+)
+target_include_directories(
+    dsd-neo_test_ui_prompt_validation
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal
+        ${CURSES_INCLUDE_DIRS}
+)
+target_compile_definitions(
+    dsd-neo_test_ui_prompt_validation
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
+target_link_libraries(
+    dsd-neo_test_ui_prompt_validation
+    PRIVATE dsd-neo_test_support ${CURSES_LIBRARIES}
+)
+add_test(NAME UI_PROMPT_VALIDATION COMMAND dsd-neo_test_ui_prompt_validation)
+
+add_executable(
     dsd-neo_test_ui_history_state
     ui/test_ui_history_state.c
     ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_history.c
@@ -1339,6 +1847,56 @@ target_link_libraries(dsd-neo_test_runtime_freq_parse PRIVATE dsd-neo_runtime)
 add_test(NAME RUNTIME_FREQ_PARSE COMMAND dsd-neo_test_runtime_freq_parse)
 
 add_executable(
+    dsd-neo_test_runtime_bootstrap_audio
+    runtime/test_runtime_bootstrap_audio.c
+    ${PROJECT_SOURCE_DIR}/src/runtime/bootstrap/audio.c
+)
+target_include_directories(
+    dsd-neo_test_runtime_bootstrap_audio
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${_PUBLIC_INCLUDES}
+)
+target_link_libraries(
+    dsd-neo_test_runtime_bootstrap_audio
+    PRIVATE dsd-neo_platform
+)
+add_test(
+    NAME RUNTIME_BOOTSTRAP_AUDIO
+    COMMAND dsd-neo_test_runtime_bootstrap_audio
+)
+
+add_executable(
+    dsd-neo_test_runtime_bootstrap_system
+    runtime/test_runtime_bootstrap_system.c
+    ${PROJECT_SOURCE_DIR}/src/runtime/bootstrap/system.c
+)
+target_include_directories(
+    dsd-neo_test_runtime_bootstrap_system
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(
+    NAME RUNTIME_BOOTSTRAP_SYSTEM
+    COMMAND dsd-neo_test_runtime_bootstrap_system
+)
+
+add_executable(
+    dsd-neo_test_runtime_bootstrap_interactive
+    runtime/test_runtime_bootstrap_interactive.c
+    ${PROJECT_SOURCE_DIR}/src/runtime/bootstrap/interactive.c
+)
+target_include_directories(
+    dsd-neo_test_runtime_bootstrap_interactive
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_compile_definitions(
+    dsd-neo_test_runtime_bootstrap_interactive
+    PRIVATE USE_RTLSDR
+)
+add_test(
+    NAME RUNTIME_BOOTSTRAP_INTERACTIVE
+    COMMAND dsd-neo_test_runtime_bootstrap_interactive
+)
+
+add_executable(
     dsd-neo_test_runtime_dmr_t3_lcn_calc
     runtime/test_runtime_dmr_t3_lcn_calc.c
 )
@@ -1365,6 +1923,22 @@ target_include_directories(
 )
 target_link_libraries(dsd-neo_test_runtime_input_spec PRIVATE dsd-neo_runtime)
 add_test(NAME RUNTIME_INPUT_SPEC COMMAND dsd-neo_test_runtime_input_spec)
+
+add_executable(
+    dsd-neo_test_runtime_path_policy
+    runtime/test_runtime_path_policy.c
+)
+target_include_directories(
+    dsd-neo_test_runtime_path_policy
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/tests/test_support
+)
+target_link_libraries(
+    dsd-neo_test_runtime_path_policy
+    PRIVATE dsd-neo_runtime dsd-neo_test_support
+)
+add_test(NAME RUNTIME_PATH_POLICY COMMAND dsd-neo_test_runtime_path_policy)
 
 add_executable(
     dsd-neo_test_runtime_rdio_export
@@ -1463,6 +2037,69 @@ target_link_libraries(
 add_test(
     NAME RUNTIME_RIGCTL_QUERY_HOOKS
     COMMAND dsd-neo_test_runtime_rigctl_query_hooks
+)
+
+add_executable(
+    dsd-neo_test_engine_rigctl_query_hooks_install
+    engine/test_engine_rigctl_query_hooks_install.c
+    ${PROJECT_SOURCE_DIR}/src/engine/rigctl_query_hooks_install.c
+)
+target_include_directories(
+    dsd-neo_test_engine_rigctl_query_hooks_install
+    PRIVATE ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_engine_rigctl_query_hooks_install
+    PRIVATE dsd-neo_runtime
+)
+add_test(
+    NAME ENGINE_RIGCTL_QUERY_HOOKS_INSTALL
+    COMMAND dsd-neo_test_engine_rigctl_query_hooks_install
+)
+
+add_executable(
+    dsd-neo_test_engine_io_hooks_install
+    engine/test_engine_io_hooks_install.c
+    ${PROJECT_SOURCE_DIR}/src/engine/udp_audio_hooks_install.c
+    ${PROJECT_SOURCE_DIR}/src/engine/rtl_stream_io_hooks_install.c
+)
+target_compile_definitions(
+    dsd-neo_test_engine_io_hooks_install
+    PRIVATE USE_RADIO
+)
+target_include_directories(
+    dsd-neo_test_engine_io_hooks_install
+    PRIVATE ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_engine_io_hooks_install
+    PRIVATE dsd-neo_runtime
+)
+add_test(
+    NAME ENGINE_IO_HOOKS_INSTALL
+    COMMAND dsd-neo_test_engine_io_hooks_install
+)
+
+add_executable(
+    dsd-neo_test_engine_rtl_stream_metrics_hooks_install
+    engine/test_engine_rtl_stream_metrics_hooks_install.c
+    ${PROJECT_SOURCE_DIR}/src/engine/rtl_stream_metrics_hooks_install.c
+)
+target_compile_definitions(
+    dsd-neo_test_engine_rtl_stream_metrics_hooks_install
+    PRIVATE USE_RADIO
+)
+target_include_directories(
+    dsd-neo_test_engine_rtl_stream_metrics_hooks_install
+    PRIVATE ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_engine_rtl_stream_metrics_hooks_install
+    PRIVATE dsd-neo_runtime
+)
+add_test(
+    NAME ENGINE_RTL_STREAM_METRICS_HOOKS_INSTALL
+    COMMAND dsd-neo_test_engine_rtl_stream_metrics_hooks_install
 )
 
 add_executable(
@@ -1743,6 +2380,47 @@ target_link_libraries(dsd-neo_test_core_audio_gain PRIVATE dsd-neo_core)
 add_test(NAME CORE_AUDIO_GAIN COMMAND dsd-neo_test_core_audio_gain)
 
 add_executable(
+    dsd-neo_test_core_audio2_helpers
+    core/test_core_audio2_helpers.c
+    ${PROJECT_SOURCE_DIR}/src/core/audio/dsd_audio2.c
+)
+target_include_directories(
+    dsd-neo_test_core_audio2_helpers
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/tests/core
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src
+)
+target_compile_definitions(
+    dsd-neo_test_core_audio2_helpers
+    PRIVATE DSD_AUDIO2_INTERNAL=
+)
+target_compile_options(
+    dsd-neo_test_core_audio2_helpers
+    PRIVATE -ffunction-sections -fdata-sections
+)
+target_link_options(dsd-neo_test_core_audio2_helpers PRIVATE -Wl,--gc-sections)
+target_link_libraries(dsd-neo_test_core_audio2_helpers PRIVATE m)
+add_test(NAME CORE_AUDIO2_HELPERS COMMAND dsd-neo_test_core_audio2_helpers)
+
+add_executable(
+    dsd-neo_test_core_misc_power_filters
+    core/test_core_misc_power_filters.c
+)
+target_include_directories(
+    dsd-neo_test_core_misc_power_filters
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_core_misc_power_filters
+    PRIVATE dsd-neo_core ${DSD_NEO_TEST_MATH_LIB}
+)
+add_test(
+    NAME CORE_MISC_POWER_FILTERS
+    COMMAND dsd-neo_test_core_misc_power_filters
+)
+
+add_executable(
     dsd-neo_test_dsp_pcm_input_staging
     dsp/test_dsp_pcm_input_staging.c
 )
@@ -1765,6 +2443,26 @@ dsd_neo_link_dsp_test(
     ${LIBSNDFILE_LIBRARIES}
 )
 add_test(NAME DSP_WAV_INPUT_EOF COMMAND dsd-neo_test_dsp_wav_input_eof)
+
+add_executable(dsd-neo_test_dsp_symbol_replay dsp/test_dsp_symbol_replay.c)
+target_compile_definitions(dsd-neo_dsp PRIVATE DSD_NEO_TEST_HOOKS)
+target_compile_definitions(
+    dsd-neo_test_dsp_symbol_replay
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
+target_include_directories(
+    dsd-neo_test_dsp_symbol_replay
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/tests/test_support
+)
+dsd_neo_link_dsp_test(
+    dsd-neo_test_dsp_symbol_replay
+    dsd-neo_test_support
+    ${DSD_NEO_TEST_MATH_LIB}
+    ${LIBSNDFILE_LIBRARIES}
+)
+add_test(NAME DSP_SYMBOL_REPLAY COMMAND dsd-neo_test_dsp_symbol_replay)
 
 add_executable(
     dsd-neo_test_core_dmr_voice_alg_gate
@@ -1793,7 +2491,7 @@ target_include_directories(
 )
 target_link_libraries(
     dsd-neo_test_core_mbe_transform_context
-    PRIVATE dsd-neo_core
+    PRIVATE dsd-neo_core dsd-neo_proto_nxdn dsd-neo_proto_dmr
 )
 add_test(
     NAME CORE_MBE_TRANSFORM_CONTEXT
@@ -1915,6 +2613,36 @@ else()
     )
 endif()
 add_test(NAME CORE_FRAME_LOG COMMAND dsd-neo_test_core_frame_log)
+
+add_executable(dsd-neo_test_core_mbe_file_io core/test_core_mbe_file_io.c)
+target_include_directories(
+    dsd-neo_test_core_mbe_file_io
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/tests/test_support
+)
+if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
+    target_link_libraries(
+        dsd-neo_test_core_mbe_file_io
+        PRIVATE
+            "-Wl,--start-group"
+            ${_DSD_RUNTIME_CLI_PARSE_LIBS}
+            "-Wl,--end-group"
+            ${LIBS}
+            dsd-neo_fec
+            dsd-neo_test_support
+    )
+else()
+    target_link_libraries(
+        dsd-neo_test_core_mbe_file_io
+        PRIVATE
+            ${_DSD_RUNTIME_CLI_PARSE_LIBS}
+            ${LIBS}
+            dsd-neo_fec
+            dsd-neo_test_support
+    )
+endif()
+add_test(NAME CORE_MBE_FILE_IO COMMAND dsd-neo_test_core_mbe_file_io)
 
 add_executable(dsd-neo_test_core_init_state core/test_core_init_state.c)
 target_include_directories(
@@ -2063,6 +2791,29 @@ else()
 endif()
 add_test(NAME ENGINE_CLEANUP_AUDIO COMMAND dsd-neo_test_engine_cleanup_audio)
 
+add_executable(dsd-neo_test_engine_run_setup engine/test_engine_run_setup.c)
+target_include_directories(
+    dsd-neo_test_engine_run_setup
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
+    target_link_libraries(
+        dsd-neo_test_engine_run_setup
+        PRIVATE
+            "-Wl,--start-group"
+            dsd-neo_engine
+            "-Wl,--end-group"
+            ${LIBS}
+            dsd-neo_test_support
+    )
+else()
+    target_link_libraries(
+        dsd-neo_test_engine_run_setup
+        PRIVATE dsd-neo_engine ${LIBS} dsd-neo_test_support
+    )
+endif()
+add_test(NAME ENGINE_RUN_SETUP COMMAND dsd-neo_test_engine_run_setup)
+
 if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
     add_executable(
         dsd-neo_test_engine_synced_trunk_scan_tick
@@ -2175,6 +2926,7 @@ target_include_directories(
         ${PROJECT_SOURCE_DIR}/src/ui/terminal
         ${CURSES_INCLUDE_DIRS}
 )
+target_compile_definitions(dsd-neo_test_runtime_config_apply PRIVATE USE_RADIO)
 set(_DSD_RUNTIME_CONFIG_APPLY_LIBS
     dsd-neo_ui_terminal
     dsd-neo_engine
@@ -2524,6 +3276,22 @@ target_include_directories(
 target_link_libraries(dsd-neo_test_p25_p1_mbt_crc16 PRIVATE dsd-neo_proto_p25)
 add_test(NAME P25_P1_MBT_CRC16 COMMAND dsd-neo_test_p25_p1_mbt_crc16)
 
+# P25 P1 TSBK vendor handler state side effects
+add_executable(
+    dsd-neo_test_p25_p1_tsbk_handlers
+    protocol/p25/test_p25_p1_tsbk_handlers.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p1_tsbk_handlers
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/protocol/p25
+)
+target_compile_options(
+    dsd-neo_test_p25_p1_tsbk_handlers
+    PRIVATE -ffunction-sections -fdata-sections
+)
+target_link_options(dsd-neo_test_p25_p1_tsbk_handlers PRIVATE -Wl,--gc-sections)
+add_test(NAME P25_P1_TSBK_HANDLERS COMMAND dsd-neo_test_p25_p1_tsbk_handlers)
+
 # P25 P1 FEC boundaries: Hamming, Golay, RS correction limits
 add_executable(
     dsd-neo_test_p25_p1_fec_boundaries
@@ -2538,6 +3306,86 @@ target_link_libraries(
     PRIVATE dsd-neo_proto_p25
 )
 add_test(NAME P25_P1_FEC_BOUNDS COMMAND dsd-neo_test_p25_p1_fec_boundaries)
+
+# P25 P1 HDU field extraction and soft RS reliability helpers
+add_executable(
+    dsd-neo_test_p25_p1_hdu_helpers
+    protocol/p25/test_p25_p1_hdu_helpers.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p1_hdu_helpers
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_compile_options(
+    dsd-neo_test_p25_p1_hdu_helpers
+    PRIVATE -ffunction-sections -fdata-sections
+)
+target_link_options(dsd-neo_test_p25_p1_hdu_helpers PRIVATE -Wl,--gc-sections)
+add_test(NAME P25_P1_HDU_HELPERS COMMAND dsd-neo_test_p25_p1_hdu_helpers)
+
+# P25 P1 common LDU IMBE/status and Hamming helpers
+add_executable(
+    dsd-neo_test_p25_p1_ldu_helpers
+    protocol/p25/test_p25_p1_ldu_helpers.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p1_ldu_helpers
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_compile_options(
+    dsd-neo_test_p25_p1_ldu_helpers
+    PRIVATE -ffunction-sections -fdata-sections
+)
+target_link_options(dsd-neo_test_p25_p1_ldu_helpers PRIVATE -Wl,--gc-sections)
+add_test(NAME P25_P1_LDU_HELPERS COMMAND dsd-neo_test_p25_p1_ldu_helpers)
+
+# P25 P1 LDU1 LCW/LSD packing and soft RS reliability helpers
+add_executable(
+    dsd-neo_test_p25_p1_ldu1_helpers
+    protocol/p25/test_p25_p1_ldu1_helpers.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p1_ldu1_helpers
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_compile_options(
+    dsd-neo_test_p25_p1_ldu1_helpers
+    PRIVATE -ffunction-sections -fdata-sections
+)
+target_link_options(dsd-neo_test_p25_p1_ldu1_helpers PRIVATE -Wl,--gc-sections)
+add_test(NAME P25_P1_LDU1_HELPERS COMMAND dsd-neo_test_p25_p1_ldu1_helpers)
+
+# P25 P1 LDU2 ESS/LSD packing and soft RS reliability helpers
+add_executable(
+    dsd-neo_test_p25_p1_ldu2_helpers
+    protocol/p25/test_p25_p1_ldu2_helpers.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p1_ldu2_helpers
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_compile_options(
+    dsd-neo_test_p25_p1_ldu2_helpers
+    PRIVATE -ffunction-sections -fdata-sections
+)
+target_link_options(dsd-neo_test_p25_p1_ldu2_helpers PRIVATE -Wl,--gc-sections)
+add_test(NAME P25_P1_LDU2_HELPERS COMMAND dsd-neo_test_p25_p1_ldu2_helpers)
+
+# P25 P1 MDPU header, candidate, and CRC assembly helpers
+add_executable(
+    dsd-neo_test_p25_p1_mdpu_helpers
+    protocol/p25/test_p25_p1_mdpu_helpers.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p1_mdpu_helpers
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_compile_options(
+    dsd-neo_test_p25_p1_mdpu_helpers
+    PRIVATE -ffunction-sections -fdata-sections
+)
+target_link_options(dsd-neo_test_p25_p1_mdpu_helpers PRIVATE -Wl,--gc-sections)
+add_test(NAME P25_P1_MDPU_HELPERS COMMAND dsd-neo_test_p25_p1_mdpu_helpers)
 
 # P25 P2 MAC vendor length overrides
 add_executable(
@@ -2876,6 +3724,17 @@ target_link_libraries(
 )
 add_test(NAME P25_P2_AUDIO_ENABLE COMMAND dsd-neo_test_p25_p2_audio_enable)
 
+# P25 P2 XCCH MAC PTT/END/IDLE slot-state helpers
+add_executable(
+    dsd-neo_test_p25_p2_xcch_helpers
+    protocol/p25/test_p25_p2_xcch_helpers.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p2_xcch_helpers
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME P25_P2_XCCH_HELPERS COMMAND dsd-neo_test_p25_p2_xcch_helpers)
+
 # P25 P1 IMBE audio playback dispatch matrix
 add_executable(
     dsd-neo_test_p25_p1_audio_dispatch
@@ -2967,6 +3826,18 @@ target_include_directories(
         ${PROJECT_SOURCE_DIR}/tests/protocol/p25
 )
 add_test(NAME P25_P1_TSBK_SEQUENCE COMMAND dsd-neo_test_p25_p1_tsbk_sequence)
+
+# P25 P1 TDU state cleanup and status-symbol handoff
+add_executable(
+    dsd-neo_test_p25_p1_tdu
+    protocol/p25/test_p25_p1_tdu.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/p25/phase1/p25p1_tdu.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p1_tdu
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME P25_P1_TDU COMMAND dsd-neo_test_p25_p1_tdu)
 
 # P25 P1 TDULC parse → LCW retune (format 0x44)
 add_executable(dsd-neo_test_p25_p1_tdulc protocol/p25/test_p25_p1_tdulc.c)
@@ -3598,7 +4469,7 @@ target_compile_definitions(
 )
 target_include_directories(
     dsd-neo_test_m17_state_dispatch
-    PRIVATE ${PROJECT_SOURCE_DIR}/include
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/protocol/m17
 )
 target_link_libraries(dsd-neo_test_m17_state_dispatch PRIVATE dsd-neo_proto_m17)
 add_test(NAME M17_STATE_DISPATCH COMMAND dsd-neo_test_m17_state_dispatch)
@@ -3839,6 +4710,10 @@ dsd_neo_link_dsp_test(dsd-neo_test_dsp_ted)
 add_test(NAME DSP_TED COMMAND dsd-neo_test_dsp_ted)
 
 add_executable(dsd-neo_test_dsp_simd_widen dsp/test_dsp_simd_widen.cpp)
+target_compile_definitions(
+    dsd-neo_test_dsp_simd_widen
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
 target_include_directories(
     dsd-neo_test_dsp_simd_widen
     PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src
@@ -3851,6 +4726,17 @@ target_include_directories(
     dsd-neo_test_dsp_simd_fir
     PRIVATE ${PROJECT_SOURCE_DIR}/include
 )
+get_target_property(_dsd_neo_dsp_sources dsd-neo_dsp SOURCES)
+if(_dsd_neo_dsp_sources MATCHES "simd_fir_avx2\\.cpp")
+    target_compile_definitions(
+        dsd-neo_test_dsp_simd_fir
+        PRIVATE DSD_NEO_TEST_HAVE_AVX2_IMPL=1
+    )
+    target_include_directories(
+        dsd-neo_test_dsp_simd_fir
+        PRIVATE ${PROJECT_SOURCE_DIR}/src
+    )
+endif()
 dsd_neo_link_dsp_test(dsd-neo_test_dsp_simd_fir)
 add_test(NAME DSP_SIMD_FIR COMMAND dsd-neo_test_dsp_simd_fir)
 
@@ -5042,6 +5928,35 @@ target_include_directories(
 dsd_neo_link_dsp_test(dsd-neo_test_frame_sync_policy ${DSD_NEO_TEST_MATH_LIB})
 add_test(NAME FRAME_SYNC_POLICY COMMAND dsd-neo_test_frame_sync_policy)
 
+# Frame sync internal helper decisions that are otherwise reached through long no-signal/RF loops.
+add_executable(
+    dsd-neo_test_frame_sync_internal_helpers
+    dsp/test_frame_sync_internal_helpers.c
+)
+target_compile_definitions(
+    dsd-neo_test_frame_sync_internal_helpers
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
+if(DSD_HAS_RADIO)
+    target_compile_definitions(
+        dsd-neo_test_frame_sync_internal_helpers
+        PRIVATE USE_RADIO
+    )
+endif()
+target_include_directories(
+    dsd-neo_test_frame_sync_internal_helpers
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+dsd_neo_link_dsp_test(
+    dsd-neo_test_frame_sync_internal_helpers
+    ${DSD_NEO_TEST_MATH_LIB}
+    ${LIBSNDFILE_LIBRARIES}
+)
+add_test(
+    NAME FRAME_SYNC_INTERNAL_HELPERS
+    COMMAND dsd-neo_test_frame_sync_internal_helpers
+)
+
 # Frame sync level-window estimator parity with the legacy sync scanner.
 add_executable(
     dsd-neo_test_frame_sync_level_window
@@ -5160,6 +6075,7 @@ add_executable(
     protocol/p25/test_p25p1_soft_rs.cpp
     ${PROJECT_SOURCE_DIR}/src/protocol/p25/phase1/p25p1_check_hdu.cpp
     ${PROJECT_SOURCE_DIR}/src/protocol/p25/phase1/p25p1_check_ldu.cpp
+    ${PROJECT_SOURCE_DIR}/src/protocol/p25/phase1/p25p1_rs_soft_reliability.cpp
     ${PROJECT_SOURCE_DIR}/src/protocol/p25/phase1/p25p1_soft.cpp
 )
 target_include_directories(
@@ -5300,6 +6216,89 @@ target_link_libraries(
 add_test(NAME IO_UDP_CONTROL COMMAND dsd-neo_test_io_udp_control)
 
 add_executable(
+    dsd-neo_test_io_rigctl_control
+    io/test_io_rigctl_control.c
+    ${PROJECT_SOURCE_DIR}/src/io/control/dsd_rigctl.c
+)
+target_compile_definitions(
+    dsd-neo_test_io_rigctl_control
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
+target_include_directories(
+    dsd-neo_test_io_rigctl_control
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_io_rigctl_control
+    PRIVATE ${DSD_NEO_TEST_MATH_LIB}
+)
+add_test(NAME IO_RIGCTL_CONTROL COMMAND dsd-neo_test_io_rigctl_control)
+
+add_executable(
+    dsd-neo_test_io_udp_socket_backends
+    io/test_io_udp_socket_backends.c
+    ${PROJECT_SOURCE_DIR}/src/io/audio_backends/udp_audio.c
+    ${PROJECT_SOURCE_DIR}/src/io/audio_backends/udp_bind.c
+    ${PROJECT_SOURCE_DIR}/src/io/audio_backends/m17_udp.c
+)
+target_include_directories(
+    dsd-neo_test_io_udp_socket_backends
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(
+    NAME IO_UDP_SOCKET_BACKENDS
+    COMMAND dsd-neo_test_io_udp_socket_backends
+)
+
+add_executable(dsd-neo_test_io_tcp_input io/test_io_tcp_input.c)
+target_include_directories(
+    dsd-neo_test_io_tcp_input
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(dsd-neo_test_io_tcp_input PRIVATE dsd-neo_io_audio)
+add_test(NAME IO_TCP_INPUT COMMAND dsd-neo_test_io_tcp_input)
+
+add_executable(
+    dsd-neo_test_io_serial_control
+    io/test_io_serial_control.c
+    ${PROJECT_SOURCE_DIR}/src/io/control/dsd_serial.c
+)
+target_compile_definitions(
+    dsd-neo_test_io_serial_control
+    PRIVATE
+        dsd_open_serial_write=test_dsd_open_serial_write
+        dsd_write=test_dsd_write
+        tcsetattr=test_tcsetattr
+        cfsetospeed=test_cfsetospeed
+        cfsetispeed=test_cfsetispeed
+        write=test_write
+)
+target_include_directories(
+    dsd-neo_test_io_serial_control
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME IO_SERIAL_CONTROL COMMAND dsd-neo_test_io_serial_control)
+
+add_executable(
+    dsd-neo_test_io_rtl_perf
+    io/test_io_rtl_perf.cpp
+    ${PROJECT_SOURCE_DIR}/src/io/radio/rtl_perf.cpp
+)
+target_compile_definitions(
+    dsd-neo_test_io_rtl_perf
+    PRIVATE
+        dsd_fopen_private=test_dsd_fopen_private
+        dsd_fileno=test_dsd_fileno
+        dsd_fstat=test_dsd_fstat
+        dsd_time_monotonic_ns=test_dsd_time_monotonic_ns
+)
+target_include_directories(
+    dsd-neo_test_io_rtl_perf
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/io/radio
+)
+add_test(NAME IO_RTL_PERF COMMAND dsd-neo_test_io_rtl_perf)
+
+add_executable(
     dsd-neo_test_io_iq_replay_effective_bytes
     io/test_io_iq_replay_effective_bytes.c
 )
@@ -5387,6 +6386,58 @@ target_link_libraries(
     PRIVATE dsd-neo_platform
 )
 add_test(NAME PLATFORM_FILE_COMPAT COMMAND dsd-neo_test_platform_file_compat)
+
+add_executable(dsd-neo_test_platform_nonce platform/test_platform_nonce.c)
+target_include_directories(
+    dsd-neo_test_platform_nonce
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(dsd-neo_test_platform_nonce PRIVATE dsd-neo_platform)
+add_test(NAME PLATFORM_NONCE COMMAND dsd-neo_test_platform_nonce)
+
+if(NOT DSD_USE_PORTAUDIO)
+    add_executable(
+        dsd-neo_test_platform_audio_pulse_guards
+        platform/test_platform_audio_pulse_guards.c
+    )
+    target_include_directories(
+        dsd-neo_test_platform_audio_pulse_guards
+        PRIVATE ${PROJECT_SOURCE_DIR}/include
+    )
+    target_link_libraries(
+        dsd-neo_test_platform_audio_pulse_guards
+        PRIVATE dsd-neo_platform
+    )
+    add_test(
+        NAME PLATFORM_AUDIO_PULSE_GUARDS
+        COMMAND dsd-neo_test_platform_audio_pulse_guards
+    )
+
+    add_executable(
+        dsd-neo_test_platform_audio_pulse_helpers
+        platform/test_platform_audio_pulse_helpers.c
+    )
+    target_include_directories(
+        dsd-neo_test_platform_audio_pulse_helpers
+        PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/platform
+    )
+    target_compile_options(
+        dsd-neo_test_platform_audio_pulse_helpers
+        PRIVATE -ffunction-sections -fdata-sections
+    )
+    target_link_options(
+        dsd-neo_test_platform_audio_pulse_helpers
+        PRIVATE -Wl,--gc-sections
+    )
+    target_link_libraries(
+        dsd-neo_test_platform_audio_pulse_helpers
+        PRIVATE ${PULSEAUDIO_LIBRARY}
+    )
+    add_test(
+        NAME PLATFORM_AUDIO_PULSE_HELPERS
+        COMMAND dsd-neo_test_platform_audio_pulse_helpers
+    )
+endif()
 
 add_executable(
     dsd-neo_test_platform_socket_resolve
@@ -5542,6 +6593,20 @@ if(DSD_HAS_RADIO)
     add_test(
         NAME IO_RTL_STREAM_PPM_SYNC
         COMMAND dsd-neo_test_io_rtl_stream_ppm_sync
+    )
+
+    add_executable(
+        dsd-neo_test_io_rtl_stream_orchestrator
+        io/test_io_rtl_stream_orchestrator.cpp
+        ${PROJECT_SOURCE_DIR}/src/io/radio/rtl_stream.cpp
+    )
+    target_include_directories(
+        dsd-neo_test_io_rtl_stream_orchestrator
+        PRIVATE ${PROJECT_SOURCE_DIR}/include
+    )
+    add_test(
+        NAME IO_RTL_STREAM_ORCHESTRATOR
+        COMMAND dsd-neo_test_io_rtl_stream_orchestrator
     )
 
     add_executable(

--- a/tests/cmake/RunCliSmoke.cmake
+++ b/tests/cmake/RunCliSmoke.cmake
@@ -1,0 +1,54 @@
+if(NOT DEFINED DSD_NEO_CLI)
+    message(FATAL_ERROR "DSD_NEO_CLI is required")
+endif()
+
+if(NOT DEFINED DSD_NEO_CLI_SMOKE_MODE)
+    message(FATAL_ERROR "DSD_NEO_CLI_SMOKE_MODE is required")
+endif()
+
+if(DSD_NEO_CLI_SMOKE_MODE STREQUAL "help")
+    set(_args "-h")
+    set(_want_rc 0)
+    set(_want_stdout_regex "Usage: dsd-neo \\[options\\].*Decoder options:")
+    set(_want_stderr_regex "")
+elseif(DSD_NEO_CLI_SMOKE_MODE STREQUAL "invalid-option")
+    set(_args "--definitely-not-an-option")
+    set(_want_rc 1)
+    set(_want_stdout_regex "Usage: dsd-neo \\[options\\]")
+    set(_want_stderr_regex "invalid option")
+else()
+    message(
+        FATAL_ERROR
+        "unknown DSD_NEO_CLI_SMOKE_MODE: ${DSD_NEO_CLI_SMOKE_MODE}"
+    )
+endif()
+
+execute_process(
+    COMMAND "${DSD_NEO_CLI}" ${_args}
+    RESULT_VARIABLE _rc
+    OUTPUT_VARIABLE _stdout
+    ERROR_VARIABLE _stderr
+)
+
+set(_combined "${_stdout}\n${_stderr}")
+
+if(NOT _rc EQUAL _want_rc)
+    message(
+        FATAL_ERROR
+        "expected ${DSD_NEO_CLI_SMOKE_MODE} rc=${_want_rc}, got ${_rc}\n${_combined}"
+    )
+endif()
+
+if(NOT _stdout MATCHES "${_want_stdout_regex}")
+    message(
+        FATAL_ERROR
+        "expected ${DSD_NEO_CLI_SMOKE_MODE} stdout to match ${_want_stdout_regex}\n${_combined}"
+    )
+endif()
+
+if(_want_stderr_regex AND NOT _stderr MATCHES "${_want_stderr_regex}")
+    message(
+        FATAL_ERROR
+        "expected ${DSD_NEO_CLI_SMOKE_MODE} stderr to match ${_want_stderr_regex}\n${_combined}"
+    )
+endif()

--- a/tests/core/mbelib.h
+++ b/tests/core/mbelib.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#pragma once
+
+typedef struct mbe_parameters {
+    int dummy;
+} mbe_parms;
+
+void mbe_floattoshort(const float* in, short* out);

--- a/tests/core/test_core_audio2_helpers.c
+++ b/tests/core/test_core_audio2_helpers.c
@@ -1,0 +1,875 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use synthetic sentinels, wrapper symbols, and
+// test-only internal helper linkage to exercise guarded behavior.
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Direct tests for pure dsd_audio2.c helper policy. These helpers are static in
+ * production; the target uses section garbage collection so uncalled playback
+ * paths do not require live audio/device stubs.
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <sndfile.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include "core/audio/dsd_audio2_internal.h"
+#include "dsd-neo/core/audio.h"
+#include "dsd-neo/core/audio_filters.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/core/synctype_ids.h"
+#include "dsd-neo/platform/audio.h"
+#include "dsd-neo/platform/file_compat.h"
+#include "dsd-neo/runtime/log.h"
+#include "dsd-neo/runtime/p25_p2_audio_ring.h"
+#include "dsd-neo/runtime/udp_audio_hooks.h"
+#include "mbelib.h"
+
+void
+dsd_neo_log_write(dsd_neo_log_level_t level, const char* format, ...) {
+    (void)level;
+    (void)format;
+}
+
+static int g_audio_write_calls;
+static size_t g_audio_write_frames;
+static int16_t g_audio_write_samples[640];
+static int g_udp_blast_calls;
+static size_t g_udp_blast_bytes;
+static uint8_t g_udp_blast_data[256];
+static int g_dsd_write_calls;
+static int g_dsd_write_fd;
+static size_t g_dsd_write_bytes;
+static uint8_t g_dsd_write_data[256];
+static int g_dmr_missing_alg_key_allowed[2];
+static int g_dmr_voice_slot_allowed[2];
+static int g_gate_mono_forced_enc = -1;
+static int g_gate_dual_forced_enc_l = -1;
+static int g_gate_dual_forced_enc_r = -1;
+
+void
+mbe_floattoshort(const float* in, short* out) {
+    if (in == NULL || out == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < 160U; i++) {
+        out[i] = (short)in[i];
+    }
+}
+
+int
+p25_p2_audio_ring_pop(dsd_state* state, int slot, float* out160) {
+    (void)state;
+    (void)slot;
+    if (out160 != NULL) {
+        for (size_t i = 0; i < 160U; i++) {
+            out160[i] = 0.0f;
+        }
+    }
+    return 0;
+}
+
+void
+hpf_dL(dsd_state* state, short* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+hpf_dR(dsd_state* state, short* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+audio_mono_to_stereo_s16(const short* in, short* out, size_t n) {
+    if (in == NULL || out == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < n; i++) {
+        out[(i * 2U) + 0U] = in[i];
+        out[(i * 2U) + 1U] = in[i];
+    }
+}
+
+void
+audio_mix_interleave_stereo_s16(const short* left, const short* right, size_t n, int encL, int encR,
+                                short* stereo_out) {
+    if (stereo_out == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < n; i++) {
+        stereo_out[(i * 2U) + 0U] = (encL || left == NULL) ? 0 : left[i];
+        stereo_out[(i * 2U) + 1U] = (encR || right == NULL) ? 0 : right[i];
+    }
+}
+
+sf_count_t
+sf_write_short(SNDFILE* sndfile, const short* ptr, sf_count_t items) {
+    (void)sndfile;
+    (void)ptr;
+    return items;
+}
+
+void
+agf(const dsd_opts* opts, dsd_state* state, float samp[160], int slot) {
+    (void)opts;
+    (void)state;
+    (void)samp;
+    (void)slot;
+}
+
+void
+audio_apply_gain_f32(float* buf, size_t n, float gain) {
+    if (!buf) {
+        return;
+    }
+    for (size_t i = 0; i < n; i++) {
+        buf[i] *= gain;
+    }
+}
+
+void
+audio_mono_to_stereo_f32(const float* in, float* out, size_t n) {
+    if (!in || !out) {
+        return;
+    }
+    for (size_t i = 0; i < n; i++) {
+        out[(i * 2U) + 0U] = in[i];
+        out[(i * 2U) + 1U] = in[i];
+    }
+}
+
+void
+audio_mix_interleave_stereo_f32(const float* left, const float* right, size_t n, int encL, int encR,
+                                float* stereo_out) {
+    if (!stereo_out) {
+        return;
+    }
+    for (size_t i = 0; i < n; i++) {
+        stereo_out[(i * 2U) + 0U] = (encL || !left) ? 0.0f : left[i];
+        stereo_out[(i * 2U) + 1U] = (encR || !right) ? 0.0f : right[i];
+    }
+}
+
+void
+audio_mix_mono_from_slots_f32(const float* left, const float* right, size_t n, int l_on, int r_on, float* mono_out) {
+    if (!mono_out) {
+        return;
+    }
+    for (size_t i = 0; i < n; i++) {
+        float sum = 0.0f;
+        int count = 0;
+        if (l_on && left) {
+            sum += left[i];
+            count++;
+        }
+        if (r_on && right) {
+            sum += right[i];
+            count++;
+        }
+        mono_out[i] = (count == 0) ? 0.0f : (sum / (float)count);
+    }
+}
+
+int
+dsd_audio_group_gate_mono(const dsd_opts* opts, const dsd_state* state, unsigned long tg, int enc_in, int* enc_out) {
+    (void)opts;
+    (void)state;
+    (void)tg;
+    if (enc_out) {
+        *enc_out = (g_gate_mono_forced_enc >= 0) ? g_gate_mono_forced_enc : enc_in;
+    }
+    return 0;
+}
+
+int
+dsd_audio_group_gate_dual(const dsd_opts* opts, const dsd_state* state, unsigned long tgL, unsigned long tgR,
+                          int encL_in, int encR_in, int* encL_out, int* encR_out) {
+    (void)opts;
+    (void)state;
+    (void)tgL;
+    (void)tgR;
+    if (encL_out) {
+        *encL_out = (g_gate_dual_forced_enc_l >= 0) ? g_gate_dual_forced_enc_l : encL_in;
+    }
+    if (encR_out) {
+        *encR_out = (g_gate_dual_forced_enc_r >= 0) ? g_gate_dual_forced_enc_r : encR_in;
+    }
+    return 0;
+}
+
+int
+dsd_audio_write(dsd_audio_stream* stream, const int16_t* buffer, size_t frames) {
+    (void)stream;
+    g_audio_write_calls++;
+    g_audio_write_frames = frames;
+    size_t samples = frames * 2U;
+    if (samples > sizeof(g_audio_write_samples) / sizeof(g_audio_write_samples[0])) {
+        samples = sizeof(g_audio_write_samples) / sizeof(g_audio_write_samples[0]);
+    }
+    if (buffer != NULL) {
+        DSD_MEMCPY(g_audio_write_samples, buffer, samples * sizeof(g_audio_write_samples[0]));
+    }
+    return (int)frames;
+}
+
+void
+dsd_udp_audio_hook_blast(const dsd_opts* opts, dsd_state* state, size_t nsam, const void* data) {
+    (void)opts;
+    (void)state;
+    g_udp_blast_calls++;
+    g_udp_blast_bytes = nsam;
+    if (data != NULL) {
+        size_t copy = nsam;
+        if (copy > sizeof(g_udp_blast_data)) {
+            copy = sizeof(g_udp_blast_data);
+        }
+        DSD_MEMCPY(g_udp_blast_data, data, copy);
+    }
+}
+
+ssize_t
+dsd_write(int fd, const void* buf, size_t count) {
+    g_dsd_write_calls++;
+    g_dsd_write_fd = fd;
+    g_dsd_write_bytes = count;
+    if (buf != NULL) {
+        size_t copy = count;
+        if (copy > sizeof(g_dsd_write_data)) {
+            copy = sizeof(g_dsd_write_data);
+        }
+        DSD_MEMCPY(g_dsd_write_data, buf, copy);
+    }
+    return (ssize_t)count;
+}
+
+int
+dsd_dmr_missing_alg_key_can_decrypt(const dsd_state* state, int slot) {
+    (void)state;
+    if (slot < 0 || slot > 1) {
+        return 0;
+    }
+    return g_dmr_missing_alg_key_allowed[slot];
+}
+
+int
+dsd_dmr_voice_slot_can_decrypt(const dsd_state* state, int slot, int algid, unsigned long long r_key) {
+    (void)state;
+    (void)algid;
+    (void)r_key;
+    if (slot < 0 || slot > 1) {
+        return 0;
+    }
+    return g_dmr_voice_slot_allowed[slot];
+}
+
+static void
+reset_sink_capture(void) {
+    g_audio_write_calls = 0;
+    g_audio_write_frames = 0;
+    DSD_MEMSET(g_audio_write_samples, 0, sizeof(g_audio_write_samples));
+    g_udp_blast_calls = 0;
+    g_udp_blast_bytes = 0;
+    DSD_MEMSET(g_udp_blast_data, 0, sizeof(g_udp_blast_data));
+    g_dsd_write_calls = 0;
+    g_dsd_write_fd = -1;
+    g_dsd_write_bytes = 0;
+    DSD_MEMSET(g_dsd_write_data, 0, sizeof(g_dsd_write_data));
+}
+
+static void
+reset_dmr_decrypt_capture(void) {
+    g_dmr_missing_alg_key_allowed[0] = 0;
+    g_dmr_missing_alg_key_allowed[1] = 0;
+    g_dmr_voice_slot_allowed[0] = 0;
+    g_dmr_voice_slot_allowed[1] = 0;
+}
+
+static void
+reset_gate_capture(void) {
+    g_gate_mono_forced_enc = -1;
+    g_gate_dual_forced_enc_l = -1;
+    g_gate_dual_forced_enc_r = -1;
+}
+
+static int
+expect_int(const char* label, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_size(const char* label, size_t got, size_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %zu want %zu\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_float(const char* label, float got, float want) {
+    const float diff = got > want ? got - want : want - got;
+    if (diff > 1e-6f) {
+        DSD_FPRINTF(stderr, "%s: got %.6f want %.6f diff %.6f\n", label, (double)got, (double)want, (double)diff);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_bytes(const char* label, const void* got, const void* want, size_t len) {
+    if (memcmp(got, want, len) != 0) {
+        DSD_FPRINTF(stderr, "%s: bytes differ\n", label);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_p25_and_nxdn_decrypt_gate_helpers(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.synctype = DSD_SYNC_P25P1_POS;
+
+    int rc = 0;
+    state.payload_algid = 0x80;
+    rc |= expect_int("p25 clear algid not encrypted", dsd_p25_algid_is_encrypted(&state), 0);
+    state.payload_algid = 0x81;
+    rc |= expect_int("p25 DES algid encrypted", dsd_p25_algid_is_encrypted(&state), 1);
+    rc |= expect_int("p25 DES without key blocked", dsd_p25_algid_can_decrypt(&state), 0);
+    state.R = 0x123456789ABCDEF0ULL;
+    rc |= expect_int("p25 DES with key allowed", dsd_p25_algid_can_decrypt(&state), 1);
+    state.R = 0;
+    state.payload_algid = 0x84;
+    rc |= expect_int("p25 AES without key blocked", dsd_p25_algid_can_decrypt(&state), 0);
+    state.aes_key_loaded[0] = 1;
+    rc |= expect_int("p25 AES with key allowed", dsd_p25_algid_can_decrypt(&state), 1);
+    state.payload_algid = 0x22;
+    rc |= expect_int("p25 unsupported algid blocked", dsd_p25_algid_can_decrypt(&state), 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.nxdn_cipher_type = 0x1;
+    rc |= expect_int("nxdn RC4 without key blocked", dsd_nxdn_can_decrypt(&state), 0);
+    state.R = 0x44;
+    rc |= expect_int("nxdn RC4 with key allowed", dsd_nxdn_can_decrypt(&state), 1);
+    state.R = 0;
+    state.nxdn_cipher_type = 0x3;
+    rc |= expect_int("nxdn AES without key blocked", dsd_nxdn_can_decrypt(&state), 0);
+    state.aes_key_loaded[0] = 1;
+    rc |= expect_int("nxdn AES with key allowed", dsd_nxdn_can_decrypt(&state), 1);
+    state.nxdn_cipher_type = 0x7;
+    rc |= expect_int("nxdn unsupported cipher blocked", dsd_nxdn_can_decrypt(&state), 0);
+    return rc;
+}
+
+static int
+test_output_helpers_dispatch_to_configured_sinks(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    dsd_audio_stream* fake_stream = (dsd_audio_stream*)&opts;
+    float float_samples[4] = {2.0f, -2.0f, 0.5f, -0.5f};
+    short short_samples[4] = {101, -202, 303, -404};
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_out_stream = fake_stream;
+    opts.pulse_digi_out_channels = 2;
+
+    int rc = 0;
+    reset_sink_capture();
+    dsd_output_float_block(&opts, &state, float_samples, 2, 2);
+    rc |= expect_int("float-output-disabled-audio", g_audio_write_calls, 0);
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 0;
+    dsd_output_float_block(&opts, &state, NULL, 2, 2);
+    rc |= expect_int("float-output-null-audio", g_audio_write_calls, 0);
+
+    dsd_output_float_block(&opts, &state, float_samples, 2, 2);
+    rc |= expect_int("float-output-audio-calls", g_audio_write_calls, 1);
+    rc |= expect_size("float-output-audio-frames", g_audio_write_frames, 2);
+    rc |= expect_int("float-output-clip-high", g_audio_write_samples[0], 32767);
+    rc |= expect_int("float-output-clip-low", g_audio_write_samples[1], -32768);
+    rc |= expect_int("float-output-half-positive", g_audio_write_samples[2], 16383);
+    rc |= expect_int("float-output-half-negative", g_audio_write_samples[3], -16383);
+
+    reset_sink_capture();
+    opts.audio_out_type = 8;
+    dsd_output_float_block(&opts, &state, float_samples, 2, 2);
+    rc |= expect_int("float-output-udp-calls", g_udp_blast_calls, 1);
+    rc |= expect_size("float-output-udp-bytes", g_udp_blast_bytes, sizeof(float_samples));
+    rc |= expect_bytes("float-output-udp-data", g_udp_blast_data, float_samples, sizeof(float_samples));
+
+    reset_sink_capture();
+    opts.audio_out_type = 1;
+    opts.audio_out_fd = 42;
+    dsd_output_float_block(&opts, &state, float_samples, 2, 2);
+    rc |= expect_int("float-output-fd-calls", g_dsd_write_calls, 1);
+    rc |= expect_int("float-output-fd", g_dsd_write_fd, 42);
+    rc |= expect_size("float-output-fd-bytes", g_dsd_write_bytes, sizeof(float_samples));
+    rc |= expect_bytes("float-output-fd-data", g_dsd_write_data, float_samples, sizeof(float_samples));
+
+    reset_sink_capture();
+    opts.audio_out_type = 0;
+    dsd_output_s16_block(&opts, &state, short_samples, 2, 2);
+    rc |= expect_int("s16-output-audio-calls", g_audio_write_calls, 1);
+    rc |= expect_size("s16-output-audio-frames", g_audio_write_frames, 2);
+    rc |= expect_bytes("s16-output-audio-data", g_audio_write_samples, short_samples, sizeof(short_samples));
+
+    reset_sink_capture();
+    opts.audio_out_type = 8;
+    dsd_output_s16_block(&opts, &state, short_samples, 2, 2);
+    rc |= expect_int("s16-output-udp-calls", g_udp_blast_calls, 1);
+    rc |= expect_size("s16-output-udp-bytes", g_udp_blast_bytes, sizeof(short_samples));
+    rc |= expect_bytes("s16-output-udp-data", g_udp_blast_data, short_samples, sizeof(short_samples));
+
+    return rc;
+}
+
+static int
+test_output_block_helpers_skip_silent_trailing_blocks(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    dsd_audio_stream* fake_stream = (dsd_audio_stream*)&opts;
+    float zero_f[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    float tiny_f[4] = {1e-13f, 0.0f, 0.0f, 0.0f};
+    float audio_f[4] = {0.25f, 0.0f, 0.0f, 0.0f};
+    const float* float_blocks[] = {zero_f, audio_f, tiny_f};
+    short zero_s[4] = {0, 0, 0, 0};
+    short audio_s[4] = {0, -77, 0, 0};
+    const short* short_blocks[] = {zero_s, audio_s, zero_s};
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.audio_out_stream = fake_stream;
+    opts.pulse_digi_out_channels = 2;
+
+    int rc = 0;
+    reset_sink_capture();
+    dsd_output_float_blocks(&opts, &state, float_blocks, 3, 2, 2, 1);
+    rc |= expect_int("float-blocks-skip-silent-calls", g_udp_blast_calls, 1);
+    rc |= expect_size("float-blocks-skip-silent-bytes", g_udp_blast_bytes, sizeof(audio_f));
+    rc |= expect_bytes("float-blocks-skip-silent-data", g_udp_blast_data, audio_f, sizeof(audio_f));
+
+    reset_sink_capture();
+    dsd_output_s16_blocks(&opts, &state, short_blocks, 3, 2, 2, 1);
+    rc |= expect_int("s16-blocks-skip-silent-calls", g_udp_blast_calls, 1);
+    rc |= expect_size("s16-blocks-skip-silent-bytes", g_udp_blast_bytes, sizeof(audio_s));
+    rc |= expect_bytes("s16-blocks-skip-silent-data", g_udp_blast_data, audio_s, sizeof(audio_s));
+
+    return rc;
+}
+
+static int
+test_output_ring_reset_helpers_preserve_below_threshold_and_clear_at_limit(void) {
+    static dsd_state state;
+    static short left_s[200];
+    static short right_s[200];
+    static float left_f[200];
+    static float right_f[200];
+    DSD_MEMSET(&state, 0, sizeof(state));
+    for (int i = 0; i < 200; i++) {
+        left_s[i] = (short)(i + 1);
+        right_s[i] = (short)(i + 2);
+        left_f[i] = (float)(i + 3);
+        right_f[i] = (float)(i + 4);
+    }
+    state.audio_out_buf = left_s;
+    state.audio_out_buf_p = left_s + 42;
+    state.audio_out_float_buf = left_f;
+    state.audio_out_float_buf_p = left_f + 42;
+    state.audio_out_bufR = right_s;
+    state.audio_out_buf_pR = right_s + 43;
+    state.audio_out_float_bufR = right_f;
+    state.audio_out_float_buf_pR = right_f + 43;
+    state.audio_out_idx2 = 799999;
+    state.audio_out_idx2R = 799999;
+
+    int rc = 0;
+    dsd_audio_maybe_reset_output_ring_left(&state);
+    dsd_audio_maybe_reset_output_ring_right(&state);
+    rc |= expect_int("ring-left-below-threshold-index", state.audio_out_idx2, 799999);
+    rc |= expect_int("ring-right-below-threshold-index", state.audio_out_idx2R, 799999);
+    rc |= expect_int("ring-left-below-threshold-short", left_s[0], 1);
+    rc |= expect_float("ring-right-below-threshold-float", right_f[0], 4.0f);
+
+    state.audio_out_idx2 = 800000;
+    state.audio_out_idx2R = 800000;
+    dsd_audio_maybe_reset_output_ring_left(&state);
+    dsd_audio_maybe_reset_output_ring_right(&state);
+    rc |= expect_int("ring-left-reset-index", state.audio_out_idx2, 0);
+    rc |= expect_int("ring-right-reset-index", state.audio_out_idx2R, 0);
+    rc |= expect_int("ring-left-reset-short-zero", left_s[99], 0);
+    rc |= expect_int("ring-right-reset-short-zero", right_s[99], 0);
+    rc |= expect_float("ring-left-reset-float-zero", left_f[99], 0.0f);
+    rc |= expect_float("ring-right-reset-float-zero", right_f[99], 0.0f);
+    rc |= expect_int("ring-left-reset-short-tail", left_s[100], 101);
+    rc |= expect_int("ring-right-reset-short-tail", right_s[100], 102);
+    rc |= expect_int("ring-left-reset-short-pointer", state.audio_out_buf_p == left_s + 100, 1);
+    rc |= expect_int("ring-right-reset-short-pointer", state.audio_out_buf_pR == right_s + 100, 1);
+    rc |= expect_int("ring-left-reset-float-pointer", state.audio_out_float_buf_p == left_f + 100, 1);
+    rc |= expect_int("ring-right-reset-float-pointer", state.audio_out_float_buf_pR == right_f + 100, 1);
+
+    return rc;
+}
+
+static int
+test_dmr_slot_mute_and_duplication_helpers(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int encL = -1;
+    int encR = -1;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.dmr_mute_encL = 1;
+    opts.dmr_mute_encR = 1;
+    state.dmr_encL = 1;
+    state.dmr_encR = 0;
+    dsd_dmr_init_slot_mute_flags(&opts, &state, &encL, &encR);
+
+    int rc = 0;
+    rc |= expect_int("dmr left encrypted muted", encL, 1);
+    rc |= expect_int("dmr right clear unmuted", encR, 0);
+
+    state.baofeng_ap = 1;
+    dsd_dmr_init_slot_mute_flags(&opts, &state, &encL, &encR);
+    rc |= expect_int("forced privacy unmutes left", encL, 0);
+    rc |= expect_int("forced privacy keeps right unmuted", encR, 0);
+
+    float a[320] = {0};
+    float b[320] = {0};
+    float c[320] = {0};
+    a[0] = 1.0f;
+    b[0] = 2.0f;
+    c[0] = 3.0f;
+    encL = 0;
+    encR = 1;
+    dsd_duplicate_active_float_slot_to_stereo(a, b, c, encL, encR, &encL, &encR);
+    rc |= expect_float("copy left to right a", a[1], 1.0f);
+    rc |= expect_float("copy left to right b", b[1], 2.0f);
+    rc |= expect_float("copy left to right c", c[1], 3.0f);
+    rc |= expect_int("right mute cleared", encR, 0);
+
+    a[2] = 4.0f;
+    a[3] = 5.0f;
+    b[2] = 6.0f;
+    b[3] = 7.0f;
+    c[2] = 8.0f;
+    c[3] = 9.0f;
+    encL = 1;
+    encR = 0;
+    dsd_duplicate_active_float_slot_to_stereo(a, b, c, encL, encR, &encL, &encR);
+    rc |= expect_float("copy right to left a", a[2], 5.0f);
+    rc |= expect_float("copy right to left b", b[2], 7.0f);
+    rc |= expect_float("copy right to left c", c[2], 9.0f);
+    rc |= expect_int("left mute cleared", encL, 0);
+    return rc;
+}
+
+static int
+test_dmr_ss3_decrypt_hold_and_copy_policy_helpers(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int encL = -1;
+    int encR = -1;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_dmr_decrypt_capture();
+
+    state.dmr_so = 0x40;
+    state.dmr_soR = 0x40;
+    dsd_dmr_ss3_init_enc_flags(&state, &encL, &encR);
+
+    int rc = 0;
+    rc |= expect_int("ss3 missing keys keep left muted", encL, 1);
+    rc |= expect_int("ss3 missing keys keep right muted", encR, 1);
+
+    g_dmr_missing_alg_key_allowed[0] = 1;
+    state.payload_algidR = 0x81;
+    g_dmr_voice_slot_allowed[1] = 1;
+    dsd_dmr_ss3_init_enc_flags(&state, &encL, &encR);
+    rc |= expect_int("ss3 missing-alg key unmutes left", encL, 0);
+    rc |= expect_int("ss3 explicit voice key unmutes right", encR, 0);
+
+    reset_dmr_decrypt_capture();
+    state.payload_algidR = 0;
+    state.baofeng_ap = 1;
+    dsd_dmr_ss3_init_enc_flags(&state, &encL, &encR);
+    rc |= expect_int("ss3 forced privacy unmutes left", encL, 0);
+    rc |= expect_int("ss3 forced privacy unmutes right", encR, 0);
+
+    state.baofeng_ap = 0;
+    state.lasttg = 111;
+    state.lasttgR = 222;
+    state.tg_hold = 999;
+    encL = 0;
+    encR = 0;
+    opts.slot_preference = -1;
+    dsd_dmr_apply_tg_hold_and_slot_preference_ss3(&opts, &state, 111, 222, &encL, &encR);
+    rc |= expect_int("ss3 tg hold mismatch mutes left", encL, 1);
+    rc |= expect_int("ss3 tg hold mismatch mutes right", encR, 1);
+    rc |= expect_int("ss3 tg hold mismatch sets dual preference", opts.slot_preference, 2);
+
+    encL = 1;
+    encR = 1;
+    state.tg_hold = 111;
+    dsd_dmr_apply_tg_hold_and_slot_preference_ss3(&opts, &state, 111, 222, &encL, &encR);
+    rc |= expect_int("ss3 tg hold left unmutes left", encL, 0);
+    rc |= expect_int("ss3 tg hold left enables slot1", opts.slot1_on, 1);
+    rc |= expect_int("ss3 tg hold left preference", opts.slot_preference, 0);
+
+    encL = 1;
+    encR = 1;
+    opts.slot2_on = 0;
+    state.tg_hold = 222;
+    dsd_dmr_apply_tg_hold_and_slot_preference_ss3(&opts, &state, 111, 222, &encL, &encR);
+    rc |= expect_int("ss3 tg hold right unmutes right", encR, 0);
+    rc |= expect_int("ss3 tg hold right enables slot2", opts.slot2_on, 1);
+    rc |= expect_int("ss3 tg hold right preference", opts.slot_preference, 1);
+
+    DSD_MEMSET(state.s_l4, 0, sizeof(state.s_l4));
+    DSD_MEMSET(state.s_r4, 0, sizeof(state.s_r4));
+    state.s_l4[0][0] = 11;
+    state.s_r4[0][0] = 44;
+    opts.slot1_on = 0;
+    opts.slot2_on = 1;
+    dsd_dmr_apply_stereo_output_policy_ss3(&opts, &state, 0, 0);
+    rc |= expect_int("ss3 slot2 only copies right to left", state.s_l4[0][0], 44);
+
+    state.s_l4[0][1] = 55;
+    state.s_r4[0][1] = 66;
+    opts.slot1_on = 1;
+    opts.slot2_on = 0;
+    dsd_dmr_apply_stereo_output_policy_ss3(&opts, &state, 0, 0);
+    rc |= expect_int("ss3 slot1 only copies left to right", state.s_r4[0][1], 55);
+
+    return rc;
+}
+
+static int
+test_p25p2_encrypted_lockout_slot_helper(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    int rc = 0;
+    state.payload_algidR = 0x81;
+    rc |= expect_int("p25p2 right encrypted without key locks out",
+                     dsd_p25p2_encrypted_lockout_slot_muted(&opts, &state, 1, 1), 1);
+    state.RR = 0x1234;
+    rc |= expect_int("p25p2 right key suppresses lockout", dsd_p25p2_encrypted_lockout_slot_muted(&opts, &state, 1, 1),
+                     0);
+    state.RR = 0;
+    opts.trunk_tune_enc_calls = 1;
+    rc |= expect_int("p25p2 trunk encrypted tuning suppresses lockout",
+                     dsd_p25p2_encrypted_lockout_slot_muted(&opts, &state, 1, 1), 0);
+    opts.trunk_tune_enc_calls = 0;
+    state.p25_p2_enc_lockout_muted[1] = 1;
+    rc |= expect_int("p25p2 existing lockout label stays muted",
+                     dsd_p25p2_encrypted_lockout_slot_muted(&opts, &state, 1, 1), 1);
+    rc |=
+        expect_int("p25p2 unmuted slot skips lockout", dsd_p25p2_encrypted_lockout_slot_muted(&opts, &state, 1, 0), 0);
+    rc |=
+        expect_int("p25p2 invalid slot skips lockout", dsd_p25p2_encrypted_lockout_slot_muted(&opts, &state, 2, 1), 0);
+    return rc;
+}
+
+static int
+test_p25p2_ss18_slot_preference_and_copy_policy_helpers(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    int rc = 0;
+    state.tg_hold = 111;
+    dsd_p25p2_apply_slot_preference_ss18(&opts, &state, 111, 222);
+    rc |= expect_int("ss18 tg hold left enables slot1", opts.slot1_on, 1);
+    rc |= expect_int("ss18 tg hold left preference", opts.slot_preference, 0);
+
+    opts.slot2_on = 0;
+    state.tg_hold = 222;
+    dsd_p25p2_apply_slot_preference_ss18(&opts, &state, 111, 222);
+    rc |= expect_int("ss18 tg hold right enables slot2", opts.slot2_on, 1);
+    rc |= expect_int("ss18 tg hold right preference", opts.slot_preference, 1);
+
+    state.tg_hold = 333;
+    dsd_p25p2_apply_slot_preference_ss18(&opts, &state, 111, 222);
+    rc |= expect_int("ss18 tg hold mismatch sets dual preference", opts.slot_preference, 2);
+
+    DSD_MEMSET(state.s_l4, 0, sizeof(state.s_l4));
+    DSD_MEMSET(state.s_r4, 0, sizeof(state.s_r4));
+    state.s_l4[0][0] = 10;
+    state.s_r4[0][0] = 20;
+    opts.slot1_on = 0;
+    opts.slot2_on = 1;
+    state.payload_algid = 0x81;
+    dsd_p25p2_apply_stereo_output_policy_ss18(&opts, &state, 1, 0);
+    rc |= expect_int("ss18 encrypted left lockout blocks right-to-left copy", state.s_l4[0][0], 0);
+    rc |= expect_int("ss18 right retained when left lockout", state.s_r4[0][0], 20);
+
+    state.s_l4[0][0] = 10;
+    state.s_r4[0][0] = 20;
+    state.R = 0x12345678ULL;
+    dsd_p25p2_apply_stereo_output_policy_ss18(&opts, &state, 1, 0);
+    rc |= expect_int("ss18 keyed left allows right-to-left copy", state.s_l4[0][0], 20);
+
+    state.s_l4[0][1] = 30;
+    state.s_r4[0][1] = 40;
+    opts.slot1_on = 1;
+    opts.slot2_on = 0;
+    state.payload_algidR = 0x84;
+    state.aes_key_loaded[1] = 0;
+    dsd_p25p2_apply_stereo_output_policy_ss18(&opts, &state, 0, 1);
+    rc |= expect_int("ss18 encrypted right lockout blocks left-to-right copy", state.s_r4[0][1], 0);
+
+    state.s_l4[0][1] = 30;
+    state.s_r4[0][1] = 40;
+    state.aes_key_loaded[1] = 1;
+    dsd_p25p2_apply_stereo_output_policy_ss18(&opts, &state, 0, 1);
+    rc |= expect_int("ss18 keyed right allows left-to-right copy", state.s_r4[0][1], 30);
+
+    return rc;
+}
+
+static int
+test_fs4_mono_mixer_averages_available_unmuted_slots(void) {
+    float lf[4][160];
+    float rf[4][160];
+    float mono[4][160];
+    int l_ok[4] = {1, 0, 1, 1};
+    int r_ok[4] = {1, 1, 0, 1};
+    DSD_MEMSET(lf, 0, sizeof(lf));
+    DSD_MEMSET(rf, 0, sizeof(rf));
+    DSD_MEMSET(mono, 0, sizeof(mono));
+    for (int j = 0; j < 4; j++) {
+        lf[j][0] = (float)(10 + j);
+        rf[j][0] = (float)(20 + j);
+    }
+
+    int rc = 0;
+    dsd_fs4_mix_mono_frames(lf, rf, 0, 0, l_ok, r_ok, mono);
+    rc |= expect_float("fs4 mono averages both slots", mono[0][0], 15.0f);
+    rc |= expect_float("fs4 mono uses right-only frame", mono[1][0], 21.0f);
+    rc |= expect_float("fs4 mono uses left-only frame", mono[2][0], 12.0f);
+    rc |= expect_float("fs4 mono averages final frame", mono[3][0], 18.0f);
+
+    DSD_MEMSET(mono, 0, sizeof(mono));
+    dsd_fs4_mix_mono_frames(lf, rf, 1, 0, l_ok, r_ok, mono);
+    rc |= expect_float("fs4 mono left-muted uses right", mono[0][0], 20.0f);
+    rc |= expect_float("fs4 mono left-muted no available right stays zero", mono[2][0], 0.0f);
+
+    DSD_MEMSET(mono, 0, sizeof(mono));
+    dsd_fs4_mix_mono_frames(lf, rf, 0, 1, l_ok, r_ok, mono);
+    rc |= expect_float("fs4 mono right-muted uses left", mono[0][0], 10.0f);
+    rc |= expect_float("fs4 mono right-muted no available left stays zero", mono[1][0], 0.0f);
+    return rc;
+}
+
+static int
+test_float_playback_orchestrators_emit_expected_blocks(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_gate_capture();
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.slot1_on = 1;
+    opts.slot2_on = 1;
+    opts.dmr_mute_encL = 1;
+    opts.dmr_mute_encR = 1;
+    opts.pulse_digi_out_channels = 2;
+    state.synctype = DSD_SYNC_P25P1_POS;
+    state.f_l[0] = 0.5f;
+    state.f_l[1] = -0.25f;
+
+    int rc = 0;
+    reset_sink_capture();
+    playSynthesizedVoiceFS(&opts, &state);
+    const float* fs_stereo = (const float*)g_udp_blast_data;
+    rc |= expect_int("fs stereo output call", g_udp_blast_calls, 1);
+    rc |= expect_size("fs stereo output bytes", g_udp_blast_bytes, 320U * sizeof(float));
+    rc |= expect_float("fs stereo left sample scaled", fs_stereo[0], 0.25f);
+    rc |= expect_float("fs stereo right sample scaled", fs_stereo[1], 0.25f);
+    rc |= expect_float("fs stereo next left scaled", fs_stereo[2], -0.125f);
+    rc |= expect_float("fs clears temp working buffer", state.audio_out_temp_buf[0], 0.0f);
+
+    state.f_l[0] = 0.75f;
+    state.payload_algid = 0x81;
+    state.R = 0;
+    reset_sink_capture();
+    playSynthesizedVoiceFS(&opts, &state);
+    rc |= expect_int("fs encrypted without key skips output", g_udp_blast_calls, 0);
+    rc |= expect_float("fs encrypted path clears temp buffer", state.audio_out_temp_buf[0], 0.0f);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.pulse_digi_out_channels = 1;
+    state.f_l4[0][0] = 0.25f;
+    state.f_r4[0][0] = 0.75f;
+    state.f_l4[1][0] = 0.5f;
+    state.f_r4[1][0] = 1.0f;
+    state.f_l4[2][0] = -0.25f;
+    state.f_r4[2][0] = 0.25f;
+    reset_sink_capture();
+    playSynthesizedVoiceFS3(&opts, &state);
+    const float* fs3_mono = (const float*)g_udp_blast_data;
+    rc |= expect_int("fs3 mono output calls", g_udp_blast_calls, 3);
+    rc |= expect_size("fs3 mono output bytes", g_udp_blast_bytes, 160U * sizeof(float));
+    rc |= expect_float("fs3 mono captures final block average", fs3_mono[0], 0.0f);
+    rc |= expect_float("fs3 resets left block", state.f_l4[0][0], 0.0f);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.dmr_encL = 1;
+    state.dmr_encR = 1;
+    reset_sink_capture();
+    playSynthesizedVoiceFS3(&opts, &state);
+    rc |= expect_int("fs3 both muted skips output", g_udp_blast_calls, 0);
+    reset_gate_capture();
+    return rc;
+}
+
+static int
+test_silent_s16_helper(void) {
+    short all_zero[4] = {0, 0, 0, 0};
+    short with_audio[4] = {0, 0, -1, 0};
+    int rc = 0;
+    rc |= expect_int("null s16 is silent", dsd_is_all_zero_s16(NULL, 4), 1);
+    rc |= expect_int("zero s16 is silent", dsd_is_all_zero_s16(all_zero, 4), 1);
+    rc |= expect_int("nonzero s16 is not silent", dsd_is_all_zero_s16(with_audio, 4), 0);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_p25_and_nxdn_decrypt_gate_helpers();
+    rc |= test_output_helpers_dispatch_to_configured_sinks();
+    rc |= test_output_block_helpers_skip_silent_trailing_blocks();
+    rc |= test_output_ring_reset_helpers_preserve_below_threshold_and_clear_at_limit();
+    rc |= test_dmr_slot_mute_and_duplication_helpers();
+    rc |= test_dmr_ss3_decrypt_hold_and_copy_policy_helpers();
+    rc |= test_p25p2_encrypted_lockout_slot_helper();
+    rc |= test_p25p2_ss18_slot_preference_and_copy_policy_helpers();
+    rc |= test_fs4_mono_mixer_averages_available_unmuted_slots();
+    rc |= test_float_playback_orchestrators_emit_expected_blocks();
+    rc |= test_silent_s16_helper();
+    return rc;
+}

--- a/tests/core/test_core_audio2_helpers.c
+++ b/tests/core/test_core_audio2_helpers.c
@@ -393,6 +393,10 @@ test_output_helpers_dispatch_to_configured_sinks(void) {
     reset_sink_capture();
     dsd_output_float_block(&opts, &state, float_samples, 2, 2);
     rc |= expect_int("float-output-disabled-audio", g_audio_write_calls, 0);
+    dsd_output_s16_block(&opts, &state, short_samples, 2, 2);
+    rc |= expect_int("s16-output-disabled-audio", g_audio_write_calls, 0);
+    rc |= expect_int("s16-output-disabled-udp", g_udp_blast_calls, 0);
+    rc |= expect_int("s16-output-disabled-fd", g_dsd_write_calls, 0);
 
     opts.audio_out = 1;
     opts.audio_out_type = 0;

--- a/tests/core/test_core_audio_gain.c
+++ b/tests/core/test_core_audio_gain.c
@@ -4,14 +4,24 @@
  */
 
 #include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/dibit.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/posix_compat.h>
+#include <errno.h>
 #include <math.h>
+#include <sndfile.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+
+enum { DSD_AUDIO_TEST_PATH_MAX = 512 };
 
 static int
 expect_true(const char* label, int cond) {
@@ -38,6 +48,124 @@ expect_float_close(const char* label, float got, float want, float tol) {
         return 1;
     }
     return 0;
+}
+
+static int
+create_temp_wav_path(const char* prefix, char* out_path, size_t out_path_sz) {
+    if (DSD_SNPRINTF(out_path, out_path_sz, "/tmp/%s_XXXXXX", prefix) >= (int)out_path_sz) {
+        DSD_FPRINTF(stderr, "FAIL: temp path too long for %s\n", prefix);
+        return 1;
+    }
+    int fd = dsd_mkstemp(out_path);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "FAIL: dsd_mkstemp failed for %s\n", prefix);
+        return 1;
+    }
+    (void)dsd_close(fd);
+    (void)remove(out_path);
+    return 0;
+}
+
+static int
+create_temp_file_fd(const char* prefix, char* out_path, size_t out_path_sz) {
+    if (DSD_SNPRINTF(out_path, out_path_sz, "/tmp/%s_XXXXXX", prefix) >= (int)out_path_sz) {
+        DSD_FPRINTF(stderr, "FAIL: temp file path too long for %s\n", prefix);
+        return -1;
+    }
+
+    int fd = dsd_mkstemp(out_path);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "FAIL: dsd_mkstemp failed for %s\n", prefix);
+    }
+    return fd;
+}
+
+static int
+create_temp_file_with_suffix(const char* prefix, const char* suffix, char* out_path, size_t out_path_sz) {
+    char base_path[DSD_AUDIO_TEST_PATH_MAX] = {0};
+    int fd = create_temp_file_fd(prefix, base_path, sizeof base_path);
+    if (fd < 0) {
+        return -1;
+    }
+
+    if (DSD_SNPRINTF(out_path, out_path_sz, "%s%s", base_path, suffix) >= (int)out_path_sz) {
+        DSD_FPRINTF(stderr, "FAIL: suffixed temp path too long for %s\n", prefix);
+        (void)dsd_close(fd);
+        (void)remove(base_path);
+        return -1;
+    }
+    if (rename(base_path, out_path) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: rename temp file to %s failed: %s\n", out_path, strerror(errno));
+        (void)dsd_close(fd);
+        (void)remove(base_path);
+        return -1;
+    }
+    return fd;
+}
+
+static int
+create_temp_dir_with_suffix(const char* prefix, const char* suffix, char* out_path, size_t out_path_sz) {
+    char base_path[DSD_AUDIO_TEST_PATH_MAX] = {0};
+    if (DSD_SNPRINTF(base_path, sizeof base_path, "/tmp/%s_XXXXXX", prefix) >= (int)sizeof base_path) {
+        DSD_FPRINTF(stderr, "FAIL: temp dir path too long for %s\n", prefix);
+        return 1;
+    }
+    if (dsd_mkdtemp(base_path) == NULL) {
+        DSD_FPRINTF(stderr, "FAIL: dsd_mkdtemp failed for %s\n", prefix);
+        return 1;
+    }
+    if (DSD_SNPRINTF(out_path, out_path_sz, "%s%s", base_path, suffix) >= (int)out_path_sz) {
+        DSD_FPRINTF(stderr, "FAIL: suffixed temp dir path too long for %s\n", prefix);
+        (void)remove(base_path);
+        return 1;
+    }
+    if (rename(base_path, out_path) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: rename temp dir to %s failed: %s\n", out_path, strerror(errno));
+        (void)remove(base_path);
+        return 1;
+    }
+    return 0;
+}
+
+static SNDFILE*
+open_temp_wav_writer(const char* path, int channels) {
+    SF_INFO info;
+    DSD_MEMSET(&info, 0, sizeof info);
+    info.samplerate = 8000;
+    info.channels = channels;
+    info.format = SF_FORMAT_WAV | SF_FORMAT_PCM_16;
+    return sf_open(path, SFM_WRITE, &info);
+}
+
+static int
+read_wav_samples(const char* path, int channels, short* out, size_t out_count) {
+    SF_INFO info;
+    DSD_MEMSET(&info, 0, sizeof info);
+    SNDFILE* file = sf_open(path, SFM_READ, &info);
+    if (!file) {
+        DSD_FPRINTF(stderr, "FAIL: sf_open read failed for %s: %s\n", path, sf_strerror(NULL));
+        return 1;
+    }
+
+    int rc = 0;
+    rc |= expect_int_eq("wav read channel count", info.channels, channels);
+    sf_count_t nread = sf_read_short(file, out, (sf_count_t)out_count);
+    rc |= expect_int_eq("wav read sample count", (int)nread, (int)out_count);
+    sf_close(file);
+    return rc;
+}
+
+static int
+read_short_file_samples(const char* path, short* out, size_t out_count) {
+    FILE* file = dsd_fopen_existing_regular_file(path, "rb");
+    if (!file) {
+        DSD_FPRINTF(stderr, "FAIL: fopen read failed for %s\n", path);
+        return 1;
+    }
+
+    size_t nread = fread(out, sizeof(short), out_count, file);
+    fclose(file);
+    return expect_int_eq("short file read sample count", (int)nread, (int)out_count);
 }
 
 static int
@@ -192,8 +320,12 @@ test_upsample_repeats_into_selected_slot_buffer(void) {
     static dsd_state state;
     DSD_MEMSET(&state, 0, sizeof(state));
 
-    float left[6] = {-1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f};
-    float right[6] = {-2.0f, -2.0f, -2.0f, -2.0f, -2.0f, -2.0f};
+    static float left[6];
+    static float right[6];
+    for (int i = 0; i < 6; i++) {
+        left[i] = -1.0f;
+        right[i] = -2.0f;
+    }
     state.audio_out_float_buf_p = left;
     state.audio_out_float_buf_pR = right;
     upsample(&state, 1.25f);
@@ -295,6 +427,609 @@ test_agf_scales_nonzero_float_block_and_updates_slot_gain(void) {
     return rc;
 }
 
+static int
+test_process_audio_native_left_clamps_and_tracks_output(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    opts.audio_gain = 1.0f;
+    opts.pulse_digi_rate_out = 8000;
+    state.aout_gain = 2.0f;
+    static short out[200];
+    static float out_float[200];
+    DSD_MEMSET(out, 0, sizeof(out));
+    DSD_MEMSET(out_float, 0, sizeof(out_float));
+    state.audio_out_buf = out;
+    state.audio_out_float_buf = out_float;
+    state.audio_out_temp_buf[0] = 20000.0f;
+    state.audio_out_temp_buf[1] = -20000.0f;
+    state.audio_out_temp_buf[2] = 100.0f;
+    state.audio_out_buf_p = state.audio_out_buf;
+    state.audio_out_float_buf_p = state.audio_out_float_buf;
+
+    processAudio(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_int_eq("left clamp positive output", out[0], 32767);
+    rc |= expect_int_eq("left clamp negative output", out[1], -32768);
+    rc |= expect_int_eq("left scaled sample output", out[2], 200);
+    rc |= expect_int_eq("left mirror positive", state.s_l[0], 32767);
+    rc |= expect_int_eq("left mirror negative", state.s_l[1], -32768);
+    rc |= expect_int_eq("left native index", state.audio_out_idx, 160);
+    rc |= expect_int_eq("left native long index", state.audio_out_idx2, 160);
+    rc |= expect_true("left output pointer advanced", state.audio_out_buf_p == state.audio_out_buf + 160);
+    rc |= expect_float_close("left manual gain unchanged", state.aout_gain, 2.0f, 1e-6f);
+    return rc;
+}
+
+static int
+test_process_audio_native_right_clamps_and_tracks_output(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    opts.audio_gainR = 1.0f;
+    opts.pulse_digi_rate_out = 8000;
+    state.aout_gainR = 3.0f;
+    static short out[200];
+    static float out_float[200];
+    DSD_MEMSET(out, 0, sizeof(out));
+    DSD_MEMSET(out_float, 0, sizeof(out_float));
+    state.audio_out_bufR = out;
+    state.audio_out_float_bufR = out_float;
+    state.audio_out_temp_bufR[0] = 12000.0f;
+    state.audio_out_temp_bufR[1] = -12000.0f;
+    state.audio_out_temp_bufR[2] = 100.0f;
+    state.audio_out_buf_pR = state.audio_out_bufR;
+    state.audio_out_float_buf_pR = state.audio_out_float_bufR;
+
+    processAudioR(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_int_eq("right clamp positive output", out[0], 32767);
+    rc |= expect_int_eq("right clamp negative output", out[1], -32768);
+    rc |= expect_int_eq("right scaled sample output", out[2], 300);
+    rc |= expect_int_eq("right mirror positive", state.s_r[0], 32767);
+    rc |= expect_int_eq("right mirror negative", state.s_r[1], -32768);
+    rc |= expect_int_eq("right native index", state.audio_out_idxR, 160);
+    rc |= expect_int_eq("right native long index", state.audio_out_idx2R, 160);
+    rc |= expect_true("right output pointer advanced", state.audio_out_buf_pR == state.audio_out_bufR + 160);
+    rc |= expect_float_close("right manual gain unchanged", state.aout_gainR, 3.0f, 1e-6f);
+    return rc;
+}
+
+static int
+test_process_audio_auto_gain_ramps_from_peak_history(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    opts.audio_gain = 0.0f;
+    opts.pulse_digi_rate_out = 8000;
+    state.aout_gain = 1.0f;
+    state.aout_max_buf_p = state.aout_max_buf;
+    static short out[200];
+    static float out_float[200];
+    DSD_MEMSET(out, 0, sizeof(out));
+    DSD_MEMSET(out_float, 0, sizeof(out_float));
+    state.audio_out_buf = out;
+    state.audio_out_float_buf = out_float;
+    for (int i = 0; i < 160; i++) {
+        state.audio_out_temp_buf[i] = 1000.0f;
+    }
+    state.audio_out_buf_p = state.audio_out_buf;
+    state.audio_out_float_buf_p = state.audio_out_float_buf;
+
+    processAudio(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_int_eq("auto gain first sample", out[0], 1000);
+    rc |= expect_int_eq("auto gain last sample ramps", out[159], 1049);
+    rc |= expect_float_close("auto gain capped ramp target", state.aout_gain, 1.05f, 1e-6f);
+    rc |= expect_int_eq("auto gain peak history index", state.aout_max_buf_idx, 1);
+    rc |= expect_float_close("auto gain peak history stores block", state.aout_max_buf[0], 1000.0f, 1e-6f);
+    rc |= expect_int_eq("auto gain output index", state.audio_out_idx, 160);
+    return rc;
+}
+
+static int
+test_process_audio_right_auto_gain_tracks_peak_history(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    opts.audio_gainR = 0.0f;
+    opts.pulse_digi_rate_out = 8000;
+    state.aout_gainR = 10.0f;
+    state.aout_max_bufR[3] = 20000.0f;
+    state.aout_max_buf_idxR = 24;
+    state.aout_max_buf_pR = state.aout_max_bufR + 24;
+    static short out[200];
+    static float out_float[200];
+    DSD_MEMSET(out, 0, sizeof(out));
+    DSD_MEMSET(out_float, 0, sizeof(out_float));
+    state.audio_out_bufR = out;
+    state.audio_out_float_bufR = out_float;
+    state.audio_out_temp_bufR[0] = 1000.0f;
+    state.audio_out_temp_bufR[1] = -2000.0f;
+    state.audio_out_temp_bufR[2] = 250.0f;
+    state.audio_out_temp_bufR[3] = -4000.0f;
+    state.audio_out_buf_pR = state.audio_out_bufR;
+    state.audio_out_float_buf_pR = state.audio_out_float_bufR;
+
+    processAudioR(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_int_eq("right auto gain first sample", out[0], 1500);
+    rc |= expect_int_eq("right auto gain negative sample", out[1], -3000);
+    rc |= expect_int_eq("right auto gain small sample", out[2], 375);
+    rc |= expect_int_eq("right auto gain peak sample", out[3], -6000);
+    rc |= expect_int_eq("right auto gain mirror sample", state.s_r[0], 1500);
+    rc |= expect_float_close("right auto gain falls to peak target", state.aout_gainR, 1.5f, 1e-6f);
+    rc |= expect_float_close("right auto gain stores block peak", state.aout_max_bufR[24], 4000.0f, 1e-6f);
+    rc |= expect_int_eq("right auto gain wraps history index", state.aout_max_buf_idxR, 0);
+    rc |= expect_true("right auto gain wraps history pointer", state.aout_max_buf_pR == state.aout_max_bufR);
+    rc |= expect_int_eq("right auto gain output index", state.audio_out_idxR, 160);
+    rc |= expect_int_eq("right auto gain long output index", state.audio_out_idx2R, 160);
+    rc |= expect_true("right auto gain output pointer advanced", state.audio_out_buf_pR == state.audio_out_bufR + 160);
+    return rc;
+}
+
+static int
+test_process_audio_upsampled_left_clamps_and_tracks_output(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    opts.audio_gain = 1.0f;
+    opts.pulse_digi_rate_out = 48000;
+    state.aout_gain = 1.0f;
+    static short out[1000];
+    static float out_float[1000];
+    DSD_MEMSET(out, 0, sizeof(out));
+    DSD_MEMSET(out_float, 0, sizeof(out_float));
+    state.audio_out_buf = out;
+    state.audio_out_float_buf = out_float;
+    state.audio_out_buf_p = state.audio_out_buf;
+    state.audio_out_float_buf_p = state.audio_out_float_buf;
+    state.audio_out_temp_buf[0] = 40000.0f;
+    state.audio_out_temp_buf[1] = -40000.0f;
+    state.audio_out_temp_buf[2] = 123.0f;
+
+    processAudio(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_int_eq("left upsample clamp positive first", out[0], 32767);
+    rc |= expect_int_eq("left upsample clamp positive repeat", out[5], 32767);
+    rc |= expect_int_eq("left upsample clamp negative first", out[6], -32768);
+    rc |= expect_int_eq("left upsample clamp negative repeat", out[11], -32768);
+    rc |= expect_int_eq("left upsample repeated sample", out[12], 123);
+    rc |= expect_int_eq("left upsample mirror positive", state.s_lu[0], 32767);
+    rc |= expect_int_eq("left upsample mirror negative", state.s_lu[6], -32768);
+    rc |= expect_int_eq("left upsample index", state.audio_out_idx, 960);
+    rc |= expect_int_eq("left upsample long index", state.audio_out_idx2, 960);
+    rc |= expect_true("left upsample output pointer advanced", state.audio_out_buf_p == state.audio_out_buf + 960);
+    rc |= expect_true("left upsample float pointer advanced",
+                      state.audio_out_float_buf_p == state.audio_out_float_buf + 960);
+    return rc;
+}
+
+static int
+test_process_audio_upsampled_right_clamps_and_tracks_output(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    opts.audio_gainR = 1.0f;
+    opts.pulse_digi_rate_out = 48000;
+    state.aout_gainR = 1.0f;
+    state.dmr_stereo = 1;
+    state.currentslot = 1;
+    static short out[1000];
+    static float out_float[1000];
+    DSD_MEMSET(out, 0, sizeof(out));
+    DSD_MEMSET(out_float, 0, sizeof(out_float));
+    state.audio_out_bufR = out;
+    state.audio_out_float_bufR = out_float;
+    state.audio_out_buf_pR = state.audio_out_bufR;
+    state.audio_out_float_buf_pR = state.audio_out_float_bufR;
+    state.audio_out_temp_bufR[0] = 50000.0f;
+    state.audio_out_temp_bufR[1] = -50000.0f;
+    state.audio_out_temp_bufR[2] = -321.0f;
+
+    processAudioR(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_int_eq("right upsample clamp positive first", out[0], 32767);
+    rc |= expect_int_eq("right upsample clamp positive repeat", out[5], 32767);
+    rc |= expect_int_eq("right upsample clamp negative first", out[6], -32768);
+    rc |= expect_int_eq("right upsample clamp negative repeat", out[11], -32768);
+    rc |= expect_int_eq("right upsample repeated sample", out[12], -321);
+    rc |= expect_int_eq("right upsample mirror positive", state.s_ru[0], 32767);
+    rc |= expect_int_eq("right upsample mirror negative", state.s_ru[6], -32768);
+    rc |= expect_int_eq("right upsample index", state.audio_out_idxR, 960);
+    rc |= expect_int_eq("right upsample long index", state.audio_out_idx2R, 960);
+    rc |= expect_true("right upsample output pointer advanced", state.audio_out_buf_pR == state.audio_out_bufR + 960);
+    rc |= expect_true("right upsample float pointer advanced",
+                      state.audio_out_float_buf_pR == state.audio_out_float_bufR + 960);
+    return rc;
+}
+
+static int
+test_play_synthesized_voice_slot_off_clears_pending_output(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    opts.slot1_on = 0;
+    static short out[200];
+    static float out_float[200];
+    for (int i = 0; i < 200; i++) {
+        out[i] = (short)(i + 1);
+        out_float[i] = (float)(i + 1);
+    }
+    state.audio_out_buf = out;
+    state.audio_out_float_buf = out_float;
+    state.audio_out_buf_p = out + 55;
+    state.audio_out_float_buf_p = out_float + 55;
+    state.audio_out_idx = 55;
+    state.audio_out_idx2 = 77;
+
+    playSynthesizedVoice(&opts, &state);
+
+    int rc = 0;
+    for (int i = 0; i < 100; i++) {
+        char label[64];
+        DSD_SNPRINTF(label, sizeof label, "slot-off clears short %d", i);
+        rc |= expect_int_eq(label, out[i], 0);
+        DSD_SNPRINTF(label, sizeof label, "slot-off clears float %d", i);
+        rc |= expect_float_close(label, out_float[i], 0.0f, 1e-6f);
+    }
+    rc |= expect_true("slot-off short pointer reset", state.audio_out_buf_p == state.audio_out_buf + 100);
+    rc |= expect_true("slot-off float pointer reset", state.audio_out_float_buf_p == state.audio_out_float_buf + 100);
+    rc |= expect_int_eq("slot-off index reset", state.audio_out_idx, 0);
+    rc |= expect_int_eq("slot-off long index reset", state.audio_out_idx2, 0);
+    return rc;
+}
+
+static int
+test_play_synthesized_voice_fd_writes_pending_pcm_and_resets_index(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    char path[DSD_AUDIO_TEST_PATH_MAX] = {0};
+    int fd = create_temp_file_fd("dsdneo_audio_fd", path, sizeof path);
+    if (fd < 0) {
+        return 1;
+    }
+
+    opts.slot1_on = 1;
+    opts.audio_out = 1;
+    opts.audio_out_type = 1;
+    opts.audio_out_fd = fd;
+    opts.delay = 2;
+    static short out[8];
+    static float out_float[8];
+    static const short initial_out[8] = {101, -202, 303, -404, 505, -606, 707, -808};
+    DSD_MEMCPY(out, initial_out, sizeof(out));
+    DSD_MEMSET(out_float, 0, sizeof(out_float));
+    state.audio_out_buf = out;
+    state.audio_out_float_buf = out_float;
+    state.audio_out_buf_p = out + 4;
+    state.audio_out_float_buf_p = out_float + 4;
+    state.audio_out_idx = 4;
+    state.audio_out_idx2 = 4;
+
+    playSynthesizedVoice(&opts, &state);
+    (void)dsd_close(fd);
+    opts.audio_out_fd = -1;
+
+    short samples[4] = {0};
+    int rc = read_short_file_samples(path, samples, 4);
+    rc |= expect_int_eq("fd write sample 0", samples[0], 101);
+    rc |= expect_int_eq("fd write sample 1", samples[1], -202);
+    rc |= expect_int_eq("fd write sample 2", samples[2], 303);
+    rc |= expect_int_eq("fd write sample 3", samples[3], -404);
+    rc |= expect_int_eq("fd write resets index", state.audio_out_idx, 0);
+    rc |= expect_int_eq("fd write leaves long index", state.audio_out_idx2, 4);
+    (void)remove(path);
+    return rc;
+}
+
+static int
+test_play_synthesized_voice_bad_fd_drops_pending_pcm(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    opts.slot1_on = 1;
+    opts.audio_out = 1;
+    opts.audio_out_type = 1;
+    opts.audio_out_fd = -1;
+    opts.delay = 0;
+    static short out[4];
+    static const short initial_out[4] = {1, 2, 3, 4};
+    DSD_MEMCPY(out, initial_out, sizeof(out));
+    state.audio_out_buf = out;
+    state.audio_out_buf_p = out + 4;
+    state.audio_out_idx = 4;
+
+    playSynthesizedVoice(&opts, &state);
+
+    return expect_int_eq("bad fd drops pending index", state.audio_out_idx, 0);
+}
+
+static int
+test_drain_audio_output_guards_and_fd_sink(void) {
+    dsd_drain_audio_output(NULL);
+
+    static dsd_opts opts = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.audio_out = 0;
+    opts.audio_out_type = 1;
+    opts.audio_out_fd = -1;
+    dsd_drain_audio_output(&opts);
+
+    char path[DSD_AUDIO_TEST_PATH_MAX] = {0};
+    int fd = create_temp_file_fd("dsdneo_audio_drain", path, sizeof path);
+    if (fd < 0) {
+        return 1;
+    }
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 1;
+    opts.audio_out_fd = fd;
+    dsd_drain_audio_output(&opts);
+    (void)dsd_close(fd);
+    (void)remove(path);
+    return 0;
+}
+
+static int
+test_write_synthesized_voice_clamps_and_writes_left_mono(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    char path[DSD_AUDIO_TEST_PATH_MAX] = {0};
+    if (create_temp_wav_path("dsdneo_audio_left", path, sizeof path) != 0) {
+        return 1;
+    }
+    opts.wav_out_f = open_temp_wav_writer(path, 1);
+    if (!opts.wav_out_f) {
+        DSD_FPRINTF(stderr, "FAIL: sf_open write failed for %s: %s\n", path, sf_strerror(NULL));
+        (void)remove(path);
+        return 1;
+    }
+
+    state.audio_out_temp_buf[0] = 40000.0f;
+    state.audio_out_temp_buf[1] = -40000.0f;
+    state.audio_out_temp_buf[2] = 1234.0f;
+    writeSynthesizedVoice(&opts, &state);
+    sf_close(opts.wav_out_f);
+    opts.wav_out_f = NULL;
+
+    short samples[160] = {0};
+    int rc = read_wav_samples(path, 1, samples, 160);
+    rc |= expect_int_eq("write left clamp high", samples[0], 32767);
+    rc |= expect_int_eq("write left clamp low", samples[1], -32768);
+    rc |= expect_int_eq("write left normal sample", samples[2], 1234);
+    rc |= expect_float_close("write left temp clamped high", state.audio_out_temp_buf[0], 32767.0f, 1e-6f);
+    rc |= expect_float_close("write left temp clamped low", state.audio_out_temp_buf[1], -32768.0f, 1e-6f);
+    (void)remove(path);
+    return rc;
+}
+
+static int
+test_write_synthesized_voice_r_clamps_and_writes_right_mono(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    char path[DSD_AUDIO_TEST_PATH_MAX] = {0};
+    if (create_temp_wav_path("dsdneo_audio_right", path, sizeof path) != 0) {
+        return 1;
+    }
+    opts.wav_out_fR = open_temp_wav_writer(path, 1);
+    if (!opts.wav_out_fR) {
+        DSD_FPRINTF(stderr, "FAIL: sf_open write failed for %s: %s\n", path, sf_strerror(NULL));
+        (void)remove(path);
+        return 1;
+    }
+
+    state.audio_out_temp_bufR[0] = 45000.0f;
+    state.audio_out_temp_bufR[1] = -45000.0f;
+    state.audio_out_temp_bufR[2] = -2345.0f;
+    writeSynthesizedVoiceR(&opts, &state);
+    sf_close(opts.wav_out_fR);
+    opts.wav_out_fR = NULL;
+
+    short samples[160] = {0};
+    int rc = read_wav_samples(path, 1, samples, 160);
+    rc |= expect_int_eq("write right clamp high", samples[0], 32767);
+    rc |= expect_int_eq("write right clamp low", samples[1], -32768);
+    rc |= expect_int_eq("write right normal sample", samples[2], -2345);
+    rc |= expect_float_close("write right temp clamped high", state.audio_out_temp_bufR[0], 32767.0f, 1e-6f);
+    rc |= expect_float_close("write right temp clamped low", state.audio_out_temp_bufR[1], -32768.0f, 1e-6f);
+    (void)remove(path);
+    return rc;
+}
+
+static int
+test_write_synthesized_voice_ms_duplicates_left_into_stereo_wav(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    char path[DSD_AUDIO_TEST_PATH_MAX] = {0};
+    if (create_temp_wav_path("dsdneo_audio_ms", path, sizeof path) != 0) {
+        return 1;
+    }
+    opts.wav_out_f = open_temp_wav_writer(path, 2);
+    if (!opts.wav_out_f) {
+        DSD_FPRINTF(stderr, "FAIL: sf_open write failed for %s: %s\n", path, sf_strerror(NULL));
+        (void)remove(path);
+        return 1;
+    }
+
+    state.audio_out_temp_buf[0] = 111.0f;
+    state.audio_out_temp_buf[1] = -222.0f;
+    writeSynthesizedVoiceMS(&opts, &state);
+    sf_close(opts.wav_out_f);
+    opts.wav_out_f = NULL;
+
+    short samples[320] = {0};
+    int rc = read_wav_samples(path, 2, samples, 320);
+    rc |= expect_int_eq("write ms left duplicate 0", samples[0], 111);
+    rc |= expect_int_eq("write ms right duplicate 0", samples[1], 111);
+    rc |= expect_int_eq("write ms left duplicate 1", samples[2], -222);
+    rc |= expect_int_eq("write ms right duplicate 1", samples[3], -222);
+    (void)remove(path);
+    return rc;
+}
+
+static int
+test_open_audio_in_device_rejects_null_arguments(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    return expect_int_eq("open input rejects null opts", openAudioInDevice(NULL, &state), -1)
+           | expect_int_eq("open input rejects null state", openAudioInDevice(&opts, NULL), -1);
+}
+
+static int
+test_open_audio_in_device_bin_symbol_file_resets_replay_state(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    char path[DSD_AUDIO_TEST_PATH_MAX] = {0};
+    int fd = create_temp_file_with_suffix("dsdneo_audio_symbols", ".bin", path, sizeof path);
+    if (fd < 0) {
+        return 1;
+    }
+    const unsigned char payload[4] = {0x02, 0x03, 0x01, 0x00};
+    if (dsd_write(fd, payload, sizeof payload) != (ssize_t)sizeof payload) {
+        DSD_FPRINTF(stderr, "FAIL: write bin symbol payload\n");
+        (void)dsd_close(fd);
+        (void)remove(path);
+        return 1;
+    }
+    (void)dsd_close(fd);
+
+    opts.audio_in_type = AUDIO_IN_PULSE;
+    opts.wav_sample_rate = 48000;
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", path);
+    state.use_throttle = 0;
+    state.symbol_replay_next_deadline_ns = 12345;
+    state.symbol_replay_format = DSD_SYMBOL_REPLAY_FORMAT_SOFT;
+    state.symbol_replay_header_checked = 1;
+    state.symbol_replay_has_soft = 1;
+
+    int rc = expect_int_eq("open bin symbol input succeeds", openAudioInDevice(&opts, &state), 0);
+    rc |= expect_int_eq("bin symbol input type", opts.audio_in_type, AUDIO_IN_SYMBOL_BIN);
+    rc |= expect_true("bin symbol file opened", opts.symbolfile != NULL);
+    rc |= expect_int_eq("bin symbol replay enables throttle", state.use_throttle, 1);
+    rc |= expect_true("bin symbol replay clears deadline", state.symbol_replay_next_deadline_ns == 0);
+    rc |=
+        expect_int_eq("bin symbol replay resets format", state.symbol_replay_format, DSD_SYMBOL_REPLAY_FORMAT_UNKNOWN);
+    rc |= expect_int_eq("bin symbol replay clears header check", state.symbol_replay_header_checked, 0);
+    rc |= expect_int_eq("bin symbol replay clears soft flag", state.symbol_replay_has_soft, 0);
+    if (opts.symbolfile) {
+        fclose(opts.symbolfile);
+        opts.symbolfile = NULL;
+    }
+    (void)remove(path);
+    return rc;
+}
+
+static int
+test_open_audio_in_device_float_symbol_file_preserves_soft_metadata(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    char path[DSD_AUDIO_TEST_PATH_MAX] = {0};
+    int fd = create_temp_file_with_suffix("dsdneo_audio_symbols", ".raw", path, sizeof path);
+    if (fd < 0) {
+        return 1;
+    }
+    const float payload[2] = {1.0f, -1.0f};
+    if (dsd_write(fd, payload, sizeof payload) != (ssize_t)sizeof payload) {
+        DSD_FPRINTF(stderr, "FAIL: write raw symbol payload\n");
+        (void)dsd_close(fd);
+        (void)remove(path);
+        return 1;
+    }
+    (void)dsd_close(fd);
+
+    opts.audio_in_type = AUDIO_IN_PULSE;
+    opts.wav_sample_rate = 48000;
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", path);
+    state.use_throttle = 1;
+    state.symbol_replay_next_deadline_ns = 9876;
+    state.symbol_replay_format = DSD_SYMBOL_REPLAY_FORMAT_SOFT;
+    state.symbol_replay_header_checked = 1;
+    state.symbol_replay_has_soft = 1;
+
+    int rc = expect_int_eq("open float symbol input succeeds", openAudioInDevice(&opts, &state), 0);
+    rc |= expect_int_eq("float symbol input type", opts.audio_in_type, AUDIO_IN_SYMBOL_FLT);
+    rc |= expect_true("float symbol file opened", opts.symbolfile != NULL);
+    rc |= expect_int_eq("float symbol replay clears throttle", state.use_throttle, 0);
+    rc |= expect_true("float symbol replay clears deadline", state.symbol_replay_next_deadline_ns == 0);
+    rc |= expect_int_eq("float symbol replay keeps format", state.symbol_replay_format, DSD_SYMBOL_REPLAY_FORMAT_SOFT);
+    rc |= expect_int_eq("float symbol replay keeps header check", state.symbol_replay_header_checked, 1);
+    rc |= expect_int_eq("float symbol replay keeps soft flag", state.symbol_replay_has_soft, 1);
+    if (opts.symbolfile) {
+        fclose(opts.symbolfile);
+        opts.symbolfile = NULL;
+    }
+    (void)remove(path);
+    return rc;
+}
+
+static int
+test_open_audio_in_device_symbol_directory_falls_back_to_pulse(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    char path[DSD_AUDIO_TEST_PATH_MAX] = {0};
+    if (create_temp_dir_with_suffix("dsdneo_audio_symbols", ".bin", path, sizeof path) != 0) {
+        return 1;
+    }
+
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", path);
+    state.use_throttle = 1;
+    state.symbol_replay_next_deadline_ns = 4567;
+
+    int rc = expect_int_eq("open symbol directory succeeds as fallback", openAudioInDevice(&opts, &state), 0);
+    rc |= expect_int_eq("symbol directory selects pulse fallback", opts.audio_in_type, AUDIO_IN_PULSE);
+    rc |= expect_true("symbol directory does not open symbol file", opts.symbolfile == NULL);
+    rc |= expect_int_eq("symbol directory clears throttle", state.use_throttle, 0);
+    rc |= expect_true("symbol directory clears deadline", state.symbol_replay_next_deadline_ns == 0);
+    (void)remove(path);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -306,5 +1041,22 @@ main(void) {
     rc |= test_upsample_repeats_into_selected_slot_buffer();
     rc |= test_manual_and_float_autogain_helpers();
     rc |= test_agf_scales_nonzero_float_block_and_updates_slot_gain();
+    rc |= test_process_audio_native_left_clamps_and_tracks_output();
+    rc |= test_process_audio_native_right_clamps_and_tracks_output();
+    rc |= test_process_audio_auto_gain_ramps_from_peak_history();
+    rc |= test_process_audio_right_auto_gain_tracks_peak_history();
+    rc |= test_process_audio_upsampled_left_clamps_and_tracks_output();
+    rc |= test_process_audio_upsampled_right_clamps_and_tracks_output();
+    rc |= test_play_synthesized_voice_slot_off_clears_pending_output();
+    rc |= test_play_synthesized_voice_fd_writes_pending_pcm_and_resets_index();
+    rc |= test_play_synthesized_voice_bad_fd_drops_pending_pcm();
+    rc |= test_drain_audio_output_guards_and_fd_sink();
+    rc |= test_write_synthesized_voice_clamps_and_writes_left_mono();
+    rc |= test_write_synthesized_voice_r_clamps_and_writes_right_mono();
+    rc |= test_write_synthesized_voice_ms_duplicates_left_into_stereo_wav();
+    rc |= test_open_audio_in_device_rejects_null_arguments();
+    rc |= test_open_audio_in_device_bin_symbol_file_resets_replay_state();
+    rc |= test_open_audio_in_device_float_symbol_file_preserves_soft_metadata();
+    rc |= test_open_audio_in_device_symbol_directory_falls_back_to_pulse();
     return rc;
 }

--- a/tests/core/test_core_audio_gain.c
+++ b/tests/core/test_core_audio_gain.c
@@ -93,10 +93,218 @@ test_agsm_handles_silence_without_invalid_values(void) {
     return rc;
 }
 
+static int
+test_audio_apply_gain_f32_multiplies_block(void) {
+    float in[4] = {1.0f, -2.0f, 0.5f, 0.0f};
+    audio_apply_gain_f32(in, 4, 2.5f);
+
+    int rc = 0;
+    rc |= expect_float_close("gain f32 sample 0", in[0], 2.5f, 1e-6f);
+    rc |= expect_float_close("gain f32 sample 1", in[1], -5.0f, 1e-6f);
+    rc |= expect_float_close("gain f32 sample 2", in[2], 1.25f, 1e-6f);
+    rc |= expect_float_close("gain f32 sample 3", in[3], 0.0f, 1e-6f);
+
+    audio_apply_gain_f32(NULL, 4, 3.0f);
+    return rc;
+}
+
+static int
+test_audio_mono_to_stereo_duplicates_samples(void) {
+    const float in_f[3] = {1.0f, -2.5f, 0.25f};
+    float out_f[6] = {0.0f};
+    audio_mono_to_stereo_f32(in_f, out_f, 3);
+
+    const short in_s[3] = {-4, 0, 1234};
+    short out_s[6] = {0};
+    audio_mono_to_stereo_s16(in_s, out_s, 3);
+
+    int rc = 0;
+    for (int i = 0; i < 3; i++) {
+        const size_t out_idx = (size_t)i * 2U;
+        char label[64];
+        DSD_SNPRINTF(label, sizeof label, "mono f32 left %d", i);
+        rc |= expect_float_close(label, out_f[out_idx], in_f[i], 1e-6f);
+        DSD_SNPRINTF(label, sizeof label, "mono f32 right %d", i);
+        rc |= expect_float_close(label, out_f[out_idx + 1U], in_f[i], 1e-6f);
+        DSD_SNPRINTF(label, sizeof label, "mono s16 left %d", i);
+        rc |= expect_int_eq(label, out_s[out_idx], in_s[i]);
+        DSD_SNPRINTF(label, sizeof label, "mono s16 right %d", i);
+        rc |= expect_int_eq(label, out_s[out_idx + 1U], in_s[i]);
+    }
+
+    float guard_f[2] = {7.0f, 8.0f};
+    audio_mono_to_stereo_f32(NULL, guard_f, 1);
+    audio_mono_to_stereo_f32(in_f, NULL, 1);
+    rc |= expect_float_close("mono f32 null input guard", guard_f[0], 7.0f, 1e-6f);
+    rc |= expect_float_close("mono f32 null output guard", guard_f[1], 8.0f, 1e-6f);
+
+    short guard_s[2] = {7, 8};
+    audio_mono_to_stereo_s16(NULL, guard_s, 1);
+    audio_mono_to_stereo_s16(in_s, NULL, 1);
+    rc |= expect_int_eq("mono s16 null input guard", guard_s[0], 7);
+    rc |= expect_int_eq("mono s16 null output guard", guard_s[1], 8);
+    return rc;
+}
+
+static int
+test_audio_mix_helpers_apply_channel_gates(void) {
+    const float left_f[2] = {1.0f, 2.0f};
+    const float right_f[2] = {10.0f, 20.0f};
+    float stereo_f[4] = {-1.0f, -1.0f, -1.0f, -1.0f};
+    audio_mix_interleave_stereo_f32(left_f, right_f, 2, 0, 1, stereo_f);
+
+    const short left_s[2] = {1, 2};
+    const short right_s[2] = {10, 20};
+    short stereo_s[4] = {-1, -1, -1, -1};
+    audio_mix_interleave_stereo_s16(left_s, right_s, 2, 1, 0, stereo_s);
+
+    float mono[2] = {-1.0f, -1.0f};
+    audio_mix_mono_from_slots_f32(left_f, right_f, 2, 1, 1, mono);
+
+    int rc = 0;
+    rc |= expect_float_close("mix f32 left 0", stereo_f[0], 1.0f, 1e-6f);
+    rc |= expect_float_close("mix f32 muted right 0", stereo_f[1], 0.0f, 1e-6f);
+    rc |= expect_float_close("mix f32 left 1", stereo_f[2], 2.0f, 1e-6f);
+    rc |= expect_float_close("mix f32 muted right 1", stereo_f[3], 0.0f, 1e-6f);
+    rc |= expect_int_eq("mix s16 muted left 0", stereo_s[0], 0);
+    rc |= expect_int_eq("mix s16 right 0", stereo_s[1], 10);
+    rc |= expect_int_eq("mix s16 muted left 1", stereo_s[2], 0);
+    rc |= expect_int_eq("mix s16 right 1", stereo_s[3], 20);
+    rc |= expect_float_close("mono average 0", mono[0], 5.5f, 1e-6f);
+    rc |= expect_float_close("mono average 1", mono[1], 11.0f, 1e-6f);
+
+    audio_mix_mono_from_slots_f32(left_f, right_f, 2, 1, 0, mono);
+    rc |= expect_float_close("mono left only", mono[0], 1.0f, 1e-6f);
+    audio_mix_mono_from_slots_f32(left_f, right_f, 2, 0, 1, mono);
+    rc |= expect_float_close("mono right only", mono[0], 10.0f, 1e-6f);
+    audio_mix_mono_from_slots_f32(left_f, right_f, 2, 0, 0, mono);
+    rc |= expect_float_close("mono neither slot", mono[0], 0.0f, 1e-6f);
+
+    float guard_f[2] = {7.0f, 8.0f};
+    audio_mix_interleave_stereo_f32(NULL, right_f, 1, 0, 0, guard_f);
+    rc |= expect_float_close("mix f32 null guard left", guard_f[0], 7.0f, 1e-6f);
+    rc |= expect_float_close("mix f32 null guard right", guard_f[1], 8.0f, 1e-6f);
+    return rc;
+}
+
+static int
+test_upsample_repeats_into_selected_slot_buffer(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    float left[6] = {-1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f};
+    float right[6] = {-2.0f, -2.0f, -2.0f, -2.0f, -2.0f, -2.0f};
+    state.audio_out_float_buf_p = left;
+    state.audio_out_float_buf_pR = right;
+    upsample(&state, 1.25f);
+
+    int rc = 0;
+    for (int i = 0; i < 6; i++) {
+        char label[64];
+        DSD_SNPRINTF(label, sizeof label, "upsample left repeat %d", i);
+        rc |= expect_float_close(label, left[i], 1.25f, 1e-6f);
+        DSD_SNPRINTF(label, sizeof label, "upsample right unchanged %d", i);
+        rc |= expect_float_close(label, right[i], -2.0f, 1e-6f);
+    }
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    for (int i = 0; i < 6; i++) {
+        left[i] = -1.0f;
+        right[i] = -2.0f;
+    }
+    state.audio_out_float_buf_p = left;
+    state.audio_out_float_buf_pR = right;
+    state.dmr_stereo = 1;
+    state.currentslot = 1;
+    upsample(&state, -0.5f);
+
+    for (int i = 0; i < 6; i++) {
+        char label[64];
+        DSD_SNPRINTF(label, sizeof label, "upsample stereo left unchanged %d", i);
+        rc |= expect_float_close(label, left[i], -1.0f, 1e-6f);
+        DSD_SNPRINTF(label, sizeof label, "upsample stereo right repeat %d", i);
+        rc |= expect_float_close(label, right[i], -0.5f, 1e-6f);
+    }
+
+    upsample(NULL, 9.0f);
+    state.audio_out_float_buf_pR = NULL;
+    upsample(&state, 9.0f);
+    return rc;
+}
+
+static int
+test_manual_and_float_autogain_helpers(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    int rc = 0;
+
+    opts.audio_gainA = 40.0f;
+    short short_samples[3] = {100, -200, 0};
+    analog_gain(&opts, &state, short_samples, 3);
+    rc |= expect_int_eq("analog gain short positive", short_samples[0], 200);
+    rc |= expect_int_eq("analog gain short negative", short_samples[1], -400);
+    rc |= expect_int_eq("analog gain short zero", short_samples[2], 0);
+
+    opts.audio_gainA = 50.0f;
+    opts.audio_in_type = AUDIO_IN_RTL;
+    float rtl_samples[2] = {0.1f, -0.2f};
+    analog_gain_f(&opts, &state, rtl_samples, 2);
+    rc |= expect_float_close("analog gain rtl positive", rtl_samples[0], 1200.0f, 1e-3f);
+    rc |= expect_float_close("analog gain rtl negative", rtl_samples[1], -2400.0f, 1e-3f);
+
+    opts.audio_in_type = AUDIO_IN_WAV;
+    float wav_samples[2] = {100.0f, -200.0f};
+    analog_gain_f(&opts, &state, wav_samples, 2);
+    rc |= expect_float_close("analog gain wav positive", wav_samples[0], 250.0f, 1e-3f);
+    rc |= expect_float_close("analog gain wav negative", wav_samples[1], -500.0f, 1e-3f);
+
+    float auto_samples[2] = {1.0f, -0.5f};
+    agsm_f(&opts, &state, auto_samples, 2);
+    rc |= expect_float_close("agsm_f positive", auto_samples[0], 4800.0f, 1e-3f);
+    rc |= expect_float_close("agsm_f negative", auto_samples[1], -2400.0f, 1e-3f);
+    rc |= expect_float_close("agsm_f stores gain", state.aout_gainA, 4800.0f, 1e-3f);
+
+    float quiet_samples[2] = {0.0f, 0.0f};
+    agsm_f(&opts, &state, quiet_samples, 2);
+    rc |= expect_float_close("agsm_f keeps silence", quiet_samples[0], 0.0f, 1e-6f);
+    rc |= expect_float_close("agsm_f caps silent gain", state.aout_gainA, 6000.0f, 1e-3f);
+    return rc;
+}
+
+static int
+test_agf_scales_nonzero_float_block_and_updates_slot_gain(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    opts.audio_gain = 25.0f;
+    state.aout_gain = 49.0f;
+
+    float samp[160];
+    for (int i = 0; i < 160; i++) {
+        samp[i] = 384.0f;
+    }
+    agf(&opts, &state, samp, 0);
+
+    int rc = 0;
+    rc |= expect_float_close("agf first clipped sample", samp[0], 0.72f, 1e-5f);
+    rc |= expect_true("agf updates left gain", state.aout_gain < 49.0f);
+
+    float silent[160] = {0.0f};
+    float before_gain = state.aout_gain;
+    agf(&opts, &state, silent, 0);
+    rc |= expect_float_close("agf silence leaves gain", state.aout_gain, before_gain, 1e-6f);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
     rc |= test_agsm_applies_gain_to_entire_block();
     rc |= test_agsm_handles_silence_without_invalid_values();
+    rc |= test_audio_apply_gain_f32_multiplies_block();
+    rc |= test_audio_mono_to_stereo_duplicates_samples();
+    rc |= test_audio_mix_helpers_apply_channel_gates();
+    rc |= test_upsample_repeats_into_selected_slot_buffer();
+    rc |= test_manual_and_float_autogain_helpers();
+    rc |= test_agf_scales_nonzero_float_block_and_updates_slot_gain();
     return rc;
 }

--- a/tests/core/test_core_audio_input_rate.c
+++ b/tests/core/test_core_audio_input_rate.c
@@ -12,11 +12,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/dsp/resampler.h"
 #include "dsd-neo/platform/file_compat.h"
+#include "dsd-neo/platform/posix_compat.h"
 #include "test_support.h"
 
 static int
@@ -105,6 +107,44 @@ create_temp_raw_pcm_wav_suffix(const char* prefix, const short* samples, size_t 
 }
 
 static int
+create_temp_raw_pcm_no_suffix(const char* prefix, const short* samples, size_t sample_count, char* out_path,
+                              size_t out_path_sz) {
+    if (!prefix || !samples || sample_count == 0 || !out_path || out_path_sz == 0) {
+        DSD_FPRINTF(stderr, "FAIL: invalid raw temp file request\n");
+        return 1;
+    }
+
+    if (DSD_SNPRINTF(out_path, out_path_sz, "/tmp/%s_XXXXXX", prefix) >= (int)out_path_sz) {
+        DSD_FPRINTF(stderr, "FAIL: temp raw path too long for %s\n", prefix);
+        return 1;
+    }
+
+    int fd = dsd_mkstemp(out_path);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "FAIL: dsd_test_mkstemp failed for %s\n", prefix);
+        return 1;
+    }
+    (void)dsd_close(fd);
+
+    FILE* fp = dsd_fopen_private(out_path, "wb");
+    if (!fp) {
+        DSD_FPRINTF(stderr, "FAIL: fopen write failed for %s\n", out_path);
+        (void)remove(out_path);
+        return 1;
+    }
+
+    size_t nwritten = fwrite(samples, sizeof(samples[0]), sample_count, fp);
+    fclose(fp);
+    if (nwritten != sample_count) {
+        DSD_FPRINTF(stderr, "FAIL: fwrite failed for %s\n", out_path);
+        (void)remove(out_path);
+        return 1;
+    }
+
+    return 0;
+}
+
+static int
 create_temp_wav_family_file(const char* prefix, int sample_rate, int format, const short* samples, size_t sample_count,
                             const char* expected_magic, char* out_path, size_t out_path_sz) {
     if (!prefix || !samples || sample_count == 0 || !expected_magic || !out_path || out_path_sz == 0
@@ -168,6 +208,54 @@ create_temp_wav_family_file(const char* prefix, int sample_rate, int format, con
         return 1;
     }
 
+    return 0;
+}
+
+static int
+create_temp_stereo_wav_file(const char* prefix, const short* interleaved_samples, size_t sample_count, char* out_path,
+                            size_t out_path_sz) {
+    if (!prefix || !interleaved_samples || sample_count == 0 || !out_path || out_path_sz == 0) {
+        DSD_FPRINTF(stderr, "FAIL: invalid stereo wav temp file request\n");
+        return 1;
+    }
+
+    char base_path[DSD_TEST_PATH_MAX] = {0};
+    int fd = dsd_test_mkstemp(base_path, sizeof base_path, prefix);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "FAIL: dsd_test_mkstemp failed for %s\n", prefix);
+        return 1;
+    }
+    (void)dsd_close(fd);
+    (void)remove(base_path);
+
+    if (DSD_SNPRINTF(out_path, out_path_sz, "%s.wav", base_path) >= (int)out_path_sz) {
+        DSD_FPRINTF(stderr, "FAIL: temp stereo wav path too long for %s\n", prefix);
+        return 1;
+    }
+
+    SF_INFO info = {0};
+    info.samplerate = 48000;
+    info.channels = 2;
+    info.format = SF_FORMAT_WAV | SF_FORMAT_PCM_16;
+
+    SNDFILE* sf = sf_open(out_path, SFM_WRITE, &info);
+    if (sf == NULL) {
+        DSD_FPRINTF(stderr, "FAIL: sf_open stereo write failed for %s: %s\n", out_path, sf_strerror(NULL));
+        (void)remove(out_path);
+        return 1;
+    }
+
+    if (sf_write_short(sf, interleaved_samples, (sf_count_t)sample_count) != (sf_count_t)sample_count) {
+        DSD_FPRINTF(stderr, "FAIL: sf_write_short stereo failed for %s\n", out_path);
+        sf_close(sf);
+        (void)remove(out_path);
+        return 1;
+    }
+    if (sf_close(sf) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: sf_close stereo failed for %s\n", out_path);
+        (void)remove(out_path);
+        return 1;
+    }
     return 0;
 }
 
@@ -453,6 +541,65 @@ test_current_input_timing_rate_prefers_active_backend(void) {
 }
 
 static int
+test_open_audio_in_device_extensionless_raw_uses_headless_rate(void) {
+    const short samples[] = {101, -202, 303, -404};
+    char path[DSD_TEST_PATH_MAX] = {0};
+    if (create_temp_raw_pcm_no_suffix("dsdneo_headless_raw", samples, sizeof samples / sizeof samples[0], path,
+                                      sizeof path)
+        != 0) {
+        return 1;
+    }
+
+    dsd_opts* opts = alloc_opts();
+    if (!opts) {
+        DSD_FPRINTF(stderr, "FAIL: alloc opts\n");
+        (void)remove(path);
+        return 1;
+    }
+    dsd_state* state = alloc_state();
+    if (!state) {
+        DSD_FPRINTF(stderr, "FAIL: alloc state\n");
+        free_opts(opts);
+        (void)remove(path);
+        return 1;
+    }
+
+    opts->wav_sample_rate = 24000;
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", path);
+    state->use_throttle = 1;
+    state->symbol_replay_next_deadline_ns = 12345;
+
+    int rc = expect_int_eq("extensionless raw input opens", openAudioInDevice(opts, state), 0);
+    rc |= expect_int_eq("extensionless raw input type", opts->audio_in_type, AUDIO_IN_WAV);
+    rc |= expect_true("extensionless raw input file opened", opts->audio_in_file != NULL);
+    rc |= expect_true("extensionless raw input info allocated", opts->audio_in_file_info != NULL);
+    if (opts->audio_in_file_info) {
+        rc |= expect_int_eq("extensionless raw sample rate", opts->audio_in_file_info->samplerate, 24000);
+        rc |= expect_int_eq("extensionless raw channel count", opts->audio_in_file_info->channels, 1);
+        rc |= expect_int_eq("extensionless raw format", opts->audio_in_file_info->format,
+                            SF_FORMAT_RAW | SF_FORMAT_PCM_16 | SF_ENDIAN_LITTLE);
+    }
+    short sample = 0;
+    sf_count_t nread = opts->audio_in_file ? sf_read_short(opts->audio_in_file, &sample, 1) : 0;
+    rc |= expect_int_eq("extensionless raw reads first sample", (int)nread, 1);
+    rc |= expect_int_eq("extensionless raw preserves sample", sample, samples[0]);
+    rc |= expect_int_eq("extensionless raw clears throttle", state->use_throttle, 0);
+    rc |= expect_true("extensionless raw clears replay deadline", state->symbol_replay_next_deadline_ns == 0);
+
+    if (opts->audio_in_file) {
+        sf_close(opts->audio_in_file);
+        opts->audio_in_file = NULL;
+    }
+    free(opts->audio_in_file_info);
+    opts->audio_in_file_info = NULL;
+    free(state);
+    free_opts(opts);
+    (void)remove(path);
+    return rc;
+}
+
+static int
 test_headerless_wav_suffix_falls_back_to_raw_pcm(void) {
     const short samples[] = {1234, -2345, 3456, -4567};
     char path[DSD_TEST_PATH_MAX] = {0};
@@ -564,6 +711,92 @@ test_rf64_wav_suffix_uses_container_metadata(void) {
 }
 
 static int
+test_mono_file_input_rejects_invalid_arguments(void) {
+    SNDFILE* file = (SNDFILE*)0x1;
+    SF_INFO* info = (SF_INFO*)0x1;
+    int active_sample_rate = -1;
+    int opened_as_container = -1;
+
+    int rc = 0;
+    rc |= expect_int_eq(
+        "mono file input rejects null path",
+        dsd_audio_open_mono_file_input(NULL, 24000, &file, &info, &active_sample_rate, &opened_as_container), -1);
+    rc |= expect_int_eq("null path leaves file untouched", file == (SNDFILE*)0x1, 1);
+    rc |= expect_int_eq("null path leaves info untouched", info == (SF_INFO*)0x1, 1);
+    rc |= expect_int_eq(
+        "mono file input rejects empty path",
+        dsd_audio_open_mono_file_input("", 24000, &file, &info, &active_sample_rate, &opened_as_container), -1);
+    rc |= expect_int_eq("mono file input rejects null file output",
+                        dsd_audio_open_mono_file_input("/tmp/no-such-file.raw", 24000, NULL, &info, &active_sample_rate,
+                                                       &opened_as_container),
+                        -1);
+    rc |= expect_int_eq("mono file input rejects null info output",
+                        dsd_audio_open_mono_file_input("/tmp/no-such-file.raw", 24000, &file, NULL, &active_sample_rate,
+                                                       &opened_as_container),
+                        -1);
+    return rc;
+}
+
+static int
+test_headerless_raw_input_defaults_nonpositive_rate_to_48000(void) {
+    const short samples[] = {42, -42};
+    char path[DSD_TEST_PATH_MAX] = {0};
+    if (create_temp_raw_pcm_wav_suffix("dsdneo_raw_default_rate", samples, sizeof samples / sizeof samples[0], path,
+                                       sizeof path)
+        != 0) {
+        return 1;
+    }
+
+    SNDFILE* file = NULL;
+    SF_INFO* info = NULL;
+    int active_sample_rate = 0;
+    int opened_as_container = 1;
+    int rc = dsd_audio_open_mono_file_input(path, 0, &file, &info, &active_sample_rate, &opened_as_container);
+    if (rc != 0) {
+        DSD_FPRINTF(stderr, "FAIL: dsd_audio_open_mono_file_input default-rate failed for %s: %s\n", path,
+                    sf_strerror(NULL));
+        (void)remove(path);
+        return 1;
+    }
+
+    rc = 0;
+    rc |= expect_int_eq("default raw input active sample rate", active_sample_rate, 48000);
+    rc |= expect_int_eq("default raw input info sample rate", info->samplerate, 48000);
+    rc |= expect_int_eq("default raw input not container", opened_as_container, 0);
+
+    sf_close(file);
+    free(info);
+    (void)remove(path);
+    return rc;
+}
+
+static int
+test_stereo_wav_container_rejected_by_mono_input_open(void) {
+    const short samples[] = {100, -100, 200, -200};
+    char path[DSD_TEST_PATH_MAX] = {0};
+    if (create_temp_stereo_wav_file("dsdneo_stereo_reject", samples, sizeof samples / sizeof samples[0], path,
+                                    sizeof path)
+        != 0) {
+        return 1;
+    }
+
+    SNDFILE* file = (SNDFILE*)0x1;
+    SF_INFO* info = (SF_INFO*)0x1;
+    int active_sample_rate = 123;
+    int opened_as_container = 123;
+    int rc = dsd_audio_open_mono_file_input(path, 24000, &file, &info, &active_sample_rate, &opened_as_container);
+
+    int expect_rc = 0;
+    expect_rc |= expect_int_eq("stereo wav rejected", rc, -1);
+    expect_rc |= expect_true("stereo reject clears file output", file == NULL);
+    expect_rc |= expect_true("stereo reject frees info output", info == NULL);
+    expect_rc |= expect_int_eq("stereo reject keeps default sample rate", active_sample_rate, 24000);
+    expect_rc |= expect_int_eq("stereo reject keeps opened-as-container false", opened_as_container, 0);
+    (void)remove(path);
+    return expect_rc;
+}
+
+static int
 test_reset_input_upsample_state_clears_staging_only(void) {
     dsd_opts* opts = alloc_opts();
     if (!opts) {
@@ -669,9 +902,13 @@ main(void) {
     rc |= test_linear_upsample_block_ends_on_current_sample();
     rc |= test_source_effective_input_rate_classifier();
     rc |= test_current_input_timing_rate_prefers_active_backend();
+    rc |= test_open_audio_in_device_extensionless_raw_uses_headless_rate();
     rc |= test_headerless_wav_suffix_falls_back_to_raw_pcm();
     rc |= test_rifx_wav_suffix_uses_container_metadata();
     rc |= test_rf64_wav_suffix_uses_container_metadata();
+    rc |= test_mono_file_input_rejects_invalid_arguments();
+    rc |= test_headerless_raw_input_defaults_nonpositive_rate_to_48000();
+    rc |= test_stereo_wav_container_rejected_by_mono_input_open();
     rc |= test_reset_input_upsample_state_clears_staging_only();
     rc |= test_reset_pcm_input_state_clears_resampler_and_staging();
     return rc;

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -9,6 +9,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/core/time_format.h>
 #include <dsd-neo/platform/sndfile_fwd.h>
 #include <dsd-neo/protocol/edacs/edacs_afs.h>
@@ -16,8 +17,10 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -31,6 +34,8 @@ static int g_beeper_count;
 static int g_last_beeper_id;
 static int g_frame_log_count;
 static char g_last_frame_log[512];
+static int g_open_wav_count;
+static int g_close_wav_count;
 
 enum {
     TEST_DMR_DATA_BURST = 6,
@@ -43,6 +48,7 @@ open_wav_file(char* dir, char* temp_filename, size_t temp_filename_size, uint16_
     UNUSED(temp_filename_size);
     UNUSED(sample_rate);
     UNUSED(ext);
+    g_open_wav_count++;
     return NULL;
 }
 
@@ -54,6 +60,7 @@ close_and_rename_wav_file(SNDFILE* wav_file, const dsd_opts* opts, const char* w
     UNUSED(wav_out_filename);
     UNUSED(dir);
     UNUSED(event_struct);
+    g_close_wav_count++;
     return NULL;
 }
 
@@ -116,6 +123,8 @@ reset_fixture(dsd_opts* opts, dsd_state* state, Event_History_I event_history[2]
     g_last_beeper_id = 0;
     g_frame_log_count = 0;
     g_last_frame_log[0] = '\0';
+    g_open_wav_count = 0;
+    g_close_wav_count = 0;
 }
 
 static int
@@ -135,6 +144,24 @@ expect_has_substr(const char* label, const char* haystack, const char* needle) {
         return 1;
     }
     return 0;
+}
+
+static int
+expect_str_eq(const char* label, const char* got, const char* want) {
+    if (got == NULL || want == NULL || strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", label, got ? got : "<null>", want ? want : "<null>");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+append_policy_label(dsd_state* state, uint32_t id, const char* mode, const char* name) {
+    dsd_tg_policy_entry row;
+    if (dsd_tg_policy_make_exact_entry(id, mode, name, DSD_TG_POLICY_SOURCE_IMPORTED, &row) != 0) {
+        return -1;
+    }
+    return dsd_tg_policy_append_exact(state, &row);
 }
 
 static int
@@ -457,6 +484,303 @@ test_source_less_current_event_updates_history_metadata(void) {
     return rc;
 }
 
+static int
+test_event_log_writes_optional_metadata_lines(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    char path[] = "/tmp/dsd-neo-events-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "mkstemp failed for event log test\n");
+        return 1;
+    }
+    close(fd);
+    remove(path);
+    DSD_SNPRINTF(opts.event_out_file, sizeof opts.event_out_file, "%s", path);
+
+    DSD_SNPRINTF(state.event_history_s[1].Event_History_Items[0].text_message,
+                 sizeof state.event_history_s[1].Event_History_Items[0].text_message, "%s", "hello text");
+    DSD_SNPRINTF(state.event_history_s[1].Event_History_Items[0].alias,
+                 sizeof state.event_history_s[1].Event_History_Items[0].alias, "%s", "Unit 7");
+    DSD_SNPRINTF(state.event_history_s[1].Event_History_Items[0].gps_s,
+                 sizeof state.event_history_s[1].Event_History_Items[0].gps_s, "%s", "41.500000 -87.250000");
+    DSD_SNPRINTF(state.event_history_s[1].Event_History_Items[0].internal_str,
+                 sizeof state.event_history_s[1].Event_History_Items[0].internal_str, "%s", "status detail");
+
+    char event_string[] = "2026-04-30 00:00:00 TEST EVENT;";
+    write_event_to_log_file(&opts, &state, 1, 1, event_string);
+
+    FILE* f = fopen(path, "rb");
+    if (f == NULL) {
+        remove(path);
+        DSD_FPRINTF(stderr, "event log was not created\n");
+        return 1;
+    }
+    char buf[4096];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    fclose(f);
+    remove(path);
+    buf[n] = '\0';
+
+    int rc = 0;
+    rc |= expect_has_substr("event log main line", buf, "TEST EVENT; Slot 2;");
+    rc |= expect_has_substr("event log text", buf, "hello text");
+    rc |= expect_has_substr("event log alias", buf, "Talker Alias: Unit 7");
+    rc |= expect_has_substr("event log gps", buf, "GPS: 41.500000 -87.250000");
+    rc |= expect_has_substr("event log internal", buf, "DSD-neo: status detail");
+    return rc;
+}
+
+static int
+test_source_transition_rotates_slot_wav_files(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    opts.wav_out_f = (SNDFILE*)0x1;
+    opts.wav_out_fR = (SNDFILE*)0x2;
+    state.event_history_s[0].Event_History_Items[0].source_id = 1234U;
+    DSD_SNPRINTF(state.event_history_s[0].Event_History_Items[0].event_string,
+                 sizeof state.event_history_s[0].Event_History_Items[0].event_string, "%s", "slot one voice");
+    state.lastsrc = 5678U;
+    watchdog_event_history(&opts, &state, 0);
+
+    int rc = 0;
+    rc |= expect_int("slot 1 wav close", g_close_wav_count, 1);
+    rc |= expect_int("slot 1 wav reopen", g_open_wav_count, 1);
+    rc |= expect_has_substr("slot 1 transition stored", state.event_history_s[0].Event_History_Items[1].event_string,
+                            "slot one voice");
+
+    g_open_wav_count = 0;
+    g_close_wav_count = 0;
+    state.event_history_s[1].Event_History_Items[0].source_id = 2222U;
+    DSD_SNPRINTF(state.event_history_s[1].Event_History_Items[0].event_string,
+                 sizeof state.event_history_s[1].Event_History_Items[0].event_string, "%s", "slot two voice");
+    state.lastsrcR = 3333U;
+    watchdog_event_history(&opts, &state, 1);
+
+    rc |= expect_int("slot 2 wav close", g_close_wav_count, 1);
+    rc |= expect_int("slot 2 wav reopen", g_open_wav_count, 1);
+    rc |= expect_has_substr("slot 2 transition stored", state.event_history_s[1].Event_History_Items[1].event_string,
+                            "slot two voice");
+    return rc;
+}
+
+static int
+test_ysf_current_sanitizes_ids_and_text_message(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    state.lastsynctype = DSD_SYNC_YSF_POS;
+    DSD_MEMSET(state.ysf_src, ' ', sizeof state.ysf_src);
+    DSD_MEMSET(state.ysf_tgt, ' ', sizeof state.ysf_tgt);
+    DSD_MEMCPY(state.ysf_src,
+               "SRC\x01"
+               "CALL",
+               8);
+    DSD_MEMCPY(state.ysf_tgt, "TG*ROOM", 7);
+    for (int i = 4; i < 8; i++) {
+        for (int j = 0; j < 20; j++) {
+            state.ysf_txt[i][j] = (j % 2 == 0) ? '*' : (char)('A' + i);
+        }
+    }
+
+    watchdog_event_current(&opts, &state, 0);
+
+    const Event_History* item = &state.event_history_s[0].Event_History_Items[0];
+    int rc = 0;
+    rc |= expect_str_eq("ysf sysid", item->sysid_string, "YSF");
+    rc |= expect_has_substr("ysf sanitized source", item->src_str, "SRC_CALL");
+    rc |= expect_has_substr("ysf target", item->tgt_str, "TG*ROOM");
+    rc |= expect_has_substr("ysf event target", item->event_string, "TGT: TG*ROOM");
+    rc |= expect_has_substr("ysf text star becomes space", item->text_message, " E E");
+    return rc;
+}
+
+static int
+test_m17_dstar_dpmr_current_strings(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    state.lastsynctype = DSD_SYNC_M17_LSF_POS;
+    state.m17_dst = 0xFFFFFFFFFFFFULL;
+    state.m17_src = 12345ULL;
+    state.m17_can = 4U;
+    DSD_SNPRINTF(state.m17_src_csd, sizeof state.m17_src_csd, "%s", "SRC CSD");
+    DSD_SNPRINTF(state.m17_dst_csd, sizeof state.m17_dst_csd, "%s", "DST CSD");
+    DSD_SNPRINTF(state.m17_src_str, sizeof state.m17_src_str, "%s", "SRCSTR");
+    DSD_SNPRINTF(state.m17_dst_str, sizeof state.m17_dst_str, "%s", "DSTSTR");
+    watchdog_event_current(&opts, &state, 0);
+
+    int rc = 0;
+    const Event_History* item = &state.event_history_s[0].Event_History_Items[0];
+    rc |= expect_str_eq("m17 src csd", item->src_str, "SRC CSD");
+    rc |= expect_has_substr("m17 broadcast event", item->event_string, "TGT: BROADCAST SRC: SRCSTR CAN: 04;");
+
+    reset_fixture(&opts, &state, event_history);
+    state.lastsynctype = DSD_SYNC_DSTAR_VOICE_POS;
+    DSD_MEMSET(state.dstar_src, ' ', sizeof state.dstar_src);
+    DSD_MEMSET(state.dstar_dst, ' ', sizeof state.dstar_dst);
+    DSD_MEMCPY(state.dstar_src, "N0CALL\x02/RPT", 11);
+    DSD_MEMCPY(state.dstar_dst, "CQCQCQ", 6);
+    watchdog_event_current(&opts, &state, 0);
+    item = &state.event_history_s[0].Event_History_Items[0];
+    rc |= expect_str_eq("dstar sysid", item->sysid_string, "DSTAR");
+    rc |= expect_has_substr("dstar sanitized source", item->src_str, "N0CALL_/RPT");
+    rc |= expect_has_substr("dstar event", item->event_string, "TGT: CQCQCQ");
+
+    reset_fixture(&opts, &state, event_history);
+    state.lastsynctype = DSD_SYNC_DPMR_FS2_POS;
+    state.dpmr_color_code = 9U;
+    DSD_SNPRINTF(state.dpmr_caller_id, sizeof state.dpmr_caller_id, "%s", "CALLER7");
+    DSD_SNPRINTF(state.dpmr_target_id, sizeof state.dpmr_target_id, "%s", "TARGET9");
+    state.dPMRVoiceFS2Frame.Version[0] = 3U;
+    watchdog_event_current(&opts, &state, 0);
+    item = &state.event_history_s[0].Event_History_Items[0];
+    rc |= expect_str_eq("dpmr sysid", item->sysid_string, "DPMR_CC_9");
+    rc |= expect_has_substr("dpmr event ids", item->event_string, "CC: 09; TGT: TARGET9; SRC: CALLER7;");
+    rc |= expect_has_substr("dpmr scrambler", item->event_string, "Scrambler Enc;");
+    return rc;
+}
+
+static int
+test_nxdn_current_includes_channel_encryption_and_policy_labels(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    state.lastsynctype = DSD_SYNC_NXDN_POS;
+    state.gi[0] = 1;
+    state.nxdn_last_rid = 41001U;
+    state.nxdn_last_tg = 51002U;
+    state.nxdn_last_ran = 23U;
+    state.nxdn_location_site_code = 5U;
+    state.nxdn_location_sys_code = 12U;
+    state.nxdn_cipher_type = 3U;
+    state.nxdn_key = 0x2AU;
+    state.nxdn_grant_chan = 198U;
+    state.nxdn_grant_freq = 453212500U;
+    if (append_policy_label(&state, 51002U, "D", "Dispatch") != 0
+        || append_policy_label(&state, 41001U, "A", "Unit 41001") != 0) {
+        DSD_FPRINTF(stderr, "failed to append NXDN policy labels\n");
+        return 1;
+    }
+
+    watchdog_event_current(&opts, &state, 0);
+
+    const Event_History* item = &state.event_history_s[0].Event_History_Items[0];
+    int rc = 0;
+    rc |= expect_str_eq("nxdn sysid", item->sysid_string, "NXDN_12_5_RAN_23");
+    rc |= expect_has_substr("nxdn channel freq", item->event_string, "CH: 198; FREQ: 453.212500 MHz;");
+    rc |= expect_has_substr("nxdn encryption", item->event_string, "ENC; ALG: 3; KID: 2A;");
+    rc |= expect_has_substr("nxdn private", item->event_string, "Private;");
+    rc |= expect_has_substr("nxdn target label", item->event_string, "TName: Dispatch; Mode: D;");
+    rc |= expect_has_substr("nxdn source label", item->event_string, "SName: Unit 41001; Mode: A;");
+    return rc;
+}
+
+static int
+test_edacs_ea_mode_current_event_and_unknown_lid(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    opts.p25_is_tuned = 1;
+    state.lastsynctype = DSD_SYNC_EDACS_POS;
+    state.lastsrc = 0x800U;
+    state.lasttg = 0x0123U;
+    state.edacs_tuned_lcn = 11U;
+    state.edacs_site_id = 12U;
+    state.edacs_area_code = 3U;
+    state.edacs_sys_id = 0x45U;
+    state.edacs_vc_call_type = 0x01U;
+    state.edacs_a_shift = 7;
+    state.edacs_f_shift = 3;
+    state.edacs_a_mask = 0x0F;
+    state.edacs_f_mask = 0x0F;
+    state.edacs_s_mask = 0x07;
+
+    watchdog_event_current(&opts, &state, 0);
+    int rc = 0;
+    rc |= expect_has_substr("edacs unknown lid", state.event_history_s[0].Event_History_Items[0].event_string,
+                            "LID: __UNK;");
+
+    reset_fixture(&opts, &state, event_history);
+    opts.p25_is_tuned = 1;
+    state.lastsynctype = DSD_SYNC_EDACS_POS;
+    state.ea_mode = 1;
+    state.lastsrc = 77001U;
+    state.lasttg = 88002U;
+    state.edacs_tuned_lcn = 12U;
+    state.edacs_site_id = 7U;
+    state.edacs_area_code = 2U;
+    state.edacs_sys_id = 0x1234U;
+    state.edacs_vc_call_type = 0x48U;
+
+    watchdog_event_current(&opts, &state, 0);
+    const Event_History* item = &state.event_history_s[0].Event_History_Items[0];
+    rc |= expect_has_substr("edacs ea target", item->event_string, "TGT: 0088002; SRC: 0077001;");
+    rc |= expect_has_substr("edacs ea site", item->event_string, "SITE: 7:2.1234;");
+    rc |= expect_has_substr("edacs ea flags", item->event_string, "Analog Group INTER Call;");
+    return rc;
+}
+
+static int
+test_p25_and_dmr_current_append_security_flags(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.lastsrc = 123456U;
+    state.lasttg = 50061U;
+    state.gi[0] = 1;
+    state.dmr_color_code = 7U;
+    state.dmr_fid = 0x10U;
+    state.dmr_so = 0x80U | 0x40U | 0x30U | 0x08U | 0x04U | 0x03U;
+    state.payload_algid = 0x21U;
+    state.payload_keyid = 0x34U;
+    watchdog_event_current(&opts, &state, 0);
+
+    int rc = 0;
+    const Event_History* item = &state.event_history_s[0].Event_History_Items[0];
+    rc |= expect_has_substr("dmr enc flag", item->event_string, "ENC;");
+    rc |= expect_has_substr("dmr alg key", item->event_string, "ALG: 21; KID: 34;");
+    rc |= expect_has_substr("dmr emergency", item->event_string, "Emergency;");
+    rc |= expect_has_substr("dmr broadcast", item->event_string, "Broadcast;");
+    rc |= expect_has_substr("dmr ovcm", item->event_string, "OVCM;");
+    rc |= expect_has_substr("dmr private", item->event_string, "Private;");
+    rc |= expect_has_substr("dmr txi", item->event_string, "TXI;");
+    rc |= expect_has_substr("dmr priority", item->event_string, "PRIORITY;");
+
+    reset_fixture(&opts, &state, event_history);
+    state.lastsynctype = DSD_SYNC_P25P2_POS;
+    state.lastsrc = 5790062U;
+    state.lasttg = 50061U;
+    state.gi[0] = 1;
+    state.nac = 0x293;
+    state.payload_algid = 0x84U;
+    state.payload_keyid = 0x2222U;
+    state.dmr_so = 0x80U;
+    watchdog_event_current(&opts, &state, 0);
+    item = &state.event_history_s[0].Event_History_Items[0];
+    rc |= expect_has_substr("p25 enc flag", item->event_string, "ENC; ALG: 84; KID: 2222;");
+    rc |= expect_has_substr("p25 emergency", item->event_string, "Emergency;");
+    rc |= expect_has_substr("p25 private", item->event_string, "Private;");
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -474,6 +798,13 @@ main(void) {
     rc |= test_dmr_event_string_keeps_full_prefix_after_sprintf_hardening();
     rc |= test_p25_event_string_keeps_full_prefix_after_sprintf_hardening();
     rc |= test_source_less_current_event_updates_history_metadata();
+    rc |= test_event_log_writes_optional_metadata_lines();
+    rc |= test_source_transition_rotates_slot_wav_files();
+    rc |= test_ysf_current_sanitizes_ids_and_text_message();
+    rc |= test_m17_dstar_dpmr_current_strings();
+    rc |= test_nxdn_current_includes_channel_encryption_and_policy_labels();
+    rc |= test_edacs_ea_mode_current_event_and_unknown_lid();
+    rc |= test_p25_and_dmr_current_append_security_flags();
 
     if (rc == 0) {
         printf("CORE_CALL_ALERT_HISTORY: OK\n");

--- a/tests/core/test_core_csv_import.c
+++ b/tests/core/test_core_csv_import.c
@@ -553,6 +553,69 @@ write_text_file(const char* path, const char* text) {
 }
 
 static int
+test_channel_import_rejects_malformed_rows_without_reusing_previous_channel(void) {
+    int failed = 0;
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    char tmpl[] = "dsd-neo-test-channel-malformed-XXXXXX";
+    int fd = -1;
+
+    if (!opts || !state) {
+        free(opts);
+        free_test_state(state);
+        return 1;
+    }
+
+    fd = dsd_mkstemp(tmpl);
+    if (fd < 0) {
+        free(opts);
+        free_test_state(state);
+        return 1;
+    }
+    (void)dsd_close(fd);
+
+    if (write_text_file(tmpl, "channel,freq\n"
+                              "12,851000000\n"
+                              "bad,852000000\n"
+                              "13,badfreq\n"
+                              "14,853000000\n"
+                              "65535,854000000\n")
+        != 0) {
+        (void)remove(tmpl);
+        free(opts);
+        free_test_state(state);
+        return 1;
+    }
+
+    DSD_SNPRINTF(opts->chan_in_file, sizeof(opts->chan_in_file), "%s", tmpl);
+    if (csvChanImport(opts, state) != 0) {
+        failed = 1;
+    }
+    if (state->trunk_chan_map[12] != 851000000L) {
+        failed = 1;
+    }
+    if (state->trunk_chan_map[13] != 0L) {
+        failed = 1;
+    }
+    if (state->trunk_chan_map[14] != 853000000L) {
+        failed = 1;
+    }
+    if (state->trunk_chan_map_used_count != 2U || state->trunk_chan_map_used[0] != 12U
+        || state->trunk_chan_map_used[1] != 14U) {
+        failed = 1;
+    }
+    if (state->lcn_freq_count != 3 || state->trunk_lcn_freq[0] != 851000000L || state->trunk_lcn_freq[1] != 0L
+        || state->trunk_lcn_freq[2] != 853000000L) {
+        failed = 1;
+    }
+
+    (void)remove(tmpl);
+    free(opts);
+    free_test_state(state);
+    return failed;
+}
+
+static int
 test_group_import_policy_and_basic_headers(void) {
     int failed = 0;
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
@@ -970,6 +1033,9 @@ main(void) {
         return 1;
     }
     if (test_group_import_invalid_ids_and_required_fields() != 0) {
+        return 1;
+    }
+    if (test_channel_import_rejects_malformed_rows_without_reusing_previous_channel() != 0) {
         return 1;
     }
     if (test_group_import_range_after_many_exact_rows() != 0) {

--- a/tests/core/test_core_dsd_time.c
+++ b/tests/core/test_core_dsd_time.c
@@ -3,10 +3,17 @@
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+#include <dsd-neo/core/cleanup.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/time_format.h>
+#include <dsd-neo/runtime/exitflag.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
+#include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/platform/timing.h"
 
@@ -20,8 +27,150 @@ expect_vc_zero(const dsd_state* state) {
     return state && state->last_vc_sync_time == 0 && state->last_vc_sync_time_m == 0.0;
 }
 
+static int
+expect_str(const char* label, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", label, got, want);
+        return 0;
+    }
+    return 1;
+}
+
+static int
+is_digit_char(char ch) {
+    return ch >= '0' && ch <= '9';
+}
+
+static int
+expect_time_shape(const char* label, const char* value, int with_colons) {
+    size_t len = strlen(value);
+    if (len != (with_colons ? 8u : 6u)) {
+        DSD_FPRINTF(stderr, "%s: unexpected length %zu in '%s'\n", label, len, value);
+        return 0;
+    }
+    for (size_t i = 0; i < len; i++) {
+        if (with_colons && (i == 2 || i == 5)) {
+            if (value[i] != ':') {
+                DSD_FPRINTF(stderr, "%s: missing colon at %zu in '%s'\n", label, i, value);
+                return 0;
+            }
+        } else if (!is_digit_char(value[i])) {
+            DSD_FPRINTF(stderr, "%s: non-digit at %zu in '%s'\n", label, i, value);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int
+expect_date_shape(const char* label, const char* value, char separator) {
+    size_t len = strlen(value);
+    size_t want_len = separator ? 10u : 8u;
+    if (len != want_len) {
+        DSD_FPRINTF(stderr, "%s: unexpected length %zu in '%s'\n", label, len, value);
+        return 0;
+    }
+    for (size_t i = 0; i < len; i++) {
+        if (separator && (i == 4 || i == 7)) {
+            if (value[i] != separator) {
+                DSD_FPRINTF(stderr, "%s: missing separator at %zu in '%s'\n", label, i, value);
+                return 0;
+            }
+        } else if (!is_digit_char(value[i])) {
+            DSD_FPRINTF(stderr, "%s: non-digit at %zu in '%s'\n", label, i, value);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int
+test_time_format_wrappers(void) {
+    int rc = 0;
+    const time_t fixed = (time_t)1700000000;
+    struct tm local_tm;
+    if (dsd_localtime(&fixed, &local_tm) != 0) {
+        return 10;
+    }
+
+    char expected_time[9];
+    char expected_time_compact[7];
+    char expected_date_hyphen[11];
+    char expected_date_compact[9];
+    DSD_SNPRINTF(expected_time, sizeof expected_time, "%02d:%02d:%02d", local_tm.tm_hour, local_tm.tm_min,
+                 local_tm.tm_sec);
+    DSD_SNPRINTF(expected_time_compact, sizeof expected_time_compact, "%02d%02d%02d", local_tm.tm_hour, local_tm.tm_min,
+                 local_tm.tm_sec);
+    DSD_SNPRINTF(expected_date_hyphen, sizeof expected_date_hyphen, "%04u-%02u-%02u",
+                 (unsigned)(local_tm.tm_year + 1900), (unsigned)(local_tm.tm_mon + 1), (unsigned)local_tm.tm_mday);
+    DSD_SNPRINTF(expected_date_compact, sizeof expected_date_compact, "%04u%02u%02u",
+                 (unsigned)(local_tm.tm_year + 1900), (unsigned)(local_tm.tm_mon + 1), (unsigned)local_tm.tm_mday);
+
+    char time_colon[9];
+    char time_compact[7];
+    char date_hyphen[11];
+    char date_compact[9];
+    getTimeN_buf(fixed, time_colon);
+    getTimeF_buf(fixed, time_compact);
+    getDateN_buf(fixed, date_hyphen);
+    getDateF_buf(fixed, date_compact);
+
+    if (!expect_str("fixed getTimeN_buf", time_colon, expected_time)) {
+        rc = 11;
+    }
+    if (!expect_str("fixed getTimeF_buf", time_compact, expected_time_compact)) {
+        rc = 12;
+    }
+    if (!expect_str("fixed getDateN_buf", date_hyphen, expected_date_hyphen)) {
+        rc = 13;
+    }
+    if (!expect_str("fixed getDateF_buf", date_compact, expected_date_compact)) {
+        rc = 14;
+    }
+
+    char now_time[7];
+    char now_time_colon[9];
+    char now_date[9];
+    char now_date_hyphen[11];
+    char now_date_slash[11];
+    getTime_buf(now_time);
+    getTimeC_buf(now_time_colon);
+    getDate_buf(now_date);
+    getDateH_buf(now_date_hyphen);
+    getDateS_buf(now_date_slash);
+
+    if (!expect_time_shape("current getTime_buf", now_time, 0)) {
+        rc = 15;
+    }
+    if (!expect_time_shape("current getTimeC_buf", now_time_colon, 1)) {
+        rc = 16;
+    }
+    if (!expect_date_shape("current getDate_buf", now_date, '\0')) {
+        rc = 17;
+    }
+    if (!expect_date_shape("current getDateH_buf", now_date_hyphen, '-')) {
+        rc = 18;
+    }
+    if (!expect_date_shape("current getDateS_buf", now_date_slash, '/')) {
+        rc = 19;
+    }
+
+    return rc;
+}
+
 int
 main(void) {
+    int rc = test_time_format_wrappers();
+    if (rc != 0) {
+        return rc;
+    }
+
+    exitflag = 0;
+    cleanupAndExit(NULL, NULL);
+    if (exitflag != 1) {
+        return 20;
+    }
+
     // dsd_state is a multi-megabyte struct; avoid Windows' default ~1MB stack.
     dsd_state* state = calloc(1, sizeof(*state));
     if (!state) {

--- a/tests/core/test_core_frame_log.c
+++ b/tests/core/test_core_frame_log.c
@@ -4,9 +4,11 @@
  */
 
 #include <dsd-neo/core/file_io.h>
+#include <dsd-neo/core/frame.h>
 #include <dsd-neo/core/init.h>
 #include <dsd-neo/core/opts.h>
 #include <errno.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #if !defined(_WIN32)
@@ -14,6 +16,8 @@
 #endif
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state.h"
+#include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/platform/file_compat.h"
 #include "test_support.h"
 
@@ -36,6 +40,37 @@ count_occurrences(const char* haystack, const char* needle) {
     return count;
 }
 
+static void
+fill_bits_from_bytes(char* bits, const uint8_t* bytes, size_t byte_count) {
+    size_t out = 0;
+    for (size_t i = 0; i < byte_count; i++) {
+        for (int bit = 7; bit >= 0; bit--) {
+            bits[out++] = (char)((bytes[i] >> bit) & 1U);
+        }
+    }
+}
+
+static int
+read_text_file(const char* path, char* buf, size_t buf_size) {
+    if (!path || !buf || buf_size == 0) {
+        return 1;
+    }
+    FILE* fp = fopen(path, "rb");
+    if (!fp) {
+        DSD_FPRINTF(stderr, "fopen(%s) failed: %s\n", path, strerror(errno));
+        return 1;
+    }
+    size_t n = fread(buf, 1, buf_size - 1, fp);
+    if (n == 0 && ferror(fp)) {
+        DSD_FPRINTF(stderr, "fread(%s) failed: %s\n", path, strerror(errno));
+        fclose(fp);
+        return 1;
+    }
+    buf[n] = '\0';
+    fclose(fp);
+    return 0;
+}
+
 static int
 test_frame_log_writes_entry(void) {
     static dsd_opts opts;
@@ -56,23 +91,11 @@ test_frame_log_writes_entry(void) {
     dsd_frame_logf(&opts, "frame=%d", 42);
     dsd_frame_log_close(&opts);
 
-    FILE* fp = fopen(path, "rb");
-    if (!fp) {
-        DSD_FPRINTF(stderr, "fopen(%s) failed: %s\n", path, strerror(errno));
-        (void)remove(path);
-        return 1;
-    }
-
     char buf[512];
-    size_t n = fread(buf, 1, sizeof buf - 1, fp);
-    if (n == 0 && ferror(fp)) {
-        DSD_FPRINTF(stderr, "fread(%s) failed: %s\n", path, strerror(errno));
-        fclose(fp);
+    if (read_text_file(path, buf, sizeof buf) != 0) {
         (void)remove(path);
         return 1;
     }
-    buf[n] = '\0';
-    fclose(fp);
     (void)remove(path);
 
     if (strstr(buf, "frame=42") == NULL) {
@@ -102,27 +125,69 @@ test_p25_sm_log_writes_entry(void) {
     dsd_p25_sm_logf(&opts, "event=test\tvalue=%d\n", 42);
     dsd_p25_sm_log_close(&opts);
 
-    FILE* fp = fopen(path, "rb");
-    if (!fp) {
-        DSD_FPRINTF(stderr, "fopen(%s) failed: %s\n", path, strerror(errno));
-        (void)remove(path);
-        return 1;
-    }
-
     char buf[512];
-    size_t n = fread(buf, 1, sizeof buf - 1, fp);
-    if (n == 0 && ferror(fp)) {
-        DSD_FPRINTF(stderr, "fread(%s) failed: %s\n", path, strerror(errno));
-        fclose(fp);
+    if (read_text_file(path, buf, sizeof buf) != 0) {
         (void)remove(path);
         return 1;
     }
-    buf[n] = '\0';
-    fclose(fp);
     (void)remove(path);
 
     if (strstr(buf, "event=test value=42") == NULL) {
         DSD_FPRINTF(stderr, "P25 SM log did not contain expected sanitized payload: %s\n", buf);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_payload_detail_helpers_write_structured_frame_log(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    initOpts(&opts);
+
+    char path[DSD_TEST_PATH_MAX];
+    int fd = dsd_test_mkstemp(path, sizeof path, "dsdneo_payload_frame_log");
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "dsd_test_mkstemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+    (void)dsd_close(fd);
+
+    DSD_SNPRINTF(opts.frame_log_file, sizeof opts.frame_log_file, "%s", path);
+    opts.frame_log_file[sizeof opts.frame_log_file - 1] = '\0';
+
+    const uint8_t imbe_bytes[11] = {0x12U, 0x34U, 0x56U, 0x78U, 0x9AU, 0xBCU, 0xDEU, 0xF0U, 0x01U, 0x23U, 0x45U};
+    char imbe_bits[88];
+    fill_bits_from_bytes(imbe_bits, imbe_bytes, sizeof imbe_bytes);
+    state.currentslot = 0;
+    state.errs = 0x0A;
+    state.errs2 = 0x0B;
+    PrintIMBEData(&opts, &state, imbe_bits);
+
+    char ambe_bits[49];
+    DSD_MEMSET(ambe_bits, 1, sizeof ambe_bits);
+    state.currentslot = 1;
+    state.errsR = 0x0C;
+    state.errs2R = 0x0D;
+    PrintAMBEData(&opts, &state, ambe_bits);
+
+    dsd_frame_log_close(&opts);
+
+    char buf[1024];
+    int rc = read_text_file(path, buf, sizeof buf);
+    (void)remove(path);
+    if (rc != 0) {
+        return 1;
+    }
+
+    if (strstr(buf, "FRAME IMBE slot=1 data=123456789ABCDEF0012345 err=[A] [B]") == NULL) {
+        DSD_FPRINTF(stderr, "IMBE frame-log payload mismatch: %s\n", buf);
+        return 1;
+    }
+    if (strstr(buf, "FRAME AMBE slot=2 data=FFFFFFFFFFFF80 err=[C] [D]") == NULL) {
+        DSD_FPRINTF(stderr, "AMBE frame-log payload mismatch: %s\n", buf);
         return 1;
     }
     return 0;
@@ -341,6 +406,125 @@ out:
     print_failure(failure, saved_errno);
     return rc;
 }
+
+static int
+test_p25_sm_log_open_error_reported_once(void) {
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    initOpts(&opts);
+
+    char dir_path[DSD_TEST_PATH_MAX];
+    if (!dsd_test_mkdtemp(dir_path, sizeof dir_path, "dsdneo_p25_sm_log_dir")) {
+        DSD_FPRINTF(stderr, "dsd_test_mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    DSD_SNPRINTF(opts.p25_sm_log_file, sizeof opts.p25_sm_log_file, "%s", dir_path);
+    opts.p25_sm_log_file[sizeof opts.p25_sm_log_file - 1] = '\0';
+
+    int rc = 0;
+    int saved_errno = 0;
+    const char* failure = NULL;
+    stderr_capture_t capture;
+    stderr_capture_init(&capture);
+    if (stderr_capture_begin(&capture, &failure, &saved_errno) != 0) {
+        rc = 1;
+        goto out;
+    }
+
+    dsd_p25_sm_logf(&opts, "event=%d", 1);
+    dsd_p25_sm_logf(&opts, "event=%d", 2);
+
+    char buf[4096];
+    if (stderr_capture_read(&capture, buf, sizeof buf, &failure, &saved_errno) != 0) {
+        rc = 1;
+        goto out;
+    }
+
+    if (count_occurrences(buf, "Unable to open P25 SM log file") != 1) {
+        failure = "P25 SM open failure should be reported once";
+        rc = 1;
+        goto out;
+    }
+
+    if (opts.p25_sm_log_open_error_reported != 1) {
+        failure = "P25 SM open error guard should remain set after repeated open failures";
+        rc = 1;
+        goto out;
+    }
+
+    if (opts.p25_sm_log_write_error_reported != 0) {
+        failure = "P25 SM write error guard should not be set by open failure";
+        rc = 1;
+        goto out;
+    }
+
+    if (opts.p25_sm_log_f != NULL) {
+        failure = "P25 SM failed open should not leave an active file handle";
+        rc = 1;
+        goto out;
+    }
+
+out:
+    stderr_capture_end(&capture);
+    (void)rmdir(dir_path);
+    print_failure(failure, saved_errno);
+    return rc;
+}
+
+static int
+test_print_frame_info_formats_p25_identifiers(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    initOpts(&opts);
+
+    int rc = 0;
+    int saved_errno = 0;
+    const char* failure = NULL;
+    stderr_capture_t capture;
+    stderr_capture_init(&capture);
+    if (stderr_capture_begin(&capture, &failure, &saved_errno) != 0) {
+        rc = 1;
+        goto out;
+    }
+
+    state.p2_wacn = 0x12345ULL;
+    state.p2_sysid = 0xABCU;
+    state.p2_cc = 0x2F0U;
+    state.p2_rfssid = 7;
+    state.p2_siteid = 9;
+    printFrameInfo(&opts, &state);
+
+    DSD_MEMSET(&state, 0, sizeof state);
+    state.nac = 0x2A3;
+    printFrameInfo(&opts, &state);
+
+    char buf[4096];
+    if (stderr_capture_read(&capture, buf, sizeof buf, &failure, &saved_errno) != 0) {
+        rc = 1;
+        goto out;
+    }
+
+    if (strstr(buf, "WACN: 12345; ") == NULL || strstr(buf, "SYS: ABC; ") == NULL
+        || strstr(buf, "NAC/CC: 2F0; ") == NULL || strstr(buf, "RFSS: 007; ") == NULL
+        || strstr(buf, "Site: 009; ") == NULL) {
+        failure = "P25 phase-2 frame identifiers were not formatted as expected";
+        rc = 1;
+        goto out;
+    }
+    if (strstr(buf, "NAC: 2A3; ") == NULL || count_occurrences(buf, "NAC/CC:") != 1) {
+        failure = "P25 frame info should fall back to NAC when p2_cc is not set";
+        rc = 1;
+        goto out;
+    }
+
+out:
+    stderr_capture_end(&capture);
+    print_failure(failure, saved_errno);
+    return rc;
+}
 #endif
 
 int
@@ -351,11 +535,20 @@ main(void) {
     if (test_p25_sm_log_writes_entry() != 0) {
         return 1;
     }
+    if (test_payload_detail_helpers_write_structured_frame_log() != 0) {
+        return 1;
+    }
 #if !defined(_WIN32)
     if (test_frame_log_write_error_reported_once() != 0) {
         return 1;
     }
     if (test_p25_sm_log_write_error_reported_once() != 0) {
+        return 1;
+    }
+    if (test_p25_sm_log_open_error_reported_once() != 0) {
+        return 1;
+    }
+    if (test_print_frame_info_formats_p25_identifiers() != 0) {
         return 1;
     }
 #endif

--- a/tests/core/test_core_input_level.c
+++ b/tests/core/test_core_input_level.c
@@ -31,6 +31,8 @@ snapshot_for(dsd_input_level_source source, double rms_dbfs, double peak_dbfs, d
 
 static void
 test_classifier_thresholds(void) {
+    assert(strcmp(dsd_input_level_status_label(DSD_INPUT_LEVEL_OK), "OK") == 0);
+
     dsd_input_level_snapshot low = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -50.0, -20.0, 0.0, 1);
     dsd_input_level_classify(&low, -40.0);
     assert(low.status == DSD_INPUT_LEVEL_LOW);
@@ -46,6 +48,19 @@ test_classifier_thresholds(void) {
     dsd_input_level_snapshot ok = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -25.0, -3.0, 0.0, 1);
     dsd_input_level_classify(&ok, -40.0);
     assert(ok.status == DSD_INPUT_LEVEL_OK);
+
+    dsd_input_level_classify(NULL, -40.0);
+
+    dsd_input_level_snapshot empty = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -20.0, -3.0, 0.0, 1);
+    empty.status = DSD_INPUT_LEVEL_HOT;
+    empty.sample_count = 0U;
+    dsd_input_level_classify(&empty, -40.0);
+    assert(empty.status == DSD_INPUT_LEVEL_UNKNOWN);
+
+    dsd_input_level_snapshot unknown_source = snapshot_for(DSD_INPUT_LEVEL_SOURCE_UNKNOWN, -20.0, -3.0, 0.0, 1);
+    unknown_source.status = DSD_INPUT_LEVEL_HOT;
+    dsd_input_level_classify(&unknown_source, -40.0);
+    assert(unknown_source.status == DSD_INPUT_LEVEL_UNKNOWN);
 }
 
 static void
@@ -362,6 +377,10 @@ test_non_tcp_silence_low_still_notifies(void) {
 static void
 test_advisory_text_selection(void) {
     char msg[128];
+    assert(dsd_input_level_format_advisory(NULL, msg, sizeof(msg)) == -1);
+    assert(dsd_input_level_format_advisory(&(dsd_input_level_snapshot){0}, NULL, sizeof(msg)) == -1);
+    assert(dsd_input_level_format_advisory(&(dsd_input_level_snapshot){0}, msg, 0U) == -1);
+
     dsd_input_level_snapshot pcm_low = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -55.0, -30.0, 0.0, 1);
     dsd_input_level_classify(&pcm_low, -40.0);
     assert(dsd_input_level_format_advisory(&pcm_low, msg, sizeof(msg)) == 0);
@@ -381,6 +400,35 @@ test_advisory_text_selection(void) {
     assert(strstr(msg, "lower RF gain") == NULL);
 }
 
+static void
+test_publish_without_state_and_default_cooldown_paths(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts != NULL);
+    assert(state != NULL);
+
+    opts->rtl_pwr = 0.25;
+    dsd_input_level_publish(opts, NULL, NULL, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(opts->rtl_pwr == 0.25);
+
+    dsd_input_level_snapshot saturated = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, 0.0, -3.0, 0.0, 350);
+    dsd_input_level_publish(opts, NULL, &saturated, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(opts->rtl_pwr == 1.0);
+
+    dsd_input_level_snapshot clipped = snapshot_for(DSD_INPUT_LEVEL_SOURCE_PCM, -10.0, -0.1, 0.2, 360);
+    opts->input_warn_cooldown_sec = 0;
+    state->input_level_last_toast_time = 355;
+    state->input_level_last_toast_status = DSD_INPUT_LEVEL_UNKNOWN;
+    state->input_level_last_toast_source = DSD_INPUT_LEVEL_SOURCE_UNKNOWN;
+    dsd_input_level_publish(opts, state, &clipped, DSD_INPUT_LEVEL_NOTIFY_ALL);
+    assert(strstr(state->ui_msg, "Input Level CLIP") != NULL);
+    assert(state->input_level_last_toast_time == 360);
+    assert(opts->last_input_warn_time == 360);
+
+    free(state);
+    free(opts);
+}
+
 int
 main(void) {
     test_classifier_thresholds();
@@ -396,5 +444,6 @@ main(void) {
     test_tcp_pcm_m17_encoder_levels_still_notify();
     test_non_tcp_silence_low_still_notifies();
     test_advisory_text_selection();
+    test_publish_without_state_and_default_cooldown_paths();
     return 0;
 }

--- a/tests/core/test_core_mbe_file_io.c
+++ b/tests/core/test_core_mbe_file_io.c
@@ -1225,6 +1225,30 @@ write_cookie_file(char* path, size_t path_size, const char* prefix, const char c
 }
 
 static int
+write_short_cookie_file(char* path, size_t path_size, const char* prefix) {
+    int fd = dsd_test_mkstemp(path, path_size, prefix);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "dsd_test_mkstemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+    FILE* f = fdopen(fd, "wb");
+    if (!f) {
+        DSD_FPRINTF(stderr, "fdopen failed: %s\n", strerror(errno));
+        (void)dsd_close(fd);
+        (void)remove(path);
+        return 1;
+    }
+    if (fwrite(".a", 1, 2, f) != 2) {
+        DSD_FPRINTF(stderr, "fwrite(%s) failed\n", path);
+        fclose(f);
+        (void)remove(path);
+        return 1;
+    }
+    fclose(f);
+    return 0;
+}
+
+static int
 test_open_mbe_in_file_classifies_cookies(void) {
     int rc = 0;
 
@@ -1262,6 +1286,34 @@ test_open_mbe_in_file_classifies_cookies(void) {
         (void)remove(path);
     }
 
+    return rc;
+}
+
+static int
+test_open_mbe_in_file_rejects_short_cookie_without_handle(void) {
+    int rc = 0;
+    char path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    state.mbe_file_type = 99;
+
+    if (write_short_cookie_file(path, sizeof path, "mbe_in_short") != 0) {
+        return 1;
+    }
+    DSD_SNPRINTF(opts.mbe_in_file, sizeof opts.mbe_in_file, "%s", path);
+
+    openMbeInFile(&opts, &state);
+    rc |= expect_int("mbe short cookie rejected", state.mbe_file_type, -1);
+    rc |= expect_true("mbe short cookie closes handle", opts.mbe_in_f == NULL);
+
+    if (opts.mbe_in_f) {
+        fclose(opts.mbe_in_f);
+        opts.mbe_in_f = NULL;
+    }
+    (void)remove(path);
     return rc;
 }
 
@@ -1727,6 +1779,7 @@ main(void) {
     rc |= test_open_mbe_out_file_creates_slot_files_and_closes();
     rc |= test_truncated_reads_fail();
     rc |= test_open_mbe_in_file_classifies_cookies();
+    rc |= test_open_mbe_in_file_rejects_short_cookie_without_handle();
     rc |= test_symbol_capture_open_writes_expected_headers();
     rc |= test_symbol_capture_auto_rotation_reopens_and_logs_event();
     rc |= test_wav_output_helpers_create_temp_and_raw_files();

--- a/tests/core/test_core_mbe_file_io.c
+++ b/tests/core/test_core_mbe_file_io.c
@@ -1,0 +1,1744 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-optin.performance.Padding,clang-analyzer-unix.Errno,clang-analyzer-unix.Stream)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/bit_packing.h>
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/file_io.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/core/time_format.h>
+#include <dsd-neo/fec/block_codes.h>
+#include <dsd-neo/protocol/dmr/dmr_const.h>
+#include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <dsd-neo/runtime/rdio_export.h>
+#include <errno.h>
+#include <sndfile.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#if DSD_PLATFORM_WIN_NATIVE
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/file_compat.h"
+#include "dsd-neo/platform/platform.h"
+#include "test_support.h"
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_byte(const char* tag, unsigned char got, unsigned char want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got 0x%02X want 0x%02X\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u16(const char* tag, uint16_t got, uint16_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %u want %u\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u64(const char* tag, uint64_t got, uint64_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got 0x%llX want 0x%llX\n", tag, (unsigned long long)got, (unsigned long long)want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_true(const char* tag, int condition) {
+    if (!condition) {
+        DSD_FPRINTF(stderr, "%s: condition failed\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u8_bits(const char* tag, const uint8_t* got, const uint8_t* want, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        if (got[i] != want[i]) {
+            DSD_FPRINTF(stderr, "%s[%zu]: got %u want %u\n", tag, i, got[i], want[i]);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+expect_bits(const char* tag, const char* got, const char* want, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        if (got[i] != want[i]) {
+            DSD_FPRINTF(stderr, "%s[%zu]: got %d want %d\n", tag, i, got[i], want[i]);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+remove_dir(const char* path) {
+#if DSD_PLATFORM_WIN_NATIVE
+    return _rmdir(path);
+#else
+    return rmdir(path);
+#endif
+}
+
+static char*
+test_getcwd(char* buf, size_t size) {
+#if DSD_PLATFORM_WIN_NATIVE
+    return _getcwd(buf, (int)size);
+#else
+    return getcwd(buf, size);
+#endif
+}
+
+static int
+test_chdir(const char* path) {
+#if DSD_PLATFORM_WIN_NATIVE
+    return _chdir(path);
+#else
+    return chdir(path);
+#endif
+}
+
+static int
+has_suffix(const char* text, const char* suffix) {
+    size_t text_len = strlen(text);
+    size_t suffix_len = strlen(suffix);
+    return text_len >= suffix_len && memcmp(text + text_len - suffix_len, suffix, suffix_len) == 0;
+}
+
+static int
+read_file_prefix(const char* path, char* out, size_t out_size) {
+    if (!path || !out || out_size == 0) {
+        return 1;
+    }
+    FILE* f = fopen(path, "rb");
+    if (!f) {
+        DSD_FPRINTF(stderr, "fopen(%s) failed: %s\n", path, strerror(errno));
+        return 1;
+    }
+    size_t n = fread(out, 1, out_size - 1, f);
+    if (n == 0 && ferror(f)) {
+        DSD_FPRINTF(stderr, "fread(%s) failed: %s\n", path, strerror(errno));
+        fclose(f);
+        return 1;
+    }
+    out[n] = '\0';
+    fclose(f);
+    return 0;
+}
+
+static int
+read_file_exact(const char* path, unsigned char* out, size_t out_size, size_t* got) {
+    if (!path || !out || !got) {
+        return 1;
+    }
+    *got = 0;
+    FILE* f = fopen(path, "rb");
+    if (!f) {
+        DSD_FPRINTF(stderr, "fopen(%s) failed: %s\n", path, strerror(errno));
+        return 1;
+    }
+    *got = fread(out, 1, out_size, f);
+    if (ferror(f)) {
+        DSD_FPRINTF(stderr, "fread(%s) failed: %s\n", path, strerror(errno));
+        fclose(f);
+        return 1;
+    }
+    if (*got == out_size) {
+        int extra = fgetc(f);
+        if (extra != EOF) {
+            DSD_FPRINTF(stderr, "%s has more than %zu bytes\n", path, out_size);
+            fclose(f);
+            return 1;
+        }
+        if (ferror(f)) {
+            DSD_FPRINTF(stderr, "fgetc(%s) failed: %s\n", path, strerror(errno));
+            fclose(f);
+            return 1;
+        }
+    }
+    fclose(f);
+    return 0;
+}
+
+static int
+read_file_bytes_prefix(const char* path, unsigned char* out, size_t want) {
+    if (!path || !out || want == 0) {
+        return 1;
+    }
+    FILE* f = fopen(path, "rb");
+    if (!f) {
+        DSD_FPRINTF(stderr, "fopen(%s) failed: %s\n", path, strerror(errno));
+        return 1;
+    }
+    size_t got = fread(out, 1, want, f);
+    if (got != want) {
+        DSD_FPRINTF(stderr, "fread(%s) got %zu want %zu\n", path, got, want);
+        fclose(f);
+        return 1;
+    }
+    fclose(f);
+    return 0;
+}
+
+static long
+file_size_or_negative(const char* path) {
+    FILE* f = fopen(path, "rb");
+    if (!f) {
+        DSD_FPRINTF(stderr, "fopen(%s) failed: %s\n", path, strerror(errno));
+        return -1;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) {
+        DSD_FPRINTF(stderr, "fseek(%s) failed: %s\n", path, strerror(errno));
+        fclose(f);
+        return -1;
+    }
+    long size = ftell(f);
+    fclose(f);
+    return size;
+}
+
+static int
+expect_wav_header(const char* tag, const char* path) {
+    unsigned char header[12];
+    if (read_file_bytes_prefix(path, header, sizeof header) != 0) {
+        return 1;
+    }
+    int rc = 0;
+    rc |= expect_true(tag, memcmp(header, "RIFF", 4) == 0);
+    rc |= expect_true(tag, memcmp(header + 8, "WAVE", 4) == 0);
+    return rc;
+}
+
+static int
+find_wav_rename_output_for_string_event(char* out, size_t out_size, const char* dir, const Event_History* item) {
+    if (!out || out_size == 0 || !dir || !item) {
+        return 0;
+    }
+
+    char datestr[9];
+    char timestr[7];
+    getDateF_buf(item->event_time, datestr);
+    getTimeF_buf(item->event_time, timestr);
+
+    for (unsigned int n = 0; n <= UINT16_MAX; n++) {
+        DSD_SNPRINTF(out, out_size, "%s/%s_%s_%05u_%s_%s_TGT_%s_SRC_%s.wav", dir, datestr, timestr, n,
+                     item->sysid_string, item->gi == 1 ? "PRIVATE" : "GROUP", item->tgt_str, item->src_str);
+        FILE* f = fopen(out, "rb");
+        if (f) {
+            fclose(f);
+            return 1;
+        }
+    }
+    out[0] = '\0';
+    return 0;
+}
+
+static int
+find_wav_rename_output_for_numeric_event(char* out, size_t out_size, const char* dir, const Event_History* item) {
+    if (!out || out_size == 0 || !dir || !item) {
+        return 0;
+    }
+
+    char datestr[9];
+    char timestr[7];
+    getDateF_buf(item->event_time, datestr);
+    getTimeF_buf(item->event_time, timestr);
+
+    for (unsigned int n = 0; n <= UINT16_MAX; n++) {
+        DSD_SNPRINTF(out, out_size, "%s/%s_%s_%05u_%s_%s_TGT_%u_SRC_%u.wav", dir, datestr, timestr, n,
+                     item->sysid_string, item->gi == 1 ? "PRIVATE" : "GROUP", item->target_id, item->source_id);
+        FILE* f = fopen(out, "rb");
+        if (f) {
+            fclose(f);
+            return 1;
+        }
+    }
+    out[0] = '\0';
+    return 0;
+}
+
+static int
+make_rdio_sidecar_path(const char* wav_path, char* out, size_t out_size) {
+    if (!wav_path || !out || out_size == 0) {
+        return 1;
+    }
+    int written = DSD_SNPRINTF(out, out_size, "%s", wav_path);
+    if (written < 0 || (size_t)written >= out_size) {
+        return 1;
+    }
+    char* dot = strrchr(out, '.');
+    if (dot && strcmp(dot, ".wav") == 0) {
+        *dot = '\0';
+    }
+    size_t base_len = strlen(out);
+    written = DSD_SNPRINTF(out + base_len, out_size - base_len, "%s", ".json");
+    return (written < 0 || (size_t)written >= out_size - base_len) ? 1 : 0;
+}
+
+static int
+write_wav_test_samples(SNDFILE* wav) {
+    const short samples[] = {1000, -1000, 500, -500};
+    sf_count_t written = sf_write_short(wav, samples, (sf_count_t)(sizeof samples / sizeof samples[0]));
+    return written == (sf_count_t)(sizeof samples / sizeof samples[0]);
+}
+
+static void
+set_bits_from_bytes(char* bits, const unsigned char* bytes, size_t nbytes) {
+    size_t k = 0;
+    for (size_t i = 0; i < nbytes; i++) {
+        for (int bit = 7; bit >= 0; bit--) {
+            bits[k++] = (char)((bytes[i] >> bit) & 1u);
+        }
+    }
+}
+
+static int
+read_bytes(FILE* f, unsigned char* out, size_t want) {
+    if (fseek(f, 0, SEEK_SET) != 0) {
+        DSD_FPRINTF(stderr, "fseek failed\n");
+        return 1;
+    }
+    clearerr(f);
+    size_t got = fread(out, 1, want, f);
+    if (got != want) {
+        if (ferror(f)) {
+            DSD_FPRINTF(stderr, "fread failed\n");
+        } else {
+            DSD_FPRINTF(stderr, "fread got %zu want %zu\n", got, want);
+        }
+        return 1;
+    }
+    return 0;
+}
+
+static int
+write_sdrtrunk_json_input(FILE** out, const char* json) {
+    if (!out || !json) {
+        return 1;
+    }
+    *out = tmpfile();
+    if (!*out) {
+        DSD_FPRINTF(stderr, "tmpfile failed: %s\n", strerror(errno));
+        return 1;
+    }
+    const size_t len = strlen(json);
+    if (fwrite(json, 1, len, *out) != len) {
+        DSD_FPRINTF(stderr, "failed to write SDRTrunk JSON input\n");
+        fclose(*out);
+        *out = NULL;
+        return 1;
+    }
+    if (fseek(*out, 0L, SEEK_SET) != 0) {
+        DSD_FPRINTF(stderr, "failed to rewind SDRTrunk JSON input: %s\n", strerror(errno));
+        fclose(*out);
+        *out = NULL;
+        return 1;
+    }
+    return 0;
+}
+
+static int
+run_sdrtrunk_json(const char* json, dsd_opts* opts, dsd_state* state) {
+    FILE* in = NULL;
+    if (write_sdrtrunk_json_input(&in, json) != 0) {
+        return 1;
+    }
+    opts->mbe_in_f = in;
+    read_sdrtrunk_json_format(opts, state);
+    fclose(in);
+    opts->mbe_in_f = NULL;
+    return 0;
+}
+
+static int
+test_imbe_save_read_roundtrip(void) {
+    int rc = 0;
+    static const unsigned char payload[11] = {0x00, 0xFF, 0x81, 0x7E, 0xA5, 0x5A, 0x3C, 0xC3, 0x18, 0xE7, 0x42};
+    char imbe_bits[88] = {0};
+    char decoded[88] = {0};
+    unsigned char bytes[12] = {0};
+    static dsd_opts opts;
+    static dsd_state state;
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    state.errs2 = 0x35;
+    set_bits_from_bytes(imbe_bits, payload, sizeof payload);
+
+    FILE* out = tmpfile();
+    if (!out) {
+        DSD_FPRINTF(stderr, "tmpfile failed: %s\n", strerror(errno));
+        return 1;
+    }
+    opts.mbe_out_f = out;
+    saveImbe4400Data(&opts, &state, imbe_bits);
+    fflush(out);
+    rc |= read_bytes(out, bytes, sizeof bytes);
+    rc |= expect_byte("imbe-err", bytes[0], 0x35);
+    for (size_t i = 0; i < sizeof payload; i++) {
+        char tag[32];
+        DSD_SNPRINTF(tag, sizeof tag, "imbe-byte-%zu", i);
+        rc |= expect_byte(tag, bytes[i + 1], payload[i]);
+    }
+
+    rewind(out);
+    DSD_MEMSET(decoded, 0x55, sizeof decoded);
+    state.errs = 0;
+    state.errs2 = 0;
+    opts.mbe_in_f = out;
+    rc |= expect_int("read-imbe", readImbe4400Data(&opts, &state, decoded), 0);
+    rc |= expect_int("imbe-state-errs", state.errs, 0x35);
+    rc |= expect_int("imbe-state-errs2", state.errs2, 0x35);
+    rc |= expect_bits("imbe-roundtrip", decoded, imbe_bits, sizeof decoded);
+
+    fclose(out);
+    opts.mbe_in_f = NULL;
+    opts.mbe_out_f = NULL;
+    return rc;
+}
+
+static int
+test_ambe_save_read_roundtrip_and_slot2(void) {
+    int rc = 0;
+    static const unsigned char payload[6] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+    char ambe_bits[49] = {0};
+    char decoded[49] = {0};
+    unsigned char bytes[8] = {0};
+    static dsd_opts opts;
+    static dsd_state state;
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    state.errs2 = 0x44;
+    state.errs2R = 0x55;
+    set_bits_from_bytes(ambe_bits, payload, sizeof payload);
+    ambe_bits[48] = 1;
+
+    FILE* out = tmpfile();
+    FILE* out_r = tmpfile();
+    if (!out || !out_r) {
+        DSD_FPRINTF(stderr, "tmpfile failed: %s\n", strerror(errno));
+        if (out) {
+            fclose(out);
+        }
+        if (out_r) {
+            fclose(out_r);
+        }
+        return 1;
+    }
+
+    opts.mbe_out_f = out;
+    saveAmbe2450Data(&opts, &state, ambe_bits);
+    fflush(out);
+    rc |= read_bytes(out, bytes, sizeof bytes);
+    rc |= expect_byte("ambe-err", bytes[0], 0x44);
+    for (size_t i = 0; i < sizeof payload; i++) {
+        char tag[32];
+        DSD_SNPRINTF(tag, sizeof tag, "ambe-byte-%zu", i);
+        rc |= expect_byte(tag, bytes[i + 1], payload[i]);
+    }
+    rc |= expect_byte("ambe-tail", bytes[7], 1);
+
+    rewind(out);
+    DSD_MEMSET(decoded, 0x55, sizeof decoded);
+    state.errs = 0;
+    state.errs2 = 0;
+    opts.mbe_in_f = out;
+    rc |= expect_int("read-ambe", readAmbe2450Data(&opts, &state, decoded), 0);
+    rc |= expect_int("ambe-state-errs", state.errs, 0x44);
+    rc |= expect_int("ambe-state-errs2", state.errs2, 0x44);
+    rc |= expect_bits("ambe-roundtrip", decoded, ambe_bits, sizeof decoded);
+
+    DSD_MEMSET(bytes, 0, sizeof bytes);
+    opts.mbe_out_fR = out_r;
+    saveAmbe2450DataR(&opts, &state, ambe_bits);
+    fflush(out_r);
+    rc |= read_bytes(out_r, bytes, sizeof bytes);
+    rc |= expect_byte("ambe-r-err", bytes[0], 0x55);
+    rc |= expect_byte("ambe-r-tail", bytes[7], 1);
+
+    fclose(out);
+    fclose(out_r);
+    opts.mbe_in_f = NULL;
+    opts.mbe_out_f = NULL;
+    opts.mbe_out_fR = NULL;
+    return rc;
+}
+
+static int
+test_bit_packing_helpers_roundtrip_and_partial_bytes(void) {
+    int rc = 0;
+    const uint8_t bits[16] = {1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0};
+    const uint8_t want_bytes[2] = {0xA5, 0x5A};
+    uint8_t packed[2] = {0};
+    uint8_t unpacked[16] = {0};
+
+    rc |= expect_u64("convert bits to output", convert_bits_into_output(bits, 16), 0xA55AULL);
+
+    pack_bit_array_into_byte_array(bits, packed, 2);
+    rc |= expect_byte("pack byte 0", packed[0], want_bytes[0]);
+    rc |= expect_byte("pack byte 1", packed[1], want_bytes[1]);
+
+    unpack_byte_array_into_bit_array(packed, unpacked, 2);
+    rc |= expect_u8_bits("unpack byte bits", unpacked, bits, sizeof bits);
+
+    const uint8_t partial_bits[10] = {1, 0, 1, 1, 0, 0, 1, 0, 1, 1};
+    uint8_t partial[2] = {0};
+    pack_bit_array_into_byte_array_asym(partial_bits, partial, (int)(sizeof partial_bits / sizeof partial_bits[0]));
+    rc |= expect_byte("partial byte 0", partial[0], 0xB2);
+    rc |= expect_byte("partial byte 1", partial[1], 0xC0);
+
+    return rc;
+}
+
+static int
+test_ambe_pack_unpack_49_bits_roundtrip(void) {
+    int rc = 0;
+    char ambe[49] = {0};
+    char decoded[49] = {0};
+    uint8_t packed[7] = {0};
+
+    for (size_t i = 0; i < sizeof ambe; i++) {
+        ambe[i] = (char)(((i * 7u) + 3u) & 1u);
+    }
+    ambe[48] = 1;
+
+    pack_ambe(ambe, packed, (int)sizeof ambe);
+    rc |= expect_true("ambe tail stored in high bit", (packed[6] & 0x80u) != 0);
+    rc |= expect_true("ambe tail padding zeroed", (packed[6] & 0x7Fu) == 0);
+
+    unpack_ambe(packed, decoded);
+    rc |= expect_bits("ambe pack/unpack", decoded, ambe, sizeof ambe);
+
+    return rc;
+}
+
+static int
+test_parse_raw_user_string_guards_and_bounds(void) {
+    int rc = 0;
+    uint8_t out[4] = {0xEE, 0xEE, 0xEE, 0xEE};
+
+    rc |= expect_u16("parse null input", parse_raw_user_string(NULL, out, sizeof out), 0);
+    rc |= expect_u16("parse null output", parse_raw_user_string("00", NULL, sizeof out), 0);
+    rc |= expect_u16("parse zero cap", parse_raw_user_string("00", out, 0), 0);
+    rc |= expect_u16("parse empty", parse_raw_user_string("", out, sizeof out), 0);
+    rc |= expect_byte("parse guards preserve byte 0", out[0], 0xEE);
+
+    DSD_MEMSET(out, 0xEE, sizeof out);
+    rc |= expect_u16("parse even hex count", parse_raw_user_string("0a1Bff", out, sizeof out), 3);
+    rc |= expect_byte("parse hex byte 0", out[0], 0x0A);
+    rc |= expect_byte("parse hex byte 1", out[1], 0x1B);
+    rc |= expect_byte("parse hex byte 2", out[2], 0xFF);
+    rc |= expect_byte("parse keeps spare byte", out[3], 0xEE);
+
+    DSD_MEMSET(out, 0xEE, sizeof out);
+    rc |= expect_u16("parse caps output", parse_raw_user_string("abcdef", out, 2), 2);
+    rc |= expect_byte("parse capped byte 0", out[0], 0xAB);
+    rc |= expect_byte("parse capped byte 1", out[1], 0xCD);
+    rc |= expect_byte("parse capped spare byte", out[2], 0xEE);
+
+    DSD_MEMSET(out, 0xEE, sizeof out);
+    rc |= expect_u16("parse invalid pair count", parse_raw_user_string("0g", out, sizeof out), 1);
+    rc |= expect_byte("parse invalid pair zeroes byte", out[0], 0x00);
+    rc |= expect_byte("parse invalid pair preserves spare", out[1], 0xEE);
+
+    DSD_MEMSET(out, 0xEE, sizeof out);
+    rc |= expect_u16("parse odd hex count", parse_raw_user_string("a5f", out, sizeof out), 2);
+    rc |= expect_byte("parse odd hex first byte", out[0], 0xA5);
+    rc |= expect_byte("parse odd hex padded high nibble", out[1], 0xF0);
+    rc |= expect_byte("parse odd hex preserves spare", out[2], 0xEE);
+
+    return rc;
+}
+
+static int
+test_sdrtrunk_json_metadata_protocols_and_time(void) {
+    int rc = 0;
+
+    struct {
+        const char* protocol;
+        int want_synctype;
+    } cases[] = {
+        {"APCO25-PHASE1", DSD_SYNC_P25P1_POS},
+        {"APCO25-PHASE2", DSD_SYNC_P25P2_POS},
+        {"DMR", DSD_SYNC_DMR_BS_DATA_POS},
+    };
+
+    for (size_t i = 0; i < sizeof cases / sizeof cases[0]; i++) {
+        char json[256];
+        static dsd_opts opts;
+        static dsd_state state;
+        static Event_History_I history[2];
+
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        DSD_MEMSET(history, 0, sizeof history);
+        opts.playfiles = 1;
+        state.event_history_s = history;
+        DSD_SNPRINTF(json, sizeof json,
+                     "{\"version\":\"2\",\"protocol\":\"%s\",\"call_type\":\"GROUP\",\"encrypted\":\"false\","
+                     "\"to\":\"1234\",\"from\":\"5678\",\"time\":\"1700000000000\"}",
+                     cases[i].protocol);
+
+        rc |= run_sdrtrunk_json(json, &opts, &state);
+        rc |= expect_int("sdrtrunk protocol synctype", state.synctype, cases[i].want_synctype);
+        rc |= expect_int("sdrtrunk protocol lastsynctype", state.lastsynctype, cases[i].want_synctype);
+        rc |= expect_int("sdrtrunk group call", state.gi[0], 0);
+        rc |= expect_int("sdrtrunk target id", (int)state.lasttg, 1234);
+        rc |= expect_int("sdrtrunk source id", (int)state.lastsrc, 5678);
+        rc |= expect_u64("sdrtrunk event time", (uint64_t)history[0].Event_History_Items[0].event_time, 1700000000ULL);
+    }
+
+    return rc;
+}
+
+static int
+test_sdrtrunk_json_encryption_metadata_updates_payload_state(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    static const char json[] =
+        "{\"version\":\"2\",\"protocol\":\"APCO25-PHASE1\",\"call_type\":\"GROUP\",\"encrypted\":\"true\","
+        "\"encryption_algorithm\":\"129\",\"encryption_key_id\":\"4660\","
+        "\"encryption_mi\":\"001122334455667788\",\"to\":\"55\",\"from\":\"66\",\"time\":\"1700000000000\"}";
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_MEMSET(history, 0, sizeof history);
+    opts.playfiles = 1;
+    state.event_history_s = history;
+
+    rc |= run_sdrtrunk_json(json, &opts, &state);
+    rc |= expect_int("sdrtrunk encrypted synctype", state.synctype, DSD_SYNC_P25P1_POS);
+    rc |= expect_int("sdrtrunk encrypted current slot", state.currentslot, 0);
+    rc |= expect_int("sdrtrunk encrypted algid", state.payload_algid, 0x81);
+    rc |= expect_u16("sdrtrunk encrypted key id", state.payload_keyid, 4660);
+    rc |= expect_u64("sdrtrunk encrypted mi truncates 18-char value", state.payload_mi, 0x0011223344556677ULL);
+    rc |= expect_int("sdrtrunk encrypted target id", (int)state.lasttg, 55);
+    rc |= expect_int("sdrtrunk encrypted source id", (int)state.lastsrc, 66);
+
+    return rc;
+}
+
+static int
+test_sdrtrunk_json_invalid_numeric_fields_reset_to_zero(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    static const char json[] =
+        "{\"protocol\":\"DMR\",\"call_type\":\"PRIVATE\",\"encrypted\":\"false\",\"to\":\"notnum\","
+        "\"from\":\"bad\",\"time\":\"bad0000000\"}";
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_MEMSET(history, 0, sizeof history);
+    opts.playfiles = 1;
+    state.lasttg = 111;
+    state.lastsrc = 222;
+    state.event_history_s = history;
+
+    rc |= run_sdrtrunk_json(json, &opts, &state);
+    rc |= expect_int("sdrtrunk invalid target zero", (int)state.lasttg, 0);
+    rc |= expect_int("sdrtrunk invalid source zero", (int)state.lastsrc, 0);
+    rc |= expect_int("sdrtrunk private call", state.gi[0], 1);
+    rc |= expect_u64("sdrtrunk invalid time zero", (uint64_t)history[0].Event_History_Items[0].event_time, 0ULL);
+
+    return rc;
+}
+
+static int
+test_sdrtrunk_json_protocol_opens_and_closes_mbe_out_file(void) {
+    int rc = 0;
+    char dir[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    static const char json[] = "{\"protocol\":\"DMR\",\"encrypted\":\"false\"}";
+
+    if (!dsd_test_mkdtemp(dir, sizeof dir, "dsdneo_sdrtrunk_mbe")) {
+        DSD_FPRINTF(stderr, "dsd_test_mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_MEMSET(history, 0, sizeof history);
+    DSD_SNPRINTF(opts.mbe_out_dir, sizeof opts.mbe_out_dir, "%s%c", dir, dsd_test_path_sep());
+    opts.playfiles = 1;
+    state.tgcount = 3;
+    state.tg[2][1] = 4;
+    state.event_history_s = history;
+
+    rc |= run_sdrtrunk_json(json, &opts, &state);
+    rc |= expect_int("sdrtrunk mbe close clears flag", opts.mbe_out, 0);
+    rc |= expect_true("sdrtrunk mbe close clears handle", opts.mbe_out_f == NULL);
+    rc |= expect_true("sdrtrunk mbe filename suffix", has_suffix(opts.mbe_out_file, "_S1.amb"));
+    rc |= expect_int("sdrtrunk mbe resets tgcount", state.tgcount, 0);
+    rc |= expect_int("sdrtrunk mbe resets tg table", state.tg[2][1], 0);
+
+    char header[8];
+    if (read_file_prefix(opts.mbe_out_path, header, sizeof header) != 0) {
+        rc = 1;
+    } else {
+        rc |= expect_true("sdrtrunk mbe header", strcmp(header, ".amb") == 0);
+    }
+
+    (void)remove(opts.mbe_out_path);
+    (void)remove_dir(dir);
+    return rc;
+}
+
+static int
+test_sdrtrunk_json_hex_voice_writes_unencrypted_mbe_records(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    static const char json[] =
+        "{\"version\":\"2\",\"protocol\":\"DMR\",\"call_type\":\"GROUP\",\"encrypted\":\"false\","
+        "\"hex\":\"000000000000000000\"}";
+    unsigned char bytes[8] = {0};
+    size_t got = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_MEMSET(history, 0, sizeof history);
+    opts.playfiles = 1;
+    opts.floating_point = 1;
+    state.event_history_s = history;
+
+    FILE* out = tmpfile();
+    if (!out) {
+        DSD_FPRINTF(stderr, "tmpfile failed: %s\n", strerror(errno));
+        return 1;
+    }
+    opts.mbe_out_f = out;
+
+    rc |= run_sdrtrunk_json(json, &opts, &state);
+    fflush(out);
+    if (fseek(out, 0, SEEK_SET) != 0) {
+        DSD_FPRINTF(stderr, "fseek(sdrtrunk hex output) failed\n");
+        rc = 1;
+    }
+    clearerr(out);
+    got = fread(bytes, 1, sizeof bytes, out);
+    if (ferror(out)) {
+        DSD_FPRINTF(stderr, "fread(sdrtrunk hex output) failed\n");
+        rc = 1;
+    }
+    rc |= expect_u16("sdrtrunk hex ambe record size", (uint16_t)got, 8);
+    rc |= expect_int("sdrtrunk hex dmr synctype", state.synctype, DSD_SYNC_DMR_BS_DATA_POS);
+    rc |= expect_int("sdrtrunk hex dmr slot", state.currentslot, 0);
+
+    fclose(out);
+    opts.mbe_out_f = NULL;
+    return rc;
+}
+
+static int
+test_sdrtrunk_json_hex_voice_blocks_encrypted_without_keystream(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    static const char json[] =
+        "{\"version\":\"2\",\"protocol\":\"APCO25-PHASE1\",\"call_type\":\"GROUP\",\"encrypted\":\"true\","
+        "\"encryption_algorithm\":\"129\",\"encryption_key_id\":\"7\",\"encryption_mi\":\"0011223344556677\","
+        "\"hex\":\"000000000000000000000000000000000000\"}";
+    unsigned char byte = 0xFF;
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_MEMSET(history, 0, sizeof history);
+    opts.playfiles = 1;
+    opts.floating_point = 1;
+    state.event_history_s = history;
+
+    FILE* out = tmpfile();
+    if (!out) {
+        DSD_FPRINTF(stderr, "tmpfile failed: %s\n", strerror(errno));
+        return 1;
+    }
+    opts.mbe_out_f = out;
+
+    rc |= run_sdrtrunk_json(json, &opts, &state);
+    fflush(out);
+    if (fseek(out, 0, SEEK_SET) != 0) {
+        DSD_FPRINTF(stderr, "fseek(sdrtrunk encrypted output) failed\n");
+        rc = 1;
+    }
+    clearerr(out);
+    int empty_check = fgetc(out);
+    if (empty_check == EOF && ferror(out)) {
+        DSD_FPRINTF(stderr, "fgetc(sdrtrunk encrypted output) failed\n");
+        rc = 1;
+    }
+    rc |= expect_int("sdrtrunk encrypted hex writes no mbe record", empty_check, EOF);
+    rc |= expect_byte("sdrtrunk encrypted hex sentinel unchanged", byte, 0xFF);
+    rc |= expect_int("sdrtrunk encrypted hex p25 synctype", state.synctype, DSD_SYNC_P25P1_POS);
+    rc |= expect_int("sdrtrunk encrypted hex algid", state.payload_algid, 0x81);
+    rc |= expect_u16("sdrtrunk encrypted hex key id", state.payload_keyid, 7);
+    rc |= expect_u64("sdrtrunk encrypted hex mi", state.payload_mi, 0x0011223344556677ULL);
+
+    fclose(out);
+    opts.mbe_out_f = NULL;
+    return rc;
+}
+
+static int
+run_sdrtrunk_voice_record_case(const char* tag, const char* json, dsd_state* state, size_t min_record_bytes) {
+    int rc = 0;
+    static dsd_opts opts;
+    static Event_History_I history[2];
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(history, 0, sizeof history);
+    opts.playfiles = 1;
+    opts.floating_point = 1;
+    opts.slot1_on = 1;
+    state->event_history_s = history;
+
+    FILE* out = tmpfile();
+    if (!out) {
+        DSD_FPRINTF(stderr, "tmpfile failed: %s\n", strerror(errno));
+        return 1;
+    }
+    opts.mbe_out_f = out;
+
+    rc |= run_sdrtrunk_json(json, &opts, state);
+    rc |= expect_int(tag, fflush(out), 0);
+    if (fseek(out, 0, SEEK_SET) != 0) {
+        DSD_FPRINTF(stderr, "fseek(%s) failed\n", tag);
+        rc = 1;
+    }
+    clearerr(out);
+    int first = fgetc(out);
+    if (first == EOF && ferror(out)) {
+        DSD_FPRINTF(stderr, "fgetc(%s) failed\n", tag);
+        rc = 1;
+    }
+    rc |= expect_true(tag, first != EOF);
+    if (first != EOF) {
+        size_t bytes = 1;
+        while (fgetc(out) != EOF) {
+            bytes++;
+        }
+        if (ferror(out)) {
+            DSD_FPRINTF(stderr, "fgetc(%s) failed\n", tag);
+            rc = 1;
+        }
+        rc |= expect_true(tag, bytes >= min_record_bytes);
+    }
+
+    fclose(out);
+    opts.mbe_out_f = NULL;
+    return rc;
+}
+
+static int
+test_sdrtrunk_json_encrypted_keystreams_write_voice_records(void) {
+    int rc = 0;
+
+    struct {
+        const char* tag;
+        const char* json;
+        unsigned long long r;
+        unsigned long long k1;
+        unsigned long long k2;
+        unsigned long long k3;
+        unsigned long long k4;
+        int forced_m;
+        unsigned long long forced_k;
+        int want_algid;
+        size_t min_record_bytes;
+    } cases[] = {
+        {"sdrtrunk p25 rc4 record",
+         "{\"version\":\"1\",\"protocol\":\"APCO25-PHASE1\",\"encrypted\":\"true\","
+         "\"encryption_algorithm\":\"170\",\"encryption_key_id\":\"7\",\"encryption_mi\":\"0011223344556677\","
+         "\"hex\":\"000000000000000000000000000000000000\"}",
+         0x0102030405ULL, 0, 0, 0, 0, 0, 0, 0xAA, 12},
+        {"sdrtrunk p25 des record",
+         "{\"version\":\"1\",\"protocol\":\"APCO25-PHASE1\",\"encrypted\":\"true\","
+         "\"encryption_algorithm\":\"129\",\"encryption_key_id\":\"7\",\"encryption_mi\":\"0011223344556677\","
+         "\"hex\":\"000000000000000000000000000000000000\"}",
+         0x0102030405ULL, 0, 0, 0, 0, 0, 0, 0x81, 12},
+        {"sdrtrunk p25 aes record",
+         "{\"version\":\"1\",\"protocol\":\"APCO25-PHASE1\",\"encrypted\":\"true\","
+         "\"encryption_algorithm\":\"137\",\"encryption_key_id\":\"7\",\"encryption_mi\":\"0011223344556677\","
+         "\"hex\":\"000000000000000000000000000000000000\"}",
+         0, 0x0011223344556677ULL, 0x8899AABBCCDDEEFFULL, 0x1021324354657687ULL, 0x98A9BACBDCEDFE0FULL, 0, 0, 0x89, 12},
+        {"sdrtrunk dmr forced bp record",
+         "{\"version\":\"2\",\"protocol\":\"DMR\",\"encrypted\":\"false\",\"hex\":\"000000000000000000\"}", 0, 0, 0, 0,
+         0, 1, 42, 0, 8},
+    };
+
+    for (size_t i = 0; i < sizeof cases / sizeof cases[0]; i++) {
+        static dsd_state state;
+        DSD_MEMSET(&state, 0, sizeof state);
+        state.R = cases[i].r;
+        state.K1 = cases[i].k1;
+        state.K2 = cases[i].k2;
+        state.K3 = cases[i].k3;
+        state.K4 = cases[i].k4;
+        state.M = cases[i].forced_m;
+        state.K = cases[i].forced_k;
+
+        rc |= run_sdrtrunk_voice_record_case(cases[i].tag, cases[i].json, &state, cases[i].min_record_bytes);
+        if (cases[i].want_algid != 0) {
+            rc |= expect_int(cases[i].tag, state.payload_algid, cases[i].want_algid);
+        }
+    }
+
+    return rc;
+}
+
+static uint8_t
+bits_to_u4_msb(const unsigned char bits4[4]) {
+    uint8_t v = 0;
+    for (int i = 0; i < 4; i++) {
+        v = (uint8_t)((v << 1U) | (bits4[i] & 1U));
+    }
+    return (uint8_t)(v & 0xFU);
+}
+
+static void
+fill_sdrtrunk_dmr_le_fragments(dsd_state* state, uint32_t mi32) {
+    uint8_t mi_bits32[32];
+    for (int i = 0; i < 32; i++) {
+        mi_bits32[i] = (uint8_t)((mi32 >> (31 - i)) & 1U);
+    }
+    const uint8_t crc = crc4(mi_bits32, 32);
+
+    unsigned char msg36[36];
+    unsigned char go36[36];
+    DSD_MEMSET(msg36, 0, sizeof msg36);
+    DSD_MEMSET(go36, 0, sizeof go36);
+    for (int i = 0; i < 32; i++) {
+        msg36[i] = (unsigned char)(mi_bits32[i] & 1U);
+    }
+    for (int i = 0; i < 4; i++) {
+        msg36[32 + i] = (unsigned char)((crc >> (3 - i)) & 1U);
+    }
+
+    for (int chunk = 0; chunk < 3; chunk++) {
+        unsigned char orig[12];
+        unsigned char enc[24];
+        DSD_MEMSET(orig, 0, sizeof orig);
+        DSD_MEMSET(enc, 0, sizeof enc);
+        for (int i = 0; i < 12; i++) {
+            orig[i] = (unsigned char)(msg36[chunk * 12 + i] & 1U);
+        }
+        Golay_24_12_encode(orig, enc);
+        for (int i = 0; i < 12; i++) {
+            go36[chunk * 12 + i] = (unsigned char)(enc[12 + i] & 1U);
+        }
+    }
+
+    for (int col = 0; col < 3; col++) {
+        for (int row = 0; row < 3; row++) {
+            const int bit_base = col * 12 + row * 4;
+            state->late_entry_mi_fragment[0][1 + row][col] = bits_to_u4_msb(&msg36[bit_base]);
+            state->late_entry_mi_fragment[0][4 + row][col] = bits_to_u4_msb(&go36[bit_base]);
+        }
+    }
+}
+
+static unsigned long long
+dmr_lfsr32_once(unsigned long long mi) {
+    unsigned long long lfsr = mi;
+    for (uint8_t cnt = 0; cnt < 32; cnt++) {
+        const unsigned long long bit = ((lfsr >> 31U) ^ (lfsr >> 3U) ^ (lfsr >> 1U)) & 0x1U;
+        lfsr = (lfsr << 1U) | bit;
+    }
+    return lfsr & 0xFFFFFFFFULL;
+}
+
+static uint8_t
+hex_char_to_nibble(char c) {
+    if (c >= '0' && c <= '9') {
+        return (uint8_t)(c - '0');
+    }
+    if (c >= 'A' && c <= 'F') {
+        return (uint8_t)(10 + c - 'A');
+    }
+    return 0;
+}
+
+static void
+set_sdrtrunk_dmr_hex_nibble_bit(char hex[19], int row, int col, uint8_t bit) {
+    if ((bit & 1U) == 0U) {
+        return;
+    }
+    for (int map_idx = 0; map_idx < 36; map_idx++) {
+        if (dmr_ambe_interleave_y[map_idx] == row && dmr_ambe_interleave_z[map_idx] == col) {
+            const int hex_idx = map_idx / 2;
+            const uint8_t mask = (map_idx % 2 == 0) ? 0x4U : 0x1U;
+            const uint8_t nibble = hex_char_to_nibble(hex[hex_idx]);
+            static const char lut[] = "0123456789ABCDEF";
+            hex[hex_idx] = lut[(nibble | mask) & 0xFU];
+            return;
+        }
+    }
+}
+
+static void
+build_sdrtrunk_dmr_late_entry_hex(uint8_t nibble, char hex[19]) {
+    DSD_MEMSET(hex, '0', 18);
+    hex[18] = '\0';
+    for (int bit_idx = 0; bit_idx < 4; bit_idx++) {
+        set_sdrtrunk_dmr_hex_nibble_bit(hex, 3, bit_idx, (uint8_t)((nibble >> (3 - bit_idx)) & 1U));
+    }
+}
+
+static int
+test_sdrtrunk_json_dmr_late_entry_updates_mi(void) {
+    int rc = 0;
+    const uint32_t mi = 0xA1B2C3D4U;
+    static dsd_state encoded;
+    static dsd_state state;
+    static dsd_opts opts;
+    static Event_History_I history[2];
+
+    DSD_MEMSET(&encoded, 0, sizeof encoded);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(history, 0, sizeof history);
+    fill_sdrtrunk_dmr_le_fragments(&encoded, mi);
+
+    char json[768];
+    size_t used = 0;
+    used += (size_t)DSD_SNPRINTF(json + used, sizeof(json) - used,
+                                 "{\"version\":\"2\",\"protocol\":\"DMR\",\"encrypted\":\"true\",");
+    for (uint8_t vc = 1; vc <= 6; vc++) {
+        for (uint8_t col = 0; col < 3; col++) {
+            char hex[19];
+            build_sdrtrunk_dmr_late_entry_hex((uint8_t)encoded.late_entry_mi_fragment[0][vc][col], hex);
+            used += (size_t)DSD_SNPRINTF(json + used, sizeof(json) - used, "\"hex\":\"%s\",", hex);
+        }
+    }
+    rc |= expect_true("sdrtrunk dmr late entry json buffer", used + 2 < sizeof json);
+    json[used - 1] = '}';
+    json[used] = '\0';
+
+    opts.playfiles = 1;
+    opts.floating_point = 1;
+    state.event_history_s = history;
+    state.M = 0x21;
+    state.R = 0x0102030405ULL;
+
+    rc |= run_sdrtrunk_json(json, &opts, &state);
+    rc |= expect_int("sdrtrunk dmr late entry synctype", state.synctype, DSD_SYNC_DMR_BS_DATA_POS);
+    rc |= expect_int("sdrtrunk dmr late entry algid", state.payload_algid, 0x21);
+    rc |= expect_u64("sdrtrunk dmr late entry mi", state.payload_mi, dmr_lfsr32_once(mi));
+    return rc;
+}
+
+static int
+test_open_mbe_out_file_creates_slot_files_and_closes(void) {
+    int rc = 0;
+
+    struct {
+        int synctype;
+        const char* suffix;
+        const char* header;
+    } slot1_cases[] = {
+        {DSD_SYNC_P25P1_POS, "_S1.imb", ".imb"},
+        {DSD_SYNC_DSTAR_VOICE_POS, "_S1.dmb", ".dmb"},
+        {DSD_SYNC_DMR_BS_VOICE_POS, "_S1.amb", ".amb"},
+    };
+
+    char dir[DSD_TEST_PATH_MAX];
+    if (!dsd_test_mkdtemp(dir, sizeof dir, "dsdneo_mbe_out")) {
+        DSD_FPRINTF(stderr, "dsd_test_mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    for (size_t i = 0; i < sizeof slot1_cases / sizeof slot1_cases[0]; i++) {
+        static dsd_opts opts;
+        static dsd_state state;
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        DSD_SNPRINTF(opts.mbe_out_dir, sizeof opts.mbe_out_dir, "%s%c", dir, dsd_test_path_sep());
+        state.synctype = slot1_cases[i].synctype;
+        state.tgcount = 7;
+        state.tg[3][2] = 9;
+
+        openMbeOutFile(&opts, &state);
+        rc |= expect_int("slot1 open flag", opts.mbe_out, 1);
+        rc |= expect_true("slot1 file handle opened", opts.mbe_out_f != NULL);
+        rc |= expect_true("slot1 filename suffix", has_suffix(opts.mbe_out_file, slot1_cases[i].suffix));
+        rc |= expect_true("slot1 path contains filename", strstr(opts.mbe_out_path, opts.mbe_out_file) != NULL);
+        rc |= expect_int("slot1 tgcount reset", state.tgcount, 0);
+        rc |= expect_int("slot1 tg table reset", state.tg[3][2], 0);
+
+        closeMbeOutFile(&opts, &state);
+        rc |= expect_int("slot1 close clears flag", opts.mbe_out, 0);
+        rc |= expect_true("slot1 close clears handle", opts.mbe_out_f == NULL);
+
+        char header[8];
+        if (read_file_prefix(opts.mbe_out_path, header, sizeof header) != 0) {
+            rc = 1;
+        } else {
+            rc |= expect_true("slot1 header", strcmp(header, slot1_cases[i].header) == 0);
+        }
+        (void)remove(opts.mbe_out_path);
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_SNPRINTF(opts.mbe_out_dir, sizeof opts.mbe_out_dir, "%s%c", dir, dsd_test_path_sep());
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.tgcount = 5;
+    state.tg[4][3] = 8;
+
+    openMbeOutFileR(&opts, &state);
+    rc |= expect_int("slot2 open flag", opts.mbe_outR, 1);
+    rc |= expect_true("slot2 file handle opened", opts.mbe_out_fR != NULL);
+    rc |= expect_true("slot2 filename suffix", has_suffix(opts.mbe_out_fileR, "_S2.amb"));
+    rc |= expect_true("slot2 path contains filename", strstr(opts.mbe_out_path, opts.mbe_out_fileR) != NULL);
+    rc |= expect_int("slot2 tgcount reset", state.tgcount, 0);
+    rc |= expect_int("slot2 tg table reset", state.tg[4][3], 0);
+
+    closeMbeOutFileR(&opts, &state);
+    rc |= expect_int("slot2 close clears flag", opts.mbe_outR, 0);
+    rc |= expect_true("slot2 close clears handle", opts.mbe_out_fR == NULL);
+
+    char header[8];
+    if (read_file_prefix(opts.mbe_out_path, header, sizeof header) != 0) {
+        rc = 1;
+    } else {
+        rc |= expect_true("slot2 header", strcmp(header, ".amb") == 0);
+    }
+    (void)remove(opts.mbe_out_path);
+    (void)remove_dir(dir);
+    return rc;
+}
+
+static int
+test_truncated_reads_fail(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    char bits[88] = {0};
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    FILE* empty = tmpfile();
+    FILE* short_imbe = tmpfile();
+    FILE* short_ambe = tmpfile();
+    if (!empty || !short_imbe || !short_ambe) {
+        DSD_FPRINTF(stderr, "tmpfile failed: %s\n", strerror(errno));
+        if (empty) {
+            fclose(empty);
+        }
+        if (short_imbe) {
+            fclose(short_imbe);
+        }
+        if (short_ambe) {
+            fclose(short_ambe);
+        }
+        return 1;
+    }
+
+    opts.mbe_in_f = empty;
+    rc |= expect_int("empty-imbe", readImbe4400Data(&opts, &state, bits), 1);
+
+    fputc(0x22, short_imbe);
+    fputc(0xAA, short_imbe);
+    rewind(short_imbe);
+    opts.mbe_in_f = short_imbe;
+    rc |= expect_int("short-imbe", readImbe4400Data(&opts, &state, bits), 1);
+
+    fputc(0x33, short_ambe);
+    for (int i = 0; i < 6; i++) {
+        fputc(0xAA, short_ambe);
+    }
+    rewind(short_ambe);
+    opts.mbe_in_f = short_ambe;
+    rc |= expect_int("short-ambe-tail", readAmbe2450Data(&opts, &state, bits), 1);
+
+    fclose(empty);
+    fclose(short_imbe);
+    fclose(short_ambe);
+    opts.mbe_in_f = NULL;
+    return rc;
+}
+
+static int
+write_cookie_file(char* path, size_t path_size, const char* prefix, const char cookie[4]) {
+    int fd = dsd_test_mkstemp(path, path_size, prefix);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "dsd_test_mkstemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+    FILE* f = fdopen(fd, "wb");
+    if (!f) {
+        DSD_FPRINTF(stderr, "fdopen failed: %s\n", strerror(errno));
+        (void)dsd_close(fd);
+        (void)remove(path);
+        return 1;
+    }
+    if (fwrite(cookie, 1, 4, f) != 4) {
+        DSD_FPRINTF(stderr, "fwrite(%s) failed\n", path);
+        fclose(f);
+        (void)remove(path);
+        return 1;
+    }
+    fclose(f);
+    return 0;
+}
+
+static int
+test_open_mbe_in_file_classifies_cookies(void) {
+    int rc = 0;
+
+    struct {
+        const char* prefix;
+        char cookie[4];
+        int want_type;
+    } cases[] = {
+        {"mbe_in_amb", {'.', 'a', 'm', 'b'}, 1},
+        {"mbe_in_imb", {'.', 'i', 'm', 'b'}, 0},
+        {"mbe_in_dmb", {'.', 'd', 'm', 'b'}, 2},
+        {"mbe_in_bad", {'n', 'o', 'p', 'e'}, 3},
+    };
+
+    for (size_t i = 0; i < sizeof cases / sizeof cases[0]; i++) {
+        char path[DSD_TEST_PATH_MAX];
+        static dsd_opts opts;
+        static dsd_state state;
+
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+
+        if (write_cookie_file(path, sizeof path, cases[i].prefix, cases[i].cookie) != 0) {
+            return 1;
+        }
+        DSD_SNPRINTF(opts.mbe_in_file, sizeof opts.mbe_in_file, "%s", path);
+
+        openMbeInFile(&opts, &state);
+        rc |= expect_int(cases[i].prefix, state.mbe_file_type, cases[i].want_type);
+
+        if (opts.mbe_in_f) {
+            fclose(opts.mbe_in_f);
+            opts.mbe_in_f = NULL;
+        }
+        (void)remove(path);
+    }
+
+    return rc;
+}
+
+static int
+test_symbol_capture_open_writes_expected_headers(void) {
+    static const unsigned char soft_header[DSD_SYMBOL_CAPTURE_SOFT_HEADER_SIZE] = {
+        'D', 'S', 'D', 'N', 'S', 'Y', 'M', '2', 2, DSD_SYMBOL_CAPTURE_SOFT_RECORD_SIZE, 0, 0, 0, 0, 0, 0,
+    };
+    int rc = 0;
+
+    struct {
+        const char* prefix;
+        uint8_t capture_format;
+        const unsigned char* want;
+        size_t want_len;
+    } cases[] = {
+        {"symbol_soft", DSD_SYMBOL_CAPTURE_FORMAT_SOFT, soft_header, sizeof soft_header},
+        {"symbol_legacy", DSD_SYMBOL_CAPTURE_FORMAT_LEGACY, NULL, 0},
+    };
+
+    for (size_t i = 0; i < sizeof cases / sizeof cases[0]; i++) {
+        char path[DSD_TEST_PATH_MAX];
+        int fd = dsd_test_mkstemp(path, sizeof path, cases[i].prefix);
+        if (fd < 0) {
+            DSD_FPRINTF(stderr, "dsd_test_mkstemp failed: %s\n", strerror(errno));
+            return 1;
+        }
+        (void)dsd_close(fd);
+        (void)remove(path);
+
+        static dsd_opts opts;
+        static dsd_state state;
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        DSD_SNPRINTF(opts.symbol_out_file, sizeof opts.symbol_out_file, "%s", path);
+        opts.symbol_capture_format = cases[i].capture_format;
+
+        openSymbolOutFile(&opts, &state);
+        rc |= expect_true("symbol file handle opened", opts.symbol_out_f != NULL);
+        closeSymbolOutFile(&opts, &state);
+        rc |= expect_true("symbol close clears handle", opts.symbol_out_f == NULL);
+
+        unsigned char bytes[DSD_SYMBOL_CAPTURE_SOFT_HEADER_SIZE];
+        size_t got = 0;
+        if (read_file_exact(path, bytes, sizeof bytes, &got) != 0) {
+            rc = 1;
+        } else {
+            rc |= expect_int("symbol file size", (int)got, (int)cases[i].want_len);
+            if (cases[i].want_len > 0) {
+                rc |= expect_true("symbol soft header bytes", memcmp(bytes, cases[i].want, cases[i].want_len) == 0);
+            }
+        }
+        (void)remove(path);
+    }
+
+    return rc;
+}
+
+static int
+test_symbol_capture_auto_rotation_reopens_and_logs_event(void) {
+    static const unsigned char soft_header[DSD_SYMBOL_CAPTURE_SOFT_HEADER_SIZE] = {
+        'D', 'S', 'D', 'N', 'S', 'Y', 'M', '2', 2, DSD_SYMBOL_CAPTURE_SOFT_RECORD_SIZE, 0, 0, 0, 0, 0, 0,
+    };
+    int rc = 0;
+    char cwd[DSD_TEST_PATH_MAX];
+    char dir[DSD_TEST_PATH_MAX];
+    char old_path[DSD_TEST_PATH_MAX];
+    char new_path[DSD_TEST_PATH_MAX];
+
+    if (!test_getcwd(cwd, sizeof cwd)) {
+        DSD_FPRINTF(stderr, "getcwd failed: %s\n", strerror(errno));
+        return 1;
+    }
+    if (!dsd_test_mkdtemp(dir, sizeof dir, "dsdneo_symbol_rotate")) {
+        DSD_FPRINTF(stderr, "dsd_test_mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+    if (dsd_test_path_join(old_path, sizeof old_path, dir, "old_symbol_capture.bin") != 0) {
+        (void)remove_dir(dir);
+        return 1;
+    }
+
+    // Seed an auto-rotated soft symbol capture with a known old filename and event history.
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_MEMSET(history, 0, sizeof history);
+    state.event_history_s = history;
+    DSD_SNPRINTF(opts.symbol_out_file, sizeof opts.symbol_out_file, "%s", old_path);
+    opts.symbol_capture_format = DSD_SYMBOL_CAPTURE_FORMAT_SOFT;
+    opts.symbol_out_file_is_auto = 1;
+    opts.symbol_out_file_creation_time = time(NULL) - 4000;
+    state.lastsrc = 1234;
+
+    openSymbolOutFile(&opts, &state);
+    rc |= expect_true("rotation source handle opened", opts.symbol_out_f != NULL);
+    if (opts.symbol_out_f) {
+        rc |= expect_true("rotation old file marker written", fputc(0xA5, opts.symbol_out_f) != EOF);
+        rc |= expect_int("rotation old file flushed", fflush(opts.symbol_out_f), 0);
+    }
+
+    // Rotate from inside the capture directory so generated relative paths can be checked.
+    time_t before = time(NULL);
+    if (test_chdir(dir) != 0) {
+        DSD_FPRINTF(stderr, "chdir(%s) failed: %s\n", dir, strerror(errno));
+        closeSymbolOutFile(&opts, &state);
+        (void)remove(old_path);
+        (void)remove_dir(dir);
+        return 1;
+    }
+    rotate_symbol_out_file(&opts, &state);
+    time_t after = time(NULL);
+    if (test_chdir(cwd) != 0) {
+        DSD_FPRINTF(stderr, "chdir(%s) restore failed: %s\n", cwd, strerror(errno));
+        closeSymbolOutFile(&opts, &state);
+        return 1;
+    }
+
+    rc |= expect_true("rotation keeps handle open", opts.symbol_out_f != NULL);
+    rc |= expect_true("rotation generated capture name", has_suffix(opts.symbol_out_file, "_dibit_capture.bin"));
+    rc |= expect_true("rotation updates creation time", opts.symbol_out_file_creation_time >= before);
+    rc |= expect_true("rotation creation time bounded", opts.symbol_out_file_creation_time <= after + 1);
+    rc |= expect_int("rotation clears lastsrc", (int)state.lastsrc, 0);
+
+    // The user-visible event should name the generated capture and use sentinel IDs.
+    Event_History* rotated = &state.event_history_s[0].Event_History_Items[1];
+    rc |= expect_int("rotation event source", (int)rotated->source_id, 0xFFFFFF);
+    rc |= expect_int("rotation event target", (int)rotated->target_id, 0xFFFFFF);
+    rc |= expect_true("rotation event string", strstr(rotated->event_string, "Dibit Capture File Rotated") != NULL);
+    rc |= expect_true("rotation event names capture", strstr(rotated->event_string, opts.symbol_out_file) != NULL);
+
+    closeSymbolOutFile(&opts, &state);
+    rc |= expect_true("rotation close clears handle", opts.symbol_out_f == NULL);
+
+    // Both old and new files should retain soft-capture headers; the old file keeps its marker.
+    unsigned char old_bytes[DSD_SYMBOL_CAPTURE_SOFT_HEADER_SIZE + 1];
+    size_t got = 0;
+    if (read_file_exact(old_path, old_bytes, sizeof old_bytes, &got) != 0) {
+        rc = 1;
+    } else {
+        rc |= expect_int("rotation old file size", (int)got, (int)sizeof old_bytes);
+        rc |= expect_true("rotation old file header", memcmp(old_bytes, soft_header, sizeof soft_header) == 0);
+        rc |= expect_byte("rotation old file marker", old_bytes[sizeof soft_header], 0xA5);
+    }
+
+    if (dsd_test_path_join(new_path, sizeof new_path, dir, opts.symbol_out_file) == 0) {
+        unsigned char new_bytes[DSD_SYMBOL_CAPTURE_SOFT_HEADER_SIZE];
+        got = 0;
+        if (read_file_exact(new_path, new_bytes, sizeof new_bytes, &got) != 0) {
+            rc = 1;
+        } else {
+            rc |= expect_int("rotation new file size", (int)got, (int)sizeof new_bytes);
+            rc |= expect_true("rotation new file header", memcmp(new_bytes, soft_header, sizeof soft_header) == 0);
+        }
+        (void)remove(new_path);
+    } else {
+        rc = 1;
+    }
+
+    (void)remove(old_path);
+    (void)remove_dir(dir);
+    return rc;
+}
+
+static int
+test_wav_output_helpers_create_temp_and_raw_files(void) {
+    int rc = 0;
+    char dir[DSD_TEST_PATH_MAX];
+    if (!dsd_test_mkdtemp(dir, sizeof dir, "dsdneo_wav_out")) {
+        DSD_FPRINTF(stderr, "dsd_test_mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    rc |= expect_true("open wav null filename rejects", open_wav_file(dir, NULL, 64, 8000, 0) == NULL);
+    char too_small[8] = {0};
+    rc |= expect_true("open wav short filename rejects",
+                      open_wav_file(dir, too_small, sizeof too_small, 8000, 0) == NULL);
+
+    struct {
+        uint8_t ext;
+        int wants_suffix;
+    } cases[] = {
+        {0, 0},
+        {1, 1},
+    };
+
+    for (size_t i = 0; i < sizeof cases / sizeof cases[0]; i++) {
+        char path[DSD_TEST_PATH_MAX];
+        DSD_MEMSET(path, 0, sizeof path);
+        SNDFILE* wav = open_wav_file(dir, path, sizeof path, 8000, cases[i].ext);
+        rc |= expect_true("open wav returns handle", wav != NULL);
+        rc |= expect_true("open wav writes temp path", strstr(path, "TEMP_") != NULL);
+        rc |= expect_true("open wav path in dir", strstr(path, dir) == path);
+        rc |= expect_int("open wav suffix policy", has_suffix(path, ".wav"), cases[i].wants_suffix);
+        if (wav) {
+            wav = close_wav_file(wav);
+            rc |= expect_true("close wav returns null", wav == NULL);
+            rc |= expect_wav_header("open wav RIFF/WAVE header", path);
+            rc |= expect_true("open wav header-only size", file_size_or_negative(path) >= 44);
+        }
+        (void)remove(path);
+    }
+
+    char raw_path[DSD_TEST_PATH_MAX];
+    int fd = dsd_test_mkstemp(raw_path, sizeof raw_path, "raw_wav");
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "dsd_test_mkstemp failed: %s\n", strerror(errno));
+        (void)remove_dir(dir);
+        return 1;
+    }
+    (void)dsd_close(fd);
+    (void)remove(raw_path);
+
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_SNPRINTF(opts.wav_out_file_raw, sizeof opts.wav_out_file_raw, "%s", raw_path);
+
+    openWavOutFileRaw(&opts, &state);
+    rc |= expect_true("raw wav handle opened", opts.wav_out_raw != NULL);
+    if (opts.wav_out_raw) {
+        opts.wav_out_raw = close_wav_file(opts.wav_out_raw);
+        rc |= expect_true("raw wav close clears handle", opts.wav_out_raw == NULL);
+        rc |= expect_wav_header("raw wav RIFF/WAVE header", raw_path);
+        rc |= expect_true("raw wav header-only size", file_size_or_negative(raw_path) >= 44);
+    }
+    (void)remove(raw_path);
+    (void)remove_dir(dir);
+    return rc;
+}
+
+static int
+test_close_and_rename_wav_removes_header_only_files(void) {
+    int rc = 0;
+    char dir[DSD_TEST_PATH_MAX];
+    if (!dsd_test_mkdtemp(dir, sizeof dir, "dsdneo_wav_close")) {
+        DSD_FPRINTF(stderr, "dsd_test_mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    rc |= expect_true("close rename null filename rejects",
+                      close_and_rename_wav_file(NULL, NULL, NULL, dir, NULL) == NULL);
+    rc |= expect_true("close rename empty filename rejects",
+                      close_and_rename_wav_file(NULL, NULL, "", dir, NULL) == NULL);
+
+    char path[DSD_TEST_PATH_MAX];
+    DSD_MEMSET(path, 0, sizeof path);
+    SNDFILE* wav = open_wav_file(dir, path, sizeof path, 8000, 1);
+    rc |= expect_true("close rename source wav opened", wav != NULL);
+    if (wav) {
+        rc |= expect_true("close rename header-only returns null",
+                          close_and_rename_wav_file(wav, NULL, path, dir, NULL) == NULL);
+        rc |= expect_true("close rename header-only removed source", file_size_or_negative(path) < 0);
+    }
+
+    (void)remove(path);
+    (void)remove_dir(dir);
+    return rc;
+}
+
+static int
+test_close_and_rename_wav_preserves_nonempty_event_file(void) {
+    int rc = 0;
+    char dir[DSD_TEST_PATH_MAX];
+    if (!dsd_test_mkdtemp(dir, sizeof dir, "dsdneo_wav_rename")) {
+        DSD_FPRINTF(stderr, "dsd_test_mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    char path[DSD_TEST_PATH_MAX];
+    DSD_MEMSET(path, 0, sizeof path);
+    SNDFILE* wav = open_wav_file(dir, path, sizeof path, 8000, 0);
+    rc |= expect_true("close rename nonempty source wav opened", wav != NULL);
+    if (wav) {
+        rc |= expect_true("close rename wrote pcm samples", write_wav_test_samples(wav));
+
+        Event_History_I history;
+        DSD_MEMSET(&history, 0, sizeof history);
+        Event_History* item = &history.Event_History_Items[0];
+        item->event_time = (time_t)1700000000;
+        item->gi = 1;
+        item->source_id = 98765U;
+        item->target_id = 12345U;
+        DSD_SNPRINTF(item->sysid_string, sizeof item->sysid_string, "%s", "SYS-A");
+        DSD_SNPRINTF(item->src_str, sizeof item->src_str, "%s", "SRCUNIT");
+        DSD_SNPRINTF(item->tgt_str, sizeof item->tgt_str, "%s", "TGTUNIT");
+
+        rc |= expect_true("close rename nonempty returns null",
+                          close_and_rename_wav_file(wav, NULL, path, dir, &history) == NULL);
+        rc |= expect_true("close rename nonempty removed temp source", file_size_or_negative(path) < 0);
+
+        char renamed[DSD_TEST_PATH_MAX];
+        rc |= expect_true("close rename nonempty creates event filename",
+                          find_wav_rename_output_for_string_event(renamed, sizeof renamed, dir, item));
+        if (renamed[0] != '\0') {
+            rc |= expect_true("close rename filename has system", strstr(renamed, "SYS-A") != NULL);
+            rc |= expect_true("close rename filename has private tag", strstr(renamed, "_PRIVATE_") != NULL);
+            rc |= expect_true("close rename filename has target string", strstr(renamed, "TGT_TGTUNIT") != NULL);
+            rc |= expect_true("close rename filename has source string", strstr(renamed, "SRC_SRCUNIT") != NULL);
+            rc |= expect_wav_header("close rename final RIFF/WAVE header", renamed);
+            rc |= expect_true("close rename final has audio data", file_size_or_negative(renamed) > 44);
+            (void)remove(renamed);
+        }
+    }
+
+    (void)remove(path);
+    (void)remove_dir(dir);
+    return rc;
+}
+
+static int
+test_close_and_rename_wav_numeric_and_failure_paths(void) {
+    int rc = 0;
+    char dir[DSD_TEST_PATH_MAX];
+    if (!dsd_test_mkdtemp(dir, sizeof dir, "dsdneo_wav_numeric")) {
+        DSD_FPRINTF(stderr, "dsd_test_mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    char path[DSD_TEST_PATH_MAX];
+    DSD_MEMSET(path, 0, sizeof path);
+    SNDFILE* wav = open_wav_file(dir, path, sizeof path, 8000, 0);
+    rc |= expect_true("numeric rename source wav opened", wav != NULL);
+    if (wav) {
+        rc |= expect_true("numeric rename wrote pcm samples", write_wav_test_samples(wav));
+
+        Event_History_I history;
+        DSD_MEMSET(&history, 0, sizeof history);
+        Event_History* item = &history.Event_History_Items[0];
+        item->event_time = (time_t)1700001000;
+        item->gi = 0;
+        item->source_id = 222U;
+        item->target_id = 333U;
+        DSD_SNPRINTF(item->sysid_string, sizeof item->sysid_string, "%s", "SYS-N");
+
+        rc |= expect_true("numeric rename returns null",
+                          close_and_rename_wav_file(wav, NULL, path, dir, &history) == NULL);
+        rc |= expect_true("numeric rename removed temp source", file_size_or_negative(path) < 0);
+
+        char renamed[DSD_TEST_PATH_MAX];
+        rc |= expect_true("numeric rename creates event filename",
+                          find_wav_rename_output_for_numeric_event(renamed, sizeof renamed, dir, item));
+        if (renamed[0] != '\0') {
+            rc |= expect_true("numeric rename filename has system", strstr(renamed, "SYS-N") != NULL);
+            rc |= expect_true("numeric rename filename has group tag", strstr(renamed, "_GROUP_") != NULL);
+            rc |= expect_true("numeric rename filename has target id", strstr(renamed, "TGT_333") != NULL);
+            rc |= expect_true("numeric rename filename has source id", strstr(renamed, "SRC_222") != NULL);
+            rc |= expect_wav_header("numeric rename final RIFF/WAVE header", renamed);
+            rc |= expect_true("numeric rename final has audio data", file_size_or_negative(renamed) > 44);
+            (void)remove(renamed);
+        }
+    }
+
+    char fail_path[DSD_TEST_PATH_MAX];
+    DSD_MEMSET(fail_path, 0, sizeof fail_path);
+    wav = open_wav_file(dir, fail_path, sizeof fail_path, 8000, 0);
+    rc |= expect_true("rename failure source wav opened", wav != NULL);
+    if (wav) {
+        rc |= expect_true("rename failure wrote pcm samples", write_wav_test_samples(wav));
+        char missing_dir[DSD_TEST_PATH_MAX];
+        DSD_SNPRINTF(missing_dir, sizeof missing_dir, "%s%cmissing", dir, dsd_test_path_sep());
+        rc |= expect_true("rename failure returns null",
+                          close_and_rename_wav_file(wav, NULL, fail_path, missing_dir, NULL) == NULL);
+        rc |= expect_true("rename failure keeps original temp wav", file_size_or_negative(fail_path) > 44);
+    }
+
+    (void)remove(path);
+    (void)remove(fail_path);
+    (void)remove_dir(dir);
+    return rc;
+}
+
+static int
+test_close_and_rename_wav_exports_rdio_sidecar(void) {
+    int rc = 0;
+    char dir[DSD_TEST_PATH_MAX];
+    if (!dsd_test_mkdtemp(dir, sizeof dir, "dsdneo_wav_rdio")) {
+        DSD_FPRINTF(stderr, "dsd_test_mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    char path[DSD_TEST_PATH_MAX];
+    DSD_MEMSET(path, 0, sizeof path);
+    SNDFILE* wav = open_wav_file(dir, path, sizeof path, 8000, 0);
+    rc |= expect_true("rdio rename source wav opened", wav != NULL);
+    if (wav) {
+        rc |= expect_true("rdio rename wrote pcm samples", write_wav_test_samples(wav));
+
+        static dsd_opts opts;
+        Event_History_I history;
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&history, 0, sizeof history);
+        opts.rdio_mode = DSD_RDIO_MODE_DIRWATCH;
+        opts.rdio_system_id = 48;
+        opts.rdio_upload_timeout_ms = 5000;
+        opts.rdio_upload_retries = 1;
+
+        Event_History* item = &history.Event_History_Items[0];
+        item->event_time = (time_t)1700002000;
+        item->gi = 0;
+        item->source_id = 660045U;
+        item->target_id = 1201U;
+        item->channel = 851012500U;
+        item->enc = 1;
+        DSD_SNPRINTF(item->sysid_string, sizeof item->sysid_string, "%s", "P25_TEST");
+        DSD_SNPRINTF(item->t_name, sizeof item->t_name, "%s", "FIRE DISP");
+
+        rc |=
+            expect_true("rdio rename returns null", close_and_rename_wav_file(wav, &opts, path, dir, &history) == NULL);
+        rc |= expect_true("rdio rename removed temp source", file_size_or_negative(path) < 0);
+
+        char renamed[DSD_TEST_PATH_MAX];
+        rc |= expect_true("rdio rename creates event filename",
+                          find_wav_rename_output_for_numeric_event(renamed, sizeof renamed, dir, item));
+        if (renamed[0] != '\0') {
+            char sidecar[DSD_TEST_PATH_MAX];
+            char body[4096];
+            if (make_rdio_sidecar_path(renamed, sidecar, sizeof sidecar) != 0
+                || read_file_prefix(sidecar, body, sizeof body) != 0) {
+                rc = 1;
+            } else {
+                rc |= expect_true("rdio sidecar start time", strstr(body, "\"start_time\": 1700002000") != NULL);
+                rc |= expect_true("rdio sidecar talkgroup", strstr(body, "\"talkgroup\": 1201") != NULL);
+                rc |=
+                    expect_true("rdio sidecar talkgroup tag", strstr(body, "\"talkgroup_tag\": \"FIRE DISP\"") != NULL);
+                rc |= expect_true("rdio sidecar source",
+                                  strstr(body, "\"srcList\": [{\"pos\":0,\"src\":660045}]") != NULL);
+                rc |= expect_true("rdio sidecar frequency", strstr(body, "\"freq\": 851012500") != NULL);
+                rc |= expect_true("rdio sidecar system", strstr(body, "\"system\": 48") != NULL);
+                rc |= expect_true("rdio sidecar short name", strstr(body, "\"short_name\": \"P25_TEST\"") != NULL);
+                rc |= expect_true("rdio sidecar encrypted", strstr(body, "\"encrypted\": true") != NULL);
+            }
+            (void)remove(sidecar);
+            (void)remove(renamed);
+        }
+    }
+
+    (void)remove(path);
+    (void)remove_dir(dir);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+
+    rc |= test_imbe_save_read_roundtrip();
+    rc |= test_ambe_save_read_roundtrip_and_slot2();
+    rc |= test_bit_packing_helpers_roundtrip_and_partial_bytes();
+    rc |= test_ambe_pack_unpack_49_bits_roundtrip();
+    rc |= test_parse_raw_user_string_guards_and_bounds();
+    rc |= test_sdrtrunk_json_metadata_protocols_and_time();
+    rc |= test_sdrtrunk_json_encryption_metadata_updates_payload_state();
+    rc |= test_sdrtrunk_json_invalid_numeric_fields_reset_to_zero();
+    rc |= test_sdrtrunk_json_protocol_opens_and_closes_mbe_out_file();
+    rc |= test_sdrtrunk_json_hex_voice_writes_unencrypted_mbe_records();
+    rc |= test_sdrtrunk_json_hex_voice_blocks_encrypted_without_keystream();
+    rc |= test_sdrtrunk_json_encrypted_keystreams_write_voice_records();
+    rc |= test_sdrtrunk_json_dmr_late_entry_updates_mi();
+    rc |= test_open_mbe_out_file_creates_slot_files_and_closes();
+    rc |= test_truncated_reads_fail();
+    rc |= test_open_mbe_in_file_classifies_cookies();
+    rc |= test_symbol_capture_open_writes_expected_headers();
+    rc |= test_symbol_capture_auto_rotation_reopens_and_logs_event();
+    rc |= test_wav_output_helpers_create_temp_and_raw_files();
+    rc |= test_close_and_rename_wav_removes_header_only_files();
+    rc |= test_close_and_rename_wav_preserves_nonempty_event_file();
+    rc |= test_close_and_rename_wav_numeric_and_failure_paths();
+    rc |= test_close_and_rename_wav_exports_rdio_sidecar();
+
+    if (rc == 0) {
+        printf("CORE_MBE_FILE_IO: OK\n");
+    }
+    return rc;
+}
+
+// NOLINTEND(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-optin.performance.Padding,clang-analyzer-unix.Errno,clang-analyzer-unix.Stream)

--- a/tests/core/test_core_mbe_transform_context.c
+++ b/tests/core/test_core_mbe_transform_context.c
@@ -1,14 +1,36 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result,bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-core.CallAndMessage,clang-analyzer-core.uninitialized.Assign)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+#include <dsd-neo/core/file_io.h>
+#include <dsd-neo/core/keyring.h>
+#include <dsd-neo/core/mbe_api.h>
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/core/vocoder.h>
+#include <dsd-neo/crypto/aes.h>
+#include <dsd-neo/crypto/dmr_keystream.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/protocol/nxdn/nxdn_lfsr.h>
+#include <errno.h>
 #include <mbelib.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
 #include "mbe_result_context.h"
+
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void dsd_mbe_init_nxdn_cipher23_keystream(dsd_state* state);
 
 static int
 expect_eq_int(const char* tag, int got, int want) {
@@ -17,6 +39,35 @@ expect_eq_int(const char* tag, int got, int want) {
         return 1;
     }
     return 0;
+}
+
+static int
+expect_eq_size(const char* tag, size_t got, size_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %zu want %zu\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_eq_mem(const char* tag, const void* got, const void* want, size_t size) {
+    if (memcmp(got, want, size) != 0) {
+        DSD_FPRINTF(stderr, "%s: buffers differ\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_any_nonzero_u8(const char* tag, const uint8_t* got, size_t size) {
+    for (size_t i = 0; i < size; i++) {
+        if (got[i] != 0) {
+            return 0;
+        }
+    }
+    DSD_FPRINTF(stderr, "%s: buffer is all zero\n", tag);
+    return 1;
 }
 
 static int
@@ -50,6 +101,104 @@ copy_imbe88(char dst[88], const char src[88]) {
     }
 }
 
+static const char k_p25p1_rc4_expected_imbe[88] = {
+    1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1,
+    0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 1, 1,
+    0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0,
+};
+
+static const char k_p25p1_aes128_expected_imbe[88] = {
+    0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1,
+    1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 1,
+    0, 1, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 0, 0, 1, 0, 1,
+};
+
+static const char k_dmr_rc4_left_expected_ambe[49] = {
+    0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1,
+    0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 0,
+};
+
+static const char k_dmr_rc4_right_expected_ambe[49] = {
+    1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0, 0, 1,
+    0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1,
+};
+
+static void
+pack_imbe88_to_bytes(char imbe_d[88], uint8_t packed[11]) {
+    int bit_index = 0;
+    for (int byte_index = 0; byte_index < 11; byte_index++) {
+        packed[byte_index] = 0;
+        for (int bit = 0; bit < 8; bit++) {
+            packed[byte_index] = (uint8_t)((packed[byte_index] << 1) | (uint8_t)(imbe_d[bit_index] & 1));
+            imbe_d[bit_index++] = 0;
+        }
+    }
+}
+
+static void
+unpack_imbe88_from_bytes(char imbe_d[88], uint8_t packed[11]) {
+    int bit_index = 0;
+    for (int byte_index = 0; byte_index < 11; byte_index++) {
+        for (int bit = 0; bit < 8; bit++) {
+            imbe_d[bit_index++] = (char)((packed[byte_index] & 0x80U) >> 7);
+            packed[byte_index] = (uint8_t)(packed[byte_index] << 1);
+        }
+    }
+}
+
+static void
+load_expected_p25p1_key_slot0(const dsd_state* state, uint8_t aes_key[32]) {
+    for (int i = 0; i < 8; i++) {
+        aes_key[i + 0] = (uint8_t)((state->A1[0] >> (56 - (i * 8))) & 0xFFU);
+        aes_key[i + 8] = (uint8_t)((state->A2[0] >> (56 - (i * 8))) & 0xFFU);
+        aes_key[i + 16] = (uint8_t)((state->A3[0] >> (56 - (i * 8))) & 0xFFU);
+        aes_key[i + 24] = (uint8_t)((state->A4[0] >> (56 - (i * 8))) & 0xFFU);
+    }
+}
+
+static void
+apply_expected_p25p1_aes128(dsd_state* state, char imbe_d[88]) {
+    uint8_t cipher[11] = {0};
+    uint8_t plain[11] = {0};
+    uint8_t aes_key[32] = {0};
+
+    load_expected_p25p1_key_slot0(state, aes_key);
+    if (state->p25vc == 0) {
+        state->octet_counter = 11 + 16;
+        DSD_MEMSET(state->ks_octetL, 0, sizeof(state->ks_octetL));
+        aes_ofb_keystream_output(state->aes_iv, aes_key, state->ks_octetL, 0, 14);
+    }
+
+    pack_imbe88_to_bytes(imbe_d, cipher);
+    for (int i = 0; i < 11; i++) {
+        plain[i] = cipher[i] ^ state->ks_octetL[state->octet_counter++];
+    }
+    unpack_imbe88_from_bytes(imbe_d, plain);
+}
+
+static void
+apply_expected_nxdn_cipher1(dsd_state* state, char ambe_d[49]) {
+    char cipher[49];
+
+    if (state->payload_miN == 0) {
+        state->payload_miN = state->R;
+    }
+    copy_ambe49(cipher, ambe_d);
+    set_bits_zero(ambe_d);
+    LFSRN(cipher, ambe_d, state);
+}
+
+static void
+apply_expected_nxdn_cipher23(dsd_state* state, char ambe_d[49]) {
+    dsd_mbe_init_nxdn_cipher23_keystream(state);
+    if (state->bit_counterL > (1568 - 49)) {
+        state->bit_counterL = (1568 - 49);
+    }
+    for (int i = 0; i < 49; i++) {
+        ambe_d[i] ^= state->ks_bitstreamL[state->bit_counterL++];
+    }
+}
+
 static void
 set_ambe2450_b0(char ambe_d[49], int b0) {
     ambe_d[0] = (char)((b0 >> 6) & 1);
@@ -59,6 +208,27 @@ set_ambe2450_b0(char ambe_d[49], int b0) {
     ambe_d[37] = (char)((b0 >> 2) & 1);
     ambe_d[38] = (char)((b0 >> 1) & 1);
     ambe_d[39] = (char)((b0 >> 0) & 1);
+}
+
+static int
+prepare_active_ambe2450_fixture(char ambe_fr[4][24], char ambe_d[49], int* errs, int* errs2,
+                                mbe_process_result* result) {
+    for (int seed = 1; seed < 96; seed++) {
+        DSD_MEMSET(ambe_fr, 0, 4 * 24 * sizeof(char));
+        DSD_MEMSET(ambe_d, 0, 49 * sizeof(char));
+        ambe_fr[(seed + 0) % 4][(seed * 5 + 3) % 24] = 1;
+        ambe_fr[(seed + 1) % 4][(seed * 7 + 11) % 24] = 1;
+        ambe_fr[(seed + 2) % 4][(seed * 13 + 17) % 24] = 1;
+        ambe_fr[(seed + 3) % 4][(seed * 19 + 23) % 24] = 1;
+
+        *errs = -1;
+        *errs2 = -1;
+        int ret = dsd_mbe_decode_ambe2450_frame(errs, errs2, (const char (*)[24])ambe_fr, ambe_d, result);
+        if (ret >= 0 && dmr_ambe49_should_skip_voice_stream(ambe_d) == 0) {
+            return 0;
+        }
+    }
+    return -1;
 }
 
 static void
@@ -81,10 +251,328 @@ init_imbe_result(mbe_process_result* result, int total_errors, int c0_errors, in
 }
 
 static int
+stored_errs_from_result(const mbe_process_result* result) {
+    return ((result->flags & MBE_PROCESS_FLAG_C0_VALID) != 0u) ? result->c0_errors : result->total_errors;
+}
+
+static int
+expect_result_fields(const char* tag, const mbe_process_result* got, const mbe_process_result* want) {
+    int rc = 0;
+    char subtag[96];
+
+    DSD_SNPRINTF(subtag, sizeof(subtag), "%s-total", tag);
+    rc |= expect_eq_int(subtag, got->total_errors, want->total_errors);
+    DSD_SNPRINTF(subtag, sizeof(subtag), "%s-c0", tag);
+    rc |= expect_eq_int(subtag, got->c0_errors, want->c0_errors);
+    DSD_SNPRINTF(subtag, sizeof(subtag), "%s-c4", tag);
+    rc |= expect_eq_int(subtag, got->c4_errors, want->c4_errors);
+    DSD_SNPRINTF(subtag, sizeof(subtag), "%s-protected", tag);
+    rc |= expect_eq_int(subtag, got->protected_errors, want->protected_errors);
+    DSD_SNPRINTF(subtag, sizeof(subtag), "%s-flags", tag);
+    rc |= expect_eq_int(subtag, (int)got->flags, (int)want->flags);
+
+    return rc;
+}
+
+static int
 result_has_marker(const mbe_process_result* result, char marker) {
     char status[96];
     mbe_formatProcessResult(status, sizeof(status), result);
     return strchr(status, marker) != NULL;
+}
+
+static int
+test_decode_wrappers_store_status_like_mbelib(void) {
+    int rc = 0;
+    int errs;
+    int errs2;
+    char imbe7200_fr[8][23] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+    char ambe2450_fr[4][24] = {{0}};
+    char direct_imbe_d[88] = {0};
+    char wrapper_imbe_d[88] = {0};
+    char direct_ambe_d[49] = {0};
+    char wrapper_ambe_d[49] = {0};
+    mbe_process_result direct_result;
+    mbe_process_result wrapper_result;
+    int direct_ret;
+    int wrapper_ret;
+
+    direct_ret = mbe_decodeImbe7200x4400Frame((const char (*)[23])imbe7200_fr, direct_imbe_d, &direct_result);
+    errs = -1;
+    errs2 = -1;
+    DSD_MEMSET(&wrapper_result, 0xA5, sizeof(wrapper_result));
+    wrapper_ret =
+        dsd_mbe_decode_imbe7200_frame(&errs, &errs2, (const char (*)[23])imbe7200_fr, wrapper_imbe_d, &wrapper_result);
+    rc |= expect_eq_int("imbe7200-ret", wrapper_ret, direct_ret);
+    rc |= expect_eq_int("imbe7200-errs", errs, stored_errs_from_result(&direct_result));
+    rc |= expect_eq_int("imbe7200-errs2", errs2, direct_result.total_errors);
+    rc |= expect_result_fields("imbe7200-result", &wrapper_result, &direct_result);
+    rc |= expect_eq_mem("imbe7200-payload", wrapper_imbe_d, direct_imbe_d, sizeof(wrapper_imbe_d));
+
+    direct_ret = mbe_decodeImbe7100x4400Frame((const char (*)[24])imbe7100_fr, direct_imbe_d, &direct_result);
+    errs = -1;
+    errs2 = -1;
+    DSD_MEMSET(wrapper_imbe_d, 0, sizeof(wrapper_imbe_d));
+    DSD_MEMSET(&wrapper_result, 0xA5, sizeof(wrapper_result));
+    wrapper_ret =
+        dsd_mbe_decode_imbe7100_frame(&errs, &errs2, (const char (*)[24])imbe7100_fr, wrapper_imbe_d, &wrapper_result);
+    rc |= expect_eq_int("imbe7100-ret", wrapper_ret, direct_ret);
+    rc |= expect_eq_int("imbe7100-errs", errs, stored_errs_from_result(&direct_result));
+    rc |= expect_eq_int("imbe7100-errs2", errs2, direct_result.total_errors);
+    rc |= expect_result_fields("imbe7100-result", &wrapper_result, &direct_result);
+    rc |= expect_eq_mem("imbe7100-payload", wrapper_imbe_d, direct_imbe_d, sizeof(wrapper_imbe_d));
+
+    direct_ret = mbe_decodeAmbe3600x2450Frame((const char (*)[24])ambe2450_fr, direct_ambe_d, &direct_result);
+    errs = -1;
+    errs2 = -1;
+    DSD_MEMSET(&wrapper_result, 0xA5, sizeof(wrapper_result));
+    wrapper_ret =
+        dsd_mbe_decode_ambe2450_frame(&errs, &errs2, (const char (*)[24])ambe2450_fr, wrapper_ambe_d, &wrapper_result);
+    rc |= expect_eq_int("ambe2450-ret", wrapper_ret, direct_ret);
+    rc |= expect_eq_int("ambe2450-errs", errs, stored_errs_from_result(&direct_result));
+    rc |= expect_eq_int("ambe2450-errs2", errs2, direct_result.total_errors);
+    rc |= expect_result_fields("ambe2450-result", &wrapper_result, &direct_result);
+    rc |= expect_eq_mem("ambe2450-payload", wrapper_ambe_d, direct_ambe_d, sizeof(wrapper_ambe_d));
+
+    return rc;
+}
+
+static int
+test_process_wrappers_match_direct_mbelib_status(void) {
+    int rc = 0;
+    int direct_errs = 5;
+    int direct_errs2 = 9;
+    int wrapper_errs = 5;
+    int wrapper_errs2 = 9;
+    char ambe_d[49] = {0};
+    char direct_err_str[96] = {0};
+    char wrapper_err_str[96] = {0};
+    float direct_audio[160] = {0};
+    float wrapper_audio[160] = {0};
+    mbe_parms direct_cur = {0};
+    mbe_parms direct_prev = {0};
+    mbe_parms direct_prev_enhanced = {0};
+    mbe_parms wrapper_cur = {0};
+    mbe_parms wrapper_prev = {0};
+    mbe_parms wrapper_prev_enhanced = {0};
+    mbe_process_result direct_result;
+    int direct_ret;
+    int wrapper_ret;
+
+    set_ambe2450_b0(ambe_d, 42);
+    mbe_initMbeParms(&direct_cur, &direct_prev, &direct_prev_enhanced);
+    mbe_initMbeParms(&wrapper_cur, &wrapper_prev, &wrapper_prev_enhanced);
+    dsd_mbe_init_result_from_errors(&direct_result, direct_errs, direct_errs2, 0u);
+
+    direct_ret = mbe_processAmbe2450Dataf(direct_audio, &direct_result, ambe_d, &direct_cur, &direct_prev,
+                                          &direct_prev_enhanced);
+    mbe_formatProcessResult(direct_err_str, sizeof(direct_err_str), &direct_result);
+    wrapper_ret = dsd_mbe_process_ambe2450_dataf(wrapper_audio, &wrapper_errs, &wrapper_errs2, wrapper_err_str,
+                                                 sizeof(wrapper_err_str), ambe_d, &wrapper_cur, &wrapper_prev,
+                                                 &wrapper_prev_enhanced, NULL);
+
+    rc |= expect_eq_int("ambe2450-process-ret", wrapper_ret, direct_ret);
+    rc |= expect_eq_int("ambe2450-process-errs", wrapper_errs, stored_errs_from_result(&direct_result));
+    rc |= expect_eq_int("ambe2450-process-errs2", wrapper_errs2, direct_result.total_errors);
+    rc |= expect_eq_size("ambe2450-process-status-len", strlen(wrapper_err_str), strlen(direct_err_str));
+    rc |= expect_eq_int("ambe2450-process-status-text", strcmp(wrapper_err_str, direct_err_str), 0);
+    rc |= expect_eq_mem("ambe2450-process-audio", wrapper_audio, direct_audio, sizeof(wrapper_audio));
+
+    DSD_MEMSET(direct_audio, 0, sizeof(direct_audio));
+    DSD_MEMSET(wrapper_audio, 0, sizeof(wrapper_audio));
+    DSD_MEMSET(direct_err_str, 0, sizeof(direct_err_str));
+    DSD_MEMSET(wrapper_err_str, 0, sizeof(wrapper_err_str));
+    mbe_initMbeParms(&direct_cur, &direct_prev, &direct_prev_enhanced);
+    mbe_initMbeParms(&wrapper_cur, &wrapper_prev, &wrapper_prev_enhanced);
+    dsd_mbe_init_result_from_errors(&direct_result, direct_errs, direct_errs2, MBE_PROCESS_FLAG_SOFT_INPUT);
+    wrapper_errs = direct_errs;
+    wrapper_errs2 = direct_errs2;
+
+    direct_ret = mbe_processAmbe2400Dataf(direct_audio, &direct_result, ambe_d, &direct_cur, &direct_prev,
+                                          &direct_prev_enhanced);
+    mbe_formatProcessResult(direct_err_str, sizeof(direct_err_str), &direct_result);
+    wrapper_ret = dsd_mbe_process_ambe2400_dataf(wrapper_audio, &wrapper_errs, &wrapper_errs2, wrapper_err_str,
+                                                 sizeof(wrapper_err_str), ambe_d, &wrapper_cur, &wrapper_prev,
+                                                 &wrapper_prev_enhanced, NULL);
+
+    rc |= expect_eq_int("ambe2400-process-ret", wrapper_ret, direct_ret);
+    rc |= expect_eq_int("ambe2400-process-errs", wrapper_errs, stored_errs_from_result(&direct_result));
+    rc |= expect_eq_int("ambe2400-process-errs2", wrapper_errs2, direct_result.total_errors);
+    rc |= expect_eq_size("ambe2400-process-status-len", strlen(wrapper_err_str), strlen(direct_err_str));
+    rc |= expect_eq_int("ambe2400-process-status-text", strcmp(wrapper_err_str, direct_err_str), 0);
+    rc |= expect_eq_mem("ambe2400-process-audio", wrapper_audio, direct_audio, sizeof(wrapper_audio));
+
+    return rc;
+}
+
+static int
+test_process_frame_wrapper_stores_status_and_audio(void) {
+    int rc = 0;
+    int direct_errs;
+    int direct_errs2;
+    int wrapper_errs = -1;
+    int wrapper_errs2 = -1;
+    char ambe_fr[4][24] = {{0}};
+    char direct_ambe_d[49] = {0};
+    char wrapper_ambe_d[49] = {0};
+    char direct_err_str[96] = {0};
+    char wrapper_err_str[96] = {0};
+    float direct_audio[160] = {0};
+    float wrapper_audio[160] = {0};
+    mbe_parms direct_cur = {0};
+    mbe_parms direct_prev = {0};
+    mbe_parms direct_prev_enhanced = {0};
+    mbe_parms wrapper_cur = {0};
+    mbe_parms wrapper_prev = {0};
+    mbe_parms wrapper_prev_enhanced = {0};
+    mbe_process_result direct_result;
+    int direct_ret;
+    int wrapper_ret;
+
+    ambe_fr[0][0] = 1;
+    ambe_fr[1][5] = 1;
+    mbe_initMbeParms(&direct_cur, &direct_prev, &direct_prev_enhanced);
+    mbe_initMbeParms(&wrapper_cur, &wrapper_prev, &wrapper_prev_enhanced);
+
+    direct_ret = mbe_processAmbe3600x2400Framef(direct_audio, &direct_result, (const char (*)[24])ambe_fr,
+                                                direct_ambe_d, &direct_cur, &direct_prev, &direct_prev_enhanced);
+    direct_errs = stored_errs_from_result(&direct_result);
+    direct_errs2 = direct_result.total_errors;
+    mbe_formatProcessResult(direct_err_str, sizeof(direct_err_str), &direct_result);
+
+    wrapper_ret = dsd_mbe_process_ambe3600x2400_framef(wrapper_audio, &wrapper_errs, &wrapper_errs2, wrapper_err_str,
+                                                       sizeof(wrapper_err_str), ambe_fr, wrapper_ambe_d, &wrapper_cur,
+                                                       &wrapper_prev, &wrapper_prev_enhanced);
+
+    rc |= expect_eq_int("ambe3600x2400-ret", wrapper_ret, direct_ret);
+    rc |= expect_eq_int("ambe3600x2400-errs", wrapper_errs, direct_errs);
+    rc |= expect_eq_int("ambe3600x2400-errs2", wrapper_errs2, direct_errs2);
+    rc |= expect_eq_int("ambe3600x2400-status-text", strcmp(wrapper_err_str, direct_err_str), 0);
+    rc |= expect_eq_mem("ambe3600x2400-payload", wrapper_ambe_d, direct_ambe_d, sizeof(wrapper_ambe_d));
+    rc |= expect_eq_mem("ambe3600x2400-audio", wrapper_audio, direct_audio, sizeof(wrapper_audio));
+
+    return rc;
+}
+
+static int
+test_keyring_tracks_aes_segment_metadata(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    const int slot0_zero_key = 0x1200;
+    const int slot1_zero_key = 0x1300;
+    const int slot1_fallback_key = 0x1400;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    state.payload_keyid = slot0_zero_key;
+    state.rkey_array_loaded[slot0_zero_key] = 1U;
+    state.rkey_array_loaded[slot0_zero_key + 0x101] = 1U;
+    state.rkey_array_loaded[slot0_zero_key + 0x201] = 1U;
+    state.rkey_array_loaded[slot0_zero_key + 0x301] = 1U;
+
+    keyring(&opts, &state);
+
+    rc |= expect_eq_int("keyring-slot0-zero-base", (int)state.R, 0);
+    rc |= expect_eq_int("keyring-slot0-zero-a1", (int)state.A1[0], 0);
+    rc |= expect_eq_int("keyring-slot0-zero-a2", (int)state.A2[0], 0);
+    rc |= expect_eq_int("keyring-slot0-zero-a3", (int)state.A3[0], 0);
+    rc |= expect_eq_int("keyring-slot0-zero-a4", (int)state.A4[0], 0);
+    rc |= expect_eq_int("keyring-slot0-zero-present-count", state.aes_key_segments[0], 4);
+    rc |= expect_eq_int("keyring-slot0-zero-not-loaded", state.aes_key_loaded[0], 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 1;
+    state.payload_keyidR = slot1_zero_key;
+    state.rkey_array_loaded[slot1_zero_key] = 1U;
+    state.rkey_array_loaded[slot1_zero_key + 0x101] = 1U;
+    state.rkey_array_loaded[slot1_zero_key + 0x201] = 1U;
+    state.rkey_array_loaded[slot1_zero_key + 0x301] = 1U;
+
+    keyring(&opts, &state);
+
+    rc |= expect_eq_int("keyring-slot1-zero-base", (int)state.RR, 0);
+    rc |= expect_eq_int("keyring-slot1-zero-a1", (int)state.A1[1], 0);
+    rc |= expect_eq_int("keyring-slot1-zero-a2", (int)state.A2[1], 0);
+    rc |= expect_eq_int("keyring-slot1-zero-a3", (int)state.A3[1], 0);
+    rc |= expect_eq_int("keyring-slot1-zero-a4", (int)state.A4[1], 0);
+    rc |= expect_eq_int("keyring-slot1-zero-present-count", state.aes_key_segments[1], 4);
+    rc |= expect_eq_int("keyring-slot1-zero-not-loaded", state.aes_key_loaded[1], 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 1;
+    state.payload_keyidR = slot1_fallback_key;
+    state.rkey_array[slot1_fallback_key + 0x101] = 0x111ULL;
+    state.rkey_array[slot1_fallback_key + 0x301] = 0x222ULL;
+
+    keyring(&opts, &state);
+
+    rc |= expect_eq_int("keyring-slot1-fallback-base", (int)state.RR, 0);
+    rc |= expect_eq_int("keyring-slot1-fallback-a1", (int)state.A1[1], 0);
+    rc |= expect_eq_int("keyring-slot1-fallback-a2", (int)state.A2[1], 0x111);
+    rc |= expect_eq_int("keyring-slot1-fallback-a3", (int)state.A3[1], 0);
+    rc |= expect_eq_int("keyring-slot1-fallback-a4", (int)state.A4[1], 0x222);
+    rc |= expect_eq_int("keyring-slot1-fallback-nonzero-count", state.aes_key_segments[1], 2);
+    rc |= expect_eq_int("keyring-slot1-fallback-loaded", state.aes_key_loaded[1], 1);
+
+    return rc;
+}
+
+static int
+test_public_result_helpers_normalize_error_counts(void) {
+    int rc = 0;
+    mbe_process_result result;
+
+    dsd_mbe_init_result_from_errors(NULL, 1, 2, MBE_PROCESS_FLAG_C0_VALID);
+
+    dsd_mbe_init_result_from_errors(&result, 6, 2, MBE_PROCESS_FLAG_C0_VALID | MBE_PROCESS_FLAG_SOFT_INPUT);
+    rc |= expect_eq_int("result-c0-errors", result.c0_errors, 6);
+    rc |= expect_eq_int("result-total-clamped", result.total_errors, 6);
+    rc |= expect_eq_int("result-protected-clamped", result.protected_errors, 0);
+    rc |= expect_flag("result-c0-valid", result.flags, MBE_PROCESS_FLAG_C0_VALID, 1);
+    rc |= expect_flag("result-soft-input", result.flags, MBE_PROCESS_FLAG_SOFT_INPUT, 1);
+
+    dsd_mbe_init_result_from_errors(&result, -4, -1, 0u);
+    rc |= expect_eq_int("result-negative-total", result.total_errors, 0);
+    rc |= expect_eq_int("result-negative-c0", result.c0_errors, 0);
+    rc |= expect_eq_int("result-negative-protected", result.protected_errors, 0);
+    rc |= expect_flag("result-negative-c0-valid", result.flags, MBE_PROCESS_FLAG_C0_VALID, 0);
+
+    return rc;
+}
+
+static int
+test_public_store_result_uses_c0_when_valid(void) {
+    int rc = 0;
+    int errs = -1;
+    int errs2 = -1;
+    char err_str[96] = {0};
+    mbe_process_result result;
+
+    init_result(&result, 9, 3, MBE_PROCESS_FLAG_C0_VALID | MBE_PROCESS_FLAG_REPEAT);
+    dsd_mbe_store_result(&errs, &errs2, err_str, sizeof err_str, &result);
+    rc |= expect_eq_int("store-c0-errs", errs, 3);
+    rc |= expect_eq_int("store-c0-total", errs2, 9);
+    rc |= expect_eq_int("store-c0-repeat-marker", strchr(err_str, 'R') != NULL, 1);
+
+    errs = -1;
+    errs2 = -1;
+    err_str[0] = 'x';
+    init_result(&result, 7, 2, MBE_PROCESS_FLAG_TONE);
+    dsd_mbe_store_result(&errs, &errs2, err_str, 1, &result);
+    rc |= expect_eq_int("store-total-errs", errs, 7);
+    rc |= expect_eq_int("store-total-errs2", errs2, 7);
+    rc |= expect_eq_int("store-size-one-nul", err_str[0], '\0');
+
+    dsd_mbe_store_result(&errs, &errs2, err_str, sizeof err_str, NULL);
+    rc |= expect_eq_int("store-null-errs-unchanged", errs, 7);
+    rc |= expect_eq_int("store-null-errs2-unchanged", errs2, 7);
+
+    dsd_mbe_store_result(NULL, NULL, NULL, 0, &result);
+
+    return rc;
 }
 
 static int
@@ -255,10 +743,1517 @@ test_changed_frame_restores_total_error_repeat_fallback(void) {
     return rc;
 }
 
+static void
+init_soft_mbe_state(dsd_state* state, mbe_parms* cur, mbe_parms* prev, mbe_parms* prev_enhanced, mbe_parms* cur2,
+                    mbe_parms* prev2, mbe_parms* prev_enhanced2) {
+    DSD_MEMSET(state, 0, sizeof(*state));
+    mbe_initMbeParms(cur, prev, prev_enhanced);
+    mbe_initMbeParms(cur2, prev2, prev_enhanced2);
+    state->cur_mp = cur;
+    state->prev_mp = prev;
+    state->prev_mp_enhanced = prev_enhanced;
+    state->cur_mp2 = cur2;
+    state->prev_mp2 = prev2;
+    state->prev_mp_enhanced2 = prev_enhanced2;
+}
+
+static int
+create_playback_temp(char* path, size_t path_size, const char* prefix) {
+    int n = DSD_SNPRINTF(path, path_size, "./%s_XXXXXX", prefix);
+    if (n < 0 || (size_t)n >= path_size) {
+        return -1;
+    }
+    return dsd_mkstemp(path);
+}
+
+static int
+create_mbe_playback_file(char* path, size_t path_size, const char cookie[4],
+                         void (*save_fn)(dsd_opts*, const dsd_state*, const char*), const char* bits, int errs2,
+                         const char* prefix) {
+    int fd = create_playback_temp(path, path_size, prefix);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "dsd_mkstemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+    FILE* f = fdopen(fd, "wb");
+    if (!f) {
+        DSD_FPRINTF(stderr, "fdopen failed: %s\n", strerror(errno));
+        dsd_close(fd);
+        (void)remove(path);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.errs2 = errs2;
+    opts.mbe_out_f = f;
+
+    int rc = 0;
+    if (fwrite(cookie, 1, 4, f) != 4) {
+        DSD_FPRINTF(stderr, "fwrite cookie failed: %s\n", strerror(errno));
+        rc = 1;
+    } else {
+        save_fn(&opts, &state, bits);
+        rc |= expect_eq_int("mbe-playback-fixture-flush", fflush(f), 0);
+    }
+
+    fclose(f);
+    opts.mbe_out_f = NULL;
+    if (rc != 0) {
+        (void)remove(path);
+    }
+    return rc;
+}
+
+static int
+test_play_mbe_files_processes_imbe_ambe_and_dstar_records(void) {
+    int rc = 0;
+    char imbe_path[1024];
+    char amb_path[1024];
+    char dmb_path[1024];
+    char imbe_bits[88] = {0};
+    char ambe_bits[49] = {0};
+
+    for (int i = 0; i < 88; i++) {
+        imbe_bits[i] = (char)(((i * 5) + 1) & 1);
+    }
+    for (int i = 0; i < 49; i++) {
+        ambe_bits[i] = (char)(((i * 7) + 3) & 1);
+    }
+
+    rc |= create_mbe_playback_file(imbe_path, sizeof imbe_path, ".imb", saveImbe4400Data, imbe_bits, 0x12,
+                                   "mbe_play_imb");
+    rc |=
+        create_mbe_playback_file(amb_path, sizeof amb_path, ".amb", saveAmbe2450Data, ambe_bits, 0x23, "mbe_play_amb");
+    rc |=
+        create_mbe_playback_file(dmb_path, sizeof dmb_path, ".dmb", saveAmbe2450Data, ambe_bits, 0x34, "mbe_play_dmb");
+    if (rc != 0) {
+        return rc;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.optind = 1;
+    state.synctype = DSD_SYNC_P25P1_POS;
+
+    char* imbe_argv[] = {"dsd-neo", imbe_path};
+    playMbeFiles(&opts, &state, 2, imbe_argv);
+
+    rc |= expect_eq_int("play-imbe-file-closed", opts.mbe_in_f == NULL, 1);
+    rc |= expect_eq_int("play-imbe-type", state.mbe_file_type, 0);
+    rc |= expect_eq_int("play-imbe-path", strcmp(opts.mbe_in_file, imbe_path), 0);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.optind = 1;
+
+    char* amb_argv[] = {"dsd-neo", amb_path};
+    playMbeFiles(&opts, &state, 2, amb_argv);
+
+    rc |= expect_eq_int("play-amb-file-closed", opts.mbe_in_f == NULL, 1);
+    rc |= expect_eq_int("play-amb-type", state.mbe_file_type, 1);
+    rc |= expect_eq_int("play-amb-path", strcmp(opts.mbe_in_file, amb_path), 0);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.optind = 1;
+
+    char* dmb_argv[] = {"dsd-neo", dmb_path};
+    playMbeFiles(&opts, &state, 2, dmb_argv);
+
+    rc |= expect_eq_int("play-dmb-file-closed", opts.mbe_in_f == NULL, 1);
+    rc |= expect_eq_int("play-dmb-type", state.mbe_file_type, 2);
+    rc |= expect_eq_int("play-dmb-path", strcmp(opts.mbe_in_file, dmb_path), 0);
+
+    (void)remove(imbe_path);
+    (void)remove(amb_path);
+    (void)remove(dmb_path);
+    return rc;
+}
+
+static void
+fill_imbe7200_soft_frame(dsd_vocoder_soft_bit frame[8][23]) {
+    for (int row = 0; row < 8; row++) {
+        for (int bit = 0; bit < 23; bit++) {
+            frame[row][bit].bit = (uint8_t)(((row * 7) + bit) & 1);
+            frame[row][bit].reliability = (uint8_t)(80 + ((row + bit) % 40));
+        }
+    }
+}
+
+static void
+fill_ambe2450_soft_frame(dsd_vocoder_soft_bit frame[4][24]) {
+    for (int row = 0; row < 4; row++) {
+        for (int bit = 0; bit < 24; bit++) {
+            frame[row][bit].bit = (uint8_t)(((row * 5) + bit + 1) & 1);
+            frame[row][bit].reliability = (uint8_t)(90 + ((row * 3 + bit) % 50));
+        }
+    }
+}
+
+static void
+copy_imbe7200_soft_to_mbelib(const dsd_vocoder_soft_bit src[8][23], mbe_soft_bit dst[8][23]) {
+    for (int row = 0; row < 8; row++) {
+        for (int bit = 0; bit < 23; bit++) {
+            dst[row][bit].bit = src[row][bit].bit;
+            dst[row][bit].reliability = src[row][bit].reliability;
+        }
+    }
+}
+
+static void
+copy_ambe2450_soft_to_mbelib(const dsd_vocoder_soft_bit src[4][24], mbe_soft_bit dst[4][24]) {
+    for (int row = 0; row < 4; row++) {
+        for (int bit = 0; bit < 24; bit++) {
+            dst[row][bit].bit = src[row][bit].bit;
+            dst[row][bit].reliability = src[row][bit].reliability;
+        }
+    }
+}
+
+static int
+test_soft_mbe_p25p1_updates_error_history(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char imbe_d[88] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    int decoded_errs2 = -1;
+    mbe_process_result result;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    int ret =
+        dsd_mbe_decode_imbe7200_frame(&expected_errs, &expected_errs2, (const char (*)[23])imbe_fr, imbe_d, &result);
+    rc |= expect_eq_int("soft-p25 fixture decodes", ret >= 0, 1);
+    decoded_errs2 = expected_errs2;
+    if (ret >= 0) {
+        mbe_initMbeParms(&cur, &prev, &prev_enhanced);
+        ret = dsd_mbe_process_imbe4400_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), imbe_d, &cur, &prev, &prev_enhanced, &result);
+        rc |= expect_eq_int("soft-p25 fixture processes", ret >= 0, 1);
+    }
+
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_P25P1_POS;
+    soft_mbe(&opts, &state, imbe_fr, NULL, NULL);
+
+    rc |= expect_eq_int("soft-p25 errs", state.errs, expected_errs);
+    rc |= expect_eq_int("soft-p25 errs2", state.errs2, expected_errs2);
+    rc |= expect_eq_int("soft-p25 debug errors", state.debug_audio_errors, decoded_errs2);
+    rc |= expect_eq_int("soft-p25 history length", state.p25_p1_voice_err_hist_len, 50);
+    rc |= expect_eq_int("soft-p25 history position", state.p25_p1_voice_err_hist_pos, 1);
+    rc |= expect_eq_int("soft-p25 history value", state.p25_p1_voice_err_hist[0], state.errs2 & 0xFF);
+    rc |= expect_eq_int("soft-p25 history sum", (int)state.p25_p1_voice_err_hist_sum, state.errs2 & 0xFF);
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_soft_p25p1_copies_soft_imbe_audio(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    dsd_vocoder_soft_bit imbe_soft[8][23];
+    mbe_soft_bit direct_soft[8][23];
+    char imbe_d[88] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    mbe_process_result result;
+
+    fill_imbe7200_soft_frame(imbe_soft);
+    copy_imbe7200_soft_to_mbelib((const dsd_vocoder_soft_bit(*)[23])imbe_soft, direct_soft);
+
+    int ret = mbe_decodeImbe7200x4400SoftFrame((const mbe_soft_bit(*)[23])direct_soft, imbe_d, &result);
+    rc |= expect_eq_int("frame-soft-p25 decode", ret >= 0, 1);
+    if (ret >= 0) {
+        expected_errs = stored_errs_from_result(&result);
+        expected_errs2 = result.total_errors;
+        mbe_initMbeParms(&cur, &prev, &prev_enhanced);
+        ret = dsd_mbe_process_imbe4400_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), imbe_d, &cur, &prev, &prev_enhanced, &result);
+        rc |= expect_eq_int("frame-soft-p25 process", ret >= 0, 1);
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_P25P1_POS;
+
+    processMbeFrameSoft(&opts, &state, imbe_soft, NULL, NULL);
+
+    rc |= expect_eq_int("frame-soft-p25 errs", state.errs, expected_errs);
+    rc |= expect_eq_int("frame-soft-p25 errs2", state.errs2, expected_errs2);
+    rc |= expect_eq_int("frame-soft-p25 status", strcmp(state.err_str, expected_err_str), 0);
+    rc |= expect_eq_mem("frame-soft-p25 temp audio", state.audio_out_temp_buf, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_mem("frame-soft-p25 staged left", state.f_l, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_int("frame-soft-p25 vc", state.p25vc, 1);
+    rc |= expect_eq_int("frame-soft-p25 history len", state.p25_p1_voice_err_hist_len, 50);
+    rc |= expect_eq_int("frame-soft-p25 history pos", state.p25_p1_voice_err_hist_pos, 1);
+    rc |= expect_eq_int("frame-soft-p25 history sum", (int)state.p25_p1_voice_err_hist_sum, state.errs2 & 0xFF);
+    rc |= expect_eq_int("frame-soft-p25 debug errors", state.debug_audio_errors, state.errs2);
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_soft_nxdn_copies_soft_ambe_audio(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    dsd_vocoder_soft_bit ambe_soft[4][24];
+    mbe_soft_bit direct_soft[4][24];
+    char ambe_d[49] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    mbe_process_result result;
+
+    fill_ambe2450_soft_frame(ambe_soft);
+    copy_ambe2450_soft_to_mbelib((const dsd_vocoder_soft_bit(*)[24])ambe_soft, direct_soft);
+
+    int ret = mbe_decodeAmbe3600x2450SoftFrame((const mbe_soft_bit(*)[24])direct_soft, ambe_d, &result);
+    rc |= expect_eq_int("frame-soft-nxdn decode", ret >= 0, 1);
+    if (ret >= 0) {
+        expected_errs = stored_errs_from_result(&result);
+        expected_errs2 = result.total_errors;
+        mbe_initMbeParms(&cur, &prev, &prev_enhanced);
+        ret = dsd_mbe_process_ambe2450_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), ambe_d, &cur, &prev, &prev_enhanced, &result);
+        rc |= expect_eq_int("frame-soft-nxdn process", ret >= 0, 1);
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_NXDN_POS;
+
+    processMbeFrameSoft(&opts, &state, NULL, ambe_soft, NULL);
+
+    rc |= expect_eq_int("frame-soft-nxdn errs", state.errs, expected_errs);
+    rc |= expect_eq_int("frame-soft-nxdn errs2", state.errs2, expected_errs2);
+    rc |= expect_eq_int("frame-soft-nxdn status", strcmp(state.err_str, expected_err_str), 0);
+    rc |= expect_eq_mem("frame-soft-nxdn temp audio", state.audio_out_temp_buf, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_mem("frame-soft-nxdn staged left", state.f_l, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_int("frame-soft-nxdn no p25 history", state.p25_p1_voice_err_hist_len, 0);
+    rc |= expect_eq_int("frame-soft-nxdn debug errors", state.debug_audio_errors, state.errs2);
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_p25p1_rc4_transforms_imbe_payload(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static dsd_state expected_state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+    char decoded_imbe_d[88] = {0};
+    char expected_imbe_d[88] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    mbe_process_result result;
+
+    imbe_fr[0][2] = 1;
+    imbe_fr[2][7] = 1;
+    imbe_fr[5][13] = 1;
+
+    int ret = dsd_mbe_decode_imbe7200_frame(&expected_errs, &expected_errs2, (const char (*)[23])imbe_fr,
+                                            decoded_imbe_d, &result);
+    rc |= expect_eq_int("p25p1-rc4 fixture decodes", ret >= 0, 1);
+    if (ret >= 0) {
+        copy_imbe88(expected_imbe_d, k_p25p1_rc4_expected_imbe);
+        DSD_MEMSET(&expected_state, 0, sizeof(expected_state));
+        expected_state.dropL = 16;
+        rc |= expect_eq_int("p25p1-rc4 drop", expected_state.dropL, 16);
+        rc |= expect_eq_int("p25p1-rc4 transformed",
+                            memcmp(expected_imbe_d, decoded_imbe_d, sizeof(expected_imbe_d)) != 0, 1);
+
+        (void)dsd_mbe_strip_imbe_context_if_changed(decoded_imbe_d, expected_imbe_d, &result);
+        mbe_initMbeParms(&cur, &prev, &prev_enhanced);
+        ret = dsd_mbe_process_imbe4400_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), expected_imbe_d, &cur, &prev, &prev_enhanced,
+                                             &result);
+        rc |= expect_eq_int("p25p1-rc4 fixture processes", ret >= 0, 1);
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_P25P1_POS;
+    state.payload_algid = 0xAA;
+    state.R = 0x0102030405ULL;
+    state.payload_miP = 0x1122334455667788ULL;
+    state.dropL = 5;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("p25p1-rc4 state drop", state.dropL, 16);
+    rc |= expect_eq_int("p25p1-rc4 vc", state.p25vc, 1);
+    rc |= expect_eq_int("p25p1-rc4 errs", state.errs, expected_errs);
+    rc |= expect_eq_int("p25p1-rc4 errs2", state.errs2, expected_errs2);
+    rc |= expect_eq_int("p25p1-rc4 status", strcmp(state.err_str, expected_err_str), 0);
+    rc |= expect_eq_mem("p25p1-rc4 temp audio", state.audio_out_temp_buf, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_mem("p25p1-rc4 staged left", state.f_l, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_int("p25p1-rc4 history len", state.p25_p1_voice_err_hist_len, 50);
+    rc |= expect_eq_int("p25p1-rc4 history pos", state.p25_p1_voice_err_hist_pos, 1);
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_p25p1_multicrypt_transforms_imbe_payload(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static dsd_state expected_state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+    char decoded_imbe_d[88] = {0};
+    char expected_imbe_d[88] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    mbe_process_result result;
+
+    imbe_fr[0][3] = 1;
+    imbe_fr[3][8] = 1;
+    imbe_fr[6][17] = 1;
+
+    // First build an independent AES128 oracle from the decoded IMBE bits so
+    // the processMbeFrame assertions do not mirror production side effects.
+    int ret = dsd_mbe_decode_imbe7200_frame(&expected_errs, &expected_errs2, (const char (*)[23])imbe_fr,
+                                            decoded_imbe_d, &result);
+    rc |= expect_eq_int("p25p1-multicrypt fixture decodes", ret >= 0, 1);
+    if (ret >= 0) {
+        copy_imbe88(expected_imbe_d, decoded_imbe_d);
+        DSD_MEMSET(&expected_state, 0, sizeof(expected_state));
+        expected_state.payload_algid = 0x89;
+        expected_state.aes_key_loaded[0] = 1;
+        expected_state.A1[0] = 0x0011223344556677ULL;
+        expected_state.A2[0] = 0x8899AABBCCDDEEFFULL;
+        expected_state.A3[0] = 0x1021324354657687ULL;
+        expected_state.A4[0] = 0x98A9BACBDCEDFE0FULL;
+        expected_state.aes_iv[0] = 0xA5;
+        expected_state.aes_iv[15] = 0x5A;
+        apply_expected_p25p1_aes128(&expected_state, expected_imbe_d);
+        rc |= expect_eq_mem("p25p1-multicrypt aes128 vector", expected_imbe_d, k_p25p1_aes128_expected_imbe,
+                            sizeof(expected_imbe_d));
+        rc |= expect_eq_int("p25p1-multicrypt aes128 counter", expected_state.octet_counter, 38);
+        rc |= expect_any_nonzero_u8("p25p1-multicrypt aes128 keystream", expected_state.ks_octetL,
+                                    sizeof(expected_state.ks_octetL));
+        rc |= expect_eq_int("p25p1-multicrypt aes128 transformed",
+                            memcmp(expected_imbe_d, decoded_imbe_d, sizeof(expected_imbe_d)) != 0, 1);
+
+        (void)dsd_mbe_strip_imbe_context_if_changed(decoded_imbe_d, expected_imbe_d, &result);
+        mbe_initMbeParms(&cur, &prev, &prev_enhanced);
+        ret = dsd_mbe_process_imbe4400_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), expected_imbe_d, &cur, &prev, &prev_enhanced,
+                                             &result);
+        rc |= expect_eq_int("p25p1-multicrypt aes128 fixture processes", ret >= 0, 1);
+    }
+
+    // Run the full P25p1 AES128 path and compare counters, keystream emission,
+    // vocoder status, and staged float audio against the oracle above.
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_P25P1_POS;
+    state.payload_algid = 0x89;
+    state.aes_key_loaded[0] = 1;
+    state.A1[0] = expected_state.A1[0];
+    state.A2[0] = expected_state.A2[0];
+    state.A3[0] = expected_state.A3[0];
+    state.A4[0] = expected_state.A4[0];
+    state.aes_iv[0] = expected_state.aes_iv[0];
+    state.aes_iv[15] = expected_state.aes_iv[15];
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("p25p1-multicrypt aes128 state counter", state.octet_counter, expected_state.octet_counter);
+    rc |= expect_eq_int("p25p1-multicrypt aes128 vc", state.p25vc, 1);
+    rc |= expect_any_nonzero_u8("p25p1-multicrypt aes128 state keystream", state.ks_octetL, sizeof(state.ks_octetL));
+    rc |= expect_eq_int("p25p1-multicrypt aes128 errs", state.errs, expected_errs);
+    rc |= expect_eq_int("p25p1-multicrypt aes128 errs2", state.errs2, expected_errs2);
+    rc |= expect_eq_int("p25p1-multicrypt aes128 status", strcmp(state.err_str, expected_err_str), 0);
+    rc |= expect_eq_mem("p25p1-multicrypt aes128 temp audio", state.audio_out_temp_buf, expected_audio,
+                        sizeof(expected_audio));
+    rc |= expect_eq_mem("p25p1-multicrypt aes128 staged left", state.f_l, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_int("p25p1-multicrypt aes128 history len", state.p25_p1_voice_err_hist_len, 50);
+    rc |= expect_eq_int("p25p1-multicrypt aes128 history pos", state.p25_p1_voice_err_hist_pos, 1);
+
+    // DES-XL shares the P25p1 IMBE transform entry point but has a distinct
+    // MI/key schedule and octet counter progression, so keep it in this fixture.
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_P25P1_POS;
+    state.payload_algid = 0x9F;
+    state.R = 0x0102030405ULL;
+    state.payload_miP = 0x1122334455667788ULL;
+    state.xl_is_hdu = 1;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("p25p1-multicrypt desxl counter", state.octet_counter, 22);
+    rc |= expect_eq_int("p25p1-multicrypt desxl vc", state.p25vc, 1);
+    rc |= expect_any_nonzero_u8("p25p1-multicrypt desxl keystream", state.ks_octetL, sizeof(state.ks_octetL));
+    rc |= expect_eq_mem("p25p1-multicrypt desxl staged left", state.f_l, state.audio_out_temp_buf, sizeof(state.f_l));
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_nxdn_cipher1_transforms_ambe_payload(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static dsd_state expected_state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+    char decoded_ambe_d[49] = {0};
+    char expected_ambe_d[49] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    mbe_process_result result;
+
+    ambe_fr[0][3] = 1;
+    ambe_fr[1][11] = 1;
+    ambe_fr[3][19] = 1;
+
+    int ret = dsd_mbe_decode_ambe2450_frame(&expected_errs, &expected_errs2, (const char (*)[24])ambe_fr,
+                                            decoded_ambe_d, &result);
+    rc |= expect_eq_int("nxdn-cipher1 fixture decodes", ret >= 0, 1);
+    if (ret >= 0) {
+        copy_ambe49(expected_ambe_d, decoded_ambe_d);
+        DSD_MEMSET(&expected_state, 0, sizeof(expected_state));
+        expected_state.R = 0x12345ULL;
+        apply_expected_nxdn_cipher1(&expected_state, expected_ambe_d);
+        rc |= expect_eq_int("nxdn-cipher1 advances mi", (int)expected_state.payload_miN, 0x0EE5);
+        rc |= expect_eq_int("nxdn-cipher1 transformed",
+                            memcmp(expected_ambe_d, decoded_ambe_d, sizeof(expected_ambe_d)) != 0, 1);
+
+        (void)dsd_mbe_strip_ambe_context_if_changed(decoded_ambe_d, expected_ambe_d, &result);
+        mbe_initMbeParms(&cur, &prev, &prev_enhanced);
+        ret = dsd_mbe_process_ambe2450_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), expected_ambe_d, &cur, &prev, &prev_enhanced,
+                                             &result);
+        rc |= expect_eq_int("nxdn-cipher1 fixture processes", ret >= 0, 1);
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_NXDN_POS;
+    state.nxdn_cipher_type = 0x01;
+    state.R = 0x12345ULL;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("nxdn-cipher1 state mi", (int)state.payload_miN, (int)expected_state.payload_miN);
+    rc |= expect_eq_int("nxdn-cipher1 errs", state.errs, expected_errs);
+    rc |= expect_eq_int("nxdn-cipher1 errs2", state.errs2, expected_errs2);
+    rc |= expect_eq_int("nxdn-cipher1 status", strcmp(state.err_str, expected_err_str), 0);
+    rc |= expect_eq_mem("nxdn-cipher1 temp audio", state.audio_out_temp_buf, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_mem("nxdn-cipher1 staged left", state.f_l, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_int("nxdn-cipher1 no p25 history", state.p25_p1_voice_err_hist_len, 0);
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_nxdn_cipher2_initializes_and_advances_keystream(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static dsd_state expected_state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+    char decoded_ambe_d[49] = {0};
+    char expected_ambe_d[49] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    mbe_process_result result;
+
+    ambe_fr[0][4] = 1;
+    ambe_fr[2][13] = 1;
+    ambe_fr[3][20] = 1;
+
+    int ret = dsd_mbe_decode_ambe2450_frame(&expected_errs, &expected_errs2, (const char (*)[24])ambe_fr,
+                                            decoded_ambe_d, &result);
+    rc |= expect_eq_int("nxdn-cipher2 fixture decodes", ret >= 0, 1);
+    if (ret >= 0) {
+        copy_ambe49(expected_ambe_d, decoded_ambe_d);
+        DSD_MEMSET(&expected_state, 0, sizeof(expected_state));
+        expected_state.nxdn_cipher_type = 0x02;
+        expected_state.nxdn_new_iv = 1;
+        expected_state.R = 0x0102030405ULL;
+        expected_state.payload_miN = 0x1122334455667788ULL;
+        apply_expected_nxdn_cipher23(&expected_state, expected_ambe_d);
+        rc |= expect_eq_int("nxdn-cipher2 clears new-iv", expected_state.nxdn_new_iv, 0);
+        rc |= expect_eq_int("nxdn-cipher2 advances bits", expected_state.bit_counterL, 49);
+        rc |= expect_any_nonzero_u8("nxdn-cipher2 keystream", expected_state.ks_bitstreamL,
+                                    sizeof(expected_state.ks_bitstreamL));
+        rc |= expect_eq_int("nxdn-cipher2 transformed",
+                            memcmp(expected_ambe_d, decoded_ambe_d, sizeof(expected_ambe_d)) != 0, 1);
+
+        (void)dsd_mbe_strip_ambe_context_if_changed(decoded_ambe_d, expected_ambe_d, &result);
+        mbe_initMbeParms(&cur, &prev, &prev_enhanced);
+        ret = dsd_mbe_process_ambe2450_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), expected_ambe_d, &cur, &prev, &prev_enhanced,
+                                             &result);
+        rc |= expect_eq_int("nxdn-cipher2 fixture processes", ret >= 0, 1);
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_NXDN_POS;
+    state.nxdn_cipher_type = 0x02;
+    state.nxdn_new_iv = 1;
+    state.R = 0x0102030405ULL;
+    state.payload_miN = 0x1122334455667788ULL;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("nxdn-cipher2 state new-iv", state.nxdn_new_iv, 0);
+    rc |= expect_eq_int("nxdn-cipher2 state bit-counter", state.bit_counterL, expected_state.bit_counterL);
+    rc |= expect_any_nonzero_u8("nxdn-cipher2 state keystream", state.ks_bitstreamL, sizeof(state.ks_bitstreamL));
+    rc |= expect_eq_int("nxdn-cipher2 errs", state.errs, expected_errs);
+    rc |= expect_eq_int("nxdn-cipher2 errs2", state.errs2, expected_errs2);
+    rc |= expect_eq_int("nxdn-cipher2 status", strcmp(state.err_str, expected_err_str), 0);
+    rc |= expect_eq_mem("nxdn-cipher2 temp audio", state.audio_out_temp_buf, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_mem("nxdn-cipher2 staged left", state.f_l, expected_audio, sizeof(expected_audio));
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_nxdn_cipher2_clamps_stale_bit_counter(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static dsd_state expected_state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+    char decoded_ambe_d[49] = {0};
+    char expected_ambe_d[49] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    mbe_process_result result;
+
+    ambe_fr[0][9] = 1;
+    ambe_fr[1][18] = 1;
+    ambe_fr[3][5] = 1;
+
+    int ret = dsd_mbe_decode_ambe2450_frame(&expected_errs, &expected_errs2, (const char (*)[24])ambe_fr,
+                                            decoded_ambe_d, &result);
+    rc |= expect_eq_int("nxdn-cipher2-clamp fixture decodes", ret >= 0, 1);
+    if (ret >= 0) {
+        copy_ambe49(expected_ambe_d, decoded_ambe_d);
+        DSD_MEMSET(&expected_state, 0, sizeof(expected_state));
+        expected_state.nxdn_cipher_type = 0x02;
+        expected_state.R = 1U;
+        expected_state.bit_counterL = 2000;
+        DSD_MEMSET(expected_state.ks_bitstreamL, 1, sizeof(expected_state.ks_bitstreamL));
+        apply_expected_nxdn_cipher23(&expected_state, expected_ambe_d);
+        rc |= expect_eq_int("nxdn-cipher2-clamp counter", expected_state.bit_counterL, 1568);
+        rc |= expect_eq_int("nxdn-cipher2-clamp transformed",
+                            memcmp(expected_ambe_d, decoded_ambe_d, sizeof(expected_ambe_d)) != 0, 1);
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_NXDN_POS;
+    state.nxdn_cipher_type = 0x02;
+    state.R = 1U;
+    state.bit_counterL = 2000;
+    DSD_MEMSET(state.ks_bitstreamL, 1, sizeof(state.ks_bitstreamL));
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("nxdn-cipher2-clamp state bit-counter", state.bit_counterL, expected_state.bit_counterL);
+    rc |= expect_eq_int("nxdn-cipher2-clamp status populated", state.err_str[0] != '\0', 1);
+    rc |= expect_eq_int("nxdn-cipher2-clamp errs updated", state.errs2 >= expected_errs2, 1);
+    rc |= expect_any_nonzero_u8("nxdn-cipher2-clamp temp audio", (const uint8_t*)state.audio_out_temp_buf,
+                                sizeof(state.audio_out_temp_buf));
+    rc |= expect_eq_mem("nxdn-cipher2-clamp staged left", state.f_l, state.audio_out_temp_buf, sizeof(state.f_l));
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_hard_dstar_stages_audio(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+    char ambe_d[49] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+
+    ambe_fr[0][0] = 1;
+    ambe_fr[2][9] = 1;
+
+    mbe_initMbeParms(&cur, &prev, &prev_enhanced);
+    int ret =
+        dsd_mbe_process_ambe3600x2400_framef(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), ambe_fr, ambe_d, &cur, &prev, &prev_enhanced);
+    rc |= expect_eq_int("frame-hard-dstar process", ret >= 0, 1);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_DSTAR_VOICE_POS;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("frame-hard-dstar errs", state.errs, expected_errs);
+    rc |= expect_eq_int("frame-hard-dstar errs2", state.errs2, expected_errs2);
+    rc |= expect_eq_int("frame-hard-dstar status", strcmp(state.err_str, expected_err_str), 0);
+    rc |=
+        expect_eq_mem("frame-hard-dstar temp audio", state.audio_out_temp_buf, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_mem("frame-hard-dstar staged left", state.f_l, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_int("frame-hard-dstar debug errors", state.debug_audio_errors, state.errs2);
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_hard_dmr_left_stages_audio(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+    char ambe_d[49] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    mbe_process_result result;
+
+    ambe_fr[1][4] = 1;
+    ambe_fr[3][19] = 1;
+
+    int ret =
+        dsd_mbe_decode_ambe2450_frame(&expected_errs, &expected_errs2, (const char (*)[24])ambe_fr, ambe_d, &result);
+    rc |= expect_eq_int("frame-hard-dmr decode", ret >= 0, 1);
+    if (ret >= 0) {
+        mbe_initMbeParms(&cur, &prev, &prev_enhanced);
+        ret = dsd_mbe_process_ambe2450_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), ambe_d, &cur, &prev, &prev_enhanced, &result);
+        rc |= expect_eq_int("frame-hard-dmr process", ret >= 0, 1);
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    opts.dmr_mono = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.currentslot = 0;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("frame-hard-dmr errs", state.errs, expected_errs);
+    rc |= expect_eq_int("frame-hard-dmr errs2", state.errs2, expected_errs2);
+    rc |= expect_eq_int("frame-hard-dmr status", strcmp(state.err_str, expected_err_str), 0);
+    rc |= expect_eq_mem("frame-hard-dmr temp audio", state.audio_out_temp_buf, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_mem("frame-hard-dmr staged left", state.f_l, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_int("frame-hard-dmr enc flag", state.dmr_encL, 0);
+    rc |= expect_eq_int("frame-hard-dmr debug errors", state.debug_audio_errors, state.errs2);
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_dmr_rc4_transforms_left_and_right_slots(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static dsd_state expected_state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+    char decoded_ambe_d[49] = {0};
+    char expected_ambe_d[49] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    mbe_process_result result;
+
+    // Decode a known active voice frame once so both slots share the same fixture payload.
+    int ret = prepare_active_ambe2450_fixture(ambe_fr, decoded_ambe_d, &expected_errs, &expected_errs2, &result);
+    rc |= expect_eq_int("dmr-rc4 active fixture", ret, 0);
+    if (ret == 0) {
+        // The expected left-slot bits are a fixed vector for this RC4/key/drop fixture.
+        copy_ambe49(expected_ambe_d, k_dmr_rc4_left_expected_ambe);
+        DSD_MEMSET(&expected_state, 0, sizeof(expected_state));
+        expected_state.dropL = 11;
+        rc |= expect_eq_int("dmr-rc4-left expected drop", expected_state.dropL, 11);
+        rc |= expect_eq_int("dmr-rc4-left transformed",
+                            memcmp(expected_ambe_d, decoded_ambe_d, sizeof(expected_ambe_d)) != 0, 1);
+
+        (void)dsd_mbe_strip_ambe_context_if_changed(decoded_ambe_d, expected_ambe_d, &result);
+        mbe_initMbeParms(&cur, &prev, &prev_enhanced);
+        ret = dsd_mbe_process_ambe2450_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), expected_ambe_d, &cur, &prev, &prev_enhanced,
+                                             &result);
+        rc |= expect_eq_int("dmr-rc4-left fixture processes", ret >= 0, 1);
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    opts.dmr_mono = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.currentslot = 0;
+    state.payload_algid = 0x21;
+    state.R = 0x0102030405ULL;
+    state.payload_mi = 0xA1B2C3D4ULL;
+    state.dropL = 4;
+
+    // Production processing performs the left-slot transform and stages decoded audio.
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("dmr-rc4-left state drop", state.dropL, expected_state.dropL);
+    rc |= expect_eq_int("dmr-rc4-left errs", state.errs, expected_errs);
+    rc |= expect_eq_int("dmr-rc4-left errs2", state.errs2, expected_errs2);
+    rc |= expect_eq_int("dmr-rc4-left status", strcmp(state.err_str, expected_err_str), 0);
+    rc |= expect_eq_int("dmr-rc4-left decryptable", state.dmr_encL, 0);
+    rc |= expect_eq_mem("dmr-rc4-left temp audio", state.audio_out_temp_buf, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_mem("dmr-rc4-left staged", state.f_l, expected_audio, sizeof(expected_audio));
+
+    expected_errs = -1;
+    expected_errs2 = -1;
+    DSD_MEMSET(decoded_ambe_d, 0, sizeof(decoded_ambe_d));
+    DSD_MEMSET(expected_ambe_d, 0, sizeof(expected_ambe_d));
+    DSD_MEMSET(expected_audio, 0, sizeof(expected_audio));
+    DSD_MEMSET(expected_err_str, 0, sizeof(expected_err_str));
+    ret = dsd_mbe_decode_ambe2450_frame(&expected_errs, &expected_errs2, (const char (*)[24])ambe_fr, decoded_ambe_d,
+                                        &result);
+    rc |= expect_eq_int("dmr-rc4-right fixture decodes", ret >= 0, 1);
+    rc |= expect_eq_int("dmr-rc4-right fixture active voice", dmr_ambe49_should_skip_voice_stream(decoded_ambe_d), 0);
+    if (ret >= 0) {
+        // The right-slot vector uses an independent key/MI/drop tuple from the left slot.
+        copy_ambe49(expected_ambe_d, k_dmr_rc4_right_expected_ambe);
+        DSD_MEMSET(&expected_state, 0, sizeof(expected_state));
+        expected_state.dropR = 16;
+        rc |= expect_eq_int("dmr-rc4-right expected drop", expected_state.dropR, 16);
+        rc |= expect_eq_int("dmr-rc4-right transformed",
+                            memcmp(expected_ambe_d, decoded_ambe_d, sizeof(expected_ambe_d)) != 0, 1);
+
+        (void)dsd_mbe_strip_ambe_context_if_changed(decoded_ambe_d, expected_ambe_d, &result);
+        mbe_initMbeParms(&cur2, &prev2, &prev_enhanced2);
+        ret = dsd_mbe_process_ambe2450_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), expected_ambe_d, &cur2, &prev2, &prev_enhanced2,
+                                             &result);
+        rc |= expect_eq_int("dmr-rc4-right fixture processes", ret >= 0, 1);
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    opts.dmr_stereo = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.currentslot = 1;
+    state.payload_algidR = 0x21;
+    state.RR = 0x0A0B0C0D0EULL;
+    state.payload_miR = 0x55667788ULL;
+    state.dropR = 9;
+
+    // The second production pass verifies right-slot state, error counters, and audio staging.
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("dmr-rc4-right state drop", state.dropR, expected_state.dropR);
+    rc |= expect_eq_int("dmr-rc4-right errs", state.errsR, expected_errs);
+    rc |= expect_eq_int("dmr-rc4-right errs2", state.errs2R, expected_errs2);
+    rc |= expect_eq_int("dmr-rc4-right status", strcmp(state.err_strR, expected_err_str), 0);
+    rc |= expect_eq_int("dmr-rc4-right decryptable", state.dmr_encR, 0);
+    rc |= expect_eq_mem("dmr-rc4-right temp audio", state.audio_out_temp_bufR, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_mem("dmr-rc4-right staged", state.f_r, expected_audio, sizeof(expected_audio));
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_dmr_reverse_mute_toggles_slot_flags(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+
+    ambe_fr[0][2] = 1;
+    ambe_fr[2][15] = 1;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    opts.dmr_mono = 1;
+    opts.reverse_mute = 1;
+    opts.unmute_encrypted_p25 = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.currentslot = 0;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("reverse-mute-left-enc", state.dmr_encL, 1);
+    rc |= expect_eq_int("reverse-mute-left-mute", opts.dmr_mute_encL, 1);
+    rc |= expect_eq_int("reverse-mute-left-unmute-p25", opts.unmute_encrypted_p25, 0);
+    rc |= expect_eq_mem("reverse-mute-left-staged", state.f_l, state.audio_out_temp_buf, sizeof(state.f_l));
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    opts.dmr_stereo = 1;
+    opts.reverse_mute = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.currentslot = 1;
+    state.dmr_soR = 0x40;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("reverse-mute-right-enc", state.dmr_encR, 0);
+    rc |= expect_eq_int("reverse-mute-right-mute", opts.dmr_mute_encR, 0);
+    rc |= expect_eq_int("reverse-mute-right-unmute-p25", opts.unmute_encrypted_p25, 1);
+    rc |= expect_eq_mem("reverse-mute-right-staged", state.f_r, state.audio_out_temp_bufR, sizeof(state.f_r));
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_dmr_missing_alg_key_unmutes_slots(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+
+    ambe_fr[0][6] = 1;
+    ambe_fr[2][18] = 1;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    opts.dmr_mono = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.currentslot = 0;
+    state.dmr_so = 0x40;
+    state.R = 0x123456789AULL;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("missing-alg-left-unmuted", state.dmr_encL, 0);
+    rc |= expect_eq_int("missing-alg-left-mute-flag", opts.dmr_mute_encL, 0);
+    rc |= expect_eq_int("missing-alg-left-debug", state.debug_audio_errors, state.errs2);
+    rc |= expect_eq_mem("missing-alg-left-staged", state.f_l, state.audio_out_temp_buf, sizeof(state.f_l));
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    opts.dmr_stereo = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.currentslot = 1;
+    state.dmr_soR = 0x40;
+    state.RR = 0x2233445566ULL;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("missing-alg-right-unmuted", state.dmr_encR, 0);
+    rc |= expect_eq_int("missing-alg-right-mute-flag", opts.dmr_mute_encR, 0);
+    rc |= expect_eq_int("missing-alg-right-debug", state.debug_audio_errorsR, state.errs2R);
+    rc |= expect_eq_mem("missing-alg-right-staged", state.f_r, state.audio_out_temp_bufR, sizeof(state.f_r));
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_dmr_post_decode_gates_override_enc_flags(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+
+    ambe_fr[1][8] = 1;
+    ambe_fr[3][21] = 1;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    opts.dmr_mono = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.currentslot = 0;
+    state.payload_algid = 0x7E;
+    state.baofeng_ap = 1;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("forced-clear-left-enc", state.dmr_encL, 0);
+    rc |= expect_eq_mem("forced-clear-left-staged", state.f_l, state.audio_out_temp_buf, sizeof(state.f_l));
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    opts.dmr_stereo = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_P25P2_POS;
+    state.currentslot = 1;
+    state.payload_algidR = 0x80;
+    state.p25_p2_audio_allowed[1] = 1;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("p25p2-metadata-gate-right-enc", state.dmr_encR, 1);
+    rc |= expect_eq_int("p25p2-metadata-gate-history-len", state.p25_p2_voice_err_hist_len, 50);
+    rc |= expect_eq_int("p25p2-metadata-gate-history-pos", state.p25_p2_voice_err_hist_pos[1], 1);
+    rc |= expect_eq_mem("p25p2-metadata-gate-right-staged", state.f_r, state.audio_out_temp_bufR, sizeof(state.f_r));
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_dmr_aes_stream_advances_slot_state(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+
+    ambe_fr[0][7] = 1;
+    ambe_fr[1][12] = 1;
+    ambe_fr[3][22] = 1;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    opts.dmr_mono = 1;
+    opts.dmr_mute_encL = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.currentslot = 0;
+    state.payload_algid = 0x24;
+    state.aes_key_loaded[0] = 1;
+    state.A1[0] = 0x0011223344556677ULL;
+    state.A2[0] = 0x8899AABBCCDDEEFFULL;
+    state.A3[0] = 0x1021324354657687ULL;
+    state.A4[0] = 0x98A9BACBDCEDFE0FULL;
+    state.aes_iv[0] = 0xA5;
+    state.aes_iv[15] = 0x5A;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("aes-left-vc", state.DMRvcL, 1);
+    rc |= expect_eq_int("aes-left-bit-counter", state.bit_counterL, 56);
+    rc |= expect_eq_int("aes-left-unmutes-slot", opts.dmr_mute_encL, 0);
+    rc |= expect_eq_int("aes-left-enc-cleared", state.dmr_encL, 0);
+    rc |= expect_any_nonzero_u8("aes-left-keystream-ready", state.ks_octetL, sizeof(state.ks_octetL));
+    rc |= expect_eq_mem("aes-left-staged", state.f_l, state.audio_out_temp_buf, sizeof(state.f_l));
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    opts.dmr_stereo = 1;
+    opts.dmr_mute_encR = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.currentslot = 1;
+    state.payload_algidR = 0x25;
+    state.aes_key_loaded[1] = 1;
+    state.A1[1] = 0xFFEEDDCCBBAA9988ULL;
+    state.A2[1] = 0x7766554433221100ULL;
+    state.A3[1] = 0x0F1E2D3C4B5A6978ULL;
+    state.A4[1] = 0x8796A5B4C3D2E1F0ULL;
+    state.aes_ivR[0] = 0x3C;
+    state.aes_ivR[15] = 0xC3;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("aes-right-vc", state.DMRvcR, 1);
+    rc |= expect_eq_int("aes-right-bit-counter", state.bit_counterR, 56);
+    rc |= expect_eq_int("aes-right-unmutes-slot", opts.dmr_mute_encR, 0);
+    rc |= expect_eq_int("aes-right-enc-cleared", state.dmr_encR, 0);
+    rc |= expect_any_nonzero_u8("aes-right-keystream-ready", state.ks_octetR, sizeof(state.ks_octetR));
+    rc |= expect_eq_mem("aes-right-staged", state.f_r, state.audio_out_temp_bufR, sizeof(state.f_r));
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_hard_p25p2_right_stages_audio(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+    char ambe_d[49] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    mbe_process_result result;
+
+    ambe_fr[0][11] = 1;
+    ambe_fr[2][20] = 1;
+
+    int ret =
+        dsd_mbe_decode_ambe2450_frame(&expected_errs, &expected_errs2, (const char (*)[24])ambe_fr, ambe_d, &result);
+    rc |= expect_eq_int("frame-hard-p25p2-r decode", ret >= 0, 1);
+    if (ret >= 0) {
+        mbe_initMbeParms(&cur2, &prev2, &prev_enhanced2);
+        ret = dsd_mbe_process_ambe2450_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), ambe_d, &cur2, &prev2, &prev_enhanced2, &result);
+        rc |= expect_eq_int("frame-hard-p25p2-r process", ret >= 0, 1);
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    opts.dmr_stereo = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_P25P2_POS;
+    state.currentslot = 1;
+    state.p2_wacn = 1;
+    state.p2_sysid = 2;
+    state.p2_cc = 3;
+    state.p25_p2_audio_allowed[1] = 1;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("frame-hard-p25p2-r keeps left errs", state.errs, 0);
+    rc |= expect_eq_int("frame-hard-p25p2-r errs", state.errsR, expected_errs);
+    rc |= expect_eq_int("frame-hard-p25p2-r errs2", state.errs2R, expected_errs2);
+    rc |= expect_eq_int("frame-hard-p25p2-r status", strcmp(state.err_strR, expected_err_str), 0);
+    rc |= expect_eq_mem("frame-hard-p25p2-r temp audio", state.audio_out_temp_bufR, expected_audio,
+                        sizeof(expected_audio));
+    rc |= expect_eq_mem("frame-hard-p25p2-r staged right", state.f_r, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_int("frame-hard-p25p2-r enc flag", state.dmr_encR, 0);
+    rc |= expect_eq_int("frame-hard-p25p2-r debug errors", state.debug_audio_errorsR, state.errs2R);
+    rc |= expect_eq_int("frame-hard-p25p2-r history length", state.p25_p2_voice_err_hist_len, 50);
+    rc |= expect_eq_int("frame-hard-p25p2-r history position", state.p25_p2_voice_err_hist_pos[1], 1);
+    rc |= expect_eq_int("frame-hard-p25p2-r history sum", (int)state.p25_p2_voice_err_hist_sum[1], state.errs2R & 0xFF);
+
+    return rc;
+}
+
+static int
+test_soft_mbe_provoice_updates_debug_errors_without_p25_history(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe7100_fr[7][24] = {{0}};
+    char imbe_d[88] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    int decoded_errs2 = -1;
+    mbe_process_result result;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    int ret = dsd_mbe_decode_imbe7100_frame(&expected_errs, &expected_errs2, (const char (*)[24])imbe7100_fr, imbe_d,
+                                            &result);
+    rc |= expect_eq_int("soft-provoice fixture decodes", ret >= 0, 1);
+    decoded_errs2 = expected_errs2;
+    if (ret >= 0) {
+        mbe_initMbeParms(&cur, &prev, &prev_enhanced);
+        ret = dsd_mbe_process_imbe4400_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), imbe_d, &cur, &prev, &prev_enhanced, &result);
+        rc |= expect_eq_int("soft-provoice fixture processes", ret >= 0, 1);
+    }
+
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_PROVOICE_POS;
+    soft_mbe(&opts, &state, NULL, NULL, imbe7100_fr);
+
+    rc |= expect_eq_int("soft-provoice errs", state.errs, expected_errs);
+    rc |= expect_eq_int("soft-provoice errs2", state.errs2, expected_errs2);
+    rc |= expect_eq_int("soft-provoice debug errors", state.debug_audio_errors, decoded_errs2);
+    rc |= expect_eq_int("soft-provoice keeps p25 history length", state.p25_p1_voice_err_hist_len, 0);
+    rc |= expect_eq_int("soft-provoice keeps p25 history sum", (int)state.p25_p1_voice_err_hist_sum, 0);
+
+    return rc;
+}
+
+static int
+test_process_mbe_frame_hard_provoice_stages_audio(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char imbe_fr[8][23] = {{0}};
+    char ambe_fr[4][24] = {{0}};
+    char imbe7100_fr[7][24] = {{0}};
+    char imbe_d[88] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    mbe_process_result result;
+
+    imbe7100_fr[0][3] = 1;
+    imbe7100_fr[2][11] = 1;
+    imbe7100_fr[6][19] = 1;
+
+    int ret = dsd_mbe_decode_imbe7100_frame(&expected_errs, &expected_errs2, (const char (*)[24])imbe7100_fr, imbe_d,
+                                            &result);
+    rc |= expect_eq_int("hard-provoice fixture decodes", ret >= 0, 1);
+    if (ret >= 0) {
+        mbe_initMbeParms(&cur, &prev, &prev_enhanced);
+        ret = dsd_mbe_process_imbe4400_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), imbe_d, &cur, &prev, &prev_enhanced, &result);
+        rc |= expect_eq_int("hard-provoice fixture processes", ret >= 0, 1);
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_PROVOICE_POS;
+
+    processMbeFrame(&opts, &state, imbe_fr, ambe_fr, imbe7100_fr);
+
+    rc |= expect_eq_int("hard-provoice errs", state.errs, expected_errs);
+    rc |= expect_eq_int("hard-provoice errs2", state.errs2, expected_errs2);
+    rc |= expect_eq_int("hard-provoice status", strcmp(state.err_str, expected_err_str), 0);
+    rc |= expect_eq_mem("hard-provoice temp audio", state.audio_out_temp_buf, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_mem("hard-provoice staged left", state.f_l, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_int("hard-provoice debug errors", state.debug_audio_errors, state.errs2);
+    rc |= expect_eq_int("hard-provoice keeps p25 history length", state.p25_p1_voice_err_hist_len, 0);
+
+    return rc;
+}
+
+static int
+test_soft_mbe_ambe2_ehr_routes_slot2_error_state(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    char ambe_fr[4][24] = {{0}};
+    char ambe_d[49] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    mbe_process_result result;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    int ret =
+        dsd_mbe_decode_ambe2450_frame(&expected_errs, &expected_errs2, (const char (*)[24])ambe_fr, ambe_d, &result);
+    rc |= expect_eq_int("soft-ehr fixture decodes", ret >= 0, 1);
+    if (ret >= 0) {
+        mbe_initMbeParms(&cur2, &prev2, &prev_enhanced2);
+        ret = dsd_mbe_process_ambe2450_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), ambe_d, &cur2, &prev2, &prev_enhanced2, &result);
+        rc |= expect_eq_int("soft-ehr fixture processes", ret >= 0, 1);
+    }
+
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.currentslot = 1;
+    state.errs = 101;
+    state.errs2 = 102;
+    state.errsR = 201;
+    state.errs2R = 202;
+
+    soft_mbe(&opts, &state, NULL, ambe_fr, NULL);
+
+    rc |= expect_eq_int("soft-ehr keeps slot1 errs", state.errs, 101);
+    rc |= expect_eq_int("soft-ehr keeps slot1 errs2", state.errs2, 102);
+    rc |= expect_eq_int("soft-ehr slot2 errs", state.errsR, expected_errs);
+    rc |= expect_eq_int("soft-ehr slot2 errs2", state.errs2R, expected_errs2);
+
+    return rc;
+}
+
+static int
+test_soft_mbe_dstar_stages_float_audio(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    mbe_parms expected_cur;
+    mbe_parms expected_prev;
+    mbe_parms expected_prev_enhanced;
+    char ambe_fr[4][24] = {{0}};
+    char expected_ambe_d[49] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+
+    ambe_fr[0][0] = 1;
+    ambe_fr[3][12] = 1;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    mbe_initMbeParms(&expected_cur, &expected_prev, &expected_prev_enhanced);
+    int ret = dsd_mbe_process_ambe3600x2400_framef(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                                   sizeof(expected_err_str), ambe_fr, expected_ambe_d, &expected_cur,
+                                                   &expected_prev, &expected_prev_enhanced);
+    rc |= expect_eq_int("soft-dstar fixture processes", ret >= 0, 1);
+
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_DSTAR_VOICE_POS;
+
+    soft_mbe(&opts, &state, NULL, ambe_fr, NULL);
+
+    rc |= expect_eq_int("soft-dstar errs", state.errs, expected_errs);
+    rc |= expect_eq_int("soft-dstar errs2", state.errs2, expected_errs2);
+    rc |= expect_eq_int("soft-dstar status", strcmp(state.err_str, expected_err_str), 0);
+    rc |= expect_eq_mem("soft-dstar temp audio", state.audio_out_temp_buf, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_mem("soft-dstar staged left", state.f_l, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_int("soft-dstar keeps right errs", state.errsR, 0);
+
+    return rc;
+}
+
+static int
+test_soft_mbe_x2_slot2_uses_right_error_state_and_stages_audio(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static mbe_parms cur;
+    static mbe_parms prev;
+    static mbe_parms prev_enhanced;
+    static mbe_parms cur2;
+    static mbe_parms prev2;
+    static mbe_parms prev_enhanced2;
+    mbe_parms expected_cur;
+    mbe_parms expected_prev;
+    mbe_parms expected_prev_enhanced;
+    char ambe_fr[4][24] = {{0}};
+    char ambe_d[49] = {0};
+    float expected_audio[160] = {0};
+    char expected_err_str[96] = {0};
+    int expected_errs = -1;
+    int expected_errs2 = -1;
+    mbe_process_result result;
+    FILE* mbe_out = tmpfile();
+
+    ambe_fr[1][3] = 1;
+    ambe_fr[2][17] = 1;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.floating_point = 1;
+    opts.mbe_out_f = mbe_out;
+    int ret =
+        dsd_mbe_decode_ambe2450_frame(&expected_errs, &expected_errs2, (const char (*)[24])ambe_fr, ambe_d, &result);
+    rc |= expect_eq_int("soft-x2 fixture decodes", ret >= 0, 1);
+    if (ret >= 0) {
+        mbe_initMbeParms(&expected_cur, &expected_prev, &expected_prev_enhanced);
+        ret = dsd_mbe_process_ambe2450_dataf(expected_audio, &expected_errs, &expected_errs2, expected_err_str,
+                                             sizeof(expected_err_str), ambe_d, &expected_cur, &expected_prev,
+                                             &expected_prev_enhanced, &result);
+        rc |= expect_eq_int("soft-x2 fixture processes", ret >= 0, 1);
+    }
+
+    init_soft_mbe_state(&state, &cur, &prev, &prev_enhanced, &cur2, &prev2, &prev_enhanced2);
+    state.synctype = DSD_SYNC_X2TDMA_VOICE_POS;
+    state.currentslot = 1;
+    state.errs = 101;
+    state.errs2 = 102;
+    state.errsR = 201;
+    state.errs2R = 202;
+
+    soft_mbe(&opts, &state, NULL, ambe_fr, NULL);
+
+    rc |= expect_eq_int("soft-x2 keeps slot1 errs", state.errs, 101);
+    rc |= expect_eq_int("soft-x2 keeps slot1 errs2", state.errs2, 102);
+    rc |= expect_eq_int("soft-x2 slot2 errs", state.errsR, expected_errs);
+    rc |= expect_eq_int("soft-x2 slot2 errs2", state.errs2R, expected_errs2);
+    rc |= expect_eq_int("soft-x2 status", strcmp(state.err_strR, expected_err_str), 0);
+    rc |= expect_eq_mem("soft-x2 temp audio", state.audio_out_temp_buf, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_mem("soft-x2 staged left", state.f_l, expected_audio, sizeof(expected_audio));
+    rc |= expect_eq_int("soft-x2 mbe output opened", mbe_out != NULL, 1);
+    if (mbe_out) {
+        rc |= expect_eq_int("soft-x2 mbe flush", fflush(mbe_out), 0);
+        if (fseek(mbe_out, 0, SEEK_SET) != 0) {
+            rc = 1;
+        }
+        clearerr(mbe_out);
+        int first = fgetc(mbe_out);
+        if (first == EOF && ferror(mbe_out)) {
+            rc = 1;
+        }
+        rc |= expect_eq_int("soft-x2 saved slot2 err byte", first, expected_errs2 & 0xFF);
+        int bytes = 0;
+        while (fgetc(mbe_out) != EOF) {
+            bytes++;
+        }
+        if (ferror(mbe_out)) {
+            rc = 1;
+        }
+        rc |= expect_eq_int("soft-x2 saved ambe payload bytes", bytes, 7);
+        fclose(mbe_out);
+        opts.mbe_out_f = NULL;
+    }
+
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
 
+    rc |= test_public_result_helpers_normalize_error_counts();
+    rc |= test_public_store_result_uses_c0_when_valid();
     rc |= test_unchanged_preserves_c0_context();
     rc |= test_changed_strips_only_c0_context();
     rc |= test_changed_without_c0_context_keeps_legacy_shape();
@@ -266,9 +2261,37 @@ main(void) {
     rc |= test_imbe_unchanged_preserves_c0_c4_context();
     rc |= test_imbe_changed_strips_c0_c4_context();
     rc |= test_changed_frame_restores_total_error_repeat_fallback();
+    rc |= test_decode_wrappers_store_status_like_mbelib();
+    rc |= test_process_wrappers_match_direct_mbelib_status();
+    rc |= test_process_frame_wrapper_stores_status_and_audio();
+    rc |= test_keyring_tracks_aes_segment_metadata();
+    rc |= test_process_mbe_frame_soft_p25p1_copies_soft_imbe_audio();
+    rc |= test_process_mbe_frame_soft_nxdn_copies_soft_ambe_audio();
+    rc |= test_process_mbe_frame_p25p1_rc4_transforms_imbe_payload();
+    rc |= test_process_mbe_frame_p25p1_multicrypt_transforms_imbe_payload();
+    rc |= test_process_mbe_frame_nxdn_cipher1_transforms_ambe_payload();
+    rc |= test_process_mbe_frame_nxdn_cipher2_initializes_and_advances_keystream();
+    rc |= test_process_mbe_frame_nxdn_cipher2_clamps_stale_bit_counter();
+    rc |= test_process_mbe_frame_hard_dstar_stages_audio();
+    rc |= test_process_mbe_frame_hard_dmr_left_stages_audio();
+    rc |= test_process_mbe_frame_dmr_rc4_transforms_left_and_right_slots();
+    rc |= test_process_mbe_frame_dmr_reverse_mute_toggles_slot_flags();
+    rc |= test_process_mbe_frame_dmr_missing_alg_key_unmutes_slots();
+    rc |= test_process_mbe_frame_dmr_post_decode_gates_override_enc_flags();
+    rc |= test_process_mbe_frame_dmr_aes_stream_advances_slot_state();
+    rc |= test_process_mbe_frame_hard_p25p2_right_stages_audio();
+    rc |= test_play_mbe_files_processes_imbe_ambe_and_dstar_records();
+    rc |= test_soft_mbe_p25p1_updates_error_history();
+    rc |= test_soft_mbe_provoice_updates_debug_errors_without_p25_history();
+    rc |= test_process_mbe_frame_hard_provoice_stages_audio();
+    rc |= test_soft_mbe_ambe2_ehr_routes_slot2_error_state();
+    rc |= test_soft_mbe_dstar_stages_float_audio();
+    rc |= test_soft_mbe_x2_slot2_uses_right_error_state_and_stages_audio();
 
     if (rc == 0) {
         printf("CORE_MBE_TRANSFORM_CONTEXT: OK\n");
     }
     return rc;
 }
+
+// NOLINTEND(bugprone-implicit-widening-of-multiplication-result,bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-core.CallAndMessage,clang-analyzer-core.uninitialized.Assign)

--- a/tests/core/test_core_misc_power_filters.c
+++ b/tests/core/test_core_misc_power_filters.c
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/audio_filters.h>
+#include <dsd-neo/core/power.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/fec/trellis.h>
+#include <dsd-neo/fec/viterbi.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static void
+test_trellis_and_viterbi_helpers(void) {
+    uint8_t decoded_bits[16];
+    uint8_t encoded_bits[40];
+    DSD_MEMSET(decoded_bits, 0xA5, sizeof(decoded_bits));
+    DSD_MEMSET(encoded_bits, 0, sizeof(encoded_bits));
+
+    trellis_decode(decoded_bits, encoded_bits, 8);
+    for (size_t i = 0; i < 8U; i++) {
+        assert(decoded_bits[i] == 0U);
+    }
+
+    assert(q_abs_diff(10U, 4U) == 6U);
+    assert(q_abs_diff(4U, 10U) == 6U);
+
+    uint16_t soft_zero[32];
+    uint8_t out[8];
+    DSD_MEMSET(soft_zero, 0, sizeof(soft_zero));
+    DSD_MEMSET(out, 0xFF, sizeof(out));
+    assert(viterbi_decode(out, soft_zero, 16U) == 0U);
+    assert(out[0] == 0U);
+
+    const uint8_t puncture[] = {1U, 0U, 1U, 1U};
+    DSD_MEMSET(out, 0xFF, sizeof(out));
+    assert(viterbi_decode_punctured(out, soft_zero, puncture, 12U, (uint16_t)(sizeof(puncture))) == 0U);
+    assert(out[0] == 0U);
+
+    viterbi_reset();
+    viterbi_decode_bit(0U, 0U, 0U);
+    DSD_MEMSET(out, 0xFF, sizeof(out));
+    (void)viterbi_chainback(out, 1U, 1U);
+    assert((out[0] & 0x80U) == 0U);
+}
+
+static void
+test_power_helpers(void) {
+    const short constant_samples[] = {1000, 1000, 1000, 1000};
+    assert(raw_pwr(constant_samples, 4, 1) == 0.0);
+    assert(raw_rms(constant_samples, 4, 1) == 0.0);
+    assert(raw_pwr(constant_samples, 0, 1) == 0.0);
+
+    const short alternating_samples[] = {32767, -32768, 32767, -32768};
+    double short_power = raw_pwr(alternating_samples, 4, 1);
+    assert(short_power > 0.99 && short_power <= 1.0);
+
+    const float float_samples[] = {32767.0f, -32768.0f, 32767.0f, -32768.0f};
+    double float_power = raw_pwr_f(float_samples, 4, 1);
+    assert(float_power > 0.99 && float_power <= 1.0);
+    assert(raw_pwr_f(float_samples, 0, 1) == 0.0);
+
+    assert(pwr_to_dB(0.0) == -120.0);
+    assert(pwr_to_dB(2.0) == 0.0);
+    assert(pwr_to_dB(1.0e-20) == -120.0);
+
+    assert(dB_to_pwr(0.0) == 1.0);
+    assert(dB_to_pwr(12.0) == 1.0);
+    assert(dB_to_pwr(-250.0) >= 0.0);
+
+    double p = dB_to_pwr(-30.0);
+    assert(fabs(pwr_to_dB(p) + 30.0) < 0.001);
+}
+
+static void
+test_audio_filter_helpers(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    init_audio_filters(&state, 0);
+    short lpf_samples[] = {12000, 12000, 12000, 12000};
+    lpf(&state, lpf_samples, 4);
+    assert(lpf_samples[0] > 0);
+    assert(lpf_samples[3] >= lpf_samples[0]);
+
+    float lpf_float[] = {12000.0f, 12000.0f, 12000.0f, 12000.0f};
+    lpf_f(&state, lpf_float, 4);
+    assert(lpf_float[0] > 0.0f);
+    assert(lpf_float[3] >= lpf_float[0]);
+
+    short hpf_samples[] = {0, 12000, 12000, 12000};
+    hpf(&state, hpf_samples, 4);
+    assert(hpf_samples[1] > 0);
+
+    float hpf_float[] = {0.0f, 12000.0f, 12000.0f, 12000.0f};
+    hpf_f(&state, hpf_float, 4);
+    assert(hpf_float[1] > 0.0f);
+
+    short pbf_samples[] = {0, 12000, 0, -12000};
+    pbf(&state, pbf_samples, 4);
+    assert(pbf_samples[1] != 0);
+
+    float pbf_float[] = {0.0f, 12000.0f, 0.0f, -12000.0f};
+    pbf_f(&state, pbf_float, 4);
+    assert(fabsf(pbf_float[1]) > 0.0f);
+
+    init_audio_filters(&state, 48000);
+    state.HRCFilterL.coef = 1.0f;
+    state.HRCFilterL.v_in[0] = -32768.0f;
+    state.HRCFilterL.v_out[0] = 40000.0f;
+    short left[] = {32767};
+    hpf_dL(&state, left, 1);
+    assert(left[0] == 32767);
+
+    state.HRCFilterR.coef = 1.0f;
+    state.HRCFilterR.v_in[0] = 32767.0f;
+    state.HRCFilterR.v_out[0] = -40000.0f;
+    short right[] = {-32768};
+    hpf_dR(&state, right, 1);
+    assert(right[0] == -32768);
+
+    short empty[] = {1234};
+    lpf(&state, empty, 0);
+    hpf(&state, empty, 0);
+    pbf(&state, empty, 0);
+    assert(empty[0] == 1234);
+}
+
+int
+main(void) {
+    test_trellis_and_viterbi_helpers();
+    test_power_helpers();
+    test_audio_filter_helpers();
+    return 0;
+}

--- a/tests/core/test_dibit_symbol_bin_soft.c
+++ b/tests/core/test_dibit_symbol_bin_soft.c
@@ -22,12 +22,21 @@
 #endif
 
 static int g_next_dibit;
+static int g_get_symbol_calls;
+static uint64_t g_now_ns;
+static int g_sleep_ms_calls;
+static int g_sleep_ns_calls;
+static int g_sleep_us_calls;
+static unsigned int g_last_sleep_ms;
+static uint64_t g_last_sleep_ns;
+static uint64_t g_last_sleep_us;
 
 float
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 getSymbol(dsd_opts* opts, dsd_state* state, int have_sync) {
     (void)opts;
     (void)have_sync;
+    g_get_symbol_calls++;
     state->symbolc = g_next_dibit;
     switch (g_next_dibit & 3) {
         case 0: return 1.0f;
@@ -42,25 +51,28 @@ getSymbol(dsd_opts* opts, dsd_state* state, int have_sync) {
 uint64_t
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_time_monotonic_ns(void) {
-    return 0;
+    return g_now_ns;
 }
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_sleep_ms(unsigned int ms) {
-    (void)ms;
+    g_sleep_ms_calls++;
+    g_last_sleep_ms = ms;
 }
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_sleep_ns(uint64_t ns) {
-    (void)ns;
+    g_sleep_ns_calls++;
+    g_last_sleep_ns = ns;
 }
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_sleep_us(uint64_t us) {
-    (void)us;
+    g_sleep_us_calls++;
+    g_last_sleep_us = us;
 }
 
 void
@@ -91,10 +103,10 @@ free_state_buffers(dsd_state* state) {
 
 static int
 init_state_buffers(dsd_state* state) {
-    state->dibit_buf = (int*)calloc(1000, sizeof(int));
-    state->dmr_payload_buf = (int*)calloc(1000, sizeof(int));
-    state->dmr_reliab_buf = (uint8_t*)calloc(1000000, sizeof(uint8_t));
-    state->dmr_soft_buf = (dsd_dibit_soft_t*)calloc(1000000, sizeof(dsd_dibit_soft_t));
+    state->dibit_buf = (int*)calloc(1000001, sizeof(int));
+    state->dmr_payload_buf = (int*)calloc(1000001, sizeof(int));
+    state->dmr_reliab_buf = (uint8_t*)calloc(1000001, sizeof(uint8_t));
+    state->dmr_soft_buf = (dsd_dibit_soft_t*)calloc(1000001, sizeof(dsd_dibit_soft_t));
     if (state->dibit_buf == NULL || state->dmr_payload_buf == NULL || state->dmr_reliab_buf == NULL
         || state->dmr_soft_buf == NULL) {
         free_state_buffers(state);
@@ -107,10 +119,23 @@ init_state_buffers(dsd_state* state) {
     return 1;
 }
 
+static void
+reset_timing_stubs(uint64_t now_ns) {
+    g_now_ns = now_ns;
+    g_sleep_ms_calls = 0;
+    g_sleep_ns_calls = 0;
+    g_sleep_us_calls = 0;
+    g_last_sleep_ms = 0;
+    g_last_sleep_ns = 0;
+    g_last_sleep_us = 0;
+}
+
 static int
 llr_matches_bit(int16_t llr, int bit) {
     return bit ? (llr > 0) : (llr < 0);
 }
+
+static void set_standard_thresholds(dsd_state* state);
 
 static int
 test_symbol_bin_soft_matches_returned_dibit(int dibit) {
@@ -280,6 +305,154 @@ test_symbol_replay_soft_metric_overrides_fallback(void) {
 }
 
 static int
+test_symbol_bin_replay_throttle_paces_from_timing_rate(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "failed to allocate state buffers\n");
+        return 1;
+    }
+
+    opts.audio_in_type = AUDIO_IN_SYMBOL_BIN;
+    opts.wav_sample_rate = 48000;
+    state.synctype = DSD_SYNC_P25P1_POS;
+    state.rf_mod = 0;
+    state.use_throttle = 1;
+    state.samplesPerSymbol = 12;
+    state.lastsynctype = -1;
+    set_standard_thresholds(&state);
+
+    int rc = 0;
+    state.symbol_throttle = 77;
+    reset_timing_stubs(1000000ULL);
+    g_next_dibit = 0;
+    int got = getDibit(&opts, &state);
+    if (got != 0 || g_sleep_us_calls != 1 || g_last_sleep_us != 77 || g_sleep_ns_calls != 0
+        || state.symbol_replay_next_deadline_ns != 0ULL) {
+        DSD_FPRINTF(stderr, "legacy symbol throttle mismatch got=%d us_calls=%d us=%llu ns_calls=%d deadline=%llu\n",
+                    got, g_sleep_us_calls, (unsigned long long)g_last_sleep_us, g_sleep_ns_calls,
+                    (unsigned long long)state.symbol_replay_next_deadline_ns);
+        rc = 1;
+    }
+
+    state.symbol_throttle = 0;
+    reset_timing_stubs(2000000ULL);
+    g_next_dibit = 1;
+    got = getDibit(&opts, &state);
+    if (got != 1 || state.symbol_replay_next_deadline_ns != 2250000ULL || g_sleep_ns_calls != 0
+        || g_sleep_ms_calls != 0) {
+        DSD_FPRINTF(stderr, "initial auto throttle mismatch got=%d deadline=%llu ns_calls=%d ms_calls=%d\n", got,
+                    (unsigned long long)state.symbol_replay_next_deadline_ns, g_sleep_ns_calls, g_sleep_ms_calls);
+        rc = 1;
+    }
+
+    reset_timing_stubs(2100000ULL);
+    g_next_dibit = 2;
+    got = getDibit(&opts, &state);
+    if (got != 2 || g_sleep_ns_calls != 1 || g_last_sleep_ns != 150000ULL
+        || state.symbol_replay_next_deadline_ns != 2500000ULL) {
+        DSD_FPRINTF(stderr, "paced auto throttle mismatch got=%d ns_calls=%d ns=%llu deadline=%llu\n", got,
+                    g_sleep_ns_calls, (unsigned long long)g_last_sleep_ns,
+                    (unsigned long long)state.symbol_replay_next_deadline_ns);
+        rc = 1;
+    }
+
+    reset_timing_stubs(253000001ULL);
+    g_next_dibit = 3;
+    got = getDibit(&opts, &state);
+    if (got != 3 || g_sleep_ns_calls != 0 || state.symbol_replay_next_deadline_ns != 253250001ULL) {
+        DSD_FPRINTF(stderr, "stalled auto throttle rebase mismatch got=%d ns_calls=%d deadline=%llu\n", got,
+                    g_sleep_ns_calls, (unsigned long long)state.symbol_replay_next_deadline_ns);
+        rc = 1;
+    }
+
+    free_state_buffers(&state);
+    return rc;
+}
+
+static int
+test_reader_wraps_legacy_ring_buffers_before_store(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "failed to allocate state buffers\n");
+        return 1;
+    }
+    set_standard_thresholds(&state);
+    state.synctype = DSD_SYNC_P25P1_POS;
+    state.lastsynctype = -1;
+    state.dibit_buf_p = state.dibit_buf + 900001;
+    state.dmr_payload_p = state.dmr_payload_buf + 900001;
+    state.dmr_reliab_p = state.dmr_reliab_buf + 900001;
+    state.dmr_soft_p = state.dmr_soft_buf + 900001;
+    g_next_dibit = 1;
+
+    dsd_dibit_soft_t soft;
+    DSD_MEMSET(&soft, 0, sizeof(soft));
+    int got = getDibitSoft(&opts, &state, &soft);
+
+    int rc = 0;
+    if (got != 1 || state.dibit_buf_p != state.dibit_buf + 201 || state.dmr_payload_p != state.dmr_payload_buf + 201
+        || state.dmr_reliab_p != state.dmr_reliab_buf + 201 || state.dmr_soft_p != state.dmr_soft_buf + 201) {
+        DSD_FPRINTF(stderr, "ring wrap pointer mismatch got=%d d=%td p=%td r=%td s=%td\n", got,
+                    state.dibit_buf_p - state.dibit_buf, state.dmr_payload_p - state.dmr_payload_buf,
+                    state.dmr_reliab_p - state.dmr_reliab_buf, state.dmr_soft_p - state.dmr_soft_buf);
+        rc = 1;
+    } else if (state.dibit_buf[200] != 1 || state.dmr_payload_buf[200] != 1
+               || state.dmr_reliab_buf[200] != soft.reliability
+               || state.dmr_soft_buf[200].reliability != soft.reliability) {
+        DSD_FPRINTF(stderr, "ring wrap stored values mismatch d=%d p=%d r=%u s=%u soft=%u\n", state.dibit_buf[200],
+                    state.dmr_payload_buf[200], state.dmr_reliab_buf[200], state.dmr_soft_buf[200].reliability,
+                    soft.reliability);
+        rc = 1;
+    }
+
+    free_state_buffers(&state);
+    return rc;
+}
+
+static int
+test_get_dibit_soft_falls_back_to_reliability_buffer(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "failed to allocate state buffers\n");
+        return 1;
+    }
+    set_standard_thresholds(&state);
+    state.synctype = DSD_SYNC_P25P1_POS;
+    state.lastsynctype = -1;
+    free(state.dmr_soft_buf);
+    state.dmr_soft_buf = NULL;
+    state.dmr_soft_p = NULL;
+    g_next_dibit = 2;
+
+    dsd_dibit_soft_t soft;
+    DSD_MEMSET(&soft, 0, sizeof(soft));
+    int got = getDibitSoft(&opts, &state, &soft);
+
+    int rc = 0;
+    if (got != 2 || soft.reliability == 0 || soft.reliability != state.dmr_reliab_p[-1]
+        || !llr_matches_bit(soft.llr[0], 1) || !llr_matches_bit(soft.llr[1], 0)) {
+        DSD_FPRINTF(stderr, "soft fallback mismatch got=%d rel=%u stored=%u llr=(%d,%d)\n", got, soft.reliability,
+                    state.dmr_reliab_p[-1], soft.llr[0], soft.llr[1]);
+        rc = 1;
+    }
+
+    free_state_buffers(&state);
+    return rc;
+}
+
+static int
 test_direct_symbol_capture_writer_formats(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -349,6 +522,220 @@ test_direct_symbol_capture_writer_formats(void) {
     return rc;
 }
 
+static void
+set_standard_thresholds(dsd_state* state) {
+    state->rf_mod = 0;
+    state->center = 0.0f;
+    state->min = -3.0f;
+    state->max = 3.0f;
+    state->lmid = -2.0f;
+    state->umid = 2.0f;
+}
+
+static int
+test_digitize_public_threshold_paths(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "failed to allocate state buffers\n");
+        return 1;
+    }
+    set_standard_thresholds(&state);
+
+    int rc = 0;
+    if (digitize(NULL, &state, 0.0f) != -1 || digitize(&opts, NULL, 0.0f) != -1) {
+        DSD_FPRINTF(stderr, "digitize NULL guard failed\n");
+        rc = 1;
+    }
+
+    state.synctype = DSD_SYNC_DSTAR_VOICE_POS;
+    if (digitize(&opts, &state, 1.0f) != 0 || state.dibit_buf_p[-1] != 1) {
+        DSD_FPRINTF(stderr, "positive two-level high symbol mismatch\n");
+        rc = 1;
+    }
+    if (digitize(&opts, &state, -1.0f) != 1 || state.dibit_buf_p[-1] != 3) {
+        DSD_FPRINTF(stderr, "positive two-level low symbol mismatch\n");
+        rc = 1;
+    }
+
+    state.synctype = DSD_SYNC_DSTAR_VOICE_NEG;
+    if (digitize(&opts, &state, 1.0f) != 1 || state.dibit_buf_p[-1] != 1) {
+        DSD_FPRINTF(stderr, "negative two-level high symbol mismatch\n");
+        rc = 1;
+    }
+    if (digitize(&opts, &state, -1.0f) != 0 || state.dibit_buf_p[-1] != 3) {
+        DSD_FPRINTF(stderr, "negative two-level low symbol mismatch\n");
+        rc = 1;
+    }
+
+    state.synctype = DSD_SYNC_P25P1_POS;
+    const float pos_symbols[4] = {1.0f, 3.0f, -1.0f, -3.0f};
+    for (int expected = 0; expected < 4; expected++) {
+        int got = digitize(&opts, &state, pos_symbols[expected]);
+        if (got != expected || state.dibit_buf_p[-1] != expected || state.last_dibit != expected) {
+            DSD_FPRINTF(stderr, "positive four-level symbol %d got=%d stored=%d last=%d\n", expected, got,
+                        state.dibit_buf_p[-1], state.last_dibit);
+            rc = 1;
+        }
+    }
+
+    state.synctype = DSD_SYNC_P25P1_NEG;
+    const int neg_expected[4] = {2, 3, 0, 1};
+    for (int i = 0; i < 4; i++) {
+        int got = digitize(&opts, &state, pos_symbols[i]);
+        if (got != neg_expected[i] || state.last_dibit != neg_expected[i]) {
+            DSD_FPRINTF(stderr, "negative four-level symbol %d got=%d last=%d\n", i, got, state.last_dibit);
+            rc = 1;
+        }
+    }
+
+    free_state_buffers(&state);
+    return rc;
+}
+
+static int
+test_reader_wrappers_and_soft_symbol_ring(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "failed to allocate state buffers\n");
+        return 1;
+    }
+    set_standard_thresholds(&state);
+    state.synctype = DSD_SYNC_P25P1_POS;
+    state.lastsynctype = -1;
+
+    int analog = 0;
+    g_next_dibit = 0;
+    int got = get_dibit_and_analog_signal(&opts, &state, &analog);
+    int rc = 0;
+    if (got != 0 || analog != 1) {
+        DSD_FPRINTF(stderr, "analog reader mismatch got=%d analog=%d\n", got, analog);
+        rc = 1;
+    }
+
+    g_next_dibit = 3;
+    got = getDibit(&opts, &state);
+    if (got != 3) {
+        DSD_FPRINTF(stderr, "public getDibit wrapper mismatch got=%d\n", got);
+        rc = 1;
+    }
+
+    uint8_t reliability = 0;
+    g_next_dibit = 1;
+    got = getDibitWithReliability(&opts, &state, &reliability);
+    if (got != 1 || reliability == 0) {
+        DSD_FPRINTF(stderr, "reliability reader mismatch got=%d rel=%u\n", got, reliability);
+        rc = 1;
+    }
+
+    state.soft_symbol_head = 511;
+    float soft_symbol = 0.0f;
+    g_next_dibit = 2;
+    got = getDibitAndSoftSymbol(&opts, &state, &soft_symbol);
+    if (got != 2 || soft_symbol != -1.0f || state.soft_symbol_buf[511] != -1.0f || state.soft_symbol_head != 0) {
+        DSD_FPRINTF(stderr, "soft symbol ring mismatch got=%d sym=%.1f stored=%.1f head=%d\n", got, soft_symbol,
+                    state.soft_symbol_buf[511], state.soft_symbol_head);
+        rc = 1;
+    }
+
+    soft_symbol_frame_begin(&state);
+    if (state.soft_symbol_frame_start != state.soft_symbol_head) {
+        DSD_FPRINTF(stderr, "soft symbol frame start mismatch %d/%d\n", state.soft_symbol_frame_start,
+                    state.soft_symbol_head);
+        rc = 1;
+    }
+
+    if (getDibitAndSoftSymbol(NULL, &state, NULL) != -1 || getDibitAndSoftSymbol(&opts, NULL, NULL) != -1) {
+        DSD_FPRINTF(stderr, "soft symbol reader NULL guard failed\n");
+        rc = 1;
+    }
+
+    free_state_buffers(&state);
+    return rc;
+}
+
+static int
+test_viterbi_metric_public_edges(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    set_standard_thresholds(&state);
+
+    int rc = 0;
+    if (soft_symbol_to_viterbi_cost(0.0f, NULL, 0) != 32768U
+        || gmsk_soft_symbol_to_viterbi_cost(0.0f, NULL) != 32768U) {
+        DSD_FPRINTF(stderr, "viterbi NULL guard failed\n");
+        rc = 1;
+    }
+
+    uint16_t positive_msb = soft_symbol_to_viterbi_cost(3.0f, &state, 0);
+    uint16_t negative_msb = soft_symbol_to_viterbi_cost(-3.0f, &state, 0);
+    uint16_t outer_lsb = soft_symbol_to_viterbi_cost(3.0f, &state, 1);
+    uint16_t inner_lsb = soft_symbol_to_viterbi_cost(1.0f, &state, 1);
+    if (!(positive_msb < 2000U && negative_msb > 63500U && inner_lsb < outer_lsb && inner_lsb < 20000U
+          && outer_lsb > 56000U)) {
+        DSD_FPRINTF(stderr, "four-level viterbi costs unexpected msb=%u/%u lsb=%u/%u\n", positive_msb, negative_msb,
+                    outer_lsb, inner_lsb);
+        rc = 1;
+    }
+
+    uint16_t low_bit = gmsk_soft_symbol_to_viterbi_cost(-3.0f, &state);
+    uint16_t high_bit = gmsk_soft_symbol_to_viterbi_cost(3.0f, &state);
+    if (!(low_bit < 2000U && high_bit > 63500U)) {
+        DSD_FPRINTF(stderr, "gmsk viterbi costs unexpected low=%u high=%u\n", low_bit, high_bit);
+        rc = 1;
+    }
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.center = 0.0f;
+    uint16_t degenerate = soft_symbol_to_viterbi_cost(0.5f, &state, 0);
+    uint16_t degenerate_gmsk = gmsk_soft_symbol_to_viterbi_cost(0.5f, &state);
+    if (degenerate == 32768U || degenerate_gmsk == 32768U) {
+        DSD_FPRINTF(stderr, "degenerate viterbi fallback stayed neutral %u/%u\n", degenerate, degenerate_gmsk);
+        rc = 1;
+    }
+
+    return rc;
+}
+
+static int
+test_skip_dibit_consumes_requested_symbols(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "failed to allocate state buffers\n");
+        return 1;
+    }
+    set_standard_thresholds(&state);
+    state.synctype = DSD_SYNC_P25P1_POS;
+    g_next_dibit = 3;
+    g_get_symbol_calls = 0;
+
+    skipDibit(&opts, &state, 3);
+
+    int rc = 0;
+    if (g_get_symbol_calls != 3) {
+        DSD_FPRINTF(stderr, "skipDibit consumed %d symbols, want 3\n", g_get_symbol_calls);
+        rc = 1;
+    } else if (state.last_dibit != 3 || state.dibit_buf_p[-1] != 3) {
+        DSD_FPRINTF(stderr, "skipDibit final dibit mismatch last=%d stored=%d\n", state.last_dibit,
+                    state.dibit_buf_p[-1]);
+        rc = 1;
+    }
+
+    free_state_buffers(&state);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -357,7 +744,14 @@ main(void) {
     }
     rc |= test_soft_symbol_capture_record();
     rc |= test_symbol_replay_soft_metric_overrides_fallback();
+    rc |= test_symbol_bin_replay_throttle_paces_from_timing_rate();
+    rc |= test_reader_wraps_legacy_ring_buffers_before_store();
+    rc |= test_get_dibit_soft_falls_back_to_reliability_buffer();
     rc |= test_direct_symbol_capture_writer_formats();
+    rc |= test_digitize_public_threshold_paths();
+    rc |= test_reader_wrappers_and_soft_symbol_ring();
+    rc |= test_viterbi_metric_public_edges();
+    rc |= test_skip_dibit_consumes_requested_symbols();
     return rc;
 }
 

--- a/tests/crypto/test_csi72.c
+++ b/tests/crypto/test_csi72.c
@@ -107,6 +107,46 @@ test_ee72_rejects_invalid_length(void) {
 }
 
 static int
+test_ee72_rejects_null_and_malformed_inputs(void) {
+    static const uint8_t original_key[] = {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8};
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMCPY(state.csi_ee_key, original_key, sizeof(original_key));
+    state.csi_ee = 1;
+
+    int rc = 0;
+    rc |= expect_int("ee72 null state", connect_systems_ee72_key_creation(NULL, "112233445566778899", 0), -1);
+    rc |= expect_int("ee72 null input", connect_systems_ee72_key_creation(&state, NULL, 0), -1);
+    rc |= expect_int("ee72 null input preserves flag", state.csi_ee, 1);
+    rc |= expect_bytes("ee72 null input preserves key", state.csi_ee_key, original_key, sizeof(original_key));
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    rc |= expect_int("ee72 invalid character", connect_systems_ee72_key_creation(&state, "11223344zz66778899", 0), -1);
+    rc |= expect_int("ee72 invalid character flag", state.csi_ee, 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    rc |= expect_int("ee72 overlong input",
+                     connect_systems_ee72_key_creation(&state, "112233445566778899AABBCCDDEEFF001122", 0), -1);
+    rc |= expect_int("ee72 overlong flag", state.csi_ee, 0);
+    return rc;
+}
+
+static int
+test_ee72_accepts_leading_space_upper_prefix_and_lowercase(void) {
+    static const uint8_t expect[] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11, 0x22};
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    int parse_rc = connect_systems_ee72_key_creation(&state, "\t 0Xaa bb cc dd ee ff 00 11 22", 0);
+
+    int rc = 0;
+    rc |= expect_int("ee72 lowercase parse", parse_rc, 0);
+    rc |= expect_int("ee72 lowercase flag", state.csi_ee, 1);
+    rc |= expect_bytes("ee72 lowercase key", state.csi_ee_key, expect, sizeof(expect));
+    return rc;
+}
+
+static int
 test_csi72_frame_transform_vector(void) {
     static const uint8_t key[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
     static const char expect[] =
@@ -126,6 +166,30 @@ test_csi72_frame_transform_vector(void) {
 
     csi72_ambe2_codeword_keystream(&state, frame);
     return expect_frame_string("csi72 frame", frame, expect);
+}
+
+static int
+test_csi72_inactive_keeps_frame(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    char frame[4][24];
+    char original[4][24];
+    for (int r = 0; r < 4; r++) {
+        for (int c = 0; c < 24; c++) {
+            frame[r][c] = (char)(((r * 24 + c) + 1) & 1);
+            original[r][c] = frame[r][c];
+        }
+    }
+
+    csi72_ambe2_codeword_keystream(NULL, frame);
+    int rc = expect_bytes("csi72 null state preserves frame", (const uint8_t*)frame, (const uint8_t*)original,
+                          sizeof(frame));
+
+    csi72_ambe2_codeword_keystream(&state, frame);
+    rc |= expect_bytes("csi72 inactive state preserves frame", (const uint8_t*)frame, (const uint8_t*)original,
+                       sizeof(frame));
+    return rc;
 }
 
 static int
@@ -163,7 +227,10 @@ main(void) {
     int rc = 0;
     rc |= test_ee72_key_parse();
     rc |= test_ee72_rejects_invalid_length();
+    rc |= test_ee72_rejects_null_and_malformed_inputs();
+    rc |= test_ee72_accepts_leading_space_upper_prefix_and_lowercase();
     rc |= test_csi72_frame_transform_vector();
+    rc |= test_csi72_inactive_keeps_frame();
     rc |= test_ee72_key_log_respects_show_keys();
     return rc;
 }

--- a/tests/crypto/test_pc4_tyt.c
+++ b/tests/crypto/test_pc4_tyt.c
@@ -331,6 +331,19 @@ test_tyt_ap_apply_skips_silence_and_zero_tail(void) {
     state.tyt_ap = 1;
 
     int rc = 0;
+    char inactive[49];
+    for (int i = 0; i < 49; i++) {
+        inactive[i] = (char)((i + 1) & 1U);
+    }
+    char inactive_original[49];
+    DSD_MEMCPY(inactive_original, inactive, sizeof(inactive_original));
+    static dsd_state inactive_state;
+    DSD_MEMSET(&inactive_state, 0, sizeof(inactive_state));
+    rc |= expect_int("tyt ap null state", tyt_ap_pc4_apply_frame49(NULL, inactive), 0);
+    rc |= expect_int("tyt ap null frame", tyt_ap_pc4_apply_frame49(&state, NULL), 0);
+    rc |= expect_int("tyt ap inactive state", tyt_ap_pc4_apply_frame49(&inactive_state, inactive), 0);
+    rc |= expect_char_frame("tyt ap inactive frame", inactive, inactive_original);
+
     char silence[49];
     fill_default_silence(silence);
     char original_silence[49];
@@ -387,6 +400,19 @@ test_tyt_ep_apply_skips_silence_and_zero_tail(void) {
     }
 
     int rc = 0;
+    char inactive[49];
+    for (int i = 0; i < 49; i++) {
+        inactive[i] = (char)((i + 1) & 1U);
+    }
+    char inactive_original[49];
+    DSD_MEMCPY(inactive_original, inactive, sizeof(inactive_original));
+    static dsd_state inactive_state;
+    DSD_MEMSET(&inactive_state, 0, sizeof(inactive_state));
+    rc |= expect_int("tyt ep null state", tyt_ep_aes_apply_frame49(NULL, inactive), 0);
+    rc |= expect_int("tyt ep null frame", tyt_ep_aes_apply_frame49(&state, NULL), 0);
+    rc |= expect_int("tyt ep inactive state", tyt_ep_aes_apply_frame49(&inactive_state, inactive), 0);
+    rc |= expect_char_frame("tyt ep inactive frame", inactive, inactive_original);
+
     char silence[49];
     fill_default_silence(silence);
     char original_silence[49];

--- a/tests/crypto/test_pc5_baofeng.c
+++ b/tests/crypto/test_pc5_baofeng.c
@@ -169,6 +169,28 @@ test_baofeng_128_key_schedule(void) {
 }
 
 static int
+test_baofeng_128_lowercase_key_schedule(void) {
+    PC5Context expected;
+    DSD_MEMSET(&expected, 0, sizeof(expected));
+    unsigned char key[16];
+    DSD_MEMSET(key, 0, sizeof(key));
+    build_pc5_128_key(0x0123456789ABCDEFULL, 0xFEDCBA9876543210ULL, key);
+    create_keys_pc5(&expected, key, sizeof(key));
+    expected.rounds = PC5_NBROUND;
+
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctxpc5, 0, sizeof(ctxpc5));
+    int parse_rc = baofeng_ap_pc5_keystream_creation(&state, "0123456789abcdef fedcba9876543210", 0);
+
+    int rc = 0;
+    rc |= expect_int("baofeng 128 lowercase parse", parse_rc, 0);
+    rc |= expect_int("baofeng 128 lowercase flag", state.baofeng_ap, 1);
+    rc |= expect_pc5_schedule("baofeng 128 lowercase", &ctxpc5, &expected);
+    return rc;
+}
+
+static int
 test_baofeng_256_key_schedule_uses_ascii_hex(void) {
     PC5Context expected;
     DSD_MEMSET(&expected, 0, sizeof(expected));
@@ -219,6 +241,99 @@ test_baofeng_rejects_invalid_hex(void) {
     int rc = 0;
     rc |= expect_int("baofeng invalid parse", parse_rc, -1);
     rc |= expect_int("baofeng invalid flag", state.baofeng_ap, 0);
+    return rc;
+}
+
+static int
+test_baofeng_rejects_null_empty_and_bad_length(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.baofeng_ap = 1;
+
+    int rc = 0;
+    rc |= expect_int("baofeng null state", baofeng_ap_pc5_keystream_creation(NULL, "0123456789ABCDEF", 0), -1);
+    rc |= expect_int("baofeng null input", baofeng_ap_pc5_keystream_creation(&state, NULL, 0), -1);
+    rc |= expect_int("baofeng null input preserves flag", state.baofeng_ap, 1);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    rc |= expect_int("baofeng empty input", baofeng_ap_pc5_keystream_creation(&state, "", 0), -1);
+    rc |= expect_int("baofeng empty flag", state.baofeng_ap, 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    rc |= expect_int("baofeng bad length", baofeng_ap_pc5_keystream_creation(&state, "0123456789ABCDEF", 0), -1);
+    rc |= expect_int("baofeng bad length flag", state.baofeng_ap, 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    rc |= expect_int("baofeng overlong input",
+                     baofeng_ap_pc5_keystream_creation(
+                         &state, "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEFF0", 0),
+                     -1);
+    rc |= expect_int("baofeng overlong flag", state.baofeng_ap, 0);
+    return rc;
+}
+
+static int
+test_baofeng_apply_inactive_and_null_guards(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    char frame[49];
+    char original[49];
+    for (int i = 0; i < 49; i++) {
+        frame[i] = (char)((i * 5 + 1) & 1);
+        original[i] = frame[i];
+    }
+
+    int rc = 0;
+    rc |= expect_int("baofeng apply null state", baofeng_pc5_apply_frame49(NULL, frame), 0);
+    rc |= expect_char_frame("baofeng null state preserves frame", frame, original);
+    rc |= expect_int("baofeng apply inactive", baofeng_pc5_apply_frame49(&state, frame), 0);
+    rc |= expect_char_frame("baofeng inactive preserves frame", frame, original);
+    state.baofeng_ap = 1;
+    rc |= expect_int("baofeng apply null frame", baofeng_pc5_apply_frame49(&state, NULL), 0);
+    return rc;
+}
+
+static int
+test_pc5_encrypt_decrypt_roundtrip_and_round_guards(void) {
+    unsigned char key[16];
+    DSD_MEMSET(key, 0, sizeof(key));
+    build_pc5_128_key(0x0123456789ABCDEFULL, 0xFEDCBA9876543210ULL, key);
+
+    PC5Context ctx;
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    create_keys_pc5(&ctx, key, sizeof(key));
+    ctx.rounds = PC5_NBROUND;
+    for (int i = 0; i < 6; i++) {
+        ctx.convert[i] = (uint8_t)((i * 3 + 1) & 0x0F);
+    }
+    uint8_t plain[6];
+    DSD_MEMCPY(plain, ctx.convert, sizeof(plain));
+
+    pc5encrypt(&ctx);
+    int rc = 0;
+    if (memcmp(ctx.convert, plain, sizeof(plain)) == 0) {
+        DSD_FPRINTF(stderr, "pc5 encrypt did not change block\n");
+        rc = 1;
+    }
+    pc5decrypt(&ctx);
+    if (memcmp(ctx.convert, plain, sizeof(plain)) != 0) {
+        DSD_FPRINTF(stderr, "pc5 decrypt did not restore encrypted block\n");
+        rc = 1;
+    }
+
+    DSD_MEMCPY(ctx.convert, plain, sizeof(plain));
+    ctx.rounds = 0;
+    pc5encrypt(&ctx);
+    rc |= expect_int("pc5 encrypt zero-round no-op", memcmp(ctx.convert, plain, sizeof(plain)), 0);
+    pc5decrypt(&ctx);
+    rc |= expect_int("pc5 decrypt zero-round no-op", memcmp(ctx.convert, plain, sizeof(plain)), 0);
+
+    ctx.rounds = 255U;
+    pc5encrypt(&ctx);
+    rc |= expect_int("pc5 encrypt high-round no-op", memcmp(ctx.convert, plain, sizeof(plain)), 0);
+    pc5decrypt(&ctx);
+    rc |= expect_int("pc5 decrypt high-round no-op", memcmp(ctx.convert, plain, sizeof(plain)), 0);
     return rc;
 }
 
@@ -325,10 +440,14 @@ int
 main(void) {
     int rc = 0;
     rc |= test_pc5_decrypt_frame_vector();
+    rc |= test_pc5_encrypt_decrypt_roundtrip_and_round_guards();
     rc |= test_baofeng_128_key_schedule();
+    rc |= test_baofeng_128_lowercase_key_schedule();
     rc |= test_baofeng_256_key_schedule_uses_ascii_hex();
     rc |= test_baofeng_256_key_schedule_preserves_ascii_case();
     rc |= test_baofeng_rejects_invalid_hex();
+    rc |= test_baofeng_rejects_null_empty_and_bad_length();
+    rc |= test_baofeng_apply_inactive_and_null_guards();
     rc |= test_baofeng_apply_skips_silence_and_zero_tail();
     rc |= test_baofeng_apply_decrypts_voice_frame();
     rc |= test_baofeng_key_log_respects_show_keys();

--- a/tests/dsp/test_dsp_audio_filters.cpp
+++ b/tests/dsp/test_dsp_audio_filters.cpp
@@ -5,9 +5,11 @@
 
 /* Unit tests: audio_lpf_filter and dc_block_filter behavior. */
 
+#include <cmath>
 #include <cstdlib>
 #include <dsd-neo/dsp/demod_pipeline.h>
 #include <dsd-neo/dsp/demod_state.h>
+#include <dsd-neo/dsp/sps_filters.h>
 #include <stdio.h>
 #include "dsd-neo/core/safe_api.h"
 
@@ -19,6 +21,62 @@ monotonic_nondecreasing(const float* x, int n) {
         }
     }
     return 1;
+}
+
+typedef float (*sps_filter_fn)(float sample, int samples_per_symbol);
+
+static int
+expect_sps_filter_response(const char* name, sps_filter_fn filter, int base_sps, int redesign_sps) {
+    init_rrc_filter_memory();
+    if (filter(123.0f, 1) != 123.0f) {
+        DSD_FPRINTF(stderr, "%s: sps<=1 bypass failed\n", name);
+        return 1;
+    }
+
+    float base_sum = 0.0f;
+    float base_abs = 0.0f;
+    for (int i = 0; i < 160; i++) {
+        float y = filter(i == 0 ? 1.0f : 0.0f, base_sps);
+        if (!std::isfinite(y)) {
+            DSD_FPRINTF(stderr, "%s: non-finite base response at %d\n", name, i);
+            return 1;
+        }
+        base_sum += y;
+        base_abs += std::fabs(y);
+    }
+    if (!(base_abs > 0.01f && base_sum > 0.80f && base_sum < 1.20f)) {
+        DSD_FPRINTF(stderr, "%s: unexpected base response sum=%f abs=%f\n", name, base_sum, base_abs);
+        return 1;
+    }
+
+    init_rrc_filter_memory();
+    float redesign_sum = 0.0f;
+    float redesign_abs = 0.0f;
+    for (int i = 0; i < 220; i++) {
+        float y = filter(i == 0 ? 1.0f : 0.0f, redesign_sps);
+        if (!std::isfinite(y)) {
+            DSD_FPRINTF(stderr, "%s: non-finite redesign response at %d\n", name, i);
+            return 1;
+        }
+        redesign_sum += y;
+        redesign_abs += std::fabs(y);
+    }
+    if (!(redesign_abs > 0.01f && redesign_sum > 0.80f && redesign_sum < 1.20f)) {
+        DSD_FPRINTF(stderr, "%s: unexpected redesign response sum=%f abs=%f\n", name, redesign_sum, redesign_abs);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_sps_filter_wrappers(void) {
+    int rc = 0;
+    rc |= expect_sps_filter_response("dmr", dmr_filter, 10, 8);
+    rc |= expect_sps_filter_response("nxdn", nxdn_filter, 20, 10);
+    rc |= expect_sps_filter_response("dpmr", dpmr_filter, 20, 12);
+    rc |= expect_sps_filter_response("m17", m17_filter, 10, 8);
+    rc |= expect_sps_filter_response("p25", p25_filter, 10, 8);
+    return rc;
 }
 
 int
@@ -77,6 +135,11 @@ main(void) {
             free(s);
             return 1;
         }
+    }
+
+    if (test_sps_filter_wrappers() != 0) {
+        free(s);
+        return 1;
     }
 
     free(s);

--- a/tests/dsp/test_dsp_costas.cpp
+++ b/tests/dsp/test_dsp_costas.cpp
@@ -18,14 +18,15 @@
  * kicks with adaptive damping for abrupt raw-error jumps.
  */
 
+#include <cmath>
 #include <dsd-neo/dsp/costas.h>
 #include <dsd-neo/dsp/demod_state.h>
 #include <dsd-neo/dsp/ted.h>
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/runtime/config.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include "dsd-neo/core/safe_api.h"
 
 static demod_state*
@@ -777,6 +778,255 @@ test_p25p2_tracking_gain_honors_runtime_override_after_lock(void) {
     return expect_p25p2_tracking_gain_after_lock("P25P2 runtime TED gain", 0.031f, 1, 0.031f);
 }
 
+/*
+ * Test: public reset helpers tolerate null pointers and clear documented state.
+ */
+static int
+test_reset_helpers_clear_tracking_state(void) {
+    dsd_costas_reset(NULL);
+    dsd_fll_band_edge_reset(NULL);
+
+    dsd_costas_loop_state_t c;
+    DSD_MEMSET(&c, 0, sizeof(c));
+    c.phase = 0.9f;
+    c.freq = -0.3f;
+    c.error = 0.2f;
+    c.error_smooth = -0.1f;
+    c.alpha = 0.04f;
+    c.initialized = 1;
+
+    dsd_costas_reset(&c);
+    if (c.phase != 0.0f || c.freq != 0.0f || c.error != 0.0f || c.error_smooth != 0.0f || c.initialized != 0
+        || c.alpha != 0.04f) {
+        DSD_FPRINTF(stderr, "RESET: Costas reset left phase=%f freq=%f err=%f smooth=%f init=%d alpha=%f\n", c.phase,
+                    c.freq, c.error, c.error_smooth, c.initialized, c.alpha);
+        return 1;
+    }
+
+    dsd_fll_band_edge_state_t f;
+    DSD_MEMSET(&f, 0, sizeof(f));
+    dsd_fll_band_edge_init(&f, 5);
+    f.phase = 0.7f;
+    f.freq = -0.2f;
+    f.delay_idx = 3;
+    f.delay_r[0] = 1.0f;
+    f.delay_i[0] = -1.0f;
+    const float tap0 = f.taps_upper_r[0];
+    const int n_taps = f.n_taps;
+
+    dsd_fll_band_edge_reset(&f);
+    if (std::fabs(f.phase) > 1e-7f || std::fabs(f.freq) > 1e-7f || f.delay_idx != 0 || std::fabs(f.delay_r[0]) > 1e-7f
+        || std::fabs(f.delay_i[0]) > 1e-7f || std::fabs(f.taps_upper_r[0] - tap0) > 1e-7f || f.n_taps != n_taps
+        || !f.initialized) {
+        DSD_FPRINTF(stderr, "RESET: FLL reset phase=%f freq=%f delay=%d tap0=%f/%f n_taps=%d/%d initialized=%d\n",
+                    f.phase, f.freq, f.delay_idx, f.taps_upper_r[0], tap0, f.n_taps, n_taps, f.initialized);
+        return 1;
+    }
+
+    return 0;
+}
+
+/*
+ * Test: diff phasor guard paths leave state untouched when there is no full
+ * complex sample to process.
+ */
+static int
+test_diff_phasor_short_block_preserves_state(void) {
+    op25_diff_phasor_cc(NULL);
+
+    static float buf[2] = {0.25f, -0.5f};
+    demod_state* s = alloc_state();
+    if (!s) {
+        DSD_FPRINTF(stderr, "alloc failed\n");
+        return 1;
+    }
+    s->lowpassed = buf;
+    s->lp_len = 1;
+    s->cqpsk_diff_prev_r = 0.4f;
+    s->cqpsk_diff_prev_j = -0.7f;
+
+    op25_diff_phasor_cc(s);
+
+    if (buf[0] != 0.25f || buf[1] != -0.5f || s->cqpsk_diff_prev_r != 0.4f || s->cqpsk_diff_prev_j != -0.7f) {
+        DSD_FPRINTF(stderr, "DIFF GUARD: short block changed buf=(%f,%f) prev=(%f,%f)\n", buf[0], buf[1],
+                    s->cqpsk_diff_prev_r, s->cqpsk_diff_prev_j);
+        free(s);
+        return 1;
+    }
+
+    free(s);
+    return 0;
+}
+
+/*
+ * Test: unsafe Costas loop state is clamped before and after a symbol update.
+ */
+static int
+test_costas_clamps_initial_phase_and_frequency(void) {
+    static float buf[4] = {0.7f, 0.0f, 0.0f, -0.7f};
+    demod_state* s = alloc_state();
+    if (!s) {
+        DSD_FPRINTF(stderr, "alloc failed\n");
+        return 1;
+    }
+    s->lowpassed = buf;
+    s->lp_len = 4;
+    s->cqpsk_enable = 1;
+    s->costas_state.initialized = 1;
+    s->costas_state.phase = 10.0f;
+    s->costas_state.freq = 2.0f;
+    s->costas_state.alpha = 0.0f;
+    s->costas_state.beta = 0.0f;
+    s->costas_state.max_freq = 1.0f;
+    s->costas_state.min_freq = -1.0f;
+
+    op25_costas_loop_cc(s);
+
+    if (fabsf(s->costas_state.phase - (float)(M_PI / 2.0)) > 0.001f || s->costas_state.freq != 1.0f
+        || !std::isfinite(buf[0]) || !std::isfinite(buf[1])) {
+        DSD_FPRINTF(stderr, "COSTAS CLAMP: high clamp phase=%f freq=%f out=(%f,%f)\n", s->costas_state.phase,
+                    s->costas_state.freq, buf[0], buf[1]);
+        free(s);
+        return 1;
+    }
+
+    buf[0] = 0.7f;
+    buf[1] = 0.0f;
+    s->lp_len = 2;
+    s->costas_state.phase = -10.0f;
+    s->costas_state.freq = -2.0f;
+
+    op25_costas_loop_cc(s);
+
+    if (fabsf(s->costas_state.phase + (float)(M_PI / 2.0)) > 0.001f || s->costas_state.freq != -1.0f) {
+        DSD_FPRINTF(stderr, "COSTAS CLAMP: low clamp phase=%f freq=%f\n", s->costas_state.phase, s->costas_state.freq);
+        free(s);
+        return 1;
+    }
+
+    free(s);
+    return 0;
+}
+
+/*
+ * Test: non-finite detector magnitudes do not train the loop and are reported
+ * as zero-confidence samples.
+ */
+static int
+test_costas_nonfinite_sample_is_rejected(void) {
+    static float buf[2] = {INFINITY, 0.5f};
+    demod_state* s = alloc_state();
+    if (!s) {
+        DSD_FPRINTF(stderr, "alloc failed\n");
+        return 1;
+    }
+    s->lowpassed = buf;
+    s->lp_len = 2;
+    s->cqpsk_enable = 1;
+    s->costas_state.initialized = 1;
+    s->costas_state.phase = 0.2f;
+    s->costas_state.freq = 0.1f;
+    s->costas_state.alpha = 0.04f;
+    s->costas_state.beta = 0.0002f;
+    s->costas_state.max_freq = 1.0f;
+    s->costas_state.min_freq = -1.0f;
+
+    op25_costas_loop_cc(s);
+
+    if (buf[0] != 0.0f || buf[1] != 0.0f || s->costas_state.error != 0.0f || s->costas_state.error_smooth != 0.0f
+        || s->costas_conf_avg_q14 != 0 || s->costas_zero_conf_pct != 100) {
+        DSD_FPRINTF(stderr, "COSTAS NONFINITE: out=(%f,%f) err=%f smooth=%f conf=%d zero=%d\n", buf[0], buf[1],
+                    s->costas_state.error, s->costas_state.error_smooth, s->costas_conf_avg_q14,
+                    s->costas_zero_conf_pct);
+        free(s);
+        return 1;
+    }
+
+    free(s);
+    return 0;
+}
+
+/*
+ * Test: Gardner refuses SPS values that would overrun the fixed MMSE delay
+ * line and reports no output symbols.
+ */
+static int
+test_gardner_oversized_sps_disables_output(void) {
+    static float buf[32];
+    for (int i = 0; i < 32; i++) {
+        buf[i] = (i & 1) ? -0.2f : 0.6f;
+    }
+
+    demod_state* s = alloc_state();
+    if (!s) {
+        DSD_FPRINTF(stderr, "alloc failed\n");
+        return 1;
+    }
+    s->cqpsk_enable = 1;
+    s->lowpassed = buf;
+    s->lp_len = 32;
+    s->ted_sps = 200;
+
+    op25_gardner_cc(s);
+
+    if (s->lp_len != 0 || s->ted_state.twice_sps != 0 || s->ted_state.omega_mid != 200.0f) {
+        DSD_FPRINTF(stderr, "GARDNER OVERSIZE: lp_len=%d twice_sps=%d omega_mid=%f\n", s->lp_len,
+                    s->ted_state.twice_sps, s->ted_state.omega_mid);
+        free(s);
+        return 1;
+    }
+
+    free(s);
+    return 0;
+}
+
+/*
+ * Test: FLL band-edge block initializes lazily and processes an IQ block in
+ * place while preserving a bounded loop state.
+ */
+static int
+test_fll_band_edge_processes_block(void) {
+    const int pairs = 64;
+    static float buf[pairs * 2];
+    for (int k = 0; k < pairs; k++) {
+        const float phase = 0.11f * (float)k;
+        buf[(size_t)k * 2] = cosf(phase);
+        buf[(size_t)k * 2 + 1] = sinf(phase);
+    }
+
+    demod_state* s = alloc_state();
+    if (!s) {
+        DSD_FPRINTF(stderr, "alloc failed\n");
+        return 1;
+    }
+    s->cqpsk_enable = 1;
+    s->lowpassed = buf;
+    s->lp_len = pairs * 2;
+    s->ted_sps = 5;
+    s->rate_out = 24000;
+
+    op25_fll_band_edge_cc(s);
+
+    dsd_fll_band_edge_state_t* f = &s->fll_band_edge_state;
+    const int expected_delay = pairs % f->n_taps;
+    if (!f->initialized || f->sps != 5 || f->n_taps != 11 || f->delay_idx != expected_delay || !std::isfinite(f->phase)
+        || !std::isfinite(f->freq) || f->freq < f->min_freq || f->freq > f->max_freq) {
+        DSD_FPRINTF(stderr, "FLL PROCESS: initialized=%d sps=%d taps=%d delay=%d/%d phase=%f freq=%f min=%f max=%f\n",
+                    f->initialized, f->sps, f->n_taps, f->delay_idx, expected_delay, f->phase, f->freq, f->min_freq,
+                    f->max_freq);
+        free(s);
+        return 1;
+    }
+    if (f->delay_r[0] == 0.0f && f->delay_i[0] == 0.0f) {
+        DSD_FPRINTF(stderr, "FLL PROCESS: delay line was not populated\n");
+        free(s);
+        return 1;
+    }
+
+    free(s);
+    return 0;
+}
+
 int
 main(void) {
     if (test_basic_passthrough() != 0) {
@@ -816,6 +1066,24 @@ main(void) {
         return 1;
     }
     if (test_p25p2_tracking_gain_honors_runtime_override_after_lock() != 0) {
+        return 1;
+    }
+    if (test_reset_helpers_clear_tracking_state() != 0) {
+        return 1;
+    }
+    if (test_diff_phasor_short_block_preserves_state() != 0) {
+        return 1;
+    }
+    if (test_costas_clamps_initial_phase_and_frequency() != 0) {
+        return 1;
+    }
+    if (test_costas_nonfinite_sample_is_rejected() != 0) {
+        return 1;
+    }
+    if (test_gardner_oversized_sps_disables_output() != 0) {
+        return 1;
+    }
+    if (test_fll_band_edge_processes_block() != 0) {
         return 1;
     }
     return 0;

--- a/tests/dsp/test_dsp_firdes.c
+++ b/tests/dsp/test_dsp_firdes.c
@@ -18,6 +18,32 @@ expect_close(const char* tag, float got, float want, float tol) {
     return 0;
 }
 
+static int
+expect_double_close(const char* tag, double got, double want, double tol) {
+    double diff = fabs(got - want);
+    if (diff > tol) {
+        DSD_FPRINTF(stderr, "%s: got %.6f want %.6f (diff=%.6f)\n", tag, got, want, diff);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_symmetric_finite_window(const char* tag, const float* taps, int ntaps) {
+    for (int i = 0; i < ntaps; i++) {
+        if (!isfinite(taps[i])) {
+            DSD_FPRINTF(stderr, "%s: tap %d is not finite: %f\n", tag, i, taps[i]);
+            return 1;
+        }
+    }
+    for (int i = 0; i < ntaps / 2; i++) {
+        if (expect_close(tag, taps[i], taps[ntaps - 1 - i], 1e-5f) != 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -53,6 +79,52 @@ main(void) {
         rc = 1;
     }
 
+    rc |= expect_double_close("hamming attenuation", dsd_window_max_attenuation(DSD_WIN_HAMMING), 53.0, 1e-9);
+    rc |= expect_double_close("hann attenuation", dsd_window_max_attenuation(DSD_WIN_HANN), 44.0, 1e-9);
+    rc |= expect_double_close("blackman attenuation", dsd_window_max_attenuation(DSD_WIN_BLACKMAN), 74.0, 1e-9);
+    rc |= expect_double_close("rectangular attenuation", dsd_window_max_attenuation(DSD_WIN_RECTANGULAR), 21.0, 1e-9);
+    rc |= expect_double_close("blackman-harris attenuation", dsd_window_max_attenuation(DSD_WIN_BLACKMAN_HARRIS), 92.0,
+                              1e-9);
+    rc |= expect_double_close("bartlett attenuation", dsd_window_max_attenuation(DSD_WIN_BARTLETT), 27.0, 1e-9);
+    rc |= expect_double_close("flattop attenuation", dsd_window_max_attenuation(DSD_WIN_FLATTOP), 93.0, 1e-9);
+    rc |= expect_double_close("default attenuation", dsd_window_max_attenuation((dsd_window_type_t)99), 53.0, 1e-9);
+
+    {
+        enum { kWindowNtaps = 17 };
+
+        static const struct {
+            dsd_window_type_t type;
+            const char* tag;
+        } window_cases[] = {
+            {DSD_WIN_HAMMING, "hamming"},         {DSD_WIN_HANN, "hann"},
+            {DSD_WIN_BLACKMAN, "blackman"},       {DSD_WIN_BLACKMAN_HARRIS, "blackman-harris"},
+            {DSD_WIN_BARTLETT, "bartlett"},       {DSD_WIN_FLATTOP, "flattop"},
+            {DSD_WIN_RECTANGULAR, "rectangular"}, {(dsd_window_type_t)99, "default-rectangular"},
+        };
+
+        for (size_t c = 0; c < sizeof window_cases / sizeof window_cases[0]; c++) {
+            float taps[kWindowNtaps];
+            dsd_window_build(window_cases[c].type, kWindowNtaps, taps);
+            rc |= expect_symmetric_finite_window(window_cases[c].tag, taps, kWindowNtaps);
+            if (window_cases[c].type == DSD_WIN_RECTANGULAR || window_cases[c].type == (dsd_window_type_t)99) {
+                for (int i = 0; i < kWindowNtaps; i++) {
+                    rc |= expect_close(window_cases[c].tag, taps[i], 1.0f, 1e-6f);
+                }
+            } else if (!(taps[kWindowNtaps / 2] > taps[0])) {
+                DSD_FPRINTF(stderr, "%s window center should exceed edge: edge=%f center=%f\n", window_cases[c].tag,
+                            taps[0], taps[kWindowNtaps / 2]);
+                rc = 1;
+            }
+        }
+    }
+
+    {
+        float one = 0.0f;
+        dsd_window_build(DSD_WIN_KAISER, 0, &one);
+        dsd_window_build(DSD_WIN_KAISER, 1, &one);
+        rc |= expect_close("kaiser single tap", one, 1.0f, 1e-6f);
+    }
+
     float taps_kaiser[512];
     float taps_rect[512];
     int ntaps_kaiser = dsd_firdes_low_pass(1.0, 48000.0, 7000.0, 1200.0, DSD_WIN_KAISER, taps_kaiser,
@@ -69,6 +141,21 @@ main(void) {
     if (ntaps_kaiser <= ntaps_rect) {
         DSD_FPRINTF(stderr, "Kaiser should require more taps than rectangular (kaiser=%d rect=%d)\n", ntaps_kaiser,
                     ntaps_rect);
+        rc = 1;
+    }
+
+    if ((ntaps_kaiser & 1) == 0 || dsd_firdes_compute_ntaps(48000.0, 1200.0, (dsd_window_type_t)99) <= 0) {
+        DSD_FPRINTF(stderr, "computed tap counts should be positive and odd\n");
+        rc = 1;
+    }
+
+    if (dsd_firdes_low_pass(1.0, 0.0, 7000.0, 1200.0, DSD_WIN_HAMMING, taps_rect, 512) != -1
+        || dsd_firdes_low_pass(1.0, 48000.0, 0.0, 1200.0, DSD_WIN_HAMMING, taps_rect, 512) != -1
+        || dsd_firdes_low_pass(1.0, 48000.0, 25000.0, 1200.0, DSD_WIN_HAMMING, taps_rect, 512) != -1
+        || dsd_firdes_low_pass(1.0, 48000.0, 7000.0, 0.0, DSD_WIN_HAMMING, taps_rect, 512) != -1
+        || dsd_firdes_low_pass(1.0, 48000.0, 7000.0, 1200.0, DSD_WIN_HAMMING, taps_rect, 4) != -1
+        || dsd_firdes_low_pass(1.0, 48000.0, 7000.0, 10.0, DSD_WIN_HAMMING, taps_rect, 4096) != -1) {
+        DSD_FPRINTF(stderr, "firdes low_pass validation guards failed\n");
         rc = 1;
     }
 

--- a/tests/dsp/test_dsp_pcm_input_staging.c
+++ b/tests/dsp/test_dsp_pcm_input_staging.c
@@ -20,8 +20,37 @@ expect_close(const char* label, float actual, float expected, float tol) {
     }
 }
 
-int
-main(void) {
+static void
+test_public_guards_and_disabled_factor(void) {
+    assert(dsd_pcm_input_uses_staged_resampler(NULL) == 0);
+    dsd_pcm_input_stage_resample(NULL, 1200.0f);
+    assert(dsd_pcm_input_begin_resampler_tail(NULL) == 0);
+    assert(dsd_pcm_input_stage_resampler_tail(NULL) == 0);
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.audio_in_type = AUDIO_IN_PULSE;
+    opts.wav_sample_rate = 8000;
+    assert(dsd_opts_input_upsample_factor(&opts) == 6);
+    assert(dsd_pcm_input_uses_staged_resampler(&opts) == 0);
+
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    opts.input_upsample_len = 3;
+    opts.input_upsample_pos = 2;
+    opts.input_upsample_tail_blocks = 1;
+    opts.input_upsample_prev = 42.0f;
+    opts.input_upsample_prev_valid = 1;
+    dsd_pcm_input_stage_resample(&opts, -120.0f);
+    assert(opts.input_upsample_len == 3);
+    assert(opts.input_upsample_pos == 2);
+    assert(opts.input_upsample_tail_blocks == 1);
+    assert(opts.input_upsample_prev == 42.0f);
+    assert(opts.input_upsample_prev_valid == 1);
+}
+
+static void
+test_staged_resampler_lifecycle(void) {
     static dsd_opts opts;
     DSD_MEMSET(&opts, 0, sizeof(opts));
     opts.audio_in_type = AUDIO_IN_TCP;
@@ -50,6 +79,10 @@ main(void) {
     assert(dsd_pcm_input_begin_resampler_tail(&opts) == 1);
 
     int expected_tail_blocks = opts.input_resampler.taps_per_phase - 1;
+    assert(opts.input_upsample_tail_blocks == expected_tail_blocks);
+    assert(dsd_pcm_input_begin_resampler_tail(&opts) == 1);
+    assert(opts.input_upsample_tail_blocks == expected_tail_blocks);
+
     int flushed_tail_blocks = 0;
     int flushed_tail_samples = 0;
     while (dsd_pcm_input_stage_resampler_tail(&opts)) {
@@ -78,5 +111,68 @@ main(void) {
     }
 
     dsd_resampler_reset(&opts.input_resampler);
+}
+
+static void
+test_stage_falls_back_when_resampler_state_rejects_block(void) {
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.audio_in_type = AUDIO_IN_TCP;
+    opts.wav_sample_rate = 8000;
+
+    const int factor = dsd_opts_input_upsample_factor(&opts);
+    dsd_pcm_input_stage_resample(&opts, 300.0f);
+    assert(opts.input_resampler.enabled == 1);
+    opts.input_resampler.phase = factor + 1;
+
+    dsd_pcm_input_stage_resample(&opts, -125.0f);
+    assert(opts.input_upsample_len == factor);
+    assert(opts.input_upsample_pos == 0);
+    assert(opts.input_upsample_prev_valid == 1);
+    assert(opts.input_upsample_prev == -125.0f);
+    for (int i = 0; i < factor; i++) {
+        char label[64];
+        DSD_SNPRINTF(label, sizeof(label), "fallback staged sample %d", i);
+        expect_close(label, opts.input_upsample_buf[i], -125.0f, 0.01f);
+    }
+
+    dsd_resampler_reset(&opts.input_resampler);
+}
+
+static void
+test_tail_flush_clears_state_when_resampler_rejects_block(void) {
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.audio_in_type = AUDIO_IN_TCP;
+    opts.wav_sample_rate = 8000;
+
+    const int factor = dsd_opts_input_upsample_factor(&opts);
+    dsd_pcm_input_stage_resample(&opts, 50.0f);
+    dsd_pcm_input_stage_resample(&opts, 75.0f);
+    assert(dsd_pcm_input_begin_resampler_tail(&opts) == 1);
+
+    opts.input_resampler.phase = factor + 1;
+    assert(dsd_pcm_input_stage_resampler_tail(&opts) == 0);
+    assert(opts.input_upsample_tail_blocks == 0);
+    assert(opts.input_resampler.phase == 0);
+    assert(opts.input_resampler.hist_head == 0);
+    assert(opts.input_upsample_prev == 0.0f);
+    assert(opts.input_upsample_prev_valid == 0);
+
+    for (int i = 0; i < opts.input_resampler.taps_per_phase * 2; i++) {
+        char label[64];
+        DSD_SNPRINTF(label, sizeof(label), "cleared history sample %d", i);
+        expect_close(label, opts.input_resampler.hist[i], 0.0f, 0.0001f);
+    }
+
+    dsd_resampler_reset(&opts.input_resampler);
+}
+
+int
+main(void) {
+    test_public_guards_and_disabled_factor();
+    test_staged_resampler_lifecycle();
+    test_stage_falls_back_when_resampler_state_rejects_block();
+    test_tail_flush_clears_state_when_resampler_rejects_block();
     return 0;
 }

--- a/tests/dsp/test_dsp_resampler.cpp
+++ b/tests/dsp/test_dsp_resampler.cpp
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(performance-no-int-to-ptr)
 /*
  * Copyright (C) 2025 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -480,6 +483,96 @@ cleanup:
     return rc;
 }
 
+static int
+test_public_guard_and_passthrough_contracts(void) {
+    dsd_resampler_reset(NULL);
+    dsd_resampler_clear_history(NULL);
+
+    dsd_resampler_state invalid = {};
+    invalid.enabled = 1;
+    invalid.L = 7;
+    invalid.M = 5;
+    invalid.taps = reinterpret_cast<float*>(static_cast<uintptr_t>(0x1));
+    invalid.hist = reinterpret_cast<float*>(static_cast<uintptr_t>(0x2));
+    if (dsd_resampler_design(&invalid, 0, 1) != 0) {
+        DSD_FPRINTF(stderr, "invalid design unexpectedly succeeded\n");
+        return 1;
+    }
+    if (invalid.enabled != 0 || invalid.L != 1 || invalid.M != 1 || invalid.taps != NULL || invalid.hist != NULL) {
+        DSD_FPRINTF(stderr, "invalid design did not reset first-use state\n");
+        return 1;
+    }
+
+    dsd_resampler_state first_use = {};
+    dsd_resampler_clear_history(&first_use);
+    if (first_use.enabled != 0 || first_use.L != 1 || first_use.M != 1 || first_use.taps != NULL
+        || first_use.hist != NULL) {
+        DSD_FPRINTF(stderr, "clear_history did not initialize first-use state\n");
+        return 1;
+    }
+
+    float in[3] = {0.25f, -0.5f, 0.75f};
+    float out[3] = {-9.0f, -9.0f, -9.0f};
+    if (dsd_resampler_process_block(NULL, in, 3, out, 3) != -1
+        || dsd_resampler_process_block(&first_use, NULL, 3, out, 3) != -1
+        || dsd_resampler_process_block(&first_use, in, -1, out, 3) != -1
+        || dsd_resampler_process_block(&first_use, in, 3, NULL, 3) != -1
+        || dsd_resampler_process_block(&first_use, in, 3, out, -1) != -1) {
+        DSD_FPRINTF(stderr, "invalid process arguments were not rejected\n");
+        return 1;
+    }
+    if (out[0] != -9.0f || out[1] != -9.0f || out[2] != -9.0f) {
+        DSD_FPRINTF(stderr, "invalid process arguments modified output\n");
+        return 1;
+    }
+
+    if (dsd_resampler_process_block(&first_use, in, 3, out, 2) != -1) {
+        DSD_FPRINTF(stderr, "passthrough capacity failure was not rejected\n");
+        return 1;
+    }
+    out[0] = out[1] = out[2] = -9.0f;
+    if (dsd_resampler_process_block(&first_use, in, 3, out, 3) != 3 || !arrays_close(out, in, 3, 0.0f)) {
+        DSD_FPRINTF(stderr, "first-use passthrough copy failed\n");
+        return 1;
+    }
+    float inout[3] = {1.0f, 2.0f, 3.0f};
+    if (dsd_resampler_process_block(&first_use, inout, 3, inout, 3) != 3 || inout[0] != 1.0f || inout[1] != 2.0f
+        || inout[2] != 3.0f) {
+        DSD_FPRINTF(stderr, "first-use in-place passthrough failed\n");
+        return 1;
+    }
+
+    demod_state* demod = alloc_demod_state();
+    if (!demod) {
+        DSD_FPRINTF(stderr, "alloc demod_state failed\n");
+        return 1;
+    }
+    resamp_design(NULL, 3, 2);
+    if (resamp_process_block(NULL, in, 3, out) != -1) {
+        DSD_FPRINTF(stderr, "demod wrapper null state was not rejected\n");
+        free_demod_state(demod);
+        return 1;
+    }
+
+    demod->resamp_enabled = 1;
+    resamp_design(demod, 3, 2);
+    if (!demod->resamp_taps || !demod->resamp_hist) {
+        DSD_FPRINTF(stderr, "demod wrapper design failed\n");
+        free_demod_state(demod);
+        return 1;
+    }
+    demod->resamp_M = 0;
+    out[0] = out[1] = out[2] = -9.0f;
+    if (resamp_process_block(demod, in, 3, out) != 3 || !arrays_close(out, in, 3, 0.0f)) {
+        DSD_FPRINTF(stderr, "demod wrapper fallback passthrough failed\n");
+        free_demod_state(demod);
+        return 1;
+    }
+
+    free_demod_state(demod);
+    return 0;
+}
+
 int
 main(void) {
     // demod_state is large; allocate on heap to avoid stack overflow
@@ -548,7 +641,13 @@ main(void) {
         free_demod_state(s);
         return 1;
     }
+    if (test_public_guard_and_passthrough_contracts() != 0) {
+        free_demod_state(s);
+        return 1;
+    }
 
     free_demod_state(s);
     return 0;
 }
+
+// NOLINTEND(performance-no-int-to-ptr)

--- a/tests/dsp/test_dsp_simd_fir.cpp
+++ b/tests/dsp/test_dsp_simd_fir.cpp
@@ -23,12 +23,23 @@
 #include "dsd-neo/core/safe_api.h"
 
 #if defined(__x86_64__) || defined(_M_X64)
+#if defined(DSD_NEO_TEST_HAVE_AVX2_IMPL)
+#include "dsp/simd_x86_cpu.h"
+#endif
 extern "C" void simd_fir_complex_apply_sse2(const float* in, int in_len, float* out, float* hist_i, float* hist_q,
                                             const float* taps, int taps_len);
 extern "C" int simd_hb_decim2_complex_sse2(const float* in, int in_len, float* out, float* hist_i, float* hist_q,
                                            const float* taps, int taps_len);
 extern "C" int simd_hb_decim2_real_sse2(const float* in, int in_len, float* out, float* hist, const float* taps,
                                         int taps_len);
+#if defined(DSD_NEO_TEST_HAVE_AVX2_IMPL)
+extern "C" void simd_fir_complex_apply_avx2(const float* in, int in_len, float* out, float* hist_i, float* hist_q,
+                                            const float* taps, int taps_len);
+extern "C" int simd_hb_decim2_complex_avx2(const float* in, int in_len, float* out, float* hist_i, float* hist_q,
+                                           const float* taps, int taps_len);
+extern "C" int simd_hb_decim2_real_avx2(const float* in, int in_len, float* out, float* hist, const float* taps,
+                                        int taps_len);
+#endif
 #endif
 
 #if defined(__aarch64__) || defined(__arm64) || defined(_M_ARM64) || defined(_M_ARM64EC)
@@ -432,6 +443,148 @@ test_direct_real_hb_backend(const char* name, real_hb_backend_fn fn) {
     return 0;
 }
 
+static int
+test_direct_backend_tail_mix(const char* name, complex_fir_backend_fn fir_fn, complex_hb_backend_fn hb_complex_fn,
+                             real_hb_backend_fn hb_real_fn) {
+    std::printf("Testing direct backend vector/tail mix (%s)...\n", name);
+
+    int rc = 0;
+
+    {
+        const int taps_len = 15;
+        const int hist_len = taps_len - 1;
+        const int N = 13; /* AVX2 path: 8-sample vector + 4-sample vector + scalar tail */
+        const float taps[taps_len] = {0.010f, -0.025f, 0.040f,  0.060f, -0.015f, 0.080f,  0.120f, 0.450f,
+                                      0.120f, 0.080f,  -0.015f, 0.060f, 0.040f,  -0.025f, 0.010f};
+
+        alignas(64) float in[N * 2];
+        alignas(64) float out_simd[N * 2];
+        alignas(64) float out_ref[N * 2];
+        alignas(64) float hist_i_simd[hist_len];
+        alignas(64) float hist_q_simd[hist_len];
+        alignas(64) float hist_i_ref[hist_len];
+        alignas(64) float hist_q_ref[hist_len];
+
+        for (int i = 0; i < N; i++) {
+            in[i << 1] = -0.9f + 0.11f * (float)i;
+            in[(i << 1) + 1] = 0.7f - 0.07f * (float)i;
+        }
+        for (int i = 0; i < hist_len; i++) {
+            hist_i_simd[i] = hist_i_ref[i] = 0.20f - 0.015f * (float)i;
+            hist_q_simd[i] = hist_q_ref[i] = -0.35f + 0.02f * (float)i;
+        }
+
+        fir_fn(in, N * 2, out_simd, hist_i_simd, hist_q_simd, taps, taps_len);
+        fir_complex_scalar_ref(in, N * 2, out_ref, hist_i_ref, hist_q_ref, taps, taps_len);
+        if (!arrays_close(out_simd, out_ref, N * 2, kTolerance)
+            || !arrays_close(hist_i_simd, hist_i_ref, hist_len, kTolerance)
+            || !arrays_close(hist_q_simd, hist_q_ref, hist_len, kTolerance)) {
+            DSD_FPRINTF(stderr, "  FAIL: FIR vector/tail mix mismatch\n");
+            rc = 1;
+        }
+    }
+
+    {
+        const int taps_len = 15;
+        const int hist_len = taps_len - 1;
+        const int N = 11; /* 5 decimated complex outputs: vector quartet + scalar tail */
+        alignas(64) float in[N * 2];
+        alignas(64) float out_simd[N * 2];
+        alignas(64) float out_ref[N * 2];
+        alignas(64) float hist_i_simd[hist_len];
+        alignas(64) float hist_q_simd[hist_len];
+        alignas(64) float hist_i_ref[hist_len];
+        alignas(64) float hist_q_ref[hist_len];
+
+        for (int i = 0; i < N; i++) {
+            in[i << 1] = -0.5f + 0.09f * (float)i;
+            in[(i << 1) + 1] = 0.25f + 0.06f * (float)i;
+        }
+        for (int i = 0; i < hist_len; i++) {
+            hist_i_simd[i] = hist_i_ref[i] = -0.10f + 0.012f * (float)i;
+            hist_q_simd[i] = hist_q_ref[i] = 0.33f - 0.018f * (float)i;
+        }
+
+        int len_simd = hb_complex_fn(in, N * 2, out_simd, hist_i_simd, hist_q_simd, hb_q15_taps, taps_len);
+        int len_ref = hb_decim2_complex_scalar_ref(in, N * 2, out_ref, hist_i_ref, hist_q_ref, hb_q15_taps, taps_len);
+        if (len_simd != len_ref || !arrays_close(out_simd, out_ref, len_simd, kTolerance)
+            || !arrays_close(hist_i_simd, hist_i_ref, hist_len, kTolerance)
+            || !arrays_close(hist_q_simd, hist_q_ref, hist_len, kTolerance)) {
+            DSD_FPRINTF(stderr, "  FAIL: complex HB vector/tail mix mismatch\n");
+            rc = 1;
+        }
+    }
+
+    {
+        const int taps_len = 15;
+        const int hist_len = taps_len - 1;
+        const int N = 19; /* 9 decimated real outputs: vector octet + scalar tail */
+        alignas(64) float in[N];
+        alignas(64) float out_simd[N];
+        alignas(64) float out_ref[N];
+        alignas(64) float hist_simd[hist_len];
+        alignas(64) float hist_ref[hist_len];
+
+        for (int i = 0; i < N; i++) {
+            in[i] = -0.65f + 0.08f * (float)i;
+        }
+        for (int i = 0; i < hist_len; i++) {
+            hist_simd[i] = hist_ref[i] = 0.18f - 0.011f * (float)i;
+        }
+
+        int len_simd = hb_real_fn(in, N, out_simd, hist_simd, hb_q15_taps, taps_len);
+        int len_ref = hb_decim2_real_scalar_ref(in, N, out_ref, hist_ref, hb_q15_taps, taps_len);
+        if (len_simd != len_ref || !arrays_close(out_simd, out_ref, len_simd, kTolerance)
+            || !arrays_close(hist_simd, hist_ref, hist_len, kTolerance)) {
+            DSD_FPRINTF(stderr, "  FAIL: real HB vector/tail mix mismatch\n");
+            rc = 1;
+        }
+    }
+
+    if (rc == 0) {
+        std::printf("  PASS\n");
+    }
+    return rc;
+}
+
+static int
+test_direct_backend_invalid_guards(const char* name, complex_fir_backend_fn fir_fn, complex_hb_backend_fn hb_complex_fn,
+                                   real_hb_backend_fn hb_real_fn) {
+    std::printf("Testing direct backend invalid guards (%s)...\n", name);
+
+    alignas(64) float in[4] = {1.0f, -1.0f, 2.0f, -2.0f};
+    alignas(64) float out[4] = {10.0f, 11.0f, 12.0f, 13.0f};
+    alignas(64) float hist_i[4] = {20.0f, 21.0f, 22.0f, 23.0f};
+    alignas(64) float hist_q[4] = {-20.0f, -21.0f, -22.0f, -23.0f};
+    alignas(64) float hist_r[4] = {30.0f, 31.0f, 32.0f, 33.0f};
+    const float even_taps[4] = {0.25f, 0.5f, 0.5f, 0.25f};
+    const float short_taps[2] = {0.5f, 0.5f};
+
+    fir_fn(in, 4, out, hist_i, hist_q, even_taps, 4);
+    fir_fn(in, 1, out, hist_i, hist_q, short_taps, 2);
+    int c0 = hb_complex_fn(in, 4, out, hist_i, hist_q, even_taps, 4);
+    int c1 = hb_complex_fn(in, 0, out, hist_i, hist_q, hb_q15_taps, 15);
+    int r0 = hb_real_fn(in, 4, out, hist_r, even_taps, 4);
+    int r1 = hb_real_fn(in, 0, out, hist_r, hb_q15_taps, 15);
+
+    if (c0 != 0 || c1 != 0 || r0 != 0 || r1 != 0) {
+        DSD_FPRINTF(stderr, "  FAIL: invalid guards returned %d/%d/%d/%d\n", c0, c1, r0, r1);
+        return 1;
+    }
+    const float want_out[4] = {10.0f, 11.0f, 12.0f, 13.0f};
+    const float want_hist_i[4] = {20.0f, 21.0f, 22.0f, 23.0f};
+    const float want_hist_q[4] = {-20.0f, -21.0f, -22.0f, -23.0f};
+    const float want_hist_r[4] = {30.0f, 31.0f, 32.0f, 33.0f};
+    if (!arrays_close(out, want_out, 4, 0.0f) || !arrays_close(hist_i, want_hist_i, 4, 0.0f)
+        || !arrays_close(hist_q, want_hist_q, 4, 0.0f) || !arrays_close(hist_r, want_hist_r, 4, 0.0f)) {
+        DSD_FPRINTF(stderr, "  FAIL: invalid guards mutated buffers\n");
+        return 1;
+    }
+
+    std::printf("  PASS\n");
+    return 0;
+}
+
 /* Test 63-tap symmetric FIR (channel LPF style) */
 static int
 test_complex_fir_63tap() {
@@ -812,6 +965,120 @@ test_zero_output_history_updates() {
     return 0;
 }
 
+static int
+test_public_scalar_fallback_edges() {
+    std::printf("Testing public scalar fallback edges...\n");
+
+    const int taps_len = 5;
+    const int hist_len = taps_len - 1;
+    const float sparse_taps[taps_len] = {0.25f, 0.0f, 0.50f, 0.0f, 0.25f};
+
+    // Complex FIR fallback should match scalar output and both I/Q histories.
+    {
+        alignas(64) float in[8] = {1.0f, -1.0f, 2.0f, -2.0f, 3.0f, -3.0f, 4.0f, -4.0f};
+        alignas(64) float out_simd[8];
+        alignas(64) float out_ref[8];
+        alignas(64) float hist_i_simd[hist_len];
+        alignas(64) float hist_q_simd[hist_len];
+        alignas(64) float hist_i_ref[hist_len];
+        alignas(64) float hist_q_ref[hist_len];
+
+        for (int i = 0; i < hist_len; i++) {
+            hist_i_simd[i] = hist_i_ref[i] = -2.0f + (float)i;
+            hist_q_simd[i] = hist_q_ref[i] = 2.0f - (float)i;
+        }
+
+        simd_fir_complex_apply(in, 8, out_simd, hist_i_simd, hist_q_simd, sparse_taps, taps_len);
+        fir_complex_scalar_ref(in, 8, out_ref, hist_i_ref, hist_q_ref, sparse_taps, taps_len);
+
+        if (!arrays_close(out_simd, out_ref, 8, kTolerance)
+            || !arrays_close(hist_i_simd, hist_i_ref, hist_len, kTolerance)
+            || !arrays_close(hist_q_simd, hist_q_ref, hist_len, kTolerance)) {
+            DSD_FPRINTF(stderr, "  FAIL: Scalar complex FIR fallback mismatch\n");
+            return 1;
+        }
+    }
+
+    // Complex halfband decimation fallback validates both returned length and history.
+    {
+        alignas(64) float in[8] = {1.0f, -1.0f, 2.0f, -2.0f, 3.0f, -3.0f, 4.0f, -4.0f};
+        alignas(64) float out_simd[4];
+        alignas(64) float out_ref[4];
+        alignas(64) float hist_i_simd[hist_len];
+        alignas(64) float hist_q_simd[hist_len];
+        alignas(64) float hist_i_ref[hist_len];
+        alignas(64) float hist_q_ref[hist_len];
+
+        for (int i = 0; i < hist_len; i++) {
+            hist_i_simd[i] = hist_i_ref[i] = 10.0f + (float)i;
+            hist_q_simd[i] = hist_q_ref[i] = -10.0f - (float)i;
+        }
+
+        int len_simd = simd_hb_decim2_complex(in, 8, out_simd, hist_i_simd, hist_q_simd, sparse_taps, taps_len);
+        int len_ref = hb_decim2_complex_scalar_ref(in, 8, out_ref, hist_i_ref, hist_q_ref, sparse_taps, taps_len);
+
+        if (len_simd != len_ref || !arrays_close(out_simd, out_ref, len_simd, kTolerance)
+            || !arrays_close(hist_i_simd, hist_i_ref, hist_len, kTolerance)
+            || !arrays_close(hist_q_simd, hist_q_ref, hist_len, kTolerance)) {
+            DSD_FPRINTF(stderr, "  FAIL: Scalar complex HB fallback mismatch\n");
+            return 1;
+        }
+    }
+
+    // Real halfband fallback should preserve scalar equivalence on output and carry history.
+    {
+        alignas(64) float in[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+        alignas(64) float out_simd[2];
+        alignas(64) float out_ref[2];
+        alignas(64) float hist_simd[hist_len];
+        alignas(64) float hist_ref[hist_len];
+
+        for (int i = 0; i < hist_len; i++) {
+            hist_simd[i] = hist_ref[i] = -4.0f + (float)i;
+        }
+
+        int len_simd = simd_hb_decim2_real(in, 4, out_simd, hist_simd, sparse_taps, taps_len);
+        int len_ref = hb_decim2_real_scalar_ref(in, 4, out_ref, hist_ref, sparse_taps, taps_len);
+
+        if (len_simd != len_ref || !arrays_close(out_simd, out_ref, len_simd, kTolerance)
+            || !arrays_close(hist_simd, hist_ref, hist_len, kTolerance)) {
+            DSD_FPRINTF(stderr, "  FAIL: Scalar real HB fallback mismatch\n");
+            return 1;
+        }
+    }
+
+    // Guard paths for invalid lengths must leave sentinels intact and emit zero output length.
+    {
+        alignas(64) float in_complex[2] = {1.0f, -1.0f};
+        alignas(64) float out_complex[2] = {11.0f, 12.0f};
+        alignas(64) float hist_i[14] = {};
+        alignas(64) float hist_q[14] = {};
+        simd_fir_complex_apply(in_complex, 1, out_complex, hist_i, hist_q, hb_q15_taps, 15);
+        if (out_complex[0] != 11.0f || out_complex[1] != 12.0f) {
+            DSD_FPRINTF(stderr, "  FAIL: Invalid complex FIR guard mutated output\n");
+            return 1;
+        }
+
+        int len = simd_hb_decim2_complex(in_complex, 1, out_complex, hist_i, hist_q, hb_q15_taps, 15);
+        if (len != 0) {
+            DSD_FPRINTF(stderr, "  FAIL: Complex HB guard returned %d\n", len);
+            return 1;
+        }
+
+        alignas(64) float in_real[1] = {1.0f};
+        alignas(64) float out_real[1] = {13.0f};
+        alignas(64) float hist_real[14] = {};
+        len = simd_hb_decim2_real(in_real, 1, out_real, hist_real, sparse_taps, 2);
+        if (len != 0 || out_real[0] != 13.0f) {
+            DSD_FPRINTF(stderr, "  FAIL: Real HB invalid-tap guard mutated output\n");
+            return 1;
+        }
+    }
+
+    std::printf("  PASS\n");
+    return 0;
+}
+
 int
 main(void) {
     std::printf("SIMD FIR implementation: %s\n\n", simd_fir_get_impl_name());
@@ -840,11 +1107,25 @@ main(void) {
     /* Regressions for history handling on short/zero-output blocks */
     failures += test_complex_short_block_history();
     failures += test_zero_output_history_updates();
+    failures += test_public_scalar_fallback_edges();
 
 #if defined(__x86_64__) || defined(_M_X64)
     failures += test_direct_complex_fir_backend("sse2", simd_fir_complex_apply_sse2);
     failures += test_direct_complex_hb_backend("sse2", simd_hb_decim2_complex_sse2);
     failures += test_direct_real_hb_backend("sse2", simd_hb_decim2_real_sse2);
+#if defined(DSD_NEO_TEST_HAVE_AVX2_IMPL)
+    if (dsd_neo_cpu_has_avx2_with_os_support()) {
+        failures += test_direct_complex_fir_backend("avx2", simd_fir_complex_apply_avx2);
+        failures += test_direct_complex_hb_backend("avx2", simd_hb_decim2_complex_avx2);
+        failures += test_direct_real_hb_backend("avx2", simd_hb_decim2_real_avx2);
+        failures += test_direct_backend_tail_mix("avx2", simd_fir_complex_apply_avx2, simd_hb_decim2_complex_avx2,
+                                                 simd_hb_decim2_real_avx2);
+        failures += test_direct_backend_invalid_guards("avx2", simd_fir_complex_apply_avx2, simd_hb_decim2_complex_avx2,
+                                                       simd_hb_decim2_real_avx2);
+    } else {
+        std::printf("Skipping direct AVX2 backend tests: CPU/OS AVX2+FMA support unavailable\n");
+    }
+#endif
 #endif
 
 #if defined(__aarch64__) || defined(__arm64) || defined(_M_ARM64) || defined(_M_ARM64EC)

--- a/tests/dsp/test_dsp_simd_widen.cpp
+++ b/tests/dsp/test_dsp_simd_widen.cpp
@@ -23,6 +23,11 @@ extern "C" uint32_t widen_rotate90_u8_to_f32_bias127_phase_neon(const unsigned c
                                                                 uint32_t phase);
 #endif
 
+#ifdef DSD_NEO_TEST_HOOKS
+extern "C" uint32_t dsd_test_widen_rotate90_u8_to_f32_bias127_phase_scalar(const unsigned char* src, float* dst,
+                                                                           uint32_t len, uint32_t phase);
+#endif
+
 static int
 arrays_close(const float* a, const float* b, int n, float tol) {
     for (int i = 0; i < n; i++) {
@@ -194,6 +199,44 @@ test_rotate_widen_backend(const char* name, widen_backend_fn fn) {
         return 1;
     }
 
+    for (unsigned int start_phase = 0; start_phase < 4U; start_phase++) {
+        const unsigned char phase_src[4] = {10, 40, 170, 230};
+        float vector_dst[4] = {0};
+        float scalar_dst[2] = {0};
+        float vector_ref[4] = {0};
+        float scalar_ref[2] = {0};
+        unsigned int phase_local_ref = start_phase;
+
+        for (int pair = 0; pair < 2; pair++) {
+            int idx = pair << 1;
+            float in_i = ((float)phase_src[idx + 0] - 127.5f) * inv;
+            float in_q = ((float)phase_src[idx + 1] - 127.5f) * inv;
+            apply_j4_rotation_ref(in_i, in_q, phase_local_ref, &vector_ref[idx + 0], &vector_ref[idx + 1]);
+            phase_local_ref = (phase_local_ref + 1U) & 3U;
+        }
+        if (fn(phase_src, vector_dst, 4U, start_phase) != phase_local_ref
+            || !arrays_close(vector_dst, vector_ref, 4, 1e-6f)) {
+            DSD_FPRINTF(stderr, "%s vector phase %u output: mismatch\n", name, start_phase);
+            return 1;
+        }
+
+        float in_i = ((float)phase_src[0] - 127.5f) * inv;
+        float in_q = ((float)phase_src[1] - 127.5f) * inv;
+        apply_j4_rotation_ref(in_i, in_q, start_phase, &scalar_ref[0], &scalar_ref[1]);
+        if (fn(phase_src, scalar_dst, 2U, start_phase) != ((start_phase + 1U) & 3U)
+            || !arrays_close(scalar_dst, scalar_ref, 2, 1e-6f)) {
+            DSD_FPRINTF(stderr, "%s scalar phase %u output: mismatch\n", name, start_phase);
+            return 1;
+        }
+    }
+
+    float guard[2] = {12.0f, -34.0f};
+    if (fn(NULL, guard, 2U, 5U) != 1U || fn(src, NULL, 2U, 6U) != 2U || fn(src, guard, 1U, 7U) != 3U
+        || guard[0] != 12.0f || guard[1] != -34.0f) {
+        DSD_FPRINTF(stderr, "%s guard: mismatch\n", name);
+        return 1;
+    }
+
     return 0;
 }
 
@@ -220,6 +263,31 @@ main(void) {
     if (!arrays_close(dst, ref, 8, 1e-6f)) {
         DSD_FPRINTF(stderr, "SIMD widen: mismatch\n");
         return 1;
+    }
+
+    {
+        float guard[2] = {12.0f, -34.0f};
+        const float want_guard[2] = {12.0f, -34.0f};
+        widen_u8_to_f32_bias127(NULL, guard, 2);
+        widen_u8_to_f32_bias127(src, guard, 0);
+        if (!arrays_close(guard, want_guard, 2, 0.0f)) {
+            DSD_FPRINTF(stderr, "SIMD widen guard: mismatch\n");
+            return 1;
+        }
+
+        widen_u8_to_f32_bias128_scalar(NULL, guard, 2);
+        widen_u8_to_f32_bias128_scalar(src, guard, 0);
+        if (!arrays_close(guard, want_guard, 2, 0.0f)) {
+            DSD_FPRINTF(stderr, "SIMD bias128 guard: mismatch\n");
+            return 1;
+        }
+
+        unsigned char rotate_guard[2] = {10, 20};
+        if (rotate90_u8_inplace_phase(NULL, 2, 5U) != 1U || rotate90_u8_inplace_phase(rotate_guard, 1, 6U) != 2U
+            || rotate_guard[0] != 10 || rotate_guard[1] != 20) {
+            DSD_FPRINTF(stderr, "Legacy byte rotate guard: mismatch\n");
+            return 1;
+        }
     }
 
     // rotate 90° with pattern per implementation: (I0,Q0),(I1,Q1)->(-Q1, I1),(I2,Q2)->(-I2,-Q2),(I3,Q3)->(Q3,-I3)
@@ -267,6 +335,13 @@ main(void) {
             return 1;
         }
     }
+
+#ifdef DSD_NEO_TEST_HOOKS
+    if (test_rotate_widen_backend("SIMD rotate+widen scalar", dsd_test_widen_rotate90_u8_to_f32_bias127_phase_scalar)
+        != 0) {
+        return 1;
+    }
+#endif
 
     {
         // Legacy byte rotation keeps capture compatibility with bias-128 widening.

--- a/tests/dsp/test_dsp_symbol_replay.c
+++ b/tests/dsp/test_dsp_symbol_replay.c
@@ -1,0 +1,534 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/audio_filters.h>
+#include <dsd-neo/core/cleanup.h>
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/power.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/symbol.h>
+#include <dsd-neo/dsp/symbol_levels.h>
+#include <dsd-neo/io/rigctl_client.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/sockets.h>
+#include <dsd-neo/runtime/exitflag.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "test_support.h"
+
+static int g_cleanup_calls = 0;
+
+static int
+symbol_level_matches(float got, uint8_t dibit) {
+    return fabsf(got - dsd_symbol_level_from_dibit(dibit)) <= 1e-6f;
+}
+
+void dsd_symbol_test_select_window(int rf_mod, int synctype, int lastsynctype, int freeze_window, int* l_edge,
+                                   int* r_edge);
+int dsd_symbol_test_adjust_timing_index(int samples_per_symbol, int symbol_center, int rf_mod, int jitter,
+                                        int have_sync, int symbol_span, int start_i, int* jitter_after);
+int dsd_symbol_test_is_m17_sync(int lastsynctype);
+unsigned int dsd_symbol_test_convert_analog_block_to_i16(const float* input, short* output, unsigned int count);
+#ifdef USE_RADIO
+int dsd_symbol_test_rtl_cache_and_center_contract(int out_values[10]);
+int dsd_symbol_test_auto_center_step_direction(int e_ema, int deadband, int* run_dir, int* run_len, int* dir_out);
+#endif
+
+dsd_socket_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+Connect(char* hostname, int portno) {
+    (void)hostname;
+    (void)portno;
+    return (dsd_socket_t)0;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+openAudioInput(dsd_opts* opts) {
+    (void)opts;
+    return -1;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+cleanupAndExit(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_cleanup_calls++;
+    exitflag = 1;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_audio_rescale_symbol_timing(dsd_state* state, int old_rate_hz, int new_rate_hz) {
+    (void)state;
+    (void)old_rate_hz;
+    (void)new_rate_hz;
+}
+
+double
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+raw_pwr_f(const float* samples, int len, int step) {
+    (void)samples;
+    (void)len;
+    (void)step;
+    return 0.0;
+}
+
+double
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+pwr_to_dB(double mean_power) {
+    (void)mean_power;
+    return 0.0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+lpf_f(dsd_state* state, float* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+hpf_f(dsd_state* state, float* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+pbf_f(dsd_state* state, float* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+agsm_f(dsd_opts* opts, dsd_state* state, float* input, int len) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+static void
+init_symbol_replay_fixture(dsd_opts* opts, dsd_state* state) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_SYMBOL_BIN;
+    opts->input_volume_multiplier = 1;
+    state->samplesPerSymbol = 1;
+    state->symbolCenter = 0;
+    state->rf_mod = 0;
+    state->jitter = -1;
+}
+
+static void
+put_le_i16(unsigned char* out, int16_t value) {
+    uint16_t u = (uint16_t)value;
+    out[0] = (unsigned char)(u & 0xFFU);
+    out[1] = (unsigned char)((u >> 8) & 0xFFU);
+}
+
+static void
+put_le_u32(unsigned char* out, uint32_t value) {
+    out[0] = (unsigned char)(value & 0xFFU);
+    out[1] = (unsigned char)((value >> 8) & 0xFFU);
+    out[2] = (unsigned char)((value >> 16) & 0xFFU);
+    out[3] = (unsigned char)((value >> 24) & 0xFFU);
+}
+
+static void
+write_soft_header(FILE* file) {
+    unsigned char header[DSD_SYMBOL_CAPTURE_SOFT_HEADER_SIZE] = {
+        'D', 'S', 'D', 'N', 'S', 'Y', 'M', '2', 2, DSD_SYMBOL_CAPTURE_SOFT_RECORD_SIZE, 0, 0, 0, 0, 0, 0,
+    };
+    assert(fwrite(header, 1, sizeof(header), file) == sizeof(header));
+}
+
+static void
+write_soft_record(FILE* file, uint8_t dibit, uint8_t reliability, int16_t llr0, int16_t llr1, float symbol) {
+    unsigned char record[DSD_SYMBOL_CAPTURE_SOFT_RECORD_SIZE];
+    uint32_t raw_symbol = 0;
+    DSD_MEMSET(record, 0, sizeof(record));
+    record[0] = dibit;
+    record[1] = reliability;
+    put_le_i16(record + 2, llr0);
+    put_le_i16(record + 4, llr1);
+    DSD_MEMCPY(&raw_symbol, &symbol, sizeof(raw_symbol));
+    put_le_u32(record + 6, raw_symbol);
+    assert(fwrite(record, 1, sizeof(record), file) == sizeof(record));
+}
+
+static void
+test_soft_symbol_replay_record(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_symbol_replay_fixture(&opts, &state);
+
+    opts.symbolfile = tmpfile();
+    assert(opts.symbolfile != NULL);
+    write_soft_header(opts.symbolfile);
+    write_soft_record(opts.symbolfile, 3, 77, -1234, 2345, 2.5f);
+    rewind(opts.symbolfile);
+
+    float symbol = getSymbol(&opts, &state, 0);
+    assert(fabsf(symbol - 2.5f) < 0.0001f);
+    assert(state.symbolc == 3);
+    assert(state.symbol_replay_format == DSD_SYMBOL_REPLAY_FORMAT_SOFT);
+    assert(state.symbol_replay_header_checked == 1);
+    assert(state.symbol_replay_has_soft == 1);
+    assert(state.symbol_replay_soft.reliability == 77);
+    assert(state.symbol_replay_soft.llr[0] == -1234);
+    assert(state.symbol_replay_soft.llr[1] == 2345);
+    assert(fabsf(state.symbol_replay_soft_symbol - 2.5f) < 0.0001f);
+    assert(state.symbol_replay_soft_records == 1U);
+    assert(state.symbolcnt == 1);
+    assert(g_cleanup_calls == 0);
+
+    fclose(opts.symbolfile);
+    opts.symbolfile = NULL;
+}
+
+static void
+test_short_file_falls_back_to_legacy_replay(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_symbol_replay_fixture(&opts, &state);
+
+    opts.symbolfile = tmpfile();
+    assert(opts.symbolfile != NULL);
+    assert(fputc(2, opts.symbolfile) != EOF);
+    assert(fputc(1, opts.symbolfile) != EOF);
+    rewind(opts.symbolfile);
+
+    assert(symbol_level_matches(getSymbol(&opts, &state, 0), 2U));
+    assert(state.symbol_replay_format == DSD_SYMBOL_REPLAY_FORMAT_LEGACY);
+    assert(state.symbol_replay_header_checked == 1);
+    assert(state.symbol_replay_has_soft == 0);
+    assert(state.symbolc == 2);
+
+    assert(symbol_level_matches(getSymbol(&opts, &state, 0), 1U));
+    assert(state.symbolc == 1);
+    assert(state.symbolcnt == 2);
+    assert(g_cleanup_calls == 0);
+
+    fclose(opts.symbolfile);
+    opts.symbolfile = NULL;
+}
+
+static void
+test_debug_replay_reopens_and_reprobes(void) {
+    char path[DSD_TEST_PATH_MAX];
+    int fd = dsd_test_mkstemp(path, sizeof(path), "dsdneo_symbol_replay");
+    assert(fd >= 0);
+    FILE* file = fdopen(fd, "wb");
+    assert(file != NULL);
+    write_soft_header(file);
+    write_soft_record(file, 0, 31, 100, -100, -3.0f);
+    assert(fclose(file) == 0);
+
+    static dsd_opts opts;
+    static dsd_state state;
+    init_symbol_replay_fixture(&opts, &state);
+    state.debug_mode = 1;
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "%s", path);
+    opts.symbolfile = dsd_fopen_existing_regular_file(path, "rb");
+    assert(opts.symbolfile != NULL);
+
+    assert(getSymbol(&opts, &state, 0) == -3.0f);
+    assert(state.symbol_replay_soft_records == 1U);
+    assert(state.symbol_replay_format == DSD_SYMBOL_REPLAY_FORMAT_SOFT);
+
+    state.symbol_replay_format = DSD_SYMBOL_REPLAY_FORMAT_LEGACY;
+    state.symbol_replay_header_checked = 1;
+    state.symbol_replay_has_soft = 1;
+    assert(getSymbol(&opts, &state, 0) == -3.0f);
+    assert(opts.symbolfile != NULL);
+    assert(opts.audio_in_type == AUDIO_IN_SYMBOL_BIN);
+    assert(state.symbol_replay_format == DSD_SYMBOL_REPLAY_FORMAT_SOFT);
+    assert(state.symbol_replay_header_checked == 1);
+    assert(state.symbol_replay_has_soft == 1);
+    assert(state.symbol_replay_soft_records == 2U);
+    assert(g_cleanup_calls == 0);
+
+    fclose(opts.symbolfile);
+    opts.symbolfile = NULL;
+    remove(path);
+}
+
+static void
+test_missing_symbol_file_returns_error_symbol(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_symbol_replay_fixture(&opts, &state);
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "%s", "missing-symbol.bin");
+    g_cleanup_calls = 0;
+    exitflag = 0;
+
+    float symbol = getSymbol(&opts, &state, 0);
+    assert(symbol == -1.0f);
+    assert(state.symbolcnt == 1);
+    assert(state.symbol_replay_header_checked == 0);
+    assert(state.symbol_replay_has_soft == 0);
+    assert(g_cleanup_calls == 0);
+    assert(exitflag == 0);
+}
+
+static void
+test_invalid_soft_header_replays_as_legacy_bytes(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_symbol_replay_fixture(&opts, &state);
+    opts.symbolfile = tmpfile();
+    assert(opts.symbolfile != NULL);
+
+    unsigned char header[DSD_SYMBOL_CAPTURE_SOFT_HEADER_SIZE] = {
+        'D', 'S', 'D', 'N', 'S', 'Y', 'M', '2', 3, DSD_SYMBOL_CAPTURE_SOFT_RECORD_SIZE, 0, 0, 0, 0, 0, 0,
+    };
+    assert(fwrite(header, 1, sizeof(header), opts.symbolfile) == sizeof(header));
+    rewind(opts.symbolfile);
+    g_cleanup_calls = 0;
+    exitflag = 0;
+
+    float symbol = getSymbol(&opts, &state, 0);
+    assert(symbol_level_matches(symbol, (uint8_t)('D' & 3)));
+    assert(state.symbol_replay_format == DSD_SYMBOL_REPLAY_FORMAT_LEGACY);
+    assert(state.symbol_replay_header_checked == 1);
+    assert(state.symbol_replay_has_soft == 0);
+    assert(state.symbolc == ('D' & 3));
+    assert(g_cleanup_calls == 0);
+
+    fclose(opts.symbolfile);
+    opts.symbolfile = NULL;
+}
+
+static void
+test_soft_header_without_record_cleans_up_at_eof(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_symbol_replay_fixture(&opts, &state);
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "%s", "soft-header-only.bin");
+    opts.symbolfile = tmpfile();
+    assert(opts.symbolfile != NULL);
+    write_soft_header(opts.symbolfile);
+    rewind(opts.symbolfile);
+    g_cleanup_calls = 0;
+    exitflag = 0;
+
+    float symbol = getSymbol(&opts, &state, 0);
+    assert(symbol == 0.0f);
+    assert(opts.symbolfile == NULL);
+    assert(state.symbol_replay_format == DSD_SYMBOL_REPLAY_FORMAT_SOFT);
+    assert(state.symbol_replay_header_checked == 1);
+    assert(state.symbol_replay_has_soft == 0);
+    assert(state.symbol_replay_soft_records == 0U);
+    assert(g_cleanup_calls == 1);
+    assert(exitflag == 1);
+}
+
+static void
+test_float_symbol_replay_scales_values(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_symbol_replay_fixture(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_SYMBOL_FLT;
+    opts.symbolfile = tmpfile();
+    assert(opts.symbolfile != NULL);
+    float value = 0.25f;
+    assert(fwrite(&value, sizeof(value), 1, opts.symbolfile) == 1);
+    rewind(opts.symbolfile);
+    g_cleanup_calls = 0;
+    exitflag = 0;
+
+    float symbol = getSymbol(&opts, &state, 0);
+    assert(fabsf(symbol - 2500.0f) < 0.0001f);
+    assert(state.symbolcnt == 1);
+    assert(g_cleanup_calls == 0);
+    assert(exitflag == 0);
+
+    fclose(opts.symbolfile);
+    opts.symbolfile = NULL;
+}
+
+static void
+test_float_symbol_replay_eof_sets_exitflag(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_symbol_replay_fixture(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_SYMBOL_FLT;
+    opts.symbolfile = tmpfile();
+    assert(opts.symbolfile != NULL);
+    g_cleanup_calls = 0;
+    exitflag = 0;
+
+    float symbol = getSymbol(&opts, &state, 0);
+    assert(symbol == 0.0f);
+    assert(state.symbolcnt == 1);
+    assert(g_cleanup_calls == 0);
+    assert(exitflag == 1);
+
+    fclose(opts.symbolfile);
+    opts.symbolfile = NULL;
+}
+
+static void
+test_symbol_helper_window_sync_and_timing_contracts(void) {
+    int l_edge = 0;
+    int r_edge = 0;
+    dsd_symbol_test_select_window(0, DSD_SYNC_YSF_POS, DSD_SYNC_NONE, 0, &l_edge, &r_edge);
+    assert(l_edge == 1);
+    assert(r_edge == 2);
+
+    dsd_symbol_test_select_window(0, DSD_SYNC_NONE, DSD_SYNC_NONE, 0, &l_edge, &r_edge);
+    assert(l_edge == 2);
+    assert(r_edge == 2);
+
+    dsd_symbol_test_select_window(0, DSD_SYNC_YSF_POS, DSD_SYNC_NONE, 1, &l_edge, &r_edge);
+    assert(l_edge == 2);
+    assert(r_edge == 2);
+
+    dsd_symbol_test_select_window(1, DSD_SYNC_NONE, DSD_SYNC_NONE, 0, &l_edge, &r_edge);
+    assert(l_edge == 1);
+    assert(r_edge == 2);
+
+    dsd_symbol_test_select_window(2, DSD_SYNC_NONE, DSD_SYNC_NONE, 0, &l_edge, &r_edge);
+    assert(l_edge == 1);
+    assert(r_edge == 1);
+
+    assert(dsd_symbol_test_is_m17_sync(DSD_SYNC_M17_STR_POS) == 1);
+    assert(dsd_symbol_test_is_m17_sync(DSD_SYNC_M17_PKT_NEG) == 1);
+    assert(dsd_symbol_test_is_m17_sync(DSD_SYNC_M17_BRT_POS) == 0);
+    assert(dsd_symbol_test_is_m17_sync(DSD_SYNC_DMR_BS_VOICE_POS) == 0);
+
+    int jitter_after = 99;
+    assert(dsd_symbol_test_adjust_timing_index(20, 9, 0, 8, 0, 20, 0, &jitter_after) == -1);
+    assert(jitter_after == -1);
+    assert(dsd_symbol_test_adjust_timing_index(20, 9, 0, 12, 0, 20, 0, &jitter_after) == 1);
+    assert(jitter_after == -1);
+
+    assert(dsd_symbol_test_adjust_timing_index(10, 4, 1, 3, 0, 10, 0, &jitter_after) == 1);
+    assert(dsd_symbol_test_adjust_timing_index(10, 4, 1, 7, 0, 10, 0, &jitter_after) == -1);
+    assert(dsd_symbol_test_adjust_timing_index(10, 4, 2, 4, 0, 10, 0, &jitter_after) == -1);
+    assert(dsd_symbol_test_adjust_timing_index(10, 4, 2, 6, 0, 10, 0, &jitter_after) == 1);
+    assert(dsd_symbol_test_adjust_timing_index(10, 4, 0, 4, 0, 10, 0, &jitter_after) == -1);
+    assert(dsd_symbol_test_adjust_timing_index(10, 4, 0, 6, 0, 10, 0, &jitter_after) == 1);
+
+    jitter_after = 99;
+    assert(dsd_symbol_test_adjust_timing_index(10, 4, 0, 4, 1, 10, 0, &jitter_after) == 0);
+    assert(jitter_after == 4);
+    assert(dsd_symbol_test_adjust_timing_index(10, 4, 0, 4, 0, 1, 0, &jitter_after) == 0);
+    assert(jitter_after == 4);
+    assert(dsd_symbol_test_adjust_timing_index(10, 4, 0, 4, 0, 10, 1, &jitter_after) == 1);
+    assert(jitter_after == 4);
+}
+
+static void
+test_symbol_helper_analog_i16_conversion_contract(void) {
+    const float input[] = {40000.0f, -40000.0f, 123.6f, -123.4f, 0.49f, -0.51f};
+    short output[sizeof(input) / sizeof(input[0])] = {0};
+
+    assert(dsd_symbol_test_convert_analog_block_to_i16(NULL, output, 1U) == 0U);
+    assert(dsd_symbol_test_convert_analog_block_to_i16(input, NULL, 1U) == 0U);
+    assert(dsd_symbol_test_convert_analog_block_to_i16(input, output, (unsigned int)(sizeof(input) / sizeof(input[0])))
+           == (unsigned int)(sizeof(input) / sizeof(input[0])));
+    assert(output[0] == 32767);
+    assert(output[1] == -32768);
+    assert(output[2] == 124);
+    assert(output[3] == -123);
+    assert(output[4] == 0);
+    assert(output[5] == -1);
+}
+
+static void
+test_symbol_helper_rtl_cache_and_center_contract(void) {
+#ifdef USE_RADIO
+    int values[10] = {0};
+    int run_dir = 7;
+    int run_len = 3;
+    int dir_out = 99;
+
+    assert(dsd_symbol_test_rtl_cache_and_center_contract(NULL) == 0);
+    assert(dsd_symbol_test_rtl_cache_and_center_contract(values) == 10);
+    assert(values[0] == 1);
+    assert(values[1] == 8);
+    assert(values[2] == 1);
+    assert(values[3] == 0);
+    assert(values[4] == 2);
+    assert(values[5] == 4800);
+    assert(values[6] == 1);
+    assert(values[7] == 125);
+    assert(values[8] == 1);
+    assert(values[9] == 0);
+
+    assert(dsd_symbol_test_auto_center_step_direction(5, 10, NULL, &run_len, &dir_out) == 0);
+    assert(dsd_symbol_test_auto_center_step_direction(5, 10, &run_dir, NULL, &dir_out) == 0);
+    assert(dsd_symbol_test_auto_center_step_direction(5, 10, &run_dir, &run_len, NULL) == 0);
+
+    assert(dsd_symbol_test_auto_center_step_direction(5, 10, &run_dir, &run_len, &dir_out) == 0);
+    assert(run_dir == 0);
+    assert(run_len == 0);
+    assert(dir_out == 99);
+
+    assert(dsd_symbol_test_auto_center_step_direction(11, 10, &run_dir, &run_len, &dir_out) == 1);
+    assert(run_dir == 1);
+    assert(run_len == 1);
+    assert(dir_out == 1);
+
+    assert(dsd_symbol_test_auto_center_step_direction(12, 10, &run_dir, &run_len, &dir_out) == 1);
+    assert(run_dir == 1);
+    assert(run_len == 2);
+    assert(dir_out == 1);
+
+    assert(dsd_symbol_test_auto_center_step_direction(-12, 10, &run_dir, &run_len, &dir_out) == 1);
+    assert(run_dir == -1);
+    assert(run_len == 1);
+    assert(dir_out == -1);
+#endif
+}
+
+int
+main(void) {
+    exitflag = 0;
+    test_soft_symbol_replay_record();
+    test_short_file_falls_back_to_legacy_replay();
+    test_debug_replay_reopens_and_reprobes();
+    test_missing_symbol_file_returns_error_symbol();
+    test_invalid_soft_header_replays_as_legacy_bytes();
+    test_soft_header_without_record_cleans_up_at_eof();
+    test_float_symbol_replay_scales_values();
+    test_float_symbol_replay_eof_sets_exitflag();
+    test_symbol_helper_window_sync_and_timing_contracts();
+    test_symbol_helper_analog_i16_conversion_contract();
+    test_symbol_helper_rtl_cache_and_center_contract();
+    return 0;
+}
+
+// NOLINTEND(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c)

--- a/tests/dsp/test_frame_sync_dmr_wav_rate.c
+++ b/tests/dsp/test_frame_sync_dmr_wav_rate.c
@@ -198,52 +198,109 @@ init_state_buffers(dsd_state* state) {
     return 1;
 }
 
+typedef struct {
+    const char* label;
+    const char* pattern;
+    int frame_dmr;
+    int frame_dstar;
+    int frame_provoice;
+    int frame_x2tdma;
+    int frame_ysf;
+    int frame_dpmr;
+    int frame_nxdn48;
+    int frame_nxdn96;
+    int inverted_x2tdma;
+    int inverted_dpmr;
+    int initial_lastsynctype;
+    int expected_sync;
+    const char* expected_ftype;
+    int expected_inverted_ysf;
+} SymbolSyncCase;
+
+typedef struct {
+    const char* label;
+    const char* pattern;
+    int inverted_dmr;
+    int initial_lastsynctype;
+    int expected_sync;
+    int expected_directmode;
+    int expected_firstframe;
+    const char* expected_ftype;
+} DmrSyncCase;
+
+static void
+init_common_wav_opts_state(dsd_opts* opts, dsd_state* state) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->wav_sample_rate = 96000;
+    opts->wav_decimator = 48000;
+    opts->mod_cli_lock = 1;
+    opts->mod_gfsk = 1;
+    opts->msize = 1;
+    opts->ssize = 128;
+
+    state->rf_mod = 2;
+    state->samplesPerSymbol = 20;
+    state->symbolCenter = 9;
+    state->p25_p2_active_slot = -1;
+    state->center = 0.0f;
+    state->min = -3.0f;
+    state->max = 3.0f;
+    state->lmid = -2.0f;
+    state->umid = 2.0f;
+    state->minref = -2.4f;
+    state->maxref = 2.4f;
+}
+
 static int
-run_dmr_wav_rate_case(void) {
+run_symbol_sync_case(const SymbolSyncCase* tc) {
     static dsd_opts opts;
     static dsd_state state;
-    DSD_MEMSET(&opts, 0, sizeof(opts));
-    DSD_MEMSET(&state, 0, sizeof(state));
+    init_common_wav_opts_state(&opts, &state);
 
     if (!init_state_buffers(&state)) {
         DSD_FPRINTF(stderr, "failed to allocate frame-sync state buffers\n");
         return 1;
     }
 
-    opts.audio_in_type = AUDIO_IN_WAV;
-    opts.wav_sample_rate = 96000;
-    opts.wav_decimator = 48000;
-    opts.frame_dmr = 1;
-    opts.mod_cli_lock = 1;
-    opts.mod_gfsk = 1;
-    opts.msize = 1;
-    opts.ssize = 128;
-
-    state.rf_mod = 2;
-    state.samplesPerSymbol = 20;
-    state.symbolCenter = 9;
-    state.p25_p2_active_slot = -1;
-    state.center = 0.0f;
-    state.min = -3.0f;
-    state.max = 3.0f;
-    state.lmid = -2.0f;
-    state.umid = 2.0f;
-    state.minref = -2.4f;
-    state.maxref = 2.4f;
-
+    opts.frame_dmr = tc->frame_dmr;
+    opts.frame_dstar = tc->frame_dstar;
+    opts.frame_provoice = tc->frame_provoice;
+    opts.frame_x2tdma = tc->frame_x2tdma;
+    opts.frame_ysf = tc->frame_ysf;
+    opts.frame_dpmr = tc->frame_dpmr;
+    opts.frame_nxdn48 = tc->frame_nxdn48;
+    opts.frame_nxdn96 = tc->frame_nxdn96;
+    opts.inverted_x2tdma = tc->inverted_x2tdma;
+    opts.inverted_dpmr = tc->inverted_dpmr;
+    state.lastsynctype = tc->initial_lastsynctype;
     g_symbol_index = 0U;
-    g_sync_pattern = DMR_BS_DATA_SYNC;
+    g_sync_pattern = tc->pattern;
     dsd_frame_sync_reset_mod_state();
 
     int sync = getFrameSync(&opts, &state);
     int rc = 0;
-    if (sync != DSD_SYNC_DMR_BS_DATA_POS) {
-        DSD_FPRINTF(stderr, "DMR WAV sync returned %d, expected %d\n", sync, DSD_SYNC_DMR_BS_DATA_POS);
+    if (sync != tc->expected_sync) {
+        DSD_FPRINTF(stderr, "%s returned %d, expected %d\n", tc->label, sync, tc->expected_sync);
         rc = 1;
     }
-    if (state.samplesPerSymbol != 20 || state.symbolCenter != 9) {
-        DSD_FPRINTF(stderr, "DMR WAV timing changed to sps=%d center=%d, expected 20/9\n", state.samplesPerSymbol,
-                    state.symbolCenter);
+    if (state.lastsynctype != tc->expected_sync) {
+        DSD_FPRINTF(stderr, "%s lastsynctype %d, expected %d\n", tc->label, state.lastsynctype, tc->expected_sync);
+        rc = 1;
+    }
+    if (state.carrier != 1) {
+        DSD_FPRINTF(stderr, "%s did not set carrier lock\n", tc->label);
+        rc = 1;
+    }
+    if (tc->expected_ftype && strcmp(state.ftype, tc->expected_ftype) != 0) {
+        DSD_FPRINTF(stderr, "%s ftype '%s', expected '%s'\n", tc->label, state.ftype, tc->expected_ftype);
+        rc = 1;
+    }
+    if (tc->frame_ysf && opts.inverted_ysf != tc->expected_inverted_ysf) {
+        DSD_FPRINTF(stderr, "%s inverted_ysf %d, expected %d\n", tc->label, opts.inverted_ysf,
+                    tc->expected_inverted_ysf);
         rc = 1;
     }
 
@@ -251,9 +308,361 @@ run_dmr_wav_rate_case(void) {
     return rc;
 }
 
+static int
+run_dmr_sync_case(const DmrSyncCase* tc) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_common_wav_opts_state(&opts, &state);
+
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "failed to allocate DMR frame-sync state buffers\n");
+        return 1;
+    }
+
+    opts.frame_dmr = 1;
+    opts.inverted_dmr = tc->inverted_dmr;
+    state.lastsynctype = tc->initial_lastsynctype;
+    g_symbol_index = 0U;
+    g_sync_pattern = tc->pattern;
+    dsd_frame_sync_reset_mod_state();
+
+    int sync = getFrameSync(&opts, &state);
+    int rc = 0;
+    if (sync != tc->expected_sync) {
+        DSD_FPRINTF(stderr, "%s returned %d, expected %d\n", tc->label, sync, tc->expected_sync);
+        rc = 1;
+    }
+    if (state.lastsynctype != tc->expected_sync) {
+        DSD_FPRINTF(stderr, "%s lastsynctype %d, expected %d\n", tc->label, state.lastsynctype, tc->expected_sync);
+        rc = 1;
+    }
+    if (state.directmode != tc->expected_directmode) {
+        DSD_FPRINTF(stderr, "%s directmode %d, expected %d\n", tc->label, state.directmode, tc->expected_directmode);
+        rc = 1;
+    }
+    if (state.firstframe != tc->expected_firstframe) {
+        DSD_FPRINTF(stderr, "%s firstframe %d, expected %d\n", tc->label, state.firstframe, tc->expected_firstframe);
+        rc = 1;
+    }
+    if (state.carrier != 1) {
+        DSD_FPRINTF(stderr, "%s did not set carrier lock\n", tc->label);
+        rc = 1;
+    }
+    if (tc->expected_ftype && strcmp(state.ftype, tc->expected_ftype) != 0) {
+        DSD_FPRINTF(stderr, "%s ftype '%s', expected '%s'\n", tc->label, state.ftype, tc->expected_ftype);
+        rc = 1;
+    }
+
+    free_state_buffers(&state);
+    return rc;
+}
+
+static int
+run_dmr_wav_rate_case(void) {
+    SymbolSyncCase tc = {
+        .label = "DMR WAV sync",
+        .pattern = DMR_BS_DATA_SYNC,
+        .frame_dmr = 1,
+        .expected_sync = DSD_SYNC_DMR_BS_DATA_POS,
+    };
+    int rc = run_symbol_sync_case(&tc);
+    if (rc != 0) {
+        return rc;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    init_common_wav_opts_state(&opts, &state);
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "failed to allocate DMR timing frame-sync state buffers\n");
+        return 1;
+    }
+    opts.frame_dmr = 1;
+    g_symbol_index = 0U;
+    g_sync_pattern = DMR_BS_DATA_SYNC;
+    dsd_frame_sync_reset_mod_state();
+    (void)getFrameSync(&opts, &state);
+    if (state.samplesPerSymbol != 20 || state.symbolCenter != 9) {
+        DSD_FPRINTF(stderr, "DMR WAV timing changed to sps=%d center=%d, expected 20/9\n", state.samplesPerSymbol,
+                    state.symbolCenter);
+        rc = 1;
+    }
+    free_state_buffers(&state);
+    return rc;
+}
+
+static int
+run_dmr_sync_variant_matrix(void) {
+    static const DmrSyncCase cases[] = {
+        {
+            .label = "DMR MS data",
+            .pattern = DMR_MS_DATA_SYNC,
+            .expected_sync = DSD_SYNC_DMR_MS_DATA,
+            .expected_directmode = 0,
+            .expected_firstframe = 0,
+            .expected_ftype = "DMR MS",
+        },
+        {
+            .label = "DMR MS voice inverted",
+            .pattern = DMR_MS_VOICE_SYNC,
+            .inverted_dmr = 1,
+            .expected_sync = DSD_SYNC_DMR_MS_DATA,
+            .expected_directmode = 0,
+            .expected_firstframe = 0,
+            .expected_ftype = "DMR MS",
+        },
+        {
+            .label = "DMR BS voice",
+            .pattern = DMR_BS_VOICE_SYNC,
+            .initial_lastsynctype = DSD_SYNC_NONE,
+            .expected_sync = DSD_SYNC_DMR_BS_VOICE_POS,
+            .expected_directmode = 0,
+            .expected_firstframe = 1,
+            .expected_ftype = "DMR ",
+        },
+        {
+            .label = "DMR BS voice inverted",
+            .pattern = DMR_BS_VOICE_SYNC,
+            .inverted_dmr = 1,
+            .expected_sync = DSD_SYNC_DMR_BS_DATA_NEG,
+            .expected_directmode = 0,
+            .expected_firstframe = 0,
+            .expected_ftype = "DMR ",
+        },
+        {
+            .label = "DMR direct TS1 data",
+            .pattern = DMR_DIRECT_MODE_TS1_DATA_SYNC,
+            .expected_sync = DSD_SYNC_DMR_MS_DATA,
+            .expected_directmode = 1,
+            .expected_firstframe = 0,
+            .expected_ftype = "DMR ",
+        },
+        {
+            .label = "DMR direct TS2 data inverted",
+            .pattern = DMR_DIRECT_MODE_TS2_DATA_SYNC,
+            .inverted_dmr = 1,
+            .initial_lastsynctype = DSD_SYNC_NONE,
+            .expected_sync = DSD_SYNC_DMR_MS_VOICE,
+            .expected_directmode = 1,
+            .expected_firstframe = 1,
+            .expected_ftype = "DMR ",
+        },
+        {
+            .label = "DMR direct TS1 voice",
+            .pattern = DMR_DIRECT_MODE_TS1_VOICE_SYNC,
+            .initial_lastsynctype = DSD_SYNC_NONE,
+            .expected_sync = DSD_SYNC_DMR_MS_VOICE,
+            .expected_directmode = 1,
+            .expected_firstframe = 1,
+            .expected_ftype = "DMR ",
+        },
+        {
+            .label = "DMR direct TS2 voice inverted",
+            .pattern = DMR_DIRECT_MODE_TS2_VOICE_SYNC,
+            .inverted_dmr = 1,
+            .expected_sync = DSD_SYNC_DMR_MS_DATA,
+            .expected_directmode = 1,
+            .expected_firstframe = 0,
+            .expected_ftype = "DMR ",
+        },
+    };
+
+    int rc = 0;
+    for (size_t i = 0; i < (sizeof(cases) / sizeof(cases[0])); i++) {
+        rc |= run_dmr_sync_case(&cases[i]);
+    }
+    return rc;
+}
+
+static int
+run_wav_protocol_sync_matrix(void) {
+    static const SymbolSyncCase cases[] = {
+        {
+            .label = "DSTAR voice positive",
+            .pattern = DSTAR_SYNC,
+            .frame_dstar = 1,
+            .expected_sync = DSD_SYNC_DSTAR_VOICE_POS,
+            .expected_ftype = "DSTAR ",
+        },
+        {
+            .label = "DSTAR voice negative",
+            .pattern = INV_DSTAR_SYNC,
+            .frame_dstar = 1,
+            .expected_sync = DSD_SYNC_DSTAR_VOICE_NEG,
+            .expected_ftype = "DSTAR ",
+        },
+        {
+            .label = "DSTAR header positive",
+            .pattern = DSTAR_HD,
+            .frame_dstar = 1,
+            .expected_sync = DSD_SYNC_DSTAR_HD_POS,
+            .expected_ftype = "DSTAR_HD ",
+        },
+        {
+            .label = "DSTAR header negative",
+            .pattern = INV_DSTAR_HD,
+            .frame_dstar = 1,
+            .expected_sync = DSD_SYNC_DSTAR_HD_NEG,
+            .expected_ftype = " DSTAR_HD",
+        },
+        {
+            .label = "ProVoice positive",
+            .pattern = PROVOICE_SYNC,
+            .frame_provoice = 1,
+            .expected_sync = DSD_SYNC_PROVOICE_POS,
+            .expected_ftype = "ProVoice ",
+        },
+        {
+            .label = "ProVoice negative",
+            .pattern = INV_PROVOICE_SYNC,
+            .frame_provoice = 1,
+            .expected_sync = DSD_SYNC_PROVOICE_NEG,
+            .expected_ftype = "ProVoice ",
+        },
+        {
+            .label = "EDACS positive",
+            .pattern = INV_EDACS_SYNC,
+            .frame_provoice = 1,
+            .expected_sync = DSD_SYNC_EDACS_POS,
+        },
+        {
+            .label = "EDACS negative",
+            .pattern = EDACS_SYNC,
+            .frame_provoice = 1,
+            .expected_sync = DSD_SYNC_EDACS_NEG,
+        },
+    };
+
+    int rc = 0;
+    for (size_t i = 0; i < (sizeof(cases) / sizeof(cases[0])); i++) {
+        rc |= run_symbol_sync_case(&cases[i]);
+    }
+    return rc;
+}
+
+static int
+run_wav_protocol_extended_sync_matrix(void) {
+    static const SymbolSyncCase cases[] = {
+        {
+            .label = "X2-TDMA BS data",
+            .pattern = X2TDMA_BS_DATA_SYNC,
+            .frame_x2tdma = 1,
+            .expected_sync = DSD_SYNC_X2TDMA_DATA_POS,
+            .expected_ftype = "X2-TDMA",
+        },
+        {
+            .label = "X2-TDMA BS voice inverted maps to data-neg",
+            .pattern = X2TDMA_BS_VOICE_SYNC,
+            .frame_x2tdma = 1,
+            .inverted_x2tdma = 1,
+            .expected_sync = DSD_SYNC_X2TDMA_DATA_NEG,
+            .expected_ftype = "X2-TDMA",
+        },
+        {
+            .label = "YSF positive",
+            .pattern = FUSION_SYNC,
+            .frame_ysf = 1,
+            .initial_lastsynctype = DSD_SYNC_YSF_POS,
+            .expected_sync = DSD_SYNC_YSF_POS,
+            .expected_inverted_ysf = 0,
+        },
+        {
+            .label = "YSF negative",
+            .pattern = INV_FUSION_SYNC,
+            .frame_ysf = 1,
+            .initial_lastsynctype = DSD_SYNC_YSF_NEG,
+            .expected_sync = DSD_SYNC_YSF_NEG,
+            .expected_inverted_ysf = 1,
+        },
+        {
+            .label = "dPMR FS2 positive",
+            .pattern = DPMR_FRAME_SYNC_2,
+            .frame_dpmr = 1,
+            .expected_sync = DSD_SYNC_DPMR_FS2_POS,
+            .expected_ftype = "dPMR ",
+        },
+        {
+            .label = "dPMR FS2 negative",
+            .pattern = INV_DPMR_FRAME_SYNC_2,
+            .frame_dpmr = 1,
+            .inverted_dpmr = 1,
+            .expected_sync = DSD_SYNC_DPMR_FS2_NEG,
+            .expected_ftype = "dPMR ",
+        },
+    };
+
+    int rc = 0;
+    for (size_t i = 0; i < (sizeof(cases) / sizeof(cases[0])); i++) {
+        rc |= run_symbol_sync_case(&cases[i]);
+    }
+    return rc;
+}
+
+static int
+run_nxdn_two_pass_case(const char* label, const char* pattern, int frame_nxdn48, int frame_nxdn96, int expected_sync) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_common_wav_opts_state(&opts, &state);
+
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "failed to allocate NXDN frame-sync state buffers\n");
+        return 1;
+    }
+
+    opts.frame_nxdn48 = frame_nxdn48;
+    opts.frame_nxdn96 = frame_nxdn96;
+    dsd_frame_sync_reset_mod_state();
+
+    g_symbol_index = 0U;
+    g_sync_pattern = pattern;
+    int sync = getFrameSync(&opts, &state);
+    int rc = 0;
+    if (sync != DSD_SYNC_NONE) {
+        DSD_FPRINTF(stderr, "%s first pass returned %d, expected no confirmed sync\n", label, sync);
+        rc = 1;
+    }
+    if (state.lastsynctype != expected_sync) {
+        DSD_FPRINTF(stderr, "%s first pass lastsynctype %d, expected staged %d\n", label, state.lastsynctype,
+                    expected_sync);
+        rc = 1;
+    }
+
+    g_symbol_index = 0U;
+    sync = getFrameSync(&opts, &state);
+    if (sync != expected_sync) {
+        DSD_FPRINTF(stderr, "%s second pass returned %d, expected %d\n", label, sync, expected_sync);
+        rc = 1;
+    }
+    if (state.lastsynctype != expected_sync) {
+        DSD_FPRINTF(stderr, "%s second pass lastsynctype %d, expected %d\n", label, state.lastsynctype, expected_sync);
+        rc = 1;
+    }
+    if (state.offset <= 0) {
+        DSD_FPRINTF(stderr, "%s did not record a positive sync offset\n", label);
+        rc = 1;
+    }
+
+    free_state_buffers(&state);
+    return rc;
+}
+
+static int
+run_nxdn_sync_confirmation_matrix(void) {
+    int rc = 0;
+    rc |= run_nxdn_two_pass_case("NXDN48 positive FSW", NXDN_FSW, 1, 0, DSD_SYNC_NXDN_POS);
+    rc |= run_nxdn_two_pass_case("NXDN96 negative FSW", INV_NXDN_FSW, 0, 1, DSD_SYNC_NXDN_NEG);
+    return rc;
+}
+
 int
 main(void) {
-    return run_dmr_wav_rate_case();
+    int rc = 0;
+    rc |= run_dmr_wav_rate_case();
+    rc |= run_dmr_sync_variant_matrix();
+    rc |= run_wav_protocol_sync_matrix();
+    rc |= run_wav_protocol_extended_sync_matrix();
+    rc |= run_nxdn_sync_confirmation_matrix();
+    return rc;
 }
 
 #if defined(__GNUC__) && !defined(__cplusplus)

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -321,12 +321,23 @@ test_rtl_symbol_profile_selection(void) {
     assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 4800, 2)
            == DSD_RTL_STREAM_CHANNEL_PROFILE_6K25);
     assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(&opts, 4800, 0) == 2);
+    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(&opts, 4800, 4) == 4);
 
     reset(&opts, &state);
     opts.frame_provoice = 1;
     assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 9600, 0)
            == DSD_RTL_STREAM_CHANNEL_PROFILE_PROVOICE);
     assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(&opts, 9600, 0) == 2);
+    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 4800, 0)
+           == DSD_RTL_STREAM_CHANNEL_PROFILE_PROVOICE);
+    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(&opts, 4800, 0) == 2);
+
+    reset(&opts, &state);
+    opts.frame_dstar = 1;
+    opts.frame_dmr = 1;
+    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 4800, 0)
+           == DSD_RTL_STREAM_CHANNEL_PROFILE_12K5);
+    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(&opts, 4800, 0) == 4);
 
     reset(&opts, &state);
     opts.frame_p25p2 = 1;

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(misc-use-internal-linkage)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/platform/sockets.h>
+#ifdef USE_RADIO
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#endif
+#include <math.h>
+#include <stdint.h>
+#include <time.h>
+
+#include "dsd-neo/core/dibit.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+dsd_socket_t
+Connect(char* hostname, int portno) { // NOLINT(misc-use-internal-linkage)
+    (void)hostname;
+    (void)portno;
+    return (dsd_socket_t)0;
+}
+
+int
+openAudioInput(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    return -1;
+}
+
+void
+cleanupAndExit(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+void
+dsd_audio_rescale_symbol_timing(dsd_state* state, int old_rate_hz, int new_rate_hz) {
+    (void)state;
+    (void)old_rate_hz;
+    (void)new_rate_hz;
+}
+
+void
+getTimeC_buf(char out[9]) { // NOLINT(misc-use-internal-linkage)
+    if (out) {
+        DSD_SNPRINTF(out, 9, "%s", "00:00:00");
+    }
+}
+
+void
+printFrameInfo(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+void
+dsd_mark_cc_sync(dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+}
+
+void
+watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+write_symbol_capture_record(dsd_opts* opts, dsd_state* state, int dibit, float symbol) {
+    (void)opts;
+    (void)state;
+    (void)dibit;
+    (void)symbol;
+}
+
+uint8_t
+dmr_compute_reliability(const dsd_state* st, float sym) {
+    (void)st;
+    (void)sym;
+    return 255;
+}
+
+double
+pwr_to_dB(double mean_power) { // NOLINT(misc-use-internal-linkage)
+    (void)mean_power;
+    return 0.0;
+}
+
+void
+lpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+hpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+pbf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+agsm_f(dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+static void
+reset(dsd_opts* opts, dsd_state* state) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+}
+
+static void
+test_sps_hunt_skips_disabled_protocol_rates(void) {
+    static const int sym_rate_cycle[] = {4800, 2400, 9600, 6000, 4800};
+    static const int levels_cycle[] = {4, 4, 2, 4, 2};
+    static const int cycle_count = (int)(sizeof(sym_rate_cycle) / sizeof(sym_rate_cycle[0]));
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_dstar = 1;
+    state.sps_hunt_idx = 3;
+    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state, sym_rate_cycle, levels_cycle, cycle_count) == 4);
+
+    reset(&opts, &state);
+    opts.frame_dmr = 1;
+    state.sps_hunt_idx = 4;
+    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state, sym_rate_cycle, levels_cycle, cycle_count) == 0);
+
+    reset(&opts, &state);
+    opts.frame_nxdn48 = 1;
+    state.sps_hunt_idx = 0;
+    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state, sym_rate_cycle, levels_cycle, cycle_count) == 1);
+
+    reset(&opts, &state);
+    opts.frame_provoice = 1;
+    state.sps_hunt_idx = 1;
+    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state, sym_rate_cycle, levels_cycle, cycle_count) == 2);
+
+    reset(&opts, &state);
+    opts.frame_p25p2 = 1;
+    state.sps_hunt_idx = 2;
+    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state, sym_rate_cycle, levels_cycle, cycle_count) == 3);
+}
+
+static void
+test_sps_hunt_profile_updates_timing(void) {
+    static const int sym_rate_cycle[] = {4800, 2400, 9600, 6000, 4800};
+    static const int levels_cycle[] = {4, 4, 2, 4, 2};
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 96000;
+    opts.wav_decimator = 48000;
+    state.sps_hunt_idx = 0;
+    state.samplesPerSymbol = 10;
+    state.symbolCenter = 4;
+
+    dsd_frame_sync_test_apply_sps_hunt_profile(&opts, &state, 1, sym_rate_cycle, levels_cycle);
+    int expected_sps = dsd_opts_compute_sps_rate(&opts, sym_rate_cycle[1], dsd_opts_current_input_timing_rate(&opts));
+    assert(state.sps_hunt_idx == 1);
+    assert(state.samplesPerSymbol == expected_sps);
+    assert(state.symbolCenter == dsd_opts_symbol_center(expected_sps));
+
+    dsd_frame_sync_test_apply_sps_hunt_profile(&opts, &state, 1, sym_rate_cycle, levels_cycle);
+    assert(state.sps_hunt_idx == 1);
+    assert(state.samplesPerSymbol == expected_sps);
+    assert(state.symbolCenter == dsd_opts_symbol_center(expected_sps));
+}
+
+static void
+test_elapsed_seconds_prefers_monotonic_then_wall_time(void) {
+    assert(fabs(dsd_frame_sync_test_elapsed_seconds(12.5, (time_t)20, 10.0, (time_t)3) - 2.5) < 0.000001);
+    assert(fabs(dsd_frame_sync_test_elapsed_seconds(12.5, (time_t)20, 0.0, (time_t)3) - 17.0) < 0.000001);
+    assert(dsd_frame_sync_test_elapsed_seconds(12.5, (time_t)20, 0.0, (time_t)0) > 1.0e8);
+}
+
+static void
+test_p25_slot_activity_honors_ring_and_hangtime(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int left_active = 0;
+    int right_active = 0;
+
+    reset(&opts, &state);
+    opts.trunk_hangtime = 2.0f;
+    state.p25_p2_last_mac_active_m[0] = 99.8;
+    state.p25_p2_last_mac_active_m[1] = 95.0;
+    state.p25_p2_audio_ring_count[0] = 1;
+    state.p25_p2_audio_allowed[1] = 1;
+    dsd_frame_sync_test_p25_slot_activity(&opts, &state, (time_t)100, 100.0, 0.75, 0.75, 1.0, &left_active,
+                                          &right_active);
+    assert(left_active == 1);
+    assert(right_active == 1);
+
+    left_active = 0;
+    right_active = 0;
+    dsd_frame_sync_test_p25_slot_activity(&opts, &state, (time_t)100, 100.0, 0.75, 0.75, 2.0, &left_active,
+                                          &right_active);
+    assert(left_active == 1);
+    assert(right_active == 0);
+}
+
+static void
+test_hamming_helpers_find_best_patterns(void) {
+    const char* patterns[] = {"012301", "333333", "111111"};
+
+    assert(dsd_frame_sync_test_hamming_distance_pattern("012301", "012301", 6) == 0);
+    assert(dsd_frame_sync_test_hamming_distance_pattern("012301", "012300", 6) == 1);
+    assert(dsd_frame_sync_test_best_ham_for_patterns("111101", patterns, 3, 6, 6) == 1);
+    assert(dsd_frame_sync_test_best_ham_for_patterns("222222", patterns, 3, 6, 3) == 3);
+    assert(dsd_frame_sync_test_best_nxdn_scaled_ham("3131331131", 24) == 0);
+    assert(dsd_frame_sync_test_best_nxdn_scaled_ham("1313113300", 24) == 5);
+}
+
+#ifdef USE_RADIO
+static void
+test_rtl_symbol_profile_selection(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_dstar = 1;
+    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 4800, 2)
+           == DSD_RTL_STREAM_CHANNEL_PROFILE_6K25);
+    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(&opts, 4800, 0) == 2);
+
+    reset(&opts, &state);
+    opts.frame_provoice = 1;
+    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 9600, 0)
+           == DSD_RTL_STREAM_CHANNEL_PROFILE_PROVOICE);
+    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(&opts, 9600, 0) == 2);
+
+    reset(&opts, &state);
+    opts.frame_p25p2 = 1;
+    state.rf_mod = 1;
+    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 6000, 0)
+           == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+
+    reset(&opts, &state);
+    opts.frame_x2tdma = 1;
+    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 6000, 0)
+           == DSD_RTL_STREAM_CHANNEL_PROFILE_12K5);
+
+    reset(&opts, &state);
+    opts.frame_dmr = 1;
+    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 4800, 0)
+           == DSD_RTL_STREAM_CHANNEL_PROFILE_12K5);
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    state.rf_mod = 0;
+    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 4800, 0)
+           == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
+    state.rf_mod = 1;
+    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 4800, 0)
+           == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+
+    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(NULL, NULL, 2400, 0) == DSD_RTL_STREAM_CHANNEL_PROFILE_6K25);
+    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(NULL, 4800, 0) == 4);
+    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(NULL, 4800, 2) == 2);
+}
+#endif
+
+int
+main(void) {
+    test_sps_hunt_skips_disabled_protocol_rates();
+    test_sps_hunt_profile_updates_timing();
+    test_elapsed_seconds_prefers_monotonic_then_wall_time();
+    test_p25_slot_activity_honors_ring_and_hangtime();
+    test_hamming_helpers_find_best_patterns();
+#ifdef USE_RADIO
+    test_rtl_symbol_profile_selection();
+#endif
+    return 0;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif
+// NOLINTEND(misc-use-internal-linkage)

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -10,8 +10,10 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/platform/sockets.h>
+#include <dsd-neo/runtime/frame_sync_hooks.h>
 #ifdef USE_RADIO
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #endif
@@ -257,6 +259,58 @@ test_hamming_helpers_find_best_patterns(void) {
 }
 
 #ifdef USE_RADIO
+static double g_snr_c4fm = -100.0;
+static double g_snr_c4fm_eye = -100.0;
+static double g_snr_cqpsk = -100.0;
+static double g_snr_qpsk_const = -100.0;
+static int g_frame_sync_tick_calls = 0;
+
+static double
+fake_snr_c4fm_db(void) {
+    return g_snr_c4fm;
+}
+
+static double
+fake_snr_c4fm_eye_db(void) {
+    return g_snr_c4fm_eye;
+}
+
+static double
+fake_snr_cqpsk_db(void) {
+    return g_snr_cqpsk;
+}
+
+static double
+fake_snr_qpsk_const_db(void) {
+    return g_snr_qpsk_const;
+}
+
+static void
+fake_p25_sm_try_tick(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_frame_sync_tick_calls++;
+}
+
+static void
+set_fake_snr(double c4fm, double c4fm_eye, double cqpsk, double qpsk_const) {
+    g_snr_c4fm = c4fm;
+    g_snr_c4fm_eye = c4fm_eye;
+    g_snr_cqpsk = cqpsk;
+    g_snr_qpsk_const = qpsk_const;
+}
+
+static void
+install_fake_snr_hooks(void) {
+    dsd_rtl_stream_metrics_hooks hooks = {
+        .snr_c4fm_db = fake_snr_c4fm_db,
+        .snr_c4fm_eye_db = fake_snr_c4fm_eye_db,
+        .snr_cqpsk_db = fake_snr_cqpsk_db,
+        .snr_qpsk_const_db = fake_snr_qpsk_const_db,
+    };
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+}
+
 static void
 test_rtl_symbol_profile_selection(void) {
     static dsd_opts opts;
@@ -303,6 +357,123 @@ test_rtl_symbol_profile_selection(void) {
     assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(NULL, 4800, 0) == 4);
     assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(NULL, 4800, 2) == 2);
 }
+
+static void
+test_modulation_snr_fallback_votes_and_dwell(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int lastt = 24;
+    int c4fm_votes = -1;
+    int qpsk_votes = -1;
+    int gfsk_votes = -1;
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    state.carrier = 1;
+    state.rf_mod = 0;
+    dsd_frame_sync_reset_mod_state();
+    set_fake_snr(-100.0, 4.0, -100.0, 12.0);
+    install_fake_snr_hooks();
+
+    dsd_frame_sync_test_auto_switch_modulation(&opts, &state, 24, &lastt);
+    dsd_frame_sync_test_get_mod_votes(&c4fm_votes, &qpsk_votes, &gfsk_votes);
+    assert(state.rf_mod == 0);
+    assert(c4fm_votes == 0);
+    assert(qpsk_votes == 1);
+    assert(gfsk_votes == 0);
+
+    lastt = 24;
+    dsd_frame_sync_test_auto_switch_modulation(&opts, &state, 24, &lastt);
+    assert(state.rf_mod == 1);
+
+    lastt = 24;
+    set_fake_snr(25.0, -100.0, 5.0, -100.0);
+    dsd_frame_sync_test_auto_switch_modulation(&opts, &state, 24, &lastt);
+    assert(state.rf_mod == 1);
+
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+}
+
+static void
+test_modulation_cli_lock_prevents_votes(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int lastt = 24;
+    int c4fm_votes = -1;
+    int qpsk_votes = -1;
+    int gfsk_votes = -1;
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_qpsk = 1;
+    state.rf_mod = 0;
+    dsd_frame_sync_reset_mod_state();
+    set_fake_snr(-100.0, -100.0, 20.0, -100.0);
+    install_fake_snr_hooks();
+
+    dsd_frame_sync_test_auto_switch_modulation(&opts, &state, 24, &lastt);
+    dsd_frame_sync_test_get_mod_votes(&c4fm_votes, &qpsk_votes, &gfsk_votes);
+    assert(state.rf_mod == 0);
+    assert(c4fm_votes == 0);
+    assert(qpsk_votes == 0);
+    assert(gfsk_votes == 0);
+
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+}
+
+static void
+test_hamming_override_can_select_qpsk(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int lastt = 24;
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    state.rf_mod = 0;
+    dsd_frame_sync_reset_mod_state();
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+    dsd_frame_sync_test_set_recent_hamming(10, 1, 24);
+
+    dsd_frame_sync_test_auto_switch_modulation(&opts, &state, 24, &lastt);
+    assert(state.rf_mod == 0);
+    lastt = 24;
+    dsd_frame_sync_test_auto_switch_modulation(&opts, &state, 24, &lastt);
+    assert(state.rf_mod == 1);
+}
+
+static void
+test_p25_trunk_tick_recency(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.p25_trunk = 1;
+    state.p25_p2_active_slot = -1;
+    state.lastsynctype = DSD_SYNC_P25P1_POS;
+    g_frame_sync_tick_calls = 0;
+    dsd_frame_sync_test_reset_p25_trunk_tick_state();
+    dsd_frame_sync_hooks_set((dsd_frame_sync_hooks){
+        .p25_sm_try_tick = fake_p25_sm_try_tick,
+    });
+
+    dsd_frame_sync_test_maybe_tick_p25_trunk_sm(&opts, &state, (time_t)100);
+    assert(g_frame_sync_tick_calls == 1);
+    dsd_frame_sync_test_maybe_tick_p25_trunk_sm(&opts, &state, (time_t)100);
+    assert(g_frame_sync_tick_calls == 1);
+
+    state.lastsynctype = DSD_SYNC_NONE;
+    dsd_frame_sync_test_maybe_tick_p25_trunk_sm(&opts, &state, (time_t)101);
+    assert(g_frame_sync_tick_calls == 2);
+    dsd_frame_sync_test_maybe_tick_p25_trunk_sm(&opts, &state, (time_t)105);
+    assert(g_frame_sync_tick_calls == 2);
+
+    state.p25_p2_active_slot = 0;
+    dsd_frame_sync_test_maybe_tick_p25_trunk_sm(&opts, &state, (time_t)106);
+    assert(g_frame_sync_tick_calls == 3);
+
+    dsd_frame_sync_hooks_set((dsd_frame_sync_hooks){0});
+}
 #endif
 
 int
@@ -314,6 +485,10 @@ main(void) {
     test_hamming_helpers_find_best_patterns();
 #ifdef USE_RADIO
     test_rtl_symbol_profile_selection();
+    test_modulation_snr_fallback_votes_and_dwell();
+    test_modulation_cli_lock_prevents_votes();
+    test_hamming_override_can_select_qpsk();
+    test_p25_trunk_tick_recency();
 #endif
     return 0;
 }

--- a/tests/dsp/test_frame_sync_level_window.c
+++ b/tests/dsp/test_frame_sync_level_window.c
@@ -50,9 +50,64 @@ test_long_window_drops_outer_outliers(void) {
     return rc;
 }
 
+static int
+test_missing_output_is_noop(void) {
+    const float sorted_levels[3] = {-1.0f, 0.0f, 1.0f};
+    float lmin = 12.0f;
+    float lmax = 34.0f;
+
+    dsd_frame_sync_estimate_sorted_window_levels(sorted_levels, 3, NULL, &lmax);
+    dsd_frame_sync_estimate_sorted_window_levels(sorted_levels, 3, &lmin, NULL);
+
+    int rc = 0;
+    rc |= expect_close("missing out min unchanged", 12.0f, lmin);
+    rc |= expect_close("missing out max unchanged", 34.0f, lmax);
+    return rc;
+}
+
+static int
+test_empty_input_clears_outputs(void) {
+    float lmin = 12.0f;
+    float lmax = 34.0f;
+
+    dsd_frame_sync_estimate_sorted_window_levels(NULL, 3, &lmin, &lmax);
+    int rc = 0;
+    rc |= expect_close("null input lmin", 0.0f, lmin);
+    rc |= expect_close("null input lmax", 0.0f, lmax);
+
+    lmin = 12.0f;
+    lmax = 34.0f;
+    const float sorted_levels[1] = {9.0f};
+    dsd_frame_sync_estimate_sorted_window_levels(sorted_levels, 0, &lmin, &lmax);
+    rc |= expect_close("zero count lmin", 0.0f, lmin);
+    rc |= expect_close("zero count lmax", 0.0f, lmax);
+    return rc;
+}
+
+static int
+test_tiny_window_uses_average(void) {
+    const float one_level[1] = {7.0f};
+    const float two_levels[2] = {-3.0f, 9.0f};
+    float lmin = 0.0f;
+    float lmax = 0.0f;
+    int rc = 0;
+
+    dsd_frame_sync_estimate_sorted_window_levels(one_level, 1, &lmin, &lmax);
+    rc |= expect_close("one lmin", 7.0f, lmin);
+    rc |= expect_close("one lmax", 7.0f, lmax);
+
+    dsd_frame_sync_estimate_sorted_window_levels(two_levels, 2, &lmin, &lmax);
+    rc |= expect_close("two lmin", 3.0f, lmin);
+    rc |= expect_close("two lmax", 3.0f, lmax);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
+    rc |= test_missing_output_is_noop();
+    rc |= test_empty_input_clears_outputs();
+    rc |= test_tiny_window_uses_average();
     rc |= test_short_window_uses_edges();
     rc |= test_long_window_drops_outer_outliers();
     return rc;

--- a/tests/dsp/test_frame_sync_policy.c
+++ b/tests/dsp/test_frame_sync_policy.c
@@ -39,6 +39,9 @@ main(void) {
     state.lastsynctype = DSD_SYNC_YSF_POS;
     assert(dsd_frame_sync_suppress_p25_alt_sync(&opts, &state) == 0);
 
+    assert(dsd_frame_sync_suppress_p25_alt_sync(NULL, &state) == 0);
+    assert(dsd_frame_sync_suppress_p25_alt_sync(&opts, NULL) == 0);
+
     reset(&opts, &state);
     opts.audio_in_type = AUDIO_IN_TCP;
     assert(dsd_frame_sync_suppress_tcp_no_signal_console(&opts, &state) == 1);
@@ -69,6 +72,9 @@ main(void) {
     opts.frame_p25p1 = 0;
     opts.frame_p25p2 = 0;
     assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) == 3);
+
+    assert(dsd_frame_sync_sps_hunt_dwell_passes(NULL, &state) == 3);
+    assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, NULL) == 3);
 
     return 0;
 }

--- a/tests/dsp/test_rtl_symbol_pipeline.cpp
+++ b/tests/dsp/test_rtl_symbol_pipeline.cpp
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(performance-enum-size)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -206,6 +209,41 @@ check_cqpsk_phase_extractor_accuracy(demod_state* s) {
     return 0;
 }
 
+static int
+check_cqpsk_squelch_emits_zero_symbols(demod_state* s) {
+    enum : unsigned short { PAIRS = 20, SPS = 7 };
+
+    reset_demod(s);
+    s->output_kind = DSD_DEMOD_OUTPUT_SYMBOL_CQPSK;
+    s->cqpsk_enable = 1;
+    s->ted_sps = SPS;
+    s->lp_len = PAIRS * 2;
+    s->mode_demod = &raw_demod;
+    s->channel_squelch_level = 0.001f;
+    for (int i = 0; i < s->lp_len; i++) {
+        s->input_cb_buf[i] = 0.0f;
+    }
+
+    full_demod(s);
+
+    const int expected_symbols = (PAIRS + SPS - 1) / SPS;
+    if (!s->channel_squelched || s->squelch_gate_open) {
+        DSD_FPRINTF(stderr, "CQPSK squelch state squelched=%d gate=%d\n", s->channel_squelched, s->squelch_gate_open);
+        return 1;
+    }
+    if (s->result_len != expected_symbols) {
+        DSD_FPRINTF(stderr, "CQPSK squelch result_len=%d, expected %d\n", s->result_len, expected_symbols);
+        return 1;
+    }
+    for (int i = 0; i < s->result_len; i++) {
+        if (s->result[i] != 0.0f) {
+            DSD_FPRINTF(stderr, "CQPSK squelch result[%d]=%.3f, expected zero\n", i, s->result[i]);
+            return 1;
+        }
+    }
+    return 0;
+}
+
 } // namespace
 
 int
@@ -219,7 +257,10 @@ main(void) {
     rc |= check_fsk_discriminator_output_contract(s);
     rc |= check_cqpsk_symbol_output_contract(s);
     rc |= check_cqpsk_phase_extractor_accuracy(s);
+    rc |= check_cqpsk_squelch_emits_zero_symbols(s);
 
     std::free(s);
     return rc;
 }
+
+// NOLINTEND(performance-enum-size)

--- a/tests/dsp/test_sync_calibration.c
+++ b/tests/dsp/test_sync_calibration.c
@@ -14,6 +14,8 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/dsp/sync_calibration.h>
+#include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/runtime/config.h>
 #include <math.h>
 #include <stdio.h>
 #include "dsd-neo/core/safe_api.h"
@@ -62,10 +64,17 @@ test_history_basic_ops(void) {
     dsd_symbol_history_push(&state, 3.0f);
     check_int("count after push", 3, dsd_symbol_history_count(&state));
 
+    rc = dsd_symbol_history_init(&state, 2);
+    check_int("reinit return", 0, rc);
+    check_int("reinit count", 0, dsd_symbol_history_count(&state));
+    check_int("reinit size", 2, state.dmr_sample_history_size);
+
+    dsd_symbol_history_push(&state, 4.0f);
+    dsd_symbol_history_push(&state, 5.0f);
+
     /* Get symbols back */
-    check_float("get_back(0)", 3.0f, dsd_symbol_history_get_back(&state, 0), FLOAT_TOL);
-    check_float("get_back(1)", 2.0f, dsd_symbol_history_get_back(&state, 1), FLOAT_TOL);
-    check_float("get_back(2)", 1.0f, dsd_symbol_history_get_back(&state, 2), FLOAT_TOL);
+    check_float("get_back(0)", 5.0f, dsd_symbol_history_get_back(&state, 0), FLOAT_TOL);
+    check_float("get_back(1)", 4.0f, dsd_symbol_history_get_back(&state, 1), FLOAT_TOL);
 
     /* Reset and verify empty */
     dsd_symbol_history_reset(&state);
@@ -76,6 +85,26 @@ test_history_basic_ops(void) {
     check_int("count after free", 0, state.dmr_sample_history_count);
 
     printf("test_history_basic_ops: passed\n\n");
+}
+
+static void
+test_history_guards(void) {
+    printf("=== test_history_guards ===\n");
+
+    static struct dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    check_int("init null state", -1, dsd_symbol_history_init(NULL, 8));
+    check_int("init zero symbols", -1, dsd_symbol_history_init(&state, 0));
+
+    dsd_symbol_history_reset(NULL);
+    dsd_symbol_history_reset(&state);
+    dsd_symbol_history_free(NULL);
+
+    check_int("guard size unchanged", 0, state.dmr_sample_history_size);
+    check_int("guard count unchanged", 0, state.dmr_sample_history_count);
+
+    printf("test_history_guards: passed\n\n");
 }
 
 /**
@@ -274,6 +303,68 @@ test_center_only_large_bias(void) {
     printf("test_center_only_large_bias: passed\n\n");
 }
 
+static void
+test_center_only_failure_modes(void) {
+    printf("=== test_center_only_failure_modes ===\n");
+
+    static struct dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    static struct dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+
+    dsd_warm_start_result_t result = dsd_sync_warm_start_center_outer_only(&opts, NULL, 24);
+    check_int("center null state", DSD_WARM_START_NULL_STATE, result);
+
+    result = dsd_sync_warm_start_center_outer_only(&opts, &state, 1);
+    check_int("center invalid length", DSD_WARM_START_DEGENERATE, result);
+
+    result = dsd_sync_warm_start_center_outer_only(&opts, &state, 4);
+    check_int("center no history", DSD_WARM_START_NO_HISTORY, result);
+
+    dsd_symbol_history_init(&state, 8);
+    dsd_symbol_history_push(&state, -3.0f);
+    dsd_symbol_history_push(&state, -3.0f);
+    dsd_symbol_history_push(&state, 3.0f);
+    result = dsd_sync_warm_start_center_outer_only(&opts, &state, 3);
+    check_int("center singleton high cluster", DSD_WARM_START_DEGENERATE, result);
+
+    dsd_symbol_history_reset(&state);
+    dsd_symbol_history_push(&state, -0.2f);
+    dsd_symbol_history_push(&state, -0.2f);
+    dsd_symbol_history_push(&state, 0.2f);
+    dsd_symbol_history_push(&state, 0.2f);
+    result = dsd_sync_warm_start_center_outer_only(&opts, &state, 4);
+    check_int("center small span", DSD_WARM_START_DEGENERATE, result);
+
+    dsd_symbol_history_free(&state);
+    printf("test_center_only_failure_modes: passed\n\n");
+}
+
+static void
+test_center_only_large_sync_uses_heap_sorted_copy(void) {
+    printf("=== test_center_only_large_sync_uses_heap_sorted_copy ===\n");
+
+    static struct dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    static struct dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+
+    dsd_symbol_history_init(&state, 80);
+    for (int i = 0; i < 35; i++) {
+        dsd_symbol_history_push(&state, -2.0f);
+        dsd_symbol_history_push(&state, 4.0f);
+    }
+
+    dsd_warm_start_result_t result = dsd_sync_warm_start_center_outer_only(&opts, &state, 70);
+    check_int("center large sync result", DSD_WARM_START_OK, result);
+    check_float("center large sync", 1.0f, state.center, FLOAT_TOL);
+
+    dsd_symbol_history_free(&state);
+    printf("test_center_only_large_sync_uses_heap_sorted_copy: passed\n\n");
+}
+
 /**
  * @brief Test warm-start returns appropriate error when history is insufficient.
  */
@@ -458,22 +549,82 @@ test_buffer_prefill(void) {
     printf("test_buffer_prefill: passed\n\n");
 }
 
+static void
+test_warm_start_prefill_clamps_to_internal_buffer(void) {
+    printf("=== test_warm_start_prefill_clamps_to_internal_buffer ===\n");
+
+    static struct dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    static struct dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.msize = 2048;
+
+    dsd_symbol_history_init(&state, 64);
+    for (int i = 0; i < 24; i++) {
+        dsd_symbol_history_push(&state, (i % 2 == 0) ? 3.0f : -3.0f);
+    }
+
+    dsd_warm_start_result_t result = dsd_sync_warm_start_thresholds_outer_only(&opts, &state, 24);
+    check_int("prefill clamp result", DSD_WARM_START_OK, result);
+    check_float("maxbuf last clamped", 3.0f, state.maxbuf[1023], FLOAT_TOL);
+    check_float("minbuf last clamped", -3.0f, state.minbuf[1023], FLOAT_TOL);
+
+    dsd_symbol_history_free(&state);
+    printf("test_warm_start_prefill_clamps_to_internal_buffer: passed\n\n");
+}
+
+static void
+test_warm_start_disabled_env(void) {
+    printf("=== test_warm_start_disabled_env ===\n");
+
+    static struct dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    static struct dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+
+    dsd_symbol_history_init(&state, 4);
+    dsd_symbol_history_push(&state, -3.0f);
+    dsd_symbol_history_push(&state, -3.0f);
+    dsd_symbol_history_push(&state, 3.0f);
+    dsd_symbol_history_push(&state, 3.0f);
+
+    (void)dsd_setenv("DSD_NEO_SYNC_WARMSTART", "0", 1);
+    dsd_neo_config_init(NULL);
+
+    dsd_warm_start_result_t result = dsd_sync_warm_start_thresholds_outer_only(&opts, &state, 4);
+    check_int("thresholds disabled", DSD_WARM_START_DISABLED, result);
+    result = dsd_sync_warm_start_center_outer_only(&opts, &state, 4);
+    check_int("center disabled", DSD_WARM_START_DISABLED, result);
+
+    (void)dsd_unsetenv("DSD_NEO_SYNC_WARMSTART");
+    dsd_neo_config_init(NULL);
+    dsd_symbol_history_free(&state);
+    printf("test_warm_start_disabled_env: passed\n\n");
+}
+
 int
 main(void) {
     printf("Generic Sync Calibration Module Tests\n");
     printf("======================================\n\n");
 
     test_history_basic_ops();
+    test_history_guards();
     test_history_wraparound();
     test_warm_start_ideal();
     test_warm_start_dc_offset();
     test_center_only_warm_start();
     test_center_only_large_bias();
+    test_center_only_failure_modes();
+    test_center_only_large_sync_uses_heap_sorted_copy();
     test_warm_start_insufficient_history();
     test_warm_start_degenerate();
     test_warm_start_various_sync_lengths();
     test_null_handling();
     test_buffer_prefill();
+    test_warm_start_prefill_clamps_to_internal_buffer();
+    test_warm_start_disabled_env();
 
     printf("======================================\n");
     printf("Tests: %d, Failures: %d\n", g_test_count, g_fail_count);

--- a/tests/engine/test_engine_io_hooks_install.c
+++ b/tests/engine/test_engine_io_hooks_install.c
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/io/udp_audio.h>
+#include <dsd-neo/runtime/rtl_stream_io_hooks.h>
+#include <dsd-neo/runtime/udp_audio_hooks.h>
+#include <stddef.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/io/rtl_stream_fwd.h"
+#include "src/engine/engine_hooks_install.h"
+
+static int g_udp_blast_calls = 0;
+static int g_udp_analog_calls = 0;
+static const dsd_opts* g_last_opts = NULL;
+static dsd_state* g_last_state = NULL;
+static size_t g_last_nsam = 0;
+static const void* g_last_data = NULL;
+
+static int g_rtl_read_calls = 0;
+static int g_rtl_return_pwr_calls = 0;
+static RtlSdrContext* g_last_rtl_ctx = NULL;
+static size_t g_last_rtl_count = 0;
+
+void
+udp_socket_blaster(const dsd_opts* opts, dsd_state* state, size_t nsam, const void* data) {
+    ++g_udp_blast_calls;
+    g_last_opts = opts;
+    g_last_state = state;
+    g_last_nsam = nsam;
+    g_last_data = data;
+}
+
+void
+udp_socket_blasterA(const dsd_opts* opts, dsd_state* state, size_t nsam, const void* data) {
+    ++g_udp_analog_calls;
+    g_last_opts = opts;
+    g_last_state = state;
+    g_last_nsam = nsam;
+    g_last_data = data;
+}
+
+int
+rtl_stream_read(RtlSdrContext* ctx, float* out, size_t count, int* out_got) {
+    ++g_rtl_read_calls;
+    g_last_rtl_ctx = ctx;
+    g_last_rtl_count = count;
+    if (out != NULL && count > 0U) {
+        out[0] = 9.5f;
+    }
+    if (out_got != NULL) {
+        *out_got = (count > 0U) ? 1 : 0;
+    }
+    return 7;
+}
+
+double
+rtl_stream_return_pwr(const RtlSdrContext* ctx) {
+    ++g_rtl_return_pwr_calls;
+    g_last_rtl_ctx = (RtlSdrContext*)ctx;
+    return 12.25;
+}
+
+static void
+reset_udp_stub(void) {
+    g_udp_blast_calls = 0;
+    g_udp_analog_calls = 0;
+    g_last_opts = NULL;
+    g_last_state = NULL;
+    g_last_nsam = 0;
+    g_last_data = NULL;
+}
+
+static void
+reset_rtl_stub(void) {
+    g_rtl_read_calls = 0;
+    g_rtl_return_pwr_calls = 0;
+    g_last_rtl_ctx = NULL;
+    g_last_rtl_count = 0;
+}
+
+static void
+test_udp_audio_installer(void) {
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    unsigned char data[4] = {1, 2, 3, 4};
+
+    dsd_udp_audio_hooks_set((dsd_udp_audio_hooks){0});
+    dsd_engine_udp_audio_hooks_install();
+
+    reset_udp_stub();
+    dsd_udp_audio_hook_blast(&opts, &state, 4U, data);
+    assert(g_udp_blast_calls == 1);
+    assert(g_udp_analog_calls == 0);
+    assert(g_last_opts == &opts);
+    assert(g_last_state == &state);
+    assert(g_last_nsam == 4U);
+    assert(g_last_data == data);
+
+    dsd_udp_audio_hook_blast_analog(&opts, &state, 2U, data);
+    assert(g_udp_blast_calls == 1);
+    assert(g_udp_analog_calls == 1);
+    assert(g_last_opts == &opts);
+    assert(g_last_state == &state);
+    assert(g_last_nsam == 2U);
+    assert(g_last_data == data);
+
+    dsd_udp_audio_hooks_set((dsd_udp_audio_hooks){0});
+}
+
+static void
+test_rtl_stream_io_installer(void) {
+    static dsd_state state = {0};
+    static RtlSdrContext* fake_ctx = (RtlSdrContext*)0x1234;
+    float sample = 0.0f;
+    int got = 0;
+
+    state.rtl_ctx = fake_ctx;
+    dsd_rtl_stream_io_hooks_set((dsd_rtl_stream_io_hooks){0});
+    dsd_engine_rtl_stream_io_hooks_install();
+
+    reset_rtl_stub();
+    assert(dsd_rtl_stream_io_hook_read(&state, &sample, 3U, &got) == 7);
+    assert(g_rtl_read_calls == 1);
+    assert(g_last_rtl_ctx == fake_ctx);
+    assert(g_last_rtl_count == 3U);
+    assert(got == 1);
+    assert(sample == 9.5f);
+
+    assert(dsd_rtl_stream_io_hook_return_pwr(&state) == 12.25);
+    assert(g_rtl_return_pwr_calls == 1);
+    assert(g_last_rtl_ctx == fake_ctx);
+
+    dsd_rtl_stream_io_hooks_set((dsd_rtl_stream_io_hooks){0});
+}
+
+int
+main(void) {
+    test_udp_audio_installer();
+    test_rtl_stream_io_installer();
+    return 0;
+}

--- a/tests/engine/test_engine_rigctl_query_hooks_install.c
+++ b/tests/engine/test_engine_rigctl_query_hooks_install.c
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/io/rigctl_client.h>
+#include <dsd-neo/platform/sockets.h>
+#include <dsd-neo/runtime/rigctl_query_hooks.h>
+#include <stddef.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "src/engine/engine_hooks_install.h"
+
+static int g_get_freq_calls = 0;
+static dsd_socket_t g_last_sockfd = DSD_INVALID_SOCKET;
+static long int g_return_freq = 0;
+
+long int
+GetCurrentFreq(dsd_socket_t sockfd) {
+    ++g_get_freq_calls;
+    g_last_sockfd = sockfd;
+    return g_return_freq;
+}
+
+static void
+reset_stub(void) {
+    g_get_freq_calls = 0;
+    g_last_sockfd = DSD_INVALID_SOCKET;
+    g_return_freq = 0;
+}
+
+int
+main(void) {
+    static dsd_opts opts = {0};
+
+    dsd_rigctl_query_hooks_set((dsd_rigctl_query_hooks){0});
+    dsd_engine_rigctl_query_hooks_install();
+
+    reset_stub();
+    assert(dsd_rigctl_query_hook_get_current_freq_hz(NULL) == 0);
+    assert(g_get_freq_calls == 0);
+
+    reset_stub();
+    opts.use_rigctl = 0;
+    opts.rigctl_sockfd = 77;
+    assert(dsd_rigctl_query_hook_get_current_freq_hz(&opts) == 0);
+    assert(g_get_freq_calls == 0);
+
+    reset_stub();
+    opts.use_rigctl = 1;
+    opts.rigctl_sockfd = DSD_INVALID_SOCKET;
+    assert(dsd_rigctl_query_hook_get_current_freq_hz(&opts) == 0);
+    assert(g_get_freq_calls == 0);
+
+    reset_stub();
+    opts.use_rigctl = 1;
+    opts.rigctl_sockfd = 88;
+    g_return_freq = 851012500L;
+    assert(dsd_rigctl_query_hook_get_current_freq_hz(&opts) == 851012500L);
+    assert(g_get_freq_calls == 1);
+    assert(g_last_sockfd == 88);
+
+    dsd_rigctl_query_hooks_set((dsd_rigctl_query_hooks){0});
+    return 0;
+}

--- a/tests/engine/test_engine_rtl_stream_metrics_hooks_install.c
+++ b/tests/engine/test_engine_rtl_stream_metrics_hooks_install.c
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(misc-use-internal-linkage)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/input_level.h>
+#include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "dsd-neo/io/rtl_stream_fwd.h"
+#include "src/engine/engine_hooks_install.h"
+
+unsigned int dsd_rtl_stream_output_rate(void);
+
+static int g_output_rate_calls;
+static int g_output_kind_calls;
+static int g_symbol_profile_calls;
+static int g_generation_calls;
+static int g_set_symbol_profile_calls;
+static int g_cqpsk_status_calls;
+static int g_cqpsk_timing_bias_calls;
+static int g_snr_bias_calls;
+static int g_snr_c4fm_calls;
+static int g_snr_c4fm_eye_calls;
+static int g_snr_cqpsk_calls;
+static int g_snr_gfsk_calls;
+static int g_snr_qpsk_const_calls;
+static int g_p25p1_ber_calls;
+static int g_p25p2_err_calls;
+static int g_stream_active_calls;
+static int g_input_level_calls;
+
+static int g_last_symbol_rate;
+static int g_last_symbol_levels;
+static int g_last_symbol_profile;
+static int g_last_p25p1_ok;
+static int g_last_p25p1_err;
+static int g_last_p25p2_slot;
+static int g_last_p25p2_facch_ok;
+static int g_last_p25p2_facch_err;
+static int g_last_p25p2_sacch_ok;
+static int g_last_p25p2_sacch_err;
+static int g_last_p25p2_voice_err;
+
+unsigned int
+dsd_rtl_stream_output_rate(void) {
+    ++g_output_rate_calls;
+    return 48000U;
+}
+
+int
+rtl_stream_get_output_kind(void) {
+    ++g_output_kind_calls;
+    return 2;
+}
+
+int
+rtl_stream_get_symbol_profile_full(int* out_symbol_rate_hz, int* out_levels, int* out_channel_profile) {
+    ++g_symbol_profile_calls;
+    if (out_symbol_rate_hz) {
+        *out_symbol_rate_hz = 6000;
+    }
+    if (out_levels) {
+        *out_levels = 4;
+    }
+    if (out_channel_profile) {
+        *out_channel_profile = 5;
+    }
+    return -6;
+}
+
+uint32_t
+rtl_stream_output_generation(void) {
+    ++g_generation_calls;
+    return 123456U;
+}
+
+int
+rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profile) {
+    ++g_set_symbol_profile_calls;
+    g_last_symbol_rate = symbol_rate_hz;
+    g_last_symbol_levels = levels;
+    g_last_symbol_profile = channel_profile;
+    return 7;
+}
+
+int
+rtl_stream_get_cqpsk_status(int* cqpsk_enable, int* cqpsk_timing_active) {
+    ++g_cqpsk_status_calls;
+    if (cqpsk_enable) {
+        *cqpsk_enable = 1;
+    }
+    if (cqpsk_timing_active) {
+        *cqpsk_timing_active = 0;
+    }
+    return -8;
+}
+
+int
+rtl_stream_cqpsk_timing_bias(const RtlSdrContext* ctx) {
+    assert(ctx == NULL);
+    ++g_cqpsk_timing_bias_calls;
+    return -13;
+}
+
+double
+rtl_stream_get_snr_bias_evm(void) {
+    ++g_snr_bias_calls;
+    return 1.25;
+}
+
+double
+rtl_stream_get_snr_c4fm(void) {
+    ++g_snr_c4fm_calls;
+    return 2.5;
+}
+
+double
+rtl_stream_estimate_snr_c4fm_eye(void) {
+    ++g_snr_c4fm_eye_calls;
+    return 3.75;
+}
+
+double
+rtl_stream_get_snr_cqpsk(void) {
+    ++g_snr_cqpsk_calls;
+    return 4.5;
+}
+
+double
+rtl_stream_get_snr_gfsk(void) {
+    ++g_snr_gfsk_calls;
+    return 5.5;
+}
+
+double
+rtl_stream_estimate_snr_qpsk_const(void) {
+    ++g_snr_qpsk_const_calls;
+    return 6.5;
+}
+
+void
+rtl_stream_p25p1_ber_update(int fec_ok_delta, int fec_err_delta) {
+    ++g_p25p1_ber_calls;
+    g_last_p25p1_ok = fec_ok_delta;
+    g_last_p25p1_err = fec_err_delta;
+}
+
+void
+rtl_stream_p25p2_err_update(int slot, int facch_ok_delta, int facch_err_delta, int sacch_ok_delta, int sacch_err_delta,
+                            int voice_err_delta) {
+    ++g_p25p2_err_calls;
+    g_last_p25p2_slot = slot;
+    g_last_p25p2_facch_ok = facch_ok_delta;
+    g_last_p25p2_facch_err = facch_err_delta;
+    g_last_p25p2_sacch_ok = sacch_ok_delta;
+    g_last_p25p2_sacch_err = sacch_err_delta;
+    g_last_p25p2_voice_err = voice_err_delta;
+}
+
+int
+rtl_stream_is_active(void) {
+    ++g_stream_active_calls;
+    return 1;
+}
+
+int
+rtl_stream_get_input_level(dsd_input_level_snapshot* out) {
+    ++g_input_level_calls;
+    if (out) {
+        out->status = DSD_INPUT_LEVEL_OK;
+        out->source = DSD_INPUT_LEVEL_SOURCE_RTL_CU8;
+        out->sample_count = 1024U;
+    }
+    return -9;
+}
+
+int
+main(void) {
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+    dsd_engine_rtl_stream_metrics_hooks_install();
+
+    assert(dsd_rtl_stream_metrics_hook_output_rate_hz() == 48000U);
+    assert(g_output_rate_calls == 1);
+    assert(dsd_rtl_stream_metrics_hook_output_kind() == 2);
+    assert(g_output_kind_calls == 1);
+
+    int rate = 0;
+    int levels = 0;
+    int profile = 0;
+    assert(dsd_rtl_stream_metrics_hook_symbol_profile(&rate, &levels, &profile) == -6);
+    assert(g_symbol_profile_calls == 1);
+    assert(rate == 6000);
+    assert(levels == 4);
+    assert(profile == 5);
+
+    assert(dsd_rtl_stream_metrics_hook_stream_generation() == 123456U);
+    assert(g_generation_calls == 1);
+    assert(dsd_rtl_stream_metrics_hook_set_symbol_profile(4800, 2, 4) == 7);
+    assert(g_set_symbol_profile_calls == 1);
+    assert(g_last_symbol_rate == 4800);
+    assert(g_last_symbol_levels == 2);
+    assert(g_last_symbol_profile == 4);
+
+    int cqpsk_enable = -1;
+    int cqpsk_timing = -1;
+    assert(dsd_rtl_stream_metrics_hook_cqpsk_status(&cqpsk_enable, &cqpsk_timing) == -8);
+    assert(g_cqpsk_status_calls == 1);
+    assert(cqpsk_enable == 1);
+    assert(cqpsk_timing == 0);
+    assert(dsd_rtl_stream_metrics_hook_cqpsk_timing_bias() == -13);
+    assert(g_cqpsk_timing_bias_calls == 1);
+
+    assert(dsd_rtl_stream_metrics_hook_snr_bias_evm() == 1.25);
+    assert(dsd_rtl_stream_metrics_hook_snr_c4fm_db() == 2.5);
+    assert(dsd_rtl_stream_metrics_hook_snr_c4fm_eye_db() == 3.75);
+    assert(dsd_rtl_stream_metrics_hook_snr_cqpsk_db() == 4.5);
+    assert(dsd_rtl_stream_metrics_hook_snr_gfsk_db() == 5.5);
+    assert(dsd_rtl_stream_metrics_hook_snr_qpsk_const_db() == 6.5);
+    assert(g_snr_bias_calls == 1);
+    assert(g_snr_c4fm_calls == 1);
+    assert(g_snr_c4fm_eye_calls == 1);
+    assert(g_snr_cqpsk_calls == 1);
+    assert(g_snr_gfsk_calls == 1);
+    assert(g_snr_qpsk_const_calls == 1);
+
+    dsd_rtl_stream_metrics_hook_p25p1_ber_update(11, 12);
+    assert(g_p25p1_ber_calls == 1);
+    assert(g_last_p25p1_ok == 11);
+    assert(g_last_p25p1_err == 12);
+    dsd_rtl_stream_metrics_hook_p25p2_err_update(1, 2, 3, 4, 5, 6);
+    assert(g_p25p2_err_calls == 1);
+    assert(g_last_p25p2_slot == 1);
+    assert(g_last_p25p2_facch_ok == 2);
+    assert(g_last_p25p2_facch_err == 3);
+    assert(g_last_p25p2_sacch_ok == 4);
+    assert(g_last_p25p2_sacch_err == 5);
+    assert(g_last_p25p2_voice_err == 6);
+
+    assert(dsd_rtl_stream_metrics_hook_stream_active() == 1);
+    assert(g_stream_active_calls == 1);
+    dsd_input_level_snapshot level = {0};
+    assert(dsd_rtl_stream_metrics_hook_input_level(&level) == -9);
+    assert(g_input_level_calls == 1);
+    assert(level.status == DSD_INPUT_LEVEL_OK);
+    assert(level.source == DSD_INPUT_LEVEL_SOURCE_RTL_CU8);
+    assert(level.sample_count == 1024U);
+
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+    return 0;
+}
+
+// NOLINTEND(misc-use-internal-linkage)

--- a/tests/engine/test_engine_run_setup.c
+++ b/tests/engine/test_engine_run_setup.c
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/init.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/power.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/engine/engine.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+int
+ui_start(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    return 0;
+}
+
+void
+ui_stop(void) { // NOLINT(misc-use-internal-linkage)
+}
+
+static int
+expect_true(const char* tag, int cond) {
+    if (!cond) {
+        DSD_FPRINTF(stderr, "%s failed\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_double_near(const char* tag, double got, double want, double tol) {
+    if (fabs(got - want) > tol) {
+        DSD_FPRINTF(stderr, "%s failed got=%f want=%f\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+init_test_runtime(dsd_opts** opts_out, dsd_state** state_out) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (opts == NULL || state == NULL) {
+        DSD_FPRINTF(stderr, "alloc-failed: runtime\n");
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+    opts->playfiles = 1;
+    opts->audio_in_type = AUDIO_IN_NULL;
+    opts->audio_out_type = 9;
+    DSD_SNPRINTF(opts->audio_out_dev, sizeof opts->audio_out_dev, "%s", "null");
+
+    *opts_out = opts;
+    *state_out = state;
+    return 0;
+}
+
+static void
+free_test_runtime(dsd_opts* opts, dsd_state* state) {
+    if (state != NULL) {
+        freeState(state);
+    }
+    free(state);
+    free(opts);
+}
+
+static int
+test_conflicting_scan_modes_fail_before_live_setup(void) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    opts->trunk_scan_enabled = 1;
+    opts->scanner_mode = 1;
+    int rc = dsd_engine_run(opts, state);
+
+    int test_rc = expect_true("conflicting scan modes rejected", rc != 0);
+    free_test_runtime(opts, state);
+    return test_rc;
+}
+
+static int
+test_m17_udp_input_and_output_specs(void) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "m17udp:rx.example:17000");
+    DSD_SNPRINTF(opts->audio_out_dev, sizeof opts->audio_out_dev, "%s", "m17udp:tx.example:17001");
+    int rc = dsd_engine_run(opts, state);
+
+    int test_rc = 0;
+    test_rc |= expect_true("m17 run ok", rc == 0);
+    test_rc |= expect_true("m17 output enables ip", opts->m17_use_ip == 1);
+    test_rc |= expect_true("m17 output type", opts->audio_out_type == 9);
+    test_rc |= expect_true("m17 host parsed", strcmp(opts->m17_hostname, "tx.example") == 0);
+    test_rc |= expect_true("m17 port parsed", opts->m17_portno == 17001);
+
+    free_test_runtime(opts, state);
+    return test_rc;
+}
+
+static int
+test_m17_userdata_is_normalized_during_common_setup(void) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    DSD_SNPRINTF(state->m17dat, sizeof state->m17dat, "%s", "M17:31:n0call:all:16000:7");
+    int rc = dsd_engine_run(opts, state);
+
+    int test_rc = 0;
+    test_rc |= expect_true("m17 userdata run ok", rc == 0);
+    test_rc |= expect_true("m17 CAN clamps to maximum", state->m17_can_en == 15);
+    test_rc |= expect_true("m17 source uppercased", strcmp(state->str50c, "N0CALL") == 0);
+    test_rc |= expect_true("m17 destination uppercased", strcmp(state->str50b, "ALL") == 0);
+    test_rc |= expect_true("m17 rate parsed", state->m17_rate == 16000);
+    test_rc |= expect_true("m17 vox clamps to enabled", state->m17_vox == 1);
+
+    free_test_runtime(opts, state);
+    return test_rc;
+}
+
+static int
+test_udp_input_defaults_and_null_output(void) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "udp");
+    int rc = dsd_engine_run(opts, state);
+
+    int test_rc = 0;
+    test_rc |= expect_true("udp run ok", rc == 0);
+    test_rc |= expect_true("udp default bind address", strcmp(opts->udp_in_bindaddr, "127.0.0.1") == 0);
+    test_rc |= expect_true("udp default port", opts->udp_in_portno == 7355);
+    test_rc |= expect_true("null output disables audio", opts->audio_out_type == 9 && opts->audio_out == 0);
+
+    free_test_runtime(opts, state);
+    return test_rc;
+}
+
+static int
+test_rtltcp_tuning_tokens_and_bias(void) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s",
+                 "rtltcp:radio.local:1234:769.00625M:28:3:24:-47:5:bias=off");
+    opts->rtl_bias_tee = 1;
+    int rc = dsd_engine_run(opts, state);
+
+    int test_rc = 0;
+    test_rc |= expect_true("rtltcp run ok", rc == 0);
+    test_rc |= expect_true("rtltcp host", strcmp(opts->rtltcp_hostname, "radio.local") == 0);
+    test_rc |= expect_true("rtltcp port", opts->rtltcp_portno == 1234);
+    test_rc |=
+        expect_true("rtltcp enables rtl input", opts->rtltcp_enabled == 1 && opts->audio_in_type == AUDIO_IN_RTL);
+    test_rc |= expect_true("rtltcp frequency", opts->rtlsdr_center_freq == 769006250U);
+    test_rc |=
+        expect_true("rtltcp gain ppm bw volume", opts->rtl_gain_value == 28 && opts->rtlsdr_ppm_error == 3
+                                                     && opts->rtl_dsp_bw_khz == 24 && opts->rtl_volume_multiplier == 5);
+    test_rc |= expect_true("rtltcp bias off", opts->rtl_bias_tee == 0);
+    test_rc |= expect_double_near("rtltcp squelch", opts->rtl_squelch_level, dB_to_pwr(-47.0), 1e-12);
+
+    free_test_runtime(opts, state);
+    return test_rc;
+}
+
+static int
+test_rtltcp_invalid_and_partial_tuning_tokens(void) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s",
+                 "rtltcp:bad-port.example:not-a-port:not-a-freq:bad-gain:bad-ppm:bogus-bw:-35:7:bias=0");
+    opts->rtl_gain_value = 14;
+    opts->rtlsdr_ppm_error = -2;
+    opts->rtl_squelch_level = 0.25;
+    opts->rtl_bias_tee = 1;
+    int rc = dsd_engine_run(opts, state);
+
+    int test_rc = 0;
+    test_rc |= expect_true("rtltcp invalid run ok", rc == 0);
+    test_rc |= expect_true("rtltcp invalid host", strcmp(opts->rtltcp_hostname, "bad-port.example") == 0);
+    test_rc |= expect_true("rtltcp invalid port defaults", opts->rtltcp_portno == 1234);
+    test_rc |= expect_true("rtltcp invalid freq becomes zero", opts->rtlsdr_center_freq == 0U);
+    test_rc |= expect_true("rtltcp invalid gain and ppm preserved",
+                           opts->rtl_gain_value == 14 && opts->rtlsdr_ppm_error == -2);
+    test_rc |= expect_true("rtltcp invalid bandwidth defaults", opts->rtl_dsp_bw_khz == 48);
+    test_rc |= expect_true("rtltcp invalid bias off", opts->rtl_bias_tee == 0);
+    test_rc |= expect_true("rtltcp invalid volume parsed", opts->rtl_volume_multiplier == 7);
+    test_rc |= expect_double_near("rtltcp invalid squelch", opts->rtl_squelch_level, dB_to_pwr(-35.0), 1e-12);
+
+    free_test_runtime(opts, state);
+
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "rtltcp:short.example:7777:450M:11:bias=on");
+    opts->rtl_bias_tee = 0;
+    rc = dsd_engine_run(opts, state);
+
+    test_rc |= expect_true("rtltcp partial run ok", rc == 0);
+    test_rc |= expect_true("rtltcp partial host", strcmp(opts->rtltcp_hostname, "short.example") == 0);
+    test_rc |= expect_true("rtltcp partial port", opts->rtltcp_portno == 7777);
+    test_rc |= expect_true("rtltcp partial freq and gain",
+                           opts->rtlsdr_center_freq == 450000000U && opts->rtl_gain_value == 11);
+    test_rc |= expect_true("rtltcp partial stops before bias", opts->rtl_bias_tee == 0);
+
+    free_test_runtime(opts, state);
+    return test_rc;
+}
+
+static int
+test_soapy_setup_normalizes_args_and_tuning(void) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s",
+                 "soapy:driver=test,serial=ABC:450.5M:7:2:12:-33:3");
+    int rc = dsd_engine_run(opts, state);
+
+    int test_rc = 0;
+    test_rc |= expect_true("soapy run ok", rc == 0);
+    test_rc |= expect_true("soapy normalizes args", strcmp(opts->audio_in_dev, "soapy:driver=test,serial=ABC") == 0);
+    test_rc |= expect_true("soapy selects rtl input", opts->audio_in_type == AUDIO_IN_RTL && opts->rtltcp_enabled == 0);
+    test_rc |= expect_true("soapy rtl-style tuning", opts->rtlsdr_center_freq == 450500000U && opts->rtl_gain_value == 7
+                                                         && opts->rtlsdr_ppm_error == 2 && opts->rtl_dsp_bw_khz == 12
+                                                         && opts->rtl_volume_multiplier == 3);
+    test_rc |= expect_double_near("soapy squelch", opts->rtl_squelch_level, dB_to_pwr(-33.0), 1e-12);
+
+    free_test_runtime(opts, state);
+    return test_rc;
+}
+
+static int
+test_iq_replay_guard_and_requested_setup(void) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "iqreplay:/tmp/capture.iq");
+    int rc = dsd_engine_run(opts, state);
+    int test_rc = expect_true("direct iqreplay rejected", rc != 0);
+    free_test_runtime(opts, state);
+
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "iqreplay:/tmp/capture.iq");
+    opts->iq_replay_requested = 1;
+    rc = dsd_engine_run(opts, state);
+    test_rc |= expect_true("requested iqreplay accepted", rc == 0);
+    test_rc |= expect_true("requested iqreplay state", opts->iq_replay_active == 1 && opts->rtltcp_enabled == 0
+                                                           && opts->audio_in_type == AUDIO_IN_RTL);
+
+    free_test_runtime(opts, state);
+    return test_rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_conflicting_scan_modes_fail_before_live_setup();
+    rc |= test_m17_udp_input_and_output_specs();
+    rc |= test_m17_userdata_is_normalized_during_common_setup();
+    rc |= test_udp_input_defaults_and_null_output();
+    rc |= test_rtltcp_tuning_tokens_and_bias();
+    rc |= test_rtltcp_invalid_and_partial_tuning_tokens();
+    rc |= test_soapy_setup_normalizes_args_and_tuning();
+    rc |= test_iq_replay_guard_and_requested_setup();
+
+    if (rc == 0) {
+        printf("ENGINE_RUN_SETUP: OK\n");
+    }
+    return rc;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/fec/test_fec_block_codes.c
+++ b/tests/fec/test_fec_block_codes.c
@@ -230,6 +230,7 @@ test_isch_soft_lookup(void) {
         reliab[i] = 220;
     }
 
+    assert(isch_lookup(isch0) == 0);
     assert(isch_lookup_soft(isch0, reliab) == 0);
 
     uint64_t corrupted = isch0;
@@ -238,7 +239,59 @@ test_isch_soft_lookup(void) {
         corrupted ^= 1ULL << (39 - low_bits[i]);
         reliab[low_bits[i]] = 10;
     }
+    assert(isch_lookup(corrupted) == 0);
+    assert(isch_lookup_soft(corrupted, NULL) == 0);
     assert(isch_lookup_soft(corrupted, reliab) == 0);
+
+    uint64_t too_far = isch0;
+    for (int i = 0; i < 8; i++) {
+        too_far ^= 1ULL << (39 - i);
+    }
+    assert(isch_lookup(too_far) == -2);
+    assert(isch_lookup_soft(too_far, reliab) == -2);
+
+    assert(isch_lookup(0x575d57f7ffULL) == -2);
+
+    return 0;
+}
+
+static void
+assert_all_zero_ints(const int* values, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        assert(values[i] == 0);
+    }
+}
+
+static int
+test_rs28_zero_codewords(void) {
+    int ess_payload[96] = {0};
+    int ess_parity[168] = {0};
+    int facch_payload[156] = {0};
+    int facch_parity[114] = {0};
+    int sacch_payload[180] = {0};
+    int sacch_parity[132] = {0};
+    int many_erasures[32];
+    for (int i = 0; i < 32; i++) {
+        many_erasures[i] = i;
+    }
+
+    assert(ez_rs28_ess(ess_payload, ess_parity) == 0);
+    assert_all_zero_ints(ess_payload, sizeof(ess_payload) / sizeof(ess_payload[0]));
+
+    assert(ez_rs28_facch(facch_payload, facch_parity) == 0);
+    assert_all_zero_ints(facch_payload, sizeof(facch_payload) / sizeof(facch_payload[0]));
+
+    assert(ez_rs28_sacch(sacch_payload, sacch_parity) == 0);
+    assert_all_zero_ints(sacch_payload, sizeof(sacch_payload) / sizeof(sacch_payload[0]));
+
+    assert(ez_rs28_ess_soft(ess_payload, ess_parity, many_erasures, 32) == 0);
+    assert_all_zero_ints(ess_payload, sizeof(ess_payload) / sizeof(ess_payload[0]));
+
+    assert(ez_rs28_facch_soft(facch_payload, facch_parity, many_erasures, 32) == 0);
+    assert_all_zero_ints(facch_payload, sizeof(facch_payload) / sizeof(facch_payload[0]));
+
+    assert(ez_rs28_sacch_soft(sacch_payload, sacch_parity, many_erasures, 32) == 0);
+    assert_all_zero_ints(sacch_payload, sizeof(sacch_payload) / sizeof(sacch_payload[0]));
 
     return 0;
 }
@@ -252,6 +305,9 @@ main(void) {
         return 1;
     }
     if (test_isch_soft_lookup() != 0) {
+        return 1;
+    }
+    if (test_rs28_zero_codewords() != 0) {
         return 1;
     }
 

--- a/tests/fec/test_fec_bptc_rs.c
+++ b/tests/fec/test_fec_bptc_rs.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result)
 /*
  * Copyright (C) 2025 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -27,6 +30,108 @@ compute_even_parity_row(uint8_t mat[8][16]) {
         }
         mat[7][col] = (uint8_t)(sum & 1U);
     }
+}
+
+static void
+fill_bptc_196x96_matrix(const uint8_t payload[96], const uint8_t r_bits[3], uint8_t matrix[13][15]) {
+    uint8_t row_data[11];
+    uint8_t row_encoded[15];
+    DSD_MEMSET(matrix, 0, 13U * 15U);
+
+    matrix[0][2] = r_bits[0] & 1U;
+    matrix[0][1] = r_bits[1] & 1U;
+    matrix[0][0] = r_bits[2] & 1U;
+    int k = 0;
+    for (int col = 3; col < 11; col++, k++) {
+        matrix[0][col] = payload[k] & 1U;
+    }
+    for (int row = 1; row < 9; row++) {
+        for (int col = 0; col < 11; col++, k++) {
+            matrix[row][col] = payload[k] & 1U;
+        }
+    }
+    assert(k == 96);
+
+    for (int row = 0; row < 9; row++) {
+        for (int col = 0; col < 11; col++) {
+            row_data[col] = matrix[row][col] & 1U;
+        }
+        Hamming_15_11_encode(row_data, row_encoded);
+        for (int col = 0; col < 15; col++) {
+            matrix[row][col] = row_encoded[col] & 1U;
+        }
+    }
+
+    for (int col = 0; col < 15; col++) {
+        uint8_t col_data[9];
+        uint8_t col_encoded[13];
+        for (int row = 0; row < 9; row++) {
+            col_data[row] = matrix[row][col] & 1U;
+        }
+        Hamming_13_9_encode(col_data, col_encoded);
+        for (int row = 0; row < 13; row++) {
+            matrix[row][col] = col_encoded[row] & 1U;
+        }
+    }
+}
+
+static void
+matrix_to_bptc_196_input(uint8_t matrix[13][15], uint8_t input[196]) {
+    DSD_MEMSET(input, 0, 196U);
+    int k = 1;
+    for (int row = 0; row < 13; row++) {
+        for (int col = 0; col < 15; col++, k++) {
+            input[k] = matrix[row][col] & 1U;
+        }
+    }
+    assert(k == 196);
+}
+
+static int
+test_bptc_196x96_extract(void) {
+    InitAllFecFunction();
+    uint8_t payload[96];
+    uint8_t r_bits[3] = {1, 0, 1};
+    for (int i = 0; i < 96; i++) {
+        payload[i] = (uint8_t)(((i * 17) + (i / 5)) & 1U);
+    }
+
+    uint8_t matrix[13][15];
+    uint8_t input[196];
+    uint8_t extracted[96];
+    uint8_t got_r[3];
+    fill_bptc_196x96_matrix(payload, r_bits, matrix);
+    matrix_to_bptc_196_input(matrix, input);
+
+    uint32_t irr = BPTC_196x96_Extract_Data(input, extracted, got_r);
+    assert(irr == 0);
+    for (int i = 0; i < 96; i++) {
+        assert(extracted[i] == payload[i]);
+    }
+    for (int i = 0; i < 3; i++) {
+        assert(got_r[i] == r_bits[i]);
+    }
+
+    uint8_t correctable[196];
+    DSD_MEMCPY(correctable, input, sizeof(correctable));
+    correctable[1 + (4 * 15) + 5] ^= 1U;
+    irr = BPTC_196x96_Extract_Data(correctable, extracted, got_r);
+    assert(irr == 0);
+    for (int i = 0; i < 96; i++) {
+        assert(extracted[i] == payload[i]);
+    }
+
+    uint8_t uncorrectable[196];
+    DSD_MEMCPY(uncorrectable, input, sizeof(uncorrectable));
+    for (int row = 0; row < 5; row++) {
+        for (int col = 0; col < 5; col++) {
+            uncorrectable[1 + (row * 15) + col] ^= 1U;
+        }
+    }
+    irr = BPTC_196x96_Extract_Data(uncorrectable, extracted, got_r);
+    assert(irr > 0);
+
+    return 0;
 }
 
 static int
@@ -207,6 +312,9 @@ test_rs_12_9(void) {
 
 int
 main(void) {
+    if (test_bptc_196x96_extract() != 0) {
+        return 1;
+    }
     if (test_bptc_128x77() != 0) {
         return 1;
     }
@@ -222,3 +330,5 @@ main(void) {
     printf("FEC BPTC+RS tests passed.\n");
     return 0;
 }
+
+// NOLINTEND(bugprone-implicit-widening-of-multiplication-result)

--- a/tests/io/test_io_input_level_metrics.c
+++ b/tests/io/test_io_input_level_metrics.c
@@ -15,6 +15,48 @@ classify(dsd_input_level_snapshot* snapshot) {
 }
 
 static void
+test_pcm_i16_metrics_with_step_and_guards(void) {
+    dsd_input_level_snapshot snapshot;
+    int16_t stepped[] = {0, 111, INT16_MAX, 222, INT16_MIN, 333};
+
+    assert(dsd_input_level_metrics_from_pcm_i16(stepped, 6U, 2U, DSD_INPUT_LEVEL_SOURCE_PCM, &snapshot) == 0);
+    classify(&snapshot);
+    assert(snapshot.source == DSD_INPUT_LEVEL_SOURCE_PCM);
+    assert(snapshot.status == DSD_INPUT_LEVEL_CLIPPING);
+    assert(snapshot.sample_count == 3U);
+    assert(fabs(snapshot.clip_pct - (200.0 / 3.0)) < 1e-9);
+    assert(snapshot.peak_dbfs <= 0.0);
+    assert(snapshot.peak_dbfs > -0.1);
+
+    assert(dsd_input_level_metrics_from_pcm_i16(NULL, 6U, 1U, DSD_INPUT_LEVEL_SOURCE_PCM, &snapshot) == -1);
+    assert(dsd_input_level_metrics_from_pcm_i16(stepped, 0U, 1U, DSD_INPUT_LEVEL_SOURCE_PCM, &snapshot) == -1);
+    assert(dsd_input_level_metrics_from_pcm_i16(stepped, 6U, 0U, DSD_INPUT_LEVEL_SOURCE_PCM, &snapshot) == -1);
+    assert(dsd_input_level_metrics_from_pcm_i16(stepped, 6U, 1U, DSD_INPUT_LEVEL_SOURCE_PCM, NULL) == -1);
+}
+
+static void
+test_pcm_f32_i16_scale_metrics_nonfinite_and_guards(void) {
+    dsd_input_level_snapshot snapshot;
+    float samples[] = {-32768.0f, 0.0f, NAN, INFINITY, -INFINITY};
+
+    assert(dsd_input_level_metrics_from_pcm_f32_i16_scale(samples, 5U, 1U, DSD_INPUT_LEVEL_SOURCE_PCM, &snapshot) == 0);
+    classify(&snapshot);
+    assert(snapshot.source == DSD_INPUT_LEVEL_SOURCE_PCM);
+    assert(snapshot.status == DSD_INPUT_LEVEL_CLIPPING);
+    assert(snapshot.sample_count == 5U);
+    assert(fabs(snapshot.clip_pct - 80.0) < 1e-9);
+    assert(snapshot.peak_dbfs <= 0.0);
+    assert(snapshot.peak_dbfs > -0.1);
+
+    assert(dsd_input_level_metrics_from_pcm_f32_i16_scale(NULL, 5U, 1U, DSD_INPUT_LEVEL_SOURCE_PCM, &snapshot) == -1);
+    assert(dsd_input_level_metrics_from_pcm_f32_i16_scale(samples, 0U, 1U, DSD_INPUT_LEVEL_SOURCE_PCM, &snapshot)
+           == -1);
+    assert(dsd_input_level_metrics_from_pcm_f32_i16_scale(samples, 5U, 0U, DSD_INPUT_LEVEL_SOURCE_PCM, &snapshot)
+           == -1);
+    assert(dsd_input_level_metrics_from_pcm_f32_i16_scale(samples, 5U, 1U, DSD_INPUT_LEVEL_SOURCE_PCM, NULL) == -1);
+}
+
+static void
 test_cu8_metrics(void) {
     uint8_t normal[128];
     for (size_t i = 0U; i < 128U; i++) {
@@ -46,6 +88,10 @@ test_cu8_metrics(void) {
     classify(&snapshot);
     assert(snapshot.status == DSD_INPUT_LEVEL_CLIPPING);
     assert(fabs(snapshot.clip_pct - 0.1) < 1e-9);
+
+    assert(dsd_input_level_metrics_from_cu8(NULL, 128U, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, &snapshot) == -1);
+    assert(dsd_input_level_metrics_from_cu8(normal, 0U, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, &snapshot) == -1);
+    assert(dsd_input_level_metrics_from_cu8(normal, 128U, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, NULL) == -1);
 }
 
 static void
@@ -64,6 +110,10 @@ test_cs16_metrics(void) {
     classify(&snapshot);
     assert(snapshot.status == DSD_INPUT_LEVEL_CLIPPING);
     assert(fabs(snapshot.clip_pct - 0.1) < 1e-9);
+
+    assert(dsd_input_level_metrics_from_cs16(NULL, 1000U, DSD_INPUT_LEVEL_SOURCE_SOAPY_CS16, &snapshot) == -1);
+    assert(dsd_input_level_metrics_from_cs16(hot, 0U, DSD_INPUT_LEVEL_SOURCE_SOAPY_CS16, &snapshot) == -1);
+    assert(dsd_input_level_metrics_from_cs16(hot, 1000U, DSD_INPUT_LEVEL_SOURCE_SOAPY_CS16, NULL) == -1);
 }
 
 static void
@@ -82,6 +132,16 @@ test_cf32_metrics(void) {
     classify(&snapshot);
     assert(snapshot.status == DSD_INPUT_LEVEL_CLIPPING);
     assert(fabs(snapshot.clip_pct - 0.1) < 1e-9);
+
+    float nonfinite[] = {NAN, -INFINITY};
+    assert(dsd_input_level_metrics_from_cf32(nonfinite, 2U, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32, &snapshot) == 0);
+    classify(&snapshot);
+    assert(snapshot.status == DSD_INPUT_LEVEL_CLIPPING);
+    assert(snapshot.clip_pct == 100.0);
+
+    assert(dsd_input_level_metrics_from_cf32(NULL, 1000U, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32, &snapshot) == -1);
+    assert(dsd_input_level_metrics_from_cf32(hot, 0U, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32, &snapshot) == -1);
+    assert(dsd_input_level_metrics_from_cf32(hot, 1000U, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32, NULL) == -1);
 }
 
 static void
@@ -94,10 +154,18 @@ test_fsk_symbol_clip_metric_is_not_rf_clipping(void) {
     assert(dsd_input_level_source_is_rf(snapshot.source) == 0);
     assert(snapshot.sample_count == 256U);
     assert(fabs(snapshot.clip_pct - 12.5) < 1e-6);
+
+    assert(dsd_input_level_metrics_from_fsk_clip(-2.0f, 12U, &snapshot) == 0);
+    assert(snapshot.clip_pct == 0.0);
+    assert(dsd_input_level_metrics_from_fsk_clip(12.5f, 0U, &snapshot) == -1);
+    assert(dsd_input_level_metrics_from_fsk_clip(NAN, 12U, &snapshot) == -1);
+    assert(dsd_input_level_metrics_from_fsk_clip(12.5f, 12U, NULL) == -1);
 }
 
 int
 main(void) {
+    test_pcm_i16_metrics_with_step_and_guards();
+    test_pcm_f32_i16_scale_metrics_nonfinite_and_guards();
     test_cu8_metrics();
     test_cs16_metrics();
     test_cf32_metrics();

--- a/tests/io/test_io_iq_capture_writer.c
+++ b/tests/io/test_io_iq_capture_writer.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -380,6 +383,75 @@ test_retune_stats_without_events_marks_not_replayable(void) {
 }
 
 static int
+test_open_resolves_single_capture_path(void) {
+    int rc = 0;
+    char dir[256];
+    char data_path[512];
+    char metadata_path[512];
+    char err[256];
+
+    if (mk_temp_dir(dir, sizeof(dir)) != 0) {
+        return 1;
+    }
+
+    path_join(data_path, sizeof(data_path), dir, "data_only.iq");
+    path_join(metadata_path, sizeof(metadata_path), dir, "data_only.iq.json");
+    dsd_iq_capture_config cfg;
+    fill_base_capture_cfg(&cfg, data_path, "", DSD_IQ_FORMAT_CU8);
+    cfg.queue_block_bytes = 4;
+    cfg.queue_block_count = 2;
+
+    dsd_iq_capture_writer* writer = NULL;
+    rc |= expect_int("open data-only path", dsd_iq_capture_open(&cfg, &writer, err, sizeof(err)), DSD_IQ_OK);
+    if (writer) {
+        uint8_t payload[2] = {1, 2};
+        rc |= expect_int("submit data-only path", dsd_iq_capture_submit(writer, payload, sizeof(payload)), DSD_IQ_OK);
+        dsd_iq_capture_final_stats stats;
+        DSD_MEMSET(&stats, 0, sizeof(stats));
+        dsd_iq_capture_close(writer, &stats);
+    }
+    {
+        dsd_iq_replay_config meta;
+        DSD_MEMSET(&meta, 0, sizeof(meta));
+        rc |= expect_int("data-only metadata parse",
+                         dsd_iq_replay_read_metadata(metadata_path, &meta, err, sizeof(err)), DSD_IQ_OK);
+        rc |= expect_true("data-only metadata data_path", strcmp(meta.data_path, data_path) == 0);
+        dsd_iq_replay_config_clear(&meta);
+    }
+
+    path_join(data_path, sizeof(data_path), dir, "metadata_only.iq");
+    path_join(metadata_path, sizeof(metadata_path), dir, "metadata_only.iq.json");
+    fill_base_capture_cfg(&cfg, "", metadata_path, DSD_IQ_FORMAT_CU8);
+    cfg.queue_block_bytes = 4;
+    cfg.queue_block_count = 2;
+    writer = NULL;
+    rc |= expect_int("open metadata-only path", dsd_iq_capture_open(&cfg, &writer, err, sizeof(err)), DSD_IQ_OK);
+    if (writer) {
+        uint8_t payload[2] = {3, 4};
+        rc |=
+            expect_int("submit metadata-only path", dsd_iq_capture_submit(writer, payload, sizeof(payload)), DSD_IQ_OK);
+        dsd_iq_capture_final_stats stats;
+        DSD_MEMSET(&stats, 0, sizeof(stats));
+        dsd_iq_capture_close(writer, &stats);
+    }
+    {
+        dsd_iq_replay_config meta;
+        DSD_MEMSET(&meta, 0, sizeof(meta));
+        rc |= expect_int("metadata-only parse", dsd_iq_replay_read_metadata(metadata_path, &meta, err, sizeof(err)),
+                         DSD_IQ_OK);
+        rc |= expect_true("metadata-only derived data path", strcmp(meta.data_path, data_path) == 0);
+        dsd_iq_replay_config_clear(&meta);
+    }
+
+    fill_base_capture_cfg(&cfg, "", "", DSD_IQ_FORMAT_CU8);
+    writer = NULL;
+    rc |= expect_int("open rejects empty paths", dsd_iq_capture_open(&cfg, &writer, err, sizeof(err)),
+                     DSD_IQ_ERR_INVALID_ARG);
+    rc |= expect_true("empty paths leaves writer null", writer == NULL);
+    return rc;
+}
+
+static int
 test_rejects_unaligned_mute_event(void) {
     int rc = 0;
     char dir[256];
@@ -426,6 +498,66 @@ test_rejects_unaligned_mute_event(void) {
     rc |= expect_int("bad mute metadata parse", dsd_iq_replay_read_metadata(metadata_path, &meta, err, sizeof(err)),
                      DSD_IQ_OK);
     rc |= expect_int("bad mute event_count", (int)meta.event_count, 0);
+    dsd_iq_replay_config_clear(&meta);
+    return rc;
+}
+
+static int
+test_rejects_event_control_bytes_and_unknown_kind(void) {
+    int rc = 0;
+    char dir[256];
+    char data_path[512];
+    char metadata_path[512];
+    char err[256];
+
+    if (mk_temp_dir(dir, sizeof(dir)) != 0) {
+        return 1;
+    }
+    path_join(data_path, sizeof(data_path), dir, "bad_event_meta.iq");
+    path_join(metadata_path, sizeof(metadata_path), dir, "bad_event_meta.iq.json");
+
+    dsd_iq_capture_config cfg;
+    fill_base_capture_cfg(&cfg, data_path, metadata_path, DSD_IQ_FORMAT_CU8);
+    cfg.queue_block_bytes = 4;
+    cfg.queue_block_count = 2;
+
+    dsd_iq_capture_writer* writer = NULL;
+    rc |= expect_int("open bad event meta", dsd_iq_capture_open(&cfg, &writer, err, sizeof(err)), DSD_IQ_OK);
+    if (!writer) {
+        return rc;
+    }
+
+    uint8_t payload[2] = {1, 2};
+    rc |= expect_int("submit bad event meta", dsd_iq_capture_submit(writer, payload, sizeof(payload)), DSD_IQ_OK);
+
+    dsd_iq_event ev;
+    DSD_MEMSET(&ev, 0, sizeof(ev));
+    ev.kind = DSD_IQ_EVENT_MUTE;
+    ev.duration_bytes = 2;
+    DSD_SNPRINTF(ev.reason, sizeof(ev.reason), "%s", "bad\nreason");
+    rc |= expect_int("reject mute control reason", dsd_iq_capture_record_event(writer, &ev), DSD_IQ_ERR_INVALID_META);
+
+    DSD_MEMSET(&ev, 0, sizeof(ev));
+    ev.kind = DSD_IQ_EVENT_RETUNE;
+    ev.center_frequency_hz = 851500000ULL;
+    ev.capture_center_frequency_hz = 851884000ULL;
+    ev.sample_rate_hz = cfg.sample_rate_hz;
+    DSD_SNPRINTF(ev.reason, sizeof(ev.reason), "%s", "bad\treason");
+    rc |= expect_int("reject retune control reason", dsd_iq_capture_record_event(writer, &ev), DSD_IQ_ERR_INVALID_META);
+
+    DSD_MEMSET(&ev, 0, sizeof(ev));
+    ev.kind = (dsd_iq_event_kind)99;
+    rc |= expect_int("reject unknown event kind", dsd_iq_capture_record_event(writer, &ev), DSD_IQ_ERR_INVALID_ARG);
+
+    dsd_iq_capture_final_stats stats;
+    DSD_MEMSET(&stats, 0, sizeof(stats));
+    dsd_iq_capture_close(writer, &stats);
+
+    dsd_iq_replay_config meta;
+    DSD_MEMSET(&meta, 0, sizeof(meta));
+    rc |= expect_int("bad event meta metadata parse",
+                     dsd_iq_replay_read_metadata(metadata_path, &meta, err, sizeof(err)), DSD_IQ_OK);
+    rc |= expect_int("bad event meta event_count", (int)meta.event_count, 0);
     dsd_iq_replay_config_clear(&meta);
     return rc;
 }
@@ -496,6 +628,65 @@ test_rejects_unreplayable_retune_reset_events(void) {
 }
 
 static int
+test_same_offset_mute_events_merge_duration(void) {
+    int rc = 0;
+    char dir[256];
+    char data_path[512];
+    char metadata_path[512];
+    char err[256];
+
+    if (mk_temp_dir(dir, sizeof(dir)) != 0) {
+        return 1;
+    }
+    path_join(data_path, sizeof(data_path), dir, "mute_merge.iq");
+    path_join(metadata_path, sizeof(metadata_path), dir, "mute_merge.iq.json");
+
+    dsd_iq_capture_config cfg;
+    fill_base_capture_cfg(&cfg, data_path, metadata_path, DSD_IQ_FORMAT_CU8);
+    cfg.queue_block_bytes = 4;
+    cfg.queue_block_count = 2;
+
+    dsd_iq_capture_writer* writer = NULL;
+    rc |= expect_int("open mute merge", dsd_iq_capture_open(&cfg, &writer, err, sizeof(err)), DSD_IQ_OK);
+    if (!writer) {
+        return rc;
+    }
+
+    uint8_t payload[2] = {1, 2};
+    rc |= expect_int("submit mute merge", dsd_iq_capture_submit(writer, payload, sizeof(payload)), DSD_IQ_OK);
+
+    dsd_iq_event ev;
+    DSD_MEMSET(&ev, 0, sizeof(ev));
+    ev.kind = DSD_IQ_EVENT_MUTE;
+    ev.duration_bytes = 2;
+    DSD_SNPRINTF(ev.reason, sizeof(ev.reason), "%s", "first_mute");
+    rc |= expect_int("record first merge mute", dsd_iq_capture_record_event(writer, &ev), DSD_IQ_OK);
+
+    DSD_MEMSET(&ev, 0, sizeof(ev));
+    ev.kind = DSD_IQ_EVENT_MUTE;
+    ev.duration_bytes = 4;
+    DSD_SNPRINTF(ev.reason, sizeof(ev.reason), "%s", "second_mute");
+    rc |= expect_int("record second merge mute", dsd_iq_capture_record_event(writer, &ev), DSD_IQ_OK);
+
+    dsd_iq_capture_final_stats stats;
+    DSD_MEMSET(&stats, 0, sizeof(stats));
+    dsd_iq_capture_close(writer, &stats);
+
+    dsd_iq_replay_config meta;
+    DSD_MEMSET(&meta, 0, sizeof(meta));
+    rc |= expect_int("mute merge metadata parse", dsd_iq_replay_read_metadata(metadata_path, &meta, err, sizeof(err)),
+                     DSD_IQ_OK);
+    rc |= expect_int("mute merge event_count", (int)meta.event_count, 1);
+    if (meta.event_count == 1) {
+        rc |= expect_int("mute merge kind", (int)meta.events[0].kind, (int)DSD_IQ_EVENT_MUTE);
+        rc |= expect_u64("mute merge offset", meta.events[0].byte_offset, 2);
+        rc |= expect_u64("mute merge duration", meta.events[0].duration_bytes, 6);
+    }
+    dsd_iq_replay_config_clear(&meta);
+    return rc;
+}
+
+static int
 test_retune_event_orders_before_same_offset_mute(void) {
     int rc = 0;
     char dir[256];
@@ -557,6 +748,68 @@ test_retune_event_orders_before_same_offset_mute(void) {
 }
 
 static int
+test_event_boundary_drops_pending_cu8_carry(void) {
+    int rc = 0;
+    char dir[256];
+    char data_path[512];
+    char metadata_path[512];
+    char err[256];
+
+    if (mk_temp_dir(dir, sizeof(dir)) != 0) {
+        return 1;
+    }
+    path_join(data_path, sizeof(data_path), dir, "carry_event.iq");
+    path_join(metadata_path, sizeof(metadata_path), dir, "carry_event.iq.json");
+
+    dsd_iq_capture_config cfg;
+    fill_base_capture_cfg(&cfg, data_path, metadata_path, DSD_IQ_FORMAT_CU8);
+    cfg.queue_block_bytes = 4;
+    cfg.queue_block_count = 2;
+
+    dsd_iq_capture_writer* writer = NULL;
+    rc |= expect_int("open carry event", dsd_iq_capture_open(&cfg, &writer, err, sizeof(err)), DSD_IQ_OK);
+    if (!writer) {
+        return rc;
+    }
+
+    uint8_t one_byte[1] = {0x80};
+    rc |= expect_int("submit carry byte", dsd_iq_capture_submit(writer, one_byte, sizeof(one_byte)), DSD_IQ_OK);
+
+    dsd_iq_event ev;
+    DSD_MEMSET(&ev, 0, sizeof(ev));
+    ev.kind = DSD_IQ_EVENT_RESET;
+    ev.center_frequency_hz = cfg.center_frequency_hz;
+    ev.capture_center_frequency_hz = cfg.capture_center_frequency_hz;
+    ev.sample_rate_hz = cfg.sample_rate_hz;
+    DSD_SNPRINTF(ev.reason, sizeof(ev.reason), "%s", "event_boundary");
+    rc |= expect_int("record carry boundary reset", dsd_iq_capture_record_event(writer, &ev), DSD_IQ_OK);
+
+    dsd_iq_capture_final_stats stats;
+    DSD_MEMSET(&stats, 0, sizeof(stats));
+    dsd_iq_capture_close(writer, &stats);
+
+    dsd_stat_t st;
+    rc |= expect_true("carry event data stat", dsd_stat_path(data_path, &st) == 0);
+    if (dsd_stat_path(data_path, &st) == 0) {
+        rc |= expect_u64("carry event writes no partial pair", (uint64_t)st.st_size, 0);
+    }
+
+    dsd_iq_replay_config meta;
+    DSD_MEMSET(&meta, 0, sizeof(meta));
+    rc |= expect_int("carry event metadata parse", dsd_iq_replay_read_metadata(metadata_path, &meta, err, sizeof(err)),
+                     DSD_IQ_OK);
+    rc |= expect_u64("carry event dropped byte", meta.capture_drops, 1);
+    rc |= expect_u64("carry event drop block", meta.capture_drop_blocks, 1);
+    rc |= expect_int("carry event event_count", (int)meta.event_count, 1);
+    if (meta.event_count == 1) {
+        rc |= expect_int("carry event kind", (int)meta.events[0].kind, (int)DSD_IQ_EVENT_RESET);
+        rc |= expect_u64("carry event offset", meta.events[0].byte_offset, 0);
+    }
+    dsd_iq_replay_config_clear(&meta);
+    return rc;
+}
+
+static int
 test_abort_removes_metadata(void) {
     int rc = 0;
     char dir[256];
@@ -594,6 +847,94 @@ test_abort_removes_metadata(void) {
     return rc;
 }
 
+static int
+test_public_error_contracts(void) {
+    int rc = 0;
+    char data_path[32];
+    char metadata_path[32];
+    char err[256];
+    dsd_iq_capture_writer* writer = NULL;
+
+    DSD_MEMSET(err, 0, sizeof(err));
+    rc |= expect_int("derive rejects null path",
+                     dsd_iq_capture_derive_paths(NULL, data_path, sizeof(data_path), metadata_path,
+                                                 sizeof(metadata_path), err, sizeof(err)),
+                     DSD_IQ_ERR_INVALID_ARG);
+    rc |= expect_true("derive null path sets error", err[0] != '\0');
+
+    rc |= expect_int("derive json suffix",
+                     dsd_iq_capture_derive_paths("capture.iq.json", data_path, sizeof(data_path), metadata_path,
+                                                 sizeof(metadata_path), err, sizeof(err)),
+                     DSD_IQ_OK);
+    rc |= expect_true("derive json data path", strcmp(data_path, "capture.iq") == 0);
+    rc |= expect_true("derive json metadata path", strcmp(metadata_path, "capture.iq.json") == 0);
+
+    rc |= expect_int("derive rejects empty json data",
+                     dsd_iq_capture_derive_paths(".json", data_path, sizeof(data_path), metadata_path,
+                                                 sizeof(metadata_path), err, sizeof(err)),
+                     DSD_IQ_ERR_INVALID_ARG);
+    rc |= expect_int(
+        "derive rejects tiny data buffer",
+        dsd_iq_capture_derive_paths("capture.iq", data_path, 4, metadata_path, sizeof(metadata_path), err, sizeof(err)),
+        DSD_IQ_ERR_INVALID_ARG);
+    rc |= expect_int(
+        "derive rejects tiny metadata buffer",
+        dsd_iq_capture_derive_paths("capture.iq", data_path, sizeof(data_path), metadata_path, 4, err, sizeof(err)),
+        DSD_IQ_ERR_INVALID_ARG);
+
+    rc |= expect_int("open rejects null cfg", dsd_iq_capture_open(NULL, &writer, err, sizeof(err)),
+                     DSD_IQ_ERR_INVALID_ARG);
+
+    dsd_iq_capture_config cfg;
+    fill_base_capture_cfg(&cfg, "data.iq", "data.iq.json", DSD_IQ_FORMAT_CU8);
+    rc |=
+        expect_int("open rejects null out", dsd_iq_capture_open(&cfg, NULL, err, sizeof(err)), DSD_IQ_ERR_INVALID_ARG);
+
+    dsd_iq_capture_config bad;
+    bad = cfg;
+    bad.sample_rate_hz = 0;
+    rc |= expect_int("open rejects zero sample rate", dsd_iq_capture_open(&bad, &writer, err, sizeof(err)),
+                     DSD_IQ_ERR_INVALID_ARG);
+    rc |= expect_true("zero sample rate leaves writer null", writer == NULL);
+
+    bad = cfg;
+    bad.base_decimation = 3;
+    rc |= expect_int("open rejects non-power-two base decimation", dsd_iq_capture_open(&bad, &writer, err, sizeof(err)),
+                     DSD_IQ_ERR_RATE_CHAIN);
+
+    bad = cfg;
+    bad.post_downsample = 0;
+    rc |= expect_int("open rejects zero post downsample", dsd_iq_capture_open(&bad, &writer, err, sizeof(err)),
+                     DSD_IQ_ERR_RATE_CHAIN);
+
+    bad = cfg;
+    bad.demod_rate_hz = 0;
+    rc |= expect_int("open rejects zero demod rate", dsd_iq_capture_open(&bad, &writer, err, sizeof(err)),
+                     DSD_IQ_ERR_RATE_CHAIN);
+
+    bad = cfg;
+    bad.demod_rate_hz = 24000;
+    rc |= expect_int("open rejects inconsistent demod rate", dsd_iq_capture_open(&bad, &writer, err, sizeof(err)),
+                     DSD_IQ_ERR_RATE_CHAIN);
+
+    bad = cfg;
+    bad.format = DSD_IQ_FORMAT_UNKNOWN;
+    rc |= expect_int("open rejects unsupported format", dsd_iq_capture_open(&bad, &writer, err, sizeof(err)),
+                     DSD_IQ_ERR_UNSUPPORTED_FMT);
+
+    bad = cfg;
+    bad.capture_stage[0] = '\0';
+    rc |= expect_int("open rejects empty capture stage", dsd_iq_capture_open(&bad, &writer, err, sizeof(err)),
+                     DSD_IQ_ERR_INVALID_META);
+
+    bad = cfg;
+    bad.source_backend[0] = '\0';
+    rc |= expect_int("open rejects empty source backend", dsd_iq_capture_open(&bad, &writer, err, sizeof(err)),
+                     DSD_IQ_ERR_INVALID_META);
+
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -602,9 +943,16 @@ main(void) {
     rc |= test_odd_cu8_preserves_iq_alignment();
     rc |= test_queue_overflow_updates_drop_counters();
     rc |= test_retune_stats_without_events_marks_not_replayable();
+    rc |= test_open_resolves_single_capture_path();
     rc |= test_rejects_unaligned_mute_event();
+    rc |= test_rejects_event_control_bytes_and_unknown_kind();
     rc |= test_rejects_unreplayable_retune_reset_events();
+    rc |= test_same_offset_mute_events_merge_duration();
     rc |= test_retune_event_orders_before_same_offset_mute();
+    rc |= test_event_boundary_drops_pending_cu8_carry();
     rc |= test_abort_removes_metadata();
+    rc |= test_public_error_contracts();
     return rc ? 1 : 0;
 }
+
+// NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange)

--- a/tests/io/test_io_iq_metadata.c
+++ b/tests/io/test_io_iq_metadata.c
@@ -1236,6 +1236,82 @@ test_relative_data_resolution_info_and_open_validation(void) {
     return rc;
 }
 
+static int
+test_replay_read_partial_eof_and_rewind(void) {
+    int rc = 0;
+    char dir[256];
+    char err[256];
+    if (mk_temp_dir(dir, sizeof(dir)) != 0) {
+        return 1;
+    }
+
+    char meta[512];
+    char data[512];
+    path_join(meta, sizeof(meta), dir, "read.iq.json");
+    path_join(data, sizeof(data), dir, "read.iq");
+    uint8_t payload[6] = {10, 11, 12, 13, 14, 15};
+    if (write_bytes_file(data, payload, sizeof(payload)) != 0) {
+        return 1;
+    }
+    if (write_valid_metadata(meta, "read.iq", "cu8", "none", "post_mute_pre_widen", 1536000, 32, 1, 48000, 0,
+                             sizeof(payload))
+        != 0) {
+        return 1;
+    }
+
+    dsd_iq_replay_config cfg;
+    dsd_iq_replay_source* src = NULL;
+    DSD_MEMSET(&cfg, 0, sizeof(cfg));
+    int prc = dsd_iq_replay_open(meta, &cfg, &src, err, sizeof(err));
+    rc |= expect_int("replay read open", prc, DSD_IQ_OK);
+    rc |= expect_true("replay read source", src != NULL);
+    if (prc != DSD_IQ_OK || src == NULL) {
+        dsd_iq_replay_config_clear(&cfg);
+        return rc;
+    }
+
+    uint8_t buf[8];
+    size_t got = 99U;
+    DSD_MEMSET(buf, 0xA5, sizeof(buf));
+    rc |= expect_int("replay read first chunk", dsd_iq_replay_read(src, buf, 4U, &got), DSD_IQ_OK);
+    rc |= expect_u64("replay read first size", got, 4U);
+    rc |= expect_true("replay read first bytes", memcmp(buf, payload, 4U) == 0);
+
+    DSD_MEMSET(buf, 0xA5, sizeof(buf));
+    got = 99U;
+    rc |= expect_int("replay read short final chunk", dsd_iq_replay_read(src, buf, 4U, &got), DSD_IQ_OK);
+    rc |= expect_u64("replay read final size", got, 2U);
+    rc |= expect_true("replay read final bytes", memcmp(buf, payload + 4U, 2U) == 0);
+    rc |= expect_int("replay read final tail untouched", buf[2], 0xA5);
+
+    DSD_MEMSET(buf, 0x5A, sizeof(buf));
+    got = 99U;
+    rc |= expect_int("replay read eof", dsd_iq_replay_read(src, buf, sizeof(buf), &got), DSD_IQ_OK);
+    rc |= expect_u64("replay read eof size", got, 0U);
+    rc |= expect_int("replay read eof untouched", buf[0], 0x5A);
+    got = 99U;
+    rc |= expect_int("replay read repeated eof", dsd_iq_replay_read(src, buf, sizeof(buf), &got), DSD_IQ_OK);
+    rc |= expect_u64("replay read repeated eof size", got, 0U);
+
+    rc |= expect_int("replay rewind", dsd_iq_replay_rewind(src), DSD_IQ_OK);
+    DSD_MEMSET(buf, 0, sizeof(buf));
+    got = 0U;
+    rc |= expect_int("replay read after rewind", dsd_iq_replay_read(src, buf, sizeof(buf), &got), DSD_IQ_OK);
+    rc |= expect_u64("replay read after rewind size", got, sizeof(payload));
+    rc |= expect_true("replay read after rewind bytes", memcmp(buf, payload, sizeof(payload)) == 0);
+
+    got = 99U;
+    rc |= expect_int("replay read zero max", dsd_iq_replay_read(src, buf, 0U, &got), DSD_IQ_OK);
+    rc |= expect_u64("replay read zero max size", got, 0U);
+    rc |=
+        expect_int("replay read null source", dsd_iq_replay_read(NULL, buf, sizeof(buf), &got), DSD_IQ_ERR_INVALID_ARG);
+    rc |= expect_int("replay rewind null", dsd_iq_replay_rewind(NULL), DSD_IQ_ERR_INVALID_ARG);
+
+    dsd_iq_replay_close(src);
+    dsd_iq_replay_config_clear(&cfg);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -1249,5 +1325,6 @@ main(void) {
     rc |= test_event_timeline_validation();
     rc |= test_rate_chain_validation();
     rc |= test_relative_data_resolution_info_and_open_validation();
+    rc |= test_replay_read_partial_eof_and_rewind();
     return rc ? 1 : 0;
 }

--- a/tests/io/test_io_iq_replay_effective_bytes.c
+++ b/tests/io/test_io_iq_replay_effective_bytes.c
@@ -6,6 +6,7 @@
 #include <dsd-neo/io/iq_replay.h>
 #include <inttypes.h>
 #include <stdio.h>
+#include <string.h>
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/io/iq_types.h"
 
@@ -27,11 +28,53 @@ expect_int(const char* label, int got, int want) {
     return 0;
 }
 
+static int
+expect_double(const char* label, double got, double want) {
+    double delta = got - want;
+    if (delta < 0.0) {
+        delta = -delta;
+    }
+    if (delta > 0.000001) {
+        DSD_FPRINTF(stderr, "FAIL: %s: got=%f want=%f\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_cstr(const char* label, const char* got, const char* want) {
+    const char* actual = got ? got : "(null)";
+    if (strcmp(actual, want) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: got=%s want=%s\n", label, actual, want);
+        return 1;
+    }
+    return 0;
+}
+
 int
 main(void) {
     int rc = 0;
     uint64_t effective = 0;
     int mismatch = 0;
+
+    rc |= expect_u64("cu8 alignment", dsd_iq_sample_format_alignment_bytes(DSD_IQ_FORMAT_CU8), 2);
+    rc |= expect_u64("cf32 alignment", dsd_iq_sample_format_alignment_bytes(DSD_IQ_FORMAT_CF32), 8);
+    rc |= expect_u64("cs16 alignment", dsd_iq_sample_format_alignment_bytes(DSD_IQ_FORMAT_CS16), 4);
+    rc |= expect_u64("unknown alignment", dsd_iq_sample_format_alignment_bytes(DSD_IQ_FORMAT_UNKNOWN), 0);
+    rc |= expect_cstr("cu8 name", dsd_iq_sample_format_name(DSD_IQ_FORMAT_CU8), "cu8");
+    rc |= expect_cstr("cf32 name", dsd_iq_sample_format_name(DSD_IQ_FORMAT_CF32), "cf32");
+    rc |= expect_cstr("cs16 name", dsd_iq_sample_format_name(DSD_IQ_FORMAT_CS16), "cs16");
+    rc |= expect_cstr("unknown name", dsd_iq_sample_format_name(DSD_IQ_FORMAT_UNKNOWN), "unknown");
+
+    rc |= expect_double("duration zero sample rate", dsd_iq_replay_estimate_duration_seconds(16, DSD_IQ_FORMAT_CU8, 0),
+                        0.0);
+    rc |= expect_double("duration unknown format",
+                        dsd_iq_replay_estimate_duration_seconds(16, DSD_IQ_FORMAT_UNKNOWN, 48000), 0.0);
+    rc |= expect_double("duration cu8", dsd_iq_replay_estimate_duration_seconds(96000, DSD_IQ_FORMAT_CU8, 48000), 1.0);
+    rc |=
+        expect_double("duration cf32", dsd_iq_replay_estimate_duration_seconds(384000, DSD_IQ_FORMAT_CF32, 48000), 1.0);
+    rc |=
+        expect_double("duration cs16", dsd_iq_replay_estimate_duration_seconds(192000, DSD_IQ_FORMAT_CS16, 48000), 1.0);
 
     rc |= expect_int("data_bytes=0 actual=10 cu8",
                      dsd_iq_replay_compute_effective_bytes(0, 10, DSD_IQ_FORMAT_CU8, &effective, &mismatch), DSD_IQ_OK);

--- a/tests/io/test_io_rigctl_control.c
+++ b/tests/io/test_io_rigctl_control.c
@@ -1,0 +1,463 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-multi-level-implicit-pointer-conversion)
+/*
+ * Rigctl control-plane tests use socket stubs to verify command/response
+ * behavior without requiring a live rigctl server or network service.
+ */
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/io/control.h>
+#include <dsd-neo/io/rigctl_client.h>
+#include <dsd-neo/platform/sockets.h>
+#include <dsd-neo/platform/timing.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/log.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/platform.h"
+
+#if !DSD_PLATFORM_WIN_NATIVE
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#endif
+
+#define MAX_COMMANDS  16
+#define MAX_RESPONSES 16
+
+static char g_commands[MAX_COMMANDS][64];
+static size_t g_command_count;
+static const char* g_responses[MAX_RESPONSES];
+static size_t g_response_count;
+static size_t g_response_index;
+static dsd_socket_t g_create_result;
+static int g_resolve_result;
+static int g_connect_result;
+static int g_close_count;
+static dsd_socket_t g_closed_sock;
+static int g_recv_timeout_count;
+static unsigned int g_last_timeout_ms;
+static int g_setsockopt_count;
+static int g_last_setsockopt_level;
+static int g_last_setsockopt_name;
+static int g_sleep_count;
+static int g_sendto_count;
+static unsigned char g_last_sendto_payload[8];
+static size_t g_last_sendto_len;
+static int g_last_sendto_port;
+static dsdneoRuntimeConfig g_config;
+
+bool dsd_rigctl_test_get_signal_level(dsd_socket_t sockfd, double* dB);
+bool dsd_rigctl_test_get_squelch_level(dsd_socket_t sockfd, double* dB);
+bool dsd_rigctl_test_set_squelch_level(dsd_socket_t sockfd, double dB);
+bool dsd_rigctl_test_get_signal_level_ex(dsd_socket_t sockfd, double* dB, int n_samp);
+void dsd_rigctl_test_rtl_udp_tune(dsd_opts* opts, dsd_state* state, long int frequency);
+
+static void
+reset_stubs(void) {
+    DSD_MEMSET(g_commands, 0, sizeof(g_commands));
+    DSD_MEMSET(g_responses, 0, sizeof(g_responses));
+    g_command_count = 0;
+    g_response_count = 0;
+    g_response_index = 0;
+    g_create_result = 41;
+    g_resolve_result = 0;
+    g_connect_result = 0;
+    g_close_count = 0;
+    g_closed_sock = DSD_INVALID_SOCKET;
+    g_recv_timeout_count = 0;
+    g_last_timeout_ms = 0;
+    g_setsockopt_count = 0;
+    g_last_setsockopt_level = 0;
+    g_last_setsockopt_name = 0;
+    g_sleep_count = 0;
+    g_sendto_count = 0;
+    DSD_MEMSET(g_last_sendto_payload, 0, sizeof(g_last_sendto_payload));
+    g_last_sendto_len = 0;
+    g_last_sendto_port = 0;
+    DSD_MEMSET(&g_config, 0, sizeof(g_config));
+    g_config.rigctl_rcvtimeo_ms = 1500;
+}
+
+static void
+push_response(const char* response) {
+    assert(g_response_count < MAX_RESPONSES);
+    g_responses[g_response_count++] = response;
+}
+
+void
+dsd_neo_log_write(dsd_neo_log_level_t level, const char* format, ...) {
+    (void)level;
+    (void)format;
+}
+
+const dsdneoRuntimeConfig*
+dsd_neo_get_config(void) {
+    return &g_config;
+}
+
+void
+dsd_neo_config_init(const dsd_opts* opts) {
+    (void)opts;
+}
+
+void
+dsd_sleep_ms(unsigned int ms) {
+    (void)ms;
+    g_sleep_count++;
+}
+
+dsd_socket_t
+dsd_socket_create(int domain, int type, int protocol) {
+    (void)domain;
+    (void)type;
+    (void)protocol;
+    return g_create_result;
+}
+
+int
+dsd_socket_close(dsd_socket_t sock) {
+    g_close_count++;
+    g_closed_sock = sock;
+    return 0;
+}
+
+int
+dsd_socket_resolve(const char* hostname, int port, struct sockaddr_in* addr) {
+    (void)hostname;
+    if (addr) {
+        DSD_MEMSET(addr, 0, sizeof(*addr));
+        addr->sin_family = AF_INET;
+        addr->sin_port = htons((uint16_t)port);
+    }
+    return g_resolve_result;
+}
+
+int
+dsd_socket_connect(dsd_socket_t sock, const struct sockaddr* addr, int addrlen) {
+    (void)sock;
+    (void)addr;
+    (void)addrlen;
+    return g_connect_result;
+}
+
+int
+dsd_socket_set_recv_timeout(dsd_socket_t sock, unsigned int timeout_ms) {
+    (void)sock;
+    g_recv_timeout_count++;
+    g_last_timeout_ms = timeout_ms;
+    return 0;
+}
+
+int
+dsd_socket_setsockopt(dsd_socket_t sock, int level, int optname, const void* optval, int optlen) {
+    (void)sock;
+    (void)optval;
+    (void)optlen;
+    g_setsockopt_count++;
+    g_last_setsockopt_level = level;
+    g_last_setsockopt_name = optname;
+    return 0;
+}
+
+int
+dsd_socket_send(dsd_socket_t sock, const void* buf, size_t len, int flags) {
+    (void)sock;
+    (void)flags;
+    assert(g_command_count < MAX_COMMANDS);
+    size_t copy_len = len;
+    if (copy_len >= sizeof(g_commands[g_command_count])) {
+        copy_len = sizeof(g_commands[g_command_count]) - 1U;
+    }
+    DSD_MEMCPY(g_commands[g_command_count], buf, copy_len);
+    g_commands[g_command_count][copy_len] = '\0';
+    g_command_count++;
+    return (int)len;
+}
+
+int
+dsd_socket_sendto(dsd_socket_t sock, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr,
+                  int addrlen) {
+    (void)sock;
+    (void)flags;
+    (void)addrlen;
+    g_sendto_count++;
+    g_last_sendto_len = len;
+    size_t copy_len = len;
+    if (copy_len > sizeof(g_last_sendto_payload)) {
+        copy_len = sizeof(g_last_sendto_payload);
+    }
+    if (buf && copy_len > 0U) {
+        DSD_MEMCPY(g_last_sendto_payload, buf, copy_len);
+    }
+    if (dest_addr) {
+        const struct sockaddr_in* in = (const struct sockaddr_in*)dest_addr;
+        g_last_sendto_port = ntohs(in->sin_port);
+    }
+    return (int)len;
+}
+
+int
+dsd_socket_recv(dsd_socket_t sock, void* buf, size_t len, int flags) {
+    (void)sock;
+    (void)flags;
+    if (!buf || len == 0U || g_response_index >= g_response_count) {
+        return 0;
+    }
+    const char* response = g_responses[g_response_index++];
+    size_t response_len = strlen(response);
+    if (response_len > len) {
+        response_len = len;
+    }
+    DSD_MEMCPY(buf, response, response_len);
+    return (int)response_len;
+}
+
+static int
+test_connect_failure_cleanup(void) {
+    reset_stubs();
+    char host[] = "rig.invalid";
+    g_create_result = 77;
+    g_resolve_result = -1;
+    assert(Connect(host, 4532) == DSD_INVALID_SOCKET);
+    assert(g_close_count == 1);
+    assert(g_closed_sock == 77);
+    assert(g_recv_timeout_count == 0);
+
+    reset_stubs();
+    g_create_result = 78;
+    g_connect_result = -1;
+    assert(Connect(host, 4532) == DSD_INVALID_SOCKET);
+    assert(g_close_count == 1);
+    assert(g_closed_sock == 78);
+    assert(g_recv_timeout_count == 0);
+    return 0;
+}
+
+static int
+test_connect_success_uses_rigctl_timeout(void) {
+    reset_stubs();
+    char host[] = "127.0.0.1";
+    g_create_result = 79;
+    g_config.rigctl_rcvtimeo_ms = 2345;
+    g_config.rigctl_rcvtimeo_is_set = 1;
+    g_config.tcp_rcvtimeo_ms = 3456;
+    g_config.tcp_rcvtimeo_is_set = 1;
+
+    assert(Connect(host, 4532) == 79);
+    assert(g_close_count == 0);
+    assert(g_recv_timeout_count == 1);
+    assert(g_last_timeout_ms == 2345U);
+    assert(g_setsockopt_count == 1);
+    assert(g_last_setsockopt_level == IPPROTO_TCP);
+    assert(g_last_setsockopt_name == TCP_NODELAY);
+    return 0;
+}
+
+static int
+test_setfreq_success_failure_and_cache(void) {
+    reset_stubs();
+    push_response("RPRT 0\n");
+    assert(SetFreq(100, 851012500L));
+    assert(g_command_count == 1);
+    assert(strcmp(g_commands[0], "F 851012500\n") == 0);
+
+    assert(SetFreq(100, 851012500L));
+    assert(g_command_count == 1);
+
+    push_response("RPRT 1\n");
+    assert(!SetFreq(100, 851025000L));
+    assert(g_command_count == 2);
+    assert(strcmp(g_commands[1], "F 851025000\n") == 0);
+    return 0;
+}
+
+static int
+test_setmodulation_fallback_and_cache(void) {
+    reset_stubs();
+    push_response("RPRT 1\n");
+    push_response("RPRT 0\n");
+    assert(SetModulation(101, 12500));
+    assert(g_command_count == 2);
+    assert(strcmp(g_commands[0], "M NFM 12500\n") == 0);
+    assert(strcmp(g_commands[1], "M FM 12500\n") == 0);
+
+    assert(SetModulation(101, 12500));
+    assert(g_command_count == 2);
+
+    push_response("RPRT 1\n");
+    push_response("RPRT 1\n");
+    assert(!SetModulation(101, 25000));
+    assert(g_command_count == 4);
+    assert(strcmp(g_commands[2], "M NFM 25000\n") == 0);
+    assert(strcmp(g_commands[3], "M FM 25000\n") == 0);
+    return 0;
+}
+
+static int
+test_get_current_freq_parses_first_line_and_errors(void) {
+    reset_stubs();
+    push_response("851037500\nRPRT 0\n");
+    assert(GetCurrentFreq(102) == 851037500L);
+    assert(g_command_count == 1);
+    assert(strcmp(g_commands[0], "f\n") == 0);
+
+    reset_stubs();
+    push_response("RPRT 1");
+    assert(GetCurrentFreq(102) == 0L);
+    return 0;
+}
+
+static int
+test_io_control_set_freq_validation_and_rigctl_dispatch(void) {
+    reset_stubs();
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    assert(io_control_set_freq(NULL, &state, 851000000L) == -1);
+    assert(io_control_set_freq(&opts, &state, 0L) == -1);
+    assert(g_command_count == 0);
+
+    opts.use_rigctl = 1;
+    opts.rigctl_sockfd = 103;
+    opts.setmod_bw = 12500;
+    push_response("RPRT 0\n");
+    push_response("RPRT 0\n");
+
+    assert(io_control_set_freq(&opts, &state, 851050000L) == 0);
+    assert(opts.rtlsdr_center_freq == 851050000U);
+    assert(g_command_count == 2);
+    assert(strcmp(g_commands[0], "M NFM 12500\n") == 0);
+    assert(strcmp(g_commands[1], "F 851050000\n") == 0);
+    return 0;
+}
+
+static int
+test_signal_and_squelch_helpers(void) {
+    reset_stubs();
+    double value = -999.0;
+    push_response("12.34\n");
+    assert(dsd_rigctl_test_get_signal_level(104, &value));
+    assert(value == 12.3);
+    assert(g_command_count == 1);
+    assert(strcmp(g_commands[0], "l\n") == 0);
+
+    reset_stubs();
+    value = -999.0;
+    push_response("0.0\n");
+    assert(!dsd_rigctl_test_get_signal_level(104, &value));
+    assert(value == 0.0);
+
+    reset_stubs();
+    value = -999.0;
+    push_response("12.0 trailing\n");
+    assert(!dsd_rigctl_test_get_signal_level(104, &value));
+    assert(value == -999.0);
+
+    reset_stubs();
+    value = -999.0;
+    push_response("-45.66\n");
+    assert(dsd_rigctl_test_get_squelch_level(104, &value));
+    assert(value == -45.7);
+    assert(g_command_count == 1);
+    assert(strcmp(g_commands[0], "l SQL\n") == 0);
+
+    reset_stubs();
+    push_response("RPRT 1");
+    assert(!dsd_rigctl_test_get_squelch_level(104, &value));
+
+    reset_stubs();
+    push_response("RPRT 0");
+    assert(dsd_rigctl_test_set_squelch_level(104, 4.5));
+    assert(g_command_count == 1);
+    assert(strcmp(g_commands[0], "L SQL 4.500000\n") == 0);
+
+    reset_stubs();
+    push_response("RPRT 1");
+    assert(!dsd_rigctl_test_set_squelch_level(104, 4.5));
+    return 0;
+}
+
+static int
+test_signal_level_average_tolerates_failed_samples(void) {
+    reset_stubs();
+    double value = -999.0;
+    push_response("10.04\n");
+    push_response("RPRT 1");
+    push_response("14.04\n");
+
+    assert(dsd_rigctl_test_get_signal_level_ex(105, &value, 3));
+    assert(value == 12.0);
+    assert(g_command_count == 3);
+    assert(g_sleep_count == 3);
+    assert(strcmp(g_commands[0], "l\n") == 0);
+    assert(strcmp(g_commands[1], "l\n") == 0);
+    assert(strcmp(g_commands[2], "l\n") == 0);
+    return 0;
+}
+
+static int
+test_legacy_udp_tune_payload_and_cache(void) {
+    reset_stubs();
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.rtl_udp_port = 6021;
+
+    dsd_rigctl_test_rtl_udp_tune(&opts, &state, 0x12345678L);
+    assert(opts.rtlsdr_center_freq == 0x12345678U);
+    assert(g_sendto_count == 1);
+    assert(g_last_sendto_len == 5U);
+    assert(g_last_sendto_port == 6021);
+    assert(g_last_sendto_payload[0] == 0x00);
+    assert(g_last_sendto_payload[1] == 0x78);
+    assert(g_last_sendto_payload[2] == 0x56);
+    assert(g_last_sendto_payload[3] == 0x34);
+    assert(g_last_sendto_payload[4] == 0x12);
+    assert(g_close_count == 1);
+
+    dsd_rigctl_test_rtl_udp_tune(&opts, &state, 0x12345678L);
+    assert(g_sendto_count == 1);
+
+    dsd_rigctl_test_rtl_udp_tune(&opts, &state, 0x12345679L);
+    assert(g_sendto_count == 2);
+
+    reset_stubs();
+    g_create_result = DSD_INVALID_SOCKET;
+    opts.rtlsdr_center_freq = 0;
+    dsd_rigctl_test_rtl_udp_tune(&opts, &state, 0x12345680L);
+    assert(opts.rtlsdr_center_freq == 0x12345680U);
+    assert(g_sendto_count == 0);
+    assert(g_close_count == 0);
+    return 0;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_connect_failure_cleanup();
+    rc |= test_connect_success_uses_rigctl_timeout();
+    rc |= test_setfreq_success_failure_and_cache();
+    rc |= test_setmodulation_fallback_and_cache();
+    rc |= test_get_current_freq_parses_first_line_and_errors();
+    rc |= test_io_control_set_freq_validation_and_rigctl_dispatch();
+    rc |= test_signal_and_squelch_helpers();
+    rc |= test_signal_level_average_tolerates_failed_samples();
+    rc |= test_legacy_udp_tune_payload_and_cache();
+    return rc;
+}
+
+// NOLINTEND(bugprone-multi-level-implicit-pointer-conversion)

--- a/tests/io/test_io_rtl_demod_config.cpp
+++ b/tests/io/test_io_rtl_demod_config.cpp
@@ -696,12 +696,7 @@ expect_direct_output_open_rate_uses_demod_rate(void) {
 }
 
 static int
-expect_private_policy_matrices(void) {
-    static constexpr int kRadioSourceRtlUsb = 0;
-    static constexpr int kRadioSourceRtlTcp = 1;
-    static constexpr int kRadioSourceSoapy = 2;
-    static constexpr int kRadioSourceIqReplay = 3;
-
+expect_parse_compatibility_matrix(void) {
     int rc = 0;
 
     int int_ok[10] = {};
@@ -764,6 +759,17 @@ expect_private_policy_matrices(void) {
     rc |= expect_int_eq("parse double rejects suffix", double_ok[5], 0);
     rc |= expect_int_eq("parse double rejects alpha", double_ok[6], 0);
     rc |= expect_int_eq("parse double rejects ERANGE", double_ok[7], 0);
+    return rc;
+}
+
+static int
+expect_source_policy_matrix(void) {
+    static constexpr int kRadioSourceRtlUsb = 0;
+    static constexpr int kRadioSourceRtlTcp = 1;
+    static constexpr int kRadioSourceSoapy = 2;
+    static constexpr int kRadioSourceIqReplay = 3;
+
+    int rc = 0;
 
     int kinds[8] = {};
     int rtltcp[8] = {};
@@ -843,6 +849,12 @@ expect_private_policy_matrices(void) {
     rc |= expect_int_eq("perf source names stable",
                         std::strcmp(names, "rtl|rtl|rtltcp|rtltcp|soapy|soapy|iq_replay|rtl"), 0);
     rc |= expect_int_eq("soapy args extraction stable", std::strcmp(soapy_args, "|||driver=rtlsdr"), 0);
+    return rc;
+}
+
+static int
+expect_mode_policy_matrix(void) {
+    int rc = 0;
 
     int mode_policy[32] = {};
     rc |= expect_int_eq("mode policy rejects null output", rtl_stream_test_mode_policy_matrix(NULL, 32U), -1);
@@ -865,6 +877,12 @@ expect_private_policy_matrices(void) {
         rc |= expect_int_eq("12.5k/CQPSK bandwidth mode detected", mode_policy[i], 1);
     }
     rc |= expect_int_eq("NXDN48 is not a 12.5k/CQPSK bandwidth mode", mode_policy[29], 0);
+    return rc;
+}
+
+static int
+expect_fsk_profile_policy_matrix(void) {
+    int rc = 0;
 
     int profiles[21] = {};
     rc |= expect_int_eq("FSK profile rejects null output", rtl_stream_test_fsk_profile_policy_matrix(NULL, 21U), -1);
@@ -893,6 +911,17 @@ expect_private_policy_matrices(void) {
     rc |= expect_int_eq("current mode opts profile wins", profiles[18], DSD_CH_LPF_PROFILE_PROVOICE);
     rc |= expect_int_eq("current mode two-level fallback", profiles[19], DSD_CH_LPF_PROFILE_6K25);
     rc |= expect_int_eq("current mode default fallback", profiles[20], DSD_CH_LPF_PROFILE_12K5);
+    return rc;
+}
+
+static int
+expect_private_policy_matrices(void) {
+    int rc = 0;
+
+    rc |= expect_parse_compatibility_matrix();
+    rc |= expect_source_policy_matrix();
+    rc |= expect_mode_policy_matrix();
+    rc |= expect_fsk_profile_policy_matrix();
     return rc;
 }
 

--- a/tests/io/test_io_rtl_demod_config.cpp
+++ b/tests/io/test_io_rtl_demod_config.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/dsp/demod_state.h>
 #include <dsd-neo/io/rtl_demod_config.h>
@@ -694,6 +695,207 @@ expect_direct_output_open_rate_uses_demod_rate(void) {
     return rc;
 }
 
+static int
+expect_private_policy_matrices(void) {
+    static constexpr int kRadioSourceRtlUsb = 0;
+    static constexpr int kRadioSourceRtlTcp = 1;
+    static constexpr int kRadioSourceSoapy = 2;
+    static constexpr int kRadioSourceIqReplay = 3;
+
+    int rc = 0;
+
+    int int_ok[10] = {};
+    int int_values[10] = {};
+    int double_ok[8] = {};
+    double double_values[8] = {};
+    rc |= expect_int_eq("parse compatibility rejects null int status",
+                        rtl_stream_test_parse_compat_matrix(NULL, int_values,
+                                                            sizeof(int_values) / sizeof(int_values[0]), double_ok,
+                                                            double_values, sizeof(double_ok) / sizeof(double_ok[0])),
+                        -1);
+    rc |= expect_int_eq("parse compatibility rejects null int values",
+                        rtl_stream_test_parse_compat_matrix(int_ok, NULL, sizeof(int_values) / sizeof(int_values[0]),
+                                                            double_ok, double_values,
+                                                            sizeof(double_ok) / sizeof(double_ok[0])),
+                        -1);
+    rc |= expect_int_eq("parse compatibility rejects short int arrays",
+                        rtl_stream_test_parse_compat_matrix(int_ok, int_values, 9U, double_ok, double_values,
+                                                            sizeof(double_ok) / sizeof(double_ok[0])),
+                        -1);
+    rc |= expect_int_eq("parse compatibility rejects null double status",
+                        rtl_stream_test_parse_compat_matrix(int_ok, int_values,
+                                                            sizeof(int_values) / sizeof(int_values[0]), NULL,
+                                                            double_values, sizeof(double_ok) / sizeof(double_ok[0])),
+                        -1);
+    rc |= expect_int_eq("parse compatibility rejects null double values",
+                        rtl_stream_test_parse_compat_matrix(int_ok, int_values,
+                                                            sizeof(int_values) / sizeof(int_values[0]), double_ok, NULL,
+                                                            sizeof(double_ok) / sizeof(double_ok[0])),
+                        -1);
+    rc |=
+        expect_int_eq("parse compatibility rejects short double arrays",
+                      rtl_stream_test_parse_compat_matrix(
+                          int_ok, int_values, sizeof(int_values) / sizeof(int_values[0]), double_ok, double_values, 7U),
+                      -1);
+    rc |= expect_int_eq("parse compatibility matrix helper",
+                        rtl_stream_test_parse_compat_matrix(int_ok, int_values, sizeof(int_ok) / sizeof(int_ok[0]),
+                                                            double_ok, double_values,
+                                                            sizeof(double_ok) / sizeof(double_ok[0])),
+                        0);
+    rc |= expect_int_eq("parse int rejects null text", int_ok[0], 0);
+    rc |= expect_int_eq("parse int rejects empty text", int_ok[1], 0);
+    rc |= expect_int_eq("parse int rejects null output", int_ok[2], 0);
+    rc |= expect_int_eq("parse int accepts positive", int_ok[3], 1);
+    rc |= expect_int_eq("parse int positive value", int_values[3], 42);
+    rc |= expect_int_eq("parse int accepts negative", int_ok[4], 1);
+    rc |= expect_int_eq("parse int negative value", int_values[4], -17);
+    rc |= expect_int_eq("parse int rejects alpha", int_ok[5], 0);
+    rc |= expect_int_eq("parse int rejects suffix", int_ok[6], 0);
+    rc |= expect_int_eq("parse int rejects ERANGE", int_ok[7], 0);
+    rc |= expect_int_eq("parse int rejects high overflow", int_ok[8], 0);
+    rc |= expect_int_eq("parse int rejects low overflow", int_ok[9], 0);
+    rc |= expect_int_eq("parse double rejects null text", double_ok[0], 0);
+    rc |= expect_int_eq("parse double rejects empty text", double_ok[1], 0);
+    rc |= expect_int_eq("parse double rejects null output", double_ok[2], 0);
+    rc |= expect_int_eq("parse double accepts positive", double_ok[3], 1);
+    rc |= expect_double_near("parse double positive value", double_values[3], 3.25, 1e-12);
+    rc |= expect_int_eq("parse double accepts negative", double_ok[4], 1);
+    rc |= expect_double_near("parse double negative value", double_values[4], -2.5, 1e-12);
+    rc |= expect_int_eq("parse double rejects suffix", double_ok[5], 0);
+    rc |= expect_int_eq("parse double rejects alpha", double_ok[6], 0);
+    rc |= expect_int_eq("parse double rejects ERANGE", double_ok[7], 0);
+
+    int kinds[8] = {};
+    int rtltcp[8] = {};
+    int soapy[8] = {};
+    int replay[8] = {};
+    int family[8] = {};
+    char names[96] = {};
+    char soapy_args[64] = {};
+    rc |= expect_int_eq("source policy rejects null kind",
+                        rtl_stream_test_source_policy_matrix(NULL, rtltcp, soapy, replay, family,
+                                                             sizeof(kinds) / sizeof(kinds[0]), names, sizeof(names),
+                                                             soapy_args, sizeof(soapy_args)),
+                        -1);
+    rc |= expect_int_eq("source policy rejects null rtltcp",
+                        rtl_stream_test_source_policy_matrix(kinds, NULL, soapy, replay, family,
+                                                             sizeof(kinds) / sizeof(kinds[0]), names, sizeof(names),
+                                                             soapy_args, sizeof(soapy_args)),
+                        -1);
+    rc |= expect_int_eq("source policy rejects null soapy",
+                        rtl_stream_test_source_policy_matrix(kinds, rtltcp, NULL, replay, family,
+                                                             sizeof(kinds) / sizeof(kinds[0]), names, sizeof(names),
+                                                             soapy_args, sizeof(soapy_args)),
+                        -1);
+    rc |= expect_int_eq("source policy rejects null replay",
+                        rtl_stream_test_source_policy_matrix(kinds, rtltcp, soapy, NULL, family,
+                                                             sizeof(kinds) / sizeof(kinds[0]), names, sizeof(names),
+                                                             soapy_args, sizeof(soapy_args)),
+                        -1);
+    rc |= expect_int_eq("source policy rejects null family",
+                        rtl_stream_test_source_policy_matrix(kinds, rtltcp, soapy, replay, NULL,
+                                                             sizeof(kinds) / sizeof(kinds[0]), names, sizeof(names),
+                                                             soapy_args, sizeof(soapy_args)),
+                        -1);
+    rc |= expect_int_eq("source policy rejects short arrays",
+                        rtl_stream_test_source_policy_matrix(kinds, rtltcp, soapy, replay, family, 7U, names,
+                                                             sizeof(names), soapy_args, sizeof(soapy_args)),
+                        -1);
+    rc |= expect_int_eq("source policy rejects null names",
+                        rtl_stream_test_source_policy_matrix(kinds, rtltcp, soapy, replay, family,
+                                                             sizeof(kinds) / sizeof(kinds[0]), NULL, sizeof(names),
+                                                             soapy_args, sizeof(soapy_args)),
+                        -1);
+    rc |= expect_int_eq("source policy rejects empty names",
+                        rtl_stream_test_source_policy_matrix(kinds, rtltcp, soapy, replay, family,
+                                                             sizeof(kinds) / sizeof(kinds[0]), names, 0U, soapy_args,
+                                                             sizeof(soapy_args)),
+                        -1);
+    rc |= expect_int_eq("source policy rejects null Soapy args",
+                        rtl_stream_test_source_policy_matrix(kinds, rtltcp, soapy, replay, family,
+                                                             sizeof(kinds) / sizeof(kinds[0]), names, sizeof(names),
+                                                             NULL, sizeof(soapy_args)),
+                        -1);
+    rc |= expect_int_eq("source policy rejects empty Soapy args",
+                        rtl_stream_test_source_policy_matrix(kinds, rtltcp, soapy, replay, family,
+                                                             sizeof(kinds) / sizeof(kinds[0]), names, sizeof(names),
+                                                             soapy_args, 0U),
+                        -1);
+    rc |= expect_int_eq("source policy matrix helper",
+                        rtl_stream_test_source_policy_matrix(kinds, rtltcp, soapy, replay, family,
+                                                             sizeof(kinds) / sizeof(kinds[0]), names, sizeof(names),
+                                                             soapy_args, sizeof(soapy_args)),
+                        0);
+    rc |= expect_int_eq("null source defaults RTL USB", kinds[0], kRadioSourceRtlUsb);
+    rc |= expect_int_eq("empty source defaults RTL USB", kinds[1], kRadioSourceRtlUsb);
+    rc |= expect_int_eq("rtltcp bare source", kinds[2], kRadioSourceRtlTcp);
+    rc |= expect_int_eq("rtltcp arg source", kinds[3], kRadioSourceRtlTcp);
+    rc |= expect_int_eq("soapy bare source", kinds[4], kRadioSourceSoapy);
+    rc |= expect_int_eq("soapy arg source", kinds[5], kRadioSourceSoapy);
+    rc |= expect_int_eq("iq replay source", kinds[6], kRadioSourceIqReplay);
+    rc |= expect_int_eq("rtl spec source", kinds[7], kRadioSourceRtlUsb);
+    rc |= expect_int_eq("rtltcp predicate only matches rtltcp", rtltcp[2] + rtltcp[3], 2);
+    rc |= expect_int_eq("soapy predicate only matches soapy", soapy[4] + soapy[5], 2);
+    rc |= expect_int_eq("replay predicate only matches replay", replay[6], 1);
+    for (size_t i = 0U; i < sizeof(family) / sizeof(family[0]); i++) {
+        rc |= expect_int_eq("radio-family predicate covers known source", family[i], 1);
+    }
+    rc |= expect_int_eq("perf source names stable",
+                        std::strcmp(names, "rtl|rtl|rtltcp|rtltcp|soapy|soapy|iq_replay|rtl"), 0);
+    rc |= expect_int_eq("soapy args extraction stable", std::strcmp(soapy_args, "|||driver=rtlsdr"), 0);
+
+    int mode_policy[32] = {};
+    rc |= expect_int_eq("mode policy rejects null output", rtl_stream_test_mode_policy_matrix(NULL, 32U), -1);
+    rc |= expect_int_eq("mode policy rejects short output", rtl_stream_test_mode_policy_matrix(mode_policy, 31U), -1);
+    rc |=
+        expect_int_eq("mode policy matrix helper",
+                      rtl_stream_test_mode_policy_matrix(mode_policy, sizeof(mode_policy) / sizeof(mode_policy[0])), 0);
+    rc |= expect_int_eq("null opts are not digital", mode_policy[0], 0);
+    for (int i = 1; i <= 11; i++) {
+        rc |= expect_int_eq("digital protocol mode detected", mode_policy[i], 1);
+    }
+    rc |= expect_int_eq("empty opts are not digital", mode_policy[12], 0);
+    rc |= expect_int_eq("null opts have no wide four-level mode", mode_policy[13], 0);
+    for (int i = 14; i <= 17; i++) {
+        rc |= expect_int_eq("wide four-level protocol mode detected", mode_policy[i], 1);
+    }
+    rc |= expect_int_eq("P25P1 is not wide four-level FSK", mode_policy[18], 0);
+    rc |= expect_int_eq("null opts have no 12.5k/CQPSK mode", mode_policy[19], 0);
+    for (int i = 20; i <= 28; i++) {
+        rc |= expect_int_eq("12.5k/CQPSK bandwidth mode detected", mode_policy[i], 1);
+    }
+    rc |= expect_int_eq("NXDN48 is not a 12.5k/CQPSK bandwidth mode", mode_policy[29], 0);
+
+    int profiles[21] = {};
+    rc |= expect_int_eq("FSK profile rejects null output", rtl_stream_test_fsk_profile_policy_matrix(NULL, 21U), -1);
+    rc |=
+        expect_int_eq("FSK profile rejects short output", rtl_stream_test_fsk_profile_policy_matrix(profiles, 20U), -1);
+    rc |= expect_int_eq("FSK profile policy matrix helper",
+                        rtl_stream_test_fsk_profile_policy_matrix(profiles, sizeof(profiles) / sizeof(profiles[0])), 0);
+    rc |= expect_int_eq("null sym-rate opts reject", profiles[0], -1);
+    rc |= expect_int_eq("null frame opts reject", profiles[1], -1);
+    rc |= expect_int_eq("ProVoice sym-rate profile", profiles[2], DSD_CH_LPF_PROFILE_PROVOICE);
+    rc |= expect_int_eq("NXDN48 sym-rate profile", profiles[3], DSD_CH_LPF_PROFILE_6K25);
+    rc |= expect_int_eq("dPMR sym-rate profile", profiles[4], DSD_CH_LPF_PROFILE_6K25);
+    rc |= expect_int_eq("X2-TDMA sym-rate profile", profiles[5], DSD_CH_LPF_PROFILE_12K5);
+    rc |= expect_int_eq("DMR frame profile", profiles[6], DSD_CH_LPF_PROFILE_12K5);
+    rc |= expect_int_eq("P25P1 frame profile", profiles[7], DSD_CH_LPF_PROFILE_P25_C4FM);
+    rc |= expect_int_eq("P25P2 frame profile", profiles[8], DSD_CH_LPF_PROFILE_P25_C4FM);
+    rc |= expect_int_eq("D-STAR frame profile", profiles[9], DSD_CH_LPF_PROFILE_6K25);
+    rc |= expect_int_eq("X2-TDMA frame profile", profiles[10], DSD_CH_LPF_PROFILE_12K5);
+    rc |= expect_int_eq("ProVoice frame profile", profiles[11], DSD_CH_LPF_PROFILE_PROVOICE);
+    rc |= expect_int_eq("2400 symbol-rate fallback profile", profiles[12], DSD_CH_LPF_PROFILE_6K25);
+    rc |= expect_int_eq("9600 symbol-rate fallback profile", profiles[13], DSD_CH_LPF_PROFILE_PROVOICE);
+    rc |= expect_int_eq("6000 symbol-rate fallback profile", profiles[14], DSD_CH_LPF_PROFILE_12K5);
+    rc |= expect_int_eq("4800 two-level fallback profile", profiles[15], DSD_CH_LPF_PROFILE_6K25);
+    rc |= expect_int_eq("4800 four-level fallback profile", profiles[16], DSD_CH_LPF_PROFILE_12K5);
+    rc |= expect_int_eq("wide fallback profile", profiles[17], DSD_CH_LPF_PROFILE_WIDE);
+    rc |= expect_int_eq("current mode opts profile wins", profiles[18], DSD_CH_LPF_PROFILE_PROVOICE);
+    rc |= expect_int_eq("current mode two-level fallback", profiles[19], DSD_CH_LPF_PROFILE_6K25);
+    rc |= expect_int_eq("current mode default fallback", profiles[20], DSD_CH_LPF_PROFILE_12K5);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -873,6 +1075,7 @@ main(void) {
     rc |= expect_public_control_wrapper_contracts();
     rc |= expect_fsk_snr_sps_uses_active_profile();
     rc |= expect_direct_output_open_rate_uses_demod_rate();
+    rc |= expect_private_policy_matrices();
     rc |= expect_steady_state_watermark_disabled("rtl_tcp keeps demod watermark disabled", "rtltcp:127.0.0.1:1234");
     rc |= expect_steady_state_watermark_disabled("rtlsdr keeps demod watermark disabled", "rtl");
     rc |= expect_steady_state_watermark_disabled("soapy keeps demod watermark disabled", "soapy:driver=test");

--- a/tests/io/test_io_rtl_demod_config.cpp
+++ b/tests/io/test_io_rtl_demod_config.cpp
@@ -18,6 +18,8 @@
 #include "dsd-neo/core/safe_api.h"
 
 extern demod_state demod;
+extern std::atomic<double> g_snr_c4fm_db;
+extern std::atomic<double> g_snr_gfsk_db;
 extern std::atomic<double> g_snr_qpsk_db;
 
 static int
@@ -29,6 +31,15 @@ static int
 expect_int_eq(const char* label, int got, int want) {
     if (got != want) {
         DSD_FPRINTF(stderr, "%s: got=%d want=%d\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_double_near(const char* label, double got, double want, double tolerance) {
+    if (fabs(got - want) > tolerance) {
+        DSD_FPRINTF(stderr, "%s: got=%f want=%f tolerance=%f\n", label, got, want, tolerance);
         return 1;
     }
     return 0;
@@ -406,6 +417,253 @@ expect_rtl_metrics_do_not_nudge_cqpsk_bandedge(void) {
 }
 
 static int
+expect_rtl_metrics_exports_and_toggles(void) {
+    int rc = 0;
+    const double kTwoPi = 6.28318530717958647692;
+    const int rate_hz = 48000;
+
+    // Spectrum sizing clamps and rejects malformed snapshots before publishing data.
+    rc |= expect_int_eq("RTL spectrum clamps below minimum", rtl_stream_spectrum_set_size(1), 64);
+    rc |= expect_int_eq("RTL spectrum reports clamped minimum", rtl_stream_spectrum_get_size(), 64);
+    rc |= expect_int_eq("RTL spectrum rounds up to power-of-two", rtl_stream_spectrum_set_size(65), 128);
+    rc |= expect_int_eq("RTL spectrum clamps above maximum", rtl_stream_spectrum_set_size(2048), 1024);
+    rc |= expect_int_eq("RTL spectrum clamps get size", rtl_stream_spectrum_get_size(), 1024);
+
+    float bins[8] = {};
+    int out_rate = -1;
+    rc |= expect_int_eq("RTL spectrum rejects null output", rtl_stream_spectrum_get(nullptr, 8, &out_rate), 0);
+    rc |= expect_int_eq("RTL spectrum rejects zero bins", rtl_stream_spectrum_get(bins, 0, &out_rate), 0);
+    rc |= expect_int_eq("RTL spectrum test size", rtl_stream_spectrum_set_size(64), 64);
+
+    DSD_MEMSET(&demod, 0, sizeof(demod));
+    demod.cqpsk_enable = 1;
+    demod.rate_out = rate_hz;
+    demod.ted_sps = 5;
+    demod.fll_band_edge_state.initialized = 1;
+    demod.fll_band_edge_state.max_freq = 1.0f;
+    demod.fll_band_edge_state.freq = 0.010f;
+    demod.costas_state.initialized = 1;
+    demod.costas_state.freq = 0.020f;
+    demod.costas_state.phase = 0.75f;
+    demod.costas_state.error = -0.25f;
+    demod.costas_state.error_smooth = 0.125f;
+    demod.ted_state.lock_count = 32;
+    demod.ted_state.lock_accum = 32.0f;
+    demod.costas_err_avg_q14 = 1234;
+    demod.costas_err_raw_avg_q14 = 2345;
+    demod.costas_conf_avg_q14 = 12000;
+    demod.costas_zero_conf_pct = 7;
+
+    // Populate a stable spectrum and verify demodulator/costas metrics exported from it.
+    static float iq[128];
+    for (int n = 0; n < 64; n++) {
+        double phase = kTwoPi * 1000.0 * (double)n / (double)rate_hz;
+        iq[(size_t)(n << 1)] = (float)cos(phase);
+        iq[(size_t)(n << 1) + 1] = (float)sin(phase);
+    }
+    rtl_metrics_update_spectrum_from_iq(iq, 128, rate_hz);
+
+    out_rate = -1;
+    rc |= expect_int_eq("RTL spectrum copies requested bins", rtl_stream_spectrum_get(bins, 8, &out_rate), 8);
+    rc |= expect_int_eq("RTL spectrum publishes rate", out_rate, rate_hz);
+    rc |= expect_int_eq("RTL metrics publishes demod rate", rtl_stream_get_demod_rate_hz(), rate_hz);
+    rc |= expect_int_eq("RTL metrics publishes Costas error", rtl_stream_get_costas_err_q14(), 1234);
+
+    rtl_stream_costas_metrics metrics = {};
+    rc |= expect_int_eq("RTL Costas metrics reject null", rtl_stream_get_costas_metrics(nullptr), -1);
+    rc |= expect_int_eq("RTL Costas metrics snapshot", rtl_stream_get_costas_metrics(&metrics), 0);
+    rc |= expect_int_eq("RTL Costas metrics smooth", metrics.err_smooth_avg_q14, 1234);
+    rc |= expect_int_eq("RTL Costas metrics raw", metrics.err_raw_avg_q14, 2345);
+    rc |= expect_int_eq("RTL Costas metrics confidence", metrics.confidence_avg_q14, 12000);
+    rc |= expect_int_eq("RTL Costas metrics zero confidence", metrics.zero_conf_pct, 7);
+
+    const double total_rad = 0.010 + (0.020 / 5.0);
+    rc |=
+        expect_double_near("RTL metrics NCO CFO", rtl_stream_get_cfo_hz(), total_rad * (double)rate_hz / kTwoPi, 0.05);
+    rc |= expect_double_near("RTL metrics FLL band-edge CFO", rtl_stream_get_fll_band_edge_freq_hz(),
+                             0.010 * (double)rate_hz / kTwoPi, 0.05);
+    rc |= expect_int_eq("RTL metrics NCO q15", rtl_stream_get_nco_q15(), (int)lrint(total_rad * (32768.0 / kTwoPi)));
+    int carrier_lock = rtl_stream_get_carrier_lock();
+    if (carrier_lock != 0 && carrier_lock != 1) {
+        DSD_FPRINTF(stderr, "RTL carrier lock returned non-boolean value=%d\n", carrier_lock);
+        rc = 1;
+    }
+    (void)rtl_stream_get_residual_cfo_hz();
+
+    // Resetting Costas state clears phase/error accumulators but preserves tuned frequency.
+    rtl_stream_reset_costas();
+    rc |= expect_double_near("RTL reset Costas preserves frequency", demod.costas_state.freq, 0.020, 1e-6);
+    rc |= expect_double_near("RTL reset Costas clears phase", demod.costas_state.phase, 0.0, 1e-6);
+    rc |= expect_double_near("RTL reset Costas clears error", demod.costas_state.error, 0.0, 1e-6);
+    rc |= expect_double_near("RTL reset Costas clears smoothed error", demod.costas_state.error_smooth, 0.0, 1e-6);
+    rc |= expect_double_near("RTL reset Costas diff prev real", demod.cqpsk_diff_prev_r, 1.0, 1e-6);
+    rc |= expect_double_near("RTL reset Costas diff prev imag", demod.cqpsk_diff_prev_j, 0.0, 1e-6);
+    rc |= expect_int_eq("RTL reset Costas clears exported error", rtl_stream_get_costas_err_q14(), 0);
+    rc |= expect_int_eq("RTL reset Costas metrics snapshot", rtl_stream_get_costas_metrics(&metrics), 0);
+    rc |= expect_int_eq("RTL reset Costas smooth metric", metrics.err_smooth_avg_q14, 0);
+    rc |= expect_int_eq("RTL reset Costas raw metric", metrics.err_raw_avg_q14, 0);
+    rc |= expect_int_eq("RTL reset Costas confidence metric", metrics.confidence_avg_q14, 0);
+    rc |= expect_int_eq("RTL reset Costas zero confidence metric", metrics.zero_conf_pct, 0);
+
+    g_snr_c4fm_db.store(11.25, std::memory_order_relaxed);
+    g_snr_qpsk_db.store(12.50, std::memory_order_relaxed);
+    g_snr_gfsk_db.store(13.75, std::memory_order_relaxed);
+    rc |= expect_double_near("RTL C4FM SNR export", rtl_stream_get_snr_c4fm(), 11.25, 1e-9);
+    rc |= expect_double_near("RTL CQPSK SNR export", rtl_stream_get_snr_cqpsk(), 12.50, 1e-9);
+    rc |= expect_double_near("RTL GFSK SNR export", rtl_stream_get_snr_gfsk(), 13.75, 1e-9);
+    g_snr_c4fm_db.store(-100.0, std::memory_order_relaxed);
+    g_snr_qpsk_db.store(-100.0, std::memory_order_relaxed);
+    g_snr_gfsk_db.store(-100.0, std::memory_order_relaxed);
+
+    // User-facing tuner toggles should round-trip through the public control wrappers.
+    rtl_stream_set_tuner_autogain(1);
+    rc |= expect_int_eq("RTL tuner autogain on", rtl_stream_get_tuner_autogain(), 1);
+    rtl_stream_set_tuner_autogain(0);
+    rc |= expect_int_eq("RTL tuner autogain off", rtl_stream_get_tuner_autogain(), 0);
+
+    rtl_stream_set_auto_ppm(1);
+    rc |= expect_int_eq("RTL auto PPM user enable", rtl_stream_get_auto_ppm(), 1);
+    rtl_stream_set_auto_ppm(0);
+    rc |= expect_int_eq("RTL auto PPM user disable", rtl_stream_get_auto_ppm(), 0);
+
+    int enabled = -1;
+    double snr_db = 0.0;
+    double df_hz = 0.0;
+    double est_ppm = 0.0;
+    int last_dir = 99;
+    int cooldown = 99;
+    int locked = 99;
+    // Auto-PPM status and lock snapshots accept optional output pointers.
+    rc |=
+        expect_int_eq("RTL auto PPM accepts null status outputs",
+                      rtl_stream_auto_ppm_get_status(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr), 0);
+    rc |= expect_int_eq(
+        "RTL auto PPM status snapshot",
+        rtl_stream_auto_ppm_get_status(&enabled, &snr_db, &df_hz, &est_ppm, &last_dir, &cooldown, &locked), 0);
+    int training = rtl_stream_auto_ppm_training_active();
+    if (training != 0 && training != 1) {
+        DSD_FPRINTF(stderr, "RTL auto PPM training returned non-boolean value=%d\n", training);
+        rc = 1;
+    }
+    int ppm = 123;
+    rc |= expect_int_eq("RTL auto PPM lock snapshot", rtl_stream_auto_ppm_get_lock(&ppm, &snr_db, &df_hz), 0);
+    rc |= expect_int_eq("RTL auto PPM accepts null lock outputs",
+                        rtl_stream_auto_ppm_get_lock(nullptr, nullptr, nullptr), 0);
+    return rc;
+}
+
+static int
+expect_public_control_wrapper_contracts(void) {
+    int rc = 0;
+
+    // Null/default wrapper calls must be safe before any demodulator state is active.
+    rc |= expect_int_eq("RTL output rate rejects null context", (int)rtl_stream_output_rate(nullptr), 0);
+    rc |= expect_int_eq("RTL monitor rate rejects null context", (int)rtl_stream_monitor_rate(nullptr), 0);
+    rc |= expect_int_eq("RTL active state defaults inactive", rtl_stream_is_active(), 0);
+
+    DSD_MEMSET(&demod, 0, sizeof(demod));
+    demod.ted_state.e_ema = 0.25f;
+    rc |= expect_int_eq("RTL timing bias exports Q14", rtl_stream_cqpsk_timing_bias(nullptr), 4096);
+    demod.ted_state.e_ema = -0.5f;
+    rc |= expect_int_eq("RTL timing bias preserves sign", rtl_stream_cqpsk_timing_bias(nullptr), -8192);
+
+    // Symbol profile setters validate input and refresh the dependent demodulator fields.
+    DSD_MEMSET(&demod, 0, sizeof(demod));
+    demod.output_kind = DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
+    demod.rate_out = 48000;
+    demod.symbol_rate_hz = 4800;
+    demod.symbol_levels = 4;
+    demod.channel_lpf_profile = DSD_CH_LPF_PROFILE_12K5;
+    demod.ted_sps = 10;
+
+    int symbol_rate = -1;
+    int levels = -1;
+    int channel_profile = -1;
+    rc |= expect_int_eq("RTL symbol profile rejects zero rate", rtl_stream_set_symbol_profile(0, 4, 0), -1);
+    rc |= expect_int_eq("RTL symbol profile rejects unsupported levels", rtl_stream_set_symbol_profile(4800, 3, 0), -1);
+    rc |= expect_int_eq("RTL symbol profile accepts null outputs",
+                        rtl_stream_get_symbol_profile_full(nullptr, nullptr, nullptr), 0);
+    rc |= expect_int_eq("RTL symbol profile accepts 2.4 ksps",
+                        rtl_stream_set_symbol_profile(2400, 4, DSD_CH_LPF_PROFILE_6K25), 0);
+    rc |= expect_int_eq("RTL symbol profile snapshot full",
+                        rtl_stream_get_symbol_profile_full(&symbol_rate, &levels, &channel_profile), 0);
+    rc |= expect_int_eq("RTL symbol profile rate", symbol_rate, 2400);
+    rc |= expect_int_eq("RTL symbol profile levels", levels, 4);
+    rc |= expect_int_eq("RTL symbol profile channel", channel_profile, DSD_CH_LPF_PROFILE_6K25);
+    rc |= expect_int_eq("RTL symbol profile recalculates FSK SPS", demod.ted_sps, 20);
+    rc |= expect_int_eq("RTL symbol profile marks Costas reset", demod.costas_reset_pending, 1);
+
+    channel_profile = -1;
+    rc |= expect_int_eq("RTL symbol profile ignores invalid channel profile",
+                        rtl_stream_set_symbol_profile(9600, 2, 999), 0);
+    rc |= expect_int_eq("RTL symbol profile snapshot compact", rtl_stream_get_symbol_profile(&symbol_rate, &levels), 0);
+    rc |= expect_int_eq("RTL compact profile rate", symbol_rate, 9600);
+    rc |= expect_int_eq("RTL compact profile levels", levels, 2);
+    rc |= expect_int_eq("RTL invalid channel profile leaves previous channel",
+                        rtl_stream_get_symbol_profile_full(nullptr, nullptr, &channel_profile), 0);
+    rc |= expect_int_eq("RTL retained channel profile", channel_profile, DSD_CH_LPF_PROFILE_6K25);
+
+    // TED controls clamp override and active SPS paths independently.
+    DSD_MEMSET(&demod, 0, sizeof(demod));
+    demod.rate_out = 48000;
+    demod.symbol_levels = 4;
+    demod.channel_lpf_profile = DSD_CH_LPF_PROFILE_12K5;
+    demod.ted_sps = 10;
+    demod.cqpsk_enable = 1;
+    rtl_stream_set_ted_sps(1);
+    rc |= expect_int_eq("RTL TED SPS clamps low override", rtl_stream_get_ted_sps_override(), 2);
+    rc |= expect_int_eq("RTL TED SPS selects CQPSK LPF", demod.channel_lpf_profile, DSD_CH_LPF_PROFILE_P25_CQPSK);
+    rtl_stream_clear_ted_sps_override();
+    rc |= expect_int_eq("RTL TED SPS override clears", rtl_stream_get_ted_sps_override(), 0);
+    rtl_stream_set_ted_sps(99);
+    rc |= expect_int_eq("RTL TED SPS clamps high override", rtl_stream_get_ted_sps_override(), 64);
+    rtl_stream_set_ted_sps_no_override(99);
+    rc |= expect_int_eq("RTL TED SPS no-override clamps active SPS", rtl_stream_get_ted_sps(), 64);
+    rc |= expect_int_eq("RTL TED SPS no-override leaves override", rtl_stream_get_ted_sps_override(), 64);
+    rtl_stream_clear_ted_sps_override();
+
+    rtl_stream_set_ted_gain(-1.0f);
+    rc |= expect_double_near("RTL TED gain clamps low", rtl_stream_get_ted_gain(), 0.01, 1e-6);
+    rtl_stream_set_ted_gain(1.0f);
+    rc |= expect_double_near("RTL TED gain clamps high", rtl_stream_get_ted_gain(), 0.50, 1e-6);
+
+    // IQ DC setup precharges from buffered samples and clamps shift configuration.
+    DSD_MEMSET(&demod, 0, sizeof(demod));
+    static float lowpassed[] = {1.0f, -3.0f, 5.0f, 7.0f};
+    demod.lowpassed = lowpassed;
+    demod.lp_len = 4;
+    int shift = -1;
+    rtl_stream_set_iq_dc(1, 3);
+    rc |= expect_int_eq("RTL IQ DC enables", rtl_stream_get_iq_dc(&shift), 1);
+    rc |= expect_int_eq("RTL IQ DC shift clamps low", shift, 6);
+    rc |= expect_double_near("RTL IQ DC precharges I average", demod.iq_dc_avg_r, 3.0, 1e-6);
+    rc |= expect_double_near("RTL IQ DC precharges Q average", demod.iq_dc_avg_i, 2.0, 1e-6);
+    rtl_stream_set_iq_dc(-1, 99);
+    rc |= expect_int_eq("RTL IQ DC negative enable keeps state", rtl_stream_get_iq_dc(&shift), 1);
+    rc |= expect_int_eq("RTL IQ DC shift clamps high", shift, 15);
+    rtl_stream_set_iq_dc(0, -1);
+    rc |= expect_int_eq("RTL IQ DC disables without changing shift", rtl_stream_get_iq_dc(&shift), 0);
+    rc |= expect_int_eq("RTL IQ DC disabled shift snapshot", shift, 15);
+
+    rtl_stream_toggle_iq_balance(1);
+    rc |= expect_int_eq("RTL IQ balance enables", rtl_stream_get_iq_balance(), 1);
+    rtl_stream_toggle_iq_balance(0);
+    rc |= expect_int_eq("RTL IQ balance disables", rtl_stream_get_iq_balance(), 0);
+
+    // Decode health stays invalid while the stream is inactive even after error updates.
+    rtl_stream_decode_health health = {};
+    rc |= expect_int_eq("RTL decode health rejects null", rtl_stream_get_decode_health(nullptr), -1);
+    rtl_stream_p25p1_ber_update(10, 5);
+    rtl_stream_p25p2_err_update(1, 2, 3, 4, 5, 6);
+    rc |= expect_int_eq("RTL inactive decode health snapshot", rtl_stream_get_decode_health(&health), 0);
+    rc |= expect_int_eq("RTL inactive decode health invalid", health.valid, 0);
+    rc |= expect_int_eq("RTL inactive P25P1 OK stays zero", (int)health.p25p1_fec_ok, 0);
+    rc |= expect_int_eq("RTL inactive P25P2 FACCH OK stays zero", (int)health.p25p2_facch_ok, 0);
+
+    return rc;
+}
+
+static int
 expect_fsk_snr_sps_uses_active_profile(void) {
     int rc = 0;
 
@@ -611,6 +869,8 @@ main(void) {
     rc |= expect_cqpsk_toggle_clears_output_contract_backlog();
     rc |= expect_cqpsk_toggle_restores_fsk_channel_profile();
     rc |= expect_rtl_metrics_do_not_nudge_cqpsk_bandedge();
+    rc |= expect_rtl_metrics_exports_and_toggles();
+    rc |= expect_public_control_wrapper_contracts();
     rc |= expect_fsk_snr_sps_uses_active_profile();
     rc |= expect_direct_output_open_rate_uses_demod_rate();
     rc |= expect_steady_state_watermark_disabled("rtl_tcp keeps demod watermark disabled", "rtltcp:127.0.0.1:1234");

--- a/tests/io/test_io_rtl_perf.cpp
+++ b/tests/io/test_io_rtl_perf.cpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Regression test: opt-in RTL performance logging must gate on the environment,
+ * aggregate counters over an interval, write CSV rows, and reset on shutdown.
+ */
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <dsd-neo/platform/file_compat.h>
+#include <stdint.h>
+#include <string>
+#include <sys/types.h>
+
+#include "rtl_perf.h"
+
+static uint64_t g_now_ns = 1000;
+static char* g_csv_data = nullptr;
+static size_t g_csv_size = 0;
+static FILE* g_csv_file = nullptr;
+static int g_open_count = 0;
+static off_t g_stub_size = 0;
+
+extern "C" uint64_t
+test_dsd_time_monotonic_ns(void) {
+    return g_now_ns;
+}
+
+extern "C" FILE*
+test_dsd_fopen_private(const char* path, const char* mode) {
+    assert(std::strcmp(path, "dsd-neo-rtl-perf.csv") == 0);
+    assert(std::strcmp(mode, "a") == 0);
+    g_open_count++;
+    g_csv_file = open_memstream(&g_csv_data, &g_csv_size);
+    return g_csv_file;
+}
+
+extern "C" int
+test_dsd_fileno(FILE* stream) {
+    assert(stream == g_csv_file);
+    return 123;
+}
+
+extern "C" int
+test_dsd_fstat(int fd, dsd_stat_t* st) {
+    assert(fd == 123);
+    if (!st) {
+        return -1;
+    }
+    std::memset(st, 0, sizeof(*st));
+    st->st_size = g_stub_size;
+    return 0;
+}
+
+static void
+reset_fixture(void) {
+    rtl_perf_shutdown();
+    unsetenv("DSD_NEO_RTL_PERF_CSV");
+    unsetenv("DSD_NEO_RTL_PERF_INTERVAL_MS");
+    free(g_csv_data);
+    g_csv_data = nullptr;
+    g_csv_size = 0;
+    g_csv_file = nullptr;
+    g_open_count = 0;
+    g_stub_size = 0;
+    g_now_ns = 1000;
+}
+
+static void
+test_disabled_without_env(void) {
+    reset_fixture();
+    assert(rtl_perf_enabled() == 0);
+    rtl_perf_record_ingest(10, 20, 3);
+    rtl_perf_record_demod_block(1, 2, 3, 4, 5);
+    rtl_perf_record_consumer_read(6, 7);
+    rtl_perf_log_snapshot snapshot{};
+    rtl_perf_maybe_log(&snapshot);
+    assert(g_open_count == 0);
+    rtl_perf_shutdown();
+    assert(rtl_perf_enabled() == 0);
+}
+
+static void
+test_csv_logging_aggregates_and_resets(void) {
+    reset_fixture();
+    setenv("DSD_NEO_RTL_PERF_CSV", "1", 1);
+    setenv("DSD_NEO_RTL_PERF_INTERVAL_MS", "1", 1);
+
+    assert(rtl_perf_enabled() == 1);
+    assert(g_open_count == 1);
+    rtl_perf_record_ingest(11, 22, 3);
+    rtl_perf_record_ingest(13, 5, 1);
+    rtl_perf_record_demod_block(17, 19, 23, 29, 31);
+    rtl_perf_record_consumer_read(37, 41);
+
+    rtl_perf_log_snapshot snapshot{};
+    snapshot.source = "rtltcp";
+    snapshot.sample_rate_hz = 48000;
+    snapshot.output_kind = 2;
+    snapshot.input_used = 10;
+    snapshot.input_capacity = 20;
+    snapshot.input_drops = 30;
+    snapshot.output_used = 40;
+    snapshot.output_capacity = 50;
+    snapshot.symbol_cache_pending = 6;
+    snapshot.snr_db = 7.25;
+    snapshot.cfo_hz = -12.5;
+    snapshot.carrier_lock = 1;
+
+    rtl_perf_maybe_log(&snapshot);
+    fflush(g_csv_file);
+    std::string before_interval(g_csv_data ? g_csv_data : "", g_csv_size);
+    assert(before_interval.find("rtltcp") == std::string::npos);
+    assert(before_interval.find("time_ms,source,rate_hz") != std::string::npos);
+
+    g_now_ns = 100001000ULL;
+    rtl_perf_maybe_log(&snapshot);
+    fflush(g_csv_file);
+    std::string first_log(g_csv_data ? g_csv_data : "", g_csv_size);
+    assert(first_log.find(",rtltcp,48000,2,10,20,30,40,50,6,2,27,4,24,1,29,31,17,19,23,1,41,37,7.250,-12.500,1\n")
+           != std::string::npos);
+
+    g_now_ns = 200001000ULL;
+    snapshot.source = nullptr;
+    snapshot.sample_rate_hz = 24000;
+    snapshot.output_kind = 9;
+    rtl_perf_maybe_log(&snapshot);
+    rtl_perf_shutdown();
+    std::string final_log(g_csv_data ? g_csv_data : "", g_csv_size);
+    assert(final_log.find(",unknown,24000,9,10,20,30,40,50,6,0,0,0,0,0,0,0,0,0,0,0,0,0,7.250,-12.500,1\n")
+           != std::string::npos);
+
+    free(g_csv_data);
+    g_csv_data = nullptr;
+    g_csv_size = 0;
+}
+
+static void
+test_existing_file_skips_header(void) {
+    reset_fixture();
+    g_stub_size = 99;
+    setenv("DSD_NEO_RTL_PERF_CSV", "1", 1);
+    setenv("DSD_NEO_RTL_PERF_INTERVAL_MS", "60001", 1);
+    assert(rtl_perf_enabled() == 1);
+    fflush(g_csv_file);
+    std::string output(g_csv_data ? g_csv_data : "", g_csv_size);
+    assert(output.find("time_ms,source") == std::string::npos);
+}
+
+int
+main(void) {
+    test_disabled_without_env();
+    test_csv_logging_aggregates_and_resets();
+    test_existing_file_skips_header();
+    reset_fixture();
+    return 0;
+}

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -10,6 +10,9 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
+#include <dsd-neo/core/input_level.h>
+#include <dsd-neo/io/iq_types.h>
 #include <dsd-neo/io/rtl_device.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include "dsd-neo/core/safe_api.h"
@@ -36,6 +39,44 @@ extern "C" int rtl_device_test_usb_manual_gain_controls(int agc_rc, int gain_mod
                                                         int* out_recorded_agc_rc);
 extern "C" int rtl_device_test_usb_auto_gain_controls(int agc_rc, int gain_mode_rc, int* out_agc_calls,
                                                       int* out_gain_mode_calls, int* out_recorded_agc_rc);
+extern "C" int rtl_device_test_u8_odd_carry_bridge(size_t* out_used, int* out_phase, int* out_carry_valid,
+                                                   uint8_t* out_carry_byte, int* out_first_status,
+                                                   int* out_second_status);
+extern "C" int rtl_device_test_u8_full_ring_drop(size_t* out_used, uint64_t* out_drops, uint64_t* out_full_events,
+                                                 int* out_phase, int* out_status);
+extern "C" int rtl_device_test_u8_generation_stale_drop(uint64_t* out_drops, int* out_phase, int* out_dev_carry_valid,
+                                                        int* out_local_carry_valid, int* out_status);
+extern "C" int rtl_device_test_replay_input_level_snapshot(int format, int backend, const char* capture_stage,
+                                                           size_t raw_bytes, size_t scratch_cap_f32, int* out_rc,
+                                                           int* out_source, uint64_t* out_count);
+
+// Mirrors the internal RTL replay-conversion test hook request layout.
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+struct rtl_device_test_replay_convert_block_request {
+    int format;
+    const char* capture_stage;
+    int fs4_shift_enabled;
+    int combine_rotate_enabled;
+    const uint8_t* raw_block;
+    size_t raw_bytes;
+    size_t out_cap_f32;
+    int start_phase;
+    int start_have_carry;
+    uint8_t start_carry_byte;
+};
+
+extern "C" int rtl_device_test_replay_convert_block(const rtl_device_test_replay_convert_block_request* request,
+                                                    float* out_f32, size_t out_f32_count, int* out_phase,
+                                                    int* out_have_carry, uint8_t* out_carry_byte);
+extern "C" int rtl_device_test_public_capture_policy(int* out_formats, size_t out_formats_len, uint32_t* out_counts,
+                                                     size_t out_counts_len);
+extern "C" int rtl_device_test_misc_string_helpers(char* tuner_labels, size_t tuner_labels_size, char* reason_small,
+                                                   size_t reason_small_size, char* reason_null, size_t reason_null_size,
+                                                   char* trimmed, size_t trimmed_size, size_t* rounded_pages,
+                                                   size_t rounded_pages_len);
+extern "C" int rtl_device_test_tcp_policy_helpers(size_t* bufsz_out, size_t bufsz_count, int* waitall_out,
+                                                  size_t waitall_count, uint64_t* delta_out, size_t delta_count,
+                                                  int* agc_out);
 extern "C" int dsd_rtl_stream_test_tune_completion_result(int wait_result, int completion_result);
 extern "C" int dsd_rtl_stream_test_manual_retune_completion_result(int retune_rc, int reconfigured, uint32_t target_hz,
                                                                    uint32_t applied_freq_hz);
@@ -65,6 +106,18 @@ expect_size_eq(const char* label, size_t got, size_t want) {
         return 1;
     }
     return 0;
+}
+
+static int
+call_replay_convert_block(int format, const char* capture_stage, int fs4_shift_enabled, int combine_rotate_enabled,
+                          const uint8_t* raw_block, size_t raw_bytes, size_t out_cap_f32, int start_phase,
+                          int start_have_carry, uint8_t start_carry_byte, float* out_f32, size_t out_f32_count,
+                          int* out_phase, int* out_have_carry, uint8_t* out_carry_byte) {
+    rtl_device_test_replay_convert_block_request request{
+        format,    capture_stage, fs4_shift_enabled, combine_rotate_enabled, raw_block,
+        raw_bytes, out_cap_f32,   start_phase,       start_have_carry,       start_carry_byte};
+    return rtl_device_test_replay_convert_block(&request, out_f32, out_f32_count, out_phase, out_have_carry,
+                                                out_carry_byte);
 }
 
 static int
@@ -450,6 +503,24 @@ main(void) {
                             rtl_device_test_begin_capture_reconfigure_without_writer(&hold), 0);
     failed |= expect_int_eq("begin reconfigure without writer activates hold", hold, 1);
 
+    int native_formats[8] = {-1, -1, -1, -1, -1, -1, -1, -1};
+    uint32_t capture_counts[5] = {99U, 99U, 99U, 99U, 99U};
+    rc = rtl_device_test_public_capture_policy(native_formats, 8U, capture_counts, 5U);
+    failed |= expect_int_eq("public capture policy helper rc", rc, 0);
+    failed |= expect_int_eq("native format null", native_formats[0], DSD_IQ_FORMAT_UNKNOWN);
+    failed |= expect_int_eq("native format usb", native_formats[1], DSD_IQ_FORMAT_CU8);
+    failed |= expect_int_eq("native format tcp", native_formats[2], DSD_IQ_FORMAT_CU8);
+    failed |= expect_int_eq("native format Soapy CF32", native_formats[3], DSD_IQ_FORMAT_CF32);
+    failed |= expect_int_eq("native format Soapy CS16", native_formats[4], DSD_IQ_FORMAT_CS16);
+    failed |= expect_int_eq("native format Soapy none", native_formats[5], DSD_IQ_FORMAT_UNKNOWN);
+    failed |= expect_int_eq("native format replay", native_formats[6], DSD_IQ_FORMAT_CS16);
+    failed |= expect_int_eq("native format unknown backend", native_formats[7], DSD_IQ_FORMAT_UNKNOWN);
+    failed |= expect_int_eq("capture count null", (int)capture_counts[0], 0);
+    failed |= expect_int_eq("capture count starts zero", (int)capture_counts[1], 0);
+    failed |= expect_int_eq("capture count ignores missing writer", (int)capture_counts[2], 0);
+    failed |= expect_int_eq("capture count increments with writer", (int)capture_counts[3], 2);
+    failed |= expect_int_eq("capture count detach resets", (int)capture_counts[4], 0);
+
     size_t held_ring_used = 99U;
     failed |= expect_int_eq("usb reconfigure discard helper",
                             rtl_device_test_usb_reconfigure_discards_samples(16U, &held_ring_used), 0);
@@ -469,6 +540,221 @@ main(void) {
                             rtl_device_test_replay_event_boundary_drained(0U, 3U, 2U), 0);
     failed |=
         expect_int_eq("reset event boundary drained", rtl_device_test_replay_event_boundary_drained(0U, 3U, 3U), 1);
+
+    /*
+     * Replay input-level snapshots preserve source identity for USB/TCP CU8 and
+     * accept CF32 only from the post-driver capture stage with aligned input and
+     * sufficient scratch space.
+     */
+    const int rtl_test_backend_usb = 0;
+    const int rtl_test_backend_tcp = 1;
+    int input_level_rc = -99;
+    int input_level_source = -99;
+    uint64_t input_level_count = 0U;
+    rc = rtl_device_test_replay_input_level_snapshot(DSD_IQ_FORMAT_CU8, rtl_test_backend_usb, "", 8U, 0U,
+                                                     &input_level_rc, &input_level_source, &input_level_count);
+    failed |= expect_int_eq("replay CU8 USB snapshot helper rc", rc, 0);
+    failed |= expect_int_eq("replay CU8 USB snapshot rc", input_level_rc, 0);
+    failed |= expect_int_eq("replay CU8 USB source", input_level_source, DSD_INPUT_LEVEL_SOURCE_RTL_CU8);
+    failed |= expect_size_eq("replay CU8 USB sample count", (size_t)input_level_count, 8U);
+
+    rc = rtl_device_test_replay_input_level_snapshot(DSD_IQ_FORMAT_CU8, rtl_test_backend_tcp, "", 8U, 0U,
+                                                     &input_level_rc, &input_level_source, &input_level_count);
+    failed |= expect_int_eq("replay CU8 TCP snapshot helper rc", rc, 0);
+    failed |= expect_int_eq("replay CU8 TCP snapshot rc", input_level_rc, 0);
+    failed |= expect_int_eq("replay CU8 TCP source", input_level_source, DSD_INPUT_LEVEL_SOURCE_RTL_TCP_CU8);
+
+    rc = rtl_device_test_replay_input_level_snapshot(DSD_IQ_FORMAT_CF32, rtl_test_backend_usb,
+                                                     "post_driver_cf32_pre_ring", 16U, 4U, &input_level_rc,
+                                                     &input_level_source, &input_level_count);
+    failed |= expect_int_eq("replay CF32 snapshot helper rc", rc, 0);
+    failed |= expect_int_eq("replay CF32 snapshot rc", input_level_rc, 0);
+    failed |= expect_int_eq("replay CF32 source", input_level_source, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32);
+    failed |= expect_size_eq("replay CF32 sample count", (size_t)input_level_count, 4U);
+
+    rc = rtl_device_test_replay_input_level_snapshot(DSD_IQ_FORMAT_CF32, rtl_test_backend_usb, "pre_ring", 16U, 4U,
+                                                     &input_level_rc, &input_level_source, &input_level_count);
+    failed |= expect_int_eq("replay CF32 rejects wrong stage helper rc", rc, 0);
+    failed |= expect_int_eq("replay CF32 rejects wrong stage", input_level_rc, -1);
+    failed |= expect_int_eq("replay CF32 wrong stage clears source", input_level_source, -1);
+    failed |= expect_size_eq("replay CF32 wrong stage clears count", (size_t)input_level_count, 0U);
+
+    rc = rtl_device_test_replay_input_level_snapshot(DSD_IQ_FORMAT_CF32, rtl_test_backend_usb,
+                                                     "post_driver_cf32_pre_ring", 10U, 4U, &input_level_rc,
+                                                     &input_level_source, &input_level_count);
+    failed |= expect_int_eq("replay CF32 rejects misaligned helper rc", rc, 0);
+    failed |= expect_int_eq("replay CF32 rejects misaligned bytes", input_level_rc, -1);
+
+    rc = rtl_device_test_replay_input_level_snapshot(DSD_IQ_FORMAT_CF32, rtl_test_backend_usb,
+                                                     "post_driver_cf32_pre_ring", 16U, 3U, &input_level_rc,
+                                                     &input_level_source, &input_level_count);
+    failed |= expect_int_eq("replay CF32 rejects small scratch helper rc", rc, 0);
+    failed |= expect_int_eq("replay CF32 rejects small scratch", input_level_rc, -1);
+
+    /*
+     * Replay sample conversion is stateful across chunks: CU8 preserves odd
+     * carry bytes, while CF32 post-driver blocks optionally apply J/4 rotation.
+     */
+    float converted[8] = {};
+    int convert_phase = -1;
+    int convert_have_carry = -1;
+    uint8_t convert_carry_byte = 0U;
+    const uint8_t cu8_with_carry[] = {128U, 130U, 132U};
+    rc = call_replay_convert_block(DSD_IQ_FORMAT_CU8, "", 0, 0, cu8_with_carry, sizeof(cu8_with_carry), 8U, 2, 1, 126U,
+                                   converted, sizeof(converted) / sizeof(converted[0]), &convert_phase,
+                                   &convert_have_carry, &convert_carry_byte);
+    failed |= expect_int_eq("replay CU8 carry conversion count", rc, 4);
+    failed |= expect_double_near("replay CU8 carried I sample", converted[0], (126.0 - 127.5) / 127.5, 1e-6);
+    failed |= expect_double_near("replay CU8 carried Q sample", converted[1], (128.0 - 127.5) / 127.5, 1e-6);
+    failed |= expect_double_near("replay CU8 aligned I sample", converted[2], (130.0 - 127.5) / 127.5, 1e-6);
+    failed |= expect_double_near("replay CU8 aligned Q sample", converted[3], (132.0 - 127.5) / 127.5, 1e-6);
+    failed |= expect_int_eq("replay CU8 no-rotate preserves phase", convert_phase, 2);
+    failed |= expect_int_eq("replay CU8 carry consumed", convert_have_carry, 0);
+    failed |= expect_int_eq("replay CU8 consumed carry byte unchanged", (int)convert_carry_byte, 126);
+
+    const uint8_t cu8_odd_tail[] = {127U, 128U, 129U};
+    rc = call_replay_convert_block(DSD_IQ_FORMAT_CU8, "", 0, 0, cu8_odd_tail, sizeof(cu8_odd_tail), 8U, 0, 0, 0U,
+                                   converted, sizeof(converted) / sizeof(converted[0]), &convert_phase,
+                                   &convert_have_carry, &convert_carry_byte);
+    failed |= expect_int_eq("replay CU8 odd tail conversion count", rc, 2);
+    failed |= expect_int_eq("replay CU8 odd tail retained", convert_have_carry, 1);
+    failed |= expect_int_eq("replay CU8 odd tail byte", (int)convert_carry_byte, 129);
+
+    float cf32_samples[] = {1.0f, 2.0f, 3.0f, 4.0f};
+    uint8_t cf32_raw[sizeof(cf32_samples)] = {};
+    DSD_MEMCPY(cf32_raw, cf32_samples, sizeof(cf32_samples));
+    rc = call_replay_convert_block(DSD_IQ_FORMAT_CF32, "post_driver_cf32_pre_ring", 1, 0, cf32_raw, sizeof(cf32_raw),
+                                   8U, 1, 0, 0U, converted, sizeof(converted) / sizeof(converted[0]), &convert_phase,
+                                   &convert_have_carry, &convert_carry_byte);
+    failed |= expect_int_eq("replay CF32 rotated conversion count", rc, 4);
+    failed |= expect_double_near("replay CF32 phase1 rotated I", converted[0], -2.0, 1e-6);
+    failed |= expect_double_near("replay CF32 phase1 rotated Q", converted[1], 1.0, 1e-6);
+    failed |= expect_double_near("replay CF32 phase2 rotated I", converted[2], -3.0, 1e-6);
+    failed |= expect_double_near("replay CF32 phase2 rotated Q", converted[3], -4.0, 1e-6);
+    failed |= expect_int_eq("replay CF32 rotation advances phase", convert_phase, 3);
+    failed |= expect_int_eq("replay CF32 leaves carry clear", convert_have_carry, 0);
+
+    rc = call_replay_convert_block(DSD_IQ_FORMAT_CF32, "pre_ring", 1, 0, cf32_raw, sizeof(cf32_raw), 8U, 1, 0, 0U,
+                                   converted, sizeof(converted) / sizeof(converted[0]), &convert_phase,
+                                   &convert_have_carry, &convert_carry_byte);
+    failed |= expect_int_eq("replay CF32 rejects wrong stage conversion", rc, -1);
+
+    rc = call_replay_convert_block(DSD_IQ_FORMAT_CS16, "", 0, 0, cu8_odd_tail, sizeof(cu8_odd_tail), 8U, 0, 0, 0U,
+                                   converted, sizeof(converted) / sizeof(converted[0]), &convert_phase,
+                                   &convert_have_carry, &convert_carry_byte);
+    failed |= expect_int_eq("replay converter rejects unsupported format", rc, -1);
+
+    /*
+     * CU8 callback chunking must preserve odd trailing bytes between callbacks,
+     * and full-ring drops must keep both drop accounting and FS/4 phase aligned.
+     */
+    size_t u8_used = 0U;
+    int u8_phase = -1;
+    int u8_carry_valid = -1;
+    uint8_t u8_carry_byte = 0U;
+    int first_status = -1;
+    int second_status = -1;
+    rc = rtl_device_test_u8_odd_carry_bridge(&u8_used, &u8_phase, &u8_carry_valid, &u8_carry_byte, &first_status,
+                                             &second_status);
+    failed |= expect_int_eq("u8 odd-carry helper rc", rc, 0);
+    failed |= expect_int_eq("u8 odd-carry first chunk accepted", first_status, 0);
+    failed |= expect_int_eq("u8 odd-carry second chunk accepted", second_status, 0);
+    failed |= expect_size_eq("u8 odd-carry bridges one IQ pair", u8_used, 2U);
+    failed |= expect_int_eq("u8 odd-carry advances one FS/4 pair", u8_phase, 1);
+    failed |= expect_int_eq("u8 odd-carry retains final byte", u8_carry_valid, 1);
+    failed |= expect_int_eq("u8 odd-carry byte preserved", (int)u8_carry_byte, 126);
+
+    uint64_t u8_drops = 0U;
+    uint64_t full_events = 0U;
+    int full_status = -1;
+    rc = rtl_device_test_u8_full_ring_drop(&u8_used, &u8_drops, &full_events, &u8_phase, &full_status);
+    failed |= expect_int_eq("u8 full-ring helper rc", rc, 0);
+    failed |= expect_int_eq("u8 full-ring reports exhaustion", full_status, 1);
+    failed |= expect_size_eq("u8 full-ring keeps one pair", u8_used, 2U);
+    failed |= expect_size_eq("u8 full-ring drops aligned remainder", (size_t)u8_drops, 4U);
+    failed |= expect_size_eq("u8 full-ring counts reserve exhaustion", (size_t)full_events, 1U);
+    failed |= expect_int_eq("u8 full-ring advances phase over committed and dropped pairs", u8_phase, 3);
+
+    int stale_dev_carry_valid = -1;
+    int stale_local_carry_valid = -1;
+    rc = rtl_device_test_u8_generation_stale_drop(&u8_drops, &u8_phase, &stale_dev_carry_valid,
+                                                  &stale_local_carry_valid, &full_status);
+    failed |= expect_int_eq("u8 stale-generation helper rc", rc, 0);
+    failed |= expect_int_eq("u8 stale-generation reports stale", full_status, 1);
+    failed |= expect_size_eq("u8 stale-generation drops produced and aligned remainder", (size_t)u8_drops, 6U);
+    failed |= expect_int_eq("u8 stale-generation advances phase over aligned remainder", u8_phase, 1);
+    failed |= expect_int_eq("u8 stale-generation clears device carry", stale_dev_carry_valid, 0);
+    failed |= expect_int_eq("u8 stale-generation clears local carry", stale_local_carry_valid, 0);
+
+    /*
+     * Miscellaneous RTL helper contracts are pure formatting/alignment rules:
+     * tuner-type labels stay stable, capture event reasons are bounded, Soapy
+     * setting text is trimmed, and rtl_tcp buffers are page-aligned upward.
+     */
+    char tuner_labels[96] = {};
+    char reason_small[8] = {};
+    char reason_null[4] = {'x', 'x', 'x', '\0'};
+    char trimmed[32] = {};
+    size_t rounded_pages[4] = {};
+    rc = rtl_device_test_misc_string_helpers(tuner_labels, sizeof(tuner_labels), reason_small, sizeof(reason_small),
+                                             reason_null, sizeof(reason_null), trimmed, sizeof(trimmed), rounded_pages,
+                                             sizeof(rounded_pages) / sizeof(rounded_pages[0]));
+    failed |= expect_int_eq("rtl misc string helper rc", rc, 0);
+    if (std::strcmp(tuner_labels, "E4000|FC0012|FC0013|FC2580|R820T|R828D|unknown") != 0) {
+        DSD_FPRINTF(stderr, "FAIL: tuner labels got='%s'\n", tuner_labels);
+        failed = 1;
+    }
+    if (std::strcmp(reason_small, "capture") != 0) {
+        DSD_FPRINTF(stderr, "FAIL: truncated reason got='%s'\n", reason_small);
+        failed = 1;
+    }
+    if (std::strcmp(reason_null, "") != 0) {
+        DSD_FPRINTF(stderr, "FAIL: null reason got='%s'\n", reason_null);
+        failed = 1;
+    }
+    if (std::strcmp(trimmed, "gain = 12.5") != 0) {
+        DSD_FPRINTF(stderr, "FAIL: trimmed setting got='%s'\n", trimmed);
+        failed = 1;
+    }
+    failed |= expect_size_eq("round zero page", rounded_pages[0], 0U);
+    failed |= expect_size_eq("round one page", rounded_pages[1], 4096U);
+    failed |= expect_size_eq("round exact page", rounded_pages[2], 4096U);
+    failed |= expect_size_eq("round next page", rounded_pages[3], 8192U);
+    failed |= expect_int_eq("rtl misc helper rejects short arrays",
+                            rtl_device_test_misc_string_helpers(tuner_labels, sizeof(tuner_labels), reason_small,
+                                                                sizeof(reason_small), reason_null, sizeof(reason_null),
+                                                                trimmed, sizeof(trimmed), rounded_pages, 3U),
+                            -1);
+
+    size_t tcp_bufsz[8] = {};
+    int tcp_waitall[4] = {};
+    uint64_t tcp_deltas[2] = {};
+    int agc_want = -1;
+    rc = rtl_device_test_tcp_policy_helpers(tcp_bufsz, sizeof(tcp_bufsz) / sizeof(tcp_bufsz[0]), tcp_waitall,
+                                            sizeof(tcp_waitall) / sizeof(tcp_waitall[0]), tcp_deltas,
+                                            sizeof(tcp_deltas) / sizeof(tcp_deltas[0]), &agc_want);
+    failed |= expect_int_eq("rtl tcp policy helper rc", rc, 0);
+    failed |= expect_size_eq("rtl tcp null default buffer", tcp_bufsz[0], 65536U);
+    failed |= expect_size_eq("rtl tcp backend default buffer", tcp_bufsz[1], 16384U);
+    failed |= expect_size_eq("rtl usb zero-rate default buffer", tcp_bufsz[2], 65536U);
+    failed |= expect_size_eq("rtl low-rate minimum buffer", tcp_bufsz[3], 16384U);
+    failed |= expect_size_eq("rtl rate-scaled buffer", tcp_bufsz[4], 38400U);
+    failed |= expect_size_eq("rtl high-rate capped buffer", tcp_bufsz[5], 262144U);
+    failed |= expect_size_eq("rtl config buffer override", tcp_bufsz[6], 12345U);
+    failed |= expect_size_eq("rtl invalid config buffer falls back", tcp_bufsz[7], 262144U);
+    failed |= expect_int_eq("rtl null waitall default", tcp_waitall[0], 1);
+    failed |= expect_int_eq("rtl tcp waitall default", tcp_waitall[1], 0);
+    failed |= expect_int_eq("rtl waitall explicit enable", tcp_waitall[2], 1);
+    failed |= expect_int_eq("rtl waitall explicit disable", tcp_waitall[3], 0);
+    failed |= expect_size_eq("rtl counter delta monotonic", (size_t)tcp_deltas[0], 60U);
+    failed |= expect_size_eq("rtl counter delta clamps wrap/reorder", (size_t)tcp_deltas[1], 0U);
+    failed |= expect_int_eq("rtl default agc config", agc_want, 1);
+
+    failed |= expect_int_eq("rtl tcp policy helper rejects short buffers",
+                            rtl_device_test_tcp_policy_helpers(tcp_bufsz, 7U, tcp_waitall,
+                                                               sizeof(tcp_waitall) / sizeof(tcp_waitall[0]), tcp_deltas,
+                                                               sizeof(tcp_deltas) / sizeof(tcp_deltas[0]), &agc_want),
+                            -1);
 
     return failed ? 1 : 0;
 }

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -454,6 +454,22 @@ main(void) {
     failed |= expect_int_eq("manual gain value still applied", gain_calls, 1);
     failed |= expect_int_eq("manual gain records AGC failure", recorded_agc_rc, -5);
 
+    rc =
+        rtl_device_test_usb_manual_gain_controls(0, -8, 0, &agc_calls, &gain_mode_calls, &gain_calls, &recorded_agc_rc);
+    failed |= expect_int_eq("manual gain mode failure remains fatal", rc, -8);
+    failed |= expect_int_eq("manual gain mode failure AGC call count", agc_calls, 1);
+    failed |= expect_int_eq("manual gain mode failure call count", gain_mode_calls, 1);
+    failed |= expect_int_eq("manual gain skips value after mode failure", gain_calls, 0);
+    failed |= expect_int_eq("manual gain mode failure records no AGC failure", recorded_agc_rc, 0);
+
+    rc =
+        rtl_device_test_usb_manual_gain_controls(0, 0, -9, &agc_calls, &gain_mode_calls, &gain_calls, &recorded_agc_rc);
+    failed |= expect_int_eq("manual gain value failure remains fatal", rc, -9);
+    failed |= expect_int_eq("manual gain value failure AGC call count", agc_calls, 1);
+    failed |= expect_int_eq("manual gain value failure mode call count", gain_mode_calls, 1);
+    failed |= expect_int_eq("manual gain value failure call count", gain_calls, 1);
+    failed |= expect_int_eq("manual gain value failure records no AGC failure", recorded_agc_rc, 0);
+
     rc = rtl_device_test_usb_auto_gain_controls(-6, 0, &agc_calls, &gain_mode_calls, &recorded_agc_rc);
     failed |= expect_int_eq("auto gain ignores AGC failure rc", rc, 0);
     failed |= expect_int_eq("auto gain AGC call count", agc_calls, 1);

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -572,6 +572,18 @@ main(void) {
     failed |= expect_int_eq("replay CF32 source", input_level_source, DSD_INPUT_LEVEL_SOURCE_SOAPY_CF32);
     failed |= expect_size_eq("replay CF32 sample count", (size_t)input_level_count, 4U);
 
+    rc = rtl_device_test_replay_input_level_snapshot(DSD_IQ_FORMAT_CS16, rtl_test_backend_usb, "", 8U, 0U,
+                                                     &input_level_rc, &input_level_source, &input_level_count);
+    failed |= expect_int_eq("replay CS16 snapshot helper rc", rc, 0);
+    failed |= expect_int_eq("replay CS16 snapshot rc", input_level_rc, 0);
+    failed |= expect_int_eq("replay CS16 source", input_level_source, DSD_INPUT_LEVEL_SOURCE_SOAPY_CS16);
+    failed |= expect_size_eq("replay CS16 sample count", (size_t)input_level_count, 4U);
+
+    rc = rtl_device_test_replay_input_level_snapshot(DSD_IQ_FORMAT_CS16, rtl_test_backend_usb, "", 6U, 0U,
+                                                     &input_level_rc, &input_level_source, &input_level_count);
+    failed |= expect_int_eq("replay CS16 rejects misaligned helper rc", rc, 0);
+    failed |= expect_int_eq("replay CS16 rejects misaligned bytes", input_level_rc, -1);
+
     rc = rtl_device_test_replay_input_level_snapshot(DSD_IQ_FORMAT_CF32, rtl_test_backend_usb, "pre_ring", 16U, 4U,
                                                      &input_level_rc, &input_level_source, &input_level_count);
     failed |= expect_int_eq("replay CF32 rejects wrong stage helper rc", rc, 0);

--- a/tests/io/test_io_rtl_stream_orchestrator.cpp
+++ b/tests/io/test_io_rtl_stream_orchestrator.cpp
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <cstdio>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/io/rtl_stream.h>
+#include <memory>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+namespace {
+struct StubState {
+    int open_rc;
+    int tune_rc;
+    int read_rc;
+    unsigned int output_rate;
+    int requested_ppm;
+    int open_calls;
+    int soft_stop_calls;
+    int tune_calls;
+    int read_calls;
+    int request_calls;
+    int adjust_calls;
+    int register_calls;
+    int unregister_calls;
+    dsd_opts* last_open_opts;
+    dsd_opts* last_registered_active;
+    dsd_opts* last_registered_caller;
+    dsd_opts* last_unregistered_active;
+    dsd_opts* last_unregistered_caller;
+    long int last_tune_hz;
+    size_t last_read_count;
+};
+
+static StubState g_stub;
+
+static void
+reset_stubs(void) {
+    g_stub = {};
+    g_stub.output_rate = 48000U;
+}
+
+static std::unique_ptr<dsd_opts>
+make_opts(int ppm = 0) {
+    std::unique_ptr<dsd_opts> opts = std::make_unique<dsd_opts>();
+    *opts = {};
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->rtlsdr_ppm_error = ppm;
+    return opts;
+}
+
+static int
+expect_int_eq(const char* label, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got=%d want=%d\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_uint_eq(const char* label, unsigned int got, unsigned int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got=%u want=%u\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_ptr_eq(const char* label, const void* got, const void* want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got=%p want=%p\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_ptr_ne(const char* label, const void* got, const void* not_want) {
+    if (got == not_want) {
+        DSD_FPRINTF(stderr, "%s: unexpected pointer=%p\n", label, got);
+        return 1;
+    }
+    return 0;
+}
+} // namespace
+
+extern "C" int
+dsd_rtl_stream_open(dsd_opts* opts) {
+    g_stub.open_calls++;
+    g_stub.last_open_opts = opts;
+    return g_stub.open_rc;
+}
+
+extern "C" void
+dsd_rtl_stream_close(void) {}
+
+extern "C" int
+dsd_rtl_stream_read(float* out, size_t count, dsd_opts* opts, const dsd_state* state) {
+    (void)out;
+    (void)state;
+    g_stub.read_calls++;
+    g_stub.last_open_opts = opts;
+    g_stub.last_read_count = count;
+    return g_stub.read_rc;
+}
+
+extern "C" int
+dsd_rtl_stream_tune(dsd_opts* opts, long int frequency) {
+    g_stub.tune_calls++;
+    g_stub.last_open_opts = opts;
+    g_stub.last_tune_hz = frequency;
+    return g_stub.tune_rc;
+}
+
+extern "C" unsigned int
+dsd_rtl_stream_output_rate(void) {
+    return g_stub.output_rate;
+}
+
+extern "C" int
+dsd_rtl_stream_soft_stop(void) {
+    g_stub.soft_stop_calls++;
+    return 0;
+}
+
+extern "C" int
+rtl_stream_request_ppm(dsd_opts* opts, int ppm) {
+    g_stub.request_calls++;
+    if (!opts) {
+        return -1;
+    }
+    opts->rtlsdr_ppm_error = ppm;
+    g_stub.requested_ppm = ppm;
+    return 0;
+}
+
+extern "C" int
+rtl_stream_adjust_ppm(dsd_opts* opts, int delta) {
+    g_stub.adjust_calls++;
+    if (!opts) {
+        return -1;
+    }
+    opts->rtlsdr_ppm_error += delta;
+    g_stub.requested_ppm = opts->rtlsdr_ppm_error;
+    return 0;
+}
+
+extern "C" int
+rtl_stream_get_requested_ppm(const dsd_opts* opts) {
+    return opts ? opts->rtlsdr_ppm_error : 0;
+}
+
+extern "C" void
+dsd_rtl_stream_register_requested_ppm_opts(dsd_opts* active_opts, dsd_opts* caller_opts) {
+    g_stub.register_calls++;
+    g_stub.last_registered_active = active_opts;
+    g_stub.last_registered_caller = caller_opts;
+}
+
+extern "C" void
+dsd_rtl_stream_unregister_requested_ppm_opts(dsd_opts* active_opts, dsd_opts* caller_opts) {
+    g_stub.unregister_calls++;
+    g_stub.last_unregistered_active = active_opts;
+    g_stub.last_unregistered_caller = caller_opts;
+}
+
+static int
+test_constructor_snapshots_and_registers_opts(void) {
+    reset_stubs();
+    std::unique_ptr<dsd_opts> caller = make_opts(7);
+
+    int rc = 0;
+    {
+        RtlSdrOrchestrator stream(*caller, caller.get());
+        caller->rtlsdr_ppm_error = 99;
+        rc |= expect_int_eq("constructor registers active opts", g_stub.register_calls, 1);
+        rc |= expect_ptr_ne("constructor copies opts", g_stub.last_registered_active, caller.get());
+        rc |= expect_ptr_eq("constructor records caller opts", g_stub.last_registered_caller, caller.get());
+        rc |= expect_int_eq("active snapshot preserves original ppm", stream.requested_ppm(), 7);
+    }
+    rc |= expect_int_eq("destructor unregisters active opts", g_stub.unregister_calls, 1);
+    rc |= expect_ptr_eq("destructor unregisters same active opts", g_stub.last_unregistered_active,
+                        g_stub.last_registered_active);
+    rc |= expect_ptr_eq("destructor unregisters caller opts", g_stub.last_unregistered_caller, caller.get());
+    return rc;
+}
+
+static int
+test_start_stop_and_destructor_lifecycle(void) {
+    reset_stubs();
+    std::unique_ptr<dsd_opts> opts = make_opts();
+
+    int rc = 0;
+    {
+        RtlSdrOrchestrator stream(*opts);
+        rc |= expect_int_eq("start succeeds", stream.start(), 0);
+        rc |= expect_int_eq("start calls open once", g_stub.open_calls, 1);
+        rc |= expect_int_eq("second start is no-op", stream.start(), 0);
+        rc |= expect_int_eq("second start keeps open count", g_stub.open_calls, 1);
+        rc |= expect_uint_eq("output rate delegates to legacy helper", RtlSdrOrchestrator::output_rate(), 48000U);
+        rc |= expect_int_eq("stop succeeds", stream.stop(), 0);
+        rc |= expect_int_eq("stop uses soft stop", g_stub.soft_stop_calls, 1);
+        rc |= expect_int_eq("second stop is no-op", stream.stop(), 0);
+        rc |= expect_int_eq("second stop keeps soft stop count", g_stub.soft_stop_calls, 1);
+    }
+    rc |= expect_int_eq("destructor does not stop already stopped stream", g_stub.soft_stop_calls, 1);
+
+    reset_stubs();
+    opts = make_opts();
+    {
+        RtlSdrOrchestrator stream(*opts);
+        rc |= expect_int_eq("start succeeds before destructor", stream.start(), 0);
+    }
+    rc |= expect_int_eq("destructor stops active stream", g_stub.soft_stop_calls, 1);
+    return rc;
+}
+
+static int
+test_start_failure_and_prestart_errors(void) {
+    reset_stubs();
+    g_stub.open_rc = -7;
+    std::unique_ptr<dsd_opts> opts = make_opts();
+    RtlSdrOrchestrator stream(*opts);
+
+    int rc = 0;
+    rc |= expect_int_eq("start propagates open failure", stream.start(), -7);
+    rc |= expect_int_eq("failed start records last error", stream.last_error_code(), -7);
+    rc |= expect_int_eq("failed start does not soft stop", g_stub.soft_stop_calls, 0);
+    rc |= expect_int_eq("prestart tune rejected", stream.tune(851000000U), -1);
+    rc |= expect_int_eq("prestart tune does not call legacy tune", g_stub.tune_calls, 0);
+
+    float sample = 0.0f;
+    int got = 123;
+    rc |= expect_int_eq("prestart read rejected", stream.read(&sample, 1U, got), -1);
+    rc |= expect_int_eq("prestart read leaves got unchanged", got, 123);
+    rc |= expect_int_eq("prestart read does not call legacy read", g_stub.read_calls, 0);
+    return rc;
+}
+
+static int
+test_tune_read_and_ppm_error_propagation(void) {
+    reset_stubs();
+    std::unique_ptr<dsd_opts> opts = make_opts(3);
+    RtlSdrOrchestrator stream(*opts);
+
+    int rc = 0;
+    rc |= expect_int_eq("start succeeds", stream.start(), 0);
+    g_stub.tune_rc = -5;
+    rc |= expect_int_eq("tune propagates failure", stream.tune(851012500U), -5);
+    rc |= expect_int_eq("tune records failure", stream.last_error_code(), -5);
+    rc |= expect_int_eq("tune records frequency", (int)g_stub.last_tune_hz, 851012500);
+    g_stub.tune_rc = 0;
+    rc |= expect_int_eq("tune success clears last error", stream.tune(851025000U), 0);
+    rc |= expect_int_eq("tune success last error", stream.last_error_code(), 0);
+
+    float samples[4] = {};
+    int got = 0;
+    g_stub.read_rc = 3;
+    rc |= expect_int_eq("read success", stream.read(samples, 4U, got), 0);
+    rc |= expect_int_eq("read returns got count", got, 3);
+    rc |= expect_int_eq("read records count", (int)g_stub.last_read_count, 4);
+    g_stub.read_rc = -9;
+    rc |= expect_int_eq("read propagates failure", stream.read(samples, 4U, got), -9);
+    rc |= expect_int_eq("read failure last error", stream.last_error_code(), -9);
+
+    rc |= expect_int_eq("request ppm delegates", stream.request_ppm(-4), 0);
+    rc |= expect_int_eq("request ppm call count", g_stub.request_calls, 1);
+    rc |= expect_int_eq("request ppm updates active snapshot", stream.requested_ppm(), -4);
+    rc |= expect_int_eq("adjust ppm delegates", stream.adjust_ppm(6), 0);
+    rc |= expect_int_eq("adjust ppm call count", g_stub.adjust_calls, 1);
+    rc |= expect_int_eq("adjust ppm updates active snapshot", stream.requested_ppm(), 2);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_constructor_snapshots_and_registers_opts();
+    rc |= test_start_stop_and_destructor_lifecycle();
+    rc |= test_start_failure_and_prestart_errors();
+    rc |= test_tune_read_and_ppm_error_propagation();
+    return rc ? 1 : 0;
+}

--- a/tests/io/test_io_rtl_stream_ppm_sync.cpp
+++ b/tests/io/test_io_rtl_stream_ppm_sync.cpp
@@ -137,6 +137,58 @@ test_c_api_create_preserves_const_source_snapshot(void) {
     return rc;
 }
 
+static int
+test_c_api_lifecycle_rejects_invalid_inputs(void) {
+    std::unique_ptr<dsd_opts> opts = make_test_opts();
+    RtlSdrContext* ctx = nullptr;
+    float sample = 0.0f;
+    int got = 99;
+
+    int rc = 0;
+    rc |= expect_int_eq("create rejects null opts", rtl_stream_create(nullptr, &ctx), -1);
+    rc |= expect_int_eq("create rejects null out ctx", rtl_stream_create(opts.get(), nullptr), -1);
+    rc |= expect_int_eq("mirrored create rejects null opts", rtl_stream_create_mirrored(nullptr, &ctx), -1);
+    rc |= expect_int_eq("mirrored create rejects null out ctx", rtl_stream_create_mirrored(opts.get(), nullptr), -1);
+    rc |= expect_int_eq("destroy accepts null ctx", rtl_stream_destroy(nullptr), 0);
+    rc |= expect_int_eq("start rejects null ctx", rtl_stream_start(nullptr), -1);
+    rc |= expect_int_eq("stop rejects null ctx", rtl_stream_stop(nullptr), -1);
+    rc |= expect_int_eq("soft stop rejects null ctx", rtl_stream_soft_stop(nullptr), -1);
+    rc |= expect_int_eq("tune rejects null ctx", rtl_stream_tune(nullptr, 851000000U), -1);
+    rc |= expect_int_eq("read rejects null ctx", rtl_stream_read(nullptr, &sample, 1U, &got), -1);
+    rc |= expect_int_eq("monitor read rejects null ctx", rtl_stream_read_monitor(nullptr, &sample, 1U, &got), -1);
+    rc |= expect_int_eq("output rate rejects null ctx", (int)rtl_stream_output_rate(nullptr), 0);
+    rc |= expect_int_eq("monitor rate rejects null ctx", (int)rtl_stream_monitor_rate(nullptr), 0);
+    return rc;
+}
+
+static int
+test_c_api_stopped_context_contracts(void) {
+    std::unique_ptr<dsd_opts> opts = make_test_opts();
+    RtlSdrContext* ctx = nullptr;
+    float sample = 0.0f;
+    int got = 99;
+
+    int rc = 0;
+    rc |= expect_int_eq("stopped context create rc", rtl_stream_create(opts.get(), &ctx), 0);
+    if (!ctx) {
+        DSD_FPRINTF(stderr, "FAIL: stopped context create returned null ctx\n");
+        return 1;
+    }
+
+    rc |= expect_int_eq("stopped context stop is no-op", rtl_stream_stop(ctx), 0);
+    rc |= expect_int_eq("stopped context soft stop is no-op", rtl_stream_soft_stop(ctx), 0);
+    rc |= expect_int_eq("stopped context tune rejected", rtl_stream_tune(ctx, 851000000U), -1);
+    rc |= expect_int_eq("stopped context read rejected", rtl_stream_read(ctx, &sample, 1U, &got), -1);
+    rc |= expect_int_eq("stopped context read rejects null output", rtl_stream_read(ctx, nullptr, 1U, &got), -1);
+    rc |= expect_int_eq("stopped context read rejects null got", rtl_stream_read(ctx, &sample, 1U, nullptr), -1);
+    rc |= expect_int_eq("stopped context monitor read rejects null output",
+                        rtl_stream_read_monitor(ctx, nullptr, 1U, &got), -1);
+    rc |= expect_int_eq("stopped context monitor read rejects null got",
+                        rtl_stream_read_monitor(ctx, &sample, 1U, nullptr), -1);
+    rc |= expect_int_eq("stopped context destroy rc", rtl_stream_destroy(ctx), 0);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -145,5 +197,7 @@ main(void) {
     rc |= test_adjust_and_getter_use_active_snapshot_when_caller_is_stale();
     rc |= test_c_api_create_mirrored_updates_live_caller_opts();
     rc |= test_c_api_create_preserves_const_source_snapshot();
+    rc |= test_c_api_lifecycle_rejects_invalid_inputs();
+    rc |= test_c_api_stopped_context_contracts();
     return rc ? 1 : 0;
 }

--- a/tests/io/test_io_serial_control.c
+++ b/tests/io/test_io_serial_control.c
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Regression test: serial radio control must map configured baud rates,
+ * preserve the opened descriptor, and send the documented resume commands.
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/io/control.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/platform.h>
+#include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/runtime/log.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#if !DSD_PLATFORM_WIN_NATIVE
+#include <termios.h>
+#include <unistd.h>
+#endif
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if !DSD_PLATFORM_WIN_NATIVE
+static int g_open_result;
+static char g_open_path[128];
+static int g_tcsetattr_calls;
+static int g_tcsetattr_fd;
+static int g_tcsetattr_action;
+static struct termios g_last_tty;
+static int g_ospeed_calls;
+static int g_ispeed_calls;
+static speed_t g_last_ospeed;
+static speed_t g_last_ispeed;
+static int g_dsd_write_fd;
+static char g_dsd_write_buf[16];
+static size_t g_dsd_write_len;
+static ssize_t g_dsd_write_result;
+static int g_write_fd;
+static unsigned char g_write_buf[16];
+static size_t g_write_len;
+static ssize_t g_write_result;
+
+static void
+reset_stubs(void) {
+    g_open_result = -1;
+    DSD_MEMSET(g_open_path, 0, sizeof(g_open_path));
+    g_tcsetattr_calls = 0;
+    g_tcsetattr_fd = -1;
+    g_tcsetattr_action = -1;
+    DSD_MEMSET(&g_last_tty, 0, sizeof(g_last_tty));
+    g_ospeed_calls = 0;
+    g_ispeed_calls = 0;
+    g_last_ospeed = 0;
+    g_last_ispeed = 0;
+    g_dsd_write_fd = -1;
+    DSD_MEMSET(g_dsd_write_buf, 0, sizeof(g_dsd_write_buf));
+    g_dsd_write_len = 0;
+    g_dsd_write_result = 7;
+    g_write_fd = -1;
+    DSD_MEMSET(g_write_buf, 0, sizeof(g_write_buf));
+    g_write_len = 0;
+    g_write_result = 5;
+}
+
+int
+test_dsd_open_serial_write(const char* path) {
+    if (path) {
+        DSD_SNPRINTF(g_open_path, sizeof(g_open_path), "%s", path);
+    }
+    return g_open_result;
+}
+
+int
+test_tcsetattr(int fd, int optional_actions, const struct termios* termios_p) {
+    g_tcsetattr_calls++;
+    g_tcsetattr_fd = fd;
+    g_tcsetattr_action = optional_actions;
+    if (termios_p) {
+        g_last_tty = *termios_p;
+    }
+    return 0;
+}
+
+int
+test_cfsetospeed(struct termios* termios_p, speed_t speed) {
+    (void)termios_p;
+    g_ospeed_calls++;
+    g_last_ospeed = speed;
+    return 0;
+}
+
+int
+test_cfsetispeed(struct termios* termios_p, speed_t speed) {
+    (void)termios_p;
+    g_ispeed_calls++;
+    g_last_ispeed = speed;
+    return 0;
+}
+
+ssize_t
+test_dsd_write(int fd, const void* buf, size_t count) {
+    g_dsd_write_fd = fd;
+    g_dsd_write_len = count;
+    if (count <= sizeof(g_dsd_write_buf)) {
+        DSD_MEMCPY(g_dsd_write_buf, buf, count);
+    }
+    return g_dsd_write_result;
+}
+
+ssize_t
+test_write(int fd, const void* buf, size_t count) {
+    g_write_fd = fd;
+    g_write_len = count;
+    if (count <= sizeof(g_write_buf)) {
+        DSD_MEMCPY(g_write_buf, buf, count);
+    }
+    return g_write_result;
+}
+#endif
+
+void
+dsd_neo_log_write(dsd_neo_log_level_t level, const char* format, ...) {
+    (void)level;
+    (void)format;
+}
+
+#if !DSD_PLATFORM_WIN_NATIVE
+static int
+expect_open_failure_sets_fd_negative(void) {
+    reset_stubs();
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_SNPRINTF(opts.serial_dev, sizeof(opts.serial_dev), "%s", "/dev/test-radio");
+    opts.serial_baud = 9600;
+    opts.serial_fd = 77;
+
+    openSerial(&opts, &state);
+    if (opts.serial_fd != -1 || strcmp(g_open_path, "/dev/test-radio") != 0 || g_tcsetattr_calls != 0) {
+        DSD_FPRINTF(stderr, "open failure did not leave serial fd negative without termios\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_open_success_maps_baud(int baud, speed_t expected_speed, int expect_speed_calls) {
+    reset_stubs();
+    g_open_result = 42;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_SNPRINTF(opts.serial_dev, sizeof(opts.serial_dev), "%s", "/dev/test-radio");
+    opts.serial_baud = baud;
+
+    openSerial(&opts, &state);
+    if (opts.serial_fd != 42 || g_tcsetattr_calls != 1 || g_tcsetattr_fd != 42 || g_tcsetattr_action != TCSANOW) {
+        DSD_FPRINTF(stderr, "open success did not configure expected descriptor\n");
+        return 1;
+    }
+    if (g_ospeed_calls != expect_speed_calls || g_ispeed_calls != expect_speed_calls) {
+        DSD_FPRINTF(stderr, "unexpected speed call counts for baud %d\n", baud);
+        return 1;
+    }
+    if (expect_speed_calls && (g_last_ospeed != expected_speed || g_last_ispeed != expected_speed)) {
+        DSD_FPRINTF(stderr, "unexpected speed selected for baud %d\n", baud);
+        return 1;
+    }
+    if ((g_last_tty.c_cflag & CSIZE) != CS8 || (g_last_tty.c_cflag & (PARENB | PARODD | CSTOPB | CRTSCTS)) != 0
+        || (g_last_tty.c_iflag & (IXON | IXOFF | IXANY)) != 0 || g_last_tty.c_lflag != 0 || g_last_tty.c_oflag != 0
+        || g_last_tty.c_cc[VMIN] != 1 || g_last_tty.c_cc[VTIME] != 5) {
+        DSD_FPRINTF(stderr, "termios flags were not configured for 8N1 raw write\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_resume_scan_commands_and_reset(void) {
+    reset_stubs();
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.serial_fd = -1;
+    state.numtdulc = 9;
+    resumeScan(&opts, &state);
+    if (state.numtdulc != 9 || g_dsd_write_len != 0 || g_write_len != 0) {
+        DSD_FPRINTF(stderr, "invalid serial fd should not send resume commands\n");
+        return 1;
+    }
+
+    opts.serial_fd = 55;
+    state.numtdulc = 9;
+    resumeScan(&opts, &state);
+    const unsigned char expected_binary[] = {2, 75, 15, 3, 93};
+    if (state.numtdulc != 0 || g_dsd_write_fd != 55 || g_dsd_write_len != 7
+        || memcmp(g_dsd_write_buf, "\rKEY00\r", 7) != 0 || g_write_fd != 55 || g_write_len != sizeof(expected_binary)
+        || memcmp(g_write_buf, expected_binary, sizeof(expected_binary)) != 0) {
+        DSD_FPRINTF(stderr, "resumeScan did not send expected command sequence\n");
+        return 1;
+    }
+
+    reset_stubs();
+    g_dsd_write_result = 3;
+    g_write_result = 2;
+    opts.serial_fd = 56;
+    state.numtdulc = 7;
+    resumeScan(&opts, &state);
+    if (state.numtdulc != 0 || g_dsd_write_len != 7 || g_write_len != 5) {
+        DSD_FPRINTF(stderr, "partial write path did not attempt both commands and reset state\n");
+        return 1;
+    }
+    return 0;
+}
+#endif
+
+int
+main(void) {
+#if DSD_PLATFORM_WIN_NATIVE
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.serial_fd = 77;
+    state.numtdulc = 5;
+    openSerial(&opts, &state);
+    if (opts.serial_fd != -1) {
+        return 1;
+    }
+    resumeScan(&opts, &state);
+    return state.numtdulc == 0 ? 0 : 1;
+#else
+    int rc = 0;
+    rc |= expect_open_failure_sets_fd_negative();
+    rc |= expect_open_success_maps_baud(9600, B9600, 1);
+    rc |= expect_open_success_maps_baud(230400, B230400, 1);
+    rc |= expect_open_success_maps_baud(12345, B115200, 1);
+    rc |= expect_open_success_maps_baud(0, 0, 0);
+    rc |= expect_resume_scan_commands_and_reset();
+    return rc;
+#endif
+}

--- a/tests/io/test_io_soapy_profile.cpp
+++ b/tests/io/test_io_soapy_profile.cpp
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -17,6 +20,7 @@ using dsdneo::SoapyProfileSelection;
 using dsdneo::SoapyRange;
 using dsdneo::SoapySettingScope;
 using dsdneo::SoapySettingValueType;
+using dsdneo::SoapyStreamFormat;
 
 static_assert(offsetof(struct rtl_soapy_config, profile) < offsetof(struct rtl_soapy_config, antenna),
               "rtl_soapy_config legacy field order changed");
@@ -60,6 +64,15 @@ expect_string(const char* label, const std::string& got, const char* want) {
 }
 
 static int
+expect_cstr(const char* label, const char* got, const char* want) {
+    if (std::string(got ? got : "") != want) {
+        DSD_FPRINTF(stderr, "%s: got \"%s\" want \"%s\"\n", label, got ? got : "(null)", want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 expect_scope(const char* label, SoapySettingScope got, SoapySettingScope want) {
     if (got != want) {
         DSD_FPRINTF(stderr, "%s: got scope=%d want=%d\n", label, (int)got, (int)want);
@@ -96,8 +109,23 @@ test_profile_selection(void) {
     rc |= expect_profile("airspy driver", {"", "airspy", "", ""}, SoapyProfileId::Airspy);
     rc |= expect_profile("sdrplay args", {"", "", "", "driver=sdrplay,serial=123"}, SoapyProfileId::Sdrplay);
     rc |= expect_profile("hackrf hardware", {"", "", "HackRF One", ""}, SoapyProfileId::Hackrf);
+    rc |= expect_profile("lime driver", {"", "lime", "", ""}, SoapyProfileId::Lime);
+    rc |= expect_profile("pluto hardware", {"", "", "AD9363", ""}, SoapyProfileId::Pluto);
+    rc |= expect_profile("rtlsdr args", {"", "", "", "driver=rtl_sdr"}, SoapyProfileId::Rtlsdr);
+    rc |= expect_profile("uhd hardware", {"", "", "USRP B200", ""}, SoapyProfileId::Uhd);
     rc |= expect_profile("requested overrides auto", {"generic", "airspy", "", ""}, SoapyProfileId::Generic);
+    rc |= expect_profile("requested alias rtl", {"rtl", "", "", ""}, SoapyProfileId::Rtlsdr);
+    rc |= expect_profile("requested alias usrp", {"usrp", "", "", ""}, SoapyProfileId::Uhd);
+    rc |= expect_profile("requested alias sdr-play", {"sdr-play", "", "", ""}, SoapyProfileId::Sdrplay);
     rc |= expect_profile("unknown falls back generic", {"", "custom", "unknown", ""}, SoapyProfileId::Generic);
+
+    SoapyProfileId parsed = SoapyProfileId::Generic;
+    rc |= expect_true("empty profile parses auto", dsdneo::soapy_profile_parse_name("", &parsed));
+    rc |= expect_true("empty profile returns auto", parsed == SoapyProfileId::Auto);
+    rc |= expect_true("profile parse rejects null out", !dsdneo::soapy_profile_parse_name("airspy", nullptr));
+    rc |= expect_true("profile parse rejects unknown", !dsdneo::soapy_profile_parse_name("mystery", &parsed));
+    rc |= expect_cstr("invalid profile id falls back generic", dsdneo::soapy_profile_by_id((SoapyProfileId)255).name,
+                      "generic");
     return rc;
 }
 
@@ -123,8 +151,21 @@ test_stream_format_selection(void) {
     std::vector<std::string> both = {"CS16", "CF32"};
     rc |= expect_string("native supported wins", dsdneo::soapy_choose_stream_format(both, "", "CS16"), "CS16");
     rc |= expect_string("forced cf32", dsdneo::soapy_choose_stream_format(both, "cf32", "CS16"), "CF32");
+    rc |= expect_string("forced cs16", dsdneo::soapy_choose_stream_format(both, "cs16", "CF32"), "CS16");
     rc |= expect_string("auto cf32 fallback", dsdneo::soapy_choose_stream_format({"CF32"}, "auto", ""), "CF32");
+    rc |= expect_string("auto cs16 fallback", dsdneo::soapy_choose_stream_format({"CS16"}, "auto", ""), "CS16");
     rc |= expect_string("unsupported forced format", dsdneo::soapy_choose_stream_format({"CS16"}, "cf32", ""), "");
+    rc |= expect_string("unknown forced format", dsdneo::soapy_choose_stream_format(both, "cu8", ""), "");
+    rc |= expect_string("no supported formats", dsdneo::soapy_choose_stream_format({}, "", "CS16"), "");
+
+    SoapyStreamFormat format = SoapyStreamFormat::CF32;
+    rc |= expect_true("empty stream format parses auto", dsdneo::soapy_stream_format_parse_name("", &format));
+    rc |= expect_true("empty stream format returns auto", format == SoapyStreamFormat::Auto);
+    rc |= expect_true("stream format rejects null out", !dsdneo::soapy_stream_format_parse_name("CF32", nullptr));
+    rc |= expect_true("stream format rejects unknown", !dsdneo::soapy_stream_format_parse_name("cu8", &format));
+    rc |= expect_cstr("stream format name cf32", dsdneo::soapy_stream_format_name(SoapyStreamFormat::CF32), "CF32");
+    rc |= expect_cstr("stream format name cs16", dsdneo::soapy_stream_format_name(SoapyStreamFormat::CS16), "CS16");
+    rc |= expect_cstr("stream format name default", dsdneo::soapy_stream_format_name((SoapyStreamFormat)255), "auto");
     return rc;
 }
 
@@ -138,11 +179,40 @@ test_range_selection(void) {
     rc |= expect_true("inside supported", supported);
     rc |= expect_double("between ranges", dsdneo::soapy_nearest_in_ranges(1200000.0, ranges, &supported), 1000000.0);
     rc |= expect_double("above ranges", dsdneo::soapy_nearest_in_ranges(4000000.0, ranges, &supported), 3000000.0);
+    rc |= expect_double("empty ranges preserve request", dsdneo::soapy_nearest_in_ranges(123.0, {}, &supported), 123.0);
+    rc |= expect_true("empty ranges unsupported", !supported);
+    rc |= expect_double("invalid ranges preserve request",
+                        dsdneo::soapy_nearest_in_ranges(123.0, {{10.0, 1.0, 1.0}}, &supported), 123.0);
+    rc |= expect_true("invalid ranges unsupported", !supported);
 
     bool adjusted = false;
     rc |= expect_double("listed sample rate",
                         dsdneo::soapy_nearest_sample_rate(768000.0, {1000000.0, 2500000.0}, {}, &adjusted), 1000000.0);
     rc |= expect_true("listed sample rate adjusted", adjusted);
+    rc |= expect_double("nonpositive sample rate preserved",
+                        dsdneo::soapy_nearest_sample_rate(0.0, {1000000.0}, ranges, &adjusted), 0.0);
+    rc |= expect_true("nonpositive sample rate not adjusted", !adjusted);
+    rc |= expect_double("range sample rate", dsdneo::soapy_nearest_sample_rate(1200000.0, {}, ranges, &adjusted),
+                        1000000.0);
+    rc |= expect_true("range sample rate adjusted", adjusted);
+    rc |= expect_double("no rate ranges preserves request", dsdneo::soapy_nearest_sample_rate(123.0, {}, {}, &adjusted),
+                        123.0);
+    rc |= expect_true("no rate ranges not adjusted", !adjusted);
+
+    rc |= expect_true("name list contains exact value", dsdneo::soapy_name_list_contains({"CF32", "CS16"}, "CS16"));
+    rc |= expect_true("name list misses case mismatch", !dsdneo::soapy_name_list_contains({"CF32"}, "cf32"));
+    return rc;
+}
+
+static int
+test_join_and_scope_names(void) {
+    int rc = 0;
+    rc |= expect_string("join empty", dsdneo::soapy_join_names({}, 0), "-");
+    rc |= expect_string("join unlimited", dsdneo::soapy_join_names({"CF32", "CS16"}, 0), "CF32,CS16");
+    rc |= expect_string("join truncated", dsdneo::soapy_join_names({"CF32", "CS16", "CU8"}, 8), "CF32,...");
+    rc |= expect_cstr("device scope name", dsdneo::soapy_setting_scope_name(SoapySettingScope::Device), "device");
+    rc |= expect_cstr("rx0 scope name", dsdneo::soapy_setting_scope_name(SoapySettingScope::Rx0), "rx0");
+    rc |= expect_cstr("default scope name", dsdneo::soapy_setting_scope_name((SoapySettingScope)255), "device");
     return rc;
 }
 
@@ -168,6 +238,10 @@ test_settings_parser_accepts_device_and_rx_scopes(void) {
     rc |= expect_scope("rx0 setting scope", settings[2].scope, SoapySettingScope::Rx0);
     rc |= expect_string("rx0 setting key", settings[2].key, "rfgain_sel");
     rc |= expect_string("rx0 setting value", settings[2].value, "4");
+
+    error = "stale";
+    rc |= expect_true("blank settings parse without outputs", dsdneo::soapy_parse_settings("   ", nullptr, &error));
+    rc |= expect_true("blank settings clears error", error.empty());
     return rc;
 }
 
@@ -247,8 +321,11 @@ main(void) {
     rc |= test_bandwidth_selection();
     rc |= test_stream_format_selection();
     rc |= test_range_selection();
+    rc |= test_join_and_scope_names();
     rc |= test_settings_parser_accepts_device_and_rx_scopes();
     rc |= test_settings_parser_rejects_invalid_items();
     rc |= test_setting_value_validation();
     return rc;
 }
+
+// NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange)

--- a/tests/io/test_io_tcp_input.c
+++ b/tests/io/test_io_tcp_input.c
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Regression test: TCP PCM input must preserve the caller-owned descriptor,
+ * read raw little-endian PCM16 samples, and invalidate itself at EOF.
+ */
+
+#include <dsd-neo/io/tcp_input.h>
+#include <dsd-neo/platform/platform.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/platform/sockets.h"
+
+#if !DSD_PLATFORM_WIN_NATIVE
+#include <stdlib.h>
+#include <unistd.h>
+#endif
+
+#if !DSD_PLATFORM_WIN_NATIVE
+static int
+write_all(int fd, const uint8_t* bytes, size_t len) {
+    size_t off = 0;
+    while (off < len) {
+        ssize_t n = write(fd, bytes + off, len - off);
+        if (n <= 0) {
+            return -1;
+        }
+        off += (size_t)n;
+    }
+    return 0;
+}
+
+static int
+create_pcm_fixture(void) {
+    char path[] = "/tmp/dsd-neo-tcp-input-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) {
+        return -1;
+    }
+    (void)unlink(path);
+
+    const uint8_t pcm[] = {
+        0x34u, 0x12u, /*  4660 */
+        0x00u, 0x80u, /* -32768 */
+        0xFFu, 0x7Fu, /*  32767 */
+    };
+    if (write_all(fd, pcm, sizeof(pcm)) != 0 || lseek(fd, 0, SEEK_SET) != 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+#endif
+
+int
+main(void) {
+    if (tcp_input_open(DSD_INVALID_SOCKET, 48000) != NULL) {
+        DSD_FPRINTF(stderr, "tcp_input_open accepted an invalid descriptor\n");
+        return 1;
+    }
+    if (tcp_input_is_valid(NULL) != 0) {
+        DSD_FPRINTF(stderr, "NULL context reported valid\n");
+        return 1;
+    }
+    if (tcp_input_get_socket(NULL) != DSD_INVALID_SOCKET) {
+        DSD_FPRINTF(stderr, "NULL context returned a real descriptor\n");
+        return 1;
+    }
+    int16_t sample = 123;
+    if (tcp_input_read_sample(NULL, &sample) != 0 || sample != 123) {
+        DSD_FPRINTF(stderr, "NULL read changed output or reported success\n");
+        return 1;
+    }
+
+#if DSD_PLATFORM_WIN_NATIVE
+    DSD_FPRINTF(stderr, "tcp_input POSIX raw descriptor test skipped on native Windows\n");
+    return 0;
+#else
+    int fd = create_pcm_fixture();
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "failed to create PCM fixture\n");
+        return 1;
+    }
+
+    tcp_input_ctx* ctx = tcp_input_open((dsd_socket_t)fd, 48000);
+    if (!ctx) {
+        DSD_FPRINTF(stderr, "tcp_input_open failed for raw PCM descriptor\n");
+        close(fd);
+        return 1;
+    }
+    if (!tcp_input_is_valid(ctx)) {
+        DSD_FPRINTF(stderr, "new TCP input context was not valid\n");
+        tcp_input_close(ctx);
+        close(fd);
+        return 1;
+    }
+    if (tcp_input_get_socket(ctx) != (dsd_socket_t)fd) {
+        DSD_FPRINTF(stderr, "TCP input did not preserve caller descriptor\n");
+        tcp_input_close(ctx);
+        close(fd);
+        return 1;
+    }
+
+    const int16_t expected[] = {4660, INT16_MIN, INT16_MAX};
+    for (size_t i = 0; i < sizeof(expected) / sizeof(expected[0]); i++) {
+        sample = 0;
+        if (!tcp_input_read_sample(ctx, &sample)) {
+            DSD_FPRINTF(stderr, "read_sample failed at sample %zu\n", i);
+            tcp_input_close(ctx);
+            close(fd);
+            return 1;
+        }
+        if (sample != expected[i]) {
+            DSD_FPRINTF(stderr, "sample %zu mismatch: got %d expected %d\n", i, (int)sample, (int)expected[i]);
+            tcp_input_close(ctx);
+            close(fd);
+            return 1;
+        }
+    }
+
+    sample = 321;
+    if (tcp_input_read_sample(ctx, &sample) != 0) {
+        DSD_FPRINTF(stderr, "EOF read unexpectedly succeeded\n");
+        tcp_input_close(ctx);
+        close(fd);
+        return 1;
+    }
+    if (tcp_input_is_valid(ctx) != 0) {
+        DSD_FPRINTF(stderr, "EOF did not invalidate TCP input context\n");
+        tcp_input_close(ctx);
+        close(fd);
+        return 1;
+    }
+    if (tcp_input_read_sample(ctx, &sample) != 0) {
+        DSD_FPRINTF(stderr, "invalidated context read unexpectedly succeeded\n");
+        tcp_input_close(ctx);
+        close(fd);
+        return 1;
+    }
+
+    tcp_input_close(ctx);
+    if (lseek(fd, 0, SEEK_SET) != 0) {
+        DSD_FPRINTF(stderr, "tcp_input_close closed the caller-owned descriptor\n");
+        close(fd);
+        return 1;
+    }
+    close(fd);
+    return 0;
+#endif
+}

--- a/tests/io/test_io_udp_input.c
+++ b/tests/io/test_io_udp_input.c
@@ -23,6 +23,15 @@
 #include "dsd-neo/dsp/resampler.h"
 
 static int
+expect_int(const char* label, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 get_bound_port(dsd_socket_t sock) {
     struct sockaddr_in sa;
 #if DSD_PLATFORM_WIN_NATIVE
@@ -59,6 +68,37 @@ send_pcm16le(dsd_socket_t sock, const char* host, int port, const int16_t* sampl
     }
     int n = dsd_socket_sendto(sock, buf, nsamp * 2, 0, (struct sockaddr*)&dst, (int)sizeof(dst));
     return (n == (int)(nsamp * 2)) ? 0 : -1;
+}
+
+static dsd_socket_t
+bind_loopback_ephemeral(int* out_port) {
+    if (!out_port) {
+        return DSD_INVALID_SOCKET;
+    }
+    *out_port = -1;
+
+    dsd_socket_t sock = dsd_socket_create(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sock == DSD_INVALID_SOCKET) {
+        return DSD_INVALID_SOCKET;
+    }
+
+    struct sockaddr_in addr;
+    DSD_MEMSET(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = 0;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (dsd_socket_bind(sock, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+        dsd_socket_close(sock);
+        return DSD_INVALID_SOCKET;
+    }
+
+    int port = get_bound_port(sock);
+    if (port <= 0) {
+        dsd_socket_close(sock);
+        return DSD_INVALID_SOCKET;
+    }
+    *out_port = port;
+    return sock;
 }
 
 typedef struct reader_state {
@@ -137,6 +177,72 @@ input_stage_was_reset(const dsd_opts* opts) {
     return 1;
 }
 
+static int
+test_startup_contracts(void) {
+    int rc = 0;
+    int16_t sample = 0;
+    dsd_socket_t reserved = DSD_INVALID_SOCKET;
+
+    udp_input_stop(NULL);
+    rc |= expect_int("read rejects null opts", udp_input_read_sample(NULL, &sample), 0);
+
+    static dsd_opts invalid;
+    DSD_MEMSET(&invalid, 0, sizeof(invalid));
+    invalid.wav_sample_rate = 48000;
+    rc |= expect_int("read rejects missing context", udp_input_read_sample(&invalid, &sample), 0);
+    rc |= expect_int("read rejects null sample output", udp_input_read_sample(&invalid, NULL), 0);
+    rc |= expect_int("start rejects null opts", udp_input_start(NULL, "127.0.0.1", 0, 48000), -1);
+    rc |= expect_int("start rejects invalid bind address", udp_input_start(&invalid, "not-a-numeric-address", 0, 48000),
+                     -1);
+
+    int reserved_port = -1;
+    reserved = bind_loopback_ephemeral(&reserved_port);
+    if (reserved == DSD_INVALID_SOCKET) {
+        DSD_FPRINTF(stderr, "failed to reserve loopback UDP port for bind-failure contract\n");
+        return 1;
+    }
+    rc |= expect_int("start rejects already-bound UDP port",
+                     udp_input_start(&invalid, "127.0.0.1", reserved_port, 48000), -1);
+    dsd_socket_close(reserved);
+    reserved = DSD_INVALID_SOCKET;
+
+    static dsd_opts any;
+    DSD_MEMSET(&any, 0, sizeof(any));
+    any.wav_sample_rate = 48000;
+    if (udp_input_start(&any, "0.0.0.0", 0, 96000) != 0) {
+        DSD_FPRINTF(stderr, "start on INADDR_ANY failed\n");
+        rc = 1;
+    } else {
+        void* first_ctx = any.udp_in_ctx;
+        dsd_socket_t first_sock = any.udp_in_sockfd;
+        rc |= expect_int("already-started start is no-op", udp_input_start(&any, "127.0.0.1", 0, 48000), 0);
+        if (any.udp_in_ctx != first_ctx || any.udp_in_sockfd != first_sock) {
+            DSD_FPRINTF(stderr, "already-started start replaced UDP input context\n");
+            rc = 1;
+        }
+        rc |= expect_int("read rejects null output on active context", udp_input_read_sample(&any, NULL), 0);
+        exitflag = 1;
+        rc |= expect_int("read exits when shutdown flag is set", udp_input_read_sample(&any, &sample), 0);
+        exitflag = 0;
+        udp_input_stop(&any);
+    }
+
+    static dsd_opts loopback_default;
+    DSD_MEMSET(&loopback_default, 0, sizeof(loopback_default));
+    loopback_default.wav_sample_rate = 48000;
+    if (udp_input_start(&loopback_default, "", 0, 48000) != 0) {
+        DSD_FPRINTF(stderr, "start with empty bind address failed\n");
+        rc = 1;
+    } else {
+        udp_input_stop(&loopback_default);
+    }
+
+    if (reserved != DSD_INVALID_SOCKET) {
+        dsd_socket_close(reserved);
+    }
+    return rc;
+}
+
 int
 main(void) {
     exitflag = 0;
@@ -151,6 +257,10 @@ main(void) {
     dsd_thread_t th = (dsd_thread_t)0;
     int th_started = 0;
     int rs_inited = 0;
+
+    if (test_startup_contracts() != 0) {
+        goto cleanup;
+    }
 
     static dsd_opts opts;
     DSD_MEMSET(&opts, 0, sizeof(opts));

--- a/tests/io/test_io_udp_socket_backends.c
+++ b/tests/io/test_io_udp_socket_backends.c
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * UDP audio/M17 backend tests use socket stubs to verify setup, address
+ * selection, and send/receive behavior without a live network peer.
+ */
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/io/m17_udp.h>
+#include <dsd-neo/io/udp_audio.h>
+#include <dsd-neo/io/udp_bind.h>
+#include <dsd-neo/io/udp_socket_connect.h>
+#include <dsd-neo/platform/sockets.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/platform.h"
+
+#if !DSD_PLATFORM_WIN_NATIVE
+#include <netinet/in.h>
+#include <sys/socket.h>
+#endif
+
+static dsd_socket_t g_create_result;
+static int g_setsockopt_result;
+static int g_resolve_result;
+static int g_create_count;
+static int g_setsockopt_count;
+static int g_resolve_count;
+static int g_bind_result;
+static int g_bind_count;
+static int g_close_count;
+static int g_recv_timeout_result;
+static int g_recv_timeout_count;
+static unsigned int g_last_recv_timeout_ms;
+static char g_last_resolve_host[64];
+static int g_last_resolve_port;
+static uint32_t g_last_bind_addr;
+static int g_last_bind_port;
+static dsd_socket_t g_last_sendto_sock;
+static uint8_t g_last_sendto_data[32];
+static size_t g_last_sendto_len;
+static int g_sendto_result;
+static int g_recvfrom_result;
+static uint8_t g_recvfrom_payload[32];
+static size_t g_recvfrom_payload_len;
+
+static void
+reset_stubs(void) {
+    g_create_result = 11;
+    g_setsockopt_result = 0;
+    g_resolve_result = 0;
+    g_bind_result = 0;
+    g_recv_timeout_result = 0;
+    g_create_count = 0;
+    g_setsockopt_count = 0;
+    g_resolve_count = 0;
+    g_bind_count = 0;
+    g_close_count = 0;
+    g_recv_timeout_count = 0;
+    g_last_recv_timeout_ms = 0U;
+    DSD_MEMSET(g_last_resolve_host, 0, sizeof(g_last_resolve_host));
+    g_last_resolve_port = 0;
+    g_last_bind_addr = 0U;
+    g_last_bind_port = 0;
+    g_last_sendto_sock = DSD_INVALID_SOCKET;
+    DSD_MEMSET(g_last_sendto_data, 0, sizeof(g_last_sendto_data));
+    g_last_sendto_len = 0;
+    g_sendto_result = 0;
+    g_recvfrom_result = 0;
+    DSD_MEMSET(g_recvfrom_payload, 0, sizeof(g_recvfrom_payload));
+    g_recvfrom_payload_len = 0;
+}
+
+dsd_socket_t
+dsd_socket_create(int domain, int type, int protocol) {
+    (void)domain;
+    (void)type;
+    (void)protocol;
+    g_create_count++;
+    return g_create_result;
+}
+
+int
+dsd_socket_close(dsd_socket_t sock) {
+    (void)sock;
+    g_close_count++;
+    return 0;
+}
+
+int
+dsd_socket_bind(dsd_socket_t sock, const struct sockaddr* addr, int addrlen) {
+    (void)sock;
+    (void)addrlen;
+    g_bind_count++;
+    const struct sockaddr_in* in = (const struct sockaddr_in*)addr;
+    if (in) {
+        g_last_bind_addr = ntohl(in->sin_addr.s_addr);
+        g_last_bind_port = ntohs(in->sin_port);
+    }
+    return g_bind_result;
+}
+
+int
+dsd_socket_set_recv_timeout(dsd_socket_t sock, unsigned int timeout_ms) {
+    (void)sock;
+    g_recv_timeout_count++;
+    g_last_recv_timeout_ms = timeout_ms;
+    return g_recv_timeout_result;
+}
+
+int
+dsd_socket_setsockopt(dsd_socket_t sock, int level, int optname, const void* optval, int optlen) {
+    (void)sock;
+    (void)level;
+    (void)optname;
+    (void)optval;
+    (void)optlen;
+    g_setsockopt_count++;
+    return g_setsockopt_result;
+}
+
+int
+dsd_socket_resolve(const char* hostname, int port, struct sockaddr_in* addr) {
+    g_resolve_count++;
+    DSD_SNPRINTF(g_last_resolve_host, sizeof(g_last_resolve_host), "%s", hostname ? hostname : "");
+    g_last_resolve_port = port;
+    if (addr) {
+        DSD_MEMSET(addr, 0, sizeof(*addr));
+        addr->sin_family = AF_INET;
+        addr->sin_port = htons((uint16_t)port);
+    }
+    return g_resolve_result;
+}
+
+int
+dsd_socket_sendto(dsd_socket_t sock, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr,
+                  int addrlen) {
+    (void)flags;
+    (void)dest_addr;
+    (void)addrlen;
+    g_last_sendto_sock = sock;
+    g_last_sendto_len = len;
+    size_t copy_len = len;
+    if (copy_len > sizeof(g_last_sendto_data)) {
+        copy_len = sizeof(g_last_sendto_data);
+    }
+    if (buf && copy_len > 0U) {
+        DSD_MEMCPY(g_last_sendto_data, buf, copy_len);
+    }
+    return g_sendto_result ? g_sendto_result : (int)len;
+}
+
+int
+dsd_socket_recvfrom(dsd_socket_t sock, void* buf, size_t len, int flags, struct sockaddr* src_addr, int* addrlen) {
+    (void)sock;
+    (void)flags;
+    (void)src_addr;
+    (void)addrlen;
+    size_t copy_len = g_recvfrom_payload_len;
+    if (copy_len > len) {
+        copy_len = len;
+    }
+    if (buf && copy_len > 0U) {
+        DSD_MEMCPY(buf, g_recvfrom_payload, copy_len);
+    }
+    return g_recvfrom_result ? g_recvfrom_result : (int)copy_len;
+}
+
+static void
+init_opts(dsd_opts* opts) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_SNPRINTF(opts->udp_hostname, sizeof(opts->udp_hostname), "%s", "239.1.2.3");
+    opts->udp_portno = 23456;
+    DSD_SNPRINTF(opts->m17_hostname, sizeof(opts->m17_hostname), "%s", "239.4.5.6");
+    opts->m17_portno = 17000;
+}
+
+static int
+test_udp_connect_failures(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_opts(&opts);
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    reset_stubs();
+    g_create_result = DSD_INVALID_SOCKET;
+    assert(udp_socket_connect(&opts, &state) == -1);
+    assert(g_create_count == 1);
+    assert(g_setsockopt_count == 0);
+    assert(g_resolve_count == 0);
+
+    reset_stubs();
+    g_setsockopt_result = 7;
+    assert(udp_socket_connect(&opts, &state) == 7);
+    assert(opts.udp_sockfd == 11);
+    assert(g_setsockopt_count == 1);
+    assert(g_resolve_count == 0);
+
+    reset_stubs();
+    g_resolve_result = -1;
+    assert(udp_socket_connect(&opts, &state) == -1);
+    assert(g_resolve_count == 1);
+    assert(strcmp(g_last_resolve_host, "239.1.2.3") == 0);
+    assert(g_last_resolve_port == 23456);
+
+    reset_stubs();
+    g_create_result = DSD_INVALID_SOCKET;
+    assert(udp_socket_connectA(&opts, &state) == -1);
+    assert(g_create_count == 1);
+    assert(g_setsockopt_count == 0);
+    assert(g_resolve_count == 0);
+
+    reset_stubs();
+    g_setsockopt_result = 8;
+    assert(udp_socket_connectA(&opts, &state) == 8);
+    assert(opts.udp_sockfdA == 11);
+    assert(g_setsockopt_count == 1);
+    assert(g_resolve_count == 0);
+
+    reset_stubs();
+    g_resolve_result = -1;
+    assert(udp_socket_connectA(&opts, &state) == -1);
+    assert(g_resolve_count == 1);
+    assert(strcmp(g_last_resolve_host, "239.1.2.3") == 0);
+    assert(g_last_resolve_port == 23458);
+    return 0;
+}
+
+static int
+test_udp_connect_success_and_send_paths(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_opts(&opts);
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    reset_stubs();
+    assert(udp_socket_connect(&opts, &state) == 0);
+    assert(opts.udp_sockfd == 11);
+    assert(g_setsockopt_count == 1);
+    assert(g_resolve_count == 1);
+    assert(strcmp(g_last_resolve_host, "239.1.2.3") == 0);
+    assert(g_last_resolve_port == 23456);
+
+    const uint8_t payload[] = {1, 2, 3, 4};
+    udp_socket_blaster(&opts, &state, sizeof(payload), payload);
+    assert(g_last_sendto_sock == opts.udp_sockfd);
+    assert(g_last_sendto_len == sizeof(payload));
+    assert(memcmp(g_last_sendto_data, payload, sizeof(payload)) == 0);
+
+    reset_stubs();
+    init_opts(&opts);
+    assert(udp_socket_connectA(&opts, &state) == 0);
+    assert(opts.udp_sockfdA == 11);
+    assert(g_last_resolve_port == 23458);
+
+    const uint8_t analog_payload[] = {9, 8, 7};
+    udp_socket_blasterA(&opts, &state, sizeof(analog_payload), analog_payload);
+    assert(g_last_sendto_sock == opts.udp_sockfdA);
+    assert(g_last_sendto_len == sizeof(analog_payload));
+    assert(memcmp(g_last_sendto_data, analog_payload, sizeof(analog_payload)) == 0);
+    return 0;
+}
+
+static int
+test_m17_connect_send_and_receive(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_opts(&opts);
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    reset_stubs();
+    assert(udp_socket_connectM17(&opts, &state) == 0);
+    assert(opts.m17_udp_sock == 11);
+    assert(g_setsockopt_count == 1);
+    assert(strcmp(g_last_resolve_host, "239.4.5.6") == 0);
+    assert(g_last_resolve_port == 17000);
+
+    const uint8_t frame[] = {0x4D, 0x31, 0x37};
+    assert(m17_socket_blaster(&opts, &state, sizeof(frame), frame) == (int)sizeof(frame));
+    assert(g_last_sendto_sock == opts.m17_udp_sock);
+    assert(g_last_sendto_len == sizeof(frame));
+    assert(memcmp(g_last_sendto_data, frame, sizeof(frame)) == 0);
+
+    const uint8_t reply[] = {0x41, 0x43, 0x4B, 0x4E};
+    DSD_MEMCPY(g_recvfrom_payload, reply, sizeof(reply));
+    g_recvfrom_payload_len = sizeof(reply);
+    uint8_t out[8] = {0};
+    assert(m17_socket_receiver(&opts, out) == (int)sizeof(reply));
+    assert(memcmp(out, reply, sizeof(reply)) == 0);
+    return 0;
+}
+
+static int
+test_m17_connect_failures(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_opts(&opts);
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    reset_stubs();
+    g_create_result = DSD_INVALID_SOCKET;
+    assert(udp_socket_connectM17(&opts, &state) == -1);
+    assert(g_setsockopt_count == 0);
+
+    reset_stubs();
+    g_setsockopt_result = 9;
+    assert(udp_socket_connectM17(&opts, &state) == 9);
+    assert(g_resolve_count == 0);
+
+    reset_stubs();
+    g_resolve_result = -1;
+    assert(udp_socket_connectM17(&opts, &state) == -1);
+    assert(g_resolve_count == 1);
+    return 0;
+}
+
+static int
+test_udp_bind_paths(void) {
+    char empty[] = "";
+    char loopback[] = "127.0.0.1";
+    char any[] = "0.0.0.0";
+
+    reset_stubs();
+    g_create_result = DSD_INVALID_SOCKET;
+    assert(UDPBind(loopback, 17001) == DSD_INVALID_SOCKET);
+    assert(g_create_count == 1);
+    assert(g_resolve_count == 0);
+    assert(g_bind_count == 0);
+    assert(g_close_count == 0);
+
+    reset_stubs();
+    g_resolve_result = -1;
+    assert(UDPBind(loopback, 17002) == DSD_INVALID_SOCKET);
+    assert(g_resolve_count == 1);
+    assert(strcmp(g_last_resolve_host, "127.0.0.1") == 0);
+    assert(g_last_resolve_port == 17002);
+    assert(g_bind_count == 0);
+    assert(g_close_count == 1);
+
+    reset_stubs();
+    g_bind_result = -1;
+    assert(UDPBind(empty, 17003) == DSD_INVALID_SOCKET);
+    assert(g_resolve_count == 1);
+    assert(strcmp(g_last_resolve_host, "127.0.0.1") == 0);
+    assert(g_bind_count == 1);
+    assert(g_close_count == 1);
+    assert(g_recv_timeout_count == 0);
+
+    reset_stubs();
+    assert(UDPBind(any, 17004) == 11);
+    assert(g_resolve_count == 0);
+    assert(g_bind_count == 1);
+    assert(g_last_bind_addr == INADDR_ANY);
+    assert(g_last_bind_port == 17004);
+    assert(g_recv_timeout_count == 1);
+    assert(g_last_recv_timeout_ms == 1U);
+
+    reset_stubs();
+    assert(UDPBind(NULL, 17005) == 11);
+    assert(g_resolve_count == 1);
+    assert(strcmp(g_last_resolve_host, "127.0.0.1") == 0);
+    assert(g_last_bind_port == 17005);
+    assert(g_recv_timeout_count == 1);
+    return 0;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_udp_connect_failures();
+    rc |= test_udp_connect_success_and_send_paths();
+    rc |= test_m17_connect_send_and_receive();
+    rc |= test_m17_connect_failures();
+    rc |= test_udp_bind_paths();
+    return rc;
+}

--- a/tests/io/test_tcp_metrics_init.cpp
+++ b/tests/io/test_tcp_metrics_init.cpp
@@ -128,6 +128,7 @@ main(void) {
     /* --- init with NULL is safe (no crash) --- */
     tcp_metrics_init(NULL, 48000);
     tcp_metrics_reset(NULL, 48000);
+    rc |= expect_int("record recv NULL is no watchdog event", tcp_metrics_record_recv(NULL, 1000, 123456789ULL), 0);
 
     return rc ? 1 : 0;
 }

--- a/tests/io/test_tcp_metrics_jitter.cpp
+++ b/tests/io/test_tcp_metrics_jitter.cpp
@@ -217,6 +217,41 @@ test_jitter_variance_is_ewma_smoothed(void) {
     return rc;
 }
 
+/**
+ * @brief A later window with no inter-recv deltas decays the EWMA value.
+ *
+ * This covers the sparse-reader case where the previous published jitter
+ * value remains useful, but absence of interval samples should move it toward
+ * zero instead of leaving stale variance indefinitely.
+ */
+static int
+test_jitter_ewma_decays_without_interval_samples(void) {
+    int rc = 0;
+    struct tcp_quality_metrics m;
+    tcp_metrics_init(&m, 48000);
+
+    uint64_t base_ns = m.window_start_ns;
+
+    tcp_metrics_record_recv(&m, 1000, base_ns + 0ULL);
+    tcp_metrics_record_recv(&m, 1000, base_ns + 50000000ULL);
+    tcp_metrics_record_recv(&m, 1000, base_ns + 200000000ULL);
+    tcp_metrics_record_recv(&m, 1000, base_ns + 250000000ULL);
+    tcp_metrics_record_recv(&m, 1000, base_ns + 500000000ULL);
+    tcp_metrics_record_recv(&m, 0, base_ns + 1000000000ULL);
+
+    struct tcp_quality_snapshot first = tcp_metrics_get_snapshot(&m);
+    rc |= expect_true("seed jitter variance is nonzero", first.jitter_variance_us2 > 0.0f);
+
+    m.last_recv_ns = 0;
+    tcp_metrics_record_recv(&m, 0, base_ns + 2000000000ULL);
+
+    struct tcp_quality_snapshot second = tcp_metrics_get_snapshot(&m);
+    rc |= expect_float_approx("empty interval window decays jitter ewma", second.jitter_variance_us2,
+                              first.jitter_variance_us2 * 0.8f, first.jitter_variance_us2 * 0.01f);
+
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -225,5 +260,6 @@ main(void) {
     rc |= test_single_delta();
     rc |= test_no_recv_events();
     rc |= test_jitter_variance_is_ewma_smoothed();
+    rc |= test_jitter_ewma_decays_without_interval_samples();
     return rc ? 1 : 0;
 }

--- a/tests/platform/test_audio_conceal_integration.cpp
+++ b/tests/platform/test_audio_conceal_integration.cpp
@@ -101,9 +101,87 @@ verify_silence(const char* label, const int16_t* buf) {
     return verify_buffer_constant(label, buf, 0);
 }
 
+static int
+test_guard_paths_and_no_last_good_silence(void) {
+    int rc = 0;
+    int16_t out[8];
+    for (int i = 0; i < 8; i++) {
+        out[i] = (int16_t)(100 + i);
+    }
+
+    rc |= expect_int("guard: null state writes zero frames", (int)audio_conceal_on_underrun(NULL, out, 4), 0);
+    rc |= expect_int("guard: null output writes zero frames", (int)audio_conceal_on_underrun(NULL, NULL, 4), 0);
+
+    struct audio_conceal_state cs;
+    DSD_MEMSET(&cs, 0, sizeof(cs));
+    cs.buffer_frames = 4;
+    cs.channels = 2;
+    cs.underrun_total = 41;
+
+    rc |= expect_int("guard: zero frames writes zero frames", (int)audio_conceal_on_underrun(&cs, out, 0), 0);
+    rc |= expect_i16("guard: zero frames leaves sample", out[0], 100);
+
+    for (int i = 0; i < 8; i++) {
+        out[i] = (int16_t)(200 + i);
+    }
+    rc |= expect_int("no last-good returns requested bounded frames", (int)audio_conceal_on_underrun(&cs, out, 3), 3);
+    for (int i = 0; i < 6; i++) {
+        rc |= expect_i16("no last-good zero-fills written sample", out[i], 0);
+    }
+    rc |= expect_i16("no last-good leaves unwritten tail", out[6], 206);
+    rc |= expect_i16("no last-good leaves final tail", out[7], 207);
+    rc |= expect_u64("no last-good increments underrun total", cs.underrun_total, 42U);
+    return rc;
+}
+
+static int
+test_short_good_buffer_tail_padding_and_custom_gain_clamps(void) {
+    int rc = 0;
+    struct audio_conceal_state cs;
+    DSD_MEMSET(&cs, 0, sizeof(cs));
+    rc |= expect_int("tail/clamp: init", audio_conceal_init(&cs, 4, 2), 0);
+
+    int16_t good[4] = {1000, -1000, 32767, -32768};
+    audio_conceal_on_good_buffer(&cs, good, 2);
+
+    rc |= expect_i16("tail/clamp: copied first sample", cs.last_good_buffer[0], 1000);
+    rc |= expect_i16("tail/clamp: copied second sample", cs.last_good_buffer[1], -1000);
+    rc |= expect_i16("tail/clamp: copied positive clamp seed", cs.last_good_buffer[2], 32767);
+    rc |= expect_i16("tail/clamp: copied negative clamp seed", cs.last_good_buffer[3], -32768);
+    for (int i = 4; i < 8; i++) {
+        rc |= expect_i16("tail/clamp: short good buffer zero-pads tail", cs.last_good_buffer[i], 0);
+    }
+
+    cs.repeat_count = 3;
+    audio_conceal_on_good_buffer(&cs, NULL, 2);
+    rc |= expect_int("tail/clamp: null good buffer does not reset repeat count", cs.repeat_count, 3);
+    audio_conceal_on_good_buffer(&cs, good, 0);
+    rc |= expect_int("tail/clamp: zero-frame good buffer does not reset repeat count", cs.repeat_count, 3);
+    cs.repeat_count = 0;
+    cs.atten_per_repeat = 2.0f;
+
+    int16_t out[8];
+    DSD_MEMSET(out, 0x7F, sizeof(out));
+    rc |= expect_int("tail/clamp: underrun writes full frame count", (int)audio_conceal_on_underrun(&cs, out, 4), 4);
+    rc |= expect_i16("tail/clamp: custom gain scales positive", out[0], 2000);
+    rc |= expect_i16("tail/clamp: custom gain scales negative", out[1], -2000);
+    rc |= expect_i16("tail/clamp: positive sample clamps", out[2], 32767);
+    rc |= expect_i16("tail/clamp: negative sample clamps", out[3], -32768);
+    for (int i = 4; i < 8; i++) {
+        rc |= expect_i16("tail/clamp: padded tail stays silent", out[i], 0);
+    }
+    rc |= expect_int("tail/clamp: underrun increments repeat", cs.repeat_count, 1);
+
+    audio_conceal_destroy(&cs);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
+
+    rc |= test_guard_paths_and_no_last_good_silence();
+    rc |= test_short_good_buffer_tail_padding_and_custom_gain_clamps();
 
     /* --- Step 1: Init concealment --- */
     struct audio_conceal_state cs;

--- a/tests/platform/test_platform_audio_pulse_guards.c
+++ b/tests/platform/test_platform_audio_pulse_guards.c
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/platform/audio.h>
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+static dsd_audio_params
+valid_params(void) {
+    dsd_audio_params params;
+    (void)DSD_MEMSET(&params, 0, sizeof(params));
+    params.sample_rate = 48000;
+    params.channels = 1;
+    params.bits_per_sample = 16;
+    params.app_name = "dsd-neo-test";
+    return params;
+}
+
+static void
+expect_error(const char* expected) {
+    const char* actual = dsd_audio_get_error();
+    assert(actual != NULL);
+    assert(strcmp(actual, expected) == 0);
+}
+
+static void
+expect_input_rejects(const dsd_audio_params* params, const char* expected_error) {
+    assert(dsd_audio_open_input(params) == NULL);
+    expect_error(expected_error);
+}
+
+static void
+expect_output_rejects(const dsd_audio_params* params, const char* expected_error) {
+    assert(dsd_audio_open_output(params) == NULL);
+    expect_error(expected_error);
+}
+
+static void
+test_backend_lifecycle_and_error_reset(void) {
+    dsd_audio_cleanup();
+
+    assert(strcmp(dsd_audio_backend_name(), "pulse") == 0);
+    assert(dsd_audio_init() == 0);
+    expect_error("");
+
+    assert(dsd_audio_init() == 0);
+    expect_error("");
+
+    dsd_audio_cleanup();
+}
+
+static void
+test_open_parameter_guards(void) {
+    dsd_audio_params params = valid_params();
+
+    expect_input_rejects(NULL, "NULL parameters");
+    expect_output_rejects(NULL, "NULL parameters");
+
+    params.sample_rate = 0;
+    expect_input_rejects(&params, "Invalid sample rate");
+    expect_output_rejects(&params, "Invalid sample rate");
+
+    params = valid_params();
+    params.sample_rate = -48000;
+    expect_input_rejects(&params, "Invalid sample rate");
+    expect_output_rejects(&params, "Invalid sample rate");
+
+    params = valid_params();
+    params.channels = 0;
+    expect_input_rejects(&params, "Invalid channel count");
+    expect_output_rejects(&params, "Invalid channel count");
+
+    params = valid_params();
+    params.channels = 256;
+    expect_input_rejects(&params, "Invalid channel count");
+    expect_output_rejects(&params, "Invalid channel count");
+}
+
+static void
+test_stream_operation_guards(void) {
+    int16_t sample = 0;
+
+    assert(dsd_audio_read(NULL, &sample, 1) == -1);
+    expect_error("Invalid arguments");
+
+    assert(dsd_audio_write(NULL, &sample, 1) == -1);
+    expect_error("Invalid arguments");
+
+    assert(dsd_audio_drain(NULL) == -1);
+    dsd_audio_close(NULL);
+}
+
+int
+main(void) {
+    test_backend_lifecycle_and_error_reset();
+    test_open_parameter_guards();
+    test_stream_operation_guards();
+    dsd_audio_cleanup();
+    return 0;
+}

--- a/tests/platform/test_platform_audio_pulse_helpers.c
+++ b/tests/platform/test_platform_audio_pulse_helpers.c
@@ -22,6 +22,27 @@
 #include "dsd-neo/platform/audio_concealment.h"
 #include "dsd-neo/platform/threading.h"
 
+static int g_pa_simple_new_fail;
+static int g_pa_simple_error;
+static int g_pa_simple_read_fail;
+static int g_pa_simple_read_calls;
+static int g_pa_simple_write_fail;
+static int g_pa_simple_write_calls;
+static int g_pa_simple_drain_fail;
+static int g_pa_simple_drain_calls;
+
+static void
+reset_pa_simple_fakes(void) {
+    g_pa_simple_new_fail = 0;
+    g_pa_simple_error = 0;
+    g_pa_simple_read_fail = 0;
+    g_pa_simple_read_calls = 0;
+    g_pa_simple_write_fail = 0;
+    g_pa_simple_write_calls = 0;
+    g_pa_simple_drain_fail = 0;
+    g_pa_simple_drain_calls = 0;
+}
+
 int
 dsd_mutex_init(dsd_mutex_t* mutex) {
     (void)mutex;
@@ -131,6 +152,12 @@ pa_simple_new(const char* server, const char* name, pa_stream_direction_t dir, c
     (void)ss;
     (void)map;
     (void)attr;
+    if (g_pa_simple_new_fail) {
+        if (error != NULL) {
+            *error = g_pa_simple_error;
+        }
+        return NULL;
+    }
     if (error != NULL) {
         *error = 0;
     }
@@ -145,6 +172,13 @@ pa_simple_free(pa_simple* s) {
 int
 pa_simple_read(pa_simple* s, void* data, size_t bytes, int* error) {
     (void)s;
+    g_pa_simple_read_calls++;
+    if (g_pa_simple_read_fail) {
+        if (error != NULL) {
+            *error = g_pa_simple_error;
+        }
+        return -1;
+    }
     if (data != NULL) {
         DSD_MEMSET(data, 0, bytes);
     }
@@ -157,6 +191,13 @@ pa_simple_read(pa_simple* s, void* data, size_t bytes, int* error) {
 int
 pa_simple_drain(pa_simple* s, int* error) {
     (void)s;
+    g_pa_simple_drain_calls++;
+    if (g_pa_simple_drain_fail) {
+        if (error != NULL) {
+            *error = g_pa_simple_error;
+        }
+        return -1;
+    }
     if (error != NULL) {
         *error = 0;
     }
@@ -168,6 +209,13 @@ pa_simple_write(pa_simple* s, const void* data, size_t bytes, int* error) {
     (void)s;
     (void)data;
     (void)bytes;
+    g_pa_simple_write_calls++;
+    if (g_pa_simple_write_fail) {
+        if (error != NULL) {
+            *error = g_pa_simple_error;
+        }
+        return -1;
+    }
     if (error != NULL) {
         *error = 0;
     }
@@ -361,6 +409,132 @@ test_pulse_async_write_policy(void) {
     assert(dsd_mutex_destroy(&stream.mu) == 0);
 }
 
+static dsd_audio_params
+pulse_test_valid_params(void) {
+    dsd_audio_params params;
+    DSD_MEMSET(&params, 0, sizeof(params));
+    params.sample_rate = 48000;
+    params.channels = 1;
+    params.bits_per_sample = 16;
+    params.app_name = "dsd-neo-pulse-helper-test";
+    return params;
+}
+
+static void
+test_pulse_simple_error_paths(void) {
+    dsd_audio_params params = pulse_test_valid_params();
+    dsd_audio_stream stream;
+    int16_t samples[4] = {1, 2, 3, 4};
+
+    reset_pa_simple_fakes();
+    g_pa_simple_new_fail = 1;
+    g_pa_simple_error = PA_ERR_CONNECTIONREFUSED;
+    assert(dsd_audio_open_input(&params) == NULL);
+    assert(strcmp(dsd_audio_get_error(), pa_strerror(PA_ERR_CONNECTIONREFUSED)) == 0);
+
+    reset_pa_simple_fakes();
+    g_pa_simple_new_fail = 1;
+    g_pa_simple_error = PA_ERR_ACCESS;
+    assert(dsd_audio_open_output(&params) == NULL);
+    assert(strcmp(dsd_audio_get_error(), pa_strerror(PA_ERR_ACCESS)) == 0);
+
+    reset_pa_simple_fakes();
+    DSD_MEMSET(&stream, 0, sizeof(stream));
+    stream.handle = (pa_simple*)0x1;
+    stream.is_input = 1;
+    stream.channels = 1;
+    g_pa_simple_read_fail = 1;
+    g_pa_simple_error = PA_ERR_IO;
+    assert(dsd_audio_read(&stream, samples, 4) == -1);
+    assert(g_pa_simple_read_calls == 1);
+    assert(strcmp(dsd_audio_get_error(), pa_strerror(PA_ERR_IO)) == 0);
+
+    reset_pa_simple_fakes();
+    DSD_MEMSET(&stream, 0, sizeof(stream));
+    stream.handle = (pa_simple*)0x1;
+    stream.is_input = 0;
+    stream.use_async = 0;
+    stream.channels = 1;
+    g_pa_simple_write_fail = 1;
+    g_pa_simple_error = PA_ERR_INTERNAL;
+    assert(dsd_audio_write(&stream, samples, 4) == -1);
+    assert(g_pa_simple_write_calls == 1);
+    assert(strcmp(dsd_audio_get_error(), pa_strerror(PA_ERR_INTERNAL)) == 0);
+
+    reset_pa_simple_fakes();
+    DSD_MEMSET(&stream, 0, sizeof(stream));
+    stream.handle = (pa_simple*)0x1;
+    stream.is_input = 0;
+    stream.use_async = 0;
+    g_pa_simple_drain_fail = 1;
+    g_pa_simple_error = PA_ERR_TIMEOUT;
+    assert(dsd_audio_drain(&stream) == -1);
+    assert(g_pa_simple_drain_calls == 1);
+    assert(strcmp(dsd_audio_get_error(), pa_strerror(PA_ERR_TIMEOUT)) == 0);
+}
+
+static void
+test_pulse_async_error_paths(void) {
+    dsd_audio_stream stream;
+    int16_t chunk[4] = {0};
+    int16_t ring[4] = {10, 11, 12, 13};
+
+    reset_pa_simple_fakes();
+    DSD_MEMSET(&stream, 0, sizeof(stream));
+    stream.handle = (pa_simple*)0x1;
+    stream.is_input = 0;
+    stream.use_async = 1;
+    stream.channels = 1;
+    stream.chunk = chunk;
+    stream.chunk_samples = 4;
+    assert(dsd_mutex_init(&stream.mu) == 0);
+    assert(dsd_cond_init(&stream.cv) == 0);
+    g_pa_simple_write_fail = 1;
+    g_pa_simple_error = PA_ERR_CONNECTIONTERMINATED;
+    assert(pulse_output_write_chunk(&stream) == -1);
+    assert(g_pa_simple_write_calls == 1);
+    assert(stream.stop == 1);
+    assert(strcmp(dsd_audio_get_error(), pa_strerror(PA_ERR_CONNECTIONTERMINATED)) == 0);
+
+    reset_pa_simple_fakes();
+    DSD_MEMSET(&stream, 0, sizeof(stream));
+    stream.handle = (pa_simple*)0x1;
+    stream.is_input = 0;
+    stream.use_async = 1;
+    stream.channels = 1;
+    stream.drain_requested = 1;
+    g_pa_simple_drain_fail = 1;
+    g_pa_simple_error = PA_ERR_TIMEOUT;
+    assert(pulse_output_handle_drain_locked(&stream) == 0);
+    assert(g_pa_simple_drain_calls == 1);
+    assert(stream.drain_requested == 0);
+    assert(stream.drain_completed == 1);
+    assert(stream.drain_failed == 1);
+    assert(strcmp(dsd_audio_get_error(), pa_strerror(PA_ERR_TIMEOUT)) == 0);
+
+    reset_pa_simple_fakes();
+    DSD_MEMSET(&stream, 0, sizeof(stream));
+    stream.handle = (pa_simple*)0x1;
+    stream.is_input = 0;
+    stream.use_async = 1;
+    stream.channels = 1;
+    stream.ring = ring;
+    stream.ring_samples_capacity = 4;
+    stream.ring_samples_count = 2;
+    stream.chunk = chunk;
+    stream.chunk_samples = 2;
+    stream.drain_requested = 1;
+    g_pa_simple_write_fail = 1;
+    g_pa_simple_error = PA_ERR_IO;
+    assert(pulse_output_handle_drain_locked(&stream) == -1);
+    assert(g_pa_simple_write_calls == 1);
+    assert(stream.stop == 1);
+    assert(strcmp(dsd_audio_get_error(), pa_strerror(PA_ERR_IO)) == 0);
+
+    assert(dsd_cond_destroy(&stream.cv) == 0);
+    assert(dsd_mutex_destroy(&stream.mu) == 0);
+}
+
 static void
 test_pulse_enum_callbacks_and_guards(void) {
     dsd_audio_device devices[2];
@@ -408,6 +582,14 @@ test_pulse_enum_callbacks_and_guards(void) {
     assert(devices[0].initialized == 1);
 
     assert(pulse_enum_op_done(NULL) == 1);
+    op = (pa_operation*)0x1;
+    enum_context no_outputs = {NULL, 1, 0};
+    enum_context no_inputs = {NULL, 1, 0};
+    assert(pulse_enum_start_query(NULL, &op, 0, &no_outputs, &ctx) == 0);
+    assert(op == NULL);
+    op = (pa_operation*)0x1;
+    assert(pulse_enum_start_query(NULL, &op, 1, &ctx, &no_inputs) == 0);
+    assert(op == NULL);
     assert(pulse_enum_start_query(NULL, &op, 2, &ctx, &ctx) == -1);
     assert(op == NULL);
     assert(strcmp(dsd_audio_get_error(), "Internal error: unexpected enumeration state") == 0);
@@ -419,6 +601,8 @@ main(void) {
     test_pulse_ring_wrap_read_and_drop();
     test_pulse_output_attr_and_async_buffers();
     test_pulse_async_write_policy();
+    test_pulse_simple_error_paths();
+    test_pulse_async_error_paths();
     test_pulse_enum_callbacks_and_guards();
     return 0;
 }

--- a/tests/platform/test_platform_audio_pulse_helpers.c
+++ b/tests/platform/test_platform_audio_pulse_helpers.c
@@ -1,0 +1,426 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-suspicious-include)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <pulse/channelmap.h>
+#include <pulse/def.h>
+#include <pulse/introspect.h>
+#include <pulse/operation.h>
+#include <pulse/sample.h>
+#include <pulse/simple.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "../../src/platform/audio_pulse.c"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/platform/audio.h"
+#include "dsd-neo/platform/audio_concealment.h"
+#include "dsd-neo/platform/threading.h"
+
+int
+dsd_mutex_init(dsd_mutex_t* mutex) {
+    (void)mutex;
+    return 0;
+}
+
+int
+dsd_mutex_destroy(dsd_mutex_t* mutex) {
+    (void)mutex;
+    return 0;
+}
+
+int
+dsd_mutex_lock(dsd_mutex_t* mutex) {
+    (void)mutex;
+    return 0;
+}
+
+int
+dsd_mutex_unlock(dsd_mutex_t* mutex) {
+    (void)mutex;
+    return 0;
+}
+
+int
+dsd_cond_init(dsd_cond_t* cond) {
+    (void)cond;
+    return 0;
+}
+
+int
+dsd_cond_destroy(dsd_cond_t* cond) {
+    (void)cond;
+    return 0;
+}
+
+int
+dsd_cond_signal(dsd_cond_t* cond) {
+    (void)cond;
+    return 0;
+}
+
+int
+dsd_cond_broadcast(dsd_cond_t* cond) {
+    (void)cond;
+    return 0;
+}
+
+int
+dsd_cond_wait(dsd_cond_t* cond, dsd_mutex_t* mutex) {
+    (void)cond;
+    (void)mutex;
+    return 0;
+}
+
+int
+dsd_cond_timedwait(dsd_cond_t* cond, dsd_mutex_t* mutex, unsigned int timeout_ms) {
+    (void)cond;
+    (void)mutex;
+    (void)timeout_ms;
+    return 0;
+}
+
+int
+dsd_thread_join(dsd_thread_t thread) {
+    (void)thread;
+    return 0;
+}
+
+int
+audio_conceal_init(struct audio_conceal_state* cs, size_t buffer_frames, int channels) {
+    (void)cs;
+    return (buffer_frames > 0U && channels > 0) ? 0 : -1;
+}
+
+void
+audio_conceal_destroy(struct audio_conceal_state* cs) {
+    (void)cs;
+}
+
+void
+audio_conceal_on_good_buffer(struct audio_conceal_state* cs, const int16_t* buf, size_t frames) {
+    (void)cs;
+    (void)buf;
+    (void)frames;
+}
+
+size_t
+audio_conceal_on_underrun(struct audio_conceal_state* cs, int16_t* out, size_t frames) {
+    const size_t channels = (cs != NULL && cs->channels > 0) ? (size_t)cs->channels : 1U;
+
+    if (out == NULL) {
+        return 0;
+    }
+    DSD_MEMSET(out, 0, frames * channels * sizeof(*out));
+    return frames;
+}
+
+pa_simple*
+pa_simple_new(const char* server, const char* name, pa_stream_direction_t dir, const char* dev, const char* stream_name,
+              const pa_sample_spec* ss, const pa_channel_map* map, const pa_buffer_attr* attr, int* error) {
+    (void)server;
+    (void)name;
+    (void)dir;
+    (void)dev;
+    (void)stream_name;
+    (void)ss;
+    (void)map;
+    (void)attr;
+    if (error != NULL) {
+        *error = 0;
+    }
+    return (pa_simple*)0x1;
+}
+
+void
+pa_simple_free(pa_simple* s) {
+    (void)s;
+}
+
+int
+pa_simple_read(pa_simple* s, void* data, size_t bytes, int* error) {
+    (void)s;
+    if (data != NULL) {
+        DSD_MEMSET(data, 0, bytes);
+    }
+    if (error != NULL) {
+        *error = 0;
+    }
+    return 0;
+}
+
+int
+pa_simple_drain(pa_simple* s, int* error) {
+    (void)s;
+    if (error != NULL) {
+        *error = 0;
+    }
+    return 0;
+}
+
+int
+pa_simple_write(pa_simple* s, const void* data, size_t bytes, int* error) {
+    (void)s;
+    (void)data;
+    (void)bytes;
+    if (error != NULL) {
+        *error = 0;
+    }
+    return 0;
+}
+
+static void
+test_pulse_size_helpers(void) {
+    size_t result = 99;
+
+    assert(ms_to_bytes(0, 1, 20) == 0);
+    assert(ms_to_bytes(48000, 0, 20) == 0);
+    assert(ms_to_bytes(48000, 1, 0) == 0);
+    assert(ms_to_bytes(1, 1, 1) == sizeof(int16_t));
+    assert(ms_to_bytes(48000, 2, 125) == 24000U);
+    assert(ms_to_bytes(INT32_MAX, UINT8_MAX, INT32_MAX) == UINT32_MAX);
+
+    assert(ms_to_frames(0, 20) == 0);
+    assert(ms_to_frames(48000, 0) == 0);
+    assert(ms_to_frames(1, 1) == 1);
+    assert(ms_to_frames(48000, 20) == 960);
+    assert(calc_chunk_frames(0) == 1);
+    assert(calc_chunk_frames(48000) == 960);
+
+    assert(size_mul_nonzero(3, 4, &result) == 1);
+    assert(result == 12);
+    assert(size_mul_nonzero(0, 4, &result) == 0);
+    assert(result == 0);
+    assert(size_mul_nonzero(SIZE_MAX, 2, &result) == 0);
+    assert(result == 0);
+    assert(size_mul_nonzero(1, 1, NULL) == 0);
+}
+
+static void
+test_pulse_ring_wrap_read_and_drop(void) {
+    dsd_audio_stream stream;
+    int16_t ring[5] = {0};
+    int16_t first_write[3] = {1, 2, 3};
+    int16_t second_write[4] = {4, 5, 6, 7};
+    int16_t third_write[4] = {10, 11, 12, 13};
+    int16_t fourth_write[2] = {20, 21};
+    int16_t out[6] = {0};
+
+    DSD_MEMSET(&stream, 0, sizeof(stream));
+    stream.ring = ring;
+    stream.ring_samples_capacity = 5;
+
+    ring_write_samples(NULL, first_write, 3);
+    ring_write_samples(&stream, NULL, 3);
+    ring_write_samples(&stream, first_write, 0);
+    assert(stream.ring_samples_count == 0);
+
+    ring_write_samples(&stream, first_write, 3);
+    assert(stream.ring_samples_tail == 3);
+    assert(stream.ring_samples_count == 3);
+    assert(ring[0] == 1 && ring[1] == 2 && ring[2] == 3);
+
+    assert(ring_read_samples(&stream, out, 2) == 2);
+    assert(out[0] == 1 && out[1] == 2);
+    assert(stream.ring_samples_head == 2);
+    assert(stream.ring_samples_count == 1);
+
+    ring_write_samples(&stream, second_write, 4);
+    assert(stream.ring_samples_tail == 2);
+    assert(stream.ring_samples_count == 5);
+    DSD_MEMSET(out, 0, sizeof(out));
+    assert(ring_read_samples(&stream, out, 5) == 5);
+    assert(out[0] == 3 && out[1] == 4 && out[2] == 5 && out[3] == 6 && out[4] == 7);
+    assert(stream.ring_samples_head == 2);
+    assert(stream.ring_samples_count == 0);
+
+    ring_write_samples(&stream, third_write, 4);
+    ring_drop_oldest(&stream, 2);
+    assert(stream.ring_samples_head == 4);
+    assert(stream.ring_samples_count == 2);
+    DSD_MEMSET(out, 0, sizeof(out));
+    assert(ring_read_samples(&stream, out, 4) == 2);
+    assert(out[0] == 12 && out[1] == 13);
+
+    ring_write_samples(&stream, fourth_write, 2);
+    ring_drop_oldest(&stream, 99);
+    assert(stream.ring_samples_count == 0);
+    assert(ring_read_samples(&stream, out, 1) == 0);
+}
+
+static void
+test_pulse_output_attr_and_async_buffers(void) {
+    dsd_audio_params params;
+    dsd_audio_stream stream;
+    pa_buffer_attr attr;
+
+    DSD_MEMSET(&params, 0, sizeof(params));
+    params.sample_rate = 48000;
+    params.channels = 2;
+    pulse_output_init_attr(&params, &attr);
+    assert(attr.tlength == 24000U);
+    assert(attr.prebuf == 11520U);
+    assert(attr.minreq == 3840U);
+
+    DSD_MEMSET(&params, 0, sizeof(params));
+    params.sample_rate = 1;
+    params.channels = 1;
+    pulse_output_init_attr(&params, &attr);
+    assert(attr.tlength == sizeof(int16_t));
+    assert(attr.prebuf == sizeof(int16_t));
+    assert(attr.minreq == sizeof(int16_t));
+
+    DSD_MEMSET(&stream, 0, sizeof(stream));
+    stream.sample_rate = 8000;
+    stream.channels = 1;
+    pulse_output_init_async_state(&stream);
+    assert(stream.use_async == 1);
+    assert(stream.stop == 0);
+    assert(stream.drain_requested == 0);
+    assert(stream.conceal_has_good == 0);
+
+    assert(pulse_output_init_async_sync(&stream) == 1);
+    assert(pulse_output_prepare_async_buffers(&stream) == 1);
+    assert(stream.chunk_frames == 160U);
+    assert(stream.chunk_samples == 160U);
+    assert(stream.ring_samples_capacity >= 1280U);
+    assert(stream.chunk != NULL);
+    assert(stream.ring != NULL);
+
+    pulse_output_disable_async(&stream, 1);
+    assert(stream.use_async == 0);
+    assert(stream.chunk == NULL);
+    assert(stream.ring == NULL);
+    assert(stream.ring_samples_capacity == 0);
+}
+
+static void
+test_pulse_async_write_policy(void) {
+    dsd_audio_stream stream;
+    int16_t samples[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+    int16_t ring[4] = {0};
+
+    DSD_MEMSET(&stream, 0, sizeof(stream));
+    stream.handle = (pa_simple*)0x1;
+    stream.is_input = 0;
+    stream.use_async = 1;
+    stream.channels = 1;
+    stream.ring = ring;
+    stream.ring_samples_capacity = 4;
+    assert(dsd_mutex_init(&stream.mu) == 0);
+    assert(dsd_cond_init(&stream.cv) == 0);
+
+    assert(dsd_audio_write(&stream, samples, 0) == 0);
+    assert(stream.ring_samples_count == 0);
+
+    assert(dsd_audio_write(&stream, samples, 3) == 3);
+    assert(stream.ring_samples_count == 3);
+    assert(stream.ring_samples_head == 0);
+    assert(stream.ring_samples_tail == 3);
+    assert(ring[0] == 1 && ring[1] == 2 && ring[2] == 3);
+
+    assert(dsd_audio_write(&stream, samples + 3, 3) == 3);
+    assert(stream.drops == 2U);
+    assert(stream.ring_samples_count == 4);
+    assert(stream.ring_samples_head == 2);
+
+    int16_t out[4] = {0};
+    assert(ring_read_samples(&stream, out, 4) == 4);
+    assert(out[0] == 3 && out[1] == 4 && out[2] == 5 && out[3] == 6);
+
+    assert(dsd_audio_write(&stream, samples, 8) == 8);
+    assert(stream.ring_samples_count == 4);
+    DSD_MEMSET(out, 0, sizeof(out));
+    assert(ring_read_samples(&stream, out, 4) == 4);
+    assert(out[0] == 5 && out[1] == 6 && out[2] == 7 && out[3] == 8);
+
+    stream.drain_requested = 1;
+    assert(dsd_audio_write(&stream, samples, 2) == 2);
+    assert(stream.drops == 4U);
+    assert(stream.ring_samples_count == 0);
+
+    stream.drain_requested = 0;
+    stream.ring = NULL;
+    assert(dsd_audio_write(&stream, samples, 1) == -1);
+
+    stream.ring = ring;
+    stream.stop = 1;
+    assert(dsd_audio_write(&stream, samples, 1) == -1);
+
+    stream.stop = 0;
+    stream.is_input = 1;
+    assert(dsd_audio_write(&stream, samples, 1) == -1);
+    assert(strcmp(dsd_audio_get_error(), "Cannot write to input stream") == 0);
+
+    assert(dsd_cond_destroy(&stream.cv) == 0);
+    assert(dsd_mutex_destroy(&stream.mu) == 0);
+}
+
+static void
+test_pulse_enum_callbacks_and_guards(void) {
+    dsd_audio_device devices[2];
+    enum_context ctx = {devices, 1, 0};
+    pa_sink_info sink;
+    pa_source_info source;
+    pa_operation* op = (pa_operation*)0x1;
+
+    DSD_MEMSET(devices, 0x5A, sizeof(devices));
+    pulse_enum_reset_devices(devices, 2);
+    assert(devices[0].initialized == 0);
+    assert(devices[1].initialized == 0);
+    pulse_enum_reset_devices(NULL, 2);
+
+    DSD_MEMSET(&sink, 0, sizeof(sink));
+    sink.index = 7;
+    sink.name = "sink-name";
+    sink.description = NULL;
+    pa_sink_enum_cb(NULL, &sink, 0, &ctx);
+    assert(ctx.current == 1);
+    assert(devices[0].index == 7);
+    assert(strcmp(devices[0].name, "sink-name") == 0);
+    assert(devices[0].description[0] == '\0');
+    assert(devices[0].is_output == 1);
+    assert(devices[0].is_input == 0);
+    assert(devices[0].initialized == 1);
+    pa_sink_enum_cb(NULL, &sink, 0, &ctx);
+    assert(ctx.current == 1);
+    pa_sink_enum_cb(NULL, &sink, 1, &ctx);
+    assert(ctx.current == 1);
+
+    DSD_MEMSET(devices, 0, sizeof(devices));
+    ctx.current = 0;
+    DSD_MEMSET(&source, 0, sizeof(source));
+    source.index = 9;
+    source.name = "source-name";
+    source.description = "source description";
+    pa_source_enum_cb(NULL, &source, 0, &ctx);
+    assert(ctx.current == 1);
+    assert(devices[0].index == 9);
+    assert(strcmp(devices[0].name, "source-name") == 0);
+    assert(strcmp(devices[0].description, "source description") == 0);
+    assert(devices[0].is_input == 1);
+    assert(devices[0].is_output == 0);
+    assert(devices[0].initialized == 1);
+
+    assert(pulse_enum_op_done(NULL) == 1);
+    assert(pulse_enum_start_query(NULL, &op, 2, &ctx, &ctx) == -1);
+    assert(op == NULL);
+    assert(strcmp(dsd_audio_get_error(), "Internal error: unexpected enumeration state") == 0);
+}
+
+int
+main(void) {
+    test_pulse_size_helpers();
+    test_pulse_ring_wrap_read_and_drop();
+    test_pulse_output_attr_and_async_buffers();
+    test_pulse_async_write_policy();
+    test_pulse_enum_callbacks_and_guards();
+    return 0;
+}
+
+// NOLINTEND(bugprone-suspicious-include)

--- a/tests/platform/test_platform_audio_pulse_helpers.c
+++ b/tests/platform/test_platform_audio_pulse_helpers.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <pulse/channelmap.h>
 #include <pulse/def.h>
+#include <pulse/error.h>
 #include <pulse/introspect.h>
 #include <pulse/operation.h>
 #include <pulse/sample.h>

--- a/tests/platform/test_platform_file_compat.c
+++ b/tests/platform/test_platform_file_compat.c
@@ -1,18 +1,168 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-unix.Errno)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
 #include <dsd-neo/platform/file_compat.h>
-
-#include "dsd-neo/platform/platform.h"
-
+#include <dsd-neo/platform/posix_compat.h>
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+
+#include "dsd-neo/platform/platform.h"
 #if !DSD_PLATFORM_WIN_NATIVE
+#include <sys/stat.h>
 #include <unistd.h>
 #endif
+
+static int
+expect_posix_compat_wrappers(void) {
+    int rc = 0;
+
+    errno = 0;
+    rc |= dsd_open_serial_write(NULL) == -1 && errno == EINVAL ? 0 : 1;
+    errno = 0;
+    rc |= dsd_open_serial_write("") == -1 && errno == EINVAL ? 0 : 1;
+
+    const char* name = "dsd_neo_serial_open_write_test.tmp";
+    (void)remove(name);
+    FILE* fp = dsd_fopen_private(name, "w");
+    if (!fp) {
+        return 1;
+    }
+    rc |= fclose(fp) == 0 ? 0 : 1;
+    int fd = dsd_open_serial_write(name);
+    if (fd < 0) {
+        rc = 1;
+    } else {
+        rc |= dsd_close(fd) == 0 ? 0 : 1;
+    }
+    (void)remove(name);
+
+    void* ptr = dsd_aligned_alloc(sizeof(void*), 64);
+    rc |= ptr != NULL ? 0 : 1;
+    dsd_aligned_free(ptr);
+
+    char file_tmpl[] = "dsd_neo_mkstemp_test_XXXXXX";
+    fd = dsd_mkstemp(file_tmpl);
+    if (fd < 0) {
+        rc = 1;
+    } else {
+        rc |= dsd_close(fd) == 0 ? 0 : 1;
+        rc |= strstr(file_tmpl, "XXXXXX") == NULL ? 0 : 1;
+        (void)remove(file_tmpl);
+    }
+
+    char dir_tmpl[] = "dsd_neo_mkdtemp_test_XXXXXX";
+    char* dir = dsd_mkdtemp(dir_tmpl);
+    if (!dir) {
+        rc = 1;
+    } else {
+        dsd_stat_t st;
+        rc |= dsd_stat_path(dir, &st) == 0 && !dsd_stat_is_regular(&st) ? 0 : 1;
+        rc |= rmdir(dir) == 0 ? 0 : 1;
+    }
+
+    return rc;
+}
+
+static int
+expect_descriptor_wrappers(void) {
+    const char* name = "dsd_neo_descriptor_wrappers_test.tmp";
+    (void)remove(name);
+
+    FILE* fp = dsd_fopen_private(name, "w+");
+    if (!fp) {
+        return 1;
+    }
+    int fd = dsd_fileno(fp);
+    int ok = fd >= 0 && dsd_fileno(NULL) == -1 && dsd_isatty(-1) == 0;
+    if (dsd_write(fd, "abc", 3) != 3 || dsd_fsync(fd) != 0) {
+        ok = 0;
+    }
+
+    dsd_stat_t st;
+    if (dsd_fstat(fd, &st) != 0 || !dsd_stat_is_regular(&st)) {
+        ok = 0;
+    }
+    if (dsd_fchmod(fd, 0600) != 0) {
+        ok = 0;
+    }
+
+    int dupfd = dsd_dup(fd);
+    if (dupfd < 0) {
+        ok = 0;
+    } else {
+        int target_fd = dsd_dup2(dupfd, dupfd);
+        if (target_fd != dupfd) {
+            ok = 0;
+        }
+        if (dsd_close(dupfd) != 0) {
+            ok = 0;
+        }
+    }
+
+    rewind(fp);
+    char buf[4] = {0};
+    if (dsd_read(fd, buf, 3) != 3 || strcmp(buf, "abc") != 0) {
+        ok = 0;
+    }
+    if (fclose(fp) != 0) {
+        ok = 0;
+    }
+    (void)remove(name);
+    return ok ? 0 : 1;
+}
+
+static int
+expect_private_open_modes_and_read_fallback(void) {
+    const char* name = "dsd_neo_private_modes_test.tmp";
+    (void)remove(name);
+
+    errno = 0;
+    if (dsd_fopen_private(NULL, "w") != NULL || errno != EINVAL) {
+        return 1;
+    }
+    errno = 0;
+    if (dsd_fopen_private(name, NULL) != NULL || errno != EINVAL) {
+        return 1;
+    }
+    errno = 0;
+    if (dsd_fopen_private(name, "") != NULL || errno != EINVAL) {
+        return 1;
+    }
+    errno = 0;
+    if (dsd_fopen_private(name, "x") != NULL || errno != EINVAL) {
+        return 1;
+    }
+
+    FILE* fp = dsd_fopen_private(name, "w");
+    if (!fp) {
+        return 1;
+    }
+    int ok = fputs("first\n", fp) >= 0 && fclose(fp) == 0;
+
+    fp = dsd_fopen_private(name, "a+");
+    if (!fp) {
+        (void)remove(name);
+        return 1;
+    }
+    ok = ok && fputs("second\n", fp) >= 0 && fclose(fp) == 0;
+
+    fp = dsd_fopen_private(name, "r");
+    if (!fp) {
+        (void)remove(name);
+        return 1;
+    }
+    char line[16];
+    ok = ok && fgets(line, sizeof line, fp) != NULL && strcmp(line, "first\n") == 0;
+    ok = ok && fclose(fp) == 0;
+    (void)remove(name);
+    return ok ? 0 : 1;
+}
 
 static int
 write_probe_file(const char* path) {
@@ -24,6 +174,55 @@ write_probe_file(const char* path) {
     if (fclose(fp) != 0) {
         rc = -1;
     }
+    return rc;
+}
+
+static int
+expect_existing_regular_file_guards(void) {
+    const char* name = "dsd_neo_existing_regular_test.tmp";
+    const char* dir_name = "dsd_neo_existing_regular_dir.tmp";
+    (void)remove(name);
+    (void)rmdir(dir_name);
+    if (write_probe_file(name) != 0) {
+        return 1;
+    }
+
+    int rc = 0;
+    errno = 0;
+    rc |= dsd_fopen_existing_regular_file(NULL, "r") == NULL && errno == EINVAL ? 0 : 1;
+    errno = 0;
+    rc |= dsd_fopen_existing_regular_file("", "r") == NULL && errno == EINVAL ? 0 : 1;
+    errno = 0;
+    rc |= dsd_fopen_existing_regular_file(name, NULL) == NULL && errno == EINVAL ? 0 : 1;
+    errno = 0;
+    rc |= dsd_fopen_existing_regular_file(name, "w") == NULL && errno == EINVAL ? 0 : 1;
+    errno = 0;
+    rc |= dsd_fopen_existing_regular_file(name, "r+") == NULL && errno == EINVAL ? 0 : 1;
+
+    FILE* fp = dsd_fopen_existing_regular_file(name, "rb");
+    if (!fp) {
+        rc = 1;
+    } else {
+        char line[16];
+        rc |= fgets(line, sizeof line, fp) != NULL && strcmp(line, "probe\n") == 0 ? 0 : 1;
+        rc |= fclose(fp) == 0 ? 0 : 1;
+    }
+
+    if (mkdir(dir_name, 0700) != 0) {
+        rc = 1;
+    } else {
+        errno = 0;
+        fp = dsd_fopen_existing_regular_file(dir_name, "r");
+        const int open_errno = errno;
+        if (fp) {
+            fclose(fp);
+            rc = 1;
+        }
+        rc |= open_errno == EINVAL ? 0 : 1;
+    }
+
+    (void)remove(name);
+    (void)rmdir(dir_name);
     return rc;
 }
 
@@ -162,6 +361,77 @@ expect_private_temp_replace(void) {
     return ok ? 0 : 1;
 }
 
+static int
+expect_private_temp_rejects_invalid_arguments(void) {
+    char tmp[32];
+    errno = 0;
+    if (dsd_fopen_private_temp_for_replace(NULL, tmp, sizeof tmp, "w") != NULL || errno != EINVAL) {
+        return 1;
+    }
+    errno = 0;
+    if (dsd_fopen_private_temp_for_replace("", tmp, sizeof tmp, "w") != NULL || errno != EINVAL) {
+        return 1;
+    }
+    errno = 0;
+    if (dsd_fopen_private_temp_for_replace("final.tmp", NULL, sizeof tmp, "w") != NULL || errno != EINVAL) {
+        return 1;
+    }
+    errno = 0;
+    if (dsd_fopen_private_temp_for_replace("final.tmp", tmp, 0, "w") != NULL || errno != EINVAL) {
+        return 1;
+    }
+    errno = 0;
+    if (dsd_fopen_private_temp_for_replace("final.tmp", tmp, sizeof tmp, "r") != NULL || errno != EINVAL) {
+        return 1;
+    }
+    errno = 0;
+    if (dsd_fopen_private_temp_for_replace("this_name_is_too_long_for_the_tmp_buffer", tmp, sizeof tmp, "w") != NULL
+        || errno != ENAMETOOLONG) {
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_replace_rejects_invalid_arguments_and_missing_tmp(void) {
+    errno = 0;
+    if (dsd_replace_file_with_temp(NULL, "final.tmp") != -1 || errno != EINVAL) {
+        return 1;
+    }
+    errno = 0;
+    if (dsd_replace_file_with_temp("", "final.tmp") != -1 || errno != EINVAL) {
+        return 1;
+    }
+    errno = 0;
+    if (dsd_replace_file_with_temp("missing.tmp", NULL) != -1 || errno != EINVAL) {
+        return 1;
+    }
+    errno = 0;
+    if (dsd_replace_file_with_temp("missing.tmp", "") != -1 || errno != EINVAL) {
+        return 1;
+    }
+    errno = 0;
+    if (dsd_replace_file_with_temp("missing_dsd_neo_replace.tmp", "final.tmp") != -1 || errno == 0) {
+        (void)remove("final.tmp");
+        return 1;
+    }
+    (void)remove("final.tmp");
+    return 0;
+}
+
+static int
+expect_null_device_is_readable(void) {
+    const char* path = dsd_null_device();
+    if (!path || path[0] == '\0') {
+        return 1;
+    }
+    FILE* fp = fopen(path, "rb");
+    if (!fp) {
+        return 1;
+    }
+    return fclose(fp) == 0 ? 0 : 1;
+}
+
 #if !DSD_PLATFORM_WIN_NATIVE
 static int
 expect_rejects_symlink(void) {
@@ -192,6 +462,10 @@ expect_rejects_symlink(void) {
 int
 main(void) {
     int rc = 0;
+    rc |= expect_posix_compat_wrappers();
+    rc |= expect_descriptor_wrappers();
+    rc |= expect_private_open_modes_and_read_fallback();
+    rc |= expect_existing_regular_file_guards();
     rc |= expect_resolves_existing_file();
     rc |= expect_opens_existing_file();
     rc |= expect_rejects_unsafe_name("");
@@ -201,8 +475,13 @@ main(void) {
     rc |= expect_rejects_missing_file();
     rc |= expect_rejects_small_buffer();
     rc |= expect_private_temp_replace();
+    rc |= expect_private_temp_rejects_invalid_arguments();
+    rc |= expect_replace_rejects_invalid_arguments_and_missing_tmp();
+    rc |= expect_null_device_is_readable();
 #if !DSD_PLATFORM_WIN_NATIVE
     rc |= expect_rejects_symlink();
 #endif
     return rc;
 }
+
+// NOLINTEND(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-unix.Errno)

--- a/tests/platform/test_platform_monotonic_cond.c
+++ b/tests/platform/test_platform_monotonic_cond.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <time.h>
 #include "dsd-neo/core/safe_api.h"
 
 struct cond_signal_ctx {
@@ -16,6 +17,10 @@ struct cond_signal_ctx {
     dsd_mutex_t* mutex;
     int* fired;
 };
+
+#if !DSD_PLATFORM_WIN_NATIVE
+int dsd_thread_create_impl(dsd_thread_t* thread, void* arg, dsd_thread_fn func);
+#endif
 
 static DSD_THREAD_RETURN_TYPE
 #if DSD_PLATFORM_WIN_NATIVE
@@ -27,6 +32,19 @@ static DSD_THREAD_RETURN_TYPE
     dsd_mutex_lock(ctx->mutex);
     *ctx->fired = 1;
     dsd_cond_signal(ctx->cond);
+    dsd_mutex_unlock(ctx->mutex);
+    DSD_THREAD_RETURN;
+}
+
+static DSD_THREAD_RETURN_TYPE
+#if DSD_PLATFORM_WIN_NATIVE
+    __stdcall
+#endif
+    immediate_signal_thread_fn(void* arg) {
+    struct cond_signal_ctx* ctx = (struct cond_signal_ctx*)arg;
+    dsd_mutex_lock(ctx->mutex);
+    *ctx->fired = 1;
+    dsd_cond_broadcast(ctx->cond);
     dsd_mutex_unlock(ctx->mutex);
     DSD_THREAD_RETURN;
 }
@@ -49,6 +67,98 @@ expect_true(const char* label, int cond) {
     return 0;
 }
 
+static int
+test_timing_wrappers(void) {
+    int rc = 0;
+    struct tm tm_out;
+    time_t fixed = 0;
+
+    errno = 0;
+    rc |= expect_int("localtime rejects null time", dsd_localtime(NULL, &tm_out), -1);
+    rc |= expect_int("localtime null time errno", errno, EINVAL);
+
+    errno = 0;
+    rc |= expect_int("localtime rejects null out", dsd_localtime(&fixed, NULL), -1);
+    rc |= expect_int("localtime null out errno", errno, EINVAL);
+
+    errno = 0;
+    rc |= expect_int("gmtime rejects null time", dsd_gmtime(NULL, &tm_out), -1);
+    rc |= expect_int("gmtime null time errno", errno, EINVAL);
+
+    rc |= expect_int("gmtime epoch", dsd_gmtime(&fixed, &tm_out), 0);
+    rc |= expect_int("gmtime epoch year", tm_out.tm_year, 70);
+    rc |= expect_int("gmtime epoch month", tm_out.tm_mon, 0);
+    rc |= expect_int("gmtime epoch day", tm_out.tm_mday, 1);
+    rc |= expect_int("localtime epoch", dsd_localtime(&fixed, &tm_out), 0);
+
+    uint64_t monotonic_ns = dsd_time_monotonic_ns();
+    uint64_t monotonic_ms = dsd_time_monotonic_ms();
+    uint64_t realtime_before = dsd_time_realtime_ns();
+    uint64_t deadline = dsd_time_deadline_ns(25);
+    uint64_t realtime_after = dsd_time_realtime_ns();
+
+    rc |= expect_true("monotonic ns initialized", monotonic_ns > 0U);
+    rc |= expect_true("monotonic ms initialized", monotonic_ms > 0U);
+    rc |= expect_true("realtime clock initialized", realtime_before > 1000000000000000000ULL);
+    rc |= expect_true("deadline is not before realtime", deadline >= realtime_before);
+    rc |= expect_true("deadline includes requested interval", deadline >= realtime_after);
+    rc |= expect_true("deadline remains close", deadline <= realtime_after + 2000000000ULL);
+
+    dsd_sleep_ns(0);
+    dsd_sleep_us(0);
+    dsd_sleep_ns(1);
+
+    return rc;
+}
+
+static int
+test_threading_wrapper_contracts(void) {
+    int rc = 0;
+
+    rc |= expect_int("mutex_init rejects null", dsd_mutex_init(NULL), EINVAL);
+    rc |= expect_int("mutex_destroy rejects null", dsd_mutex_destroy(NULL), EINVAL);
+    rc |= expect_int("mutex_lock rejects null", dsd_mutex_lock(NULL), EINVAL);
+    rc |= expect_int("mutex_unlock rejects null", dsd_mutex_unlock(NULL), EINVAL);
+    rc |= expect_int("cond_init rejects null", dsd_cond_init(NULL), EINVAL);
+    rc |= expect_int("cond_init_monotonic rejects null", dsd_cond_init_monotonic(NULL), EINVAL);
+    rc |= expect_int("cond_destroy rejects null", dsd_cond_destroy(NULL), EINVAL);
+    rc |= expect_int("cond_wait rejects null cond", dsd_cond_wait(NULL, (dsd_mutex_t*)1), EINVAL);
+    rc |= expect_int("cond_wait rejects null mutex", dsd_cond_wait((dsd_cond_t*)1, NULL), EINVAL);
+    rc |= expect_int("cond_timedwait rejects null cond", dsd_cond_timedwait(NULL, (dsd_mutex_t*)1, 1), EINVAL);
+    rc |= expect_int("cond_timedwait rejects null mutex", dsd_cond_timedwait((dsd_cond_t*)1, NULL, 1), EINVAL);
+    rc |= expect_int("cond_timedwait_monotonic rejects null cond",
+                     dsd_cond_timedwait_monotonic(NULL, (dsd_mutex_t*)1, 1), EINVAL);
+    rc |= expect_int("cond_timedwait_monotonic rejects null mutex",
+                     dsd_cond_timedwait_monotonic((dsd_cond_t*)1, NULL, 1), EINVAL);
+    rc |= expect_int("cond_signal rejects null", dsd_cond_signal(NULL), EINVAL);
+    rc |= expect_int("cond_broadcast rejects null", dsd_cond_broadcast(NULL), EINVAL);
+
+    dsd_thread_t self = dsd_thread_self();
+    rc |= expect_true("thread self is nonzero", (uintptr_t)self != 0U);
+
+#if !DSD_PLATFORM_WIN_NATIVE
+    dsd_thread_t thread;
+    dsd_thread_t* null_thread = NULL;
+    dsd_thread_fn null_fn = NULL;
+    rc |= expect_int("thread_create_impl rejects null thread",
+                     dsd_thread_create_impl(NULL, NULL, immediate_signal_thread_fn), EINVAL);
+    rc |= expect_int("thread_create_impl rejects null function", dsd_thread_create_impl(&thread, NULL, NULL), EINVAL);
+    rc |= expect_int("thread_create macro rejects null thread",
+                     dsd_thread_create(null_thread, immediate_signal_thread_fn, NULL), EINVAL);
+    rc |= expect_int("thread_create macro rejects null function", dsd_thread_create(&thread, null_fn, NULL), EINVAL);
+#endif
+
+    int prio_rc = dsd_thread_set_realtime_priority(-1000);
+    rc |=
+        expect_true("realtime priority wrapper returns status", prio_rc == 0 || prio_rc == EPERM || prio_rc == EINVAL);
+
+    int affinity_rc = dsd_thread_set_affinity(0);
+    rc |= expect_true("affinity wrapper returns status",
+                      affinity_rc == 0 || affinity_rc == EINVAL || affinity_rc == EPERM || affinity_rc == ESRCH);
+
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -56,6 +166,9 @@ main(void) {
     dsd_cond_t cond;
     int fired = 0;
     dsd_thread_t thread;
+
+    rc |= test_timing_wrappers();
+    rc |= test_threading_wrapper_contracts();
 
     rc |= expect_int("mutex_init", dsd_mutex_init(&mutex), 0);
     rc |= expect_int("cond_init_monotonic", dsd_cond_init_monotonic(&cond), 0);
@@ -93,5 +206,23 @@ main(void) {
 
     rc |= expect_int("cond_destroy", dsd_cond_destroy(&cond), 0);
     rc |= expect_int("mutex_destroy", dsd_mutex_destroy(&mutex), 0);
+
+    dsd_cond_t regular_cond;
+    fired = 0;
+    rc |= expect_int("regular mutex_init", dsd_mutex_init(&mutex), 0);
+    rc |= expect_int("regular cond_init", dsd_cond_init(&regular_cond), 0);
+    struct cond_signal_ctx regular_ctx = {&regular_cond, &mutex, &fired};
+    rc |= expect_int("regular thread_create", dsd_thread_create(&thread, immediate_signal_thread_fn, &regular_ctx), 0);
+    rc |= expect_int("regular mutex_lock", dsd_mutex_lock(&mutex), 0);
+    while (!fired) {
+        rc |= expect_int("regular cond_wait", dsd_cond_wait(&regular_cond, &mutex), 0);
+    }
+    rc |= expect_int("regular mutex_unlock", dsd_mutex_unlock(&mutex), 0);
+    rc |= expect_int("regular thread_join", dsd_thread_join(thread), 0);
+    rc |= expect_int("cond_signal success", dsd_cond_signal(&regular_cond), 0);
+    rc |= expect_int("cond_broadcast success", dsd_cond_broadcast(&regular_cond), 0);
+    rc |= expect_int("regular cond_destroy", dsd_cond_destroy(&regular_cond), 0);
+    rc |= expect_int("regular mutex_destroy", dsd_mutex_destroy(&mutex), 0);
+
     return rc ? 1 : 0;
 }

--- a/tests/platform/test_platform_nonce.c
+++ b/tests/platform/test_platform_nonce.c
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/platform/nonce.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/safe_api.h"
+
+static int
+expect_int(const char* label, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "FAIL: %s: got=%d want=%d\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+all_bytes_equal(const unsigned char* bytes, size_t size, unsigned char value) {
+    for (size_t i = 0; i < size; i++) {
+        if (bytes[i] != value) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int
+test_noop_inputs(void) {
+    int rc = 0;
+    unsigned char bytes[8];
+    DSD_MEMSET(bytes, 0xA5, sizeof bytes);
+
+    dsd_nonce_fill(NULL, 16);
+    dsd_nonce_fill(bytes, 0);
+
+    rc |= expect_int("zero-size fill preserves buffer", all_bytes_equal(bytes, sizeof bytes, 0xA5), 1);
+    return rc;
+}
+
+static int
+test_bounded_fill(void) {
+    int rc = 0;
+    unsigned char bytes[24];
+    DSD_MEMSET(bytes, 0xA5, sizeof bytes);
+
+    dsd_nonce_fill(bytes + 4, 16);
+
+    rc |= expect_int("prefix sentinel preserved", all_bytes_equal(bytes, 4, 0xA5), 1);
+    rc |= expect_int("suffix sentinel preserved", all_bytes_equal(bytes + 20, 4, 0xA5), 1);
+    rc |= expect_int("payload bytes written", all_bytes_equal(bytes + 4, 16, 0xA5), 0);
+    return rc;
+}
+
+static int
+test_multiblock_fill(void) {
+    int rc = 0;
+    unsigned char bytes[33];
+    DSD_MEMSET(bytes, 0, sizeof bytes);
+
+    dsd_nonce_fill(bytes, sizeof bytes);
+
+    rc |= expect_int("multi-block payload written", all_bytes_equal(bytes, sizeof bytes, 0), 0);
+    rc |= expect_int("separate generated blocks differ", memcmp(bytes, bytes + 8, 8) == 0, 0);
+    return rc;
+}
+
+static int
+test_u16_wrapper(void) {
+    uint16_t first = dsd_nonce_u16();
+    uint16_t samples[8];
+    for (size_t i = 0; i < sizeof samples / sizeof samples[0]; i++) {
+        samples[i] = dsd_nonce_u16();
+        if (samples[i] != first) {
+            return 0;
+        }
+    }
+    DSD_FPRINTF(stderr, "FAIL: dsd_nonce_u16 returned the same value for every sample: %u\n", (unsigned)first);
+    return 1;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_noop_inputs();
+    rc |= test_bounded_fill();
+    rc |= test_multiblock_fill();
+    rc |= test_u16_wrapper();
+    return rc ? 1 : 0;
+}

--- a/tests/platform/test_platform_socket_resolve.c
+++ b/tests/platform/test_platform_socket_resolve.c
@@ -5,15 +5,19 @@
 
 #include <dsd-neo/platform/platform.h>
 #include <dsd-neo/platform/sockets.h>
+#include <errno.h>
 #include <stdio.h>
+#include <string.h>
 #include "dsd-neo/core/safe_api.h"
 
 #if DSD_PLATFORM_WIN_NATIVE
 #include <winsock2.h>
 #else
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #endif
 
 static int
@@ -47,6 +51,214 @@ expect_numeric_ipv4_resolves(const char* host, int port) {
     return 0;
 }
 
+#if !DSD_PLATFORM_WIN_NATIVE
+static int
+get_bound_addr(dsd_socket_t sock, struct sockaddr_in* addr) {
+    socklen_t len = sizeof(*addr);
+    DSD_MEMSET(addr, 0, sizeof(*addr));
+    if (getsockname(sock, (struct sockaddr*)addr, &len) != 0) {
+        DSD_FPRINTF(stderr, "getsockname failed: %s\n", strerror(errno));
+        return 1;
+    }
+    if (addr->sin_family != AF_INET || ntohs(addr->sin_port) == 0) {
+        DSD_FPRINTF(stderr, "expected bound IPv4 socket with ephemeral port\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_udp_loopback_round_trips(void) {
+    int rc = 0;
+    dsd_socket_t rx = dsd_socket_create(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    dsd_socket_t tx = dsd_socket_create(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (rx == DSD_INVALID_SOCKET || tx == DSD_INVALID_SOCKET) {
+        DSD_FPRINTF(stderr, "failed to create UDP sockets\n");
+        rc = 1;
+        goto done;
+    }
+
+    struct sockaddr_in bind_addr;
+    DSD_MEMSET(&bind_addr, 0, sizeof(bind_addr));
+    bind_addr.sin_family = AF_INET;
+    bind_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    bind_addr.sin_port = htons(0);
+    if (dsd_socket_bind(rx, (const struct sockaddr*)&bind_addr, (int)sizeof(bind_addr)) != 0) {
+        DSD_FPRINTF(stderr, "UDP bind failed: %s\n", strerror(dsd_socket_get_error()));
+        rc = 1;
+        goto done;
+    }
+
+    struct sockaddr_in rx_addr;
+    rc |= get_bound_addr(rx, &rx_addr);
+
+    const struct timeval expected_tv = {.tv_sec = 1, .tv_usec = 250000};
+    if (dsd_socket_set_recv_timeout(rx, 1250) != 0 || dsd_socket_set_send_timeout(tx, 1250) != 0) {
+        DSD_FPRINTF(stderr, "socket timeout setup failed\n");
+        rc = 1;
+        goto done;
+    }
+    struct timeval got_tv;
+    int got_len = (int)sizeof(got_tv);
+    if (dsd_socket_getsockopt(rx, SOL_SOCKET, SO_RCVTIMEO, &got_tv, &got_len) != 0 || got_len != (int)sizeof(got_tv)
+        || got_tv.tv_sec != expected_tv.tv_sec || got_tv.tv_usec != expected_tv.tv_usec) {
+        DSD_FPRINTF(stderr, "receive timeout round-trip mismatch\n");
+        rc = 1;
+    }
+
+    errno = 0;
+    if (dsd_socket_getsockopt(rx, SOL_SOCKET, SO_RCVTIMEO, &got_tv, NULL) != -1 || errno != EINVAL) {
+        DSD_FPRINTF(stderr, "expected getsockopt NULL length to fail with EINVAL\n");
+        rc = 1;
+    }
+
+    if (dsd_socket_set_nonblocking(rx, 1) != 0 || !(fcntl(rx, F_GETFL, 0) & O_NONBLOCK)
+        || dsd_socket_set_nonblocking(rx, 0) != 0 || (fcntl(rx, F_GETFL, 0) & O_NONBLOCK)) {
+        DSD_FPRINTF(stderr, "nonblocking toggle mismatch\n");
+        rc = 1;
+    }
+
+    const char first[] = "udp-sendto";
+    if (dsd_socket_sendto(tx, first, sizeof(first), 0, (const struct sockaddr*)&rx_addr, (int)sizeof(rx_addr))
+        != (int)sizeof(first)) {
+        DSD_FPRINTF(stderr, "UDP sendto failed\n");
+        rc = 1;
+        goto done;
+    }
+    char buf[32];
+    struct sockaddr_in src_addr;
+    int src_len = (int)sizeof(src_addr);
+    DSD_MEMSET(&src_addr, 0, sizeof(src_addr));
+    int n = dsd_socket_recvfrom(rx, buf, sizeof(buf), 0, (struct sockaddr*)&src_addr, &src_len);
+    if (n != (int)sizeof(first) || memcmp(buf, first, sizeof(first)) != 0 || src_len <= 0) {
+        DSD_FPRINTF(stderr, "UDP recvfrom payload/source mismatch\n");
+        rc = 1;
+    }
+
+    if (dsd_socket_connect(tx, (const struct sockaddr*)&rx_addr, (int)sizeof(rx_addr)) != 0) {
+        DSD_FPRINTF(stderr, "UDP connect failed\n");
+        rc = 1;
+        goto done;
+    }
+    const char second[] = "udp-send";
+    if (dsd_socket_send(tx, second, sizeof(second), 0) != (int)sizeof(second)
+        || dsd_socket_recv(rx, buf, sizeof(buf), 0) != (int)sizeof(second)
+        || memcmp(buf, second, sizeof(second)) != 0) {
+        DSD_FPRINTF(stderr, "UDP connected send/recv mismatch\n");
+        rc = 1;
+    }
+
+    errno = EAGAIN;
+    if (dsd_socket_get_error() != EAGAIN) {
+        DSD_FPRINTF(stderr, "socket error wrapper did not return errno\n");
+        rc = 1;
+    }
+
+done:
+    if (rx != DSD_INVALID_SOCKET) {
+        (void)dsd_socket_close(rx);
+    }
+    if (tx != DSD_INVALID_SOCKET) {
+        (void)dsd_socket_close(tx);
+    }
+    return rc;
+}
+
+static int
+expect_tcp_loopback_accepts(void) {
+    int rc = 0;
+    dsd_socket_t listener = dsd_socket_create(AF_INET, SOCK_STREAM, 0);
+    dsd_socket_t client = DSD_INVALID_SOCKET;
+    dsd_socket_t accepted = DSD_INVALID_SOCKET;
+    dsd_socket_t client2 = DSD_INVALID_SOCKET;
+    dsd_socket_t accepted2 = DSD_INVALID_SOCKET;
+    if (listener == DSD_INVALID_SOCKET) {
+        DSD_FPRINTF(stderr, "failed to create TCP listener\n");
+        return 1;
+    }
+
+    int reuse = 1;
+    (void)dsd_socket_setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, &reuse, (int)sizeof(reuse));
+
+    struct sockaddr_in bind_addr;
+    DSD_MEMSET(&bind_addr, 0, sizeof(bind_addr));
+    bind_addr.sin_family = AF_INET;
+    bind_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    bind_addr.sin_port = htons(0);
+    if (dsd_socket_bind(listener, (const struct sockaddr*)&bind_addr, (int)sizeof(bind_addr)) != 0
+        || dsd_socket_listen(listener, 2) != 0) {
+        DSD_FPRINTF(stderr, "TCP bind/listen failed: %s\n", strerror(dsd_socket_get_error()));
+        rc = 1;
+        goto done;
+    }
+
+    struct sockaddr_in listener_addr;
+    rc |= get_bound_addr(listener, &listener_addr);
+
+    client = dsd_socket_create(AF_INET, SOCK_STREAM, 0);
+    if (client == DSD_INVALID_SOCKET
+        || dsd_socket_connect(client, (const struct sockaddr*)&listener_addr, (int)sizeof(listener_addr)) != 0) {
+        DSD_FPRINTF(stderr, "TCP connect failed: %s\n", strerror(dsd_socket_get_error()));
+        rc = 1;
+        goto done;
+    }
+
+    struct sockaddr_in peer_addr;
+    int peer_len = (int)sizeof(peer_addr);
+    DSD_MEMSET(&peer_addr, 0, sizeof(peer_addr));
+    accepted = dsd_socket_accept(listener, (struct sockaddr*)&peer_addr, &peer_len);
+    if (accepted == DSD_INVALID_SOCKET || peer_len <= 0 || peer_addr.sin_family != AF_INET) {
+        DSD_FPRINTF(stderr, "TCP accept with peer address failed\n");
+        rc = 1;
+        goto done;
+    }
+
+    const char payload[] = "tcp-payload";
+    char buf[32];
+    if (dsd_socket_send(client, payload, sizeof(payload), 0) != (int)sizeof(payload)
+        || dsd_socket_recv(accepted, buf, sizeof(buf), 0) != (int)sizeof(payload)
+        || memcmp(buf, payload, sizeof(payload)) != 0) {
+        DSD_FPRINTF(stderr, "TCP send/recv payload mismatch\n");
+        rc = 1;
+    }
+    if (dsd_socket_shutdown(accepted, SHUT_RDWR) != 0) {
+        DSD_FPRINTF(stderr, "TCP shutdown failed\n");
+        rc = 1;
+    }
+
+    client2 = dsd_socket_create(AF_INET, SOCK_STREAM, 0);
+    if (client2 == DSD_INVALID_SOCKET
+        || dsd_socket_connect(client2, (const struct sockaddr*)&listener_addr, (int)sizeof(listener_addr)) != 0) {
+        DSD_FPRINTF(stderr, "second TCP connect failed\n");
+        rc = 1;
+        goto done;
+    }
+    accepted2 = dsd_socket_accept(listener, NULL, NULL);
+    if (accepted2 == DSD_INVALID_SOCKET) {
+        DSD_FPRINTF(stderr, "TCP accept with NULL peer address failed\n");
+        rc = 1;
+    }
+
+done:
+    if (accepted2 != DSD_INVALID_SOCKET) {
+        (void)dsd_socket_close(accepted2);
+    }
+    if (client2 != DSD_INVALID_SOCKET) {
+        (void)dsd_socket_close(client2);
+    }
+    if (accepted != DSD_INVALID_SOCKET) {
+        (void)dsd_socket_close(accepted);
+    }
+    if (client != DSD_INVALID_SOCKET) {
+        (void)dsd_socket_close(client);
+    }
+    if (listener != DSD_INVALID_SOCKET) {
+        (void)dsd_socket_close(listener);
+    }
+    return rc;
+}
+#endif
+
 int
 main(void) {
     int rc = 0;
@@ -57,6 +269,18 @@ main(void) {
 
     rc |= expect_numeric_ipv4_resolves("127.0.0.1", 7355);
     rc |= expect_numeric_ipv4_resolves("192.168.1.50", 7355);
+    if (dsd_socket_resolve(NULL, 7355, &(struct sockaddr_in){0}) != -1) {
+        DSD_FPRINTF(stderr, "expected NULL hostname resolve to fail\n");
+        rc = 1;
+    }
+    if (dsd_socket_resolve("127.0.0.1", 7355, NULL) != -1) {
+        DSD_FPRINTF(stderr, "expected NULL output resolve to fail\n");
+        rc = 1;
+    }
+#if !DSD_PLATFORM_WIN_NATIVE
+    rc |= expect_udp_loopback_round_trips();
+    rc |= expect_tcp_loopback_accepts();
+#endif
 
     dsd_socket_cleanup();
     return rc ? 1 : 0;

--- a/tests/protocol/dmr/test_dmr_bit_utils.c
+++ b/tests/protocol/dmr/test_dmr_bit_utils.c
@@ -37,6 +37,18 @@ test_hamming17123_single_bit_correction(void) {
     }
 }
 
+static void
+test_hamming17123_uncorrectable_word_is_rejected(void) {
+    uint8_t word[17];
+    uint8_t expected[17];
+    build_slc17(expected, 0x5A6U);
+    DSD_MEMCPY(word, expected, sizeof(word));
+
+    word[0] ^= 1U;
+    word[2] ^= 1U;
+    assert(Hamming17123(word) == false);
+}
+
 int
 main(void) {
     // Build a 16-bit pattern 0xABCD in MSB-first bit order
@@ -52,6 +64,7 @@ main(void) {
     assert(ConvertBitIntoBytes(bits, 0) == 0ULL);
 
     test_hamming17123_single_bit_correction();
+    test_hamming17123_uncorrectable_word_is_rejected();
 
     printf("DMR bit utils: OK\n");
     return 0;

--- a/tests/protocol/dmr/test_dmr_block_crypto.c
+++ b/tests/protocol/dmr/test_dmr_block_crypto.c
@@ -396,6 +396,31 @@ test_aes_missing_key_still_normalizes_alg(void) {
     return rc;
 }
 
+static int
+test_malformed_window_decrypt_rejects_without_mutating_payload(void) {
+    static dsd_state state;
+    dmr_block_crypto_ctx ctx;
+    const uint8_t slot = 0;
+    const uint8_t start = 12U;
+    uint8_t before[sizeof(state.dmr_pdu_sf[slot])];
+    int rc = 0;
+
+    seed_window(&state, slot, start, 32U);
+    state.payload_algid = 1;
+    state.payload_keyid = 0x33;
+    state.payload_mi = 0x01020304ULL;
+    state.rkey_array[0x33] = 0x0123456789ULL;
+    fill_pattern(state.dmr_pdu_sf[slot], sizeof(state.dmr_pdu_sf[slot]), 0x91U);
+    DSD_MEMCPY(before, state.dmr_pdu_sf[slot], sizeof(before));
+
+    dmr_block_crypto_load_ctx(&state, slot, 1, 24, &ctx);
+    rc |= expect_int("malformed ctx keeps start", ctx.start, start);
+    rc |= expect_int("malformed ctx empty window", ctx.end, 0);
+    rc |= expect_int("malformed decrypt result", dmr_block_crypto_decrypt_payload(&state, slot, &ctx, 0), 0);
+    rc |= expect_bytes("malformed decrypt preserves payload", state.dmr_pdu_sf[slot], before, sizeof(before));
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -408,5 +433,6 @@ main(void) {
     rc |= test_des_decrypts_window_with_manual_key_fallback();
     rc |= test_basic_privacy_decrypts_window();
     rc |= test_aes_missing_key_still_normalizes_alg();
+    rc |= test_malformed_window_decrypt_rejects_without_mutating_payload();
     return rc;
 }

--- a/tests/protocol/dmr/test_dmr_bs_sync_times.c
+++ b/tests/protocol/dmr/test_dmr_bs_sync_times.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(performance-no-int-to-ptr)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -32,21 +35,143 @@
 
 volatile uint8_t exitflag = 0;
 
-static uint8_t g_dibits[256];
+static uint8_t g_dibits[512];
+static int g_bootstrap_payload[90];
 static size_t g_dibit_index = 0;
+static unsigned int g_open_left_calls;
+static unsigned int g_open_right_calls;
+static unsigned int g_close_left_calls;
+static unsigned int g_close_right_calls;
+static unsigned int g_process_mbe_calls;
+static unsigned int g_play_fs3_calls;
+static unsigned int g_play_ss3_calls;
+static unsigned int g_ui_redraw_calls;
+static unsigned int g_history_calls[2];
+static unsigned int g_current_calls[2];
+static unsigned int g_data_sync_calls;
+static unsigned int g_data_burst_calls;
+static uint8_t g_data_burst_last;
+static unsigned int g_debug_dump_calls;
+static uint8_t g_debug_dump_last_slot;
+static uint8_t g_debug_dump_last_type;
+static unsigned int g_cach_calls;
+static unsigned int g_reset_blocks_calls;
+static unsigned int g_alg_refresh_calls;
+static unsigned int g_alg_reset_calls;
+static unsigned int g_refresh_error_calls;
+static unsigned int g_hytera_refresh_calls;
+static unsigned int g_late_entry_calls;
+static uint8_t g_late_entry_last_vc;
+static unsigned int g_sbrc_calls;
+static uint8_t g_sbrc_last_power;
+static unsigned int g_sm_voice_sync_calls;
+static int g_sm_voice_sync_last_slot;
+static unsigned int g_sm_tick_calls;
+static unsigned int g_confidence_reset_calls;
+static unsigned int g_confidence_reset_slot_calls;
+static unsigned int g_confidence_reset_last_slot;
+static unsigned int g_confidence_voice_sync_calls;
+static unsigned int g_confidence_voice_burst_calls;
+static dmr_confidence_result g_confidence_result = DMR_CONFIDENCE_LOCKED;
+static int g_voice_slot_open = 1;
+static int g_any_voice_open = 0;
 
 static void
-load_voice_burst_stream(void) {
-    DSD_MEMSET(g_dibits, 0, sizeof(g_dibits));
+reset_spies(void) {
     g_dibit_index = 0;
+    g_open_left_calls = 0;
+    g_open_right_calls = 0;
+    g_close_left_calls = 0;
+    g_close_right_calls = 0;
+    g_process_mbe_calls = 0;
+    g_play_fs3_calls = 0;
+    g_play_ss3_calls = 0;
+    g_ui_redraw_calls = 0;
+    g_history_calls[0] = 0;
+    g_history_calls[1] = 0;
+    g_current_calls[0] = 0;
+    g_current_calls[1] = 0;
+    g_data_sync_calls = 0;
+    g_data_burst_calls = 0;
+    g_data_burst_last = 0;
+    g_debug_dump_calls = 0;
+    g_debug_dump_last_slot = 0xFFU;
+    g_debug_dump_last_type = 0;
+    g_cach_calls = 0;
+    g_reset_blocks_calls = 0;
+    g_alg_refresh_calls = 0;
+    g_alg_reset_calls = 0;
+    g_refresh_error_calls = 0;
+    g_hytera_refresh_calls = 0;
+    g_late_entry_calls = 0;
+    g_late_entry_last_vc = 0;
+    g_sbrc_calls = 0;
+    g_sbrc_last_power = 0;
+    g_sm_voice_sync_calls = 0;
+    g_sm_voice_sync_last_slot = -1;
+    g_sm_tick_calls = 0;
+    g_confidence_reset_calls = 0;
+    g_confidence_reset_slot_calls = 0;
+    g_confidence_reset_last_slot = 0xFFU;
+    g_confidence_voice_sync_calls = 0;
+    g_confidence_voice_burst_calls = 0;
+    g_confidence_result = DMR_CONFIDENCE_LOCKED;
+    g_voice_slot_open = 1;
+    g_any_voice_open = 0;
+    exitflag = 0;
+}
+
+static void
+set_cach_tact_bit(size_t burst_start, uint8_t tact_index, uint8_t value) {
+    static const int cach_interleave[24] = {
+        0, 7, 8, 9, 1, 10, 11, 12, 2, 13, 14, 15, 3, 16, 4, 17, 18, 19, 5, 20, 21, 22, 6, 23,
+    };
+    for (size_t packed = 0; packed < 24U; packed++) {
+        if (cach_interleave[packed] != tact_index) {
+            continue;
+        }
+        uint8_t mask = (uint8_t)(packed % 2U == 0U ? 2U : 1U);
+        if (value != 0U) {
+            g_dibits[burst_start + (packed / 2U)] |= mask;
+        } else {
+            g_dibits[burst_start + (packed / 2U)] &= (uint8_t)~mask;
+        }
+        return;
+    }
+}
+
+static void
+set_sync_dibits(size_t burst_start, const char* sync) {
+    const size_t sync_offset = burst_start + 12U + 36U + 18U;
+    for (size_t i = 0; sync[i] != '\0'; i++) {
+        g_dibits[sync_offset + i] = (sync[i] == '3') ? 2U : 0U;
+    }
+}
+
+static void
+load_single_burst_stream(uint8_t slot, const char* sync) {
+    DSD_MEMSET(g_dibits, 0, sizeof(g_dibits));
+    reset_spies();
 
     g_dibits[12U + 16U] = 1U;
     g_dibits[144U + 12U + 16U] = 1U;
+    set_cach_tact_bit(0, 1, slot);
+    set_sync_dibits(0, sync);
+}
 
-    const size_t sync_offset = 12U + 36U + 18U;
-    for (size_t i = 0; DMR_BS_VOICE_SYNC[i] != '\0'; i++) {
-        g_dibits[sync_offset + i] = (DMR_BS_VOICE_SYNC[i] == '3') ? 2U : 0U;
+static void
+load_voice_burst_stream(void) {
+    load_single_burst_stream(0, DMR_BS_VOICE_SYNC);
+}
+
+static void
+load_bootstrap_voice_stream(uint8_t slot) {
+    load_single_burst_stream(slot, DMR_BS_VOICE_SYNC);
+    for (size_t i = 0; i < 90U; i++) {
+        g_bootstrap_payload[i] = g_dibits[i];
     }
+    DSD_MEMSET(g_dibits + 144U, 0, 144U);
+    g_dibit_index = 90U;
 }
 
 int
@@ -97,26 +222,30 @@ dsd_fopen_private(const char* path, const char* mode) {
 
 void
 openMbeOutFile(dsd_opts* opts, dsd_state* state) {
-    (void)opts;
     (void)state;
+    g_open_left_calls++;
+    opts->mbe_out_f = (FILE*)(uintptr_t)1;
 }
 
 void
 openMbeOutFileR(dsd_opts* opts, dsd_state* state) {
-    (void)opts;
     (void)state;
+    g_open_right_calls++;
+    opts->mbe_out_fR = (FILE*)(uintptr_t)1;
 }
 
 void
 closeMbeOutFile(dsd_opts* opts, dsd_state* state) {
-    (void)opts;
     (void)state;
+    g_close_left_calls++;
+    opts->mbe_out_f = NULL;
 }
 
 void
 closeMbeOutFileR(dsd_opts* opts, dsd_state* state) {
-    (void)opts;
     (void)state;
+    g_close_right_calls++;
+    opts->mbe_out_fR = NULL;
 }
 
 void
@@ -126,38 +255,42 @@ processMbeFrame(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], char ambe
     (void)imbe_fr;
     (void)ambe_fr;
     (void)imbe7100_fr;
+    g_process_mbe_calls++;
 }
 
 void
 playSynthesizedVoiceFS3(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_play_fs3_calls++;
 }
 
 void
 playSynthesizedVoiceSS3(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_play_ss3_calls++;
 }
 
 void
 ui_publish_both_and_redraw(const dsd_opts* opts, const dsd_state* state) {
     (void)opts;
     (void)state;
+    g_ui_redraw_calls++;
 }
 
 void
 watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot) {
     (void)opts;
     (void)state;
-    (void)slot;
+    g_history_calls[slot & 1U]++;
 }
 
 void
 watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) {
     (void)opts;
     (void)state;
-    (void)slot;
+    g_current_calls[slot & 1U]++;
 }
 
 void
@@ -177,6 +310,7 @@ void
 dmr_data_sync(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_data_sync_calls++;
 }
 
 void
@@ -184,15 +318,17 @@ dmr_data_burst_handler(dsd_opts* opts, dsd_state* state, uint8_t info[196], uint
     (void)opts;
     (void)state;
     (void)info;
-    (void)databurst;
+    g_data_burst_calls++;
+    g_data_burst_last = databurst;
 }
 
 void
 dmr_debug_dump_burst(const dsd_opts* opts, const dsd_state* state, uint8_t slot_index, uint8_t burst_type) {
     (void)opts;
     (void)state;
-    (void)slot_index;
-    (void)burst_type;
+    g_debug_dump_calls++;
+    g_debug_dump_last_slot = slot_index;
+    g_debug_dump_last_type = burst_type;
 }
 
 uint8_t
@@ -200,6 +336,7 @@ dmr_cach(dsd_opts* opts, dsd_state* state, uint8_t cach_bits[25]) {
     (void)opts;
     (void)state;
     (void)cach_bits;
+    g_cach_calls++;
     return 0;
 }
 
@@ -207,29 +344,34 @@ void
 dmr_reset_blocks(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_reset_blocks_calls++;
 }
 
 void
 dmr_alg_refresh(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_alg_refresh_calls++;
 }
 
 void
 dmr_alg_reset(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_alg_reset_calls++;
 }
 
 void
 dmr_refresh_algids_on_error(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_refresh_error_calls++;
 }
 
 void
 hytera_enhanced_alg_refresh(dsd_state* state) {
     (void)state;
+    g_hytera_refresh_calls++;
 }
 
 void
@@ -241,43 +383,51 @@ dmr_late_entry_mi_fragment(dsd_opts* opts, dsd_state* state, uint8_t vc, uint8_t
     (void)ambe_fr;
     (void)ambe_fr2;
     (void)ambe_fr3;
+    g_late_entry_calls++;
+    g_late_entry_last_vc = vc;
 }
 
 void
 dmr_sbrc(const dsd_opts* opts, dsd_state* state, uint8_t power) {
     (void)opts;
     (void)state;
-    (void)power;
+    g_sbrc_calls++;
+    g_sbrc_last_power = power;
 }
 
 void
 dmr_sm_emit_voice_sync(dsd_opts* opts, dsd_state* state, int slot) {
     (void)opts;
     (void)state;
-    (void)slot;
+    g_sm_voice_sync_calls++;
+    g_sm_voice_sync_last_slot = slot;
 }
 
 void
 dmr_sm_tick(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_sm_tick_calls++;
 }
 
 void
 dmr_confidence_reset(dsd_state* state) {
     (void)state;
+    g_confidence_reset_calls++;
 }
 
 void
 dmr_confidence_reset_slot(dsd_state* state, unsigned int slot) {
     (void)state;
-    (void)slot;
+    g_confidence_reset_slot_calls++;
+    g_confidence_reset_last_slot = slot;
 }
 
 void
 dmr_confidence_note_voice_sync(dsd_state* state, unsigned int slot) {
     (void)state;
     (void)slot;
+    g_confidence_voice_sync_calls++;
 }
 
 dmr_confidence_result
@@ -285,20 +435,21 @@ dmr_confidence_note_voice_burst(dsd_state* state, unsigned int slot, unsigned in
     (void)state;
     (void)slot;
     (void)color_code;
-    return DMR_CONFIDENCE_LOCKED;
+    g_confidence_voice_burst_calls++;
+    return g_confidence_result;
 }
 
 int
 dmr_confidence_voice_slot_open(const dsd_state* state, unsigned int slot) {
     (void)state;
     (void)slot;
-    return 1;
+    return g_voice_slot_open;
 }
 
 int
 dmr_confidence_any_voice_open(const dsd_state* state) {
     (void)state;
-    return 0;
+    return g_any_voice_open;
 }
 
 static void
@@ -321,9 +472,191 @@ test_bs_voice_sync_refreshes_when_trunk_alias_tuned(void) {
     assert(state.last_cc_sync_time_m > 0.0);
 }
 
+static void
+test_bs_slot2_voice_routes_right_channel_and_post_skip_hooks(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.floating_point = 1;
+    opts.pulse_digi_rate_out = 8000;
+    opts.use_ncurses_terminal = 1;
+    DSD_SNPRINTF(opts.mbe_out_dir, sizeof(opts.mbe_out_dir), "%s", "captures");
+    state.currentslot = 1;
+    state.dmr_color_code = 16;
+    load_single_burst_stream(1, DMR_BS_VOICE_SYNC);
+    g_any_voice_open = 1;
+
+    dmrBS(&opts, &state);
+
+    assert(state.dmrburstR == 16);
+    assert(g_open_right_calls == 1U);
+    assert(g_open_left_calls == 0U);
+    assert(g_close_right_calls == 1U);
+    assert(g_process_mbe_calls == 3U);
+    assert(g_play_fs3_calls == 1U);
+    assert(g_play_ss3_calls == 0U);
+    assert(g_ui_redraw_calls == 1U);
+    assert(g_history_calls[0] == 1U);
+    assert(g_history_calls[1] == 1U);
+    assert(g_current_calls[0] == 1U);
+    assert(g_current_calls[1] == 1U);
+    assert(g_debug_dump_calls == 1U);
+    assert(g_debug_dump_last_slot == 1U);
+    assert(g_debug_dump_last_type == 0x10U);
+    assert(g_cach_calls == 1U);
+    assert(g_late_entry_calls == 1U);
+    assert(g_late_entry_last_vc == 1U);
+    assert(g_sm_voice_sync_calls == 1U);
+    assert(g_sm_voice_sync_last_slot == 1);
+    assert(g_sm_tick_calls == 1U);
+    assert(g_confidence_voice_sync_calls == 1U);
+    assert(g_confidence_voice_burst_calls == 1U);
+}
+
+static void
+test_bs_slot2_voice_integer_output_uses_ss3_playback(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.floating_point = 0;
+    opts.pulse_digi_rate_out = 8000;
+    state.currentslot = 1;
+    state.dmr_color_code = 16;
+    load_single_burst_stream(1, DMR_BS_VOICE_SYNC);
+    g_any_voice_open = 1;
+
+    dmrBS(&opts, &state);
+
+    assert(state.dmrburstR == 16);
+    assert(g_play_fs3_calls == 0U);
+    assert(g_play_ss3_calls == 1U);
+    assert(g_process_mbe_calls == 3U);
+    assert(g_sm_voice_sync_last_slot == 1);
+}
+
+static void
+test_bs_data_sync_closes_slot_file_and_resets_error_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.mbe_out_fR = (FILE*)(uintptr_t)1;
+    state.currentslot = 1;
+    load_single_burst_stream(1, DMR_BS_DATA_SYNC);
+
+    dmrBS(&opts, &state);
+
+    assert(g_data_sync_calls == 1U);
+    assert(g_close_right_calls == 1U);
+    assert(opts.mbe_out_fR == NULL);
+    assert(g_process_mbe_calls == 0U);
+    assert(g_sm_voice_sync_calls == 0U);
+    assert(g_reset_blocks_calls == 1U);
+    assert(g_refresh_error_calls == 1U);
+    assert(g_confidence_reset_calls == 1U);
+}
+
+static void
+test_bs_confidence_reject_resets_slot_without_voice_decode(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.currentslot = 0;
+    state.dmr_color_code = 16;
+    load_single_burst_stream(0, DMR_BS_VOICE_SYNC);
+    g_confidence_result = DMR_CONFIDENCE_REJECT;
+
+    dmrBS(&opts, &state);
+
+    assert(g_confidence_voice_sync_calls == 1U);
+    assert(g_confidence_voice_burst_calls == 1U);
+    assert(g_confidence_reset_slot_calls == 1U);
+    assert(g_confidence_reset_last_slot == 0U);
+    assert(g_debug_dump_calls == 0U);
+    assert(g_process_mbe_calls == 0U);
+    assert(g_reset_blocks_calls == 1U);
+    assert(g_refresh_error_calls == 1U);
+    assert(g_confidence_reset_calls == 1U);
+}
+
+static void
+test_bs_voice_gate_closed_skips_decode_but_keeps_loop_hooks(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.use_ncurses_terminal = 1;
+    state.currentslot = 0;
+    state.dmr_color_code = 16;
+    load_single_burst_stream(0, DMR_BS_VOICE_SYNC);
+    g_voice_slot_open = 0;
+
+    dmrBS(&opts, &state);
+
+    assert(g_confidence_voice_sync_calls == 1U);
+    assert(g_confidence_voice_burst_calls == 1U);
+    assert(g_debug_dump_calls == 0U);
+    assert(g_process_mbe_calls == 0U);
+    assert(g_late_entry_calls == 0U);
+    assert(g_sm_voice_sync_calls == 0U);
+    assert(g_ui_redraw_calls == 1U);
+    assert(g_history_calls[0] == 1U);
+    assert(g_history_calls[1] == 1U);
+    assert(g_current_calls[0] == 1U);
+    assert(g_current_calls[1] == 1U);
+    assert(g_sm_tick_calls == 1U);
+}
+
+static void
+test_bs_bootstrap_prefetched_voice_runs_first_frame_path(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.trunk_is_tuned = 1;
+    opts.floating_point = 1;
+    opts.pulse_digi_rate_out = 8000;
+    DSD_SNPRINTF(opts.mbe_out_dir, sizeof(opts.mbe_out_dir), "%s", "captures");
+    state.currentslot = 1;
+    state.dmr_color_code = 16;
+    state.dmr_payload_p = g_bootstrap_payload + 90U;
+    load_bootstrap_voice_stream(1);
+    g_any_voice_open = 1;
+
+    dmrBSBootstrap(&opts, &state);
+
+    assert(g_debug_dump_calls >= 1U);
+    assert(g_alg_reset_calls == 1U);
+    assert(g_process_mbe_calls >= 3U);
+    assert(g_cach_calls >= 1U);
+    assert(g_late_entry_calls >= 1U);
+    assert(g_open_right_calls == 1U);
+    assert(g_close_right_calls >= 1U);
+    assert(g_play_fs3_calls >= 1U);
+    assert(state.last_vc_sync_time > 0);
+    assert(state.last_vc_sync_time_m > 0.0);
+}
+
 int
 main(void) {
     test_bs_voice_sync_refreshes_when_trunk_alias_tuned();
+    test_bs_slot2_voice_routes_right_channel_and_post_skip_hooks();
+    test_bs_slot2_voice_integer_output_uses_ss3_playback();
+    test_bs_data_sync_closes_slot_file_and_resets_error_state();
+    test_bs_confidence_reject_resets_slot_without_voice_decode();
+    test_bs_voice_gate_closed_skips_decode_but_keeps_loop_hooks();
+    test_bs_bootstrap_prefetched_voice_runs_first_frame_path();
     printf("DMR BS sync times: OK\n");
     return 0;
 }
+
+// NOLINTEND(performance-no-int-to-ptr)

--- a/tests/protocol/dmr/test_dmr_confidence_gate.c
+++ b/tests/protocol/dmr/test_dmr_confidence_gate.c
@@ -38,8 +38,10 @@ test_idle_data_can_lock_color_code(void) {
 
     assert(dmr_confidence_note_data_burst(&state, 3, 9) == DMR_CONFIDENCE_PENDING);
     assert(dmr_confidence_note_data_burst(&state, 3, 9) == DMR_CONFIDENCE_LOCKED);
+    assert(dmr_confidence_note_data_burst(&state, 3, 1) == DMR_CONFIDENCE_LOCKED);
     assert(state.dmr_confidence_locked == 1);
     assert(state.dmr_confidence_color_code == 3);
+    assert(state.dmr_confidence_mismatch_count == 0);
     assert(state.dmr_color_code == 3);
 }
 
@@ -69,6 +71,19 @@ test_voice_requires_voice_sync_before_open(void) {
     assert(dmr_confidence_note_voice_burst(&state, 1, 3) == DMR_CONFIDENCE_LOCKED);
     assert(dmr_confidence_voice_slot_open(&state, 1) == 1);
     assert(dmr_confidence_any_voice_open(&state) == 1);
+
+    dmr_confidence_note_voice_sync(&state, 0);
+    assert(dmr_confidence_note_voice_burst(&state, 0, 3) == DMR_CONFIDENCE_PENDING);
+    assert(dmr_confidence_note_voice_burst(&state, 0, 3) == DMR_CONFIDENCE_LOCKED);
+    assert(dmr_confidence_voice_slot_open(&state, 0) == 1);
+
+    dmr_confidence_reset_slot(&state, 1);
+    assert(dmr_confidence_voice_slot_open(&state, 1) == 0);
+    assert(dmr_confidence_voice_slot_open(&state, 0) == 1);
+    assert(dmr_confidence_any_voice_open(&state) == 1);
+
+    dmr_confidence_reset_slot(&state, 7);
+    assert(dmr_confidence_voice_slot_open(&state, 0) == 1);
 }
 
 static void

--- a/tests/protocol/dmr/test_dmr_crc_masks.c
+++ b/tests/protocol/dmr/test_dmr_crc_masks.c
@@ -13,6 +13,7 @@
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include "dsd-neo/core/safe_api.h"
 
 #define RS_12_9_DATASIZE     9
@@ -33,6 +34,26 @@ uint32_t ComputeAndCorrectFullLinkControlCrc(uint8_t* FullLinkControlDataBytes, 
                                              uint32_t CRCMask);
 
 static void
+build_masked_lc_codeword(rs_12_9_codeword_t* cw, uint32_t mask24, uint32_t* parity_unmasked) {
+    // Build a 12-byte LC codeword with valid RS(12,9) parity, then mask it.
+    DSD_MEMSET(cw, 0, sizeof(*cw));
+
+    // Deterministic 9-byte LC payload
+    for (int i = 0; i < RS_12_9_DATASIZE; i++) {
+        cw->data[i] = (uint8_t)(0x10 + i * 7);
+    }
+
+    rs_12_9_checksum_t* chk = rs_12_9_calc_checksum(cw);
+    // Save unmasked parity for later comparison
+    *parity_unmasked = ((uint32_t)chk->bytes[0] << 16) | ((uint32_t)chk->bytes[1] << 8) | ((uint32_t)chk->bytes[2]);
+
+    // Write masked parity into cw
+    cw->data[9] = (uint8_t)(chk->bytes[0] ^ (uint8_t)(mask24 >> 16));
+    cw->data[10] = (uint8_t)(chk->bytes[1] ^ (uint8_t)(mask24 >> 8));
+    cw->data[11] = (uint8_t)(chk->bytes[2] ^ (uint8_t)(mask24 >> 0));
+}
+
+static void
 append_bits(uint8_t* dst, unsigned start, uint32_t val, unsigned k) {
     // Append k bits of val MSB-first into dst starting at index 'start'
     for (unsigned i = 0; i < k; i++) {
@@ -43,24 +64,9 @@ append_bits(uint8_t* dst, unsigned start, uint32_t val, unsigned k) {
 
 static void
 test_lc_crc24_mask(uint32_t mask24) {
-    // Build a 12-byte LC codeword with valid RS(12,9) parity, then mask it.
     rs_12_9_codeword_t cw;
-    DSD_MEMSET(&cw, 0, sizeof(cw));
-
-    // Deterministic 9-byte LC payload
-    for (int i = 0; i < RS_12_9_DATASIZE; i++) {
-        cw.data[i] = (uint8_t)(0x10 + i * 7);
-    }
-
-    rs_12_9_checksum_t* chk = rs_12_9_calc_checksum(&cw);
-    // Save unmasked parity for later comparison
-    uint32_t parity_unmasked =
-        ((uint32_t)chk->bytes[0] << 16) | ((uint32_t)chk->bytes[1] << 8) | ((uint32_t)chk->bytes[2]);
-
-    // Write masked parity into cw
-    cw.data[9] = (uint8_t)(chk->bytes[0] ^ (uint8_t)(mask24 >> 16));
-    cw.data[10] = (uint8_t)(chk->bytes[1] ^ (uint8_t)(mask24 >> 8));
-    cw.data[11] = (uint8_t)(chk->bytes[2] ^ (uint8_t)(mask24 >> 0));
+    uint32_t parity_unmasked = 0;
+    build_masked_lc_codeword(&cw, mask24, &parity_unmasked);
 
     // Feed into CRC check/correct with the same mask
     uint32_t crc_computed = 0;
@@ -69,12 +75,41 @@ test_lc_crc24_mask(uint32_t mask24) {
     assert(crc_computed == parity_unmasked);
 
     // Ensure output remains masked
+    rs_12_9_checksum_t* chk = rs_12_9_calc_checksum(&cw);
     assert(cw.data[9] == (uint8_t)(chk->bytes[0] ^ (uint8_t)(mask24 >> 16)));
     assert(cw.data[10] == (uint8_t)(chk->bytes[1] ^ (uint8_t)(mask24 >> 8)));
     assert(cw.data[11] == (uint8_t)(chk->bytes[2] ^ (uint8_t)(mask24 >> 0)));
+}
 
-    // Note: Do not assert failure cases here; RS(12,9) correction behavior may
-    // vary with error locations. This test focuses on mask application success.
+static void
+test_lc_crc24_corrects_single_byte_error(void) {
+    rs_12_9_codeword_t cw;
+    rs_12_9_codeword_t expected;
+    uint32_t parity_unmasked = 0;
+    const uint32_t mask24 = 0x969696U;
+    build_masked_lc_codeword(&cw, mask24, &parity_unmasked);
+    DSD_MEMCPY(&expected, &cw, sizeof(expected));
+
+    cw.data[2] ^= 0x55U;
+    uint32_t crc_computed = 0;
+    uint32_t ok = ComputeAndCorrectFullLinkControlCrc(cw.data, &crc_computed, mask24);
+    assert(ok == 1);
+    assert(crc_computed == parity_unmasked);
+    assert(memcmp(cw.data, expected.data, sizeof(cw.data)) == 0);
+}
+
+static void
+test_lc_crc24_rejects_uncorrectable_error(void) {
+    rs_12_9_codeword_t cw;
+    uint32_t parity_unmasked = 0;
+    const uint32_t mask24 = 0x999999U;
+    build_masked_lc_codeword(&cw, mask24, &parity_unmasked);
+
+    cw.data[1] ^= 0x22U;
+    cw.data[7] ^= 0x11U;
+    uint32_t crc_computed = 0;
+    uint32_t ok = ComputeAndCorrectFullLinkControlCrc(cw.data, &crc_computed, mask24);
+    assert(ok == 0);
 }
 
 static void
@@ -113,6 +148,8 @@ main(void) {
     // 24-bit LC masks (VLC/TLC)
     test_lc_crc24_mask(0x969696); // VLC
     test_lc_crc24_mask(0x999999); // TLC
+    test_lc_crc24_corrects_single_byte_error();
+    test_lc_crc24_rejects_uncorrectable_error();
 
     // 16-bit CCITT masks for other PDUs
     test_ccitt16_mask(0x6969); // PI

--- a/tests/protocol/dmr/test_dmr_crc_props.c
+++ b/tests/protocol/dmr/test_dmr_crc_props.c
@@ -51,6 +51,35 @@ test_crc8_append_property(void) {
 }
 
 static void
+test_crc7_crc8_length_guards(void) {
+    uint8_t bits[256];
+    DSD_MEMSET(bits, 1, sizeof(bits));
+
+    assert(crc8(bits, 248U) != 0U);
+    assert(crc8(bits, 249U) == 0U);
+    assert(crc7(bits, 249U) != 0U);
+    assert(crc7(bits, 250U) == 0U);
+}
+
+static void
+test_crc5_sum_mod31_contract(void) {
+    uint8_t zero_bits[72];
+    uint8_t patterned_bits[72];
+    DSD_MEMSET(zero_bits, 0, sizeof(zero_bits));
+    DSD_MEMSET(patterned_bits, 0, sizeof(patterned_bits));
+
+    assert(ComputeCrc5Bit(zero_bits) == 0U);
+
+    for (unsigned byte = 0; byte < 9U; byte++) {
+        uint8_t value = (uint8_t)(byte + 1U);
+        for (unsigned bit = 0; bit < 8U; bit++) {
+            patterned_bits[(byte * 8U) + bit] = (uint8_t)((value >> (7U - bit)) & 1U);
+        }
+    }
+    assert(ComputeCrc5Bit(patterned_bits) == 14U);
+}
+
+static void
 test_crc3_append_property(void) {
     uint8_t bits[16] = {1, 1, 0, 1, 0, 0, 1, 1};
     unsigned L = 8;
@@ -91,6 +120,8 @@ int
 main(void) {
     test_crc7_append_property();
     test_crc8_append_property();
+    test_crc7_crc8_length_guards();
+    test_crc5_sum_mod31_contract();
     test_crc3_append_property();
     test_crc4_append_property();
     test_ccitt_zeros();

--- a/tests/protocol/dmr/test_dmr_csbk_helpers.c
+++ b/tests/protocol/dmr/test_dmr_csbk_helpers.c
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Focused coverage for DMR CSBK parse/table helper contracts.
+ */
+
+#include "dsd-neo/core/safe_api.h"
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/protocol/dmr/dmr_csbk_parse.h>
+#include <dsd-neo/protocol/dmr/dmr_csbk_tables.h>
+#include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
+#include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int g_group_calls;
+static int g_indiv_calls;
+static long g_last_freq;
+static int g_last_lpcn;
+static int g_last_target;
+static int g_last_source;
+
+uint64_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ConvertBitIntoBytes(const uint8_t* bits, uint32_t n) {
+    uint64_t value = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        value = (value << 1U) | (uint64_t)(bits[i] & 1U);
+    }
+    return value;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_sm_emit_group_grant(dsd_opts* opts, dsd_state* state, long freq_hz, int lpcn, int tg, int src) {
+    (void)opts;
+    (void)state;
+    g_group_calls++;
+    g_last_freq = freq_hz;
+    g_last_lpcn = lpcn;
+    g_last_target = tg;
+    g_last_source = src;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_sm_emit_indiv_grant(dsd_opts* opts, dsd_state* state, long freq_hz, int lpcn, int dst, int src) {
+    (void)opts;
+    (void)state;
+    g_indiv_calls++;
+    g_last_freq = freq_hz;
+    g_last_lpcn = lpcn;
+    g_last_target = dst;
+    g_last_source = src;
+}
+
+static void
+set_bits(uint8_t bits[80], size_t offset, size_t width, uint32_t value) {
+    for (size_t i = 0; i < width; i++) {
+        size_t shift = width - 1U - i;
+        bits[offset + i] = (uint8_t)((value >> shift) & 1U);
+    }
+}
+
+static void
+reset_grant_spy(void) {
+    g_group_calls = 0;
+    g_indiv_calls = 0;
+    g_last_freq = 0;
+    g_last_lpcn = 0;
+    g_last_target = 0;
+    g_last_source = 0;
+}
+
+static void
+test_parse_rejects_null_arguments(void) {
+    uint8_t bits[80] = {0};
+    uint8_t bytes[10] = {0};
+    struct dmr_csbk_result result;
+
+    assert(dmr_csbk_parse(NULL, bytes, &result) < 0);
+    assert(dmr_csbk_parse(bits, NULL, &result) < 0);
+    assert(dmr_csbk_parse(bits, bytes, NULL) < 0);
+}
+
+static void
+test_parse_non_grant_header_only(void) {
+    uint8_t bits[80] = {0};
+    uint8_t bytes[10] = {0};
+    struct dmr_csbk_result result;
+
+    bytes[0] = 0x80U | 0x40U | 12U;
+    bytes[1] = 0x23U;
+
+    assert(dmr_csbk_parse(bits, bytes, &result) == 0);
+    assert(result.lb == 1U);
+    assert(result.pf == 1U);
+    assert(result.opcode == 12U);
+    assert(result.fid == 0x23U);
+    assert(result.lpcn == 0U);
+    assert(result.target == 0U);
+    assert(result.bits == bits);
+    assert(result.bytes == bytes);
+}
+
+static void
+test_parse_and_handle_group_grant(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80] = {0};
+    uint8_t bytes[10] = {0};
+    struct dmr_csbk_result result;
+    reset_grant_spy();
+
+    bytes[0] = 0x80U | 49U;
+    bytes[1] = 0x11U;
+    set_bits(bits, 16U, 12U, 0x2A5U);
+    set_bits(bits, 16U, 13U, 0x54BU);
+    bits[29] = 1U;
+    bits[30] = 0U;
+    bits[31] = 1U;
+    set_bits(bits, 32U, 24U, 0x123456U);
+    set_bits(bits, 56U, 24U, 0x654321U);
+
+    assert(dmr_csbk_parse(bits, bytes, &result) == 0);
+    result.freq_hz = 851012500L;
+    assert(result.opcode == 49U);
+    assert(result.fid == 0x11U);
+    assert(result.lpcn == 0x2A5U);
+    assert(result.pluschannum == 0x54CU);
+    assert(result.lcn == bits[28]);
+    assert(result.st1 == 1U);
+    assert(result.st2 == 0U);
+    assert(result.st3 == 1U);
+    assert(result.target == 0x123456U);
+    assert(result.source == 0x654321U);
+
+    dmr_csbk_handle(&result, &opts, &state);
+    assert(g_group_calls == 1);
+    assert(g_indiv_calls == 0);
+    assert(g_last_freq == 851012500L);
+    assert(g_last_lpcn == 0x2A5);
+    assert(g_last_target == 0x123456);
+    assert(g_last_source == 0x654321);
+}
+
+static void
+test_handle_individual_and_ignored_paths(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    struct dmr_csbk_result result = {0};
+    reset_grant_spy();
+
+    dmr_csbk_handle(NULL, &opts, &state);
+    dmr_csbk_handle(&result, NULL, &state);
+    dmr_csbk_handle(&result, &opts, NULL);
+    assert(g_group_calls == 0);
+    assert(g_indiv_calls == 0);
+
+    result.opcode = 48U;
+    result.freq_hz = 935000000L;
+    result.lpcn = 123U;
+    result.target = 77U;
+    result.source = 88U;
+    dmr_csbk_handle(&result, &opts, &state);
+    assert(g_group_calls == 0);
+    assert(g_indiv_calls == 1);
+    assert(g_last_freq == 935000000L);
+    assert(g_last_lpcn == 123);
+    assert(g_last_target == 77);
+    assert(g_last_source == 88);
+
+    result.opcode = 47U;
+    dmr_csbk_handle(&result, &opts, &state);
+    assert(g_indiv_calls == 1);
+}
+
+static void
+test_opcode_names_cover_grant_table(void) {
+    assert(strcmp(dmr_csbk_grant_opcode_name(48U), "Private Voice Channel Grant (PV_GRANT)") == 0);
+    assert(strcmp(dmr_csbk_grant_opcode_name(49U), "Talkgroup Voice Channel Grant (TV_GRANT)") == 0);
+    assert(strcmp(dmr_csbk_grant_opcode_name(50U), "Broadcast Voice Channel Grant (BTV_GRANT)") == 0);
+    assert(strcmp(dmr_csbk_grant_opcode_name(51U), "Private Data Channel Grant: Single Item (PD_GRANT)") == 0);
+    assert(strcmp(dmr_csbk_grant_opcode_name(52U), "Talkgroup Data Channel Grant: Single Item (TD_GRANT)") == 0);
+    assert(strcmp(dmr_csbk_grant_opcode_name(53U), "Duplex Private Voice Channel Grant (PV_GRANT_DX)") == 0);
+    assert(strcmp(dmr_csbk_grant_opcode_name(54U), "Duplex Private Data Channel Grant (PD_GRANT_DX)") == 0);
+    assert(strcmp(dmr_csbk_grant_opcode_name(55U), "Private Data Channel Grant: Multi Item (PD_GRANT)") == 0);
+    assert(strcmp(dmr_csbk_grant_opcode_name(56U), "Talkgroup Data Channel Grant: Multi Item (TD_GRANT)") == 0);
+    assert(strcmp(dmr_csbk_grant_opcode_name(57U), "Unknown CSBK") == 0);
+}
+
+int
+main(void) {
+    test_parse_rejects_null_arguments();
+    test_parse_non_grant_header_only();
+    test_parse_and_handle_group_grant();
+    test_handle_individual_and_ignored_paths();
+    test_opcode_names_cover_grant_table();
+    DSD_FPRINTF(stdout, "DMR_CSBK_HELPERS: OK\n");
+    return 0;
+}

--- a/tests/protocol/dmr/test_dmr_data_sync.c
+++ b/tests/protocol/dmr/test_dmr_data_sync.c
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Focused coverage for the cached DMR data-sync path.
+ */
+
+#include "dsd-neo/core/safe_api.h"
+
+#include <assert.h>
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/sync_patterns.h>
+#include <dsd-neo/fec/block_codes.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
+#include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "dmr_confidence.h"
+
+static int g_hamming_ok;
+static int g_golay_ok;
+static uint8_t g_decoded_slot;
+static uint8_t g_decoded_color;
+static uint8_t g_decoded_burst;
+static int g_handler_calls;
+static int g_sm_calls;
+static int g_reset_calls;
+static int g_skip_calls;
+static int g_handler_slot;
+static uint8_t g_handler_burst;
+static uint8_t g_handler_info[196];
+static uint8_t g_handler_reliab[98];
+
+static void
+reset_fixture(void) {
+    g_hamming_ok = 1;
+    g_golay_ok = 1;
+    g_decoded_slot = 1;
+    g_decoded_color = 5;
+    g_decoded_burst = 7;
+    g_handler_calls = 0;
+    g_sm_calls = 0;
+    g_reset_calls = 0;
+    g_skip_calls = 0;
+    g_handler_slot = -1;
+    g_handler_burst = 0;
+    DSD_MEMSET(g_handler_info, 0, sizeof(g_handler_info));
+    DSD_MEMSET(g_handler_reliab, 0, sizeof(g_handler_reliab));
+}
+
+bool
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+Hamming_7_4_decode(unsigned char* rx_bits) {
+    if (g_hamming_ok == 0) {
+        return false;
+    }
+    DSD_MEMSET(rx_bits, 0, 7U);
+    rx_bits[1] = g_decoded_slot;
+    return true;
+}
+
+bool
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+Golay_20_8_decode(unsigned char* rx_bits) {
+    if (g_golay_ok == 0) {
+        return false;
+    }
+    DSD_MEMSET(rx_bits, 0, 20U);
+    rx_bits[0] = (unsigned char)((g_decoded_color >> 3U) & 1U);
+    rx_bits[1] = (unsigned char)((g_decoded_color >> 2U) & 1U);
+    rx_bits[2] = (unsigned char)((g_decoded_color >> 1U) & 1U);
+    rx_bits[3] = (unsigned char)(g_decoded_color & 1U);
+    rx_bits[4] = (unsigned char)((g_decoded_burst >> 3U) & 1U);
+    rx_bits[5] = (unsigned char)((g_decoded_burst >> 2U) & 1U);
+    rx_bits[6] = (unsigned char)((g_decoded_burst >> 1U) & 1U);
+    rx_bits[7] = (unsigned char)(g_decoded_burst & 1U);
+    return true;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+get_dibit_and_analog_signal(dsd_opts* opts, dsd_state* state, int* out_analog_signal) {
+    (void)opts;
+    (void)state;
+    if (out_analog_signal != NULL) {
+        *out_analog_signal = 0;
+    }
+    return 0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+skipDibit(dsd_opts* opts, dsd_state* state, int count) {
+    (void)opts;
+    (void)state;
+    g_skip_calls += count;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_data_burst_handler_ex(dsd_opts* opts, dsd_state* state, uint8_t info[196], uint8_t databurst,
+                          const uint8_t* reliab98) {
+    (void)opts;
+    g_handler_calls++;
+    g_handler_slot = state->currentslot;
+    g_handler_burst = databurst;
+    DSD_MEMCPY(g_handler_info, info, sizeof(g_handler_info));
+    DSD_MEMCPY(g_handler_reliab, reliab98, sizeof(g_handler_reliab));
+}
+
+uint8_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_cach(dsd_opts* opts, dsd_state* state, uint8_t cach_bits[25]) {
+    (void)opts;
+    (void)state;
+    (void)cach_bits;
+    return 0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_reset_blocks(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_reset_calls++;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_sm_emit_data_sync(dsd_opts* opts, dsd_state* state, int slot) {
+    (void)opts;
+    (void)state;
+    g_sm_calls++;
+    assert(slot == (int)g_decoded_slot);
+}
+
+size_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_debug_format_burst(char* out, size_t out_size, const dsd_state* state, uint8_t slot_index, uint8_t burst_type) {
+    (void)state;
+    (void)slot_index;
+    (void)burst_type;
+    if (out_size == 0U) {
+        return 0U;
+    }
+    out[0] = '\0';
+    return 0U;
+}
+
+dmr_confidence_result
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_confidence_note_data_burst(dsd_state* state, unsigned int color_code, unsigned int burst) {
+    (void)state;
+    (void)color_code;
+    (void)burst;
+    return DMR_CONFIDENCE_LOCKED;
+}
+
+static int
+sync_char_to_dibit(char c) {
+    return c == '3' ? 2 : 0;
+}
+
+static void
+fill_sync_payload(int payload[90], const char* sync) {
+    for (size_t i = 0; i < 24U; i++) {
+        payload[66U + i] = sync_char_to_dibit(sync[i]);
+    }
+}
+
+static void
+prepare_state(dsd_state* state, int payload[90], uint8_t reliab[90]) {
+    DSD_MEMSET(state, 0, sizeof(*state));
+    for (size_t i = 0; i < 90U; i++) {
+        payload[i] = (int)(i & 3U);
+        reliab[i] = (uint8_t)(40U + i);
+    }
+    fill_sync_payload(payload, DMR_BS_DATA_SYNC);
+
+    state->dmr_payload_p = payload + 90;
+    state->dmr_reliab_buf = reliab;
+    state->dmr_reliab_p = reliab + 90;
+    state->dmr_stereo = 1;
+    for (size_t i = 0; i < 144U; i++) {
+        state->dmr_stereo_payload[i] = (int)((i + 1U) & 3U);
+        state->dmr_stereo_reliab[i] = (uint8_t)(200U - (i % 64U));
+    }
+    for (size_t i = 0; i < 90U; i++) {
+        state->dmr_stereo_payload[i] = payload[i];
+    }
+}
+
+static void
+test_data_sync_dispatches_burst_and_reliability(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int payload[90];
+    uint8_t reliab[90];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_state(&state, payload, reliab);
+    reset_fixture();
+
+    opts.dmr_mono = 1;
+    dmr_data_sync(&opts, &state);
+
+    assert(g_handler_calls == 1);
+    assert(g_handler_slot == 1);
+    assert(g_handler_burst == 7U);
+    assert(g_sm_calls == 1);
+    assert(g_reset_calls == 0);
+    assert(g_skip_calls == 0);
+    assert(state.currentslot == 1);
+    assert(state.color_code == 5);
+    assert(state.dmr_color_code == 5);
+    assert(state.dmrburstR == 7U);
+    assert(strcmp(state.slot1light, " slot1 ") == 0);
+    assert(strcmp(state.slot2light, "[slot2]") == 0);
+    assert(g_handler_reliab[0] == reliab[12]);
+    assert(g_handler_reliab[48] == reliab[60]);
+    assert(g_handler_reliab[49] == state.dmr_stereo_reliab[95]);
+    assert(g_handler_reliab[97] == state.dmr_stereo_reliab[143]);
+}
+
+static void
+test_cach_failure_resets_without_dispatch(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int payload[90];
+    uint8_t reliab[90];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_state(&state, payload, reliab);
+    reset_fixture();
+    g_hamming_ok = 0;
+
+    opts.dmr_mono = 1;
+    dmr_data_sync(&opts, &state);
+
+    assert(g_handler_calls == 0);
+    assert(g_sm_calls == 0);
+    assert(g_reset_calls == 1);
+    assert(g_skip_calls == 0);
+}
+
+int
+main(void) {
+    test_data_sync_dispatches_burst_and_reliability();
+    test_cach_failure_resets_without_dispatch();
+    DSD_FPRINTF(stdout, "DMR_DATA_SYNC: OK\n");
+    return 0;
+}

--- a/tests/protocol/dmr/test_dmr_data_sync.c
+++ b/tests/protocol/dmr/test_dmr_data_sync.c
@@ -28,12 +28,19 @@ static uint8_t g_decoded_color;
 static uint8_t g_decoded_burst;
 static int g_handler_calls;
 static int g_sm_calls;
+static int g_sm_last_slot;
 static int g_reset_calls;
 static int g_skip_calls;
 static int g_handler_slot;
+static int g_live_dibit_index;
+static int g_live_symbols[64];
+static int g_live_dibits[64];
+static int g_cach_calls;
+static int g_debug_format_calls;
 static uint8_t g_handler_burst;
 static uint8_t g_handler_info[196];
 static uint8_t g_handler_reliab[98];
+static dmr_confidence_result g_confidence_result;
 
 static void
 reset_fixture(void) {
@@ -44,10 +51,19 @@ reset_fixture(void) {
     g_decoded_burst = 7;
     g_handler_calls = 0;
     g_sm_calls = 0;
+    g_sm_last_slot = -1;
     g_reset_calls = 0;
     g_skip_calls = 0;
     g_handler_slot = -1;
+    g_live_dibit_index = 0;
+    g_cach_calls = 0;
+    g_debug_format_calls = 0;
     g_handler_burst = 0;
+    g_confidence_result = DMR_CONFIDENCE_LOCKED;
+    for (size_t i = 0; i < 64U; i++) {
+        g_live_symbols[i] = 0;
+        g_live_dibits[i] = 0;
+    }
     DSD_MEMSET(g_handler_info, 0, sizeof(g_handler_info));
     DSD_MEMSET(g_handler_reliab, 0, sizeof(g_handler_reliab));
 }
@@ -86,10 +102,15 @@ int
 get_dibit_and_analog_signal(dsd_opts* opts, dsd_state* state, int* out_analog_signal) {
     (void)opts;
     (void)state;
-    if (out_analog_signal != NULL) {
-        *out_analog_signal = 0;
+    int index = g_live_dibit_index;
+    if (index >= (int)(sizeof(g_live_dibits) / sizeof(g_live_dibits[0]))) {
+        index = (int)(sizeof(g_live_dibits) / sizeof(g_live_dibits[0])) - 1;
     }
-    return 0;
+    if (out_analog_signal != NULL) {
+        *out_analog_signal = g_live_symbols[index];
+    }
+    g_live_dibit_index++;
+    return g_live_dibits[index] & 3;
 }
 
 void
@@ -118,6 +139,7 @@ dmr_cach(dsd_opts* opts, dsd_state* state, uint8_t cach_bits[25]) {
     (void)opts;
     (void)state;
     (void)cach_bits;
+    g_cach_calls++;
     return 0;
 }
 
@@ -135,7 +157,7 @@ dmr_sm_emit_data_sync(dsd_opts* opts, dsd_state* state, int slot) {
     (void)opts;
     (void)state;
     g_sm_calls++;
-    assert(slot == (int)g_decoded_slot);
+    g_sm_last_slot = slot;
 }
 
 size_t
@@ -143,12 +165,11 @@ size_t
 dmr_debug_format_burst(char* out, size_t out_size, const dsd_state* state, uint8_t slot_index, uint8_t burst_type) {
     (void)state;
     (void)slot_index;
-    (void)burst_type;
+    g_debug_format_calls++;
     if (out_size == 0U) {
         return 0U;
     }
-    out[0] = '\0';
-    return 0U;
+    return DSD_SNPRINTF(out, out_size, "debug-burst-%u", burst_type);
 }
 
 dmr_confidence_result
@@ -157,7 +178,7 @@ dmr_confidence_note_data_burst(dsd_state* state, unsigned int color_code, unsign
     (void)state;
     (void)color_code;
     (void)burst;
-    return DMR_CONFIDENCE_LOCKED;
+    return g_confidence_result;
 }
 
 static int
@@ -195,11 +216,19 @@ prepare_state(dsd_state* state, int payload[90], uint8_t reliab[90]) {
 }
 
 static void
+prepare_live_symbols(int symbol, int dibit) {
+    for (size_t i = 0; i < 64U; i++) {
+        g_live_symbols[i] = symbol;
+        g_live_dibits[i] = dibit;
+    }
+}
+
+static void
 test_data_sync_dispatches_burst_and_reliability(void) {
     static dsd_opts opts;
     static dsd_state state;
-    int payload[90];
-    uint8_t reliab[90];
+    static int payload[90];
+    static uint8_t reliab[90];
     DSD_MEMSET(&opts, 0, sizeof(opts));
     prepare_state(&state, payload, reliab);
     reset_fixture();
@@ -211,6 +240,7 @@ test_data_sync_dispatches_burst_and_reliability(void) {
     assert(g_handler_slot == 1);
     assert(g_handler_burst == 7U);
     assert(g_sm_calls == 1);
+    assert(g_sm_last_slot == 1);
     assert(g_reset_calls == 0);
     assert(g_skip_calls == 0);
     assert(state.currentslot == 1);
@@ -223,14 +253,15 @@ test_data_sync_dispatches_burst_and_reliability(void) {
     assert(g_handler_reliab[48] == reliab[60]);
     assert(g_handler_reliab[49] == state.dmr_stereo_reliab[95]);
     assert(g_handler_reliab[97] == state.dmr_stereo_reliab[143]);
+    assert(g_cach_calls == 0);
 }
 
 static void
 test_cach_failure_resets_without_dispatch(void) {
     static dsd_opts opts;
     static dsd_state state;
-    int payload[90];
-    uint8_t reliab[90];
+    static int payload[90];
+    static uint8_t reliab[90];
     DSD_MEMSET(&opts, 0, sizeof(opts));
     prepare_state(&state, payload, reliab);
     reset_fixture();
@@ -245,10 +276,198 @@ test_cach_failure_resets_without_dispatch(void) {
     assert(g_skip_calls == 0);
 }
 
+static void
+test_golay_failure_resets_and_skips_live_tail(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int payload[90];
+    static uint8_t reliab[90];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_state(&state, payload, reliab);
+    reset_fixture();
+    g_golay_ok = 0;
+    state.dmr_stereo = 0;
+    state.min = 0;
+    state.lmid = 10;
+    state.center = 20;
+    state.umid = 30;
+    state.max = 40;
+    prepare_live_symbols(40, 3);
+
+    dmr_data_sync(&opts, &state);
+
+    assert(g_handler_calls == 0);
+    assert(g_sm_calls == 0);
+    assert(g_reset_calls == 1);
+    assert(g_skip_calls == 66);
+    assert(g_live_dibit_index == 5);
+}
+
+static void
+test_live_second_half_reliability_and_debug_output(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int payload[90];
+    static uint8_t reliab[90];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_state(&state, payload, reliab);
+    reset_fixture();
+    state.dmr_stereo = 0;
+    state.min = 0;
+    state.lmid = 10;
+    state.center = 20;
+    state.umid = 30;
+    state.max = 40;
+    opts.dmr_debug_burst = 1;
+    opts.dmr_mono = 1;
+    prepare_live_symbols(40, 3);
+
+    dmr_data_sync(&opts, &state);
+
+    assert(g_handler_calls == 1);
+    assert(g_handler_burst == 7U);
+    assert(g_handler_reliab[49] == 255U);
+    assert(g_handler_reliab[97] == 255U);
+    assert(g_skip_calls == 66);
+    assert(g_live_dibit_index == 54);
+    assert(g_debug_format_calls == 1);
+}
+
+static uint8_t
+run_live_reliability_symbol(int symbol) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int payload[90];
+    static uint8_t reliab[90];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_state(&state, payload, reliab);
+    reset_fixture();
+    state.dmr_stereo = 0;
+    state.min = 0;
+    state.lmid = 10;
+    state.center = 20;
+    state.umid = 30;
+    state.max = 40;
+    opts.dmr_mono = 1;
+    prepare_live_symbols(symbol, 3);
+
+    dmr_data_sync(&opts, &state);
+
+    assert(g_handler_calls == 1);
+    assert(g_live_dibit_index == 54);
+    return g_handler_reliab[49];
+}
+
+static void
+test_live_reliability_interpolation_bands(void) {
+    assert(run_live_reliability_symbol(25) == 255U);
+    assert(run_live_reliability_symbol(15) == 255U);
+    assert(run_live_reliability_symbol(5) == 127U);
+}
+
+static void
+test_direct_mode_sync_overrides_cach_slot(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int payload[90];
+    static uint8_t reliab[90];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_state(&state, payload, reliab);
+    reset_fixture();
+    fill_sync_payload(payload, DMR_DIRECT_MODE_TS1_DATA_SYNC);
+    for (size_t i = 0; i < 24U; i++) {
+        state.dmr_stereo_payload[66U + i] = payload[66U + i];
+    }
+    opts.dmr_mono = 1;
+    g_decoded_slot = 1;
+
+    dmr_data_sync(&opts, &state);
+
+    assert(g_handler_calls == 1);
+    assert(g_handler_slot == 0);
+    assert(g_sm_calls == 1);
+    assert(g_sm_last_slot == 0);
+    assert(state.currentslot == 0);
+    assert(strcmp(state.slot1light, "[sLoT1]") == 0);
+    assert(strcmp(state.slot2light, "[DMODE]") == 0);
+}
+
+static void
+test_confidence_pending_and_reject_gate_dispatch(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int payload[90];
+    static uint8_t reliab[90];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_state(&state, payload, reliab);
+    reset_fixture();
+    opts.dmr_mono = 0;
+    g_confidence_result = DMR_CONFIDENCE_PENDING;
+
+    dmr_data_sync(&opts, &state);
+
+    assert(g_handler_calls == 0);
+    assert(g_sm_calls == 0);
+    assert(g_cach_calls == 0);
+    assert(g_reset_calls == 0);
+    assert(state.dmrburstR == 7U);
+
+    prepare_state(&state, payload, reliab);
+    reset_fixture();
+    opts.dmr_mono = 0;
+    g_confidence_result = DMR_CONFIDENCE_REJECT;
+
+    dmr_data_sync(&opts, &state);
+
+    assert(g_handler_calls == 0);
+    assert(g_sm_calls == 0);
+    assert(g_reset_calls == 1);
+    assert(state.dmrburstR == 7U);
+}
+
+static void
+test_connect_plus_idle_bursts_clear_tuned_sync_times(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int payload[90];
+    static uint8_t reliab[90];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_state(&state, payload, reliab);
+    reset_fixture();
+
+    opts.dmr_mono = 1;
+    opts.trunk_enable = 1;
+    opts.trunk_is_tuned = 1;
+    state.is_con_plus = 1;
+    state.dmrburstL = 9;
+    state.last_cc_sync_time = 10;
+    state.last_vc_sync_time = 20;
+    state.last_cc_sync_time_m = 30.0;
+    state.last_vc_sync_time_m = 40.0;
+    g_decoded_slot = 1;
+    g_decoded_burst = 9;
+
+    dmr_data_sync(&opts, &state);
+
+    assert(g_handler_calls == 1);
+    assert(state.dmrburstL == 9);
+    assert(state.dmrburstR == 9);
+    assert(state.last_cc_sync_time == 0);
+    assert(state.last_vc_sync_time == 0);
+    assert(state.last_cc_sync_time_m == 0.0);
+    assert(state.last_vc_sync_time_m == 0.0);
+}
+
 int
 main(void) {
     test_data_sync_dispatches_burst_and_reliability();
     test_cach_failure_resets_without_dispatch();
+    test_golay_failure_resets_and_skips_live_tail();
+    test_live_second_half_reliability_and_debug_output();
+    test_live_reliability_interpolation_bands();
+    test_direct_mode_sync_overrides_cach_slot();
+    test_confidence_pending_and_reject_gate_dispatch();
+    test_connect_plus_idle_bursts_clear_tuned_sync_times();
     DSD_FPRINTF(stdout, "DMR_DATA_SYNC: OK\n");
     return 0;
 }

--- a/tests/protocol/dmr/test_dmr_dburst_profile.c
+++ b/tests/protocol/dmr/test_dmr_dburst_profile.c
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/bit_packing.h>
+#include <dsd-neo/core/gps.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/fec/bptc.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
+#include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <dsd-neo/protocol/dmr/r34_viterbi.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "dsd-neo/core/safe_api.h"
+
+FILE*
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_fopen_private(const char* path, const char* mode) {
+    (void)path;
+    (void)mode;
+    return NULL;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+pack_bit_array_into_byte_array(const uint8_t* bits, uint8_t* bytes, int len) {
+    if (len <= 0) {
+        return;
+    }
+    const size_t byte_count = (size_t)len;
+    DSD_MEMSET(bytes, 0, byte_count * sizeof(uint8_t));
+    for (size_t byte = 0U; byte < byte_count; byte++) {
+        for (size_t bit = 0U; bit < 8U; bit++) {
+            bytes[byte] = (uint8_t)((bytes[byte] << 1U) | (bits[(byte * 8U) + bit] & 1U));
+        }
+    }
+}
+
+enum {
+    TEST_DBURST_F_BPTC = 1U << 0U,
+    TEST_DBURST_F_TRELLIS = 1U << 1U,
+    TEST_DBURST_F_LC = 1U << 3U,
+    TEST_DBURST_F_FULL = 1U << 4U,
+    TEST_DBURST_F_UDT = 0x80U,
+};
+
+uint64_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ConvertBitIntoBytes(const uint8_t* bits, uint32_t n) {
+    uint64_t value = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        value = (value << 1U) | (uint64_t)(bits[i] & 1U);
+    }
+    return value;
+}
+
+uint16_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ComputeCrc9Bit(const uint8_t* bits, uint32_t len) {
+    (void)bits;
+    (void)len;
+    return 0;
+}
+
+uint16_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ComputeCrcCCITT(const uint8_t* bits) {
+    (void)bits;
+    return 0;
+}
+
+uint8_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ComputeCrc5Bit(const uint8_t* bits) {
+    (void)bits;
+    return 0;
+}
+
+uint32_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ComputeAndCorrectFullLinkControlCrc(uint8_t* bytes, uint32_t* computed, uint32_t mask) {
+    (void)bytes;
+    (void)mask;
+    if (computed != NULL) {
+        *computed = 0;
+    }
+    return 1;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+BPTCDeInterleaveDMRData(const uint8_t* input, uint8_t* output) {
+    (void)input;
+    if (output != NULL) {
+        DSD_MEMSET(output, 0, 196U);
+    }
+}
+
+uint32_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+BPTC_196x96_Extract_Data(uint8_t input[196], uint8_t output[96], uint8_t reserved[3]) {
+    (void)input;
+    if (output != NULL) {
+        DSD_MEMSET(output, 0, 96U);
+    }
+    if (reserved != NULL) {
+        DSD_MEMSET(reserved, 0, 3U);
+    }
+    return 0;
+}
+
+uint32_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+BPTC_128x77_Extract_Data(uint8_t input[8][16], uint8_t output[77]) {
+    (void)input;
+    if (output != NULL) {
+        DSD_MEMSET(output, 0, 77U);
+    }
+    return 0;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_r34_viterbi_decode(const uint8_t* dibits, uint8_t bytes18[18]) {
+    (void)dibits;
+    DSD_MEMSET(bytes18, 0, 18U);
+    return 0;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_r34_viterbi_decode_soft(const uint8_t* dibits, const uint8_t* reliab, uint8_t bytes18[18]) {
+    (void)dibits;
+    (void)reliab;
+    DSD_MEMSET(bytes18, 0, 18U);
+    return 0;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_r34_viterbi_decode_list(const uint8_t* dibits, const uint8_t* reliab, dmr_r34_candidate* out, int max_candidates,
+                            int* out_count) {
+    (void)dibits;
+    (void)reliab;
+    (void)out;
+    (void)max_candidates;
+    if (out_count != NULL) {
+        *out_count = 0;
+    }
+    return -1;
+}
+
+uint32_t
+dmr_34(const uint8_t* input, uint8_t treturn[18]) {
+    (void)input;
+    DSD_MEMSET(treturn, 0, 18U);
+    return 0;
+}
+
+void
+dmr_pi(dsd_opts* opts, dsd_state* state, uint8_t PI_BYTE[], uint32_t CRCCorrect, uint32_t IrrecoverableErrors) {
+    (void)opts;
+    (void)state;
+    (void)PI_BYTE;
+    (void)CRCCorrect;
+    (void)IrrecoverableErrors;
+}
+
+void
+dmr_flco(dsd_opts* opts, dsd_state* state, uint8_t lc_bits[], uint32_t CRCCorrect, uint32_t* IrrecoverableErrors,
+         uint8_t type) {
+    (void)opts;
+    (void)state;
+    (void)lc_bits;
+    (void)CRCCorrect;
+    (void)IrrecoverableErrors;
+    (void)type;
+}
+
+void
+dmr_cspdu(dsd_opts* opts, dsd_state* state, uint8_t cs_pdu_bits[], uint8_t cs_pdu[], uint32_t CRCCorrect,
+          uint32_t IrrecoverableErrors) {
+    (void)opts;
+    (void)state;
+    (void)cs_pdu_bits;
+    (void)cs_pdu;
+    (void)CRCCorrect;
+    (void)IrrecoverableErrors;
+}
+
+void
+dmr_dheader(dsd_opts* opts, dsd_state* state, uint8_t dheader[], uint8_t dheader_bits[], uint32_t CRCCorrect,
+            uint32_t IrrecoverableErrors) {
+    (void)opts;
+    (void)state;
+    (void)dheader;
+    (void)dheader_bits;
+    (void)CRCCorrect;
+    (void)IrrecoverableErrors;
+}
+
+void
+dmr_block_assembler(dsd_opts* opts, dsd_state* state, uint8_t block_bytes[], uint8_t block_len, uint8_t databurst,
+                    uint8_t type) {
+    (void)opts;
+    (void)state;
+    (void)block_bytes;
+    (void)block_len;
+    (void)databurst;
+    (void)type;
+}
+
+void
+dmr_reset_blocks(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+lip_protocol_decoder(const dsd_opts* opts, dsd_state* state, const uint8_t* lc_bits) {
+    (void)opts;
+    (void)state;
+    (void)lc_bits;
+}
+
+static int
+expect_u8(const char* tag, uint8_t got, uint8_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %u want %u\n", tag, (unsigned)got, (unsigned)want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u32(const char* tag, uint32_t got, uint32_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got 0x%08X want 0x%08X\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_str(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+capture_profile(uint8_t databurst, uint8_t conf_data, uint8_t header_format, uint8_t* pdu_len, uint8_t* pdu_start,
+                uint8_t* crclen, uint32_t* crcmask, uint8_t* flags, char subtype[8], uint8_t* data_p_head) {
+    static dsd_opts opts;
+    static dsd_state state;
+    dsd_neo_dmr_test_dburst_profile_result result;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.currentslot = 1;
+    state.data_p_head[1] = 1;
+    state.data_conf_data[1] = conf_data;
+    state.data_header_format[1] = header_format;
+    if (!dsd_neo_dmr_test_dburst_profile(&opts, &state, databurst, 1, &result)) {
+        return 0;
+    }
+
+    *pdu_len = result.pdu_len;
+    *pdu_start = result.pdu_start;
+    *crclen = result.crclen;
+    *crcmask = result.crcmask;
+    *flags = result.flags;
+    DSD_SNPRINTF(subtype, 8U, "%s", result.subtype);
+    *data_p_head = result.data_p_head;
+    return 1;
+}
+
+static int
+test_base_profiles(void) {
+    int rc = 0;
+    uint8_t pdu_len = 0;
+    uint8_t pdu_start = 0xFFU;
+    uint8_t crclen = 0;
+    uint32_t crcmask = 0;
+    uint8_t flags = 0;
+    uint8_t data_p_head = 0;
+    char subtype[8];
+    DSD_MEMSET(subtype, 0, sizeof(subtype));
+
+    rc |= expect_u8(
+        "pi-profile-ok",
+        (uint8_t)capture_profile(0x00U, 0U, 1U, &pdu_len, &pdu_start, &crclen, &crcmask, &flags, subtype, &data_p_head),
+        1U);
+    rc |= expect_str("pi-subtype", subtype, " PI  ");
+    rc |= expect_u8("pi-pdu-len", pdu_len, 12U);
+    rc |= expect_u8("pi-pdu-start", pdu_start, 0U);
+    rc |= expect_u8("pi-crclen", crclen, 16U);
+    rc |= expect_u32("pi-crcmask", crcmask, 0x6969U);
+    rc |= expect_u8("pi-flags", flags, TEST_DBURST_F_BPTC);
+    rc |= expect_u8("pi-clears-data-p-head", data_p_head, 0U);
+
+    rc |= expect_u8(
+        "vlc-profile-ok",
+        (uint8_t)capture_profile(0x01U, 0U, 1U, &pdu_len, &pdu_start, &crclen, &crcmask, &flags, subtype, &data_p_head),
+        1U);
+    rc |= expect_str("vlc-subtype", subtype, " VLC ");
+    rc |= expect_u8("vlc-flags", flags, TEST_DBURST_F_BPTC | TEST_DBURST_F_LC);
+    rc |= expect_u8("vlc-crclen", crclen, 24U);
+    rc |= expect_u32("vlc-crcmask", crcmask, 0x969696U);
+
+    rc |= expect_u8(
+        "r34-profile-ok",
+        (uint8_t)capture_profile(0x08U, 0U, 1U, &pdu_len, &pdu_start, &crclen, &crcmask, &flags, subtype, &data_p_head),
+        1U);
+    rc |= expect_str("r34-subtype", subtype, " R34U ");
+    rc |= expect_u8("r34-pdu-len", pdu_len, 18U);
+    rc |= expect_u8("r34-flags", flags, TEST_DBURST_F_TRELLIS);
+    rc |= expect_u8("r34-keeps-data-p-head", data_p_head, 1U);
+    return rc;
+}
+
+static int
+test_dynamic_profiles(void) {
+    int rc = 0;
+    uint8_t pdu_len = 0;
+    uint8_t pdu_start = 0;
+    uint8_t crclen = 0;
+    uint32_t crcmask = 0;
+    uint8_t flags = 0;
+    uint8_t data_p_head = 0;
+    char subtype[8];
+    DSD_MEMSET(subtype, 0, sizeof(subtype));
+
+    rc |= expect_u8(
+        "r12c-profile-ok",
+        (uint8_t)capture_profile(0x07U, 1U, 1U, &pdu_len, &pdu_start, &crclen, &crcmask, &flags, subtype, &data_p_head),
+        1U);
+    rc |= expect_str("r12c-subtype", subtype, " R12C ");
+    rc |= expect_u8("r12c-pdu-len", pdu_len, 10U);
+    rc |= expect_u8("r12c-pdu-start", pdu_start, 2U);
+    rc |= expect_u8("r12c-crclen", crclen, 9U);
+    rc |= expect_u8("r12c-flags", flags, TEST_DBURST_F_BPTC);
+
+    rc |= expect_u8(
+        "udtc-profile-ok",
+        (uint8_t)capture_profile(0x07U, 1U, 0U, &pdu_len, &pdu_start, &crclen, &crcmask, &flags, subtype, &data_p_head),
+        1U);
+    rc |= expect_str("udtc-subtype", subtype, " UDTC ");
+    rc |= expect_u8("udtc-pdu-len", pdu_len, 10U);
+    rc |= expect_u8("udtc-flags", flags, TEST_DBURST_F_BPTC | TEST_DBURST_F_UDT);
+
+    rc |= expect_u8(
+        "r34c-profile-ok",
+        (uint8_t)capture_profile(0x08U, 1U, 1U, &pdu_len, &pdu_start, &crclen, &crcmask, &flags, subtype, &data_p_head),
+        1U);
+    rc |= expect_str("r34c-subtype", subtype, " R34C ");
+    rc |= expect_u8("r34c-pdu-len", pdu_len, 16U);
+    rc |= expect_u8("r34c-pdu-start", pdu_start, 2U);
+
+    rc |= expect_u8(
+        "full-confirmed-profile-ok",
+        (uint8_t)capture_profile(0x0AU, 1U, 1U, &pdu_len, &pdu_start, &crclen, &crcmask, &flags, subtype, &data_p_head),
+        1U);
+    rc |= expect_str("full-confirmed-subtype", subtype, " R_1C ");
+    rc |= expect_u8("full-confirmed-pdu-len", pdu_len, 22U);
+    rc |= expect_u8("full-confirmed-pdu-start", pdu_start, 2U);
+    rc |= expect_u8("full-confirmed-flags", flags, TEST_DBURST_F_FULL);
+    return rc;
+}
+
+static int
+test_special_profiles(void) {
+    int rc = 0;
+    uint8_t pdu_len = 0;
+    uint8_t pdu_start = 0;
+    uint8_t crclen = 0;
+    uint32_t crcmask = 0;
+    uint8_t flags = 0;
+    uint8_t data_p_head = 0;
+    char subtype[8];
+    DSD_MEMSET(subtype, 0, sizeof(subtype));
+
+    rc |= expect_u8(
+        "embedded-profile-ok",
+        (uint8_t)capture_profile(0xEBU, 0U, 1U, &pdu_len, &pdu_start, &crclen, &crcmask, &flags, subtype, &data_p_head),
+        1U);
+    rc |= expect_u8("embedded-pdu-len", pdu_len, 9U);
+    rc |= expect_u8("embedded-crclen", crclen, 5U);
+    rc |= expect_u8("embedded-clears-data-p-head", data_p_head, 0U);
+
+    rc |= expect_u8(
+        "unknown-profile-ok",
+        (uint8_t)capture_profile(0x40U, 0U, 1U, &pdu_len, &pdu_start, &crclen, &crcmask, &flags, subtype, &data_p_head),
+        1U);
+    rc |= expect_str("unknown-subtype", subtype, " _UNK ");
+    rc |= expect_u8("unknown-pdu-len", pdu_len, 25U);
+    rc |= expect_u8("unknown-flags", flags, TEST_DBURST_F_FULL);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_base_profiles();
+    rc |= test_dynamic_profiles();
+    rc |= test_special_profiles();
+    if (rc == 0) {
+        printf("DMR_DBURST_PROFILE: OK\n");
+    }
+    return rc;
+}

--- a/tests/protocol/dmr/test_dmr_dburst_profile.c
+++ b/tests/protocol/dmr/test_dmr_dburst_profile.c
@@ -19,6 +19,61 @@
 #include <string.h>
 #include "dsd-neo/core/safe_api.h"
 
+static int g_pi_calls;
+static int g_flco_calls;
+static uint8_t g_flco_last_type;
+static uint32_t g_flco_last_crc_correct;
+static int g_cspdu_calls;
+static uint32_t g_cspdu_last_crc_correct;
+static int g_dheader_calls;
+static uint32_t g_dheader_last_crc_correct;
+static int g_block_assembler_calls;
+static uint8_t g_block_assembler_last_len;
+static uint8_t g_block_assembler_last_burst;
+static uint8_t g_block_assembler_last_type;
+static int g_lip_calls;
+static int g_reset_blocks_calls;
+static uint32_t g_bptc_extract_errors;
+static uint8_t g_bptc_reserved[3];
+static uint8_t g_bptc_bits[96];
+static int g_r34_soft_status;
+static int g_r34_hard_status;
+static int g_r34_list_status;
+static int g_r34_list_count;
+static uint8_t g_r34_soft_bytes[18];
+static uint8_t g_r34_hard_bytes[18];
+static uint8_t g_r34_legacy_bytes[18];
+static dmr_r34_candidate g_r34_candidates[4];
+
+static void
+reset_handler_counters(void) {
+    g_pi_calls = 0;
+    g_flco_calls = 0;
+    g_flco_last_type = 0;
+    g_flco_last_crc_correct = 0;
+    g_cspdu_calls = 0;
+    g_cspdu_last_crc_correct = 0;
+    g_dheader_calls = 0;
+    g_dheader_last_crc_correct = 0;
+    g_block_assembler_calls = 0;
+    g_block_assembler_last_len = 0;
+    g_block_assembler_last_burst = 0;
+    g_block_assembler_last_type = 0;
+    g_lip_calls = 0;
+    g_reset_blocks_calls = 0;
+    g_bptc_extract_errors = 0;
+    DSD_MEMSET(g_bptc_reserved, 0, sizeof(g_bptc_reserved));
+    DSD_MEMSET(g_bptc_bits, 0, sizeof(g_bptc_bits));
+    g_r34_soft_status = 0;
+    g_r34_hard_status = 0;
+    g_r34_list_status = -1;
+    g_r34_list_count = 0;
+    DSD_MEMSET(g_r34_soft_bytes, 0, sizeof(g_r34_soft_bytes));
+    DSD_MEMSET(g_r34_hard_bytes, 0, sizeof(g_r34_hard_bytes));
+    DSD_MEMSET(g_r34_legacy_bytes, 0, sizeof(g_r34_legacy_bytes));
+    DSD_MEMSET(g_r34_candidates, 0, sizeof(g_r34_candidates));
+}
+
 FILE*
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_fopen_private(const char* path, const char* mode) {
@@ -107,12 +162,12 @@ uint32_t
 BPTC_196x96_Extract_Data(uint8_t input[196], uint8_t output[96], uint8_t reserved[3]) {
     (void)input;
     if (output != NULL) {
-        DSD_MEMSET(output, 0, 96U);
+        DSD_MEMCPY(output, g_bptc_bits, 96U);
     }
     if (reserved != NULL) {
-        DSD_MEMSET(reserved, 0, 3U);
+        DSD_MEMCPY(reserved, g_bptc_reserved, 3U);
     }
-    return 0;
+    return g_bptc_extract_errors;
 }
 
 uint32_t
@@ -129,8 +184,8 @@ int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dmr_r34_viterbi_decode(const uint8_t* dibits, uint8_t bytes18[18]) {
     (void)dibits;
-    DSD_MEMSET(bytes18, 0, 18U);
-    return 0;
+    DSD_MEMCPY(bytes18, g_r34_hard_bytes, 18U);
+    return g_r34_hard_status;
 }
 
 int
@@ -138,8 +193,8 @@ int
 dmr_r34_viterbi_decode_soft(const uint8_t* dibits, const uint8_t* reliab, uint8_t bytes18[18]) {
     (void)dibits;
     (void)reliab;
-    DSD_MEMSET(bytes18, 0, 18U);
-    return 0;
+    DSD_MEMCPY(bytes18, g_r34_soft_bytes, 18U);
+    return g_r34_soft_status;
 }
 
 int
@@ -148,18 +203,23 @@ dmr_r34_viterbi_decode_list(const uint8_t* dibits, const uint8_t* reliab, dmr_r3
                             int* out_count) {
     (void)dibits;
     (void)reliab;
-    (void)out;
-    (void)max_candidates;
-    if (out_count != NULL) {
-        *out_count = 0;
+    if (out != NULL && max_candidates > 0) {
+        int count = g_r34_list_count;
+        if (count > max_candidates) {
+            count = max_candidates;
+        }
+        DSD_MEMCPY(out, g_r34_candidates, (size_t)count * sizeof(out[0]));
     }
-    return -1;
+    if (out_count != NULL) {
+        *out_count = g_r34_list_count;
+    }
+    return g_r34_list_status;
 }
 
 uint32_t
 dmr_34(const uint8_t* input, uint8_t treturn[18]) {
     (void)input;
-    DSD_MEMSET(treturn, 0, 18U);
+    DSD_MEMCPY(treturn, g_r34_legacy_bytes, 18U);
     return 0;
 }
 
@@ -170,6 +230,7 @@ dmr_pi(dsd_opts* opts, dsd_state* state, uint8_t PI_BYTE[], uint32_t CRCCorrect,
     (void)PI_BYTE;
     (void)CRCCorrect;
     (void)IrrecoverableErrors;
+    g_pi_calls++;
 }
 
 void
@@ -178,9 +239,10 @@ dmr_flco(dsd_opts* opts, dsd_state* state, uint8_t lc_bits[], uint32_t CRCCorrec
     (void)opts;
     (void)state;
     (void)lc_bits;
-    (void)CRCCorrect;
     (void)IrrecoverableErrors;
-    (void)type;
+    g_flco_calls++;
+    g_flco_last_type = type;
+    g_flco_last_crc_correct = CRCCorrect;
 }
 
 void
@@ -190,8 +252,9 @@ dmr_cspdu(dsd_opts* opts, dsd_state* state, uint8_t cs_pdu_bits[], uint8_t cs_pd
     (void)state;
     (void)cs_pdu_bits;
     (void)cs_pdu;
-    (void)CRCCorrect;
     (void)IrrecoverableErrors;
+    g_cspdu_calls++;
+    g_cspdu_last_crc_correct = CRCCorrect;
 }
 
 void
@@ -201,8 +264,9 @@ dmr_dheader(dsd_opts* opts, dsd_state* state, uint8_t dheader[], uint8_t dheader
     (void)state;
     (void)dheader;
     (void)dheader_bits;
-    (void)CRCCorrect;
     (void)IrrecoverableErrors;
+    g_dheader_calls++;
+    g_dheader_last_crc_correct = CRCCorrect;
 }
 
 void
@@ -211,15 +275,17 @@ dmr_block_assembler(dsd_opts* opts, dsd_state* state, uint8_t block_bytes[], uin
     (void)opts;
     (void)state;
     (void)block_bytes;
-    (void)block_len;
-    (void)databurst;
-    (void)type;
+    g_block_assembler_calls++;
+    g_block_assembler_last_len = block_len;
+    g_block_assembler_last_burst = databurst;
+    g_block_assembler_last_type = type;
 }
 
 void
 dmr_reset_blocks(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_reset_blocks_calls++;
 }
 
 void
@@ -227,6 +293,7 @@ lip_protocol_decoder(const dsd_opts* opts, dsd_state* state, const uint8_t* lc_b
     (void)opts;
     (void)state;
     (void)lc_bits;
+    g_lip_calls++;
 }
 
 static int
@@ -254,6 +321,33 @@ expect_str(const char* tag, const char* got, const char* want) {
         return 1;
     }
     return 0;
+}
+
+static void
+write_bits_u32(uint8_t* bits, size_t start, size_t count, uint32_t value) {
+    for (size_t i = 0; i < count; i++) {
+        const size_t shift = count - 1U - i;
+        bits[start + i] = (uint8_t)((value >> shift) & 1U);
+    }
+}
+
+static void
+write_byte_bits(uint8_t* bits, size_t start, uint8_t value) {
+    write_bits_u32(bits, start, 8U, value);
+}
+
+static void
+write_confirmed_crc9_payload(uint8_t* bits, uint8_t dbsn, uint16_t crc_mask) {
+    write_bits_u32(bits, 0U, 7U, dbsn);
+    write_bits_u32(bits, 7U, 9U, crc_mask);
+}
+
+static void
+write_confirmed_crc9_bytes(uint8_t* bytes, uint8_t dbsn, uint16_t crc_mask) {
+    uint8_t bits[144];
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    write_confirmed_crc9_payload(bits, dbsn, crc_mask);
+    pack_bit_array_into_byte_array(bits, bytes, 18);
 }
 
 static int
@@ -406,12 +500,227 @@ test_special_profiles(void) {
     return rc;
 }
 
+static void
+prepare_handler_state(dsd_opts* opts, dsd_state* state, uint8_t info[196], uint8_t databurst, uint8_t conf_data,
+                      uint8_t header_format, int audio_in_type) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(info, 0, 196U);
+    reset_handler_counters();
+    opts->audio_in_type = audio_in_type;
+    state->currentslot = 1;
+    state->dmr_color_code = 16;
+    state->data_p_head[1] = 1;
+    state->data_conf_data[1] = conf_data;
+    state->data_header_format[1] = header_format;
+    if (databurst == 0x0BU) {
+        info[4] = 0;
+    }
+}
+
+static int
+test_handler_dispatch_paths(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t info[196];
+
+    prepare_handler_state(&opts, &state, info, 0x03U, 0U, 1U, 0);
+    dmr_data_burst_handler(&opts, &state, info, 0x03U);
+    rc |= expect_u8("csbk-call", (uint8_t)g_cspdu_calls, 1U);
+    rc |= expect_u8("csbk-clears-head", state.data_p_head[1], 0U);
+    rc |= expect_u8("csbk-crc-fails-with-stub-mask", (uint8_t)g_cspdu_last_crc_correct, 0U);
+    rc |= expect_str("csbk-subtype", state.fsubtype, " CSBK ");
+
+    prepare_handler_state(&opts, &state, info, 0x04U, 0U, 1U, 0);
+    state.data_block_counter[1] = 7;
+    dmr_data_burst_handler(&opts, &state, info, 0x04U);
+    rc |= expect_u8("mbch-block-call", (uint8_t)g_block_assembler_calls, 1U);
+    rc |= expect_u8("mbch-block-type", g_block_assembler_last_type, 2U);
+    rc |= expect_u8("mbch-header-valid", state.data_header_valid[1], 1U);
+    rc |= expect_u8("mbch-counter-reset", state.data_block_counter[1], 0U);
+
+    prepare_handler_state(&opts, &state, info, 0x06U, 0U, 1U, 0);
+    dmr_data_burst_handler(&opts, &state, info, 0x06U);
+    rc |= expect_u8("data-header-call", (uint8_t)g_dheader_calls, 1U);
+    rc |= expect_u8("data-header-keeps-head", state.data_p_head[1], 1U);
+    rc |= expect_u8("data-header-crc-fails-with-stub-mask", (uint8_t)g_dheader_last_crc_correct, 0U);
+
+    prepare_handler_state(&opts, &state, info, 0x07U, 0U, 1U, 0);
+    dmr_data_burst_handler(&opts, &state, info, 0x07U);
+    rc |= expect_u8("r12u-block-call", (uint8_t)g_block_assembler_calls, 1U);
+    rc |= expect_u8("r12u-block-type", g_block_assembler_last_type, 1U);
+    rc |= expect_u8("r12u-block-len", g_block_assembler_last_len, 12U);
+
+    prepare_handler_state(&opts, &state, info, 0x07U, 1U, 0U, 0);
+    dmr_data_burst_handler(&opts, &state, info, 0x07U);
+    rc |= expect_u8("udtc-block-call", (uint8_t)g_block_assembler_calls, 1U);
+    rc |= expect_u8("udtc-block-type", g_block_assembler_last_type, 3U);
+    rc |= expect_u8("udtc-block-len", g_block_assembler_last_len, 10U);
+
+    prepare_handler_state(&opts, &state, info, 0x08U, 0U, 1U, AUDIO_IN_SYMBOL_BIN);
+    dmr_data_burst_handler(&opts, &state, info, 0x08U);
+    rc |= expect_u8("r34u-block-call", (uint8_t)g_block_assembler_calls, 1U);
+    rc |= expect_u8("r34u-block-burst", g_block_assembler_last_burst, 0x08U);
+    rc |= expect_u8("r34u-block-len", g_block_assembler_last_len, 18U);
+
+    prepare_handler_state(&opts, &state, info, 0x0AU, 0U, 1U, 0);
+    dmr_data_burst_handler(&opts, &state, info, 0x0AU);
+    rc |= expect_u8("full-rate-block-call", (uint8_t)g_block_assembler_calls, 1U);
+    rc |= expect_u8("full-rate-block-burst", g_block_assembler_last_burst, 0x0AU);
+    rc |= expect_u8("full-rate-block-len", g_block_assembler_last_len, 24U);
+
+    prepare_handler_state(&opts, &state, info, 0x0BU, 0U, 1U, 0);
+    dmr_data_burst_handler(&opts, &state, info, 0x0BU);
+    rc |= expect_u8("usbd-lip-call", (uint8_t)g_lip_calls, 1U);
+    rc |= expect_str("usbd-subtype", state.fsubtype, " USBD ");
+
+    prepare_handler_state(&opts, &state, info, 0xEBU, 0U, 1U, 0);
+    dmr_data_burst_handler(&opts, &state, info, 0xEBU);
+    rc |= expect_u8("embedded-flco-call", (uint8_t)g_flco_calls, 1U);
+    rc |= expect_u8("embedded-flco-type", g_flco_last_type, 3U);
+    rc |= expect_u8("embedded-crc-correct", (uint8_t)g_flco_last_crc_correct, 1U);
+
+    return rc;
+}
+
+static int
+test_handler_additional_dispatch_paths(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t info[196];
+
+    prepare_handler_state(&opts, &state, info, 0x00U, 0U, 1U, 0);
+    dmr_data_burst_handler(&opts, &state, info, 0x00U);
+    rc |= expect_u8("pi-call", (uint8_t)g_pi_calls, 1U);
+    rc |= expect_u8("pi-clears-head", state.data_p_head[1], 0U);
+
+    prepare_handler_state(&opts, &state, info, 0x01U, 0U, 1U, 0);
+    dmr_data_burst_handler(&opts, &state, info, 0x01U);
+    rc |= expect_u8("vlc-flco-call", (uint8_t)g_flco_calls, 1U);
+    rc |= expect_u8("vlc-flco-type", g_flco_last_type, 1U);
+    rc |= expect_u8("vlc-crc-correct", (uint8_t)g_flco_last_crc_correct, 1U);
+
+    prepare_handler_state(&opts, &state, info, 0x02U, 0U, 1U, 0);
+    dmr_data_burst_handler(&opts, &state, info, 0x02U);
+    rc |= expect_u8("tlc-flco-call", (uint8_t)g_flco_calls, 1U);
+    rc |= expect_u8("tlc-flco-type", g_flco_last_type, 2U);
+
+    prepare_handler_state(&opts, &state, info, 0x05U, 0U, 1U, 0);
+    dmr_data_burst_handler(&opts, &state, info, 0x05U);
+    rc |= expect_u8("mbcc-block-call", (uint8_t)g_block_assembler_calls, 1U);
+    rc |= expect_u8("mbcc-block-type", g_block_assembler_last_type, 2U);
+    rc |= expect_u8("mbcc-block-len", g_block_assembler_last_len, 12U);
+
+    prepare_handler_state(&opts, &state, info, 0x40U, 0U, 1U, 0);
+    dmr_data_burst_handler(&opts, &state, info, 0x40U);
+    rc |= expect_str("unknown-handler-subtype", state.fsubtype, " _UNK ");
+    rc |= expect_u8("unknown-handler-no-assembler", (uint8_t)g_block_assembler_calls, 0U);
+    return rc;
+}
+
+static int
+test_bptc_ras_and_usbd_services(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t info[196];
+
+    prepare_handler_state(&opts, &state, info, 0x06U, 0U, 1U, 0);
+    g_bptc_reserved[2] = 1U;
+    dmr_data_burst_handler(&opts, &state, info, 0x06U);
+    rc |= expect_u8("ras-data-header-call", (uint8_t)g_dheader_calls, 1U);
+    rc |= expect_u8("ras-crc-presented-correct", (uint8_t)g_dheader_last_crc_correct, 1U);
+    rc |= expect_u8("ras-header-valid", state.data_block_crc_valid[1][0], 1U);
+
+    prepare_handler_state(&opts, &state, info, 0x06U, 0U, 1U, 0);
+    g_bptc_reserved[2] = 1U;
+    write_byte_bits(g_bptc_bits, 8U, 0x68U);
+    dmr_data_burst_handler(&opts, &state, info, 0x06U);
+    rc |= expect_u8("ras-disabled-by-proprietary-header-call", (uint8_t)g_dheader_calls, 1U);
+    rc |= expect_u8("ras-disabled-crc-stays-failed", (uint8_t)g_dheader_last_crc_correct, 0U);
+
+    prepare_handler_state(&opts, &state, info, 0x0BU, 0U, 1U, 0);
+    write_byte_bits(g_bptc_bits, 0U, 0x90U);
+    dmr_data_burst_handler(&opts, &state, info, 0x0BU);
+    rc |= expect_u8("usbd-reserved-service-no-lip", (uint8_t)g_lip_calls, 0U);
+    rc |= expect_str("usbd-reserved-service-subtype", state.fsubtype, " USBD ");
+    return rc;
+}
+
+static int
+test_confirmed_sequence_paths(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t info[196];
+
+    prepare_handler_state(&opts, &state, info, 0x07U, 1U, 1U, 0);
+    state.data_block_counter[1] = 4U;
+    write_confirmed_crc9_payload(g_bptc_bits, 12U, 0U);
+    dmr_data_burst_handler(&opts, &state, info, 0x07U);
+    rc |= expect_u8("r12c-crc-records-failure", state.data_block_crc_valid[1][4], 0U);
+    rc |= expect_u8("r12c-non-aggressive-seeds-dbsn", state.data_dbsn_have[1], 1U);
+    rc |= expect_u8("r12c-expected-dbsn", state.data_dbsn_expected[1], 13U);
+    rc |= expect_u8("r12c-dispatched-after-seed", (uint8_t)g_block_assembler_calls, 1U);
+
+    prepare_handler_state(&opts, &state, info, 0x0AU, 1U, 1U, 0);
+    opts.aggressive_framesync = 1;
+    state.data_dbsn_have[1] = 1U;
+    state.data_dbsn_expected[1] = 7U;
+    state.data_block_counter[1] = 5U;
+    write_confirmed_crc9_payload(info, 5U, 0x10FU);
+    dmr_data_burst_handler(&opts, &state, info, 0x0AU);
+    rc |= expect_u8("full-confirmed-crc-records-pass", state.data_block_crc_valid[1][5], 1U);
+    rc |= expect_u8("full-confirmed-seq-reset", (uint8_t)g_reset_blocks_calls, 1U);
+    rc |= expect_u8("full-confirmed-seq-suppresses-dispatch", (uint8_t)g_block_assembler_calls, 0U);
+    return rc;
+}
+
+static int
+test_trellis_candidate_and_fallback_paths(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t info[196];
+    uint8_t reliab[98];
+
+    prepare_handler_state(&opts, &state, info, 0x08U, 1U, 1U, 0);
+    state.data_dbsn_have[1] = 1U;
+    state.data_dbsn_expected[1] = 9U;
+    state.data_block_counter[1] = 6U;
+    DSD_MEMSET(reliab, 7, sizeof(reliab));
+    g_r34_list_status = 0;
+    g_r34_list_count = 2;
+    write_confirmed_crc9_bytes(g_r34_candidates[0].bytes18, 3U, 0U);
+    write_confirmed_crc9_bytes(g_r34_candidates[1].bytes18, 9U, 0x1FFU);
+    dmr_data_burst_handler_ex(&opts, &state, info, 0x08U, reliab);
+    rc |= expect_u8("r34c-list-crc-records-pass", state.data_block_crc_valid[1][6], 1U);
+    rc |= expect_u8("r34c-list-updates-dbsn", state.data_dbsn_expected[1], 10U);
+    rc |= expect_u8("r34c-list-dispatches", (uint8_t)g_block_assembler_calls, 1U);
+    rc |= expect_u8("r34c-list-block-len", g_block_assembler_last_len, 16U);
+
+    prepare_handler_state(&opts, &state, info, 0x08U, 0U, 1U, 0);
+    DSD_MEMSET(reliab, 13, sizeof(reliab));
+    g_r34_soft_bytes[2] = 0xA5U;
+    dmr_data_burst_handler_ex(&opts, &state, info, 0x08U, reliab);
+    rc |= expect_u8("r34u-soft-fallback-dispatches", (uint8_t)g_block_assembler_calls, 1U);
+    rc |= expect_u8("r34u-soft-fallback-len", g_block_assembler_last_len, 18U);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
     rc |= test_base_profiles();
     rc |= test_dynamic_profiles();
     rc |= test_special_profiles();
+    rc |= test_handler_dispatch_paths();
+    rc |= test_handler_additional_dispatch_paths();
+    rc |= test_bptc_ras_and_usbd_services();
+    rc |= test_confirmed_sequence_paths();
+    rc |= test_trellis_candidate_and_fallback_paths();
     if (rc == 0) {
         printf("DMR_DBURST_PROFILE: OK\n");
     }

--- a/tests/protocol/dmr/test_dmr_debug_burst.c
+++ b/tests/protocol/dmr/test_dmr_debug_burst.c
@@ -3,11 +3,14 @@
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
@@ -91,10 +94,74 @@ test_payload_formatter(void) {
     return expect_debug_burst_line("payload", actual, expected);
 }
 
+static int
+test_formatter_guards_and_truncation(void) {
+    int payload[144];
+    DSD_MEMSET(payload, 0, sizeof(payload));
+
+    char actual[8] = {'x', 'x', 'x', 'x', 'x', 'x', 'x', '\0'};
+    if (dmr_debug_format_burst_payload(NULL, sizeof(actual), payload, 0, 0x01) != 0U) {
+        DSD_FPRINTF(stderr, "NULL output was accepted\n");
+        return 1;
+    }
+    if (dmr_debug_format_burst_payload(actual, 0U, payload, 0, 0x01) != 0U) {
+        DSD_FPRINTF(stderr, "zero-sized output was accepted\n");
+        return 1;
+    }
+    if (dmr_debug_format_burst_payload(actual, sizeof(actual), NULL, 0, 0x01) != 0U) {
+        DSD_FPRINTF(stderr, "NULL payload was accepted\n");
+        return 1;
+    }
+    if (dmr_debug_format_burst_payload(actual, sizeof(actual), payload, 2, 0x01) != 0U) {
+        DSD_FPRINTF(stderr, "invalid slot was accepted\n");
+        return 1;
+    }
+    if (dmr_debug_format_burst(actual, sizeof(actual), NULL, 0, 0x01) != 0U) {
+        DSD_FPRINTF(stderr, "NULL state was accepted\n");
+        return 1;
+    }
+
+    char header_only[8];
+    size_t n = dmr_debug_format_burst_payload(header_only, sizeof(header_only), payload, 0, 0x55);
+    if (n <= sizeof(header_only) || header_only[sizeof(header_only) - 1U] != '\0') {
+        DSD_FPRINTF(stderr, "header truncation contract failed n=%zu tail=%d\n", n,
+                    (int)header_only[sizeof(header_only) - 1U]);
+        return 1;
+    }
+
+    char short_line[43];
+    n = dmr_debug_format_burst_payload(short_line, sizeof(short_line), payload, 0, 0x55);
+    if (n <= sizeof(short_line) || short_line[sizeof(short_line) - 1U] != '\0') {
+        DSD_FPRINTF(stderr, "payload truncation contract failed n=%zu tail=%d\n", n,
+                    (int)short_line[sizeof(short_line) - 1U]);
+        return 1;
+    }
+
+    return 0;
+}
+
+static int
+test_debug_dump_gate_and_enabled_path(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    dmr_debug_dump_burst(NULL, &state, 0, 0x01);
+    dmr_debug_dump_burst(&opts, NULL, 0, 0x01);
+    dmr_debug_dump_burst(&opts, &state, 0, 0x01);
+    opts.dmr_debug_burst = 1;
+    dmr_debug_dump_burst(&opts, &state, 2, 0x01);
+    dmr_debug_dump_burst(&opts, &state, 0, 0x01);
+    return 0;
+}
+
 int
 main(void) {
     int rc = 0;
     rc |= test_state_formatter();
     rc |= test_payload_formatter();
+    rc |= test_formatter_guards_and_truncation();
+    rc |= test_debug_dump_gate_and_enabled_path();
     return rc;
 }

--- a/tests/protocol/dmr/test_dmr_embedded_gps_position_error.c
+++ b/tests/protocol/dmr/test_dmr_embedded_gps_position_error.c
@@ -29,7 +29,19 @@
 #endif
 
 void dmr_embedded_gps(dsd_opts* opts, dsd_state* state, uint8_t lc_bits[]);
+void apx_embedded_gps(dsd_opts* opts, dsd_state* state, uint8_t lc_bits[]);
+void harris_gps(dsd_opts* opts, dsd_state* state, int slot, uint8_t* input);
+void lip_protocol_decoder(dsd_opts* opts, dsd_state* state, uint8_t* input);
+void nmea_iec_61162_1(dsd_opts* opts, dsd_state* state, uint8_t* input, uint32_t src, int type);
+void nmea_harris(dsd_opts* opts, dsd_state* state, uint8_t* input, uint32_t src, int slot);
 uint8_t nmea_sentence_checker(dsd_opts* opts, dsd_state* state, uint8_t* input, uint8_t slot, int len_bytes);
+void nxdn_gps_report(dsd_opts* opts, dsd_state* state, uint8_t* input, uint32_t src);
+
+static int g_watchdog_calls;
+static uint32_t g_watchdog_src;
+static uint32_t g_watchdog_dst;
+static uint8_t g_watchdog_slot;
+static char g_watchdog_data[128];
 
 // Minimal stubs for direct link with dsd_gps.c
 uint64_t
@@ -84,10 +96,11 @@ void
 watchdog_event_datacall(dsd_opts* opts, dsd_state* state, uint32_t src, uint32_t dst, char* data_string, uint8_t slot) {
     (void)opts;
     (void)state;
-    (void)src;
-    (void)dst;
-    (void)data_string;
-    (void)slot;
+    g_watchdog_calls++;
+    g_watchdog_src = src;
+    g_watchdog_dst = dst;
+    g_watchdog_slot = slot;
+    DSD_SNPRINTF(g_watchdog_data, sizeof g_watchdog_data, "%s", data_string ? data_string : "");
 }
 
 void
@@ -136,6 +149,15 @@ expect_u32(const char* tag, uint32_t got, uint32_t want) {
 }
 
 static void
+reset_watchdog_capture(void) {
+    g_watchdog_calls = 0;
+    g_watchdog_src = 0;
+    g_watchdog_dst = 0;
+    g_watchdog_slot = 0xFFU;
+    DSD_MEMSET(g_watchdog_data, 0, sizeof g_watchdog_data);
+}
+
+static void
 set_pos_err(uint8_t* lc_bits, uint8_t pos_err) {
     // pos_err is 3 bits at positions 20..22, MSB-first.
     lc_bits[20] = (pos_err >> 2) & 1;
@@ -165,6 +187,208 @@ nmea_ascii_to_bits(uint8_t* out_bits, int out_bits_len, const char* sentence) {
     }
 }
 
+static void
+set_bits_msb(uint8_t* bits_out, int out_bits_len, int bit_offset, uint32_t value, int bit_count) {
+    if (bit_offset < 0 || bit_count < 0 || bit_offset + bit_count > out_bits_len) {
+        DSD_FPRINTF(stderr, "set_bits_msb: need=%d have=%d\n", bit_offset + bit_count, out_bits_len);
+        exit(2);
+    }
+
+    for (int b = 0; b < bit_count; b++) {
+        bits_out[bit_offset + b] = (uint8_t)((value >> (bit_count - 1 - b)) & 1U);
+    }
+}
+
+static int
+test_packed_nmea_formats(dsd_opts* opts, dsd_state* st) {
+    int rc = 0;
+
+    {
+        uint8_t bits[128];
+        DSD_MEMSET(bits, 0, sizeof bits);
+        bits[1] = 1U; // north
+        bits[2] = 1U; // east
+        bits[3] = 1U; // fix valid
+        set_bits_msb(bits, (int)sizeof bits, 4, 10U, 7);
+        set_bits_msb(bits, (int)sizeof bits, 11, 41U, 7);
+        set_bits_msb(bits, (int)sizeof bits, 18, 30U, 6);
+        set_bits_msb(bits, (int)sizeof bits, 24, 0U, 14);
+        set_bits_msb(bits, (int)sizeof bits, 38, 87U, 8);
+        set_bits_msb(bits, (int)sizeof bits, 46, 15U, 6);
+        set_bits_msb(bits, (int)sizeof bits, 52, 0U, 14);
+        set_bits_msb(bits, (int)sizeof bits, 66, 12U, 5);
+        set_bits_msb(bits, (int)sizeof bits, 71, 34U, 6);
+        set_bits_msb(bits, (int)sizeof bits, 77, 56U, 6);
+        set_bits_msb(bits, (int)sizeof bits, 103, 123U, 9);
+
+        st->currentslot = 0;
+        DSD_MEMSET(st->dmr_embedded_gps[0], 0, sizeof st->dmr_embedded_gps[0]);
+        DSD_MEMSET(st->event_history_s[0].Event_History_Items[0].gps_s, 0,
+                   sizeof st->event_history_s[0].Event_History_Items[0].gps_s);
+        nmea_iec_61162_1(opts, st, bits, 900001U, 2);
+
+        rc |= expect_has_substr(st->dmr_embedded_gps[0], "41.500000", "nmea-iec-lat");
+        rc |= expect_has_substr(st->dmr_embedded_gps[0], "87.250000", "nmea-iec-lon");
+        rc |= expect_has_substr(st->event_history_s[0].Event_History_Items[0].gps_s, "41.500000", "nmea-iec-event-lat");
+    }
+
+    {
+        uint8_t bits[160];
+        DSD_MEMSET(bits, 0, sizeof bits);
+        set_bits_msb(bits, (int)sizeof bits, 0, 0x2AA4U, 16);
+        set_bits_msb(bits, (int)sizeof bits, 40, 5000U, 16);
+        bits[56] = 1U; // negative latitude
+        set_bits_msb(bits, (int)sizeof bits, 57, 30U, 7);
+        set_bits_msb(bits, (int)sizeof bits, 64, 41U, 8);
+        set_bits_msb(bits, (int)sizeof bits, 72, 2500U, 16);
+        bits[88] = 1U; // negative longitude
+        set_bits_msb(bits, (int)sizeof bits, 89, 15U, 7);
+        set_bits_msb(bits, (int)sizeof bits, 96, 87U, 8);
+        set_bits_msb(bits, (int)sizeof bits, 104, 3661U, 16);
+        set_bits_msb(bits, (int)sizeof bits, 135, 270U, 9);
+
+        DSD_MEMSET(st->dmr_embedded_gps[1], 0, sizeof st->dmr_embedded_gps[1]);
+        DSD_MEMSET(st->event_history_s[1].Event_History_Items[0].gps_s, 0,
+                   sizeof st->event_history_s[1].Event_History_Items[0].gps_s);
+        st->event_history_s[1].Event_History_Items[0].source_id = 900002U;
+        nmea_harris(opts, st, bits, 900002U, 2);
+
+        rc |= expect_has_substr(st->dmr_embedded_gps[1], "-41.508333", "harris-nmea-lat");
+        rc |= expect_has_substr(st->dmr_embedded_gps[1], "-87.254167", "harris-nmea-lon");
+        rc |= expect_has_substr(st->dmr_embedded_gps[1], "270", "harris-nmea-heading");
+        rc |= expect_has_substr(st->event_history_s[1].Event_History_Items[0].gps_s, "-87.254167",
+                                "harris-nmea-event-lon");
+    }
+
+    return rc;
+}
+
+static int
+test_lip_and_vendor_gps(dsd_opts* opts, dsd_state* st) {
+    int rc = 0;
+
+    {
+        uint8_t bits[96];
+        DSD_MEMSET(bits, 0, sizeof bits);
+        set_bits_msb(bits, (int)sizeof bits, 6, 2U, 2); // time elapsed
+        bits[8] = 1U;                                   // west
+        set_bits_msb(bits, (int)sizeof bits, 9, 0x010000U, 24);
+        bits[33] = 1U; // south
+        set_bits_msb(bits, (int)sizeof bits, 34, 0x020000U, 23);
+        set_bits_msb(bits, (int)sizeof bits, 57, 3U, 2);
+        set_bits_msb(bits, (int)sizeof bits, 59, 40U, 7);
+        set_bits_msb(bits, (int)sizeof bits, 66, 6U, 4);
+        set_bits_msb(bits, (int)sizeof bits, 70, 5U, 3);
+        set_bits_msb(bits, (int)sizeof bits, 73, 0x5AU, 8);
+
+        st->currentslot = 1;
+        DSD_MEMSET(st->dmr_embedded_gps[1], 0, sizeof st->dmr_embedded_gps[1]);
+        DSD_MEMSET(st->event_history_s[1].Event_History_Items[0].gps_s, 0,
+                   sizeof st->event_history_s[1].Event_History_Items[0].gps_s);
+        lip_protocol_decoder(opts, st, bits);
+
+        rc |= expect_has_substr(st->dmr_embedded_gps[1], "090; LIP:", "lip-slot1-prefix");
+        rc |= expect_has_substr(st->dmr_embedded_gps[1], "S", "lip-south");
+        rc |= expect_has_substr(st->dmr_embedded_gps[1], "W", "lip-west");
+        rc |= expect_has_substr(st->dmr_embedded_gps[1], "Err: 2000m", "lip-position-error");
+        rc |= expect_has_substr(st->event_history_s[1].Event_History_Items[0].gps_s, "090; LIP:", "lip-event");
+    }
+
+    {
+        uint8_t bits[96];
+        DSD_MEMSET(bits, 0, sizeof bits);
+        st->currentslot = 1;
+        st->lastsrcR = 0x102030;
+        st->event_history_s[1].Event_History_Items[0].source_id = 0x102030;
+        DSD_MEMSET(st->dmr_embedded_gps[1], 0, sizeof st->dmr_embedded_gps[1]);
+        DSD_MEMSET(st->event_history_s[1].Event_History_Items[0].gps_s, 0,
+                   sizeof st->event_history_s[1].Event_History_Items[0].gps_s);
+        bits[1] = 1U;  // res_a
+        bits[23] = 1U; // expired/last fix
+        bits[24] = 1U; // negative latitude
+        set_bits_msb(bits, (int)sizeof bits, 25, 0x200000U, 23);
+        bits[48] = 1U; // west longitude encoding
+        set_bits_msb(bits, (int)sizeof bits, 49, 0x300000U, 23);
+
+        apx_embedded_gps(opts, st, bits);
+
+        rc |= expect_has_substr(st->dmr_embedded_gps[1], "GPS:", "apx-gps-string");
+        rc |= expect_has_substr(st->dmr_embedded_gps[1], "Last Fix", "apx-expired");
+        rc |= expect_has_substr(st->event_history_s[1].Event_History_Items[0].gps_s, "Last Fix", "apx-event");
+    }
+
+    {
+        uint8_t bits[160];
+        DSD_MEMSET(bits, 0, sizeof bits);
+        st->currentslot = 0;
+        st->lastsrc = 0x445566;
+        DSD_MEMSET(st->dmr_embedded_gps[0], 0, sizeof st->dmr_embedded_gps[0]);
+        set_bits_msb(bits, (int)sizeof bits, 40, 1234U, 16);
+        set_bits_msb(bits, (int)sizeof bits, 58, 30U, 6);
+        set_bits_msb(bits, (int)sizeof bits, 65, 41U, 7);
+        bits[72] = 1U;
+        set_bits_msb(bits, (int)sizeof bits, 72, 5678U, 16);
+        set_bits_msb(bits, (int)sizeof bits, 90, 15U, 6);
+        set_bits_msb(bits, (int)sizeof bits, 96, 87U, 8);
+        set_bits_msb(bits, (int)sizeof bits, 104, 3723U, 16);
+        set_bits_msb(bits, (int)sizeof bits, 120, 90U, 8);
+        set_bits_msb(bits, (int)sizeof bits, 128, 0x8000U, 16);
+
+        harris_gps(opts, st, 0, bits);
+
+        rc |= expect_has_substr(st->dmr_embedded_gps[0], "GPS:", "legacy-harris-gps");
+        rc |= expect_has_substr(st->dmr_embedded_gps[0], "41.", "legacy-harris-lat");
+        rc |= expect_has_substr(st->dmr_embedded_gps[0], "87.", "legacy-harris-lon");
+    }
+
+    return rc;
+}
+
+static int
+test_nxdn_gps_report_paths(dsd_opts* opts, dsd_state* st) {
+    int rc = 0;
+    uint8_t bits[280];
+
+    DSD_MEMSET(bits, 0, sizeof bits);
+    set_bits_msb(bits, (int)sizeof bits, 16, 2500U, 15);
+    set_bits_msb(bits, (int)sizeof bits, 56, 123U, 16);
+    set_bits_msb(bits, (int)sizeof bits, 74, 321U, 14);
+    set_bits_msb(bits, (int)sizeof bits, 92, 2700U, 12);
+    set_bits_msb(bits, (int)sizeof bits, 136, 25U, 7);
+    set_bits_msb(bits, (int)sizeof bits, 143, 6U, 4);
+    set_bits_msb(bits, (int)sizeof bits, 147, 21U, 5);
+    set_bits_msb(bits, (int)sizeof bits, 152, 8715U, 16);
+    set_bits_msb(bits, (int)sizeof bits, 184, 4130U, 16);
+    set_bits_msb(bits, (int)sizeof bits, 200, 5000U, 15);
+    set_bits_msb(bits, (int)sizeof bits, 247, 14U, 5);
+    set_bits_msb(bits, (int)sizeof bits, 252, 45U, 6);
+    st->dmr_lrrp_source[0] = 1234U;
+    st->dmr_lrrp_target[0] = 5678U;
+    DSD_MEMSET(st->event_history_s[0].Event_History_Items[0].gps_s, 0,
+               sizeof st->event_history_s[0].Event_History_Items[0].gps_s);
+    reset_watchdog_capture();
+
+    nxdn_gps_report(opts, st, bits, 900003U);
+
+    rc |= expect_has_substr(st->event_history_s[0].Event_History_Items[0].gps_s, "41.", "nxdn-gps-lat");
+    rc |= expect_has_substr(st->event_history_s[0].Event_History_Items[0].gps_s, "87.", "nxdn-gps-lon");
+    rc |= expect_i("nxdn-watchdog-calls", g_watchdog_calls, 1);
+    rc |= expect_u32("nxdn-watchdog-src", g_watchdog_src, 1234U);
+    rc |= expect_u32("nxdn-watchdog-dst", g_watchdog_dst, 5678U);
+    rc |= expect_u32("nxdn-source-reset", st->dmr_lrrp_source[0], 0U);
+    rc |= expect_u32("nxdn-target-reset", st->dmr_lrrp_target[0], 0U);
+
+    DSD_MEMSET(bits, 0, sizeof bits);
+    set_bits_msb(bits, (int)sizeof bits, 184, 9900U, 16);
+    st->dmr_lrrp_source[0] = 4444U;
+    st->dmr_lrrp_target[0] = 5555U;
+    nxdn_gps_report(opts, st, bits, 0U);
+    rc |= expect_u32("nxdn-invalid-source-reset", st->dmr_lrrp_source[0], 0U);
+    rc |= expect_u32("nxdn-invalid-target-reset", st->dmr_lrrp_target[0], 0U);
+
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -180,6 +404,9 @@ main(void) {
     if (!st.event_history_s) {
         return 100;
     }
+    rc |= test_packed_nmea_formats(&opts, &st);
+    rc |= test_lip_and_vendor_gps(&opts, &st);
+    rc |= test_nxdn_gps_report_paths(&opts, &st);
 
     uint8_t lc_bits[80];
     DSD_MEMSET(lc_bits, 0, sizeof lc_bits);

--- a/tests/protocol/dmr/test_dmr_embedded_gps_position_error.c
+++ b/tests/protocol/dmr/test_dmr_embedded_gps_position_error.c
@@ -484,6 +484,33 @@ main(void) {
         rc |= expect_u32("nmea-invalid-tgt-reset", st.dmr_lrrp_target[0], 0U);
     }
 
+    // NMEA sentence checker: missing checksum delimiter still clears LRRP state without emitting an event.
+    {
+        static const char nmea_missing_star[] = "$GPRMC,TEST\r\n";
+        uint8_t bits[8 * (int)(sizeof(nmea_missing_star) - 1)];
+        int len_bytes = nmea_len_bits(nmea_missing_star);
+        nmea_ascii_to_bits(bits, (int)sizeof(bits), nmea_missing_star);
+        st.dmr_lrrp_source[0] = 555U;
+        st.dmr_lrrp_target[0] = 666U;
+        reset_watchdog_capture();
+        if (st.event_history_s != NULL) {
+            DSD_MEMSET(st.event_history_s[0].Event_History_Items[0].text_message, 0,
+                       sizeof(st.event_history_s[0].Event_History_Items[0].text_message));
+        }
+        uint8_t ok = nmea_sentence_checker(&opts, &st, bits, 0, len_bytes);
+        rc |= expect_u8("nmea-missing-star", ok, 0U);
+        rc |= expect_i("nmea-missing-star-watchdog", g_watchdog_calls, 0);
+        if (st.event_history_s != NULL) {
+            rc |= expect_i("nmea-missing-star-text-empty", st.event_history_s[0].Event_History_Items[0].text_message[0],
+                           0);
+        } else {
+            DSD_FPRINTF(stderr, "%s\n", "nmea-missing-star-text-empty: event_history_s is NULL");
+            rc |= 1;
+        }
+        rc |= expect_u32("nmea-missing-star-src-reset", st.dmr_lrrp_source[0], 0U);
+        rc |= expect_u32("nmea-missing-star-tgt-reset", st.dmr_lrrp_target[0], 0U);
+    }
+
     // NMEA checker should still validate even if event history is unavailable.
     {
         static const char nmea_ok[] = "$GPRMC,TEST*71\r\n";

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -784,6 +784,35 @@ test_encrypted_flco_lockout_inserts_policy_and_event_history(void) {
 }
 
 static void
+test_encrypted_flco_allowed_tuning_skips_lockout_policy(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_tg_policy_lookup lookup;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+    init_event_history(&history[0], 0, 1);
+    init_event_history(&history[1], 0, 1);
+    state.event_history_s = history;
+    opts.trunk_enable = 1;
+    opts.trunk_tune_enc_calls = 1;
+    state.currentslot = 0;
+
+    build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 4321U, 8765U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+
+    assert(irr == 0);
+    assert(dsd_tg_policy_lookup_id(&state, 4321U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_NONE);
+    assert(history[0].Event_History_Items[0].internal_str[0] == '\0');
+    dsd_state_ext_free_all(&state);
+}
+
+static void
 test_completed_slco_tier3_site_parameters_update_state(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -901,6 +930,7 @@ main(void) {
     test_cach_completed_fragment_crc_error_reports_voice_payload_context();
     test_cach_fragment_counter_overflow_resets_fragments();
     test_encrypted_flco_lockout_inserts_policy_and_event_history();
+    test_encrypted_flco_allowed_tuning_skips_lockout_policy();
     test_completed_slco_tier3_site_parameters_update_state();
     test_completed_slco_connect_plus_and_xpt_update_site_state();
     test_completed_slco_capacity_plus_hold_returns_to_rest_channel();

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -1,20 +1,31 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
 #include <assert.h>
+#include <dsd-neo/core/events.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/fec/block_codes.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
+#include <dsd-neo/protocol/dmr/dmr_utils_api.h>
 #include <dsd-neo/protocol/edacs/edacs_afs.h>
 #include <dsd-neo/protocol/nxdn/nxdn_lfsr.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
+
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_ext.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "test_support.h"
 
@@ -47,6 +58,118 @@ bytes_to_bits(uint8_t* bits, const uint8_t* bytes, size_t nbytes) {
     }
 }
 
+static void
+build_tact(uint8_t out[7], uint8_t lcss) {
+    unsigned char orig[4] = {0, 0, (uint8_t)((lcss >> 1U) & 1U), (uint8_t)(lcss & 1U)};
+    unsigned char enc[7];
+    Hamming_7_4_encode(orig, enc);
+    for (int i = 0; i < 7; i++) {
+        out[i] = enc[i] & 1U;
+    }
+}
+
+static void
+build_cach_fragment(uint8_t cach_bits[25], uint8_t lcss, const uint8_t slc[17]) {
+    DSD_MEMSET(cach_bits, 0, 25U);
+    build_tact(cach_bits, lcss);
+    for (int i = 0; i < 17; i++) {
+        cach_bits[i + 7] = slc[i] & 1U;
+    }
+}
+
+static void
+build_slc17(uint8_t slc[17], uint8_t slco, uint8_t ts1_act, uint8_t ts2_act) {
+    DSD_MEMSET(slc, 0, 17U);
+    write_bits_u64(slc, 0U, slco, 4U);
+    write_bits_u64(slc, 4U, ts1_act, 4U);
+    write_bits_u64(slc, 8U, ts2_act, 4U);
+    slc[12] = slc[0] ^ slc[1] ^ slc[2] ^ slc[3] ^ slc[6] ^ slc[7] ^ slc[9];
+    slc[13] = slc[0] ^ slc[1] ^ slc[2] ^ slc[3] ^ slc[4] ^ slc[7] ^ slc[8] ^ slc[10];
+    slc[14] = slc[1] ^ slc[2] ^ slc[3] ^ slc[4] ^ slc[5] ^ slc[8] ^ slc[9] ^ slc[11];
+    slc[15] = slc[0] ^ slc[1] ^ slc[4] ^ slc[5] ^ slc[7] ^ slc[10];
+    slc[16] = slc[0] ^ slc[1] ^ slc[2] ^ slc[5] ^ slc[6] ^ slc[8] ^ slc[11];
+}
+
+static void
+build_hamming17123_payload(uint8_t out[17], const uint8_t payload[12]) {
+    DSD_MEMSET(out, 0, 17U);
+    for (int i = 0; i < 12; i++) {
+        out[i] = payload[i] & 1U;
+    }
+    out[12] = out[0] ^ out[1] ^ out[2] ^ out[3] ^ out[6] ^ out[7] ^ out[9];
+    out[13] = out[0] ^ out[1] ^ out[2] ^ out[3] ^ out[4] ^ out[7] ^ out[8] ^ out[10];
+    out[14] = out[1] ^ out[2] ^ out[3] ^ out[4] ^ out[5] ^ out[8] ^ out[9] ^ out[11];
+    out[15] = out[0] ^ out[1] ^ out[4] ^ out[5] ^ out[7] ^ out[10];
+    out[16] = out[0] ^ out[1] ^ out[2] ^ out[5] ^ out[6] ^ out[8] ^ out[11];
+}
+
+static void
+make_slco_crc_residue_zero(uint8_t slco_bits[36]) {
+    for (uint32_t nonce = 0; nonce <= 0xFFU; nonce++) {
+        write_bits_u64(slco_bits, 28U, nonce, 8U);
+        if (crc8(slco_bits, 36U) == 0U) {
+            return;
+        }
+    }
+    assert(!"unable to derive zero-residue SLC payload");
+}
+
+static void
+build_completed_slco_cach(uint8_t cach[4][25], uint8_t slco_bits[36]) {
+    uint8_t expanded[68];
+    uint8_t raw[68];
+
+    make_slco_crc_residue_zero(slco_bits);
+    DSD_MEMSET(expanded, 0, sizeof(expanded));
+    DSD_MEMSET(raw, 0, sizeof(raw));
+    for (int word = 0; word < 3; word++) {
+        build_hamming17123_payload(&expanded[word * 17], &slco_bits[word * 12]);
+    }
+
+    for (int i = 0; i < 67; i++) {
+        raw[(i * 4) % 67] = expanded[i];
+    }
+    raw[67] = expanded[67];
+
+    build_cach_fragment(cach[0], 1U, &raw[0]);
+    build_cach_fragment(cach[1], 3U, &raw[17]);
+    build_cach_fragment(cach[2], 3U, &raw[34]);
+    build_cach_fragment(cach[3], 2U, &raw[51]);
+}
+
+static void
+build_completed_slco_cach_without_crc_fixup(uint8_t cach[4][25], const uint8_t slco_bits[36]) {
+    uint8_t expanded[68];
+    uint8_t raw[68];
+
+    DSD_MEMSET(expanded, 0, sizeof(expanded));
+    DSD_MEMSET(raw, 0, sizeof(raw));
+    for (int word = 0; word < 3; word++) {
+        build_hamming17123_payload(&expanded[word * 17], &slco_bits[word * 12]);
+    }
+
+    for (int i = 0; i < 67; i++) {
+        raw[(i * 4) % 67] = expanded[i];
+    }
+    raw[67] = expanded[67];
+
+    build_cach_fragment(cach[0], 1U, &raw[0]);
+    build_cach_fragment(cach[1], 3U, &raw[17]);
+    build_cach_fragment(cach[2], 3U, &raw[34]);
+    build_cach_fragment(cach[3], 2U, &raw[51]);
+}
+
+static void
+run_completed_slco(dsd_opts* opts, dsd_state* state, uint8_t slco_bits[36]) {
+    uint8_t cach[4][25];
+
+    build_completed_slco_cach(cach, slco_bits);
+    assert(dmr_cach(opts, state, cach[0]) == 0U);
+    assert(dmr_cach(opts, state, cach[1]) == 0U);
+    assert(dmr_cach(opts, state, cach[2]) == 0U);
+    assert(dmr_cach(opts, state, cach[3]) == 0U);
+}
+
 static uint8_t
 hytera_checksum(const uint8_t bytes[8]) {
     uint8_t checksum = 0;
@@ -64,6 +187,8 @@ static uint32_t s_scan_activity_source = 0;
 static int s_scan_activity_is_private = 0;
 static int s_scan_activity_encrypted = 0;
 static int s_scan_activity_data_call = 0;
+static int s_tune_to_cc_calls = 0;
+static long int s_tune_to_cc_freq = 0;
 
 static void
 capture_scan_dmr_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target, uint32_t source,
@@ -82,6 +207,16 @@ static void
 clear_scan_hooks(void) {
     dsd_trunk_scan_hooks hooks = {0};
     dsd_trunk_scan_hooks_set(hooks);
+}
+
+static dsd_trunk_tune_result
+capture_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    (void)opts;
+    (void)state;
+    (void)ted_sps;
+    s_tune_to_cc_calls++;
+    s_tune_to_cc_freq = freq;
+    return DSD_TRUNK_TUNE_RESULT_OK;
 }
 
 static void
@@ -342,14 +477,435 @@ test_hytera_flco_scan_hook_uses_final_call_type(void) {
     assert(s_scan_activity_is_private == 1);
 }
 
+static void
+seed_td_lc_slot(dsd_opts* opts, dsd_state* state, unsigned int slot) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+
+    opts->floating_point = 1;
+    opts->audio_gain = 6.25f;
+    state->currentslot = slot;
+    if (slot == 0U) {
+        state->dmr_fid = 0x68;
+        state->dmr_so = 0x40;
+        state->lasttg = 1001;
+        state->lastsrc = 2002;
+        state->payload_algid = 0x22;
+        state->payload_keyid = 0x33;
+        state->payload_mi = 0x123456789AULL;
+        state->aout_gain = 1.0f;
+    } else {
+        state->dmr_fidR = 0x68;
+        state->dmr_soR = 0x40;
+        state->lasttgR = 3003;
+        state->lastsrcR = 4004;
+        state->payload_algidR = 0x44;
+        state->payload_keyidR = 0x55;
+        state->payload_miR = 0xABCDEF0123ULL;
+        state->aout_gainR = 2.0f;
+    }
+
+    state->dmr_alias_block_len[slot] = 7;
+    state->dmr_alias_char_size[slot] = 1;
+    state->dmr_alias_format[slot] = 2;
+    DSD_SNPRINTF(state->generic_talker_alias[slot], sizeof(state->generic_talker_alias[slot]), "alias");
+    DSD_MEMSET(state->dmr_pdu_sf[slot], 0x5A, sizeof(state->dmr_pdu_sf[slot]));
+    DSD_SNPRINTF(state->dmr_embedded_gps[slot], sizeof(state->dmr_embedded_gps[slot]), "gps");
+    DSD_SNPRINTF(state->dmr_lrrp_gps[slot], sizeof(state->dmr_lrrp_gps[slot]), "lrrp");
+}
+
+static void
+assert_td_lc_slot_reset(const dsd_state* state, unsigned int slot) {
+    if (slot == 0U) {
+        assert(state->dmr_fid == 0);
+        assert(state->dmr_so == 0);
+        assert(state->lasttg == 0);
+        assert(state->lastsrc == 0);
+        assert(state->payload_algid == 0);
+        assert(state->payload_keyid == 0);
+        assert(state->payload_mi == 0);
+        assert(state->aout_gain == 6.25f);
+    } else {
+        assert(state->dmr_fidR == 0);
+        assert(state->dmr_soR == 0);
+        assert(state->lasttgR == 0);
+        assert(state->lastsrcR == 0);
+        assert(state->payload_algidR == 0);
+        assert(state->payload_keyidR == 0);
+        assert(state->payload_miR == 0);
+        assert(state->aout_gainR == 6.25f);
+    }
+
+    assert(state->dmr_alias_block_len[slot] == 0);
+    assert(state->dmr_alias_char_size[slot] == 0);
+    assert(state->dmr_alias_format[slot] == 0);
+    assert(strcmp(state->generic_talker_alias[slot], "") == 0);
+    assert(state->dmr_pdu_sf[slot][0] == 0);
+    assert(strcmp(state->dmr_embedded_gps[slot], "") == 0);
+    assert(strcmp(state->dmr_lrrp_gps[slot], "") == 0);
+}
+
+static void
+test_td_lc_resets_slot_call_privacy_and_alias_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+
+    seed_td_lc_slot(&opts, &state, 0U);
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
+    assert(irr == 0);
+    assert_td_lc_slot_reset(&state, 0U);
+
+    irr = 0;
+    seed_td_lc_slot(&opts, &state, 1U);
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 3003U, 4004U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
+    assert(irr == 0);
+    assert_td_lc_slot_reset(&state, 1U);
+}
+
+static void
+test_capacity_plus_rest_channel_and_call_class_are_packed_fields(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    build_regular_flco(bits, 0x04U, 0x10U, 0x00U, 0x123456U, 0xA5BEEFU);
+    write_bits_u64(bits, 52U, 9U, 4U);
+    write_bits_u64(bits, 56U, 0xBEEFU, 16U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    assert(irr == 0);
+    assert(state.dmr_rest_channel == 9);
+    assert(state.lasttg == 0x123456U);
+    assert(state.lastsrc == 0xBEEFU);
+    assert(state.gi[0] == 0);
+    assert(strcmp(state.call_string[0], "   Group             ") == 0);
+
+    irr = 0;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 1;
+    build_regular_flco(bits, 0x07U, 0x10U, 0x00U, 0x654321U, 0xC0DEU);
+    write_bits_u64(bits, 52U, 3U, 4U);
+    write_bits_u64(bits, 56U, 0xC0DEU, 16U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    assert(irr == 0);
+    assert(state.dmr_rest_channel == 3);
+    assert(state.lasttgR == 0x654321U);
+    assert(state.lastsrcR == 0xC0DEU);
+    assert(state.gi[1] == 1);
+    assert(strcmp(state.call_string[1], " Private             ") == 0);
+}
+
+static void
+test_hytera_xpt_alert_records_free_lcn_and_targets(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    build_regular_flco(bits, 0x09U, 0x68U, 0x00U, 0U, 0U);
+    bits[1] = 1U;
+    write_bits_u64(bits, 16U, 4U, 4U);
+    write_bits_u64(bits, 24U, 6U, 4U);
+    write_bits_u64(bits, 28U, 2U, 4U);
+    write_bits_u64(bits, 32U, 0x00FEU, 16U);
+    write_bits_u64(bits, 56U, 0xCAFEU, 16U);
+
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+
+    assert(irr == 0);
+    assert(strcmp(state.dmr_branding, "  Hytera") == 0);
+    assert(strcmp(state.dmr_branding_sub, "XPT ") == 0);
+    assert(strcmp(state.dmr_site_parms, "Free LCN - 6 ") == 0);
+    assert(state.lasttg == 0);
+    assert(state.lastsrc == 0);
+}
+
+static void
+test_cach_single_fragment_throttle_and_reject_paths(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t slc[17];
+    uint8_t cach[25];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    build_slc17(slc, 0x1U, 0x8U, 0x0U);
+    build_cach_fragment(cach, 0U, slc);
+
+    assert(dmr_cach(&opts, &state, cach) == 0U);
+    assert(state.slco_sfrag_last[0] != 0);
+    time_t first_seen = state.slco_sfrag_last[0];
+
+    assert(dmr_cach(&opts, &state, cach) == 0U);
+    assert(state.slco_sfrag_last[0] == first_seen);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 1;
+    build_slc17(slc, 0x1U, 0x8U, 0x0U);
+    slc[0] ^= 1U;
+    slc[1] ^= 1U;
+    slc[2] ^= 1U;
+    build_cach_fragment(cach, 0U, slc);
+
+    assert(dmr_cach(&opts, &state, cach) == 1U);
+    assert(state.slco_sfrag_last[1] == 0);
+}
+
+static void
+test_cach_single_fragment_labels_cover_known_and_reserved_codes(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t slc[17];
+    uint8_t cach[25];
+    char out[2048];
+
+    const uint8_t cases[] = {0x0U, 0x2U, 0x3U, 0x8U, 0x9U, 0xAU, 0xEU};
+    const char* labels[] = {"SLCO NULL",       "SLC C_SYS_PARMS",           "SLC P_SYS_PARMS",
+                            "SLCO Hytera XPT", "SLCO Connect Plus Traffic", "SLCO Connect Plus Control",
+                            "OPC=0xE"};
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        DSD_MEMSET(&opts, 0, sizeof(opts));
+        DSD_MEMSET(&state, 0, sizeof(state));
+        state.currentslot = 0;
+        build_slc17(slc, cases[i], 0x8U, 0xDU);
+        build_cach_fragment(cach, 0U, slc);
+
+        dsd_test_capture_stderr cap;
+        assert(dsd_test_capture_stderr_begin(&cap, "dmr_cach_single_labels") == 0);
+        assert(dmr_cach(&opts, &state, cach) == 0U);
+        assert(dsd_test_capture_stderr_end(&cap) == 0);
+        assert(read_file_to_buffer(cap.path, out, sizeof(out)) == 0);
+        (void)remove(cap.path);
+        assert(strstr(out, labels[i]) != NULL);
+    }
+}
+
+static void
+test_cach_completed_fragment_crc_error_reports_voice_payload_context(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t slco[36];
+    uint8_t cach[4][25];
+    char out[2048];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(slco, 0, sizeof(slco));
+    opts.payload = 1;
+    state.currentslot = 0;
+    state.dmrburstL = 16;
+    write_bits_u64(slco, 0U, 0x1U, 4U);
+    write_bits_u64(slco, 4U, 0xCU, 4U);
+    write_bits_u64(slco, 8U, 0xFU, 4U);
+    build_completed_slco_cach_without_crc_fixup(cach, slco);
+
+    dsd_test_capture_stderr cap;
+    assert(dsd_test_capture_stderr_begin(&cap, "dmr_cach_crc_error") == 0);
+    assert(dmr_cach(&opts, &state, cach[0]) == 0U);
+    assert(dmr_cach(&opts, &state, cach[1]) == 0U);
+    assert(dmr_cach(&opts, &state, cach[2]) == 0U);
+    assert(dmr_cach(&opts, &state, cach[3]) == 0U);
+    assert(dsd_test_capture_stderr_end(&cap) == 0);
+    assert(read_file_to_buffer(cap.path, out, sizeof(out)) == 0);
+    (void)remove(cap.path);
+    assert(strstr(out, "SLCO CRC ERR") != NULL);
+}
+
+static void
+test_cach_fragment_counter_overflow_resets_fragments(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t slc[17];
+    uint8_t cach[25];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    build_slc17(slc, 0x0U, 0x0U, 0x0U);
+
+    build_cach_fragment(cach, 1U, slc);
+    assert(dmr_cach(&opts, &state, cach) == 0U);
+    assert(state.dmr_cach_counter == 0);
+
+    build_cach_fragment(cach, 3U, slc);
+    assert(dmr_cach(&opts, &state, cach) == 0U);
+    assert(state.dmr_cach_counter == 1);
+    assert(dmr_cach(&opts, &state, cach) == 0U);
+    assert(state.dmr_cach_counter == 2);
+    assert(dmr_cach(&opts, &state, cach) == 0U);
+    assert(state.dmr_cach_counter == 3);
+    assert(dmr_cach(&opts, &state, cach) == 1U);
+    assert(state.dmr_cach_counter == 0);
+    assert(state.dmr_cach_fragment[0][0] == 1U);
+}
+
+static void
+test_encrypted_flco_lockout_inserts_policy_and_event_history(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_tg_policy_lookup lookup;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+    init_event_history(&history[0], 0, 1);
+    init_event_history(&history[1], 0, 1);
+    state.event_history_s = history;
+    opts.trunk_enable = 1;
+    opts.trunk_tune_enc_calls = 0;
+    state.currentslot = 0;
+
+    build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1234U, 5678U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+
+    assert(irr == 0);
+    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_EXACT);
+    assert(strcmp(lookup.entry.mode, "B") == 0);
+    assert(strcmp(lookup.entry.name, "ENC LO") == 0);
+    assert(lookup.entry.source == DSD_TG_POLICY_SOURCE_ENC_LOCKOUT);
+    assert(strstr(history[0].Event_History_Items[0].internal_str, "Target: 1234; has been locked out;") != NULL);
+    dsd_state_ext_free_all(&state);
+}
+
+static void
+test_completed_slco_tier3_site_parameters_update_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t slco[36];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(slco, 0, sizeof(slco));
+    write_bits_u64(slco, 0U, 0x2U, 4U);
+    write_bits_u64(slco, 4U, 1U, 2U);
+    write_bits_u64(slco, 6U, 17U, 7U);
+    write_bits_u64(slco, 13U, 3U, 5U);
+    slco[18] = 1U;
+    write_bits_u64(slco, 19U, 0x12U, 9U);
+
+    run_completed_slco(&opts, &state, slco);
+
+    assert(strncmp(state.dmr_site_parms, "TIII Small:", 11U) == 0);
+    assert(strstr(state.dmr_site_parms, ";") != NULL);
+}
+
+static void
+test_completed_slco_connect_plus_and_xpt_update_site_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t slco[36];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(slco, 0, sizeof(slco));
+    write_bits_u64(slco, 0U, 0x9U, 4U);
+    write_bits_u64(slco, 8U, 0x12U, 8U);
+    write_bits_u64(slco, 16U, 0x34U, 8U);
+    run_completed_slco(&opts, &state, slco);
+    assert(strcmp(state.dmr_site_parms, "18-52 ") == 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(slco, 0, sizeof(slco));
+    write_bits_u64(slco, 0U, 0xAU, 4U);
+    write_bits_u64(slco, 8U, 0x56U, 8U);
+    write_bits_u64(slco, 16U, 0x78U, 8U);
+    state.last_vc_sync_time = time(NULL);
+    run_completed_slco(&opts, &state, slco);
+    assert(strcmp(state.dmr_site_parms, "86-120 ") == 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(slco, 0, sizeof(slco));
+    write_bits_u64(slco, 0U, 0x8U, 4U);
+    write_bits_u64(slco, 12U, 6U, 4U);
+    write_bits_u64(slco, 16U, 2U, 4U);
+    write_bits_u64(slco, 20U, 0x5AU, 8U);
+    run_completed_slco(&opts, &state, slco);
+    assert(strcmp(state.dmr_branding_sub, "XPT ") == 0);
+    assert(strcmp(state.dmr_site_parms, "Free LCN - 6 ") == 0);
+}
+
+static void
+test_completed_slco_capacity_plus_hold_returns_to_rest_channel(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t slco[36];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(slco, 0, sizeof(slco));
+    opts.trunk_enable = 1;
+    opts.trunk_is_tuned = 1;
+    opts.p25_is_tuned = 1;
+    state.tg_hold = 99U;
+    state.lasttg = 11;
+    state.lasttgR = 22;
+    state.dmrburstL = 16;
+    state.dmrburstR = 16;
+    state.trunk_vc_freq[0] = 852000000L;
+    state.trunk_vc_freq[1] = 852000000L;
+    state.p25_vc_freq[0] = 853000000L;
+    state.p25_vc_freq[1] = 853000000L;
+    state.trunk_chan_map[4] = 851250000L;
+    s_tune_to_cc_calls = 0;
+    s_tune_to_cc_freq = 0;
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
+        .tune_to_cc_result = capture_tune_to_cc,
+    });
+
+    write_bits_u64(slco, 0U, 0xFU, 4U);
+    write_bits_u64(slco, 16U, 4U, 4U);
+    write_bits_u64(slco, 20U, 2U, 2U);
+    write_bits_u64(slco, 22U, 5U, 3U);
+    run_completed_slco(&opts, &state, slco);
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+
+    assert(s_tune_to_cc_calls == 1);
+    assert(s_tune_to_cc_freq == 851250000L);
+    assert(opts.trunk_is_tuned == 0);
+    assert(opts.p25_is_tuned == 0);
+    assert(state.trunk_vc_freq[0] == 0);
+    assert(state.p25_vc_freq[0] == 0);
+}
+
 int
 main(void) {
+    InitAllFecFunction();
+
     test_flco_output_uses_real_newlines();
     test_hytera_basic_key_output_uses_segment_count();
     test_kirisun_flco_sets_late_entry_mode();
     test_hytera_enhanced_flco_uses_secondary_checksum();
     test_flco_scan_hook_reports_encrypted_service_option();
     test_hytera_flco_scan_hook_uses_final_call_type();
+    test_td_lc_resets_slot_call_privacy_and_alias_state();
+    test_capacity_plus_rest_channel_and_call_class_are_packed_fields();
+    test_hytera_xpt_alert_records_free_lcn_and_targets();
+    test_cach_single_fragment_throttle_and_reject_paths();
+    test_cach_single_fragment_labels_cover_known_and_reserved_codes();
+    test_cach_completed_fragment_crc_error_reports_voice_payload_context();
+    test_cach_fragment_counter_overflow_resets_fragments();
+    test_encrypted_flco_lockout_inserts_policy_and_event_history();
+    test_completed_slco_tier3_site_parameters_update_state();
+    test_completed_slco_connect_plus_and_xpt_update_site_state();
+    test_completed_slco_capacity_plus_hold_returns_to_rest_channel();
     printf("DMR FLCO privacy modes: OK\n");
     return 0;
 }
+
+// NOLINTEND(bugprone-implicit-widening-of-multiplication-result)

--- a/tests/protocol/dmr/test_dmr_grant_policy.c
+++ b/tests/protocol/dmr/test_dmr_grant_policy.c
@@ -543,6 +543,15 @@ main(void) {
     dmr_cspdu(opts, st, bits, bytes, 1U, 0U);
     rc |= expect_true("invalid zero grant channel does not tune", opts->trunk_is_tuned == 0);
 
+    return_to_cc(opts, st);
+    const uint16_t unmapped_lpcn = 0x0123;
+    DSD_MEMSET(st->active_channel[0], 0, sizeof(st->active_channel[0]));
+    build_grant(bits, bytes, 49U, unmapped_lpcn, 3325U, 4425U, 0U);
+    dmr_cspdu(opts, st, bits, bytes, 1U, 0U);
+    rc |= expect_true("unmapped logical grant records active channel",
+                      strstr(st->active_channel[0], "Active Group Ch: 0123 (TDMA S1) TG: 3325;") != NULL);
+    rc |= expect_true("unmapped logical grant does not tune", opts->trunk_is_tuned == 0 && st->trunk_vc_freq[0] == 0);
+
     st->trunk_chan_map[lpcn] = freq;
     st->tg_hold = 3330U;
     st->last_vc_sync_time = 123;

--- a/tests/protocol/dmr/test_dmr_grant_policy.c
+++ b/tests/protocol/dmr/test_dmr_grant_policy.c
@@ -16,12 +16,15 @@
 #include <dsd-neo/io/rigctl_client.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <dsd-neo/runtime/rigctl_query_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
+
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -31,6 +34,8 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #endif
+
+static int g_rotate_symbol_out_file_calls = 0;
 
 static int
 expect_true(const char* tag, int cond) {
@@ -87,6 +92,7 @@ void
 rotate_symbol_out_file(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_rotate_symbol_out_file_calls++;
 }
 
 bool
@@ -114,6 +120,8 @@ struct RtlSdrContext;
 struct RtlSdrContext* g_rtl_ctx = 0; // NOLINT(misc-use-internal-linkage)
 static int g_dmr_reset_blocks_calls = 0;
 static int g_result_tune_to_freq_calls = 0;
+static int g_fail_tune_to_freq_calls = 0;
+static int g_return_to_cc_result_calls = 0;
 
 int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -205,6 +213,16 @@ build_grant(uint8_t* bits, uint8_t* bytes, uint8_t opcode, uint16_t lpcn, uint32
 }
 
 static void
+build_absolute_grant(uint8_t* bits, uint8_t* bytes, uint8_t opcode, uint32_t target, uint32_t source, uint8_t slot,
+                     uint16_t mbc_lpcn, uint16_t rx_int, uint16_t rx_step) {
+    build_grant(bits, bytes, opcode, 0x0FFFU, target, source, slot);
+    write_bits_u32(bits, 112U, 0U, 4U);
+    write_bits_u32(bits, 118U, mbc_lpcn & 0x0FFFU, 12U);
+    write_bits_u32(bits, 153U, rx_int & 0x03FFU, 10U);
+    write_bits_u32(bits, 163U, rx_step & 0x1FFFU, 13U);
+}
+
+static void
 build_cap_plus_3e_single_group(uint8_t* bits, uint8_t* bytes, uint8_t rest_lsn, uint8_t active_lsn, uint8_t target) {
     DSD_MEMSET(bits, 0, 256);
     DSD_MEMSET(bytes, 0, 48);
@@ -218,6 +236,33 @@ build_cap_plus_3e_single_group(uint8_t* bits, uint8_t* bytes, uint8_t rest_lsn, 
     write_bits_u32(bits, 32U, target, 8U);
 }
 
+static void
+build_cap_plus_3e_single_private(uint8_t* bits, uint8_t* bytes, uint8_t rest_lsn, uint8_t active_lsn, uint16_t target) {
+    DSD_MEMSET(bits, 0, 256);
+    DSD_MEMSET(bytes, 0, 48);
+    bytes[0] = 0x3EU;
+    bytes[1] = 0x10U;
+
+    write_bits_u32(bits, 16U, 3U, 2U); // single-block Cap+ channel status
+    bits[18] = 0U;                     // TS1 status bank
+    write_bits_u32(bits, 20U, rest_lsn & 0x0FU, 4U);
+    write_bits_u32(bits, 40U, 0x80U >> ((active_lsn - 1U) & 7U), 8U); // private/data bank flag
+    bits[48U + (active_lsn - 1U)] = 1U;
+    write_bits_u32(bits, 56U, target, 16U);
+}
+
+static void
+build_cap_plus_3e_single_idle(uint8_t* bits, uint8_t* bytes, uint8_t rest_lsn) {
+    DSD_MEMSET(bits, 0, 256);
+    DSD_MEMSET(bytes, 0, 48);
+    bytes[0] = 0x3EU;
+    bytes[1] = 0x10U;
+
+    write_bits_u32(bits, 16U, 3U, 2U); // single-block Cap+ channel status
+    bits[18] = 0U;                     // TS1 status bank
+    write_bits_u32(bits, 20U, rest_lsn & 0x0FU, 4U);
+}
+
 static dsd_trunk_tune_result
 cap_plus_result_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     (void)ted_sps;
@@ -229,6 +274,35 @@ cap_plus_result_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, in
     return DSD_TRUNK_TUNE_RESULT_OK;
 }
 
+static dsd_trunk_tune_result
+fail_result_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    (void)opts;
+    (void)state;
+    (void)freq;
+    (void)ted_sps;
+    g_fail_tune_to_freq_calls++;
+    return DSD_TRUNK_TUNE_RESULT_FAILED;
+}
+
+static dsd_trunk_tune_result
+result_return_to_cc(dsd_opts* opts, dsd_state* state) {
+    g_return_to_cc_result_calls++;
+    if (opts) {
+        opts->trunk_is_tuned = 0;
+    }
+    if (state) {
+        state->trunk_vc_freq[0] = 0;
+        state->trunk_vc_freq[1] = 0;
+    }
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static long int
+fake_get_current_freq_hz(const dsd_opts* opts) {
+    (void)opts;
+    return 859987500L;
+}
+
 static int
 seed_exact(dsd_state* st, uint32_t id, const char* mode, const char* name) {
     dsd_tg_policy_entry row;
@@ -236,6 +310,162 @@ seed_exact(dsd_state* st, uint32_t id, const char* mode, const char* name) {
         return -1;
     }
     return dsd_tg_policy_upsert_exact(st, &row, DSD_TG_POLICY_UPSERT_REPLACE_FIRST);
+}
+
+static void
+build_con_plus_voice(uint8_t* bits, uint8_t* bytes, uint32_t source, uint32_t target, uint8_t lcn, uint8_t slot,
+                     uint8_t opt) {
+    DSD_MEMSET(bits, 0, 256);
+    DSD_MEMSET(bytes, 0, 48);
+    bytes[0] = 0x03U;
+    bytes[1] = 0x06U;
+    bytes[2] = (uint8_t)((source >> 16U) & 0xFFU);
+    bytes[3] = (uint8_t)((source >> 8U) & 0xFFU);
+    bytes[4] = (uint8_t)(source & 0xFFU);
+    bytes[5] = (uint8_t)((target >> 16U) & 0xFFU);
+    bytes[6] = (uint8_t)((target >> 8U) & 0xFFU);
+    bytes[7] = (uint8_t)(target & 0xFFU);
+    bytes[8] = (uint8_t)(((lcn & 0x0FU) << 4U) | ((slot & 1U) << 3U));
+    bytes[9] = opt;
+}
+
+static void
+build_con_plus_data(uint8_t* bits, uint8_t* bytes, uint32_t target, uint8_t lcn, uint8_t slot) {
+    DSD_MEMSET(bits, 0, 256);
+    DSD_MEMSET(bytes, 0, 48);
+    bytes[0] = 0x06U;
+    bytes[1] = 0x06U;
+    bytes[2] = (uint8_t)((target >> 16U) & 0xFFU);
+    bytes[3] = (uint8_t)((target >> 8U) & 0xFFU);
+    bytes[4] = (uint8_t)(target & 0xFFU);
+    bytes[5] = (uint8_t)(((lcn & 0x0FU) << 4U) | ((slot & 1U) << 3U));
+}
+
+static void
+build_con_plus_termination(uint8_t* bits, uint8_t* bytes, uint32_t target) {
+    DSD_MEMSET(bits, 0, 256);
+    DSD_MEMSET(bytes, 0, 48);
+    bytes[0] = 0x0CU;
+    bytes[1] = 0x06U;
+    bytes[2] = (uint8_t)((target >> 16U) & 0xFFU);
+    bytes[3] = (uint8_t)((target >> 8U) & 0xFFU);
+    bytes[4] = (uint8_t)(target & 0xFFU);
+}
+
+static void
+build_pf0(uint8_t* bits, uint8_t* bytes, uint8_t opcode, uint8_t fid) {
+    DSD_MEMSET(bits, 0, 256);
+    DSD_MEMSET(bytes, 0, 48);
+    bytes[0] = (uint8_t)(opcode & 0x3FU);
+    bytes[1] = fid;
+}
+
+static void
+build_preamble(uint8_t* bits, uint8_t* bytes, uint8_t content, uint8_t gi, uint8_t blocks, uint32_t target,
+               uint32_t source) {
+    build_pf0(bits, bytes, 61U, 0U);
+    bits[16] = (uint8_t)(content & 1U);
+    bits[17] = (uint8_t)(gi & 1U);
+    write_bits_u32(bits, 24U, blocks, 8U);
+    write_bits_u32(bits, 32U, target & 0x00FFFFFFU, 24U);
+    write_bits_u32(bits, 56U, source & 0x00FFFFFFU, 24U);
+}
+
+static void
+build_p_protect(uint8_t* bits, uint8_t* bytes, uint8_t kind, uint8_t gi, uint32_t target, uint32_t source) {
+    build_pf0(bits, bytes, 47U, 0U);
+    write_bits_u32(bits, 28U, kind & 0x07U, 3U);
+    bits[31] = (uint8_t)(gi & 1U);
+    write_bits_u32(bits, 32U, target & 0x00FFFFFFU, 24U);
+    write_bits_u32(bits, 56U, source & 0x00FFFFFFU, 24U);
+}
+
+static void
+build_c_ahoy(uint8_t* bits, uint8_t* bytes, uint8_t gi, uint8_t svc_kind, uint32_t target, uint32_t source) {
+    build_pf0(bits, bytes, 28U, 0U);
+    bits[25] = (uint8_t)(gi & 1U);
+    write_bits_u32(bits, 28U, svc_kind & 0x0FU, 4U);
+    write_bits_u32(bits, 32U, target & 0x00FFFFFFU, 24U);
+    write_bits_u32(bits, 56U, source & 0x00FFFFFFU, 24U);
+}
+
+static void
+build_aloha(uint8_t* bits, uint8_t* bytes, uint8_t fid) {
+    build_pf0(bits, bytes, 25U, fid);
+}
+
+static void
+build_c_move(uint8_t* bits, uint8_t* bytes, uint16_t lpcn, uint8_t slot, uint32_t target, uint32_t source) {
+    build_pf0(bits, bytes, 57U, 0U);
+    write_bits_u32(bits, 16U, lpcn & 0x0FFFU, 12U);
+    bits[28] = (uint8_t)(slot & 1U);
+    write_bits_u32(bits, 32U, target & 0x00FFFFFFU, 24U);
+    write_bits_u32(bits, 56U, source & 0x00FFFFFFU, 24U);
+}
+
+static void
+build_p_clear(uint8_t* bits, uint8_t* bytes, uint8_t fid) {
+    build_pf0(bits, bytes, 46U, fid);
+}
+
+static void
+build_c_bcast_ann_wd_tscc(uint8_t* bits, uint8_t* bytes, uint16_t ch1, uint16_t ch2, uint8_t ch1_flag,
+                          uint8_t ch2_flag) {
+    build_pf0(bits, bytes, 40U, 0U);
+    write_bits_u32(bits, 16U, 0U, 5U);
+    bits[33] = (uint8_t)(ch1_flag & 1U);
+    bits[34] = (uint8_t)(ch2_flag & 1U);
+    write_bits_u32(bits, 56U, ch1 & 0x0FFFU, 12U);
+    write_bits_u32(bits, 68U, ch2 & 0x0FFFU, 12U);
+}
+
+static void
+build_c_bcast_chan_freq(uint8_t* bits, uint8_t* bytes, uint16_t channel, uint16_t rx_int, uint16_t rx_step) {
+    build_pf0(bits, bytes, 40U, 0U);
+    write_bits_u32(bits, 16U, 5U, 5U);
+    write_bits_u32(bits, 68U, channel & 0x0FFFU, 12U);
+    write_bits_u32(bits, 112U, 0U, 4U);
+    write_bits_u32(bits, 118U, channel & 0x0FFFU, 12U);
+    write_bits_u32(bits, 130U, rx_int & 0x03FFU, 10U);
+    write_bits_u32(bits, 140U, rx_step & 0x1FFFU, 13U);
+    write_bits_u32(bits, 153U, rx_int & 0x03FFU, 10U);
+    write_bits_u32(bits, 163U, rx_step & 0x1FFFU, 13U);
+}
+
+static void
+build_c_bcast_adjacent_apcn(uint8_t* bits, uint8_t* bytes, uint16_t channel, uint16_t rx_int, uint16_t rx_step) {
+    build_pf0(bits, bytes, 40U, 0U);
+    write_bits_u32(bits, 16U, 6U, 5U);
+    bits[56] = 1U;
+    write_bits_u32(bits, 68U, 0x0FFFU, 12U);
+    write_bits_u32(bits, 112U, 0U, 4U);
+    write_bits_u32(bits, 118U, channel & 0x0FFFU, 12U);
+    write_bits_u32(bits, 130U, rx_int & 0x03FFU, 10U);
+    write_bits_u32(bits, 140U, rx_step & 0x1FFFU, 13U);
+    write_bits_u32(bits, 153U, rx_int & 0x03FFU, 10U);
+    write_bits_u32(bits, 163U, rx_step & 0x1FFFU, 13U);
+}
+
+static void
+build_xpt_site_status(uint8_t* bits, uint8_t* bytes, uint8_t seq, uint8_t free_lcn, const uint8_t status[6],
+                      const uint8_t tg[6]) {
+    build_pf0(bits, bytes, 0x0AU, 0x68U);
+    write_bits_u32(bits, 0U, seq & 0x03U, 2U);
+    write_bits_u32(bits, 16U, free_lcn & 0x0FU, 4U);
+    for (size_t i = 0; i < 6U; i++) {
+        write_bits_u32(bits, 20U + (i * 2U), status[i] & 0x03U, 2U);
+        write_bits_u32(bits, 32U + (i * 8U), tg[i], 8U);
+    }
+}
+
+static void
+build_xpt_adjacent(uint8_t* bits, uint8_t* bytes, uint8_t seq, const uint8_t site_id[4], const uint8_t free_lcn[4]) {
+    build_pf0(bits, bytes, 0x0BU, 0x68U);
+    write_bits_u32(bits, 0U, seq & 0x03U, 2U);
+    for (size_t i = 0; i < 4U; i++) {
+        write_bits_u32(bits, 16U + (i * 16U), site_id[i] & 0x1FU, 5U);
+        write_bits_u32(bits, 24U + (i * 16U), free_lcn[i] & 0x0FU, 4U);
+    }
 }
 
 int
@@ -292,6 +522,49 @@ main(void) {
     dmr_cspdu(opts, st, bits, bytes, 1U, 0U);
     rc |= expect_true("data grant enabled for tuning is normalized to group", dmr_sm_get_ctx()->vc_tg == 1300);
 
+    return_to_cc(opts, st);
+    build_absolute_grant(bits, bytes, 49U, 3300U, 4400U, 0U, 88U, 452U, 100U);
+    dmr_cspdu(opts, st, bits, bytes, 1U, 0U);
+    rc |= expect_true("absolute grant learns mbc lpcn", st->trunk_chan_map[88] == 452012500L);
+    rc |= expect_true("absolute grant marks unconfirmed trust while off cc", st->dmr_lcn_trust[88] == 2U);
+    rc |= expect_true("absolute grant active channel uses mbc lpcn",
+                      strstr(st->active_channel[0], "Active Group Ch: 0058 (TDMA S1) TG: 3300;") != NULL);
+    rc |= expect_true("absolute grant dispatches learned frequency",
+                      opts->trunk_is_tuned == 1 && st->trunk_vc_freq[0] == 452012500L);
+
+    return_to_cc(opts, st);
+    build_absolute_grant(bits, bytes, 49U, 3310U, 4410U, 0U, 89U, 453U, 200U);
+    write_bits_u32(bits, 112U, 3U, 4U);
+    dmr_cspdu(opts, st, bits, bytes, 1U, 0U);
+    rc |= expect_true("unknown absolute cdef does not learn lpcn", st->trunk_chan_map[89] == 0);
+    rc |= expect_true("unknown absolute cdef does not tune", opts->trunk_is_tuned == 0);
+
+    build_grant(bits, bytes, 49U, 0U, 3320U, 4420U, 0U);
+    dmr_cspdu(opts, st, bits, bytes, 1U, 0U);
+    rc |= expect_true("invalid zero grant channel does not tune", opts->trunk_is_tuned == 0);
+
+    st->trunk_chan_map[lpcn] = freq;
+    st->tg_hold = 3330U;
+    st->last_vc_sync_time = 123;
+    st->last_vc_sync_time_m = 456.0;
+    opts->trunk_enable = 0;
+    opts->trunk_is_tuned = 0;
+    build_grant(bits, bytes, 49U, lpcn, 3330U, 4430U, 0U);
+    dmr_cspdu(opts, st, bits, bytes, 1U, 0U);
+    rc |= expect_true("tg hold grant clears wall-clock vc sync", st->last_vc_sync_time == 0);
+    rc |= expect_true("tg hold grant clears monotonic vc sync", st->last_vc_sync_time_m == 0.0);
+    rc |= expect_true("trunk disabled hold grant records vc frequency", st->trunk_vc_freq[0] == freq);
+    rc |= expect_true("trunk disabled hold grant does not tune", opts->trunk_is_tuned == 0);
+    st->tg_hold = 0;
+
+    opts->trunk_enable = 0;
+    opts->trunk_is_tuned = 0;
+    build_grant(bits, bytes, 49U, lpcn, 3340U, 4440U, 1U);
+    dmr_cspdu(opts, st, bits, bytes, 1U, 0U);
+    rc |= expect_true("trunk disabled grant still records vc frequency", st->trunk_vc_freq[0] == freq);
+    rc |= expect_true("trunk disabled grant does not tune", opts->trunk_is_tuned == 0);
+    opts->trunk_enable = 1;
+
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
         .tune_to_freq_result = cap_plus_result_tune_to_freq,
     });
@@ -311,7 +584,430 @@ main(void) {
     rc |= expect_true("cap+ 3e tune hook called", g_result_tune_to_freq_calls == 1);
     rc |= expect_true("cap+ 3e tune updates rtl center", cap_opts.rtlsdr_center_freq == cap_grant_freq);
     rc |= expect_true("cap+ 3e reset uses pre-tune center", g_dmr_reset_blocks_calls == 1);
+
+    init_env(&cap_opts, &cap_st);
+    cap_opts.rtlsdr_center_freq = cap_old_freq;
+    cap_st.trunk_cc_freq = cap_old_freq;
+    cap_st.trunk_chan_map[3] = 853250000L;
+    cap_st.last_vc_sync_time = time(NULL) - 10;
+    g_dmr_reset_blocks_calls = 0;
+    g_result_tune_to_freq_calls = 0;
+    build_cap_plus_3e_single_private(bits, bytes, 1U, 3U, 4242U);
+    dmr_cspdu(&cap_opts, &cap_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("cap+ 3e private tune hook called", g_result_tune_to_freq_calls == 1);
+    rc |= expect_true("cap+ 3e private tune updates VC", cap_st.trunk_vc_freq[0] == 853250000L);
+    rc |= expect_true("cap+ 3e private active channel", strstr(cap_st.active_channel[3], "LSN:3 PC:4242;") != NULL);
+    rc |= expect_true("cap+ 3e private clears block counter", cap_st.cap_plus_block_num[0] == 0);
+
+    init_env(&cap_opts, &cap_st);
+    cap_opts.trunk_tune_private_calls = 0;
+    cap_st.trunk_chan_map[3] = 853250000L;
+    cap_st.last_vc_sync_time = time(NULL) - 10;
+    g_result_tune_to_freq_calls = 0;
+    build_cap_plus_3e_single_private(bits, bytes, 1U, 3U, 4242U);
+    dmr_cspdu(&cap_opts, &cap_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("cap+ 3e private disabled suppresses tune",
+                      g_result_tune_to_freq_calls == 0 && cap_opts.trunk_is_tuned == 0);
+    rc |= expect_true("cap+ 3e private disabled omits active PC", cap_st.active_channel[3][0] == '\0');
+
+    init_env(&cap_opts, &cap_st);
+    cap_st.trunk_cc_freq = 851000000L;
+    cap_st.trunk_chan_map[4] = 852000000L;
+    cap_st.last_vc_sync_time = time(NULL) - 10;
+    g_result_tune_to_freq_calls = 0;
+    build_cap_plus_3e_single_idle(bits, bytes, 4U);
+    dmr_cspdu(&cap_opts, &cap_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("cap+ 3e idle rest channel becomes CC", cap_st.trunk_cc_freq == 852000000L);
+    rc |= expect_true("cap+ 3e idle rest channel does not tune VC", g_result_tune_to_freq_calls == 0);
+    rc |= expect_true("cap+ 3e idle rest channel still brands", strcmp(cap_st.dmr_branding_sub, "Cap+ ") == 0);
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+
+    static dsd_opts con_opts;
+    static dsd_state con_st;
+    init_env(&con_opts, &con_st);
+    con_opts.trunk_tune_data_calls = 1;
+    con_st.trunk_chan_map[5] = 855125000L;
+    con_st.last_vc_sync_time = time(NULL) - 10;
+    build_con_plus_voice(bits, bytes, 0x112233U, 0x445566U, 5U, 1U, 2U);
+    dmr_cspdu(&con_opts, &con_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("con+ voice group tune", con_opts.trunk_is_tuned == 1 && con_st.trunk_vc_freq[0] == 855125000L);
+    rc |= expect_true("con+ voice branding", strcmp(con_st.dmr_branding, "Motorola") == 0);
+    rc |= expect_true("con+ voice sub-branding", strcmp(con_st.dmr_branding_sub, "Con+ ") == 0);
+    rc |= expect_true("con+ voice active slot",
+                      strstr(con_st.active_channel[1], "Active Ch: 0005 (TDMA S2) TG: 4478310;") != NULL);
+    rc |= expect_true("con+ voice state-machine tg", dmr_sm_get_ctx()->vc_tg == 0x445566);
+
+    init_env(&con_opts, &con_st);
+    con_opts.trunk_tune_private_calls = 1;
+    con_st.trunk_chan_map[6] = 855250000L;
+    con_st.last_vc_sync_time = time(NULL) - 10;
+    build_con_plus_voice(bits, bytes, 0x001122U, 0x003344U, 6U, 0U, 3U);
+    dmr_cspdu(&con_opts, &con_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("con+ private voice tunes individual grant",
+                      con_opts.trunk_is_tuned == 1 && con_st.trunk_vc_freq[0] == 855250000L);
+    rc |= expect_true("con+ private voice state-machine target/source",
+                      dmr_sm_get_ctx()->vc_tg == 0 && dmr_sm_get_ctx()->vc_src == 0x001122);
+    rc |= expect_true("con+ private voice marks flavor", con_st.is_con_plus == 1);
+    rc |= expect_true("con+ private voice active slot",
+                      strstr(con_st.active_channel[0], "Active Ch: 0006 (TDMA S1) TG: 13124;") != NULL);
+
+    init_env(&con_opts, &con_st);
+    con_opts.trunk_tune_group_calls = 0;
+    con_st.trunk_chan_map[5] = 855125000L;
+    con_st.last_vc_sync_time = time(NULL) - 10;
+    build_con_plus_voice(bits, bytes, 0x112233U, 0x445566U, 5U, 1U, 2U);
+    dmr_cspdu(&con_opts, &con_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("con+ group disabled keeps grant visible",
+                      strstr(con_st.active_channel[1], "Active Ch: 0005 (TDMA S2) TG: 4478310;") != NULL);
+    rc |= expect_true("con+ group disabled suppresses tune",
+                      con_opts.trunk_is_tuned == 0 && dmr_sm_get_ctx()->vc_tg == 0);
+    rc |= expect_true("con+ group disabled still brands", strcmp(con_st.dmr_branding_sub, "Con+ ") == 0);
+
+    init_env(&con_opts, &con_st);
+    con_opts.trunk_tune_data_calls = 1;
+    con_st.trunk_chan_map[4] = 856250000L;
+    con_st.last_vc_sync_time = time(NULL) - 10;
+    g_dmr_reset_blocks_calls = 0;
+    g_result_tune_to_freq_calls = 0;
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
+        .tune_to_freq_result = cap_plus_result_tune_to_freq,
+    });
+    build_con_plus_data(bits, bytes, 0x00CAFEU, 4U, 0U);
+    dmr_cspdu(&con_opts, &con_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("con+ data tune hook called", g_result_tune_to_freq_calls == 1);
+    rc |= expect_true("con+ data tune updates VC", con_st.trunk_vc_freq[0] == 856250000L);
+    rc |= expect_true("con+ data reset blocks", g_dmr_reset_blocks_calls == 1);
+    rc |= expect_true("con+ data active slot",
+                      strstr(con_st.active_channel[0], "Active Ch: 0004 (TDMA S1) TG: 51966;") != NULL);
+    rc |= expect_true("con+ data marks flavor", con_st.is_con_plus == 1);
+
+    init_env(&con_opts, &con_st);
+    con_opts.trunk_tune_data_calls = 0;
+    DSD_SNPRINTF(con_st.active_channel[0], sizeof(con_st.active_channel[0]), "pre-data-channel");
+    build_con_plus_data(bits, bytes, 0x00CAFEU, 4U, 0U);
+    dmr_cspdu(&con_opts, &con_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("con+ data disabled suppresses tune", con_opts.trunk_is_tuned == 0 && con_st.is_con_plus == 0);
+    rc |= expect_true("con+ data disabled still brands", strcmp(con_st.dmr_branding_sub, "Con+ ") == 0);
+
+    init_env(&con_opts, &con_st);
+    con_opts.trunk_tune_data_calls = 1;
+    con_opts.trunk_use_allow_list = 1;
+    con_opts.verbose = 1;
+    con_st.trunk_chan_map[4] = 856250000L;
+    con_st.last_vc_sync_time = time(NULL) - 10;
+    build_con_plus_data(bits, bytes, 0x00CAFEU, 4U, 0U);
+    dmr_cspdu(&con_opts, &con_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("con+ data policy block keeps grant visible",
+                      strstr(con_st.active_channel[0], "Active Ch: 0004 (TDMA S1) TG: 51966;") != NULL);
+    rc |=
+        expect_true("con+ data policy block suppresses tune", con_opts.trunk_is_tuned == 0 && con_st.is_con_plus == 0);
+
+    init_env(&con_opts, &con_st);
+    con_opts.trunk_tune_data_calls = 1;
+    con_st.trunk_chan_map[4] = 856250000L;
+    con_st.last_active_time = time(NULL);
+    con_st.last_vc_sync_time = time(NULL) - 10;
+    DSD_SNPRINTF(con_st.active_channel[0], sizeof(con_st.active_channel[0]), "previous active");
+    g_fail_tune_to_freq_calls = 0;
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
+        .tune_to_freq_result = fail_result_tune_to_freq,
+    });
+    build_con_plus_data(bits, bytes, 0x00CAFEU, 4U, 0U);
+    dmr_cspdu(&con_opts, &con_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("con+ data failed tune hook called", g_fail_tune_to_freq_calls == 1);
+    rc |= expect_true("con+ data rollback active", strcmp(con_st.active_channel[0], "previous active") == 0);
+    rc |= expect_true("con+ data failed tune does not mark flavor", con_st.is_con_plus == 0);
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+
+    init_env(&con_opts, &con_st);
+    con_st.trunk_chan_map[5] = 855125000L;
+    con_st.last_vc_sync_time = time(NULL) - 10;
+    build_con_plus_voice(bits, bytes, 0x112233U, 0x445566U, 5U, 1U, 2U);
+    dmr_cspdu(&con_opts, &con_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("con+ termination setup tunes vc",
+                      con_opts.trunk_is_tuned == 1 && dmr_sm_get_ctx()->vc_tg == 0x445566);
+    dmr_sm_emit_voice_sync(&con_opts, &con_st, 0);
+    dmr_sm_emit_voice_sync(&con_opts, &con_st, 1);
+    rc |= expect_true("con+ termination setup marks voice active",
+                      dmr_sm_get_ctx()->slots[0].voice_active == 1 && dmr_sm_get_ctx()->slots[1].voice_active == 1);
+    build_con_plus_termination(bits, bytes, 0x445566U);
+    dmr_cspdu(&con_opts, &con_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("con+ termination clears voice activity",
+                      dmr_sm_get_ctx()->slots[0].voice_active == 0 && dmr_sm_get_ctx()->slots[1].voice_active == 0);
+    rc |= expect_true("con+ termination leaves tuned grant pending", con_opts.trunk_is_tuned == 1
+                                                                         && con_st.p25_sm_release_count == 0
+                                                                         && dmr_sm_get_ctx()->vc_tg == 0x445566);
+    rc |= expect_true("con+ termination keeps branding", strcmp(con_st.dmr_branding_sub, "Con+ ") == 0);
+
+    static dsd_opts pf0_opts;
+    static dsd_state pf0_st;
+    init_env(&pf0_opts, &pf0_st);
+    pf0_st.currentslot = 0;
+    build_preamble(bits, bytes, 1U, 1U, 4U, 0x00ABCDU, 0x001234U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("preamble marks slot 1 data burst", pf0_st.dmrburstL == 6);
+    rc |= expect_true("preamble leaves other burst alone", pf0_st.dmrburstR == 0);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_st.currentslot = 1;
+    build_preamble(bits, bytes, 0U, 0U, 2U, 0x00BCDEU, 0x002345U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("preamble marks slot 2 data burst", pf0_st.dmrburstR == 6);
+    rc |= expect_true("preamble slot 2 leaves slot 1 burst alone", pf0_st.dmrburstL == 0);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_st.currentslot = 0;
+    build_p_protect(bits, bytes, 0U, 1U, 0x003333U, 0x004444U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("group protect marks slot 1 voice burst", pf0_st.dmrburstL == 1);
+    rc |= expect_true("group protect maps GI to group", pf0_st.gi[0] == 0);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_st.currentslot = 1;
+    build_p_protect(bits, bytes, 1U, 0U, 0x005555U, 0x006666U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("private protect marks slot 2 voice burst", pf0_st.dmrburstR == 1);
+    rc |= expect_true("private protect maps GI to private", pf0_st.gi[1] == 1);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_opts.trunk_is_tuned = 1;
+    pf0_st.last_vc_sync_time = 0;
+    pf0_st.last_vc_sync_time_m = 0.0;
+    build_p_protect(bits, bytes, 2U, 1U, 0x007777U, 0x008888U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("hangtime protect refreshes wall-clock VC sync", pf0_st.last_vc_sync_time > 0);
+    rc |= expect_true("hangtime protect refreshes monotonic VC sync", pf0_st.last_vc_sync_time_m > 0.0);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_st.currentslot = 1;
+    pf0_st.gi[1] = 9;
+    build_c_ahoy(bits, bytes, 1U, 4U, 0x009999U, 0x000777U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("c_ahoy group maps slot GI to group", pf0_st.gi[1] == 0);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_st.currentslot = 0;
+    pf0_st.gi[0] = 9;
+    build_c_ahoy(bits, bytes, 0U, 2U, 0x008888U, 0x000666U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("c_ahoy private maps slot GI to private", pf0_st.gi[0] == 1);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_opts.use_rigctl = 1;
+    pf0_opts.trunk_is_tuned = 0;
+    pf0_st.trunk_cc_freq = 0;
+    g_rotate_symbol_out_file_calls = 0;
+    dsd_rigctl_query_hooks_set((dsd_rigctl_query_hooks){
+        .get_current_freq_hz = fake_get_current_freq_hz,
+    });
+    build_aloha(bits, bytes, 0U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    dsd_rigctl_query_hooks_set((dsd_rigctl_query_hooks){0});
+    rc |= expect_true("aloha rigctl learns control-channel frequency", pf0_st.trunk_cc_freq == 859987500L);
+    rc |= expect_true("aloha rigctl rotates output file on cc", g_rotate_symbol_out_file_calls == 1);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_opts.audio_in_type = AUDIO_IN_RTL;
+    pf0_opts.rtlsdr_center_freq = 460012500L;
+    pf0_opts.trunk_is_tuned = 0;
+    pf0_st.trunk_cc_freq = 0;
+    g_rotate_symbol_out_file_calls = 0;
+    build_aloha(bits, bytes, 0U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("aloha rtl learns control-channel frequency", pf0_st.trunk_cc_freq == 460012500L);
+    rc |= expect_true("aloha rtl rotates output file on cc", g_rotate_symbol_out_file_calls == 1);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_opts.trunk_enable = 0;
+    pf0_st.gi[0] = 0;
+    build_c_move(bits, bytes, 12U, 0U, 0x001234U, 0x005678U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("c_move slot 1 target", pf0_st.lasttg == 0x001234U);
+    rc |= expect_true("c_move slot 1 source", pf0_st.lastsrc == 0x005678U);
+    rc |= expect_true("c_move slot 1 call string", strcmp(pf0_st.call_string[0], "   Group  Move      ") == 0);
+    rc |= expect_true("c_move slot 1 debounces opposite slot", pf0_st.dmrburstL == 16 && pf0_st.dmrburstR == 9);
+    rc |= expect_true("c_move slot 1 active channel",
+                      strstr(pf0_st.active_channel[0], "Active Ch: 000C (TDMA S1) TG: 4660;") != NULL);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_opts.trunk_enable = 0;
+    pf0_st.gi[1] = 1;
+    build_c_move(bits, bytes, 13U, 1U, 0x002345U, 0x006789U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("c_move slot 2 target", pf0_st.lasttgR == 0x002345U);
+    rc |= expect_true("c_move slot 2 source", pf0_st.lastsrcR == 0x006789U);
+    rc |= expect_true("c_move slot 2 call string", strcmp(pf0_st.call_string[1], " Private  Move      ") == 0);
+    rc |= expect_true("c_move slot 2 debounces opposite slot", pf0_st.dmrburstR == 16 && pf0_st.dmrburstL == 9);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_opts.trunk_enable = 0;
+    pf0_st.currentslot = 0;
+    pf0_st.dmrburstL = 6;
+    pf0_st.dmrburstR = 6;
+    DSD_SNPRINTF(pf0_st.call_string[0], sizeof(pf0_st.call_string[0]), "slot one active");
+    build_p_clear(bits, bytes, 0U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("p_clear trunk disabled leaves slot 1 burst", pf0_st.dmrburstL == 6);
+    rc |= expect_true("p_clear trunk disabled leaves opposite burst", pf0_st.dmrburstR == 6);
+    rc |= expect_true("p_clear trunk disabled leaves slot 1 call string",
+                      strcmp(pf0_st.call_string[0], "slot one active") == 0);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_opts.trunk_is_tuned = 1;
+    pf0_st.currentslot = 1;
+    pf0_st.dmrburstL = 6;
+    pf0_st.dmrburstR = 16;
+    DSD_SNPRINTF(pf0_st.call_string[1], sizeof(pf0_st.call_string[1]), "slot two data");
+    DSD_SNPRINTF(pf0_st.active_channel[1], sizeof(pf0_st.active_channel[1]), "slot two data channel");
+    build_p_clear(bits, bytes, 0U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("p_clear data clears slot 2 burst state", pf0_st.dmrburstL == 9 && pf0_st.dmrburstR == 9);
+    rc |= expect_true("p_clear data clears slot 2 call string", pf0_st.call_string[1][0] == '\0');
+    rc |= expect_true("p_clear data clears slot 2 active channel", pf0_st.active_channel[1][0] == '\0');
+    rc |= expect_true("p_clear data does not force release", pf0_st.trunk_sm_force_release == 0);
+    rc |= expect_true("p_clear data does not return to cc", pf0_st.p25_sm_release_count == 0);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_st.trunk_chan_map[lpcn] = freq;
+    pf0_st.last_vc_sync_time = time(NULL) - 10;
+    build_grant(bits, bytes, 49U, lpcn, 5500U, 6500U, 1U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("p_clear hold setup tunes vc", pf0_opts.trunk_is_tuned == 1 && dmr_sm_get_ctx()->vc_tg == 5500);
+    pf0_st.currentslot = 1;
+    pf0_st.lasttgR = 5500;
+    pf0_st.tg_hold = 5500U;
+    pf0_st.dmrburstL = 16;
+    pf0_st.dmrburstR = 16;
+    DSD_SNPRINTF(pf0_st.call_string[1], sizeof(pf0_st.call_string[1]), "slot two voice");
+    DSD_SNPRINTF(pf0_st.active_channel[1], sizeof(pf0_st.active_channel[1]), "slot two voice channel");
+    g_return_to_cc_result_calls = 0;
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
+        .return_to_cc_result = result_return_to_cc,
+    });
+    build_p_clear(bits, bytes, 0U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    rc |= expect_true("p_clear hold forced return hook called", g_return_to_cc_result_calls == 1);
+    rc |= expect_true("p_clear hold clears force latch", pf0_st.trunk_sm_force_release == 0);
+    rc |= expect_true("p_clear hold returns to cc", pf0_opts.trunk_is_tuned == 0 && pf0_st.p25_sm_release_count == 1);
+    rc |= expect_true("p_clear hold clears slot 2 labels",
+                      pf0_st.call_string[1][0] == '\0' && pf0_st.active_channel[1][0] == '\0');
+    pf0_st.tg_hold = 0;
+
+    init_env(&pf0_opts, &pf0_st);
+    build_c_bcast_chan_freq(bits, bytes, 77U, 451U, 100U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("c_bcast channel frequency learned", pf0_st.trunk_chan_map[77] == 451012500L);
+    rc |= expect_true("c_bcast channel frequency tracked", pf0_st.trunk_lcn_freq[0] == 451012500L);
+    dsd_state_ext_free_all(&pf0_st);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_opts.dmr_t3_heuristic_fill = 1;
+    pf0_st.trunk_chan_map[10] = 451000000L;
+    pf0_st.trunk_chan_map[12] = 451025000L;
+    build_c_bcast_adjacent_apcn(bits, bytes, 14U, 451U, 400U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("c_bcast apcn learned anchor", pf0_st.trunk_chan_map[14] == 451050000L);
+    rc |= expect_true("heuristic fill synthesizes missing lcn 11", pf0_st.trunk_chan_map[11] == 451012500L);
+    rc |= expect_true("heuristic fill synthesizes missing lcn 13", pf0_st.trunk_chan_map[13] == 451037500L);
+    dsd_state_ext_free_all(&pf0_st);
+
+    init_env(&pf0_opts, &pf0_st);
+    pf0_opts.trunk_enable = 1;
+    pf0_opts.trunk_is_tuned = 0;
+    pf0_st.trunk_cc_freq = 851000000L;
+    pf0_st.trunk_chan_map[11] = 851000000L;
+    pf0_st.trunk_chan_map[22] = 852250000L;
+    g_return_to_cc_result_calls = 0;
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
+        .return_to_cc_result = result_return_to_cc,
+    });
+    build_c_bcast_ann_wd_tscc(bits, bytes, 11U, 22U, 1U, 0U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    rc |= expect_true("c_bcast tscc switch hook called", g_return_to_cc_result_calls == 1);
+    rc |= expect_true("c_bcast tscc switch commits new cc", pf0_st.trunk_cc_freq == 852250000L);
+    dsd_state_ext_free_all(&pf0_st);
+
+    static dsd_opts xpt_opts;
+    static dsd_state xpt_st;
+    init_env(&xpt_opts, &xpt_st);
+    xpt_opts.audio_in_type = AUDIO_IN_RTL;
+    xpt_opts.rtlsdr_center_freq = 461250000L;
+    xpt_st.trunk_chan_map[1] = 461262500L;
+    xpt_st.trunk_chan_map[2] = 461275000L;
+    xpt_st.last_vc_sync_time = time(NULL) - 10;
+    uint8_t xpt_status[6] = {3U, 2U, 1U, 0U, 3U, 0U};
+    uint8_t xpt_tg[6] = {77U, 88U, 0U, 0U, 99U, 0U};
+    build_xpt_site_status(bits, bytes, 0U, 2U, xpt_status, xpt_tg);
+    dmr_cspdu(&xpt_opts, &xpt_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("xpt site status updates site parms", strcmp(xpt_st.dmr_site_parms, "Free LCN - 2 ") == 0);
+    rc |= expect_true("xpt site status records active TG",
+                      strstr(xpt_st.active_channel[0], "LSN:1 TG:77;") != NULL
+                          && strstr(xpt_st.active_channel[0], "LSN:5 TG:99;") != NULL);
+    rc |=
+        expect_true("xpt site status records active private", strstr(xpt_st.active_channel[0], "LSN:2 PC:88;") != NULL);
+    rc |= expect_true("xpt site status sets rtl control channel",
+                      xpt_opts.trunk_is_tuned == 1 && xpt_st.trunk_cc_freq == 461250000L);
+    rc |= expect_true("xpt site status sets branding", strcmp(xpt_st.dmr_branding_sub, "XPT ") == 0);
+    rc |= expect_true("xpt site status emits grant", dmr_sm_get_ctx()->vc_tg == 77);
+    dsd_state_ext_free_all(&xpt_st);
+
+    init_env(&xpt_opts, &xpt_st);
+    xpt_opts.audio_in_type = AUDIO_IN_RTL;
+    xpt_opts.rtlsdr_center_freq = 462000000L;
+    xpt_opts.trunk_tune_private_calls = 1;
+    xpt_st.trunk_chan_map[7] = 462012500L;
+    xpt_st.last_vc_sync_time = time(NULL) - 10;
+    g_rotate_symbol_out_file_calls = 0;
+    uint8_t xpt_private_status[6] = {2U, 0U, 0U, 0U, 0U, 0U};
+    uint8_t xpt_private_tg[6] = {0U, 0U, 0U, 0U, 0U, 0U};
+    build_xpt_site_status(bits, bytes, 1U, 0U, xpt_private_status, xpt_private_tg);
+    dmr_cspdu(&xpt_opts, &xpt_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("xpt seq1 status-only private emits placeholder grant", dmr_sm_get_ctx()->vc_tg == 1);
+    rc |= expect_true("xpt seq1 private uses banked LSN map", xpt_st.trunk_vc_freq[0] == 462012500L);
+    rc |= expect_true("xpt seq1 learns rtl control channel", xpt_st.trunk_cc_freq == 462000000L);
+    rc |= expect_true("xpt seq1 rotates symbols before tune", g_rotate_symbol_out_file_calls == 1);
+    rc |= expect_true("xpt seq1 writes banked active channel", xpt_st.active_channel[1][0] == '\0');
+    dsd_state_ext_free_all(&xpt_st);
+
+    init_env(&xpt_opts, &xpt_st);
+    xpt_opts.audio_in_type = AUDIO_IN_RTL;
+    xpt_opts.rtlsdr_center_freq = 463000000L;
+    xpt_st.trunk_chan_map[13] = 463012500L;
+    xpt_st.last_vc_sync_time = time(NULL);
+    uint8_t xpt_debounce_status[6] = {3U, 0U, 0U, 0U, 0U, 0U};
+    uint8_t xpt_debounce_tg[6] = {55U, 0U, 0U, 0U, 0U, 0U};
+    build_xpt_site_status(bits, bytes, 2U, 0U, xpt_debounce_status, xpt_debounce_tg);
+    dmr_cspdu(&xpt_opts, &xpt_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("xpt seq2 records banked active TG", strstr(xpt_st.active_channel[2], "LSN:13 TG:55;") != NULL);
+    rc |= expect_true("xpt seq2 debounce suppresses grant", dmr_sm_get_ctx()->vc_tg == 0);
+    rc |= expect_true("xpt seq2 still learns rtl control channel", xpt_st.trunk_cc_freq == 463000000L);
+    dsd_state_ext_free_all(&xpt_st);
+
+    init_env(&xpt_opts, &xpt_st);
+    xpt_opts.audio_in_type = AUDIO_IN_RTL;
+    xpt_opts.rtlsdr_center_freq = 464000000L;
+    xpt_opts.trunk_use_allow_list = 1;
+    xpt_opts.verbose = 1;
+    xpt_st.trunk_chan_map[1] = 464012500L;
+    xpt_st.last_vc_sync_time = time(NULL) - 10;
+    uint8_t xpt_block_status[6] = {3U, 0U, 0U, 0U, 0U, 0U};
+    uint8_t xpt_block_tg[6] = {44U, 0U, 0U, 0U, 0U, 0U};
+    build_xpt_site_status(bits, bytes, 0U, 0U, xpt_block_status, xpt_block_tg);
+    dmr_cspdu(&xpt_opts, &xpt_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("xpt allow-list block keeps active TG visible",
+                      strstr(xpt_st.active_channel[0], "LSN:1 TG:44;") != NULL);
+    rc |= expect_true("xpt allow-list block suppresses grant", dmr_sm_get_ctx()->vc_tg == 0);
+    rc |= expect_true("xpt allow-list block does not tune VC", xpt_st.trunk_vc_freq[0] == 0);
+    dsd_state_ext_free_all(&xpt_st);
+
+    init_env(&xpt_opts, &xpt_st);
+    uint8_t xpt_sites[4] = {3U, 4U, 0U, 7U};
+    uint8_t xpt_free[4] = {2U, 5U, 0U, 9U};
+    build_xpt_adjacent(bits, bytes, 2U, xpt_sites, xpt_free);
+    dmr_cspdu(&xpt_opts, &xpt_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("xpt adjacent sets branding", strcmp(xpt_st.dmr_branding_sub, "XPT ") == 0);
 
     if (rc == 0) {
         printf("DMR_GRANT_POLICY: OK\n");

--- a/tests/protocol/dmr/test_dmr_le_infer_algid.c
+++ b/tests/protocol/dmr/test_dmr_le_infer_algid.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -73,32 +76,161 @@ fill_le_fragments_for_mi(dsd_state* state, uint8_t slot, uint32_t mi32) {
 }
 
 static void
-run_case(unsigned long long key, uint32_t mi, int expect_algid) {
+write_nibble_to_ambe(uint8_t frame[4][24], uint8_t nibble) {
+    DSD_MEMSET(frame, 0, 4U * 24U * sizeof(frame[0][0]));
+    for (int i = 0; i < 4; i++) {
+        frame[3][i] = (uint8_t)((nibble >> (3 - i)) & 1U);
+    }
+}
+
+static void
+run_case(uint8_t slot, unsigned long long key, uint32_t mi, int expect_algid) {
     static dsd_opts opts;
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
 
-    state.currentslot = 0;
+    state.currentslot = slot;
     state.M = 0;
     state.R = key;
     state.RR = key;
     state.dmr_so = 0x40U;
+    state.dmr_soR = 0x40U;
+
+    fill_le_fragments_for_mi(&state, slot, mi);
+    dmr_late_entry_mi(&opts, &state);
+
+    if (slot == 0U) {
+        assert(state.payload_algid == expect_algid);
+        assert(state.payload_keyid == 0xFF);
+        if (expect_algid == 0x21) {
+            assert((uint32_t)state.payload_mi == mi);
+        } else if (expect_algid == 0x22) {
+            assert(state.payload_miP != 0);
+            assert((uint32_t)(state.payload_miP >> 32) == mi);
+            assert((uint32_t)state.payload_mi == (uint32_t)state.payload_miP);
+        } else {
+            assert(0 && "unexpected algid");
+        }
+        assert(state.payload_algidR == 0);
+        return;
+    }
+
+    assert(state.payload_algidR == expect_algid);
+    assert(state.payload_keyidR == 0xFF);
+    if (expect_algid == 0x21) {
+        assert((uint32_t)state.payload_miR == mi);
+    } else if (expect_algid == 0x22) {
+        assert(state.payload_miN != 0);
+        assert((uint32_t)(state.payload_miN >> 32) == mi);
+        assert((uint32_t)state.payload_miR == (uint32_t)state.payload_miN);
+    } else {
+        assert(0 && "unexpected algid");
+    }
+    assert(state.payload_algid == 0);
+}
+
+static void
+test_fragment_wrapper_maps_slot2_to_slot1_and_triggers_decode(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static dsd_state encoded;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&encoded, 0, sizeof(encoded));
+
+    const uint32_t mi = 0x55667788U;
+    state.currentslot = 2;
+    state.M = 0;
+    state.RR = 0x0123456789ABCDULL;
+    state.dmr_soR = 0x40U;
+
+    fill_le_fragments_for_mi(&encoded, 1, mi);
+    for (uint8_t vc = 1; vc <= 6; vc++) {
+        uint8_t ambe_fr[4][24];
+        uint8_t ambe_fr2[4][24];
+        uint8_t ambe_fr3[4][24];
+        write_nibble_to_ambe(ambe_fr, (uint8_t)encoded.late_entry_mi_fragment[1][vc][0]);
+        write_nibble_to_ambe(ambe_fr2, (uint8_t)encoded.late_entry_mi_fragment[1][vc][1]);
+        write_nibble_to_ambe(ambe_fr3, (uint8_t)encoded.late_entry_mi_fragment[1][vc][2]);
+        if (vc == 6U) {
+            state.currentslot = 1;
+        }
+        dmr_late_entry_mi_fragment(&opts, &state, vc, ambe_fr, ambe_fr2, ambe_fr3);
+    }
+
+    assert(state.late_entry_mi_fragment[0][1][0] == 0);
+    assert(state.late_entry_mi_fragment[1][1][0] == encoded.late_entry_mi_fragment[1][1][0]);
+    assert(state.payload_algidR == 0x22);
+    assert(state.payload_keyidR == 0xFF);
+    assert(state.payload_miN != 0);
+    assert((uint32_t)(state.payload_miN >> 32) == mi);
+}
+
+static void
+test_verified_mi_updates_existing_slot_mi(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    const uint32_t mi = 0xA1B2C3D4U;
+    state.currentslot = 0;
+    state.M = 0;
+    state.payload_algid = 0x21;
+    state.payload_keyid = 0x34;
+    state.payload_mi = 0x01020304ULL;
 
     fill_le_fragments_for_mi(&state, 0, mi);
     dmr_late_entry_mi(&opts, &state);
 
-    assert(state.payload_algid == expect_algid);
-    assert(state.payload_keyid == 0xFF);
-    if (expect_algid == 0x21) {
-        assert((uint32_t)state.payload_mi == mi);
-    } else if (expect_algid == 0x22) {
-        assert(state.payload_miP != 0);
-        assert((uint32_t)(state.payload_miP >> 32) == mi);
-        assert((uint32_t)state.payload_mi == (uint32_t)state.payload_miP);
-    } else {
-        assert(0 && "unexpected algid");
-    }
+    assert(state.payload_algid == 0x21);
+    assert(state.payload_keyid == 0x34);
+    assert((uint32_t)state.payload_mi == mi);
+}
+
+static void
+test_alg_refresh_on_error_refreshes_each_encrypted_slot(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.K1 = 1;
+    state.payload_algid = 0x21;
+    state.payload_mi = 0x11223344ULL;
+    state.DMRvcL = 7;
+    state.payload_algidR = 0x22;
+    state.payload_miR = 0x55667788ULL;
+    state.DMRvcR = 9;
+
+    dmr_refresh_algids_on_error(&opts, &state);
+
+    assert(state.dropL == 256);
+    assert(state.dropR == 256);
+    assert(state.DMRvcL == 0);
+    assert(state.DMRvcR == 0);
+    assert(state.currentslot == 1);
+}
+
+static void
+test_alg_refresh_ignores_invalid_current_slot(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.currentslot = 2;
+    state.payload_algid = 0x21;
+    state.DMRvcL = 5;
+    state.DMRvcR = 6;
+
+    dmr_alg_refresh(&opts, &state);
+
+    assert(state.dropL == 0);
+    assert(state.dropR == 0);
+    assert(state.DMRvcL == 5);
+    assert(state.DMRvcR == 6);
 }
 
 int
@@ -106,11 +238,21 @@ main(void) {
     InitAllFecFunction();
 
     // RC4 key (<=40-bit) should infer ALG ID 0x21.
-    run_case(0xE3AE36E22AULL, 0xEC60C8BEU, 0x21);
+    run_case(0, 0xE3AE36E22AULL, 0xEC60C8BEU, 0x21);
 
     // DES key (>40-bit) should infer ALG ID 0x22.
-    run_case(0x0123456789ABCDULL, 0x11223344U, 0x22);
+    run_case(0, 0x0123456789ABCDULL, 0x11223344U, 0x22);
+
+    // Slot 2 should infer through the right-slot state and LFSR fields.
+    run_case(1, 0x0123456789ABCDULL, 0x22334455U, 0x22);
+
+    test_fragment_wrapper_maps_slot2_to_slot1_and_triggers_decode();
+    test_verified_mi_updates_existing_slot_mi();
+    test_alg_refresh_on_error_refreshes_each_encrypted_slot();
+    test_alg_refresh_ignores_invalid_current_slot();
 
     printf("DMR LE infer algid: OK\n");
     return 0;
 }
+
+// NOLINTEND(bugprone-implicit-widening-of-multiplication-result)

--- a/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
@@ -31,6 +31,23 @@
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #endif
 
+static unsigned int g_lip_calls;
+static unsigned int g_datacall_calls;
+static uint32_t g_datacall_src;
+static uint32_t g_datacall_dst;
+static uint8_t g_datacall_slot;
+static char g_datacall_text[512];
+
+static void
+reset_spies(void) {
+    g_lip_calls = 0;
+    g_datacall_calls = 0;
+    g_datacall_src = 0;
+    g_datacall_dst = 0;
+    g_datacall_slot = 0;
+    DSD_MEMSET(g_datacall_text, 0, sizeof(g_datacall_text));
+}
+
 // Minimal stubs for direct link with dmr_pdu.c
 const char*
 dsd_degrees_glyph(void) {
@@ -56,6 +73,7 @@ lip_protocol_decoder(dsd_opts* opts, dsd_state* state, uint8_t* input) {
     (void)opts;
     (void)state;
     (void)input;
+    g_lip_calls++;
 }
 
 void
@@ -71,10 +89,11 @@ void
 watchdog_event_datacall(dsd_opts* opts, dsd_state* state, uint32_t src, uint32_t dst, char* str, uint8_t slot) {
     (void)opts;
     (void)state;
-    (void)src;
-    (void)dst;
-    (void)str;
-    (void)slot;
+    g_datacall_calls++;
+    g_datacall_src = src;
+    g_datacall_dst = dst;
+    g_datacall_slot = slot;
+    DSD_SNPRINTF(g_datacall_text, sizeof(g_datacall_text), "%s", str ? str : "");
 }
 
 void
@@ -89,6 +108,8 @@ getDateS_buf(char out[11]) {
 
 // Under test
 void decode_ip_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, uint8_t* input);
+void dmr_sd_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* DMR_PDU);
+void dmr_udp_comp_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* DMR_PDU);
 void utf8_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input);
 
 static int
@@ -289,6 +310,146 @@ build_ipv4_udp_empty_payload(uint8_t* out, size_t cap, uint16_t dst_port) {
     return ip_total_len;
 }
 
+static size_t
+build_ipv4_udp_payload(uint8_t* out, size_t cap, uint16_t dst_port, const uint8_t* payload, size_t payload_len) {
+    DSD_MEMSET(out, 0, cap);
+
+    const size_t ip_header_len = 20u;
+    const size_t udp_len = 8u + payload_len;
+    const size_t ip_total_len = ip_header_len + udp_len;
+    if (cap < ip_total_len || udp_len > UINT16_MAX) {
+        return 0;
+    }
+
+    out[0] = (uint8_t)((4u << 4) | 5u);
+    out[2] = (uint8_t)((ip_total_len >> 8) & 0xFFu);
+    out[3] = (uint8_t)(ip_total_len & 0xFFu);
+    out[8] = 0x40;
+    out[9] = 0x11;
+
+    out[12] = 1;
+    out[13] = 2;
+    out[14] = 3;
+    out[15] = 4;
+    out[16] = 5;
+    out[17] = 6;
+    out[18] = 7;
+    out[19] = 8;
+
+    const size_t udp_off = ip_header_len;
+    out[udp_off + 0] = 0x30;
+    out[udp_off + 1] = 0x39;
+    out[udp_off + 2] = (uint8_t)((dst_port >> 8) & 0xFFu);
+    out[udp_off + 3] = (uint8_t)(dst_port & 0xFFu);
+    out[udp_off + 4] = (uint8_t)((udp_len >> 8) & 0xFFu);
+    out[udp_off + 5] = (uint8_t)(udp_len & 0xFFu);
+    if (payload_len != 0U && payload != NULL) {
+        DSD_MEMCPY(out + udp_off + 8u, payload, payload_len);
+    }
+
+    return ip_total_len;
+}
+
+static size_t
+build_ipv4_truncated_udp_header(uint8_t* out, size_t cap) {
+    DSD_MEMSET(out, 0, cap);
+    const size_t ip_total_len = 24u;
+    if (cap < ip_total_len) {
+        return 0;
+    }
+    out[0] = (uint8_t)((4u << 4) | 5u);
+    out[2] = 0;
+    out[3] = (uint8_t)ip_total_len;
+    out[8] = 0x40;
+    out[9] = 0x11;
+    out[12] = 1;
+    out[13] = 2;
+    out[14] = 3;
+    out[15] = 4;
+    out[16] = 5;
+    out[17] = 6;
+    out[18] = 7;
+    out[19] = 8;
+    out[20] = 0x30;
+    out[21] = 0x39;
+    out[22] = 0x0F;
+    out[23] = 0xA7;
+    return ip_total_len;
+}
+
+static size_t
+build_ipv4_icmp_attached_udp_service(uint8_t* out, size_t cap, uint16_t attached_port) {
+    uint8_t attached[96];
+    const uint8_t payload[] = {0xA5, 0x5A};
+    size_t attached_len = build_ipv4_udp_payload(attached, sizeof attached, attached_port, payload, sizeof payload);
+    const size_t ip_header_len = 20u;
+    const size_t icmp_len = 8u;
+    const size_t ip_total_len = ip_header_len + icmp_len + attached_len;
+    if (attached_len == 0U || cap < ip_total_len || ip_total_len > UINT16_MAX) {
+        return 0;
+    }
+
+    DSD_MEMSET(out, 0, cap);
+    out[0] = (uint8_t)((4u << 4) | 5u);
+    out[2] = (uint8_t)((ip_total_len >> 8) & 0xFFu);
+    out[3] = (uint8_t)(ip_total_len & 0xFFu);
+    out[8] = 0x40;
+    out[9] = 0x01;
+    out[12] = 9;
+    out[13] = 8;
+    out[14] = 7;
+    out[15] = 6;
+    out[16] = 5;
+    out[17] = 4;
+    out[18] = 3;
+    out[19] = 2;
+
+    const size_t icmp_off = ip_header_len;
+    out[icmp_off + 0] = 0x03;
+    out[icmp_off + 1] = 0x03;
+    out[icmp_off + 2] = 0x12;
+    out[icmp_off + 3] = 0x34;
+    DSD_MEMCPY(out + icmp_off + icmp_len, attached, attached_len);
+    return ip_total_len;
+}
+
+static size_t
+build_compressed_udp_utf16_text(uint8_t* out, size_t cap) {
+    if (cap < 9U) {
+        return 0;
+    }
+    DSD_MEMSET(out, 0, cap);
+    out[0] = 0x12;
+    out[1] = 0x34;                  // compressed IP ID
+    out[2] = 0x12;                  // SAID=Ethernet, DAID=Group Network
+    out[3] = (uint8_t)(0x80U | 1U); // opcode bit + SPID=UTF-16BE text
+    out[4] = 63U;                   // DPID=reserved 7-bit index
+    out[5] = 0x00;
+    out[6] = 'O';
+    out[7] = 0x00;
+    out[8] = 'K';
+    return 9U;
+}
+
+static size_t
+build_compressed_udp_lip_with_extended_src_port(uint8_t* out, size_t cap) {
+    if (cap < 10U) {
+        return 0;
+    }
+    DSD_MEMSET(out, 0, cap);
+    out[0] = 0x00;
+    out[1] = 0x7B;
+    out[2] = 0xB0; // SAID=manufacturer-specific, DAID=radio network
+    out[3] = 0x00; // SPID extended at byte 5
+    out[4] = 0x03; // DPID=reserved; SPID extension below selects LIP
+    out[5] = 0x00;
+    out[6] = 0x02; // SPID=Location Interface Protocol
+    out[7] = 0xA5;
+    out[8] = 0x5A;
+    out[9] = 0xC3;
+    return 10U;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -300,7 +461,7 @@ main(void) {
     st.currentslot = 0;
     opts.lrrp_file_output = 0;
 
-    st.event_history_s = (Event_History_I*)calloc(1u, sizeof(Event_History_I));
+    st.event_history_s = (Event_History_I*)calloc(2u, sizeof(Event_History_I));
     if (!st.event_history_s) {
         return 100;
     }
@@ -309,6 +470,7 @@ main(void) {
 
     // Case 1: standard IPv4 header (IHL=5). Ensure SPEED/HEADING are not truncated.
     {
+        reset_spies();
         size_t plen = build_ipv4_udp_lrrp(pkt, sizeof pkt, 5);
         st.dmr_lrrp_gps[0][0] = '\0';
         decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
@@ -318,6 +480,7 @@ main(void) {
 
     // Case 2: IPv4 options present (IHL=6). Decoder must honor IHL to locate UDP.
     {
+        reset_spies();
         size_t plen = build_ipv4_udp_lrrp(pkt, sizeof pkt, 6);
         st.dmr_lrrp_gps[0][0] = '\0';
         decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
@@ -327,6 +490,7 @@ main(void) {
 
     // Case 3: Vertex TMS on UDP/5007 should not trim valid text when data_block_poc is non-zero.
     {
+        reset_spies();
         size_t plen = build_ipv4_udp_vertex_tms(pkt, sizeof pkt, 5);
         st.data_block_poc[0] = 2; // non-zero from RF block framing; not part of UDP payload length
         st.dmr_lrrp_gps[0][0] = '\0';
@@ -338,6 +502,7 @@ main(void) {
 
     // Case 4: EF Johnson Atlas Data Registration Server on UDP/9361 should be labeled.
     {
+        reset_spies();
         size_t plen = build_ipv4_udp_empty_payload(pkt, sizeof pkt, 9361);
         st.dmr_lrrp_gps[0][0] = '\0';
         decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
@@ -346,6 +511,7 @@ main(void) {
 
     // Case 5: Short/empty UDP TMS payload should be reported as truncated, not indexed past the payload.
     {
+        reset_spies();
         size_t plen = build_ipv4_udp_empty_payload(pkt, sizeof pkt, 4007);
         st.dmr_lrrp_gps[0][0] = '\0';
         decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
@@ -354,6 +520,7 @@ main(void) {
 
     // Case 6: UTF-8 event text appends one bounded character at a time.
     {
+        reset_spies();
         const uint8_t text[] = {'A', 'B', 'C'};
         st.event_history_s[0].Event_History_Items[0].text_message[0] = '\0';
         utf8_to_text(&st, 1, (uint16_t)sizeof text, text);
@@ -362,6 +529,151 @@ main(void) {
                         st.event_history_s[0].Event_History_Items[0].text_message);
             rc |= 1;
         }
+    }
+
+    // Case 7: compressed UDP text dispatch resolves index labels, UTF-16 text, and datacall metadata.
+    {
+        reset_spies();
+        size_t plen = build_compressed_udp_utf16_text(pkt, sizeof pkt);
+        st.currentslot = 1;
+        st.event_history_s[1].Event_History_Items[0].text_message[0] = '\0';
+        dmr_udp_comp_pdu(&opts, &st, (uint16_t)plen, pkt);
+        rc |= expect_has_substr(st.event_history_s[1].Event_History_Items[0].text_message, "OK",
+                                "compressed text payload");
+        if (g_datacall_calls != 1U || g_datacall_src != 1U || g_datacall_dst != 2U || g_datacall_slot != 1U) {
+            DSD_FPRINTF(stderr, "compressed datacall metadata mismatch calls=%u src=%u dst=%u slot=%u\n",
+                        g_datacall_calls, g_datacall_src, g_datacall_dst, g_datacall_slot);
+            rc |= 1;
+        }
+        rc |= expect_has_substr(g_datacall_text, "SRC: 1:1", "compressed source summary");
+        rc |= expect_has_substr(g_datacall_text, "DST: 2:63", "compressed destination summary");
+    }
+
+    // Case 8: compressed UDP with an extended source port should dispatch bounded LIP bits once.
+    {
+        reset_spies();
+        size_t plen = build_compressed_udp_lip_with_extended_src_port(pkt, sizeof pkt);
+        st.currentslot = 0;
+        dmr_udp_comp_pdu(&opts, &st, (uint16_t)plen, pkt);
+        if (g_lip_calls != 1U) {
+            DSD_FPRINTF(stderr, "compressed LIP dispatch count mismatch: %u\n", g_lip_calls);
+            rc |= 1;
+        }
+        rc |= expect_has_substr(g_datacall_text, "SRC: 11:2", "compressed extended source summary");
+    }
+
+    // Case 9: compressed UDP guards short/null PDUs without emitting datacalls.
+    {
+        reset_spies();
+        dmr_udp_comp_pdu(&opts, &st, 4, pkt);
+        dmr_udp_comp_pdu(&opts, &st, 5, NULL);
+        if (g_datacall_calls != 0U || g_lip_calls != 0U) {
+            DSD_FPRINTF(stderr, "compressed short guard emitted calls=%u lip=%u\n", g_datacall_calls, g_lip_calls);
+            rc |= 1;
+        }
+    }
+
+    // Case 10: generic short data emits source/target datacall metadata without requiring LOCN parsing.
+    {
+        reset_spies();
+        const uint8_t text[] = {'H', 'E', 'L', 'L', 'O'};
+        st.currentslot = 0;
+        st.data_header_format[0] = 0;
+        st.dmr_lrrp_source[0] = 1234;
+        st.dmr_lrrp_target[0] = 5678;
+        dmr_sd_pdu(&opts, &st, (uint16_t)sizeof text, text);
+        if (g_datacall_calls != 1U || g_datacall_src != 1234U || g_datacall_dst != 5678U) {
+            DSD_FPRINTF(stderr, "short data datacall mismatch calls=%u src=%u dst=%u\n", g_datacall_calls,
+                        g_datacall_src, g_datacall_dst);
+            rc |= 1;
+        }
+        rc |= expect_has_substr(g_datacall_text, "Short Data SRC: 1234; TGT: 5678;", "short data summary");
+    }
+
+    // Case 11: UDP application service ports update GPS/event summaries by service kind.
+    {
+        const struct {
+            uint16_t port;
+            const char* tag;
+        } cases[] = {
+            {4005U, "ARS SRC:"},        {4008U, "Telemetry SRC:"}, {4009U, "OTAP SRC:"},
+            {4012U, "Batt. Man. SRC:"}, {4013U, "JTS SRC:"},       {4069U, "SCADA SRC:"},
+        };
+
+        const uint8_t ars_payload[] = {'A', 'R', 'S', 0};
+        for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+            reset_spies();
+            const uint8_t* payload = (cases[i].port == 4005U) ? ars_payload : NULL;
+            size_t payload_len = (cases[i].port == 4005U) ? sizeof(ars_payload) : 0U;
+            size_t plen = build_ipv4_udp_payload(pkt, sizeof pkt, cases[i].port, payload, payload_len);
+            st.currentslot = 0;
+            st.dmr_lrrp_gps[0][0] = '\0';
+            decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
+            rc |= expect_has_substr(st.dmr_lrrp_gps[0], cases[i].tag, "udp service label");
+        }
+    }
+
+    // Case 12: UDP/4007 TMS acknowledgment and UTF-16 text take distinct state paths.
+    {
+        reset_spies();
+        const uint8_t ack_payload[] = {0x00, 0x05, 0x01, 0x00, 0x00};
+        size_t plen = build_ipv4_udp_payload(pkt, sizeof pkt, 4007U, ack_payload, sizeof(ack_payload));
+        st.currentslot = 0;
+        st.dmr_lrrp_gps[0][0] = '\0';
+        decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
+        rc |= expect_has_substr(st.dmr_lrrp_gps[0], "Acknowledgment;", "tms acknowledgment");
+
+        reset_spies();
+        const uint8_t text_payload[] = {0x00, 0x06, 0x00, 0x00, 'O', 0x00, 'K'};
+        plen = build_ipv4_udp_payload(pkt, sizeof pkt, 4007U, text_payload, sizeof(text_payload));
+        st.event_history_s[0].Event_History_Items[0].text_message[0] = '\0';
+        st.dmr_lrrp_gps[0][0] = '\0';
+        decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
+        rc |= expect_has_substr(st.dmr_lrrp_gps[0], "TMS SRC:", "tms text label");
+        rc |= expect_has_substr(st.event_history_s[0].Event_History_Items[0].text_message, "OK", "tms text payload");
+    }
+
+    // Case 13: unknown UDP and truncated UDP headers emit bounded datacall summaries.
+    {
+        reset_spies();
+        size_t plen = build_ipv4_udp_payload(pkt, sizeof pkt, 65000U, NULL, 0U);
+        st.dmr_lrrp_gps[0][0] = '\0';
+        decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
+        rc |= expect_has_substr(st.dmr_lrrp_gps[0], "Unknown UDP Port;", "unknown udp label");
+        rc |= expect_has_substr(g_datacall_text, "Unknown UDP Port;", "unknown udp datacall");
+
+        reset_spies();
+        plen = build_ipv4_truncated_udp_header(pkt, sizeof pkt);
+        st.dmr_lrrp_gps[0][0] = '\0';
+        decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
+        rc |= expect_has_substr(st.dmr_lrrp_gps[0], "Truncated UDP;", "truncated udp label");
+        rc |= expect_has_substr(g_datacall_text, "Truncated UDP;", "truncated udp datacall");
+    }
+
+    // Case 14: ICMP destination-unreachable with an attached IPv4 message recursively decodes the attachment.
+    {
+        reset_spies();
+        size_t plen = build_ipv4_icmp_attached_udp_service(pkt, sizeof pkt, 4008U);
+        st.dmr_lrrp_gps[0][0] = '\0';
+        decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
+        rc |= expect_has_substr(st.dmr_lrrp_gps[0], "Telemetry SRC:", "icmp attached telemetry label");
+        rc |= expect_has_substr(g_datacall_text, "Telemetry SRC:", "icmp attached telemetry datacall");
+        if (g_datacall_calls != 2U) {
+            DSD_FPRINTF(stderr, "icmp attached datacall count mismatch: %u\n", g_datacall_calls);
+            rc |= 1;
+        }
+    }
+
+    // Case 15: malformed TMS address length is bounded and reported as truncated.
+    {
+        reset_spies();
+        const uint8_t malformed_addr_payload[] = {0x00, 0x08, 0x00, 0x04, 0x00};
+        size_t plen =
+            build_ipv4_udp_payload(pkt, sizeof pkt, 4007U, malformed_addr_payload, sizeof(malformed_addr_payload));
+        st.dmr_lrrp_gps[0][0] = '\0';
+        decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
+        rc |= expect_has_substr(st.dmr_lrrp_gps[0], "Truncated;", "tms malformed address truncation");
+        rc |= expect_has_substr(g_datacall_text, "Truncated;", "tms malformed address datacall");
     }
 
     free(st.event_history_s);

--- a/tests/protocol/dmr/test_dmr_lrrp_position_token_precedence.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_position_token_precedence.c
@@ -212,6 +212,27 @@ main(void) {
     dmr_lrrp(&opts, &st, (uint16_t)i, /*src*/ 123, /*dst*/ 456, pdu, 1);
     rc |= expect_has_point(st.dmr_lrrp_gps[0], exp_lat, exp_lon, "position precedence");
 
+    // Unknown LRRP message types still carry usable position payloads in the field.
+    DSD_MEMSET(&st, 0, sizeof st);
+    st.currentslot = 0;
+    DSD_MEMSET(pdu, 0, sizeof pdu);
+    i = 0;
+    pdu[i++] = 0x99; // unknown LRRP type
+    pdu[i++] = 9;    // POINT_2D token length
+    pdu[i++] = 0x66; // POINT_2D token id
+    pdu[i++] = (lat_p3d >> 24) & 0xFF;
+    pdu[i++] = (lat_p3d >> 16) & 0xFF;
+    pdu[i++] = (lat_p3d >> 8) & 0xFF;
+    pdu[i++] = (lat_p3d >> 0) & 0xFF;
+    pdu[i++] = (lon_p3d >> 24) & 0xFF;
+    pdu[i++] = (lon_p3d >> 16) & 0xFF;
+    pdu[i++] = (lon_p3d >> 8) & 0xFF;
+    pdu[i++] = (lon_p3d >> 0) & 0xFF;
+
+    expected_from_raw(lat_p3d, lon_p3d, &exp_lat, &exp_lon);
+    dmr_lrrp(&opts, &st, (uint16_t)i, /*src*/ 321, /*dst*/ 654, pdu, 1);
+    rc |= expect_has_point(st.dmr_lrrp_gps[0], exp_lat, exp_lon, "unknown type with point token");
+
     return rc;
 }
 

--- a/tests/protocol/dmr/test_dmr_ms_data.c
+++ b/tests/protocol/dmr/test_dmr_ms_data.c
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Focused coverage for the DMR MS/direct-mode data collector.
+ */
+
+#include "dsd-neo/core/safe_api.h"
+
+#include <assert.h>
+#include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/time_format.h>
+#include <dsd-neo/core/vocoder.h>
+#include <dsd-neo/crypto/dmr_keystream.h>
+#include <dsd-neo/fec/block_codes.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
+#include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
+#include <dsd-neo/runtime/telemetry.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int g_stream[320];
+static size_t g_stream_index;
+static int g_data_sync_calls;
+static int g_data_sync_stereo;
+static int g_data_sync_ms_mode;
+static int g_data_sync_directmode;
+static int g_data_sync_payload[144];
+
+static void
+reset_fixture(void) {
+    g_stream_index = 0U;
+    g_data_sync_calls = 0;
+    g_data_sync_stereo = 0;
+    g_data_sync_ms_mode = 0;
+    g_data_sync_directmode = 0;
+    DSD_MEMSET(g_stream, 0, sizeof(g_stream));
+    DSD_MEMSET(g_data_sync_payload, 0, sizeof(g_data_sync_payload));
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+getDibit(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    assert(g_stream_index < (sizeof(g_stream) / sizeof(g_stream[0])));
+    return g_stream[g_stream_index++] & 3;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+skipDibit(dsd_opts* opts, dsd_state* state, int count) {
+    (void)opts;
+    (void)state;
+    g_stream_index += (size_t)count;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+getTimeC_buf(char out[9]) {
+    DSD_SNPRINTF(out, 9, "%s", "00:00:00");
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_data_sync(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    g_data_sync_calls++;
+    g_data_sync_stereo = state->dmr_stereo;
+    g_data_sync_ms_mode = state->dmr_ms_mode;
+    g_data_sync_directmode = state->directmode;
+    assert(strcmp(state->slot1light, "") == 0);
+    assert(strcmp(state->slot2light, "") == 0);
+    DSD_MEMCPY(g_data_sync_payload, state->dmr_stereo_payload, sizeof(g_data_sync_payload));
+}
+
+bool
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+Hamming_7_4_decode(unsigned char* rx_bits) {
+    (void)rx_bits;
+    return true;
+}
+
+bool
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+QR_16_7_6_decode(unsigned char* rx_bits) {
+    (void)rx_bits;
+    return true;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_mark_vc_sync(dsd_state* state) {
+    (void)state;
+}
+
+FILE*
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_fopen_private(const char* path, const char* mode) {
+    (void)path;
+    (void)mode;
+    return NULL;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+processMbeFrame(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], char ambe_fr[4][24], char imbe7100_fr[7][24]) {
+    (void)opts;
+    (void)state;
+    (void)imbe_fr;
+    (void)ambe_fr;
+    (void)imbe7100_fr;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+playSynthesizedVoiceFS3(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+playSynthesizedVoiceSS3(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ui_publish_both_and_redraw(const dsd_opts* opts, const dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+tyt16_ambe2_codeword_keystream(const dsd_state* state, char ambe_fr[4][24], int fnum) {
+    (void)state;
+    (void)ambe_fr;
+    (void)fnum;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+csi72_ambe2_codeword_keystream(dsd_state* state, char ambe_fr[4][24]) {
+    (void)state;
+    (void)ambe_fr;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_data_burst_handler(dsd_opts* opts, dsd_state* state, uint8_t info[196], uint8_t databurst) {
+    (void)opts;
+    (void)state;
+    (void)info;
+    (void)databurst;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_debug_dump_burst(const dsd_opts* opts, const dsd_state* state, uint8_t slot_index, uint8_t burst_type) {
+    (void)opts;
+    (void)state;
+    (void)slot_index;
+    (void)burst_type;
+}
+
+size_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_debug_format_burst_payload(char* out, size_t out_size, const int payload[144], uint8_t slot_index,
+                               uint8_t burst_type) {
+    (void)payload;
+    (void)slot_index;
+    (void)burst_type;
+    if (out_size == 0U) {
+        return 0U;
+    }
+    out[0] = '\0';
+    return 0U;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_alg_refresh(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+hytera_enhanced_alg_refresh(dsd_state* state) {
+    (void)state;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_late_entry_mi_fragment(dsd_opts* opts, dsd_state* state, uint8_t vc, uint8_t ambe_fr[4][24],
+                           uint8_t ambe_fr2[4][24], uint8_t ambe_fr3[4][24]) {
+    (void)opts;
+    (void)state;
+    (void)vc;
+    (void)ambe_fr;
+    (void)ambe_fr2;
+    (void)ambe_fr3;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_sbrc(const dsd_opts* opts, dsd_state* state, uint8_t power) {
+    (void)opts;
+    (void)state;
+    (void)power;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_sm_emit_voice_sync(dsd_opts* opts, dsd_state* state, int slot) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_sm_tick(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+static void
+prepare_state(dsd_state* state, int payload[90]) {
+    DSD_MEMSET(state, 0, sizeof(*state));
+    for (size_t i = 0; i < 90U; i++) {
+        payload[i] = (int)(i & 3U);
+    }
+    state->dmr_payload_p = payload + 90;
+    state->dmr_color_code = 16;
+    state->dmr_stereo = 7;
+    state->dmr_ms_mode = 8;
+    state->directmode = 1;
+    DSD_SNPRINTF(state->slot1light, sizeof(state->slot1light), "%s", "stale1");
+    DSD_SNPRINTF(state->slot2light, sizeof(state->slot2light), "%s", "stale2");
+}
+
+static void
+load_live_half(void) {
+    for (size_t i = 0; i < 54U; i++) {
+        g_stream[i] = (int)((i + 1U) & 3U);
+    }
+    for (size_t i = 54U; i < 264U; i++) {
+        g_stream[i] = 3;
+    }
+}
+
+static void
+test_ms_data_collects_payload_and_cleans_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int payload[90];
+    reset_fixture();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_state(&state, payload);
+    load_live_half();
+
+    dmrMSData(&opts, &state);
+
+    assert(g_data_sync_calls == 1);
+    assert(g_data_sync_stereo == 1);
+    assert(g_data_sync_ms_mode == 1);
+    assert(g_data_sync_directmode == 1);
+    assert(g_stream_index == 264U);
+    assert(state.dmr_stereo == 0);
+    assert(state.dmr_ms_mode == 0);
+    assert(state.directmode == 0);
+    assert(g_data_sync_payload[0] == payload[0]);
+    assert(g_data_sync_payload[89] == payload[89]);
+    assert(g_data_sync_payload[90] == g_stream[0]);
+    assert(g_data_sync_payload[143] == g_stream[53]);
+    for (size_t i = 0; i < 144U; i++) {
+        assert(state.dmr_stereo_payload[i] == 1);
+    }
+}
+
+static void
+test_ms_data_applies_inversion_to_cached_and_live_halves(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int payload[90];
+    reset_fixture();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_state(&state, payload);
+    load_live_half();
+    opts.inverted_dmr = 1;
+
+    dmrMSData(&opts, &state);
+
+    assert(g_data_sync_calls == 1);
+    assert(g_data_sync_payload[0] == ((payload[0] ^ 2) & 3));
+    assert(g_data_sync_payload[1] == ((payload[1] ^ 2) & 3));
+    assert(g_data_sync_payload[89] == ((payload[89] ^ 2) & 3));
+    assert(g_data_sync_payload[90] == ((g_stream[0] ^ 2) & 3));
+    assert(g_data_sync_payload[143] == ((g_stream[53] ^ 2) & 3));
+    assert(state.dmr_stereo == 0);
+    assert(state.dmr_ms_mode == 0);
+    assert(state.directmode == 0);
+}
+
+int
+main(void) {
+    test_ms_data_collects_payload_and_cleans_state();
+    test_ms_data_applies_inversion_to_cached_and_live_halves();
+    DSD_FPRINTF(stdout, "DMR_MS_DATA: OK\n");
+    return 0;
+}

--- a/tests/protocol/dmr/test_dmr_ms_data.c
+++ b/tests/protocol/dmr/test_dmr_ms_data.c
@@ -27,21 +27,63 @@
 #include <stdio.h>
 #include <string.h>
 
-static int g_stream[320];
+static int g_stream[4096];
 static size_t g_stream_index;
+static int g_skip_calls;
+static int g_skip_total;
 static int g_data_sync_calls;
 static int g_data_sync_stereo;
 static int g_data_sync_ms_mode;
 static int g_data_sync_directmode;
 static int g_data_sync_payload[144];
+static int g_mark_vc_sync_calls;
+static int g_fopen_private_calls;
+static int g_process_mbe_calls;
+static int g_play_fs3_calls;
+static int g_play_ss3_calls;
+static int g_ui_calls;
+static int g_watchdog_history_calls;
+static int g_watchdog_current_calls;
+static int g_tyt_keystream_calls;
+static int g_csi_keystream_calls;
+static int g_data_burst_calls;
+static int g_debug_dump_calls;
+static int g_debug_format_calls;
+static int g_alg_refresh_calls;
+static int g_hytera_refresh_calls;
+static int g_late_entry_calls;
+static int g_sbrc_calls;
+static int g_voice_sync_calls;
+static int g_sm_tick_calls;
 
 static void
 reset_fixture(void) {
     g_stream_index = 0U;
+    g_skip_calls = 0;
+    g_skip_total = 0;
     g_data_sync_calls = 0;
     g_data_sync_stereo = 0;
     g_data_sync_ms_mode = 0;
     g_data_sync_directmode = 0;
+    g_mark_vc_sync_calls = 0;
+    g_fopen_private_calls = 0;
+    g_process_mbe_calls = 0;
+    g_play_fs3_calls = 0;
+    g_play_ss3_calls = 0;
+    g_ui_calls = 0;
+    g_watchdog_history_calls = 0;
+    g_watchdog_current_calls = 0;
+    g_tyt_keystream_calls = 0;
+    g_csi_keystream_calls = 0;
+    g_data_burst_calls = 0;
+    g_debug_dump_calls = 0;
+    g_debug_format_calls = 0;
+    g_alg_refresh_calls = 0;
+    g_hytera_refresh_calls = 0;
+    g_late_entry_calls = 0;
+    g_sbrc_calls = 0;
+    g_voice_sync_calls = 0;
+    g_sm_tick_calls = 0;
     DSD_MEMSET(g_stream, 0, sizeof(g_stream));
     DSD_MEMSET(g_data_sync_payload, 0, sizeof(g_data_sync_payload));
 }
@@ -60,6 +102,8 @@ void
 skipDibit(dsd_opts* opts, dsd_state* state, int count) {
     (void)opts;
     (void)state;
+    g_skip_calls++;
+    g_skip_total += count;
     g_stream_index += (size_t)count;
 }
 
@@ -100,6 +144,7 @@ void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_mark_vc_sync(dsd_state* state) {
     (void)state;
+    g_mark_vc_sync_calls++;
 }
 
 FILE*
@@ -107,6 +152,7 @@ FILE*
 dsd_fopen_private(const char* path, const char* mode) {
     (void)path;
     (void)mode;
+    g_fopen_private_calls++;
     return NULL;
 }
 
@@ -118,6 +164,7 @@ processMbeFrame(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], char ambe
     (void)imbe_fr;
     (void)ambe_fr;
     (void)imbe7100_fr;
+    g_process_mbe_calls++;
 }
 
 void
@@ -125,6 +172,7 @@ void
 playSynthesizedVoiceFS3(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_play_fs3_calls++;
 }
 
 void
@@ -132,6 +180,7 @@ void
 playSynthesizedVoiceSS3(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_play_ss3_calls++;
 }
 
 void
@@ -139,6 +188,7 @@ void
 ui_publish_both_and_redraw(const dsd_opts* opts, const dsd_state* state) {
     (void)opts;
     (void)state;
+    g_ui_calls++;
 }
 
 void
@@ -147,6 +197,7 @@ watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot) {
     (void)opts;
     (void)state;
     (void)slot;
+    g_watchdog_history_calls++;
 }
 
 void
@@ -155,6 +206,7 @@ watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) {
     (void)opts;
     (void)state;
     (void)slot;
+    g_watchdog_current_calls++;
 }
 
 void
@@ -163,6 +215,7 @@ tyt16_ambe2_codeword_keystream(const dsd_state* state, char ambe_fr[4][24], int 
     (void)state;
     (void)ambe_fr;
     (void)fnum;
+    g_tyt_keystream_calls++;
 }
 
 void
@@ -170,6 +223,7 @@ void
 csi72_ambe2_codeword_keystream(dsd_state* state, char ambe_fr[4][24]) {
     (void)state;
     (void)ambe_fr;
+    g_csi_keystream_calls++;
 }
 
 void
@@ -179,6 +233,7 @@ dmr_data_burst_handler(dsd_opts* opts, dsd_state* state, uint8_t info[196], uint
     (void)state;
     (void)info;
     (void)databurst;
+    g_data_burst_calls++;
 }
 
 void
@@ -188,6 +243,7 @@ dmr_debug_dump_burst(const dsd_opts* opts, const dsd_state* state, uint8_t slot_
     (void)state;
     (void)slot_index;
     (void)burst_type;
+    g_debug_dump_calls++;
 }
 
 size_t
@@ -200,6 +256,7 @@ dmr_debug_format_burst_payload(char* out, size_t out_size, const int payload[144
     if (out_size == 0U) {
         return 0U;
     }
+    g_debug_format_calls++;
     out[0] = '\0';
     return 0U;
 }
@@ -209,12 +266,14 @@ void
 dmr_alg_refresh(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_alg_refresh_calls++;
 }
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 hytera_enhanced_alg_refresh(dsd_state* state) {
     (void)state;
+    g_hytera_refresh_calls++;
 }
 
 void
@@ -227,6 +286,7 @@ dmr_late_entry_mi_fragment(dsd_opts* opts, dsd_state* state, uint8_t vc, uint8_t
     (void)ambe_fr;
     (void)ambe_fr2;
     (void)ambe_fr3;
+    g_late_entry_calls++;
 }
 
 void
@@ -235,6 +295,7 @@ dmr_sbrc(const dsd_opts* opts, dsd_state* state, uint8_t power) {
     (void)opts;
     (void)state;
     (void)power;
+    g_sbrc_calls++;
 }
 
 void
@@ -243,6 +304,7 @@ dmr_sm_emit_voice_sync(dsd_opts* opts, dsd_state* state, int slot) {
     (void)opts;
     (void)state;
     (void)slot;
+    g_voice_sync_calls++;
 }
 
 void
@@ -250,6 +312,14 @@ void
 dmr_sm_tick(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_sm_tick_calls++;
+}
+
+static void
+load_voice_stream(void) {
+    for (size_t i = 0; i < (sizeof(g_stream) / sizeof(g_stream[0])); i++) {
+        g_stream[i] = (int)(i & 3U);
+    }
 }
 
 static void
@@ -281,7 +351,7 @@ static void
 test_ms_data_collects_payload_and_cleans_state(void) {
     static dsd_opts opts;
     static dsd_state state;
-    int payload[90];
+    static int payload[90];
     reset_fixture();
     DSD_MEMSET(&opts, 0, sizeof(opts));
     prepare_state(&state, payload);
@@ -310,7 +380,7 @@ static void
 test_ms_data_applies_inversion_to_cached_and_live_halves(void) {
     static dsd_opts opts;
     static dsd_state state;
-    int payload[90];
+    static int payload[90];
     reset_fixture();
     DSD_MEMSET(&opts, 0, sizeof(opts));
     prepare_state(&state, payload);
@@ -330,10 +400,97 @@ test_ms_data_applies_inversion_to_cached_and_live_halves(void) {
     assert(state.directmode == 0);
 }
 
+static void
+test_ms_voice_cycle_processes_frames_and_cleans_mode_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_fixture();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    load_voice_stream();
+
+    opts.floating_point = 1;
+    opts.pulse_digi_out_channels = 2;
+    opts.use_ncurses_terminal = 1;
+    state.payload_algid = 0x02;
+    state.static_ks_counter[0] = 7;
+    state.vertex_ks_counter[0] = 8;
+    state.vertex_ks_active_idx[0] = 2;
+    state.vertex_ks_warned[0] = 1;
+    state.tyt_bp = 1;
+    state.csi_ee = 1;
+
+    dmrMS(&opts, &state);
+
+    assert(g_voice_sync_calls == 5);
+    assert(g_process_mbe_calls == 15);
+    assert(g_play_fs3_calls == 5);
+    assert(g_play_ss3_calls == 0);
+    assert(g_late_entry_calls == 5);
+    assert(g_tyt_keystream_calls == 15);
+    assert(g_csi_keystream_calls == 15);
+    assert(g_data_burst_calls == 1);
+    assert(g_sbrc_calls == 1);
+    assert(g_alg_refresh_calls == 1);
+    assert(g_hytera_refresh_calls == 1);
+    assert(g_ui_calls == 4);
+    assert(g_watchdog_history_calls == 4);
+    assert(g_watchdog_current_calls == 4);
+    assert(g_sm_tick_calls == 4);
+    assert(g_mark_vc_sync_calls == 5);
+    assert(g_debug_dump_calls == 5);
+    assert(g_skip_calls == 5);
+    assert(g_skip_total == 720);
+    assert(g_stream_index == 1506U);
+    assert(state.dmr_stereo == 0);
+    assert(state.dmr_ms_mode == 0);
+    assert(state.directmode == 0);
+    assert(state.static_ks_counter[0] == 0);
+    assert(state.vertex_ks_counter[0] == 0);
+    assert(state.vertex_ks_active_idx[0] == -1);
+    assert(state.vertex_ks_warned[0] == 0);
+}
+
+static void
+test_ms_bootstrap_uses_cached_payload_then_enters_voice_cycle(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int payload[90];
+    reset_fixture();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_state(&state, payload);
+    load_voice_stream();
+
+    opts.floating_point = 0;
+    opts.pulse_digi_out_channels = 2;
+    opts.use_dsp_output = 1;
+    opts.dmr_debug_burst = 1;
+    opts.dmr_le = 2;
+    state.dmr_color_code = 5;
+
+    dmrMSBootstrap(&opts, &state);
+
+    assert(g_voice_sync_calls == 6);
+    assert(g_process_mbe_calls == 18);
+    assert(g_play_fs3_calls == 0);
+    assert(g_play_ss3_calls == 6);
+    assert(g_late_entry_calls == 0);
+    assert(g_debug_format_calls == 1);
+    assert(g_fopen_private_calls == 6);
+    assert(g_skip_calls == 6);
+    assert(g_skip_total == 864);
+    assert(g_stream_index == 1704U);
+    assert(state.dmr_stereo == 0);
+    assert(state.dmr_ms_mode == 0);
+    assert(state.directmode == 0);
+}
+
 int
 main(void) {
     test_ms_data_collects_payload_and_cleans_state();
     test_ms_data_applies_inversion_to_cached_and_live_halves();
+    test_ms_voice_cycle_processes_frames_and_cleans_mode_state();
+    test_ms_bootstrap_uses_cached_payload_then_enters_voice_cycle();
     DSD_FPRINTF(stdout, "DMR_MS_DATA: OK\n");
     return 0;
 }

--- a/tests/protocol/dmr/test_dmr_pi_kirisun.c
+++ b/tests/protocol/dmr/test_dmr_pi_kirisun.c
@@ -9,6 +9,7 @@
 #include <dsd-neo/fec/block_codes.h>
 #include <dsd-neo/fec/bptc.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
+#include <dsd-neo/protocol/dmr/dmr_utils_api.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -43,6 +44,26 @@ load_single_burst_value(dsd_state* state, uint8_t slot, uint16_t sb_value) {
     for (int i = 0; i < 32; i++) {
         state->dmr_embedded_signalling[slot][5][i + 8] = interleaved[i];
     }
+}
+
+static uint16_t
+build_rc_command_value(uint8_t rc_value) {
+    uint8_t rc_bits[4];
+    for (int i = 0; i < 4; i++) {
+        rc_bits[i] = (uint8_t)((rc_value >> (3 - i)) & 1U);
+    }
+    const uint8_t masked_crc = (uint8_t)(crc7(rc_bits, 4U) ^ 0x7AU);
+    return (uint16_t)(((uint16_t)(rc_value & 0xFU) << 7U) | masked_crc);
+}
+
+static uint16_t
+build_txi_value(uint8_t opcode, uint8_t delay) {
+    const uint8_t low8 = (uint8_t)(((delay & 0x1FU) << 3U) | (opcode & 0x7U));
+    uint8_t low_bits[8];
+    for (int i = 0; i < 8; i++) {
+        low_bits[i] = (uint8_t)((low8 >> (7 - i)) & 1U);
+    }
+    return (uint16_t)(((uint16_t)crc3(low_bits, 8U) << 8U) | low8);
 }
 
 static uint8_t
@@ -93,6 +114,63 @@ test_pi_kirisun_requires_crc_ok(void) {
 }
 
 static void
+test_pi_kirisun_slot1_sets_fields_and_le_mode(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.currentslot = 1;
+    uint8_t pi[10] = {0x37, 0x0A, 0x55, 0xAA, 0xBB, 0xCC, 0xDD, 0x00, 0x00, 0x09};
+    dmr_pi(&opts, &state, pi, 1, 0);
+
+    assert(state.dmr_soR == 0x55);
+    assert(state.payload_algidR == 0x37);
+    assert(state.payload_miR == 0xAABBCCDDULL);
+    assert(state.payload_keyidR == (uint8_t)((0x37U * 0x000009U) & 0xFFU));
+    assert(opts.dmr_le == 3);
+}
+
+static void
+test_pi_kirisun_generic_alg_sets_fields(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.currentslot = 0;
+    uint8_t pi[10] = {0x38, 0x0A, 0x66, 0x01, 0x02, 0x03, 0x04, 0x00, 0x00, 0x05};
+    dmr_pi(&opts, &state, pi, 1, 0);
+
+    assert(state.dmr_so == 0x66);
+    assert(state.payload_algid == 0x38);
+    assert(state.payload_mi == 0x01020304ULL);
+    assert(state.payload_keyid == (uint8_t)((0x38U * 0x000005U) & 0xFFU));
+    assert(opts.dmr_le == 3);
+}
+
+static void
+test_pi_irrecoverable_error_is_noop(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.trunk_is_tuned = 1;
+    opts.dmr_le = 1;
+    state.currentslot = 0;
+    uint8_t pi[10] = {0x36, 0x0A, 0x40, 0x11, 0x22, 0x33, 0x44, 0x00, 0x00, 0x01};
+    dmr_pi(&opts, &state, pi, 1, 1);
+
+    assert(state.payload_algid == 0);
+    assert(state.payload_keyid == 0);
+    assert(state.payload_mi == 0);
+    assert(state.last_vc_sync_time == 0);
+    assert(state.last_cc_sync_time == 0);
+    assert(opts.dmr_le == 1);
+}
+
+static void
 test_pi_dmra_normalizes_aes128_and_expands_iv(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -119,6 +197,40 @@ test_pi_dmra_normalizes_aes128_and_expands_iv(void) {
 }
 
 static void
+test_pi_dmra_normalizes_rc4_without_iv_expansion(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.currentslot = 0;
+    state.DMRvcL = 9;
+    uint8_t pi[10] = {0x01, 0x10, 0x45, 0x10, 0x20, 0x30, 0x40, 0x00, 0x00, 0x00};
+    dmr_pi(&opts, &state, pi, 1, 0);
+
+    assert(state.payload_algid == 0x21);
+    assert(state.payload_keyid == 0x45);
+    assert(state.payload_mi == 0x10203040ULL);
+    assert(state.DMRvcL == 9);
+}
+
+static void
+test_pi_dmra_native_family_algid_preserves_rc4_id(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.currentslot = 0;
+    uint8_t pi[10] = {0x21, 0x10, 0x46, 0x55, 0x66, 0x77, 0x88, 0x00, 0x00, 0x00};
+    dmr_pi(&opts, &state, pi, 1, 0);
+
+    assert(state.payload_algid == 0x21);
+    assert(state.payload_keyid == 0x46);
+    assert(state.payload_mi == 0x55667788ULL);
+}
+
+static void
 test_pi_dmra_normalizes_des_on_slot1_and_expands_iv(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -135,6 +247,58 @@ test_pi_dmra_normalizes_des_on_slot1_and_expands_iv(void) {
     assert((uint32_t)(state.payload_miN >> 32ULL) == 0xCAFEBABEU);
     assert((uint32_t)state.payload_miR == (uint32_t)state.payload_miN);
     assert(state.DMRvcR == 0);
+}
+
+static void
+test_pi_dmra_normalizes_aes256_on_slot1_and_expands_iv(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.currentslot = 1;
+    state.DMRvcR = 8;
+    uint8_t pi[10] = {0x05, 0x10, 0x78, 0x22, 0x33, 0x44, 0x55, 0x00, 0x00, 0x00};
+    dmr_pi(&opts, &state, pi, 1, 0);
+
+    const unsigned long long next_mi =
+        ((unsigned long long)state.aes_ivR[4] << 24ULL) | ((unsigned long long)state.aes_ivR[5] << 16ULL)
+        | ((unsigned long long)state.aes_ivR[6] << 8ULL) | ((unsigned long long)state.aes_ivR[7] << 0ULL);
+
+    assert(state.payload_algidR == 0x25);
+    assert(state.payload_keyidR == 0x78);
+    assert(state.aes_ivR[0] == 0x22);
+    assert(state.aes_ivR[1] == 0x33);
+    assert(state.aes_ivR[2] == 0x44);
+    assert(state.aes_ivR[3] == 0x55);
+    assert(state.payload_miR == next_mi);
+    assert(state.DMRvcR == 0);
+}
+
+static void
+test_pi_dmra_normalizes_aes256_on_slot0_and_expands_iv(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.currentslot = 0;
+    state.DMRvcL = 8;
+    uint8_t pi[10] = {0x05, 0x10, 0x79, 0x33, 0x44, 0x55, 0x66, 0x00, 0x00, 0x00};
+    dmr_pi(&opts, &state, pi, 1, 0);
+
+    const unsigned long long next_mi =
+        ((unsigned long long)state.aes_iv[4] << 24ULL) | ((unsigned long long)state.aes_iv[5] << 16ULL)
+        | ((unsigned long long)state.aes_iv[6] << 8ULL) | ((unsigned long long)state.aes_iv[7] << 0ULL);
+
+    assert(state.payload_algid == 0x25);
+    assert(state.payload_keyid == 0x79);
+    assert(state.aes_iv[0] == 0x33);
+    assert(state.aes_iv[1] == 0x44);
+    assert(state.aes_iv[2] == 0x55);
+    assert(state.aes_iv[3] == 0x66);
+    assert(state.payload_mi == next_mi);
+    assert(state.DMRvcL == 0);
 }
 
 static void
@@ -161,7 +325,9 @@ test_pi_hytera_enhanced_checksum_sets_slot1_fields(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
 
     opts.dmr_le = 1;
+    opts.show_keys = 0;
     state.currentslot = 1;
+    state.RR = 0x123456789AULL;
     uint8_t pi[10] = {0x02, 0x68, 0x34, 0x01, 0x23, 0x45, 0x67, 0x89, 0x00, 0x00};
     pi[9] = hytera_pi_checksum(pi);
     dmr_pi(&opts, &state, pi, 1, 0);
@@ -171,6 +337,41 @@ test_pi_hytera_enhanced_checksum_sets_slot1_fields(void) {
     assert(state.payload_keyidR == 0x34);
     assert(state.payload_miR == 0x0123456789ULL);
     assert(opts.dmr_le == 2);
+}
+
+static void
+test_pi_hytera_slot0_checksum_key_and_error_paths(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.dmr_le = 1;
+    opts.show_keys = 1;
+    state.currentslot = 0;
+    state.R = 0x0102030405ULL;
+    uint8_t pi[10] = {0x02, 0x68, 0x21, 0x10, 0x32, 0x54, 0x76, 0x98, 0x00, 0x00};
+    pi[9] = hytera_pi_checksum(pi);
+    dmr_pi(&opts, &state, pi, 1, 0);
+
+    assert((state.dmr_so & 0x40U) != 0U);
+    assert(state.payload_algid == 0x02);
+    assert(state.payload_keyid == 0x21);
+    assert(state.payload_mi == 0x1032547698ULL);
+    assert(opts.dmr_le == 2);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.dmr_le = 1;
+    state.currentslot = 0;
+    pi[9] ^= 0x7FU;
+    dmr_pi(&opts, &state, pi, 1, 0);
+
+    assert((state.dmr_so & 0x40U) != 0U);
+    assert(state.payload_algid == 0x02);
+    assert(state.payload_keyid == 0x21);
+    assert(state.payload_mi == 0x1032547698ULL);
+    assert(opts.dmr_le == 1);
 }
 
 static void
@@ -210,6 +411,42 @@ test_alg_refresh_advances_kirisun_mi(void) {
     assert((uint32_t)state.payload_mi == expected);
     assert(state.DMRvcL == 0);
     assert(state.dropL == 256);
+}
+
+static void
+test_lfsr_refresh_updates_slot1_variants(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.currentslot = 1;
+    state.payload_algidR = 0x21;
+    state.payload_keyidR = 0x66;
+    state.payload_miR = 0x89ABCDEFULL;
+    LFSR(&state);
+    assert(state.payload_miR != 0x89ABCDEFULL);
+
+    state.payload_algidR = 0x24;
+    state.payload_keyidR = 0x77;
+    state.payload_miR = 0x11223344ULL;
+    state.DMRvcR = 6;
+    LFSR128d(&state);
+    assert(state.aes_ivR[0] == 0x11);
+    assert(state.aes_ivR[1] == 0x22);
+    assert(state.aes_ivR[2] == 0x33);
+    assert(state.aes_ivR[3] == 0x44);
+    assert(state.payload_miR != 0x11223344ULL);
+    assert(state.DMRvcR == 0);
+}
+
+static void
+test_hytera_refresh_advances_feedback_branch(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.currentslot = 0;
+    state.payload_mi = 0x8000000000ULL;
+    hytera_enhanced_alg_refresh(&state);
+    assert(state.payload_mi != 0x8000000000ULL);
 }
 
 static void
@@ -271,21 +508,137 @@ test_sbrc_kirisun_gate_ignores_stale_kirisun_alg(void) {
     assert(state.payload_keyidR == 0x12);
 }
 
+static void
+test_sbrc_standard_slot0_encryption_identifiers(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    const uint8_t algs[] = {1U, 2U, 4U, 5U};
+
+    for (size_t i = 0; i < sizeof(algs) / sizeof(algs[0]); i++) {
+        DSD_MEMSET(&opts, 0, sizeof(opts));
+        DSD_MEMSET(&state, 0, sizeof(state));
+
+        const uint8_t alg = algs[i];
+        const uint8_t key = (uint8_t)(0x20U + alg);
+        opts.dmr_le = 1;
+        opts.payload = 1;
+        state.currentslot = 0;
+        state.dmr_so = 0x40U;
+        load_single_burst_value(&state, 0, (uint16_t)(((uint16_t)key << 3U) | alg));
+
+        dmr_sbrc(&opts, &state, 0);
+
+        assert(state.payload_algid == (int)(alg + 0x20U));
+        assert(state.payload_keyid == key);
+        assert(state.payload_algidR == 0);
+    }
+}
+
+static void
+test_sbrc_standard_slot1_encryption_identifier_guards(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.dmr_le = 1;
+    state.currentslot = 1;
+    state.dmr_soR = 0x40U;
+    state.M = 1;
+    load_single_burst_value(&state, 1, (uint16_t)((0x44U << 3U) | 5U));
+    dmr_sbrc(&opts, &state, 0);
+    assert(state.payload_algidR == 0);
+    assert(state.payload_keyidR == 0);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.dmr_le = 1;
+    state.currentslot = 1;
+    state.dmr_soR = 0x40U;
+    load_single_burst_value(&state, 1, (uint16_t)((0x44U << 3U) | 5U));
+    dmr_sbrc(&opts, &state, 0);
+    assert(state.payload_algidR == 0x25);
+    assert(state.payload_keyidR == 0x44);
+}
+
+static void
+test_sbrc_reverse_channel_commands(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.dmr_le = 1;
+    state.currentslot = 0;
+    load_single_burst_value(&state, 0, build_rc_command_value(5U));
+    dmr_sbrc(&opts, &state, 1);
+    assert(state.payload_algid == 0);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.dmr_le = 1;
+    state.currentslot = 0;
+    load_single_burst_value(&state, 0, build_rc_command_value(6U));
+    dmr_sbrc(&opts, &state, 1);
+    assert(state.payload_algid == 0);
+}
+
+static void
+test_sbrc_txi_commands(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    const uint8_t delays[] = {2U, 4U, 6U, 8U};
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.dmr_le = 1;
+    opts.payload = 1;
+    state.currentslot = 0;
+    load_single_burst_value(&state, 0, build_txi_value(0U, 5U));
+    dmr_sbrc(&opts, &state, 0);
+    assert(state.payload_algid == 0);
+
+    for (size_t i = 0; i < sizeof(delays) / sizeof(delays[0]); i++) {
+        DSD_MEMSET(&opts, 0, sizeof(opts));
+        DSD_MEMSET(&state, 0, sizeof(state));
+        opts.dmr_le = 1;
+        opts.payload = 1;
+        state.currentslot = 0;
+        load_single_burst_value(&state, 0, build_txi_value(3U, delays[i]));
+        dmr_sbrc(&opts, &state, 0);
+        assert(state.payload_algid == 0);
+    }
+}
+
 int
 main(void) {
     InitAllFecFunction();
 
     test_pi_kirisun_slot0_sets_fields_and_le_mode();
     test_pi_kirisun_requires_crc_ok();
+    test_pi_kirisun_slot1_sets_fields_and_le_mode();
+    test_pi_kirisun_generic_alg_sets_fields();
+    test_pi_irrecoverable_error_is_noop();
     test_pi_dmra_normalizes_aes128_and_expands_iv();
+    test_pi_dmra_normalizes_rc4_without_iv_expansion();
+    test_pi_dmra_native_family_algid_preserves_rc4_id();
     test_pi_dmra_normalizes_des_on_slot1_and_expands_iv();
+    test_pi_dmra_normalizes_aes256_on_slot1_and_expands_iv();
+    test_pi_dmra_normalizes_aes256_on_slot0_and_expands_iv();
     test_pi_dmra_rejects_algid_outside_dmra_range();
     test_pi_hytera_enhanced_checksum_sets_slot1_fields();
+    test_pi_hytera_slot0_checksum_key_and_error_paths();
     test_pi_refreshes_sync_time_when_trunk_tuned();
     test_alg_refresh_advances_kirisun_mi();
+    test_lfsr_refresh_updates_slot1_variants();
+    test_hytera_refresh_advances_feedback_branch();
     test_sbrc_kirisun_gate_rejects_non_kirisun_calls();
     test_sbrc_kirisun_gate_accepts_kirisun_calls();
     test_sbrc_kirisun_gate_ignores_stale_kirisun_alg();
+    test_sbrc_standard_slot0_encryption_identifiers();
+    test_sbrc_standard_slot1_encryption_identifier_guards();
+    test_sbrc_reverse_channel_commands();
+    test_sbrc_txi_commands();
     printf("DMR PI Kirisun: OK\n");
     return 0;
 }

--- a/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
+++ b/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
@@ -35,6 +35,24 @@ extern void dmr_reset_blocks(dsd_opts* opts, dsd_state* state);
 static unsigned int g_decode_ip_calls;
 static uint16_t g_decode_ip_last_len;
 static uint8_t g_decode_ip_first_byte;
+static unsigned int g_sd_pdu_calls;
+static uint16_t g_sd_pdu_last_len;
+static uint8_t g_sd_pdu_first_byte;
+static unsigned int g_udp_comp_calls;
+static uint16_t g_udp_comp_last_len;
+static uint8_t g_udp_comp_first_byte;
+static unsigned int g_datacall_calls;
+static uint32_t g_datacall_last_src;
+static uint32_t g_datacall_last_dst;
+static uint8_t g_datacall_last_slot;
+static char g_datacall_last_text[256];
+static unsigned int g_lip_calls;
+static unsigned int g_nmea_calls;
+static uint32_t g_nmea_last_src;
+static int g_nmea_last_type;
+static unsigned int g_utf8_calls;
+static uint16_t g_utf8_last_len;
+static uint8_t g_utf8_first_byte;
 
 static int
 read_file_to_buffer(const char* path, char* out, size_t out_size) {
@@ -83,10 +101,11 @@ void
 watchdog_event_datacall(dsd_opts* opts, dsd_state* state, uint32_t src, uint32_t dst, char* data_string, uint8_t slot) {
     (void)opts;
     (void)state;
-    (void)src;
-    (void)dst;
-    (void)data_string;
-    (void)slot;
+    g_datacall_calls++;
+    g_datacall_last_src = src;
+    g_datacall_last_dst = dst;
+    g_datacall_last_slot = slot;
+    DSD_SNPRINTF(g_datacall_last_text, sizeof(g_datacall_last_text), "%s", data_string ? data_string : "");
 }
 
 void
@@ -95,6 +114,7 @@ lip_protocol_decoder(dsd_opts* opts, dsd_state* state, uint8_t* input) {
     (void)opts;
     (void)state;
     (void)input;
+    g_lip_calls++;
 }
 
 void
@@ -103,8 +123,9 @@ nmea_iec_61162_1(dsd_opts* opts, dsd_state* state, uint8_t* input, uint32_t src,
     (void)opts;
     (void)state;
     (void)input;
-    (void)src;
-    (void)type;
+    g_nmea_calls++;
+    g_nmea_last_src = src;
+    g_nmea_last_type = type;
 }
 
 // Stubs to avoid linking runtime/core
@@ -204,8 +225,9 @@ void
 dmr_sd_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, uint8_t* DMR_PDU) {
     (void)opts;
     (void)state;
-    (void)len;
-    (void)DMR_PDU;
+    g_sd_pdu_calls++;
+    g_sd_pdu_last_len = len;
+    g_sd_pdu_first_byte = DMR_PDU ? DMR_PDU[0] : 0U;
 }
 
 void
@@ -213,8 +235,9 @@ void
 dmr_udp_comp_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* DMR_PDU) {
     (void)opts;
     (void)state;
-    (void)len;
-    (void)DMR_PDU;
+    g_udp_comp_calls++;
+    g_udp_comp_last_len = len;
+    g_udp_comp_first_byte = DMR_PDU ? DMR_PDU[0] : 0U;
 }
 
 void
@@ -247,8 +270,9 @@ void
 utf8_to_text(dsd_state* state, uint8_t wr, uint16_t len, uint8_t* input) {
     (void)state;
     (void)wr;
-    (void)len;
-    (void)input;
+    g_utf8_calls++;
+    g_utf8_last_len = len;
+    g_utf8_first_byte = input ? input[0] : 0U;
 }
 
 void
@@ -266,6 +290,139 @@ set_bits(uint8_t* bits, int start, uint32_t value, int nbits) {
         int bit = (int)((value >> (nbits - 1 - i)) & 1U);
         bits[start + i] = (uint8_t)bit;
     }
+}
+
+static void
+set_byte_bits(uint8_t* bytes, size_t start, uint32_t value, size_t nbits) {
+    for (size_t i = 0; i < nbits; i++) {
+        size_t bit_index = start + i;
+        size_t byte_index = bit_index / 8U;
+        uint8_t mask = (uint8_t)(1U << (7U - (bit_index % 8U)));
+        if (((value >> (nbits - 1U - i)) & 1U) != 0U) {
+            bytes[byte_index] |= mask;
+        } else {
+            bytes[byte_index] &= (uint8_t)~mask;
+        }
+    }
+}
+
+static void
+pack_bits_to_bytes(const uint8_t* bits, uint8_t* bytes, size_t nbits) {
+    DSD_MEMSET(bytes, 0, (nbits + 7U) / 8U);
+    for (size_t i = 0; i < nbits; i++) {
+        if (bits[i] != 0U) {
+            bytes[i / 8U] |= (uint8_t)(1U << (7U - (i % 8U)));
+        }
+    }
+}
+
+static void
+append_type2_crc16(uint8_t* block, size_t block_len) {
+    uint8_t bits[96];
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    for (size_t i = 0; i < block_len; i++) {
+        for (size_t bit = 0; bit < 8U; bit++) {
+            bits[(i * 8U) + bit] = (uint8_t)((block[i] >> (7U - bit)) & 1U);
+        }
+    }
+    uint32_t crc = ComputeCrcCCITT16d(bits, (uint16_t)((block_len * 8U) - 16U));
+    block[block_len - 2U] = (uint8_t)((crc >> 8U) & 0xFFU);
+    block[block_len - 1U] = (uint8_t)(crc & 0xFFU);
+}
+
+static void
+build_udt_header(uint8_t dheader[12], uint8_t bits[196], uint8_t udt_format, uint32_t target, uint32_t source) {
+    DSD_MEMSET(dheader, 0, 12);
+    DSD_MEMSET(bits, 0, 196);
+    set_bits(bits, 4, 0U, 4); // DPF=0 UDT
+    set_bits(bits, 8, 0U, 4); // SAP=0 UDT
+    set_bits(bits, 12, udt_format, 4);
+    set_bits(bits, 16, target & 0x00FFFFFFU, 24);
+    set_bits(bits, 40, source & 0x00FFFFFFU, 24);
+    set_bits(bits, 70, 0U, 2); // encoded UAB 0 -> one appended block
+    pack_bits_to_bytes(bits, dheader, 96);
+}
+
+static void
+build_udt_iso7_block(uint8_t block[12], const char* text) {
+    DSD_MEMSET(block, 0, 12);
+    for (size_t i = 0; text[i] != '\0' && i < 11U; i++) {
+        set_byte_bits(block, i * 7U, (uint8_t)text[i] & 0x7FU, 7U);
+    }
+    append_type2_crc16(block, 12);
+}
+
+static void
+build_udt_iso8_block(uint8_t block[12], const char* text) {
+    DSD_MEMSET(block, 0, 12);
+    for (size_t i = 0; text[i] != '\0' && i < 10U; i++) {
+        set_byte_bits(block, i * 8U, (uint8_t)text[i], 8U);
+    }
+    append_type2_crc16(block, 12);
+}
+
+static void
+build_udt_bcd_block(uint8_t block[12], const uint8_t* digits, size_t count) {
+    DSD_MEMSET(block, 0, 12);
+    for (size_t i = 0; i < count && i < 20U; i++) {
+        set_byte_bits(block, i * 4U, digits[i] & 0x0FU, 4U);
+    }
+    append_type2_crc16(block, 12);
+}
+
+static void
+build_udt_utf16_block(uint8_t block[12], const uint16_t* chars, size_t count) {
+    DSD_MEMSET(block, 0, 12);
+    for (size_t i = 0; i < count && i < 5U; i++) {
+        set_byte_bits(block, i * 16U, chars[i], 16U);
+    }
+    append_type2_crc16(block, 12);
+}
+
+static void
+build_udt_mixed_utf16_block(uint8_t block[12], uint32_t address, const uint16_t* chars, size_t count) {
+    DSD_MEMSET(block, 0, 12);
+    set_byte_bits(block, 8U, address & 0x00FFFFFFU, 24U);
+    for (size_t i = 0; i < count && i < 3U; i++) {
+        set_byte_bits(block, 32U + (i * 16U), chars[i], 16U);
+    }
+    append_type2_crc16(block, 12);
+}
+
+static void
+build_udt_ip4_block(uint8_t block[12], uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+    DSD_MEMSET(block, 0, 12);
+    set_byte_bits(block, 0U, a, 8U);
+    set_byte_bits(block, 8U, b, 8U);
+    set_byte_bits(block, 16U, c, 8U);
+    set_byte_bits(block, 24U, d, 8U);
+    append_type2_crc16(block, 12);
+}
+
+static void
+build_udt_flag_block(uint8_t block[12], uint8_t encrypted) {
+    DSD_MEMSET(block, 0, 12);
+    set_byte_bits(block, 0U, encrypted & 1U, 1U);
+    append_type2_crc16(block, 12);
+}
+
+static void
+build_udt_binary_block(uint8_t block[12], const uint8_t* bytes, size_t count) {
+    DSD_MEMSET(block, 0, 12);
+    size_t copy = count < 10U ? count : 10U;
+    if (copy > 0U) {
+        DSD_MEMCPY(block, bytes, copy);
+    }
+    append_type2_crc16(block, 12);
+}
+
+static void
+build_udt_appended_addressing_block(uint8_t block[12], uint8_t res, uint8_t ok, uint32_t address) {
+    DSD_MEMSET(block, 0, 12);
+    set_byte_bits(block, 0U, res & 0x7FU, 7U);
+    set_byte_bits(block, 7U, ok & 1U, 1U);
+    set_byte_bits(block, 8U, address & 0x00FFFFFFU, 24U);
+    append_type2_crc16(block, 12);
 }
 
 static void
@@ -307,6 +464,31 @@ append_type1_crc32(uint8_t* bytes, size_t count) {
 }
 
 static void
+reset_datacall_spy(void) {
+    g_decode_ip_calls = 0;
+    g_decode_ip_last_len = 0;
+    g_decode_ip_first_byte = 0;
+    g_sd_pdu_calls = 0;
+    g_sd_pdu_last_len = 0;
+    g_sd_pdu_first_byte = 0;
+    g_udp_comp_calls = 0;
+    g_udp_comp_last_len = 0;
+    g_udp_comp_first_byte = 0;
+    g_datacall_calls = 0;
+    g_datacall_last_src = 0;
+    g_datacall_last_dst = 0;
+    g_datacall_last_slot = 0;
+    DSD_MEMSET(g_datacall_last_text, 0, sizeof(g_datacall_last_text));
+    g_lip_calls = 0;
+    g_nmea_calls = 0;
+    g_nmea_last_src = 0;
+    g_nmea_last_type = 0;
+    g_utf8_calls = 0;
+    g_utf8_last_len = 0;
+    g_utf8_first_byte = 0;
+}
+
+static void
 test_reset_blocks_restores_integer_defaults(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -332,6 +514,179 @@ test_reset_blocks_restores_integer_defaults(void) {
     assert(state.data_header_format[1] == 7);
     assert(state.data_dbsn_have[0] == 0);
     assert(state.data_dbsn_expected[0] == 0);
+}
+
+static void
+test_udt_iso7_single_block_dispatches_text_event(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    uint8_t dheader[12];
+    uint8_t bits[196];
+    uint8_t block[12];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+    state.event_history_s = history;
+    state.currentslot = 0;
+    opts.aggressive_framesync = 1;
+    build_udt_header(dheader, bits, 0x03U, 0x000111U, 0x000222U);
+    build_udt_iso7_block(block, "HELLO");
+    reset_datacall_spy();
+
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
+    assert(state.data_header_format[0] == 0);
+    assert(state.data_header_blocks[0] == 1);
+    assert(state.data_header_valid[0] == 1);
+    assert(state.data_block_counter[0] == 1);
+    state.data_block_crc_valid[0][0] = 1;
+
+    dmr_block_assembler(&opts, &state, block, (uint8_t)sizeof(block), 0x0BU, 3U);
+
+    assert(g_datacall_calls == 1U);
+    assert(g_datacall_last_src == 0x000222U);
+    assert(g_datacall_last_dst == 0x000111U);
+    assert(g_datacall_last_slot == 0U);
+    assert(strstr(g_datacall_last_text, "ISO7 Text") != NULL);
+    assert(strstr(state.event_history_s[0].Event_History_Items[0].text_message, "HELLO") != NULL);
+    assert(state.lastsrc == 0);
+    assert(state.lasttg == 0);
+    assert(state.data_header_valid[0] == 0);
+    assert(state.data_header_format[0] == 7);
+}
+
+static void
+run_udt_single_block_on_slot(uint8_t format, const uint8_t block[12], uint8_t slot, dsd_state* state_out) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    uint8_t dheader[12];
+    uint8_t bits[196];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+    state.event_history_s = history;
+    state.currentslot = slot & 1U;
+    opts.aggressive_framesync = 1;
+    build_udt_header(dheader, bits, format, 0x000111U, 0x000222U);
+    reset_datacall_spy();
+
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
+    assert(state.data_header_valid[state.currentslot] == 1);
+    assert(state.data_block_counter[state.currentslot] == 1);
+    state.data_block_crc_valid[state.currentslot][0] = 1;
+
+    uint8_t mutable_block[12];
+    DSD_MEMCPY(mutable_block, block, sizeof(mutable_block));
+    dmr_block_assembler(&opts, &state, mutable_block, (uint8_t)sizeof(mutable_block), 0x0BU, 3U);
+
+    if (state_out != NULL) {
+        DSD_MEMCPY(state_out, &state, sizeof(*state_out));
+    }
+}
+
+static void
+run_udt_single_block(uint8_t format, const uint8_t block[12], dsd_state* state_out) {
+    run_udt_single_block_on_slot(format, block, 0U, state_out);
+}
+
+static void
+test_udt_text_and_dispatch_formats(void) {
+    uint8_t block[12];
+    uint8_t bcd[] = {1, 2, 10, 11, 15, 12};
+    uint16_t utf16_chars[] = {'O', 'K', 0x263A};
+    uint16_t mixed_chars[] = {'G', 'O'};
+    static dsd_state state_copy;
+
+    build_udt_iso8_block(block, "WORLD");
+    run_udt_single_block(0x04U, block, &state_copy);
+    assert(g_datacall_calls == 1U);
+    assert(strstr(g_datacall_last_text, "ISO8 Text") != NULL);
+    assert(strstr(state_copy.event_history_s[0].Event_History_Items[0].text_message, "WORLD") != NULL);
+
+    build_udt_bcd_block(block, bcd, sizeof(bcd));
+    run_udt_single_block(0x02U, block, &state_copy);
+    assert(g_datacall_calls == 1U);
+    assert(strstr(g_datacall_last_text, "Dialer Digits") != NULL);
+    assert(strstr(state_copy.event_history_s[0].Event_History_Items[0].text_message, "12*# ") != NULL);
+
+    build_udt_utf16_block(block, utf16_chars, sizeof(utf16_chars) / sizeof(utf16_chars[0]));
+    run_udt_single_block(0x07U, block, &state_copy);
+    assert(g_datacall_calls == 1U);
+    assert(strstr(g_datacall_last_text, "UTF16 Text") != NULL);
+    assert(strstr(state_copy.event_history_s[0].Event_History_Items[0].text_message, "OK") != NULL);
+
+    build_udt_mixed_utf16_block(block, 0x00ABCDEFU, mixed_chars, sizeof(mixed_chars) / sizeof(mixed_chars[0]));
+    run_udt_single_block(0x0AU, block, &state_copy);
+    assert(g_datacall_calls == 1U);
+    assert(strstr(g_datacall_last_text, "Mixed Add/Text") != NULL);
+    assert(strstr(state_copy.event_history_s[0].Event_History_Items[0].text_message, "Address: 11259375;GO") != NULL);
+
+    build_udt_ip4_block(block, 192U, 168U, 1U, 55U);
+    run_udt_single_block(0x06U, block, &state_copy);
+    assert(g_datacall_calls == 1U);
+    assert(strstr(g_datacall_last_text, "IP4") != NULL);
+
+    build_udt_flag_block(block, 0U);
+    run_udt_single_block(0x05U, block, NULL);
+    assert(g_nmea_calls == 1U);
+    assert(g_nmea_last_src == 0x000222U);
+    assert(g_nmea_last_type == 1);
+    assert(strstr(g_datacall_last_text, "NMEA") != NULL);
+
+    build_udt_flag_block(block, 0U);
+    run_udt_single_block(0x0BU, block, NULL);
+    assert(g_lip_calls == 1U);
+    assert(strstr(g_datacall_last_text, "LIP") != NULL);
+}
+
+static void
+test_udt_binary_addressing_reserved_and_slot1_paths(void) {
+    uint8_t block[12];
+    static dsd_state state_copy;
+    const uint8_t binary_payload[] = {'B', 'I', 'N', 0x00};
+
+    build_udt_binary_block(block, binary_payload, sizeof(binary_payload));
+    run_udt_single_block(0x00U, block, NULL);
+    assert(g_datacall_calls == 1U);
+    assert(g_utf8_calls == 1U);
+    assert(g_utf8_last_len == 10U);
+    assert(g_utf8_first_byte == 'B');
+    assert(strstr(g_datacall_last_text, "Binary Data") != NULL);
+
+    build_udt_appended_addressing_block(block, 3U, 1U, 0x00C0FFEEU);
+    run_udt_single_block(0x01U, block, NULL);
+    assert(g_datacall_calls == 1U);
+    assert(g_utf8_calls == 0U);
+    assert(g_nmea_calls == 0U);
+    assert(g_lip_calls == 0U);
+    assert(strstr(g_datacall_last_text, "Appended Addressing") != NULL);
+
+    build_udt_flag_block(block, 1U);
+    run_udt_single_block(0x05U, block, NULL);
+    assert(g_datacall_calls == 1U);
+    assert(g_nmea_calls == 0U);
+    assert(strstr(g_datacall_last_text, "NMEA") != NULL);
+
+    build_udt_flag_block(block, 0U);
+    run_udt_single_block(0x08U, block, NULL);
+    assert(g_datacall_calls == 1U);
+    assert(strstr(g_datacall_last_text, "MFID Specific") != NULL);
+
+    build_udt_flag_block(block, 0U);
+    run_udt_single_block(0x0CU, block, NULL);
+    assert(g_datacall_calls == 1U);
+    assert(strstr(g_datacall_last_text, "Reserved") != NULL);
+
+    build_udt_iso8_block(block, "SLOT1");
+    run_udt_single_block_on_slot(0x04U, block, 1U, &state_copy);
+    assert(g_datacall_calls == 1U);
+    assert(g_datacall_last_slot == 1U);
+    assert(state_copy.lastsrcR == 0);
+    assert(state_copy.lasttgR == 0);
+    assert(strstr(state_copy.event_history_s[1].Event_History_Items[0].text_message, "SLOT1") != NULL);
 }
 
 static void
@@ -362,6 +717,107 @@ test_crc_valid_type1_pdu_dispatches_in_strict_mode(void) {
     assert(g_decode_ip_calls == 1U);
     assert(g_decode_ip_last_len == 20U);
     assert(g_decode_ip_first_byte == 0x45U);
+}
+
+static void
+run_type1_pdu_for_sap(uint8_t sap, const uint8_t block[12]) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.aggressive_framesync = 1;
+    state.currentslot = 0;
+    state.data_header_valid[0] = 1;
+    state.data_header_blocks[0] = 1;
+    state.data_header_format[0] = 2;
+    state.data_header_sap[0] = sap;
+    state.data_block_counter[0] = 1;
+    reset_datacall_spy();
+
+    uint8_t mutable_block[12];
+    DSD_MEMCPY(mutable_block, block, sizeof(mutable_block));
+    dmr_block_assembler(&opts, &state, mutable_block, (uint8_t)sizeof(mutable_block), 0, 1);
+}
+
+static void
+test_crc_valid_type1_pdu_dispatches_short_data_and_udp_saps(void) {
+    uint8_t block[12] = {0x83, 0x10, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0, 0, 0, 0};
+    append_type1_crc32(block, sizeof(block));
+
+    run_type1_pdu_for_sap(10U, block);
+    assert(g_sd_pdu_calls == 1U);
+    assert(g_sd_pdu_last_len == 20U);
+    assert(g_sd_pdu_first_byte == 0x83U);
+    assert(g_decode_ip_calls == 0U);
+    assert(g_udp_comp_calls == 0U);
+
+    run_type1_pdu_for_sap(2U, block);
+    assert(g_udp_comp_calls == 1U);
+    assert(g_udp_comp_last_len == 20U);
+    assert(g_udp_comp_first_byte == 0x83U);
+    assert(g_decode_ip_calls == 0U);
+    assert(g_sd_pdu_calls == 0U);
+
+    run_type1_pdu_for_sap(3U, block);
+    assert(g_udp_comp_calls == 1U);
+    assert(g_udp_comp_last_len == 20U);
+    assert(g_udp_comp_first_byte == 0x83U);
+    assert(g_decode_ip_calls == 0U);
+    assert(g_sd_pdu_calls == 0U);
+}
+
+static void
+test_type1_encrypted_notice_reports_missing_key(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t block[12] = {0x45, 0x00, 0x00, 0x14, 0x12, 0x34, 0x00, 0x00, 0, 0, 0, 0};
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    append_type1_crc32(block, sizeof(block));
+    opts.aggressive_framesync = 1;
+    state.currentslot = 0;
+    state.data_header_valid[0] = 1;
+    state.data_header_blocks[0] = 1;
+    state.data_header_format[0] = 2;
+    state.data_header_sap[0] = 4;
+    state.data_block_counter[0] = 1;
+    state.dmr_lrrp_source[0] = 0x1234U;
+    state.dmr_lrrp_target[0] = 0x5678U;
+    state.dmr_so = 0x100;
+    state.payload_algid = 4;
+    state.payload_keyid = 0x42;
+    reset_datacall_spy();
+
+    dmr_block_assembler(&opts, &state, block, (uint8_t)sizeof(block), 0, 1);
+
+    assert(g_decode_ip_calls == 0U);
+    assert(g_datacall_calls == 1U);
+    assert(g_datacall_last_src == 0x1234U);
+    assert(g_datacall_last_dst == 0x5678U);
+    assert(strstr(g_datacall_last_text, "ENC PDU") != NULL);
+    assert(strstr(state.dmr_lrrp_gps[0], "ENC PDU") != NULL);
+}
+
+static void
+test_type2_rejects_out_of_bounds_aggregate_length(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t block[12] = {0x80, 0x01, 0x02, 0x03};
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    state.data_header_valid[0] = 1;
+    state.data_block_counter[0] = 9;
+    state.data_block_crc_valid[0][0] = 1;
+
+    dmr_block_assembler(&opts, &state, block, (uint8_t)sizeof(block), 0, 2);
+
+    assert(state.data_block_counter[0] == 4);
+    assert(state.data_block_crc_valid[0][0] == 0);
+    assert(state.data_header_valid[0] == 1);
 }
 
 static int
@@ -417,13 +873,171 @@ test_data_header_prints_fsn_and_final_flag(void) {
     return rc;
 }
 
+static void
+test_irrecoverable_header_resets_data_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t dheader[12];
+    uint8_t bits[196];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(dheader, 0, sizeof(dheader));
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    state.currentslot = 1;
+    state.data_header_valid[1] = 1;
+    state.data_p_head[1] = 1;
+    state.data_conf_data[1] = 1;
+    state.data_block_counter[1] = 9;
+    state.data_header_blocks[1] = 9;
+    state.data_header_format[1] = 2;
+    DSD_SNPRINTF(state.dmr_lrrp_gps[1], sizeof(state.dmr_lrrp_gps[1]), "%s", "stale gps");
+
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/0, /*IrrecoverableErrors=*/1);
+
+    assert(state.data_header_valid[1] == 0);
+    assert(state.data_p_head[1] == 0);
+    assert(state.data_conf_data[1] == 0);
+    assert(state.data_block_counter[1] == 1);
+    assert(state.data_header_blocks[1] == 1);
+    assert(state.data_header_format[1] == 7);
+    assert(strcmp(state.dmr_lrrp_gps[1], "") == 0);
+}
+
+static int
+test_response_header_reports_nack_reason(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t dheader[12];
+    uint8_t bits[196];
+    char output[2048];
+    dsd_test_capture_stderr cap;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(dheader, 0, sizeof(dheader));
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    state.currentslot = 0;
+    opts.aggressive_framesync = 1;
+    set_bits(bits, 4, 1U, 4); // DPF=1, response packet
+    set_bits(bits, 8, 4U, 4); // SAP=4, IP based
+    set_bits(bits, 16, 0x000123U, 24);
+    set_bits(bits, 40, 0x000456U, 24);
+    set_bits(bits, 72, 1U, 2); // NACK class
+    set_bits(bits, 74, 3U, 3); // memory full
+
+    if (dsd_test_capture_stderr_begin(&cap, "dmr_header_response_nack") != 0) {
+        return 1;
+    }
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
+    if (dsd_test_capture_stderr_end(&cap) != 0 || read_file_to_buffer(cap.path, output, sizeof(output)) != 0) {
+        (void)remove(cap.path);
+        return 1;
+    }
+    (void)remove(cap.path);
+
+    assert(state.data_header_format[0] == 1);
+    assert(state.data_header_valid[0] == 1);
+    assert(strcmp(state.dmr_lrrp_gps[0], "") == 0);
+    return expect_contains("response-nack", output, "NACK - Memory Full");
+}
+
+static void
+test_short_data_defined_sets_blocks_and_confirmed_flag(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t dheader[12];
+    uint8_t bits[196];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(dheader, 0, sizeof(dheader));
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    state.currentslot = 0;
+    opts.aggressive_framesync = 1;
+    set_bits(bits, 1, 1U, 1);  // response requested
+    set_bits(bits, 2, 1U, 2);  // S_AB high bits
+    set_bits(bits, 4, 13U, 4); // DPF=13, short data defined
+    set_bits(bits, 8, 10U, 4); // SAP=short data
+    set_bits(bits, 12, 1U, 4); // S_AB low bits: total blocks 5
+    set_bits(bits, 16, 0x010203U, 24);
+    set_bits(bits, 40, 0x040506U, 24);
+    set_bits(bits, 64, 18U, 6); // DD format UTF-8
+    set_bits(bits, 72, 7U, 8);  // pad bits
+
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
+
+    assert(state.data_header_format[0] == 13);
+    assert(state.data_header_sap[0] == 10);
+    assert(state.data_header_blocks[0] == 5);
+    assert(state.data_conf_data[0] == 1);
+    assert(strstr(state.dmr_lrrp_gps[0], "Short DT") != NULL);
+    assert(strstr(state.dmr_lrrp_gps[0], "- RSP REQ") != NULL);
+}
+
+static void
+test_motorola_encryption_header_updates_payload_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t dheader[12];
+    uint8_t bits[196];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(dheader, 0, sizeof(dheader));
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    state.currentslot = 0;
+    state.data_ks_start[0] = 3;
+    set_bits(bits, 0, 2U, 4);            // p_sap != 1
+    set_bits(bits, 4, 15U, 4);           // DPF=15, proprietary
+    set_bits(bits, 8, 0x10U, 8);         // Motorola MFID
+    set_bits(bits, 17, 4U, 3);           // AES128
+    set_bits(bits, 20, 1U, 4);           // encrypted
+    set_bits(bits, 24, 0x42U, 8);        // key id
+    set_bits(bits, 48, 0x11223344U, 32); // MI(32)
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
+    assert(state.dmr_so == 0x100);
+    assert(state.payload_algid == 4);
+    assert(state.payload_keyid == 0x42);
+    assert((uint32_t)state.payload_mi == 0x11223344U);
+    assert(state.data_ks_start[0] == 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    state.currentslot = 1;
+    state.data_ks_start[1] = 3;
+    set_bits(bits, 0, 2U, 4);
+    set_bits(bits, 4, 15U, 4);
+    set_bits(bits, 8, 0x10U, 8);
+    set_bits(bits, 17, 5U, 3); // AES256
+    set_bits(bits, 20, 1U, 4);
+    set_bits(bits, 24, 0x24U, 8);
+    set_bits(bits, 48, 0x55667788U, 32);
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
+    assert(state.dmr_soR == 0x100);
+    assert(state.payload_algidR == 5);
+    assert(state.payload_keyidR == 0x24);
+    assert((uint32_t)state.payload_miR == 0x55667788U);
+    assert(state.data_ks_start[1] == 0);
+}
+
 int
 main(int argc, char** argv) {
     (void)argc;
     (void)argv;
     test_reset_blocks_restores_integer_defaults();
+    test_udt_iso7_single_block_dispatches_text_event();
+    test_udt_text_and_dispatch_formats();
+    test_udt_binary_addressing_reserved_and_slot1_paths();
     test_crc_valid_type1_pdu_dispatches_in_strict_mode();
+    test_crc_valid_type1_pdu_dispatches_short_data_and_udp_saps();
+    test_type1_encrypted_notice_reports_missing_key();
+    test_type2_rejects_out_of_bounds_aggregate_length();
     int rc = test_data_header_prints_fsn_and_final_flag();
+    test_irrecoverable_header_resets_data_state();
+    rc |= test_response_header_reports_nack_reason();
+    test_short_data_defined_sets_blocks_and_confirmed_flag();
+    test_motorola_encryption_header_updates_payload_state();
 
     static dsd_opts opts;
     static dsd_state state;

--- a/tests/protocol/dmr/test_dmr_t3_sm_return_to_cc_matrix.c
+++ b/tests/protocol/dmr/test_dmr_t3_sm_return_to_cc_matrix.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(clang-analyzer-optin.core.EnumCastOutOfRange)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -15,7 +18,10 @@
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -147,6 +153,11 @@ dmr_hook_return_to_cc(dsd_opts* opts, dsd_state* state) {
     return dmr_pop_result(g_hooks.return_results, g_hooks.return_count, &g_hooks.return_pos);
 }
 
+static void*
+dmr_hook_scan_ctx(void) {
+    return &g_ctx;
+}
+
 static void
 dmr_install_hooks(void) {
     dsd_trunk_tuning_hooks hooks = {0};
@@ -167,6 +178,16 @@ dmr_expect(int cond, const char* grant, const char* flow, const char* script, co
     }
     DSD_FPRINTF(stderr, "FAIL grant=%s flow=%s script=%s check=%s\n", grant, flow, script, check);
     return 1;
+}
+
+static int
+dmr_expect_close(double actual, double expected, double tolerance, const char* grant, const char* flow,
+                 const char* script, const char* check) {
+    double delta = actual - expected;
+    if (delta < 0.0) {
+        delta = -delta;
+    }
+    return dmr_expect(delta <= tolerance, grant, flow, script, check);
 }
 
 static void
@@ -190,6 +211,13 @@ dmr_setup_fixture(const dmr_grant_case* grant) {
     g_ctx.hangtime_s = 0.1;
     g_ctx.grant_timeout_s = 0.1;
     g_ctx.cc_grace_s = 0.1;
+}
+
+static void
+dmr_setup_blank_fixture(void) {
+    DSD_MEMSET(&g_opts, 0, sizeof(g_opts));
+    DSD_MEMSET(&g_state, 0, sizeof(g_state));
+    DSD_MEMSET(&g_ctx, 0, sizeof(g_ctx));
 }
 
 static void
@@ -581,6 +609,199 @@ dmr_run_cc_loss_reacquire_case(void) {
     return rc;
 }
 
+static int
+dmr_run_state_name_and_guard_case(void) {
+    const char* grant = "api";
+    const char* flow = "guards";
+    const char* script = "no-op";
+    dmr_setup_blank_fixture();
+
+    int rc = 0;
+    rc |= dmr_expect(dmr_sm_state_name(DMR_SM_IDLE)[0] == 'I', grant, flow, script, "idle state name");
+    rc |= dmr_expect(dmr_sm_state_name(DMR_SM_ON_CC)[0] == 'O', grant, flow, script, "on-cc state name");
+    rc |= dmr_expect(dmr_sm_state_name(DMR_SM_TUNED)[0] == 'T', grant, flow, script, "tuned state name");
+    rc |= dmr_expect(dmr_sm_state_name(DMR_SM_HUNTING)[0] == 'H', grant, flow, script, "hunting state name");
+    rc |= dmr_expect(dmr_sm_state_name((dmr_sm_state_e)99)[0] == '?', grant, flow, script, "unknown state name");
+
+    dmr_sm_init_ctx(NULL, &g_opts, &g_state);
+    dmr_sm_event(NULL, &g_opts, &g_state, &(dmr_sm_event_t){.type = DMR_SM_EV_CC_SYNC});
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, NULL);
+    dmr_sm_tick_ctx(NULL, &g_opts, &g_state);
+    dmr_sm_on_neighbor_update(&g_opts, NULL, (const long[]){851012500L}, 1);
+    dmr_sm_on_neighbor_update(&g_opts, &g_state, NULL, 1);
+    dmr_sm_on_neighbor_update(&g_opts, &g_state, (const long[]){851012500L}, 0);
+    rc |= dmr_expect(g_ctx.initialized == 0 && g_ctx.state == DMR_SM_IDLE, grant, flow, script,
+                     "guard no-ops preserved blank context");
+    return rc;
+}
+
+static int
+dmr_run_auto_init_and_idle_hunting_case(void) {
+    const char* grant = "api";
+    const char* flow = "auto-init";
+    const char* script = "sync";
+    dmr_setup_blank_fixture();
+    dmr_install_hooks();
+
+    int rc = 0;
+    dmr_sm_event_t ev = {.type = DMR_SM_EV_SYNC_LOST};
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+    rc |= dmr_expect(g_ctx.initialized == 1 && g_ctx.state == DMR_SM_IDLE, grant, flow, script,
+                     "sync-lost auto-inits idle context");
+
+    dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+    rc |= dmr_expect(g_ctx.state == DMR_SM_IDLE, grant, flow, script, "idle tick is stable");
+
+    g_ctx.state = DMR_SM_HUNTING;
+    dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+    rc |= dmr_expect(g_ctx.state == DMR_SM_HUNTING, grant, flow, script, "hunting tick is stable");
+
+    ev = dmr_sm_ev_cc_sync();
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+    rc |= dmr_expect(g_ctx.state == DMR_SM_ON_CC && g_ctx.t_cc_sync_m > 0.0, grant, flow, script,
+                     "cc sync reacquires from hunting");
+
+    g_ctx.t_cc_sync_m = 0.0;
+    dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+    rc |= dmr_expect(g_ctx.state == DMR_SM_ON_CC, grant, flow, script, "on-cc tick without timestamp is stable");
+    return rc;
+}
+
+static int
+dmr_run_rejected_grant_contracts(void) {
+    const char* flow = "rejected-grants";
+    const char* script = "no-tune";
+    dmr_grant_case grant = {"explicit-disabled", 852012500L, 0, 0, 0};
+    dmr_reset_hooks();
+    dmr_install_hooks();
+    dmr_setup_fixture(&grant);
+
+    g_opts.trunk_enable = 0;
+    dmr_sm_event_t ev = dmr_sm_ev_group_grant(grant.freq_hz, 0, 1201, 7201);
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+
+    int rc = 0;
+    rc |= dmr_expect(g_hooks.tune_calls == 0, grant.name, flow, script, "disabled trunking did not tune");
+    rc |= dmr_expect(g_ctx.state == DMR_SM_ON_CC && g_opts.trunk_is_tuned == 0, grant.name, flow, script,
+                     "disabled trunking stayed on control channel");
+
+    g_opts.trunk_enable = 1;
+    g_state.trunk_cc_freq = 0;
+    ev = dmr_sm_ev_group_grant(grant.freq_hz, 0, 1202, 7202);
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+    rc |= dmr_expect(g_hooks.tune_calls == 0, grant.name, flow, script, "missing control channel did not tune");
+
+    g_state.trunk_cc_freq = 851012500L;
+    ev = dmr_sm_ev_group_grant(0, 0, 1203, 7203);
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+    rc |= dmr_expect(g_hooks.tune_calls == 0, grant.name, flow, script, "unresolved grant did not tune");
+    rc |= dmr_expect(g_state.p25_sm_tune_count == 0 && g_ctx.vc_freq_hz == 0, grant.name, flow, script,
+                     "rejected grants preserved voice-channel state");
+    return rc;
+}
+
+static int
+dmr_run_data_sync_and_stale_slot_case(void) {
+    const char* flow = "data-sync";
+    const char* script = "slot-normalize";
+    dmr_grant_case grant = {"explicit-frequency", 852012500L, 0, 0, 0};
+    dmr_reset_hooks();
+    g_hooks.tune_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.tune_count = 1;
+    g_hooks.return_results[0] = DSD_TRUNK_TUNE_RESULT_OK;
+    g_hooks.return_count = 1;
+    dmr_install_hooks();
+    dmr_setup_fixture(&grant);
+
+    int rc = dmr_send_initial_grant(&grant, 0, flow, script);
+    if (rc != 0) {
+        return rc;
+    }
+
+    dmr_sm_event_t ev = dmr_sm_ev_data_sync(7);
+    dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
+    rc |= dmr_expect(g_ctx.slots[0].last_active_m > 0.0 && g_ctx.slots[1].last_active_m == 0.0, grant.name, flow,
+                     script, "invalid data slot normalized to slot zero");
+    rc |= dmr_expect(g_ctx.t_voice_m > 0.0 && g_state.last_vc_sync_time_m == g_ctx.t_voice_m, grant.name, flow, script,
+                     "data sync arms hangtime timestamp");
+
+    double stale_m = dsd_time_now_monotonic_s() - 1.0;
+    g_ctx.t_tune_m = 0.0;
+    g_ctx.t_voice_m = 0.0;
+    g_ctx.slots[0].voice_active = 1;
+    g_ctx.slots[0].last_active_m = stale_m;
+    dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);
+    rc |= dmr_expect(g_ctx.slots[0].voice_active == 0 && g_ctx.state == DMR_SM_TUNED, grant.name, flow, script,
+                     "stale voice slot clears without grant timeout");
+
+    double before = g_ctx.t_voice_m;
+    ev = dmr_sm_ev_data_sync(0);
+    dmr_sm_event(&g_ctx, NULL, &g_state, &ev);
+    rc |= dmr_expect(g_ctx.t_voice_m == before, grant.name, flow, script, "data sync without opts is ignored");
+    return rc;
+}
+
+static int
+dmr_run_global_emit_and_scan_hook_case(void) {
+    const char* grant = "global";
+    const char* flow = "emit";
+    const char* script = "scan-hook";
+    dmr_setup_blank_fixture();
+    dmr_install_hooks();
+    g_opts.trunk_enable = 1;
+    g_opts.trunk_tune_data_calls = 1;
+    g_state.trunk_cc_freq = 851012500L;
+    dmr_sm_init_ctx(&g_ctx, &g_opts, &g_state);
+
+    dsd_trunk_scan_hooks hooks = {0};
+    hooks.dmr_ctx = dmr_hook_scan_ctx;
+    dsd_trunk_scan_hooks_set(hooks);
+
+    int rc = 0;
+    rc |= dmr_expect(dmr_sm_get_ctx() == &g_ctx, grant, flow, script, "scan hook supplies DMR context");
+
+    dmr_sm_event_t ev = dmr_sm_ev_cc_sync();
+    dmr_sm_emit(&g_opts, &g_state, &ev);
+    rc |= dmr_expect(g_ctx.state == DMR_SM_ON_CC && g_ctx.t_cc_sync_m > 0.0, grant, flow, script,
+                     "generic emit delivered cc sync");
+
+    dmr_sm_emit_data_sync(&g_opts, &g_state, 1);
+    rc |= dmr_expect(g_ctx.slots[1].last_active_m > 0.0, grant, flow, script, "global data-sync emit delivered slot");
+
+    g_ctx.state = DMR_SM_HUNTING;
+    dmr_sm_emit_cc_sync(&g_opts, &g_state);
+    rc |= dmr_expect(g_ctx.state == DMR_SM_ON_CC, grant, flow, script, "global cc-sync emit reacquires");
+
+    dsd_trunk_scan_hooks_set((dsd_trunk_scan_hooks){0});
+    return rc;
+}
+
+static int
+dmr_run_config_override_case(void) {
+    const char* grant = "config";
+    const char* flow = "override";
+    const char* script = "env";
+    dmr_setup_blank_fixture();
+    g_opts.trunk_hangtime = 0.25f;
+    g_state.trunk_cc_freq = 851012500L;
+
+    int rc = 0;
+    rc |= dmr_expect(dsd_setenv("DSD_NEO_DMR_HANGTIME", "1.25", 1) == 0, grant, flow, script, "set hangtime env");
+    rc |= dmr_expect(dsd_setenv("DSD_NEO_DMR_GRANT_TIMEOUT", "6.5", 1) == 0, grant, flow, script,
+                     "set grant-timeout env");
+    dsd_neo_config_init(NULL);
+    dmr_sm_init_ctx(&g_ctx, &g_opts, &g_state);
+    rc |= dmr_expect_close(g_ctx.hangtime_s, 1.25, 1e-9, grant, flow, script, "config hangtime overrides opts");
+    rc |= dmr_expect_close(g_ctx.grant_timeout_s, 6.5, 1e-9, grant, flow, script,
+                           "config grant timeout overrides default");
+    rc |= dmr_expect(g_ctx.state == DMR_SM_ON_CC, grant, flow, script, "config fixture starts on control channel");
+
+    dsd_unsetenv("DSD_NEO_DMR_HANGTIME");
+    dsd_unsetenv("DSD_NEO_DMR_GRANT_TIMEOUT");
+    dsd_neo_config_init(NULL);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -614,8 +835,15 @@ main(void) {
 
     rc |= dmr_run_untrusted_off_cc_reject_case();
     rc |= dmr_run_cc_loss_reacquire_case();
+    rc |= dmr_run_state_name_and_guard_case();
+    rc |= dmr_run_auto_init_and_idle_hunting_case();
+    rc |= dmr_run_rejected_grant_contracts();
+    rc |= dmr_run_data_sync_and_stale_slot_case();
+    rc |= dmr_run_global_emit_and_scan_hook_case();
+    rc |= dmr_run_config_override_case();
 
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    dsd_trunk_scan_hooks_set((dsd_trunk_scan_hooks){0});
     if (rc == 0) {
         printf("DMR_T3_SM_RETURN_TO_CC_MATRIX: OK\n");
     }
@@ -625,3 +853,4 @@ main(void) {
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic pop
 #endif
+// NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange)

--- a/tests/protocol/dmr/test_dmr_talker_alias_header_len.c
+++ b/tests/protocol/dmr/test_dmr_talker_alias_header_len.c
@@ -21,6 +21,8 @@
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #endif
 
+static int g_unicode_supported;
+
 // Minimal stubs needed to link `src/core/util/dsd_alias.c` in isolation.
 uint16_t
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -46,7 +48,7 @@ ConvertBitIntoBytes(const uint8_t* BufferIn, uint32_t BitLength) {
 int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_unicode_supported(void) {
-    return 0;
+    return g_unicode_supported;
 }
 
 void
@@ -73,6 +75,18 @@ bytes_to_bits_msb(uint8_t* bits_out, size_t bits_out_sz, const uint8_t* in, size
     }
 }
 
+static void
+value_to_bits_msb(uint8_t* bits_out, size_t bit_offset, size_t bits_out_sz, uint32_t value, uint8_t bit_count) {
+    if (bit_offset + bit_count > bits_out_sz) {
+        DSD_FPRINTF(stderr, "value_to_bits_msb: need=%zu have=%zu\n", bit_offset + bit_count, bits_out_sz);
+        exit(2);
+    }
+
+    for (uint8_t b = 0; b < bit_count; b++) {
+        bits_out[bit_offset + b] = (uint8_t)((value >> (bit_count - 1u - b)) & 1u);
+    }
+}
+
 static int
 expect_has_substr(const char* buf, const char* needle, const char* tag) {
     if (!buf || !strstr(buf, needle)) {
@@ -80,6 +94,336 @@ expect_has_substr(const char* buf, const char* needle, const char* tag) {
         return 1;
     }
     return 0;
+}
+
+static int
+expect_str(const char* got, const char* want, const char* tag) {
+    if (!got || strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got ? got : "(null)", want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u8(uint8_t got, uint8_t want, const char* tag) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got 0x%02X want 0x%02X\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_policy_name(const dsd_state* st, uint32_t id, const char* want, const char* tag) {
+    dsd_tg_policy_lookup lookup;
+    if (dsd_tg_policy_lookup_id(st, id, &lookup) != 0 || lookup.match != DSD_TG_POLICY_MATCH_EXACT
+        || strcmp(lookup.entry.name, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: missing policy id=%u name='%s'\n", tag, id, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_direct_dmr_alias_decoders(dsd_opts* opts, dsd_state* st) {
+    int rc = 0;
+
+    DSD_MEMSET(st->dmr_pdu_sf[0], 0, sizeof(st->dmr_pdu_sf[0]));
+    value_to_bits_msb(st->dmr_pdu_sf[0], 0, sizeof(st->dmr_pdu_sf[0]), 'K', 7);
+    value_to_bits_msb(st->dmr_pdu_sf[0], 7, sizeof(st->dmr_pdu_sf[0]), ',', 7);
+    value_to_bits_msb(st->dmr_pdu_sf[0], 14, sizeof(st->dmr_pdu_sf[0]), '7', 7);
+    st->lastsrc = 700001u;
+    st->event_history_s[0].Event_History_Items[0].source_id = st->lastsrc;
+    dmr_talker_alias_lc_decode(opts, st, 0, 0, 7, 3);
+    rc |= expect_str(st->generic_talker_alias[0], "Talker Alias: K,7; ", "iso7 generic alias");
+    rc |= expect_str(st->event_history_s[0].Event_History_Items[0].alias, "K,7; ", "iso7 event alias");
+    if (st->generic_talker_alias_src[0] != (uint32_t)st->lastsrc) {
+        DSD_FPRINTF(stderr, "iso7 generic alias source mismatch\n");
+        rc = 1;
+    }
+
+    DSD_MEMSET(st->dmr_pdu_sf[1], 0, sizeof(st->dmr_pdu_sf[1]));
+    value_to_bits_msb(st->dmr_pdu_sf[1], 0, sizeof(st->dmr_pdu_sf[1]), 'A', 16);
+    value_to_bits_msb(st->dmr_pdu_sf[1], 16, sizeof(st->dmr_pdu_sf[1]), 0, 16);
+    value_to_bits_msb(st->dmr_pdu_sf[1], 32, sizeof(st->dmr_pdu_sf[1]), 0x0100U, 16);
+    st->lastsrcR = 700002u;
+    st->event_history_s[1].Event_History_Items[0].source_id = st->lastsrcR;
+    dmr_talker_alias_lc_decode(opts, st, 1, 1, 16, 3);
+    rc |= expect_str(st->generic_talker_alias[1], "Talker Alias: A *; ", "utf16 generic alias");
+    rc |= expect_str(st->event_history_s[1].Event_History_Items[0].alias, "A *; ", "utf16 event alias");
+    if (st->generic_talker_alias_src[1] != (uint32_t)st->lastsrcR) {
+        DSD_FPRINTF(stderr, "utf16 generic alias source mismatch\n");
+        rc = 1;
+    }
+
+    return rc;
+}
+
+static int
+test_harris_l3h_alias_state(dsd_opts* opts, dsd_state* st) {
+    int rc = 0;
+    uint8_t input[12];
+    DSD_MEMSET(input, 0, sizeof input);
+    input[4] = 'B';
+    input[5] = 'O';
+    input[6] = 'B';
+    input[7] = ',';
+    input[8] = 0x01;
+
+    DSD_MEMSET(st->dmr_pdu_sf[0], 0xA5, sizeof(st->dmr_pdu_sf[0]));
+    st->lastsrc = 700003u;
+    st->lasttg = 42u;
+    st->event_history_s[0].Event_History_Items[0].source_id = st->lastsrc;
+
+    l3h_embedded_alias_decode(opts, st, 0, 8, input);
+
+    rc |= expect_str(st->event_history_s[0].Event_History_Items[0].alias, "BOB. ", "l3h event alias");
+    if (st->dmr_pdu_sf[0][0] != 0) {
+        DSD_FPRINTF(stderr, "l3h decode did not clear alias storage\n");
+        rc = 1;
+    }
+
+    rc |= expect_policy_name(st, st->lastsrc, "BOB. ", "l3h runtime alias policy");
+
+    DSD_MEMSET(input, 0, sizeof input);
+    input[4] = 'R';
+    input[5] = 'O';
+    input[6] = ',';
+    input[7] = 0x01;
+    input[8] = '2';
+
+    DSD_MEMSET(st->dmr_pdu_sf[1], 0xA5, sizeof(st->dmr_pdu_sf[1]));
+    st->lastsrcR = 700004u;
+    st->lasttgR = 43u;
+    st->event_history_s[1].Event_History_Items[0].source_id = st->lastsrcR;
+
+    l3h_embedded_alias_decode(opts, st, 1, 8, input);
+
+    rc |= expect_str(st->event_history_s[1].Event_History_Items[0].alias, "RO. 2", "l3h slot1 event alias");
+    rc |= expect_u8(st->dmr_pdu_sf[1][0], 0U, "l3h slot1 clears storage");
+    rc |= expect_policy_name(st, st->lastsrcR, "RO. 2", "l3h slot1 runtime alias policy");
+
+    return rc;
+}
+
+static int
+test_apx_alias_phase_storage(dsd_opts* opts, dsd_state* st) {
+    int rc = 0;
+    uint8_t header1[72];
+    uint8_t block1[72];
+    uint8_t header2[136];
+    uint8_t block2[144];
+
+    DSD_MEMSET(header1, 0, sizeof(header1));
+    value_to_bits_msb(header1, 0, sizeof(header1), 0x1590U, 16);
+    value_to_bits_msb(header1, 32, sizeof(header1), 2U, 8);
+    value_to_bits_msb(header1, 56, sizeof(header1), 0x0AU, 4);
+    DSD_MEMSET(st->dmr_pdu_sf[0], 0xA5, sizeof(st->dmr_pdu_sf[0]));
+    apx_embedded_alias_header_phase1(opts, st, 0, header1);
+    rc |= expect_u8(st->dmr_pdu_sf[0][0], header1[0], "apx-p1-header-copy-first");
+    rc |= expect_u8(st->dmr_pdu_sf[0][32], header1[32], "apx-p1-header-len-copy");
+    rc |= expect_u8(st->dmr_pdu_sf[0][71], header1[71], "apx-p1-header-copy-last");
+
+    DSD_MEMSET(block1, 0, sizeof(block1));
+    value_to_bits_msb(block1, 16, sizeof(block1), 0U, 8);
+    value_to_bits_msb(block1, 24, sizeof(block1), 0x0AU, 4);
+    for (size_t i = 28U; i < sizeof(block1); i++) {
+        block1[i] = (uint8_t)(i & 1U);
+    }
+    apx_embedded_alias_blocks_phase1(opts, st, 0, block1);
+    for (size_t i = 0U; i < 44U; i++) {
+        rc |= expect_u8(st->dmr_pdu_sf[0][72U + i], block1[28U + i], "apx-p1-block-copy");
+    }
+
+    DSD_MEMSET(st->dmr_pdu_sf[0], 0xA5, sizeof(st->dmr_pdu_sf[0]));
+    DSD_MEMSET(block1, 0, sizeof(block1));
+    apx_embedded_alias_blocks_phase1(opts, st, 0, block1);
+    rc |= expect_u8(st->dmr_pdu_sf[0][0], 0U, "apx-p1-missing-header-clears-first");
+    rc |= expect_u8(st->dmr_pdu_sf[0][120], 0U, "apx-p1-missing-header-clears-later");
+
+    DSD_MEMSET(header2, 0, sizeof(header2));
+    value_to_bits_msb(header2, 0, sizeof(header2), 0x9190U, 16);
+    value_to_bits_msb(header2, 40, sizeof(header2), 3U, 8);
+    value_to_bits_msb(header2, 56, sizeof(header2), 1U, 8);
+    value_to_bits_msb(header2, 64, sizeof(header2), 0x0BU, 4);
+    DSD_MEMSET(st->dmr_pdu_sf[1], 0xA5, sizeof(st->dmr_pdu_sf[1]));
+    apx_embedded_alias_header_phase2(opts, st, 1, header2);
+    rc |= expect_u8(st->dmr_pdu_sf[1][0], header2[0], "apx-p2-header-copy-first");
+    rc |= expect_u8(st->dmr_pdu_sf[1][32], header2[40], "apx-p2-header-len-repacked");
+    rc |= expect_u8(st->dmr_pdu_sf[1][56], header2[56], "apx-p2-header-tail-copy");
+
+    DSD_MEMSET(block2, 0, sizeof(block2));
+    value_to_bits_msb(block2, 24, sizeof(block2), 1U, 8);
+    value_to_bits_msb(block2, 32, sizeof(block2), 0x0BU, 4);
+    for (size_t i = 36U; i < 136U; i++) {
+        block2[i] = (uint8_t)((i + 1U) & 1U);
+    }
+    apx_embedded_alias_blocks_phase2(opts, st, 1, block2);
+    for (size_t i = 0U; i < 100U; i++) {
+        rc |= expect_u8(st->dmr_pdu_sf[1][136U + i], block2[36U + i], "apx-p2-block-copy");
+    }
+
+    DSD_MEMSET(st->dmr_pdu_sf[1], 0xA5, sizeof(st->dmr_pdu_sf[1]));
+    DSD_MEMSET(block2, 0, sizeof(block2));
+    apx_embedded_alias_blocks_phase2(opts, st, 1, block2);
+    rc |= expect_u8(st->dmr_pdu_sf[1][0], 0U, "apx-p2-missing-header-clears-first");
+    rc |= expect_u8(st->dmr_pdu_sf[1][200], 0U, "apx-p2-missing-header-clears-later");
+    return rc;
+}
+
+static int
+test_tait_iso7_alias_sanitizes_and_policies(dsd_opts* opts, dsd_state* st) {
+    int rc = 0;
+    uint8_t tait_bits[64];
+    DSD_MEMSET(tait_bits, 0, sizeof tait_bits);
+    value_to_bits_msb(tait_bits, 16, sizeof(tait_bits), 'A', 7);
+    value_to_bits_msb(tait_bits, 23, sizeof(tait_bits), ',', 7);
+    value_to_bits_msb(tait_bits, 30, sizeof(tait_bits), 0x1FU, 7);
+    value_to_bits_msb(tait_bits, 37, sizeof(tait_bits), 'Z', 7);
+
+    st->lastsrc = 700005u;
+    st->nac = 0x293u;
+    st->event_history_s[0].Event_History_Items[0].source_id = st->lastsrc;
+
+    tait_iso7_embedded_alias_decode(opts, st, 0, 4, tait_bits);
+
+    rc |= expect_str(st->event_history_s[0].Event_History_Items[0].alias, "A. Z", "tait event alias");
+    rc |= expect_policy_name(st, st->lastsrc, "A. Z", "tait runtime alias policy");
+
+    return rc;
+}
+
+static int
+test_dmr_alias_block_guards_leave_state(dsd_opts* opts, dsd_state* st) {
+    int rc = 0;
+    uint8_t lc_bits[80];
+    DSD_MEMSET(lc_bits, 0, sizeof lc_bits);
+
+    st->dmr_alias_char_size[0] = 0;
+    DSD_MEMSET(st->dmr_pdu_sf[0], 0xA5, sizeof(st->dmr_pdu_sf[0]));
+    dmr_talker_alias_lc_blocks(opts, st, 0, 0, lc_bits);
+    rc |= expect_u8(st->dmr_pdu_sf[0][0], 0xA5U, "dmr alias missing header leaves storage");
+    rc |= expect_u8(st->dmr_pdu_sf[0][48], 0xA5U, "dmr alias missing header leaves later storage");
+
+    st->dmr_alias_char_size[0] = 8;
+    DSD_MEMSET(st->dmr_pdu_sf[0], 0x5A, sizeof(st->dmr_pdu_sf[0]));
+    dmr_talker_alias_lc_blocks(opts, st, 0, 4, lc_bits);
+    rc |= expect_u8(st->dmr_pdu_sf[0][48], 0x5AU, "dmr alias invalid block leaves payload start");
+    rc |= expect_u8(st->dmr_pdu_sf[0][104], 0x5AU, "dmr alias invalid block leaves next payload");
+
+    return rc;
+}
+
+static int
+test_dmr_alias_header_and_block_format_variants(dsd_opts* opts, dsd_state* st) {
+    int rc = 0;
+    uint8_t lc_bits[96];
+
+    DSD_MEMSET(lc_bits, 0, sizeof lc_bits);
+    value_to_bits_msb(lc_bits, 16, sizeof(lc_bits), 0U, 2);
+    value_to_bits_msb(lc_bits, 18, sizeof(lc_bits), 5U, 5);
+    value_to_bits_msb(lc_bits, 23, sizeof(lc_bits), 'H', 7);
+    value_to_bits_msb(lc_bits, 30, sizeof(lc_bits), 'I', 7);
+    st->lastsrc = 700006u;
+    st->event_history_s[0].Event_History_Items[0].source_id = st->lastsrc;
+
+    dmr_talker_alias_lc_header(opts, st, 0, lc_bits);
+    rc |= expect_u8(st->dmr_alias_char_size[0], 7U, "dmr alias iso7 char size");
+    rc |= expect_u8(st->dmr_alias_block_len[0], 5U, "dmr alias iso7 block len");
+    rc |= expect_str(st->generic_talker_alias[0], "Talker Alias: HI; ", "dmr alias iso7 header text");
+    rc |= expect_str(st->event_history_s[0].Event_History_Items[0].alias, "HI; ", "dmr alias iso7 event text");
+
+    DSD_MEMSET(lc_bits, 0, sizeof lc_bits);
+    value_to_bits_msb(lc_bits, 16, sizeof(lc_bits), 'J', 7);
+    value_to_bits_msb(lc_bits, 23, sizeof(lc_bits), 'K', 7);
+    dmr_talker_alias_lc_blocks(opts, st, 0, 0, lc_bits);
+    rc |= expect_str(st->generic_talker_alias[0], "Talker Alias: HI     JK; ", "dmr alias iso7 block text");
+    rc |= expect_u8(st->dmr_pdu_sf[0][49], lc_bits[16], "dmr alias iso7 block copy");
+
+    DSD_MEMSET(lc_bits, 0, sizeof lc_bits);
+    value_to_bits_msb(lc_bits, 16, sizeof(lc_bits), 3U, 2);
+    value_to_bits_msb(lc_bits, 18, sizeof(lc_bits), 3U, 5);
+    value_to_bits_msb(lc_bits, 24, sizeof(lc_bits), 'Q', 16);
+    value_to_bits_msb(lc_bits, 40, sizeof(lc_bits), 0U, 16);
+    value_to_bits_msb(lc_bits, 56, sizeof(lc_bits), 0x0100U, 16);
+    st->lastsrcR = 700007u;
+    st->event_history_s[1].Event_History_Items[0].source_id = st->lastsrcR;
+
+    dmr_talker_alias_lc_header(opts, st, 1, lc_bits);
+    rc |= expect_u8(st->dmr_alias_char_size[1], 16U, "dmr alias utf16 char size");
+    rc |= expect_u8(st->dmr_alias_block_len[1], 3U, "dmr alias utf16 block len");
+    rc |= expect_str(st->generic_talker_alias[1], "Talker Alias: Q *; ", "dmr alias utf16 header text");
+    rc |= expect_str(st->event_history_s[1].Event_History_Items[0].alias, "Q *; ", "dmr alias utf16 event text");
+
+    DSD_MEMSET(st->dmr_pdu_sf[1], 0, sizeof(st->dmr_pdu_sf[1]));
+    value_to_bits_msb(st->dmr_pdu_sf[1], 0, sizeof(st->dmr_pdu_sf[1]), 'Z', 16);
+    st->dmr_alias_char_size[1] = 16;
+    DSD_MEMSET(lc_bits, 0, sizeof lc_bits);
+    value_to_bits_msb(lc_bits, 16, sizeof(lc_bits), '1', 16);
+    value_to_bits_msb(lc_bits, 32, sizeof(lc_bits), '2', 16);
+    value_to_bits_msb(lc_bits, 48, sizeof(lc_bits), '3', 16);
+    dmr_talker_alias_lc_blocks(opts, st, 1, 0, lc_bits);
+    rc |= expect_str(st->generic_talker_alias[1], "Talker Alias: Z  123; ", "dmr alias utf16 block text");
+    rc |= expect_u8(st->dmr_pdu_sf[1][48], lc_bits[16], "dmr alias utf16 block copy");
+
+    return rc;
+}
+
+static int
+test_dmr_alias_invalid_characters_and_unicode_branch(dsd_opts* opts, dsd_state* st) {
+    int rc = 0;
+
+    DSD_MEMSET(st->dmr_pdu_sf[0], 0, sizeof(st->dmr_pdu_sf[0]));
+    value_to_bits_msb(st->dmr_pdu_sf[0], 0, sizeof(st->dmr_pdu_sf[0]), 'A', 8);
+    value_to_bits_msb(st->dmr_pdu_sf[0], 8, sizeof(st->dmr_pdu_sf[0]), 0x7FU, 8);
+    value_to_bits_msb(st->dmr_pdu_sf[0], 16, sizeof(st->dmr_pdu_sf[0]), 0xFFU, 8);
+    value_to_bits_msb(st->dmr_pdu_sf[0], 24, sizeof(st->dmr_pdu_sf[0]), 'B', 8);
+    st->lastsrc = 700008u;
+    st->event_history_s[0].Event_History_Items[0].source_id = st->lastsrc;
+
+    dmr_talker_alias_lc_decode(opts, st, 0, 2, 8, 4);
+    rc |= expect_str(st->generic_talker_alias[0], "Talker Alias: A  B; ", "dmr alias iso8 invalid chars");
+    rc |= expect_str(st->event_history_s[0].Event_History_Items[0].alias, "A  B; ", "dmr alias iso8 event chars");
+
+    DSD_MEMSET(st->dmr_pdu_sf[1], 0, sizeof(st->dmr_pdu_sf[1]));
+    value_to_bits_msb(st->dmr_pdu_sf[1], 0, sizeof(st->dmr_pdu_sf[1]), 'C', 16);
+    st->lastsrcR = 700009u;
+    st->event_history_s[1].Event_History_Items[0].source_id = st->lastsrcR;
+    g_unicode_supported = 1;
+    dmr_talker_alias_lc_decode(opts, st, 1, 3, 16, 1);
+    g_unicode_supported = 0;
+    rc |= expect_str(st->generic_talker_alias[1], "Talker Alias: C; ", "dmr alias unicode-supported text");
+    rc |= expect_str(st->event_history_s[1].Event_History_Items[0].alias, "C; ", "dmr alias unicode-supported event");
+
+    return rc;
+}
+
+static int
+test_apx_alias_dump_updates_history_and_policy(dsd_opts* opts, dsd_state* st) {
+    int rc = 0;
+    uint8_t input[160];
+    uint8_t decoded[8];
+    DSD_MEMSET(input, 0, sizeof input);
+    DSD_MEMSET(decoded, 0, sizeof decoded);
+
+    const uint32_t rid = 0x000ABCU;
+    value_to_bits_msb(input, 72, sizeof(input), 0x12345U, 20);
+    value_to_bits_msb(input, 92, sizeof(input), 0x678U, 12);
+    value_to_bits_msb(input, 104, sizeof(input), rid, 24);
+    decoded[1] = 'M';
+    decoded[3] = ',';
+    decoded[5] = 0x01;
+
+    st->event_history_s[0].Event_History_Items[0].source_id = rid;
+
+    apx_embedded_alias_dump(opts, st, 0, 6, input, decoded);
+
+    rc |= expect_has_substr(st->event_history_s[0].Event_History_Items[0].alias, "M. ;  FQ-SUID: 12345:678.000ABC",
+                            "apx dump event alias");
+    rc |= expect_policy_name(st, rid, "M. ", "apx dump runtime alias policy");
+
+    return rc;
 }
 
 int
@@ -115,6 +459,14 @@ main(void) {
 
     dmr_talker_alias_lc_header(opts, st, 0, lc_bits);
     rc |= expect_has_substr(st->generic_talker_alias[0], "KE8NAX", "talker_alias_header");
+    rc |= test_direct_dmr_alias_decoders(opts, st);
+    rc |= test_harris_l3h_alias_state(opts, st);
+    rc |= test_apx_alias_phase_storage(opts, st);
+    rc |= test_tait_iso7_alias_sanitizes_and_policies(opts, st);
+    rc |= test_dmr_alias_block_guards_leave_state(opts, st);
+    rc |= test_dmr_alias_header_and_block_format_variants(opts, st);
+    rc |= test_dmr_alias_invalid_characters_and_unicode_branch(opts, st);
+    rc |= test_apx_alias_dump_updates_history_and_policy(opts, st);
 
     // Runtime alias handling stores learned aliases through the policy table.
     st->lastsrc = 600000u;

--- a/tests/protocol/dpmr/test_dpmr_sync_dispatch.c
+++ b/tests/protocol/dpmr/test_dpmr_sync_dispatch.c
@@ -9,29 +9,40 @@
 #include <assert.h>
 #include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/file_io.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <stdio.h>
 #include <string.h>
 
 int dsd_dispatch_matches_dpmr(int synctype);
+void dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state);
+
+static int g_close_calls;
+static int g_open_calls;
+static int g_voice_calls;
 
 void
 closeMbeOutFile(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_close_calls++;
 }
 
 void
 openMbeOutFile(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_open_calls++;
 }
 
 void
 processdPMRvoice(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_voice_calls++;
 }
 
 static void
@@ -67,11 +78,58 @@ test_synctype_helpers(void) {
     assert(!dsd_dispatch_matches_dpmr(DSD_SYNC_NXDN_POS));
 }
 
+static void
+test_dispatch_close_only_syncs(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.mbe_out_f = stdout;
+    state.synctype = DSD_SYNC_DPMR_FS1_POS;
+    dsd_dispatch_handle_dpmr(&opts, &state);
+    assert(g_close_calls == 1);
+    assert(g_voice_calls == 0);
+
+    state.synctype = DSD_SYNC_DPMR_FS3_NEG;
+    dsd_dispatch_handle_dpmr(&opts, &state);
+    assert(g_close_calls == 2);
+
+    state.synctype = DSD_SYNC_DPMR_FS4_POS;
+    dsd_dispatch_handle_dpmr(&opts, &state);
+    assert(g_close_calls == 3);
+}
+
+static void
+test_dispatch_voice_sync_resets_state_and_processes_voice(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    DSD_SNPRINTF(opts.mbe_out_dir, sizeof(opts.mbe_out_dir), "%s", "captures");
+    state.synctype = DSD_SYNC_DPMR_FS2_POS;
+    state.nac = 123;
+    state.lastsrc = 456;
+    state.lasttg = 789;
+
+    dsd_dispatch_handle_dpmr(&opts, &state);
+
+    assert(g_open_calls == 1);
+    assert(g_voice_calls == 1);
+    assert(state.nac == 0);
+    assert(state.lastsrc == 0);
+    assert(state.lasttg == 0);
+    assert(strcmp(state.fsubtype, " VOICE        ") == 0);
+}
+
 int
 main(void) {
     test_sync_pattern_lengths();
     test_sync_pattern_pairs();
     test_synctype_helpers();
+    test_dispatch_close_only_syncs();
+    test_dispatch_voice_sync_resets_state_and_processes_voice();
     printf("DPMR_SYNC_DISPATCH: OK\n");
     return 0;
 }

--- a/tests/protocol/dpmr/test_dpmr_voice_bridge.c
+++ b/tests/protocol/dpmr/test_dpmr_voice_bridge.c
@@ -19,6 +19,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 
@@ -34,6 +35,7 @@ static int g_mbe_synctype[8];
 static int g_mbe_cipher[8];
 static int g_mbe_enc[8];
 static unsigned long long g_mbe_mi[8];
+static int g_dibit_calls;
 
 static void
 reset_capture(void) {
@@ -44,12 +46,14 @@ reset_capture(void) {
     DSD_MEMSET(g_mbe_cipher, 0, sizeof(g_mbe_cipher));
     DSD_MEMSET(g_mbe_enc, 0, sizeof(g_mbe_enc));
     DSD_MEMSET(g_mbe_mi, 0, sizeof(g_mbe_mi));
+    g_dibit_calls = 0;
 }
 
 int
 getDibit(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_dibit_calls++;
     return 0;
 }
 
@@ -76,6 +80,15 @@ Hamming_12_8_decode(unsigned char* rxBits, unsigned char* decodedBits, int nbCod
 
 void dsd_test_dpmr_play_voice_frames(dsd_opts* opts, dsd_state* state,
                                      char ambe_fr[NB_OF_DPMR_VOICE_FRAME_TO_DECODE * 4][4][24]);
+void dsd_test_dpmr_deinterleave_6x12(const uint8_t* input, uint8_t* output);
+uint8_t dsd_test_dpmr_crc7(const uint8_t* input, uint32_t bit_length);
+void dsd_test_dpmr_convert_air_interface_id(uint32_t ai_id, char id[8]);
+uint8_t dsd_test_dpmr_extract_cch_crc(const uint8_t cch_bits[48]);
+void dsd_test_dpmr_update_superframe_part(dsd_opts* opts, dsd_state* state, uint32_t frame0, uint32_t frame1,
+                                          uint32_t id_value, bool crc0_ok, bool crc1_ok, bool hamming0_ok,
+                                          bool hamming1_ok);
+void dsd_test_dpmr_print_ids(dsd_state* state, const char called_id[8], const char calling_id[8]);
+void processdPMRvoice(dsd_opts* opts, dsd_state* state);
 
 void
 processMbeFrame(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], char ambe_fr[4][24], char imbe7100_fr[7][24]) {
@@ -198,11 +211,199 @@ test_second_group_scrambler_bridge_unmutes_with_key(void) {
     return rc;
 }
 
+static int
+test_deinterleave_transposes_6x12_blocks(void) {
+    uint8_t input[72];
+    uint8_t output[72];
+    for (uint32_t i = 0; i < 72U; i++) {
+        input[i] = (uint8_t)i;
+        output[i] = 0U;
+    }
+
+    dsd_test_dpmr_deinterleave_6x12(input, output);
+
+    int rc = 0;
+    for (uint32_t j = 0; j < 6U; j++) {
+        for (uint32_t i = 0; i < 12U; i++) {
+            char tag[40];
+            DSD_SNPRINTF(tag, sizeof(tag), "deinterleave-%u-%u", (unsigned)i, (unsigned)j);
+            rc |= expect_int(tag, output[(j * 12U) + i], input[(i * 6U) + j]);
+        }
+    }
+    return rc;
+}
+
+static int
+test_crc7_and_air_interface_id_helpers(void) {
+    static const uint8_t crc_bits[12] = {1, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 1};
+    uint8_t cch_bits[48] = {0};
+    char id[8];
+    int rc = 0;
+
+    rc |= expect_int("crc7-empty", dsd_test_dpmr_crc7(crc_bits, 0U), 0x00);
+    rc |= expect_int("crc7-pattern", dsd_test_dpmr_crc7(crc_bits, 12U), 0x24);
+    cch_bits[41] = 1U;
+    cch_bits[43] = 1U;
+    cch_bits[46] = 1U;
+    rc |= expect_int("cch-crc-extract", dsd_test_dpmr_extract_cch_crc(cch_bits), 0x52);
+
+    dsd_test_dpmr_convert_air_interface_id(0U, id);
+    rc |= expect_int("aiid-zero", strcmp(id, "0000000"), 0);
+    dsd_test_dpmr_convert_air_interface_id(10U, id);
+    rc |= expect_int("aiid-star-low", strcmp(id, "000000*"), 0);
+    dsd_test_dpmr_convert_air_interface_id(1464100U, id);
+    rc |= expect_int("aiid-first-digit", strcmp(id, "1000000"), 0);
+    dsd_test_dpmr_convert_air_interface_id(1464110U, id);
+    rc |= expect_int("aiid-first-digit-with-star", strcmp(id, "100000*"), 0);
+    return rc;
+}
+
+static int
+test_superframe_part_updates_called_and_calling_ids(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    dsd_test_dpmr_update_superframe_part(&opts, &state, 0U, 1U, 1464100U, true, true, false, false);
+    rc |= expect_int("called-id", strcmp((const char*)state.dPMRVoiceFS2Frame.CalledID, "1000000"), 0);
+    rc |= expect_int("called-id-ok", (int)state.dPMRVoiceFS2Frame.CalledIDOk, 1);
+    rc |= expect_int("called-next-part", opts.dPMR_next_part_of_superframe, 2);
+    rc |= expect_int("calling-id-preserved-empty", strcmp((const char*)state.dPMRVoiceFS2Frame.CallingID, ""), 0);
+
+    dsd_test_dpmr_update_superframe_part(&opts, &state, 2U, 3U, 1464110U, false, false, true, true);
+    rc |= expect_int("calling-id", strcmp((const char*)state.dPMRVoiceFS2Frame.CallingID, "100000*"), 0);
+    rc |= expect_int("calling-id-ok-from-hamming", (int)state.dPMRVoiceFS2Frame.CallingIDOk, 1);
+    rc |= expect_int("calling-next-part", opts.dPMR_next_part_of_superframe, 1);
+    rc |= expect_int("called-id-preserved", strcmp((const char*)state.dPMRVoiceFS2Frame.CalledID, "1000000"), 0);
+
+    dsd_test_dpmr_update_superframe_part(&opts, &state, 0U, 1U, 10U, false, false, true, false);
+    rc |= expect_int("weak-called-id", strcmp((const char*)state.dPMRVoiceFS2Frame.CalledID, "000000*"), 0);
+    rc |= expect_int("weak-called-id-not-ok", (int)state.dPMRVoiceFS2Frame.CalledIDOk, 0);
+    rc |= expect_int("weak-called-next-part", opts.dPMR_next_part_of_superframe, 2);
+
+    state.dPMRVoiceFS2Frame.CalledIDOk = 1U;
+    state.dPMRVoiceFS2Frame.CallingIDOk = 1U;
+    dsd_test_dpmr_update_superframe_part(&opts, &state, 1U, 2U, 0U, false, false, false, false);
+    rc |= expect_int("unknown-clears-called-ok", (int)state.dPMRVoiceFS2Frame.CalledIDOk, 0);
+    rc |= expect_int("unknown-clears-calling-ok", (int)state.dPMRVoiceFS2Frame.CallingIDOk, 0);
+    rc |= expect_int("unknown-toggles-next-part", opts.dPMR_next_part_of_superframe, 1);
+
+    opts.dPMR_next_part_of_superframe = 1;
+    dsd_test_dpmr_update_superframe_part(&opts, &state, 1U, 2U, 0U, false, false, false, false);
+    rc |= expect_int("unknown-toggles-next-part-back", opts.dPMR_next_part_of_superframe, 2);
+
+    opts.dPMR_next_part_of_superframe = 0;
+    dsd_test_dpmr_update_superframe_part(&opts, &state, 1U, 2U, 0U, false, false, false, false);
+    rc |= expect_int("unknown-keeps-zero-part", opts.dPMR_next_part_of_superframe, 0);
+    return rc;
+}
+
+static int
+test_id_print_side_effects_track_valid_target_caller_and_color(void) {
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.dPMRVoiceFS2Frame.CalledIDOk = 1U;
+    state.dPMRVoiceFS2Frame.CallingIDOk = 1U;
+    state.dPMRVoiceFS2Frame.ColorCode[0] = 12U;
+
+    dsd_test_dpmr_print_ids(&state, "1000000", "200000*");
+
+    rc |= expect_int("print-target-id", strcmp(state.dpmr_target_id, "1000000"), 0);
+    rc |= expect_int("print-caller-id", strcmp(state.dpmr_caller_id, "200000*"), 0);
+    rc |= expect_int("print-color-code", state.dpmr_color_code, 12);
+    return rc;
+}
+
+static int
+test_id_print_side_effects_suppress_invalid_ids(void) {
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_SNPRINTF(state.dpmr_target_id, sizeof(state.dpmr_target_id), "%s", "prior-tg");
+    DSD_SNPRINTF(state.dpmr_caller_id, sizeof(state.dpmr_caller_id), "%s", "prior-src");
+    state.dpmr_color_code = 7;
+    state.dPMRVoiceFS2Frame.CalledIDOk = 0U;
+    state.dPMRVoiceFS2Frame.CallingIDOk = 1U;
+    state.dPMRVoiceFS2Frame.ColorCode[0] = 4U;
+
+    dsd_test_dpmr_print_ids(&state, "3000000", "4000000");
+
+    rc |= expect_int("invalid-called-keeps-target", strcmp(state.dpmr_target_id, "prior-tg"), 0);
+    rc |= expect_int("invalid-called-keeps-caller", strcmp(state.dpmr_caller_id, "prior-src"), 0);
+    rc |= expect_int("invalid-called-keeps-color", state.dpmr_color_code, 7);
+
+    state.dPMRVoiceFS2Frame.CalledIDOk = 1U;
+    state.dPMRVoiceFS2Frame.CallingIDOk = 0U;
+    dsd_test_dpmr_print_ids(&state, "5000000", "6000000");
+    rc |= expect_int("invalid-calling-updates-target", strcmp(state.dpmr_target_id, "5000000"), 0);
+    rc |= expect_int("invalid-calling-keeps-caller", strcmp(state.dpmr_caller_id, "prior-src"), 0);
+    rc |= expect_int("invalid-calling-keeps-color", state.dpmr_color_code, 7);
+    return rc;
+}
+
+static int
+test_process_dpmr_voice_zero_stream_updates_cch_and_dispatches_voice(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.synctype = DSD_SYNC_DPMR_FS1_POS;
+    state.dPMRVoiceFS2Frame.ColorCode[0] = (unsigned int)(-1);
+    reset_capture();
+
+    processdPMRvoice(&opts, &state);
+
+    rc |= expect_int("process-dibit-count", g_dibit_calls, 372);
+    rc |= expect_int("process-mbe-calls", (int)g_mbe_calls, 8);
+    rc |= expect_int("process-ms-calls", g_ms_calls, 8);
+    rc |= expect_int("process-fm-calls", g_fm_calls, 0);
+    for (int i = 0; i < 8; i++) {
+        rc |= expect_int("process-synctype", g_mbe_synctype[i], DSD_SYNC_DPMR_FS1_POS);
+        rc |= expect_int("process-cipher", g_mbe_cipher[i], 0);
+        rc |= expect_int("process-clear-audio", g_mbe_enc[i], 0);
+    }
+
+    for (uint32_t i = 0; i < NB_OF_DPMR_VOICE_FRAME_TO_DECODE; i++) {
+        char tag[64];
+        DSD_SNPRINTF(tag, sizeof(tag), "process-hamming-ok-%u", (unsigned)i);
+        rc |= expect_int(tag, (int)state.dPMRVoiceFS2Frame.CCHDataHammingOk[i], 1);
+        DSD_SNPRINTF(tag, sizeof(tag), "process-crc-ok-%u", (unsigned)i);
+        rc |= expect_int(tag, (int)state.dPMRVoiceFS2Frame.CCHDataCrcOk[i], 1);
+        DSD_SNPRINTF(tag, sizeof(tag), "process-frame-number-%u", (unsigned)i);
+        rc |= expect_int(tag, (int)state.dPMRVoiceFS2Frame.FrameNumbering[i], 0);
+        DSD_SNPRINTF(tag, sizeof(tag), "process-comm-mode-%u", (unsigned)i);
+        rc |= expect_int(tag, (int)state.dPMRVoiceFS2Frame.CommunicationMode[i], 0);
+        DSD_SNPRINTF(tag, sizeof(tag), "process-version-%u", (unsigned)i);
+        rc |= expect_int(tag, (int)state.dPMRVoiceFS2Frame.Version[i], 0);
+    }
+
+    rc |= expect_int("process-called-id", strcmp((const char*)state.dPMRVoiceFS2Frame.CalledID, "0000000"), 0);
+    rc |= expect_int("process-called-id-ok", (int)state.dPMRVoiceFS2Frame.CalledIDOk, 1);
+    rc |= expect_int("process-next-part", opts.dPMR_next_part_of_superframe, 2);
+    rc |= expect_int("process-invalid-color-code", (int)state.dPMRVoiceFS2Frame.ColorCode[0], -1);
+    rc |= expect_int("process-no-color-side-effect", state.dpmr_color_code, 0);
+    rc |= expect_int("process-final-synctype", state.synctype, DSD_SYNC_DPMR_FS1_POS);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
     rc |= test_first_group_scrambler_bridge_mutes_without_key();
     rc |= test_second_group_scrambler_bridge_unmutes_with_key();
+    rc |= test_deinterleave_transposes_6x12_blocks();
+    rc |= test_crc7_and_air_interface_id_helpers();
+    rc |= test_superframe_part_updates_called_and_calling_ids();
+    rc |= test_id_print_side_effects_track_valid_target_caller_and_color();
+    rc |= test_id_print_side_effects_suppress_invalid_ids();
+    rc |= test_process_dpmr_voice_zero_stream_updates_cch_and_dispatches_voice();
 
     if (rc == 0) {
         printf("DPMR_VOICE_BRIDGE: OK\n");

--- a/tests/protocol/dstar/test_dstar_header_utils.c
+++ b/tests/protocol/dstar/test_dstar_header_utils.c
@@ -7,10 +7,13 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/protocol/dstar/dstar.h>
+#include <dsd-neo/protocol/dstar/dstar_header.h>
 #include <dsd-neo/protocol/dstar/dstar_header_utils.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "dsd-neo/core/dibit.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -19,7 +22,15 @@ static const uint8_t k_slow_data_scrambler[24] = {
     0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1,
 };
 
+uint16_t
+gmsk_soft_symbol_to_viterbi_cost(float symbol, const dsd_state* state) {
+    (void)state;
+    return symbol > 0.0F ? 0xF000U : 0x1000U;
+}
+
 static void pack_slow_data_bytes(const uint8_t bytes[60], uint8_t bits[480]);
+static void build_encoded_header_fixture(int hard_rx[DSD_DSTAR_HEADER_CODED_BITS],
+                                         float soft_rx[DSD_DSTAR_HEADER_CODED_BITS]);
 static void set_compacted_slow_data_bytes(uint8_t bytes[60], const uint8_t compact[51]);
 
 static void
@@ -153,6 +164,73 @@ test_soft_decode_pipeline(void) {
 
     assert(out_len == DSD_DSTAR_HEADER_INFO_BITS);
     assert(memcmp(info_bits, decoded, sizeof(info_bits)) == 0);
+}
+
+static void
+build_encoded_header_fixture(int hard_rx[DSD_DSTAR_HEADER_CODED_BITS], float soft_rx[DSD_DSTAR_HEADER_CODED_BITS]) {
+    uint8_t header[41];
+    int info_bits[DSD_DSTAR_HEADER_INFO_BITS];
+    int coded[DSD_DSTAR_HEADER_CODED_BITS];
+    int interleaved[DSD_DSTAR_HEADER_CODED_BITS];
+
+    DSD_MEMSET(header, 0, sizeof header);
+    header[0] = 0xF8U;
+    DSD_MEMCPY(header + 3, "RPT2TST ", 8);
+    DSD_MEMCPY(header + 11, "RPT1TST ", 8);
+    DSD_MEMCPY(header + 19, "CQCQCQ  ", 8);
+    DSD_MEMCPY(header + 27, "N0CALL  /TST", 12);
+
+    DSD_MEMSET(info_bits, 0, sizeof info_bits);
+    for (int byte_idx = 0; byte_idx < 41; byte_idx++) {
+        for (int bit = 0; bit < 8; bit++) {
+            info_bits[(byte_idx * 8) + bit] = (header[byte_idx] >> bit) & 0x1;
+        }
+    }
+
+    convolution_encode(info_bits, DSD_DSTAR_HEADER_INFO_BITS, coded);
+    dstar_interleave_header_bits(coded, interleaved, DSD_DSTAR_HEADER_CODED_BITS);
+    dstar_scramble_header_bits(interleaved, hard_rx, DSD_DSTAR_HEADER_CODED_BITS);
+
+    for (size_t i = 0; i < DSD_DSTAR_HEADER_CODED_BITS; i++) {
+        soft_rx[i] = hard_rx[i] ? 1.0F : -1.0F;
+    }
+}
+
+static void
+test_hard_header_decode_extracts_callsigns(void) {
+    static dsd_state state;
+    int hard_rx[DSD_DSTAR_HEADER_CODED_BITS];
+    float soft_rx[DSD_DSTAR_HEADER_CODED_BITS];
+
+    DSD_MEMSET(&state, 0, sizeof state);
+    build_encoded_header_fixture(hard_rx, soft_rx);
+
+    dstar_header_decode(&state, hard_rx);
+
+    assert(strcmp(state.dstar_rpt2, "RPT2TST ") == 0);
+    assert(strcmp(state.dstar_rpt1, "RPT1TST ") == 0);
+    assert(strcmp(state.dstar_dst, "CQCQCQ  ") == 0);
+    assert(strcmp(state.dstar_src, "N0CALL  /TST") == 0);
+}
+
+static void
+test_soft_header_decode_extracts_callsigns(void) {
+    static dsd_state state;
+    int hard_rx[DSD_DSTAR_HEADER_CODED_BITS];
+    float soft_rx[DSD_DSTAR_HEADER_CODED_BITS];
+
+    DSD_MEMSET(&state, 0, sizeof state);
+    state.min = -1.0F;
+    state.center = 0.0F;
+    state.max = 1.0F;
+    build_encoded_header_fixture(hard_rx, soft_rx);
+
+    dstar_header_decode_soft(&state, soft_rx);
+
+    assert(strcmp(state.dstar_rpt2, "RPT2TST ") == 0);
+    assert(strcmp(state.dstar_rpt1, "RPT1TST ") == 0);
+    assert(strcmp(state.dstar_dst, "CQCQCQ  ") == 0);
+    assert(strcmp(state.dstar_src, "N0CALL  /TST") == 0);
 }
 
 static void
@@ -315,6 +393,8 @@ main(void) {
     test_interleave_roundtrip();
     test_decode_pipeline();
     test_soft_decode_pipeline();
+    test_hard_header_decode_extracts_callsigns();
+    test_soft_header_decode_extracts_callsigns();
     test_crc16();
     test_slow_data_header_accepts_wire_crc_order();
     test_slow_data_text_keeps_byte_after_marker();

--- a/tests/protocol/dstar/test_dstar_process.c
+++ b/tests/protocol/dstar/test_dstar_process.c
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Focused checks for D-STAR voice/header processing loop boundaries.
+ */
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#include <assert.h>
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/vocoder.h>
+#include <dsd-neo/protocol/dstar/dstar.h>
+#include <dsd-neo/protocol/dstar/dstar_header.h>
+#include <dsd-neo/protocol/dstar/dstar_header_utils.h>
+#include <dsd-neo/runtime/telemetry.h>
+#include <stdint.h>
+#include <stdio.h>
+
+enum {
+    DSTAR_VOICE_FRAMES = 21,
+    DSTAR_VOICE_DIBITS_PER_FRAME = 72,
+    DSTAR_SLOW_DATA_FRAMES = 20,
+    DSTAR_SLOW_DATA_DIBITS_PER_FRAME = 24,
+    DSTAR_EXPECTED_VOICE_DIBITS = DSTAR_VOICE_FRAMES * DSTAR_VOICE_DIBITS_PER_FRAME,
+    DSTAR_EXPECTED_SLOW_DIBITS = DSTAR_SLOW_DATA_FRAMES * DSTAR_SLOW_DATA_DIBITS_PER_FRAME,
+};
+
+static int dibit_calls;
+static int soft_symbol_calls;
+static int soft_mbe_calls;
+static int slow_data_calls;
+static int ui_calls;
+static int watchdog_history_calls;
+static int watchdog_current_calls;
+static int header_decode_soft_calls;
+static uint8_t captured_slow_data[DSTAR_EXPECTED_SLOW_DIBITS];
+static char captured_ambe_frame[4][24];
+static float captured_soft_symbols[DSD_DSTAR_HEADER_CODED_BITS];
+
+static void
+reset_counters(void) {
+    dibit_calls = 0;
+    soft_symbol_calls = 0;
+    soft_mbe_calls = 0;
+    slow_data_calls = 0;
+    ui_calls = 0;
+    watchdog_history_calls = 0;
+    watchdog_current_calls = 0;
+    header_decode_soft_calls = 0;
+    DSD_MEMSET(captured_slow_data, 0, sizeof(captured_slow_data));
+    DSD_MEMSET(captured_ambe_frame, 0, sizeof(captured_ambe_frame));
+    DSD_MEMSET(captured_soft_symbols, 0, sizeof(captured_soft_symbols));
+}
+
+int
+getDibit(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    int value = dibit_calls & 3;
+    dibit_calls++;
+    return value;
+}
+
+int
+getDibitAndSoftSymbol(dsd_opts* opts, dsd_state* state, float* out_soft_symbol) {
+    (void)opts;
+    (void)state;
+    assert(out_soft_symbol != NULL);
+    *out_soft_symbol = (float)(soft_symbol_calls + 1) * 0.25F;
+    soft_symbol_calls++;
+    return soft_symbol_calls & 3;
+}
+
+void
+soft_mbe(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], char ambe_fr[4][24], char imbe7100_fr[7][24]) {
+    (void)opts;
+    (void)state;
+    assert(imbe_fr == NULL);
+    assert(ambe_fr != NULL);
+    assert(imbe7100_fr == NULL);
+    if (soft_mbe_calls == 0) {
+        DSD_MEMCPY(captured_ambe_frame, ambe_fr, sizeof(captured_ambe_frame));
+    }
+    soft_mbe_calls++;
+}
+
+void
+processDSTAR_SD(const dsd_opts* opts, dsd_state* state, uint8_t* sd) {
+    (void)opts;
+    (void)state;
+    assert(sd != NULL);
+    DSD_MEMCPY(captured_slow_data, sd, sizeof(captured_slow_data));
+    slow_data_calls++;
+}
+
+void
+ui_publish_both_and_redraw(const dsd_opts* opts, const dsd_state* state) {
+    (void)opts;
+    (void)state;
+    ui_calls++;
+}
+
+void
+watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    assert(slot == 0);
+    watchdog_history_calls++;
+}
+
+void
+watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    assert(slot == 0);
+    watchdog_current_calls++;
+}
+
+void
+dstar_header_decode_soft(struct dsd_state* state, const float soft_symbols[DSD_DSTAR_HEADER_CODED_BITS]) {
+    (void)state;
+    assert(soft_symbols != NULL);
+    DSD_MEMCPY(captured_soft_symbols, soft_symbols, sizeof(captured_soft_symbols));
+    header_decode_soft_calls++;
+}
+
+static void
+assert_voice_loop_counts(int expected_ui_calls) {
+    assert(dibit_calls == DSTAR_EXPECTED_VOICE_DIBITS + DSTAR_EXPECTED_SLOW_DIBITS);
+    assert(soft_mbe_calls == DSTAR_VOICE_FRAMES);
+    assert(slow_data_calls == 1);
+    assert(ui_calls == expected_ui_calls);
+    assert(watchdog_history_calls == DSTAR_VOICE_FRAMES);
+    assert(watchdog_current_calls == DSTAR_VOICE_FRAMES);
+}
+
+static void
+assert_first_ambe_frame_is_interleaved_lsb_stream(void) {
+    assert(captured_ambe_frame[0][10] == 0);
+    assert(captured_ambe_frame[0][22] == 1);
+    assert(captured_ambe_frame[3][11] == 0);
+    assert(captured_ambe_frame[2][9] == 1);
+}
+
+static void
+assert_slow_data_starts_after_first_voice_frame(void) {
+    for (int i = 0; i < DSTAR_SLOW_DATA_DIBITS_PER_FRAME; i++) {
+        int expected = (DSTAR_VOICE_DIBITS_PER_FRAME + i) & 3;
+        assert(captured_slow_data[i] == (uint8_t)expected);
+    }
+}
+
+static void
+test_voice_process_without_ncurses(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_counters();
+
+    processDSTAR(&opts, &state);
+
+    assert_voice_loop_counts(0);
+    assert(soft_symbol_calls == 0);
+    assert(header_decode_soft_calls == 0);
+    assert_first_ambe_frame_is_interleaved_lsb_stream();
+    assert_slow_data_starts_after_first_voice_frame();
+}
+
+static void
+test_voice_process_with_ncurses_refresh(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.use_ncurses_terminal = 1;
+    reset_counters();
+
+    processDSTAR(&opts, &state);
+
+    assert_voice_loop_counts(DSTAR_VOICE_FRAMES);
+    assert(soft_symbol_calls == 0);
+    assert(header_decode_soft_calls == 0);
+}
+
+static void
+test_header_process_captures_header_then_voice(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_counters();
+
+    processDSTAR_HD(&opts, &state);
+
+    assert(soft_symbol_calls == DSD_DSTAR_HEADER_CODED_BITS);
+    assert(header_decode_soft_calls == 1);
+    assert(captured_soft_symbols[0] == 0.25F);
+    assert(captured_soft_symbols[DSD_DSTAR_HEADER_CODED_BITS - 1] == 165.0F);
+    assert_voice_loop_counts(0);
+}
+
+int
+main(void) {
+    test_voice_process_without_ncurses();
+    test_voice_process_with_ncurses_refresh();
+    test_header_process_captures_header_then_voice();
+    printf("DSTAR_PROCESS: OK\n");
+    return 0;
+}

--- a/tests/protocol/edacs/test_edacs_grant_tune_matrix.c
+++ b/tests/protocol/edacs/test_edacs_grant_tune_matrix.c
@@ -30,7 +30,6 @@
 #ifdef USE_RADIO
 #include <dsd-neo/runtime/rtl_stream_io_hooks.h>
 #endif
-#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -1154,7 +1153,7 @@ edacs_run_analog_loop_helper_cases(void) {
     DSD_MEMSET(analog3, 0, sizeof(analog3));
     opts.audio_in_type = AUDIO_IN_TCP;
     opts.input_volume_multiplier = 2;
-    opts.tcp_in_ctx = (tcp_input_ctx*)(void*)&tcp_ctx_token;
+    opts.tcp_in_ctx = (tcp_input_ctx*)&tcp_ctx_token;
     edacs_install_net_audio_hooks();
 
     rc |= edacs_expect(dsd_neo_edacs_test_collect_analog_triplet(&opts, &state, analog1, analog2, analog3, &pwr) == 1,
@@ -1185,7 +1184,7 @@ edacs_run_analog_loop_helper_cases(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     opts.audio_in_type = AUDIO_IN_RTL;
     opts.rtl_volume_multiplier = 2;
-    state.rtl_ctx = (struct RtlSdrContext*)(void*)&tcp_ctx_token;
+    state.rtl_ctx = (struct RtlSdrContext*)&tcp_ctx_token;
     edacs_install_rtl_stream_hooks();
     pwr = -1.0;
     rc |= edacs_expect(dsd_neo_edacs_test_collect_analog_triplet(&opts, &state, analog1, analog2, analog3, &pwr) == 1,
@@ -1286,7 +1285,7 @@ edacs_run_analog_loop_helper_cases(void) {
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
     opts.audio_in_type = AUDIO_IN_TCP;
-    opts.tcp_in_ctx = (tcp_input_ctx*)(void*)&tcp_ctx_token;
+    opts.tcp_in_ctx = (tcp_input_ctx*)&tcp_ctx_token;
     g_tcp_fail_at = 5;
     edacs_install_net_audio_hooks();
     pwr = 123.0;
@@ -1303,7 +1302,7 @@ edacs_run_analog_loop_helper_cases(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     opts.audio_in_type = AUDIO_IN_RTL;
     opts.rtl_volume_multiplier = 1;
-    state.rtl_ctx = (struct RtlSdrContext*)(void*)&tcp_ctx_token;
+    state.rtl_ctx = (struct RtlSdrContext*)&tcp_ctx_token;
     g_rtl_fail_at = 3;
     edacs_install_rtl_stream_hooks();
     rc |= edacs_expect(dsd_neo_edacs_test_collect_analog_triplet(&opts, &state, analog1, analog2, analog3, &pwr) == 0,

--- a/tests/protocol/edacs/test_edacs_grant_tune_matrix.c
+++ b/tests/protocol/edacs/test_edacs_grant_tune_matrix.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -15,10 +18,14 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/protocol/edacs/edacs.h>
+#include <dsd-neo/runtime/rigctl_query_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
+#include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -30,6 +37,21 @@
 
 void dsd_neo_edacs_test_process_valid_frame(dsd_opts* opts, dsd_state* state, unsigned long long int msg_1,
                                             unsigned long long int msg_2);
+const char* dsd_neo_edacs_test_lcn_status_string(int lcn);
+short dsd_neo_edacs_test_apply_input_volume(int multiplier, short sample);
+unsigned long long int dsd_neo_edacs_test_vote_frames(unsigned long long int fr_1_4, unsigned long long int fr_2_5,
+                                                      unsigned long long int fr_3_6);
+int dsd_neo_edacs_test_update_squelch_count(double pwr, double sql, int count);
+int dsd_neo_edacs_test_should_release_voice(unsigned long long int sr, int sql_disabled, time_t start_time,
+                                            double no_sql_watchdog_s);
+void dsd_neo_edacs_test_update_lcn_count(dsd_state* state, int lcn);
+void dsd_neo_edacs_test_build_raw_frames(const int edacs_bit[241], unsigned long long int* fr_1,
+                                         unsigned long long int* fr_2, unsigned long long int* fr_3,
+                                         unsigned long long int* fr_4, unsigned long long int* fr_5,
+                                         unsigned long long int* fr_6);
+unsigned long long int dsd_neo_edacs_test_build_symbol_register(const dsd_opts* opts, dsd_state* state,
+                                                                const short analog1[960]);
+void dsd_neo_edacs_test_reset_digitize_overflow(dsd_state* state);
 
 typedef struct {
     const char* name;
@@ -61,6 +83,7 @@ static int g_cc_tune_count = 0;
 static int g_skip_dibit_count = 0;
 static long g_last_vc_freq = 0;
 static long g_last_cc_freq = 0;
+static long g_rigctl_current_freq = 0;
 
 void
 // NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
@@ -118,12 +141,21 @@ edacs_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_s
     return g_cc_result;
 }
 
+static long int
+edacs_hook_get_current_freq_hz(const dsd_opts* opts) {
+    (void)opts;
+    return g_rigctl_current_freq;
+}
+
 static void
 edacs_install_hooks(void) {
     dsd_trunk_tuning_hooks hooks = {0};
     hooks.tune_to_freq_result = edacs_hook_tune_to_freq;
     hooks.tune_to_cc_result = edacs_hook_tune_to_cc;
     dsd_trunk_tuning_hooks_set(hooks);
+    dsd_rigctl_query_hooks_set((dsd_rigctl_query_hooks){
+        .get_current_freq_hz = edacs_hook_get_current_freq_hz,
+    });
 }
 
 static int
@@ -169,6 +201,21 @@ edacs_extended_group_msg1(int mt1, int lcn, int group) {
 }
 
 static unsigned long long int
+edacs_extended_group_update_msg1(int mt1, int lcn, int group, int is_update) {
+    unsigned long long int msg = edacs_extended_group_msg1(mt1, lcn, group);
+    msg |= (unsigned long long int)(is_update ? 1U : 0U) << 16U;
+    return msg;
+}
+
+static unsigned long long int
+edacs_extended_group_msg2(int source, int is_emergency, int is_tx_trunking) {
+    unsigned long long int msg = (unsigned long long int)(source & 0xFFFFF);
+    msg |= (unsigned long long int)(is_emergency ? 1U : 0U) << 20U;
+    msg |= (unsigned long long int)(is_tx_trunking ? 1U : 0U) << 21U;
+    return msg;
+}
+
+static unsigned long long int
 edacs_extended_icall_msg1(int target) {
     unsigned long long int msg = 0x10ULL << 23U;
     msg |= 1ULL << 21U;
@@ -180,6 +227,125 @@ static unsigned long long int
 edacs_extended_icall_msg2(int lcn, int source) {
     unsigned long long int msg = (unsigned long long int)(lcn & 0x1F) << 20U;
     msg |= (unsigned long long int)(source & 0xFFFFF);
+    return msg;
+}
+
+static unsigned long long int
+edacs_standard_data_msg1(int is_individual_call, int lcn, int target, int is_individual_id) {
+    unsigned long long int msg = 5ULL << 25U;
+    msg |= (unsigned long long int)(is_individual_call ? 1U : 0U) << 24U;
+    msg |= 1ULL << 23U;
+    msg |= (unsigned long long int)(lcn & 0x1F) << 15U;
+    msg |= (unsigned long long int)(is_individual_id ? 1U : 0U) << 14U;
+    msg |= (unsigned long long int)(target & 0x3FFF);
+    return msg;
+}
+
+static unsigned long long int
+edacs_standard_data_msg2(int port) {
+    return (unsigned long long int)(port & 0x7) << 20U;
+}
+
+static unsigned long long int
+edacs_standard_interconnect_msg1(int mt_c, int lcn, int target, int is_individual_id) {
+    unsigned long long int msg = (7ULL << 25U) | (1ULL << 22U);
+    msg |= (unsigned long long int)(mt_c & 0x3) << 20U;
+    msg |= (unsigned long long int)(lcn & 0x1F) << 15U;
+    msg |= (unsigned long long int)(is_individual_id ? 1U : 0U) << 14U;
+    msg |= (unsigned long long int)(target & 0x3FFF);
+    return msg;
+}
+
+static unsigned long long int
+edacs_standard_channel_update_msg1(int mt_c, int lcn, int group, int is_emergency) {
+    unsigned long long int msg = (7ULL << 25U) | (3ULL << 22U);
+    msg |= (unsigned long long int)(mt_c & 0x3) << 20U;
+    msg |= (unsigned long long int)(lcn & 0x1F) << 15U;
+    msg |= (unsigned long long int)(is_emergency ? 1U : 0U) << 13U;
+    msg |= (unsigned long long int)(group & 0x7FF);
+    return msg;
+}
+
+static unsigned long long int
+edacs_standard_channel_update_individual_msg1(int mt_c, int lcn, int lid) {
+    unsigned long long int msg = (7ULL << 25U) | (3ULL << 22U);
+    msg |= (unsigned long long int)(mt_c & 0x3) << 20U;
+    msg |= (unsigned long long int)(lcn & 0x1F) << 15U;
+    msg |= 1ULL << 14U;
+    msg |= (unsigned long long int)(lid & 0x3FFF);
+    return msg;
+}
+
+static unsigned long long int
+edacs_standard_mt_d_msg1(int mt_d) {
+    return (7ULL << 25U) | (7ULL << 22U) | ((unsigned long long int)(mt_d & 0x1F) << 17U);
+}
+
+static unsigned long long int
+edacs_standard_site_id_msg1(int cc_lcn, int priority, int site_id, int is_auxiliary) {
+    unsigned long long int msg = edacs_standard_mt_d_msg1(0x08);
+    msg |= (unsigned long long int)(cc_lcn & 0x1F) << 12U;
+    msg |= (unsigned long long int)(priority & 0x7) << 9U;
+    msg |= (unsigned long long int)(is_auxiliary ? 1U : 0U) << 5U;
+    msg |= (unsigned long long int)(site_id & 0x1F);
+    return msg;
+}
+
+static unsigned long long int
+edacs_standard_all_call_msg1(int lcn, int is_digital, int lid) {
+    unsigned long long int msg = edacs_standard_mt_d_msg1(0x0F);
+    msg |= (unsigned long long int)(lcn & 0x1F) << 12U;
+    msg |= (unsigned long long int)(is_digital ? 1U : 0U) << 11U;
+    msg |= 1ULL << 9U;
+    msg |= (unsigned long long int)(lid & 0x7F);
+    return msg;
+}
+
+static unsigned long long int
+edacs_standard_all_call_msg2(int lid) {
+    return (unsigned long long int)((lid >> 7U) & 0x7F) << 1U;
+}
+
+static unsigned long long int
+edacs_extended_mt2_msg1(int mt2) {
+    return (0x1FULL << 23U) | ((unsigned long long int)(mt2 & 0xF) << 19U);
+}
+
+static unsigned long long int
+edacs_extended_system_info_msg1(int system) {
+    return edacs_extended_mt2_msg1(0x8) | (unsigned long long int)(system & 0xFFFF);
+}
+
+static unsigned long long int
+edacs_extended_site_id_msg1(int site_id, int area) {
+    unsigned long long int msg = edacs_extended_mt2_msg1(0xA);
+    msg |= (unsigned long long int)(site_id & 0xE0) << 7U;
+    msg |= (unsigned long long int)(area & 0x7F) << 5U;
+    msg |= (unsigned long long int)(site_id & 0x1F);
+    return msg;
+}
+
+static unsigned long long int
+edacs_extended_test_call_msg1(int cc_lcn, int wc_lcn) {
+    unsigned long long int msg = edacs_extended_mt2_msg1(0x0);
+    msg |= (unsigned long long int)(cc_lcn & 0x1F) << 13U;
+    msg |= (unsigned long long int)(wc_lcn & 0x1F) << 7U;
+    return msg;
+}
+
+static unsigned long long int
+edacs_extended_channel_assignment_msg2(int lcn, int source) {
+    unsigned long long int msg = (unsigned long long int)(lcn & 0x1F) << 20U;
+    msg |= (unsigned long long int)(source & 0xFFFFF);
+    return msg;
+}
+
+static unsigned long long int
+edacs_extended_all_call_msg1(int lcn, int is_digital, int is_update) {
+    unsigned long long int msg = 0x16ULL << 23U;
+    msg |= (unsigned long long int)(lcn & 0x1F) << 17U;
+    msg |= (unsigned long long int)(is_digital ? 1U : 0U) << 16U;
+    msg |= (unsigned long long int)(is_update ? 1U : 0U) << 15U;
     return msg;
 }
 
@@ -206,6 +372,34 @@ edacs_setup_fixture(const edacs_grant_case* test_case) {
     g_skip_dibit_count = 0;
     g_last_vc_freq = 0;
     g_last_cc_freq = 0;
+    g_rigctl_current_freq = 0;
+}
+
+static void
+edacs_setup_state_fixture(int ea_mode) {
+    DSD_MEMSET(&g_opts, 0, sizeof(g_opts));
+    DSD_MEMSET(&g_state, 0, sizeof(g_state));
+
+    g_opts.p25_trunk = 1;
+    g_opts.trunk_enable = 1;
+    g_state.ea_mode = ea_mode;
+    g_state.edacs_cc_lcn = 1;
+    g_state.edacs_tuned_lcn = -1;
+    g_state.trunk_lcn_freq[0] = 851012500L;
+    g_state.trunk_lcn_freq[3] = 852762500L;
+    g_state.trunk_lcn_freq[8] = 854012500L;
+    g_state.p25_cc_freq = g_state.trunk_lcn_freq[0];
+    g_state.trunk_cc_freq = g_state.trunk_lcn_freq[0];
+
+    g_vc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_vc_tune_count = 0;
+    g_cc_tune_count = 0;
+    g_skip_dibit_count = 0;
+    g_last_vc_freq = 0;
+    g_last_cc_freq = 0;
+    g_rigctl_current_freq = 0;
+    edacs_install_hooks();
 }
 
 static int
@@ -451,6 +645,360 @@ edacs_run_retune_after_eot_case(const edacs_grant_case* test_case) {
     return rc;
 }
 
+static int
+edacs_run_standard_state_cases(void) {
+    int rc = 0;
+
+    edacs_setup_state_fixture(0);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_data_msg1(0, 4, 777, 0),
+                                           edacs_standard_data_msg2(5));
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 4, "standard-data-group", "state", "tracked data LCN");
+    rc |= edacs_expect(g_state.lasttg == 777 && g_state.lastsrc == 0x800, "standard-data-group", "state",
+                       "tracked data target/source");
+    rc |= edacs_expect(g_state.edacs_vc_call_type == EDACS_IS_GROUP, "standard-data-group", "state",
+                       "tracked group data call type");
+
+    edacs_setup_state_fixture(0);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_data_msg1(1, 9, 12345, 1),
+                                           edacs_standard_data_msg2(3));
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 9, "standard-data-individual", "state", "tracked data LCN");
+    rc |= edacs_expect(g_state.lasttg == 12345 && g_state.lastsrc == 0x800, "standard-data-individual", "state",
+                       "tracked individual data target/source");
+    rc |= edacs_expect(g_state.edacs_vc_call_type == EDACS_IS_INDIVIDUAL, "standard-data-individual", "state",
+                       "tracked individual data call type");
+
+    edacs_setup_state_fixture(0);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_interconnect_msg1(3, 4, 3210, 1), 0);
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 4, "standard-interconnect", "state", "tracked interconnect LCN");
+    rc |= edacs_expect(g_state.lasttg == 0 && g_state.lastsrc == 3210, "standard-interconnect", "state",
+                       "tracked interconnect target");
+    rc |= edacs_expect((g_state.edacs_vc_call_type & (EDACS_IS_VOICE | EDACS_IS_INTERCONNECT | EDACS_IS_DIGITAL))
+                           == (EDACS_IS_VOICE | EDACS_IS_INTERCONNECT | EDACS_IS_DIGITAL),
+                       "standard-interconnect", "state", "tracked interconnect flags");
+
+    edacs_setup_state_fixture(0);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_channel_update_msg1(1, 4, 654, 1), 0);
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 4, "standard-channel-update", "state", "tracked update LCN");
+    rc |= edacs_expect(g_state.lasttg == 654 && g_state.lastsrc == 0x800, "standard-channel-update", "state",
+                       "tracked update target/source");
+    rc |= edacs_expect(
+        (g_state.edacs_vc_call_type & (EDACS_IS_VOICE | EDACS_IS_GROUP | EDACS_IS_DIGITAL | EDACS_IS_EMERGENCY))
+            == (EDACS_IS_VOICE | EDACS_IS_GROUP | EDACS_IS_DIGITAL | EDACS_IS_EMERGENCY),
+        "standard-channel-update", "state", "tracked update flags");
+
+    edacs_setup_state_fixture(0);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_group_msg1(1, 6, 0x080, 3000),
+                                           edacs_standard_group_msg2(3000));
+    rc |=
+        edacs_expect(g_state.edacs_vc_lcn == 6, "standard-analog-agency-emergency", "state", "tracked voice group LCN");
+    rc |= edacs_expect(g_state.lasttg == 0x080 && g_state.lastsrc == 3000, "standard-analog-agency-emergency", "state",
+                       "tracked voice group ids");
+    rc |= edacs_expect(
+        (g_state.edacs_vc_call_type
+         & (EDACS_IS_VOICE | EDACS_IS_GROUP | EDACS_IS_EMERGENCY | EDACS_IS_AGENCY_CALL | EDACS_IS_DIGITAL))
+            == (EDACS_IS_VOICE | EDACS_IS_GROUP | EDACS_IS_EMERGENCY | EDACS_IS_AGENCY_CALL),
+        "standard-analog-agency-emergency", "state", "tracked analog agency emergency flags");
+
+    edacs_setup_state_fixture(0);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_channel_update_msg1(0, 7, 0x088, 0), 0);
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 7, "standard-channel-update-fleet", "state", "tracked fleet update LCN");
+    rc |= edacs_expect(g_state.lasttg == 0x088 && g_state.lastsrc == 0x800, "standard-channel-update-fleet", "state",
+                       "tracked fleet update target/source");
+    rc |= edacs_expect(
+        (g_state.edacs_vc_call_type & (EDACS_IS_VOICE | EDACS_IS_GROUP | EDACS_IS_FLEET_CALL | EDACS_IS_DIGITAL))
+            == (EDACS_IS_VOICE | EDACS_IS_GROUP | EDACS_IS_FLEET_CALL),
+        "standard-channel-update-fleet", "state", "tracked analog fleet update flags");
+
+    edacs_setup_state_fixture(0);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_channel_update_individual_msg1(3, 8, 4321),
+                                           1234);
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 8, "standard-channel-update-individual", "state",
+                       "tracked individual update LCN");
+    rc |= edacs_expect(g_state.lasttg == 4321 && g_state.lastsrc == 0x800, "standard-channel-update-individual",
+                       "state", "tracked individual update target/source");
+    rc |= edacs_expect((g_state.edacs_vc_call_type & (EDACS_IS_VOICE | EDACS_IS_INDIVIDUAL | EDACS_IS_DIGITAL))
+                           == (EDACS_IS_VOICE | EDACS_IS_INDIVIDUAL | EDACS_IS_DIGITAL),
+                       "standard-channel-update-individual", "state", "tracked digital individual update flags");
+
+    edacs_setup_state_fixture(0);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_channel_update_individual_msg1(0, 9, 0),
+                                           0);
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 9, "standard-channel-update-test-call", "state",
+                       "tracked test-call update LCN");
+    rc |= edacs_expect(g_state.lasttg == 0 && g_state.lastsrc == 0x800, "standard-channel-update-test-call", "state",
+                       "tracked test-call update target/source");
+    rc |= edacs_expect(g_state.edacs_vc_call_type == (EDACS_IS_VOICE | EDACS_IS_TEST_CALL),
+                       "standard-channel-update-test-call", "state", "tracked test-call update flags");
+
+    edacs_setup_state_fixture(0);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_individual_msg1(10, 0, 1), 0);
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 10, "standard-individual-test-call", "state",
+                       "tracked individual test-call LCN");
+    rc |= edacs_expect(g_state.lasttg == 0 && g_state.lastsrc == 0, "standard-individual-test-call", "state",
+                       "tracked individual test-call ids");
+    rc |= edacs_expect(g_state.edacs_vc_call_type == (EDACS_IS_VOICE | EDACS_IS_TEST_CALL | EDACS_IS_DIGITAL),
+                       "standard-individual-test-call", "state", "tracked individual test-call flags");
+
+    edacs_setup_state_fixture(0);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_site_id_msg1(4, 2, 0x1B, 0), 0);
+    rc |= edacs_expect(g_state.edacs_site_id == 0x1B, "standard-site-id", "state", "tracked site id");
+    rc |= edacs_expect(g_state.edacs_cc_lcn == 4, "standard-site-id", "state", "tracked CC LCN");
+    rc |= edacs_expect(g_state.p25_cc_freq == 852762500L && g_state.trunk_cc_freq == 852762500L, "standard-site-id",
+                       "state", "updated CC frequency from LCN map");
+
+    edacs_setup_state_fixture(0);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_site_id_msg1(9, 3, 0x0C, 1), 0);
+    rc |= edacs_expect(g_state.edacs_site_id == 0x0C, "standard-aux-site-id", "state", "tracked auxiliary site id");
+    rc |= edacs_expect(g_state.edacs_cc_lcn == 1, "standard-aux-site-id", "state",
+                       "auxiliary site did not replace CC LCN");
+    rc |= edacs_expect(g_state.trunk_cc_freq == 851012500L, "standard-aux-site-id", "state",
+                       "auxiliary site preserved CC frequency");
+
+    edacs_setup_state_fixture(0);
+    g_opts.use_rigctl = 1;
+    g_rigctl_current_freq = 855262500L;
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_site_id_msg1(12, 1, 0x12, 0), 0);
+    rc |= edacs_expect(g_state.edacs_site_id == 0x12, "standard-site-id-rigctl-capture", "state", "tracked site id");
+    rc |= edacs_expect(g_state.edacs_cc_lcn == 12, "standard-site-id-rigctl-capture", "state", "tracked rigctl CC LCN");
+    rc |= edacs_expect(g_state.trunk_lcn_freq[11] == 855262500L, "standard-site-id-rigctl-capture", "state",
+                       "captured missing LCN frequency from rigctl");
+    rc |= edacs_expect(g_state.p25_cc_freq == 855262500L && g_state.trunk_cc_freq == 855262500L,
+                       "standard-site-id-rigctl-capture", "state", "updated CC frequency from captured rigctl LCN");
+
+    edacs_setup_state_fixture(0);
+    g_opts.audio_in_type = AUDIO_IN_RTL;
+    g_opts.rtlsdr_center_freq = 856012500U;
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_site_id_msg1(13, 1, 0x13, 0), 0);
+    rc |= edacs_expect(g_state.edacs_cc_lcn == 13, "standard-site-id-rtl-capture", "state", "tracked RTL CC LCN");
+    rc |= edacs_expect(g_state.trunk_lcn_freq[12] == 856012500L, "standard-site-id-rtl-capture", "state",
+                       "captured missing LCN frequency from RTL center frequency");
+    rc |= edacs_expect(g_state.p25_cc_freq == 856012500L && g_state.trunk_cc_freq == 856012500L,
+                       "standard-site-id-rtl-capture", "state", "updated CC frequency from captured RTL LCN");
+
+    edacs_setup_state_fixture(0);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_standard_all_call_msg1(9, 1, 1010),
+                                           edacs_standard_all_call_msg2(1010));
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 9, "standard-all-call", "state", "tracked all-call LCN");
+    rc |= edacs_expect(g_state.lasttg == 0 && g_state.lastsrc == 1010, "standard-all-call", "state",
+                       "tracked all-call ids");
+    rc |= edacs_expect((g_state.edacs_vc_call_type & (EDACS_IS_VOICE | EDACS_IS_ALL_CALL | EDACS_IS_DIGITAL))
+                           == (EDACS_IS_VOICE | EDACS_IS_ALL_CALL | EDACS_IS_DIGITAL),
+                       "standard-all-call", "state", "tracked all-call flags");
+
+    return rc;
+}
+
+static int
+edacs_run_extended_state_cases(void) {
+    int rc = 0;
+
+    edacs_setup_state_fixture(1);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_extended_system_info_msg1(0x4567), 9);
+    rc |= edacs_expect(g_state.edacs_sys_id == 0x4567, "extended-system-info", "state", "tracked system id");
+    rc |= edacs_expect(g_state.edacs_cc_lcn == 9, "extended-system-info", "state", "tracked CC LCN");
+    rc |= edacs_expect(g_state.p25_cc_freq == 854012500L && g_state.trunk_cc_freq == 854012500L, "extended-system-info",
+                       "state", "updated CC frequency from LCN map");
+
+    edacs_setup_state_fixture(1);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_extended_site_id_msg1(0xA5, 0x34), 0);
+    rc |= edacs_expect(g_state.edacs_site_id == 0xA5, "extended-site-id", "state", "tracked site id");
+    rc |= edacs_expect(g_state.edacs_area_code == 0x34, "extended-site-id", "state", "tracked area code");
+
+    edacs_setup_state_fixture(1);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_extended_test_call_msg1(4, 9), 0);
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 9, "extended-test-call", "state", "tracked test-call working LCN");
+    rc |= edacs_expect(g_state.lasttg == 999999999 && g_state.lastsrc == 999999999, "extended-test-call", "state",
+                       "tracked test-call ids");
+    rc |= edacs_expect(g_state.edacs_vc_call_type == (EDACS_IS_VOICE | EDACS_IS_TEST_CALL), "extended-test-call",
+                       "state", "tracked test-call flags");
+
+    edacs_setup_state_fixture(1);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, 0x12ULL << 23U,
+                                           edacs_extended_channel_assignment_msg2(4, 0xABCDE));
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 4, "extended-channel-assignment", "state",
+                       "tracked channel assignment LCN");
+    rc |= edacs_expect(g_state.lastsrc == 0xABCDE, "extended-channel-assignment", "state",
+                       "tracked channel assignment source");
+    rc |= edacs_expect(g_state.edacs_vc_call_type == EDACS_IS_INDIVIDUAL, "extended-channel-assignment", "state",
+                       "tracked channel assignment call type");
+
+    edacs_setup_state_fixture(1);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_extended_all_call_msg1(4, 1, 1), 0xBCDEF);
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 4, "extended-all-call", "state", "tracked all-call LCN");
+    rc |= edacs_expect(g_state.lasttg == 0 && g_state.lastsrc == 0xBCDEF, "extended-all-call", "state",
+                       "tracked all-call ids");
+    rc |= edacs_expect((g_state.edacs_vc_call_type & (EDACS_IS_VOICE | EDACS_IS_ALL_CALL | EDACS_IS_DIGITAL))
+                           == (EDACS_IS_VOICE | EDACS_IS_ALL_CALL | EDACS_IS_DIGITAL),
+                       "extended-all-call", "state", "tracked all-call flags");
+
+    edacs_setup_state_fixture(1);
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_extended_group_update_msg1(0x6, 5, 0x3456, 1),
+                                           edacs_extended_group_msg2(0x45678, 1, 1));
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 5, "extended-analog-group-emergency-update", "state",
+                       "tracked analog group update LCN");
+    rc |= edacs_expect(g_state.lasttg == 0x3456 && g_state.lastsrc == 0x45678, "extended-analog-group-emergency-update",
+                       "state", "tracked analog group update ids");
+    rc |= edacs_expect(
+        (g_state.edacs_vc_call_type & (EDACS_IS_VOICE | EDACS_IS_GROUP | EDACS_IS_EMERGENCY | EDACS_IS_DIGITAL))
+            == (EDACS_IS_VOICE | EDACS_IS_GROUP | EDACS_IS_EMERGENCY),
+        "extended-analog-group-emergency-update", "state", "tracked analog emergency update flags");
+
+    edacs_setup_state_fixture(1);
+    g_state.edacs_vc_lcn = 17;
+    g_state.lastsrc = 0x12345;
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_extended_group_msg1(0x3, 0, 0x2222),
+                                           edacs_extended_group_msg2(0, 0, 1));
+    rc |= edacs_expect(g_state.edacs_vc_lcn == 17, "extended-zero-lcn-source-group", "state",
+                       "zero LCN preserved previous VC LCN");
+    rc |= edacs_expect(g_state.lasttg == 0x2222 && g_state.lastsrc == 0x12345, "extended-zero-lcn-source-group",
+                       "state", "zero source preserved previous source");
+    rc |= edacs_expect(g_state.edacs_vc_call_type == (EDACS_IS_VOICE | EDACS_IS_GROUP | EDACS_IS_DIGITAL),
+                       "extended-zero-lcn-source-group", "state", "tracked digital group flags with zero fields");
+
+    edacs_setup_state_fixture(1);
+    g_state.edacs_sys_id = 0x1111;
+    g_state.edacs_cc_lcn = 6;
+    g_state.p25_cc_freq = 852512500L;
+    g_state.trunk_cc_freq = 852512500L;
+    dsd_neo_edacs_test_process_valid_frame(&g_opts, &g_state, edacs_extended_system_info_msg1(0x7777), 0);
+    rc |= edacs_expect(g_state.edacs_sys_id == 0x1111, "extended-system-info-zero-lcn", "state",
+                       "zero LCN preserved previous system id");
+    rc |= edacs_expect(g_state.edacs_cc_lcn == 6, "extended-system-info-zero-lcn", "state",
+                       "zero LCN preserved previous CC LCN");
+    rc |= edacs_expect(g_state.p25_cc_freq == 852512500L && g_state.trunk_cc_freq == 852512500L,
+                       "extended-system-info-zero-lcn", "state", "zero LCN preserved CC frequencies");
+
+    return rc;
+}
+
+static int
+edacs_run_helper_contract_cases(void) {
+    int rc = 0;
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    rc |= edacs_expect(strcmp(dsd_neo_edacs_test_lcn_status_string(26), "[Reserved LCN Status]") == 0, "helpers",
+                       "lcn-status", "reserved status label");
+    rc |= edacs_expect(strcmp(dsd_neo_edacs_test_lcn_status_string(28), "[Convert To Callee]") == 0, "helpers",
+                       "lcn-status", "convert-to-callee label");
+    rc |= edacs_expect(strcmp(dsd_neo_edacs_test_lcn_status_string(31), "[Call Denied]") == 0, "helpers", "lcn-status",
+                       "call-denied label");
+    rc |= edacs_expect(dsd_neo_edacs_test_lcn_status_string(12)[0] == '\0', "helpers", "lcn-status",
+                       "ordinary LCN has no status label");
+
+    rc |= edacs_expect(dsd_neo_edacs_test_apply_input_volume(0, 1234) == 1234, "helpers", "input-volume",
+                       "disabled multiplier preserves sample");
+    rc |= edacs_expect(dsd_neo_edacs_test_apply_input_volume(3, 12000) == 32767, "helpers", "input-volume",
+                       "positive multiplier clamps high");
+    rc |= edacs_expect(dsd_neo_edacs_test_apply_input_volume(4, -12000) == -32768, "helpers", "input-volume",
+                       "positive multiplier clamps low");
+    rc |= edacs_expect(dsd_neo_edacs_test_apply_input_volume(2, 1000) == 2000, "helpers", "input-volume",
+                       "positive multiplier scales in range");
+
+    const unsigned long long int frame_a = 0x00F0F0F0F0ULL;
+    const unsigned long long int frame_b_inverted = (~0x00F0F0F0F1ULL) & 0xFFFFFFFFFFULL;
+    const unsigned long long int frame_c = 0x00F0F0F0F0ULL;
+    rc |= edacs_expect(dsd_neo_edacs_test_vote_frames(frame_a, frame_b_inverted, frame_c) == frame_a, "helpers", "vote",
+                       "majority vote repairs inverted copy bit");
+
+    rc |= edacs_expect(dsd_neo_edacs_test_update_squelch_count(1.0, 2.0, 5) == 4, "helpers", "squelch",
+                       "below-squelch decrements countdown");
+    rc |= edacs_expect(dsd_neo_edacs_test_update_squelch_count(3.0, 2.0, 1) == 5, "helpers", "squelch",
+                       "above-squelch resets countdown");
+
+    rc |= edacs_expect(dsd_neo_edacs_test_should_release_voice(0xAAAAAAAAAAAAAAAAULL, 0, time(NULL), 20.0) == 1,
+                       "helpers", "release", "dotting sequence releases voice");
+    rc |= edacs_expect(dsd_neo_edacs_test_should_release_voice(0x0000000000000000ULL, 0, time(NULL), 20.0) == 0,
+                       "helpers", "release", "non-dotting with squelch enabled stays active");
+    rc |= edacs_expect(dsd_neo_edacs_test_should_release_voice(0x0000000000000000ULL, 1, time(NULL) - 30, 20.0) == 1,
+                       "helpers", "release", "disabled-squelch watchdog releases voice");
+
+    dsd_neo_edacs_test_update_lcn_count(&state, 5);
+    rc |= edacs_expect(state.edacs_lcn_count == 5, "helpers", "lcn-count", "valid LCN raises count");
+    dsd_neo_edacs_test_update_lcn_count(&state, 31);
+    rc |= edacs_expect(state.edacs_lcn_count == 5, "helpers", "lcn-count", "reserved status LCN does not raise count");
+    dsd_neo_edacs_test_update_lcn_count(&state, 4);
+    rc |= edacs_expect(state.edacs_lcn_count == 5, "helpers", "lcn-count", "lower LCN preserves count");
+
+    static const unsigned long long int words[6] = {
+        0x0123456789ULL, 0x0FEDCBA987ULL, 0x055AA55AA5ULL, 0x0AA55AA55AULL, 0x0000000000ULL, 0x0FFFFFFFFFULL,
+    };
+    int edacs_bit[241];
+    DSD_MEMSET(edacs_bit, 0, sizeof(edacs_bit));
+    for (size_t word = 0U; word < 6U; word++) {
+        for (int bit = 0; bit < 40; bit++) {
+            edacs_bit[(word * 40U) + (size_t)bit] = (int)((words[word] >> (39 - bit)) & 1ULL);
+        }
+    }
+
+    unsigned long long int fr_1 = 0ULL;
+    unsigned long long int fr_2 = 0ULL;
+    unsigned long long int fr_3 = 0ULL;
+    unsigned long long int fr_4 = 0ULL;
+    unsigned long long int fr_5 = 0ULL;
+    unsigned long long int fr_6 = 0ULL;
+    dsd_neo_edacs_test_build_raw_frames(edacs_bit, &fr_1, &fr_2, &fr_3, &fr_4, &fr_5, &fr_6);
+    rc |= edacs_expect(fr_1 == words[0], "helpers", "raw-frame-build", "first raw frame packed from bits");
+    rc |= edacs_expect(fr_2 == words[1], "helpers", "raw-frame-build", "second raw frame packed from bits");
+    rc |= edacs_expect(fr_3 == words[2], "helpers", "raw-frame-build", "third raw frame packed from bits");
+    rc |= edacs_expect(fr_4 == words[3], "helpers", "raw-frame-build", "fourth raw frame packed from bits");
+    rc |= edacs_expect(fr_5 == words[4], "helpers", "raw-frame-build", "fifth raw frame packed from bits");
+    rc |= edacs_expect(fr_6 == words[5], "helpers", "raw-frame-build", "sixth raw frame packed from bits");
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    static int dibit_buf[900256];
+    static int payload_buf[900256];
+    DSD_MEMSET(dibit_buf, 0, sizeof(dibit_buf));
+    DSD_MEMSET(payload_buf, 0, sizeof(payload_buf));
+    state.dibit_buf = dibit_buf;
+    state.dmr_payload_buf = payload_buf;
+    state.synctype = DSD_SYNC_EDACS_POS;
+    state.center = 0;
+    state.dibit_buf_p = state.dibit_buf;
+    state.dmr_payload_p = state.dmr_payload_buf;
+    static short analog[960];
+    unsigned long long int expected_sr = 0ULL;
+    for (int sample = 0; sample < 960; sample++) {
+        analog[sample] = 0;
+    }
+    for (int bit = 0; bit < 192; bit++) {
+        const int value = (bit % 3) == 0 ? 700 : -700;
+        analog[bit * 5] = (short)value;
+        expected_sr = (expected_sr << 1U) | (unsigned long long int)(value > state.center ? 0U : 1U);
+    }
+
+    const unsigned long long int sr = dsd_neo_edacs_test_build_symbol_register(&opts, &state, analog);
+    rc |= edacs_expect(sr == expected_sr, "helpers", "symbol-register", "register packed digitized analog symbols");
+    rc |= edacs_expect(state.dibit_buf_p == state.dibit_buf + 192, "helpers", "symbol-register",
+                       "digitizer advanced dibit buffer once per symbol");
+    for (int bit = 0; bit < 192; bit++) {
+        const int want_stored_dibit = analog[bit * 5] > state.center ? 1 : 3;
+        rc |= edacs_expect(state.dibit_buf[bit] == want_stored_dibit, "helpers", "symbol-register",
+                           "stored two-level EDACS dibit");
+    }
+    rc |= edacs_expect(dsd_neo_edacs_test_build_symbol_register(NULL, &state, analog) == 0ULL, "helpers",
+                       "symbol-register", "null opts guard returns zero");
+
+    state.dibit_buf_p = state.dibit_buf + 900001;
+    state.dmr_payload_p = state.dmr_payload_buf + 900005;
+    dsd_neo_edacs_test_reset_digitize_overflow(&state);
+    rc |= edacs_expect(state.dibit_buf_p == state.dibit_buf + 200, "helpers", "overflow-reset",
+                       "large dibit pointer reset to guard offset");
+    rc |= edacs_expect(state.dmr_payload_p == state.dmr_payload_buf + 200, "helpers", "overflow-reset",
+                       "large payload pointer reset to guard offset");
+    state.dibit_buf_p = state.dibit_buf + 199;
+    state.dmr_payload_p = state.dmr_payload_buf + 199;
+    dsd_neo_edacs_test_reset_digitize_overflow(&state);
+    rc |= edacs_expect(state.dibit_buf_p == state.dibit_buf + 199, "helpers", "overflow-reset",
+                       "in-range dibit pointer preserved");
+    rc |= edacs_expect(state.dmr_payload_p == state.dmr_payload_buf + 199, "helpers", "overflow-reset",
+                       "in-range payload pointer preserved");
+
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -527,8 +1075,12 @@ main(void) {
     rc |= edacs_run_eot_retry_after_reject_case(DSD_TRUNK_TUNE_RESULT_FAILED, "failed-then-ok");
     rc |= edacs_run_eot_retry_after_reject_case(DSD_TRUNK_TUNE_RESULT_TIMEOUT, "timeout-then-ok");
     rc |= edacs_run_retune_after_eot_case(&cases[3]);
+    rc |= edacs_run_standard_state_cases();
+    rc |= edacs_run_extended_state_cases();
+    rc |= edacs_run_helper_contract_cases();
 
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    dsd_rigctl_query_hooks_set((dsd_rigctl_query_hooks){0});
     if (rc == 0) {
         printf("EDACS_GRANT_TUNE_MATRIX: OK\n");
     }
@@ -538,3 +1090,4 @@ main(void) {
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic pop
 #endif
+// NOLINTEND(bugprone-implicit-widening-of-multiplication-result)

--- a/tests/protocol/edacs/test_edacs_grant_tune_matrix.c
+++ b/tests/protocol/edacs/test_edacs_grant_tune_matrix.c
@@ -19,9 +19,18 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/protocol/edacs/edacs.h>
+#include <dsd-neo/runtime/exitflag.h>
+#include <dsd-neo/runtime/net_audio_input_hooks.h>
 #include <dsd-neo/runtime/rigctl_query_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <dsd-neo/runtime/udp_audio_hooks.h>
+#ifdef USE_RADIO
+#include <dsd-neo/runtime/rtl_stream_io_hooks.h>
+#endif
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -52,6 +61,12 @@ void dsd_neo_edacs_test_build_raw_frames(const int edacs_bit[241], unsigned long
 unsigned long long int dsd_neo_edacs_test_build_symbol_register(const dsd_opts* opts, dsd_state* state,
                                                                 const short analog1[960]);
 void dsd_neo_edacs_test_reset_digitize_overflow(dsd_state* state);
+int dsd_neo_edacs_test_collect_analog_triplet(dsd_opts* opts, dsd_state* state, short* analog1, short* analog2,
+                                              short* analog3, double* pwr);
+void dsd_neo_edacs_test_emit_analog_audio(dsd_opts* opts, dsd_state* state, const short* analog1, const short* analog2,
+                                          const short* analog3);
+int dsd_neo_edacs_test_static_wav_downsample(const short* src, short* out, size_t out_count);
+double dsd_neo_edacs_test_no_sql_watchdog_window(double trunk_hangtime);
 
 typedef struct {
     const char* name;
@@ -84,6 +99,19 @@ static int g_skip_dibit_count = 0;
 static long g_last_vc_freq = 0;
 static long g_last_cc_freq = 0;
 static long g_rigctl_current_freq = 0;
+static int g_tcp_read_count = 0;
+static int g_tcp_close_count = 0;
+static int g_tcp_fail_at = -1;
+static int g_udp_read_count = 0;
+static int g_udp_fail_every = 0;
+static int g_udp_blast_count = 0;
+static size_t g_udp_blast_bytes[3];
+static short g_udp_blast_first[3];
+#ifdef USE_RADIO
+static int g_rtl_read_count = 0;
+static int g_rtl_return_pwr_count = 0;
+static int g_rtl_fail_at = -1;
+#endif
 
 void
 // NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
@@ -156,6 +184,114 @@ edacs_install_hooks(void) {
     dsd_rigctl_query_hooks_set((dsd_rigctl_query_hooks){
         .get_current_freq_hz = edacs_hook_get_current_freq_hz,
     });
+}
+
+static int
+edacs_fake_tcp_read_sample(tcp_input_ctx* ctx, int16_t* out) {
+    (void)ctx;
+    const int index = g_tcp_read_count++;
+    if (out == NULL || (g_tcp_fail_at >= 0 && index == g_tcp_fail_at)) {
+        return 0;
+    }
+    *out = (int16_t)(1000 + index);
+    return 1;
+}
+
+static void
+edacs_fake_tcp_close(tcp_input_ctx* ctx) {
+    (void)ctx;
+    g_tcp_close_count++;
+}
+
+static int
+edacs_fake_udp_read_sample(dsd_opts* opts, int16_t* out) {
+    (void)opts;
+    const int index = g_udp_read_count++;
+    if (out == NULL || (g_udp_fail_every > 0 && (index % g_udp_fail_every) == 0)) {
+        return 0;
+    }
+    *out = (int16_t)(2000 + index);
+    return 1;
+}
+
+static void
+edacs_install_net_audio_hooks(void) {
+    dsd_net_audio_input_hooks hooks = {0};
+    hooks.tcp_read_sample = edacs_fake_tcp_read_sample;
+    hooks.tcp_close = edacs_fake_tcp_close;
+    hooks.udp_read_sample = edacs_fake_udp_read_sample;
+    dsd_net_audio_input_hooks_set(hooks);
+}
+
+static void
+edacs_fake_blast_analog(const dsd_opts* opts, dsd_state* state, size_t nsam, const void* data) {
+    (void)opts;
+    (void)state;
+    if (g_udp_blast_count < 3) {
+        g_udp_blast_bytes[g_udp_blast_count] = nsam;
+        g_udp_blast_first[g_udp_blast_count] = data != NULL ? ((const short*)data)[0] : 0;
+    }
+    g_udp_blast_count++;
+}
+
+static void
+edacs_install_udp_output_hooks(void) {
+    dsd_udp_audio_hooks_set((dsd_udp_audio_hooks){
+        .blast_analog = edacs_fake_blast_analog,
+    });
+}
+
+#ifdef USE_RADIO
+static int
+edacs_fake_rtl_read(void* rtl_ctx, float* out, size_t count, int* out_got) {
+    (void)rtl_ctx;
+    const int index = g_rtl_read_count++;
+    if (out_got != NULL) {
+        *out_got = 0;
+    }
+    if (out == NULL || out_got == NULL || count != 1U || (g_rtl_fail_at >= 0 && index == g_rtl_fail_at)) {
+        return -1;
+    }
+    out[0] = 100.0f + (float)index;
+    *out_got = 1;
+    return 0;
+}
+
+static double
+edacs_fake_rtl_return_pwr(const void* rtl_ctx) {
+    (void)rtl_ctx;
+    g_rtl_return_pwr_count++;
+    return 77.25;
+}
+
+static void
+edacs_install_rtl_stream_hooks(void) {
+    dsd_rtl_stream_io_hooks_set((dsd_rtl_stream_io_hooks){
+        .read = edacs_fake_rtl_read,
+        .return_pwr = edacs_fake_rtl_return_pwr,
+    });
+}
+#endif
+
+static void
+edacs_reset_audio_hook_state(void) {
+    g_tcp_read_count = 0;
+    g_tcp_close_count = 0;
+    g_tcp_fail_at = -1;
+    g_udp_read_count = 0;
+    g_udp_fail_every = 0;
+    g_udp_blast_count = 0;
+    DSD_MEMSET(g_udp_blast_bytes, 0, sizeof(g_udp_blast_bytes));
+    DSD_MEMSET(g_udp_blast_first, 0, sizeof(g_udp_blast_first));
+    dsd_net_audio_input_hooks_set((dsd_net_audio_input_hooks){0});
+    dsd_udp_audio_hooks_set((dsd_udp_audio_hooks){0});
+#ifdef USE_RADIO
+    g_rtl_read_count = 0;
+    g_rtl_return_pwr_count = 0;
+    g_rtl_fail_at = -1;
+    dsd_rtl_stream_io_hooks_set((dsd_rtl_stream_io_hooks){0});
+#endif
+    dsd_exitflag_store(0);
 }
 
 static int
@@ -999,6 +1135,187 @@ edacs_run_helper_contract_cases(void) {
     return rc;
 }
 
+static int
+edacs_run_analog_loop_helper_cases(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static short analog1[960];
+    static short analog2[960];
+    static short analog3[960];
+    double pwr = -1.0;
+    int tcp_ctx_token = 0xEAA5;
+
+    edacs_reset_audio_hook_state();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(analog1, 0, sizeof(analog1));
+    DSD_MEMSET(analog2, 0, sizeof(analog2));
+    DSD_MEMSET(analog3, 0, sizeof(analog3));
+    opts.audio_in_type = AUDIO_IN_TCP;
+    opts.input_volume_multiplier = 2;
+    opts.tcp_in_ctx = (tcp_input_ctx*)(void*)&tcp_ctx_token;
+    edacs_install_net_audio_hooks();
+
+    rc |= edacs_expect(dsd_neo_edacs_test_collect_analog_triplet(&opts, &state, analog1, analog2, analog3, &pwr) == 1,
+                       "analog-helpers", "tcp-collect", "TCP triplet collection succeeded");
+    rc |= edacs_expect(g_tcp_read_count == 2880, "analog-helpers", "tcp-collect", "TCP read exactly three blocks");
+    rc |= edacs_expect(g_tcp_close_count == 0, "analog-helpers", "tcp-collect", "TCP success did not close input");
+    rc |= edacs_expect(analog1[0] == 2000 && analog1[959] == 3918 && analog2[0] == 3920 && analog3[959] == 7758,
+                       "analog-helpers", "tcp-collect", "TCP samples preserved block ordering and volume scaling");
+    rc |= edacs_expect(pwr > 0.0, "analog-helpers", "tcp-collect", "TCP collection updated power");
+
+    edacs_reset_audio_hook_state();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_in_type = AUDIO_IN_UDP;
+    g_udp_fail_every = 4;
+    edacs_install_net_audio_hooks();
+    pwr = -1.0;
+    rc |= edacs_expect(dsd_neo_edacs_test_collect_analog_triplet(&opts, &state, analog1, analog2, analog3, &pwr) == 1,
+                       "analog-helpers", "udp-collect", "UDP triplet collection tolerates dropped samples");
+    rc |= edacs_expect(g_udp_read_count == 2880, "analog-helpers", "udp-collect", "UDP read exactly three blocks");
+    rc |= edacs_expect(analog1[0] == 0 && analog1[1] == 2001 && analog1[4] == 0 && analog2[0] == 0, "analog-helpers",
+                       "udp-collect", "UDP failed reads become zero samples");
+    rc |= edacs_expect(pwr > 0.0, "analog-helpers", "udp-collect", "UDP collection updated power");
+
+#ifdef USE_RADIO
+    edacs_reset_audio_hook_state();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtl_volume_multiplier = 2;
+    state.rtl_ctx = (struct RtlSdrContext*)(void*)&tcp_ctx_token;
+    edacs_install_rtl_stream_hooks();
+    pwr = -1.0;
+    rc |= edacs_expect(dsd_neo_edacs_test_collect_analog_triplet(&opts, &state, analog1, analog2, analog3, &pwr) == 1,
+                       "analog-helpers", "rtl-collect", "RTL triplet collection succeeded");
+    rc |= edacs_expect(g_rtl_read_count == 2880, "analog-helpers", "rtl-collect", "RTL read exactly three blocks");
+    rc |= edacs_expect(g_rtl_return_pwr_count == 1 && pwr == 77.25, "analog-helpers", "rtl-collect",
+                       "RTL collection used squelch power hook");
+    rc |= edacs_expect(analog1[0] == 200 && analog2[0] == 2120 && analog3[959] == 5958, "analog-helpers", "rtl-collect",
+                       "RTL samples preserved block ordering and volume scaling");
+#endif
+
+    static short wav_src[960];
+    static short wav_out[320];
+    for (int i = 0; i < 960; i++) {
+        wav_src[i] = (short)i;
+    }
+    DSD_MEMSET(wav_out, 0, sizeof(wav_out));
+    rc |= edacs_expect(dsd_neo_edacs_test_static_wav_downsample(wav_src, wav_out, 320U) == 0, "analog-helpers",
+                       "static-wav", "static WAV downsample helper accepted full output");
+    rc |= edacs_expect(wav_out[0] == 0 && wav_out[1] == 0 && wav_out[2] == 6 && wav_out[3] == 6 && wav_out[318] == 954
+                           && wav_out[319] == 954,
+                       "analog-helpers", "static-wav", "static WAV helper picked every sixth sample as stereo");
+    wav_out[0] = -123;
+    rc |= edacs_expect(dsd_neo_edacs_test_static_wav_downsample(wav_src, wav_out, 319U) == -1 && wav_out[0] == -123,
+                       "analog-helpers", "static-wav", "short output buffer is rejected without mutation");
+
+    rc |= edacs_expect(dsd_neo_edacs_test_no_sql_watchdog_window(0.5) == 20.0, "analog-helpers", "watchdog",
+                       "No-SQL watchdog clamps low hangtime");
+    rc |= edacs_expect(dsd_neo_edacs_test_no_sql_watchdog_window(4.5) == 45.0, "analog-helpers", "watchdog",
+                       "No-SQL watchdog preserves midrange hangtime");
+    rc |= edacs_expect(dsd_neo_edacs_test_no_sql_watchdog_window(8.0) == 60.0, "analog-helpers", "watchdog",
+                       "No-SQL watchdog clamps high hangtime");
+    rc |= edacs_expect(dsd_neo_edacs_test_should_release_voice(0x0000000000000000ULL, 1, time(NULL) - 5, 20.0) == 0,
+                       "analog-helpers", "watchdog", "No-SQL watchdog does not release before window");
+
+    static short out1[960];
+    static short out2[960];
+    static short out3[960];
+    for (int i = 0; i < 960; i++) {
+        out1[i] = (short)(11 + i);
+        out2[i] = (short)(22 + i);
+        out3[i] = (short)(33 + i);
+    }
+
+    edacs_reset_audio_hook_state();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    edacs_install_udp_output_hooks();
+    dsd_neo_edacs_test_emit_analog_audio(&opts, &state, out1, out2, out3);
+    rc |= edacs_expect(g_udp_blast_count == 3, "analog-helpers", "udp-output", "UDP output emitted three blocks");
+    rc |= edacs_expect(g_udp_blast_bytes[0] == 1920U && g_udp_blast_bytes[1] == 1920U && g_udp_blast_bytes[2] == 1920U,
+                       "analog-helpers", "udp-output", "UDP output emitted 960 short samples per block");
+    rc |= edacs_expect(g_udp_blast_first[0] == 11 && g_udp_blast_first[1] == 22 && g_udp_blast_first[2] == 33,
+                       "analog-helpers", "udp-output", "UDP output preserved block order");
+
+    char raw_path[] = "dsdneo_edacs_raw_XXXXXX";
+    int raw_fd = dsd_mkstemp(raw_path);
+    if (raw_fd < 0) {
+        rc |= edacs_expect(0, "analog-helpers", "raw-output", "created temporary raw output");
+    } else {
+        DSD_MEMSET(&opts, 0, sizeof(opts));
+        DSD_MEMSET(&state, 0, sizeof(state));
+        opts.audio_out_type = 1;
+        opts.floating_point = 0;
+        opts.slot1_on = 1;
+        opts.audio_out_fd = raw_fd;
+        dsd_neo_edacs_test_emit_analog_audio(&opts, &state, out1, out2, out3);
+        dsd_stat_t st;
+        DSD_MEMSET(&st, 0, sizeof(st));
+        rc |= edacs_expect(dsd_fstat(raw_fd, &st) == 0 && (long long)st.st_size == 5760LL, "analog-helpers",
+                           "raw-output", "raw fd output wrote three 960-sample blocks");
+        (void)dsd_close(raw_fd);
+        FILE* fp = fopen(raw_path, "rb");
+        if (fp == NULL) {
+            rc |= edacs_expect(0, "analog-helpers", "raw-output", "reopened raw output for verification");
+        } else {
+            short first1 = 0;
+            short first2 = 0;
+            short first3 = 0;
+            rc |= edacs_expect(fread(&first1, sizeof(first1), 1U, fp) == 1U, "analog-helpers", "raw-output",
+                               "read first raw block sample");
+            rc |= edacs_expect(fseek(fp, (long)(960U * sizeof(short)), SEEK_SET) == 0
+                                   && fread(&first2, sizeof(first2), 1U, fp) == 1U,
+                               "analog-helpers", "raw-output", "read second raw block sample");
+            rc |= edacs_expect(fseek(fp, (long)(1920U * sizeof(short)), SEEK_SET) == 0
+                                   && fread(&first3, sizeof(first3), 1U, fp) == 1U,
+                               "analog-helpers", "raw-output", "read third raw block sample");
+            rc |= edacs_expect(first1 == 11 && first2 == 22 && first3 == 33, "analog-helpers", "raw-output",
+                               "raw fd output preserved block order");
+            (void)fclose(fp);
+        }
+        (void)remove(raw_path);
+    }
+
+    edacs_reset_audio_hook_state();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_in_type = AUDIO_IN_TCP;
+    opts.tcp_in_ctx = (tcp_input_ctx*)(void*)&tcp_ctx_token;
+    g_tcp_fail_at = 5;
+    edacs_install_net_audio_hooks();
+    pwr = 123.0;
+    rc |= edacs_expect(dsd_neo_edacs_test_collect_analog_triplet(&opts, &state, analog1, analog2, analog3, &pwr) == 0,
+                       "analog-helpers", "tcp-cleanup", "TCP read failure aborts collection");
+    rc |= edacs_expect(g_tcp_read_count == 6 && g_tcp_close_count == 1 && opts.tcp_in_ctx == NULL, "analog-helpers",
+                       "tcp-cleanup", "TCP read failure closes and clears input context");
+    rc |=
+        edacs_expect(dsd_exitflag_load() == 1, "analog-helpers", "tcp-cleanup", "TCP read failure requested shutdown");
+
+#ifdef USE_RADIO
+    edacs_reset_audio_hook_state();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtl_volume_multiplier = 1;
+    state.rtl_ctx = (struct RtlSdrContext*)(void*)&tcp_ctx_token;
+    g_rtl_fail_at = 3;
+    edacs_install_rtl_stream_hooks();
+    rc |= edacs_expect(dsd_neo_edacs_test_collect_analog_triplet(&opts, &state, analog1, analog2, analog3, &pwr) == 0,
+                       "analog-helpers", "rtl-cleanup", "RTL read failure aborts collection");
+    rc |= edacs_expect(g_rtl_read_count == 4 && dsd_exitflag_load() == 1, "analog-helpers", "rtl-cleanup",
+                       "RTL read failure requested shutdown after bounded reads");
+#endif
+
+    edacs_reset_audio_hook_state();
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -1078,9 +1395,15 @@ main(void) {
     rc |= edacs_run_standard_state_cases();
     rc |= edacs_run_extended_state_cases();
     rc |= edacs_run_helper_contract_cases();
+    rc |= edacs_run_analog_loop_helper_cases();
 
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
     dsd_rigctl_query_hooks_set((dsd_rigctl_query_hooks){0});
+    dsd_net_audio_input_hooks_set((dsd_net_audio_input_hooks){0});
+    dsd_udp_audio_hooks_set((dsd_udp_audio_hooks){0});
+#ifdef USE_RADIO
+    dsd_rtl_stream_io_hooks_set((dsd_rtl_stream_io_hooks){0});
+#endif
     if (rc == 0) {
         printf("EDACS_GRANT_TUNE_MATRIX: OK\n");
     }

--- a/tests/protocol/m17/test_m17_state_dispatch.c
+++ b/tests/protocol/m17/test_m17_state_dispatch.c
@@ -1563,6 +1563,16 @@ test_encoder_packet_payload_layout(void) {
     DSD_MEMSET(full_bits, 0xA5, sizeof(full_bits));
     err |= expect_int("packet layout null guard",
                       dsd_neo_m17_test_prepare_pkt_payload("x", NULL, full_bits, &app_len, &block, &lst, &crc), -1);
+    err |= expect_int("packet layout null bits guard",
+                      dsd_neo_m17_test_prepare_pkt_payload("x", packed, NULL, &app_len, &block, &lst, &crc), -1);
+    err |= expect_int("packet layout null app-len guard",
+                      dsd_neo_m17_test_prepare_pkt_payload("x", packed, full_bits, NULL, &block, &lst, &crc), -1);
+    err |= expect_int("packet layout null block guard",
+                      dsd_neo_m17_test_prepare_pkt_payload("x", packed, full_bits, &app_len, NULL, &lst, &crc), -1);
+    err |= expect_int("packet layout null last-count guard",
+                      dsd_neo_m17_test_prepare_pkt_payload("x", packed, full_bits, &app_len, &block, NULL, &crc), -1);
+    err |= expect_int("packet layout null crc guard",
+                      dsd_neo_m17_test_prepare_pkt_payload("x", packed, full_bits, &app_len, &block, &lst, NULL), -1);
 
     err |= expect_int("packet layout short text",
                       dsd_neo_m17_test_prepare_pkt_payload("hi", packed, full_bits, &app_len, &block, &lst, &crc), 0);
@@ -1659,6 +1669,27 @@ test_encoder_packet_state_overrides_prepare_lsf_and_payload(void) {
         "packet state helper null guard",
         dsd_neo_m17_test_prepare_pkt_from_state(NULL, lsf_bits, packed, &app_len, &lsf_crc, &can, &dst, &src), -1);
     err |= expect_int(
+        "packet state helper null LSF guard",
+        dsd_neo_m17_test_prepare_pkt_from_state(&state, NULL, packed, &app_len, &lsf_crc, &can, &dst, &src), -1);
+    err |= expect_int(
+        "packet state helper null packet guard",
+        dsd_neo_m17_test_prepare_pkt_from_state(&state, lsf_bits, NULL, &app_len, &lsf_crc, &can, &dst, &src), -1);
+    err |= expect_int(
+        "packet state helper null app-len guard",
+        dsd_neo_m17_test_prepare_pkt_from_state(&state, lsf_bits, packed, NULL, &lsf_crc, &can, &dst, &src), -1);
+    err |= expect_int(
+        "packet state helper null LSF CRC guard",
+        dsd_neo_m17_test_prepare_pkt_from_state(&state, lsf_bits, packed, &app_len, NULL, &can, &dst, &src), -1);
+    err |= expect_int(
+        "packet state helper null CAN guard",
+        dsd_neo_m17_test_prepare_pkt_from_state(&state, lsf_bits, packed, &app_len, &lsf_crc, NULL, &dst, &src), -1);
+    err |= expect_int(
+        "packet state helper null dst guard",
+        dsd_neo_m17_test_prepare_pkt_from_state(&state, lsf_bits, packed, &app_len, &lsf_crc, &can, NULL, &src), -1);
+    err |= expect_int(
+        "packet state helper null src guard",
+        dsd_neo_m17_test_prepare_pkt_from_state(&state, lsf_bits, packed, &app_len, &lsf_crc, &can, &dst, NULL), -1);
+    err |= expect_int(
         "packet default state helper",
         dsd_neo_m17_test_prepare_pkt_from_state(&state, lsf_bits, packed, &app_len, &lsf_crc, &can, &dst, &src), 0);
     err |= expect_u8("packet default CAN", can, 7U);
@@ -1697,6 +1728,87 @@ test_encoder_packet_state_overrides_prepare_lsf_and_payload(void) {
     return err;
 }
 
+static int
+test_m17_hook_argument_guards(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t bits[M17_LICH_BITS];
+    uint8_t payload_bits[M17_STREAM_PAYLOAD_BITS];
+    uint8_t full_payload_bits[M17_PAYLOAD_BITS];
+    uint8_t processed_bits[M17_STREAM_PAYLOAD_BITS];
+    uint8_t lsf_bits[TEST_M17_LSF_BITS];
+    uint8_t lsf_packed[M17_LSF_BYTES];
+    uint8_t conn[11];
+    uint8_t disc[10];
+    uint8_t eotx[10];
+    uint8_t dibits[M17_FRAME_SYMBOLS];
+    uint8_t reversed[208];
+    uint8_t bert_bits[M17_BERT_PAYLOAD_BITS];
+    int err = 0;
+
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    DSD_MEMSET(payload_bits, 0, sizeof(payload_bits));
+    DSD_MEMSET(full_payload_bits, 0, sizeof(full_payload_bits));
+    DSD_MEMSET(processed_bits, 0x5A, sizeof(processed_bits));
+    DSD_MEMSET(lsf_bits, 0xA5, sizeof(lsf_bits));
+    DSD_MEMSET(lsf_packed, 0x5A, sizeof(lsf_packed));
+    DSD_MEMSET(conn, 0x11, sizeof(conn));
+    DSD_MEMSET(disc, 0x22, sizeof(disc));
+    DSD_MEMSET(eotx, 0x33, sizeof(eotx));
+    DSD_MEMSET(dibits, 0x44, sizeof(dibits));
+    DSD_MEMSET(reversed, 0x66, sizeof(reversed));
+    DSD_MEMSET(bert_bits, 0, sizeof(bert_bits));
+
+    err |= expect_int("process LICH rejects null state", dsd_neo_m17_test_process_lich(NULL, opts, bits), -1);
+    err |= expect_int("process LICH rejects null opts", dsd_neo_m17_test_process_lich(state, NULL, bits), -1);
+    err |= expect_int("process LICH rejects null bits", dsd_neo_m17_test_process_lich(state, opts, NULL), -1);
+
+    err |= expect_int("stream dispatch rejects null state",
+                      dsd_neo_m17_test_dispatch_stream_payload(opts, NULL, payload_bits, 0U, processed_bits),
+                      DSD_NEO_M17_TEST_STREAM_INVALID);
+    err |= expect_int("stream dispatch rejects null payload",
+                      dsd_neo_m17_test_dispatch_stream_payload(opts, state, NULL, 0U, processed_bits),
+                      DSD_NEO_M17_TEST_STREAM_INVALID);
+    err |= expect_int("stream dispatch rejects null output",
+                      dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, 0U, NULL),
+                      DSD_NEO_M17_TEST_STREAM_INVALID);
+
+    state->m17_bert_bits = 1234U;
+    dsd_neo_m17_test_process_bert_payload(NULL, state, bert_bits);
+    err |= expect_int("BERT null opts preserves state", (int)state->m17_bert_bits, 1234);
+    dsd_neo_m17_test_process_bert_payload(opts, state, NULL);
+    err |= expect_int("BERT null bits preserves state", (int)state->m17_bert_bits, 1234);
+
+    state->carrier = 1;
+    state->synctype = DSD_SYNC_M17_STR_POS;
+    dsd_neo_m17_test_dispatch_ip_frame(NULL, state, bits, sizeof(bits));
+    err |= expect_int("IP dispatch null opts preserves carrier", state->carrier, 1);
+    dsd_neo_m17_test_dispatch_ip_frame(opts, NULL, bits, sizeof(bits));
+    dsd_neo_m17_test_dispatch_ip_frame(opts, state, NULL, sizeof(bits));
+    err |= expect_int("IP dispatch null frame preserves synctype", state->synctype, DSD_SYNC_M17_STR_POS);
+
+    dsd_neo_m17_test_setup_conn_disc_eotx(0x0123456789ABULL, 'A', NULL, disc, eotx);
+    err |= expect_u8("setup CONN null guard preserves DISC", disc[0], 0x22U);
+    dsd_neo_m17_test_setup_conn_disc_eotx(0x0123456789ABULL, 'A', conn, NULL, eotx);
+    err |= expect_u8("setup DISC null guard preserves CONN", conn[0], 0x11U);
+    dsd_neo_m17_test_setup_conn_disc_eotx(0x0123456789ABULL, 'A', conn, disc, NULL);
+    err |= expect_u8("setup EOTX null guard preserves EOTX", eotx[0], 0x33U);
+
+    err |= expect_int("attach LSF CRC rejects null LSF", dsd_neo_m17_test_attach_lsf_crc(NULL, lsf_packed), 0);
+    err |= expect_int("attach LSF CRC rejects null packed", dsd_neo_m17_test_attach_lsf_crc(lsf_bits, NULL), 0);
+    dsd_neo_m17_test_load_lsf_callsigns(NULL, 1ULL, 2ULL);
+    dsd_neo_m17_test_apply_frame_prefix_dibits(2, NULL);
+    dsd_neo_m17_test_load_payload_dibits(NULL, dibits);
+    err |= expect_u8("payload dibits null input preserves output", dibits[M17_SYNC_SYMBOLS], 0x44U);
+    dsd_neo_m17_test_load_payload_dibits(full_payload_bits, NULL);
+    dsd_neo_m17_test_reverse_brt_bits(NULL, reversed);
+    err |= expect_u8("reverse BRT null input preserves output", reversed[0], 0x66U);
+
+    return err;
+}
+
 int
 main(void) {
     int err = 0;
@@ -1730,6 +1842,7 @@ main(void) {
     err |= test_encoder_packet_payload_layout();
     err |= test_packet_protocol_identifier_utf8_boundaries();
     err |= test_encoder_packet_state_overrides_prepare_lsf_and_payload();
+    err |= test_m17_hook_argument_guards();
 
     if (err == 0) {
         printf("M17_STATE_DISPATCH: OK\n");

--- a/tests/protocol/m17/test_m17_state_dispatch.c
+++ b/tests/protocol/m17/test_m17_state_dispatch.c
@@ -626,12 +626,19 @@ test_stream_dispatch_can_filter_and_aes_gates(void) {
     state->m17_str_dt = 1U;
     state->m17_can = 9U;
     state->m17_can_en = 8;
+    state->m17_enc = 2U;
+    state->m17_payload_decrypted = 6U;
+    DSD_MEMSET(processed_bits, 0xA5U, sizeof(processed_bits));
 
     int err = 0;
     err |= expect_int(
         "CAN filter blocks stream",
         dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, M17_REF_AES_TRANSMITTED_FN, processed_bits),
         DSD_NEO_M17_TEST_STREAM_CAN_FILTERED);
+    for (size_t i = 0U; i < sizeof(processed_bits); i++) {
+        err |= expect_u8("CAN-filtered stream clears output", processed_bits[i], 0U);
+    }
+    err |= expect_u8("CAN-filtered stream preserves decrypt flag", state->m17_payload_decrypted, 6U);
 
     state->m17_can_en = -1;
     state->m17_enc = 2U;

--- a/tests/protocol/m17/test_m17_state_dispatch.c
+++ b/tests/protocol/m17/test_m17_state_dispatch.c
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "fixtures/m17_reference_vectors.h"
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/m17/m17.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/protocol/m17/m17_parse.h"
+
+struct CODEC2;
+
+static dsd_opts g_opts;
+static dsd_state g_state;
+
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+uint64_t ConvertBitIntoBytes(const uint8_t* bits, uint32_t n);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void CNXDNConvolution_start(void);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void CNXDNConvolution_decode(uint8_t s0, uint8_t s1);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void CNXDNConvolution_chainback(unsigned char* out, unsigned int nBits);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void codec2_decode(struct CODEC2* codec2_state, short speech[], const unsigned char* bits);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void codec2_encode(struct CODEC2* codec2_state, unsigned char* bits, short speech[]);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+int codec2_samples_per_frame(struct CODEC2* codec2_state);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+void LFSRN(const char* BufferIn, char* BufferOut, dsd_state* state);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+uint16_t ComputeCrcCCITT16d(const uint8_t* buf, uint32_t len);
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+int Connect(char* hostname, int portno);
+
+uint64_t
+ConvertBitIntoBytes(const uint8_t* bits, uint32_t n) {
+    uint64_t value = 0ULL;
+    for (uint32_t i = 0U; i < n; i++) {
+        value = (value << 1U) | (uint64_t)(bits[i] & 1U);
+    }
+    return value;
+}
+
+void
+CNXDNConvolution_start(void) {}
+
+void
+CNXDNConvolution_decode(uint8_t s0, uint8_t s1) {
+    (void)s0;
+    (void)s1;
+}
+
+void
+CNXDNConvolution_chainback(unsigned char* out, unsigned int nBits) {
+    (void)out;
+    (void)nBits;
+}
+
+void
+codec2_decode(struct CODEC2* codec2_state, short speech[], const unsigned char* bits) {
+    (void)codec2_state;
+    (void)speech;
+    (void)bits;
+}
+
+void
+codec2_encode(struct CODEC2* codec2_state, unsigned char* bits, short speech[]) {
+    (void)codec2_state;
+    (void)bits;
+    (void)speech;
+}
+
+int
+codec2_samples_per_frame(struct CODEC2* codec2_state) {
+    (void)codec2_state;
+    return 0;
+}
+
+void
+LFSRN(const char* BufferIn, char* BufferOut, dsd_state* state) {
+    (void)BufferIn;
+    (void)BufferOut;
+    (void)state;
+}
+
+uint16_t
+ComputeCrcCCITT16d(const uint8_t* buf, uint32_t len) {
+    (void)buf;
+    (void)len;
+    return 0U;
+}
+
+int
+Connect(char* hostname, int portno) {
+    (void)hostname;
+    (void)portno;
+    return -1;
+}
+
+static void
+bytes_to_bits(const uint8_t* bytes, uint8_t* bits, size_t byte_count) {
+    for (size_t byte = 0U; byte < byte_count; byte++) {
+        for (size_t bit = 0U; bit < 8U; bit++) {
+            bits[(byte * 8U) + bit] = (uint8_t)((bytes[byte] >> (7U - bit)) & 1U);
+        }
+    }
+}
+
+static int
+expect_u64(const char* label, unsigned long long got, unsigned long long want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got 0x%llX want 0x%llX\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u8(const char* label, uint8_t got, uint8_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %u want %u\n", label, (unsigned)got, (unsigned)want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_int(const char* label, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_bytes(const char* label, const uint8_t* got, const uint8_t* want, size_t n) {
+    if (memcmp(got, want, n) != 0) {
+        DSD_FPRINTF(stderr, "%s: byte mismatch\n", label);
+        return 1;
+    }
+    return 0;
+}
+
+static struct m17_lsf_result
+valid_lsf_result(void) {
+    struct m17_lsf_result res;
+    DSD_MEMSET(&res, 0, sizeof(res));
+    res.dst = 0x0000009FDD51ULL;
+    res.src = 0x0000009FDD51ULL;
+    res.type_word = 0x0555U;
+    res.packet_stream = 1U;
+    res.dt = 2U;
+    res.et = 2U;
+    res.es = 0U;
+    res.cn = 9U;
+    res.signature = 1U;
+    res.meta_is_iv = 1U;
+    res.dst_is_valid = 1U;
+    res.src_is_valid = 1U;
+    res.type_reserved_valid = 1U;
+    DSD_MEMCPY(res.dst_csd, "AB1CD", 6U);
+    DSD_MEMCPY(res.src_csd, "AB1CD", 6U);
+    DSD_MEMCPY(res.meta, M17_REF_AES_NONCE, sizeof(res.meta));
+    return res;
+}
+
+static int
+test_lsf_application_resets_and_stores_state(void) {
+    dsd_state* state = &g_state;
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_dst = 0x1111ULL;
+    state->m17_src = 0x2222ULL;
+    state->m17_can = 3U;
+    state->m17_enc = 1U;
+    state->m17_payload_decrypted = 1U;
+    state->m17_signature_received_mask = 0x0FU;
+    state->m17_signature_complete = 1U;
+    state->m17_signature_bad_sequence = 1U;
+    state->m17_signature_verification_status = 99U;
+    DSD_MEMSET(state->m17_signature_digest, 0xA5, sizeof(state->m17_signature_digest));
+    DSD_MEMSET(state->m17_signature, 0x5A, sizeof(state->m17_signature));
+
+    struct m17_lsf_result res = valid_lsf_result();
+    int err = 0;
+    err |= expect_int("valid LSF applied", dsd_neo_m17_test_apply_lsf_result(state, &res), 1);
+    err |= expect_u64("LSF dst", state->m17_dst, res.dst);
+    err |= expect_u64("LSF src", state->m17_src, res.src);
+    err |= expect_u8("LSF CAN", state->m17_can, res.cn);
+    err |= expect_u8("LSF dt", state->m17_str_dt, res.dt);
+    err |= expect_u8("LSF enc", state->m17_enc, res.et);
+    err |= expect_u8("LSF enc subtype", state->m17_enc_st, res.es);
+    err |= expect_u8("LSF payload decrypted reset", state->m17_payload_decrypted, 0U);
+    err |= expect_u8("LSF signature advertised", state->m17_signature_advertised, 1U);
+    err |= expect_u8("LSF signature mask reset", state->m17_signature_received_mask, 0U);
+    err |= expect_u8("LSF signature complete reset", state->m17_signature_complete, 0U);
+    err |= expect_u8("LSF signature sequence reset", state->m17_signature_bad_sequence, 0U);
+    err |= expect_u8("LSF signature status reset", state->m17_signature_verification_status, 0U);
+    err |= expect_bytes("LSF meta nonce", state->m17_meta, M17_REF_AES_NONCE, sizeof(M17_REF_AES_NONCE));
+    for (size_t i = 0U; i < sizeof(state->m17_signature_digest); i++) {
+        err |= expect_u8("LSF digest reset", state->m17_signature_digest[i], 0U);
+    }
+    for (size_t i = 0U; i < sizeof(state->m17_signature); i++) {
+        err |= expect_u8("LSF signature buffer reset", state->m17_signature[i], 0U);
+    }
+    if (strcmp(state->m17_dst_str, "AB1CD") != 0 || strcmp(state->m17_src_str, "AB1CD") != 0) {
+        DSD_FPRINTF(stderr, "LSF callsigns: dst='%s' src='%s'\n", state->m17_dst_str, state->m17_src_str);
+        err |= 1;
+    }
+    return err;
+}
+
+static int
+test_lsf_rejects_reserved_type_without_replacing_state(void) {
+    dsd_state* state = &g_state;
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_dst = 0x1111ULL;
+    state->m17_src = 0x2222ULL;
+    state->m17_can = 4U;
+    state->m17_enc = 1U;
+
+    struct m17_lsf_result res = valid_lsf_result();
+    res.rs = 1U;
+
+    int err = 0;
+    err |= expect_int("reserved LSF rejected", dsd_neo_m17_test_apply_lsf_result(state, &res), 0);
+    err |= expect_u64("reserved LSF dst preserved", state->m17_dst, 0x1111ULL);
+    err |= expect_u64("reserved LSF src preserved", state->m17_src, 0x2222ULL);
+    err |= expect_u8("reserved LSF CAN preserved", state->m17_can, 4U);
+    err |= expect_u8("reserved LSF enc preserved", state->m17_enc, 1U);
+    return err;
+}
+
+static int
+test_stream_dispatch_can_filter_and_aes_gates(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t payload_bits[128];
+    uint8_t processed_bits[128];
+    uint8_t plaintext_bits[128];
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+
+    bytes_to_bits(M17_REF_AES_CIPHERTEXT, payload_bits, sizeof(M17_REF_AES_CIPHERTEXT));
+    bytes_to_bits(M17_REF_AES_PLAINTEXT, plaintext_bits, sizeof(M17_REF_AES_PLAINTEXT));
+    state->m17_str_dt = 1U;
+    state->m17_can = 9U;
+    state->m17_can_en = 8;
+
+    int err = 0;
+    err |= expect_int(
+        "CAN filter blocks stream",
+        dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, M17_REF_AES_TRANSMITTED_FN, processed_bits),
+        DSD_NEO_M17_TEST_STREAM_CAN_FILTERED);
+
+    state->m17_can_en = -1;
+    state->m17_enc = 2U;
+    state->m17_enc_st = 0U;
+    DSD_MEMCPY(state->m17_meta, M17_REF_AES_NONCE, sizeof(M17_REF_AES_NONCE));
+    err |= expect_int(
+        "AES missing key locks stream",
+        dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, M17_REF_AES_TRANSMITTED_FN, processed_bits),
+        DSD_NEO_M17_TEST_STREAM_ENCRYPTED_LOCKED);
+
+    DSD_MEMCPY(state->aes_key, M17_REF_AES128_KEY, sizeof(M17_REF_AES128_KEY));
+    state->aes_key_loaded[0] = 1;
+    state->aes_key_segments[0] = 2U;
+    state->m17_payload_decrypted = 7U;
+    err |= expect_int(
+        "AES stream dispatches",
+        dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, M17_REF_AES_TRANSMITTED_FN, processed_bits),
+        DSD_NEO_M17_TEST_STREAM_ENCRYPTED_DISPATCHED);
+    err |= expect_bytes("AES stream plaintext bits", processed_bits, plaintext_bits, sizeof(plaintext_bits));
+    err |= expect_u8("AES transient decrypt flag restored", state->m17_payload_decrypted, 7U);
+    return err;
+}
+
+int
+main(void) {
+    int err = 0;
+    err |= test_lsf_application_resets_and_stores_state();
+    err |= test_lsf_rejects_reserved_type_without_replacing_state();
+    err |= test_stream_dispatch_can_filter_and_aes_gates();
+
+    if (err == 0) {
+        printf("M17_STATE_DISPATCH: OK\n");
+    }
+    return err;
+}

--- a/tests/protocol/m17/test_m17_state_dispatch.c
+++ b/tests/protocol/m17/test_m17_state_dispatch.c
@@ -1,25 +1,47 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
 #include "fixtures/m17_reference_vectors.h"
 
+#include <assert.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/protocol/m17/m17.h>
+#include <dsd-neo/runtime/udp_audio_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/protocol/m17/m17_parse.h"
+#include "dsd-neo/protocol/m17/m17_tables.h"
+#include "m17_algorithms.h"
 
 struct CODEC2;
 
 static dsd_opts g_opts;
 static dsd_state g_state;
+static int g_codec2_decode_calls;
+static unsigned char g_codec2_last_bits[8];
+static int g_udp_audio_calls;
+static size_t g_udp_audio_last_nsam;
+static const dsd_opts* g_udp_audio_last_opts;
+static dsd_state* g_udp_audio_last_state;
+static short g_udp_audio_last_first_sample;
+static int g_conv_start_calls;
+static int g_conv_decode_calls;
+static int g_conv_chainback_calls;
+static unsigned int g_conv_chainback_bits;
+static uint8_t g_conv_first_symbols[8];
+
+enum { TEST_M17_LSF_BITS = M17_LSF_BYTES * 8U };
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 uint64_t ConvertBitIntoBytes(const uint8_t* bits, uint32_t n);
@@ -52,25 +74,44 @@ ConvertBitIntoBytes(const uint8_t* bits, uint32_t n) {
 }
 
 void
-CNXDNConvolution_start(void) {}
+CNXDNConvolution_start(void) {
+    g_conv_start_calls++;
+}
 
 void
 CNXDNConvolution_decode(uint8_t s0, uint8_t s1) {
-    (void)s0;
-    (void)s1;
+    const int index = g_conv_decode_calls * 2;
+    if (index + 1 < (int)sizeof(g_conv_first_symbols)) {
+        g_conv_first_symbols[index] = s0;
+        g_conv_first_symbols[index + 1] = s1;
+    }
+    g_conv_decode_calls++;
 }
 
 void
 CNXDNConvolution_chainback(unsigned char* out, unsigned int nBits) {
-    (void)out;
-    (void)nBits;
+    g_conv_chainback_calls++;
+    g_conv_chainback_bits = nBits;
+    if (out != NULL) {
+        const unsigned int byte_count = (nBits + 7U) / 8U;
+        for (unsigned int i = 0U; i < byte_count; i++) {
+            out[i] = (unsigned char)(0xA0U + i);
+        }
+    }
 }
 
 void
 codec2_decode(struct CODEC2* codec2_state, short speech[], const unsigned char* bits) {
     (void)codec2_state;
-    (void)speech;
-    (void)bits;
+    g_codec2_decode_calls++;
+    if (bits != NULL) {
+        DSD_MEMCPY(g_codec2_last_bits, bits, sizeof(g_codec2_last_bits));
+    }
+    if (speech != NULL) {
+        for (size_t i = 0U; i < 160U; i++) {
+            speech[i] = (short)(1000 + g_codec2_decode_calls + (int)i);
+        }
+    }
 }
 
 void
@@ -105,6 +146,44 @@ Connect(char* hostname, int portno) {
     (void)hostname;
     (void)portno;
     return -1;
+}
+
+static void
+fake_udp_audio_blast(const dsd_opts* opts, dsd_state* state, size_t nsam, const void* data) {
+    g_udp_audio_calls++;
+    g_udp_audio_last_opts = opts;
+    g_udp_audio_last_state = state;
+    g_udp_audio_last_nsam = nsam;
+    g_udp_audio_last_first_sample = (data != NULL) ? ((const short*)data)[0] : 0;
+}
+
+static void
+reset_audio_fakes(void) {
+    dsd_udp_audio_hooks hooks = {0};
+    dsd_udp_audio_hooks_set(hooks);
+    g_codec2_decode_calls = 0;
+    DSD_MEMSET(g_codec2_last_bits, 0, sizeof(g_codec2_last_bits));
+    g_udp_audio_calls = 0;
+    g_udp_audio_last_nsam = 0U;
+    g_udp_audio_last_opts = NULL;
+    g_udp_audio_last_state = NULL;
+    g_udp_audio_last_first_sample = 0;
+}
+
+static void
+reset_convolution_fake(void) {
+    g_conv_start_calls = 0;
+    g_conv_decode_calls = 0;
+    g_conv_chainback_calls = 0;
+    g_conv_chainback_bits = 0U;
+    DSD_MEMSET(g_conv_first_symbols, 0, sizeof(g_conv_first_symbols));
+}
+
+static void
+install_fake_udp_audio(void) {
+    dsd_udp_audio_hooks hooks = {0};
+    hooks.blast = fake_udp_audio_blast;
+    dsd_udp_audio_hooks_set(hooks);
 }
 
 static void
@@ -152,6 +231,111 @@ expect_bytes(const char* label, const uint8_t* got, const uint8_t* want, size_t 
     return 0;
 }
 
+static unsigned long long
+bits_to_u64(const uint8_t* bits, size_t n) {
+    unsigned long long value = 0ULL;
+    for (size_t i = 0U; i < n; i++) {
+        value = (value << 1U) | (unsigned long long)(bits[i] & 1U);
+    }
+    return value;
+}
+
+static void
+write_bits_from_u64(uint8_t* bits, unsigned long long value, size_t n) {
+    for (size_t i = 0U; i < n; i++) {
+        const size_t shift = n - 1U - i;
+        bits[i] = (uint8_t)((value >> shift) & 1U);
+    }
+}
+
+static void
+pack_bits_msb(const uint8_t* bits, size_t bit_count, uint8_t* bytes, size_t byte_count) {
+    DSD_MEMSET(bytes, 0, byte_count);
+    for (size_t bit = 0U; bit < bit_count; bit++) {
+        if ((bits[bit] & 1U) != 0U) {
+            bytes[bit / 8U] |= (uint8_t)(1U << (7U - (bit % 8U)));
+        }
+    }
+}
+
+static void
+expect_signature_slice(uint8_t* out, size_t offset) {
+    bytes_to_bits(M17_REF_SIGNATURE_BYTES + offset, out, 16U);
+}
+
+static void
+build_lsf_bits(uint8_t lsf_bits[TEST_M17_LSF_BITS], unsigned long long dst, unsigned long long src, uint16_t type_word,
+               const uint8_t meta[M17_AES_NONCE_BYTES]) {
+    DSD_MEMSET(lsf_bits, 0, TEST_M17_LSF_BITS);
+    dsd_neo_m17_test_load_lsf_callsigns(lsf_bits, dst, src);
+    write_bits_from_u64(lsf_bits + 96, type_word, 16U);
+    if (meta != NULL) {
+        for (size_t i = 0U; i < M17_AES_NONCE_BYTES; i++) {
+            write_bits_from_u64(lsf_bits + 112U + (i * 8U), meta[i], 8U);
+        }
+    }
+}
+
+static void
+build_encoded_lich_chunk(const uint8_t lsf_bits[TEST_M17_LSF_BITS], uint8_t lich_counter,
+                         uint8_t encoded[M17_LICH_BITS]) {
+    uint8_t content[M17_LICH_CONTENT_BITS];
+    DSD_MEMSET(content, 0, sizeof(content));
+    DSD_MEMSET(encoded, 0, M17_LICH_BITS);
+    assert(m17_lich_build_content(lsf_bits, lich_counter, content) == 0);
+    m17_lich_encode_bits(content, encoded);
+}
+
+static void
+build_ip_stream_frame(uint8_t ip_frame[54], const uint8_t lsf_bits[TEST_M17_LSF_BITS], uint16_t sid, uint16_t fn,
+                      uint8_t eot, const uint8_t payload_bits[M17_STREAM_PAYLOAD_BITS]) {
+    uint8_t ip_bits[52U * 8U];
+    DSD_MEMSET(ip_bits, 0, sizeof(ip_bits));
+
+    write_bits_from_u64(ip_bits, (unsigned long long)'M', 8U);
+    write_bits_from_u64(ip_bits + 8, (unsigned long long)'1', 8U);
+    write_bits_from_u64(ip_bits + 16, (unsigned long long)'7', 8U);
+    write_bits_from_u64(ip_bits + 24, (unsigned long long)' ', 8U);
+    write_bits_from_u64(ip_bits + 32, sid, 16U);
+    for (size_t i = 0U; i < M17_LSF_LSD_BITS; i++) {
+        ip_bits[48U + i] = lsf_bits[i];
+    }
+    ip_bits[272] = (uint8_t)(eot & 1U);
+    write_bits_from_u64(ip_bits + 273, fn & 0x7FFFU, 15U);
+    for (size_t i = 0U; i < M17_STREAM_PAYLOAD_BITS; i++) {
+        ip_bits[288U + i] = payload_bits[i];
+    }
+
+    pack_bits_msb(ip_bits, sizeof(ip_bits), ip_frame, 52U);
+    const uint16_t crc = m17_crc16(ip_frame, 52U);
+    ip_frame[52] = (uint8_t)((crc >> 8U) & 0xFFU);
+    ip_frame[53] = (uint8_t)(crc & 0xFFU);
+}
+
+static size_t
+build_ip_mpkt_frame(uint8_t* ip_frame, size_t ip_frame_len, const uint8_t lsf_bits[TEST_M17_LSF_BITS], uint16_t sid,
+                    const uint8_t* app, size_t app_len) {
+    const size_t frame_len = 34U + app_len + 3U;
+    if (ip_frame == NULL || lsf_bits == NULL || app == NULL || ip_frame_len < frame_len) {
+        return 0U;
+    }
+
+    DSD_MEMSET(ip_frame, 0, ip_frame_len);
+    ip_frame[0] = 'M';
+    ip_frame[1] = 'P';
+    ip_frame[2] = 'K';
+    ip_frame[3] = 'T';
+    ip_frame[4] = (uint8_t)((sid >> 8U) & 0xFFU);
+    ip_frame[5] = (uint8_t)(sid & 0xFFU);
+    pack_bits_msb(lsf_bits, M17_LSF_LSD_BITS, ip_frame + 6, M17_LSF_LSD_BYTES);
+    DSD_MEMCPY(ip_frame + 34, app, app_len);
+
+    const uint16_t crc = m17_crc16(ip_frame, (uint16_t)(frame_len - 2U));
+    ip_frame[frame_len - 2U] = (uint8_t)((crc >> 8U) & 0xFFU);
+    ip_frame[frame_len - 1U] = (uint8_t)(crc & 0xFFU);
+    return frame_len;
+}
+
 static struct m17_lsf_result
 valid_lsf_result(void) {
     struct m17_lsf_result res;
@@ -173,6 +357,102 @@ valid_lsf_result(void) {
     DSD_MEMCPY(res.src_csd, "AB1CD", 6U);
     DSD_MEMCPY(res.meta, M17_REF_AES_NONCE, sizeof(res.meta));
     return res;
+}
+
+static int
+test_embedded_lich_chunks_store_and_finalize_lsf_state(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t lsf_bits[TEST_M17_LSF_BITS];
+    uint8_t lsf_packed[M17_LSF_BYTES];
+    uint8_t encoded[M17_LICH_BITS];
+
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(lsf_packed, 0, sizeof(lsf_packed));
+
+    const unsigned long long dst = m17_encode_b40_callsign(0ULL, M17_REF_LSF_DST_CSD);
+    const unsigned long long src = m17_encode_b40_callsign(0ULL, M17_REF_LSF_SRC_CSD);
+    const uint16_t type_word = dsd_neo_m17_test_compose_frame_info(1U, 2U, 0U, 0U, 6U, 1U, 0U);
+    build_lsf_bits(lsf_bits, dst, src, type_word, NULL);
+    (void)dsd_neo_m17_test_attach_lsf_crc(lsf_bits, lsf_packed);
+
+    int err = 0;
+    for (uint8_t chunk = 0U; chunk < (M17_LICH_CHUNKS - 1U); chunk++) {
+        build_encoded_lich_chunk(lsf_bits, chunk, encoded);
+        err |= expect_int("LICH chunk accepted", dsd_neo_m17_test_process_lich(state, opts, encoded), 0);
+        for (size_t bit = 0U; bit < M17_LICH_CHUNK_BITS; bit++) {
+            err |= expect_u8("LICH chunk stored", state->m17_lsf[((size_t)chunk * M17_LICH_CHUNK_BITS) + bit],
+                             lsf_bits[((size_t)chunk * M17_LICH_CHUNK_BITS) + bit]);
+        }
+        err |= expect_u64("LICH does not decode before final chunk", state->m17_dst, 0ULL);
+    }
+
+    build_encoded_lich_chunk(lsf_bits, (uint8_t)(M17_LICH_CHUNKS - 1U), encoded);
+    err |= expect_int("final LICH chunk accepted", dsd_neo_m17_test_process_lich(state, opts, encoded), 0);
+    err |= expect_u64("final LICH decodes dst", state->m17_dst, dst);
+    err |= expect_u64("final LICH decodes src", state->m17_src, src);
+    err |= expect_u8("final LICH decodes data type", state->m17_str_dt, 2U);
+    err |= expect_u8("final LICH decodes CAN", state->m17_can, 6U);
+    err |= expect_u8("final LICH clear encryption", state->m17_enc, 0U);
+    err |= expect_u8("final LICH advertises signature", state->m17_signature_advertised, 1U);
+    for (size_t bit = 0U; bit < TEST_M17_LSF_BITS; bit++) {
+        err |= expect_u8("final LICH clears staged LSF", state->m17_lsf[bit], 0U);
+    }
+    if (strcmp(state->m17_dst_str, M17_REF_LSF_DST_CSD) != 0 || strcmp(state->m17_src_str, M17_REF_LSF_SRC_CSD) != 0) {
+        DSD_FPRINTF(stderr, "final LICH callsigns: dst='%s' src='%s'\n", state->m17_dst_str, state->m17_src_str);
+        err |= 1;
+    }
+    return err;
+}
+
+static int
+test_embedded_lich_rejects_invalid_counter_and_gates_bad_lsf_crc(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t lsf_bits[TEST_M17_LSF_BITS];
+    uint8_t lsf_packed[M17_LSF_BYTES];
+    uint8_t encoded[M17_LICH_BITS];
+
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(lsf_packed, 0, sizeof(lsf_packed));
+
+    const unsigned long long dst = m17_encode_b40_callsign(0ULL, M17_REF_LSF_DST_CSD);
+    const unsigned long long src = m17_encode_b40_callsign(0ULL, M17_REF_LSF_SRC_CSD);
+    const uint16_t type_word = dsd_neo_m17_test_compose_frame_info(1U, 1U, 0U, 0U, 7U, 0U, 0U);
+    build_lsf_bits(lsf_bits, dst, src, type_word, NULL);
+    (void)dsd_neo_m17_test_attach_lsf_crc(lsf_bits, lsf_packed);
+
+    uint8_t invalid_content[M17_LICH_CONTENT_BITS];
+    DSD_MEMSET(invalid_content, 0, sizeof(invalid_content));
+    invalid_content[40] = 1U;
+    invalid_content[41] = 1U;
+    invalid_content[42] = 0U;
+    m17_lich_encode_bits(invalid_content, encoded);
+    DSD_MEMSET(state->m17_lsf, 0x5AU, sizeof(state->m17_lsf));
+
+    int err = 0;
+    err |= expect_int("invalid-counter LICH chunk rejected", dsd_neo_m17_test_process_lich(state, opts, encoded), -1);
+    for (size_t bit = 0U; bit < TEST_M17_LSF_BITS; bit++) {
+        err |= expect_u8("invalid-counter LICH preserves staged LSF", state->m17_lsf[bit], 0x5AU);
+    }
+
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->aggressive_framesync = 1;
+    state->m17_dst = 0x111122223333ULL;
+    state->m17_src = 0x444455556666ULL;
+    lsf_bits[M17_LSF_LSD_BITS + 3U] ^= 1U;
+    for (uint8_t chunk = 0U; chunk < M17_LICH_CHUNKS; chunk++) {
+        build_encoded_lich_chunk(lsf_bits, chunk, encoded);
+        err |= expect_int("bad CRC LICH chunk accepted", dsd_neo_m17_test_process_lich(state, opts, encoded), 0);
+    }
+    err |= expect_u64("bad LSF CRC preserves dst under aggressive sync", state->m17_dst, 0x111122223333ULL);
+    err |= expect_u64("bad LSF CRC preserves src under aggressive sync", state->m17_src, 0x444455556666ULL);
+    for (size_t bit = 0U; bit < TEST_M17_LSF_BITS; bit++) {
+        err |= expect_u8("bad LSF CRC clears staged LSF", state->m17_lsf[bit], 0U);
+    }
+    return err;
 }
 
 static int
@@ -242,6 +522,96 @@ test_lsf_rejects_reserved_type_without_replacing_state(void) {
 }
 
 static int
+test_lsf_rejects_invalid_addresses_without_replacing_state(void) {
+    dsd_state* state = &g_state;
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_dst = 0x1234ULL;
+    state->m17_src = 0x5678ULL;
+    state->m17_can = 6U;
+    state->m17_str_dt = 3U;
+
+    struct m17_lsf_result res = valid_lsf_result();
+    res.dst_is_valid = 0U;
+
+    int err = 0;
+    err |= expect_int("invalid destination rejected", dsd_neo_m17_test_apply_lsf_result(state, &res), 0);
+    err |= expect_u64("invalid destination preserves dst", state->m17_dst, 0x1234ULL);
+    err |= expect_u64("invalid destination preserves src", state->m17_src, 0x5678ULL);
+    err |= expect_u8("invalid destination preserves CAN", state->m17_can, 6U);
+    err |= expect_u8("invalid destination preserves data type", state->m17_str_dt, 3U);
+
+    res = valid_lsf_result();
+    res.src_is_valid = 0U;
+    err |= expect_int("invalid source rejected", dsd_neo_m17_test_apply_lsf_result(state, &res), 0);
+    err |= expect_u64("invalid source preserves dst", state->m17_dst, 0x1234ULL);
+    err |= expect_u64("invalid source preserves src", state->m17_src, 0x5678ULL);
+    err |= expect_u8("invalid source preserves CAN", state->m17_can, 6U);
+    err |= expect_u8("invalid source preserves data type", state->m17_str_dt, 3U);
+    return err;
+}
+
+static int
+test_lsf_null_meta_decodes_text_and_honors_can_filter(void) {
+    dsd_state* state = &g_state;
+    uint8_t expected_text[M17_TEXT_BLOCK_BYTES];
+    DSD_MEMSET(expected_text, 0, sizeof(expected_text));
+    DSD_MEMCPY(expected_text, "LSF-META-TEXT", M17_TEXT_BLOCK_BYTES);
+
+    struct m17_lsf_result res = valid_lsf_result();
+    res.et = 0U;
+    res.es = 0U;
+    res.has_meta = 1U;
+    res.meta_is_iv = 0U;
+    res.cn = 9U;
+    DSD_MEMSET(res.meta, 0, sizeof(res.meta));
+    res.meta[0] = 0x11U;
+    DSD_MEMCPY(res.meta + 1, expected_text, M17_TEXT_BLOCK_BYTES);
+
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_can_en = -1;
+
+    int err = 0;
+    err |= expect_int("null META LSF accepted", dsd_neo_m17_test_apply_lsf_result(state, &res), 1);
+    err |= expect_u8("null META text expected bitmap", state->m17_text_meta_expected_bitmap, 0x01U);
+    err |= expect_u8("null META text received bitmap", state->m17_text_meta_received_bitmap, 0x01U);
+    err |= expect_u8("null META text control", state->m17_text_meta_control_or, 0x11U);
+    err |= expect_bytes("null META text bytes", state->m17_text_meta, expected_text, sizeof(expected_text));
+    err |= expect_bytes("null META payload stored", state->m17_meta, res.meta, sizeof(res.meta));
+
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_can_en = 4;
+    state->m17_text_meta_expected_bitmap = 0x0FU;
+    state->m17_text_meta_received_bitmap = 0x02U;
+    state->m17_text_meta_control_or = 0xF2U;
+    DSD_MEMSET(state->m17_text_meta, 0x5AU, sizeof(state->m17_text_meta));
+
+    err |= expect_int("CAN-filtered null META LSF accepted", dsd_neo_m17_test_apply_lsf_result(state, &res), 1);
+    err |= expect_u8("CAN-filtered null META preserves expected", state->m17_text_meta_expected_bitmap, 0x0FU);
+    err |= expect_u8("CAN-filtered null META preserves received", state->m17_text_meta_received_bitmap, 0x02U);
+    err |= expect_u8("CAN-filtered null META preserves control", state->m17_text_meta_control_or, 0xF2U);
+    for (size_t i = 0U; i < sizeof(state->m17_text_meta); i++) {
+        err |= expect_u8("CAN-filtered null META preserves text", state->m17_text_meta[i], 0x5AU);
+    }
+
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_can_en = -1;
+    state->m17_text_meta_expected_bitmap = 0x0FU;
+    state->m17_text_meta_received_bitmap = 0x02U;
+    state->m17_text_meta_control_or = 0xF2U;
+    DSD_MEMSET(state->m17_text_meta, 0x5AU, sizeof(state->m17_text_meta));
+    res.es = 3U;
+
+    err |= expect_int("reserved null META LSF accepted", dsd_neo_m17_test_apply_lsf_result(state, &res), 1);
+    err |= expect_u8("reserved null META preserves expected", state->m17_text_meta_expected_bitmap, 0x0FU);
+    err |= expect_u8("reserved null META preserves received", state->m17_text_meta_received_bitmap, 0x02U);
+    err |= expect_u8("reserved null META preserves control", state->m17_text_meta_control_or, 0xF2U);
+    for (size_t i = 0U; i < sizeof(state->m17_text_meta); i++) {
+        err |= expect_u8("reserved null META preserves text", state->m17_text_meta[i], 0x5AU);
+    }
+    return err;
+}
+
+static int
 test_stream_dispatch_can_filter_and_aes_gates(void) {
     dsd_opts* opts = &g_opts;
     dsd_state* state = &g_state;
@@ -285,15 +655,1079 @@ test_stream_dispatch_can_filter_and_aes_gates(void) {
     return err;
 }
 
+static int
+test_stream_dispatch_legacy_aes_key_segments(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t payload_bits[128];
+    uint8_t processed_bits[128];
+    uint8_t plaintext_bits[128];
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+
+    bytes_to_bits(M17_REF_AES_CIPHERTEXT, payload_bits, sizeof(M17_REF_AES_CIPHERTEXT));
+    bytes_to_bits(M17_REF_AES_PLAINTEXT, plaintext_bits, sizeof(M17_REF_AES_PLAINTEXT));
+    DSD_MEMCPY(state->m17_meta, M17_REF_AES_NONCE, sizeof(M17_REF_AES_NONCE));
+    state->m17_str_dt = 1U;
+    state->m17_can_en = -1;
+    state->m17_enc = 2U;
+    state->m17_enc_st = 0U;
+    state->K1 = 0x0001020304050607ULL;
+    state->K2 = 0x08090A0B0C0D0E0FULL;
+
+    int err = 0;
+    err |= expect_int(
+        "legacy AES key dispatches",
+        dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, M17_REF_AES_TRANSMITTED_FN, processed_bits),
+        DSD_NEO_M17_TEST_STREAM_ENCRYPTED_DISPATCHED);
+    err |= expect_bytes("legacy AES key plaintext bits", processed_bits, plaintext_bits, sizeof(plaintext_bits));
+    return err;
+}
+
+static int
+test_stream_dispatch_rejects_invalid_arguments_and_unknown_encryption(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t payload_bits[128];
+    uint8_t processed_bits[128];
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(payload_bits, 1, sizeof(payload_bits));
+    DSD_MEMSET(processed_bits, 0xA5, sizeof(processed_bits));
+
+    int err = 0;
+    err |= expect_int(
+        "stream null opts rejected",
+        dsd_neo_m17_test_dispatch_stream_payload(NULL, state, payload_bits, M17_REF_STREAM_FN, processed_bits),
+        DSD_NEO_M17_TEST_STREAM_INVALID);
+    for (size_t i = 0U; i < sizeof(processed_bits); i++) {
+        err |= expect_u8("stream null opts preserves output", processed_bits[i], 0xA5U);
+    }
+
+    state->m17_can_en = -1;
+    state->m17_enc = 3U;
+    state->m17_str_dt = 1U;
+    err |= expect_int(
+        "unknown encryption locks stream",
+        dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, M17_REF_STREAM_FN, processed_bits),
+        DSD_NEO_M17_TEST_STREAM_ENCRYPTED_LOCKED);
+    for (size_t i = 0U; i < sizeof(processed_bits); i++) {
+        err |= expect_u8("unknown encryption clears output", processed_bits[i], 0U);
+    }
+    err |= expect_u8("unknown encryption leaves decrypt flag clear", state->m17_payload_decrypted, 0U);
+    return err;
+}
+
+static int
+test_stream_dispatch_scrambler_decrypts_with_seed_and_subtype(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t payload_bits[128];
+    uint8_t processed_bits[128];
+    uint8_t expected_bits[128];
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(payload_bits, 0, sizeof(payload_bits));
+    DSD_MEMSET(expected_bits, 0, sizeof(expected_bits));
+
+    for (size_t i = 0U; i < sizeof(payload_bits); i++) {
+        payload_bits[i] = (uint8_t)(((i * 3U) + 1U) & 1U);
+    }
+    const uint8_t subtype = 1U;
+    const uint32_t seed = 0xACE1U;
+    const uint16_t frame_number = 0x0123U;
+    assert(m17_scrambler_apply_bits(subtype, seed, frame_number, payload_bits, expected_bits, M17_STREAM_PAYLOAD_BITS)
+           == 0);
+
+    state->m17_can_en = -1;
+    state->m17_enc = 1U;
+    state->m17_enc_st = subtype;
+    state->m17_str_dt = 1U;
+    state->R = seed;
+    state->m17_payload_decrypted = 9U;
+
+    int err = 0;
+    err |= expect_int("scrambler stream dispatches",
+                      dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, frame_number, processed_bits),
+                      DSD_NEO_M17_TEST_STREAM_ENCRYPTED_DISPATCHED);
+    err |= expect_bytes("scrambler stream output", processed_bits, expected_bits, sizeof(expected_bits));
+    err |= expect_u8("scrambler transient decrypt flag restored", state->m17_payload_decrypted, 9U);
+    return err;
+}
+
+static int
+test_stream_dispatch_legacy_aes_array_key_segments(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t payload_bits[128];
+    uint8_t processed_bits[128];
+    uint8_t plaintext_bits[128];
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+
+    bytes_to_bits(M17_REF_AES_CIPHERTEXT, payload_bits, sizeof(M17_REF_AES_CIPHERTEXT));
+    bytes_to_bits(M17_REF_AES_PLAINTEXT, plaintext_bits, sizeof(M17_REF_AES_PLAINTEXT));
+    DSD_MEMCPY(state->m17_meta, M17_REF_AES_NONCE, sizeof(M17_REF_AES_NONCE));
+    state->m17_str_dt = 1U;
+    state->m17_can_en = -1;
+    state->m17_enc = 2U;
+    state->m17_enc_st = 0U;
+    state->A1[0] = 0x0001020304050607ULL;
+    state->A2[0] = 0x08090A0B0C0D0E0FULL;
+
+    int err = 0;
+    err |= expect_int(
+        "legacy AES array key dispatches",
+        dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, M17_REF_AES_TRANSMITTED_FN, processed_bits),
+        DSD_NEO_M17_TEST_STREAM_ENCRYPTED_DISPATCHED);
+    err |= expect_bytes("legacy AES array key plaintext bits", processed_bits, plaintext_bits, sizeof(plaintext_bits));
+    return err;
+}
+
+static int
+test_stream_signature_frames_are_consumed_and_verify_without_key(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t payload_bits[128];
+    uint8_t processed_bits[128];
+    static const uint16_t signature_fns[4] = {M17_STREAM_SIGNATURE_FN0, M17_STREAM_SIGNATURE_FN1,
+                                              M17_STREAM_SIGNATURE_FN2, M17_STREAM_SIGNATURE_FN3};
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_signature_advertised = 1U;
+    state->m17_str_dt = 2U;
+
+    int err = 0;
+    for (size_t i = 0U; i < 4U; i++) {
+        expect_signature_slice(payload_bits, i * 16U);
+        err |= expect_int(
+            "signature payload consumed",
+            dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, signature_fns[i], processed_bits),
+            DSD_NEO_M17_TEST_STREAM_SIGNATURE_CONSUMED);
+        err |=
+            expect_u8("signature received mask", state->m17_signature_received_mask, (uint8_t)((1U << (i + 1U)) - 1U));
+        err |= expect_bytes("signature bytes stored", state->m17_signature + (i * 16U),
+                            M17_REF_SIGNATURE_BYTES + (i * 16U), 16U);
+    }
+    err |= expect_u8("signature complete", state->m17_signature_complete, 1U);
+    err |= expect_u8("signature sequence ok", state->m17_signature_bad_sequence, 0U);
+    err |= expect_u8("signature no public key status", state->m17_signature_verification_status, 4U);
+    return err;
+}
+
+static int
+test_stream_signature_out_of_order_marks_sequence_error(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t payload_bits[128];
+    uint8_t processed_bits[128];
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_signature_advertised = 1U;
+    state->m17_str_dt = 3U;
+
+    expect_signature_slice(payload_bits, 16U);
+
+    int err = 0;
+    err |= expect_int(
+        "out-of-order signature consumed",
+        dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, M17_STREAM_SIGNATURE_FN1, processed_bits),
+        DSD_NEO_M17_TEST_STREAM_SIGNATURE_CONSUMED);
+    err |= expect_u8("out-of-order signature mask", state->m17_signature_received_mask, 0x02U);
+    err |= expect_u8("out-of-order signature sequence", state->m17_signature_bad_sequence, 1U);
+    err |= expect_u8("out-of-order signature incomplete", state->m17_signature_complete, 0U);
+    return err;
+}
+
+static int
+test_clear_signed_payload_updates_digest_and_dispatches(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t payload_bits[128];
+    uint8_t processed_bits[128];
+    uint8_t expected_digest[16];
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_signature_advertised = 1U;
+    state->m17_str_dt = 1U;
+    state->m17_can_en = -1;
+
+    bytes_to_bits(M17_REF_STREAM_PAYLOAD_BYTES, payload_bits, sizeof(M17_REF_STREAM_PAYLOAD_BYTES));
+    DSD_MEMCPY(expected_digest, M17_REF_STREAM_PAYLOAD_BYTES, sizeof(expected_digest));
+    const uint8_t first = expected_digest[0];
+    DSD_MEMMOVE(expected_digest, expected_digest + 1, sizeof(expected_digest) - 1U);
+    expected_digest[sizeof(expected_digest) - 1U] = first;
+
+    int err = 0;
+    err |= expect_int(
+        "clear signed payload dispatches",
+        dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, M17_REF_STREAM_FN, processed_bits),
+        DSD_NEO_M17_TEST_STREAM_CLEAR_DISPATCHED);
+    err |= expect_bytes("clear signed payload preserved", processed_bits, payload_bits, sizeof(payload_bits));
+    err |= expect_bytes("clear signed payload digest", state->m17_signature_digest, expected_digest,
+                        sizeof(expected_digest));
+    err |= expect_u8("clear signed payload decrypt flag restored", state->m17_payload_decrypted, 0U);
+    return err;
+}
+
+#ifdef USE_CODEC2
+static int
+test_stream_voice_3200_dispatch_routes_pair_audio_to_udp(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    static const uint8_t payload_bytes[16] = {0x10U, 0x11U, 0x12U, 0x13U, 0x14U, 0x15U, 0x16U, 0x17U,
+                                              0x20U, 0x21U, 0x22U, 0x23U, 0x24U, 0x25U, 0x26U, 0x27U};
+    uint8_t payload_bits[128];
+    uint8_t processed_bits[128];
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    reset_audio_fakes();
+    install_fake_udp_audio();
+
+    opts->slot1_on = 1;
+    opts->audio_out_type = 8;
+    state->m17_str_dt = 2U;
+    state->m17_can_en = -1;
+    bytes_to_bits(payload_bytes, payload_bits, sizeof(payload_bytes));
+
+    int err = 0;
+    err |= expect_int(
+        "3200 voice stream dispatches",
+        dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, M17_REF_STREAM_FN, processed_bits),
+        DSD_NEO_M17_TEST_STREAM_CLEAR_DISPATCHED);
+    err |= expect_bytes("3200 voice processed bits", processed_bits, payload_bits, sizeof(payload_bits));
+    err |= expect_int("3200 voice Codec2 decodes", g_codec2_decode_calls, 2);
+    err |= expect_bytes("3200 voice second codec frame", g_codec2_last_bits, payload_bytes + 8U, 8U);
+    err |= expect_int("3200 voice UDP calls", g_udp_audio_calls, 2);
+    err |= expect_int("3200 voice UDP bytes", (int)g_udp_audio_last_nsam, (int)(160U * sizeof(short)));
+    err |= expect_int("3200 voice UDP last sample", (int)g_udp_audio_last_first_sample, 1002);
+    err |= expect_int("3200 voice UDP opts", g_udp_audio_last_opts == opts, 1);
+    err |= expect_int("3200 voice UDP state", g_udp_audio_last_state == state, 1);
+    reset_audio_fakes();
+    return err;
+}
+
+static int
+test_stream_voice_1600_dispatch_routes_single_audio_to_udp(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    static const uint8_t payload_bytes[16] = {0x30U, 0x31U, 0x32U, 0x33U, 0x34U, 0x35U, 0x36U, 0x37U,
+                                              0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U, 0x00U};
+    uint8_t payload_bits[128];
+    uint8_t processed_bits[128];
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    reset_audio_fakes();
+    install_fake_udp_audio();
+
+    opts->slot1_on = 1;
+    opts->audio_out_type = 8;
+    state->m17_str_dt = 3U;
+    state->m17_can_en = -1;
+    bytes_to_bits(payload_bytes, payload_bits, sizeof(payload_bytes));
+
+    int err = 0;
+    err |= expect_int(
+        "1600 voice stream dispatches",
+        dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, M17_REF_STREAM_FN, processed_bits),
+        DSD_NEO_M17_TEST_STREAM_CLEAR_DISPATCHED);
+    err |= expect_bytes("1600 voice processed bits", processed_bits, payload_bits, sizeof(payload_bits));
+    err |= expect_int("1600 voice Codec2 decodes", g_codec2_decode_calls, 1);
+    err |= expect_bytes("1600 voice codec frame", g_codec2_last_bits, payload_bytes, 8U);
+    err |= expect_int("1600 voice UDP calls", g_udp_audio_calls, 1);
+    err |= expect_int("1600 voice UDP bytes", (int)g_udp_audio_last_nsam, (int)(320U * sizeof(short)));
+    err |= expect_int("1600 voice UDP first sample", (int)g_udp_audio_last_first_sample, 1001);
+    reset_audio_fakes();
+    return err;
+}
+
+static int
+test_stream_voice_audio_gate_suppresses_udp_when_slot_disabled(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    static const uint8_t payload_bytes[16] = {0x40U, 0x41U, 0x42U, 0x43U, 0x44U, 0x45U, 0x46U, 0x47U,
+                                              0x50U, 0x51U, 0x52U, 0x53U, 0x54U, 0x55U, 0x56U, 0x57U};
+    uint8_t payload_bits[128];
+    uint8_t processed_bits[128];
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    reset_audio_fakes();
+    install_fake_udp_audio();
+
+    opts->slot1_on = 0;
+    opts->audio_out_type = 8;
+    state->m17_str_dt = 2U;
+    state->m17_can_en = -1;
+    bytes_to_bits(payload_bytes, payload_bits, sizeof(payload_bytes));
+
+    int err = 0;
+    err |= expect_int(
+        "slot-disabled voice stream dispatches",
+        dsd_neo_m17_test_dispatch_stream_payload(opts, state, payload_bits, M17_REF_STREAM_FN, processed_bits),
+        DSD_NEO_M17_TEST_STREAM_CLEAR_DISPATCHED);
+    err |= expect_int("slot-disabled voice still decodes", g_codec2_decode_calls, 2);
+    err |= expect_int("slot-disabled voice suppresses UDP", g_udp_audio_calls, 0);
+    err |= expect_int("slot-disabled voice leaves UDP byte count clear", (int)g_udp_audio_last_nsam, 0);
+    reset_audio_fakes();
+    return err;
+}
+#endif
+
+static int
+test_bert_payload_locks_from_default_state_and_continues(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t bert_bits[M17_BERT_PAYLOAD_BITS];
+    uint16_t tx_lfsr = 1U;
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+
+    m17_prbs9_fill_bits(&tx_lfsr, bert_bits, M17_BERT_PAYLOAD_BITS);
+    dsd_neo_m17_test_process_bert_payload(opts, state, bert_bits);
+
+    int err = 0;
+    err |= expect_u8("BERT locks from default LFSR", state->m17_bert_locked, 1U);
+    err |= expect_int("BERT first payload counted bits", (int)state->m17_bert_bits,
+                      M17_BERT_PAYLOAD_BITS - M17_PRBS9_LOCK_BITS);
+    err |= expect_int("BERT first payload errors", (int)state->m17_bert_errors, 0);
+    err |= expect_int("BERT first payload resyncs", (int)state->m17_bert_resyncs, 0);
+
+    m17_prbs9_fill_bits(&tx_lfsr, bert_bits, M17_BERT_PAYLOAD_BITS);
+    dsd_neo_m17_test_process_bert_payload(opts, state, bert_bits);
+
+    err |= expect_u8("BERT stays locked", state->m17_bert_locked, 1U);
+    err |= expect_int("BERT second payload counted bits", (int)state->m17_bert_bits,
+                      (M17_BERT_PAYLOAD_BITS - M17_PRBS9_LOCK_BITS) + M17_BERT_PAYLOAD_BITS);
+    err |= expect_int("BERT second payload errors", (int)state->m17_bert_errors, 0);
+    err |= expect_int("BERT second payload resyncs", (int)state->m17_bert_resyncs, 0);
+    return err;
+}
+
+static int
+test_bert_payload_resyncs_after_error_threshold(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t bert_bits[M17_BERT_PAYLOAD_BITS];
+    uint16_t tx_lfsr = 1U;
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_bert_lfsr = 1U;
+    state->m17_bert_locked = 1U;
+
+    m17_prbs9_fill_bits(&tx_lfsr, bert_bits, M17_BERT_PAYLOAD_BITS);
+    for (int i = 0; i < 19; i++) {
+        bert_bits[i] ^= 1U;
+    }
+
+    dsd_neo_m17_test_process_bert_payload(opts, state, bert_bits);
+
+    int err = 0;
+    err |= expect_u8("BERT relocks after threshold", state->m17_bert_locked, 1U);
+    err |= expect_int("BERT resync count", (int)state->m17_bert_resyncs, 1);
+    err |= expect_int("BERT threshold counted bits", (int)state->m17_bert_bits,
+                      M17_BERT_PAYLOAD_BITS - M17_PRBS9_LOCK_BITS);
+    err |= expect_int("BERT threshold errors", (int)state->m17_bert_errors, 19);
+    err |= expect_int("BERT window after relock", (int)state->m17_bert_window_bits,
+                      M17_BERT_PAYLOAD_BITS - M17_PRBS9_RESYNC_WINDOW_BITS - M17_PRBS9_LOCK_BITS);
+    err |= expect_int("BERT window errors reset after resync", (int)state->m17_bert_window_errors, 0);
+    return err;
+}
+
+static int
+test_bert_hard_payload_decode_primitives(void) {
+    uint8_t input_bits[M17_PAYLOAD_BITS];
+    uint8_t depunc[M17_BERT_TYPE2_BITS];
+    uint8_t expected_depunc[M17_BERT_TYPE2_BITS];
+    uint8_t unpacked[24];
+    uint8_t expected_unpacked[16];
+    uint8_t bert_bits[M17_BERT_PAYLOAD_BITS];
+    uint8_t chainback_bytes[25];
+    uint8_t expected_bert_bits[200];
+    int bit_in = 0;
+
+    for (int i = 0; i < M17_PAYLOAD_BITS; i++) {
+        input_bits[i] = (uint8_t)(((i * 5) + 1) & 1);
+    }
+    DSD_MEMSET(depunc, 0xA5, sizeof(depunc));
+    DSD_MEMSET(expected_depunc, 0, sizeof(expected_depunc));
+
+    dsd_neo_m17_test_depuncture_p2_hard(input_bits, depunc, M17_BERT_TYPE2_BITS);
+    for (int i = 0; i < M17_BERT_TYPE2_BITS; i++) {
+        if (m17_puncture_pattern_2[i % M17_PUNCTURE_P2_LEN] == 1U && bit_in < M17_PAYLOAD_BITS) {
+            expected_depunc[i] = input_bits[bit_in++];
+        }
+    }
+
+    int err = 0;
+    err |= expect_int("BERT depuncture consumes payload", bit_in, M17_PAYLOAD_BITS);
+    err |= expect_bytes("BERT depunctured P2 bits", depunc, expected_depunc, sizeof(depunc));
+
+    DSD_MEMSET(depunc, 0x5A, sizeof(depunc));
+    dsd_neo_m17_test_depuncture_p2_hard(input_bits, depunc, -1);
+    err |= expect_u8("BERT depuncture negative guard preserves output", depunc[0], 0x5AU);
+
+    static const uint8_t packed[2] = {0xA5U, 0x3CU};
+    static const uint8_t unpacked_expected[16] = {1U, 0U, 1U, 0U, 0U, 1U, 0U, 1U, 0U, 0U, 1U, 1U, 1U, 1U, 0U, 0U};
+    DSD_MEMSET(unpacked, 0xCC, sizeof(unpacked));
+    DSD_MEMCPY(expected_unpacked, unpacked_expected, sizeof(expected_unpacked));
+    dsd_neo_m17_test_unpack_bytes_to_bits(packed, 2, unpacked);
+    err |= expect_bytes("BERT byte unpack MSB first", unpacked, expected_unpacked, sizeof(expected_unpacked));
+    err |= expect_u8("BERT byte unpack does not overrun", unpacked[16], 0xCCU);
+    dsd_neo_m17_test_unpack_bytes_to_bits(NULL, 2, unpacked);
+    err |= expect_u8("BERT byte unpack null guard preserves output", unpacked[0], 1U);
+
+    reset_convolution_fake();
+    DSD_MEMSET(bert_bits, 0x5A, sizeof(bert_bits));
+    dsd_neo_m17_test_decode_bert_payload_bits(input_bits, bert_bits);
+    err |= expect_int("BERT hard decode starts convolution", g_conv_start_calls, 1);
+    err |= expect_int("BERT hard decode symbol pairs", g_conv_decode_calls, M17_BERT_TYPE1_FLUSH_BITS);
+    err |= expect_int("BERT hard decode chainback calls", g_conv_chainback_calls, 1);
+    err |= expect_int("BERT hard decode chainback bits", (int)g_conv_chainback_bits, M17_BERT_PAYLOAD_BITS);
+    for (int i = 0; i < (int)sizeof(g_conv_first_symbols); i++) {
+        err |= expect_u8("BERT hard decode feeds depunctured soft symbols", g_conv_first_symbols[i],
+                         (uint8_t)(expected_depunc[i] << 1U));
+    }
+
+    for (size_t i = 0U; i < sizeof(chainback_bytes); i++) {
+        chainback_bytes[i] = (uint8_t)(0xA0U + i);
+    }
+    bytes_to_bits(chainback_bytes, expected_bert_bits, sizeof(chainback_bytes));
+    err |=
+        expect_bytes("BERT hard decode unpacks chainback bytes", bert_bits, expected_bert_bits, M17_BERT_PAYLOAD_BITS);
+    return err;
+}
+
+static int
+test_frame_info_packet_and_ip_helpers(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+
+    int err = 0;
+    err |= expect_int("frame info masks fields", dsd_neo_m17_test_compose_frame_info(3U, 7U, 6U, 5U, 0x1FU, 3U, 0x1FU),
+                      0xFFB7);
+    err |= expect_int("frame info selected fields", dsd_neo_m17_test_compose_frame_info(1U, 2U, 1U, 3U, 9U, 1U, 0xAU),
+                      0xACED);
+
+    uint8_t ip_frame[12];
+    DSD_MEMSET(ip_frame, 0, sizeof(ip_frame));
+    ip_frame[4] = 0x01U;
+    ip_frame[5] = 0x23U;
+    ip_frame[6] = 0x45U;
+    ip_frame[7] = 0x67U;
+    ip_frame[8] = 0x89U;
+    ip_frame[9] = 0xABU;
+    err |= expect_u64("IP source", dsd_neo_m17_test_read_ip_source(ip_frame), 0x0123456789ABULL);
+    err |= expect_u64("IP null source", dsd_neo_m17_test_read_ip_source(NULL), 0ULL);
+
+    err |= expect_int("pkt negative clamp", dsd_neo_m17_test_pkt_ptr_clamped(-4), 0);
+    err |= expect_int("pkt second frame ptr", dsd_neo_m17_test_pkt_ptr_clamped(2), 50);
+    err |= expect_int("pkt high clamp", dsd_neo_m17_test_pkt_ptr_clamped(99), 825);
+
+    err |=
+        expect_int("clear packet not encrypted", dsd_neo_m17_test_decode_pkt_should_report_encrypted(state, 0x05U), 0);
+    state->m17_enc = 2U;
+    err |= expect_int("GNSS meta allowed while encrypted",
+                      dsd_neo_m17_test_decode_pkt_should_report_encrypted(state, 0x81U), 0);
+    err |=
+        expect_int("SMS blocked while encrypted", dsd_neo_m17_test_decode_pkt_should_report_encrypted(state, 0x05U), 1);
+    state->m17_payload_decrypted = 1U;
+    err |= expect_int("decrypted packet allowed", dsd_neo_m17_test_decode_pkt_should_report_encrypted(state, 0x05U), 0);
+
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->carrier = 1;
+    state->synctype = DSD_SYNC_M17_STR_POS;
+    uint8_t disc[10] = {'D', 'I', 'S', 'C', 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB};
+    dsd_neo_m17_test_dispatch_ip_frame(opts, state, disc, sizeof(disc));
+    err |= expect_int("DISC drops carrier", state->carrier, 0);
+    err |= expect_int("DISC clears synctype", state->synctype, DSD_SYNC_NONE);
+
+    state->carrier = 1;
+    state->synctype = DSD_SYNC_M17_STR_POS;
+    uint8_t eotx[10] = {'E', 'O', 'T', 'X', 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB};
+    dsd_neo_m17_test_dispatch_ip_frame(opts, state, eotx, sizeof(eotx));
+    err |= expect_int("EOTX drops carrier", state->carrier, 0);
+    err |= expect_int("EOTX clears synctype", state->synctype, DSD_SYNC_NONE);
+
+    state->carrier = 1;
+    state->synctype = DSD_SYNC_M17_STR_POS;
+    uint8_t conn[11] = {'C', 'O', 'N', 'N', 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 'A'};
+    dsd_neo_m17_test_dispatch_ip_frame(opts, state, conn, sizeof(conn));
+    err |= expect_int("CONN keeps carrier", state->carrier, 1);
+    err |= expect_int("CONN keeps synctype", state->synctype, DSD_SYNC_M17_STR_POS);
+
+    uint8_t ping[10] = {'P', 'I', 'N', 'G', 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB};
+    dsd_neo_m17_test_dispatch_ip_frame(opts, state, ping, sizeof(ping));
+    err |= expect_int("PING keeps carrier", state->carrier, 1);
+    err |= expect_int("PING keeps synctype", state->synctype, DSD_SYNC_M17_STR_POS);
+
+    uint8_t pong[10] = {'P', 'O', 'N', 'G', 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB};
+    dsd_neo_m17_test_dispatch_ip_frame(opts, state, pong, sizeof(pong));
+    err |= expect_int("PONG keeps carrier", state->carrier, 1);
+    err |= expect_int("PONG keeps synctype", state->synctype, DSD_SYNC_M17_STR_POS);
+
+    uint8_t short_mpkt[12] = {'M', 'P', 'K', 'T', 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0x55, 0xAA};
+    state->m17_dst = 0x111122223333ULL;
+    state->m17_src = 0x444455556666ULL;
+    dsd_neo_m17_test_dispatch_ip_frame(opts, state, short_mpkt, sizeof(short_mpkt));
+    err |= expect_u64("short MPKT preserves dst", state->m17_dst, 0x111122223333ULL);
+    err |= expect_u64("short MPKT preserves src", state->m17_src, 0x444455556666ULL);
+
+    uint8_t unknown[10] = {'N', 'O', 'P', 'E', 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB};
+    state->carrier = 1;
+    state->synctype = DSD_SYNC_M17_STR_POS;
+    dsd_neo_m17_test_dispatch_ip_frame(opts, state, unknown, sizeof(unknown));
+    err |= expect_int("unknown IP magic preserves carrier", state->carrier, 1);
+    err |= expect_int("unknown IP magic preserves synctype", state->synctype, DSD_SYNC_M17_STR_POS);
+    return err;
+}
+
+static int
+test_ip_stream_frames_apply_crc_gated_lsf_state(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t lsf_bits[TEST_M17_LSF_BITS];
+    uint8_t payload_bits[M17_STREAM_PAYLOAD_BITS];
+    uint8_t ip_frame[54];
+    uint8_t counter[M17_AES_COUNTER_BYTES];
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(payload_bits, 0, sizeof(payload_bits));
+    DSD_MEMSET(counter, 0, sizeof(counter));
+
+    const unsigned long long dst = m17_encode_b40_callsign(0ULL, M17_REF_LSF_DST_CSD);
+    const unsigned long long src = m17_encode_b40_callsign(0ULL, M17_REF_LSF_SRC_CSD);
+    const uint16_t type_word = dsd_neo_m17_test_compose_frame_info(1U, 1U, 2U, 0U, 5U, 0U, 0U);
+    build_lsf_bits(lsf_bits, dst, src, type_word, M17_REF_AES_NONCE);
+    bytes_to_bits(M17_REF_STREAM_PAYLOAD_BYTES, payload_bits, sizeof(M17_REF_STREAM_PAYLOAD_BYTES));
+    build_ip_stream_frame(ip_frame, lsf_bits, 0xBEEF, M17_REF_STREAM_FN, 0U, payload_bits);
+
+    state->m17_can_en = -1;
+    dsd_neo_m17_test_dispatch_ip_frame(opts, state, ip_frame, sizeof(ip_frame));
+
+    int err = 0;
+    err |= expect_int("valid IP stream sets carrier", state->carrier, 1);
+    err |= expect_int("valid IP stream sets synctype", state->synctype, DSD_SYNC_M17_STR_POS);
+    err |= expect_u64("valid IP stream dst", state->m17_dst, dst);
+    err |= expect_u64("valid IP stream src", state->m17_src, src);
+    err |= expect_u8("valid IP stream data type", state->m17_str_dt, 1U);
+    err |= expect_u8("valid IP stream CAN", state->m17_can, 5U);
+    err |= expect_u8("valid IP stream AES mode", state->m17_enc, 2U);
+    err |= expect_u8("valid IP stream AES subtype", state->m17_enc_st, 0U);
+    err |= expect_u8("valid IP stream remains locked without key", state->m17_payload_decrypted, 0U);
+    err |= expect_bytes("valid IP stream nonce", state->m17_meta, M17_REF_AES_NONCE, sizeof(M17_REF_AES_NONCE));
+    for (size_t i = 0U; i < M17_LSF_LSD_BITS; i++) {
+        err |= expect_u8("valid IP stream copied LSF bits", state->m17_lsf[i], lsf_bits[i]);
+    }
+
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_can_en = -1;
+    state->m17_str_dt = 1U;
+    state->m17_dst = 0x111122223333ULL;
+    state->m17_src = 0x444455556666ULL;
+    state->m17_enc = 0U;
+    DSD_MEMSET(state->m17_meta, 0x5A, sizeof(state->m17_meta));
+    m17_aes_build_counter(state->m17_meta, (uint16_t)(M17_STREAM_FRAME_END_MASK | M17_REF_STREAM_FN), counter);
+    build_ip_stream_frame(ip_frame, lsf_bits, 0xBEEF, M17_REF_STREAM_FN, 1U, payload_bits);
+    ip_frame[52] ^= 0x01U;
+
+    dsd_neo_m17_test_dispatch_ip_frame(opts, state, ip_frame, sizeof(ip_frame));
+    err |= expect_int("bad IP stream CRC sets carrier", state->carrier, 1);
+    err |= expect_int("bad IP stream CRC sets synctype", state->synctype, DSD_SYNC_M17_STR_POS);
+    err |= expect_u64("bad IP stream CRC preserves dst", state->m17_dst, 0x111122223333ULL);
+    err |= expect_u64("bad IP stream CRC preserves src", state->m17_src, 0x444455556666ULL);
+    err |= expect_u8("bad IP stream CRC preserves enc", state->m17_enc, 0U);
+    err |= expect_u8("bad IP stream CRC stores counter high", state->m17_meta[14], counter[14]);
+    err |= expect_u8("bad IP stream CRC stores counter low", state->m17_meta[15], counter[15]);
+    return err;
+}
+
+static int
+test_ip_mpkt_frames_apply_crc_gated_packet_state(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t lsf_bits[TEST_M17_LSF_BITS];
+    uint8_t mpkt_frame[80];
+    uint8_t app[2U + M17_META_BYTES];
+    uint8_t expected_text[M17_TEXT_BLOCK_BYTES];
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(app, 0, sizeof(app));
+    DSD_MEMSET(expected_text, 0, sizeof(expected_text));
+
+    const unsigned long long dst = m17_encode_b40_callsign(0ULL, M17_REF_LSF_DST_CSD);
+    const unsigned long long src = m17_encode_b40_callsign(0ULL, M17_REF_LSF_SRC_CSD);
+    const uint16_t packet_type_word = dsd_neo_m17_test_compose_frame_info(0U, 0U, 0U, 0U, 5U, 0U, 0U);
+    build_lsf_bits(lsf_bits, dst, src, packet_type_word, NULL);
+
+    app[0] = 0xC2U;
+    app[1] = 0x80U;
+    app[2] = 0x11U;
+    DSD_MEMCPY(app + 3, "IP-MPKT-OK", 10U);
+    DSD_MEMCPY(expected_text, "IP-MPKT-OK", 10U);
+    const size_t mpkt_len = build_ip_mpkt_frame(mpkt_frame, sizeof(mpkt_frame), lsf_bits, 0xCAFEU, app, sizeof(app));
+
+    state->m17_can_en = -1;
+    dsd_neo_m17_test_dispatch_ip_frame(opts, state, mpkt_frame, (int)mpkt_len);
+
+    int err = 0;
+    err |= expect_u64("valid MPKT dst", state->m17_dst, dst);
+    err |= expect_u64("valid MPKT src", state->m17_src, src);
+    err |= expect_u8("valid MPKT packet mode data type", state->m17_str_dt, 20U);
+    err |= expect_u8("valid MPKT CAN", state->m17_can, 5U);
+    err |= expect_u8("valid MPKT clear encryption", state->m17_enc, 0U);
+    err |= expect_u8("valid MPKT text expected bitmap", state->m17_text_meta_expected_bitmap, 0x01U);
+    err |= expect_u8("valid MPKT text received bitmap", state->m17_text_meta_received_bitmap, 0x01U);
+    err |= expect_u8("valid MPKT text control", state->m17_text_meta_control_or, 0x11U);
+    err |= expect_bytes("valid MPKT text bytes", state->m17_text_meta, expected_text, sizeof(expected_text));
+
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_can_en = -1;
+    state->m17_dst = 0xAAAABBBBCCCCULL;
+    state->m17_src = 0x111122223333ULL;
+    state->m17_text_meta_expected_bitmap = 0x0FU;
+    state->m17_text_meta_received_bitmap = 0x02U;
+    state->m17_text_meta_control_or = 0xF2U;
+    DSD_MEMSET(state->m17_text_meta, 0x5AU, sizeof(state->m17_text_meta));
+    build_ip_mpkt_frame(mpkt_frame, sizeof(mpkt_frame), lsf_bits, 0xCAFEU, app, sizeof(app));
+    mpkt_frame[mpkt_len - 1U] ^= 0x01U;
+
+    dsd_neo_m17_test_dispatch_ip_frame(opts, state, mpkt_frame, (int)mpkt_len);
+    err |= expect_u64("bad MPKT CRC preserves dst", state->m17_dst, 0xAAAABBBBCCCCULL);
+    err |= expect_u64("bad MPKT CRC preserves src", state->m17_src, 0x111122223333ULL);
+    err |= expect_u8("bad MPKT CRC preserves text expected", state->m17_text_meta_expected_bitmap, 0x0FU);
+    err |= expect_u8("bad MPKT CRC preserves text received", state->m17_text_meta_received_bitmap, 0x02U);
+    err |= expect_u8("bad MPKT CRC preserves text control", state->m17_text_meta_control_or, 0xF2U);
+    for (size_t i = 0U; i < sizeof(state->m17_text_meta); i++) {
+        err |= expect_u8("bad MPKT CRC preserves text bytes", state->m17_text_meta[i], 0x5AU);
+    }
+    return err;
+}
+
+static void
+build_packet_text_meta_app(uint8_t app[2U + M17_META_BYTES], const char text[M17_TEXT_BLOCK_BYTES]) {
+    DSD_MEMSET(app, 0, 2U + M17_META_BYTES);
+    app[0] = 0xC2U;
+    app[1] = 0x80U;
+    app[2] = 0x11U;
+    DSD_MEMCPY(app + 3, text, M17_TEXT_BLOCK_BYTES);
+}
+
+static void
+stage_packet_with_crc(dsd_state* state, const uint8_t* app, uint16_t app_len, uint16_t crc) {
+    DSD_MEMSET(state->m17_pkt, 0, sizeof(state->m17_pkt));
+    DSD_MEMCPY(state->m17_pkt, app, app_len);
+    state->m17_pkt[app_len] = (uint8_t)(crc >> 8U);
+    state->m17_pkt[app_len + 1U] = (uint8_t)(crc & 0xFFU);
+}
+
+static int
+test_packet_eot_finalization_crc_gates_decode_and_clears_state(void) {
+    dsd_opts* opts = &g_opts;
+    dsd_state* state = &g_state;
+    uint8_t app[2U + M17_META_BYTES];
+    uint8_t expected_text[M17_TEXT_BLOCK_BYTES];
+    static const char text[M17_TEXT_BLOCK_BYTES] = {'R', 'F', '-', 'P', 'K', 'T', '-', 'O', 'K', 0, 0, 0, 0};
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(expected_text, 0, sizeof(expected_text));
+    build_packet_text_meta_app(app, text);
+    DSD_MEMCPY(expected_text, text, sizeof(expected_text));
+
+    const uint16_t app_len = (uint16_t)sizeof(app);
+    const size_t total_len = (size_t)app_len + (size_t)M17_PACKET_CRC_BYTES;
+    const uint16_t crc = m17_crc16(app, app_len);
+    state->m17_can_en = -1;
+    state->m17_pbc_ct = 4;
+    stage_packet_with_crc(state, app, app_len, crc);
+
+    dsd_neo_m17_test_finalize_packet_eot(opts, state, app_len, (int)(app_len + M17_PACKET_CRC_BYTES));
+
+    int err = 0;
+    err |= expect_u8("valid packet EOT text expected bitmap", state->m17_text_meta_expected_bitmap, 0x01U);
+    err |= expect_u8("valid packet EOT text received bitmap", state->m17_text_meta_received_bitmap, 0x01U);
+    err |= expect_u8("valid packet EOT text control", state->m17_text_meta_control_or, 0x11U);
+    err |= expect_bytes("valid packet EOT text bytes", state->m17_text_meta, expected_text, sizeof(expected_text));
+    err |= expect_int("valid packet EOT clears PBC", state->m17_pbc_ct, 0);
+    for (size_t i = 0U; i < total_len; i++) {
+        err |= expect_u8("valid packet EOT clears packet buffer", state->m17_pkt[i], 0U);
+    }
+
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_can_en = -1;
+    state->m17_pbc_ct = 2;
+    state->m17_text_meta_expected_bitmap = 0x0FU;
+    state->m17_text_meta_received_bitmap = 0x02U;
+    state->m17_text_meta_control_or = 0xF2U;
+    DSD_MEMSET(state->m17_text_meta, 0x5AU, sizeof(state->m17_text_meta));
+    opts->aggressive_framesync = 1;
+    stage_packet_with_crc(state, app, app_len, (uint16_t)(crc ^ 0x0001U));
+
+    dsd_neo_m17_test_finalize_packet_eot(opts, state, app_len, (int)(app_len + M17_PACKET_CRC_BYTES));
+
+    err |= expect_u8("bad packet CRC preserves text expected", state->m17_text_meta_expected_bitmap, 0x0FU);
+    err |= expect_u8("bad packet CRC preserves text received", state->m17_text_meta_received_bitmap, 0x02U);
+    err |= expect_u8("bad packet CRC preserves text control", state->m17_text_meta_control_or, 0xF2U);
+    for (size_t i = 0U; i < sizeof(state->m17_text_meta); i++) {
+        err |= expect_u8("bad packet CRC preserves text bytes", state->m17_text_meta[i], 0x5AU);
+    }
+    err |= expect_int("bad packet CRC clears PBC", state->m17_pbc_ct, 0);
+    for (size_t i = 0U; i < total_len; i++) {
+        err |= expect_u8("bad packet CRC clears packet buffer", state->m17_pkt[i], 0U);
+    }
+
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    state->m17_can_en = -1;
+    stage_packet_with_crc(state, app, app_len, (uint16_t)(crc ^ 0x0001U));
+
+    dsd_neo_m17_test_finalize_packet_eot(opts, state, app_len, (int)(app_len + M17_PACKET_CRC_BYTES));
+
+    err |=
+        expect_u8("non-aggressive bad CRC still decodes expected bitmap", state->m17_text_meta_expected_bitmap, 0x01U);
+    err |=
+        expect_u8("non-aggressive bad CRC still decodes received bitmap", state->m17_text_meta_received_bitmap, 0x01U);
+    err |= expect_u8("non-aggressive bad CRC still decodes control", state->m17_text_meta_control_or, 0x11U);
+    err |=
+        expect_bytes("non-aggressive bad CRC text bytes", state->m17_text_meta, expected_text, sizeof(expected_text));
+    return err;
+}
+
+static int
+test_encoder_control_lsf_and_dibit_helpers(void) {
+    uint8_t conn[11];
+    uint8_t disc[10];
+    uint8_t eotx[10];
+    uint8_t lsf_bits[240];
+    uint8_t lsf_packed[30];
+    uint8_t dibits[M17_FRAME_SYMBOLS];
+    uint8_t payload_bits[M17_PAYLOAD_BITS];
+    DSD_MEMSET(conn, 0xA5, sizeof(conn));
+    DSD_MEMSET(disc, 0xA5, sizeof(disc));
+    DSD_MEMSET(eotx, 0xA5, sizeof(eotx));
+    DSD_MEMSET(lsf_bits, 0, sizeof(lsf_bits));
+    DSD_MEMSET(lsf_packed, 0, sizeof(lsf_packed));
+    DSD_MEMSET(dibits, 0, sizeof(dibits));
+    DSD_MEMSET(payload_bits, 0, sizeof(payload_bits));
+
+    dsd_neo_m17_test_setup_conn_disc_eotx(0x0123456789ABULL, 'Z', conn, disc, eotx);
+
+    int err = 0;
+    static const uint8_t want_conn[11] = {'C', 'O', 'N', 'N', 0x01U, 0x23U, 0x45U, 0x67U, 0x89U, 0xABU, 'Z'};
+    static const uint8_t want_disc[10] = {'D', 'I', 'S', 'C', 0x01U, 0x23U, 0x45U, 0x67U, 0x89U, 0xABU};
+    static const uint8_t want_eotx[10] = {'E', 'O', 'T', 'X', 0x01U, 0x23U, 0x45U, 0x67U, 0x89U, 0xABU};
+    err |= expect_bytes("CONN frame", conn, want_conn, sizeof(want_conn));
+    err |= expect_bytes("DISC frame", disc, want_disc, sizeof(want_disc));
+    err |= expect_bytes("EOTX frame", eotx, want_eotx, sizeof(want_eotx));
+
+    const unsigned long long dst = m17_encode_b40_callsign(0ULL, M17_REF_LSF_DST_CSD);
+    const unsigned long long src = m17_encode_b40_callsign(0ULL, M17_REF_LSF_SRC_CSD);
+    dsd_neo_m17_test_load_lsf_callsigns(lsf_bits, dst, src);
+    const uint16_t type_word = dsd_neo_m17_test_compose_frame_info(1U, 2U, 0U, 0U, 9U, 1U, 0U);
+    for (int i = 0; i < 16; i++) {
+        lsf_bits[96 + i] = (uint8_t)((type_word >> (15 - i)) & 1U);
+    }
+    const uint16_t crc = dsd_neo_m17_test_attach_lsf_crc(lsf_bits, lsf_packed);
+    err |= expect_u64("LSF dst bits", bits_to_u64(lsf_bits, 48U), dst);
+    err |= expect_u64("LSF src bits", bits_to_u64(lsf_bits + 48, 48U), src);
+    err |= expect_int("LSF type word", (int)bits_to_u64(lsf_bits + 96, 16U), type_word);
+    err |= expect_int("LSF packed CRC", crc, m17_crc16(lsf_packed, M17_LSF_LSD_BYTES));
+    err |= expect_int("LSF CRC bits", (int)bits_to_u64(lsf_bits + M17_LSF_LSD_BITS, M17_LSF_CRC_BITS), crc);
+
+    dsd_neo_m17_test_apply_frame_prefix_dibits(2, dibits);
+    uint8_t want_sync[M17_SYNC_SYMBOLS];
+    DSD_MEMSET(want_sync, 0, sizeof(want_sync));
+    m17_fill_sync_dibits_from_word(M17_SYNC_STREAM_WORD, want_sync);
+    err |= expect_bytes("stream sync prefix", dibits, want_sync, sizeof(want_sync));
+    for (int i = M17_SYNC_SYMBOLS; i < M17_FRAME_SYMBOLS; i++) {
+        err |= expect_u8("stream prefix leaves payload clear", dibits[i], 0U);
+    }
+
+    DSD_MEMSET(dibits, 0, sizeof(dibits));
+    dsd_neo_m17_test_apply_frame_prefix_dibits(55, dibits);
+    uint8_t want_eot_dibits[M17_FRAME_SYMBOLS];
+    DSD_MEMSET(want_eot_dibits, 0, sizeof(want_eot_dibits));
+    m17_fill_repeating_16bit_dibits(M17_EOT_MARKER_WORD, want_eot_dibits);
+    err |= expect_bytes("EOT repeating prefix", dibits, want_eot_dibits, sizeof(want_eot_dibits));
+
+    for (int i = 0; i < M17_PAYLOAD_BITS; i++) {
+        payload_bits[i] = (uint8_t)(i & 1);
+    }
+    DSD_MEMSET(dibits, 0xEE, sizeof(dibits));
+    dsd_neo_m17_test_load_payload_dibits(payload_bits, dibits);
+    err |= expect_u8("payload helper preserves prefix byte", dibits[0], 0xEEU);
+    for (int i = 0; i < M17_PAYLOAD_SYMBOLS; i++) {
+        err |= expect_u8("payload dibit mapping", dibits[i + M17_SYNC_SYMBOLS], 1U);
+    }
+
+    err |= expect_int("clip high", dsd_neo_m17_test_clip_float_to_short(40000.0f), 32767);
+    err |= expect_int("clip low", dsd_neo_m17_test_clip_float_to_short(-40000.0f), -32768);
+    err |= expect_int("clip rounded positive", dsd_neo_m17_test_clip_float_to_short(123.6f), 124);
+    err |= expect_int("clip rounded negative", dsd_neo_m17_test_clip_float_to_short(-123.4f), -123);
+
+    uint8_t symbol_dibits[M17_FRAME_SYMBOLS];
+    int symbols[M17_FRAME_SYMBOLS];
+    int upsampled[M17_FRAME_SYMBOLS * M17_RECOMMENDED_UPSAMPLE_FACTOR];
+    short baseband[M17_FRAME_SYMBOLS * M17_RECOMMENDED_UPSAMPLE_FACTOR];
+    DSD_MEMSET(symbol_dibits, 0, sizeof(symbol_dibits));
+    DSD_MEMSET(symbols, 0, sizeof(symbols));
+    DSD_MEMSET(upsampled, 0, sizeof(upsampled));
+    DSD_MEMSET(baseband, 0, sizeof(baseband));
+    symbol_dibits[0] = 0U;
+    symbol_dibits[1] = 1U;
+    symbol_dibits[2] = 2U;
+    symbol_dibits[3] = 3U;
+    symbol_dibits[4] = 7U;
+    dsd_neo_m17_test_dibits_to_symbols(symbol_dibits, symbols);
+    err |= expect_int("dibit 0 symbol", symbols[0], 1);
+    err |= expect_int("dibit 1 symbol", symbols[1], 3);
+    err |= expect_int("dibit 2 symbol", symbols[2], -1);
+    err |= expect_int("dibit 3 symbol", symbols[3], -3);
+    err |= expect_int("dibit masked symbol", symbols[4], -3);
+
+    dsd_neo_m17_test_upsample_symbols_10x(symbols, upsampled);
+    for (int i = 0; i < M17_RECOMMENDED_UPSAMPLE_FACTOR; i++) {
+        err |= expect_int("first symbol upsampled", upsampled[i], 1);
+        err |= expect_int("second symbol upsampled", upsampled[M17_RECOMMENDED_UPSAMPLE_FACTOR + i], 3);
+    }
+
+    dsd_neo_m17_test_baseband_no_filter(upsampled, baseband);
+    err |= expect_int("baseband symbol +1", baseband[0], 7168);
+    err |= expect_int("baseband symbol +3", baseband[M17_RECOMMENDED_UPSAMPLE_FACTOR], 21504);
+    symbols[0] = -1;
+    symbols[1] = -3;
+    DSD_MEMSET(upsampled, 0, sizeof(upsampled));
+    DSD_MEMSET(baseband, 0, sizeof(baseband));
+    dsd_neo_m17_test_upsample_symbols_10x(symbols, upsampled);
+    dsd_neo_m17_test_baseband_no_filter(upsampled, baseband);
+    err |= expect_int("baseband symbol -1", baseband[0], -7168);
+    err |= expect_int("baseband symbol -3", baseband[M17_RECOMMENDED_UPSAMPLE_FACTOR], -21504);
+
+    DSD_MEMSET(symbol_dibits, 0x22, sizeof(symbol_dibits));
+    for (size_t i = 0U; i < (M17_FRAME_SYMBOLS * M17_RECOMMENDED_UPSAMPLE_FACTOR); i++) {
+        baseband[i] = 55;
+    }
+    dsd_neo_m17_test_maybe_apply_dead_air(1, symbol_dibits, baseband);
+    err |= expect_u8("non-dead-air preserves dibit", symbol_dibits[0], 0x22U);
+    err |= expect_int("non-dead-air preserves baseband", baseband[0], 55);
+    dsd_neo_m17_test_maybe_apply_dead_air(99, symbol_dibits, baseband);
+    for (int i = 0; i < M17_FRAME_SYMBOLS; i++) {
+        err |= expect_u8("dead-air dibit marker", symbol_dibits[i], 0xFFU);
+    }
+    for (size_t i = 0U; i < (M17_FRAME_SYMBOLS * M17_RECOMMENDED_UPSAMPLE_FACTOR); i++) {
+        err |= expect_int("dead-air baseband silence", baseband[i], 0);
+    }
+
+    uint8_t bert_bits[M17_BERT_PAYLOAD_BITS];
+    uint8_t reversed[208];
+    for (int i = 0; i < M17_BERT_PAYLOAD_BITS; i++) {
+        bert_bits[i] = (uint8_t)((i % 3) == 0);
+    }
+    DSD_MEMSET(reversed, 0xA5, sizeof(reversed));
+    dsd_neo_m17_test_reverse_brt_bits(bert_bits, reversed);
+    err |= expect_u8("BERT reverse leading zero 0", reversed[0], 0U);
+    err |= expect_u8("BERT reverse leading zero 1", reversed[1], 0U);
+    err |= expect_u8("BERT reverse leading zero 2", reversed[2], 0U);
+    for (int i = 0; i < M17_BERT_PAYLOAD_BITS; i++) {
+        err |= expect_u8("BERT reverse payload", reversed[i + 3], bert_bits[(M17_BERT_PAYLOAD_BITS - 1) - i]);
+    }
+    err |= expect_u8("BERT reverse trailing zero", reversed[200], 0U);
+
+    err |= expect_int("strlen null", (int)dsd_neo_m17_test_strlen_limit(NULL, 9U), 0);
+    err |= expect_int("strlen full", (int)dsd_neo_m17_test_strlen_limit("abc", 9U), 3);
+    err |= expect_int("strlen capped", (int)dsd_neo_m17_test_strlen_limit("abcdef", 3U), 3);
+    err |= expect_int("strlen zero cap", (int)dsd_neo_m17_test_strlen_limit("abcdef", 0U), 0);
+
+    return err;
+}
+
+static int
+test_encoder_packet_payload_layout(void) {
+    uint8_t packed[M17_PACKET_MAX_TOTAL_BYTES];
+    uint8_t full_bits[M17_PACKET_MAX_FRAMES * M17_PACKET_CHUNK_BITS];
+    uint16_t app_len = 0;
+    int block = 0;
+    uint8_t lst = 0;
+    uint16_t crc = 0;
+    int err = 0;
+
+    DSD_MEMSET(packed, 0xA5, sizeof(packed));
+    DSD_MEMSET(full_bits, 0xA5, sizeof(full_bits));
+    err |= expect_int("packet layout null guard",
+                      dsd_neo_m17_test_prepare_pkt_payload("x", NULL, full_bits, &app_len, &block, &lst, &crc), -1);
+
+    err |= expect_int("packet layout short text",
+                      dsd_neo_m17_test_prepare_pkt_payload("hi", packed, full_bits, &app_len, &block, &lst, &crc), 0);
+    err |= expect_int("packet short app len", app_len, 4);
+    err |= expect_int("packet short block count", block, 1);
+    err |= expect_u8("packet short last frame bytes", lst, 6U);
+    err |= expect_u8("packet protocol SMS", packed[0], 0x05U);
+    err |= expect_u8("packet text h", packed[1], 'h');
+    err |= expect_u8("packet text i", packed[2], 'i');
+    err |= expect_u8("packet text terminator", packed[3], 0U);
+    err |= expect_int("packet short crc", crc, m17_crc16(packed, app_len));
+    err |= expect_u8("packet crc high", packed[app_len], (uint8_t)(crc >> 8U));
+    err |= expect_u8("packet crc low", packed[app_len + 1U], (uint8_t)(crc & 0xFFU));
+    err |= expect_u8("packet first bit", full_bits[0], 0U);
+    err |= expect_u8("packet protocol low bit", full_bits[7], 1U);
+    err |= expect_u8("packet h high bit", full_bits[8], 0U);
+    err |= expect_u8("packet h bit 1", full_bits[9], 1U);
+
+    char long_text[M17_PACKET_MAX_APPLICATION_BYTES + 64U];
+    for (size_t i = 0U; i < sizeof(long_text) - 1U; i++) {
+        long_text[i] = (char)('A' + (i % 26U));
+    }
+    long_text[sizeof(long_text) - 1U] = '\0';
+    DSD_MEMSET(packed, 0, sizeof(packed));
+    DSD_MEMSET(full_bits, 0, sizeof(full_bits));
+    err |=
+        expect_int("packet layout max text",
+                   dsd_neo_m17_test_prepare_pkt_payload(long_text, packed, full_bits, &app_len, &block, &lst, &crc), 0);
+    err |= expect_int("packet max app len", app_len, M17_PACKET_MAX_APPLICATION_BYTES);
+    err |= expect_int("packet max block count", block, M17_PACKET_MAX_FRAMES);
+    err |= expect_u8("packet max last frame bytes", lst, M17_PACKET_CHUNK_BYTES);
+    err |= expect_u8("packet max protocol", packed[0], 0x05U);
+    err |= expect_u8("packet max last text", packed[M17_PACKET_MAX_APPLICATION_BYTES - 2U],
+                     (uint8_t)long_text[M17_PACKET_MAX_APPLICATION_BYTES - 3U]);
+    err |= expect_u8("packet max terminator", packed[M17_PACKET_MAX_APPLICATION_BYTES - 1U], 0U);
+    err |= expect_int("packet max crc", crc, m17_crc16(packed, app_len));
+
+    return err;
+}
+
+static int
+test_packet_protocol_identifier_utf8_boundaries(void) {
+    uint8_t out[4];
+    int err = 0;
+
+    DSD_MEMSET(out, 0xA5, sizeof(out));
+    err |= expect_int("packet protocol null guard", (int)dsd_neo_m17_test_encode_packet_protocol_id(0x05U, NULL), 0);
+    err |= expect_int("packet protocol high guard",
+                      (int)dsd_neo_m17_test_encode_packet_protocol_id(M17_PACKET_PROTOCOL_MAX + 1U, out), 0);
+    for (size_t i = 0U; i < sizeof(out); i++) {
+        err |= expect_u8("packet protocol invalid preserves output", out[i], 0xA5U);
+    }
+
+    static const uint8_t want_sms[4] = {0x05U, 0xA5U, 0xA5U, 0xA5U};
+    err |= expect_int("packet protocol one byte", (int)dsd_neo_m17_test_encode_packet_protocol_id(0x05U, out), 1);
+    err |= expect_bytes("packet protocol one-byte layout", out, want_sms, sizeof(want_sms));
+
+    DSD_MEMSET(out, 0xA5, sizeof(out));
+    static const uint8_t want_text_meta[4] = {0xC2U, 0x80U, 0xA5U, 0xA5U};
+    err |= expect_int("packet protocol two bytes", (int)dsd_neo_m17_test_encode_packet_protocol_id(0x80U, out), 2);
+    err |= expect_bytes("packet protocol two-byte layout", out, want_text_meta, sizeof(want_text_meta));
+
+    DSD_MEMSET(out, 0xA5, sizeof(out));
+    static const uint8_t want_three[4] = {0xE0U, 0xA0U, 0x80U, 0xA5U};
+    err |= expect_int("packet protocol three bytes", (int)dsd_neo_m17_test_encode_packet_protocol_id(0x0800U, out), 3);
+    err |= expect_bytes("packet protocol three-byte layout", out, want_three, sizeof(want_three));
+
+    DSD_MEMSET(out, 0xA5, sizeof(out));
+    static const uint8_t want_max[4] = {0xF7U, 0xBFU, 0xBFU, 0xBFU};
+    err |= expect_int("packet protocol four bytes",
+                      (int)dsd_neo_m17_test_encode_packet_protocol_id(M17_PACKET_PROTOCOL_MAX, out), 4);
+    err |= expect_bytes("packet protocol four-byte layout", out, want_max, sizeof(want_max));
+
+    return err;
+}
+
+static int
+test_encoder_packet_state_overrides_prepare_lsf_and_payload(void) {
+    static dsd_state state;
+    uint8_t lsf_bits[240];
+    uint8_t packed[M17_PACKET_MAX_TOTAL_BYTES];
+    uint16_t app_len = 0U;
+    uint16_t lsf_crc = 0U;
+    uint8_t can = 0U;
+    unsigned long long dst = 0ULL;
+    unsigned long long src = 0ULL;
+    int err = 0;
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.m17_can_en = -1;
+    DSD_MEMSET(lsf_bits, 0xA5, sizeof(lsf_bits));
+    DSD_MEMSET(packed, 0xA5, sizeof(packed));
+    err |= expect_int(
+        "packet state helper null guard",
+        dsd_neo_m17_test_prepare_pkt_from_state(NULL, lsf_bits, packed, &app_len, &lsf_crc, &can, &dst, &src), -1);
+    err |= expect_int(
+        "packet default state helper",
+        dsd_neo_m17_test_prepare_pkt_from_state(&state, lsf_bits, packed, &app_len, &lsf_crc, &can, &dst, &src), 0);
+    err |= expect_u8("packet default CAN", can, 7U);
+    err |= expect_u64("packet default dst broadcast", dst, 0xFFFFFFFFFFFFULL);
+    err |= expect_u64("packet default src", src, m17_encode_b40_callsign(0ULL, "DSD-neo  "));
+    err |= expect_int("packet default LSF type", (int)bits_to_u64(lsf_bits + 96, 16U),
+                      dsd_neo_m17_test_compose_frame_info(0U, 0U, 0U, 0U, 7U, 0U, 0U));
+    err |= expect_int("packet default LSF CRC bits", (int)bits_to_u64(lsf_bits + M17_LSF_LSD_BITS, M17_LSF_CRC_BITS),
+                      lsf_crc);
+    err |= expect_int("packet default app length", app_len, 447);
+    err |= expect_u8("packet default protocol", packed[0], 0x05U);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.m17_can_en = 3;
+    DSD_SNPRINTF(state.str50c, sizeof(state.str50c), "%s", "N0CALL");
+    DSD_SNPRINTF(state.str50b, sizeof(state.str50b), "%s", "ALL");
+    DSD_SNPRINTF(state.m17sms, sizeof(state.m17sms), "%s", "override");
+    DSD_MEMSET(lsf_bits, 0, sizeof(lsf_bits));
+    DSD_MEMSET(packed, 0, sizeof(packed));
+
+    err |= expect_int(
+        "packet override state helper",
+        dsd_neo_m17_test_prepare_pkt_from_state(&state, lsf_bits, packed, &app_len, &lsf_crc, &can, &dst, &src), 0);
+    err |= expect_u8("packet override CAN", can, 3U);
+    err |= expect_u64("packet ALL dst broadcast", dst, 0xFFFFFFFFFFFFULL);
+    err |= expect_u64("packet override src", src, m17_encode_b40_callsign(0ULL, "N0CALL"));
+    err |= expect_int("packet override LSF type", (int)bits_to_u64(lsf_bits + 96, 16U),
+                      dsd_neo_m17_test_compose_frame_info(0U, 0U, 0U, 0U, 3U, 0U, 0U));
+    err |= expect_int("packet override LSF CRC bits", (int)bits_to_u64(lsf_bits + M17_LSF_LSD_BITS, M17_LSF_CRC_BITS),
+                      lsf_crc);
+    err |= expect_int("packet override app len", app_len, 10);
+    err |= expect_u8("packet override protocol", packed[0], 0x05U);
+    err |= expect_bytes("packet override text", packed + 1, (const uint8_t*)"override", 8U);
+    err |= expect_u8("packet override terminator", packed[9], 0U);
+
+    return err;
+}
+
 int
 main(void) {
     int err = 0;
+    err |= test_embedded_lich_chunks_store_and_finalize_lsf_state();
+    err |= test_embedded_lich_rejects_invalid_counter_and_gates_bad_lsf_crc();
     err |= test_lsf_application_resets_and_stores_state();
     err |= test_lsf_rejects_reserved_type_without_replacing_state();
+    err |= test_lsf_rejects_invalid_addresses_without_replacing_state();
+    err |= test_lsf_null_meta_decodes_text_and_honors_can_filter();
     err |= test_stream_dispatch_can_filter_and_aes_gates();
+    err |= test_stream_dispatch_legacy_aes_key_segments();
+    err |= test_stream_dispatch_rejects_invalid_arguments_and_unknown_encryption();
+    err |= test_stream_dispatch_scrambler_decrypts_with_seed_and_subtype();
+    err |= test_stream_dispatch_legacy_aes_array_key_segments();
+    err |= test_stream_signature_frames_are_consumed_and_verify_without_key();
+    err |= test_stream_signature_out_of_order_marks_sequence_error();
+    err |= test_clear_signed_payload_updates_digest_and_dispatches();
+#ifdef USE_CODEC2
+    err |= test_stream_voice_3200_dispatch_routes_pair_audio_to_udp();
+    err |= test_stream_voice_1600_dispatch_routes_single_audio_to_udp();
+    err |= test_stream_voice_audio_gate_suppresses_udp_when_slot_disabled();
+#endif
+    err |= test_bert_payload_locks_from_default_state_and_continues();
+    err |= test_bert_payload_resyncs_after_error_threshold();
+    err |= test_bert_hard_payload_decode_primitives();
+    err |= test_frame_info_packet_and_ip_helpers();
+    err |= test_ip_stream_frames_apply_crc_gated_lsf_state();
+    err |= test_ip_mpkt_frames_apply_crc_gated_packet_state();
+    err |= test_packet_eot_finalization_crc_gates_decode_and_clears_state();
+    err |= test_encoder_control_lsf_and_dibit_helpers();
+    err |= test_encoder_packet_payload_layout();
+    err |= test_packet_protocol_identifier_utf8_boundaries();
+    err |= test_encoder_packet_state_overrides_prepare_lsf_and_payload();
 
     if (err == 0) {
         printf("M17_STATE_DISPATCH: OK\n");
     }
     return err;
 }
+
+// NOLINTEND(bugprone-implicit-widening-of-multiplication-result)

--- a/tests/protocol/nxdn/test_nxdn_alias_fallback.c
+++ b/tests/protocol/nxdn/test_nxdn_alias_fallback.c
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Focused checks for the no-iconv NXDN alias text fallback.
+ */
+
+#include <dsd-neo/protocol/nxdn/nxdn_alias_decode.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "dsd-neo/core/safe_api.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+uint64_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ConvertBitIntoBytes(const uint8_t* bits, uint32_t n) {
+    uint64_t v = 0ULL;
+    for (uint32_t i = 0; i < n; i++) {
+        v = (v << 1U) | (uint64_t)(bits[i] & 1U);
+    }
+    return v;
+}
+
+static int
+expect_str(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_size(const char* tag, size_t got, size_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %zu want %zu\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_no_iconv_fallback_text_classes(void) {
+    char out[32];
+    int rc = 0;
+
+    static const uint8_t ascii_padded[] = {'N', 'X', 'D', 'N', ' ', ' ', 0x00, 'Z'};
+    size_t out_len = nxdn_alias_decode_shift_jis_like(ascii_padded, sizeof(ascii_padded), out, sizeof(out));
+    rc |= expect_str("fallback ASCII trims trailing spaces", out, "NXDN");
+    rc |= expect_size("fallback ASCII length", out_len, 4U);
+
+    static const uint8_t halfwidth_katakana[] = {0xA1U, 0x00U};
+    out_len = nxdn_alias_decode_shift_jis_like(halfwidth_katakana, sizeof(halfwidth_katakana), out, sizeof(out));
+    rc |= expect_str("fallback half-width katakana", out, "\xEF\xBD\xA1");
+    rc |= expect_size("fallback half-width katakana length", out_len, strlen(out));
+
+    static const uint8_t unsupported_multibyte[] = {0x93U, 0xFAU, 0x00U};
+    out_len = nxdn_alias_decode_shift_jis_like(unsupported_multibyte, sizeof(unsupported_multibyte), out, sizeof(out));
+    rc |= expect_str("fallback unsupported multibyte replacement", out, "\xEF\xBF\xBD");
+    rc |= expect_size("fallback unsupported multibyte length", out_len, strlen(out));
+
+    static const uint8_t invalid_byte[] = {0x80U, 0x00U};
+    out_len = nxdn_alias_decode_shift_jis_like(invalid_byte, sizeof(invalid_byte), out, sizeof(out));
+    rc |= expect_str("fallback invalid byte marker", out, "?");
+    rc |= expect_size("fallback invalid byte length", out_len, 1U);
+
+    return rc;
+}
+
+static int
+test_no_iconv_fallback_bounds(void) {
+    char out[4];
+    static const uint8_t input[] = {'A', 'B', 'C', 'D', 'E', 0x00U};
+    size_t out_len = nxdn_alias_decode_shift_jis_like(input, sizeof(input), out, sizeof(out));
+
+    int rc = 0;
+    rc |= expect_str("fallback bounded output", out, "ABC");
+    rc |= expect_size("fallback bounded length", out_len, 3U);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+
+    rc |= test_no_iconv_fallback_text_classes();
+    rc |= test_no_iconv_fallback_bounds();
+
+    if (rc == 0) {
+        printf("NXDN_ALIAS_FALLBACK: OK\n");
+    }
+    return rc;
+}

--- a/tests/protocol/nxdn/test_nxdn_convolution.c
+++ b/tests/protocol/nxdn/test_nxdn_convolution.c
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Regression vectors for the NXDN Viterbi hard/soft convolution decoder.
+ */
+
+#include <dsd-neo/protocol/nxdn/nxdn_convolution.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "dsd-neo/core/safe_api.h"
+
+static int
+expect_byte(const char* tag, size_t index, uint8_t got, uint8_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s[%zu]: got 0x%02X want 0x%02X\n", tag, index, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_buffer(const char* tag, const uint8_t* got, const uint8_t* want, size_t len) {
+    int rc = 0;
+    for (size_t i = 0U; i < len; i++) {
+        rc |= expect_byte(tag, i, got[i], want[i]);
+    }
+    return rc;
+}
+
+static void
+decode_hard_symbols(const uint8_t* symbols, size_t pair_count, unsigned int out_bits, uint8_t* out, size_t out_len) {
+    DSD_MEMSET(out, 0, out_len);
+
+    CNXDNConvolution_init();
+    CNXDNConvolution_start();
+    for (size_t i = 0U; i < pair_count; i++) {
+        CNXDNConvolution_decode(symbols[i * 2U], symbols[(i * 2U) + 1U]);
+    }
+    CNXDNConvolution_chainback(out, out_bits);
+}
+
+static void
+decode_soft_symbols(const uint8_t* symbols, const uint8_t* reliabilities, size_t pair_count, unsigned int out_bits,
+                    uint8_t* out, size_t out_len) {
+    DSD_MEMSET(out, 0, out_len);
+
+    CNXDNConvolution_init();
+    CNXDNConvolution_start();
+    for (size_t i = 0U; i < pair_count; i++) {
+        CNXDNConvolution_decode_soft(symbols[i * 2U], symbols[(i * 2U) + 1U], reliabilities[i * 2U],
+                                     reliabilities[(i * 2U) + 1U]);
+    }
+    CNXDNConvolution_chainback(out, out_bits);
+}
+
+static int
+test_hard_decode_vector(void) {
+    static const uint8_t symbols[] = {0, 0, 0, 2, 2, 2, 2, 0, 0, 0, 2, 0, 0, 2, 2, 2, 0, 0, 0, 2, 2, 0, 0, 0};
+    static const uint8_t expected[] = {0x88U, 0xE0U};
+
+    uint8_t out[sizeof(expected)];
+    decode_hard_symbols(symbols, sizeof(symbols) / 2U, 12U, out, sizeof(out));
+    return expect_buffer("hard-decode", out, expected, sizeof(expected));
+}
+
+static int
+test_soft_decode_vector(void) {
+    static const uint8_t symbols[] = {0, 0, 0, 2, 2, 2, 2, 0, 0, 0, 2, 0, 0, 2, 2, 2, 0, 0, 0, 2, 2, 0, 0, 0};
+    static const uint8_t reliabilities[sizeof(symbols)] = {
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    };
+    static const uint8_t expected[] = {0x03U, 0x00U};
+
+    uint8_t out[sizeof(expected)];
+    decode_soft_symbols(symbols, reliabilities, sizeof(symbols) / 2U, 12U, out, sizeof(out));
+    return expect_buffer("soft-decode", out, expected, sizeof(expected));
+}
+
+static int
+test_soft_decode_clamps_large_metrics(void) {
+    static const uint8_t symbols[] = {9, 9, 2, 0, 0, 2, 2, 2, 0, 0, 2, 0, 0, 2, 2, 2, 0, 0, 0, 2, 2, 0, 0, 0};
+    static const uint8_t reliabilities[sizeof(symbols)] = {
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    };
+    static const uint8_t expected[] = {0xD3U, 0x00U};
+
+    uint8_t out[sizeof(expected)];
+    decode_soft_symbols(symbols, reliabilities, sizeof(symbols) / 2U, 12U, out, sizeof(out));
+    return expect_buffer("soft-clamp", out, expected, sizeof(expected));
+}
+
+static int
+test_chainback_zero_bits_preserves_output(void) {
+    uint8_t out[2] = {0xA5U, 0x5AU};
+
+    CNXDNConvolution_init();
+    CNXDNConvolution_start();
+    CNXDNConvolution_chainback(out, 0U);
+
+    int rc = 0;
+    rc |= expect_byte("zero-chainback", 0U, out[0], 0xA5U);
+    rc |= expect_byte("zero-chainback", 1U, out[1], 0x5AU);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+
+    rc |= test_hard_decode_vector();
+    rc |= test_soft_decode_vector();
+    rc |= test_soft_decode_clamps_large_metrics();
+    rc |= test_chainback_zero_bits_preserves_output();
+
+    if (rc == 0) {
+        printf("NXDN_CONVOLUTION: OK\n");
+    }
+    return rc;
+}

--- a/tests/protocol/nxdn/test_nxdn_deperm_primitives.c
+++ b/tests/protocol/nxdn/test_nxdn_deperm_primitives.c
@@ -708,6 +708,67 @@ test_facch3_udch2_crc_state_update(void) {
     return rc;
 }
 
+static int
+test_facch3_udch2_split_block_storage_and_crc_gate(void) {
+    uint8_t bits[160];
+    uint8_t bytes[24];
+    uint8_t trellis0[96];
+    uint8_t trellis1[96];
+    uint8_t m_data0[12];
+    uint8_t m_data1[12];
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(bits, 0xA5, sizeof(bits));
+    DSD_MEMSET(bytes, 0x5A, sizeof(bytes));
+    for (size_t i = 0U; i < sizeof(trellis0); i++) {
+        trellis0[i] = (uint8_t)((i + 1U) & 1U);
+        trellis1[i] = (uint8_t)(i & 1U);
+    }
+    write_bits_msb(trellis0, 2U, 6U, 0x10U);
+    for (size_t i = 0U; i < sizeof(m_data0); i++) {
+        m_data0[i] = (uint8_t)(0x20U + i);
+        m_data1[i] = (uint8_t)(0x80U + i);
+    }
+
+    dsd_neo_nxdn_test_facch3_udch2_store_block(bits, bytes, 1U, trellis1, m_data1);
+    for (size_t i = 0U; i < 80U; i++) {
+        rc |= expect_u8_at("facch3-split-first-half-untouched", i, bits[i], 0xA5U);
+        rc |= expect_u8_at("facch3-split-second-half", i, bits[i + 80U], trellis1[i]);
+    }
+    for (size_t i = 0U; i < 12U; i++) {
+        rc |= expect_u8_at("facch3-split-first-bytes-untouched", i, bytes[i], 0x5AU);
+        rc |= expect_u8_at("facch3-split-second-bytes", i, bytes[i + 12U], m_data1[i]);
+    }
+
+    dsd_neo_nxdn_test_facch3_udch2_store_block(bits, bytes, 0U, trellis0, m_data0);
+    for (size_t i = 0U; i < 80U; i++) {
+        rc |= expect_u8_at("facch3-split-first-half", i, bits[i], trellis0[i]);
+        rc |= expect_u8_at("facch3-split-second-half-preserved", i, bits[i + 80U], trellis1[i]);
+    }
+    for (size_t i = 0U; i < 12U; i++) {
+        rc |= expect_u8_at("facch3-split-first-bytes", i, bytes[i], m_data0[i]);
+        rc |= expect_u8_at("facch3-split-second-bytes-preserved", i, bytes[i + 12U], m_data1[i]);
+    }
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    dsd_neo_nxdn_test_facch3_udch2_state_update(&opts, &state, bits, bytes, 0x111U, 0x111U, 0x222U, 0x222U, 1U);
+    rc |= expect_u8_at("facch3-split-good-format", 0U, state.data_header_format[0], 1U);
+    rc |= expect_u8_at("facch3-split-good-message-type", 0U, state.NxdnElementsContent.MessageType, 0x10U);
+    rc |= expect_u8_at("facch3-split-good-crc", 0U, state.NxdnElementsContent.VCallCrcIsGood, 1U);
+
+    state.data_header_format[0] = 9U;
+    state.NxdnElementsContent.MessageType = 0x22U;
+    state.NxdnElementsContent.VCallCrcIsGood = 0U;
+    dsd_neo_nxdn_test_facch3_udch2_state_update(&opts, &state, bits, bytes, 0x111U, 0x111U, 0x222U, 0x223U, 0U);
+    rc |= expect_u8_at("udch2-split-bad-keeps-format", 0U, state.data_header_format[0], 9U);
+    rc |= expect_u8_at("udch2-split-bad-keeps-message-type", 0U, state.NxdnElementsContent.MessageType, 0x22U);
+    rc |= expect_u8_at("udch2-split-bad-keeps-crc", 0U, state.NxdnElementsContent.VCallCrcIsGood, 0U);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -724,6 +785,7 @@ main(void) {
     rc |= test_pich_tch_dcr_csm_alias_state();
     rc |= test_facch2_udch_crc_state_update();
     rc |= test_facch3_udch2_crc_state_update();
+    rc |= test_facch3_udch2_split_block_storage_and_crc_gate();
 
     if (rc == 0) {
         printf("NXDN_DEPERM_PRIMITIVES: OK\n");

--- a/tests/protocol/nxdn/test_nxdn_deperm_primitives.c
+++ b/tests/protocol/nxdn/test_nxdn_deperm_primitives.c
@@ -1,0 +1,732 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Regression checks for NXDN deinterleave and depuncture primitives shared by
+ * SACCH, FACCH, CAC, FACCH2, and FACCH3 soft-decision paths.
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/protocol/nxdn/nxdn_deperm.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static int
+expect_u8_at(const char* tag, size_t index, uint8_t got, uint8_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s[%zu]: got 0x%02X want 0x%02X\n", tag, index, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u16(const char* tag, uint16_t got, uint16_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got 0x%04X want 0x%04X\n", tag, (unsigned)got, (unsigned)want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_str(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static void
+fill_input(uint8_t* input, uint8_t* reliab, size_t len) {
+    for (size_t i = 0U; i < len; i++) {
+        input[i] = (uint8_t)((i * 3U + 1U) & 0xFFU);
+        reliab[i] = (uint8_t)(255U - ((i * 5U) & 0xFFU));
+    }
+}
+
+static void
+write_bits_msb(uint8_t* bits, size_t start, size_t nbits, uint32_t value) {
+    for (size_t i = 0U; i < nbits; i++) {
+        const size_t shift = nbits - 1U - i;
+        bits[start + i] = (uint8_t)((value >> shift) & 1U);
+    }
+}
+
+static unsigned long long
+advance_nxdn_lfsr_seed(unsigned long long seed, int calls) {
+    int lfsr = (int)(seed & 0x7FFFULL);
+    for (int call = 0; call < calls; call++) {
+        for (int i = 0; i < 49; i++) {
+            const int bit = ((lfsr >> 1) ^ (lfsr >> 0)) & 1;
+            lfsr = ((lfsr >> 1) | (bit << 14));
+        }
+    }
+    return (unsigned long long)(lfsr & 0x7FFF);
+}
+
+static int
+expect_matrix_deperm(const char* tag, const uint8_t* input, const uint8_t* reliab, const uint8_t* deperm,
+                     const uint8_t* deperm_rel, size_t len, size_t columns) {
+    int rc = 0;
+    const size_t rows = len / columns;
+
+    for (size_t i = 0U; i < len; i++) {
+        const size_t out = (i % rows) * columns + (i / rows);
+        rc |= expect_u8_at(tag, out, deperm[out], input[i]);
+        rc |= expect_u8_at("deperm reliability", out, deperm_rel[out], reliab[i]);
+    }
+    return rc;
+}
+
+static int
+test_depermute_matrices(void) {
+    int rc = 0;
+
+    {
+        uint8_t input[60];
+        uint8_t reliab[60];
+        uint8_t deperm[60];
+        uint8_t deperm_rel[60];
+        fill_input(input, reliab, sizeof(input));
+        DSD_MEMSET(deperm, 0xA5, sizeof(deperm));
+        DSD_MEMSET(deperm_rel, 0x5A, sizeof(deperm_rel));
+
+        dsd_neo_nxdn_test_depermute_12_5(input, reliab, deperm, deperm_rel);
+        rc |= expect_matrix_deperm("deperm-12x5", input, reliab, deperm, deperm_rel, sizeof(input), 12U);
+    }
+
+    {
+        uint8_t input[144];
+        uint8_t reliab[144];
+        uint8_t deperm[144];
+        uint8_t deperm_rel[144];
+        fill_input(input, reliab, sizeof(input));
+        DSD_MEMSET(deperm, 0xA5, sizeof(deperm));
+        DSD_MEMSET(deperm_rel, 0x5A, sizeof(deperm_rel));
+
+        dsd_neo_nxdn_test_depermute_16_9(input, reliab, deperm, deperm_rel);
+        rc |= expect_matrix_deperm("deperm-16x9", input, reliab, deperm, deperm_rel, sizeof(input), 16U);
+    }
+
+    {
+        uint8_t input[300];
+        uint8_t reliab[300];
+        uint8_t deperm[300];
+        uint8_t deperm_rel[300];
+        fill_input(input, reliab, sizeof(input));
+        DSD_MEMSET(deperm, 0xA5, sizeof(deperm));
+        DSD_MEMSET(deperm_rel, 0x5A, sizeof(deperm_rel));
+
+        dsd_neo_nxdn_test_depermute_12_25(input, reliab, deperm, deperm_rel);
+        rc |= expect_matrix_deperm("deperm-12x25", input, reliab, deperm, deperm_rel, sizeof(input), 12U);
+    }
+
+    {
+        uint8_t input[348];
+        uint8_t reliab[348];
+        uint8_t deperm[348];
+        uint8_t deperm_rel[348];
+        fill_input(input, reliab, sizeof(input));
+        DSD_MEMSET(deperm, 0xA5, sizeof(deperm));
+        DSD_MEMSET(deperm_rel, 0x5A, sizeof(deperm_rel));
+
+        dsd_neo_nxdn_test_depermute_12_29(input, reliab, deperm, deperm_rel);
+        rc |= expect_matrix_deperm("deperm-12x29", input, reliab, deperm, deperm_rel, sizeof(input), 12U);
+    }
+
+    return rc;
+}
+
+static int
+expect_depuncture_12_5_group(const uint8_t* deperm, const uint8_t* deperm_rel, const uint8_t* depunc,
+                             const uint8_t* depunc_rel, size_t in_base, size_t out_base) {
+    static const uint8_t map[] = {0, 1, 2, 3, 4, 0xFFU, 5, 6, 7, 8, 9, 0xFFU};
+    int rc = 0;
+
+    for (size_t i = 0U; i < sizeof(map); i++) {
+        if (map[i] == 0xFFU) {
+            rc |= expect_u8_at("depunc-12-5-erasure-bit", out_base + i, depunc[out_base + i], 0U);
+            rc |= expect_u8_at("depunc-12-5-erasure-rel", out_base + i, depunc_rel[out_base + i], 0U);
+        } else {
+            rc |= expect_u8_at("depunc-12-5-bit", out_base + i, depunc[out_base + i], deperm[in_base + map[i]]);
+            rc |= expect_u8_at("depunc-12-5-rel", out_base + i, depunc_rel[out_base + i], deperm_rel[in_base + map[i]]);
+        }
+    }
+    return rc;
+}
+
+static int
+test_depuncture_12_5(void) {
+    uint8_t deperm[60];
+    uint8_t deperm_rel[60];
+    uint8_t depunc[72];
+    uint8_t depunc_rel[72];
+    int rc = 0;
+
+    fill_input(deperm, deperm_rel, sizeof(deperm));
+    DSD_MEMSET(depunc, 0xA5, sizeof(depunc));
+    DSD_MEMSET(depunc_rel, 0x5A, sizeof(depunc_rel));
+
+    dsd_neo_nxdn_test_depuncture_12_5(deperm, deperm_rel, depunc, depunc_rel);
+    for (size_t group = 0U; group < 6U; group++) {
+        rc |= expect_depuncture_12_5_group(deperm, deperm_rel, depunc, depunc_rel, group * 10U, group * 12U);
+    }
+    return rc;
+}
+
+static int
+test_depuncture_16_9(void) {
+    uint8_t deperm[144];
+    uint8_t deperm_rel[144];
+    uint8_t depunc[192];
+    uint8_t depunc_rel[192];
+    int rc = 0;
+
+    fill_input(deperm, deperm_rel, sizeof(deperm));
+    DSD_MEMSET(depunc, 0xA5, sizeof(depunc));
+    DSD_MEMSET(depunc_rel, 0x5A, sizeof(depunc_rel));
+
+    dsd_neo_nxdn_test_depuncture_16_9(deperm, deperm_rel, depunc, depunc_rel);
+    for (size_t i = 0U; i < 144U; i += 3U) {
+        const size_t out = (i / 3U) * 4U;
+        rc |= expect_u8_at("depunc-16-9-bit-a", out, depunc[out], deperm[i]);
+        rc |= expect_u8_at("depunc-16-9-rel-a", out, depunc_rel[out], deperm_rel[i]);
+        rc |= expect_u8_at("depunc-16-9-erasure-bit", out + 1U, depunc[out + 1U], 0U);
+        rc |= expect_u8_at("depunc-16-9-erasure-rel", out + 1U, depunc_rel[out + 1U], 0U);
+        rc |= expect_u8_at("depunc-16-9-bit-b", out + 2U, depunc[out + 2U], deperm[i + 1U]);
+        rc |= expect_u8_at("depunc-16-9-rel-b", out + 2U, depunc_rel[out + 2U], deperm_rel[i + 1U]);
+        rc |= expect_u8_at("depunc-16-9-bit-c", out + 3U, depunc[out + 3U], deperm[i + 2U]);
+        rc |= expect_u8_at("depunc-16-9-rel-c", out + 3U, depunc_rel[out + 3U], deperm_rel[i + 2U]);
+    }
+    return rc;
+}
+
+static int
+test_depuncture_12_group(void) {
+    static const uint8_t map[] = {0, 1, 2, 0xFFU, 3, 4, 5, 6, 7, 8, 9, 0xFFU, 10, 11};
+    uint8_t deperm[24];
+    uint8_t deperm_rel[24];
+    uint8_t depunc[28];
+    uint8_t depunc_rel[28];
+    int rc = 0;
+
+    fill_input(deperm, deperm_rel, sizeof(deperm));
+    DSD_MEMSET(depunc, 0xA5, sizeof(depunc));
+    DSD_MEMSET(depunc_rel, 0x5A, sizeof(depunc_rel));
+
+    dsd_neo_nxdn_test_depuncture_12_group(deperm, deperm_rel, 2U, depunc, depunc_rel);
+    for (size_t group = 0U; group < 2U; group++) {
+        for (size_t i = 0U; i < sizeof(map); i++) {
+            const size_t out = (group * sizeof(map)) + i;
+            if (map[i] == 0xFFU) {
+                rc |= expect_u8_at("depunc-12-group-erasure-bit", out, depunc[out], 0U);
+                rc |= expect_u8_at("depunc-12-group-erasure-rel", out, depunc_rel[out], 0U);
+            } else {
+                const size_t in = (group * 12U) + map[i];
+                rc |= expect_u8_at("depunc-12-group-bit", out, depunc[out], deperm[in]);
+                rc |= expect_u8_at("depunc-12-group-rel", out, depunc_rel[out], deperm_rel[in]);
+            }
+        }
+    }
+    return rc;
+}
+
+static int
+test_crc_helpers(void) {
+    static const uint8_t empty[1] = {0U};
+    static const uint8_t zeros6[6] = {0U, 0U, 0U, 0U, 0U, 0U};
+    static const uint8_t ones6[6] = {1U, 1U, 1U, 1U, 1U, 1U};
+    static const uint8_t pattern8[8] = {1U, 0U, 1U, 1U, 0U, 0U, 1U, 0U};
+    uint8_t pattern25[25];
+    uint8_t pattern26[26];
+    uint8_t pattern171[171];
+    int rc = 0;
+
+    for (size_t i = 0U; i < sizeof(pattern25); i++) {
+        pattern25[i] = (uint8_t)((i * 5U + 1U) & 1U);
+    }
+    for (size_t i = 0U; i < sizeof(pattern26); i++) {
+        pattern26[i] = (uint8_t)((i * 3U + 1U) & 1U);
+    }
+    for (size_t i = 0U; i < sizeof(pattern171); i++) {
+        pattern171[i] = (uint8_t)((i * 7U + 3U) & 1U);
+    }
+
+    rc |= expect_int("load empty", load_i(empty, 0), 0);
+    rc |= expect_int("load pattern8", load_i(pattern8, (int)sizeof(pattern8)), 0xB2);
+
+    rc |= expect_u8_at("crc6 empty", 0U, crc6(empty, 0), 63U);
+    rc |= expect_u8_at("crc6 zeros6", 0U, crc6(zeros6, (int)sizeof(zeros6)), 24U);
+    rc |= expect_u8_at("crc6 ones6", 0U, crc6(ones6, (int)sizeof(ones6)), 0U);
+    rc |= expect_u8_at("crc6 pattern26", 0U, crc6(pattern26, (int)sizeof(pattern26)), 46U);
+
+    rc |= expect_u8_at("crc7 empty", 0U, crc7_scch(empty, 0), 127U);
+    rc |= expect_u8_at("crc7 pattern25", 0U, crc7_scch(pattern25, (int)sizeof(pattern25)), 16U);
+
+    rc |= expect_u16("crc16cac empty", crc16cac(empty, 0), 0x3C11U);
+    rc |= expect_u16("crc16cac pattern8", crc16cac(pattern8, (int)sizeof(pattern8)), 0xF862U);
+    rc |= expect_u16("crc16cac pattern171", crc16cac(pattern171, (int)sizeof(pattern171)), 0x2608U);
+    return rc;
+}
+
+static int
+test_bit_window_and_state_helpers(void) {
+    static const uint8_t bytes[3] = {0xA5U, 0x3CU, 0x01U};
+    static const uint8_t expected_bits[24] = {1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+    uint8_t bits[24];
+    uint8_t roundtrip[3];
+    uint8_t trellis[8];
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(bits, 0xA5, sizeof(bits));
+    DSD_MEMSET(roundtrip, 0, sizeof(roundtrip));
+    dsd_neo_nxdn_test_unpack_bytes_msb(bytes, sizeof(bytes), bits);
+    for (size_t i = 0U; i < sizeof(bits); i++) {
+        rc |= expect_u8_at("unpack-msb", i, bits[i], expected_bits[i]);
+    }
+    dsd_neo_nxdn_test_pack_bits_msb(bits, sizeof(roundtrip), roundtrip);
+    for (size_t i = 0U; i < sizeof(roundtrip); i++) {
+        rc |= expect_u8_at("pack-msb", i, roundtrip[i], bytes[i]);
+    }
+    rc |= expect_u8_at("bits-to-u16", 0U, (uint8_t)dsd_neo_nxdn_test_bits_to_u16(bits, 8), bytes[0]);
+    rc |= expect_u8_at("dcr-sb0-call", 0U, (uint8_t)dsd_neo_nxdn_test_dcr_is_sb0_message_type(0x01U), 1U);
+    rc |= expect_u8_at("dcr-sb0-idle", 0U, (uint8_t)dsd_neo_nxdn_test_dcr_is_sb0_message_type(0x02U), 0U);
+    rc |= expect_u8_at("sacch-sf2-part", 0U, (uint8_t)dsd_neo_nxdn_test_sacch_part_of_frame(2U), 1U);
+    rc |= expect_u8_at("sacch-sf1-part", 0U, (uint8_t)dsd_neo_nxdn_test_sacch_part_of_frame(1U), 2U);
+    rc |= expect_u8_at("sacch-sf0-part", 0U, (uint8_t)dsd_neo_nxdn_test_sacch_part_of_frame(0U), 3U);
+    rc |= expect_u8_at("sacch-sf3-invalid", 0U, (uint8_t)dsd_neo_nxdn_test_sacch_part_of_frame(3U), 0U);
+
+    DSD_MEMSET(trellis, 0, sizeof(trellis));
+    trellis[2] = 1U;
+    trellis[4] = 1U;
+    trellis[7] = 1U;
+    rc |= expect_u8_at("ran-from-trellis", 0U, (uint8_t)dsd_neo_nxdn_test_ran_from_trellis(trellis), 0x29U);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.payload_miN = 0x11U;
+    state.R = 0x12345U;
+    dsd_neo_nxdn_test_reset_payload_seed_if_forced(&state);
+    rc |= expect_u8_at("seed-not-forced", 0U, (uint8_t)state.payload_miN, 0x11U);
+    state.nxdn_cipher_type = 1;
+    dsd_neo_nxdn_test_reset_payload_seed_if_forced(&state);
+    rc |= expect_u8_at("seed-forced-cipher-low", 0U, (uint8_t)state.payload_miN, 0x45U);
+    state.payload_miN = 0x22U;
+    state.nxdn_cipher_type = 0;
+    state.M = 1;
+    dsd_neo_nxdn_test_reset_payload_seed_if_forced(&state);
+    rc |= expect_u8_at("seed-forced-m-low", 0U, (uint8_t)state.payload_miN, 0x45U);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.payload_miN = 0x33U;
+    state.R = 0x2468U;
+    state.M = 1;
+    dsd_neo_nxdn_test_prepare_sacch_payload_seed(&state, 0);
+    rc |= expect_int("prepare-part0-forced-seed", (int)state.payload_miN, 0x2468);
+
+    state.payload_miN = 0x44U;
+    state.nxdn_cipher_type = 0;
+    state.M = 1;
+    dsd_neo_nxdn_test_prepare_sacch_payload_seed(&state, 2);
+    rc |= expect_int("prepare-noncipher-nonzero-part-preserves-seed", (int)state.payload_miN, 0x44);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.R = 0x2468U;
+    state.nxdn_cipher_type = 1;
+    dsd_neo_nxdn_test_prepare_sacch_payload_seed(&state, 2);
+    rc |= expect_int("prepare-cipher-part-advances-seed", (int)state.payload_miN,
+                     (int)advance_nxdn_lfsr_seed(0x2468U, 8));
+    return rc;
+}
+
+static void
+init_sacch2_state(dsd_state* state, Event_History_I histories[2]) {
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(histories, 0, sizeof(Event_History_I) * 2U);
+    DSD_MEMSET(state->nxdn_sacch_frame_segment, 1, sizeof(state->nxdn_sacch_frame_segment));
+    DSD_MEMSET(state->nxdn_sacch_frame_segcrc, 1, sizeof(state->nxdn_sacch_frame_segcrc));
+    state->event_history_s = histories;
+}
+
+static void
+make_sacch2_trellis(uint8_t trellis[32], uint8_t sf_fb, uint8_t sf_num, uint8_t sf_mes) {
+    DSD_MEMSET(trellis, 0, 32U);
+    trellis[0] = (uint8_t)(sf_fb & 1U);
+    write_bits_msb(trellis, 1U, 2U, sf_num & 0x03U);
+    write_bits_msb(trellis, 3U, 5U, sf_mes & 0x1FU);
+}
+
+static void
+make_sacch_trellis(uint8_t trellis[32], uint8_t sf, uint8_t ran) {
+    DSD_MEMSET(trellis, 0, 32U);
+    write_bits_msb(trellis, 0U, 2U, sf & 0x03U);
+    write_bits_msb(trellis, 2U, 6U, ran & 0x3FU);
+    for (size_t i = 8U; i < 26U; i++) {
+        trellis[i] = (uint8_t)((i + ran) & 1U);
+    }
+}
+
+static void
+make_csm_trellis(uint8_t trellis[96], const uint8_t digits[9]) {
+    DSD_MEMSET(trellis, 0, 96U);
+    for (size_t i = 0U; i < 9U; i++) {
+        write_bits_msb(trellis, i * 4U, 4U, digits[i] & 0x0FU);
+    }
+}
+
+static void
+make_facch2_trellis(uint8_t trellis[208], uint8_t sf, uint8_t ran, uint8_t message_type) {
+    DSD_MEMSET(trellis, 0, 208U);
+    write_bits_msb(trellis, 0U, 2U, sf & 0x03U);
+    write_bits_msb(trellis, 2U, 6U, ran & 0x3FU);
+    write_bits_msb(trellis, 10U, 6U, message_type & 0x3FU);
+}
+
+static void
+make_facch3_bits(uint8_t bits[160], uint8_t message_type) {
+    DSD_MEMSET(bits, 0, 160U);
+    write_bits_msb(bits, 2U, 6U, message_type & 0x3FU);
+}
+
+static int
+expect_sacch_reset_to_ones(const dsd_state* state) {
+    int rc = 0;
+    for (size_t frame = 0U; frame < 4U; frame++) {
+        rc |= expect_u8_at("sacch2-reset-crc", frame, state->nxdn_sacch_frame_segcrc[frame], 1U);
+        for (size_t bit = 0U; bit < 18U; bit++) {
+            rc |= expect_u8_at("sacch2-reset-segment", (frame * 18U) + bit, state->nxdn_sacch_frame_segment[frame][bit],
+                               1U);
+        }
+    }
+    return rc;
+}
+
+static int
+test_sacch_state_update(void) {
+    static const uint8_t m_data[5] = {0x11U, 0x22U, 0x33U, 0x44U, 0x55U};
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t trellis[32];
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(state.nxdn_sacch_frame_segment, 0xA5, sizeof(state.nxdn_sacch_frame_segment));
+    DSD_MEMSET(state.nxdn_sacch_frame_segcrc, 0, sizeof(state.nxdn_sacch_frame_segcrc));
+    state.nxdn_sacch_non_superframe = 0;
+    state.nxdn_part_of_frame = 0;
+    make_sacch_trellis(trellis, 2U, 0x15U);
+
+    dsd_neo_nxdn_test_sacch_state_update(&opts, &state, trellis, m_data, 0x2AU, 0x2AU);
+    rc |= expect_int("sacch-sf-good-part", state.nxdn_part_of_frame, 1);
+    rc |= expect_int("sacch-sf-good-ran", (int)state.nxdn_ran, 0x15);
+    rc |= expect_int("sacch-sf-good-last-ran", (int)state.nxdn_last_ran, 0x15);
+    rc |= expect_u8_at("sacch-sf-good-segcrc", 1U, state.nxdn_sacch_frame_segcrc[1], 0U);
+    for (size_t i = 0U; i < 18U; i++) {
+        rc |= expect_u8_at("sacch-sf-good-segment-copy", i, state.nxdn_sacch_frame_segment[1][i], trellis[i + 8U]);
+    }
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(state.nxdn_sacch_frame_segment, 0, sizeof(state.nxdn_sacch_frame_segment));
+    DSD_MEMSET(state.nxdn_sacch_frame_segcrc, 0, sizeof(state.nxdn_sacch_frame_segcrc));
+    state.nxdn_sacch_non_superframe = 0;
+    state.nxdn_part_of_frame = 0;
+    make_sacch_trellis(trellis, 1U, 0x09U);
+
+    dsd_neo_nxdn_test_sacch_state_update(&opts, &state, trellis, m_data, 0x10U, 0x10U);
+    rc |= expect_int("sacch-sf-out-of-order-part", state.nxdn_part_of_frame, 2);
+    rc |= expect_u8_at("sacch-sf-out-of-order-reset-prior-segcrc", 0U, state.nxdn_sacch_frame_segcrc[0], 1U);
+    rc |= expect_u8_at("sacch-sf-out-of-order-current-segcrc", 2U, state.nxdn_sacch_frame_segcrc[2], 0U);
+    for (size_t i = 0U; i < 18U; i++) {
+        rc |= expect_u8_at("sacch-sf-out-of-order-current-copy", i, state.nxdn_sacch_frame_segment[2][i],
+                           trellis[i + 8U]);
+    }
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(state.nxdn_sacch_frame_segment, 0, sizeof(state.nxdn_sacch_frame_segment));
+    DSD_MEMSET(state.nxdn_sacch_frame_segcrc, 0, sizeof(state.nxdn_sacch_frame_segcrc));
+    state.nxdn_sacch_non_superframe = 0;
+    state.nxdn_part_of_frame = 1;
+    make_sacch_trellis(trellis, 1U, 0x2AU);
+
+    dsd_neo_nxdn_test_sacch_state_update(&opts, &state, trellis, m_data, 0x01U, 0x00U);
+    rc |= expect_int("sacch-sf-bad-crc-part", state.nxdn_part_of_frame, 2);
+    rc |= expect_u8_at("sacch-sf-bad-crc-segcrc", 2U, state.nxdn_sacch_frame_segcrc[2], 1U);
+    rc |= expect_u8_at("sacch-sf-bad-crc-reset-other", 0U, state.nxdn_sacch_frame_segcrc[0], 1U);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(state.nxdn_sacch_frame_segment, 0, sizeof(state.nxdn_sacch_frame_segment));
+    DSD_MEMSET(state.nxdn_sacch_frame_segcrc, 0, sizeof(state.nxdn_sacch_frame_segcrc));
+    state.nxdn_sacch_non_superframe = 1;
+    state.nxdn_part_of_frame = 3;
+    state.M = 1;
+    state.R = 0x2468U;
+    state.payload_miN = 0x11U;
+    make_sacch_trellis(trellis, 3U, 0x3FU);
+
+    dsd_neo_nxdn_test_sacch_state_update(&opts, &state, trellis, m_data, 0x01U, 0x00U);
+    rc |= expect_int("sacch-nsf-bad-crc-part-reset", state.nxdn_part_of_frame, 0);
+    rc |= expect_int("sacch-nsf-bad-crc-forced-seed", (int)state.payload_miN, 0x2468);
+    rc |= expect_sacch_reset_to_ones(&state);
+    return rc;
+}
+
+static int
+test_sacch2_state_update(void) {
+    static const uint8_t m_data[5] = {0xA1U, 0xB2U, 0xC3U, 0xD4U, 0xE5U};
+    static Event_History_I histories[2];
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t trellis[32];
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    init_sacch2_state(&state, histories);
+    state.M = 1;
+    state.payload_miN = 0x1234U;
+    make_sacch2_trellis(trellis, 1U, 2U, 0x01U);
+    write_bits_msb(trellis, 8U, 2U, 0x01U);
+    write_bits_msb(trellis, 10U, 9U, 0x123U);
+
+    dsd_neo_nxdn_test_sacch2_state_update(&opts, &state, trellis, m_data, 0x2AU, 0x2AU);
+    rc |= expect_u8_at("sacch2-good-message-type", 0U, state.nxdn_dcr_sf_message_type, 0x01U);
+    rc |= expect_u8_at("sacch2-good-segcrc", 2U, state.nxdn_sacch_frame_segcrc[2], 0U);
+    rc |= expect_u8_at("sacch2-single-copy-cipher-msb", 0U, state.dmr_pdu_sf[0][0], 0U);
+    rc |= expect_u8_at("sacch2-single-copy-cipher-lsb", 1U, state.dmr_pdu_sf[0][1], 1U);
+    rc |= expect_int("sacch2-single-payload-seed-clear", (int)state.payload_miN, 0);
+    rc |= expect_int("sacch2-single-last-ran", (int)state.nxdn_last_ran, 7);
+    rc |= expect_int("sacch2-single-last-tg", state.nxdn_last_tg, 777);
+    rc |= expect_int("sacch2-single-last-rid", state.nxdn_last_rid, 777);
+    rc |= expect_str("sacch2-single-alias", state.generic_talker_alias[0], "JPN DCR");
+    rc |= expect_str("sacch2-single-event-alias", histories[0].Event_History_Items[0].alias, "JPN DCR; ");
+    rc |= expect_int("sacch2-single-cipher", state.nxdn_cipher_type, 1);
+    rc |= expect_int("sacch2-single-enc-lockout", state.dmr_encL, 1);
+
+    init_sacch2_state(&state, histories);
+    DSD_MEMSET(state.nxdn_sacch_frame_segment, 0, sizeof(state.nxdn_sacch_frame_segment));
+    DSD_MEMSET(state.nxdn_sacch_frame_segcrc, 0, sizeof(state.nxdn_sacch_frame_segcrc));
+    DSD_MEMSET(state.dmr_pdu_sf[0], 0xA5, sizeof(state.dmr_pdu_sf[0]));
+    make_sacch2_trellis(trellis, 0U, 0U, 0x02U);
+    write_bits_msb(trellis, 8U, 2U, 0x00U);
+    write_bits_msb(trellis, 10U, 9U, 0x055U);
+
+    dsd_neo_nxdn_test_sacch2_state_update(&opts, &state, trellis, m_data, 0x11U, 0x11U);
+    rc |= expect_u8_at("sacch2-complete-message-type", 0U, state.nxdn_dcr_sf_message_type, 0x02U);
+    rc |= expect_sacch_reset_to_ones(&state);
+    rc |= expect_u8_at("sacch2-complete-clears-pdu", 0U, state.dmr_pdu_sf[0][0], 0U);
+    rc |= expect_str("sacch2-complete-alias", state.generic_talker_alias[0], "JPN DCR");
+
+    init_sacch2_state(&state, histories);
+    state.M = 1;
+    state.payload_miN = 0x55U;
+    make_sacch2_trellis(trellis, 1U, 2U, 0x1EU);
+
+    dsd_neo_nxdn_test_sacch2_state_update(&opts, &state, trellis, m_data, 0x01U, 0x00U);
+    rc |= expect_u8_at("sacch2-bad-crc-message-type", 0U, state.nxdn_dcr_sf_message_type, 0xFFU);
+    rc |= expect_u8_at("sacch2-bad-crc-segcrc", 2U, state.nxdn_sacch_frame_segcrc[2], 1U);
+    rc |= expect_int("sacch2-bad-crc-seed-clear", (int)state.payload_miN, 0);
+    rc |= expect_int("sacch2-bad-crc-no-tg", state.nxdn_last_tg, 0);
+    rc |= expect_str("sacch2-bad-crc-no-alias", state.generic_talker_alias[0], "");
+    return rc;
+}
+
+static int
+test_cac_crc_failure_reset(void) {
+    static const uint8_t m_data[22] = {0};
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t trellis[176];
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(trellis, 0, sizeof(trellis));
+    write_bits_msb(trellis, 2U, 6U, 0x2DU);
+
+    state.synctype = DSD_SYNC_NXDN_POS;
+    state.lastsynctype = DSD_SYNC_NXDN_POS;
+    state.carrier = 1;
+    state.center = 5.0f;
+    state.jitter = 9;
+    state.min = -9.0f;
+    state.max = 9.0f;
+    state.dibit_buf_p = state.dibit_buf + 42;
+    state.symbolcnt = 99;
+    state.offset = 7;
+    state.data_header_blocks[0] = 7;
+    state.data_header_padding[0] = 3;
+    state.data_header_format[0] = 9;
+    state.data_header_valid[0] = 1;
+    state.payload_algid = 0xAAU;
+    state.payload_keyid = 0xBBBBU;
+    state.payload_mi = 0xCCCCU;
+    state.aes_ivR[0] = 0x5AU;
+
+    for (int i = 0; i < 10; i++) {
+        dsd_neo_nxdn_test_cac_state_update(&opts, &state, trellis, m_data, 1U);
+    }
+    rc |= expect_int("cac-before-threshold-carrier", state.carrier, 1);
+    rc |= expect_int("cac-before-threshold-format", state.data_header_format[0], 9);
+
+    dsd_neo_nxdn_test_cac_state_update(&opts, &state, trellis, m_data, 1U);
+    rc |= expect_int("cac-reset-synctype", state.synctype, DSD_SYNC_NONE);
+    rc |= expect_int("cac-reset-last-sync", state.lastsynctype, DSD_SYNC_NONE);
+    rc |= expect_int("cac-reset-carrier", state.carrier, 0);
+    rc |= expect_int("cac-reset-jitter", state.jitter, -1);
+    rc |= expect_int("cac-reset-symbolcnt", state.symbolcnt, 0);
+    rc |= expect_int("cac-reset-offset", state.offset, 0);
+    rc |= expect_int("cac-reset-dibit-pointer", (int)(state.dibit_buf_p - state.dibit_buf), 200);
+    rc |= expect_int("cac-reset-data-blocks", state.data_header_blocks[0], 1);
+    rc |= expect_int("cac-reset-data-padding", state.data_header_padding[0], 0);
+    rc |= expect_int("cac-reset-data-format", state.data_header_format[0], 0);
+    rc |= expect_int("cac-reset-data-valid", state.data_header_valid[0], 0);
+    rc |= expect_int("cac-reset-payload-algid", state.payload_algid, 0);
+    rc |= expect_int("cac-reset-payload-keyid", state.payload_keyid, 0);
+    rc |= expect_int("cac-reset-payload-mi", (int)state.payload_mi, 0);
+    rc |= expect_u8_at("cac-reset-aes-iv", 0U, state.aes_ivR[0], 0U);
+
+    dsd_neo_nxdn_test_cac_state_update(&opts, &state, trellis, m_data, 1U);
+    rc |= expect_int("cac-counter-cleared-after-reset", state.carrier, 0);
+    return rc;
+}
+
+static int
+test_pich_tch_dcr_csm_alias_state(void) {
+    static const uint8_t csm_digits[9] = {1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 9U};
+    static const uint8_t m_data[12] = {0};
+    static Event_History_I histories[2];
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t trellis[96];
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(histories, 0, sizeof(histories));
+    state.event_history_s = histories;
+    state.nxdn_dcr_sf_message_type = 0x01U;
+    make_csm_trellis(trellis, csm_digits);
+
+    dsd_neo_nxdn_test_pich_tch_state_update(&opts, &state, trellis, m_data, 0x123U, 0x123U, 0x08U);
+    rc |= expect_str("pich-csm-alias", state.generic_talker_alias[0], "CSM 123456789");
+    rc |= expect_str("pich-csm-event-alias", histories[0].Event_History_Items[0].alias, "CSM 123456789; ");
+
+    DSD_SNPRINTF(state.generic_talker_alias[0], sizeof(state.generic_talker_alias[0]), "%s", "KEEP");
+    DSD_SNPRINTF(histories[0].Event_History_Items[0].alias, sizeof(histories[0].Event_History_Items[0].alias), "%s",
+                 "KEEP; ");
+    state.nxdn_dcr_sf_message_type = 0x02U;
+
+    dsd_neo_nxdn_test_pich_tch_state_update(&opts, &state, trellis, m_data, 0x123U, 0x123U, 0x08U);
+    rc |= expect_str("pich-non-sb0-keeps-alias", state.generic_talker_alias[0], "KEEP");
+    rc |= expect_str("pich-non-sb0-keeps-event-alias", histories[0].Event_History_Items[0].alias, "KEEP; ");
+    return rc;
+}
+
+static int
+test_facch2_udch_crc_state_update(void) {
+    static const uint8_t m_data[26] = {0};
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t trellis[208];
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    make_facch2_trellis(trellis, 1U, 0x2AU, 0x10U);
+
+    dsd_neo_nxdn_test_facch2_udch_state_update(&opts, &state, trellis, m_data, 0x456U, 0x456U, 1U);
+    rc |= expect_int("facch2-good-ran", (int)state.nxdn_last_ran, 0x2A);
+    rc |= expect_int("facch2-good-part", state.nxdn_part_of_frame, 2);
+    rc |= expect_u8_at("facch2-good-format", 0U, state.data_header_format[0], 1U);
+    rc |= expect_u8_at("facch2-good-message-type", 0U, state.NxdnElementsContent.MessageType, 0x10U);
+    rc |= expect_u8_at("facch2-good-crc", 0U, state.NxdnElementsContent.VCallCrcIsGood, 1U);
+
+    state.nxdn_last_ran = 0x33U;
+    state.nxdn_part_of_frame = 7;
+    state.data_header_format[0] = 9U;
+    state.NxdnElementsContent.MessageType = 0x22U;
+    state.NxdnElementsContent.VCallCrcIsGood = 0U;
+
+    dsd_neo_nxdn_test_facch2_udch_state_update(&opts, &state, trellis, m_data, 0x456U, 0x457U, 1U);
+    rc |= expect_int("facch2-bad-keeps-ran", (int)state.nxdn_last_ran, 0x33);
+    rc |= expect_int("facch2-bad-part-reset", state.nxdn_part_of_frame, 0);
+    rc |= expect_u8_at("facch2-bad-keeps-format", 0U, state.data_header_format[0], 9U);
+    rc |= expect_u8_at("facch2-bad-skips-elements", 0U, state.NxdnElementsContent.MessageType, 0x22U);
+    return rc;
+}
+
+static int
+test_facch3_udch2_crc_state_update(void) {
+    uint8_t bits[160];
+    uint8_t bytes[24];
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(bytes, 0, sizeof(bytes));
+    for (size_t i = 0U; i < sizeof(bytes); i++) {
+        bytes[i] = (uint8_t)(0x30U + i);
+    }
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    make_facch3_bits(bits, 0x10U);
+
+    dsd_neo_nxdn_test_facch3_udch2_state_update(&opts, &state, bits, bytes, 0x123U, 0x123U, 0x456U, 0x456U, 1U);
+    rc |= expect_u8_at("facch3-good-format", 0U, state.data_header_format[0], 1U);
+    rc |= expect_u8_at("facch3-good-message-type", 0U, state.NxdnElementsContent.MessageType, 0x10U);
+    rc |= expect_u8_at("facch3-good-crc", 0U, state.NxdnElementsContent.VCallCrcIsGood, 1U);
+
+    state.data_header_format[0] = 9U;
+    state.NxdnElementsContent.MessageType = 0x22U;
+    state.NxdnElementsContent.VCallCrcIsGood = 0U;
+
+    dsd_neo_nxdn_test_facch3_udch2_state_update(&opts, &state, bits, bytes, 0x123U, 0x124U, 0x456U, 0x456U, 0U);
+    rc |= expect_u8_at("udch2-bad-keeps-format", 0U, state.data_header_format[0], 9U);
+    rc |= expect_u8_at("udch2-bad-skips-elements", 0U, state.NxdnElementsContent.MessageType, 0x22U);
+    rc |= expect_u8_at("udch2-bad-keeps-crc", 0U, state.NxdnElementsContent.VCallCrcIsGood, 0U);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+
+    rc |= test_depermute_matrices();
+    rc |= test_depuncture_12_5();
+    rc |= test_depuncture_16_9();
+    rc |= test_depuncture_12_group();
+    rc |= test_crc_helpers();
+    rc |= test_bit_window_and_state_helpers();
+    rc |= test_sacch_state_update();
+    rc |= test_sacch2_state_update();
+    rc |= test_cac_crc_failure_reset();
+    rc |= test_pich_tch_dcr_csm_alias_state();
+    rc |= test_facch2_udch_crc_state_update();
+    rc |= test_facch3_udch2_crc_state_update();
+
+    if (rc == 0) {
+        printf("NXDN_DEPERM_PRIMITIVES: OK\n");
+    }
+    return rc;
+}

--- a/tests/protocol/nxdn/test_nxdn_element_bounds.c
+++ b/tests/protocol/nxdn/test_nxdn_element_bounds.c
@@ -9,6 +9,7 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -26,9 +27,17 @@
 
 void NXDN_Elements_Content_decode(dsd_opts* opts, dsd_state* state, uint8_t CrcCorrect, const uint8_t* ElementsContent,
                                   size_t elements_bits);
+void NXDN_SACCH_Full_decode(dsd_opts* opts, dsd_state* state);
 
 static int g_alias_prop_calls;
 static uint8_t g_alias_prop_crc_ok;
+static int g_channel_to_frequency_calls;
+static int g_channel_to_frequency_quiet_calls;
+static uint16_t g_channel_to_frequency_channel;
+static uint16_t g_channel_to_frequency_quiet_channel;
+static uint16_t g_channel_to_frequency_channels[8];
+static uint16_t g_mapped_channel;
+static long int g_mapped_channel_freq;
 
 /*
  * Link stubs:
@@ -114,16 +123,22 @@ long int
 nxdn_channel_to_frequency(dsd_opts* opts, dsd_state* state, uint16_t channel) {
     (void)opts;
     (void)state;
-    (void)channel;
-    return 0;
+    g_channel_to_frequency_calls++;
+    g_channel_to_frequency_channel = channel;
+    if (g_channel_to_frequency_calls
+        <= (int)(sizeof(g_channel_to_frequency_channels) / sizeof(g_channel_to_frequency_channels[0]))) {
+        g_channel_to_frequency_channels[g_channel_to_frequency_calls - 1] = channel;
+    }
+    return (channel == g_mapped_channel) ? g_mapped_channel_freq : 0;
 }
 
 long int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 nxdn_channel_to_frequency_quiet(dsd_state* state, uint16_t channel) {
     (void)state;
-    (void)channel;
-    return 0;
+    g_channel_to_frequency_quiet_calls++;
+    g_channel_to_frequency_quiet_channel = channel;
+    return (channel == g_mapped_channel) ? g_mapped_channel_freq : 0;
 }
 
 void
@@ -180,6 +195,13 @@ static uint8_t g_aes_iv[16];
 static uint8_t g_aes_key[32];
 static int g_aes_type;
 static int g_aes_blocks;
+static int g_tune_cc_calls;
+static long int g_tune_cc_freq;
+static int g_tune_cc_ted_sps;
+static int g_tune_freq_calls;
+static long int g_tune_freq_freq;
+static int g_tune_freq_ted_sps;
+static long int g_current_rigctl_freq;
 
 static void
 reset_datacall_capture(void) {
@@ -213,6 +235,24 @@ reset_crypto_stub_capture(void) {
     DSD_MEMSET(g_aes_key, 0, sizeof(g_aes_key));
     g_aes_type = 0;
     g_aes_blocks = 0;
+}
+
+static void
+reset_assignment_capture(void) {
+    g_tune_cc_calls = 0;
+    g_tune_cc_freq = 0;
+    g_tune_cc_ted_sps = -1;
+    g_tune_freq_calls = 0;
+    g_tune_freq_freq = 0;
+    g_tune_freq_ted_sps = -1;
+    g_current_rigctl_freq = 0;
+    g_channel_to_frequency_calls = 0;
+    g_channel_to_frequency_quiet_calls = 0;
+    g_channel_to_frequency_channel = 0;
+    g_channel_to_frequency_quiet_channel = 0;
+    DSD_MEMSET(g_channel_to_frequency_channels, 0, sizeof(g_channel_to_frequency_channels));
+    g_mapped_channel = 0;
+    g_mapped_channel_freq = 0;
 }
 
 void
@@ -275,7 +315,7 @@ long int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_rigctl_query_hook_get_current_freq_hz(const dsd_opts* opts) {
     (void)opts;
-    return 0;
+    return g_current_rigctl_freq;
 }
 
 uint64_t
@@ -289,18 +329,22 @@ dsd_trunk_tune_result
 dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     (void)opts;
     (void)state;
-    (void)freq;
-    (void)ted_sps;
+    g_tune_cc_calls++;
+    g_tune_cc_freq = freq;
+    g_tune_cc_ted_sps = ted_sps;
     return DSD_TRUNK_TUNE_RESULT_OK;
 }
 
 dsd_trunk_tune_result
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
-    (void)opts;
     (void)state;
-    (void)freq;
-    (void)ted_sps;
+    g_tune_freq_calls++;
+    g_tune_freq_freq = freq;
+    g_tune_freq_ted_sps = ted_sps;
+    if (opts != NULL) {
+        opts->p25_is_tuned = 1;
+    }
     return DSD_TRUNK_TUNE_RESULT_OK;
 }
 
@@ -423,6 +467,38 @@ expect_contains(const char* tag, const char* got, const char* want) {
 }
 
 static int
+all_sacch_segments_are(uint8_t value, const dsd_state* state) {
+    for (size_t frame = 0U; frame < 4U; frame++) {
+        if (state->nxdn_sacch_frame_segcrc[frame] != value) {
+            return 0;
+        }
+        for (size_t bit = 0U; bit < 18U; bit++) {
+            if (state->nxdn_sacch_frame_segment[frame][bit] != value) {
+                return 0;
+            }
+        }
+    }
+    return 1;
+}
+
+static int
+active_channels_are_zero(const dsd_state* state) {
+    for (size_t i = 0U; i < 31U; i++) {
+        if (state->active_channel[i][0] != '\0') {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static void
+load_sacch_segments_from_bits(dsd_state* state, const uint8_t* bits) {
+    for (size_t frame = 0U; frame < 4U; frame++) {
+        DSD_MEMCPY(state->nxdn_sacch_frame_segment[frame], &bits[frame * 18U], 18U);
+    }
+}
+
+static int
 read_capture_file(const char* path, char* out, size_t out_size) {
     if (path == NULL || out == NULL || out_size == 0U) {
         return 1;
@@ -436,6 +512,153 @@ read_capture_file(const char* path, char* out, size_t out_size) {
     out[nread] = '\0';
     (void)fclose(fp);
     return 0;
+}
+
+static int
+test_decode_guards_and_unknown_dispatch(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    uint8_t bits[16];
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
+        free(state);
+        free(opts);
+        return 1;
+    }
+    DSD_MEMSET(bits, 0, sizeof(bits));
+
+    state->NxdnElementsContent.MessageType = 0x55U;
+    state->NxdnElementsContent.VCallCrcIsGood = 1U;
+    NXDN_Elements_Content_decode(NULL, state, 0U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, NULL, 0U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, 0U, NULL, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, 0U, bits, 7U);
+
+    int rc = 0;
+    rc |= expect_int("decode-guards-type-preserved", state->NxdnElementsContent.MessageType, 0x55);
+    rc |= expect_int("decode-guards-crc-preserved", state->NxdnElementsContent.VCallCrcIsGood, 1);
+
+    set_message_type(bits, 0x2AU);
+    state->data_header_valid[0] = 1U;
+    NXDN_Elements_Content_decode(opts, state, 0U, bits, sizeof(bits));
+    rc |= expect_int("unknown-type-recorded", state->NxdnElementsContent.MessageType, 0x2A);
+    rc |= expect_int("unknown-crc-recorded", state->NxdnElementsContent.VCallCrcIsGood, 0);
+    rc |= expect_int("unknown-keeps-data-state", state->data_header_valid[0], 1);
+
+    free(state);
+    free(opts);
+    return rc;
+}
+
+static int
+test_sacch_full_decode_crc_gate_and_reset(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    uint8_t bits[72];
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
+        free(state);
+        free(opts);
+        return 1;
+    }
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    reset_datacall_capture();
+
+    set_message_type(bits, 0x17U);
+    bits[8] = 1U;
+    bits[9] = 1U;
+    write_bits_u64(bits, 10U, 3U, 6U);
+    write_ascii_bits(bits, 16U, "NODE");
+    load_sacch_segments_from_bits(state, bits);
+    state->nxdn_sacch_frame_segcrc[0] = 0U;
+    state->nxdn_sacch_frame_segcrc[1] = 1U;
+    state->nxdn_sacch_frame_segcrc[2] = 0U;
+    state->nxdn_sacch_frame_segcrc[3] = 0U;
+
+    NXDN_SACCH_Full_decode(opts, state);
+
+    int rc = 0;
+    rc |= expect_string("sacch-bad-crc-no-event", g_datacall_event, "");
+    rc |= expect_int("sacch-bad-crc-reset", all_sacch_segments_are(1U, state), 1);
+
+    load_sacch_segments_from_bits(state, bits);
+    DSD_MEMSET(state->nxdn_sacch_frame_segcrc, 0, sizeof(state->nxdn_sacch_frame_segcrc));
+    reset_datacall_capture();
+
+    NXDN_SACCH_Full_decode(opts, state);
+
+    rc |= expect_string("sacch-good-crc-event", g_datacall_event, "NXDN Digital Station ID: NODE");
+    rc |= expect_int("sacch-good-crc-reset", all_sacch_segments_are(1U, state), 1);
+    rc |= expect_int("sacch-recorded-type", state->NxdnElementsContent.MessageType, 0x17);
+
+    free(state);
+    free(opts);
+    return rc;
+}
+
+static int
+test_disc_trunk_return_clears_call_state(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    uint8_t bits[96];
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
+        free(state);
+        free(opts);
+        return 1;
+    }
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    set_message_type(bits, 0x11U);
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    opts->p25_is_tuned = 1;
+    state->p25_cc_freq = 851012500L;
+    state->nxdn_last_rid = 0x1234;
+    state->nxdn_last_tg = 0x4567;
+    state->nxdn_cipher_type = 2;
+    state->data_header_valid[0] = 1;
+    state->data_header_blocks[0] = 7;
+    state->payload_algid = 3;
+    state->payload_keyid = 44;
+    state->payload_mi = 0x1122334455667788ULL;
+    state->dmr_lrrp_source[0] = 99;
+    state->dmr_lrrp_target[0] = 100;
+    DSD_SNPRINTF(state->call_string[0], sizeof(state->call_string[0]), "%s", "active");
+    DSD_SNPRINTF(state->nxdn_call_type, sizeof(state->nxdn_call_type), "%s", "Group");
+    DSD_SNPRINTF(state->active_channel[3], sizeof(state->active_channel[3]), "%s", "busy");
+    DSD_MEMSET(state->nxdn_sacch_frame_segment, 0, sizeof(state->nxdn_sacch_frame_segment));
+    DSD_MEMSET(state->nxdn_sacch_frame_segcrc, 0, sizeof(state->nxdn_sacch_frame_segcrc));
+    g_alias_prop_calls = 0;
+    g_tune_cc_calls = 0;
+    g_tune_cc_freq = 0;
+    g_tune_cc_ted_sps = -1;
+
+    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+
+    int rc = 0;
+    rc |= expect_int("disc-tune-cc-called", g_tune_cc_calls, 1);
+    rc |= expect_int("disc-tune-cc-freq", (int)g_tune_cc_freq, (int)851012500L);
+    rc |= expect_int("disc-tune-cc-sps", g_tune_cc_ted_sps, 0);
+    rc |= expect_int("disc-trunk-cleared", opts->trunk_is_tuned, 0);
+    rc |= expect_int("disc-p25-cleared", opts->p25_is_tuned, 0);
+    rc |= expect_int("disc-rid-reset", state->nxdn_last_rid, 0);
+    rc |= expect_int("disc-tg-reset", state->nxdn_last_tg, 0);
+    rc |= expect_int("disc-cipher-reset", state->nxdn_cipher_type, 0);
+    rc |= expect_int("disc-call-string-cleared", state->call_string[0][0], '\0');
+    rc |= expect_int("disc-call-type-cleared", state->nxdn_call_type[0], '\0');
+    rc |= expect_int("disc-data-valid-reset", state->data_header_valid[0], 0);
+    rc |= expect_int("disc-data-blocks-reset", state->data_header_blocks[0], 1);
+    rc |= expect_int("disc-payload-alg-reset", state->payload_algid, 0);
+    rc |= expect_int("disc-payload-key-reset", state->payload_keyid, 0);
+    rc |= expect_u64("disc-payload-mi-reset", (uint64_t)state->payload_mi, 0ULL);
+    rc |= expect_int("disc-lrrp-src-reset", state->dmr_lrrp_source[0], 0);
+    rc |= expect_int("disc-lrrp-tgt-reset", state->dmr_lrrp_target[0], 0);
+    rc |= expect_int("disc-sacch-reset", all_sacch_segments_are(1U, state), 1);
+    rc |= expect_int("disc-active-channels-reset", active_channels_are_zero(state), 1);
+
+    free(state);
+    free(opts);
+    return rc;
 }
 
 static int
@@ -610,6 +833,177 @@ test_dst_id_info_complete_event(void) {
     rc |= expect_int("dst-id-src", (int)g_datacall_src, 65520);
     rc |= expect_int("dst-id-dst", (int)g_datacall_dst, 0);
     rc |= expect_int("dst-id-slot", (int)g_datacall_slot, 0);
+    free(state);
+    free(opts);
+    return rc;
+}
+
+static int
+test_srv_info_anchors_control_channel_from_rigctl(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    uint8_t bits[96];
+    const uint32_t location_id = (1U << 12U) | 0x234U;
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
+        free(state);
+        free(opts);
+        return 1;
+    }
+    DSD_MEMSET(bits, 0, sizeof(bits));
+
+    set_message_type(bits, 0x19U);
+    write_bits_u64(bits, 8U, location_id, 24U);
+    write_bits_u64(bits, 32U, 0x1200U, 16U);
+    write_bits_u64(bits, 48U, 0x345678U, 24U);
+    opts->trunk_enable = 1;
+    opts->use_rigctl = 1;
+    state->p25_cc_freq = 851012500L;
+    state->trunk_cc_freq = 851012500L;
+    state->nxdn_last_rid = 0x1111U;
+    state->nxdn_last_tg = 0x2222U;
+    state->nxdn_grant_chan = 77U;
+    DSD_SNPRINTF(state->active_channel[3], sizeof(state->active_channel[3]), "%s", "stale");
+    g_current_rigctl_freq = 855262500L;
+
+    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+
+    int rc = 0;
+    rc |= expect_int("srv-info-message-type", state->NxdnElementsContent.MessageType, 0x19);
+    rc |= expect_int("srv-info-last-rid-reset", state->nxdn_last_rid, 0);
+    rc |= expect_int("srv-info-last-tg-reset", state->nxdn_last_tg, 0);
+    rc |= expect_int("srv-info-ran", state->nxdn_last_ran, 0x34);
+    rc |= expect_int("srv-info-site-code", state->nxdn_location_site_code, 0x234);
+    rc |= expect_int("srv-info-sys-code", state->nxdn_location_sys_code, 1);
+    rc |= expect_string("srv-info-category", state->nxdn_location_category, "Global");
+    rc |= expect_int("srv-info-cc-freq", (int)state->p25_cc_freq, (int)855262500L);
+    rc |= expect_int("srv-info-trunk-cc-freq", (int)state->trunk_cc_freq, (int)855262500L);
+    rc |= expect_int("srv-info-active-channels-reset", active_channels_are_zero(state), 1);
+    rc |= expect_int("srv-info-grant-chan-reset", state->nxdn_grant_chan, 0);
+
+    g_current_rigctl_freq = 0;
+    free(state);
+    free(opts);
+    return rc;
+}
+
+static int
+test_cch_dfa_maps_secondary_channels_and_seeds_control_frequency(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    uint8_t bits[128];
+    const uint32_t location_id = (2U << 12U) | 0x021U;
+    const uint16_t ofn1 = 0x1221U;
+    const uint16_t ifn1 = 0x2332U;
+    const uint16_t ofn2 = 0x3443U;
+    const uint16_t ifn2 = 0x4554U;
+    const long int cc_freq = 852262500L;
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
+        free(state);
+        free(opts);
+        return 1;
+    }
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    reset_assignment_capture();
+
+    state->nxdn_rcn = 1;
+    g_mapped_channel = ofn1;
+    g_mapped_channel_freq = cc_freq;
+
+    set_message_type(bits, 0x1AU);
+    write_bits_u64(bits, 8U, location_id, 24U);
+    write_bits_u64(bits, 32U, 0x13U, 6U);
+    write_bits_u64(bits, 38U, 1U, 2U);
+    write_bits_u64(bits, 40U, ofn1, 16U);
+    write_bits_u64(bits, 56U, ifn1, 16U);
+    write_bits_u64(bits, 80U, ofn2, 16U);
+    write_bits_u64(bits, 96U, ifn2, 16U);
+
+    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+
+    int rc = 0;
+    rc |= expect_int("cch-dfa-message-type", state->NxdnElementsContent.MessageType, 0x1A);
+    rc |= expect_int("cch-dfa-ran", state->nxdn_last_ran, 0x21);
+    rc |= expect_int("cch-dfa-site-code", state->nxdn_location_site_code, 0x21);
+    rc |= expect_int("cch-dfa-sys-code", state->nxdn_location_sys_code, 2);
+    rc |= expect_string("cch-dfa-category", state->nxdn_location_category, "Global");
+    rc |= expect_int("cch-dfa-frequency-calls", g_channel_to_frequency_calls, 4);
+    rc |= expect_int("cch-dfa-call-ofn2", g_channel_to_frequency_channels[0], ofn2);
+    rc |= expect_int("cch-dfa-call-ifn2", g_channel_to_frequency_channels[1], ifn2);
+    rc |= expect_int("cch-dfa-call-ofn1", g_channel_to_frequency_channels[2], ofn1);
+    rc |= expect_int("cch-dfa-call-ifn1", g_channel_to_frequency_channels[3], ifn1);
+    rc |= expect_int("cch-dfa-last-channel", g_channel_to_frequency_channel, ifn1);
+    rc |= expect_int("cch-dfa-lcn-freq", (int)state->trunk_lcn_freq[0], (int)cc_freq);
+    rc |= expect_int("cch-dfa-p25-cc", (int)state->p25_cc_freq, (int)cc_freq);
+    rc |= expect_int("cch-dfa-trunk-cc", (int)state->trunk_cc_freq, (int)cc_freq);
+    rc |= expect_int("cch-dfa-lcn-count", state->lcn_freq_count, 1);
+
+    free(state);
+    free(opts);
+    return rc;
+}
+
+static int
+test_adj_site_skips_disabled_entries_for_channel_and_dfa_versions(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    uint8_t ch_bits[128];
+    uint8_t dfa_bits[112];
+    const uint32_t site1 = (3U << 12U) | 0x011U;
+    const uint32_t site2 = (4U << 12U) | 0x022U;
+    const uint32_t site3 = (5U << 12U) | 0x033U;
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
+        free(state);
+        free(opts);
+        return 1;
+    }
+    DSD_MEMSET(ch_bits, 0, sizeof(ch_bits));
+    DSD_MEMSET(dfa_bits, 0, sizeof(dfa_bits));
+    reset_assignment_capture();
+
+    set_message_type(ch_bits, 0x1BU);
+    write_bits_u64(ch_bits, 8U, site1, 24U);
+    write_bits_u64(ch_bits, 32U, 0x10U, 6U);
+    write_bits_u64(ch_bits, 38U, 0x111U, 10U);
+    write_bits_u64(ch_bits, 48U, site2, 24U);
+    write_bits_u64(ch_bits, 72U, 0x12U, 6U);
+    write_bits_u64(ch_bits, 78U, 0x222U, 10U);
+    write_bits_u64(ch_bits, 88U, site3, 24U);
+    write_bits_u64(ch_bits, 112U, 0x03U, 6U);
+    write_bits_u64(ch_bits, 118U, 0x333U, 10U);
+
+    NXDN_Elements_Content_decode(opts, state, 1U, ch_bits, sizeof(ch_bits));
+
+    int rc = 0;
+    rc |= expect_int("adj-site-ch-calls", g_channel_to_frequency_calls, 2);
+    rc |= expect_int("adj-site-ch-first", g_channel_to_frequency_channels[0], 0x222);
+    rc |= expect_int("adj-site-ch-second", g_channel_to_frequency_channels[1], 0x333);
+    rc |= expect_int("adj-site-ch-last", g_channel_to_frequency_channel, 0x333);
+    rc |= expect_int("adj-site-current-site-preserved", state->nxdn_location_site_code, 0);
+    rc |= expect_int("adj-site-current-sys-preserved", state->nxdn_location_sys_code, 0);
+
+    reset_assignment_capture();
+    state->nxdn_rcn = 1;
+    set_message_type(dfa_bits, 0x1BU);
+    write_bits_u64(dfa_bits, 8U, site1, 24U);
+    write_bits_u64(dfa_bits, 32U, 0x20U, 6U);
+    write_bits_u64(dfa_bits, 38U, 2U, 2U);
+    write_bits_u64(dfa_bits, 40U, 0x1771U, 16U);
+    write_bits_u64(dfa_bits, 56U, site2, 24U);
+    write_bits_u64(dfa_bits, 80U, 0x04U, 6U);
+    write_bits_u64(dfa_bits, 86U, 1U, 2U);
+    write_bits_u64(dfa_bits, 88U, 0x2882U, 16U);
+
+    NXDN_Elements_Content_decode(opts, state, 1U, dfa_bits, sizeof(dfa_bits));
+
+    rc |= expect_int("adj-site-dfa-calls", g_channel_to_frequency_calls, 1);
+    rc |= expect_int("adj-site-dfa-channel", g_channel_to_frequency_channel, 0x2882);
+    rc |= expect_int("adj-site-dfa-first", g_channel_to_frequency_channels[0], 0x2882);
+    rc |= expect_int("adj-site-dfa-current-site-preserved", state->nxdn_location_site_code, 0);
+    rc |= expect_int("adj-site-dfa-current-sys-preserved", state->nxdn_location_sys_code, 0);
+
     free(state);
     free(opts);
     return rc;
@@ -810,6 +1204,22 @@ write_vcall_fields(uint8_t* bits, uint8_t message_type, uint8_t cc_option, uint8
 }
 
 static void
+write_assignment_fields(uint8_t* bits, uint8_t message_type, uint8_t cc_option, uint8_t call_type,
+                        uint8_t voice_call_option, uint16_t source, uint16_t destination, uint16_t channel,
+                        uint16_t ofn) {
+    set_message_type(bits, message_type);
+    write_bits_u64(bits, 8U, cc_option, 8U);
+    write_bits_u64(bits, 16U, call_type, 3U);
+    write_bits_u64(bits, 19U, voice_call_option, 5U);
+    write_bits_u64(bits, 24U, source, 16U);
+    write_bits_u64(bits, 40U, destination, 16U);
+    write_bits_u64(bits, 62U, channel, 10U);
+    if (ofn != 0U) {
+        write_bits_u64(bits, 64U, ofn, 16U);
+    }
+}
+
+static void
 write_vcall_iv_fields(uint8_t* bits, uint64_t iv) {
     set_message_type(bits, 0x03U);
     write_bits_u64(bits, 8U, iv, 64U);
@@ -979,10 +1389,132 @@ test_arib_tx_release_uses_shifted_fields_and_clears_call(void) {
     return rc;
 }
 
+static int
+test_assignment_group_grant_anchors_tunes_and_loads_scrambler(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    uint8_t bits[96];
+    const uint16_t channel = 0x12AU;
+    const long int grant_freq = 855512500L;
+    const long int control_freq = 851012500L;
+    const uint16_t source = 0x0123U;
+    const uint16_t target = 0x0456U;
+    const unsigned long long scrambler_key = 12345ULL;
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
+        free(state);
+        free(opts);
+        return 1;
+    }
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    reset_assignment_capture();
+
+    opts->p25_trunk = 1;
+    opts->trunk_tune_group_calls = 1;
+    opts->use_rigctl = 1;
+    state->lastsynctype = DSD_SYNC_NXDN_POS;
+    state->M = 1;
+    state->rkey_array[target] = scrambler_key;
+    g_current_rigctl_freq = control_freq;
+    g_mapped_channel = channel;
+    g_mapped_channel_freq = grant_freq;
+
+    write_assignment_fields(bits, 0x04U, 0x80U, 1U, 0U, source, target, channel, 0U);
+    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+
+    int rc = 0;
+    rc |= expect_int("assignment-group-quiet-channel", g_channel_to_frequency_quiet_channel, channel);
+    rc |= expect_int("assignment-group-channel", g_channel_to_frequency_channel, channel);
+    rc |= expect_int("assignment-group-tune-calls", g_tune_freq_calls, 1);
+    rc |= expect_int("assignment-group-tune-freq", (int)g_tune_freq_freq, (int)grant_freq);
+    rc |= expect_int("assignment-group-tune-sps", g_tune_freq_ted_sps, 0);
+    rc |= expect_int("assignment-group-cc-freq", (int)state->p25_cc_freq, (int)control_freq);
+    rc |= expect_int("assignment-group-trunk-cc-freq", (int)state->trunk_cc_freq, (int)control_freq);
+    rc |= expect_int("assignment-group-grant-channel", state->nxdn_grant_chan, channel);
+    rc |= expect_int("assignment-group-grant-freq", (int)state->nxdn_grant_freq, (int)grant_freq);
+    rc |= expect_contains("assignment-group-active", state->active_channel[0], "Active Ch: 298");
+    rc |= expect_contains("assignment-group-active-tg", state->active_channel[0], "TG: 1110 SRC: 291");
+    rc |= expect_string("assignment-group-call-type", state->nxdn_call_type, "Group Call");
+    rc |= expect_string("assignment-group-call-string", state->call_string[0], "Group Call Emergency");
+    rc |= expect_u64("assignment-group-key", (uint64_t)state->R, (uint64_t)scrambler_key);
+    rc |= expect_u64("assignment-group-mi", (uint64_t)state->payload_miN, (uint64_t)scrambler_key);
+    rc |= expect_int("assignment-group-m-cipher", state->nxdn_cipher_type, 1);
+    rc |= expect_int("assignment-group-sync-reset", state->lastsynctype, DSD_SYNC_NONE);
+    rc |= expect_int("assignment-group-sacch-reset", all_sacch_segments_are(1U, state), 1);
+
+    free(state);
+    free(opts);
+    return rc;
+}
+
+static int
+test_assignment_data_gate_and_duplicate_release(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    uint8_t data_bits[96];
+    uint8_t dup_bits[96];
+    const uint16_t data_channel = 0x0088U;
+    const uint16_t voice_channel = 0x0055U;
+    const long int data_freq = 856112500L;
+    const long int voice_freq = 857112500L;
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
+        free(state);
+        free(opts);
+        return 1;
+    }
+    DSD_MEMSET(data_bits, 0, sizeof(data_bits));
+    DSD_MEMSET(dup_bits, 0, sizeof(dup_bits));
+    reset_assignment_capture();
+
+    opts->p25_trunk = 1;
+    opts->trunk_tune_group_calls = 1;
+    opts->trunk_tune_data_calls = 0;
+    state->p25_cc_freq = 851012500L;
+    state->trunk_cc_freq = 851012500L;
+    g_mapped_channel = data_channel;
+    g_mapped_channel_freq = data_freq;
+
+    write_assignment_fields(data_bits, 0x0DU, 0x00U, 1U, 3U, 0x0201U, 0x0302U, data_channel, 0U);
+    NXDN_Elements_Content_decode(opts, state, 1U, data_bits, sizeof(data_bits));
+
+    int rc = 0;
+    rc |= expect_int("assignment-data-grant-channel", state->nxdn_grant_chan, data_channel);
+    rc |= expect_int("assignment-data-grant-freq", (int)state->nxdn_grant_freq, (int)data_freq);
+    rc |= expect_int("assignment-data-no-tune", g_tune_freq_calls, 0);
+    rc |= expect_contains("assignment-data-active", state->active_channel[0], "TG: 770 SRC: 513");
+
+    reset_assignment_capture();
+    opts->trunk_tune_data_calls = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_hangtime = 0;
+    state->last_vc_sync_time = 0;
+    state->lastsynctype = DSD_SYNC_NXDN_NEG;
+    g_mapped_channel = voice_channel;
+    g_mapped_channel_freq = voice_freq;
+
+    write_assignment_fields(dup_bits, 0x05U, 0x00U, 1U, 2U, 0x0401U, 0x0502U, voice_channel, 0U);
+    NXDN_Elements_Content_decode(opts, state, 1U, dup_bits, sizeof(dup_bits));
+
+    rc |= expect_int("assignment-dup-channel", state->nxdn_grant_chan, voice_channel);
+    rc |= expect_int("assignment-dup-tune-calls", g_tune_freq_calls, 1);
+    rc |= expect_int("assignment-dup-tune-freq", (int)g_tune_freq_freq, (int)voice_freq);
+    rc |= expect_int("assignment-dup-sync-reset", state->lastsynctype, DSD_SYNC_NONE);
+    rc |= expect_string("assignment-dup-call-string", state->call_string[0], "Group Call");
+    rc |= expect_contains("assignment-dup-active", state->active_channel[0], "TG: 1282 SRC: 1025");
+
+    free(state);
+    free(opts);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
 
+    rc |= test_decode_guards_and_unknown_dispatch();
+    rc |= test_sacch_full_decode_crc_gate_and_reset();
+    rc |= test_disc_trunk_return_clears_call_state();
     rc |= test_sdcall_header_short_is_ignored();
     rc |= test_sdcall_iv_short_type_c_is_ignored();
     rc |= test_sdcall_iv_type_d_min_length_is_accepted();
@@ -990,12 +1522,17 @@ main(void) {
     rc |= test_short_dcall_data_is_rejected(0x39U, "sdcall-data-short");
     rc |= test_short_dcall_data_is_rejected(0x0BU, "dcall-data-short");
     rc |= test_dst_id_info_complete_event();
+    rc |= test_srv_info_anchors_control_channel_from_rigctl();
+    rc |= test_cch_dfa_maps_secondary_channels_and_seeds_control_frequency();
+    rc |= test_adj_site_skips_disabled_entries_for_channel_and_dfa_versions();
     rc |= test_sdcall_des_data_decrypts_and_resets();
     rc |= test_dcall_aes_data_decrypts_with_manual_key_and_iv();
     rc |= test_arib_vcall_uses_shifted_fields();
     rc |= test_vcall_des_keyloader_and_iv_signal();
     rc |= test_vcall_aes_keyloader_and_iv_signal();
     rc |= test_arib_tx_release_uses_shifted_fields_and_clears_call();
+    rc |= test_assignment_group_grant_anchors_tunes_and_loads_scrambler();
+    rc |= test_assignment_data_gate_and_duplicate_release();
 
     if (rc == 0) {
         printf("NXDN_ELEMENT_BOUNDS: OK\n");

--- a/tests/protocol/nxdn/test_nxdn_element_bounds.c
+++ b/tests/protocol/nxdn/test_nxdn_element_bounds.c
@@ -1261,6 +1261,38 @@ test_arib_vcall_uses_shifted_fields(void) {
 }
 
 static int
+test_bad_crc_encrypted_vcall_records_metadata(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    uint8_t bits[96];
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
+        free(state);
+        free(opts);
+        return 1;
+    }
+    DSD_MEMSET(bits, 0, sizeof(bits));
+
+    write_vcall_fields(bits, 0x01U, 0x20U, 1U, 2U, 0x1357U, 0x2468U, 3U, 0x09U);
+    NXDN_Elements_Content_decode(opts, state, 0U, bits, sizeof(bits));
+
+    int rc = 0;
+    rc |= expect_int("bad-crc-vcall-type", state->NxdnElementsContent.MessageType, 0x01);
+    rc |= expect_int("bad-crc-vcall-crc", state->NxdnElementsContent.VCallCrcIsGood, 0);
+    rc |= expect_int("bad-crc-vcall-src", state->NxdnElementsContent.SourceUnitID, 0x1357);
+    rc |= expect_int("bad-crc-vcall-dst", state->NxdnElementsContent.DestinationID, 0x2468);
+    rc |= expect_int("bad-crc-vcall-cipher", state->NxdnElementsContent.CipherType, 3);
+    rc |= expect_int("bad-crc-vcall-key", state->NxdnElementsContent.KeyID, 0x09);
+    rc |= expect_int("bad-crc-vcall-last-rid", state->nxdn_last_rid, 0x1357);
+    rc |= expect_int("bad-crc-vcall-last-tg", state->nxdn_last_tg, 0x2468);
+    rc |= expect_int("bad-crc-vcall-cipher-state", state->nxdn_cipher_type, 3);
+    rc |= expect_int("bad-crc-vcall-lockout", state->dmr_encL, 1);
+    free(state);
+    free(opts);
+    return rc;
+}
+
+static int
 test_vcall_des_keyloader_and_iv_signal(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
@@ -1528,6 +1560,7 @@ main(void) {
     rc |= test_sdcall_des_data_decrypts_and_resets();
     rc |= test_dcall_aes_data_decrypts_with_manual_key_and_iv();
     rc |= test_arib_vcall_uses_shifted_fields();
+    rc |= test_bad_crc_encrypted_vcall_records_metadata();
     rc |= test_vcall_des_keyloader_and_iv_signal();
     rc |= test_vcall_aes_keyloader_and_iv_signal();
     rc |= test_arib_tx_release_uses_shifted_fields_and_clears_call();

--- a/tests/protocol/nxdn/test_nxdn_frame_routing.c
+++ b/tests/protocol/nxdn/test_nxdn_frame_routing.c
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/file_io.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/platform/timing.h>
+#include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <dsd-neo/protocol/nxdn/nxdn.h>
+#include <dsd-neo/protocol/nxdn/nxdn_deperm.h>
+#include <dsd-neo/protocol/nxdn/nxdn_lfsr.h>
+#include <dsd-neo/protocol/nxdn/nxdn_voice.h>
+#include <stdint.h>
+#include <stdio.h>
+
+static dsd_opts g_opts;
+static dsd_state g_state;
+static int g_lfsr_calls;
+static int g_sacch_calls;
+static int g_scch_calls;
+static int g_cac_calls;
+static int g_facch_calls;
+static int g_facch_part_mask;
+static int g_facch2_calls;
+static int g_udch_calls;
+static int g_facch3_calls;
+static int g_udch2_calls;
+static int g_sacch2_calls;
+static int g_pich_tch_calls;
+static int g_voice_calls;
+static int g_last_voice;
+static uint8_t g_last_sacch_bit;
+static uint8_t g_last_sacch_reliab;
+static uint8_t g_last_facch_bit;
+static uint8_t g_last_facch_reliab;
+static uint8_t g_last_cac_bit;
+static uint8_t g_last_cac_reliab;
+
+static int
+expect_int(const char* label, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u64(const char* label, unsigned long long got, unsigned long long want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %llu want %llu\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static void
+reset_state(void) {
+    DSD_MEMSET(&g_opts, 0, sizeof(g_opts));
+    DSD_MEMSET(&g_state, 0, sizeof(g_state));
+    g_lfsr_calls = 0;
+    g_sacch_calls = 0;
+    g_scch_calls = 0;
+    g_cac_calls = 0;
+    g_facch_calls = 0;
+    g_facch_part_mask = 0;
+    g_facch2_calls = 0;
+    g_udch_calls = 0;
+    g_facch3_calls = 0;
+    g_udch2_calls = 0;
+    g_sacch2_calls = 0;
+    g_pich_tch_calls = 0;
+    g_voice_calls = 0;
+    g_last_voice = 0;
+    g_last_sacch_bit = 0;
+    g_last_sacch_reliab = 0;
+    g_last_facch_bit = 0;
+    g_last_facch_reliab = 0;
+    g_last_cac_bit = 0;
+    g_last_cac_reliab = 0;
+}
+
+static void
+fill_soft_bits(uint8_t bits[364], uint8_t reliab[364]) {
+    for (size_t i = 0U; i < 364U; i++) {
+        bits[i] = (uint8_t)(((i * 5U) + 1U) & 1U);
+        reliab[i] = (uint8_t)(250U - (i % 200U));
+    }
+}
+
+void
+LFSRN(const char* buffer_in, char* buffer_out, dsd_state* state) {
+    (void)buffer_in;
+    (void)buffer_out;
+    g_lfsr_calls++;
+    state->payload_miN++;
+}
+
+void
+nxdn_descramble_with_seed(uint8_t dibits[], int len, uint16_t seed) {
+    (void)dibits;
+    (void)len;
+    (void)seed;
+}
+
+uint64_t
+ConvertBitIntoBytes(const uint8_t* buffer_in, uint32_t bit_length) {
+    uint64_t out = 0;
+    for (uint32_t i = 0U; i < bit_length; i++) {
+        out = (out << 1U) | (uint64_t)(buffer_in[i] & 1U);
+    }
+    return out;
+}
+
+int
+getDibitWithReliability(dsd_opts* opts, dsd_state* state, uint8_t* out_reliability) {
+    (void)opts;
+    (void)state;
+    if (out_reliability != NULL) {
+        *out_reliability = 255U;
+    }
+    return 0;
+}
+
+uint64_t
+dsd_time_monotonic_ns(void) {
+    return 42000000000ULL;
+}
+
+void
+printFrameSync(const dsd_opts* opts, const dsd_state* state, const char* frametype, int offset,
+               const char* modulation) {
+    (void)opts;
+    (void)state;
+    (void)frametype;
+    (void)offset;
+    (void)modulation;
+}
+
+void
+openMbeOutFile(dsd_opts* opts, dsd_state* state) {
+    (void)state;
+    opts->mbe_out_f = stdout;
+}
+
+void
+closeMbeOutFile(dsd_opts* opts, dsd_state* state) {
+    (void)state;
+    opts->mbe_out_f = NULL;
+}
+
+void
+nxdn_deperm_sacch_soft(dsd_opts* opts, dsd_state* state, uint8_t bits[60], const uint8_t reliab[60]) {
+    (void)opts;
+    (void)state;
+    g_sacch_calls++;
+    g_last_sacch_bit = bits[0];
+    g_last_sacch_reliab = reliab[0];
+}
+
+void
+nxdn_deperm_scch_soft(dsd_opts* opts, dsd_state* state, uint8_t bits[60], const uint8_t reliab[60], uint8_t direction) {
+    (void)opts;
+    (void)state;
+    (void)bits;
+    (void)reliab;
+    g_scch_calls++;
+    g_facch_part_mask |= (int)direction << 8;
+}
+
+void
+nxdn_deperm_cac_soft(dsd_opts* opts, dsd_state* state, uint8_t bits[300], const uint8_t reliab[300]) {
+    (void)opts;
+    (void)state;
+    g_cac_calls++;
+    g_last_cac_bit = bits[0];
+    g_last_cac_reliab = reliab[0];
+}
+
+void
+nxdn_deperm_facch_soft(dsd_opts* opts, dsd_state* state, uint8_t bits[144], const uint8_t reliab[144], uint8_t part) {
+    (void)opts;
+    (void)state;
+    g_facch_calls++;
+    g_facch_part_mask |= 1 << part;
+    g_last_facch_bit = bits[0];
+    g_last_facch_reliab = reliab[0];
+}
+
+void
+nxdn_deperm_facch2_udch_soft(dsd_opts* opts, dsd_state* state, uint8_t bits[348], const uint8_t reliab[348],
+                             uint8_t is_facch2) {
+    (void)opts;
+    (void)state;
+    (void)bits;
+    (void)reliab;
+    if (is_facch2 != 0U) {
+        g_facch2_calls++;
+    } else {
+        g_udch_calls++;
+    }
+}
+
+void
+nxdn_deperm_facch3_udch2_soft(dsd_opts* opts, dsd_state* state, uint8_t bits[288], const uint8_t reliab[288],
+                              uint8_t is_facch3) {
+    (void)opts;
+    (void)state;
+    (void)bits;
+    (void)reliab;
+    if (is_facch3 != 0U) {
+        g_facch3_calls++;
+    } else {
+        g_udch2_calls++;
+    }
+}
+
+void
+nxdn_deperm_sacch2_soft(const dsd_opts* opts, dsd_state* state, uint8_t bits[60], const uint8_t reliab[60]) {
+    (void)opts;
+    (void)state;
+    (void)bits;
+    (void)reliab;
+    g_sacch2_calls++;
+}
+
+void
+nxdn_deperm_pich_tch_soft(const dsd_opts* opts, dsd_state* state, uint8_t bits[144], const uint8_t reliab[144],
+                          uint8_t lich) {
+    (void)opts;
+    (void)state;
+    (void)bits;
+    (void)reliab;
+    (void)lich;
+    g_pich_tch_calls++;
+}
+
+void
+nxdn_voice(dsd_opts* opts, dsd_state* state, int voice, uint8_t dbuf[182], const uint8_t* dbuf_reliab) {
+    (void)opts;
+    (void)state;
+    (void)dbuf;
+    (void)dbuf_reliab;
+    g_voice_calls++;
+    g_last_voice = voice;
+}
+
+static int
+route(uint8_t lich, const uint8_t bits[364], const uint8_t reliab[364]) {
+    return dsd_neo_nxdn_test_route_decoded_lich(&g_opts, &g_state, lich, bits, reliab);
+}
+
+static int
+test_control_channel_routes_and_reliability(void) {
+    int rc = 0;
+    uint8_t bits[364];
+    uint8_t reliab[364];
+    fill_soft_bits(bits, reliab);
+
+    reset_state();
+    rc |= expect_int("cac accepted", route(0x01U, bits, reliab), 1);
+    rc |= expect_int("cac route", g_cac_calls, 1);
+    rc |= expect_int("cac first bit", g_last_cac_bit, bits[16]);
+    rc |= expect_int("cac first reliability", g_last_cac_reliab, reliab[16]);
+
+    reset_state();
+    rc |= expect_int("sacch/facch accepted", route(0x32U, bits, reliab), 1);
+    rc |= expect_int("sacch route", g_sacch_calls, 1);
+    rc |= expect_int("facch route", g_facch_calls, 1);
+    rc |= expect_int("voice route", g_voice_calls, 1);
+    rc |= expect_int("voice mode", g_last_voice, 2);
+    rc |= expect_int("sacch first bit", g_last_sacch_bit, bits[16]);
+    rc |= expect_int("sacch first reliability", g_last_sacch_reliab, reliab[16]);
+    rc |= expect_int("facch first bit", g_last_facch_bit, bits[76]);
+    rc |= expect_int("facch first reliability", g_last_facch_reliab, reliab[76]);
+
+    reset_state();
+    rc |= expect_int("facch-both accepted", route(0x20U, bits, reliab), 1);
+    rc |= expect_int("facch both routes", g_facch_calls, 2);
+    rc |= expect_int("non-superframe sacch mode", g_state.nxdn_sacch_non_superframe, 1);
+
+    reset_state();
+    rc |= expect_int("scch accepted", route(0x76U, bits, reliab), 1);
+    rc |= expect_int("scch route", g_scch_calls, 1);
+
+    reset_state();
+    rc |= expect_int("facch2 accepted", route(0x28U, bits, reliab), 1);
+    rc |= expect_int("facch2 route", g_facch2_calls, 1);
+    rc |= expect_int("udch accepted", route(0x2EU, bits, reliab), 1);
+    rc |= expect_int("udch route", g_udch_calls, 1);
+
+    reset_state();
+    rc |= expect_int("facch3 accepted", route(0x68U, bits, reliab), 1);
+    rc |= expect_int("facch3 route", g_facch3_calls, 1);
+    reset_state();
+    rc |= expect_int("udch2 accepted", route(0x6EU, bits, reliab), 1);
+    rc |= expect_int("udch2 route", g_udch2_calls, 1);
+
+    reset_state();
+    rc |= expect_int("sacch2-pich accepted", route(0x08U, bits, reliab), 1);
+    rc |= expect_int("sacch2 route", g_sacch2_calls, 1);
+    rc |= expect_int("pich single route", g_pich_tch_calls, 1);
+    reset_state();
+    rc |= expect_int("sacch2-pich both accepted", route(0x48U, bits, reliab), 1);
+    rc |= expect_int("pich both routes", g_pich_tch_calls, 2);
+
+    return rc;
+}
+
+static int
+test_bad_frame_and_filter_gates(void) {
+    int rc = 0;
+    uint8_t bits[364];
+    uint8_t reliab[364];
+    fill_soft_bits(bits, reliab);
+
+    reset_state();
+    g_state.carrier = 1;
+    g_state.synctype = 99;
+    g_state.lastsynctype = 99;
+    rc |= expect_int("unsupported lich rejected", route(0x7FU, bits, reliab), 0);
+    rc |= expect_int("unsupported lich marks sync none", g_state.lastsynctype, DSD_SYNC_NONE);
+    rc |= expect_int("unsupported lich clears carrier after sync reject", g_state.carrier, 0);
+    rc |= expect_int("unsupported lich sacch reset", g_state.nxdn_sacch_frame_segment[0][0], 1);
+    rc |= expect_int("unsupported lich sacch crc reset", g_state.nxdn_sacch_frame_segcrc[0], 1);
+
+    reset_state();
+    g_opts.p25_trunk = 1;
+    rc |= expect_int("inbound trunk lich rejected", route(0x38U, bits, reliab), 0);
+    rc |= expect_int("inbound trunk marks sync none", g_state.lastsynctype, DSD_SYNC_NONE);
+
+    return rc;
+}
+
+static int
+test_lfsr_and_scanner_state(void) {
+    int rc = 0;
+    uint8_t bits[364];
+    uint8_t reliab[364];
+    fill_soft_bits(bits, reliab);
+
+    reset_state();
+    g_state.nxdn_cipher_type = 0x1;
+    g_state.R = 0x1234U;
+    rc |= expect_int("data frame accepted", route(0x01U, bits, reliab), 1);
+    rc |= expect_u64("data frame seeds mi", g_state.payload_miN, 0x1238ULL);
+    rc |= expect_int("data frame lfsr calls", g_lfsr_calls, 4);
+
+    reset_state();
+    g_state.nxdn_cipher_type = 0x2;
+    rc |= expect_int("data aes accepted", route(0x01U, bits, reliab), 1);
+    rc |= expect_u64("data aes bit counter", (unsigned long long)g_state.bit_counterL, 196ULL);
+
+    reset_state();
+    g_state.M = 1;
+    g_state.R = 0x2000U;
+    rc |= expect_int("voice facch accepted", route(0x32U, bits, reliab), 1);
+    rc |= expect_int("voice sets cipher type", g_state.nxdn_cipher_type, 1);
+    rc |= expect_int("pre voice lfsr calls", g_lfsr_calls, 2);
+    rc |= expect_u64("pre voice seeds mi", g_state.payload_miN, 0x2002ULL);
+
+    reset_state();
+    g_state.nxdn_cipher_type = 0x2;
+    rc |= expect_int("post voice facch2 accepted", route(0x34U, bits, reliab), 1);
+    rc |= expect_u64("post voice facch2 bit counter", (unsigned long long)g_state.bit_counterL, 98ULL);
+
+    reset_state();
+    g_opts.scanner_mode = 1;
+    rc |= expect_int("scanner accepted", route(0x01U, bits, reliab), 1);
+    rc |= expect_int("scanner extends cc sync", g_state.last_cc_sync_time > 0, 1);
+    rc |= expect_int("carrier active", g_state.carrier, 1);
+
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+
+    rc |= test_control_channel_routes_and_reliability();
+    rc |= test_bad_frame_and_filter_gates();
+    rc |= test_lfsr_and_scanner_state();
+
+    if (rc == 0) {
+        DSD_FPRINTF(stdout, "NXDN_FRAME_ROUTING: OK\n");
+    }
+    return rc;
+}

--- a/tests/protocol/nxdn/test_nxdn_frame_routing.c
+++ b/tests/protocol/nxdn/test_nxdn_frame_routing.c
@@ -34,6 +34,9 @@ static int g_sacch2_calls;
 static int g_pich_tch_calls;
 static int g_voice_calls;
 static int g_last_voice;
+static uint8_t g_dibit_stream[182];
+static uint8_t g_dibit_reliab_stream[182];
+static size_t g_dibit_stream_pos;
 static uint8_t g_last_sacch_bit;
 static uint8_t g_last_sacch_reliab;
 static uint8_t g_last_facch_bit;
@@ -77,6 +80,9 @@ reset_state(void) {
     g_pich_tch_calls = 0;
     g_voice_calls = 0;
     g_last_voice = 0;
+    DSD_MEMSET(g_dibit_stream, 0, sizeof(g_dibit_stream));
+    DSD_MEMSET(g_dibit_reliab_stream, 255, sizeof(g_dibit_reliab_stream));
+    g_dibit_stream_pos = 0U;
     g_last_sacch_bit = 0;
     g_last_sacch_reliab = 0;
     g_last_facch_bit = 0;
@@ -121,10 +127,17 @@ int
 getDibitWithReliability(dsd_opts* opts, dsd_state* state, uint8_t* out_reliability) {
     (void)opts;
     (void)state;
-    if (out_reliability != NULL) {
-        *out_reliability = 255U;
+    uint8_t dibit = 0U;
+    uint8_t reliab = 255U;
+    if (g_dibit_stream_pos < (sizeof(g_dibit_stream) / sizeof(g_dibit_stream[0]))) {
+        dibit = g_dibit_stream[g_dibit_stream_pos];
+        reliab = g_dibit_reliab_stream[g_dibit_stream_pos];
+        g_dibit_stream_pos++;
     }
-    return 0;
+    if (out_reliability != NULL) {
+        *out_reliability = reliab;
+    }
+    return dibit;
 }
 
 uint64_t
@@ -255,6 +268,32 @@ route(uint8_t lich, const uint8_t bits[364], const uint8_t reliab[364]) {
     return dsd_neo_nxdn_test_route_decoded_lich(&g_opts, &g_state, lich, bits, reliab);
 }
 
+static uint8_t
+encoded_lich_full(uint8_t lich) {
+    uint8_t full = (uint8_t)(lich << 1U);
+    uint8_t parity = (uint8_t)(((full >> 7U) + (full >> 6U) + (full >> 5U) + (full >> 4U)) & 1U);
+    if (lich == 0x08U || lich == 0x4AU || lich == 0x48U || lich == 0x46U) {
+        parity = (uint8_t)(((full >> 7U) + (full >> 6U) + (full >> 5U) + (full >> 4U) + (full >> 3U) + (full >> 2U)
+                            + (full >> 1U))
+                           & 1U);
+    }
+    return (uint8_t)(full | parity);
+}
+
+static void
+prepare_frame_stream(uint8_t lich, int force_bad_parity) {
+    const uint8_t full = (uint8_t)(encoded_lich_full(lich) ^ (force_bad_parity ? 1U : 0U));
+    for (size_t i = 0U; i < (sizeof(g_dibit_stream) / sizeof(g_dibit_stream[0])); i++) {
+        if (i < 8U) {
+            g_dibit_stream[i] = (uint8_t)((((full >> (7U - i)) & 1U) << 1U) | 1U);
+        } else {
+            g_dibit_stream[i] = (uint8_t)((((i * 3U) + 1U) & 0x3U));
+        }
+        g_dibit_reliab_stream[i] = (uint8_t)(240U - (i % 120U));
+    }
+    g_dibit_stream_pos = 0U;
+}
+
 static int
 test_control_channel_routes_and_reliability(void) {
     int rc = 0;
@@ -320,6 +359,14 @@ test_bad_frame_and_filter_gates(void) {
     fill_soft_bits(bits, reliab);
 
     reset_state();
+    rc |= expect_int("route null opts", dsd_neo_nxdn_test_route_decoded_lich(NULL, &g_state, 0x01U, bits, reliab), -1);
+    rc |= expect_int("route null state", dsd_neo_nxdn_test_route_decoded_lich(&g_opts, NULL, 0x01U, bits, reliab), -1);
+    rc |=
+        expect_int("route null bits", dsd_neo_nxdn_test_route_decoded_lich(&g_opts, &g_state, 0x01U, NULL, reliab), -1);
+    rc |=
+        expect_int("route null reliab", dsd_neo_nxdn_test_route_decoded_lich(&g_opts, &g_state, 0x01U, bits, NULL), -1);
+
+    reset_state();
     g_state.carrier = 1;
     g_state.synctype = 99;
     g_state.lastsynctype = 99;
@@ -333,6 +380,41 @@ test_bad_frame_and_filter_gates(void) {
     g_opts.p25_trunk = 1;
     rc |= expect_int("inbound trunk lich rejected", route(0x38U, bits, reliab), 0);
     rc |= expect_int("inbound trunk marks sync none", g_state.lastsynctype, DSD_SYNC_NONE);
+
+    return rc;
+}
+
+static int
+test_public_frame_entry_lich_collection(void) {
+    int rc = 0;
+
+    reset_state();
+    g_opts.frame_nxdn48 = 1;
+    g_state.lastsynctype = DSD_SYNC_NXDN_POS;
+    prepare_frame_stream(0x01U, 0);
+    nxdn_frame(&g_opts, &g_state);
+    rc |= expect_int("frame consumed dibits", (int)g_dibit_stream_pos, 182);
+    rc |= expect_int("frame cac route", g_cac_calls, 1);
+    rc |= expect_int("frame carrier active", g_state.carrier, 1);
+    rc |= expect_int("frame cc mono timestamp", g_state.last_cc_sync_time_m == 42.0, 1);
+    rc |= expect_int("frame cac reliability", g_last_cac_reliab, g_dibit_reliab_stream[8]);
+
+    reset_state();
+    g_opts.frame_nxdn48 = 1;
+    prepare_frame_stream(0x08U, 0);
+    nxdn_frame(&g_opts, &g_state);
+    rc |= expect_int("frame special parity accepted", g_sacch2_calls, 1);
+    rc |= expect_int("frame special pich", g_pich_tch_calls, 1);
+
+    reset_state();
+    g_state.carrier = 1;
+    g_state.synctype = DSD_SYNC_NXDN_POS;
+    g_state.lastsynctype = DSD_SYNC_NXDN_POS;
+    prepare_frame_stream(0x01U, 1);
+    nxdn_frame(&g_opts, &g_state);
+    rc |= expect_int("frame parity consumed lich only", (int)g_dibit_stream_pos, 8);
+    rc |= expect_int("frame parity rejects sync", g_state.lastsynctype, DSD_SYNC_NONE);
+    rc |= expect_int("frame parity clears carrier", g_state.carrier, 0);
 
     return rc;
 }
@@ -370,6 +452,21 @@ test_lfsr_and_scanner_state(void) {
     rc |= expect_u64("post voice facch2 bit counter", (unsigned long long)g_state.bit_counterL, 98ULL);
 
     reset_state();
+    DSD_SNPRINTF(g_opts.mbe_out_dir, sizeof(g_opts.mbe_out_dir), "%s", "mbe");
+    rc |= expect_int("voice opens mbe file route", route(0x32U, bits, reliab), 1);
+    rc |= expect_int("voice opened mbe file", g_opts.mbe_out_f == stdout, 1);
+    g_opts.frame_nxdn48 = 1;
+    rc |= expect_int("nxdn48 data closes mbe file route", route(0x01U, bits, reliab), 1);
+    rc |= expect_int("nxdn48 data closed mbe file", g_opts.mbe_out_f == NULL, 1);
+
+    reset_state();
+    g_opts.mbe_out_f = stdout;
+    g_opts.frame_nxdn96 = 1;
+    g_state.last_vc_sync_time = 0;
+    rc |= expect_int("nxdn96 stale data closes mbe file route", route(0x01U, bits, reliab), 1);
+    rc |= expect_int("nxdn96 stale data closed mbe file", g_opts.mbe_out_f == NULL, 1);
+
+    reset_state();
     g_opts.scanner_mode = 1;
     rc |= expect_int("scanner accepted", route(0x01U, bits, reliab), 1);
     rc |= expect_int("scanner extends cc sync", g_state.last_cc_sync_time > 0, 1);
@@ -384,6 +481,7 @@ main(void) {
 
     rc |= test_control_channel_routes_and_reliability();
     rc |= test_bad_frame_and_filter_gates();
+    rc |= test_public_frame_entry_lich_collection();
     rc |= test_lfsr_and_scanner_state();
 
     if (rc == 0) {

--- a/tests/protocol/nxdn/test_nxdn_message_crc32.c
+++ b/tests/protocol/nxdn/test_nxdn_message_crc32.c
@@ -155,6 +155,19 @@ expect_int(const char* tag, int got, int want) {
 }
 
 static int
+expect_float_close(const char* tag, float got, float want, float epsilon) {
+    float delta = got - want;
+    if (delta < 0.0f) {
+        delta = -delta;
+    }
+    if (delta > epsilon) {
+        DSD_FPRINTF(stderr, "%s: got %.6f want %.6f\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 expect_label(const char* tag, uint8_t message_type, const char* want) {
     const char* got = nxdn_message_type_label(message_type);
     if ((got == NULL) != (want == NULL)) {
@@ -183,57 +196,81 @@ all_sacch_segments_are(uint8_t value, const dsd_state* state) {
     return 1;
 }
 
+static void
+seed_call_state(dsd_opts* opts, dsd_state* state) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->floating_point = 1;
+    opts->audio_gain = 2.5f;
+    state->aout_gain = 9.0f;
+    state->nxdn_last_rid = 1234;
+    state->nxdn_last_tg = 5678;
+    state->nxdn_cipher_type = 1;
+    state->keyloader = 1;
+    state->R = 42;
+    DSD_SNPRINTF(state->nxdn_call_type, sizeof(state->nxdn_call_type), "%s", "voice");
+    DSD_MEMSET(state->nxdn_sacch_frame_segcrc, 0, sizeof(state->nxdn_sacch_frame_segcrc));
+    DSD_MEMSET(state->nxdn_sacch_frame_segment, 0, sizeof(state->nxdn_sacch_frame_segment));
+}
+
+static int
+expect_call_reset(const char* label, const dsd_opts* opts, const dsd_state* state, int alias_calls, int key_cleared) {
+    int rc = 0;
+    rc |= expect_int(label, alias_calls, 1);
+    rc |= expect_int("call-reset-rid-reset", state->nxdn_last_rid, 0);
+    rc |= expect_int("call-reset-tg-reset", state->nxdn_last_tg, 0);
+    rc |= expect_int("call-reset-cipher-reset", state->nxdn_cipher_type, 0);
+    rc |= expect_int("call-reset-r-state", state->R, key_cleared ? 0 : 42);
+    rc |= expect_int("call-reset-call-type-cleared", state->nxdn_call_type[0], '\0');
+    rc |= expect_int("call-reset-sacch-reset", all_sacch_segments_are(1U, state), 1);
+    rc |= expect_float_close("call-reset-gain-reset", state->aout_gain, opts->audio_gain, 1e-6f);
+    return rc;
+}
+
 static int
 test_message_type_reset_contract(void) {
     int rc = 0;
     static dsd_opts opts;
     static dsd_state state;
 
-    DSD_MEMSET(&opts, 0, sizeof(opts));
-    DSD_MEMSET(&state, 0, sizeof(state));
+    seed_call_state(&opts, &state);
     g_alias_reset_calls = 0;
-
-    opts.floating_point = 1;
-    opts.audio_gain = 2.5f;
-    state.aout_gain = 9.0f;
-    state.nxdn_last_rid = 1234;
-    state.nxdn_last_tg = 5678;
-    state.nxdn_cipher_type = 1;
-    state.keyloader = 1;
-    state.R = 42;
-    DSD_SNPRINTF(state.nxdn_call_type, sizeof(state.nxdn_call_type), "%s", "voice");
-    DSD_MEMSET(state.nxdn_sacch_frame_segcrc, 0, sizeof(state.nxdn_sacch_frame_segcrc));
-    DSD_MEMSET(state.nxdn_sacch_frame_segment, 0, sizeof(state.nxdn_sacch_frame_segment));
 
     nxdn_message_type(&opts, &state, 0x08U);
-    rc |= expect_int("tx-rel-alias-reset", g_alias_reset_calls, 1);
-    rc |= expect_int("tx-rel-rid-reset", state.nxdn_last_rid, 0);
-    rc |= expect_int("tx-rel-tg-reset", state.nxdn_last_tg, 0);
-    rc |= expect_int("tx-rel-cipher-reset", state.nxdn_cipher_type, 0);
-    rc |= expect_int("tx-rel-keyloader-r-reset", state.R, 0);
-    rc |= expect_int("tx-rel-call-type-cleared", state.nxdn_call_type[0], '\0');
-    rc |= expect_int("tx-rel-sacch-reset", all_sacch_segments_are(1U, &state), 1);
-    rc |= expect_int("tx-rel-gain-reset", state.aout_gain == opts.audio_gain, 1);
+    rc |= expect_call_reset("tx-rel-alias-reset", &opts, &state, g_alias_reset_calls, 1);
 
-    DSD_MEMSET(&state, 0, sizeof(state));
+    seed_call_state(&opts, &state);
     g_alias_reset_calls = 0;
-    state.aout_gain = 9.0f;
-    state.nxdn_last_rid = 1234;
-    state.nxdn_last_tg = 5678;
-    state.nxdn_cipher_type = 1;
-    state.keyloader = 1;
-    state.R = 42;
+    state.keyloader = 0;
+    nxdn_message_type(&opts, &state, 0x11U);
+    rc |= expect_call_reset("disc-alias-reset", &opts, &state, g_alias_reset_calls, 0);
+
+    seed_call_state(&opts, &state);
+    g_alias_reset_calls = 0;
+    opts.floating_point = 0;
+    nxdn_message_type(&opts, &state, 0xE8U);
+    rc |= expect_int("b54-tx-rel-alias-reset", g_alias_reset_calls, 1);
+    rc |= expect_int("b54-tx-rel-rid-reset", state.nxdn_last_rid, 0);
+    rc |= expect_int("b54-tx-rel-tg-reset", state.nxdn_last_tg, 0);
+    rc |= expect_int("b54-tx-rel-cipher-reset", state.nxdn_cipher_type, 0);
+    rc |= expect_int("b54-tx-rel-keyloader-r-reset", state.R, 0);
+    rc |= expect_int("b54-tx-rel-call-type-cleared", state.nxdn_call_type[0], '\0');
+    rc |= expect_int("b54-tx-rel-sacch-reset", all_sacch_segments_are(1U, &state), 1);
+    rc |= expect_float_close("b54-tx-rel-floating-point-off-keeps-gain", state.aout_gain, 9.0f, 1e-6f);
+
+    seed_call_state(&opts, &state);
+    g_alias_reset_calls = 0;
 
     nxdn_message_type(&opts, &state, 0x07U);
     rc |= expect_int("tx-rel-ex-no-alias-reset", g_alias_reset_calls, 0);
     rc |= expect_int("tx-rel-ex-rid-kept", state.nxdn_last_rid, 1234);
     rc |= expect_int("tx-rel-ex-tg-kept", state.nxdn_last_tg, 5678);
     rc |= expect_int("tx-rel-ex-r-kept", state.R, 42);
-    rc |= expect_int("tx-rel-ex-gain-reset", state.aout_gain == opts.audio_gain, 1);
+    rc |= expect_float_close("tx-rel-ex-gain-reset", state.aout_gain, opts.audio_gain, 1e-6f);
 
     state.aout_gain = 7.0f;
     nxdn_message_type(&opts, &state, 0x10U);
-    rc |= expect_int("idle-gain-kept", state.aout_gain == 7.0f, 1);
+    rc |= expect_float_close("idle-gain-kept", state.aout_gain, 7.0f, 1e-6f);
     rc |= expect_int("idle-rid-kept", state.nxdn_last_rid, 1234);
     return rc;
 }

--- a/tests/protocol/nxdn/test_nxdn_message_crc32.c
+++ b/tests/protocol/nxdn/test_nxdn_message_crc32.c
@@ -7,7 +7,9 @@
  * NXDN data-call CRC32 (MSB-first, init all-ones, no final xor) unit checks.
  */
 
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/protocol/nxdn/nxdn_deperm.h>
 #include <stdint.h>
@@ -19,6 +21,8 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #endif
+
+static int g_alias_reset_calls;
 
 /*
  * Link stubs:
@@ -101,6 +105,7 @@ void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 nxdn_alias_reset(dsd_state* state) {
     (void)state;
+    g_alias_reset_calls++;
 }
 
 void
@@ -141,6 +146,15 @@ expect_u32(const char* tag, uint32_t got, uint32_t want) {
 }
 
 static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 expect_label(const char* tag, uint8_t message_type, const char* want) {
     const char* got = nxdn_message_type_label(message_type);
     if ((got == NULL) != (want == NULL)) {
@@ -152,6 +166,76 @@ expect_label(const char* tag, uint8_t message_type, const char* want) {
         return 1;
     }
     return 0;
+}
+
+static int
+all_sacch_segments_are(uint8_t value, const dsd_state* state) {
+    for (size_t frame = 0U; frame < 4U; frame++) {
+        if (state->nxdn_sacch_frame_segcrc[frame] != value) {
+            return 0;
+        }
+        for (size_t bit = 0U; bit < 18U; bit++) {
+            if (state->nxdn_sacch_frame_segment[frame][bit] != value) {
+                return 0;
+            }
+        }
+    }
+    return 1;
+}
+
+static int
+test_message_type_reset_contract(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    g_alias_reset_calls = 0;
+
+    opts.floating_point = 1;
+    opts.audio_gain = 2.5f;
+    state.aout_gain = 9.0f;
+    state.nxdn_last_rid = 1234;
+    state.nxdn_last_tg = 5678;
+    state.nxdn_cipher_type = 1;
+    state.keyloader = 1;
+    state.R = 42;
+    DSD_SNPRINTF(state.nxdn_call_type, sizeof(state.nxdn_call_type), "%s", "voice");
+    DSD_MEMSET(state.nxdn_sacch_frame_segcrc, 0, sizeof(state.nxdn_sacch_frame_segcrc));
+    DSD_MEMSET(state.nxdn_sacch_frame_segment, 0, sizeof(state.nxdn_sacch_frame_segment));
+
+    nxdn_message_type(&opts, &state, 0x08U);
+    rc |= expect_int("tx-rel-alias-reset", g_alias_reset_calls, 1);
+    rc |= expect_int("tx-rel-rid-reset", state.nxdn_last_rid, 0);
+    rc |= expect_int("tx-rel-tg-reset", state.nxdn_last_tg, 0);
+    rc |= expect_int("tx-rel-cipher-reset", state.nxdn_cipher_type, 0);
+    rc |= expect_int("tx-rel-keyloader-r-reset", state.R, 0);
+    rc |= expect_int("tx-rel-call-type-cleared", state.nxdn_call_type[0], '\0');
+    rc |= expect_int("tx-rel-sacch-reset", all_sacch_segments_are(1U, &state), 1);
+    rc |= expect_int("tx-rel-gain-reset", state.aout_gain == opts.audio_gain, 1);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    g_alias_reset_calls = 0;
+    state.aout_gain = 9.0f;
+    state.nxdn_last_rid = 1234;
+    state.nxdn_last_tg = 5678;
+    state.nxdn_cipher_type = 1;
+    state.keyloader = 1;
+    state.R = 42;
+
+    nxdn_message_type(&opts, &state, 0x07U);
+    rc |= expect_int("tx-rel-ex-no-alias-reset", g_alias_reset_calls, 0);
+    rc |= expect_int("tx-rel-ex-rid-kept", state.nxdn_last_rid, 1234);
+    rc |= expect_int("tx-rel-ex-tg-kept", state.nxdn_last_tg, 5678);
+    rc |= expect_int("tx-rel-ex-r-kept", state.R, 42);
+    rc |= expect_int("tx-rel-ex-gain-reset", state.aout_gain == opts.audio_gain, 1);
+
+    state.aout_gain = 7.0f;
+    nxdn_message_type(&opts, &state, 0x10U);
+    rc |= expect_int("idle-gain-kept", state.aout_gain == 7.0f, 1);
+    rc |= expect_int("idle-rid-kept", state.nxdn_last_rid, 1234);
+    return rc;
 }
 
 int
@@ -186,6 +270,7 @@ main(void) {
     rc |= expect_label("label-dcr-tx-rel-silent", 0x88U, "");
     rc |= expect_label("label-dcr-idle-silent", 0x90U, "");
     rc |= expect_label("label-unknown", 0xFEU, NULL);
+    rc |= test_message_type_reset_contract();
 
     return rc;
 }

--- a/tests/protocol/nxdn/test_nxdn_trunk_diag.c
+++ b/tests/protocol/nxdn/test_nxdn_trunk_diag.c
@@ -7,11 +7,14 @@
  * NXDN trunking diagnostics: missing channel->frequency mapping tracking.
  */
 
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/protocol/nxdn/nxdn_trunk_diag.h>
 #include <stdint.h>
 #include <stdio.h>
+
+#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
@@ -47,7 +50,13 @@ main(void) {
     int rc = 0;
 
     static dsd_state state;
+    static dsd_opts opts;
     uint16_t out[8];
+
+    rc |= expect_eq_int("note-null-state", nxdn_trunk_diag_note_missing_channel(NULL, 12), 0);
+    rc |= expect_eq_int("note-zero-channel", nxdn_trunk_diag_note_missing_channel(&state, 0), 0);
+    rc |= expect_eq_int("note-max-channel", nxdn_trunk_diag_note_missing_channel(&state, UINT16_MAX), 0);
+    rc |= expect_eq_size("collect-null-state", nxdn_trunk_diag_collect_unmapped_channels(NULL, out, 8), 0);
 
     DSD_MEMSET(out, 0, sizeof out);
     rc |= expect_eq_size("empty-total", nxdn_trunk_diag_collect_unmapped_channels(&state, out, 8), 0);
@@ -67,6 +76,49 @@ main(void) {
     rc |= expect_eq_size("total-1-after-map", nxdn_trunk_diag_collect_unmapped_channels(&state, out, 8), 1);
     rc |= expect_eq_u16("out0-ch13-after-map", out[0], 13);
 
+    nxdn_trunk_diag_log_missing_channel_once(NULL, &state, 14, "null-opts");
+    nxdn_trunk_diag_log_missing_channel_once(&opts, NULL, 14, "null-state");
+    nxdn_trunk_diag_log_summary(NULL, &state);
+    nxdn_trunk_diag_log_summary(&opts, NULL);
+    nxdn_trunk_diag_log_summary(&opts, &state);
+    rc |= expect_eq_size("empty-opts-does-not-log-or-record",
+                         nxdn_trunk_diag_collect_unmapped_channels(&state, NULL, 0), 1);
+
+    (void)DSD_SNPRINTF(opts.chan_in_file, sizeof opts.chan_in_file, "%s", "channels.csv");
+
+    static dsd_state log_state;
+    log_state.trunk_chan_map[21] = 851000000;
+    nxdn_trunk_diag_log_missing_channel_once(&opts, &log_state, 0, "invalid-zero");
+    nxdn_trunk_diag_log_missing_channel_once(&opts, &log_state, UINT16_MAX, "invalid-max");
+    nxdn_trunk_diag_log_missing_channel_once(&opts, &log_state, 21, "mapped");
+    rc |= expect_eq_size("invalid-and-mapped-log-skipped",
+                         nxdn_trunk_diag_collect_unmapped_channels(&log_state, NULL, 0), 0);
+
+    nxdn_trunk_diag_log_missing_channel_once(&opts, &log_state, 20, "grant");
+    nxdn_trunk_diag_log_missing_channel_once(&opts, &log_state, 20, "");
+    nxdn_trunk_diag_log_missing_channel_once(&opts, &log_state, 22, NULL);
+
+    DSD_MEMSET(out, 0, sizeof out);
+    rc |= expect_eq_size("log-recorded-two", nxdn_trunk_diag_collect_unmapped_channels(&log_state, out, 8), 2);
+    rc |= expect_eq_u16("log-out0-ch20", out[0], 20);
+    rc |= expect_eq_u16("log-out1-ch22", out[1], 22);
+    rc |=
+        expect_eq_size("log-recorded-two-null-out", nxdn_trunk_diag_collect_unmapped_channels(&log_state, NULL, 0), 2);
+    nxdn_trunk_diag_log_summary(&opts, &log_state);
+
+    static dsd_state overflow_state;
+    for (uint16_t ch = 30; ch < 50; ch++) {
+        rc |= expect_eq_int("overflow-note", nxdn_trunk_diag_note_missing_channel(&overflow_state, ch), 1);
+    }
+    DSD_MEMSET(out, 0, sizeof out);
+    rc |= expect_eq_size("overflow-total-cap3", nxdn_trunk_diag_collect_unmapped_channels(&overflow_state, out, 3), 20);
+    rc |= expect_eq_u16("overflow-out0", out[0], 30);
+    rc |= expect_eq_u16("overflow-out1", out[1], 31);
+    rc |= expect_eq_u16("overflow-out2", out[2], 32);
+    nxdn_trunk_diag_log_summary(&opts, &overflow_state);
+
     dsd_state_ext_free_all(&state);
+    dsd_state_ext_free_all(&log_state);
+    dsd_state_ext_free_all(&overflow_state);
     return rc;
 }

--- a/tests/protocol/nxdn/test_nxdn_voice_mapping.c
+++ b/tests/protocol/nxdn/test_nxdn_voice_mapping.c
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/vocoder.h>
+#include <dsd-neo/protocol/nxdn/nxdn_voice.h>
+
+#include <stdint.h>
+#include <stdio.h>
+
+static int g_hard_calls;
+static int g_soft_calls;
+static int g_play_ms_calls;
+static int g_play_fm_calls;
+static char g_last_hard[4][24];
+static dsd_vocoder_soft_bit g_last_soft[4][24];
+static dsd_opts g_opts;
+static dsd_state g_state;
+
+static int
+expect_int(const char* label, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_float(const char* label, float got, float want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %.3f want %.3f\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static void
+reset_spies(void) {
+    g_hard_calls = 0;
+    g_soft_calls = 0;
+    g_play_ms_calls = 0;
+    g_play_fm_calls = 0;
+    DSD_MEMSET(g_last_hard, 0, sizeof(g_last_hard));
+    DSD_MEMSET(g_last_soft, 0, sizeof(g_last_soft));
+}
+
+static void
+reset_decoder_objects(void) {
+    DSD_MEMSET(&g_opts, 0, sizeof(g_opts));
+    DSD_MEMSET(&g_state, 0, sizeof(g_state));
+}
+
+static void
+fill_dibits(uint8_t dbuf[182], uint8_t reliab[182]) {
+    for (int i = 0; i < 182; i++) {
+        dbuf[i] = (uint8_t)(((i & 1) << 1) | ((i >> 1) & 1));
+        reliab[i] = (uint8_t)(200 - i);
+    }
+}
+
+void
+processMbeFrame(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], char ambe_fr[4][24], char imbe7100_fr[7][24]) {
+    (void)opts;
+    (void)imbe_fr;
+    (void)imbe7100_fr;
+    g_hard_calls++;
+    DSD_MEMCPY(g_last_hard, ambe_fr, sizeof(g_last_hard));
+    for (int i = 0; i < 160; i++) {
+        state->audio_out_temp_buf[i] = (float)(g_hard_calls * 1000 + i);
+    }
+}
+
+void
+processMbeFrameSoft(dsd_opts* opts, dsd_state* state, dsd_vocoder_soft_bit imbe_fr[8][23],
+                    dsd_vocoder_soft_bit ambe_fr[4][24], dsd_vocoder_soft_bit imbe7100_fr[7][24]) {
+    (void)opts;
+    (void)imbe_fr;
+    (void)imbe7100_fr;
+    g_soft_calls++;
+    DSD_MEMCPY(g_last_soft, ambe_fr, sizeof(g_last_soft));
+    for (int i = 0; i < 160; i++) {
+        state->audio_out_temp_buf[i] = (float)(g_soft_calls * 2000 + i);
+    }
+}
+
+void
+playSynthesizedVoiceMS(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_play_ms_calls++;
+}
+
+void
+playSynthesizedVoiceFM(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_play_fm_calls++;
+}
+
+static int
+test_hard_voice_modes(void) {
+    int err = 0;
+    uint8_t dbuf[182];
+    uint8_t reliab[182];
+
+    reset_decoder_objects();
+    fill_dibits(dbuf, reliab);
+
+    reset_spies();
+    nxdn_voice(&g_opts, &g_state, 1, dbuf, NULL);
+    err |= expect_int("voice 1 hard frames", g_hard_calls, 2);
+    err |= expect_int("voice 1 short playback", g_play_ms_calls, 2);
+    err |= expect_int("voice 1 float playback", g_play_fm_calls, 0);
+    err |= expect_int("voice 1 final high bit", g_last_hard[0][23], (dbuf[74] >> 1) & 1);
+    err |= expect_int("voice 1 final low bit", g_last_hard[0][5], dbuf[74] & 1);
+    err |= expect_float("voice 1 copies final audio", g_state.f_l[7], 2007.0f);
+
+    reset_spies();
+    reset_decoder_objects();
+    nxdn_voice(&g_opts, &g_state, 2, dbuf, NULL);
+    err |= expect_int("voice 2 hard frames", g_hard_calls, 2);
+    err |= expect_int("voice 2 starts at second half high bit", g_last_hard[0][23], (dbuf[146] >> 1) & 1);
+    err |= expect_int("voice 2 starts at second half low bit", g_last_hard[0][5], dbuf[146] & 1);
+
+    reset_spies();
+    reset_decoder_objects();
+    g_opts.floating_point = 1;
+    nxdn_voice(&g_opts, &g_state, 3, dbuf, NULL);
+    err |= expect_int("voice 3 hard frames", g_hard_calls, 4);
+    err |= expect_int("voice 3 short playback", g_play_ms_calls, 0);
+    err |= expect_int("voice 3 float playback", g_play_fm_calls, 4);
+    err |= expect_float("voice 3 copies final audio", g_state.f_l[159], 4159.0f);
+
+    reset_spies();
+    nxdn_voice(&g_opts, &g_state, 0, dbuf, NULL);
+    err |= expect_int("voice 0 does not decode", g_hard_calls, 0);
+    err |= expect_int("voice 0 does not play", g_play_fm_calls, 0);
+
+    return err;
+}
+
+static int
+test_soft_reliability_mapping(void) {
+    int err = 0;
+    uint8_t dbuf[182];
+    uint8_t reliab[182];
+
+    reset_decoder_objects();
+    fill_dibits(dbuf, reliab);
+
+    reset_spies();
+    nxdn_voice(&g_opts, &g_state, 1, dbuf, reliab);
+
+    err |= expect_int("soft voice calls", g_soft_calls, 2);
+    err |= expect_int("soft path bypasses hard decoder", g_hard_calls, 0);
+    err |= expect_int("soft high bit", g_last_soft[0][23].bit, (dbuf[74] >> 1) & 1);
+    err |= expect_int("soft high reliability", g_last_soft[0][23].reliability, reliab[74]);
+    err |= expect_int("soft low bit", g_last_soft[0][5].bit, dbuf[74] & 1);
+    err |= expect_int("soft low reliability", g_last_soft[0][5].reliability, reliab[74]);
+    err |= expect_float("soft copies final audio", g_state.f_l[3], 4003.0f);
+
+    return err;
+}
+
+int
+main(void) {
+    int err = 0;
+
+    err |= test_hard_voice_modes();
+    err |= test_soft_reliability_mapping();
+
+    if (err == 0) {
+        DSD_FPRINTF(stdout, "NXDN_VOICE_MAPPING: OK\n");
+    }
+    return err;
+}

--- a/tests/protocol/nxdn/test_nxdn_voice_mapping.c
+++ b/tests/protocol/nxdn/test_nxdn_voice_mapping.c
@@ -32,8 +32,12 @@ expect_int(const char* label, int got, int want) {
 
 static int
 expect_float(const char* label, float got, float want) {
-    if (got != want) {
-        DSD_FPRINTF(stderr, "%s: got %.3f want %.3f\n", label, got, want);
+    float delta = got - want;
+    if (delta < 0.0f) {
+        delta = -delta;
+    }
+    if (delta > 1e-6f) {
+        DSD_FPRINTF(stderr, "%s: got %.6f want %.6f\n", label, got, want);
         return 1;
     }
     return 0;

--- a/tests/protocol/p25/test_p25_12_list.c
+++ b/tests/protocol/p25/test_p25_12_list.c
@@ -69,9 +69,30 @@ main(void) {
     dibits_to_llr(dibits, bit_llr, 200);
 
     p25_12_candidate_t list[P25_12_MAX_CANDIDATES];
+    if (p25_12_soft_llr_list(dibits, NULL, list, P25_12_MAX_CANDIDATES) != 0
+        || p25_12_soft_llr_list(dibits, bit_llr, NULL, P25_12_MAX_CANDIDATES) != 0
+        || p25_12_soft_llr_list(dibits, bit_llr, list, 0) != 0) {
+        DSD_FPRINTF(stderr, "P25 1/2 list guard failed\n");
+        return 1;
+    }
+
     int list_count = p25_12_soft_llr_list(dibits, bit_llr, list, P25_12_MAX_CANDIDATES);
     if (list_count <= 0 || memcmp(list[0].bytes, payload, sizeof(payload)) != 0) {
         DSD_FPRINTF(stderr, "clean P25 1/2 list decode failed count=%d\n", list_count);
+        return 1;
+    }
+
+    uint8_t best[12] = {0};
+    int metric = p25_12_soft_llr(dibits, bit_llr, best);
+    if (metric != 0 || memcmp(best, payload, sizeof(payload)) != 0) {
+        DSD_FPRINTF(stderr, "clean P25 1/2 single decode failed metric=%d\n", metric);
+        return 1;
+    }
+
+    DSD_MEMSET(list, 0, sizeof(list));
+    list_count = p25_12_soft_llr_list(dibits, bit_llr, list, P25_12_MAX_CANDIDATES + 3);
+    if (list_count != P25_12_MAX_CANDIDATES || memcmp(list[0].bytes, payload, sizeof(payload)) != 0) {
+        DSD_FPRINTF(stderr, "clamped P25 1/2 list decode failed count=%d\n", list_count);
         return 1;
     }
 
@@ -92,6 +113,13 @@ main(void) {
     }
     if (!found_original) {
         DSD_FPRINTF(stderr, "noisy P25 1/2 list decode did not include original count=%d\n", list_count);
+        return 2;
+    }
+
+    DSD_MEMSET(best, 0, sizeof(best));
+    (void)p25_12_soft_llr(noisy_dibits, bit_llr, best);
+    if (memcmp(best, list[0].bytes, sizeof(best)) != 0) {
+        DSD_FPRINTF(stderr, "noisy P25 1/2 single/list best mismatch\n");
         return 2;
     }
 

--- a/tests/protocol/p25/test_p25_cc_cache_path.c
+++ b/tests/protocol/p25/test_p25_cc_cache_path.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(readability-suspicious-call-argument)
 /*
  * Copyright (C) 2025 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -65,6 +68,30 @@ write_cache_fixture(const char* path) {
     return 1;
 }
 
+static int
+read_file_text(const char* path, char* out, size_t out_len) {
+    FILE* fp = dsd_fopen_existing_regular_file(path, "r");
+    if (!fp) {
+        DSD_FPRINTF(stderr, "failed to read cache file: %s\n", strerror(errno));
+        return 0;
+    }
+    size_t n = fread(out, 1, out_len - 1U, fp);
+    out[n] = '\0';
+    fclose(fp);
+    return 1;
+}
+
+static int
+expect_contains(const char* tag, const char* haystack, const char* needle, int want) {
+    int found = strstr(haystack ? haystack : "", needle ? needle : "") != NULL;
+    if (found != want) {
+        DSD_FPRINTF(stderr, "%s: substring '%s' found=%d want=%d in '%s'\n", tag, needle ? needle : "(null)", found,
+                    want, haystack ? haystack : "(null)");
+        return 1;
+    }
+    return 0;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -83,12 +110,17 @@ main(void) {
     char out[1024];
     int ok = p25_cc_build_cache_path(&st, out, sizeof out);
     rc |= expect_eq_int("no identity", ok, 0);
+    rc |= expect_eq_int("null state path", p25_cc_build_cache_path(NULL, out, sizeof out), 0);
+    rc |= expect_eq_int("null out path", p25_cc_build_cache_path(&st, NULL, sizeof out), 0);
+    rc |= expect_eq_int("zero out path", p25_cc_build_cache_path(&st, out, 0), 0);
 
     // With WACN/SYSID only
     st.p2_wacn = 0xABCDEULL;
     st.p2_sysid = 0x123ULL;
     ok = p25_cc_build_cache_path(&st, out, sizeof out);
     rc |= expect_eq_int("iden only ok", ok, 1);
+    char tiny[8];
+    rc |= expect_eq_int("path too small", p25_cc_build_cache_path(&st, tiny, sizeof tiny), 0);
     char want1[1024];
     DSD_SNPRINTF(want1, sizeof want1, "%s/p25_cc_%05lX_%03lX.txt", dir, (unsigned long)st.p2_wacn,
                  (unsigned long)st.p2_sysid);
@@ -110,6 +142,7 @@ main(void) {
 
     static dsd_opts opts;
     DSD_MEMSET(&opts, 0, sizeof opts);
+    p25_cc_try_load_cache(&opts, NULL);
     p25_cc_try_load_cache(&opts, &st);
 
     const dsd_trunk_cc_candidates* cc = dsd_trunk_cc_candidates_peek(&st);
@@ -124,5 +157,38 @@ main(void) {
                             1);
     }
 
+    p25_cc_try_load_cache(&opts, &st);
+    rc |= expect_eq_int("already loaded preserves count", cc ? cc->count : 0, 2);
+
+    static dsd_state missing;
+    DSD_MEMSET(&missing, 0, sizeof missing);
+    missing.p2_wacn = 0xABCDEULL;
+    missing.p2_sysid = 0x124ULL;
+    missing.p2_rfssid = 8ULL;
+    missing.p2_siteid = 12ULL;
+    p25_cc_try_load_cache(&opts, &missing);
+    rc |= expect_eq_int("missing cache marked loaded", missing.p25_cc_cache_loaded, 1);
+    rc |= expect_eq_int("missing cache count", dsd_trunk_cc_candidates_peek(&missing) != NULL, 0);
+
+    rc |= expect_eq_int("add null candidate", p25_cc_add_candidate(NULL, 852111111L, 1), 0);
+    rc |= expect_eq_int("add zero candidate", p25_cc_add_candidate(&st, 0, 1), 0);
+    st.p25_cc_freq = 852222222L;
+    rc |= expect_eq_int("add current cc candidate", p25_cc_add_candidate(&st, 852222222L, 1), 0);
+    rc |= expect_eq_int("add current-site candidate", p25_cc_add_candidate(&st, 852555555L, 1), 1);
+    rc |= expect_eq_int("add generic candidate", dsd_trunk_cc_candidates_add_with_flags(&st, 852666666L, 1, 0), 1);
+
+    p25_cc_persist_cache(&opts, NULL);
+    p25_cc_persist_cache(&opts, &st);
+    char persisted[512];
+    if (!read_file_text(out, persisted, sizeof persisted)) {
+        return 102;
+    }
+    rc |= expect_contains("persisted candidate 0", persisted, "cc 851222222\n", 1);
+    rc |= expect_contains("persisted candidate 1", persisted, "cc 851333333\n", 1);
+    rc |= expect_contains("persisted added current-site", persisted, "cc 852555555\n", 1);
+    rc |= expect_contains("persisted excludes generic", persisted, "852666666", 0);
+
     return rc;
 }
+
+// NOLINTEND(readability-suspicious-call-argument)

--- a/tests/protocol/p25/test_p25_frequency_map.c
+++ b/tests/protocol/p25/test_p25_frequency_map.c
@@ -7,10 +7,19 @@
  * P25 channel→frequency mapping tests (FDMA/TDMA + overrides).
  */
 
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/p25/p25_frequency.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+struct RtlSdrContext;
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -20,10 +29,6 @@
 // Use shim to avoid pulling in external deps like mbelib.
 int p25_test_frequency_for(int iden, int type, int tdma, long base, int spac, int chan16, long map_override,
                            long* out_freq);
-
-// Stubs to satisfy linked objects from p25 proto lib
-typedef struct dsd_opts dsd_opts;
-typedef struct dsd_state dsd_state;
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -105,9 +110,27 @@ rtl_stream_tune(struct RtlSdrContext* ctx, uint32_t center_freq_hz) { // NOLINT(
 }
 
 static int
+expect_eq_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 expect_eq_long(const char* tag, long got, long want) {
     if (got != want) {
         DSD_FPRINTF(stderr, "%s: got %ld want %ld\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_eq_str(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got, want);
         return 1;
     }
     return 0;
@@ -144,6 +167,99 @@ main(void) {
         long f = 0;
         p25_test_frequency_for(1, /*type*/ 1, /*tdma*/ 0, 851000000 / 5, 100, 0x1005, 762000000, &f);
         rc |= expect_eq_long("map override", f, 762000000);
+    }
+
+    // Public trace and guard behavior.
+    {
+        p25_freq_trace_t trace;
+        DSD_MEMSET(&trace, 0xA5, sizeof(trace));
+        rc |= expect_eq_long("trace missing state", process_channel_to_freq_trace(NULL, NULL, 0x1000, &trace), 0);
+        rc |= expect_eq_str("trace missing state source", trace.source, "invalid-state");
+        rc |= expect_eq_str("trace missing state failure", trace.failure, "missing-state");
+
+        static dsd_state st;
+        DSD_MEMSET(&st, 0, sizeof(st));
+        rc |= expect_eq_long("trace sentinel channel", process_channel_to_freq_trace(NULL, &st, 0xFFFF, &trace), 0);
+        rc |= expect_eq_str("trace sentinel source", trace.source, "invalid-channel");
+        rc |= expect_eq_str("trace sentinel failure", trace.failure, "sentinel-channel");
+
+        rc |= expect_eq_long("trace missing iden", process_channel_to_freq_trace(NULL, &st, 0x1001, &trace), 0);
+        rc |= expect_eq_str("trace missing iden source", trace.source, "missing-iden-fdma");
+        rc |= expect_eq_str("trace missing iden failure", trace.failure, "missing-iden-params");
+
+        dsd_state_set_trunk_chan_freq(&st, 0x1001U, 765432100L);
+        p25_invalidate_chan_map_for_iden(NULL, 1);
+        p25_invalidate_chan_map_for_iden(&st, -1);
+        p25_invalidate_chan_map_for_iden(&st, 16);
+        rc |= expect_eq_long("invalid iden did not clear map", st.trunk_chan_map[0x1001], 765432100L);
+        p25_invalidate_chan_map_for_iden(&st, 1);
+        rc |= expect_eq_long("valid iden clears map", st.trunk_chan_map[0x1001], 0);
+
+        st.p25_chan_tdma_explicit[3] = 2;
+        st.p25_iden_fdma[3].populated = 1;
+        st.p25_iden_tdma[3].populated = 1;
+        p25_reset_iden_tables(NULL);
+        p25_reset_iden_tables(&st);
+        rc |= expect_eq_int("reset explicit tdma", st.p25_chan_tdma_explicit[3], 0);
+        rc |= expect_eq_int("reset fdma populated", st.p25_iden_fdma[3].populated, 0);
+        rc |= expect_eq_int("reset tdma populated", st.p25_iden_tdma[3].populated, 0);
+
+        static dsd_opts opts;
+        DSD_MEMSET(&opts, 0, sizeof(opts));
+        opts.verbose = 2;
+        st.p25_iden_fdma[1].populated = 1;
+        st.p25_iden_fdma[1].chan_type = 1;
+        st.p25_iden_fdma[1].base_freq = 851000000 / 5;
+        st.p25_iden_fdma[1].chan_spac = 100;
+        rc |= expect_eq_long("verbose computed p25", process_channel_to_freq(&opts, &st, 0x1002),
+                             851000000 + 2 * 100 * 125);
+    }
+
+    // NXDN channel mapping uses the same module and should cover DFA/cache/no-map paths.
+    {
+        static dsd_state ns;
+        static dsd_opts opts;
+        DSD_MEMSET(&ns, 0, sizeof(ns));
+        DSD_MEMSET(&opts, 0, sizeof(opts));
+
+        dsd_state_set_trunk_chan_freq(&ns, 10U, 123456789L);
+        rc |= expect_eq_long("nxdn cache verbose", nxdn_channel_to_frequency(&opts, &ns, 10U), 123456789L);
+        rc |= expect_eq_long("nxdn cache quiet", nxdn_channel_to_frequency_quiet(&ns, 10U), 123456789L);
+        rc |= expect_eq_long("nxdn quiet null state", nxdn_channel_to_frequency_quiet(NULL, 10U), 0);
+
+        DSD_MEMSET(&ns, 0, sizeof(ns));
+        rc |= expect_eq_long("nxdn no rcn verbose", nxdn_channel_to_frequency(&opts, &ns, 10U), 0);
+        rc |= expect_eq_long("nxdn no rcn quiet", nxdn_channel_to_frequency_quiet(&ns, 10U), 0);
+
+        ns.nxdn_rcn = 1;
+        ns.nxdn_base_freq = 1;
+        ns.nxdn_step = 2;
+        rc |= expect_eq_long("nxdn dfa base1 step2 verbose", nxdn_channel_to_frequency(&opts, &ns, 10U), 100012500L);
+
+        DSD_MEMSET(&ns, 0, sizeof(ns));
+        ns.nxdn_rcn = 1;
+        ns.nxdn_base_freq = 2;
+        ns.nxdn_step = 3;
+        rc |= expect_eq_long("nxdn dfa base2 step3 quiet", nxdn_channel_to_frequency_quiet(&ns, 10U), 330031250L);
+
+        DSD_MEMSET(&ns, 0, sizeof(ns));
+        ns.nxdn_rcn = 1;
+        ns.nxdn_base_freq = 3;
+        ns.nxdn_step = 2;
+        rc |= expect_eq_long("nxdn dfa base3 quiet", nxdn_channel_to_frequency_quiet(&ns, 10U), 400012500L);
+
+        DSD_MEMSET(&ns, 0, sizeof(ns));
+        ns.nxdn_rcn = 1;
+        ns.nxdn_base_freq = 4;
+        ns.nxdn_step = 3;
+        rc |= expect_eq_long("nxdn dfa base4 quiet", nxdn_channel_to_frequency_quiet(&ns, 10U), 750031250L);
+
+        DSD_MEMSET(&ns, 0, sizeof(ns));
+        ns.nxdn_rcn = 1;
+        ns.nxdn_base_freq = 99;
+        ns.nxdn_step = 99;
+        rc |= expect_eq_long("nxdn dfa unknown verbose", nxdn_channel_to_frequency(&opts, &ns, 10U), 0);
+        rc |= expect_eq_long("nxdn dfa unknown quiet", nxdn_channel_to_frequency_quiet(&ns, 10U), 0);
     }
 
     return rc;

--- a/tests/protocol/p25/test_p25_iden_lcw_full.c
+++ b/tests/protocol/p25/test_p25_iden_lcw_full.c
@@ -257,6 +257,87 @@ test_lcw_vuhf_populates_fdma(void) {
 }
 
 static int
+test_lcw_control_channel_provenance_promotes_trust(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state st;
+    uint8_t bits[96];
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&st, 0, sizeof st);
+
+    opts.p25_is_tuned = 0;
+    st.p25_cc_freq = 851000000;
+    st.p2_wacn = 0xABCDE;
+    st.p2_sysid = 0x123;
+    st.p2_rfssid = 0x45;
+    st.p2_siteid = 0x67;
+
+    int iden = 5;
+    long base = 851000000L / 5L;
+    build_lcw_standard(bits, iden, 0x24, 1, 12, 100, (unsigned long)base);
+
+    p25_lcw(&opts, &st, bits, 0);
+
+    rc |= expect_eq_u8("cc trust promoted", st.p25_iden_fdma[iden].trust, 2);
+    rc |= expect_eq_long("cc provenance wacn", (long)st.p25_iden_fdma[iden].wacn, 0xABCDE);
+    rc |= expect_eq_long("cc provenance sysid", (long)st.p25_iden_fdma[iden].sysid, 0x123);
+    rc |= expect_eq_long("cc provenance rfss", (long)st.p25_iden_fdma[iden].rfss, 0x45);
+    rc |= expect_eq_long("cc provenance site", (long)st.p25_iden_fdma[iden].site, 0x67);
+    rc |= expect_eq_int("cc positive offset", st.p25_iden_fdma[iden].trans_off, 12);
+
+    if (rc == 0) {
+        DSD_FPRINTF(stderr, "PASS test_lcw_control_channel_provenance_promotes_trust\n");
+    }
+    return rc;
+}
+
+static int
+test_lcw_rejects_incomplete_fdma_updates(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state st;
+    uint8_t bits[96];
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&st, 0, sizeof st);
+
+    int iden = 6;
+    st.p25_iden_fdma[iden].base_freq = 12345678L;
+    st.p25_iden_fdma[iden].chan_type = 1;
+    st.p25_iden_fdma[iden].chan_spac = 25;
+    st.p25_iden_fdma[iden].trans_off = -3;
+    st.p25_iden_fdma[iden].bw_vu = 2;
+    st.p25_iden_fdma[iden].trust = 2;
+    st.p25_iden_fdma[iden].populated = 1;
+    st.p25_chan_tdma_explicit[iden] = 3;
+    st.trunk_chan_map[(iden << 12) | 0x0010] = 987654321L;
+
+    build_lcw_standard(bits, iden, 0x55, 0, 7, 0, 850000000UL / 5UL);
+    p25_lcw(&opts, &st, bits, 0);
+
+    rc |= expect_eq_long("zero spacing preserves base", st.p25_iden_fdma[iden].base_freq, 12345678L);
+    rc |= expect_eq_int("zero spacing preserves spacing", st.p25_iden_fdma[iden].chan_spac, 25);
+    rc |= expect_eq_int("zero spacing preserves offset", st.p25_iden_fdma[iden].trans_off, -3);
+    rc |= expect_eq_u8("zero spacing preserves bw", st.p25_iden_fdma[iden].bw_vu, 2);
+    rc |= expect_eq_u8("zero spacing preserves bitmask", st.p25_chan_tdma_explicit[iden], 3);
+    rc |= expect_eq_long("zero spacing preserves cache", st.trunk_chan_map[(iden << 12) | 0x0010], 987654321L);
+
+    build_lcw_vuhf(bits, iden, 4, 1, 88, 100, 0);
+    p25_lcw(&opts, &st, bits, 0);
+
+    rc |= expect_eq_long("zero base preserves base", st.p25_iden_fdma[iden].base_freq, 12345678L);
+    rc |= expect_eq_int("zero base preserves spacing", st.p25_iden_fdma[iden].chan_spac, 25);
+    rc |= expect_eq_int("zero base preserves offset", st.p25_iden_fdma[iden].trans_off, -3);
+    rc |= expect_eq_u8("zero base preserves bw", st.p25_iden_fdma[iden].bw_vu, 2);
+    rc |= expect_eq_u8("zero base preserves bitmask", st.p25_chan_tdma_explicit[iden], 3);
+    rc |= expect_eq_long("zero base preserves cache", st.trunk_chan_map[(iden << 12) | 0x0010], 987654321L);
+
+    if (rc == 0) {
+        DSD_FPRINTF(stderr, "PASS test_lcw_rejects_incomplete_fdma_updates\n");
+    }
+    return rc;
+}
+
+static int
 test_lcw_replaces_existing_fdma(void) {
     int rc = 0;
     static dsd_opts opts;
@@ -320,6 +401,8 @@ main(void) {
 
     rc |= test_lcw_standard_populates_fdma();
     rc |= test_lcw_vuhf_populates_fdma();
+    rc |= test_lcw_control_channel_provenance_promotes_trust();
+    rc |= test_lcw_rejects_incomplete_fdma_updates();
     rc |= test_lcw_replaces_existing_fdma();
     rc |= test_iden_cache_invalidation_covers_last_channel();
 

--- a/tests/protocol/p25/test_p25_iden_variants.c
+++ b/tests/protocol/p25/test_p25_iden_variants.c
@@ -147,6 +147,22 @@ main(void) {
         return 8;
     }
 
+    long invalid = 777;
+    int invalid_rc = p25_test_frequency_for(/*iden*/ 16, /*type*/ 0, /*tdma*/ 0, /*base*/ 1000, /*spac*/ 1,
+                                            /*chan16*/ (1 << 12) | 1, /*map_override*/ 0, &invalid);
+    if (invalid_rc != -1) {
+        return 9;
+    }
+    if (expect_eq_long("invalid iden preserves output", invalid, 777)) {
+        return 10;
+    }
+
+    int null_out_rc = p25_test_frequency_for(/*iden*/ 1, /*type*/ 0, /*tdma*/ 0, /*base*/ 1000, /*spac*/ 1,
+                                             /*chan16*/ (1 << 12) | 1, /*map_override*/ 0, NULL);
+    if (null_out_rc != 0) {
+        return 11;
+    }
+
     DSD_FPRINTF(stderr, "P25 IDEN variant checks passed\n");
     return 0;
 }

--- a/tests/protocol/p25/test_p25_lcw_src_zero_guard.c
+++ b/tests/protocol/p25/test_p25_lcw_src_zero_guard.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(misc-use-internal-linkage)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -21,6 +24,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -32,7 +36,20 @@
 
 struct RtlSdrContext;
 
+uint64_t ConvertBitIntoBytes(const uint8_t* BufferIn, uint32_t BitLength);
 void p25_lcw(dsd_opts* opts, dsd_state* state, uint8_t LCW_bits[], uint8_t irrecoverable_errors);
+
+static int g_nmea_harris_calls;
+static uint32_t g_nmea_harris_src;
+static uint16_t g_nmea_harris_prefix;
+static int g_apx_gps_calls;
+static int g_apx_alias_header_calls;
+static int g_apx_alias_block_calls;
+static int g_l3h_alias_block_calls;
+static int g_tait_alias_calls;
+static uint8_t g_last_alias_slot;
+static int16_t g_tait_alias_len;
+static uint16_t g_last_alias_prefix;
 
 /* ── Strong stubs (same set used by test_p25_lcw_call_term) ────────────── */
 
@@ -89,8 +106,9 @@ void
 apx_embedded_alias_header_phase1(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t* lc_bits) {
     (void)opts;
     (void)state;
-    (void)slot;
-    (void)lc_bits;
+    g_apx_alias_header_calls++;
+    g_last_alias_slot = slot;
+    g_last_alias_prefix = (uint16_t)ConvertBitIntoBytes(lc_bits, 16);
 }
 
 void
@@ -98,8 +116,9 @@ void
 apx_embedded_alias_blocks_phase1(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t* lc_bits) {
     (void)opts;
     (void)state;
-    (void)slot;
-    (void)lc_bits;
+    g_apx_alias_block_calls++;
+    g_last_alias_slot = slot;
+    g_last_alias_prefix = (uint16_t)ConvertBitIntoBytes(lc_bits, 16);
 }
 
 void
@@ -107,8 +126,9 @@ void
 l3h_embedded_alias_blocks_phase1(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t* lc_bits) {
     (void)opts;
     (void)state;
-    (void)slot;
-    (void)lc_bits;
+    g_l3h_alias_block_calls++;
+    g_last_alias_slot = slot;
+    g_last_alias_prefix = (uint16_t)ConvertBitIntoBytes(lc_bits, 16);
 }
 
 void
@@ -116,9 +136,10 @@ void
 tait_iso7_embedded_alias_decode(dsd_opts* opts, dsd_state* state, uint8_t slot, int16_t len, uint8_t* input) {
     (void)opts;
     (void)state;
-    (void)slot;
-    (void)len;
-    (void)input;
+    g_tait_alias_calls++;
+    g_last_alias_slot = slot;
+    g_tait_alias_len = len;
+    g_last_alias_prefix = (uint16_t)ConvertBitIntoBytes(input, 16);
 }
 
 void
@@ -126,7 +147,8 @@ void
 apx_embedded_gps(dsd_opts* opts, dsd_state* state, uint8_t* lc_bits) {
     (void)opts;
     (void)state;
-    (void)lc_bits;
+    g_apx_gps_calls++;
+    g_last_alias_prefix = (uint16_t)ConvertBitIntoBytes(lc_bits, 16);
 }
 
 void
@@ -134,8 +156,9 @@ void
 nmea_harris(dsd_opts* opts, dsd_state* state, uint8_t* input, uint32_t src, int slot) {
     (void)opts;
     (void)state;
-    (void)input;
-    (void)src;
+    g_nmea_harris_calls++;
+    g_nmea_harris_src = src;
+    g_nmea_harris_prefix = (uint16_t)ConvertBitIntoBytes(input, 16);
     (void)slot;
 }
 
@@ -181,6 +204,24 @@ main(void) {
     static dsd_opts opts;
     static dsd_state st;
     install_trunk_tuning_hooks();
+
+    /*
+     * Public guard returns must leave state untouched and tolerate NULL inputs.
+     */
+    {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&st, 0, sizeof st);
+        st.lastsrc = 0x13579B;
+
+        uint8_t lcw[96];
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+
+        p25_lcw(NULL, &st, lcw, /*irrecoverable_errors*/ 0);
+        p25_lcw(&opts, NULL, lcw, /*irrecoverable_errors*/ 0);
+        p25_lcw(&opts, &st, NULL, /*irrecoverable_errors*/ 0);
+
+        rc |= expect_true("NullGuards_preserve_state", st.lastsrc == 0x13579B);
+    }
 
     /*
      * Test case 1 — Format 0x00 (Group Voice Channel User)
@@ -353,9 +394,393 @@ main(void) {
         rc |= expect_true("TaitD8Fmt01_radio_24bit_at_bit48", st.lastsrc == 0x2468AC);
     }
 
+    /*
+     * Format 0x00 service options drive the user-visible call string prefix.
+     * Emergency takes priority over the encrypted bit when both are present.
+     */
+    {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&st, 0, sizeof st);
+        opts.payload = 1;
+
+        uint8_t lcw[96];
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x00);
+        set_bits_msb(lcw, 8, 8, 0x00);
+        set_bits_msb(lcw, 16, 8, 0xFF);
+        set_bits_msb(lcw, 32, 16, 0x1234);
+        set_bits_msb(lcw, 48, 24, 0x456789);
+
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+
+        rc |= expect_true("Fmt0x00_emergency_prefix", strstr(st.call_string[0], "Emergency") != NULL);
+        rc |= expect_true("Fmt0x00_emergency_group_state", st.gi[0] == 0 && st.lasttg == 0x1234);
+    }
+
+    /*
+     * Format 0x03 should mark an individual/private call and preserve the encrypted
+     * service option in the call string.
+     */
+    {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&st, 0, sizeof st);
+
+        uint8_t lcw[96];
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x03);
+        set_bits_msb(lcw, 8, 8, 0x00);
+        set_bits_msb(lcw, 16, 8, 0x40);
+        set_bits_msb(lcw, 24, 24, 0x010203);
+        set_bits_msb(lcw, 48, 24, 0x040506);
+
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+
+        rc |= expect_true("Fmt0x03_encrypted_private_prefix", strstr(st.call_string[0], "Encrypted") != NULL);
+        rc |= expect_true("Fmt0x03_private_state", st.gi[0] == 1 && st.lasttg == 0x010203 && st.lastsrc == 0x040506);
+    }
+
+    /*
+     * Format 0x42 carries two implicit group voice channel updates. When the two
+     * groups differ, both active-channel slots should be refreshed.
+     */
+    {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&st, 0, sizeof st);
+
+        uint8_t lcw[96];
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x42);
+        set_bits_msb(lcw, 8, 16, 0x1111);
+        set_bits_msb(lcw, 24, 16, 0x2222);
+        set_bits_msb(lcw, 40, 16, 0x3333);
+        set_bits_msb(lcw, 56, 16, 0x4444);
+
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+
+        rc |= expect_true("Fmt0x42_first_active_channel", strstr(st.active_channel[0], "1111") != NULL);
+        rc |= expect_true("Fmt0x42_second_active_channel", strstr(st.active_channel[1], "3333") != NULL);
+    }
+
+    /*
+     * Format 0x4A is an extended unit-to-unit voice channel user. It does not set
+     * source/target state today, but it must mark the call as individual.
+     */
+    {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&st, 0, sizeof st);
+
+        uint8_t lcw[96];
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x4A);
+        set_bits_msb(lcw, 8, 8, 0x00);
+        set_bits_msb(lcw, 16, 24, 0x101112);
+        set_bits_msb(lcw, 40, 24, 0x202122);
+
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+
+        rc |= expect_true("Fmt0x4A_sets_individual_flag", st.gi[0] == 1);
+    }
+
+    /*
+     * Format 0x50 updates affiliation/query context when both group and source
+     * are present.
+     */
+    {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&st, 0, sizeof st);
+
+        uint8_t lcw[96];
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x50);
+        set_bits_msb(lcw, 8, 8, 0x00);
+        set_bits_msb(lcw, 32, 16, 0x3456);
+        set_bits_msb(lcw, 48, 24, 0x654321);
+
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+
+        rc |= expect_true("Fmt0x50_group_affiliation_target", st.lasttg == 0x3456);
+        rc |= expect_true("Fmt0x50_group_affiliation_source", st.lastsrc == 0x654321);
+    }
+
+    /*
+     * Exercise the known protection ALGID map, including values that previously
+     * only appeared in display text. The persistent state must still record the
+     * exact ALGID/KID payload.
+     */
+    {
+        const uint8_t algids[] = {0x81, 0x82, 0x83, 0x84, 0x85, 0x88, 0x89, 0x9F, 0xAA, 0xAF};
+        for (size_t i = 0; i < sizeof(algids) / sizeof(algids[0]); i++) {
+            DSD_MEMSET(&opts, 0, sizeof opts);
+            DSD_MEMSET(&st, 0, sizeof st);
+
+            uint8_t lcw[96];
+            DSD_MEMSET(lcw, 0, sizeof lcw);
+            set_bits_msb(lcw, 0, 8, 0x65);
+            set_bits_msb(lcw, 8, 8, 0x00);
+            set_bits_msb(lcw, 24, 8, algids[i]);
+            set_bits_msb(lcw, 32, 16, (uint32_t)(0x1200U + i));
+            set_bits_msb(lcw, 48, 24, 0x010203);
+
+            p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+
+            rc |= expect_true("Fmt0x65_known_algid_valid", st.p25_prot_valid == 1);
+            rc |= expect_true("Fmt0x65_known_algid_value", st.p25_prot_algid == algids[i]);
+            rc |= expect_true("Fmt0x65_known_algid_kid", st.p25_prot_kid == (int)(0x1200U + i));
+        }
+    }
+
+    /*
+     * Unknown ALGIDs do not have a printable name, but the raw protection
+     * parameters are still meaningful decoder state.
+     */
+    {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&st, 0, sizeof st);
+
+        uint8_t lcw[96];
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x65);
+        set_bits_msb(lcw, 8, 8, 0x00);
+        set_bits_msb(lcw, 24, 8, 0x01);
+        set_bits_msb(lcw, 32, 16, 0xBEEF);
+        set_bits_msb(lcw, 48, 24, 0x010203);
+
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+
+        rc |= expect_true("Fmt0x65_unknown_algid_valid", st.p25_prot_valid == 1);
+        rc |= expect_true("Fmt0x65_unknown_algid_value", st.p25_prot_algid == 0x01);
+        rc |= expect_true("Fmt0x65_unknown_algid_kid", st.p25_prot_kid == 0xBEEF);
+    }
+
+    /*
+     * MFID90 regroup channel users update both current call state and the
+     * patch table. Set the rendering flag bits too so the parser keeps their
+     * positions distinct from SG/SRC fields.
+     */
+    {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&st, 0, sizeof st);
+
+        uint8_t lcw[96];
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x00);
+        set_bits_msb(lcw, 8, 8, 0x90);
+        lcw[16] = 1;
+        lcw[17] = 1;
+        lcw[31] = 1;
+        set_bits_msb(lcw, 32, 16, 0x345);
+        set_bits_msb(lcw, 48, 24, 0x6789AB);
+
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+
+        rc |= expect_true("MFID90_regroup_lasttg", st.lasttg == 0x345);
+        rc |= expect_true("MFID90_regroup_lastsrc", st.lastsrc == 0x6789AB);
+        rc |= expect_true("MFID90_regroup_group_call", st.gi[0] == 0);
+        rc |= expect_true("MFID90_regroup_patch_count", st.p25_patch_count == 1);
+        rc |= expect_true("MFID90_regroup_patch_sgid", st.p25_patch_sgid[0] == 0x345);
+        rc |= expect_true("MFID90_regroup_patch_active", st.p25_patch_is_patch[0] == 1 && st.p25_patch_active[0] == 1);
+    }
+
+    /*
+     * MFID90 regroup channel updates do not currently retain SG/channel state,
+     * but they must continue to mark the call as a group call.
+     */
+    {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&st, 0, sizeof st);
+        st.gi[0] = 1;
+
+        uint8_t lcw[96];
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x01);
+        set_bits_msb(lcw, 8, 8, 0x90);
+        lcw[16] = 1;
+        lcw[17] = 1;
+        set_bits_msb(lcw, 24, 16, 0x456);
+        set_bits_msb(lcw, 56, 16, 0x1234);
+
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+
+        rc |= expect_true("MFID90_regroup_update_group_call", st.gi[0] == 0);
+    }
+
+    /*
+     * Harris GPS is assembled from a block-1 prefix plus block-2 continuation.
+     * A valid prefix dispatches to the GPS decoder stub and then clears the
+     * scratch buffer; a missing block 1 only clears scratch state.
+     */
+    {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&st, 0, sizeof st);
+        g_nmea_harris_calls = 0;
+        g_nmea_harris_src = 0;
+        g_nmea_harris_prefix = 0;
+        st.lastsrc = 0x123456;
+
+        uint8_t lcw[96];
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x2A);
+        set_bits_msb(lcw, 8, 8, 0xA4);
+        set_bits_msb(lcw, 16, 8, 0x5A);
+        set_bits_msb(lcw, 40, 8, 0xC3);
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+        rc |= expect_true("HarrisGPS_block1_prefix", (uint16_t)ConvertBitIntoBytes(st.dmr_pdu_sf[0], 16) == 0x2AA4);
+        rc |= expect_true("HarrisGPS_block1_payload_copy", st.dmr_pdu_sf[0][40] == 0 && st.dmr_pdu_sf[0][41] == 1);
+
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x2B);
+        set_bits_msb(lcw, 8, 8, 0xA4);
+        set_bits_msb(lcw, 16, 8, 0x66);
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+        rc |= expect_true("HarrisGPS_valid_dispatch", g_nmea_harris_calls == 1);
+        rc |= expect_true("HarrisGPS_dispatch_src", g_nmea_harris_src == 0x123456);
+        rc |= expect_true("HarrisGPS_dispatch_prefix", g_nmea_harris_prefix == 0x2AA4);
+        rc |= expect_true("HarrisGPS_clears_scratch", st.dmr_pdu_sf[0][0] == 0 && st.dmr_pdu_sf[0][40] == 0);
+
+        DSD_MEMSET(st.dmr_pdu_sf[0], 1, sizeof(st.dmr_pdu_sf[0]));
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x2B);
+        set_bits_msb(lcw, 8, 8, 0xA4);
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+        rc |= expect_true("HarrisGPS_missing_block1_no_dispatch", g_nmea_harris_calls == 1);
+        rc |= expect_true("HarrisGPS_missing_block1_clears_scratch", st.dmr_pdu_sf[0][0] == 0);
+    }
+
+    /*
+     * Vendor LCW alias/GPS opcodes should delegate to their protocol-specific
+     * decoders with the raw LCW bits and voice slot 0, rather than only printing
+     * static labels.
+     */
+    {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&st, 0, sizeof st);
+        g_apx_gps_calls = 0;
+        g_apx_alias_header_calls = 0;
+        g_apx_alias_block_calls = 0;
+        g_l3h_alias_block_calls = 0;
+        g_tait_alias_calls = 0;
+        g_last_alias_slot = 0xFF;
+        g_tait_alias_len = 0;
+        g_last_alias_prefix = 0;
+
+        uint8_t lcw[96];
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x06);
+        set_bits_msb(lcw, 8, 8, 0x90);
+        set_bits_msb(lcw, 16, 8, 0xA1);
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+        rc |= expect_true("MFID90_GPS_dispatch", g_apx_gps_calls == 1);
+        rc |= expect_true("MFID90_GPS_prefix", g_last_alias_prefix == 0x0690);
+
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x15);
+        set_bits_msb(lcw, 8, 8, 0x90);
+        set_bits_msb(lcw, 16, 8, 0xB2);
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+        rc |= expect_true("MFID90_alias_header_dispatch", g_apx_alias_header_calls == 1);
+        rc |= expect_true("MFID90_alias_header_slot", g_last_alias_slot == 0);
+        rc |= expect_true("MFID90_alias_header_prefix", g_last_alias_prefix == 0x1590);
+
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x17);
+        set_bits_msb(lcw, 8, 8, 0x90);
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+        rc |= expect_true("MFID90_alias_block_dispatch", g_apx_alias_block_calls == 1);
+        rc |= expect_true("MFID90_alias_block_slot", g_last_alias_slot == 0);
+
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x32);
+        set_bits_msb(lcw, 8, 8, 0xA4);
+        set_bits_msb(lcw, 16, 8, 0xC3);
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+        rc |= expect_true("MFIDA4_alias_block_dispatch", g_l3h_alias_block_calls == 1);
+        rc |= expect_true("MFIDA4_alias_block_slot", g_last_alias_slot == 0);
+        rc |= expect_true("MFIDA4_alias_block_prefix", g_last_alias_prefix == 0x32A4);
+
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x00);
+        set_bits_msb(lcw, 8, 8, 0xD8);
+        set_bits_msb(lcw, 16, 8, 0xD4);
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+        rc |= expect_true("MFIDD8_tait_alias_dispatch", g_tait_alias_calls == 1);
+        rc |= expect_true("MFIDD8_tait_alias_slot", g_last_alias_slot == 0);
+        rc |= expect_true("MFIDD8_tait_alias_len", g_tait_alias_len == 8);
+        rc |= expect_true("MFIDD8_tait_alias_prefix", g_last_alias_prefix == 0x00D8);
+    }
+
+    /*
+     * Unknown and protected LCWs are tolerated as no-op control messages: they
+     * must not rewrite remembered call state or invoke vendor payload decoders.
+     */
+    {
+        static const struct {
+            const char* name;
+            uint8_t format;
+            uint8_t mfid;
+        } unknown_cases[] = {
+            {"UnknownStandard_no_state_mutation", 0x30, 0x00}, {"UnknownMoto_no_state_mutation", 0x30, 0x90},
+            {"UnknownHarris_no_state_mutation", 0x30, 0xA4},   {"UnknownTait_no_state_mutation", 0x30, 0xD8},
+            {"UnknownVendor_no_state_mutation", 0x30, 0x7F},
+        };
+
+        for (size_t i = 0; i < sizeof(unknown_cases) / sizeof(unknown_cases[0]); i++) {
+            DSD_MEMSET(&opts, 0, sizeof opts);
+            DSD_MEMSET(&st, 0, sizeof st);
+            st.lastsrc = 0x123456;
+            st.lasttg = 0x3456;
+            st.gi[0] = 1;
+            st.p25_prot_valid = 1;
+            st.p25_prot_algid = 0x84;
+            st.p25_prot_kid = 0x4321;
+            g_apx_gps_calls = 0;
+            g_apx_alias_header_calls = 0;
+            g_apx_alias_block_calls = 0;
+            g_l3h_alias_block_calls = 0;
+            g_tait_alias_calls = 0;
+
+            uint8_t lcw[96];
+            DSD_MEMSET(lcw, 0, sizeof lcw);
+            set_bits_msb(lcw, 0, 8, unknown_cases[i].format);
+            set_bits_msb(lcw, 8, 8, unknown_cases[i].mfid);
+            set_bits_msb(lcw, 16, 8, 0xFF);
+            set_bits_msb(lcw, 48, 24, 0x654321);
+
+            p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+
+            rc |= expect_true(unknown_cases[i].name,
+                              st.lastsrc == 0x123456 && st.lasttg == 0x3456 && st.gi[0] == 1 && st.p25_prot_valid == 1
+                                  && st.p25_prot_algid == 0x84 && st.p25_prot_kid == 0x4321 && g_apx_gps_calls == 0
+                                  && g_apx_alias_header_calls == 0 && g_apx_alias_block_calls == 0
+                                  && g_l3h_alias_block_calls == 0 && g_tait_alias_calls == 0);
+        }
+    }
+
+    {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&st, 0, sizeof st);
+        st.lastsrc = 0x234567;
+        st.lasttg = 0x4567;
+        st.gi[0] = 1;
+        st.p25_prot_valid = 0;
+
+        uint8_t lcw[96];
+        DSD_MEMSET(lcw, 0, sizeof lcw);
+        set_bits_msb(lcw, 0, 8, 0x80);
+        set_bits_msb(lcw, 8, 8, 0x00);
+        set_bits_msb(lcw, 16, 8, 0xFF);
+        set_bits_msb(lcw, 32, 16, 0x1234);
+        set_bits_msb(lcw, 48, 24, 0x654321);
+
+        p25_lcw(&opts, &st, lcw, /*irrecoverable_errors*/ 0);
+
+        rc |= expect_true("ProtectedLCW_no_state_mutation",
+                          st.lastsrc == 0x234567 && st.lasttg == 0x4567 && st.gi[0] == 1 && st.p25_prot_valid == 0);
+    }
+
     return rc;
 }
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic pop
 #endif
+// NOLINTEND(misc-use-internal-linkage)

--- a/tests/protocol/p25/test_p25_mbt_adj_rfss.c
+++ b/tests/protocol/p25/test_p25_mbt_adj_rfss.c
@@ -324,6 +324,34 @@ main(void) {
         rc |= expect_eq_long("ambtc_0x3e_sysid_unchanged", sid, 0);
     }
 
+    {
+        uint8_t mbt[48];
+        DSD_MEMSET(mbt, 0, sizeof(mbt));
+        long cc = 111, w = 222;
+        int sid = 333;
+        int sh = p25_test_decode_mbt_with_iden(mbt, (int)sizeof(mbt), /*iden*/ -1, type, tdma, base5, spac125, &cc, &w,
+                                               &sid);
+        rc |= expect_eq_long("invalid iden rejected", sh, -2);
+        rc |= expect_eq_long("invalid iden preserves cc", cc, 111);
+        rc |= expect_eq_long("invalid iden preserves wacn", w, 222);
+        rc |= expect_eq_long("invalid iden preserves sysid", sid, 333);
+    }
+
+    {
+        uint8_t mbt[48];
+        DSD_MEMSET(mbt, 0, sizeof(mbt));
+        long cc = 444;
+        int nb_count = 555;
+        long nb_freqs[P25_NB_MAX];
+        DSD_MEMSET(nb_freqs, 0x7F, sizeof(nb_freqs));
+        p25_test_iden_config bad_cfg = {/*iden*/ 16, type, tdma, base5, spac125};
+        p25_test_mbt_outputs outputs = {&cc, NULL, NULL, &nb_count, nb_freqs};
+        int sh = p25_test_decode_mbt_with_iden_nb(mbt, (int)sizeof(mbt), &bad_cfg, &outputs);
+        rc |= expect_eq_long("invalid nb iden rejected", sh, -2);
+        rc |= expect_eq_long("invalid nb iden preserves cc", cc, 444);
+        rc |= expect_eq_long("invalid nb iden preserves count", nb_count, 555);
+    }
+
     return rc;
 }
 

--- a/tests/protocol/p25/test_p25_p1_hdu_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_hdu_helpers.c
@@ -1,0 +1,724 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result,bugprone-suspicious-include)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * P25 P1 HDU helper tests: verify the deterministic field packing and
+ * soft-decision RS reliability ordering used before HDU decode side effects.
+ */
+
+#include <dsd-neo/protocol/p25/p25p1_soft.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/dibit.h"
+#include "dsd-neo/core/opts.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/core/talkgroup_policy.h"
+#include "dsd-neo/platform/timing.h"
+#include "dsd-neo/protocol/p25/p25_lfsr.h"
+#include "dsd-neo/protocol/p25/p25_status_symbol.h"
+#include "dsd-neo/protocol/p25/p25_trunk_sm.h"
+#include "dsd-neo/protocol/p25/p25p1_check_hdu.h"
+#include "dsd-neo/runtime/p25_optional_hooks.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+uint8_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25p1_llr_reliability(const int16_t* llr, int bit_count) {
+    if (llr == NULL || bit_count <= 0) {
+        return 0;
+    }
+
+    int min_reliability = 255;
+    for (int i = 0; i < bit_count; i++) {
+        int reliab = llr[i] < 0 ? -(int)llr[i] : (int)llr[i];
+        if (reliab > 255) {
+            reliab = 255;
+        }
+        if (reliab < min_reliability) {
+            min_reliability = reliab;
+        }
+    }
+    return (uint8_t)min_reliability;
+}
+
+uint64_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ConvertBitIntoBytes(const uint8_t* BufferIn, uint32_t BitLength) {
+    uint64_t out = 0;
+    for (uint32_t i = 0; i < BitLength; i++) {
+        out = (out << 1U) | (uint64_t)(BufferIn[i] & 1U);
+    }
+    return out;
+}
+
+#include "../../../src/protocol/p25/phase1/p25p1_hdu.c"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif
+
+static int g_lfsr128_calls;
+static int g_release_calls;
+static int g_watchdog_calls;
+static int g_write_event_calls;
+static int g_push_event_calls;
+static int g_init_event_calls;
+static int g_policy_make_calls;
+static int g_policy_upsert_calls;
+static uint32_t g_last_policy_id;
+static uint8_t g_last_policy_source;
+static dsd_tg_policy_upsert_mode g_last_policy_upsert_mode;
+static const char* g_lookup_label;
+static Event_History_I g_event_history[2];
+static int g_hard_golay_fixed;
+static int g_hard_golay_result;
+static int g_soft_golay_fixed;
+static int g_soft_golay_result;
+static char g_soft_golay_hex[6];
+static char g_soft_golay_parity[12];
+static int g_rs_hard_result;
+static int g_rs_soft_result;
+static int g_soft_input_count;
+static int g_soft_input_index;
+static int g_soft_dibits[400];
+static dsd_dibit_soft_t g_soft_values[400];
+static int g_status_accum_count;
+static int g_status_values[16];
+
+static void
+reset_soft_inputs(void) {
+    g_soft_input_count = 0;
+    g_soft_input_index = 0;
+    DSD_MEMSET(g_soft_dibits, 0, sizeof(g_soft_dibits));
+    DSD_MEMSET(g_soft_values, 0, sizeof(g_soft_values));
+    g_status_accum_count = 0;
+    DSD_MEMSET(g_status_values, 0, sizeof(g_status_values));
+}
+
+static void
+append_soft_input(int dibit, uint8_t reliability, int16_t llr0, int16_t llr1) {
+    if (g_soft_input_count >= (int)(sizeof(g_soft_dibits) / sizeof(g_soft_dibits[0]))) {
+        return;
+    }
+    g_soft_dibits[g_soft_input_count] = dibit & 0x03;
+    g_soft_values[g_soft_input_count].reliability = reliability;
+    g_soft_values[g_soft_input_count].llr[0] = llr0;
+    g_soft_values[g_soft_input_count].llr[1] = llr1;
+    g_soft_input_count++;
+}
+
+int
+getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
+    (void)opts;
+    (void)state;
+    if (g_soft_input_index >= g_soft_input_count) {
+        if (out_soft != NULL) {
+            DSD_MEMSET(out_soft, 0, sizeof(*out_soft));
+        }
+        return 0;
+    }
+    if (out_soft != NULL) {
+        *out_soft = g_soft_values[g_soft_input_index];
+    }
+    return g_soft_dibits[g_soft_input_index++];
+}
+
+void
+p25_status_accum_add(dsd_state* state, int dibit_value) {
+    (void)state;
+    g_status_values[g_status_accum_count++] = dibit_value & 0x03;
+}
+
+void
+p25_status_accum_ensure_started(dsd_state* state) {
+    (void)state;
+}
+
+void
+p25_status_accum_classify(dsd_state* state, const dsd_opts* opts) {
+    (void)state;
+    (void)opts;
+}
+
+uint64_t
+dsd_time_monotonic_ns(void) {
+    return 123456789000ULL;
+}
+
+int
+check_and_fix_golay_24_6(char* hex, const char* parity, int* fixed_errors) {
+    (void)hex;
+    (void)parity;
+    if (fixed_errors != NULL) {
+        *fixed_errors = g_hard_golay_fixed;
+    }
+    return g_hard_golay_result;
+}
+
+int
+check_and_fix_golay_24_6_soft(char* data, const char* parity, const int* reliab, int* fixed) {
+    (void)reliab;
+    if (fixed != NULL) {
+        *fixed = g_soft_golay_fixed;
+    }
+    if (g_soft_golay_result == 0) {
+        DSD_MEMCPY(data, g_soft_golay_hex, sizeof(g_soft_golay_hex));
+        DSD_MEMCPY((char*)parity, g_soft_golay_parity, sizeof(g_soft_golay_parity));
+    }
+    return g_soft_golay_result;
+}
+
+int
+check_and_fix_redsolomon_36_20_17(char* data, const char* parity) {
+    (void)data;
+    (void)parity;
+    return g_rs_hard_result;
+}
+
+int
+p25p1_rs_36_20_17_soft_reliability(char* data, const char* parity, const uint8_t* data_reliab,
+                                   const uint8_t* parity_reliab) {
+    (void)data;
+    (void)parity;
+    (void)data_reliab;
+    (void)parity_reliab;
+    return g_rs_soft_result;
+}
+
+void
+LFSR128(dsd_state* state) {
+    (void)state;
+    g_lfsr128_calls++;
+}
+
+void
+p25_sm_on_release(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_release_calls++;
+}
+
+int
+dsd_tg_policy_lookup_label(const dsd_state* state, uint32_t id, char* mode, size_t mode_sz, char* name,
+                           size_t name_sz) {
+    (void)state;
+    (void)id;
+    if (g_lookup_label == NULL) {
+        return 0;
+    }
+    if (mode != NULL && mode_sz > 0U) {
+        (void)DSD_SNPRINTF(mode, mode_sz, "%s", "DE");
+    }
+    if (name != NULL && name_sz > 0U) {
+        (void)DSD_SNPRINTF(name, name_sz, "%s", g_lookup_label);
+    }
+    return 1;
+}
+
+int
+dsd_tg_policy_make_exact_entry(uint32_t id, const char* mode, const char* name, dsd_tg_policy_entry_source source,
+                               dsd_tg_policy_entry* out) {
+    g_policy_make_calls++;
+    if (out == NULL) {
+        return -1;
+    }
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->id_start = id;
+    out->id_end = id;
+    out->source = (uint8_t)source;
+    (void)DSD_SNPRINTF(out->mode, sizeof(out->mode), "%s", mode != NULL ? mode : "");
+    (void)DSD_SNPRINTF(out->name, sizeof(out->name), "%s", name != NULL ? name : "");
+    return 0;
+}
+
+int
+dsd_tg_policy_upsert_exact(dsd_state* state, const dsd_tg_policy_entry* entry, dsd_tg_policy_upsert_mode mode) {
+    (void)state;
+    g_policy_upsert_calls++;
+    g_last_policy_upsert_mode = mode;
+    if (entry != NULL) {
+        g_last_policy_id = entry->id_start;
+        g_last_policy_source = entry->source;
+    }
+    return 0;
+}
+
+void
+dsd_p25_optional_hook_watchdog_event_current(dsd_opts* opts, dsd_state* state, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    g_watchdog_calls++;
+}
+
+void
+dsd_p25_optional_hook_write_event_to_log_file(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite,
+                                              char* event_string) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)swrite;
+    (void)event_string;
+    g_write_event_calls++;
+}
+
+void
+dsd_p25_optional_hook_push_event_history(Event_History_I* event_struct) {
+    (void)event_struct;
+    g_push_event_calls++;
+}
+
+void
+dsd_p25_optional_hook_init_event_history(Event_History_I* event_struct, uint8_t start, uint8_t stop) {
+    (void)event_struct;
+    (void)start;
+    (void)stop;
+    g_init_event_calls++;
+}
+
+static void
+reset_hook_counters(void) {
+    g_lfsr128_calls = 0;
+    g_release_calls = 0;
+    g_watchdog_calls = 0;
+    g_write_event_calls = 0;
+    g_push_event_calls = 0;
+    g_init_event_calls = 0;
+    g_policy_make_calls = 0;
+    g_policy_upsert_calls = 0;
+    g_last_policy_id = 0U;
+    g_last_policy_source = 0U;
+    g_last_policy_upsert_mode = 0;
+    g_lookup_label = NULL;
+}
+
+static void
+reset_fec_stubs(void) {
+    g_hard_golay_fixed = 0;
+    g_hard_golay_result = 0;
+    g_soft_golay_fixed = 0;
+    g_soft_golay_result = 1;
+    DSD_MEMSET(g_soft_golay_hex, 0, sizeof(g_soft_golay_hex));
+    DSD_MEMSET(g_soft_golay_parity, 0, sizeof(g_soft_golay_parity));
+    g_rs_hard_result = 0;
+    g_rs_soft_result = 1;
+}
+
+static void
+put_bits(char dst[6], const char* bits) {
+    for (int i = 0; i < 6; i++) {
+        dst[i] = (char)(bits[i] == '1');
+    }
+}
+
+static int
+expect_string(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got \"%s\" want \"%s\"\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u8(const char* tag, uint8_t got, uint8_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %u want %u\n", tag, (unsigned int)got, (unsigned int)want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u64(const char* tag, unsigned long long got, unsigned long long want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %llu want %llu\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_hdu_extracts_payload_fields(void) {
+    char hex_data[20][6] = {{0}};
+    uint8_t mi[73];
+    char algid[9];
+    char kid[17];
+
+    put_bits(hex_data[19], "100001");
+    put_bits(hex_data[18], "010010");
+    put_bits(hex_data[17], "110011");
+    put_bits(hex_data[16], "001100");
+    put_bits(hex_data[15], "101101");
+    put_bits(hex_data[14], "011110");
+    put_bits(hex_data[13], "111000");
+    put_bits(hex_data[12], "000111");
+    put_bits(hex_data[11], "101010");
+    put_bits(hex_data[10], "010101");
+    put_bits(hex_data[9], "111111");
+    put_bits(hex_data[8], "000000");
+    put_bits(hex_data[7], "001011");
+    put_bits(hex_data[6], "101100");
+    put_bits(hex_data[5], "011001");
+    put_bits(hex_data[4], "110010");
+    put_bits(hex_data[3], "001101");
+    put_bits(hex_data[2], "100000");
+
+    hdu_extract_mi_algid_kid((const char (*)[6])hex_data, mi, algid, kid);
+
+    int rc = 0;
+    rc |= expect_string("MI", (const char*)mi,
+                        "100001010010110011001100101101011110111000000111101010010101111111000000");
+    rc |= expect_string("ALGID", algid, "11000110");
+    rc |= expect_string("KID", kid, "0111001000110110");
+    return rc;
+}
+
+static void
+set_symbol_reliability(P25P1SoftDibit* symbol, int minimum_reliability) {
+    symbol[0].llr[0] = (int16_t)(minimum_reliability + 6);
+    symbol[0].llr[1] = (int16_t)-(minimum_reliability + 5);
+    symbol[1].llr[0] = (int16_t)(minimum_reliability + 4);
+    symbol[1].llr[1] = (int16_t)-(minimum_reliability + 3);
+    symbol[2].llr[0] = (int16_t)(minimum_reliability + 2);
+    symbol[2].llr[1] = (int16_t)minimum_reliability;
+}
+
+static int
+test_hdu_rs_reliability_uses_wire_order(void) {
+    P25P1SoftDibit soft_dibits[20 * (3 + 6) + 16 * (3 + 6)] = {0};
+    uint8_t data_reliab[20] = {0};
+    uint8_t parity_reliab[16] = {0};
+
+    for (int wire_symbol = 0; wire_symbol < 20; wire_symbol++) {
+        set_symbol_reliability(&soft_dibits[wire_symbol * (3 + 6)], 20 + wire_symbol);
+    }
+    for (int wire_symbol = 0; wire_symbol < 16; wire_symbol++) {
+        set_symbol_reliability(&soft_dibits[(20 * (3 + 6)) + (wire_symbol * (3 + 6))], 80 + wire_symbol);
+    }
+
+    build_hdu_rs_reliability(soft_dibits, data_reliab, parity_reliab);
+
+    int rc = 0;
+    rc |= expect_u8("data[0] reliability", data_reliab[0], 39);
+    rc |= expect_u8("data[19] reliability", data_reliab[19], 20);
+    rc |= expect_u8("parity[0] reliability", parity_reliab[0], 95);
+    rc |= expect_u8("parity[15] reliability", parity_reliab[15], 80);
+    return rc;
+}
+
+static int
+test_soft_abs_i16_handles_negative_and_saturated_inputs(void) {
+    int rc = 0;
+    if (soft_abs_i16((int16_t)-123) != 123) {
+        DSD_FPRINTF(stderr, "negative soft abs mismatch\n");
+        rc = 1;
+    }
+    if (soft_abs_i16((int16_t)0) != 0) {
+        DSD_FPRINTF(stderr, "zero soft abs mismatch\n");
+        rc = 1;
+    }
+    if (soft_abs_i16((int16_t)-32768) != 32768) {
+        DSD_FPRINTF(stderr, "int16 minimum soft abs mismatch\n");
+        rc = 1;
+    }
+    return rc;
+}
+
+static int
+test_hdu_soft_dibit_reader_contracts(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    char out[4] = {0};
+    P25P1SoftDibit soft_dibit;
+    P25P1SoftDibit soft_dibits[4];
+    int status_count;
+    int soft_dibit_index;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&soft_dibit, 0, sizeof(soft_dibit));
+    reset_soft_inputs();
+    append_soft_input(3, 70U, 7, -8);
+    append_soft_input(2, 44U, -5, 6);
+    status_count = 35;
+
+    int dibit = read_dibit_soft(&opts, &state, out, &status_count, &soft_dibit);
+    rc |= expect_int("status-boundary-data-dibit", dibit, 2);
+    rc |= expect_int("status-boundary-output-msb", out[0], 1);
+    rc |= expect_int("status-boundary-output-lsb", out[1], 0);
+    rc |= expect_int("status-boundary-counter-reset", status_count, 1);
+    rc |= expect_int("status-boundary-symbol-recorded", g_status_accum_count, 1);
+    rc |= expect_int("status-boundary-symbol-value", g_status_values[0], 3);
+    rc |= expect_int("status-boundary-soft-index", g_soft_input_index, 2);
+    rc |= expect_u8("status-boundary-reliability", soft_dibit.reliab, 44U);
+    rc |= expect_int("status-boundary-llr0", soft_dibit.llr[0], -5);
+    rc |= expect_int("status-boundary-llr1", soft_dibit.llr[1], 6);
+
+    reset_soft_inputs();
+    append_soft_input(2, 30U, 11, -12);
+    append_soft_input(1, 31U, 13, -14);
+    DSD_MEMSET(out, 0, sizeof(out));
+    DSD_MEMSET(soft_dibits, 0, sizeof(soft_dibits));
+    status_count = 33;
+    soft_dibit_index = 0;
+
+    read_dibit_update_soft_data(&opts, &state, out, 4U, &status_count, soft_dibits, &soft_dibit_index);
+    rc |= expect_int("update-output-0", out[0], 1);
+    rc |= expect_int("update-output-1", out[1], 0);
+    rc |= expect_int("update-output-2", out[2], 0);
+    rc |= expect_int("update-output-3", out[3], 1);
+    rc |= expect_int("update-no-status-before-boundary", g_status_accum_count, 0);
+    rc |= expect_int("update-status-counter", status_count, 35);
+    rc |= expect_int("update-soft-count", soft_dibit_index, 2);
+    rc |= expect_u8("update-soft0-reliability", soft_dibits[0].reliab, 30U);
+    rc |= expect_u8("update-soft1-reliability", soft_dibits[1].reliab, 31U);
+
+    reset_soft_inputs();
+    for (int i = 0; i < 5; i++) {
+        append_soft_input(i & 0x03, (uint8_t)(50 + i), (int16_t)i, (int16_t)-i);
+    }
+    append_soft_input(2, 90U, 21, -22);
+
+    hdu_consume_trailing_dibits_and_status(&opts, &state);
+    rc |= expect_int("trailing-consume-count", g_soft_input_index, 6);
+    rc |= expect_int("trailing-status-count", g_status_accum_count, 1);
+    rc |= expect_int("trailing-status-value", g_status_values[0], 2);
+
+    return rc;
+}
+
+static int
+test_hdu_fec_helpers_account_for_hard_soft_and_failed_corrections(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    char hex[6] = {1, 0, 1, 0, 1, 0};
+    char parity[12] = {0};
+    P25P1SoftDibit soft_dibits[9];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(soft_dibits, 0, sizeof(soft_dibits));
+    for (int i = 0; i < 9; i++) {
+        soft_dibits[i].llr[0] = (int16_t)(i + 10);
+        soft_dibits[i].llr[1] = (int16_t)-(i + 20);
+    }
+
+    reset_fec_stubs();
+    g_hard_golay_fixed = 2;
+    correct_hex_word(&opts, &state, hex, parity, NULL);
+    rc |= expect_int("hard golay fixed errors counted", state.debug_header_errors, 2);
+    rc |= expect_int("hard golay no critical error", state.debug_header_critical_errors, 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_fec_stubs();
+    g_hard_golay_result = 1;
+    g_soft_golay_result = 0;
+    g_soft_golay_fixed = 3;
+    put_bits(g_soft_golay_hex, "010101");
+    for (int i = 0; i < 12; i++) {
+        g_soft_golay_parity[i] = (char)(i & 1);
+    }
+    correct_hex_word(&opts, &state, hex, parity, soft_dibits);
+    rc |= expect_int("soft golay success count", (int)state.p25_p1_soft_golay_ok, 1);
+    rc |= expect_int("soft golay fixed errors counted", state.debug_header_errors, 3);
+    rc |= expect_int("soft golay avoids critical", state.debug_header_critical_errors, 0);
+    rc |= expect_int("soft golay replaces hex bit", hex[0], 0);
+    rc |= expect_int("soft golay replaces parity bit", parity[1], 1);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_fec_stubs();
+    g_hard_golay_result = 1;
+    g_soft_golay_result = 1;
+    correct_hex_word(&opts, &state, hex, parity, soft_dibits);
+    rc |= expect_int("golay failure critical", state.debug_header_critical_errors, 1);
+
+    return rc;
+}
+
+static int
+test_hdu_read_and_fec_updates_rs_success_soft_success_and_failure_state(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    char hex_data[20][6];
+    char hex_parity[16][6];
+    P25P1SoftDibit soft_dibits[20 * (3 + 6) + 16 * (3 + 6)];
+    int status_count;
+    int soft_dibit_index;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(hex_data, 0, sizeof(hex_data));
+    DSD_MEMSET(hex_parity, 0, sizeof(hex_parity));
+    DSD_MEMSET(soft_dibits, 0, sizeof(soft_dibits));
+    reset_soft_inputs();
+    reset_fec_stubs();
+    status_count = 21;
+    soft_dibit_index = 0;
+
+    rc |= expect_int(
+        "hdu rs hard success",
+        hdu_read_and_fec(&opts, &state, hex_data, hex_parity, soft_dibits, &status_count, &soft_dibit_index), 0);
+    rc |= expect_int("hdu rs hard fec ok", (int)state.p25_p1_voice_fec_ok, 1);
+    rc |= expect_int("hdu rs hard fec err", (int)state.p25_p1_voice_fec_err, 0);
+    rc |= expect_int("hdu rs hard soft count", (int)state.p25_p1_soft_rs_ok, 0);
+    rc |= expect_int("hdu rs hard collected soft dibits", soft_dibit_index, 324);
+    rc |= expect_int("hdu rs hard sync time set", state.last_vc_sync_time != 0, 1);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_soft_inputs();
+    reset_fec_stubs();
+    g_rs_hard_result = 1;
+    g_rs_soft_result = 0;
+    status_count = 21;
+    soft_dibit_index = 0;
+    rc |= expect_int(
+        "hdu rs soft success",
+        hdu_read_and_fec(&opts, &state, hex_data, hex_parity, soft_dibits, &status_count, &soft_dibit_index), 0);
+    rc |= expect_int("hdu rs soft fec ok", (int)state.p25_p1_voice_fec_ok, 1);
+    rc |= expect_int("hdu rs soft count", (int)state.p25_p1_soft_rs_ok, 1);
+    rc |= expect_int("hdu rs soft no critical", state.debug_header_critical_errors, 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_soft_inputs();
+    reset_fec_stubs();
+    g_rs_hard_result = 1;
+    g_rs_soft_result = 1;
+    status_count = 21;
+    soft_dibit_index = 0;
+    rc |= expect_int(
+        "hdu rs failure result",
+        hdu_read_and_fec(&opts, &state, hex_data, hex_parity, soft_dibits, &status_count, &soft_dibit_index), 1);
+    rc |= expect_int("hdu rs failure fec err", (int)state.p25_p1_voice_fec_err, 1);
+    rc |= expect_int("hdu rs failure critical", state.debug_header_critical_errors, 1);
+    rc |= expect_int("hdu rs failure no fec ok", (int)state.p25_p1_voice_fec_ok, 0);
+
+    return rc;
+}
+
+static int
+test_hdu_unmute_policy_and_good_decode_state(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.payload_algid = 0xAA;
+    state.R = 0x12345U;
+    hdu_apply_unmute_policy(&opts, &state);
+    rc |= expect_int("rc4 key unmutes encrypted p25", opts.unmute_encrypted_p25, 1);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.unmute_encrypted_p25 = 1;
+    state.payload_algid = 0xAA;
+    hdu_apply_unmute_policy(&opts, &state);
+    rc |= expect_int("missing rc4 key mutes encrypted p25", opts.unmute_encrypted_p25, 0);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.payload_algid = 0x84;
+    state.aes_key_loaded[0] = 1;
+    state.A1[0] = 0x1111111111111111ULL;
+    state.A2[0] = 0x2222222222222222ULL;
+    state.A3[0] = 0x3333333333333333ULL;
+    state.A4[0] = 0x4444444444444444ULL;
+    hdu_apply_unmute_policy(&opts, &state);
+    rc |= expect_int("aes key unmutes encrypted p25", opts.unmute_encrypted_p25, 1);
+
+    reset_hook_counters();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.aes_key_loaded[0] = 1;
+    hdu_handle_good_decode(&opts, &state, 0x84, 0x1234, 0x01020304ULL, 0x05060708ULL, 0x09ULL);
+    rc |= expect_int("good hdu algid", state.payload_algid, 0x84);
+    rc |= expect_int("good hdu kid", state.payload_keyid, 0x1234);
+    rc |= expect_u64("good hdu mi", state.payload_miP, 0x0102030405060708ULL);
+    rc |= expect_int("good hdu xl flag", state.xl_is_hdu, 1);
+    rc |= expect_int("good hdu aes lfsr", g_lfsr128_calls, 1);
+    rc |= expect_int("good hdu no lockout release", g_release_calls, 0);
+
+    return rc;
+}
+
+static int
+test_hdu_encrypted_trunk_lockout_state(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset_hook_counters();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(g_event_history, 0, sizeof(g_event_history));
+    state.event_history_s = g_event_history;
+    opts.p25_trunk = 1;
+    opts.p25_is_tuned = 1;
+    DSD_SNPRINTF(opts.event_out_file, sizeof(opts.event_out_file), "%s", "events.log");
+    state.lasttg = 1234;
+    g_lookup_label = "Secure TG";
+
+    hdu_handle_good_decode(&opts, &state, 0xAA, 0x2A2A, 0xAABBCCDDULL, 0x10203040ULL, 0ULL);
+
+    rc |= expect_int("lockout clears algid", state.payload_algid, 0);
+    rc |= expect_int("lockout clears kid", state.payload_keyid, 0);
+    rc |= expect_u64("lockout clears mi", state.payload_miP, 0ULL);
+    rc |= expect_int("lockout force release", state.p25_sm_force_release, 1);
+    rc |= expect_int("lockout release hook", g_release_calls, 1);
+    rc |= expect_int("lockout policy make", g_policy_make_calls, 1);
+    rc |= expect_int("lockout policy upsert", g_policy_upsert_calls, 1);
+    rc |= expect_int("lockout policy id", (int)g_last_policy_id, 1234);
+    rc |= expect_int("lockout policy source", (int)g_last_policy_source, DSD_TG_POLICY_SOURCE_ENC_LOCKOUT);
+    rc |= expect_int("lockout policy mode", (int)g_last_policy_upsert_mode, DSD_TG_POLICY_UPSERT_REPLACE_FIRST);
+    rc |= expect_int("lockout watchdog", g_watchdog_calls, 1);
+    rc |= expect_int("lockout event write", g_write_event_calls, 1);
+    rc |= expect_int("lockout event push", g_push_event_calls, 1);
+    rc |= expect_int("lockout event init", g_init_event_calls, 1);
+    rc |= expect_int("lockout call string cleared", state.call_string[0][0] == ' ', 1);
+
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    reset_fec_stubs();
+    rc |= test_hdu_extracts_payload_fields();
+    rc |= test_hdu_rs_reliability_uses_wire_order();
+    rc |= test_soft_abs_i16_handles_negative_and_saturated_inputs();
+    rc |= test_hdu_soft_dibit_reader_contracts();
+    rc |= test_hdu_fec_helpers_account_for_hard_soft_and_failed_corrections();
+    rc |= test_hdu_read_and_fec_updates_rs_success_soft_success_and_failure_state();
+    rc |= test_hdu_unmute_policy_and_good_decode_state();
+    rc |= test_hdu_encrypted_trunk_lockout_state();
+    return rc;
+}
+
+// NOLINTEND(bugprone-implicit-widening-of-multiplication-result,bugprone-suspicious-include)

--- a/tests/protocol/p25/test_p25_p1_lcw_gating.c
+++ b/tests/protocol/p25/test_p25_p1_lcw_gating.c
@@ -206,6 +206,32 @@ main(void) {
     p25_lcw(&opts, &st, lcw, 0);
     rc |= expect_eq_int("clear->tune", g_tunes, 1);
 
+    // Trunking disabled: a decoded 0x44 grant may update display state, but it
+    // must not be treated as a trunking grant.
+    opts.p25_trunk = 0;
+    g_tunes = 0;
+    p25_lcw(&opts, &st, lcw, 0);
+    rc |= expect_eq_int("no trunk->no-tune", g_tunes, 0);
+    opts.p25_trunk = 1;
+
+    // Retune disabled should warn only once and never dispatch a grant.
+    opts.p25_lcw_retune = 0;
+    st.p25_lcw_retune_disabled_warned = 0;
+    g_tunes = 0;
+    p25_lcw(&opts, &st, lcw, 0);
+    rc |= expect_eq_int("retune disabled no tune", g_tunes, 0);
+    rc |= expect_eq_int("retune disabled warned", st.p25_lcw_retune_disabled_warned, 1);
+    p25_lcw(&opts, &st, lcw, 0);
+    rc |= expect_eq_int("retune disabled warned once", st.p25_lcw_retune_disabled_warned, 1);
+    opts.p25_lcw_retune = 1;
+
+    // TG hold mismatch suppresses an otherwise tunable group grant.
+    st.tg_hold = tg + 1;
+    g_tunes = 0;
+    p25_lcw(&opts, &st, lcw, 0);
+    rc |= expect_eq_int("tg hold mismatch no tune", g_tunes, 0);
+    st.tg_hold = 0;
+
     // Failed-VC backoff must also apply to LCW 0x44 explicit grants.
     st.p25_retune_block_freq = 851125000;
     st.p25_retune_block_slot = -1;

--- a/tests/protocol/p25/test_p25_p1_ldu1_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_ldu1_helpers.c
@@ -1,0 +1,726 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result,bugprone-suspicious-include)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * P25 P1 LDU1 helper tests: verify deterministic LCW/LSD field packing and
+ * soft-decision RS reliability ordering independent of live IMBE collection.
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/platform/timing.h>
+#include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <dsd-neo/protocol/p25/p25_lcw.h>
+#include <dsd-neo/protocol/p25/p25p1_check_ldu.h>
+#include <dsd-neo/protocol/p25/p25p1_ldu.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "dsd-neo/core/dibit.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/protocol/p25/p25_status_symbol.h"
+#include "dsd-neo/protocol/p25/p25p1_soft.h"
+
+#define SOFTID 1
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+static int g_hard_rs_result;
+static int g_soft_rs_result;
+static int g_lsd_soft_result = 1;
+static int g_lcw_calls;
+static int g_policy_make_calls;
+static int g_policy_upsert_calls;
+static int g_soft_dibit_value;
+static int g_get_dibit_soft_calls;
+static int g_read_dibit_soft_calls;
+static int g_read_dibit_soft_values[16];
+static int g_status_add_calls;
+static int g_status_classify_calls;
+static int g_last_status_dibit;
+static const dsd_opts* g_last_classify_opts;
+static uint32_t g_last_policy_id;
+static uint8_t g_last_policy_source;
+static dsd_tg_policy_upsert_mode g_last_policy_upsert_mode;
+static char g_last_policy_mode[8];
+static char g_last_policy_name[32];
+
+uint64_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ConvertBitIntoBytes(const uint8_t* BufferIn, uint32_t BitLength) {
+    uint64_t out = 0;
+    for (uint32_t i = 0; i < BitLength; i++) {
+        out = (out << 1) | (uint64_t)(BufferIn[i] & 1U);
+    }
+    return out;
+}
+
+uint8_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25p1_hamming_rs_symbol_reliability(const P25P1SoftDibit* symbol) {
+    if (symbol == NULL) {
+        return 0;
+    }
+
+    int min_reliability = 255;
+    for (int i = 0; i < 3; i++) {
+        int r0 = symbol[i].llr[0] < 0 ? -(int)symbol[i].llr[0] : (int)symbol[i].llr[0];
+        int r1 = symbol[i].llr[1] < 0 ? -(int)symbol[i].llr[1] : (int)symbol[i].llr[1];
+        if (r0 < min_reliability) {
+            min_reliability = r0;
+        }
+        if (r1 < min_reliability) {
+            min_reliability = r1;
+        }
+    }
+    return (uint8_t)min_reliability;
+}
+
+uint64_t
+dsd_time_monotonic_ns(void) {
+    return 43000000000ULL;
+}
+
+int
+check_and_fix_reedsolomon_24_12_13(char* data, const char* parity) {
+    (void)data;
+    (void)parity;
+    return g_hard_rs_result;
+}
+
+int
+p25p1_rs_24_12_13_soft_reliability(char* data, const char* parity, const uint8_t* data_reliab,
+                                   const uint8_t* parity_reliab) {
+    (void)data;
+    (void)parity;
+    (void)data_reliab;
+    (void)parity_reliab;
+    return g_soft_rs_result;
+}
+
+int
+p25_lsd_fec_16x8_soft(uint8_t* bits16, const int16_t llr16[16]) {
+    (void)bits16;
+    (void)llr16;
+    return g_lsd_soft_result;
+}
+
+int
+getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
+    (void)opts;
+    (void)state;
+    g_get_dibit_soft_calls++;
+    if (out_soft != NULL) {
+        out_soft->reliability = 77U;
+        out_soft->llr[0] = 12;
+        out_soft->llr[1] = -8;
+    }
+    return g_soft_dibit_value;
+}
+
+int
+read_dibit_soft(dsd_opts* opts, dsd_state* state, char* output, int* status_count, P25P1SoftDibit* soft_dibit) {
+    (void)opts;
+    (void)state;
+    const int call = g_read_dibit_soft_calls++;
+    const int dibit = g_read_dibit_soft_values[call % 16] & 0x03;
+    if (status_count != NULL) {
+        (*status_count)++;
+    }
+    if (output != NULL) {
+        output[0] = (char)((dibit >> 1) & 1);
+        output[1] = (char)(dibit & 1);
+    }
+    if (soft_dibit != NULL) {
+        soft_dibit->reliab = (uint8_t)(90 + call);
+        soft_dibit->llr[0] = (int16_t)(100 + call);
+        soft_dibit->llr[1] = (int16_t)(-50 - call);
+    }
+    return dibit;
+}
+
+void
+p25_status_accum_add(dsd_state* state, int dibit_value) {
+    (void)state;
+    g_status_add_calls++;
+    g_last_status_dibit = dibit_value;
+}
+
+void
+p25_status_accum_classify(dsd_state* state, const dsd_opts* opts) {
+    g_status_classify_calls++;
+    g_last_classify_opts = opts;
+    if (state != NULL) {
+        state->p25_ss_classification = P25_SS_CLASS_INFRASTRUCTURE;
+    }
+}
+
+void
+p25_status_accum_ensure_started(dsd_state* state) {
+    (void)state;
+}
+
+void
+process_IMBE(dsd_opts* opts, dsd_state* state, int* status_count) {
+    (void)opts;
+    (void)state;
+    (void)status_count;
+}
+
+void
+p25p1_play_imbe_audio(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+p25_sm_emit_active(dsd_opts* opts, dsd_state* state, int slot) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+read_and_correct_hex_word(dsd_opts* opts, dsd_state* state, char* hex, int* status_count, P25P1SoftDibit* soft_dibits,
+                          int* soft_dibit_index) {
+    (void)opts;
+    (void)state;
+    (void)hex;
+    (void)status_count;
+    (void)soft_dibits;
+    (void)soft_dibit_index;
+}
+
+void
+p25_lcw(dsd_opts* opts, dsd_state* state, uint8_t LCW_bits[], uint8_t irrecoverable_errors) {
+    (void)opts;
+    (void)state;
+    (void)LCW_bits;
+    (void)irrecoverable_errors;
+    g_lcw_calls++;
+}
+
+int
+dsd_tg_policy_make_exact_entry(uint32_t id, const char* mode, const char* name, dsd_tg_policy_entry_source source,
+                               dsd_tg_policy_entry* out) {
+    g_policy_make_calls++;
+    if (out == NULL) {
+        return -1;
+    }
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->id_start = id;
+    out->id_end = id;
+    out->source = (uint8_t)source;
+    (void)DSD_SNPRINTF(out->mode, sizeof(out->mode), "%s", mode != NULL ? mode : "");
+    (void)DSD_SNPRINTF(out->name, sizeof(out->name), "%s", name != NULL ? name : "");
+    return 0;
+}
+
+int
+dsd_tg_policy_upsert_exact(dsd_state* state, const dsd_tg_policy_entry* entry, dsd_tg_policy_upsert_mode mode) {
+    (void)state;
+    g_policy_upsert_calls++;
+    g_last_policy_upsert_mode = mode;
+    if (entry != NULL) {
+        g_last_policy_id = entry->id_start;
+        g_last_policy_source = entry->source;
+        (void)DSD_SNPRINTF(g_last_policy_mode, sizeof(g_last_policy_mode), "%s", entry->mode);
+        (void)DSD_SNPRINTF(g_last_policy_name, sizeof(g_last_policy_name), "%s", entry->name);
+    }
+    return 0;
+}
+
+#include "../../../src/protocol/p25/phase1/p25p1_ldu1.c"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif
+
+static void
+put_bits6(char dst[6], const char* bits) {
+    for (int i = 0; i < 6; i++) {
+        dst[i] = (char)(bits[i] == '1');
+    }
+}
+
+static void
+put_u8_bits(uint8_t* dst, uint8_t value) {
+    for (int i = 0; i < 8; i++) {
+        dst[i] = (uint8_t)((value >> (7 - i)) & 1U);
+    }
+}
+
+static void
+reset_hook_counters(void) {
+    g_hard_rs_result = 0;
+    g_soft_rs_result = 0;
+    g_lsd_soft_result = 1;
+    g_lcw_calls = 0;
+    g_policy_make_calls = 0;
+    g_policy_upsert_calls = 0;
+    g_soft_dibit_value = 0;
+    g_get_dibit_soft_calls = 0;
+    g_read_dibit_soft_calls = 0;
+    DSD_MEMSET(g_read_dibit_soft_values, 0, sizeof(g_read_dibit_soft_values));
+    g_status_add_calls = 0;
+    g_status_classify_calls = 0;
+    g_last_status_dibit = -1;
+    g_last_classify_opts = NULL;
+    g_last_policy_id = 0U;
+    g_last_policy_source = 0U;
+    g_last_policy_upsert_mode = 0;
+    g_last_policy_mode[0] = '\0';
+    g_last_policy_name[0] = '\0';
+}
+
+static int
+expect_string(const char* tag, const uint8_t* got, const char* want) {
+    if (strcmp((const char*)got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got \"%s\" want \"%s\"\n", tag, (const char*)got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u8(const char* tag, uint8_t got, uint8_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got 0x%02X want 0x%02X\n", tag, (unsigned int)got, (unsigned int)want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_cstr(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got \"%s\" want \"%s\"\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_ldu1_unpack_lc_fields(void) {
+    char hex_data[12][6] = {{0}};
+    uint8_t lcformat[9];
+    uint8_t mfid[9];
+    uint8_t lcinfo[57];
+
+    put_bits6(hex_data[11], "101010");
+    put_bits6(hex_data[10], "101100");
+    put_bits6(hex_data[9], "110011");
+    put_bits6(hex_data[8], "000001");
+    put_bits6(hex_data[7], "000010");
+    put_bits6(hex_data[6], "000100");
+    put_bits6(hex_data[5], "001000");
+    put_bits6(hex_data[4], "010000");
+    put_bits6(hex_data[3], "100000");
+    put_bits6(hex_data[2], "111100");
+    put_bits6(hex_data[1], "001111");
+    put_bits6(hex_data[0], "010101");
+
+    p25p1_ldu1_unpack_lc_fields(hex_data, lcformat, mfid, lcinfo);
+
+    int rc = 0;
+    rc |= expect_string("lcformat", lcformat, "10101010");
+    rc |= expect_string("mfid", mfid, "11001100");
+    rc |= expect_string("lcinfo", lcinfo, "11000001000010000100001000010000100000111100001111010101");
+    return rc;
+}
+
+static int
+test_ldu1_build_lcw_buffers(void) {
+    uint8_t lcformat[9] = {'1', '0', '1', '0', '1', '0', '1', '0', 0};
+    uint8_t mfid[9] = {'1', '1', '0', '0', '1', '1', '0', '0', 0};
+    uint8_t lcinfo[57] = {0};
+    const uint8_t want_payload[7] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE};
+    uint8_t LCW_bytes[9];
+    uint8_t LCW_bits[72];
+
+    for (int byte = 0; byte < 7; byte++) {
+        put_u8_bits(&lcinfo[byte * 8], want_payload[byte]);
+    }
+    lcinfo[56] = 0;
+
+    p25p1_ldu1_build_lcw_buffers(lcformat, mfid, lcinfo, LCW_bytes, LCW_bits);
+
+    int rc = 0;
+    rc |= expect_u8("LCW byte 0", LCW_bytes[0], 0xAA);
+    rc |= expect_u8("LCW byte 1", LCW_bytes[1], 0xCC);
+    for (int byte = 0; byte < 7; byte++) {
+        char tag[32];
+        DSD_SNPRINTF(tag, sizeof(tag), "LCW payload byte %d", byte);
+        rc |= expect_u8(tag, LCW_bytes[byte + 2], want_payload[byte]);
+    }
+    for (int bit = 0; bit < 72; bit++) {
+        uint8_t want = (uint8_t)((LCW_bytes[bit / 8] >> (7 - (bit % 8))) & 1U);
+        if (LCW_bits[bit] != want) {
+            DSD_FPRINTF(stderr, "LCW bit %d: got %u want %u\n", bit, (unsigned int)LCW_bits[bit], (unsigned int)want);
+            rc = 1;
+        }
+    }
+    return rc;
+}
+
+static int
+test_lsd_corrected_byte(void) {
+    const uint8_t bits16[16] = {1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0};
+    char out_bits[9];
+
+    uint8_t value = p25p1_lsd_corrected_byte(bits16, out_bits);
+
+    int rc = 0;
+    rc |= expect_u8("LSD byte", value, 0xA5);
+    if (strcmp(out_bits, "10100101") != 0) {
+        DSD_FPRINTF(stderr, "LSD out bits: got \"%s\" want \"10100101\"\n", out_bits);
+        rc = 1;
+    }
+    if (p25p1_lsd_corrected_byte(bits16, NULL) != 0xA5) {
+        DSD_FPRINTF(stderr, "LSD null-output byte mismatch\n");
+        rc = 1;
+    }
+    return rc;
+}
+
+static void
+set_symbol_reliability(P25P1SoftDibit* symbol, int minimum_reliability) {
+    symbol[0].llr[0] = (int16_t)(minimum_reliability + 5);
+    symbol[0].llr[1] = (int16_t)-(minimum_reliability + 4);
+    symbol[1].llr[0] = (int16_t)(minimum_reliability + 3);
+    symbol[1].llr[1] = (int16_t)-(minimum_reliability + 2);
+    symbol[2].llr[0] = (int16_t)(minimum_reliability + 1);
+    symbol[2].llr[1] = (int16_t)minimum_reliability;
+}
+
+static int
+test_ldu1_rs_reliability_uses_wire_order(void) {
+    P25P1SoftDibit soft_dibits[12 * (3 + 2) + 12 * (3 + 2)] = {0};
+    uint8_t data_reliab[12] = {0};
+    uint8_t parity_reliab[12] = {0};
+
+    for (int wire_symbol = 0; wire_symbol < 12; wire_symbol++) {
+        set_symbol_reliability(&soft_dibits[wire_symbol * (3 + 2)], 30 + wire_symbol);
+    }
+    for (int wire_symbol = 0; wire_symbol < 12; wire_symbol++) {
+        set_symbol_reliability(&soft_dibits[(12 * (3 + 2)) + (wire_symbol * (3 + 2))], 70 + wire_symbol);
+    }
+
+    build_ldu1_rs_reliability(soft_dibits, data_reliab, parity_reliab);
+
+    int rc = 0;
+    rc |= expect_u8("data[0] reliability", data_reliab[0], 41);
+    rc |= expect_u8("data[11] reliability", data_reliab[11], 30);
+    rc |= expect_u8("parity[0] reliability", parity_reliab[0], 81);
+    rc |= expect_u8("parity[11] reliability", parity_reliab[11], 70);
+    return rc;
+}
+
+static void
+fill_lsd_byte(uint8_t bits16[16], uint8_t value) {
+    for (int i = 0; i < 8; i++) {
+        bits16[i] = (uint8_t)(((value >> (7 - i)) & 1U) != 0U);
+    }
+}
+
+static int
+test_ldu1_init_and_fec_outcomes(void) {
+    static dsd_state state;
+    ldu1_decode_ctx_t ctx;
+    char hex_data[12][6] = {{0}};
+    char hex_parity[12][6] = {{0}};
+    P25P1SoftDibit soft_dibits[12 * (3 + 2) + 12 * (3 + 2)] = {0};
+    int rc = 0;
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.p25vc = 7;
+    p25p1_ldu1_init_decode_ctx(&state, &ctx);
+    rc |= expect_int("init status count", ctx.status_count, 21);
+    rc |= expect_int("init clears p25vc", state.p25vc, 0);
+
+    reset_hook_counters();
+    rc |= expect_int("hard RS success result", p25p1_ldu1_apply_rs_fec(&state, hex_data, hex_parity, soft_dibits), 0);
+    rc |= expect_int("hard RS success ok count", state.p25_p1_voice_fec_ok, 1);
+    rc |= expect_int("hard RS success err count", state.p25_p1_voice_fec_err, 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_hook_counters();
+    g_hard_rs_result = 1;
+    g_soft_rs_result = 0;
+    rc |= expect_int("soft RS recovery result", p25p1_ldu1_apply_rs_fec(&state, hex_data, hex_parity, soft_dibits), 0);
+    rc |= expect_int("soft RS recovery count", state.p25_p1_soft_rs_ok, 1);
+    rc |= expect_int("soft RS recovery ok count", state.p25_p1_voice_fec_ok, 1);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_hook_counters();
+    g_hard_rs_result = 1;
+    g_soft_rs_result = 1;
+    rc |= expect_int("RS failure result", p25p1_ldu1_apply_rs_fec(&state, hex_data, hex_parity, soft_dibits), 1);
+    rc |= expect_int("RS failure err count", state.p25_p1_voice_fec_err, 1);
+    rc |= expect_int("RS failure critical count", state.debug_header_critical_errors, 1);
+    return rc;
+}
+
+static int
+test_ldu1_hold_hysteresis_refreshes_only_recent_activity(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.trunk_hangtime = 0.0;
+    state.last_vc_sync_time = time(NULL);
+    state.last_vc_sync_time_m = 17.0;
+
+    p25p1_ldu1_refresh_vc_hysteresis(&opts, &state);
+    rc |= expect_int("recent VC monotonic refresh", (int)state.last_vc_sync_time_m, 43);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.trunk_hangtime = 1.0;
+    state.last_vc_sync_time = time(NULL) - 10;
+    state.last_vc_sync_time_m = 19.0;
+
+    p25p1_ldu1_refresh_vc_hysteresis(&opts, &state);
+    rc |= expect_int("stale VC monotonic preserved", (int)state.last_vc_sync_time_m, 19);
+    return rc;
+}
+
+static int
+test_ldu1_lcw_output_dispatch(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t lcw_bits[72] = {0};
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_hook_counters();
+
+    p25p1_ldu1_handle_lcw_output(&opts, &state, lcw_bits, 0);
+    rc |= expect_int("LCW dispatch on good FEC", g_lcw_calls, 1);
+
+    p25p1_ldu1_handle_lcw_output(&opts, &state, lcw_bits, 1);
+    rc |= expect_int("LCW dispatch suppressed on FEC error", g_lcw_calls, 1);
+    return rc;
+}
+
+static int
+test_ldu1_finalize_status_feeds_trailing_symbol(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_hook_counters();
+    g_soft_dibit_value = 3;
+
+    p25p1_ldu1_finalize_status(&opts, &state);
+
+    rc |= expect_int("status getDibitSoft calls", g_get_dibit_soft_calls, 1);
+    rc |= expect_int("status add calls", g_status_add_calls, 1);
+    rc |= expect_int("status trailing dibit", g_last_status_dibit, 3);
+    rc |= expect_int("status classify calls", g_status_classify_calls, 1);
+    if (g_last_classify_opts != &opts) {
+        DSD_FPRINTF(stderr, "status classify opts pointer mismatch\n");
+        rc = 1;
+    }
+    rc |= expect_int("status classification side effect", state.p25_ss_classification, P25_SS_CLASS_INFRASTRUCTURE);
+    return rc;
+}
+
+static int
+test_ldu1_collect_lsd_stores_soft_bits_and_counters(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    ldu1_decode_ctx_t ctx;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    reset_hook_counters();
+    ctx.status_count = 4;
+    state.dropL = 10;
+    state.octet_counter = 20;
+
+    static const int dibits[16] = {
+        2, 2, 1, 1, // LSD1 0xA5
+        3, 0, 3, 0, // LSD1 parity bits
+        0, 3, 3, 0, // LSD2 0x3C
+        1, 2, 1, 2, // LSD2 parity bits
+    };
+    for (size_t i = 0U; i < 16U; i++) {
+        g_read_dibit_soft_values[i] = dibits[i];
+    }
+
+    p25p1_ldu1_collect_lsd(&opts, &state, &ctx);
+
+    rc |= expect_int("LSD read calls", g_read_dibit_soft_calls, 16);
+    rc |= expect_int("LSD status count", ctx.status_count, 20);
+    rc |= expect_int("LSD drop counter", state.dropL, 12);
+    rc |= expect_int("LSD octet counter", state.octet_counter, 22);
+    rc |= expect_u8("LSD1 collected byte", ctx.lsd_hex1, 0xA5U);
+    rc |= expect_u8("LSD2 collected byte", ctx.lsd_hex2, 0x3CU);
+    rc |= expect_cstr("LSD1 bit string", ctx.lsd1, "10100101");
+    rc |= expect_cstr("LSD2 bit string", ctx.lsd2, "00111100");
+    rc |= expect_u8("LSD1 data bit 0", ctx.lowspeeddata[0], 1U);
+    rc |= expect_u8("LSD1 data bit 7", ctx.lowspeeddata[7], 1U);
+    rc |= expect_u8("LSD1 parity bit 8", ctx.lowspeeddata[8], 1U);
+    rc |= expect_u8("LSD2 data bit 16", ctx.lowspeeddata[16], 0U);
+    rc |= expect_u8("LSD2 data bit 23", ctx.lowspeeddata[23], 0U);
+    rc |= expect_u8("LSD2 parity bit 24", ctx.lowspeeddata[24], 0U);
+    rc |= expect_int("LSD1 first LLR0", ctx.lowspeed_llr[0], 100);
+    rc |= expect_int("LSD1 first LLR1", ctx.lowspeed_llr[1], -50);
+    rc |= expect_int("LSD1 parity LLR0", ctx.lowspeed_llr[8], 104);
+    rc |= expect_int("LSD2 first LLR0", ctx.lowspeed_llr[16], 108);
+    rc |= expect_int("LSD2 parity LLR1", ctx.lowspeed_llr[25], -62);
+    return rc;
+}
+
+static int
+test_ldu1_lsd_correction_respects_encryption(void) {
+    static dsd_state state;
+    ldu1_decode_ctx_t ctx;
+    int rc = 0;
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    reset_hook_counters();
+    fill_lsd_byte(ctx.lowspeeddata + 0, 0x41U);
+    fill_lsd_byte(ctx.lowspeeddata + 16, 0x42U);
+    state.payload_algid = 0x80;
+    p25p1_ldu1_correct_lsd(&state, &ctx);
+    rc |= expect_int("clear LSD1 ok", ctx.lsd1_okay, 1);
+    rc |= expect_int("clear LSD2 ok", ctx.lsd2_okay, 1);
+    rc |= expect_u8("clear LSD1", ctx.lsd_hex1, 0x41U);
+    rc |= expect_u8("clear LSD2", ctx.lsd_hex2, 0x42U);
+
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    fill_lsd_byte(ctx.lowspeeddata + 0, 0x41U);
+    fill_lsd_byte(ctx.lowspeeddata + 16, 0x42U);
+    state.payload_algid = 0x84;
+    p25p1_ldu1_correct_lsd(&state, &ctx);
+    rc |= expect_u8("encrypted LSD1 suppressed", ctx.lsd_hex1, 0U);
+    rc |= expect_u8("encrypted LSD2 suppressed", ctx.lsd_hex2, 0U);
+    return rc;
+}
+
+static int
+test_ldu1_softid_alias_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    ldu1_decode_ctx_t ctx;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    reset_hook_counters();
+
+    state.dmr_alias_format[0] = 0x02;
+    state.dmr_alias_block_len[0] = 2;
+    state.lastsrc = 1357;
+    state.payload_algid = 0x80;
+    ctx.lsd_hex1 = 0x41;
+    ctx.lsd_hex2 = 0x42;
+    ctx.lsd1_okay = 1;
+    ctx.lsd2_okay = 1;
+
+    p25p1_ldu1_handle_softid(&opts, &state, &ctx);
+    rc |= expect_int("softid counter after segment", state.data_block_counter[0], 2);
+    rc |= expect_int("softid policy make", g_policy_make_calls, 1);
+    rc |= expect_int("softid policy upserts", g_policy_upsert_calls, 2);
+    rc |= expect_int("softid policy id", (int)g_last_policy_id, 1357);
+    rc |= expect_int("softid policy source", (int)g_last_policy_source, (int)DSD_TG_POLICY_SOURCE_RUNTIME_ALIAS);
+    rc |=
+        expect_int("softid last upsert mode", (int)g_last_policy_upsert_mode, (int)DSD_TG_POLICY_UPSERT_ADD_IF_MISSING);
+    rc |= expect_cstr("softid clear mode", g_last_policy_mode, "D");
+    rc |= expect_cstr("softid alias name", g_last_policy_name, "AB");
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    ctx.lsd_hex1 = 0x02;
+    ctx.lsd_hex2 = 0x0B;
+    ctx.lsd1_okay = 1;
+    ctx.lsd2_okay = 1;
+    p25p1_ldu1_handle_softid(&opts, &state, &ctx);
+    rc |= expect_int("softid begin format", state.dmr_alias_format[0], 0x02);
+    rc |= expect_int("softid begin clamped length", state.dmr_alias_block_len[0], 8);
+    rc |= expect_int("softid begin counter", state.data_block_counter[0], 0);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    reset_hook_counters();
+    state.dmr_alias_format[0] = 0x02;
+    state.dmr_alias_block_len[0] = 2;
+    state.lastsrc = 2468;
+    state.payload_algid = 0xAA;
+    opts.trunk_tune_enc_calls = 0;
+    ctx.lsd_hex1 = 0x19;
+    ctx.lsd_hex2 = 0x7F;
+    ctx.lsd1_okay = 1;
+    ctx.lsd2_okay = 1;
+    p25p1_ldu1_handle_softid(&opts, &state, &ctx);
+    rc |= expect_int("softid invalid chars advance counter", state.data_block_counter[0], 2);
+    rc |= expect_int("softid invalid chars kept zero", state.dmr_alias_block_segment[0][0][0][0], 0);
+    rc |= expect_int("softid encrypted policy make", g_policy_make_calls, 1);
+    rc |= expect_int("softid encrypted policy upserts", g_policy_upsert_calls, 2);
+    rc |= expect_cstr("softid encrypted no-key mode", g_last_policy_mode, "DE");
+    rc |= expect_cstr("softid invalid alias name empty", g_last_policy_name, "");
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    ctx.lsd_hex1 = 0x02;
+    ctx.lsd_hex2 = 0x04;
+    ctx.lsd1_okay = 1;
+    ctx.lsd2_okay = 0;
+    p25p1_ldu1_handle_softid(&opts, &state, &ctx);
+    rc |= expect_int("softid begin rejects bad second LSD", state.dmr_alias_format[0], 0);
+    rc |= expect_int("softid begin reject preserves counter", state.data_block_counter[0], 0);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_ldu1_unpack_lc_fields();
+    rc |= test_ldu1_build_lcw_buffers();
+    rc |= test_lsd_corrected_byte();
+    rc |= test_ldu1_rs_reliability_uses_wire_order();
+    rc |= test_ldu1_init_and_fec_outcomes();
+    rc |= test_ldu1_hold_hysteresis_refreshes_only_recent_activity();
+    rc |= test_ldu1_lcw_output_dispatch();
+    rc |= test_ldu1_finalize_status_feeds_trailing_symbol();
+    rc |= test_ldu1_collect_lsd_stores_soft_bits_and_counters();
+    rc |= test_ldu1_lsd_correction_respects_encryption();
+    rc |= test_ldu1_softid_alias_state();
+    return rc;
+}
+
+// NOLINTEND(bugprone-implicit-widening-of-multiplication-result,bugprone-suspicious-include)

--- a/tests/protocol/p25/test_p25_p1_ldu2_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_ldu2_helpers.c
@@ -1,0 +1,911 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result,bugprone-suspicious-include)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * P25 P1 LDU2 helper tests: verify deterministic ESS/LSD field packing,
+ * decrypt-key gating, and soft-decision RS reliability ordering.
+ */
+
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/protocol/p25/p25_status_symbol.h>
+#include <dsd-neo/protocol/p25/p25p1_check_ldu.h>
+#include <dsd-neo/protocol/p25/p25p1_ldu.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "dsd-neo/core/opts.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/protocol/p25/p25p1_soft.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+uint8_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25p1_hamming_rs_symbol_reliability(const P25P1SoftDibit* symbol) {
+    if (symbol == NULL) {
+        return 0;
+    }
+
+    int min_reliability = 255;
+    for (int i = 0; i < 3; i++) {
+        int r0 = symbol[i].llr[0] < 0 ? -(int)symbol[i].llr[0] : (int)symbol[i].llr[0];
+        int r1 = symbol[i].llr[1] < 0 ? -(int)symbol[i].llr[1] : (int)symbol[i].llr[1];
+        if (r0 < min_reliability) {
+            min_reliability = r0;
+        }
+        if (r1 < min_reliability) {
+            min_reliability = r1;
+        }
+    }
+    return (uint8_t)min_reliability;
+}
+
+static int g_hard_rs_result;
+static int g_soft_rs_result;
+static int g_lsd_soft_result;
+static int g_lfsr128_calls;
+static int g_release_calls;
+static int g_watchdog_calls;
+static int g_write_event_calls;
+static int g_push_event_calls;
+static int g_init_event_calls;
+static int g_policy_make_calls;
+static int g_policy_upsert_calls;
+static int g_soft_dibit_value;
+static int g_get_dibit_soft_calls;
+static int g_read_dibit_soft_calls;
+static int g_read_dibit_soft_values[16];
+static int g_status_add_calls;
+static int g_status_classify_calls;
+static int g_last_status_dibit;
+static const dsd_opts* g_last_classify_opts;
+static uint32_t g_last_policy_id;
+static uint8_t g_last_policy_source;
+static dsd_tg_policy_upsert_mode g_last_policy_upsert_mode;
+static const char* g_lookup_label;
+static Event_History_I g_event_history[2];
+
+int
+check_and_fix_reedsolomon_24_16_9(char* data, const char* parity) {
+    (void)data;
+    (void)parity;
+    return g_hard_rs_result;
+}
+
+int
+p25p1_rs_24_16_9_soft_reliability(char* data, const char* parity, const uint8_t* data_reliab,
+                                  const uint8_t* parity_reliab) {
+    (void)data;
+    (void)parity;
+    (void)data_reliab;
+    (void)parity_reliab;
+    return g_soft_rs_result;
+}
+
+int
+p25_lsd_fec_16x8_soft(uint8_t* bits16, const int16_t llr16[16]) {
+    (void)bits16;
+    (void)llr16;
+    return g_lsd_soft_result;
+}
+
+uint64_t
+dsd_time_monotonic_ns(void) {
+    return 42000000000ULL;
+}
+
+uint64_t
+ConvertBitIntoBytes(const uint8_t* BufferIn, uint32_t BitLength) {
+    uint64_t value = 0;
+    for (uint32_t i = 0; i < BitLength; i++) {
+        value = (value << 1U) | (uint64_t)(BufferIn[i] & 1U);
+    }
+    return value;
+}
+
+void
+LFSR128(dsd_state* state) {
+    (void)state;
+    g_lfsr128_calls++;
+}
+
+int
+getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
+    (void)opts;
+    (void)state;
+    g_get_dibit_soft_calls++;
+    if (out_soft != NULL) {
+        out_soft->reliability = 88U;
+        out_soft->llr[0] = -9;
+        out_soft->llr[1] = 14;
+    }
+    return g_soft_dibit_value;
+}
+
+int
+read_dibit_soft(dsd_opts* opts, dsd_state* state, char* output, int* status_count, P25P1SoftDibit* soft_dibit) {
+    (void)opts;
+    (void)state;
+    const int call = g_read_dibit_soft_calls++;
+    const int dibit = g_read_dibit_soft_values[call % 16] & 0x03;
+    if (status_count != NULL) {
+        (*status_count)++;
+    }
+    if (output != NULL) {
+        output[0] = (char)((dibit >> 1) & 1);
+        output[1] = (char)(dibit & 1);
+    }
+    if (soft_dibit != NULL) {
+        soft_dibit->reliab = (uint8_t)(80 + call);
+        soft_dibit->llr[0] = (int16_t)(100 + call);
+        soft_dibit->llr[1] = (int16_t)(-60 - call);
+    }
+    return dibit;
+}
+
+void
+p25_status_accum_add(dsd_state* state, int dibit_value) {
+    (void)state;
+    g_status_add_calls++;
+    g_last_status_dibit = dibit_value;
+}
+
+void
+p25_status_accum_classify(dsd_state* state, const dsd_opts* opts) {
+    g_status_classify_calls++;
+    g_last_classify_opts = opts;
+    if (state != NULL) {
+        state->p25_ss_classification = P25_SS_CLASS_SUBSCRIBER;
+    }
+}
+
+void
+p25_status_accum_ensure_started(dsd_state* state) {
+    (void)state;
+}
+
+void
+LFSRP(dsd_state* state) {
+    (void)state;
+}
+
+void
+process_IMBE(dsd_opts* opts, dsd_state* state, int* status_count) {
+    (void)opts;
+    (void)state;
+    (void)status_count;
+}
+
+void
+p25p1_play_imbe_audio(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+p25_sm_emit_active(dsd_opts* opts, dsd_state* state, int slot) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+read_and_correct_hex_word(dsd_opts* opts, dsd_state* state, char* hex, int* status_count, P25P1SoftDibit* soft_dibits,
+                          int* soft_dibit_index) {
+    (void)opts;
+    (void)state;
+    (void)hex;
+    (void)status_count;
+    (void)soft_dibits;
+    (void)soft_dibit_index;
+}
+
+void
+p25_sm_on_release(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_release_calls++;
+}
+
+int
+dsd_tg_policy_lookup_label(const dsd_state* state, uint32_t id, char* mode, size_t mode_sz, char* name,
+                           size_t name_sz) {
+    (void)state;
+    (void)id;
+    if (g_lookup_label == NULL) {
+        return 0;
+    }
+    if (mode != NULL && mode_sz > 0U) {
+        (void)DSD_SNPRINTF(mode, mode_sz, "%s", "DE");
+    }
+    if (name != NULL && name_sz > 0U) {
+        (void)DSD_SNPRINTF(name, name_sz, "%s", g_lookup_label);
+    }
+    return 1;
+}
+
+int
+dsd_tg_policy_make_exact_entry(uint32_t id, const char* mode, const char* name, dsd_tg_policy_entry_source source,
+                               dsd_tg_policy_entry* out) {
+    g_policy_make_calls++;
+    if (out == NULL) {
+        return -1;
+    }
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->id_start = id;
+    out->id_end = id;
+    out->source = (uint8_t)source;
+    (void)DSD_SNPRINTF(out->mode, sizeof(out->mode), "%s", mode != NULL ? mode : "");
+    (void)DSD_SNPRINTF(out->name, sizeof(out->name), "%s", name != NULL ? name : "");
+    return 0;
+}
+
+int
+dsd_tg_policy_upsert_exact(dsd_state* state, const dsd_tg_policy_entry* entry, dsd_tg_policy_upsert_mode mode) {
+    (void)state;
+    g_policy_upsert_calls++;
+    g_last_policy_upsert_mode = mode;
+    if (entry != NULL) {
+        g_last_policy_id = entry->id_start;
+        g_last_policy_source = entry->source;
+    }
+    return 0;
+}
+
+void
+dsd_p25_optional_hook_watchdog_event_current(dsd_opts* opts, dsd_state* state, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    g_watchdog_calls++;
+}
+
+void
+dsd_p25_optional_hook_write_event_to_log_file(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite,
+                                              char* event_string) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)swrite;
+    (void)event_string;
+    g_write_event_calls++;
+}
+
+void
+dsd_p25_optional_hook_push_event_history(Event_History_I* event_struct) {
+    (void)event_struct;
+    g_push_event_calls++;
+}
+
+void
+dsd_p25_optional_hook_init_event_history(Event_History_I* event_struct, uint8_t start, uint8_t stop) {
+    (void)event_struct;
+    (void)start;
+    (void)stop;
+    g_init_event_calls++;
+}
+
+#include "../../../src/protocol/p25/phase1/p25p1_ldu2.c"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif
+
+static void
+put_bits6(char dst[6], const char* bits) {
+    for (int i = 0; i < 6; i++) {
+        dst[i] = (char)(bits[i] == '1');
+    }
+}
+
+static void
+reset_hook_counters(void) {
+    g_hard_rs_result = 0;
+    g_soft_rs_result = 0;
+    g_lsd_soft_result = 1;
+    g_lfsr128_calls = 0;
+    g_release_calls = 0;
+    g_watchdog_calls = 0;
+    g_write_event_calls = 0;
+    g_push_event_calls = 0;
+    g_init_event_calls = 0;
+    g_policy_make_calls = 0;
+    g_policy_upsert_calls = 0;
+    g_soft_dibit_value = 0;
+    g_get_dibit_soft_calls = 0;
+    g_read_dibit_soft_calls = 0;
+    DSD_MEMSET(g_read_dibit_soft_values, 0, sizeof g_read_dibit_soft_values);
+    g_status_add_calls = 0;
+    g_status_classify_calls = 0;
+    g_last_status_dibit = -1;
+    g_last_classify_opts = NULL;
+    g_last_policy_id = 0U;
+    g_last_policy_source = 0U;
+    g_last_policy_upsert_mode = 0;
+    g_lookup_label = NULL;
+}
+
+static int
+expect_string(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got \"%s\" want \"%s\"\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u8(const char* tag, uint8_t got, uint8_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got 0x%02X want 0x%02X\n", tag, (unsigned int)got, (unsigned int)want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u64(const char* tag, unsigned long long got, unsigned long long want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %llu want %llu\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_ldu2_extracts_ess_fields(void) {
+    char hex_data[16][6] = {{0}};
+    uint8_t mi[73];
+    char algid[9];
+    char kid[17];
+
+    put_bits6(hex_data[15], "100001");
+    put_bits6(hex_data[14], "010010");
+    put_bits6(hex_data[13], "110011");
+    put_bits6(hex_data[12], "001100");
+    put_bits6(hex_data[11], "101101");
+    put_bits6(hex_data[10], "011110");
+    put_bits6(hex_data[9], "111000");
+    put_bits6(hex_data[8], "000111");
+    put_bits6(hex_data[7], "101010");
+    put_bits6(hex_data[6], "010101");
+    put_bits6(hex_data[5], "111111");
+    put_bits6(hex_data[4], "000000");
+    put_bits6(hex_data[3], "101100");
+    put_bits6(hex_data[2], "110011");
+    put_bits6(hex_data[1], "001101");
+    put_bits6(hex_data[0], "010110");
+
+    ldu2_extract_ess_fields((const char (*)[6])hex_data, mi, algid, kid);
+
+    int rc = 0;
+    rc |= expect_string("MI", (const char*)mi,
+                        "100001010010110011001100101101011110111000000111101010010101111111000000");
+    rc |= expect_string("ALGID", algid, "10110011");
+    rc |= expect_string("KID", kid, "0011001101010110");
+    return rc;
+}
+
+static int
+test_lsd_corrected_byte(void) {
+    const uint8_t bits16[16] = {0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1};
+    char out_bits[9];
+
+    uint8_t value = p25p1_lsd_corrected_byte(bits16, out_bits);
+
+    int rc = 0;
+    rc |= expect_u8("LSD byte", value, 0x5A);
+    rc |= expect_string("LSD out bits", out_bits, "01011010");
+    rc |= expect_u8("LSD null output byte", p25p1_lsd_corrected_byte(bits16, NULL), 0x5A);
+    return rc;
+}
+
+static void
+set_symbol_reliability(P25P1SoftDibit* symbol, int minimum_reliability) {
+    symbol[0].llr[0] = (int16_t)(minimum_reliability + 5);
+    symbol[0].llr[1] = (int16_t)-(minimum_reliability + 4);
+    symbol[1].llr[0] = (int16_t)(minimum_reliability + 3);
+    symbol[1].llr[1] = (int16_t)-(minimum_reliability + 2);
+    symbol[2].llr[0] = (int16_t)(minimum_reliability + 1);
+    symbol[2].llr[1] = (int16_t)minimum_reliability;
+}
+
+static int
+test_ldu2_rs_reliability_uses_wire_order(void) {
+    P25P1SoftDibit soft_dibits[16 * (3 + 2) + 8 * (3 + 2)] = {0};
+    uint8_t data_reliab[16] = {0};
+    uint8_t parity_reliab[8] = {0};
+
+    for (int wire_symbol = 0; wire_symbol < 16; wire_symbol++) {
+        set_symbol_reliability(&soft_dibits[wire_symbol * (3 + 2)], 40 + wire_symbol);
+    }
+    for (int wire_symbol = 0; wire_symbol < 8; wire_symbol++) {
+        set_symbol_reliability(&soft_dibits[(16 * (3 + 2)) + (wire_symbol * (3 + 2))], 90 + wire_symbol);
+    }
+
+    build_ldu2_rs_reliability(soft_dibits, data_reliab, parity_reliab);
+
+    int rc = 0;
+    rc |= expect_u8("data[0] reliability", data_reliab[0], 55);
+    rc |= expect_u8("data[15] reliability", data_reliab[15], 40);
+    rc |= expect_u8("parity[0] reliability", parity_reliab[0], 97);
+    rc |= expect_u8("parity[7] reliability", parity_reliab[7], 90);
+    return rc;
+}
+
+static int
+test_ldu2_decrypt_key_gate(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    int rc = 0;
+
+    state.payload_algid = 0xAA;
+    rc |= expect_int("ADP without key", ldu2_payload_has_decrypt_key(&state), 0);
+    state.R = 0x1234U;
+    rc |= expect_int("ADP with key", ldu2_payload_has_decrypt_key(&state), 1);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.payload_algid = 0x84;
+    rc |= expect_int("AES without key", ldu2_payload_has_decrypt_key(&state), 0);
+    state.aes_key_loaded[0] = 1;
+    rc |= expect_int("AES with key", ldu2_payload_has_decrypt_key(&state), 1);
+
+    state.payload_algid = 0x80;
+    rc |= expect_int("clear voice is not decrypt-keyed", ldu2_payload_has_decrypt_key(&state), 0);
+    return rc;
+}
+
+static void
+fill_ess_fields(char hex_data[16][6], unsigned long long mi_hi64, uint8_t mi_tail8, uint8_t algid, uint16_t kid) {
+    char mi_bits[72];
+    for (int i = 0; i < 64; i++) {
+        mi_bits[i] = ((mi_hi64 >> (63 - i)) & 1ULL) != 0ULL ? '1' : '0';
+    }
+    for (int i = 0; i < 8; i++) {
+        mi_bits[64 + i] = ((mi_tail8 >> (7 - i)) & 1U) != 0U ? '1' : '0';
+    }
+
+    int pos = 0;
+    for (int row = 15; row >= 4; row--) {
+        for (int bit = 0; bit < 6; bit++) {
+            hex_data[row][bit] = (char)(mi_bits[pos++] == '1');
+        }
+    }
+
+    for (int bit = 0; bit < 6; bit++) {
+        hex_data[3][bit] = (char)(((algid >> (7 - bit)) & 1U) != 0U);
+    }
+    hex_data[2][0] = (char)(((algid >> 1) & 1U) != 0U);
+    hex_data[2][1] = (char)((algid & 1U) != 0U);
+    for (int bit = 0; bit < 4; bit++) {
+        hex_data[2][bit + 2] = (char)(((kid >> (15 - bit)) & 1U) != 0U);
+    }
+    for (int bit = 0; bit < 6; bit++) {
+        hex_data[1][bit] = (char)(((kid >> (11 - bit)) & 1U) != 0U);
+        hex_data[0][bit] = (char)(((kid >> (5 - bit)) & 1U) != 0U);
+    }
+}
+
+static void
+fill_lsd_byte(uint8_t bits16[16], uint8_t value) {
+    for (int i = 0; i < 8; i++) {
+        bits16[i] = (uint8_t)(((value >> (7 - i)) & 1U) != 0U);
+    }
+}
+
+static int
+test_ldu2_early_unmute_policy(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    char hex_data[16][6] = {{0}};
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    fill_ess_fields(hex_data, 0x0102030405060708ULL, 0x09U, 0xAAU, 0x1234U);
+    state.R = 0x55AAU;
+    ldu2_maybe_apply_early_unmute(&opts, &state, (const char (*)[6])hex_data);
+    rc |= expect_int("RC4 early unmute with key", opts.unmute_encrypted_p25, 1);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.unmute_encrypted_p25 = 1;
+    ldu2_maybe_apply_early_unmute(&opts, &state, (const char (*)[6])hex_data);
+    rc |= expect_int("RC4 early mute without key", opts.unmute_encrypted_p25, 0);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.unmute_encrypted_p25 = 7;
+    fill_ess_fields(hex_data, 0x0102030405060708ULL, 0x09U, 0x84U, 0x1234U);
+    ldu2_maybe_apply_early_unmute(&opts, &state, (const char (*)[6])hex_data);
+    rc |= expect_int("AES early policy leaves mute state for key check", opts.unmute_encrypted_p25, 7);
+    return rc;
+}
+
+static int
+test_ldu2_fec_outcomes(void) {
+    static dsd_state state;
+    char hex_data[16][6] = {{0}};
+    char hex_parity[8][6] = {{0}};
+    P25P1SoftDibit soft_dibits[16 * (3 + 2) + 8 * (3 + 2)] = {0};
+    int rc = 0;
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_hook_counters();
+    g_hard_rs_result = 0;
+    rc |= expect_int("hard RS success result", ldu2_run_fec(&state, hex_data, hex_parity, soft_dibits), 0);
+    rc |= expect_int("hard RS success ok count", state.p25_p1_voice_fec_ok, 1);
+    rc |= expect_int("hard RS success err count", state.p25_p1_voice_fec_err, 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_hook_counters();
+    g_hard_rs_result = 1;
+    g_soft_rs_result = 0;
+    rc |= expect_int("soft RS recovery result", ldu2_run_fec(&state, hex_data, hex_parity, soft_dibits), 0);
+    rc |= expect_int("soft RS recovery count", state.p25_p1_soft_rs_ok, 1);
+    rc |= expect_int("soft RS recovery ok count", state.p25_p1_voice_fec_ok, 1);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_hook_counters();
+    g_hard_rs_result = 1;
+    g_soft_rs_result = 1;
+    rc |= expect_int("RS failure result", ldu2_run_fec(&state, hex_data, hex_parity, soft_dibits), 1);
+    rc |= expect_int("RS failure err count", state.p25_p1_voice_fec_err, 1);
+    rc |= expect_int("RS failure critical count", state.debug_header_critical_errors, 1);
+    return rc;
+}
+
+static int
+test_ldu2_hold_hysteresis_refreshes_only_recent_activity(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.trunk_hangtime = 0.0;
+    state.last_vc_sync_time = time(NULL);
+    state.last_vc_sync_time_m = 17.0;
+
+    ldu2_refresh_hold_hysteresis(&opts, &state);
+    rc |= expect_int("recent VC monotonic refresh", (int)state.last_vc_sync_time_m, 42);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.trunk_hangtime = 1.0;
+    state.last_vc_sync_time = time(NULL) - 10;
+    state.last_vc_sync_time_m = 19.0;
+
+    ldu2_refresh_hold_hysteresis(&opts, &state);
+    rc |= expect_int("stale VC monotonic preserved", (int)state.last_vc_sync_time_m, 19);
+    return rc;
+}
+
+static int
+test_ldu2_consume_trailing_status_feeds_classifier(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_hook_counters();
+    g_soft_dibit_value = 1;
+
+    ldu2_consume_trailing_status(&opts, &state);
+
+    rc |= expect_int("status getDibitSoft calls", g_get_dibit_soft_calls, 1);
+    rc |= expect_int("status add calls", g_status_add_calls, 1);
+    rc |= expect_int("status trailing dibit", g_last_status_dibit, 1);
+    rc |= expect_int("status classify calls", g_status_classify_calls, 1);
+    if (g_last_classify_opts != &opts) {
+        DSD_FPRINTF(stderr, "status classify opts pointer mismatch\n");
+        rc = 1;
+    }
+    rc |= expect_int("status classification side effect", state.p25_ss_classification, P25_SS_CLASS_SUBSCRIBER);
+    return rc;
+}
+
+static int
+test_ldu2_capture_lsd_reads_soft_octets_and_updates_counters(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    Ldu2Frame frame;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&frame, 0, sizeof(frame));
+    reset_hook_counters();
+
+    const int dibits[16] = {1, 2, 3, 0, 2, 1, 0, 3, 3, 3, 0, 0, 1, 1, 2, 2};
+    for (int i = 0; i < 16; i++) {
+        g_read_dibit_soft_values[i] = dibits[i];
+    }
+    frame.status_count = 21;
+    state.dropL = 10;
+    state.octet_counter = 4;
+
+    ldu2_capture_lsd(&opts, &state, &frame);
+
+    rc |= expect_int("LDU2 LSD soft reads", g_read_dibit_soft_calls, 16);
+    rc |= expect_int("LDU2 LSD status count", frame.status_count, 37);
+    rc |= expect_string("LDU2 LSD1 bits", frame.lsd1, "01101100");
+    rc |= expect_string("LDU2 LSD2 bits", frame.lsd2, "11110000");
+    rc |= expect_u8("LDU2 LSD1 byte", frame.lsd_hex1, 0x6CU);
+    rc |= expect_u8("LDU2 LSD2 byte", frame.lsd_hex2, 0xF0U);
+    rc |= expect_int("LDU2 LSD data bit 0", frame.lowspeeddata[0], 0);
+    rc |= expect_int("LDU2 LSD data bit 7", frame.lowspeeddata[7], 0);
+    rc |= expect_int("LDU2 LSD parity bit 8", frame.lowspeeddata[8], 1);
+    rc |= expect_int("LDU2 LSD parity bit 15", frame.lowspeeddata[15], 1);
+    rc |= expect_int("LDU2 LSD second data bit 16", frame.lowspeeddata[16], 1);
+    rc |= expect_int("LDU2 LSD second parity bit 31", frame.lowspeeddata[31], 0);
+    rc |= expect_int("LDU2 LSD first llr", frame.lowspeed_llr[0], 100);
+    rc |= expect_int("LDU2 LSD first lsb llr", frame.lowspeed_llr[1], -60);
+    rc |= expect_int("LDU2 LSD last llr", frame.lowspeed_llr[31], -75);
+    rc |= expect_int("LDU2 LSD drop counter", state.dropL, 12);
+    rc |= expect_int("LDU2 LSD octet counter", state.octet_counter, 6);
+    return rc;
+}
+
+static int
+test_ldu2_decode_unmute_and_lsd_alias_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    Ldu2Frame frame;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&frame, 0, sizeof(frame));
+    reset_hook_counters();
+
+    fill_ess_fields(frame.hex_data, 0x123456789ABCDEF0ULL, 0x12U, 0x84U, 0x1234U);
+    fill_lsd_byte(frame.lowspeeddata + 0, 0x41U);
+    fill_lsd_byte(frame.lowspeeddata + 16, 0x42U);
+    state.payload_algid = 0x80;
+    state.aes_key_loaded[0] = 1;
+    state.dmr_alias_format[0] = 0x02;
+    state.dmr_alias_block_len[0] = 2;
+    state.lastsrc = 77;
+
+    ldu2_decode_post_fec_fields(&state, &frame);
+    ldu2_print_decode_result(&opts, &state, &frame);
+    ldu2_handle_lsd_alias(&opts, &state, &frame);
+
+    rc |= expect_int("decoded ALGID", state.payload_algid, 0x84);
+    rc |= expect_int("decoded KID", state.payload_keyid, 0x1234);
+    rc |= expect_u64("decoded MI", state.payload_miP, 0x123456789ABCDEF0ULL);
+    rc |= expect_u8("decoded LSD1", frame.lsd_hex1, 0x41U);
+    rc |= expect_u8("decoded LSD2", frame.lsd_hex2, 0x42U);
+    rc |= expect_int("AES LDU2 unmute", opts.unmute_encrypted_p25, 1);
+    rc |= expect_int("alias finalized resets format", state.dmr_alias_format[0], 0);
+    rc |= expect_int("alias policy make count", g_policy_make_calls, 1);
+    rc |= expect_int("alias policy upsert count", g_policy_upsert_calls, 2);
+    rc |= expect_int("alias policy id", (int)g_last_policy_id, 77);
+    rc |= expect_int("alias policy source", (int)g_last_policy_source, (int)DSD_TG_POLICY_SOURCE_RUNTIME_ALIAS);
+    rc |=
+        expect_int("alias last upsert mode", (int)g_last_policy_upsert_mode, (int)DSD_TG_POLICY_UPSERT_ADD_IF_MISSING);
+    return rc;
+}
+
+static int
+test_ldu2_decode_post_fec_rejects_malformed_ess_bits(void) {
+    static dsd_state state;
+    Ldu2Frame frame;
+    int rc = 0;
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&frame, 0, sizeof(frame));
+    reset_hook_counters();
+
+    fill_ess_fields(frame.hex_data, 0x0102030405060708ULL, 0x09U, 0x80U, 0x1234U);
+    frame.hex_data[3][0] = 2;
+    frame.hex_data[2][2] = 2;
+    fill_lsd_byte(frame.lowspeeddata + 0, 0x41U);
+    fill_lsd_byte(frame.lowspeeddata + 16, 0x42U);
+    state.payload_algid = 0x84;
+
+    ldu2_decode_post_fec_fields(&state, &frame);
+
+    rc |= expect_int("malformed ALGID falls back to zero", frame.algidhex, 0);
+    rc |= expect_int("malformed KID falls back to zero", frame.kidhex, 0);
+    rc |= expect_u64("malformed ESS keeps MI high", frame.mihex1, 0x01020304ULL);
+    rc |= expect_u64("malformed ESS keeps MI low", frame.mihex2, 0x05060708ULL);
+    rc |= expect_u64("malformed ESS keeps MI tail", frame.mihex3, 0x09ULL);
+    rc |= expect_string("malformed ESS LSD1 bits", frame.lsd1, "01000001");
+    rc |= expect_string("malformed ESS LSD2 bits", frame.lsd2, "01000010");
+    rc |= expect_u8("encrypted malformed ESS suppresses LSD1", frame.lsd_hex1, 0U);
+    rc |= expect_u8("encrypted malformed ESS suppresses LSD2", frame.lsd_hex2, 0U);
+    return rc;
+}
+
+static int
+test_ldu2_unmute_policy_variants(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.payload_algid = 0x81;
+    state.R = 0x123456789ABCDEF0ULL;
+    ldu2_apply_unmute_policy(&opts, &state);
+    rc |= expect_int("RC4 0x81 key unmutes", opts.unmute_encrypted_p25, 1);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.payload_algid = 0x9F;
+    state.R = 0x123456789ABCDEF0ULL;
+    ldu2_apply_unmute_policy(&opts, &state);
+    rc |= expect_int("RC4 0x9F key unmutes", opts.unmute_encrypted_p25, 1);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.payload_algid = 0x89;
+    state.aes_key_loaded[0] = 1;
+    state.A1[0] = 0x0011223344556677ULL;
+    state.A2[0] = 0x8899AABBCCDDEEFFULL;
+    ldu2_apply_unmute_policy(&opts, &state);
+    rc |= expect_int("AES-128 key unmutes", opts.unmute_encrypted_p25, 1);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.unmute_encrypted_p25 = 1;
+    state.payload_algid = 0x83;
+    ldu2_apply_unmute_policy(&opts, &state);
+    rc |= expect_int("unknown encrypted ALGID mutes", opts.unmute_encrypted_p25, 0);
+    return rc;
+}
+
+static int
+test_ldu2_lsd_alias_begin_clamps_length(void) {
+    static dsd_state state;
+    Ldu2Frame frame;
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&frame, 0, sizeof(frame));
+    frame.lsd_hex1 = 0x02;
+    frame.lsd_hex2 = 0x0B;
+    frame.lsd1_okay = 1;
+    frame.lsd2_okay = 1;
+
+    ldu2_maybe_begin_lsd_alias(&state, &frame);
+
+    int rc = 0;
+    rc |= expect_int("alias begin format", state.dmr_alias_format[0], 0x02);
+    rc |= expect_int("alias begin clamped length", state.dmr_alias_block_len[0], 8);
+    rc |= expect_int("alias begin counter reset", state.data_block_counter[0], 0);
+    return rc;
+}
+
+static int
+test_ldu2_encrypted_trunk_lockout_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(g_event_history, 0, sizeof(g_event_history));
+    reset_hook_counters();
+
+    opts.p25_trunk = 1;
+    opts.p25_is_tuned = 1;
+    opts.trunk_tune_enc_calls = 0;
+    (void)DSD_SNPRINTF(opts.event_out_file, sizeof(opts.event_out_file), "%s", "events.log");
+    state.event_history_s = g_event_history;
+    state.payload_algid = 0xAA;
+    state.payload_keyid = 0x2A2A;
+    state.lasttg = 2468;
+
+    ldu2_maybe_enc_lockout(&opts, &state, 0);
+
+    rc |= expect_int("lockout release", g_release_calls, 1);
+    rc |= expect_int("lockout policy make", g_policy_make_calls, 1);
+    rc |= expect_int("lockout policy upsert", g_policy_upsert_calls, 1);
+    rc |= expect_int("lockout policy id", (int)g_last_policy_id, 2468);
+    rc |= expect_int("lockout policy source", (int)g_last_policy_source, (int)DSD_TG_POLICY_SOURCE_ENC_LOCKOUT);
+    rc |= expect_int("lockout policy mode", (int)g_last_policy_upsert_mode, (int)DSD_TG_POLICY_UPSERT_REPLACE_FIRST);
+    rc |= expect_int("lockout watchdog", g_watchdog_calls, 1);
+    rc |= expect_int("lockout write event", g_write_event_calls, 1);
+    rc |= expect_int("lockout push event", g_push_event_calls, 1);
+    rc |= expect_int("lockout init event", g_init_event_calls, 1);
+
+    reset_hook_counters();
+    state.R = 0x1234U;
+    ldu2_maybe_enc_lockout(&opts, &state, 0);
+    rc |= expect_int("lockout skipped with key", g_release_calls, 0);
+    rc |= expect_int("lockout skipped policy", g_policy_make_calls, 0);
+    return rc;
+}
+
+static int
+test_ldu2_lockout_suppression_variants(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(g_event_history, 0, sizeof(g_event_history));
+    reset_hook_counters();
+
+    state.event_history_s = g_event_history;
+    ldu2_record_enc_lockout(&opts, &state, 0);
+    rc |= expect_int("zero talkgroup skips policy", g_policy_make_calls, 0);
+    rc |= expect_int("zero talkgroup skips release", g_release_calls, 0);
+
+    reset_hook_counters();
+    g_lookup_label = "Known ENC";
+    ldu2_record_enc_lockout(&opts, &state, 2468);
+    rc |= expect_int("existing lockout still builds policy", g_policy_make_calls, 1);
+    rc |= expect_int("existing lockout upserts policy", g_policy_upsert_calls, 1);
+    rc |= expect_int("existing lockout skips event", g_watchdog_calls, 0);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(g_event_history, 0, sizeof(g_event_history));
+    reset_hook_counters();
+    opts.p25_trunk = 1;
+    opts.p25_is_tuned = 1;
+    state.event_history_s = g_event_history;
+    state.payload_algid = 0xAA;
+    state.lasttg = 2468;
+    (void)DSD_SNPRINTF(state.event_history_s[0].Event_History_Items[1].internal_str,
+                       sizeof state.event_history_s[0].Event_History_Items[1].internal_str,
+                       "Target: %d; has been locked out; Encryption Lock Out Enabled.", state.lasttg);
+
+    ldu2_maybe_enc_lockout(&opts, &state, 0);
+    rc |= expect_int("duplicate lockout still releases", g_release_calls, 1);
+    rc |= expect_int("duplicate lockout watchdog", g_watchdog_calls, 1);
+    rc |= expect_int("duplicate lockout no history push", g_push_event_calls, 0);
+    rc |= expect_int("duplicate lockout no history init", g_init_event_calls, 0);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_ldu2_extracts_ess_fields();
+    rc |= test_lsd_corrected_byte();
+    rc |= test_ldu2_rs_reliability_uses_wire_order();
+    rc |= test_ldu2_decrypt_key_gate();
+    rc |= test_ldu2_early_unmute_policy();
+    rc |= test_ldu2_fec_outcomes();
+    rc |= test_ldu2_hold_hysteresis_refreshes_only_recent_activity();
+    rc |= test_ldu2_consume_trailing_status_feeds_classifier();
+    rc |= test_ldu2_capture_lsd_reads_soft_octets_and_updates_counters();
+    rc |= test_ldu2_decode_unmute_and_lsd_alias_state();
+    rc |= test_ldu2_decode_post_fec_rejects_malformed_ess_bits();
+    rc |= test_ldu2_unmute_policy_variants();
+    rc |= test_ldu2_lsd_alias_begin_clamps_length();
+    rc |= test_ldu2_encrypted_trunk_lockout_state();
+    rc |= test_ldu2_lockout_suppression_variants();
+    return rc;
+}
+
+// NOLINTEND(bugprone-implicit-widening-of-multiplication-result,bugprone-suspicious-include)

--- a/tests/protocol/p25/test_p25_p1_ldu_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_ldu_helpers.c
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-suspicious-include)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * P25 P1 common LDU helper tests: verify shared IMBE/status and Hamming
+ * correction helpers without requiring a live LDU1/LDU2 dibit stream.
+ */
+
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/vocoder.h>
+#include <dsd-neo/protocol/p25/p25_status_symbol.h>
+#include <dsd-neo/protocol/p25/p25p1_check_ldu.h>
+#include <dsd-neo/protocol/p25/p25p1_hdu.h>
+#include <dsd-neo/protocol/p25/p25p1_soft.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/protocol/p25/p25p1_const.h"
+
+static int g_status_dibit;
+static int g_status_add_count;
+static int g_get_dibit_soft_count;
+static int g_dibit_sequence_len;
+static int g_dibit_sequence[80];
+static int g_vocoder_calls;
+static dsd_vocoder_soft_bit g_last_imbe_soft[8][23];
+static int g_hard_hamming_result;
+static int g_soft_hamming_result;
+static char g_read_word_bits[6];
+static char g_read_parity_bits[4];
+static char g_soft_hamming_output[10];
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
+    (void)opts;
+    (void)state;
+    int call_index = g_get_dibit_soft_count++;
+    int dibit = g_status_dibit;
+    const int sequence_capacity = (int)(sizeof(g_dibit_sequence) / sizeof(g_dibit_sequence[0]));
+    if (call_index >= 0 && call_index < g_dibit_sequence_len && call_index < sequence_capacity) {
+        dibit = g_dibit_sequence[call_index];
+    }
+    if (out_soft != NULL) {
+        out_soft->llr[0] = (int16_t)(11 + call_index);
+        out_soft->llr[1] = (int16_t)(-(12 + call_index));
+    }
+    return dibit;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_status_accum_add(dsd_state* state, int dibit_value) {
+    (void)state;
+    g_status_add_count++;
+    g_status_dibit = dibit_value;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+processMbeFrameSoft(dsd_opts* opts, dsd_state* state, dsd_vocoder_soft_bit imbe_fr[8][23],
+                    dsd_vocoder_soft_bit ambe_fr[4][24], dsd_vocoder_soft_bit imbe7100_fr[7][24]) {
+    (void)opts;
+    (void)state;
+    (void)imbe_fr;
+    (void)ambe_fr;
+    (void)imbe7100_fr;
+    g_vocoder_calls++;
+    DSD_MEMCPY(g_last_imbe_soft, imbe_fr, sizeof(g_last_imbe_soft));
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+read_word(dsd_opts* opts, dsd_state* state, char* word, unsigned int length, int* status_count,
+          P25P1SoftDibit* soft_dibits, int* soft_dibit_index) {
+    (void)opts;
+    (void)state;
+    (void)status_count;
+    for (unsigned int idx = 0; idx < length && idx < 6; idx++) {
+        word[idx] = g_read_word_bits[idx];
+    }
+    if (soft_dibits != NULL && soft_dibit_index != NULL) {
+        for (int idx = 0; idx < 3; idx++) {
+            soft_dibits[*soft_dibit_index + idx].llr[0] = (int16_t)(30 + idx);
+            soft_dibits[*soft_dibit_index + idx].llr[1] = (int16_t)(-(40 + idx));
+        }
+        *soft_dibit_index += 3;
+    }
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+read_hamm_parity(dsd_opts* opts, dsd_state* state, char* parity, int* status_count, P25P1SoftDibit* soft_dibits,
+                 int* soft_dibit_index) {
+    (void)opts;
+    (void)state;
+    (void)status_count;
+    for (int idx = 0; idx < 4; idx++) {
+        parity[idx] = g_read_parity_bits[idx];
+    }
+    if (soft_dibits != NULL && soft_dibit_index != NULL) {
+        for (int idx = 0; idx < 2; idx++) {
+            soft_dibits[*soft_dibit_index + idx].llr[0] = (int16_t)(50 + idx);
+            soft_dibits[*soft_dibit_index + idx].llr[1] = (int16_t)(-(60 + idx));
+        }
+        *soft_dibit_index += 2;
+    }
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+check_and_fix_hamming_10_6_3(char* hex, char* parity) {
+    (void)hex;
+    (void)parity;
+    return g_hard_hamming_result;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+hamming_10_6_3_soft(const char* bits, const int* reliab, char* out_bits) {
+    (void)bits;
+    (void)reliab;
+    DSD_MEMCPY(out_bits, g_soft_hamming_output, 10);
+    return g_soft_hamming_result;
+}
+
+uint8_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25p1_llr_reliability(const int16_t* llr, int bit_count) {
+    int min_reliability = 255;
+    for (int bit = 0; bit < bit_count; bit++) {
+        int reliab = llr[bit] < 0 ? -(int)llr[bit] : (int)llr[bit];
+        if (reliab < min_reliability) {
+            min_reliability = reliab;
+        }
+    }
+    return (uint8_t)min_reliability;
+}
+
+#include "../../../src/protocol/p25/phase1/p25p1_ldu.c"
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_mem(const char* tag, const char* got, const char* want, size_t len) {
+    if (memcmp(got, want, len) != 0) {
+        DSD_FPRINTF(stderr, "%s: buffer mismatch\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_ldu_input_guards_and_status_symbol(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    char hex[6] = {0};
+    int status_count = 34;
+    int soft_index = 0;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    int rc = 0;
+    rc |= expect_int("valid inputs", has_valid_ldu_read_inputs(&opts, &state, hex, &status_count, &soft_index), 1);
+    rc |= expect_int("null opts invalid", has_valid_ldu_read_inputs(NULL, &state, hex, &status_count, &soft_index), 0);
+    rc |= expect_int("null index invalid", has_valid_ldu_read_inputs(&opts, &state, hex, &status_count, NULL), 0);
+
+    maybe_read_midframe_status_symbol(&opts, &state, &status_count);
+    rc |= expect_int("status count increments before symbol", status_count, 35);
+    rc |= expect_int("no status add before symbol", g_status_add_count, 0);
+
+    g_status_dibit = 3;
+    maybe_read_midframe_status_symbol(&opts, &state, &status_count);
+    rc |= expect_int("status count reset after symbol", status_count, 1);
+    rc |= expect_int("status add count", g_status_add_count, 1);
+    rc |= expect_int("status dibit forwarded", g_status_dibit, 3);
+    return rc;
+}
+
+static int
+test_ldu_soft_hamming_inputs_and_reliability(void) {
+    P25P1SoftDibit soft[5] = {
+        {.llr = {10, -11}}, {.llr = {-12, 13}}, {.llr = {14, -15}}, {.llr = {-16, 17}}, {.llr = {18, -19}},
+    };
+    char bits[10] = {0};
+    int reliab[10] = {0};
+    const char raw_hex[6] = {1, 0, 1, 1, 0, 0};
+    const char raw_parity[4] = {0, 1, 1, 0};
+
+    build_soft_hamming_inputs(bits, reliab, raw_hex, raw_parity, soft, 0);
+
+    int rc = 0;
+    rc |= expect_mem("soft hamming bits", bits, "\001\000\001\001\000\000\000\001\001\000", 10);
+    static const int want_reliab[10] = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+    for (int idx = 0; idx < 10; idx++) {
+        rc |= expect_int("soft hamming reliability", reliab[idx], want_reliab[idx]);
+    }
+    rc |= expect_int("symbol reliability first three dibits", p25p1_hamming_rs_symbol_reliability(soft), 10);
+    rc |= expect_int("null symbol reliability", p25p1_hamming_rs_symbol_reliability(NULL), 0);
+    return rc;
+}
+
+static int
+test_ldu_soft_hamming_fix_paths(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    char hex[6] = {1, 0, 1, 0, 1, 0};
+    char parity[4] = {1, 1, 0, 0};
+    const char hard_bits[10] = {1, 0, 1, 0, 1, 0, 1, 1, 0, 0};
+    P25P1SoftDibit soft[5] = {0};
+
+    g_soft_hamming_result = 2;
+    DSD_MEMSET(g_soft_hamming_output, 0, sizeof(g_soft_hamming_output));
+    int rc = 0;
+    rc |= expect_int("soft irrecoverable returns hard result",
+                     apply_soft_hamming_fix(&state, hex, parity, hard_bits, hex, parity, 2, soft, 0), 2);
+    rc |= expect_int("soft ok count unchanged", (int)state.p25_p1_soft_hamming_ok, 0);
+
+    static const char corrected[10] = {0, 1, 0, 1, 0, 1, 1, 0, 1, 0};
+    DSD_MEMCPY(g_soft_hamming_output, corrected, sizeof(corrected));
+    g_soft_hamming_result = 1;
+    rc |= expect_int("soft corrected result",
+                     apply_soft_hamming_fix(&state, hex, parity, hard_bits, hex, parity, 1, soft, 0), 1);
+    rc |= expect_int("soft ok count increment", (int)state.p25_p1_soft_hamming_ok, 1);
+    rc |= expect_mem("corrected hex", hex, corrected, 6);
+    rc |= expect_mem("corrected parity", parity, corrected + 6, 4);
+    return rc;
+}
+
+static int
+test_ldu_read_and_correct_hex_word(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMCPY(g_read_word_bits, "\001\000\001\000\001\000", 6);
+    DSD_MEMCPY(g_read_parity_bits, "\001\001\000\000", 4);
+    static const char corrected[10] = {1, 1, 0, 0, 1, 1, 0, 1, 0, 1};
+    DSD_MEMCPY(g_soft_hamming_output, corrected, sizeof(corrected));
+    g_hard_hamming_result = 1;
+    g_soft_hamming_result = 0;
+
+    char hex[6] = {0};
+    int status_count = 4;
+    int soft_index = 0;
+    P25P1SoftDibit soft[5] = {0};
+    read_and_correct_hex_word(&opts, &state, hex, &status_count, soft, &soft_index);
+
+    int rc = 0;
+    rc |= expect_int("soft dibit index", soft_index, 5);
+    rc |= expect_mem("read corrected hex", hex, corrected, 6);
+    rc |= expect_int("soft hamming count through read", (int)state.p25_p1_soft_hamming_ok, 1);
+    rc |= expect_int("no hard error after soft fix", (int)state.debug_header_errors, 0);
+
+    state.debug_header_errors = 0;
+    g_hard_hamming_result = 1;
+    read_and_correct_hex_word(&opts, &state, hex, &status_count, NULL, &soft_index);
+    rc |= expect_int("hard corrected header error", (int)state.debug_header_errors, 1);
+    return rc;
+}
+
+static int
+test_ldu_imbe_skip_and_encryption_flag(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    char imbe_fr[8][23] = {{0}};
+    dsd_vocoder_soft_bit imbe_soft_fr[8][23] = {{{0}}};
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    static const int non_standard_ones[] = {15, 16, 17};
+    for (unsigned int idx = 0; idx < sizeof(non_standard_ones) / sizeof(non_standard_ones[0]); idx++) {
+        imbe_fr[0][non_standard_ones[idx]] = 1;
+    }
+
+    g_vocoder_calls = 0;
+    process_imbe_or_skip_non_standard(&opts, &state, imbe_fr, imbe_soft_fr);
+    int rc = 0;
+    rc |= expect_int("non-standard c0 skipped", g_vocoder_calls, 0);
+    imbe_fr[0][0] = 1;
+    process_imbe_or_skip_non_standard(&opts, &state, imbe_fr, imbe_soft_fr);
+    rc |= expect_int("standard c0 dispatched", g_vocoder_calls, 1);
+
+    state.payload_algid = 0x80;
+    update_ldu_encryption_flag(&state);
+    rc |= expect_int("clear algid not encrypted", state.dmr_encL, 0);
+    state.payload_algid = 0x00;
+    update_ldu_encryption_flag(&state);
+    rc |= expect_int("unknown algid encrypted until confirmed", state.dmr_encL, 1);
+    return rc;
+}
+
+static int
+test_ldu_process_imbe_status_cadence_and_soft_dispatch(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(g_last_imbe_soft, 0, sizeof(g_last_imbe_soft));
+
+    g_get_dibit_soft_count = 0;
+    g_status_add_count = 0;
+    g_vocoder_calls = 0;
+    g_dibit_sequence_len = 74;
+    for (int idx = 0; idx < g_dibit_sequence_len; idx++) {
+        g_dibit_sequence[idx] = idx & 0x3;
+    }
+    g_dibit_sequence[34] = 2;
+    g_dibit_sequence[70] = 3;
+
+    state.payload_algid = 0x80;
+    int status_count = 1;
+    process_IMBE(&opts, &state, &status_count);
+
+    int rc = 0;
+    rc |= expect_int("soft dibits consumed including status", g_get_dibit_soft_count, 74);
+    rc |= expect_int("midframe status symbols forwarded", g_status_add_count, 2);
+    rc |= expect_int("last status dibit forwarded", g_status_dibit, 3);
+    rc |= expect_int("status cadence carries forward", status_count, 3);
+    rc |= expect_int("clear payload keeps encryption flag clear", state.dmr_encL, 0);
+    rc |= expect_int("IMBE dispatched once", g_vocoder_calls, 1);
+
+    const int first_voice_call = 0;
+    int first_dibit = g_dibit_sequence[first_voice_call];
+    rc |= expect_int("first interleaved MSB",
+                     g_last_imbe_soft[p25p1_imbe_interleave_w[0]][p25p1_imbe_interleave_x[0]].bit,
+                     (first_dibit >> 1) & 1);
+    rc |= expect_int("first interleaved LSB",
+                     g_last_imbe_soft[p25p1_imbe_interleave_y[0]][p25p1_imbe_interleave_z[0]].bit, first_dibit & 1);
+    rc |= expect_int("first MSB reliability",
+                     g_last_imbe_soft[p25p1_imbe_interleave_w[0]][p25p1_imbe_interleave_x[0]].reliability, 11);
+    rc |= expect_int("first LSB reliability",
+                     g_last_imbe_soft[p25p1_imbe_interleave_y[0]][p25p1_imbe_interleave_z[0]].reliability, 12);
+
+    const int voice_index_after_first_status = 34;
+    const int call_after_first_status = voice_index_after_first_status + 1;
+    int dibit_after_first_status = g_dibit_sequence[call_after_first_status];
+    rc |= expect_int("voice after status MSB",
+                     g_last_imbe_soft[p25p1_imbe_interleave_w[voice_index_after_first_status]]
+                                     [p25p1_imbe_interleave_x[voice_index_after_first_status]]
+                                         .bit,
+                     (dibit_after_first_status >> 1) & 1);
+    rc |= expect_int("voice after status LSB",
+                     g_last_imbe_soft[p25p1_imbe_interleave_y[voice_index_after_first_status]]
+                                     [p25p1_imbe_interleave_z[voice_index_after_first_status]]
+                                         .bit,
+                     dibit_after_first_status & 1);
+    rc |= expect_int("voice after status MSB reliability",
+                     g_last_imbe_soft[p25p1_imbe_interleave_w[voice_index_after_first_status]]
+                                     [p25p1_imbe_interleave_x[voice_index_after_first_status]]
+                                         .reliability,
+                     11 + call_after_first_status);
+    rc |= expect_int("voice after status LSB reliability",
+                     g_last_imbe_soft[p25p1_imbe_interleave_y[voice_index_after_first_status]]
+                                     [p25p1_imbe_interleave_z[voice_index_after_first_status]]
+                                         .reliability,
+                     12 + call_after_first_status);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_ldu_input_guards_and_status_symbol();
+    rc |= test_ldu_soft_hamming_inputs_and_reliability();
+    rc |= test_ldu_soft_hamming_fix_paths();
+    rc |= test_ldu_read_and_correct_hex_word();
+    rc |= test_ldu_imbe_skip_and_encryption_flag();
+    rc |= test_ldu_process_imbe_status_cadence_and_soft_dispatch();
+    return rc;
+}
+
+// NOLINTEND(bugprone-suspicious-include)

--- a/tests/protocol/p25/test_p25_p1_mdpu_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_mdpu_helpers.c
@@ -1,0 +1,870 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-suspicious-include)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * P25 P1 MDPU helper tests: verify deterministic header, CRC candidate,
+ * repetition, and rate 3/4 bit-assembly behavior without live dibit input.
+ */
+
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <dsd-neo/protocol/p25/p25_12.h>
+#include <dsd-neo/protocol/p25/p25_crc.h>
+#include <dsd-neo/protocol/p25/p25_pdu.h>
+#include <dsd-neo/protocol/p25/p25_status_symbol.h>
+#include <dsd-neo/protocol/p25/p25p1_mbf34.h>
+#include <dsd-neo/protocol/p25/p25p1_pdu_trunking.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static p25_12_candidate_t g_soft_candidates[P25_12_MAX_CANDIDATES];
+static int g_soft_candidate_count;
+static uint8_t g_r12_fallback_bytes[12];
+static int g_r12_fallback_calls;
+static p25_mbf34_candidate_t g_mbf34_candidates[P25_MBF34_MAX_CANDIDATES];
+static int g_mbf34_candidate_count;
+static uint8_t g_mbf34_fallback_bytes[18];
+static int g_mbf34_fallback_calls;
+static int g_get_dibit_soft_calls;
+static int g_status_add_calls;
+static int g_last_status_dibit;
+static int g_pdu_header_calls;
+static int g_pdu_data_calls;
+static int g_pdu_trunking_calls;
+static int g_status_ensure_started_calls;
+static int g_status_classify_calls;
+static int g_last_pdu_data_len;
+
+static uint16_t
+test_crc16_bits(const int* payload, int len) {
+    uint16_t crc = 0;
+    const uint16_t poly = 0x1021;
+    for (int bit = 0; bit < len; bit++) {
+        if (((crc >> 15) & 1) ^ (payload[bit] & 1)) {
+            crc = (uint16_t)((crc << 1) ^ poly);
+        } else {
+            crc = (uint16_t)(crc << 1);
+        }
+    }
+    return (uint16_t)(crc ^ 0xFFFF);
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+crc16_lb_bridge(const int* payload, int len) {
+    uint16_t extracted = 0;
+    for (int bit = 0; bit < 16; bit++) {
+        extracted = (uint16_t)((extracted << 1) | (payload[len + bit] & 1));
+    }
+    return (test_crc16_bits(payload, len) == extracted) ? 0 : 1;
+}
+
+uint64_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ConvertBitIntoBytes(const uint8_t* buffer_in, uint32_t bit_length) {
+    uint64_t value = 0;
+    for (uint32_t bit = 0; bit < bit_length; bit++) {
+        value = (value << 1) | (uint64_t)(buffer_in[bit] & 1);
+    }
+    return value;
+}
+
+uint16_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+ComputeCrc9Bit(const uint8_t* data, uint32_t bit_count) {
+    uint16_t crc = 0;
+    for (uint32_t bit = 0; bit < bit_count; bit++) {
+        crc = (uint16_t)(((crc << 1) ^ (data[bit] & 1U) ^ ((crc >> 8) & 1U)) & 0x1FFU);
+    }
+    return crc;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_12_soft_llr_list(const uint8_t* input, const int16_t* bit_llr196, p25_12_candidate_t* candidates,
+                     int max_candidates) {
+    (void)input;
+    (void)bit_llr196;
+    int count = (g_soft_candidate_count < max_candidates) ? g_soft_candidate_count : max_candidates;
+    for (int idx = 0; idx < count; idx++) {
+        candidates[idx] = g_soft_candidates[idx];
+    }
+    return count;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_12_soft_llr(const uint8_t* input, const int16_t* bit_llr196, uint8_t treturn[12]) {
+    (void)input;
+    (void)bit_llr196;
+    g_r12_fallback_calls++;
+    DSD_MEMCPY(treturn, g_r12_fallback_bytes, sizeof(g_r12_fallback_bytes));
+    return 0;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_mbf34_decode_soft_list(const uint8_t dibits[98], const int16_t bit_llr[196], p25_mbf34_candidate_t* candidates,
+                           int max_candidates) {
+    (void)dibits;
+    (void)bit_llr;
+    int count = (g_mbf34_candidate_count < max_candidates) ? g_mbf34_candidate_count : max_candidates;
+    for (int idx = 0; idx < count; idx++) {
+        candidates[idx] = g_mbf34_candidates[idx];
+    }
+    return count;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_mbf34_decode_soft(const uint8_t dibits[98], const int16_t bit_llr[196], uint8_t out[18]) {
+    (void)dibits;
+    (void)bit_llr;
+    g_mbf34_fallback_calls++;
+    DSD_MEMCPY(out, g_mbf34_fallback_bytes, sizeof(g_mbf34_fallback_bytes));
+    return 0;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
+    (void)opts;
+    (void)state;
+    int call = g_get_dibit_soft_calls++;
+    if (out_soft != NULL) {
+        out_soft->llr[0] = (int16_t)(1000 + call);
+        out_soft->llr[1] = (int16_t)(-(2000 + call));
+    }
+    return call & 0x3;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_status_accum_add(dsd_state* state, int dibit_value) {
+    (void)state;
+    g_status_add_calls++;
+    g_last_status_dibit = dibit_value;
+}
+
+void
+p25_decode_pdu_header(dsd_opts* opts, dsd_state* state, const uint8_t* input) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    g_pdu_header_calls++;
+}
+
+void
+p25_decode_pdu_data(dsd_opts* opts, dsd_state* state, uint8_t* input, int len) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    g_pdu_data_calls++;
+    g_last_pdu_data_len = len;
+}
+
+void
+p25_decode_pdu_trunking(dsd_opts* opts, dsd_state* state, const uint8_t* mpdu_byte) {
+    (void)opts;
+    (void)state;
+    (void)mpdu_byte;
+    g_pdu_trunking_calls++;
+}
+
+void
+p25_status_accum_ensure_started(dsd_state* state) {
+    (void)state;
+    g_status_ensure_started_calls++;
+}
+
+void
+p25_status_accum_classify(dsd_state* state, const dsd_opts* opts) {
+    (void)state;
+    (void)opts;
+    g_status_classify_calls++;
+}
+
+#include "../../../src/protocol/p25/phase1/p25p1_mdpu.c"
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u8(const char* tag, uint8_t got, uint8_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got 0x%02X want 0x%02X\n", tag, (unsigned int)got, (unsigned int)want);
+        return 1;
+    }
+    return 0;
+}
+
+static void
+reset_dispatch_counters(void) {
+    g_pdu_header_calls = 0;
+    g_pdu_data_calls = 0;
+    g_pdu_trunking_calls = 0;
+    g_status_ensure_started_calls = 0;
+    g_status_classify_calls = 0;
+    g_last_pdu_data_len = 0;
+}
+
+static void
+bytes_to_int_bits(const uint8_t* bytes, int byte_count, int* bits) {
+    for (int byte_idx = 0; byte_idx < byte_count; byte_idx++) {
+        for (int bit = 0; bit < 8; bit++) {
+            bits[(byte_idx * 8) + bit] = (bytes[byte_idx] >> (7 - bit)) & 1;
+        }
+    }
+}
+
+static void
+append_crc16(uint8_t bytes[P25_MPDU_R12_BYTES]) {
+    int bits[P25_MPDU_HEADER_BITS] = {0};
+    bytes_to_int_bits(bytes, P25_MPDU_R12_BYTES, bits);
+    uint16_t crc = test_crc16_bits(bits, 80);
+    bytes[10] = (uint8_t)(crc >> 8);
+    bytes[11] = (uint8_t)(crc & 0xFF);
+}
+
+static void
+bytes_to_u8_bits(const uint8_t* bytes, int byte_count, uint8_t* bits) {
+    for (int byte_idx = 0; byte_idx < byte_count; byte_idx++) {
+        for (int bit = 0; bit < 8; bit++) {
+            bits[(byte_idx * 8) + bit] = (uint8_t)((bytes[byte_idx] >> (7 - bit)) & 1);
+        }
+    }
+}
+
+static void
+set_mbf34_crc9_extension(uint8_t bytes[P25_MPDU_R34_BYTES]) {
+    bytes[0] &= 0xFEU;
+    bytes[1] = 0;
+    uint16_t crc9 = p25_mpdu_candidate_crc9(bytes);
+    bytes[0] = (uint8_t)((bytes[0] & 0xFEU) | ((crc9 >> 8) & 1U));
+    bytes[1] = (uint8_t)(crc9 & 0xFFU);
+}
+
+static int
+test_context_init_and_saturating_add(void) {
+    P25MpduContext ctx;
+    p25_mpdu_context_init(&ctx);
+
+    int rc = 0;
+    rc |= expect_int("default end", ctx.end, 3);
+    rc |= expect_int("header crc init", ctx.hdr_rep_crc[0], -2);
+    rc |= expect_int("payload crc init", ctx.err[1], -2);
+    rc |= expect_int("positive saturation", saturating_llr_add(INT16_MAX - 2, 10), INT16_MAX);
+    rc |= expect_int("negative saturation", saturating_llr_add(INT16_MIN + 2, -10), INT16_MIN);
+    rc |= expect_int("ordinary add", saturating_llr_add(100, -25), 75);
+    return rc;
+}
+
+static int
+test_prepare_state_resets_mpdu_frame_context(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.slot_preference = 1;
+    state.p25_p1_duid_mpdu = 41;
+    state.voice_counter[0] = 7;
+    state.voice_counter[1] = 8;
+    state.s_l4[0][0] = 11;
+    state.s_r4[0][0] = 12;
+    state.currentslot = 1;
+    state.last_active_time = time(NULL) - 10;
+    DSD_SNPRINTF(state.call_string[0], sizeof(state.call_string[0]), "%s", "left");
+    DSD_SNPRINTF(state.call_string[1], sizeof(state.call_string[1]), "%s", "right");
+    DSD_SNPRINTF(state.active_channel[0], sizeof(state.active_channel[0]), "%s", "active");
+    reset_dispatch_counters();
+
+    p25_mpdu_prepare_state(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_int("mpdu counter increment", (int)state.p25_p1_duid_mpdu, 42);
+    rc |= expect_int("left voice counter reset", state.voice_counter[0], 0);
+    rc |= expect_int("right voice counter reset", state.voice_counter[1], 0);
+    rc |= expect_int("left 4v samples reset", state.s_l4[0][0], 0);
+    rc |= expect_int("right 4v samples reset", state.s_r4[0][0], 0);
+    rc |= expect_int("slot preference set", opts.slot_preference, 2);
+    rc |= expect_int("current slot reset", state.currentslot, 0);
+    rc |= expect_int("status accumulator started", g_status_ensure_started_calls, 1);
+    rc |= expect_int("left call string padded", strcmp(state.call_string[0], "                     "), 0);
+    rc |= expect_int("right call string padded", strcmp(state.call_string[1], "                     "), 0);
+    rc |= expect_int("stale active channel cleared", state.active_channel[0][0], 0);
+    return rc;
+}
+
+static int
+test_header_store_and_update_fields(void) {
+    P25MpduContext ctx;
+    static dsd_opts opts;
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+
+    const uint8_t header[P25_MPDU_R12_BYTES] = {0x56, 0x3D, 0x12, 0x34, 0x56, 0x78, 0x8C, 0x9A, 0xBC, 0xDE, 0x00, 0x00};
+    bytes_to_int_bits(header, P25_MPDU_R12_BYTES, ctx.tsbk_decoded_bits);
+    p25_mpdu_store_r12_block(&ctx, 0);
+
+    int rc = 0;
+    rc |= expect_u8("stored byte 0", ctx.mpdu_byte[0], 0x56);
+    rc |= expect_u8("stored byte 7", ctx.mpdu_byte[7], 0x9A);
+
+    opts.aggressive_framesync = 1;
+    ctx.hdr_rep_crc[0] = 1;
+    p25_mpdu_update_header_from_first_block(&ctx, &opts);
+    rc |= expect_int("aggressive bad header leaves fmt unchanged", ctx.fmt, 0);
+
+    ctx.hdr_rep_crc[0] = 0;
+    p25_mpdu_update_header_from_first_block(&ctx, &opts);
+    rc |= expect_int("io", ctx.io, 0);
+    rc |= expect_int("fmt", ctx.fmt, 0x16);
+    rc |= expect_int("sap", ctx.sap, 0x3D);
+    rc |= expect_int("blks", ctx.blks, 12);
+    rc |= expect_int("rate34", ctx.r34, 1);
+    rc |= expect_int("large trunking end clamp", ctx.end, 4);
+    return rc;
+}
+
+static int
+test_candidate_selection_uses_crc_fields(void) {
+    p25_mbf34_candidate_t mbf[P25_MBF34_MAX_CANDIDATES];
+    DSD_MEMSET(mbf, 0, sizeof(mbf));
+    for (int byte_idx = 0; byte_idx < P25_MPDU_R34_BYTES; byte_idx++) {
+        mbf[0].bytes[byte_idx] = (uint8_t)(0x10 + byte_idx);
+        mbf[1].bytes[byte_idx] = (uint8_t)(0x80 ^ (byte_idx * 7));
+    }
+    set_mbf34_crc9_extension(mbf[1].bytes);
+
+    p25_12_candidate_t r12[P25_12_MAX_CANDIDATES];
+    DSD_MEMSET(r12, 0, sizeof(r12));
+    for (int byte_idx = 0; byte_idx < P25_MPDU_R12_BYTES; byte_idx++) {
+        r12[0].bytes[byte_idx] = (uint8_t)(0xA0 + byte_idx);
+        r12[1].bytes[byte_idx] = (uint8_t)(0x30 + (byte_idx * 3));
+    }
+    append_crc16(r12[1].bytes);
+
+    int rc = 0;
+    rc |= expect_int("mbf34 crc9 candidate", p25_mpdu_select_mbf34_candidate(mbf, 2), 1);
+    mbf[1].bytes[1] ^= 0x01;
+    rc |= expect_int("mbf34 fallback candidate", p25_mpdu_select_mbf34_candidate(mbf, 2), 0);
+    rc |= expect_int("r12 crc16 candidate", p25_mpdu_select_crc16_candidate(r12, 2), 1);
+    r12[1].bytes[11] ^= 0x01;
+    rc |= expect_int("r12 fallback candidate", p25_mpdu_select_crc16_candidate(r12, 2), 0);
+    return rc;
+}
+
+static int
+test_read_repetition_captures_soft_symbols_and_status_dibits(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    P25MpduContext ctx;
+    int expected_dibit[P25_MPDU_TSBK_DIBITS] = {0};
+    int expected_call[P25_MPDU_TSBK_DIBITS] = {0};
+    int expected_count = 0;
+    int expected_status_count = 0;
+    int expected_last_status = 0;
+    int expected_skip = 36 - 14;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_mpdu_context_init(&ctx);
+    g_get_dibit_soft_calls = 0;
+    g_status_add_calls = 0;
+    g_last_status_dibit = -1;
+
+    for (int call = 0; call < 101 && expected_count < P25_MPDU_TSBK_DIBITS; call++) {
+        int dibit = call & 0x3;
+        if ((expected_skip / 36) == 0) {
+            expected_dibit[expected_count] = dibit;
+            expected_call[expected_count] = call;
+            expected_count++;
+        } else {
+            expected_status_count++;
+            expected_last_status = dibit;
+            expected_skip = 0;
+        }
+        expected_skip++;
+    }
+
+    int skipdibit = 36 - 14;
+    p25_mpdu_read_repetition(&opts, &state, &ctx, &skipdibit);
+
+    int rc = 0;
+    rc |= expect_int("captured dibits", expected_count, P25_MPDU_TSBK_DIBITS);
+    rc |= expect_int("soft reader calls", g_get_dibit_soft_calls, 101);
+    rc |= expect_int("status dibits forwarded", g_status_add_calls, expected_status_count);
+    rc |= expect_int("last status dibit", g_last_status_dibit, expected_last_status);
+    rc |= expect_int("skip state carried", skipdibit, expected_skip);
+    for (int idx = 0; idx < P25_MPDU_TSBK_DIBITS; idx++) {
+        rc |= expect_int("captured dibit", ctx.tsbk_dibit[idx], expected_dibit[idx]);
+        rc |= expect_int("captured llr msb", ctx.tsbk_llr[(idx * 2) + 0], 1000 + expected_call[idx]);
+        rc |= expect_int("captured llr lsb", ctx.tsbk_llr[(idx * 2) + 1], -(2000 + expected_call[idx]));
+    }
+    return rc;
+}
+
+static int
+test_decode_blocks_use_candidates_or_fallback_and_pack_crc_bits(void) {
+    P25MpduContext ctx;
+    int rc = 0;
+
+    p25_mpdu_context_init(&ctx);
+    DSD_MEMSET(g_soft_candidates, 0, sizeof(g_soft_candidates));
+    g_soft_candidate_count = 2;
+    for (int byte_idx = 0; byte_idx < P25_MPDU_R12_BYTES; byte_idx++) {
+        g_soft_candidates[0].bytes[byte_idx] = (uint8_t)(0x40 + byte_idx);
+        g_soft_candidates[1].bytes[byte_idx] = (uint8_t)(0x90 + byte_idx);
+    }
+    append_crc16(g_soft_candidates[1].bytes);
+    p25_mpdu_decode_r12_block(&ctx, 0);
+    rc |= expect_u8("r12 header selected valid candidate", ctx.tsbk_byte[0], g_soft_candidates[1].bytes[0]);
+
+    p25_mpdu_decode_r12_block(&ctx, 1);
+    rc |= expect_u8("r12 data block uses first candidate", ctx.tsbk_byte[0], g_soft_candidates[0].bytes[0]);
+
+    DSD_MEMSET(g_r12_fallback_bytes, 0, sizeof(g_r12_fallback_bytes));
+    for (int byte_idx = 0; byte_idx < P25_MPDU_R12_BYTES; byte_idx++) {
+        g_r12_fallback_bytes[byte_idx] = (uint8_t)(0xC0 + byte_idx);
+    }
+    g_soft_candidate_count = 0;
+    g_r12_fallback_calls = 0;
+    p25_mpdu_decode_r12_block(&ctx, 0);
+    rc |= expect_int("r12 fallback called", g_r12_fallback_calls, 1);
+    rc |= expect_u8("r12 fallback bytes copied", ctx.tsbk_byte[5], g_r12_fallback_bytes[5]);
+
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    DSD_MEMSET(g_mbf34_candidates, 0, sizeof(g_mbf34_candidates));
+    g_mbf34_candidate_count = 2;
+    for (int byte_idx = 0; byte_idx < P25_MPDU_R34_BYTES; byte_idx++) {
+        g_mbf34_candidates[0].bytes[byte_idx] = (uint8_t)(0x10 + byte_idx);
+        g_mbf34_candidates[1].bytes[byte_idx] = (uint8_t)(0x80 ^ (byte_idx * 9));
+    }
+    set_mbf34_crc9_extension(g_mbf34_candidates[1].bytes);
+    p25_mpdu_decode_r34_block(&ctx, 1);
+    rc |= expect_u8("r34 selected crc9 candidate", ctx.r34byte_b[0], g_mbf34_candidates[1].bytes[0]);
+    rc |= expect_u8("r34 stored block bytes", ctx.r34bytes[17], g_mbf34_candidates[1].bytes[17]);
+    rc |= expect_int("r34 crc32 bit count", ctx.crc_bit_count, 128);
+    rc |= expect_int("r34 crc9 bit count", ctx.crc9_bit_count, 135);
+    rc |= expect_int("r34 first crc bit", ctx.mpdu_crc_bits[0], (g_mbf34_candidates[1].bytes[2] >> 7) & 1);
+    rc |= expect_int("r34 first crc9 bit", ctx.mpdu_crc9_bits[0], (g_mbf34_candidates[1].bytes[0] >> 7) & 1);
+
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    DSD_MEMSET(g_mbf34_fallback_bytes, 0, sizeof(g_mbf34_fallback_bytes));
+    for (int byte_idx = 0; byte_idx < P25_MPDU_R34_BYTES; byte_idx++) {
+        g_mbf34_fallback_bytes[byte_idx] = (uint8_t)(0xE0 + byte_idx);
+    }
+    g_mbf34_candidate_count = 0;
+    g_mbf34_fallback_calls = 0;
+    p25_mpdu_decode_r34_block(&ctx, 1);
+    rc |= expect_int("r34 fallback called", g_mbf34_fallback_calls, 1);
+    rc |= expect_u8("r34 fallback bytes copied", ctx.r34byte_b[4], g_mbf34_fallback_bytes[4]);
+    return rc;
+}
+
+static int
+test_finalize_header_selects_best_rep_and_majority(void) {
+    static dsd_state state;
+    P25MpduContext ctx;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_mpdu_context_init(&ctx);
+
+    ctx.end = 3;
+    ctx.blks = 0;
+    ctx.hdr_rep_crc[0] = 7;
+    ctx.hdr_rep_crc[1] = 0;
+    ctx.hdr_rep_crc[2] = 9;
+    for (int byte_idx = 0; byte_idx < P25_MPDU_R12_BYTES; byte_idx++) {
+        ctx.hdr_rep_bytes[1][byte_idx] = (uint8_t)(0xE0 + byte_idx);
+    }
+    p25_mpdu_finalize_header(&state, &ctx);
+
+    int rc = 0;
+    rc |= expect_int("best rep crc", ctx.err[0], 0);
+    rc |= expect_u8("best rep byte", ctx.mpdu_byte[3], 0xE3);
+    rc |= expect_int("fec ok count", (int)state.p25_p1_fec_ok, 1);
+    rc |= expect_int("soft combined count", (int)state.p25_p1_soft_combined_ok, 0);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_mpdu_context_init(&ctx);
+    uint8_t valid_header[P25_MPDU_R12_BYTES] = {0x37, 0x3D, 0x00, 0x01, 0x10, 0x0A, 0x01, 0x33, 0x01, 0x02, 0x00, 0x00};
+    append_crc16(valid_header);
+    ctx.end = 3;
+    ctx.blks = 0;
+    ctx.hdr_rep_crc[0] = 5;
+    ctx.hdr_rep_crc[1] = 6;
+    ctx.hdr_rep_crc[2] = 7;
+    for (int rep = 0; rep < P25_MPDU_HEADER_REPS; rep++) {
+        bytes_to_u8_bits(valid_header, P25_MPDU_R12_BYTES, ctx.hdr_rep_bits[rep]);
+    }
+    g_soft_candidate_count = 0;
+    p25_mpdu_finalize_header(&state, &ctx);
+
+    rc |= expect_int("majority rebuilt crc", ctx.err[0], 0);
+    rc |= expect_u8("majority rebuilt byte", ctx.mpdu_byte[7], 0x33);
+    rc |= expect_int("majority fec ok count", (int)state.p25_p1_fec_ok, 1);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_mpdu_context_init(&ctx);
+    uint8_t combined_header[P25_MPDU_R12_BYTES] = {0x17, 0x3D, 0x55, 0x44, 0x33, 0x22,
+                                                   0x01, 0x77, 0x88, 0x99, 0x00, 0x00};
+    append_crc16(combined_header);
+    ctx.end = 3;
+    ctx.blks = 0;
+    ctx.hdr_rep_crc[0] = 5;
+    ctx.hdr_rep_crc[1] = 6;
+    ctx.hdr_rep_crc[2] = 7;
+    DSD_MEMSET(g_soft_candidates, 0, sizeof(g_soft_candidates));
+    g_soft_candidate_count = 2;
+    for (int byte_idx = 0; byte_idx < P25_MPDU_R12_BYTES; byte_idx++) {
+        g_soft_candidates[0].bytes[byte_idx] = (uint8_t)(0xA0 + byte_idx);
+        g_soft_candidates[1].bytes[byte_idx] = combined_header[byte_idx];
+    }
+    p25_mpdu_finalize_header(&state, &ctx);
+    g_soft_candidate_count = 0;
+
+    rc |= expect_int("combined header crc", ctx.err[0], 0);
+    rc |= expect_u8("combined header byte", ctx.mpdu_byte[8], combined_header[8]);
+    rc |= expect_int("combined fec ok count", (int)state.p25_p1_fec_ok, 1);
+    rc |= expect_int("combined soft count", (int)state.p25_p1_soft_combined_ok, 1);
+    return rc;
+}
+
+static int
+test_rate34_crc_bit_packing(void) {
+    P25MpduContext ctx;
+    p25_mpdu_context_init(&ctx);
+    ctx.blks = 1;
+
+    uint8_t payload[16] = {0xC0, 0x01, 0x22, 0x43, 0x64, 0x85, 0xA6, 0xC7,
+                           0xE8, 0x09, 0x2A, 0x4B, 0x00, 0x00, 0x00, 0x00};
+    uint32_t crc = crc32mbf(payload, 96);
+    payload[12] = (uint8_t)(crc >> 24);
+    payload[13] = (uint8_t)(crc >> 16);
+    payload[14] = (uint8_t)(crc >> 8);
+    payload[15] = (uint8_t)crc;
+    bytes_to_u8_bits(payload, 16, ctx.mpdu_crc_bits);
+
+    uint32_t extracted = 0;
+    uint32_t computed = 1;
+    p25_mpdu_compute_rate34_crc(&ctx, &extracted, &computed);
+
+    int rc = 0;
+    rc |= expect_int("rate34 crc extracted", (int)extracted, (int)crc);
+    rc |= expect_int("rate34 crc computed", (int)computed, (int)crc);
+    rc |= expect_int("rate34 crc ok", ctx.err[1], 0);
+    return rc;
+}
+
+static int
+test_rate34_zero_block_crc_and_multiblock_reconstruction(void) {
+    P25MpduContext ctx;
+    uint8_t dbsn[P25_MPDU_MAX_DATA_BLOCKS] = {0};
+    uint16_t crc9_ext[P25_MPDU_MAX_DATA_BLOCKS] = {0};
+    uint16_t crc9_cmp[P25_MPDU_MAX_DATA_BLOCKS] = {0};
+    uint32_t extracted = 123;
+    uint32_t computed = 456;
+    int rc = 0;
+
+    p25_mpdu_context_init(&ctx);
+    ctx.blks = 0;
+    p25_mpdu_compute_rate34_crc(&ctx, &extracted, &computed);
+    rc |= expect_int("rate34 zero-block extracted", (int)extracted, 0);
+    rc |= expect_int("rate34 zero-block computed", (int)computed, 0);
+    rc |= expect_int("rate34 zero-block crc ok", ctx.err[1], 0);
+
+    p25_mpdu_context_init(&ctx);
+    ctx.blks = 2;
+    for (int byte_idx = 0; byte_idx < P25_MPDU_R34_BYTES * 2; byte_idx++) {
+        ctx.r34bytes[byte_idx] = (uint8_t)(0x30 + byte_idx);
+    }
+    int mpdu_idx = p25_mpdu_reconstruct_rate34_payload(&ctx, dbsn, crc9_ext, crc9_cmp);
+
+    rc |= expect_int("rate34 multiblock reconstruction index", mpdu_idx, 45);
+    rc |= expect_u8("rate34 block0 dbsn", dbsn[0], ctx.r34bytes[0] >> 1);
+    rc |= expect_u8("rate34 block1 dbsn", dbsn[1], ctx.r34bytes[18] >> 1);
+    rc |= expect_u8("rate34 block0 first data byte", ctx.mpdu_byte[P25_MPDU_R12_BYTES], ctx.r34bytes[2]);
+    rc |= expect_u8("rate34 block0 last data byte", ctx.mpdu_byte[P25_MPDU_R12_BYTES + 15], ctx.r34bytes[17]);
+    rc |= expect_u8("rate34 block1 first data byte skips crc fields", ctx.mpdu_byte[P25_MPDU_R12_BYTES + 16],
+                    ctx.r34bytes[20]);
+    rc |= expect_u8("rate34 block1 last data byte", ctx.mpdu_byte[P25_MPDU_R12_BYTES + 31], ctx.r34bytes[35]);
+    rc |= expect_u8("rate34 trailing dispatch-excluded byte", ctx.mpdu_byte[P25_MPDU_R12_BYTES + 32], 0);
+    return rc;
+}
+
+static void
+fill_rate12_payload_with_crc(P25MpduContext* ctx, const uint8_t payload_prefix[8]) {
+    for (int idx = 0; idx < 8; idx++) {
+        ctx->mpdu_byte[P25_MPDU_R12_BYTES + idx] = payload_prefix[idx];
+    }
+    uint32_t crc = crc32mbf(ctx->mpdu_byte + P25_MPDU_R12_BYTES, 64);
+    ctx->mpdu_byte[20] = (uint8_t)(crc >> 24);
+    ctx->mpdu_byte[21] = (uint8_t)(crc >> 16);
+    ctx->mpdu_byte[22] = (uint8_t)(crc >> 8);
+    ctx->mpdu_byte[23] = (uint8_t)crc;
+}
+
+static int
+test_decode_header_if_usable_dispatch_gate(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    P25MpduContext ctx;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_mpdu_context_init(&ctx);
+    ctx.err[0] = 1;
+    ctx.mpdu_byte[0] = 0x37;
+    ctx.mpdu_byte[1] = 0x3D;
+    ctx.mpdu_byte[6] = 0x02;
+    opts.aggressive_framesync = 1;
+    reset_dispatch_counters();
+
+    p25_mpdu_decode_header_if_usable(&opts, &state, &ctx);
+    rc |= expect_int("aggressive bad header skip", g_pdu_header_calls, 0);
+    rc |= expect_int("aggressive bad header fmt unchanged", ctx.fmt, 0);
+
+    opts.aggressive_framesync = 0;
+    p25_mpdu_decode_header_if_usable(&opts, &state, &ctx);
+    rc |= expect_int("relaxed bad header dispatch", g_pdu_header_calls, 1);
+    rc |= expect_int("relaxed header io", ctx.io, 1);
+    rc |= expect_int("relaxed header fmt", ctx.fmt, 0x17);
+    rc |= expect_int("relaxed header sap", ctx.sap, 0x3D);
+    rc |= expect_int("relaxed header blks", ctx.blks, 2);
+    return rc;
+}
+
+static int
+test_rate12_payload_crc_dispatch_and_cleanup(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    P25MpduContext ctx;
+    const uint8_t payload_prefix[8] = {0x81, 0x02, 0x23, 0x44, 0x65, 0x86, 0xA7, 0xC8};
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_mpdu_context_init(&ctx);
+    ctx.blks = 1;
+    ctx.err[1] = -2;
+    state.lasttg = 100;
+    state.lastsrc = 200;
+    fill_rate12_payload_with_crc(&ctx, payload_prefix);
+    reset_dispatch_counters();
+
+    p25_mpdu_handle_rate12(&opts, &state, &ctx);
+    rc |= expect_int("rate12 crc ok", ctx.err[1], 0);
+    rc |= expect_int("rate12 data dispatch", g_pdu_data_calls, 1);
+    rc |= expect_int("rate12 data len", g_last_pdu_data_len, 24);
+    rc |= expect_int("rate12 clears tg", state.lasttg, 0);
+    rc |= expect_int("rate12 clears src", state.lastsrc, 0);
+
+    p25_mpdu_context_init(&ctx);
+    ctx.blks = 0;
+    ctx.err[1] = -2;
+    state.lasttg = 300;
+    state.lastsrc = 400;
+    reset_dispatch_counters();
+    p25_mpdu_handle_rate12(&opts, &state, &ctx);
+    rc |= expect_int("rate12 zero-block crc ok", ctx.err[1], 0);
+    rc |= expect_int("rate12 zero-block no data dispatch", g_pdu_data_calls, 0);
+    rc |= expect_int("rate12 zero-block clears tg", state.lasttg, 0);
+    rc |= expect_int("rate12 zero-block clears src", state.lastsrc, 0);
+
+    p25_mpdu_context_init(&ctx);
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    ctx.blks = 1;
+    ctx.err[1] = -2;
+    ctx.mpdu_byte[P25_MPDU_R12_BYTES] = 0x55;
+    opts.aggressive_framesync = 1;
+    state.lasttg = 500;
+    state.lastsrc = 600;
+    reset_dispatch_counters();
+    p25_mpdu_handle_rate12(&opts, &state, &ctx);
+    rc |= expect_int("rate12 bad crc aggressive suppresses dispatch", g_pdu_data_calls, 0);
+    rc |= expect_int("rate12 bad crc preserved", ctx.err[1] != 0, 1);
+    rc |= expect_int("rate12 bad crc aggressive clears tg", state.lasttg, 0);
+
+    p25_mpdu_context_init(&ctx);
+    ctx.blks = 1;
+    ctx.err[1] = -2;
+    ctx.mpdu_byte[P25_MPDU_R12_BYTES] = 0x56;
+    opts.aggressive_framesync = 0;
+    state.lasttg = 700;
+    state.lastsrc = 800;
+    reset_dispatch_counters();
+    p25_mpdu_handle_rate12(&opts, &state, &ctx);
+    rc |= expect_int("rate12 bad crc relaxed dispatches", g_pdu_data_calls, 1);
+    rc |= expect_int("rate12 bad crc relaxed len", g_last_pdu_data_len, 24);
+    rc |= expect_int("rate12 bad crc relaxed clears src", state.lastsrc, 0);
+    return rc;
+}
+
+static int
+test_rate34_dispatch_reconstructs_payload_and_clears_last_call(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    P25MpduContext ctx;
+    uint8_t payload[16] = {0xC0, 0x01, 0x22, 0x43, 0x64, 0x85, 0xA6, 0xC7,
+                           0xE8, 0x09, 0x2A, 0x4B, 0x00, 0x00, 0x00, 0x00};
+    uint32_t crc = crc32mbf(payload, 96);
+    payload[12] = (uint8_t)(crc >> 24);
+    payload[13] = (uint8_t)(crc >> 16);
+    payload[14] = (uint8_t)(crc >> 8);
+    payload[15] = (uint8_t)crc;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_mpdu_context_init(&ctx);
+    ctx.r34 = 1;
+    ctx.sap = 0x20;
+    ctx.fmt = 0x16;
+    ctx.blks = 1;
+    ctx.err[1] = -2;
+    bytes_to_u8_bits(payload, 16, ctx.mpdu_crc_bits);
+    for (int byte_idx = 0; byte_idx < P25_MPDU_R34_BYTES; byte_idx++) {
+        ctx.r34bytes[byte_idx] = (uint8_t)(0x20 + byte_idx);
+    }
+    state.lasttg = 900;
+    state.lastsrc = 901;
+    reset_dispatch_counters();
+
+    p25_mpdu_dispatch_payload(&opts, &state, &ctx);
+
+    int rc = 0;
+    rc |= expect_int("rate34 crc ok", ctx.err[1], 0);
+    rc |= expect_int("rate34 data dispatch", g_pdu_data_calls, 1);
+    rc |= expect_int("rate34 data len", g_last_pdu_data_len, 28);
+    rc |= expect_u8("rate34 first reconstructed payload", ctx.mpdu_byte[P25_MPDU_R12_BYTES], ctx.r34bytes[2]);
+    rc |= expect_u8("rate34 last block byte", ctx.mpdu_byte[P25_MPDU_R12_BYTES + 15], ctx.r34bytes[17]);
+    rc |= expect_int("rate34 clears tg", state.lasttg, 0);
+    rc |= expect_int("rate34 clears src", state.lastsrc, 0);
+    return rc;
+}
+
+static int
+test_trunking_payload_crc_dispatch(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    P25MpduContext ctx;
+    const uint8_t payload_prefix[8] = {0x91, 0x12, 0x33, 0x54, 0x75, 0x96, 0xB7, 0xD8};
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_mpdu_context_init(&ctx);
+    ctx.sap = 0x3D;
+    ctx.fmt = 0x17;
+    ctx.io = 1;
+    ctx.blks = 1;
+    ctx.err[0] = 0;
+    ctx.err[1] = -2;
+    fill_rate12_payload_with_crc(&ctx, payload_prefix);
+    reset_dispatch_counters();
+
+    rc |= expect_int("trunking handler accepted", p25_mpdu_handle_trunking(&opts, &state, &ctx), 1);
+    rc |= expect_int("trunking crc ok", ctx.err[1], 0);
+    rc |= expect_int("trunking dispatch", g_pdu_trunking_calls, 1);
+
+    ctx.err[0] = 1;
+    ctx.err[1] = -2;
+    reset_dispatch_counters();
+    rc |= expect_int("trunking handler accepted bad header", p25_mpdu_handle_trunking(&opts, &state, &ctx), 1);
+    rc |= expect_int("trunking bad header suppresses dispatch", g_pdu_trunking_calls, 0);
+
+    ctx.sap = 0x20;
+    reset_dispatch_counters();
+    rc |= expect_int("non-trunking handler rejected", p25_mpdu_handle_trunking(&opts, &state, &ctx), 0);
+    return rc;
+}
+
+static int
+test_process_mpdu_zero_block_header_orchestration(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    P25MpduContext probe;
+    uint8_t header[P25_MPDU_R12_BYTES] = {0x17, 0x20, 0x10, 0x11, 0x12, 0x13, 0x00, 0x15, 0x16, 0x17, 0x00, 0x00};
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(g_soft_candidates, 0, sizeof(g_soft_candidates));
+    append_crc16(header);
+    DSD_MEMCPY(g_soft_candidates[0].bytes, header, sizeof(header));
+    g_soft_candidate_count = 1;
+    g_r12_fallback_calls = 0;
+    g_mbf34_candidate_count = 0;
+    g_mbf34_fallback_calls = 0;
+    g_get_dibit_soft_calls = 0;
+    g_status_add_calls = 0;
+    state.lasttg = 77;
+    state.lastsrc = 88;
+    state.last_active_time = time(NULL);
+    reset_dispatch_counters();
+
+    processMPDU(&opts, &state);
+
+    rc |= expect_int("process mpdu counter", (int)state.p25_p1_duid_mpdu, 1);
+    rc |= expect_int("process used soft dibit reader", g_get_dibit_soft_calls, 101);
+    rc |= expect_int("process avoided r12 fallback", g_r12_fallback_calls, 0);
+    rc |= expect_int("process avoided r34 fallback", g_mbf34_fallback_calls, 0);
+    rc |= expect_int("process header dispatch", g_pdu_header_calls, 1);
+    rc |= expect_int("process no data dispatch for zero block", g_pdu_data_calls, 0);
+    rc |= expect_int("process fec ok", (int)state.p25_p1_fec_ok, 1);
+    rc |= expect_int("process clears tg", state.lasttg, 0);
+    rc |= expect_int("process clears src", state.lastsrc, 0);
+    rc |= expect_int("process classifies status", g_status_classify_calls, 1);
+
+    p25_mpdu_context_init(&probe);
+    DSD_MEMCPY(probe.tsbk_byte, header, sizeof(header));
+    p25_mpdu_unpack_tsbk_bytes(&probe);
+    p25_mpdu_store_header_rep(&probe, 0);
+    rc |= expect_int("stored header rep crc", probe.hdr_rep_crc[0], 0);
+    rc |= expect_u8("stored header rep byte", probe.hdr_rep_bytes[0][3], header[3]);
+    p25_mpdu_store_header_rep(&probe, P25_MPDU_HEADER_REPS);
+    rc |= expect_int("out-of-range header rep ignored", probe.hdr_rep_crc[0], 0);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_context_init_and_saturating_add();
+    rc |= test_prepare_state_resets_mpdu_frame_context();
+    rc |= test_header_store_and_update_fields();
+    rc |= test_candidate_selection_uses_crc_fields();
+    rc |= test_read_repetition_captures_soft_symbols_and_status_dibits();
+    rc |= test_decode_blocks_use_candidates_or_fallback_and_pack_crc_bits();
+    rc |= test_finalize_header_selects_best_rep_and_majority();
+    rc |= test_rate34_crc_bit_packing();
+    rc |= test_rate34_zero_block_crc_and_multiblock_reconstruction();
+    rc |= test_decode_header_if_usable_dispatch_gate();
+    rc |= test_rate12_payload_crc_dispatch_and_cleanup();
+    rc |= test_rate34_dispatch_reconstructs_payload_and_clears_last_call();
+    rc |= test_trunking_payload_crc_dispatch();
+    rc |= test_process_mpdu_zero_block_header_orchestration();
+    return rc;
+}
+
+// NOLINTEND(bugprone-suspicious-include)

--- a/tests/protocol/p25/test_p25_p1_pdu_es_ext.c
+++ b/tests/protocol/p25/test_p25_p1_pdu_es_ext.c
@@ -40,16 +40,23 @@ const dsdneoRuntimeConfig* dsd_neo_get_config(void);
 // Shim to invoke real decoder
 void p25_test_p1_pdu_data_decode(const unsigned char* input, int len);
 
+static int g_datacall_count;
+static int g_history_count;
+static uint32_t g_datacall_src;
+static uint32_t g_datacall_dst;
+static char g_datacall_text[256];
+
 // Stubs required by linked decoder units
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 watchdog_event_datacall(dsd_opts* opts, dsd_state* state, uint32_t src, uint32_t dst, char* str, uint8_t slot) {
     (void)opts;
     (void)state;
-    (void)src;
-    (void)dst;
-    (void)str;
     (void)slot;
+    g_datacall_count++;
+    g_datacall_src = src;
+    g_datacall_dst = dst;
+    DSD_SNPRINTF(g_datacall_text, sizeof(g_datacall_text), "%s", str ? str : "");
 }
 
 void
@@ -58,6 +65,7 @@ watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot) {
     (void)opts;
     (void)state;
     (void)slot;
+    g_history_count++;
 }
 
 void
@@ -225,6 +233,33 @@ expect_u8(const char* label, uint8_t got, uint8_t want) {
 }
 
 static int
+expect_u32(const char* label, uint32_t got, uint32_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got 0x%08X want 0x%08X\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_contains(const char* label, const char* got, const char* needle) {
+    if (got == NULL || strstr(got, needle) == NULL) {
+        DSD_FPRINTF(stderr, "%s: missing '%s' in '%s'\n", label, needle, got ? got : "(null)");
+        return 1;
+    }
+    return 0;
+}
+
+static void
+reset_watchdog_counters(void) {
+    g_datacall_count = 0;
+    g_history_count = 0;
+    g_datacall_src = 0;
+    g_datacall_dst = 0;
+    g_datacall_text[0] = '\0';
+}
+
+static int
 test_p25_pdu_des_decrypt_vector(void) {
     static const uint8_t expect[] = {0x67, 0xAE, 0x7A, 0x29, 0x61, 0xDF, 0xA3, 0x45};
     static dsd_opts opts;
@@ -312,6 +347,153 @@ test_p25_pdu_missing_keys_stay_encrypted(void) {
     rc |= expect_bytes("P25 PDU DES missing-key unchanged", des_input, expect, sizeof expect);
     rc |= expect_bytes("P25 PDU RC4 missing-key unchanged", rc4_input, expect, sizeof expect);
     rc |= expect_bytes("P25 PDU AES missing-key unchanged", aes_input, expect, sizeof expect);
+    return rc;
+}
+
+static int
+test_p25_pdu_label_helpers(void) {
+    char label[48];
+    int rc = 0;
+
+    label[0] = 'x';
+    p25_decode_sap(0, label, sizeof(label));
+    rc |= expect_contains("SAP user-data label", label, "User Data");
+
+    p25_decode_sap(0xFE, label, sizeof(label));
+    rc |= expect_contains("SAP unknown label", label, "Unknown SAP");
+
+    label[0] = 'x';
+    p25_decode_rsp(0, 0, 0, label, sizeof(label));
+    rc |= expect_contains("RSP ACK label", label, "ACK");
+
+    p25_decode_rsp(1, 4, 0, label, sizeof(label));
+    rc |= expect_contains("RSP NACK undeliverable label", label, "Undeliverable");
+
+    p25_decode_rsp(2, 0, 0, label, sizeof(label));
+    rc |= expect_contains("RSP SACK label", label, "SACK");
+
+    p25_decode_rsp(3, 0, 0, label, sizeof(label));
+    rc |= expect_contains("RSP unknown label", label, "Unknown RSP");
+
+    p25_decode_sap(0, NULL, sizeof(label));
+    p25_decode_rsp(0, 0, 0, NULL, sizeof(label));
+    p25_decode_sap(0, label, 0);
+    p25_decode_rsp(0, 0, 0, label, 0);
+    return rc;
+}
+
+static int
+test_p25_pdu_header_state_updates(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    uint8_t header[12];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    DSD_MEMSET(header, 0, sizeof(header));
+
+    header[0] = 0x30; // io=1, fmt=16
+    header[1] = 4;    // Packet Data
+    header[3] = 0x12;
+    header[4] = 0x34;
+    header[5] = 0x56;
+    header[6] = 0x82; // FMF plus two blocks
+    header[7] = 0x05; // pad
+    header[8] = 0x21; // NS/FSNF
+    header[9] = 0x07; // offset
+
+    reset_watchdog_counters();
+    p25_decode_pdu_header(&opts, &st, header);
+    int rc = 0;
+    rc |= expect_u32("header lasttg", st.lasttg, 0x123456);
+    rc |= expect_u32("header lastsrc any", st.lastsrc, 0xFFFFFF);
+    rc |= expect_contains("header data-call summary", st.dmr_lrrp_gps[0], "Packet Data");
+    rc |= expect_u32("header non-response no datacall", (uint32_t)g_datacall_count, 0);
+
+    DSD_MEMSET(&st, 0, sizeof(st));
+    DSD_MEMSET(header, 0, sizeof(header));
+    header[0] = 0x03; // response format
+    header[1] = (uint8_t)((1U << 6) | (4U << 3) | 2U);
+    header[3] = 0x00;
+    header[4] = 0x01;
+    header[5] = 0x23;
+    reset_watchdog_counters();
+    p25_decode_pdu_header(&opts, &st, header);
+    rc |= expect_u32("response final lasttg", st.lasttg, 0x000123);
+    rc |= expect_u32("response final lastsrc", st.lastsrc, 0xFFFFFF);
+    rc |= expect_u32("response datacall count", (uint32_t)g_datacall_count, 1);
+    rc |= expect_u32("response history count", (uint32_t)g_history_count, 1);
+    rc |= expect_u32("response datacall src", g_datacall_src, 0xFFFFFF);
+    rc |= expect_contains("response datacall text", g_datacall_text, "Undeliverable");
+
+    DSD_MEMSET(&st, 0, sizeof(st));
+    st.lastsrc = 0x111111;
+    st.lasttg = 0x222222;
+    DSD_MEMSET(header, 0, sizeof(header));
+    header[0] = 0x10;
+    header[1] = 61; // trunking-control SAP is intentionally skipped
+    header[3] = 0xAA;
+    header[4] = 0xBB;
+    header[5] = 0xCC;
+    reset_watchdog_counters();
+    p25_decode_pdu_header(&opts, &st, header);
+    rc |= expect_u32("trunking header preserves src", st.lastsrc, 0x111111);
+    rc |= expect_u32("trunking header preserves tg", st.lasttg, 0x222222);
+    rc |= expect_u32("trunking header no datacall", (uint32_t)g_datacall_count, 0);
+    return rc;
+}
+
+static int
+test_p25_pdu_es_headers_decrypt_and_advance(void) {
+    static const uint8_t des_expect[] = {0x67, 0xAE, 0x7A, 0x29, 0x61, 0xDF, 0xA3, 0x45};
+    static dsd_opts opts;
+    static dsd_state st;
+    uint8_t es[13 + sizeof(des_expect)];
+    uint8_t es2[12 + 4];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    DSD_MEMSET(es, 0, sizeof(es));
+    DSD_MEMSET(es2, 0, sizeof(es2));
+    st.R = 0x133457799BBCDFF1ULL;
+
+    es[0] = 0x01;
+    es[1] = 0x23;
+    es[2] = 0x45;
+    es[3] = 0x67;
+    es[4] = 0x89;
+    es[5] = 0xAB;
+    es[6] = 0xCD;
+    es[7] = 0xEF;
+    es[9] = 0x81;  // DES
+    es[12] = 0xE0; // aux_res=3, aux_sap=32
+
+    uint8_t sap = 0;
+    int ptr = 0;
+    uint8_t encrypted = p25_decode_es_header(&opts, &st, es, &sap, &ptr, (int)sizeof(es));
+    int rc = 0;
+    rc |= expect_u8("ES header decrypt flag", encrypted, 0);
+    rc |= expect_u8("ES header aux SAP", sap, 32);
+    rc |= expect_u32("ES header ptr", (uint32_t)ptr, 13);
+    rc |= expect_bytes("ES header DES payload", es + 13, des_expect, sizeof(des_expect));
+
+    es2[0] = 0x80; // clear
+    es2[1] = 0x12;
+    es2[2] = 0x34;
+    es2[3] = 0x01;
+    es2[4] = 0x23;
+    es2[5] = 0x45;
+    es2[6] = 0x67;
+    es2[7] = 0x89;
+    es2[8] = 0xAB;
+    es2[9] = 0xCD;
+    es2[10] = 0xEF;
+    es2[12] = 0xCA;
+    es2[13] = 0xFE;
+    ptr = 5;
+    encrypted = p25_decode_es_header_2(&opts, &st, es2, &ptr, (int)sizeof(es2));
+    rc |= expect_u8("ES header 2 clear flag", encrypted, 0);
+    rc |= expect_u32("ES header 2 ptr", (uint32_t)ptr, 17);
+    rc |= expect_u8("ES header 2 payload unchanged 0", es2[12], 0xCA);
+    rc |= expect_u8("ES header 2 payload unchanged 1", es2[13], 0xFE);
     return rc;
 }
 
@@ -418,6 +600,9 @@ main(void) {
     rc |= test_p25_pdu_rc4_decrypt_vector();
     rc |= test_p25_pdu_aes128_decrypt_vector();
     rc |= test_p25_pdu_missing_keys_stay_encrypted();
+    rc |= test_p25_pdu_label_helpers();
+    rc |= test_p25_pdu_header_state_updates();
+    rc |= test_p25_pdu_es_headers_decrypt_and_advance();
     return rc;
 }
 

--- a/tests/protocol/p25/test_p25_p1_pdu_private_allowlist.c
+++ b/tests/protocol/p25/test_p25_p1_pdu_private_allowlist.c
@@ -8,11 +8,13 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/protocol/p25/p25p1_pdu_trunking.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -24,6 +26,14 @@
 #endif
 
 struct RtlSdrContext;
+
+static int g_seed_count;
+static int g_group_grant_count;
+static int g_enc_lockout_count;
+static int g_last_group_channel;
+static int g_last_group_svc;
+static int g_last_group_tg;
+static int g_last_group_src;
 
 bool
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -58,6 +68,17 @@ expect_true(const char* tag, int cond) {
         return 1;
     }
     return 0;
+}
+
+static void
+reset_calls(void) {
+    g_seed_count = 0;
+    g_group_grant_count = 0;
+    g_enc_lockout_count = 0;
+    g_last_group_channel = 0;
+    g_last_group_svc = 0;
+    g_last_group_tg = 0;
+    g_last_group_src = 0;
 }
 
 static int
@@ -152,6 +173,7 @@ p25_emit_enc_lockout_once(dsd_opts* opts, dsd_state* state, uint8_t slot, int tg
     (void)slot;
     (void)tg;
     (void)svc_bits;
+    g_enc_lockout_count++;
 }
 
 void
@@ -159,6 +181,7 @@ void
 p25_sm_seed_cc_from_current_tuner_if_unknown(const dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_seed_count++;
 }
 
 void
@@ -166,10 +189,11 @@ void
 p25_sm_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
     (void)opts;
     (void)state;
-    (void)channel;
-    (void)svc_bits;
-    (void)tg;
-    (void)src;
+    g_group_grant_count++;
+    g_last_group_channel = channel;
+    g_last_group_svc = svc_bits;
+    g_last_group_tg = tg;
+    g_last_group_src = src;
 }
 
 void
@@ -252,6 +276,81 @@ main(void) {
     opts.p25_is_tuned = 0;
     p25_decode_pdu_trunking(&opts, &st, mpdu);
     rc |= expect_true("p1 pdu private known target tunes", st.p25_sm_tune_count == before + 1);
+
+    rc |= expect_true("policy seed group grant", seed_policy_group(&st, 0x1234u, "A", "TG-ALLOW") == 0);
+    DSD_MEMSET(mpdu, 0, sizeof mpdu);
+    mpdu[0] = 0x17; // ALT MBT
+    mpdu[2] = 0x00;
+    mpdu[7] = 0x00; // Group Voice Channel Grant Update - Extended
+    mpdu[8] = 0x00; // clear voice service
+    mpdu[3] = 0x01;
+    mpdu[4] = 0x02;
+    mpdu[5] = 0x03; // source
+    mpdu[14] = 0x10;
+    mpdu[15] = 0x0A;
+    mpdu[16] = 0x10;
+    mpdu[17] = 0x0A;
+    mpdu[18] = 0x12;
+    mpdu[19] = 0x34; // group
+    opts.p25_trunk = 1;
+    opts.trunk_use_allow_list = 0;
+    opts.trunk_tune_enc_calls = 1;
+    opts.payload = 0;
+    opts.p25_is_tuned = 0;
+    reset_calls();
+    p25_decode_pdu_trunking(&opts, &st, mpdu);
+    rc |= expect_true("p1 pdu group emergency state", st.p25_call_emergency[0] == 0);
+    rc |= expect_true("p1 pdu group priority state", st.p25_call_priority[0] == 0);
+    rc |= expect_true("p1 pdu group active channel", strstr(st.active_channel[0], "TG: 4660") != NULL);
+
+    DSD_MEMSET(mpdu, 0, sizeof mpdu);
+    mpdu[0] = 0x17;
+    mpdu[2] = 0x00;
+    mpdu[7] = 0x08; // Telephone Interconnect Voice Channel Grant
+    mpdu[3] = 0x01;
+    mpdu[4] = 0x02;
+    mpdu[5] = 0x03; // target
+    mpdu[12] = 0x10;
+    mpdu[13] = 0x0A;
+    mpdu[16] = 0x00;
+    mpdu[17] = 0x20; // timer
+    opts.p25_trunk = 0;
+    opts.trunk_use_allow_list = 0;
+    opts.payload = 0;
+    opts.p25_is_tuned = 0;
+    st.lasttg = 0x010203;
+    st.synctype = DSD_SYNC_P25P1_POS;
+    st.p25_vc_freq[0] = 0;
+    st.p25_vc_freq[1] = 0;
+    reset_calls();
+    p25_decode_pdu_trunking(&opts, &st, mpdu);
+    rc |= expect_true("p1 pdu telephone nontrunk p1 vc freq", st.p25_vc_freq[0] == 851125000);
+    rc |= expect_true("p1 pdu telephone p1 leaves slot 2 freq", st.p25_vc_freq[1] == 0);
+    rc |= expect_true("p1 pdu telephone no trunk tune hook",
+                      g_group_grant_count == 0 && st.p25_sm_tune_count == before + 1);
+    rc |= expect_true("p1 pdu telephone active channel", strstr(st.active_channel[0], "Active Tele Ch: 100A") != NULL);
+
+    rc |= expect_true("policy seed mfid90 sg", seed_policy_group(&st, 0x2222u, "A", "SG-ALLOW") == 0);
+    DSD_MEMSET(mpdu, 0, sizeof mpdu);
+    mpdu[0] = 0x17;
+    mpdu[2] = 0x90;
+    mpdu[7] = 0x02; // MFID90 Group Regroup Channel Grant - Explicit
+    mpdu[3] = 0x04;
+    mpdu[4] = 0x05;
+    mpdu[5] = 0x06; // source
+    mpdu[12] = 0x10;
+    mpdu[13] = 0x0A;
+    mpdu[14] = 0x10;
+    mpdu[15] = 0x0A;
+    mpdu[16] = 0x22;
+    mpdu[17] = 0x22; // supergroup
+    opts.p25_trunk = 1;
+    opts.trunk_use_allow_list = 0;
+    opts.trunk_tune_enc_calls = 1;
+    opts.p25_is_tuned = 0;
+    reset_calls();
+    p25_decode_pdu_trunking(&opts, &st, mpdu);
+    rc |= expect_true("p1 pdu mfid90 active channel", strstr(st.active_channel[0], "SG: 8738") != NULL);
 
     dsd_state_ext_free_all(&st);
 

--- a/tests/protocol/p25/test_p25_p1_sync_dispatch.c
+++ b/tests/protocol/p25/test_p25_p1_sync_dispatch.c
@@ -28,6 +28,29 @@ int dsd_dispatch_matches_p25p1(int synctype);
 void dsd_dispatch_handle_p25p1(dsd_opts* opts, dsd_state* state);
 
 static char g_test_duid[3] = "03";
+static int g_check_result = NID_OK;
+static int g_new_nac = 0x293;
+static int g_error_count;
+static int g_last_observed_nac;
+static int g_open_mbe_calls;
+static int g_close_mbe_calls;
+static int g_close_mbe_r_calls;
+static int g_resume_calls;
+static int g_status_classify_calls;
+
+static void
+reset_stub_state(void) {
+    DSD_SNPRINTF(g_test_duid, sizeof(g_test_duid), "03");
+    g_check_result = NID_OK;
+    g_new_nac = 0x293;
+    g_error_count = 0;
+    g_last_observed_nac = -1;
+    g_open_mbe_calls = 0;
+    g_close_mbe_calls = 0;
+    g_close_mbe_r_calls = 0;
+    g_resume_calls = 0;
+    g_status_classify_calls = 0;
+}
 
 int
 getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
@@ -56,11 +79,11 @@ check_NID_with_observed_nac_soft(const char* bch_code, const uint8_t* reliab63, 
                                  char* new_duid, unsigned char parity, uint8_t parity_reliab, int* error_count) {
     (void)bch_code;
     (void)reliab63;
-    (void)observed_nac;
     (void)parity;
     (void)parity_reliab;
+    g_last_observed_nac = observed_nac;
     if (new_nac != NULL) {
-        *new_nac = 0x293;
+        *new_nac = g_new_nac;
     }
     if (new_duid != NULL) {
         new_duid[0] = g_test_duid[0];
@@ -68,9 +91,9 @@ check_NID_with_observed_nac_soft(const char* bch_code, const uint8_t* reliab63, 
         new_duid[2] = '\0';
     }
     if (error_count != NULL) {
-        *error_count = 0;
+        *error_count = g_error_count;
     }
-    return NID_OK;
+    return g_check_result;
 }
 
 void
@@ -82,18 +105,21 @@ printFrameInfo(dsd_opts* opts, dsd_state* state) {
 void
 openMbeOutFile(dsd_opts* opts, dsd_state* state) {
     (void)state;
+    ++g_open_mbe_calls;
     opts->mbe_out_f = stdout;
 }
 
 void
 closeMbeOutFile(dsd_opts* opts, dsd_state* state) {
     (void)state;
+    ++g_close_mbe_calls;
     opts->mbe_out_f = NULL;
 }
 
 void
 closeMbeOutFileR(dsd_opts* opts, dsd_state* state) {
     (void)state;
+    ++g_close_mbe_r_calls;
     opts->mbe_out_fR = NULL;
 }
 
@@ -101,6 +127,7 @@ void
 resumeScan(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    ++g_resume_calls;
 }
 
 void
@@ -125,6 +152,7 @@ void
 p25_status_accum_classify(dsd_state* state, const dsd_opts* opts) {
     (void)state;
     (void)opts;
+    ++g_status_classify_calls;
 }
 
 void
@@ -198,6 +226,7 @@ test_simple_tdu_dispatch_defaults(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
+    reset_stub_state();
 
     state.synctype = DSD_SYNC_P25P1_POS;
     DSD_SNPRINTF(g_test_duid, sizeof(g_test_duid), "03");
@@ -225,6 +254,7 @@ expect_stale_data_call_display_cleared(const char* duid, unsigned int expected_b
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
+    reset_stub_state();
 
     state.synctype = DSD_SYNC_P25P1_POS;
     seed_stale_data_call_display(&state);
@@ -255,12 +285,130 @@ test_p25p1_dispatch_clears_stale_data_call_display(void) {
     }
 }
 
+static void
+expect_observed_nac(const char* label, unsigned long long p2_cc, int p2_hardset, int nac, int expected_observed_nac) {
+    (void)label;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_stub_state();
+
+    state.synctype = DSD_SYNC_P25P1_POS;
+    state.p2_cc = p2_cc;
+    state.p2_hardset = p2_hardset;
+    state.nac = nac;
+
+    dsd_dispatch_handle_p25p1(&opts, &state);
+
+    assert(g_last_observed_nac == expected_observed_nac);
+}
+
+static void
+test_p25p1_observed_nac_priority(void) {
+    expect_observed_nac("hardset-p2-cc", 0x123ULL, 1, 0x234, 0x123);
+    expect_observed_nac("decoded-nac", 0x123ULL, 0, 0x234, 0x234);
+    expect_observed_nac("fallback-p2-cc", 0x456ULL, 0, 0, 0x456);
+    expect_observed_nac("invalid-values", 0xFFFULL, 0, 0xFFF, 0);
+}
+
+static void
+test_p25p1_nid_correction_and_failure_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_stub_state();
+
+    g_check_result = NID_PARITY_OVERRIDE;
+    g_error_count = 3;
+    g_new_nac = 0x321;
+    DSD_SNPRINTF(g_test_duid, sizeof(g_test_duid), "03");
+
+    dsd_dispatch_handle_p25p1(&opts, &state);
+
+    assert(state.nid_corrections_total == 3U);
+    assert(state.nid_parity_overrides == 1U);
+    assert(state.nac == 0x321);
+    assert(state.p2_cc == 0x321ULL);
+    assert(state.debug_header_errors == 2U);
+    assert(state.nid_failures_total == 0U);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_stub_state();
+    g_check_result = NID_DECODE_FAIL;
+    DSD_SNPRINTF(g_test_duid, sizeof(g_test_duid), "11");
+
+    dsd_dispatch_handle_p25p1(&opts, &state);
+
+    assert(state.nid_failures_total == 1U);
+    assert(state.debug_header_critical_errors == 1U);
+    assert(state.lastp25type == 0);
+    assert(strcmp(state.fsubtype, "              ") == 0);
+    assert(g_status_classify_calls == 1);
+}
+
+static void
+test_p25p1_mbe_output_and_resume_side_effects(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_stub_state();
+
+    DSD_SNPRINTF(opts.mbe_out_dir, sizeof(opts.mbe_out_dir), "captures");
+    opts.mbe_out_f = (FILE*)0x1;
+    DSD_SNPRINTF(g_test_duid, sizeof(g_test_duid), "00");
+
+    dsd_dispatch_handle_p25p1(&opts, &state);
+
+    assert(g_close_mbe_calls == 1);
+    assert(g_open_mbe_calls == 1);
+    assert(opts.mbe_out_f == stdout);
+    assert(state.lastp25type == 2);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_stub_state();
+    DSD_SNPRINTF(opts.mbe_out_dir, sizeof(opts.mbe_out_dir), "captures");
+    opts.mbe_out_f = (FILE*)0x1;
+    opts.mbe_out_fR = (FILE*)0x2;
+    opts.resume = 1;
+    DSD_SNPRINTF(g_test_duid, sizeof(g_test_duid), "13");
+
+    dsd_dispatch_handle_p25p1(&opts, &state);
+
+    assert(g_close_mbe_calls == 1);
+    assert(g_close_mbe_r_calls == 1);
+    assert(g_resume_calls == 1);
+    assert(opts.mbe_out_f == NULL);
+    assert(opts.mbe_out_fR == NULL);
+    assert(state.lastp25type == 3);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_stub_state();
+    opts.resume = 1;
+    state.numtdulc = 1;
+    DSD_SNPRINTF(g_test_duid, sizeof(g_test_duid), "33");
+
+    dsd_dispatch_handle_p25p1(&opts, &state);
+
+    assert(g_resume_calls == 1);
+    assert(state.numtdulc == 2);
+    assert(state.lastp25type == 0);
+}
+
 int
 main(void) {
     test_sync_pattern_lengths();
     test_synctype_helpers();
     test_simple_tdu_dispatch_defaults();
     test_p25p1_dispatch_clears_stale_data_call_display();
+    test_p25p1_observed_nac_priority();
+    test_p25p1_nid_correction_and_failure_state();
+    test_p25p1_mbe_output_and_resume_side_effects();
     printf("P25_P1_SYNC_DISPATCH: OK\n");
     return 0;
 }

--- a/tests/protocol/p25/test_p25_p1_tdu.c
+++ b/tests/protocol/p25/test_p25_p1_tdu.c
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(misc-use-internal-linkage)
+/*
+ * Focused checks for P25 Phase 1 TDU state cleanup and status-symbol handoff.
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/p25/p25.h>
+#include <dsd-neo/protocol/p25/p25_status_symbol.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/timing.h"
+
+static int g_read_zeros_calls;
+static unsigned int g_read_zeros_length;
+static int g_read_zeros_initial_status_count;
+static int g_status_count_after_read = 35;
+static int g_get_dibit_soft_calls;
+static int g_status_symbol = 3;
+static int g_status_ensure_calls;
+static int g_status_add_calls;
+static int g_last_status_add_value;
+static int g_status_classify_calls;
+static int g_sm_tdu_calls;
+
+static int
+float_close(float got, float want, float epsilon) {
+    float delta = got - want;
+    if (delta < 0.0F) {
+        delta = -delta;
+    }
+    return delta <= epsilon;
+}
+
+void read_zeros(dsd_opts* opts, dsd_state* state, unsigned int length, int* status_count);
+
+uint64_t
+dsd_time_monotonic_ns(void) {
+    return 1234500000000ULL;
+}
+
+void
+read_zeros(dsd_opts* opts, dsd_state* state, unsigned int length, int* status_count) {
+    (void)opts;
+    (void)state;
+    assert(status_count != NULL);
+    ++g_read_zeros_calls;
+    g_read_zeros_length = length;
+    g_read_zeros_initial_status_count = *status_count;
+    *status_count = g_status_count_after_read;
+}
+
+int
+getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
+    (void)opts;
+    (void)state;
+    assert(out_soft != NULL);
+    ++g_get_dibit_soft_calls;
+    out_soft->reliability = 255U;
+    out_soft->llr[0] = 100;
+    out_soft->llr[1] = -100;
+    return g_status_symbol;
+}
+
+void
+p25_status_accum_ensure_started(dsd_state* state) {
+    (void)state;
+    ++g_status_ensure_calls;
+}
+
+void
+p25_status_accum_add(dsd_state* state, int dibit_value) {
+    (void)state;
+    ++g_status_add_calls;
+    g_last_status_add_value = dibit_value;
+}
+
+void
+p25_status_accum_classify(dsd_state* state, const dsd_opts* opts) {
+    (void)state;
+    (void)opts;
+    ++g_status_classify_calls;
+}
+
+void
+p25_sm_emit_tdu(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    ++g_sm_tdu_calls;
+}
+
+static void
+reset_harness(void) {
+    g_read_zeros_calls = 0;
+    g_read_zeros_length = 0;
+    g_read_zeros_initial_status_count = 0;
+    g_status_count_after_read = 35;
+    g_get_dibit_soft_calls = 0;
+    g_status_symbol = 3;
+    g_status_ensure_calls = 0;
+    g_status_add_calls = 0;
+    g_last_status_add_value = -1;
+    g_status_classify_calls = 0;
+    g_sm_tdu_calls = 0;
+}
+
+static void
+seed_active_call_state(dsd_opts* opts, dsd_state* state) {
+    DSD_MEMSET(opts, 0, sizeof *opts);
+    DSD_MEMSET(state, 0, sizeof *state);
+    DSD_SNPRINTF(state->call_string[0], sizeof state->call_string[0], "%s", "active slot 0");
+    DSD_SNPRINTF(state->call_string[1], sizeof state->call_string[1], "%s", "active slot 1");
+    state->currentslot = 1;
+    state->payload_miP = 0x112233445566ULL;
+    state->payload_algid = 0x80;
+    state->payload_keyid = 0x1234;
+    state->p25_call_emergency[0] = 1;
+    state->p25_call_priority[0] = 1;
+    state->p25_call_is_packet[0] = 1;
+}
+
+static void
+assert_common_tdu_state(const dsd_opts* opts, const dsd_state* state) {
+    (void)opts;
+    assert(state->p25_p1_duid_tdu == 1U);
+    assert(state->currentslot == 0);
+    assert(g_status_ensure_calls == 1);
+    assert(g_read_zeros_calls == 1);
+    assert(g_read_zeros_length == 28U);
+    assert(g_read_zeros_initial_status_count == 21);
+    assert(g_get_dibit_soft_calls == 1);
+    assert(g_status_add_calls == 1);
+    assert(g_last_status_add_value == g_status_symbol);
+    assert(g_status_classify_calls == 1);
+    assert(g_sm_tdu_calls == 1);
+    assert(strcmp(state->call_string[0], "                     ") == 0);
+    assert(strcmp(state->call_string[1], "                     ") == 0);
+    assert(state->p25_p1_last_tdu != (time_t)0);
+    assert(state->p25_p1_last_tdu_m > 0.0);
+    assert(state->payload_miP == 0);
+    assert(state->payload_algid == 0);
+    assert(state->payload_keyid == 0);
+    assert(state->p25_call_emergency[0] == 0);
+    assert(state->p25_call_priority[0] == 0);
+    assert(state->p25_call_is_packet[0] == 0);
+}
+
+static void
+test_tdu_resets_call_crypto_state_and_restores_float_gain(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset_harness();
+    seed_active_call_state(&opts, &state);
+    opts.floating_point = 1;
+    opts.audio_gain = 2.25F;
+    state.aout_gain = -1.0F;
+
+    processTDU(&opts, &state);
+
+    assert_common_tdu_state(&opts, &state);
+    assert(float_close(state.aout_gain, opts.audio_gain, 1e-6F));
+}
+
+static void
+test_tdu_preserves_gain_when_integer_output_and_reports_sync_mismatch(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset_harness();
+    seed_active_call_state(&opts, &state);
+    g_status_count_after_read = 12;
+    g_status_symbol = 1;
+    opts.floating_point = 0;
+    opts.audio_gain = 2.25F;
+    state.aout_gain = 7.0F;
+
+    processTDU(&opts, &state);
+
+    assert_common_tdu_state(&opts, &state);
+    assert(float_close(state.aout_gain, 7.0F, 1e-6F));
+}
+
+int
+main(void) {
+    test_tdu_resets_call_crypto_state_and_restores_float_gain();
+    test_tdu_preserves_gain_when_integer_output_and_reports_sync_mismatch();
+    printf("P25_P1_TDU: OK\n");
+    return 0;
+}
+
+// NOLINTEND(misc-use-internal-linkage)

--- a/tests/protocol/p25/test_p25_p1_tdulc.c
+++ b/tests/protocol/p25/test_p25_p1_tdulc.c
@@ -37,6 +37,9 @@ static int g_channel = -1;
 static int g_svc = -1;
 static int g_tg = -1;
 static int g_src = -1;
+static int g_rs_hard_result = 0;
+static int g_rs_soft_result = 1;
+static int g_rs_soft_called = 0;
 
 static void
 sm_noop_init(dsd_opts* opts, dsd_state* state) {
@@ -196,7 +199,7 @@ int
 check_and_fix_reedsolomon_24_12_13(char* data, char* parity) {
     (void)data;
     (void)parity;
-    return 0; // no irrecoverable errors
+    return g_rs_hard_result;
 }
 
 int
@@ -214,6 +217,18 @@ void
 encode_reedsolomon_24_12_13(char* data, char* parity) {
     (void)data;
     (void)parity;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25p1_rs_24_12_13_soft_reliability(char* data, const char* parity, const uint8_t* data_reliab,
+                                   const uint8_t* parity_reliab) {
+    (void)data;
+    (void)parity;
+    (void)data_reliab;
+    (void)parity_reliab;
+    g_rs_soft_called++;
+    return g_rs_soft_result;
 }
 
 int
@@ -415,6 +430,7 @@ main(void) {
     opts.p25_is_tuned = 0;
     opts.floating_point = 1;
     opts.audio_gain = 3.5F;
+    opts.payload = 0;
     state.p25_cc_freq = 851000000;
     state.tg_hold = 0;
     int lastsrc = 0x00ABCDEF;
@@ -434,6 +450,9 @@ main(void) {
     DSD_SNPRINTF(state.call_string[0], sizeof(state.call_string[0]), "%s", "left active");
     DSD_SNPRINTF(state.call_string[1], sizeof(state.call_string[1]), "%s", "right active");
     g_called = 0;
+    g_rs_hard_result = 0;
+    g_rs_soft_result = 1;
+    g_rs_soft_called = 0;
     processTDULC(&opts, &state);
     rc |= expect_eq_int("grant called", g_called, 1);
     rc |= expect_eq_int("grant channel", g_channel, 0x100A);
@@ -472,6 +491,34 @@ main(void) {
     g_called = 0;
     processTDULC(&opts, &state);
     rc |= expect_eq_int("unsupported format", g_called, 0);
+
+    // Case 5: Hard Reed-Solomon failure recovered by soft reliability still dispatches LCW.
+    build_lcw_words(0x44, 0x00, 0x00, 0x3456, 0x100A, 0x0000);
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.p25_lcw_retune = 1;
+    opts.trunk_tune_enc_calls = 1;
+    opts.payload = 1;
+    state.p25_cc_freq = 851000000;
+    state.lastsrc = (unsigned long long)lastsrc;
+    state.synctype = DSD_SYNC_P25P1_POS;
+    state.p25_chan_iden = 1;
+    state.p25_iden_fdma[1].chan_type = 1;
+    state.p25_iden_fdma[1].chan_spac = 100;
+    state.p25_iden_fdma[1].base_freq = 851000000 / 5;
+    state.p25_iden_fdma[1].trust = 2;
+    state.p25_iden_fdma[1].populated = 1;
+    state.p25_chan_tdma_explicit[1] = 1;
+    g_called = 0;
+    g_rs_hard_result = 1;
+    g_rs_soft_result = 0;
+    g_rs_soft_called = 0;
+    processTDULC(&opts, &state);
+    rc |= expect_eq_int("soft rs called", g_rs_soft_called, 1);
+    rc |= expect_eq_int("soft rs recovered", (int)state.p25_p1_soft_rs_ok, 1);
+    rc |= expect_eq_int("soft rs fec ok", (int)state.p25_p1_voice_fec_ok, 1);
+    rc |= expect_eq_int("soft rs fec err", (int)state.p25_p1_voice_fec_err, 0);
+    rc |= expect_eq_int("soft rs dispatch", g_called, 1);
+    rc |= expect_eq_int("soft rs grant tg", g_tg, 0x3456);
 
     return rc;
 }

--- a/tests/protocol/p25/test_p25_p1_tsbk_handlers.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_handlers.c
@@ -1,0 +1,678 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-suspicious-include)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * P25 P1 TSBK handler tests: verify deterministic vendor handler side effects
+ * without depending on live TSBK dibit capture or terminal text formatting.
+ */
+
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/file_io.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/platform/timing.h>
+#include <dsd-neo/protocol/p25/p25_12.h>
+#include <dsd-neo/protocol/p25/p25_callsign.h>
+#include <dsd-neo/protocol/p25/p25_crc.h>
+#include <dsd-neo/protocol/p25/p25_frequency.h>
+#include <dsd-neo/protocol/p25/p25_status_symbol.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/protocol/p25/p25_vpdu.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "p25_mfid90_utils.h"
+
+static int g_add_wgid_count;
+static int g_add_wuid_count;
+static int g_remove_wgid_count;
+static int g_update_count;
+static int g_kas_count;
+static int g_seed_count;
+static int g_grant_count;
+static int g_mac_count;
+static int g_last_sg;
+static int g_last_wgid;
+static uint32_t g_last_wuid;
+static int g_last_update_patch;
+static int g_last_update_active;
+static int g_last_key;
+static int g_last_ssn;
+static int g_last_grant_channel;
+static int g_last_grant_tg;
+static int g_last_grant_src;
+static int g_neighbor_update_count;
+static int g_neighbor_update_last_count;
+static long g_neighbor_update_last_freq;
+static int g_confirm_idens_count;
+static long int g_channel_freq;
+static int g_soft_llr_count;
+static int g_soft_llr_list_count;
+static int g_crc_call_count;
+static int g_crc_accept_call;
+static int g_candidate_count;
+
+enum { TEST_TSBK_BYTES_PER_BLOCK = 12 };
+
+static uint8_t g_candidate_bytes[P25_12_MAX_CANDIDATES][TEST_TSBK_BYTES_PER_BLOCK];
+static uint8_t g_soft_llr_bytes[TEST_TSBK_BYTES_PER_BLOCK];
+
+uint64_t
+dsd_time_monotonic_ns(void) {
+    return 41000000000ULL;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_patch_update(dsd_state* state, int sgid, int is_patch, int active) {
+    (void)state;
+    g_update_count++;
+    g_last_sg = sgid;
+    g_last_update_patch = is_patch;
+    g_last_update_active = active;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_patch_add_wgid(dsd_state* state, int sgid, int wgid) {
+    (void)state;
+    g_add_wgid_count++;
+    g_last_sg = sgid;
+    g_last_wgid = wgid;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_patch_add_wuid(dsd_state* state, int sgid, uint32_t wuid) {
+    (void)state;
+    g_add_wuid_count++;
+    g_last_sg = sgid;
+    g_last_wuid = wuid;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_patch_remove_wgid(dsd_state* state, int sgid, int wgid) {
+    (void)state;
+    g_remove_wgid_count++;
+    g_last_sg = sgid;
+    g_last_wgid = wgid;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_patch_remove_wuid(dsd_state* state, int sgid, uint32_t wuid) {
+    (void)state;
+    (void)sgid;
+    (void)wuid;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_patch_set_kas(dsd_state* state, int sgid, int key, int alg, int ssn) {
+    (void)state;
+    (void)alg;
+    g_kas_count++;
+    g_last_sg = sgid;
+    g_last_key = key;
+    g_last_ssn = ssn;
+}
+
+long int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+process_channel_to_freq(const dsd_opts* opts, dsd_state* state, int channel) {
+    (void)opts;
+    (void)state;
+    (void)channel;
+    return g_channel_freq;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_format_chan_suffix(const dsd_state* state, uint16_t chan, int slot_hint, char* out, size_t outsz) {
+    (void)state;
+    (void)slot_hint;
+    DSD_SNPRINTF(out, outsz, "/%04X", chan);
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_sm_seed_cc_from_current_tuner_if_unknown(const dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_seed_count++;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_sm_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
+    (void)opts;
+    (void)state;
+    (void)svc_bits;
+    g_grant_count++;
+    g_last_grant_channel = channel;
+    g_last_grant_tg = tg;
+    g_last_grant_src = src;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_sm_on_neighbor_update(dsd_opts* opts, dsd_state* state, const long* freqs, int count) {
+    (void)opts;
+    (void)state;
+    g_neighbor_update_count++;
+    g_neighbor_update_last_count = count;
+    g_neighbor_update_last_freq = (freqs != NULL && count > 0) ? freqs[0] : 0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_confirm_idens_for_current_site(dsd_state* state) {
+    (void)state;
+    g_confirm_idens_count++;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+process_MAC_VPDU(dsd_opts* opts, dsd_state* state, int type, unsigned long long int mac[24]) {
+    (void)opts;
+    (void)state;
+    (void)type;
+    (void)mac;
+    g_mac_count++;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_wacn_sysid_to_callsign(uint32_t wacn, uint16_t sysid, char callsign[7]) {
+    (void)wacn;
+    (void)sysid;
+    DSD_SNPRINTF(callsign, 7, "TST123");
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_mfid90_base_station_id_decode(const uint8_t tsbk_byte[12], char* cwid, size_t cwid_size, uint16_t* channel) {
+    (void)tsbk_byte;
+    DSD_SNPRINTF(cwid, cwid_size, "%s", "CWID");
+    *channel = 0x1234;
+    return 4;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
+    (void)opts;
+    (void)state;
+    if (out_soft != NULL) {
+        out_soft->llr[0] = 100;
+        out_soft->llr[1] = -100;
+    }
+    return 0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_status_accum_ensure_started(dsd_state* state) {
+    (void)state;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_status_accum_add(dsd_state* state, int dibit_value) {
+    (void)state;
+    (void)dibit_value;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_status_accum_classify(dsd_state* state, const dsd_opts* opts) {
+    (void)state;
+    (void)opts;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_12_soft_llr(const uint8_t* input, const int16_t* bit_llr196, uint8_t treturn[12]) {
+    (void)input;
+    (void)bit_llr196;
+    g_soft_llr_count++;
+    DSD_MEMCPY(treturn, g_soft_llr_bytes, TEST_TSBK_BYTES_PER_BLOCK);
+    return 0;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_12_soft_llr_list(const uint8_t* input, const int16_t* bit_llr196, p25_12_candidate_t* candidates,
+                     int max_candidates) {
+    (void)input;
+    (void)bit_llr196;
+    g_soft_llr_list_count++;
+    int count = g_candidate_count;
+    if (count > max_candidates) {
+        count = max_candidates;
+    }
+    for (int i = 0; i < count; i++) {
+        DSD_MEMCPY(candidates[i].bytes, g_candidate_bytes[i], TEST_TSBK_BYTES_PER_BLOCK);
+    }
+    return count;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+crc16_lb_bridge(const int* payload, int len) {
+    (void)payload;
+    (void)len;
+    g_crc_call_count++;
+    if (g_crc_accept_call > 0) {
+        return (g_crc_call_count == g_crc_accept_call) ? 0 : 1;
+    }
+    return 0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+rotate_symbol_out_file(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+#include "../../../src/protocol/p25/phase1/p25p1_tsbk.c"
+
+static void
+reset_calls(void) {
+    g_add_wgid_count = 0;
+    g_add_wuid_count = 0;
+    g_remove_wgid_count = 0;
+    g_update_count = 0;
+    g_kas_count = 0;
+    g_seed_count = 0;
+    g_grant_count = 0;
+    g_mac_count = 0;
+    g_last_sg = 0;
+    g_last_wgid = 0;
+    g_last_wuid = 0;
+    g_last_update_patch = 0;
+    g_last_update_active = 0;
+    g_last_key = 0;
+    g_last_ssn = 0;
+    g_last_grant_channel = 0;
+    g_last_grant_tg = 0;
+    g_last_grant_src = 0;
+    g_neighbor_update_count = 0;
+    g_neighbor_update_last_count = 0;
+    g_neighbor_update_last_freq = 0;
+    g_confirm_idens_count = 0;
+    g_channel_freq = 0;
+    g_soft_llr_count = 0;
+    g_soft_llr_list_count = 0;
+    g_crc_call_count = 0;
+    g_crc_accept_call = 0;
+    g_candidate_count = 0;
+    DSD_MEMSET(g_candidate_bytes, 0, sizeof(g_candidate_bytes));
+    DSD_MEMSET(g_soft_llr_bytes, 0, sizeof(g_soft_llr_bytes));
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_long(const char* tag, long got, long want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %ld want %ld\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_bytes(const char* tag, const uint8_t* got, const uint8_t* want, size_t len) {
+    if (memcmp(got, want, len) != 0) {
+        DSD_FPRINTF(stderr, "%s: byte mismatch\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_crc_candidate_selection_and_fallback(void) {
+    uint8_t dibits[TSBK_DIBITS_PER_REP] = {0};
+    int16_t llr[TSBK_SOFT_BITS_PER_REP] = {0};
+    uint8_t out[TSBK_BYTES_PER_BLOCK] = {0};
+    uint8_t want[TSBK_BYTES_PER_BLOCK] = {0};
+
+    reset_calls();
+    g_candidate_count = 3;
+    g_crc_accept_call = 2;
+    for (int c = 0; c < g_candidate_count; c++) {
+        for (int i = 0; i < TSBK_BYTES_PER_BLOCK; i++) {
+            g_candidate_bytes[c][i] = (uint8_t)((c + 1) * 0x10 + i);
+        }
+    }
+    DSD_MEMCPY(want, g_candidate_bytes[1], sizeof(want));
+    tsbk_decode_repetition_bytes(dibits, llr, out);
+
+    int rc = 0;
+    rc |= expect_int("candidate list decoder used", g_soft_llr_list_count, 1);
+    rc |= expect_int("candidate crc attempts", g_crc_call_count, 2);
+    rc |= expect_int("fallback decoder skipped", g_soft_llr_count, 0);
+    rc |= expect_bytes("selected crc-clean candidate", out, want, sizeof(out));
+
+    reset_calls();
+    g_candidate_count = 2;
+    g_crc_accept_call = 9;
+    for (int c = 0; c < g_candidate_count; c++) {
+        for (int i = 0; i < TSBK_BYTES_PER_BLOCK; i++) {
+            g_candidate_bytes[c][i] = (uint8_t)(0x80 + (c * 0x10) + i);
+        }
+    }
+    DSD_MEMCPY(want, g_candidate_bytes[0], sizeof(want));
+    tsbk_decode_repetition_bytes(dibits, llr, out);
+    rc |= expect_int("all candidates tried before default", g_crc_call_count, 2);
+    rc |= expect_bytes("default candidate retained", out, want, sizeof(out));
+
+    reset_calls();
+    for (int i = 0; i < TSBK_BYTES_PER_BLOCK; i++) {
+        g_soft_llr_bytes[i] = (uint8_t)(0xA0 + i);
+        want[i] = g_soft_llr_bytes[i];
+    }
+    tsbk_decode_repetition_bytes(dibits, llr, out);
+    rc |= expect_int("fallback list called", g_soft_llr_list_count, 1);
+    rc |= expect_int("fallback decoder called", g_soft_llr_count, 1);
+    rc |= expect_bytes("fallback bytes copied", out, want, sizeof(out));
+    return rc;
+}
+
+static int
+test_mfid90_regroup_add_delete(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    uint8_t add_tsbk[TSBK_BYTES_PER_BLOCK] = {0};
+    add_tsbk[2] = 0x12;
+    add_tsbk[3] = 0x34;
+    add_tsbk[4] = 0x01;
+    add_tsbk[5] = 0x02;
+    add_tsbk[8] = 0x03;
+    add_tsbk[9] = 0x04;
+
+    reset_calls();
+    tsbk_handle_mfid90_regroup_add_del(&state, add_tsbk, 1);
+    int rc = 0;
+    rc |= expect_int("add wgid count", g_add_wgid_count, 2);
+    rc |= expect_int("add last sg", g_last_sg, 0x1234);
+    rc |= expect_int("add last wgid", g_last_wgid, 0x0304);
+    rc |= expect_int("add update count", g_update_count, 1);
+    rc |= expect_int("add update patch", g_last_update_patch, 1);
+    rc |= expect_int("add update active", g_last_update_active, 1);
+
+    reset_calls();
+    tsbk_handle_mfid90_regroup_add_del(&state, add_tsbk, 0);
+    rc |= expect_int("delete wgid count", g_remove_wgid_count, 2);
+    rc |= expect_int("delete update count", g_update_count, 0);
+    rc |= expect_int("delete last wgid", g_last_wgid, 0x0304);
+    return rc;
+}
+
+static int
+test_mfid_a4_patch_and_simulselect_paths(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    uint8_t tsbk[TSBK_BYTES_PER_BLOCK] = {0};
+    tsbk[0] = 0x30;
+    tsbk[2] = (uint8_t)((0x3 << 5) | 0x07);
+    tsbk[3] = 0x12;
+    tsbk[4] = 0x34;
+    tsbk[5] = 0xBE;
+    tsbk[6] = 0xEF;
+    tsbk[7] = 0x01;
+    tsbk[8] = 0x02;
+    tsbk[9] = 0x03;
+
+    reset_calls();
+    tsbk_handle_mfid_a4(&state, tsbk);
+    int rc = 0;
+    rc |= expect_int("a4 patch adds wgid", g_add_wgid_count, 1);
+    rc |= expect_int("a4 patch sg", g_last_sg, 0x1234);
+    rc |= expect_int("a4 patch wgid", g_last_wgid, 0x010203);
+    rc |= expect_int("a4 patch update count", g_update_count, 1);
+    rc |= expect_int("a4 patch is_patch", g_last_update_patch, 1);
+    rc |= expect_int("a4 patch active", g_last_update_active, 1);
+    rc |= expect_int("a4 patch kas key", g_last_key, 0xBEEF);
+    rc |= expect_int("a4 patch kas ssn", g_last_ssn, 7);
+
+    tsbk[2] = (uint8_t)((0x4 << 5) | 0x05);
+    reset_calls();
+    tsbk_handle_mfid_a4(&state, tsbk);
+    rc |= expect_int("a4 simulselect adds wuid", g_add_wuid_count, 1);
+    rc |= expect_int("a4 simulselect wuid", (int)g_last_wuid, 0x010203);
+    rc |= expect_int("a4 simulselect is_patch", g_last_update_patch, 0);
+    rc |= expect_int("a4 simulselect inactive", g_last_update_active, 0);
+    rc |= expect_int("a4 simulselect ssn", g_last_ssn, 5);
+
+    tsbk[0] = 0x31;
+    reset_calls();
+    tsbk_handle_mfid_a4(&state, tsbk);
+    rc |= expect_int("a4 non-op ignored", g_add_wgid_count + g_add_wuid_count + g_update_count + g_kas_count, 0);
+    return rc;
+}
+
+static int
+test_mfid90_grant_seeds_trunk_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.p25_trunk = 1;
+
+    uint8_t tsbk[TSBK_BYTES_PER_BLOCK] = {0};
+    tsbk[3] = 0x12;
+    tsbk[4] = 0x34;
+    tsbk[5] = 0x45;
+    tsbk[6] = 0x67;
+    tsbk[7] = 0x01;
+    tsbk[8] = 0x02;
+    tsbk[9] = 0x03;
+
+    reset_calls();
+    g_channel_freq = 851012500;
+    tsbk_handle_mfid90_grant(&opts, &state, tsbk);
+    int rc = 0;
+    rc |= expect_int("grant seed count", g_seed_count, 1);
+    rc |= expect_int("grant count", g_grant_count, 1);
+    rc |= expect_int("grant channel", g_last_grant_channel, 0x1234);
+    rc |= expect_int("grant tg", g_last_grant_tg, 0x4567);
+    rc |= expect_int("grant src", g_last_grant_src, 0x010203);
+    rc |= expect_int("active channel set", strstr(state.active_channel[0], "1234/1234") != NULL, 1);
+
+    reset_calls();
+    g_channel_freq = 0;
+    tsbk_handle_mfid90_grant(&opts, &state, tsbk);
+    rc |= expect_int("zero freq skips grant", g_grant_count, 0);
+    return rc;
+}
+
+static int
+test_mfid90_grant_update_trunk_dispatch(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.p25_trunk = 1;
+
+    uint8_t tsbk[TSBK_BYTES_PER_BLOCK] = {0};
+    tsbk[2] = 0x11;
+    tsbk[3] = 0x22;
+    tsbk[4] = 0x33;
+    tsbk[5] = 0x44;
+    tsbk[6] = 0x55;
+    tsbk[7] = 0x66;
+    tsbk[8] = 0x77;
+    tsbk[9] = 0x88;
+
+    reset_calls();
+    g_channel_freq = 851012500;
+    tsbk_handle_mfid90_grant_update(&opts, &state, tsbk);
+    int rc = 0;
+    rc |= expect_int("grant update seeds twice", g_seed_count, 2);
+    rc |= expect_int("grant update count", g_grant_count, 2);
+    rc |= expect_int("grant update last channel", g_last_grant_channel, 0x5566);
+    rc |= expect_int("grant update last tg", g_last_grant_tg, 0x7788);
+    rc |= expect_int("grant update source is zero", g_last_grant_src, 0);
+    rc |= expect_int("grant update active channel", strstr(state.active_channel[0], "1122/1122") != NULL, 1);
+
+    tsbk[2] = 0x00;
+    tsbk[3] = 0x00;
+    reset_calls();
+    g_channel_freq = 851012500;
+    tsbk_handle_mfid90_grant_update(&opts, &state, tsbk);
+    rc |= expect_int("zero first channel skips first grant", g_grant_count, 1);
+    rc |= expect_int("zero first channel still grants second", g_last_grant_channel, 0x5566);
+
+    reset_calls();
+    g_channel_freq = 0;
+    tsbk_handle_mfid90_grant_update(&opts, &state, tsbk);
+    rc |= expect_int("zero translated freq skips update grants", g_grant_count, 0);
+    return rc;
+}
+
+static int
+test_network_status_state_policy(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    uint8_t tsbk[TSBK_BYTES_PER_BLOCK] = {0};
+    tsbk[3] = 0xAB;
+    tsbk[4] = 0xCD;
+    tsbk[5] = 0xE1;
+    tsbk[6] = 0x23;
+    tsbk[7] = 0x45;
+    tsbk[8] = 0x67;
+
+    reset_calls();
+    state.p25_cc_is_tdma = 1;
+    g_channel_freq = 851012500;
+    tsbk_handle_network_status(&opts, &state, tsbk);
+    int rc = 0;
+    rc |= expect_long("accepted p25 cc", state.p25_cc_freq, 851012500);
+    rc |= expect_long("accepted trunk cc", state.trunk_cc_freq, 851012500);
+    rc |= expect_int("accepted cc is fdma", state.p25_cc_is_tdma, 0);
+    rc |= expect_long("accepted wacn", state.p2_wacn, 0xABCDE);
+    rc |= expect_int("accepted sysid", state.p2_sysid, 0x123);
+    rc |= expect_int("neighbor update count", g_neighbor_update_count, 1);
+    rc |= expect_int("neighbor update length", g_neighbor_update_last_count, 1);
+    rc |= expect_long("neighbor update freq", g_neighbor_update_last_freq, 851012500);
+    rc |= expect_long("lcn zero learned", state.trunk_lcn_freq[0], 851012500);
+    rc |= expect_int("iden confirmation", g_confirm_idens_count, 1);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.p25_is_tuned = 1;
+    state.p25_cc_freq = 860012500;
+    state.trunk_cc_freq = 860012500;
+    state.p25_cc_is_tdma = 1;
+    state.p2_wacn = 0x11111;
+    state.p2_sysid = 0x222;
+    reset_calls();
+    g_channel_freq = 851012500;
+    tsbk_handle_network_status(&opts, &state, tsbk);
+    rc |= expect_long("voice tuned preserves p25 cc", state.p25_cc_freq, 860012500);
+    rc |= expect_long("voice tuned preserves trunk cc", state.trunk_cc_freq, 860012500);
+    rc |= expect_int("voice tuned preserves tdma marker", state.p25_cc_is_tdma, 1);
+    rc |= expect_long("voice tuned preserves wacn", state.p2_wacn, 0x11111);
+    rc |= expect_int("voice tuned preserves sysid", state.p2_sysid, 0x222);
+    rc |= expect_int("voice tuned skips neighbor", g_neighbor_update_count, 0);
+    rc |= expect_int("voice tuned skips iden confirmation", g_confirm_idens_count, 0);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.p25_cc_is_tdma = 1;
+    reset_calls();
+    g_channel_freq = 0;
+    tsbk_handle_network_status(&opts, &state, tsbk);
+    rc |= expect_long("invalid channel leaves p25 cc", state.p25_cc_freq, 0);
+    rc |= expect_int("invalid channel still records fdma", state.p25_cc_is_tdma, 0);
+    rc |= expect_long("invalid channel records wacn", state.p2_wacn, 0xABCDE);
+    rc |= expect_int("invalid channel records sysid", state.p2_sysid, 0x123);
+    rc |= expect_int("invalid channel skips neighbor", g_neighbor_update_count, 0);
+    rc |= expect_int("invalid channel skips iden confirmation", g_confirm_idens_count, 0);
+    return rc;
+}
+
+static int
+test_dispatch_gates_mac_and_vendor_handlers(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    tsbk_decode_ctx_t ctx;
+    unsigned long long pdu[24] = {0};
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+
+    int rc = 0;
+    reset_calls();
+    tsbk_dispatch_message(&opts, &state, &ctx, 1, 0, 0, pdu);
+    rc |= expect_int("err skips dispatch", g_mac_count + g_add_wgid_count, 0);
+
+    reset_calls();
+    pdu[1] = 0x40;
+    tsbk_dispatch_message(&opts, &state, &ctx, 0, 0, 0, pdu);
+    rc |= expect_int("standard dispatch mac", g_mac_count, 1);
+
+    reset_calls();
+    pdu[1] = 0x7B;
+    tsbk_dispatch_message(&opts, &state, &ctx, 0, 0, 0, pdu);
+    rc |= expect_int("0x7b pdu suppressed", g_mac_count, 0);
+
+    reset_calls();
+    ctx.tsbk_byte[0] = 0x40;
+    ctx.tsbk_byte[5] = 0x12;
+    ctx.tsbk_byte[6] = 0x34;
+    ctx.tsbk_byte[7] = 0x56;
+    ctx.tsbk_byte[8] = 0x78;
+    ctx.tsbk_byte[9] = 0x90;
+    tsbk_dispatch_message(&opts, &state, &ctx, 0, 0, 1, pdu);
+    rc |= expect_int("protected isp skips mac", g_mac_count, 0);
+
+    reset_calls();
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    ctx.tsbk_byte[0] = 0x00;
+    ctx.tsbk_byte[2] = 0x00;
+    ctx.tsbk_byte[3] = 0x55;
+    ctx.tsbk_byte[4] = 0x00;
+    ctx.tsbk_byte[5] = 0x66;
+    tsbk_dispatch_message(&opts, &state, &ctx, 0, 0x90, 0, pdu);
+    rc |= expect_int("mfid90 dispatch", g_add_wgid_count, 1);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_crc_candidate_selection_and_fallback();
+    rc |= test_mfid90_regroup_add_delete();
+    rc |= test_mfid_a4_patch_and_simulselect_paths();
+    rc |= test_mfid90_grant_seeds_trunk_state();
+    rc |= test_mfid90_grant_update_trunk_dispatch();
+    rc |= test_network_status_state_policy();
+    rc |= test_dispatch_gates_mac_and_vendor_handlers();
+    return rc;
+}
+
+// NOLINTEND(bugprone-suspicious-include)

--- a/tests/protocol/p25/test_p25_p1_tsbk_vpdu.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_vpdu.c
@@ -212,8 +212,12 @@ static int
 test_extended_function_command_abbreviated(void) {
     int rc = 0;
 
+    rc |= expect_str_has("extfn label check", p25_extended_function_class0_operand_label(0x00), "Radio Check");
     rc |= expect_str_has("extfn label inhibit", p25_extended_function_class0_operand_label(0x7F), "Radio Inhibit");
     rc |= expect_str_has("extfn label detach", p25_extended_function_class0_operand_label(0x7D), "Radio Detach");
+    rc |= expect_str_has("extfn label uninhibit", p25_extended_function_class0_operand_label(0x7E), "Radio Uninhibit");
+    rc |= expect_str_has("extfn label reserved", p25_extended_function_class0_operand_label(0x01), "Reserved");
+    rc |= expect_str_has("extfn ack masks label", p25_extended_function_class0_operand_label(0x80), "Radio Check");
     rc |= expect_eq("extfn ack bit", p25_extended_function_operand_is_ack(0xFF), 1);
     rc |= expect_eq("extfn no ack bit", p25_extended_function_operand_is_ack(0x7F), 0);
 

--- a/tests/protocol/p25/test_p25_p2_mixer_gate.c
+++ b/tests/protocol/p25/test_p25_p2_mixer_gate.c
@@ -77,6 +77,38 @@ fill_f32_frame(float frame[160], float value) {
 }
 
 static int
+short_18_blocks_are_clear(short frames[18][160]) {
+    for (int frame = 0; frame < 18; frame++) {
+        for (int i = 0; i < 160; i++) {
+            if (frames[frame][i] != 0) {
+                return 0;
+            }
+        }
+    }
+    return 1;
+}
+
+static int
+short_block_is_clear(const short* samples, size_t count) {
+    for (size_t i = 0; i < count; i++) {
+        if (samples[i] != 0) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int
+float_block_is_clear(const float* samples, size_t count) {
+    for (size_t i = 0; i < count; i++) {
+        if (samples[i] < -1.0e-6f || samples[i] > 1.0e-6f) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int
 run_fs4_left_active_case_ext(int enc_lockout_enabled, int expect_right_silent, int muted_slot_algid,
                              int muted_slot_aes_loaded, unsigned long long muted_slot_key, int muted_slot_svc,
                              int muted_slot_marker) {
@@ -284,6 +316,329 @@ run_ss18_right_active_case(int enc_lockout_enabled, int expect_left_silent, int 
                                           muted_slot_aes_loaded, muted_slot_key, 0x40, 0);
 }
 
+static int
+run_ss18_partial_flush_case(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.floating_point = 0;
+    opts.pulse_digi_rate_out = 8000;
+    opts.slot1_on = 1;
+    opts.slot2_on = 1;
+    st.s_l4[0][0] = 321;
+    st.s_r4[0][0] = -654;
+    st.voice_counter[0] = 7;
+    st.voice_counter[1] = 8;
+    st.p25_p2_audio_allowed[0] = 0;
+    st.p25_p2_audio_allowed[1] = 0;
+
+    dsd_p25p2_flush_partial_audio(&opts, &st);
+
+    short out[160 * 2] = {0};
+    const size_t expected_bytes = (size_t)160 * 2U * sizeof(out[0]);
+    rc |= expect_eq("partial flush captured calls", g_audio_capture_calls >= 1, 1);
+    int copied = copy_capture_bytes("partial flush captured bytes", out, expected_bytes);
+    rc |= copied;
+    if (copied == 0) {
+        rc |= expect_eq("partial flush left sample", out[0], 321);
+        rc |= expect_eq("partial flush right sample", out[1], -654);
+    }
+    rc |= expect_eq("partial flush allowed left", st.p25_p2_audio_allowed[0], 1);
+    rc |= expect_eq("partial flush allowed right", st.p25_p2_audio_allowed[1], 1);
+    rc |= expect_eq("partial flush voice counter left", st.voice_counter[0], 0);
+    rc |= expect_eq("partial flush voice counter right", st.voice_counter[1], 0);
+    rc |= expect_eq("partial flush clears left frames", short_18_blocks_are_clear(st.s_l4), 1);
+    rc |= expect_eq("partial flush clears right frames", short_18_blocks_are_clear(st.s_r4), 1);
+    return rc;
+}
+
+static int
+run_ss18_partial_flush_guard_case(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.floating_point = 1;
+    opts.pulse_digi_rate_out = 8000;
+    opts.slot1_on = 1;
+    opts.slot2_on = 1;
+    st.s_l4[0][0] = 111;
+    st.voice_counter[0] = 3;
+
+    dsd_p25p2_flush_partial_audio(&opts, &st);
+
+    rc |= expect_eq("partial flush fp guard calls", g_audio_capture_calls, 0);
+    rc |= expect_eq("partial flush fp guard preserves sample", st.s_l4[0][0], 111);
+    rc |= expect_eq("partial flush fp guard preserves counter", st.voice_counter[0], 3);
+
+    opts.floating_point = 0;
+    opts.pulse_digi_rate_out = 48000;
+    dsd_p25p2_flush_partial_audio(&opts, &st);
+    rc |= expect_eq("partial flush rate guard calls", g_audio_capture_calls, 0);
+    rc |= expect_eq("partial flush rate guard preserves sample", st.s_l4[0][0], 111);
+    return rc;
+}
+
+static int
+run_short_mono_playback_case(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.slot1_on = 1;
+    st.audio_out_idx = 160;
+    st.audio_out_idx2 = 800000;
+    st.audio_out_buf_p = st.audio_out_buf + 100;
+    st.audio_out_float_buf_p = st.audio_out_float_buf + 100;
+    for (int i = 0; i < 160; i++) {
+        st.s_l[i] = (short)(i + 1);
+    }
+
+    playSynthesizedVoiceMS(&opts, &st);
+
+    short out[160] = {0};
+    rc |= expect_eq("short mono captured calls", g_audio_capture_calls, 1);
+    int copied = copy_capture_bytes("short mono captured bytes", out, sizeof(out));
+    rc |= copied;
+    if (copied == 0) {
+        rc |= expect_eq("short mono first sample", out[0], 1);
+        rc |= expect_eq("short mono last sample", out[159], 160);
+    }
+    rc |= expect_eq("short mono resets idx", st.audio_out_idx, 0);
+    rc |= expect_eq("short mono resets ring span", st.audio_out_idx2, 0);
+    rc |= expect_eq("short mono clears s_l", short_block_is_clear(st.s_l, 160), 1);
+    rc |= expect_true("short mono resets short ptr", st.audio_out_buf_p == st.audio_out_buf + 100);
+    rc |= expect_true("short mono resets float ptr", st.audio_out_float_buf_p == st.audio_out_float_buf + 100);
+    return rc;
+}
+
+static int
+run_float_mono_playback_case(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.slot1_on = 1;
+    opts.audio_gain = 25;
+    st.aout_gain = 49.0f;
+    st.audio_out_idx2 = 800000;
+    st.audio_out_buf_p = st.audio_out_buf + 100;
+    st.audio_out_float_buf_p = st.audio_out_float_buf + 100;
+    fill_f32_frame(st.f_l, 0.25f);
+
+    playSynthesizedVoiceFM(&opts, &st);
+
+    float out[160] = {0.0f};
+    rc |= expect_eq("float mono captured calls", g_audio_capture_calls, 1);
+    int copied = copy_capture_bytes("float mono captured bytes", out, sizeof(out));
+    rc |= copied;
+    if (copied == 0) {
+        rc |= expect_true("float mono audible", out[0] != 0.0f);
+    }
+    rc |= expect_eq("float mono resets ring span", st.audio_out_idx2, 0);
+    rc |= expect_eq("float mono clears f_l", float_block_is_clear(st.f_l, 160), 1);
+    rc |= expect_true("float mono resets short ptr", st.audio_out_buf_p == st.audio_out_buf + 100);
+    rc |= expect_true("float mono resets float ptr", st.audio_out_float_buf_p == st.audio_out_float_buf + 100);
+    return rc;
+}
+
+static int
+run_short_stereo_fdma_playback_case(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.slot1_on = 1;
+    st.audio_out_idx = 160;
+    st.audio_out_idxR = 160;
+    st.audio_out_idx2 = 800000;
+    st.audio_out_idx2R = 800000;
+    st.audio_out_buf_p = st.audio_out_buf + 100;
+    st.audio_out_buf_pR = st.audio_out_bufR + 100;
+    st.audio_out_float_buf_p = st.audio_out_float_buf + 100;
+    st.audio_out_float_buf_pR = st.audio_out_float_bufR + 100;
+    for (int i = 0; i < 160; i++) {
+        st.s_l[i] = (short)(i + 10);
+        st.s_r[i] = (short)(-i - 10);
+    }
+
+    playSynthesizedVoiceSS(&opts, &st);
+
+    short out[160 * 2] = {0};
+    rc |= expect_eq("short stereo fdma calls", g_audio_capture_calls, 1);
+    int copied = copy_capture_bytes("short stereo fdma bytes", out, sizeof(out));
+    rc |= copied;
+    if (copied == 0) {
+        rc |= expect_eq("short stereo fdma left sample", out[0], 10);
+        rc |= expect_eq("short stereo fdma right sample", out[1], 10);
+        rc |= expect_eq("short stereo fdma last left", out[318], 169);
+        rc |= expect_eq("short stereo fdma last right", out[319], 169);
+    }
+    rc |= expect_eq("short stereo fdma clears left", short_block_is_clear(st.s_l, 160), 1);
+    rc |= expect_eq("short stereo fdma clears right", short_block_is_clear(st.s_r, 160), 1);
+    rc |= expect_eq("short stereo fdma resets left idx", st.audio_out_idx, 0);
+    rc |= expect_eq("short stereo fdma resets right idx", st.audio_out_idxR, 0);
+    rc |= expect_eq("short stereo fdma resets left ring", st.audio_out_idx2, 0);
+    rc |= expect_eq("short stereo fdma resets right ring", st.audio_out_idx2R, 0);
+    rc |= expect_true("short stereo fdma resets left short ptr", st.audio_out_buf_p == st.audio_out_buf + 100);
+    rc |= expect_true("short stereo fdma resets right short ptr", st.audio_out_buf_pR == st.audio_out_bufR + 100);
+    return rc;
+}
+
+static int
+run_short_stereo_dmr3_playback_case(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.slot1_on = 1;
+    opts.slot2_on = 1;
+    st.audio_out_idx = 160;
+    st.audio_out_idxR = 160;
+    st.audio_out_idx2 = 800000;
+    st.audio_out_idx2R = 800000;
+    st.audio_out_buf_p = st.audio_out_buf + 100;
+    st.audio_out_buf_pR = st.audio_out_bufR + 100;
+    st.audio_out_float_buf_p = st.audio_out_float_buf + 100;
+    st.audio_out_float_buf_pR = st.audio_out_float_bufR + 100;
+    for (int i = 0; i < 160; i++) {
+        st.s_l4[0][i] = (short)(100 + i);
+        st.s_r4[0][i] = (short)(-100 - i);
+        st.s_l4[1][i] = (short)(200 + i);
+        st.s_r4[1][i] = (short)(-200 - i);
+        st.s_l4[2][i] = (short)(300 + i);
+        st.s_r4[2][i] = (short)(-300 - i);
+    }
+
+    playSynthesizedVoiceSS3(&opts, &st);
+
+    short out[160 * 2] = {0};
+    rc |= expect_eq("short stereo dmr3 calls", g_audio_capture_calls, 3);
+    int copied = copy_capture_bytes("short stereo dmr3 first bytes", out, sizeof(out));
+    rc |= copied;
+    if (copied == 0) {
+        rc |= expect_eq("short stereo dmr3 first left", out[0], 100);
+        rc |= expect_eq("short stereo dmr3 first right", out[1], -100);
+        rc |= expect_eq("short stereo dmr3 last left", out[318], 259);
+        rc |= expect_eq("short stereo dmr3 last right", out[319], -259);
+    }
+    rc |= expect_eq("short stereo dmr3 clears left", short_18_blocks_are_clear(st.s_l4), 1);
+    rc |= expect_eq("short stereo dmr3 clears right", short_18_blocks_are_clear(st.s_r4), 1);
+    rc |= expect_eq("short stereo dmr3 resets left ring", st.audio_out_idx2, 0);
+    rc |= expect_eq("short stereo dmr3 resets right ring", st.audio_out_idx2R, 0);
+    rc |= expect_true("short stereo dmr3 resets left short ptr", st.audio_out_buf_p == st.audio_out_buf + 100);
+    rc |= expect_true("short stereo dmr3 resets right short ptr", st.audio_out_buf_pR == st.audio_out_bufR + 100);
+    return rc;
+}
+
+static int
+run_beeper_float_stereo_case(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.floating_point = 1;
+    opts.pulse_digi_out_channels = 2;
+
+    beeper(&opts, &st, 1, 40, 86, 1);
+
+    float out[160 * 2] = {0.0f};
+    rc |= expect_eq("beeper float stereo calls", g_audio_capture_calls, 2);
+    int copied = copy_capture_bytes("beeper float stereo bytes", out, sizeof(out));
+    rc |= copied;
+    if (copied == 0) {
+        int saw_right_audio = 0;
+        int saw_left_audio = 0;
+        for (int i = 0; i < 160; i++) {
+            if (out[(i * 2) + 0] != 0.0f) {
+                saw_left_audio = 1;
+            }
+            if (out[(i * 2) + 1] != 0.0f) {
+                saw_right_audio = 1;
+            }
+        }
+        rc |= expect_eq("beeper float stereo left silent", saw_left_audio, 0);
+        rc |= expect_eq("beeper float stereo right audible", saw_right_audio, 1);
+    }
+    return rc;
+}
+
+static int
+run_beeper_short_mono_case(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.floating_point = 0;
+    opts.pulse_digi_out_channels = 1;
+
+    beeper(&opts, &st, 0, 40, 86, 1);
+
+    short out[160] = {0};
+    rc |= expect_eq("beeper short mono calls", g_audio_capture_calls, 2);
+    int copied = copy_capture_bytes("beeper short mono bytes", out, sizeof(out));
+    rc |= copied;
+    if (copied == 0) {
+        int saw_audio = 0;
+        for (int i = 0; i < 160; i++) {
+            if (out[i] != 0) {
+                saw_audio = 1;
+            }
+        }
+        rc |= expect_eq("beeper short mono audible", saw_audio, 1);
+    }
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -373,6 +728,14 @@ main(void) {
                                      /*muted_slot_aes_loaded*/ 1, /*muted_slot_key*/ 0ULL);
     rc |= run_ss18_right_active_case(/*enc_lockout_enabled*/ 1, /*expect_left_silent*/ 0, /*muted_slot_algid*/ 0x81,
                                      /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 1ULL);
+    rc |= run_ss18_partial_flush_case();
+    rc |= run_ss18_partial_flush_guard_case();
+    rc |= run_short_mono_playback_case();
+    rc |= run_float_mono_playback_case();
+    rc |= run_short_stereo_fdma_playback_case();
+    rc |= run_short_stereo_dmr3_playback_case();
+    rc |= run_beeper_float_stereo_case();
+    rc |= run_beeper_short_mono_case();
     dsd_udp_audio_hooks_set((dsd_udp_audio_hooks){0});
 
     return rc;

--- a/tests/protocol/p25/test_p25_p2_reliability.c
+++ b/tests/protocol/p25/test_p25_p2_reliability.c
@@ -25,6 +25,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
+#include <time.h>
+
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -44,6 +47,11 @@ extern int ess_a[2][168];
 extern int16_t ess_a_llr[2][168];
 extern void p25_p2_frame_reset(void);
 extern void process_ESS(dsd_opts* opts, dsd_state* state);
+extern void p25p2_test_teardown_call(dsd_opts* opts, dsd_state* state);
+extern void p25p2_test_process_facchc(dsd_opts* opts, dsd_state* state, int timeslot_index);
+extern void p25p2_test_process_isch(dsd_opts* opts, dsd_state* state, int framing_index);
+extern void p25p2_test_process_p2_duid(dsd_opts* opts, dsd_state* state);
+extern void p25p2_test_process_sacchc(dsd_opts* opts, dsd_state* state, int timeslot_index);
 
 static int g_ess_hard_rc = 0;
 static int g_ess_soft_min_success = -1;
@@ -51,6 +59,26 @@ static int g_ess_soft_success_rc = 0;
 static int g_ess_soft_calls = 0;
 static int g_ess_soft_last_n = 0;
 static int g_ess_soft_mutate_algid = -1;
+static int g_lfsrp_calls = 0;
+static int g_lfsr128_calls = 0;
+static int g_lfsr128_last_slot = -1;
+static int g_facch_min_success = 0;
+static int g_facch_success_rc = 0;
+static int g_facch_calls = 0;
+static int g_facch_last_erasures = 0;
+static int g_sacch_min_success = 0;
+static int g_sacch_success_rc = 0;
+static int g_sacch_calls = 0;
+static int g_sacch_last_erasures = 0;
+static int g_facch_mac_calls = 0;
+static int g_facch_mac_last_opcode = -1;
+static int g_sacch_mac_calls = 0;
+static int g_sacch_mac_last_opcode = -1;
+static int g_isch_lookup_result = -1;
+static uint8_t g_isch_last_reliab[40] = {0};
+static int g_ss18_calls = 0;
+static int g_ss18_allowed_l = -1;
+static int g_ss18_allowed_r = -1;
 
 bool
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -148,7 +176,9 @@ void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 playSynthesizedVoiceSS18(dsd_opts* opts, dsd_state* state) {
     (void)opts;
-    (void)state;
+    g_ss18_calls++;
+    g_ss18_allowed_l = state ? state->p25_p2_audio_allowed[0] : -1;
+    g_ss18_allowed_r = state ? state->p25_p2_audio_allowed[1] : -1;
 }
 
 void
@@ -200,6 +230,7 @@ void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 LFSRP(dsd_state* state) {
     (void)state;
+    g_lfsrp_calls++;
 }
 
 void
@@ -212,7 +243,8 @@ void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 p25_lfsr128_slot(dsd_state* state, int slot) {
     (void)state;
-    (void)slot;
+    g_lfsr128_calls++;
+    g_lfsr128_last_slot = slot;
 }
 
 /* RS decoders */
@@ -244,13 +276,15 @@ int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 isch_lookup(uint64_t isch) {
     (void)isch;
-    return -1;
+    return g_isch_lookup_result;
 }
 
 int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 isch_lookup_soft(uint64_t isch, const uint8_t reliab40[40]) {
-    (void)reliab40;
+    if (reliab40) {
+        DSD_MEMCPY(g_isch_last_reliab, reliab40, sizeof(g_isch_last_reliab));
+    }
     return isch_lookup(isch);
 }
 
@@ -260,8 +294,9 @@ ez_rs28_facch_soft(int* payload, int* parity, const int* erasures, int n_erasure
     (void)payload;
     (void)parity;
     (void)erasures;
-    (void)n_erasures;
-    return 0;
+    g_facch_calls++;
+    g_facch_last_erasures = n_erasures;
+    return n_erasures >= g_facch_min_success ? g_facch_success_rc : -1;
 }
 
 int
@@ -270,8 +305,9 @@ ez_rs28_sacch_soft(int* payload, int* parity, const int* erasures, int n_erasure
     (void)payload;
     (void)parity;
     (void)erasures;
-    (void)n_erasures;
-    return 0;
+    g_sacch_calls++;
+    g_sacch_last_erasures = n_erasures;
+    return n_erasures >= g_sacch_min_success ? g_sacch_success_rc : -1;
 }
 
 int
@@ -298,7 +334,8 @@ void
 process_SACCH_MAC_PDU(dsd_opts* opts, dsd_state* state, int* bits) {
     (void)opts;
     (void)state;
-    (void)bits;
+    g_sacch_mac_calls++;
+    g_sacch_mac_last_opcode = (bits[0] << 2) | (bits[1] << 1) | bits[2];
 }
 
 void
@@ -306,7 +343,8 @@ void
 process_FACCH_MAC_PDU(dsd_opts* opts, dsd_state* state, int* bits) {
     (void)opts;
     (void)state;
-    (void)bits;
+    g_facch_mac_calls++;
+    g_facch_mac_last_opcode = (bits[0] << 2) | (bits[1] << 1) | bits[2];
 }
 
 /* Dibit acquisition */
@@ -348,6 +386,89 @@ reset_ess_stubs(void) {
     g_ess_soft_calls = 0;
     g_ess_soft_last_n = 0;
     g_ess_soft_mutate_algid = -1;
+    g_lfsrp_calls = 0;
+    g_lfsr128_calls = 0;
+    g_lfsr128_last_slot = -1;
+}
+
+static void
+reset_xcch_stubs(void) {
+    g_facch_min_success = 0;
+    g_facch_success_rc = 0;
+    g_facch_calls = 0;
+    g_facch_last_erasures = 0;
+    g_sacch_min_success = 0;
+    g_sacch_success_rc = 0;
+    g_sacch_calls = 0;
+    g_sacch_last_erasures = 0;
+    g_facch_mac_calls = 0;
+    g_facch_mac_last_opcode = -1;
+    g_sacch_mac_calls = 0;
+    g_sacch_mac_last_opcode = -1;
+    g_isch_lookup_result = -1;
+    DSD_MEMSET(g_isch_last_reliab, 0, sizeof(g_isch_last_reliab));
+}
+
+static void
+reset_playback_stub(void) {
+    g_ss18_calls = 0;
+    g_ss18_allowed_l = -1;
+    g_ss18_allowed_r = -1;
+}
+
+static void
+set_p2bit(int index, int bit) {
+    p2bit[index] = bit ? 1 : 0;
+}
+
+static void
+seed_xcch_opcode(int timeslot_index, int opcode) {
+    int base = timeslot_index * 360;
+    set_p2bit(base + 2, (opcode >> 2) & 1);
+    set_p2bit(base + 3, (opcode >> 1) & 1);
+    set_p2bit(base + 4, opcode & 1);
+}
+
+static void
+seed_duid_bits(int timeslot_index, uint8_t duid) {
+    static const int duid_offsets[8] = {0, 1, 74, 75, 244, 245, 318, 319};
+    int base = timeslot_index * 360;
+    for (int i = 0; i < 8; i++) {
+        int abs_bit = base + duid_offsets[i];
+        set_p2bit(abs_bit, (duid >> (7 - i)) & 1U);
+        p2llr[abs_bit] = 200;
+    }
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_str(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got \"%s\" want \"%s\"\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_s16_clear(const char* tag, short frames[18][160]) {
+    for (int j = 0; j < 18; j++) {
+        for (int i = 0; i < 160; i++) {
+            if (frames[j][i] != 0) {
+                DSD_FPRINTF(stderr, "%s: frame[%d][%d] remained %d\n", tag, j, i, frames[j][i]);
+                return 1;
+            }
+        }
+    }
+    return 0;
 }
 
 static void
@@ -461,6 +582,571 @@ test_ess_des_manual_key_preserves_audio_gate(void) {
     printf("FAIL (alg=0x%02X keyid=0x%04X mi=0x%016llX gate=%d ok=%u)\n", state.payload_algid, state.payload_keyid,
            state.payload_miP, state.p25_p2_audio_allowed[0], state.p25_p2_rs_ess_ok);
     return 1;
+}
+
+static int
+test_ess_aes_slot1_loaded_key_preserves_audio_gate(void) {
+    printf("Test 15: ESS AES slot 1 loaded key preserves audio gate... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_ess_soft_inputs(&state);
+    reset_ess_stubs();
+    set_p25p2_threshold(64);
+
+    opts.p25_trunk = 1;
+    opts.p25_is_tuned = 1;
+    opts.trunk_tune_enc_calls = 0;
+    state.currentslot = 1;
+    state.lasttgR = 5678;
+    state.dmrburstR = 21;
+    state.aes_key_loaded[1] = 1;
+    set_ess_payload_bits(&state, 1, 0x84, 0x1357, 0x0123456789ABCDEFULL);
+
+    process_ESS(&opts, &state);
+
+    if (state.payload_algidR == 0x84 && state.payload_keyidR == 0x1357 && state.payload_miN == 0x0123456789ABCDEFULL
+        && state.p25_p2_audio_allowed[1] == 1 && state.p25_p2_rs_ess_ok == 1 && g_lfsr128_calls == 1
+        && g_lfsr128_last_slot == 1) {
+        printf("PASS\n");
+        return 0;
+    }
+
+    printf("FAIL (alg=0x%02X keyid=0x%04X mi=0x%016llX gate=%d ok=%u lfsr128=%d slot=%d)\n", state.payload_algidR,
+           state.payload_keyidR, state.payload_miN, state.p25_p2_audio_allowed[1], state.p25_p2_rs_ess_ok,
+           g_lfsr128_calls, g_lfsr128_last_slot);
+    return 1;
+}
+
+static int
+test_ess_allow_list_blocks_clear_audio_gate(void) {
+    printf("Test 16: ESS allow-list blocks clear audio gate... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_ess_soft_inputs(&state);
+    reset_ess_stubs();
+    set_p25p2_threshold(64);
+
+    opts.trunk_use_allow_list = 1;
+    state.lasttg = 1234;
+    state.tg_hold = 9999;
+    state.dmrburstL = 20;
+    set_ess_payload_bits(&state, 0, 0x80, 0x0000, 0x0000000000000000ULL);
+
+    process_ESS(&opts, &state);
+
+    if (state.payload_algid == 0x80 && state.p25_p2_audio_allowed[0] == 0 && state.p25_p2_enc_lockout_muted[0] == 0
+        && state.p25_p2_rs_ess_ok == 1) {
+        printf("PASS\n");
+        return 0;
+    }
+
+    printf("FAIL (alg=0x%02X gate=%d marker=%u ok=%u)\n", state.payload_algid, state.p25_p2_audio_allowed[0],
+           state.p25_p2_enc_lockout_muted[0], state.p25_p2_rs_ess_ok);
+    return 1;
+}
+
+static int
+test_ess_decode_failure_refreshes_existing_crypto_state(void) {
+    printf("Test 17: ESS failure refreshes existing crypto state... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_ess_soft_inputs(&state);
+    reset_ess_stubs();
+    set_p25p2_threshold(64);
+
+    state.currentslot = 0;
+    state.payload_algid = 0x81;
+    state.payload_keyid = 0x2468;
+    state.payload_miP = 0x1122334455667788ULL;
+    g_ess_hard_rc = -1;
+    g_ess_soft_min_success = -1;
+
+    process_ESS(&opts, &state);
+
+    if (state.p25_p2_rs_ess_err == 1 && state.p25_p2_rs_ess_ok == 0 && g_lfsrp_calls == 1 && g_lfsr128_calls == 0) {
+        printf("PASS\n");
+        return 0;
+    }
+
+    printf("FAIL (err=%u ok=%u lfsrp=%d lfsr128=%d)\n", state.p25_p2_rs_ess_err, state.p25_p2_rs_ess_ok, g_lfsrp_calls,
+           g_lfsr128_calls);
+    return 1;
+}
+
+static int
+test_ess_decode_failure_refreshes_existing_aes_state(void) {
+    printf("Test 18: ESS failure refreshes existing AES state... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_ess_soft_inputs(&state);
+    reset_ess_stubs();
+    set_p25p2_threshold(64);
+
+    state.currentslot = 1;
+    state.payload_algidR = 0x89;
+    state.payload_keyidR = 0x1357;
+    state.payload_miN = 0x0123456789ABCDEFULL;
+    g_ess_hard_rc = -1;
+    g_ess_soft_min_success = -1;
+
+    process_ESS(&opts, &state);
+
+    if (state.p25_p2_rs_ess_err == 1 && g_lfsrp_calls == 1 && g_lfsr128_calls == 1 && g_lfsr128_last_slot == 1) {
+        printf("PASS\n");
+        return 0;
+    }
+
+    printf("FAIL (err=%u lfsrp=%d lfsr128=%d slot=%d)\n", state.p25_p2_rs_ess_err, g_lfsrp_calls, g_lfsr128_calls,
+           g_lfsr128_last_slot);
+    return 1;
+}
+
+static int
+test_facchc_success_routes_opcode_and_counters(void) {
+    printf("Test 19: FACCHc success routes opcode and counters... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_p2_frame_reset();
+    reset_xcch_stubs();
+
+    state.currentslot = 1;
+    g_facch_success_rc = 3;
+    seed_xcch_opcode(2, 5);
+
+    p25p2_test_process_facchc(&opts, &state, 2);
+
+    int rc = 0;
+    rc |= expect_int("facch ok", (int)state.p25_p2_rs_facch_ok, 1);
+    rc |= expect_int("facch err", (int)state.p25_p2_rs_facch_err, 0);
+    rc |= expect_int("facch corr", (int)state.p25_p2_rs_facch_corr, 3);
+    rc |= expect_int("facch slot1 opcode", state.dmr_soR, 5);
+    rc |= expect_int("facch mac calls", g_facch_mac_calls, 1);
+    rc |= expect_int("facch mac opcode", g_facch_mac_last_opcode, 5);
+    rc |= expect_int("facch fixed erasures", g_facch_last_erasures, 18);
+    if (rc == 0) {
+        printf("PASS\n");
+    } else {
+        printf("FAIL\n");
+    }
+    return rc;
+}
+
+static int
+test_facchc_failure_preserves_mac_and_counts_error(void) {
+    printf("Test 20: FACCHc failure counts error without MAC dispatch... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_p2_frame_reset();
+    reset_xcch_stubs();
+
+    state.currentslot = 0;
+    state.dmr_so = 99;
+    g_facch_min_success = 99;
+    seed_xcch_opcode(0, 3);
+
+    p25p2_test_process_facchc(&opts, &state, 0);
+
+    int rc = 0;
+    rc |= expect_int("facch failure ok", (int)state.p25_p2_rs_facch_ok, 0);
+    rc |= expect_int("facch failure err", (int)state.p25_p2_rs_facch_err, 1);
+    rc |= expect_int("facch failure opcode captured", state.dmr_so, 3);
+    rc |= expect_int("facch failure no mac", g_facch_mac_calls, 0);
+    rc |= expect_int("facch failure tried ranked erasures", g_facch_calls > 1, 1);
+    if (rc == 0) {
+        printf("PASS\n");
+    } else {
+        printf("FAIL\n");
+    }
+    return rc;
+}
+
+static int
+test_sacchc_dynamic_erasure_success_maps_inverse_slot(void) {
+    printf("Test 21: SACCHc dynamic erasure success maps inverse slot... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_p2_frame_reset();
+    reset_xcch_stubs();
+    set_p25p2_threshold(64);
+
+    state.currentslot = 0;
+    g_sacch_min_success = 12;
+    g_sacch_success_rc = 4;
+    seed_xcch_opcode(1, 6);
+
+    p25p2_test_process_sacchc(&opts, &state, 1);
+
+    int rc = 0;
+    rc |= expect_int("sacch ok", (int)state.p25_p2_rs_sacch_ok, 1);
+    rc |= expect_int("sacch err", (int)state.p25_p2_rs_sacch_err, 0);
+    rc |= expect_int("sacch corr", (int)state.p25_p2_rs_sacch_corr, 4);
+    rc |= expect_int("sacch dynamic erasure", (int)state.p25_p2_soft_erasure_ok, 1);
+    rc |= expect_int("sacch inverse opcode", state.dmr_soR, 6);
+    rc |= expect_int("sacch mac calls", g_sacch_mac_calls, 1);
+    rc |= expect_int("sacch mac opcode", g_sacch_mac_last_opcode, 6);
+    rc |= expect_int("sacch erasure depth", g_sacch_last_erasures, 12);
+    if (rc == 0) {
+        printf("PASS\n");
+    } else {
+        printf("FAIL\n");
+    }
+    return rc;
+}
+
+static int
+test_isch_channel_one_location_sets_scramble_offset(void) {
+    printf("Test 22: ISCH channel/location sets scramble offset... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_p2_frame_reset();
+    reset_xcch_stubs();
+
+    p2bit[320] = 1;
+    g_isch_lookup_result = (1 << 5) | (0 << 3);
+    state.p2_scramble_offset = -1;
+    p25p2_test_process_isch(&opts, &state, 3);
+
+    int rc = 0;
+    rc |= expect_int("isch loc0 channel", state.p2_vch_chan_num, 1);
+    rc |= expect_int("isch loc0 offset", state.p2_scramble_offset, 9);
+
+    g_isch_lookup_result = (1 << 5) | (1 << 3);
+    state.p2_scramble_offset = -1;
+    p25p2_test_process_isch(&opts, &state, 1);
+    rc |= expect_int("isch loc1 offset", state.p2_scramble_offset, 3);
+
+    g_isch_lookup_result = (1 << 5) | (2 << 3);
+    state.p2_scramble_offset = -1;
+    p25p2_test_process_isch(&opts, &state, 2);
+    rc |= expect_int("isch loc2 offset", state.p2_scramble_offset, 6);
+
+    g_isch_lookup_result = -1;
+    state.p2_vch_chan_num = 7;
+    state.p2_scramble_offset = 42;
+    p25p2_test_process_isch(&opts, &state, 0);
+    rc |= expect_int("isch invalid preserves channel", state.p2_vch_chan_num, 7);
+    rc |= expect_int("isch invalid preserves offset", state.p2_scramble_offset, 42);
+
+    if (rc == 0) {
+        printf("PASS\n");
+    } else {
+        printf("FAIL\n");
+    }
+    return rc;
+}
+
+static int
+test_duid_exact_or_null_soft_metrics_preserve_hard_decision(void) {
+    printf("Test 25: DUID exact/null soft metrics preserve hard decision... ");
+    uint8_t unreliable[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    int rc = 0;
+    rc |= expect_int("duid exact with unreliable metrics", p25p2_duid_lookup_soft_test(0x17U, unreliable), 1);
+    rc |= expect_int("duid null metrics uses hard table", p25p2_duid_lookup_soft_test(0x17U, NULL), 1);
+
+    if (rc == 0) {
+        printf("PASS\n");
+    } else {
+        printf("FAIL\n");
+    }
+    return rc;
+}
+
+static int
+test_isch_reliability_clamps_llr_magnitude(void) {
+    printf("Test 26: ISCH reliability clamps LLR magnitude... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_p2_frame_reset();
+    reset_xcch_stubs();
+
+    p2bit[320] = 1;
+    p2llr[320] = 300;
+    p2llr[321] = -123;
+    g_isch_lookup_result = -1;
+
+    p25p2_test_process_isch(&opts, &state, 0);
+
+    int rc = 0;
+    rc |= expect_int("isch clamp high reliability", g_isch_last_reliab[0], 255);
+    rc |= expect_int("isch abs negative reliability", g_isch_last_reliab[1], 123);
+    rc |= expect_int("isch failed decode preserves channel", state.p2_vch_chan_num, 0);
+
+    if (rc == 0) {
+        printf("PASS\n");
+    } else {
+        printf("FAIL\n");
+    }
+    return rc;
+}
+
+static void
+seed_teardown_dirty_state(dsd_state* state) {
+    state->p25_p2_audio_allowed[0] = 0;
+    state->p25_p2_audio_allowed[1] = 0;
+    state->p25_p2_enc_lockout_muted[0] = 1;
+    state->p25_p2_enc_lockout_muted[1] = 1;
+    state->p25_p2_audio_ring_count[0] = 2;
+    state->p25_p2_audio_ring_count[1] = 3;
+    state->voice_counter[0] = 7;
+    state->voice_counter[1] = 9;
+    state->p25_p2_last_mac_active[0] = 111;
+    state->p25_p2_last_mac_active[1] = 222;
+    state->p25_p2_last_end_ptt[0] = 333;
+    state->p25_p2_last_end_ptt[1] = 444;
+    state->p25_call_is_packet[0] = 1;
+    state->p25_call_is_packet[1] = 1;
+    state->p25_call_emergency[0] = 1;
+    state->p25_call_emergency[1] = 1;
+    state->p25_call_priority[0] = 5;
+    state->p25_call_priority[1] = 6;
+    state->payload_algid = 0x81;
+    state->payload_keyid = 0x2468;
+    state->payload_miP = 0x1122334455667788ULL;
+    state->payload_algidR = 0x84;
+    state->payload_keyidR = 0x1357;
+    state->payload_miN = 0x0123456789ABCDEFULL;
+    DSD_SNPRINTF(state->call_string[0], sizeof state->call_string[0], "%s", "left call");
+    DSD_SNPRINTF(state->call_string[1], sizeof state->call_string[1], "%s", "right call");
+}
+
+static int
+expect_teardown_common_reset(const dsd_state* state) {
+    int rc = 0;
+    rc |= expect_int("teardown gate left", state->p25_p2_audio_allowed[0], 0);
+    rc |= expect_int("teardown gate right", state->p25_p2_audio_allowed[1], 0);
+    rc |= expect_int("teardown marker left", state->p25_p2_enc_lockout_muted[0], 0);
+    rc |= expect_int("teardown marker right", state->p25_p2_enc_lockout_muted[1], 0);
+    rc |= expect_int("teardown ring left", state->p25_p2_audio_ring_count[0], 0);
+    rc |= expect_int("teardown ring right", state->p25_p2_audio_ring_count[1], 0);
+    rc |= expect_int("teardown voice counter left", state->voice_counter[0], 0);
+    rc |= expect_int("teardown voice counter right", state->voice_counter[1], 0);
+    rc |= expect_int("teardown mac active left", (int)state->p25_p2_last_mac_active[0], 0);
+    rc |= expect_int("teardown mac active right", (int)state->p25_p2_last_mac_active[1], 0);
+    rc |= expect_int("teardown end ptt left", (int)state->p25_p2_last_end_ptt[0], 0);
+    rc |= expect_int("teardown end ptt right", (int)state->p25_p2_last_end_ptt[1], 0);
+    rc |= expect_int("teardown packet left", state->p25_call_is_packet[0], 0);
+    rc |= expect_int("teardown packet right", state->p25_call_is_packet[1], 0);
+    rc |= expect_int("teardown emergency left", state->p25_call_emergency[0], 0);
+    rc |= expect_int("teardown emergency right", state->p25_call_emergency[1], 0);
+    rc |= expect_int("teardown priority left", state->p25_call_priority[0], 0);
+    rc |= expect_int("teardown priority right", state->p25_call_priority[1], 0);
+    rc |= expect_int("teardown alg left", state->payload_algid, 0);
+    rc |= expect_int("teardown key left", state->payload_keyid, 0);
+    rc |= expect_int("teardown mi left", state->payload_miP != 0ULL, 0);
+    rc |= expect_int("teardown alg right", state->payload_algidR, 0);
+    rc |= expect_int("teardown key right", state->payload_keyidR, 0);
+    rc |= expect_int("teardown mi right", state->payload_miN != 0ULL, 0);
+    rc |= expect_str("teardown call string left", state->call_string[0], "                     ");
+    rc |= expect_str("teardown call string right", state->call_string[1], "                     ");
+    return rc;
+}
+
+static int
+test_teardown_flushes_partial_int16_audio_and_resets_call_state(void) {
+    printf("Test 23: teardown flushes partial int16 audio and resets call state... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_playback_stub();
+
+    opts.floating_point = 0;
+    opts.pulse_digi_rate_out = 8000;
+    seed_teardown_dirty_state(&state);
+    state.s_l4[2][17] = 123;
+    state.s_r4[4][31] = -234;
+
+    p25p2_test_teardown_call(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_int("teardown playback calls", g_ss18_calls, 1);
+    rc |= expect_int("teardown playback gate left", g_ss18_allowed_l, 1);
+    rc |= expect_int("teardown playback gate right", g_ss18_allowed_r, 1);
+    rc |= expect_teardown_common_reset(&state);
+    rc |= expect_s16_clear("teardown clear left short audio", state.s_l4);
+    rc |= expect_s16_clear("teardown clear right short audio", state.s_r4);
+
+    if (rc == 0) {
+        printf("PASS\n");
+    } else {
+        printf("FAIL\n");
+    }
+    return rc;
+}
+
+static int
+test_teardown_without_partial_int16_audio_skips_playback_but_clears_state(void) {
+    printf("Test 24: teardown without partial int16 audio skips playback but clears state... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_playback_stub();
+
+    opts.floating_point = 0;
+    opts.pulse_digi_rate_out = 8000;
+    seed_teardown_dirty_state(&state);
+
+    p25p2_test_teardown_call(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_int("teardown no-audio playback calls", g_ss18_calls, 0);
+    rc |= expect_int("teardown no-audio playback left unchanged", g_ss18_allowed_l, -1);
+    rc |= expect_int("teardown no-audio playback right unchanged", g_ss18_allowed_r, -1);
+    rc |= expect_teardown_common_reset(&state);
+
+    if (rc == 0) {
+        printf("PASS\n");
+    } else {
+        printf("FAIL\n");
+    }
+    return rc;
+}
+
+static int
+test_duid_invalid_burst_aborts_and_clears_crypto_state(void) {
+    printf("Test 27: DUID repeated invalid bursts abort and clear crypto state... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    p25_p2_frame_reset();
+
+    state.currentslot = 0;
+    state.payload_algid = 0x81;
+    state.payload_keyid = 0x2468;
+    state.payload_algidR = 0x84;
+    state.payload_keyidR = 0x1357;
+    state.p2_is_lcch = 1;
+    state.p25_p2_enc_lockout_muted[0] = 1;
+    state.p25_p2_enc_lockout_muted[1] = 1;
+    state.fourv_counter[0] = 3;
+    state.fourv_counter[1] = 4;
+    state.voice_counter[0] = 5;
+    state.voice_counter[1] = 6;
+    seed_duid_bits(0, 0x03U);
+    seed_duid_bits(1, 0x03U);
+
+    p25p2_test_process_p2_duid(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_int("invalid abort alg left", state.payload_algid, 0);
+    rc |= expect_int("invalid abort key left", state.payload_keyid, 0);
+    rc |= expect_int("invalid abort alg right", state.payload_algidR, 0);
+    rc |= expect_int("invalid abort key right", state.payload_keyidR, 0);
+    rc |= expect_int("invalid abort lcch", state.p2_is_lcch, 0);
+    rc |= expect_int("invalid abort marker left", state.p25_p2_enc_lockout_muted[0], 0);
+    rc |= expect_int("invalid abort marker right", state.p25_p2_enc_lockout_muted[1], 0);
+    rc |= expect_int("invalid abort fourv left", state.fourv_counter[0], 0);
+    rc |= expect_int("invalid abort fourv right", state.fourv_counter[1], 0);
+    rc |= expect_int("invalid abort voice left", state.voice_counter[0], 0);
+    rc |= expect_int("invalid abort voice right", state.voice_counter[1], 0);
+    if (rc == 0) {
+        printf("PASS\n");
+    } else {
+        printf("FAIL\n");
+    }
+    return rc;
+}
+
+static void
+prepare_lcch_release_duids(void) {
+    p25_p2_frame_reset();
+    for (int i = 0; i < 4; i++) {
+        seed_duid_bits(i, 0xD1U);
+        seed_xcch_opcode(i, 0);
+    }
+}
+
+static int
+test_duid_lcch_release_defers_during_vc_grace(void) {
+    printf("Test 28: DUID LCCH release defers during VC grace... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_xcch_stubs();
+    prepare_lcch_release_duids();
+
+    time_t now = time(NULL);
+    opts.floating_point = 0;
+    opts.pulse_digi_rate_out = 8000;
+    opts.p25_trunk = 1;
+    opts.p25_is_tuned = 1;
+    opts.trunk_hangtime = 1;
+    state.currentslot = 0;
+    state.last_vc_sync_time = now - 10;
+    state.p25_last_vc_tune_time = now;
+    state.p25_cfg_vc_grace_s = 60.0;
+
+    p25p2_test_process_p2_duid(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_int("grace release force", state.p25_sm_force_release, 0);
+    rc |= expect_int("grace tuned remains", opts.p25_is_tuned, 1);
+    rc |= expect_int("grace lcch seen", state.p2_is_lcch, 1);
+    rc |= expect_int("grace sacch dispatches", g_sacch_mac_calls, 4);
+    if (rc == 0) {
+        printf("PASS\n");
+    } else {
+        printf("FAIL\n");
+    }
+    return rc;
+}
+
+static int
+test_duid_lcch_release_tears_down_after_vc_grace(void) {
+    printf("Test 29: DUID LCCH release tears down after VC grace... ");
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_xcch_stubs();
+    reset_playback_stub();
+    prepare_lcch_release_duids();
+
+    time_t now = time(NULL);
+    opts.floating_point = 0;
+    opts.pulse_digi_rate_out = 8000;
+    opts.p25_trunk = 1;
+    opts.p25_is_tuned = 1;
+    opts.trunk_hangtime = 1;
+    state.currentslot = 0;
+    state.last_vc_sync_time = now - 10;
+    state.p25_last_vc_tune_time = now - 10;
+    state.p25_cfg_vc_grace_s = 0.25;
+    seed_teardown_dirty_state(&state);
+    state.last_vc_sync_time = now - 10;
+    state.p25_last_vc_tune_time = now - 10;
+    state.p25_cfg_vc_grace_s = 0.25;
+
+    p25p2_test_process_p2_duid(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_int("post-grace release force", state.p25_sm_force_release, 1);
+    rc |= expect_teardown_common_reset(&state);
+    rc |= expect_int("post-grace sacch dispatches", g_sacch_mac_calls >= 1, 1);
+    if (rc == 0) {
+        printf("PASS\n");
+    } else {
+        printf("FAIL\n");
+    }
+    return rc;
 }
 
 int
@@ -633,6 +1319,21 @@ main(void) {
     failures += test_ess_soft_accepts_deep_erasure();
     failures += test_ess_soft_failure_counts_once();
     failures += test_ess_des_manual_key_preserves_audio_gate();
+    failures += test_ess_aes_slot1_loaded_key_preserves_audio_gate();
+    failures += test_ess_allow_list_blocks_clear_audio_gate();
+    failures += test_ess_decode_failure_refreshes_existing_crypto_state();
+    failures += test_ess_decode_failure_refreshes_existing_aes_state();
+    failures += test_facchc_success_routes_opcode_and_counters();
+    failures += test_facchc_failure_preserves_mac_and_counts_error();
+    failures += test_sacchc_dynamic_erasure_success_maps_inverse_slot();
+    failures += test_isch_channel_one_location_sets_scramble_offset();
+    failures += test_duid_exact_or_null_soft_metrics_preserve_hard_decision();
+    failures += test_isch_reliability_clamps_llr_magnitude();
+    failures += test_teardown_flushes_partial_int16_audio_and_resets_call_state();
+    failures += test_teardown_without_partial_int16_audio_skips_playback_but_clears_state();
+    failures += test_duid_invalid_burst_aborts_and_clears_crypto_state();
+    failures += test_duid_lcch_release_defers_during_vc_grace();
+    failures += test_duid_lcch_release_tears_down_after_vc_grace();
 
     printf("\n%d test(s) failed\n", failures);
     return failures > 0 ? 1 : 0;

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -16,6 +16,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -122,6 +123,15 @@ static int
 expect_true(const char* tag, int cond) {
     if (!cond) {
         DSD_FPRINTF(stderr, "%s: expected true\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_contains(const char* tag, const char* text, const char* needle) {
+    if (text == NULL || needle == NULL || strstr(text, needle) == NULL) {
+        DSD_FPRINTF(stderr, "%s: '%s' did not contain '%s'\n", tag, text ? text : "(null)", needle ? needle : "(null)");
         return 1;
     }
     return 0;
@@ -449,6 +459,256 @@ main(void) {
         rc |= expect_eq_long("p2 rejected nsb preserves trunk cc", state.trunk_cc_freq, cc);
         rc |= expect_true("p2 rejected nsb skips wacn", state.p2_wacn == 0);
         rc |= expect_true("p2 rejected nsb skips sysid", state.p2_sysid == 0);
+    }
+
+    // Case K: accepted P2 abbreviated NSB promotes the current CC to TDMA,
+    // stores system identity, seeds LCN0, and confirms matching IDEN provenance.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 1;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_iden_fdma[iden].wacn = 0xABCDE;
+        state.p25_iden_fdma[iden].sysid = 0x123;
+
+        MAC[1] = 0x7B; // Network Status Broadcast - Abbreviated
+        MAC[2] = 0x01; // LRA
+        MAC[3] = 0xAB;
+        MAC[4] = 0xCD;
+        MAC[5] = 0xE1; // WACN 0xABCDE, SYSID high nibble 0x1
+        MAC[6] = 0x23; // SYSID low byte
+        MAC[7] = 0x10;
+        MAC[8] = 0x0A; // channel 0x100A -> 851.125 MHz
+        MAC[9] = 0x00; // sysclass
+        MAC[10] = 0x00;
+        MAC[11] = 0x55; // NAC
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_true("p2 accepted nsb marks system tdma", state.p25_sys_is_tdma == 1);
+        rc |= expect_true("p2 accepted nsb marks cc tdma", state.p25_cc_is_tdma == 1);
+        rc |= expect_eq_long("p2 accepted nsb p25 cc", state.p25_cc_freq, 851125000);
+        rc |= expect_eq_long("p2 accepted nsb trunk cc", state.trunk_cc_freq, 851125000);
+        rc |= expect_eq_long("p2 accepted nsb lcn0", state.trunk_lcn_freq[0], 851125000);
+        rc |= expect_eq_long("p2 accepted nsb wacn", (long)state.p2_wacn, 0xABCDE);
+        rc |= expect_eq_long("p2 accepted nsb sysid", (long)state.p2_sysid, 0x123);
+        rc |= expect_eq_long("p2 accepted nsb nac", (long)state.p2_cc, 0x055);
+        rc |= expect_eq_long("p2 accepted nsb confirms iden", state.p25_iden_fdma[iden].trust, 2);
+    }
+
+    // Case L: accepted P2 extended NSB resolves both T/R channels and updates
+    // TDMA CC identity through the same state-machine notification path.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].populated = 1;
+
+        MAC[1] = 0xFB; // Network Status Broadcast - Extended
+        MAC[2] = 0x02; // LRA
+        MAC[3] = 0xAB;
+        MAC[4] = 0xCD;
+        MAC[5] = 0xE1; // WACN 0xABCDE, SYSID high nibble 0x1
+        MAC[6] = 0x23; // SYSID low byte
+        MAC[7] = 0x10;
+        MAC[8] = 0x0A; // CHAN-T 0x100A
+        MAC[9] = 0x10;
+        MAC[10] = 0x0B; // CHAN-R 0x100B
+        MAC[12] = 0x00;
+        MAC[13] = 0x56; // NAC
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_true("p2 accepted nsb-ext marks system tdma", state.p25_sys_is_tdma == 1);
+        rc |= expect_true("p2 accepted nsb-ext marks cc tdma", state.p25_cc_is_tdma == 1);
+        rc |= expect_eq_long("p2 accepted nsb-ext p25 cc", state.p25_cc_freq, 851125000);
+        rc |= expect_eq_long("p2 accepted nsb-ext trunk cc", state.trunk_cc_freq, 851125000);
+        rc |= expect_eq_long("p2 accepted nsb-ext chan-t cache", state.trunk_chan_map[0x100A], 851125000);
+        rc |= expect_eq_long("p2 accepted nsb-ext chan-r cache", state.trunk_chan_map[0x100B], 851137500);
+        rc |= expect_eq_long("p2 accepted nsb-ext wacn", (long)state.p2_wacn, 0xABCDE);
+        rc |= expect_eq_long("p2 accepted nsb-ext sysid", (long)state.p2_sysid, 0x123);
+        rc |= expect_eq_long("p2 accepted nsb-ext nac", (long)state.p2_cc, 0x056);
+    }
+
+    // Case M: encrypted explicit multi-grants should publish channel state but
+    // suppress retune when encrypted following is disabled and no clear key is known.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        opts.trunk_tune_enc_calls = 0;
+        state.p25_cc_freq = cc;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+
+        MAC[1] = 0x25; // Group Voice Channel Grant Update Multiple - Explicit
+        MAC[2] = 0x40; // encrypted svc1
+        MAC[3] = 0x10;
+        MAC[4] = 0x0A;
+        MAC[5] = 0x00;
+        MAC[6] = 0x00;
+        MAC[7] = 0x12;
+        MAC[8] = 0x34;
+        MAC[9] = 0x40; // encrypted svc2
+        MAC[10] = 0x10;
+        MAC[11] = 0x0B;
+        MAC[12] = 0x00;
+        MAC[13] = 0x00;
+        MAC[14] = 0x56;
+        MAC[15] = 0x78;
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_true("0x25 encrypted multi suppressed tune", opts.p25_is_tuned == 0);
+        rc |= expect_eq_long("0x25 encrypted multi no vc", state.p25_vc_freq[0], 0);
+        rc |= expect_contains("0x25 encrypted multi active ch group1", state.active_channel[0], "TG: 4660");
+        rc |= expect_contains("0x25 encrypted multi active ch group2", state.active_channel[0], "TG: 22136");
+    }
+
+    // Case N: encrypted implicit triple updates are also blocked before candidate
+    // tuning while still refreshing active-channel state.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        opts.trunk_tune_enc_calls = 0;
+        state.p25_cc_freq = cc;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+
+        MAC[1] = 0x05; // Group Voice Channel Grant Update Multiple - Implicit
+        MAC[2] = 0x40;
+        MAC[3] = 0x10;
+        MAC[4] = 0x0A;
+        MAC[5] = 0x12;
+        MAC[6] = 0x34;
+        MAC[7] = 0x40;
+        MAC[8] = 0x10;
+        MAC[9] = 0x0B;
+        MAC[10] = 0x56;
+        MAC[11] = 0x78;
+        MAC[12] = 0x40;
+        MAC[13] = 0x10;
+        MAC[14] = 0x0C;
+        MAC[15] = 0x9A;
+        MAC[16] = 0xBC;
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_true("0x05 encrypted triple suppressed tune", opts.p25_is_tuned == 0);
+        rc |= expect_eq_long("0x05 encrypted triple no vc", state.p25_vc_freq[0], 0);
+        rc |= expect_contains("0x05 encrypted triple active group1", state.active_channel[0], "TG: 4660");
+        rc |= expect_contains("0x05 encrypted triple active group2", state.active_channel[0], "TG: 22136");
+        rc |= expect_contains("0x05 encrypted triple active group3", state.active_channel[0], "TG: 39612");
+    }
+
+    // Case O: telephone interconnect grants carry service state and tune like
+    // private calls when private-call following is enabled.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_private_calls = 1;
+        state.p25_cc_freq = cc;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+
+        MAC[0] = 0x07; // implicit telephone grant uses the unshifted VPDU layout
+        MAC[1] = 0x48; // Telephone Interconnect Voice Channel Grant - implicit
+        MAC[2] = 0x93; // emergency, packet, priority 3
+        MAC[3] = 0x10;
+        MAC[4] = 0x0A;
+        MAC[5] = 0x00;
+        MAC[6] = 0x2A; // timer
+        MAC[7] = 0x03;
+        MAC[8] = 0x04;
+        MAC[9] = 0x05; // target
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_true("0x48 telephone no unsupported tune", opts.p25_is_tuned == 0);
+        rc |= expect_eq_long("0x48 telephone no vc", state.p25_vc_freq[0], 0);
+        rc |= expect_contains("0x48 telephone active", state.active_channel[0], "Active Tele Ch: 100A");
+        rc |= expect_contains("0x48 telephone target", state.active_channel[0], "TGT: 197637");
+        rc |= expect_eq_long("0x48 telephone svc", state.dmr_so, 0x93);
+        rc |= expect_eq_long("0x48 telephone emergency", state.p25_call_emergency[0], 1);
+        rc |= expect_eq_long("0x48 telephone packet", state.p25_call_is_packet[0], 1);
+    }
+
+    // Case P: explicit SNDCP data grants update data-channel state in playback
+    // mode, with P25p2 playback mirroring both TDMA slots.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 0;
+        state.lasttg = 0x030405;
+        state.synctype = DSD_SYNC_P25P2_POS;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+
+        MAC[1] = 0x54; // SNDCP Data Channel Grant - explicit
+        MAC[2] = 0x22; // DSO
+        MAC[3] = 0x10;
+        MAC[4] = 0x0A; // CHAN-T
+        MAC[5] = 0x10;
+        MAC[6] = 0x0B; // CHAN-R
+        MAC[7] = 0x03;
+        MAC[8] = 0x04;
+        MAC[9] = 0x05; // target
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_contains("0x54 data active", state.active_channel[0], "Active Data Ch: 100A");
+        rc |= expect_contains("0x54 data target", state.active_channel[0], "TGT: 197637");
+        rc |= expect_eq_long("0x54 data vc0", state.p25_vc_freq[0], 851125000);
+        rc |= expect_eq_long("0x54 data vc1", state.p25_vc_freq[1], 851125000);
     }
 
     return rc;

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -1,0 +1,711 @@
+// SPDX-License-Identifier: ISC
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-suspicious-include)
+/*
+ * Focused P25 Phase 2 XCCH tests for MAC PTT/END/IDLE dispatch and slot state.
+ */
+
+#include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/file_io.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/platform/timing.h>
+#include <dsd-neo/protocol/p25/p25_crc.h>
+#include <dsd-neo/protocol/p25/p25_lfsr.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/protocol/p25/p25_vpdu.h>
+#include <dsd-neo/runtime/p25_p2_audio_ring.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int g_audio_allow;
+static int g_crc12_result;
+static int g_crc16_result;
+static int g_vpdu_count;
+static int g_vpdu_type;
+static unsigned long long int g_vpdu_mac[24];
+static int g_ptt_count[2];
+static int g_active_count[2];
+static int g_end_count[2];
+static int g_idle_count[2];
+static int g_enc_count[2];
+static int g_enc_algid[2];
+static int g_enc_keyid[2];
+static int g_enc_tg[2];
+static int g_close_l_count;
+static int g_close_r_count;
+static int g_ring_reset_count[2];
+static int g_lfsr_count[2];
+static uint64_t g_now_ns;
+
+uint64_t
+dsd_time_monotonic_ns(void) {
+    g_now_ns += 1000000000ULL;
+    return g_now_ns;
+}
+
+int
+crc12_xb_bridge(const int* payload, int len) {
+    (void)payload;
+    (void)len;
+    return g_crc12_result;
+}
+
+int
+crc16_lb_bridge(const int* payload, int len) {
+    (void)payload;
+    (void)len;
+    return g_crc16_result;
+}
+
+void
+process_MAC_VPDU(dsd_opts* opts, dsd_state* state, int type, unsigned long long int mac[24]) {
+    (void)opts;
+    (void)state;
+    g_vpdu_count++;
+    g_vpdu_type = type;
+    for (int i = 0; i < 24; i++) {
+        g_vpdu_mac[i] = mac[i];
+    }
+}
+
+int
+dsd_p25p2_decode_audio_allowed(const dsd_opts* opts, const dsd_state* state, int slot, int alg) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)alg;
+    return g_audio_allow;
+}
+
+void
+p25_p2_audio_ring_reset(dsd_state* state, int slot) {
+    if (slot >= 0 && slot <= 1) {
+        state->p25_p2_audio_ring_count[slot] = 0;
+        g_ring_reset_count[slot]++;
+        return;
+    }
+
+    state->p25_p2_audio_ring_count[0] = 0;
+    state->p25_p2_audio_ring_count[1] = 0;
+    g_ring_reset_count[0]++;
+    g_ring_reset_count[1]++;
+}
+
+void
+p25_lfsr128_slot(dsd_state* state, int slot) {
+    (void)state;
+    if (slot >= 0 && slot <= 1) {
+        g_lfsr_count[slot]++;
+    }
+}
+
+void
+p25_sm_emit_ptt(dsd_opts* opts, dsd_state* state, int slot) {
+    (void)opts;
+    (void)state;
+    if (slot >= 0 && slot <= 1) {
+        g_ptt_count[slot]++;
+    }
+}
+
+void
+p25_sm_emit_active(dsd_opts* opts, dsd_state* state, int slot) {
+    (void)opts;
+    (void)state;
+    if (slot >= 0 && slot <= 1) {
+        g_active_count[slot]++;
+    }
+}
+
+void
+p25_sm_emit_end(dsd_opts* opts, dsd_state* state, int slot) {
+    (void)opts;
+    (void)state;
+    if (slot >= 0 && slot <= 1) {
+        g_end_count[slot]++;
+    }
+}
+
+void
+p25_sm_emit_idle(dsd_opts* opts, dsd_state* state, int slot) {
+    (void)opts;
+    (void)state;
+    if (slot >= 0 && slot <= 1) {
+        g_idle_count[slot]++;
+    }
+}
+
+void
+p25_sm_emit_enc(dsd_opts* opts, dsd_state* state, int slot, int algid, int keyid, int tg) {
+    (void)opts;
+    (void)state;
+    if (slot >= 0 && slot <= 1) {
+        g_enc_count[slot]++;
+        g_enc_algid[slot] = algid;
+        g_enc_keyid[slot] = keyid;
+        g_enc_tg[slot] = tg;
+    }
+}
+
+void
+closeMbeOutFile(dsd_opts* opts, dsd_state* state) {
+    (void)state;
+    g_close_l_count++;
+    opts->mbe_out_f = NULL;
+}
+
+void
+closeMbeOutFileR(dsd_opts* opts, dsd_state* state) {
+    (void)state;
+    g_close_r_count++;
+    opts->mbe_out_fR = NULL;
+}
+
+#include "../../../src/protocol/p25/phase2/p25p2_xcch.c"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static void
+reset_stubs(void) {
+    g_audio_allow = 1;
+    g_crc12_result = 0;
+    g_crc16_result = 0;
+    g_vpdu_count = 0;
+    g_vpdu_type = -1;
+    DSD_MEMSET(g_vpdu_mac, 0, sizeof(g_vpdu_mac));
+    DSD_MEMSET(g_ptt_count, 0, sizeof(g_ptt_count));
+    DSD_MEMSET(g_active_count, 0, sizeof(g_active_count));
+    DSD_MEMSET(g_end_count, 0, sizeof(g_end_count));
+    DSD_MEMSET(g_idle_count, 0, sizeof(g_idle_count));
+    DSD_MEMSET(g_enc_count, 0, sizeof(g_enc_count));
+    DSD_MEMSET(g_enc_algid, 0, sizeof(g_enc_algid));
+    DSD_MEMSET(g_enc_keyid, 0, sizeof(g_enc_keyid));
+    DSD_MEMSET(g_enc_tg, 0, sizeof(g_enc_tg));
+    g_close_l_count = 0;
+    g_close_r_count = 0;
+    DSD_MEMSET(g_ring_reset_count, 0, sizeof(g_ring_reset_count));
+    DSD_MEMSET(g_lfsr_count, 0, sizeof(g_lfsr_count));
+    g_now_ns = 0;
+}
+
+static int
+expect_int(const char* label, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "FAIL: %s got %d want %d\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u64(const char* label, unsigned long long int got, unsigned long long int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "FAIL: %s got 0x%016llX want 0x%016llX\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static void
+fill_mac(unsigned long long int mac[24], int algid, int keyid, int src, int tg) {
+    DSD_MEMSET(mac, 0, sizeof(unsigned long long int) * 24U);
+    mac[1] = 0x11;
+    mac[2] = 0x22;
+    mac[3] = 0x33;
+    mac[4] = 0x44;
+    mac[5] = 0x55;
+    mac[6] = 0x66;
+    mac[7] = 0x77;
+    mac[8] = 0x88;
+    mac[10] = (unsigned long long int)algid;
+    mac[11] = (unsigned long long int)((keyid >> 8) & 0xFF);
+    mac[12] = (unsigned long long int)(keyid & 0xFF);
+    mac[13] = (unsigned long long int)((src >> 16) & 0xFF);
+    mac[14] = (unsigned long long int)((src >> 8) & 0xFF);
+    mac[15] = (unsigned long long int)(src & 0xFF);
+    mac[16] = (unsigned long long int)((tg >> 8) & 0xFF);
+    mac[17] = (unsigned long long int)(tg & 0xFF);
+}
+
+static void
+pack_payload_from_mac(int* payload, int bit_count, const unsigned long long int mac[24], int opcode, int mac_offset,
+                      int res) {
+    int k = 0;
+    int bytes = bit_count / 8;
+
+    for (int i = 0; i < bit_count; i++) {
+        payload[i] = 0;
+    }
+
+    for (int j = 0; j < bytes; j++) {
+        unsigned long long int byte = mac[j] & 0xFFULL;
+        for (int i = 7; i >= 0; i--) {
+            payload[k++] = (int)((byte >> i) & 1ULL);
+        }
+    }
+
+    payload[0] = (opcode >> 2) & 1;
+    payload[1] = (opcode >> 1) & 1;
+    payload[2] = opcode & 1;
+    payload[3] = (mac_offset >> 2) & 1;
+    payload[4] = (mac_offset >> 1) & 1;
+    payload[5] = mac_offset & 1;
+    payload[6] = (res >> 1) & 1;
+    payload[7] = res & 1;
+}
+
+static int
+test_slot_ptt_and_end_helpers(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    unsigned long long int mac[24];
+    int rc = 0;
+
+    reset_stubs();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.floating_point = 1;
+    opts.audio_gain = 3;
+    state.aout_gain = 0.5F;
+    state.aout_gainR = 0.25F;
+    state.p25_p2_enc_lockout_muted[0] = 1;
+    state.fourv_counter[0] = 9;
+    state.voice_counter[0] = 7;
+    fill_mac(mac, 0x84, 0x2468, 0x010203, 0x1234);
+
+    p25p2_xcch_handle_ptt_slot(&opts, &state, mac, 0, 0);
+    rc |= expect_int("slot0 lastsrc", state.lastsrc, 0x010203);
+    rc |= expect_int("slot0 lasttg", state.lasttg, 0x1234);
+    rc |= expect_int("slot0 algid", state.payload_algid, 0x84);
+    rc |= expect_int("slot0 keyid", state.payload_keyid, 0x2468);
+    rc |= expect_u64("slot0 mi", state.payload_miP, 0x1122334455667788ULL);
+    rc |= expect_int("slot0 drop", state.dropL, 256);
+    rc |= expect_int("slot0 burst", (int)state.dmrburstL, 20);
+    rc |= expect_int("slot0 audio gate", state.p25_p2_audio_allowed[0], 1);
+    rc |= expect_int("slot0 mute marker", state.p25_p2_enc_lockout_muted[0], 0);
+    rc |= expect_int("slot0 fourv reset", state.fourv_counter[0], 0);
+    rc |= expect_int("slot0 voice reset", state.voice_counter[0], 0);
+    rc |= expect_int("slot0 gain reset", (int)state.aout_gain, 3);
+    rc |= expect_int("slot0 enc emitted", g_enc_count[0], 1);
+    rc |= expect_int("slot0 enc algid", g_enc_algid[0], 0x84);
+    rc |= expect_int("slot0 lfsr", g_lfsr_count[0], 1);
+
+    reset_stubs();
+    g_audio_allow = 0;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.lastsrcR = 0xAAAAAA;
+    state.p25_p2_enc_lockout_muted[1] = 1;
+    fill_mac(mac, 0x80, 0x1111, 0, 0x4567);
+
+    p25p2_xcch_handle_ptt_slot(&opts, &state, mac, 1, 1);
+    rc |= expect_int("slot1 zero source preserves lastsrcR", state.lastsrcR, 0xAAAAAA);
+    rc |= expect_int("slot1 lasttgR", state.lasttgR, 0x4567);
+    rc |= expect_int("slot1 algid", state.payload_algidR, 0x80);
+    rc |= expect_int("slot1 keyid", state.payload_keyidR, 0x1111);
+    rc |= expect_int("slot1 burst forced", (int)state.dmrburstR, 20);
+    rc |= expect_int("slot1 audio closed", state.p25_p2_audio_allowed[1], 0);
+    rc |= expect_int("slot1 clear alg skips enc", g_enc_count[1], 0);
+
+    reset_stubs();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.floating_point = 1;
+    opts.audio_gain = 4;
+    opts.mbe_out_f = (FILE*)0x1;
+    state.keyloader = 1;
+    state.lastsrc = 0x112233;
+    state.lasttg = 0x2222;
+    state.payload_algid = 0x81;
+    state.payload_keyid = 0x9999;
+    state.payload_miP = 0x0102030405060708ULL;
+    state.R = 0x1234567890ULL;
+    state.A1[0] = 1;
+    state.A2[0] = 2;
+    state.A3[0] = 3;
+    state.A4[0] = 4;
+    state.aes_key_loaded[0] = 1;
+    state.aes_key_segments[0] = 4;
+    state.p25_p2_audio_allowed[0] = 1;
+    state.p25_p2_enc_lockout_muted[0] = 1;
+    state.fourv_counter[0] = 8;
+    state.voice_counter[0] = 6;
+    DSD_SNPRINTF(state.call_string[0], sizeof(state.call_string[0]), "%s", "active call");
+    DSD_SNPRINTF(state.dmr_embedded_gps[0], sizeof(state.dmr_embedded_gps[0]), "%s", "gps");
+    DSD_SNPRINTF(state.dmr_lrrp_gps[0], sizeof(state.dmr_lrrp_gps[0]), "%s", "lrrp");
+
+    p25p2_xcch_handle_end_slot(&opts, &state, 0, 1);
+    rc |= expect_int("end slot0 src clear", state.lastsrc, 0);
+    rc |= expect_int("end slot0 tg clear", state.lasttg, 0);
+    rc |= expect_int("end slot0 alg clear", state.payload_algid, 0);
+    rc |= expect_int("end slot0 key clear", state.payload_keyid, 0);
+    rc |= expect_int("end slot0 drop", state.dropL, 256);
+    rc |= expect_int("end slot0 burst", (int)state.dmrburstL, 23);
+    rc |= expect_int("end slot0 audio clear", state.p25_p2_audio_allowed[0], 0);
+    rc |= expect_int("end slot0 close", g_close_l_count, 1);
+    rc |= expect_int("end slot0 key clear", (int)state.R, 0);
+    rc |= expect_int("end slot0 aes clear", state.aes_key_loaded[0], 0);
+    rc |= expect_int("end slot0 gps clear", state.dmr_embedded_gps[0][0], '\0');
+    rc |= expect_int("end slot0 lrrp clear", state.dmr_lrrp_gps[0][0], '\0');
+    rc |= expect_int("end slot0 call blank", strncmp(state.call_string[0], P25P2_EMPTY_CALL_STRING, 21), 0);
+
+    return rc;
+}
+
+static int
+test_facch_public_dispatch_and_crc_gates(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    unsigned long long int mac[24];
+    int payload[156];
+    int rc = 0;
+
+    reset_stubs();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    fill_mac(mac, 0x80, 0x1357, 0x010204, 0x2468);
+    pack_payload_from_mac(payload, 156, mac, 0x1, 0x5, 0x2);
+    state.currentslot = 1;
+
+    process_FACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("facch ptt count", g_ptt_count[1], 0);
+    rc |= expect_int("facch slot1 tg", state.lasttgR, 0x2468);
+    rc |= expect_int("facch slot1 src", state.lastsrcR, 0x010204);
+    rc |= expect_int("facch slot1 key", state.payload_keyidR, 0x1357);
+    rc |= expect_int("facch slot1 gate", state.p25_p2_audio_allowed[1], 1);
+    rc |= expect_int("facch slot1 burst", (int)state.dmrburstR, 20);
+
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 1;
+    state.lasttgR = 77;
+    state.p25_p2_audio_allowed[1] = 1;
+    state.p25_p2_audio_ring_count[1] = 3;
+    DSD_SNPRINTF(state.call_string[1], sizeof(state.call_string[1]), "%s", "unit call");
+    pack_payload_from_mac(payload, 156, mac, 0x3, 0, 0);
+
+    process_FACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("facch idle emitted", g_idle_count[1], 1);
+    rc |= expect_int("facch idle vpdu", g_vpdu_count, 1);
+    rc |= expect_int("facch idle vpdu type", g_vpdu_type, 0);
+    rc |= expect_int("facch idle tg clear", state.lasttgR, 0);
+    rc |= expect_int("facch idle gate clear", state.p25_p2_audio_allowed[1], 0);
+    rc |= expect_int("facch idle ring reset", g_ring_reset_count[1], 1);
+    rc |= expect_int("facch idle call blank", strncmp(state.call_string[1], P25P2_EMPTY_CALL_STRING, 21), 0);
+
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 1;
+    g_crc12_result = 1;
+    mac[1] = 0x44;
+    pack_payload_from_mac(payload, 156, mac, 0x1, 0, 0);
+
+    process_FACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("facch crc abort leaves tg", state.lasttgR, 0);
+    rc |= expect_int("facch crc abort no vpdu", g_vpdu_count, 0);
+    rc |= expect_int("facch crc abort no gate", state.p25_p2_audio_allowed[1], 0);
+
+    return rc;
+}
+
+static int
+test_sacch_dispatch_and_lcch_crc_abort(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    unsigned long long int mac[24];
+    int payload[180];
+    int rc = 0;
+
+    reset_stubs();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    fill_mac(mac, 0x80, 0x2222, 0x030405, 0x3456);
+    pack_payload_from_mac(payload, 180, mac, 0x1, 0x1, 0x3);
+    state.currentslot = 0;
+
+    process_SACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("sacch opposite slot src", state.lastsrcR, 0x030405);
+    rc |= expect_int("sacch opposite slot tg", state.lasttgR, 0x3456);
+    rc |= expect_int("sacch ptt emitted", g_ptt_count[1], 1);
+    rc |= expect_int("sacch last active stamped", state.p25_p2_last_mac_active_m[1] > 0.0 ? 1 : 0, 1);
+
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    state.p2_is_lcch = 1;
+    opts.aggressive_framesync = 1;
+    state.p25_p2_audio_allowed[1] = 1;
+    state.p25_p2_audio_ring_count[1] = 4;
+    g_crc16_result = 1;
+    mac[1] = 0x55;
+    pack_payload_from_mac(payload, 180, mac, 0x0, 0, 0);
+
+    process_SACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("lcch crc abort clears lcch", state.p2_is_lcch, 0);
+    rc |= expect_int("lcch crc abort clears gate", state.p25_p2_audio_allowed[1], 0);
+    rc |= expect_int("lcch crc abort resets ring", g_ring_reset_count[1], 1);
+    rc |= expect_int("lcch crc abort no vpdu", g_vpdu_count, 0);
+
+    return rc;
+}
+
+static int
+test_sacch_end_idle_active_hangtime_dispatch(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    unsigned long long int mac[24];
+    int payload[180];
+    int rc = 0;
+
+    reset_stubs();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    state.keyloader = 1;
+    state.lastsrcR = 0x445566;
+    state.lasttgR = 0x3344;
+    state.payload_algidR = 0x84;
+    state.payload_keyidR = 0x2468;
+    state.RR = 0x123456789ABCULL;
+    state.A1[1] = 1;
+    state.A2[1] = 2;
+    state.A3[1] = 3;
+    state.A4[1] = 4;
+    state.aes_key_loaded[1] = 1;
+    state.aes_key_segments[1] = 4;
+    state.p25_p2_audio_allowed[1] = 1;
+    opts.mbe_out_fR = (FILE*)0x1;
+    DSD_SNPRINTF(state.call_string[1], sizeof(state.call_string[1]), "%s", "right call");
+    DSD_SNPRINTF(state.dmr_embedded_gps[1], sizeof(state.dmr_embedded_gps[1]), "%s", "gps");
+    DSD_SNPRINTF(state.dmr_lrrp_gps[1], sizeof(state.dmr_lrrp_gps[1]), "%s", "lrrp");
+    fill_mac(mac, 0x80, 0, 0, 0);
+    pack_payload_from_mac(payload, 180, mac, 0x2, 0, 0);
+
+    process_SACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("sacch end emitted", g_end_count[1], 1);
+    rc |= expect_int("sacch end src clear", state.lastsrcR, 0);
+    rc |= expect_int("sacch end tg clear", state.lasttgR, 0);
+    rc |= expect_int("sacch end alg clear", state.payload_algidR, 0);
+    rc |= expect_int("sacch end keyid clear", state.payload_keyidR, 0);
+    rc |= expect_int("sacch end gate clear", state.p25_p2_audio_allowed[1], 0);
+    rc |= expect_int("sacch end burst", (int)state.dmrburstR, 23);
+    rc |= expect_int("sacch end close right", g_close_r_count, 1);
+    rc |= expect_int("sacch end key clear", (int)state.RR, 0);
+    rc |= expect_int("sacch end aes clear", state.aes_key_loaded[1], 0);
+    rc |= expect_int("sacch end gps clear", state.dmr_embedded_gps[1][0], '\0');
+    rc |= expect_int("sacch end lrrp clear", state.dmr_lrrp_gps[1][0], '\0');
+    rc |= expect_int("sacch end call blank", strncmp(state.call_string[1], P25P2_EMPTY_CALL_STRING, 21), 0);
+
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    state.p25_p2_audio_allowed[1] = 1;
+    state.p25_p2_enc_lockout_muted[1] = 1;
+    state.p25_call_is_packet[1] = 1;
+    DSD_SNPRINTF(state.call_string[1], sizeof(state.call_string[1]), "%s", "packet");
+    pack_payload_from_mac(payload, 180, mac, 0x3, 0, 0);
+
+    process_SACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("sacch idle emitted", g_idle_count[1], 1);
+    rc |= expect_int("sacch idle vpdu", g_vpdu_count, 1);
+    rc |= expect_int("sacch idle vpdu type", g_vpdu_type, 1);
+    rc |= expect_int("sacch idle burst", (int)state.dmrburstR, 24);
+    rc |= expect_int("sacch idle gate clear", state.p25_p2_audio_allowed[1], 0);
+    rc |= expect_int("sacch idle packet clear", state.p25_call_is_packet[1], 0);
+    rc |= expect_int("sacch idle mute clear", state.p25_p2_enc_lockout_muted[1], 0);
+    rc |= expect_int("sacch idle call blank", strncmp(state.call_string[1], P25P2_EMPTY_CALL_STRING, 21), 0);
+
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    state.payload_algidR = 0x81;
+    state.payload_keyidR = 0x2222;
+    state.lasttgR = 0x3456;
+    pack_payload_from_mac(payload, 180, mac, 0x4, 0, 0);
+
+    process_SACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("sacch active vpdu", g_vpdu_count, 1);
+    rc |= expect_int("sacch active vpdu type", g_vpdu_type, 1);
+    rc |= expect_int("sacch active gate", state.p25_p2_audio_allowed[1], 1);
+    rc |= expect_int("sacch active burst", (int)state.dmrburstR, 21);
+    rc |= expect_int("sacch active enc emitted", g_enc_count[1], 1);
+    rc |= expect_int("sacch active enc alg", g_enc_algid[1], 0x81);
+    rc |= expect_int("sacch active timestamp", state.p25_p2_last_mac_active_m[1] > 0.0 ? 1 : 0, 1);
+
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    state.currentslot = 0;
+    opts.mbe_out_fR = (FILE*)0x1;
+    pack_payload_from_mac(payload, 180, mac, 0x6, 0, 0);
+
+    process_SACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("sacch hangtime vpdu", g_vpdu_count, 1);
+    rc |= expect_int("sacch hangtime vpdu type", g_vpdu_type, 1);
+    rc |= expect_int("sacch hangtime burst right", (int)state.dmrburstR, 22);
+    rc |= expect_int("sacch hangtime close right", g_close_r_count, 1);
+
+    return rc;
+}
+
+static int
+test_facch_active_end_hangtime_and_invalid_slot_guards(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    unsigned long long int mac[24];
+    int payload[156];
+    int rc = 0;
+
+    reset_stubs();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    fill_mac(mac, 0x80, 0, 0, 0);
+
+    p25p2_xcch_handle_facch_mac_end(&opts, &state, 2);
+    p25p2_xcch_handle_facch_mac_idle(&opts, &state, 2, mac);
+    p25p2_xcch_handle_facch_mac_active(&opts, &state, 2, mac);
+    rc |= expect_int("facch invalid no end", g_end_count[0] + g_end_count[1], 0);
+    rc |= expect_int("facch invalid no idle", g_idle_count[0] + g_idle_count[1], 0);
+    rc |= expect_int("facch invalid no active", g_active_count[0] + g_active_count[1], 0);
+    rc |= expect_int("facch invalid no vpdu", g_vpdu_count, 0);
+    rc |= expect_int("facch invalid no burst left", (int)state.dmrburstL, 0);
+
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    state.currentslot = 0;
+    state.keyloader = 1;
+    state.lastsrc = 0x123456;
+    state.lasttg = 0x4567;
+    state.payload_algid = 0x81;
+    state.payload_keyid = 0x5555;
+    state.R = 0x12345678ULL;
+    state.A1[0] = 5;
+    state.aes_key_loaded[0] = 1;
+    state.aes_key_segments[0] = 2;
+    state.p25_p2_audio_allowed[0] = 1;
+    opts.mbe_out_f = (FILE*)0x1;
+    DSD_SNPRINTF(state.call_string[0], sizeof(state.call_string[0]), "%s", "left call");
+    pack_payload_from_mac(payload, 156, mac, 0x2, 0, 0);
+
+    process_FACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("facch end emitted", g_end_count[0], 1);
+    rc |= expect_int("facch end src clear", state.lastsrc, 0);
+    rc |= expect_int("facch end tg clear", state.lasttg, 0);
+    rc |= expect_int("facch end gate clear", state.p25_p2_audio_allowed[0], 0);
+    rc |= expect_int("facch end burst", (int)state.dmrburstL, 23);
+    rc |= expect_int("facch end close left", g_close_l_count, 1);
+    rc |= expect_int("facch end key clear", (int)state.R, 0);
+    rc |= expect_int("facch end call blank", strncmp(state.call_string[0], P25P2_EMPTY_CALL_STRING, 21), 0);
+
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    state.currentslot = 1;
+    state.payload_algidR = 0x84;
+    state.payload_keyidR = 0x7777;
+    state.lasttgR = 0x7654;
+    pack_payload_from_mac(payload, 156, mac, 0x4, 0, 0);
+
+    process_FACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("facch active emitted", g_active_count[1], 1);
+    rc |= expect_int("facch active vpdu", g_vpdu_count, 1);
+    rc |= expect_int("facch active vpdu type", g_vpdu_type, 0);
+    rc |= expect_int("facch active gate", state.p25_p2_audio_allowed[1], 1);
+    rc |= expect_int("facch active burst", (int)state.dmrburstR, 21);
+    rc |= expect_int("facch active enc emitted", g_enc_count[1], 1);
+    rc |= expect_int("facch active enc alg", g_enc_algid[1], 0x84);
+
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    state.currentslot = 1;
+    opts.mbe_out_fR = (FILE*)0x1;
+    pack_payload_from_mac(payload, 156, mac, 0x6, 0, 0);
+
+    process_FACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("facch hangtime vpdu", g_vpdu_count, 1);
+    rc |= expect_int("facch hangtime vpdu type", g_vpdu_type, 0);
+    rc |= expect_int("facch hangtime burst right", (int)state.dmrburstR, 22);
+    rc |= expect_int("facch hangtime close right", g_close_r_count, 1);
+
+    return rc;
+}
+
+static int
+test_voice_counter_reset_helpers(void) {
+    static dsd_state state;
+    int rc = 0;
+
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    state.payload_algid = 0x81;
+    state.payload_algidR = 0x80;
+    state.DMRvcL = 11;
+    state.DMRvcR = 12;
+    p25p2_xcch_reset_ptt_voice_counter_sacch(&state);
+    rc |= expect_int("sacch encrypted opposite resets right", state.DMRvcR, 0);
+    rc |= expect_int("sacch preserves left", state.DMRvcL, 11);
+
+    state.currentslot = 1;
+    state.payload_algid = 0x80;
+    state.payload_algidR = 0x84;
+    state.DMRvcL = 13;
+    state.DMRvcR = 14;
+    p25p2_xcch_reset_ptt_voice_counter_sacch(&state);
+    rc |= expect_int("sacch encrypted opposite resets left", state.DMRvcL, 0);
+    rc |= expect_int("sacch preserves right", state.DMRvcR, 14);
+
+    state.currentslot = 0;
+    state.payload_algid = 0x89;
+    state.payload_algidR = 0x80;
+    state.DMRvcL = 21;
+    state.DMRvcR = 22;
+    p25p2_xcch_reset_ptt_voice_counter_facch(&state);
+    rc |= expect_int("facch encrypted current resets left", state.DMRvcL, 0);
+    rc |= expect_int("facch preserves right", state.DMRvcR, 22);
+
+    state.currentslot = 1;
+    state.payload_algid = 0x80;
+    state.payload_algidR = 0x81;
+    state.DMRvcL = 23;
+    state.DMRvcR = 24;
+    p25p2_xcch_reset_ptt_voice_counter_facch(&state);
+    rc |= expect_int("facch encrypted current resets right", state.DMRvcR, 0);
+    rc |= expect_int("facch preserves left", state.DMRvcL, 23);
+
+    state.currentslot = 0;
+    state.payload_algid = 0x80;
+    state.DMRvcL = 31;
+    state.DMRvcR = 32;
+    p25p2_xcch_reset_ptt_voice_counter_facch(&state);
+    rc |= expect_int("facch clear alg preserves left", state.DMRvcL, 31);
+    rc |= expect_int("facch clear alg preserves right", state.DMRvcR, 32);
+
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+
+    rc |= test_slot_ptt_and_end_helpers();
+    rc |= test_facch_public_dispatch_and_crc_gates();
+    rc |= test_sacch_dispatch_and_lcch_crc_abort();
+    rc |= test_sacch_end_idle_active_hangtime_dispatch();
+    rc |= test_facch_active_end_hangtime_and_invalid_slot_guards();
+    rc |= test_voice_counter_reset_helpers();
+
+    if (rc != 0) {
+        return 1;
+    }
+
+    printf("P25_P2_XCCH_HELPERS: OK\n");
+    return 0;
+}
+
+// NOLINTEND(bugprone-suspicious-include)

--- a/tests/protocol/p25/test_p25_p2_ysf_sync_dispatch.c
+++ b/tests/protocol/p25/test_p25_p2_ysf_sync_dispatch.c
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Focused checks for the small P25 Phase 2 and YSF dispatch wrappers.
+ */
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/protocol/p25/p25.h>
+#include <dsd-neo/protocol/ysf/ysf.h>
+#include <stdio.h>
+#include <string.h>
+
+int dsd_dispatch_matches_p25p2(int synctype);
+void dsd_dispatch_handle_p25p2(dsd_opts* opts, dsd_state* state);
+int dsd_dispatch_matches_ysf(int synctype);
+void dsd_dispatch_handle_ysf(dsd_opts* opts, dsd_state* state);
+
+static int g_process_p2_calls;
+static int g_process_ysf_calls;
+
+void
+processP2(dsd_opts* opts, dsd_state* state) {
+    assert(opts != NULL);
+    assert(state != NULL);
+    g_process_p2_calls++;
+    state->lastp25type = 2;
+}
+
+void
+processYSF(dsd_opts* opts, dsd_state* state) {
+    assert(opts != NULL);
+    assert(state != NULL);
+    g_process_ysf_calls++;
+    DSD_SNPRINTF(state->fsubtype, sizeof(state->fsubtype), "%s", " YSF          ");
+}
+
+static void
+test_p25p2_match_and_dispatch(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    assert(dsd_dispatch_matches_p25p2(DSD_SYNC_P25P2_POS));
+    assert(dsd_dispatch_matches_p25p2(DSD_SYNC_P25P2_NEG));
+    assert(!dsd_dispatch_matches_p25p2(DSD_SYNC_P25P1_POS));
+    assert(!dsd_dispatch_matches_p25p2(DSD_SYNC_YSF_POS));
+
+    dsd_dispatch_handle_p25p2(&opts, &state);
+    assert(g_process_p2_calls == 1);
+    assert(state.lastp25type == 2);
+}
+
+static void
+test_ysf_match_and_dispatch(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    assert(dsd_dispatch_matches_ysf(DSD_SYNC_YSF_POS));
+    assert(dsd_dispatch_matches_ysf(DSD_SYNC_YSF_NEG));
+    assert(!dsd_dispatch_matches_ysf(DSD_SYNC_P25P2_POS));
+    assert(!dsd_dispatch_matches_ysf(DSD_SYNC_DMR_BS_DATA_POS));
+
+    dsd_dispatch_handle_ysf(&opts, &state);
+    assert(g_process_ysf_calls == 1);
+    assert(strcmp(state.fsubtype, " YSF          ") == 0);
+}
+
+int
+main(void) {
+    test_p25p2_match_and_dispatch();
+    test_ysf_match_and_dispatch();
+    printf("P25_P2_YSF_SYNC_DISPATCH: OK\n");
+    return 0;
+}

--- a/tests/protocol/p25/test_p25_patch_tracking.c
+++ b/tests/protocol/p25/test_p25_patch_tracking.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-misplaced-widening-cast)
 /*
  * Copyright (C) 2025 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -81,6 +84,15 @@ expect_true(const char* tag, int cond) {
 }
 
 static int
+expect_eq_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 find_idx(const dsd_state* st, uint16_t sgid) {
     for (int i = 0; i < st->p25_patch_count && i < 8; i++) {
         if (st->p25_patch_sgid[i] == sgid) {
@@ -88,6 +100,95 @@ find_idx(const dsd_state* st, uint16_t sgid) {
         }
     }
     return -1;
+}
+
+static int
+test_guard_replacement_and_policy_edges(void) {
+    int rc = 0;
+    static dsd_state st;
+    char out[128];
+
+    DSD_MEMSET(&st, 0, sizeof st);
+    p25_patch_update(NULL, 1, 1, 1);
+    p25_patch_add_wgid(NULL, 1, 1);
+    p25_patch_add_wuid(NULL, 1, 1);
+    p25_patch_remove_wgid(NULL, 1, 1);
+    p25_patch_remove_wuid(NULL, 1, 1);
+    p25_patch_clear_sg(NULL, 1);
+    p25_patch_set_kas(NULL, 1, 0, 0, 0);
+    rc |= expect_eq_int("summary null out", p25_patch_compose_summary(&st, NULL, sizeof out), 0);
+    rc |= expect_eq_int("summary zero cap", p25_patch_compose_summary(&st, out, 0), 0);
+    rc |= expect_eq_int("summary null state", p25_patch_compose_summary(NULL, out, sizeof out), 0);
+    rc |= expect_eq_int("details null out", p25_patch_compose_details(&st, NULL, sizeof out), 0);
+    rc |= expect_eq_int("details zero cap", p25_patch_compose_details(&st, out, 0), 0);
+    rc |= expect_eq_int("details null state", p25_patch_compose_details(NULL, out, sizeof out), 0);
+    rc |= expect_eq_int("tg clear null", p25_patch_tg_key_is_clear(NULL, 123), 0);
+    rc |= expect_eq_int("sg clear null", p25_patch_sg_key_is_clear(NULL, 123), 0);
+
+    st.p25_patch_count = -3;
+    p25_patch_update(&st, 300, 1, 1);
+    rc |= expect_eq_int("negative count recovers", st.p25_patch_count, 1);
+    rc |= expect_eq_int("negative count stores sgid", st.p25_patch_sgid[0], 300);
+
+    DSD_MEMSET(&st, 0, sizeof st);
+    st.p25_patch_count = 8;
+    for (int i = 0; i < 8; i++) {
+        st.p25_patch_sgid[i] = (uint16_t)(100 + i);
+        st.p25_patch_last_update[i] = (time_t)(1000 + i);
+        st.p25_patch_wgid_count[i] = 1;
+        st.p25_patch_key_valid[i] = 1;
+    }
+    p25_patch_update(&st, 999, 0, 1);
+    rc |= expect_eq_int("full table count", st.p25_patch_count, 8);
+    rc |= expect_eq_int("full table replaces stalest", st.p25_patch_sgid[0], 999);
+    rc |= expect_eq_int("replacement clears wgid count", st.p25_patch_wgid_count[0], 0);
+    rc |= expect_eq_int("replacement clears key valid", st.p25_patch_key_valid[0], 0);
+    rc |= expect_eq_int("replacement stores simulselect", st.p25_patch_is_patch[0], 0);
+
+    DSD_MEMSET(&st, 0, sizeof st);
+    p25_patch_update(&st, 10, 1, 1);
+    p25_patch_add_wgid(&st, 10, 111);
+    p25_patch_set_kas(&st, 10, 0x2222, 0x84, 3);
+    p25_patch_update(&st, 20, 1, 1);
+    p25_patch_add_wgid(&st, 20, 222);
+    int stale = find_idx(&st, 10);
+    if (stale >= 0) {
+        st.p25_patch_last_update[stale] = time(NULL) - 21;
+    }
+    int active = find_idx(&st, 20);
+    if (active >= 0) {
+        st.p25_patch_last_update[active] = time(NULL);
+    }
+    (void)p25_patch_compose_details(&st, out, sizeof out);
+    rc |= expect_eq_int("sweep compacts count", st.p25_patch_count, 1);
+    rc |= expect_eq_int("sweep preserves active sgid", st.p25_patch_sgid[0], 20);
+    rc |= expect_eq_int("sweep preserves active member", st.p25_patch_wgid[0][0], 222);
+
+    DSD_MEMSET(&st, 0, sizeof st);
+    p25_patch_add_wuid(&st, 77, 1001);
+    p25_patch_add_wuid(&st, 77, 1002);
+    p25_patch_remove_wuid(&st, 77, 1001);
+    rc |= expect_eq_int("remove wuid keeps one", st.p25_patch_wuid_count[0], 1);
+    rc |= expect_eq_int("remove wuid swaps tail", (int)st.p25_patch_wuid[0][0], 1002);
+    rc |= expect_eq_int("remove wuid stays active", st.p25_patch_active[0], 1);
+    p25_patch_remove_wuid(&st, 77, 1002);
+    rc |= expect_eq_int("remove final wuid clears count", st.p25_patch_wuid_count[0], 0);
+    rc |= expect_eq_int("remove final wuid deactivates", st.p25_patch_active[0], 0);
+
+    DSD_MEMSET(&st, 0, sizeof st);
+    p25_patch_add_wgid(&st, 69, 0x2345);
+    p25_patch_set_kas(&st, 69, 0, 0x84, 17);
+    rc |= expect_eq_int("clear tg policy active", p25_patch_tg_key_is_clear(&st, 0x2345), 1);
+    rc |= expect_eq_int("clear sg policy active", p25_patch_sg_key_is_clear(&st, 69), 1);
+    st.p25_patch_last_update[0] = time(NULL) - 21;
+    rc |= expect_eq_int("clear tg policy stale", p25_patch_tg_key_is_clear(&st, 0x2345), 0);
+    rc |= expect_eq_int("clear sg policy stale", p25_patch_sg_key_is_clear(&st, 69), 0);
+    st.p25_patch_last_update[0] = time(NULL);
+    p25_patch_set_kas(&st, 69, 0x1234, -1, -1);
+    rc |= expect_eq_int("nonclear tg policy", p25_patch_tg_key_is_clear(&st, 0x2345), 0);
+    rc |= expect_eq_int("nonclear sg policy", p25_patch_sg_key_is_clear(&st, 69), 0);
+
+    return rc;
 }
 
 int
@@ -167,6 +268,7 @@ main(void) {
 
     // SG077[S] still present (simulselect) with U:3
     rc |= expect_true("SG077 remains", strstr(det, "SG077[S]") != NULL);
+    rc |= test_guard_replacement_and_policy_edges();
 
     (void)errno;
     return rc;
@@ -175,3 +277,4 @@ main(void) {
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic pop
 #endif
+// NOLINTEND(bugprone-misplaced-widening-cast)

--- a/tests/protocol/p25/test_p25_sm_api_override.c
+++ b/tests/protocol/p25/test_p25_sm_api_override.c
@@ -5,6 +5,7 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/platform/timing.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm_api.h>
 #include <stdio.h>
@@ -205,12 +206,35 @@ main(void) {
     DSD_MEMSET(&guarded_opts, 0, sizeof(guarded_opts));
     DSD_MEMSET(&guarded_state, 0, sizeof(guarded_state));
     g_tick_calls = 0;
+    p25_sm_try_tick(NULL, &guarded_state);
+    p25_sm_try_tick(&guarded_opts, NULL);
+    rc |= expect_eq_int("try_tick_null_guards", g_tick_calls, 0);
     p25_sm_try_tick(&guarded_opts, &guarded_state);
     rc |= expect_eq_int("try_tick_disabled", g_tick_calls, 0);
 
     guarded_opts.p25_trunk = 1;
+    rc |= expect_eq_int("tick_guard_enter", p25_sm_tick_guard_try_enter(), 1);
+    p25_sm_try_tick(&guarded_opts, &guarded_state);
+    rc |= expect_eq_int("try_tick_guarded", g_tick_calls, 0);
+    p25_sm_tick_guard_leave();
+
     p25_sm_try_tick(&guarded_opts, &guarded_state);
     rc |= expect_eq_int("try_tick_enabled", g_tick_calls, 1);
+    rc |= expect_eq_int("in_tick_idle", p25_sm_in_tick(), 0);
+
+    p25_sm_watchdog_start(NULL, &guarded_state);
+    p25_sm_watchdog_start(&guarded_opts, NULL);
+    rc |= expect_eq_int("watchdog_start_null_guards", g_tick_calls, 1);
+
+    guarded_opts.use_ncurses_terminal = 1;
+    p25_sm_watchdog_start(&guarded_opts, &guarded_state);
+    dsd_sleep_ms(60U);
+    p25_sm_watchdog_stop();
+    rc |= expect_eq_int("watchdog_stop_idle", p25_sm_in_tick(), 0);
+    if (g_tick_calls < 2) {
+        DSD_FPRINTF(stderr, "watchdog thread did not tick: calls=%d\n", g_tick_calls);
+        rc |= 1;
+    }
 
     return rc;
 }

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -11,8 +11,13 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/rigctl_query_hooks.h>
+#ifdef USE_RADIO
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#endif
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdio.h>
@@ -737,6 +742,56 @@ main(void) {
     p25_sm_tick_ctx(&ctx18, &o18, &s18);
     assert(ctx18.state == P25_SM_ON_CC);
     assert(g_result_tune_to_cc_calls == cc_calls_before_seeded_release_tick);
+
+#ifdef USE_RADIO
+    // 20) A failed CQPSK retry must roll back the one-shot override and TDMA timing.
+    static dsd_opts o19;
+    static dsd_state s19;
+    DSD_MEMSET(&o19, 0, sizeof(o19));
+    DSD_MEMSET(&s19, 0, sizeof(s19));
+    o19.p25_trunk = 1;
+    o19.trunk_tune_group_calls = 1;
+    o19.audio_in_type = AUDIO_IN_RTL;
+    o19.trunk_hangtime = 5.0f;
+    o19.p25_grant_voice_to_s = 5.0;
+    s19.p25_cc_freq = 851000000;
+    s19.trunk_cc_freq = 851000000;
+    s19.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s19.p25_iden_fdma[id9].chan_type = 1;
+    s19.p25_iden_fdma[id9].chan_spac = 100;
+    s19.p25_iden_fdma[id9].trust = 2;
+    s19.p25_iden_fdma[id9].populated = 1;
+    s19.p25_chan_tdma_explicit[id9] = 2;
+    s19.p25_vc_cqpsk_pref = -1;
+    (void)dsd_unsetenv("DSD_NEO_CQPSK");
+    dsd_neo_config_init(&o19);
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+
+    p25_sm_ctx_t ctx19;
+    p25_sm_init_ctx(&ctx19, &o19, &s19);
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_result_tune_to_freq_calls = 0;
+    p25_sm_event(&ctx19, &o19, &s19, &ev9);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(ctx19.state == P25_SM_TUNED);
+    assert(ctx19.vc_is_tdma == 1);
+    assert(o19.p25_is_tuned == 1);
+    const int tuned_sps = s19.samplesPerSymbol;
+    const int tuned_center = s19.symbolCenter;
+
+    s19.p25_vc_cqpsk_override = 0;
+    ctx19.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    int calls_before_cqpsk_retry = g_result_tune_to_freq_calls;
+    p25_sm_tick_ctx(&ctx19, &o19, &s19);
+    assert(g_result_tune_to_freq_calls == calls_before_cqpsk_retry + 1);
+    assert(ctx19.vc_cqpsk_retry_done == 0);
+    assert(s19.p25_vc_cqpsk_override == 0);
+    assert(s19.samplesPerSymbol == tuned_sps);
+    assert(s19.symbolCenter == tuned_center);
+    assert(ctx19.state == P25_SM_TUNED);
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+#endif
 
     install_trunk_tuning_hooks();
 

--- a/tests/protocol/p25/test_p25_sm_tags_ring.c
+++ b/tests/protocol/p25/test_p25_sm_tags_ring.c
@@ -50,11 +50,23 @@ main(void) {
     rc |= expect_int("init count", st.p25_sm_tag_count, 0);
     rc |= expect_int("init head", st.p25_sm_tag_head, 0);
 
+    /* Null opts/state should be accepted as no-op guards. */
+    p25_sm_log_status(NULL, &st, "ignored");
+    p25_sm_log_status(&opts, NULL, "ignored");
+    rc |= expect_int("guard count", st.p25_sm_tag_count, 0);
+    rc |= expect_int("guard head", st.p25_sm_tag_head, 0);
+
     /* Null/empty tags should not modify the ring. */
     p25_sm_log_status(&opts, &st, NULL);
     p25_sm_log_status(&opts, &st, "");
     rc |= expect_int("no-op count", st.p25_sm_tag_count, 0);
     rc |= expect_int("no-op head", st.p25_sm_tag_head, 0);
+
+    opts.verbose = 2;
+    p25_sm_log_status(&opts, &st, NULL);
+    opts.verbose = 0;
+    rc |= expect_int("verbose no-op count", st.p25_sm_tag_count, 0);
+    rc |= expect_int("verbose no-op head", st.p25_sm_tag_head, 0);
 
     /* Push more than capacity and verify that only the last 8 tags remain. */
     const int N = 10;

--- a/tests/protocol/p25/test_p25p1_soft_hamming.cpp
+++ b/tests/protocol/p25/test_p25p1_soft_hamming.cpp
@@ -212,6 +212,24 @@ test_high_reliability_no_change() {
     }
 }
 
+static void
+test_table_impl_public_guards() {
+    Hamming_10_6_3_TableImpl hamming;
+    int decoded = 123;
+
+    ASSERT_EQ(hamming.decode(-1, &decoded), 2, "Negative table decode input should fail");
+    ASSERT_EQ(decoded, 0, "Negative table decode input should clear output");
+
+    decoded = 123;
+    ASSERT_EQ(hamming.decode(1024, &decoded), 2, "Out-of-range table decode input should fail");
+    ASSERT_EQ(decoded, 0, "Out-of-range table decode input should clear output");
+
+    ASSERT_EQ(hamming.decode(0, nullptr), 2, "Null table decode output should fail");
+
+    ASSERT_EQ(hamming.encode(-1), 0, "Negative table encode input should clamp to zero");
+    ASSERT_EQ(hamming.encode(64), 0, "Out-of-range table encode input should clamp to zero");
+}
+
 int
 main(void) {
     test_no_error();
@@ -219,6 +237,7 @@ main(void) {
     test_two_errors_with_soft_info();
     test_soft_hard_override_toggle();
     test_high_reliability_no_change();
+    test_table_impl_public_guards();
 
     if (g_fail_count > 0) {
         DSD_FPRINTF(stderr, "FAILED: %d test(s) failed\n", g_fail_count);

--- a/tests/protocol/p25/test_p25p1_soft_rs.cpp
+++ b/tests/protocol/p25/test_p25p1_soft_rs.cpp
@@ -150,6 +150,92 @@ test_hdu_soft_rs_mixed_errors_and_erasures(void) {
 }
 
 static int
+test_hdu_golay24_6_wrappers(void) {
+    char hex[6];
+    char parity[12];
+    char expected[6];
+
+    set_symbol(hex, 0, 0x2A);
+    DSD_MEMCPY(expected, hex, sizeof(hex));
+    encode_golay_24_6(hex, parity);
+
+    char data_fix[6];
+    char parity_fix[12];
+    DSD_MEMCPY(data_fix, hex, sizeof(data_fix));
+    DSD_MEMCPY(parity_fix, parity, sizeof(parity_fix));
+    data_fix[0] ^= 1;
+    data_fix[5] ^= 1;
+    parity_fix[3] ^= 1;
+
+    int fixed = 0;
+    if (check_and_fix_golay_24_6(data_fix, parity_fix, &fixed) != 0) {
+        DSD_FPRINTF(stderr, "hdu Golay(24,6) failed to correct three errors\n");
+        return 1;
+    }
+    if (std::memcmp(data_fix, expected, sizeof(data_fix)) != 0 || fixed <= 0) {
+        DSD_FPRINTF(stderr, "hdu Golay(24,6) corrected data mismatch fixed=%d\n", fixed);
+        return 1;
+    }
+
+    DSD_MEMCPY(data_fix, hex, sizeof(data_fix));
+    DSD_MEMCPY(parity_fix, parity, sizeof(parity_fix));
+    data_fix[0] ^= 1;
+    data_fix[1] ^= 1;
+    data_fix[2] ^= 1;
+    parity_fix[0] ^= 1;
+    fixed = 0;
+    if (check_and_fix_golay_24_6(data_fix, parity_fix, &fixed) == 0) {
+        DSD_FPRINTF(stderr, "hdu Golay(24,6) unexpectedly corrected four errors\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_hdu_ranked_reliability_above_threshold(void) {
+    char data[20 * 6];
+    char parity[16 * 6];
+    char expected[20 * 6];
+    uint8_t data_reliab[20];
+    uint8_t parity_reliab[16];
+
+    fill_data(data, 20, 47);
+    encode_reedsolomon_36_20_17(data, parity);
+    DSD_MEMCPY(expected, data, sizeof(data));
+
+    DSD_MEMSET(data_reliab, 200, sizeof(data_reliab));
+    DSD_MEMSET(parity_reliab, 200, sizeof(parity_reliab));
+    for (int i = 0; i < 10; i++) {
+        corrupt_symbol(data, i, 0x11 + i);
+        data_reliab[i] = 100;
+    }
+
+    if (p25p1_rs_36_20_17_soft_reliability(NULL, parity, data_reliab, parity_reliab) != 1
+        || p25p1_rs_36_20_17_soft_reliability(data, NULL, data_reliab, parity_reliab) != 1
+        || p25p1_rs_36_20_17_soft_reliability(data, parity, NULL, parity_reliab) != 1
+        || p25p1_rs_36_20_17_soft_reliability(data, parity, data_reliab, NULL) != 1) {
+        DSD_FPRINTF(stderr, "hdu ranked reliability NULL guard failed\n");
+        return 1;
+    }
+
+    char hard_data[20 * 6];
+    DSD_MEMCPY(hard_data, data, sizeof(data));
+    if (check_and_fix_redsolomon_36_20_17(hard_data, parity) == 0) {
+        DSD_FPRINTF(stderr, "hdu hard RS unexpectedly corrected 10 weak high-confidence errors\n");
+        return 1;
+    }
+    if (p25p1_rs_36_20_17_soft_reliability(data, parity, data_reliab, parity_reliab) != 0) {
+        DSD_FPRINTF(stderr, "hdu ranked reliability soft RS failed\n");
+        return 1;
+    }
+    if (std::memcmp(data, expected, sizeof(data)) != 0) {
+        DSD_FPRINTF(stderr, "hdu ranked reliability data mismatch\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
 test_ldu1_soft_rs(void) {
     char data[12 * 6];
     char parity[12 * 6];
@@ -212,6 +298,50 @@ test_ldu1_soft_rs_mixed_errors_and_erasures(void) {
     }
     if (std::memcmp(data, expected, sizeof(data)) != 0) {
         DSD_FPRINTF(stderr, "ldu1 mixed errors+erasures data mismatch\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_ldu1_ranked_reliability_above_threshold(void) {
+    char data[12 * 6];
+    char parity[12 * 6];
+    char expected[12 * 6];
+    uint8_t data_reliab[12];
+    uint8_t parity_reliab[12];
+
+    fill_data(data, 12, 37);
+    encode_reedsolomon_24_12_13(data, parity);
+    DSD_MEMCPY(expected, data, sizeof(data));
+
+    DSD_MEMSET(data_reliab, 200, sizeof(data_reliab));
+    DSD_MEMSET(parity_reliab, 200, sizeof(parity_reliab));
+    for (int i = 0; i < 7; i++) {
+        corrupt_symbol(data, i, 0x17 + i);
+        data_reliab[i] = 100;
+    }
+
+    if (p25p1_rs_24_12_13_soft_reliability(NULL, parity, data_reliab, parity_reliab) != 1
+        || p25p1_rs_24_12_13_soft_reliability(data, NULL, data_reliab, parity_reliab) != 1
+        || p25p1_rs_24_12_13_soft_reliability(data, parity, NULL, parity_reliab) != 1
+        || p25p1_rs_24_12_13_soft_reliability(data, parity, data_reliab, NULL) != 1) {
+        DSD_FPRINTF(stderr, "ldu1 ranked reliability NULL guard failed\n");
+        return 1;
+    }
+
+    char hard_data[12 * 6];
+    DSD_MEMCPY(hard_data, data, sizeof(data));
+    if (check_and_fix_reedsolomon_24_12_13(hard_data, parity) == 0) {
+        DSD_FPRINTF(stderr, "ldu1 hard RS unexpectedly corrected 7 weak high-confidence errors\n");
+        return 1;
+    }
+    if (p25p1_rs_24_12_13_soft_reliability(data, parity, data_reliab, parity_reliab) != 0) {
+        DSD_FPRINTF(stderr, "ldu1 ranked reliability soft RS failed\n");
+        return 1;
+    }
+    if (std::memcmp(data, expected, sizeof(data)) != 0) {
+        DSD_FPRINTF(stderr, "ldu1 ranked reliability data mismatch\n");
         return 1;
     }
     return 0;
@@ -320,17 +450,44 @@ test_ldu2_ranked_reliability_above_threshold(void) {
     return 0;
 }
 
+static int
+test_ldu2_ranked_reliability_null_guards(void) {
+    char data[16 * 6];
+    char parity[8 * 6];
+    uint8_t data_reliab[16];
+    uint8_t parity_reliab[8];
+
+    fill_data(data, 16, 17);
+    encode_reedsolomon_24_16_9(data, parity);
+
+    DSD_MEMSET(data_reliab, 200, sizeof(data_reliab));
+    DSD_MEMSET(parity_reliab, 200, sizeof(parity_reliab));
+
+    if (p25p1_rs_24_16_9_soft_reliability(NULL, parity, data_reliab, parity_reliab) != 1
+        || p25p1_rs_24_16_9_soft_reliability(data, NULL, data_reliab, parity_reliab) != 1
+        || p25p1_rs_24_16_9_soft_reliability(data, parity, NULL, parity_reliab) != 1
+        || p25p1_rs_24_16_9_soft_reliability(data, parity, data_reliab, NULL) != 1) {
+        DSD_FPRINTF(stderr, "ldu2 ranked reliability NULL guard failed\n");
+        return 1;
+    }
+    return 0;
+}
+
 int
 main(void) {
     int rc = 0;
     rc |= test_erasure_mapping();
     rc |= test_hdu_soft_rs();
     rc |= test_hdu_soft_rs_mixed_errors_and_erasures();
+    rc |= test_hdu_golay24_6_wrappers();
+    rc |= test_hdu_ranked_reliability_above_threshold();
     rc |= test_ldu1_soft_rs();
     rc |= test_ldu1_soft_rs_mixed_errors_and_erasures();
+    rc |= test_ldu1_ranked_reliability_above_threshold();
     rc |= test_ldu2_soft_rs();
     rc |= test_ldu2_soft_rs_mixed_errors_and_erasures();
     rc |= test_ldu2_ranked_reliability_above_threshold();
+    rc |= test_ldu2_ranked_reliability_null_guards();
     if (rc == 0) {
         DSD_FPRINTF(stderr, "PASSED: P25P1 soft RS tests passed\n");
     }

--- a/tests/protocol/provoice/test_provoice_process.c
+++ b/tests/protocol/provoice/test_provoice_process.c
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Focused checks for ProVoice voice processing loop boundaries.
+ */
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "provoice_frame.h"
+
+#include <assert.h>
+#include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/vocoder.h>
+#include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <dsd-neo/protocol/provoice/provoice.h>
+#include <dsd-neo/protocol/provoice/provoice_const.h>
+#include <stdint.h>
+#include <stdio.h>
+
+enum {
+    PROVOICE_EXPECTED_HEADER_BITS = 64 + 16 + 64,
+    PROVOICE_EXPECTED_BF_PREFIX_BITS = 2 + 16,
+    PROVOICE_EXPECTED_TRAILER_BITS = 2,
+    PROVOICE_EXPECTED_TOTAL_DIBITS = PROVOICE_EXPECTED_HEADER_BITS + (2 * DSD_PROVOICE_FRAME_PAIR_DIBITS)
+                                     + PROVOICE_EXPECTED_BF_PREFIX_BITS + PROVOICE_EXPECTED_TRAILER_BITS,
+};
+
+static int dibit_calls;
+static int mbe_calls;
+static int play_ms_calls;
+static int play_fm_calls;
+static int convert_calls;
+static const uint8_t* convert_base;
+static uint32_t convert_lengths[8];
+static size_t convert_offsets[8];
+static char captured_first_frame[DSD_PROVOICE_IMBE_ROWS][DSD_PROVOICE_IMBE_COLS];
+
+static void
+reset_counters(void) {
+    dibit_calls = 0;
+    mbe_calls = 0;
+    play_ms_calls = 0;
+    play_fm_calls = 0;
+    convert_calls = 0;
+    convert_base = NULL;
+    DSD_MEMSET(convert_lengths, 0, sizeof(convert_lengths));
+    DSD_MEMSET(convert_offsets, 0, sizeof(convert_offsets));
+    DSD_MEMSET(captured_first_frame, 0, sizeof(captured_first_frame));
+}
+
+int
+getDibit(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    int value = dibit_calls & 1;
+    dibit_calls++;
+    return value;
+}
+
+uint64_t
+ConvertBitIntoBytes(const uint8_t* BufferIn, uint32_t BitLength) {
+    assert(BufferIn != NULL);
+    assert(convert_calls < (int)(sizeof(convert_lengths) / sizeof(convert_lengths[0])));
+    if (convert_base == NULL) {
+        convert_base = BufferIn;
+    }
+    convert_offsets[convert_calls] = (size_t)(BufferIn - convert_base);
+    convert_lengths[convert_calls] = BitLength;
+    convert_calls++;
+
+    uint64_t value = 0;
+    for (uint32_t i = 0; i < BitLength && i < 64; i++) {
+        value = (value << 1) | (uint64_t)(BufferIn[i] & 1U);
+    }
+    return value;
+}
+
+void
+processMbeFrame(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], char ambe_fr[4][24], char imbe7100_fr[7][24]) {
+    (void)opts;
+    (void)state;
+    assert(imbe_fr == NULL);
+    assert(ambe_fr == NULL);
+    assert(imbe7100_fr != NULL);
+    if (mbe_calls == 0) {
+        DSD_MEMCPY(captured_first_frame, imbe7100_fr, sizeof(captured_first_frame));
+    }
+    mbe_calls++;
+}
+
+void
+playSynthesizedVoiceMS(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    play_ms_calls++;
+}
+
+void
+playSynthesizedVoiceFM(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    play_fm_calls++;
+}
+
+static void
+assert_convert_offsets_and_lengths(void) {
+    assert(convert_calls == 4);
+    assert(convert_offsets[0] == 0U);
+    assert(convert_lengths[0] == 64U);
+    assert(convert_offsets[1] == 64U);
+    assert(convert_lengths[1] == 16U);
+    assert(convert_offsets[2] == 80U);
+    assert(convert_lengths[2] == 64U);
+    assert(convert_offsets[3] == (size_t)54U * 8U);
+    assert(convert_lengths[3] == 16U);
+}
+
+static void
+assert_first_imbe_frame_uses_interleave_schedule(void) {
+    int first_pair_start = PROVOICE_EXPECTED_HEADER_BITS;
+    assert(captured_first_frame[provoice_interleave_w[0]][provoice_interleave_x[0]] == (char)(first_pair_start & 1));
+    assert(captured_first_frame[provoice_interleave_w[1]][provoice_interleave_x[1]]
+           == (char)((first_pair_start + 1) & 1));
+    assert(captured_first_frame[provoice_interleave_w[5]][provoice_interleave_x[5]]
+           == (char)((first_pair_start + 5) & 1));
+}
+
+static void
+test_process_voice_integer_playback(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.payload = 1;
+    opts.floating_point = 0;
+    opts.p25_trunk = 1;
+    opts.p25_is_tuned = 1;
+    state.ea_mode = 1;
+    state.lasttg = 100344;
+    state.lastsrc = 321;
+    state.edacs_site_id = 7;
+    state.edacs_tuned_lcn = 4;
+    reset_counters();
+
+    processProVoice(&opts, &state);
+
+    assert(dibit_calls == PROVOICE_EXPECTED_TOTAL_DIBITS);
+    assert(mbe_calls == 4);
+    assert(play_ms_calls == 4);
+    assert(play_fm_calls == 0);
+    assert_convert_offsets_and_lengths();
+    assert_first_imbe_frame_uses_interleave_schedule();
+}
+
+static void
+test_process_voice_float_playback(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.floating_point = 1;
+    opts.p25_trunk = 1;
+    opts.p25_is_tuned = 1;
+    state.ea_mode = 0;
+    state.lastsrc = 0x123;
+    state.edacs_site_id = 9;
+    state.edacs_tuned_lcn = 6;
+    reset_counters();
+
+    processProVoice(&opts, &state);
+
+    assert(dibit_calls == PROVOICE_EXPECTED_TOTAL_DIBITS);
+    assert(mbe_calls == 4);
+    assert(play_ms_calls == 0);
+    assert(play_fm_calls == 4);
+    assert_convert_offsets_and_lengths();
+}
+
+int
+main(void) {
+    test_process_voice_integer_playback();
+    test_process_voice_float_playback();
+    printf("PROVOICE_PROCESS: OK\n");
+    return 0;
+}

--- a/tests/protocol/x2tdma/test_x2tdma_data.c
+++ b/tests/protocol/x2tdma/test_x2tdma_data.c
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Focused coverage for the cached X2-TDMA data slot decoder.
+ */
+
+#include "dsd-neo/core/safe_api.h"
+
+#include <assert.h>
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/sync_patterns.h>
+#include <dsd-neo/protocol/x2tdma/x2tdma.h>
+#include <stdio.h>
+#include <string.h>
+
+static int g_skip_calls;
+static int g_skip_total;
+
+static void
+reset_fixture(dsd_opts* opts, dsd_state* state, int dibits[90]) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(dibits, 0, 90U * sizeof(dibits[0]));
+    state->dibit_buf_p = dibits + 90;
+    g_skip_calls = 0;
+    g_skip_total = 0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+skipDibit(dsd_opts* opts, dsd_state* state, int count) {
+    (void)opts;
+    (void)state;
+    g_skip_calls++;
+    g_skip_total += count;
+}
+
+static int
+dibit_for_sync_char(char ch, int inverted) {
+    const int decoded = (ch == '3') ? 2 : 0;
+    return inverted ? (decoded ^ 2) : decoded;
+}
+
+static void
+set_sync(int dibits[90], const char sync[25], int inverted) {
+    for (int i = 0; i < 24; i++) {
+        dibits[66 + i] = dibit_for_sync_char(sync[i], inverted);
+    }
+}
+
+static void
+set_slot_from_cach(int dibits[90], int slot, int inverted) {
+    int decoded = (slot == 0) ? 0 : 2;
+    dibits[2] = inverted ? (decoded ^ 2) : decoded;
+}
+
+static void
+set_bursttype(int dibits[90], const char bursttype[5], int inverted) {
+    int first = ((bursttype[0] - '0') << 1) | (bursttype[1] - '0');
+    int second = ((bursttype[2] - '0') << 1) | (bursttype[3] - '0');
+    dibits[63] = inverted ? (first ^ 2) : first;
+    dibits[64] = inverted ? (second ^ 2) : second;
+}
+
+static void
+assert_common_skip(void) {
+    assert(g_skip_calls == 1);
+    assert(g_skip_total == 120);
+}
+
+static void
+test_data_sync_marks_slot_and_maps_bursttype(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int dibits[90];
+
+    reset_fixture(&opts, &state, dibits);
+    opts.errorbars = 0;
+    set_slot_from_cach(dibits, 0, opts.inverted_x2tdma);
+    set_bursttype(dibits, "0110", opts.inverted_x2tdma);
+    set_sync(dibits, X2TDMA_BS_DATA_SYNC, opts.inverted_x2tdma);
+
+    processX2TDMAdata(&opts, &state);
+
+    assert(state.currentslot == 0);
+    assert(strcmp(state.slot0light, "[slot0]") == 0);
+    assert(strcmp(state.fsubtype, " DATA Header  ") == 0);
+    assert_common_skip();
+}
+
+static void
+test_inverted_mobile_data_marks_slot_one(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int dibits[90];
+
+    reset_fixture(&opts, &state, dibits);
+    opts.inverted_x2tdma = 1;
+    set_slot_from_cach(dibits, 1, opts.inverted_x2tdma);
+    set_bursttype(dibits, "1001", opts.inverted_x2tdma);
+    set_sync(dibits, X2TDMA_MS_DATA_SYNC, opts.inverted_x2tdma);
+
+    processX2TDMAdata(&opts, &state);
+
+    assert(state.currentslot == 1);
+    assert(strcmp(state.slot1light, "[slot1]") == 0);
+    assert(strcmp(state.fsubtype, " Slot idle    ") == 0);
+    assert_common_skip();
+}
+
+static void
+test_unknown_burst_without_data_sync_uses_blank_subtype(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int dibits[90];
+
+    reset_fixture(&opts, &state, dibits);
+    set_slot_from_cach(dibits, 0, opts.inverted_x2tdma);
+    set_bursttype(dibits, "1111", opts.inverted_x2tdma);
+    set_sync(dibits, X2TDMA_BS_VOICE_SYNC, opts.inverted_x2tdma);
+
+    processX2TDMAdata(&opts, &state);
+
+    assert(state.currentslot == 0);
+    assert(state.slot0light[0] == '[');
+    assert(state.slot0light[6] == ']');
+    assert(strcmp(state.fsubtype, "              ") == 0);
+    assert_common_skip();
+}
+
+int
+main(void) {
+    test_data_sync_marks_slot_and_maps_bursttype();
+    test_inverted_mobile_data_marks_slot_one();
+    test_unknown_burst_without_data_sync_uses_blank_subtype();
+    printf("X2TDMA_DATA: OK\n");
+    return 0;
+}

--- a/tests/protocol/x2tdma/test_x2tdma_voice_helpers.c
+++ b/tests/protocol/x2tdma/test_x2tdma_voice_helpers.c
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: ISC
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-signed-char-misuse,cert-str34-c,bugprone-suspicious-include)
+/*
+ * Focused coverage for X2-TDMA voice slot state, signaling, and AMBE dispatch.
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/sync_patterns.h>
+#include <dsd-neo/core/vocoder.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "x2tdma_frame.h"
+
+static int g_get_queue[512];
+static int g_get_len;
+static int g_get_pos;
+static int g_skip_calls;
+static int g_skip_total;
+static int g_soft_calls;
+static int g_soft_first_bit[8];
+
+static void
+reset_stubs(void) {
+    DSD_MEMSET(g_get_queue, 0, sizeof(g_get_queue));
+    DSD_MEMSET(g_soft_first_bit, 0, sizeof(g_soft_first_bit));
+    g_get_len = 0;
+    g_get_pos = 0;
+    g_skip_calls = 0;
+    g_skip_total = 0;
+    g_soft_calls = 0;
+}
+
+static int
+dibit_for_sync_char(char ch, int inverted) {
+    const int decoded = (ch == '3') ? 2 : 0;
+    return inverted ? (decoded ^ 2) : decoded;
+}
+
+static void
+append_dibit(int dibit) {
+    assert(g_get_len < (int)(sizeof(g_get_queue) / sizeof(g_get_queue[0])));
+    g_get_queue[g_get_len++] = dibit;
+}
+
+static void
+append_zeros(int count) {
+    for (int i = 0; i < count; i++) {
+        append_dibit(0);
+    }
+}
+
+static void
+append_sync(const char sync[25], int inverted) {
+    for (int i = 0; i < 24; i++) {
+        append_dibit(dibit_for_sync_char(sync[i], inverted));
+    }
+}
+
+int
+getDibit(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    assert(g_get_pos < g_get_len);
+    return g_get_queue[g_get_pos++];
+}
+
+void
+skipDibit(dsd_opts* opts, dsd_state* state, int count) {
+    (void)opts;
+    (void)state;
+    g_skip_calls++;
+    g_skip_total += count;
+}
+
+void
+soft_mbe(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], char ambe_fr[4][24], char imbe7100_fr[7][24]) {
+    (void)opts;
+    (void)state;
+    (void)imbe_fr;
+    (void)imbe7100_fr;
+    assert(ambe_fr != NULL);
+    assert(g_soft_calls < (int)(sizeof(g_soft_first_bit) / sizeof(g_soft_first_bit[0])));
+    g_soft_first_bit[g_soft_calls++] = ambe_fr[0][0];
+}
+
+#include "../../../src/protocol/x2tdma/x2tdma_voice.c"
+
+static void
+set_syncdata_from_sync(x2tdma_voice_ctx* ctx, const char sync[25]) {
+    for (int i = 0; i < 24; i++) {
+        ctx->syncdata[i] = dibit_for_sync_char(sync[i], 0);
+        ctx->sync[i] = sync[i];
+    }
+    ctx->sync[24] = '\0';
+    ctx->syncdata[24] = '\0';
+}
+
+static void
+set_slot_from_cach(int dibits[144], int slot, int inverted) {
+    int decoded = (slot == 0) ? 0 : 2;
+    dibits[54 + 2] = inverted ? (decoded ^ 2) : decoded;
+}
+
+static void
+set_slot_sync(int dibits[144], const char sync[25], int inverted) {
+    for (int i = 0; i < 24; i++) {
+        dibits[54 + 12 + 36 + 18 + i] = dibit_for_sync_char(sync[i], inverted);
+    }
+}
+
+static void
+set_slot_ambe_seed(int dibits[144]) {
+    for (int i = 0; i < 36; i++) {
+        dibits[54 + 12 + i] = (i & 1) ? 1 : 2;
+    }
+    for (int i = 0; i < 18; i++) {
+        dibits[54 + 12 + 36 + i] = (i & 1) ? 3 : 0;
+    }
+}
+
+static void
+prepare_stream_after_slot(const char next_sync[25], int inverted) {
+    append_zeros(18 + 36);
+    append_zeros(12);
+    append_sync(next_sync, inverted);
+}
+
+static void
+test_slot_light_and_mute_helpers(void) {
+    static dsd_state state;
+    x2tdma_voice_ctx ctx;
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+
+    x2tdma_update_currentslot_from_cach(&state, 0);
+    assert(state.currentslot == 0);
+    assert(state.slot0light[0] == '[');
+    assert(state.slot0light[6] == ']');
+    assert(state.slot1light[0] == ' ');
+    assert(state.slot1light[6] == ' ');
+
+    x2tdma_update_currentslot_from_cach(&state, 2);
+    assert(state.currentslot == 1);
+    assert(state.slot1light[0] == '[');
+    assert(state.slot1light[6] == ']');
+    assert(state.slot0light[0] == ' ');
+    assert(state.slot0light[6] == ' ');
+
+    set_syncdata_from_sync(&ctx, X2TDMA_BS_DATA_SYNC);
+    x2tdma_update_mute_and_lights(&ctx, &state);
+    assert(ctx.mutecurrentslot == 1);
+    assert(strcmp(state.slot1light, "[slot1]") == 0);
+
+    set_syncdata_from_sync(&ctx, X2TDMA_BS_VOICE_SYNC);
+    x2tdma_update_mute_and_lights(&ctx, &state);
+    assert(ctx.mutecurrentslot == 0);
+    assert(strcmp(state.slot1light, "[SLOT1]") == 0);
+
+    ctx.msMode = 0;
+    set_syncdata_from_sync(&ctx, X2TDMA_MS_VOICE_SYNC);
+    x2tdma_update_ms_mode(&ctx);
+    assert(ctx.msMode == 1);
+}
+
+static void
+test_signaling_extracts_lc_mi_and_encryption_fields(void) {
+    static dsd_state state;
+    x2tdma_voice_ctx ctx;
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    DSD_MEMSET(ctx.lcformat, '_', 8);
+    DSD_MEMSET(ctx.mfid, '_', 8);
+    DSD_MEMSET(ctx.lcinfo, '_', 56);
+    dsd_x2tdma_init_mi_placeholder(ctx.mi);
+    set_syncdata_from_sync(&ctx, X2TDMA_BS_VOICE_SYNC);
+    ctx.syncdata[1] = 0;
+    ctx.syncdata[2] = 0;
+
+    ctx.eeei = 0;
+    ctx.aiei = 0;
+    x2tdma_decode_signal_j1(&ctx);
+    x2tdma_decode_signal_j2(&ctx);
+    x2tdma_decode_signal_j4(&ctx);
+    assert(ctx.lcformat[0] == '1');
+    assert(ctx.lcformat[7] == '1');
+    assert(ctx.mfid[0] == '1');
+    assert(ctx.lcinfo[55] == '0');
+    assert(ctx.mi[0] == '_');
+
+    dsd_x2tdma_init_mi_placeholder(ctx.mi);
+    ctx.syncdata[1] = 1;
+    ctx.syncdata[2] = 0;
+    x2tdma_decode_signal_j1(&ctx);
+    x2tdma_decode_signal_j2(&ctx);
+    x2tdma_decode_signal_j4(&ctx);
+    assert(ctx.mi[0] == '1');
+    assert(ctx.mi[71] == '0');
+
+    ctx.syncdata[1] = 0;
+    x2tdma_decode_signal_j3(&ctx, &state);
+    assert(strcmp(state.algid, "10001010") == 0);
+    assert(strcmp(state.keyid, "1000100010101000") == 0);
+
+    ctx.syncdata[1] = 1;
+    x2tdma_decode_signal_j3(&ctx, &state);
+    assert(strcmp(state.algid, "________") == 0);
+    assert(strcmp(state.keyid, "________________") == 0);
+}
+
+static void
+test_voice_frame_dispatch_gates_first_frame_and_mute(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    x2tdma_voice_ctx ctx;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    reset_stubs();
+    append_zeros(18 + 36);
+
+    state.firstframe = 1;
+    ctx.mutecurrentslot = 0;
+    x2tdma_process_voice_frames(&opts, &state, &ctx);
+    assert(state.firstframe == 0);
+    assert(g_soft_calls == 1);
+    assert(g_get_pos == 54);
+
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    reset_stubs();
+    append_zeros(18 + 36);
+    state.firstframe = 0;
+    ctx.mutecurrentslot = 0;
+    x2tdma_process_voice_frames(&opts, &state, &ctx);
+    assert(g_soft_calls == 3);
+    assert(g_get_pos == 54);
+
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    reset_stubs();
+    append_zeros(18 + 36);
+    ctx.mutecurrentslot = 1;
+    x2tdma_process_voice_frames(&opts, &state, &ctx);
+    assert(g_soft_calls == 0);
+    assert(g_get_pos == 54);
+}
+
+static void
+test_slot_iteration_voice_and_data_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    x2tdma_voice_ctx ctx;
+    int dibits[144];
+    int* dibit_p;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    DSD_MEMSET(dibits, 0, sizeof(dibits));
+    reset_stubs();
+    set_slot_from_cach(dibits, 0, opts.inverted_x2tdma);
+    set_slot_ambe_seed(dibits);
+    set_slot_sync(dibits, X2TDMA_BS_VOICE_SYNC, opts.inverted_x2tdma);
+    prepare_stream_after_slot(X2TDMA_BS_DATA_SYNC, opts.inverted_x2tdma);
+    dibit_p = dibits;
+
+    x2tdma_process_slot_iteration(&opts, &state, &ctx, 0, &dibit_p);
+    assert(dibit_p == dibits + 144);
+    assert(state.currentslot == 0);
+    assert(strcmp(state.slot0light, "[SLOT0]") == 0);
+    assert(strcmp(state.slot1light, " slot1 ") == 0);
+    assert(ctx.mutecurrentslot == 0);
+    assert(g_soft_calls == 3);
+    assert(g_skip_calls == 1);
+    assert(g_skip_total == 54);
+    assert(g_get_pos == g_get_len);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    DSD_MEMSET(dibits, 0, sizeof(dibits));
+    reset_stubs();
+    set_slot_from_cach(dibits, 1, opts.inverted_x2tdma);
+    set_slot_sync(dibits, X2TDMA_MS_DATA_SYNC, opts.inverted_x2tdma);
+    prepare_stream_after_slot(X2TDMA_BS_VOICE_SYNC, opts.inverted_x2tdma);
+    dibit_p = dibits;
+
+    x2tdma_process_slot_iteration(&opts, &state, &ctx, 0, &dibit_p);
+    assert(state.currentslot == 1);
+    assert(strcmp(state.slot1light, "[slot1]") == 0);
+    assert(strcmp(state.slot0light, " slot0 ") == 0);
+    assert(ctx.mutecurrentslot == 1);
+    assert(ctx.msMode == 1);
+    assert(g_soft_calls == 0);
+    assert(g_skip_calls == 1);
+    assert(g_skip_total == 54);
+}
+
+int
+main(void) {
+    test_slot_light_and_mute_helpers();
+    test_signaling_extracts_lc_mi_and_encryption_fields();
+    test_voice_frame_dispatch_gates_first_frame_and_mute();
+    test_slot_iteration_voice_and_data_state();
+    printf("X2TDMA_VOICE_HELPERS: OK\n");
+    return 0;
+}
+
+// NOLINTEND(bugprone-signed-char-misuse,cert-str34-c,bugprone-suspicious-include)

--- a/tests/protocol/ysf/test_ysf_dch_decode.c
+++ b/tests/protocol/ysf/test_ysf_dch_decode.c
@@ -1,0 +1,778 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,misc-use-internal-linkage)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/fec/block_codes.h>
+#include <dsd-neo/protocol/ysf/ysf.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+typedef struct mbe_parms mbe_parms;
+typedef struct mbe_process_result mbe_process_result;
+
+uint64_t ConvertBitIntoBytes(const uint8_t* bits, uint32_t n);         // NOLINT(misc-use-internal-linkage)
+void LFSRN(const char* buffer_in, char* buffer_out, dsd_state* state); // NOLINT(misc-use-internal-linkage)
+uint16_t ComputeCrcCCITT16d(const uint8_t* buf, uint32_t len);         // NOLINT(misc-use-internal-linkage)
+int Connect(char* hostname, int portno);                               // NOLINT(misc-use-internal-linkage)
+int __wrap_getDibit(dsd_opts* opts, dsd_state* state);                 // NOLINT(misc-use-internal-linkage)
+void __wrap_processMbeFrame(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], char ambe_fr[4][24],
+                            char imbe7100_fr[7][24]); // NOLINT(misc-use-internal-linkage)
+int __wrap_dsd_mbe_process_ambe2450_dataf(float* aout_buf, int* errs, int* errs2, char* err_str, size_t err_str_size,
+                                          const char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp,
+                                          mbe_parms* prev_mp_enhanced,
+                                          mbe_process_result* result); // NOLINT(misc-use-internal-linkage)
+
+static uint8_t g_dibit_stream[512];
+static size_t g_dibit_stream_len;
+static size_t g_dibit_stream_pos;
+static int g_mbe_call_count;
+static int g_process_mbe_call_count;
+static int g_process_mbe_synctype[5];
+static int g_process_mbe_ambe_nonnull[5];
+static int g_mbe_inbound_errs2[5];
+
+int
+// NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+__wrap_getDibit(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    if (g_dibit_stream_pos >= g_dibit_stream_len) {
+        return 0;
+    }
+    return g_dibit_stream[g_dibit_stream_pos++];
+}
+
+void
+// NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+__wrap_processMbeFrame(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], char ambe_fr[4][24],
+                       char imbe7100_fr[7][24]) {
+    (void)opts;
+    (void)imbe_fr;
+    (void)imbe7100_fr;
+
+    assert(g_process_mbe_call_count < 5);
+    g_process_mbe_synctype[g_process_mbe_call_count] = state->synctype;
+    g_process_mbe_ambe_nonnull[g_process_mbe_call_count] = (ambe_fr != NULL);
+    g_process_mbe_call_count++;
+}
+
+static int
+parity32(uint32_t value) {
+    value ^= value >> 16;
+    value ^= value >> 8;
+    value ^= value >> 4;
+    value &= 0xFU;
+    return (0x6996U >> value) & 1U;
+}
+
+static void
+encode_k5_bits_to_dibits(const uint8_t* bits, size_t bit_count, uint8_t* dibits) {
+    uint32_t reg = 0U;
+
+    for (size_t i = 0; i < bit_count; i++) {
+        reg = (reg << 1U) | (uint32_t)(bits[i] & 1U);
+        uint8_t b0 = (uint8_t)parity32(reg & 0x19U);
+        uint8_t b1 = (uint8_t)parity32(reg & 0x17U);
+        dibits[i] = (uint8_t)((b0 << 1U) | b1);
+    }
+}
+
+uint64_t
+ConvertBitIntoBytes(const uint8_t* bits, uint32_t n) {
+    uint64_t value = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        value = (value << 1U) | (uint64_t)(bits[i] & 1U);
+    }
+    return value;
+}
+
+void
+LFSRN(const char* buffer_in, char* buffer_out, dsd_state* state) {
+    (void)buffer_in;
+    (void)buffer_out;
+    (void)state;
+}
+
+uint16_t
+ComputeCrcCCITT16d(const uint8_t* buf, uint32_t len) {
+    (void)buf;
+    (void)len;
+    return 0;
+}
+
+int
+Connect(char* hostname, int portno) {
+    (void)hostname;
+    (void)portno;
+    return -1;
+}
+
+int
+// NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+__wrap_dsd_mbe_process_ambe2450_dataf(float* aout_buf, int* errs, int* errs2, char* err_str, size_t err_str_size,
+                                      const char ambe_d[49], mbe_parms* cur_mp, mbe_parms* prev_mp,
+                                      mbe_parms* prev_mp_enhanced, mbe_process_result* result) {
+    (void)ambe_d;
+    (void)cur_mp;
+    (void)prev_mp;
+    (void)prev_mp_enhanced;
+    (void)result;
+
+    assert(g_mbe_call_count < 5);
+    g_mbe_inbound_errs2[g_mbe_call_count] = *errs2;
+    if (errs != NULL) {
+        *errs = 4 + g_mbe_call_count;
+    }
+    if (err_str != NULL && err_str_size > 0U) {
+        DSD_SNPRINTF(err_str, err_str_size, "stub-%d", g_mbe_call_count);
+    }
+    for (size_t i = 0; i < 160U; i++) {
+        aout_buf[i] = (float)(g_mbe_call_count + 1);
+    }
+    g_mbe_call_count++;
+    return 0;
+}
+
+static void
+pack_bytes_to_bits(const char* bytes, size_t byte_count, uint8_t* bits) {
+    for (size_t i = 0; i < byte_count; i++) {
+        uint8_t value = (uint8_t)bytes[i];
+        for (size_t bit = 0; bit < 8U; bit++) {
+            bits[(i * 8U) + bit] = (uint8_t)((value >> (7U - bit)) & 1U);
+        }
+    }
+}
+
+static void
+set_bits_msb(uint8_t* bits, size_t offset, size_t width, uint32_t value) {
+    for (size_t i = 0; i < width; i++) {
+        bits[offset + i] = (uint8_t)((value >> (width - 1U - i)) & 1U);
+    }
+}
+
+static void
+append_ysf_crc(uint8_t fich_bits[48]) {
+    for (uint32_t crc = 0; crc <= 0xFFFFU; crc++) {
+        for (size_t bit = 0; bit < 16U; bit++) {
+            fich_bits[32U + bit] = (uint8_t)((crc >> (15U - bit)) & 1U);
+        }
+        if (dsd_neo_ysf_test_crc16(fich_bits, 48) == 0U) {
+            return;
+        }
+    }
+
+    assert(!"reachable CRC value not found");
+}
+
+static uint8_t
+test_ysf_pn95_bit(size_t bit_index) {
+    uint16_t lfsr = 0x1C9U;
+    bit_index %= 512U;
+
+    for (size_t i = 0; i <= bit_index; i++) {
+        uint8_t bit = (uint8_t)(lfsr & 1U);
+        uint16_t feedback = (uint16_t)(((lfsr >> 4U) ^ lfsr) & 1U);
+        lfsr = (uint16_t)((lfsr >> 1U) | (feedback << 8U));
+        if (i == bit_index) {
+            return bit;
+        }
+    }
+
+    return 0U;
+}
+
+static void
+append_crc_to_payload(uint8_t* bits, size_t total_bits) {
+    assert(total_bits >= 16U);
+
+    for (uint32_t crc = 0; crc <= 0xFFFFU; crc++) {
+        for (size_t bit = 0; bit < 16U; bit++) {
+            bits[(total_bits - 16U) + bit] = (uint8_t)((crc >> (15U - bit)) & 1U);
+        }
+        if (dsd_neo_ysf_test_crc16(bits, (int)total_bits) == 0U) {
+            return;
+        }
+    }
+
+    assert(!"reachable DCH CRC value not found");
+}
+
+static void
+encode_dch_payload_to_input(const char* payload, size_t byte_count, uint8_t* input, size_t total_bits, size_t columns,
+                            int corrupt_crc) {
+    uint8_t bits[180];
+    uint8_t dibits[180];
+    size_t payload_bits = byte_count * 8U;
+    size_t interleaved_slots = columns * 20U;
+
+    assert(total_bits <= sizeof(bits));
+    assert(total_bits <= sizeof(dibits));
+    assert(total_bits <= interleaved_slots);
+    assert(interleaved_slots <= sizeof(dibits));
+
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    DSD_MEMSET(dibits, 0, sizeof(dibits));
+    DSD_MEMSET(input, 0, interleaved_slots);
+    pack_bytes_to_bits(payload, byte_count, bits);
+
+    for (size_t i = 0; i < payload_bits; i++) {
+        bits[i] ^= test_ysf_pn95_bit(i);
+    }
+    append_crc_to_payload(bits, total_bits);
+    if (corrupt_crc) {
+        bits[3] ^= 1U;
+    }
+
+    encode_k5_bits_to_dibits(bits, interleaved_slots, dibits);
+    for (size_t i = 0; i < 20U; i++) {
+        for (size_t j = 0; j < columns; j++) {
+            input[i + (j * 20U)] = dibits[j + (i * columns)];
+        }
+    }
+}
+
+static void
+make_fich_bits(uint8_t fich_bits[48]) {
+    DSD_MEMSET(fich_bits, 0, 48U);
+    set_bits_msb(fich_bits, 0U, 2U, 1U);   // fi
+    set_bits_msb(fich_bits, 4U, 2U, 3U);   // cm
+    set_bits_msb(fich_bits, 6U, 2U, 2U);   // bn
+    set_bits_msb(fich_bits, 8U, 2U, 1U);   // bt
+    set_bits_msb(fich_bits, 10U, 3U, 5U);  // fn
+    set_bits_msb(fich_bits, 13U, 3U, 6U);  // ft
+    set_bits_msb(fich_bits, 18U, 3U, 4U);  // mr
+    set_bits_msb(fich_bits, 21U, 1U, 1U);  // vp
+    set_bits_msb(fich_bits, 22U, 2U, 2U);  // dt
+    set_bits_msb(fich_bits, 24U, 1U, 1U);  // st
+    set_bits_msb(fich_bits, 25U, 7U, 42U); // sc
+    append_ysf_crc(fich_bits);
+}
+
+static void
+make_fich_bits_for_full_rate_data(uint8_t fich_bits[48]) {
+    DSD_MEMSET(fich_bits, 0, 48U);
+    set_bits_msb(fich_bits, 0U, 2U, 0U);  // fi: header communication channel
+    set_bits_msb(fich_bits, 4U, 2U, 0U);  // cm: group/CQ
+    set_bits_msb(fich_bits, 6U, 2U, 0U);  // bn
+    set_bits_msb(fich_bits, 8U, 2U, 1U);  // bt
+    set_bits_msb(fich_bits, 10U, 3U, 0U); // fn
+    set_bits_msb(fich_bits, 13U, 3U, 1U); // ft
+    set_bits_msb(fich_bits, 18U, 3U, 1U); // mr
+    set_bits_msb(fich_bits, 21U, 1U, 0U); // vp
+    set_bits_msb(fich_bits, 22U, 2U, 1U); // dt: full-rate data
+    set_bits_msb(fich_bits, 24U, 1U, 0U); // st
+    set_bits_msb(fich_bits, 25U, 7U, 0U); // sc
+    append_ysf_crc(fich_bits);
+}
+
+static void
+make_fich_bits_for_vd_type1(uint8_t fich_bits[48]) {
+    DSD_MEMSET(fich_bits, 0, 48U);
+    set_bits_msb(fich_bits, 0U, 2U, 1U);  // fi: V/D mode
+    set_bits_msb(fich_bits, 4U, 2U, 0U);  // cm: group/CQ
+    set_bits_msb(fich_bits, 6U, 2U, 0U);  // bn
+    set_bits_msb(fich_bits, 8U, 2U, 0U);  // bt
+    set_bits_msb(fich_bits, 10U, 3U, 0U); // fn: destination/source
+    set_bits_msb(fich_bits, 13U, 3U, 0U); // ft
+    set_bits_msb(fich_bits, 18U, 3U, 1U); // mr
+    set_bits_msb(fich_bits, 21U, 1U, 0U); // vp
+    set_bits_msb(fich_bits, 22U, 2U, 0U); // dt: V/D Type 1
+    set_bits_msb(fich_bits, 24U, 1U, 0U); // st
+    set_bits_msb(fich_bits, 25U, 7U, 0U); // sc
+    append_ysf_crc(fich_bits);
+}
+
+static void
+make_fich_bits_for_vd_type2(uint8_t fich_bits[48]) {
+    DSD_MEMSET(fich_bits, 0, 48U);
+    set_bits_msb(fich_bits, 0U, 2U, 1U);  // fi: V/D mode
+    set_bits_msb(fich_bits, 4U, 2U, 0U);  // cm: group/CQ
+    set_bits_msb(fich_bits, 6U, 2U, 0U);  // bn
+    set_bits_msb(fich_bits, 8U, 2U, 0U);  // bt
+    set_bits_msb(fich_bits, 10U, 3U, 1U); // fn: source
+    set_bits_msb(fich_bits, 13U, 3U, 5U); // ft
+    set_bits_msb(fich_bits, 18U, 3U, 1U); // mr
+    set_bits_msb(fich_bits, 21U, 1U, 0U); // vp
+    set_bits_msb(fich_bits, 22U, 2U, 2U); // dt: V/D Type 2
+    set_bits_msb(fich_bits, 24U, 1U, 0U); // st
+    set_bits_msb(fich_bits, 25U, 7U, 0U); // sc
+    append_ysf_crc(fich_bits);
+}
+
+static void
+encode_fich_input(const uint8_t fich_bits[48], int corrupt_payload_crc, int corrupt_golay, uint8_t input[100]) {
+    uint8_t encoded_words[96];
+    uint8_t source_bits[48];
+    uint8_t dibits[100];
+
+    for (size_t i = 0; i < 100U; i++) {
+        input[i] = 0U;
+        dibits[i] = 0U;
+    }
+    DSD_MEMCPY(source_bits, fich_bits, 48U);
+    if (corrupt_payload_crc) {
+        source_bits[7] ^= 1U;
+    }
+
+    for (size_t word = 0; word < 4U; word++) {
+        uint8_t msg[12];
+        for (size_t bit = 0; bit < 12U; bit++) {
+            msg[bit] = source_bits[(word * 12U) + bit];
+        }
+        Golay_24_12_encode(msg, &encoded_words[word * 24U]);
+    }
+
+    if (corrupt_golay) {
+        encoded_words[12] ^= 1U;
+        encoded_words[13] ^= 1U;
+        encoded_words[14] ^= 1U;
+        encoded_words[15] ^= 1U;
+        encoded_words[16] ^= 1U;
+    }
+
+    encode_k5_bits_to_dibits(encoded_words, 96U, dibits);
+    for (size_t i = 0; i < 20U; i++) {
+        for (size_t j = 0; j < 5U; j++) {
+            input[i + (j * 20U)] = dibits[j + (i * 5U)];
+        }
+    }
+}
+
+static void
+append_dibits_to_stream(const uint8_t* dibits, size_t count) {
+    assert(g_dibit_stream_len + count <= sizeof(g_dibit_stream));
+    DSD_MEMCPY(&g_dibit_stream[g_dibit_stream_len], dibits, count);
+    g_dibit_stream_len += count;
+}
+
+static void
+append_interleaved_full_rate_dch_blocks(const uint8_t dch0[180], const uint8_t dch1[180]) {
+    for (size_t block = 0; block < 5U; block++) {
+        append_dibits_to_stream(&dch0[block * 36U], 36U);
+        append_dibits_to_stream(&dch1[block * 36U], 36U);
+    }
+}
+
+static void
+append_vd_type1_blocks(const uint8_t dch[180], uint8_t voice_seed) {
+    uint8_t voice[36];
+
+    for (size_t block = 0; block < 5U; block++) {
+        append_dibits_to_stream(&dch[block * 36U], 36U);
+        for (size_t i = 0; i < sizeof(voice); i++) {
+            voice[i] = (uint8_t)((voice_seed + block + i) & 3U);
+        }
+        append_dibits_to_stream(voice, sizeof(voice));
+    }
+}
+
+static void
+append_type2_vech_dibits(uint8_t error_bit) {
+    static const uint8_t vd2_interleave[104] = {
+        0,  26, 52, 78, 1,  27, 53, 79, 2,  28, 54, 80, 3,  29,  55, 81, 4,  30,  56, 82, 5,  31,  57, 83, 6,  32,
+        58, 84, 7,  33, 59, 85, 8,  34, 60, 86, 9,  35, 61, 87,  10, 36, 62, 88,  11, 37, 63, 89,  12, 38, 64, 90,
+        13, 39, 65, 91, 14, 40, 66, 92, 15, 41, 67, 93, 16, 42,  68, 94, 17, 43,  69, 95, 18, 44,  70, 96, 19, 45,
+        71, 97, 20, 46, 72, 98, 21, 47, 73, 99, 22, 48, 74, 100, 23, 49, 75, 101, 24, 50, 76, 102, 25, 51, 77, 103};
+
+    for (size_t i = 0; i < 52U; i++) {
+        uint8_t msb_index = vd2_interleave[i * 2U];
+        uint8_t lsb_index = vd2_interleave[(i * 2U) + 1U];
+        uint8_t desired_msb = 0U;
+        uint8_t desired_lsb = (lsb_index == 103U) ? error_bit : 0U;
+        uint8_t source_msb = desired_msb ^ test_ysf_pn95_bit(msb_index);
+        uint8_t source_lsb = desired_lsb ^ test_ysf_pn95_bit(lsb_index);
+        uint8_t dibit = (uint8_t)((source_msb << 1U) | source_lsb);
+        append_dibits_to_stream(&dibit, 1U);
+    }
+}
+
+static void
+test_dch_csd1_tracks_destination_and_source(void) {
+    static dsd_state state;
+    uint8_t bits[160];
+    const char payload[] = "DESTCALL01SRCCALL02";
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    pack_bytes_to_bits(payload, 20U, bits);
+
+    dsd_neo_ysf_test_decode_dch(&state, 0, 0, 0, 0, 0, bits);
+
+    assert(strcmp(state.ysf_tgt, "DESTCALL01") == 0);
+    assert(strcmp(state.ysf_src, "SRCCALL02") == 0);
+}
+
+static void
+test_dch_rid_mode_preserves_target_and_source_state(void) {
+    static dsd_state state;
+    uint8_t bits[160];
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    pack_bytes_to_bits("DSTR1SRCR2FULLSRC003", 20U, bits);
+
+    dsd_neo_ysf_test_decode_dch(&state, 0, 0, 0, 0, 1, bits);
+
+    assert(strcmp(state.ysf_tgt, "DSTR1SRCR2") == 0);
+    assert(strcmp(state.ysf_src, "FULLSRC003") == 0);
+
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    pack_bytes_to_bits("RID01RID02", 10U, bits);
+
+    dsd_neo_ysf_test_decode_dch2(&state, 0, 0, 0, 5, 1, bits);
+
+    assert(strcmp(state.ysf_tgt, "RID01RID02") == 0);
+    assert(strcmp(state.ysf_src, "FULLSRC003") == 0);
+}
+
+static void
+test_dch_csd2_tracks_uplink_and_downlink(void) {
+    static dsd_state state;
+    uint8_t bits[160];
+    const char payload[] = "UPLINK0001DOWNLINK02";
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    pack_bytes_to_bits(payload, 20U, bits);
+
+    dsd_neo_ysf_test_decode_dch(&state, 1, 0, 0, 0, 0, bits);
+
+    assert(strcmp(state.ysf_upl, "UPLINK0001") == 0);
+    assert(strcmp(state.ysf_dnl, "DOWNLINK02") == 0);
+}
+
+static void
+test_dch_text_clears_and_sanitizes_segments(void) {
+    static dsd_state state;
+    uint8_t bits[160];
+    char payload[20] = {'A', '\n', 0x19, 0x7F, 'Z', ' ', '1', '2', '3', '4',
+                        'b', 'a',  'd',  0x01, 'x', 'y', 'z', '!', '?', '~'};
+
+    DSD_MEMSET(&state, 0x5A, sizeof(state));
+    state.event_history_s = NULL;
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    pack_bytes_to_bits(payload, sizeof(payload), bits);
+
+    dsd_neo_ysf_test_decode_dch(&state, 2, 0, 0, 1, 0, bits);
+
+    assert(state.ysf_txt[0][0] == 'A');
+    assert(state.ysf_txt[0][1] == ' ');
+    assert(state.ysf_txt[0][2] == ' ');
+    assert(state.ysf_txt[0][3] == ' ');
+    assert(state.ysf_txt[0][4] == 'Z');
+    assert(state.ysf_txt[0][13] == ' ');
+    assert(state.ysf_txt[0][19] == '~');
+}
+
+static void
+test_dch2_tracks_destination_source_links_and_remarks(void) {
+    static dsd_state state;
+    uint8_t bits[80];
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    pack_bytes_to_bits("DEST2CALL3", 10U, bits);
+    dsd_neo_ysf_test_decode_dch2(&state, 0, 0, 0, 5, 0, bits);
+    assert(strcmp(state.ysf_tgt, "DEST2CALL3") == 0);
+
+    pack_bytes_to_bits("SRC2CALL45", 10U, bits);
+    dsd_neo_ysf_test_decode_dch2(&state, 0, 0, 1, 5, 0, bits);
+    assert(strcmp(state.ysf_src, "SRC2CALL45") == 0);
+
+    pack_bytes_to_bits("UP2CALL678", 10U, bits);
+    dsd_neo_ysf_test_decode_dch2(&state, 0, 0, 2, 5, 0, bits);
+    assert(strcmp(state.ysf_upl, "UP2CALL678") == 0);
+
+    pack_bytes_to_bits("DN2CALL901", 10U, bits);
+    dsd_neo_ysf_test_decode_dch2(&state, 0, 0, 3, 5, 0, bits);
+    assert(strcmp(state.ysf_dnl, "DN2CALL901") == 0);
+
+    pack_bytes_to_bits("RM1AARM2BB", 10U, bits);
+    dsd_neo_ysf_test_decode_dch2(&state, 0, 0, 4, 5, 0, bits);
+    assert(strcmp(state.ysf_rm1, "RM1AA") == 0);
+    assert(strcmp(state.ysf_rm2, "RM2BB") == 0);
+
+    pack_bytes_to_bits("RM3CCRM4DD", 10U, bits);
+    dsd_neo_ysf_test_decode_dch2(&state, 0, 0, 5, 5, 0, bits);
+    assert(strcmp(state.ysf_rm3, "RM3CC") == 0);
+    assert(strcmp(state.ysf_rm4, "RM4DD") == 0);
+}
+
+static void
+test_ysf_crc16_known_values(void) {
+    uint8_t bits[48];
+
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    assert(dsd_neo_ysf_test_crc16(bits, 0) == 0xFFFFU);
+    assert(dsd_neo_ysf_test_crc16(bits, 48) == 0xFFFFU);
+
+    for (size_t i = 0; i < sizeof(bits); i++) {
+        bits[i] = (uint8_t)((i * 3U) & 1U);
+    }
+    assert(dsd_neo_ysf_test_crc16(bits, 48) == 0x2DF0U);
+}
+
+static void
+test_ysf_fich_conv_decodes_fields_and_failures(void) {
+    uint8_t fich_bits[48];
+    uint8_t input[100];
+    uint8_t dest[32];
+    uint32_t v_error = UINT32_MAX;
+
+    InitAllFecFunction();
+    make_fich_bits(fich_bits);
+
+    encode_fich_input(fich_bits, 0, 0, input);
+    DSD_MEMSET(dest, 0xA5, sizeof(dest));
+    assert(dsd_neo_ysf_test_conv_fich(input, dest, &v_error) == 0);
+    assert(v_error != UINT32_MAX);
+    assert(memcmp(dest, fich_bits, 32U) == 0);
+    assert(ConvertBitIntoBytes(&dest[0], 2U) == 1U);
+    assert(ConvertBitIntoBytes(&dest[4], 2U) == 3U);
+    assert(ConvertBitIntoBytes(&dest[6], 2U) == 2U);
+    assert(ConvertBitIntoBytes(&dest[8], 2U) == 1U);
+    assert(ConvertBitIntoBytes(&dest[10], 3U) == 5U);
+    assert(ConvertBitIntoBytes(&dest[13], 3U) == 6U);
+    assert(ConvertBitIntoBytes(&dest[18], 3U) == 4U);
+    assert(dest[21] == 1U);
+    assert(ConvertBitIntoBytes(&dest[22], 2U) == 2U);
+    assert(dest[24] == 1U);
+    assert(ConvertBitIntoBytes(&dest[25], 7U) == 42U);
+
+    encode_fich_input(fich_bits, 1, 0, input);
+    assert(dsd_neo_ysf_test_conv_fich(input, dest, NULL) == -2);
+
+    encode_fich_input(fich_bits, 0, 1, input);
+    assert(dsd_neo_ysf_test_conv_fich(input, dest, NULL) != 0);
+}
+
+static void
+test_ysf_type2_ambe_majority_and_tail_bits(void) {
+    uint8_t vech_bits[104];
+    uint8_t temp[512];
+    char ambe_d[49];
+
+    DSD_MEMSET(vech_bits, 0, sizeof(vech_bits));
+    DSD_MEMSET(temp, 0xA5, sizeof(temp));
+    DSD_MEMSET(ambe_d, 0x5A, sizeof(ambe_d));
+
+    vech_bits[0] = 1U;
+    vech_bits[1] = 1U;
+    vech_bits[2] = 0U;
+    vech_bits[3] = 1U;
+    vech_bits[4] = 0U;
+    vech_bits[5] = 0U;
+    for (size_t i = 0; i < 22U; i++) {
+        vech_bits[81U + i] = (uint8_t)(i & 1U);
+    }
+
+    dsd_neo_ysf_test_build_type2_ambe(vech_bits, temp, ambe_d);
+
+    assert(temp[0] == 1U);
+    assert(temp[1] == 0U);
+    for (size_t i = 0; i < 22U; i++) {
+        assert(temp[27U + i] == (uint8_t)(i & 1U));
+    }
+    for (size_t i = 0; i < 49U; i++) {
+        assert((uint8_t)ambe_d[i] == temp[i]);
+    }
+    assert(temp[49] == 0U);
+}
+
+static void
+test_ysf_conv_dch_decodes_valid_csd1_and_rejects_crc_error(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t input[180];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    encode_dch_payload_to_input("DCHDST0001DCHSRC0002", 20U, input, 176U, 9U, 0);
+
+    assert(dsd_neo_ysf_test_conv_dch(&opts, &state, 0, 0, 0, 0, 0, input) == 0);
+    assert(strcmp(state.ysf_tgt, "DCHDST0001") == 0);
+    assert(strcmp(state.ysf_src, "DCHSRC0002") == 0);
+
+    DSD_SNPRINTF(state.ysf_tgt, sizeof(state.ysf_tgt), "%s", "UNCHANGED");
+    DSD_SNPRINTF(state.ysf_src, sizeof(state.ysf_src), "%s", "UNCHANGED");
+    encode_dch_payload_to_input("BADDST0001BADSRC0002", 20U, input, 176U, 9U, 1);
+
+    assert(dsd_neo_ysf_test_conv_dch(&opts, &state, 0, 0, 0, 0, 0, input) == -2);
+    assert(strcmp(state.ysf_tgt, "UNCHANGED") == 0);
+    assert(strcmp(state.ysf_src, "UNCHANGED") == 0);
+}
+
+static void
+test_ysf_conv_dch2_decodes_valid_source_and_rejects_crc_error(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t input[100];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    encode_dch_payload_to_input("DCH2SRC789", 10U, input, 96U, 5U, 0);
+
+    assert(dsd_neo_ysf_test_conv_dch2(&opts, &state, 0, 0, 1, 5, 0, input) == 0);
+    assert(strcmp(state.ysf_src, "DCH2SRC789") == 0);
+
+    DSD_SNPRINTF(state.ysf_src, sizeof(state.ysf_src), "%s", "UNCHANGED");
+    encode_dch_payload_to_input("DCH2BAD789", 10U, input, 96U, 5U, 1);
+
+    assert(dsd_neo_ysf_test_conv_dch2(&opts, &state, 0, 0, 1, 5, 0, input) == -2);
+    assert(strcmp(state.ysf_src, "UNCHANGED") == 0);
+}
+
+static void
+test_process_ysf_full_rate_data_routes_fich_and_dch_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t fich_bits[48];
+    uint8_t fich_input[100];
+    uint8_t dch0[180];
+    uint8_t dch1[180];
+
+    InitAllFecFunction();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(g_dibit_stream, 0, sizeof(g_dibit_stream));
+    g_dibit_stream_len = 0;
+    g_dibit_stream_pos = 0;
+
+    make_fich_bits_for_full_rate_data(fich_bits);
+    encode_fich_input(fich_bits, 0, 0, fich_input);
+    encode_dch_payload_to_input("PYSFDST001PYSFSRC002", 20U, dch0, 176U, 9U, 0);
+    encode_dch_payload_to_input("PYSFUPL003PYSFDNL004", 20U, dch1, 176U, 9U, 0);
+
+    append_dibits_to_stream(fich_input, 100U);
+    append_interleaved_full_rate_dch_blocks(dch0, dch1);
+
+    processYSF(&opts, &state);
+
+    assert(g_dibit_stream_pos == g_dibit_stream_len);
+    assert(state.ysf_fi == 0U);
+    assert(state.ysf_dt == 1U);
+    assert(state.ysf_cm == 0U);
+    assert(strcmp(state.ysf_tgt, "PYSFDST001") == 0);
+    assert(strcmp(state.ysf_src, "PYSFSRC002") == 0);
+    assert(strcmp(state.ysf_upl, "PYSFUPL003") == 0);
+    assert(strcmp(state.ysf_dnl, "PYSFDNL004") == 0);
+}
+
+static void
+test_process_ysf_vd_type1_routes_ehr_voice_and_dch_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t fich_bits[48];
+    uint8_t fich_input[100];
+    uint8_t dch[180];
+
+    InitAllFecFunction();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(g_dibit_stream, 0, sizeof(g_dibit_stream));
+    DSD_MEMSET(g_process_mbe_synctype, 0, sizeof(g_process_mbe_synctype));
+    DSD_MEMSET(g_process_mbe_ambe_nonnull, 0, sizeof(g_process_mbe_ambe_nonnull));
+    g_dibit_stream_len = 0;
+    g_dibit_stream_pos = 0;
+    g_process_mbe_call_count = 0;
+
+    make_fich_bits_for_vd_type1(fich_bits);
+    encode_fich_input(fich_bits, 0, 0, fich_input);
+    encode_dch_payload_to_input("VD1DST0001VD1SRC0002", 20U, dch, 176U, 9U, 0);
+
+    append_dibits_to_stream(fich_input, 100U);
+    append_vd_type1_blocks(dch, 1U);
+
+    processYSF(&opts, &state);
+
+    assert(g_dibit_stream_pos == g_dibit_stream_len);
+    assert(g_process_mbe_call_count == 4);
+    for (size_t i = 0; i < 4U; i++) {
+        assert(g_process_mbe_synctype[i] == DSD_SYNC_NXDN_POS);
+        assert(g_process_mbe_ambe_nonnull[i] == 1);
+    }
+    assert(state.synctype == 0);
+    assert(state.ysf_fi == 1U);
+    assert(state.ysf_dt == 0U);
+    assert(state.ysf_cm == 0U);
+    assert(strcmp(state.ysf_tgt, "VD1DST0001") == 0);
+    assert(strcmp(state.ysf_src, "VD1SRC0002") == 0);
+}
+
+static void
+test_process_ysf_vd_type2_routes_dch2_voice_and_audio_errors(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t fich_bits[48];
+    uint8_t fich_input[100];
+    uint8_t dch2[100];
+
+    InitAllFecFunction();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(g_dibit_stream, 0, sizeof(g_dibit_stream));
+    DSD_MEMSET(g_mbe_inbound_errs2, 0, sizeof(g_mbe_inbound_errs2));
+    g_dibit_stream_len = 0;
+    g_dibit_stream_pos = 0;
+    g_mbe_call_count = 0;
+    opts.floating_point = 1;
+
+    make_fich_bits_for_vd_type2(fich_bits);
+    encode_fich_input(fich_bits, 0, 0, fich_input);
+    encode_dch_payload_to_input("VD2SRC4444", 10U, dch2, 96U, 5U, 0);
+
+    append_dibits_to_stream(fich_input, 100U);
+    for (size_t block = 0; block < 5U; block++) {
+        append_dibits_to_stream(&dch2[block * 20U], 20U);
+        append_type2_vech_dibits((block % 2U) == 0U ? 1U : 0U);
+    }
+
+    processYSF(&opts, &state);
+
+    assert(g_dibit_stream_pos == g_dibit_stream_len);
+    assert(g_mbe_call_count == 5);
+    assert(g_mbe_inbound_errs2[0] == 1);
+    assert(g_mbe_inbound_errs2[1] == 0);
+    assert(g_mbe_inbound_errs2[2] == 1);
+    assert(g_mbe_inbound_errs2[3] == 0);
+    assert(g_mbe_inbound_errs2[4] == 1);
+    assert(state.debug_audio_errors == 3);
+    assert(state.ysf_fi == 1U);
+    assert(state.ysf_dt == 2U);
+    assert(strcmp(state.ysf_src, "VD2SRC4444") == 0);
+    assert(strcmp(state.err_str, "stub-4") == 0);
+    assert(state.f_l[0] == 5.0F);
+    assert(state.f_l[159] == 5.0F);
+}
+
+int
+main(void) {
+    test_dch_csd1_tracks_destination_and_source();
+    test_dch_rid_mode_preserves_target_and_source_state();
+    test_dch_csd2_tracks_uplink_and_downlink();
+    test_dch_text_clears_and_sanitizes_segments();
+    test_dch2_tracks_destination_source_links_and_remarks();
+    test_ysf_crc16_known_values();
+    test_ysf_fich_conv_decodes_fields_and_failures();
+    test_ysf_type2_ambe_majority_and_tail_bits();
+    test_ysf_conv_dch_decodes_valid_csd1_and_rejects_crc_error();
+    test_ysf_conv_dch2_decodes_valid_source_and_rejects_crc_error();
+    test_process_ysf_full_rate_data_routes_fich_and_dch_state();
+    test_process_ysf_vd_type1_routes_ehr_voice_and_dch_state();
+    test_process_ysf_vd_type2_routes_dch2_voice_and_audio_errors();
+    return 0;
+}
+
+// NOLINTEND(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,misc-use-internal-linkage)

--- a/tests/runtime/test_config_validation.cpp
+++ b/tests/runtime/test_config_validation.cpp
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-multi-level-implicit-pointer-conversion,clang-analyzer-optin.core.EnumCastOutOfRange)
 /*
  * Copyright (C) 2025 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -329,6 +332,145 @@ test_profile_trunk_scan_inherits_base_targets_csv(void) {
 
     dsd_user_config_diags_free(&diags);
     (void)remove(path);
+    return result;
+}
+
+static int
+validate_config_stream_contents(const char* contents, dsdcfg_diagnostics_t* diags) {
+    FILE* tmp = tmpfile();
+    if (!tmp) {
+        DSD_FPRINTF(stderr, "FAIL: tmpfile() failed for config validation stream\n");
+        return -1;
+    }
+
+    size_t len = strlen(contents);
+    if (len > 0U && fwrite(contents, 1U, len, tmp) != len) {
+        DSD_FPRINTF(stderr, "FAIL: fwrite() failed for config validation stream\n");
+        fclose(tmp);
+        return -1;
+    }
+    if (fflush(tmp) != 0 || fseek(tmp, 0L, SEEK_SET) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: stream setup failed for config validation stream\n");
+        fclose(tmp);
+        return -1;
+    }
+
+    int rc = dsd_user_config_validate_stream(tmp, diags);
+    fclose(tmp);
+    return rc;
+}
+
+static int
+has_global_diag_message(const dsdcfg_diagnostics_t* diags, const char* message) {
+    if (!diags || !message) {
+        return 0;
+    }
+    for (int i = 0; i < diags->count; i++) {
+        if (diags->items[i].level == DSDCFG_DIAG_ERROR && diags->items[i].section[0] == '\0'
+            && diags->items[i].key[0] == '\0' && strstr(diags->items[i].message, message)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+test_validate_stream_rejects_null_stream(void) {
+    dsdcfg_diagnostics_t diags;
+    DSD_MEMSET(&diags, 0, sizeof(diags));
+
+    int rc = dsd_user_config_validate_stream(NULL, &diags);
+
+    int result = 0;
+    if (rc == 0) {
+        DSD_FPRINTF(stderr, "FAIL: null config validation stream should return error\n");
+        result = 1;
+    }
+    if (!has_global_diag_message(&diags, "No config stream provided")) {
+        DSD_FPRINTF(stderr, "FAIL: missing null stream validation diagnostic\n");
+        result = 1;
+    }
+
+    dsd_user_config_diags_free(&diags);
+    return result;
+}
+
+static int
+test_validate_stream_runs_composed_trunk_scan_checks(void) {
+    static const char* ini = "version = 1\n"
+                             "\n"
+                             "[trunk_scan]\n"
+                             "enabled = true\n";
+
+    dsdcfg_diagnostics_t diags;
+    DSD_MEMSET(&diags, 0, sizeof(diags));
+
+    int rc = validate_config_stream_contents(ini, &diags);
+
+    int result = 0;
+    if (rc == 0) {
+        DSD_FPRINTF(stderr, "FAIL: stream trunk_scan without targets_csv should cause error\n");
+        result = 1;
+    }
+    if (!has_trunk_scan_required_diag(&diags, "trunk_scan", "targets_csv")) {
+        DSD_FPRINTF(stderr, "FAIL: missing stream trunk_scan targets_csv diagnostic\n");
+        result = 1;
+    }
+
+    dsd_user_config_diags_free(&diags);
+    return result;
+}
+
+static int
+test_validate_stream_runs_profile_composed_checks(void) {
+    static const char* ini = "version = 1\n"
+                             "\n"
+                             "[profile.scan]\n"
+                             "trunk_scan.enabled = true\n";
+
+    dsdcfg_diagnostics_t diags;
+    DSD_MEMSET(&diags, 0, sizeof(diags));
+
+    int rc = validate_config_stream_contents(ini, &diags);
+
+    int result = 0;
+    if (rc == 0) {
+        DSD_FPRINTF(stderr, "FAIL: stream profile trunk_scan without targets_csv should cause error\n");
+        result = 1;
+    }
+    if (!has_trunk_scan_required_diag(&diags, "profile.scan", "trunk_scan.targets_csv")) {
+        DSD_FPRINTF(stderr, "FAIL: missing stream profile trunk_scan targets_csv diagnostic\n");
+        result = 1;
+    }
+
+    dsd_user_config_diags_free(&diags);
+    return result;
+}
+
+static int
+test_validate_stream_accepts_profile_inherited_targets_csv(void) {
+    static const char* ini = "version = 1\n"
+                             "\n"
+                             "[trunk_scan]\n"
+                             "enabled = false\n"
+                             "targets_csv = \"/tmp/base-targets.csv\"\n"
+                             "\n"
+                             "[profile.scan]\n"
+                             "trunk_scan.enabled = true\n";
+
+    dsdcfg_diagnostics_t diags;
+    DSD_MEMSET(&diags, 0, sizeof(diags));
+
+    int rc = validate_config_stream_contents(ini, &diags);
+
+    int result = 0;
+    if (rc != 0 || diags.error_count > 0) {
+        DSD_FPRINTF(stderr, "FAIL: stream profile trunk_scan should inherit base targets_csv (rc=%d errors=%d)\n", rc,
+                    diags.error_count);
+        result = 1;
+    }
+
+    dsd_user_config_diags_free(&diags);
     return result;
 }
 
@@ -890,10 +1032,176 @@ test_profile_valid_values(void) {
     return result;
 }
 
+static int
+test_schema_accessors_and_type_names(void) {
+    int result = 0;
+    int count = dsdcfg_schema_count();
+    if (count <= 0) {
+        DSD_FPRINTF(stderr, "FAIL: schema count should be positive\n");
+        return 1;
+    }
+
+    if (dsdcfg_schema_get(-1) != NULL || dsdcfg_schema_get(count) != NULL) {
+        DSD_FPRINTF(stderr, "FAIL: schema_get accepted out-of-range index\n");
+        result = 1;
+    }
+
+    const dsdcfg_schema_entry_t* source = dsdcfg_schema_find("INPUT", "SOURCE");
+    if (!source || strcmp(source->section, "input") != 0 || strcmp(source->key, "source") != 0
+        || source->type != DSDCFG_TYPE_ENUM || !source->allowed || !strstr(source->allowed, "rtltcp")) {
+        DSD_FPRINTF(stderr, "FAIL: schema_find failed for case-insensitive input.source\n");
+        result = 1;
+    }
+    if (dsdcfg_schema_find(NULL, "source") != NULL || dsdcfg_schema_find("input", NULL) != NULL
+        || dsdcfg_schema_find("input", "missing") != NULL) {
+        DSD_FPRINTF(stderr, "FAIL: schema_find accepted null or unknown key\n");
+        result = 1;
+    }
+
+    const char* desc = dsd_config_key_description("recording", "rdio_mode");
+    if (!desc || !strstr(desc, "rdio-scanner")) {
+        DSD_FPRINTF(stderr, "FAIL: description lookup failed for recording.rdio_mode\n");
+        result = 1;
+    }
+    if (dsd_config_key_description("recording", "missing") != NULL) {
+        DSD_FPRINTF(stderr, "FAIL: description lookup accepted unknown key\n");
+        result = 1;
+    }
+    if (!dsd_config_key_is_deprecated("input", "pulse_input") || dsd_config_key_is_deprecated("input", "source")
+        || dsd_config_key_is_deprecated("input", "missing")) {
+        DSD_FPRINTF(stderr, "FAIL: deprecated-key lookup mismatch\n");
+        result = 1;
+    }
+
+    if (strcmp(dsdcfg_type_name(DSDCFG_TYPE_STRING), "string") != 0
+        || strcmp(dsdcfg_type_name(DSDCFG_TYPE_INT), "int") != 0
+        || strcmp(dsdcfg_type_name(DSDCFG_TYPE_BOOL), "bool") != 0
+        || strcmp(dsdcfg_type_name(DSDCFG_TYPE_ENUM), "enum") != 0
+        || strcmp(dsdcfg_type_name(DSDCFG_TYPE_PATH), "path") != 0
+        || strcmp(dsdcfg_type_name(DSDCFG_TYPE_FREQ), "freq") != 0
+        || strcmp(dsdcfg_type_name((dsdcfg_type_t)99), "unknown") != 0) {
+        DSD_FPRINTF(stderr, "FAIL: type-name mapping mismatch\n");
+        result = 1;
+    }
+
+    const char* sections[16];
+    DSD_MEMSET(sections, 0, sizeof(sections));
+    int section_count = dsdcfg_schema_sections(sections, 16);
+    if (section_count < 8 || !sections[0] || strcmp(sections[0], "input") != 0) {
+        DSD_FPRINTF(stderr, "FAIL: schema_sections did not return expected section list\n");
+        result = 1;
+    }
+    if (dsdcfg_schema_sections(NULL, 16) != 0 || dsdcfg_schema_sections(sections, 0) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: schema_sections accepted invalid output arguments\n");
+        result = 1;
+    }
+    const char* one_section[1] = {NULL};
+    if (dsdcfg_schema_sections(one_section, 1) != 1 || !one_section[0] || strcmp(one_section[0], "input") != 0) {
+        DSD_FPRINTF(stderr, "FAIL: schema_sections did not honor max_sections\n");
+        result = 1;
+    }
+
+    return result;
+}
+
+static int
+test_diagnostics_direct_api_and_print_formats(void) {
+    dsdcfg_diags_init(NULL);
+    dsdcfg_diags_add(NULL, DSDCFG_DIAG_ERROR, 1, "input", "source", "ignored");
+    dsdcfg_diags_free(NULL);
+    dsdcfg_diags_print(NULL, stderr, NULL);
+
+    dsdcfg_diagnostics_t diags;
+    DSD_MEMSET(&diags, 0, sizeof(diags));
+    dsdcfg_diags_init(&diags);
+    if (diags.items != NULL || diags.count != 0 || diags.capacity != 0 || diags.error_count != 0
+        || diags.warning_count != 0) {
+        DSD_FPRINTF(stderr, "FAIL: diagnostics init did not clear structure\n");
+        return 1;
+    }
+
+    dsdcfg_diags_add(&diags, DSDCFG_DIAG_WARNING, 7, "input", "pulse_input", "deprecated alias");
+    dsdcfg_diags_add(&diags, DSDCFG_DIAG_ERROR, 9, "mode", "decode", "invalid mode");
+    dsdcfg_diags_add(&diags, DSDCFG_DIAG_INFO, 3, "trunking", NULL, "section info");
+    dsdcfg_diags_add(&diags, DSDCFG_DIAG_INFO, 0, NULL, NULL, "global info");
+    if (diags.count != 4 || diags.warning_count != 1 || diags.error_count != 1) {
+        DSD_FPRINTF(stderr, "FAIL: diagnostics counts mismatch\n");
+        dsdcfg_diags_free(&diags);
+        return 1;
+    }
+
+    int result = 0;
+    if (strcmp(diags.items[0].section, "input") != 0 || strcmp(diags.items[0].key, "pulse_input") != 0
+        || strcmp(diags.items[0].message, "deprecated alias") != 0) {
+        DSD_FPRINTF(stderr, "FAIL: diagnostic field storage mismatch\n");
+        result = 1;
+    }
+
+    FILE* tmp = tmpfile();
+    if (!tmp) {
+        DSD_FPRINTF(stderr, "FAIL: tmpfile() failed\n");
+        dsdcfg_diags_free(&diags);
+        return 1;
+    }
+
+    dsdcfg_diags_print(&diags, tmp, "config.ini");
+    if (fseek(tmp, 0, SEEK_SET) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: fseek() failed for diagnostics output\n");
+        fclose(tmp);
+        dsdcfg_diags_free(&diags);
+        return 1;
+    }
+    char output[2048];
+    size_t n = fread(output, 1, sizeof(output) - 1U, tmp);
+    output[n] = '\0';
+    fclose(tmp);
+
+    if (!strstr(output, "config.ini:7: warning [input] pulse_input: deprecated alias")
+        || !strstr(output, "config.ini:9: error [mode] decode: invalid mode")
+        || !strstr(output, "config.ini:3: info [trunking]: section info") || !strstr(output, "info: global info")
+        || !strstr(output, "Summary: 1 error(s), 1 warning(s)")) {
+        DSD_FPRINTF(stderr, "FAIL: diagnostics path print output mismatch\n%s\n", output);
+        result = 1;
+    }
+
+    tmp = tmpfile();
+    if (!tmp) {
+        DSD_FPRINTF(stderr, "FAIL: tmpfile() failed for no-path diagnostics output\n");
+        dsdcfg_diags_free(&diags);
+        return 1;
+    }
+    dsdcfg_diags_print(&diags, tmp, NULL);
+    if (fseek(tmp, 0, SEEK_SET) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: fseek() failed for no-path diagnostics output\n");
+        fclose(tmp);
+        dsdcfg_diags_free(&diags);
+        return 1;
+    }
+    n = fread(output, 1, sizeof(output) - 1U, tmp);
+    output[n] = '\0';
+    fclose(tmp);
+    if (!strstr(output, "line 7: warning [input] pulse_input: deprecated alias")) {
+        DSD_FPRINTF(stderr, "FAIL: diagnostics no-path line format mismatch\n%s\n", output);
+        result = 1;
+    }
+
+    dsdcfg_diags_print(&diags, NULL, NULL);
+    dsdcfg_diags_free(&diags);
+    if (diags.items != NULL || diags.count != 0 || diags.capacity != 0 || diags.error_count != 0
+        || diags.warning_count != 0) {
+        DSD_FPRINTF(stderr, "FAIL: diagnostics free did not clear structure\n");
+        result = 1;
+    }
+
+    return result;
+}
+
 int
 main(void) {
     int rc = 0;
 
+    rc |= test_schema_accessors_and_type_names();
+    rc |= test_diagnostics_direct_api_and_print_formats();
     rc |= test_valid_config();
     rc |= test_trunk_scan_enabled_requires_targets_csv();
     rc |= test_trunk_scan_rejects_global_channel_map();
@@ -901,6 +1209,10 @@ main(void) {
     rc |= test_profile_trunk_scan_rejects_inherited_channel_map();
     rc |= test_profile_trunk_scan_enabled_requires_targets_csv();
     rc |= test_profile_trunk_scan_inherits_base_targets_csv();
+    rc |= test_validate_stream_rejects_null_stream();
+    rc |= test_validate_stream_runs_composed_trunk_scan_checks();
+    rc |= test_validate_stream_runs_profile_composed_checks();
+    rc |= test_validate_stream_accepts_profile_inherited_targets_csv();
     rc |= test_unknown_key_warning();
     rc |= test_unknown_section_warning();
     rc |= test_invalid_enum_error();
@@ -923,3 +1235,5 @@ main(void) {
 
     return rc;
 }
+
+// NOLINTEND(bugprone-multi-level-implicit-pointer-conversion,clang-analyzer-optin.core.EnumCastOutOfRange)

--- a/tests/runtime/test_runtime_bootstrap_audio.c
+++ b/tests/runtime/test_runtime_bootstrap_audio.c
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-unix.Errno)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/platform/audio.h>
+#include <dsd-neo/runtime/cli.h>
+#include <dsd-neo/runtime/log.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+
+static int g_enum_rc;
+static dsd_audio_device g_inputs[16];
+static dsd_audio_device g_outputs[16];
+static int g_last_max_count;
+
+void
+dsd_neo_log_write(dsd_neo_log_level_t level, const char* format, ...) {
+    (void)level;
+    (void)format;
+}
+
+int
+dsd_audio_enumerate_devices(dsd_audio_device* inputs, dsd_audio_device* outputs, int max_count) {
+    g_last_max_count = max_count;
+    if (g_enum_rc < 0) {
+        return g_enum_rc;
+    }
+    if (inputs) {
+        DSD_MEMCPY(inputs, g_inputs, sizeof g_inputs);
+    }
+    if (outputs) {
+        DSD_MEMCPY(outputs, g_outputs, sizeof g_outputs);
+    }
+    return 0;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_str(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static void
+reset_devices(void) {
+    g_enum_rc = 0;
+    g_last_max_count = 0;
+    DSD_MEMSET(g_inputs, 0, sizeof g_inputs);
+    DSD_MEMSET(g_outputs, 0, sizeof g_outputs);
+
+    g_inputs[0].initialized = 1;
+    DSD_SNPRINTF(g_inputs[0].name, sizeof g_inputs[0].name, "%s", "input-one");
+    DSD_SNPRINTF(g_inputs[0].description, sizeof g_inputs[0].description, "%s", "Input One");
+    g_inputs[1].initialized = 1;
+    DSD_SNPRINTF(g_inputs[1].name, sizeof g_inputs[1].name, "%s", "input-two");
+    DSD_SNPRINTF(g_inputs[1].description, sizeof g_inputs[1].description, "%s", "Input Two");
+
+    g_outputs[0].initialized = 1;
+    DSD_SNPRINTF(g_outputs[0].name, sizeof g_outputs[0].name, "%s", "output-one");
+    DSD_SNPRINTF(g_outputs[0].description, sizeof g_outputs[0].description, "%s", "Output One");
+    g_outputs[1].initialized = 1;
+    DSD_SNPRINTF(g_outputs[1].name, sizeof g_outputs[1].name, "%s", "output-two");
+    DSD_SNPRINTF(g_outputs[1].description, sizeof g_outputs[1].description, "%s", "Output Two");
+}
+
+#if !defined(_WIN32)
+typedef void (*bootstrap_audio_fn)(dsd_opts* opts);
+
+static int
+with_stdin_text(const char* text, bootstrap_audio_fn fn, dsd_opts* opts) {
+    int rc = 0;
+    FILE* f = tmpfile();
+    if (!f) {
+        DSD_FPRINTF(stderr, "tmpfile failed: %s\n", strerror(errno));
+        return 1;
+    }
+    if (fputs(text, f) < 0) {
+        DSD_FPRINTF(stderr, "fputs failed\n");
+        fclose(f);
+        return 1;
+    }
+    if (fseek(f, 0, SEEK_SET) != 0) {
+        DSD_FPRINTF(stderr, "fseek(input) failed: %s\n", strerror(errno));
+        fclose(f);
+        return 1;
+    }
+    clearerr(f);
+
+    int stdin_fd = fileno(stdin);
+    if (stdin_fd < 0) {
+        DSD_FPRINTF(stderr, "fileno(stdin) failed: %s\n", strerror(errno));
+        fclose(f);
+        return 1;
+    }
+    int input_fd = fileno(f);
+    if (input_fd < 0) {
+        DSD_FPRINTF(stderr, "fileno(input) failed: %s\n", strerror(errno));
+        fclose(f);
+        return 1;
+    }
+
+    int saved = dup(stdin_fd);
+    if (saved < 0) {
+        DSD_FPRINTF(stderr, "dup(stdin) failed: %s\n", strerror(errno));
+        fclose(f);
+        return 1;
+    }
+    if (fflush(stdin) != 0) {
+        DSD_FPRINTF(stderr, "fflush(stdin) failed: %s\n", strerror(errno));
+        close(saved);
+        fclose(f);
+        return 1;
+    }
+    if (dup2(input_fd, stdin_fd) < 0) {
+        DSD_FPRINTF(stderr, "dup2(input, stdin) failed: %s\n", strerror(errno));
+        close(saved);
+        fclose(f);
+        return 1;
+    }
+
+    fn(opts);
+
+    if (dup2(saved, stdin_fd) < 0) {
+        DSD_FPRINTF(stderr, "dup2(saved, stdin) failed: %s\n", strerror(errno));
+        rc = 1;
+    }
+    close(saved);
+    fclose(f);
+    return rc;
+}
+
+static int
+test_output_selection_defaults_and_clamps(void) {
+    int rc = 0;
+    static dsd_opts opts;
+
+    reset_devices();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    rc |= with_stdin_text("\n", dsd_bootstrap_choose_audio_output, &opts);
+    rc |= expect_str("output-empty-default", opts.audio_out_dev, "pulse");
+    rc |= expect_int("output-enum-max", g_last_max_count, 16);
+
+    reset_devices();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    rc |= with_stdin_text("2\n", dsd_bootstrap_choose_audio_output, &opts);
+    rc |= expect_str("output-select-second", opts.audio_out_dev, "pulse:output-two");
+
+    reset_devices();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    rc |= with_stdin_text("99\n", dsd_bootstrap_choose_audio_output, &opts);
+    rc |= expect_str("output-clamp-high", opts.audio_out_dev, "pulse:output-two");
+
+    reset_devices();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    rc |= with_stdin_text("bad\n", dsd_bootstrap_choose_audio_output, &opts);
+    rc |= expect_str("output-invalid-default", opts.audio_out_dev, "pulse");
+
+    return rc;
+}
+
+static int
+test_input_selection_defaults_and_clamps(void) {
+    int rc = 0;
+    static dsd_opts opts;
+
+    reset_devices();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    rc |= with_stdin_text("1\r\n", dsd_bootstrap_choose_audio_input, &opts);
+    rc |= expect_str("input-select-first", opts.audio_in_dev, "pulse:input-one");
+
+    reset_devices();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    rc |= with_stdin_text("-2\n", dsd_bootstrap_choose_audio_input, &opts);
+    rc |= expect_str("input-clamp-low", opts.audio_in_dev, "pulse");
+
+    reset_devices();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    rc |= with_stdin_text("99\n", dsd_bootstrap_choose_audio_input, &opts);
+    rc |= expect_str("input-clamp-high", opts.audio_in_dev, "pulse:input-two");
+
+    return rc;
+}
+#endif
+
+static int
+test_enumeration_failure_uses_default_devices(void) {
+    int rc = 0;
+    static dsd_opts opts;
+
+    reset_devices();
+    g_enum_rc = -1;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    dsd_bootstrap_choose_audio_output(&opts);
+    rc |= expect_str("output-enum-fail", opts.audio_out_dev, "pulse");
+
+    reset_devices();
+    g_enum_rc = -1;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    dsd_bootstrap_choose_audio_input(&opts);
+    rc |= expect_str("input-enum-fail", opts.audio_in_dev, "pulse");
+
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+
+    rc |= test_enumeration_failure_uses_default_devices();
+#if !defined(_WIN32)
+    rc |= test_output_selection_defaults_and_clamps();
+    rc |= test_input_selection_defaults_and_clamps();
+#else
+    DSD_FPRINTF(stderr, "stdin redirection coverage skipped on Windows\n");
+#endif
+
+    if (rc == 0) {
+        printf("RUNTIME_BOOTSTRAP_AUDIO: OK\n");
+    }
+    return rc;
+}
+
+// NOLINTEND(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-unix.Errno)

--- a/tests/runtime/test_runtime_bootstrap_interactive.c
+++ b/tests/runtime/test_runtime_bootstrap_interactive.c
@@ -1,0 +1,561 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-unix.Errno)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/csv_import.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/runtime/cli.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/log.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static int g_isatty = 1;
+static int g_config_available = 1;
+static dsdneoRuntimeConfig g_config;
+static int g_config_init_calls;
+static dsdneoUserDecodeMode g_last_decode_mode = DSDCFG_MODE_UNSET;
+static dsdDecodePresetProfile g_last_decode_profile = DSD_DECODE_PRESET_PROFILE_CONFIG;
+static int g_audio_input_calls;
+static int g_audio_output_calls;
+static int g_chan_import_calls;
+static int g_group_import_calls;
+static int g_chan_import_rc;
+static int g_group_import_rc;
+
+void
+dsd_neo_log_write(dsd_neo_log_level_t level, const char* format, ...) {
+    (void)level;
+    (void)format;
+}
+
+int
+dsd_isatty(int fd) {
+    (void)fd;
+    return g_isatty;
+}
+
+void
+dsd_neo_config_init(const dsd_opts* opts) {
+    (void)opts;
+    ++g_config_init_calls;
+    g_config_available = 1;
+    DSD_MEMSET(&g_config, 0, sizeof g_config);
+}
+
+const dsdneoRuntimeConfig*
+dsd_neo_get_config(void) {
+    return g_config_available ? &g_config : NULL;
+}
+
+int
+dsd_apply_decode_mode_preset(dsdneoUserDecodeMode mode, dsdDecodePresetProfile profile, dsd_opts* opts,
+                             dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_last_decode_mode = mode;
+    g_last_decode_profile = profile;
+    return 0;
+}
+
+void
+dsd_bootstrap_choose_audio_input(dsd_opts* opts) {
+    ++g_audio_input_calls;
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "pulse:stub-input");
+}
+
+void
+dsd_bootstrap_choose_audio_output(dsd_opts* opts) {
+    ++g_audio_output_calls;
+    DSD_SNPRINTF(opts->audio_out_dev, sizeof opts->audio_out_dev, "%s", "pulse:stub-output");
+}
+
+int
+dsd_stat_path(const char* path, dsd_stat_t* st) {
+    if (!path || !st) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (strcmp(path, "chan.csv") != 0 && strcmp(path, "group.csv") != 0) {
+        errno = ENOENT;
+        return -1;
+    }
+    DSD_MEMSET(st, 0, sizeof *st);
+    st->st_mode = S_IFREG;
+    return 0;
+}
+
+int
+dsd_stat_is_regular(const dsd_stat_t* st) {
+    return st && S_ISREG(st->st_mode);
+}
+
+int
+csvChanImport(const dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    ++g_chan_import_calls;
+    return g_chan_import_rc;
+}
+
+int
+csvGroupImport(const dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    ++g_group_import_calls;
+    return g_group_import_rc;
+}
+
+static void
+reset_harness(void) {
+    g_isatty = 1;
+    g_config_available = 1;
+    DSD_MEMSET(&g_config, 0, sizeof g_config);
+    g_config_init_calls = 0;
+    g_last_decode_mode = DSDCFG_MODE_UNSET;
+    g_last_decode_profile = DSD_DECODE_PRESET_PROFILE_CONFIG;
+    g_audio_input_calls = 0;
+    g_audio_output_calls = 0;
+    g_chan_import_calls = 0;
+    g_group_import_calls = 0;
+    g_chan_import_rc = 0;
+    g_group_import_rc = 0;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_str(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+#if !defined(_WIN32)
+typedef void (*bootstrap_interactive_fn)(dsd_opts* opts, dsd_state* state);
+
+static int
+with_stdin_text(const char* text, bootstrap_interactive_fn fn, dsd_opts* opts, dsd_state* state) {
+    int rc = 0;
+    FILE* f = tmpfile();
+    if (!f) {
+        DSD_FPRINTF(stderr, "tmpfile failed: %s\n", strerror(errno));
+        return 1;
+    }
+    if (fputs(text, f) < 0) {
+        DSD_FPRINTF(stderr, "fputs failed\n");
+        fclose(f);
+        return 1;
+    }
+    if (fseek(f, 0, SEEK_SET) != 0) {
+        DSD_FPRINTF(stderr, "fseek(input) failed: %s\n", strerror(errno));
+        fclose(f);
+        return 1;
+    }
+    clearerr(f);
+
+    int stdin_fd = fileno(stdin);
+    if (stdin_fd < 0) {
+        DSD_FPRINTF(stderr, "fileno(stdin) failed: %s\n", strerror(errno));
+        fclose(f);
+        return 1;
+    }
+    int input_fd = fileno(f);
+    if (input_fd < 0) {
+        DSD_FPRINTF(stderr, "fileno(input) failed: %s\n", strerror(errno));
+        fclose(f);
+        return 1;
+    }
+
+    int saved = dup(stdin_fd);
+    if (saved < 0) {
+        DSD_FPRINTF(stderr, "dup(stdin) failed: %s\n", strerror(errno));
+        fclose(f);
+        return 1;
+    }
+    if (fflush(stdin) != 0) {
+        DSD_FPRINTF(stderr, "fflush(stdin) failed: %s\n", strerror(errno));
+        close(saved);
+        fclose(f);
+        return 1;
+    }
+    if (dup2(input_fd, stdin_fd) < 0) {
+        DSD_FPRINTF(stderr, "dup2(input, stdin) failed: %s\n", strerror(errno));
+        close(saved);
+        fclose(f);
+        return 1;
+    }
+    clearerr(stdin);
+
+    fn(opts, state);
+
+    if (dup2(saved, stdin_fd) < 0) {
+        DSD_FPRINTF(stderr, "dup2(saved, stdin) failed: %s\n", strerror(errno));
+        rc = 1;
+    }
+    clearerr(stdin);
+    close(saved);
+    fclose(f);
+    return rc;
+}
+
+static int
+test_pulse_defaults_apply_decode_and_ncurses(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset_harness();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    rc |= with_stdin_text("\n4\n\n", dsd_bootstrap_interactive, &opts, &state);
+    rc |= expect_int("pulse-audio-input-calls", g_audio_input_calls, 1);
+    rc |= expect_int("pulse-audio-output-calls", g_audio_output_calls, 1);
+    rc |= expect_str("pulse-audio-in", opts.audio_in_dev, "pulse:stub-input");
+    rc |= expect_str("pulse-audio-out", opts.audio_out_dev, "pulse:stub-output");
+    rc |= expect_int("pulse-decode-mode", g_last_decode_mode, DSDCFG_MODE_DMR);
+    rc |= expect_int("pulse-decode-profile", g_last_decode_profile, DSD_DECODE_PRESET_PROFILE_INTERACTIVE);
+    rc |= expect_int("pulse-ncurses-default", opts.use_ncurses_terminal, 1);
+    return rc;
+}
+
+static int
+test_rtltcp_trunking_imports_group_allow_list_and_null_output(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    const char* input = "3\n"
+                        "host.example\n"
+                        "2345\n"
+                        "851.375M\n"
+                        "30\n"
+                        "-5\n"
+                        "12\n"
+                        "7\n"
+                        "2\n"
+                        "2\n"
+                        "y\n"
+                        "chan.csv\n"
+                        "group.csv\n"
+                        "y\n"
+                        "n\n"
+                        "y\n"
+                        "n\n";
+
+    reset_harness();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    rc |= with_stdin_text(input, dsd_bootstrap_interactive, &opts, &state);
+    rc |= expect_str("rtltcp-audio-in", opts.audio_in_dev, "rtltcp:host.example:2345:851.375M:30:-5:12:7:2");
+    rc |= expect_int("rtltcp-decode-mode", g_last_decode_mode, DSDCFG_MODE_P25P1);
+    rc |= expect_int("rtltcp-trunk-p25", opts.p25_trunk, 1);
+    rc |= expect_int("rtltcp-trunk-enable", opts.trunk_enable, 1);
+    rc |= expect_str("rtltcp-channel-file", opts.chan_in_file, "chan.csv");
+    rc |= expect_str("rtltcp-group-file", opts.group_in_file, "group.csv");
+    rc |= expect_int("rtltcp-channel-import", g_chan_import_calls, 1);
+    rc |= expect_int("rtltcp-group-import", g_group_import_calls, 1);
+    rc |= expect_int("rtltcp-allow-list", opts.trunk_use_allow_list, 1);
+    rc |= expect_str("rtltcp-null-output", opts.audio_out_dev, "null");
+    rc |= expect_int("rtltcp-audio-output-chooser", g_audio_output_calls, 0);
+    rc |= expect_int("rtltcp-ncurses-disabled", opts.use_ncurses_terminal, 0);
+    return rc;
+}
+
+static int
+test_tcp_trunking_enables_default_rigctl_and_skips_missing_csv(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    const char* input = "5\n"
+                        "\n"
+                        "9999\n"
+                        "13\n"
+                        "y\n"
+                        "missing-chan.csv\n"
+                        "missing-group.csv\n"
+                        "n\n"
+                        "n\n"
+                        "\n";
+
+    reset_harness();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    rc |= with_stdin_text(input, dsd_bootstrap_interactive, &opts, &state);
+    rc |= expect_str("tcp-audio-in", opts.audio_in_dev, "tcp:127.0.0.1:9999");
+    rc |= expect_int("tcp-decode-mode", g_last_decode_mode, DSDCFG_MODE_TDMA);
+    rc |= expect_int("tcp-trunk-enable", opts.trunk_enable, 1);
+    rc |= expect_int("tcp-use-rigctl", opts.use_rigctl, 1);
+    rc |= expect_int("tcp-rigctl-port", opts.rigctlportno, 4532);
+    rc |= expect_int("tcp-channel-import-skipped", g_chan_import_calls, 0);
+    rc |= expect_int("tcp-group-import-skipped", g_group_import_calls, 0);
+    rc |= expect_str("tcp-no-null-output", opts.audio_out_dev, "");
+    rc |= expect_int("tcp-ncurses-default", opts.use_ncurses_terminal, 1);
+    return rc;
+}
+
+static int
+test_udp_eof_uses_socket_defaults_and_default_pulse_output(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset_harness();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    rc |= with_stdin_text("6\n", dsd_bootstrap_interactive, &opts, &state);
+    rc |= expect_str("udp-default-audio-in", opts.audio_in_dev, "udp:127.0.0.1:7355");
+    rc |= expect_int("udp-default-decode-mode", g_last_decode_mode, DSDCFG_MODE_AUTO);
+    rc |= expect_int("udp-default-audio-output", g_audio_output_calls, 1);
+    rc |= expect_str("udp-default-audio-out", opts.audio_out_dev, "pulse:stub-output");
+    rc |= expect_int("udp-default-ncurses", opts.use_ncurses_terminal, 1);
+    return rc;
+}
+
+static int
+test_file_input_applies_clamped_low_sample_rate(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    const char* input = "4\n"
+                        "capture.raw\n"
+                        "1\n"
+                        "14\n"
+                        "n\n"
+                        "n\n"
+                        "n\n";
+
+    reset_harness();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    state.samplesPerSymbol = 10;
+    state.symbolCenter = 4;
+
+    rc |= with_stdin_text(input, dsd_bootstrap_interactive, &opts, &state);
+    rc |= expect_str("file-audio-in", opts.audio_in_dev, "capture.raw");
+    rc |= expect_int("file-clamped-sample-rate", opts.wav_sample_rate, 8000);
+    rc |= expect_int("file-effective-sample-rate", dsd_opts_effective_input_rate(&opts), 48000);
+    rc |= expect_int("file-samples-per-symbol", state.samplesPerSymbol, 10);
+    rc |= expect_int("file-symbol-center", state.symbolCenter, 4);
+    rc |= expect_int("file-decode-mode", g_last_decode_mode, DSDCFG_MODE_ANALOG);
+    rc |= expect_str("file-output-left-empty", opts.audio_out_dev, "");
+    rc |= expect_int("file-ncurses-disabled", opts.use_ncurses_terminal, 0);
+    return rc;
+}
+
+static int
+test_empty_file_path_falls_back_to_pulse_devices(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    const char* input = "4\n"
+                        "\n"
+                        "4\n"
+                        "n\n";
+
+    reset_harness();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    rc |= with_stdin_text(input, dsd_bootstrap_interactive, &opts, &state);
+    rc |= expect_int("empty-file-audio-input-calls", g_audio_input_calls, 1);
+    rc |= expect_int("empty-file-audio-output-calls", g_audio_output_calls, 1);
+    rc |= expect_str("empty-file-pulse-input", opts.audio_in_dev, "pulse:stub-input");
+    rc |= expect_str("empty-file-pulse-output", opts.audio_out_dev, "pulse:stub-output");
+    rc |= expect_int("empty-file-decode-mode", g_last_decode_mode, DSDCFG_MODE_DMR);
+    rc |= expect_int("empty-file-ncurses-disabled", opts.use_ncurses_terminal, 0);
+    return rc;
+}
+
+static int
+test_rtl_input_formats_clamped_radio_options(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    const char* input = "2\n"
+                        "851.375M\n"
+                        "999\n"
+                        "-1\n"
+                        "999\n"
+                        "3\n"
+                        "-1001\n"
+                        "9\n"
+                        "14\n"
+                        "n\n"
+                        "n\n"
+                        "n\n";
+
+    reset_harness();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    rc |= with_stdin_text(input, dsd_bootstrap_interactive, &opts, &state);
+    rc |= expect_str("rtl-clamped-audio-in", opts.audio_in_dev, "rtl:255:851.375M:0:200:4:-1000:3");
+    rc |= expect_int("rtl-decode-mode", g_last_decode_mode, DSDCFG_MODE_ANALOG);
+    rc |= expect_str("rtl-output-left-empty", opts.audio_out_dev, "");
+    rc |= expect_int("rtl-ncurses-disabled", opts.use_ncurses_terminal, 0);
+    return rc;
+}
+
+static int
+test_invalid_prompt_values_use_documented_defaults(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    const char* input = "bogus\n"
+                        "bogus\n"
+                        "maybe\n";
+
+    reset_harness();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    rc |= with_stdin_text(input, dsd_bootstrap_interactive, &opts, &state);
+    rc |= expect_str("invalid-default-pulse-input", opts.audio_in_dev, "pulse:stub-input");
+    rc |= expect_str("invalid-default-pulse-output", opts.audio_out_dev, "pulse:stub-output");
+    rc |= expect_int("invalid-default-decode-mode", g_last_decode_mode, DSDCFG_MODE_AUTO);
+    rc |= expect_int("invalid-default-ncurses", opts.use_ncurses_terminal, 1);
+    return rc;
+}
+
+static int
+test_rtl_empty_frequency_falls_back_to_pulse_devices(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    const char* input = "2\n"
+                        "\n"
+                        "14\n"
+                        "n\n";
+
+    reset_harness();
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    rc |= with_stdin_text(input, dsd_bootstrap_interactive, &opts, &state);
+    rc |= expect_int("rtl-empty-frequency-input-calls", g_audio_input_calls, 1);
+    rc |= expect_int("rtl-empty-frequency-output-calls", g_audio_output_calls, 1);
+    rc |= expect_str("rtl-empty-frequency-pulse-input", opts.audio_in_dev, "pulse:stub-input");
+    rc |= expect_str("rtl-empty-frequency-pulse-output", opts.audio_out_dev, "pulse:stub-output");
+    rc |= expect_int("rtl-empty-frequency-decode-mode", g_last_decode_mode, DSDCFG_MODE_ANALOG);
+    rc |= expect_int("rtl-empty-frequency-ncurses-disabled", opts.use_ncurses_terminal, 0);
+    return rc;
+}
+#endif
+
+static int
+test_non_tty_keeps_defaults(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset_harness();
+    g_isatty = 0;
+    g_config_available = 0;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", "sentinel-in");
+    DSD_SNPRINTF(opts.audio_out_dev, sizeof opts.audio_out_dev, "%s", "sentinel-out");
+
+    dsd_bootstrap_interactive(&opts, &state);
+    rc |= expect_str("non-tty-audio-in", opts.audio_in_dev, "sentinel-in");
+    rc |= expect_str("non-tty-audio-out", opts.audio_out_dev, "sentinel-out");
+    rc |= expect_int("non-tty-config-init", g_config_init_calls, 0);
+    rc |= expect_int("non-tty-decode-mode", g_last_decode_mode, DSDCFG_MODE_UNSET);
+    return rc;
+}
+
+static int
+test_config_no_bootstrap_skips_wizard(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset_harness();
+    g_config.no_bootstrap_enable = 1;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    dsd_bootstrap_interactive(&opts, &state);
+    rc |= expect_int("no-bootstrap-audio-input", g_audio_input_calls, 0);
+    rc |= expect_int("no-bootstrap-audio-output", g_audio_output_calls, 0);
+    rc |= expect_int("no-bootstrap-decode-mode", g_last_decode_mode, DSDCFG_MODE_UNSET);
+    rc |= expect_int("no-bootstrap-ncurses", opts.use_ncurses_terminal, 0);
+    return rc;
+}
+
+static int
+test_missing_config_initializes_runtime_config(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset_harness();
+    g_config_available = 0;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+#if !defined(_WIN32)
+    rc |= with_stdin_text("\n1\nn\n", dsd_bootstrap_interactive, &opts, &state);
+#else
+    dsd_bootstrap_interactive(&opts, &state);
+#endif
+    rc |= expect_int("missing-config-init", g_config_init_calls, 1);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+
+    rc |= test_non_tty_keeps_defaults();
+    rc |= test_config_no_bootstrap_skips_wizard();
+    rc |= test_missing_config_initializes_runtime_config();
+#if !defined(_WIN32)
+    rc |= test_pulse_defaults_apply_decode_and_ncurses();
+    rc |= test_rtltcp_trunking_imports_group_allow_list_and_null_output();
+    rc |= test_tcp_trunking_enables_default_rigctl_and_skips_missing_csv();
+    rc |= test_udp_eof_uses_socket_defaults_and_default_pulse_output();
+    rc |= test_file_input_applies_clamped_low_sample_rate();
+    rc |= test_empty_file_path_falls_back_to_pulse_devices();
+    rc |= test_rtl_input_formats_clamped_radio_options();
+    rc |= test_invalid_prompt_values_use_documented_defaults();
+    rc |= test_rtl_empty_frequency_falls_back_to_pulse_devices();
+#else
+    DSD_FPRINTF(stderr, "stdin redirection coverage skipped on Windows\n");
+#endif
+
+    if (rc == 0) {
+        printf("RUNTIME_BOOTSTRAP_INTERACTIVE: OK\n");
+    }
+    return rc;
+}
+
+// NOLINTEND(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-unix.Errno)

--- a/tests/runtime/test_runtime_bootstrap_system.c
+++ b/tests/runtime/test_runtime_bootstrap_system.c
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/runtime/cli.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/log.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+
+#if defined(__SSE__) || defined(__SSE2__)
+#include <xmmintrin.h>
+#endif
+
+static dsdneoRuntimeConfig g_config;
+static int g_config_available = 1;
+static int g_config_init_calls;
+static int g_config_init_ftz_daz_enable;
+static int g_log_notice_calls;
+static char g_last_log[128];
+
+void
+dsd_neo_log_write(dsd_neo_log_level_t level, const char* format, ...) {
+    if (level == LOG_LEVEL_INFO) {
+        ++g_log_notice_calls;
+    }
+    va_list ap;
+    va_start(ap, format);
+    (void)DSD_VSNPRINTF(g_last_log, sizeof g_last_log, format, ap);
+    va_end(ap);
+}
+
+void
+dsd_neo_config_init(const dsd_opts* opts) {
+    (void)opts;
+    ++g_config_init_calls;
+    g_config_available = 1;
+    DSD_MEMSET(&g_config, 0, sizeof g_config);
+    g_config.ftz_daz_enable = g_config_init_ftz_daz_enable;
+}
+
+const dsdneoRuntimeConfig*
+dsd_neo_get_config(void) {
+    return g_config_available ? &g_config : NULL;
+}
+
+static void
+reset_harness(void) {
+    DSD_MEMSET(&g_config, 0, sizeof g_config);
+    g_config_available = 1;
+    g_config_init_calls = 0;
+    g_config_init_ftz_daz_enable = 0;
+    g_log_notice_calls = 0;
+    g_last_log[0] = '\0';
+}
+
+static void
+test_missing_config_initializes_and_honors_disabled_default(void) {
+    reset_harness();
+    g_config_available = 0;
+
+    dsd_bootstrap_enable_ftz_daz_if_enabled();
+
+#if defined(__SSE__) || defined(__SSE2__)
+    assert(g_config_init_calls == 1);
+    assert(g_log_notice_calls == 0);
+#else
+    assert(g_config_init_calls == 0);
+#endif
+}
+
+static void
+test_disabled_config_does_not_log_or_change_mode(void) {
+    reset_harness();
+
+#if defined(__SSE__) || defined(__SSE2__)
+    unsigned int original = _mm_getcsr();
+    dsd_bootstrap_enable_ftz_daz_if_enabled();
+    assert(_mm_getcsr() == original);
+    assert(g_log_notice_calls == 0);
+#else
+    dsd_bootstrap_enable_ftz_daz_if_enabled();
+#endif
+}
+
+static void
+test_enabled_config_sets_ftz_daz_bits(void) {
+    reset_harness();
+    g_config.ftz_daz_enable = 1;
+
+#if defined(__SSE__) || defined(__SSE2__)
+    const unsigned int ftz_daz_bits = (1u << 15) | (1u << 6);
+    unsigned int original = _mm_getcsr();
+    _mm_setcsr(original & ~ftz_daz_bits);
+
+    dsd_bootstrap_enable_ftz_daz_if_enabled();
+
+    assert((_mm_getcsr() & ftz_daz_bits) == ftz_daz_bits);
+    assert(g_log_notice_calls == 1);
+    assert(strstr(g_last_log, "FTZ/DAZ") != NULL);
+    _mm_setcsr(original);
+#else
+    dsd_bootstrap_enable_ftz_daz_if_enabled();
+    assert(g_log_notice_calls == 0);
+#endif
+}
+
+int
+main(void) {
+    test_missing_config_initializes_and_honors_disabled_default();
+    test_disabled_config_does_not_log_or_change_mode();
+    test_enabled_config_sets_ftz_daz_bits();
+
+    printf("RUNTIME_BOOTSTRAP_SYSTEM: OK\n");
+    return 0;
+}

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -2426,6 +2426,111 @@ test_bootstrap_profile_disables_autosave(void) {
 }
 
 static int
+test_bootstrap_missing_profile_errors_without_applying_config_or_cli(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    (void)dsd_unsetenv("DSD_NEO_CONFIG");
+    (void)dsd_setenv("DSD_NEO_NO_BOOTSTRAP", "1", 1);
+
+    static const char* ini = "version = 1\n"
+                             "\n"
+                             "[input]\n"
+                             "source = \"rtl\"\n"
+                             "rtl_device = 7\n"
+                             "rtl_freq = \"851.0125M\"\n"
+                             "\n"
+                             "[trunking]\n"
+                             "enabled = true\n"
+                             "\n"
+                             "[profile.valid]\n"
+                             "output.ncurses_ui = true\n";
+
+    char cfg_path[1024];
+    if (test_create_temp_ini_with_contents(ini, cfg_path, sizeof cfg_path) != 0) {
+        DSD_FPRINTF(stderr, "failed to create temp profile ini\n");
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--config";
+    char arg2[1024];
+    char arg3[] = "--profile";
+    char arg4[] = "missing";
+    char arg5[] = "-N";
+    DSD_SNPRINTF(arg2, sizeof arg2, "%s", cfg_path);
+    char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, NULL};
+
+    dsd_test_capture_stderr cap;
+    if (dsd_test_capture_stderr_begin(&cap, "runtime_cli_missing_profile") != 0) {
+        (void)remove(cfg_path);
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    int argc_effective = 0;
+    int exit_rc = -1;
+    int rc = dsd_runtime_bootstrap(6, argv, opts, state, &argc_effective, &exit_rc);
+
+    int capture_failed = dsd_test_capture_stderr_end(&cap);
+    char stderr_buf[2048];
+    stderr_buf[0] = '\0';
+    if (!capture_failed) {
+        capture_failed = read_file_to_buffer(cap.path, stderr_buf, sizeof stderr_buf);
+    }
+    (void)remove(cap.path);
+
+    int test_rc = 0;
+    if (capture_failed) {
+        DSD_FPRINTF(stderr, "failed to capture missing-profile diagnostics\n");
+        test_rc = 1;
+    }
+    if (rc != DSD_BOOTSTRAP_ERROR || exit_rc != 1) {
+        DSD_FPRINTF(stderr, "expected missing profile bootstrap error, got rc=%d exit_rc=%d\n", rc, exit_rc);
+        test_rc = 1;
+    }
+    if (!strstr(stderr_buf, "Profile 'missing' not found")) {
+        DSD_FPRINTF(stderr, "expected missing profile diagnostic, got:\n%s\n", stderr_buf);
+        test_rc = 1;
+    }
+    if (opts->use_ncurses_terminal != 0) {
+        DSD_FPRINTF(stderr, "missing profile should stop before CLI -N applies, got ncurses=%d\n",
+                    opts->use_ncurses_terminal);
+        test_rc = 1;
+    }
+    if (strncmp(opts->audio_in_dev, "rtl:", 4) == 0 || opts->trunk_enable != 0 || opts->p25_trunk != 0) {
+        DSD_FPRINTF(stderr, "missing profile should not apply config: input=%s trunk=%d p25=%d\n", opts->audio_in_dev,
+                    opts->trunk_enable, opts->p25_trunk);
+        test_rc = 1;
+    }
+    if (state->cli_argc_effective != 0) {
+        DSD_FPRINTF(stderr, "missing profile should stop before recording effective CLI args, got %d\n",
+                    state->cli_argc_effective);
+        test_rc = 1;
+    }
+
+    (void)remove(cfg_path);
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
 test_bootstrap_cli_call_alert_restores_all_config_filtered_events(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
@@ -5767,6 +5872,7 @@ main(void) {
     rc |= test_bootstrap_inherited_trunk_scan_preserves_timing_overrides();
     rc |= test_bootstrap_config_one_shots_skip_trunk_scan_runtime_validation();
     rc |= test_bootstrap_profile_disables_autosave();
+    rc |= test_bootstrap_missing_profile_errors_without_applying_config_or_cli();
     rc |= test_bootstrap_cli_call_alert_restores_all_config_filtered_events();
     rc |= test_r_playback_optind_is_first_file_regardless_of_option_order();
     rc |= test_open_mbe_missing_file_leaves_stream_null();

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -18,11 +18,12 @@
 #include <dsd-neo/runtime/call_alert.h>
 #include <dsd-neo/runtime/cli.h>
 #include <dsd-neo/runtime/rdio_export.h>
+#include <inttypes.h>
 #include <sndfile.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -1430,6 +1431,104 @@ test_bootstrap_missing_explicit_config_keeps_autosave_path(void) {
 }
 
 static int
+test_bootstrap_rejects_too_long_explicit_config_path(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    (void)dsd_unsetenv("DSD_NEO_CONFIG");
+    (void)dsd_setenv("DSD_NEO_NO_BOOTSTRAP", "1", 1);
+
+    char too_long_path[3072];
+    DSD_MEMSET(too_long_path, 'a', sizeof too_long_path);
+    too_long_path[sizeof too_long_path - 1] = '\0';
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--config";
+    char* argv[] = {arg0, arg1, too_long_path, NULL};
+
+    int argc_effective = 99;
+    int exit_rc = -1;
+    int rc = dsd_runtime_bootstrap(3, argv, opts, state, &argc_effective, &exit_rc);
+
+    int test_rc = 0;
+    if (rc != DSD_BOOTSTRAP_ERROR || exit_rc != 1) {
+        DSD_FPRINTF(stderr, "expected too-long config path error, got rc=%d exit_rc=%d\n", rc, exit_rc);
+        test_rc = 1;
+    }
+    if (state->config_autosave_enabled || state->config_autosave_path[0] != '\0') {
+        DSD_FPRINTF(stderr, "expected invalid config path to leave autosave disabled, got enabled=%d path=%s\n",
+                    state->config_autosave_enabled, state->config_autosave_path);
+        test_rc = 1;
+    }
+
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
+test_bootstrap_guard_rejects_invalid_arguments(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    char arg0[] = "dsd-neo";
+    char* argv[] = {arg0, NULL};
+
+    int exit_rc = -1;
+    int test_rc = 0;
+    int rc = dsd_runtime_bootstrap(1, argv, NULL, state, NULL, &exit_rc);
+    if (rc != DSD_BOOTSTRAP_ERROR || exit_rc != 1) {
+        DSD_FPRINTF(stderr, "expected NULL opts guard error, got rc=%d exit_rc=%d\n", rc, exit_rc);
+        test_rc = 1;
+    }
+
+    exit_rc = -1;
+    rc = dsd_runtime_bootstrap(1, argv, opts, NULL, NULL, &exit_rc);
+    if (rc != DSD_BOOTSTRAP_ERROR || exit_rc != 1) {
+        DSD_FPRINTF(stderr, "expected NULL state guard error, got rc=%d exit_rc=%d\n", rc, exit_rc);
+        test_rc = 1;
+    }
+
+    exit_rc = -1;
+    rc = dsd_runtime_bootstrap(-1, argv, opts, state, NULL, &exit_rc);
+    if (rc != DSD_BOOTSTRAP_ERROR || exit_rc != 1) {
+        DSD_FPRINTF(stderr, "expected negative argc guard error, got rc=%d exit_rc=%d\n", rc, exit_rc);
+        test_rc = 1;
+    }
+
+    exit_rc = -1;
+    rc = dsd_runtime_bootstrap(1, NULL, opts, state, NULL, &exit_rc);
+    if (rc != DSD_BOOTSTRAP_ERROR || exit_rc != 1) {
+        DSD_FPRINTF(stderr, "expected NULL argv guard error, got rc=%d exit_rc=%d\n", rc, exit_rc);
+        test_rc = 1;
+    }
+
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
 test_bootstrap_validate_config_accepts_external_path(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
@@ -1529,6 +1628,57 @@ test_bootstrap_validate_config_reports_trunk_scan_diagnostics(void) {
 }
 
 static int
+test_bootstrap_validate_config_strict_warning_exits_two(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    char cfg_path[1024];
+    if (test_create_temp_ini_in_tmpdir_with_contents("version = 1\n"
+                                                     "\n"
+                                                     "[input]\n"
+                                                     "source = \"pulse\"\n"
+                                                     "unknown_key = true\n",
+                                                     cfg_path, sizeof cfg_path)
+        != 0) {
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--validate-config";
+    char arg2[1024];
+    char arg3[] = "--strict-config";
+    DSD_SNPRINTF(arg2, sizeof arg2, "%s", cfg_path);
+    char* argv[] = {arg0, arg1, arg2, arg3, NULL};
+
+    int argc_effective = 0;
+    int exit_rc = -1;
+    int rc = dsd_runtime_bootstrap(4, argv, opts, state, &argc_effective, &exit_rc);
+    int test_rc = 0;
+    if (rc != DSD_BOOTSTRAP_EXIT || exit_rc != 2) {
+        DSD_FPRINTF(stderr, "expected strict warning validate exit 2, got rc=%d exit_rc=%d\n", rc, exit_rc);
+        test_rc = 1;
+    }
+
+    (void)remove(cfg_path);
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
 test_bootstrap_list_profiles_accepts_external_config_path(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
@@ -1568,6 +1718,52 @@ test_bootstrap_list_profiles_accepts_external_config_path(void) {
     int test_rc = 0;
     if (rc != DSD_BOOTSTRAP_EXIT || exit_rc != 0) {
         DSD_FPRINTF(stderr, "expected external list-profiles to exit 0, got rc=%d exit_rc=%d\n", rc, exit_rc);
+        test_rc = 1;
+    }
+
+    (void)remove(cfg_path);
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
+test_bootstrap_list_profiles_reports_empty_config(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    char cfg_path[1024];
+    if (test_create_temp_ini_in_tmpdir_with_contents("version = 1\n", cfg_path, sizeof cfg_path) != 0) {
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--config";
+    char arg2[1024];
+    char arg3[] = "--list-profiles";
+    DSD_SNPRINTF(arg2, sizeof arg2, "%s", cfg_path);
+    char* argv[] = {arg0, arg1, arg2, arg3, NULL};
+
+    int argc_effective = 0;
+    int exit_rc = -1;
+    test_redirect_stdout_to_null();
+    int rc = dsd_runtime_bootstrap(4, argv, opts, state, &argc_effective, &exit_rc);
+    int test_rc = 0;
+    if (rc != DSD_BOOTSTRAP_EXIT || exit_rc != 0) {
+        DSD_FPRINTF(stderr, "expected empty profile list to exit 0, got rc=%d exit_rc=%d\n", rc, exit_rc);
         test_rc = 1;
     }
 
@@ -1869,6 +2065,72 @@ test_bootstrap_inherited_trunk_scan_allows_cli_channel_map(void) {
     }
 
     (void)remove(chan_path);
+    (void)remove(cfg_path);
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
+test_bootstrap_inherited_trunk_scan_disables_for_positional_input(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    (void)dsd_unsetenv("DSD_NEO_CONFIG");
+    (void)dsd_setenv("DSD_NEO_NO_BOOTSTRAP", "1", 1);
+
+    static const char* ini = "version = 1\n"
+                             "\n"
+                             "[trunk_scan]\n"
+                             "enabled = true\n"
+                             "targets_csv = \"targets.csv\"\n";
+
+    char cfg_path[1024];
+    if (test_create_temp_ini_with_contents(ini, cfg_path, sizeof cfg_path) != 0) {
+        DSD_FPRINTF(stderr, "failed to create temp trunk scan ini\n");
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--config";
+    char arg2[1024];
+    char arg3[] = "input.amb";
+    DSD_SNPRINTF(arg2, sizeof arg2, "%s", cfg_path);
+    char* argv[] = {arg0, arg1, arg2, arg3, NULL};
+
+    int argc_effective = 0;
+    int exit_rc = -1;
+    int rc = dsd_runtime_bootstrap(4, argv, opts, state, &argc_effective, &exit_rc);
+
+    int test_rc = 0;
+    if (rc != DSD_BOOTSTRAP_CONTINUE || exit_rc != 0) {
+        DSD_FPRINTF(stderr, "expected positional input bootstrap continue, got rc=%d exit_rc=%d\n", rc, exit_rc);
+        test_rc = 1;
+    }
+    if (opts->trunk_scan_enabled != 0) {
+        DSD_FPRINTF(stderr, "expected positional input to disable inherited trunk scan, got %d\n",
+                    opts->trunk_scan_enabled);
+        test_rc = 1;
+    }
+    if (argc_effective != 2 || strcmp(argv[1], "input.amb") != 0) {
+        DSD_FPRINTF(stderr, "expected positional playback arg to survive compaction, argc=%d arg1=%s\n", argc_effective,
+                    argc_effective > 1 ? argv[1] : "(missing)");
+        test_rc = 1;
+    }
+
     (void)remove(cfg_path);
     freeState(state);
     free(opts);
@@ -3225,6 +3487,52 @@ test_iq_capture_max_mb_missing_value_returns_error(void) {
 }
 
 static int
+test_iq_capture_max_mb_rejects_invalid_values(void) {
+    const char* invalid_options[] = {
+        "--iq-capture-max-mb=",
+        "--iq-capture-max-mb=12mb",
+        "--iq-capture-max-mb=18446744073709551616",
+        "--iq-capture-max-mb=17592186044416",
+    };
+    int test_rc = 0;
+
+    for (size_t i = 0; i < sizeof(invalid_options) / sizeof(invalid_options[0]); i++) {
+        dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+        dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+        if (!opts || !state) {
+            free(opts);
+            free(state);
+            DSD_FPRINTF(stderr, "out of memory\n");
+            return 1;
+        }
+
+        initOpts(opts);
+        initState(state);
+
+        char arg0[] = "dsd-neo";
+        char arg1[96];
+        DSD_SNPRINTF(arg1, sizeof arg1, "%s", invalid_options[i]);
+        char* argv[] = {arg0, arg1, NULL};
+
+        int argc_effective = 0;
+        int exit_rc = -1;
+        int rc = dsd_parse_args(2, argv, opts, state, &argc_effective, &exit_rc);
+        if (rc != DSD_PARSE_ERROR || exit_rc != 1 || opts->iq_capture_max_bytes != 0U) {
+            DSD_FPRINTF(stderr,
+                        "expected invalid %s to fail without setting max bytes, got rc=%d exit_rc=%d max=%" PRIu64 "\n",
+                        invalid_options[i], rc, exit_rc, opts->iq_capture_max_bytes);
+            test_rc = 1;
+        }
+
+        freeState(state);
+        free(opts);
+        free(state);
+    }
+
+    return test_rc;
+}
+
+static int
 test_iq_replay_missing_value_returns_error(void) {
     return test_missing_required_long_option_value_returns_error("--iq-replay");
 }
@@ -3403,6 +3711,45 @@ test_rtl_udp_control_invalid_bind_returns_error(void) {
     free(opts);
     free(state);
     return 0;
+}
+
+static int
+test_rtl_udp_control_rejects_malformed_numeric_binds(void) {
+    const char* invalid_binds[] = {"999.1.1.1", "1.2.3.", "1.2.3"};
+    int test_rc = 0;
+
+    for (size_t i = 0; i < sizeof(invalid_binds) / sizeof(invalid_binds[0]); i++) {
+        dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+        dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+        if (!opts || !state) {
+            free(opts);
+            free(state);
+            DSD_FPRINTF(stderr, "out of memory\n");
+            return 1;
+        }
+
+        initOpts(opts);
+        initState(state);
+
+        char arg0[] = "dsd-neo";
+        char arg1[] = "--rtl-udp-control-bind";
+        char* argv[] = {arg0, arg1, (char*)invalid_binds[i], NULL};
+
+        int argc_effective = 0;
+        int exit_rc = -1;
+        int rc = dsd_parse_args(3, argv, opts, state, &argc_effective, &exit_rc);
+        if (rc != DSD_PARSE_ERROR || exit_rc != 1) {
+            DSD_FPRINTF(stderr, "expected invalid bind %s to fail, got rc=%d exit_rc=%d\n", invalid_binds[i], rc,
+                        exit_rc);
+            test_rc = 1;
+        }
+
+        freeState(state);
+        free(opts);
+        free(state);
+    }
+
+    return test_rc;
 }
 
 static int
@@ -3831,6 +4178,58 @@ test_m17_signature_public_key_long_option_parse(void) {
     if (state->m17_signature_public_key_loaded != 1U
         || memcmp(state->m17_signature_public_key, expected, sizeof(expected)) != 0) {
         DSD_FPRINTF(stderr, "expected parsed M17 signature public key bytes to match\n");
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    freeState(state);
+    free(opts);
+    free(state);
+    return 0;
+}
+
+static int
+test_m17_signature_public_key_accepts_lowercase_spaced_hex(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--m17-signature-public-key";
+    char arg2[] = "  0x253dd9ce177042a6056f069c096a68f9937e5ec82f76f49bdcb78ee10b691373a\n"
+                  "48911b59c269eaa33bc428fe598ce87add4ed6d1b4e0efafb2558456dfc35de";
+    char* argv[] = {arg0, arg1, arg2, NULL};
+
+    int argc_effective = 0;
+    int exit_rc = -1;
+    int rc = dsd_parse_args(3, argv, opts, state, &argc_effective, &exit_rc);
+    if (rc != DSD_PARSE_CONTINUE) {
+        DSD_FPRINTF(stderr, "expected rc=%d, got %d (exit_rc=%d)\n", DSD_PARSE_CONTINUE, rc, exit_rc);
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    static const uint8_t expected[DSD_ECDSA_P256_PUBLIC_KEY_BYTES] = {
+        0x25U, 0x3DU, 0xD9U, 0xCEU, 0x17U, 0x70U, 0x42U, 0xA6U, 0x05U, 0x6FU, 0x06U, 0x9CU, 0x09U, 0x6AU, 0x68U, 0xF9U,
+        0x93U, 0x7EU, 0x5EU, 0xC8U, 0x2FU, 0x76U, 0xF4U, 0x9BU, 0xDCU, 0xB7U, 0x8EU, 0xE1U, 0x0BU, 0x69U, 0x13U, 0x73U,
+        0xA4U, 0x89U, 0x11U, 0xB5U, 0x9CU, 0x26U, 0x9EU, 0xAAU, 0x33U, 0xBCU, 0x42U, 0x8FU, 0xE5U, 0x98U, 0xCEU, 0x87U,
+        0xADU, 0xD4U, 0xEDU, 0x6DU, 0x1BU, 0x4EU, 0x0EU, 0xFAU, 0xFBU, 0x25U, 0x58U, 0x45U, 0x6DU, 0xFCU, 0x35U, 0xDEU,
+    };
+    if (state->m17_signature_public_key_loaded != 1U
+        || memcmp(state->m17_signature_public_key, expected, sizeof(expected)) != 0) {
+        DSD_FPRINTF(stderr, "expected lowercase spaced M17 signature public key bytes to match\n");
         freeState(state);
         free(opts);
         free(state);
@@ -4452,6 +4851,73 @@ test_bootstrap_config_file_rate_survives_cli_provoice_preset(void) {
 }
 
 static int
+test_bootstrap_compact_s_rate_override_clears_config_file_rate(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    (void)dsd_unsetenv("DSD_NEO_CONFIG");
+    (void)dsd_setenv("DSD_NEO_NO_BOOTSTRAP", "1", 1);
+
+    static const char* ini = "version = 1\n"
+                             "\n"
+                             "[input]\n"
+                             "source = \"file\"\n"
+                             "file_path = \"/tmp/input.wav\"\n"
+                             "file_sample_rate = 96000\n";
+
+    char cfg_path[1024];
+    if (test_create_temp_ini_with_contents(ini, cfg_path, sizeof cfg_path) != 0) {
+        DSD_FPRINTF(stderr, "failed to create temp file-input ini\n");
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--config";
+    char arg2[1024];
+    char arg3[] = "-s44100";
+    DSD_SNPRINTF(arg2, sizeof arg2, "%s", cfg_path);
+    char* argv[] = {arg0, arg1, arg2, arg3, NULL};
+
+    int argc_effective = 0;
+    int exit_rc = -1;
+    int rc = dsd_runtime_bootstrap(4, argv, opts, state, &argc_effective, &exit_rc);
+
+    int test_rc = 0;
+    if (rc != DSD_BOOTSTRAP_CONTINUE || exit_rc != 0) {
+        DSD_FPRINTF(stderr, "expected compact -s bootstrap continue, got rc=%d exit_rc=%d\n", rc, exit_rc);
+        test_rc = 1;
+    }
+    if (opts->wav_sample_rate != 44100 || dsd_opts_effective_input_rate(opts) != 44100) {
+        DSD_FPRINTF(stderr, "expected compact -s44100 to keep 44100 Hz, got raw=%d effective=%d\n",
+                    opts->wav_sample_rate, dsd_opts_effective_input_rate(opts));
+        test_rc = 1;
+    }
+    if (opts->staged_file_sample_rate != 0) {
+        DSD_FPRINTF(stderr, "expected compact -s44100 to clear staged config rate, got %d\n",
+                    opts->staged_file_sample_rate);
+        test_rc = 1;
+    }
+
+    (void)remove(cfg_path);
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
 test_s_8000_keeps_valid_symbol_timing_for_provoice(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
@@ -4686,6 +5152,96 @@ test_trunk_scan_cli_clears_inherited_channel_map(void) {
     freeState(state);
     free(opts);
     free(state);
+    return test_rc;
+}
+
+static int
+test_trunk_scan_inherited_state_rejects_invalid_runtime_combinations(void) {
+    int test_rc = 0;
+
+    for (int scenario = 0; scenario < 3; scenario++) {
+        dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+        dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+        if (!opts || !state) {
+            free(opts);
+            free(state);
+            return 1;
+        }
+        initOpts(opts);
+        initState(state);
+
+        opts->trunk_scan_enabled = 1;
+        if (scenario == 0) {
+            opts->scanner_mode = 1;
+            DSD_SNPRINTF(opts->trunk_scan_targets_csv, sizeof opts->trunk_scan_targets_csv, "%s", "targets.csv");
+        } else if (scenario == 1) {
+            DSD_SNPRINTF(opts->trunk_scan_targets_csv, sizeof opts->trunk_scan_targets_csv, "%s", "targets.csv");
+            DSD_SNPRINTF(opts->chan_in_file, sizeof opts->chan_in_file, "%s", "global_channels.csv");
+        }
+
+        char arg0[] = "dsd-neo";
+        char* argv[] = {arg0, NULL};
+        int argc_effective = 0;
+        int exit_rc = -1;
+        int rc = dsd_parse_args(1, argv, opts, state, &argc_effective, &exit_rc);
+        if (rc != DSD_PARSE_ERROR || exit_rc != 1) {
+            DSD_FPRINTF(stderr, "expected inherited trunk-scan scenario %d to fail, got rc=%d exit_rc=%d\n", scenario,
+                        rc, exit_rc);
+            test_rc = 1;
+        }
+
+        freeState(state);
+        free(opts);
+        free(state);
+    }
+
+    return test_rc;
+}
+
+static int
+test_trunk_scan_rejects_ms_values_outside_range(void) {
+    const char* argv_sets[][3] = {
+        {"dsd-neo", "--trunk-scan-dwell-ms", "249"},
+        {"dsd-neo", "--trunk-scan-activity-hold-ms=600001", NULL},
+    };
+    const int argc_values[] = {3, 2};
+    int test_rc = 0;
+
+    for (size_t i = 0; i < sizeof(argc_values) / sizeof(argc_values[0]); i++) {
+        dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+        dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+        if (!opts || !state) {
+            free(opts);
+            free(state);
+            return 1;
+        }
+        initOpts(opts);
+        initState(state);
+
+        char arg0[32];
+        char arg1[64];
+        char arg2[32];
+        DSD_SNPRINTF(arg0, sizeof arg0, "%s", argv_sets[i][0]);
+        DSD_SNPRINTF(arg1, sizeof arg1, "%s", argv_sets[i][1]);
+        if (argv_sets[i][2]) {
+            DSD_SNPRINTF(arg2, sizeof arg2, "%s", argv_sets[i][2]);
+        }
+        char* argv[] = {arg0, arg1, argv_sets[i][2] ? arg2 : NULL, NULL};
+
+        int argc_effective = 0;
+        int exit_rc = -1;
+        int rc = dsd_parse_args(argc_values[i], argv, opts, state, &argc_effective, &exit_rc);
+        if (rc != DSD_PARSE_ERROR || exit_rc != 1) {
+            DSD_FPRINTF(stderr, "expected trunk-scan millisecond option %s to fail, got rc=%d exit_rc=%d\n", arg1, rc,
+                        exit_rc);
+            test_rc = 1;
+        }
+
+        freeState(state);
+        free(opts);
+        free(state);
+    }
+
     return test_rc;
 }
 
@@ -5195,13 +5751,18 @@ main(void) {
     rc |= test_bootstrap_treats_lone_ini_as_config();
     rc |= test_bootstrap_accepts_explicit_config_path_outside_cwd();
     rc |= test_bootstrap_missing_explicit_config_keeps_autosave_path();
+    rc |= test_bootstrap_rejects_too_long_explicit_config_path();
+    rc |= test_bootstrap_guard_rejects_invalid_arguments();
     rc |= test_bootstrap_validate_config_accepts_external_path();
+    rc |= test_bootstrap_validate_config_strict_warning_exits_two();
     rc |= test_bootstrap_validate_config_reports_trunk_scan_diagnostics();
     rc |= test_bootstrap_list_profiles_accepts_external_config_path();
+    rc |= test_bootstrap_list_profiles_reports_empty_config();
     rc |= test_bootstrap_print_config_normalizes_soapy_shorthand();
     rc |= test_bootstrap_profile_preserves_trunking_with_ncurses_cli();
     rc |= test_bootstrap_inherited_trunk_scan_preserves_ui_only_short_options();
     rc |= test_bootstrap_inherited_trunk_scan_allows_cli_channel_map();
+    rc |= test_bootstrap_inherited_trunk_scan_disables_for_positional_input();
     rc |= test_bootstrap_inherited_trunk_scan_disables_for_long_only_runtime_mode();
     rc |= test_bootstrap_inherited_trunk_scan_preserves_timing_overrides();
     rc |= test_bootstrap_config_one_shots_skip_trunk_scan_runtime_validation();
@@ -5225,10 +5786,13 @@ main(void) {
     rc |= test_trunk_scan_conflicts_with_legacy_scanner();
     rc |= test_trunk_scan_rejects_global_channel_map();
     rc |= test_trunk_scan_cli_clears_inherited_channel_map();
+    rc |= test_trunk_scan_inherited_state_rejects_invalid_runtime_combinations();
+    rc |= test_trunk_scan_rejects_ms_values_outside_range();
     rc |= test_iq_capture_long_options_parse();
     rc |= test_iq_capture_missing_value_returns_error();
     rc |= test_iq_capture_format_missing_value_returns_error();
     rc |= test_iq_capture_max_mb_missing_value_returns_error();
+    rc |= test_iq_capture_max_mb_rejects_invalid_values();
     rc |= test_iq_replay_long_options_parse();
     rc |= test_iq_replay_audio_classifier_respects_radio_guard();
     rc |= test_iq_replay_rate_missing_value_returns_error();
@@ -5240,6 +5804,7 @@ main(void) {
     rc |= test_rtl_udp_control_missing_port_returns_error();
     rc |= test_rtl_udp_control_bind_long_option_parse();
     rc |= test_rtl_udp_control_invalid_bind_returns_error();
+    rc |= test_rtl_udp_control_rejects_malformed_numeric_binds();
     rc |= test_rtl_udp_control_port_too_large_returns_error();
     rc |= test_rtl_udp_control_bind_missing_value_returns_error();
     rc |= test_dmr_baofeng_pc5_long_option_parse();
@@ -5250,6 +5815,7 @@ main(void) {
     rc |= test_dmr_force_algid_long_option_parse();
     rc |= test_dmr_force_algid_long_option_rejects_invalid_value();
     rc |= test_m17_signature_public_key_long_option_parse();
+    rc |= test_m17_signature_public_key_accepts_lowercase_spaced_hex();
     rc |= test_m17_signature_public_key_long_option_rejects_invalid_value();
     rc |= test_m17_signature_public_key_missing_value_returns_error();
     rc |= test_dmr_baofeng_pc5_long_option_rejects_invalid_key();
@@ -5263,6 +5829,7 @@ main(void) {
     rc |= test_mc_before_legacy_fr_preserves_c4fm_lock();
     rc |= test_f_nxdn48_clears_dmr_mono_after_fr();
     rc |= test_bootstrap_config_file_rate_survives_cli_provoice_preset();
+    rc |= test_bootstrap_compact_s_rate_override_clears_config_file_rate();
     rc |= test_s_8000_keeps_valid_symbol_timing_for_provoice();
     rc |= test_m3_override_survives_file_rate_rescale_after_f2();
     rc |= test_bootstrap_config_file_rate_rescales_manual_m3_override();

--- a/tests/runtime/test_runtime_config_apply.cpp
+++ b/tests/runtime/test_runtime_config_apply.cpp
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(performance-type-promotion-in-math-fn)
 /*
  * Copyright (C) 2025 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -18,17 +21,25 @@
 #include <dsd-neo/core/init.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/exitflag.h>
 #include <dsd-neo/ui/ui_async.h>
 #include <dsd-neo/ui/ui_cmd.h>
+#include <dsd-neo/ui/ui_dsp_cmd.h>
 #include <math.h>
 #include <sndfile.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "dsd-neo/core/dibit.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/platform/file_compat.h"
 #include "dsd-neo/platform/posix_compat.h"
@@ -79,6 +90,24 @@ expect_float_ne(const char* label, float lhs, float rhs) {
         return 1;
     }
     return 0;
+}
+
+static int
+expect_float_near(const char* label, float got, float want, float tolerance) {
+    if (fabsf(got - want) > tolerance) {
+        DSD_FPRINTF(stderr, "FAIL: %s (got %.6f want %.6f)\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static uint16_t
+static_bits_to_u16(const uint8_t bits[882]) {
+    uint16_t value = 0U;
+    for (int i = 0; i < 16; ++i) {
+        value = (uint16_t)((value << 1U) | (uint16_t)(bits[i] & 1U));
+    }
+    return value;
 }
 
 static int g_tcp_connect_audio_calls = 0;
@@ -249,6 +278,29 @@ create_temp_wav_file(const char* prefix, int sample_rate, int channels, char* ou
 }
 
 static int
+create_removed_temp_path(const char* prefix, char* out_path, size_t out_path_sz) {
+    if (!prefix || !out_path || out_path_sz == 0) {
+        DSD_FPRINTF(stderr, "FAIL: invalid temp path request\n");
+        return 1;
+    }
+
+    char path[DSD_TEST_PATH_MAX] = {0};
+    int fd = dsd_test_mkstemp(path, sizeof path, prefix);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "FAIL: dsd_test_mkstemp failed for %s\n", prefix);
+        return 1;
+    }
+    (void)dsd_close(fd);
+    (void)remove(path);
+
+    if (DSD_SNPRINTF(out_path, out_path_sz, "%s", path) >= (int)out_path_sz) {
+        DSD_FPRINTF(stderr, "FAIL: temp path too long for %s\n", prefix);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 create_temp_raw_pcm_wav_suffix(const char* prefix, const short* samples, size_t sample_count, char* out_path,
                                size_t out_path_sz) {
     if (!prefix || !samples || sample_count == 0 || !out_path || out_path_sz == 0) {
@@ -323,6 +375,97 @@ test_basic_pulse_config_apply(void) {
     rc |= expect_true("ncurses flag enabled", opts->use_ncurses_terminal);
     rc |= expect_true("pulse input preserved", strncmp(opts->audio_in_dev, "pulse", 5) == 0);
     rc |= expect_true("pulse output preserved", strncmp(opts->audio_out_dev, "pulse", 5) == 0);
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_command_queue_applies_fifo(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    int32_t first = 5;
+    int32_t second = 11;
+    ui_post_cmd(UI_CMD_GAIN_SET, &first, sizeof first);
+    ui_post_cmd(UI_CMD_GAIN_SET, &second, sizeof second);
+
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("FIFO drain count", applied, 2);
+    rc |= expect_int_eq("FIFO final digital gain", (int)opts->audio_gain, second);
+    rc |= expect_int_eq("FIFO final left state gain", (int)state->aout_gain, second);
+    rc |= expect_int_eq("FIFO final right state gain", (int)state->aout_gainR, second);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_command_queue_overflow_drops_oldest(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    dsd_exitflag_store(0);
+    ui_post_cmd(UI_CMD_QUIT, NULL, 0);
+    for (int i = 0; i < 127; i++) {
+        int32_t gain = i;
+        ui_post_cmd(UI_CMD_GAIN_SET, &gain, sizeof gain);
+    }
+
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("overflow keeps bounded queue depth", applied, 127);
+    rc |= expect_int_eq("overflow drops oldest quit command", (int)dsd_exitflag_load(), 0);
+    rc |= expect_int_eq("overflow applies newest gain command with clamp", (int)opts->audio_gain, 50);
+    rc |= expect_int_eq("overflow updates gain snapshot", (int)state->aout_gain, 50);
+
+    dsd_exitflag_store(0);
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_command_queue_truncates_oversized_payload_string(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    enum { OVERSIZED_PAYLOAD_LEN = UI_CMD_DATA_MAX + 97 };
+
+    char* oversized = (char*)malloc(OVERSIZED_PAYLOAD_LEN);
+    if (!oversized) {
+        DSD_FPRINTF(stderr, "FAIL: oversized payload alloc\n");
+        free_test_runtime(&runtime);
+        return 1;
+    }
+    DSD_MEMSET(oversized, 'x', OVERSIZED_PAYLOAD_LEN);
+
+    ui_post_cmd(UI_CMD_INPUT_WAV_SET, oversized, OVERSIZED_PAYLOAD_LEN);
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("oversized string command drain count", applied, 1);
+    rc |= expect_int_eq("oversized string switches input type", opts->audio_in_type, AUDIO_IN_WAV);
+    rc |= expect_int_eq("oversized string is field bounded", (int)strlen(opts->audio_in_dev),
+                        (int)sizeof(opts->audio_in_dev) - 1);
+    rc |= expect_true("oversized string preserves copied prefix",
+                      strspn(opts->audio_in_dev, "x") == strlen(opts->audio_in_dev));
+    rc |= expect_true("oversized string writes toast", strstr(state->ui_msg, "Applied: WAV input") != NULL);
+
+    free(oversized);
     free_test_runtime(&runtime);
     return rc;
 }
@@ -682,6 +825,61 @@ test_ui_aes_key_command_clears_manual_hytera_fields(void) {
 }
 
 static int
+test_ui_aes_key_command_handles_zero_and_short_payloads(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    state->A1[0] = 0x1111ULL;
+    state->aes_key_loaded[0] = 1;
+    state->aes_key_segments[0] = 2U;
+    state->H = 0x1234ULL;
+    state->K1 = 0x5678ULL;
+    state->hytera_key_segments = 1U;
+    state->keyloader = 1;
+    opts->dmr_mute_encL = 1;
+    opts->dmr_mute_encR = 1;
+
+    uint64_t short_payload[3] = {0x10ULL, 0x20ULL, 0x30ULL};
+    ui_post_cmd(UI_CMD_KEY_AES_SET, short_payload, sizeof short_payload);
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("short AES key command is drained", applied, 1);
+    rc |= expect_u64_eq("short AES preserves A1", state->A1[0], 0x1111ULL);
+    rc |= expect_int_eq("short AES preserves loaded flag", state->aes_key_loaded[0], 1);
+    rc |= expect_int_eq("short AES preserves segment count", (int)state->aes_key_segments[0], 2);
+    rc |= expect_int_eq("short AES preserves keyloader", state->keyloader, 1);
+    rc |= expect_int_eq("short AES preserves encrypted mute", opts->dmr_mute_encL, 1);
+
+    struct AesKeyPayload {
+        uint64_t K1, K2, K3, K4;
+    } zero = {0ULL, 0ULL, 0ULL, 0ULL};
+
+    ui_post_cmd(UI_CMD_KEY_AES_SET, &zero, sizeof zero);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("zero AES key command is drained", applied, 1);
+    rc |= expect_u64_eq("zero AES clears A1 slot 0", state->A1[0], 0ULL);
+    rc |= expect_u64_eq("zero AES clears A4 slot 1", state->A4[1], 0ULL);
+    rc |= expect_int_eq("zero AES leaves slot 0 unloaded", state->aes_key_loaded[0], 0);
+    rc |= expect_int_eq("zero AES leaves slot 1 unloaded", state->aes_key_loaded[1], 0);
+    rc |= expect_int_eq("zero AES records full segment width slot 0", (int)state->aes_key_segments[0], 4);
+    rc |= expect_int_eq("zero AES records full segment width slot 1", (int)state->aes_key_segments[1], 4);
+    rc |= expect_u64_eq("zero AES clears Hytera H", state->H, 0ULL);
+    rc |= expect_u64_eq("zero AES clears Hytera K1", state->K1, 0ULL);
+    rc |= expect_int_eq("zero AES clears Hytera segment count", (int)state->hytera_key_segments, 0);
+    rc |= expect_int_eq("zero AES clears keyloader", state->keyloader, 0);
+    rc |= expect_int_eq("zero AES unmutes encrypted left", opts->dmr_mute_encL, 0);
+    rc |= expect_int_eq("zero AES unmutes encrypted right", opts->dmr_mute_encR, 0);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
 test_ui_hytera_status_counts_k_fields_only(void) {
     test_runtime runtime;
     if (alloc_test_runtime(&runtime) != 0) {
@@ -710,6 +908,55 @@ test_ui_hytera_status_counts_k_fields_only(void) {
     state->K2 = 0ULL;
     state->K4 = 0x8877665544332211ULL;
     rc |= expect_int_eq("UI Hytera 256-bit status counts upper K fields", (int)ui_hytera_key_segment_count(state), 4);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_hytera_key_command_records_segment_variants(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    struct HyteraKeyPayload {
+        uint64_t H, K1, K2, K3, K4;
+    } p = {0ULL, 0ULL, 0ULL, 0ULL, 0ULL};
+
+    state->hytera_key_segments = 4U;
+    state->keyloader = 1;
+    opts->dmr_mute_encL = 1;
+    opts->dmr_mute_encR = 1;
+    ui_post_cmd(UI_CMD_KEY_HYTERA_SET, &p, sizeof p);
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("zero Hytera command is drained", applied, 1);
+    rc |= expect_int_eq("zero Hytera clears segment count", (int)state->hytera_key_segments, 0);
+    rc |= expect_int_eq("zero Hytera clears keyloader", state->keyloader, 0);
+    rc |= expect_int_eq("zero Hytera unmutes encrypted left", opts->dmr_mute_encL, 0);
+    rc |= expect_int_eq("zero Hytera unmutes encrypted right", opts->dmr_mute_encR, 0);
+
+    p.H = 0x10ULL;
+    p.K1 = 0x11ULL;
+    p.K2 = 0x22ULL;
+    state->hytera_key_segments = 0U;
+    ui_post_cmd(UI_CMD_KEY_HYTERA_SET, &p, sizeof p);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("two-segment Hytera command is drained", applied, 1);
+    rc |= expect_int_eq("two-segment Hytera records segment count", (int)state->hytera_key_segments, 2);
+    rc |= expect_u64_eq("two-segment Hytera stores K2", state->K2, p.K2);
+
+    p.K3 = 0x33ULL;
+    p.K4 = 0ULL;
+    ui_post_cmd(UI_CMD_KEY_HYTERA_SET, &p, sizeof p);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("upper-segment Hytera command is drained", applied, 1);
+    rc |= expect_int_eq("upper-segment Hytera records four segments", (int)state->hytera_key_segments, 4);
+    rc |= expect_u64_eq("upper-segment Hytera stores K3", state->K3, p.K3);
 
     free_test_runtime(&runtime);
     return rc;
@@ -773,6 +1020,978 @@ test_ui_hytera_key_command_preserves_aes_metadata(void) {
     rc |= expect_u64_eq("UI Hytera preserves AES A4 slot 1", state->A4[1], 0xB82DAA36789C8EE2ULL);
     rc |= expect_true("UI Hytera preserves AES key bytes",
                       memcmp(state->aes_key, expected_aes_key, sizeof expected_aes_key) == 0);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_basic_key_commands_reset_payload_mute_state(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    state->K = 0x12345678U;
+    state->keyloader = 1;
+    state->payload_keyid = 77;
+    state->payload_keyidR = 88;
+    opts->dmr_mute_encL = 1;
+    opts->dmr_mute_encR = 1;
+
+    uint8_t short_key = 0xFEU;
+    ui_post_cmd(UI_CMD_KEY_BASIC_SET, &short_key, sizeof short_key);
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("short basic key command is drained", applied, 1);
+    rc |= expect_int_eq("short basic key preserves K", (int)state->K, 0x12345678);
+    rc |= expect_int_eq("short basic key preserves keyloader", state->keyloader, 1);
+    rc |= expect_int_eq("short basic key preserves left mute", opts->dmr_mute_encL, 1);
+    rc |= expect_int_eq("short basic key preserves right mute", opts->dmr_mute_encR, 1);
+
+    uint32_t basic = 0xA5A55A5AU;
+    ui_post_cmd(UI_CMD_KEY_BASIC_SET, &basic, sizeof basic);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("basic key command is drained", applied, 1);
+    rc |= expect_int_eq("basic key command sets K", (int)state->K, (int)basic);
+    rc |= expect_int_eq("basic key clears keyloader", state->keyloader, 0);
+    rc |= expect_int_eq("basic key clears left payload key ID", state->payload_keyid, 0);
+    rc |= expect_int_eq("basic key clears right payload key ID", state->payload_keyidR, 0);
+    rc |= expect_int_eq("basic key unmutes encrypted left", opts->dmr_mute_encL, 0);
+    rc |= expect_int_eq("basic key unmutes encrypted right", opts->dmr_mute_encR, 0);
+
+    state->keyloader = 1;
+    state->payload_keyid = 9;
+    state->payload_keyidR = 10;
+    opts->dmr_mute_encL = 1;
+    opts->dmr_mute_encR = 1;
+
+    uint32_t scrambler = 0x0001C0DEU;
+    ui_post_cmd(UI_CMD_KEY_SCRAMBLER_SET, &scrambler, sizeof scrambler);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("scrambler key command is drained", applied, 1);
+    rc |= expect_int_eq("scrambler key command sets R", (int)state->R, (int)scrambler);
+    rc |= expect_int_eq("scrambler key clears keyloader", state->keyloader, 0);
+    rc |= expect_int_eq("scrambler key unmutes encrypted left", opts->dmr_mute_encL, 0);
+    rc |= expect_int_eq("scrambler key unmutes encrypted right", opts->dmr_mute_encR, 0);
+
+    DSD_MEMSET(state->static_ks_bits, 0, sizeof state->static_ks_bits);
+    state->ken_sc = 0;
+    ui_post_cmd(UI_CMD_KEY_KEN_SCR_SET, "1", sizeof "1");
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("Kenwood stream key command is drained", applied, 1);
+    rc |= expect_int_eq("Kenwood stream key enables forced scrambler", state->ken_sc, 1);
+    rc |=
+        expect_int_eq("Kenwood stream key seeds slot 0 bits", static_bits_to_u16(state->static_ks_bits[0]) >> 8U, 0x80);
+    rc |=
+        expect_int_eq("Kenwood stream key seeds slot 1 bits", static_bits_to_u16(state->static_ks_bits[1]) >> 8U, 0x80);
+
+    DSD_MEMSET(state->static_ks_bits, 0, sizeof state->static_ks_bits);
+    state->any_bp = 0;
+    ui_post_cmd(UI_CMD_KEY_ANYTONE_BP_SET, "2345", sizeof "2345");
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("Anytone BP stream key command is drained", applied, 1);
+    rc |= expect_int_eq("Anytone BP stream key enables forced mode", state->any_bp, 1);
+    rc |= expect_int_eq("Anytone BP stream key permutes slot 0 bits", static_bits_to_u16(state->static_ks_bits[0]),
+                        0xDBBD);
+    rc |= expect_int_eq("Anytone BP stream key permutes slot 1 bits", static_bits_to_u16(state->static_ks_bits[1]),
+                        0xDBBD);
+
+    state->keyloader = 1;
+    state->payload_keyid = 11;
+    state->payload_keyidR = 12;
+    opts->dmr_mute_encL = 1;
+    opts->dmr_mute_encR = 1;
+
+    uint64_t rc4des = 0x0123456789ABCDEFULL;
+    ui_post_cmd(UI_CMD_KEY_RC4DES_SET, &rc4des, sizeof rc4des);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("RC4/DES key command is drained", applied, 1);
+    rc |= expect_u64_eq("RC4/DES key command sets R", state->R, rc4des);
+    rc |= expect_u64_eq("RC4/DES key command sets RR", state->RR, rc4des);
+    rc |= expect_int_eq("RC4/DES key clears keyloader", state->keyloader, 0);
+    rc |= expect_int_eq("RC4/DES key clears left payload key ID", state->payload_keyid, 0);
+    rc |= expect_int_eq("RC4/DES key clears right payload key ID", state->payload_keyidR, 0);
+    rc |= expect_int_eq("RC4/DES key unmutes encrypted left", opts->dmr_mute_encL, 0);
+    rc |= expect_int_eq("RC4/DES key unmutes encrypted right", opts->dmr_mute_encR, 0);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_m17_user_data_command_truncates_to_state_buffer(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_state* state = runtime.state;
+
+    DSD_SNPRINTF(state->m17dat, sizeof state->m17dat, "%s", "stale");
+    char payload[128];
+    DSD_MEMSET(payload, 'M', sizeof payload);
+
+    ui_post_cmd(UI_CMD_M17_USER_DATA_SET, payload, sizeof payload);
+    int applied = ui_drain_cmds(runtime.opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("M17 user data command is drained", applied, 1);
+    rc |= expect_int_eq("M17 user data is field bounded", (int)strlen(state->m17dat), (int)sizeof(state->m17dat) - 1);
+    rc |= expect_true("M17 user data preserves copied payload prefix",
+                      strspn(state->m17dat, "M") == strlen(state->m17dat));
+    rc |= expect_int_eq("M17 user data is NUL terminated", state->m17dat[sizeof(state->m17dat) - 1], '\0');
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_runtime_toggle_commands_dispatch_through_queue(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    opts->dmr_le = 0;
+    opts->unmute_encrypted_p25 = 0;
+    opts->dmr_mute_encL = 1;
+    opts->dmr_mute_encR = 0;
+    opts->inverted_x2tdma = 0;
+    opts->inverted_dmr = 1;
+    opts->inverted_dpmr = 0;
+    opts->inverted_m17 = 1;
+
+    ui_post_cmd(UI_CMD_DMR_LE_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_ALL_MUTES_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_INV_X2_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_INV_DMR_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_INV_DPMR_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_INV_M17_TOGGLE, NULL, 0);
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("runtime toggle drain count", applied, 6);
+    rc |= expect_int_eq("DMR LE toggled through queue", opts->dmr_le, 1);
+    rc |= expect_int_eq("P25 encrypted unmute toggled through queue", opts->unmute_encrypted_p25, 1);
+    rc |= expect_int_eq("DMR left mute toggled through queue", opts->dmr_mute_encL, 0);
+    rc |= expect_int_eq("DMR right mute toggled through queue", opts->dmr_mute_encR, 1);
+    rc |= expect_int_eq("X2 inversion toggled through queue", opts->inverted_x2tdma, 1);
+    rc |= expect_int_eq("DMR inversion toggled through queue", opts->inverted_dmr, 0);
+    rc |= expect_int_eq("dPMR inversion toggled through queue", opts->inverted_dpmr, 1);
+    rc |= expect_int_eq("M17 inversion toggled through queue", opts->inverted_m17, 0);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_legacy_toggle_commands_dispatch_through_queue(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    opts->aggressive_framesync = 0;
+    opts->p25_lcw_retune = 1;
+    opts->p25_prefer_candidates = 0;
+    opts->reverse_mute = 1;
+    opts->use_lpf = 0;
+    opts->use_hpf = 1;
+    opts->use_pbf = 0;
+    opts->use_hpf_d = 1;
+    opts->payload = 0;
+
+    ui_post_cmd(UI_CMD_CRC_RELAX_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_AGGR_SYNC_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_LCW_RETUNE_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_P25_CC_CAND_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_REVERSE_MUTE_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_LPF_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_HPF_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_PBF_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_HPF_D_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_PAYLOAD_TOGGLE, NULL, 0);
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("legacy toggle drain count", applied, 10);
+    rc |= expect_int_eq("CRC relax then aggr-sync aliases toggle twice", opts->aggressive_framesync, 0);
+    rc |= expect_int_eq("LCW retune toggled through queue", opts->p25_lcw_retune, 0);
+    rc |= expect_int_eq("P25 CC candidates toggled through queue", opts->p25_prefer_candidates, 1);
+    rc |= expect_int_eq("reverse mute toggled through queue", opts->reverse_mute, 0);
+    rc |= expect_int_eq("LPF toggled through queue", opts->use_lpf, 1);
+    rc |= expect_int_eq("HPF toggled through queue", opts->use_hpf, 0);
+    rc |= expect_int_eq("PBF toggled through queue", opts->use_pbf, 1);
+    rc |= expect_int_eq("HPF-D toggled through queue", opts->use_hpf_d, 0);
+    rc |= expect_int_eq("payload display toggled through queue", opts->payload, 1);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_dsp_op_commands_dispatch_through_queue(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+    int rc = 0;
+
+    rtl_stream_toggle_cqpsk(0);
+    UiDspPayload dsp = {.op = UI_DSP_OP_TOGGLE_CQ};
+    ui_post_cmd(UI_CMD_DSP_OP, &dsp, sizeof dsp);
+    int applied = ui_drain_cmds(opts, state);
+    int cq = 0;
+    rtl_stream_get_cqpsk_status(&cq, NULL);
+    rc |= expect_int_eq("DSP CQPSK toggle command drains", applied, 1);
+    rc |= expect_int_eq("DSP CQPSK toggle enables mode", cq, 1);
+
+    rtl_stream_toggle_iq_balance(0);
+    (void)dsd_unsetenv("DSD_NEO_IQ_BALANCE");
+    dsp.op = UI_DSP_OP_TOGGLE_IQBAL;
+    ui_post_cmd(UI_CMD_DSP_OP, &dsp, sizeof dsp);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("DSP IQ balance command drains", applied, 1);
+    rc |= expect_int_eq("DSP IQ balance toggles on", rtl_stream_get_iq_balance(), 1);
+    rc |= expect_true("DSP IQ balance publishes env", strcmp(dsd_neo_env_get("DSD_NEO_IQ_BALANCE"), "1") == 0);
+
+    rtl_stream_set_iq_dc(0, 4);
+    int dc_shift = 0;
+    (void)rtl_stream_get_iq_dc(&dc_shift);
+    int dc_shift_before_toggle = dc_shift;
+    (void)dsd_unsetenv("DSD_NEO_IQ_DC_BLOCK");
+    dsp.op = UI_DSP_OP_IQ_DC_TOGGLE;
+    ui_post_cmd(UI_CMD_DSP_OP, &dsp, sizeof dsp);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("DSP IQ DC command drains", applied, 1);
+    rc |= expect_int_eq("DSP IQ DC toggles on", rtl_stream_get_iq_dc(&dc_shift), 1);
+    rc |= expect_int_eq("DSP IQ DC toggle preserves shift", dc_shift, dc_shift_before_toggle);
+    rc |= expect_true("DSP IQ DC publishes env", strcmp(dsd_neo_env_get("DSD_NEO_IQ_DC_BLOCK"), "1") == 0);
+
+    dsp.op = UI_DSP_OP_IQ_DC_K_DELTA;
+    dsp.a = 3;
+    ui_post_cmd(UI_CMD_DSP_OP, &dsp, sizeof dsp);
+    applied = ui_drain_cmds(opts, state);
+    (void)rtl_stream_get_iq_dc(&dc_shift);
+    rc |= expect_int_eq("DSP IQ DC shift command drains", applied, 1);
+    rc |= expect_int_eq("DSP IQ DC shift applies delta", dc_shift, dc_shift_before_toggle + 3);
+
+    rtl_stream_set_ted_gain(0.1f);
+    dsp.op = UI_DSP_OP_TED_GAIN_SET;
+    dsp.a = 999;
+    ui_post_cmd(UI_CMD_DSP_OP, &dsp, sizeof dsp);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("DSP TED gain command drains", applied, 1);
+    rc |= expect_float_near("DSP TED gain command clamps high", rtl_stream_get_ted_gain(), 0.5f, 0.0001f);
+
+    rtl_stream_set_tuner_autogain(0);
+    dsp.op = UI_DSP_OP_TUNER_AUTOGAIN_TOGGLE;
+    ui_post_cmd(UI_CMD_DSP_OP, &dsp, sizeof dsp);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("DSP tuner autogain command drains", applied, 1);
+    rc |= expect_int_eq("DSP tuner autogain toggles on", rtl_stream_get_tuner_autogain(), 1);
+
+    rtl_stream_toggle_iq_balance(1);
+    uint8_t short_payload[1] = {0U};
+    ui_post_cmd(UI_CMD_DSP_OP, short_payload, sizeof short_payload);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("short DSP command still drains", applied, 1);
+    rc |= expect_int_eq("short DSP command preserves IQ balance", rtl_stream_get_iq_balance(), 1);
+
+    (void)dsd_unsetenv("DSD_NEO_IQ_BALANCE");
+    (void)dsd_unsetenv("DSD_NEO_IQ_DC_BLOCK");
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_legacy_slot_and_display_commands_update_state(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    for (int i = 0; i < 100; ++i) {
+        state->audio_out_float_buf[i] = 1.0f;
+        state->audio_out_buf[i] = 123;
+        state->audio_out_float_bufR[i] = 2.0f;
+        state->audio_out_bufR[i] = 456;
+    }
+    state->audio_out_idx = 77;
+    state->audio_out_idx2 = 88;
+    state->audio_out_idxR = 55;
+    state->audio_out_idx2R = 66;
+    opts->slot1_on = 1;
+    opts->slot2_on = 1;
+    opts->slot_preference = 0;
+
+    ui_post_cmd(UI_CMD_SLOT1_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_SLOT2_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_SLOT_PREF_CYCLE, NULL, 0);
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("slot command drain count", applied, 3);
+    rc |= expect_int_eq("slot1 toggled off", opts->slot1_on, 0);
+    rc |= expect_int_eq("slot2 toggled off", opts->slot2_on, 0);
+    rc |= expect_int_eq("slot preference cycles after slot toggles", opts->slot_preference, 1);
+    rc |= expect_true("slot1 float cursor moves to flushed tail",
+                      state->audio_out_float_buf_p == state->audio_out_float_buf + 100);
+    rc |= expect_true("slot1 pcm cursor moves to flushed tail", state->audio_out_buf_p == state->audio_out_buf + 100);
+    rc |= expect_true("slot2 float cursor moves to flushed tail",
+                      state->audio_out_float_buf_pR == state->audio_out_float_bufR + 100);
+    rc |= expect_true("slot2 pcm cursor moves to flushed tail", state->audio_out_buf_pR == state->audio_out_bufR + 100);
+    rc |= expect_int_eq("slot1 float index reset", state->audio_out_idx2, 0);
+    rc |= expect_int_eq("slot1 pcm index reset", state->audio_out_idx, 0);
+    rc |= expect_int_eq("slot2 float index reset", state->audio_out_idx2R, 0);
+    rc |= expect_int_eq("slot2 pcm index reset", state->audio_out_idxR, 0);
+    rc |= expect_true("slot1 audio buffer cleared",
+                      state->audio_out_float_buf[0] == 0.0f && state->audio_out_buf[0] == 0);
+    rc |= expect_true("slot2 audio buffer cleared",
+                      state->audio_out_float_bufR[0] == 0.0f && state->audio_out_bufR[0] == 0);
+
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    opts->constellation = 0;
+    ui_post_cmd(UI_CMD_CONST_TOGGLE, NULL, 0);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("non-RTL constellation command drains", applied, 1);
+    rc |= expect_int_eq("non-RTL constellation remains disabled", opts->constellation, 0);
+
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->mod_qpsk = 1;
+    opts->const_gate_qpsk = 0.80f;
+    opts->eye_view = 0;
+    opts->eye_unicode = 0;
+    opts->eye_color = 0;
+    opts->fsk_hist_view = 0;
+    opts->spectrum_view = 0;
+    float delta = 0.25f;
+    ui_post_cmd(UI_CMD_CONST_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_CONST_NORM_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_CONST_GATE_DELTA, &delta, sizeof delta);
+    ui_post_cmd(UI_CMD_EYE_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_FSK_HIST_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_SPECTRUM_TOGGLE, NULL, 0);
+    applied = ui_drain_cmds(opts, state);
+
+    rc |= expect_int_eq("RTL display command drain count", applied, 6);
+    rc |= expect_int_eq("RTL constellation toggled on", opts->constellation, 1);
+    rc |= expect_int_eq("constellation normalization toggled", opts->const_norm_mode, 1);
+    rc |= expect_true("constellation gate clamps high", fabsf(opts->const_gate_qpsk - 0.90f) <= 1e-6f);
+    rc |= expect_int_eq("eye view toggled on", opts->eye_view, 1);
+    rc |= expect_int_eq("FSK histogram toggled on", opts->fsk_hist_view, 1);
+    rc |= expect_int_eq("spectrum view toggled on", opts->spectrum_view, 1);
+
+    (void)rtl_stream_spectrum_set_size(128);
+    int32_t spectrum_delta = 70;
+    ui_post_cmd(UI_CMD_SPEC_SIZE_DELTA, &spectrum_delta, sizeof spectrum_delta);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("spectrum size command drains", applied, 1);
+    rc |= expect_int_eq("spectrum size delta rounds to next power of two", rtl_stream_spectrum_get_size(), 256);
+
+    ui_post_cmd(UI_CMD_EYE_UNICODE_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_EYE_COLOR_TOGGLE, NULL, 0);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("eye format command drain count", applied, 2);
+    rc |= expect_int_eq("eye unicode toggled on", opts->eye_unicode, 1);
+    rc |= expect_int_eq("eye color toggled on", opts->eye_color, 1);
+
+    (void)rtl_stream_spectrum_set_size(64);
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_legacy_protocol_reset_and_mode_toggles(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    opts->dmr_dmrla_is_set = 1;
+    opts->dmr_dmrla_n = 9;
+    state->dmr_rest_channel = 4;
+    state->dmr_mfid = 0x68;
+    DSD_SNPRINTF(state->dmr_branding, sizeof state->dmr_branding, "%s", "brand");
+    DSD_SNPRINTF(state->nxdn_location_category, sizeof state->nxdn_location_category, "%s", "cat");
+    state->nxdn_last_ran = 5;
+    state->nxdn_ran = 6;
+    state->nxdn_rcn = 7;
+    state->nxdn_base_freq = 200;
+    state->nxdn_step = 25;
+    state->nxdn_bw = 12;
+
+    opts->m17encoder = 1;
+    state->m17encoder_tx = 1;
+    state->m17encoder_eot = 0;
+    opts->frame_provoice = 1;
+    state->esk_mask = 0;
+    state->ea_mode = 0;
+    state->edacs_site_id = 3;
+    state->edacs_lcn_count = 5;
+    state->edacs_cc_lcn = 2;
+    state->edacs_vc_lcn = 4;
+    state->edacs_tuned_lcn = 6;
+    state->edacs_vc_call_type = 1;
+    state->p25_cc_freq = 851000000;
+    state->trunk_cc_freq = 852000000;
+    opts->p25_is_tuned = 1;
+    state->lasttg = 123;
+    state->lastsrc = 456;
+
+    ui_post_cmd(UI_CMD_DMR_RESET, NULL, 0);
+    ui_post_cmd(UI_CMD_M17_TX_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_PROVOICE_ESK_TOGGLE, NULL, 0);
+    ui_post_cmd(UI_CMD_PROVOICE_MODE_TOGGLE, NULL, 0);
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("protocol reset command drain count", applied, 4);
+    rc |= expect_int_eq("DMR rest channel reset", state->dmr_rest_channel, -1);
+    rc |= expect_int_eq("DMR MFID reset", state->dmr_mfid, -1);
+    rc |= expect_true("DMR branding reset", state->dmr_branding[0] == '\0');
+    rc |= expect_int_eq("DMR LA state reset", opts->dmr_dmrla_is_set, 0);
+    rc |= expect_int_eq("DMR LA count reset", opts->dmr_dmrla_n, 0);
+    rc |= expect_true("NXDN category reset", strcmp(state->nxdn_location_category, " ") == 0);
+    rc |= expect_int_eq("NXDN last RAN reset", state->nxdn_last_ran, -1);
+    rc |= expect_int_eq("NXDN RAN reset", state->nxdn_ran, 0);
+    rc |= expect_int_eq("NXDN RCN reset", state->nxdn_rcn, 0);
+    rc |= expect_int_eq("NXDN base reset", state->nxdn_base_freq, 0);
+    rc |= expect_int_eq("NXDN step reset", state->nxdn_step, 0);
+    rc |= expect_int_eq("NXDN bandwidth reset", state->nxdn_bw, 0);
+    rc |= expect_int_eq("M17 TX toggled off", state->m17encoder_tx, 0);
+    rc |= expect_int_eq("M17 EOT marked", state->m17encoder_eot, 1);
+    rc |= expect_int_eq("ProVoice ESK enabled", state->esk_mask, 0xA0);
+    rc |= expect_int_eq("ProVoice EA mode toggled", state->ea_mode, 1);
+    rc |= expect_int_eq("ProVoice site reset", state->edacs_site_id, 0);
+    rc |= expect_int_eq("ProVoice tuned LCN reset", state->edacs_tuned_lcn, -1);
+    rc |= expect_int_eq("ProVoice P25 CC reset", (int)state->p25_cc_freq, 0);
+    rc |= expect_int_eq("ProVoice trunk CC reset", (int)state->trunk_cc_freq, 0);
+    rc |= expect_int_eq("ProVoice tuned flag reset", opts->p25_is_tuned, 0);
+    rc |= expect_int_eq("ProVoice last TG reset", state->lasttg, 0);
+    rc |= expect_int_eq("ProVoice last source reset", state->lastsrc, 0);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_replay_and_stop_playback_manage_symbol_state(void) {
+    char sym_path[DSD_TEST_PATH_MAX] = {0};
+    int fd = dsd_test_mkstemp(sym_path, sizeof sym_path, "dsdneo_ui_replay_symbol");
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "FAIL: temp symbol replay file\n");
+        return 1;
+    }
+    const uint8_t bytes[] = {0x01U, 0x02U, 0x03U};
+    ssize_t nwritten = write(fd, bytes, sizeof bytes);
+    (void)dsd_close(fd);
+    if (nwritten != (ssize_t)sizeof bytes) {
+        DSD_FPRINTF(stderr, "FAIL: write temp symbol replay file\n");
+        (void)remove(sym_path);
+        return 1;
+    }
+
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        (void)remove(sym_path);
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", sym_path);
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    state->symbol_replay_format = DSD_SYMBOL_REPLAY_FORMAT_SOFT;
+    state->symbol_replay_header_checked = 1;
+    state->symbol_replay_has_soft = 1;
+
+    ui_post_cmd(UI_CMD_REPLAY_LAST, NULL, 0);
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("replay last command drains", applied, 1);
+    rc |= expect_int_eq("replay last switches to symbol bin", opts->audio_in_type, AUDIO_IN_SYMBOL_BIN);
+    rc |= expect_true("replay last opens symbol file", opts->symbolfile != NULL);
+    rc |= expect_int_eq("replay last resets format", state->symbol_replay_format, DSD_SYMBOL_REPLAY_FORMAT_UNKNOWN);
+    rc |= expect_int_eq("replay last clears header checked", state->symbol_replay_header_checked, 0);
+    rc |= expect_int_eq("replay last clears soft flag", state->symbol_replay_has_soft, 0);
+
+    opts->audio_out_type = 1;
+    ui_post_cmd(UI_CMD_STOP_PLAYBACK, NULL, 0);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("stop playback command drains", applied, 1);
+    rc |= expect_true("stop playback closes symbol file", opts->symbolfile == NULL);
+    rc |= expect_int_eq("stop playback falls back to stdin without Pulse output", opts->audio_in_type, AUDIO_IN_STDIN);
+
+    free_test_runtime(&runtime);
+    (void)remove(sym_path);
+    return rc;
+}
+
+static int
+test_ui_io_command_queue_applies_local_input_and_network_payloads(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    struct HostPortPayload {
+        char host[256];
+        int32_t port;
+    };
+
+    struct HostPortPayload tcp = {0};
+    DSD_SNPRINTF(tcp.host, sizeof tcp.host, "%s", "example.invalid");
+    tcp.port = 7355;
+    reset_tcp_connect_audio_fake();
+    ui_post_cmd(UI_CMD_TCP_CONNECT_AUDIO_CFG, &tcp, sizeof tcp);
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("TCP command drain count", applied, 1);
+    rc |= expect_int_eq("TCP command calls connector", g_tcp_connect_audio_calls, 1);
+    rc |= expect_true("TCP command passes host", strcmp(g_last_tcp_connect_audio_host, "example.invalid") == 0);
+    rc |= expect_int_eq("TCP command passes port", g_last_tcp_connect_audio_port, 7355);
+    rc |= expect_int_eq("TCP command switches input type on success", opts->audio_in_type, AUDIO_IN_TCP);
+    rc |= expect_true("TCP command stores host on success", strcmp(opts->tcp_hostname, "example.invalid") == 0);
+    rc |= expect_true("TCP command writes success toast", strstr(state->ui_msg, "TCP audio connected") != NULL);
+
+    struct HostPortPayload tcp_fail = {0};
+    DSD_SNPRINTF(tcp_fail.host, sizeof tcp_fail.host, "%s", "fail.invalid");
+    tcp_fail.port = 1234;
+    g_tcp_connect_audio_result = -1;
+    ui_post_cmd(UI_CMD_TCP_CONNECT_AUDIO_CFG, &tcp_fail, sizeof tcp_fail);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("TCP failure command drain count", applied, 1);
+    rc |= expect_int_eq("TCP failure still calls connector", g_tcp_connect_audio_calls, 2);
+    rc |=
+        expect_true("TCP failure does not replace connected host", strcmp(opts->tcp_hostname, "example.invalid") == 0);
+    rc |= expect_true("TCP failure writes failure toast", strstr(state->ui_msg, "TCP audio connect failed") != NULL);
+
+    struct HostPortPayload udp = {0};
+    udp.port = 45000;
+    ui_post_cmd(UI_CMD_UDP_INPUT_CFG, &udp, sizeof udp);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("UDP input command drain count", applied, 1);
+    rc |= expect_int_eq("UDP input switches input type", opts->audio_in_type, AUDIO_IN_UDP);
+    rc |= expect_int_eq("UDP input stores port", opts->udp_in_portno, 45000);
+    rc |= expect_true("UDP input allows empty bind address", opts->udp_in_bindaddr[0] == '\0');
+    rc |= expect_true("UDP input uses logical device name", strcmp(opts->audio_in_dev, "udp") == 0);
+    rc |= expect_true("UDP input toast uses loopback fallback", strstr(state->ui_msg, "127.0.0.1:45000") != NULL);
+
+    const char wav_path[] = "/tmp/dsdneo-input.wav";
+    ui_post_cmd(UI_CMD_INPUT_WAV_SET, wav_path, sizeof wav_path);
+    ui_post_cmd(UI_CMD_INPUT_SYM_STREAM_SET, "capture.sym", sizeof "capture.sym");
+    ui_post_cmd(UI_CMD_INPUT_SET_PULSE, NULL, 0);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("local input command drain count", applied, 3);
+    rc |= expect_int_eq("Pulse input command wins final type", opts->audio_in_type, AUDIO_IN_PULSE);
+    rc |= expect_true("Pulse input command stores logical device", strcmp(opts->audio_in_dev, "pulse") == 0);
+    rc |= expect_true("Pulse input command writes toast", strstr(state->ui_msg, "Input switched to Pulse") != NULL);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_file_open_commands_report_service_results(void) {
+    char static_path[DSD_TEST_PATH_MAX] = {0};
+    char raw_path[DSD_TEST_PATH_MAX] = {0};
+    char sym_out_path[DSD_TEST_PATH_MAX] = {0};
+    char sym_in_path[DSD_TEST_PATH_MAX] = {0};
+    if (create_removed_temp_path("dsdneo_queue_static_wav", static_path, sizeof static_path) != 0
+        || create_removed_temp_path("dsdneo_queue_raw_wav", raw_path, sizeof raw_path) != 0
+        || create_removed_temp_path("dsdneo_queue_symbol_out", sym_out_path, sizeof sym_out_path) != 0) {
+        return 1;
+    }
+
+    int fd = dsd_test_mkstemp(sym_in_path, sizeof sym_in_path, "dsdneo_queue_symbol_in");
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "FAIL: dsd_test_mkstemp failed for symbol input\n");
+        return 1;
+    }
+    (void)dsd_close(fd);
+    FILE* sym_fp = dsd_fopen_private(sym_in_path, "wb");
+    if (!sym_fp) {
+        DSD_FPRINTF(stderr, "FAIL: fopen write failed for %s\n", sym_in_path);
+        (void)remove(sym_in_path);
+        return 1;
+    }
+    (void)fputs("01230123", sym_fp);
+    fclose(sym_fp);
+
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        (void)remove(sym_in_path);
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+    int rc = 0;
+
+    ui_post_cmd(UI_CMD_WAV_STATIC_OPEN, static_path, strlen(static_path) + 1);
+    int applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("static WAV command drains", applied, 1);
+    rc |= expect_true("static WAV opens SNDFILE", opts->wav_out_f != NULL);
+    rc |= expect_true("static WAV stores requested path", strcmp(opts->wav_out_file, static_path) == 0);
+    rc |= expect_int_eq("static WAV sets mono/static flag", opts->static_wav_file, 1);
+    rc |= expect_int_eq("static WAV clears stereo WAV mode", opts->dmr_stereo_wav, 0);
+    rc |= expect_true("static WAV writes toast", strstr(state->ui_msg, "Static WAV output") != NULL);
+    if (opts->wav_out_f) {
+        sf_close(opts->wav_out_f);
+        opts->wav_out_f = NULL;
+    }
+
+    ui_post_cmd(UI_CMD_WAV_RAW_OPEN, raw_path, strlen(raw_path) + 1);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("raw WAV command drains", applied, 1);
+    rc |= expect_true("raw WAV opens SNDFILE", opts->wav_out_raw != NULL);
+    rc |= expect_true("raw WAV stores requested path", strcmp(opts->wav_out_file_raw, raw_path) == 0);
+    rc |= expect_true("raw WAV writes toast", strstr(state->ui_msg, "Raw WAV output") != NULL);
+    if (opts->wav_out_raw) {
+        sf_close(opts->wav_out_raw);
+        opts->wav_out_raw = NULL;
+    }
+
+    ui_post_cmd(UI_CMD_SYMCAP_OPEN, sym_out_path, strlen(sym_out_path) + 1);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("symbol capture command drains", applied, 1);
+    rc |= expect_true("symbol capture opens file", opts->symbol_out_f != NULL);
+    rc |= expect_true("symbol capture stores requested path", strcmp(opts->symbol_out_file, sym_out_path) == 0);
+    rc |= expect_true("symbol capture writes toast", strstr(state->ui_msg, "Symbol capture") != NULL);
+    if (opts->symbol_out_f) {
+        fclose(opts->symbol_out_f);
+        opts->symbol_out_f = NULL;
+    }
+
+    state->symbol_replay_format = DSD_SYMBOL_REPLAY_FORMAT_SOFT;
+    state->symbol_replay_header_checked = 1;
+    state->symbol_replay_has_soft = 1;
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    ui_post_cmd(UI_CMD_SYMBOL_IN_OPEN, sym_in_path, strlen(sym_in_path) + 1);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("symbol input command drains", applied, 1);
+    rc |= expect_true("symbol input opens file", opts->symbolfile != NULL);
+    rc |= expect_int_eq("symbol input switches input type", opts->audio_in_type, AUDIO_IN_SYMBOL_BIN);
+    rc |= expect_true("symbol input stores requested path", strcmp(opts->audio_in_dev, sym_in_path) == 0);
+    rc |= expect_int_eq("symbol input resets replay format", state->symbol_replay_format,
+                        DSD_SYMBOL_REPLAY_FORMAT_UNKNOWN);
+    rc |= expect_int_eq("symbol input clears header checked", state->symbol_replay_header_checked, 0);
+    rc |= expect_int_eq("symbol input clears soft flag", state->symbol_replay_has_soft, 0);
+    rc |= expect_true("symbol input writes toast", strstr(state->ui_msg, "Symbol input") != NULL);
+    if (opts->symbolfile) {
+        fclose(opts->symbolfile);
+        opts->symbolfile = NULL;
+    }
+
+    free_test_runtime(&runtime);
+    (void)remove(static_path);
+    (void)remove(raw_path);
+    (void)remove(sym_out_path);
+    (void)remove(sym_in_path);
+    return rc;
+}
+
+static int
+test_ui_legacy_file_capture_commands_manage_handles(void) {
+    char wav_dir[DSD_TEST_PATH_MAX] = {0};
+    char sym_path[DSD_TEST_PATH_MAX] = {0};
+    if (!dsd_test_mkdtemp(wav_dir, sizeof wav_dir, "dsdneo_queue_wav_dir")
+        || create_removed_temp_path("dsdneo_queue_sym_stop", sym_path, sizeof sym_path) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: temp capture path setup failed\n");
+        return 1;
+    }
+
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        (void)remove(wav_dir);
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+    int rc = 0;
+
+    DSD_SNPRINTF(opts->wav_out_dir, sizeof opts->wav_out_dir, "%s", wav_dir);
+    ui_post_cmd(UI_CMD_WAV_START, NULL, 0);
+    int applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("legacy WAV start command drains", applied, 1);
+    rc |= expect_true("legacy WAV start opens left handle", opts->wav_out_f != NULL);
+    rc |= expect_true("legacy WAV start opens right handle", opts->wav_out_fR != NULL);
+    rc |= expect_int_eq("legacy WAV start enables stereo WAV", opts->dmr_stereo_wav, 1);
+    rc |= expect_true("legacy WAV start stores left temp under dir",
+                      strstr(opts->wav_out_file, wav_dir) == opts->wav_out_file);
+    rc |= expect_true("legacy WAV start stores right temp under dir",
+                      strstr(opts->wav_out_fileR, wav_dir) == opts->wav_out_fileR);
+
+    ui_post_cmd(UI_CMD_WAV_STOP, NULL, 0);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("legacy WAV stop command drains", applied, 1);
+    rc |= expect_true("legacy WAV stop closes left handle", opts->wav_out_f == NULL);
+    rc |= expect_true("legacy WAV stop closes right handle", opts->wav_out_fR == NULL);
+    rc |= expect_true("legacy WAV stop clears left filename", opts->wav_out_file[0] == '\0');
+    rc |= expect_true("legacy WAV stop clears right filename", opts->wav_out_fileR[0] == '\0');
+    rc |= expect_int_eq("legacy WAV stop disables stereo WAV", opts->dmr_stereo_wav, 0);
+
+    FILE* sym_fp = dsd_fopen_private(sym_path, "wb");
+    if (!sym_fp) {
+        DSD_FPRINTF(stderr, "FAIL: symbol capture stop setup failed for %s\n", sym_path);
+        rc |= 1;
+    } else {
+        opts->symbol_out_f = sym_fp;
+        DSD_SNPRINTF(opts->symbol_out_file, sizeof opts->symbol_out_file, "%s", sym_path);
+        opts->symbol_out_file_is_auto = 1;
+        ui_post_cmd(UI_CMD_SYMCAP_STOP, NULL, 0);
+        applied = ui_drain_cmds(opts, state);
+        rc |= expect_int_eq("symbol capture stop command drains", applied, 1);
+        rc |= expect_true("symbol capture stop closes handle", opts->symbol_out_f == NULL);
+        rc |= expect_true("symbol capture stop stages replay input path", strcmp(opts->audio_in_dev, sym_path) == 0);
+        rc |= expect_int_eq("symbol capture stop clears auto flag", opts->symbol_out_file_is_auto, 0);
+    }
+
+    free_test_runtime(&runtime);
+    (void)remove(sym_path);
+    (void)remove(wav_dir);
+    return rc;
+}
+
+static int
+test_ui_import_and_dsp_output_commands_report_service_results(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+    int rc = 0;
+
+    ui_post_cmd(UI_CMD_DSP_OUT_SET, "queue-dsp.bin", sizeof "queue-dsp.bin");
+    int applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("DSP output command drains", applied, 1);
+    rc |= expect_int_eq("DSP output enables file sink", opts->use_dsp_output, 1);
+    rc |= expect_true("DSP output stores generated path", strstr(opts->dsp_out_file, "DSP/queue-dsp.bin") != NULL);
+    rc |= expect_true("DSP output writes success toast", strstr(state->ui_msg, "Applied: DSP output") != NULL);
+
+    const char* missing_chan = "./missing-channel-map.csv";
+    ui_post_cmd(UI_CMD_IMPORT_CHANNEL_MAP, missing_chan, strlen(missing_chan) + 1U);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("channel import command drains", applied, 1);
+    rc |= expect_true("channel import records requested path", strcmp(opts->chan_in_file, missing_chan) == 0);
+    rc |= expect_true("channel import failure toast", strstr(state->ui_msg, "Failed: Channel map import") != NULL);
+
+    const char* missing_group = "./missing-group-list.csv";
+    ui_post_cmd(UI_CMD_IMPORT_GROUP_LIST, missing_group, strlen(missing_group) + 1U);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("group import command drains", applied, 1);
+    rc |= expect_true("group import records requested path", strcmp(opts->group_in_file, missing_group) == 0);
+    rc |= expect_true("group import failure toast", strstr(state->ui_msg, "Failed: Group list reload") != NULL);
+
+    const char* missing_dec = "./missing-keys-dec.csv";
+    ui_post_cmd(UI_CMD_IMPORT_KEYS_DEC, missing_dec, strlen(missing_dec) + 1U);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("decimal keys import command drains", applied, 1);
+    rc |= expect_true("decimal keys import records requested path", strcmp(opts->key_in_file, missing_dec) == 0);
+    rc |= expect_true("decimal keys import failure toast", strstr(state->ui_msg, "Failed: Keys (DEC) import") != NULL);
+
+    const char* missing_hex = "./missing-keys-hex.csv";
+    ui_post_cmd(UI_CMD_IMPORT_KEYS_HEX, missing_hex, strlen(missing_hex) + 1U);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("hex keys import command drains", applied, 1);
+    rc |= expect_true("hex keys import records requested path", strcmp(opts->key_in_file, missing_hex) == 0);
+    rc |= expect_true("hex keys import failure toast", strstr(state->ui_msg, "Failed: Keys (HEX) import") != NULL);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_malformed_payload_commands_drain_without_mutation(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    struct ShortHostPortPayload {
+        char host[256];
+    } short_tcp = {{0}};
+
+    DSD_SNPRINTF(short_tcp.host, sizeof short_tcp.host, "%s", "short.invalid");
+
+    DSD_SNPRINTF(opts->tcp_hostname, sizeof opts->tcp_hostname, "%s", "old.invalid");
+    opts->tcp_portno = 31337;
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    DSD_SNPRINTF(state->ui_msg, sizeof state->ui_msg, "%s", "sentinel");
+    reset_tcp_connect_audio_fake();
+
+    ui_post_cmd(UI_CMD_TCP_CONNECT_AUDIO_CFG, &short_tcp, sizeof short_tcp);
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("short TCP payload command is drained", applied, 1);
+    rc |= expect_int_eq("short TCP payload does not call connector", g_tcp_connect_audio_calls, 0);
+    rc |= expect_true("short TCP payload preserves host", strcmp(opts->tcp_hostname, "old.invalid") == 0);
+    rc |= expect_int_eq("short TCP payload preserves port", opts->tcp_portno, 31337);
+    rc |= expect_int_eq("short TCP payload preserves input type", opts->audio_in_type, AUDIO_IN_PULSE);
+    rc |= expect_true("short TCP payload preserves toast", strcmp(state->ui_msg, "sentinel") == 0);
+
+    uint8_t short_scalar = 0x7FU;
+    opts->setmod_bw = 12500;
+    state->tg_hold = 4242U;
+    opts->trunk_hangtime = 7.25f;
+    opts->slot_preference = 1;
+    opts->slot1_on = 1;
+    opts->slot2_on = 0;
+    ui_post_cmd(UI_CMD_RIGCTL_SET_MOD_BW, &short_scalar, sizeof short_scalar);
+    ui_post_cmd(UI_CMD_TG_HOLD_SET, &short_scalar, sizeof short_scalar);
+    ui_post_cmd(UI_CMD_HANGTIME_SET, &short_scalar, sizeof short_scalar);
+    ui_post_cmd(UI_CMD_SLOT_PREF_SET, &short_scalar, sizeof short_scalar);
+    ui_post_cmd(UI_CMD_SLOTS_ONOFF_SET, &short_scalar, sizeof short_scalar);
+    applied = ui_drain_cmds(opts, state);
+
+    rc |= expect_int_eq("short scalar payload commands are drained", applied, 5);
+    rc |= expect_int_eq("short rigctl payload preserves bandwidth", opts->setmod_bw, 12500);
+    rc |= expect_int_eq("short TG payload preserves hold", (int)state->tg_hold, 4242);
+    rc |= expect_true("short hangtime payload preserves value", fabs(opts->trunk_hangtime - 7.25f) <= 1e-6f);
+    rc |= expect_int_eq("short slot preference payload preserves value", opts->slot_preference, 1);
+    rc |= expect_int_eq("short slot mask payload preserves slot 1", opts->slot1_on, 1);
+    rc |= expect_int_eq("short slot mask payload preserves slot 2", opts->slot2_on, 0);
+
+    struct ShortP2Payload {
+        uint64_t w;
+        uint64_t s;
+    } short_p2 = {0xABCDEULL, 0x123ULL};
+
+    state->p2_wacn = 0x11111ULL;
+    state->p2_sysid = 0x222ULL;
+    state->p2_cc = 0x333ULL;
+    state->p2_hardset = 1;
+    ui_post_cmd(UI_CMD_P25_P2_PARAMS_SET, &short_p2, sizeof short_p2);
+    applied = ui_drain_cmds(opts, state);
+
+    rc |= expect_int_eq("short P25 P2 params command is drained", applied, 1);
+    rc |= expect_u64_eq("short P25 P2 params preserves WACN", state->p2_wacn, 0x11111ULL);
+    rc |= expect_u64_eq("short P25 P2 params preserves SYSID", state->p2_sysid, 0x222ULL);
+    rc |= expect_u64_eq("short P25 P2 params preserves CC", state->p2_cc, 0x333ULL);
+    rc |= expect_int_eq("short P25 P2 params preserves hardset", state->p2_hardset, 1);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_runtime_parameter_commands_clamp_and_update_state(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    int32_t mod_bw = 50000;
+    uint32_t tg = 123456U;
+    double hangtime = -2.5;
+    int32_t slot_pref = 9;
+    int32_t slot_mask = 2;
+
+    ui_post_cmd(UI_CMD_RIGCTL_SET_MOD_BW, &mod_bw, sizeof mod_bw);
+    ui_post_cmd(UI_CMD_TG_HOLD_SET, &tg, sizeof tg);
+    ui_post_cmd(UI_CMD_HANGTIME_SET, &hangtime, sizeof hangtime);
+    ui_post_cmd(UI_CMD_SLOT_PREF_SET, &slot_pref, sizeof slot_pref);
+    ui_post_cmd(UI_CMD_SLOTS_ONOFF_SET, &slot_mask, sizeof slot_mask);
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("runtime parameter drain count", applied, 5);
+    rc |= expect_int_eq("rigctl bandwidth clamps high", opts->setmod_bw, 25000);
+    rc |= expect_int_eq("TG hold updates state", (int)state->tg_hold, (int)tg);
+    rc |= expect_true("negative hangtime clamps to zero", fabs(opts->trunk_hangtime) <= 1e-9);
+    rc |= expect_int_eq("slot preference clamps high", opts->slot_preference, 1);
+    rc |= expect_int_eq("slot mask clears slot 1", opts->slot1_on, 0);
+    rc |= expect_int_eq("slot mask enables slot 2", opts->slot2_on, 1);
+    rc |= expect_true("last runtime command writes slot mask toast", strstr(state->ui_msg, "Slot mask -> 2") != NULL);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_ui_output_lrrp_and_p25_parameter_commands_dispatch_through_queue(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    ui_post_cmd(UI_CMD_PULSE_OUT_SET, "speaker", sizeof "speaker");
+    ui_post_cmd(UI_CMD_PULSE_IN_SET, "microphone", sizeof "microphone");
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("Pulse I/O command drain count", applied, 2);
+    rc |= expect_true("Pulse output selects pulse device", strcmp(opts->audio_out_dev, "pulse") == 0);
+    rc |= expect_int_eq("Pulse output selects pulse backend", opts->audio_out_type, 0);
+    rc |= expect_true("Pulse input selects pulse device", strcmp(opts->audio_in_dev, "pulse") == 0);
+    rc |= expect_int_eq("Pulse input selects pulse backend", opts->audio_in_type, AUDIO_IN_PULSE);
+    rc |= expect_true("Pulse input writes toast", strstr(state->ui_msg, "Pulse input") != NULL);
+
+    ui_post_cmd(UI_CMD_LRRP_SET_HOME, NULL, 0);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("LRRP home command drain count", applied, 1);
+    rc |= expect_int_eq("LRRP home enables output", opts->lrrp_file_output, 1);
+    rc |= expect_true("LRRP home stores expanded filename", strstr(opts->lrrp_out_file, "lrrp.txt") != NULL);
+    rc |= expect_true("LRRP home writes toast", strstr(state->ui_msg, "LRRP output") != NULL);
+
+    ui_post_cmd(UI_CMD_LRRP_SET_DSDP, NULL, 0);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("LRRP DSDPlus command drain count", applied, 1);
+    rc |= expect_int_eq("LRRP DSDPlus keeps output enabled", opts->lrrp_file_output, 1);
+    rc |= expect_true("LRRP DSDPlus stores standard filename", strcmp(opts->lrrp_out_file, "DSDPlus.LRRP") == 0);
+
+    const char lrrp_path[] = "custom-lrrp.txt";
+    ui_post_cmd(UI_CMD_LRRP_SET_CUSTOM, lrrp_path, sizeof lrrp_path);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("LRRP custom command drain count", applied, 1);
+    rc |= expect_int_eq("LRRP custom enables output", opts->lrrp_file_output, 1);
+    rc |= expect_true("LRRP custom stores path", strcmp(opts->lrrp_out_file, lrrp_path) == 0);
+    rc |= expect_true("LRRP custom writes toast", strstr(state->ui_msg, "LRRP output") != NULL);
+
+    ui_post_cmd(UI_CMD_LRRP_DISABLE, NULL, 0);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("LRRP disable command drain count", applied, 1);
+    rc |= expect_int_eq("LRRP disable clears output flag", opts->lrrp_file_output, 0);
+    rc |= expect_true("LRRP disable clears path", opts->lrrp_out_file[0] == '\0');
+
+    struct P2Payload {
+        uint64_t w;
+        uint64_t s;
+        uint64_t n;
+    } p2 = {0x1FFFFFULL, 0x1FFFULL, 0x1FFFULL};
+
+    ui_post_cmd(UI_CMD_P25_P2_PARAMS_SET, &p2, sizeof p2);
+    applied = ui_drain_cmds(opts, state);
+    rc |= expect_int_eq("P25 P2 params command drain count", applied, 1);
+    rc |= expect_u64_eq("P25 P2 WACN clamps", state->p2_wacn, 0xFFFFFULL);
+    rc |= expect_u64_eq("P25 P2 SYSID clamps", state->p2_sysid, 0xFFFULL);
+    rc |= expect_u64_eq("P25 P2 CC clamps", state->p2_cc, 0xFFFULL);
+    rc |= expect_int_eq("P25 P2 hardset enabled after nonzero params", state->p2_hardset, 1);
 
     free_test_runtime(&runtime);
     return rc;
@@ -1228,20 +2447,98 @@ test_omitted_rtl_ppm_apply_preserves_live_request(void) {
     return rc;
 }
 
+static int
+test_ui_rtl_setting_commands_stage_without_live_restart(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    opts->rtl_needs_restart = 0;
+    opts->rtl_started = 0;
+    opts->rtl_dev_index = 5;
+    opts->rtl_gain_value = 3;
+    opts->rtl_dsp_bw_khz = 12;
+    opts->rtl_volume_multiplier = 2;
+    opts->rtl_bias_tee = 0;
+    opts->rtltcp_autotune = 0;
+    opts->rtl_auto_ppm = 0;
+
+    int32_t dev = -4;
+    int32_t gain = 75;
+    int32_t ppm = 205;
+    int32_t bw = 7;
+    double sql_db = -42.0;
+    int32_t vol = 8;
+    int32_t on = 1;
+    ui_post_cmd(UI_CMD_RTL_SET_DEV, &dev, sizeof dev);
+    ui_post_cmd(UI_CMD_RTL_SET_GAIN, &gain, sizeof gain);
+    ui_post_cmd(UI_CMD_RTL_SET_PPM, &ppm, sizeof ppm);
+    ui_post_cmd(UI_CMD_RTL_SET_BW, &bw, sizeof bw);
+    ui_post_cmd(UI_CMD_RTL_SET_SQL_DB, &sql_db, sizeof sql_db);
+    ui_post_cmd(UI_CMD_RTL_SET_VOL_MULT, &vol, sizeof vol);
+    ui_post_cmd(UI_CMD_RTL_SET_BIAS_TEE, &on, sizeof on);
+    ui_post_cmd(UI_CMD_RTLTCP_SET_AUTOTUNE, &on, sizeof on);
+    ui_post_cmd(UI_CMD_RTL_SET_AUTO_PPM, &on, sizeof on);
+    int applied = ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("RTL setting commands drain count", applied, 9);
+    rc |= expect_int_eq("RTL device command clamps negative index", opts->rtl_dev_index, 0);
+    rc |= expect_int_eq("RTL gain command clamps max", opts->rtl_gain_value, 49);
+    rc |= expect_int_eq("RTL PPM command clamps max", opts->rtlsdr_ppm_error, 200);
+    rc |= expect_int_eq("RTL bandwidth command falls back to supported default", opts->rtl_dsp_bw_khz, 48);
+    rc |= expect_true("RTL squelch command stores requested dB",
+                      fabs(pwr_to_dB(opts->rtl_squelch_level) - sql_db) < 0.001);
+    rc |= expect_int_eq("RTL volume command clamps invalid multiplier", opts->rtl_volume_multiplier, 1);
+    rc |= expect_int_eq("RTL bias command stores state without live context", opts->rtl_bias_tee, 1);
+    rc |= expect_int_eq("RTL TCP autotune command stores state", opts->rtltcp_autotune, 1);
+    rc |= expect_int_eq("RTL auto PPM command stores state", opts->rtl_auto_ppm, 1);
+    rc |= expect_int_eq("RTL inactive setting commands do not start stream", opts->rtl_started, 0);
+    rc |= expect_true("RTL setting commands leave restart staged", opts->rtl_needs_restart == 1);
+    rc |= expect_true("RTL auto PPM command writes final toast", strstr(state->ui_msg, "Auto PPM -> On") != NULL);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+
 #endif
 
 int
 main(void) {
     int rc = 0;
     rc |= test_basic_pulse_config_apply();
+    rc |= test_ui_command_queue_applies_fifo();
+    rc |= test_ui_command_queue_overflow_drops_oldest();
+    rc |= test_ui_command_queue_truncates_oversized_payload_string();
     rc |= test_ui_profile_selection_applies_overlay_and_disables_autosave();
     rc |= test_ui_profile_menu_no_profiles_does_not_apply_base_config();
     rc |= test_stereo_file_hot_swap_rolls_back_to_live_input();
     rc |= test_call_alert_off_selection_survives_ui_command_path();
     rc |= test_ui_visibility_toggles_preserve_show_keys();
     rc |= test_ui_aes_key_command_clears_manual_hytera_fields();
+    rc |= test_ui_aes_key_command_handles_zero_and_short_payloads();
     rc |= test_ui_hytera_status_counts_k_fields_only();
+    rc |= test_ui_hytera_key_command_records_segment_variants();
     rc |= test_ui_hytera_key_command_preserves_aes_metadata();
+    rc |= test_ui_basic_key_commands_reset_payload_mute_state();
+    rc |= test_ui_m17_user_data_command_truncates_to_state_buffer();
+    rc |= test_ui_runtime_toggle_commands_dispatch_through_queue();
+    rc |= test_ui_legacy_toggle_commands_dispatch_through_queue();
+    rc |= test_ui_dsp_op_commands_dispatch_through_queue();
+    rc |= test_ui_legacy_slot_and_display_commands_update_state();
+    rc |= test_ui_legacy_protocol_reset_and_mode_toggles();
+    rc |= test_ui_replay_and_stop_playback_manage_symbol_state();
+    rc |= test_ui_io_command_queue_applies_local_input_and_network_payloads();
+    rc |= test_ui_file_open_commands_report_service_results();
+    rc |= test_ui_legacy_file_capture_commands_manage_handles();
+    rc |= test_ui_import_and_dsp_output_commands_report_service_results();
+    rc |= test_ui_malformed_payload_commands_drain_without_mutation();
+    rc |= test_ui_runtime_parameter_commands_clamp_and_update_state();
+    rc |= test_ui_output_lrrp_and_p25_parameter_commands_dispatch_through_queue();
     rc |= test_return_cc_uses_pulse_rate_not_stale_file_rate();
     rc |= test_file_config_apply_keeps_live_pulse_timing();
     rc |= test_file_config_apply_keeps_live_socket_timing();
@@ -1252,6 +2549,7 @@ main(void) {
     rc |= test_same_value_rtl_ppm_retry_is_republished();
     rc |= test_zero_rtl_ppm_apply_updates_live_request();
     rc |= test_omitted_rtl_ppm_apply_preserves_live_request();
+    rc |= test_ui_rtl_setting_commands_stage_without_live_restart();
 #endif
     return rc ? 1 : 0;
 }
@@ -1259,3 +2557,4 @@ main(void) {
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic pop
 #endif
+// NOLINTEND(performance-type-promotion-in-math-fn)

--- a/tests/runtime/test_runtime_config_user.cpp
+++ b/tests/runtime/test_runtime_config_user.cpp
@@ -181,6 +181,85 @@ test_decode_mode_aliases_and_guards(void) {
 }
 
 static int
+test_unknown_section_warnings_do_not_mutate_loaded_config(void) {
+    static const char* ini = "version = 1\n"
+                             "\n"
+                             "[input]\n"
+                             "source = \"pulse\"\n"
+                             "\n"
+                             "[unexpected]\n"
+                             "source = \"rtl\"\n"
+                             "rtl_device = 9\n"
+                             "rtl_freq = \"851.0125M\"\n"
+                             "\n"
+                             "[mode]\n"
+                             "decode = \"nxdn48\"\n";
+
+    char path[DSD_TEST_PATH_MAX];
+    if (write_temp_config(ini, path, sizeof path) != 0) {
+        return 1;
+    }
+
+    dsdcfg_diagnostics_t diags;
+    DSD_MEMSET(&diags, 0, sizeof(diags));
+    int validate_rc = dsd_user_config_validate(path, &diags);
+
+    int rc = 0;
+    if (validate_rc != 0 || diags.error_count != 0 || diags.warning_count == 0) {
+        DSD_FPRINTF(stderr, "expected unknown section to validate with warning only, rc=%d errors=%d warnings=%d\n",
+                    validate_rc, diags.error_count, diags.warning_count);
+        rc |= 1;
+    }
+    int found_unknown_section = 0;
+    for (int i = 0; i < diags.count; i++) {
+        if (diags.items[i].level == DSDCFG_DIAG_WARNING && strcmp(diags.items[i].section, "unexpected") == 0
+            && strstr(diags.items[i].message, "Unknown section")) {
+            found_unknown_section = 1;
+            break;
+        }
+    }
+    if (!found_unknown_section) {
+        DSD_FPRINTF(stderr, "missing unknown-section warning diagnostic\n");
+        rc |= 1;
+    }
+    dsd_user_config_diags_free(&diags);
+
+    dsdneoUserConfig cfg;
+    if (dsd_user_config_load(path, &cfg) != 0) {
+        DSD_FPRINTF(stderr, "dsd_user_config_load failed for warning-only config %s\n", path);
+        (void)remove(path);
+        return 1;
+    }
+    if (!cfg.has_input || cfg.input_source != DSDCFG_INPUT_PULSE) {
+        DSD_FPRINTF(stderr, "unknown section mutated input source=%d has_input=%d\n", (int)cfg.input_source,
+                    cfg.has_input);
+        rc |= 1;
+    }
+    if (cfg.rtl_device == 9 || cfg.rtl_freq[0] != '\0') {
+        DSD_FPRINTF(stderr, "unknown section leaked RTL fields device=%d freq=%s\n", cfg.rtl_device, cfg.rtl_freq);
+        rc |= 1;
+    }
+    if (!cfg.has_mode || cfg.decode_mode != DSDCFG_MODE_NXDN48) {
+        DSD_FPRINTF(stderr, "known mode section after unknown section did not load, mode=%d has=%d\n",
+                    (int)cfg.decode_mode, cfg.has_mode);
+        rc |= 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_opts_and_state(opts, state);
+    dsd_apply_user_config_to_opts(&cfg, &opts, &state);
+    if (opts.audio_in_type == AUDIO_IN_RTL || strncmp(opts.audio_in_dev, "rtl:", 4) == 0) {
+        DSD_FPRINTF(stderr, "unknown section applied RTL input to live opts: type=%d dev=%s\n", opts.audio_in_type,
+                    opts.audio_in_dev);
+        rc |= 1;
+    }
+
+    (void)remove(path);
+    return rc;
+}
+
+static int
 test_render_input_variants_and_save_atomic(void) {
     dsdneoUserConfig cfg;
     DSD_MEMSET(&cfg, 0, sizeof cfg);
@@ -1422,6 +1501,7 @@ main(void) {
     int rc = 0;
     rc |= test_apply_file_input_rescales_symbol_timing();
     rc |= test_decode_mode_aliases_and_guards();
+    rc |= test_unknown_section_warnings_do_not_mutate_loaded_config();
     rc |= test_render_input_variants_and_save_atomic();
     rc |= test_load_and_apply_basic();
     rc |= test_load_and_apply_alerts_empty_event_mask();

--- a/tests/runtime/test_runtime_config_user.cpp
+++ b/tests/runtime/test_runtime_config_user.cpp
@@ -83,6 +83,16 @@ render_config_to_buffer(const dsdneoUserConfig* cfg, char* out, size_t out_sz) {
 }
 
 static int
+expect_contains(const char* label, const char* haystack, const char* needle) {
+    if (!haystack || !needle || !strstr(haystack, needle)) {
+        DSD_FPRINTF(stderr, "FAIL: %s missing \"%s\" in:\n%s\n", label, needle ? needle : "(null)",
+                    haystack ? haystack : "(null)");
+        return 1;
+    }
+    return 0;
+}
+
+static int
 test_apply_file_input_rescales_symbol_timing(void) {
     dsdneoUserConfig cfg = {};
     cfg.version = 1;
@@ -127,6 +137,187 @@ test_apply_file_input_rescales_symbol_timing(void) {
         rc |= 1;
     }
 
+    return rc;
+}
+
+static int
+test_decode_mode_aliases_and_guards(void) {
+    static const char* ini = "version = 1\n"
+                             "\n"
+                             "[mode]\n"
+                             "decode = \"provoice\"\n";
+
+    char path[DSD_TEST_PATH_MAX];
+    if (write_temp_config(ini, path, sizeof path) != 0) {
+        return 1;
+    }
+
+    dsdneoUserConfig cfg;
+    if (dsd_user_config_load(path, &cfg) != 0) {
+        DSD_FPRINTF(stderr, "dsd_user_config_load failed for alias config %s\n", path);
+        (void)remove(path);
+        return 1;
+    }
+
+    int rc = 0;
+    if (!cfg.has_mode || cfg.decode_mode != DSDCFG_MODE_EDACS_PV) {
+        DSD_FPRINTF(stderr, "decode alias provoice not parsed as EDACS/PV, mode=%d\n", (int)cfg.decode_mode);
+        rc |= 1;
+    }
+
+    dsdneoUserConfig bad_cfg;
+    bad_cfg.version = 99;
+    if (dsd_user_config_load(NULL, &bad_cfg) == 0 || bad_cfg.version != 1) {
+        DSD_FPRINTF(stderr, "load NULL path should fail and reset config version=%d\n", bad_cfg.version);
+        rc |= 1;
+    }
+    if (dsd_user_config_load(path, NULL) == 0) {
+        DSD_FPRINTF(stderr, "load NULL config should fail\n");
+        rc |= 1;
+    }
+
+    (void)remove(path);
+    return rc;
+}
+
+static int
+test_render_input_variants_and_save_atomic(void) {
+    dsdneoUserConfig cfg;
+    DSD_MEMSET(&cfg, 0, sizeof cfg);
+    cfg.version = 1;
+    cfg.has_input = 1;
+    cfg.has_output = 1;
+    cfg.output_backend = DSDCFG_OUTPUT_PULSE;
+    DSD_SNPRINTF(cfg.pulse_output, sizeof cfg.pulse_output, "%s", "speaker");
+    cfg.ncurses_ui = 1;
+    cfg.has_mode = 1;
+    cfg.decode_mode = DSDCFG_MODE_M17;
+    cfg.has_demod = 1;
+    cfg.demod_path = DSDCFG_DEMOD_AUTO;
+    cfg.has_logging = 1;
+    DSD_SNPRINTF(cfg.event_log, sizeof cfg.event_log, "%s", "/tmp/events.log");
+    DSD_SNPRINTF(cfg.frame_log, sizeof cfg.frame_log, "%s", "/tmp/frames.log");
+    DSD_SNPRINTF(cfg.p25_sm_log, sizeof cfg.p25_sm_log, "%s", "/tmp/p25-sm.log");
+    cfg.has_recording = 1;
+    cfg.per_call_wav = 0;
+    DSD_SNPRINTF(cfg.per_call_wav_dir, sizeof cfg.per_call_wav_dir, "%s", "/tmp/wav");
+    DSD_SNPRINTF(cfg.static_wav_path, sizeof cfg.static_wav_path, "%s", "/tmp/static.wav");
+    DSD_SNPRINTF(cfg.raw_wav_path, sizeof cfg.raw_wav_path, "%s", "/tmp/raw.wav");
+    cfg.rdio_mode = DSD_RDIO_MODE_DIRWATCH;
+    cfg.rdio_system_id = 12;
+    DSD_SNPRINTF(cfg.rdio_api_url, sizeof cfg.rdio_api_url, "%s", "http://rdio.local");
+    DSD_SNPRINTF(cfg.rdio_api_key, sizeof cfg.rdio_api_key, "%s", "secret");
+    cfg.rdio_upload_timeout_ms = 6000;
+    cfg.rdio_upload_retries = 2;
+    cfg.rdio_api_delete_after_upload = 1;
+    cfg.has_dsp = 1;
+    cfg.iq_balance = 1;
+    cfg.iq_dc_block = 1;
+
+    char rendered[8192];
+    int rc = 0;
+
+    cfg.input_source = DSDCFG_INPUT_RTL;
+    cfg.rtl_device = 3;
+    DSD_SNPRINTF(cfg.rtl_freq, sizeof cfg.rtl_freq, "%s", "851.375M");
+    cfg.rtl_gain = 29;
+    cfg.rtl_ppm = 0;
+    cfg.rtl_ppm_is_set = 1;
+    cfg.rtl_bw_khz = 16;
+    cfg.rtl_sql = -45;
+    cfg.rtl_volume = 4;
+    cfg.rtl_auto_ppm = 1;
+    if (render_config_to_buffer(&cfg, rendered, sizeof rendered) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("render rtl source", rendered, "source = \"rtl\"\n");
+    rc |= expect_contains("render rtl device", rendered, "rtl_device = 3\n");
+    rc |= expect_contains("render rtl explicit zero ppm", rendered, "rtl_ppm = 0\n");
+    rc |= expect_contains("render auto demod", rendered, "demod = \"auto\"\n");
+    rc |= expect_contains("render pulse sink", rendered, "pulse_sink = \"speaker\"\n");
+    rc |= expect_contains("render event log", rendered, "event_log = \"/tmp/events.log\"\n");
+    rc |= expect_contains("render static wav", rendered, "static_wav = \"/tmp/static.wav\"\n");
+    rc |= expect_contains("render raw wav", rendered, "raw_wav = \"/tmp/raw.wav\"\n");
+    rc |= expect_contains("render rdio api key", rendered, "rdio_api_key = \"secret\"\n");
+    rc |= expect_contains("render dsp balance", rendered, "iq_balance = true\n");
+
+    cfg.input_source = DSDCFG_INPUT_RTLTCP;
+    DSD_SNPRINTF(cfg.rtltcp_host, sizeof cfg.rtltcp_host, "%s", "127.0.0.1");
+    cfg.rtltcp_port = 1234;
+    if (render_config_to_buffer(&cfg, rendered, sizeof rendered) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("render rtltcp source", rendered, "source = \"rtltcp\"\n");
+    rc |= expect_contains("render rtltcp host", rendered, "rtltcp_host = \"127.0.0.1\"\n");
+    rc |= expect_contains("render rtltcp port", rendered, "rtltcp_port = 1234\n");
+
+    cfg.input_source = DSDCFG_INPUT_FILE;
+    DSD_SNPRINTF(cfg.file_path, sizeof cfg.file_path, "%s", "/tmp/input.wav");
+    cfg.file_sample_rate = 96000;
+    if (render_config_to_buffer(&cfg, rendered, sizeof rendered) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("render file source", rendered, "source = \"file\"\n");
+    rc |= expect_contains("render file path", rendered, "file_path = \"/tmp/input.wav\"\n");
+    rc |= expect_contains("render file sample rate", rendered, "file_sample_rate = 96000\n");
+
+    cfg.input_source = DSDCFG_INPUT_TCP;
+    DSD_SNPRINTF(cfg.tcp_host, sizeof cfg.tcp_host, "%s", "localhost");
+    cfg.tcp_port = 7355;
+    if (render_config_to_buffer(&cfg, rendered, sizeof rendered) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("render tcp source", rendered, "source = \"tcp\"\n");
+    rc |= expect_contains("render tcp host", rendered, "tcp_host = \"localhost\"\n");
+    rc |= expect_contains("render tcp port", rendered, "tcp_port = 7355\n");
+
+    char base_path[DSD_TEST_PATH_MAX];
+    int fd = dsd_test_mkstemp(base_path, sizeof base_path, "dsdneo_config_save");
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "dsd_test_mkstemp failed for save path\n");
+        return 1;
+    }
+    (void)dsd_close(fd);
+    (void)remove(base_path);
+
+    char save_dir[DSD_TEST_PATH_MAX];
+    char save_subdir[DSD_TEST_PATH_MAX];
+    char save_path[DSD_TEST_PATH_MAX];
+    DSD_SNPRINTF(save_dir, sizeof save_dir, "%s.d", base_path);
+    DSD_SNPRINTF(save_subdir, sizeof save_subdir, "%s/sub", save_dir);
+    DSD_SNPRINTF(save_path, sizeof save_path, "%s/config.ini", save_subdir);
+
+    if (dsd_user_config_save_atomic(NULL, &cfg) == 0 || dsd_user_config_save_atomic("", &cfg) == 0
+        || dsd_user_config_save_atomic(save_path, NULL) == 0) {
+        DSD_FPRINTF(stderr, "save_atomic guard should reject NULL/empty inputs\n");
+        rc |= 1;
+    }
+    if (dsd_user_config_save_atomic(save_path, &cfg) != 0) {
+        DSD_FPRINTF(stderr, "save_atomic failed for %s: %s\n", save_path, strerror(errno));
+        rc |= 1;
+    } else {
+        dsdneoUserConfig loaded;
+        if (dsd_user_config_load(save_path, &loaded) != 0) {
+            DSD_FPRINTF(stderr, "load saved config failed for %s\n", save_path);
+            rc |= 1;
+        } else {
+            rc |= (loaded.input_source == DSDCFG_INPUT_TCP) ? 0 : 1;
+            if (loaded.input_source != DSDCFG_INPUT_TCP || strcmp(loaded.tcp_host, "localhost") != 0
+                || loaded.tcp_port != 7355 || loaded.decode_mode != DSDCFG_MODE_M17
+                || loaded.demod_path != DSDCFG_DEMOD_AUTO || !loaded.has_dsp || !loaded.iq_balance
+                || !loaded.iq_dc_block) {
+                DSD_FPRINTF(stderr,
+                            "saved config reload mismatch source=%d host=%s port=%d mode=%d demod=%d dsp=%d/%d\n",
+                            (int)loaded.input_source, loaded.tcp_host, loaded.tcp_port, (int)loaded.decode_mode,
+                            (int)loaded.demod_path, loaded.iq_balance, loaded.iq_dc_block);
+                rc |= 1;
+            }
+        }
+    }
+
+    (void)remove(save_path);
+    (void)remove(save_subdir);
+    (void)remove(save_dir);
     return rc;
 }
 
@@ -714,6 +905,63 @@ test_snapshot_roundtrip_zero_rtl_ppm(void) {
 }
 
 static int
+test_snapshot_rtl_and_rtltcp_device_specs(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    dsdneoUserConfig snap;
+    int rc = 0;
+
+    reset_opts_and_state(opts, state);
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", "rtl:7:451.125M:19:-2:12:-55:6");
+    opts.rtlsdr_center_freq = 451125000U;
+    opts.rtl_gain_value = 21;
+    opts.rtlsdr_ppm_error = -4;
+    opts.rtl_dsp_bw_khz = 12;
+    opts.rtl_squelch_level = 2.0;
+    opts.rtl_volume_multiplier = 6;
+    opts.rtl_auto_ppm = 1;
+
+    dsd_snapshot_opts_to_user_config(&opts, &state, &snap);
+    if (!snap.has_input || snap.input_source != DSDCFG_INPUT_RTL || snap.rtl_device != 7) {
+        DSD_FPRINTF(stderr, "snapshot RTL source/device mismatch source=%d device=%d\n", (int)snap.input_source,
+                    snap.rtl_device);
+        rc |= 1;
+    }
+    if (strcmp(snap.rtl_freq, "451125000") != 0 || snap.rtl_gain != 21 || snap.rtl_ppm != -4 || snap.rtl_bw_khz != 12
+        || snap.rtl_sql != 0 || snap.rtl_volume != 6 || !snap.rtl_ppm_is_set || snap.rtl_auto_ppm != 1) {
+        DSD_FPRINTF(stderr, "snapshot RTL tuning mismatch freq=%s gain=%d ppm=%d bw=%d sql=%d vol=%d auto=%d\n",
+                    snap.rtl_freq, snap.rtl_gain, snap.rtl_ppm, snap.rtl_bw_khz, snap.rtl_sql, snap.rtl_volume,
+                    snap.rtl_auto_ppm);
+        rc |= 1;
+    }
+
+    reset_opts_and_state(opts, state);
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", "rtltcp:radio.local:1234:769.00625M:28:3:24:-47:5");
+    opts.rtlsdr_center_freq = 769006250U;
+    opts.rtl_gain_value = 28;
+    opts.rtlsdr_ppm_error = 3;
+    opts.rtl_dsp_bw_khz = 24;
+    opts.rtl_squelch_level = 1e-30;
+    opts.rtl_volume_multiplier = 5;
+
+    dsd_snapshot_opts_to_user_config(&opts, &state, &snap);
+    if (!snap.has_input || snap.input_source != DSDCFG_INPUT_RTLTCP || strcmp(snap.rtltcp_host, "radio.local") != 0
+        || snap.rtltcp_port != 1234) {
+        DSD_FPRINTF(stderr, "snapshot RTLTCP source mismatch source=%d host=%s port=%d\n", (int)snap.input_source,
+                    snap.rtltcp_host, snap.rtltcp_port);
+        rc |= 1;
+    }
+    if (strcmp(snap.rtl_freq, "769006250") != 0 || snap.rtl_gain != 28 || snap.rtl_ppm != 3 || snap.rtl_bw_khz != 24
+        || snap.rtl_sql != -120 || snap.rtl_volume != 5 || !snap.rtl_ppm_is_set) {
+        DSD_FPRINTF(stderr, "snapshot RTLTCP tuning mismatch freq=%s gain=%d ppm=%d bw=%d sql=%d vol=%d\n",
+                    snap.rtl_freq, snap.rtl_gain, snap.rtl_ppm, snap.rtl_bw_khz, snap.rtl_sql, snap.rtl_volume);
+        rc |= 1;
+    }
+
+    return rc;
+}
+
+static int
 test_load_and_apply_rtltcp_regression(void) {
     static const char* ini = "version = 1\n"
                              "\n"
@@ -1173,12 +1421,15 @@ int
 main(void) {
     int rc = 0;
     rc |= test_apply_file_input_rescales_symbol_timing();
+    rc |= test_decode_mode_aliases_and_guards();
+    rc |= test_render_input_variants_and_save_atomic();
     rc |= test_load_and_apply_basic();
     rc |= test_load_and_apply_alerts_empty_event_mask();
     rc |= test_load_and_apply_soapy_input_no_args();
     rc |= test_load_and_apply_soapy_input_with_args();
     rc |= test_snapshot_roundtrip_soapy_args();
     rc |= test_snapshot_roundtrip_zero_rtl_ppm();
+    rc |= test_snapshot_rtl_and_rtltcp_device_specs();
     rc |= test_load_and_apply_rtltcp_regression();
     rc |= test_snapshot_roundtrip();
     rc |= test_apply_demod_lock();

--- a/tests/runtime/test_runtime_config_user.cpp
+++ b/tests/runtime/test_runtime_config_user.cpp
@@ -23,6 +23,7 @@
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/platform/file_compat.h"
 #include "dsd-neo/runtime/call_alert.h"
+#include "dsd-neo/runtime/config_schema.h"
 #include "test_support.h"
 
 static int

--- a/tests/runtime/test_runtime_decode_mode.c
+++ b/tests/runtime/test_runtime_decode_mode.c
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(clang-analyzer-optin.performance.Padding)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -187,6 +190,240 @@ test_interactive_x2_and_ysf_behavior(void) {
     return 0;
 }
 
+static int
+test_cli_preset_mapping_and_guards(void) {
+    static const struct {
+        char preset;
+        dsdneoUserDecodeMode mode;
+    } cases[] = {
+        {'a', DSDCFG_MODE_AUTO},   {'A', DSDCFG_MODE_ANALOG}, {'d', DSDCFG_MODE_DSTAR}, {'x', DSDCFG_MODE_X2TDMA},
+        {'t', DSDCFG_MODE_TDMA},   {'1', DSDCFG_MODE_P25P1},  {'2', DSDCFG_MODE_P25P2}, {'s', DSDCFG_MODE_DMR},
+        {'i', DSDCFG_MODE_NXDN48}, {'n', DSDCFG_MODE_NXDN96}, {'y', DSDCFG_MODE_YSF},   {'m', DSDCFG_MODE_M17},
+    };
+
+    dsdneoUserDecodeMode mode = DSDCFG_MODE_UNSET;
+    if (dsd_decode_mode_from_cli_preset('a', NULL) != -1) {
+        DSD_FPRINTF(stderr, "NULL output preset parse should fail\n");
+        return 1;
+    }
+    if (dsd_decode_mode_from_cli_preset('?', &mode) != -1 || mode != DSDCFG_MODE_UNSET) {
+        DSD_FPRINTF(stderr, "invalid preset parse should fail without changing mode\n");
+        return 1;
+    }
+
+    for (size_t i = 0; i < sizeof cases / sizeof cases[0]; i++) {
+        mode = DSDCFG_MODE_UNSET;
+        if (dsd_decode_mode_from_cli_preset(cases[i].preset, &mode) != 0 || mode != cases[i].mode) {
+            DSD_FPRINTF(stderr, "preset %c mapped to %d, expected %d\n", cases[i].preset, (int)mode,
+                        (int)cases[i].mode);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int
+test_remaining_preset_modes(void) {
+    static const struct {
+        dsdneoUserDecodeMode mode;
+        dsdDecodePresetProfile profile;
+        const char* name;
+        int frame_dstar;
+        int frame_x2tdma;
+        int frame_p25p1;
+        int frame_p25p2;
+        int frame_nxdn48;
+        int frame_nxdn96;
+        int frame_dmr;
+        int frame_dpmr;
+        int frame_provoice;
+        int frame_ysf;
+        int frame_m17;
+        int samples_per_symbol;
+        int symbol_center;
+        int rf_mod;
+        int pulse_channels;
+    } cases[] = {
+        {DSDCFG_MODE_P25P1, DSD_DECODE_PRESET_PROFILE_CLI, "P25p1", 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+        {DSDCFG_MODE_NXDN96, DSD_DECODE_PRESET_PROFILE_INTERACTIVE, "NXDN96", 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 20, 9, 0,
+         1},
+        {DSDCFG_MODE_DSTAR, DSD_DECODE_PRESET_PROFILE_CLI, "DSTAR", 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+        {DSDCFG_MODE_EDACS_PV, DSD_DECODE_PRESET_PROFILE_CLI, "EDACS/PV", 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 5, 2, 2, 1},
+        {DSDCFG_MODE_DPMR, DSD_DECODE_PRESET_PROFILE_CLI, "dPMR", 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 20, 9, 0, 1},
+        {DSDCFG_MODE_M17, DSD_DECODE_PRESET_PROFILE_CLI, "M17", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1},
+        {DSDCFG_MODE_TDMA, DSD_DECODE_PRESET_PROFILE_CLI, "TDMA", 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2},
+    };
+
+    for (size_t i = 0; i < sizeof cases / sizeof cases[0]; i++) {
+        static dsd_opts opts;
+        static dsd_state state;
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        state.samplesPerSymbol = -1;
+        state.symbolCenter = -1;
+        opts.use_cosine_filter = 1;
+
+        if (dsd_apply_decode_mode_preset(cases[i].mode, cases[i].profile, &opts, &state) != 0) {
+            DSD_FPRINTF(stderr, "preset %s apply failed\n", cases[i].name);
+            return 1;
+        }
+        if (strcmp(opts.output_name, cases[i].name) != 0) {
+            DSD_FPRINTF(stderr, "preset output name mismatch: got %s expected %s\n", opts.output_name, cases[i].name);
+            return 1;
+        }
+        if (!(opts.frame_dstar == cases[i].frame_dstar && opts.frame_x2tdma == cases[i].frame_x2tdma
+              && opts.frame_p25p1 == cases[i].frame_p25p1 && opts.frame_p25p2 == cases[i].frame_p25p2
+              && opts.frame_nxdn48 == cases[i].frame_nxdn48 && opts.frame_nxdn96 == cases[i].frame_nxdn96
+              && opts.frame_dmr == cases[i].frame_dmr && opts.frame_dpmr == cases[i].frame_dpmr
+              && opts.frame_provoice == cases[i].frame_provoice && opts.frame_ysf == cases[i].frame_ysf
+              && opts.frame_m17 == cases[i].frame_m17)) {
+            DSD_FPRINTF(stderr, "preset %s frame flags mismatch\n", cases[i].name);
+            return 1;
+        }
+        if (cases[i].samples_per_symbol > 0
+            && !(state.samplesPerSymbol == cases[i].samples_per_symbol
+                 && state.symbolCenter == cases[i].symbol_center)) {
+            DSD_FPRINTF(stderr, "preset %s timing mismatch sps=%d center=%d\n", cases[i].name, state.samplesPerSymbol,
+                        state.symbolCenter);
+            return 1;
+        }
+        if (state.rf_mod != cases[i].rf_mod || opts.pulse_digi_out_channels != cases[i].pulse_channels) {
+            DSD_FPRINTF(stderr, "preset %s rf/audio mismatch rf_mod=%d channels=%d\n", cases[i].name, state.rf_mod,
+                        opts.pulse_digi_out_channels);
+            return 1;
+        }
+        if (cases[i].mode == DSDCFG_MODE_M17 && opts.use_cosine_filter != 0) {
+            DSD_FPRINTF(stderr, "M17 should disable cosine filter\n");
+            return 1;
+        }
+        if (cases[i].mode == DSDCFG_MODE_EDACS_PV && (state.ea_mode != 0 || state.esk_mask != 0)) {
+            DSD_FPRINTF(stderr, "EDACS/PV should clear EA/ESK state\n");
+            return 1;
+        }
+    }
+
+    static dsd_opts opts = {0};
+    static dsd_state state = {0};
+    if (dsd_apply_decode_mode_preset(DSDCFG_MODE_P25P1, DSD_DECODE_PRESET_PROFILE_CLI, NULL, &state) != -1
+        || dsd_apply_decode_mode_preset(DSDCFG_MODE_P25P1, DSD_DECODE_PRESET_PROFILE_CLI, &opts, NULL) != -1
+        || dsd_apply_decode_mode_preset(DSDCFG_MODE_UNSET, DSD_DECODE_PRESET_PROFILE_CLI, &opts, &state) != -1) {
+        DSD_FPRINTF(stderr, "preset apply guards should reject NULL/unknown modes\n");
+        return 1;
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    opts.dmr_mono = 1;
+    state.dmr_stereo = 1;
+    if (dsd_apply_decode_mode_preset(DSDCFG_MODE_NXDN96, DSD_DECODE_PRESET_PROFILE_CONFIG, &opts, &state) != 0) {
+        DSD_FPRINTF(stderr, "config NXDN96 apply failed\n");
+        return 1;
+    }
+    if (opts.dmr_mono != 1 || state.dmr_stereo != 1) {
+        DSD_FPRINTF(stderr, "config NXDN96 should preserve mono/state stereo settings\n");
+        return 1;
+    }
+
+    return 0;
+}
+
+static int
+test_symbol_timing_and_inference(void) {
+    static const struct {
+        dsdneoUserDecodeMode mode;
+        int expected_sps;
+        int expected_center;
+    } timing_cases[] = {
+        {DSDCFG_MODE_P25P2, 16, 6},    {DSDCFG_MODE_NXDN48, 40, 18}, {DSDCFG_MODE_DPMR, 40, 18},
+        {DSDCFG_MODE_EDACS_PV, 10, 4}, {DSDCFG_MODE_DMR, 20, 8},
+    };
+
+    static const struct {
+        unsigned int bit;
+        dsdneoUserDecodeMode expected;
+    } infer_cases[] = {
+        {1u << 6, DSDCFG_MODE_DMR},    {1u << 2, DSDCFG_MODE_P25P1},  {1u << 3, DSDCFG_MODE_P25P2},
+        {1u << 4, DSDCFG_MODE_NXDN48}, {1u << 5, DSDCFG_MODE_NXDN96}, {1u << 1, DSDCFG_MODE_X2TDMA},
+        {1u << 9, DSDCFG_MODE_YSF},    {1u << 0, DSDCFG_MODE_DSTAR},  {1u << 8, DSDCFG_MODE_EDACS_PV},
+        {1u << 7, DSDCFG_MODE_DPMR},   {1u << 10, DSDCFG_MODE_M17},
+    };
+
+    dsd_apply_decode_mode_symbol_timing(DSDCFG_MODE_DMR, 96000, NULL);
+
+    for (size_t i = 0; i < sizeof timing_cases / sizeof timing_cases[0]; i++) {
+        static dsd_state state;
+        DSD_MEMSET(&state, 0, sizeof state);
+        dsd_apply_decode_mode_symbol_timing(timing_cases[i].mode, 96000, &state);
+        if (state.samplesPerSymbol != timing_cases[i].expected_sps
+            || state.symbolCenter != timing_cases[i].expected_center || state.jitter != -1) {
+            DSD_FPRINTF(stderr, "timing mode %d mismatch sps=%d center=%d jitter=%d\n", (int)timing_cases[i].mode,
+                        state.samplesPerSymbol, state.symbolCenter, state.jitter);
+            return 1;
+        }
+    }
+
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof state);
+    dsd_apply_decode_mode_symbol_timing(DSDCFG_MODE_DMR, 48000, &state);
+    if (state.samplesPerSymbol != 10 || state.symbolCenter != 4) {
+        DSD_FPRINTF(stderr, "48000 timing should keep base DMR timing\n");
+        return 1;
+    }
+
+    if (dsd_infer_decode_mode_preset(NULL) != DSDCFG_MODE_AUTO) {
+        DSD_FPRINTF(stderr, "NULL infer should return AUTO\n");
+        return 1;
+    }
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.analog_only = 1;
+    opts.monitor_input_audio = 1;
+    if (dsd_infer_decode_mode_preset(&opts) != DSDCFG_MODE_ANALOG) {
+        DSD_FPRINTF(stderr, "analog monitor infer mismatch\n");
+        return 1;
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_dmr = 1;
+    if (dsd_infer_decode_mode_preset(&opts) != DSDCFG_MODE_TDMA) {
+        DSD_FPRINTF(stderr, "TDMA infer mismatch\n");
+        return 1;
+    }
+
+    for (size_t i = 0; i < sizeof infer_cases / sizeof infer_cases[0]; i++) {
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        opts.frame_dstar = (infer_cases[i].bit & (1u << 0)) != 0;
+        opts.frame_x2tdma = (infer_cases[i].bit & (1u << 1)) != 0;
+        opts.frame_p25p1 = (infer_cases[i].bit & (1u << 2)) != 0;
+        opts.frame_p25p2 = (infer_cases[i].bit & (1u << 3)) != 0;
+        opts.frame_nxdn48 = (infer_cases[i].bit & (1u << 4)) != 0;
+        opts.frame_nxdn96 = (infer_cases[i].bit & (1u << 5)) != 0;
+        opts.frame_dmr = (infer_cases[i].bit & (1u << 6)) != 0;
+        opts.frame_dpmr = (infer_cases[i].bit & (1u << 7)) != 0;
+        opts.frame_provoice = (infer_cases[i].bit & (1u << 8)) != 0;
+        opts.frame_ysf = (infer_cases[i].bit & (1u << 9)) != 0;
+        opts.frame_m17 = (infer_cases[i].bit & (1u << 10)) != 0;
+        if (dsd_infer_decode_mode_preset(&opts) != infer_cases[i].expected) {
+            DSD_FPRINTF(stderr, "infer bit %u mismatch\n", infer_cases[i].bit);
+            return 1;
+        }
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.frame_dstar = 1;
+    opts.frame_dmr = 1;
+    if (dsd_infer_decode_mode_preset(&opts) != DSDCFG_MODE_AUTO) {
+        DSD_FPRINTF(stderr, "mixed unsupported infer should return AUTO\n");
+        return 1;
+    }
+
+    return 0;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -195,5 +432,10 @@ main(void) {
     rc |= test_dmr_prefers_gfsk();
     rc |= test_dmr_preserves_manual_c4fm_lock();
     rc |= test_interactive_x2_and_ysf_behavior();
+    rc |= test_cli_preset_mapping_and_guards();
+    rc |= test_remaining_preset_modes();
+    rc |= test_symbol_timing_and_inference();
     return rc;
 }
+
+// NOLINTEND(clang-analyzer-optin.performance.Padding)

--- a/tests/runtime/test_runtime_dmr_t3_lcn_calc.c
+++ b/tests/runtime/test_runtime_dmr_t3_lcn_calc.c
@@ -64,6 +64,17 @@ test_empty_csv_fails(void) {
 }
 
 static void
+test_invalid_signed_numeric_prefixes_are_skipped(void) {
+    char path[DSD_TEST_PATH_MAX];
+
+    clear_dmr_t3_env();
+    dsd_neo_config_init(NULL);
+    write_temp_csv(path, "site,freq\nA,+not-a-number7\nB,-0\nC,0\n");
+    assert(dsd_cli_calc_dmr_t3_lcn_from_csv(path) == 2);
+    remove(path);
+}
+
+static void
 test_single_frequency_uses_default_start_lcn(void) {
     char path[DSD_TEST_PATH_MAX];
 
@@ -82,6 +93,17 @@ test_unsorted_duplicates_infer_step(void) {
     dsd_neo_config_init(NULL);
     write_temp_csv(path, "site,freq\nB,851.025\nA,851.0125\nC,851.025\nD,851.0375\n");
     assert(dsd_cli_calc_dmr_t3_lcn_from_csv(path) == 0);
+    remove(path);
+}
+
+static void
+test_too_small_spacing_without_configured_step_fails(void) {
+    char path[DSD_TEST_PATH_MAX];
+
+    clear_dmr_t3_env();
+    dsd_neo_config_init(NULL);
+    write_temp_csv(path, "site,freq\nA,851000000\nB,851000050\n");
+    assert(dsd_cli_calc_dmr_t3_lcn_from_csv(path) == 3);
     remove(path);
 }
 
@@ -106,8 +128,10 @@ int
 main(void) {
     test_missing_file_fails();
     test_empty_csv_fails();
+    test_invalid_signed_numeric_prefixes_are_skipped();
     test_single_frequency_uses_default_start_lcn();
     test_unsorted_duplicates_infer_step();
+    test_too_small_spacing_without_configured_step_fails();
     test_configured_step_and_anchor_are_accepted();
     printf("RUNTIME_DMR_T3_LCN_CALC: OK\n");
     return 0;

--- a/tests/runtime/test_runtime_dmr_t3_lcn_calc.c
+++ b/tests/runtime/test_runtime_dmr_t3_lcn_calc.c
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <stdio.h>
+
+#include <dsd-neo/platform/platform.h>
+#include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/runtime/cli.h>
+#include <dsd-neo/runtime/config.h>
+#include "test_support.h"
+
+#if DSD_PLATFORM_WIN_NATIVE
+#include <io.h>
+#define dsd_fdopen _fdopen
+#else
+#define dsd_fdopen fdopen
+#endif
+
+static void
+clear_dmr_t3_env(void) {
+    (void)dsd_unsetenv("DSD_NEO_DMR_T3_STEP_HZ");
+    (void)dsd_unsetenv("DSD_NEO_DMR_T3_CC_FREQ");
+    (void)dsd_unsetenv("DSD_NEO_DMR_T3_CC_LCN");
+    (void)dsd_unsetenv("DSD_NEO_DMR_T3_START_LCN");
+}
+
+static void
+write_temp_csv(char path[DSD_TEST_PATH_MAX], const char* body) {
+    int fd;
+    FILE* fp;
+
+    fd = dsd_test_mkstemp(path, DSD_TEST_PATH_MAX, "dsdneo_t3_lcn");
+    assert(fd >= 0);
+
+    fp = dsd_fdopen(fd, "w");
+    assert(fp != NULL);
+    assert(fputs(body, fp) >= 0);
+    assert(fclose(fp) == 0);
+}
+
+static void
+test_missing_file_fails(void) {
+    char path[DSD_TEST_PATH_MAX];
+
+    clear_dmr_t3_env();
+    dsd_neo_config_init(NULL);
+    assert(dsd_test_make_temp_template(path, sizeof path, "dsdneo_missing_t3_lcn") == 0);
+    (void)remove(path);
+    assert(dsd_cli_calc_dmr_t3_lcn_from_csv(path) == 1);
+}
+
+static void
+test_empty_csv_fails(void) {
+    char path[DSD_TEST_PATH_MAX];
+
+    clear_dmr_t3_env();
+    dsd_neo_config_init(NULL);
+    write_temp_csv(path, "header,value\nno frequency here\n");
+    assert(dsd_cli_calc_dmr_t3_lcn_from_csv(path) == 2);
+    remove(path);
+}
+
+static void
+test_single_frequency_uses_default_start_lcn(void) {
+    char path[DSD_TEST_PATH_MAX];
+
+    clear_dmr_t3_env();
+    dsd_neo_config_init(NULL);
+    write_temp_csv(path, "site,freq\nA,851.0125\n");
+    assert(dsd_cli_calc_dmr_t3_lcn_from_csv(path) == 0);
+    remove(path);
+}
+
+static void
+test_unsorted_duplicates_infer_step(void) {
+    char path[DSD_TEST_PATH_MAX];
+
+    clear_dmr_t3_env();
+    dsd_neo_config_init(NULL);
+    write_temp_csv(path, "site,freq\nB,851.025\nA,851.0125\nC,851.025\nD,851.0375\n");
+    assert(dsd_cli_calc_dmr_t3_lcn_from_csv(path) == 0);
+    remove(path);
+}
+
+static void
+test_configured_step_and_anchor_are_accepted(void) {
+    char path[DSD_TEST_PATH_MAX];
+
+    clear_dmr_t3_env();
+    (void)dsd_setenv("DSD_NEO_DMR_T3_STEP_HZ", "12500", 1);
+    (void)dsd_setenv("DSD_NEO_DMR_T3_CC_FREQ", "851.025M", 1);
+    (void)dsd_setenv("DSD_NEO_DMR_T3_CC_LCN", "10", 1);
+    (void)dsd_setenv("DSD_NEO_DMR_T3_START_LCN", "3", 1);
+    dsd_neo_config_init(NULL);
+
+    write_temp_csv(path, "site,freq\nA,851012500\nB,851025000\nC,851037500\n");
+    assert(dsd_cli_calc_dmr_t3_lcn_from_csv(path) == 0);
+    remove(path);
+    clear_dmr_t3_env();
+}
+
+int
+main(void) {
+    test_missing_file_fails();
+    test_empty_csv_fails();
+    test_single_frequency_uses_default_start_lcn();
+    test_unsorted_duplicates_infer_step();
+    test_configured_step_and_anchor_are_accepted();
+    printf("RUNTIME_DMR_T3_LCN_CALC: OK\n");
+    return 0;
+}

--- a/tests/runtime/test_runtime_frame_sync_hooks.c
+++ b/tests/runtime/test_runtime_frame_sync_hooks.c
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(performance-no-int-to-ptr)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/runtime/frame_sync_hooks.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static int g_try_tick_calls;
+static int g_release_calls;
+static int g_eot_calls;
+static int g_no_carrier_calls;
+static dsd_opts* g_last_opts;
+static dsd_state* g_last_state;
+
+static void
+reset_counters(void) {
+    g_try_tick_calls = 0;
+    g_release_calls = 0;
+    g_eot_calls = 0;
+    g_no_carrier_calls = 0;
+    g_last_opts = NULL;
+    g_last_state = NULL;
+}
+
+static void
+record_args(dsd_opts* opts, dsd_state* state) {
+    g_last_opts = opts;
+    g_last_state = state;
+}
+
+static void
+hook_try_tick(dsd_opts* opts, dsd_state* state) {
+    g_try_tick_calls++;
+    record_args(opts, state);
+}
+
+static void
+hook_release(dsd_opts* opts, dsd_state* state) {
+    g_release_calls++;
+    record_args(opts, state);
+}
+
+static void
+hook_eot(dsd_opts* opts, dsd_state* state) {
+    g_eot_calls++;
+    record_args(opts, state);
+}
+
+static void
+hook_no_carrier(dsd_opts* opts, dsd_state* state) {
+    g_no_carrier_calls++;
+    record_args(opts, state);
+}
+
+static void
+test_empty_hooks_are_noops(dsd_opts* opts, dsd_state* state) {
+    dsd_frame_sync_hooks_set((dsd_frame_sync_hooks){0});
+    reset_counters();
+
+    dsd_frame_sync_hook_p25_sm_try_tick(opts, state);
+    dsd_frame_sync_hook_p25_sm_on_release(opts, state);
+    dsd_frame_sync_hook_eot_cc(opts, state);
+    dsd_frame_sync_hook_no_carrier(opts, state);
+
+    assert(g_try_tick_calls == 0);
+    assert(g_release_calls == 0);
+    assert(g_eot_calls == 0);
+    assert(g_no_carrier_calls == 0);
+    assert(g_last_opts == NULL);
+    assert(g_last_state == NULL);
+}
+
+static void
+test_installed_hooks_forward_args(dsd_opts* opts, dsd_state* state) {
+    dsd_frame_sync_hooks hooks = {
+        .p25_sm_try_tick = hook_try_tick,
+        .p25_sm_on_release = hook_release,
+        .eot_cc = hook_eot,
+        .no_carrier = hook_no_carrier,
+    };
+    dsd_frame_sync_hooks_set(hooks);
+    reset_counters();
+
+    dsd_frame_sync_hook_p25_sm_try_tick(opts, state);
+    assert(g_try_tick_calls == 1);
+    assert(g_last_opts == opts);
+    assert(g_last_state == state);
+
+    dsd_frame_sync_hook_p25_sm_on_release(opts, state);
+    assert(g_release_calls == 1);
+    assert(g_last_opts == opts);
+    assert(g_last_state == state);
+
+    dsd_frame_sync_hook_eot_cc(opts, state);
+    assert(g_eot_calls == 1);
+    assert(g_last_opts == opts);
+    assert(g_last_state == state);
+
+    dsd_frame_sync_hook_no_carrier(opts, state);
+    assert(g_no_carrier_calls == 1);
+    assert(g_last_opts == opts);
+    assert(g_last_state == state);
+}
+
+static void
+test_partial_reinstall_replaces_table(dsd_opts* opts, dsd_state* state) {
+    dsd_frame_sync_hooks_set((dsd_frame_sync_hooks){
+        .p25_sm_try_tick = hook_try_tick,
+        .no_carrier = hook_no_carrier,
+    });
+    reset_counters();
+
+    dsd_frame_sync_hook_p25_sm_try_tick(opts, state);
+    dsd_frame_sync_hook_p25_sm_on_release(opts, state);
+    dsd_frame_sync_hook_eot_cc(opts, state);
+    dsd_frame_sync_hook_no_carrier(opts, state);
+
+    assert(g_try_tick_calls == 1);
+    assert(g_release_calls == 0);
+    assert(g_eot_calls == 0);
+    assert(g_no_carrier_calls == 1);
+    assert(g_last_opts == opts);
+    assert(g_last_state == state);
+}
+
+int
+main(void) {
+    dsd_opts* opts = (dsd_opts*)(uintptr_t)0x1234U;
+    dsd_state* state = (dsd_state*)(uintptr_t)0x5678U;
+
+    test_empty_hooks_are_noops(opts, state);
+    test_installed_hooks_forward_args(opts, state);
+    test_partial_reinstall_replaces_table(opts, state);
+
+    dsd_frame_sync_hooks_set((dsd_frame_sync_hooks){0});
+    return 0;
+}
+
+// NOLINTEND(performance-no-int-to-ptr)

--- a/tests/runtime/test_runtime_input_ring_init.cpp
+++ b/tests/runtime/test_runtime_input_ring_init.cpp
@@ -1,15 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(performance-no-int-to-ptr)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+#include <atomic>
 #include <dsd-neo/platform/threading.h>
 #include <dsd-neo/platform/timing.h>
 #include <dsd-neo/runtime/input_ring.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
+
 #include "dsd-neo/core/safe_api.h"
+
+extern "C" volatile uint8_t exitflag;
 
 extern "C" int
 dsd_rtl_stream_should_exit(void) {
@@ -44,9 +51,108 @@ expect_float(const char* label, float got, float want) {
     return 0;
 }
 
+static int
+test_guard_and_wrap_contracts(void) {
+    int rc = 0;
+    float sample = 1.0f;
+    float out[8] = {0.0f};
+    float* p1 = reinterpret_cast<float*>(static_cast<uintptr_t>(1U));
+    float* p2 = reinterpret_cast<float*>(static_cast<uintptr_t>(2U));
+    size_t n1 = 9U;
+    size_t n2 = 10U;
+
+    input_ring_destroy(NULL);
+    input_ring_enable_space_notify(NULL, 1);
+    input_ring_write(NULL, &sample, 1U);
+
+    struct input_ring_state ring;
+    DSD_MEMSET(&ring, 0, sizeof(ring));
+    input_ring_read_commit(NULL, 1U);
+    input_ring_read_commit(&ring, 1U);
+
+    rc |= expect_int("init guard ring", input_ring_init(&ring, 8U), 0);
+    input_ring_enable_space_notify(&ring, 2);
+    rc |= expect_int("space notify enabled", ring.space_notify_enabled.load(), 1);
+    input_ring_enable_space_notify(&ring, 0);
+    rc |= expect_int("space notify disabled", ring.space_notify_enabled.load(), 0);
+
+    input_ring_commit(&ring, 0U);
+    rc |= expect_size("commit zero keeps empty", input_ring_used(&ring), 0U);
+    input_ring_write(&ring, NULL, 1U);
+    input_ring_write(&ring, &sample, 0U);
+    rc |= expect_size("write guards keep empty", input_ring_used(&ring), 0U);
+
+    ring.head.store(6U);
+    ring.tail.store(4U);
+    rc |= expect_int("reserve wrap", input_ring_reserve(&ring, 4U, &p1, &n1, &p2, &n2), 4);
+    rc |= expect_int("reserve wrap p1", p1 == ring.buffer + 6U, 1);
+    rc |= expect_size("reserve wrap n1", n1, 2U);
+    rc |= expect_int("reserve wrap p2", p2 == ring.buffer, 1);
+    rc |= expect_size("reserve wrap n2", n2, 2U);
+
+    input_ring_clear(&ring);
+    ring.head.store(6U);
+    ring.tail.store(5U);
+    float end_write[2] = {30.0f, 31.0f};
+    input_ring_write(&ring, end_write, 2U);
+    rc |= expect_size("write exact end wraps head", ring.head.load(), 0U);
+
+    input_ring_clear(&ring);
+    ring.buffer[6] = 40.0f;
+    ring.buffer[7] = 41.0f;
+    ring.head.store(0U);
+    ring.tail.store(6U);
+    rc |= expect_int("read block exact end", input_ring_read_block(&ring, out, 2U), 2);
+    rc |= expect_float("read block exact end out[0]", out[0], 40.0f);
+    rc |= expect_float("read block exact end out[1]", out[1], 41.0f);
+    rc |= expect_size("read block exact end wraps tail", ring.tail.load(), 0U);
+
+    input_ring_clear(&ring);
+    rc |= expect_int("read block zero", input_ring_read_block(&ring, out, 0U), 0);
+    exitflag = 1U;
+    rc |= expect_int("read block exit", input_ring_read_block(&ring, out, 1U), -1);
+    exitflag = 0U;
+    rc |= expect_int("read reserve null ring", input_ring_read_reserve(NULL, 1U, &p1, &n1, &p2, &n2), -1);
+    rc |= expect_int("read reserve null p1", input_ring_read_reserve(&ring, 1U, NULL, &n1, &p2, &n2), -1);
+    rc |= expect_int("read reserve null n1", input_ring_read_reserve(&ring, 1U, &p1, NULL, &p2, &n2), -1);
+    rc |= expect_int("read reserve null p2", input_ring_read_reserve(&ring, 1U, &p1, &n1, NULL, &n2), -1);
+    rc |= expect_int("read reserve null n2", input_ring_read_reserve(&ring, 1U, &p1, &n1, &p2, NULL), -1);
+    p1 = reinterpret_cast<float*>(static_cast<uintptr_t>(1U));
+    p2 = reinterpret_cast<float*>(static_cast<uintptr_t>(2U));
+    n1 = 9U;
+    n2 = 10U;
+    rc |= expect_int("read reserve zero", input_ring_read_reserve(&ring, 0U, &p1, &n1, &p2, &n2), 0);
+    rc |= expect_int("read reserve zero p1", p1 == NULL, 1);
+    rc |= expect_size("read reserve zero n1", n1, 0U);
+    rc |= expect_int("read reserve zero p2", p2 == NULL, 1);
+    rc |= expect_size("read reserve zero n2", n2, 0U);
+
+    float write_full[9] = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+    input_ring_write(&ring, write_full, 7U);
+    rc |= expect_size("full ring used", input_ring_used(&ring), 7U);
+    input_ring_write(&ring, write_full + 7U, 2U);
+    rc |= expect_size("full ring drops keep used", input_ring_used(&ring), 7U);
+    rc |= expect_int("full ring drops counted", ring.producer_drops.load() == 2U, 1);
+
+    input_ring_read_commit(&ring, 99U);
+    rc |= expect_size("overconsume clamps to available", input_ring_used(&ring), 0U);
+
+    input_ring_enable_space_notify(&ring, 1);
+    input_ring_write(&ring, write_full, 2U);
+    rc |= expect_int("read block two", input_ring_read_block(&ring, out, 2U), 2);
+    rc |= expect_float("read block out[0]", out[0], 0.0f);
+    rc |= expect_float("read block out[1]", out[1], 1.0f);
+    rc |= expect_size("read block consumed", input_ring_used(&ring), 0U);
+
+    input_ring_destroy(&ring);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
+
+    rc |= test_guard_and_wrap_contracts();
 
     rc |= expect_int("init(NULL, 8)", input_ring_init(NULL, 8), -1);
 
@@ -139,3 +245,5 @@ main(void) {
 
     return rc ? 1 : 0;
 }
+
+// NOLINTEND(performance-no-int-to-ptr)

--- a/tests/runtime/test_runtime_log.cpp
+++ b/tests/runtime/test_runtime_log.cpp
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-unix.Errno,misc-use-internal-linkage)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/runtime/log.h>
+
+typedef struct capture_stderr {
+    FILE* file;
+    int saved_fd;
+} capture_stderr;
+
+static void
+set_env_flag(const char* name, const char* value) {
+    int rc = value != nullptr ? dsd_setenv(name, value, 1) : dsd_unsetenv(name);
+    assert(rc == 0);
+}
+
+static capture_stderr
+capture_stderr_begin(void) {
+    capture_stderr capture;
+    capture.file = tmpfile();
+    capture.saved_fd = -1;
+    assert(capture.file != nullptr);
+
+    fflush(stderr);
+    capture.saved_fd = dsd_dup(dsd_fileno(stderr));
+    assert(capture.saved_fd >= 0);
+    assert(dsd_dup2(dsd_fileno(capture.file), dsd_fileno(stderr)) >= 0);
+    return capture;
+}
+
+static void
+capture_stderr_end(capture_stderr* capture, char* out, size_t out_size) {
+    assert(capture != nullptr);
+    assert(capture->file != nullptr);
+    assert(out != nullptr);
+    assert(out_size > 0);
+    out[0] = '\0';
+
+    int flush_rc = fflush(stderr);
+    assert(flush_rc == 0);
+    if (flush_rc != 0) {
+        fclose(capture->file);
+        capture->file = nullptr;
+        return;
+    }
+    int restore_rc = dsd_dup2(capture->saved_fd, dsd_fileno(stderr));
+    assert(restore_rc >= 0);
+    if (restore_rc < 0) {
+        fclose(capture->file);
+        capture->file = nullptr;
+        return;
+    }
+    int close_rc = dsd_close(capture->saved_fd);
+    assert(close_rc == 0);
+    if (close_rc != 0) {
+        fclose(capture->file);
+        capture->file = nullptr;
+        return;
+    }
+    capture->saved_fd = -1;
+
+    int seek_rc = fseek(capture->file, 0, SEEK_SET);
+    assert(seek_rc == 0);
+    if (seek_rc != 0) {
+        out[0] = '\0';
+        fclose(capture->file);
+        capture->file = nullptr;
+        return;
+    }
+    clearerr(capture->file);
+    size_t nread = fread(out, 1, out_size - 1, capture->file);
+    assert(ferror(capture->file) == 0);
+    if (ferror(capture->file) != 0) {
+        out[0] = '\0';
+    } else {
+        out[nread] = '\0';
+    }
+    fclose(capture->file);
+    capture->file = nullptr;
+}
+
+static void
+test_log_write_formats_and_preserves_utf8_when_supported(void) {
+    char out[128];
+    set_env_flag("DSD_FORCE_ASCII", nullptr);
+    set_env_flag("DSD_FORCE_UTF8", "1");
+
+    capture_stderr capture = capture_stderr_begin();
+    dsd_neo_log_write(LOG_LEVEL_WARN, "Temp %s %d\n", "\xC2\xB0", 7);
+    capture_stderr_end(&capture, out, sizeof(out));
+
+    assert(strcmp(out, "Temp \xC2\xB0 7\n") == 0);
+}
+
+static void
+test_log_write_applies_ascii_fallback_when_unicode_disabled(void) {
+    char out[128];
+    set_env_flag("DSD_FORCE_ASCII", "1");
+    set_env_flag("DSD_FORCE_UTF8", nullptr);
+
+    capture_stderr capture = capture_stderr_begin();
+    dsd_neo_log_write(LOG_LEVEL_INFO, "Glyphs %s %d\n", "\xC2\xB0 \xE2\x80\x93 \xE2\x98\x83", 3);
+    capture_stderr_end(&capture, out, sizeof(out));
+
+    assert(strcmp(out, "Glyphs  deg - ? 3\n") == 0);
+}
+
+static void
+test_log_write_ignores_null_format(void) {
+    char out[16];
+    set_env_flag("DSD_FORCE_ASCII", nullptr);
+    set_env_flag("DSD_FORCE_UTF8", "1");
+
+    capture_stderr capture = capture_stderr_begin();
+    dsd_neo_log_write(LOG_LEVEL_ERROR, nullptr);
+    capture_stderr_end(&capture, out, sizeof(out));
+
+    assert(out[0] == '\0');
+}
+
+int
+main(void) {
+    test_log_write_formats_and_preserves_utf8_when_supported();
+    test_log_write_applies_ascii_fallback_when_unicode_disabled();
+    test_log_write_ignores_null_format();
+
+    set_env_flag("DSD_FORCE_ASCII", nullptr);
+    set_env_flag("DSD_FORCE_UTF8", nullptr);
+
+    std::puts("RUNTIME_LOG: OK");
+    return 0;
+}
+
+// NOLINTEND(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-unix.Errno,misc-use-internal-linkage)

--- a/tests/runtime/test_runtime_mem.cpp
+++ b/tests/runtime/test_runtime_mem.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <dsd-neo/runtime/mem.h>
+
+static void
+test_aligned_malloc_rejects_zero_size(void) {
+    assert(dsd_neo_aligned_malloc(0) == nullptr);
+}
+
+static void
+test_aligned_malloc_returns_aligned_writable_memory(void) {
+    void* ptr = dsd_neo_aligned_malloc(DSD_NEO_ALIGN * 2U);
+    assert(ptr != nullptr);
+    assert((reinterpret_cast<std::uintptr_t>(ptr) % DSD_NEO_ALIGN) == 0U);
+
+    std::memset(ptr, 0x5A, DSD_NEO_ALIGN * 2U);
+    const unsigned char* bytes = static_cast<const unsigned char*>(ptr);
+    assert(bytes[0] == 0x5AU);
+    assert(bytes[DSD_NEO_ALIGN * 2U - 1U] == 0x5AU);
+
+    dsd_neo_aligned_free(ptr);
+}
+
+static void
+test_aligned_free_accepts_null(void) {
+    dsd_neo_aligned_free(nullptr);
+}
+
+int
+main(void) {
+    test_aligned_malloc_rejects_zero_size();
+    test_aligned_malloc_returns_aligned_writable_memory();
+    test_aligned_free_accepts_null();
+
+    std::puts("RUNTIME_MEM: OK");
+    return 0;
+}
+
+// NOLINTEND(bugprone-implicit-widening-of-multiplication-result)

--- a/tests/runtime/test_runtime_path_policy.c
+++ b/tests/runtime/test_runtime_path_policy.c
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/platform/platform.h>
+#include <dsd-neo/runtime/path_policy.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#if DSD_PLATFORM_WIN_NATIVE
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif
+
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/platform/file_compat.h"
+#include "test_support.h"
+
+static int
+write_temp_file(char* out_path, size_t out_size) {
+    int fd = dsd_test_mkstemp(out_path, out_size, "dsdneo_path_policy");
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "dsd_test_mkstemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    static const char payload[] = "path policy\n";
+    ssize_t written = dsd_write(fd, payload, sizeof(payload) - 1U);
+    int saved_errno = errno;
+    (void)dsd_close(fd);
+    errno = saved_errno;
+    if (written < 0 || (size_t)written != sizeof(payload) - 1U) {
+        DSD_FPRINTF(stderr, "write_temp_file write failed: %s\n", strerror(errno));
+        (void)remove(out_path);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_expand_fails(const char* requested, char* out, size_t out_size, int expected_errno) {
+    errno = 0;
+    if (dsd_path_expand_user(requested, out, out_size) == 0 || errno != expected_errno) {
+        DSD_FPRINTF(stderr, "expand failure mismatch for \"%s\": errno=%d expected=%d\n",
+                    requested ? requested : "(null)", errno, expected_errno);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_expand_and_absolute_guards(void) {
+    char out[DSD_TEST_PATH_MAX];
+    int rc = 0;
+
+    rc |= expect_expand_fails(NULL, out, sizeof(out), EINVAL);
+    rc |= expect_expand_fails("", out, sizeof(out), EINVAL);
+    rc |= expect_expand_fails("abc", NULL, sizeof(out), EINVAL);
+    rc |= expect_expand_fails("abc", out, 0, EINVAL);
+    rc |= expect_expand_fails("abcdef", out, 4, ENAMETOOLONG);
+
+    if (dsd_path_expand_user("abc", out, sizeof(out)) != 0 || strcmp(out, "abc") != 0) {
+        DSD_FPRINTF(stderr, "basic expand failed: rc errno=%d out=%s\n", errno, out);
+        rc |= 1;
+    }
+
+    if (dsd_path_is_absolute(NULL) || dsd_path_is_absolute("") || dsd_path_is_absolute("relative")) {
+        DSD_FPRINTF(stderr, "absolute-path guard mismatch\n");
+        rc |= 1;
+    }
+    if (!dsd_path_is_absolute("/tmp/file") || !dsd_path_is_absolute("\\tmp\\file")) {
+        DSD_FPRINTF(stderr, "slash absolute-path detection mismatch\n");
+        rc |= 1;
+    }
+#if DSD_PLATFORM_WIN_NATIVE
+    if (!dsd_path_is_absolute("C:\\tmp\\file") || dsd_path_is_absolute("C:relative")) {
+        DSD_FPRINTF(stderr, "Windows drive absolute-path detection mismatch\n");
+        rc |= 1;
+    }
+#endif
+
+    return rc;
+}
+
+static int
+test_relative_resolution(void) {
+    char out[DSD_TEST_PATH_MAX];
+    int rc = 0;
+
+    if (dsd_path_resolve_relative_to_file(NULL, "leaf.txt", out, sizeof(out)) != 0 || strcmp(out, "leaf.txt") != 0) {
+        DSD_FPRINTF(stderr, "NULL base relative resolution mismatch: %s\n", out);
+        rc |= 1;
+    }
+    errno = 0;
+    if (dsd_path_resolve_relative_to_file(NULL, "leaf.txt", NULL, sizeof(out)) == 0 || errno != EINVAL) {
+        DSD_FPRINTF(stderr, "NULL output relative resolution guard mismatch: errno=%d\n", errno);
+        rc |= 1;
+    }
+    if (dsd_path_resolve_relative_to_file("", "leaf.txt", out, sizeof(out)) != 0 || strcmp(out, "leaf.txt") != 0) {
+        DSD_FPRINTF(stderr, "empty base relative resolution mismatch: %s\n", out);
+        rc |= 1;
+    }
+    if (dsd_path_resolve_relative_to_file("<stdin>", "leaf.txt", out, sizeof(out)) != 0
+        || strcmp(out, "leaf.txt") != 0) {
+        DSD_FPRINTF(stderr, "pseudo base relative resolution mismatch: %s\n", out);
+        rc |= 1;
+    }
+    if (dsd_path_resolve_relative_to_file("config.ini", "leaf.txt", out, sizeof(out)) != 0
+        || strcmp(out, "leaf.txt") != 0) {
+        DSD_FPRINTF(stderr, "base without separator resolution mismatch: %s\n", out);
+        rc |= 1;
+    }
+    if (dsd_path_resolve_relative_to_file("dir/config.ini", "leaf.txt", out, sizeof(out)) != 0
+        || strcmp(out, "dir/leaf.txt") != 0) {
+        DSD_FPRINTF(stderr, "slash base relative resolution mismatch: %s\n", out);
+        rc |= 1;
+    }
+    if (dsd_path_resolve_relative_to_file("dir\\config.ini", "leaf.txt", out, sizeof(out)) != 0
+        || strcmp(out, "dir\\leaf.txt") != 0) {
+        DSD_FPRINTF(stderr, "backslash base relative resolution mismatch: %s\n", out);
+        rc |= 1;
+    }
+    if (dsd_path_resolve_relative_to_file("dir/sub\\config.ini", "leaf.txt", out, sizeof(out)) != 0
+        || strcmp(out, "dir/sub\\leaf.txt") != 0) {
+        DSD_FPRINTF(stderr, "mixed-separator base relative resolution mismatch: %s\n", out);
+        rc |= 1;
+    }
+
+    errno = 0;
+    if (dsd_path_resolve_relative_to_file("dir/config.ini", "leaf.txt", out, 5) == 0 || errno != ENAMETOOLONG) {
+        DSD_FPRINTF(stderr, "short relative output buffer mismatch: errno=%d\n", errno);
+        rc |= 1;
+    }
+    errno = 0;
+    if (dsd_path_resolve_relative_to_file("dir/config.ini", "", out, sizeof(out)) == 0 || errno != EINVAL) {
+        DSD_FPRINTF(stderr, "relative empty requested guard mismatch: errno=%d\n", errno);
+        rc |= 1;
+    }
+
+    return rc;
+}
+
+static int
+test_open_regular_file_paths(void) {
+    char path[DSD_TEST_PATH_MAX];
+    if (write_temp_file(path, sizeof(path)) != 0) {
+        return 1;
+    }
+
+    int rc = 0;
+    char opened[DSD_TEST_PATH_MAX];
+    FILE* fp = dsd_path_fopen_user_read_file(path, opened, sizeof(opened));
+    if (!fp || strcmp(opened, path) != 0) {
+        DSD_FPRINTF(stderr, "fopen regular file failed: errno=%d opened=%s\n", errno, opened);
+        rc |= 1;
+    }
+    if (fp) {
+        (void)fclose(fp);
+    }
+
+    opened[0] = '\0';
+    fp = dsd_path_fopen_user_read_file(path, NULL, 0);
+    if (!fp) {
+        DSD_FPRINTF(stderr, "fopen regular file without output buffer failed: errno=%d\n", errno);
+        rc |= 1;
+    }
+    if (fp) {
+        (void)fclose(fp);
+    }
+
+    errno = 0;
+    if (dsd_path_fopen_user_read_file(path, opened, 4) != NULL || errno != ENAMETOOLONG) {
+        DSD_FPRINTF(stderr, "fopen short output buffer mismatch: errno=%d\n", errno);
+        rc |= 1;
+    }
+
+    errno = 0;
+    if (dsd_path_resolve_user_read_file(path, opened, sizeof(opened)) != 0 || strcmp(opened, path) != 0) {
+        DSD_FPRINTF(stderr, "resolve regular file failed: errno=%d opened=%s\n", errno, opened);
+        rc |= 1;
+    }
+
+    (void)remove(path);
+    return rc;
+}
+
+static int
+test_open_failure_paths(void) {
+    char missing[DSD_TEST_PATH_MAX];
+    if (dsd_test_path_join(missing, sizeof(missing), dsd_test_tmpdir(), "dsdneo_path_policy_missing_file") != 0) {
+        DSD_FPRINTF(stderr, "missing path join failed: %s\n", strerror(errno));
+        return 1;
+    }
+    (void)remove(missing);
+
+    int rc = 0;
+    char out[DSD_TEST_PATH_MAX];
+    errno = 0;
+    if (dsd_path_resolve_user_read_file(missing, out, sizeof(out)) == 0 || errno == 0) {
+        DSD_FPRINTF(stderr, "missing file resolve unexpectedly succeeded or left errno unset\n");
+        rc |= 1;
+    }
+
+    char dir[DSD_TEST_PATH_MAX];
+    if (!dsd_test_mkdtemp(dir, sizeof(dir), "dsdneo_path_policy_dir")) {
+        DSD_FPRINTF(stderr, "dsd_test_mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+    errno = 0;
+    if (dsd_path_fopen_user_read_file(dir, out, sizeof(out)) != NULL || errno != EINVAL) {
+        DSD_FPRINTF(stderr, "directory open rejection mismatch: errno=%d\n", errno);
+        rc |= 1;
+    }
+#if DSD_PLATFORM_WIN_NATIVE
+    (void)_rmdir(dir);
+#else
+    (void)rmdir(dir);
+#endif
+
+    errno = 0;
+    if (dsd_path_fopen_user_read_file("", out, sizeof(out)) != NULL || errno != EINVAL) {
+        DSD_FPRINTF(stderr, "empty fopen requested guard mismatch: errno=%d\n", errno);
+        rc |= 1;
+    }
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_expand_and_absolute_guards();
+    rc |= test_relative_resolution();
+    rc |= test_open_regular_file_paths();
+    rc |= test_open_failure_paths();
+    if (rc != 0) {
+        return 1;
+    }
+
+    DSD_FPRINTF(stderr, "runtime path policy tests OK\n");
+    return 0;
+}

--- a/tests/runtime/test_runtime_rdio_export.c
+++ b/tests/runtime/test_runtime_rdio_export.c
@@ -163,6 +163,184 @@ write_pcm16_mono_wav(const char* path, int sample_rate, int duration_s) {
 }
 
 static int
+write_pcm16_mono_wav_with_extra_chunks(const char* path, int sample_rate, int duration_s) {
+    if (!path || sample_rate <= 0 || duration_s <= 0) {
+        return 1;
+    }
+
+    FILE* fp = dsd_fopen_private(path, "wb");
+    if (!fp) {
+        DSD_FPRINTF(stderr, "fopen(%s) failed: %s\n", path, strerror(errno));
+        return 1;
+    }
+
+    uint32_t sample_count = (uint32_t)sample_rate * (uint32_t)duration_s;
+    uint32_t data_bytes = sample_count * 2U;
+    uint32_t byte_rate = (uint32_t)sample_rate * 2U;
+    uint32_t riff_size = 50U + data_bytes;
+
+    unsigned char header[12];
+    DSD_MEMCPY(header + 0, "RIFF", 4);
+    header[4] = (unsigned char)(riff_size & 0xffU);
+    header[5] = (unsigned char)((riff_size >> 8) & 0xffU);
+    header[6] = (unsigned char)((riff_size >> 16) & 0xffU);
+    header[7] = (unsigned char)((riff_size >> 24) & 0xffU);
+    DSD_MEMCPY(header + 8, "WAVE", 4);
+    if (fwrite(header, 1, sizeof(header), fp) != sizeof(header)) {
+        DSD_FPRINTF(stderr, "fwrite RIFF header failed: %s\n", strerror(errno));
+        fclose(fp);
+        return 1;
+    }
+
+    const unsigned char junk[12] = {'J', 'U', 'N', 'K', 3, 0, 0, 0, 'x', 'y', 'z', 0};
+    if (fwrite(junk, 1, sizeof(junk), fp) != sizeof(junk)) {
+        DSD_FPRINTF(stderr, "fwrite JUNK chunk failed: %s\n", strerror(errno));
+        fclose(fp);
+        return 1;
+    }
+
+    unsigned char fmt[26];
+    DSD_MEMCPY(fmt + 0, "fmt ", 4);
+    fmt[4] = 18;
+    fmt[5] = 0;
+    fmt[6] = 0;
+    fmt[7] = 0;
+    fmt[8] = 1;
+    fmt[9] = 0;
+    fmt[10] = 1;
+    fmt[11] = 0;
+    fmt[12] = (unsigned char)(sample_rate & 0xffU);
+    fmt[13] = (unsigned char)((sample_rate >> 8) & 0xffU);
+    fmt[14] = (unsigned char)((sample_rate >> 16) & 0xffU);
+    fmt[15] = (unsigned char)((sample_rate >> 24) & 0xffU);
+    fmt[16] = (unsigned char)(byte_rate & 0xffU);
+    fmt[17] = (unsigned char)((byte_rate >> 8) & 0xffU);
+    fmt[18] = (unsigned char)((byte_rate >> 16) & 0xffU);
+    fmt[19] = (unsigned char)((byte_rate >> 24) & 0xffU);
+    fmt[20] = 2;
+    fmt[21] = 0;
+    fmt[22] = 16;
+    fmt[23] = 0;
+    fmt[24] = 0;
+    fmt[25] = 0;
+    if (fwrite(fmt, 1, sizeof(fmt), fp) != sizeof(fmt)) {
+        DSD_FPRINTF(stderr, "fwrite extended fmt chunk failed: %s\n", strerror(errno));
+        fclose(fp);
+        return 1;
+    }
+
+    unsigned char data_hdr[8];
+    DSD_MEMCPY(data_hdr + 0, "data", 4);
+    data_hdr[4] = (unsigned char)(data_bytes & 0xffU);
+    data_hdr[5] = (unsigned char)((data_bytes >> 8) & 0xffU);
+    data_hdr[6] = (unsigned char)((data_bytes >> 16) & 0xffU);
+    data_hdr[7] = (unsigned char)((data_bytes >> 24) & 0xffU);
+    if (fwrite(data_hdr, 1, sizeof(data_hdr), fp) != sizeof(data_hdr)) {
+        DSD_FPRINTF(stderr, "fwrite data header failed: %s\n", strerror(errno));
+        fclose(fp);
+        return 1;
+    }
+
+    unsigned char zeros[1024] = {0};
+    uint32_t remaining = data_bytes;
+    while (remaining > 0) {
+        size_t chunk = remaining < sizeof(zeros) ? (size_t)remaining : sizeof(zeros);
+        if (fwrite(zeros, 1, chunk, fp) != chunk) {
+            DSD_FPRINTF(stderr, "fwrite data failed: %s\n", strerror(errno));
+            fclose(fp);
+            return 1;
+        }
+        remaining -= (uint32_t)chunk;
+    }
+
+    if (fclose(fp) != 0) {
+        DSD_FPRINTF(stderr, "fclose failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    return 0;
+}
+
+static int
+write_wav_with_custom_fmt(const char* path, uint32_t sample_rate, uint16_t block_align, uint32_t fmt_size) {
+    FILE* fp = dsd_fopen_private(path, "wb");
+    if (!fp) {
+        DSD_FPRINTF(stderr, "fopen(%s) failed: %s\n", path, strerror(errno));
+        return 1;
+    }
+
+    unsigned char header[12];
+    DSD_MEMCPY(header + 0, "RIFF", 4);
+    header[4] = 44;
+    header[5] = 0;
+    header[6] = 0;
+    header[7] = 0;
+    DSD_MEMCPY(header + 8, "WAVE", 4);
+    if (fwrite(header, 1, sizeof(header), fp) != sizeof(header)) {
+        DSD_FPRINTF(stderr, "fwrite RIFF header failed: %s\n", strerror(errno));
+        fclose(fp);
+        return 1;
+    }
+
+    unsigned char fmt[24];
+    DSD_MEMSET(fmt, 0, sizeof(fmt));
+    DSD_MEMCPY(fmt + 0, "fmt ", 4);
+    fmt[4] = (unsigned char)(fmt_size & 0xffU);
+    fmt[5] = (unsigned char)((fmt_size >> 8) & 0xffU);
+    fmt[6] = (unsigned char)((fmt_size >> 16) & 0xffU);
+    fmt[7] = (unsigned char)((fmt_size >> 24) & 0xffU);
+    fmt[8] = 1;
+    fmt[10] = 1;
+    fmt[12] = (unsigned char)(sample_rate & 0xffU);
+    fmt[13] = (unsigned char)((sample_rate >> 8) & 0xffU);
+    fmt[14] = (unsigned char)((sample_rate >> 16) & 0xffU);
+    fmt[15] = (unsigned char)((sample_rate >> 24) & 0xffU);
+    fmt[20] = (unsigned char)(block_align & 0xffU);
+    fmt[21] = (unsigned char)((block_align >> 8) & 0xffU);
+    fmt[22] = 16;
+    size_t fmt_payload = fmt_size < 16U ? (size_t)fmt_size : 16U;
+    if (fwrite(fmt, 1, 8U + fmt_payload, fp) != 8U + fmt_payload) {
+        DSD_FPRINTF(stderr, "fwrite custom fmt failed: %s\n", strerror(errno));
+        fclose(fp);
+        return 1;
+    }
+
+    const unsigned char data_hdr[8] = {'d', 'a', 't', 'a', 0x80, 0x3e, 0, 0};
+    if (fwrite(data_hdr, 1, sizeof(data_hdr), fp) != sizeof(data_hdr)) {
+        DSD_FPRINTF(stderr, "fwrite custom data header failed: %s\n", strerror(errno));
+        fclose(fp);
+        return 1;
+    }
+
+    if (fclose(fp) != 0) {
+        DSD_FPRINTF(stderr, "fclose failed: %s\n", strerror(errno));
+        return 1;
+    }
+    return 0;
+}
+
+static int
+write_bytes_file(const char* path, const unsigned char* data, size_t len) {
+    FILE* fp = dsd_fopen_private(path, "wb");
+    if (!fp) {
+        DSD_FPRINTF(stderr, "fopen(%s) failed: %s\n", path, strerror(errno));
+        return 1;
+    }
+
+    if (len > 0 && fwrite(data, 1, len, fp) != len) {
+        DSD_FPRINTF(stderr, "fwrite bytes failed: %s\n", strerror(errno));
+        fclose(fp);
+        return 1;
+    }
+
+    if (fclose(fp) != 0) {
+        DSD_FPRINTF(stderr, "fclose failed: %s\n", strerror(errno));
+        return 1;
+    }
+    return 0;
+}
+
+static int
 read_file(const char* path, char* out, size_t out_size) {
     if (!out || out_size == 0) {
         return 1;
@@ -375,6 +553,19 @@ rdio_test_http_server_start(rdio_test_http_server* server, char* out_api_url, si
 static int
 test_mode_parser(void) {
     int mode = -1;
+    if (dsd_rdio_mode_from_string("off", NULL) == 0) {
+        DSD_FPRINTF(stderr, "mode parser accepted null output\n");
+        return 1;
+    }
+    if (dsd_rdio_mode_from_string(NULL, &mode) != 0 || mode != DSD_RDIO_MODE_OFF) {
+        DSD_FPRINTF(stderr, "mode parser failed for null input\n");
+        return 1;
+    }
+    mode = -1;
+    if (dsd_rdio_mode_from_string("", &mode) != 0 || mode != DSD_RDIO_MODE_OFF) {
+        DSD_FPRINTF(stderr, "mode parser failed for empty input\n");
+        return 1;
+    }
     if (dsd_rdio_mode_from_string("off", &mode) != 0 || mode != DSD_RDIO_MODE_OFF) {
         DSD_FPRINTF(stderr, "mode parser failed for off\n");
         return 1;
@@ -391,8 +582,20 @@ test_mode_parser(void) {
         DSD_FPRINTF(stderr, "mode parser failed for both\n");
         return 1;
     }
+    if (dsd_rdio_mode_from_string("DiRwAtCh", &mode) != 0 || mode != DSD_RDIO_MODE_DIRWATCH) {
+        DSD_FPRINTF(stderr, "mode parser failed for mixed-case dirwatch\n");
+        return 1;
+    }
     if (dsd_rdio_mode_from_string("invalid", &mode) == 0) {
         DSD_FPRINTF(stderr, "mode parser accepted invalid value\n");
+        return 1;
+    }
+    if (strcmp(dsd_rdio_mode_to_string(DSD_RDIO_MODE_OFF), "off") != 0
+        || strcmp(dsd_rdio_mode_to_string(DSD_RDIO_MODE_DIRWATCH), "dirwatch") != 0
+        || strcmp(dsd_rdio_mode_to_string(DSD_RDIO_MODE_API), "api") != 0
+        || strcmp(dsd_rdio_mode_to_string(DSD_RDIO_MODE_BOTH), "both") != 0
+        || strcmp(dsd_rdio_mode_to_string(99), "off") != 0) {
+        DSD_FPRINTF(stderr, "mode to-string mapping failed\n");
         return 1;
     }
     return 0;
@@ -623,6 +826,476 @@ test_duration_uses_wav_samplerate(void) {
     free(hist);
     free(opts);
 
+    return rc;
+}
+
+static int
+test_duration_skips_extra_wav_chunks(void) {
+    char dir_template[DSD_TEST_PATH_MAX] = {0};
+    if (!dsd_test_mkdtemp(dir_template, sizeof(dir_template), "dsdneo_rdio_export_wav_chunks")) {
+        DSD_FPRINTF(stderr, "mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    char wav_path[DSD_TEST_PATH_MAX] = {0};
+    char json_path[DSD_TEST_PATH_MAX] = {0};
+    if (dsd_test_path_join(wav_path, sizeof(wav_path), dir_template, "chunked.wav") != 0
+        || dsd_test_path_join(json_path, sizeof(json_path), dir_template, "chunked.json") != 0) {
+        DSD_FPRINTF(stderr, "path join failed\n");
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    if (write_pcm16_mono_wav_with_extra_chunks(wav_path, 8000, 3) != 0) {
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    Event_History_I* hist = (Event_History_I*)calloc(1, sizeof(*hist));
+    if (!opts || !hist) {
+        DSD_FPRINTF(stderr, "allocation failed\n");
+        free(hist);
+        free(opts);
+        (void)remove(wav_path);
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+    opts->rdio_mode = DSD_RDIO_MODE_DIRWATCH;
+    opts->rdio_system_id = 48;
+
+    hist->Event_History_Items[0].event_time = (time_t)1700000100;
+    hist->Event_History_Items[0].target_id = 1202;
+
+    if (dsd_rdio_export_call(opts, hist, wav_path) != 0) {
+        DSD_FPRINTF(stderr, "dsd_rdio_export_call failed for chunked wav\n");
+        free(hist);
+        free(opts);
+        (void)remove(wav_path);
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    char body[4096];
+    if (read_file(json_path, body, sizeof(body)) != 0) {
+        DSD_FPRINTF(stderr, "failed reading sidecar %s\n", json_path);
+        free(hist);
+        free(opts);
+        (void)remove(wav_path);
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    int rc = 0;
+    if (!strstr(body, "\"stop_time\": 1700000103")) {
+        DSD_FPRINTF(stderr, "stop_time should skip extra WAV chunks and use 3-second duration\n%s\n", body);
+        rc = 1;
+    }
+
+    (void)remove(json_path);
+    (void)remove(wav_path);
+    remove_empty_dir(dir_template);
+    free(hist);
+    free(opts);
+    return rc;
+}
+
+static int
+test_duration_rejects_invalid_wav_format_values(void) {
+    char dir_template[DSD_TEST_PATH_MAX] = {0};
+    if (!dsd_test_mkdtemp(dir_template, sizeof(dir_template), "dsdneo_rdio_export_wav_invalid")) {
+        DSD_FPRINTF(stderr, "mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    struct {
+        const char* wav_name;
+        const char* json_name;
+        uint32_t sample_rate;
+        uint16_t block_align;
+        uint32_t fmt_size;
+    } cases[] = {
+        {"short_fmt.wav", "short_fmt.json", 8000U, 2U, 15U},
+        {"zero_rate.wav", "zero_rate.json", 0U, 2U, 16U},
+        {"zero_align.wav", "zero_align.json", 8000U, 0U, 16U},
+    };
+
+    static dsd_opts opts;
+    Event_History_I hist;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&hist, 0, sizeof(hist));
+    opts.rdio_mode = DSD_RDIO_MODE_DIRWATCH;
+    opts.rdio_system_id = 48;
+    hist.Event_History_Items[0].event_time = (time_t)1700000150;
+    hist.Event_History_Items[0].target_id = 1203;
+
+    int rc = 0;
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        char wav_path[DSD_TEST_PATH_MAX] = {0};
+        char json_path[DSD_TEST_PATH_MAX] = {0};
+        if (dsd_test_path_join(wav_path, sizeof(wav_path), dir_template, cases[i].wav_name) != 0
+            || dsd_test_path_join(json_path, sizeof(json_path), dir_template, cases[i].json_name) != 0) {
+            DSD_FPRINTF(stderr, "path join failed for invalid wav case %zu\n", i);
+            rc = 1;
+            break;
+        }
+        if (write_wav_with_custom_fmt(wav_path, cases[i].sample_rate, cases[i].block_align, cases[i].fmt_size) != 0) {
+            (void)remove(wav_path);
+            rc = 1;
+            break;
+        }
+        if (dsd_rdio_export_call(&opts, &hist, wav_path) != 0) {
+            DSD_FPRINTF(stderr, "export failed for invalid wav duration case %zu\n", i);
+            (void)remove(wav_path);
+            rc = 1;
+            break;
+        }
+
+        char body[4096];
+        if (read_file(json_path, body, sizeof(body)) != 0) {
+            DSD_FPRINTF(stderr, "failed reading invalid wav sidecar %s\n", json_path);
+            (void)remove(wav_path);
+            rc = 1;
+            break;
+        }
+        if (!strstr(body, "\"stop_time\": 1700000150")) {
+            DSD_FPRINTF(stderr, "invalid WAV format should produce zero-duration sidecar for case %zu\n%s\n", i, body);
+            rc = 1;
+        }
+        (void)remove(json_path);
+        (void)remove(wav_path);
+        if (rc != 0) {
+            break;
+        }
+    }
+
+    remove_empty_dir(dir_template);
+    return rc;
+}
+
+static int
+test_duration_uses_zero_for_missing_or_truncated_wav(void) {
+    char dir_template[DSD_TEST_PATH_MAX] = {0};
+    if (!dsd_test_mkdtemp(dir_template, sizeof(dir_template), "dsdneo_rdio_export_wav_unreadable")) {
+        DSD_FPRINTF(stderr, "mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    struct {
+        const char* wav_name;
+        const char* json_name;
+        const unsigned char* bytes;
+        size_t len;
+    } cases[] = {
+        {"missing.wav", "missing.json", NULL, 0U},
+        {"truncated.wav", "truncated.json", (const unsigned char*)"RIFF", 4U},
+    };
+
+    static dsd_opts opts;
+    Event_History_I hist;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&hist, 0, sizeof(hist));
+    opts.rdio_mode = DSD_RDIO_MODE_DIRWATCH;
+    opts.rdio_system_id = 48;
+    hist.Event_History_Items[0].event_time = (time_t)1700000160;
+    hist.Event_History_Items[0].target_id = 1204;
+
+    int rc = 0;
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        char wav_path[DSD_TEST_PATH_MAX] = {0};
+        char json_path[DSD_TEST_PATH_MAX] = {0};
+        if (dsd_test_path_join(wav_path, sizeof(wav_path), dir_template, cases[i].wav_name) != 0
+            || dsd_test_path_join(json_path, sizeof(json_path), dir_template, cases[i].json_name) != 0) {
+            DSD_FPRINTF(stderr, "path join failed for unreadable wav case %zu\n", i);
+            rc = 1;
+            break;
+        }
+
+        if (cases[i].bytes && write_bytes_file(wav_path, cases[i].bytes, cases[i].len) != 0) {
+            rc = 1;
+            break;
+        }
+        if (dsd_rdio_export_call(&opts, &hist, wav_path) != 0) {
+            DSD_FPRINTF(stderr, "export failed for unreadable wav duration case %zu\n", i);
+            (void)remove(wav_path);
+            rc = 1;
+            break;
+        }
+
+        char body[4096];
+        if (read_file(json_path, body, sizeof(body)) != 0) {
+            DSD_FPRINTF(stderr, "failed reading unreadable wav sidecar %s\n", json_path);
+            (void)remove(wav_path);
+            rc = 1;
+            break;
+        }
+        if (!strstr(body, "\"stop_time\": 1700000160")) {
+            DSD_FPRINTF(stderr, "unreadable WAV should produce zero-duration sidecar for case %zu\n%s\n", i, body);
+            rc = 1;
+        }
+        (void)remove(json_path);
+        (void)remove(wav_path);
+        if (rc != 0) {
+            break;
+        }
+    }
+
+    remove_empty_dir(dir_template);
+    return rc;
+}
+
+static int
+test_export_guards_and_invalid_mode_are_noops(void) {
+    char dir_template[DSD_TEST_PATH_MAX] = {0};
+    if (!dsd_test_mkdtemp(dir_template, sizeof(dir_template), "dsdneo_rdio_export_guards")) {
+        DSD_FPRINTF(stderr, "mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    char wav_path[DSD_TEST_PATH_MAX] = {0};
+    char json_path[DSD_TEST_PATH_MAX] = {0};
+    if (dsd_test_path_join(wav_path, sizeof(wav_path), dir_template, "call.wav") != 0
+        || dsd_test_path_join(json_path, sizeof(json_path), dir_template, "call.json") != 0) {
+        DSD_FPRINTF(stderr, "path join failed\n");
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    if (write_dummy_wav(wav_path) != 0) {
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    Event_History_I hist;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&hist, 0, sizeof(hist));
+    opts.rdio_mode = 99;
+    hist.Event_History_Items[0].event_time = (time_t)1700000200;
+    hist.Event_History_Items[0].target_id = 2;
+
+    int rc = 0;
+    if (dsd_rdio_export_call(NULL, &hist, wav_path) == 0) {
+        DSD_FPRINTF(stderr, "export accepted null opts\n");
+        rc = 1;
+    }
+    if (dsd_rdio_export_call(&opts, &hist, NULL) == 0) {
+        DSD_FPRINTF(stderr, "export accepted null wav path\n");
+        rc = 1;
+    }
+    if (dsd_rdio_export_call(&opts, &hist, "") == 0) {
+        DSD_FPRINTF(stderr, "export accepted empty wav path\n");
+        rc = 1;
+    }
+    if (dsd_rdio_export_call(&opts, &hist, wav_path) != 0) {
+        DSD_FPRINTF(stderr, "invalid rdio mode should be treated as disabled\n");
+        rc = 1;
+    }
+    if (file_exists(json_path)) {
+        DSD_FPRINTF(stderr, "invalid rdio mode should not create sidecar\n");
+        (void)remove(json_path);
+        rc = 1;
+    }
+
+    (void)remove(wav_path);
+    remove_empty_dir(dir_template);
+    return rc;
+}
+
+static int
+test_missing_talkgroup_rejects_sidecar(void) {
+    char dir_template[DSD_TEST_PATH_MAX] = {0};
+    if (!dsd_test_mkdtemp(dir_template, sizeof(dir_template), "dsdneo_rdio_export_missing_tg")) {
+        DSD_FPRINTF(stderr, "mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    char wav_path[DSD_TEST_PATH_MAX] = {0};
+    char json_path[DSD_TEST_PATH_MAX] = {0};
+    if (dsd_test_path_join(wav_path, sizeof(wav_path), dir_template, "call.wav") != 0
+        || dsd_test_path_join(json_path, sizeof(json_path), dir_template, "call.json") != 0) {
+        DSD_FPRINTF(stderr, "path join failed\n");
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    if (write_dummy_wav(wav_path) != 0) {
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    Event_History_I hist;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&hist, 0, sizeof(hist));
+    opts.rdio_mode = DSD_RDIO_MODE_DIRWATCH;
+    opts.rdio_system_id = 48;
+    hist.Event_History_Items[0].event_time = (time_t)1700000300;
+
+    int rc = 0;
+    if (dsd_rdio_export_call(&opts, &hist, wav_path) == 0) {
+        DSD_FPRINTF(stderr, "export accepted missing talkgroup\n");
+        rc = 1;
+    }
+    if (file_exists(json_path)) {
+        DSD_FPRINTF(stderr, "missing talkgroup should not create sidecar\n");
+        (void)remove(json_path);
+        rc = 1;
+    }
+
+    (void)remove(wav_path);
+    remove_empty_dir(dir_template);
+    return rc;
+}
+
+static int
+test_sidecar_escapes_strings_and_tgt_fallback(void) {
+    char dir_template[DSD_TEST_PATH_MAX] = {0};
+    if (!dsd_test_mkdtemp(dir_template, sizeof(dir_template), "dsdneo_rdio_export_escape")) {
+        DSD_FPRINTF(stderr, "mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    char wav_path[DSD_TEST_PATH_MAX] = {0};
+    char json_path[DSD_TEST_PATH_MAX] = {0};
+    if (dsd_test_path_join(wav_path, sizeof(wav_path), dir_template, "escape.wav") != 0
+        || dsd_test_path_join(json_path, sizeof(json_path), dir_template, "escape.json") != 0) {
+        DSD_FPRINTF(stderr, "path join failed\n");
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    if (write_dummy_wav(wav_path) != 0) {
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    Event_History_I hist;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&hist, 0, sizeof(hist));
+    opts.rdio_mode = DSD_RDIO_MODE_DIRWATCH;
+    opts.rdio_system_id = -1;
+    hist.Event_History_Items[0].event_time = (time_t)1700000400;
+    hist.Event_History_Items[0].target_id = 44;
+    hist.Event_History_Items[0].source_id = 0;
+    hist.Event_History_Items[0].channel = 12345;
+    DSD_SNPRINTF(hist.Event_History_Items[0].tgt_str, sizeof(hist.Event_History_Items[0].tgt_str), "TG \"A\"\\B\n\t%c",
+                 1);
+    DSD_SNPRINTF(hist.Event_History_Items[0].sysid_string, sizeof(hist.Event_History_Items[0].sysid_string),
+                 "SYS \"Q\"\\R\b\f\r");
+
+    if (dsd_rdio_export_call(&opts, &hist, wav_path) != 0) {
+        DSD_FPRINTF(stderr, "export failed for escaped string sidecar\n");
+        (void)remove(wav_path);
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    char body[4096];
+    if (read_file(json_path, body, sizeof(body)) != 0) {
+        DSD_FPRINTF(stderr, "failed reading escaped sidecar %s\n", json_path);
+        (void)remove(wav_path);
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    int rc = 0;
+    if (!strstr(body, "\"talkgroup_tag\": \"TG \\\"A\\\"\\\\B\\n\\t\\u0001\"")) {
+        DSD_FPRINTF(stderr, "sidecar did not escape fallback talkgroup tag\n%s\n", body);
+        rc = 1;
+    }
+    if (!strstr(body, "\"srcList\": []")) {
+        DSD_FPRINTF(stderr, "sidecar should omit zero source from srcList\n%s\n", body);
+        rc = 1;
+    }
+    if (!strstr(body, "\"freq\": 0")) {
+        DSD_FPRINTF(stderr, "sidecar should clamp sub-MHz frequency to zero\n%s\n", body);
+        rc = 1;
+    }
+    if (!strstr(body, "\"system\": 0")) {
+        DSD_FPRINTF(stderr, "sidecar should clamp negative system id to zero\n%s\n", body);
+        rc = 1;
+    }
+    if (!strstr(body, "\"short_name\": \"SYS \\\"Q\\\"\\\\R\\b\\f\\r\"")) {
+        DSD_FPRINTF(stderr, "sidecar did not escape short_name\n%s\n", body);
+        rc = 1;
+    }
+
+    (void)remove(json_path);
+    (void)remove(wav_path);
+    remove_empty_dir(dir_template);
+    return rc;
+}
+
+static int
+test_sidecar_private_fallback_and_malformed_wav_duration(void) {
+    char dir_template[DSD_TEST_PATH_MAX] = {0};
+    if (!dsd_test_mkdtemp(dir_template, sizeof(dir_template), "dsdneo_rdio_export_private")) {
+        DSD_FPRINTF(stderr, "mkdtemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+
+    char wav_path[DSD_TEST_PATH_MAX] = {0};
+    char json_path[DSD_TEST_PATH_MAX] = {0};
+    if (dsd_test_path_join(wav_path, sizeof(wav_path), dir_template, "private.wav") != 0
+        || dsd_test_path_join(json_path, sizeof(json_path), dir_template, "private.json") != 0) {
+        DSD_FPRINTF(stderr, "path join failed\n");
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    FILE* fp = dsd_fopen_private(wav_path, "wb");
+    if (!fp) {
+        DSD_FPRINTF(stderr, "fopen(%s) failed: %s\n", wav_path, strerror(errno));
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+    if (fwrite("RIFF\012\0\0\0WAVE", 1, 12, fp) != 12U || fclose(fp) != 0) {
+        DSD_FPRINTF(stderr, "failed writing malformed wav fixture\n");
+        (void)remove(wav_path);
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    Event_History_I hist;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&hist, 0, sizeof(hist));
+    opts.rdio_mode = DSD_RDIO_MODE_DIRWATCH;
+    opts.rdio_system_id = 7;
+    hist.Event_History_Items[0].event_time = (time_t)1700000500;
+    hist.Event_History_Items[0].target_id = 77;
+    hist.Event_History_Items[0].gi = 1;
+
+    if (dsd_rdio_export_call(&opts, &hist, wav_path) != 0) {
+        DSD_FPRINTF(stderr, "export failed for private fallback sidecar\n");
+        (void)remove(wav_path);
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    char body[4096];
+    if (read_file(json_path, body, sizeof(body)) != 0) {
+        DSD_FPRINTF(stderr, "failed reading private fallback sidecar %s\n", json_path);
+        (void)remove(wav_path);
+        remove_empty_dir(dir_template);
+        return 1;
+    }
+
+    int rc = 0;
+    if (!strstr(body, "\"talkgroup_tag\": \"PRIVATE\"")) {
+        DSD_FPRINTF(stderr, "private call fallback tag missing\n%s\n", body);
+        rc = 1;
+    }
+    if (!strstr(body, "\"stop_time\": 1700000500")) {
+        DSD_FPRINTF(stderr, "malformed wav should produce zero-duration sidecar\n%s\n", body);
+        rc = 1;
+    }
+
+    (void)remove(json_path);
+    (void)remove(wav_path);
+    remove_empty_dir(dir_template);
     return rc;
 }
 
@@ -919,6 +1592,13 @@ main(void) {
     rc |= test_dirwatch_sidecar_generation();
     rc |= test_mode_off_no_sidecar();
     rc |= test_duration_uses_wav_samplerate();
+    rc |= test_duration_skips_extra_wav_chunks();
+    rc |= test_duration_rejects_invalid_wav_format_values();
+    rc |= test_duration_uses_zero_for_missing_or_truncated_wav();
+    rc |= test_export_guards_and_invalid_mode_are_noops();
+    rc |= test_missing_talkgroup_rejects_sidecar();
+    rc |= test_sidecar_escapes_strings_and_tgt_fallback();
+    rc |= test_sidecar_private_fallback_and_malformed_wav_duration();
     rc |= test_api_shutdown_drains_queue();
     rc |= test_api_delete_after_successful_upload();
     rc |= test_api_upload_does_not_follow_redirect();

--- a/tests/runtime/test_runtime_rings.cpp
+++ b/tests/runtime/test_runtime_rings.cpp
@@ -14,10 +14,13 @@
 #include <dsd-neo/platform/threading.h>
 #include <dsd-neo/runtime/input_ring.h>
 #include <dsd-neo/runtime/ring.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/platform/platform.h"
+
+extern "C" volatile uint8_t exitflag;
 
 /* RTL-SDR stream exit shim (when USE_RTLSDR is enabled in runtime) */
 extern "C" int
@@ -206,6 +209,113 @@ test_output_ring_wrap_and_read(void) {
     return 0;
 }
 
+static int
+init_output_ring(struct output_state* o, size_t cap) {
+    DSD_MEMSET(o, 0, sizeof(*o));
+    o->buffer = (float*)calloc(cap, sizeof(float));
+    if (!o->buffer) {
+        return -1;
+    }
+    o->capacity = cap;
+    o->head.store(0);
+    o->tail.store(0);
+    o->write_timeouts.store(0);
+    o->read_timeouts.store(0);
+    dsd_cond_init(&o->ready);
+    dsd_mutex_init(&o->ready_m);
+    dsd_cond_init(&o->space);
+    return 0;
+}
+
+static void
+destroy_output_ring(struct output_state* o) {
+    dsd_cond_destroy(&o->space);
+    dsd_mutex_destroy(&o->ready_m);
+    dsd_cond_destroy(&o->ready);
+    free(o->buffer);
+    o->buffer = NULL;
+}
+
+static int
+test_output_ring_guards_and_single_reads(void) {
+    float out = 99.0f;
+    float data[4] = {10, 20, 30, 40};
+    float batch[4] = {0};
+    struct output_state o;
+    DSD_MEMSET(&o, 0, sizeof(o));
+
+    ring_write(NULL, data, 1);
+    ring_write_no_signal(NULL, data, 1);
+    if (ring_read_one(NULL, &out) != -1 || ring_read_batch(NULL, batch, 1) != -1 || ring_read_batch(&o, batch, 1) != -1
+        || ring_read_batch(&o, batch, 0) != 0) {
+        DSD_FPRINTF(stderr, "output_ring guards: NULL/no-buffer guards failed\n");
+        return 1;
+    }
+
+    if (init_output_ring(&o, 6) != 0) {
+        DSD_FPRINTF(stderr, "output_ring guards: allocation failed\n");
+        return 1;
+    }
+
+    ring_write(&o, data, 1);
+    if (ring_used(&o) != 1 || ring_read_one(&o, &out) != 0 || out != 10.0f || ring_used(&o) != 0) {
+        DSD_FPRINTF(stderr, "output_ring guards: write/read-one simple path failed\n");
+        destroy_output_ring(&o);
+        return 1;
+    }
+
+    o.head.store(5);
+    o.tail.store(3);
+    ring_write_no_signal(&o, data, 1);
+    if (o.head.load() != 0 || o.buffer[5] != 10.0f) {
+        DSD_FPRINTF(stderr, "output_ring guards: no-signal exact-end write failed\n");
+        destroy_output_ring(&o);
+        return 1;
+    }
+
+    ring_clear(&o);
+    o.head.store(4);
+    o.tail.store(2);
+    ring_write(&o, data + 1, 3);
+    if (o.head.load() != 1 || o.buffer[4] != 20.0f || o.buffer[5] != 30.0f || o.buffer[0] != 40.0f) {
+        DSD_FPRINTF(stderr, "output_ring guards: ring_write wrap split failed\n");
+        destroy_output_ring(&o);
+        return 1;
+    }
+
+    ring_clear(&o);
+    ring_write_signal_on_empty_transition(&o, data, 2);
+    if (ring_used(&o) != 2) {
+        DSD_FPRINTF(stderr, "output_ring guards: signal-on-empty write failed\n");
+        destroy_output_ring(&o);
+        return 1;
+    }
+
+    ring_clear(&o);
+    o.tail.store(5);
+    o.head.store(0);
+    o.buffer[5] = 77.0f;
+    out = 0.0f;
+    if (ring_read_one(&o, &out) != 0 || out != 77.0f || o.tail.load() != 0) {
+        DSD_FPRINTF(stderr, "output_ring guards: read-one wrap failed\n");
+        destroy_output_ring(&o);
+        return 1;
+    }
+
+    ring_clear(&o);
+    exitflag = 1;
+    if (ring_read_one(&o, &out) != -1 || ring_read_batch(&o, batch, 2) != -1) {
+        DSD_FPRINTF(stderr, "output_ring guards: empty read exit paths failed\n");
+        exitflag = 0;
+        destroy_output_ring(&o);
+        return 1;
+    }
+    exitflag = 0;
+
+    destroy_output_ring(&o);
+    return 0;
+}
+
 struct OutputWriterArgs { // NOLINT(misc-use-internal-linkage)
     struct output_state* ring;
     const float* data;
@@ -388,6 +498,7 @@ main(void) {
     rc |= test_input_ring_wrap_and_read();
     rc |= test_output_ring_wrap_and_read();
     rc |= test_input_ring_drop_on_full();
+    rc |= test_output_ring_guards_and_single_reads();
     rc |= test_output_ring_blocking_producer_consumer();
     if (rc == 0) {
         DSD_FPRINTF(stderr, "runtime ring tests: OK\n");

--- a/tests/runtime/test_runtime_rt_sched.cpp
+++ b/tests/runtime/test_runtime_rt_sched.cpp
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#define DSD_NEO_TEST_HOOKS 1
+
+#include <cassert>
+#include <cstdarg>
+#include <cstring>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/log.h>
+#include <dsd-neo/runtime/rt_sched.h>
+#include <errno.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+
+static dsdneoRuntimeConfig g_config;
+static const dsdneoRuntimeConfig* g_config_ptr = &g_config;
+static int g_config_init_calls = 0;
+static int g_rt_calls = 0;
+static int g_affinity_calls = 0;
+static int g_last_priority = -1;
+static int g_last_cpu = -1;
+static int g_rt_rc = 0;
+static int g_affinity_rc = 0;
+static int g_rt_errno = EPERM;
+static int g_affinity_errno = EINVAL;
+static int g_log_counts[4];
+
+extern "C" const dsdneoRuntimeConfig*
+dsd_neo_get_config(void) {
+    return g_config_ptr;
+}
+
+extern "C" void
+dsd_neo_config_init(const dsd_opts* opts) {
+    (void)opts;
+    ++g_config_init_calls;
+}
+
+extern "C" int
+dsd_thread_set_realtime_priority(int priority) {
+    ++g_rt_calls;
+    g_last_priority = priority;
+    errno = g_rt_errno;
+    return g_rt_rc;
+}
+
+extern "C" int
+dsd_thread_set_affinity(int cpu_index) {
+    ++g_affinity_calls;
+    g_last_cpu = cpu_index;
+    errno = g_affinity_errno;
+    return g_affinity_rc;
+}
+
+extern "C" void
+dsd_neo_log_write(dsd_neo_log_level_t level, const char* format, ...) {
+    assert(format != nullptr);
+    if (level >= LOG_LEVEL_ERROR && level <= LOG_LEVEL_DEBUG) {
+        ++g_log_counts[level];
+    }
+    va_list ap;
+    va_start(ap, format);
+    va_end(ap);
+}
+
+static void
+reset_state(void) {
+    DSD_MEMSET(&g_config, 0, sizeof(g_config));
+    g_config_ptr = &g_config;
+    g_config_init_calls = 0;
+    g_rt_calls = 0;
+    g_affinity_calls = 0;
+    g_last_priority = -1;
+    g_last_cpu = -1;
+    g_rt_rc = 0;
+    g_affinity_rc = 0;
+    g_rt_errno = EPERM;
+    g_affinity_errno = EINVAL;
+    DSD_MEMSET(g_log_counts, 0, sizeof(g_log_counts));
+}
+
+static void
+enable_config(void) {
+    g_config.rt_sched_enable = 1;
+    g_config.rt_prio_usb_is_set = 1;
+    g_config.rt_prio_usb = 80;
+    g_config.rt_prio_dongle_is_set = 1;
+    g_config.rt_prio_dongle = 81;
+    g_config.rt_prio_demod_is_set = 1;
+    g_config.rt_prio_demod = 82;
+    g_config.cpu_usb_is_set = 1;
+    g_config.cpu_usb = 1;
+    g_config.cpu_dongle_is_set = 1;
+    g_config.cpu_dongle = 2;
+    g_config.cpu_demod_is_set = 1;
+    g_config.cpu_demod = 3;
+}
+
+static void
+test_role_resolvers(void) {
+    reset_state();
+    enable_config();
+
+    assert(strcmp(dsd_neo_rt_sched_test_role_or_default("USB"), "USB") == 0);
+    assert(strcmp(dsd_neo_rt_sched_test_role_or_default(nullptr), "RT") == 0);
+    assert(dsd_neo_rt_sched_test_resolve_role_rt_priority(nullptr, "USB") == 0);
+    assert(dsd_neo_rt_sched_test_resolve_role_rt_priority(&g_config, nullptr) == 0);
+    assert(dsd_neo_rt_sched_test_resolve_role_rt_priority(&g_config, "USB") == 80);
+    assert(dsd_neo_rt_sched_test_resolve_role_rt_priority(&g_config, "DONGLE") == 81);
+    assert(dsd_neo_rt_sched_test_resolve_role_rt_priority(&g_config, "DEMOD") == 82);
+    assert(dsd_neo_rt_sched_test_resolve_role_rt_priority(&g_config, "OTHER") == 0);
+
+    assert(dsd_neo_rt_sched_test_resolve_role_cpu_affinity(nullptr, "USB") == -1);
+    assert(dsd_neo_rt_sched_test_resolve_role_cpu_affinity(&g_config, nullptr) == -1);
+    assert(dsd_neo_rt_sched_test_resolve_role_cpu_affinity(&g_config, "USB") == 1);
+    assert(dsd_neo_rt_sched_test_resolve_role_cpu_affinity(&g_config, "DONGLE") == 2);
+    assert(dsd_neo_rt_sched_test_resolve_role_cpu_affinity(&g_config, "DEMOD") == 3);
+    assert(dsd_neo_rt_sched_test_resolve_role_cpu_affinity(&g_config, "OTHER") == -1);
+}
+
+static void
+test_disabled_and_missing_config_paths(void) {
+    reset_state();
+    g_config_ptr = nullptr;
+    maybe_set_thread_realtime_and_affinity("USB");
+    assert(g_config_init_calls == 1);
+    assert(g_rt_calls == 0);
+    assert(g_affinity_calls == 0);
+
+    reset_state();
+    maybe_set_thread_realtime_and_affinity("USB");
+    assert(g_config_init_calls == 0);
+    assert(g_rt_calls == 0);
+    assert(g_affinity_calls == 0);
+}
+
+static void
+test_public_call_success_and_failure_paths(void) {
+    reset_state();
+    enable_config();
+    maybe_set_thread_realtime_and_affinity("USB");
+    assert(g_rt_calls == 1);
+    assert(g_last_priority == 80);
+    assert(g_affinity_calls == 1);
+    assert(g_last_cpu == 1);
+    assert(g_log_counts[LOG_LEVEL_INFO] == 2);
+
+    reset_state();
+    enable_config();
+    g_rt_rc = EINVAL;
+    g_affinity_rc = EPERM;
+    maybe_set_thread_realtime_and_affinity("DONGLE");
+    assert(g_rt_calls == 1);
+    assert(g_last_priority == 81);
+    assert(g_affinity_calls == 1);
+    assert(g_last_cpu == 2);
+    assert(g_log_counts[LOG_LEVEL_WARN] == 2);
+
+    reset_state();
+    enable_config();
+    g_config.cpu_demod_is_set = 0;
+    maybe_set_thread_realtime_and_affinity("DEMOD");
+    assert(g_rt_calls == 1);
+    assert(g_last_priority == 82);
+    assert(g_affinity_calls == 0);
+
+    reset_state();
+    enable_config();
+    maybe_set_thread_realtime_and_affinity(nullptr);
+    assert(g_rt_calls == 1);
+    assert(g_last_priority == 0);
+    assert(g_affinity_calls == 0);
+}
+
+int
+main(void) {
+    test_role_resolvers();
+    test_disabled_and_missing_config_paths();
+    test_public_call_success_and_failure_paths();
+    return 0;
+}

--- a/tests/runtime/test_runtime_trunk_cc_candidates.c
+++ b/tests/runtime/test_runtime_trunk_cc_candidates.c
@@ -12,6 +12,29 @@
 #include "dsd-neo/core/state_fwd.h"
 
 static void
+test_public_guards(void) {
+    dsd_state* st = calloc(1, sizeof(*st));
+    assert(st != NULL);
+    long out = 1234;
+
+    assert(dsd_trunk_cc_candidates_get(NULL) == NULL);
+    assert(dsd_trunk_cc_candidates_peek(NULL) == NULL);
+    assert(dsd_trunk_cc_candidates_add(NULL, 100, 1) == 0);
+    assert(dsd_trunk_cc_candidates_add(st, 0, 1) == 0);
+    assert(dsd_trunk_cc_candidates_next(NULL, 0.0, &out) == 0);
+    assert(out == 1234);
+    assert(dsd_trunk_cc_candidates_next(st, 0.0, NULL) == 0);
+    assert(dsd_trunk_cc_candidates_next(st, 0.0, &out) == 0);
+    assert(out == 1234);
+
+    dsd_trunk_cc_candidates_set_cooldown(NULL, 100, 1.0);
+    dsd_trunk_cc_candidates_set_cooldown(st, 100, 1.0);
+
+    dsd_state_ext_free_all(st);
+    free(st);
+}
+
+static void
 test_add_dedup_rollover(void) {
     dsd_state* st = calloc(1, sizeof(*st));
     assert(st != NULL);
@@ -57,6 +80,42 @@ test_add_dedup_rollover(void) {
 
     dsd_state_ext_free_all(st2);
     free(st2);
+    dsd_state_ext_free_all(st);
+    free(st);
+}
+
+static void
+test_invalid_count_is_cleared_before_failure(void) {
+    dsd_state* st = calloc(1, sizeof(*st));
+    assert(st != NULL);
+
+    assert(dsd_trunk_cc_candidates_add(st, 100, 0) == 1);
+    dsd_trunk_cc_candidates* cc = dsd_trunk_cc_candidates_get(st);
+    assert(cc != NULL);
+
+    cc->count = DSD_TRUNK_CC_CANDIDATES_MAX + 1;
+    cc->idx = 9;
+    cc->candidates[0] = 100;
+    cc->flags[0] = DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE;
+    cc->cool_until[0] = 20.0;
+    assert(dsd_trunk_cc_candidates_add(st, 200, 1) == 0);
+    assert(cc->count == 0);
+    assert(cc->idx == 0);
+    assert(cc->candidates[0] == 0);
+    assert(cc->flags[0] == 0);
+    assert(cc->cool_until[0] == 0.0);
+
+    assert(dsd_trunk_cc_candidates_add(st, 300, 0) == 1);
+    cc->count = -1;
+    cc->idx = 3;
+    cc->candidates[0] = 300;
+    long out = 0;
+    assert(dsd_trunk_cc_candidates_next(st, 0.0, &out) == 0);
+    assert(out == 0);
+    assert(cc->count == 0);
+    assert(cc->idx == 0);
+    assert(cc->candidates[0] == 0);
+
     dsd_state_ext_free_all(st);
     free(st);
 }
@@ -128,10 +187,32 @@ test_next_and_cooldown(void) {
     free(st);
 }
 
+static void
+test_cooldown_ignores_zero_and_missing_frequencies(void) {
+    dsd_state* st = calloc(1, sizeof(*st));
+    assert(st != NULL);
+    assert(dsd_trunk_cc_candidates_add(st, 100, 0) == 1);
+
+    dsd_trunk_cc_candidates* cc = dsd_trunk_cc_candidates_get(st);
+    assert(cc != NULL);
+    assert(cc->cool_until[0] == 0.0);
+
+    dsd_trunk_cc_candidates_set_cooldown(st, 0, 5.0);
+    assert(cc->cool_until[0] == 0.0);
+    dsd_trunk_cc_candidates_set_cooldown(st, 200, 5.0);
+    assert(cc->cool_until[0] == 0.0);
+
+    dsd_state_ext_free_all(st);
+    free(st);
+}
+
 int
 main(void) {
+    test_public_guards();
     test_add_dedup_rollover();
+    test_invalid_count_is_cleared_before_failure();
     test_filtered_iteration();
     test_next_and_cooldown();
+    test_cooldown_ignores_zero_and_missing_frequencies();
     return 0;
 }

--- a/tests/runtime/test_runtime_unicode_block_glyphs.c
+++ b/tests/runtime/test_runtime_unicode_block_glyphs.c
@@ -4,14 +4,107 @@
  */
 
 #include <assert.h>
+#include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/runtime/unicode.h>
+#include <locale.h>
 #include <stdio.h>
+#include <string.h>
 
 static void
 set_env_flag(const char* name, const char* value) {
     int rc = value ? dsd_setenv(name, value, 1) : dsd_unsetenv(name);
     assert(rc == 0);
+}
+
+static void
+test_locale_init_force_ascii_and_c_locale_detection(void) {
+    char out[64];
+    char saved_locale[128] = {0};
+    const char* current_locale = setlocale(LC_CTYPE, NULL);
+    if (current_locale) {
+        DSD_SNPRINTF(saved_locale, sizeof(saved_locale), "%s", current_locale);
+    }
+
+    set_env_flag("DSD_FORCE_ASCII", "1");
+    set_env_flag("DSD_FORCE_UTF8", NULL);
+    dsd_unicode_init_locale();
+    assert(dsd_unicode_supported() == 0);
+    dsd_unicode_init_locale();
+    assert(strcmp(dsd_unicode_or_ascii("unicode", "ascii"), "ascii") == 0);
+
+    set_env_flag("DSD_FORCE_ASCII", NULL);
+    set_env_flag("DSD_FORCE_UTF8", NULL);
+    if (setlocale(LC_CTYPE, "C") != NULL) {
+        assert(dsd_unicode_supported() == 0);
+        assert(dsd_unicode_block_glyphs_supported() == 0);
+
+        assert(dsd_ascii_fallback("bad "
+                                  "\xC2"
+                                  "\xA9"
+                                  " "
+                                  "\x80"
+                                  " end",
+                                  out, sizeof(out))
+               == out);
+        assert(strcmp(out, "bad ? ? end") == 0);
+    }
+
+    if (saved_locale[0] != '\0') {
+        assert(setlocale(LC_CTYPE, saved_locale) != NULL);
+    }
+}
+
+static void
+test_force_flags_and_selector_helpers(void) {
+    char out[64];
+
+    set_env_flag("DSD_FORCE_ASCII", "1");
+    set_env_flag("DSD_FORCE_UTF8", "1");
+    assert(dsd_unicode_supported() == 0);
+    assert(dsd_unicode_block_glyphs_supported() == 0);
+    assert(strcmp(dsd_unicode_or_ascii("unicode", "ascii"), "ascii") == 0);
+    assert(strcmp(dsd_degrees_glyph(), " deg") == 0);
+
+    assert(dsd_ascii_fallback("Temp \xC2\xB0 \xC2\xB5 \xC3\x97 \xE2\x89\x88", out, sizeof(out)) == out);
+    assert(strcmp(out, "Temp  deg u x ~") == 0);
+
+    set_env_flag("DSD_FORCE_ASCII", NULL);
+    set_env_flag("DSD_FORCE_UTF8", "1");
+    assert(dsd_unicode_supported() == 1);
+    assert(dsd_unicode_block_glyphs_supported() == 1);
+    assert(strcmp(dsd_unicode_or_ascii("unicode", "ascii"), "unicode") == 0);
+    assert(strcmp(dsd_degrees_glyph(), "\xC2\xB0") == 0);
+
+    assert(dsd_ascii_fallback("abcdef", out, 4) == out);
+    assert(strcmp(out, "abc") == 0);
+}
+
+static void
+test_ascii_fallback_replacements_and_bounds(void) {
+    char out[64];
+
+    set_env_flag("DSD_FORCE_ASCII", "1");
+    set_env_flag("DSD_FORCE_UTF8", NULL);
+
+    assert(dsd_ascii_fallback(NULL, out, sizeof(out)) == out);
+    out[0] = 'x';
+    assert(dsd_ascii_fallback("ignored", out, 0) == out);
+    assert(out[0] == 'x');
+
+    assert(dsd_ascii_fallback("A\xE2\x80\x93"
+                              "B\xE2\x80\x94"
+                              "C\xE2\x80\xA6"
+                              "D",
+                              out, sizeof(out))
+           == out);
+    assert(strcmp(out, "A-B-C...D") == 0);
+
+    assert(dsd_ascii_fallback("bad \xE2\x98\x83 \xF0\x9F\x98\x80 end", out, sizeof(out)) == out);
+    assert(strcmp(out, "bad ? ? end") == 0);
+
+    assert(dsd_ascii_fallback("123456", out, 5) == out);
+    assert(strcmp(out, "1234") == 0);
 }
 
 int
@@ -26,6 +119,13 @@ main(void) {
     set_env_flag("DSD_FORCE_ASCII", NULL);
     set_env_flag("DSD_FORCE_UTF8", "1");
     assert(dsd_unicode_block_glyphs_supported() == 1);
+
+    set_env_flag("DSD_FORCE_ASCII", NULL);
+    set_env_flag("DSD_FORCE_UTF8", NULL);
+
+    test_locale_init_force_ascii_and_c_locale_detection();
+    test_force_flags_and_selector_helpers();
+    test_ascii_fallback_replacements_and_bounds();
 
     set_env_flag("DSD_FORCE_ASCII", NULL);
     set_env_flag("DSD_FORCE_UTF8", NULL);

--- a/tests/runtime/test_runtime_worker_pool.cpp
+++ b/tests/runtime/test_runtime_worker_pool.cpp
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(misc-use-internal-linkage)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <atomic>
+#include <cassert>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/worker_pool.h>
+#include <pthread.h>
+#include <stdlib.h>
+
+struct demod_state;
+
+struct CounterArg {
+    std::atomic<int>* counter;
+    pthread_t* thread_seen;
+};
+
+static void
+increment_counter(void* arg) {
+    CounterArg* counter_arg = static_cast<CounterArg*>(arg);
+    counter_arg->counter->fetch_add(1, std::memory_order_relaxed);
+    if (counter_arg->thread_seen != nullptr) {
+        *counter_arg->thread_seen = pthread_self();
+    }
+}
+
+static demod_state*
+state_key(void* storage) {
+    return static_cast<demod_state*>(storage);
+}
+
+static void
+set_mt_config(const char* value) {
+    if (value != nullptr) {
+        setenv("DSD_NEO_MT", value, 1);
+    } else {
+        unsetenv("DSD_NEO_MT");
+    }
+    dsd_neo_config_init(nullptr);
+}
+
+static void
+test_disabled_mode_runs_synchronously(void) {
+    int key_storage = 0;
+    std::atomic<int> counter{0};
+    pthread_t task0_thread = {};
+    pthread_t task1_thread = {};
+    CounterArg arg0{&counter, &task0_thread};
+    CounterArg arg1{&counter, &task1_thread};
+    pthread_t caller = pthread_self();
+
+    set_mt_config(nullptr);
+    demod_mt_destroy(state_key(&key_storage));
+    demod_mt_init(state_key(&key_storage));
+    demod_mt_run_two(state_key(&key_storage), increment_counter, &arg0, increment_counter, &arg1);
+
+    assert(counter.load(std::memory_order_relaxed) == 2);
+    assert(pthread_equal(task0_thread, caller) != 0);
+    assert(pthread_equal(task1_thread, caller) != 0);
+    demod_mt_destroy(state_key(&key_storage));
+}
+
+static void
+test_enabled_mode_runs_and_tears_down(void) {
+    int key_storage = 0;
+    std::atomic<int> counter{0};
+    pthread_t task0_thread = {};
+    pthread_t task1_thread = {};
+    CounterArg arg0{&counter, &task0_thread};
+    CounterArg arg1{&counter, &task1_thread};
+    pthread_t caller = pthread_self();
+
+    set_mt_config("1");
+    demod_mt_destroy(state_key(&key_storage));
+    demod_mt_init(state_key(&key_storage));
+    demod_mt_init(state_key(&key_storage));
+
+    demod_mt_run_two(state_key(&key_storage), increment_counter, &arg0, nullptr, nullptr);
+    assert(counter.load(std::memory_order_relaxed) == 1);
+    assert(!pthread_equal(task0_thread, caller));
+
+    demod_mt_run_two(state_key(&key_storage), increment_counter, &arg0, increment_counter, &arg1);
+    assert(counter.load(std::memory_order_relaxed) == 3);
+    assert(!pthread_equal(task0_thread, caller));
+    assert(!pthread_equal(task1_thread, caller));
+
+    demod_mt_destroy(state_key(&key_storage));
+    demod_mt_destroy(state_key(&key_storage));
+
+    task0_thread = {};
+    task1_thread = {};
+    demod_mt_run_two(state_key(&key_storage), increment_counter, &arg0, increment_counter, &arg1);
+    assert(counter.load(std::memory_order_relaxed) == 5);
+    assert(pthread_equal(task0_thread, caller) != 0);
+    assert(pthread_equal(task1_thread, caller) != 0);
+}
+
+int
+main(void) {
+    test_disabled_mode_runs_synchronously();
+    test_enabled_mode_runs_and_tears_down();
+    unsetenv("DSD_NEO_MT");
+    dsd_neo_config_init(nullptr);
+    return 0;
+}
+
+// NOLINTEND(misc-use-internal-linkage)

--- a/tests/ui/curses.h
+++ b/tests/ui/curses.h
@@ -7,11 +7,35 @@
 #define DSD_NEO_TESTS_UI_CURSES_H
 
 typedef struct WINDOW WINDOW;
+typedef int chtype;
 
-#define ERR       (-1)
-#define KEY_ENTER 343
+#define ERR           (-1)
+#define TRUE          1
+#define KEY_ENTER     343
+
+#define COLOR_BLACK   0
+#define COLOR_RED     1
+#define COLOR_GREEN   2
+#define COLOR_YELLOW  3
+#define COLOR_BLUE    4
+#define COLOR_MAGENTA 5
+#define COLOR_CYAN    6
+#define COLOR_WHITE   7
 
 extern WINDOW* stdscr;
+WINDOW* initscr(void);
+int curs_set(int visibility);
+void timeout(int delay);
+int start_color(void);
+int keypad(WINDOW* win, int bf);
+int has_colors(void);
+int use_default_colors(void);
+int assume_default_colors(int fg, int bg);
+int init_pair(short pair, short fg, short bg);
+int noecho(void);
+int cbreak(void);
+int endwin(void);
+int set_escdelay(int size);
 int wgetch(WINDOW* win);
 
 #define getch() wgetch(stdscr)

--- a/tests/ui/test_ui_async_lifecycle.c
+++ b/tests/ui/test_ui_async_lifecycle.c
@@ -1,0 +1,433 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Lifecycle contracts for the async UI wrapper without starting a real curses thread.
+ */
+
+#include <curses.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/platform/threading.h>
+#include <dsd-neo/platform/timing.h>
+#include <dsd-neo/runtime/control_pump.h>
+#include <dsd-neo/ui/menu_core.h>
+#include <dsd-neo/ui/ncurses.h>
+#include <dsd-neo/ui/ui_async.h>
+#include <dsd-neo/ui/ui_history.h>
+#include <dsd-neo/ui/ui_opts_snapshot.h>
+#include <dsd-neo/ui/ui_prims.h>
+#include <dsd-neo/ui/ui_snapshot.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "telemetry_hooks_impl.h"
+
+WINDOW* stdscr;
+
+static int g_create_calls;
+static int g_join_calls;
+static int g_history_mode = -1;
+static int g_fail_create;
+static dsd_control_pump_fn g_control_pump;
+static const dsd_opts* g_latest_opts;
+static const dsd_state* g_latest_state;
+static int g_menu_open;
+static int g_menu_handle_calls;
+static int g_menu_tick_calls;
+static int g_commit_calls;
+static int g_getch_calls;
+static int g_getch_value = ERR;
+static int g_keypad_calls;
+static int g_timeout_calls;
+static int g_escdelay_calls;
+static int g_clearok_calls;
+static int g_ncurses_input_calls;
+static int g_last_menu_key = ERR;
+static int g_last_ncurses_key = ERR;
+static int g_printer_calls;
+static const dsd_opts* g_printer_opts;
+static const dsd_state* g_printer_state;
+static uint64_t g_time_ns;
+
+int
+dsd_thread_create_impl(dsd_thread_t* thread, void* arg, dsd_thread_fn func) {
+    (void)arg;
+    g_create_calls++;
+    if (g_fail_create) {
+        return EAGAIN;
+    }
+    if (!thread || !func) {
+        return EINVAL;
+    }
+    *thread = (dsd_thread_t)0x1234U;
+    return 0;
+}
+
+int
+dsd_thread_join(dsd_thread_t thread) {
+    (void)thread;
+    g_join_calls++;
+    return 0;
+}
+
+void
+dsd_runtime_set_control_pump(dsd_control_pump_fn fn) {
+    g_control_pump = fn;
+}
+
+void
+ui_history_set_mode(int mode) {
+    g_history_mode = mode;
+}
+
+int
+ui_drain_cmds(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    return 7;
+}
+
+void
+ui_terminal_install_telemetry_hooks(void) {}
+
+int
+ui_menu_is_open(void) {
+    return g_menu_open;
+}
+
+int
+ui_menu_handle_key(int ch, dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_menu_handle_calls++;
+    g_last_menu_key = ch;
+    return 0;
+}
+
+void
+ui_menu_tick(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_menu_tick_calls++;
+}
+
+void
+ui_commit_frame(void) {
+    g_commit_calls++;
+}
+
+const dsd_opts*
+ui_get_latest_opts_snapshot(void) {
+    return g_latest_opts;
+}
+
+const dsd_state*
+ui_get_latest_snapshot(void) {
+    return g_latest_state;
+}
+
+void
+ncursesOpen(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+ncursesClose(void) {}
+
+void
+ncursesPrinter(dsd_opts* opts, dsd_state* state) {
+    g_printer_calls++;
+    g_printer_opts = opts;
+    g_printer_state = state;
+}
+
+uint8_t
+ncurses_input_handler(dsd_opts* opts, dsd_state* state, int c) {
+    (void)opts;
+    (void)state;
+    g_ncurses_input_calls++;
+    g_last_ncurses_key = c;
+    return 0U;
+}
+
+uint64_t
+dsd_time_monotonic_ns(void) {
+    return g_time_ns;
+}
+
+void
+dsd_sleep_ms(unsigned int ms) {
+    (void)ms;
+}
+
+int
+set_escdelay(int delay) {
+    (void)delay;
+    g_escdelay_calls++;
+    return 0;
+}
+
+int
+keypad(WINDOW* win, bool bf) {
+    (void)win;
+    (void)bf;
+    g_keypad_calls++;
+    return 0;
+}
+
+void
+wtimeout(WINDOW* win, int delay) {
+    (void)win;
+    (void)delay;
+    g_timeout_calls++;
+}
+
+int
+wgetch(WINDOW* win) {
+    (void)win;
+    g_getch_calls++;
+    return g_getch_value;
+}
+
+int
+clearok(WINDOW* win, bool bf) {
+    (void)win;
+    (void)bf;
+    g_clearok_calls++;
+    return 0;
+}
+
+int
+resize_term(int lines, int columns) {
+    (void)lines;
+    (void)columns;
+    return 0;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_ptr(const char* tag, const void* got, const void* want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %p want %p\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_pump_set(const char* tag, dsd_control_pump_fn fn) {
+    if (!fn) {
+        DSD_FPRINTF(stderr, "%s: expected non-NULL pointer\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_pump_null(const char* tag, dsd_control_pump_fn fn) {
+    if (fn) {
+        DSD_FPRINTF(stderr, "%s: expected NULL pointer\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_ui_start_failure_resets_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.ncurses_history = 2;
+
+    g_create_calls = 0;
+    g_join_calls = 0;
+    g_history_mode = -1;
+    g_control_pump = NULL;
+    g_fail_create = 1;
+
+    int rc = expect_int("start-failure-return", ui_start(&opts, &state), -1);
+    rc |= expect_int("start-failure-create-count", g_create_calls, 1);
+    rc |= expect_int("start-failure-history-mode", g_history_mode, 2);
+    rc |= expect_pump_null("start-failure-control-pump", g_control_pump);
+    rc |= expect_int("start-failure-thread-context", ui_is_thread_context(), 0);
+
+    ui_stop();
+    rc |= expect_int("start-failure-no-join", g_join_calls, 0);
+    return rc;
+}
+
+static int
+test_ui_start_stop_idempotency_and_control_pump(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.ncurses_history = 1;
+
+    g_create_calls = 0;
+    g_join_calls = 0;
+    g_history_mode = -1;
+    g_control_pump = NULL;
+    g_fail_create = 0;
+
+    int rc = expect_int("start-success-return", ui_start(&opts, &state), 0);
+    rc |= expect_int("start-success-create-count", g_create_calls, 1);
+    rc |= expect_int("start-success-history-mode", g_history_mode, 1);
+    rc |= expect_pump_set("start-success-control-pump", g_control_pump);
+
+    rc |= expect_int("duplicate-start-return", ui_start(&opts, &state), 0);
+    rc |= expect_int("duplicate-start-no-create", g_create_calls, 1);
+
+    g_control_pump(&opts, &state);
+
+    ui_terminal_telemetry_request_redraw();
+    ui_stop();
+    rc |= expect_int("stop-join-count", g_join_calls, 1);
+    rc |= expect_pump_null("stop-control-pump", g_control_pump);
+
+    ui_stop();
+    rc |= expect_int("second-stop-no-join", g_join_calls, 1);
+    return rc;
+}
+
+static void
+reset_frame_counters(void) {
+    g_menu_open = 0;
+    g_menu_handle_calls = 0;
+    g_menu_tick_calls = 0;
+    g_commit_calls = 0;
+    g_getch_calls = 0;
+    g_getch_value = ERR;
+    g_keypad_calls = 0;
+    g_timeout_calls = 0;
+    g_escdelay_calls = 0;
+    g_clearok_calls = 0;
+    g_ncurses_input_calls = 0;
+    g_last_menu_key = ERR;
+    g_last_ncurses_key = ERR;
+    g_printer_calls = 0;
+    g_printer_opts = NULL;
+    g_printer_state = NULL;
+    g_latest_opts = NULL;
+    g_latest_state = NULL;
+    g_time_ns = 0U;
+}
+
+static int
+test_ui_single_frame_snapshot_input_and_draw_helpers(void) {
+    static dsd_opts opts;
+    static dsd_opts latest_opts;
+    static dsd_state state;
+    static dsd_state latest_state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&latest_opts, 0, sizeof(latest_opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&latest_state, 0, sizeof(latest_state));
+    opts.use_ncurses_terminal = 1;
+    latest_opts.use_ncurses_terminal = 1;
+
+    reset_frame_counters();
+    dsd_neo_ui_async_test_set_context(&opts, &state);
+    stdscr = NULL;
+
+    int rc = 0;
+    rc |= expect_ptr("opts snapshot fallback", dsd_neo_ui_async_test_opts_snapshot_or_default(), &opts);
+    g_latest_opts = &latest_opts;
+    rc |= expect_ptr("opts snapshot preferred", dsd_neo_ui_async_test_opts_snapshot_or_default(), &latest_opts);
+    rc |= expect_int("curses inactive without stdscr", dsd_neo_ui_async_test_curses_is_active(&opts), 0);
+    stdscr = (WINDOW*)0x1;
+    rc |= expect_int("curses active with stdscr", dsd_neo_ui_async_test_curses_is_active(&opts), 1);
+    latest_opts.use_ncurses_terminal = 0;
+    rc |= expect_int("curses inactive when disabled", dsd_neo_ui_async_test_curses_is_active(&latest_opts), 0);
+
+    opts.audio_in_type = AUDIO_IN_STDIN;
+    g_getch_value = 'x';
+    rc |= expect_int("stdin input suppresses getch", dsd_neo_ui_async_test_read_key_nonblocking(&opts), ERR);
+    rc |= expect_int("stdin input getch count", g_getch_calls, 0);
+
+    opts.audio_in_type = 0;
+    g_getch_value = 'n';
+    rc |= expect_int("non-stdin input reads getch", dsd_neo_ui_async_test_read_key_nonblocking(&opts), 'n');
+    rc |= expect_int("non-stdin getch count", g_getch_calls, 1);
+
+    reset_frame_counters();
+    dsd_neo_ui_async_test_set_context(&opts, &state);
+    stdscr = (WINDOW*)0x1;
+    g_getch_value = 'a';
+    dsd_neo_ui_async_test_process_input_frame(&opts);
+    rc |= expect_int("configure escdelay once", g_escdelay_calls, 1);
+    rc |= expect_int("configure keypad once", g_keypad_calls, 1);
+    rc |= expect_int("configure timeout once", g_timeout_calls, 1);
+    rc |= expect_int("normal input delivered", g_ncurses_input_calls, 1);
+    rc |= expect_int("normal input key", g_last_ncurses_key, 'a');
+
+    g_getch_value = KEY_RESIZE;
+    dsd_neo_ui_async_test_process_input_frame(&opts);
+    rc |= expect_int("configure not repeated", g_escdelay_calls, 1);
+    rc |= expect_int("resize clearok", g_clearok_calls, 1);
+
+    uint64_t last_draw_ns = 100U;
+    g_time_ns = 100U;
+    dsd_neo_ui_async_test_draw_if_needed(&opts, &last_draw_ns, 1000U);
+    rc |= expect_int("resize dirty draws", g_printer_calls, 1);
+    rc |= expect_ptr("draw fallback state", g_printer_state, &state);
+    rc |= expect_int("draw context restored", ui_is_thread_context(), 0);
+
+    reset_frame_counters();
+    dsd_neo_ui_async_test_set_context(&opts, &state);
+    stdscr = (WINDOW*)0x1;
+    g_menu_open = 1;
+    g_getch_value = 'm';
+    dsd_neo_ui_async_test_process_input_frame(&opts);
+    rc |= expect_int("menu key handled", g_menu_handle_calls, 1);
+    rc |= expect_int("menu key value", g_last_menu_key, 'm');
+    rc |= expect_int("menu tick", g_menu_tick_calls, 1);
+    rc |= expect_int("menu commit", g_commit_calls, 1);
+
+    reset_frame_counters();
+    dsd_neo_ui_async_test_set_context(&opts, &state);
+    g_latest_state = &latest_state;
+    g_time_ns = 500U;
+    last_draw_ns = 500U;
+    dsd_neo_ui_async_test_draw_if_needed(&opts, &last_draw_ns, 1000U);
+    rc |= expect_int("clean frame skipped", g_printer_calls, 0);
+    ui_terminal_telemetry_request_redraw();
+    dsd_neo_ui_async_test_draw_if_needed(&opts, &last_draw_ns, 1000U);
+    rc |= expect_int("dirty frame draws", g_printer_calls, 1);
+    rc |= expect_ptr("draw uses latest state", g_printer_state, &latest_state);
+    rc |= expect_ptr("draw opts", g_printer_opts, &opts);
+    rc |= expect_int("draw commit", g_commit_calls, 1);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+
+    rc |= test_ui_start_failure_resets_state();
+    rc |= test_ui_start_stop_idempotency_and_control_pump();
+    rc |= test_ui_single_frame_snapshot_input_and_draw_helpers();
+
+    if (rc == 0) {
+        printf("UI_ASYNC_LIFECYCLE: OK\n");
+    }
+    return rc;
+}

--- a/tests/ui/test_ui_cmd_actions.c
+++ b/tests/ui/test_ui_cmd_actions.c
@@ -1,0 +1,478 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Deterministic contracts for terminal UI command action registries.
+ */
+
+#include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/ui/menu_services.h>
+#include <dsd-neo/ui/ui_cmd.h>
+#include <dsd-neo/ui/ui_cmd_dispatch.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static int g_open_audio_calls;
+static int g_close_audio_calls;
+static int g_open_audio_rc;
+static int g_reset_history_calls;
+static int g_disable_event_log_calls;
+static int g_set_event_log_calls;
+static int g_set_event_log_rc;
+static char g_set_event_log_path[256];
+
+int
+openAudioOutput(dsd_opts* opts) {
+    (void)opts;
+    g_open_audio_calls++;
+    return g_open_audio_rc;
+}
+
+void
+closeAudioOutput(dsd_opts* opts) {
+    (void)opts;
+    g_close_audio_calls++;
+}
+
+void
+svc_reset_event_history(dsd_state* state) {
+    g_reset_history_calls++;
+    if (state) {
+        state->eh_index = 0;
+        state->eh_slot = 0;
+    }
+}
+
+void
+svc_disable_event_log(dsd_opts* opts) {
+    (void)opts;
+    g_disable_event_log_calls++;
+}
+
+int
+svc_set_event_log(dsd_opts* opts, const char* path) {
+    (void)opts;
+    g_set_event_log_calls++;
+    DSD_SNPRINTF(g_set_event_log_path, sizeof(g_set_event_log_path), "%s", path ? path : "");
+    return g_set_event_log_rc;
+}
+
+static int
+expect_true(const char* tag, int cond) {
+    if (!cond) {
+        DSD_FPRINTF(stderr, "%s: expectation failed\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+dispatch_one(const struct UiCmdReg* regs, dsd_opts* opts, dsd_state* state, const struct UiCmd* cmd) {
+    for (const struct UiCmdReg* r = regs; r && r->fn; r++) {
+        if (r->id == cmd->id) {
+            return r->fn(opts, state, cmd);
+        }
+    }
+    return 0;
+}
+
+static struct UiCmd
+cmd_i32(int id, int32_t value) {
+    struct UiCmd cmd;
+    DSD_MEMSET(&cmd, 0, sizeof(cmd));
+    cmd.id = id;
+    cmd.n = sizeof(value);
+    DSD_MEMCPY(cmd.data, &value, sizeof(value));
+    return cmd;
+}
+
+static struct UiCmd
+cmd_double(int id, double value) {
+    struct UiCmd cmd;
+    DSD_MEMSET(&cmd, 0, sizeof(cmd));
+    cmd.id = id;
+    cmd.n = sizeof(value);
+    DSD_MEMCPY(cmd.data, &value, sizeof(value));
+    return cmd;
+}
+
+static struct UiCmd
+cmd_slot(int id, uint8_t slot) {
+    struct UiCmd cmd;
+    DSD_MEMSET(&cmd, 0, sizeof(cmd));
+    cmd.id = id;
+    cmd.n = 1;
+    cmd.data[0] = slot;
+    return cmd;
+}
+
+static struct UiCmd
+cmd_path(int id, const char* path) {
+    struct UiCmd cmd;
+    size_t n = strlen(path);
+    DSD_MEMSET(&cmd, 0, sizeof(cmd));
+    cmd.id = id;
+    cmd.n = n;
+    DSD_MEMCPY(cmd.data, path, n);
+    return cmd;
+}
+
+static int
+test_audio_actions(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    struct UiCmd cmd;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    cmd = cmd_i32(UI_CMD_GAIN_SET, 60);
+    rc |= expect_int("gain set dispatch", dispatch_one(ui_actions_audio, &opts, &state, &cmd), 1);
+    rc |= expect_int("gain set clamps opts", opts.audio_gain, 50);
+    rc |= expect_int("gain set mirrors right", opts.audio_gainR, 50);
+    rc |= expect_int("gain set mirrors state", state.aout_gain, 50);
+    cmd = cmd_i32(UI_CMD_GAIN_SET, -4);
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("gain set clamps low opts", opts.audio_gain, 0);
+    rc |= expect_int("gain set low keeps playback default", state.aout_gain, 25);
+    opts.audio_gain = 49;
+    cmd = cmd_i32(UI_CMD_GAIN_DELTA, 5);
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("gain delta clamps high", opts.audio_gain, 50);
+
+    cmd = cmd_i32(UI_CMD_GAIN_DELTA, -80);
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("gain delta clamps opts", opts.audio_gain, 0);
+    rc |= expect_int("zero gain keeps playback gain default left", state.aout_gain, 25);
+    rc |= expect_int("zero gain keeps playback gain default right", state.aout_gainR, 25);
+
+    opts.audio_gainA = 49;
+    cmd = cmd_i32(UI_CMD_AGAIN_DELTA, 7);
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("analog gain delta clamps high", opts.audio_gainA, 50);
+    cmd = cmd_i32(UI_CMD_AGAIN_DELTA, -90);
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("analog gain delta clamps low", opts.audio_gainA, 0);
+    cmd = cmd_i32(UI_CMD_AGAIN_SET, -9);
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("analog gain set clamps low", opts.audio_gainA, 0);
+    cmd = cmd_i32(UI_CMD_AGAIN_SET, 60);
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("analog gain set clamps high", opts.audio_gainA, 50);
+
+    cmd = cmd_double(UI_CMD_INPUT_WARN_DB_SET, 12.5);
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_true("input warn clamps high", opts.input_warn_db == 0.0);
+    cmd = cmd_double(UI_CMD_INPUT_WARN_DB_SET, -500.0);
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_true("input warn clamps low", opts.input_warn_db == -200.0);
+
+    cmd.id = UI_CMD_INPUT_MONITOR_TOGGLE;
+    cmd.n = 0;
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("input monitor toggle enables", opts.monitor_input_audio, 1);
+    cmd.id = UI_CMD_COSINE_FILTER_TOGGLE;
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("cosine filter toggle enables", opts.use_cosine_filter, 1);
+
+    cmd = cmd_i32(UI_CMD_INPUT_VOL_SET, 0);
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("input volume set clamps low", opts.input_volume_multiplier, 1);
+    cmd = cmd_i32(UI_CMD_INPUT_VOL_SET, 99);
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("input volume set clamps high", opts.input_volume_multiplier, 16);
+    opts.audio_in_type = 0;
+    opts.input_volume_multiplier = 1;
+    cmd.id = UI_CMD_INPUT_VOL_CYCLE;
+    cmd.n = 0;
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("standard input volume cycles", opts.input_volume_multiplier, 2);
+    rc |= expect_true("standard input volume toast", strstr(state.ui_msg, "Input Volume: 2X") != NULL);
+    opts.input_volume_multiplier = 9;
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("standard input volume resets", opts.input_volume_multiplier, 1);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtl_volume_multiplier = 2;
+    cmd.id = UI_CMD_INPUT_VOL_CYCLE;
+    cmd.n = 0;
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("rtl input volume cycles", opts.rtl_volume_multiplier, 3);
+    rc |= expect_true("rtl input volume toast", strstr(state.ui_msg, "RTL Monitor Gain: 3X") != NULL);
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("rtl input volume resets", opts.rtl_volume_multiplier, 1);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_out = 0;
+    opts.audio_out_type = 0;
+    g_open_audio_calls = 0;
+    g_close_audio_calls = 0;
+    g_open_audio_rc = -1;
+    cmd.id = UI_CMD_TOGGLE_MUTE;
+    cmd.n = 0;
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("mute failed open leaves output off", opts.audio_out, 0);
+    rc |= expect_int("mute failed open calls close", g_close_audio_calls, 1);
+    rc |= expect_int("mute failed open calls open", g_open_audio_calls, 1);
+    rc |= expect_true("mute failed open toast", strstr(state.ui_msg, "open failed") != NULL);
+    g_open_audio_calls = 0;
+    g_close_audio_calls = 0;
+    g_open_audio_rc = 0;
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("mute successful open enables output", opts.audio_out, 1);
+    rc |= expect_int("mute successful open calls close", g_close_audio_calls, 1);
+    rc |= expect_int("mute successful open calls open", g_open_audio_calls, 1);
+    rc |= expect_true("mute successful open toast", strstr(state.ui_msg, "Output: On") != NULL);
+    dispatch_one(ui_actions_audio, &opts, &state, &cmd);
+    rc |= expect_int("mute toggle disables output", opts.audio_out, 0);
+    rc |= expect_true("mute disabled toast", strstr(state.ui_msg, "Output: Muted") != NULL);
+
+    return rc;
+}
+
+static int
+test_trunk_actions(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    struct UiCmd cmd;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    cmd.id = UI_CMD_TRUNK_TOGGLE;
+    cmd.n = 0;
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("trunk toggle enables p25 trunk", opts.p25_trunk, 1);
+    rc |= expect_int("trunk toggle enables trunk tune", opts.trunk_enable, 1);
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("trunk toggle disables p25 trunk", opts.p25_trunk, 0);
+    rc |= expect_int("trunk toggle disables trunk tune", opts.trunk_enable, 0);
+
+    opts.p25_trunk = 1;
+    opts.trunk_tune_group_calls = 1;
+    cmd.id = UI_CMD_TRUNK_GROUP_TOGGLE;
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("group toggle works only while trunking", opts.trunk_tune_group_calls, 0);
+
+    state.lasttg = 1234;
+    cmd = cmd_slot(UI_CMD_TG_HOLD_TOGGLE, 0);
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("tg hold slot 0 uses lasttg", (int)state.tg_hold, 1234);
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("tg hold slot 0 clears", (int)state.tg_hold, 0);
+
+    opts.frame_nxdn48 = 1;
+    state.lasttg = 0;
+    state.tg_hold = 0;
+    state.nxdn_last_tg = 2345;
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("tg hold nxdn fallback", (int)state.tg_hold, 2345);
+
+    opts.frame_nxdn48 = 0;
+    opts.frame_provoice = 1;
+    state.ea_mode = 0;
+    state.tg_hold = 0;
+    state.lastsrc = 2346;
+    cmd = cmd_slot(UI_CMD_TG_HOLD_TOGGLE, 0);
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("tg hold provoice slot 0 fallback", (int)state.tg_hold, 2346);
+
+    state.tg_hold = 0;
+    state.lastsrcR = 3456;
+    cmd = cmd_slot(UI_CMD_TG_HOLD_TOGGLE, 1);
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("tg hold provoice slot 1 fallback", (int)state.tg_hold, 3456);
+
+    state.lasttgR = 4567;
+    state.tg_hold = 0;
+    opts.frame_provoice = 0;
+    cmd = cmd_slot(UI_CMD_TG_HOLD_TOGGLE, 3);
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("tg hold slot 1 uses lasttgR", (int)state.tg_hold, 4567);
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("tg hold slot 1 clears", (int)state.tg_hold, 0);
+
+    opts.frame_nxdn96 = 1;
+    state.lasttgR = 0;
+    state.tg_hold = 0;
+    state.nxdn_last_tg = 5678;
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("tg hold slot 1 nxdn fallback", (int)state.tg_hold, 5678);
+    opts.frame_nxdn96 = 0;
+
+    cmd.id = UI_CMD_SCANNER_TOGGLE;
+    cmd.n = 0;
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("scanner toggle enables scanner", opts.scanner_mode, 1);
+    rc |= expect_int("scanner toggle disables trunking", opts.p25_trunk, 0);
+
+    opts.trunk_use_allow_list = 0;
+    opts.trunk_tune_private_calls = 1;
+    opts.trunk_tune_data_calls = 0;
+    opts.trunk_tune_enc_calls = 1;
+    cmd.n = 0;
+    cmd.id = UI_CMD_TRUNK_WLIST_TOGGLE;
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("trunk allow-list toggle enables", opts.trunk_use_allow_list, 1);
+    cmd.id = UI_CMD_TRUNK_PRIV_TOGGLE;
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("trunk private toggle disables", opts.trunk_tune_private_calls, 0);
+    cmd.id = UI_CMD_TRUNK_DATA_TOGGLE;
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("trunk data toggle enables", opts.trunk_tune_data_calls, 1);
+    cmd.id = UI_CMD_TRUNK_ENC_TOGGLE;
+    dispatch_one(ui_actions_trunk, &opts, &state, &cmd);
+    rc |= expect_int("trunk encrypted toggle disables", opts.trunk_tune_enc_calls, 0);
+
+    return rc;
+}
+
+static int
+test_radio_actions(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    struct UiCmd cmd;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    cmd = cmd_i32(UI_CMD_PPM_DELTA, -7);
+    dispatch_one(ui_actions_radio, &opts, &state, &cmd);
+    rc |= expect_int("ppm delta applies without radio backend", opts.rtlsdr_ppm_error, -7);
+
+    cmd.id = UI_CMD_INVERT_TOGGLE;
+    cmd.n = 0;
+    dispatch_one(ui_actions_radio, &opts, &state, &cmd);
+    rc |= expect_int("invert dmr", opts.inverted_dmr, 1);
+    rc |= expect_int("invert dpmr", opts.inverted_dpmr, 1);
+    rc |= expect_int("invert x2", opts.inverted_x2tdma, 1);
+    rc |= expect_int("invert ysf", opts.inverted_ysf, 1);
+    rc |= expect_int("invert m17", opts.inverted_m17, 1);
+
+    cmd.id = UI_CMD_MOD_TOGGLE;
+    dispatch_one(ui_actions_radio, &opts, &state, &cmd);
+    rc |= expect_int("mod toggle selects qpsk", opts.mod_qpsk, 1);
+    rc |= expect_int("mod toggle clears c4fm", opts.mod_c4fm, 0);
+    rc |= expect_int("mod toggle updates rf_mod", state.rf_mod, 1);
+    rc |= expect_int("mod toggle p25p1 sps", state.samplesPerSymbol, 10);
+    rc |= expect_int("mod toggle p25p1 center", state.symbolCenter, 4);
+    dispatch_one(ui_actions_radio, &opts, &state, &cmd);
+    rc |= expect_int("mod toggle returns c4fm", opts.mod_c4fm, 1);
+    rc |= expect_int("mod toggle clears qpsk", opts.mod_qpsk, 0);
+    rc |= expect_int("mod toggle clears rf_mod", state.rf_mod, 0);
+
+    cmd.id = UI_CMD_MOD_P2_TOGGLE;
+    dispatch_one(ui_actions_radio, &opts, &state, &cmd);
+    rc |= expect_int("mod p2 toggle selects qpsk", opts.mod_qpsk, 1);
+    rc |= expect_int("mod p2 toggle sets rf_mod", state.rf_mod, 1);
+    rc |= expect_int("mod p2 toggle qpsk sps", state.samplesPerSymbol, 8);
+    rc |= expect_int("mod p2 toggle qpsk center", state.symbolCenter, 3);
+    dispatch_one(ui_actions_radio, &opts, &state, &cmd);
+    rc |= expect_int("mod p2 toggle returns c4fm", opts.mod_c4fm, 1);
+    rc |= expect_int("mod p2 toggle p25p2 sps", state.samplesPerSymbol, 8);
+    rc |= expect_int("mod p2 toggle p25p2 center", state.symbolCenter, 3);
+
+    return rc;
+}
+
+static int
+test_logging_actions(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    struct UiCmd cmd;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.eh_index = 254;
+    cmd.id = UI_CMD_EH_NEXT;
+    cmd.n = 0;
+    dispatch_one(ui_actions_logging, &opts, &state, &cmd);
+    rc |= expect_int("event history next clamps", state.eh_index, 254);
+    state.eh_index = 10;
+    dispatch_one(ui_actions_logging, &opts, &state, &cmd);
+    rc |= expect_int("event history next increments", state.eh_index, 11);
+    cmd.id = UI_CMD_EH_PREV;
+    dispatch_one(ui_actions_logging, &opts, &state, &cmd);
+    rc |= expect_int("event history prev decrements", state.eh_index, 10);
+
+    state.eh_slot = 0;
+    state.eh_index = 9;
+    cmd.id = UI_CMD_EH_TOGGLE_SLOT;
+    dispatch_one(ui_actions_logging, &opts, &state, &cmd);
+    rc |= expect_int("event history slot cycles to slot 1", state.eh_slot, 1);
+    rc |= expect_int("event history slot 1 resets index", state.eh_index, 0);
+    state.eh_index = 8;
+    dispatch_one(ui_actions_logging, &opts, &state, &cmd);
+    rc |= expect_int("event history slot cycles to slot 2", state.eh_slot, 2);
+    rc |= expect_int("event history slot 2 resets index", state.eh_index, 0);
+    state.eh_index = 7;
+    dispatch_one(ui_actions_logging, &opts, &state, &cmd);
+    rc |= expect_int("event history slot cycles to all", state.eh_slot, 0);
+    rc |= expect_int("event history slot all resets index", state.eh_index, 0);
+
+    DSD_SNPRINTF(state.ui_msg, sizeof(state.ui_msg), "stale");
+    state.ui_msg_expire = 99;
+    cmd.id = UI_CMD_UI_MSG_CLEAR;
+    dispatch_one(ui_actions_logging, &opts, &state, &cmd);
+    rc |= expect_true("ui message clear empties toast", state.ui_msg[0] == '\0');
+    rc |= expect_int("ui message clear expires", (int)state.ui_msg_expire, 0);
+
+    g_reset_history_calls = 0;
+    cmd.id = UI_CMD_EH_RESET;
+    dispatch_one(ui_actions_logging, &opts, &state, &cmd);
+    rc |= expect_int("event history reset service called", g_reset_history_calls, 1);
+    rc |= expect_true("event history reset toast", strstr(state.ui_msg, "Event history reset") != NULL);
+
+    g_disable_event_log_calls = 0;
+    cmd.id = UI_CMD_EVENT_LOG_DISABLE;
+    dispatch_one(ui_actions_logging, &opts, &state, &cmd);
+    rc |= expect_int("event log disable service called", g_disable_event_log_calls, 1);
+    rc |= expect_true("event log disable toast", strstr(state.ui_msg, "Event log disabled") != NULL);
+
+    g_set_event_log_calls = 0;
+    g_set_event_log_rc = 0;
+    cmd = cmd_path(UI_CMD_EVENT_LOG_SET, "/tmp/ui-actions.log");
+    dispatch_one(ui_actions_logging, &opts, &state, &cmd);
+    rc |= expect_int("event log set service called", g_set_event_log_calls, 1);
+    rc |= expect_true("event log set path passed", strcmp(g_set_event_log_path, "/tmp/ui-actions.log") == 0);
+    rc |= expect_true("event log set toast", strstr(state.ui_msg, "Event log -> /tmp/ui-actions.log") != NULL);
+
+    g_set_event_log_rc = -1;
+    cmd = cmd_path(UI_CMD_EVENT_LOG_SET, "/bad");
+    dispatch_one(ui_actions_logging, &opts, &state, &cmd);
+    rc |= expect_true("event log set failure toast", strstr(state.ui_msg, "path invalid") != NULL);
+
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_audio_actions();
+    rc |= test_trunk_actions();
+    rc |= test_radio_actions();
+    rc |= test_logging_actions();
+    if (rc == 0) {
+        printf("UI_CMD_ACTIONS: OK\n");
+    }
+    return rc;
+}

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1,0 +1,536 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Deterministic queue-level contracts for UI commands handled in ui_cmd_queue.c.
+ */
+
+#include <dsd-neo/core/init.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/ui/ui_async.h>
+#include <dsd-neo/ui/ui_cmd.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u64(const char* tag, uint64_t got, uint64_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %llu want %llu\n", tag, (unsigned long long)got, (unsigned long long)want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_true(const char* tag, int cond) {
+    if (!cond) {
+        DSD_FPRINTF(stderr, "%s: expectation failed\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_str(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got \"%s\" want \"%s\"\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_contains(const char* tag, const char* haystack, const char* needle) {
+    if (!haystack || !needle || !strstr(haystack, needle)) {
+        DSD_FPRINTF(stderr, "%s: \"%s\" does not contain \"%s\"\n", tag, haystack ? haystack : "(null)",
+                    needle ? needle : "(null)");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+write_file_bytes(const char* path, const void* data, size_t n) {
+    FILE* f = fopen(path, "wb");
+    if (!f) {
+        DSD_FPRINTF(stderr, "failed to create %s\n", path);
+        return 1;
+    }
+    int rc = 0;
+    if (n > 0U && fwrite(data, 1U, n, f) != n) {
+        DSD_FPRINTF(stderr, "failed to write %s\n", path);
+        rc = 1;
+    }
+    if (fclose(f) != 0) {
+        DSD_FPRINTF(stderr, "failed to close %s\n", path);
+        rc = 1;
+    }
+    return rc;
+}
+
+static void
+init_test_context(dsd_opts* opts, dsd_state* state) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    initOpts(opts);
+    initState(state);
+    state->cli_argc_effective = 0;
+    state->cli_argv = NULL;
+}
+
+static int
+post_empty(int id) {
+    return ui_post_cmd(id, NULL, 0U);
+}
+
+static int
+post_i32(int id, int32_t value) {
+    return ui_post_cmd(id, &value, sizeof(value));
+}
+
+static int
+post_u32(int id, uint32_t value) {
+    return ui_post_cmd(id, &value, sizeof(value));
+}
+
+static int
+post_u64(int id, uint64_t value) {
+    return ui_post_cmd(id, &value, sizeof(value));
+}
+
+static int
+post_double(int id, double value) {
+    return ui_post_cmd(id, &value, sizeof(value));
+}
+
+static int
+post_float(int id, float value) {
+    return ui_post_cmd(id, &value, sizeof(value));
+}
+
+static int
+post_string(int id, const char* value) {
+    return ui_post_cmd(id, value, strlen(value) + 1U);
+}
+
+static int
+post_host_port(int id, const char* host, int32_t port) {
+    uint8_t payload[256 + sizeof(port)];
+    DSD_MEMSET(payload, 0, sizeof(payload));
+    DSD_SNPRINTF((char*)payload, 256U, "%s", host);
+    DSD_MEMCPY(payload + 256U, &port, sizeof(port));
+    return ui_post_cmd(id, payload, sizeof(payload));
+}
+
+static int
+post_hytera_key(uint64_t h, uint64_t k1, uint64_t k2, uint64_t k3, uint64_t k4) {
+    struct {
+        uint64_t H;
+        uint64_t K1;
+        uint64_t K2;
+        uint64_t K3;
+        uint64_t K4;
+    } payload;
+
+    payload.H = h;
+    payload.K1 = k1;
+    payload.K2 = k2;
+    payload.K3 = k3;
+    payload.K4 = k4;
+    return ui_post_cmd(UI_CMD_KEY_HYTERA_SET, &payload, sizeof(payload));
+}
+
+static int
+post_aes_key(uint64_t k1, uint64_t k2, uint64_t k3, uint64_t k4) {
+    struct {
+        uint64_t K1;
+        uint64_t K2;
+        uint64_t K3;
+        uint64_t K4;
+    } payload;
+
+    payload.K1 = k1;
+    payload.K2 = k2;
+    payload.K3 = k3;
+    payload.K4 = k4;
+    return ui_post_cmd(UI_CMD_KEY_AES_SET, &payload, sizeof(payload));
+}
+
+static int
+post_p2_params(uint64_t wacn, uint64_t sysid, uint64_t cc) {
+    struct {
+        uint64_t w;
+        uint64_t s;
+        uint64_t n;
+    } payload;
+
+    payload.w = wacn;
+    payload.s = sysid;
+    payload.n = cc;
+    return ui_post_cmd(UI_CMD_P25_P2_PARAMS_SET, &payload, sizeof(payload));
+}
+
+static int
+post_call_alert_events(uint8_t events) {
+    return ui_post_cmd(UI_CMD_CALL_ALERT_EVENTS_SET, &events, sizeof(events));
+}
+
+static int
+test_visibility_and_queue_overflow(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    init_test_context(&opts, &state);
+
+    rc |= expect_int("initial queue empty", ui_drain_cmds(&opts, &state), 0);
+
+    post_empty(UI_CMD_UI_SHOW_DSP_PANEL_TOGGLE);
+    post_empty(UI_CMD_UI_SHOW_P25_METRICS_TOGGLE);
+    post_empty(UI_CMD_UI_SHOW_P25_AFFIL_TOGGLE);
+    post_empty(UI_CMD_UI_SHOW_P25_NEIGHBORS_TOGGLE);
+    post_empty(UI_CMD_UI_SHOW_P25_IDEN_TOGGLE);
+    post_empty(UI_CMD_UI_SHOW_P25_CCC_TOGGLE);
+    post_empty(UI_CMD_UI_SHOW_CHANNELS_TOGGLE);
+    post_empty(UI_CMD_UI_SHOW_P25_CALLSIGN_TOGGLE);
+    rc |= expect_int("visibility commands applied", ui_drain_cmds(&opts, &state), 8);
+    rc |= expect_int("dsp panel visible", opts.show_dsp_panel, 1);
+    rc |= expect_int("p25 metrics visible", opts.show_p25_metrics, 1);
+    rc |= expect_int("p25 affiliations visible", opts.show_p25_affiliations, 1);
+    rc |= expect_int("p25 neighbors visible", opts.show_p25_neighbors, 1);
+    rc |= expect_int("p25 iden visible", opts.show_p25_iden_plan, 1);
+    rc |= expect_int("p25 candidates visible", opts.show_p25_cc_candidates, 1);
+    rc |= expect_int("channels visible", opts.show_channels, 1);
+    rc |= expect_int("callsign visible", opts.show_p25_callsign_decode, 1);
+
+    opts.show_channels = 0;
+    for (int i = 0; i < 140; i++) {
+        post_empty(UI_CMD_UI_SHOW_CHANNELS_TOGGLE);
+    }
+    rc |= expect_int("overflow keeps bounded queue depth", ui_drain_cmds(&opts, &state), 127);
+    rc |= expect_int("overflow drains newest visibility toggles", opts.show_channels, 1);
+
+    freeState(&state);
+    return rc;
+}
+
+static int
+test_key_and_runtime_state_commands(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    init_test_context(&opts, &state);
+
+    opts.dmr_mute_encL = 1;
+    opts.dmr_mute_encR = 1;
+    state.payload_keyid = 9;
+    state.payload_keyidR = 10;
+
+    post_u32(UI_CMD_KEY_BASIC_SET, 0x12345678U);
+    post_u32(UI_CMD_KEY_SCRAMBLER_SET, 0x11112222U);
+    post_u64(UI_CMD_KEY_RC4DES_SET, 0x55667788ULL);
+    post_hytera_key(0xAU, 1U, 2U, 0U, 0U);
+    post_aes_key(3U, 4U, 5U, 6U);
+    post_string(UI_CMD_M17_USER_DATA_SET, "0,DEST,SOURCE");
+    post_i32(UI_CMD_RIGCTL_SET_MOD_BW, 12500);
+    post_u32(UI_CMD_TG_HOLD_SET, 4567U);
+    post_double(UI_CMD_HANGTIME_SET, 2.5);
+    post_i32(UI_CMD_SLOT_PREF_SET, 1);
+    post_i32(UI_CMD_SLOTS_ONOFF_SET, 2);
+    post_p2_params(0xABCDEU, 0x123U, 0x456U);
+
+    rc |= expect_int("key/runtime commands applied", ui_drain_cmds(&opts, &state), 12);
+    rc |= expect_u64("basic key loaded", state.K, 0x12345678ULL);
+    rc |= expect_u64("scrambler key loaded", state.R, 0x55667788ULL);
+    rc |= expect_u64("rc4des key mirror loaded", state.RR, 0x55667788ULL);
+    rc |= expect_int("key mute reset left", opts.dmr_mute_encL, 0);
+    rc |= expect_int("key mute reset right", opts.dmr_mute_encR, 0);
+    rc |= expect_int("payload key reset left", state.payload_keyid, 0);
+    rc |= expect_int("payload key reset right", state.payload_keyidR, 0);
+    rc |= expect_u64("aes key loaded", state.A1[0], 3ULL);
+    rc |= expect_int("aes key load flag left", state.aes_key_loaded[0], 1);
+    rc |= expect_int("aes key segments left", state.aes_key_segments[0], 4);
+    rc |= expect_u64("hytera state cleared by aes", state.H, 0ULL);
+    rc |= expect_int("m17 user data copied", strncmp(state.m17dat, "0,DEST,SOURCE", sizeof(state.m17dat)), 0);
+    rc |= expect_int("rigctl bw set", opts.setmod_bw, 12500);
+    rc |= expect_u64("tg hold set", state.tg_hold, 4567ULL);
+    rc |= expect_true("hangtime set", opts.trunk_hangtime > 2.49 && opts.trunk_hangtime < 2.51);
+    rc |= expect_int("slot preference set", opts.slot_preference, 1);
+    rc |= expect_int("slot1 disabled by mask", opts.slot1_on, 0);
+    rc |= expect_int("slot2 enabled by mask", opts.slot2_on, 1);
+    rc |= expect_u64("p2 wacn set", state.p2_wacn, 0xABCDEULL);
+    rc |= expect_u64("p2 sysid set", state.p2_sysid, 0x123ULL);
+    rc |= expect_u64("p2 cc set", state.p2_cc, 0x456ULL);
+
+    uint8_t short_payload = 0xFFU;
+    state.K = 0x99999999U;
+    state.A1[0] = 0x55U;
+    post_u32(UI_CMD_KEY_BASIC_SET, 0x01020304U);
+    ui_post_cmd(UI_CMD_KEY_AES_SET, &short_payload, sizeof(short_payload));
+    post_string(UI_CMD_M17_USER_DATA_SET, "");
+    rc |= expect_int("short key payload commands applied", ui_drain_cmds(&opts, &state), 3);
+    rc |= expect_u64("basic key still updates before short aes", state.K, 0x01020304ULL);
+    rc |= expect_u64("short aes ignored", state.A1[0], 0x55ULL);
+    rc |= expect_str("empty m17 payload clears value", state.m17dat, "");
+
+    freeState(&state);
+    return rc;
+}
+
+static int
+test_file_network_and_import_commands(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    const char* symbol_out = "ui_cmd_queue_symbols_out.bin";
+    const char* symbol_in = "ui_cmd_queue_symbols_in.bin";
+    const char* missing_csv = "ui_cmd_queue_missing.csv";
+    const unsigned char symbol_data[] = {0x12U, 0x34U, 0x56U, 0x78U};
+
+    remove(symbol_out);
+    remove(symbol_in);
+    remove(missing_csv);
+
+    init_test_context(&opts, &state);
+
+    rc |= write_file_bytes(symbol_in, symbol_data, sizeof(symbol_data));
+
+    post_string(UI_CMD_DSP_OUT_SET, "stream.float");
+    post_string(UI_CMD_SYMCAP_OPEN, symbol_out);
+    post_string(UI_CMD_SYMBOL_IN_OPEN, symbol_in);
+    rc |= expect_int("file command group applied", ui_drain_cmds(&opts, &state), 3);
+    rc |= expect_int("dsp output enabled", opts.use_dsp_output, 1);
+    rc |= expect_str("dsp output path", opts.dsp_out_file, "./DSP/stream.float");
+    rc |= expect_str("symbol output path", opts.symbol_out_file, symbol_out);
+    rc |= expect_true("symbol output opened", opts.symbol_out_f != NULL);
+    rc |= expect_true("symbol input opened", opts.symbolfile != NULL);
+    rc |= expect_int("symbol input type selected", opts.audio_in_type, AUDIO_IN_SYMBOL_BIN);
+    rc |= expect_int("symbol replay format reset", state.symbol_replay_format, 0);
+    rc |= expect_int("symbol replay header reset", state.symbol_replay_header_checked, 0);
+
+    if (opts.symbol_out_f) {
+        fclose(opts.symbol_out_f);
+        opts.symbol_out_f = NULL;
+    }
+    if (opts.symbolfile) {
+        fclose(opts.symbolfile);
+        opts.symbolfile = NULL;
+    }
+
+    post_string(UI_CMD_PULSE_OUT_SET, "sink0");
+    post_string(UI_CMD_PULSE_IN_SET, "source0");
+    rc |= expect_int("pulse command group applied", ui_drain_cmds(&opts, &state), 2);
+    rc |= expect_str("pulse output selected", opts.audio_out_dev, "pulse");
+    rc |= expect_int("pulse output type selected", opts.audio_out_type, 0);
+    rc |= expect_str("pulse input selected", opts.audio_in_dev, "pulse");
+    rc |= expect_int("pulse input type selected", opts.audio_in_type, AUDIO_IN_PULSE);
+
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", "unchanged");
+    opts.audio_in_type = AUDIO_IN_STDIN;
+    ui_post_cmd(UI_CMD_UDP_INPUT_CFG, NULL, 0U);
+    rc |= expect_int("malformed udp input command applied", ui_drain_cmds(&opts, &state), 1);
+    rc |= expect_str("malformed udp input leaves device", opts.audio_in_dev, "unchanged");
+    rc |= expect_int("malformed udp input leaves type", opts.audio_in_type, AUDIO_IN_STDIN);
+
+    post_host_port(UI_CMD_UDP_OUT_CFG, "127.0.0.1", 0);
+    post_host_port(UI_CMD_TCP_CONNECT_AUDIO_CFG, "127.0.0.1", -1);
+    post_host_port(UI_CMD_RIGCTL_CONNECT_CFG, "127.0.0.1", -1);
+    rc |= expect_int("network failure command group applied", ui_drain_cmds(&opts, &state), 3);
+    rc |= expect_contains("rigctl failure toast", state.ui_msg, "Rigctl connect failed");
+    rc |= expect_int("rigctl remains disabled", opts.use_rigctl, 0);
+
+    post_empty(UI_CMD_LRRP_SET_DSDP);
+    rc |= expect_int("lrrp dsdp applied", ui_drain_cmds(&opts, &state), 1);
+    rc |= expect_str("lrrp dsdp path", opts.lrrp_out_file, "DSDPlus.LRRP");
+    rc |= expect_int("lrrp dsdp enabled", opts.lrrp_file_output, 1);
+
+    post_string(UI_CMD_LRRP_SET_CUSTOM, "positions.csv");
+    rc |= expect_int("lrrp custom applied", ui_drain_cmds(&opts, &state), 1);
+    rc |= expect_str("lrrp custom path", opts.lrrp_out_file, "positions.csv");
+
+    post_string(UI_CMD_IMPORT_CHANNEL_MAP, missing_csv);
+    post_string(UI_CMD_IMPORT_GROUP_LIST, missing_csv);
+    post_string(UI_CMD_IMPORT_KEYS_DEC, missing_csv);
+    post_string(UI_CMD_IMPORT_KEYS_HEX, missing_csv);
+    rc |= expect_int("import failure group applied", ui_drain_cmds(&opts, &state), 4);
+    rc |= expect_str("channel import path copied", opts.chan_in_file, missing_csv);
+    rc |= expect_str("group import path copied", opts.group_in_file, missing_csv);
+    rc |= expect_str("key import path copied", opts.key_in_file, missing_csv);
+    rc |= expect_contains("key import failure toast", state.ui_msg, "Failed: Keys (HEX)");
+
+    post_string(UI_CMD_EVENT_LOG_SET, "events.log");
+    rc |= expect_int("event log set applied", ui_drain_cmds(&opts, &state), 1);
+    rc |= expect_str("event log path set", opts.event_out_file, "events.log");
+    post_empty(UI_CMD_EVENT_LOG_DISABLE);
+    rc |= expect_int("event log disable applied", ui_drain_cmds(&opts, &state), 1);
+    rc |= expect_str("event log disabled", opts.event_out_file, "");
+
+    remove(symbol_out);
+    remove(symbol_in);
+    freeState(&state);
+    return rc;
+}
+
+static int
+test_io_and_legacy_state_commands(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    init_test_context(&opts, &state);
+
+    opts.slot1_on = 1;
+    opts.slot2_on = 1;
+    opts.slot_preference = 0;
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.const_gate_other = 0.05f;
+    opts.const_gate_qpsk = 0.10f;
+    opts.const_norm_mode = 0;
+    opts.eye_unicode = 0;
+    opts.eye_color = 0;
+    opts.use_lpf = 0;
+    opts.use_hpf = 0;
+    opts.use_pbf = 0;
+    opts.use_hpf_d = 0;
+    opts.aggressive_framesync = 0;
+    opts.call_alert_events = 0xFFU;
+    opts.call_alert = 0;
+    opts.p25_lcw_retune = 0;
+    opts.reverse_mute = 0;
+    opts.inverted_x2tdma = 0;
+    opts.inverted_dmr = 0;
+    opts.inverted_dpmr = 0;
+    opts.inverted_m17 = 0;
+    opts.m17encoder = 1;
+    opts.frame_provoice = 1;
+    state.ea_mode = 0;
+
+    post_empty(UI_CMD_CONST_TOGGLE);
+    post_empty(UI_CMD_CONST_NORM_TOGGLE);
+    post_float(UI_CMD_CONST_GATE_DELTA, 1.0f);
+    post_empty(UI_CMD_EYE_TOGGLE);
+    post_empty(UI_CMD_EYE_UNICODE_TOGGLE);
+    post_empty(UI_CMD_EYE_COLOR_TOGGLE);
+    post_empty(UI_CMD_FSK_HIST_TOGGLE);
+    post_empty(UI_CMD_SPECTRUM_TOGGLE);
+    post_empty(UI_CMD_TOGGLE_COMPACT);
+    post_empty(UI_CMD_SLOT1_TOGGLE);
+    post_empty(UI_CMD_SLOT2_TOGGLE);
+    post_empty(UI_CMD_SLOT_PREF_CYCLE);
+    post_empty(UI_CMD_PAYLOAD_TOGGLE);
+    post_empty(UI_CMD_P25_GA_TOGGLE);
+    post_empty(UI_CMD_LPF_TOGGLE);
+    post_empty(UI_CMD_HPF_TOGGLE);
+    post_empty(UI_CMD_PBF_TOGGLE);
+    post_empty(UI_CMD_HPF_D_TOGGLE);
+    post_empty(UI_CMD_AGGR_SYNC_TOGGLE);
+    post_empty(UI_CMD_CALL_ALERT_TOGGLE);
+    post_call_alert_events(0U);
+    post_empty(UI_CMD_CRC_RELAX_TOGGLE);
+    post_empty(UI_CMD_LCW_RETUNE_TOGGLE);
+    post_empty(UI_CMD_P25_CC_CAND_TOGGLE);
+    post_empty(UI_CMD_REVERSE_MUTE_TOGGLE);
+    post_empty(UI_CMD_INV_X2_TOGGLE);
+    post_empty(UI_CMD_INV_DMR_TOGGLE);
+    post_empty(UI_CMD_INV_DPMR_TOGGLE);
+    post_empty(UI_CMD_INV_M17_TOGGLE);
+    post_string(UI_CMD_INPUT_WAV_SET, "input.wav");
+    post_string(UI_CMD_INPUT_SYM_STREAM_SET, "symbols.f32");
+    post_empty(UI_CMD_INPUT_SET_PULSE);
+    post_host_port(UI_CMD_UDP_INPUT_CFG, "0.0.0.0", 7355);
+    post_empty(UI_CMD_M17_TX_TOGGLE);
+    post_empty(UI_CMD_PROVOICE_ESK_TOGGLE);
+    post_empty(UI_CMD_PROVOICE_MODE_TOGGLE);
+    post_empty(UI_CMD_LRRP_DISABLE);
+    post_empty(UI_CMD_DMR_RESET);
+
+    rc |= expect_int("io/legacy commands applied", ui_drain_cmds(&opts, &state), 38);
+    rc |= expect_str("udp input selected", opts.audio_in_dev, "udp");
+    rc |= expect_int("udp input type", opts.audio_in_type, AUDIO_IN_UDP);
+    rc |= expect_str("udp bind copied", opts.udp_in_bindaddr, "0.0.0.0");
+    rc |= expect_int("udp port copied", opts.udp_in_portno, 7355);
+    rc |= expect_int("compact toggled", opts.ncurses_compact, 1);
+    rc |= expect_int("slot1 disabled", opts.slot1_on, 0);
+    rc |= expect_int("slot2 disabled", opts.slot2_on, 0);
+    rc |= expect_int("slot preference cycled", opts.slot_preference, 1);
+    rc |= expect_int("payload toggled", opts.payload, 1);
+    rc |= expect_int("p25 ga toggled", opts.show_p25_group_affiliations, 1);
+    rc |= expect_int("lpf toggled", opts.use_lpf, 1);
+    rc |= expect_int("hpf toggled", opts.use_hpf, 1);
+    rc |= expect_int("pbf toggled", opts.use_pbf, 1);
+    rc |= expect_int("hpf-d toggled", opts.use_hpf_d, 1);
+    rc |= expect_int("aggressive sync toggled twice", opts.aggressive_framesync, 0);
+    rc |= expect_int("call alert disabled by empty event mask", opts.call_alert, 0);
+    rc |= expect_int("call alert events masked to zero", opts.call_alert_events, 0);
+    rc |= expect_int("lcw retune toggled", opts.p25_lcw_retune, 1);
+    rc |= expect_int("candidate preference toggled", opts.p25_prefer_candidates, 1);
+    rc |= expect_int("x2 inverted", opts.inverted_x2tdma, 1);
+    rc |= expect_int("dmr inverted", opts.inverted_dmr, 1);
+    rc |= expect_int("dpmr inverted", opts.inverted_dpmr, 1);
+    rc |= expect_int("m17 inverted", opts.inverted_m17, 1);
+    rc |= expect_int("constellation toggled", opts.constellation, 1);
+    rc |= expect_int("constellation normalization toggled", opts.const_norm_mode, 1);
+    rc |= expect_true("constellation gate clamped", opts.const_gate_other > 0.89f && opts.const_gate_other <= 0.90f);
+    rc |= expect_int("eye toggled", opts.eye_view, 1);
+    rc |= expect_int("eye unicode toggled", opts.eye_unicode, 1);
+    rc |= expect_int("eye color toggled", opts.eye_color, 1);
+    rc |= expect_int("fsk histogram toggled", opts.fsk_hist_view, 1);
+    rc |= expect_int("spectrum toggled", opts.spectrum_view, 1);
+    rc |= expect_int("m17 tx toggled", state.m17encoder_tx, 1);
+    rc |= expect_int("provoice esk toggled", state.esk_mask, 0xA0);
+    rc |= expect_int("provoice mode toggled", state.ea_mode, 1);
+    rc |= expect_int("lrrp disabled", opts.lrrp_file_output, 0);
+    rc |= expect_int("dmr reset rest channel", state.dmr_rest_channel, -1);
+    rc |= expect_int("dmr reset mfid", state.dmr_mfid, -1);
+
+    post_empty(UI_CMD_FORCE_PRIV_TOGGLE);
+    post_empty(UI_CMD_FORCE_PRIV_TOGGLE);
+    post_empty(UI_CMD_FORCE_RC4_TOGGLE);
+    post_empty(UI_CMD_SLOT1_TOGGLE);
+    post_empty(UI_CMD_SLOT2_TOGGLE);
+    post_empty(UI_CMD_SLOT_PREF_CYCLE);
+    post_empty(UI_CMD_SLOT_PREF_CYCLE);
+    post_empty(UI_CMD_M17_TX_TOGGLE);
+    post_empty(UI_CMD_PROVOICE_ESK_TOGGLE);
+    post_empty(UI_CMD_PROVOICE_MODE_TOGGLE);
+    rc |= expect_int("second legacy command group applied", ui_drain_cmds(&opts, &state), 10);
+    rc |= expect_int("force rc4 selected", state.M, 0x21);
+    rc |= expect_int("slot1 re-enabled", opts.slot1_on, 1);
+    rc |= expect_int("slot2 re-enabled", opts.slot2_on, 1);
+    rc |= expect_int("slot preference wrapped", opts.slot_preference, 0);
+    rc |= expect_int("m17 tx toggled off sets eot", state.m17encoder_tx, 0);
+    rc |= expect_int("m17 tx eot set", state.m17encoder_eot, 1);
+    rc |= expect_int("provoice esk toggled back", state.esk_mask, 0);
+    rc |= expect_int("provoice mode toggled back", state.ea_mode, 0);
+
+    freeState(&state);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_visibility_and_queue_overflow();
+    rc |= test_key_and_runtime_state_commands();
+    rc |= test_file_network_and_import_commands();
+    rc |= test_io_and_legacy_state_commands();
+    if (rc == 0) {
+        printf("UI_CMD_QUEUE: OK\n");
+    }
+    return rc;
+}

--- a/tests/ui/test_ui_hotkeys_regression.c
+++ b/tests/ui/test_ui_hotkeys_regression.c
@@ -45,6 +45,7 @@ static int g_history_cycle_calls = 0;
 static int g_menu_open = 0;
 static int g_menu_handle_key_calls = 0;
 static int g_menu_last_key = ERR;
+static int g_menu_open_async_calls = 0;
 
 int
 ui_post_cmd(int cmd_id, const void* payload, size_t payload_sz) { // NOLINT(misc-use-internal-linkage)
@@ -105,6 +106,7 @@ void
 ui_menu_open_async(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
     (void)opts;
     (void)state;
+    g_menu_open_async_calls++;
 }
 
 WINDOW* stdscr = NULL;
@@ -129,11 +131,26 @@ cap_reset(void) {
     g_menu_open = 0;
     g_menu_handle_key_calls = 0;
     g_menu_last_key = ERR;
+    g_menu_open_async_calls = 0;
 }
 
 static uint32_t
 cap_u32(void) {
     uint32_t v = 0;
+    DSD_MEMCPY(&v, g_cap.data, sizeof(v));
+    return v;
+}
+
+static int32_t
+cap_i32(void) {
+    int32_t v = 0;
+    DSD_MEMCPY(&v, g_cap.data, sizeof(v));
+    return v;
+}
+
+static float
+cap_f32(void) {
+    float v = 0.0f;
     DSD_MEMCPY(&v, g_cap.data, sizeof(v));
     return v;
 }
@@ -149,6 +166,13 @@ main(void) {
         return 1;
     }
 
+    /* Null inputs are treated as consumed and do not enqueue commands. */
+    cap_reset();
+    assert(ncurses_input_handler(NULL, state, DSD_KEY_MUTE_LOWER) == 1);
+    assert(g_cap.calls == 0);
+    assert(ncurses_input_handler(opts, NULL, DSD_KEY_MUTE_LOWER) == 1);
+    assert(g_cap.calls == 0);
+
     /* Open menu overlay should receive keys before hotkeys and keep input consumed. */
     cap_reset();
     g_menu_open = 1;
@@ -157,6 +181,19 @@ main(void) {
     assert(g_menu_last_key == DSD_KEY_HISTORY);
     assert(g_history_cycle_calls == 0);
     assert(g_cap.calls == 0);
+
+    /* Open menu overlay should ignore no-key polls without dispatching. */
+    cap_reset();
+    g_menu_open = 1;
+    assert(ncurses_input_handler(opts, state, -1) == 1);
+    assert(g_menu_handle_key_calls == 0);
+    assert(g_cap.calls == 0);
+
+    /* Escape drains pending bytes and consumes the key without queueing. */
+    cap_reset();
+    assert(ncurses_input_handler(opts, state, DSD_KEY_ESC) == 1);
+    assert(g_cap.calls == 0);
+    assert(g_history_cycle_calls == 0);
 
     /* 'h' must cycle immediately in UI thread (no command queue dependency). */
     cap_reset();
@@ -171,6 +208,29 @@ main(void) {
     assert(g_cap.calls == 0);
     assert(g_history_cycle_calls == 2);
     assert(g_redraw_calls == 2);
+
+    /* Delta hotkeys should post signed/floating payloads immediately. */
+    cap_reset();
+    assert(ncurses_input_handler(opts, state, DSD_KEY_GAIN_PLUS) == 1);
+    assert(g_cap.id == UI_CMD_GAIN_DELTA);
+    assert(g_cap.n == sizeof(int32_t));
+    assert(cap_i32() == 1);
+
+    cap_reset();
+    assert(ncurses_input_handler(opts, state, DSD_KEY_AGAIN_MINUS) == 1);
+    assert(g_cap.id == UI_CMD_AGAIN_DELTA);
+    assert(cap_i32() == -1);
+
+    cap_reset();
+    assert(ncurses_input_handler(opts, state, DSD_KEY_CONST_GATE_DEC) == 1);
+    assert(g_cap.id == UI_CMD_CONST_GATE_DELTA);
+    assert(g_cap.n == sizeof(float));
+    assert(cap_f32() < -0.019f && cap_f32() > -0.021f);
+
+    cap_reset();
+    assert(ncurses_input_handler(opts, state, DSD_KEY_PPM_DOWN) == 1);
+    assert(g_cap.id == UI_CMD_PPM_DELTA);
+    assert(cap_i32() == -1);
 
     /* 'k' should set hold from slot-1 TG when no hold is active. */
     cap_reset();
@@ -244,6 +304,50 @@ main(void) {
     assert(g_cap.calls == 1);
     assert(g_cap.id == UI_CMD_TRUNK_ENC_TOGGLE);
     assert(g_cap.n == 0);
+
+    /* Enter opens the menu only when the M17 encoder is not active. */
+    cap_reset();
+    opts->m17encoder = 0;
+    assert(ncurses_input_handler(opts, state, DSD_KEY_ENTER) == 1);
+    assert(g_menu_open_async_calls == 1);
+    assert(g_cap.calls == 0);
+
+    cap_reset();
+    opts->m17encoder = 1;
+    assert(ncurses_input_handler(opts, state, DSD_KEY_ENTER) == 1);
+    assert(g_menu_open_async_calls == 0);
+    assert(g_cap.calls == 0);
+
+    /* Event-history toggle key is repurposed for M17 TX while encoder mode is active. */
+    cap_reset();
+    opts->m17encoder = 0;
+    assert(ncurses_input_handler(opts, state, DSD_KEY_EH_TOGGLE) == 1);
+    assert(g_cap.id == UI_CMD_EH_TOGGLE_SLOT);
+    assert(g_cap.n == 0);
+
+    cap_reset();
+    opts->m17encoder = 1;
+    assert(ncurses_input_handler(opts, state, DSD_KEY_EH_TOGGLE) == 1);
+    assert(g_cap.id == UI_CMD_M17_TX_TOGGLE);
+    assert(g_cap.n == 0);
+
+    /* Slot lockout hotkeys should carry the exact slot index. */
+    cap_reset();
+    assert(ncurses_input_handler(opts, state, '!') == 1);
+    assert(g_cap.id == UI_CMD_LOCKOUT_SLOT);
+    assert(g_cap.n == sizeof(uint8_t));
+    assert(g_cap.data[0] == 0U);
+
+    cap_reset();
+    assert(ncurses_input_handler(opts, state, '@') == 1);
+    assert(g_cap.id == UI_CMD_LOCKOUT_SLOT);
+    assert(g_cap.n == sizeof(uint8_t));
+    assert(g_cap.data[0] == 1U);
+
+    /* Unknown keys are still consumed but do not enqueue command work. */
+    cap_reset();
+    assert(ncurses_input_handler(opts, state, '~') == 1);
+    assert(g_cap.calls == 0);
 
     printf("UI_HOTKEYS_REGRESSION: OK\n");
     free(state);

--- a/tests/ui/test_ui_menu_actions.c
+++ b/tests/ui/test_ui_menu_actions.c
@@ -1,0 +1,1440 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Deterministic contracts for terminal UI menu action handlers.
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/platform/audio.h>
+#include <dsd-neo/platform/platform.h>
+#include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/runtime/call_alert.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/exitflag.h>
+#include <dsd-neo/ui/ui_async.h>
+#include <dsd-neo/ui/ui_cmd.h>
+#include <sndfile.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/ui/menu_core.h"
+#include "menu_actions.h"
+#include "menu_callbacks.h"
+#include "menu_env.h"
+#include "menu_internal.h"
+#include "menu_prompts.h"
+
+typedef struct {
+    int id;
+    size_t n;
+    uint8_t data[UI_CMD_DATA_MAX];
+    int calls;
+} CmdCapture;
+
+typedef struct {
+    char title[128];
+    char prefill[256];
+    size_t cap;
+    int initial_int;
+    double initial_double;
+    void* user;
+    ui_prompt_string_done_fn str_cb;
+    ui_prompt_int_done_fn int_cb;
+    ui_prompt_double_done_fn double_cb;
+    int calls;
+} PromptCapture;
+
+typedef struct {
+    char title[128];
+    const char* labels[32];
+    int n;
+    void* user;
+    void (*on_done)(void*, int);
+    int calls;
+} ChooserCapture;
+
+static CmdCapture g_cmd;
+static PromptCapture g_prompt;
+static ChooserCapture g_chooser;
+static char g_status[256];
+static int g_status_calls;
+static dsdneoRuntimeConfig g_cfg;
+static int g_cfg_valid = 1;
+static const char* g_default_config_path = "/tmp/default.toml";
+static int g_save_atomic_rc;
+static int g_snapshot_calls;
+static int g_list_profiles_rc;
+static char g_env_name[128];
+static char g_env_value[128];
+static int g_env_set_calls;
+static int g_env_int_value = 77;
+static double g_env_double_value = 12.5;
+static int g_reparse_calls;
+static int g_audio_enum_rc;
+static dsd_audio_device g_audio_inputs[2];
+static dsd_audio_device g_audio_outputs[2];
+
+volatile uint8_t exitflag;
+
+static void
+reset_capture(void) {
+    DSD_MEMSET(&g_cmd, 0, sizeof g_cmd);
+    DSD_MEMSET(&g_prompt, 0, sizeof g_prompt);
+    DSD_MEMSET(&g_chooser, 0, sizeof g_chooser);
+    DSD_MEMSET(g_status, 0, sizeof g_status);
+    g_status_calls = 0;
+    DSD_MEMSET(&g_cfg, 0, sizeof g_cfg);
+    g_cfg_valid = 1;
+    g_default_config_path = "/tmp/default.toml";
+    g_save_atomic_rc = 0;
+    g_snapshot_calls = 0;
+    g_list_profiles_rc = 0;
+    DSD_MEMSET(g_env_name, 0, sizeof g_env_name);
+    DSD_MEMSET(g_env_value, 0, sizeof g_env_value);
+    g_env_set_calls = 0;
+    g_env_int_value = 77;
+    g_env_double_value = 12.5;
+    g_reparse_calls = 0;
+    g_audio_enum_rc = 0;
+    DSD_MEMSET(g_audio_inputs, 0, sizeof g_audio_inputs);
+    DSD_MEMSET(g_audio_outputs, 0, sizeof g_audio_outputs);
+    exitflag = 0;
+}
+
+static void
+release_prompt_user(void) {
+    free(g_prompt.user);
+    g_prompt.user = NULL;
+}
+
+static UiCtx
+make_ctx(dsd_opts* opts, dsd_state* state) {
+    UiCtx ctx;
+    ctx.opts = opts;
+    ctx.state = state;
+    return ctx;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_str(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int32_t
+cmd_i32(void) {
+    int32_t v = 0;
+    assert(g_cmd.n >= sizeof v);
+    DSD_MEMCPY(&v, g_cmd.data, sizeof v);
+    return v;
+}
+
+static void
+free_profile_ctx(ProfileSelCtx* pctx) {
+    if (!pctx) {
+        return;
+    }
+    if (pctx->names) {
+        for (int i = 0; i < pctx->n; i++) {
+            free((void*)pctx->names[i]);
+        }
+    }
+    free((void*)pctx->labels);
+    free((void*)pctx->names);
+    free(pctx);
+}
+
+static void
+free_pulse_ctx(PulseSelCtx* pctx) {
+    if (!pctx) {
+        return;
+    }
+    if (pctx->names) {
+        for (int i = 0; i < pctx->n; i++) {
+            free((void*)pctx->names[i]);
+        }
+    }
+    if (pctx->bufs) {
+        for (int i = 0; i < pctx->n; i++) {
+            free(pctx->bufs[i]);
+        }
+    }
+    free((void*)pctx->labels);
+    free((void*)pctx->names);
+    free((void*)pctx->bufs);
+    free(pctx);
+}
+
+int
+ui_post_cmd(int cmd_id, const void* payload, size_t payload_sz) {
+    g_cmd.id = cmd_id;
+    g_cmd.n = payload_sz;
+    if (payload_sz > sizeof(g_cmd.data)) {
+        payload_sz = sizeof(g_cmd.data);
+    }
+    DSD_MEMSET(g_cmd.data, 0, sizeof g_cmd.data);
+    if (payload && payload_sz > 0) {
+        DSD_MEMCPY(g_cmd.data, payload, payload_sz);
+    }
+    g_cmd.calls++;
+    return 0;
+}
+
+void ui_statusf(const char* fmt, ...) DSD_ATTR_FORMAT(printf, 1, 2);
+
+void
+ui_statusf(const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    (void)DSD_VSNPRINTF(g_status, sizeof g_status, fmt, ap);
+    va_end(ap);
+    g_status_calls++;
+}
+
+void
+ui_prompt_open_string_async_impl(const char* title, const char* prefill, size_t cap, void* user,
+                                 ui_prompt_string_done_fn on_done) {
+    DSD_SNPRINTF(g_prompt.title, sizeof g_prompt.title, "%s", title ? title : "");
+    DSD_SNPRINTF(g_prompt.prefill, sizeof g_prompt.prefill, "%s", prefill ? prefill : "");
+    g_prompt.cap = cap;
+    g_prompt.user = user;
+    g_prompt.str_cb = on_done;
+    g_prompt.int_cb = NULL;
+    g_prompt.double_cb = NULL;
+    g_prompt.calls++;
+}
+
+void
+ui_prompt_open_int_async_impl(const char* title, int initial, void* user, ui_prompt_int_done_fn cb) {
+    DSD_SNPRINTF(g_prompt.title, sizeof g_prompt.title, "%s", title ? title : "");
+    g_prompt.initial_int = initial;
+    g_prompt.user = user;
+    g_prompt.str_cb = NULL;
+    g_prompt.int_cb = cb;
+    g_prompt.double_cb = NULL;
+    g_prompt.calls++;
+}
+
+void
+ui_prompt_open_double_async_impl(const char* title, double initial, void* user, ui_prompt_double_done_fn cb) {
+    DSD_SNPRINTF(g_prompt.title, sizeof g_prompt.title, "%s", title ? title : "");
+    g_prompt.initial_double = initial;
+    g_prompt.user = user;
+    g_prompt.str_cb = NULL;
+    g_prompt.int_cb = NULL;
+    g_prompt.double_cb = cb;
+    g_prompt.calls++;
+}
+
+void
+ui_chooser_start_impl(const char* title, const char* const* items, int count, void* user, void (*on_done)(void*, int)) {
+    DSD_SNPRINTF(g_chooser.title, sizeof g_chooser.title, "%s", title ? title : "");
+    g_chooser.n = count;
+    for (int i = 0; i < count && i < (int)(sizeof g_chooser.labels / sizeof g_chooser.labels[0]); i++) {
+        g_chooser.labels[i] = items[i];
+    }
+    g_chooser.user = user;
+    g_chooser.on_done = on_done;
+    g_chooser.calls++;
+}
+
+const dsdneoRuntimeConfig*
+dsd_neo_get_config(void) {
+    return g_cfg_valid ? &g_cfg : NULL;
+}
+
+const char*
+dsd_user_config_default_path(void) {
+    return g_default_config_path;
+}
+
+int
+dsd_user_config_save_atomic(const char* path, const dsdneoUserConfig* cfg) {
+    (void)path;
+    (void)cfg;
+    return g_save_atomic_rc;
+}
+
+void
+dsd_snapshot_opts_to_user_config(const dsd_opts* opts, const dsd_state* state, dsdneoUserConfig* cfg) {
+    (void)opts;
+    (void)state;
+    if (cfg) {
+        DSD_MEMSET(cfg, 0, sizeof *cfg);
+    }
+    g_snapshot_calls++;
+}
+
+int
+dsd_user_config_list_profiles(const char* path, const char** names, char* names_buf, size_t names_buf_size,
+                              int max_names) {
+    (void)path;
+    if (g_list_profiles_rc <= 0) {
+        return g_list_profiles_rc;
+    }
+    assert(names_buf_size >= 16);
+    assert(max_names >= 2);
+    DSD_SNPRINTF(names_buf, names_buf_size, "base");
+    DSD_SNPRINTF(names_buf + 8, names_buf_size - 8, "mobile");
+    names[0] = names_buf;
+    names[1] = names_buf + 8;
+    return 2;
+}
+
+int
+dsd_setenv(const char* name, const char* value, int overwrite) {
+    (void)overwrite;
+    DSD_SNPRINTF(g_env_name, sizeof g_env_name, "%s", name ? name : "");
+    DSD_SNPRINTF(g_env_value, sizeof g_env_value, "%s", value ? value : "");
+    g_env_set_calls++;
+    return 0;
+}
+
+int
+env_get_int(const char* name, int defv) {
+    (void)name;
+    (void)defv;
+    return g_env_int_value;
+}
+
+double
+env_get_double(const char* name, double defv) {
+    (void)name;
+    (void)defv;
+    return g_env_double_value;
+}
+
+void
+env_reparse_runtime_cfg(dsd_opts* opts) {
+    (void)opts;
+    g_reparse_calls++;
+}
+
+int
+dsd_audio_enumerate_devices(dsd_audio_device* inputs, dsd_audio_device* outputs, int max_count) {
+    if (g_audio_enum_rc < 0) {
+        return g_audio_enum_rc;
+    }
+    if (max_count > 0) {
+        inputs[0] = g_audio_inputs[0];
+        outputs[0] = g_audio_outputs[0];
+    }
+    if (max_count > 1) {
+        inputs[1] = g_audio_inputs[1];
+        outputs[1] = g_audio_outputs[1];
+    }
+    return 0;
+}
+
+void
+cb_event_log_set(void* v, const char* path) {
+    (void)v;
+    (void)path;
+}
+
+void
+cb_static_wav(void* v, const char* path) {
+    (void)v;
+    (void)path;
+}
+
+void
+cb_raw_wav(void* v, const char* path) {
+    (void)v;
+    (void)path;
+}
+
+void
+cb_dsp_out(void* v, const char* name) {
+    (void)v;
+    (void)name;
+}
+
+void
+cb_config_load(void* v, const char* path) {
+    (void)v;
+    (void)path;
+}
+
+void
+cb_config_save_as(void* v, const char* path) {
+    (void)v;
+    (void)path;
+}
+
+void
+chooser_done_config_profile(void* u, int sel) {
+    (void)u;
+    (void)sel;
+}
+
+void
+cb_setmod_bw(void* v, int ok, int bw) {
+    (void)v;
+    (void)ok;
+    (void)bw;
+}
+
+void
+cb_import_chan(void* v, const char* p) {
+    (void)v;
+    (void)p;
+}
+
+void
+cb_import_group(void* v, const char* p) {
+    (void)v;
+    (void)p;
+}
+
+void
+cb_tg_hold(void* v, int ok, int tg) {
+    (void)v;
+    (void)ok;
+    (void)tg;
+}
+
+void
+cb_hangtime(void* v, int ok, double s) {
+    (void)v;
+    (void)ok;
+    (void)s;
+}
+
+void
+cb_slot_pref(void* v, int ok, int p) {
+    (void)v;
+    (void)ok;
+    (void)p;
+}
+
+void
+cb_slots_on(void* v, int ok, int m) {
+    (void)v;
+    (void)ok;
+    (void)m;
+}
+
+void
+cb_keys_dec(void* v, const char* p) {
+    (void)v;
+    (void)p;
+}
+
+void
+cb_keys_hex(void* v, const char* p) {
+    (void)v;
+    (void)p;
+}
+
+void
+cb_tyt_ap(void* v, const char* s) {
+    (void)v;
+    (void)s;
+}
+
+void
+cb_retevis_rc2(void* v, const char* s) {
+    (void)v;
+    (void)s;
+}
+
+void
+cb_tyt_ep(void* v, const char* s) {
+    (void)v;
+    (void)s;
+}
+
+void
+cb_ken_scr(void* v, const char* s) {
+    (void)v;
+    (void)s;
+}
+
+void
+cb_anytone_bp(void* v, const char* s) {
+    (void)v;
+    (void)s;
+}
+
+void
+cb_xor_ks(void* v, const char* s) {
+    (void)v;
+    (void)s;
+}
+
+void
+cb_p2_step(void* u, const char* text) {
+    (void)u;
+    (void)text;
+}
+
+void
+cb_input_warn(void* v, int ok, double thr) {
+    (void)v;
+    (void)ok;
+    (void)thr;
+}
+
+void
+cb_audio_lpf(void* v, int ok, int hz) {
+    (void)v;
+    (void)ok;
+    (void)hz;
+}
+
+void
+cb_env_edit_name(void* u, const char* name) {
+    (void)u;
+    (void)name;
+}
+
+void
+cb_auto_ppm_snr(void* v, int ok, double d) {
+    (void)v;
+    (void)ok;
+    (void)d;
+}
+
+void
+cb_auto_ppm_pwr(void* v, int ok, double d) {
+    (void)v;
+    (void)ok;
+    (void)d;
+}
+
+void
+cb_auto_ppm_zeroppm(void* v, int ok, double p) {
+    (void)v;
+    (void)ok;
+    (void)p;
+}
+
+void
+cb_auto_ppm_zerohz(void* v, int ok, int h) {
+    (void)v;
+    (void)ok;
+    (void)h;
+}
+
+void
+cb_tcp_prebuf(void* v, int ok, int ms) {
+    (void)v;
+    (void)ok;
+    (void)ms;
+}
+
+void
+cb_tcp_rcvbuf(void* v, int ok, int sz) {
+    (void)v;
+    (void)ok;
+    (void)sz;
+}
+
+void
+cb_tcp_rcvtimeo(void* v, int ok, int ms) {
+    (void)v;
+    (void)ok;
+    (void)ms;
+}
+
+void
+cb_io_save_symbol_capture(void* v, const char* path) {
+    (void)v;
+    (void)path;
+}
+
+void
+cb_io_read_symbol_bin(void* v, const char* path) {
+    (void)v;
+    (void)path;
+}
+
+void
+chooser_done_pulse_out(void* u, int sel) {
+    (void)u;
+    (void)sel;
+}
+
+void
+chooser_done_pulse_in(void* u, int sel) {
+    (void)u;
+    (void)sel;
+}
+
+void
+cb_udp_out_host(void* u, const char* host) {
+    (void)u;
+    (void)host;
+}
+
+void
+cb_tcp_host(void* u, const char* host) {
+    (void)u;
+    (void)host;
+}
+
+void
+cb_gain_dig(void* u, int ok, double g) {
+    (void)u;
+    (void)ok;
+    (void)g;
+}
+
+void
+cb_gain_ana(void* u, int ok, double g) {
+    (void)u;
+    (void)ok;
+    (void)g;
+}
+
+void
+cb_input_vol(void* u, int ok, int m) {
+    (void)u;
+    (void)ok;
+    (void)m;
+}
+
+void
+cb_rig_host(void* u, const char* host) {
+    (void)u;
+    (void)host;
+}
+
+void
+cb_switch_to_wav(void* v, const char* path) {
+    (void)v;
+    (void)path;
+}
+
+void
+cb_switch_to_symbol(void* v, const char* path) {
+    (void)v;
+    (void)path;
+}
+
+void
+cb_udp_in_addr(void* u, const char* addr) {
+    (void)u;
+    (void)addr;
+}
+
+void
+cb_key_basic(void* v, int ok, int val) {
+    (void)v;
+    (void)ok;
+    (void)val;
+}
+
+void
+cb_hytera_step(void* u, const char* text) {
+    (void)u;
+    (void)text;
+}
+
+void
+cb_key_scrambler(void* v, int ok, int val) {
+    (void)v;
+    (void)ok;
+    (void)val;
+}
+
+void
+cb_key_rc4des(void* v, const char* text) {
+    (void)v;
+    (void)text;
+}
+
+void
+cb_aes_step(void* u, const char* text) {
+    (void)u;
+    (void)text;
+}
+
+void
+cb_lr_custom(void* v, const char* path) {
+    (void)v;
+    (void)path;
+}
+
+void
+cb_m17_user_data(void* u, const char* text) {
+    (void)u;
+    (void)text;
+}
+
+void
+cb_set_p25_num(void* u, int ok, double val) {
+    (void)u;
+    (void)ok;
+    (void)val;
+}
+
+static int
+test_simple_commands_and_prompts(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_SNPRINTF(opts.event_out_file, sizeof opts.event_out_file, "events.log");
+    DSD_SNPRINTF(opts.wav_out_file, sizeof opts.wav_out_file, "static.wav");
+    DSD_SNPRINTF(opts.dsp_out_file, sizeof opts.dsp_out_file, "dsp");
+    opts.setmod_bw = 12500;
+    opts.slot_preference = 1;
+    opts.slot1_on = 1;
+    state.tg_hold = 1234;
+    UiCtx ctx = make_ctx(&opts, &state);
+
+    reset_capture();
+    act_toggle_invert(NULL);
+    rc |= expect_int("invert command", g_cmd.id, UI_CMD_INVERT_TOGGLE);
+    act_exit(NULL);
+    rc |= expect_int("exit flag", exitflag, 1);
+
+    reset_capture();
+    act_event_log_set(&ctx);
+    rc |= expect_str("event prompt title", g_prompt.title, "Event log filename");
+    rc |= expect_str("event prompt prefill", g_prompt.prefill, "events.log");
+    rc |= expect_int("event prompt cap", (int)g_prompt.cap, 1024);
+
+    reset_capture();
+    act_static_wav(&ctx);
+    rc |= expect_str("static wav prompt", g_prompt.prefill, "static.wav");
+
+    reset_capture();
+    act_dsp_out(&ctx);
+    rc |= expect_str("dsp prompt", g_prompt.prefill, "dsp");
+    rc |= expect_int("dsp prompt cap", (int)g_prompt.cap, 256);
+
+    reset_capture();
+    act_setmod_bw(&ctx);
+    rc |= expect_str("setmod prompt", g_prompt.title, "Setmod BW (Hz)");
+    rc |= expect_int("setmod initial", g_prompt.initial_int, 12500);
+
+    reset_capture();
+    act_tg_hold(&ctx);
+    rc |= expect_int("tg hold initial", g_prompt.initial_int, 1234);
+
+    reset_capture();
+    act_slot_pref(&ctx);
+    rc |= expect_int("slot pref initial", g_prompt.initial_int, 2);
+
+    reset_capture();
+    act_slots_on(&ctx);
+    rc |= expect_int("slot mask initial", g_prompt.initial_int, 1);
+
+    return rc;
+}
+
+static int
+test_config_profile_and_env_actions(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    UiCtx ctx = make_ctx(&opts, &state);
+
+    reset_capture();
+    DSD_SNPRINTF(state.config_autosave_path, sizeof state.config_autosave_path, "/tmp/current.toml");
+    act_config_load(&ctx);
+    rc |= expect_str("config load uses autosave", g_prompt.prefill, "/tmp/current.toml");
+
+    reset_capture();
+    act_config_save_current(&ctx);
+    rc |= expect_int("save current snapshots", g_snapshot_calls, 1);
+    rc |= expect_str("save current status", g_status, "Config saved to /tmp/current.toml");
+
+    reset_capture();
+    g_list_profiles_rc = 2;
+    act_config_load_profile(&ctx);
+    rc |= expect_str("profile chooser title", g_chooser.title, "Load Profile");
+    rc |= expect_int("profile chooser count", g_chooser.n, 2);
+    rc |= expect_str("profile label zero", g_chooser.labels[0], "base");
+    free_profile_ctx((ProfileSelCtx*)g_chooser.user);
+
+    reset_capture();
+    g_cfg.deemph_mode = DSD_NEO_DEEMPH_OFF;
+    act_deemph_cycle(&ctx);
+    rc |= expect_str("deemph env", g_env_name, "DSD_NEO_DEEMPH");
+    rc |= expect_str("deemph value", g_env_value, "50");
+    rc |= expect_int("deemph reparse", g_reparse_calls, 1);
+
+    reset_capture();
+    opts.audio_in_type = AUDIO_IN_RTL;
+    g_cfg.tcp_waitall_enable = 1;
+    act_tcp_waitall(&ctx);
+    rc |= expect_str("tcp waitall env", g_env_name, "DSD_NEO_TCP_WAITALL");
+    rc |= expect_str("tcp waitall value", g_env_value, "0");
+    rc |= expect_int("tcp waitall restart", g_cmd.id, UI_CMD_RTL_RESTART);
+
+    reset_capture();
+    act_auto_ppm_zerohz_prompt(&ctx);
+    rc |= expect_int("auto ppm hz initial", g_prompt.initial_int, 77);
+    rc |= expect_str("auto ppm hz title", g_prompt.title, "Auto-PPM zero-lock Hz");
+
+    reset_capture();
+    act_set_p25_min_follow(&ctx);
+    rc |= expect_str("p25 prompt title", g_prompt.title, "P25: Min follow dwell (s)");
+    rc |= expect_int("p25 prompt initial", g_prompt.initial_double == 12.5, 1);
+    free(g_prompt.user);
+
+    return rc;
+}
+
+static int
+test_io_actions_and_choosers(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_SNPRINTF(opts.udp_hostname, sizeof opts.udp_hostname, "239.1.2.3");
+    DSD_SNPRINTF(opts.tcp_hostname, sizeof opts.tcp_hostname, "tcp.local");
+    DSD_SNPRINTF(opts.rigctlhostname, sizeof opts.rigctlhostname, "rig.local");
+    DSD_SNPRINTF(opts.pa_output_idx, sizeof opts.pa_output_idx, "pulse0");
+    opts.input_volume_multiplier = 16;
+    UiCtx ctx = make_ctx(&opts, &state);
+
+    reset_capture();
+    io_select_call_alert_events(&ctx);
+    rc |= expect_str("call alert chooser", g_chooser.title, "Call Alert Events");
+    rc |= expect_int("call alert choice count", g_chooser.n, 8);
+    assert(g_chooser.on_done != NULL);
+    g_chooser.on_done(g_chooser.user, 7);
+    rc |= expect_int("call alert command", g_cmd.id, UI_CMD_CALL_ALERT_EVENTS_SET);
+    rc |= expect_int("call alert all mask", g_cmd.data[0], DSD_CALL_ALERT_EVENT_ALL);
+
+    reset_capture();
+    opts.dmr_stereo_wav = 0;
+    opts.wav_out_f = NULL;
+    io_enable_per_call_wav(&ctx);
+    rc |= expect_int("per-call wav start command", g_cmd.id, UI_CMD_WAV_START);
+    rc |= expect_int("per-call wav flag", opts.dmr_stereo_wav, 1);
+
+    reset_capture();
+    opts.wav_out_f = (SNDFILE*)0x1;
+    io_enable_per_call_wav(&ctx);
+    rc |= expect_int("per-call wav stop command", g_cmd.id, UI_CMD_WAV_STOP);
+    rc |= expect_int("per-call wav cleared", opts.dmr_stereo_wav, 0);
+
+    reset_capture();
+    g_audio_outputs[0].initialized = 1;
+    g_audio_outputs[0].index = 3;
+    DSD_SNPRINTF(g_audio_outputs[0].name, sizeof g_audio_outputs[0].name, "out0");
+    DSD_SNPRINTF(g_audio_outputs[0].description, sizeof g_audio_outputs[0].description, "Output Zero");
+    io_set_pulse_out(&ctx);
+    rc |= expect_str("pulse out chooser", g_chooser.title, "Select Pulse Output");
+    rc |= expect_int("pulse out count", g_chooser.n, 1);
+    rc |= expect_int("pulse out label has index", strstr(g_chooser.labels[0], "[3] out0") != NULL, 1);
+    free_pulse_ctx((PulseSelCtx*)g_chooser.user);
+
+    reset_capture();
+    io_set_udp_out(&ctx);
+    rc |= expect_str("udp out prompt prefill", g_prompt.prefill, "239.1.2.3");
+    release_prompt_user();
+
+    reset_capture();
+    io_tcp_direct_link(&ctx);
+    rc |= expect_str("tcp prompt prefill", g_prompt.prefill, "tcp.local");
+    release_prompt_user();
+
+    reset_capture();
+    io_rigctl_config(&ctx);
+    rc |= expect_str("rig prompt prefill", g_prompt.prefill, "rig.local");
+    release_prompt_user();
+
+    reset_capture();
+    io_input_vol_up(&ctx);
+    rc |= expect_int("input volume up capped", cmd_i32(), 16);
+
+    reset_capture();
+    io_input_vol_dn(&ctx);
+    rc |= expect_int("input volume down", cmd_i32(), 15);
+
+    reset_capture();
+    switch_out_pulse(&ctx);
+    rc |= expect_int("pulse out command", g_cmd.id, UI_CMD_PULSE_OUT_SET);
+    rc |= expect_str("pulse out payload", (const char*)g_cmd.data, "pulse0");
+
+    return rc;
+}
+
+static int
+test_key_lrrp_and_display_actions(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_SNPRINTF(state.m17dat, sizeof state.m17dat, "1,N0CALL,N1CALL");
+    state.p2_wacn = 0xABCDE;
+    UiCtx ctx = make_ctx(&opts, &state);
+
+    reset_capture();
+    key_basic(&ctx);
+    rc |= expect_str("basic key prompt", g_prompt.title, "Basic Privacy Key Number (DEC)");
+
+    reset_capture();
+    key_hytera(&ctx);
+    rc |= expect_str("hytera prompt", g_prompt.title, "Hytera Privacy Key 1 (HEX)");
+    release_prompt_user();
+
+    reset_capture();
+    key_aes(&ctx);
+    rc |= expect_str("aes prompt", g_prompt.title, "AES Segment 1 (HEX) or 0");
+    release_prompt_user();
+
+    reset_capture();
+    act_p2_params(&ctx);
+    rc |= expect_str("p2 prompt prefill", g_prompt.prefill, "ABCDE");
+    release_prompt_user();
+
+    reset_capture();
+    lr_home(&ctx);
+    rc |= expect_int("lrrp home command", g_cmd.id, UI_CMD_LRRP_SET_HOME);
+
+    reset_capture();
+    act_m17_user_data(&ctx);
+    rc |= expect_str("m17 prefill", g_prompt.prefill, "1,N0CALL,N1CALL");
+    release_prompt_user();
+
+    reset_capture();
+    act_toggle_ui_p25_neighbors(&ctx);
+    rc |= expect_int("ui neighbors command", g_cmd.id, UI_CMD_UI_SHOW_P25_NEIGHBORS_TOGGLE);
+
+    reset_capture();
+    act_toggle_ui_p25_metrics(&ctx);
+    rc |= expect_int("ui metrics command", g_cmd.id, UI_CMD_UI_SHOW_P25_METRICS_TOGGLE);
+
+    reset_capture();
+    act_toggle_ui_p25_affil(&ctx);
+    rc |= expect_int("ui affiliation command", g_cmd.id, UI_CMD_UI_SHOW_P25_AFFIL_TOGGLE);
+
+    reset_capture();
+    act_toggle_ui_p25_ga(&ctx);
+    rc |= expect_int("ui grant activity command", g_cmd.id, UI_CMD_P25_GA_TOGGLE);
+
+    reset_capture();
+    act_toggle_ui_p25_iden(&ctx);
+    rc |= expect_int("ui iden command", g_cmd.id, UI_CMD_UI_SHOW_P25_IDEN_TOGGLE);
+
+    reset_capture();
+    act_toggle_ui_p25_ccc(&ctx);
+    rc |= expect_int("ui ccc command", g_cmd.id, UI_CMD_UI_SHOW_P25_CCC_TOGGLE);
+
+    reset_capture();
+    act_toggle_ui_channels(&ctx);
+    rc |= expect_int("ui channels command", g_cmd.id, UI_CMD_UI_SHOW_CHANNELS_TOGGLE);
+
+    reset_capture();
+    act_toggle_ui_p25_callsign(&ctx);
+    rc |= expect_int("ui callsign command", g_cmd.id, UI_CMD_UI_SHOW_P25_CALLSIGN_TOGGLE);
+
+    reset_capture();
+    switch_to_pulse(&ctx);
+    rc |= expect_int("switch pulse command", g_cmd.id, UI_CMD_INPUT_SET_PULSE);
+
+    reset_capture();
+    switch_to_udp(&ctx);
+    rc |= expect_str("udp input default", g_prompt.prefill, "127.0.0.1");
+    release_prompt_user();
+
+    return rc;
+}
+
+static int
+test_additional_prompt_and_toggle_actions(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_SNPRINTF(opts.wav_out_file_raw, sizeof opts.wav_out_file_raw, "raw.wav");
+    opts.trunk_hangtime = 2.75;
+    opts.input_warn_db = -37.5;
+    UiCtx ctx = make_ctx(&opts, &state);
+
+    reset_capture();
+    act_toggle_payload(NULL);
+    rc |= expect_int("payload toggle command", g_cmd.id, UI_CMD_PAYLOAD_TOGGLE);
+
+    reset_capture();
+    act_reset_eh(NULL);
+    rc |= expect_int("event history reset command", g_cmd.id, UI_CMD_EH_RESET);
+
+    reset_capture();
+    act_event_log_disable(NULL);
+    rc |= expect_int("event log disable command", g_cmd.id, UI_CMD_EVENT_LOG_DISABLE);
+
+    reset_capture();
+    act_raw_wav(&ctx);
+    rc |= expect_str("raw wav prompt title", g_prompt.title, "Raw WAV filename");
+    rc |= expect_str("raw wav prompt prefill", g_prompt.prefill, "raw.wav");
+
+    reset_capture();
+    act_import_chan(&ctx);
+    rc |= expect_str("channel import prompt", g_prompt.title, "Channel map CSV");
+    rc |= expect_int("channel import cap", (int)g_prompt.cap, 1024);
+
+    reset_capture();
+    act_import_group(&ctx);
+    rc |= expect_str("group import prompt", g_prompt.title, "Group list CSV");
+
+    reset_capture();
+    act_keys_dec(&ctx);
+    rc |= expect_str("keys dec prompt", g_prompt.title, "Keys CSV (DEC)");
+
+    reset_capture();
+    act_keys_hex(&ctx);
+    rc |= expect_str("keys hex prompt", g_prompt.title, "Keys CSV (HEX)");
+
+    reset_capture();
+    act_tyt_ap(&ctx);
+    rc |= expect_str("tyt ap prompt", g_prompt.title, "TYT AP string");
+    rc |= expect_int("tyt ap cap", (int)g_prompt.cap, 256);
+
+    reset_capture();
+    act_retevis_rc2(&ctx);
+    rc |= expect_str("retevis prompt", g_prompt.title, "Retevis AP string");
+
+    reset_capture();
+    act_tyt_ep(&ctx);
+    rc |= expect_str("tyt ep prompt", g_prompt.title, "TYT EP string");
+
+    reset_capture();
+    act_ken_scr(&ctx);
+    rc |= expect_str("kenwood prompt", g_prompt.title, "Kenwood scrambler");
+
+    reset_capture();
+    act_anytone_bp(&ctx);
+    rc |= expect_str("anytone prompt", g_prompt.title, "Anytone BP");
+
+    reset_capture();
+    act_xor_ks(&ctx);
+    rc |= expect_str("xor prompt", g_prompt.title, "XOR keystream");
+
+    reset_capture();
+    act_hangtime(&ctx);
+    rc |= expect_str("hangtime prompt", g_prompt.title, "Hangtime seconds");
+    rc |= expect_int("hangtime initial", g_prompt.initial_double == 2.75, 1);
+
+    reset_capture();
+    act_config_save_as(&ctx);
+    rc |= expect_str("save as prompt", g_prompt.title, "Save config to path");
+    rc |= expect_str("save as default path", g_prompt.prefill, "/tmp/default.toml");
+    rc |= expect_int("save as prompt cap", (int)g_prompt.cap, 512);
+
+    reset_capture();
+    act_crc_relax(NULL);
+    rc |= expect_int("crc relax command", g_cmd.id, UI_CMD_CRC_RELAX_TOGGLE);
+
+    reset_capture();
+    act_trunk_toggle(NULL);
+    rc |= expect_int("trunk toggle command", g_cmd.id, UI_CMD_TRUNK_TOGGLE);
+    rc |= expect_str("trunk toggle status", g_status, "Trunking toggle requested...");
+
+    reset_capture();
+    act_scan_toggle(NULL);
+    rc |= expect_int("scanner toggle command", g_cmd.id, UI_CMD_SCANNER_TOGGLE);
+    rc |= expect_str("scanner toggle status", g_status, "Scanner toggle requested...");
+
+    reset_capture();
+    act_lcw_toggle(NULL);
+    rc |= expect_int("lcw toggle command", g_cmd.id, UI_CMD_LCW_RETUNE_TOGGLE);
+
+    reset_capture();
+    act_p25_enc_lockout(NULL);
+    rc |= expect_int("p25 enc lockout command", g_cmd.id, UI_CMD_TRUNK_ENC_TOGGLE);
+
+    reset_capture();
+    act_allow_toggle(NULL);
+    rc |= expect_int("allow toggle command", g_cmd.id, UI_CMD_TRUNK_WLIST_TOGGLE);
+
+    reset_capture();
+    act_tune_group(NULL);
+    rc |= expect_int("group tuning command", g_cmd.id, UI_CMD_TRUNK_GROUP_TOGGLE);
+
+    reset_capture();
+    act_tune_priv(NULL);
+    rc |= expect_int("private tuning command", g_cmd.id, UI_CMD_TRUNK_PRIV_TOGGLE);
+
+    reset_capture();
+    act_tune_data(NULL);
+    rc |= expect_int("data tuning command", g_cmd.id, UI_CMD_TRUNK_DATA_TOGGLE);
+
+    reset_capture();
+    act_rev_mute(NULL);
+    rc |= expect_int("reverse mute command", g_cmd.id, UI_CMD_REVERSE_MUTE_TOGGLE);
+
+    reset_capture();
+    act_dmr_le(NULL);
+    rc |= expect_int("dmr late entry command", g_cmd.id, UI_CMD_DMR_LE_TOGGLE);
+
+    reset_capture();
+    key_scrambler(&ctx);
+    rc |= expect_str("scrambler prompt", g_prompt.title, "NXDN/dPMR Scrambler Key (DEC)");
+
+    reset_capture();
+    key_force_bp(NULL);
+    rc |= expect_int("force basic privacy command", g_cmd.id, UI_CMD_FORCE_PRIV_TOGGLE);
+
+    reset_capture();
+    key_rc4des(&ctx);
+    rc |= expect_str("rc4des prompt", g_prompt.title, "RC4/DES Key (HEX)");
+    rc |= expect_int("rc4des prompt cap", (int)g_prompt.cap, 128);
+
+    reset_capture();
+    lr_dsdp(NULL);
+    rc |= expect_int("lrrp dsdp command", g_cmd.id, UI_CMD_LRRP_SET_DSDP);
+
+    reset_capture();
+    lr_custom(&ctx);
+    rc |= expect_str("lrrp custom prompt", g_prompt.title, "Enter LRRP output filename");
+
+    reset_capture();
+    lr_off(NULL);
+    rc |= expect_int("lrrp disable command", g_cmd.id, UI_CMD_LRRP_DISABLE);
+
+    reset_capture();
+    act_set_input_warn(&ctx);
+    rc |= expect_str("input warn prompt", g_prompt.title, "Low input warning threshold (dBFS)");
+    rc |= expect_int("input warn opts initial", g_prompt.initial_double == -37.5, 1);
+
+    reset_capture();
+    act_set_input_warn(NULL);
+    rc |= expect_int("input warn env fallback", g_prompt.initial_double == 12.5, 1);
+
+#if defined(__SSE__) || defined(__SSE2__)
+    reset_capture();
+    g_cfg.ftz_daz_enable = 0;
+    act_toggle_ftz_daz(&ctx);
+    rc |= expect_str("ftz env", g_env_name, "DSD_NEO_FTZ_DAZ");
+    rc |= expect_str("ftz value", g_env_value, "1");
+    rc |= expect_int("ftz reparse", g_reparse_calls, 1);
+#endif
+
+    reset_capture();
+    g_cfg.audio_lpf_is_set = 1;
+    g_cfg.audio_lpf_disable = 0;
+    g_cfg.audio_lpf_cutoff_hz = 3200;
+    act_set_audio_lpf(&ctx);
+    rc |= expect_str("audio lpf prompt", g_prompt.title, "Audio LPF cutoff Hz (0=off)");
+    rc |= expect_int("audio lpf initial", g_prompt.initial_int, 3200);
+
+    reset_capture();
+    g_cfg.audio_lpf_is_set = 1;
+    g_cfg.audio_lpf_disable = 1;
+    g_cfg.audio_lpf_cutoff_hz = 2800;
+    act_set_audio_lpf(&ctx);
+    rc |= expect_int("audio lpf disabled initial", g_prompt.initial_int, 0);
+
+    reset_capture();
+    act_window_freeze_toggle(&ctx);
+    rc |= expect_str("window freeze env", g_env_name, "DSD_NEO_WINDOW_FREEZE");
+    rc |= expect_str("window freeze value", g_env_value, "1");
+    rc |= expect_int("window freeze reparse", g_reparse_calls, 1);
+
+    reset_capture();
+    g_cfg.auto_ppm_freeze_enable = 1;
+    act_auto_ppm_freeze(&ctx);
+    rc |= expect_str("auto ppm freeze env", g_env_name, "DSD_NEO_AUTO_PPM_FREEZE");
+    rc |= expect_str("auto ppm freeze value", g_env_value, "0");
+
+    reset_capture();
+    act_auto_ppm_snr_prompt(&ctx);
+    rc |= expect_str("auto ppm snr title", g_prompt.title, "Auto-PPM SNR threshold (dB)");
+    rc |= expect_int("auto ppm snr initial", g_prompt.initial_double == 12.5, 1);
+
+    reset_capture();
+    act_auto_ppm_pwr_prompt(&ctx);
+    rc |= expect_str("auto ppm power title", g_prompt.title, "Auto-PPM min power (dB)");
+    rc |= expect_int("auto ppm power initial", g_prompt.initial_double == 12.5, 1);
+
+    reset_capture();
+    act_auto_ppm_zeroppm_prompt(&ctx);
+    rc |= expect_str("auto ppm zeroppm title", g_prompt.title, "Auto-PPM zero-lock PPM");
+    rc |= expect_int("auto ppm zeroppm initial", g_prompt.initial_double == 12.5, 1);
+
+    reset_capture();
+    act_set_p25_vc_grace(&ctx);
+    rc |= expect_str("p25 vc grace prompt", g_prompt.title, "P25: VC grace seconds");
+    rc |= expect_str("p25 vc grace env", ((P25NumCtx*)g_prompt.user)->name, "DSD_NEO_P25_VC_GRACE");
+    release_prompt_user();
+
+    reset_capture();
+    act_set_p25_grant_voice(&ctx);
+    rc |= expect_str("p25 grant voice prompt", g_prompt.title, "P25: Grant->Voice timeout (s)");
+    rc |= expect_str("p25 grant voice env", ((P25NumCtx*)g_prompt.user)->name, "DSD_NEO_P25_GRANT_VOICE_TO");
+    release_prompt_user();
+
+    reset_capture();
+    act_set_p25_retune_backoff(&ctx);
+    rc |= expect_str("p25 retune backoff prompt", g_prompt.title, "P25: Retune backoff (s)");
+    rc |= expect_str("p25 retune backoff env", ((P25NumCtx*)g_prompt.user)->name, "DSD_NEO_P25_RETUNE_BACKOFF");
+    release_prompt_user();
+
+    reset_capture();
+    act_set_p25_cc_grace(&ctx);
+    rc |= expect_str("p25 cc grace prompt", g_prompt.title, "P25: CC hunt grace (s)");
+    rc |= expect_str("p25 cc grace env", ((P25NumCtx*)g_prompt.user)->name, "DSD_NEO_P25_CC_GRACE");
+    release_prompt_user();
+
+    reset_capture();
+    act_set_p25_force_extra(&ctx);
+    rc |= expect_str("p25 force extra prompt", g_prompt.title, "P25: Safety-net extra (s)");
+    rc |= expect_str("p25 force extra env", ((P25NumCtx*)g_prompt.user)->name, "DSD_NEO_P25_FORCE_RELEASE_EXTRA");
+    release_prompt_user();
+
+    reset_capture();
+    act_set_p25_force_margin(&ctx);
+    rc |= expect_str("p25 force margin prompt", g_prompt.title, "P25: Safety-net margin (s)");
+    rc |= expect_str("p25 force margin env", ((P25NumCtx*)g_prompt.user)->name, "DSD_NEO_P25_FORCE_RELEASE_MARGIN");
+    release_prompt_user();
+
+    reset_capture();
+    act_set_p25_p1_err_pct(&ctx);
+    rc |= expect_str("p25 p1 err pct prompt", g_prompt.title, "P25p1: Error-hold percent");
+    rc |= expect_str("p25 p1 err pct env", ((P25NumCtx*)g_prompt.user)->name, "DSD_NEO_P25P1_ERR_HOLD_PCT");
+    release_prompt_user();
+
+    reset_capture();
+    act_set_p25_p1_err_sec(&ctx);
+    rc |= expect_str("p25 p1 err sec prompt", g_prompt.title, "P25p1: Error-hold seconds");
+    rc |= expect_str("p25 p1 err sec env", ((P25NumCtx*)g_prompt.user)->name, "DSD_NEO_P25P1_ERR_HOLD_S");
+    release_prompt_user();
+
+    reset_capture();
+    act_tcp_prebuf_prompt(&ctx);
+    rc |= expect_str("tcp prebuf prompt", g_prompt.title, "RTL-TCP prebuffer (ms)");
+    rc |= expect_int("tcp prebuf initial", g_prompt.initial_int, 77);
+
+    reset_capture();
+    act_tcp_rcvbuf_prompt(&ctx);
+    rc |= expect_str("tcp rcvbuf prompt", g_prompt.title, "RTL-TCP SO_RCVBUF (0=default)");
+    rc |= expect_int("tcp rcvbuf initial", g_prompt.initial_int, 77);
+
+    reset_capture();
+    act_tcp_rcvtimeo_prompt(&ctx);
+    rc |= expect_str("tcp rcvtimeo prompt", g_prompt.title, "RTL-TCP SO_RCVTIMEO (ms; 0=off)");
+    rc |= expect_int("tcp rcvtimeo initial", g_prompt.initial_int, 77);
+
+    reset_capture();
+    act_rt_sched(&ctx);
+    rc |= expect_str("rt sched env", g_env_name, "DSD_NEO_RT_SCHED");
+    rc |= expect_str("rt sched value", g_env_value, "1");
+
+    reset_capture();
+    g_cfg.mt_is_set = 1;
+    g_cfg.mt_enable = 1;
+    act_mt(&ctx);
+    rc |= expect_str("mt env", g_env_name, "DSD_NEO_MT");
+    rc |= expect_str("mt value", g_env_value, "0");
+
+    reset_capture();
+    act_env_editor(&ctx);
+    rc |= expect_str("env editor prompt", g_prompt.title, "Enter DSD_NEO_* variable name");
+    rc |= expect_str("env editor prefill", g_prompt.prefill, "DSD_NEO_");
+    release_prompt_user();
+
+    reset_capture();
+    inv_x2(NULL);
+    rc |= expect_int("x2 inversion command", g_cmd.id, UI_CMD_INV_X2_TOGGLE);
+
+    reset_capture();
+    inv_dmr(NULL);
+    rc |= expect_int("dmr inversion command", g_cmd.id, UI_CMD_INV_DMR_TOGGLE);
+
+    reset_capture();
+    inv_dpmr(NULL);
+    rc |= expect_int("dpmr inversion command", g_cmd.id, UI_CMD_INV_DPMR_TOGGLE);
+
+    reset_capture();
+    inv_m17(NULL);
+    rc |= expect_int("m17 inversion command", g_cmd.id, UI_CMD_INV_M17_TOGGLE);
+
+    reset_capture();
+    io_replay_last_symbol_bin(NULL);
+    rc |= expect_int("replay last command", g_cmd.id, UI_CMD_REPLAY_LAST);
+
+    reset_capture();
+    io_stop_symbol_playback(NULL);
+    rc |= expect_int("stop playback command", g_cmd.id, UI_CMD_STOP_PLAYBACK);
+
+    reset_capture();
+    io_stop_symbol_saving(NULL);
+    rc |= expect_int("stop symbol capture command", g_cmd.id, UI_CMD_SYMCAP_STOP);
+
+    reset_capture();
+    io_save_symbol_capture(&ctx);
+    rc |= expect_str("save symbol prompt", g_prompt.title, "Enter Symbol Capture Filename");
+
+    reset_capture();
+    io_read_symbol_bin(&ctx);
+    rc |= expect_str("read symbol prompt", g_prompt.title, "Enter Symbol Capture Filename");
+
+    reset_capture();
+    io_toggle_mute_enc(NULL);
+    rc |= expect_int("all mutes toggle command", g_cmd.id, UI_CMD_ALL_MUTES_TOGGLE);
+
+    reset_capture();
+    io_toggle_call_alert(NULL);
+    rc |= expect_int("call alert toggle command", g_cmd.id, UI_CMD_CALL_ALERT_TOGGLE);
+
+    reset_capture();
+    io_toggle_cc_candidates(NULL);
+    rc |= expect_int("cc candidates command", g_cmd.id, UI_CMD_P25_CC_CAND_TOGGLE);
+
+    reset_capture();
+    io_set_gain_dig(&ctx);
+    rc |= expect_str("digital gain prompt", g_prompt.title, "Digital output gain (0=auto; 1..50)");
+
+    reset_capture();
+    io_set_gain_ana(&ctx);
+    rc |= expect_str("analog gain prompt", g_prompt.title, "Analog output gain (0..100)");
+
+    reset_capture();
+    io_toggle_monitor(NULL);
+    rc |= expect_int("input monitor command", g_cmd.id, UI_CMD_INPUT_MONITOR_TOGGLE);
+
+    reset_capture();
+    io_toggle_cosine(NULL);
+    rc |= expect_int("cosine filter command", g_cmd.id, UI_CMD_COSINE_FILTER_TOGGLE);
+
+    reset_capture();
+    opts.input_volume_multiplier = 0;
+    io_set_input_volume(&ctx);
+    rc |= expect_int("input volume prompt low clamp", g_prompt.initial_int, 1);
+
+    reset_capture();
+    opts.input_volume_multiplier = 20;
+    io_set_input_volume(&ctx);
+    rc |= expect_int("input volume prompt high clamp", g_prompt.initial_int, 16);
+
+    reset_capture();
+    switch_to_wav(&ctx);
+    rc |= expect_str("switch wav prompt", g_prompt.title, "Enter WAV/RAW filename (or named pipe)");
+
+    reset_capture();
+    switch_to_symbol(&ctx);
+    rc |= expect_str("switch symbol prompt", g_prompt.title, "Enter symbol .bin/.raw/.sym filename");
+
+    reset_capture();
+    DSD_SNPRINTF(opts.tcp_hostname, sizeof opts.tcp_hostname, "switch-tcp.local");
+    switch_to_tcp(&ctx);
+    rc |= expect_str("switch tcp prompt", g_prompt.prefill, "switch-tcp.local");
+    release_prompt_user();
+
+    reset_capture();
+    DSD_SNPRINTF(opts.udp_hostname, sizeof opts.udp_hostname, "239.9.8.7");
+    switch_out_udp(&ctx);
+    rc |= expect_str("switch out udp prompt", g_prompt.prefill, "239.9.8.7");
+    release_prompt_user();
+
+    reset_capture();
+    switch_out_toggle_mute(NULL);
+    rc |= expect_int("output mute toggle command", g_cmd.id, UI_CMD_TOGGLE_MUTE);
+
+    return rc;
+}
+
+static int
+test_config_and_pulse_failure_variants(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    UiCtx ctx = make_ctx(&opts, &state);
+
+    reset_capture();
+    act_config_load(&ctx);
+    rc |= expect_str("config load default path", g_prompt.prefill, "/tmp/default.toml");
+
+    reset_capture();
+    g_save_atomic_rc = -1;
+    act_config_save_current(&ctx);
+    rc |= expect_int("save current failure snapshots", g_snapshot_calls, 1);
+    rc |= expect_str("save current failure status", g_status, "Failed to save config to /tmp/default.toml");
+
+    reset_capture();
+    act_config_save_default(&ctx);
+    rc |= expect_str("save default autosave path", state.config_autosave_path, "/tmp/default.toml");
+    rc |= expect_str("save default status", g_status, "Config saved to /tmp/default.toml");
+
+    reset_capture();
+    g_default_config_path = "";
+    act_config_save_default(&ctx);
+    rc |= expect_str("save default missing status", g_status, "No default config path; nothing saved");
+
+    reset_capture();
+    g_list_profiles_rc = -1;
+    act_config_load_profile(&ctx);
+    rc |= expect_str("profile read failure", g_status, "Failed to read profiles from /tmp/default.toml");
+
+    reset_capture();
+    g_list_profiles_rc = 0;
+    act_config_load_profile(&ctx);
+    rc |= expect_str("profile empty status", g_status, "No profiles found in /tmp/default.toml");
+
+    reset_capture();
+    g_audio_enum_rc = -1;
+    io_set_pulse_in(&ctx);
+    rc |= expect_str("pulse input enum failure", g_status, "Failed to get audio device list");
+
+    reset_capture();
+    io_set_pulse_out(&ctx);
+    rc |= expect_str("pulse output empty status", g_status, "No Pulse outputs found");
+
+    reset_capture();
+    g_audio_inputs[0].initialized = 1;
+    g_audio_inputs[0].index = 4;
+    DSD_SNPRINTF(g_audio_inputs[0].name, sizeof g_audio_inputs[0].name, "in0");
+    DSD_SNPRINTF(g_audio_inputs[0].description, sizeof g_audio_inputs[0].description, "Input Zero");
+    io_set_pulse_in(&ctx);
+    rc |= expect_str("pulse input chooser", g_chooser.title, "Select Pulse Input");
+    rc |= expect_int("pulse input count", g_chooser.n, 1);
+    rc |= expect_int("pulse input label has index", strstr(g_chooser.labels[0], "[4] in0") != NULL, 1);
+    free_pulse_ctx((PulseSelCtx*)g_chooser.user);
+
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_simple_commands_and_prompts();
+    rc |= test_config_profile_and_env_actions();
+    rc |= test_io_actions_and_choosers();
+    rc |= test_key_lrrp_and_display_actions();
+    rc |= test_additional_prompt_and_toggle_actions();
+    rc |= test_config_and_pulse_failure_variants();
+    if (rc == 0) {
+        printf("UI_MENU_ACTIONS: OK\n");
+    }
+    return rc;
+}

--- a/tests/ui/test_ui_menu_callbacks.c
+++ b/tests/ui/test_ui_menu_callbacks.c
@@ -1,0 +1,978 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-branch-clone,misc-redundant-expression)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Deterministic contracts for terminal UI menu prompt callbacks.
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/platform/platform.h>
+#include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/ui/ui_async.h>
+#include <dsd-neo/ui/ui_cmd.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/ui/menu_core.h"
+#include "menu_callbacks.h"
+#include "menu_env.h"
+#include "menu_internal.h"
+#include "menu_prompts.h"
+
+typedef struct {
+    int id;
+    size_t n;
+    uint8_t data[UI_CMD_DATA_MAX];
+    int calls;
+} CmdCapture;
+
+typedef struct {
+    char title[128];
+    char prefill[256];
+    size_t cap;
+    void* user;
+    ui_prompt_string_done_fn str_cb;
+    ui_prompt_int_done_fn int_cb;
+    int initial_int;
+    int calls;
+} PromptCapture;
+
+static CmdCapture g_cmd;
+static PromptCapture g_prompt;
+static char g_status[256];
+static int g_status_calls;
+static char g_env_name[128];
+static char g_env_value[128];
+static int g_env_set_calls;
+static int g_env_unset_calls;
+static char g_env_int_name[128];
+static int g_env_int_value;
+static int g_env_int_calls;
+static char g_env_double_name[128];
+static double g_env_double_value;
+static int g_env_double_calls;
+static int g_reparse_calls;
+static const char* g_env_get_value;
+static int g_config_load_rc;
+static int g_profile_load_rc;
+static int g_config_save_rc;
+static int g_snapshot_calls;
+
+int
+ui_post_cmd(int cmd_id, const void* payload, size_t payload_sz) {
+    g_cmd.id = cmd_id;
+    g_cmd.n = payload_sz;
+    if (payload_sz > sizeof(g_cmd.data)) {
+        payload_sz = sizeof(g_cmd.data);
+    }
+    DSD_MEMSET(g_cmd.data, 0, sizeof(g_cmd.data));
+    if (payload && payload_sz > 0) {
+        DSD_MEMCPY(g_cmd.data, payload, payload_sz);
+    }
+    g_cmd.calls++;
+    return 0;
+}
+
+void ui_statusf(const char* fmt, ...) DSD_ATTR_FORMAT(printf, 1, 2);
+
+void
+ui_statusf(const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    (void)DSD_VSNPRINTF(g_status, sizeof g_status, fmt, ap);
+    va_end(ap);
+    g_status_calls++;
+}
+
+void
+ui_prompt_open_string_async_impl(const char* title, const char* prefill, size_t cap, void* user,
+                                 ui_prompt_string_done_fn on_done) {
+    DSD_SNPRINTF(g_prompt.title, sizeof g_prompt.title, "%s", title ? title : "");
+    DSD_SNPRINTF(g_prompt.prefill, sizeof g_prompt.prefill, "%s", prefill ? prefill : "");
+    g_prompt.cap = cap;
+    g_prompt.user = user;
+    g_prompt.str_cb = on_done;
+    g_prompt.int_cb = NULL;
+    g_prompt.calls++;
+}
+
+void
+ui_prompt_open_int_async_impl(const char* title, int initial, void* user, ui_prompt_int_done_fn cb) {
+    DSD_SNPRINTF(g_prompt.title, sizeof g_prompt.title, "%s", title ? title : "");
+    g_prompt.initial_int = initial;
+    g_prompt.user = user;
+    g_prompt.int_cb = cb;
+    g_prompt.str_cb = NULL;
+    g_prompt.calls++;
+}
+
+void
+ui_prompt_open_double_async_impl(const char* title, double initial, void* user, ui_prompt_double_done_fn cb) {
+    (void)title;
+    (void)initial;
+    (void)user;
+    (void)cb;
+    assert(!"double prompt should not be opened by this test batch");
+}
+
+void
+env_set_int(const char* name, int v) {
+    DSD_SNPRINTF(g_env_int_name, sizeof g_env_int_name, "%s", name ? name : "");
+    g_env_int_value = v;
+    g_env_int_calls++;
+}
+
+void
+env_set_double(const char* name, double v) {
+    DSD_SNPRINTF(g_env_double_name, sizeof g_env_double_name, "%s", name ? name : "");
+    g_env_double_value = v;
+    g_env_double_calls++;
+}
+
+int
+env_get_int(const char* name, int defv) {
+    (void)name;
+    return defv;
+}
+
+double
+env_get_double(const char* name, double defv) {
+    (void)name;
+    return defv;
+}
+
+void
+env_reparse_runtime_cfg(dsd_opts* opts) {
+    (void)opts;
+    g_reparse_calls++;
+}
+
+int
+parse_hex_u64(const char* s, unsigned long long* out) {
+    if (!s || !*s || !out) {
+        return 0;
+    }
+    errno = 0;
+    char* end = NULL;
+    unsigned long long v = strtoull(s, &end, 16);
+    if (errno != 0 || !end || *end != '\0') {
+        return 0;
+    }
+    *out = v;
+    return 1;
+}
+
+int
+dsd_setenv(const char* name, const char* value, int overwrite) {
+    DSD_SNPRINTF(g_env_name, sizeof g_env_name, "%s", name ? name : "");
+    DSD_SNPRINTF(g_env_value, sizeof g_env_value, "%s", value ? value : "");
+    g_env_set_calls++;
+    (void)overwrite;
+    return 0;
+}
+
+int
+dsd_unsetenv(const char* name) {
+    DSD_SNPRINTF(g_env_name, sizeof g_env_name, "%s", name ? name : "");
+    g_env_unset_calls++;
+    return 0;
+}
+
+const char*
+dsd_neo_env_get(const char* name) {
+    (void)name;
+    return g_env_get_value;
+}
+
+int
+dsd_user_config_load(const char* path, dsdneoUserConfig* cfg) {
+    (void)path;
+    if (cfg) {
+        DSD_MEMSET(cfg, 0, sizeof *cfg);
+    }
+    return g_config_load_rc;
+}
+
+int
+dsd_user_config_load_profile(const char* path, const char* profile_name, dsdneoUserConfig* cfg) {
+    (void)path;
+    (void)profile_name;
+    if (cfg) {
+        DSD_MEMSET(cfg, 0, sizeof *cfg);
+    }
+    return g_profile_load_rc;
+}
+
+int
+dsd_user_config_save_atomic(const char* path, const dsdneoUserConfig* cfg) {
+    (void)path;
+    (void)cfg;
+    return g_config_save_rc;
+}
+
+void
+dsd_snapshot_opts_to_user_config(const dsd_opts* opts, const dsd_state* state, dsdneoUserConfig* cfg) {
+    (void)opts;
+    (void)state;
+    if (cfg) {
+        DSD_MEMSET(cfg, 0, sizeof *cfg);
+    }
+    g_snapshot_calls++;
+}
+
+static void
+reset_capture(void) {
+    DSD_MEMSET(&g_cmd, 0, sizeof g_cmd);
+    DSD_MEMSET(&g_prompt, 0, sizeof g_prompt);
+    DSD_MEMSET(g_status, 0, sizeof g_status);
+    g_status_calls = 0;
+    DSD_MEMSET(g_env_name, 0, sizeof g_env_name);
+    DSD_MEMSET(g_env_value, 0, sizeof g_env_value);
+    g_env_set_calls = 0;
+    g_env_unset_calls = 0;
+    DSD_MEMSET(g_env_int_name, 0, sizeof g_env_int_name);
+    g_env_int_value = 0;
+    g_env_int_calls = 0;
+    DSD_MEMSET(g_env_double_name, 0, sizeof g_env_double_name);
+    g_env_double_value = 0.0;
+    g_env_double_calls = 0;
+    g_reparse_calls = 0;
+    g_env_get_value = NULL;
+    g_config_load_rc = 0;
+    g_profile_load_rc = 0;
+    g_config_save_rc = 0;
+    g_snapshot_calls = 0;
+}
+
+static UiCtx
+make_ctx(dsd_opts* opts, dsd_state* state) {
+    UiCtx ctx;
+    ctx.opts = opts;
+    ctx.state = state;
+    return ctx;
+}
+
+static int
+expect_str(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_cmd_string(const char* tag, int want_id, const char* want_payload) {
+    int rc = 0;
+    rc |= expect_int(tag, g_cmd.calls, 1);
+    rc |= expect_int(tag, g_cmd.id, want_id);
+    rc |= expect_str(tag, (const char*)g_cmd.data, want_payload);
+    return rc;
+}
+
+static int32_t
+cmd_i32(void) {
+    int32_t v = 0;
+    assert(g_cmd.n >= sizeof v);
+    DSD_MEMCPY(&v, g_cmd.data, sizeof v);
+    return v;
+}
+
+static uint32_t
+cmd_u32(void) {
+    uint32_t v = 0;
+    assert(g_cmd.n >= sizeof v);
+    DSD_MEMCPY(&v, g_cmd.data, sizeof v);
+    return v;
+}
+
+static uint64_t
+cmd_u64(void) {
+    uint64_t v = 0;
+    assert(g_cmd.n >= sizeof v);
+    DSD_MEMCPY(&v, g_cmd.data, sizeof v);
+    return v;
+}
+
+static double
+cmd_double(void) {
+    double v = 0.0;
+    assert(g_cmd.n >= sizeof v);
+    DSD_MEMCPY(&v, g_cmd.data, sizeof v);
+    return v;
+}
+
+static char*
+dup_test_string(const char* s) {
+    size_t n = strlen(s) + 1U;
+    char* out = (char*)malloc(n);
+    assert(out != NULL);
+    DSD_MEMCPY(out, s, n);
+    return out;
+}
+
+static ProfileSelCtx*
+make_profile_ctx(dsd_state* state, const char* path, const char* profile) {
+    ProfileSelCtx* pctx = (ProfileSelCtx*)calloc(1, sizeof *pctx);
+    assert(pctx != NULL);
+    pctx->state = state;
+    DSD_SNPRINTF(pctx->path, sizeof pctx->path, "%s", path);
+    pctx->n = 1;
+    pctx->labels = (const char**)calloc(1, sizeof(char*));
+    pctx->names = (const char**)calloc(1, sizeof(char*));
+    assert(pctx->labels != NULL && pctx->names != NULL);
+    pctx->names[0] = dup_test_string(profile);
+    pctx->labels[0] = pctx->names[0];
+    return pctx;
+}
+
+static PulseSelCtx*
+make_pulse_ctx(dsd_state* state, const char* first, const char* second) {
+    (void)state;
+    PulseSelCtx* pctx = (PulseSelCtx*)calloc(1, sizeof *pctx);
+    assert(pctx != NULL);
+    pctx->n = 2;
+    pctx->labels = (const char**)calloc(2, sizeof(char*));
+    pctx->names = (const char**)calloc(2, sizeof(char*));
+    pctx->bufs = (char**)calloc(2, sizeof(char*));
+    assert(pctx->labels != NULL && pctx->names != NULL && pctx->bufs != NULL);
+    pctx->names[0] = dup_test_string(first);
+    pctx->names[1] = dup_test_string(second);
+    pctx->bufs[0] = dup_test_string("label-buffer-0");
+    pctx->bufs[1] = dup_test_string("label-buffer-1");
+    pctx->labels[0] = pctx->bufs[0];
+    pctx->labels[1] = pctx->bufs[1];
+    return pctx;
+}
+
+static int
+test_path_and_file_callbacks(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    UiCtx ctx = make_ctx(&opts, &state);
+
+    reset_capture();
+    cb_event_log_set(&ctx, "");
+    rc |= expect_int("empty event path no command", g_cmd.calls, 0);
+
+    reset_capture();
+    cb_event_log_set(&ctx, "/tmp/events.log");
+    rc |= expect_cmd_string("event path command", UI_CMD_EVENT_LOG_SET, "/tmp/events.log");
+
+    reset_capture();
+    cb_static_wav(&ctx, "static.wav");
+    rc |= expect_cmd_string("static wav command", UI_CMD_WAV_STATIC_OPEN, "static.wav");
+
+    reset_capture();
+    cb_raw_wav(&ctx, "raw.wav");
+    rc |= expect_cmd_string("raw wav command", UI_CMD_WAV_RAW_OPEN, "raw.wav");
+
+    reset_capture();
+    cb_dsp_out(&ctx, "capture-base");
+    rc |= expect_cmd_string("dsp out command", UI_CMD_DSP_OUT_SET, "capture-base");
+
+    reset_capture();
+    cb_import_chan(&ctx, "channels.csv");
+    rc |= expect_cmd_string("channel import command", UI_CMD_IMPORT_CHANNEL_MAP, "channels.csv");
+
+    reset_capture();
+    cb_import_group(&ctx, "groups.csv");
+    rc |= expect_cmd_string("group import command", UI_CMD_IMPORT_GROUP_LIST, "groups.csv");
+
+    reset_capture();
+    cb_keys_dec(&ctx, "keys-dec.csv");
+    rc |= expect_cmd_string("keys dec command", UI_CMD_IMPORT_KEYS_DEC, "keys-dec.csv");
+
+    reset_capture();
+    cb_keys_hex(&ctx, "keys-hex.csv");
+    rc |= expect_cmd_string("keys hex command", UI_CMD_IMPORT_KEYS_HEX, "keys-hex.csv");
+
+    reset_capture();
+    cb_io_save_symbol_capture(&ctx, "symbols.bin");
+    rc |= expect_cmd_string("symbol capture command", UI_CMD_SYMCAP_OPEN, "symbols.bin");
+
+    reset_capture();
+    cb_io_read_symbol_bin(&ctx, "replay.bin");
+    rc |= expect_cmd_string("symbol input read command", UI_CMD_SYMBOL_IN_OPEN, "replay.bin");
+
+    reset_capture();
+    cb_switch_to_wav(&ctx, "input.wav");
+    rc |= expect_cmd_string("wav input command", UI_CMD_INPUT_WAV_SET, "input.wav");
+
+    reset_capture();
+    cb_switch_to_symbol(&ctx, "capture.bin");
+    rc |= expect_cmd_string("symbol bin route", UI_CMD_SYMBOL_IN_OPEN, "capture.bin");
+
+    reset_capture();
+    cb_switch_to_symbol(&ctx, "stream.raw");
+    rc |= expect_cmd_string("symbol stream route", UI_CMD_INPUT_SYM_STREAM_SET, "stream.raw");
+
+    return rc;
+}
+
+static int
+test_config_callbacks_apply_and_report_failures(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    UiCtx ctx = make_ctx(&opts, &state);
+
+    reset_capture();
+    cb_config_load(&ctx, "");
+    rc |= expect_str("config load cancel status", g_status, "Config load canceled");
+    rc |= expect_int("config load cancel no command", g_cmd.calls, 0);
+
+    reset_capture();
+    g_config_load_rc = -1;
+    cb_config_load(&ctx, "/tmp/bad.toml");
+    rc |= expect_str("config load failure", g_status, "Failed to load config from /tmp/bad.toml");
+    rc |= expect_int("config load failure no command", g_cmd.calls, 0);
+
+    reset_capture();
+    cb_config_load(&ctx, "/tmp/good.toml");
+    rc |= expect_int("config load command", g_cmd.id, UI_CMD_CONFIG_APPLY);
+    rc |= expect_int("config load autosave enabled", state.config_autosave_enabled, 1);
+    rc |= expect_str("config load autosave path", state.config_autosave_path, "/tmp/good.toml");
+    rc |= expect_str("config load success status", g_status, "Config loaded from /tmp/good.toml");
+
+    reset_capture();
+    cb_config_save_as(&ctx, NULL);
+    rc |= expect_str("config save cancel status", g_status, "Config save canceled");
+    rc |= expect_int("config save cancel no snapshot", g_snapshot_calls, 0);
+
+    reset_capture();
+    cb_config_save_as(&ctx, "/tmp/save.toml");
+    rc |= expect_int("config save snapshots", g_snapshot_calls, 1);
+    rc |= expect_str("config save success status", g_status, "Config saved to /tmp/save.toml");
+
+    reset_capture();
+    g_config_save_rc = -1;
+    cb_config_save_as(&ctx, "/tmp/save-fail.toml");
+    rc |= expect_int("config save failure snapshots", g_snapshot_calls, 1);
+    rc |= expect_str("config save failure status", g_status, "Failed to save config to /tmp/save-fail.toml");
+
+    reset_capture();
+    ProfileSelCtx* pctx = make_profile_ctx(&state, "/tmp/profiles.toml", "mobile");
+    chooser_done_config_profile(pctx, 0);
+    rc |= expect_int("profile load command", g_cmd.id, UI_CMD_CONFIG_APPLY);
+    rc |= expect_int("profile load disables autosave", state.config_autosave_enabled, 0);
+    rc |= expect_str("profile load path", state.config_autosave_path, "/tmp/profiles.toml");
+    rc |= expect_str("profile load status", g_status, "Profile loaded: mobile");
+
+    reset_capture();
+    pctx = make_profile_ctx(&state, "/tmp/profiles.toml", "field");
+    g_profile_load_rc = -1;
+    chooser_done_config_profile(pctx, 0);
+    rc |= expect_int("profile failure no command", g_cmd.calls, 0);
+    rc |= expect_str("profile load failure", g_status, "Failed to load profile field from /tmp/profiles.toml");
+
+    reset_capture();
+    pctx = make_profile_ctx(&state, "/tmp/profiles.toml", "base");
+    chooser_done_config_profile(pctx, -1);
+    rc |= expect_int("profile cancel no command", g_cmd.calls, 0);
+    rc |= expect_int("profile cancel no status", g_status_calls, 0);
+
+    return rc;
+}
+
+static int
+test_typed_callbacks_clamp_and_cancel(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    UiCtx ctx = make_ctx(&opts, &state);
+
+    reset_capture();
+    cb_setmod_bw(&ctx, 0, 1234);
+    rc |= expect_int("canceled setmod no command", g_cmd.calls, 0);
+
+    reset_capture();
+    cb_setmod_bw(&ctx, 1, 40000);
+    rc |= expect_int("setmod command", g_cmd.id, UI_CMD_RIGCTL_SET_MOD_BW);
+    rc |= expect_int("setmod clamped", cmd_i32(), 25000);
+    rc |= expect_int("setmod adjusted status", strstr(g_status, "adjusted") != NULL, 1);
+
+    reset_capture();
+    cb_tg_hold(&ctx, 1, -7);
+    rc |= expect_int("tg hold command", g_cmd.id, UI_CMD_TG_HOLD_SET);
+    rc |= expect_int("tg hold clamped", (int)cmd_u32(), 0);
+
+    reset_capture();
+    cb_hangtime(&ctx, 1, -1.25);
+    rc |= expect_int("hangtime command", g_cmd.id, UI_CMD_HANGTIME_SET);
+    rc |= expect_int("hangtime clamped", cmd_double() == 0.0, 1);
+
+    reset_capture();
+    cb_slot_pref(&ctx, 1, 7);
+    rc |= expect_int("slot pref command", g_cmd.id, UI_CMD_SLOT_PREF_SET);
+    rc |= expect_int("slot pref clamped zero-based", cmd_i32(), 1);
+
+    reset_capture();
+    cb_slots_on(&ctx, 1, -9);
+    rc |= expect_int("slot mask command", g_cmd.id, UI_CMD_SLOTS_ONOFF_SET);
+    rc |= expect_int("slot mask clamped", cmd_i32(), 0);
+
+    return rc;
+}
+
+static int
+test_key_callbacks_validate_and_pack(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    UiCtx ctx = make_ctx(&opts, &state);
+    static const char tyt_ap_value[] = "fixture-tyt-ap";
+    static const char retevis_rc2_value[] = "fixture-retevis-rc2";
+    static const char tyt_ep_value[] = "fixture-tyt-ep";
+
+    reset_capture();
+    cb_tyt_ap(&ctx, "");
+    rc |= expect_int("empty tyt ap no command", g_cmd.calls, 0);
+
+    reset_capture();
+    cb_tyt_ap(&ctx, tyt_ap_value);
+    rc |= expect_cmd_string("tyt ap command", UI_CMD_KEY_TYT_AP_SET, tyt_ap_value);
+
+    reset_capture();
+    cb_retevis_rc2(&ctx, retevis_rc2_value);
+    rc |= expect_cmd_string("retevis rc2 command", UI_CMD_KEY_RETEVIS_RC2_SET, retevis_rc2_value);
+
+    reset_capture();
+    cb_tyt_ep(&ctx, tyt_ep_value);
+    rc |= expect_cmd_string("tyt ep command", UI_CMD_KEY_TYT_EP_SET, tyt_ep_value);
+
+    reset_capture();
+    cb_ken_scr(&ctx, "123456789");
+    rc |= expect_cmd_string("kenwood scrambler command", UI_CMD_KEY_KEN_SCR_SET, "123456789");
+
+    reset_capture();
+    cb_anytone_bp(&ctx, "1A2B");
+    rc |= expect_cmd_string("anytone bp command", UI_CMD_KEY_ANYTONE_BP_SET, "1A2B");
+
+    reset_capture();
+    cb_xor_ks(&ctx, "4:01020304");
+    rc |= expect_cmd_string("xor keystream command", UI_CMD_KEY_XOR_SET, "4:01020304");
+
+    reset_capture();
+    cb_key_basic(&ctx, 1, 999);
+    rc |= expect_int("basic key command", g_cmd.id, UI_CMD_KEY_BASIC_SET);
+    rc |= expect_int("basic key clamp", (int)cmd_u32(), 255);
+
+    reset_capture();
+    cb_key_scrambler(&ctx, 1, 999999);
+    rc |= expect_int("scrambler key command", g_cmd.id, UI_CMD_KEY_SCRAMBLER_SET);
+    rc |= expect_int("scrambler key clamp", (int)cmd_u32(), 0x7FFF);
+
+    reset_capture();
+    cb_key_rc4des(&ctx, "not-hex");
+    rc |= expect_int("invalid rc4des no command", g_cmd.calls, 0);
+
+    reset_capture();
+    cb_key_rc4des(&ctx, "1A2B");
+    rc |= expect_int("rc4des command", g_cmd.id, UI_CMD_KEY_RC4DES_SET);
+    rc |= expect_int("rc4des value", cmd_u64() == 0x1A2BULL, 1);
+
+    reset_capture();
+    HyCtx* hc = (HyCtx*)calloc(1, sizeof *hc);
+    assert(hc != NULL);
+    hc->c = &ctx;
+    cb_hytera_step(hc, "not-hex");
+    rc |= expect_int("invalid hytera reprompts", g_prompt.calls, 1);
+    rc |= expect_int("invalid hytera no command", g_cmd.calls, 0);
+    cb_hytera_step(hc, "10");
+    cb_hytera_step(hc, "20");
+    cb_hytera_step(hc, "30");
+    cb_hytera_step(hc, "40");
+    rc |= expect_int("hytera command", g_cmd.id, UI_CMD_KEY_HYTERA_SET);
+    uint64_t hy[5] = {0};
+    DSD_MEMCPY(hy, g_cmd.data, sizeof hy);
+    rc |= expect_int("hytera H", hy[0] == 0x10ULL, 1);
+    rc |= expect_int("hytera K1", hy[1] == 0x10ULL, 1);
+    rc |= expect_int("hytera K4", hy[4] == 0x40ULL, 1);
+
+    reset_capture();
+    AesCtx* ac = (AesCtx*)calloc(1, sizeof *ac);
+    assert(ac != NULL);
+    ac->c = &ctx;
+    cb_aes_step(ac, "bad-hex");
+    rc |= expect_int("invalid aes reprompts", g_prompt.calls, 1);
+    rc |= expect_str("invalid aes keeps bad prefill", g_prompt.prefill, "bad-hex");
+    rc |= expect_int("invalid aes no command", g_cmd.calls, 0);
+    cb_aes_step(ac, "1");
+    cb_aes_step(ac, "2");
+    cb_aes_step(ac, "3");
+    cb_aes_step(ac, "4");
+    rc |= expect_int("aes command", g_cmd.id, UI_CMD_KEY_AES_SET);
+    uint64_t aes[4] = {0};
+    DSD_MEMCPY(aes, g_cmd.data, sizeof aes);
+    rc |= expect_int("aes K1", aes[0] == 1ULL, 1);
+    rc |= expect_int("aes K4", aes[3] == 4ULL, 1);
+
+    reset_capture();
+    state.p2_sysid = 0x2AAU;
+    state.p2_cc = 0x3BBU;
+    P2Ctx* pc = (P2Ctx*)calloc(1, sizeof *pc);
+    assert(pc != NULL);
+    pc->c = &ctx;
+    cb_p2_step(pc, "12345");
+    rc |= expect_int("p2 sysid prompt", g_prompt.calls, 1);
+    rc |= expect_str("p2 sysid prefill", g_prompt.prefill, "2AA");
+    cb_p2_step(pc, "678");
+    rc |= expect_str("p2 cc prefill", g_prompt.prefill, "3BB");
+    cb_p2_step(pc, "9AB");
+    rc |= expect_int("p2 params command", g_cmd.id, UI_CMD_P25_P2_PARAMS_SET);
+    uint64_t p2[3] = {0};
+    DSD_MEMCPY(p2, g_cmd.data, sizeof p2);
+    rc |= expect_int("p2 wacn", p2[0] == 0x12345ULL, 1);
+    rc |= expect_int("p2 sysid", p2[1] == 0x678ULL, 1);
+    rc |= expect_int("p2 cc", p2[2] == 0x9ABULL, 1);
+
+    return rc;
+}
+
+static int
+test_network_and_io_callbacks_pack_payloads(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    opts.udp_portno = 4567;
+    opts.tcp_portno = 3456;
+    UiCtx ctx = make_ctx(&opts, &state);
+
+    reset_capture();
+    UdpOutCtx* uo = (UdpOutCtx*)calloc(1, sizeof *uo);
+    assert(uo != NULL);
+    uo->c = &ctx;
+    cb_udp_out_host(uo, "127.0.0.1");
+    rc |= expect_int("udp out prompts for port", g_prompt.calls, 1);
+    rc |= expect_int("udp out default port", g_prompt.initial_int, 4567);
+    assert(g_prompt.int_cb != NULL);
+    g_prompt.int_cb(g_prompt.user, 1, 9999);
+    rc |= expect_int("udp out command", g_cmd.id, UI_CMD_UDP_OUT_CFG);
+
+    struct {
+        char host[256];
+        int32_t port;
+    } hp;
+
+    DSD_MEMCPY(&hp, g_cmd.data, sizeof hp);
+    rc |= expect_str("udp out host", hp.host, "127.0.0.1");
+    rc |= expect_int("udp out port", hp.port, 9999);
+
+    reset_capture();
+    TcpLinkCtx* tc = (TcpLinkCtx*)calloc(1, sizeof *tc);
+    assert(tc != NULL);
+    tc->c = &ctx;
+    cb_tcp_host(tc, "radio.local");
+    rc |= expect_int("tcp prompts for port", g_prompt.calls, 1);
+    rc |= expect_int("tcp default port", g_prompt.initial_int, 3456);
+    assert(g_prompt.int_cb != NULL);
+    g_prompt.int_cb(g_prompt.user, 1, 7355);
+    rc |= expect_int("tcp command", g_cmd.id, UI_CMD_TCP_CONNECT_AUDIO_CFG);
+    DSD_MEMCPY(&hp, g_cmd.data, sizeof hp);
+    rc |= expect_str("tcp host", hp.host, "radio.local");
+    rc |= expect_int("tcp port", hp.port, 7355);
+
+    reset_capture();
+    opts.udp_in_portno = 2468;
+    UdpInCtx* ui = (UdpInCtx*)calloc(1, sizeof *ui);
+    assert(ui != NULL);
+    ui->c = &ctx;
+    cb_udp_in_addr(ui, "0.0.0.0");
+    rc |= expect_int("udp in prompts for port", g_prompt.calls, 1);
+    rc |= expect_int("udp in default port", g_prompt.initial_int, 2468);
+    assert(g_prompt.int_cb != NULL);
+    g_prompt.int_cb(g_prompt.user, 1, 8899);
+    rc |= expect_int("udp in command", g_cmd.id, UI_CMD_UDP_INPUT_CFG);
+    DSD_MEMCPY(&hp, g_cmd.data, sizeof hp);
+    rc |= expect_str("udp in bind", hp.host, "0.0.0.0");
+    rc |= expect_int("udp in port", hp.port, 8899);
+
+    reset_capture();
+    opts.rigctlportno = 4444;
+    RigCtx* rig_ok = (RigCtx*)calloc(1, sizeof *rig_ok);
+    assert(rig_ok != NULL);
+    rig_ok->c = &ctx;
+    cb_rig_host(rig_ok, "rig.local");
+    rc |= expect_int("rig prompts for port", g_prompt.calls, 1);
+    rc |= expect_int("rig default port", g_prompt.initial_int, 4444);
+    assert(g_prompt.int_cb != NULL);
+    g_prompt.int_cb(g_prompt.user, 1, 4555);
+    rc |= expect_int("rig command", g_cmd.id, UI_CMD_RIGCTL_CONNECT_CFG);
+    DSD_MEMCPY(&hp, g_cmd.data, sizeof hp);
+    rc |= expect_str("rig host", hp.host, "rig.local");
+    rc |= expect_int("rig port", hp.port, 4555);
+
+    reset_capture();
+    RigCtx* rig = (RigCtx*)calloc(1, sizeof *rig);
+    assert(rig != NULL);
+    rig->c = &ctx;
+    cb_rig_host(rig, "");
+    rc |= expect_int("empty rig host frees without prompt", g_prompt.calls, 0);
+    rc |= expect_int("empty rig host no command", g_cmd.calls, 0);
+
+    return rc;
+}
+
+static int
+test_gain_rtl_and_env_callbacks(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    UiCtx ctx = make_ctx(&opts, &state);
+
+    reset_capture();
+    cb_gain_dig(&ctx, 1, 70.0);
+    rc |= expect_int("digital gain command", g_cmd.id, UI_CMD_GAIN_SET);
+    rc |= expect_int("digital gain clamped", cmd_i32(), 50);
+
+    reset_capture();
+    cb_gain_ana(&ctx, 1, -3.0);
+    rc |= expect_int("analog gain command", g_cmd.id, UI_CMD_AGAIN_SET);
+    rc |= expect_int("analog gain lower clamp", cmd_i32(), 0);
+    rc |= expect_int("analog gain adjusted status", strstr(g_status, "adjusted") != NULL, 1);
+
+    reset_capture();
+    cb_input_vol(&ctx, 1, 99);
+    rc |= expect_int("input volume command", g_cmd.id, UI_CMD_INPUT_VOL_SET);
+    rc |= expect_int("input volume upper clamp", cmd_i32(), 16);
+
+    reset_capture();
+    cb_rtl_dev(&ctx, 1, 2);
+    rc |= expect_int("rtl dev command", g_cmd.id, UI_CMD_RTL_SET_DEV);
+    rc |= expect_int("rtl dev value", cmd_i32(), 2);
+
+    reset_capture();
+    cb_rtl_freq(&ctx, 1, 851012500);
+    rc |= expect_int("rtl freq command", g_cmd.id, UI_CMD_RTL_SET_FREQ);
+    rc |= expect_int("rtl freq value", cmd_i32(), 851012500);
+
+    reset_capture();
+    cb_rtl_gain(&ctx, 1, 77);
+    rc |= expect_int("rtl gain command", g_cmd.id, UI_CMD_RTL_SET_GAIN);
+    rc |= expect_int("rtl gain clamped", cmd_i32(), 49);
+
+    reset_capture();
+    cb_rtl_ppm(&ctx, 1, -250);
+    rc |= expect_int("rtl ppm command", g_cmd.id, UI_CMD_RTL_SET_PPM);
+    rc |= expect_int("rtl ppm clamped", cmd_i32(), -200);
+
+    reset_capture();
+    cb_rtl_bw(&ctx, 1, 13);
+    rc |= expect_int("rtl bw command", g_cmd.id, UI_CMD_RTL_SET_BW);
+    rc |= expect_int("rtl bw nearest", cmd_i32(), 12);
+
+    reset_capture();
+    cb_rtl_sql(&ctx, 1, -42.5);
+    rc |= expect_int("rtl sql command", g_cmd.id, UI_CMD_RTL_SET_SQL_DB);
+    rc |= expect_int("rtl sql value", cmd_double() == -42.5, 1);
+
+    reset_capture();
+    cb_rtl_vol(&ctx, 1, 9);
+    rc |= expect_int("rtl vol command", g_cmd.id, UI_CMD_RTL_SET_VOL_MULT);
+    rc |= expect_int("rtl vol clamped", cmd_i32(), 3);
+
+    reset_capture();
+    cb_input_warn(&ctx, 1, 5.0);
+    rc |= expect_int("input warn command", g_cmd.id, UI_CMD_INPUT_WARN_DB_SET);
+    rc |= expect_int("input warn clamp", cmd_double() == 0.0, 1);
+    rc |= expect_str("input warn env name", g_env_double_name, "DSD_NEO_INPUT_WARN_DB");
+    rc |= expect_int("input warn env value", g_env_double_value == 0.0, 1);
+
+    reset_capture();
+    cb_audio_lpf(&ctx, 1, 0);
+    rc |= expect_str("audio lpf off env name", g_env_name, "DSD_NEO_AUDIO_LPF");
+    rc |= expect_str("audio lpf off env value", g_env_value, "off");
+    rc |= expect_int("audio lpf off reparse", g_reparse_calls, 1);
+
+    reset_capture();
+    cb_auto_ppm_snr(&ctx, 1, 27.5);
+    rc |= expect_str("auto ppm snr env name", g_env_double_name, "DSD_NEO_AUTO_PPM_SNR_DB");
+    rc |= expect_int("auto ppm snr env value", g_env_double_value == 27.5, 1);
+
+    reset_capture();
+    cb_auto_ppm_pwr(&ctx, 1, -31.25);
+    rc |= expect_str("auto ppm pwr env name", g_env_double_name, "DSD_NEO_AUTO_PPM_PWR_DB");
+    rc |= expect_int("auto ppm pwr env value", g_env_double_value == -31.25, 1);
+
+    reset_capture();
+    cb_auto_ppm_zeroppm(&ctx, 1, 0.75);
+    rc |= expect_str("auto ppm zero ppm env name", g_env_double_name, "DSD_NEO_AUTO_PPM_ZEROLOCK_PPM");
+    rc |= expect_int("auto ppm zero ppm env value", g_env_double_value == 0.75, 1);
+
+    reset_capture();
+    cb_auto_ppm_zerohz(&ctx, 1, 125);
+    rc |= expect_str("auto ppm zero hz env name", g_env_int_name, "DSD_NEO_AUTO_PPM_ZEROLOCK_HZ");
+    rc |= expect_int("auto ppm zero hz env value", g_env_int_value, 125);
+
+    reset_capture();
+    P25NumCtx* pc = (P25NumCtx*)calloc(1, sizeof *pc);
+    assert(pc != NULL);
+    pc->name = "DSD_NEO_P25_TEST_NUM";
+    cb_set_p25_num(pc, 1, 42.25);
+    rc |= expect_str("p25 num env name", g_env_double_name, "DSD_NEO_P25_TEST_NUM");
+    rc |= expect_int("p25 num env value", g_env_double_value == 42.25, 1);
+
+    reset_capture();
+    opts.audio_in_type = AUDIO_IN_RTL;
+    cb_tcp_prebuf(&ctx, 1, 250);
+    rc |= expect_str("tcp prebuf env name", g_env_int_name, "DSD_NEO_TCP_PREBUF_MS");
+    rc |= expect_int("tcp prebuf env value", g_env_int_value, 250);
+    rc |= expect_int("tcp prebuf restarts rtl", g_cmd.id, UI_CMD_RTL_RESTART);
+
+    reset_capture();
+    opts.audio_in_type = AUDIO_IN_RTL;
+    cb_tcp_rcvbuf(&ctx, 1, 0);
+    rc |= expect_str("tcp rcvbuf clear env name", g_env_name, "DSD_NEO_TCP_RCVBUF");
+    rc |= expect_str("tcp rcvbuf clear env value", g_env_value, "");
+    rc |= expect_int("tcp rcvbuf clear restarts rtl", g_cmd.id, UI_CMD_RTL_RESTART);
+
+    reset_capture();
+    opts.audio_in_type = AUDIO_IN_PULSE;
+    cb_tcp_rcvtimeo(&ctx, 1, 1500);
+    rc |= expect_str("tcp rcvtimeo env name", g_env_int_name, "DSD_NEO_TCP_RCVTIMEO");
+    rc |= expect_int("tcp rcvtimeo env value", g_env_int_value, 1500);
+    rc |= expect_int("tcp rcvtimeo pulse no restart", g_cmd.calls, 0);
+
+    return rc;
+}
+
+static int
+test_env_editor_and_protocol_callbacks(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    UiCtx ctx = make_ctx(&opts, &state);
+
+    reset_capture();
+    EnvEditCtx* bad = (EnvEditCtx*)calloc(1, sizeof *bad);
+    assert(bad != NULL);
+    bad->c = &ctx;
+    cb_env_edit_name(bad, "PATH");
+    rc |= expect_int("invalid env name no prompt", g_prompt.calls, 0);
+    rc |= expect_int("invalid env name status", strstr(g_status, "DSD_NEO_") != NULL, 1);
+
+    reset_capture();
+    g_env_get_value = "old";
+    EnvEditCtx* ec = (EnvEditCtx*)calloc(1, sizeof *ec);
+    assert(ec != NULL);
+    ec->c = &ctx;
+    cb_env_edit_name(ec, "DSD_NEO_TEST_VALUE");
+    rc |= expect_int("valid env name prompts", g_prompt.calls, 1);
+    rc |= expect_str("env prompt prefill", g_prompt.prefill, "old");
+    assert(g_prompt.str_cb != NULL);
+    g_prompt.str_cb(g_prompt.user, "new");
+    rc |= expect_str("env set name", g_env_name, "DSD_NEO_TEST_VALUE");
+    rc |= expect_str("env set value", g_env_value, "new");
+    rc |= expect_int("env set reparse", g_reparse_calls, 1);
+
+    reset_capture();
+    EnvEditCtx* clear = (EnvEditCtx*)calloc(1, sizeof *clear);
+    assert(clear != NULL);
+    clear->c = &ctx;
+    DSD_SNPRINTF(clear->name, sizeof clear->name, "%s", "DSD_NEO_CLEAR_ME");
+    cb_env_edit_value(clear, "");
+    rc |= expect_str("env clear name", g_env_name, "DSD_NEO_CLEAR_ME");
+    rc |= expect_int("env clear calls unset", g_env_unset_calls, 1);
+    rc |= expect_int("env clear reparses", g_reparse_calls, 1);
+
+    reset_capture();
+    cb_lr_custom(&ctx, "lrrp.txt");
+    rc |= expect_cmd_string("lrrp custom", UI_CMD_LRRP_SET_CUSTOM, "lrrp.txt");
+
+    reset_capture();
+    M17Ctx* mc = (M17Ctx*)calloc(1, sizeof *mc);
+    assert(mc != NULL);
+    mc->c = &ctx;
+    cb_m17_user_data(mc, "0,DEST,SOURCE");
+    rc |= expect_cmd_string("m17 user data", UI_CMD_M17_USER_DATA_SET, "0,DEST,SOURCE");
+
+    return rc;
+}
+
+static int
+test_pulse_chooser_callbacks_pack_selected_names(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    reset_capture();
+    PulseSelCtx* out = make_pulse_ctx(&state, "speaker.monitor", "headphones");
+    chooser_done_pulse_out(out, 1);
+    rc |= expect_cmd_string("pulse out selected command", UI_CMD_PULSE_OUT_SET, "headphones");
+    rc |= expect_int("pulse out status", strstr(g_status, "Pulse out requested: headphones") != NULL, 1);
+
+    reset_capture();
+    PulseSelCtx* in = make_pulse_ctx(&state, "mic0", "line-in");
+    chooser_done_pulse_in(in, 0);
+    rc |= expect_cmd_string("pulse in selected command", UI_CMD_PULSE_IN_SET, "mic0");
+    rc |= expect_int("pulse in status", strstr(g_status, "Pulse in requested: mic0") != NULL, 1);
+
+    reset_capture();
+    PulseSelCtx* cancel = make_pulse_ctx(&state, "unused0", "unused1");
+    chooser_done_pulse_in(cancel, -1);
+    rc |= expect_int("pulse cancel no command", g_cmd.calls, 0);
+    rc |= expect_int("pulse cancel no status", g_status_calls, 0);
+
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_path_and_file_callbacks();
+    rc |= test_config_callbacks_apply_and_report_failures();
+    rc |= test_typed_callbacks_clamp_and_cancel();
+    rc |= test_key_callbacks_validate_and_pack();
+    rc |= test_network_and_io_callbacks_pack_payloads();
+    rc |= test_gain_rtl_and_env_callbacks();
+    rc |= test_env_editor_and_protocol_callbacks();
+    rc |= test_pulse_chooser_callbacks_pack_selected_names();
+    if (rc == 0) {
+        printf("UI_MENU_CALLBACKS: OK\n");
+    }
+    return rc;
+}
+
+// NOLINTEND(bugprone-branch-clone,misc-redundant-expression)

--- a/tests/ui/test_ui_menu_defs.c
+++ b/tests/ui/test_ui_menu_defs.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(misc-use-internal-linkage)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/ui/menu_defs.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/ui/menu_core.h"
+
+const NcMenuItem IO_MENU_ITEMS[] = {{.id = "io.child", .label = "IO Child"}};
+const size_t IO_MENU_ITEMS_LEN = sizeof IO_MENU_ITEMS / sizeof IO_MENU_ITEMS[0];
+const NcMenuItem LOGGING_MENU_ITEMS[] = {{.id = "logging.child", .label = "Logging Child"}};
+const size_t LOGGING_MENU_ITEMS_LEN = sizeof LOGGING_MENU_ITEMS / sizeof LOGGING_MENU_ITEMS[0];
+const NcMenuItem TRUNK_MENU_ITEMS[] = {{.id = "trunk.child", .label = "Trunk Child"}};
+const size_t TRUNK_MENU_ITEMS_LEN = sizeof TRUNK_MENU_ITEMS / sizeof TRUNK_MENU_ITEMS[0];
+const NcMenuItem KEYS_MENU_ITEMS[] = {{.id = "keys.child", .label = "Keys Child"}};
+const size_t KEYS_MENU_ITEMS_LEN = sizeof KEYS_MENU_ITEMS / sizeof KEYS_MENU_ITEMS[0];
+const NcMenuItem UI_DISPLAY_MENU_ITEMS[] = {{.id = "ui.child", .label = "UI Child"}};
+const size_t UI_DISPLAY_MENU_ITEMS_LEN = sizeof UI_DISPLAY_MENU_ITEMS / sizeof UI_DISPLAY_MENU_ITEMS[0];
+const NcMenuItem LRRP_MENU_ITEMS[] = {{.id = "lrrp.child", .label = "LRRP Child"}};
+const size_t LRRP_MENU_ITEMS_LEN = sizeof LRRP_MENU_ITEMS / sizeof LRRP_MENU_ITEMS[0];
+const NcMenuItem CONFIG_MENU_ITEMS[] = {{.id = "config.child", .label = "Config Child"}};
+const size_t CONFIG_MENU_ITEMS_LEN = sizeof CONFIG_MENU_ITEMS / sizeof CONFIG_MENU_ITEMS[0];
+const NcMenuItem ADV_MENU_ITEMS[] = {{.id = "adv.child", .label = "Advanced Child"}};
+const size_t ADV_MENU_ITEMS_LEN = sizeof ADV_MENU_ITEMS / sizeof ADV_MENU_ITEMS[0];
+
+static int g_exit_calls = 0;
+
+bool
+io_rtl_active(const void* ctx) {
+    return ctx != NULL;
+}
+
+void
+act_exit(void* v) {
+    (void)v;
+    g_exit_calls++;
+}
+
+static int
+expect_true(const char* label, int cond) {
+    if (!cond) {
+        DSD_FPRINTF(stderr, "FAIL: %s\n", label);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_size_eq(const char* label, size_t got, size_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "FAIL: %s (got %zu want %zu)\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_str_eq(const char* label, const char* got, const char* want) {
+    if (!got || strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s (got %s want %s)\n", label, got ? got : "(null)", want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_menu_item(const NcMenuItem* item, const char* id, const char* label, const NcMenuItem* submenu,
+                 size_t submenu_len) {
+    int rc = 0;
+    rc |= expect_true("menu item", item != NULL);
+    if (!item) {
+        return rc;
+    }
+    rc |= expect_str_eq("menu id", item->id, id);
+    rc |= expect_str_eq("menu label", item->label, label);
+    rc |= expect_true("menu has help", item->help != NULL && item->help[0] != '\0');
+    rc |= expect_true("submenu pointer", item->submenu == submenu);
+    rc |= expect_size_eq("submenu length", item->submenu_len, submenu_len);
+    return rc;
+}
+
+static int
+test_main_menu_contract(void) {
+    const NcMenuItem* items = NULL;
+    const NcMenuItem* second_items = NULL;
+    size_t n = 0;
+    size_t second_n = 0;
+    int rc = 0;
+
+    ui_menu_get_main_items(NULL, NULL, NULL);
+    ui_menu_get_main_items(&items, &n, NULL);
+    ui_menu_get_main_items(&second_items, &second_n, NULL);
+
+    rc |= expect_true("main menu pointer set", items != NULL);
+    rc |= expect_size_eq("main menu count", n, 10U);
+    rc |= expect_true("main menu pointer stable", second_items == items);
+    rc |= expect_size_eq("main menu count stable", second_n, n);
+    if (items == NULL || n < 10U) {
+        return rc != 0 ? rc : 1;
+    }
+
+    rc |= expect_menu_item(&items[0], "main.io", "Devices & IO", IO_MENU_ITEMS, IO_MENU_ITEMS_LEN);
+    rc |= expect_menu_item(&items[1], "main.logging", "Logging & Capture", LOGGING_MENU_ITEMS, LOGGING_MENU_ITEMS_LEN);
+    rc |= expect_menu_item(&items[2], "main.trunk", "Trunking & Control", TRUNK_MENU_ITEMS, TRUNK_MENU_ITEMS_LEN);
+    rc |= expect_menu_item(&items[3], "main.keys", "Keys & Security", KEYS_MENU_ITEMS, KEYS_MENU_ITEMS_LEN);
+    rc |= expect_menu_item(&items[5], "main.ui", "UI Display", UI_DISPLAY_MENU_ITEMS, UI_DISPLAY_MENU_ITEMS_LEN);
+    rc |= expect_menu_item(&items[6], "lrrp", "LRRP", LRRP_MENU_ITEMS, LRRP_MENU_ITEMS_LEN);
+    rc |= expect_menu_item(&items[7], "main.config", "Config", CONFIG_MENU_ITEMS, CONFIG_MENU_ITEMS_LEN);
+    rc |= expect_menu_item(&items[8], "main.adv", "Advanced & Env", ADV_MENU_ITEMS, ADV_MENU_ITEMS_LEN);
+
+    rc |= expect_str_eq("DSP menu id", items[4].id, "main.dsp");
+    rc |= expect_true("DSP predicate wired", items[4].is_enabled == io_rtl_active);
+    rc |= expect_true("DSP submenu disabled without USE_RADIO", items[4].submenu == NULL);
+    rc |= expect_size_eq("DSP submenu length without USE_RADIO", items[4].submenu_len, 0U);
+
+    rc |= expect_str_eq("exit id", items[9].id, "exit");
+    rc |= expect_true("exit has no submenu", items[9].submenu == NULL && items[9].submenu_len == 0U);
+    rc |= expect_true("exit action wired", items[9].on_select == act_exit);
+    items[9].on_select(NULL);
+    rc |= expect_size_eq("exit action invoked", (size_t)g_exit_calls, 1U);
+
+    return rc;
+}
+
+int
+main(void) {
+    return test_main_menu_contract() ? 1 : 0;
+}
+
+// NOLINTEND(misc-use-internal-linkage)

--- a/tests/ui/test_ui_menu_env.c
+++ b/tests/ui/test_ui_menu_env.c
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+
+#include <dsd-neo/platform/posix_compat.h>
+
+#include "menu_env.h"
+
+static void
+test_int_env_defaults_and_validation(void) {
+    (void)dsd_unsetenv("DSD_NEO_TEST_MENU_INT");
+    assert(env_get_int("DSD_NEO_TEST_MENU_INT", 17) == 17);
+
+    env_set_int("DSD_NEO_TEST_MENU_INT", -42);
+    assert(env_get_int("DSD_NEO_TEST_MENU_INT", 17) == -42);
+
+    (void)dsd_setenv("DSD_NEO_TEST_MENU_INT", "12junk", 1);
+    assert(env_get_int("DSD_NEO_TEST_MENU_INT", 17) == 0);
+
+    (void)dsd_unsetenv("DSD_NEO_TEST_MENU_INT");
+}
+
+static void
+test_double_env_defaults_and_validation(void) {
+    (void)dsd_unsetenv("DSD_NEO_TEST_MENU_DOUBLE");
+    assert(env_get_double("DSD_NEO_TEST_MENU_DOUBLE", 1.25) == 1.25);
+
+    env_set_double("DSD_NEO_TEST_MENU_DOUBLE", -3.5);
+    assert(fabs(env_get_double("DSD_NEO_TEST_MENU_DOUBLE", 1.25) - -3.5) < 0.000001);
+
+    (void)dsd_setenv("DSD_NEO_TEST_MENU_DOUBLE", "3.25x", 1);
+    assert(env_get_double("DSD_NEO_TEST_MENU_DOUBLE", 1.25) == 0.0);
+
+    (void)dsd_unsetenv("DSD_NEO_TEST_MENU_DOUBLE");
+}
+
+static void
+test_hex_u64_parser(void) {
+    unsigned long long out = 0;
+
+    assert(parse_hex_u64(NULL, &out) == 0);
+    assert(parse_hex_u64("", &out) == 0);
+    assert(parse_hex_u64("1234", NULL) == 0);
+    assert(parse_hex_u64("12xx", &out) == 0);
+
+    assert(parse_hex_u64("1A2b", &out) == 1);
+    assert(out == 0x1A2bULL);
+}
+
+int
+main(void) {
+    test_int_env_defaults_and_validation();
+    test_double_env_defaults_and_validation();
+    test_hex_u64_parser();
+    printf("UI_MENU_ENV: OK\n");
+    return 0;
+}

--- a/tests/ui/test_ui_menu_labels.c
+++ b/tests/ui/test_ui_menu_labels.c
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Deterministic contracts for terminal UI menu label helpers.
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/io/tcp_input.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/runtime/call_alert.h>
+#include <dsd-neo/runtime/config.h>
+#include <sndfile.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "menu_env.h"
+#include "menu_internal.h"
+#include "menu_labels.h"
+
+static dsdneoRuntimeConfig g_cfg;
+static int g_cfg_valid = 1;
+static int g_stat_path_rc = -1;
+static int g_tcp_valid = 1;
+static int g_env_int_value;
+static int g_env_int_has_value;
+static double g_env_double_value;
+static int g_env_double_has_value;
+
+const dsdneoRuntimeConfig*
+dsd_neo_get_config(void) {
+    return g_cfg_valid ? &g_cfg : NULL;
+}
+
+int
+env_get_int(const char* name, int defv) {
+    (void)name;
+    return g_env_int_has_value ? g_env_int_value : defv;
+}
+
+double
+env_get_double(const char* name, double defv) {
+    (void)name;
+    return g_env_double_has_value ? g_env_double_value : defv;
+}
+
+int
+tcp_input_is_valid(const tcp_input_ctx* ctx) {
+    return (ctx != NULL && g_tcp_valid) ? 1 : 0;
+}
+
+int
+dsd_stat_path(const char* path, dsd_stat_t* st) {
+    (void)path;
+    if (st) {
+        DSD_MEMSET(st, 0, sizeof(*st));
+    }
+    return g_stat_path_rc;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_str(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static void
+reset_fixture(dsd_opts* opts, dsd_state* state, UiCtx* ctx) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(&g_cfg, 0, sizeof(g_cfg));
+    g_cfg_valid = 1;
+    g_stat_path_rc = -1;
+    g_tcp_valid = 1;
+    g_env_int_value = 0;
+    g_env_int_has_value = 0;
+    g_env_double_value = 0.0;
+    g_env_double_has_value = 0;
+    ctx->opts = opts;
+    ctx->state = state;
+}
+
+static int
+test_visibility_and_state_labels(void) {
+    int rc = 0;
+    char b[160];
+    static dsd_opts opts;
+    static dsd_state state;
+    UiCtx ctx;
+    reset_fixture(&opts, &state, &ctx);
+
+    rc |= expect_int("always-on predicate", io_always_on(NULL), 1);
+    rc |= expect_int("rtl active null ctx", io_rtl_active(NULL), 0);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    rc |= expect_int("rtl active input", io_rtl_active(&ctx), 1);
+
+    opts.inverted_dmr = 1;
+    rc |= expect_str("invert all active", lbl_invert_all(&ctx, b, sizeof(b)), "Toggle Signal Inversion [Active]");
+    opts.payload = 0;
+    rc |= expect_str("payload inactive", lbl_toggle_payload(&ctx, b, sizeof(b)), "Toggle Payload Logging [Inactive]");
+    opts.p25_trunk = 1;
+    rc |= expect_str("trunk active", lbl_trunk(&ctx, b, sizeof(b)), "Toggle Trunking [Active]");
+    opts.scanner_mode = 0;
+    rc |= expect_str("scanner inactive", lbl_scan(&ctx, b, sizeof(b)), "Toggle Scanning Mode [Inactive]");
+    opts.p25_lcw_retune = 1;
+    rc |= expect_str("lcw active", lbl_lcw(&ctx, b, sizeof(b)), "Toggle P25 LCW Retune [Active]");
+    opts.trunk_tune_enc_calls = 0;
+    rc |= expect_str("p25 enc lockout on", lbl_p25_enc_lockout(&ctx, b, sizeof(b)), "P25 Encrypted Call Lockout [On]");
+    opts.aggressive_framesync = 0;
+    rc |= expect_str("crc relaxed active", lbl_crc_relax(&ctx, b, sizeof(b)), "Toggle Relaxed CRC checks [Active]");
+    opts.trunk_use_allow_list = 1;
+    rc |= expect_str("allow active", lbl_allow(&ctx, b, sizeof(b)), "Toggle Allow/White List [Active]");
+    opts.trunk_tune_group_calls = 1;
+    opts.trunk_tune_private_calls = 0;
+    opts.trunk_tune_data_calls = 1;
+    rc |= expect_str("tune group active", lbl_tune_group(&ctx, b, sizeof(b)), "Toggle Tune Group Calls [Active]");
+    rc |=
+        expect_str("tune private inactive", lbl_tune_priv(&ctx, b, sizeof(b)), "Toggle Tune Private Calls [Inactive]");
+    rc |= expect_str("tune data active", lbl_tune_data(&ctx, b, sizeof(b)), "Toggle Tune Data Calls [Active]");
+    opts.reverse_mute = 1;
+    opts.dmr_le = 1;
+    opts.p25_prefer_candidates = 1;
+    rc |= expect_str("reverse mute active", lbl_rev_mute(&ctx, b, sizeof(b)), "Toggle Reverse Mute [Active]");
+    rc |= expect_str("dmr le active", lbl_dmr_le(&ctx, b, sizeof(b)), "Toggle DMR Late Entry [Active]");
+    rc |= expect_str("prefer cc active", lbl_pref_cc(&ctx, b, sizeof(b)), "Prefer P25 CC Candidates [Active]");
+
+    return rc;
+}
+
+static int
+test_call_alert_slot_and_muting_labels(void) {
+    int rc = 0;
+    char b[160];
+    static dsd_opts opts;
+    static dsd_state state;
+    UiCtx ctx;
+    reset_fixture(&opts, &state, &ctx);
+
+    opts.slot_preference = 0;
+    rc |= expect_str("slot pref one", lbl_slotpref(&ctx, b, sizeof(b)), "Set TDMA Slot Preference... [now 1]");
+    opts.slot_preference = 1;
+    rc |= expect_str("slot pref two", lbl_slotpref(&ctx, b, sizeof(b)), "Set TDMA Slot Preference... [now 2]");
+    opts.slot_preference = 5;
+    rc |= expect_str("slot pref auto", lbl_slotpref(&ctx, b, sizeof(b)), "Set TDMA Slot Preference... [now Auto]");
+
+    opts.slot1_on = 1;
+    opts.slot2_on = 1;
+    rc |= expect_str("slots both", lbl_slots_on(&ctx, b, sizeof(b)), "Set TDMA Synth Slots... [now both]");
+    opts.slot2_on = 0;
+    rc |= expect_str("slot one", lbl_slots_on(&ctx, b, sizeof(b)), "Set TDMA Synth Slots... [now 1]");
+    opts.slot1_on = 0;
+    opts.slot2_on = 1;
+    rc |= expect_str("slot two", lbl_slots_on(&ctx, b, sizeof(b)), "Set TDMA Synth Slots... [now 2]");
+    opts.slot2_on = 0;
+    rc |= expect_str("slots off", lbl_slots_on(&ctx, b, sizeof(b)), "Set TDMA Synth Slots... [now off]");
+
+    opts.dmr_mute_encL = 1;
+    opts.dmr_mute_encR = 1;
+    opts.unmute_encrypted_p25 = 0;
+    rc |= expect_str("muting active", lbl_muting(&ctx, b, sizeof(b)), "Toggle Encrypted Audio Muting [Active]");
+    opts.unmute_encrypted_p25 = 1;
+    rc |= expect_str("muting inactive", lbl_muting(&ctx, b, sizeof(b)), "Toggle Encrypted Audio Muting [Inactive]");
+
+    opts.call_alert = 0;
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_ALL;
+    rc |= expect_str("call alert inactive", lbl_call_alert(&ctx, b, sizeof(b)), "Toggle Call Alert Beep [Inactive]");
+    rc |= expect_str("call alert events off when disabled", lbl_call_alert_events(&ctx, b, sizeof(b)),
+                     "Call Alert Events [Off]");
+    opts.call_alert = 1;
+    opts.call_alert_events = 0;
+    rc |= expect_str("call alert all when enabled with default", lbl_call_alert_events(&ctx, b, sizeof(b)),
+                     "Call Alert Events [All]");
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START | DSD_CALL_ALERT_EVENT_DATA;
+    rc |= expect_str("call alert start data", lbl_call_alert_events(&ctx, b, sizeof(b)),
+                     "Call Alert Events [Start+Data]");
+
+    return rc;
+}
+
+static int
+test_io_and_capture_labels(void) {
+    int rc = 0;
+    char b[192];
+    static dsd_opts opts;
+    static dsd_state state;
+    UiCtx ctx;
+    reset_fixture(&opts, &state, &ctx);
+
+    rc |= expect_str("current input null", lbl_current_input(NULL, b, sizeof(b)), "Current Input: ?");
+    opts.audio_out_type = 0;
+    rc |= expect_str("current output pulse default", lbl_current_output(&ctx, b, sizeof(b)),
+                     "Current Output: Pulse [default]");
+    DSD_SNPRINTF(opts.pa_output_idx, sizeof(opts.pa_output_idx), "%s", "alsa_output.monitor");
+    rc |= expect_str("current output pulse index", lbl_current_output(&ctx, b, sizeof(b)),
+                     "Current Output: Pulse [alsa_output.monitor]");
+    opts.audio_out_type = 8;
+    DSD_SNPRINTF(opts.udp_hostname, sizeof(opts.udp_hostname), "%s", "239.1.2.3");
+    opts.udp_portno = 23456;
+    rc |=
+        expect_str("current output udp", lbl_current_output(&ctx, b, sizeof(b)), "Current Output: UDP 239.1.2.3:23456");
+
+    opts.audio_in_type = AUDIO_IN_TCP;
+    DSD_SNPRINTF(opts.tcp_hostname, sizeof(opts.tcp_hostname), "%s", "tcp.example");
+    opts.tcp_portno = 7355;
+    rc |= expect_str("current input tcp", lbl_current_input(&ctx, b, sizeof(b)), "Current Input: TCP tcp.example:7355");
+    opts.audio_in_type = AUDIO_IN_UDP;
+    opts.udp_in_portno = 7356;
+    rc |= expect_str("current input udp default addr", lbl_current_input(&ctx, b, sizeof(b)),
+                     "Current Input: UDP 127.0.0.1:7356");
+    opts.audio_in_type = AUDIO_IN_WAV;
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "%s", "capture.wav");
+    rc |= expect_str("current input file", lbl_current_input(&ctx, b, sizeof(b)), "Current Input: capture.wav");
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtl_dev_index = 2;
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "%s", "rtl");
+    rc |= expect_str("current input rtl", lbl_current_input(&ctx, b, sizeof(b)), "Current Input: RTL-SDR dev 2");
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "%s", "soapy:driver=test");
+    rc |= expect_str("current input soapy", lbl_current_input(&ctx, b, sizeof(b)),
+                     "Current Input: SoapySDR [driver=test]");
+    opts.audio_in_type = AUDIO_IN_PULSE;
+    rc |= expect_str("current input pulse", lbl_current_input(&ctx, b, sizeof(b)), "Current Input: Pulse");
+    opts.audio_in_type = AUDIO_IN_STDIN;
+    rc |= expect_str("current input stdin", lbl_current_input(&ctx, b, sizeof(b)), "Current Input: STDIN");
+
+    opts.audio_out = 0;
+    rc |= expect_str("output muted", lbl_out_mute(&ctx, b, sizeof(b)), "Mute Output [On]");
+    opts.monitor_input_audio = 1;
+    opts.use_cosine_filter = 1;
+    opts.input_volume_multiplier = 0;
+    rc |= expect_str("monitor active", lbl_monitor(&ctx, b, sizeof(b)), "Toggle Source Audio Monitor [Active]");
+    rc |= expect_str("cosine active", lbl_cosine(&ctx, b, sizeof(b)), "Toggle Cosine Filter [Active]");
+    rc |= expect_str("input volume clamps display minimum", lbl_input_volume(&ctx, b, sizeof(b)), "Input Volume: 1X");
+
+    opts.audio_in_type = AUDIO_IN_TCP;
+    opts.tcp_in_ctx = (tcp_input_ctx*)0x1;
+    g_tcp_valid = 1;
+    rc |= expect_str("tcp active", lbl_tcp(&ctx, b, sizeof(b)), "TCP Direct Audio: tcp.example:7355 [Active]");
+    g_tcp_valid = 0;
+    rc |= expect_str("tcp inactive", lbl_tcp(&ctx, b, sizeof(b)), "TCP Direct Audio: tcp.example:7355 [Inactive]");
+
+    opts.use_rigctl = 1;
+    opts.rigctl_sockfd = 4;
+    DSD_SNPRINTF(opts.rigctlhostname, sizeof(opts.rigctlhostname), "%s", "rig.local");
+    opts.rigctlportno = 4532;
+    rc |= expect_str("rigctl active", lbl_rigctl(&ctx, b, sizeof(b)), "Rigctl: rig.local:4532 [Active]");
+    opts.rigctl_sockfd = 0;
+    rc |= expect_str("rigctl inactive", lbl_rigctl(&ctx, b, sizeof(b)), "Rigctl: rig.local:4532 [Inactive]");
+
+    opts.symbol_out_f = (FILE*)0x1;
+    DSD_SNPRINTF(opts.symbol_out_file, sizeof(opts.symbol_out_file), "%s", "symbols.bin");
+    rc |= expect_str("symbol save active", lbl_sym_save(&ctx, b, sizeof(b)),
+                     "Save Symbols to File [Active: symbols.bin]");
+    rc |= expect_str("symbol capture active", lbl_stop_symbol_capture(&ctx, b, sizeof(b)),
+                     "Stop Symbol Capture [Active: symbols.bin]");
+    opts.dmr_stereo_wav = 1;
+    opts.wav_out_f = (SNDFILE*)0x1;
+    rc |= expect_str("per call wav active", lbl_per_call_wav(&ctx, b, sizeof(b)), "Save Per-Call WAV [Active]");
+    opts.symbolfile = (FILE*)0x2;
+    opts.audio_in_type = AUDIO_IN_SYMBOL_BIN;
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "%s", "last.bin");
+    rc |= expect_str("stop playback active", lbl_stop_symbol_playback(&ctx, b, sizeof(b)),
+                     "Stop Symbol Playback [Active: last.bin]");
+    g_stat_path_rc = 0;
+    rc |= expect_str("replay last available", lbl_replay_last(&ctx, b, sizeof(b)),
+                     "Replay Last Symbol Capture [last.bin]");
+    g_stat_path_rc = -1;
+    rc |= expect_str("replay last inactive", lbl_replay_last(&ctx, b, sizeof(b)),
+                     "Replay Last Symbol Capture [Inactive]");
+
+    return rc;
+}
+
+static int
+test_env_config_display_and_key_labels(void) {
+    int rc = 0;
+    char b[192];
+    static dsd_opts opts;
+    static dsd_state state;
+    UiCtx ctx;
+    reset_fixture(&opts, &state, &ctx);
+
+    opts.input_warn_db = -33.5;
+    rc |= expect_str("input warn from opts", lbl_input_warn(&ctx, b, sizeof(b)), "Low Input Warning: -33.5 dBFS");
+    g_env_double_has_value = 1;
+    g_env_double_value = -22.25;
+    rc |= expect_str("input warn from env default path", lbl_input_warn(NULL, b, sizeof(b)),
+                     "Low Input Warning: -22.2 dBFS");
+    rc |= expect_str("auto ppm snr env", lbl_auto_ppm_snr(NULL, b, sizeof(b)), "Auto-PPM SNR threshold: -22.2 dB");
+    rc |= expect_str("auto ppm pwr env", lbl_auto_ppm_pwr(NULL, b, sizeof(b)), "Auto-PPM Min power: -22.2 dB");
+    g_env_double_value = 0.75;
+    rc |= expect_str("auto ppm zeroppm env", lbl_auto_ppm_zeroppm(NULL, b, sizeof(b)), "Auto-PPM Zero-lock PPM: 0.75");
+    g_env_int_has_value = 1;
+    g_env_int_value = 75;
+    rc |= expect_str("auto ppm zerohz env", lbl_auto_ppm_zerohz(NULL, b, sizeof(b)), "Auto-PPM Zero-lock Hz: 75");
+    rc |= expect_str("tcp prebuffer env", lbl_tcp_prebuf(NULL, b, sizeof(b)), "RTL-TCP Prebuffer: 75 ms");
+    rc |= expect_str("tcp rcvbuf env", lbl_tcp_rcvbuf(NULL, b, sizeof(b)), "RTL-TCP SO_RCVBUF: 75 bytes");
+    rc |= expect_str("tcp rcvtimeo env", lbl_tcp_rcvtimeo(NULL, b, sizeof(b)), "RTL-TCP SO_RCVTIMEO: 75 ms");
+
+    g_cfg.deemph_mode = DSD_NEO_DEEMPH_NFM;
+    rc |= expect_str("deemphasis nfm", lbl_deemph(NULL, b, sizeof(b)), "Deemphasis: NFM");
+    g_cfg.audio_lpf_is_set = 1;
+    g_cfg.audio_lpf_cutoff_hz = 4200;
+    rc |= expect_str("audio lpf active", lbl_audio_lpf(NULL, b, sizeof(b)), "Audio LPF: 4200 Hz");
+    g_cfg.window_freeze_is_set = 1;
+    g_cfg.window_freeze = 1;
+    rc |= expect_str("window freeze on", lbl_window_freeze(NULL, b, sizeof(b)), "Freeze Symbol Window: On");
+    g_cfg.auto_ppm_freeze_enable = 1;
+    rc |= expect_str("auto ppm freeze on", lbl_auto_ppm_freeze(NULL, b, sizeof(b)), "Auto-PPM Freeze: On");
+    g_cfg.tcp_waitall_enable = 1;
+    rc |= expect_str("tcp waitall on", lbl_tcp_waitall(NULL, b, sizeof(b)), "RTL-TCP MSG_WAITALL: On");
+    g_cfg.rt_sched_enable = 1;
+    rc |= expect_str("rt sched on", lbl_rt_sched(NULL, b, sizeof(b)), "Realtime Scheduling: On");
+    g_cfg.mt_is_set = 1;
+    g_cfg.mt_enable = 1;
+    rc |= expect_str("mt on", lbl_mt(NULL, b, sizeof(b)), "Intra-block MT: On");
+
+    opts.show_p25_metrics = 1;
+    opts.show_p25_group_affiliations = 1;
+    opts.show_channels = 1;
+    rc |= expect_str("show p25 metrics", lbl_ui_p25_metrics(&ctx, b, sizeof(b)), "Show P25 Metrics [On]");
+    rc |= expect_str("show p25 affiliations off", lbl_ui_p25_affil(&ctx, b, sizeof(b)), "Show P25 Affiliations [Off]");
+    rc |=
+        expect_str("show p25 group affiliation", lbl_ui_p25_ga(&ctx, b, sizeof(b)), "Show P25 Group Affiliation [On]");
+    rc |= expect_str("show p25 neighbors off", lbl_ui_p25_neighbors(&ctx, b, sizeof(b)), "Show P25 Neighbors [Off]");
+    rc |= expect_str("show p25 iden off", lbl_ui_p25_iden(&ctx, b, sizeof(b)), "Show P25 IDEN Plan [Off]");
+    rc |= expect_str("show p25 cc candidates off", lbl_ui_p25_ccc(&ctx, b, sizeof(b)), "Show P25 CC Candidates [Off]");
+    rc |= expect_str("show channels", lbl_ui_channels(&ctx, b, sizeof(b)), "Show Channels [On]");
+    rc |=
+        expect_str("show p25 callsign off", lbl_ui_p25_callsign(&ctx, b, sizeof(b)), "Show P25 Callsign Decode [Off]");
+
+    opts.lrrp_file_output = 1;
+    DSD_SNPRINTF(opts.lrrp_out_file, sizeof(opts.lrrp_out_file), "%s", "lrrp.log");
+    rc |= expect_str("lrrp active", lbl_lrrp_current(&ctx, b, sizeof(b)), "LRRP Output [Active: lrrp.log]");
+    state.M = 1;
+    rc |= expect_str("force bp active", lbl_key_force_bp(&ctx, b, sizeof(b)), "Force BP/Scr Priority [Active]");
+    state.H = 0x1234U;
+    state.K1 = 0x11U;
+    state.hytera_key_segments = 1;
+    rc |= expect_str("hytera 40 bit", lbl_key_hytera(&ctx, b, sizeof(b)), "Hytera Privacy (HEX) [40-bit]");
+    state.hytera_key_segments = 2;
+    state.K2 = 0x22U;
+    rc |= expect_str("hytera 128 bit", lbl_key_hytera(&ctx, b, sizeof(b)), "Hytera Privacy (HEX) [128-bit]");
+    state.hytera_key_segments = 4;
+    state.K3 = 0x33U;
+    state.K4 = 0x44U;
+    rc |= expect_str("hytera 256 bit", lbl_key_hytera(&ctx, b, sizeof(b)), "Hytera Privacy (HEX) [256-bit]");
+    DSD_SNPRINTF(state.m17dat, sizeof(state.m17dat), "%s", "unit test");
+    rc |= expect_str("m17 user data", lbl_m17_user_data(&ctx, b, sizeof(b)), "M17 Encoder User Data: unit test");
+
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_visibility_and_state_labels();
+    rc |= test_call_alert_slot_and_muting_labels();
+    rc |= test_io_and_capture_labels();
+    rc |= test_env_config_display_and_key_labels();
+    return rc ? 1 : 0;
+}

--- a/tests/ui/test_ui_menu_labels_radio.c
+++ b/tests/ui/test_ui_menu_labels_radio.c
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Deterministic contracts for USE_RADIO terminal UI menu labels and predicates.
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/io/tcp_input.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/ui/menu_core.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/io/rtl_stream_fwd.h"
+#include "menu_env.h"
+#include "menu_internal.h"
+#include "menu_items.h"
+#include "menu_labels.h"
+
+static dsdneoRuntimeConfig g_cfg;
+static int g_cfg_valid = 1;
+static int g_env_int_value;
+static int g_env_int_has_value;
+static double g_env_double_value;
+static int g_env_double_has_value;
+static int g_rtl_cqpsk;
+static int g_rtl_iq_balance;
+static int g_rtl_iq_dc_on;
+static int g_rtl_iq_dc_k;
+static float g_rtl_ted_gain;
+static int g_rtl_timing_bias;
+static int g_rtl_auto_ppm;
+static int g_rtl_tuner_autogain;
+static int g_rtl_output_kind;
+static int g_ted_child_visible;
+
+static bool
+ted_child_visible(const void* ctx) {
+    (void)ctx;
+    return g_ted_child_visible != 0;
+}
+
+const NcMenuItem DSP_TED_ITEMS[] = {
+    {"ted-visible", "TED Visible", NULL, NULL, ted_child_visible, NULL, NULL, 0},
+};
+const size_t DSP_TED_ITEMS_LEN = sizeof DSP_TED_ITEMS / sizeof DSP_TED_ITEMS[0];
+
+int
+ui_submenu_has_visible(const NcMenuItem* items, size_t n, const void* ctx) {
+    if (!items) {
+        return 0;
+    }
+    for (size_t i = 0; i < n; i++) {
+        if (!items[i].is_enabled || items[i].is_enabled(ctx)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+const dsdneoRuntimeConfig*
+dsd_neo_get_config(void) {
+    return g_cfg_valid ? &g_cfg : NULL;
+}
+
+int
+env_get_int(const char* name, int defv) {
+    (void)name;
+    return g_env_int_has_value ? g_env_int_value : defv;
+}
+
+double
+env_get_double(const char* name, double defv) {
+    (void)name;
+    return g_env_double_has_value ? g_env_double_value : defv;
+}
+
+int
+tcp_input_is_valid(const tcp_input_ctx* ctx) {
+    (void)ctx;
+    return 0;
+}
+
+int
+dsd_stat_path(const char* path, dsd_stat_t* st) {
+    (void)path;
+    if (st) {
+        DSD_MEMSET(st, 0, sizeof(*st));
+    }
+    return -1;
+}
+
+int
+rtl_stream_get_output_kind(void) {
+    return g_rtl_output_kind;
+}
+
+int
+rtl_stream_get_cqpsk_status(int* cqpsk_enable, int* cqpsk_timing_active) {
+    if (cqpsk_enable) {
+        *cqpsk_enable = g_rtl_cqpsk;
+    }
+    if (cqpsk_timing_active) {
+        *cqpsk_timing_active = g_rtl_cqpsk;
+    }
+    return 0;
+}
+
+int
+rtl_stream_get_iq_balance(void) {
+    return g_rtl_iq_balance;
+}
+
+int
+rtl_stream_get_iq_dc(int* out_shift_k) {
+    if (out_shift_k) {
+        *out_shift_k = g_rtl_iq_dc_k;
+    }
+    return g_rtl_iq_dc_on;
+}
+
+float
+rtl_stream_get_ted_gain(void) {
+    return g_rtl_ted_gain;
+}
+
+int
+rtl_stream_cqpsk_timing_bias(const RtlSdrContext* ctx) {
+    (void)ctx;
+    return g_rtl_timing_bias;
+}
+
+int
+rtl_stream_get_auto_ppm(void) {
+    return g_rtl_auto_ppm;
+}
+
+int
+rtl_stream_get_tuner_autogain(void) {
+    return g_rtl_tuner_autogain;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_str(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static void
+reset_fixture(dsd_opts* opts, dsd_state* state, UiCtx* ctx) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(&g_cfg, 0, sizeof(g_cfg));
+    g_cfg_valid = 1;
+    g_env_int_value = 0;
+    g_env_int_has_value = 0;
+    g_env_double_value = 0.0;
+    g_env_double_has_value = 0;
+    g_rtl_cqpsk = 0;
+    g_rtl_iq_balance = 0;
+    g_rtl_iq_dc_on = 0;
+    g_rtl_iq_dc_k = 0;
+    g_rtl_ted_gain = 0.0f;
+    g_rtl_timing_bias = 0;
+    g_rtl_auto_ppm = 0;
+    g_rtl_tuner_autogain = 0;
+    g_rtl_output_kind = RTL_STREAM_OUTPUT_SYMBOL_CQPSK;
+    g_ted_child_visible = 0;
+    ctx->opts = opts;
+    ctx->state = state;
+}
+
+static int
+test_radio_modulation_predicates(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    UiCtx ctx;
+    reset_fixture(&opts, &state, &ctx);
+
+    rc |= expect_int("fallback current modulation", ui_current_mod(&ctx), 0);
+    rc |= expect_int("fallback not qpsk", is_not_qpsk(&ctx), 1);
+    state.rf_mod = 2;
+    rc |= expect_int("rf mod gfsk", ui_current_mod(&ctx), 2);
+    opts.mod_cli_lock = 1;
+    opts.mod_qpsk = 1;
+    rc |= expect_int("cli qpsk overrides rf", ui_current_mod(&ctx), 1);
+    rc |= expect_int("qpsk predicate", is_mod_qpsk(&ctx), 1);
+    g_rtl_cqpsk = 1;
+    opts.mod_qpsk = 0;
+    opts.mod_gfsk = 1;
+    rc |= expect_int("live cqpsk snaps qpsk", ui_current_mod(&ctx), 1);
+    rc |= expect_int("cq predicate", dsp_cq_on(&ctx), 1);
+
+    g_rtl_output_kind = RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
+    rc |= expect_int("ted hidden for fsk discriminator", is_ted_allowed(&ctx), 0);
+    g_rtl_output_kind = RTL_STREAM_OUTPUT_SYMBOL_CQPSK;
+    rc |= expect_int("ted allowed for qpsk symbol output", is_ted_allowed(&ctx), 1);
+    g_ted_child_visible = 0;
+    rc |= expect_int("ted submenu hidden", dsp_ted_any(&ctx), 0);
+    g_ted_child_visible = 1;
+    rc |= expect_int("ted submenu visible", dsp_ted_any(&ctx), 1);
+
+    return rc;
+}
+
+static int
+test_radio_dsp_labels(void) {
+    int rc = 0;
+    char b[160];
+    static dsd_opts opts;
+    static dsd_state state;
+    UiCtx ctx;
+    reset_fixture(&opts, &state, &ctx);
+
+    rc |= expect_str("cq inactive", lbl_onoff_cq(&ctx, b, sizeof(b)), "Toggle CQPSK [Inactive]");
+    g_rtl_cqpsk = 1;
+    rc |= expect_str("cq active", lbl_onoff_cq(&ctx, b, sizeof(b)), "Toggle CQPSK [Active]");
+    g_rtl_iq_balance = 1;
+    rc |= expect_str("iq balance active", lbl_onoff_iqbal(&ctx, b, sizeof(b)), "Toggle IQ Balance [Active]");
+    g_rtl_iq_dc_on = 1;
+    g_rtl_iq_dc_k = 5;
+    rc |= expect_str("iq dc on", lbl_iq_dc(&ctx, b, sizeof(b)), "IQ DC Block [On]");
+    rc |= expect_str("iq dc k", lbl_iq_dc_k(&ctx, b, sizeof(b)), "IQ DC Shift k: 5 (+/-)");
+    g_rtl_ted_gain = 0.0746f;
+    rc |= expect_str("ted gain milli rounds", lbl_ted_gain(&ctx, b, sizeof(b)), "CQPSK Timing Gain: 75 (x0.001, +/-)");
+    g_rtl_timing_bias = -123;
+    rc |= expect_str("timing bias", lbl_cqpsk_timing_bias(&ctx, b, sizeof(b)), "CQPSK Timing Bias (EMA): -123");
+
+    opts.show_dsp_panel = 1;
+    opts.rtl_bias_tee = 1;
+    opts.rtltcp_autotune = 1;
+    rc |= expect_str("dsp panel on", lbl_dsp_panel(&ctx, b, sizeof(b)), "Show DSP Panel [On]");
+    rc |= expect_str("bias tee on", lbl_rtl_bias(&ctx, b, sizeof(b)), "Bias Tee: On");
+    rc |= expect_str("rtl tcp autotune on", lbl_rtl_rtltcp_autotune(&ctx, b, sizeof(b)),
+                     "RTL-TCP Adaptive Networking: On");
+
+    return rc;
+}
+
+static int
+test_radio_config_labels(void) {
+    int rc = 0;
+    char b[160];
+    static dsd_opts opts;
+    static dsd_state state;
+    UiCtx ctx;
+    reset_fixture(&opts, &state, &ctx);
+
+    opts.rtl_auto_ppm = 1;
+    rc |= expect_str("auto ppm opts fallback", lbl_rtl_auto_ppm(&ctx, b, sizeof(b)), "Auto-PPM (Spectrum): On");
+    state.rtl_ctx = (RtlSdrContext*)0x1;
+    g_rtl_auto_ppm = 0;
+    rc |= expect_str("auto ppm live off", lbl_rtl_auto_ppm(&ctx, b, sizeof(b)), "Auto-PPM (Spectrum): Off");
+    g_rtl_auto_ppm = 1;
+    rc |= expect_str("auto ppm live on", lbl_rtl_auto_ppm(&ctx, b, sizeof(b)), "Auto-PPM (Spectrum): On");
+
+    state.rtl_ctx = NULL;
+    g_cfg.tuner_autogain_enable = 1;
+    rc |= expect_str("tuner autogain config", lbl_rtl_tuner_autogain(&ctx, b, sizeof(b)), "Tuner Autogain: On");
+    state.rtl_ctx = (RtlSdrContext*)0x1;
+    g_rtl_tuner_autogain = 0;
+    rc |= expect_str("tuner autogain live off", lbl_rtl_tuner_autogain(&ctx, b, sizeof(b)), "Tuner Autogain: Off");
+    g_rtl_tuner_autogain = 1;
+    rc |= expect_str("tuner autogain live on", lbl_rtl_tuner_autogain(&ctx, b, sizeof(b)), "Tuner Autogain: On");
+
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_radio_modulation_predicates();
+    rc |= test_radio_dsp_labels();
+    rc |= test_radio_config_labels();
+    return rc ? 1 : 0;
+}

--- a/tests/ui/test_ui_menu_navigation.c
+++ b/tests/ui/test_ui_menu_navigation.c
@@ -13,6 +13,7 @@
 
 #include <assert.h>
 #include <curses.h>
+#include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/ui/menu_core.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -38,6 +39,18 @@ volatile uint8_t exitflag = 0; // NOLINT(misc-use-internal-linkage)
 
 static int g_action_calls = 0;
 static const char* g_last_action = NULL;
+static int g_fixture = 0;
+static int g_prompt_active = 0;
+static int g_prompt_key_calls = 0;
+static int g_prompt_render_calls = 0;
+static int g_help_active = 0;
+static int g_help_key_calls = 0;
+static int g_help_open_calls = 0;
+static int g_help_render_calls = 0;
+static char g_last_help[128];
+static int g_chooser_active = 0;
+static int g_chooser_key_calls = 0;
+static int g_chooser_render_calls = 0;
 
 static void
 capture_action(const char* id) {
@@ -98,6 +111,10 @@ static const NcMenuItem SUB_ITEMS[] = {
     {.id = "sub1", .label = "Sub Item 2", .on_select = act_sub1},
 };
 
+static const NcMenuItem HELP_ONLY_ITEMS[] = {
+    {.id = "help0", .label = "Help Only", .help = "leaf help text"},
+};
+
 static const NcMenuItem ROOT_ITEMS[] = {
     {.id = "root0", .label = "Root 0", .on_select = act_root0},
     {.id = "root1", .label = "Root 1", .is_enabled = item_disabled, .on_select = act_root0},
@@ -112,6 +129,21 @@ static void
 reset_capture(void) {
     g_action_calls = 0;
     g_last_action = NULL;
+}
+
+static void
+reset_modal_capture(void) {
+    g_prompt_active = 0;
+    g_prompt_key_calls = 0;
+    g_prompt_render_calls = 0;
+    g_help_active = 0;
+    g_help_key_calls = 0;
+    g_help_open_calls = 0;
+    g_help_render_calls = 0;
+    g_last_help[0] = '\0';
+    g_chooser_active = 0;
+    g_chooser_key_calls = 0;
+    g_chooser_render_calls = 0;
 }
 
 static void
@@ -135,61 +167,75 @@ void
 ui_menu_get_main_items(const NcMenuItem** out_items, size_t* out_n, UiCtx* ctx) { // NOLINT(misc-use-internal-linkage)
     (void)ctx;
     if (out_items) {
-        *out_items = ROOT_ITEMS;
+        *out_items = (g_fixture == 1) ? NULL : ((g_fixture == 2) ? HELP_ONLY_ITEMS : ROOT_ITEMS);
     }
     if (out_n) {
-        *out_n = sizeof ROOT_ITEMS / sizeof ROOT_ITEMS[0];
+        if (g_fixture == 1) {
+            *out_n = 0;
+        } else if (g_fixture == 2) {
+            *out_n = sizeof HELP_ONLY_ITEMS / sizeof HELP_ONLY_ITEMS[0];
+        } else {
+            *out_n = sizeof ROOT_ITEMS / sizeof ROOT_ITEMS[0];
+        }
     }
 }
 
 int
 ui_prompt_active(void) { // NOLINT(misc-use-internal-linkage)
-    return 0;
+    return g_prompt_active;
 }
 
 int
 ui_prompt_handle_key(int ch) { // NOLINT(misc-use-internal-linkage)
     (void)ch;
-    return 0;
+    g_prompt_key_calls++;
+    return 1;
 }
 
 void
 ui_prompt_render(void) { // NOLINT(misc-use-internal-linkage)
+    g_prompt_render_calls++;
 }
 
 int
 ui_help_active(void) { // NOLINT(misc-use-internal-linkage)
-    return 0;
+    return g_help_active;
 }
 
 int
 ui_help_handle_key(int ch) { // NOLINT(misc-use-internal-linkage)
     (void)ch;
-    return 0;
+    g_help_key_calls++;
+    return 1;
 }
 
 void
 ui_help_open(const char* help) { // NOLINT(misc-use-internal-linkage)
-    (void)help;
+    g_help_active = 1;
+    g_help_open_calls++;
+    DSD_SNPRINTF(g_last_help, sizeof g_last_help, "%s", help ? help : "");
 }
 
 void
 ui_help_render(void) { // NOLINT(misc-use-internal-linkage)
+    g_help_render_calls++;
 }
 
 int
 ui_chooser_active(void) { // NOLINT(misc-use-internal-linkage)
-    return 0;
+    return g_chooser_active;
 }
 
 int
 ui_chooser_handle_key(int ch) { // NOLINT(misc-use-internal-linkage)
     (void)ch;
-    return 0;
+    g_chooser_key_calls++;
+    return 1;
 }
 
 void
 ui_chooser_render(void) { // NOLINT(misc-use-internal-linkage)
+    g_chooser_render_calls++;
 }
 
 int
@@ -324,6 +370,11 @@ main(void) {
     dsd_opts* opts = (dsd_opts*)&opts_token;
     dsd_state* state = (dsd_state*)&state_token;
 
+    g_fixture = 1;
+    ui_menu_open_async(opts, state);
+    assert(ui_menu_is_open() == 0);
+
+    g_fixture = 0;
     reset_capture();
     ui_menu_open_async(opts, state);
     assert(ui_menu_is_open() == 1);
@@ -401,6 +452,39 @@ main(void) {
     assert(ui_menu_handle_key(KEY_END, opts, state) == 1);
     assert(ui_menu_handle_key('\r', opts, state) == 1);
     assert_last_action("root6");
+
+    assert(ui_menu_handle_key(KEY_LEFT, opts, state) == 1);
+    assert(ui_menu_is_open() == 0);
+
+    g_fixture = 2;
+    reset_capture();
+    reset_modal_capture();
+    ui_menu_open_async(opts, state);
+    assert(ui_menu_is_open() == 1);
+    assert(ui_menu_handle_key(KEY_RIGHT, opts, state) == 1);
+    assert(g_action_calls == 0);
+    assert(g_help_open_calls == 1);
+    assert(strcmp(g_last_help, "leaf help text") == 0);
+    assert(g_help_active == 1);
+    assert(ui_menu_handle_key(KEY_DOWN, opts, state) == 1);
+    assert(g_help_key_calls == 1);
+    ui_menu_tick(opts, state);
+    assert(g_help_render_calls == 1);
+    g_help_active = 0;
+
+    g_prompt_active = 1;
+    assert(ui_menu_handle_key(KEY_DOWN, opts, state) == 1);
+    assert(g_prompt_key_calls == 1);
+    ui_menu_tick(opts, state);
+    assert(g_prompt_render_calls == 1);
+    g_prompt_active = 0;
+
+    g_chooser_active = 1;
+    assert(ui_menu_handle_key(KEY_UP, opts, state) == 1);
+    assert(g_chooser_key_calls == 1);
+    ui_menu_tick(opts, state);
+    assert(g_chooser_render_calls == 1);
+    g_chooser_active = 0;
 
     assert(ui_menu_handle_key(KEY_LEFT, opts, state) == 1);
     assert(ui_menu_is_open() == 0);

--- a/tests/ui/test_ui_menu_render_helpers.c
+++ b/tests/ui/test_ui_menu_render_helpers.c
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <curses.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/ui/menu_core.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "menu_internal.h"
+
+typedef struct {
+    int enabled_mask;
+    const char* dynamic_suffix;
+} RenderCtx;
+
+static int g_make_window_calls;
+static int g_make_window_h;
+static int g_make_window_w;
+static int g_make_window_y;
+static int g_make_window_x;
+static FILE* g_term_in;
+static FILE* g_term_out;
+static SCREEN* g_screen;
+static int g_status_peek_calls;
+static int g_status_clear_calls;
+static int g_status_peek_result;
+static char g_status_text[64];
+
+WINDOW* ui_make_window(int h, int w, int y, int x);  // NOLINT(misc-use-internal-linkage)
+int ui_status_peek(char* buf, size_t n, time_t now); // NOLINT(misc-use-internal-linkage)
+void ui_status_clear_if_expired(time_t now);         // NOLINT(misc-use-internal-linkage)
+
+WINDOW*
+ui_make_window(int h, int w, int y, int x) { // NOLINT(misc-use-internal-linkage)
+    g_make_window_calls++;
+    g_make_window_h = h;
+    g_make_window_w = w;
+    g_make_window_y = y;
+    g_make_window_x = x;
+    return NULL;
+}
+
+int
+ui_status_peek(char* buf, size_t n, time_t now) { // NOLINT(misc-use-internal-linkage)
+    (void)now;
+    g_status_peek_calls++;
+    if (!g_status_peek_result) {
+        return 0;
+    }
+    if (buf && n > 0) {
+        DSD_SNPRINTF(buf, n, "%s", g_status_text);
+    }
+    return 1;
+}
+
+void
+ui_status_clear_if_expired(time_t now) { // NOLINT(misc-use-internal-linkage)
+    (void)now;
+    g_status_clear_calls++;
+}
+
+static bool
+enabled_bit0(const void* ctx) {
+    const RenderCtx* render_ctx = (const RenderCtx*)ctx;
+    return render_ctx && ((render_ctx->enabled_mask & 0x01) != 0);
+}
+
+static bool
+enabled_bit1(const void* ctx) {
+    const RenderCtx* render_ctx = (const RenderCtx*)ctx;
+    return render_ctx && ((render_ctx->enabled_mask & 0x02) != 0);
+}
+
+static const char*
+dynamic_label(const void* ctx, char* buf, size_t buf_len) {
+    const RenderCtx* render_ctx = (const RenderCtx*)ctx;
+    DSD_SNPRINTF(buf, buf_len, "Dynamic-%s",
+                 (render_ctx && render_ctx->dynamic_suffix) ? render_ctx->dynamic_suffix : "off");
+    return buf;
+}
+
+static const char*
+empty_dynamic_label(const void* ctx, char* buf, size_t buf_len) {
+    (void)ctx;
+    if (buf_len > 0) {
+        buf[0] = '\0';
+    }
+    return buf;
+}
+
+static const NcMenuItem EMPTY_CHILDREN[] = {
+    {.id = "hidden0", .label = "Hidden 0", .is_enabled = enabled_bit0},
+    {.id = "hidden1", .label = "Hidden 1", .is_enabled = enabled_bit0},
+};
+
+static const NcMenuItem MIXED_CHILDREN[] = {
+    {.id = "hidden", .label = "Hidden", .is_enabled = enabled_bit0},
+    {.id = "visible", .label = "Visible child", .is_enabled = enabled_bit1},
+};
+
+static const NcMenuItem ITEMS[] = {
+    {.id = "plain-id"},
+    {.id = "off0", .label = "Off 0", .is_enabled = enabled_bit0},
+    {.id = "submenu-empty",
+     .label = "Empty submenu",
+     .submenu = EMPTY_CHILDREN,
+     .submenu_len = sizeof EMPTY_CHILDREN / sizeof EMPTY_CHILDREN[0]},
+    {.id = "submenu-visible",
+     .label = "Shown submenu",
+     .submenu = MIXED_CHILDREN,
+     .submenu_len = sizeof MIXED_CHILDREN / sizeof MIXED_CHILDREN[0]},
+    {.id = "dynamic", .label = "Fallback dynamic", .label_fn = dynamic_label},
+    {.id = "empty-dynamic", .label = "Fallback", .label_fn = empty_dynamic_label},
+};
+
+static void
+test_visibility_helpers(void) {
+    RenderCtx none = {0, "on"};
+    RenderCtx child_visible = {0x02, "on"};
+
+    assert(ui_is_enabled(NULL, &none) == 0);
+    assert(ui_is_enabled(&ITEMS[0], &none) == 1);
+    assert(ui_is_enabled(&ITEMS[1], &none) == 0);
+    assert(ui_is_enabled(&ITEMS[2], &none) == 0);
+    assert(ui_submenu_has_visible(EMPTY_CHILDREN, sizeof EMPTY_CHILDREN / sizeof EMPTY_CHILDREN[0], &none) == 0);
+
+    assert(ui_is_enabled(&ITEMS[3], &child_visible) == 1);
+    assert(ui_submenu_has_visible(MIXED_CHILDREN, sizeof MIXED_CHILDREN / sizeof MIXED_CHILDREN[0], &child_visible)
+           == 1);
+    assert(ui_submenu_has_visible(NULL, 2, &child_visible) == 0);
+    assert(ui_submenu_has_visible(MIXED_CHILDREN, 0, &child_visible) == 0);
+}
+
+static void
+test_enabled_navigation_and_visible_index(void) {
+    RenderCtx ctx = {0x02, "wide"};
+    size_t count = sizeof ITEMS / sizeof ITEMS[0];
+
+    assert(ui_next_enabled(NULL, count, &ctx, 0, 1) == 0);
+    assert(ui_next_enabled(ITEMS, 0, &ctx, 0, 1) == 0);
+    assert(ui_next_enabled(ITEMS, count, &ctx, 0, 1) == 3);
+    assert(ui_next_enabled(ITEMS, count, &ctx, 3, 1) == 4);
+    assert(ui_next_enabled(ITEMS, count, &ctx, 0, -1) == 5);
+
+    RenderCtx none = {0, "wide"};
+    assert(ui_next_enabled(&ITEMS[1], 1, &none, 0, 1) == 0);
+
+    assert(ui_visible_index_for_item(NULL, count, &ctx, 0) == 0);
+    assert(ui_visible_index_for_item(ITEMS, count, &ctx, -1) == 0);
+    assert(ui_visible_index_for_item(ITEMS, count, &ctx, (int)count) == 0);
+    assert(ui_visible_index_for_item(ITEMS, count, &ctx, 0) == 0);
+    assert(ui_visible_index_for_item(ITEMS, count, &ctx, 3) == 1);
+    assert(ui_visible_index_for_item(ITEMS, count, &ctx, 4) == 2);
+    assert(ui_visible_index_for_item(ITEMS, count, &ctx, 1) == 0);
+}
+
+static void
+test_count_and_labels(void) {
+    RenderCtx ctx = {0x02, "wide"};
+    int maxlab = -1;
+    int visible = ui_visible_count_and_maxlab(ITEMS, sizeof ITEMS / sizeof ITEMS[0], &ctx, &maxlab);
+    assert(visible == 4);
+    assert(maxlab == (int)strlen("Shown submenu >"));
+
+    assert(ui_visible_count_and_maxlab(ITEMS, sizeof ITEMS / sizeof ITEMS[0], &ctx, NULL) == 4);
+
+    char label[64];
+    const char* got = ui_menu_item_label_for_test(NULL, &ctx, label, sizeof label);
+    assert(strcmp(got, "") == 0);
+
+    got = ui_menu_item_label_for_test(&ITEMS[0], &ctx, label, sizeof label);
+    assert(strcmp(got, "plain-id") == 0);
+
+    got = ui_menu_item_label_for_test(&ITEMS[4], &ctx, label, sizeof label);
+    assert(got == label);
+    assert(strcmp(got, "Dynamic-wide") == 0);
+
+    got = ui_menu_item_label_for_test(&ITEMS[5], &ctx, label, sizeof label);
+    assert(strcmp(got, "Fallback") == 0);
+
+    got = ui_menu_item_label_for_test(&ITEMS[3], &ctx, label, sizeof label);
+    assert(got == label);
+    assert(strcmp(got, "Shown submenu >") == 0);
+
+    char tiny[3];
+    got = ui_menu_item_label_for_test(&ITEMS[3], &ctx, tiny, sizeof tiny);
+    assert(got == tiny);
+    assert(strcmp(tiny, "Sh") == 0);
+}
+
+static void
+test_overlay_size_helpers(void) {
+    UiMenuFrame frame = {0};
+    frame.title = "Long overlay title";
+
+    assert(ui_overlay_cap_then_floor_for_test(90, 78, 10) == 78);
+    assert(ui_overlay_cap_then_floor_for_test(4, 78, 10) == 10);
+    assert(ui_overlay_cap_then_floor_for_test(42, 78, 10) == 42);
+
+    assert(ui_overlay_center_axis_for_test(80, 20) == 30);
+    assert(ui_overlay_center_axis_for_test(20, 80) == 0);
+
+    assert(ui_overlay_compute_height_for_test(0) == 9);
+    assert(ui_overlay_compute_height_for_test(2) == 9);
+    assert(ui_overlay_compute_height_for_test(8) == 15);
+
+    assert(ui_overlay_compute_width_for_test(NULL, 0) == 50);
+    assert(ui_overlay_compute_width_for_test(&frame, 8) == 50);
+    frame.title = "A title that is deliberately longer than the footer helper text";
+    assert(ui_overlay_compute_width_for_test(&frame, 8) == (int)strlen(frame.title) + 4);
+    frame.title = "";
+    assert(ui_overlay_compute_width_for_test(&frame, 80) == 84);
+}
+
+static void
+test_overlay_layout_helper(void) {
+    RenderCtx ctx = {0x02, "wide"};
+    UiMenuFrame frame = {0};
+    frame.items = ITEMS;
+    frame.n = sizeof ITEMS / sizeof ITEMS[0];
+    frame.title = "Menu";
+
+    ui_overlay_layout_for_test(NULL, &ctx, 40, 30);
+
+    ui_overlay_layout_for_test(&frame, &ctx, 40, 30);
+    assert(frame.h == 11);
+    assert(frame.w == 28);
+    assert(frame.y == 14);
+    assert(frame.x == 1);
+
+    frame.items = NULL;
+    frame.h = 3;
+    frame.w = 4;
+    frame.y = 5;
+    frame.x = 6;
+    ui_overlay_layout_for_test(&frame, &ctx, 40, 30);
+    assert(frame.h == 3);
+    assert(frame.w == 4);
+    assert(frame.y == 5);
+    assert(frame.x == 6);
+
+    frame.items = ITEMS;
+    frame.n = sizeof ITEMS / sizeof ITEMS[0];
+    ui_overlay_layout_for_test(&frame, &ctx, 7, 9);
+    assert(frame.h == 6);
+    assert(frame.w == 10);
+    assert(frame.y == 0);
+    assert(frame.x == 0);
+}
+
+static void
+test_render_window_guard_paths(void) {
+    int top = 7;
+    ui_draw_menu(NULL, ITEMS, sizeof ITEMS / sizeof ITEMS[0], 3, &top, "Ignored", NULL);
+    assert(top == 7);
+
+    ui_overlay_ensure_window(NULL);
+
+    UiMenuFrame frame = {0};
+    frame.h = 12;
+    frame.w = 34;
+    frame.y = 5;
+    frame.x = 6;
+    g_make_window_calls = 0;
+    ui_overlay_ensure_window(&frame);
+    assert(frame.win == NULL);
+    assert(g_make_window_calls == 1);
+    assert(g_make_window_h == 12);
+    assert(g_make_window_w == 34);
+    assert(g_make_window_y == 5);
+    assert(g_make_window_x == 6);
+
+    ui_overlay_recreate_if_needed(NULL);
+    ui_overlay_recreate_if_needed(&frame);
+    assert(frame.win == NULL);
+}
+
+static int
+start_curses_render_test(void) {
+#ifdef _WIN32
+    return 0;
+#else
+    const char* term = getenv("TERM");
+    if (term == NULL || term[0] == '\0') {
+        (void)setenv("TERM", "xterm-256color", 1);
+    }
+    (void)setenv("LINES", "24", 1);
+    (void)setenv("COLUMNS", "80", 1);
+    g_term_in = tmpfile();
+    g_term_out = tmpfile();
+    if (!g_term_in || !g_term_out) {
+        return 0;
+    }
+    g_screen = newterm(NULL, g_term_out, g_term_in);
+    if (!g_screen) {
+        return 0;
+    }
+    (void)set_term(g_screen);
+    return 1;
+#endif
+}
+
+static void
+stop_curses_render_test(void) {
+    if (g_screen) {
+        endwin();
+        g_screen = NULL;
+    }
+    if (g_term_in) {
+        fclose(g_term_in);
+        g_term_in = NULL;
+    }
+    if (g_term_out) {
+        fclose(g_term_out);
+        g_term_out = NULL;
+    }
+}
+
+static void
+read_window_line(WINDOW* win, int y, char* out, size_t out_size) {
+    assert(out_size > 0);
+    out[0] = '\0';
+    assert(mvwinnstr(win, y, 0, out, (int)out_size - 1) != ERR);
+    out[out_size - 1] = '\0';
+}
+
+static void
+test_draw_menu_scrolls_and_renders_enabled_items(void) {
+    if (!start_curses_render_test()) {
+        stop_curses_render_test();
+        printf("UI_MENU_RENDER_HELPERS: curses draw test skipped\n");
+        return;
+    }
+
+    RenderCtx ctx = {0x02, "wide"};
+    WINDOW* win = newwin(9, 52, 0, 0);
+    assert(win != NULL);
+
+    int top = 0;
+    g_status_peek_calls = 0;
+    g_status_clear_calls = 0;
+    g_status_peek_result = 1;
+    DSD_SNPRINTF(g_status_text, sizeof g_status_text, "ready");
+
+    ui_draw_menu(win, ITEMS, sizeof ITEMS / sizeof ITEMS[0], 4, &top, "Menu Title", &ctx);
+    assert(top == 1);
+    assert(g_status_peek_calls == 1);
+    assert(g_status_clear_calls == 0);
+
+    char line[96];
+    read_window_line(win, 1, line, sizeof line);
+    assert(strstr(line, "Menu Title") != NULL);
+
+    read_window_line(win, 2, line, sizeof line);
+    assert(strstr(line, "Shown submenu >") != NULL);
+
+    read_window_line(win, 3, line, sizeof line);
+    assert(strstr(line, "Dynamic-wide") != NULL);
+
+    read_window_line(win, 4, line, sizeof line);
+    assert(strstr(line, "Fallback") == NULL);
+
+    read_window_line(win, 5, line, sizeof line);
+    assert(strstr(line, "Arrows/PgUp/PgDn/Home/End  (3/4)") != NULL);
+
+    read_window_line(win, 7, line, sizeof line);
+    assert(strstr(line, "Status: ready") != NULL);
+
+    g_status_peek_result = 0;
+    ui_draw_menu(win, ITEMS, sizeof ITEMS / sizeof ITEMS[0], 0, NULL, NULL, &ctx);
+    assert(g_status_clear_calls == 1);
+
+    UiMenuFrame frame = {0};
+    frame.items = ITEMS;
+    frame.n = sizeof ITEMS / sizeof ITEMS[0];
+    frame.title = "Live Layout";
+    ui_overlay_layout(&frame, &ctx);
+    assert(frame.h == 11);
+    assert(frame.w == 50);
+    assert(frame.y == 6);
+    assert(frame.x == 15);
+
+    delwin(win);
+    stop_curses_render_test();
+}
+
+int
+main(void) {
+    test_visibility_helpers();
+    test_enabled_navigation_and_visible_index();
+    test_count_and_labels();
+    test_overlay_size_helpers();
+    test_overlay_layout_helper();
+    test_render_window_guard_paths();
+    test_draw_menu_scrolls_and_renders_enabled_items();
+    printf("UI_MENU_RENDER_HELPERS: OK\n");
+    return 0;
+}

--- a/tests/ui/test_ui_menu_services.c
+++ b/tests/ui/test_ui_menu_services.c
@@ -1,0 +1,674 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Deterministic contracts for terminal UI menu service helpers.
+ */
+
+#include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/constants.h>
+#include <dsd-neo/core/csv_import.h>
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/file_io.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/power.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/io/control.h>
+#include <dsd-neo/io/rigctl_client.h>
+#include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/io/udp_socket_connect.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/runtime/call_alert.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/log.h>
+#include <dsd-neo/ui/menu_services.h>
+#include <sndfile.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/io/rtl_stream_fwd.h"
+#include "dsd-neo/platform/sockets.h"
+
+void
+dsd_neo_log_write(dsd_neo_log_level_t level, const char* format, ...) {
+    (void)level;
+    (void)format;
+}
+
+FILE*
+dsd_fopen_existing_regular_file(const char* path, const char* mode) {
+    (void)path;
+    (void)mode;
+    return NULL;
+}
+
+int
+dsd_fileno(FILE* fp) {
+    (void)fp;
+    return -1;
+}
+
+int
+dsd_fstat(int fd, dsd_stat_t* st) {
+    (void)fd;
+    (void)st;
+    return -1;
+}
+
+int
+dsd_stat_path(const char* path, dsd_stat_t* st) {
+    (void)path;
+    (void)st;
+    return -1;
+}
+
+int
+dsd_stat_is_regular(const dsd_stat_t* st) {
+    (void)st;
+    return 0;
+}
+
+int
+dsd_mkdir(const char* path, int mode) {
+    (void)path;
+    (void)mode;
+    return -1;
+}
+
+int
+dsd_setenv(const char* name, const char* value, int overwrite) {
+    (void)name;
+    (void)value;
+    (void)overwrite;
+    return 0;
+}
+
+void
+parse_audio_output_string(dsd_opts* opts, char* input) {
+    (void)opts;
+    (void)input;
+}
+
+void
+parse_audio_input_string(dsd_opts* opts, char* input) {
+    (void)opts;
+    (void)input;
+}
+
+SNDFILE*
+open_wav_file(char* dir, char* temp_filename, size_t temp_filename_size, uint16_t sample_rate, uint8_t ext) {
+    (void)dir;
+    (void)temp_filename;
+    (void)temp_filename_size;
+    (void)sample_rate;
+    (void)ext;
+    return NULL;
+}
+
+void
+openSymbolOutFile(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+closeSymbolOutFile(dsd_opts* opts, dsd_state* state) {
+    if (opts) {
+        opts->symbol_out_f = NULL;
+    }
+    (void)state;
+}
+
+void
+openWavOutFileLR(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+openWavOutFileRaw(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+int
+csvChanImport(const dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    return -1;
+}
+
+int
+csvKeyImportDec(const dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    return -1;
+}
+
+int
+csvKeyImportHex(const dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    return -1;
+}
+
+int
+dsd_tg_policy_reload_group_file(const dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    return -1;
+}
+
+double
+dB_to_pwr(double dB) {
+    return dB;
+}
+
+int
+dsd_config_expand_path(const char* input, char* output, size_t output_size) {
+    if (!input || !output || output_size == 0) {
+        return -1;
+    }
+    DSD_SNPRINTF(output, output_size, "%s", input);
+    return 0;
+}
+
+void
+init_event_history(Event_History_I* event_struct, uint8_t start, uint8_t stop) {
+    if (!event_struct) {
+        return;
+    }
+    for (uint8_t i = start; i < stop; i++) {
+        DSD_MEMSET(&event_struct->Event_History_Items[i], 0, sizeof(event_struct->Event_History_Items[i]));
+        event_struct->Event_History_Items[i].color_pair = 4;
+        event_struct->Event_History_Items[i].systype = -1;
+        event_struct->Event_History_Items[i].subtype = -1;
+    }
+}
+
+dsd_socket_t
+Connect(char* hostname, int portno) {
+    (void)hostname;
+    (void)portno;
+    return 0;
+}
+
+int
+udp_socket_connect(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    return -1;
+}
+
+int
+udp_socket_connectA(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    return -1;
+}
+
+int
+io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
+    (void)opts;
+    (void)state;
+    (void)freq;
+    return -1;
+}
+
+int
+rtl_stream_soft_stop(RtlSdrContext* ctx) {
+    (void)ctx;
+    return 0;
+}
+
+int
+rtl_stream_destroy(RtlSdrContext* ctx) {
+    (void)ctx;
+    return 0;
+}
+
+int
+rtl_stream_create_mirrored(dsd_opts* opts, RtlSdrContext** out_ctx) {
+    (void)opts;
+    if (out_ctx) {
+        *out_ctx = NULL;
+    }
+    return -1;
+}
+
+int
+rtl_stream_start(RtlSdrContext* ctx) {
+    (void)ctx;
+    return -1;
+}
+
+int
+rtl_stream_request_ppm(dsd_opts* opts, int ppm) {
+    if (!opts) {
+        return -1;
+    }
+    if (ppm < -200) {
+        ppm = -200;
+    }
+    if (ppm > 200) {
+        ppm = 200;
+    }
+    opts->rtlsdr_ppm_error = ppm;
+    return 0;
+}
+
+void
+rtl_stream_set_channel_squelch(float level) {
+    (void)level;
+}
+
+int
+rtl_stream_set_bias_tee(int on) {
+    (void)on;
+    return 0;
+}
+
+void
+rtl_stream_set_rtltcp_autotune(int onoff) {
+    (void)onoff;
+}
+
+void
+rtl_stream_set_auto_ppm(int onoff) {
+    (void)onoff;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_uint(const char* tag, unsigned got, unsigned want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %u want %u\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_ull(const char* tag, unsigned long long got, unsigned long long want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %llu want %llu\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_double(const char* tag, double got, double want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %.3f want %.3f\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_str(const char* tag, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_mute_alert_and_inversion_toggles(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+
+    rc |= expect_int("all mutes null guard", svc_toggle_all_mutes(NULL), -1);
+    opts.unmute_encrypted_p25 = 0;
+    opts.dmr_mute_encL = 1;
+    opts.dmr_mute_encR = 0;
+    rc |= expect_int("all mutes toggle success", svc_toggle_all_mutes(&opts), 0);
+    rc |= expect_int("p25 unmute toggled", opts.unmute_encrypted_p25, 1);
+    rc |= expect_int("dmr left mute toggled", opts.dmr_mute_encL, 0);
+    rc |= expect_int("dmr right mute toggled", opts.dmr_mute_encR, 1);
+
+    rc |= expect_int("call alert null guard", svc_toggle_call_alert(NULL), -1);
+    opts.call_alert = 0;
+    opts.call_alert_events = (uint8_t)(0x80u | DSD_CALL_ALERT_EVENT_DATA);
+    rc |= expect_int("call alert valid event toggle", svc_toggle_call_alert(&opts), 0);
+    rc |= expect_int("call alert masks invalid event bits", opts.call_alert_events, DSD_CALL_ALERT_EVENT_DATA);
+    rc |= expect_int("call alert enables when masked events remain", opts.call_alert, 1);
+    rc |= expect_int("call alert disables on second toggle", svc_toggle_call_alert(&opts), 0);
+    rc |= expect_int("call alert disabled", opts.call_alert, 0);
+
+    opts.call_alert = 0;
+    opts.call_alert_events = 0x80u;
+    rc |= expect_int("call alert invalid-only success", svc_toggle_call_alert(&opts), 0);
+    rc |= expect_int("call alert invalid-only masks to zero", opts.call_alert_events, 0);
+    rc |= expect_int("call alert stays disabled without valid events", opts.call_alert, 0);
+
+    opts.inverted_dmr = 0;
+    opts.inverted_dpmr = 1;
+    opts.inverted_x2tdma = 1;
+    opts.inverted_ysf = 0;
+    opts.inverted_m17 = 1;
+    svc_toggle_inversion(&opts);
+    rc |= expect_int("global inversion dmr drives group", opts.inverted_dmr, 1);
+    rc |= expect_int("global inversion dpmr follows group", opts.inverted_dpmr, 1);
+    rc |= expect_int("global inversion x2 follows group", opts.inverted_x2tdma, 1);
+    rc |= expect_int("global inversion ysf follows group", opts.inverted_ysf, 1);
+    rc |= expect_int("global inversion m17 follows group", opts.inverted_m17, 1);
+    svc_toggle_inv_dmr(&opts);
+    svc_toggle_inv_dpmr(&opts);
+    svc_toggle_inv_x2(&opts);
+    svc_toggle_inv_m17(&opts);
+    rc |= expect_int("dmr protocol inversion toggled independently", opts.inverted_dmr, 0);
+    rc |= expect_int("dpmr protocol inversion toggled independently", opts.inverted_dpmr, 0);
+    rc |= expect_int("x2 protocol inversion toggled independently", opts.inverted_x2tdma, 0);
+    rc |= expect_int("m17 protocol inversion toggled independently", opts.inverted_m17, 0);
+    rc |= expect_int("ysf inversion unchanged by specific toggles", opts.inverted_ysf, 1);
+
+    return rc;
+}
+
+static int
+test_lrrp_event_log_and_history_state(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I histories[2];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(histories, 0, sizeof(histories));
+
+    rc |= expect_int("lrrp home null opts", svc_lrrp_set_home(NULL), -1);
+    rc |= expect_int("lrrp home success", svc_lrrp_set_home(&opts), 0);
+    rc |= expect_int("lrrp home enables output", opts.lrrp_file_output, 1);
+    rc |= expect_str("lrrp home path expanded", opts.lrrp_out_file, "~/lrrp.txt");
+    rc |= expect_int("lrrp custom null opts", svc_lrrp_set_custom(NULL, "x.lrrp"), -1);
+    rc |= expect_int("lrrp custom empty path", svc_lrrp_set_custom(&opts, ""), -1);
+    rc |= expect_int("lrrp dsdp success", svc_lrrp_set_dsdp(&opts), 0);
+    rc |= expect_int("lrrp dsdp enables output", opts.lrrp_file_output, 1);
+    rc |= expect_str("lrrp dsdp path", opts.lrrp_out_file, "DSDPlus.LRRP");
+    rc |= expect_int("lrrp custom success", svc_lrrp_set_custom(&opts, "custom.lrrp"), 0);
+    rc |= expect_str("lrrp custom path", opts.lrrp_out_file, "custom.lrrp");
+    svc_lrrp_disable(&opts);
+    rc |= expect_int("lrrp disable clears flag", opts.lrrp_file_output, 0);
+    rc |= expect_int("lrrp disable clears path", opts.lrrp_out_file[0], '\0');
+
+    rc |= expect_int("event log null opts", svc_set_event_log(NULL, "events.log"), -1);
+    rc |= expect_int("event log empty path", svc_set_event_log(&opts, ""), -1);
+    rc |= expect_int("event log valid path", svc_set_event_log(&opts, "events.log"), 0);
+    rc |= expect_str("event log stores path", opts.event_out_file, "events.log");
+    svc_disable_event_log(&opts);
+    rc |= expect_int("event log disable clears path", opts.event_out_file[0], '\0');
+
+    DSD_SNPRINTF(histories[0].Event_History_Items[0].event_string,
+                 sizeof(histories[0].Event_History_Items[0].event_string), "%s", "slot0");
+    histories[0].Event_History_Items[0].source_id = 1234U;
+    DSD_SNPRINTF(histories[1].Event_History_Items[254].event_string,
+                 sizeof(histories[1].Event_History_Items[254].event_string), "%s", "slot1");
+    histories[1].Event_History_Items[254].source_id = 5678U;
+    state.event_history_s = histories;
+    svc_reset_event_history(&state);
+    rc |= expect_int("history slot0 event reset", histories[0].Event_History_Items[0].event_string[0], '\0');
+    rc |= expect_uint("history slot0 source reset", histories[0].Event_History_Items[0].source_id, 0U);
+    rc |= expect_int("history slot1 event reset", histories[1].Event_History_Items[254].event_string[0], '\0');
+    rc |= expect_uint("history slot1 source reset", histories[1].Event_History_Items[254].source_id, 0U);
+
+    return rc;
+}
+
+static int
+test_p2_trunking_and_slot_controls(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    svc_set_p2_params(&state, 0xFFFFFFULL, 0xFFFFULL, 0xFFFFULL);
+    rc |= expect_ull("p2 wacn clamps to 20 bits", state.p2_wacn, 0xFFFFFULL);
+    rc |= expect_ull("p2 sysid clamps to 12 bits", state.p2_sysid, 0xFFFULL);
+    rc |= expect_ull("p2 cc clamps to 12 bits", state.p2_cc, 0xFFFULL);
+    rc |= expect_int("p2 hardset enabled when all fields nonzero", state.p2_hardset, 1);
+    svc_set_p2_params(&state, 0, 1, 1);
+    rc |= expect_int("p2 hardset disabled when any field zero", state.p2_hardset, 0);
+
+    opts.p25_trunk = 0;
+    opts.trunk_enable = 0;
+    opts.scanner_mode = 1;
+    svc_toggle_trunking(&opts);
+    rc |= expect_int("trunk toggle enables p25 trunk", opts.p25_trunk, 1);
+    rc |= expect_int("trunk toggle mirrors trunk_enable", opts.trunk_enable, 1);
+    rc |= expect_int("trunk toggle disables scanner", opts.scanner_mode, 0);
+    svc_toggle_scanner(&opts);
+    rc |= expect_int("scanner toggle enables scanner", opts.scanner_mode, 1);
+    rc |= expect_int("scanner toggle disables p25 trunk", opts.p25_trunk, 0);
+    rc |= expect_int("scanner toggle disables trunk enable", opts.trunk_enable, 0);
+
+    svc_toggle_tune_group(&opts);
+    svc_toggle_tune_private(&opts);
+    svc_toggle_tune_data(&opts);
+    rc |= expect_int("group-call tune toggled", opts.trunk_tune_group_calls, 1);
+    rc |= expect_int("private-call tune toggled", opts.trunk_tune_private_calls, 1);
+    rc |= expect_int("data-call tune toggled", opts.trunk_tune_data_calls, 1);
+
+    svc_set_tg_hold(&state, 65535U);
+    rc |= expect_uint("tg hold stored", state.tg_hold, 65535U);
+    svc_set_hangtime(&opts, -2.5);
+    rc |= expect_double("negative hangtime clamps to zero", opts.trunk_hangtime, 0.0);
+    svc_set_hangtime(&opts, 3.25);
+    rc |= expect_double("positive hangtime stored", opts.trunk_hangtime, 3.25);
+
+    svc_set_rigctl_setmod_bw(&opts, -10);
+    rc |= expect_int("negative setmod bandwidth clamps low", opts.setmod_bw, 0);
+    svc_set_rigctl_setmod_bw(&opts, 99999);
+    rc |= expect_int("setmod bandwidth clamps high", opts.setmod_bw, 25000);
+    svc_set_rigctl_setmod_bw(&opts, 12500);
+    rc |= expect_int("setmod bandwidth stores in range", opts.setmod_bw, 12500);
+
+    svc_toggle_reverse_mute(&opts);
+    svc_toggle_crc_relax(&opts);
+    svc_toggle_lcw_retune(&opts);
+    svc_toggle_dmr_le(&opts);
+    rc |= expect_int("reverse mute toggled", opts.reverse_mute, 1);
+    rc |= expect_int("crc relax toggled", opts.aggressive_framesync, 1);
+    rc |= expect_int("lcw retune toggled", opts.p25_lcw_retune, 1);
+    rc |= expect_int("dmr little-endian toggled", opts.dmr_le, 1);
+
+    svc_set_slot_pref(&opts, -1);
+    rc |= expect_int("slot preference clamps low", opts.slot_preference, 0);
+    svc_set_slot_pref(&opts, 42);
+    rc |= expect_int("slot preference clamps high", opts.slot_preference, 1);
+    svc_set_slots_onoff(&opts, 1);
+    rc |= expect_int("slot mask enables slot1", opts.slot1_on, 1);
+    rc |= expect_int("slot mask disables slot2", opts.slot2_on, 0);
+    svc_set_slots_onoff(&opts, 2);
+    rc |= expect_int("slot mask disables slot1", opts.slot1_on, 0);
+    rc |= expect_int("slot mask enables slot2", opts.slot2_on, 1);
+    svc_set_slots_onoff(&opts, 3);
+    rc |= expect_int("slot mask enables both slot1", opts.slot1_on, 1);
+    rc |= expect_int("slot mask enables both slot2", opts.slot2_on, 1);
+
+    return rc;
+}
+
+static int
+test_payload_symbol_and_pulse_state(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+
+    opts.payload = 0;
+    svc_toggle_payload(&opts);
+    rc |= expect_int("payload toggle enables", opts.payload, 1);
+    svc_toggle_payload(&opts);
+    rc |= expect_int("payload toggle disables", opts.payload, 0);
+
+    opts.audio_out_type = 0;
+    opts.audio_in_type = AUDIO_IN_SYMBOL_BIN;
+    svc_stop_symbol_playback(&opts);
+    rc |= expect_int("stop symbol playback restores pulse when output is pulse", opts.audio_in_type, AUDIO_IN_PULSE);
+    opts.audio_out_type = 1;
+    opts.audio_in_type = AUDIO_IN_SYMBOL_BIN;
+    svc_stop_symbol_playback(&opts);
+    rc |= expect_int("stop symbol playback restores stdin for non-pulse output", opts.audio_in_type, AUDIO_IN_STDIN);
+
+    DSD_SNPRINTF(opts.symbol_out_file, sizeof opts.symbol_out_file, "%s", "last-symbol.bin");
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", "old-input");
+    opts.symbol_out_f = (FILE*)&opts;
+    svc_stop_symbol_saving(&opts, NULL);
+    rc |= expect_int("stop symbol saving closes output handle", opts.symbol_out_f == NULL, 1);
+    rc |= expect_str("stop symbol saving stores replay path", opts.audio_in_dev, "last-symbol.bin");
+
+    rc |= expect_int("pulse output null opts", svc_set_pulse_output(NULL, "1"), -1);
+    rc |= expect_int("pulse input null opts", svc_set_pulse_input(NULL, "1"), -1);
+    rc |= expect_int("pulse output valid index", svc_set_pulse_output(&opts, "2"), 0);
+    rc |= expect_str("pulse output device set", opts.audio_out_dev, "pulse");
+    rc |= expect_int("pulse output type set", opts.audio_out_type, 0);
+    rc |= expect_int("pulse input valid index", svc_set_pulse_input(&opts, "3"), 0);
+    rc |= expect_str("pulse input device set", opts.audio_in_dev, "pulse");
+    rc |= expect_int("pulse input type set", opts.audio_in_type, AUDIO_IN_PULSE);
+
+    return rc;
+}
+
+#ifdef USE_RADIO
+static int
+test_rtl_service_option_contracts(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    rc |= expect_int("rtl enable null opts", svc_rtl_enable_input(NULL, &state), -1);
+    rc |= expect_int("rtl enable null state", svc_rtl_enable_input(&opts, NULL), -1);
+    rc |= expect_int("rtl enable restart failure", svc_rtl_enable_input(&opts, &state), -1);
+    rc |= expect_int("rtl enable selects rtl input before restart", opts.audio_in_type, AUDIO_IN_RTL);
+    rc |= expect_int("rtl enable leaves stream stopped after create failure", opts.rtl_started, 0);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", "soapy:driver=rtlsdr");
+    rc |= expect_int("soapy dev index is unsupported", svc_rtl_set_dev_index(&opts, &state, 2), DSD_ERR_NOT_SUPPORTED);
+
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", "rtl");
+    rc |= expect_int("rtl dev index clamps low", svc_rtl_set_dev_index(&opts, &state, -3), 0);
+    rc |= expect_int("rtl dev index stored", opts.rtl_dev_index, 0);
+    rc |= expect_int("rtl dev index marks restart", opts.rtl_needs_restart, 1);
+
+    opts.audio_in_type = AUDIO_IN_RTL;
+    rc |= expect_int("active rtl dev index returns restart failure", svc_rtl_set_dev_index(&opts, &state, 4), -1);
+    rc |= expect_int("active rtl dev index stores requested index", opts.rtl_dev_index, 4);
+    rc |= expect_int("active rtl restart clears pending flag before create failure", opts.rtl_needs_restart, 0);
+
+    opts.audio_in_type = 0;
+    rc |= expect_int("rtl gain clamps high", svc_rtl_set_gain(&opts, &state, 99), 0);
+    rc |= expect_int("rtl gain stored", opts.rtl_gain_value, 49);
+    rc |= expect_int("rtl bandwidth invalid defaults", svc_rtl_set_bandwidth(&opts, &state, 7), 0);
+    rc |= expect_int("rtl bandwidth default stored", opts.rtl_dsp_bw_khz, 48);
+    rc |= expect_int("rtl bandwidth valid stored", svc_rtl_set_bandwidth(&opts, &state, 12), 0);
+    rc |= expect_int("rtl bandwidth exact stored", opts.rtl_dsp_bw_khz, 12);
+
+    rc |= expect_int("rtl ppm clamps high", svc_rtl_set_ppm(&opts, 300), 0);
+    rc |= expect_int("rtl ppm stored", opts.rtlsdr_ppm_error, 200);
+    rc |= expect_int("rtl squelch stores converted threshold", svc_rtl_set_sql_db(&opts, -12.5), 0);
+    rc |= expect_double("rtl squelch level stored", opts.rtl_squelch_level, -12.5);
+    rc |= expect_int("rtl volume invalid defaults", svc_rtl_set_volume_mult(&opts, -1), 0);
+    rc |= expect_int("rtl volume default stored", opts.rtl_volume_multiplier, 1);
+    rc |= expect_int("rtl volume valid stored", svc_rtl_set_volume_mult(&opts, 3), 0);
+    rc |= expect_int("rtl volume exact stored", opts.rtl_volume_multiplier, 3);
+
+    state.rtl_ctx = (RtlSdrContext*)&state;
+    rc |= expect_int("rtl bias tee live apply", svc_rtl_set_bias_tee(&opts, &state, 7), 0);
+    rc |= expect_int("rtl bias tee boolean stored", opts.rtl_bias_tee, 1);
+    rc |= expect_int("rtltcp autotune live apply", svc_rtltcp_set_autotune(&opts, &state, 1), 0);
+    rc |= expect_int("rtltcp autotune stored", opts.rtltcp_autotune, 1);
+    rc |= expect_int("rtl auto ppm live apply", svc_rtl_set_auto_ppm(&opts, &state, 0), 0);
+    rc |= expect_int("rtl auto ppm stored", opts.rtl_auto_ppm, 0);
+
+    return rc;
+}
+#endif
+
+static int
+test_file_network_and_import_failure_contracts(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    rc |= expect_int("symbol out empty path", svc_open_symbol_out(&opts, &state, ""), -1);
+    rc |= expect_int("symbol out failed open", svc_open_symbol_out(&opts, &state, "capture.sym"), -1);
+    rc |= expect_str("symbol out path still stored", opts.symbol_out_file, "capture.sym");
+
+    rc |= expect_int("symbol in missing file", svc_open_symbol_in(&opts, &state, "missing.sym"), -1);
+    rc |= expect_int("symbol in missing leaves type unchanged", opts.audio_in_type, 0);
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", "last.sym");
+    rc |= expect_int("symbol replay missing file", svc_replay_last_symbol(&opts, &state), -1);
+
+    rc |= expect_int("static wav invalid path", svc_open_static_wav(&opts, &state, ""), -1);
+    rc |= expect_int("static wav failed open", svc_open_static_wav(&opts, &state, "static.wav"), -1);
+    rc |= expect_str("static wav path stored before open", opts.wav_out_file, "static.wav");
+    rc |= expect_int("static wav mode marked", opts.static_wav_file, 1);
+    rc |= expect_int("raw wav failed open", svc_open_raw_wav(&opts, &state, "raw.wav"), -1);
+    rc |= expect_str("raw wav path stored before open", opts.wav_out_file_raw, "raw.wav");
+
+    rc |= expect_int("dsp output empty name", svc_set_dsp_output_file(&opts, ""), -1);
+    rc |= expect_int("dsp output valid name", svc_set_dsp_output_file(&opts, "symbols.dsp"), 0);
+    rc |= expect_str("dsp output path uses DSP directory", opts.dsp_out_file, "./DSP/symbols.dsp");
+    rc |= expect_int("dsp output flag set", opts.use_dsp_output, 1);
+
+    rc |= expect_int("udp output invalid port", svc_udp_output_config(&opts, &state, "127.0.0.1", 0), -1);
+    rc |= expect_int("udp output socket failure", svc_udp_output_config(&opts, &state, "239.0.0.1", 23456), -1);
+    rc |= expect_str("udp output host stored before connect", opts.udp_hostname, "239.0.0.1");
+    rc |= expect_int("udp output port stored before connect", opts.udp_portno, 23456);
+    rc |= expect_int("udp output type not enabled on connect failure", opts.audio_out_type, 0);
+
+    rc |= expect_int("rigctl invalid port", svc_rigctl_connect(&opts, "localhost", 0), -1);
+    rc |= expect_int("rigctl connect failure", svc_rigctl_connect(&opts, "rig.local", 4532), -1);
+    rc |= expect_str("rigctl host stored before connect", opts.rigctlhostname, "rig.local");
+    rc |= expect_int("rigctl port stored before connect", opts.rigctlportno, 4532);
+    rc |= expect_int("rigctl disabled after connect failure", opts.use_rigctl, 0);
+
+    rc |= expect_int("channel import failure", svc_import_channel_map(&opts, &state, "channels.csv"), -1);
+    rc |= expect_str("channel import path stored", opts.chan_in_file, "channels.csv");
+    rc |= expect_int("group import failure", svc_import_group_list(&opts, &state, "groups.csv"), -1);
+    rc |= expect_str("group import path stored", opts.group_in_file, "groups.csv");
+    rc |= expect_int("keys dec import failure", svc_import_keys_dec(&opts, &state, "keys.csv"), -1);
+    rc |= expect_str("keys dec import path stored", opts.key_in_file, "keys.csv");
+    rc |= expect_int("keys hex import failure", svc_import_keys_hex(&opts, &state, "keys.hex"), -1);
+    rc |= expect_str("keys hex import path stored", opts.key_in_file, "keys.hex");
+
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_mute_alert_and_inversion_toggles();
+    rc |= test_lrrp_event_log_and_history_state();
+    rc |= test_p2_trunking_and_slot_controls();
+    rc |= test_payload_symbol_and_pulse_state();
+#ifdef USE_RADIO
+    rc |= test_rtl_service_option_contracts();
+#endif
+    rc |= test_file_network_and_import_failure_contracts();
+    return rc ? 1 : 0;
+}

--- a/tests/ui/test_ui_ncurses_init.c
+++ b/tests/ui/test_ui_ncurses_init.c
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(misc-use-internal-linkage)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/runtime/unicode.h>
+#include <dsd-neo/ui/ncurses.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "curses.h"
+
+struct WINDOW {
+    int unused;
+};
+
+WINDOW g_stdscr_storage;
+WINDOW* stdscr = &g_stdscr_storage;
+
+static int g_initscr_calls;
+static int g_endwin_calls;
+static int g_escdelay_value;
+static int g_has_colors = 1;
+static int g_use_default_colors_calls;
+static int g_assume_default_colors_calls;
+static int g_init_pair_calls;
+
+static int g_isatty_result;
+static int g_dup_result = 10;
+static int g_devnull_open_ok = 1;
+static int g_fileno_stderr = 2;
+static int g_fileno_devnull = 99;
+static FILE* g_devnull_file;
+static int g_fileno_calls;
+static int g_isatty_calls;
+static int g_dup_calls;
+static int g_dup2_calls;
+static int g_dup2_old[4];
+static int g_dup2_new[4];
+static int g_close_calls;
+static int g_closed_fd[4];
+static int g_fopen_private_calls;
+static const char* g_fopen_private_path;
+static const char* g_fopen_private_mode;
+static int g_unicode_init_calls;
+
+WINDOW*
+initscr(void) {
+    g_initscr_calls++;
+    return stdscr;
+}
+
+int
+curs_set(int visibility) {
+    (void)visibility;
+    return 0;
+}
+
+void
+timeout(int delay) {
+    (void)delay;
+}
+
+int
+start_color(void) {
+    return 0;
+}
+
+int
+keypad(WINDOW* win, int bf) {
+    (void)win;
+    (void)bf;
+    return 0;
+}
+
+int
+has_colors(void) {
+    return g_has_colors;
+}
+
+int
+use_default_colors(void) {
+    g_use_default_colors_calls++;
+    return 0;
+}
+
+int
+assume_default_colors(int fg, int bg) {
+    (void)fg;
+    (void)bg;
+    g_assume_default_colors_calls++;
+    return 0;
+}
+
+int
+init_pair(short pair, short fg, short bg) {
+    (void)pair;
+    (void)fg;
+    (void)bg;
+    g_init_pair_calls++;
+    return 0;
+}
+
+int
+noecho(void) {
+    return 0;
+}
+
+int
+cbreak(void) {
+    return 0;
+}
+
+int
+endwin(void) {
+    g_endwin_calls++;
+    return 0;
+}
+
+int
+set_escdelay(int size) {
+    g_escdelay_value = size;
+    return 0;
+}
+
+int
+wgetch(WINDOW* win) {
+    (void)win;
+    return ERR;
+}
+
+void
+dsd_unicode_init_locale(void) {
+    g_unicode_init_calls++;
+}
+
+int
+dsd_fileno(FILE* fp) {
+    g_fileno_calls++;
+    if (fp == stderr) {
+        return g_fileno_stderr;
+    }
+    if (fp == g_devnull_file) {
+        return g_fileno_devnull;
+    }
+    return -1;
+}
+
+int
+dsd_isatty(int fd) {
+    g_isatty_calls++;
+    assert(fd == g_fileno_stderr);
+    return g_isatty_result;
+}
+
+int
+dsd_dup(int oldfd) {
+    g_dup_calls++;
+    assert(oldfd == g_fileno_stderr);
+    return g_dup_result;
+}
+
+int
+dsd_dup2(int oldfd, int newfd) {
+    assert(g_dup2_calls < 4);
+    g_dup2_old[g_dup2_calls] = oldfd;
+    g_dup2_new[g_dup2_calls] = newfd;
+    g_dup2_calls++;
+    return newfd;
+}
+
+int
+dsd_close(int fd) {
+    assert(g_close_calls < 4);
+    g_closed_fd[g_close_calls++] = fd;
+    return 0;
+}
+
+FILE*
+dsd_fopen_private(const char* path, const char* mode) {
+    g_fopen_private_calls++;
+    g_fopen_private_path = path;
+    g_fopen_private_mode = mode;
+    if (!g_devnull_open_ok) {
+        return NULL;
+    }
+    g_devnull_file = tmpfile();
+    assert(g_devnull_file != NULL);
+    return g_devnull_file;
+}
+
+const char*
+dsd_null_device(void) {
+    return "test-null";
+}
+
+static void
+reset_stubs(void) {
+    g_initscr_calls = 0;
+    g_endwin_calls = 0;
+    g_escdelay_value = 0;
+    g_has_colors = 1;
+    g_use_default_colors_calls = 0;
+    g_assume_default_colors_calls = 0;
+    g_init_pair_calls = 0;
+    g_isatty_result = 0;
+    g_dup_result = 10;
+    g_devnull_open_ok = 1;
+    g_devnull_file = NULL;
+    g_fileno_calls = 0;
+    g_isatty_calls = 0;
+    g_dup_calls = 0;
+    g_dup2_calls = 0;
+    DSD_MEMSET(g_dup2_old, 0, sizeof(g_dup2_old));
+    DSD_MEMSET(g_dup2_new, 0, sizeof(g_dup2_new));
+    g_close_calls = 0;
+    DSD_MEMSET(g_closed_fd, 0, sizeof(g_closed_fd));
+    g_fopen_private_calls = 0;
+    g_fopen_private_path = NULL;
+    g_fopen_private_mode = NULL;
+    g_unicode_init_calls = 0;
+    DSD_MEMSET(edacs_channel_tree, 0x5A, sizeof(edacs_channel_tree));
+}
+
+static void
+test_non_tty_stderr_is_not_suppressed(void) {
+    reset_stubs();
+    g_isatty_result = 0;
+
+    ncursesOpen(NULL, NULL);
+    ncursesClose();
+
+    assert(g_unicode_init_calls == 1);
+    assert(g_initscr_calls == 1);
+    assert(g_escdelay_value == 25);
+    assert(g_use_default_colors_calls == 1);
+    assert(g_assume_default_colors_calls == 1);
+    assert(g_init_pair_calls > 0);
+    assert(edacs_channel_tree[0][0] == 0ULL);
+    assert(g_isatty_calls == 1);
+    assert(g_dup_calls == 0);
+    assert(g_fopen_private_calls == 0);
+    assert(g_dup2_calls == 0);
+    assert(g_close_calls == 0);
+    assert(g_endwin_calls == 1);
+}
+
+static void
+test_tty_stderr_suppressed_once_and_restored(void) {
+    reset_stubs();
+    g_isatty_result = 1;
+    g_dup_result = 42;
+
+    ncursesOpen(NULL, NULL);
+    ncursesOpen(NULL, NULL);
+    ncursesClose();
+
+    assert(g_dup_calls == 1);
+    assert(g_fopen_private_calls == 1);
+    assert(strcmp(g_fopen_private_path, "test-null") == 0);
+    assert(strcmp(g_fopen_private_mode, "w") == 0);
+    assert(g_dup2_calls == 2);
+    assert(g_dup2_old[0] == g_fileno_devnull);
+    assert(g_dup2_new[0] == g_fileno_stderr);
+    assert(g_dup2_old[1] == 42);
+    assert(g_dup2_new[1] == g_fileno_stderr);
+    assert(g_close_calls == 1);
+    assert(g_closed_fd[0] == 42);
+    assert(g_endwin_calls == 1);
+
+    ncursesClose();
+    assert(g_dup2_calls == 2);
+    assert(g_close_calls == 1);
+    assert(g_endwin_calls == 2);
+}
+
+static void
+test_devnull_open_failure_closes_backup(void) {
+    reset_stubs();
+    g_isatty_result = 1;
+    g_dup_result = 77;
+    g_devnull_open_ok = 0;
+
+    ncursesOpen(NULL, NULL);
+    ncursesClose();
+
+    assert(g_dup_calls == 1);
+    assert(g_fopen_private_calls == 1);
+    assert(g_dup2_calls == 0);
+    assert(g_close_calls == 1);
+    assert(g_closed_fd[0] == 77);
+    assert(g_endwin_calls == 1);
+}
+
+int
+main(void) {
+    test_non_tty_stderr_is_not_suppressed();
+    test_tty_stderr_suppressed_once_and_restored();
+    test_devnull_open_failure_closes_backup();
+    return 0;
+}
+
+// NOLINTEND(misc-use-internal-linkage)

--- a/tests/ui/test_ui_ncurses_p25_display_helpers.c
+++ b/tests/ui/test_ui_ncurses_p25_display_helpers.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include "dsd-neo/platform/platform.h"
 
 int ncurses_last_synctype;
 
@@ -35,6 +36,8 @@ reset_printw_capture(void) {
     DSD_MEMSET(g_printw_capture, 0, sizeof(g_printw_capture));
     g_printw_capture_len = 0U;
 }
+
+static void append_printw_capture(const char* fmt, va_list ap) DSD_ATTR_FORMAT(printf, 1, 0);
 
 static void
 append_printw_capture(const char* fmt, va_list ap) {

--- a/tests/ui/test_ui_ncurses_p25_display_helpers.c
+++ b/tests/ui/test_ui_ncurses_p25_display_helpers.c
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-suspicious-include)
+/*
+ * Pure-helper checks for ncurses P25 display state.
+ */
+
+#include <assert.h>
+#include <curses.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/platform/timing.h>
+#include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/trunk_cc_candidates.h>
+#include <dsd-neo/ui/ncurses_internal.h>
+#include <dsd-neo/ui/ui_prims.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+int ncurses_last_synctype;
+
+static dsd_trunk_cc_candidates g_cc_candidates;
+static dsdneoRuntimeConfig g_runtime_config;
+
+uint64_t
+dsd_time_monotonic_ns(void) { // NOLINT(misc-use-internal-linkage)
+    return 0;
+}
+
+const dsdneoRuntimeConfig*
+dsd_neo_get_config(void) { // NOLINT(misc-use-internal-linkage)
+    return &g_runtime_config;
+}
+
+int
+p25_sm_in_tick(void) { // NOLINT(misc-use-internal-linkage)
+    return 0;
+}
+
+const dsd_trunk_cc_candidates*
+dsd_trunk_cc_candidates_peek(const dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    return &g_cc_candidates;
+}
+
+const char*
+dsd_synctype_to_string(int synctype) { // NOLINT(misc-use-internal-linkage)
+    (void)synctype;
+    return "SYNC";
+}
+
+int
+compute_percentiles_u8(const uint8_t* src, int len, double* p50, double* p95) { // NOLINT(misc-use-internal-linkage)
+    (void)src;
+    (void)len;
+    if (p50) {
+        *p50 = 0.0;
+    }
+    if (p95) {
+        *p95 = 0.0;
+    }
+    return 0;
+}
+
+void
+ui_print_lborder_green(void) { // NOLINT(misc-use-internal-linkage)
+}
+
+short
+ui_iden_color_pair(int iden) { // NOLINT(misc-use-internal-linkage)
+    return (short)(20 + iden);
+}
+
+int
+printw(const char* fmt, ...) { // NOLINT(misc-use-internal-linkage)
+    (void)fmt;
+    return 0;
+}
+
+int
+wprintw(WINDOW* win, const char* fmt, ...) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)fmt;
+    return 0;
+}
+
+int
+waddch(WINDOW* win, const chtype ch) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)ch;
+    return 0;
+}
+
+int
+waddnstr(WINDOW* win, const char* str, int n) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)str;
+    (void)n;
+    return 0;
+}
+
+int
+wattr_on(WINDOW* win, attr_t attrs, void* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)attrs;
+    (void)opts;
+    return 0;
+}
+
+int
+wattr_off(WINDOW* win, attr_t attrs, void* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)attrs;
+    (void)opts;
+    return 0;
+}
+
+int
+wattr_get(WINDOW* win, attr_t* attrs, short* pair, void* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)opts;
+    if (attrs) {
+        *attrs = 0;
+    }
+    if (pair) {
+        *pair = 0;
+    }
+    return 0;
+}
+
+int
+wattr_set(WINDOW* win, attr_t attrs, short pair, void* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)attrs;
+    (void)pair;
+    (void)opts;
+    return 0;
+}
+
+WINDOW* stdscr;
+
+#include "../../src/ui/terminal/ncurses_p25_display.c"
+#include "dsd-neo/core/opts.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/protocol/p25/p25_trunk_sm.h"
+
+static void
+set_fdma_iden(dsd_state* state, int iden, int base_freq, int spacing, int explicit_tdma) {
+    state->p25_iden_fdma[iden].populated = 1;
+    state->p25_iden_fdma[iden].base_freq = base_freq;
+    state->p25_iden_fdma[iden].chan_spac = spacing;
+    state->p25_chan_tdma_explicit[iden] = (uint8_t)explicit_tdma;
+}
+
+static void
+set_tdma_iden(dsd_state* state, int iden, int base_freq, int spacing, int chan_type) {
+    state->p25_iden_tdma[iden].populated = 1;
+    state->p25_iden_tdma[iden].base_freq = base_freq;
+    state->p25_iden_tdma[iden].chan_spac = spacing;
+    state->p25_iden_tdma[iden].chan_type = chan_type;
+}
+
+static int
+run_iden_match_cases(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.synctype = DSD_SYNC_P25P1_POS;
+
+    set_fdma_iden(&state, 2, 154000000, 100, 1);
+    const int fdma_ch = (2 << 12) | 7;
+    const long fdma_freq = (154000000L * 5L) + (7L * 100L * 125L);
+    assert(ui_is_iden_channel(&state, fdma_ch, fdma_freq) == 1);
+
+    int iden = -1;
+    assert(ui_match_iden_channel(&state, fdma_ch, fdma_freq, &iden) == 1);
+    assert(iden == 2);
+    assert(ui_match_iden_channel(&state, fdma_ch, fdma_freq + 125L, &iden) == 0);
+    assert(iden == 2);
+
+    state.p25_cc_is_tdma = 1;
+    set_fdma_iden(&state, 3, 160000000, 50, 0);
+    const int implicit_tdma_ch = (3 << 12) | 8;
+    const long implicit_tdma_freq = (160000000L * 5L) + (4L * 50L * 125L);
+    assert(ui_is_iden_channel(&state, implicit_tdma_ch, implicit_tdma_freq) == 1);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.synctype = DSD_SYNC_P25P2_POS;
+    set_tdma_iden(&state, 4, 170000000, 25, 4);
+    const int tdma_ch = (4 << 12) | 9;
+    const long tdma_freq = (170000000L * 5L) + (2L * 25L * 125L);
+    assert(ui_is_iden_channel(&state, tdma_ch, tdma_freq) == 1);
+    assert(ui_is_iden_channel(&state, tdma_ch, tdma_freq + 1L) == 0);
+    assert(ui_is_iden_channel(&state, 0, tdma_freq) == 0);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    assert(ui_is_iden_channel(&state, tdma_ch, tdma_freq) == 0);
+    assert(ui_is_iden_channel(NULL, tdma_ch, tdma_freq) == 0);
+
+    return 0;
+}
+
+static int
+run_active_vc_cases(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    assert(ui_guess_active_vc_freq(NULL) == 0);
+    assert(ui_guess_active_vc_freq(&state) == 0);
+
+    state.p25_vc_freq[0] = 851012500L;
+    assert(ui_guess_active_vc_freq(&state) == 851012500L);
+
+    state.trunk_vc_freq[0] = 852012500L;
+    assert(ui_guess_active_vc_freq(&state) == 852012500L);
+
+    state.trunk_vc_freq[0] = 0;
+    state.p25_vc_freq[0] = 0;
+    DSD_SNPRINTF(state.active_channel[2], sizeof(state.active_channel[2]), "TG 123 Ch: 123A slot 1");
+    state.trunk_chan_map[0x123A] = 853012500L;
+    assert(ui_guess_active_vc_freq(&state) == 853012500L);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_SNPRINTF(state.active_channel[0], sizeof(state.active_channel[0]), "TG 456 Ch: 1234");
+    state.trunk_chan_map[1234] = 854012500L;
+    assert(ui_guess_active_vc_freq(&state) == 854012500L);
+
+    return 0;
+}
+
+static int
+run_voice_average_cases(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    double avg = -1.0;
+    assert(compute_p25p1_voice_avg_err(&state, &avg) == 0);
+    assert(avg == -1.0);
+    state.p25_p1_voice_err_hist_len = 4;
+    state.p25_p1_voice_err_hist_sum = 22;
+    assert(compute_p25p1_voice_avg_err(&state, &avg) == 1);
+    assert(avg == 5.5);
+    assert(compute_p25p1_voice_avg_err(&state, NULL) == 1);
+
+    assert(compute_p25p2_voice_avg_err(&state, -1, &avg) == 0);
+    assert(compute_p25p2_voice_avg_err(&state, 2, &avg) == 0);
+    state.p25_p2_voice_err_hist_len = 3;
+    state.p25_p2_voice_err_hist_sum[0] = 9;
+    state.p25_p2_voice_err_hist_sum[1] = 12;
+    assert(compute_p25p2_voice_avg_err(&state, 0, &avg) == 1);
+    assert(avg == 3.0);
+    assert(compute_p25p2_voice_avg_err(&state, 1, &avg) == 1);
+    assert(avg == 4.0);
+    assert(compute_p25p2_voice_avg_err(&state, 1, NULL) == 1);
+
+    return 0;
+}
+
+static int
+run_neighbor_helper_cases(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&g_cc_candidates, 0, sizeof(g_cc_candidates));
+
+    state.p25_nb_count = 5;
+    state.p25_cc_freq = 852012500L;
+    state.p25_nb_entries[0].freq = 851012500L;
+    state.p25_nb_entries[0].last_seen = 100;
+    state.p25_nb_entries[1].freq = 0;
+    state.p25_nb_entries[1].last_seen = 300;
+    state.p25_nb_entries[2].freq = 852012500L;
+    state.p25_nb_entries[2].last_seen = 125;
+    state.p25_nb_entries[3].freq = 853012500L;
+    state.p25_nb_entries[3].last_seen = 175;
+    state.p25_nb_entries[4].freq = 854012500L;
+    state.p25_nb_entries[4].last_seen = 50;
+
+    int idxs[4] = {-1, -1, -1, -1};
+    assert(ui_collect_neighbor_indices(&state, idxs, 3) == 3);
+    assert(idxs[0] == 0);
+    assert(idxs[1] == 2);
+    assert(idxs[2] == 3);
+
+    ui_sort_neighbors_by_last_seen(&state, idxs, 3);
+    assert(idxs[0] == 3);
+    assert(idxs[1] == 2);
+    assert(idxs[2] == 0);
+
+    g_cc_candidates.count = 2;
+    g_cc_candidates.candidates[0] = 853012500L;
+    g_cc_candidates.candidates[1] = 855012500L;
+    assert(ui_freq_in_cc_candidates(&state, 853012500L) == 1);
+    assert(ui_freq_in_cc_candidates(&state, 851012500L) == 0);
+
+    char line[96];
+    assert(ui_format_neighbor_line(&state, 3, (time_t)200, line, sizeof(line)) > 0);
+    assert(strstr(line, "853.012500 MHz") != NULL);
+    assert(strstr(line, " [C]") != NULL);
+    assert(strstr(line, "age:25s") != NULL);
+
+    assert(ui_format_neighbor_line(&state, 2, (time_t)100, line, sizeof(line)) > 0);
+    assert(strstr(line, "852.012500 MHz [CC]") != NULL);
+    assert(strstr(line, "age:0s") != NULL);
+
+    return 0;
+}
+
+static int
+run_trunk_sm_helper_cases(void) {
+    assert(strcmp(ui_p25_sm_mode_to_str(DSD_P25_SM_MODE_ON_CC), "CC") == 0);
+    assert(strcmp(ui_p25_sm_mode_to_str(DSD_P25_SM_MODE_ON_VC), "VC") == 0);
+    assert(strcmp(ui_p25_sm_mode_to_str(DSD_P25_SM_MODE_HANG), "HANG") == 0);
+    assert(strcmp(ui_p25_sm_mode_to_str(DSD_P25_SM_MODE_HUNTING), "HUNT") == 0);
+    assert(strcmp(ui_p25_sm_mode_to_str(DSD_P25_SM_MODE_ARMED), "ARM") == 0);
+    assert(strcmp(ui_p25_sm_mode_to_str(DSD_P25_SM_MODE_FOLLOW), "FOL") == 0);
+    assert(strcmp(ui_p25_sm_mode_to_str(DSD_P25_SM_MODE_RETURNING), "RET") == 0);
+    assert(strcmp(ui_p25_sm_mode_to_str(-1), "?") == 0);
+
+    assert(ui_sm_tag_symbol("after-tune") == 'V');
+    assert(ui_sm_tag_symbol("after-release") == 'R');
+    assert(ui_sm_tag_symbol("release-deferred") == 'H');
+    assert(ui_sm_tag_symbol("after-neigh") == 'N');
+    assert(ui_sm_tag_symbol("tick") == 'T');
+    assert(ui_sm_tag_symbol("other") == '?');
+
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.p25_sm_tag_head = 2;
+    assert(ui_p25_sm_tag_idx(&state, 0) == 1);
+    assert(ui_p25_sm_tag_idx(&state, 1) == 0);
+    assert(ui_p25_sm_tag_idx(&state, 2) == 7);
+
+    char path[16] = {0};
+    int wrote = ui_append_sm_path_symbol(path, sizeof(path), 0, 'V');
+    assert(wrote == 1);
+    assert(strcmp(path, "V") == 0);
+    wrote = ui_append_sm_path_symbol(path, sizeof(path), wrote, 'R');
+    assert(wrote == 2);
+    assert(strcmp(path, "V\xE2\x86\x92R") == 0);
+
+    char full[4] = "ABC";
+    assert(ui_append_sm_path_symbol(full, sizeof(full), 1, 'Z') == 1);
+    assert(strcmp(full, "ABC") == 0);
+
+    return 0;
+}
+
+static int
+run_iden_summary_helper_cases(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    int total = -1;
+    int confirmed = -1;
+    assert(ui_p25_iden_confirmed_count(&state, &total, &confirmed) == 0);
+    assert(total == 0);
+    assert(confirmed == 0);
+
+    state.p25_iden_fdma[1].populated = 1;
+    state.p25_iden_fdma[1].trust = 1;
+    state.p25_iden_tdma[1].populated = 1;
+    state.p25_iden_tdma[1].trust = 2;
+    state.p25_iden_fdma[2].populated = 1;
+    state.p25_iden_fdma[2].trust = 3;
+    assert(ui_p25_iden_confirmed_count(&state, &total, &confirmed) == 1);
+    assert(total == 3);
+    assert(confirmed == 2);
+
+    assert(ui_p25_iden_entry_has_data(&state.p25_iden_fdma[1]) == 0);
+    state.p25_iden_fdma[1].base_freq = 851000000;
+    assert(ui_p25_iden_entry_has_data(&state.p25_iden_fdma[1]) == 1);
+    state.p25_iden_fdma[1].base_freq = 0;
+    state.p25_iden_fdma[1].chan_spac = 50;
+    assert(ui_p25_iden_entry_has_data(&state.p25_iden_fdma[1]) == 1);
+
+    assert(strcmp(ui_p25_iden_trust_str(2), "ok") == 0);
+    assert(strcmp(ui_p25_iden_trust_str(1), "prov") == 0);
+    assert(strcmp(ui_p25_iden_trust_str(0), "-") == 0);
+
+    return 0;
+}
+
+static int
+run_p2_gate_helper_cases(void) {
+    DSD_MEMSET(&g_runtime_config, 0, sizeof(g_runtime_config));
+    g_runtime_config.p25_ring_hold_s = 1.25;
+    g_runtime_config.p25_mac_hold_s = 4.5;
+
+    double ring_hold = 0.0;
+    double mac_hold = 0.0;
+    ui_get_p2_hold_windows(&ring_hold, &mac_hold);
+    assert(ring_hold == 1.25);
+    assert(mac_hold == 4.5);
+
+    assert(ui_clamp_p2_ring_fill(-2) == 0);
+    assert(ui_clamp_p2_ring_fill(2) == 2);
+    assert(ui_clamp_p2_ring_fill(99) == DSD_P25_P2_AUDIO_RING_DEPTH);
+
+    assert(ui_p2_ring_recent(0, 0.2, 0.75) == 0);
+    assert(ui_p2_ring_recent(1, -0.1, 0.75) == 0);
+    assert(ui_p2_ring_recent(1, 0.8, 0.75) == 0);
+    assert(ui_p2_ring_recent(1, 0.75, 0.75) == 1);
+
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.trunk_hangtime = 2.0;
+
+    assert(ui_p2_slot_active(&opts, &state, 0, 5.0, 0.0, 0.75, 3.0) == 0);
+    state.p25_p2_audio_allowed[0] = 1;
+    assert(ui_p2_slot_active(&opts, &state, 0, 5.0, 0.0, 0.75, 3.0) == 1);
+    assert(ui_p2_slot_active(&opts, &state, 0, 5.0, 3.0, 0.75, 3.0) == 0);
+    state.p25_p2_audio_ring_count[0] = 1;
+    assert(ui_p2_slot_active(&opts, &state, 0, 0.5, 3.0, 0.75, 3.0) == 1);
+    state.p25_p2_audio_allowed[0] = 0;
+    state.p25_p2_audio_ring_count[0] = 0;
+    assert(ui_p2_slot_active(&opts, &state, 0, 2.5, 9.0, 0.75, 3.0) == 1);
+
+    return 0;
+}
+
+int
+main(void) {
+    run_iden_match_cases();
+    run_active_vc_cases();
+    run_voice_average_cases();
+    run_neighbor_helper_cases();
+    run_trunk_sm_helper_cases();
+    run_iden_summary_helper_cases();
+    run_p2_gate_helper_cases();
+    printf("UI_NCURSES_P25_DISPLAY_HELPERS: OK\n");
+    return 0;
+}
+
+// NOLINTEND(bugprone-suspicious-include)

--- a/tests/ui/test_ui_ncurses_p25_display_helpers.c
+++ b/tests/ui/test_ui_ncurses_p25_display_helpers.c
@@ -17,6 +17,7 @@
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/ui/ncurses_internal.h>
 #include <dsd-neo/ui/ui_prims.h>
+#include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -26,6 +27,37 @@ int ncurses_last_synctype;
 
 static dsd_trunk_cc_candidates g_cc_candidates;
 static dsdneoRuntimeConfig g_runtime_config;
+static char g_printw_capture[4096];
+static size_t g_printw_capture_len;
+
+static void
+reset_printw_capture(void) {
+    DSD_MEMSET(g_printw_capture, 0, sizeof(g_printw_capture));
+    g_printw_capture_len = 0U;
+}
+
+static void
+append_printw_capture(const char* fmt, va_list ap) {
+    if (!fmt || g_printw_capture_len >= sizeof(g_printw_capture) - 1U) {
+        return;
+    }
+    size_t remaining = sizeof(g_printw_capture) - g_printw_capture_len;
+    int wrote = DSD_VSNPRINTF(g_printw_capture + g_printw_capture_len, remaining, fmt, ap);
+    if (wrote <= 0) {
+        return;
+    }
+    if ((size_t)wrote >= remaining) {
+        g_printw_capture_len = sizeof(g_printw_capture) - 1U;
+    } else {
+        g_printw_capture_len += (size_t)wrote;
+    }
+}
+
+static void
+assert_capture_contains(const char* needle) {
+    assert(needle != NULL);
+    assert(strstr(g_printw_capture, needle) != NULL);
+}
 
 uint64_t
 dsd_time_monotonic_ns(void) { // NOLINT(misc-use-internal-linkage)
@@ -78,7 +110,10 @@ ui_iden_color_pair(int iden) { // NOLINT(misc-use-internal-linkage)
 
 int
 printw(const char* fmt, ...) { // NOLINT(misc-use-internal-linkage)
-    (void)fmt;
+    va_list ap;
+    va_start(ap, fmt);
+    append_printw_capture(fmt, ap);
+    va_end(ap);
     return 0;
 }
 
@@ -385,6 +420,64 @@ run_iden_summary_helper_cases(void) {
 }
 
 static int
+run_iden_render_cases(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.p25_iden_fdma[5].populated = 1;
+    state.p25_iden_fdma[5].base_freq = 170200000;
+    state.p25_iden_fdma[5].chan_spac = 100;
+    state.p25_iden_fdma[5].chan_type = 1;
+    state.p25_iden_fdma[5].trans_off = -45000000;
+    state.p25_iden_fdma[5].trust = 2;
+    state.p25_iden_fdma[5].wacn = 0xABCDEULL;
+    state.p25_iden_fdma[5].sysid = 0x123ULL;
+    state.p25_iden_fdma[5].rfss = 2ULL;
+    state.p25_iden_fdma[5].site = 7ULL;
+    state.p25_iden_tdma[5].populated = 1;
+    state.p25_iden_tdma[5].base_freq = 170400000;
+    state.p25_iden_tdma[5].chan_spac = 50;
+    state.p25_iden_tdma[5].chan_type = 4;
+    state.p25_iden_tdma[5].trust = 1;
+
+    reset_printw_capture();
+    ui_print_p25_iden_plan(NULL, &state);
+    assert_capture_contains("IDEN 5: FDMA[F/T] type:1 base:851.000000MHz spac:0.012500MHz off:-45000000 trust:ok");
+    assert_capture_contains("W:ABCDE S:123");
+    assert_capture_contains("R:2 I:7");
+    assert_capture_contains("IDEN 5: TDMA[F/T] type:4 base:852.000000MHz spac:0.006250MHz off:0 trust:prov");
+
+    return 0;
+}
+
+static int
+run_p25_frequency_display_cases(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.trunk_cc_freq = 851012500L;
+    state.trunk_vc_freq[0] = 852012500L;
+    reset_printw_capture();
+    assert(ui_print_p25_cc_vc_metric(&state) == 1);
+    assert_capture_contains("| CC/VC: CC:851.012500 MHz VC:852.012500 MHz");
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.p25_cc_freq = 853012500L;
+    DSD_SNPRINTF(state.active_channel[3], sizeof(state.active_channel[3]), "Active Group Ch: 123A TG: 100;");
+    state.trunk_chan_map[0x123A] = 854012500L;
+    reset_printw_capture();
+    assert(ui_print_p25_cc_vc_metric(&state) == 1);
+    assert_capture_contains("| CC/VC: CC:853.012500 MHz VC:854.012500 MHz");
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_printw_capture();
+    assert(ui_print_p25_cc_vc_metric(&state) == 1);
+    assert_capture_contains("| CC/VC: CC:- VC:-");
+
+    return 0;
+}
+
+static int
 run_p2_gate_helper_cases(void) {
     DSD_MEMSET(&g_runtime_config, 0, sizeof(g_runtime_config));
     g_runtime_config.p25_ring_hold_s = 1.25;
@@ -432,6 +525,8 @@ main(void) {
     run_neighbor_helper_cases();
     run_trunk_sm_helper_cases();
     run_iden_summary_helper_cases();
+    run_iden_render_cases();
+    run_p25_frequency_display_cases();
     run_p2_gate_helper_cases();
     printf("UI_NCURSES_P25_DISPLAY_HELPERS: OK\n");
     return 0;

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -30,6 +30,7 @@
 #include <dsd-neo/ui/ui_async.h>
 #include <dsd-neo/ui/ui_history.h>
 #include <dsd-neo/ui/ui_prims.h>
+#include <stdarg.h>
 #include <stdint.h>
 #include <string.h>
 #include <time.h>
@@ -38,9 +39,44 @@ int ncurses_last_synctype;
 WINDOW* stdscr;
 unsigned long long int edacs_channel_tree[33][6];
 
+static char g_printw_capture[4096];
+static size_t g_printw_capture_len;
+
+static void
+reset_printw_capture(void) {
+    DSD_MEMSET(g_printw_capture, 0, sizeof(g_printw_capture));
+    g_printw_capture_len = 0U;
+}
+
+static void
+append_printw_capture(const char* fmt, va_list ap) {
+    if (!fmt || g_printw_capture_len >= sizeof(g_printw_capture) - 1U) {
+        return;
+    }
+    size_t remaining = sizeof(g_printw_capture) - g_printw_capture_len;
+    int wrote = DSD_VSNPRINTF(g_printw_capture + g_printw_capture_len, remaining, fmt, ap);
+    if (wrote <= 0) {
+        return;
+    }
+    if ((size_t)wrote >= remaining) {
+        g_printw_capture_len = sizeof(g_printw_capture) - 1U;
+    } else {
+        g_printw_capture_len += (size_t)wrote;
+    }
+}
+
+static void
+assert_capture_contains(const char* needle) {
+    assert(needle != NULL);
+    assert(strstr(g_printw_capture, needle) != NULL);
+}
+
 int
 printw(const char* fmt, ...) { // NOLINT(misc-use-internal-linkage)
-    (void)fmt;
+    va_list ap;
+    va_start(ap, fmt);
+    append_printw_capture(fmt, ap);
+    va_end(ap);
     return 0;
 }
 
@@ -356,6 +392,138 @@ test_input_source_helpers(void) {
     assert(ui_audio_in_is_soapy(&opts) == 1);
     DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "rtl");
     assert(ui_audio_in_is_soapy(&opts) == 0);
+}
+
+static void
+test_basic_input_source_rendering(void) {
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+
+    opts.audio_in_type = AUDIO_IN_PULSE;
+    opts.pulse_digi_rate_in = 48000;
+    opts.pulse_digi_in_channels = 2;
+    opts.input_volume_multiplier = 3;
+    opts.use_rigctl = 1;
+    opts.rigctlportno = 4532;
+    DSD_SNPRINTF(opts.pa_input_idx, sizeof(opts.pa_input_idx), "pulse-device");
+    DSD_SNPRINTF(opts.tcp_hostname, sizeof(opts.tcp_hostname), "radio.local");
+    reset_printw_capture();
+    ui_render_basic_input_sources(&opts);
+    assert_capture_contains("| Pulse Signal Input:  48 kHz; 2 Ch;");
+    assert_capture_contains(" D: pulse-device;");
+    assert_capture_contains("RIG: radio.local:4532;");
+    assert_capture_contains(" IV: 3X;");
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.audio_in_type = AUDIO_IN_TCP;
+    opts.wav_sample_rate = 48000;
+    opts.tcp_portno = 7355;
+    opts.input_volume_multiplier = 4;
+    DSD_SNPRINTF(opts.tcp_hostname, sizeof(opts.tcp_hostname), "10.0.0.5");
+    reset_printw_capture();
+    ui_render_basic_input_sources(&opts);
+    assert_capture_contains("| TCP Signal Input: 10.0.0.5:7355; 48 kHz; 1 Ch;");
+    assert_capture_contains(" IV: 4X;");
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.audio_in_type = AUDIO_IN_UDP;
+    opts.wav_sample_rate = 96000;
+    opts.udp_in_portno = 23456;
+    opts.input_volume_multiplier = 5;
+    reset_printw_capture();
+    ui_render_basic_input_sources(&opts);
+    assert_capture_contains("| UDP Signal Input: 127.0.0.1:23456; 96 kHz; 1 Ch;");
+    assert_capture_contains("[Waiting]");
+
+    opts.udp_in_packets = 42ULL;
+    opts.udp_in_drops = 3ULL;
+    DSD_SNPRINTF(opts.udp_in_bindaddr, sizeof(opts.udp_in_bindaddr), "0.0.0.0");
+    reset_printw_capture();
+    ui_render_basic_input_sources(&opts);
+    assert_capture_contains("| UDP Signal Input: 0.0.0.0:23456; 96 kHz; 1 Ch;");
+    assert_capture_contains("Pkts:42 Drops:3");
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    opts.input_volume_multiplier = 2;
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "capture.wav");
+    reset_printw_capture();
+    ui_render_basic_input_sources(&opts);
+    assert_capture_contains("| WAV Audio Input: capture.wav; 48000 kHz;");
+    assert_capture_contains(" IV: 2X;");
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.audio_in_type = AUDIO_IN_STDIN;
+    reset_printw_capture();
+    ui_render_basic_input_sources(&opts);
+    assert_capture_contains("| STDIN Standard Input: - Menu Disabled when using STDIN!");
+}
+
+static void
+test_rtl_and_soapy_input_source_rendering(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtl_dev_index = 2;
+    opts.rtl_gain_value = 21;
+    opts.rtl_volume_multiplier = 3;
+    opts.rtlsdr_ppm_error = -7;
+    opts.rtl_squelch_level = -37.5f;
+    opts.rtl_dsp_bw_khz = 24;
+    opts.rtlsdr_center_freq = 851012500;
+    opts.rtl_udp_port = 5555;
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "rtl");
+    DSD_SNPRINTF(opts.rtl_udp_bindaddr, sizeof(opts.rtl_udp_bindaddr), "127.0.0.1");
+    reset_printw_capture();
+    ui_render_rtl_input_source(&opts, &state);
+    assert_capture_contains("| RTL: 2;");
+    assert_capture_contains(" G: 21dB;");
+    assert_capture_contains(" Mon: 3X;");
+    assert_capture_contains(" PPM: -7;");
+    assert_capture_contains(" SQL: -37.5 dB;");
+    assert_capture_contains(" DSP-BW: 24 kHz;");
+    assert_capture_contains(" FRQ: 851012500;");
+    assert_capture_contains("| Auto PPM: Off");
+    assert_capture_contains("| External RTL Tuning on UDP: 127.0.0.1:5555");
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtl_gain_value = 0;
+    opts.rtl_dsp_bw_khz = 12;
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "soapy:driver=rtlsdr");
+    reset_printw_capture();
+    ui_render_rtl_input_source(&opts, &state);
+    assert_capture_contains("| SoapySDR: driver=rtlsdr;");
+    assert_capture_contains(" G: AGC;");
+    assert_capture_contains(" DSP-BW: 12 kHz;");
+
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "soapy");
+    reset_printw_capture();
+    ui_render_rtl_input_source(&opts, &state);
+    assert_capture_contains("| SoapySDR;");
+}
+
+static void
+test_rtl_auto_ppm_status_rendering(void) {
+    reset_printw_capture();
+    ui_print_rtl_auto_ppm_status_values(0, 0, 0, -100.0, 0.0, 0);
+    assert_capture_contains("| Auto PPM: Off");
+
+    reset_printw_capture();
+    ui_print_rtl_auto_ppm_status_values(1, 0, 0, 18.2, -122.5, 1);
+    assert_capture_contains("| Auto PPM: On; SNR: 18.2 dB; df: -122.5 Hz; step: +1;");
+
+    reset_printw_capture();
+    ui_print_rtl_auto_ppm_status_values(1, 0, 0, 20.0, 0.0, 0);
+    assert_capture_contains("| Auto PPM: On; SNR: 20.0 dB; df: 0.0 Hz; step: hold;");
+
+    reset_printw_capture();
+    ui_print_rtl_auto_ppm_status_values(1, 1, -12, 25.0, 10.0, -1);
+    assert_capture_contains("| Auto PPM: Locked (PPM: -12)");
 }
 
 static void
@@ -684,6 +852,9 @@ test_lock_and_protocol_helpers(void) {
 int
 main(void) {
     test_input_source_helpers();
+    test_basic_input_source_rendering();
+    test_rtl_and_soapy_input_source_rendering();
+    test_rtl_auto_ppm_status_rendering();
     test_demod_symbol_rate_helpers();
     test_input_level_policy();
     test_history_and_sort_helpers();

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -34,6 +34,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <time.h>
+#include "dsd-neo/platform/platform.h"
 
 int ncurses_last_synctype;
 WINDOW* stdscr;
@@ -47,6 +48,8 @@ reset_printw_capture(void) {
     DSD_MEMSET(g_printw_capture, 0, sizeof(g_printw_capture));
     g_printw_capture_len = 0U;
 }
+
+static void append_printw_capture(const char* fmt, va_list ap) DSD_ATTR_FORMAT(printf, 1, 0);
 
 static void
 append_printw_capture(const char* fmt, va_list ap) {

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -1,0 +1,698 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-suspicious-include)
+/*
+ * Pure-helper checks for the ncurses dashboard printer.
+ */
+
+#include <assert.h>
+#include <curses.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/power.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/sync_patterns.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/protocol/edacs/edacs_afs.h>
+#include <dsd-neo/protocol/m17/m17_parse.h>
+#include <dsd-neo/protocol/p25/p25_callsign.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/telemetry.h>
+#include <dsd-neo/ui/menu_core.h>
+#include <dsd-neo/ui/ncurses.h>
+#include <dsd-neo/ui/ncurses_dsp_display.h>
+#include <dsd-neo/ui/ncurses_internal.h>
+#include <dsd-neo/ui/ncurses_p25_display.h>
+#include <dsd-neo/ui/ncurses_trunk_display.h>
+#include <dsd-neo/ui/panels.h>
+#include <dsd-neo/ui/ui_async.h>
+#include <dsd-neo/ui/ui_history.h>
+#include <dsd-neo/ui/ui_prims.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+int ncurses_last_synctype;
+WINDOW* stdscr;
+unsigned long long int edacs_channel_tree[33][6];
+
+int
+printw(const char* fmt, ...) { // NOLINT(misc-use-internal-linkage)
+    (void)fmt;
+    return 0;
+}
+
+int
+wprintw(WINDOW* win, const char* fmt, ...) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)fmt;
+    return 0;
+}
+
+int
+waddch(WINDOW* win, const chtype ch) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)ch;
+    return 0;
+}
+
+int
+waddnstr(WINDOW* win, const char* str, int n) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)str;
+    (void)n;
+    return 0;
+}
+
+int
+wattr_on(WINDOW* win, attr_t attrs, void* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)attrs;
+    (void)opts;
+    return 0;
+}
+
+int
+wattr_off(WINDOW* win, attr_t attrs, void* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)attrs;
+    (void)opts;
+    return 0;
+}
+
+int
+werase(WINDOW* win) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    return 0;
+}
+
+int
+wmove(WINDOW* win, int y, int x) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)y;
+    (void)x;
+    return 0;
+}
+
+int
+whline(WINDOW* win, chtype ch, int n) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)ch;
+    (void)n;
+    return 0;
+}
+
+int
+getmaxx(const WINDOW* win) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    return 80;
+}
+
+int
+getmaxy(const WINDOW* win) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    return 24;
+}
+
+int
+getcurx(const WINDOW* win) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    return 0;
+}
+
+int
+getcury(const WINDOW* win) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    return 0;
+}
+
+int
+ui_is_thread_context(void) { // NOLINT(misc-use-internal-linkage)
+    return 1;
+}
+
+void
+ui_publish_both_and_redraw(const dsd_opts* opts, const dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+int
+ui_is_locked_from_label(const dsd_state* state, const char* label) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    return label != NULL && strstr(label, "Locked") != NULL;
+}
+
+int
+dsd_tg_policy_lookup_label(const dsd_state* state, uint32_t id, char* mode, size_t mode_sz, char* name,
+                           size_t name_sz) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    if (id != 1234U) {
+        return 0;
+    }
+    if (mode && mode_sz > 0U) {
+        DSD_SNPRINTF(mode, mode_sz, "A");
+    }
+    if (name && name_sz > 0U) {
+        DSD_SNPRINTF(name, name_sz, "Dispatch");
+    }
+    return 1;
+}
+
+double
+pwr_to_dB(double mean_power) { // NOLINT(misc-use-internal-linkage)
+    return mean_power;
+}
+
+const char*
+dsd_input_level_status_label(dsd_input_level_status status) { // NOLINT(misc-use-internal-linkage)
+    (void)status;
+    return "ok";
+}
+
+const char*
+dsd_input_level_display_label(dsd_input_level_source source) { // NOLINT(misc-use-internal-linkage)
+    (void)source;
+    return "Input";
+}
+
+int
+dsd_input_level_source_is_rf(dsd_input_level_source source) { // NOLINT(misc-use-internal-linkage)
+    return source != DSD_INPUT_LEVEL_SOURCE_PCM;
+}
+
+int
+getAfsString(const dsd_state* state, char* buffer, int a, int f, int s) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    (void)a;
+    (void)f;
+    (void)s;
+    DSD_SNPRINTF(buffer, 8, "00-00");
+    return 0;
+}
+
+int
+getAfsStringLength(const dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    return 6;
+}
+
+int
+compute_p25p1_voice_avg_err(const dsd_state* s, double* out_avg) { // NOLINT(misc-use-internal-linkage)
+    (void)s;
+    if (out_avg) {
+        *out_avg = 0.0;
+    }
+    return 0;
+}
+
+size_t
+ui_history_compact_event_text(char* out, size_t out_size, const char* event_text,
+                              int mode) { // NOLINT(misc-use-internal-linkage)
+    (void)mode;
+    if (out_size > 0U) {
+        DSD_SNPRINTF(out, out_size, "%s", event_text ? event_text : "");
+    }
+    return event_text ? strlen(event_text) : 0U;
+}
+
+time_t
+ui_history_event_sort_time(const char* event_text, time_t fallback_time) { // NOLINT(misc-use-internal-linkage)
+    (void)event_text;
+    return fallback_time;
+}
+
+int
+ui_history_get_mode(void) { // NOLINT(misc-use-internal-linkage)
+    return 0;
+}
+
+const char*
+dsd_synctype_to_string(int synctype) { // NOLINT(misc-use-internal-linkage)
+    (void)synctype;
+    return "SYNC";
+}
+
+uint8_t
+m17_address_classify(unsigned long long address) { // NOLINT(misc-use-internal-linkage)
+    (void)address;
+    return M17_ADDRESS_STANDARD;
+}
+
+int
+p25_patch_compose_details(const dsd_state* state, char* out, size_t cap) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    if (cap > 0U) {
+        out[0] = '\0';
+    }
+    return 0;
+}
+
+void
+p25_wacn_sysid_to_callsign(uint32_t wacn, uint16_t sysid, char out[7]) { // NOLINT(misc-use-internal-linkage)
+    (void)wacn;
+    (void)sysid;
+    if (out) {
+        out[0] = '\0';
+    }
+}
+
+long int
+ui_guess_active_vc_freq(const dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    return 0;
+}
+
+int
+ui_menu_is_open(void) { // NOLINT(misc-use-internal-linkage)
+    return 0;
+}
+
+void
+ui_menu_tick(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+void
+ui_print_header(const char* title) {
+    (void)title;
+} // NOLINT(misc-use-internal-linkage)
+
+void
+ui_print_hr(void) {} // NOLINT(misc-use-internal-linkage)
+
+void
+ui_print_lborder_green(void) {} // NOLINT(misc-use-internal-linkage)
+
+void
+ui_panel_header_render(const dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+void
+ui_panel_footer_status_render(const dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+void
+ui_print_learned_lcns(const dsd_opts* opts, const dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+int
+ui_print_p25_metrics(const dsd_opts* opts, const dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    return 0;
+}
+
+void
+ui_print_p25_neighbors(const dsd_opts* opts, const dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+void
+ui_print_p25_iden_plan(const dsd_opts* opts, const dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+void
+ui_print_p25_cc_candidates(const dsd_opts* opts, const dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+void
+print_dsp_status(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+#include "../../src/ui/terminal/dsd_ncurses_printer.c"
+#include "dsd-neo/core/input_level.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/secret_redaction.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static void
+test_input_source_helpers(void) {
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+
+    assert(ui_audio_in_is_soapy(NULL) == 0);
+    assert(ui_audio_in_is_soapy(&opts) == 0);
+
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "soapy");
+    assert(ui_audio_in_is_soapy(&opts) == 1);
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "soapy:driver=rtlsdr");
+    assert(ui_audio_in_is_soapy(&opts) == 1);
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof(opts.audio_in_dev), "rtl");
+    assert(ui_audio_in_is_soapy(&opts) == 0);
+}
+
+static void
+test_demod_symbol_rate_helpers(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    assert(ui_demod_symbol_rate_hz(NULL, NULL) == 48000);
+
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    state.samplesPerSymbol = 10;
+    assert(ui_demod_symbol_rate_hz(&opts, &state) == 4800);
+
+    opts.wav_sample_rate = 44100;
+    state.samplesPerSymbol = 9;
+    assert(ui_demod_symbol_rate_hz(&opts, &state) == 4900);
+
+    state.samplesPerSymbol = 0;
+    assert(ui_demod_symbol_rate_hz(&opts, &state) == 44100);
+
+    opts.audio_in_type = AUDIO_IN_PULSE;
+    opts.pulse_digi_rate_in = 0;
+    state.samplesPerSymbol = 12;
+    assert(ui_demod_symbol_rate_hz(&opts, &state) == 4000);
+}
+
+static void
+test_input_level_policy(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    assert(ui_compute_input_level_and_color(NULL, &state) == 0);
+    assert(ui_compute_input_level_and_color(&opts, NULL) == 0);
+
+    state.carrier = 0;
+    state.max = 10000.0f;
+    assert(ui_compute_input_level_and_color(&opts, &state) == 0);
+
+    state.carrier = 1;
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.mod_qpsk = 0;
+    state.rf_mod = 0;
+    state.max = 8200.0f;
+    assert(ui_compute_input_level_and_color(&opts, &state) == 50);
+
+    opts.mod_qpsk = 1;
+    assert(ui_compute_input_level_and_color(&opts, &state) == 100);
+
+    opts.mod_qpsk = 0;
+    opts.audio_in_type = AUDIO_IN_SYMBOL_BIN;
+    assert(ui_compute_input_level_and_color(&opts, &state) == 50);
+
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtl_dsp_bw_khz = 48;
+    state.max = 0.075f;
+    assert(ui_compute_input_level_and_color(&opts, &state) == 50);
+}
+
+static void
+test_history_and_sort_helpers(void) {
+    Event_History item;
+    DSD_MEMSET(&item, 0, sizeof(item));
+    assert(ui_eh_item_has_content(NULL) == 0);
+    assert(ui_eh_item_has_content(&item) == 0);
+
+    DSD_SNPRINTF(item.alias, sizeof(item.alias), "Unit 12");
+    assert(ui_eh_item_has_content(&item) == 1);
+
+    time_t last_seen[4] = {(time_t)10, (time_t)40, (time_t)20, (time_t)30};
+    int idxs[4] = {0, 1, 2, 3};
+    ui_sort_indices_by_last_seen(last_seen, idxs, 4);
+    assert(idxs[0] == 1);
+    assert(idxs[1] == 3);
+    assert(idxs[2] == 2);
+    assert(idxs[3] == 0);
+
+    ui_history_item_ref newer = {.slot = 1, .idx = 7, .sort_time = (time_t)200};
+    ui_history_item_ref older = {.slot = 0, .idx = 1, .sort_time = (time_t)100};
+    assert(ui_history_item_ref_compare(&newer, &older) < 0);
+    assert(ui_history_item_ref_compare(&older, &newer) > 0);
+
+    ui_history_item_ref same_time_low_idx = {.slot = 1, .idx = 2, .sort_time = (time_t)200};
+    ui_history_item_ref same_time_high_idx = {.slot = 0, .idx = 3, .sort_time = (time_t)200};
+    assert(ui_history_item_ref_compare(&same_time_low_idx, &same_time_high_idx) < 0);
+
+    static dsd_state state;
+    static Event_History_I history[2];
+    ui_history_item_ref refs[4];
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+    DSD_MEMSET(refs, 0, sizeof(refs));
+    state.event_history_s = history;
+
+    DSD_SNPRINTF(history[0].Event_History_Items[1].event_string, sizeof(history[0].Event_History_Items[1].event_string),
+                 "slot0 old");
+    history[0].Event_History_Items[1].event_time = (time_t)100;
+    DSD_SNPRINTF(history[1].Event_History_Items[3].text_message, sizeof(history[1].Event_History_Items[3].text_message),
+                 "slot1 newest");
+    history[1].Event_History_Items[3].event_time = (time_t)300;
+    DSD_SNPRINTF(history[1].Event_History_Items[4].alias, sizeof(history[1].Event_History_Items[4].alias),
+                 "slot1 middle");
+    history[1].Event_History_Items[4].event_time = (time_t)200;
+
+    assert(ui_history_collect_slot_items(NULL, 0, refs, 0U, 4U) == 0U);
+    assert(ui_history_collect_slot_items(&state, 2, refs, 0U, 4U) == 0U);
+    assert(ui_history_collect_slot_items(&state, 0, NULL, 0U, 4U) == 0U);
+    assert(ui_history_collect_slot_items(&state, 0, refs, 4U, 4U) == 4U);
+
+    DSD_MEMSET(refs, 0, sizeof(refs));
+    assert(ui_history_collect_slot_items(&state, 0, refs, 0U, 4U) == 1U);
+    assert(refs[0].slot == 0);
+    assert(refs[0].idx == 1);
+    assert(refs[0].sort_time == (time_t)100);
+
+    DSD_MEMSET(refs, 0, sizeof(refs));
+    assert(ui_history_collect_sorted_items(&state, 2, refs, 4U) == 3U);
+    assert(refs[0].slot == 1);
+    assert(refs[0].idx == 3);
+    assert(refs[1].slot == 1);
+    assert(refs[1].idx == 4);
+    assert(refs[2].slot == 0);
+    assert(refs[2].idx == 1);
+}
+
+static void
+test_history_viewport_helpers(void) {
+    int draw_footer = 1;
+    ui_history_render_ctx ctx;
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+
+    ui_history_setup_render_ctx(1, &draw_footer, &ctx);
+    assert(draw_footer == 1);
+    assert(ctx.history_mode == 1);
+    assert(ctx.rows == 24);
+    assert(ctx.cols == 80);
+    assert(ctx.history_stop_y == 22);
+    assert(ctx.events_to_show == 22);
+    assert(ctx.string_size == 71);
+
+    assert(ui_history_has_room_for_line(0) == 0);
+    assert(ui_history_has_room_for_line(1) == 1);
+    assert(ui_history_clamp_line_size(&ctx, 2) == 71U);
+    assert(ui_history_clamp_line_size(&ctx, 90) == 0U);
+
+    draw_footer = 1;
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    ui_history_setup_render_ctx(2, &draw_footer, &ctx);
+    assert(draw_footer == 1);
+    assert(ctx.history_mode == 2);
+    assert(ctx.events_to_show == 22);
+    assert(ctx.history_stop_y == 22);
+    assert(ctx.string_size == 1999U);
+    assert(ui_history_clamp_line_size(&ctx, 90) == 1999U);
+
+    Event_History item;
+    DSD_MEMSET(&item, 0, sizeof(item));
+    assert(ui_history_print_detail_line(1, UINT8_MAX, "Alias: ", "") == 1);
+    assert(ui_history_print_detail_line(1, UINT8_MAX, "Alias: ", NULL) == 1);
+    assert(ui_history_print_detail_line(0, UINT8_MAX, "Alias: ", "Unit") == 0);
+    assert(ui_history_print_detail_line(1, 0, "Alias: ", "Unit") == 1);
+}
+
+static void
+test_hytera_key_format_helper(void) {
+    static dsd_state state;
+    char key_text[96];
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(key_text, 0, sizeof(key_text));
+
+    state.K1 = 0x123456789AULL;
+    assert(strcmp(ui_format_hytera_key(key_text, sizeof(key_text), &state, 1, 1U), "123456789A") == 0);
+    assert(strcmp(ui_format_hytera_key(key_text, sizeof(key_text), &state, 0, 1U), DSD_SECRET_REDACTED) == 0);
+
+    state.K1 = 0x1111222233334444ULL;
+    state.K2 = 0x5555666677778888ULL;
+    assert(strcmp(ui_format_hytera_key(key_text, sizeof(key_text), &state, 1, 2U), "1111222233334444 5555666677778888")
+           == 0);
+
+    state.K3 = 0x9999AAAABBBBCCCCULL;
+    state.K4 = 0xDDDDEEEEFFFF0001ULL;
+    assert(strcmp(ui_format_hytera_key(key_text, sizeof(key_text), &state, 1, 4U),
+                  "1111222233334444 5555666677778888 9999AAAABBBBCCCC DDDDEEEEFFFF0001")
+           == 0);
+
+    state.K1 = 0xABCDEF123456ULL;
+    assert(strcmp(ui_format_hytera_key(key_text, sizeof(key_text), &state, 1, 3U), "CDEF123456") == 0);
+}
+
+static void
+test_edacs_tree_update_helpers(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(edacs_channel_tree, 0, sizeof(edacs_channel_tree));
+    ncurses_last_synctype = DSD_SYNC_NONE;
+
+    ui_update_sync_and_edacs_tree(NULL);
+    assert(ncurses_last_synctype == DSD_SYNC_NONE);
+
+    state.synctype = DSD_SYNC_EDACS_POS;
+    state.carrier = 0;
+    state.edacs_vc_lcn = 5;
+    ui_update_sync_and_edacs_tree(&state);
+    assert(ncurses_last_synctype == DSD_SYNC_EDACS_POS);
+    assert(edacs_channel_tree[5][1] == 0ULL);
+
+    state.carrier = 1;
+    state.lasttg = 1234;
+    state.lastsrc = 5678;
+    state.edacs_vc_call_type = EDACS_IS_GROUP;
+    ui_update_sync_and_edacs_tree(&state);
+    assert(edacs_channel_tree[5][0] == (unsigned long long)DSD_SYNC_EDACS_POS);
+    assert(edacs_channel_tree[5][1] == 5ULL);
+    assert(edacs_channel_tree[5][2] == 1234ULL);
+    assert(edacs_channel_tree[5][3] == 5678ULL);
+    assert(edacs_channel_tree[5][4] == (unsigned long long)EDACS_IS_GROUP);
+    assert(edacs_channel_tree[5][5] != 0ULL);
+
+    edacs_channel_tree[5][3] = 77ULL;
+    state.synctype = DSD_SYNC_NONE;
+    state.lastsrc = 0;
+    state.lasttg = 4321;
+    ui_update_sync_and_edacs_tree(&state);
+    assert(ncurses_last_synctype == DSD_SYNC_EDACS_POS);
+    assert(edacs_channel_tree[5][2] == 4321ULL);
+    assert(edacs_channel_tree[5][3] == 77ULL);
+
+    state.lastsrc = 0x800;
+    ui_update_sync_and_edacs_tree(&state);
+    assert(edacs_channel_tree[5][3] == 0ULL);
+
+    state.ea_mode = 1;
+    state.lastsrc = 0;
+    edacs_channel_tree[5][3] = 99ULL;
+    ui_update_sync_and_edacs_tree(&state);
+    assert(edacs_channel_tree[5][3] == 0ULL);
+}
+
+static void
+test_patch_and_slot_helpers(void) {
+    char tokens[48][64];
+    int count = 0;
+    DSD_MEMSET(tokens, 0, sizeof(tokens));
+    ui_parse_patch_tokens(" TG 100 ; ; TG 200 ; very-long-token-that-keeps-its-text ", tokens, &count);
+    assert(count == 3);
+    assert(strcmp(tokens[0], "TG 100") == 0);
+    assert(strcmp(tokens[1], "TG 200") == 0);
+    assert(strcmp(tokens[2], "very-long-token-that-keeps-its-text") == 0);
+    assert(ui_patch_tokens_col_width(tokens, count) == 28);
+
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.dmrburstL = 16;
+    state.dmrburstR = 21;
+    state.lasttg = 101;
+    state.lasttgR = 202;
+    state.lastsrc = 303;
+    state.lastsrcR = 404;
+    state.payload_algid = 0x24;
+    state.payload_algidR = 0x21;
+    state.payload_keyid = 11;
+    state.payload_keyidR = 22;
+    state.payload_mi = 0x12345678ULL;
+    state.payload_miR = 0x87654321ULL;
+    state.payload_miP = 0x1111222233334444ULL;
+    state.payload_miN = 0x5555666677778888ULL;
+    state.R = 0x12345ULL;
+    state.RR = 0x67890ULL;
+    state.aes_key_loaded[0] = 1;
+    state.A2[0] = 0x1111ULL;
+    state.A4[0] = 0x2222ULL;
+    DSD_SNPRINTF(state.call_string[1], sizeof(state.call_string[1]), "slot-two-call");
+    DSD_SNPRINTF(state.dmr_embedded_gps[1], sizeof(state.dmr_embedded_gps[1]), "gps");
+    DSD_SNPRINTF(state.dmr_lrrp_gps[1], sizeof(state.dmr_lrrp_gps[1]), "lrrp");
+    DSD_SNPRINTF(state.generic_talker_alias[1], sizeof(state.generic_talker_alias[1]), "alias");
+
+    ui_slot_view right = ui_build_slot_view(&state, 1);
+    assert(right.slot_no == 2);
+    assert(right.burst == 21);
+    assert(right.lasttg == 202);
+    assert(right.lastsrc == 404);
+    assert(right.payload_algid == 0x21);
+    assert(right.payload_keyid == 22);
+    assert(right.payload_mi_dmr == 0x87654321ULL);
+    assert(right.payload_mi_p25 == 0x5555666677778888ULL);
+    assert(right.rc4_key == 0x67890ULL);
+    assert(strcmp(right.call_banner, "slot-two-call") == 0);
+    assert(strcmp(right.embedded_gps, "gps") == 0);
+    assert(strcmp(right.lrrp_gps, "lrrp") == 0);
+    assert(strcmp(right.talker_alias, "alias") == 0);
+
+    assert(ui_slot_has_dxtra_embedded(1, 26) == 1);
+    assert(ui_slot_has_dxtra_embedded(2, 26) == 0);
+    assert(ui_slot_has_dxtra_embedded(2, 21) == 1);
+}
+
+static void
+test_lock_and_protocol_helpers(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    assert(ui_channel_label_is_locked(&opts, &state, "Already Locked") == 1);
+    assert(ui_channel_label_is_locked(NULL, &state, "TG: 123") == 0);
+
+    opts.trunk_tune_data_calls = 0;
+    assert(ui_channel_label_is_locked(&opts, &state, "Active Data Ch: 7") == 1);
+    opts.trunk_tune_data_calls = 1;
+    opts.trunk_tune_group_calls = 0;
+    assert(ui_channel_label_is_locked(&opts, &state, "TG: 123") == 1);
+    opts.trunk_tune_group_calls = 1;
+    opts.trunk_tune_private_calls = 0;
+    assert(ui_channel_label_is_locked(&opts, &state, "TGT: 456") == 1);
+
+    DSD_SNPRINTF(state.nxdn_location_category, sizeof(state.nxdn_location_category), "Type-D");
+    assert(ui_nxdn_is_idas(&state) == 1);
+    DSD_SNPRINTF(state.nxdn_location_category, sizeof(state.nxdn_location_category), "Type-C");
+    assert(ui_nxdn_is_idas(&state) == 0);
+}
+
+int
+main(void) {
+    test_input_source_helpers();
+    test_demod_symbol_rate_helpers();
+    test_input_level_policy();
+    test_history_and_sort_helpers();
+    test_history_viewport_helpers();
+    test_hytera_key_format_helper();
+    test_edacs_tree_update_helpers();
+    test_patch_and_slot_helpers();
+    test_lock_and_protocol_helpers();
+    return 0;
+}
+
+// NOLINTEND(bugprone-suspicious-include)

--- a/tests/ui/test_ui_ncurses_trunk_display_helpers.c
+++ b/tests/ui/test_ui_ncurses_trunk_display_helpers.c
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-suspicious-include)
+/*
+ * Pure-helper checks for ncurses trunk channel display state.
+ */
+
+#include <assert.h>
+#include <curses.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "../../src/ui/terminal/ncurses_trunk_display.c"
+#include "dsd-neo/core/opts.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/core/synctype_ids.h"
+#include "dsd-neo/ui/ncurses_p25_display.h"
+#include "dsd-neo/ui/ui_prims.h"
+
+static char g_output[8192];
+static int g_header_calls;
+static int g_border_calls;
+static int g_attron_calls;
+static int g_attroff_calls;
+static int g_attr_get_calls;
+static int g_attr_set_calls;
+static int g_last_attron;
+static int g_last_attroff;
+static int g_last_attr_set_attrs;
+static short g_last_attr_set_pair;
+static int g_iden_match_channel = -1;
+static long int g_iden_match_freq;
+static int g_iden_match_iden;
+
+static void
+append_text(const char* text) {
+    const size_t used = strlen(g_output);
+    if (used >= sizeof(g_output) - 1U) {
+        return;
+    }
+    DSD_SNPRINTF(g_output + used, sizeof(g_output) - used, "%s", text ? text : "");
+}
+
+static void
+reset_render_capture(void) {
+    g_output[0] = '\0';
+    g_header_calls = 0;
+    g_border_calls = 0;
+    g_attron_calls = 0;
+    g_attroff_calls = 0;
+    g_attr_get_calls = 0;
+    g_attr_set_calls = 0;
+    g_last_attron = 0;
+    g_last_attroff = 0;
+    g_last_attr_set_attrs = 0;
+    g_last_attr_set_pair = 0;
+    g_iden_match_channel = -1;
+    g_iden_match_freq = 0;
+    g_iden_match_iden = 0;
+}
+
+static int
+count_substring(const char* haystack, const char* needle) {
+    int count = 0;
+    const char* pos = haystack;
+    while ((pos = strstr(pos, needle)) != NULL) {
+        count++;
+        pos += strlen(needle);
+    }
+    return count;
+}
+
+void
+ui_print_header(const char* title) { // NOLINT(misc-use-internal-linkage)
+    g_header_calls++;
+    append_text("[");
+    append_text(title);
+    append_text("]\n");
+}
+
+void
+ui_print_lborder_green(void) { // NOLINT(misc-use-internal-linkage)
+    g_border_calls++;
+    append_text("|");
+}
+
+short
+ui_iden_color_pair(int iden) { // NOLINT(misc-use-internal-linkage)
+    return (short)(21 + (iden & 7));
+}
+
+int
+ui_match_iden_channel(const dsd_state* state, int ch16, long int freq,
+                      int* out_iden) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    if (out_iden) {
+        *out_iden = g_iden_match_iden;
+    }
+    return ch16 == g_iden_match_channel && freq == g_iden_match_freq;
+}
+
+int
+wattr_on(WINDOW* win, attr_t attrs, void* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)opts;
+    g_attron_calls++;
+    g_last_attron = (int)attrs;
+    return 0;
+}
+
+int
+wattr_off(WINDOW* win, attr_t attrs, void* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)opts;
+    g_attroff_calls++;
+    g_last_attroff = (int)attrs;
+    return 0;
+}
+
+int
+wattr_get(WINDOW* win, attr_t* attrs, short* pair, void* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)opts;
+    g_attr_get_calls++;
+    if (attrs) {
+        *attrs = 77;
+    }
+    if (pair) {
+        *pair = 6;
+    }
+    return 0;
+}
+
+int
+wattr_set(WINDOW* win, attr_t attrs, short pair, void* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)opts;
+    g_attr_set_calls++;
+    g_last_attr_set_attrs = (int)attrs;
+    g_last_attr_set_pair = pair;
+    return 0;
+}
+
+int
+waddch(WINDOW* win, const chtype ch) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    char text[2] = {(char)ch, '\0'};
+    append_text(text);
+    return 0;
+}
+
+int
+waddnstr(WINDOW* win, const char* str, int n) { // NOLINT(misc-use-internal-linkage)
+    (void)win;
+    (void)n;
+    append_text(str);
+    return 0;
+}
+
+int
+printw(const char* fmt, ...) { // NOLINT(misc-use-internal-linkage)
+    char text[256];
+    va_list ap;
+    va_start(ap, fmt);
+    DSD_VSNPRINTF(text, sizeof(text), fmt, ap);
+    va_end(ap);
+    append_text(text);
+    return 0;
+}
+
+static void
+add_trunk_channel(dsd_state* state, uint16_t channel, long int freq) {
+    assert(channel < DSD_TRUNK_CHAN_MAP_SIZE);
+    state->trunk_chan_map_used[state->trunk_chan_map_used_count++] = channel;
+    state->trunk_chan_map[channel] = freq;
+}
+
+static void
+test_public_guards_do_not_render(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    reset_render_capture();
+    ui_print_learned_lcns(NULL, &state);
+    ui_print_learned_lcns(&opts, NULL);
+    ui_print_learned_lcns(&opts, &state);
+    opts.p25_trunk = 1;
+    ui_print_learned_lcns(&opts, &state);
+
+    assert(g_header_calls == 0);
+    assert(g_border_calls == 0);
+    assert(g_attron_calls == 0);
+    assert(g_output[0] == '\0');
+}
+
+static void
+test_channel_map_rendering_dedupes_and_reports_extra(void) {
+    static dsd_state state;
+    ui_trunk_render_state render;
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_MEMSET(&render, 0, sizeof render);
+
+    add_trunk_channel(&state, 0, 850000000L);
+    for (int i = 0; i < UI_TRUNK_MAX_MAP_PRINT + 2; i++) {
+        add_trunk_channel(&state, (uint16_t)(0x100U + (uint16_t)i), 851000000L + (long)i * 12500L);
+    }
+    add_trunk_channel(&state, 0x180, state.trunk_chan_map[0x100]);
+
+    reset_render_capture();
+    ui_trunk_render_chan_map(&state, state.trunk_chan_map_used_count, &render);
+
+    assert(count_substring(g_output, "CH ") == UI_TRUNK_MAX_MAP_PRINT);
+    assert(strstr(g_output, "CH 0100: 851.000000 MHz") != NULL);
+    assert(strstr(g_output, "CH 011F: 851.387500 MHz") != NULL);
+    assert(strstr(g_output, "CH 0120:") == NULL);
+    assert(strstr(g_output, "850.000000 MHz") == NULL);
+    assert(strstr(g_output, "... and 2 more learned channels") != NULL);
+    assert(render.seen_count == UI_TRUNK_MAX_MAP_PRINT + 2);
+    assert(render.col_in_row == 0);
+}
+
+static void
+test_lcn_rendering_uses_map_channel_and_fallback(void) {
+    static dsd_state state;
+    ui_trunk_render_state render;
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_MEMSET(&render, 0, sizeof render);
+    add_trunk_channel(&state, 0x1234, 851012500L);
+    state.trunk_lcn_freq[0] = 851012500L;
+    state.trunk_lcn_freq[1] = 852012500L;
+    ui_trunk_mark_freq_seen(&render, 851012500L);
+
+    reset_render_capture();
+    ui_trunk_render_lcn_freqs(&state, state.trunk_chan_map_used_count, &render);
+
+    assert(strstr(g_output, "CH 1234:") == NULL);
+    assert(strstr(g_output, "CH ----: 852.012500 MHz") != NULL);
+    assert(render.seen_count == 2);
+
+    DSD_MEMSET(&render, 0, sizeof render);
+    reset_render_capture();
+    ui_trunk_render_lcn_freqs(&state, state.trunk_chan_map_used_count, &render);
+    assert(strstr(g_output, "CH 1234: 851.012500 MHz") != NULL);
+    assert(strstr(g_output, "CH ----: 852.012500 MHz") != NULL);
+    assert(render.seen_count == 2);
+}
+
+static void
+test_iden_rendering_restores_saved_attrs(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof state);
+    g_iden_match_channel = 0x1234;
+    g_iden_match_freq = 851012500L;
+    g_iden_match_iden = 3;
+
+    reset_render_capture();
+    g_iden_match_channel = 0x1234;
+    g_iden_match_freq = 851012500L;
+    g_iden_match_iden = 3;
+    ui_trunk_print_channel_freq(&state, 0x1234, 851012500L);
+
+    assert(strstr(g_output, "CH 1234[I3]: 851.012500 MHz") != NULL);
+    assert(g_attr_get_calls == 1);
+    assert(g_attron_calls == 1);
+    assert(PAIR_NUMBER(g_last_attron) == 24);
+    assert(g_attr_set_calls == 1);
+    assert(g_last_attr_set_attrs == 77);
+    assert(g_last_attr_set_pair == 6);
+}
+
+static void
+test_public_render_applies_color_and_p25_legend(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    opts.p25_trunk = 1;
+    state.carrier = 1;
+    state.synctype = DSD_SYNC_P25P2_POS;
+    add_trunk_channel(&state, 0x1234, 851012500L);
+
+    reset_render_capture();
+    ui_print_learned_lcns(&opts, &state);
+
+    assert(g_header_calls == 1);
+    assert(strstr(g_output, "[Channels]") != NULL);
+    assert(strstr(g_output, "CH 1234: 851.012500 MHz") != NULL);
+    assert(strstr(g_output, "Legend: IDEN colors I0 I1 I2 I3 I4 I5 I6 I7") != NULL);
+    assert(g_attron_calls >= 10);
+    assert(g_attroff_calls == 8);
+    assert(PAIR_NUMBER(g_last_attroff) == 28);
+    assert(PAIR_NUMBER(g_last_attron) == 3);
+}
+
+static void
+test_public_render_uses_idle_color_without_p25_legend(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    opts.p25_trunk = 1;
+    state.carrier = 0;
+    state.synctype = DSD_SYNC_DMR_BS_DATA_POS;
+    state.trunk_lcn_freq[0] = 852012500L;
+
+    reset_render_capture();
+    ui_print_learned_lcns(&opts, &state);
+
+    assert(strstr(g_output, "CH ----: 852.012500 MHz") != NULL);
+    assert(strstr(g_output, "Legend:") == NULL);
+    assert(PAIR_NUMBER(g_last_attron) == 4);
+}
+
+static void
+test_lcn_presence(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    assert(!ui_trunk_has_lcn_freq(&state));
+    state.trunk_lcn_freq[25] = 851000000;
+    assert(ui_trunk_has_lcn_freq(&state));
+}
+
+static void
+test_seen_frequency_tracking_is_bounded_and_dedupes(void) {
+    ui_trunk_render_state render;
+    DSD_MEMSET(&render, 0, sizeof render);
+
+    assert(!ui_trunk_freq_seen(&render, 851000000));
+    ui_trunk_mark_freq_seen(&render, 851000000);
+    ui_trunk_mark_freq_seen(&render, 852000000);
+    assert(ui_trunk_freq_seen(&render, 851000000));
+    assert(ui_trunk_freq_seen(&render, 852000000));
+    assert(!ui_trunk_freq_seen(&render, 853000000));
+
+    render.seen_count = UI_TRUNK_SEEN_FREQ_CAP;
+    render.seen_freqs[UI_TRUNK_SEEN_FREQ_CAP - 1] = 900000000;
+    ui_trunk_mark_freq_seen(&render, 901000000);
+    assert(render.seen_count == UI_TRUNK_SEEN_FREQ_CAP);
+    assert(!ui_trunk_freq_seen(&render, 901000000));
+}
+
+static void
+test_find_channel_for_frequency_uses_tracked_entries_only(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    state.trunk_chan_map_used_count = 4;
+    state.trunk_chan_map_used[0] = 0x0000;
+    state.trunk_chan_map_used[1] = 0x1234;
+    state.trunk_chan_map_used[2] = DSD_TRUNK_CHAN_MAP_SIZE;
+    state.trunk_chan_map_used[3] = 0x2345;
+    state.trunk_chan_map[0x1234] = 851012500;
+    state.trunk_chan_map[0x2345] = 852012500;
+
+    assert(ui_trunk_find_channel_for_freq(&state, state.trunk_chan_map_used_count, 851012500) == 0x1234);
+    assert(ui_trunk_find_channel_for_freq(&state, state.trunk_chan_map_used_count, 852012500) == 0x2345);
+    assert(ui_trunk_find_channel_for_freq(&state, state.trunk_chan_map_used_count, 853012500) == -1);
+    assert(ui_trunk_find_channel_for_freq(&state, 1, 851012500) == -1);
+}
+
+int
+main(void) {
+    test_public_guards_do_not_render();
+    test_lcn_presence();
+    test_seen_frequency_tracking_is_bounded_and_dedupes();
+    test_find_channel_for_frequency_uses_tracked_entries_only();
+    test_channel_map_rendering_dedupes_and_reports_extra();
+    test_lcn_rendering_uses_map_channel_and_fallback();
+    test_iden_rendering_restores_saved_attrs();
+    test_public_render_applies_color_and_p25_legend();
+    test_public_render_uses_idle_color_without_p25_legend();
+    return 0;
+}
+
+// NOLINTEND(bugprone-suspicious-include)

--- a/tests/ui/test_ui_ncurses_utils.c
+++ b/tests/ui/test_ui_ncurses_utils.c
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/runtime/unicode.h>
+#include <dsd-neo/ui/ncurses_internal.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static int
+expect_true(const char* label, int cond) {
+    if (!cond) {
+        DSD_FPRINTF(stderr, "FAIL: %s\n", label);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_int_eq(const char* label, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "FAIL: %s (got %d want %d)\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_double_eq(const char* label, double got, double want) {
+    if (fabs(got - want) > 1e-9) {
+        DSD_FPRINTF(stderr, "FAIL: %s (got %.9f want %.9f)\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+add_policy(dsd_state* state, uint32_t id, const char* mode, const char* name) {
+    dsd_tg_policy_entry entry;
+    if (dsd_tg_policy_make_exact_entry(id, mode, name, DSD_TG_POLICY_SOURCE_IMPORTED, &entry) != 0) {
+        return -1;
+    }
+    return dsd_tg_policy_upsert_exact(state, &entry, DSD_TG_POLICY_UPSERT_REPLACE_FIRST);
+}
+
+static int
+test_unicode_wrappers_and_shared_sync_state(void) {
+    int rc = 0;
+    rc |= expect_int_eq("unicode wrapper delegates", ui_unicode_supported(), dsd_unicode_supported());
+    rc |= expect_int_eq("block glyph wrapper delegates", ui_block_glyphs_supported(),
+                        dsd_unicode_block_glyphs_supported());
+
+    rc |= expect_int_eq("initial sync type", ncurses_last_synctype, DSD_SYNC_NONE);
+    ncurses_last_synctype = DSD_SYNC_P25P1_POS;
+    rc |= expect_int_eq("shared sync type is mutable", ncurses_last_synctype, DSD_SYNC_P25P1_POS);
+    ncurses_last_synctype = DSD_SYNC_NONE;
+    return rc;
+}
+
+static int
+test_int_selection_helpers(void) {
+    int a = 7;
+    int b = -3;
+    swap_int_local(&a, &b);
+
+    int rc = 0;
+    rc |= expect_int_eq("swap lhs", a, -3);
+    rc |= expect_int_eq("swap rhs", b, 7);
+
+    int low = 1;
+    int mid = 4;
+    int high = 9;
+    rc |= expect_true("cmp less", cmp_int_asc(&low, &mid) < 0);
+    rc |= expect_true("cmp equal", cmp_int_asc(&mid, &mid) == 0);
+    rc |= expect_true("cmp greater", cmp_int_asc(&high, &mid) > 0);
+
+    int vals_min[] = {9, -4, 3, 3, 7, 0, 11};
+    int vals_mid[] = {9, -4, 3, 3, 7, 0, 11};
+    int vals_max[] = {9, -4, 3, 3, 7, 0, 11};
+    rc |= expect_int_eq("select min", select_k_int_local(vals_min, 7, 0), -4);
+    rc |= expect_int_eq("select duplicate median", select_k_int_local(vals_mid, 7, 3), 3);
+    rc |= expect_int_eq("select max", select_k_int_local(vals_max, 7, 6), 11);
+    return rc;
+}
+
+static int
+test_percentiles_u8(void) {
+    uint8_t samples[] = {10, 1, 40, 30, 20};
+    double p50 = -1.0;
+    double p95 = -1.0;
+
+    int rc = 0;
+    rc |= expect_int_eq("null percentile source", compute_percentiles_u8(NULL, 5, &p50, &p95), 0);
+    rc |= expect_int_eq("empty percentile source", compute_percentiles_u8(samples, 0, &p50, &p95), 0);
+    rc |= expect_int_eq("percentile success", compute_percentiles_u8(samples, 5, &p50, &p95), 1);
+    rc |= expect_double_eq("percentile p50", p50, 20.0);
+    rc |= expect_double_eq("percentile p95", p95, 40.0);
+    rc |= expect_int_eq("percentile accepts null outputs", compute_percentiles_u8(samples, 5, NULL, NULL), 1);
+    return rc;
+}
+
+static int
+test_lockout_label_policy_lookup(void) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!state) {
+        DSD_FPRINTF(stderr, "FAIL: state alloc\n");
+        return 1;
+    }
+
+    int rc = 0;
+    rc |= expect_true("add B policy", add_policy(state, 123U, "B", "BLOCK") == 0);
+    rc |= expect_true("add DE policy", add_policy(state, 456U, "DE", "ENC-BLOCK") == 0);
+    rc |= expect_true("add A policy", add_policy(state, 789U, "A", "ALLOW") == 0);
+
+    dsd_tg_policy_entry range;
+    rc |= expect_true("make range policy",
+                      dsd_tg_policy_make_exact_entry(1000U, "B", "RANGE-BLOCK", DSD_TG_POLICY_SOURCE_IMPORTED, &range)
+                          == 0);
+    range.id_end = 1099U;
+    range.is_range = 1U;
+    rc |= expect_true("add range policy", dsd_tg_policy_add_range_entry(state, &range) == 0);
+
+    rc |= expect_int_eq("null state not locked", ui_is_locked_from_label(NULL, "TG: 123"), 0);
+    rc |= expect_int_eq("null label not locked", ui_is_locked_from_label(state, NULL), 0);
+    rc |= expect_int_eq("empty label not locked", ui_is_locked_from_label(state, ""), 0);
+    rc |= expect_int_eq("missing target prefix not locked", ui_is_locked_from_label(state, "SRC: 123"), 0);
+    rc |= expect_int_eq("invalid target not locked", ui_is_locked_from_label(state, "TG: abc"), 0);
+    rc |= expect_int_eq("zero target not locked", ui_is_locked_from_label(state, "TG: 0"), 0);
+    rc |= expect_int_eq("overflow target not locked", ui_is_locked_from_label(state, "TG: 4294967296"), 0);
+    rc |= expect_int_eq("TG B mode locks", ui_is_locked_from_label(state, "Voice TG: 123 src 4"), 1);
+    rc |= expect_int_eq("TGT DE mode locks", ui_is_locked_from_label(state, "Call TGT:456 slot 2"), 1);
+    rc |= expect_int_eq("allow mode does not lock", ui_is_locked_from_label(state, "TG: 789"), 0);
+    rc |= expect_int_eq("range-only match does not lock label", ui_is_locked_from_label(state, "TG: 1005"), 0);
+
+    dsd_state_ext_free_all(state);
+    free(state);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_unicode_wrappers_and_shared_sync_state();
+    rc |= test_int_selection_helpers();
+    rc |= test_percentiles_u8();
+    rc |= test_lockout_label_policy_lookup();
+    return rc ? 1 : 0;
+}

--- a/tests/ui/test_ui_ncurses_visualizers_helpers.c
+++ b/tests/ui/test_ui_ncurses_visualizers_helpers.c
@@ -1,0 +1,675 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-suspicious-include)
+/*
+ * Pure-helper checks for RTL ncurses visualizer math and bucketing.
+ */
+
+#define USE_RTLSDR    1
+#define PRETTY_COLORS 1
+
+#include <assert.h>
+#include <curses.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/platform/platform.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <string.h>
+
+static char g_render_out[32768];
+static size_t g_render_len;
+static int g_attron_count;
+static int g_attroff_count;
+static int g_has_colors;
+static int g_test_rows = 24;
+static int g_test_cols = 80;
+
+static void
+render_reset(void) {
+    g_render_len = 0;
+    g_render_out[0] = '\0';
+    g_attron_count = 0;
+    g_attroff_count = 0;
+}
+
+static void
+render_append(const char* text) {
+    size_t n = strlen(text);
+    if (n >= sizeof(g_render_out) - g_render_len) {
+        n = sizeof(g_render_out) - g_render_len - 1;
+    }
+    DSD_MEMCPY(g_render_out + g_render_len, text, n);
+    g_render_len += n;
+    g_render_out[g_render_len] = '\0';
+}
+
+static int test_printw(const char* fmt, ...) DSD_ATTR_FORMAT(printf, 1, 2);
+static int test_addch(const chtype ch);
+static int test_addstr(const char* text);
+static int test_attron(int attrs);
+static int test_attroff(int attrs);
+static int test_has_colors(void);
+static int test_init_pair(short pair, short f, short b);
+
+#undef getmaxyx
+#undef addch
+#undef addstr
+#undef attron
+#undef attroff
+#define getmaxyx(win, y, x)                                                                                            \
+    do {                                                                                                               \
+        (void)(win);                                                                                                   \
+        (y) = g_test_rows;                                                                                             \
+        (x) = g_test_cols;                                                                                             \
+    } while (0)
+#define printw     test_printw
+#define addch      test_addch
+#define addstr     test_addstr
+#define attron     test_attron
+#define attroff    test_attroff
+#define has_colors test_has_colors
+#define init_pair  test_init_pair
+
+#include "../../src/ui/terminal/ncurses_visualizers.c"
+#include "dsd-neo/core/opts.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/io/rtl_stream_c.h"
+#include "dsd-neo/ui/ncurses_internal.h"
+#include "dsd-neo/ui/ui_prims.h"
+
+#undef init_pair
+#undef has_colors
+#undef attroff
+#undef attron
+#undef addstr
+#undef addch
+#undef printw
+#undef getmaxyx
+
+static int
+test_printw(const char* fmt, ...) {
+    char tmp[512];
+    va_list ap;
+    va_start(ap, fmt);
+    int n = DSD_VSNPRINTF(tmp, sizeof(tmp), fmt, ap);
+    va_end(ap);
+    if (n > 0) {
+        render_append(tmp);
+    }
+    return n;
+}
+
+static int
+test_addch(const chtype ch) {
+    char tmp[2] = {(char)(ch & 0xFF), '\0'};
+    render_append(tmp);
+    return 0;
+}
+
+static int
+test_addstr(const char* text) {
+    render_append(text ? text : "");
+    return 0;
+}
+
+static int
+test_attron(int attrs) {
+    (void)attrs;
+    g_attron_count++;
+    return 0;
+}
+
+static int
+test_attroff(int attrs) {
+    (void)attrs;
+    g_attroff_count++;
+    return 0;
+}
+
+static int
+test_has_colors(void) {
+    return g_has_colors;
+}
+
+static int
+test_init_pair(short pair, short f, short b) {
+    (void)pair;
+    (void)f;
+    (void)b;
+    return 0;
+}
+
+int
+select_k_int_local(int* a, int n, int k) { // NOLINT(misc-use-internal-linkage)
+    for (int i = 0; i < n; i++) {
+        for (int j = i + 1; j < n; j++) {
+            if (a[j] < a[i]) {
+                int tmp = a[i];
+                a[i] = a[j];
+                a[j] = tmp;
+            }
+        }
+    }
+    return a[k];
+}
+
+int
+ui_block_glyphs_supported(void) { // NOLINT(misc-use-internal-linkage)
+    return 0;
+}
+
+double
+ui_gamma_map01(double f) { // NOLINT(misc-use-internal-linkage)
+    if (f < 0.0) {
+        return 0.0;
+    }
+    if (f > 1.0) {
+        return 1.0;
+    }
+    return sqrt(f);
+}
+
+void
+ui_print_hr(void) { // NOLINT(misc-use-internal-linkage)
+}
+
+void
+ui_print_header(const char* title) { // NOLINT(misc-use-internal-linkage)
+    (void)title;
+}
+
+void
+ui_print_lborder(void) { // NOLINT(misc-use-internal-linkage)
+}
+
+int
+rtl_stream_constellation_get(float* out, int max_points) { // NOLINT(misc-use-internal-linkage)
+    (void)out;
+    (void)max_points;
+    return 0;
+}
+
+int
+rtl_stream_eye_get(float* out, int max_samples, int* out_sps) { // NOLINT(misc-use-internal-linkage)
+    (void)out;
+    (void)max_samples;
+    if (out_sps) {
+        *out_sps = 0;
+    }
+    return 0;
+}
+
+double
+rtl_stream_get_snr_c4fm(void) { // NOLINT(misc-use-internal-linkage)
+    return -100.0;
+}
+
+double
+rtl_stream_get_snr_bias_c4fm(void) { // NOLINT(misc-use-internal-linkage)
+    return 0.0;
+}
+
+int
+rtl_stream_spectrum_get_size(void) { // NOLINT(misc-use-internal-linkage)
+    return 128;
+}
+
+int
+rtl_stream_spectrum_get(float* out, int max_bins, int* out_rate) { // NOLINT(misc-use-internal-linkage)
+    (void)out;
+    (void)max_bins;
+    if (out_rate) {
+        *out_rate = 0;
+    }
+    return 0;
+}
+
+static int
+sum_density(const unsigned short* den, int n) {
+    int sum = 0;
+    for (int i = 0; i < n; i++) {
+        sum += den[i];
+    }
+    return sum;
+}
+
+static void
+test_density_and_constellation_helpers(void) {
+    assert(clamp_int_local(-2, 0, 4) == 0);
+    assert(clamp_int_local(6, 0, 4) == 4);
+    assert(clamp_float_local(-0.5f, 0.0f, 1.0f) == 0.0f);
+    assert(clamp_float_local(1.5f, 0.0f, 1.0f) == 1.0f);
+    assert(density_palette_index(-1.0, 10) == 0);
+    assert(density_palette_index(2.0, 10) == 9);
+    assert(density_color_pair_id(40, 7, 1.0) == 46);
+    assert(fabs(density_gamma_value(25, 100) - 0.5) < 0.0001);
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    assert(fabs(constellation_gate_squared(&opts) - 0.0) < 0.0001);
+    opts.mod_qpsk = 1;
+    opts.const_gate_qpsk = 2.0f;
+    assert(fabs(constellation_gate_squared(&opts) - 0.81) < 0.0001);
+    opts.mod_qpsk = 0;
+    opts.const_gate_other = -1.0f;
+    assert(fabs(constellation_gate_squared(&opts) - 0.0) < 0.0001);
+
+    constellation_geom geom = constellation_compute_geometry(9, 7);
+    assert(geom.W == 9);
+    assert(geom.H == 7);
+    assert(geom.cx == 4);
+    assert(geom.cy == 3);
+    assert(geom.x0 >= 0);
+    assert(geom.x1 < geom.W);
+
+    constellation_geom tiny_geom = constellation_compute_geometry(2, 1);
+    assert(tiny_geom.x1 >= tiny_geom.x0);
+    assert(tiny_geom.y1 >= tiny_geom.y0);
+
+    unsigned short den[9 * 7];
+    DSD_MEMSET(den, 0, sizeof den);
+    const float iq[] = {1.0f, 0.0f, -1.0f, 0.0f, 0.0f, 1.0f};
+    unsigned short dmax = constellation_accumulate_density(iq, 3, NULL, &geom, 16384, 0.0, den);
+    assert(dmax == 1);
+    assert(sum_density(den, 9 * 7) == 3);
+
+    const float gated_iq[] = {0.001f, 0.0f, -0.001f, 0.0f};
+    DSD_MEMSET(den, 0, sizeof den);
+    dmax = constellation_accumulate_density(gated_iq, 2, NULL, &geom, 16384, 0.01, den);
+    assert(dmax == 1);
+    assert(sum_density(den, 9 * 7) == 0);
+
+    const float zero_iq[] = {0.0f, 0.0f, 0.5f, 0.0f};
+    opts.const_norm_mode = 1;
+    DSD_MEMSET(den, 0, sizeof den);
+    dmax = constellation_accumulate_density(zero_iq, 2, &opts, &geom, 16384, 0.0, den);
+    assert(dmax == 1);
+    assert(sum_density(den, 9 * 7) == 1);
+    opts.const_norm_mode = 0;
+
+    unsigned short* dynamic_den = NULL;
+    assert(constellation_prepare_density_buffer(3, 4, &dynamic_den));
+    assert(dynamic_den != NULL);
+    dynamic_den[0] = 9;
+    assert(constellation_prepare_density_buffer(3, 4, &dynamic_den));
+    assert(dynamic_den[0] == 0);
+
+    int y_start = -1;
+    int y_end = -1;
+    constellation_active_y_bounds(den, &geom, &y_start, &y_end);
+    assert(y_start >= geom.y0);
+    assert(y_end <= geom.y1);
+    assert(y_end >= y_start);
+
+    assert(constellation_axis_char(1, 1) == '+');
+    assert(constellation_axis_char(1, 0) == '-');
+    assert(constellation_axis_char(0, 1) == '|');
+
+    constellation_style style;
+    DSD_MEMSET(&style, 0, sizeof style);
+    style.ascii_len = (int)(sizeof(k_density_ascii_palette) - 1);
+    style.block_len = (int)(sizeof(k_density_block_palette) / sizeof(k_density_block_palette[0]));
+    style.dot_len = (int)(sizeof(k_constellation_dot_palette) / sizeof(k_constellation_dot_palette[0]));
+    style.color_len = (int)(sizeof(k_density_color_seq) / sizeof(k_density_color_seq[0]));
+    style.color_base = 41;
+    int last_pair = -1;
+    assert(constellation_density_char(&style, 1, 4, &last_pair) == '=');
+    assert(last_pair == -1);
+
+    constellation_style made_style = constellation_make_style(&opts);
+    assert(made_style.use_unicode == 0);
+    assert(made_style.use_dots == 1);
+    assert(made_style.color_enabled == 0);
+    assert(made_style.color_base == 41);
+
+    char ch = '?';
+    constellation_density_glyph(&style, 0.0, &ch);
+    assert(ch == ' ');
+    constellation_density_glyph(&style, 1.0, &ch);
+    assert(ch == '@');
+
+    const float scale_small[] = {0.01f, 0.0f, 0.02f, 0.0f, 0.03f, 0.0f, 0.04f, 0.0f};
+    const float scale_large[] = {0.50f, 0.0f, 0.75f, 0.0f, 1.00f, 0.0f, 1.25f, 0.0f};
+    int r_small = constellation_compute_scale_radius(scale_small, 4);
+    int r_large = constellation_compute_scale_radius(scale_large, 4);
+    assert(r_small >= 64);
+    assert(r_large > r_small);
+
+    g_test_rows = 10;
+    g_test_cols = 20;
+    int grid_w = 0;
+    int grid_h = 0;
+    constellation_grid_size(&grid_w, &grid_h);
+    assert(grid_w == 32);
+    assert(grid_h == 12);
+    g_test_rows = 50;
+    g_test_cols = 90;
+    constellation_grid_size(&grid_w, &grid_h);
+    assert(grid_w == 86);
+    assert(grid_h == 25);
+    g_test_rows = 24;
+    g_test_cols = 80;
+
+    constellation_geom render_geom = constellation_compute_geometry(9, 7);
+    unsigned short render_den[9 * 7];
+    DSD_MEMSET(render_den, 0, sizeof render_den);
+    render_den[(size_t)render_geom.cy * (size_t)render_geom.W + (size_t)render_geom.cx] = 4;
+    render_den[(size_t)(render_geom.cy - 1) * (size_t)render_geom.W + (size_t)(render_geom.cx + 1)] = 2;
+    render_reset();
+    constellation_render_rows(&style, &render_geom, render_den, render_geom.cy - 1, render_geom.cy, 4);
+    assert(strchr(g_render_out, '+') != NULL);
+    assert(strchr(g_render_out, '-') != NULL);
+    assert(strchr(g_render_out, '*') != NULL);
+
+    style.color_enabled = 1;
+    style.guide_h_pair = 49;
+    style.guide_v_pair = 50;
+    style.guide_x_pair = 51;
+    int color_pair = -1;
+    render_reset();
+    constellation_render_cell(&style, &render_geom, render_den, render_geom.cx + 1, render_geom.cy - 1, 4, &color_pair);
+    assert(g_attron_count > 0);
+    assert(color_pair >= style.color_base);
+    render_reset();
+    constellation_render_cell(&style, &render_geom, render_den, render_geom.cx, render_geom.cy, 4, &color_pair);
+    assert(g_attron_count > 0);
+    assert(g_attroff_count > 0);
+    style.color_enabled = 0;
+
+    render_reset();
+    constellation_print_legend(&opts, &style);
+    assert(strstr(g_render_out, "Ref: axes") != NULL);
+    assert(strstr(g_render_out, "Density: . : - = + * # @") != NULL);
+    assert(strstr(g_render_out, "Norm: radial") != NULL);
+
+    render_reset();
+    print_density_color_bar(0, 41, style.color_len);
+    assert(strstr(g_render_out, "Color:") != NULL);
+    assert(strstr(g_render_out, "low -> high") != NULL);
+    assert(strstr(g_render_out, "0%") != NULL);
+    assert(strstr(g_render_out, "100%") != NULL);
+}
+
+static void
+test_eye_helpers(void) {
+    const float samples[] = {-4.0f, -3.0f, -2.0f, -1.0f, 0.0f, 1.0f, 2.0f, 3.0f};
+    int q1 = 0;
+    int q2 = 0;
+    int q3 = 0;
+    eye_compute_quartiles(samples, 8, 1.0f, 64, &q1, &q2, &q3);
+    assert(q1 <= q2);
+    assert(q2 <= q3);
+
+    unsigned short den[12 * 8];
+    DSD_MEMSET(den, 0, sizeof den);
+    den[(4 * 12) + 0] = 65535;
+    eye_accumulate_density(samples, 8, 1.0f, 64, 4, 8, 12, 8, den);
+    assert(den[(4 * 12) + 0] == 65535);
+    assert(eye_density_max(den, 12, 8) == 65535);
+
+    unsigned short* dynamic_den = NULL;
+    assert(eye_prepare_density_buffer(4, 5, &dynamic_den));
+    assert(dynamic_den != NULL);
+    dynamic_den[0] = 7;
+    assert(eye_prepare_density_buffer(4, 5, &dynamic_den));
+    assert(dynamic_den[0] == 0);
+
+    assert(eye_row_for_level(64, 64, 4, 8) == 1);
+    assert(eye_row_for_level(-64, 64, 4, 8) == 7);
+    assert(eye_boundary_col(0, 8, 12) == 0);
+    assert(eye_boundary_col(7, 8, 12) == 11);
+    assert(eye_overlay_char(' ', 1, 1) == '+');
+    assert(eye_overlay_char('.', 1, 0) == '-');
+    assert(eye_overlay_char('#', 1, 0) == '=');
+    assert(eye_overlay_char('#', 0, 1) == '+');
+
+    eye_style style;
+    DSD_MEMSET(&style, 0, sizeof style);
+    style.color_len = (int)(sizeof(k_density_color_seq) / sizeof(k_density_color_seq[0]));
+    style.color_base = 21;
+    int last_pair = -1;
+    assert(eye_ascii_density_char(0.0) == ' ');
+    assert(eye_ascii_density_char(1.0) == '@');
+    assert(eye_density_char(&style, 1, 4, &last_pair) == '=');
+    assert(last_pair == -1);
+    style.unicode_requested = 1;
+    assert(eye_density_char(&style, 1, 4, &last_pair) == 0);
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    eye_style made_style = eye_make_style(&opts, 0);
+    assert(made_style.use_unicode_ui == 0);
+    assert(made_style.unicode_requested == 0);
+    assert(made_style.color_enabled == 0);
+    assert(eye_effective_unicode_ui(&opts) == 0);
+
+    eye_plot plot;
+    DSD_MEMSET(&plot, 0, sizeof plot);
+    plot.yq1 = 1;
+    plot.yq2 = 3;
+    plot.yq3 = 5;
+    plot.xb0 = 0;
+    plot.xb1 = 6;
+    plot.xb2 = 11;
+    assert(eye_is_hline(&plot, 3));
+    assert(!eye_is_hline(&plot, 4));
+    assert(eye_is_vline(&plot, 6));
+    assert(!eye_is_vline(&plot, 7));
+
+    assert(eye_snr_in_window(3, 4, 12, 1));
+    assert(!eye_snr_in_window(8, 4, 12, 1));
+    assert(eye_snr_bucket(-5, -1, 1, 5) == 0);
+    assert(eye_snr_bucket(0, -1, 1, 5) == 1);
+    assert(eye_snr_bucket(3, -1, 1, 5) == 2);
+    assert(eye_snr_bucket(9, -1, 1, 5) == 3);
+
+    long long cnt[4] = {20, 20, 20, 20};
+    double sum[4] = {-200.0, -60.0, 60.0, 200.0};
+    double mu[4] = {0.0, 0.0, 0.0, 0.0};
+    assert(eye_snr_level_means(cnt, sum, mu) == 80);
+    assert(eye_snr_has_levels(80, cnt));
+    assert(eye_snr_signal_var(mu, cnt, 80) > 0.0);
+    assert(!eye_snr_has_levels(50, cnt));
+
+    float snr_samples[800];
+    for (int i = 0; i < 800; i++) {
+        int symbol = (i / 8) & 3;
+        int noise = (i & 1) ? 3 : -3;
+        int base = (symbol == 0) ? -90 : (symbol == 1) ? -30 : (symbol == 2) ? 30 : 90;
+        snr_samples[i] = (float)(base + noise);
+    }
+    long long cnt2[4] = {0, 0, 0, 0};
+    double sum2[4] = {0.0, 0.0, 0.0, 0.0};
+    eye_snr_collect_bins(snr_samples, 800, 8, 2, 6, 1, -60, 0, 60, cnt2, sum2);
+    assert(cnt2[0] > 0);
+    assert(cnt2[1] > 0);
+    assert(cnt2[2] > 0);
+    assert(cnt2[3] > 0);
+    double mu2[4] = {0.0, 0.0, 0.0, 0.0};
+    long long total2 = eye_snr_level_means(cnt2, sum2, mu2);
+    assert(eye_snr_noise_var(snr_samples, 800, 8, 2, 6, 1, -60, 0, 60, mu2, total2) > 0.0);
+    assert(eye_estimate_snr_fallback(snr_samples, 800, 4, 8, -60, 0, 60, -100.0) > -20.0);
+    assert(eye_estimate_snr_fallback(snr_samples, 80, 4, 8, -60, 0, 60, -17.5) == -17.5);
+    assert(eye_smooth_peak(samples, 8, 64.0f) >= 64);
+
+    g_test_rows = 9;
+    g_test_cols = 18;
+    int eye_w = 0;
+    int eye_h = 0;
+    eye_grid_size(&eye_w, &eye_h);
+    assert(eye_w == 32);
+    assert(eye_h == 12);
+    g_test_rows = 60;
+    g_test_cols = 90;
+    eye_grid_size(&eye_w, &eye_h);
+    assert(eye_w == 86);
+    assert(eye_h == 20);
+    g_test_rows = 24;
+    g_test_cols = 80;
+
+    unsigned short eye_den[8 * 6];
+    DSD_MEMSET(eye_den, 0, sizeof eye_den);
+    eye_den[(2 * 8) + 3] = 4;
+    eye_plot render_plot;
+    DSD_MEMSET(&render_plot, 0, sizeof render_plot);
+    render_plot.den = eye_den;
+    render_plot.W = 8;
+    render_plot.H = 6;
+    render_plot.dmax = 4;
+    render_plot.yq1 = 1;
+    render_plot.yq2 = 2;
+    render_plot.yq3 = 4;
+    render_plot.xb0 = 0;
+    render_plot.xb1 = 3;
+    render_plot.xb2 = 7;
+    render_reset();
+    eye_render_rows(&style, &render_plot);
+    assert(strchr(g_render_out, '+') != NULL);
+    assert(strchr(g_render_out, '-') != NULL);
+    assert(strchr(g_render_out, '|') != NULL);
+
+    style.color_enabled = 1;
+    style.guide_h_pair = 29;
+    style.guide_v_pair = 30;
+    style.guide_x_pair = 31;
+    int color_pair = -1;
+    render_reset();
+    eye_render_cell(&style, &render_plot, 3, 2, &color_pair);
+    assert(g_attron_count > 0);
+    assert(g_attroff_count > 0);
+    style.color_enabled = 0;
+
+    render_reset();
+    eye_print_legend(&style);
+    assert(strstr(g_render_out, "Ref: '-' Q1/Q3") != NULL);
+    assert(strstr(g_render_out, "Density: . : - = + * # @") != NULL);
+}
+
+static void
+test_histogram_and_spectrum_helpers(void) {
+    assert(fsk_hist_bucket_for_value(-5, -1, 1, 5) == 0);
+    assert(fsk_hist_bucket_for_value(0, -1, 1, 5) == 1);
+    assert(fsk_hist_bucket_for_value(3, -1, 1, 5) == 2);
+    assert(fsk_hist_bucket_for_value(9, -1, 1, 5) == 3);
+
+    const float hist_samples[] = {-1.0f, -0.5f, 0.5f, 1.0f};
+    int peak = 0;
+    double dc_norm = fsk_hist_dc_offset_norm(hist_samples, 4, 100.0f, &peak);
+    assert(peak == 100);
+    assert(fabs(dc_norm) < 0.0001);
+
+    int vals[8];
+    int m = fsk_hist_collect_values(hist_samples, 4, 100.0f, vals);
+    assert(m == 4);
+    assert(vals[0] == -100);
+    assert(vals[3] == 100);
+
+    int64_t bins[4] = {0, 0, 0, 0};
+    fsk_hist_count_bins(hist_samples, 4, 100.0f, -50, 0, 50, bins);
+    assert(bins[0] == 2);
+    assert(bins[1] == 0);
+    assert(bins[2] == 1);
+    assert(bins[3] == 1);
+
+    int qvals[] = {-120, -40, -20, -10, 10, 20, 40, 120};
+    int q1 = 0;
+    int q2 = 0;
+    int q3 = 0;
+    fsk_hist_compute_quartiles(qvals, 8, &q1, &q2, &q3);
+    assert(q1 <= q2);
+    assert(q2 <= q3);
+
+    const float fft_bins[] = {1.0f, 3.0f, 2.0f, 7.0f, 4.0f, 0.0f};
+    float col[4];
+    spectrum_resample_columns(fft_bins, 6, col, 3);
+    assert(col[0] == 3.0f);
+    assert(col[1] == 7.0f);
+    assert(col[2] == 4.0f);
+    spectrum_resample_columns(fft_bins, 3, col, 4);
+    assert(col[0] == 1.0f);
+    assert(col[3] == 2.0f);
+
+    float vmin = 0.0f;
+    float vmax = 0.0f;
+    float span = 0.0f;
+    spectrum_range(col, 4, &vmin, &vmax, &span);
+    assert(vmax == 3.0f);
+    assert(vmin == -57.0f);
+    assert(span == 60.0f);
+
+    assert(spectrum_color_pair_for_level(0.10f) == 13);
+    assert(spectrum_color_pair_for_level(0.50f) == 12);
+    assert(spectrum_color_pair_for_level(0.90f) == 11);
+
+    render_reset();
+    fsk_hist_draw_ruler(-50, 0, 50, -100, 100);
+    assert(strstr(g_render_out, "Ruler:") != NULL);
+    assert(strstr(g_render_out, "Median='+'") != NULL);
+    assert(strchr(g_render_out, '+') != NULL);
+
+    const int64_t bar_bins[4] = {1, 2, 4, 8};
+    render_reset();
+    fsk_hist_draw_bars(bar_bins, 0.125);
+    assert(strstr(g_render_out, "DC Offset: +12.50%") != NULL);
+    assert(strstr(g_render_out, "L3(-)") != NULL);
+    assert(strstr(g_render_out, "L3(+)") != NULL);
+    assert(strstr(g_render_out, " 8\n") != NULL);
+
+    g_test_rows = 12;
+    g_test_cols = 20;
+    assert(spectrum_grid_width() == 32);
+    assert(spectrum_grid_height() == 10);
+    g_test_rows = 90;
+    g_test_cols = 3000;
+    assert(spectrum_grid_width() == 2048);
+    assert(spectrum_grid_height() == 30);
+    g_test_rows = 24;
+    g_test_cols = 80;
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    g_has_colors = 1;
+    opts.eye_color = 1;
+    render_reset();
+    spectrum_draw_cell(&opts, 0, vmax, vmin, vmax, span, 0, 4);
+    assert(strcmp(g_render_out, "#") == 0);
+    assert(g_attron_count == 1);
+    assert(g_attroff_count == 1);
+    render_reset();
+    spectrum_draw_cell(&opts, 0, vmin, vmin, vmax, span, 0, 4);
+    assert(strcmp(g_render_out, " ") == 0);
+
+    const float plot_cols[] = {vmin, vmax};
+    render_reset();
+    spectrum_draw_plot(&opts, plot_cols, 2, 3, vmin, vmax, span, 0);
+    assert(strstr(g_render_out, " #\n") != NULL);
+    assert(strstr(g_render_out, "##\n") != NULL);
+
+    render_reset();
+    spectrum_print_legend(&opts, 48000, 48, 0, vmax, vmin);
+    assert(strstr(g_render_out, "Span: 48.0 kHz") != NULL);
+    assert(strstr(g_render_out, "FFT: 128") != NULL);
+    assert(strstr(g_render_out, "Glyphs: ASCII; colored") != NULL);
+    assert(strstr(g_render_out, "Color:") != NULL);
+    g_has_colors = 0;
+
+    render_reset();
+    print_fsk_hist_view();
+    assert(strstr(g_render_out, "(no samples)") != NULL);
+
+    render_reset();
+    print_spectrum_view(&opts);
+    assert(strstr(g_render_out, "(no spectrum yet)") != NULL);
+}
+
+int
+main(void) {
+    test_density_and_constellation_helpers();
+    test_eye_helpers();
+    test_histogram_and_spectrum_helpers();
+    return 0;
+}
+
+// NOLINTEND(bugprone-suspicious-include)

--- a/tests/ui/test_ui_opts_snapshot.c
+++ b/tests/ui/test_ui_opts_snapshot.c
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/ui/ui_opts_snapshot.h>
+
+#include "telemetry_hooks_impl.h"
+
+static void
+test_initial_snapshot_is_absent(void) {
+    assert(ui_get_latest_opts_snapshot() == NULL);
+}
+
+static void
+test_publish_copies_latest_options(void) {
+    static dsd_opts opts;
+    const dsd_opts* snap;
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.audio_out = 1;
+    opts.rtlsdr_center_freq = 851012500U;
+    opts.rtlsdr_ppm_error = -2;
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", "rtl:0:851.0125M");
+
+    ui_terminal_telemetry_publish_opts_snapshot(&opts);
+    opts.audio_in_type = AUDIO_IN_TCP;
+    opts.rtlsdr_center_freq = 0U;
+    opts.audio_in_dev[0] = '\0';
+
+    snap = ui_get_latest_opts_snapshot();
+    assert(snap != NULL);
+    assert(snap->audio_in_type == AUDIO_IN_RTL);
+    assert(snap->audio_out == 1);
+    assert(snap->rtlsdr_center_freq == 851012500U);
+    assert(snap->rtlsdr_ppm_error == -2);
+    assert(strcmp(snap->audio_in_dev, "rtl:0:851.0125M") == 0);
+}
+
+static void
+test_republish_updates_stable_consumer_copy(void) {
+    static dsd_opts opts;
+    const dsd_opts* first;
+    const dsd_opts* second;
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    ui_terminal_telemetry_publish_opts_snapshot(&opts);
+    first = ui_get_latest_opts_snapshot();
+    assert(first != NULL);
+    assert(first->audio_in_type == AUDIO_IN_WAV);
+
+    opts.audio_in_type = AUDIO_IN_UDP;
+    opts.udp_portno = 7355;
+    ui_terminal_telemetry_publish_opts_snapshot(&opts);
+    second = ui_get_latest_opts_snapshot();
+    assert(second == first);
+    assert(second->audio_in_type == AUDIO_IN_UDP);
+    assert(second->udp_portno == 7355);
+}
+
+int
+main(void) {
+    test_initial_snapshot_is_absent();
+    test_publish_copies_latest_options();
+    test_republish_updates_stable_consumer_copy();
+    printf("UI_OPTS_SNAPSHOT: OK\n");
+    return 0;
+}

--- a/tests/ui/test_ui_panels_header_footer.c
+++ b/tests/ui/test_ui_panels_header_footer.c
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(misc-use-internal-linkage)
+/*
+ * Focused checks for terminal header/footer panel contracts without a real
+ * curses screen.
+ */
+
+#include <assert.h>
+#include <curses.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/ui/panels.h>
+#include <dsd-neo/ui/ui_prims.h>
+#include <stdarg.h>
+#include <string.h>
+#include <time.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+const char GIT_TAG[] = "test-tag";
+const char GIT_HASH[] = "test-hash";
+
+static int g_attron_calls;
+static int g_attroff_calls;
+static int g_hr_calls;
+static int g_printw_calls;
+static int g_last_attron;
+static int g_last_attroff;
+static char g_last_printw[256];
+
+static void
+reset_calls(void) {
+    g_attron_calls = 0;
+    g_attroff_calls = 0;
+    g_hr_calls = 0;
+    g_printw_calls = 0;
+    g_last_attron = 0;
+    g_last_attroff = 0;
+    g_last_printw[0] = '\0';
+}
+
+int
+attron(int attrs) { // NOLINT(misc-use-internal-linkage)
+    g_attron_calls++;
+    g_last_attron = attrs;
+    return 0;
+}
+
+int
+attroff(int attrs) { // NOLINT(misc-use-internal-linkage)
+    g_attroff_calls++;
+    g_last_attroff = attrs;
+    return 0;
+}
+
+int
+printw(const char* fmt, ...) { // NOLINT(misc-use-internal-linkage)
+    va_list ap;
+    va_start(ap, fmt);
+    DSD_VSNPRINTF(g_last_printw, sizeof g_last_printw, fmt, ap);
+    va_end(ap);
+    g_printw_calls++;
+    return 0;
+}
+
+void
+ui_print_hr(void) { // NOLINT(misc-use-internal-linkage)
+    g_hr_calls++;
+}
+
+static void
+test_header_null_opts_is_noop(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    reset_calls();
+    ui_panel_header_render(NULL, &state);
+
+    assert(g_attron_calls == 0);
+    assert(g_attroff_calls == 0);
+    assert(g_hr_calls == 0);
+    assert(g_printw_calls == 0);
+}
+
+static void
+test_header_compact_renders_without_banner_color(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    opts.ncurses_compact = 1;
+
+    reset_calls();
+    ui_panel_header_render(&opts, &state);
+
+    assert(g_attron_calls == 0);
+    assert(g_attroff_calls == 0);
+    assert(g_hr_calls == 2);
+    assert(g_printw_calls == 1);
+    assert(strstr(g_last_printw, "test-tag") != NULL);
+    assert(strstr(g_last_printw, "test-hash") != NULL);
+}
+
+static void
+test_header_compact_trunk_restores_trunk_color(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    opts.ncurses_compact = 1;
+    opts.p25_trunk = 1;
+
+    reset_calls();
+    ui_panel_header_render(&opts, &state);
+
+    assert(g_attron_calls == 1);
+    assert(g_last_attron == COLOR_PAIR(4));
+    assert(g_attroff_calls == 0);
+    assert(g_hr_calls == 2);
+    assert(g_printw_calls == 1);
+}
+
+static void
+test_header_full_renders_banner_and_body_colors(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    reset_calls();
+    ui_panel_header_render(&opts, &state);
+
+    assert(g_attron_calls == 2);
+    assert(g_attroff_calls == 1);
+    assert(g_last_attroff == COLOR_PAIR(6));
+    assert(g_last_attron == COLOR_PAIR(4));
+    assert(g_hr_calls == 2);
+    assert(g_printw_calls == 1);
+}
+
+static void
+test_footer_null_inputs_are_noop(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    reset_calls();
+    ui_panel_footer_status_render(NULL, &state);
+    ui_panel_footer_status_render(&opts, NULL);
+
+    assert(g_attron_calls == 0);
+    assert(g_attroff_calls == 0);
+    assert(g_hr_calls == 0);
+    assert(g_printw_calls == 0);
+}
+
+static void
+test_footer_active_toast_renders_without_clearing(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_SNPRINTF(state.ui_msg, sizeof state.ui_msg, "muted");
+    state.ui_msg_expire = time(NULL) + 60;
+
+    reset_calls();
+    ui_panel_footer_status_render(&opts, &state);
+
+    assert(g_attron_calls == 1);
+    assert(g_last_attron == COLOR_PAIR(2));
+    assert(g_attroff_calls == 1);
+    assert(g_last_attroff == COLOR_PAIR(2));
+    assert(g_hr_calls == 1);
+    assert(g_printw_calls == 1);
+    assert(strstr(g_last_printw, "muted") != NULL);
+    assert(strcmp(state.ui_msg, "muted") == 0);
+}
+
+static void
+test_footer_expired_toast_clears_snapshot_only(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_SNPRINTF(state.ui_msg, sizeof state.ui_msg, "expired");
+    state.ui_msg_expire = time(NULL) - 1;
+
+    reset_calls();
+    ui_panel_footer_status_render(&opts, &state);
+
+    assert(g_attron_calls == 0);
+    assert(g_attroff_calls == 0);
+    assert(g_hr_calls == 0);
+    assert(g_printw_calls == 0);
+    assert(state.ui_msg[0] == '\0');
+    assert(state.ui_msg_expire == 0);
+}
+
+int
+main(void) {
+    test_header_null_opts_is_noop();
+    test_header_compact_renders_without_banner_color();
+    test_header_compact_trunk_restores_trunk_color();
+    test_header_full_renders_banner_and_body_colors();
+    test_footer_null_inputs_are_noop();
+    test_footer_active_toast_renders_without_clearing();
+    test_footer_expired_toast_clears_snapshot_only();
+    return 0;
+}
+
+// NOLINTEND(misc-use-internal-linkage)

--- a/tests/ui/test_ui_prims_status_gamma.c
+++ b/tests/ui/test_ui_prims_status_gamma.c
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
+// invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// NOLINTBEGIN(bugprone-suspicious-include)
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <curses.h>
+#include <dsd-neo/core/safe_api.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+static int g_fake_stdscr_storage;
+static int g_fake_window_storage;
+static int g_other_window_storage;
+WINDOW* stdscr;
+
+static int g_rows;
+static int g_cols;
+static int g_cur_y;
+static int g_cur_x;
+static int g_newwin_h;
+static int g_newwin_w;
+static int g_newwin_y;
+static int g_newwin_x;
+static int g_keypad_count;
+static bool g_keypad_enabled;
+static int g_wtimeout_count;
+static int g_wtimeout_delay;
+static int g_wborder_count;
+static int g_wnoutrefresh_count;
+static int g_delwin_count;
+static WINDOW* g_delwin_arg;
+static int g_doupdate_count;
+static int g_wmove_count;
+static int g_last_move_y;
+static int g_last_move_x;
+static int g_whline_count;
+static int g_last_hline_y;
+static int g_last_hline_x;
+static chtype g_last_hline_ch;
+static int g_last_hline_len;
+static int g_waddch_count;
+static chtype g_last_addch;
+static int g_waddnstr_count;
+static char g_added_text[64];
+static int g_wattr_get_count;
+static int g_wattr_on_count;
+static attr_t g_last_attr_on;
+static int g_wattr_set_count;
+static attr_t g_last_attr_set;
+static NCURSES_PAIRS_T g_last_pair_set;
+static WINDOW* g_newwin_result;
+
+static void
+reset_curses_stubs(void) {
+    stdscr = (WINDOW*)&g_fake_stdscr_storage;
+    g_newwin_result = (WINDOW*)&g_fake_window_storage;
+    g_rows = 24;
+    g_cols = 80;
+    g_cur_y = 0;
+    g_cur_x = 0;
+    g_newwin_h = 0;
+    g_newwin_w = 0;
+    g_newwin_y = 0;
+    g_newwin_x = 0;
+    g_keypad_count = 0;
+    g_keypad_enabled = false;
+    g_wtimeout_count = 0;
+    g_wtimeout_delay = -1;
+    g_wborder_count = 0;
+    g_wnoutrefresh_count = 0;
+    g_delwin_count = 0;
+    g_delwin_arg = NULL;
+    g_doupdate_count = 0;
+    g_wmove_count = 0;
+    g_last_move_y = -1;
+    g_last_move_x = -1;
+    g_whline_count = 0;
+    g_last_hline_y = -1;
+    g_last_hline_x = -1;
+    g_last_hline_ch = 0;
+    g_last_hline_len = -1;
+    g_waddch_count = 0;
+    g_last_addch = 0;
+    g_waddnstr_count = 0;
+    g_added_text[0] = '\0';
+    g_wattr_get_count = 0;
+    g_wattr_on_count = 0;
+    g_last_attr_on = 0;
+    g_wattr_set_count = 0;
+    g_last_attr_set = 0;
+    g_last_pair_set = 0;
+}
+
+WINDOW*
+newwin(int h, int w, int y, int x) {
+    g_newwin_h = h;
+    g_newwin_w = w;
+    g_newwin_y = y;
+    g_newwin_x = x;
+    return g_newwin_result;
+}
+
+int
+keypad(WINDOW* win, bool enabled) {
+    assert(win == g_newwin_result);
+    g_keypad_count++;
+    g_keypad_enabled = enabled;
+    return OK;
+}
+
+void
+wtimeout(WINDOW* win, int delay) {
+    assert(win == g_newwin_result);
+    g_wtimeout_count++;
+    g_wtimeout_delay = delay;
+}
+
+int
+wborder(WINDOW* win, chtype ls, chtype rs, chtype ts, chtype bs, chtype tl, chtype tr, chtype bl, chtype br) {
+    (void)ls;
+    (void)rs;
+    (void)ts;
+    (void)bs;
+    (void)tl;
+    (void)tr;
+    (void)bl;
+    (void)br;
+    assert(win == g_newwin_result);
+    g_wborder_count++;
+    return OK;
+}
+
+int
+wnoutrefresh(WINDOW* win) {
+    assert(win == g_newwin_result);
+    g_wnoutrefresh_count++;
+    return OK;
+}
+
+int
+delwin(WINDOW* win) {
+    g_delwin_count++;
+    g_delwin_arg = win;
+    return OK;
+}
+
+int
+doupdate(void) {
+    g_doupdate_count++;
+    return OK;
+}
+
+int
+getmaxy(const WINDOW* win) {
+    assert(win == stdscr);
+    return g_rows;
+}
+
+int
+getmaxx(const WINDOW* win) {
+    assert(win == stdscr);
+    return g_cols;
+}
+
+int
+getcury(const WINDOW* win) {
+    assert(win == stdscr);
+    return g_cur_y;
+}
+
+int
+getcurx(const WINDOW* win) {
+    assert(win == stdscr);
+    return g_cur_x;
+}
+
+int
+wmove(WINDOW* win, int y, int x) {
+    assert(win == stdscr);
+    g_wmove_count++;
+    g_last_move_y = y;
+    g_last_move_x = x;
+    return OK;
+}
+
+int
+whline(WINDOW* win, chtype ch, int n) {
+    assert(win == stdscr);
+    g_whline_count++;
+    g_last_hline_y = g_last_move_y;
+    g_last_hline_x = g_last_move_x;
+    g_last_hline_ch = ch;
+    g_last_hline_len = n;
+    return OK;
+}
+
+int
+waddch(WINDOW* win, const chtype ch) {
+    assert(win == stdscr);
+    g_waddch_count++;
+    g_last_addch = ch;
+    return OK;
+}
+
+int
+waddnstr(WINDOW* win, const char* str, int n) {
+    assert(win == stdscr);
+    (void)n;
+    g_waddnstr_count++;
+    if (str) {
+        const size_t used = strlen(g_added_text);
+        if (used < sizeof(g_added_text) - 1U) {
+            size_t copy_len = strlen(str);
+            const size_t avail = sizeof(g_added_text) - used - 1U;
+            if (copy_len > avail) {
+                copy_len = avail;
+            }
+            DSD_MEMCPY(g_added_text + used, str, copy_len);
+            g_added_text[used + copy_len] = '\0';
+        }
+    }
+    return OK;
+}
+
+int
+wattr_get(WINDOW* win, attr_t* attrs, NCURSES_PAIRS_T* pair, void* opts) {
+    (void)opts;
+    assert(win == stdscr);
+    g_wattr_get_count++;
+    *attrs = (attr_t)0x1234;
+    *pair = (NCURSES_PAIRS_T)9;
+    return OK;
+}
+
+int
+wattr_on(WINDOW* win, attr_t attrs, void* opts) {
+    (void)opts;
+    assert(win == stdscr);
+    g_wattr_on_count++;
+    g_last_attr_on = attrs;
+    return OK;
+}
+
+int
+wattr_set(WINDOW* win, attr_t attrs, NCURSES_PAIRS_T pair, void* opts) {
+    (void)opts;
+    assert(win == stdscr);
+    g_wattr_set_count++;
+    g_last_attr_set = attrs;
+    g_last_pair_set = pair;
+    return OK;
+}
+
+#include "../../src/ui/terminal/ui_prims.c"
+
+static void
+test_status_lifecycle(void) {
+    char buf[32];
+    time_t now = time(NULL);
+
+    ui_status_clear_if_expired(now + 10);
+    assert(ui_status_peek(NULL, sizeof buf, now) == 0);
+    assert(ui_status_peek(buf, 0, now) == 0);
+    assert(ui_status_peek(buf, sizeof buf, now) == 0);
+
+    ui_statusf(NULL);
+    assert(ui_status_peek(buf, sizeof buf, now) == 0);
+
+    ui_statusf("level %d", 7);
+    now = time(NULL);
+    assert(ui_status_peek(buf, sizeof buf, now) == 1);
+    assert(strcmp(buf, "level 7") == 0);
+
+    ui_status_clear_if_expired(now);
+    assert(ui_status_peek(buf, sizeof buf, now) == 1);
+    assert(strcmp(buf, "level 7") == 0);
+
+    assert(ui_status_peek(buf, 5, now) == 1);
+    assert(strcmp(buf, "leve") == 0);
+
+    assert(ui_status_peek(buf, sizeof buf, now + 10) == 0);
+    ui_status_clear_if_expired(now + 10);
+    assert(ui_status_peek(buf, sizeof buf, now) == 0);
+}
+
+static void
+test_iden_color_mapping(void) {
+    assert(ui_iden_color_pair(-4) == 21);
+    assert(ui_iden_color_pair(0) == 21);
+    assert(ui_iden_color_pair(7) == 28);
+    assert(ui_iden_color_pair(8) == 21);
+    assert(ui_iden_color_pair(15) == 28);
+}
+
+static void
+test_gamma_map_contract(void) {
+    assert(ui_gamma_map01(-0.25) == 0.0);
+    assert(ui_gamma_map01(0.0) == 0.0);
+    assert(ui_gamma_map01(1.0) == 1.0);
+    assert(ui_gamma_map01(1.25) == 1.0);
+
+    double quarter = ui_gamma_map01(0.25);
+    double half = ui_gamma_map01(0.5);
+    double three_quarters = ui_gamma_map01(0.75);
+
+    assert(quarter > 0.49 && quarter < 0.52);
+    assert(half > quarter);
+    assert(half > 0.70 && half < 0.72);
+    assert(three_quarters > half);
+    assert(three_quarters > 0.86 && three_quarters < 0.88);
+}
+
+static void
+test_window_lifecycle_contracts(void) {
+    reset_curses_stubs();
+    WINDOW* win = ui_make_window(4, 20, 2, 3);
+    assert(win == g_newwin_result);
+    assert(g_newwin_h == 4);
+    assert(g_newwin_w == 20);
+    assert(g_newwin_y == 2);
+    assert(g_newwin_x == 3);
+    assert(g_keypad_count == 1);
+    assert(g_keypad_enabled == true);
+    assert(g_wtimeout_count == 1);
+    assert(g_wtimeout_delay == 0);
+    assert(g_wborder_count == 1);
+    assert(g_wnoutrefresh_count == 1);
+
+    reset_curses_stubs();
+    g_newwin_result = NULL;
+    assert(ui_make_window(1, 2, 3, 4) == NULL);
+    assert(g_keypad_count == 0);
+    assert(g_wtimeout_count == 0);
+    assert(g_wborder_count == 0);
+    assert(g_wnoutrefresh_count == 0);
+
+    reset_curses_stubs();
+    win = (WINDOW*)&g_other_window_storage;
+    ui_destroy_window(&win);
+    assert(g_delwin_count == 1);
+    assert(g_delwin_arg == (WINDOW*)&g_other_window_storage);
+    assert(win == NULL);
+    ui_destroy_window(NULL);
+    ui_destroy_window(&win);
+    assert(g_delwin_count == 1);
+
+    ui_commit_frame();
+    assert(g_doupdate_count == 1);
+}
+
+static void
+test_drawing_helpers_use_terminal_geometry(void) {
+    reset_curses_stubs();
+    g_rows = 3;
+    g_cols = 6;
+    g_cur_y = 1;
+    ui_print_hr();
+    assert(g_whline_count == 1);
+    assert(g_last_hline_y == 1);
+    assert(g_last_hline_x == 0);
+    assert(g_last_hline_ch == '-');
+    assert(g_last_hline_len == 6);
+    assert(g_wmove_count == 2);
+    assert(g_last_move_y == 2);
+    assert(g_last_move_x == 0);
+    assert(g_waddch_count == 0);
+
+    reset_curses_stubs();
+    g_rows = 0;
+    g_cols = 0;
+    ui_print_hr();
+    assert(g_last_hline_len == 80);
+    assert(g_waddch_count == 1);
+    assert(g_last_addch == '\n');
+
+    reset_curses_stubs();
+    g_rows = 2;
+    g_cols = 10;
+    g_cur_y = 0;
+    ui_print_header("TG");
+    assert(g_waddnstr_count == 2);
+    assert(strcmp(g_added_text, "--TG") == 0);
+    assert(g_whline_count == 1);
+    assert(g_last_hline_y == 0);
+    assert(g_last_hline_x == 4);
+    assert(g_last_hline_len == 6);
+    assert(g_last_move_y == 1);
+    assert(g_last_move_x == 0);
+
+    reset_curses_stubs();
+    g_rows = 1;
+    g_cols = 3;
+    ui_print_header(NULL);
+    assert(strcmp(g_added_text, "--") == 0);
+    assert(g_last_hline_len == 78);
+    assert(g_waddch_count == 1);
+    assert(g_last_addch == '\n');
+}
+
+static void
+test_border_helpers_restore_saved_attributes(void) {
+    reset_curses_stubs();
+    ui_print_lborder();
+    assert(g_wattr_get_count == 1);
+    assert(g_wattr_on_count == 1);
+    assert(g_last_attr_on == COLOR_PAIR(4));
+    assert(g_waddch_count == 1);
+    assert(g_last_addch == '|');
+    assert(g_wattr_set_count == 1);
+    assert(g_last_attr_set == (attr_t)0x1234);
+    assert(g_last_pair_set == (NCURSES_PAIRS_T)9);
+
+    reset_curses_stubs();
+    ui_print_lborder_green();
+    assert(g_wattr_on_count == 1);
+    assert(g_last_attr_on == COLOR_PAIR(3));
+    assert(g_wattr_set_count == 1);
+    assert(g_last_attr_set == (attr_t)0x1234);
+    assert(g_last_pair_set == (NCURSES_PAIRS_T)9);
+}
+
+int
+main(void) {
+    test_status_lifecycle();
+    test_iden_color_mapping();
+    test_gamma_map_contract();
+    test_window_lifecycle_contracts();
+    test_drawing_helpers_use_terminal_geometry();
+    test_border_helpers_restore_saved_attributes();
+    printf("UI_PRIMS_STATUS_GAMMA: OK\n");
+    return 0;
+}
+
+// NOLINTEND(bugprone-suspicious-include)

--- a/tests/ui/test_ui_prompt_validation.c
+++ b/tests/ui/test_ui_prompt_validation.c
@@ -1,0 +1,668 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <curses.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/platform/platform.h>
+#include <dsd-neo/ui/keymap.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "menu_prompts.h"
+
+static int g_string_done_called = 0;
+static int g_string_was_null = 0;
+static char g_string_text[128];
+static int g_int_done_called = 0;
+static int g_int_ok = -1;
+static int g_int_value = -1;
+static int g_double_done_called = 0;
+static int g_double_ok = -1;
+static double g_double_value = -1.0;
+static int g_status_called = 0;
+static char g_status_text[128];
+
+WINDOW* ui_make_window(int h, int w, int y, int x);                  // NOLINT(misc-use-internal-linkage)
+void ui_statusf(const char* fmt, ...) DSD_ATTR_FORMAT(printf, 1, 2); // NOLINT(misc-use-internal-linkage)
+
+WINDOW*
+ui_make_window(int h, int w, int y, int x) { // NOLINT(misc-use-internal-linkage)
+    (void)h;
+    (void)w;
+    (void)y;
+    (void)x;
+    return NULL;
+}
+
+void
+ui_statusf(const char* fmt, ...) { // NOLINT(misc-use-internal-linkage)
+    va_list ap;
+    va_start(ap, fmt);
+    DSD_VSNPRINTF(g_status_text, sizeof g_status_text, fmt, ap);
+    va_end(ap);
+    g_status_called++;
+}
+
+static void
+reset_string_capture(void) {
+    g_string_done_called = 0;
+    g_string_was_null = 0;
+    g_string_text[0] = '\0';
+}
+
+static void
+capture_string_done(void* user, const char* text) {
+    (void)user;
+    g_string_done_called++;
+    g_string_was_null = (text == NULL);
+    if (text) {
+        DSD_SNPRINTF(g_string_text, sizeof g_string_text, "%s", text);
+    } else {
+        g_string_text[0] = '\0';
+    }
+}
+
+static void
+reset_int_capture(void) {
+    g_int_done_called = 0;
+    g_int_ok = -1;
+    g_int_value = -1;
+    g_status_called = 0;
+    g_status_text[0] = '\0';
+}
+
+static void
+capture_int_done(void* user, int ok, int value) {
+    (void)user;
+    g_int_done_called++;
+    g_int_ok = ok;
+    g_int_value = value;
+}
+
+static void
+reset_double_capture(void) {
+    g_double_done_called = 0;
+    g_double_ok = -1;
+    g_double_value = -1.0;
+    g_status_called = 0;
+    g_status_text[0] = '\0';
+}
+
+static void
+capture_double_done(void* user, int ok, double value) {
+    (void)user;
+    g_double_done_called++;
+    g_double_ok = ok;
+    g_double_value = value;
+}
+
+static void
+clear_prompt_prefill(void) {
+    for (int i = 0; i < 16; i++) {
+        assert(ui_prompt_handle_key(KEY_BACKSPACE) == 1);
+    }
+}
+
+static void
+type_text(const char* text) {
+    for (const char* p = text; p && *p; p++) {
+        assert(ui_prompt_handle_key((unsigned char)*p) == 1);
+    }
+}
+
+static void
+test_string_prompt_completion_paths(void) {
+    assert(ui_prompt_handle_key('x') == 0);
+
+    reset_string_capture();
+    ui_prompt_open_string_async("Small", "abc", 1, capture_string_done, NULL);
+    assert(ui_prompt_active() == 1);
+    assert(ui_prompt_handle_key('Z') == 1);
+    assert(ui_prompt_handle_key('\r') == 1);
+    assert(g_string_done_called == 1);
+    assert(g_string_was_null == 0);
+    assert(strcmp(g_string_text, "a") == 0);
+    assert(ui_prompt_active() == 0);
+
+    reset_string_capture();
+    ui_prompt_open_string_async("Empty", NULL, 8, capture_string_done, NULL);
+    assert(ui_prompt_handle_key('\r') == 1);
+    assert(g_string_done_called == 1);
+    assert(g_string_was_null == 0);
+    assert(strcmp(g_string_text, "") == 0);
+
+    reset_string_capture();
+    ui_prompt_open_string_async("Cancel", "kept", 16, capture_string_done, NULL);
+    assert(ui_prompt_handle_key(DSD_KEY_ESC) == 1);
+    assert(g_string_done_called == 1);
+    assert(g_string_was_null == 1);
+
+    reset_string_capture();
+    ui_prompt_open_string_async("Force close", "pending", 16, capture_string_done, NULL);
+    ui_prompt_close_all();
+    assert(g_string_done_called == 1);
+    assert(g_string_was_null == 1);
+    ui_prompt_close_all();
+    assert(g_string_done_called == 1);
+}
+
+static void
+test_string_prompt_key_edges(void) {
+    reset_string_capture();
+    ui_prompt_open_string_async("Capacity", "a", 3, capture_string_done, NULL);
+    assert(ui_prompt_handle_key('b') == 1);
+    assert(ui_prompt_handle_key('c') == 1);
+    assert(ui_prompt_handle_key('d') == 1);
+    assert(ui_prompt_handle_key(KEY_ENTER) == 1);
+    assert(g_string_done_called == 1);
+    assert(g_string_was_null == 0);
+    assert(strcmp(g_string_text, "ab") == 0);
+
+    reset_string_capture();
+    ui_prompt_open_string_async("Alternate delete", "abc", 16, capture_string_done, NULL);
+    assert(ui_prompt_handle_key(127) == 1);
+    assert(ui_prompt_handle_key(8) == 1);
+    assert(ui_prompt_handle_key(1) == 1);
+    assert(ui_prompt_handle_key('\n') == 1);
+    assert(g_string_done_called == 1);
+    assert(strcmp(g_string_text, "a") == 0);
+
+    reset_string_capture();
+    ui_prompt_open_string_async("Printable q", "", 16, capture_string_done, NULL);
+    assert(ui_prompt_handle_key(KEY_RESIZE) == 1);
+    assert(ui_prompt_handle_key(ERR) == 1);
+    assert(g_string_done_called == 0);
+    assert(ui_prompt_handle_key('q') == 1);
+    assert(ui_prompt_handle_key('\r') == 1);
+    assert(g_string_done_called == 1);
+    assert(g_string_was_null == 0);
+    assert(strcmp(g_string_text, "q") == 0);
+}
+
+static void
+test_string_prompt_cursor_editing(void) {
+    reset_string_capture();
+    ui_prompt_open_string_async("Edit", "abcd", 16, capture_string_done, NULL);
+    assert(ui_prompt_handle_key(KEY_HOME) == 1);
+    assert(ui_prompt_handle_key('X') == 1);
+    assert(ui_prompt_handle_key(KEY_RIGHT) == 1);
+    assert(ui_prompt_handle_key(KEY_RIGHT) == 1);
+    assert(ui_prompt_handle_key(KEY_DC) == 1);
+    assert(ui_prompt_handle_key(KEY_END) == 1);
+    assert(ui_prompt_handle_key('Y') == 1);
+    assert(ui_prompt_handle_key(KEY_LEFT) == 1);
+    assert(ui_prompt_handle_key(KEY_BACKSPACE) == 1);
+    assert(ui_prompt_handle_key('\r') == 1);
+    assert(g_string_done_called == 1);
+    assert(g_string_was_null == 0);
+    assert(strcmp(g_string_text, "XabY") == 0);
+}
+
+static void
+test_typed_prompt_validation(void) {
+    reset_int_capture();
+    ui_prompt_open_int_async("Integer", 42, capture_int_done, NULL);
+    assert(ui_prompt_handle_key('\r') == 1);
+    assert(g_int_done_called == 1);
+    assert(g_int_ok == 1);
+    assert(g_int_value == 42);
+    assert(g_status_called == 0);
+
+    reset_int_capture();
+    ui_prompt_open_int_async("Integer", 0, capture_int_done, NULL);
+    clear_prompt_prefill();
+    assert(ui_prompt_handle_key('x') == 1);
+    assert(ui_prompt_handle_key('\r') == 1);
+    assert(g_int_done_called == 1);
+    assert(g_int_ok == 0);
+    assert(g_int_value == 0);
+    assert(g_status_called == 1);
+    assert(strcmp(g_status_text, "Invalid integer input") == 0);
+
+    reset_int_capture();
+    ui_prompt_open_int_async("Integer", 0, capture_int_done, NULL);
+    clear_prompt_prefill();
+    assert(ui_prompt_handle_key('\r') == 1);
+    assert(g_int_done_called == 1);
+    assert(g_int_ok == 0);
+    assert(g_int_value == 0);
+    assert(g_status_called == 0);
+
+    reset_double_capture();
+    ui_prompt_open_double_async("Number", 1.25, capture_double_done, NULL);
+    assert(ui_prompt_handle_key('\r') == 1);
+    assert(g_double_done_called == 1);
+    assert(g_double_ok == 1);
+    assert(g_double_value > 1.249 && g_double_value < 1.251);
+    assert(g_status_called == 0);
+
+    reset_double_capture();
+    ui_prompt_open_double_async("Number", 0.0, capture_double_done, NULL);
+    clear_prompt_prefill();
+    type_text("1.2x");
+    assert(ui_prompt_handle_key('\r') == 1);
+    assert(g_double_done_called == 1);
+    assert(g_double_ok == 0);
+    assert(g_double_value == 0.0);
+    assert(g_status_called == 1);
+    assert(strcmp(g_status_text, "Invalid numeric input") == 0);
+}
+
+static void
+test_typed_prompt_cancel_paths(void) {
+    reset_int_capture();
+    ui_prompt_open_int_async("Integer cancel", 123, capture_int_done, NULL);
+    assert(ui_prompt_handle_key(DSD_KEY_ESC) == 1);
+    assert(g_int_done_called == 1);
+    assert(g_int_ok == 0);
+    assert(g_int_value == 0);
+    assert(g_status_called == 0);
+
+    reset_double_capture();
+    ui_prompt_open_double_async("Number cancel", 3.5, capture_double_done, NULL);
+    ui_prompt_close_all();
+    assert(g_double_done_called == 1);
+    assert(g_double_ok == 0);
+    assert(g_double_value == 0.0);
+    assert(g_status_called == 0);
+}
+
+typedef struct {
+    int calls;
+    int first_sel;
+    int second_sel;
+} ChooserCapture;
+
+static const char* const CHOOSER_ONE[] = {"one", "two", "three"};
+static const char* const CHOOSER_TWO[] = {"red", "green"};
+static const char* const CHOOSER_MANY[] = {"zero", "one", "two", "three", "four", "five"};
+
+static void
+capture_chooser_reentry(void* user, int selected) {
+    ChooserCapture* capture = (ChooserCapture*)user;
+    capture->calls++;
+    if (capture->calls == 1) {
+        capture->first_sel = selected;
+        ui_chooser_start("Second", CHOOSER_TWO, 2, capture_chooser_reentry, user);
+        return;
+    }
+    capture->second_sel = selected;
+}
+
+static void
+capture_chooser_selected(void* user, int selected) {
+    int* out = (int*)user;
+    *out = selected;
+}
+
+static void
+test_chooser_edge_paths(void) {
+    assert(ui_chooser_handle_key('x') == 0);
+
+    int selected = -2;
+    ui_chooser_start("Empty", NULL, 0, capture_chooser_selected, &selected);
+    assert(selected == -1);
+    assert(ui_chooser_active() == 0);
+
+    selected = -2;
+    ui_chooser_start("Single", CHOOSER_ONE, 1, capture_chooser_selected, &selected);
+    assert(ui_chooser_handle_key(KEY_RESIZE) == 1);
+    assert(ui_chooser_handle_key(KEY_UP) == 1);
+    assert(ui_chooser_handle_key(KEY_DOWN) == 1);
+    assert(ui_chooser_handle_key(KEY_ENTER) == 1);
+    assert(selected == 0);
+    assert(ui_chooser_active() == 0);
+
+    ChooserCapture capture = {0, -2, -2};
+    ui_chooser_start("First", CHOOSER_ONE, 3, capture_chooser_reentry, &capture);
+    assert(ui_chooser_active() == 1);
+    assert(ui_chooser_handle_key(KEY_DOWN) == 1);
+    assert(ui_chooser_handle_key(KEY_RIGHT) == 1);
+    assert(capture.calls == 1);
+    assert(capture.first_sel == 1);
+    assert(ui_chooser_active() == 1);
+
+    UiChooserTestSnapshot snapshot = ui_chooser_test_snapshot();
+    assert(snapshot.count == 2);
+    assert(snapshot.sel == 0);
+    assert(ui_chooser_handle_key('q') == 1);
+    assert(capture.calls == 2);
+    assert(capture.second_sel == -1);
+    assert(ui_chooser_active() == 0);
+}
+
+static void
+test_chooser_page_navigation_clamps_selection(void) {
+    int selected = -2;
+    ui_chooser_start("Many", CHOOSER_MANY, 6, capture_chooser_selected, &selected);
+    ui_chooser_test_set_page_rows(3);
+    UiChooserTestSnapshot snapshot = ui_chooser_test_snapshot();
+    assert(snapshot.sel == 0);
+    assert(snapshot.top == 0);
+
+    assert(ui_chooser_handle_key(KEY_NPAGE) == 1);
+    snapshot = ui_chooser_test_snapshot();
+    assert(snapshot.sel == 2);
+    assert(snapshot.top == 2);
+
+    assert(ui_chooser_handle_key(KEY_NPAGE) == 1);
+    snapshot = ui_chooser_test_snapshot();
+    assert(snapshot.sel == 4);
+    assert(snapshot.top == 3);
+
+    assert(ui_chooser_handle_key(KEY_END) == 1);
+    snapshot = ui_chooser_test_snapshot();
+    assert(snapshot.sel == 5);
+    assert(snapshot.top == 3);
+
+    assert(ui_chooser_handle_key(KEY_PPAGE) == 1);
+    snapshot = ui_chooser_test_snapshot();
+    assert(snapshot.sel == 3);
+    assert(snapshot.top == 1);
+
+    assert(ui_chooser_handle_key(KEY_HOME) == 1);
+    snapshot = ui_chooser_test_snapshot();
+    assert(snapshot.sel == 0);
+    assert(snapshot.top == 0);
+
+    assert(ui_chooser_handle_key('\r') == 1);
+    assert(selected == 0);
+    assert(ui_chooser_active() == 0);
+}
+
+static void
+test_chooser_up_down_wraparound(void) {
+    int selected = -2;
+    ui_chooser_start("Wrap", CHOOSER_ONE, 3, capture_chooser_selected, &selected);
+    ui_chooser_test_set_page_rows(2);
+
+    assert(ui_chooser_handle_key(KEY_UP) == 1);
+    UiChooserTestSnapshot snapshot = ui_chooser_test_snapshot();
+    assert(snapshot.sel == 2);
+    assert(snapshot.top == 1);
+
+    assert(ui_chooser_handle_key(KEY_DOWN) == 1);
+    snapshot = ui_chooser_test_snapshot();
+    assert(snapshot.sel == 0);
+    assert(snapshot.top == 0);
+
+    assert(ui_chooser_handle_key(KEY_LEFT) == 1);
+    assert(selected == -1);
+    assert(ui_chooser_active() == 0);
+}
+
+static void
+test_help_activation_and_close_keys(void) {
+    ui_help_close();
+    ui_help_open(NULL);
+    assert(ui_help_active() == 0);
+    ui_help_open("");
+    assert(ui_help_active() == 0);
+
+    ui_help_open("line one\nline two");
+    assert(ui_help_active() == 1);
+    assert(ui_help_handle_key(ERR) == 1);
+    assert(ui_help_active() == 1);
+    assert(ui_help_handle_key('h') == 1);
+    assert(ui_help_active() == 0);
+
+    ui_help_open("close with enter");
+    assert(ui_help_active() == 1);
+    assert(ui_help_handle_key('\r') == 1);
+    assert(ui_help_active() == 0);
+
+    ui_help_open("close with escape");
+    assert(ui_help_active() == 1);
+    assert(ui_help_handle_key(DSD_KEY_ESC) == 1);
+    assert(ui_help_active() == 0);
+
+    ui_help_open("close with shifted help");
+    assert(ui_help_active() == 1);
+    assert(ui_help_handle_key('H') == 1);
+    assert(ui_help_active() == 0);
+
+    ui_help_open("close with left");
+    assert(ui_help_active() == 1);
+    assert(ui_help_handle_key(KEY_LEFT) == 1);
+    assert(ui_help_active() == 0);
+}
+
+static void
+test_help_scroll_navigation_clamps_to_content(void) {
+    ui_help_open("scrollable help");
+    assert(ui_help_active() == 1);
+    ui_help_test_set_metrics(12, 4, -5);
+    UiHelpTestSnapshot snapshot = ui_help_test_snapshot();
+    assert(snapshot.scroll == 0);
+    assert(snapshot.line_count == 12);
+    assert(snapshot.page_rows == 4);
+
+    assert(ui_help_handle_key(KEY_DOWN) == 1);
+    snapshot = ui_help_test_snapshot();
+    assert(snapshot.scroll == 1);
+
+    assert(ui_help_handle_key(KEY_NPAGE) == 1);
+    snapshot = ui_help_test_snapshot();
+    assert(snapshot.scroll == 4);
+
+    assert(ui_help_handle_key(KEY_END) == 1);
+    snapshot = ui_help_test_snapshot();
+    assert(snapshot.scroll == 8);
+
+    assert(ui_help_handle_key(KEY_DOWN) == 1);
+    snapshot = ui_help_test_snapshot();
+    assert(snapshot.scroll == 8);
+
+    assert(ui_help_handle_key(KEY_PPAGE) == 1);
+    snapshot = ui_help_test_snapshot();
+    assert(snapshot.scroll == 5);
+
+    assert(ui_help_handle_key(KEY_UP) == 1);
+    snapshot = ui_help_test_snapshot();
+    assert(snapshot.scroll == 4);
+
+    assert(ui_help_handle_key(KEY_HOME) == 1);
+    snapshot = ui_help_test_snapshot();
+    assert(snapshot.scroll == 0);
+
+    assert(ui_help_handle_key(KEY_UP) == 1);
+    snapshot = ui_help_test_snapshot();
+    assert(snapshot.scroll == 0);
+
+    assert(ui_help_handle_key(KEY_RESIZE) == 1);
+    assert(ui_help_active() == 1);
+    assert(ui_help_handle_key('x') == 1);
+    assert(ui_help_active() == 1);
+    assert(ui_help_handle_key('Q') == 1);
+    assert(ui_help_active() == 0);
+}
+
+static void
+test_help_wrap_text_contracts(void) {
+    char line[64];
+
+    int count = ui_help_wrap_line_for_test("alpha beta", 20, 0, line, sizeof line);
+    assert(count == 1);
+    assert(strcmp(line, "alpha beta") == 0);
+
+    count = ui_help_wrap_line_for_test("   \nnext", 10, 0, line, sizeof line);
+    assert(count == 2);
+    assert(strcmp(line, "") == 0);
+
+    count = ui_help_wrap_line_for_test("   \nnext", 10, 1, line, sizeof line);
+    assert(count == 2);
+    assert(strcmp(line, "next") == 0);
+
+    count = ui_help_wrap_line_for_test("alpha beta\nsuperlongword tail", 6, 0, line, sizeof line);
+    assert(count == 6);
+    assert(strcmp(line, "alpha") == 0);
+
+    count = ui_help_wrap_line_for_test("alpha beta\nsuperlongword tail", 6, 1, line, sizeof line);
+    assert(count == 6);
+    assert(strcmp(line, "beta") == 0);
+
+    count = ui_help_wrap_line_for_test("alpha beta\nsuperlongword tail", 6, 2, line, sizeof line);
+    assert(count == 6);
+    assert(strcmp(line, "superl") == 0);
+
+    count = ui_help_wrap_line_for_test("alpha beta\nsuperlongword tail", 6, 3, line, sizeof line);
+    assert(count == 6);
+    assert(strcmp(line, "ongwor") == 0);
+
+    count = ui_help_wrap_line_for_test("alpha beta\nsuperlongword tail", 6, 5, line, sizeof line);
+    assert(count == 6);
+    assert(strcmp(line, "tail") == 0);
+
+    count = ui_help_wrap_line_for_test(NULL, 12, 0, line, sizeof line);
+    assert(count == 1);
+    assert(strcmp(line, "") == 0);
+
+    count = ui_help_wrap_line_for_test("ignored", 0, 0, line, sizeof line);
+    assert(count == 0);
+    assert(strcmp(line, "") == 0);
+}
+
+static void
+test_chooser_layout_contracts(void) {
+    static const char* const ITEMS[] = {"short", "a much longer option"};
+    int h = -1;
+    int w = -1;
+    int y = -1;
+    int x = -1;
+
+    int max_item = ui_chooser_max_item_width_for_test(ITEMS, 2);
+    assert(max_item == (int)strlen("a much longer option"));
+    assert(ui_chooser_max_item_width_for_test(ITEMS, 0) == 0);
+
+    assert(ui_chooser_layout_for_test("Pick", "Footer", max_item, 2, 24, 80, &h, &w, &y, &x) == 1);
+    assert(h == 7);
+    assert(w == 26);
+    assert(y == 8);
+    assert(x == 27);
+
+    assert(ui_chooser_layout_for_test("Pick", "Footer", max_item, 12, 10, 24, &h, &w, &y, &x) == 1);
+    assert(h == 8);
+    assert(w == 22);
+    assert(y == 1);
+    assert(x == 1);
+
+    assert(ui_chooser_layout_for_test("Pick", "Footer", max_item, 2, 3, 80, &h, &w, &y, &x) == 0);
+    assert(ui_chooser_layout_for_test("Pick", "Footer", max_item, 2, 24, 7, &h, &w, &y, &x) == 0);
+    assert(ui_chooser_layout_for_test(NULL, "Footer", max_item, 2, 24, 80, &h, &w, &y, &x) == 0);
+    assert(ui_chooser_layout_for_test("Pick", NULL, max_item, 2, 24, 80, &h, &w, &y, &x) == 0);
+}
+
+static void
+test_prompt_layout_and_view_contracts(void) {
+    assert(ui_prompt_center_axis_for_test(24, 8) == 8);
+    assert(ui_prompt_center_axis_for_test(4, 9) == 0);
+
+    assert(ui_prompt_fit_width_for_test(60, 80) == 60);
+    assert(ui_prompt_fit_width_for_test(90, 80) == 78);
+    assert(ui_prompt_fit_width_for_test(5, 80) == 10);
+    assert(ui_prompt_fit_width_for_test(20, 3) == 0);
+    assert(ui_prompt_fit_width_for_test(20, 8) == 8);
+
+    assert(ui_prompt_fit_height_for_test(8, 24) == 8);
+    assert(ui_prompt_fit_height_for_test(12, 8) == 6);
+    assert(ui_prompt_fit_height_for_test(2, 10) == 6);
+    assert(ui_prompt_fit_height_for_test(2, 5) == 3);
+    assert(ui_prompt_fit_height_for_test(8, 2) == 0);
+
+    int title_y = -2;
+    int input_y = -2;
+    int footer_y = -2;
+    ui_prompt_rows_for_test(6, NULL, &input_y, &footer_y);
+    assert(input_y == -2);
+    assert(footer_y == -2);
+
+    ui_prompt_rows_for_test(6, &title_y, &input_y, &footer_y);
+    assert(title_y == 1);
+    assert(input_y == 3);
+    assert(footer_y == 4);
+    ui_prompt_rows_for_test(5, &title_y, &input_y, &footer_y);
+    assert(title_y == 1);
+    assert(input_y == 2);
+    assert(footer_y == 3);
+    ui_prompt_rows_for_test(4, &title_y, &input_y, &footer_y);
+    assert(title_y == 1);
+    assert(input_y == 2);
+    assert(footer_y == -1);
+    ui_prompt_rows_for_test(3, &title_y, &input_y, &footer_y);
+    assert(title_y == -1);
+    assert(input_y == 1);
+    assert(footer_y == -1);
+
+    int field_col = -1;
+    int field_right = -1;
+    int field_width = -1;
+    ui_prompt_field_geometry_for_test(12, &field_col, NULL, &field_width);
+    assert(field_col == -1);
+    assert(field_width == -1);
+
+    ui_prompt_field_geometry_for_test(12, &field_col, &field_right, &field_width);
+    assert(field_col == 4);
+    assert(field_right == 10);
+    assert(field_width == 6);
+    ui_prompt_field_geometry_for_test(4, &field_col, &field_right, &field_width);
+    assert(field_col == 2);
+    assert(field_right == 2);
+    assert(field_width == 1);
+    ui_prompt_field_geometry_for_test(2, &field_col, &field_right, &field_width);
+    assert(field_col == 2);
+    assert(field_right == 0);
+    assert(field_width == 1);
+
+    UiPromptViewTestSnapshot view = ui_prompt_view_for_test("abc", 99, 4, 12, 8);
+    assert(view.start == 0);
+    assert(view.cursor == 3);
+    assert(view.show_left_ellipsis == 0);
+    assert(view.cursor_x == 7);
+
+    view = ui_prompt_view_for_test("abcdefghij", 10, 4, 12, 8);
+    assert(view.start == 6);
+    assert(view.cursor == 10);
+    assert(view.show_left_ellipsis == 1);
+    assert(view.cursor_x == 11);
+
+    view = ui_prompt_view_for_test("abcdefghij", 2, 4, 12, 8);
+    assert(view.start == 0);
+    assert(view.cursor == 2);
+    assert(view.show_left_ellipsis == 0);
+    assert(view.cursor_x == 6);
+
+    view = ui_prompt_view_for_test("abcdefghij", 9, 4, 12, 3);
+    assert(view.start == 7);
+    assert(view.cursor == 9);
+    assert(view.show_left_ellipsis == 0);
+    assert(view.cursor_x == 6);
+
+    view = ui_prompt_view_for_test(NULL, 99, -5, 0, 8);
+    assert(view.start == 0);
+    assert(view.cursor == 0);
+    assert(view.show_left_ellipsis == 0);
+    assert(view.cursor_x == 2);
+}
+
+int
+main(void) {
+    test_string_prompt_completion_paths();
+    test_string_prompt_key_edges();
+    test_string_prompt_cursor_editing();
+    test_typed_prompt_validation();
+    test_typed_prompt_cancel_paths();
+    test_chooser_edge_paths();
+    test_chooser_page_navigation_clamps_selection();
+    test_chooser_up_down_wraparound();
+    test_help_activation_and_close_keys();
+    test_help_scroll_navigation_clamps_to_content();
+    test_help_wrap_text_contracts();
+    test_chooser_layout_contracts();
+    test_prompt_layout_and_view_contracts();
+    printf("UI_PROMPT_VALIDATION: OK\n");
+    return 0;
+}

--- a/tests/ui/test_ui_snr_meter.c
+++ b/tests/ui/test_ui_snr_meter.c
@@ -4,10 +4,14 @@
  */
 
 #include <assert.h>
+#include <curses.h>
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/ui/ncurses_snr.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 
 int ui_unicode_supported(void);      // NOLINT(misc-use-internal-linkage)
@@ -21,6 +25,23 @@ int ui_block_glyphs_supported(void); // NOLINT(misc-use-internal-linkage)
 #define DSD_NEO_TEST_FAST_MATH 0
 #endif
 
+struct render_capture {
+    char out[128];
+    size_t len;
+    int attr_get_calls;
+    int attr_set_calls;
+    int attron_count;
+    int attroff_count;
+    unsigned long attron_values[64];
+    unsigned long attroff_values[64];
+    unsigned long saved_attrs;
+    short saved_pair;
+    unsigned long last_attr_set_attrs;
+    short last_attr_set_pair;
+};
+
+static struct render_capture g_capture;
+
 int
 ui_unicode_supported(void) { // NOLINT(misc-use-internal-linkage)
     return 0;
@@ -29,6 +50,89 @@ ui_unicode_supported(void) { // NOLINT(misc-use-internal-linkage)
 int
 ui_block_glyphs_supported(void) { // NOLINT(misc-use-internal-linkage)
     return 0;
+}
+
+static void
+capture_reset(struct render_capture* cap) {
+    DSD_MEMSET(cap, 0, sizeof(*cap));
+    cap->saved_attrs = 0x1234UL;
+    cap->saved_pair = 5;
+}
+
+static int
+capture_ch(unsigned long ch) {
+    struct render_capture* cap = &g_capture;
+    if (cap->len + 1 < sizeof(cap->out)) {
+        cap->out[cap->len++] = (char)(ch & A_CHARTEXT);
+        cap->out[cap->len] = '\0';
+    }
+    return 0;
+}
+
+static int
+capture_str(const char* text) {
+    struct render_capture* cap = &g_capture;
+    if (!text) {
+        return 0;
+    }
+    while (*text && cap->len + 1 < sizeof(cap->out)) {
+        cap->out[cap->len++] = *text++;
+    }
+    cap->out[cap->len] = '\0';
+    return 0;
+}
+
+static int
+capture_attron(unsigned long attrs) {
+    struct render_capture* cap = &g_capture;
+    if (cap->attron_count < (int)(sizeof(cap->attron_values) / sizeof(cap->attron_values[0]))) {
+        cap->attron_values[cap->attron_count] = attrs;
+    }
+    cap->attron_count++;
+    return 0;
+}
+
+static int
+capture_attroff(unsigned long attrs) {
+    struct render_capture* cap = &g_capture;
+    if (cap->attroff_count < (int)(sizeof(cap->attroff_values) / sizeof(cap->attroff_values[0]))) {
+        cap->attroff_values[cap->attroff_count] = attrs;
+    }
+    cap->attroff_count++;
+    return 0;
+}
+
+static int
+capture_attr_get(unsigned long* attrs, short* pair) {
+    struct render_capture* cap = &g_capture;
+    cap->attr_get_calls++;
+    if (attrs) {
+        *attrs = cap->saved_attrs;
+    }
+    if (pair) {
+        *pair = cap->saved_pair;
+    }
+    return 0;
+}
+
+static int
+capture_attr_set(unsigned long attrs, short pair) {
+    struct render_capture* cap = &g_capture;
+    cap->attr_set_calls++;
+    cap->last_attr_set_attrs = attrs;
+    cap->last_attr_set_pair = pair;
+    return 0;
+}
+
+static void
+install_capture(void) {
+    dsd_ncurses_snr_set_emit_hooks_for_test(capture_ch, capture_str, capture_attron, capture_attroff, capture_attr_get,
+                                            capture_attr_set);
+}
+
+static void
+clear_capture_hooks(void) {
+    dsd_ncurses_snr_set_emit_hooks_for_test(NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
 static void
@@ -50,6 +154,138 @@ assert_ascii(double snr_db, const char* expected) {
     }
     assert(strcmp(actual, expected) == 0);
     assert(actual[9] == '\0');
+}
+
+static void
+assert_double_eq(double actual, double expected) {
+    if (fabs(actual - expected) > 0.000001) {
+        DSD_FPRINTF(stderr, "double mismatch: expected %.6f, got %.6f\n", expected, actual);
+    }
+    assert(fabs(actual - expected) <= 0.000001);
+}
+
+static void
+test_snr_history_routes_clamps_and_wraps(void) {
+    dsd_ncurses_snr_hist_reset_for_test();
+    assert(dsd_ncurses_snr_hist_len_for_test(0) == 0);
+    assert(dsd_ncurses_snr_hist_head_for_test(0) == 0);
+    assert(dsd_ncurses_snr_hist_len_for_test(1) == 0);
+    assert(dsd_ncurses_snr_hist_len_for_test(2) == 0);
+
+    snr_hist_push(0, -51.0);
+    assert(dsd_ncurses_snr_hist_len_for_test(0) == 0);
+
+    snr_hist_push(0, -50.0);
+    assert(dsd_ncurses_snr_hist_len_for_test(0) == 1);
+    assert(dsd_ncurses_snr_hist_head_for_test(0) == 1);
+    assert_double_eq(dsd_ncurses_snr_hist_value_for_test(0, 0), -50.0);
+
+    snr_hist_push(1, 61.0);
+    assert(dsd_ncurses_snr_hist_len_for_test(1) == 1);
+    assert(dsd_ncurses_snr_hist_head_for_test(1) == 1);
+    assert_double_eq(dsd_ncurses_snr_hist_value_for_test(1, 0), 60.0);
+
+    snr_hist_push(2, 7.0);
+    snr_hist_push(99, 8.0);
+    assert(dsd_ncurses_snr_hist_len_for_test(2) == 2);
+    assert(dsd_ncurses_snr_hist_len_for_test(99) == 2);
+    assert(dsd_ncurses_snr_hist_head_for_test(2) == 2);
+    assert_double_eq(dsd_ncurses_snr_hist_value_for_test(2, 0), 7.0);
+    assert_double_eq(dsd_ncurses_snr_hist_value_for_test(2, 1), 8.0);
+
+    dsd_ncurses_snr_hist_reset_for_test();
+    for (int i = 0; i < 51; i++) {
+        snr_hist_push(0, (double)i);
+    }
+    assert(dsd_ncurses_snr_hist_len_for_test(0) == 48);
+    assert(dsd_ncurses_snr_hist_head_for_test(0) == 3);
+    assert_double_eq(dsd_ncurses_snr_hist_value_for_test(0, 3), 3.0);
+    assert_double_eq(dsd_ncurses_snr_hist_value_for_test(0, 2), 50.0);
+}
+
+static void
+test_snr_sparkline_window_helpers(void) {
+    assert(dsd_ncurses_snr_hist_render_count_for_test(0, 24) == 0);
+    assert(dsd_ncurses_snr_hist_render_count_for_test(7, 24) == 7);
+    assert(dsd_ncurses_snr_hist_render_count_for_test(48, 24) == 24);
+
+    assert(dsd_ncurses_snr_hist_render_start_for_test(3, 48, 48) == 3);
+    assert(dsd_ncurses_snr_hist_render_start_for_test(3, 48, 24) == 27);
+    assert(dsd_ncurses_snr_hist_render_start_for_test(10, 5, 3) == 7);
+
+    assert(dsd_ncurses_snr_level_index_for_test(-20.0, -15.0, 45.0, 8) == 0);
+    assert(dsd_ncurses_snr_level_index_for_test(30.0, -15.0, 45.0, 8) == 7);
+    assert(dsd_ncurses_snr_level_index_for_test(100.0, -15.0, 45.0, 8) == 7);
+    assert(dsd_ncurses_snr_level_index_for_test(0.0, -15.0, 45.0, 8) == 2);
+}
+
+static void
+test_snr_public_meter_rendering_ascii_and_color_restore(void) {
+    struct render_capture* cap = &g_capture;
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+
+    capture_reset(cap);
+    install_capture();
+    print_snr_meter(&opts, 12.0, 0);
+    assert(strcmp(cap->out, "| | | |  ") == 0);
+    assert(cap->attr_get_calls == 1);
+    assert(cap->attron_count == 4);
+    assert(cap->attroff_count == 4);
+    for (int i = 0; i < cap->attron_count; i++) {
+        assert(cap->attron_values[i] == (unsigned long)COLOR_PAIR(6));
+        assert(cap->attroff_values[i] == (unsigned long)COLOR_PAIR(6));
+    }
+    assert(cap->attr_set_calls == 5);
+    assert(cap->last_attr_set_attrs == cap->saved_attrs);
+    assert(cap->last_attr_set_pair == cap->saved_pair);
+    clear_capture_hooks();
+}
+
+static void
+test_snr_public_sparkline_rendering_ascii_and_quality_colors(void) {
+    struct render_capture* cap = &g_capture;
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+
+    dsd_ncurses_snr_hist_reset_for_test();
+    print_snr_sparkline(&opts, 0);
+
+    capture_reset(cap);
+    install_capture();
+    snr_hist_push(0, -15.0);
+    snr_hist_push(0, 4.0);
+    snr_hist_push(0, 10.0);
+    snr_hist_push(0, 30.0);
+    print_snr_sparkline(&opts, 0);
+    assert(strcmp(cap->out, ".-=#") == 0);
+    assert(cap->attr_get_calls == 1);
+    assert(cap->attron_count == 4);
+    assert(cap->attroff_count == 4);
+    assert(cap->attron_values[0] == (unsigned long)COLOR_PAIR(13));
+    assert(cap->attron_values[1] == (unsigned long)COLOR_PAIR(12));
+    assert(cap->attron_values[2] == (unsigned long)COLOR_PAIR(11));
+    assert(cap->attron_values[3] == (unsigned long)COLOR_PAIR(11));
+    for (int i = 0; i < cap->attron_count; i++) {
+        assert(cap->attroff_values[i] == cap->attron_values[i]);
+    }
+    assert(cap->attr_set_calls == 1);
+    assert(cap->last_attr_set_attrs == cap->saved_attrs);
+    assert(cap->last_attr_set_pair == cap->saved_pair);
+
+    capture_reset(cap);
+    install_capture();
+    dsd_ncurses_snr_hist_reset_for_test();
+    snr_hist_push(1, 9.0);
+    snr_hist_push(1, 10.0);
+    snr_hist_push(1, 16.0);
+    print_snr_sparkline(&opts, 1);
+    assert(strcmp(cap->out, "==+") == 0);
+    assert(cap->attron_count == 3);
+    assert(cap->attron_values[0] == (unsigned long)COLOR_PAIR(13));
+    assert(cap->attron_values[1] == (unsigned long)COLOR_PAIR(12));
+    assert(cap->attron_values[2] == (unsigned long)COLOR_PAIR(11));
+    clear_capture_hooks();
 }
 
 int
@@ -93,6 +329,11 @@ main(void) {
         assert(strcmp(tiny, "| ") == 0);
         assert(tiny[2] == '\0');
     }
+
+    test_snr_history_routes_clamps_and_wraps();
+    test_snr_sparkline_window_helpers();
+    test_snr_public_meter_rendering_ascii_and_color_restore();
+    test_snr_public_sparkline_rendering_ascii_and_quality_colors();
 
     printf("UI_SNR_METER: OK\n");
     return 0;

--- a/tests/ui/test_ui_snr_readout.c
+++ b/tests/ui/test_ui_snr_readout.c
@@ -93,6 +93,19 @@ expect_readout(const char* name, int rf_mod, double expected_snr, const char* ex
 }
 
 static void
+expect_invalid_readout(const char* name, int rf_mod, double expected_snr, const char* expected_label) {
+    ui_snr_readout got = ui_snr_readout_for_mod(rf_mod);
+    const char* actual_label = got.mod_label ? got.mod_label : "";
+    if (got.valid || fabs(got.snr_db - expected_snr) > 1e-6 || strcmp(actual_label, expected_label) != 0) {
+        (void)DSD_FPRINTF(stderr, "%s: valid=%d snr=%.6f label=%s\n", name, got.valid, got.snr_db,
+                          actual_label[0] ? actual_label : "(null)");
+    }
+    assert(got.valid == 0);
+    assert(fabs(got.snr_db - expected_snr) <= 1e-6);
+    assert(strcmp(actual_label, expected_label) == 0);
+}
+
+static void
 test_c4fm_uses_direct_snr(void) {
     reset_fakes();
     g_snr_c4fm = 18.25;
@@ -154,6 +167,50 @@ test_qpsk_uses_cqpsk_snr(void) {
 
     expect_readout("qpsk", 1, 12.75, "QPSK");
     assert(g_snr_cqpsk_calls == 1);
+    assert(g_snr_qpsk_const_calls == 0);
+}
+
+static void
+test_qpsk_uses_constellation_fallback(void) {
+    reset_fakes();
+    g_snr_cqpsk = -100.0;
+    g_snr_qpsk_const = 9.5;
+
+    expect_readout("qpsk-constellation-fallback", 1, 9.5, "QPSK");
+    assert(g_snr_cqpsk_calls == 1);
+    assert(g_snr_qpsk_const_calls == 1);
+    assert(g_snr_c4fm_calls == 0);
+    assert(g_snr_gfsk_calls == 0);
+}
+
+static void
+test_qpsk_uses_best_legacy_snr_when_constellation_invalid(void) {
+    reset_fakes();
+    g_snr_cqpsk = -100.0;
+    g_snr_qpsk_const = -100.0;
+    g_snr_c4fm = 4.25;
+    g_snr_gfsk = 6.75;
+
+    expect_readout("qpsk-legacy-best-fallback", 1, 6.75, "QPSK");
+    assert(g_snr_cqpsk_calls == 1);
+    assert(g_snr_qpsk_const_calls == 1);
+    assert(g_snr_c4fm_calls == 1);
+    assert(g_snr_gfsk_calls == 1);
+}
+
+static void
+test_qpsk_reports_invalid_when_all_estimates_stale(void) {
+    reset_fakes();
+    g_snr_cqpsk = -100.0;
+    g_snr_qpsk_const = -50.0;
+    g_snr_c4fm = -50.0;
+    g_snr_gfsk = -100.0;
+
+    expect_invalid_readout("qpsk-all-invalid", 1, -100.0, "QPSK");
+    assert(g_snr_cqpsk_calls == 1);
+    assert(g_snr_qpsk_const_calls == 1);
+    assert(g_snr_c4fm_calls == 1);
+    assert(g_snr_gfsk_calls == 1);
 }
 
 int
@@ -164,6 +221,9 @@ main(void) {
     test_gfsk_falls_back_when_direct_snr_invalid();
     test_c4fm_snr_at_invalid_threshold_falls_back();
     test_qpsk_uses_cqpsk_snr();
+    test_qpsk_uses_constellation_fallback();
+    test_qpsk_uses_best_legacy_snr_when_constellation_invalid();
+    test_qpsk_reports_invalid_when_all_estimates_stale();
     printf("UI_SNR_READOUT: OK\n");
     return 0;
 }

--- a/tests/ui/test_ui_telemetry_hooks_install.c
+++ b/tests/ui/test_ui_telemetry_hooks_install.c
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Focused checks for terminal telemetry hook installation.
+ */
+
+#include <assert.h>
+#include <dsd-neo/runtime/telemetry.h>
+#include <stddef.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "telemetry_hooks_impl.h"
+
+static dsd_telemetry_hooks g_hooks;
+static int g_snapshot_calls;
+static int g_opts_snapshot_calls;
+static int g_redraw_calls;
+
+void
+dsd_telemetry_hooks_set(dsd_telemetry_hooks hooks) { // NOLINT(misc-use-internal-linkage)
+    g_hooks = hooks;
+}
+
+void
+ui_terminal_telemetry_publish_snapshot(const dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    g_snapshot_calls++;
+}
+
+void
+ui_terminal_telemetry_publish_opts_snapshot(const dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    g_opts_snapshot_calls++;
+}
+
+void
+ui_terminal_telemetry_request_redraw(void) { // NOLINT(misc-use-internal-linkage)
+    g_redraw_calls++;
+}
+
+int
+main(void) {
+    ui_terminal_install_telemetry_hooks();
+
+    assert(g_hooks.publish_snapshot == ui_terminal_telemetry_publish_snapshot);
+    assert(g_hooks.publish_opts_snapshot == ui_terminal_telemetry_publish_opts_snapshot);
+    assert(g_hooks.request_redraw == ui_terminal_telemetry_request_redraw);
+
+    g_hooks.publish_snapshot(NULL);
+    g_hooks.publish_opts_snapshot(NULL);
+    g_hooks.request_redraw();
+
+    assert(g_snapshot_calls == 1);
+    assert(g_opts_snapshot_calls == 1);
+    assert(g_redraw_calls == 1);
+    return 0;
+}

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -10,7 +10,8 @@ BUILD_DIR="$ROOT_DIR/build/coverage-debug"
 BUILD_PRESET=${BUILD_PRESET:-coverage-debug-clean}
 TEST_PRESET=${TEST_PRESET:-coverage-debug}
 COVERAGE_SCOPE=${COVERAGE_SCOPE:-src}
-LCOV_IGNORE_ERRORS=(--ignore-errors "negative,inconsistent,unused")
+LCOV_BRANCH_ARGS=(--branch-coverage)
+LCOV_IGNORE_ERRORS=(--ignore-errors "negative,inconsistent,unused,mismatch")
 GENHTML_IGNORE_ERRORS=(--ignore-errors inconsistent)
 THIRD_PARTY_EXCLUDES=("${ROOT_DIR}/src/third_party/*")
 
@@ -30,14 +31,15 @@ pushd "$BUILD_DIR" > /dev/null
 # GCC/lcov can emit malformed negative or inconsistent counters for some
 # optimized/generated paths even when CTest passes. Keep the report generation
 # tolerant of those counters while still surfacing lcov warnings on stderr.
-lcov --capture --directory . --output-file coverage.info "${LCOV_IGNORE_ERRORS[@]}" > /dev/null
+lcov "${LCOV_BRANCH_ARGS[@]}" --capture --directory . --output-file coverage.info "${LCOV_IGNORE_ERRORS[@]}" > /dev/null
 
 case "$COVERAGE_SCOPE" in
   src | project)
     REPORT_NAME="coverage.src.info"
     REPORT_DIR="coverage_html"
     REPORT_LABEL="project src/ excluding src/third_party"
-    lcov --extract coverage.info "${ROOT_DIR}/src/*" -o "$REPORT_NAME" "${LCOV_IGNORE_ERRORS[@]}" > /dev/null
+    lcov "${LCOV_BRANCH_ARGS[@]}" --extract coverage.info "${ROOT_DIR}/src/*" -o "$REPORT_NAME" \
+      "${LCOV_IGNORE_ERRORS[@]}" > /dev/null
     ;;
   protocol)
     REPORT_NAME="coverage.protocol.info"
@@ -49,7 +51,8 @@ case "$COVERAGE_SCOPE" in
       EXTRACT_ARGS+=("${ROOT_DIR}/src/protocol/${proto}/*")
     done
     EXTRACT_ARGS+=("${ROOT_DIR}/src/fec/*")
-    lcov --extract coverage.info "${EXTRACT_ARGS[@]}" -o "$REPORT_NAME" "${LCOV_IGNORE_ERRORS[@]}" > /dev/null
+    lcov "${LCOV_BRANCH_ARGS[@]}" --extract coverage.info "${EXTRACT_ARGS[@]}" -o "$REPORT_NAME" \
+      "${LCOV_IGNORE_ERRORS[@]}" > /dev/null
     ;;
   *)
     echo "Unknown COVERAGE_SCOPE: $COVERAGE_SCOPE" >&2
@@ -59,13 +62,15 @@ case "$COVERAGE_SCOPE" in
 esac
 
 FILTERED_REPORT="${REPORT_NAME%.info}.filtered.info"
-lcov --remove "$REPORT_NAME" "${THIRD_PARTY_EXCLUDES[@]}" -o "$FILTERED_REPORT" "${LCOV_IGNORE_ERRORS[@]}" > /dev/null
+lcov "${LCOV_BRANCH_ARGS[@]}" --remove "$REPORT_NAME" "${THIRD_PARTY_EXCLUDES[@]}" -o "$FILTERED_REPORT" \
+  "${LCOV_IGNORE_ERRORS[@]}" > /dev/null
 mv "$FILTERED_REPORT" "$REPORT_NAME"
 
 rm -rf -- "$REPORT_DIR"
-genhtml "$REPORT_NAME" --output-directory "$REPORT_DIR" "${GENHTML_IGNORE_ERRORS[@]}" > /dev/null
+genhtml "${LCOV_BRANCH_ARGS[@]}" "$REPORT_NAME" --output-directory "$REPORT_DIR" "${GENHTML_IGNORE_ERRORS[@]}" \
+  > /dev/null
 printf 'Coverage summary (%s)\n' "$REPORT_LABEL"
-lcov --summary "$REPORT_NAME"
+lcov "${LCOV_BRANCH_ARGS[@]}" --summary "$REPORT_NAME" "${LCOV_IGNORE_ERRORS[@]}"
 popd > /dev/null
 
 echo "Coverage HTML: $BUILD_DIR/$REPORT_DIR/index.html"


### PR DESCRIPTION
## Summary

- Adds focused RTL/radio test hooks for parser, source-policy, mode-policy, and FSK profile decisions, with assertions in `IO_RTL_DEMOD_CONFIG` and additional manual-gain retune failure coverage.
- Adds deterministic `UI_CMD_QUEUE` coverage for UI command queue state transitions, bounded overflow, key/runtime setters, file/network/import commands, and legacy toggles.
- Extends M17 state-dispatch guard coverage and frame-sync RTL symbol profile assertions.

## Validation

- `tools/preflight_ci.sh`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure` (476/476 passed)
- `tools/coverage.sh` (476/476 passed)
- `git diff --check`

Coverage summary for project `src/` excluding `src/third_party`:

- Lines: 77.1% (65099 / 84446)
- Functions: 88.4% (6507 / 7359)
- Branches: 58.2% (33305 / 57196)

Existing lcov warnings remain during coverage report generation for the platform atomic test negative count, duplicate function metadata in `src/core/frames/dsd_dibit.c`, allocator exception tag mismatch, and inconsistent branch data at `src/io/radio/rtl_sdr_fm.cpp:657` and `src/io/radio/soapy_profile.cpp:444`.