### PR TITLE
security: resolve code scanning alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,6 +3,19 @@ name: "DSD-neo CodeQL config"
 queries:
   - uses: security-and-quality
 
+# Keep quality coverage enabled, but do not publish repo-specific noise as
+# security alerts. These rules are covered by local review/CI practices or are
+# known false positives for this test-heavy C/C++ codebase.
+query-filters:
+  - exclude:
+      id: cpp/poorly-documented-function
+  - exclude:
+      id: cpp/unused-static-function
+  - exclude:
+      id: cpp/include-non-header
+  - exclude:
+      id: cpp/useless-expression
+
 # Keep vendored upstream libraries out of project-owned CodeQL results.
 paths-ignore:
   - "src/third_party/**"

--- a/.github/requirements/semgrep.txt
+++ b/.github/requirements/semgrep.txt
@@ -604,9 +604,9 @@ pydantic-core==2.46.4 \
     --hash=sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff \
     --hash=sha256:fd8b3d9fd264be37976686c7f65cd52a83f5e84f4bfd2adf9c1d469676bbb6ae
     # via pydantic
-pydantic-settings==2.14.1 \
-    --hash=sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de \
-    --hash=sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa
+pydantic-settings==2.14.2 \
+    --hash=sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440 \
+    --hash=sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f
     # via mcp
 pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \

--- a/src/ui/terminal/menu_actions.c
+++ b/src/ui/terminal/menu_actions.c
@@ -457,6 +457,7 @@ act_p2_params(void* v) {
     if (!pc) {
         return;
     }
+    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     pc->c = c;
     pc->step = 0;
     pc->w = pc->s = pc->n = 0ULL;
@@ -573,6 +574,7 @@ act_env_editor(void* v) {
     if (!ec) {
         return;
     }
+    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     ec->c = (UiCtx*)v;
     ui_prompt_open_string_async("Enter DSD_NEO_* variable name", "DSD_NEO_", 128, cb_env_edit_name, ec);
 }
@@ -630,6 +632,7 @@ act_prompt_p25_num(void* v, const char* env_name, const char* title, double defv
     if (!pc) {
         return;
     }
+    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     pc->c = c;
     pc->name = env_name;
     ui_prompt_open_double_async(title, defv, cb_set_p25_num, pc);
@@ -863,6 +866,7 @@ io_set_pulse_device_common(void* vctx, int is_input, const char* chooser_title, 
         ui_statusf("Out of memory");
         return;
     }
+    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives chooser completion.
     pctx->c = c;
     pctx->labels = labels;
     pctx->names = names;
@@ -888,6 +892,7 @@ io_set_udp_out(void* vctx) {
     if (!u) {
         return;
     }
+    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     u->c = c;
     const char* src = c->opts->udp_hostname[0] ? c->opts->udp_hostname : "127.0.0.1";
     DSD_SNPRINTF(u->host, sizeof u->host, "%.*s", (int)sizeof(u->host) - 1, src);
@@ -901,6 +906,7 @@ io_tcp_direct_link(void* vctx) {
     if (!u) {
         return;
     }
+    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     u->c = c;
     const char* defh = c->opts->tcp_hostname[0] ? c->opts->tcp_hostname : "localhost";
     DSD_SNPRINTF(u->host, sizeof u->host, "%.*s", (int)sizeof(u->host) - 1, defh);
@@ -975,6 +981,7 @@ io_rigctl_config(void* vctx) {
     if (!u) {
         return;
     }
+    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     u->c = c;
     const char* defh = c->opts->rigctlhostname[0] ? c->opts->rigctlhostname : "localhost";
     DSD_SNPRINTF(u->host, sizeof u->host, "%.*s", (int)sizeof(u->host) - 1, defh);
@@ -1040,6 +1047,7 @@ switch_to_udp(void* vctx) {
     if (!u) {
         return;
     }
+    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     u->c = c;
     const char* defa = c->opts->udp_in_bindaddr[0] ? c->opts->udp_in_bindaddr : "127.0.0.1";
     DSD_SNPRINTF(u->addr, sizeof u->addr, "%.*s", (int)sizeof(u->addr) - 1, defa);
@@ -1080,6 +1088,7 @@ key_hytera(void* v) {
     if (!hc) {
         return;
     }
+    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     hc->c = c;
     hc->step = 0;
     ui_prompt_open_string_async("Hytera Privacy Key 1 (HEX)", NULL, 128, cb_hytera_step, hc);
@@ -1110,6 +1119,7 @@ key_aes(void* v) {
     if (!ac) {
         return;
     }
+    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     ac->c = c;
     ac->step = 0;
     ui_prompt_open_string_async("AES Segment 1 (HEX) or 0", NULL, 128, cb_aes_step, ac);
@@ -1154,6 +1164,7 @@ act_m17_user_data(void* v) {
     if (!mc) {
         return;
     }
+    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     mc->c = c;
     ui_prompt_open_string_async("Enter M17 User Data (CAN,DST,SRC)", pre, 128, cb_m17_user_data, mc);
 }

--- a/src/ui/terminal/menu_prompts.c
+++ b/src/ui/terminal/menu_prompts.c
@@ -271,6 +271,7 @@ ui_prompt_open_string_async_impl(const char* title, const char* prefill, size_t 
     g_prompt.active = 1;
     g_prompt.title = title;
     g_prompt.on_done_str = on_done;
+    // codeql[cpp/stack-address-escape] Prompt callers must keep user context alive until completion/cancel.
     g_prompt.user = user;
     if (cap < 2) {
         cap = 2;
@@ -363,6 +364,7 @@ ui_prompt_open_int_async_impl(const char* title, int initial, void* user, ui_pro
         return;
     }
     pic->cb = cb;
+    // codeql[cpp/stack-address-escape] Typed prompt wrappers preserve the caller's prompt context.
     pic->user = user;
     ui_prompt_open_string_async(title, pre, 64, ui_prompt_int_finish, pic);
 }
@@ -380,6 +382,7 @@ ui_prompt_open_double_async_impl(const char* title, double initial, void* user, 
         return;
     }
     pdc->cb = cb;
+    // codeql[cpp/stack-address-escape] Typed prompt wrappers preserve the caller's prompt context.
     pdc->user = user;
     ui_prompt_open_string_async(title, pre, 64, ui_prompt_double_finish, pdc);
 }
@@ -1054,6 +1057,7 @@ ui_chooser_start_impl(const char* title, const char* const* items, int count, vo
     g_chooser.top = 0;
     g_chooser.page_rows = 0;
     g_chooser.on_done = on_done;
+    // codeql[cpp/stack-address-escape] Chooser callers must keep user context alive until completion/cancel.
     g_chooser.user = user;
     if (g_chooser.win) {
         delwin(g_chooser.win);

--- a/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
+++ b/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
@@ -346,7 +346,7 @@ build_udt_header(uint8_t dheader[12], uint8_t bits[196], uint8_t udt_format, uin
 static void
 build_udt_iso7_block(uint8_t block[12], const char* text) {
     DSD_MEMSET(block, 0, 12);
-    for (size_t i = 0; text[i] != '\0' && i < 11U; i++) {
+    for (size_t i = 0; i < 11U && text[i] != '\0'; i++) {
         set_byte_bits(block, i * 7U, (uint8_t)text[i] & 0x7FU, 7U);
     }
     append_type2_crc16(block, 12);
@@ -355,7 +355,7 @@ build_udt_iso7_block(uint8_t block[12], const char* text) {
 static void
 build_udt_iso8_block(uint8_t block[12], const char* text) {
     DSD_MEMSET(block, 0, 12);
-    for (size_t i = 0; text[i] != '\0' && i < 10U; i++) {
+    for (size_t i = 0; i < 10U && text[i] != '\0'; i++) {
         set_byte_bits(block, i * 8U, (uint8_t)text[i], 8U);
     }
     append_type2_crc16(block, 12);

--- a/tests/protocol/dmr/test_dmr_t3_sm_return_to_cc_matrix.c
+++ b/tests/protocol/dmr/test_dmr_t3_sm_return_to_cc_matrix.c
@@ -722,8 +722,9 @@ dmr_run_data_sync_and_stale_slot_case(void) {
     dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
     rc |= dmr_expect(g_ctx.slots[0].last_active_m > 0.0 && g_ctx.slots[1].last_active_m == 0.0, grant.name, flow,
                      script, "invalid data slot normalized to slot zero");
-    rc |= dmr_expect(g_ctx.t_voice_m > 0.0 && g_state.last_vc_sync_time_m == g_ctx.t_voice_m, grant.name, flow, script,
-                     "data sync arms hangtime timestamp");
+    rc |= dmr_expect(g_ctx.t_voice_m > 0.0, grant.name, flow, script, "data sync arms hangtime timestamp");
+    rc |= dmr_expect_close(g_state.last_vc_sync_time_m, g_ctx.t_voice_m, 1.0e-9, grant.name, flow, script,
+                           "data sync records matching voice sync time");
 
     double stale_m = dsd_time_now_monotonic_s() - 1.0;
     g_ctx.t_tune_m = 0.0;
@@ -737,7 +738,8 @@ dmr_run_data_sync_and_stale_slot_case(void) {
     double before = g_ctx.t_voice_m;
     ev = dmr_sm_ev_data_sync(0);
     dmr_sm_event(&g_ctx, NULL, &g_state, &ev);
-    rc |= dmr_expect(g_ctx.t_voice_m == before, grant.name, flow, script, "data sync without opts is ignored");
+    rc |= dmr_expect_close(g_ctx.t_voice_m, before, 1.0e-9, grant.name, flow, script,
+                           "data sync without opts is ignored");
     return rc;
 }
 

--- a/tests/protocol/edacs/test_edacs_grant_tune_matrix.c
+++ b/tests/protocol/edacs/test_edacs_grant_tune_matrix.c
@@ -1143,7 +1143,8 @@ edacs_run_analog_loop_helper_cases(void) {
     static short analog2[960];
     static short analog3[960];
     double pwr = -1.0;
-    int tcp_ctx_token = 0xEAA5;
+    static int tcp_ctx_token;
+    tcp_ctx_token = 0xEAA5;
 
     edacs_reset_audio_hook_state();
     DSD_MEMSET(&opts, 0, sizeof(opts));

--- a/tests/protocol/x2tdma/test_x2tdma_data.c
+++ b/tests/protocol/x2tdma/test_x2tdma_data.c
@@ -75,7 +75,7 @@ static void
 test_data_sync_marks_slot_and_maps_bursttype(void) {
     static dsd_opts opts;
     static dsd_state state;
-    int dibits[90];
+    static int dibits[90];
 
     reset_fixture(&opts, &state, dibits);
     opts.errorbars = 0;
@@ -95,7 +95,7 @@ static void
 test_inverted_mobile_data_marks_slot_one(void) {
     static dsd_opts opts;
     static dsd_state state;
-    int dibits[90];
+    static int dibits[90];
 
     reset_fixture(&opts, &state, dibits);
     opts.inverted_x2tdma = 1;
@@ -115,7 +115,7 @@ static void
 test_unknown_burst_without_data_sync_uses_blank_subtype(void) {
     static dsd_opts opts;
     static dsd_state state;
-    int dibits[90];
+    static int dibits[90];
 
     reset_fixture(&opts, &state, dibits);
     set_slot_from_cach(dibits, 0, opts.inverted_x2tdma);

--- a/tests/runtime/test_runtime_log.cpp
+++ b/tests/runtime/test_runtime_log.cpp
@@ -54,8 +54,8 @@ capture_stderr_end(capture_stderr* capture, char* out, size_t out_size) {
         return;
     }
     int restore_rc = dsd_dup2(capture->saved_fd, dsd_fileno(stderr));
-    assert(restore_rc >= 0);
     if (restore_rc < 0) {
+        assert(restore_rc >= 0);
         fclose(capture->file);
         capture->file = nullptr;
         return;

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/init.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/ui/ui_async.h>
 #include <dsd-neo/ui/ui_cmd.h>
 #include <stdint.h>
@@ -68,7 +69,7 @@ expect_contains(const char* tag, const char* haystack, const char* needle) {
 
 static int
 write_file_bytes(const char* path, const void* data, size_t n) {
-    FILE* f = fopen(path, "wb");
+    FILE* f = dsd_fopen_private(path, "wb");
     if (!f) {
         DSD_FPRINTF(stderr, "failed to create %s\n", path);
         return 1;

--- a/tests/ui/test_ui_menu_callbacks.c
+++ b/tests/ui/test_ui_menu_callbacks.c
@@ -376,7 +376,8 @@ test_path_and_file_callbacks(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof opts);
     DSD_MEMSET(&state, 0, sizeof state);
-    UiCtx ctx = make_ctx(&opts, &state);
+    static UiCtx ctx;
+    ctx = make_ctx(&opts, &state);
 
     reset_capture();
     cb_event_log_set(&ctx, "");
@@ -444,7 +445,8 @@ test_config_callbacks_apply_and_report_failures(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof opts);
     DSD_MEMSET(&state, 0, sizeof state);
-    UiCtx ctx = make_ctx(&opts, &state);
+    static UiCtx ctx;
+    ctx = make_ctx(&opts, &state);
 
     reset_capture();
     cb_config_load(&ctx, "");
@@ -511,7 +513,8 @@ test_typed_callbacks_clamp_and_cancel(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof opts);
     DSD_MEMSET(&state, 0, sizeof state);
-    UiCtx ctx = make_ctx(&opts, &state);
+    static UiCtx ctx;
+    ctx = make_ctx(&opts, &state);
 
     reset_capture();
     cb_setmod_bw(&ctx, 0, 1234);
@@ -553,7 +556,8 @@ test_key_callbacks_validate_and_pack(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof opts);
     DSD_MEMSET(&state, 0, sizeof state);
-    UiCtx ctx = make_ctx(&opts, &state);
+    static UiCtx ctx;
+    ctx = make_ctx(&opts, &state);
     static const char tyt_ap_value[] = "fixture-tyt-ap";
     static const char retevis_rc2_value[] = "fixture-retevis-rc2";
     static const char tyt_ep_value[] = "fixture-tyt-ep";
@@ -672,7 +676,8 @@ test_network_and_io_callbacks_pack_payloads(void) {
     DSD_MEMSET(&state, 0, sizeof state);
     opts.udp_portno = 4567;
     opts.tcp_portno = 3456;
-    UiCtx ctx = make_ctx(&opts, &state);
+    static UiCtx ctx;
+    ctx = make_ctx(&opts, &state);
 
     reset_capture();
     UdpOutCtx* uo = (UdpOutCtx*)calloc(1, sizeof *uo);
@@ -756,7 +761,8 @@ test_gain_rtl_and_env_callbacks(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof opts);
     DSD_MEMSET(&state, 0, sizeof state);
-    UiCtx ctx = make_ctx(&opts, &state);
+    static UiCtx ctx;
+    ctx = make_ctx(&opts, &state);
 
     reset_capture();
     cb_gain_dig(&ctx, 1, 70.0);
@@ -881,7 +887,8 @@ test_env_editor_and_protocol_callbacks(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof opts);
     DSD_MEMSET(&state, 0, sizeof state);
-    UiCtx ctx = make_ctx(&opts, &state);
+    static UiCtx ctx;
+    ctx = make_ctx(&opts, &state);
 
     reset_capture();
     EnvEditCtx* bad = (EnvEditCtx*)calloc(1, sizeof *bad);

--- a/tests/ui/test_ui_menu_services.c
+++ b/tests/ui/test_ui_menu_services.c
@@ -27,6 +27,7 @@
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/log.h>
 #include <dsd-neo/ui/menu_services.h>
+#include <math.h>
 #include <sndfile.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -315,7 +316,7 @@ expect_ull(const char* tag, unsigned long long got, unsigned long long want) {
 
 static int
 expect_double(const char* tag, double got, double want) {
-    if (got != want) {
+    if (fabs(got - want) > 1.0e-9) {
         DSD_FPRINTF(stderr, "%s: got %.3f want %.3f\n", tag, got, want);
         return 1;
     }


### PR DESCRIPTION
## Summary
- keep CodeQL `security-and-quality` enabled while filtering repo-specific noisy quality queries
- update the Semgrep tooling lockfile to patched `pydantic-settings==2.14.2`
- fix actionable CodeQL findings around private file creation, bounds checks, float comparisons, test fixture lifetimes, and prompt context lifetime documentation

## Root Cause
GitHub Security was receiving a mix of true findings and noisy CodeQL quality results. The Dependabot alert came from the Semgrep tooling lockfile pinning `pydantic-settings==2.14.1`. Several CodeQL reports were actionable test-harness issues, while others came from intentional private-source inclusion, generated/static helper patterns, curses side-effect modeling, or async prompt lifetime contracts.

## Resolution
- Added targeted CodeQL query filters for the non-actionable quality rules: `cpp/poorly-documented-function`, `cpp/unused-static-function`, `cpp/include-non-header`, and `cpp/useless-expression`.
- Updated `pydantic-settings` to `2.14.2`.
- Reworked tests and helpers to avoid the actionable `world-writable-file-creation`, `offset-use-before-range-check`, `equality-on-floats`, `constant-comparison`, and test fixture `stack-address-escape` reports.
- Added narrow inline CodeQL suppressions for the menu prompt context lifetime false positives, with the lifetime contract documented at each storage point.

## Expected Security Alert Outcome
After CodeQL and Dependabot rerun on the target branch, the remaining open reports should be the two existing Scorecard items that require repository policy changes: code-review and branch-protection.

## Validation
- `cmake --build --preset dev-debug -j --target dsd-neo_ui_terminal dsd-neo_test_ui_menu_callbacks dsd-neo_test_ui_prompt_validation dsd-neo_test_ui_chooser_navigation`
- `ctest --test-dir build/dev-debug --output-on-failure -R '^(X2TDMA_DATA|RUNTIME_LOG|UI_MENU_SERVICES|UI_MENU_CALLBACKS|UI_CMD_QUEUE|DMR_T3_SM_RETURN_TO_CC_MATRIX|DMR_RELAXED_HEADER_IP|EDACS_GRANT_TUNE_MATRIX|UI_PROMPT_VALIDATION|UI_CHOOSER_NAVIGATION)$'`
- `tools/osv_scan.sh`
- pre-push quality hook
