### PR TITLE
ui: stabilize async menu context

### DIFF
--- a/src/ui/terminal/menu_actions.c
+++ b/src/ui/terminal/menu_actions.c
@@ -457,7 +457,6 @@ act_p2_params(void* v) {
     if (!pc) {
         return;
     }
-    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     pc->c = c;
     pc->step = 0;
     pc->w = pc->s = pc->n = 0ULL;
@@ -574,7 +573,6 @@ act_env_editor(void* v) {
     if (!ec) {
         return;
     }
-    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     ec->c = (UiCtx*)v;
     ui_prompt_open_string_async("Enter DSD_NEO_* variable name", "DSD_NEO_", 128, cb_env_edit_name, ec);
 }
@@ -632,7 +630,6 @@ act_prompt_p25_num(void* v, const char* env_name, const char* title, double defv
     if (!pc) {
         return;
     }
-    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     pc->c = c;
     pc->name = env_name;
     ui_prompt_open_double_async(title, defv, cb_set_p25_num, pc);
@@ -866,7 +863,6 @@ io_set_pulse_device_common(void* vctx, int is_input, const char* chooser_title, 
         ui_statusf("Out of memory");
         return;
     }
-    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives chooser completion.
     pctx->c = c;
     pctx->labels = labels;
     pctx->names = names;
@@ -892,7 +888,6 @@ io_set_udp_out(void* vctx) {
     if (!u) {
         return;
     }
-    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     u->c = c;
     const char* src = c->opts->udp_hostname[0] ? c->opts->udp_hostname : "127.0.0.1";
     DSD_SNPRINTF(u->host, sizeof u->host, "%.*s", (int)sizeof(u->host) - 1, src);
@@ -906,7 +901,6 @@ io_tcp_direct_link(void* vctx) {
     if (!u) {
         return;
     }
-    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     u->c = c;
     const char* defh = c->opts->tcp_hostname[0] ? c->opts->tcp_hostname : "localhost";
     DSD_SNPRINTF(u->host, sizeof u->host, "%.*s", (int)sizeof(u->host) - 1, defh);
@@ -981,7 +975,6 @@ io_rigctl_config(void* vctx) {
     if (!u) {
         return;
     }
-    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     u->c = c;
     const char* defh = c->opts->rigctlhostname[0] ? c->opts->rigctlhostname : "localhost";
     DSD_SNPRINTF(u->host, sizeof u->host, "%.*s", (int)sizeof(u->host) - 1, defh);
@@ -1047,7 +1040,6 @@ switch_to_udp(void* vctx) {
     if (!u) {
         return;
     }
-    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     u->c = c;
     const char* defa = c->opts->udp_in_bindaddr[0] ? c->opts->udp_in_bindaddr : "127.0.0.1";
     DSD_SNPRINTF(u->addr, sizeof u->addr, "%.*s", (int)sizeof(u->addr) - 1, defa);
@@ -1088,7 +1080,6 @@ key_hytera(void* v) {
     if (!hc) {
         return;
     }
-    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     hc->c = c;
     hc->step = 0;
     ui_prompt_open_string_async("Hytera Privacy Key 1 (HEX)", NULL, 128, cb_hytera_step, hc);
@@ -1119,7 +1110,6 @@ key_aes(void* v) {
     if (!ac) {
         return;
     }
-    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     ac->c = c;
     ac->step = 0;
     ui_prompt_open_string_async("AES Segment 1 (HEX) or 0", NULL, 128, cb_aes_step, ac);
@@ -1164,7 +1154,6 @@ act_m17_user_data(void* v) {
     if (!mc) {
         return;
     }
-    // codeql[cpp/stack-address-escape] Menu UiCtx is owned by the active menu and outlives this prompt chain.
     mc->c = c;
     ui_prompt_open_string_async("Enter M17 User Data (CAN,DST,SRC)", pre, 128, cb_m17_user_data, mc);
 }

--- a/src/ui/terminal/menu_core.c
+++ b/src/ui/terminal/menu_core.c
@@ -37,6 +37,14 @@
 static int g_overlay_open = 0;
 static UiMenuFrame g_stack[8];
 static int g_depth = 0;
+static UiCtx g_ctx;
+
+static UiCtx*
+ui_menu_stable_ctx(dsd_opts* opts, dsd_state* state) {
+    g_ctx.opts = opts;
+    g_ctx.state = state;
+    return &g_ctx;
+}
 
 static int
 ui_frame_items_rows(const UiMenuFrame* f) {
@@ -354,10 +362,10 @@ ui_menu_is_activate_key(int ch) {
 
 void
 ui_menu_open_async(dsd_opts* opts, dsd_state* state) {
-    UiCtx ctx = {opts, state};
+    UiCtx* ctx = ui_menu_stable_ctx(opts, state);
     const NcMenuItem* items = NULL;
     size_t n = 0;
-    ui_menu_get_main_items(&items, &n, &ctx);
+    ui_menu_get_main_items(&items, &n, ctx);
     if (!items || n == 0) {
         return;
     }
@@ -375,10 +383,10 @@ ui_menu_open_async(dsd_opts* opts, dsd_state* state) {
     DSD_MEMSET(g_stack, 0, sizeof(g_stack));
     g_stack[0].items = items;
     g_stack[0].n = n;
-    g_stack[0].hi = ui_first_enabled_idx(items, n, &ctx);
+    g_stack[0].hi = ui_first_enabled_idx(items, n, ctx);
     g_stack[0].top = 0;
     g_stack[0].title = "Main Menu";
-    ui_overlay_layout(&g_stack[0], &ctx);
+    ui_overlay_layout(&g_stack[0], ctx);
 }
 
 int
@@ -388,7 +396,7 @@ ui_menu_is_open(void) {
 
 int
 ui_menu_handle_key(int ch, dsd_opts* opts, dsd_state* state) {
-    UiCtx ctx = {opts, state};
+    UiCtx* ctx = ui_menu_stable_ctx(opts, state);
     if (!g_overlay_open || g_depth <= 0) {
         return 0;
     }
@@ -401,36 +409,36 @@ ui_menu_handle_key(int ch, dsd_opts* opts, dsd_state* state) {
         ui_overlay_close_all();
         return 1;
     }
-    if (ui_menu_handle_resize(f, &ctx, ch)) {
+    if (ui_menu_handle_resize(f, ctx, ch)) {
         return 1;
     }
     if (ch == ERR) {
         return 0;
     }
-    if (ui_menu_handle_arrow_keys(f, &ctx, ch)) {
+    if (ui_menu_handle_arrow_keys(f, ctx, ch)) {
         return 1;
     }
-    if (ui_menu_handle_edge_keys(f, &ctx, ch)) {
+    if (ui_menu_handle_edge_keys(f, ctx, ch)) {
         return 1;
     }
-    if (ui_menu_handle_page_keys(f, &ctx, ch)) {
+    if (ui_menu_handle_page_keys(f, ctx, ch)) {
         return 1;
     }
-    if (ui_menu_handle_help_key(f, &ctx, ch)) {
+    if (ui_menu_handle_help_key(f, ctx, ch)) {
         return 1;
     }
     if (ui_menu_handle_back_key(ch)) {
         return 1;
     }
     if (ui_menu_is_activate_key(ch)) {
-        return ui_menu_activate_current(&ctx);
+        return ui_menu_activate_current(ctx);
     }
     return 0;
 }
 
 void
 ui_menu_tick(dsd_opts* opts, dsd_state* state) {
-    UiCtx ctx = {opts, state};
+    const UiCtx* ctx = ui_menu_stable_ctx(opts, state);
     if (!g_overlay_open || g_depth <= 0) {
         return;
     }
@@ -450,12 +458,12 @@ ui_menu_tick(dsd_opts* opts, dsd_state* state) {
         return;
     }
     UiMenuFrame* f = &g_stack[g_depth - 1];
-    if (f->items && f->n > 0 && !ui_is_enabled(&f->items[f->hi], &ctx)) {
-        f->hi = ui_next_enabled(f->items, f->n, &ctx, f->hi, +1);
+    if (f->items && f->n > 0 && !ui_is_enabled(&f->items[f->hi], ctx)) {
+        f->hi = ui_next_enabled(f->items, f->n, ctx, f->hi, +1);
     }
     // Ensure window exists with up-to-date geometry
-    ui_overlay_layout(f, &ctx);
-    ui_frame_keep_highlight_visible(f, &ctx);
+    ui_overlay_layout(f, ctx);
+    ui_frame_keep_highlight_visible(f, ctx);
     ui_overlay_recreate_if_needed(f);
     ui_overlay_ensure_window(f);
     if (!f->win) {
@@ -463,5 +471,5 @@ ui_menu_tick(dsd_opts* opts, dsd_state* state) {
     }
     char breadcrumb[256];
     ui_overlay_breadcrumb(breadcrumb, sizeof breadcrumb);
-    ui_draw_menu(f->win, f->items, f->n, f->hi, &f->top, breadcrumb, &ctx);
+    ui_draw_menu(f->win, f->items, f->n, f->hi, &f->top, breadcrumb, ctx);
 }

--- a/src/ui/terminal/menu_prompts.c
+++ b/src/ui/terminal/menu_prompts.c
@@ -271,7 +271,6 @@ ui_prompt_open_string_async_impl(const char* title, const char* prefill, size_t 
     g_prompt.active = 1;
     g_prompt.title = title;
     g_prompt.on_done_str = on_done;
-    // codeql[cpp/stack-address-escape] Prompt callers must keep user context alive until completion/cancel.
     g_prompt.user = user;
     if (cap < 2) {
         cap = 2;
@@ -364,7 +363,6 @@ ui_prompt_open_int_async_impl(const char* title, int initial, void* user, ui_pro
         return;
     }
     pic->cb = cb;
-    // codeql[cpp/stack-address-escape] Typed prompt wrappers preserve the caller's prompt context.
     pic->user = user;
     ui_prompt_open_string_async(title, pre, 64, ui_prompt_int_finish, pic);
 }
@@ -382,7 +380,6 @@ ui_prompt_open_double_async_impl(const char* title, double initial, void* user, 
         return;
     }
     pdc->cb = cb;
-    // codeql[cpp/stack-address-escape] Typed prompt wrappers preserve the caller's prompt context.
     pdc->user = user;
     ui_prompt_open_string_async(title, pre, 64, ui_prompt_double_finish, pdc);
 }
@@ -1057,7 +1054,6 @@ ui_chooser_start_impl(const char* title, const char* const* items, int count, vo
     g_chooser.top = 0;
     g_chooser.page_rows = 0;
     g_chooser.on_done = on_done;
-    // codeql[cpp/stack-address-escape] Chooser callers must keep user context alive until completion/cancel.
     g_chooser.user = user;
     if (g_chooser.win) {
         delwin(g_chooser.win);

--- a/tests/ui/test_ui_menu_actions.c
+++ b/tests/ui/test_ui_menu_actions.c
@@ -707,7 +707,8 @@ test_simple_commands_and_prompts(void) {
     opts.slot_preference = 1;
     opts.slot1_on = 1;
     state.tg_hold = 1234;
-    UiCtx ctx = make_ctx(&opts, &state);
+    static UiCtx ctx;
+    ctx = make_ctx(&opts, &state);
 
     reset_capture();
     act_toggle_invert(NULL);
@@ -757,7 +758,8 @@ test_config_profile_and_env_actions(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof opts);
     DSD_MEMSET(&state, 0, sizeof state);
-    UiCtx ctx = make_ctx(&opts, &state);
+    static UiCtx ctx;
+    ctx = make_ctx(&opts, &state);
 
     reset_capture();
     DSD_SNPRINTF(state.config_autosave_path, sizeof state.config_autosave_path, "/tmp/current.toml");
@@ -818,7 +820,8 @@ test_io_actions_and_choosers(void) {
     DSD_SNPRINTF(opts.rigctlhostname, sizeof opts.rigctlhostname, "rig.local");
     DSD_SNPRINTF(opts.pa_output_idx, sizeof opts.pa_output_idx, "pulse0");
     opts.input_volume_multiplier = 16;
-    UiCtx ctx = make_ctx(&opts, &state);
+    static UiCtx ctx;
+    ctx = make_ctx(&opts, &state);
 
     reset_capture();
     io_select_call_alert_events(&ctx);
@@ -893,7 +896,8 @@ test_key_lrrp_and_display_actions(void) {
     DSD_MEMSET(&state, 0, sizeof state);
     DSD_SNPRINTF(state.m17dat, sizeof state.m17dat, "1,N0CALL,N1CALL");
     state.p2_wacn = 0xABCDE;
-    UiCtx ctx = make_ctx(&opts, &state);
+    static UiCtx ctx;
+    ctx = make_ctx(&opts, &state);
 
     reset_capture();
     key_basic(&ctx);
@@ -977,7 +981,8 @@ test_additional_prompt_and_toggle_actions(void) {
     DSD_SNPRINTF(opts.wav_out_file_raw, sizeof opts.wav_out_file_raw, "raw.wav");
     opts.trunk_hangtime = 2.75;
     opts.input_warn_db = -37.5;
-    UiCtx ctx = make_ctx(&opts, &state);
+    static UiCtx ctx;
+    ctx = make_ctx(&opts, &state);
 
     reset_capture();
     act_toggle_payload(NULL);
@@ -1369,7 +1374,8 @@ test_config_and_pulse_failure_variants(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof opts);
     DSD_MEMSET(&state, 0, sizeof state);
-    UiCtx ctx = make_ctx(&opts, &state);
+    static UiCtx ctx;
+    ctx = make_ctx(&opts, &state);
 
     reset_capture();
     act_config_load(&ctx);

--- a/tests/ui/test_ui_menu_navigation.c
+++ b/tests/ui/test_ui_menu_navigation.c
@@ -365,8 +365,8 @@ resize_term(int lines, int columns) {
 
 int
 main(void) {
-    unsigned char opts_token = 0;
-    unsigned char state_token = 0;
+    static unsigned char opts_token;
+    static unsigned char state_token;
     dsd_opts* opts = (dsd_opts*)&opts_token;
     dsd_state* state = (dsd_state*)&state_token;
 

--- a/tests/ui/test_ui_menu_paging_viewport.c
+++ b/tests/ui/test_ui_menu_paging_viewport.c
@@ -221,8 +221,8 @@ resize_term(int lines, int columns) {
 
 int
 main(void) {
-    unsigned char opts_token = 0;
-    unsigned char state_token = 0;
+    static unsigned char opts_token;
+    static unsigned char state_token;
     dsd_opts* opts = (dsd_opts*)&opts_token;
     dsd_state* state = (dsd_state*)&state_token;
 

--- a/tests/ui/test_ui_prompt_validation.c
+++ b/tests/ui/test_ui_prompt_validation.c
@@ -303,7 +303,8 @@ static void
 test_chooser_edge_paths(void) {
     assert(ui_chooser_handle_key('x') == 0);
 
-    int selected = -2;
+    static int selected;
+    selected = -2;
     ui_chooser_start("Empty", NULL, 0, capture_chooser_selected, &selected);
     assert(selected == -1);
     assert(ui_chooser_active() == 0);
@@ -317,7 +318,8 @@ test_chooser_edge_paths(void) {
     assert(selected == 0);
     assert(ui_chooser_active() == 0);
 
-    ChooserCapture capture = {0, -2, -2};
+    static ChooserCapture capture;
+    capture = (ChooserCapture){0, -2, -2};
     ui_chooser_start("First", CHOOSER_ONE, 3, capture_chooser_reentry, &capture);
     assert(ui_chooser_active() == 1);
     assert(ui_chooser_handle_key(KEY_DOWN) == 1);
@@ -337,7 +339,8 @@ test_chooser_edge_paths(void) {
 
 static void
 test_chooser_page_navigation_clamps_selection(void) {
-    int selected = -2;
+    static int selected;
+    selected = -2;
     ui_chooser_start("Many", CHOOSER_MANY, 6, capture_chooser_selected, &selected);
     ui_chooser_test_set_page_rows(3);
     UiChooserTestSnapshot snapshot = ui_chooser_test_snapshot();
@@ -376,7 +379,8 @@ test_chooser_page_navigation_clamps_selection(void) {
 
 static void
 test_chooser_up_down_wraparound(void) {
-    int selected = -2;
+    static int selected;
+    selected = -2;
     ui_chooser_start("Wrap", CHOOSER_ONE, 3, capture_chooser_selected, &selected);
     ui_chooser_test_set_page_rows(2);
 


### PR DESCRIPTION
## Summary
- store the terminal menu `UiCtx` in stable overlay-owned storage instead of recreating it on each stack frame
- route menu open, key handling, and render ticks through that stable context before async prompts or choosers run callbacks
- remove obsolete inline CodeQL suppressions and align async prompt/chooser tests with the same lifetime contract

## Issue
After the prior security cleanup, 17 code scanning items remained open: 15 CodeQL `cpp/stack-address-escape` alerts in the terminal menu path and the 2 expected Scorecard items for code review and branch protection. The CodeQL menu findings were valid: async prompt and chooser callbacks could retain a `UiCtx *` that originally came from a stack-local context in `ui_menu_handle_key` or `ui_menu_tick`.

## Resolution
This change makes the overlay context stable for the lifetime of the menu overlay and updates it from the current `opts` and `state` pointers on each public menu entry point. Async prompt and chooser contexts now receive a stable `UiCtx *`, and the test fixtures that intentionally store async callback users use static storage rather than stack-only addresses.

## Expected Security Alert Outcome
After CodeQL reruns on `main`, the 15 remaining `cpp/stack-address-escape` alerts should close. The only expected open code quality reports should remain the two Scorecard policy items: code-review and branch-protection.

## Validation
- `cmake --build --preset dev-debug -j --target dsd-neo_ui_terminal dsd-neo_test_ui_menu_navigation dsd-neo_test_ui_menu_paging_viewport dsd-neo_test_ui_menu_actions dsd-neo_test_ui_prompt_validation`
- `ctest --test-dir build/dev-debug --output-on-failure -R '^(UI_MENU_NAVIGATION|UI_MENU_PAGING_VIEWPORT|UI_MENU_ACTIONS|UI_MENU_CALLBACKS|UI_PROMPT_VALIDATION|UI_CHOOSER_NAVIGATION)$'`
- pre-push quality hook
