### PR TITLE
audio: pace finite-input playback

### DIFF
--- a/include/dsd-neo/core/audio.h
+++ b/include/dsd-neo/core/audio.h
@@ -43,6 +43,8 @@ void closeAudioOutput(dsd_opts* opts);
 
 /** @brief Best-effort drain of audio output buffers. Safe no-op when disabled. */
 void dsd_drain_audio_output(dsd_opts* opts);
+/** @brief Reopen local output streams when the active input changes async/sync output policy. */
+int dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts);
 
 /** @brief Write synthesized mono voice samples for slot 1. */
 void writeSynthesizedVoice(dsd_opts* opts, dsd_state* state);

--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -98,7 +98,8 @@ struct dsd_opts {
     int rtlsdr_ppm_error;
     dsd_audio_in_type audio_in_type; ///< Audio input source (see dsd_audio_in_type)
     int audio_out_fd;
-    int audio_out_type; // 0 for pulse, 1 for file/stdout, 8 for UDP
+    int audio_out_type;            // 0 for pulse, 1 for file/stdout, 8 for UDP
+    int audio_output_async_policy; // async mode applied to currently open local output streams
     int split;
     int playoffset;
     int playoffsetR;

--- a/include/dsd-neo/platform/audio.h
+++ b/include/dsd-neo/platform/audio.h
@@ -41,6 +41,7 @@ typedef struct dsd_audio_params {
     int bits_per_sample;  /* 16 */
     const char* device;   /* Device name/identifier, or NULL for default */
     const char* app_name; /* Application name for audio server (optional) */
+    int async_output;     /* nonzero enables low-latency async output with overrun drops */
 } dsd_audio_params;
 
 /**

--- a/src/core/audio/dsd_audio.c
+++ b/src/core/audio/dsd_audio.c
@@ -267,7 +267,8 @@ dsd_audio_should_use_async_output(const dsd_opts* opts) {
     if (!opts) {
         return 0;
     }
-    return dsd_audio_input_type_uses_async_output(opts->audio_in_type, opts->playfiles, opts->audio_in_dev);
+    return dsd_audio_input_type_uses_async_output(opts->audio_in_type, opts->playfiles, opts->audio_in_dev,
+                                                  opts->m17decoderip);
 }
 
 int
@@ -331,6 +332,9 @@ dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) {
         return 0;
     }
 
+    if (opts->audio_output_async_policy == 0) {
+        dsd_drain_audio_output(opts);
+    }
     closeAudioOutput(opts);
     if (openAudioOutput(opts) != 0) {
         LOG_ERROR("Failed to reconfigure audio output for input policy\n");
@@ -375,6 +379,9 @@ dsd_drain_audio_output(dsd_opts* opts) {
     if (opts->audio_out_type == 0) {
         if (opts->audio_out_stream) {
             (void)dsd_audio_drain(opts->audio_out_stream);
+        }
+        if (opts->audio_out_streamR) {
+            (void)dsd_audio_drain(opts->audio_out_streamR);
         }
         if (opts->audio_raw_out) {
             (void)dsd_audio_drain(opts->audio_raw_out);

--- a/src/core/audio/dsd_audio.c
+++ b/src/core/audio/dsd_audio.c
@@ -41,6 +41,7 @@
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/dsp/resampler.h"
+#include "dsd_audio_internal.h"
 
 static int
 dsd_audio_path_is_wav_container(const char* path) {
@@ -261,6 +262,14 @@ closeAudioInput(dsd_opts* opts) {
     }
 }
 
+static int
+dsd_audio_should_use_async_output(const dsd_opts* opts) {
+    if (!opts) {
+        return 0;
+    }
+    return dsd_audio_input_type_uses_async_output(opts->audio_in_type, opts->playfiles);
+}
+
 int
 openAudioOutput(dsd_opts* opts) {
     const char* dev = NULL;
@@ -269,8 +278,10 @@ openAudioOutput(dsd_opts* opts) {
     }
 
     dsd_audio_params params;
+    DSD_MEMSET(&params, 0, sizeof(params));
     params.device = dev;
     params.app_name = "DSD-neo";
+    params.async_output = dsd_audio_should_use_async_output(opts);
 
     /* Open raw/analog output stream for ProVoice or analog monitor mode */
     if (opts->frame_provoice == 1 || opts->monitor_input_audio == 1) {
@@ -310,6 +321,7 @@ openAudioInput(dsd_opts* opts) {
     }
 
     dsd_audio_params params;
+    DSD_MEMSET(&params, 0, sizeof(params));
     params.sample_rate = opts->pulse_digi_rate_in;
     params.channels = opts->pulse_digi_in_channels;
     params.bits_per_sample = 16;

--- a/src/core/audio/dsd_audio.c
+++ b/src/core/audio/dsd_audio.c
@@ -267,7 +267,7 @@ dsd_audio_should_use_async_output(const dsd_opts* opts) {
     if (!opts) {
         return 0;
     }
-    return dsd_audio_input_type_uses_async_output(opts->audio_in_type, opts->playfiles);
+    return dsd_audio_input_type_uses_async_output(opts->audio_in_type, opts->playfiles, opts->audio_in_dev);
 }
 
 int
@@ -309,6 +309,32 @@ openAudioOutput(dsd_opts* opts) {
             }
             return -1;
         }
+    }
+    opts->audio_output_async_policy = params.async_output ? 1 : 0;
+    return 0;
+}
+
+int
+dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) {
+    if (!opts) {
+        return -1;
+    }
+    if (opts->audio_out != 1 || opts->audio_out_type != 0) {
+        return 0;
+    }
+    if (!opts->audio_out_stream && !opts->audio_out_streamR && !opts->audio_raw_out) {
+        return 0;
+    }
+
+    int async_policy = dsd_audio_should_use_async_output(opts);
+    if (opts->audio_output_async_policy == async_policy) {
+        return 0;
+    }
+
+    closeAudioOutput(opts);
+    if (openAudioOutput(opts) != 0) {
+        LOG_ERROR("Failed to reconfigure audio output for input policy\n");
+        return -1;
     }
     return 0;
 }
@@ -1116,5 +1142,5 @@ openAudioInDevice(dsd_opts* opts, dsd_state* state) {
     } else {
         DSD_FPRINTF(stderr, "Audio In/Out Device: %s\n", opts->audio_in_dev);
     }
-    return 0;
+    return dsd_audio_reconfigure_output_for_input_policy(opts);
 }

--- a/src/core/audio/dsd_audio_internal.h
+++ b/src/core/audio/dsd_audio_internal.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: ISC
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef DSD_NEO_SRC_CORE_AUDIO_DSD_AUDIO_INTERNAL_H
+#define DSD_NEO_SRC_CORE_AUDIO_DSD_AUDIO_INTERNAL_H
+
+#include <dsd-neo/core/opts.h>
+
+static inline int
+dsd_audio_input_type_uses_async_output(int audio_in_type, int playfiles) {
+    if (playfiles == 1) {
+        return 0;
+    }
+
+    switch (audio_in_type) {
+        case AUDIO_IN_STDIN:
+        case AUDIO_IN_WAV:
+        case AUDIO_IN_SYMBOL_BIN:
+        case AUDIO_IN_SYMBOL_FLT:
+        case AUDIO_IN_NULL: return 0;
+        default: break;
+    }
+
+    return 1;
+}
+
+#endif /* DSD_NEO_SRC_CORE_AUDIO_DSD_AUDIO_INTERNAL_H */

--- a/src/core/audio/dsd_audio_internal.h
+++ b/src/core/audio/dsd_audio_internal.h
@@ -9,7 +9,7 @@
 #include <dsd-neo/core/opts.h>
 
 static inline int
-dsd_audio_input_type_uses_async_output(int audio_in_type, int playfiles, const char* audio_in_dev) {
+dsd_audio_input_type_uses_async_output(int audio_in_type, int playfiles, const char* audio_in_dev, int m17decoderip) {
     if (playfiles == 1) {
         return 0;
     }
@@ -19,7 +19,7 @@ dsd_audio_input_type_uses_async_output(int audio_in_type, int playfiles, const c
         case AUDIO_IN_WAV:
         case AUDIO_IN_SYMBOL_BIN:
         case AUDIO_IN_SYMBOL_FLT: return 0;
-        case AUDIO_IN_NULL: return dsd_opts_audio_in_dev_is_m17udp_spec(audio_in_dev) ? 1 : 0;
+        case AUDIO_IN_NULL: return (m17decoderip == 1 || dsd_opts_audio_in_dev_is_m17udp_spec(audio_in_dev)) ? 1 : 0;
         default: break;
     }
 

--- a/src/core/audio/dsd_audio_internal.h
+++ b/src/core/audio/dsd_audio_internal.h
@@ -9,7 +9,7 @@
 #include <dsd-neo/core/opts.h>
 
 static inline int
-dsd_audio_input_type_uses_async_output(int audio_in_type, int playfiles) {
+dsd_audio_input_type_uses_async_output(int audio_in_type, int playfiles, const char* audio_in_dev) {
     if (playfiles == 1) {
         return 0;
     }
@@ -18,8 +18,8 @@ dsd_audio_input_type_uses_async_output(int audio_in_type, int playfiles) {
         case AUDIO_IN_STDIN:
         case AUDIO_IN_WAV:
         case AUDIO_IN_SYMBOL_BIN:
-        case AUDIO_IN_SYMBOL_FLT:
-        case AUDIO_IN_NULL: return 0;
+        case AUDIO_IN_SYMBOL_FLT: return 0;
+        case AUDIO_IN_NULL: return dsd_opts_audio_in_dev_is_m17udp_spec(audio_in_dev) ? 1 : 0;
         default: break;
     }
 

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -1156,6 +1156,20 @@ symbol_stop_after_shutdown(float* sample_out) {
 }
 
 static inline int
+symbol_open_pulse_input_and_reconfigure_output(dsd_opts* opts, dsd_state* state) {
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    if (openAudioInput(opts) != 0) {
+        cleanupAndExit(opts, state);
+        return 0;
+    }
+    if (dsd_audio_reconfigure_output_for_input_policy(opts) != 0) {
+        cleanupAndExit(opts, state);
+        return 0;
+    }
+    return 1;
+}
+
+static inline int
 symbol_read_sample_stdin(dsd_opts* opts, dsd_state* state, float* sample_out) {
     if (symbol_stop_after_shutdown(sample_out)) {
         return 0;
@@ -1205,12 +1219,7 @@ symbol_read_sample_wav(dsd_opts* opts, dsd_state* state, float* sample_out) {
         symbol_close_audio_in_file(opts);
         DSD_FPRINTF(stderr, "\nEnd of %s\n", opts->audio_in_dev);
         if (opts->audio_out_type == 0 && opts->use_ncurses_terminal == 1) {
-            opts->audio_in_type = AUDIO_IN_PULSE;
-            if (openAudioInput(opts) != 0) {
-                cleanupAndExit(opts, state);
-                return 0;
-            }
-            return 1;
+            return symbol_open_pulse_input_and_reconfigure_output(opts, state);
         }
         cleanupAndExit(opts, state);
         return 0;
@@ -1462,10 +1471,8 @@ symbol_read_sample_tcp(dsd_opts* opts, dsd_state* state, float* sample_out) {
             dsd_net_audio_input_hook_tcp_close(opts->tcp_in_ctx);
             opts->tcp_in_ctx = NULL;
             dsd_socket_close(opts->tcp_sockfd);
-            opts->audio_in_type = AUDIO_IN_PULSE;
             opts->tcp_sockfd = 0;
-            if (openAudioInput(opts) != 0) {
-                cleanupAndExit(opts, state);
+            if (!symbol_open_pulse_input_and_reconfigure_output(opts, state)) {
                 return 0;
             }
             *sample_out = 0;
@@ -1706,10 +1713,7 @@ symbol_process_symbol_bin_input(dsd_opts* opts, dsd_state* state, float* symbol_
             return 1;
         }
         if (opts->audio_out_type == 0 && opts->use_ncurses_terminal == 1) {
-            opts->audio_in_type = AUDIO_IN_PULSE;
-            if (openAudioInput(opts) != 0) {
-                cleanupAndExit(opts, state);
-            }
+            (void)symbol_open_pulse_input_and_reconfigure_output(opts, state);
             *symbol_out = 0.0f;
             return 1;
         }

--- a/src/platform/audio_portaudio.c
+++ b/src/platform/audio_portaudio.c
@@ -692,7 +692,7 @@ portaudio_init_output_stream_state(dsd_audio_stream* stream, const dsd_audio_par
     stream->is_input = 0;
     stream->channels = params->channels;
     stream->sample_rate = params->sample_rate;
-    stream->use_async = 1;
+    stream->use_async = params->async_output ? 1 : 0;
     stream->thread_started = 0;
     stream->stop = 0;
     stream->drain_requested = 0;
@@ -831,9 +831,12 @@ dsd_audio_open_output(const dsd_audio_params* params) {
 
     portaudio_init_output_stream_state(stream, params);
 
-    int async_sync_inited = portaudio_init_async_sync(stream);
-    if (!async_sync_inited) {
-        stream->use_async = 0;
+    int async_sync_inited = 0;
+    if (stream->use_async) {
+        async_sync_inited = portaudio_init_async_sync(stream);
+        if (!async_sync_inited) {
+            stream->use_async = 0;
+        }
     }
 
     if (stream->use_async) {

--- a/src/platform/audio_pulse.c
+++ b/src/platform/audio_pulse.c
@@ -698,9 +698,9 @@ pulse_output_init_attr(const dsd_audio_params* params, pa_buffer_attr* attr) {
 }
 
 static void
-pulse_output_init_async_state(dsd_audio_stream* stream) {
+pulse_output_init_async_state(dsd_audio_stream* stream, int async_output) {
     /* Async output pump: decouple decode thread from Pulse writes. */
-    stream->use_async = 1;
+    stream->use_async = async_output ? 1 : 0;
     stream->thread_started = 0;
     stream->stop = 0;
     stream->drain_requested = 0;
@@ -828,7 +828,7 @@ dsd_audio_open_output(const dsd_audio_params* params) {
     stream->is_input = 0;
     stream->channels = params->channels;
     stream->sample_rate = params->sample_rate;
-    pulse_output_init_async_state(stream);
+    pulse_output_init_async_state(stream, params->async_output);
 
     if (stream->use_async) {
         int async_sync_inited = pulse_output_init_async_sync(stream);

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -46,9 +46,7 @@ dmr_slot_is_known(const dsd_state* state) {
     if (!state) {
         return 0;
     }
-    /* In simplex/MS mode there is no CACH-derived slot signaling, so avoid
-     * presenting a hard slot number that can be misread as authoritative. */
-    return state->dmr_ms_mode == 0;
+    return state->currentslot == 0 || state->currentslot == 1;
 }
 
 static inline void

--- a/src/protocol/dmr/dmr_trunk_sm.c
+++ b/src/protocol/dmr/dmr_trunk_sm.c
@@ -33,9 +33,14 @@ now_monotonic(void) {
 
 static void
 sm_log(const dsd_opts* opts, const char* tag) {
-    if (opts && opts->verbose > 1 && tag) {
+    if (opts && opts->trunk_enable == 1 && opts->verbose > 1 && tag) {
         DSD_FPRINTF(stderr, "\n[DMR SM] %s\n", tag);
     }
+}
+
+static int
+sm_status_log_enabled(const dsd_opts* opts) {
+    return opts && opts->trunk_enable == 1 && opts->verbose > 0;
 }
 
 static long
@@ -57,7 +62,7 @@ lpcn_is_trusted(const dsd_opts* opts, dsd_state* state, int lpcn) {
     uint8_t trust = state->dmr_lcn_trust[lpcn];
     int on_cc = (state->trunk_cc_freq != 0 && opts && opts->trunk_is_tuned == 0);
     if (trust < 2 && !on_cc) {
-        if (opts && opts->verbose > 0) {
+        if (sm_status_log_enabled(opts)) {
             DSD_FPRINTF(stderr, "\n  DMR SM: block tune LPCN=%d (untrusted off-CC)\n", lpcn);
         }
         return 0;
@@ -73,7 +78,7 @@ set_state(dmr_sm_ctx_t* ctx, const dsd_opts* opts, dmr_sm_state_e new_state, con
     dmr_sm_state_e old = ctx->state;
     ctx->state = new_state;
 
-    if (opts && opts->verbose > 0) {
+    if (sm_status_log_enabled(opts)) {
         DSD_FPRINTF(stderr, "\n[DMR SM] %s -> %s (%s)\n", dmr_sm_state_name(old), dmr_sm_state_name(new_state),
                     reason ? reason : "");
     }
@@ -199,7 +204,7 @@ handle_grant(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const dmr_sm_e
     state->last_t3_tune_time_m = now_m;
     state->p25_sm_tune_count++;
 
-    if (opts->verbose > 0) {
+    if (sm_status_log_enabled(opts)) {
         DSD_FPRINTF(stderr, "\n  DMR SM: Tune VC freq=%.6lf MHz\n", (double)freq / 1000000.0);
     }
 

--- a/src/ui/terminal/ui_cmd_queue.c
+++ b/src/ui/terminal/ui_cmd_queue.c
@@ -118,6 +118,23 @@ ui_set_toast(dsd_state* state, int ttl_s, const char* fmt, ...) {
     state->ui_msg_expire = time(NULL) + ttl_s;
 }
 
+static int
+ui_reconfigure_output_for_input_policy(dsd_opts* opts, dsd_state* state) {
+    if (dsd_audio_reconfigure_output_for_input_policy(opts) != 0) {
+        ui_set_toast(state, 4, "Failed: audio output reconfigure");
+        return -1;
+    }
+    return 0;
+}
+
+static void
+ui_set_tcp_audio_connected_toast_if_output_ready(dsd_opts* opts, dsd_state* state, const char* host, int port) {
+    if (ui_reconfigure_output_for_input_policy(opts, state) != 0) {
+        return;
+    }
+    ui_set_toast(state, 3, "TCP audio connected: %s:%d", host, port);
+}
+
 #ifdef USE_RADIO
 static inline int
 ui_rc_is_not_supported(int rc) {
@@ -570,7 +587,9 @@ ui_cmd_handle_symbol_in_open(dsd_opts* opts, dsd_state* state, const struct UiCm
         if (ui_cmd_copy_payload_string(c, path, sizeof path)) {
             int rc = svc_open_symbol_in(opts, state, path);
             if (rc == 0) {
-                ui_set_toast(state, 3, "Applied: Symbol input -> %s", path);
+                if (ui_reconfigure_output_for_input_policy(opts, state) == 0) {
+                    ui_set_toast(state, 3, "Applied: Symbol input -> %s", path);
+                }
             } else {
                 ui_set_toast(state, 4, "Failed: Symbol input open -> %s", path);
             }
@@ -583,7 +602,9 @@ static int
 ui_cmd_handle_input_wav_set(dsd_opts* opts, dsd_state* state, const struct UiCmd* c) {
     if (c->n > 0 && ui_cmd_copy_payload_string(c, opts->audio_in_dev, sizeof opts->audio_in_dev)) {
         opts->audio_in_type = AUDIO_IN_WAV;
-        ui_set_toast(state, 3, "Applied: WAV input -> %s", opts->audio_in_dev);
+        if (ui_reconfigure_output_for_input_policy(opts, state) == 0) {
+            ui_set_toast(state, 3, "Applied: WAV input -> %s", opts->audio_in_dev);
+        }
     }
     return 1;
 }
@@ -592,7 +613,9 @@ static int
 ui_cmd_handle_input_sym_stream_set(dsd_opts* opts, dsd_state* state, const struct UiCmd* c) {
     if (c->n > 0 && ui_cmd_copy_payload_string(c, opts->audio_in_dev, sizeof opts->audio_in_dev)) {
         opts->audio_in_type = AUDIO_IN_SYMBOL_FLT;
-        ui_set_toast(state, 3, "Applied: Symbol stream input -> %s", opts->audio_in_dev);
+        if (ui_reconfigure_output_for_input_policy(opts, state) == 0) {
+            ui_set_toast(state, 3, "Applied: Symbol stream input -> %s", opts->audio_in_dev);
+        }
     }
     return 1;
 }
@@ -602,7 +625,9 @@ ui_cmd_handle_input_set_pulse(dsd_opts* opts, dsd_state* state, const struct UiC
     (void)c;
     DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "pulse");
     opts->audio_in_type = AUDIO_IN_PULSE;
-    ui_set_toast(state, 3, "Applied: Input switched to Pulse");
+    if (ui_reconfigure_output_for_input_policy(opts, state) == 0) {
+        ui_set_toast(state, 3, "Applied: Input switched to Pulse");
+    }
     return 1;
 }
 
@@ -654,7 +679,7 @@ ui_cmd_handle_tcp_connect_audio_cfg(dsd_opts* opts, dsd_state* state, const stru
     if (state && ui_cmd_parse_host_port_payload(c, host, sizeof host, &port)) {
         int rc = svc_tcp_connect_audio(opts, host, port);
         if (rc == 0) {
-            ui_set_toast(state, 3, "TCP audio connected: %s:%d", host, (int)port);
+            ui_set_tcp_audio_connected_toast_if_output_ready(opts, state, host, (int)port);
         } else {
             ui_set_toast(state, 4, "TCP audio connect failed: %s:%d", host, (int)port);
         }
@@ -686,7 +711,9 @@ ui_cmd_handle_udp_input_cfg(dsd_opts* opts, dsd_state* state, const struct UiCmd
         opts->udp_in_portno = port;
         DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "udp");
         opts->audio_in_type = AUDIO_IN_UDP;
-        ui_set_toast(state, 3, "UDP input set: %s:%d", bind[0] ? bind : "127.0.0.1", (int)port);
+        if (ui_reconfigure_output_for_input_policy(opts, state) == 0) {
+            ui_set_toast(state, 3, "UDP input set: %s:%d", bind[0] ? bind : "127.0.0.1", (int)port);
+        }
     }
     return 1;
 }
@@ -730,7 +757,9 @@ ui_cmd_handle_rtl_enable_input(dsd_opts* opts, dsd_state* state, const struct Ui
     if (state) {
         int rc = svc_rtl_enable_input(opts, state);
         if (rc == 0) {
-            ui_set_toast(state, 3, "Applied: RTL input enabled");
+            if (ui_reconfigure_output_for_input_policy(opts, state) == 0) {
+                ui_set_toast(state, 3, "Applied: RTL input enabled");
+            }
         } else if (ui_rc_is_not_supported(rc)) {
             ui_set_toast(state, 3, "Unsupported: active radio backend cannot enable RTL input");
         } else {
@@ -1073,7 +1102,9 @@ apply_cmd_io_and_import_pulse_io(dsd_opts* opts, dsd_state* state, const struct 
                 name[n] = '\0';
                 int rc = svc_set_pulse_input(opts, name);
                 if (rc == 0) {
-                    ui_set_toast(state, 3, "Applied: Pulse input -> %s", name);
+                    if (ui_reconfigure_output_for_input_policy(opts, state) == 0) {
+                        ui_set_toast(state, 3, "Applied: Pulse input -> %s", name);
+                    }
                 } else {
                     ui_set_toast(state, 4, "Failed: Pulse input -> %s", name);
                 }
@@ -2102,7 +2133,7 @@ apply_cmd_legacy_trunk_controls(dsd_opts* opts, dsd_state* state, const struct U
             int rc = svc_tcp_connect_audio(opts, opts->tcp_hostname, opts->tcp_portno);
             if (rc == 0) {
                 LOG_INFO("TCP Socket Connected Successfully.\n");
-                ui_set_toast(state, 3, "TCP audio connected: %s:%d", opts->tcp_hostname, opts->tcp_portno);
+                ui_set_tcp_audio_connected_toast_if_output_ready(opts, state, opts->tcp_hostname, opts->tcp_portno);
             } else {
                 LOG_ERROR("TCP Socket Connection Error.\n");
                 ui_set_toast(state, 4, "TCP audio connect failed: %s:%d", opts->tcp_hostname, opts->tcp_portno);
@@ -2344,6 +2375,7 @@ ui_cmd_handle_replay_last_legacy(dsd_opts* opts, dsd_state* state, const struct 
             state->symbol_replay_format = DSD_SYMBOL_REPLAY_FORMAT_UNKNOWN;
             state->symbol_replay_header_checked = 0;
             state->symbol_replay_has_soft = 0;
+            (void)ui_reconfigure_output_for_input_policy(opts, state);
         }
     }
     return 1;
@@ -2383,7 +2415,6 @@ ui_cmd_handle_wav_stop_legacy(dsd_opts* opts, dsd_state* state, const struct UiC
 
 static int
 ui_cmd_handle_stop_playback_legacy(dsd_opts* opts, dsd_state* state, const struct UiCmd* c) {
-    (void)state;
     (void)c;
     if (opts->symbolfile != NULL) {
         if (opts->audio_in_type == AUDIO_IN_SYMBOL_BIN) {
@@ -2399,9 +2430,12 @@ ui_cmd_handle_stop_playback_legacy(dsd_opts* opts, dsd_state* state, const struc
         opts->audio_in_type = AUDIO_IN_PULSE;
         if (openAudioInput(opts) != 0) {
             LOG_ERROR("UI: failed to open PulseAudio input\n");
+        } else {
+            (void)ui_reconfigure_output_for_input_policy(opts, state);
         }
     } else {
         opts->audio_in_type = AUDIO_IN_STDIN;
+        (void)ui_reconfigure_output_for_input_policy(opts, state);
     }
     return 1;
 }
@@ -2454,6 +2488,7 @@ apply_cmd_legacy_misc_config(dsd_opts* opts, dsd_state* state, const struct UiCm
                 restore_live_pcm_rate_after_staged_file_apply(opts, &cfg, old_wav_sample_rate);
                 apply_cfg_file_runtime_rate(opts, state, &cfg, old_runtime_input_rate, old_samples_per_symbol,
                                             old_symbol_center, old_jitter);
+                (void)ui_reconfigure_output_for_input_policy(opts, state);
             }
             return 1;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2377,6 +2377,19 @@ target_include_directories(
     PRIVATE ${PROJECT_SOURCE_DIR}/include
 )
 target_link_libraries(dsd-neo_test_core_audio_gain PRIVATE dsd-neo_core)
+if(NOT APPLE AND NOT WIN32 AND (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang"))
+    target_compile_definitions(
+        dsd-neo_test_core_audio_gain
+        PRIVATE DSD_NEO_TEST_AUDIO_WRAP
+    )
+    target_link_options(
+        dsd-neo_test_core_audio_gain
+        PRIVATE
+            "LINKER:--wrap=dsd_audio_open_output"
+            "LINKER:--wrap=dsd_audio_close"
+            "LINKER:--wrap=dsd_audio_drain"
+    )
+endif()
 add_test(NAME CORE_AUDIO_GAIN COMMAND dsd-neo_test_core_audio_gain)
 
 add_executable(

--- a/tests/core/test_core_audio_gain.c
+++ b/tests/core/test_core_audio_gain.c
@@ -7,11 +7,13 @@
 #include <dsd-neo/core/dibit.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/platform/audio.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/platform/posix_compat.h>
 #include <errno.h>
 #include <math.h>
 #include <sndfile.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -23,6 +25,83 @@
 #include "dsd-neo/core/state_fwd.h"
 
 enum { DSD_AUDIO_TEST_PATH_MAX = 512 };
+
+#ifdef DSD_NEO_TEST_AUDIO_WRAP
+enum {
+    DSD_AUDIO_WRAP_EVENT_DRAIN = 1,
+    DSD_AUDIO_WRAP_EVENT_CLOSE = 2,
+    DSD_AUDIO_WRAP_EVENT_OPEN = 3,
+};
+
+typedef struct audio_wrap_event {
+    dsd_audio_stream* stream;
+    int kind;
+    int async_output;
+} audio_wrap_event;
+
+static uintptr_t g_audio_wrap_existing_streams[4];
+static uintptr_t g_audio_wrap_open_streams[4];
+static audio_wrap_event g_audio_wrap_events[16];
+static int g_audio_wrap_event_count;
+static int g_audio_wrap_open_count;
+
+// GNU ld --wrap requires these exact external symbol names.
+// NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,misc-use-internal-linkage)
+dsd_audio_stream* __wrap_dsd_audio_open_output(const dsd_audio_params* params);
+void __wrap_dsd_audio_close(dsd_audio_stream* stream);
+int __wrap_dsd_audio_drain(dsd_audio_stream* stream);
+
+// NOLINTEND(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,misc-use-internal-linkage)
+
+static dsd_audio_stream*
+audio_wrap_existing_stream(int index) {
+    return (dsd_audio_stream*)&g_audio_wrap_existing_streams[index];
+}
+
+static void
+audio_wrap_reset(void) {
+    DSD_MEMSET(g_audio_wrap_events, 0, sizeof g_audio_wrap_events);
+    g_audio_wrap_event_count = 0;
+    g_audio_wrap_open_count = 0;
+}
+
+static void
+audio_wrap_record(int kind, dsd_audio_stream* stream, int async_output) {
+    if (g_audio_wrap_event_count >= (int)(sizeof g_audio_wrap_events / sizeof g_audio_wrap_events[0])) {
+        return;
+    }
+    g_audio_wrap_events[g_audio_wrap_event_count].kind = kind;
+    g_audio_wrap_events[g_audio_wrap_event_count].stream = stream;
+    g_audio_wrap_events[g_audio_wrap_event_count].async_output = async_output;
+    g_audio_wrap_event_count++;
+}
+
+// NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,misc-use-internal-linkage)
+dsd_audio_stream*
+__wrap_dsd_audio_open_output(const dsd_audio_params* params) {
+    int index = g_audio_wrap_open_count;
+    if (index >= (int)(sizeof g_audio_wrap_open_streams / sizeof g_audio_wrap_open_streams[0])) {
+        index = (int)(sizeof g_audio_wrap_open_streams / sizeof g_audio_wrap_open_streams[0]) - 1;
+    }
+    dsd_audio_stream* stream = (dsd_audio_stream*)&g_audio_wrap_open_streams[index];
+    g_audio_wrap_open_count++;
+    audio_wrap_record(DSD_AUDIO_WRAP_EVENT_OPEN, stream, params ? params->async_output : 0);
+    return stream;
+}
+
+void
+__wrap_dsd_audio_close(dsd_audio_stream* stream) {
+    audio_wrap_record(DSD_AUDIO_WRAP_EVENT_CLOSE, stream, 0);
+}
+
+int
+__wrap_dsd_audio_drain(dsd_audio_stream* stream) {
+    audio_wrap_record(DSD_AUDIO_WRAP_EVENT_DRAIN, stream, 0);
+    return 0;
+}
+
+// NOLINTEND(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,misc-use-internal-linkage)
+#endif
 
 static int
 expect_true(const char* label, int cond) {
@@ -798,6 +877,65 @@ test_drain_audio_output_guards_and_fd_sink(void) {
 }
 
 static int
+test_drain_audio_output_drains_all_local_streams(void) {
+#ifndef DSD_NEO_TEST_AUDIO_WRAP
+    return 0;
+#else
+    static dsd_opts opts = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.audio_out = 1;
+    opts.audio_out_type = 0;
+    opts.audio_out_stream = audio_wrap_existing_stream(0);
+    opts.audio_out_streamR = audio_wrap_existing_stream(1);
+    opts.audio_raw_out = audio_wrap_existing_stream(2);
+
+    audio_wrap_reset();
+    dsd_drain_audio_output(&opts);
+
+    int rc = expect_int_eq("local drain event count", g_audio_wrap_event_count, 3);
+    rc |= expect_int_eq("primary stream drained", g_audio_wrap_events[0].kind, DSD_AUDIO_WRAP_EVENT_DRAIN);
+    rc |= expect_true("primary drain stream", g_audio_wrap_events[0].stream == opts.audio_out_stream);
+    rc |= expect_int_eq("right stream drained", g_audio_wrap_events[1].kind, DSD_AUDIO_WRAP_EVENT_DRAIN);
+    rc |= expect_true("right drain stream", g_audio_wrap_events[1].stream == opts.audio_out_streamR);
+    rc |= expect_int_eq("raw stream drained", g_audio_wrap_events[2].kind, DSD_AUDIO_WRAP_EVENT_DRAIN);
+    rc |= expect_true("raw drain stream", g_audio_wrap_events[2].stream == opts.audio_raw_out);
+    return rc;
+#endif
+}
+
+static int
+test_reconfigure_drains_sync_output_before_policy_close(void) {
+#ifndef DSD_NEO_TEST_AUDIO_WRAP
+    return 0;
+#else
+    static dsd_opts opts = {0};
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.audio_out = 1;
+    opts.audio_out_type = 0;
+    opts.analog_only = 0;
+    opts.audio_output_async_policy = 0;
+    opts.audio_in_type = AUDIO_IN_PULSE;
+    opts.pulse_digi_rate_out = 8000;
+    opts.pulse_digi_out_channels = 1;
+    opts.audio_out_stream = audio_wrap_existing_stream(0);
+
+    audio_wrap_reset();
+    int rc =
+        expect_int_eq("reconfigure sync to async succeeds", dsd_audio_reconfigure_output_for_input_policy(&opts), 0);
+    rc |= expect_int_eq("sync reconfigure event count", g_audio_wrap_event_count, 3);
+    rc |= expect_int_eq("sync stream drained first", g_audio_wrap_events[0].kind, DSD_AUDIO_WRAP_EVENT_DRAIN);
+    rc |= expect_true("sync drain uses old stream", g_audio_wrap_events[0].stream == audio_wrap_existing_stream(0));
+    rc |= expect_int_eq("sync stream closed after drain", g_audio_wrap_events[1].kind, DSD_AUDIO_WRAP_EVENT_CLOSE);
+    rc |= expect_true("sync close uses old stream", g_audio_wrap_events[1].stream == audio_wrap_existing_stream(0));
+    rc |= expect_int_eq("async stream reopened", g_audio_wrap_events[2].kind, DSD_AUDIO_WRAP_EVENT_OPEN);
+    rc |= expect_int_eq("new open is async", g_audio_wrap_events[2].async_output, 1);
+    rc |= expect_int_eq("async policy recorded", opts.audio_output_async_policy, 1);
+    rc |= expect_true("new stream installed", opts.audio_out_stream == g_audio_wrap_events[2].stream);
+    return rc;
+#endif
+}
+
+static int
 test_write_synthesized_voice_clamps_and_writes_left_mono(void) {
     static dsd_opts opts = {0};
     static dsd_state state = {0};
@@ -1034,22 +1172,24 @@ test_open_audio_in_device_symbol_directory_falls_back_to_pulse(void) {
 static int
 test_async_output_policy_keeps_file_replays_synchronous(void) {
     int rc = 0;
-    rc |=
-        expect_int_eq("stdin output is synchronous", dsd_audio_input_type_uses_async_output(AUDIO_IN_STDIN, 0, ""), 0);
-    rc |= expect_int_eq("wav replay output is synchronous", dsd_audio_input_type_uses_async_output(AUDIO_IN_WAV, 0, ""),
+    rc |= expect_int_eq("stdin output is synchronous", dsd_audio_input_type_uses_async_output(AUDIO_IN_STDIN, 0, "", 0),
                         0);
+    rc |= expect_int_eq("wav replay output is synchronous",
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_WAV, 0, "", 0), 0);
     rc |= expect_int_eq("bin symbol replay output is synchronous",
-                        dsd_audio_input_type_uses_async_output(AUDIO_IN_SYMBOL_BIN, 0, ""), 0);
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_SYMBOL_BIN, 0, "", 0), 0);
     rc |= expect_int_eq("float symbol replay output is synchronous",
-                        dsd_audio_input_type_uses_async_output(AUDIO_IN_SYMBOL_FLT, 0, ""), 0);
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_SYMBOL_FLT, 0, "", 0), 0);
     rc |= expect_int_eq("null input output is synchronous",
-                        dsd_audio_input_type_uses_async_output(AUDIO_IN_NULL, 0, ""), 0);
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_NULL, 0, "", 0), 0);
     rc |= expect_int_eq("m17udp null input output may be async",
-                        dsd_audio_input_type_uses_async_output(AUDIO_IN_NULL, 0, "m17udp:127.0.0.1:17000"), 1);
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_NULL, 0, "m17udp:127.0.0.1:17000", 0), 1);
+    rc |= expect_int_eq("m17 ip null input stays async after device mutation",
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_NULL, 0, "pulse", 1), 1);
     rc |= expect_int_eq("pulse input output may be async",
-                        dsd_audio_input_type_uses_async_output(AUDIO_IN_PULSE, 0, ""), 1);
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_PULSE, 0, "", 0), 1);
     rc |= expect_int_eq("playfiles forces synchronous output",
-                        dsd_audio_input_type_uses_async_output(AUDIO_IN_PULSE, 1, ""), 0);
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_PULSE, 1, "", 0), 0);
     return rc;
 }
 
@@ -1074,6 +1214,8 @@ main(void) {
     rc |= test_play_synthesized_voice_fd_writes_pending_pcm_and_resets_index();
     rc |= test_play_synthesized_voice_bad_fd_drops_pending_pcm();
     rc |= test_drain_audio_output_guards_and_fd_sink();
+    rc |= test_drain_audio_output_drains_all_local_streams();
+    rc |= test_reconfigure_drains_sync_output_before_policy_close();
     rc |= test_write_synthesized_voice_clamps_and_writes_left_mono();
     rc |= test_write_synthesized_voice_r_clamps_and_writes_right_mono();
     rc |= test_write_synthesized_voice_ms_duplicates_left_into_stereo_wav();

--- a/tests/core/test_core_audio_gain.c
+++ b/tests/core/test_core_audio_gain.c
@@ -1034,18 +1034,22 @@ test_open_audio_in_device_symbol_directory_falls_back_to_pulse(void) {
 static int
 test_async_output_policy_keeps_file_replays_synchronous(void) {
     int rc = 0;
-    rc |= expect_int_eq("stdin output is synchronous", dsd_audio_input_type_uses_async_output(AUDIO_IN_STDIN, 0), 0);
-    rc |= expect_int_eq("wav replay output is synchronous", dsd_audio_input_type_uses_async_output(AUDIO_IN_WAV, 0), 0);
+    rc |=
+        expect_int_eq("stdin output is synchronous", dsd_audio_input_type_uses_async_output(AUDIO_IN_STDIN, 0, ""), 0);
+    rc |= expect_int_eq("wav replay output is synchronous", dsd_audio_input_type_uses_async_output(AUDIO_IN_WAV, 0, ""),
+                        0);
     rc |= expect_int_eq("bin symbol replay output is synchronous",
-                        dsd_audio_input_type_uses_async_output(AUDIO_IN_SYMBOL_BIN, 0), 0);
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_SYMBOL_BIN, 0, ""), 0);
     rc |= expect_int_eq("float symbol replay output is synchronous",
-                        dsd_audio_input_type_uses_async_output(AUDIO_IN_SYMBOL_FLT, 0), 0);
-    rc |=
-        expect_int_eq("null input output is synchronous", dsd_audio_input_type_uses_async_output(AUDIO_IN_NULL, 0), 0);
-    rc |=
-        expect_int_eq("pulse input output may be async", dsd_audio_input_type_uses_async_output(AUDIO_IN_PULSE, 0), 1);
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_SYMBOL_FLT, 0, ""), 0);
+    rc |= expect_int_eq("null input output is synchronous",
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_NULL, 0, ""), 0);
+    rc |= expect_int_eq("m17udp null input output may be async",
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_NULL, 0, "m17udp:127.0.0.1:17000"), 1);
+    rc |= expect_int_eq("pulse input output may be async",
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_PULSE, 0, ""), 1);
     rc |= expect_int_eq("playfiles forces synchronous output",
-                        dsd_audio_input_type_uses_async_output(AUDIO_IN_PULSE, 1), 0);
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_PULSE, 1, ""), 0);
     return rc;
 }
 

--- a/tests/core/test_core_audio_gain.c
+++ b/tests/core/test_core_audio_gain.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <sys/types.h>
 
+#include "../../src/core/audio/dsd_audio_internal.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -1030,6 +1031,24 @@ test_open_audio_in_device_symbol_directory_falls_back_to_pulse(void) {
     return rc;
 }
 
+static int
+test_async_output_policy_keeps_file_replays_synchronous(void) {
+    int rc = 0;
+    rc |= expect_int_eq("stdin output is synchronous", dsd_audio_input_type_uses_async_output(AUDIO_IN_STDIN, 0), 0);
+    rc |= expect_int_eq("wav replay output is synchronous", dsd_audio_input_type_uses_async_output(AUDIO_IN_WAV, 0), 0);
+    rc |= expect_int_eq("bin symbol replay output is synchronous",
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_SYMBOL_BIN, 0), 0);
+    rc |= expect_int_eq("float symbol replay output is synchronous",
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_SYMBOL_FLT, 0), 0);
+    rc |=
+        expect_int_eq("null input output is synchronous", dsd_audio_input_type_uses_async_output(AUDIO_IN_NULL, 0), 0);
+    rc |=
+        expect_int_eq("pulse input output may be async", dsd_audio_input_type_uses_async_output(AUDIO_IN_PULSE, 0), 1);
+    rc |= expect_int_eq("playfiles forces synchronous output",
+                        dsd_audio_input_type_uses_async_output(AUDIO_IN_PULSE, 1), 0);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -1058,5 +1077,6 @@ main(void) {
     rc |= test_open_audio_in_device_bin_symbol_file_resets_replay_state();
     rc |= test_open_audio_in_device_float_symbol_file_preserves_soft_metadata();
     rc |= test_open_audio_in_device_symbol_directory_falls_back_to_pulse();
+    rc |= test_async_output_policy_keeps_file_replays_synchronous();
     return rc;
 }

--- a/tests/dsp/test_dsp_symbol_replay.c
+++ b/tests/dsp/test_dsp_symbol_replay.c
@@ -63,6 +63,13 @@ openAudioInput(dsd_opts* opts) {
     return -1;
 }
 
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) {
+    (void)opts;
+    return 0;
+}
+
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 cleanupAndExit(dsd_opts* opts, dsd_state* state) {

--- a/tests/dsp/test_dsp_wav_input_eof.c
+++ b/tests/dsp/test_dsp_wav_input_eof.c
@@ -40,6 +40,13 @@ openAudioInput(dsd_opts* opts) {
     return -1;
 }
 
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) {
+    (void)opts;
+    return 0;
+}
+
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 cleanupAndExit(dsd_opts* opts, dsd_state* state) {

--- a/tests/dsp/test_frame_sync_dmr_wav_rate.c
+++ b/tests/dsp/test_frame_sync_dmr_wav_rate.c
@@ -40,6 +40,12 @@ openAudioInput(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
     return -1;
 }
 
+int
+dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    return 0;
+}
+
 void
 cleanupAndExit(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
     (void)opts;

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -43,6 +43,12 @@ openAudioInput(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
     return -1;
 }
 
+int
+dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    return 0;
+}
+
 void
 cleanupAndExit(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
     (void)opts;

--- a/tests/dsp/test_frame_sync_m17.c
+++ b/tests/dsp/test_frame_sync_m17.c
@@ -43,6 +43,12 @@ openAudioInput(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
     return -1;
 }
 
+int
+dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    return 0;
+}
+
 void
 cleanupAndExit(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
     (void)opts;

--- a/tests/dsp/test_frame_sync_p25p2_rtl.c
+++ b/tests/dsp/test_frame_sync_p25p2_rtl.c
@@ -46,6 +46,12 @@ openAudioInput(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
     return -1;
 }
 
+int
+dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    return 0;
+}
+
 void
 cleanupAndExit(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
     (void)opts;

--- a/tests/dsp/test_rtl_symbol_cache_generation.c
+++ b/tests/dsp/test_rtl_symbol_cache_generation.c
@@ -58,6 +58,13 @@ openAudioInput(dsd_opts* opts) {
     return -1;
 }
 
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) {
+    (void)opts;
+    return 0;
+}
+
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 cleanupAndExit(dsd_opts* opts, dsd_state* state) {

--- a/tests/platform/test_platform_audio_pulse_guards.c
+++ b/tests/platform/test_platform_audio_pulse_guards.c
@@ -7,8 +7,12 @@
 #include <dsd-neo/platform/audio.h>
 
 #include <assert.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+
+_Static_assert(offsetof(dsd_audio_params, async_output) > offsetof(dsd_audio_params, app_name),
+               "async_output must follow existing positional initializer fields");
 
 static dsd_audio_params
 valid_params(void) {
@@ -95,11 +99,24 @@ test_stream_operation_guards(void) {
     dsd_audio_close(NULL);
 }
 
+static void
+test_audio_params_preserves_positional_initializer_prefix(void) {
+    dsd_audio_params params = {48000, 1, 16, "pulse-dev", "dsd-neo-positional-test", 0};
+
+    assert(params.sample_rate == 48000);
+    assert(params.channels == 1);
+    assert(params.bits_per_sample == 16);
+    assert(strcmp(params.device, "pulse-dev") == 0);
+    assert(strcmp(params.app_name, "dsd-neo-positional-test") == 0);
+    assert(params.async_output == 0);
+}
+
 int
 main(void) {
     test_backend_lifecycle_and_error_reset();
     test_open_parameter_guards();
     test_stream_operation_guards();
+    test_audio_params_preserves_positional_initializer_prefix();
     dsd_audio_cleanup();
     return 0;
 }

--- a/tests/platform/test_platform_audio_pulse_helpers.c
+++ b/tests/platform/test_platform_audio_pulse_helpers.c
@@ -327,7 +327,7 @@ test_pulse_output_attr_and_async_buffers(void) {
     DSD_MEMSET(&stream, 0, sizeof(stream));
     stream.sample_rate = 8000;
     stream.channels = 1;
-    pulse_output_init_async_state(&stream);
+    pulse_output_init_async_state(&stream, 1);
     assert(stream.use_async == 1);
     assert(stream.stop == 0);
     assert(stream.drain_requested == 0);
@@ -346,6 +346,10 @@ test_pulse_output_attr_and_async_buffers(void) {
     assert(stream.chunk == NULL);
     assert(stream.ring == NULL);
     assert(stream.ring_samples_capacity == 0);
+
+    DSD_MEMSET(&stream, 0, sizeof(stream));
+    pulse_output_init_async_state(&stream, 0);
+    assert(stream.use_async == 0);
 }
 
 static void
@@ -419,6 +423,27 @@ pulse_test_valid_params(void) {
     params.bits_per_sample = 16;
     params.app_name = "dsd-neo-pulse-helper-test";
     return params;
+}
+
+static void
+test_pulse_sync_output_open_uses_blocking_write(void) {
+    dsd_audio_params params = pulse_test_valid_params();
+    int16_t samples[4] = {1, 2, 3, 4};
+
+    params.async_output = 0;
+    reset_pa_simple_fakes();
+
+    dsd_audio_stream* stream = dsd_audio_open_output(&params);
+    assert(stream != NULL);
+    assert(stream->use_async == 0);
+
+    assert(dsd_audio_write(stream, samples, 4) == 4);
+    assert(g_pa_simple_write_calls == 1);
+
+    assert(dsd_audio_drain(stream) == 0);
+    assert(g_pa_simple_drain_calls == 1);
+
+    dsd_audio_close(stream);
 }
 
 static void
@@ -602,6 +627,7 @@ main(void) {
     test_pulse_ring_wrap_read_and_drop();
     test_pulse_output_attr_and_async_buffers();
     test_pulse_async_write_policy();
+    test_pulse_sync_output_open_uses_blocking_write();
     test_pulse_simple_error_paths();
     test_pulse_async_error_paths();
     test_pulse_enum_callbacks_and_guards();

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -284,6 +284,44 @@ capture_regular_flco(uint8_t type, char* out, size_t out_size) {
 }
 
 static int
+capture_ms_direct_flco(char* out, size_t out_size) {
+    if (out == NULL || out_size == 0U) {
+        return -1;
+    }
+    out[0] = '\0';
+
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    state.dmr_ms_mode = 1;
+
+    dsd_test_capture_stderr cap;
+    if (dsd_test_capture_stderr_begin(&cap, "dmr_ms_direct_flco") != 0) {
+        return -1;
+    }
+
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+
+    int rc = dsd_test_capture_stderr_end(&cap);
+    if (rc != 0) {
+        (void)remove(cap.path);
+        return -1;
+    }
+
+    rc = read_file_to_buffer(cap.path, out, out_size);
+    (void)remove(cap.path);
+    if (irr != 0U) {
+        return -1;
+    }
+    return rc;
+}
+
+static int
 capture_hytera_basic_key_output(unsigned int slot, uint8_t segment_count, char* out, size_t out_size) {
     if (out == NULL || out_size == 0U || slot > 1U) {
         return -1;
@@ -335,6 +373,14 @@ test_flco_output_uses_real_newlines(void) {
     assert(capture_regular_flco(1U, out, sizeof(out)) == 0);
     assert(strchr(out, '\n') != NULL);
     assert(strstr(out, "\\n") == NULL);
+}
+
+static void
+test_ms_direct_flco_reports_internal_slot_one(void) {
+    char out[2048];
+    assert(capture_ms_direct_flco(out, sizeof(out)) == 0);
+    assert(strstr(out, " SLOT 1 ") != NULL);
+    assert(strstr(out, " SLOT ?") == NULL);
 }
 
 static void
@@ -917,6 +963,7 @@ main(void) {
     InitAllFecFunction();
 
     test_flco_output_uses_real_newlines();
+    test_ms_direct_flco_reports_internal_slot_one();
     test_hytera_basic_key_output_uses_segment_count();
     test_kirisun_flco_sets_late_entry_mode();
     test_hytera_enhanced_flco_uses_secondary_checksum();


### PR DESCRIPTION
## Summary

This fixes sped-up/choppy live playback when decoding finite inputs such as WAV and symbol replay files. Those inputs can decode faster than real time, so sending them through the low-latency async output queue could overrun the queue and drop older decoded samples.

The fix keeps live/radio inputs on async output, but routes finite replay inputs through blocking Pulse/PortAudio output so playback is paced by the sink.

Also included:
- keep the public audio parameter initializer prefix stable by appending the new output flag
- add regression coverage for the output policy and blocking write path
- report the internal slot for DMR MS/direct-mode FLCO output instead of `SLOT ?`
- gate DMR trunk state-machine status logs to trunking mode

## Validation

- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure -R 'CORE_AUDIO_GAIN|PLATFORM_AUDIO_PULSE_HELPERS|PLATFORM_AUDIO_PULSE_GUARDS|DMR_FLCO_PRIVACY_MODES|DMR_T3_SM_|DMR_SYNC_DISPATCH|DMR_MS_DATA|FRAME_SYNC_DMR_WAV_RATE'`
- `ctest --preset dev-debug --output-on-failure`
- pre-push guardrails, clang-format, clang-tidy, cppcheck, IWYU, and lizard