### PR TITLE
p25: clamp phase2 MAC octets

### DIFF
--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -4099,7 +4099,11 @@ p25p2_vpdu_advance_segment(p25p2_vpdu_ctx* ctx) {
 
 void
 process_MAC_VPDU(dsd_opts* opts, dsd_state* state, int type, unsigned long long int mac[24]) {
-    const unsigned long long int* MAC = mac;
+    unsigned long long int mac_octets[24] = {0};
+    for (int bi = 0; bi < 24; bi++) {
+        mac_octets[bi] = mac[bi] & 0xFFu;
+    }
+    const unsigned long long int* MAC = mac_octets;
     //handle variable content MAC PDUs (Active, Idle, Hangtime, or Signal)
     //use type to specify SACCH or FACCH, so we know if we should invert the currentslot when assigning ids etc
 
@@ -4107,7 +4111,7 @@ process_MAC_VPDU(dsd_opts* opts, dsd_state* state, int type, unsigned long long 
     // 2 = Manufacturer Message, 3 Phase 1 OSP/ISP extended/explicit
 
     struct p25p2_mac_result mac_res;
-    if (p25p2_mac_parse(type, mac, &mac_res) != 0) {
+    if (p25p2_mac_parse(type, MAC, &mac_res) != 0) {
         return;
     }
 
@@ -4115,7 +4119,7 @@ process_MAC_VPDU(dsd_opts* opts, dsd_state* state, int type, unsigned long long 
         .opts = opts,
         .state = state,
         .type = type,
-        .mac = mac,
+        .mac = mac_octets,
         .mac_res = &mac_res,
         .len_a = mac_res.len_a,
         .len_b = mac_res.len_b,

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -83,17 +83,17 @@ p25p2_xcch_tg_from_mac(const unsigned long long int mac[24]) {
 
 static int
 p25p2_xcch_extract_opcode(const int* payload) {
-    return (payload[0] << 2) | (payload[1] << 1) | payload[2];
+    return ((payload[0] & 1) << 2) | ((payload[1] & 1) << 1) | (payload[2] & 1);
 }
 
 static int
 p25p2_xcch_extract_mac_offset(const int* payload) {
-    return (payload[3] << 2) | (payload[4] << 1) | payload[5];
+    return ((payload[3] & 1) << 2) | ((payload[4] & 1) << 1) | (payload[5] & 1);
 }
 
 static int
 p25p2_xcch_extract_res(const int* payload) {
-    return (payload[6] << 1) | payload[7];
+    return ((payload[6] & 1) << 1) | (payload[7] & 1);
 }
 
 static void
@@ -103,14 +103,15 @@ p25p2_xcch_unpack_mac_bits(const int* payload, int full_octets, int tail_start, 
 
     for (int j = 0; j < full_octets; j++) {
         for (int i = 0; i < 8; i++) {
-            byte = (byte << 1) | payload[k++];
+            byte = (byte << 1) | (payload[k++] & 1);
         }
         mac[j] = (unsigned long long int)byte;
         byte = 0;
     }
 
-    mac[full_octets] = (unsigned long long int)((payload[tail_start] << 7) | (payload[tail_start + 1] << 6)
-                                                | (payload[tail_start + 2] << 5) | (payload[tail_start + 3] << 4));
+    mac[full_octets] =
+        (unsigned long long int)(((payload[tail_start] & 1) << 7) | ((payload[tail_start + 1] & 1) << 6)
+                                 | ((payload[tail_start + 2] & 1) << 5) | ((payload[tail_start + 3] & 1) << 4));
 }
 
 static void

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -583,8 +583,54 @@ main(void) {
         process_MAC_VPDU(&opts, &state, 0, MAC);
         rc |= expect_true("0x25 encrypted multi suppressed tune", opts.p25_is_tuned == 0);
         rc |= expect_eq_long("0x25 encrypted multi no vc", state.p25_vc_freq[0], 0);
+        rc |= expect_contains("0x25 encrypted multi active ch1", state.active_channel[0], "Active Ch: 100A");
+        rc |= expect_contains("0x25 encrypted multi active ch2", state.active_channel[0], "Ch: 100B");
         rc |= expect_contains("0x25 encrypted multi active ch group1", state.active_channel[0], "TG: 4660");
         rc |= expect_contains("0x25 encrypted multi active ch group2", state.active_channel[0], "TG: 22136");
+    }
+
+    // Case M2: MAC words are specified as octets. If high bits leak into a
+    // word, the VPDU decoder must mask them before rendering active channels.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        opts.trunk_tune_enc_calls = 1;
+        state.p25_cc_freq = cc;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+
+        MAC[1] = 0x25; // Group Voice Channel Grant Update Multiple - Explicit
+        MAC[2] = 0x00;
+        MAC[3] = 0x10;
+        MAC[4] = 0x0A;
+        MAC[5] = 0x00;
+        MAC[6] = 0x00;
+        MAC[7] = 0xCE6387; // group high octet should become 0x87
+        MAC[8] = 0x00;
+        MAC[9] = 0x00;
+        MAC[10] = 0xBF776F; // channel high octet should become 0x6F
+        MAC[11] = 0x10;
+        MAC[12] = 0x00;
+        MAC[13] = 0x00;
+        MAC[14] = 0x00;
+        MAC[15] = 0x3E;
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_contains("0x25 octet clamp active ch1", state.active_channel[0], "Active Ch: 100A");
+        rc |= expect_contains("0x25 octet clamp active ch2", state.active_channel[0], "Ch: 6F10");
+        rc |= expect_contains("0x25 octet clamp group1", state.active_channel[0], "TG: 34560");
+        rc |= expect_contains("0x25 octet clamp group2", state.active_channel[0], "TG: 62");
     }
 
     // Case N: encrypted implicit triple updates are also blocked before candidate


### PR DESCRIPTION
## Summary

- Normalize P25 Phase 2 MAC words to octets before VPDU parsing and dispatch.
- Mask XCCH payload values down to bits while unpacking MAC bytes.
- Add regression coverage for multi-grant active-channel rendering when MAC words carry high-bit contamination.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented. Parser-scoped change with focused tests and pre-push guardrails.
- [x] High-risk areas touched are marked: parser.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. No suppressions added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [ ] `cmake --build --preset dev-debug -j`
- [ ] `ctest --preset dev-debug --output-on-failure`
- [ ] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes
- [x] `ctest --preset dev-debug -R 'P25_P2_(VPDU_GRANTS|XCCH_HELPERS)' --output-on-failure`
- [x] Pre-push changed-file guardrails: clang-format, clang-tidy, cppcheck strict, IWYU strict, GCC analyzer strict, Semgrep strict, Lizard complexity

## Risk

- Security/dependency impact: none expected.
- CLI/UI behavior impact: prevents malformed P25 Phase 2 active-channel text from displaying impossible channel and talkgroup values.
- Compatibility or packaging impact: none expected.
