### PR TITLE
frontend: add terminal-neutral boundary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ option(
 )
 option(DSD_ENABLE_RTLSDR "Enable RTL-SDR backend support" ON)
 option(DSD_ENABLE_SOAPYSDR "Enable SoapySDR backend support" ON)
+option(DSD_ENABLE_TERMINAL_UI "Enable ncurses/PDCurses terminal frontend" ON)
 set(DSD_SOAPYSDR_MIN_VERSION "0.8.1")
 option(
     DSD_REQUIRE_RTLSDR
@@ -704,58 +705,68 @@ message(STATUS "Radio pipeline available: ${DSD_HAS_RADIO}")
 # Curses library selection:
 # - Windows: PDCurses
 # - POSIX: ncurses via CMake's FindCurses
-if(WIN32)
-    find_package(PDCurses REQUIRED)
-    set(CURSES_LIBRARIES PDCurses::PDCurses)
-    set(CURSES_INCLUDE_DIRS ${PDCURSES_INCLUDE_DIRS})
-    add_compile_definitions(DSD_USE_PDCURSES)
-    include(CheckCSourceCompiles)
-    set(_CMAKE_REQUIRED_DEFINITIONS_SAVE "${CMAKE_REQUIRED_DEFINITIONS}")
-    set(_CMAKE_REQUIRED_INCLUDES_SAVE "${CMAKE_REQUIRED_INCLUDES}")
-    set(_CMAKE_REQUIRED_LIBRARIES_SAVE "${CMAKE_REQUIRED_LIBRARIES}")
-    set(CMAKE_REQUIRED_DEFINITIONS -DPDC_WIDE)
-    set(CMAKE_REQUIRED_INCLUDES ${PDCURSES_INCLUDE_DIRS})
-    set(CMAKE_REQUIRED_LIBRARIES PDCurses::PDCurses)
-    unset(DSD_HAS_PDCURSES_WIDE_API CACHE)
-    check_c_source_compiles(
+if(DSD_ENABLE_TERMINAL_UI)
+    if(WIN32)
+        find_package(PDCurses REQUIRED)
+        set(CURSES_LIBRARIES PDCurses::PDCurses)
+        set(CURSES_INCLUDE_DIRS ${PDCURSES_INCLUDE_DIRS})
+        add_compile_definitions(DSD_USE_PDCURSES)
+        include(CheckCSourceCompiles)
+        set(_CMAKE_REQUIRED_DEFINITIONS_SAVE "${CMAKE_REQUIRED_DEFINITIONS}")
+        set(_CMAKE_REQUIRED_INCLUDES_SAVE "${CMAKE_REQUIRED_INCLUDES}")
+        set(_CMAKE_REQUIRED_LIBRARIES_SAVE "${CMAKE_REQUIRED_LIBRARIES}")
+        set(CMAKE_REQUIRED_DEFINITIONS -DPDC_WIDE)
+        set(CMAKE_REQUIRED_INCLUDES ${PDCURSES_INCLUDE_DIRS})
+        set(CMAKE_REQUIRED_LIBRARIES PDCurses::PDCurses)
+        unset(DSD_HAS_PDCURSES_WIDE_API CACHE)
+        check_c_source_compiles(
+            "
+            #include <wchar.h>
+            #include <curses.h>
+            int main(void) {
+                static const wchar_t glyph[] = {0x2588, 0};
+                return addwstr(glyph);
+            }
         "
-        #include <wchar.h>
-        #include <curses.h>
-        int main(void) {
-            static const wchar_t glyph[] = {0x2588, 0};
-            return addwstr(glyph);
-        }
-    "
-        DSD_HAS_PDCURSES_WIDE_API
-    )
-    set(CMAKE_REQUIRED_DEFINITIONS "${_CMAKE_REQUIRED_DEFINITIONS_SAVE}")
-    set(CMAKE_REQUIRED_INCLUDES "${_CMAKE_REQUIRED_INCLUDES_SAVE}")
-    set(CMAKE_REQUIRED_LIBRARIES "${_CMAKE_REQUIRED_LIBRARIES_SAVE}")
-    unset(_CMAKE_REQUIRED_DEFINITIONS_SAVE)
-    unset(_CMAKE_REQUIRED_INCLUDES_SAVE)
-    unset(_CMAKE_REQUIRED_LIBRARIES_SAVE)
-    if(DSD_HAS_PDCURSES_WIDE_API)
-        add_compile_definitions(DSD_HAS_PDCURSES_WIDE_API=1 PDC_WIDE)
+            DSD_HAS_PDCURSES_WIDE_API
+        )
+        set(CMAKE_REQUIRED_DEFINITIONS "${_CMAKE_REQUIRED_DEFINITIONS_SAVE}")
+        set(CMAKE_REQUIRED_INCLUDES "${_CMAKE_REQUIRED_INCLUDES_SAVE}")
+        set(CMAKE_REQUIRED_LIBRARIES "${_CMAKE_REQUIRED_LIBRARIES_SAVE}")
+        unset(_CMAKE_REQUIRED_DEFINITIONS_SAVE)
+        unset(_CMAKE_REQUIRED_INCLUDES_SAVE)
+        unset(_CMAKE_REQUIRED_LIBRARIES_SAVE)
+        if(DSD_HAS_PDCURSES_WIDE_API)
+            add_compile_definitions(DSD_HAS_PDCURSES_WIDE_API=1 PDC_WIDE)
+        endif()
+        message(STATUS "Curses backend: PDCurses")
+        message(
+            STATUS
+            "PDCurses wide-character API: ${DSD_HAS_PDCURSES_WIDE_API}"
+        )
+    else()
+        find_package(Curses REQUIRED)
+        # Some ncurses installs do not provide a top-level curses.h shim in the
+        # include root. Our code includes <curses.h>, so add the ncursesw subdir
+        # when needed.
+        if(CURSES_NEED_WIDE)
+            foreach(_curses_inc IN LISTS CURSES_INCLUDE_DIRS)
+                if(
+                    EXISTS "${_curses_inc}/ncursesw/curses.h"
+                    AND NOT EXISTS "${_curses_inc}/curses.h"
+                )
+                    list(APPEND CURSES_INCLUDE_DIRS "${_curses_inc}/ncursesw")
+                endif()
+            endforeach()
+            list(REMOVE_DUPLICATES CURSES_INCLUDE_DIRS)
+        endif()
+        message(STATUS "Curses backend: ncurses")
     endif()
-    message(STATUS "Curses backend: PDCurses")
-    message(STATUS "PDCurses wide-character API: ${DSD_HAS_PDCURSES_WIDE_API}")
 else()
-    find_package(Curses REQUIRED)
-    # Some ncurses installs do not provide a top-level curses.h shim in the
-    # include root. Our code includes <curses.h>, so add the ncursesw subdir
-    # when needed.
-    if(CURSES_NEED_WIDE)
-        foreach(_curses_inc IN LISTS CURSES_INCLUDE_DIRS)
-            if(
-                EXISTS "${_curses_inc}/ncursesw/curses.h"
-                AND NOT EXISTS "${_curses_inc}/curses.h"
-            )
-                list(APPEND CURSES_INCLUDE_DIRS "${_curses_inc}/ncursesw")
-            endif()
-        endforeach()
-        list(REMOVE_DUPLICATES CURSES_INCLUDE_DIRS)
-    endif()
-    message(STATUS "Curses backend: ncurses")
+    set(CURSES_INCLUDE_DIRS "")
+    set(CURSES_LIBRARIES "")
+    set(DSD_HAS_PDCURSES_WIDE_API OFF)
+    message(STATUS "Terminal UI disabled: curses discovery skipped")
 endif()
 
 find_package(CODEC2)
@@ -784,7 +795,7 @@ endif()
 
 # Aggregate include directories; when using the modern package, we still add
 # the mbelib-neo leaf include directory so #include <mbelib.h> continues to work.
-set(_PUBLIC_INCLUDES ${LIBSNDFILE_INCLUDE_DIR} ${CURSES_INCLUDE_DIRS})
+set(_PUBLIC_INCLUDES ${LIBSNDFILE_INCLUDE_DIR})
 if(MBE_INCLUDE_DIR)
     list(APPEND _PUBLIC_INCLUDES ${MBE_INCLUDE_DIR})
 endif()
@@ -802,12 +813,7 @@ else()
     set(AUDIO_LIBS ${PULSEAUDIO_SIMPLE_LIBRARY} ${PULSEAUDIO_LIBRARY})
 endif()
 
-set(LIBS
-    ${MBE_LINK_TARGET}
-    ${LIBSNDFILE_LIBRARIES}
-    ${AUDIO_LIBS}
-    ${CURSES_LIBRARIES}
-)
+set(LIBS ${MBE_LINK_TARGET} ${LIBSNDFILE_LIBRARIES} ${AUDIO_LIBS})
 
 # -----------------------------------------------------------------------------
 # Optional feature interface targets

--- a/apps/dsd-cli/CMakeLists.txt
+++ b/apps/dsd-cli/CMakeLists.txt
@@ -1,17 +1,19 @@
 add_executable(dsd-neo)
 
-target_sources(dsd-neo PRIVATE main.c)
+target_sources(dsd-neo PRIVATE main.c frontend.c)
 
 # Link against modular libraries
 target_link_libraries(
     dsd-neo
-    PRIVATE
-        dsd-neo_engine
-        dsd-neo_ui_terminal
-        dsd-neo_feature_rtlsdr
-        dsd-neo_feature_codec2
-        ${LIBS}
+    PRIVATE dsd-neo_engine dsd-neo_feature_rtlsdr dsd-neo_feature_codec2 ${LIBS}
 )
+
+if(DSD_ENABLE_TERMINAL_UI)
+    target_compile_definitions(dsd-neo PRIVATE DSD_CLI_HAS_TERMINAL_UI=1)
+    target_link_libraries(dsd-neo PRIVATE dsd-neo_ui_terminal)
+else()
+    target_compile_definitions(dsd-neo PRIVATE DSD_CLI_HAS_TERMINAL_UI=0)
+endif()
 
 # Target include directories (prefer target-scoped over global)
 target_include_directories(dsd-neo SYSTEM PRIVATE ${_PUBLIC_INCLUDES})

--- a/apps/dsd-cli/frontend.c
+++ b/apps/dsd-cli/frontend.c
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: ISC
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "frontend.h"
+
+#include <dsd-neo/core/opts.h>
+#include <stdio.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/engine/engine.h"
+
+#if DSD_CLI_HAS_TERMINAL_UI
+#include <dsd-neo/app_control/snapshot.h>
+#include <dsd-neo/ui/ui_async.h>
+#endif
+
+#if DSD_CLI_HAS_TERMINAL_UI
+static int
+dsd_cli_terminal_start(dsd_opts* opts, dsd_state* state, void* context) {
+    (void)context;
+    if (!dsd_opts_frontend_is_terminal(opts)) {
+        return 0;
+    }
+    if (ui_start(opts, state) != 0) {
+        DSD_FPRINTF(stderr, "Failed to start terminal UI\n");
+        return -1;
+    }
+    return 0;
+}
+
+static void
+dsd_cli_terminal_stop(dsd_opts* opts, dsd_state* state, void* context) {
+    (void)opts;
+    (void)state;
+    (void)context;
+    ui_stop();
+}
+#endif
+
+int
+dsd_cli_frontend_select(dsd_opts* opts, dsd_state* state, dsd_engine_lifecycle_hooks* hooks_storage,
+                        const dsd_engine_lifecycle_hooks** out_hooks) {
+    if (!opts || !hooks_storage || !out_hooks) {
+        return -1;
+    }
+    *out_hooks = NULL;
+    if (!dsd_opts_frontend_active(opts)) {
+        return 0;
+    }
+    if (!dsd_opts_frontend_is_terminal(opts)) {
+        DSD_FPRINTF(stderr, "Unsupported frontend kind: %d\n", (int)opts->frontend_kind);
+        return -1;
+    }
+
+#if DSD_CLI_HAS_TERMINAL_UI
+    if (state) {
+        dsd_app_telemetry_publish_opts_snapshot(opts);
+        dsd_app_telemetry_publish_snapshot(state);
+    }
+    *hooks_storage = (dsd_engine_lifecycle_hooks){
+        .start = dsd_cli_terminal_start,
+        .stop = dsd_cli_terminal_stop,
+        .context = NULL,
+    };
+    *out_hooks = hooks_storage;
+    return 0;
+#else
+    (void)state;
+    DSD_FPRINTF(stderr, "Terminal frontend requested, but this build was configured with DSD_ENABLE_TERMINAL_UI=OFF\n");
+    return -1;
+#endif
+}

--- a/apps/dsd-cli/frontend.h
+++ b/apps/dsd-cli/frontend.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: ISC
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef DSD_NEO_APPS_DSD_CLI_FRONTEND_H_
+#define DSD_NEO_APPS_DSD_CLI_FRONTEND_H_
+
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/engine/engine.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int dsd_cli_frontend_select(dsd_opts* opts, dsd_state* state, dsd_engine_lifecycle_hooks* hooks_storage,
+                            const dsd_engine_lifecycle_hooks** out_hooks);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_APPS_DSD_CLI_FRONTEND_H_ */

--- a/apps/dsd-cli/main.c
+++ b/apps/dsd-cli/main.c
@@ -25,33 +25,12 @@
 #include <dsd-neo/engine/engine.h>
 #include <dsd-neo/runtime/bootstrap.h>
 #include <dsd-neo/runtime/exitflag.h>
-#include <dsd-neo/ui/ui_async.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
-
-static int
-dsd_cli_ui_start(dsd_opts* opts, dsd_state* state, void* context) {
-    (void)context;
-    if (opts->use_ncurses_terminal != 1) {
-        return 0;
-    }
-    if (ui_start(opts, state) != 0) {
-        DSD_FPRINTF(stderr, "Failed to start ncurses UI\n");
-        return -1;
-    }
-    return 0;
-}
-
-static void
-dsd_cli_ui_stop(dsd_opts* opts, dsd_state* state, void* context) {
-    (void)opts;
-    (void)state;
-    (void)context;
-    ui_stop();
-}
+#include "frontend.h"
 
 int
 main(int argc, char** argv) {
@@ -81,12 +60,14 @@ main(int argc, char** argv) {
         free(state);
         return exit_rc;
     }
-    dsd_engine_lifecycle_hooks lifecycle_hooks = {
-        .start = dsd_cli_ui_start,
-        .stop = dsd_cli_ui_stop,
-        .context = NULL,
-    };
-    const dsd_engine_lifecycle_hooks* run_hooks = opts->use_ncurses_terminal == 1 ? &lifecycle_hooks : NULL;
+    dsd_engine_lifecycle_hooks lifecycle_hooks = {0};
+    const dsd_engine_lifecycle_hooks* run_hooks = NULL;
+    if (dsd_cli_frontend_select(opts, state, &lifecycle_hooks, &run_hooks) != 0) {
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
     int rc = dsd_engine_run_with_lifecycle(opts, state, run_hooks);
     freeState(state);
     free(opts);

--- a/cmake/arch_rules.cmake
+++ b/cmake/arch_rules.cmake
@@ -116,6 +116,20 @@ foreach(_ARCH_RULES_REL IN LISTS _ARCH_RULES_FILES)
         set(_ARCH_RULES_ENGINE_FORBIDDEN_AREA ON)
     endif()
 
+    set(_ARCH_RULES_FRONTEND_KIND_BACKEND_AREA OFF)
+    if(
+        _ARCH_RULES_REL
+            MATCHES
+            "^(src/dsp/|src/protocol/|src/engine/|include/dsd-neo/dsp/|include/dsd-neo/protocol/|include/dsd-neo/engine/)"
+    )
+        set(_ARCH_RULES_FRONTEND_KIND_BACKEND_AREA ON)
+    endif()
+
+    set(_ARCH_RULES_UI_RTL_FORBIDDEN_AREA OFF)
+    if(_ARCH_RULES_REL MATCHES "^(src/ui/|include/dsd-neo/ui/)")
+        set(_ARCH_RULES_UI_RTL_FORBIDDEN_AREA ON)
+    endif()
+
     file(
         STRINGS "${_ARCH_RULES_ABS}"
         _ARCH_RULES_EXIT_LINES
@@ -138,6 +152,62 @@ foreach(_ARCH_RULES_REL IN LISTS _ARCH_RULES_FILES)
         )
         math(EXPR _ARCH_RULES_VIOLATIONS "${_ARCH_RULES_VIOLATIONS} + 1")
     endforeach()
+
+    if(_ARCH_RULES_FRONTEND_KIND_BACKEND_AREA)
+        file(
+            STRINGS "${_ARCH_RULES_ABS}"
+            _ARCH_RULES_FRONTEND_KIND_LINES
+            REGEX "((->)|(\\.))frontend_kind"
+        )
+
+        foreach(
+            _ARCH_RULES_FRONTEND_KIND_LINE
+            IN
+            LISTS _ARCH_RULES_FRONTEND_KIND_LINES
+        )
+            if(_ARCH_RULES_FRONTEND_KIND_LINE MATCHES "^[ \t]*(//|/\\*)")
+                continue()
+            endif()
+
+            string(
+                STRIP "${_ARCH_RULES_FRONTEND_KIND_LINE}"
+                _ARCH_RULES_FRONTEND_KIND_LINE_STRIPPED
+            )
+            message(
+                SEND_ERROR
+                "ARCH_RULES: ${_ARCH_RULES_REL}: backend code must use frontend predicates, not direct frontend_kind access '${_ARCH_RULES_FRONTEND_KIND_LINE_STRIPPED}'"
+            )
+            math(EXPR _ARCH_RULES_VIOLATIONS "${_ARCH_RULES_VIOLATIONS} + 1")
+        endforeach()
+    endif()
+
+    if(_ARCH_RULES_UI_RTL_FORBIDDEN_AREA)
+        file(
+            STRINGS "${_ARCH_RULES_ABS}"
+            _ARCH_RULES_UI_RTL_CALL_LINES
+            REGEX "rtl_stream_"
+        )
+
+        foreach(
+            _ARCH_RULES_UI_RTL_CALL_LINE
+            IN
+            LISTS _ARCH_RULES_UI_RTL_CALL_LINES
+        )
+            if(_ARCH_RULES_UI_RTL_CALL_LINE MATCHES "^[ \t]*(//|/\\*)")
+                continue()
+            endif()
+
+            string(
+                STRIP "${_ARCH_RULES_UI_RTL_CALL_LINE}"
+                _ARCH_RULES_UI_RTL_CALL_LINE_STRIPPED
+            )
+            message(
+                SEND_ERROR
+                "ARCH_RULES: ${_ARCH_RULES_REL}: terminal UI must use app-control metrics, not rtl_stream_* directly '${_ARCH_RULES_UI_RTL_CALL_LINE_STRIPPED}'"
+            )
+            math(EXPR _ARCH_RULES_VIOLATIONS "${_ARCH_RULES_VIOLATIONS} + 1")
+        endforeach()
+    endif()
 
     file(
         STRINGS "${_ARCH_RULES_ABS}"
@@ -213,6 +283,18 @@ foreach(_ARCH_RULES_REL IN LISTS _ARCH_RULES_FILES)
             message(
                 SEND_ERROR
                 "ARCH_RULES: ${_ARCH_RULES_REL}: forbidden IO include '${_ARCH_RULES_HEADER}'"
+            )
+            math(EXPR _ARCH_RULES_VIOLATIONS "${_ARCH_RULES_VIOLATIONS} + 1")
+            continue()
+        endif()
+
+        if(
+            _ARCH_RULES_UI_RTL_FORBIDDEN_AREA
+            AND _ARCH_RULES_HEADER MATCHES "^dsd-neo/io/rtl"
+        )
+            message(
+                SEND_ERROR
+                "ARCH_RULES: ${_ARCH_RULES_REL}: terminal UI must use app-control metrics, not RTL include '${_ARCH_RULES_HEADER}'"
             )
             math(EXPR _ARCH_RULES_VIOLATIONS "${_ARCH_RULES_VIOLATIONS} + 1")
             continue()

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,7 +4,7 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 
 ## Cheatsheet
 
-- Help: `dsd-neo -h` | UI/logs: `-N`, `-Z` | List devices: `-O`
+- Help: `dsd-neo -h` | UI/logs: `--frontend terminal`, `-Z` | List devices: `-O`
 - Inputs: `-i pulse | file.wav | rtl[:...] | rtltcp[:...] | soapy[:args[:freq[:gain[:ppm[:bw[:sql[:vol]]]]]]] | tcp[:host[:port]] | udp[:bind_addr[:port]] | m17udp[:bind_addr[:port]] | -`
 - Outputs: `-o pulse | null | udp[:host[:port]] | m17udp[:host[:port]] | -`
 - Record/Logs/Debug: `-6 file.wav`, `-w file.wav`, `-P`, `-7 ./calls`, `-d ./mbe`, `-J events.log`, `--frame-log frames.log`, `--p25-sm-log p25-sm.log`, `-L lrrp.log`, `-Q dsp.bin`, `-c symbols.bin`, `-r *.mbe`, `--dmr-debug-burst`
@@ -24,15 +24,15 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 ## Quick Start
 
 - Show help: `dsd-neo -h`
-- PulseAudio in, play out, UI on: `dsd-neo -i pulse -o pulse -N`
-- UDP audio in to PulseAudio out: `dsd-neo -i udp:0.0.0.0:7355 -o pulse -N`
-- Follow DMR trunking (TCP PCM input + rigctl): `dsd-neo -fs -i tcp -U 4532 -T -C dmr_t3_chan.csv -G group.csv -N`
-- Follow DMR trunking (RTL‑SDR): `dsd-neo -fs -i rtl:0:450M:26:-2:48:0:2 -T -C connect_plus_chan.csv -G group.csv -N`
-- Follow DMR trunking (SoapySDR): `dsd-neo -fs -i soapy:driver=airspy -T -C connect_plus_chan.csv -G group.csv -N`
-- Scan several P25/DMR targets with one tuner: `dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv -N`
-- Capture RTL I/Q + metadata: `dsd-neo -i rtl:0:851.375M:22:0:48:0:2 --iq-capture p25-control.iq -N`
+- PulseAudio in, play out, UI on: `dsd-neo -i pulse -o pulse --frontend terminal`
+- UDP audio in to PulseAudio out: `dsd-neo -i udp:0.0.0.0:7355 -o pulse --frontend terminal`
+- Follow DMR trunking (TCP PCM input + rigctl): `dsd-neo -fs -i tcp -U 4532 -T -C dmr_t3_chan.csv -G group.csv --frontend terminal`
+- Follow DMR trunking (RTL‑SDR): `dsd-neo -fs -i rtl:0:450M:26:-2:48:0:2 -T -C connect_plus_chan.csv -G group.csv --frontend terminal`
+- Follow DMR trunking (SoapySDR): `dsd-neo -fs -i soapy:driver=airspy -T -C connect_plus_chan.csv -G group.csv --frontend terminal`
+- Scan several P25/DMR targets with one tuner: `dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal`
+- Capture RTL I/Q + metadata: `dsd-neo -i rtl:0:851.375M:22:0:48:0:2 --iq-capture p25-control.iq --frontend terminal`
 - Inspect a capture: `dsd-neo --iq-info p25-control.iq.json`
-- Replay a capture through demod: `dsd-neo --iq-replay p25-control.iq.json -f1 -N`
+- Replay a capture through demod: `dsd-neo --iq-replay p25-control.iq.json -f1 --frontend terminal`
 - Play saved MBE files: `dsd-neo -r *.mbe`
 - Decode MBE to a WAV (no speaker output): `dsd-neo -o null -w decoded.wav -r call.mbe`
 
@@ -101,12 +101,12 @@ Tip: If paths or names contain spaces, wrap them in single quotes.
 
 ## Display & UI
 
-- `-N` Use the ncurses terminal UI
+- `--frontend terminal` Use the terminal UI
 - `-Z` Log MBE/PDU payloads to the console (verbose)
 - `--frame-log <file>` Append one-line timestamped frame traces (separate from event log)
 - `--p25-sm-log <file>` Append one-line P25 state-machine decision diagnostics (separate from stdout/stderr, event log, and frame log)
 - `-O` List PulseAudio input sources and output sinks
-- The ncurses input section shows advisory `Input Level`/`RF Level` health when metrics are available. `LOW` uses
+- The terminal input section shows advisory `Input Level`/`RF Level` health when metrics are available. `LOW` uses
   `--input-level-warn-db`; `HOT` means peak at or above `-1.0 dBFS`; `CLIP` means at least `0.1%` clipped or near-rail
   samples. TCP PCM idle/search level advisories are status-only to avoid console spam. These advisories never adjust
   gain automatically.
@@ -392,7 +392,7 @@ M17 `-M` details
 
 Examples
 
-- `dsd-neo -fZ -M M17:9:DSD-NEO:ARANCORMO -i pulse -6 m17signal.wav -8 -N`
+- `dsd-neo -fZ -M M17:9:DSD-NEO:ARANCORMO -i pulse -6 m17signal.wav -8 --frontend terminal`
 - `dsd-neo -fP -M M17:9:DSD-NEO:ARANCORMO -6 m17pkt.wav -8`
 
 ## Keys & Privacy (advanced)
@@ -575,16 +575,16 @@ Debug (verbose/developer)
 
 ## Handy Examples
 
-- UDP in → Pulse out with UI: `dsd-neo -i udp -o pulse -N`
-- RTL‑TCP in with ncurses UI: `dsd-neo -i rtltcp:127.0.0.1:1234 -N`
-- SoapySDR in with explicit driver args: `dsd-neo -i soapy:driver=sdrplay -N`
+- UDP in → Pulse out with UI: `dsd-neo -i udp -o pulse --frontend terminal`
+- RTL‑TCP in with terminal UI: `dsd-neo -i rtltcp:127.0.0.1:1234 --frontend terminal`
+- SoapySDR in with explicit driver args: `dsd-neo -i soapy:driver=sdrplay --frontend terminal`
 - SoapySDR with SDRplay settings in config: `soapy_settings = "rfnotch_ctrl=true,dabnotch_ctrl=true,biasT_ctrl=false,agc_setpoint=-30,rfgain_sel=4"`
-- SoapySDR args + RTL-style tuning in one input spec: `dsd-neo -i soapy:driver=sdrplay:851.375M:22:-2:24:0:2 -N`
-- Save per‑call WAVs to a folder: `dsd-neo -7 ./calls -P -N`
-- Strictly P25 Phase 1 from TCP audio: `dsd-neo -f1 -i tcp -N`
-- Capture I/Q while decoding RTL input: `dsd-neo -i rtl:0:851.375M:22:0:48:0:2 --iq-capture p25-control.iq -N`
+- SoapySDR args + RTL-style tuning in one input spec: `dsd-neo -i soapy:driver=sdrplay:851.375M:22:-2:24:0:2 --frontend terminal`
+- Save per‑call WAVs to a folder: `dsd-neo -7 ./calls -P --frontend terminal`
+- Strictly P25 Phase 1 from TCP audio: `dsd-neo -f1 -i tcp --frontend terminal`
+- Capture I/Q while decoding RTL input: `dsd-neo -i rtl:0:851.375M:22:0:48:0:2 --iq-capture p25-control.iq --frontend terminal`
 - Print capture metadata and replayability summary: `dsd-neo --iq-info p25-control.iq.json`
-- Replay capture in realtime loop mode: `dsd-neo --iq-replay p25-control.iq.json --iq-replay-rate realtime --iq-loop -N`
+- Replay capture in realtime loop mode: `dsd-neo --iq-replay p25-control.iq.json --iq-replay-rate realtime --iq-loop --frontend terminal`
 
 ## Manual Validation Checklist
 

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -201,10 +201,11 @@ Build files: `src/protocol/CMakeLists.txt` and per‑protocol `src/protocol/<nam
 - Path: `src/ui`, `include/dsd-neo/ui`
 - Target: `dsd-neo_ui_terminal`
 - Responsibilities:
-  - ncurses terminal UI (panels, logging, protocol displays, visualizers)
+  - Terminal frontend implementation (panels, logging, protocol displays, visualizers)
   - Data-driven, nonblocking menu overlay implemented under `src/ui/terminal/` (`menu_*.c`, `menus/menu_defs.c`)
-  - Radio-driven UI controls are gated by `USE_RADIO`; current live visualizer renderers (constellation, eye diagram,
-    spectrum, FSK histogram) are RTL-shim based and gated by `USE_RTLSDR`
+  - Frontend-facing status, control, and DSP/RTL metrics flow through `include/dsd-neo/app_control/frontend.h` and
+    app-control commands; terminal UI code must not include IO/RTL headers directly.
+  - Radio-driven UI controls are gated by `USE_RADIO`; visualizers consume app-control frontend metric APIs.
 
 Build files: `src/ui/CMakeLists.txt`, `src/ui/terminal/CMakeLists.txt`
 
@@ -272,7 +273,7 @@ Common interface targets:
 
 Optional feature interface targets (compile definitions + include paths; stubbed out when deps are missing):
 
-- `dsd-neo_feature_colors` — `PRETTY_COLORS` when ncurses UI colors are enabled (`COLORS`)
+- `dsd-neo_feature_colors` — `PRETTY_COLORS` when terminal UI colors are enabled (`COLORS`)
 - `dsd-neo_feature_colors_logs` — `PRETTY_COLORS_LOGS` when colored terminal/log output is enabled (`COLORSLOGS`)
 - `dsd-neo_feature_pvc` — `PVCONVENTIONAL` when ProVoice conventional frame sync is enabled (`PVC`)
 - `dsd-neo_feature_lz` — `LIMAZULUTWEAKS` when LimaZulu NXDN tweaks are enabled (`LZ`)
@@ -285,6 +286,6 @@ Optional feature interface targets (compile definitions + include paths; stubbed
 
 External dependencies (resolved via CMake):
 
-- Required: LibSndFile; curses (ncursesw/PDCurses); an audio backend (PulseAudio by default, PortAudio on Windows);
-  MBE vocoder (`mbe-neo` 2.x).
+- Required: LibSndFile; an audio backend (PulseAudio by default, PortAudio on Windows); MBE vocoder (`mbe-neo` 2.x).
+- Terminal frontend: curses (ncursesw/PDCurses), enabled by default with `DSD_ENABLE_TERMINAL_UI=ON`.
 - Optional: RTL‑SDR, SoapySDR >= 0.8.1, CODEC2, libcurl.

--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -63,7 +63,7 @@ rtl_freq = "851.375M"       # supports K/M/G suffix or raw Hz
 
 [output]
 backend = "pulse"           # pulse / null
-ncurses_ui = true           # map to -N / use_ncurses_terminal
+frontend = "terminal"       # none / terminal
 
 [alerts]
 enabled = false             # map to -a / call alert toggle
@@ -146,7 +146,7 @@ mode.decode = "dmr"
 
 [profile.scanner]
 mode.decode = "auto"
-output.ncurses_ui = true
+output.frontend = terminal
 ```
 
 ### Usage
@@ -162,7 +162,7 @@ dsd-neo --config config.ini --profile p25_trunk
 dsd-neo --config config.ini --list-profiles
 ```
 
-The ncurses Config menu also supports `Load Profile...`, which lists profiles from
+The terminal Config menu also supports `Load Profile...`, which lists profiles from
 the active config path and applies the selected overlay to the running session.
 
 ### Behavior
@@ -300,7 +300,7 @@ small subset is exposed as config keys for convenience (for example
 | `backend` | ENUM | Audio output backend (`pulse|null`) | `pulse` |
 | `pulse_sink` | STRING | PulseAudio sink device | (empty) |
 | `pulse_output` | STRING | Deprecated alias for `pulse_sink` | (empty) |
-| `ncurses_ui` | BOOL | Enable ncurses UI | `false` |
+| `frontend` | ENUM | Frontend implementation (`none|terminal`) | `none` |
 
 **[mode] section:**
 | Key | Type | Description | Default |
@@ -601,7 +601,7 @@ Config/CLI interaction:
 - `--validate-config` reports an error when trunk scan and `[trunking] chan_csv` are both enabled.
 - If trunk scan is inherited from a config file, one-off CLI arguments that select another input, mode, channel map,
   file/replay input, trunking mode, or legacy scan mode disable the inherited scan for that run. UI-only flags such as
-  `-N` and trunk-scan timing overrides keep the inherited scan enabled.
+  `--frontend terminal` and trunk-scan timing overrides keep the inherited scan enabled.
 - Explicit profile runs preserve the profile's trunk scan settings and disable autosave for that process, like other
   profile-based runs.
 
@@ -698,9 +698,9 @@ through selecting input, mode, trunking, and UI options.
 
 ---
 
-## ncurses UI Config Menu
+## Terminal UI Config Menu
 
-When running with the ncurses UI (`ncurses_ui = true` or `-N`), the
+When running with the terminal UI (`frontend = "terminal"` or `--frontend terminal`), the
 **Config** menu provides:
 
 - **Save Config (Current)**: Save current settings to the active config path (loaded via `--config` or **Load Config...**).

--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -301,6 +301,7 @@ small subset is exposed as config keys for convenience (for example
 | `pulse_sink` | STRING | PulseAudio sink device | (empty) |
 | `pulse_output` | STRING | Deprecated alias for `pulse_sink` | (empty) |
 | `frontend` | ENUM | Frontend implementation (`none|terminal`) | `none` |
+| `ncurses_ui` | BOOL | Deprecated alias for `frontend`; `true` maps to `terminal`, `false` maps to `none` | `false` |
 
 **[mode] section:**
 | Key | Type | Description | Default |

--- a/docs/iq-capture-replay.md
+++ b/docs/iq-capture-replay.md
@@ -8,9 +8,9 @@ RTL demodulation path used by live radio input.
 ## Quick Commands
 
 ```bash
-dsd-neo -i rtl:0:851.375M:22:0:48:0:2 --iq-capture p25-control.iq -N
+dsd-neo -i rtl:0:851.375M:22:0:48:0:2 --iq-capture p25-control.iq --frontend terminal
 dsd-neo --iq-info p25-control.iq.json
-dsd-neo --iq-replay p25-control.iq.json -f1 -N
+dsd-neo --iq-replay p25-control.iq.json -f1 --frontend terminal
 ```
 
 ## CLI Flags

--- a/docs/soapysdr.md
+++ b/docs/soapysdr.md
@@ -141,13 +141,13 @@ Examples:
 
 ```bash
 # Use saved config
-dsd-neo --config ~/.config/dsd-neo/config.ini -N
+dsd-neo --config ~/.config/dsd-neo/config.ini --frontend terminal
 
 # One-shot trunking with explicit Soapy args
-dsd-neo -fs -i soapy:driver=airspy -T -C connect_plus_chan.csv -G group.csv -N
+dsd-neo -fs -i soapy:driver=airspy -T -C connect_plus_chan.csv -G group.csv --frontend terminal
 
 # One-shot Soapy args + startup tuning
-dsd-neo -fs -i soapy:driver=airspy:851.375M:22:-2:24:0:2 -T -C connect_plus_chan.csv -G group.csv -N
+dsd-neo -fs -i soapy:driver=airspy:851.375M:22:-2:24:0:2 -T -C connect_plus_chan.csv -G group.csv --frontend terminal
 ```
 
 ## Behavior and limits vs RTL/RTL-TCP
@@ -188,5 +188,5 @@ Manual driver-setting check:
 
 ```bash
 SoapySDRUtil --probe="driver=sdrplay"
-dsd-neo --config ~/.config/dsd-neo/config.ini -N
+dsd-neo --config ~/.config/dsd-neo/config.ini --frontend terminal
 ```

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -76,13 +76,13 @@ Target list limits and validation:
 For a mixed P25/DMR scan with an RTL-SDR:
 
 ```sh
-dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv -N
+dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal
 ```
 
 For an external receiver that sends PCM audio over TCP and is tuned through rigctl:
 
 ```sh
-dsd-neo -ft -i tcp -U 4532 --trunk-scan ~/radio/trunk_scan_targets.csv -G ~/radio/group.csv -N
+dsd-neo -ft -i tcp -U 4532 --trunk-scan ~/radio/trunk_scan_targets.csv -G ~/radio/group.csv --frontend terminal
 ```
 
 Optional timing controls:
@@ -92,7 +92,7 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
   --trunk-scan ~/radio/trunk_scan_targets.csv \
   --trunk-scan-dwell-ms 5000 \
   --trunk-scan-activity-hold-ms 2000 \
-  -N
+  --frontend terminal
 ```
 
 - `--trunk-scan-dwell-ms <ms>` sets the default idle dwell for targets whose `dwell_ms` column is empty. Default:
@@ -123,7 +123,7 @@ rtl_bw_khz = 48
 decode = "tdma"
 
 [output]
-ncurses_ui = true
+frontend = "terminal"
 
 [trunking]
 group_csv = "~/radio/group.csv"
@@ -234,7 +234,7 @@ rotating across unrelated scan targets.
 Existing single-system trunking commands still work:
 
 ```sh
-dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 -T -C dmr_t3_chan.csv -G group.csv -N
+dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 -T -C dmr_t3_chan.csv -G group.csv --frontend terminal
 ```
 
 To scan multiple systems with one receiver:

--- a/docs/udp-control.md
+++ b/docs/udp-control.md
@@ -10,7 +10,7 @@ but you still want DSD-neo to own the RTL demod pipeline.
 Start `dsd-neo` with RTL or RTL-TCP input and add `--rtl-udp-control <port>`:
 
 ```bash
-dsd-neo -i rtl:0:851.375M:22:-2:24:0:2 --rtl-udp-control 9911 -N
+dsd-neo -i rtl:0:851.375M:22:-2:24:0:2 --rtl-udp-control 9911 --frontend terminal
 ```
 
 Notes:

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -1,13 +1,13 @@
 # Terminal UI (ncurses) Guide
 
-This guide covers the interactive terminal UI enabled with `-N`: how to open the menu overlay and the most useful
+This guide covers the interactive terminal UI enabled with `--frontend terminal`: how to open the menu overlay and the most useful
 hotkeys.
 
 For CLI flags and inputs/outputs, see `docs/cli.md`.
 
 ## Start the UI
 
-- Enable UI: `dsd-neo -N ...`
+- Enable UI: `dsd-neo --frontend terminal ...`
 - Quit: `q`
 - Open the menu overlay: `Enter`
 

--- a/include/dsd-neo/app_control/frontend.h
+++ b/include/dsd-neo/app_control/frontend.h
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Frontend-facing app-control status and metrics API.
+ *
+ * This boundary exposes copied status and plain metric values to frontends
+ * without leaking live dsd_opts/dsd_state pointers or IO-layer RTL types.
+ */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_FRONTEND_H_
+#define DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_FRONTEND_H_
+
+#include <dsd-neo/core/input_level.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <stdint.h>
+#include "dsd-neo/platform/platform.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct dsd_frontend_status {
+    dsd_frontend_kind frontend_kind;
+    uint8_t terminal_compact;
+    uint8_t terminal_history;
+
+    int audio_in_type;
+    int audio_out_type;
+    int audio_out;
+    char audio_in_dev[2048];
+    char audio_out_dev[1024];
+    char pa_input_idx[100];
+    char pa_output_idx[100];
+    char tcp_hostname[1024];
+    int tcp_portno;
+    char udp_hostname[1024];
+    int udp_portno;
+    char udp_in_bindaddr[256];
+    int udp_in_portno;
+    char rigctlhostname[1024];
+    int rigctlportno;
+    int use_rigctl;
+
+    int config_autosave_enabled;
+    char config_autosave_path[2048];
+
+    uint64_t p2_wacn;
+    uint64_t p2_sysid;
+    uint64_t p2_cc;
+    uint32_t tg_hold;
+    uint32_t lasttg;
+    uint32_t lasttgR;
+    int slot_preference;
+    int slot1_on;
+    int slot2_on;
+    double trunk_hangtime;
+    int p25_trunk;
+    int trunk_enable;
+    int scanner_mode;
+
+    int rtl_dev_index;
+    uint32_t rtlsdr_center_freq;
+    int rtl_gain_value;
+    int rtlsdr_ppm_error;
+    int rtl_dsp_bw_khz;
+    double rtl_squelch_level;
+    int rtl_volume_multiplier;
+    int rtl_bias_tee;
+    int rtltcp_autotune;
+    int rtl_auto_ppm;
+    double input_warn_db;
+    int input_volume_multiplier;
+} dsd_frontend_status;
+
+typedef struct dsd_frontend_decode_health {
+    int valid;
+    uint32_t generation;
+    unsigned int p25p1_fec_ok;
+    unsigned int p25p1_fec_err;
+    unsigned int p25p2_facch_ok;
+    unsigned int p25p2_facch_err;
+    unsigned int p25p2_sacch_ok;
+    unsigned int p25p2_sacch_err;
+    unsigned int p25p2_voice_err;
+} dsd_frontend_decode_health;
+
+typedef struct dsd_frontend_costas_metrics {
+    int err_smooth_avg_q14;
+    int err_raw_avg_q14;
+    int confidence_avg_q14;
+    int zero_conf_pct;
+} dsd_frontend_costas_metrics;
+
+typedef enum DSD_ATTR_PACKED {
+    DSD_FRONTEND_RTL_OUTPUT_AUDIO_MONITOR = 0,
+    DSD_FRONTEND_RTL_OUTPUT_FSK_DISCRIMINATOR = 1,
+    DSD_FRONTEND_RTL_OUTPUT_SYMBOL_CQPSK = 2
+} dsd_frontend_rtl_output_kind;
+
+typedef struct dsd_frontend_metrics {
+    unsigned int output_rate_hz;
+    int output_kind;
+    int symbol_rate_hz;
+    int symbol_levels;
+    int channel_profile;
+    uint32_t stream_generation;
+    int stream_active;
+    dsd_input_level_snapshot input_level;
+
+    int cqpsk_enable;
+    int cqpsk_timing_active;
+    int cqpsk_timing_bias;
+    double snr_bias_evm;
+    double snr_bias_c4fm;
+    double snr_c4fm_db;
+    double snr_c4fm_eye_db;
+    double snr_cqpsk_db;
+    double snr_gfsk_db;
+    double snr_gfsk_eye_db;
+    double snr_qpsk_const_db;
+
+    int iq_balance;
+    int iq_dc_enabled;
+    int iq_dc_shift_k;
+    int ted_sps;
+    float ted_gain;
+    double cfo_hz;
+    int carrier_lock;
+    int costas_err_q14;
+    int nco_q15;
+    int demod_rate_hz;
+    double fll_band_edge_freq_hz;
+    dsd_frontend_costas_metrics costas;
+
+    int spectrum_size;
+    int requested_ppm;
+    int tuner_gain_tenth_db;
+    int tuner_gain_is_auto;
+    int tuner_gain_valid;
+    int auto_ppm_enabled;
+    int auto_ppm_locked;
+    int auto_ppm_locked_ppm;
+    int auto_ppm_step_dir;
+    double auto_ppm_snr_db;
+    double auto_ppm_df_hz;
+    int tuner_autogain;
+    dsd_frontend_decode_health decode_health;
+} dsd_frontend_metrics;
+
+void dsd_app_frontend_status_from_opts_state(const dsd_opts* opts, const dsd_state* state, dsd_frontend_status* out);
+int dsd_app_frontend_get_status(dsd_frontend_status* out);
+int dsd_app_frontend_get_metrics(const dsd_opts* opts, const dsd_state* state, dsd_frontend_metrics* out);
+
+int dsd_app_frontend_constellation_get(float* out_xy, int max_points);
+int dsd_app_frontend_eye_get(float* out, int max_samples, int* out_sps);
+int dsd_app_frontend_spectrum_get(float* out_db, int max_bins, int* out_rate);
+int dsd_app_frontend_spectrum_get_size(void);
+int dsd_app_frontend_spectrum_set_size(int n);
+
+int dsd_app_frontend_requested_ppm(const dsd_opts* opts);
+float dsd_app_frontend_ted_gain(void);
+int dsd_app_frontend_auto_ppm_enabled(const dsd_state* state, int configured);
+int dsd_app_frontend_tuner_autogain_enabled(const dsd_state* state, int configured);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_FRONTEND_H_ */

--- a/include/dsd-neo/app_control/frontend.h
+++ b/include/dsd-neo/app_control/frontend.h
@@ -152,9 +152,19 @@ typedef struct dsd_frontend_metrics {
     dsd_frontend_decode_health decode_health;
 } dsd_frontend_metrics;
 
+enum {
+    DSD_FRONTEND_SNR_FALLBACK_C4FM_EYE = 1u << 0,
+    DSD_FRONTEND_SNR_FALLBACK_GFSK_EYE = 1u << 1,
+    DSD_FRONTEND_SNR_FALLBACK_QPSK_CONST = 1u << 2,
+    DSD_FRONTEND_SNR_FALLBACK_ALL =
+        DSD_FRONTEND_SNR_FALLBACK_C4FM_EYE | DSD_FRONTEND_SNR_FALLBACK_GFSK_EYE | DSD_FRONTEND_SNR_FALLBACK_QPSK_CONST
+};
+
 void dsd_app_frontend_status_from_opts_state(const dsd_opts* opts, const dsd_state* state, dsd_frontend_status* out);
 int dsd_app_frontend_get_status(dsd_frontend_status* out);
 int dsd_app_frontend_get_metrics(const dsd_opts* opts, const dsd_state* state, dsd_frontend_metrics* out);
+int dsd_app_frontend_get_metrics_with_snr_fallbacks(const dsd_opts* opts, const dsd_state* state,
+                                                    dsd_frontend_metrics* out, unsigned int snr_fallbacks);
 
 int dsd_app_frontend_constellation_get(float* out_xy, int max_points);
 int dsd_app_frontend_eye_get(float* out, int max_samples, int* out_sps);

--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -182,9 +182,9 @@ struct dsd_opts {
     int pulse_digi_in_channels;
     int pulse_digi_out_channels;
     int pulse_flush;
-    uint8_t use_ncurses_terminal;
-    uint8_t ncurses_compact;
-    uint8_t ncurses_history;
+    dsd_frontend_kind frontend_kind;
+    uint8_t terminal_compact;
+    uint8_t terminal_history;
     uint8_t eye_view;                    //ncurses timing/eye diagram for C4FM/FSK (0=off)
     uint8_t fsk_hist_view;               //ncurses 4-level histogram for C4FM/FSK (0=off)
     uint8_t spectrum_view;               //ncurses spectrum analyzer for complex baseband (0=off)
@@ -713,5 +713,15 @@ dsd_opts_compute_sps(const dsd_opts* opts, int sym_rate_hz) {
 static inline int
 dsd_opts_symbol_center(int sps) {
     return (sps - 1) / 2;
+}
+
+static inline int
+dsd_opts_frontend_active(const dsd_opts* opts) {
+    return opts != NULL && opts->frontend_kind != DSD_FRONTEND_NONE;
+}
+
+static inline int
+dsd_opts_frontend_is_terminal(const dsd_opts* opts) {
+    return opts != NULL && opts->frontend_kind == DSD_FRONTEND_TERMINAL;
 }
 #endif /* DSD_NEO_INCLUDE_DSD_NEO_CORE_OPTS_H_H */

--- a/include/dsd-neo/core/opts_fwd.h
+++ b/include/dsd-neo/core/opts_fwd.h
@@ -14,9 +14,13 @@
 #ifndef DSD_NEO_INCLUDE_DSD_NEO_CORE_OPTS_FWD_H_H
 #define DSD_NEO_INCLUDE_DSD_NEO_CORE_OPTS_FWD_H_H
 
+#include <dsd-neo/platform/platform.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef enum DSD_ATTR_PACKED { DSD_FRONTEND_NONE = 0, DSD_FRONTEND_TERMINAL = 1 } dsd_frontend_kind;
 
 typedef struct dsd_opts dsd_opts;
 /* Opaque TCP audio input context referenced by dsd_opts without requiring IO-layer includes. */

--- a/include/dsd-neo/runtime/config.h
+++ b/include/dsd-neo/runtime/config.h
@@ -581,7 +581,7 @@ typedef struct dsdneoUserConfig {
     int has_output;
     dsdneoUserOutputBackend output_backend;
     char pulse_output[256];
-    int ncurses_ui; /* bool */
+    dsd_frontend_kind frontend_kind;
 
     /* [mode] */
     int has_mode;

--- a/include/dsd-neo/runtime/config.h
+++ b/include/dsd-neo/runtime/config.h
@@ -582,6 +582,7 @@ typedef struct dsdneoUserConfig {
     dsdneoUserOutputBackend output_backend;
     char pulse_output[256];
     dsd_frontend_kind frontend_kind;
+    int frontend_kind_is_set;
 
     /* [mode] */
     int has_mode;

--- a/include/dsd-neo/runtime/rtl_stream_metrics_hooks.h
+++ b/include/dsd-neo/runtime/rtl_stream_metrics_hooks.h
@@ -38,6 +38,7 @@ typedef struct {
     double (*snr_c4fm_eye_db)(void);
     double (*snr_cqpsk_db)(void);
     double (*snr_gfsk_db)(void);
+    double (*snr_gfsk_eye_db)(void);
     double (*snr_qpsk_const_db)(void);
     void (*p25p1_ber_update)(int ok_delta, int err_delta);
     void (*p25p2_err_update)(int slot, int facch_ok, int facch_err, int sacch_ok, int sacch_err, int voice_err);
@@ -70,6 +71,7 @@ double dsd_rtl_stream_metrics_hook_snr_c4fm_db(void);
 double dsd_rtl_stream_metrics_hook_snr_c4fm_eye_db(void);
 double dsd_rtl_stream_metrics_hook_snr_cqpsk_db(void);
 double dsd_rtl_stream_metrics_hook_snr_gfsk_db(void);
+double dsd_rtl_stream_metrics_hook_snr_gfsk_eye_db(void);
 double dsd_rtl_stream_metrics_hook_snr_qpsk_const_db(void);
 void dsd_rtl_stream_metrics_hook_p25p1_ber_update(int ok_delta, int err_delta);
 void dsd_rtl_stream_metrics_hook_p25p2_err_update(int slot, int facch_ok, int facch_err, int sacch_ok, int sacch_err,

--- a/include/dsd-neo/ui/ui_async.h
+++ b/include/dsd-neo/ui/ui_async.h
@@ -58,6 +58,8 @@ const dsd_opts* dsd_neo_ui_async_test_opts_snapshot_or_default(void);
 int dsd_neo_ui_async_test_curses_is_active(const dsd_opts* opts);
 int dsd_neo_ui_async_test_read_key_nonblocking(const dsd_opts* opts);
 void dsd_neo_ui_async_test_process_input_frame(const dsd_opts* opts);
+int dsd_neo_ui_async_test_open_curses_if_needed(void);
+void dsd_neo_ui_async_test_close_curses_if_opened(int curses_opened);
 void dsd_neo_ui_async_test_draw_if_needed(const dsd_opts* opts, uint64_t* last_draw_ns, uint64_t frame_ns);
 #endif
 

--- a/src/app_control/CMakeLists.txt
+++ b/src/app_control/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
         actions/actions_radio.c
         actions/actions_trunk.c
         actions/actions_logging.c
+        frontend.c
         ui_cmd_queue.c
         ui_snapshot.c
         ui_opts_snapshot.c

--- a/src/app_control/frontend.c
+++ b/src/app_control/frontend.c
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/app_control/frontend.h>
+#include <dsd-neo/app_control/snapshot.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#include <string.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#ifdef USE_RADIO
+#include <dsd-neo/io/rtl_stream_c.h>
+#endif
+
+static void
+copy_text(char* dst, size_t dst_size, const char* src) {
+    if (!dst || dst_size == 0) {
+        return;
+    }
+    DSD_SNPRINTF(dst, dst_size, "%s", src ? src : "");
+    dst[dst_size - 1] = '\0';
+}
+
+void
+dsd_app_frontend_status_from_opts_state(const dsd_opts* opts, const dsd_state* state, dsd_frontend_status* out) {
+    if (!out) {
+        return;
+    }
+    DSD_MEMSET(out, 0, sizeof(*out));
+    if (opts) {
+        out->frontend_kind = opts->frontend_kind;
+        out->terminal_compact = opts->terminal_compact;
+        out->terminal_history = opts->terminal_history;
+        out->audio_in_type = opts->audio_in_type;
+        out->audio_out_type = opts->audio_out_type;
+        out->audio_out = opts->audio_out;
+        copy_text(out->audio_in_dev, sizeof out->audio_in_dev, opts->audio_in_dev);
+        copy_text(out->audio_out_dev, sizeof out->audio_out_dev, opts->audio_out_dev);
+        copy_text(out->pa_input_idx, sizeof out->pa_input_idx, opts->pa_input_idx);
+        copy_text(out->pa_output_idx, sizeof out->pa_output_idx, opts->pa_output_idx);
+        copy_text(out->tcp_hostname, sizeof out->tcp_hostname, opts->tcp_hostname);
+        out->tcp_portno = opts->tcp_portno;
+        copy_text(out->udp_hostname, sizeof out->udp_hostname, opts->udp_hostname);
+        out->udp_portno = opts->udp_portno;
+        copy_text(out->udp_in_bindaddr, sizeof out->udp_in_bindaddr, opts->udp_in_bindaddr);
+        out->udp_in_portno = opts->udp_in_portno;
+        copy_text(out->rigctlhostname, sizeof out->rigctlhostname, opts->rigctlhostname);
+        out->rigctlportno = opts->rigctlportno;
+        out->use_rigctl = opts->use_rigctl;
+        out->slot_preference = opts->slot_preference;
+        out->slot1_on = opts->slot1_on;
+        out->slot2_on = opts->slot2_on;
+        out->trunk_hangtime = opts->trunk_hangtime;
+        out->p25_trunk = opts->p25_trunk;
+        out->trunk_enable = opts->trunk_enable;
+        out->scanner_mode = opts->scanner_mode;
+        out->rtl_dev_index = opts->rtl_dev_index;
+        out->rtlsdr_center_freq = opts->rtlsdr_center_freq;
+        out->rtl_gain_value = opts->rtl_gain_value;
+        out->rtlsdr_ppm_error = opts->rtlsdr_ppm_error;
+        out->rtl_dsp_bw_khz = opts->rtl_dsp_bw_khz;
+        out->rtl_squelch_level = opts->rtl_squelch_level;
+        out->rtl_volume_multiplier = opts->rtl_volume_multiplier;
+        out->rtl_bias_tee = opts->rtl_bias_tee;
+        out->rtltcp_autotune = opts->rtltcp_autotune;
+        out->rtl_auto_ppm = opts->rtl_auto_ppm;
+        out->input_warn_db = opts->input_warn_db;
+        out->input_volume_multiplier = opts->input_volume_multiplier;
+    }
+    if (state) {
+        out->config_autosave_enabled = state->config_autosave_enabled;
+        copy_text(out->config_autosave_path, sizeof out->config_autosave_path, state->config_autosave_path);
+        out->p2_wacn = state->p2_wacn;
+        out->p2_sysid = state->p2_sysid;
+        out->p2_cc = state->p2_cc;
+        out->tg_hold = (uint32_t)state->tg_hold;
+        out->lasttg = (uint32_t)state->lasttg;
+        out->lasttgR = (uint32_t)state->lasttgR;
+    }
+}
+
+int
+dsd_app_frontend_get_status(dsd_frontend_status* out) {
+    if (!out) {
+        return -1;
+    }
+    dsd_app_frontend_status_from_opts_state(dsd_app_get_latest_opts_snapshot(), dsd_app_get_latest_snapshot(), out);
+    return 0;
+}
+
+static void
+frontend_metrics_defaults(dsd_frontend_metrics* out, const dsd_opts* opts) {
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->snr_c4fm_db = -100.0;
+    out->snr_c4fm_eye_db = -100.0;
+    out->snr_cqpsk_db = -100.0;
+    out->snr_gfsk_db = -100.0;
+    out->snr_gfsk_eye_db = -100.0;
+    out->snr_qpsk_const_db = -100.0;
+    out->requested_ppm = opts ? opts->rtlsdr_ppm_error : 0;
+    out->tuner_gain_is_auto = 1;
+}
+
+static void
+frontend_metrics_from_runtime_hooks(dsd_frontend_metrics* out) {
+    out->output_rate_hz = dsd_rtl_stream_metrics_hook_output_rate_hz();
+    out->output_kind = dsd_rtl_stream_metrics_hook_output_kind();
+    (void)dsd_rtl_stream_metrics_hook_symbol_profile(&out->symbol_rate_hz, &out->symbol_levels, &out->channel_profile);
+    out->stream_generation = dsd_rtl_stream_metrics_hook_stream_generation();
+    out->stream_active = dsd_rtl_stream_metrics_hook_stream_active();
+    (void)dsd_rtl_stream_metrics_hook_input_level(&out->input_level);
+    (void)dsd_rtl_stream_metrics_hook_cqpsk_status(&out->cqpsk_enable, &out->cqpsk_timing_active);
+    out->cqpsk_timing_bias = dsd_rtl_stream_metrics_hook_cqpsk_timing_bias();
+    out->snr_bias_evm = dsd_rtl_stream_metrics_hook_snr_bias_evm();
+    out->snr_c4fm_db = dsd_rtl_stream_metrics_hook_snr_c4fm_db();
+    out->snr_c4fm_eye_db = dsd_rtl_stream_metrics_hook_snr_c4fm_eye_db();
+    out->snr_cqpsk_db = dsd_rtl_stream_metrics_hook_snr_cqpsk_db();
+    out->snr_gfsk_db = dsd_rtl_stream_metrics_hook_snr_gfsk_db();
+    out->snr_qpsk_const_db = dsd_rtl_stream_metrics_hook_snr_qpsk_const_db();
+}
+
+#ifdef USE_RADIO
+static void
+frontend_metrics_from_radio(const dsd_opts* opts, const dsd_state* state, dsd_frontend_metrics* out) {
+    int iq_dc_k = 0;
+    out->iq_balance = rtl_stream_get_iq_balance();
+    out->iq_dc_enabled = rtl_stream_get_iq_dc(&iq_dc_k);
+    out->iq_dc_shift_k = iq_dc_k;
+    out->ted_sps = rtl_stream_get_ted_sps();
+    out->ted_gain = rtl_stream_get_ted_gain();
+    out->cfo_hz = rtl_stream_get_cfo_hz();
+    out->carrier_lock = rtl_stream_get_carrier_lock();
+    out->costas_err_q14 = rtl_stream_get_costas_err_q14();
+    out->nco_q15 = rtl_stream_get_nco_q15();
+    out->demod_rate_hz = rtl_stream_get_demod_rate_hz();
+    out->fll_band_edge_freq_hz = rtl_stream_get_fll_band_edge_freq_hz();
+    out->spectrum_size = rtl_stream_spectrum_get_size();
+    out->snr_bias_c4fm = rtl_stream_get_snr_bias_c4fm();
+    out->snr_gfsk_eye_db = rtl_stream_estimate_snr_gfsk_eye();
+    out->requested_ppm = rtl_stream_get_requested_ppm(opts);
+    out->tuner_gain_valid = (rtl_stream_get_gain(&out->tuner_gain_tenth_db, &out->tuner_gain_is_auto) == 0) ? 1 : 0;
+    out->auto_ppm_enabled = rtl_stream_get_auto_ppm();
+    out->tuner_autogain = rtl_stream_get_tuner_autogain();
+
+    rtl_stream_costas_metrics cm;
+    DSD_MEMSET(&cm, 0, sizeof(cm));
+    if (rtl_stream_get_costas_metrics(&cm) == 0) {
+        out->costas.err_smooth_avg_q14 = cm.err_smooth_avg_q14;
+        out->costas.err_raw_avg_q14 = cm.err_raw_avg_q14;
+        out->costas.confidence_avg_q14 = cm.confidence_avg_q14;
+        out->costas.zero_conf_pct = cm.zero_conf_pct;
+        out->costas_err_q14 = cm.err_smooth_avg_q14;
+    }
+
+    int ap_locked = 0;
+    (void)rtl_stream_auto_ppm_get_status(&out->auto_ppm_enabled, &out->auto_ppm_snr_db, &out->auto_ppm_df_hz, NULL,
+                                         &out->auto_ppm_step_dir, NULL, &ap_locked);
+    out->auto_ppm_locked = ap_locked;
+    if (ap_locked) {
+        (void)rtl_stream_auto_ppm_get_lock(&out->auto_ppm_locked_ppm, NULL, NULL);
+    }
+
+    rtl_stream_decode_health health;
+    DSD_MEMSET(&health, 0, sizeof(health));
+    if (rtl_stream_get_decode_health(&health) == 0) {
+        out->decode_health.valid = health.valid;
+        out->decode_health.generation = health.generation;
+        out->decode_health.p25p1_fec_ok = health.p25p1_fec_ok;
+        out->decode_health.p25p1_fec_err = health.p25p1_fec_err;
+        out->decode_health.p25p2_facch_ok = health.p25p2_facch_ok;
+        out->decode_health.p25p2_facch_err = health.p25p2_facch_err;
+        out->decode_health.p25p2_sacch_ok = health.p25p2_sacch_ok;
+        out->decode_health.p25p2_sacch_err = health.p25p2_sacch_err;
+        out->decode_health.p25p2_voice_err = health.p25p2_voice_err;
+    }
+    if (state && state->rtl_ctx) {
+        out->output_rate_hz = rtl_stream_output_rate(state->rtl_ctx);
+    }
+}
+#endif
+
+int
+dsd_app_frontend_get_metrics(const dsd_opts* opts, const dsd_state* state, dsd_frontend_metrics* out) {
+    if (!out) {
+        return -1;
+    }
+    frontend_metrics_defaults(out, opts);
+    frontend_metrics_from_runtime_hooks(out);
+#ifdef USE_RADIO
+    frontend_metrics_from_radio(opts, state, out);
+#else
+    (void)state;
+#endif
+    return 0;
+}
+
+int
+dsd_app_frontend_constellation_get(float* out_xy, int max_points) {
+#ifdef USE_RADIO
+    return rtl_stream_constellation_get(out_xy, max_points);
+#else
+    (void)out_xy;
+    (void)max_points;
+    return 0;
+#endif
+}
+
+int
+dsd_app_frontend_eye_get(float* out, int max_samples, int* out_sps) {
+#ifdef USE_RADIO
+    return rtl_stream_eye_get(out, max_samples, out_sps);
+#else
+    (void)out;
+    (void)max_samples;
+    if (out_sps) {
+        *out_sps = 0;
+    }
+    return 0;
+#endif
+}
+
+int
+dsd_app_frontend_spectrum_get(float* out_db, int max_bins, int* out_rate) {
+#ifdef USE_RADIO
+    return rtl_stream_spectrum_get(out_db, max_bins, out_rate);
+#else
+    (void)out_db;
+    (void)max_bins;
+    if (out_rate) {
+        *out_rate = 0;
+    }
+    return 0;
+#endif
+}
+
+int
+dsd_app_frontend_spectrum_get_size(void) {
+#ifdef USE_RADIO
+    return rtl_stream_spectrum_get_size();
+#else
+    return 0;
+#endif
+}
+
+int
+dsd_app_frontend_spectrum_set_size(int n) {
+#ifdef USE_RADIO
+    return rtl_stream_spectrum_set_size(n);
+#else
+    (void)n;
+    return -1;
+#endif
+}
+
+int
+dsd_app_frontend_requested_ppm(const dsd_opts* opts) {
+#ifdef USE_RADIO
+    return rtl_stream_get_requested_ppm(opts);
+#else
+    return opts ? opts->rtlsdr_ppm_error : 0;
+#endif
+}
+
+float
+dsd_app_frontend_ted_gain(void) {
+#ifdef USE_RADIO
+    return rtl_stream_get_ted_gain();
+#else
+    return 0.0f;
+#endif
+}
+
+int
+dsd_app_frontend_auto_ppm_enabled(const dsd_state* state, int configured) {
+#ifdef USE_RADIO
+    if (state && state->rtl_ctx) {
+        return rtl_stream_get_auto_ppm();
+    }
+#else
+    (void)state;
+#endif
+    return configured ? 1 : 0;
+}
+
+int
+dsd_app_frontend_tuner_autogain_enabled(const dsd_state* state, int configured) {
+#ifdef USE_RADIO
+    if (state && state->rtl_ctx) {
+        return rtl_stream_get_tuner_autogain();
+    }
+#else
+    (void)state;
+#endif
+    return configured ? 1 : 0;
+}

--- a/src/app_control/frontend.c
+++ b/src/app_control/frontend.c
@@ -17,6 +17,8 @@
 #include <dsd-neo/io/rtl_stream_c.h>
 #endif
 
+enum { FRONTEND_SNR_INVALID_DB = -50 };
+
 static void
 copy_text(char* dst, size_t dst_size, const char* src) {
     if (!dst || dst_size == 0) {
@@ -106,6 +108,11 @@ frontend_metrics_defaults(dsd_frontend_metrics* out, const dsd_opts* opts) {
     out->tuner_gain_is_auto = 1;
 }
 
+static int
+frontend_snr_value_is_valid(double snr_db) {
+    return snr_db > (double)FRONTEND_SNR_INVALID_DB;
+}
+
 static void
 frontend_metrics_from_runtime_hooks(dsd_frontend_metrics* out) {
     out->output_rate_hz = dsd_rtl_stream_metrics_hook_output_rate_hz();
@@ -118,10 +125,22 @@ frontend_metrics_from_runtime_hooks(dsd_frontend_metrics* out) {
     out->cqpsk_timing_bias = dsd_rtl_stream_metrics_hook_cqpsk_timing_bias();
     out->snr_bias_evm = dsd_rtl_stream_metrics_hook_snr_bias_evm();
     out->snr_c4fm_db = dsd_rtl_stream_metrics_hook_snr_c4fm_db();
-    out->snr_c4fm_eye_db = dsd_rtl_stream_metrics_hook_snr_c4fm_eye_db();
     out->snr_cqpsk_db = dsd_rtl_stream_metrics_hook_snr_cqpsk_db();
     out->snr_gfsk_db = dsd_rtl_stream_metrics_hook_snr_gfsk_db();
-    out->snr_qpsk_const_db = dsd_rtl_stream_metrics_hook_snr_qpsk_const_db();
+}
+
+static void
+frontend_metrics_add_snr_fallbacks(dsd_frontend_metrics* out, unsigned int snr_fallbacks) {
+    if ((snr_fallbacks & DSD_FRONTEND_SNR_FALLBACK_C4FM_EYE) != 0u && !frontend_snr_value_is_valid(out->snr_c4fm_db)) {
+        out->snr_c4fm_eye_db = dsd_rtl_stream_metrics_hook_snr_c4fm_eye_db();
+    }
+    if ((snr_fallbacks & DSD_FRONTEND_SNR_FALLBACK_GFSK_EYE) != 0u && !frontend_snr_value_is_valid(out->snr_gfsk_db)) {
+        out->snr_gfsk_eye_db = dsd_rtl_stream_metrics_hook_snr_gfsk_eye_db();
+    }
+    if ((snr_fallbacks & DSD_FRONTEND_SNR_FALLBACK_QPSK_CONST) != 0u
+        && !frontend_snr_value_is_valid(out->snr_cqpsk_db)) {
+        out->snr_qpsk_const_db = dsd_rtl_stream_metrics_hook_snr_qpsk_const_db();
+    }
 }
 
 #ifdef USE_RADIO
@@ -141,7 +160,6 @@ frontend_metrics_from_radio(const dsd_opts* opts, const dsd_state* state, dsd_fr
     out->fll_band_edge_freq_hz = rtl_stream_get_fll_band_edge_freq_hz();
     out->spectrum_size = rtl_stream_spectrum_get_size();
     out->snr_bias_c4fm = rtl_stream_get_snr_bias_c4fm();
-    out->snr_gfsk_eye_db = rtl_stream_estimate_snr_gfsk_eye();
     out->requested_ppm = rtl_stream_get_requested_ppm(opts);
     out->tuner_gain_valid = (rtl_stream_get_gain(&out->tuner_gain_tenth_db, &out->tuner_gain_is_auto) == 0) ? 1 : 0;
     out->auto_ppm_enabled = rtl_stream_get_auto_ppm();
@@ -196,6 +214,17 @@ dsd_app_frontend_get_metrics(const dsd_opts* opts, const dsd_state* state, dsd_f
 #else
     (void)state;
 #endif
+    return 0;
+}
+
+int
+dsd_app_frontend_get_metrics_with_snr_fallbacks(const dsd_opts* opts, const dsd_state* state, dsd_frontend_metrics* out,
+                                                unsigned int snr_fallbacks) {
+    int rc = dsd_app_frontend_get_metrics(opts, state, out);
+    if (rc != 0) {
+        return rc;
+    }
+    frontend_metrics_add_snr_fallbacks(out, snr_fallbacks);
     return 0;
 }
 

--- a/src/app_control/ui_cmd_queue.c
+++ b/src/app_control/ui_cmd_queue.c
@@ -1824,7 +1824,7 @@ apply_cmd_legacy_basic_a(dsd_opts* opts, dsd_state* state, const struct UiCmd* c
                 state->M = 0x21;
             }
             return 1;
-        case UI_CMD_TOGGLE_COMPACT: opts->ncurses_compact = opts->ncurses_compact ? 0 : 1; return 1;
+        case UI_CMD_TOGGLE_COMPACT: opts->terminal_compact = opts->terminal_compact ? 0 : 1; return 1;
         case UI_CMD_HISTORY_CYCLE:
             (void)ui_history_cycle_mode();
             ui_request_redraw();

--- a/src/app_control/ui_cmd_queue.c
+++ b/src/app_control/ui_cmd_queue.c
@@ -2476,12 +2476,20 @@ apply_cmd_legacy_misc_config(dsd_opts* opts, dsd_state* state, const struct UiCm
                 int old_samples_per_symbol = state->samplesPerSymbol;
                 int old_symbol_center = state->symbolCenter;
                 int old_jitter = state->jitter;
+                dsd_frontend_kind old_frontend_kind = opts->frontend_kind;
 
                 DSD_SNPRINTF(old_audio_in_dev, sizeof old_audio_in_dev, "%s", opts->audio_in_dev);
                 DSD_SNPRINTF(old_audio_out_dev, sizeof old_audio_out_dev, "%s", opts->audio_out_dev);
 
                 DSD_MEMCPY(&cfg, c->data, sizeof cfg);
                 dsd_apply_user_config_to_opts(&cfg, opts, state);
+                /*
+                 * Frontend lifecycle is owned by startup and ui_start/ui_stop.
+                 * Runtime config/profile loads may carry persisted frontend
+                 * defaults, but flipping this live can strand an active curses
+                 * session before the UI thread has a chance to shut it down.
+                 */
+                opts->frontend_kind = old_frontend_kind;
 #ifdef USE_RADIO
                 apply_cfg_live_rtl_ppm_request(opts, &cfg, old_audio_in_type);
 #endif

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -229,11 +229,11 @@ static void
 init_opts_runtime_and_network_defaults(dsd_opts* opts) {
     DSD_SNPRINTF(opts->output_name, sizeof opts->output_name, "%s", "AUTO");
     opts->pulse_flush = 1; //set 0 to flush, 1 for flushed
-    opts->use_ncurses_terminal = 0;
-    opts->ncurses_compact = 0;
-    opts->ncurses_history = 1;
+    opts->frontend_kind = DSD_FRONTEND_NONE;
+    opts->terminal_compact = 0;
+    opts->terminal_history = 1;
 #ifdef LIMAZULUTWEAKS
-    opts->ncurses_compact = 1;
+    opts->terminal_compact = 1;
 #endif
     opts->payload = 0;
     opts->inverted_dpmr = 0;

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -291,7 +291,7 @@ enum { DSD_FRAME_SYNC_UI_PUBLISH_INTERVAL_MS = 50 };
 
 static void
 frame_sync_publish_ui_throttled(const dsd_opts* opts, const dsd_state* state) {
-    if (!opts || opts->use_ncurses_terminal != 1) {
+    if (!dsd_opts_frontend_active(opts)) {
         return;
     }
 

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -1218,7 +1218,7 @@ symbol_read_sample_wav(dsd_opts* opts, dsd_state* state, float* sample_out) {
         }
         symbol_close_audio_in_file(opts);
         DSD_FPRINTF(stderr, "\nEnd of %s\n", opts->audio_in_dev);
-        if (opts->audio_out_type == 0 && opts->use_ncurses_terminal == 1) {
+        if (opts->audio_out_type == 0 && dsd_opts_frontend_active(opts)) {
             return symbol_open_pulse_input_and_reconfigure_output(opts, state);
         }
         cleanupAndExit(opts, state);
@@ -1712,7 +1712,7 @@ symbol_process_symbol_bin_input(dsd_opts* opts, dsd_state* state, float* symbol_
             *symbol_out = 0.0f;
             return 1;
         }
-        if (opts->audio_out_type == 0 && opts->use_ncurses_terminal == 1) {
+        if (opts->audio_out_type == 0 && dsd_opts_frontend_active(opts)) {
             (void)symbol_open_pulse_input_and_reconfigure_output(opts, state);
             *symbol_out = 0.0f;
             return 1;

--- a/src/engine/rtl_stream_metrics_hooks_install.c
+++ b/src/engine/rtl_stream_metrics_hooks_install.c
@@ -35,6 +35,7 @@ dsd_engine_rtl_stream_metrics_hooks_install(void) {
     hooks.snr_c4fm_eye_db = rtl_stream_estimate_snr_c4fm_eye;
     hooks.snr_cqpsk_db = rtl_stream_get_snr_cqpsk;
     hooks.snr_gfsk_db = rtl_stream_get_snr_gfsk;
+    hooks.snr_gfsk_eye_db = rtl_stream_estimate_snr_gfsk_eye;
     hooks.snr_qpsk_const_db = rtl_stream_estimate_snr_qpsk_const;
     hooks.p25p1_ber_update = rtl_stream_p25p1_ber_update;
     hooks.p25p2_err_update = rtl_stream_p25p2_err_update;

--- a/src/protocol/dmr/dmr_bs.c
+++ b/src/protocol/dmr/dmr_bs.c
@@ -702,7 +702,7 @@ run_dmr_bs_post_skip(dsd_opts* opts, dsd_state* state, dmr_bs_ctx* ctx) {
         return DMR_BS_ACTION_END;
     }
 
-    if (opts->use_ncurses_terminal == 1) {
+    if (dsd_opts_frontend_active(opts)) {
         ui_publish_both_and_redraw(opts, state);
     }
 

--- a/src/protocol/dmr/dmr_ms.c
+++ b/src/protocol/dmr/dmr_ms.c
@@ -249,7 +249,7 @@ dmr_ms_advance_voice_cycle(dsd_opts* opts, dsd_state* state, uint8_t* vc) {
     }
 
     skipDibit(opts, state, 144); // skip to next TDMA channel
-    if (opts->use_ncurses_terminal == 1) {
+    if (dsd_opts_frontend_active(opts)) {
         ui_publish_both_and_redraw(opts, state);
     }
 

--- a/src/protocol/dstar/dstar.c
+++ b/src/protocol/dstar/dstar.c
@@ -54,7 +54,7 @@ processDSTAR(dsd_opts* opts, dsd_state* state) {
         }
 
         //since we are in a long loop, use this to improve response time in ncurses
-        if (opts->use_ncurses_terminal == 1) {
+        if (dsd_opts_frontend_active(opts)) {
             ui_publish_both_and_redraw(opts, state);
         }
 

--- a/src/protocol/edacs/edacs-fme.c
+++ b/src/protocol/edacs/edacs-fme.c
@@ -483,7 +483,7 @@ edacs_print_analog_status(const dsd_opts* opts, const dsd_state* state, int afs,
         DSD_FPRINTF(stderr, "Analog Floating Point Output Not Supported");
     }
 
-    if (opts->use_ncurses_terminal == 1) {
+    if (dsd_opts_frontend_active(opts)) {
         ui_publish_both_and_redraw(opts, state);
     }
 }

--- a/src/protocol/m17/m17.c
+++ b/src/protocol/m17/m17.c
@@ -2477,7 +2477,7 @@ m17_str_handle_tx_idle(m17_str_ctx* ctx, const m17_str_frame_ctx* frame) {
 
 static void
 m17_str_iter_tail(m17_str_ctx* ctx) {
-    if (ctx->opts->use_ncurses_terminal == 1) {
+    if (dsd_opts_frontend_active(ctx->opts)) {
         ui_publish_both_and_redraw(ctx->opts, ctx->state);
     }
     watchdog_event_history(ctx->opts, ctx->state, 0);
@@ -2541,7 +2541,7 @@ m17_str_init(m17_str_ctx* ctx, dsd_opts* opts, dsd_state* state) {
     DSD_MEMSET(ctx->nil, 0, sizeof(ctx->nil));
     opts->frame_m17 = 1;
     state->m17encoder_tx = 1;
-    if (opts->use_ncurses_terminal == 1 && state->m17_vox == 0) {
+    if (dsd_opts_frontend_active(opts) && state->m17_vox == 0) {
         state->m17encoder_tx = 0;
     }
 
@@ -3656,7 +3656,7 @@ processM17IPF(dsd_opts* opts, dsd_state* state) {
 
         m17_ip_dispatch_frame(opts, state, ip_frame, err);
 
-        if (opts->use_ncurses_terminal == 1) {
+        if (dsd_opts_frontend_active(opts)) {
             ui_publish_both_and_redraw(opts, state);
         }
         watchdog_event_history(opts, state, 0);

--- a/src/protocol/p25/p25_sm_watchdog.c
+++ b/src/protocol/p25/p25_sm_watchdog.c
@@ -69,7 +69,7 @@ static DSD_THREAD_RETURN_TYPE
         // otherwise, tick faster under ncurses to reduce perceived wedges.
         int ms = g_p25_sm_wd_ms;
         if (ms <= 0) {
-            ms = (g_opts && g_opts->use_ncurses_terminal == 1) ? 200 : 400; // 200ms UI, 400ms headless
+            ms = dsd_opts_frontend_active(g_opts) ? 200 : 400; // 200ms frontend, 400ms headless
         }
         if (ms < 20) {
             ms = 20; // clamp to sane bounds

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -1756,7 +1756,7 @@ p25p2_duid_should_abort(dsd_state* state, int err_counter) {
 
 static void
 p25p2_duid_post_timeslot(dsd_opts* opts, dsd_state* state, int sacch_status) {
-    if (opts->use_ncurses_terminal == 1) {
+    if (dsd_opts_frontend_active(opts)) {
         ui_publish_both_and_redraw(opts, state);
     }
 

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -66,6 +66,11 @@ target_include_directories(
     PRIVATE ${_PUBLIC_INCLUDES}
 )
 
+target_compile_definitions(
+    dsd-neo_runtime
+    PRIVATE DSD_RUNTIME_HAS_TERMINAL_UI=$<BOOL:${DSD_ENABLE_TERMINAL_UI}>
+)
+
 # Link platform abstraction library for threading primitives
 target_link_libraries(
     dsd-neo_runtime

--- a/src/runtime/bootstrap/bootstrap.c
+++ b/src/runtime/bootstrap/bootstrap.c
@@ -625,10 +625,45 @@ bootstrap_apply_runtime_config_after_cli(dsd_opts* opts, dsd_state* state) {
     dsd_apply_runtime_config_to_opts(dsd_neo_get_config(), opts, state);
 }
 
+static int
+bootstrap_compacted_arg_is_trunking_ui_only(const char* arg) {
+    if (!arg || arg[0] != '-' || arg[1] == '\0' || arg[1] == '-') {
+        return 0;
+    }
+    for (int i = 1; arg[i] != '\0'; i++) {
+        if (arg[i] != 'N') {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int
+bootstrap_effective_cli_has_trunking_override(int argc_effective, char** argv) {
+    if (argc_effective <= 1) {
+        return 0;
+    }
+    if (!argv) {
+        return 1;
+    }
+    for (int i = 1; i < argc_effective; i++) {
+        const char* arg = argv[i];
+        if (!arg) {
+            break;
+        }
+        if (bootstrap_compacted_arg_is_trunking_ui_only(arg)) {
+            continue;
+        }
+        return 1;
+    }
+    return 0;
+}
+
 static void
-bootstrap_apply_trunk_cli_gating(dsd_opts* opts, int argc_effective, int user_cfg_loaded,
+bootstrap_apply_trunk_cli_gating(dsd_opts* opts, int argc_effective, char** argv, int user_cfg_loaded,
                                  int explicit_profile_selected) {
-    if (argc_effective > 1 && user_cfg_loaded && !opts->trunk_cli_seen && !explicit_profile_selected) {
+    if (bootstrap_effective_cli_has_trunking_override(argc_effective, argv) && user_cfg_loaded && !opts->trunk_cli_seen
+        && !explicit_profile_selected) {
         opts->p25_trunk = 0;
         opts->trunk_enable = 0;
     }
@@ -720,7 +755,8 @@ dsd_runtime_bootstrap(int argc, char** argv, dsd_opts* opts, dsd_state* state, i
         return boot_rc;
     }
     bootstrap_apply_runtime_config_after_cli(opts, state);
-    bootstrap_apply_trunk_cli_gating(opts, argc_effective, user_cfg_loaded, explicit_profile_selected);
+    bootstrap_apply_trunk_cli_gating(opts, state->cli_argc_effective, state->cli_argv, user_cfg_loaded,
+                                     explicit_profile_selected);
 
     boot_rc = bootstrap_handle_post_parse_actions(&args, opts, state, config_env, out_exit_rc);
     if (boot_rc != DSD_BOOTSTRAP_CONTINUE) {

--- a/src/runtime/bootstrap/interactive.c
+++ b/src/runtime/bootstrap/interactive.c
@@ -19,6 +19,10 @@
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
+#ifndef DSD_RUNTIME_HAS_TERMINAL_UI
+#define DSD_RUNTIME_HAS_TERMINAL_UI 1
+#endif
+
 static int
 path_is_regular_file(const char* path) {
     dsd_stat_t st;
@@ -353,6 +357,20 @@ interactive_maybe_configure_output(dsd_opts* opts, int src) {
     }
 }
 
+static void
+interactive_maybe_enable_terminal_frontend(dsd_opts* opts) {
+#if DSD_RUNTIME_HAS_TERMINAL_UI
+    int want_terminal = prompt_yes_no("Enable terminal frontend (--frontend terminal)?", 1);
+    if (want_terminal) {
+        opts->frontend_kind = DSD_FRONTEND_TERMINAL;
+    }
+#else
+    if (opts) {
+        opts->frontend_kind = DSD_FRONTEND_NONE;
+    }
+#endif
+}
+
 void
 dsd_bootstrap_interactive(dsd_opts* opts, dsd_state* state) {
     if (!dsd_isatty(DSD_STDIN_FILENO) || !dsd_isatty(DSD_STDOUT_FILENO)) {
@@ -389,11 +407,7 @@ dsd_bootstrap_interactive(dsd_opts* opts, dsd_state* state) {
 
     interactive_maybe_configure_trunking(mode, src, opts, state);
     interactive_maybe_configure_output(opts, src);
-
-    int want_terminal = prompt_yes_no("Enable terminal frontend (--frontend terminal)?", 1);
-    if (want_terminal) {
-        opts->frontend_kind = DSD_FRONTEND_TERMINAL;
-    }
+    interactive_maybe_enable_terminal_frontend(opts);
 
     LOG_NOTICE("Interactive setup complete.\n");
 }

--- a/src/runtime/bootstrap/interactive.c
+++ b/src/runtime/bootstrap/interactive.c
@@ -390,9 +390,9 @@ dsd_bootstrap_interactive(dsd_opts* opts, dsd_state* state) {
     interactive_maybe_configure_trunking(mode, src, opts, state);
     interactive_maybe_configure_output(opts, src);
 
-    int want_ncurses = prompt_yes_no("Enable ncurses terminal UI (-N)?", 1);
-    if (want_ncurses) {
-        opts->use_ncurses_terminal = 1;
+    int want_terminal = prompt_yes_no("Enable terminal frontend (--frontend terminal)?", 1);
+    if (want_terminal) {
+        opts->frontend_kind = DSD_FRONTEND_TERMINAL;
     }
 
     LOG_NOTICE("Interactive setup complete.\n");

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -1849,6 +1849,11 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
             opts->payload = 1;                                                                                         \
             LOG_NOTICE("Logging MBE/PDU payloads to console.\n");                                                      \
             break;                                                                                                     \
+        case 'N':                                                                                                      \
+            /* Legacy alias for --frontend terminal */                                                                 \
+            opts->frontend_kind = DSD_FRONTEND_TERMINAL;                                                               \
+            LOG_NOTICE("Frontend: terminal\n");                                                                        \
+            break;                                                                                                     \
         case 'P':                                                                                                      \
             if (opts->static_wav_file == 1) {                                                                          \
                 /* Allow CLI to override config-derived static WAV settings (file not opened yet). */                  \
@@ -2618,7 +2623,7 @@ dsd_parse_short_opts(int argc, char** argv, dsd_opts* opts, dsd_state* state, in
     int cli_manual_timing_center = 0;
     while ((c = getopt(argc, argv,
                        "~yhaepPqs:t:v:z:i:o:d:c:g:n:w:B:C:R:f:m:x:A:S:M:G:D:L:V:U:YK:b:H:X:Q:WrlZTF@:!:01:2:345:6:7:_:"
-                       "89:Ek:I:J:Oj^"))
+                       "89:Ek:I:J:Oj^N"))
            != -1) {
         DSD_PARSE_SHORT_OPTS_SWITCH_BLOCK();
     }

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -339,6 +339,22 @@ cli_parse_double_strict(const char* in, double* out) {
 }
 
 static int
+cli_parse_frontend_kind(const char* in, dsd_frontend_kind* out) {
+    if (!in || !*in || !out) {
+        return 0;
+    }
+    if (dsd_strcasecmp(in, "none") == 0) {
+        *out = DSD_FRONTEND_NONE;
+        return 1;
+    }
+    if (dsd_strcasecmp(in, "terminal") == 0) {
+        *out = DSD_FRONTEND_TERMINAL;
+        return 1;
+    }
+    return 0;
+}
+
+static int
 cli_parse_long_option(const char* option_name, const char* in, int base, long* out, int* out_exit_rc) {
     if (cli_parse_long_base(in, base, out)) {
         return 1;
@@ -832,6 +848,19 @@ cli_next_arg(char** argv, int i, int* arg_advance) {
             dsd_setenv("DSD_NEO_AUTO_PPM", "1", 1);                                                                    \
             continue;                                                                                                  \
         }                                                                                                              \
+        if (strcmp(argv[i], "--frontend") == 0) {                                                                      \
+            if (i + 1 >= argc) {                                                                                       \
+                LOG_ERROR("--frontend requires a value (none|terminal)\n");                                            \
+                cli_set_exit_rc(out_exit_rc, 1);                                                                       \
+                return DSD_PARSE_ERROR;                                                                                \
+            }                                                                                                          \
+            frontend_cli = DSD_PARSE_ARGS_NEXT_ARG();                                                                  \
+            continue;                                                                                                  \
+        }                                                                                                              \
+        if (strncmp(argv[i], "--frontend=", 11) == 0) {                                                                \
+            frontend_cli = argv[i] + 11;                                                                               \
+            continue;                                                                                                  \
+        }                                                                                                              \
         if (strcmp(argv[i], "--input-volume") == 0 && i + 1 < argc) {                                                  \
             input_vol_cli = DSD_PARSE_ARGS_NEXT_ARG();                                                                 \
             continue;                                                                                                  \
@@ -1213,6 +1242,17 @@ cli_next_arg(char** argv, int i, int* arg_advance) {
         opts->rtl_udp_bindaddr[sizeof opts->rtl_udp_bindaddr - 1] = '\0';                                              \
     }                                                                                                                  \
                                                                                                                        \
+    if (frontend_cli) {                                                                                                \
+        dsd_frontend_kind frontend = DSD_FRONTEND_NONE;                                                                \
+        if (!cli_parse_frontend_kind(frontend_cli, &frontend)) {                                                       \
+            LOG_ERROR("Invalid --frontend value \"%s\" (expected none|terminal)\n", frontend_cli);                     \
+            cli_set_exit_rc(out_exit_rc, 1);                                                                           \
+            return DSD_PARSE_ERROR;                                                                                    \
+        }                                                                                                              \
+        opts->frontend_kind = frontend;                                                                                \
+        LOG_NOTICE("Frontend: %s\n", frontend == DSD_FRONTEND_TERMINAL ? "terminal" : "none");                         \
+    }                                                                                                                  \
+                                                                                                                       \
     /* Apply input volume and warn threshold */                                                                        \
     if (input_vol_cli) {                                                                                               \
         long parsed_mv = 0;                                                                                            \
@@ -1409,6 +1449,7 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
     const char* calc_start_cli = NULL;
     const char* input_vol_cli = NULL;
     const char* input_warn_db_cli = NULL;
+    const char* frontend_cli = NULL;
     const char* frame_log_cli = NULL;
     const char* p25_sm_log_cli = NULL;
     const char* rdio_mode_cli = NULL;
@@ -1856,7 +1897,6 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
             DSD_STRNCPY(opts->audio_in_dev, optarg, 2047);                                                             \
             opts->audio_in_dev[2047] = '\0';                                                                           \
             break;                                                                                                     \
-        case 'N': opts->use_ncurses_terminal = 1; break;                                                               \
         case 'T':                                                                                                      \
             /* Enable trunking features; protocol-agnostic alias kept in sync */                                       \
             opts->p25_trunk = 1;                                                                                       \
@@ -2577,7 +2617,7 @@ dsd_parse_short_opts(int argc, char** argv, dsd_opts* opts, dsd_state* state, in
     int cli_manual_timing_sps = 0;
     int cli_manual_timing_center = 0;
     while ((c = getopt(argc, argv,
-                       "~yhaepPqs:t:v:z:i:o:d:c:g:n:w:B:C:R:f:m:x:A:S:M:G:D:L:V:U:YK:b:H:X:NQ:WrlZTF@:!:01:2:345:6:7:_:"
+                       "~yhaepPqs:t:v:z:i:o:d:c:g:n:w:B:C:R:f:m:x:A:S:M:G:D:L:V:U:YK:b:H:X:Q:WrlZTF@:!:01:2:345:6:7:_:"
                        "89:Ek:I:J:Oj^"))
            != -1) {
         DSD_PARSE_SHORT_OPTS_SWITCH_BLOCK();

--- a/src/runtime/cli/compact.c
+++ b/src/runtime/cli/compact.c
@@ -82,6 +82,7 @@ static const char* const k_skip_exact_next_any[] = {
     "--dmr-force-algid",
     "--m17-signature-public-key",
     "--auto-ppm-snr",
+    "--frontend",
     "--profile",
     "--p25-vc-grace",
     "--p25-min-follow-dwell",
@@ -135,6 +136,7 @@ static const char* const k_skip_prefix[] = {
     "--trunk-scan=",
     "--trunk-scan-dwell-ms=",
     "--trunk-scan-activity-hold-ms=",
+    "--frontend=",
 };
 
 int

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -33,6 +33,7 @@ dsd_cli_usage_section_intro(void) {
     printf("Display Options:\n");
     printf("      --frontend <none|terminal>  Select frontend implementation\n");
     printf("                 dsd-neo --frontend terminal 2> console_log.txt\n");
+    printf("  -N            Enable terminal frontend (alias for --frontend terminal)\n");
     printf("  -Z            Log MBE/PDU Payloads to console\n");
     printf("      --frame-log <file>    Append one-line timestamped frame trace output\n");
     printf("      --p25-sm-log <file>   Append P25 state-machine decision diagnostics\n");

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -31,8 +31,8 @@ dsd_cli_usage_section_intro(void) {
     printf("      --strict-config        Treat --validate-config warnings as errors\n");
     printf("\n");
     printf("Display Options:\n");
-    printf("  -N            Use NCurses Terminal\n");
-    printf("                 dsd-neo -N 2> console_log.txt\n");
+    printf("      --frontend <none|terminal>  Select frontend implementation\n");
+    printf("                 dsd-neo --frontend terminal 2> console_log.txt\n");
     printf("  -Z            Log MBE/PDU Payloads to console\n");
     printf("      --frame-log <file>    Append one-line timestamped frame trace output\n");
     printf("      --p25-sm-log <file>   Append P25 state-machine decision diagnostics\n");
@@ -112,7 +112,7 @@ dsd_cli_usage_section_io(void) {
            "Switch)\n");
     printf(
         "  -P            Enable Per Call WAV file saving. (Do not use with -w filename.wav single wav file switch)\n");
-    printf("                 (Per Call works with everything now and doesn't require ncurses terminal!)\n");
+    printf("                 (Per Call works with everything now and doesn't require terminal frontend!)\n");
     printf("      --rdio-mode <off|dirwatch|api|both>  Export per-call WAV metadata for rdio-scanner\n");
     printf("      --rdio-system-id <N>  rdio-scanner numeric system ID (required for API uploads)\n");
     printf("      --rdio-api-url <url>  rdio-scanner API base URL (default http://127.0.0.1:3000)\n");
@@ -159,7 +159,7 @@ dsd_cli_usage_section_radio_and_encoder(void) {
     printf(" Usage: rtltcp[:host:port[:freq:gain:ppm:bw:sql:vol[:bias[=on|off]]]]\n");
     printf("  host: default 127.0.0.1; port: default 1234\n");
     printf("  Remaining fields mirror rtl: string semantics.\n");
-    printf(" Example: dsd-neo -i rtltcp:192.168.1.10:1234:851.375M:22:-2:24:0:2 -N\n");
+    printf(" Example: dsd-neo -i rtltcp:192.168.1.10:1234:851.375M:22:-2:24:0:2 --frontend terminal\n");
     printf("\n");
     printf("SoapySDR options:\n");
     printf(" Usage: soapy[:args[:freq[:gain[:ppm[:bw[:sql[:vol]]]]]]]\n");
@@ -168,9 +168,9 @@ dsd_cli_usage_section_radio_and_encoder(void) {
     printf("  If omitted, Soapy uses existing/default rtl_* tuning values from config/CLI.\n");
     printf("\n");
     printf("UDP examples:\n");
-    printf(" Example: dsd-neo -i udp -o pulse -N\n");
+    printf(" Example: dsd-neo -i udp -o pulse --frontend terminal\n");
     printf("   Listen for UDP audio on 127.0.0.1:7355 and play to PulseAudio.\n");
-    printf(" Example: dsd-neo -i udp:0.0.0.0:7355 -o pulse -N\n");
+    printf(" Example: dsd-neo -i udp:0.0.0.0:7355 -o pulse --frontend terminal\n");
     printf("   Bind all interfaces; point GQRX/SDR++ UDP audio to this host:port.\n");
     printf("\n");
     printf("Encoder options:\n");
@@ -189,11 +189,13 @@ dsd_cli_usage_section_radio_and_encoder(void) {
     printf("      --iq-replay-rate <mode>  Replay pacing mode (fast|realtime)\n");
     printf("      --iq-loop              Loop I/Q replay at EOF\n");
     printf("      --iq-info <path>       Print metadata/alignment summary and exit\n");
-    printf(" Example: dsd-neo -fZ -M M17:9:DSD-NEO:ARANCORMO -i pulse -6 m17signal.wav -8 -N 2> m17encoderlog.txt\n");
+    printf(" Example: dsd-neo -fZ -M M17:9:DSD-NEO:ARANCORMO -i pulse -6 m17signal.wav -8 --frontend terminal 2> "
+           "m17encoderlog.txt\n");
     printf("   Run M17 Encoding, listening to pulse audio server, with internal decode/playback and output to 48k/1 "
            "wav file\n");
     printf("\n");
-    printf(" Example: dsd-neo -fZ -M M17:9:DSD-NEO:ARANCORMO -i tcp -o pulse -8 -N 2> m17encoderlog.txt\n");
+    printf(" Example: dsd-neo -fZ -M M17:9:DSD-NEO:ARANCORMO -i tcp -o pulse -8 --frontend terminal 2> "
+           "m17encoderlog.txt\n");
     printf("   Run M17 Encoding, listening to default tcp input, without internal decode/playback and output to 48k/1 "
            "analog output device\n");
     printf("\n");
@@ -401,8 +403,10 @@ dsd_cli_usage_section_trunking_and_tools(void) {
     printf("                 May vary based on system stregnth, etc.\n");
     printf("  -t <secs>     Set Trunking or Scan Speed VC/sync loss hangtime in seconds. (default = 2 seconds)\n");
     printf("\n");
-    printf(" Trunking Example TCP: dsd-neo -fs -i tcp -U 4532 -T -C dmr_t3_chan.csv -G group.csv -N 2> log.txt\n");
-    printf(" Trunking Example RTL: dsd-neo -fs -i rtl:0:450M:26:-2:8 -T -C connect_plus_chan.csv -G group.csv -N 2> "
+    printf(" Trunking Example TCP: dsd-neo -fs -i tcp -U 4532 -T -C dmr_t3_chan.csv -G group.csv --frontend terminal "
+           "2> log.txt\n");
+    printf(" Trunking Example RTL: dsd-neo -fs -i rtl:0:450M:26:-2:8 -T -C connect_plus_chan.csv -G group.csv "
+           "--frontend terminal 2> "
            "log.txt\n");
     printf("\n");
     printf("DMR TIII Tools:\n");

--- a/src/runtime/config_schema.c
+++ b/src/runtime/config_schema.c
@@ -58,7 +58,7 @@ static const dsdcfg_schema_entry_t s_schema[] = {
     {"output", "pulse_sink", "PulseAudio sink device name", "", NULL, DSDCFG_TYPE_STRING, 0, 0, 0},
     {"output", "pulse_output", "PulseAudio output device (alias for pulse_sink)", "", NULL, DSDCFG_TYPE_STRING, 0, 0,
      1}, /* deprecated alias */
-    {"output", "ncurses_ui", "Enable ncurses terminal UI", "false", NULL, DSDCFG_TYPE_BOOL, 0, 0, 0},
+    {"output", "frontend", "Frontend implementation", "none", "none|terminal", DSDCFG_TYPE_ENUM, 0, 0, 0},
 
     /* [mode] section */
     {"mode", "decode", "Decode mode preset", "auto",

--- a/src/runtime/config_schema.c
+++ b/src/runtime/config_schema.c
@@ -59,6 +59,8 @@ static const dsdcfg_schema_entry_t s_schema[] = {
     {"output", "pulse_output", "PulseAudio output device (alias for pulse_sink)", "", NULL, DSDCFG_TYPE_STRING, 0, 0,
      1}, /* deprecated alias */
     {"output", "frontend", "Frontend implementation", "none", "none|terminal", DSDCFG_TYPE_ENUM, 0, 0, 0},
+    {"output", "ncurses_ui", "Enable terminal frontend (alias for frontend)", "false", NULL, DSDCFG_TYPE_BOOL, 0, 0,
+     1}, /* deprecated alias */
 
     /* [mode] section */
     {"mode", "decode", "Decode mode preset", "auto",

--- a/src/runtime/config_user.cpp
+++ b/src/runtime/config_user.cpp
@@ -817,7 +817,9 @@ render_output_section(FILE* out, const dsdneoUserConfig* cfg) {
     if (cfg->pulse_output[0]) {
         DSD_FPRINTF(out, "pulse_sink = \"%s\"\n", cfg->pulse_output);
     }
-    DSD_FPRINTF(out, "frontend = \"%s\"\n", frontend_kind_to_ini_name(cfg->frontend_kind));
+    if (cfg->frontend_kind_is_set) {
+        DSD_FPRINTF(out, "frontend = \"%s\"\n", frontend_kind_to_ini_name(cfg->frontend_kind));
+    }
     DSD_FPRINTF(out, "\n");
 }
 
@@ -1123,7 +1125,9 @@ apply_output_config(const dsdneoUserConfig* cfg, dsd_opts* opts) {
         case DSDCFG_OUTPUT_NULL: DSD_SNPRINTF(opts->audio_out_dev, sizeof opts->audio_out_dev, "%s", "null"); break;
         default: break;
     }
-    opts->frontend_kind = cfg->frontend_kind;
+    if (cfg->frontend_kind_is_set) {
+        opts->frontend_kind = cfg->frontend_kind;
+    }
 }
 
 static void
@@ -1438,6 +1442,7 @@ snapshot_output_config(const dsd_opts* opts, dsdneoUserConfig* cfg) {
         cfg->output_backend = DSDCFG_OUTPUT_UNSET;
     }
     cfg->frontend_kind = opts->frontend_kind;
+    cfg->frontend_kind_is_set = 1;
 }
 
 static void

--- a/src/runtime/config_user.cpp
+++ b/src/runtime/config_user.cpp
@@ -657,6 +657,15 @@ ini_bool(int value) {
     return value ? "true" : "false";
 }
 
+static const char*
+frontend_kind_to_ini_name(dsd_frontend_kind frontend) {
+    switch (frontend) {
+        case DSD_FRONTEND_TERMINAL: return "terminal";
+        case DSD_FRONTEND_NONE:
+        default: return "none";
+    }
+}
+
 static void
 render_input_source(FILE* out, dsdneoUserInputSource source) {
     switch (source) {
@@ -808,7 +817,7 @@ render_output_section(FILE* out, const dsdneoUserConfig* cfg) {
     if (cfg->pulse_output[0]) {
         DSD_FPRINTF(out, "pulse_sink = \"%s\"\n", cfg->pulse_output);
     }
-    DSD_FPRINTF(out, "ncurses_ui = %s\n", ini_bool(cfg->ncurses_ui));
+    DSD_FPRINTF(out, "frontend = \"%s\"\n", frontend_kind_to_ini_name(cfg->frontend_kind));
     DSD_FPRINTF(out, "\n");
 }
 
@@ -1114,9 +1123,7 @@ apply_output_config(const dsdneoUserConfig* cfg, dsd_opts* opts) {
         case DSDCFG_OUTPUT_NULL: DSD_SNPRINTF(opts->audio_out_dev, sizeof opts->audio_out_dev, "%s", "null"); break;
         default: break;
     }
-    if (cfg->ncurses_ui) {
-        opts->use_ncurses_terminal = 1;
-    }
+    opts->frontend_kind = cfg->frontend_kind;
 }
 
 static void
@@ -1430,7 +1437,7 @@ snapshot_output_config(const dsd_opts* opts, dsdneoUserConfig* cfg) {
     } else {
         cfg->output_backend = DSDCFG_OUTPUT_UNSET;
     }
-    cfg->ncurses_ui = opts->use_ncurses_terminal ? 1 : 0;
+    cfg->frontend_kind = opts->frontend_kind;
 }
 
 static void

--- a/src/runtime/config_user_loader.cpp
+++ b/src/runtime/config_user_loader.cpp
@@ -414,6 +414,7 @@ apply_output_section_key(dsdneoUserConfig* cfg, const char* key_lc, const char* 
         dsd_frontend_kind frontend = DSD_FRONTEND_NONE;
         if (parse_frontend_kind_value(val, &frontend) == 0) {
             cfg->frontend_kind = frontend;
+            cfg->frontend_kind_is_set = 1;
         }
     }
 }

--- a/src/runtime/config_user_loader.cpp
+++ b/src/runtime/config_user_loader.cpp
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "config_user_internal.h"
+#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/runtime/call_alert.h"
 
@@ -260,6 +261,22 @@ parse_output_backend_value(const char* val, dsdneoUserOutputBackend* out_backend
 }
 
 static int
+parse_frontend_kind_value(const char* val, dsd_frontend_kind* out_frontend) {
+    if (!val || !*val || !out_frontend) {
+        return -1;
+    }
+    if (dsd_strcasecmp(val, "none") == 0) {
+        *out_frontend = DSD_FRONTEND_NONE;
+        return 0;
+    }
+    if (dsd_strcasecmp(val, "terminal") == 0) {
+        *out_frontend = DSD_FRONTEND_TERMINAL;
+        return 0;
+    }
+    return -1;
+}
+
+static int
 parse_demod_path_value(const char* val, dsdneoUserDemodPath* out_path) {
     if (!val || !*val || !out_path) {
         return -1;
@@ -393,10 +410,10 @@ apply_output_section_key(dsdneoUserConfig* cfg, const char* key_lc, const char* 
         }
     } else if (strcmp(key_lc, "pulse_sink") == 0 || strcmp(key_lc, "pulse_output") == 0) {
         copy_text_value(cfg->pulse_output, sizeof cfg->pulse_output, val);
-    } else if (strcmp(key_lc, "ncurses_ui") == 0) {
-        int b = 0;
-        if (parse_bool(val, &b) == 0) {
-            cfg->ncurses_ui = b;
+    } else if (strcmp(key_lc, "frontend") == 0) {
+        dsd_frontend_kind frontend = DSD_FRONTEND_NONE;
+        if (parse_frontend_kind_value(val, &frontend) == 0) {
+            cfg->frontend_kind = frontend;
         }
     }
 }

--- a/src/runtime/config_user_loader.cpp
+++ b/src/runtime/config_user_loader.cpp
@@ -276,6 +276,12 @@ parse_frontend_kind_value(const char* val, dsd_frontend_kind* out_frontend) {
     return -1;
 }
 
+static void
+set_config_frontend_kind(dsdneoUserConfig* cfg, dsd_frontend_kind frontend) {
+    cfg->frontend_kind = frontend;
+    cfg->frontend_kind_is_set = 1;
+}
+
 static int
 parse_demod_path_value(const char* val, dsdneoUserDemodPath* out_path) {
     if (!val || !*val || !out_path) {
@@ -413,8 +419,12 @@ apply_output_section_key(dsdneoUserConfig* cfg, const char* key_lc, const char* 
     } else if (strcmp(key_lc, "frontend") == 0) {
         dsd_frontend_kind frontend = DSD_FRONTEND_NONE;
         if (parse_frontend_kind_value(val, &frontend) == 0) {
-            cfg->frontend_kind = frontend;
-            cfg->frontend_kind_is_set = 1;
+            set_config_frontend_kind(cfg, frontend);
+        }
+    } else if (strcmp(key_lc, "ncurses_ui") == 0) {
+        int enabled = 0;
+        if (parse_bool(val, &enabled) == 0) {
+            set_config_frontend_kind(cfg, enabled ? DSD_FRONTEND_TERMINAL : DSD_FRONTEND_NONE);
         }
     }
 }

--- a/src/runtime/rtl_stream_metrics_hooks.c
+++ b/src/runtime/rtl_stream_metrics_hooks.c
@@ -152,6 +152,14 @@ dsd_rtl_stream_metrics_hook_snr_gfsk_db(void) {
 }
 
 double
+dsd_rtl_stream_metrics_hook_snr_gfsk_eye_db(void) {
+    if (g_rtl_stream_metrics_hooks.snr_gfsk_eye_db) {
+        return g_rtl_stream_metrics_hooks.snr_gfsk_eye_db();
+    }
+    return -100.0;
+}
+
+double
 dsd_rtl_stream_metrics_hook_snr_qpsk_const_db(void) {
     if (g_rtl_stream_metrics_hooks.snr_qpsk_const_db) {
         return g_rtl_stream_metrics_hooks.snr_qpsk_const_db();

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -1,1 +1,3 @@
-add_subdirectory(terminal)
+if(DSD_ENABLE_TERMINAL_UI)
+    add_subdirectory(terminal)
+endif()

--- a/src/ui/terminal/CMakeLists.txt
+++ b/src/ui/terminal/CMakeLists.txt
@@ -32,10 +32,8 @@ target_sources(
 
 target_include_directories(
     dsd-neo_ui_terminal
-    PUBLIC ${PROJECT_SOURCE_DIR}/include
-    PRIVATE ${_PUBLIC_INCLUDES}
-    PRIVATE ${CURSES_INCLUDE_DIRS}
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC ${PROJECT_SOURCE_DIR}/include ${CURSES_INCLUDE_DIRS}
+    PRIVATE ${_PUBLIC_INCLUDES} ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_link_libraries(

--- a/src/ui/terminal/CMakeLists.txt
+++ b/src/ui/terminal/CMakeLists.txt
@@ -34,6 +34,7 @@ target_include_directories(
     dsd-neo_ui_terminal
     PUBLIC ${PROJECT_SOURCE_DIR}/include
     PRIVATE ${_PUBLIC_INCLUDES}
+    PRIVATE ${CURSES_INCLUDE_DIRS}
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -49,7 +50,7 @@ target_link_libraries(
 
 target_link_libraries(
     dsd-neo_ui_terminal
-    PRIVATE dsd-neo_warnings dsd-neo_feature_colors
+    PRIVATE dsd-neo_warnings dsd-neo_feature_colors ${CURSES_LIBRARIES}
 )
 
 install(

--- a/src/ui/terminal/dsd_ncurses_handler.c
+++ b/src/ui/terminal/dsd_ncurses_handler.c
@@ -12,6 +12,7 @@
 
 #include <curses.h>
 #include <dsd-neo/app_control/commands.h>
+#include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/app_control/history.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
@@ -25,9 +26,6 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/platform/platform.h"
-#ifdef USE_RTLSDR
-#include <dsd-neo/io/rtl_stream_c.h>
-#endif
 
 typedef struct {
     int key;
@@ -167,10 +165,10 @@ ncurses_handle_delta_keys(int c) {
         case DSD_KEY_PPM_DOWN: ncurses_post_delta_i32(UI_CMD_PPM_DELTA, -1); return 1;
 #ifdef USE_RTLSDR
         case DSD_KEY_SPEC_DEC:
-            ncurses_post_delta_i32(UI_CMD_SPEC_SIZE_DELTA, -(rtl_stream_spectrum_get_size() / 2));
+            ncurses_post_delta_i32(UI_CMD_SPEC_SIZE_DELTA, -(dsd_app_frontend_spectrum_get_size() / 2));
             return 1;
         case DSD_KEY_SPEC_INC:
-            ncurses_post_delta_i32(UI_CMD_SPEC_SIZE_DELTA, +(rtl_stream_spectrum_get_size()));
+            ncurses_post_delta_i32(UI_CMD_SPEC_SIZE_DELTA, +(dsd_app_frontend_spectrum_get_size()));
             return 1;
 #endif
         default: return 0;

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -19,6 +19,7 @@
 #include "dsd-neo/core/input_level.h"
 
 #include <curses.h>
+#include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/app_control/history.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/power.h>
@@ -54,7 +55,6 @@
 #include "ui_snr_readout.h"
 
 #ifdef USE_RADIO
-#include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/ui/keymap.h>
 #include <dsd-neo/ui/ncurses_snr.h>
 #include <dsd-neo/ui/ncurses_visualizers.h>
@@ -147,15 +147,16 @@ ui_demod_symbol_rate_hz(const dsd_opts* opts, const dsd_state* state) {
 
 #ifdef USE_RADIO
     if (opts && state && opts->audio_in_type == AUDIO_IN_RTL && state->rtl_ctx) {
-        int symbol_rate_hz = 0;
-        int output_kind = rtl_stream_get_output_kind();
+        dsd_frontend_metrics metrics;
+        (void)dsd_app_frontend_get_metrics(opts, state, &metrics);
         /* RTL direct symbol paths feed one decoded symbol per sample; report the configured profile rate. */
-        if ((output_kind == RTL_STREAM_OUTPUT_SYMBOL_CQPSK || output_kind == RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR)
-            && rtl_stream_get_symbol_profile(&symbol_rate_hz, NULL) == 0 && symbol_rate_hz > 0) {
-            return symbol_rate_hz;
+        if ((metrics.output_kind == DSD_FRONTEND_RTL_OUTPUT_SYMBOL_CQPSK
+             || metrics.output_kind == DSD_FRONTEND_RTL_OUTPUT_FSK_DISCRIMINATOR)
+            && metrics.symbol_rate_hz > 0) {
+            return metrics.symbol_rate_hz;
         }
 
-        sample_rate_hz = (int)rtl_stream_output_rate(state->rtl_ctx);
+        sample_rate_hz = (int)metrics.output_rate_hz;
     }
 #endif
 
@@ -309,16 +310,14 @@ ui_print_rtl_gain_field(dsd_opts* opts) {
 #else
     /* Show applied tuner gain when available (actual driver value),
        otherwise fall back to requested value. */
-    int g10 = 0, is_auto = 1;
-    int have = 0;
-    if (rtl_stream_get_gain(&g10, &is_auto) == 0) {
-        have = 1;
-    }
-    if (have) {
-        if (is_auto) {
+    dsd_frontend_metrics metrics;
+    (void)dsd_app_frontend_get_metrics(opts, NULL, &metrics);
+    if (metrics.tuner_gain_valid) {
+        if (metrics.tuner_gain_is_auto) {
             printw(" G: AGC;");
         } else {
-            int gdB = (g10 >= 0) ? (g10 + 5) / 10 : (g10 - 5) / 10;
+            int gdB = (metrics.tuner_gain_tenth_db >= 0) ? (metrics.tuner_gain_tenth_db + 5) / 10
+                                                         : (metrics.tuner_gain_tenth_db - 5) / 10;
             printw(" G: %idB;", gdB);
         }
     } else {
@@ -333,12 +332,7 @@ ui_print_rtl_gain_field(dsd_opts* opts) {
 
 static void
 ui_print_rtl_ppm_field(const dsd_opts* opts) {
-    int requested_ppm = 0;
-#ifdef USE_RADIO
-    requested_ppm = rtl_stream_get_requested_ppm(opts);
-#else
-    requested_ppm = opts->rtlsdr_ppm_error;
-#endif
+    int requested_ppm = dsd_app_frontend_requested_ppm(opts);
     printw(" PPM: %i;", requested_ppm); //Adjust manually now with { and }
 }
 
@@ -363,19 +357,10 @@ ui_print_rtl_auto_ppm_status(void) {
     ui_print_rtl_auto_ppm_status_values(0, 0, 0, -100.0, 0.0, 0);
 #else
     /* Show carrier/error-based auto PPM status snapshot */
-    int ap_en = 0, ap_dir = 0, ap_locked = 0;
-    double ap_snr = -100.0, ap_df = 0.0;
-    (void)rtl_stream_auto_ppm_get_status(&ap_en, &ap_snr, &ap_df, NULL, &ap_dir, NULL, &ap_locked);
-    if (ap_locked) {
-        int locked_ppm = 0;
-        double lsnr = -100.0, ldf = 0.0;
-        (void)rtl_stream_auto_ppm_get_lock(&locked_ppm, &lsnr, &ldf);
-        (void)lsnr;
-        (void)ldf;
-        ui_print_rtl_auto_ppm_status_values(ap_en, ap_locked, locked_ppm, ap_snr, ap_df, ap_dir);
-        return;
-    }
-    ui_print_rtl_auto_ppm_status_values(ap_en, ap_locked, 0, ap_snr, ap_df, ap_dir);
+    dsd_frontend_metrics metrics;
+    (void)dsd_app_frontend_get_metrics(NULL, NULL, &metrics);
+    ui_print_rtl_auto_ppm_status_values(metrics.auto_ppm_enabled, metrics.auto_ppm_locked, metrics.auto_ppm_locked_ppm,
+                                        metrics.auto_ppm_snr_db, metrics.auto_ppm_df_hz, metrics.auto_ppm_step_dir);
 #endif
 }
 
@@ -955,7 +940,7 @@ ui_render_rtl_visual_aids(dsd_opts* opts, dsd_state* state) {
     /* Only show RTL-SDR section and render visualizers when RTL input is active */
     if (opts->audio_in_type == AUDIO_IN_RTL) {
         ui_print_header(ui_audio_in_is_soapy(opts) ? "SoapySDR Visual Aids" : "RTL-SDR Visual Aids");
-        int nfft = rtl_stream_spectrum_get_size();
+        int nfft = dsd_app_frontend_spectrum_get_size();
         ui_print_rtl_visual_aids_controls(opts, nfft);
         ui_render_rtl_visual_aid_panels(opts, state);
     }

--- a/src/ui/terminal/menu_actions.c
+++ b/src/ui/terminal/menu_actions.c
@@ -10,11 +10,11 @@
 
 #include "menu_actions.h"
 #include <dsd-neo/app_control/commands.h>
+#include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
-#include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/audio.h>
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/runtime/config.h>
@@ -1243,7 +1243,7 @@ rtl_set_gain(void* v) {
 void
 rtl_set_ppm(void* v) {
     UiCtx* c = (UiCtx*)v;
-    ui_prompt_open_int_async("PPM error (-200..200)", rtl_stream_get_requested_ppm(c->opts), cb_rtl_ppm, c);
+    ui_prompt_open_int_async("PPM error (-200..200)", dsd_app_frontend_requested_ppm(c->opts), cb_rtl_ppm, c);
 }
 
 void
@@ -1345,7 +1345,7 @@ act_iq_dc_k_dn(void* v) {
 void
 act_ted_gain_up(void* v) {
     UNUSED(v);
-    float g = rtl_stream_get_ted_gain();
+    float g = dsd_app_frontend_ted_gain();
     int g_milli = (int)(g * 1000.0f + 0.5f);
     if (g_milli < 500) {
         g_milli += 5;
@@ -1357,7 +1357,7 @@ act_ted_gain_up(void* v) {
 void
 act_ted_gain_dn(void* v) {
     UNUSED(v);
-    float g = rtl_stream_get_ted_gain();
+    float g = dsd_app_frontend_ted_gain();
     int g_milli = (int)(g * 1000.0f + 0.5f);
     if (g_milli > 10) {
         g_milli -= 5;

--- a/src/ui/terminal/menu_labels.c
+++ b/src/ui/terminal/menu_labels.c
@@ -9,7 +9,7 @@
  */
 
 #include "menu_labels.h"
-#include <dsd-neo/core/constants.h>
+#include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/io/tcp_input.h>
@@ -25,12 +25,6 @@
 #include "menu_internal.h"
 #include "menu_items.h"
 #include "ui_key_status.h"
-
-#ifdef USE_RADIO
-#include <dsd-neo/io/rtl_stream_c.h>
-#else
-extern int rtl_stream_get_auto_ppm(void);
-#endif
 
 // ---- Visibility/predicate functions ----
 
@@ -59,18 +53,24 @@ io_rtl_active(const void* ctx) {
 }
 
 #ifdef USE_RADIO
+static dsd_frontend_metrics
+menu_frontend_metrics(const void* v) {
+    const UiCtx* c = (const UiCtx*)v;
+    dsd_frontend_metrics metrics;
+    (void)dsd_app_frontend_get_metrics(c ? c->opts : NULL, c ? c->state : NULL, &metrics);
+    return metrics;
+}
+
 static bool
-rtl_fsk_symbol_output_active_for_ui(void) {
-    int output_kind = rtl_stream_get_output_kind();
-    return output_kind == RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
+rtl_fsk_symbol_output_active_for_ui(const void* v) {
+    dsd_frontend_metrics metrics = menu_frontend_metrics(v);
+    return metrics.output_kind == DSD_FRONTEND_RTL_OUTPUT_FSK_DISCRIMINATOR;
 }
 
 bool
 dsp_cq_on(const void* v) {
-    UNUSED(v);
-    int cq = 0;
-    rtl_stream_get_cqpsk_status(&cq, NULL);
-    return cq != 0;
+    dsd_frontend_metrics metrics = menu_frontend_metrics(v);
+    return metrics.cqpsk_enable != 0;
 }
 
 int
@@ -98,9 +98,8 @@ ui_current_mod(const void* v) {
     }
 
     // Snap to the active DSP path: CQPSK toggle always means QPSK path
-    int cq = 0;
-    rtl_stream_get_cqpsk_status(&cq, NULL);
-    if (cq) {
+    dsd_frontend_metrics metrics = menu_frontend_metrics(v);
+    if (metrics.cqpsk_enable) {
         mod = 1;
     }
 
@@ -123,7 +122,7 @@ is_not_qpsk(const void* v) {
 
 bool
 is_ted_allowed(const void* v) {
-    return !rtl_fsk_symbol_output_active_for_ui() && is_mod_qpsk(v);
+    return !rtl_fsk_symbol_output_active_for_ui(v) && is_mod_qpsk(v);
 }
 
 // DSP submenu arrays declared in menu_items.h
@@ -891,43 +890,36 @@ lbl_m17_user_data(const void* v, char* b, size_t n) {
 
 const char*
 lbl_onoff_cq(const void* v, char* b, size_t n) {
-    UNUSED(v);
-    int cq = 0;
-    rtl_stream_get_cqpsk_status(&cq, NULL);
-    DSD_SNPRINTF(b, n, "Toggle CQPSK [%s]", cq ? "Active" : "Inactive");
+    dsd_frontend_metrics metrics = menu_frontend_metrics(v);
+    DSD_SNPRINTF(b, n, "Toggle CQPSK [%s]", metrics.cqpsk_enable ? "Active" : "Inactive");
     return b;
 }
 
 const char*
 lbl_onoff_iqbal(const void* v, char* b, size_t n) {
-    UNUSED(v);
-    int on = rtl_stream_get_iq_balance();
-    DSD_SNPRINTF(b, n, "Toggle IQ Balance [%s]", on ? "Active" : "Inactive");
+    dsd_frontend_metrics metrics = menu_frontend_metrics(v);
+    DSD_SNPRINTF(b, n, "Toggle IQ Balance [%s]", metrics.iq_balance ? "Active" : "Inactive");
     return b;
 }
 
 const char*
 lbl_iq_dc(const void* v, char* b, size_t n) {
-    UNUSED(v);
-    int k = 0;
-    int on = rtl_stream_get_iq_dc(&k);
-    DSD_SNPRINTF(b, n, "IQ DC Block [%s]", on ? "On" : "Off");
+    dsd_frontend_metrics metrics = menu_frontend_metrics(v);
+    DSD_SNPRINTF(b, n, "IQ DC Block [%s]", metrics.iq_dc_enabled ? "On" : "Off");
     return b;
 }
 
 const char*
 lbl_iq_dc_k(const void* v, char* b, size_t n) {
-    UNUSED(v);
-    int k = 0;
-    rtl_stream_get_iq_dc(&k);
-    DSD_SNPRINTF(b, n, "IQ DC Shift k: %d (+/-)", k);
+    dsd_frontend_metrics metrics = menu_frontend_metrics(v);
+    DSD_SNPRINTF(b, n, "IQ DC Shift k: %d (+/-)", metrics.iq_dc_shift_k);
     return b;
 }
 
 const char*
 lbl_ted_gain(const void* v, char* b, size_t n) {
-    UNUSED(v);
-    float g = rtl_stream_get_ted_gain();
+    dsd_frontend_metrics metrics = menu_frontend_metrics(v);
+    float g = metrics.ted_gain;
     int g_milli = (int)(g * 1000.0f + 0.5f);
     DSD_SNPRINTF(b, n, "CQPSK Timing Gain: %d (x0.001, +/-)", g_milli);
     return b;
@@ -935,9 +927,8 @@ lbl_ted_gain(const void* v, char* b, size_t n) {
 
 const char*
 lbl_cqpsk_timing_bias(const void* v, char* b, size_t n) {
-    UNUSED(v);
-    int eb = rtl_stream_cqpsk_timing_bias(NULL);
-    DSD_SNPRINTF(b, n, "CQPSK Timing Bias (EMA): %d", eb);
+    dsd_frontend_metrics metrics = menu_frontend_metrics(v);
+    DSD_SNPRINTF(b, n, "CQPSK Timing Bias (EMA): %d", metrics.cqpsk_timing_bias);
     return b;
 }
 
@@ -964,12 +955,8 @@ lbl_rtl_rtltcp_autotune(const void* v, char* b, size_t n) {
 
 const char*
 lbl_rtl_auto_ppm(const void* v, char* b, size_t n) {
-    UiCtx* c = (UiCtx*)v;
-    int on = c->opts->rtl_auto_ppm ? 1 : 0;
-    /* If stream active, reflect runtime state */
-    if (c->state && c->state->rtl_ctx) {
-        on = rtl_stream_get_auto_ppm();
-    }
+    const UiCtx* c = (const UiCtx*)v;
+    int on = dsd_app_frontend_auto_ppm_enabled(c ? c->state : NULL, (c && c->opts) ? c->opts->rtl_auto_ppm : 0);
     DSD_SNPRINTF(b, n, "Auto-PPM (Spectrum): %s", on ? "On" : "Off");
     return b;
 }
@@ -977,13 +964,8 @@ lbl_rtl_auto_ppm(const void* v, char* b, size_t n) {
 const char*
 lbl_rtl_tuner_autogain(const void* v, char* b, size_t n) {
     const UiCtx* c = (const UiCtx*)v;
-    int on = 0;
-    if (c->state && c->state->rtl_ctx) {
-        on = rtl_stream_get_tuner_autogain();
-    } else {
-        const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
-        on = (cfg && cfg->tuner_autogain_enable) ? 1 : 0;
-    }
+    const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
+    int on = dsd_app_frontend_tuner_autogain_enabled(c ? c->state : NULL, (cfg && cfg->tuner_autogain_enable) ? 1 : 0);
     DSD_SNPRINTF(b, n, "Tuner Autogain: %s", on ? "On" : "Off");
     return b;
 }

--- a/src/ui/terminal/ncurses_dsp_display.c
+++ b/src/ui/terminal/ncurses_dsp_display.c
@@ -8,6 +8,7 @@
  */
 
 #include <curses.h>
+#include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state.h>
@@ -19,10 +20,6 @@
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/platform/platform.h"
 #include "ncurses_dsp_status_format.h"
-
-#ifdef USE_RTLSDR
-#include <dsd-neo/io/rtl_stream_c.h>
-#endif
 
 #ifdef USE_RADIO
 
@@ -75,6 +72,7 @@ dsp_status_print_squelch(const dsd_opts* opts) {
 #ifdef USE_RTLSDR
 
 typedef struct {
+    dsd_frontend_metrics metrics;
     int cq;
     int cq_timing;
     int iqb;
@@ -98,20 +96,20 @@ dsp_status_mod_label(int mod) {
 static void
 dsp_status_capture(dsp_status_snapshot* snap, const dsd_state* state) {
     DSD_MEMSET(snap, 0, sizeof(*snap));
-    rtl_stream_get_cqpsk_status(&snap->cq, &snap->cq_timing);
-    snap->iqb = rtl_stream_get_iq_balance();
-    snap->dc_on = rtl_stream_get_iq_dc(&snap->dc_k);
+    (void)dsd_app_frontend_get_metrics(NULL, state, &snap->metrics);
+    snap->cq = snap->metrics.cqpsk_enable;
+    snap->cq_timing = snap->metrics.cqpsk_timing_active;
+    snap->iqb = snap->metrics.iq_balance;
+    snap->dc_on = snap->metrics.iq_dc_enabled;
+    snap->dc_k = snap->metrics.iq_dc_shift_k;
     snap->mod = state ? state->rf_mod : (snap->cq ? 1 : 0);
     snap->modlab = dsp_status_mod_label(snap->mod);
 }
 
 static void
 dsp_status_print_ted(const dsp_status_snapshot* snap) {
-    int ted_sps = rtl_stream_get_ted_sps();
-    float ted_gain = rtl_stream_get_ted_gain();
-    int timing_bias = rtl_stream_cqpsk_timing_bias(NULL);
-    ui_print_kv_line("CQPSK Timing", "[%s] sps:%d g:%.3f bias:%d", snap->cq_timing ? "On" : "Off", ted_sps, ted_gain,
-                     timing_bias);
+    ui_print_kv_line("CQPSK Timing", "[%s] sps:%d g:%.3f bias:%d", snap->cq_timing ? "On" : "Off",
+                     snap->metrics.ted_sps, snap->metrics.ted_gain, snap->metrics.cqpsk_timing_bias);
 }
 
 static void
@@ -126,22 +124,13 @@ dsp_status_print_front_and_path(const dsp_status_snapshot* snap) {
 }
 
 static void
-dsp_status_print_cqpsk_metrics(void) {
-    double cfo = rtl_stream_get_cfo_hz();
-    int clk = rtl_stream_get_carrier_lock();
-    rtl_stream_costas_metrics cm;
-    DSD_MEMSET(&cm, 0, sizeof(cm));
-    int e14 = rtl_stream_get_costas_err_q14();
-    if (rtl_stream_get_costas_metrics(&cm) == 0) {
-        e14 = cm.err_smooth_avg_q14;
-    }
-    int nco_q15 = rtl_stream_get_nco_q15();
-    int Fs = rtl_stream_get_demod_rate_hz();
-    double fll_be_hz = rtl_stream_get_fll_band_edge_freq_hz();
-    ui_print_kv_line("FLL BE", "Freq=%+0.1f Hz", fll_be_hz);
-    ui_print_kv_line("Carrier", "NCO=%+0.1f Hz  %s", cfo, clk ? "Locked" : "Acq");
-    ui_print_kv_line("Costas/NCO", "ErrS=%d ErrR=%d Conf=%0.2f Fade=%d%% NCO(q15)=%d Fs=%d Hz", e14, cm.err_raw_avg_q14,
-                     (double)cm.confidence_avg_q14 / 16384.0, cm.zero_conf_pct, nco_q15, Fs);
+dsp_status_print_cqpsk_metrics(const dsp_status_snapshot* snap) {
+    const dsd_frontend_metrics* metrics = &snap->metrics;
+    ui_print_kv_line("FLL BE", "Freq=%+0.1f Hz", metrics->fll_band_edge_freq_hz);
+    ui_print_kv_line("Carrier", "NCO=%+0.1f Hz  %s", metrics->cfo_hz, metrics->carrier_lock ? "Locked" : "Acq");
+    ui_print_kv_line("Costas/NCO", "ErrS=%d ErrR=%d Conf=%0.2f Fade=%d%% NCO(q15)=%d Fs=%d Hz", metrics->costas_err_q14,
+                     metrics->costas.err_raw_avg_q14, (double)metrics->costas.confidence_avg_q14 / 16384.0,
+                     metrics->costas.zero_conf_pct, metrics->nco_q15, metrics->demod_rate_hz);
 }
 
 #endif
@@ -172,7 +161,7 @@ print_dsp_status(dsd_opts* opts, dsd_state* state) {
     dsp_status_print_squelch(opts);
 #ifdef USE_RTLSDR
     if (snap.cq) {
-        dsp_status_print_cqpsk_metrics();
+        dsp_status_print_cqpsk_metrics(&snap);
     }
 #endif
     attroff(COLOR_PAIR(14));

--- a/src/ui/terminal/ncurses_p25_display.c
+++ b/src/ui/terminal/ncurses_p25_display.c
@@ -8,12 +8,12 @@
  */
 
 #include <curses.h>
+#include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
-#include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
@@ -572,14 +572,15 @@ ui_print_p25_rtl_metrics(int is_p25p1, int is_p25p2) {
     if (!is_p25p1 && !is_p25p2) {
         return 0;
     }
-    rtl_stream_decode_health health;
-    DSD_MEMSET(&health, 0, sizeof(health));
-    if (rtl_stream_get_decode_health(&health) != 0 || !health.valid) {
+    dsd_frontend_metrics metrics;
+    (void)dsd_app_frontend_get_metrics(NULL, NULL, &metrics);
+    const dsd_frontend_decode_health* health = &metrics.decode_health;
+    if (!health->valid) {
         return 0;
     }
-    printw("| RTL Health: P1 FEC %u/%u P2 FACCH %u/%u SACCH %u/%u VERR %u\n", health.p25p1_fec_ok, health.p25p1_fec_err,
-           health.p25p2_facch_ok, health.p25p2_facch_err, health.p25p2_sacch_ok, health.p25p2_sacch_err,
-           health.p25p2_voice_err);
+    printw("| RTL Health: P1 FEC %u/%u P2 FACCH %u/%u SACCH %u/%u VERR %u\n", health->p25p1_fec_ok,
+           health->p25p1_fec_err, health->p25p2_facch_ok, health->p25p2_facch_err, health->p25p2_sacch_ok,
+           health->p25p2_sacch_err, health->p25p2_voice_err);
     return 1;
 #else
     UNUSED(is_p25p1);

--- a/src/ui/terminal/ncurses_visualizers.c
+++ b/src/ui/terminal/ncurses_visualizers.c
@@ -8,6 +8,7 @@
  */
 
 #include <curses.h>
+#include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/ui/ncurses_visualizers.h>
 #include <dsd-neo/ui/ui_prims.h>
@@ -17,7 +18,6 @@
 #ifdef USE_RTLSDR
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
-#include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/ui/ncurses_internal.h>
 #include <math.h>
 #include <stdint.h>
@@ -964,11 +964,12 @@ eye_estimate_snr_fallback(const float* buf, int n, int sps, int two_sps, int q1,
     double noise_var = eye_snr_noise_var(buf, n, two_sps, c1, c2, win, q1, q2, q3, mu, total);
     double sig_var = eye_snr_signal_var(mu, cnt, total);
     if (noise_var > 1e-9 && sig_var > 1e-9) {
-#ifdef USE_RTLSDR
-        double bias = rtl_stream_get_snr_bias_c4fm();
-#else
-        double bias = 8.0;
-#endif
+        dsd_frontend_metrics metrics;
+        (void)dsd_app_frontend_get_metrics(NULL, NULL, &metrics);
+        double bias = metrics.snr_bias_c4fm;
+        if (bias == 0.0) {
+            bias = 8.0;
+        }
         snr_db = 10.0 * log10(sig_var / noise_var) - bias;
     }
     return snr_db;
@@ -983,7 +984,7 @@ print_constellation_view(dsd_opts* opts, dsd_state* state) {
     enum { MAXP = 4096 };
 
     float buf[(size_t)MAXP * 2];
-    int n = rtl_stream_constellation_get(buf, MAXP);
+    int n = dsd_app_frontend_constellation_get(buf, MAXP);
     ui_print_header("Constellation");
     if (n <= 0) {
         ui_print_lborder();
@@ -1039,7 +1040,7 @@ print_eye_view(dsd_opts* opts, dsd_state* state) {
 
     static float buf[(size_t)MAXS];
     int sps = 0;
-    int n = rtl_stream_eye_get(buf, MAXS, &sps);
+    int n = dsd_app_frontend_eye_get(buf, MAXS, &sps);
     ui_print_header("Eye Diagram (C4FM/FSK)");
     int use_unicode_ui = eye_effective_unicode_ui(opts);
     if (n <= 0 || sps <= 0) {
@@ -1106,7 +1107,9 @@ print_eye_view(dsd_opts* opts, dsd_state* state) {
     }
 #ifdef USE_RTLSDR
     if (is_c4fm) {
-        snr_db = rtl_stream_get_snr_c4fm();
+        dsd_frontend_metrics metrics;
+        (void)dsd_app_frontend_get_metrics(opts, state, &metrics);
+        snr_db = metrics.snr_c4fm_db;
     }
 #endif
     if (is_c4fm && snr_db < -20.0) {
@@ -1261,7 +1264,7 @@ print_fsk_hist_view_rtlsdr(void) {
     static float buf[(size_t)MAXS];
     static int vals[8192];
     int sps = 0;
-    int n = rtl_stream_eye_get(buf, MAXS, &sps);
+    int n = dsd_app_frontend_eye_get(buf, MAXS, &sps);
     UNUSED(sps);
 
     ui_print_header("FSK 4-Level Histogram");
@@ -1323,7 +1326,7 @@ print_fsk_hist_view(void) {
 #ifdef USE_RTLSDR
 static int
 spectrum_nfft_clamped(void) {
-    int nfft = rtl_stream_spectrum_get_size();
+    int nfft = dsd_app_frontend_spectrum_get_size();
     if (nfft < 64) {
         nfft = 64;
     }
@@ -1484,7 +1487,7 @@ spectrum_print_color_legend(int use_unicode) {
 static void
 spectrum_print_legend(const dsd_opts* opts, int rate, int w, int use_unicode, float vmax, float vmin) {
     float span_hz = (float)rate;
-    int nfft2 = rtl_stream_spectrum_get_size();
+    int nfft2 = dsd_app_frontend_spectrum_get_size();
     const char* df = use_unicode ? "\xCE\x94"
                                    "f"
                                  : "df";
@@ -1512,7 +1515,7 @@ print_spectrum_view_rtlsdr(const dsd_opts* opts) {
 
     int rate = 0;
     int nfft = spectrum_nfft_clamped();
-    int n = rtl_stream_spectrum_get(bins_static, nfft, &rate);
+    int n = dsd_app_frontend_spectrum_get(bins_static, nfft, &rate);
     ui_print_header("Spectrum Analyzer");
     if (n <= 0) {
         printw("| (no spectrum yet)\n");

--- a/src/ui/terminal/panels/header.c
+++ b/src/ui/terminal/panels/header.c
@@ -24,7 +24,7 @@ ui_panel_header_render(const dsd_opts* opts, dsd_state* state) {
         return;
     }
     // header banner
-    if (opts->ncurses_compact == 1) {
+    if (opts->terminal_compact == 1) {
         ui_print_hr();
         printw("| Digital Speech Decoder: DSD-neo %s (%s)  | Enter=Menu  q=Quit\n", GIT_TAG, GIT_HASH);
         ui_print_hr();
@@ -37,7 +37,7 @@ ui_panel_header_render(const dsd_opts* opts, dsd_state* state) {
         attron(COLOR_PAIR(4));
     }
     // fix color/pair issue when compact and trunking enabled
-    if (opts->ncurses_compact == 1 && opts->p25_trunk == 1) {
+    if (opts->terminal_compact == 1 && opts->p25_trunk == 1) {
         attron(COLOR_PAIR(4));
     }
 }

--- a/src/ui/terminal/ui_async.c
+++ b/src/ui/terminal/ui_async.c
@@ -113,6 +113,22 @@ ui_process_input_frame(const dsd_opts* osnap) {
     ui_handle_normal_input(ch);
 }
 
+static int
+ui_open_curses_if_needed(void) {
+    if (!dsd_opts_frontend_is_terminal(g_ui_opts)) {
+        return 0;
+    }
+    ncursesOpen(g_ui_opts, g_ui_state);
+    return 1;
+}
+
+static void
+ui_close_curses_if_opened(int curses_opened) {
+    if (curses_opened) {
+        ncursesClose();
+    }
+}
+
 static void
 ui_draw_frame(const dsd_opts* osnap) {
     /* Draw using a state snapshot when available */
@@ -168,6 +184,16 @@ dsd_neo_ui_async_test_process_input_frame(const dsd_opts* opts) {
     ui_process_input_frame(opts);
 }
 
+int
+dsd_neo_ui_async_test_open_curses_if_needed(void) {
+    return ui_open_curses_if_needed();
+}
+
+void
+dsd_neo_ui_async_test_close_curses_if_opened(int curses_opened) {
+    ui_close_curses_if_opened(curses_opened);
+}
+
 void
 dsd_neo_ui_async_test_draw_if_needed(const dsd_opts* opts, uint64_t* last_draw_ns, uint64_t frame_ns) {
     if (last_draw_ns == NULL) {
@@ -187,9 +213,7 @@ static DSD_THREAD_RETURN_TYPE
     const unsigned int sleep_ms = 15; // ~15 ms sleep cadence
 
     // Initialize ncurses lifecycle in UI thread
-    if (dsd_opts_frontend_is_terminal(g_ui_opts)) {
-        ncursesOpen(g_ui_opts, g_ui_state);
-    }
+    int curses_opened = ui_open_curses_if_needed();
 
     uint64_t last_draw_ns = dsd_time_monotonic_ns();
     const uint64_t frame_ns = 66ULL * 1000ULL * 1000ULL; // ~15 FPS cap
@@ -205,9 +229,7 @@ static DSD_THREAD_RETURN_TYPE
         dsd_sleep_ms(sleep_ms);
     }
 
-    if (dsd_opts_frontend_is_terminal(g_ui_opts)) {
-        ncursesClose();
-    }
+    ui_close_curses_if_opened(curses_opened);
 
     DSD_THREAD_RETURN;
 }

--- a/src/ui/terminal/ui_async.c
+++ b/src/ui/terminal/ui_async.c
@@ -54,7 +54,7 @@ ui_get_opts_snapshot_or_default(void) {
 
 static int
 ui_curses_is_active(const dsd_opts* osnap) {
-    return (osnap && osnap->use_ncurses_terminal == 1 && stdscr != NULL);
+    return (dsd_opts_frontend_is_terminal(osnap) && stdscr != NULL);
 }
 
 static void
@@ -187,7 +187,7 @@ static DSD_THREAD_RETURN_TYPE
     const unsigned int sleep_ms = 15; // ~15 ms sleep cadence
 
     // Initialize ncurses lifecycle in UI thread
-    if (g_ui_opts && g_ui_opts->use_ncurses_terminal == 1) {
+    if (dsd_opts_frontend_is_terminal(g_ui_opts)) {
         ncursesOpen(g_ui_opts, g_ui_state);
     }
 
@@ -205,7 +205,7 @@ static DSD_THREAD_RETURN_TYPE
         dsd_sleep_ms(sleep_ms);
     }
 
-    if (g_ui_opts && g_ui_opts->use_ncurses_terminal == 1) {
+    if (dsd_opts_frontend_is_terminal(g_ui_opts)) {
         ncursesClose();
     }
 
@@ -221,7 +221,7 @@ ui_start(dsd_opts* opts, dsd_state* state) {
     dsd_app_install_telemetry_hooks();
     g_ui_opts = opts;
     g_ui_state = state;
-    ui_history_set_mode(opts ? opts->ncurses_history : 1);
+    ui_history_set_mode(opts ? opts->terminal_history : 1);
     atomic_store(&g_ui_stop, 0);
 
     if (dsd_thread_create(&g_ui_thread, ui_thread_main, NULL) != 0) {

--- a/src/ui/terminal/ui_snr_readout.c
+++ b/src/ui/terminal/ui_snr_readout.c
@@ -33,7 +33,7 @@ ui_snr_value_is_valid(double snr) {
 static double
 ui_snr_get_c4fm_value(void) {
     dsd_frontend_metrics metrics;
-    (void)dsd_app_frontend_get_metrics(NULL, NULL, &metrics);
+    (void)dsd_app_frontend_get_metrics_with_snr_fallbacks(NULL, NULL, &metrics, DSD_FRONTEND_SNR_FALLBACK_C4FM_EYE);
     double snr = metrics.snr_c4fm_db;
     if (!ui_snr_value_is_valid(snr)) {
         double fb = metrics.snr_c4fm_eye_db;
@@ -47,7 +47,7 @@ ui_snr_get_c4fm_value(void) {
 static double
 ui_snr_get_qpsk_value(void) {
     dsd_frontend_metrics metrics;
-    (void)dsd_app_frontend_get_metrics(NULL, NULL, &metrics);
+    (void)dsd_app_frontend_get_metrics_with_snr_fallbacks(NULL, NULL, &metrics, DSD_FRONTEND_SNR_FALLBACK_QPSK_CONST);
     double snr = metrics.snr_cqpsk_db;
     if (!ui_snr_value_is_valid(snr)) {
         double fb = metrics.snr_qpsk_const_db;
@@ -68,7 +68,7 @@ ui_snr_get_qpsk_value(void) {
 static double
 ui_snr_get_gfsk_value(void) {
     dsd_frontend_metrics metrics;
-    (void)dsd_app_frontend_get_metrics(NULL, NULL, &metrics);
+    (void)dsd_app_frontend_get_metrics_with_snr_fallbacks(NULL, NULL, &metrics, DSD_FRONTEND_SNR_FALLBACK_GFSK_EYE);
     double snr = metrics.snr_gfsk_db;
     if (!ui_snr_value_is_valid(snr)) {
         double fb = metrics.snr_gfsk_eye_db;

--- a/src/ui/terminal/ui_snr_readout.c
+++ b/src/ui/terminal/ui_snr_readout.c
@@ -5,8 +5,10 @@
 
 #include "ui_snr_readout.h"
 
+#include <stddef.h>
+
 #ifdef USE_RADIO
-#include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/app_control/frontend.h>
 #endif
 
 enum { UI_SNR_INVALID_DB = -50 };
@@ -30,9 +32,11 @@ ui_snr_value_is_valid(double snr) {
 
 static double
 ui_snr_get_c4fm_value(void) {
-    double snr = rtl_stream_get_snr_c4fm();
+    dsd_frontend_metrics metrics;
+    (void)dsd_app_frontend_get_metrics(NULL, NULL, &metrics);
+    double snr = metrics.snr_c4fm_db;
     if (!ui_snr_value_is_valid(snr)) {
-        double fb = rtl_stream_estimate_snr_c4fm_eye();
+        double fb = metrics.snr_c4fm_eye_db;
         if (ui_snr_value_is_valid(fb)) {
             snr = fb;
         }
@@ -42,14 +46,16 @@ ui_snr_get_c4fm_value(void) {
 
 static double
 ui_snr_get_qpsk_value(void) {
-    double snr = rtl_stream_get_snr_cqpsk();
+    dsd_frontend_metrics metrics;
+    (void)dsd_app_frontend_get_metrics(NULL, NULL, &metrics);
+    double snr = metrics.snr_cqpsk_db;
     if (!ui_snr_value_is_valid(snr)) {
-        double fb = rtl_stream_estimate_snr_qpsk_const();
+        double fb = metrics.snr_qpsk_const_db;
         if (ui_snr_value_is_valid(fb)) {
             snr = fb;
         } else {
-            double snr_c = rtl_stream_get_snr_c4fm();
-            double snr_g = rtl_stream_get_snr_gfsk();
+            double snr_c = metrics.snr_c4fm_db;
+            double snr_g = metrics.snr_gfsk_db;
             double snr_fb = (snr_c > snr_g) ? snr_c : snr_g;
             if (ui_snr_value_is_valid(snr_fb)) {
                 snr = snr_fb;
@@ -61,9 +67,11 @@ ui_snr_get_qpsk_value(void) {
 
 static double
 ui_snr_get_gfsk_value(void) {
-    double snr = rtl_stream_get_snr_gfsk();
+    dsd_frontend_metrics metrics;
+    (void)dsd_app_frontend_get_metrics(NULL, NULL, &metrics);
+    double snr = metrics.snr_gfsk_db;
     if (!ui_snr_value_is_valid(snr)) {
-        double fb = rtl_stream_estimate_snr_gfsk_eye();
+        double fb = metrics.snr_gfsk_eye_db;
         if (ui_snr_value_is_valid(fb)) {
             snr = fb;
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1984,7 +1984,9 @@ target_include_directories(
 )
 target_compile_definitions(
     dsd-neo_test_runtime_bootstrap_interactive
-    PRIVATE USE_RTLSDR
+    PRIVATE
+        USE_RTLSDR
+        DSD_RUNTIME_HAS_TERMINAL_UI=$<BOOL:${DSD_ENABLE_TERMINAL_UI}>
 )
 add_test(
     NAME RUNTIME_BOOTSTRAP_INTERACTIVE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1861,6 +1861,25 @@ target_link_libraries(dsd-neo_test_ui_opts_snapshot PRIVATE dsd-neo_platform)
 add_test(NAME UI_OPTS_SNAPSHOT COMMAND dsd-neo_test_ui_opts_snapshot)
 
 add_executable(
+    dsd-neo_test_ui_frontend_status_metrics
+    ui/test_ui_frontend_status_metrics.c
+    ${PROJECT_SOURCE_DIR}/src/app_control/frontend.c
+    ${PROJECT_SOURCE_DIR}/src/runtime/rtl_stream_metrics_hooks.c
+)
+target_include_directories(
+    dsd-neo_test_ui_frontend_status_metrics
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_ui_frontend_status_metrics
+    PRIVATE dsd-neo_platform
+)
+add_test(
+    NAME UI_FRONTEND_STATUS_METRICS
+    COMMAND dsd-neo_test_ui_frontend_status_metrics
+)
+
+add_executable(
     dsd-neo_test_runtime_freq_parse
     runtime/test_runtime_freq_parse.c
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1200,20 +1200,24 @@ add_test(
     COMMAND dsd-neo_test_runtime_p25_p2_audio_ring
 )
 
-add_executable(
-    dsd-neo_test_ui_async_lifecycle
-    ui/test_ui_async_lifecycle.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_async.c
-)
-target_compile_definitions(
-    dsd-neo_test_ui_async_lifecycle
-    PRIVATE DSD_NEO_THREADING_NO_INLINE_CREATE DSD_NEO_TEST_HOOKS
-)
-target_include_directories(
-    dsd-neo_test_ui_async_lifecycle
-    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
-)
-add_test(NAME UI_ASYNC_LIFECYCLE COMMAND dsd-neo_test_ui_async_lifecycle)
+if(DSD_ENABLE_TERMINAL_UI)
+    add_executable(
+        dsd-neo_test_ui_async_lifecycle
+        ui/test_ui_async_lifecycle.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_async.c
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_async_lifecycle
+        PRIVATE DSD_NEO_THREADING_NO_INLINE_CREATE DSD_NEO_TEST_HOOKS
+    )
+    target_include_directories(
+        dsd-neo_test_ui_async_lifecycle
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+    )
+    add_test(NAME UI_ASYNC_LIFECYCLE COMMAND dsd-neo_test_ui_async_lifecycle)
+endif()
 
 add_executable(
     dsd-neo_test_ui_cmd_actions
@@ -1241,113 +1245,123 @@ target_include_directories(
 target_compile_definitions(dsd-neo_test_ui_menu_services PRIVATE USE_RADIO)
 add_test(NAME UI_MENU_SERVICES COMMAND dsd-neo_test_ui_menu_services)
 
-add_executable(
-    dsd-neo_test_ui_menu_labels
-    ui/test_ui_menu_labels.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_labels.c
-)
-target_include_directories(
-    dsd-neo_test_ui_menu_labels
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
-)
-add_test(NAME UI_MENU_LABELS COMMAND dsd-neo_test_ui_menu_labels)
+if(DSD_ENABLE_TERMINAL_UI)
+    add_executable(
+        dsd-neo_test_ui_menu_labels
+        ui/test_ui_menu_labels.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_labels.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_menu_labels
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${CURSES_INCLUDE_DIRS}
+    )
+    add_test(NAME UI_MENU_LABELS COMMAND dsd-neo_test_ui_menu_labels)
 
-add_executable(
-    dsd-neo_test_ui_menu_labels_radio
-    ui/test_ui_menu_labels_radio.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_labels.c
-)
-target_include_directories(
-    dsd-neo_test_ui_menu_labels_radio
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
-)
-target_compile_definitions(dsd-neo_test_ui_menu_labels_radio PRIVATE USE_RADIO)
-add_test(NAME UI_MENU_LABELS_RADIO COMMAND dsd-neo_test_ui_menu_labels_radio)
+    add_executable(
+        dsd-neo_test_ui_menu_labels_radio
+        ui/test_ui_menu_labels_radio.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_labels.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_menu_labels_radio
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${CURSES_INCLUDE_DIRS}
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_menu_labels_radio
+        PRIVATE USE_RADIO
+    )
+    add_test(
+        NAME UI_MENU_LABELS_RADIO
+        COMMAND dsd-neo_test_ui_menu_labels_radio
+    )
 
-add_executable(
-    dsd-neo_test_ui_menu_render_helpers
-    ui/test_ui_menu_render_helpers.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_render.c
-)
-target_include_directories(
-    dsd-neo_test_ui_menu_render_helpers
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
-)
-target_compile_definitions(
-    dsd-neo_test_ui_menu_render_helpers
-    PRIVATE DSD_NEO_TEST_HOOKS
-)
-target_link_libraries(
-    dsd-neo_test_ui_menu_render_helpers
-    PRIVATE ${CURSES_LIBRARIES}
-)
-add_test(
-    NAME UI_MENU_RENDER_HELPERS
-    COMMAND dsd-neo_test_ui_menu_render_helpers
-)
+    add_executable(
+        dsd-neo_test_ui_menu_render_helpers
+        ui/test_ui_menu_render_helpers.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_render.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_menu_render_helpers
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${CURSES_INCLUDE_DIRS}
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_menu_render_helpers
+        PRIVATE DSD_NEO_TEST_HOOKS
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_menu_render_helpers
+        PRIVATE ${CURSES_LIBRARIES}
+    )
+    add_test(
+        NAME UI_MENU_RENDER_HELPERS
+        COMMAND dsd-neo_test_ui_menu_render_helpers
+    )
 
-add_executable(
-    dsd-neo_test_ui_menu_defs
-    ui/test_ui_menu_defs.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menus/menu_defs.c
-)
-target_include_directories(
-    dsd-neo_test_ui_menu_defs
-    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
-)
-add_test(NAME UI_MENU_DEFS COMMAND dsd-neo_test_ui_menu_defs)
+    add_executable(
+        dsd-neo_test_ui_menu_defs
+        ui/test_ui_menu_defs.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/menus/menu_defs.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_menu_defs
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+    )
+    add_test(NAME UI_MENU_DEFS COMMAND dsd-neo_test_ui_menu_defs)
 
-add_executable(
-    dsd-neo_test_ui_panels_header_footer
-    ui/test_ui_panels_header_footer.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/panels/header.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/panels/footer.c
-)
-target_compile_definitions(
-    dsd-neo_test_ui_panels_header_footer
-    PRIVATE NCURSES_NOMACROS
-)
-target_include_directories(
-    dsd-neo_test_ui_panels_header_footer
-    PRIVATE ${PROJECT_SOURCE_DIR}/include ${CURSES_INCLUDE_DIRS}
-)
-target_link_libraries(
-    dsd-neo_test_ui_panels_header_footer
-    PRIVATE ${CURSES_LIBRARIES}
-)
-add_test(
-    NAME UI_PANELS_HEADER_FOOTER
-    COMMAND dsd-neo_test_ui_panels_header_footer
-)
+    add_executable(
+        dsd-neo_test_ui_panels_header_footer
+        ui/test_ui_panels_header_footer.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/panels/header.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/panels/footer.c
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_panels_header_footer
+        PRIVATE NCURSES_NOMACROS
+    )
+    target_include_directories(
+        dsd-neo_test_ui_panels_header_footer
+        PRIVATE ${PROJECT_SOURCE_DIR}/include ${CURSES_INCLUDE_DIRS}
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_panels_header_footer
+        PRIVATE ${CURSES_LIBRARIES}
+    )
+    add_test(
+        NAME UI_PANELS_HEADER_FOOTER
+        COMMAND dsd-neo_test_ui_panels_header_footer
+    )
 
-add_executable(
-    dsd-neo_test_ui_ncurses_visualizers_helpers
-    ui/test_ui_ncurses_visualizers_helpers.c
-)
-target_include_directories(
-    dsd-neo_test_ui_ncurses_visualizers_helpers
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
-)
-target_link_libraries(
-    dsd-neo_test_ui_ncurses_visualizers_helpers
-    PRIVATE ${CURSES_LIBRARIES} ${DSD_NEO_TEST_MATH_LIB}
-)
-add_test(
-    NAME UI_NCURSES_VISUALIZERS_HELPERS
-    COMMAND dsd-neo_test_ui_ncurses_visualizers_helpers
-)
+    add_executable(
+        dsd-neo_test_ui_ncurses_visualizers_helpers
+        ui/test_ui_ncurses_visualizers_helpers.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_ncurses_visualizers_helpers
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${CURSES_INCLUDE_DIRS}
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_ncurses_visualizers_helpers
+        PRIVATE ${CURSES_LIBRARIES} ${DSD_NEO_TEST_MATH_LIB}
+    )
+    add_test(
+        NAME UI_NCURSES_VISUALIZERS_HELPERS
+        COMMAND dsd-neo_test_ui_ncurses_visualizers_helpers
+    )
+endif()
 
 add_executable(
     dsd-neo_test_ui_telemetry_hooks_install
@@ -1363,106 +1377,115 @@ add_test(
     COMMAND dsd-neo_test_ui_telemetry_hooks_install
 )
 
-add_executable(
-    dsd-neo_test_ui_ncurses_trunk_display_helpers
-    ui/test_ui_ncurses_trunk_display_helpers.c
-)
-target_include_directories(
-    dsd-neo_test_ui_ncurses_trunk_display_helpers
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
-)
-target_link_libraries(
-    dsd-neo_test_ui_ncurses_trunk_display_helpers
-    PRIVATE ${CURSES_LIBRARIES}
-)
-add_test(
-    NAME UI_NCURSES_TRUNK_DISPLAY_HELPERS
-    COMMAND dsd-neo_test_ui_ncurses_trunk_display_helpers
-)
+if(DSD_ENABLE_TERMINAL_UI)
+    add_executable(
+        dsd-neo_test_ui_ncurses_trunk_display_helpers
+        ui/test_ui_ncurses_trunk_display_helpers.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_ncurses_trunk_display_helpers
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${CURSES_INCLUDE_DIRS}
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_ncurses_trunk_display_helpers
+        PRIVATE ${CURSES_LIBRARIES}
+    )
+    add_test(
+        NAME UI_NCURSES_TRUNK_DISPLAY_HELPERS
+        COMMAND dsd-neo_test_ui_ncurses_trunk_display_helpers
+    )
 
-add_executable(
-    dsd-neo_test_ui_ncurses_p25_display_helpers
-    ui/test_ui_ncurses_p25_display_helpers.c
-)
-target_include_directories(
-    dsd-neo_test_ui_ncurses_p25_display_helpers
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
-)
-target_link_libraries(
-    dsd-neo_test_ui_ncurses_p25_display_helpers
-    PRIVATE ${CURSES_LIBRARIES}
-)
-add_test(
-    NAME UI_NCURSES_P25_DISPLAY_HELPERS
-    COMMAND dsd-neo_test_ui_ncurses_p25_display_helpers
-)
+    add_executable(
+        dsd-neo_test_ui_ncurses_p25_display_helpers
+        ui/test_ui_ncurses_p25_display_helpers.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_ncurses_p25_display_helpers
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${CURSES_INCLUDE_DIRS}
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_ncurses_p25_display_helpers
+        PRIVATE ${CURSES_LIBRARIES}
+    )
+    add_test(
+        NAME UI_NCURSES_P25_DISPLAY_HELPERS
+        COMMAND dsd-neo_test_ui_ncurses_p25_display_helpers
+    )
 
-add_executable(
-    dsd-neo_test_ui_ncurses_printer_helpers
-    ui/test_ui_ncurses_printer_helpers.c
-)
-target_include_directories(
-    dsd-neo_test_ui_ncurses_printer_helpers
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
-)
-target_compile_options(
-    dsd-neo_test_ui_ncurses_printer_helpers
-    PRIVATE -Wno-unused-function
-)
-target_link_libraries(
-    dsd-neo_test_ui_ncurses_printer_helpers
-    PRIVATE ${CURSES_LIBRARIES} ${DSD_NEO_TEST_MATH_LIB}
-)
-add_test(
-    NAME UI_NCURSES_PRINTER_HELPERS
-    COMMAND dsd-neo_test_ui_ncurses_printer_helpers
-)
+    add_executable(
+        dsd-neo_test_ui_ncurses_printer_helpers
+        ui/test_ui_ncurses_printer_helpers.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_ncurses_printer_helpers
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${CURSES_INCLUDE_DIRS}
+    )
+    target_compile_options(
+        dsd-neo_test_ui_ncurses_printer_helpers
+        PRIVATE -Wno-unused-function
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_ncurses_printer_helpers
+        PRIVATE ${CURSES_LIBRARIES} ${DSD_NEO_TEST_MATH_LIB}
+    )
+    add_test(
+        NAME UI_NCURSES_PRINTER_HELPERS
+        COMMAND dsd-neo_test_ui_ncurses_printer_helpers
+    )
 
-add_executable(
-    dsd-neo_test_ui_menu_callbacks
-    ui/test_ui_menu_callbacks.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_callbacks.c
-)
-target_include_directories(
-    dsd-neo_test_ui_menu_callbacks
-    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
-)
-add_test(NAME UI_MENU_CALLBACKS COMMAND dsd-neo_test_ui_menu_callbacks)
+    add_executable(
+        dsd-neo_test_ui_menu_callbacks
+        ui/test_ui_menu_callbacks.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_callbacks.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_menu_callbacks
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+    )
+    add_test(NAME UI_MENU_CALLBACKS COMMAND dsd-neo_test_ui_menu_callbacks)
 
-add_executable(
-    dsd-neo_test_ui_menu_actions
-    ui/test_ui_menu_actions.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_actions.c
-)
-target_include_directories(
-    dsd-neo_test_ui_menu_actions
-    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
-)
-add_test(NAME UI_MENU_ACTIONS COMMAND dsd-neo_test_ui_menu_actions)
+    add_executable(
+        dsd-neo_test_ui_menu_actions
+        ui/test_ui_menu_actions.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_actions.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_menu_actions
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+    )
+    add_test(NAME UI_MENU_ACTIONS COMMAND dsd-neo_test_ui_menu_actions)
 
-add_executable(
-    dsd-neo_test_ui_hotkeys_regression
-    ui/test_ui_hotkeys_regression.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/dsd_ncurses_handler.c
-)
-target_include_directories(
-    dsd-neo_test_ui_hotkeys_regression
-    PRIVATE ${PROJECT_SOURCE_DIR}/tests/ui ${PROJECT_SOURCE_DIR}/include
-)
-target_link_libraries(
-    dsd-neo_test_ui_hotkeys_regression
-    PRIVATE dsd-neo_platform
-)
-add_test(NAME UI_HOTKEYS_REGRESSION COMMAND dsd-neo_test_ui_hotkeys_regression)
+    add_executable(
+        dsd-neo_test_ui_hotkeys_regression
+        ui/test_ui_hotkeys_regression.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/dsd_ncurses_handler.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_hotkeys_regression
+        PRIVATE ${PROJECT_SOURCE_DIR}/tests/ui ${PROJECT_SOURCE_DIR}/include
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_hotkeys_regression
+        PRIVATE dsd-neo_platform
+    )
+    add_test(
+        NAME UI_HOTKEYS_REGRESSION
+        COMMAND dsd-neo_test_ui_hotkeys_regression
+    )
+endif()
 
 add_executable(
     dsd-neo_test_ui_tcp_audio_connect
@@ -1482,325 +1505,353 @@ target_include_directories(
 )
 add_test(NAME UI_BURST_ACTIVE_CALL COMMAND dsd-neo_test_ui_burst_active_call)
 
-add_executable(
-    dsd-neo_test_ui_ncurses_utils
-    ui/test_ui_ncurses_utils.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_utils.c
-)
-target_include_directories(
-    dsd-neo_test_ui_ncurses_utils
-    PRIVATE ${PROJECT_SOURCE_DIR}/include
-)
-target_link_libraries(
-    dsd-neo_test_ui_ncurses_utils
-    PRIVATE dsd-neo_core dsd-neo_runtime ${DSD_NEO_TEST_MATH_LIB}
-)
-add_test(NAME UI_NCURSES_UTILS COMMAND dsd-neo_test_ui_ncurses_utils)
-
-add_executable(
-    dsd-neo_test_ui_ncurses_init
-    ui/test_ui_ncurses_init.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_init.c
-)
-target_include_directories(
-    dsd-neo_test_ui_ncurses_init
-    PRIVATE ${PROJECT_SOURCE_DIR}/tests/ui ${PROJECT_SOURCE_DIR}/include
-)
-add_test(NAME UI_NCURSES_INIT COMMAND dsd-neo_test_ui_ncurses_init)
-
-add_executable(
-    dsd-neo_test_ui_dsp_squelch_status
-    ui/test_ui_dsp_squelch_status.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_dsp_status_format.c
-)
-target_include_directories(
-    dsd-neo_test_ui_dsp_squelch_status
-    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
-)
-target_link_libraries(
-    dsd-neo_test_ui_dsp_squelch_status
-    PRIVATE dsd-neo_core ${DSD_NEO_TEST_MATH_LIB}
-)
-add_test(NAME UI_DSP_SQUELCH_STATUS COMMAND dsd-neo_test_ui_dsp_squelch_status)
-
-add_executable(
-    dsd-neo_test_ui_dsp_display_radio_compile
-    ui/test_ui_dsp_display_radio_compile.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_dsp_display.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_prims.c
-)
-target_compile_definitions(
-    dsd-neo_test_ui_dsp_display_radio_compile
-    PRIVATE USE_RADIO
-)
-target_include_directories(
-    dsd-neo_test_ui_dsp_display_radio_compile
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${_PUBLIC_INCLUDES}
-)
-target_link_libraries(
-    dsd-neo_test_ui_dsp_display_radio_compile
-    PRIVATE ${CURSES_LIBRARIES} ${DSD_NEO_TEST_MATH_LIB}
-)
-add_test(
-    NAME UI_DSP_DISPLAY_RADIO_COMPILE
-    COMMAND dsd-neo_test_ui_dsp_display_radio_compile
-)
-
-add_executable(
-    dsd-neo_test_ui_prims_status_gamma
-    ui/test_ui_prims_status_gamma.c
-)
-target_include_directories(
-    dsd-neo_test_ui_prims_status_gamma
-    PRIVATE ${PROJECT_SOURCE_DIR}/include ${CURSES_INCLUDE_DIRS}
-)
-target_link_libraries(
-    dsd-neo_test_ui_prims_status_gamma
-    PRIVATE ${DSD_NEO_TEST_MATH_LIB}
-)
-add_test(NAME UI_PRIMS_STATUS_GAMMA COMMAND dsd-neo_test_ui_prims_status_gamma)
-
-add_executable(
-    dsd-neo_test_ui_snr_meter
-    ui/test_ui_snr_meter.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_snr.c
-)
-target_include_directories(
-    dsd-neo_test_ui_snr_meter
-    PRIVATE ${PROJECT_SOURCE_DIR}/include ${CURSES_INCLUDE_DIRS}
-)
-target_compile_definitions(
-    dsd-neo_test_ui_snr_meter
-    PRIVATE DSD_NEO_TEST_HOOKS PRETTY_COLORS
-)
-if(DSD_ENABLE_FAST_MATH)
-    target_compile_definitions(
-        dsd-neo_test_ui_snr_meter
-        PRIVATE DSD_NEO_FAST_MATH=1
-    )
-endif()
-target_link_libraries(
-    dsd-neo_test_ui_snr_meter
-    PRIVATE ${CURSES_LIBRARIES} ${DSD_NEO_TEST_MATH_LIB}
-)
-add_test(NAME UI_SNR_METER COMMAND dsd-neo_test_ui_snr_meter)
-
-add_executable(
-    dsd-neo_test_ui_snr_readout
-    ui/test_ui_snr_readout.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_snr_readout.c
-)
-target_include_directories(
-    dsd-neo_test_ui_snr_readout
-    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
-)
-target_compile_definitions(
-    dsd-neo_test_ui_snr_readout
-    PRIVATE DSD_NEO_TEST_HOOKS USE_RADIO
-)
-target_link_libraries(
-    dsd-neo_test_ui_snr_readout
-    PRIVATE ${DSD_NEO_TEST_MATH_LIB}
-)
-add_test(NAME UI_SNR_READOUT COMMAND dsd-neo_test_ui_snr_readout)
-
-add_executable(
-    dsd-neo_test_ui_snr_readout_no_radio
-    ui/test_ui_snr_readout_no_radio.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_snr_readout.c
-)
-target_include_directories(
-    dsd-neo_test_ui_snr_readout_no_radio
-    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
-)
-add_test(
-    NAME UI_SNR_READOUT_NO_RADIO
-    COMMAND dsd-neo_test_ui_snr_readout_no_radio
-)
-
-if(NOT DSD_HAS_PDCURSES_WIDE_API)
+if(DSD_ENABLE_TERMINAL_UI)
     add_executable(
-        dsd-neo_test_ui_snr_meter_pdc_wide_no_api
+        dsd-neo_test_ui_ncurses_utils
+        ui/test_ui_ncurses_utils.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_utils.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_ncurses_utils
+        PRIVATE ${PROJECT_SOURCE_DIR}/include
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_ncurses_utils
+        PRIVATE dsd-neo_core dsd-neo_runtime ${DSD_NEO_TEST_MATH_LIB}
+    )
+    add_test(NAME UI_NCURSES_UTILS COMMAND dsd-neo_test_ui_ncurses_utils)
+
+    add_executable(
+        dsd-neo_test_ui_ncurses_init
+        ui/test_ui_ncurses_init.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_init.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_ncurses_init
+        PRIVATE ${PROJECT_SOURCE_DIR}/tests/ui ${PROJECT_SOURCE_DIR}/include
+    )
+    add_test(NAME UI_NCURSES_INIT COMMAND dsd-neo_test_ui_ncurses_init)
+
+    add_executable(
+        dsd-neo_test_ui_dsp_squelch_status
+        ui/test_ui_dsp_squelch_status.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_dsp_status_format.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_dsp_squelch_status
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_dsp_squelch_status
+        PRIVATE dsd-neo_core ${DSD_NEO_TEST_MATH_LIB}
+    )
+    add_test(
+        NAME UI_DSP_SQUELCH_STATUS
+        COMMAND dsd-neo_test_ui_dsp_squelch_status
+    )
+
+    add_executable(
+        dsd-neo_test_ui_dsp_display_radio_compile
+        ui/test_ui_dsp_display_radio_compile.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_dsp_display.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_prims.c
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_dsp_display_radio_compile
+        PRIVATE USE_RADIO
+    )
+    target_include_directories(
+        dsd-neo_test_ui_dsp_display_radio_compile
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${_PUBLIC_INCLUDES}
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_dsp_display_radio_compile
+        PRIVATE ${CURSES_LIBRARIES} ${DSD_NEO_TEST_MATH_LIB}
+    )
+    add_test(
+        NAME UI_DSP_DISPLAY_RADIO_COMPILE
+        COMMAND dsd-neo_test_ui_dsp_display_radio_compile
+    )
+
+    add_executable(
+        dsd-neo_test_ui_prims_status_gamma
+        ui/test_ui_prims_status_gamma.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_prims_status_gamma
+        PRIVATE ${PROJECT_SOURCE_DIR}/include ${CURSES_INCLUDE_DIRS}
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_prims_status_gamma
+        PRIVATE ${DSD_NEO_TEST_MATH_LIB}
+    )
+    add_test(
+        NAME UI_PRIMS_STATUS_GAMMA
+        COMMAND dsd-neo_test_ui_prims_status_gamma
+    )
+
+    add_executable(
+        dsd-neo_test_ui_snr_meter
         ui/test_ui_snr_meter.c
         ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_snr.c
     )
     target_include_directories(
-        dsd-neo_test_ui_snr_meter_pdc_wide_no_api
+        dsd-neo_test_ui_snr_meter
         PRIVATE ${PROJECT_SOURCE_DIR}/include ${CURSES_INCLUDE_DIRS}
     )
     target_compile_definitions(
-        dsd-neo_test_ui_snr_meter_pdc_wide_no_api
-        PRIVATE DSD_NEO_TEST_HOOKS DSD_USE_PDCURSES PDC_WIDE PRETTY_COLORS
+        dsd-neo_test_ui_snr_meter
+        PRIVATE DSD_NEO_TEST_HOOKS PRETTY_COLORS
     )
     if(DSD_ENABLE_FAST_MATH)
         target_compile_definitions(
-            dsd-neo_test_ui_snr_meter_pdc_wide_no_api
+            dsd-neo_test_ui_snr_meter
             PRIVATE DSD_NEO_FAST_MATH=1
         )
     endif()
     target_link_libraries(
-        dsd-neo_test_ui_snr_meter_pdc_wide_no_api
+        dsd-neo_test_ui_snr_meter
         PRIVATE ${CURSES_LIBRARIES} ${DSD_NEO_TEST_MATH_LIB}
     )
+    add_test(NAME UI_SNR_METER COMMAND dsd-neo_test_ui_snr_meter)
+
+    add_executable(
+        dsd-neo_test_ui_snr_readout
+        ui/test_ui_snr_readout.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_snr_readout.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_snr_readout
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_snr_readout
+        PRIVATE DSD_NEO_TEST_HOOKS USE_RADIO
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_snr_readout
+        PRIVATE ${DSD_NEO_TEST_MATH_LIB}
+    )
+    add_test(NAME UI_SNR_READOUT COMMAND dsd-neo_test_ui_snr_readout)
+
+    add_executable(
+        dsd-neo_test_ui_snr_readout_no_radio
+        ui/test_ui_snr_readout_no_radio.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/ui_snr_readout.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_snr_readout_no_radio
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+    )
     add_test(
-        NAME UI_SNR_METER_PDC_WIDE_NO_API
-        COMMAND dsd-neo_test_ui_snr_meter_pdc_wide_no_api
+        NAME UI_SNR_READOUT_NO_RADIO
+        COMMAND dsd-neo_test_ui_snr_readout_no_radio
     )
-endif()
 
-add_executable(
-    dsd-neo_test_ui_menu_navigation
-    ui/test_ui_menu_navigation.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_core.c
-)
-target_include_directories(
-    dsd-neo_test_ui_menu_navigation
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
-)
-if(MSVC)
-    target_compile_definitions(
+    if(NOT DSD_HAS_PDCURSES_WIDE_API)
+        add_executable(
+            dsd-neo_test_ui_snr_meter_pdc_wide_no_api
+            ui/test_ui_snr_meter.c
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal/ncurses_snr.c
+        )
+        target_include_directories(
+            dsd-neo_test_ui_snr_meter_pdc_wide_no_api
+            PRIVATE ${PROJECT_SOURCE_DIR}/include ${CURSES_INCLUDE_DIRS}
+        )
+        target_compile_definitions(
+            dsd-neo_test_ui_snr_meter_pdc_wide_no_api
+            PRIVATE DSD_NEO_TEST_HOOKS DSD_USE_PDCURSES PDC_WIDE PRETTY_COLORS
+        )
+        if(DSD_ENABLE_FAST_MATH)
+            target_compile_definitions(
+                dsd-neo_test_ui_snr_meter_pdc_wide_no_api
+                PRIVATE DSD_NEO_FAST_MATH=1
+            )
+        endif()
+        target_link_libraries(
+            dsd-neo_test_ui_snr_meter_pdc_wide_no_api
+            PRIVATE ${CURSES_LIBRARIES} ${DSD_NEO_TEST_MATH_LIB}
+        )
+        add_test(
+            NAME UI_SNR_METER_PDC_WIDE_NO_API
+            COMMAND dsd-neo_test_ui_snr_meter_pdc_wide_no_api
+        )
+    endif()
+
+    add_executable(
         dsd-neo_test_ui_menu_navigation
-        PRIVATE CURSES_LIBRARY
+        ui/test_ui_menu_navigation.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_core.c
     )
-endif()
-target_link_libraries(dsd-neo_test_ui_menu_navigation PRIVATE dsd-neo_platform)
-add_test(NAME UI_MENU_NAVIGATION COMMAND dsd-neo_test_ui_menu_navigation)
+    target_include_directories(
+        dsd-neo_test_ui_menu_navigation
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${CURSES_INCLUDE_DIRS}
+    )
+    if(MSVC)
+        target_compile_definitions(
+            dsd-neo_test_ui_menu_navigation
+            PRIVATE CURSES_LIBRARY
+        )
+    endif()
+    target_link_libraries(
+        dsd-neo_test_ui_menu_navigation
+        PRIVATE dsd-neo_platform
+    )
+    add_test(NAME UI_MENU_NAVIGATION COMMAND dsd-neo_test_ui_menu_navigation)
 
-add_executable(
-    dsd-neo_test_ui_menu_paging_viewport
-    ui/test_ui_menu_paging_viewport.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_core.c
-)
-target_include_directories(
-    dsd-neo_test_ui_menu_paging_viewport
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
-)
-if(MSVC)
-    target_compile_definitions(
+    add_executable(
         dsd-neo_test_ui_menu_paging_viewport
-        PRIVATE CURSES_LIBRARY
+        ui/test_ui_menu_paging_viewport.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_core.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_menu_paging_viewport
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${CURSES_INCLUDE_DIRS}
+    )
+    if(MSVC)
+        target_compile_definitions(
+            dsd-neo_test_ui_menu_paging_viewport
+            PRIVATE CURSES_LIBRARY
+        )
+    endif()
+    target_link_libraries(
+        dsd-neo_test_ui_menu_paging_viewport
+        PRIVATE dsd-neo_platform
+    )
+    add_test(
+        NAME UI_MENU_PAGING_VIEWPORT
+        COMMAND dsd-neo_test_ui_menu_paging_viewport
+    )
+
+    add_executable(
+        dsd-neo_test_ui_menu_dynamic_label
+        ui/test_ui_menu_dynamic_label.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_render.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_menu_dynamic_label
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${CURSES_INCLUDE_DIRS}
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_menu_dynamic_label
+        PRIVATE DSD_NEO_TEST_HOOKS
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_menu_dynamic_label
+        PRIVATE ${CURSES_LIBRARIES}
+    )
+    add_test(
+        NAME UI_MENU_DYNAMIC_LABEL
+        COMMAND dsd-neo_test_ui_menu_dynamic_label
+    )
+
+    add_executable(
+        dsd-neo_test_ui_menu_env
+        ui/test_ui_menu_env.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_env.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_menu_env
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_menu_env
+        PRIVATE dsd-neo_runtime ${DSD_NEO_TEST_MATH_LIB}
+    )
+    add_test(NAME UI_MENU_ENV COMMAND dsd-neo_test_ui_menu_env)
+
+    add_executable(
+        dsd-neo_test_ui_chooser_navigation
+        ui/test_ui_chooser_navigation.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_prompts.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_chooser_navigation
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${CURSES_INCLUDE_DIRS}
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_chooser_navigation
+        PRIVATE DSD_NEO_TEST_HOOKS
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_chooser_navigation
+        PRIVATE dsd-neo_test_support ${CURSES_LIBRARIES}
+    )
+    add_test(
+        NAME UI_CHOOSER_NAVIGATION
+        COMMAND dsd-neo_test_ui_chooser_navigation
+    )
+
+    add_executable(
+        dsd-neo_test_ui_prompt_cursor
+        ui/test_ui_prompt_cursor.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_prompts.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_prompt_cursor
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${CURSES_INCLUDE_DIRS}
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_prompt_cursor
+        PRIVATE DSD_NEO_TEST_HOOKS
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_prompt_cursor
+        PRIVATE dsd-neo_test_support ${CURSES_LIBRARIES}
+    )
+    add_test(NAME UI_PROMPT_CURSOR COMMAND dsd-neo_test_ui_prompt_cursor)
+
+    add_executable(
+        dsd-neo_test_ui_prompt_validation
+        ui/test_ui_prompt_validation.c
+        ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_prompts.c
+    )
+    target_include_directories(
+        dsd-neo_test_ui_prompt_validation
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/ui/terminal
+            ${CURSES_INCLUDE_DIRS}
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_prompt_validation
+        PRIVATE DSD_NEO_TEST_HOOKS
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_prompt_validation
+        PRIVATE dsd-neo_test_support ${CURSES_LIBRARIES}
+    )
+    add_test(
+        NAME UI_PROMPT_VALIDATION
+        COMMAND dsd-neo_test_ui_prompt_validation
     )
 endif()
-target_link_libraries(
-    dsd-neo_test_ui_menu_paging_viewport
-    PRIVATE dsd-neo_platform
-)
-add_test(
-    NAME UI_MENU_PAGING_VIEWPORT
-    COMMAND dsd-neo_test_ui_menu_paging_viewport
-)
-
-add_executable(
-    dsd-neo_test_ui_menu_dynamic_label
-    ui/test_ui_menu_dynamic_label.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_render.c
-)
-target_include_directories(
-    dsd-neo_test_ui_menu_dynamic_label
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
-)
-target_compile_definitions(
-    dsd-neo_test_ui_menu_dynamic_label
-    PRIVATE DSD_NEO_TEST_HOOKS
-)
-target_link_libraries(
-    dsd-neo_test_ui_menu_dynamic_label
-    PRIVATE ${CURSES_LIBRARIES}
-)
-add_test(NAME UI_MENU_DYNAMIC_LABEL COMMAND dsd-neo_test_ui_menu_dynamic_label)
-
-add_executable(
-    dsd-neo_test_ui_menu_env
-    ui/test_ui_menu_env.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_env.c
-)
-target_include_directories(
-    dsd-neo_test_ui_menu_env
-    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
-)
-target_link_libraries(
-    dsd-neo_test_ui_menu_env
-    PRIVATE dsd-neo_runtime ${DSD_NEO_TEST_MATH_LIB}
-)
-add_test(NAME UI_MENU_ENV COMMAND dsd-neo_test_ui_menu_env)
-
-add_executable(
-    dsd-neo_test_ui_chooser_navigation
-    ui/test_ui_chooser_navigation.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_prompts.c
-)
-target_include_directories(
-    dsd-neo_test_ui_chooser_navigation
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
-)
-target_compile_definitions(
-    dsd-neo_test_ui_chooser_navigation
-    PRIVATE DSD_NEO_TEST_HOOKS
-)
-target_link_libraries(
-    dsd-neo_test_ui_chooser_navigation
-    PRIVATE dsd-neo_test_support ${CURSES_LIBRARIES}
-)
-add_test(NAME UI_CHOOSER_NAVIGATION COMMAND dsd-neo_test_ui_chooser_navigation)
-
-add_executable(
-    dsd-neo_test_ui_prompt_cursor
-    ui/test_ui_prompt_cursor.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_prompts.c
-)
-target_include_directories(
-    dsd-neo_test_ui_prompt_cursor
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
-)
-target_compile_definitions(
-    dsd-neo_test_ui_prompt_cursor
-    PRIVATE DSD_NEO_TEST_HOOKS
-)
-target_link_libraries(
-    dsd-neo_test_ui_prompt_cursor
-    PRIVATE dsd-neo_test_support ${CURSES_LIBRARIES}
-)
-add_test(NAME UI_PROMPT_CURSOR COMMAND dsd-neo_test_ui_prompt_cursor)
-
-add_executable(
-    dsd-neo_test_ui_prompt_validation
-    ui/test_ui_prompt_validation.c
-    ${PROJECT_SOURCE_DIR}/src/ui/terminal/menu_prompts.c
-)
-target_include_directories(
-    dsd-neo_test_ui_prompt_validation
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
-)
-target_compile_definitions(
-    dsd-neo_test_ui_prompt_validation
-    PRIVATE DSD_NEO_TEST_HOOKS
-)
-target_link_libraries(
-    dsd-neo_test_ui_prompt_validation
-    PRIVATE dsd-neo_test_support ${CURSES_LIBRARIES}
-)
-add_test(NAME UI_PROMPT_VALIDATION COMMAND dsd-neo_test_ui_prompt_validation)
 
 add_executable(
     dsd-neo_test_ui_history_state
@@ -2978,10 +3029,7 @@ set_source_files_properties(
 )
 target_include_directories(
     dsd-neo_test_runtime_config_apply
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src/ui/terminal
-        ${CURSES_INCLUDE_DIRS}
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/terminal
 )
 set(_DSD_RUNTIME_CONFIG_APPLY_LIBS
     dsd-neo_app_control
@@ -3009,7 +3057,7 @@ add_test(NAME RUNTIME_CONFIG_APPLY COMMAND dsd-neo_test_runtime_config_apply)
 add_executable(dsd-neo_test_ui_cmd_queue ui/test_ui_cmd_queue.c)
 target_include_directories(
     dsd-neo_test_ui_cmd_queue
-    PRIVATE ${PROJECT_SOURCE_DIR}/include ${CURSES_INCLUDE_DIRS}
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
 )
 if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
     target_link_libraries(

--- a/tests/engine/test_engine_rtl_stream_metrics_hooks_install.c
+++ b/tests/engine/test_engine_rtl_stream_metrics_hooks_install.c
@@ -30,6 +30,7 @@ static int g_snr_c4fm_calls;
 static int g_snr_c4fm_eye_calls;
 static int g_snr_cqpsk_calls;
 static int g_snr_gfsk_calls;
+static int g_snr_gfsk_eye_calls;
 static int g_snr_qpsk_const_calls;
 static int g_p25p1_ber_calls;
 static int g_p25p2_err_calls;
@@ -140,6 +141,12 @@ rtl_stream_get_snr_gfsk(void) {
 }
 
 double
+rtl_stream_estimate_snr_gfsk_eye(void) {
+    ++g_snr_gfsk_eye_calls;
+    return 6.25;
+}
+
+double
 rtl_stream_estimate_snr_qpsk_const(void) {
     ++g_snr_qpsk_const_calls;
     return 6.5;
@@ -222,12 +229,14 @@ main(void) {
     assert(dsd_rtl_stream_metrics_hook_snr_c4fm_eye_db() == 3.75);
     assert(dsd_rtl_stream_metrics_hook_snr_cqpsk_db() == 4.5);
     assert(dsd_rtl_stream_metrics_hook_snr_gfsk_db() == 5.5);
+    assert(dsd_rtl_stream_metrics_hook_snr_gfsk_eye_db() == 6.25);
     assert(dsd_rtl_stream_metrics_hook_snr_qpsk_const_db() == 6.5);
     assert(g_snr_bias_calls == 1);
     assert(g_snr_c4fm_calls == 1);
     assert(g_snr_c4fm_eye_calls == 1);
     assert(g_snr_cqpsk_calls == 1);
     assert(g_snr_gfsk_calls == 1);
+    assert(g_snr_gfsk_eye_calls == 1);
     assert(g_snr_qpsk_const_calls == 1);
 
     dsd_rtl_stream_metrics_hook_p25p1_ber_update(11, 12);

--- a/tests/protocol/dmr/test_dmr_bs_sync_times.c
+++ b/tests/protocol/dmr/test_dmr_bs_sync_times.c
@@ -481,7 +481,7 @@ test_bs_slot2_voice_routes_right_channel_and_post_skip_hooks(void) {
 
     opts.floating_point = 1;
     opts.pulse_digi_rate_out = 8000;
-    opts.use_ncurses_terminal = 1;
+    opts.frontend_kind = DSD_FRONTEND_TERMINAL;
     DSD_SNPRINTF(opts.mbe_out_dir, sizeof(opts.mbe_out_dir), "%s", "captures");
     state.currentslot = 1;
     state.dmr_color_code = 16;
@@ -593,7 +593,7 @@ test_bs_voice_gate_closed_skips_decode_but_keeps_loop_hooks(void) {
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
 
-    opts.use_ncurses_terminal = 1;
+    opts.frontend_kind = DSD_FRONTEND_TERMINAL;
     state.currentslot = 0;
     state.dmr_color_code = 16;
     load_single_burst_stream(0, DMR_BS_VOICE_SYNC);

--- a/tests/protocol/dmr/test_dmr_ms_data.c
+++ b/tests/protocol/dmr/test_dmr_ms_data.c
@@ -411,7 +411,7 @@ test_ms_voice_cycle_processes_frames_and_cleans_mode_state(void) {
 
     opts.floating_point = 1;
     opts.pulse_digi_out_channels = 2;
-    opts.use_ncurses_terminal = 1;
+    opts.frontend_kind = DSD_FRONTEND_TERMINAL;
     state.payload_algid = 0x02;
     state.static_ks_counter[0] = 7;
     state.vertex_ks_counter[0] = 8;

--- a/tests/protocol/dstar/test_dstar_process.c
+++ b/tests/protocol/dstar/test_dstar_process.c
@@ -177,7 +177,7 @@ test_voice_process_with_ncurses_refresh(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
-    opts.use_ncurses_terminal = 1;
+    opts.frontend_kind = DSD_FRONTEND_TERMINAL;
     reset_counters();
 
     processDSTAR(&opts, &state);

--- a/tests/protocol/p25/test_p25_sm_api_override.c
+++ b/tests/protocol/p25/test_p25_sm_api_override.c
@@ -226,7 +226,7 @@ main(void) {
     p25_sm_watchdog_start(&guarded_opts, NULL);
     rc |= expect_eq_int("watchdog_start_null_guards", g_tick_calls, 1);
 
-    guarded_opts.use_ncurses_terminal = 1;
+    guarded_opts.frontend_kind = DSD_FRONTEND_TERMINAL;
     p25_sm_watchdog_start(&guarded_opts, &guarded_state);
     dsd_sleep_ms(60U);
     p25_sm_watchdog_stop();

--- a/tests/runtime/test_config_profile.cpp
+++ b/tests/runtime/test_config_profile.cpp
@@ -201,7 +201,7 @@ test_profile_multiple_overrides(void) {
         DSD_FPRINTF(stderr, "FAIL: trunking should be enabled\n");
         result = 1;
     }
-    if (!cfg.frontend_kind) {
+    if (!cfg.frontend_kind || !cfg.frontend_kind_is_set) {
         DSD_FPRINTF(stderr, "FAIL: frontend should be enabled\n");
         result = 1;
     }
@@ -260,7 +260,7 @@ test_profile_bool_aliases(void) {
         DSD_FPRINTF(stderr, "FAIL: load with bool_aliases profile failed (rc=%d)\n", rc);
         result = 1;
     }
-    if (!cfg.frontend_kind) {
+    if (!cfg.frontend_kind || !cfg.frontend_kind_is_set) {
         DSD_FPRINTF(stderr, "FAIL: expected frontend on from profile alias\n");
         result = 1;
     }
@@ -670,7 +670,7 @@ test_include_directive(void) {
     }
 
     /* Values from main file should also be present */
-    if (!cfg.frontend_kind) {
+    if (!cfg.frontend_kind || !cfg.frontend_kind_is_set) {
         DSD_FPRINTF(stderr, "FAIL: include: frontend should be true from main config\n");
         result = 1;
     }

--- a/tests/runtime/test_config_profile.cpp
+++ b/tests/runtime/test_config_profile.cpp
@@ -163,7 +163,7 @@ test_profile_multiple_overrides(void) {
                              "\n"
                              "[output]\n"
                              "backend = \"pulse\"\n"
-                             "ncurses_ui = false\n"
+                             "frontend = \"none\"\n"
                              "\n"
                              "[mode]\n"
                              "decode = \"auto\"\n"
@@ -174,7 +174,7 @@ test_profile_multiple_overrides(void) {
                              "[profile.p25_trunk]\n"
                              "mode.decode = \"p25p1\"\n"
                              "trunking.enabled = true\n"
-                             "output.ncurses_ui = true\n";
+                             "output.frontend = terminal\n";
 
     char path[DSD_TEST_PATH_MAX];
     if (write_temp_config(ini, path, sizeof path) != 0) {
@@ -201,8 +201,8 @@ test_profile_multiple_overrides(void) {
         DSD_FPRINTF(stderr, "FAIL: trunking should be enabled\n");
         result = 1;
     }
-    if (!cfg.ncurses_ui) {
-        DSD_FPRINTF(stderr, "FAIL: ncurses_ui should be enabled\n");
+    if (!cfg.frontend_kind) {
+        DSD_FPRINTF(stderr, "FAIL: frontend should be enabled\n");
         result = 1;
     }
 
@@ -226,7 +226,7 @@ test_profile_bool_aliases(void) {
                              "\n"
                              "[output]\n"
                              "backend = \"pulse\"\n"
-                             "ncurses_ui = false\n"
+                             "frontend = \"none\"\n"
                              "\n"
                              "[trunking]\n"
                              "enabled = true\n"
@@ -237,7 +237,7 @@ test_profile_bool_aliases(void) {
                              "tune_enc_calls = true\n"
                              "\n"
                              "[profile.bool_aliases]\n"
-                             "output.ncurses_ui = on\n"
+                             "output.frontend = terminal\n"
                              "trunking.enabled = off\n"
                              "trunking.allow_list = on\n"
                              "trunking.tune_group_calls = off\n"
@@ -260,8 +260,8 @@ test_profile_bool_aliases(void) {
         DSD_FPRINTF(stderr, "FAIL: load with bool_aliases profile failed (rc=%d)\n", rc);
         result = 1;
     }
-    if (!cfg.ncurses_ui) {
-        DSD_FPRINTF(stderr, "FAIL: expected ncurses_ui on from profile alias\n");
+    if (!cfg.frontend_kind) {
+        DSD_FPRINTF(stderr, "FAIL: expected frontend on from profile alias\n");
         result = 1;
     }
     if (cfg.trunk_enabled) {
@@ -631,7 +631,7 @@ test_include_directive(void) {
                  "version = 1\n"
                  "\n"
                  "[output]\n"
-                 "ncurses_ui = true\n",
+                 "frontend = \"terminal\"\n",
                  included_path);
 
     char main_path[DSD_TEST_PATH_MAX];
@@ -670,8 +670,8 @@ test_include_directive(void) {
     }
 
     /* Values from main file should also be present */
-    if (!cfg.ncurses_ui) {
-        DSD_FPRINTF(stderr, "FAIL: include: ncurses_ui should be true from main config\n");
+    if (!cfg.frontend_kind) {
+        DSD_FPRINTF(stderr, "FAIL: include: frontend should be true from main config\n");
         result = 1;
     }
 

--- a/tests/runtime/test_runtime_bootstrap_interactive.c
+++ b/tests/runtime/test_runtime_bootstrap_interactive.c
@@ -25,6 +25,16 @@
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
+#ifndef DSD_RUNTIME_HAS_TERMINAL_UI
+#define DSD_RUNTIME_HAS_TERMINAL_UI 1
+#endif
+
+#if DSD_RUNTIME_HAS_TERMINAL_UI
+#define EXPECTED_DEFAULT_FRONTEND DSD_FRONTEND_TERMINAL
+#else
+#define EXPECTED_DEFAULT_FRONTEND DSD_FRONTEND_NONE
+#endif
+
 static int g_isatty = 1;
 static int g_config_available = 1;
 static dsdneoRuntimeConfig g_config;
@@ -240,7 +250,7 @@ test_pulse_defaults_apply_decode_and_ncurses(void) {
     rc |= expect_str("pulse-audio-out", opts.audio_out_dev, "pulse:stub-output");
     rc |= expect_int("pulse-decode-mode", g_last_decode_mode, DSDCFG_MODE_DMR);
     rc |= expect_int("pulse-decode-profile", g_last_decode_profile, DSD_DECODE_PRESET_PROFILE_INTERACTIVE);
-    rc |= expect_int("pulse-ncurses-default", opts.frontend_kind, DSD_FRONTEND_TERMINAL);
+    rc |= expect_int("pulse-ncurses-default", opts.frontend_kind, EXPECTED_DEFAULT_FRONTEND);
     return rc;
 }
 
@@ -316,7 +326,7 @@ test_tcp_trunking_enables_default_rigctl_and_skips_missing_csv(void) {
     rc |= expect_int("tcp-channel-import-skipped", g_chan_import_calls, 0);
     rc |= expect_int("tcp-group-import-skipped", g_group_import_calls, 0);
     rc |= expect_str("tcp-no-null-output", opts.audio_out_dev, "");
-    rc |= expect_int("tcp-ncurses-default", opts.frontend_kind, DSD_FRONTEND_TERMINAL);
+    rc |= expect_int("tcp-ncurses-default", opts.frontend_kind, EXPECTED_DEFAULT_FRONTEND);
     return rc;
 }
 
@@ -335,7 +345,7 @@ test_udp_eof_uses_socket_defaults_and_default_pulse_output(void) {
     rc |= expect_int("udp-default-decode-mode", g_last_decode_mode, DSDCFG_MODE_AUTO);
     rc |= expect_int("udp-default-audio-output", g_audio_output_calls, 1);
     rc |= expect_str("udp-default-audio-out", opts.audio_out_dev, "pulse:stub-output");
-    rc |= expect_int("udp-default-ncurses", opts.frontend_kind, DSD_FRONTEND_TERMINAL);
+    rc |= expect_int("udp-default-ncurses", opts.frontend_kind, EXPECTED_DEFAULT_FRONTEND);
     return rc;
 }
 
@@ -441,7 +451,7 @@ test_invalid_prompt_values_use_documented_defaults(void) {
     rc |= expect_str("invalid-default-pulse-input", opts.audio_in_dev, "pulse:stub-input");
     rc |= expect_str("invalid-default-pulse-output", opts.audio_out_dev, "pulse:stub-output");
     rc |= expect_int("invalid-default-decode-mode", g_last_decode_mode, DSDCFG_MODE_AUTO);
-    rc |= expect_int("invalid-default-ncurses", opts.frontend_kind, DSD_FRONTEND_TERMINAL);
+    rc |= expect_int("invalid-default-ncurses", opts.frontend_kind, EXPECTED_DEFAULT_FRONTEND);
     return rc;
 }
 

--- a/tests/runtime/test_runtime_bootstrap_interactive.c
+++ b/tests/runtime/test_runtime_bootstrap_interactive.c
@@ -240,7 +240,7 @@ test_pulse_defaults_apply_decode_and_ncurses(void) {
     rc |= expect_str("pulse-audio-out", opts.audio_out_dev, "pulse:stub-output");
     rc |= expect_int("pulse-decode-mode", g_last_decode_mode, DSDCFG_MODE_DMR);
     rc |= expect_int("pulse-decode-profile", g_last_decode_profile, DSD_DECODE_PRESET_PROFILE_INTERACTIVE);
-    rc |= expect_int("pulse-ncurses-default", opts.use_ncurses_terminal, 1);
+    rc |= expect_int("pulse-ncurses-default", opts.frontend_kind, DSD_FRONTEND_TERMINAL);
     return rc;
 }
 
@@ -283,7 +283,7 @@ test_rtltcp_trunking_imports_group_allow_list_and_null_output(void) {
     rc |= expect_int("rtltcp-allow-list", opts.trunk_use_allow_list, 1);
     rc |= expect_str("rtltcp-null-output", opts.audio_out_dev, "null");
     rc |= expect_int("rtltcp-audio-output-chooser", g_audio_output_calls, 0);
-    rc |= expect_int("rtltcp-ncurses-disabled", opts.use_ncurses_terminal, 0);
+    rc |= expect_int("rtltcp-ncurses-disabled", opts.frontend_kind, DSD_FRONTEND_NONE);
     return rc;
 }
 
@@ -316,7 +316,7 @@ test_tcp_trunking_enables_default_rigctl_and_skips_missing_csv(void) {
     rc |= expect_int("tcp-channel-import-skipped", g_chan_import_calls, 0);
     rc |= expect_int("tcp-group-import-skipped", g_group_import_calls, 0);
     rc |= expect_str("tcp-no-null-output", opts.audio_out_dev, "");
-    rc |= expect_int("tcp-ncurses-default", opts.use_ncurses_terminal, 1);
+    rc |= expect_int("tcp-ncurses-default", opts.frontend_kind, DSD_FRONTEND_TERMINAL);
     return rc;
 }
 
@@ -335,7 +335,7 @@ test_udp_eof_uses_socket_defaults_and_default_pulse_output(void) {
     rc |= expect_int("udp-default-decode-mode", g_last_decode_mode, DSDCFG_MODE_AUTO);
     rc |= expect_int("udp-default-audio-output", g_audio_output_calls, 1);
     rc |= expect_str("udp-default-audio-out", opts.audio_out_dev, "pulse:stub-output");
-    rc |= expect_int("udp-default-ncurses", opts.use_ncurses_terminal, 1);
+    rc |= expect_int("udp-default-ncurses", opts.frontend_kind, DSD_FRONTEND_TERMINAL);
     return rc;
 }
 
@@ -366,7 +366,7 @@ test_file_input_applies_clamped_low_sample_rate(void) {
     rc |= expect_int("file-symbol-center", state.symbolCenter, 4);
     rc |= expect_int("file-decode-mode", g_last_decode_mode, DSDCFG_MODE_ANALOG);
     rc |= expect_str("file-output-left-empty", opts.audio_out_dev, "");
-    rc |= expect_int("file-ncurses-disabled", opts.use_ncurses_terminal, 0);
+    rc |= expect_int("file-ncurses-disabled", opts.frontend_kind, DSD_FRONTEND_NONE);
     return rc;
 }
 
@@ -390,7 +390,7 @@ test_empty_file_path_falls_back_to_pulse_devices(void) {
     rc |= expect_str("empty-file-pulse-input", opts.audio_in_dev, "pulse:stub-input");
     rc |= expect_str("empty-file-pulse-output", opts.audio_out_dev, "pulse:stub-output");
     rc |= expect_int("empty-file-decode-mode", g_last_decode_mode, DSDCFG_MODE_DMR);
-    rc |= expect_int("empty-file-ncurses-disabled", opts.use_ncurses_terminal, 0);
+    rc |= expect_int("empty-file-ncurses-disabled", opts.frontend_kind, DSD_FRONTEND_NONE);
     return rc;
 }
 
@@ -420,7 +420,7 @@ test_rtl_input_formats_clamped_radio_options(void) {
     rc |= expect_str("rtl-clamped-audio-in", opts.audio_in_dev, "rtl:255:851.375M:0:200:4:-1000:3");
     rc |= expect_int("rtl-decode-mode", g_last_decode_mode, DSDCFG_MODE_ANALOG);
     rc |= expect_str("rtl-output-left-empty", opts.audio_out_dev, "");
-    rc |= expect_int("rtl-ncurses-disabled", opts.use_ncurses_terminal, 0);
+    rc |= expect_int("rtl-ncurses-disabled", opts.frontend_kind, DSD_FRONTEND_NONE);
     return rc;
 }
 
@@ -441,7 +441,7 @@ test_invalid_prompt_values_use_documented_defaults(void) {
     rc |= expect_str("invalid-default-pulse-input", opts.audio_in_dev, "pulse:stub-input");
     rc |= expect_str("invalid-default-pulse-output", opts.audio_out_dev, "pulse:stub-output");
     rc |= expect_int("invalid-default-decode-mode", g_last_decode_mode, DSDCFG_MODE_AUTO);
-    rc |= expect_int("invalid-default-ncurses", opts.use_ncurses_terminal, 1);
+    rc |= expect_int("invalid-default-ncurses", opts.frontend_kind, DSD_FRONTEND_TERMINAL);
     return rc;
 }
 
@@ -465,7 +465,7 @@ test_rtl_empty_frequency_falls_back_to_pulse_devices(void) {
     rc |= expect_str("rtl-empty-frequency-pulse-input", opts.audio_in_dev, "pulse:stub-input");
     rc |= expect_str("rtl-empty-frequency-pulse-output", opts.audio_out_dev, "pulse:stub-output");
     rc |= expect_int("rtl-empty-frequency-decode-mode", g_last_decode_mode, DSDCFG_MODE_ANALOG);
-    rc |= expect_int("rtl-empty-frequency-ncurses-disabled", opts.use_ncurses_terminal, 0);
+    rc |= expect_int("rtl-empty-frequency-ncurses-disabled", opts.frontend_kind, DSD_FRONTEND_NONE);
     return rc;
 }
 #endif
@@ -507,7 +507,7 @@ test_config_no_bootstrap_skips_wizard(void) {
     rc |= expect_int("no-bootstrap-audio-input", g_audio_input_calls, 0);
     rc |= expect_int("no-bootstrap-audio-output", g_audio_output_calls, 0);
     rc |= expect_int("no-bootstrap-decode-mode", g_last_decode_mode, DSDCFG_MODE_UNSET);
-    rc |= expect_int("no-bootstrap-ncurses", opts.use_ncurses_terminal, 0);
+    rc |= expect_int("no-bootstrap-ncurses", opts.frontend_kind, DSD_FRONTEND_NONE);
     return rc;
 }
 

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -236,6 +236,42 @@ test_unknown_option_returns_error_and_does_not_exit(void) {
 }
 
 static int
+test_N_short_option_enables_terminal_frontend(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+    initOpts(opts);
+    initState(state);
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "-N";
+    char* argv[] = {arg0, arg1, NULL};
+
+    int argc_effective = 0;
+    int exit_rc = 0;
+
+    int rc = dsd_parse_args(2, argv, opts, state, &argc_effective, &exit_rc);
+    int test_rc = 0;
+    if (rc != DSD_PARSE_CONTINUE) {
+        DSD_FPRINTF(stderr, "expected rc=%d, got %d (exit_rc=%d)\n", DSD_PARSE_CONTINUE, rc, exit_rc);
+        test_rc = 1;
+    }
+    if (opts->frontend_kind != DSD_FRONTEND_TERMINAL) {
+        DSD_FPRINTF(stderr, "expected -N to enable terminal frontend, got frontend_kind=%d\n", opts->frontend_kind);
+        test_rc = 1;
+    }
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
 expect_numeric_parse_error(const char* option, const char* value) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
@@ -5846,6 +5882,7 @@ main(void) {
     rc |= test_help_returns_one_shot_and_does_not_exit();
     rc |= test_invalid_option_returns_error_and_does_not_exit();
     rc |= test_unknown_option_returns_error_and_does_not_exit();
+    rc |= test_N_short_option_enables_terminal_frontend();
     rc |= test_numeric_options_reject_trailing_junk();
     rc |= test_H_loads_aes256_key_for_both_slots();
     rc |= test_H_zero_key_keeps_dmr_encrypted_audio_muted();

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -1413,6 +1413,80 @@ test_bootstrap_accepts_explicit_config_path_outside_cwd(void) {
 }
 
 static int
+test_bootstrap_config_trunking_preserves_legacy_terminal_alias(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    (void)dsd_unsetenv("DSD_NEO_CONFIG");
+    (void)dsd_setenv("DSD_NEO_NO_BOOTSTRAP", "1", 1);
+
+    char cfg_path[1024];
+    if (test_create_temp_ini_in_tmpdir_with_contents("version = 1\n"
+                                                     "\n"
+                                                     "[input]\n"
+                                                     "source = \"rtl\"\n"
+                                                     "rtl_device = 0\n"
+                                                     "rtl_freq = \"100000000\"\n"
+                                                     "\n"
+                                                     "[trunking]\n"
+                                                     "enabled = true\n",
+                                                     cfg_path, sizeof cfg_path)
+        != 0) {
+        DSD_FPRINTF(stderr, "failed to create external temp ini\n");
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--config";
+    char arg2[1024];
+    char arg3[] = "-N";
+    DSD_SNPRINTF(arg2, sizeof arg2, "%s", cfg_path);
+    char* argv[] = {arg0, arg1, arg2, arg3, NULL};
+
+    int argc_effective = 0;
+    int exit_rc = -1;
+    int rc = dsd_runtime_bootstrap(4, argv, opts, state, &argc_effective, &exit_rc);
+
+    int test_rc = 0;
+    if (rc != DSD_BOOTSTRAP_CONTINUE || exit_rc != 0) {
+        DSD_FPRINTF(stderr, "expected legacy terminal alias bootstrap continue, got rc=%d exit_rc=%d\n", rc, exit_rc);
+        test_rc = 1;
+    }
+    if (argc_effective != 2 || !state->cli_argv || !state->cli_argv[1] || strcmp(state->cli_argv[1], "-N") != 0) {
+        DSD_FPRINTF(stderr, "expected compacted CLI to retain -N, argc=%d arg1=%s\n", argc_effective,
+                    (argc_effective > 1 && state->cli_argv && state->cli_argv[1]) ? state->cli_argv[1] : "(missing)");
+        test_rc = 1;
+    }
+    if (opts->trunk_enable != 1 || opts->p25_trunk != 1) {
+        DSD_FPRINTF(stderr, "expected config trunking preserved with -N, got trunk_enable=%d p25_trunk=%d\n",
+                    opts->trunk_enable, opts->p25_trunk);
+        test_rc = 1;
+    }
+    if (opts->frontend_kind != DSD_FRONTEND_TERMINAL) {
+        DSD_FPRINTF(stderr, "expected -N to enable terminal frontend, got frontend_kind=%d\n", opts->frontend_kind);
+        test_rc = 1;
+    }
+
+    (void)remove(cfg_path);
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
 test_bootstrap_missing_explicit_config_keeps_autosave_path(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
@@ -5897,6 +5971,7 @@ main(void) {
     rc |= test_nxdn_pn95_seed_option_matches_reference_bounds();
     rc |= test_bootstrap_treats_lone_ini_as_config();
     rc |= test_bootstrap_accepts_explicit_config_path_outside_cwd();
+    rc |= test_bootstrap_config_trunking_preserves_legacy_terminal_alias();
     rc |= test_bootstrap_missing_explicit_config_keeps_autosave_path();
     rc |= test_bootstrap_rejects_too_long_explicit_config_path();
     rc |= test_bootstrap_guard_rejects_invalid_arguments();

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -1874,13 +1874,14 @@ test_bootstrap_profile_preserves_trunking_with_ncurses_cli(void) {
     char arg2[1024];
     char arg3[] = "--profile";
     char arg4[] = "p25_trunk";
-    char arg5[] = "-N";
+    char arg5[] = "--frontend";
+    char arg6[] = "terminal";
     DSD_SNPRINTF(arg2, sizeof arg2, "%s", cfg_path);
-    char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, NULL};
+    char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, NULL};
 
     int argc_effective = 0;
     int exit_rc = -1;
-    int rc = dsd_runtime_bootstrap(6, argv, opts, state, &argc_effective, &exit_rc);
+    int rc = dsd_runtime_bootstrap(7, argv, opts, state, &argc_effective, &exit_rc);
     if (rc != DSD_BOOTSTRAP_CONTINUE) {
         DSD_FPRINTF(stderr, "expected rc=%d, got %d (exit_rc=%d)\n", DSD_BOOTSTRAP_CONTINUE, rc, exit_rc);
         (void)remove(cfg_path);
@@ -1901,8 +1902,9 @@ test_bootstrap_profile_preserves_trunking_with_ncurses_cli(void) {
                     opts->trunk_scan_enabled, opts->trunk_scan_targets_csv);
         test_rc = 1;
     }
-    if (opts->use_ncurses_terminal != 1) {
-        DSD_FPRINTF(stderr, "expected -N to remain applied, got use_ncurses_terminal=%d\n", opts->use_ncurses_terminal);
+    if (opts->frontend_kind != DSD_FRONTEND_TERMINAL) {
+        DSD_FPRINTF(stderr, "expected --frontend terminal to remain applied, got frontend_kind=%d\n",
+                    opts->frontend_kind);
         test_rc = 1;
     }
     if (strncmp(opts->audio_in_dev, "rtl:", 4) != 0) {
@@ -1953,15 +1955,16 @@ test_bootstrap_inherited_trunk_scan_preserves_ui_only_short_options(void) {
     char arg0[] = "dsd-neo";
     char arg1[] = "--config";
     char arg2[1024];
-    char arg3[] = "-N";
-    char arg4[] = "-v";
-    char arg5[] = "3";
+    char arg3[] = "--frontend";
+    char arg4[] = "terminal";
+    char arg5[] = "-v";
+    char arg6[] = "3";
     DSD_SNPRINTF(arg2, sizeof arg2, "%s", cfg_path);
-    char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, NULL};
+    char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, NULL};
 
     int argc_effective = 0;
     int exit_rc = -1;
-    int rc = dsd_runtime_bootstrap(6, argv, opts, state, &argc_effective, &exit_rc);
+    int rc = dsd_runtime_bootstrap(7, argv, opts, state, &argc_effective, &exit_rc);
 
     int test_rc = 0;
     if (rc != DSD_BOOTSTRAP_CONTINUE || exit_rc != 0) {
@@ -1973,8 +1976,9 @@ test_bootstrap_inherited_trunk_scan_preserves_ui_only_short_options(void) {
                     opts->trunk_scan_enabled, opts->trunk_scan_targets_csv);
         test_rc = 1;
     }
-    if (opts->use_ncurses_terminal != 1) {
-        DSD_FPRINTF(stderr, "expected -N to remain applied, got use_ncurses_terminal=%d\n", opts->use_ncurses_terminal);
+    if (opts->frontend_kind != DSD_FRONTEND_TERMINAL) {
+        DSD_FPRINTF(stderr, "expected --frontend terminal to remain applied, got frontend_kind=%d\n",
+                    opts->frontend_kind);
         test_rc = 1;
     }
     if (opts->use_pbf != 1 || opts->use_lpf != 1 || opts->use_hpf != 0 || opts->use_hpf_d != 0) {
@@ -2453,7 +2457,7 @@ test_bootstrap_missing_profile_errors_without_applying_config_or_cli(void) {
                              "enabled = true\n"
                              "\n"
                              "[profile.valid]\n"
-                             "output.ncurses_ui = true\n";
+                             "output.frontend = terminal\n";
 
     char cfg_path[1024];
     if (test_create_temp_ini_with_contents(ini, cfg_path, sizeof cfg_path) != 0) {
@@ -2469,9 +2473,10 @@ test_bootstrap_missing_profile_errors_without_applying_config_or_cli(void) {
     char arg2[1024];
     char arg3[] = "--profile";
     char arg4[] = "missing";
-    char arg5[] = "-N";
+    char arg5[] = "--frontend";
+    char arg6[] = "terminal";
     DSD_SNPRINTF(arg2, sizeof arg2, "%s", cfg_path);
-    char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, NULL};
+    char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, NULL};
 
     dsd_test_capture_stderr cap;
     if (dsd_test_capture_stderr_begin(&cap, "runtime_cli_missing_profile") != 0) {
@@ -2484,7 +2489,7 @@ test_bootstrap_missing_profile_errors_without_applying_config_or_cli(void) {
 
     int argc_effective = 0;
     int exit_rc = -1;
-    int rc = dsd_runtime_bootstrap(6, argv, opts, state, &argc_effective, &exit_rc);
+    int rc = dsd_runtime_bootstrap(7, argv, opts, state, &argc_effective, &exit_rc);
 
     int capture_failed = dsd_test_capture_stderr_end(&cap);
     char stderr_buf[2048];
@@ -2507,9 +2512,9 @@ test_bootstrap_missing_profile_errors_without_applying_config_or_cli(void) {
         DSD_FPRINTF(stderr, "expected missing profile diagnostic, got:\n%s\n", stderr_buf);
         test_rc = 1;
     }
-    if (opts->use_ncurses_terminal != 0) {
-        DSD_FPRINTF(stderr, "missing profile should stop before CLI -N applies, got ncurses=%d\n",
-                    opts->use_ncurses_terminal);
+    if (opts->frontend_kind != DSD_FRONTEND_NONE) {
+        DSD_FPRINTF(stderr, "missing profile should stop before CLI frontend applies, got frontend_kind=%d\n",
+                    opts->frontend_kind);
         test_rc = 1;
     }
     if (strncmp(opts->audio_in_dev, "rtl:", 4) == 0 || opts->trunk_enable != 0 || opts->p25_trunk != 0) {

--- a/tests/runtime/test_runtime_config_apply.cpp
+++ b/tests/runtime/test_runtime_config_apply.cpp
@@ -367,7 +367,7 @@ test_basic_pulse_config_apply(void) {
     cfg.has_output = 1;
     cfg.output_backend = DSDCFG_OUTPUT_PULSE;
     DSD_SNPRINTF(cfg.pulse_output, sizeof cfg.pulse_output, "%s", "test-sink");
-    cfg.ncurses_ui = 1;
+    cfg.frontend_kind = DSD_FRONTEND_TERMINAL;
 
     // Public API: ui_post_cmd() enqueues; ui_drain_cmds() is called from the
     // demod loop to apply pending commands. For the purposes of this test we
@@ -376,7 +376,7 @@ test_basic_pulse_config_apply(void) {
     ui_drain_cmds(opts, state);
 
     int rc = 0;
-    rc |= expect_true("ncurses flag enabled", opts->use_ncurses_terminal);
+    rc |= expect_int_eq("terminal frontend enabled", opts->frontend_kind, DSD_FRONTEND_TERMINAL);
     rc |= expect_true("pulse input preserved", strncmp(opts->audio_in_dev, "pulse", 5) == 0);
     rc |= expect_true("pulse output preserved", strncmp(opts->audio_out_dev, "pulse", 5) == 0);
     free_test_runtime(&runtime);
@@ -571,7 +571,7 @@ test_ui_profile_selection_applies_overlay_and_disables_autosave(void) {
                              "\n"
                              "[output]\n"
                              "backend = \"null\"\n"
-                             "ncurses_ui = false\n"
+                             "frontend = \"none\"\n"
                              "\n"
                              "[mode]\n"
                              "decode = \"p25p1\"\n"
@@ -581,7 +581,7 @@ test_ui_profile_selection_applies_overlay_and_disables_autosave(void) {
                              "\n"
                              "[profile.beta]\n"
                              "mode.decode = \"dmr\"\n"
-                             "output.ncurses_ui = true\n";
+                             "output.frontend = terminal\n";
 
     char path[DSD_TEST_PATH_MAX] = {0};
     if (create_temp_config_file(ini, path, sizeof path) != 0) {
@@ -614,7 +614,7 @@ test_ui_profile_selection_applies_overlay_and_disables_autosave(void) {
     rc |= expect_true("UI profile load retains config path", strcmp(state->config_autosave_path, path) == 0);
     rc |= expect_true("UI profile overlay applies DMR mode",
                       opts->frame_dmr == 1 && opts->frame_p25p1 == 0 && opts->frame_p25p2 == 0 && opts->frame_ysf == 0);
-    rc |= expect_int_eq("UI profile overlay applies ncurses flag", opts->use_ncurses_terminal, 1);
+    rc |= expect_int_eq("UI profile overlay applies terminal frontend", opts->frontend_kind, DSD_FRONTEND_TERMINAL);
 
     free_test_runtime(&runtime);
     (void)remove(path);
@@ -627,7 +627,7 @@ test_ui_profile_menu_no_profiles_does_not_apply_base_config(void) {
                              "\n"
                              "[output]\n"
                              "backend = \"null\"\n"
-                             "ncurses_ui = true\n";
+                             "frontend = \"terminal\"\n";
 
     char path[DSD_TEST_PATH_MAX] = {0};
     if (create_temp_config_file(ini, path, sizeof path) != 0) {
@@ -652,7 +652,7 @@ test_ui_profile_menu_no_profiles_does_not_apply_base_config(void) {
     int rc = 0;
     rc |= expect_int_eq("no-profile UI load leaves autosave enabled", state->config_autosave_enabled, 1);
     rc |= expect_true("no-profile UI load retains config path", strcmp(state->config_autosave_path, path) == 0);
-    rc |= expect_int_eq("no-profile UI load does not apply base ncurses flag", opts->use_ncurses_terminal, 0);
+    rc |= expect_int_eq("no-profile UI load does not apply base frontend", opts->frontend_kind, DSD_FRONTEND_NONE);
 
     free_test_runtime(&runtime);
     (void)remove(path);

--- a/tests/runtime/test_runtime_config_apply.cpp
+++ b/tests/runtime/test_runtime_config_apply.cpp
@@ -46,11 +46,21 @@
 #include "dsd-neo/platform/file_compat.h"
 #include "dsd-neo/platform/posix_compat.h"
 #include "dsd-neo/runtime/call_alert.h"
-#include "menu_actions.h"
-#include "menu_callbacks.h"
-#include "menu_internal.h"
 #include "test_support.h"
 #include "ui_key_status.h"
+
+typedef struct UiCtx {
+    dsd_opts* opts;
+    dsd_state* state;
+} UiCtx;
+
+typedef struct ProfileSelCtx {
+    dsd_state* state;
+    char path[1024];
+    const char** labels;
+    const char** names;
+    int n;
+} ProfileSelCtx;
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -368,6 +378,7 @@ test_basic_pulse_config_apply(void) {
     cfg.output_backend = DSDCFG_OUTPUT_PULSE;
     DSD_SNPRINTF(cfg.pulse_output, sizeof cfg.pulse_output, "%s", "test-sink");
     cfg.frontend_kind = DSD_FRONTEND_TERMINAL;
+    cfg.frontend_kind_is_set = 1;
 
     // Public API: ui_post_cmd() enqueues; ui_drain_cmds() is called from the
     // demod loop to apply pending commands. For the purposes of this test we
@@ -380,6 +391,58 @@ test_basic_pulse_config_apply(void) {
     rc |= expect_true("pulse input preserved", strncmp(opts->audio_in_dev, "pulse", 5) == 0);
     rc |= expect_true("pulse output preserved", strncmp(opts->audio_out_dev, "pulse", 5) == 0);
     free_test_runtime(&runtime);
+    return rc;
+}
+
+static int
+test_output_config_without_frontend_preserves_active_frontend(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    opts->frontend_kind = DSD_FRONTEND_TERMINAL;
+    DSD_SNPRINTF(opts->audio_out_dev, sizeof opts->audio_out_dev, "%s", "pulse");
+    opts->audio_out_type = 0;
+
+    static const char* ini = "version = 1\n"
+                             "\n"
+                             "[output]\n"
+                             "backend = \"null\"\n";
+
+    char path[DSD_TEST_PATH_MAX] = {0};
+    if (create_temp_config_file(ini, path, sizeof path) != 0) {
+        free_test_runtime(&runtime);
+        return 1;
+    }
+
+    dsdneoUserConfig cfg = {0};
+    if (dsd_user_config_load(path, &cfg) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: could not load output-only config %s\n", path);
+        free_test_runtime(&runtime);
+        (void)remove(path);
+        return 1;
+    }
+
+    ui_post_cmd(UI_CMD_CONFIG_APPLY, &cfg, sizeof cfg);
+    ui_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_int_eq("output-only config omits frontend", cfg.frontend_kind_is_set, 0);
+    rc |= expect_int_eq("output-only apply preserves active frontend", opts->frontend_kind, DSD_FRONTEND_TERMINAL);
+    rc |= expect_true("output-only apply still changes backend", strcmp(opts->audio_out_dev, "null") == 0);
+
+    cfg.frontend_kind = DSD_FRONTEND_NONE;
+    cfg.frontend_kind_is_set = 1;
+    ui_post_cmd(UI_CMD_CONFIG_APPLY, &cfg, sizeof cfg);
+    ui_drain_cmds(opts, state);
+
+    rc |= expect_int_eq("explicit frontend none disables active frontend", opts->frontend_kind, DSD_FRONTEND_NONE);
+
+    free_test_runtime(&runtime);
+    (void)remove(path);
     return rc;
 }
 
@@ -519,7 +582,7 @@ make_test_profile_context(dsd_state* state, const char* path) {
     return pctx;
 }
 
-void
+static void
 chooser_done_config_profile(void* u, int sel) {
     ProfileSelCtx* pctx = (ProfileSelCtx*)u;
     if (!pctx) {
@@ -543,7 +606,7 @@ chooser_done_config_profile(void* u, int sel) {
     free_test_profile_context(pctx);
 }
 
-void
+static void
 act_config_load_profile(void* v) {
     UiCtx* c = (UiCtx*)v;
     if (!c || !c->state) {
@@ -2571,6 +2634,7 @@ int
 main(void) {
     int rc = 0;
     rc |= test_basic_pulse_config_apply();
+    rc |= test_output_config_without_frontend_preserves_active_frontend();
     rc |= test_ui_command_queue_applies_fifo();
     rc |= test_ui_command_queue_overflow_drops_oldest();
     rc |= test_ui_command_queue_truncates_oversized_payload_string();

--- a/tests/runtime/test_runtime_config_apply.cpp
+++ b/tests/runtime/test_runtime_config_apply.cpp
@@ -368,6 +368,7 @@ test_basic_pulse_config_apply(void) {
     opts->audio_in_type = AUDIO_IN_PULSE;
     DSD_SNPRINTF(opts->audio_out_dev, sizeof opts->audio_out_dev, "%s", "pulse");
     opts->audio_out_type = 0;
+    opts->frontend_kind = DSD_FRONTEND_NONE;
 
     dsdneoUserConfig cfg = {0};
     cfg.version = 1;
@@ -387,7 +388,7 @@ test_basic_pulse_config_apply(void) {
     ui_drain_cmds(opts, state);
 
     int rc = 0;
-    rc |= expect_int_eq("terminal frontend enabled", opts->frontend_kind, DSD_FRONTEND_TERMINAL);
+    rc |= expect_int_eq("runtime config apply preserves disabled frontend", opts->frontend_kind, DSD_FRONTEND_NONE);
     rc |= expect_true("pulse input preserved", strncmp(opts->audio_in_dev, "pulse", 5) == 0);
     rc |= expect_true("pulse output preserved", strncmp(opts->audio_out_dev, "pulse", 5) == 0);
     free_test_runtime(&runtime);
@@ -439,10 +440,39 @@ test_output_config_without_frontend_preserves_active_frontend(void) {
     ui_post_cmd(UI_CMD_CONFIG_APPLY, &cfg, sizeof cfg);
     ui_drain_cmds(opts, state);
 
-    rc |= expect_int_eq("explicit frontend none disables active frontend", opts->frontend_kind, DSD_FRONTEND_NONE);
+    rc |= expect_int_eq("explicit frontend none preserves active frontend", opts->frontend_kind, DSD_FRONTEND_TERMINAL);
+
+    static const char* legacy_ini = "version = 1\n"
+                                    "\n"
+                                    "[output]\n"
+                                    "backend = \"null\"\n"
+                                    "ncurses_ui = false\n";
+
+    char legacy_path[DSD_TEST_PATH_MAX] = {0};
+    if (create_temp_config_file(legacy_ini, legacy_path, sizeof legacy_path) != 0) {
+        free_test_runtime(&runtime);
+        (void)remove(path);
+        return rc | 1;
+    }
+
+    dsdneoUserConfig legacy_cfg = {0};
+    if (dsd_user_config_load(legacy_path, &legacy_cfg) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: could not load legacy ncurses_ui=false config %s\n", legacy_path);
+        free_test_runtime(&runtime);
+        (void)remove(path);
+        (void)remove(legacy_path);
+        return rc | 1;
+    }
+
+    ui_post_cmd(UI_CMD_CONFIG_APPLY, &legacy_cfg, sizeof legacy_cfg);
+    ui_drain_cmds(opts, state);
+
+    rc |=
+        expect_int_eq("legacy ncurses_ui=false preserves active frontend", opts->frontend_kind, DSD_FRONTEND_TERMINAL);
 
     free_test_runtime(&runtime);
     (void)remove(path);
+    (void)remove(legacy_path);
     return rc;
 }
 
@@ -658,6 +688,7 @@ test_ui_profile_selection_applies_overlay_and_disables_autosave(void) {
     }
     dsd_opts* opts = runtime.opts;
     dsd_state* state = runtime.state;
+    opts->frontend_kind = DSD_FRONTEND_NONE;
     state->config_autosave_enabled = 1;
     DSD_SNPRINTF(state->config_autosave_path, sizeof state->config_autosave_path, "%s", path);
 
@@ -677,7 +708,7 @@ test_ui_profile_selection_applies_overlay_and_disables_autosave(void) {
     rc |= expect_true("UI profile load retains config path", strcmp(state->config_autosave_path, path) == 0);
     rc |= expect_true("UI profile overlay applies DMR mode",
                       opts->frame_dmr == 1 && opts->frame_p25p1 == 0 && opts->frame_p25p2 == 0 && opts->frame_ysf == 0);
-    rc |= expect_int_eq("UI profile overlay applies terminal frontend", opts->frontend_kind, DSD_FRONTEND_TERMINAL);
+    rc |= expect_int_eq("UI profile overlay preserves runtime frontend", opts->frontend_kind, DSD_FRONTEND_NONE);
 
     free_test_runtime(&runtime);
     (void)remove(path);

--- a/tests/runtime/test_runtime_config_user.cpp
+++ b/tests/runtime/test_runtime_config_user.cpp
@@ -585,6 +585,78 @@ test_load_and_apply_basic(void) {
 }
 
 static int
+test_load_legacy_ncurses_ui_alias(void) {
+    static const char* true_ini = "version = 1\n"
+                                  "\n"
+                                  "[output]\n"
+                                  "ncurses_ui = true\n";
+
+    char true_path[DSD_TEST_PATH_MAX];
+    if (write_temp_config(true_ini, true_path, sizeof true_path) != 0) {
+        return 1;
+    }
+
+    dsdcfg_diagnostics_t diags;
+    DSD_MEMSET(&diags, 0, sizeof(diags));
+    int validate_rc = dsd_user_config_validate(true_path, &diags);
+
+    int rc = 0;
+    if (validate_rc != 0 || diags.error_count != 0) {
+        DSD_FPRINTF(stderr, "legacy ncurses_ui alias should validate without errors, rc=%d errors=%d warnings=%d\n",
+                    validate_rc, diags.error_count, diags.warning_count);
+        rc |= 1;
+    }
+    int found_deprecated_alias = 0;
+    for (int i = 0; i < diags.count; i++) {
+        if (diags.items[i].level == DSDCFG_DIAG_INFO && strcmp(diags.items[i].section, "output") == 0
+            && strcmp(diags.items[i].key, "ncurses_ui") == 0 && strstr(diags.items[i].message, "deprecated")) {
+            found_deprecated_alias = 1;
+            break;
+        }
+    }
+    if (!found_deprecated_alias) {
+        DSD_FPRINTF(stderr, "missing deprecated diagnostic for output.ncurses_ui alias\n");
+        rc |= 1;
+    }
+    dsd_user_config_diags_free(&diags);
+
+    dsdneoUserConfig cfg;
+    if (dsd_user_config_load(true_path, &cfg) != 0) {
+        DSD_FPRINTF(stderr, "dsd_user_config_load failed for legacy ncurses_ui=true config %s\n", true_path);
+        (void)remove(true_path);
+        return rc | 1;
+    }
+    if (!cfg.has_output || !cfg.frontend_kind_is_set || cfg.frontend_kind != DSD_FRONTEND_TERMINAL) {
+        DSD_FPRINTF(stderr, "legacy ncurses_ui=true did not enable terminal frontend, has=%d set=%d kind=%d\n",
+                    cfg.has_output, cfg.frontend_kind_is_set, (int)cfg.frontend_kind);
+        rc |= 1;
+    }
+    (void)remove(true_path);
+
+    static const char* false_ini = "version = 1\n"
+                                   "\n"
+                                   "[output]\n"
+                                   "ncurses_ui = false\n";
+
+    char false_path[DSD_TEST_PATH_MAX];
+    if (write_temp_config(false_ini, false_path, sizeof false_path) != 0) {
+        return rc | 1;
+    }
+    if (dsd_user_config_load(false_path, &cfg) != 0) {
+        DSD_FPRINTF(stderr, "dsd_user_config_load failed for legacy ncurses_ui=false config %s\n", false_path);
+        (void)remove(false_path);
+        return rc | 1;
+    }
+    if (!cfg.has_output || !cfg.frontend_kind_is_set || cfg.frontend_kind != DSD_FRONTEND_NONE) {
+        DSD_FPRINTF(stderr, "legacy ncurses_ui=false did not disable frontend, has=%d set=%d kind=%d\n", cfg.has_output,
+                    cfg.frontend_kind_is_set, (int)cfg.frontend_kind);
+        rc |= 1;
+    }
+    (void)remove(false_path);
+    return rc;
+}
+
+static int
 test_load_and_apply_alerts_empty_event_mask(void) {
     static const char* ini = "version = 1\n"
                              "\n"
@@ -1507,6 +1579,7 @@ main(void) {
     rc |= test_unknown_section_warnings_do_not_mutate_loaded_config();
     rc |= test_render_input_variants_and_save_atomic();
     rc |= test_load_and_apply_basic();
+    rc |= test_load_legacy_ncurses_ui_alias();
     rc |= test_load_and_apply_alerts_empty_event_mask();
     rc |= test_load_and_apply_soapy_input_no_args();
     rc |= test_load_and_apply_soapy_input_with_args();

--- a/tests/runtime/test_runtime_config_user.cpp
+++ b/tests/runtime/test_runtime_config_user.cpp
@@ -269,7 +269,7 @@ test_render_input_variants_and_save_atomic(void) {
     cfg.has_output = 1;
     cfg.output_backend = DSDCFG_OUTPUT_PULSE;
     DSD_SNPRINTF(cfg.pulse_output, sizeof cfg.pulse_output, "%s", "speaker");
-    cfg.ncurses_ui = 1;
+    cfg.frontend_kind = DSD_FRONTEND_TERMINAL;
     cfg.has_mode = 1;
     cfg.decode_mode = DSDCFG_MODE_M17;
     cfg.has_demod = 1;
@@ -422,7 +422,7 @@ test_load_and_apply_basic(void) {
                              "\n"
                              "[output]\n"
                              "backend = \"null\"\n"
-                             "ncurses_ui = true\n"
+                             "frontend = \"terminal\"\n"
                              "\n"
                              "[mode]\n"
                              "decode = \"dmr\"\n"
@@ -478,7 +478,7 @@ test_load_and_apply_basic(void) {
         DSD_FPRINTF(stderr, "input section not parsed as RTL\n");
         rc |= 1;
     }
-    if (!cfg.has_output || cfg.output_backend != DSDCFG_OUTPUT_NULL || cfg.ncurses_ui != 1) {
+    if (!cfg.has_output || cfg.output_backend != DSDCFG_OUTPUT_NULL || cfg.frontend_kind != DSD_FRONTEND_TERMINAL) {
         DSD_FPRINTF(stderr, "output section not parsed correctly\n");
         rc |= 1;
     }
@@ -517,8 +517,8 @@ test_load_and_apply_basic(void) {
         DSD_FPRINTF(stderr, "audio_out_dev mismatch: \"%s\"\n", opts.audio_out_dev);
         rc |= 1;
     }
-    if (opts.use_ncurses_terminal != 1) {
-        DSD_FPRINTF(stderr, "use_ncurses_terminal not enabled\n");
+    if (opts.frontend_kind != DSD_FRONTEND_TERMINAL) {
+        DSD_FPRINTF(stderr, "terminal frontend not enabled\n");
         rc |= 1;
     }
     if (!(opts.frame_dmr == 1 && opts.frame_p25p1 == 0 && opts.frame_p25p2 == 0 && opts.frame_ysf == 0)) {
@@ -1100,7 +1100,7 @@ test_snapshot_roundtrip(void) {
                              "\n"
                              "[output]\n"
                              "backend = \"pulse\"\n"
-                             "ncurses_ui = false\n"
+                             "frontend = \"none\"\n"
                              "\n"
                              "[mode]\n"
                              "decode = \"analog\"\n"

--- a/tests/runtime/test_runtime_config_user.cpp
+++ b/tests/runtime/test_runtime_config_user.cpp
@@ -270,6 +270,7 @@ test_render_input_variants_and_save_atomic(void) {
     cfg.output_backend = DSDCFG_OUTPUT_PULSE;
     DSD_SNPRINTF(cfg.pulse_output, sizeof cfg.pulse_output, "%s", "speaker");
     cfg.frontend_kind = DSD_FRONTEND_TERMINAL;
+    cfg.frontend_kind_is_set = 1;
     cfg.has_mode = 1;
     cfg.decode_mode = DSDCFG_MODE_M17;
     cfg.has_demod = 1;
@@ -478,7 +479,8 @@ test_load_and_apply_basic(void) {
         DSD_FPRINTF(stderr, "input section not parsed as RTL\n");
         rc |= 1;
     }
-    if (!cfg.has_output || cfg.output_backend != DSDCFG_OUTPUT_NULL || cfg.frontend_kind != DSD_FRONTEND_TERMINAL) {
+    if (!cfg.has_output || cfg.output_backend != DSDCFG_OUTPUT_NULL || cfg.frontend_kind != DSD_FRONTEND_TERMINAL
+        || !cfg.frontend_kind_is_set) {
         DSD_FPRINTF(stderr, "output section not parsed correctly\n");
         rc |= 1;
     }

--- a/tests/runtime/test_runtime_rtl_stream_metrics_hooks.c
+++ b/tests/runtime/test_runtime_rtl_stream_metrics_hooks.c
@@ -23,6 +23,7 @@ static int g_snr_c4fm_calls = 0;
 static int g_snr_c4fm_eye_calls = 0;
 static int g_snr_cqpsk_calls = 0;
 static int g_snr_gfsk_calls = 0;
+static int g_snr_gfsk_eye_calls = 0;
 static int g_snr_qpsk_const_calls = 0;
 static int g_p25p1_ber_calls = 0;
 static int g_p25p2_err_calls = 0;
@@ -139,6 +140,12 @@ fake_snr_gfsk_db(void) {
 }
 
 static double
+fake_snr_gfsk_eye_db(void) {
+    g_snr_gfsk_eye_calls++;
+    return 43.21;
+}
+
+static double
 fake_snr_qpsk_const_db(void) {
     g_snr_qpsk_const_calls++;
     return 45.67;
@@ -230,6 +237,7 @@ main(void) {
     assert(dsd_rtl_stream_metrics_hook_snr_c4fm_eye_db() == -100.0);
     assert(dsd_rtl_stream_metrics_hook_snr_cqpsk_db() == -100.0);
     assert(dsd_rtl_stream_metrics_hook_snr_gfsk_db() == -100.0);
+    assert(dsd_rtl_stream_metrics_hook_snr_gfsk_eye_db() == -100.0);
     assert(dsd_rtl_stream_metrics_hook_snr_qpsk_const_db() == -100.0);
 
     dsd_rtl_stream_metrics_hook_p25p1_ber_update(1, 0);
@@ -258,6 +266,7 @@ main(void) {
     g_snr_c4fm_eye_calls = 0;
     g_snr_cqpsk_calls = 0;
     g_snr_gfsk_calls = 0;
+    g_snr_gfsk_eye_calls = 0;
     g_snr_qpsk_const_calls = 0;
     g_p25p1_ber_calls = 0;
     g_p25p2_err_calls = 0;
@@ -280,6 +289,7 @@ main(void) {
     hooks.snr_c4fm_eye_db = fake_snr_c4fm_eye_db;
     hooks.snr_cqpsk_db = fake_snr_cqpsk_db;
     hooks.snr_gfsk_db = fake_snr_gfsk_db;
+    hooks.snr_gfsk_eye_db = fake_snr_gfsk_eye_db;
     hooks.snr_qpsk_const_db = fake_snr_qpsk_const_db;
     hooks.p25p1_ber_update = fake_p25p1_ber_update;
     hooks.p25p2_err_update = fake_p25p2_err_update;
@@ -341,6 +351,9 @@ main(void) {
 
     assert(dsd_rtl_stream_metrics_hook_snr_gfsk_db() == 34.56);
     assert(g_snr_gfsk_calls == 1);
+
+    assert(dsd_rtl_stream_metrics_hook_snr_gfsk_eye_db() == 43.21);
+    assert(g_snr_gfsk_eye_calls == 1);
 
     assert(dsd_rtl_stream_metrics_hook_snr_qpsk_const_db() == 45.67);
     assert(g_snr_qpsk_const_calls == 1);

--- a/tests/ui/test_ui_async_lifecycle.c
+++ b/tests/ui/test_ui_async_lifecycle.c
@@ -267,7 +267,7 @@ test_ui_start_failure_resets_state(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
-    opts.ncurses_history = 2;
+    opts.terminal_history = 2;
 
     g_create_calls = 0;
     g_join_calls = 0;
@@ -292,7 +292,7 @@ test_ui_start_stop_idempotency_and_control_pump(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
-    opts.ncurses_history = 1;
+    opts.terminal_history = 1;
 
     g_create_calls = 0;
     g_join_calls = 0;
@@ -354,8 +354,8 @@ test_ui_single_frame_snapshot_input_and_draw_helpers(void) {
     DSD_MEMSET(&latest_opts, 0, sizeof(latest_opts));
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&latest_state, 0, sizeof(latest_state));
-    opts.use_ncurses_terminal = 1;
-    latest_opts.use_ncurses_terminal = 1;
+    opts.frontend_kind = DSD_FRONTEND_TERMINAL;
+    latest_opts.frontend_kind = DSD_FRONTEND_TERMINAL;
 
     reset_frame_counters();
     dsd_neo_ui_async_test_set_context(&opts, &state);
@@ -368,7 +368,7 @@ test_ui_single_frame_snapshot_input_and_draw_helpers(void) {
     rc |= expect_int("curses inactive without stdscr", dsd_neo_ui_async_test_curses_is_active(&opts), 0);
     stdscr = (WINDOW*)0x1;
     rc |= expect_int("curses active with stdscr", dsd_neo_ui_async_test_curses_is_active(&opts), 1);
-    latest_opts.use_ncurses_terminal = 0;
+    latest_opts.frontend_kind = DSD_FRONTEND_NONE;
     rc |= expect_int("curses inactive when disabled", dsd_neo_ui_async_test_curses_is_active(&latest_opts), 0);
 
     opts.audio_in_type = AUDIO_IN_STDIN;

--- a/tests/ui/test_ui_async_lifecycle.c
+++ b/tests/ui/test_ui_async_lifecycle.c
@@ -47,6 +47,8 @@ static int g_getch_value = ERR;
 static int g_keypad_calls;
 static int g_timeout_calls;
 static int g_escdelay_calls;
+static int g_ncurses_open_calls;
+static int g_ncurses_close_calls;
 static int g_clearok_calls;
 static int g_ncurses_input_calls;
 static int g_last_menu_key = ERR;
@@ -150,10 +152,13 @@ void
 ncursesOpen(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    g_ncurses_open_calls++;
 }
 
 void
-ncursesClose(void) {}
+ncursesClose(void) {
+    g_ncurses_close_calls++;
+}
 
 void
 ncursesPrinter(dsd_opts* opts, dsd_state* state) {
@@ -320,6 +325,36 @@ test_ui_start_stop_idempotency_and_control_pump(void) {
     return rc;
 }
 
+static int
+test_ui_curses_close_uses_opened_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.frontend_kind = DSD_FRONTEND_TERMINAL;
+
+    g_ncurses_open_calls = 0;
+    g_ncurses_close_calls = 0;
+    dsd_neo_ui_async_test_set_context(&opts, &state);
+
+    int curses_opened = dsd_neo_ui_async_test_open_curses_if_needed();
+    opts.frontend_kind = DSD_FRONTEND_NONE;
+    dsd_neo_ui_async_test_close_curses_if_opened(curses_opened);
+
+    int rc = expect_int("curses-opened", curses_opened, 1);
+    rc |= expect_int("curses-open-count", g_ncurses_open_calls, 1);
+    rc |= expect_int("curses-close-after-frontend-change", g_ncurses_close_calls, 1);
+
+    g_ncurses_open_calls = 0;
+    g_ncurses_close_calls = 0;
+    curses_opened = dsd_neo_ui_async_test_open_curses_if_needed();
+    dsd_neo_ui_async_test_close_curses_if_opened(curses_opened);
+    rc |= expect_int("curses-not-opened-after-disable", curses_opened, 0);
+    rc |= expect_int("curses-no-open-after-disable", g_ncurses_open_calls, 0);
+    rc |= expect_int("curses-no-close-after-disable", g_ncurses_close_calls, 0);
+    return rc;
+}
+
 static void
 reset_frame_counters(void) {
     g_menu_open = 0;
@@ -437,6 +472,7 @@ main(void) {
 
     rc |= test_ui_start_failure_resets_state();
     rc |= test_ui_start_stop_idempotency_and_control_pump();
+    rc |= test_ui_curses_close_uses_opened_state();
     rc |= test_ui_single_frame_snapshot_input_and_draw_helpers();
 
     if (rc == 0) {

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -464,7 +464,7 @@ test_io_and_legacy_state_commands(void) {
     rc |= expect_int("udp input type", opts.audio_in_type, AUDIO_IN_UDP);
     rc |= expect_str("udp bind copied", opts.udp_in_bindaddr, "0.0.0.0");
     rc |= expect_int("udp port copied", opts.udp_in_portno, 7355);
-    rc |= expect_int("compact toggled", opts.ncurses_compact, 1);
+    rc |= expect_int("compact toggled", opts.terminal_compact, 1);
     rc |= expect_int("slot1 disabled", opts.slot1_on, 0);
     rc |= expect_int("slot2 disabled", opts.slot2_on, 0);
     rc |= expect_int("slot preference cycled", opts.slot_preference, 1);

--- a/tests/ui/test_ui_frontend_status_metrics.c
+++ b/tests/ui/test_ui_frontend_status_metrics.c
@@ -18,6 +18,12 @@
 
 static const dsd_opts* g_latest_opts;
 static const dsd_state* g_latest_state;
+static int g_snr_c4fm_eye_calls;
+static int g_snr_gfsk_eye_calls;
+static int g_snr_qpsk_const_calls;
+static double g_snr_c4fm = 23.5;
+static double g_snr_cqpsk = 19.25;
+static double g_snr_gfsk = 17.75;
 
 const dsd_opts*
 dsd_app_get_latest_opts_snapshot(void) {
@@ -139,7 +145,45 @@ hook_cqpsk_status(int* out_cqpsk_enable, int* out_cqpsk_timing_active) {
 
 static double
 hook_snr_c4fm(void) {
-    return 23.5;
+    return g_snr_c4fm;
+}
+
+static double
+hook_snr_cqpsk(void) {
+    return g_snr_cqpsk;
+}
+
+static double
+hook_snr_gfsk(void) {
+    return g_snr_gfsk;
+}
+
+static double
+hook_snr_c4fm_eye(void) {
+    ++g_snr_c4fm_eye_calls;
+    return 7.25;
+}
+
+static double
+hook_snr_gfsk_eye(void) {
+    ++g_snr_gfsk_eye_calls;
+    return 6.5;
+}
+
+static double
+hook_snr_qpsk_const(void) {
+    ++g_snr_qpsk_const_calls;
+    return 9.75;
+}
+
+static void
+reset_snr_hook_fakes(double c4fm, double cqpsk, double gfsk) {
+    g_snr_c4fm = c4fm;
+    g_snr_cqpsk = cqpsk;
+    g_snr_gfsk = gfsk;
+    g_snr_c4fm_eye_calls = 0;
+    g_snr_gfsk_eye_calls = 0;
+    g_snr_qpsk_const_calls = 0;
 }
 
 static void
@@ -169,7 +213,13 @@ test_metrics_fallback_and_runtime_hooks(void) {
     hooks.symbol_profile = hook_symbol_profile;
     hooks.cqpsk_status = hook_cqpsk_status;
     hooks.snr_c4fm_db = hook_snr_c4fm;
+    hooks.snr_c4fm_eye_db = hook_snr_c4fm_eye;
+    hooks.snr_cqpsk_db = hook_snr_cqpsk;
+    hooks.snr_gfsk_db = hook_snr_gfsk;
+    hooks.snr_gfsk_eye_db = hook_snr_gfsk_eye;
+    hooks.snr_qpsk_const_db = hook_snr_qpsk_const;
     dsd_rtl_stream_metrics_hooks_set(&hooks);
+    reset_snr_hook_fakes(23.5, 19.25, 17.75);
     assert(dsd_app_frontend_get_metrics(&opts, &state, &metrics) == 0);
     assert(metrics.output_kind == DSD_FRONTEND_RTL_OUTPUT_SYMBOL_CQPSK);
     assert(metrics.output_rate_hz == 48000U);
@@ -179,6 +229,47 @@ test_metrics_fallback_and_runtime_hooks(void) {
     assert(metrics.cqpsk_enable == 1);
     assert(metrics.cqpsk_timing_active == 1);
     assert(metrics.snr_c4fm_db == 23.5);
+    assert(metrics.snr_cqpsk_db == 19.25);
+    assert(metrics.snr_gfsk_db == 17.75);
+    assert(metrics.snr_c4fm_eye_db == -100.0);
+    assert(metrics.snr_gfsk_eye_db == -100.0);
+    assert(metrics.snr_qpsk_const_db == -100.0);
+    assert(g_snr_c4fm_eye_calls == 0);
+    assert(g_snr_gfsk_eye_calls == 0);
+    assert(g_snr_qpsk_const_calls == 0);
+
+    assert(dsd_app_frontend_get_metrics_with_snr_fallbacks(&opts, &state, &metrics, DSD_FRONTEND_SNR_FALLBACK_ALL)
+           == 0);
+    assert(metrics.snr_c4fm_db == 23.5);
+    assert(metrics.snr_cqpsk_db == 19.25);
+    assert(metrics.snr_gfsk_db == 17.75);
+    assert(metrics.snr_c4fm_eye_db == -100.0);
+    assert(metrics.snr_gfsk_eye_db == -100.0);
+    assert(metrics.snr_qpsk_const_db == -100.0);
+    assert(g_snr_c4fm_eye_calls == 0);
+    assert(g_snr_gfsk_eye_calls == 0);
+    assert(g_snr_qpsk_const_calls == 0);
+
+    reset_snr_hook_fakes(-100.0, -100.0, -100.0);
+    assert(dsd_app_frontend_get_metrics_with_snr_fallbacks(
+               &opts, &state, &metrics, DSD_FRONTEND_SNR_FALLBACK_C4FM_EYE | DSD_FRONTEND_SNR_FALLBACK_QPSK_CONST)
+           == 0);
+    assert(metrics.snr_c4fm_eye_db == 7.25);
+    assert(metrics.snr_qpsk_const_db == 9.75);
+    assert(metrics.snr_gfsk_eye_db == -100.0);
+    assert(g_snr_c4fm_eye_calls == 1);
+    assert(g_snr_gfsk_eye_calls == 0);
+    assert(g_snr_qpsk_const_calls == 1);
+
+    reset_snr_hook_fakes(-100.0, -100.0, -100.0);
+    assert(dsd_app_frontend_get_metrics_with_snr_fallbacks(&opts, &state, &metrics, DSD_FRONTEND_SNR_FALLBACK_GFSK_EYE)
+           == 0);
+    assert(metrics.snr_c4fm_eye_db == -100.0);
+    assert(metrics.snr_gfsk_eye_db == 6.5);
+    assert(metrics.snr_qpsk_const_db == -100.0);
+    assert(g_snr_c4fm_eye_calls == 0);
+    assert(g_snr_gfsk_eye_calls == 1);
+    assert(g_snr_qpsk_const_calls == 0);
     dsd_rtl_stream_metrics_hooks_set(NULL);
 }
 

--- a/tests/ui/test_ui_frontend_status_metrics.c
+++ b/tests/ui/test_ui_frontend_status_metrics.c
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <dsd-neo/app_control/frontend.h>
+#include <dsd-neo/app_control/snapshot.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static const dsd_opts* g_latest_opts;
+static const dsd_state* g_latest_state;
+
+const dsd_opts*
+dsd_app_get_latest_opts_snapshot(void) {
+    return g_latest_opts;
+}
+
+const dsd_state*
+dsd_app_get_latest_snapshot(void) {
+    return g_latest_state;
+}
+
+static void
+fill_frontend_inputs(dsd_opts* opts, dsd_state* state) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->frontend_kind = DSD_FRONTEND_TERMINAL;
+    opts->terminal_compact = 1;
+    opts->terminal_history = 0;
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->audio_out_type = 0;
+    opts->audio_out = 1;
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "rtl:0:851.0125M");
+    DSD_SNPRINTF(opts->audio_out_dev, sizeof opts->audio_out_dev, "%s", "pulse");
+    DSD_SNPRINTF(opts->pa_input_idx, sizeof opts->pa_input_idx, "%s", "source");
+    DSD_SNPRINTF(opts->pa_output_idx, sizeof opts->pa_output_idx, "%s", "sink");
+    opts->rtl_dev_index = 2;
+    opts->rtlsdr_center_freq = 851012500U;
+    opts->rtl_gain_value = 24;
+    opts->rtlsdr_ppm_error = -3;
+    opts->rtl_dsp_bw_khz = 24;
+    opts->rtl_auto_ppm = 1;
+    opts->input_warn_db = -42.5;
+
+    state->config_autosave_enabled = 1;
+    DSD_SNPRINTF(state->config_autosave_path, sizeof state->config_autosave_path, "%s", "/tmp/dsd-neo.ini");
+    state->p2_wacn = 0xbee00U;
+    state->p2_sysid = 0x123U;
+    state->p2_cc = 0x456U;
+    state->tg_hold = 1001;
+    state->lasttg = 1002;
+    state->lasttgR = 1003;
+}
+
+static void
+test_status_copies_opts_and_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    dsd_frontend_status status;
+    fill_frontend_inputs(&opts, &state);
+
+    dsd_app_frontend_status_from_opts_state(&opts, &state, &status);
+    opts.audio_in_dev[0] = '\0';
+    state.config_autosave_path[0] = '\0';
+
+    assert(status.frontend_kind == DSD_FRONTEND_TERMINAL);
+    assert(status.terminal_compact == 1);
+    assert(status.terminal_history == 0);
+    assert(status.audio_in_type == AUDIO_IN_RTL);
+    assert(status.audio_out == 1);
+    assert(strcmp(status.audio_in_dev, "rtl:0:851.0125M") == 0);
+    assert(strcmp(status.config_autosave_path, "/tmp/dsd-neo.ini") == 0);
+    assert(status.rtlsdr_center_freq == 851012500U);
+    assert(status.rtlsdr_ppm_error == -3);
+    assert(status.rtl_auto_ppm == 1);
+    assert(status.p2_wacn == 0xbee00U);
+    assert(status.tg_hold == 1001U);
+    assert(status.lasttgR == 1003U);
+}
+
+static void
+test_status_reads_latest_snapshots(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    dsd_frontend_status status;
+    fill_frontend_inputs(&opts, &state);
+    g_latest_opts = &opts;
+    g_latest_state = &state;
+
+    assert(dsd_app_frontend_get_status(&status) == 0);
+    assert(status.frontend_kind == DSD_FRONTEND_TERMINAL);
+    assert(status.rtl_dev_index == 2);
+    assert(status.config_autosave_enabled == 1);
+}
+
+static int
+hook_output_kind(void) {
+    return DSD_FRONTEND_RTL_OUTPUT_SYMBOL_CQPSK;
+}
+
+static unsigned int
+hook_output_rate(void) {
+    return 48000U;
+}
+
+static int
+hook_symbol_profile(int* out_symbol_rate_hz, int* out_levels, int* out_channel_profile) {
+    if (out_symbol_rate_hz) {
+        *out_symbol_rate_hz = 4800;
+    }
+    if (out_levels) {
+        *out_levels = 4;
+    }
+    if (out_channel_profile) {
+        *out_channel_profile = 5;
+    }
+    return 0;
+}
+
+static int
+hook_cqpsk_status(int* out_cqpsk_enable, int* out_cqpsk_timing_active) {
+    if (out_cqpsk_enable) {
+        *out_cqpsk_enable = 1;
+    }
+    if (out_cqpsk_timing_active) {
+        *out_cqpsk_timing_active = 1;
+    }
+    return 0;
+}
+
+static double
+hook_snr_c4fm(void) {
+    return 23.5;
+}
+
+static void
+test_metrics_fallback_and_runtime_hooks(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    dsd_frontend_metrics metrics;
+    fill_frontend_inputs(&opts, &state);
+
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+    assert(dsd_app_frontend_get_metrics(&opts, NULL, &metrics) == 0);
+    assert(metrics.output_rate_hz == 0U);
+    assert(metrics.snr_c4fm_db == -100.0);
+    assert(metrics.snr_gfsk_eye_db == -100.0);
+    assert(metrics.requested_ppm == -3);
+    assert(metrics.tuner_gain_is_auto == 1);
+    assert(metrics.spectrum_size == 0);
+    assert(dsd_app_frontend_constellation_get(NULL, 0) == 0);
+    assert(dsd_app_frontend_spectrum_get_size() == 0);
+    assert(dsd_app_frontend_spectrum_set_size(256) == -1);
+    assert(dsd_app_frontend_auto_ppm_enabled(NULL, 1) == 1);
+    assert(dsd_app_frontend_tuner_autogain_enabled(NULL, 0) == 0);
+
+    dsd_rtl_stream_metrics_hooks hooks = {0};
+    hooks.output_kind = hook_output_kind;
+    hooks.output_rate_hz = hook_output_rate;
+    hooks.symbol_profile = hook_symbol_profile;
+    hooks.cqpsk_status = hook_cqpsk_status;
+    hooks.snr_c4fm_db = hook_snr_c4fm;
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+    assert(dsd_app_frontend_get_metrics(&opts, &state, &metrics) == 0);
+    assert(metrics.output_kind == DSD_FRONTEND_RTL_OUTPUT_SYMBOL_CQPSK);
+    assert(metrics.output_rate_hz == 48000U);
+    assert(metrics.symbol_rate_hz == 4800);
+    assert(metrics.symbol_levels == 4);
+    assert(metrics.channel_profile == 5);
+    assert(metrics.cqpsk_enable == 1);
+    assert(metrics.cqpsk_timing_active == 1);
+    assert(metrics.snr_c4fm_db == 23.5);
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+}
+
+int
+main(void) {
+    test_status_copies_opts_and_state();
+    test_status_reads_latest_snapshots();
+    test_metrics_fallback_and_runtime_hooks();
+    printf("UI_FRONTEND_STATUS_METRICS: OK\n");
+    return 0;
+}

--- a/tests/ui/test_ui_hotkeys_regression.c
+++ b/tests/ui/test_ui_hotkeys_regression.c
@@ -197,7 +197,7 @@ main(void) {
 
     /* 'h' must cycle immediately in UI thread (no command queue dependency). */
     cap_reset();
-    opts->ncurses_history = 1;
+    opts->terminal_history = 1;
     assert(ncurses_input_handler(opts, state, DSD_KEY_HISTORY) == 1);
     assert(ui_history_get_mode() == 2);
     assert(g_cap.calls == 0);

--- a/tests/ui/test_ui_menu_labels_radio.c
+++ b/tests/ui/test_ui_menu_labels_radio.c
@@ -7,6 +7,7 @@
  * Deterministic contracts for USE_RADIO terminal UI menu labels and predicates.
  */
 
+#include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
@@ -148,6 +149,40 @@ rtl_stream_get_auto_ppm(void) {
 int
 rtl_stream_get_tuner_autogain(void) {
     return g_rtl_tuner_autogain;
+}
+
+int
+dsd_app_frontend_get_metrics(const dsd_opts* opts, const dsd_state* state, dsd_frontend_metrics* out) {
+    (void)opts;
+    (void)state;
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->output_kind = g_rtl_output_kind;
+    out->cqpsk_enable = g_rtl_cqpsk;
+    out->cqpsk_timing_active = g_rtl_cqpsk;
+    out->iq_balance = g_rtl_iq_balance;
+    out->iq_dc_enabled = g_rtl_iq_dc_on;
+    out->iq_dc_shift_k = g_rtl_iq_dc_k;
+    out->ted_gain = g_rtl_ted_gain;
+    out->cqpsk_timing_bias = g_rtl_timing_bias;
+    out->auto_ppm_enabled = g_rtl_auto_ppm;
+    out->tuner_autogain = g_rtl_tuner_autogain;
+    return 0;
+}
+
+int
+dsd_app_frontend_auto_ppm_enabled(const dsd_state* state, int configured) {
+    if (state && state->rtl_ctx) {
+        return g_rtl_auto_ppm;
+    }
+    return configured ? 1 : 0;
+}
+
+int
+dsd_app_frontend_tuner_autogain_enabled(const dsd_state* state, int configured) {
+    if (state && state->rtl_ctx) {
+        return g_rtl_tuner_autogain;
+    }
+    return configured ? 1 : 0;
 }
 
 static int

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -376,10 +376,16 @@ print_dsp_status(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal
 }
 
 #include "../../src/ui/terminal/dsd_ncurses_printer.c"
+#include "dsd-neo/app_control/frontend.h"
 #include "dsd-neo/core/input_level.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/secret_redaction.h"
 #include "dsd-neo/core/state_fwd.h"
+
+int
+dsd_app_frontend_requested_ppm(const dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
+    return opts ? opts->rtlsdr_ppm_error : 0;
+}
 
 static void
 test_input_source_helpers(void) {

--- a/tests/ui/test_ui_ncurses_visualizers_helpers.c
+++ b/tests/ui/test_ui_ncurses_visualizers_helpers.c
@@ -73,8 +73,10 @@ static int test_init_pair(short pair, short f, short b);
 #define init_pair  test_init_pair
 
 #include "../../src/ui/terminal/ncurses_visualizers.c"
+#include "dsd-neo/app_control/frontend.h"
 #include "dsd-neo/core/opts.h"
 #include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/io/rtl_stream_c.h"
 #include "dsd-neo/ui/ncurses_internal.h"
 #include "dsd-neo/ui/ui_prims.h"
@@ -224,6 +226,36 @@ rtl_stream_spectrum_get(float* out, int max_bins, int* out_rate) { // NOLINT(mis
         *out_rate = 0;
     }
     return 0;
+}
+
+int
+dsd_app_frontend_get_metrics(const dsd_opts* opts, const dsd_state* state, dsd_frontend_metrics* out) {
+    (void)opts;
+    (void)state;
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->snr_bias_c4fm = rtl_stream_get_snr_bias_c4fm();
+    out->snr_c4fm_db = rtl_stream_get_snr_c4fm();
+    return 0;
+}
+
+int
+dsd_app_frontend_constellation_get(float* out_xy, int max_points) {
+    return rtl_stream_constellation_get(out_xy, max_points);
+}
+
+int
+dsd_app_frontend_eye_get(float* out, int max_samples, int* out_sps) {
+    return rtl_stream_eye_get(out, max_samples, out_sps);
+}
+
+int
+dsd_app_frontend_spectrum_get(float* out_db, int max_bins, int* out_rate) {
+    return rtl_stream_spectrum_get(out_db, max_bins, out_rate);
+}
+
+int
+dsd_app_frontend_spectrum_get_size(void) {
+    return rtl_stream_spectrum_get_size();
 }
 
 static int

--- a/tests/ui/test_ui_panels_header_footer.c
+++ b/tests/ui/test_ui_panels_header_footer.c
@@ -92,7 +92,7 @@ test_header_compact_renders_without_banner_color(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof opts);
     DSD_MEMSET(&state, 0, sizeof state);
-    opts.ncurses_compact = 1;
+    opts.terminal_compact = 1;
 
     reset_calls();
     ui_panel_header_render(&opts, &state);
@@ -111,7 +111,7 @@ test_header_compact_trunk_restores_trunk_color(void) {
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof opts);
     DSD_MEMSET(&state, 0, sizeof state);
-    opts.ncurses_compact = 1;
+    opts.terminal_compact = 1;
     opts.p25_trunk = 1;
 
     reset_calls();

--- a/tests/ui/test_ui_snr_readout.c
+++ b/tests/ui/test_ui_snr_readout.c
@@ -36,6 +36,13 @@ dsd_app_frontend_get_metrics(const dsd_opts* opts, const dsd_state* state, dsd_f
     return 0;
 }
 
+int
+dsd_app_frontend_get_metrics_with_snr_fallbacks(const dsd_opts* opts, const dsd_state* state, dsd_frontend_metrics* out,
+                                                unsigned int snr_fallbacks) {
+    (void)snr_fallbacks;
+    return dsd_app_frontend_get_metrics(opts, state, out);
+}
+
 static void
 reset_fakes(void) {
     ui_snr_readout_reset_for_test();

--- a/tests/ui/test_ui_snr_readout.c
+++ b/tests/ui/test_ui_snr_readout.c
@@ -5,20 +5,16 @@
 
 #include "ui_snr_readout.h"
 
-#include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/app_control/frontend.h>
 
 #include <assert.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
+#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
 
-static int g_snr_c4fm_calls = 0;
-static int g_snr_c4fm_eye_calls = 0;
-static int g_snr_cqpsk_calls = 0;
-static int g_snr_gfsk_calls = 0;
-static int g_snr_gfsk_eye_calls = 0;
-static int g_snr_qpsk_const_calls = 0;
 static double g_snr_c4fm = -100.0;
 static double g_snr_c4fm_eye = -100.0;
 static double g_snr_cqpsk = -100.0;
@@ -26,51 +22,23 @@ static double g_snr_gfsk = -100.0;
 static double g_snr_gfsk_eye = -100.0;
 static double g_snr_qpsk_const = -100.0;
 
-double
-rtl_stream_get_snr_c4fm(void) {
-    g_snr_c4fm_calls++;
-    return g_snr_c4fm;
-}
-
-double
-rtl_stream_estimate_snr_c4fm_eye(void) {
-    g_snr_c4fm_eye_calls++;
-    return g_snr_c4fm_eye;
-}
-
-double
-rtl_stream_get_snr_cqpsk(void) {
-    g_snr_cqpsk_calls++;
-    return g_snr_cqpsk;
-}
-
-double
-rtl_stream_get_snr_gfsk(void) {
-    g_snr_gfsk_calls++;
-    return g_snr_gfsk;
-}
-
-double
-rtl_stream_estimate_snr_gfsk_eye(void) {
-    g_snr_gfsk_eye_calls++;
-    return g_snr_gfsk_eye;
-}
-
-double
-rtl_stream_estimate_snr_qpsk_const(void) {
-    g_snr_qpsk_const_calls++;
-    return g_snr_qpsk_const;
+int
+dsd_app_frontend_get_metrics(const dsd_opts* opts, const dsd_state* state, dsd_frontend_metrics* out) {
+    (void)opts;
+    (void)state;
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->snr_c4fm_db = g_snr_c4fm;
+    out->snr_c4fm_eye_db = g_snr_c4fm_eye;
+    out->snr_cqpsk_db = g_snr_cqpsk;
+    out->snr_gfsk_db = g_snr_gfsk;
+    out->snr_gfsk_eye_db = g_snr_gfsk_eye;
+    out->snr_qpsk_const_db = g_snr_qpsk_const;
+    return 0;
 }
 
 static void
 reset_fakes(void) {
     ui_snr_readout_reset_for_test();
-    g_snr_c4fm_calls = 0;
-    g_snr_c4fm_eye_calls = 0;
-    g_snr_cqpsk_calls = 0;
-    g_snr_gfsk_calls = 0;
-    g_snr_gfsk_eye_calls = 0;
-    g_snr_qpsk_const_calls = 0;
     g_snr_c4fm = -100.0;
     g_snr_c4fm_eye = -100.0;
     g_snr_cqpsk = -100.0;
@@ -111,8 +79,6 @@ test_c4fm_uses_direct_snr(void) {
     g_snr_c4fm = 18.25;
 
     expect_readout("c4fm-direct", 0, 18.25, "C4FM");
-    assert(g_snr_c4fm_calls == 1);
-    assert(g_snr_c4fm_eye_calls == 0);
 }
 
 static void
@@ -124,8 +90,6 @@ test_c4fm_keeps_stable_direct_snr(void) {
     for (int i = 0; i < 64; i++) {
         expect_readout("c4fm-stable-direct", 0, 18.25, "C4FM");
     }
-    assert(g_snr_c4fm_calls == 64);
-    assert(g_snr_c4fm_eye_calls == 0);
 }
 
 static void
@@ -134,8 +98,6 @@ test_gfsk_uses_direct_snr(void) {
     g_snr_gfsk = 21.5;
 
     expect_readout("gfsk-direct", 2, 21.5, "GFSK");
-    assert(g_snr_gfsk_calls == 1);
-    assert(g_snr_gfsk_eye_calls == 0);
 }
 
 static void
@@ -145,8 +107,6 @@ test_gfsk_falls_back_when_direct_snr_invalid(void) {
     g_snr_gfsk_eye = 7.25;
 
     expect_readout("gfsk-fallback", 2, 7.25, "GFSK");
-    assert(g_snr_gfsk_calls == 1);
-    assert(g_snr_gfsk_eye_calls == 1);
 }
 
 static void
@@ -156,8 +116,6 @@ test_c4fm_snr_at_invalid_threshold_falls_back(void) {
     g_snr_c4fm_eye = 5.5;
 
     expect_readout("c4fm-threshold-fallback", 0, 5.5, "C4FM");
-    assert(g_snr_c4fm_calls == 1);
-    assert(g_snr_c4fm_eye_calls == 1);
 }
 
 static void
@@ -166,8 +124,6 @@ test_qpsk_uses_cqpsk_snr(void) {
     g_snr_cqpsk = 12.75;
 
     expect_readout("qpsk", 1, 12.75, "QPSK");
-    assert(g_snr_cqpsk_calls == 1);
-    assert(g_snr_qpsk_const_calls == 0);
 }
 
 static void
@@ -177,10 +133,6 @@ test_qpsk_uses_constellation_fallback(void) {
     g_snr_qpsk_const = 9.5;
 
     expect_readout("qpsk-constellation-fallback", 1, 9.5, "QPSK");
-    assert(g_snr_cqpsk_calls == 1);
-    assert(g_snr_qpsk_const_calls == 1);
-    assert(g_snr_c4fm_calls == 0);
-    assert(g_snr_gfsk_calls == 0);
 }
 
 static void
@@ -192,10 +144,6 @@ test_qpsk_uses_best_legacy_snr_when_constellation_invalid(void) {
     g_snr_gfsk = 6.75;
 
     expect_readout("qpsk-legacy-best-fallback", 1, 6.75, "QPSK");
-    assert(g_snr_cqpsk_calls == 1);
-    assert(g_snr_qpsk_const_calls == 1);
-    assert(g_snr_c4fm_calls == 1);
-    assert(g_snr_gfsk_calls == 1);
 }
 
 static void
@@ -207,10 +155,6 @@ test_qpsk_reports_invalid_when_all_estimates_stale(void) {
     g_snr_gfsk = -100.0;
 
     expect_invalid_readout("qpsk-all-invalid", 1, -100.0, "QPSK");
-    assert(g_snr_cqpsk_calls == 1);
-    assert(g_snr_qpsk_const_calls == 1);
-    assert(g_snr_c4fm_calls == 1);
-    assert(g_snr_gfsk_calls == 1);
 }
 
 int


### PR DESCRIPTION
## Summary

- Replaces ncurses-specific frontend options, config, and CLI surfaces with `frontend_kind`, typed predicates, and `--frontend none|terminal`.
- Splits terminal UI discovery and linkage behind `DSD_ENABLE_TERMINAL_UI`, with CLI startup routed through an app-local frontend selector.
- Adds app-control frontend status and metrics APIs for terminal menu defaults, DSP panels, and visualizers.
- Updates architecture guardrails, documentation, and focused runtime/UI/protocol tests for the new boundary.

## Impact

This is a breaking cleanup for ncurses-shaped public names. Terminal UI remains enabled by default, while no-terminal builds fail early with a clear startup error if the terminal frontend is requested.

## Validation

- `cmake -P cmake/arch_rules.cmake`
- `cmake --preset dev-debug`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure`
- no-terminal configure/build smoke check with `-DDSD_ENABLE_TERMINAL_UI=OFF`
- `tools/preflight_ci.sh`
- push-time pre-push checks