### PR TITLE
macos: fix portable dylib staging

### DIFF
--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -531,10 +531,72 @@ jobs:
             fi
           done
 
+          list_rpaths() {
+            local file="$1"
+            otool -l "$file" | awk '
+              /cmd LC_RPATH/ { in_rpath = 1; next }
+              in_rpath && /^[[:space:]]*path / { print $2; in_rpath = 0 }
+            '
+          }
+
+          resolve_rpath_dep() {
+            local file="$1"
+            local dep="$2"
+            local suffix="${dep#@rpath/}"
+            local loader_dir exe_dir rpath resolved candidate
+            loader_dir=$(cd "$(dirname "$file")" && pwd)
+            exe_dir=$(cd "$STAGE/bin" && pwd)
+
+            while IFS= read -r rpath; do
+              case "$rpath" in
+                @loader_path) resolved="$loader_dir" ;;
+                @loader_path/*) resolved="$loader_dir/${rpath#@loader_path/}" ;;
+                @executable_path) resolved="$exe_dir" ;;
+                @executable_path/*) resolved="$exe_dir/${rpath#@executable_path/}" ;;
+                *) resolved="$rpath" ;;
+              esac
+              candidate="$resolved/$suffix"
+              if [ -f "$candidate" ]; then
+                printf '%s\n' "$candidate"
+                return 0
+              fi
+            done < <(list_rpaths "$file")
+
+            return 1
+          }
+
+          resolve_dep_path() {
+            local file="$1"
+            local dep="$2"
+            local loader_dir exe_dir rel candidate
+
+            case "$dep" in
+              /usr/lib/*|/System/*) return 1 ;;
+              @rpath/*)
+                resolve_rpath_dep "$file" "$dep"
+                ;;
+              @loader_path/*)
+                loader_dir=$(cd "$(dirname "$file")" && pwd)
+                rel="${dep#@loader_path/}"
+                candidate="$loader_dir/$rel"
+                [ -f "$candidate" ] && printf '%s\n' "$candidate"
+                ;;
+              @executable_path/*)
+                exe_dir=$(cd "$STAGE/bin" && pwd)
+                rel="${dep#@executable_path/}"
+                candidate="$exe_dir/$rel"
+                [ -f "$candidate" ] && printf '%s\n' "$candidate"
+                ;;
+              *)
+                [ -f "$dep" ] && printf '%s\n' "$dep"
+                ;;
+            esac
+          }
+
           # Helper: collect dylib deps of a file and copy non-system libs into $STAGE/lib
           collect_deps() {
             local file="$1"
-            local libs lib base
+            local libs lib base resolved
             libs=$(otool -L "$file" | tail -n +2 | awk '{print $1}')
             for lib in $libs; do
               # Skip system libraries
@@ -544,9 +606,9 @@ jobs:
               base=$(basename "$lib")
               # Prefer copied version if we already staged it
               if [ ! -f "$STAGE/lib/$base" ]; then
-                # Resolve potential symlink
-                if [ -f "$lib" ]; then
-                  cp -f "$lib" "$STAGE/lib/$base" 2>/dev/null || true
+                # Resolve @rpath/@loader_path dependencies and potential symlinks.
+                if resolved=$(resolve_dep_path "$file" "$lib"); then
+                  cp -f "$resolved" "$STAGE/lib/$base"
                 fi
               fi
             done
@@ -572,19 +634,30 @@ jobs:
           # Normalize install names for staged libs and rebasing binary to @rpath
           add_rpath() {
             local bin="$1"
-            # Add rpath if not present
-            if ! otool -l "$bin" | grep -A2 LC_RPATH | grep -q '@executable_path/../lib'; then
-              install_name_tool -add_rpath "@executable_path/../lib" "$bin" || true
+            local rpath="$2"
+            if ! list_rpaths "$bin" | grep -Fxq "$rpath"; then
+              install_name_tool -add_rpath "$rpath" "$bin"
             fi
           }
 
-          add_rpath "$STAGE/bin/dsd-neo"
+          strip_absolute_rpaths() {
+            local bin="$1"
+            local rpath
+            while IFS= read -r rpath; do
+              case "$rpath" in
+                /*) install_name_tool -delete_rpath "$rpath" "$bin" ;;
+              esac
+            done < <(list_rpaths "$bin")
+          }
+
+          add_rpath "$STAGE/bin/dsd-neo" "@executable_path/../lib"
 
           # Set id for staged libs and change references in the main binary
           for lib in "$STAGE"/lib/*.dylib; do
             [ -f "$lib" ] || continue
             base=$(basename "$lib")
-            install_name_tool -id "@rpath/$base" "$lib" || true
+            install_name_tool -id "@rpath/$base" "$lib"
+            add_rpath "$lib" "@loader_path"
           done
 
           # Rewire binary deps to @rpath when we staged the lib
@@ -593,7 +666,10 @@ jobs:
             case "$dep" in /usr/lib/*|/System/*|$STAGE/*) continue;; esac
             base=$(basename "$dep")
             if [ -f "$STAGE/lib/$base" ]; then
-              install_name_tool -change "$dep" "@rpath/$base" "$STAGE/bin/dsd-neo" || true
+              new_dep="@rpath/$base"
+              if [ "$dep" != "$new_dep" ]; then
+                install_name_tool -change "$dep" "$new_dep" "$STAGE/bin/dsd-neo"
+              fi
             fi
           done < <(otool -L "$STAGE/bin/dsd-neo" | tail -n +2)
 
@@ -605,9 +681,18 @@ jobs:
               case "$dep" in /usr/lib/*|/System/*|$STAGE/*) continue;; esac
               base=$(basename "$dep")
               if [ -f "$STAGE/lib/$base" ]; then
-                install_name_tool -change "$dep" "@rpath/$base" "$tgt" || true
+                new_dep="@rpath/$base"
+                if [ "$dep" != "$new_dep" ]; then
+                  install_name_tool -change "$dep" "$new_dep" "$tgt"
+                fi
               fi
             done < <(otool -L "$tgt" | tail -n +2)
+          done
+
+          strip_absolute_rpaths "$STAGE/bin/dsd-neo"
+          for lib in "$STAGE"/lib/*.dylib; do
+            [ -f "$lib" ] || continue
+            strip_absolute_rpaths "$lib"
           done
 
           # Emit manifest for auditing
@@ -622,14 +707,14 @@ jobs:
             while IFS= read -r -d '' lib; do
               tools/check_release_hardening.sh "$lib" build/dev-release
             done
+          tools/check_macos_portable_deps.sh dist/dsd-neo-macos
 
       - name: Smoke test staged binary
         shell: bash
         run: |
           set -euo pipefail
           STAGE="dist/dsd-neo-macos"
-          export DYLD_FALLBACK_LIBRARY_PATH="$STAGE/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
-          "$STAGE/bin/dsd-neo" -h || true
+          "$STAGE/bin/dsd-neo" -h
 
       - name: Create DMG
         id: dmg
@@ -671,7 +756,6 @@ jobs:
           hdiutil attach "$dmg" -nobrowse -noverify -mountpoint "$mnt"
           trap 'hdiutil detach "$mnt" -force || true' EXIT
           # Run help from inside the mounted DMG
-          export DYLD_FALLBACK_LIBRARY_PATH="$mnt/dsd-neo-macos/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
           "$mnt/dsd-neo-macos/bin/dsd-neo" -h || (echo 'Running help from DMG failed' >&2; exit 1)
           hdiutil detach "$mnt" -force
           trap - EXIT

--- a/src/runtime/bootstrap/interactive.c
+++ b/src/runtime/bootstrap/interactive.c
@@ -4,6 +4,7 @@
  */
 
 #include <dsd-neo/core/csv_import.h>
+#include <dsd-neo/core/frontend_types.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/string_utils.h>

--- a/tests/protocol/p25/test_p25_sm_api_override.c
+++ b/tests/protocol/p25/test_p25_sm_api_override.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+#include <dsd-neo/core/frontend_types.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/platform/timing.h>

--- a/tests/runtime/test_runtime_bootstrap_interactive.c
+++ b/tests/runtime/test_runtime_bootstrap_interactive.c
@@ -7,6 +7,7 @@
  */
 
 #include <dsd-neo/core/csv_import.h>
+#include <dsd-neo/core/frontend_types.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/platform/file_compat.h>

--- a/tools/check_macos_portable_deps.sh
+++ b/tools/check_macos_portable_deps.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+set -euo pipefail
+
+stage=${1:-dist/dsd-neo-macos}
+exe="$stage/bin/dsd-neo"
+lib_dir="$stage/lib"
+manifest="$stage/dylibs-manifest.txt"
+
+find_otool() {
+  if command -v otool > /dev/null 2>&1; then
+    command -v otool
+    return 0
+  fi
+  if command -v llvm-otool > /dev/null 2>&1; then
+    command -v llvm-otool
+    return 0
+  fi
+  return 1
+}
+
+otool_bin=$(find_otool) || {
+  echo "otool or llvm-otool is required for macOS portable dependency checks." >&2
+  exit 2
+}
+
+if [[ ! -f "$exe" ]]; then
+  echo "macOS portable executable not found: $exe" >&2
+  exit 2
+fi
+if [[ ! -d "$lib_dir" ]]; then
+  echo "macOS portable library directory not found: $lib_dir" >&2
+  exit 2
+fi
+
+list_deps() {
+  "$otool_bin" -L "$1" | tail -n +2 | awk '{print $1}'
+}
+
+list_rpaths() {
+  "$otool_bin" -l "$1" | awk '
+    /cmd LC_RPATH/ { in_rpath = 1; next }
+    in_rpath && /^[[:space:]]*path / { print $2; in_rpath = 0 }
+  '
+}
+
+resolve_rpath_dep() {
+  local file=$1
+  local dep=$2
+  local suffix=${dep#@rpath/}
+  local loader_dir
+  local rpath
+  local resolved
+  local candidate
+
+  loader_dir=$(dirname "$file")
+  while IFS= read -r rpath; do
+    case "$rpath" in
+      @loader_path)
+        resolved=$loader_dir
+        ;;
+      @loader_path/*)
+        resolved="$loader_dir/${rpath#@loader_path/}"
+        ;;
+      @executable_path)
+        resolved="$stage/bin"
+        ;;
+      @executable_path/*)
+        resolved="$stage/bin/${rpath#@executable_path/}"
+        ;;
+      *)
+        resolved=$rpath
+        ;;
+    esac
+    candidate="$resolved/$suffix"
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done < <(list_rpaths "$file")
+
+  return 1
+}
+
+resolve_token_path() {
+  local file=$1
+  local dep=$2
+  local rel
+
+  case "$dep" in
+    @loader_path/*)
+      rel=${dep#@loader_path/}
+      printf '%s/%s\n' "$(dirname "$file")" "$rel"
+      ;;
+    @executable_path/*)
+      rel=${dep#@executable_path/}
+      printf '%s/%s\n' "$stage/bin" "$rel"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_system_dep() {
+  case "$1" in
+    /usr/lib/* | /System/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+errors=0
+report_error() {
+  echo "ERROR: $*" >&2
+  errors=$((errors + 1))
+}
+
+macho_files=("$exe")
+while IFS= read -r -d '' lib; do
+  macho_files+=("$lib")
+done < <(find "$lib_dir" -maxdepth 1 -type f -name '*.dylib' -print0)
+
+for file in "${macho_files[@]}"; do
+  rel=${file#"$stage"/}
+
+  while IFS= read -r rpath; do
+    [[ -z "$rpath" ]] && continue
+    case "$rpath" in
+      /*) report_error "$rel has non-portable LC_RPATH: $rpath" ;;
+    esac
+  done < <(list_rpaths "$file")
+
+  while IFS= read -r dep; do
+    [[ -z "$dep" ]] && continue
+    if is_system_dep "$dep"; then
+      continue
+    fi
+
+    case "$dep" in
+      @rpath/*)
+        base=${dep##*/}
+        if [[ "$file" == "$lib_dir/"* && "$base" == "$(basename "$file")" ]]; then
+          continue
+        fi
+        if [[ ! -f "$lib_dir/$base" ]]; then
+          report_error "$rel loads $dep but $lib_dir/$base is missing"
+        elif ! resolve_rpath_dep "$file" "$dep" > /dev/null; then
+          report_error "$rel loads $dep but no LC_RPATH resolves it to the staged lib directory"
+        fi
+        ;;
+      @loader_path/* | @executable_path/*)
+        resolved=$(resolve_token_path "$file" "$dep")
+        if [[ ! -f "$resolved" ]]; then
+          report_error "$rel loads $dep but $resolved is missing"
+        fi
+        ;;
+      /*)
+        report_error "$rel has non-system absolute dependency: $dep"
+        ;;
+      *)
+        report_error "$rel has unsupported dependency path: $dep"
+        ;;
+    esac
+  done < <(list_deps "$file")
+done
+
+if [[ -f "$manifest" ]]; then
+  manifest_expected=$(mktemp)
+  manifest_actual=$(mktemp)
+  trap 'rm -f "$manifest_expected" "$manifest_actual"' EXIT
+  sort -f "$manifest" > "$manifest_expected"
+  find "$lib_dir" -maxdepth 1 -type f -name '*.dylib' -exec basename {} \; | sort -f > "$manifest_actual"
+  if ! diff -u "$manifest_expected" "$manifest_actual" >&2; then
+    report_error "dylibs-manifest.txt does not match staged lib directory"
+  fi
+else
+  report_error "missing dylibs manifest: $manifest"
+fi
+
+if ((errors > 0)); then
+  echo "macOS portable dependency check failed with $errors issue(s)." >&2
+  exit 1
+fi
+
+echo "macOS portable dependency check passed: $stage"


### PR DESCRIPTION
## Summary

Fixes #206.

- Resolve `@rpath`, `@loader_path`, and `@executable_path` dependencies while staging the macOS portable DMG tree.
- Add local runtime search paths for the packaged executable and staged dylibs, then strip absolute Homebrew and runner paths from shipped Mach-O files.
- Add a portable dependency audit script that fails when staged dylibs are missing, unresolved, or depend on non-portable absolute paths.
- Run macOS DMG smoke tests without `DYLD_FALLBACK_LIBRARY_PATH` so CI validates the package as users run it.
- Add direct `frontend_types` includes required by the main-branch IWYU job.

## Root Cause

The v2.2.0 arm64 DMG binary referenced `@rpath/libmbe-neo.2.dylib`, but the staging script only copied dependencies that appeared as literal filesystem paths. That skipped `libmbe-neo.2.dylib` and left build-machine rpaths in the package, allowing runtime resolution to depend on the user's Homebrew environment.

The linked IWYU failure on `main` was caused by files using `DSD_FRONTEND_*` enum values through transitive includes instead of including `dsd-neo/core/frontend_types.h` directly.

## Validation

- `tools/shell_lint.sh tools/check_macos_portable_deps.sh`
- `tools/workflow_lint.sh .github/workflows/macos-ci.yaml`
- `tools/iwyu.sh --strict --jobs 1 src/runtime/bootstrap/interactive.c tests/protocol/p25/test_p25_sm_api_override.c tests/runtime/test_runtime_bootstrap_interactive.c`
- `git diff --check`
- `tools/check_macos_portable_deps.sh` against the released v2.2.0 DMG extraction, confirming it flags the missing `libmbe-neo.2.dylib` and non-portable rpaths.
- Pre-push hook guardrails completed successfully while pushing the branch.