### PR TITLE
macos: re-sign portable Mach-O files

### DIFF
--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -698,6 +698,22 @@ jobs:
           # Emit manifest for auditing
           find "$STAGE/lib" -maxdepth 1 -type f -name '*.dylib' -exec basename {} \; | sort -f > "$STAGE/dylibs-manifest.txt"
 
+      - name: Sign staged Mach-O files
+        shell: bash
+        run: |
+          set -euo pipefail
+          sign_and_verify() {
+            local file="$1"
+            codesign --force --sign - "$file"
+            codesign --verify --strict --verbose=2 "$file"
+          }
+
+          find dist/dsd-neo-macos/lib -maxdepth 1 -type f -name '*.dylib' -print0 |
+            while IFS= read -r -d '' lib; do
+              sign_and_verify "$lib"
+            done
+          sign_and_verify dist/dsd-neo-macos/bin/dsd-neo
+
       - name: Verify staged release hardening
         shell: bash
         run: |

--- a/tools/check_macos_portable_deps.sh
+++ b/tools/check_macos_portable_deps.sh
@@ -115,6 +115,23 @@ report_error() {
   errors=$((errors + 1))
 }
 
+verify_code_signature() {
+  local file=$1
+  local rel=$2
+
+  case "$(uname -s)" in
+    Darwin)
+      if ! command -v codesign > /dev/null 2>&1; then
+        echo "codesign is required for macOS portable signature checks." >&2
+        exit 2
+      fi
+      if ! codesign --verify --strict --verbose=2 "$file" > /dev/null 2>&1; then
+        report_error "$rel has an invalid code signature"
+      fi
+      ;;
+  esac
+}
+
 macho_files=("$exe")
 while IFS= read -r -d '' lib; do
   macho_files+=("$lib")
@@ -122,6 +139,7 @@ done < <(find "$lib_dir" -maxdepth 1 -type f -name '*.dylib' -print0)
 
 for file in "${macho_files[@]}"; do
   rel=${file#"$stage"/}
+  verify_code_signature "$file" "$rel"
 
   while IFS= read -r rpath; do
     [[ -z "$rpath" ]] && continue


### PR DESCRIPTION
## Summary

Fixes #206.

- Re-sign every staged macOS dylib after `install_name_tool` rewrites package load commands.
- Re-sign and verify the staged `dsd-neo` executable after dylibs are signed.
- Extend the macOS portable dependency audit to fail on invalid code signatures when it runs on Darwin.

## Root Cause

The previous portable dependency fix normalized the packaged `@rpath` graph, but it modified Homebrew-sourced dylibs after they already carried embedded code signatures. The resulting package had correct load paths while several bundled dylibs still contained stale page hashes, causing macOS to terminate startup with `SIGKILL (Code Signature Invalid)`.

## Validation

- `tools/shell_lint.sh tools/check_macos_portable_deps.sh`
- `tools/workflow_lint.sh .github/workflows/macos-ci.yaml`
- `tools/check_macos_portable_deps.sh /tmp/dsd-neo-issue206/extracted/dsd-neo/dsd-neo-macos`
- `git diff --check`
- Pre-push guardrails completed successfully while pushing `fix/macos-portable-codesign`.