### PR TITLE
macos: bundle ncurses terminfo in portable dmg

### DIFF
--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -518,6 +518,31 @@ jobs:
           cp -f packaging/macos/README-macos.txt "$STAGE/" || true
           cp -f packaging/macos/dsd-neo.sh "$STAGE/" || true
           chmod +x "$STAGE/dsd-neo.sh" || true
+          # Homebrew ncurses needs its terminfo database at runtime. The
+          # database is data rather than a dylib, so otool-based dependency
+          # staging will not discover it.
+          TERMINFO_SRC=""
+          for candidate in \
+            "$HB_PREFIX/opt/ncurses/share/terminfo" \
+            "$HB_PREFIX/share/terminfo" \
+            /usr/share/terminfo; do
+            if [ -d "$candidate" ]; then
+              TERMINFO_SRC="$candidate"
+              break
+            fi
+          done
+          if [ -z "$TERMINFO_SRC" ]; then
+            echo "ERROR: could not locate ncurses terminfo database" >&2
+            exit 1
+          fi
+          rm -rf "$STAGE/share/terminfo"
+          mkdir -p "$STAGE/share/terminfo"
+          cp -a "$TERMINFO_SRC"/. "$STAGE/share/terminfo"/
+          if ! find "$STAGE/share/terminfo" -type f -name xterm-256color -print -quit | grep -q .; then
+            echo "ERROR: staged terminfo database is missing xterm-256color" >&2
+            exit 1
+          fi
+
           # Bundle license/notice files
           DOCDIR="$STAGE/share/doc/dsd-neo"
           mkdir -p "$DOCDIR/licenses"
@@ -730,7 +755,18 @@ jobs:
         run: |
           set -euo pipefail
           STAGE="dist/dsd-neo-macos"
-          "$STAGE/bin/dsd-neo" -h
+          "$STAGE/dsd-neo.sh" -h
+
+      - name: Verify bundled terminfo
+        shell: bash
+        run: |
+          set -euo pipefail
+          STAGE="dist/dsd-neo-macos"
+          if command -v infocmp > /dev/null 2>&1; then
+            TERMINFO_DIRS="$STAGE/share/terminfo:/usr/share/terminfo" infocmp xterm-256color > /dev/null
+          else
+            echo "infocmp not available; terminfo payload checked by tools/check_macos_portable_deps.sh"
+          fi
 
       - name: Create DMG
         id: dmg
@@ -772,7 +808,7 @@ jobs:
           hdiutil attach "$dmg" -nobrowse -noverify -mountpoint "$mnt"
           trap 'hdiutil detach "$mnt" -force || true' EXIT
           # Run help from inside the mounted DMG
-          "$mnt/dsd-neo-macos/bin/dsd-neo" -h || (echo 'Running help from DMG failed' >&2; exit 1)
+          "$mnt/dsd-neo-macos/dsd-neo.sh" -h || (echo 'Running help from DMG failed' >&2; exit 1)
           hdiutil detach "$mnt" -force
           trap - EXIT
 

--- a/packaging/macos/README-macos.txt
+++ b/packaging/macos/README-macos.txt
@@ -6,6 +6,7 @@ Contents
 - lib/*.dylib              : Bundled runtime library dependencies (when available)
 - dsd-neo.sh               : Launcher that sets DYLD paths and runs dsd-neo
 - dylibs-manifest.txt      : Bundled dylib inventory
+- share/terminfo/          : Bundled ncurses terminal descriptions
 - share/doc/dsd-neo/       : License and third-party notice files
 
 Usage
@@ -16,7 +17,8 @@ Usage
    ./dsd-neo.sh -h
 
 Notes
-- The launcher sets DYLD_FALLBACK_LIBRARY_PATH to use bundled libs.
+- The launcher sets DYLD_FALLBACK_LIBRARY_PATH to use bundled libs and
+  TERMINFO_DIRS to use bundled ncurses terminal descriptions.
 - CI currently produces an arm64 portable DMG from the dev-release preset.
 - This portable build uses PulseAudio by default. If you do not see audio
   devices or get silence, install and start PulseAudio via Homebrew:

--- a/packaging/macos/dsd-neo.sh
+++ b/packaging/macos/dsd-neo.sh
@@ -6,4 +6,9 @@ DIR=$(cd "$(dirname "$0")" && pwd)
 # Prefer bundled libraries
 export DYLD_FALLBACK_LIBRARY_PATH="$DIR/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"
 
+# Prefer bundled ncurses terminal descriptions when the portable package
+# includes them. This keeps Homebrew ncurses usable on systems without
+# Homebrew's terminfo database installed.
+export TERMINFO_DIRS="$DIR/share/terminfo:/usr/share/terminfo:${TERMINFO_DIRS:-}"
+
 exec "$DIR/bin/dsd-neo" "$@"

--- a/tools/check_macos_portable_deps.sh
+++ b/tools/check_macos_portable_deps.sh
@@ -6,6 +6,8 @@ stage=${1:-dist/dsd-neo-macos}
 exe="$stage/bin/dsd-neo"
 lib_dir="$stage/lib"
 manifest="$stage/dylibs-manifest.txt"
+launcher="$stage/dsd-neo.sh"
+terminfo_dir="$stage/share/terminfo"
 
 find_otool() {
   if command -v otool > /dev/null 2>&1; then
@@ -193,6 +195,18 @@ if [[ -f "$manifest" ]]; then
   fi
 else
   report_error "missing dylibs manifest: $manifest"
+fi
+
+if [[ ! -d "$terminfo_dir" ]]; then
+  report_error "missing bundled terminfo directory: $terminfo_dir"
+elif ! find "$terminfo_dir" -type f -name xterm-256color -print -quit | grep -q .; then
+  report_error "bundled terminfo directory is missing xterm-256color"
+fi
+
+if [[ ! -f "$launcher" ]]; then
+  report_error "missing macOS launcher: $launcher"
+elif ! grep -q 'TERMINFO_DIRS=.*/share/terminfo' "$launcher"; then
+  report_error "macOS launcher does not add bundled terminfo to TERMINFO_DIRS"
 fi
 
 if ((errors > 0)); then


### PR DESCRIPTION
## Summary

- Bundle the ncurses terminfo database into the macOS portable DMG under `share/terminfo`.
- Point the macOS launcher at the bundled terminfo directory through `TERMINFO_DIRS`.
- Extend portable package validation and smoke checks so missing `xterm-256color` terminfo is caught before release.

## Root Cause

The portable package was bundling Homebrew `libncursesw.dylib`, but not the non-library terminfo database that ncurses needs to initialize terminal types such as `xterm-256color`. That left users without the matching Homebrew terminfo files hitting `ncurses: cannot initialize terminal type` when the terminal frontend started.

Addresses #206.

## Validation

- `git diff --check`
- `bash -n packaging/macos/dsd-neo.sh tools/check_macos_portable_deps.sh`
- `shellcheck packaging/macos/dsd-neo.sh tools/check_macos_portable_deps.sh`
- `actionlint .github/workflows/macos-ci.yaml`
- pre-push hook: install runtime destination check, secret/workflow/dependency guardrails, Semgrep, shell lint, workflow lint, zizmor, Lizard