### PR TITLE
p25: avoid persistent encrypted grant lockout

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -931,9 +931,10 @@ struct dsd_state {
     uint32_t p25_src_nid; // 20-bit WACN from SUID extension
 
     // P25 current-call flags (per logical slot; FDMA uses slot 0)
-    uint8_t p25_call_emergency[2]; // 1 if current call is emergency
-    uint8_t p25_call_priority[2];  // 0..7 call priority (0 if unknown)
-    uint8_t p25_call_is_packet[2]; // 1 if call/service marked as packet (data), else 0
+    uint8_t p25_call_emergency[2];        // 1 if current call is emergency
+    uint8_t p25_call_priority[2];         // 0..7 call priority (0 if unknown)
+    uint8_t p25_call_is_packet[2];        // 1 if call/service marked as packet (data), else 0
+    uint8_t p25_service_options_valid[2]; // 1 when dmr_so/dmr_soR hold fresh P25 service options
 
     //experimental symbol file capture read throttle
     int symbol_throttle;                     //throttle speed

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -572,6 +572,41 @@ watchdog_event_current_init_base(const dsd_state* state, uint8_t slot, watchdog_
     }
 }
 
+static int
+watchdog_event_p25_algid_is_encrypted(uint8_t alg_id) {
+    return alg_id != 0U && alg_id != 0x80U;
+}
+
+static int
+watchdog_event_p25_has_current_voice_alg(const dsd_state* state) {
+    if (state == NULL) {
+        return 0;
+    }
+    if (DSD_SYNC_IS_P25P2(state->lastsynctype)) {
+        return 1;
+    }
+    if (!DSD_SYNC_IS_P25P1(state->lastsynctype)) {
+        return 0;
+    }
+    return state->lastp25type == 1 || state->lastp25type == 2;
+}
+
+static void
+watchdog_event_current_normalize_p25_crypto(const dsd_state* state, watchdog_event_current_ctx* ctx) {
+    if (state == NULL || ctx == NULL || !DSD_SYNC_IS_P25(state->lastsynctype)) {
+        return;
+    }
+
+    if (watchdog_event_p25_algid_is_encrypted(ctx->alg_id) && watchdog_event_p25_has_current_voice_alg(state)) {
+        ctx->enc = 1;
+        return;
+    }
+
+    ctx->alg_id = 0;
+    ctx->key_id = 0;
+    ctx->mi = 0;
+}
+
 static void
 watchdog_event_current_apply_nxdn(const dsd_state* state, watchdog_event_current_ctx* ctx) {
     ctx->source_id = state->nxdn_last_rid;
@@ -890,6 +925,8 @@ watchdog_event_current_build_event_p25(const dsd_state* state, uint8_t slot, con
         char ess_str[30];
         DSD_SNPRINTF(ess_str, sizeof(ess_str), "ENC; ALG: %02X; KID: %04X; ", ctx->alg_id, ctx->key_id);
         watchdog_event_str_append(event_string, event_size, ess_str);
+    } else if (ctx->enc) {
+        watchdog_event_str_append(event_string, event_size, "ENC; ");
     }
     if (ctx->svc_opts & 0x80) {
         watchdog_event_str_append(event_string, event_size, "Emergency; ");
@@ -993,6 +1030,7 @@ watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) {
         watchdog_event_current_apply_slot0_overrides(opts, state, event_struct, &ctx);
     }
 
+    watchdog_event_current_normalize_p25_crypto(state, &ctx);
     watchdog_event_current_load_labels(state, &ctx);
 
     const char* sys_string = dsd_synctype_to_string(state->lastsynctype);

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -591,10 +591,23 @@ watchdog_event_p25_has_current_voice_alg(const dsd_state* state) {
     return state->lastp25type == 1 || state->lastp25type == 2;
 }
 
+static int
+watchdog_event_p25_has_current_service_options(const dsd_state* state, uint8_t slot) {
+    if (state == NULL || !DSD_SYNC_IS_P25(state->lastsynctype)) {
+        return 0;
+    }
+    return state->p25_service_options_valid[slot & 1U] != 0 ? 1 : 0;
+}
+
 static void
-watchdog_event_current_normalize_p25_crypto(const dsd_state* state, watchdog_event_current_ctx* ctx) {
+watchdog_event_current_normalize_p25_crypto(const dsd_state* state, uint8_t slot, watchdog_event_current_ctx* ctx) {
     if (state == NULL || ctx == NULL || !DSD_SYNC_IS_P25(state->lastsynctype)) {
         return;
+    }
+
+    if (!watchdog_event_p25_has_current_service_options(state, slot)) {
+        ctx->svc_opts = 0;
+        ctx->enc = 0;
     }
 
     if (watchdog_event_p25_algid_is_encrypted(ctx->alg_id) && watchdog_event_p25_has_current_voice_alg(state)) {
@@ -1030,7 +1043,7 @@ watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) {
         watchdog_event_current_apply_slot0_overrides(opts, state, event_struct, &ctx);
     }
 
-    watchdog_event_current_normalize_p25_crypto(state, &ctx);
+    watchdog_event_current_normalize_p25_crypto(state, slot, &ctx);
     watchdog_event_current_load_labels(state, &ctx);
 
     const char* sys_string = dsd_synctype_to_string(state->lastsynctype);

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -692,6 +692,8 @@ init_state_protocol_defaults_a(dsd_state* state) {
     // Clear P25 call flags
     state->p25_call_emergency[0] = state->p25_call_emergency[1] = 0;
     state->p25_call_priority[0] = state->p25_call_priority[1] = 0;
+    state->p25_call_is_packet[0] = state->p25_call_is_packet[1] = 0;
+    state->p25_service_options_valid[0] = state->p25_service_options_valid[1] = 0;
 
     // Initialize P25 Phase 1 metrics counters (also reset on retune)
     state->p25_p1_fec_ok = 0;

--- a/src/core/vocoder/dsd_mbe.c
+++ b/src/core/vocoder/dsd_mbe.c
@@ -855,6 +855,7 @@ static void
 mbe_slot_apply_straight_ks_left(dsd_state* state, char ambe_d[49]) {
     if (state->straight_ks == 1 && state->straight_mod > 0) {
         state->dmr_so = 0;
+        state->p25_service_options_valid[0] = 0;
         state->payload_algid = 0;
         straight_mod_xor_apply_frame49(state, state->currentslot, ambe_d);
     }
@@ -864,6 +865,7 @@ static void
 mbe_slot_apply_straight_ks_right(dsd_state* state, char ambe_d[49]) {
     if (state->straight_ks == 1 && state->straight_mod > 0) {
         state->dmr_soR = 0;
+        state->p25_service_options_valid[1] = 0;
         state->payload_algidR = 0;
         straight_mod_xor_apply_frame49(state, state->currentslot, ambe_d);
     }

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -149,6 +149,7 @@ typedef struct {
     uint8_t p25_call_emergency[2];
     uint8_t p25_call_priority[2];
     uint8_t p25_call_is_packet[2];
+    uint8_t p25_service_options_valid[2];
     uint8_t p25_patch_is_patch[8];
     uint8_t p25_patch_active[8];
     uint8_t p25_patch_wgid_count[8];
@@ -749,6 +750,10 @@ trunk_scan_save_call_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot* s
     DSD_MEMCPY(snapshot->p25_call_emergency, state->p25_call_emergency, sizeof(snapshot->p25_call_emergency));
     DSD_MEMCPY(snapshot->p25_call_priority, state->p25_call_priority, sizeof(snapshot->p25_call_priority));
     DSD_MEMCPY(snapshot->p25_call_is_packet, state->p25_call_is_packet, sizeof(snapshot->p25_call_is_packet));
+    DSD_MEMCPY(snapshot->p25_service_options_valid, state->p25_service_options_valid,
+               sizeof(snapshot->p25_service_options_valid));
+    snapshot->dmr_so = state->dmr_so;
+    snapshot->dmr_soR = state->dmr_soR;
     snapshot->lasttg = state->lasttg;
     snapshot->lasttgR = state->lasttgR;
     snapshot->lastsrc = state->lastsrc;
@@ -761,6 +766,10 @@ trunk_scan_restore_call_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot
     DSD_MEMCPY(state->p25_call_emergency, snapshot->p25_call_emergency, sizeof(state->p25_call_emergency));
     DSD_MEMCPY(state->p25_call_priority, snapshot->p25_call_priority, sizeof(state->p25_call_priority));
     DSD_MEMCPY(state->p25_call_is_packet, snapshot->p25_call_is_packet, sizeof(state->p25_call_is_packet));
+    DSD_MEMCPY(state->p25_service_options_valid, snapshot->p25_service_options_valid,
+               sizeof(state->p25_service_options_valid));
+    state->dmr_so = snapshot->dmr_so;
+    state->dmr_soR = snapshot->dmr_soR;
     state->lasttg = snapshot->lasttg;
     state->lasttgR = snapshot->lasttgR;
     state->lastsrc = snapshot->lastsrc;

--- a/src/protocol/p25/p25_lcw.c
+++ b/src/protocol/p25/p25_lcw.c
@@ -185,6 +185,7 @@ p25_lcw_handle_format_00(p25_lcw_ctx* ctx) {
 
     ctx->state->gi[0] = 0;
     ctx->state->dmr_so = ctx->lc_svcopt;
+    ctx->state->p25_service_options_valid[0] = 1;
     if (group != 0) {
         ctx->state->lasttg = group;
     }
@@ -218,6 +219,7 @@ p25_lcw_handle_format_03(p25_lcw_ctx* ctx) {
     ctx->state->generic_talker_alias_src[0] = 0;
     ctx->state->gi[0] = 1;
     ctx->state->dmr_so = ctx->lc_svcopt;
+    ctx->state->p25_service_options_valid[0] = 1;
 
     p25_lcw_set_call_string_prefix(ctx->state, " Private ", ctx->lc_svcopt);
 }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1345,6 +1345,10 @@ p25_release_clear_decoder_state(dsd_opts* opts, dsd_state* state) {
         state->payload_keyidR = 0;
         state->payload_miP = 0;
         state->payload_miN = 0;
+        state->dmr_so = 0;
+        state->dmr_soR = 0;
+        state->p25_service_options_valid[0] = 0;
+        state->p25_service_options_valid[1] = 0;
         state->p25_p2_enc_lockout_muted[0] = 0;
         state->p25_p2_enc_lockout_muted[1] = 0;
         state->p25_sm_release_count++;
@@ -2198,9 +2202,11 @@ p25_emit_enc_lockout_once(dsd_opts* opts, dsd_state* state, uint8_t slot, int tg
     if ((slot & 1) == 0) {
         state->lasttg = (uint32_t)tg;
         state->dmr_so = (uint16_t)svc_bits;
+        state->p25_service_options_valid[0] = (svc_bits != 0) ? 1U : 0U;
     } else {
         state->lasttgR = (uint32_t)tg;
         state->dmr_soR = (uint16_t)svc_bits;
+        state->p25_service_options_valid[1] = (svc_bits != 0) ? 1U : 0U;
     }
     state->gi[slot & 1] = 0;
 

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -356,40 +356,6 @@ is_tdma_channel(const dsd_state* state, int channel) {
     return 0;
 }
 
-static int
-p25_upsert_de_lockout(dsd_state* state, int tg, int* out_was_de) {
-    int was_de = 0;
-    const char* name = "ENC LO";
-    char mode_buf[8];
-    char name_buf[50];
-    dsd_tg_policy_entry entry;
-
-    if (!state || tg <= 0) {
-        if (out_was_de) {
-            *out_was_de = 0;
-        }
-        return 1;
-    }
-
-    if (dsd_tg_policy_lookup_label(state, (uint32_t)tg, mode_buf, sizeof(mode_buf), name_buf, sizeof(name_buf))) {
-        was_de = (strcmp(mode_buf, "DE") == 0);
-        if (name_buf[0] != '\0') {
-            name = name_buf;
-        }
-    }
-    if (out_was_de) {
-        *out_was_de = was_de;
-    }
-    if (was_de) {
-        return 0;
-    }
-
-    if (dsd_tg_policy_make_exact_entry((uint32_t)tg, "DE", name, DSD_TG_POLICY_SOURCE_ENC_LOCKOUT, &entry) != 0) {
-        return 1;
-    }
-    return dsd_tg_policy_upsert_exact(state, &entry, DSD_TG_POLICY_UPSERT_REPLACE_FIRST);
-}
-
 static inline int
 channel_slot(const dsd_state* state, int channel) {
     return is_tdma_channel(state, channel) ? ((channel & 1) ? 1 : 0) : -1;
@@ -2223,16 +2189,8 @@ p25_sm_update_audio_gate(p25_sm_ctx_t* ctx, dsd_state* state, int slot, int algi
 
 void
 p25_emit_enc_lockout_once(dsd_opts* opts, dsd_state* state, uint8_t slot, int tg, int svc_bits) {
-    int already_de = 0;
     if (!opts || !state || tg <= 0) {
         return;
-    }
-
-    if (p25_upsert_de_lockout(state, tg, &already_de) != 0) {
-        return;
-    }
-    if (already_de) {
-        return; // already marked; event previously emitted
     }
 
     // Prepare per-slot context. Keep live encryption fields intact: callers may
@@ -2263,7 +2221,7 @@ p25_emit_enc_lockout_once(dsd_opts* opts, dsd_state* state, uint8_t slot, int tg
             dsd_p25_optional_hook_push_event_history(eh);
             dsd_p25_optional_hook_init_event_history(eh, 0, 1);
         }
-    } else if (opts && opts->verbose > 1) {
+    } else if (opts->verbose > 1) {
         p25_sm_log_status(opts, state, "enc-lo-skip-nohist");
     }
 }

--- a/src/protocol/p25/phase1/p25p1_hdu.c
+++ b/src/protocol/p25/phase1/p25p1_hdu.c
@@ -24,7 +24,6 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/parse.h>
 #include <dsd-neo/core/state.h>
-#include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
 #include <dsd-neo/protocol/p25/p25.h>
 #include <dsd-neo/protocol/p25/p25_lfsr.h>
@@ -323,19 +322,6 @@ hdu_read_and_fec(dsd_opts* opts, dsd_state* state, char hex_data[20][6], char he
 static void
 hdu_record_enc_lockout(dsd_opts* opts, dsd_state* state, int ttg) {
     if (ttg == 0) {
-        return;
-    }
-
-    char lockout_name_buf[50];
-    const char* lockout_name = "ENC LO";
-    dsd_tg_policy_entry lockout_entry;
-    if (dsd_tg_policy_lookup_label(state, (uint32_t)ttg, NULL, 0, lockout_name_buf, sizeof(lockout_name_buf))) {
-        lockout_name = lockout_name_buf;
-    }
-    if (dsd_tg_policy_make_exact_entry((uint32_t)ttg, "DE", lockout_name, DSD_TG_POLICY_SOURCE_ENC_LOCKOUT,
-                                       &lockout_entry)
-            != 0
-        || dsd_tg_policy_upsert_exact(state, &lockout_entry, DSD_TG_POLICY_UPSERT_REPLACE_FIRST) != 0) {
         return;
     }
 

--- a/src/protocol/p25/phase1/p25p1_ldu2.c
+++ b/src/protocol/p25/phase1/p25p1_ldu2.c
@@ -548,6 +548,7 @@ ldu2_maybe_enc_lockout(dsd_opts* opts, dsd_state* state, int irrecoverable_error
 
     ldu2_record_enc_lockout(opts, state, state->lasttg);
     DSD_FPRINTF(stderr, " No Enc Following on P25p1 Trunking; Return to CC; \n");
+    state->p25_sm_force_release = 1;
     p25_sm_on_release(opts, state);
 }
 

--- a/src/protocol/p25/phase1/p25p1_ldu2.c
+++ b/src/protocol/p25/phase1/p25p1_ldu2.c
@@ -504,23 +504,6 @@ ldu2_record_enc_lockout(dsd_opts* opts, dsd_state* state, int talkgroup) {
         return;
     }
 
-    int enc_existing = 0;
-    char lockout_name_buf[50];
-    const char* lockout_name = "ENC LO";
-    dsd_tg_policy_entry lockout_entry;
-    if (dsd_tg_policy_lookup_label(state, (uint32_t)talkgroup, NULL, 0, lockout_name_buf, sizeof(lockout_name_buf))) {
-        enc_existing = 1;
-        lockout_name = lockout_name_buf;
-    }
-
-    if (dsd_tg_policy_make_exact_entry((uint32_t)talkgroup, "DE", lockout_name, DSD_TG_POLICY_SOURCE_ENC_LOCKOUT,
-                                       &lockout_entry)
-            != 0
-        || dsd_tg_policy_upsert_exact(state, &lockout_entry, DSD_TG_POLICY_UPSERT_REPLACE_FIRST) != 0
-        || enc_existing != 0) {
-        return;
-    }
-
     DSD_SNPRINTF(state->event_history_s[0].Event_History_Items[0].internal_str,
                  sizeof state->event_history_s[0].Event_History_Items[0].internal_str,
                  "Target: %d; has been locked out; Encryption Lock Out Enabled.", talkgroup);

--- a/src/protocol/p25/phase1/p25p1_pdu_trunking.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_trunking.c
@@ -156,6 +156,9 @@ p25_mbt_try_bridge_iden_updates(dsd_opts* opts, dsd_state* state, const uint8_t*
 
 static void DSD_ATTR_USED
 p25_print_voice_svc_common(const dsd_opts* opts, dsd_state* state, int svc) {
+    state->dmr_so = (uint16_t)svc;
+    state->p25_service_options_valid[0] = 1;
+
     if (svc & 0x80) {
         DSD_FPRINTF(stderr, " Emergency");
         state->p25_call_emergency[0] = 1;

--- a/src/protocol/p25/phase1/p25p1_tdu.c
+++ b/src/protocol/p25/phase1/p25p1_tdu.c
@@ -81,4 +81,6 @@ processTDU(dsd_opts* opts, dsd_state* state) {
     state->p25_call_emergency[0] = 0;
     state->p25_call_priority[0] = 0;
     state->p25_call_is_packet[0] = 0;
+    state->dmr_so = 0;
+    state->p25_service_options_valid[0] = 0;
 }

--- a/src/protocol/p25/phase1/p25p1_tdulc.c
+++ b/src/protocol/p25/phase1/p25p1_tdulc.c
@@ -323,6 +323,8 @@ processTDULC(dsd_opts* opts, dsd_state* state) {
     state->p25_call_emergency[0] = 0;
     state->p25_call_priority[0] = 0;
     state->p25_call_is_packet[0] = 0;
+    state->dmr_so = 0;
+    state->p25_service_options_valid[0] = 0;
 
     char dodeca_data[6][12];
     char dodeca_parity[6][12];

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -67,6 +67,8 @@ tsbk_prepare_frame_state(dsd_opts* opts, dsd_state* state) {
 
     // Ensure slot index is sane when swapping protocols.
     state->currentslot = 0;
+    state->dmr_so = 0;
+    state->p25_service_options_valid[0] = 0;
 
     p25_status_accum_ensure_started(state);
 

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -277,6 +277,10 @@ p25_p2_teardown_call(dsd_opts* opts, dsd_state* state) {
     state->p25_call_emergency[1] = 0;
     state->p25_call_priority[0] = 0;
     state->p25_call_priority[1] = 0;
+    state->dmr_so = 0;
+    state->dmr_soR = 0;
+    state->p25_service_options_valid[0] = 0;
+    state->p25_service_options_valid[1] = 0;
     state->payload_algid = 0;
     state->payload_keyid = 0;
     state->payload_miP = 0ULL;
@@ -695,8 +699,10 @@ process_FACCHc(dsd_opts* opts, dsd_state* state) {
 
     if (state->currentslot == 0) {
         state->dmr_so = opcode;
+        state->p25_service_options_valid[0] = 0;
     } else {
         state->dmr_soR = opcode;
+        state->p25_service_options_valid[1] = 0;
     }
 
     if (ec >= 0) {
@@ -755,8 +761,10 @@ process_FACCHs(dsd_opts* opts, dsd_state* state) {
 
     if (state->currentslot == 0) {
         state->dmr_so = opcode;
+        state->p25_service_options_valid[0] = 0;
     } else {
         state->dmr_soR = opcode;
+        state->p25_service_options_valid[1] = 0;
     }
 
     if (ec >= 0) {
@@ -812,8 +820,10 @@ process_SACCHc(dsd_opts* opts, dsd_state* state) {
     //set inverse true for SACCH
     if (state->currentslot == 0) {
         state->dmr_soR = opcode;
+        state->p25_service_options_valid[1] = 0;
     } else {
         state->dmr_so = opcode;
+        state->p25_service_options_valid[0] = 0;
     }
 
     if (ec >= 0) {
@@ -869,8 +879,10 @@ process_SACCHs(dsd_opts* opts, dsd_state* state) {
     //set inverse true for SACCH
     if (state->currentslot == 0) {
         state->dmr_soR = opcode;
+        state->p25_service_options_valid[1] = 0;
     } else {
         state->dmr_so = opcode;
+        state->p25_service_options_valid[0] = 0;
     }
 
     if (ec >= 0) {

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -641,8 +641,10 @@ static void
 p25p2_vpdu_store_slot_svc(dsd_state* state, int slot, int svc) {
     if ((slot & 1) == 0) {
         state->dmr_so = (uint16_t)svc;
+        state->p25_service_options_valid[0] = 1;
     } else {
         state->dmr_soR = (uint16_t)svc;
+        state->p25_service_options_valid[1] = 1;
     }
 }
 

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -570,6 +570,12 @@ p25p2_xcch_handle_sacch_mac_idle(dsd_opts* opts, dsd_state* state, uint8_t slot,
     p25p2_xcch_blank_slot_call_string(state, slot);
     p25p2_xcch_set_slot_audio_allowed(state, slot, 0);
     state->p25_call_is_packet[slot] = 0;
+    state->p25_service_options_valid[slot] = 0;
+    if (slot == 0) {
+        state->dmr_so = 0;
+    } else {
+        state->dmr_soR = 0;
+    }
 }
 
 static void

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -147,6 +147,15 @@ expect_has_substr(const char* label, const char* haystack, const char* needle) {
 }
 
 static int
+expect_no_substr(const char* label, const char* haystack, const char* needle) {
+    if (haystack != NULL && needle != NULL && strstr(haystack, needle) != NULL) {
+        DSD_FPRINTF(stderr, "%s: unexpected '%s' in '%s'\n", label, needle, haystack);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 expect_str_eq(const char* label, const char* got, const char* want) {
     if (got == NULL || want == NULL || strcmp(got, want) != 0) {
         DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", label, got ? got : "<null>", want ? want : "<null>");
@@ -778,6 +787,56 @@ test_p25_and_dmr_current_append_security_flags(void) {
     rc |= expect_has_substr("p25 enc flag", item->event_string, "ENC; ALG: 84; KID: 2222;");
     rc |= expect_has_substr("p25 emergency", item->event_string, "Emergency;");
     rc |= expect_has_substr("p25 private", item->event_string, "Private;");
+
+    reset_fixture(&opts, &state, event_history);
+    state.lastsynctype = DSD_SYNC_P25P1_POS;
+    state.lastp25type = 3;
+    state.lastsrc = 5790062U;
+    state.lasttg = 50061U;
+    state.gi[0] = 0;
+    state.nac = 0x293;
+    state.payload_algid = 0xBBU;
+    state.payload_keyid = 0xC021U;
+    state.dmr_so = 0;
+    watchdog_event_current(&opts, &state, 0);
+    item = &state.event_history_s[0].Event_History_Items[0];
+    rc |= expect_no_substr("p25 clear grant ignores stale enc", item->event_string, "ENC;");
+    rc |= expect_no_substr("p25 clear grant ignores stale alg", item->event_string, "ALG:");
+    rc |= expect_int("p25 clear grant clears event alg", item->enc_alg, 0);
+    rc |= expect_int("p25 clear grant remains clear", item->enc, 0);
+
+    reset_fixture(&opts, &state, event_history);
+    state.lastsynctype = DSD_SYNC_P25P1_POS;
+    state.lastp25type = 3;
+    state.lastsrc = 5790062U;
+    state.lasttg = 50061U;
+    state.gi[0] = 0;
+    state.nac = 0x293;
+    state.payload_algid = 0xBBU;
+    state.payload_keyid = 0xC021U;
+    state.dmr_so = 0x40U;
+    watchdog_event_current(&opts, &state, 0);
+    item = &state.event_history_s[0].Event_History_Items[0];
+    rc |= expect_has_substr("p25 grant service option keeps enc", item->event_string, "ENC;");
+    rc |= expect_no_substr("p25 grant service option omits stale alg", item->event_string, "ALG:");
+    rc |= expect_int("p25 grant service option clears event alg", item->enc_alg, 0);
+    rc |= expect_int("p25 grant service option encrypted", item->enc, 1);
+
+    reset_fixture(&opts, &state, event_history);
+    state.lastsynctype = DSD_SYNC_P25P1_POS;
+    state.lastp25type = 2;
+    state.lastsrc = 5790062U;
+    state.lasttg = 50061U;
+    state.gi[0] = 0;
+    state.nac = 0x293;
+    state.payload_algid = 0x84U;
+    state.payload_keyid = 0x2222U;
+    state.dmr_so = 0;
+    watchdog_event_current(&opts, &state, 0);
+    item = &state.event_history_s[0].Event_History_Items[0];
+    rc |= expect_has_substr("p25 validated voice alg renders", item->event_string, "ENC; ALG: 84; KID: 2222;");
+    rc |= expect_int("p25 validated voice alg marks encrypted", item->enc, 1);
+    rc |= expect_int("p25 validated voice alg kept", item->enc_alg, 0x84);
     return rc;
 }
 

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -782,6 +782,7 @@ test_p25_and_dmr_current_append_security_flags(void) {
     state.payload_algid = 0x84U;
     state.payload_keyid = 0x2222U;
     state.dmr_so = 0x80U;
+    state.p25_service_options_valid[0] = 1;
     watchdog_event_current(&opts, &state, 0);
     item = &state.event_history_s[0].Event_History_Items[0];
     rc |= expect_has_substr("p25 enc flag", item->event_string, "ENC; ALG: 84; KID: 2222;");
@@ -812,9 +813,27 @@ test_p25_and_dmr_current_append_security_flags(void) {
     state.lasttg = 50061U;
     state.gi[0] = 0;
     state.nac = 0x293;
+    state.payload_algid = 0;
+    state.payload_keyid = 0;
+    state.dmr_so = 0x40U;
+    state.p25_service_options_valid[0] = 0;
+    watchdog_event_current(&opts, &state, 0);
+    item = &state.event_history_s[0].Event_History_Items[0];
+    rc |= expect_no_substr("p25 stale service option ignores enc", item->event_string, "ENC;");
+    rc |= expect_int("p25 stale service option clears svc", item->svc, 0);
+    rc |= expect_int("p25 stale service option remains clear", item->enc, 0);
+
+    reset_fixture(&opts, &state, event_history);
+    state.lastsynctype = DSD_SYNC_P25P1_POS;
+    state.lastp25type = 3;
+    state.lastsrc = 5790062U;
+    state.lasttg = 50061U;
+    state.gi[0] = 0;
+    state.nac = 0x293;
     state.payload_algid = 0xBBU;
     state.payload_keyid = 0xC021U;
     state.dmr_so = 0x40U;
+    state.p25_service_options_valid[0] = 1;
     watchdog_event_current(&opts, &state, 0);
     item = &state.event_history_s[0].Event_History_Items[0];
     rc |= expect_has_substr("p25 grant service option keeps enc", item->event_string, "ENC;");

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -126,6 +126,19 @@ main(void) {
     p25_sm_on_group_grant(&opts, &st, ch, /*svc*/ 0x00, /*tg*/ 1103, /*src*/ 2103);
     rc |= expect_true("group mode DE blocked", st.p25_sm_tune_count == before);
 
+    // Runtime encrypted-call lockout must not persist as a TG policy block.
+    rc |= expect_true("seed mixed-mode group", seed_exact(&st, 1104, "A", "MIXED", 0, 0) == 0);
+    p25_sm_on_release(&opts, &st);
+    opts.trunk_tune_enc_calls = 0;
+    opts.p25_is_tuned = 0;
+    before = st.p25_sm_tune_count;
+    p25_sm_on_group_grant(&opts, &st, ch, /*svc*/ 0x40, /*tg*/ 1104, /*src*/ 2104);
+    rc |= expect_true("encrypted mixed-mode grant blocked", st.p25_sm_tune_count == before);
+    opts.p25_is_tuned = 0;
+    p25_sm_on_group_grant(&opts, &st, ch, /*svc*/ 0x00, /*tg*/ 1104, /*src*/ 2105);
+    rc |= expect_true("later clear mixed-mode grant tunes", st.p25_sm_tune_count == before + 1);
+    opts.trunk_tune_enc_calls = 1;
+
     // Matching hold does not override explicit B/DE blocks in grant-compatible hold mode.
     st.tg_hold = 1102;
     before = st.p25_sm_tune_count;

--- a/tests/protocol/p25/test_p25_p1_hdu_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_hdu_helpers.c
@@ -692,11 +692,8 @@ test_hdu_encrypted_trunk_lockout_state(void) {
     rc |= expect_u64("lockout clears mi", state.payload_miP, 0ULL);
     rc |= expect_int("lockout force release", state.p25_sm_force_release, 1);
     rc |= expect_int("lockout release hook", g_release_calls, 1);
-    rc |= expect_int("lockout policy make", g_policy_make_calls, 1);
-    rc |= expect_int("lockout policy upsert", g_policy_upsert_calls, 1);
-    rc |= expect_int("lockout policy id", (int)g_last_policy_id, 1234);
-    rc |= expect_int("lockout policy source", (int)g_last_policy_source, DSD_TG_POLICY_SOURCE_ENC_LOCKOUT);
-    rc |= expect_int("lockout policy mode", (int)g_last_policy_upsert_mode, DSD_TG_POLICY_UPSERT_REPLACE_FIRST);
+    rc |= expect_int("lockout does not make runtime policy", g_policy_make_calls, 0);
+    rc |= expect_int("lockout does not upsert runtime policy", g_policy_upsert_calls, 0);
     rc |= expect_int("lockout watchdog", g_watchdog_calls, 1);
     rc |= expect_int("lockout event write", g_write_event_calls, 1);
     rc |= expect_int("lockout event push", g_push_event_calls, 1);

--- a/tests/protocol/p25/test_p25_p1_ldu2_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_ldu2_helpers.c
@@ -825,11 +825,8 @@ test_ldu2_encrypted_trunk_lockout_state(void) {
     ldu2_maybe_enc_lockout(&opts, &state, 0);
 
     rc |= expect_int("lockout release", g_release_calls, 1);
-    rc |= expect_int("lockout policy make", g_policy_make_calls, 1);
-    rc |= expect_int("lockout policy upsert", g_policy_upsert_calls, 1);
-    rc |= expect_int("lockout policy id", (int)g_last_policy_id, 2468);
-    rc |= expect_int("lockout policy source", (int)g_last_policy_source, (int)DSD_TG_POLICY_SOURCE_ENC_LOCKOUT);
-    rc |= expect_int("lockout policy mode", (int)g_last_policy_upsert_mode, (int)DSD_TG_POLICY_UPSERT_REPLACE_FIRST);
+    rc |= expect_int("lockout does not make runtime policy", g_policy_make_calls, 0);
+    rc |= expect_int("lockout does not upsert runtime policy", g_policy_upsert_calls, 0);
     rc |= expect_int("lockout watchdog", g_watchdog_calls, 1);
     rc |= expect_int("lockout write event", g_write_event_calls, 1);
     rc |= expect_int("lockout push event", g_push_event_calls, 1);
@@ -862,9 +859,9 @@ test_ldu2_lockout_suppression_variants(void) {
     reset_hook_counters();
     g_lookup_label = "Known ENC";
     ldu2_record_enc_lockout(&opts, &state, 2468);
-    rc |= expect_int("existing lockout still builds policy", g_policy_make_calls, 1);
-    rc |= expect_int("existing lockout upserts policy", g_policy_upsert_calls, 1);
-    rc |= expect_int("existing lockout skips event", g_watchdog_calls, 0);
+    rc |= expect_int("labeled lockout does not make runtime policy", g_policy_make_calls, 0);
+    rc |= expect_int("labeled lockout does not upsert runtime policy", g_policy_upsert_calls, 0);
+    rc |= expect_int("labeled lockout still logs event", g_watchdog_calls, 1);
 
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));

--- a/tests/protocol/p25/test_p25_p1_ldu2_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_ldu2_helpers.c
@@ -825,6 +825,7 @@ test_ldu2_encrypted_trunk_lockout_state(void) {
     ldu2_maybe_enc_lockout(&opts, &state, 0);
 
     rc |= expect_int("lockout release", g_release_calls, 1);
+    rc |= expect_int("lockout force release", state.p25_sm_force_release, 1);
     rc |= expect_int("lockout does not make runtime policy", g_policy_make_calls, 0);
     rc |= expect_int("lockout does not upsert runtime policy", g_policy_upsert_calls, 0);
     rc |= expect_int("lockout watchdog", g_watchdog_calls, 1);
@@ -833,9 +834,11 @@ test_ldu2_encrypted_trunk_lockout_state(void) {
     rc |= expect_int("lockout init event", g_init_event_calls, 1);
 
     reset_hook_counters();
+    state.p25_sm_force_release = 0;
     state.R = 0x1234U;
     ldu2_maybe_enc_lockout(&opts, &state, 0);
     rc |= expect_int("lockout skipped with key", g_release_calls, 0);
+    rc |= expect_int("lockout skipped force release", state.p25_sm_force_release, 0);
     rc |= expect_int("lockout skipped policy", g_policy_make_calls, 0);
     return rc;
 }

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -21,7 +21,6 @@
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdio.h>
-#include <string.h>
 #include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -187,12 +186,11 @@ main(void) {
     assert(s4.payload_algid == 0x84);
     assert(s4.payload_keyid == 0x1234);
     assert(s4.payload_miP == 0x1122334455667788ULL);
-    // re-emit should no-op
+    // re-emit should not create a runtime policy block
     p25_emit_enc_lockout_once(&o4, &s4, 0, 1234, 0x40);
     dsd_tg_policy_lookup lockout_lookup;
     assert(dsd_tg_policy_lookup_id(&s4, 1234U, &lockout_lookup) == 0);
-    assert(lockout_lookup.match == DSD_TG_POLICY_MATCH_EXACT);
-    assert(strcmp(lockout_lookup.entry.mode, "DE") == 0);
+    assert(lockout_lookup.match == DSD_TG_POLICY_MATCH_NONE);
 
     // 4) NAC mismatch uses the latched expected CC NAC, not mutable state->p2_cc.
     static dsd_opts o5;


### PR DESCRIPTION
## Summary

Fixes a P25 encryption-classification path where encrypted-call lockout events could persist as runtime talkgroup policy and cause later clear grants for the same talkgroup to stay blocked until restart.

## Root Cause

The encrypted lockout/event helpers were upserting `DE` / `ENC LO` runtime talkgroup policy entries. That made a transient encrypted grant look like a durable user policy decision. Event rendering could also carry stale P25 voice ALG/KID state into control-channel grant history.

## Changes

- Stop encrypted lockout event helpers from creating runtime talkgroup policy entries.
- Keep encrypted lockout reporting/history behavior without mutating later grant policy.
- Normalize P25 event crypto fields so stale ALG/KID values are only retained for current voice contexts.
- Add regression coverage for encrypted-then-clear P25 grants and stale crypto rendering in event history.

## Validation

- `cmake --build --preset dev-debug -j`
- `ctest --test-dir build/dev-debug -R "P25_P1_(LDU2|HDU|TSBK)|P25_GRANT_POLICY|P25_ENC_OVERRIDE|CORE_CALL_ALERT_HISTORY|APP_CONTROL_SNAPSHOT_EVENT_HISTORY" --output-on-failure`
- Pre-push checks passed: clang-format, clang-tidy, cppcheck, IWYU, GCC analyzer, Semgrep, and Lizard.