### PR TITLE
p25: cache encrypted TG voice lockouts

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -31,6 +31,7 @@
 enum DSD_ATTR_PACKED {
     DSD_P25_P2_AUDIO_RING_DEPTH = 4,
     DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH = 8,
+    DSD_P25_ENC_TG_CACHE_DEPTH = 8,
     DSD_TRUNK_CHAN_MAP_SIZE = 0xFFFF,
     DSD_VERTEX_KS_MAP_MAX = 64,
     DSD_RTL_SYMBOL_CACHE_CAP = 512,
@@ -767,6 +768,10 @@ struct dsd_state {
     time_t p25_retune_block_history_until[DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH];
     long p25_retune_block_history_freq[DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH];
     int p25_retune_block_history_slot[DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH]; // -1 when N/A
+    // Transient encrypted-call cache: blocks ambiguous no-SVC grants after proven ENC lockout.
+    time_t p25_enc_tg_cache_until[DSD_P25_ENC_TG_CACHE_DEPTH];
+    uint32_t p25_enc_tg_cache_tg[DSD_P25_ENC_TG_CACHE_DEPTH];
+    unsigned int p25_enc_tg_cache_next;
     // Cached P25 SM tunables (seconds), resolved once at p25_sm_init()
     double p25_cfg_vc_grace_s;
     double p25_cfg_grant_voice_to_s;

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -53,6 +53,12 @@ typedef enum {
     P25_SM_HUNTING,  // Lost CC, searching candidates
 } p25_sm_state_e;
 
+enum {
+    // Grant decoder sentinel for opcodes that do not carry service options.
+    // Passing svc_bits=0 remains an explicit clear service option for compatibility.
+    P25_SM_SVC_UNKNOWN = -1,
+};
+
 /* ============================================================================
  * Events
  * ============================================================================ */
@@ -78,7 +84,7 @@ typedef struct {
     int tg;       // Talkgroup (for GRANT, 0 if individual)
     int src;      // Source RID (for GRANT)
     int dst;      // Destination RID (for individual GRANT)
-    int svc_bits; // Service options (for GRANT)
+    int svc_bits; // Service options (for GRANT), or P25_SM_SVC_UNKNOWN when absent
     int is_group; // 1 for group grant, 0 for individual
     int algid;    // Algorithm ID (for ENC event)
     int keyid;    // Key ID (for ENC event)
@@ -368,7 +374,7 @@ void p25_sm_init(dsd_opts* opts, dsd_state* state);
  * @param opts Decoder options.
  * @param state Decoder state.
  * @param channel Voice channel number.
- * @param svc_bits Service options associated with the grant.
+ * @param svc_bits Service options associated with the grant, or P25_SM_SVC_UNKNOWN when absent.
  * @param tg Talkgroup.
  * @param src Source RID.
  */
@@ -380,7 +386,7 @@ void p25_sm_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int sv
  * @param opts Decoder options.
  * @param state Decoder state.
  * @param channel Voice channel number.
- * @param svc_bits Service options associated with the grant.
+ * @param svc_bits Service options associated with the grant, or P25_SM_SVC_UNKNOWN when absent.
  * @param dst Destination RID.
  * @param src Source RID.
  */
@@ -703,8 +709,8 @@ void p25_ga_tick(dsd_state* state);
 /**
  * @brief Emit a single encryption lockout event for a talkgroup.
  *
- * Marks the TG as encrypted (mode "DE") if not already and pushes the
- * corresponding event to history/log exactly once per TG until scrubbed.
+ * Records transient encrypted-call state and pushes the corresponding event to history/log exactly once per TG until
+ * scrubbed.
  *
  * @param opts Decoder options.
  * @param state Decoder state.
@@ -713,6 +719,18 @@ void p25_ga_tick(dsd_state* state);
  * @param svc_bits Optional service bits (pass 0 if unknown).
  */
 void p25_emit_enc_lockout_once(dsd_opts* opts, dsd_state* state, uint8_t slot, int tg, int svc_bits);
+
+/**
+ * @brief Record transient encrypted-call state for a talkgroup without emitting a user-visible event.
+ *
+ * Used by lockout paths that already own event-history reporting. The record expires with the effective P25 retune
+ * backoff window and is never written to persistent talkgroup policy.
+ *
+ * @param opts Decoder options.
+ * @param state Decoder state.
+ * @param tg Talkgroup proven encrypted.
+ */
+void p25_sm_note_encrypted_call(dsd_opts* opts, dsd_state* state, int tg);
 
 #ifdef __cplusplus
 }

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -858,6 +858,9 @@ init_state_p25_retune_backoff_defaults(dsd_state* state) {
     for (int i = 0; i < DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH; i++) {
         state->p25_retune_block_history_slot[i] = -1;
     }
+    DSD_MEMSET(state->p25_enc_tg_cache_until, 0, sizeof(state->p25_enc_tg_cache_until));
+    DSD_MEMSET(state->p25_enc_tg_cache_tg, 0, sizeof(state->p25_enc_tg_cache_tg));
+    state->p25_enc_tg_cache_next = 0;
 }
 
 static void

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -77,6 +77,7 @@ typedef struct {
     p25_iden_entry_t p25_iden_fdma[16];
     p25_iden_entry_t p25_iden_tdma[16];
     time_t p25_retune_block_history_until[DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH];
+    time_t p25_enc_tg_cache_until[DSD_P25_ENC_TG_CACHE_DEPTH];
     time_t p25_aff_last_seen[256];
     time_t p25_ga_last_seen[512];
     long int trunk_chan_map[DSD_TRUNK_CHAN_MAP_SIZE];
@@ -133,6 +134,8 @@ typedef struct {
     uint16_t trunk_chan_map_used[DSD_TRUNK_CHAN_MAP_SIZE];
     long p25_retune_block_history_freq[DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH];
     int p25_retune_block_history_slot[DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH];
+    uint32_t p25_enc_tg_cache_tg[DSD_P25_ENC_TG_CACHE_DEPTH];
+    unsigned int p25_enc_tg_cache_next;
     uint8_t p25_prot_valid;
     uint8_t p25_prot_algid;
     uint8_t p25_cc_prot_valid;
@@ -789,6 +792,10 @@ trunk_scan_save_p25_retune_snapshot(const dsd_state* state, dsd_trunk_scan_snaps
                sizeof(snapshot->p25_retune_block_history_freq));
     DSD_MEMCPY(snapshot->p25_retune_block_history_slot, state->p25_retune_block_history_slot,
                sizeof(snapshot->p25_retune_block_history_slot));
+    DSD_MEMCPY(snapshot->p25_enc_tg_cache_until, state->p25_enc_tg_cache_until,
+               sizeof(snapshot->p25_enc_tg_cache_until));
+    DSD_MEMCPY(snapshot->p25_enc_tg_cache_tg, state->p25_enc_tg_cache_tg, sizeof(snapshot->p25_enc_tg_cache_tg));
+    snapshot->p25_enc_tg_cache_next = state->p25_enc_tg_cache_next;
 }
 
 static void
@@ -803,6 +810,9 @@ trunk_scan_restore_p25_retune_snapshot(dsd_state* state, const dsd_trunk_scan_sn
                sizeof(state->p25_retune_block_history_freq));
     DSD_MEMCPY(state->p25_retune_block_history_slot, snapshot->p25_retune_block_history_slot,
                sizeof(state->p25_retune_block_history_slot));
+    DSD_MEMCPY(state->p25_enc_tg_cache_until, snapshot->p25_enc_tg_cache_until, sizeof(state->p25_enc_tg_cache_until));
+    DSD_MEMCPY(state->p25_enc_tg_cache_tg, snapshot->p25_enc_tg_cache_tg, sizeof(state->p25_enc_tg_cache_tg));
+    state->p25_enc_tg_cache_next = snapshot->p25_enc_tg_cache_next;
 }
 
 static void

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -500,12 +500,18 @@ log_preempt_decision(const p25_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_st
 
 typedef struct {
     int svc;
+    int svc_valid;
     int data_call;
     int encrypted_call;
     int enc_override_clear;
     int is_indiv;
     int tg;
 } p25_grant_eval_ctx_t;
+
+static int
+p25_sm_svc_bits_valid(int svc_bits) {
+    return svc_bits >= 0;
+}
 
 static p25_grant_eval_ctx_t
 p25_grant_eval_ctx_from_event(const p25_sm_event_t* ev) {
@@ -514,12 +520,118 @@ p25_grant_eval_ctx_from_event(const p25_sm_event_t* ev) {
     if (!ev) {
         return ctx;
     }
-    ctx.svc = ev->svc_bits;
-    ctx.data_call = SVC_IS_DATA(ctx.svc) ? 1 : 0;
-    ctx.encrypted_call = SVC_IS_ENC(ctx.svc) ? 1 : 0;
+    ctx.svc_valid = p25_sm_svc_bits_valid(ev->svc_bits);
+    ctx.svc = ctx.svc_valid ? ev->svc_bits : 0;
+    ctx.data_call = (ctx.svc_valid && SVC_IS_DATA(ctx.svc)) ? 1 : 0;
+    ctx.encrypted_call = (ctx.svc_valid && SVC_IS_ENC(ctx.svc)) ? 1 : 0;
     ctx.is_indiv = !ev->is_group;
     ctx.tg = ctx.is_indiv ? ev->dst : ev->tg;
     return ctx;
+}
+
+static void
+p25_enc_tg_cache_clear_entry(dsd_state* state, int idx) {
+    if (!state || idx < 0 || idx >= DSD_P25_ENC_TG_CACHE_DEPTH) {
+        return;
+    }
+    state->p25_enc_tg_cache_until[idx] = 0;
+    state->p25_enc_tg_cache_tg[idx] = 0;
+}
+
+static int
+p25_enc_tg_cache_find_active(dsd_state* state, int tg, time_t now) {
+    if (!state || tg <= 0) {
+        return -1;
+    }
+    for (int i = 0; i < DSD_P25_ENC_TG_CACHE_DEPTH; i++) {
+        time_t until = state->p25_enc_tg_cache_until[i];
+        if (until <= 0) {
+            continue;
+        }
+        if (now >= until) {
+            p25_enc_tg_cache_clear_entry(state, i);
+            continue;
+        }
+        if (state->p25_enc_tg_cache_tg[i] == (uint32_t)tg) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static void
+p25_enc_tg_cache_clear_tg(dsd_state* state, int tg) {
+    if (!state || tg <= 0) {
+        return;
+    }
+    for (int i = 0; i < DSD_P25_ENC_TG_CACHE_DEPTH; i++) {
+        if (state->p25_enc_tg_cache_tg[i] == (uint32_t)tg) {
+            p25_enc_tg_cache_clear_entry(state, i);
+        }
+    }
+}
+
+static int
+p25_enc_tg_cache_refresh_until(const dsd_opts* opts, time_t now, time_t* out_until) {
+    if (!out_until) {
+        return 0;
+    }
+    double backoff_s = p25_failed_vc_retune_backoff_s(opts);
+    time_t backoff_wall = p25_backoff_wall_seconds(backoff_s);
+    if (backoff_wall <= 0) {
+        return 0;
+    }
+    *out_until = now + backoff_wall;
+    return 1;
+}
+
+static int
+p25_enc_tg_cache_choose_slot(dsd_state* state, time_t now) {
+    int first_expired = -1;
+    if (!state) {
+        return -1;
+    }
+    for (int i = 0; i < DSD_P25_ENC_TG_CACHE_DEPTH; i++) {
+        if (state->p25_enc_tg_cache_until[i] <= now) {
+            first_expired = i;
+            break;
+        }
+    }
+    if (first_expired >= 0) {
+        return first_expired;
+    }
+    int idx = (int)(state->p25_enc_tg_cache_next % DSD_P25_ENC_TG_CACHE_DEPTH);
+    state->p25_enc_tg_cache_next++;
+    return idx;
+}
+
+void
+p25_sm_note_encrypted_call(dsd_opts* opts, dsd_state* state, int tg) {
+    if (!opts || !state || tg <= 0 || opts->trunk_tune_enc_calls != 0) {
+        return;
+    }
+    if (p25_patch_tg_key_is_clear(state, tg) || p25_patch_sg_key_is_clear(state, tg)) {
+        return;
+    }
+
+    time_t now = time(NULL);
+    time_t until = 0;
+    if (!p25_enc_tg_cache_refresh_until(opts, now, &until)) {
+        return;
+    }
+
+    int idx = p25_enc_tg_cache_find_active(state, tg, now);
+    if (idx < 0) {
+        idx = p25_enc_tg_cache_choose_slot(state, now);
+    }
+    if (idx < 0) {
+        return;
+    }
+
+    state->p25_enc_tg_cache_tg[idx] = (uint32_t)tg;
+    state->p25_enc_tg_cache_until[idx] = until;
+    p25_sm_diagf(opts, state, NULL, "enc_tg_cache_arm", "tg=%d idx=%d until=%ld", tg, idx, (long)until);
+    sm_log(opts, state, "enc-tg-cache-arm");
 }
 
 static void
@@ -534,6 +646,55 @@ p25_grant_apply_clear_override(const dsd_opts* opts, const dsd_state* state, p25
             eval_ctx->enc_override_clear = 1;
         }
     }
+}
+
+static void
+p25_grant_clear_transient_cache_if_clear(dsd_state* state, const p25_grant_eval_ctx_t* eval_ctx) {
+    if (!state || !eval_ctx || eval_ctx->is_indiv || eval_ctx->tg <= 0) {
+        return;
+    }
+    if ((eval_ctx->svc_valid && !eval_ctx->encrypted_call) || eval_ctx->enc_override_clear) {
+        p25_enc_tg_cache_clear_tg(state, eval_ctx->tg);
+    }
+}
+
+static int
+p25_grant_patch_clear_key(const dsd_state* state, const p25_grant_eval_ctx_t* eval_ctx) {
+    if (!state || !eval_ctx || eval_ctx->is_indiv || eval_ctx->tg <= 0) {
+        return 0;
+    }
+    return (p25_patch_tg_key_is_clear(state, eval_ctx->tg) || p25_patch_sg_key_is_clear(state, eval_ctx->tg)) ? 1 : 0;
+}
+
+static int
+p25_grant_transient_enc_cache_blocks(dsd_opts* opts, dsd_state* state, const p25_grant_eval_ctx_t* eval_ctx) {
+    if (!opts || !state || !eval_ctx || eval_ctx->is_indiv || eval_ctx->tg <= 0 || opts->trunk_tune_enc_calls != 0) {
+        return 0;
+    }
+    if (eval_ctx->svc_valid) {
+        return 0;
+    }
+    if (p25_grant_patch_clear_key(state, eval_ctx)) {
+        p25_enc_tg_cache_clear_tg(state, eval_ctx->tg);
+        return 0;
+    }
+
+    time_t now = time(NULL);
+    int idx = p25_enc_tg_cache_find_active(state, eval_ctx->tg, now);
+    if (idx < 0) {
+        return 0;
+    }
+
+    time_t until = 0;
+    if (p25_enc_tg_cache_refresh_until(opts, now, &until)) {
+        state->p25_enc_tg_cache_until[idx] = until;
+    } else {
+        p25_enc_tg_cache_clear_entry(state, idx);
+        return 0;
+    }
+    p25_sm_diagf(opts, state, NULL, "grant_enc_cache_skip", "tg=%d idx=%d until=%ld", eval_ctx->tg, idx, (long)until);
+    sm_log(opts, state, "grant-enc-cache");
+    return 1;
 }
 
 static int
@@ -590,6 +751,7 @@ grant_allowed(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, dsd_tg
 
     eval_ctx = p25_grant_eval_ctx_from_event(ev);
     p25_grant_apply_clear_override(opts, state, &eval_ctx);
+    p25_grant_clear_transient_cache_if_clear(state, &eval_ctx);
     if (p25_grant_eval_policy(opts, state, ev, &eval_ctx, &decision) != 0) {
         return 0;
     }
@@ -598,6 +760,10 @@ grant_allowed(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, dsd_tg
         if (out_decision) {
             *out_decision = decision;
         }
+        return 0;
+    }
+
+    if (p25_grant_transient_enc_cache_blocks(opts, state, &eval_ctx)) {
         return 0;
     }
 
@@ -2196,6 +2362,8 @@ p25_emit_enc_lockout_once(dsd_opts* opts, dsd_state* state, uint8_t slot, int tg
     if (!opts || !state || tg <= 0) {
         return;
     }
+
+    p25_sm_note_encrypted_call(opts, state, tg);
 
     // Prepare per-slot context. Keep live encryption fields intact: callers may
     // still need ALG/KID/MI after this helper returns to keep audio gates closed.

--- a/src/protocol/p25/phase1/p25p1_hdu.c
+++ b/src/protocol/p25/phase1/p25p1_hdu.c
@@ -325,6 +325,8 @@ hdu_record_enc_lockout(dsd_opts* opts, dsd_state* state, int ttg) {
         return;
     }
 
+    p25_sm_note_encrypted_call(opts, state, ttg);
+
     DSD_SNPRINTF(state->event_history_s[0].Event_History_Items[0].internal_str,
                  sizeof(state->event_history_s[0].Event_History_Items[0].internal_str),
                  "Target: %d; has been locked out; Encryption Lock Out Enabled.", ttg);

--- a/src/protocol/p25/phase1/p25p1_ldu2.c
+++ b/src/protocol/p25/phase1/p25p1_ldu2.c
@@ -504,6 +504,8 @@ ldu2_record_enc_lockout(dsd_opts* opts, dsd_state* state, int talkgroup) {
         return;
     }
 
+    p25_sm_note_encrypted_call(opts, state, talkgroup);
+
     DSD_SNPRINTF(state->event_history_s[0].Event_History_Items[0].internal_str,
                  sizeof state->event_history_s[0].Event_History_Items[0].internal_str,
                  "Target: %d; has been locked out; Encryption Lock Out Enabled.", talkgroup);

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -239,7 +239,7 @@ tsbk_handle_mfid90_grant(dsd_opts* opts, dsd_state* state, const uint8_t tsbk_by
     DSD_FPRINTF(stderr, "\n");
     if (opts->p25_trunk == 1 && freq != 0) {
         p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
-        p25_sm_on_group_grant(opts, state, channel, /*svc*/ 0, sg, source);
+        p25_sm_on_group_grant(opts, state, channel, P25_SM_SVC_UNKNOWN, sg, source);
     }
 }
 
@@ -262,11 +262,11 @@ tsbk_handle_mfid90_grant_update(dsd_opts* opts, dsd_state* state, const uint8_t 
     DSD_FPRINTF(stderr, "\n");
     if (opts->p25_trunk == 1 && ch1 != 0 && freq1 != 0) {
         p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
-        p25_sm_on_group_grant(opts, state, ch1, /*svc*/ 0, sg1, /*src*/ 0);
+        p25_sm_on_group_grant(opts, state, ch1, P25_SM_SVC_UNKNOWN, sg1, /*src*/ 0);
     }
     if (opts->p25_trunk == 1 && ch2 != 0 && freq2 != 0) {
         p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
-        p25_sm_on_group_grant(opts, state, ch2, /*svc*/ 0, sg2, /*src*/ 0);
+        p25_sm_on_group_grant(opts, state, ch2, P25_SM_SVC_UNKNOWN, sg2, /*src*/ 0);
     }
 }
 

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -305,6 +305,9 @@ p25p2_mac_policy_flag(int svc_bits, int policy_override, int bit) {
     if (policy_override >= 0) {
         return policy_override ? 1 : 0;
     }
+    if (svc_bits < 0) {
+        return 0;
+    }
     return (svc_bits & bit) ? 1 : 0;
 }
 
@@ -403,9 +406,8 @@ p25p2_mac_handle_indiv(const struct p25p2_mac_result* res, dsd_opts* opts, dsd_s
     if (opts->p25_trunk != 1) {
         return;
     }
-    enc_for_policy =
-        (policy_encrypted_override >= 0) ? (policy_encrypted_override ? 1 : 0) : ((svc_bits & 0x40) ? 1 : 0);
-    data_for_policy = (policy_data_override >= 0) ? (policy_data_override ? 1 : 0) : ((svc_bits & 0x10) ? 1 : 0);
+    enc_for_policy = p25p2_mac_policy_flag(svc_bits, policy_encrypted_override, 0x40);
+    data_for_policy = p25p2_mac_policy_flag(svc_bits, policy_data_override, 0x10);
     if (dsd_tg_policy_evaluate_private_call(opts, state, (uint32_t)source, (uint32_t)target, enc_for_policy,
                                             data_for_policy, DSD_TG_POLICY_PRIVATE_ALLOWLIST_UNKNOWN_BLOCK,
                                             DSD_TG_POLICY_HOLD_COMPAT_GRANT, &decision)
@@ -414,12 +416,6 @@ p25p2_mac_handle_indiv(const struct p25p2_mac_result* res, dsd_opts* opts, dsd_s
         return;
     }
     p25_sm_on_indiv_grant(opts, state, channel, svc_bits, target, source);
-}
-
-static inline int
-p25_mfid90_enc_lockout_blocks(const dsd_opts* opts, const dsd_state* state, int group) {
-    return opts && state && opts->trunk_tune_enc_calls == 0 && !p25_patch_tg_key_is_clear(state, group)
-           && !p25_patch_sg_key_is_clear(state, group);
 }
 
 static inline void
@@ -1040,10 +1036,9 @@ p25p2_vpdu_iter_block_01(p25p2_vpdu_ctx* ctx) {
         p25p2_vpdu_print_group_label(state, (uint32_t)sgroup);
 
         if (p25p2_vpdu_can_tune(opts, state, freq)) {
-            /* No SVC bits are carried here; use conservative ENC gating policy facts. */
-            const int policy_encrypted = p25_mfid90_enc_lockout_blocks(opts, state, sgroup) ? 1 : 0;
-            p25p2_mac_handle(&mac_res, opts, state, channel, /*svc_bits*/ 0, sgroup, /*src*/ 0, policy_encrypted,
-                             /*policy_data*/ 0, /*emit_enc_lockout*/ 0);
+            /* No SVC bits are carried here; let the SM apply transient encrypted-call memory. */
+            p25p2_mac_handle(&mac_res, opts, state, channel, P25_SM_SVC_UNKNOWN, sgroup, /*src*/ 0,
+                             /*policy_encrypted*/ -1, /*policy_data*/ 0, /*emit_enc_lockout*/ 0);
         }
         // If playing back files, and we still want to see what freqs are in use in the ncurses terminal
         //might only want to do these on a grant update, and not a grant by itself?
@@ -1091,10 +1086,9 @@ p25p2_vpdu_iter_block_02(p25p2_vpdu_ctx* ctx) {
         p25p2_vpdu_print_group_label(state, (uint32_t)sgroup);
 
         if (p25p2_vpdu_can_tune(opts, state, freq)) {
-            /* No SVC bits are carried here; use conservative ENC gating policy facts. */
-            const int policy_encrypted = p25_mfid90_enc_lockout_blocks(opts, state, sgroup) ? 1 : 0;
-            p25p2_mac_handle(&mac_res, opts, state, channel, /*svc_bits*/ 0, sgroup, /*src*/ 0, policy_encrypted,
-                             /*policy_data*/ 0, /*emit_enc_lockout*/ 0);
+            /* No SVC bits are carried here; let the SM apply transient encrypted-call memory. */
+            p25p2_mac_handle(&mac_res, opts, state, channel, P25_SM_SVC_UNKNOWN, sgroup, /*src*/ 0,
+                             /*policy_encrypted*/ -1, /*policy_data*/ 0, /*emit_enc_lockout*/ 0);
         }
         // If playing back files, and we still want to see what freqs are in use in the ncurses terminal
         //might only want to do these on a grant update, and not a grant by itself?
@@ -1157,9 +1151,8 @@ p25p2_vpdu_iter_block_03(p25p2_vpdu_ctx* ctx) {
             int tunable_chan = (j == 0) ? channel1 : channel2;
             int tunable_group = (j == 0) ? group1 : group2;
             long int tunable_freq = (j == 0) ? freq1 : freq2;
-            int policy_encrypted = p25_mfid90_enc_lockout_blocks(opts, state, tunable_group) ? 1 : 0;
-            p25p2_vpdu_group_candidate candidate = {tunable_chan, tunable_group, tunable_freq, 0};
-            p25p2_vpdu_candidate_policy policy = {policy_encrypted, 0, 0, 1};
+            p25p2_vpdu_group_candidate candidate = {tunable_chan, tunable_group, tunable_freq, P25_SM_SVC_UNKNOWN};
+            p25p2_vpdu_candidate_policy policy = {-1, 0, 0, 1};
             int tuned = p25p2_vpdu_try_group_candidate(&mac_res, opts, state, &candidate, &policy);
             if (tuned) {
                 break;
@@ -1346,7 +1339,7 @@ p25p2_vpdu_iter_block_06(p25p2_vpdu_ctx* ctx) {
 
         if (p25p2_vpdu_can_tune(opts, state, freq)) {
             int policy_encrypted = (opts->trunk_tune_enc_calls == 0) ? 1 : 0;
-            p25p2_mac_handle_indiv(&mac_res, opts, state, channel, /*svc_bits*/ 0, target, source, policy_encrypted,
+            p25p2_mac_handle_indiv(&mac_res, opts, state, channel, P25_SM_SVC_UNKNOWN, target, source, policy_encrypted,
                                    /*policy_data*/ 0);
         }
         p25p2_vpdu_update_playback_if_match(opts, state, target, freq);
@@ -1534,8 +1527,8 @@ p25p2_vpdu_iter_block_09(p25p2_vpdu_ctx* ctx) {
             int tunable_chan = (j == 0) ? channel1 : channel2;
             int tunable_group = (j == 0) ? group1 : group2;
             long int tunable_freq = (j == 0) ? freq1 : freq2;
-            p25p2_vpdu_group_candidate candidate = {tunable_chan, tunable_group, tunable_freq, 0};
-            const p25p2_vpdu_candidate_policy policy = {0, 0, 0, 1};
+            p25p2_vpdu_group_candidate candidate = {tunable_chan, tunable_group, tunable_freq, P25_SM_SVC_UNKNOWN};
+            const p25p2_vpdu_candidate_policy policy = {-1, 0, 0, 1};
             int tuned = p25p2_vpdu_try_group_candidate(&mac_res, opts, state, &candidate, &policy);
             if (tuned) {
                 break;
@@ -1640,7 +1633,7 @@ p25p2_vpdu_iter_block_11(p25p2_vpdu_ctx* ctx) {
 
         if (p25p2_vpdu_can_tune(opts, state, freq)) {
             const int policy_encrypted = (opts->trunk_tune_enc_calls == 0) ? 1 : 0;
-            p25p2_mac_handle_indiv(&mac_res, opts, state, channelt, /*svc_bits*/ 0, (int)target, /*src*/ 0,
+            p25p2_mac_handle_indiv(&mac_res, opts, state, channelt, P25_SM_SVC_UNKNOWN, (int)target, /*src*/ 0,
                                    policy_encrypted, /*policy_data*/ 1);
         }
         if (opts->p25_trunk == 0) {
@@ -1884,9 +1877,8 @@ p25p2_vpdu_iter_block_17(p25p2_vpdu_ctx* ctx) {
         DSD_FPRINTF(stderr, "\n");
         // Route through SM for tuning consideration
         if (opts->p25_trunk == 1 && channel != 0 && freq != 0) {
-            const int policy_encrypted = p25_mfid90_enc_lockout_blocks(opts, state, sg) ? 1 : 0;
-            p25p2_mac_handle(&mac_res, opts, state, channel, /*svc_bits*/ 0, sg, /*src*/ 0, policy_encrypted,
-                             /*policy_data*/ 0, /*emit_enc_lockout*/ 0);
+            p25p2_mac_handle(&mac_res, opts, state, channel, P25_SM_SVC_UNKNOWN, sg, /*src*/ 0,
+                             /*policy_encrypted*/ -1, /*policy_data*/ 0, /*emit_enc_lockout*/ 0);
         }
     }
 

--- a/src/ui/terminal/dsd-neo/ui/ncurses_internal.h
+++ b/src/ui/terminal/dsd-neo/ui/ncurses_internal.h
@@ -30,6 +30,7 @@ int select_k_int_local(int* a, int n, int k);
 int cmp_int_asc(const void* a, const void* b);
 int compute_percentiles_u8(const uint8_t* src, int len, double* p50, double* p95);
 int ui_is_locked_from_label(const dsd_state* state, const char* label);
+int ui_is_transient_enc_locked_from_label(const dsd_state* state, const char* label);
 int ui_unicode_supported(void);
 int ui_block_glyphs_supported(void);
 

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -1901,6 +1901,9 @@ ui_channel_label_is_locked(const dsd_opts* opts, const dsd_state* state, const c
     if (locked || !opts) {
         return locked;
     }
+    if (opts->trunk_tune_enc_calls == 0 && ui_is_transient_enc_locked_from_label(state, label)) {
+        return 1;
+    }
     if (opts->trunk_tune_data_calls == 0 && strstr(label, "Active Data Ch:") != NULL) {
         return 1;
     }

--- a/src/ui/terminal/ncurses_utils.c
+++ b/src/ui/terminal/ncurses_utils.c
@@ -7,6 +7,7 @@
  * Shared utility functions for ncurses UI modules
  */
 
+#include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/runtime/unicode.h>
@@ -15,6 +16,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "dsd-neo/core/state_fwd.h"
 
@@ -112,12 +114,9 @@ compute_percentiles_u8(const uint8_t* src, int len, double* p50, double* p95) {
     return 1;
 }
 
-/* Determine if an Active Channel label refers to a locked-out target.
- * Supports both "TG:" (group) and "TGT:" (target/private/data) fields.
- * Returns 1 when the referenced ID is marked with groupMode "DE" or "B". */
-int
-ui_is_locked_from_label(const dsd_state* state, const char* label) {
-    if (!state || !label || !*label) {
+static int
+ui_extract_target_id_from_label(const char* label, uint32_t* out_id) {
+    if (!label || !*label) {
         return 0;
     }
     /* Try group first ("TG:") */
@@ -141,9 +140,47 @@ ui_is_locked_from_label(const dsd_state* state, const char* label) {
     if (endp == pos || id <= 0 || id > UINT32_MAX) {
         return 0;
     }
+    if (out_id) {
+        *out_id = (uint32_t)id;
+    }
+    return 1;
+}
+
+/* Determine if an Active Channel label refers to a locked-out target.
+ * Supports both "TG:" (group) and "TGT:" (target/private/data) fields.
+ * Returns 1 when the referenced ID is marked with groupMode "DE" or "B". */
+int
+ui_is_locked_from_label(const dsd_state* state, const char* label) {
+    if (!state) {
+        return 0;
+    }
+    uint32_t id = 0;
+    if (!ui_extract_target_id_from_label(label, &id)) {
+        return 0;
+    }
     char mode[8];
-    if (dsd_tg_policy_lookup_label(state, (uint32_t)id, mode, sizeof(mode), NULL, 0)) {
+    if (dsd_tg_policy_lookup_label(state, id, mode, sizeof(mode), NULL, 0)) {
         if (strcmp(mode, "DE") == 0 || strcmp(mode, "B") == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int
+ui_is_transient_enc_locked_from_label(const dsd_state* state, const char* label) {
+    if (!state
+        || !(DSD_SYNC_IS_P25P1(state->synctype) || DSD_SYNC_IS_P25P2(state->synctype)
+             || DSD_SYNC_IS_P25P1(state->lastsynctype) || DSD_SYNC_IS_P25P2(state->lastsynctype))) {
+        return 0;
+    }
+    uint32_t id = 0;
+    if (!ui_extract_target_id_from_label(label, &id)) {
+        return 0;
+    }
+    const time_t now = time(NULL);
+    for (int i = 0; i < DSD_P25_ENC_TG_CACHE_DEPTH; i++) {
+        if (state->p25_enc_tg_cache_tg[i] == id && state->p25_enc_tg_cache_until[i] > now) {
             return 1;
         }
     }

--- a/src/ui/terminal/ncurses_utils.c
+++ b/src/ui/terminal/ncurses_utils.c
@@ -119,19 +119,22 @@ ui_extract_target_id_from_label(const char* label, uint32_t* out_id) {
     if (!label || !*label) {
         return 0;
     }
-    /* Try group first ("TG:") */
+    /* Try group, generic target, then MFID90 regroup supergroup labels. */
     const char* pos = strstr(label, "TG:");
+    size_t prefix_len = 3;
     if (!pos) {
         /* Fallback to generic target ("TGT:") often used for private/data */
         pos = strstr(label, "TGT:");
+        prefix_len = 4;
+    }
+    if (!pos) {
+        pos = strstr(label, "SG:");
+        prefix_len = 3;
     }
     if (!pos) {
         return 0;
     }
-    pos += 3; /* skip TG: or TGT: prefix; both are 3 chars before ':' */
-    if (*pos == ':') {
-        pos++;
-    }
+    pos += prefix_len;
     while (*pos == ' ') {
         pos++;
     }
@@ -147,7 +150,8 @@ ui_extract_target_id_from_label(const char* label, uint32_t* out_id) {
 }
 
 /* Determine if an Active Channel label refers to a locked-out target.
- * Supports both "TG:" (group) and "TGT:" (target/private/data) fields.
+ * Supports "TG:" (group), "TGT:" (target/private/data), and "SG:" (regroup
+ * supergroup) fields.
  * Returns 1 when the referenced ID is marked with groupMode "DE" or "B". */
 int
 ui_is_locked_from_label(const dsd_state* state, const char* label) {

--- a/tests/core/test_core_init_state.c
+++ b/tests/core/test_core_init_state.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/p25_cqpsk_dibit.h>
 #include <dsd-neo/core/state.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -63,6 +64,11 @@ main(void) {
         state->p25_retune_block_history_until[i] = 1234567890 + i;
         state->p25_retune_block_history_freq[i] = 851125000L + i;
         state->p25_retune_block_history_slot[i] = i % 2;
+    }
+    state->p25_enc_tg_cache_next = 3U;
+    for (int i = 0; i < DSD_P25_ENC_TG_CACHE_DEPTH; i++) {
+        state->p25_enc_tg_cache_until[i] = 1234567890 + i;
+        state->p25_enc_tg_cache_tg[i] = (uint32_t)(2400 + i);
     }
     state->rtl_symbol_cache[0] = 1234.0f;
     state->rtl_symbol_cache[DSD_RTL_SYMBOL_CACHE_CAP - 1] = 5678.0f;
@@ -252,6 +258,20 @@ main(void) {
             freeState(state);
             free(state);
             return 23;
+        }
+    }
+    if (state->p25_enc_tg_cache_next != 0U) {
+        DSD_FPRINTF(stderr, "initState did not reset P25 encrypted TG cache cursor\n");
+        freeState(state);
+        free(state);
+        return 24;
+    }
+    for (int i = 0; i < DSD_P25_ENC_TG_CACHE_DEPTH; i++) {
+        if (state->p25_enc_tg_cache_until[i] != 0 || state->p25_enc_tg_cache_tg[i] != 0U) {
+            DSD_FPRINTF(stderr, "initState did not reset P25 encrypted TG cache\n");
+            freeState(state);
+            free(state);
+            return 25;
         }
     }
 

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -1945,14 +1945,19 @@ test_p25_retune_backoff_state_isolated_per_target(void) {
     state.p25_retune_block_history_until[0] = until0;
     state.p25_retune_block_history_freq[0] = 851125000L;
     state.p25_retune_block_history_slot[0] = 1;
+    state.p25_enc_tg_cache_until[0] = until0;
+    state.p25_enc_tg_cache_tg[0] = 2468U;
+    state.p25_enc_tg_cache_next = 5U;
 
     dsd_engine_trunk_scan_test_set_now(0.26);
     dsd_engine_trunk_scan_tick(&opts, &state);
     if (dsd_engine_trunk_scan_active_index(&state) != 1 || state.p25_retune_block_until != 0
-        || state.p25_retune_block_freq != 0 || state.p25_retune_block_history_until[0] != 0) {
-        DSD_FPRINTF(stderr, "retune-backoff leaked into target 1 active=%zu until=%ld freq=%ld hist=%ld\n",
+        || state.p25_retune_block_freq != 0 || state.p25_retune_block_history_until[0] != 0
+        || state.p25_enc_tg_cache_until[0] != 0 || state.p25_enc_tg_cache_tg[0] != 0U) {
+        DSD_FPRINTF(stderr, "retune-backoff leaked into target 1 active=%zu until=%ld freq=%ld hist=%ld enc=%ld/%u\n",
                     dsd_engine_trunk_scan_active_index(&state), (long)state.p25_retune_block_until,
-                    state.p25_retune_block_freq, (long)state.p25_retune_block_history_until[0]);
+                    state.p25_retune_block_freq, (long)state.p25_retune_block_history_until[0],
+                    (long)state.p25_enc_tg_cache_until[0], state.p25_enc_tg_cache_tg[0]);
         test_rc = 1;
     }
 
@@ -1964,16 +1969,24 @@ test_p25_retune_backoff_state_isolated_per_target(void) {
     state.p25_retune_block_history_until[0] = until1;
     state.p25_retune_block_history_freq[0] = 852125000L;
     state.p25_retune_block_history_slot[0] = 0;
+    state.p25_enc_tg_cache_until[0] = until1;
+    state.p25_enc_tg_cache_tg[0] = 3579U;
+    state.p25_enc_tg_cache_next = 7U;
 
     dsd_engine_trunk_scan_test_set_now(0.52);
     dsd_engine_trunk_scan_tick(&opts, &state);
     if (dsd_engine_trunk_scan_active_index(&state) != 0 || state.p25_retune_block_until != until0
         || state.p25_retune_block_freq != 851125000L || state.p25_retune_block_slot != 1
         || state.p25_retune_block_next != 5U || state.p25_retune_block_history_until[0] != until0
-        || state.p25_retune_block_history_freq[0] != 851125000L || state.p25_retune_block_history_slot[0] != 1) {
-        DSD_FPRINTF(stderr, "retune-backoff target 0 restore failed active=%zu until=%ld freq=%ld slot=%d next=%u\n",
-                    dsd_engine_trunk_scan_active_index(&state), (long)state.p25_retune_block_until,
-                    state.p25_retune_block_freq, state.p25_retune_block_slot, state.p25_retune_block_next);
+        || state.p25_retune_block_history_freq[0] != 851125000L || state.p25_retune_block_history_slot[0] != 1
+        || state.p25_enc_tg_cache_until[0] != until0 || state.p25_enc_tg_cache_tg[0] != 2468U
+        || state.p25_enc_tg_cache_next != 5U) {
+        DSD_FPRINTF(
+            stderr,
+            "retune-backoff target 0 restore failed active=%zu until=%ld freq=%ld slot=%d next=%u enc=%ld/%u/%u\n",
+            dsd_engine_trunk_scan_active_index(&state), (long)state.p25_retune_block_until, state.p25_retune_block_freq,
+            state.p25_retune_block_slot, state.p25_retune_block_next, (long)state.p25_enc_tg_cache_until[0],
+            state.p25_enc_tg_cache_tg[0], state.p25_enc_tg_cache_next);
         test_rc = 1;
     }
 
@@ -1982,10 +1995,15 @@ test_p25_retune_backoff_state_isolated_per_target(void) {
     if (dsd_engine_trunk_scan_active_index(&state) != 1 || state.p25_retune_block_until != until1
         || state.p25_retune_block_freq != 852125000L || state.p25_retune_block_slot != 0
         || state.p25_retune_block_next != 7U || state.p25_retune_block_history_until[0] != until1
-        || state.p25_retune_block_history_freq[0] != 852125000L || state.p25_retune_block_history_slot[0] != 0) {
-        DSD_FPRINTF(stderr, "retune-backoff target 1 restore failed active=%zu until=%ld freq=%ld slot=%d next=%u\n",
-                    dsd_engine_trunk_scan_active_index(&state), (long)state.p25_retune_block_until,
-                    state.p25_retune_block_freq, state.p25_retune_block_slot, state.p25_retune_block_next);
+        || state.p25_retune_block_history_freq[0] != 852125000L || state.p25_retune_block_history_slot[0] != 0
+        || state.p25_enc_tg_cache_until[0] != until1 || state.p25_enc_tg_cache_tg[0] != 3579U
+        || state.p25_enc_tg_cache_next != 7U) {
+        DSD_FPRINTF(
+            stderr,
+            "retune-backoff target 1 restore failed active=%zu until=%ld freq=%ld slot=%d next=%u enc=%ld/%u/%u\n",
+            dsd_engine_trunk_scan_active_index(&state), (long)state.p25_retune_block_until, state.p25_retune_block_freq,
+            state.p25_retune_block_slot, state.p25_retune_block_next, (long)state.p25_enc_tg_cache_until[0],
+            state.p25_enc_tg_cache_tg[0], state.p25_enc_tg_cache_next);
         test_rc = 1;
     }
 

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -70,6 +70,36 @@ seed_exact(dsd_state* st, uint32_t id, const char* mode, const char* name, int p
     return dsd_tg_policy_upsert_exact(st, &row, DSD_TG_POLICY_UPSERT_REPLACE_FIRST);
 }
 
+static void
+seed_fdma_iden(dsd_state* st, int id) {
+    st->p25_chan_iden = id;
+    st->p25_iden_fdma[id].base_freq = 851000000 / 5;
+    st->p25_iden_fdma[id].chan_type = 1;
+    st->p25_iden_fdma[id].chan_spac = 100;
+    st->p25_iden_fdma[id].trust = 2;
+    st->p25_iden_fdma[id].populated = 1;
+    st->p25_chan_tdma_explicit[id] = 1;
+}
+
+static int
+tg_policy_is_absent(const dsd_state* st, uint32_t tg) {
+    dsd_tg_policy_lookup lookup;
+    if (dsd_tg_policy_lookup_id(st, tg, &lookup) != 0) {
+        return 0;
+    }
+    return lookup.match == DSD_TG_POLICY_MATCH_NONE;
+}
+
+static int
+enc_tg_cache_is_absent(const dsd_state* st, uint32_t tg) {
+    for (int i = 0; i < DSD_P25_ENC_TG_CACHE_DEPTH; i++) {
+        if (st->p25_enc_tg_cache_tg[i] == tg && st->p25_enc_tg_cache_until[i] > 0) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -88,14 +118,7 @@ main(void) {
 
     // FDMA IDEN
     int id = 1;
-    st.p25_chan_iden = id;
-    // Populate new dual-array
-    st.p25_iden_fdma[id].base_freq = 851000000 / 5;
-    st.p25_iden_fdma[id].chan_type = 1;
-    st.p25_iden_fdma[id].chan_spac = 100;
-    st.p25_iden_fdma[id].trust = 2;
-    st.p25_iden_fdma[id].populated = 1;
-    st.p25_chan_tdma_explicit[id] = 1; // FDMA known
+    seed_fdma_iden(&st, id);
     int ch = (id << 12) | 0x000A;
     (void)dsd_setenv("DSD_NEO_TG_PREEMPT_MIN_DWELL_MS", "0", 1);
     (void)dsd_setenv("DSD_NEO_TG_PREEMPT_COOLDOWN_MS", "0", 1);
@@ -138,6 +161,43 @@ main(void) {
     p25_sm_on_group_grant(&opts, &st, ch, /*svc*/ 0x00, /*tg*/ 1104, /*src*/ 2105);
     rc |= expect_true("later clear mixed-mode grant tunes", st.p25_sm_tune_count == before + 1);
     opts.trunk_tune_enc_calls = 1;
+
+    // Transient encrypted-call memory blocks only ambiguous no-SVC grants and never writes TG policy.
+    {
+        static dsd_opts cache_opts;
+        static dsd_state cache_st;
+        DSD_MEMSET(&cache_opts, 0, sizeof cache_opts);
+        DSD_MEMSET(&cache_st, 0, sizeof cache_st);
+        cache_opts.p25_trunk = 1;
+        cache_opts.trunk_tune_group_calls = 1;
+        cache_opts.trunk_tune_private_calls = 1;
+        cache_opts.trunk_tune_data_calls = 1;
+        cache_opts.trunk_tune_enc_calls = 0;
+        cache_st.p25_cc_freq = 851000000;
+        seed_fdma_iden(&cache_st, id);
+        p25_sm_init(&cache_opts, &cache_st);
+
+        before = cache_st.p25_sm_tune_count;
+        p25_sm_on_group_grant(&cache_opts, &cache_st, ch, P25_SM_SVC_UNKNOWN, /*tg*/ 1300, /*src*/ 2300);
+        rc |= expect_true("unknown-svc grant initially tunes", cache_st.p25_sm_tune_count == before + 1);
+
+        p25_emit_enc_lockout_once(&cache_opts, &cache_st, 0, 1300, /*svc*/ 0);
+        p25_sm_on_release(&cache_opts, &cache_st);
+        before = cache_st.p25_sm_tune_count;
+        cache_opts.p25_is_tuned = 0;
+        p25_sm_on_group_grant(&cache_opts, &cache_st, ch, P25_SM_SVC_UNKNOWN, /*tg*/ 1300, /*src*/ 2301);
+        rc |= expect_true("unknown-svc grant skipped by transient enc cache", cache_st.p25_sm_tune_count == before);
+        rc |= expect_true("transient enc cache does not add TG policy", tg_policy_is_absent(&cache_st, 1300U));
+
+        cache_opts.p25_is_tuned = 0;
+        p25_sm_on_group_grant(&cache_opts, &cache_st, ch, /*svc*/ 0x00, /*tg*/ 1300, /*src*/ 2302);
+        rc |=
+            expect_true("explicit clear grant bypasses transient enc cache", cache_st.p25_sm_tune_count == before + 1);
+        rc |= expect_true("explicit clear grant clears transient enc cache", enc_tg_cache_is_absent(&cache_st, 1300U));
+        rc |= expect_true("explicit clear grant does not add TG policy", tg_policy_is_absent(&cache_st, 1300U));
+        p25_sm_on_release(&cache_opts, &cache_st);
+        p25_sm_init(&opts, &st);
+    }
 
     // Matching hold does not override explicit B/DE blocks in grant-compatible hold mode.
     st.tg_hold = 1102;

--- a/tests/protocol/p25/test_p25_p1_hdu_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_hdu_helpers.c
@@ -212,6 +212,13 @@ p25_sm_on_release(dsd_opts* opts, dsd_state* state) {
     g_release_calls++;
 }
 
+void
+p25_sm_note_encrypted_call(dsd_opts* opts, dsd_state* state, int tg) {
+    (void)opts;
+    (void)state;
+    (void)tg;
+}
+
 int
 dsd_tg_policy_lookup_label(const dsd_state* state, uint32_t id, char* mode, size_t mode_sz, char* name,
                            size_t name_sz) {

--- a/tests/protocol/p25/test_p25_p1_ldu2_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_ldu2_helpers.c
@@ -221,6 +221,13 @@ p25_sm_on_release(dsd_opts* opts, dsd_state* state) {
     g_release_calls++;
 }
 
+void
+p25_sm_note_encrypted_call(dsd_opts* opts, dsd_state* state, int tg) {
+    (void)opts;
+    (void)state;
+    (void)tg;
+}
+
 int
 dsd_tg_policy_lookup_label(const dsd_state* state, uint32_t id, char* mode, size_t mode_sz, char* name,
                            size_t name_sz) {

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -445,7 +445,43 @@ main(void) {
         rc |= expect_eq_long("0x42 blocked vc", state.p25_vc_freq[0], 0);
     }
 
-    // Case J: rejected P2 NSBs still prove the system carries TDMA voice without changing return CC metadata.
+    // Case J: no-SVC 0x42 grants honor transient encrypted-call memory after a proven VC lockout.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        opts.trunk_tune_enc_calls = 0;
+        state.p25_cc_freq = cc;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+        p25_sm_init(&opts, &state);
+        p25_emit_enc_lockout_once(&opts, &state, 0, 0x1234, /*svc_bits*/ 0);
+
+        MAC[1] = 0x42; // Group Voice Channel Grant Update - Implicit
+        MAC[2] = 0x10;
+        MAC[3] = 0x0A; // channel1 0x100A -> 851.125 MHz
+        MAC[4] = 0x12;
+        MAC[5] = 0x34; // group1
+        MAC[6] = 0x10;
+        MAC[7] = 0x0A; // channel2 same as channel1, so only one candidate is tried
+        MAC[8] = 0x12;
+        MAC[9] = 0x35; // group2
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_true("0x42 blocked by transient enc cache", opts.p25_is_tuned == 0);
+        rc |= expect_eq_long("0x42 transient enc cache vc", state.p25_vc_freq[0], 0);
+    }
+
+    // Case K: rejected P2 NSBs still prove the system carries TDMA voice without changing return CC metadata.
     {
         static dsd_opts opts;
         static dsd_state state;

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -186,6 +186,13 @@ main(void) {
     assert(s4.payload_algid == 0x84);
     assert(s4.payload_keyid == 0x1234);
     assert(s4.payload_miP == 0x1122334455667788ULL);
+    int enc_cache_seen = 0;
+    for (int i = 0; i < DSD_P25_ENC_TG_CACHE_DEPTH; i++) {
+        if (s4.p25_enc_tg_cache_tg[i] == 1234U && s4.p25_enc_tg_cache_until[i] > time(NULL)) {
+            enc_cache_seen = 1;
+        }
+    }
+    assert(enc_cache_seen == 1);
     // re-emit should not create a runtime policy block
     p25_emit_enc_lockout_once(&o4, &s4, 0, 1234, 0x40);
     dsd_tg_policy_lookup lockout_lookup;

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -178,6 +178,12 @@ ui_is_locked_from_label(const dsd_state* state, const char* label) { // NOLINT(m
 }
 
 int
+ui_is_transient_enc_locked_from_label(const dsd_state* state, const char* label) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    return label != NULL && strstr(label, "TransientEnc") != NULL;
+}
+
+int
 dsd_tg_policy_lookup_label(const dsd_state* state, uint32_t id, char* mode, size_t mode_sz, char* name,
                            size_t name_sz) { // NOLINT(misc-use-internal-linkage)
     (void)state;

--- a/tests/ui/test_ui_ncurses_utils.c
+++ b/tests/ui/test_ui_ncurses_utils.c
@@ -122,6 +122,7 @@ test_lockout_label_policy_lookup(void) {
     rc |= expect_true("add B policy", add_policy(state, 123U, "B", "BLOCK") == 0);
     rc |= expect_true("add DE policy", add_policy(state, 456U, "DE", "ENC-BLOCK") == 0);
     rc |= expect_true("add A policy", add_policy(state, 789U, "A", "ALLOW") == 0);
+    rc |= expect_true("add SG policy", add_policy(state, 321U, "DE", "SG-ENC-BLOCK") == 0);
 
     dsd_tg_policy_entry range;
     rc |= expect_true("make range policy",
@@ -140,6 +141,7 @@ test_lockout_label_policy_lookup(void) {
     rc |= expect_int_eq("overflow target not locked", ui_is_locked_from_label(state, "TG: 4294967296"), 0);
     rc |= expect_int_eq("TG B mode locks", ui_is_locked_from_label(state, "Voice TG: 123 src 4"), 1);
     rc |= expect_int_eq("TGT DE mode locks", ui_is_locked_from_label(state, "Call TGT:456 slot 2"), 1);
+    rc |= expect_int_eq("SG DE mode locks", ui_is_locked_from_label(state, "MFID90 GRG Grant: 82F2 SG: 321;"), 1);
     rc |= expect_int_eq("allow mode does not lock", ui_is_locked_from_label(state, "TG: 789"), 0);
     rc |= expect_int_eq("range-only match does not lock label", ui_is_locked_from_label(state, "TG: 1005"), 0);
 
@@ -153,6 +155,8 @@ test_lockout_label_policy_lookup(void) {
     state->synctype = DSD_SYNC_P25P1_POS;
     rc |= expect_int_eq("transient enc cache locks active TG",
                         ui_is_transient_enc_locked_from_label(state, "Active Ch: 82F2 TG: 21001;"), 1);
+    rc |= expect_int_eq("transient enc cache locks active SG",
+                        ui_is_transient_enc_locked_from_label(state, "MFID90 GRG Grant: 82F2 SG: 21001;"), 1);
     rc |= expect_int_eq("transient enc cache does not mutate policy lock helper",
                         ui_is_locked_from_label(state, "Active Ch: 82F2 TG: 21001;"), 0);
     state->p25_enc_tg_cache_until[0] = now - 1;

--- a/tests/ui/test_ui_ncurses_utils.c
+++ b/tests/ui/test_ui_ncurses_utils.c
@@ -13,6 +13,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -141,6 +142,27 @@ test_lockout_label_policy_lookup(void) {
     rc |= expect_int_eq("TGT DE mode locks", ui_is_locked_from_label(state, "Call TGT:456 slot 2"), 1);
     rc |= expect_int_eq("allow mode does not lock", ui_is_locked_from_label(state, "TG: 789"), 0);
     rc |= expect_int_eq("range-only match does not lock label", ui_is_locked_from_label(state, "TG: 1005"), 0);
+
+    const time_t now = time(NULL);
+    state->p25_enc_tg_cache_tg[0] = 21001U;
+    state->p25_enc_tg_cache_until[0] = now + 10;
+    state->synctype = DSD_SYNC_NONE;
+    state->lastsynctype = DSD_SYNC_NONE;
+    rc |= expect_int_eq("transient cache requires p25 sync",
+                        ui_is_transient_enc_locked_from_label(state, "Active Ch: 82F2 TG: 21001;"), 0);
+    state->synctype = DSD_SYNC_P25P1_POS;
+    rc |= expect_int_eq("transient enc cache locks active TG",
+                        ui_is_transient_enc_locked_from_label(state, "Active Ch: 82F2 TG: 21001;"), 1);
+    rc |= expect_int_eq("transient enc cache does not mutate policy lock helper",
+                        ui_is_locked_from_label(state, "Active Ch: 82F2 TG: 21001;"), 0);
+    state->p25_enc_tg_cache_until[0] = now - 1;
+    rc |= expect_int_eq("expired transient enc cache does not lock",
+                        ui_is_transient_enc_locked_from_label(state, "Active Ch: 82F2 TG: 21001;"), 0);
+    state->p25_enc_tg_cache_until[0] = now + 10;
+    state->synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state->lastsynctype = DSD_SYNC_NONE;
+    rc |= expect_int_eq("non-p25 transient enc cache does not lock",
+                        ui_is_transient_enc_locked_from_label(state, "Active Ch: 82F2 TG: 21001;"), 0);
 
     dsd_state_ext_free_all(state);
     free(state);


### PR DESCRIPTION
## Summary

- Add a transient P25 encrypted talkgroup cache so ambiguous no-SVC grants are skipped after a proven voice-channel encryption lockout without mutating persistent TG policy.
- Distinguish absent service options from explicit clear service options, allowing explicit clear grants to tune immediately and clear transient cache state.
- Preserve the transient cache in trunk-scan target snapshots and add regressions for P1/P2 encrypted retune-loop cases, VPDU 0x42, init, and scan-target isolation.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: none.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [ ] `ctest --preset dev-debug --output-on-failure`
- [x] `ctest --preset dev-debug --output-on-failure -R 'P25_GRANT_POLICY|P25_RETUNE_BACKOFF_SLOT|P25_P2_VPDU_GRANTS|P25_P1_LDU2_HELPERS|P25_P1_HDU_HELPERS|P25_SM_CORE|CORE_INIT_STATE|ENGINE_TRUNK_SCAN'`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes

## Risk

- Security/dependency impact: none expected; no dependency, crypto, workflow, or credential handling changes.
- CLI/UI behavior impact: P25 trunking should avoid repeated retunes to known encrypted calls when encryption following is disabled; explicit clear grants remain tunable.
- Compatibility or packaging impact: none expected; no user-facing option, CLI, or packaging changes.