### PR TITLE
p25: add patch-aware regroup following

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -971,6 +971,7 @@ struct dsd_state {
     uint8_t p25_call_priority[2];         // 0..7 call priority (0 if unknown)
     uint8_t p25_call_is_packet[2];        // 1 if call/service marked as packet (data), else 0
     uint8_t p25_service_options_valid[2]; // 1 when dmr_so/dmr_soR hold fresh P25 service options
+    uint32_t p25_policy_tg[2];            // matched policy TG for patched SG calls; 0 means use OTA TG
 
     //experimental symbol file capture read throttle
     int symbol_throttle;                     //throttle speed

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -381,6 +381,22 @@ void p25_sm_init(dsd_opts* opts, dsd_state* state);
 void p25_sm_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src);
 
 /**
+ * @brief Apply group grant policy side effects without attempting route/tune.
+ *
+ * Use when a decoder has a valid group grant but cannot yet resolve or follow
+ * its channel. This preserves encrypted lockout/cache and clear-key regroup
+ * policy behavior until a tunable grant arrives.
+ *
+ * @param opts Decoder options.
+ * @param state Decoder state.
+ * @param channel Voice channel number.
+ * @param svc_bits Service options associated with the grant, or P25_SM_SVC_UNKNOWN when absent.
+ * @param tg Talkgroup.
+ * @param src Source RID.
+ */
+void p25_sm_apply_group_grant_policy(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src);
+
+/**
  * @brief Handle an individual (unit-to-unit/telephone) voice channel grant.
  *
  * @param opts Decoder options.

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -620,6 +620,21 @@ void p25_patch_remove_wuid(dsd_state* state, int sgid, uint32_t wuid);
 void p25_patch_clear_sg(dsd_state* state, int sgid);
 
 /**
+ * @brief Prepare an MFID GRG update, clearing inactive or version-replaced state.
+ *
+ * Inactive GRG commands remove the supergroup record. Active commands with a
+ * changed SSN clear stale membership before the caller adds the new members.
+ *
+ * @param state Decoder state holding patch context.
+ * @param sgid Super Group ID.
+ * @param is_patch 1 for two-way patch, 0 for simulselect.
+ * @param active 1 to activate/update, 0 to deactivate/clear.
+ * @param ssn SSN from GRG options, or -1 when absent.
+ * @return 1 if members should be processed, 0 when the command cleared state.
+ */
+int p25_patch_prepare_grg_update(dsd_state* state, int sgid, int is_patch, int active, int ssn);
+
+/**
  * @brief Set optional Key/Alg/SSN context for an SG.
  *
  * Values of -1 leave the existing field unchanged.
@@ -651,6 +666,19 @@ int p25_patch_tg_key_is_clear(const dsd_state* state, int tg);
  * @return 1 if active and explicitly clear; 0 otherwise.
  */
 int p25_patch_sg_key_is_clear(const dsd_state* state, int sgid);
+
+/**
+ * @brief Collect active WGID members for a supergroup.
+ *
+ * Stale, inactive, and non-existent supergroups return 0.
+ *
+ * @param state Decoder state (read-only).
+ * @param sgid Super Group ID.
+ * @param out Optional WGID destination array.
+ * @param cap Capacity of destination array.
+ * @return Number of active WGID members known for the SG.
+ */
+int p25_patch_collect_active_wgids(const dsd_state* state, int sgid, uint16_t* out, size_t cap);
 
 /* ============================================================================
  * Affiliation (RID) tracking

--- a/src/core/audio/dsd_audio_gate.c
+++ b/src/core/audio/dsd_audio_gate.c
@@ -115,6 +115,26 @@ dsd_audio_group_source_id(const dsd_state* state, unsigned long tg) {
 }
 
 static uint32_t
+dsd_audio_group_source_id_for_slot(const dsd_state* state, int slot, uint32_t ota_target, uint32_t policy_tg) {
+    if (!state || slot < 0 || slot > 1) {
+        return dsd_audio_group_source_id(state, policy_tg);
+    }
+
+    int raw_target = (slot == 0) ? state->lasttg : state->lasttgR;
+    int raw_source = (slot == 0) ? state->lastsrc : state->lastsrcR;
+    if (raw_source <= 0) {
+        return 0;
+    }
+    if (raw_target >= 0 && (uint32_t)raw_target == ota_target) {
+        return (uint32_t)raw_source;
+    }
+    if (raw_target >= 0 && (uint32_t)raw_target == policy_tg) {
+        return (uint32_t)raw_source;
+    }
+    return dsd_audio_group_source_id(state, policy_tg);
+}
+
+static uint32_t
 dsd_audio_p25_policy_target_for_slot(const dsd_state* state, int slot, uint32_t ota_target) {
     if (!dsd_audio_p25_policy_tg_valid_for_slot(state, slot, ota_target)) {
         return ota_target;
@@ -316,9 +336,12 @@ dsd_p25p2_decode_audio_allowed(const dsd_opts* opts, const dsd_state* state, int
     return 0;
 }
 
-int
-dsd_audio_group_gate_mono(const dsd_opts* opts, const dsd_state* state, unsigned long tg, int enc_in, int* enc_out) {
+static int
+dsd_audio_group_gate_slot(const dsd_opts* opts, const dsd_state* state, int slot, unsigned long tg, int enc_in,
+                          int* enc_out) {
     dsd_tg_policy_decision decision;
+    uint32_t ota_tg = (uint32_t)tg;
+    uint32_t policy_tg = 0;
     uint32_t source_id = 0;
 
     if (!opts || !state || !enc_out) {
@@ -326,8 +349,13 @@ dsd_audio_group_gate_mono(const dsd_opts* opts, const dsd_state* state, unsigned
     }
 
     int enc = (enc_in != 0) ? 1 : 0;
-    uint32_t policy_tg = dsd_audio_p25_policy_target_for_group(state, (uint32_t)tg);
-    source_id = dsd_audio_group_source_id(state, policy_tg);
+    if (slot >= 0 && slot <= 1) {
+        policy_tg = dsd_audio_p25_policy_target_for_slot(state, slot, ota_tg);
+        source_id = dsd_audio_group_source_id_for_slot(state, slot, ota_tg, policy_tg);
+    } else {
+        policy_tg = dsd_audio_p25_policy_target_for_group(state, ota_tg);
+        source_id = dsd_audio_group_source_id(state, policy_tg);
+    }
 
     if (dsd_tg_policy_evaluate_group_call(opts, state, policy_tg, source_id, 0, 0, DSD_TG_POLICY_HOLD_FORCE_MEDIA_ONLY,
                                           &decision)
@@ -344,14 +372,19 @@ dsd_audio_group_gate_mono(const dsd_opts* opts, const dsd_state* state, unsigned
 }
 
 int
+dsd_audio_group_gate_mono(const dsd_opts* opts, const dsd_state* state, unsigned long tg, int enc_in, int* enc_out) {
+    return dsd_audio_group_gate_slot(opts, state, -1, tg, enc_in, enc_out);
+}
+
+int
 dsd_audio_group_gate_dual(const dsd_opts* opts, const dsd_state* state, unsigned long tgL, unsigned long tgR,
                           int encL_in, int encR_in, int* encL_out, int* encR_out) {
     if (!encL_out || !encR_out) {
         return -1;
     }
     int rc = 0;
-    rc |= dsd_audio_group_gate_mono(opts, state, tgL, encL_in, encL_out);
-    rc |= dsd_audio_group_gate_mono(opts, state, tgR, encR_in, encR_out);
+    rc |= dsd_audio_group_gate_slot(opts, state, 0, tgL, encL_in, encL_out);
+    rc |= dsd_audio_group_gate_slot(opts, state, 1, tgR, encR_in, encR_out);
     return rc;
 }
 

--- a/src/core/audio/dsd_audio_gate.c
+++ b/src/core/audio/dsd_audio_gate.c
@@ -18,9 +18,58 @@
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <time.h>
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
+
+#define DSD_AUDIO_P25_PATCH_TTL_SECONDS 20
+
+static int
+dsd_audio_state_is_p25(const dsd_state* state) {
+    return (state && (DSD_SYNC_IS_P25(state->synctype) || DSD_SYNC_IS_P25(state->lastsynctype))) ? 1 : 0;
+}
+
+static int
+dsd_audio_p25_patch_member_active(const dsd_state* state, uint32_t ota_target, uint32_t policy_tg) {
+    if (!state || ota_target == 0U || ota_target > UINT16_MAX || policy_tg == 0U || policy_tg > UINT16_MAX
+        || policy_tg == ota_target) {
+        return 0;
+    }
+
+    time_t now = time(NULL);
+    for (int i = 0; i < state->p25_patch_count && i < 8; i++) {
+        if (!state->p25_patch_active[i] || state->p25_patch_sgid[i] != (uint16_t)ota_target) {
+            continue;
+        }
+        if (state->p25_patch_last_update[i] > 0
+            && (now - state->p25_patch_last_update[i]) > DSD_AUDIO_P25_PATCH_TTL_SECONDS) {
+            continue;
+        }
+        uint8_t count = state->p25_patch_wgid_count[i];
+        for (int k = 0; k < count && k < 8; k++) {
+            if (state->p25_patch_wgid[i][k] == (uint16_t)policy_tg) {
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+static int
+dsd_audio_p25_policy_tg_valid_for_slot(const dsd_state* state, int slot, uint32_t ota_target) {
+    if (!dsd_audio_state_is_p25(state) || slot < 0 || slot > 1) {
+        return 0;
+    }
+
+    int raw_target = (slot == 0) ? state->lasttg : state->lasttgR;
+    if (raw_target <= 0 || (uint32_t)raw_target != ota_target) {
+        return 0;
+    }
+
+    return dsd_audio_p25_patch_member_active(state, ota_target, state->p25_policy_tg[slot]);
+}
 
 static uint32_t
 dsd_audio_group_source_id(const dsd_state* state, unsigned long tg) {
@@ -28,10 +77,12 @@ dsd_audio_group_source_id(const dsd_state* state, unsigned long tg) {
     if (!state) {
         return 0;
     }
-    if (state->p25_policy_tg[0] == id && state->lasttg > 0) {
+    if (state->lasttg > 0 && state->p25_policy_tg[0] == id
+        && dsd_audio_p25_policy_tg_valid_for_slot(state, 0, (uint32_t)state->lasttg)) {
         return (uint32_t)state->lastsrc;
     }
-    if (state->p25_policy_tg[1] == id && state->lasttgR > 0) {
+    if (state->lasttgR > 0 && state->p25_policy_tg[1] == id
+        && dsd_audio_p25_policy_tg_valid_for_slot(state, 1, (uint32_t)state->lasttgR)) {
         return (uint32_t)state->lastsrcR;
     }
     if (state->lasttg >= 0 && (uint32_t)state->lasttg == id) {
@@ -43,17 +94,12 @@ dsd_audio_group_source_id(const dsd_state* state, unsigned long tg) {
     return 0;
 }
 
-static int
-dsd_audio_state_is_p25(const dsd_state* state) {
-    return (state && (DSD_SYNC_IS_P25(state->synctype) || DSD_SYNC_IS_P25(state->lastsynctype))) ? 1 : 0;
-}
-
 static uint32_t
 dsd_audio_p25_policy_target_for_slot(const dsd_state* state, int slot, uint32_t ota_target) {
-    if (!dsd_audio_state_is_p25(state) || slot < 0 || slot > 1) {
+    if (!dsd_audio_p25_policy_tg_valid_for_slot(state, slot, ota_target)) {
         return ota_target;
     }
-    return (state->p25_policy_tg[slot] != 0U) ? state->p25_policy_tg[slot] : ota_target;
+    return state->p25_policy_tg[slot];
 }
 
 static uint32_t
@@ -61,10 +107,12 @@ dsd_audio_p25_policy_target_for_group(const dsd_state* state, uint32_t ota_targe
     if (!dsd_audio_state_is_p25(state)) {
         return ota_target;
     }
-    if (state->lasttg >= 0 && (uint32_t)state->lasttg == ota_target && state->p25_policy_tg[0] != 0U) {
+    if (state->lasttg > 0 && (uint32_t)state->lasttg == ota_target
+        && dsd_audio_p25_policy_tg_valid_for_slot(state, 0, ota_target)) {
         return state->p25_policy_tg[0];
     }
-    if (state->lasttgR >= 0 && (uint32_t)state->lasttgR == ota_target && state->p25_policy_tg[1] != 0U) {
+    if (state->lasttgR > 0 && (uint32_t)state->lasttgR == ota_target
+        && dsd_audio_p25_policy_tg_valid_for_slot(state, 1, ota_target)) {
         return state->p25_policy_tg[1];
     }
     return ota_target;

--- a/src/core/audio/dsd_audio_gate.c
+++ b/src/core/audio/dsd_audio_gate.c
@@ -28,6 +28,12 @@ dsd_audio_group_source_id(const dsd_state* state, unsigned long tg) {
     if (!state) {
         return 0;
     }
+    if (state->p25_policy_tg[0] == id && state->lasttg > 0) {
+        return (uint32_t)state->lastsrc;
+    }
+    if (state->p25_policy_tg[1] == id && state->lasttgR > 0) {
+        return (uint32_t)state->lastsrcR;
+    }
     if (state->lasttg >= 0 && (uint32_t)state->lasttg == id) {
         return state->lastsrc;
     }
@@ -35,6 +41,33 @@ dsd_audio_group_source_id(const dsd_state* state, unsigned long tg) {
         return state->lastsrcR;
     }
     return 0;
+}
+
+static int
+dsd_audio_state_is_p25(const dsd_state* state) {
+    return (state && (DSD_SYNC_IS_P25(state->synctype) || DSD_SYNC_IS_P25(state->lastsynctype))) ? 1 : 0;
+}
+
+static uint32_t
+dsd_audio_p25_policy_target_for_slot(const dsd_state* state, int slot, uint32_t ota_target) {
+    if (!dsd_audio_state_is_p25(state) || slot < 0 || slot > 1) {
+        return ota_target;
+    }
+    return (state->p25_policy_tg[slot] != 0U) ? state->p25_policy_tg[slot] : ota_target;
+}
+
+static uint32_t
+dsd_audio_p25_policy_target_for_group(const dsd_state* state, uint32_t ota_target) {
+    if (!dsd_audio_state_is_p25(state)) {
+        return ota_target;
+    }
+    if (state->lasttg >= 0 && (uint32_t)state->lasttg == ota_target && state->p25_policy_tg[0] != 0U) {
+        return state->p25_policy_tg[0];
+    }
+    if (state->lasttgR >= 0 && (uint32_t)state->lasttgR == ota_target && state->p25_policy_tg[1] != 0U) {
+        return state->p25_policy_tg[1];
+    }
+    return ota_target;
 }
 
 static int
@@ -204,8 +237,9 @@ dsd_p25p2_decode_audio_allowed(const dsd_opts* opts, const dsd_state* state, int
             return dsd_p25p2_media_decision_allows_audio(&decision);
         }
     } else {
-        if (dsd_tg_policy_evaluate_group_call(opts, state, target, source, 0, 0, DSD_TG_POLICY_HOLD_FORCE_MEDIA_ONLY,
-                                              &decision)
+        uint32_t policy_target = dsd_audio_p25_policy_target_for_slot(state, slot, target);
+        if (dsd_tg_policy_evaluate_group_call(opts, state, policy_target, source, 0, 0,
+                                              DSD_TG_POLICY_HOLD_FORCE_MEDIA_ONLY, &decision)
             == 0) {
             return dsd_p25p2_media_decision_allows_audio(&decision);
         }
@@ -224,10 +258,11 @@ dsd_audio_group_gate_mono(const dsd_opts* opts, const dsd_state* state, unsigned
     }
 
     int enc = (enc_in != 0) ? 1 : 0;
-    source_id = dsd_audio_group_source_id(state, tg);
+    uint32_t policy_tg = dsd_audio_p25_policy_target_for_group(state, (uint32_t)tg);
+    source_id = dsd_audio_group_source_id(state, policy_tg);
 
-    if (dsd_tg_policy_evaluate_group_call(opts, state, (uint32_t)tg, source_id, 0, 0,
-                                          DSD_TG_POLICY_HOLD_FORCE_MEDIA_ONLY, &decision)
+    if (dsd_tg_policy_evaluate_group_call(opts, state, policy_tg, source_id, 0, 0, DSD_TG_POLICY_HOLD_FORCE_MEDIA_ONLY,
+                                          &decision)
         == 0) {
         if (decision.tg_hold_active && decision.tg_hold_match) {
             enc = 0;
@@ -284,6 +319,7 @@ dsd_audio_record_policy_blocks(const dsd_opts* opts, const dsd_state* state, int
     }
 
     tg = (slot == 1) ? (unsigned long)state->lasttgR : (unsigned long)state->lasttg;
+    tg = (unsigned long)dsd_audio_p25_policy_target_for_slot(state, slot, (uint32_t)tg);
     source_id = (slot == 1) ? state->lastsrcR : state->lastsrc;
     if (dsd_tg_policy_evaluate_group_call(opts, state, (uint32_t)tg, source_id, 0, 0,
                                           DSD_TG_POLICY_HOLD_FORCE_MEDIA_ONLY, &decision)

--- a/src/core/audio/dsd_audio_gate.c
+++ b/src/core/audio/dsd_audio_gate.c
@@ -30,29 +30,50 @@ dsd_audio_state_is_p25(const dsd_state* state) {
 }
 
 static int
+dsd_audio_p25_policy_pair_valid(uint32_t ota_target, uint32_t policy_tg) {
+    return (ota_target != 0U && ota_target <= UINT16_MAX && policy_tg != 0U && policy_tg <= UINT16_MAX
+            && policy_tg != ota_target)
+               ? 1
+               : 0;
+}
+
+static int
+dsd_audio_p25_patch_entry_current(const dsd_state* state, int idx, uint32_t ota_target, time_t now) {
+    if (!state || idx < 0 || idx >= 8 || !state->p25_patch_active[idx]
+        || state->p25_patch_sgid[idx] != (uint16_t)ota_target) {
+        return 0;
+    }
+    if (state->p25_patch_last_update[idx] > 0
+        && (now - state->p25_patch_last_update[idx]) > DSD_AUDIO_P25_PATCH_TTL_SECONDS) {
+        return 0;
+    }
+    return 1;
+}
+
+static int
+dsd_audio_p25_patch_entry_has_wgid(const dsd_state* state, int idx, uint32_t policy_tg) {
+    uint8_t count = state->p25_patch_wgid_count[idx];
+    for (int k = 0; k < count && k < 8; k++) {
+        if (state->p25_patch_wgid[idx][k] == (uint16_t)policy_tg) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
 dsd_audio_p25_patch_member_active(const dsd_state* state, uint32_t ota_target, uint32_t policy_tg) {
-    if (!state || ota_target == 0U || ota_target > UINT16_MAX || policy_tg == 0U || policy_tg > UINT16_MAX
-        || policy_tg == ota_target) {
+    if (!state || !dsd_audio_p25_policy_pair_valid(ota_target, policy_tg)) {
         return 0;
     }
 
     time_t now = time(NULL);
     for (int i = 0; i < state->p25_patch_count && i < 8; i++) {
-        if (!state->p25_patch_active[i] || state->p25_patch_sgid[i] != (uint16_t)ota_target) {
-            continue;
-        }
-        if (state->p25_patch_last_update[i] > 0
-            && (now - state->p25_patch_last_update[i]) > DSD_AUDIO_P25_PATCH_TTL_SECONDS) {
-            continue;
-        }
-        uint8_t count = state->p25_patch_wgid_count[i];
-        for (int k = 0; k < count && k < 8; k++) {
-            if (state->p25_patch_wgid[i][k] == (uint16_t)policy_tg) {
-                return 1;
-            }
+        if (dsd_audio_p25_patch_entry_current(state, i, ota_target, now)
+            && dsd_audio_p25_patch_entry_has_wgid(state, i, policy_tg)) {
+            return 1;
         }
     }
-
     return 0;
 }
 

--- a/src/core/audio/dsd_audio_gate.c
+++ b/src/core/audio/dsd_audio_gate.c
@@ -16,7 +16,6 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
-#include <stddef.h>
 #include <stdint.h>
 #include <time.h>
 

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -694,6 +694,7 @@ init_state_protocol_defaults_a(dsd_state* state) {
     state->p25_call_priority[0] = state->p25_call_priority[1] = 0;
     state->p25_call_is_packet[0] = state->p25_call_is_packet[1] = 0;
     state->p25_service_options_valid[0] = state->p25_service_options_valid[1] = 0;
+    state->p25_policy_tg[0] = state->p25_policy_tg[1] = 0;
 
     // Initialize P25 Phase 1 metrics counters (also reset on retune)
     state->p25_p1_fec_ok = 0;

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -125,6 +125,7 @@ typedef struct {
     uint32_t p25_patch_wuid[8][8];
     uint32_t p25_aff_rid[256];
     uint32_t p25_ga_rid[512];
+    uint32_t p25_policy_tg[2];
     uint16_t p25_prot_kid;
     int16_t p25_sys_time_offset;
     uint16_t p25_patch_sgid[8];
@@ -753,6 +754,7 @@ trunk_scan_save_call_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot* s
     DSD_MEMCPY(snapshot->p25_call_emergency, state->p25_call_emergency, sizeof(snapshot->p25_call_emergency));
     DSD_MEMCPY(snapshot->p25_call_priority, state->p25_call_priority, sizeof(snapshot->p25_call_priority));
     DSD_MEMCPY(snapshot->p25_call_is_packet, state->p25_call_is_packet, sizeof(snapshot->p25_call_is_packet));
+    DSD_MEMCPY(snapshot->p25_policy_tg, state->p25_policy_tg, sizeof(snapshot->p25_policy_tg));
     DSD_MEMCPY(snapshot->p25_service_options_valid, state->p25_service_options_valid,
                sizeof(snapshot->p25_service_options_valid));
     snapshot->dmr_so = state->dmr_so;
@@ -769,6 +771,7 @@ trunk_scan_restore_call_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot
     DSD_MEMCPY(state->p25_call_emergency, snapshot->p25_call_emergency, sizeof(state->p25_call_emergency));
     DSD_MEMCPY(state->p25_call_priority, snapshot->p25_call_priority, sizeof(state->p25_call_priority));
     DSD_MEMCPY(state->p25_call_is_packet, snapshot->p25_call_is_packet, sizeof(state->p25_call_is_packet));
+    DSD_MEMCPY(state->p25_policy_tg, snapshot->p25_policy_tg, sizeof(state->p25_policy_tg));
     DSD_MEMCPY(state->p25_service_options_valid, snapshot->p25_service_options_valid,
                sizeof(state->p25_service_options_valid));
     state->dmr_so = snapshot->dmr_so;

--- a/src/protocol/p25/p25_patch.c
+++ b/src/protocol/p25/p25_patch.c
@@ -31,6 +31,33 @@ find_patch_idx(const dsd_state* state, uint16_t sgid) {
     return -1;
 }
 
+static int
+p25_patch_entry_is_stale(const dsd_state* state, int idx, time_t now) {
+    if (!state || idx < 0 || idx >= 8) {
+        return 1;
+    }
+    return (state->p25_patch_last_update[idx] > 0 && (now - state->p25_patch_last_update[idx]) > P25_PATCH_TTL_SECONDS)
+               ? 1
+               : 0;
+}
+
+static void
+p25_patch_clear_entry_context(dsd_state* state, int idx) {
+    if (!state || idx < 0 || idx >= 8) {
+        return;
+    }
+    state->p25_patch_wgid_count[idx] = 0;
+    state->p25_patch_wuid_count[idx] = 0;
+    for (int k = 0; k < 8; k++) {
+        state->p25_patch_wgid[idx][k] = 0;
+        state->p25_patch_wuid[idx][k] = 0;
+    }
+    state->p25_patch_key[idx] = 0;
+    state->p25_patch_alg[idx] = 0;
+    state->p25_patch_ssn[idx] = 0;
+    state->p25_patch_key_valid[idx] = 0;
+}
+
 static void
 p25_patch_sweep_stale(dsd_state* state) {
     if (!state) {
@@ -105,9 +132,7 @@ p25_patch_update(dsd_state* state, int sgid, int is_patch, int active) {
     state->p25_patch_is_patch[idx] = is_patch ? 1 : 0;
     state->p25_patch_active[idx] = active ? 1 : 0;
     state->p25_patch_last_update[idx] = now;
-    state->p25_patch_wgid_count[idx] = 0;
-    state->p25_patch_wuid_count[idx] = 0;
-    state->p25_patch_key_valid[idx] = 0;
+    p25_patch_clear_entry_context(state, idx);
 }
 
 int
@@ -348,9 +373,38 @@ p25_patch_clear_sg(dsd_state* state, int sgid) {
     if (idx < 0) {
         return;
     }
-    state->p25_patch_wgid_count[idx] = 0;
-    state->p25_patch_wuid_count[idx] = 0;
+    p25_patch_clear_entry_context(state, idx);
     state->p25_patch_active[idx] = 0;
+    state->p25_patch_last_update[idx] = time(NULL);
+}
+
+int
+p25_patch_prepare_grg_update(dsd_state* state, int sgid, int is_patch, int active, int ssn) {
+    if (!state || sgid <= 0 || sgid > 0xFFFF) {
+        return 0;
+    }
+
+    const int normalized_ssn = (ssn >= 0) ? (ssn & 0x1F) : -1;
+    int idx = find_patch_idx(state, (uint16_t)sgid);
+    if (!active) {
+        if (idx < 0) {
+            p25_patch_update(state, sgid, is_patch, 0);
+        }
+        p25_patch_clear_sg(state, sgid);
+        idx = find_patch_idx(state, (uint16_t)sgid);
+        if (idx >= 0) {
+            state->p25_patch_is_patch[idx] = is_patch ? 1 : 0;
+        }
+        return 0;
+    }
+
+    if (idx >= 0 && state->p25_patch_active[idx] != 0 && normalized_ssn >= 0
+        && state->p25_patch_ssn[idx] != (uint8_t)normalized_ssn) {
+        p25_patch_clear_entry_context(state, idx);
+    }
+
+    p25_patch_update(state, sgid, is_patch, 1);
+    return 1;
 }
 
 void
@@ -432,4 +486,29 @@ p25_patch_sg_key_is_clear(const dsd_state* state, int sgid) {
         return (s->p25_patch_key_valid[i] && s->p25_patch_key[i] == 0) ? 1 : 0;
     }
     return 0;
+}
+
+int
+p25_patch_collect_active_wgids(const dsd_state* state, int sgid, uint16_t* out, size_t cap) {
+    if (!state || sgid <= 0 || sgid > 0xFFFF) {
+        return 0;
+    }
+
+    time_t now = time(NULL);
+    int idx = find_patch_idx(state, (uint16_t)sgid);
+    if (idx < 0 || !state->p25_patch_active[idx] || p25_patch_entry_is_stale(state, idx, now)) {
+        return 0;
+    }
+
+    int count = state->p25_patch_wgid_count[idx];
+    if (count < 0) {
+        count = 0;
+    }
+    if (count > 8) {
+        count = 8;
+    }
+    for (int i = 0; out && i < count && (size_t)i < cap; i++) {
+        out[i] = state->p25_patch_wgid[idx][i];
+    }
+    return count;
 }

--- a/src/protocol/p25/p25_patch.c
+++ b/src/protocol/p25/p25_patch.c
@@ -58,6 +58,39 @@ p25_patch_clear_entry_context(dsd_state* state, int idx) {
     state->p25_patch_key_valid[idx] = 0;
 }
 
+static int
+p25_patch_replacement_idx(const dsd_state* state, int active, time_t now) {
+    if (!state) {
+        return -1;
+    }
+
+    for (int i = 0; i < 8; i++) {
+        if (!state->p25_patch_active[i]) {
+            return i;
+        }
+    }
+
+    for (int i = 0; i < 8; i++) {
+        if (p25_patch_entry_is_stale(state, i, now)) {
+            return i;
+        }
+    }
+
+    if (!active) {
+        return -1;
+    }
+
+    int repl = 0;
+    time_t oldest = state->p25_patch_last_update[0];
+    for (int i = 1; i < 8; i++) {
+        if (state->p25_patch_last_update[i] < oldest) {
+            oldest = state->p25_patch_last_update[i];
+            repl = i;
+        }
+    }
+    return repl;
+}
+
 static void
 p25_patch_sweep_stale(dsd_state* state) {
     if (!state) {
@@ -115,16 +148,11 @@ p25_patch_update(dsd_state* state, int sgid, int is_patch, int active) {
         idx = 0;
     }
     if (idx >= 8) {
-        // Replace the stalest entry
-        int repl = 0;
-        time_t oldest = state->p25_patch_last_update[0];
-        for (int i = 1; i < 8; i++) {
-            if (state->p25_patch_last_update[i] < oldest) {
-                oldest = state->p25_patch_last_update[i];
-                repl = i;
-            }
+        state->p25_patch_count = 8;
+        idx = p25_patch_replacement_idx(state, active ? 1 : 0, now);
+        if (idx < 0) {
+            return;
         }
-        idx = repl;
     } else {
         state->p25_patch_count = idx + 1;
     }

--- a/src/protocol/p25/p25_patch.c
+++ b/src/protocol/p25/p25_patch.c
@@ -501,9 +501,6 @@ p25_patch_collect_active_wgids(const dsd_state* state, int sgid, uint16_t* out, 
     }
 
     int count = state->p25_patch_wgid_count[idx];
-    if (count < 0) {
-        count = 0;
-    }
     if (count > 8) {
         count = 8;
     }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1180,6 +1180,71 @@ p25_grant_seed_cc_before_vc_tune(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_st
     set_state(ctx, opts, state, P25_SM_ON_CC, "grant-cc-seed");
 }
 
+typedef struct {
+    dsd_tg_policy_call_route route;
+    int slot;
+    int target_id;
+    int needs_retune;
+    int clear_policy_slot_only;
+    int ted_sps;
+    long freq;
+    double now_m;
+} p25_grant_route_ctx_t;
+
+static void
+p25_grant_log_freq(dsd_opts* opts, const dsd_state* state, const p25_sm_ctx_t* ctx, const p25_sm_event_t* ev, long freq,
+                   const p25_freq_trace_t* freq_trace) {
+    if (!freq_trace) {
+        return;
+    }
+    p25_sm_diagf(opts, state, ctx, "grant_freq",
+                 "ch=0x%04X freq=%ld source=%s failure=%s iden=%d type=%d tdma=%d denom=%d step=%d cached=%d "
+                 "ambiguous=%d base=%ld spacing=%ld tg=%d src=%d dst=%d svc=0x%02X",
+                 ev->channel & 0xFFFF, freq, freq_trace->source, freq_trace->failure[0] ? freq_trace->failure : "none",
+                 freq_trace->iden, freq_trace->chan_type, freq_trace->use_tdma, freq_trace->denom, freq_trace->step,
+                 freq_trace->cached, freq_trace->ambiguous, freq_trace->base_hz, freq_trace->spacing_hz, ev->tg,
+                 ev->src, ev->dst, ev->svc_bits);
+}
+
+static int
+p25_grant_should_clear_slot_only(const p25_sm_ctx_t* ctx, const dsd_state* state, const p25_sm_event_t* ev, long freq,
+                                 int slot) {
+    if (!ctx || !state || !ev || slot < 0 || slot > 1) {
+        return 0;
+    }
+    return (ctx->state == P25_SM_TUNED && ctx->vc_freq_hz == freq && ctx->vc_is_tdma
+            && is_tdma_channel(state, ev->channel))
+               ? 1
+               : 0;
+}
+
+static int
+p25_grant_prepare_route(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev,
+                        const dsd_tg_policy_decision* decision, p25_grant_route_ctx_t* out) {
+    p25_freq_trace_t freq_trace;
+    if (!ctx || !opts || !state || !ev || !decision || !out) {
+        return 0;
+    }
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->freq = process_channel_to_freq_trace(opts, state, ev->channel, &freq_trace);
+    p25_grant_log_freq(opts, state, ctx, ev, out->freq, &freq_trace);
+    if (out->freq == 0) {
+        sm_log(opts, state, "grant-no-freq");
+        return 0;
+    }
+
+    out->now_m = now_monotonic();
+    out->slot = channel_slot(state, ev->channel);
+    if (p25_grant_retune_blocked(opts, state, out->freq, out->slot, ev->channel)) {
+        return 0;
+    }
+    out->needs_retune = (ctx->state == P25_SM_TUNED && ctx->vc_freq_hz != 0 && ctx->vc_freq_hz != out->freq) ? 1 : 0;
+    out->clear_policy_slot_only = p25_grant_should_clear_slot_only(ctx, state, ev, out->freq, out->slot);
+    out->target_id = p25_grant_target_id(ev, decision);
+    p25_grant_fill_route(&out->route, ev, out->freq, out->slot, out->needs_retune, out->target_id);
+    return 1;
+}
+
 /* ============================================================================
  * Event Handlers
  * ============================================================================ */
@@ -1187,15 +1252,7 @@ p25_grant_seed_cc_before_vc_tune(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_st
 static void
 handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev) {
     dsd_tg_policy_decision decision;
-    dsd_tg_policy_call_route route;
-    int slot = 0;
-    int target_id = 0;
-    int ted_sps = 0;
-    int needs_retune = 0;
-    int clear_policy_slot_only = 0;
-    long freq = 0;
-    double now_m = 0.0;
-    p25_freq_trace_t freq_trace;
+    p25_grant_route_ctx_t grant;
     if (!ctx || !ev || !opts || !state) {
         return;
     }
@@ -1205,63 +1262,42 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
         return;
     }
 
-    freq = process_channel_to_freq_trace(opts, state, ev->channel, &freq_trace);
-    p25_sm_diagf(opts, state, ctx, "grant_freq",
-                 "ch=0x%04X freq=%ld source=%s failure=%s iden=%d type=%d tdma=%d denom=%d step=%d cached=%d "
-                 "ambiguous=%d base=%ld spacing=%ld tg=%d src=%d dst=%d svc=0x%02X",
-                 ev->channel & 0xFFFF, freq, freq_trace.source, freq_trace.failure[0] ? freq_trace.failure : "none",
-                 freq_trace.iden, freq_trace.chan_type, freq_trace.use_tdma, freq_trace.denom, freq_trace.step,
-                 freq_trace.cached, freq_trace.ambiguous, freq_trace.base_hz, freq_trace.spacing_hz, ev->tg, ev->src,
-                 ev->dst, ev->svc_bits);
-    if (freq == 0) {
-        sm_log(opts, state, "grant-no-freq");
+    if (!p25_grant_prepare_route(ctx, opts, state, ev, &decision, &grant)) {
         return;
     }
-
-    now_m = now_monotonic();
-    slot = channel_slot(state, ev->channel);
-    if (p25_grant_retune_blocked(opts, state, freq, slot, ev->channel)) {
-        return;
-    }
-    needs_retune = (ctx->state == P25_SM_TUNED && ctx->vc_freq_hz != 0 && ctx->vc_freq_hz != freq) ? 1 : 0;
-    clear_policy_slot_only = (ctx->state == P25_SM_TUNED && ctx->vc_freq_hz == freq && ctx->vc_is_tdma
-                              && is_tdma_channel(state, ev->channel) && slot >= 0 && slot <= 1)
-                                 ? 1
-                                 : 0;
-    target_id = p25_grant_target_id(ev, &decision);
-    p25_grant_fill_route(&route, ev, freq, slot, needs_retune, target_id);
 
     // Skip if already tuned to same frequency AND same TG (avoid bounce on duplicate grants)
     // Different TG/call type should still trigger a new tune
-    if (p25_grant_handle_duplicate(ctx, opts, state, &route, &decision, freq, target_id, now_m)) {
-        p25_grant_store_policy_tg(state, ev, slot, &decision);
+    if (p25_grant_handle_duplicate(ctx, opts, state, &grant.route, &decision, grant.freq, grant.target_id,
+                                   grant.now_m)) {
+        p25_grant_store_policy_tg(state, ev, grant.slot, &decision);
         return;
     }
 
-    if (!p25_grant_preempt_active_call_if_needed(ctx, opts, state, &route, &decision, now_m)) {
+    if (!p25_grant_preempt_active_call_if_needed(ctx, opts, state, &grant.route, &decision, grant.now_m)) {
         return;
     }
 
-    p25_grant_seed_cc_before_vc_tune(ctx, opts, state, now_m);
+    p25_grant_seed_cc_before_vc_tune(ctx, opts, state, grant.now_m);
 
-    if (!p25_grant_try_tune_vc(ctx, ev, opts, state, freq, slot, &ted_sps)) {
+    if (!p25_grant_try_tune_vc(ctx, ev, opts, state, grant.freq, grant.slot, &grant.ted_sps)) {
         return;
     }
-    p25_grant_store_vc_context(ctx, state, ev, freq, target_id, now_m);
+    p25_grant_store_vc_context(ctx, state, ev, grant.freq, grant.target_id, grant.now_m);
     p25_grant_clear_slot_state(ctx);
-    p25_grant_clear_replaced_policy_tg(state, slot, clear_policy_slot_only);
-    p25_grant_store_policy_tg(state, ev, slot, &decision);
+    p25_grant_clear_replaced_policy_tg(state, grant.slot, grant.clear_policy_slot_only);
+    p25_grant_store_policy_tg(state, ev, grant.slot, &decision);
     ctx->tune_count++;
     ctx->grant_count++;
-    p25_grant_debug_log_tdma(opts, state, ctx, ev, freq, ted_sps);
+    p25_grant_debug_log_tdma(opts, state, ctx, ev, grant.freq, grant.ted_sps);
 
     state->p25_sm_tune_count++;
-    (void)dsd_tg_policy_note_active_call(state, &route, &decision, now_m);
+    (void)dsd_tg_policy_note_active_call(state, &grant.route, &decision, grant.now_m);
     p25_sm_diagf(opts, state, ctx, "grant_accept",
                  "ch=0x%04X freq=%ld slot=%d target=%d ota_tg=%d src=%d needs_retune=%d "
                  "prio=%d preempt=%d",
-                 ev->channel & 0xFFFF, freq, slot, target_id, ev->tg, ev->src, needs_retune, decision.priority,
-                 decision.preempt_requested);
+                 ev->channel & 0xFFFF, grant.freq, grant.slot, grant.target_id, ev->tg, ev->src, grant.needs_retune,
+                 decision.priority, decision.preempt_requested);
 
     set_state(ctx, opts, state, P25_SM_TUNED, "grant");
 }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1302,6 +1302,20 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     set_state(ctx, opts, state, P25_SM_TUNED, "grant");
 }
 
+void
+p25_sm_apply_group_grant_policy(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
+    if (!opts || !state || opts->p25_trunk != 1) {
+        return;
+    }
+
+    p25_sm_event_t ev = p25_sm_ev_group_grant(channel, 0, tg, src, svc_bits);
+    dsd_tg_policy_decision decision;
+    if (grant_allowed(opts, state, &ev, &decision)) {
+        p25_sm_diagf(opts, state, NULL, "grant_policy_only", "ch=0x%04X tg=%d src=%d svc=0x%02X policy_tg=%u",
+                     channel & 0xFFFF, tg, src, svc_bits & 0xFF, decision.target_id);
+    }
+}
+
 // Helper to check if slot has decryption capability
 static int
 slot_can_decrypt(const dsd_state* state, int slot, int algid) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1076,6 +1076,19 @@ p25_grant_store_policy_tg(dsd_state* state, const p25_sm_event_t* ev, int slot,
     state->p25_policy_tg[1] = 0;
 }
 
+static void
+p25_grant_clear_replaced_policy_tg(dsd_state* state, int slot, int slot_only) {
+    if (!state) {
+        return;
+    }
+    if (slot_only && slot >= 0 && slot <= 1) {
+        state->p25_policy_tg[slot] = 0;
+        return;
+    }
+    state->p25_policy_tg[0] = 0;
+    state->p25_policy_tg[1] = 0;
+}
+
 static int
 p25_retune_block_slot_matches(int blocked_slot, int grant_slot) {
     return blocked_slot == grant_slot;
@@ -1179,6 +1192,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     int target_id = 0;
     int ted_sps = 0;
     int needs_retune = 0;
+    int clear_policy_slot_only = 0;
     long freq = 0;
     double now_m = 0.0;
     p25_freq_trace_t freq_trace;
@@ -1210,6 +1224,10 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
         return;
     }
     needs_retune = (ctx->state == P25_SM_TUNED && ctx->vc_freq_hz != 0 && ctx->vc_freq_hz != freq) ? 1 : 0;
+    clear_policy_slot_only = (ctx->state == P25_SM_TUNED && ctx->vc_freq_hz == freq && ctx->vc_is_tdma
+                              && is_tdma_channel(state, ev->channel) && slot >= 0 && slot <= 1)
+                                 ? 1
+                                 : 0;
     target_id = p25_grant_target_id(ev, &decision);
     p25_grant_fill_route(&route, ev, freq, slot, needs_retune, target_id);
 
@@ -1231,8 +1249,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     }
     p25_grant_store_vc_context(ctx, state, ev, freq, target_id, now_m);
     p25_grant_clear_slot_state(ctx);
-    state->p25_policy_tg[0] = 0;
-    state->p25_policy_tg[1] = 0;
+    p25_grant_clear_replaced_policy_tg(state, slot, clear_policy_slot_only);
     p25_grant_store_policy_tg(state, ev, slot, &decision);
     ctx->tune_count++;
     ctx->grant_count++;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -708,9 +708,45 @@ p25_grant_eval_policy(const dsd_opts* opts, const dsd_state* state, const p25_sm
             opts, state, (uint32_t)ev->src, (uint32_t)ev->dst, eval_ctx->encrypted_call, eval_ctx->data_call,
             DSD_TG_POLICY_PRIVATE_ALLOWLIST_UNKNOWN_ALLOW, DSD_TG_POLICY_HOLD_COMPAT_GRANT, out_decision);
     }
-    return dsd_tg_policy_evaluate_group_call(opts, state, (uint32_t)eval_ctx->tg, (uint32_t)ev->src,
-                                             eval_ctx->encrypted_call, eval_ctx->data_call,
-                                             DSD_TG_POLICY_HOLD_COMPAT_GRANT, out_decision);
+    uint16_t members[8] = {0};
+    int member_count =
+        p25_patch_collect_active_wgids(state, eval_ctx->tg, members, sizeof(members) / sizeof(members[0]));
+    dsd_tg_policy_decision best;
+    dsd_tg_policy_decision first;
+    int have_best = 0;
+    int have_first = 0;
+    DSD_MEMSET(&best, 0, sizeof(best));
+    DSD_MEMSET(&first, 0, sizeof(first));
+
+    for (int i = 0; i <= member_count; i++) {
+        uint32_t target = (i == 0) ? (uint32_t)eval_ctx->tg : (uint32_t)members[i - 1];
+        dsd_tg_policy_decision candidate;
+        if (i > 0 && (target == 0U || target == (uint32_t)eval_ctx->tg)) {
+            continue;
+        }
+        if (dsd_tg_policy_evaluate_group_call(opts, state, target, (uint32_t)ev->src, eval_ctx->encrypted_call,
+                                              eval_ctx->data_call, DSD_TG_POLICY_HOLD_COMPAT_GRANT, &candidate)
+            != 0) {
+            return -1;
+        }
+        if (!have_first) {
+            first = candidate;
+            have_first = 1;
+        }
+        if (!candidate.tune_allowed) {
+            continue;
+        }
+        if (!have_best || (candidate.tg_hold_match && !best.tg_hold_match)
+            || (candidate.tg_hold_match == best.tg_hold_match && candidate.priority > best.priority)
+            || (candidate.tg_hold_match == best.tg_hold_match && candidate.priority == best.priority
+                && candidate.preempt_requested && !best.preempt_requested)) {
+            best = candidate;
+            have_best = 1;
+        }
+    }
+
+    *out_decision = have_best ? best : first;
+    return have_first ? 0 : -1;
 }
 
 static int
@@ -720,9 +756,10 @@ p25_grant_handle_policy_block(dsd_opts* opts, dsd_state* state, const p25_grant_
         return 0;
     }
     p25_sm_diagf((dsd_opts*)opts, state, NULL, "grant_block",
-                 "reason=%s tg=%d svc=0x%02X data=%d enc=%d indiv=%d block=0x%08X",
-                 grant_block_log_tag(eval_ctx->is_indiv, decision->block_reasons), eval_ctx->tg, eval_ctx->svc,
-                 eval_ctx->data_call, eval_ctx->encrypted_call, eval_ctx->is_indiv, decision->block_reasons);
+                 "reason=%s tg=%d policy_tg=%u svc=0x%02X data=%d enc=%d indiv=%d block=0x%08X",
+                 grant_block_log_tag(eval_ctx->is_indiv, decision->block_reasons), eval_ctx->tg, decision->target_id,
+                 eval_ctx->svc, eval_ctx->data_call, eval_ctx->encrypted_call, eval_ctx->is_indiv,
+                 decision->block_reasons);
     sm_log(opts, state, grant_block_log_tag(eval_ctx->is_indiv, decision->block_reasons));
     if (!eval_ctx->is_indiv && eval_ctx->tg > 0 && (decision->block_reasons & DSD_TG_POLICY_BLOCK_ENCRYPTED_DISABLED)) {
         p25_emit_enc_lockout_once(opts, state, 0, eval_ctx->tg, eval_ctx->svc);
@@ -1001,6 +1038,23 @@ p25_grant_handle_duplicate(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_st
     return 1;
 }
 
+static void
+p25_grant_store_policy_tg(dsd_state* state, const p25_sm_event_t* ev, int slot,
+                          const dsd_tg_policy_decision* decision) {
+    if (!state || !ev || !decision || !ev->is_group) {
+        return;
+    }
+
+    uint32_t policy_tg =
+        (decision->target_id > 0U && decision->target_id != (uint32_t)ev->tg) ? decision->target_id : 0U;
+    if (slot >= 0 && slot <= 1) {
+        state->p25_policy_tg[slot] = policy_tg;
+        return;
+    }
+    state->p25_policy_tg[0] = policy_tg;
+    state->p25_policy_tg[1] = 0;
+}
+
 static int
 p25_retune_block_slot_matches(int blocked_slot, int grant_slot) {
     return blocked_slot == grant_slot;
@@ -1141,6 +1195,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     // Skip if already tuned to same frequency AND same TG (avoid bounce on duplicate grants)
     // Different TG/call type should still trigger a new tune
     if (p25_grant_handle_duplicate(ctx, opts, state, &route, &decision, freq, target_id, now_m)) {
+        p25_grant_store_policy_tg(state, ev, slot, &decision);
         return;
     }
 
@@ -1155,6 +1210,9 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     }
     p25_grant_store_vc_context(ctx, state, ev, freq, target_id, now_m);
     p25_grant_clear_slot_state(ctx);
+    state->p25_policy_tg[0] = 0;
+    state->p25_policy_tg[1] = 0;
+    p25_grant_store_policy_tg(state, ev, slot, &decision);
     ctx->tune_count++;
     ctx->grant_count++;
     p25_grant_debug_log_tdma(opts, state, ctx, ev, freq, ted_sps);
@@ -1162,9 +1220,9 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     state->p25_sm_tune_count++;
     (void)dsd_tg_policy_note_active_call(state, &route, &decision, now_m);
     p25_sm_diagf(opts, state, ctx, "grant_accept",
-                 "ch=0x%04X freq=%ld slot=%d target=%d src=%d needs_retune=%d "
+                 "ch=0x%04X freq=%ld slot=%d target=%d ota_tg=%d src=%d needs_retune=%d "
                  "prio=%d preempt=%d",
-                 ev->channel & 0xFFFF, freq, slot, target_id, ev->src, needs_retune, decision.priority,
+                 ev->channel & 0xFFFF, freq, slot, target_id, ev->tg, ev->src, needs_retune, decision.priority,
                  decision.preempt_requested);
 
     set_state(ctx, opts, state, P25_SM_TUNED, "grant");
@@ -1517,6 +1575,8 @@ p25_release_clear_decoder_state(dsd_opts* opts, dsd_state* state) {
         state->p25_service_options_valid[1] = 0;
         state->p25_p2_enc_lockout_muted[0] = 0;
         state->p25_p2_enc_lockout_muted[1] = 0;
+        state->p25_policy_tg[0] = 0;
+        state->p25_policy_tg[1] = 0;
         state->p25_sm_release_count++;
     }
     if (opts) {
@@ -2376,6 +2436,7 @@ p25_emit_enc_lockout_once(dsd_opts* opts, dsd_state* state, uint8_t slot, int tg
         state->dmr_soR = (uint16_t)svc_bits;
         state->p25_service_options_valid[1] = (svc_bits != 0) ? 1U : 0U;
     }
+    state->p25_policy_tg[slot & 1] = 0;
     state->gi[slot & 1] = 0;
 
     // Compose event text and push

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1219,7 +1219,7 @@ p25_grant_should_clear_slot_only(const p25_sm_ctx_t* ctx, const dsd_state* state
 }
 
 static int
-p25_grant_prepare_route(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev,
+p25_grant_prepare_route(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev,
                         const dsd_tg_policy_decision* decision, p25_grant_route_ctx_t* out) {
     p25_freq_trace_t freq_trace;
     if (!ctx || !opts || !state || !ev || !decision || !out) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -698,16 +698,26 @@ p25_grant_transient_enc_cache_blocks(dsd_opts* opts, dsd_state* state, const p25
 }
 
 static int
-p25_grant_eval_policy(const dsd_opts* opts, const dsd_state* state, const p25_sm_event_t* ev,
-                      const p25_grant_eval_ctx_t* eval_ctx, dsd_tg_policy_decision* out_decision) {
-    if (!opts || !state || !ev || !eval_ctx || !out_decision) {
-        return -1;
+p25_grant_policy_candidate_is_better(const dsd_tg_policy_decision* candidate, const dsd_tg_policy_decision* best,
+                                     int have_best) {
+    if (!candidate || !candidate->tune_allowed) {
+        return 0;
     }
-    if (eval_ctx->is_indiv) {
-        return dsd_tg_policy_evaluate_private_call(
-            opts, state, (uint32_t)ev->src, (uint32_t)ev->dst, eval_ctx->encrypted_call, eval_ctx->data_call,
-            DSD_TG_POLICY_PRIVATE_ALLOWLIST_UNKNOWN_ALLOW, DSD_TG_POLICY_HOLD_COMPAT_GRANT, out_decision);
+    if (!have_best || !best) {
+        return 1;
     }
+    if (candidate->tg_hold_match != best->tg_hold_match) {
+        return candidate->tg_hold_match ? 1 : 0;
+    }
+    if (candidate->priority != best->priority) {
+        return (candidate->priority > best->priority) ? 1 : 0;
+    }
+    return (candidate->preempt_requested && !best->preempt_requested) ? 1 : 0;
+}
+
+static int
+p25_grant_eval_group_policy(const dsd_opts* opts, const dsd_state* state, const p25_sm_event_t* ev,
+                            const p25_grant_eval_ctx_t* eval_ctx, dsd_tg_policy_decision* out_decision) {
     uint16_t members[8] = {0};
     int member_count =
         p25_patch_collect_active_wgids(state, eval_ctx->tg, members, sizeof(members) / sizeof(members[0]));
@@ -733,20 +743,31 @@ p25_grant_eval_policy(const dsd_opts* opts, const dsd_state* state, const p25_sm
             first = candidate;
             have_first = 1;
         }
-        if (!candidate.tune_allowed) {
-            continue;
-        }
-        if (!have_best || (candidate.tg_hold_match && !best.tg_hold_match)
-            || (candidate.tg_hold_match == best.tg_hold_match && candidate.priority > best.priority)
-            || (candidate.tg_hold_match == best.tg_hold_match && candidate.priority == best.priority
-                && candidate.preempt_requested && !best.preempt_requested)) {
+        if (p25_grant_policy_candidate_is_better(&candidate, &best, have_best)) {
             best = candidate;
             have_best = 1;
         }
     }
 
+    if (!have_first) {
+        return -1;
+    }
     *out_decision = have_best ? best : first;
-    return have_first ? 0 : -1;
+    return 0;
+}
+
+static int
+p25_grant_eval_policy(const dsd_opts* opts, const dsd_state* state, const p25_sm_event_t* ev,
+                      const p25_grant_eval_ctx_t* eval_ctx, dsd_tg_policy_decision* out_decision) {
+    if (!opts || !state || !ev || !eval_ctx || !out_decision) {
+        return -1;
+    }
+    if (eval_ctx->is_indiv) {
+        return dsd_tg_policy_evaluate_private_call(
+            opts, state, (uint32_t)ev->src, (uint32_t)ev->dst, eval_ctx->encrypted_call, eval_ctx->data_call,
+            DSD_TG_POLICY_PRIVATE_ALLOWLIST_UNKNOWN_ALLOW, DSD_TG_POLICY_HOLD_COMPAT_GRANT, out_decision);
+    }
+    return p25_grant_eval_group_policy(opts, state, ev, eval_ctx, out_decision);
 }
 
 static int

--- a/src/protocol/p25/phase1/p25p1_mdpu.c
+++ b/src/protocol/p25/phase1/p25p1_mdpu.c
@@ -597,6 +597,7 @@ static void
 p25_mpdu_clear_last_call(dsd_state* state) {
     state->lasttg = 0;
     state->lastsrc = 0;
+    state->p25_policy_tg[0] = 0;
 }
 
 static void

--- a/src/protocol/p25/phase1/p25p1_pdu_data.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_data.c
@@ -793,10 +793,14 @@ p25_update_pdu_header_state(dsd_opts* opts, dsd_state* state, const P25PduHeader
         watchdog_event_datacall(opts, state, state->lastsrc, state->lasttg, state->dmr_lrrp_gps[0], 0);
         state->lastsrc = 0;
         state->lasttg = 0;
+        state->p25_policy_tg[0] = 0;
         watchdog_event_history(opts, state, 0);
         dsd_p25_optional_hook_watchdog_event_current(opts, state, 0);
     }
 
+    if ((uint32_t)state->lasttg != h->address) {
+        state->p25_policy_tg[0] = 0;
+    }
     state->lasttg = h->address;
     state->lastsrc = 0xFFFFFF; // none given, unless extended, so put any here for now
 }
@@ -1035,6 +1039,7 @@ p25_decode_pdu_data(dsd_opts* opts, dsd_state* state, uint8_t* input, int len) {
     watchdog_event_datacall(opts, state, state->lastsrc, state->lasttg, state->dmr_lrrp_gps[0], 0);
     state->lastsrc = 0;
     state->lasttg = 0;
+    state->p25_policy_tg[0] = 0;
     watchdog_event_history(opts, state, 0);
     dsd_p25_optional_hook_watchdog_event_current(opts, state, 0);
 }

--- a/src/protocol/p25/phase1/p25p1_pdu_trunking.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_trunking.c
@@ -465,24 +465,9 @@ p25_handle_mbt_group_voice_grant(dsd_opts* opts, dsd_state* state, const uint8_t
 
     p25p1_pdu_print_group_label(state, (uint32_t)group);
 
-    dsd_tg_policy_decision decision;
-    int enc_for_policy = (svc & 0x40) ? 1 : 0;
-    if (enc_for_policy && opts->trunk_tune_enc_calls == 0
-        && (p25_patch_tg_key_is_clear(state, group) || p25_patch_sg_key_is_clear(state, group))) {
-        enc_for_policy = 0;
-    }
-
-    if (dsd_tg_policy_evaluate_group_call(opts, state, (uint32_t)group, (uint32_t)source, enc_for_policy,
-                                          (svc & 0x10) ? 1 : 0, DSD_TG_POLICY_HOLD_COMPAT_GRANT, &decision)
-            != 0
-        || !decision.tune_allowed) {
-        if (decision.block_reasons & DSD_TG_POLICY_BLOCK_ENCRYPTED_DISABLED) {
-            p25_emit_enc_lockout_once(opts, state, 0, group, svc);
-        }
-        return;
-    }
-
     if (p25p1_pdu_can_tune_grant(opts, state, freq1)) {
+        // The trunk state machine owns group-grant policy so patched
+        // supergroup grants can be evaluated against their member talkgroups.
         p25_sm_on_group_grant(opts, state, channelt, svc, group, (int)source);
     }
 }
@@ -788,23 +773,9 @@ p25_handle_mbt_mfid90_group_regroup(dsd_opts* opts, dsd_state* state, const uint
 
     p25p1_pdu_print_group_label(state, (uint32_t)group);
 
-    dsd_tg_policy_decision decision;
-    int enc_for_policy = (svc & 0x40) ? 1 : 0;
-    if (enc_for_policy && opts->trunk_tune_enc_calls == 0 && p25_patch_sg_key_is_clear(state, group)) {
-        enc_for_policy = 0;
-    }
-
-    if (dsd_tg_policy_evaluate_group_call(opts, state, (uint32_t)group, (uint32_t)source, enc_for_policy,
-                                          (svc & 0x10) ? 1 : 0, DSD_TG_POLICY_HOLD_COMPAT_GRANT, &decision)
-            != 0
-        || !decision.tune_allowed) {
-        if (decision.block_reasons & DSD_TG_POLICY_BLOCK_ENCRYPTED_DISABLED) {
-            p25_emit_enc_lockout_once(opts, state, 0, group, svc);
-        }
-        return;
-    }
-
     if (p25p1_pdu_can_tune_grant(opts, state, freq1)) {
+        // The trunk state machine owns group-grant policy so patched
+        // supergroup grants can be evaluated against their member talkgroups.
         p25_sm_on_group_grant(opts, state, channelt, svc, group, (int)source);
     }
 }

--- a/src/protocol/p25/phase1/p25p1_pdu_trunking.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_trunking.c
@@ -226,14 +226,14 @@ p25p1_pdu_can_tune_grant(const dsd_opts* opts, dsd_state* state, long int freq) 
 }
 
 static void
-p25p1_pdu_dispatch_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc, int group, int source,
+p25p1_pdu_dispatch_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int group, int src,
                                long int freq) {
     // The trunk state machine owns group-grant policy so patched supergroup
     // grants can be evaluated against their member talkgroups.
     if (p25p1_pdu_can_tune_grant(opts, state, freq)) {
-        p25_sm_on_group_grant(opts, state, channel, svc, group, source);
+        p25_sm_on_group_grant(opts, state, channel, svc_bits, group, src);
     } else {
-        p25_sm_apply_group_grant_policy(opts, state, channel, svc, group, source);
+        p25_sm_apply_group_grant_policy(opts, state, channel, svc_bits, group, src);
     }
 }
 
@@ -450,21 +450,21 @@ p25_handle_mbt_tdma_iden_foreign_system(const uint8_t* mpdu_byte) {
 
 static void DSD_ATTR_USED
 p25_handle_mbt_group_voice_grant(dsd_opts* opts, dsd_state* state, const uint8_t* mpdu_byte) {
-    int svc = mpdu_byte[8];
+    int svc_bits = mpdu_byte[8];
     int channelt = (mpdu_byte[14] << 8) | mpdu_byte[15];
     int channelr = (mpdu_byte[16] << 8) | mpdu_byte[17];
-    long int source = (mpdu_byte[3] << 16) | (mpdu_byte[4] << 8) | mpdu_byte[5];
+    long int src = (mpdu_byte[3] << 16) | (mpdu_byte[4] << 8) | mpdu_byte[5];
     int group = (mpdu_byte[18] << 8) | mpdu_byte[19];
     long int freq1 = 0;
     long int freq2 = 0;
     UNUSED(freq2);
 
     DSD_FPRINTF(stderr, "%s\n ", KYEL);
-    p25_print_voice_svc_common(opts, state, svc);
+    p25_print_voice_svc_common(opts, state, svc_bits);
 
     DSD_FPRINTF(stderr, " Group Voice Channel Grant Update - Extended");
-    DSD_FPRINTF(stderr, "\n  SVC [%02X] CHAN-T [%04X] CHAN-R [%04X] Group [%d][%04X]", svc, channelt, channelr, group,
-                group);
+    DSD_FPRINTF(stderr, "\n  SVC [%02X] CHAN-T [%04X] CHAN-R [%04X] Group [%d][%04X]", svc_bits, channelt, channelr,
+                group, group);
 
     freq1 = process_channel_to_freq(opts, state, channelt);
     (void)process_channel_to_freq(opts, state, channelr);
@@ -477,7 +477,7 @@ p25_handle_mbt_group_voice_grant(dsd_opts* opts, dsd_state* state, const uint8_t
 
     p25p1_pdu_print_group_label(state, (uint32_t)group);
 
-    p25p1_pdu_dispatch_group_grant(opts, state, channelt, svc, group, (int)source, freq1);
+    p25p1_pdu_dispatch_group_grant(opts, state, channelt, svc_bits, group, (int)src, freq1);
 }
 
 static void DSD_ATTR_USED
@@ -752,23 +752,23 @@ p25_handle_mbt_mfid_a4(const uint8_t* mpdu_byte, int blks, uint8_t opcode, size_
 
 static void DSD_ATTR_USED
 p25_handle_mbt_mfid90_group_regroup(dsd_opts* opts, dsd_state* state, const uint8_t* mpdu_byte) {
-    int svc = mpdu_byte[8];
+    int svc_bits = mpdu_byte[8];
     int channelt = (mpdu_byte[12] << 8) | mpdu_byte[13];
     int channelr = (mpdu_byte[14] << 8) | mpdu_byte[15];
-    long int source = (mpdu_byte[3] << 16) | (mpdu_byte[4] << 8) | mpdu_byte[5];
+    long int src = (mpdu_byte[3] << 16) | (mpdu_byte[4] << 8) | mpdu_byte[5];
     int group = (mpdu_byte[16] << 8) | mpdu_byte[17];
     long int freq1 = 0;
     long int freq2 = 0;
     UNUSED(freq2);
 
     DSD_FPRINTF(stderr, "%s\n ", KYEL);
-    if (svc & 0x40) {
+    if (svc_bits & 0x40) {
         DSD_FPRINTF(stderr, " Encrypted");
     }
 
     DSD_FPRINTF(stderr, " MFID90 Group Regroup Channel Grant - Explicit");
-    DSD_FPRINTF(stderr, "\n  RES/P [%02X] CHAN-T [%04X] CHAN-R [%04X] SG [%d][%04X]", svc, channelt, channelr, group,
-                group);
+    DSD_FPRINTF(stderr, "\n  RES/P [%02X] CHAN-T [%04X] CHAN-R [%04X] SG [%d][%04X]", svc_bits, channelt, channelr,
+                group, group);
 
     freq1 = process_channel_to_freq(opts, state, channelt);
     (void)process_channel_to_freq(opts, state, channelr);
@@ -781,7 +781,7 @@ p25_handle_mbt_mfid90_group_regroup(dsd_opts* opts, dsd_state* state, const uint
 
     p25p1_pdu_print_group_label(state, (uint32_t)group);
 
-    p25p1_pdu_dispatch_group_grant(opts, state, channelt, svc, group, (int)source, freq1);
+    p25p1_pdu_dispatch_group_grant(opts, state, channelt, svc_bits, group, (int)src, freq1);
 }
 
 static void DSD_ATTR_USED

--- a/src/protocol/p25/phase1/p25p1_pdu_trunking.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_trunking.c
@@ -225,6 +225,18 @@ p25p1_pdu_can_tune_grant(const dsd_opts* opts, dsd_state* state, long int freq) 
     return state->p25_cc_freq != 0;
 }
 
+static void
+p25p1_pdu_dispatch_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc, int group, int source,
+                               long int freq) {
+    // The trunk state machine owns group-grant policy so patched supergroup
+    // grants can be evaluated against their member talkgroups.
+    if (p25p1_pdu_can_tune_grant(opts, state, freq)) {
+        p25_sm_on_group_grant(opts, state, channel, svc, group, source);
+    } else {
+        p25_sm_apply_group_grant_policy(opts, state, channel, svc, group, source);
+    }
+}
+
 static void DSD_ATTR_USED
 p25_mbt_try_bridge_iden_updates(dsd_opts* opts, dsd_state* state, const uint8_t* mpdu_byte, size_t mpdu_len,
                                 const p25p1_mbt_fields* fields) {
@@ -465,11 +477,7 @@ p25_handle_mbt_group_voice_grant(dsd_opts* opts, dsd_state* state, const uint8_t
 
     p25p1_pdu_print_group_label(state, (uint32_t)group);
 
-    if (p25p1_pdu_can_tune_grant(opts, state, freq1)) {
-        // The trunk state machine owns group-grant policy so patched
-        // supergroup grants can be evaluated against their member talkgroups.
-        p25_sm_on_group_grant(opts, state, channelt, svc, group, (int)source);
-    }
+    p25p1_pdu_dispatch_group_grant(opts, state, channelt, svc, group, (int)source, freq1);
 }
 
 static void DSD_ATTR_USED
@@ -773,11 +781,7 @@ p25_handle_mbt_mfid90_group_regroup(dsd_opts* opts, dsd_state* state, const uint
 
     p25p1_pdu_print_group_label(state, (uint32_t)group);
 
-    if (p25p1_pdu_can_tune_grant(opts, state, freq1)) {
-        // The trunk state machine owns group-grant policy so patched
-        // supergroup grants can be evaluated against their member talkgroups.
-        p25_sm_on_group_grant(opts, state, channelt, svc, group, (int)source);
-    }
+    p25p1_pdu_dispatch_group_grant(opts, state, channelt, svc, group, (int)source, freq1);
 }
 
 static void DSD_ATTR_USED

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -412,18 +412,28 @@ tsbk_deny_reason_str(uint8_t code) {
 }
 
 static void
-tsbk_handle_mfid90_extended_function(const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK]) {
+tsbk_handle_mfid90_extended_function(dsd_state* state, const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK]) {
     int class_id = tsbk_byte[2];
     int operand = tsbk_byte[3];
     int argument = tsbk_u24(tsbk_byte, 4);
     int target = tsbk_u24(tsbk_byte, 7);
+    int sg = argument & 0xFFFF;
 
     DSD_FPRINTF(stderr, "\n MFID90 (Moto) Extended Function Command\n");
     DSD_FPRINTF(stderr, "  Class [%02X] Operand [%02X] Arg [%06X] Target [%d]", class_id, operand, argument, target);
     if (class_id == 0x02 && operand == 0x00) {
         DSD_FPRINTF(stderr, " Create Supergroup");
+        if (sg != 0) {
+            p25_patch_prepare_grg_update(state, sg, /*is_patch*/ 1, /*active*/ 1, /*ssn*/ -1);
+            if (target != 0) {
+                p25_patch_add_wuid(state, sg, (uint32_t)target);
+            }
+        }
     } else if (class_id == 0x02 && operand == 0x01) {
         DSD_FPRINTF(stderr, " Cancel Supergroup");
+        if (sg != 0) {
+            p25_patch_clear_sg(state, sg);
+        }
     }
     DSD_FPRINTF(stderr, "\n");
 }
@@ -595,7 +605,7 @@ tsbk_handle_mfid90_regroup_grants(dsd_opts* opts, dsd_state* state, const uint8_
         case 0x01: tsbk_handle_mfid90_regroup_add_del(state, tsbk_byte, 0); break;
         case 0x02: tsbk_handle_mfid90_grant(opts, state, tsbk_byte); break;
         case 0x03: tsbk_handle_mfid90_grant_update(opts, state, tsbk_byte); break;
-        case 0x04: tsbk_handle_mfid90_extended_function(tsbk_byte); break;
+        case 0x04: tsbk_handle_mfid90_extended_function(state, tsbk_byte); break;
         case 0x05: tsbk_handle_mfid90_traffic_channel_id(tsbk_byte); break;
         default: return 0;
     }
@@ -647,25 +657,38 @@ tsbk_handle_mfid_a4(dsd_state* state, const uint8_t tsbk_byte[TSBK_BYTES_PER_BLO
 
     int sg = (tsbk_byte[3] << 8) | tsbk_byte[4];
     int key = (tsbk_byte[5] << 8) | tsbk_byte[6];
-    int add = (tsbk_byte[7] << 16) | (tsbk_byte[8] << 8) | tsbk_byte[9];
+    int alg = tsbk_byte[7];
+    int wgid = (tsbk_byte[8] << 8) | tsbk_byte[9];
+    int wuid = (tsbk_byte[7] << 16) | (tsbk_byte[8] << 8) | tsbk_byte[9];
     int tga = tsbk_byte[2] >> 5;
     int ssn = tsbk_byte[2] & 0x1F;
+    int is_patch = ((tga & 0x4) == 0) ? 1 : 0;
+    int active = (tga & 0x1) ? 1 : 0;
     DSD_FPRINTF(stderr, "%s", KYEL);
     DSD_FPRINTF(stderr, "\n MFID A4 (Harris) Group Regroup Explicit Encryption Command\n");
+    DSD_FPRINTF(stderr, "  SG: %d; KEY ID: %04X; ", sg, key);
     if ((tga & 0x2) == 2) {
-        DSD_FPRINTF(stderr, "  SG: %d; KEY ID: %04X; WGID: %d; ", sg, key, add);
-        p25_patch_add_wgid(state, sg, add);
+        DSD_FPRINTF(stderr, "ALG: %02X; WGID: %d; ", alg, wgid);
     } else {
-        DSD_FPRINTF(stderr, "  SG: %d; KEY ID: %04X; WUID: %d; ", sg, key, add);
-        p25_patch_add_wuid(state, sg, (uint32_t)add);
+        DSD_FPRINTF(stderr, "WUID: %d; ", wuid);
     }
     DSD_FPRINTF(stderr, (tga & 0x4) ? " Simulselect" : " Patch");
     DSD_FPRINTF(stderr, (tga & 0x1) ? " Active;" : " Inactive;");
     DSD_FPRINTF(stderr, " SSN: %02d \n", ssn);
-    int is_patch = ((tga & 0x4) == 0) ? 1 : 0;
-    int active = (tga & 0x1) ? 1 : 0;
-    p25_patch_update(state, sg, is_patch, active);
-    p25_patch_set_kas(state, sg, key, -1, ssn);
+    if (!p25_patch_prepare_grg_update(state, sg, is_patch, active, ssn)) {
+        return;
+    }
+    if ((tga & 0x2) == 2) {
+        if (wgid != 0) {
+            p25_patch_add_wgid(state, sg, wgid);
+        }
+        p25_patch_set_kas(state, sg, key, alg, ssn);
+    } else {
+        if (wuid != 0) {
+            p25_patch_add_wuid(state, sg, (uint32_t)wuid);
+        }
+        p25_patch_set_kas(state, sg, key, -1, ssn);
+    }
 }
 
 static uint32_t

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -3057,6 +3057,91 @@ BLOCK_END:
     ctx->iter_idx = i;
 }
 
+static int
+p25p2_vpdu_harris_a4_msg_len(int len_b, int len_grg) {
+    return (len_grg > 0 && len_grg < len_b) ? len_grg : len_b;
+}
+
+static void
+p25p2_vpdu_print_harris_a4_options(int tga, int ssn) {
+    DSD_FPRINTF(stderr, "\n MFID A4 (Harris) Group Regroup Explicit Encryption Command\n");
+    DSD_FPRINTF(stderr, (tga & 0x4) ? " Simulselect" : " Patch");
+    DSD_FPRINTF(stderr, (tga & 0x1) ? " Active;" : " Inactive;");
+    DSD_FPRINTF(stderr, " SSN: %02d;", ssn);
+}
+
+static int
+p25p2_vpdu_harris_a4_wgid_count(int msg_len) {
+    int count = (msg_len >= 11) ? ((msg_len - 9) / 2) : 0;
+    return (count > 4) ? 4 : count;
+}
+
+static int
+p25p2_vpdu_harris_a4_wuid_count(int msg_len) {
+    int count = (msg_len >= 11) ? ((msg_len - 8) / 3) : 0;
+    return (count > 3) ? 3 : count;
+}
+
+static void
+p25p2_vpdu_handle_harris_a4_wgid(dsd_state* state, const unsigned long long int* mac, int len_a, int msg_len,
+                                 int is_patch, int active, int ssn) {
+    int sg = (mac[5 + len_a] << 8) | mac[6 + len_a];
+    int key = (mac[7 + len_a] << 8) | mac[8 + len_a];
+    int alg = mac[9 + len_a];
+    DSD_FPRINTF(stderr, " SG: %d; KEY ID: %04X; ALG: %02X;\n  ", sg, key, alg);
+    if (!p25_patch_prepare_grg_update(state, sg, is_patch, active, ssn)) {
+        return;
+    }
+
+    int count = p25p2_vpdu_harris_a4_wgid_count(msg_len);
+    for (int wi = 0; wi < count && (10 + len_a + (wi * 2) + 1) < 24; wi++) {
+        int wgid = (mac[10 + len_a + (wi * 2)] << 8) | mac[11 + len_a + (wi * 2)];
+        DSD_FPRINTF(stderr, "WGID: %d; ", wgid);
+        if (wgid != 0) {
+            p25_patch_add_wgid(state, sg, wgid);
+        }
+    }
+    p25_patch_set_kas(state, sg, key, alg, ssn);
+}
+
+static void
+p25p2_vpdu_handle_harris_a4_wuid(dsd_state* state, const unsigned long long int* mac, int len_a, int msg_len,
+                                 int is_patch, int active, int ssn) {
+    int sg = (mac[5 + len_a] << 8) | mac[6 + len_a];
+    int key = (mac[7 + len_a] << 8) | mac[8 + len_a];
+    DSD_FPRINTF(stderr, "  SG: %d KEY ID: %04X", sg, key);
+    if (!p25_patch_prepare_grg_update(state, sg, is_patch, active, ssn)) {
+        return;
+    }
+
+    int count = p25p2_vpdu_harris_a4_wuid_count(msg_len);
+    for (int wi = 0; wi < count && (9 + len_a + (wi * 3) + 2) < 24; wi++) {
+        int wuid = (mac[9 + len_a + (wi * 3)] << 16) | (mac[10 + len_a + (wi * 3)] << 8) | mac[11 + len_a + (wi * 3)];
+        DSD_FPRINTF(stderr, " WUID: %d;", wuid);
+        if (wuid != 0) {
+            p25_patch_add_wuid(state, sg, (uint32_t)wuid);
+        }
+    }
+    p25_patch_set_kas(state, sg, key, -1, ssn);
+}
+
+static void
+p25p2_vpdu_handle_harris_a4_grg(dsd_state* state, const unsigned long long int* mac, int len_a, int len_b) {
+    int len_grg = mac[3 + len_a] & 0x3F;
+    int msg_len = p25p2_vpdu_harris_a4_msg_len(len_b, len_grg);
+    int tga = mac[4 + len_a] >> 5;
+    int ssn = mac[4 + len_a] & 0x1F;
+    int is_patch = ((tga & 0x4) == 0) ? 1 : 0;
+    int active = (tga & 0x1) ? 1 : 0;
+
+    p25p2_vpdu_print_harris_a4_options(tga, ssn);
+    if ((tga & 0x2) == 2) {
+        p25p2_vpdu_handle_harris_a4_wgid(state, mac, len_a, msg_len, is_patch, active, ssn);
+    } else {
+        p25p2_vpdu_handle_harris_a4_wuid(state, mac, len_a, msg_len, is_patch, active, ssn);
+    }
+}
+
 static void
 p25p2_vpdu_iter_block_37(p25p2_vpdu_ctx* ctx) {
     dsd_state* state VPDU_MAYBE_UNUSED = ctx->state;
@@ -3072,79 +3157,7 @@ p25p2_vpdu_iter_block_37(p25p2_vpdu_ctx* ctx) {
 
     if (MAC[1 + len_a] == 0xB0 && MAC[2 + len_a] == 0xA4) //&& MAC[2+len_a] == 0xA4
     {
-        int len_grg = MAC[3 + len_a] & 0x3F; //MFID Len in Octets
-        int msg_len = len_b;
-        int tga = MAC[4 + len_a] >> 5;   //3 bit TGA values from GRG_Options
-        int ssn = MAC[4 + len_a] & 0x1F; //5 bit SSN from from GRG_Options
-        int is_patch = ((tga & 0x4) == 0) ? 1 : 0;
-        int active = (tga & 0x1) ? 1 : 0;
-
-        if (len_grg > 0 && len_grg < msg_len) {
-            msg_len = len_grg;
-        }
-
-        DSD_FPRINTF(stderr, "\n MFID A4 (Harris) Group Regroup Explicit Encryption Command\n");
-        if ((tga & 4) == 4) {
-            DSD_FPRINTF(stderr, " Simulselect"); //one-way regroup
-        } else {
-            DSD_FPRINTF(stderr, " Patch"); //two-way regroup
-        }
-        if (tga & 1) {
-            DSD_FPRINTF(stderr, " Active;"); //activated
-        } else {
-            DSD_FPRINTF(stderr, " Inactive;"); //deactivated
-        }
-
-        DSD_FPRINTF(stderr, " SSN: %02d;", ssn);
-
-        if ((tga & 0x2) == 2) //group WGID to supergroup
-        {
-            int sg = (MAC[5 + len_a] << 8) | MAC[6 + len_a];
-            int key = (MAC[7 + len_a] << 8) | MAC[8 + len_a];
-            int alg = MAC[9 + len_a];
-            DSD_FPRINTF(stderr, " SG: %d; KEY ID: %04X; ALG: %02X;\n  ", sg, key, alg);
-            if (!p25_patch_prepare_grg_update(state, sg, is_patch, active, ssn)) {
-                goto BLOCK_END;
-            }
-
-            int count = (msg_len >= 11) ? ((msg_len - 9) / 2) : 0;
-            if (count > 4) {
-                count = 4;
-            }
-            for (int wi = 0; wi < count && (10 + len_a + (wi * 2) + 1) < 24; wi++) {
-                int wgid = (MAC[10 + len_a + (wi * 2)] << 8) | MAC[11 + len_a + (wi * 2)];
-                DSD_FPRINTF(stderr, "WGID: %d; ", wgid);
-                if (wgid != 0) {
-                    p25_patch_add_wgid(state, sg, wgid);
-                }
-            }
-            p25_patch_set_kas(state, sg, key, alg, ssn);
-
-        }
-
-        else if ((tga & 0x2) == 0) //individual WUID to supergroup
-        {
-            int sg = (MAC[5 + len_a] << 8) | MAC[6 + len_a];
-            int key = (MAC[7 + len_a] << 8) | MAC[8 + len_a];
-            DSD_FPRINTF(stderr, "  SG: %d KEY ID: %04X", sg, key);
-            if (!p25_patch_prepare_grg_update(state, sg, is_patch, active, ssn)) {
-                goto BLOCK_END;
-            }
-
-            int count = (msg_len >= 11) ? ((msg_len - 8) / 3) : 0;
-            if (count > 3) {
-                count = 3;
-            }
-            for (int wi = 0; wi < count && (9 + len_a + (wi * 3) + 2) < 24; wi++) {
-                int wuid =
-                    (MAC[9 + len_a + (wi * 3)] << 16) | (MAC[10 + len_a + (wi * 3)] << 8) | MAC[11 + len_a + (wi * 3)];
-                DSD_FPRINTF(stderr, " WUID: %d;", wuid);
-                if (wuid != 0) {
-                    p25_patch_add_wuid(state, sg, (uint32_t)wuid);
-                }
-            }
-            p25_patch_set_kas(state, sg, key, -1, ssn);
-        }
+        p25p2_vpdu_handle_harris_a4_grg(state, MAC, len_a, len_b);
     }
 
     if (len_b < 0) {

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -313,27 +313,6 @@ p25p2_mac_policy_flag(int svc_bits, int policy_override, int bit) {
     return (svc_bits & bit) ? 1 : 0;
 }
 
-static int
-p25p2_mac_group_enc_for_policy(const dsd_opts* opts, const dsd_state* state, int group, int svc_bits,
-                               int policy_encrypted_override) {
-    int enc_for_policy = p25p2_mac_policy_flag(svc_bits, policy_encrypted_override, 0x40);
-    if (!(enc_for_policy && policy_encrypted_override < 0 && opts->trunk_tune_enc_calls == 0)) {
-        return enc_for_policy;
-    }
-    if (p25_patch_tg_key_is_clear(state, group) || p25_patch_sg_key_is_clear(state, group)) {
-        return 0;
-    }
-    return enc_for_policy;
-}
-
-static int
-p25p2_mac_group_policy_allows(const dsd_opts* opts, const dsd_state* state, int group, int source, int enc_for_policy,
-                              int data_for_policy, dsd_tg_policy_decision* decision) {
-    int rc = dsd_tg_policy_evaluate_group_call(opts, state, (uint32_t)group, (uint32_t)source, enc_for_policy,
-                                               data_for_policy, DSD_TG_POLICY_HOLD_COMPAT_GRANT, decision);
-    return (rc == 0 && decision->tune_allowed);
-}
-
 /* Emit a compact JSON line for a P25 Phase 2 MAC PDU when enabled. */
 static void
 p25p2_emit_mac_json_if_enabled(const dsd_state* state, int xch_type, uint8_t mfid, uint8_t opcode, int slot, int len_b,
@@ -374,8 +353,10 @@ p25p2_emit_mac_json_if_enabled(const dsd_state* state, int xch_type, uint8_t mfi
 static void
 p25p2_mac_handle(const struct p25p2_mac_result* res, dsd_opts* opts, dsd_state* state, int channel, int svc_bits,
                  int group, int source, int policy_encrypted_override, int policy_data_override, int emit_enc_lockout) {
-    dsd_tg_policy_decision decision;
     (void)res;
+    (void)policy_encrypted_override;
+    (void)policy_data_override;
+    (void)emit_enc_lockout;
     if (!opts || !state) {
         return;
     }
@@ -383,15 +364,8 @@ p25p2_mac_handle(const struct p25p2_mac_result* res, dsd_opts* opts, dsd_state* 
         return;
     }
 
-    int enc_for_policy = p25p2_mac_group_enc_for_policy(opts, state, group, svc_bits, policy_encrypted_override);
-    int data_for_policy = p25p2_mac_policy_flag(svc_bits, policy_data_override, 0x10);
-    if (!p25p2_mac_group_policy_allows(opts, state, group, source, enc_for_policy, data_for_policy, &decision)) {
-        if (emit_enc_lockout && (decision.block_reasons & DSD_TG_POLICY_BLOCK_ENCRYPTED_DISABLED)) {
-            p25_emit_enc_lockout_once(opts, state, 0, group, svc_bits);
-        }
-        return;
-    }
-
+    // The trunk state machine owns group-grant policy so patched supergroup
+    // grants can be evaluated against their member talkgroups.
     p25_sm_on_group_grant(opts, state, channel, svc_bits, group, source);
 }
 

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -856,10 +856,33 @@ p25p2_vpdu_set_private_call_banner(dsd_state* state, int slot, int svc) {
     }
 }
 
+static int
+p25p2_vpdu_policy_tg_matches_patch_member(const dsd_state* state, int slot, int talkgroup) {
+    uint16_t wgids[8] = {0};
+    int count = 0;
+    uint32_t policy_tg = 0;
+    if (!state || slot < 0 || slot > 1 || talkgroup <= 0) {
+        return 0;
+    }
+
+    policy_tg = state->p25_policy_tg[slot & 1];
+    if (policy_tg == 0U || policy_tg > 0xFFFFU) {
+        return 0;
+    }
+
+    count = p25_patch_collect_active_wgids(state, talkgroup, wgids, sizeof(wgids) / sizeof(wgids[0]));
+    for (int i = 0; i < count && i < 8; i++) {
+        if ((uint32_t)wgids[i] == policy_tg) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static void
 p25p2_vpdu_update_group_last_ids(dsd_state* state, int slot, int talkgroup, int source) {
     int previous = (slot == 0) ? state->lasttg : state->lasttgR;
-    if (previous != talkgroup) {
+    if (previous != talkgroup && !p25p2_vpdu_policy_tg_matches_patch_member(state, slot & 1, talkgroup)) {
         state->p25_policy_tg[slot & 1] = 0;
     }
     if (slot == 0) {

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -767,6 +767,7 @@ p25p2_vpdu_clear_slot_banner(dsd_state* state, int slot) {
 static void
 p25p2_vpdu_gate_slot_audio(dsd_state* state, int slot) {
     state->p25_p2_audio_allowed[slot] = 0;
+    state->p25_policy_tg[slot & 1] = 0;
     p25_p2_audio_ring_reset(state, slot);
 }
 
@@ -883,6 +884,10 @@ p25p2_vpdu_set_private_call_banner(dsd_state* state, int slot, int svc) {
 
 static void
 p25p2_vpdu_update_group_last_ids(dsd_state* state, int slot, int talkgroup, int source) {
+    int previous = (slot == 0) ? state->lasttg : state->lasttgR;
+    if (previous != talkgroup) {
+        state->p25_policy_tg[slot & 1] = 0;
+    }
     if (slot == 0) {
         state->lasttg = talkgroup;
         if (source != 0) {
@@ -902,6 +907,7 @@ p25p2_vpdu_update_group_last_ids(dsd_state* state, int slot, int talkgroup, int 
 
 static void
 p25p2_vpdu_update_private_last_ids(dsd_state* state, int slot, int talkgroup, int source) {
+    state->p25_policy_tg[slot & 1] = 0;
     if (slot == 0) {
         state->lasttg = talkgroup;
         if (source != 0) {
@@ -3067,8 +3073,15 @@ p25p2_vpdu_iter_block_37(p25p2_vpdu_ctx* ctx) {
     if (MAC[1 + len_a] == 0xB0 && MAC[2 + len_a] == 0xA4) //&& MAC[2+len_a] == 0xA4
     {
         int len_grg = MAC[3 + len_a] & 0x3F; //MFID Len in Octets
-        int tga = MAC[4 + len_a] >> 5;       //3 bit TGA values from GRG_Options
-        int ssn = MAC[4 + len_a] & 0x1F;     //5 bit SSN from from GRG_Options
+        int msg_len = len_b;
+        int tga = MAC[4 + len_a] >> 5;   //3 bit TGA values from GRG_Options
+        int ssn = MAC[4 + len_a] & 0x1F; //5 bit SSN from from GRG_Options
+        int is_patch = ((tga & 0x4) == 0) ? 1 : 0;
+        int active = (tga & 0x1) ? 1 : 0;
+
+        if (len_grg > 0 && len_grg < msg_len) {
+            msg_len = len_grg;
+        }
 
         DSD_FPRINTF(stderr, "\n MFID A4 (Harris) Group Regroup Explicit Encryption Command\n");
         if ((tga & 4) == 4) {
@@ -3089,32 +3102,22 @@ p25p2_vpdu_iter_block_37(p25p2_vpdu_ctx* ctx) {
             int sg = (MAC[5 + len_a] << 8) | MAC[6 + len_a];
             int key = (MAC[7 + len_a] << 8) | MAC[8 + len_a];
             int alg = MAC[9 + len_a];
-            int t1 = (MAC[10 + len_a] << 8) | MAC[11 + len_a];
-            int t2 = (MAC[12 + len_a] << 8) | MAC[13 + len_a];
-            int t3 = (MAC[14 + len_a] << 8) | MAC[15 + len_a];
-            int t4 = (MAC[16 + len_a] << 8) | MAC[17 + len_a];
-            UNUSED4(t1, t2, t3, t4);
             DSD_FPRINTF(stderr, " SG: %d; KEY ID: %04X; ALG: %02X;\n  ", sg, key, alg);
-            int a = 0;
-            int wgid = 0;
-
-            for (int wi = 10; wi <= len_grg;) {
-                //failsafe to prevent oob array
-                if ((wi + len_a) > 20) {
-                    ctx->end_pdu = 1;
-                    goto BLOCK_END;
-                }
-                wgid = (MAC[10 + len_a + a] << 8) | MAC[11 + len_a + a];
-                DSD_FPRINTF(stderr, "WGID: %d; ", wgid);
-                p25_patch_add_wgid(state, sg, wgid);
-                a = a + 2;
-                wi = wi + 2;
+            if (!p25_patch_prepare_grg_update(state, sg, is_patch, active, ssn)) {
+                goto BLOCK_END;
             }
 
-            // Update patch tracker for this SG (two-way patch if bit4 of TGA is 0)
-            int is_patch = ((tga & 0x4) == 0) ? 1 : 0;
-            int active = (tga & 0x1) ? 1 : 0;
-            p25_patch_update(state, sg, is_patch, active);
+            int count = (msg_len >= 11) ? ((msg_len - 9) / 2) : 0;
+            if (count > 4) {
+                count = 4;
+            }
+            for (int wi = 0; wi < count && (10 + len_a + (wi * 2) + 1) < 24; wi++) {
+                int wgid = (MAC[10 + len_a + (wi * 2)] << 8) | MAC[11 + len_a + (wi * 2)];
+                DSD_FPRINTF(stderr, "WGID: %d; ", wgid);
+                if (wgid != 0) {
+                    p25_patch_add_wgid(state, sg, wgid);
+                }
+            }
             p25_patch_set_kas(state, sg, key, alg, ssn);
 
         }
@@ -3123,19 +3126,23 @@ p25p2_vpdu_iter_block_37(p25p2_vpdu_ctx* ctx) {
         {
             int sg = (MAC[5 + len_a] << 8) | MAC[6 + len_a];
             int key = (MAC[7 + len_a] << 8) | MAC[8 + len_a];
-            int t1 = (MAC[9 + len_a] << 16) | (MAC[10 + len_a] << 8) | MAC[11 + len_a];
-            int t2 = (MAC[12 + len_a] << 16) | (MAC[13 + len_a] << 8) | MAC[14 + len_a];
-            int t3 = (MAC[15 + len_a] << 16) | (MAC[16 + len_a] << 8) | MAC[17 + len_a];
             DSD_FPRINTF(stderr, "  SG: %d KEY ID: %04X", sg, key);
-            DSD_FPRINTF(stderr, " WUID: %d; WUID: %d; WUID: %d; ", t1, t2, t3);
-            p25_patch_add_wuid(state, sg, (uint32_t)t1);
-            p25_patch_add_wuid(state, sg, (uint32_t)t2);
-            p25_patch_add_wuid(state, sg, (uint32_t)t3);
+            if (!p25_patch_prepare_grg_update(state, sg, is_patch, active, ssn)) {
+                goto BLOCK_END;
+            }
 
-            // Update patch tracker
-            int is_patch = ((tga & 0x4) == 0) ? 1 : 0;
-            int active = (tga & 0x1) ? 1 : 0;
-            p25_patch_update(state, sg, is_patch, active);
+            int count = (msg_len >= 11) ? ((msg_len - 8) / 3) : 0;
+            if (count > 3) {
+                count = 3;
+            }
+            for (int wi = 0; wi < count && (9 + len_a + (wi * 3) + 2) < 24; wi++) {
+                int wuid =
+                    (MAC[9 + len_a + (wi * 3)] << 16) | (MAC[10 + len_a + (wi * 3)] << 8) | MAC[11 + len_a + (wi * 3)];
+                DSD_FPRINTF(stderr, " WUID: %d;", wuid);
+                if (wuid != 0) {
+                    p25_patch_add_wuid(state, sg, (uint32_t)wuid);
+                }
+            }
             p25_patch_set_kas(state, sg, key, -1, ssn);
         }
     }
@@ -4815,6 +4822,21 @@ p25p2_vpdu_handle_motorola_regroup_extended_function(const p25p2_vpdu_ctx* ctx) 
     DSD_FPRINTF(stderr, "\n  Class [%02X] Operand [%02X] Arg [%06X] Target [%d]", class_id, operand, argument, target);
     if (class_id == 0) {
         DSD_FPRINTF(stderr, " %s", p25_extended_function_class0_operand_label((uint8_t)operand));
+    } else if (class_id == 0x02 && operand == 0x00) {
+        int sg = argument & 0xFFFF;
+        DSD_FPRINTF(stderr, " Create Supergroup");
+        if (sg != 0) {
+            p25_patch_prepare_grg_update(ctx->state, sg, /*is_patch*/ 1, /*active*/ 1, /*ssn*/ -1);
+            if (target != 0) {
+                p25_patch_add_wuid(ctx->state, sg, (uint32_t)target);
+            }
+        }
+    } else if (class_id == 0x02 && operand == 0x01) {
+        int sg = argument & 0xFFFF;
+        DSD_FPRINTF(stderr, " Cancel Supergroup");
+        if (sg != 0) {
+            p25_patch_clear_sg(ctx->state, sg);
+        }
     }
 }
 

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -571,6 +571,7 @@ p25p2_xcch_handle_sacch_mac_idle(dsd_opts* opts, dsd_state* state, uint8_t slot,
     state->p25_p2_enc_lockout_muted[slot] = 0;
     p25p2_xcch_blank_slot_call_string(state, slot);
     p25p2_xcch_set_slot_audio_allowed(state, slot, 0);
+    state->p25_policy_tg[slot & 1] = 0;
     state->p25_call_is_packet[slot] = 0;
     state->p25_service_options_valid[slot] = 0;
     if (slot == 0) {

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -179,10 +179,6 @@ p25p2_xcch_set_slot_mi(dsd_state* state, int slot, unsigned long long int mi) {
 
 static void
 p25p2_xcch_set_slot_tg(dsd_state* state, int slot, int tg) {
-    int previous = (slot == 0) ? state->lasttg : state->lasttgR;
-    if (previous != tg) {
-        state->p25_policy_tg[slot & 1] = 0;
-    }
     if (slot == 0) {
         state->lasttg = tg;
     } else {

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -179,6 +179,10 @@ p25p2_xcch_set_slot_mi(dsd_state* state, int slot, unsigned long long int mi) {
 
 static void
 p25p2_xcch_set_slot_tg(dsd_state* state, int slot, int tg) {
+    int previous = (slot == 0) ? state->lasttg : state->lasttgR;
+    if (previous != tg) {
+        state->p25_policy_tg[slot & 1] = 0;
+    }
     if (slot == 0) {
         state->lasttg = tg;
     } else {
@@ -208,6 +212,7 @@ p25p2_xcch_clear_slot_ids(dsd_state* state, int slot) {
         state->lastsrcR = 0;
         state->lasttgR = 0;
     }
+    state->p25_policy_tg[slot & 1] = 0;
 }
 
 static void
@@ -456,6 +461,7 @@ p25p2_xcch_reset_idle_slot_facch(dsd_state* state, int slot) {
         state->lastsrcR = 0;
         state->lasttgR = 0;
     }
+    state->p25_policy_tg[slot & 1] = 0;
 }
 
 static int

--- a/tests/core/test_core_audio_group_gate.c
+++ b/tests/core/test_core_audio_group_gate.c
@@ -388,6 +388,34 @@ main(void) {
         rc |= expect_eq("case10b-rec-allow", allow, 0);
     }
 
+    // Case 10c: Dual-slot P25 SG calls must apply each slot's patched policy TG independently.
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    reset_state(st);
+    opts->trunk_use_allow_list = 1;
+    rc |= expect_eq("case10c-seed-right-member", seed_policy_group(st, 9602U, "A", "RIGHT-PATCH-MEMBER"), 0);
+    st->synctype = DSD_SYNC_P25P2_POS;
+    st->lasttg = 9600;
+    st->lasttgR = 9600;
+    st->lastsrc = 777003;
+    st->lastsrcR = 777004;
+    st->p25_policy_tg[0] = 9601U;
+    st->p25_policy_tg[1] = 9602U;
+    st->p25_patch_count = 1;
+    st->p25_patch_sgid[0] = 9600U;
+    st->p25_patch_is_patch[0] = 1U;
+    st->p25_patch_active[0] = 1U;
+    st->p25_patch_last_update[0] = time(NULL);
+    st->p25_patch_wgid_count[0] = 2U;
+    st->p25_patch_wgid[0][0] = 9601U;
+    st->p25_patch_wgid[0][1] = 9602U;
+    {
+        int outL = -1;
+        int outR = -1;
+        rc |= expect_eq("case10c-ret", dsd_audio_group_gate_dual(opts, st, 9600UL, 9600UL, 0, 0, &outL, &outR), 0);
+        rc |= expect_eq("case10c-outL", outL, 1);
+        rc |= expect_eq("case10c-outR", outR, 0);
+    }
+
     if (rc == 0) {
         printf("CORE_AUDIO_GROUP_GATE: OK\n");
     }

--- a/tests/core/test_core_audio_group_gate.c
+++ b/tests/core/test_core_audio_group_gate.c
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -52,6 +53,17 @@ seed_policy_group(dsd_state* st, uint32_t tg, const char* mode, const char* name
         return -1;
     }
     return dsd_tg_policy_append_exact(st, &row);
+}
+
+static void
+seed_active_patch_member(dsd_state* st, uint16_t sg, uint16_t wg) {
+    st->p25_patch_count = 1;
+    st->p25_patch_sgid[0] = sg;
+    st->p25_patch_is_patch[0] = 1U;
+    st->p25_patch_active[0] = 1U;
+    st->p25_patch_last_update[0] = time(NULL);
+    st->p25_patch_wgid_count[0] = 1U;
+    st->p25_patch_wgid[0][0] = wg;
 }
 
 static void
@@ -322,6 +334,59 @@ main(void) {
     st->lasttg = 0;
     st->gi[0] = 0;
     rc |= expect_eq("case9-target-zero-gi-unset", dsd_p25p2_decode_audio_allowed(opts, st, 0, 0), 0);
+
+    // Case 10: P25 patch-member policy targets are only honored while the OTA SG still owns the active member.
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    reset_state(st);
+    opts->trunk_use_allow_list = 1;
+    rc |= expect_eq("case10-seed-member", seed_policy_group(st, 9401U, "A", "PATCH-MEMBER"), 0);
+    st->synctype = DSD_SYNC_P25P2_POS;
+    st->currentslot = 0;
+    st->gi[0] = 0;
+    st->lasttg = 9400;
+    st->lastsrc = 777001;
+    st->p25_policy_tg[0] = 9401U;
+    st->p25_p2_audio_allowed[0] = 1U;
+    seed_active_patch_member(st, 9400U, 9401U);
+    {
+        int out = -1;
+        int allow = -1;
+        rc |= expect_eq("case10-aud-ret-valid", dsd_audio_group_gate_mono(opts, st, 9400UL, 0, &out), 0);
+        rc |= expect_eq("case10-aud-out-valid", out, 0);
+        rc |= expect_eq("case10-decode-valid", dsd_p25p2_decode_audio_allowed(opts, st, 0, 0), 1);
+        rc |= expect_eq("case10-rec-ret-valid", dsd_audio_record_gate_mono(opts, st, &allow), 0);
+        rc |= expect_eq("case10-rec-allow-valid", allow, 1);
+
+        st->p25_patch_active[0] = 0U;
+        rc |= expect_eq("case10-aud-ret-inactive", dsd_audio_group_gate_mono(opts, st, 9400UL, 0, &out), 0);
+        rc |= expect_eq("case10-aud-out-inactive", out, 1);
+        rc |= expect_eq("case10-decode-inactive", dsd_p25p2_decode_audio_allowed(opts, st, 0, 0), 0);
+        rc |= expect_eq("case10-rec-ret-inactive", dsd_audio_record_gate_mono(opts, st, &allow), 0);
+        rc |= expect_eq("case10-rec-allow-inactive", allow, 0);
+    }
+
+    // Case 10b: A live member from another SG must not be substituted for changed slot metadata.
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    reset_state(st);
+    opts->trunk_use_allow_list = 1;
+    rc |= expect_eq("case10b-seed-member", seed_policy_group(st, 9501U, "A", "OTHER-PATCH-MEMBER"), 0);
+    st->synctype = DSD_SYNC_P25P2_POS;
+    st->currentslot = 0;
+    st->gi[0] = 0;
+    st->lasttg = 9502;
+    st->lastsrc = 777002;
+    st->p25_policy_tg[0] = 9501U;
+    st->p25_p2_audio_allowed[0] = 1U;
+    seed_active_patch_member(st, 9500U, 9501U);
+    {
+        int out = -1;
+        int allow = -1;
+        rc |= expect_eq("case10b-aud-ret", dsd_audio_group_gate_mono(opts, st, 9502UL, 0, &out), 0);
+        rc |= expect_eq("case10b-aud-out", out, 1);
+        rc |= expect_eq("case10b-decode", dsd_p25p2_decode_audio_allowed(opts, st, 0, 0), 0);
+        rc |= expect_eq("case10b-rec-ret", dsd_audio_record_gate_mono(opts, st, &allow), 0);
+        rc |= expect_eq("case10b-rec-allow", allow, 0);
+    }
 
     if (rc == 0) {
         printf("CORE_AUDIO_GROUP_GATE: OK\n");

--- a/tests/core/test_core_init_state.c
+++ b/tests/core/test_core_init_state.c
@@ -107,6 +107,8 @@ main(void) {
     state->payload_keyid = 0x1234;
     state->payload_keyidR = 0x5678;
     state->p25_p2_enc_lockout_muted[0] = 1U;
+    state->p25_policy_tg[0] = 0x1234U;
+    state->p25_policy_tg[1] = 0x5678U;
     state->p25_mac_frag[0].active = 1U;
     state->p25_mac_frag[0].opcode = 0x89U;
     state->p25_mac_frag[0].data_len = 4U;
@@ -171,7 +173,7 @@ main(void) {
     if (state->payload_mi != 0ULL || state->payload_miR != 0ULL || state->payload_miN != 0ULL
         || state->payload_miP != 0ULL || state->payload_algid != 0 || state->payload_algidR != 0
         || state->payload_keyid != 0 || state->payload_keyidR != 0 || state->p25_p2_enc_lockout_muted[0] != 0U
-        || state->p25_p2_enc_lockout_muted[1] != 0U) {
+        || state->p25_p2_enc_lockout_muted[1] != 0U || state->p25_policy_tg[0] != 0U || state->p25_policy_tg[1] != 0U) {
         DSD_FPRINTF(stderr, "initState did not clear payload crypto metadata\n");
         freeState(state);
         free(state);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -651,6 +651,8 @@ seed_target0_p25_state(dsd_state* state) {
     state->p25_call_emergency[0] = 1;
     state->p25_call_priority[0] = 7;
     state->p25_call_is_packet[0] = 1;
+    state->p25_policy_tg[0] = 200;
+    state->p25_policy_tg[1] = 201;
 }
 
 static void
@@ -721,6 +723,8 @@ seed_target1_p25_state(dsd_state* state) {
     state->p25_call_emergency[0] = 0;
     state->p25_call_priority[0] = 2;
     state->p25_call_is_packet[0] = 0;
+    state->p25_policy_tg[0] = 901;
+    state->p25_policy_tg[1] = 902;
 }
 
 static int
@@ -730,7 +734,8 @@ expect_empty_target_p25_state(const dsd_state* state) {
         || state->p25_site_network_active_valid != 0 || state->p25_patch_count != 0 || state->p25_aff_count != 0
         || state->p25_ga_count != 0 || state->p25_nb_count != 0 || state->p25_secondary_cc_count != 0
         || state->p25_pending_announcement_count != 0 || state->p25_src_nid != 0 || state->p25_call_emergency[0] != 0
-        || state->p25_call_priority[0] != 0 || state->p25_call_is_packet[0] != 0) {
+        || state->p25_call_priority[0] != 0 || state->p25_call_is_packet[0] != 0 || state->p25_policy_tg[0] != 0
+        || state->p25_policy_tg[1] != 0) {
         DSD_FPRINTF(stderr, "target 0 P25 state leaked into empty target 1 snapshot\n");
         return 1;
     }
@@ -772,7 +777,7 @@ expect_target0_p25_state(const dsd_state* state) {
         || state->p25_nb_entries[0].lra != 0x55 || state->p25_nb_entries[0].lra_valid != 1
         || state->p25_nb_entries[0].cfva_valid != 1 || state->p25_nb_entries[0].last_seen != 444
         || state->p25_src_nid != 0xABCDE || state->p25_call_emergency[0] != 1 || state->p25_call_priority[0] != 7
-        || state->p25_call_is_packet[0] != 1) {
+        || state->p25_call_is_packet[0] != 1 || state->p25_policy_tg[0] != 200 || state->p25_policy_tg[1] != 201) {
         DSD_FPRINTF(stderr, "P25 neighbor/current-call state leaked across scan targets\n");
         test_rc = 1;
     }

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -83,6 +83,17 @@ seed_fdma_iden(dsd_state* st, int id) {
     st->p25_chan_tdma_explicit[id] = 1;
 }
 
+static void
+seed_tdma_iden(dsd_state* st, int id) {
+    st->p25_chan_iden = id;
+    st->p25_iden_tdma[id].base_freq = 851000000 / 5;
+    st->p25_iden_tdma[id].chan_type = 3;
+    st->p25_iden_tdma[id].chan_spac = 100;
+    st->p25_iden_tdma[id].trust = 2;
+    st->p25_iden_tdma[id].populated = 1;
+    st->p25_chan_tdma_explicit[id] = 2;
+}
+
 static int
 tg_policy_is_absent(const dsd_state* st, uint32_t tg) {
     dsd_tg_policy_lookup lookup;
@@ -307,6 +318,34 @@ main(void) {
     p25_sm_on_group_grant(&opts, &st, ch, /*svc*/ 0x00, /*tg*/ 1501, /*src*/ 2501);
     rc |= expect_true("patch member preempt tunes", st.p25_sm_tune_count == before + 1);
     rc |= expect_true("patch member preempt policy tg", st.p25_policy_tg[0] == 1502U);
+
+    // Same-frequency TDMA grants update one slot without clearing the other slot's patch policy mapping.
+    {
+        static dsd_opts dual_opts;
+        static dsd_state dual_st;
+        DSD_MEMSET(&dual_opts, 0, sizeof dual_opts);
+        DSD_MEMSET(&dual_st, 0, sizeof dual_st);
+        dual_opts.p25_trunk = 1;
+        dual_opts.trunk_tune_group_calls = 1;
+        dual_opts.trunk_tune_private_calls = 1;
+        dual_opts.trunk_tune_data_calls = 1;
+        dual_opts.trunk_tune_enc_calls = 1;
+        dual_opts.trunk_use_allow_list = 1;
+        dual_st.p25_cc_freq = 851000000;
+        seed_tdma_iden(&dual_st, id);
+        p25_sm_init(&dual_opts, &dual_st);
+
+        rc |= expect_true("seed dual slot member 0", seed_exact(&dual_st, 1502, "A", "SLOT0-MEMBER", 0, 0) == 0);
+        rc |= expect_true("seed dual slot member 1", seed_exact(&dual_st, 1602, "A", "SLOT1-MEMBER", 0, 0) == 0);
+        p25_patch_add_wgid(&dual_st, 1501, 1502);
+        p25_patch_add_wgid(&dual_st, 1601, 1602);
+
+        p25_sm_on_group_grant(&dual_opts, &dual_st, 0x100B, /*svc*/ 0x00, /*tg*/ 1601, /*src*/ 2601);
+        rc |= expect_true("dual slot1 policy tg stored", dual_st.p25_policy_tg[1] == 1602U);
+        p25_sm_on_group_grant(&dual_opts, &dual_st, 0x100A, /*svc*/ 0x00, /*tg*/ 1501, /*src*/ 2600);
+        rc |= expect_true("dual slot0 policy tg stored", dual_st.p25_policy_tg[0] == 1502U);
+        rc |= expect_true("dual slot1 policy tg preserved", dual_st.p25_policy_tg[1] == 1602U);
+    }
 
     (void)dsd_unsetenv("DSD_NEO_TG_PREEMPT_MIN_DWELL_MS");
     (void)dsd_unsetenv("DSD_NEO_TG_PREEMPT_COOLDOWN_MS");

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -5,8 +5,10 @@
 
 /* Verify policy-backed P25 grant filtering behavior in the trunk SM path. */
 
+#include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
@@ -136,6 +138,46 @@ main(void) {
     p25_sm_on_group_grant(&opts, &st, ch, /*svc*/ 0x00, /*tg*/ 1101, /*src*/ 2101);
     rc |= expect_true("group known A tunes", st.p25_sm_tune_count == before + 1);
 
+    // Active patch members can satisfy grant policy while the OTA target remains the supergroup.
+    p25_sm_on_release(&opts, &st);
+    opts.trunk_use_allow_list = 0;
+    st.tg_hold = 1401;
+    p25_patch_add_wgid(&st, 1400, 1401);
+    before = st.p25_sm_tune_count;
+    opts.p25_is_tuned = 0;
+    p25_sm_on_group_grant(&opts, &st, ch, /*svc*/ 0x00, /*tg*/ 1400, /*src*/ 2400);
+    rc |= expect_true("patch member hold tunes supergroup", st.p25_sm_tune_count == before + 1);
+    rc |= expect_true("patch member hold stores policy tg", st.p25_policy_tg[0] == 1401U);
+    st.synctype = DSD_SYNC_P25P1_POS;
+    st.lasttg = 1400;
+    st.lastsrc = 2400;
+    int enc = 1;
+    rc |= expect_true("patch member hold audio gate call", dsd_audio_group_gate_mono(&opts, &st, 1400, enc, &enc) == 0);
+    rc |= expect_true("patch member hold audio gate opens", enc == 0);
+    st.tg_hold = 0;
+
+    p25_sm_on_release(&opts, &st);
+    opts.trunk_use_allow_list = 1;
+    rc |= expect_true("seed patch member allow", seed_exact(&st, 1403, "A", "PATCH-MEMBER", 0, 0) == 0);
+    p25_patch_add_wgid(&st, 1402, 1403);
+    before = st.p25_sm_tune_count;
+    opts.p25_is_tuned = 0;
+    p25_sm_on_group_grant(&opts, &st, ch, /*svc*/ 0x00, /*tg*/ 1402, /*src*/ 2402);
+    rc |= expect_true("patch member allowlist tunes supergroup", st.p25_sm_tune_count == before + 1);
+    rc |= expect_true("patch member allowlist policy tg", st.p25_policy_tg[0] == 1403U);
+    st.synctype = DSD_SYNC_P25P2_POS;
+    st.lasttg = 1402;
+    st.lastsrc = 2402;
+    st.gi[0] = 0;
+    rc |= expect_true("patch member allowlist p2 media gate", dsd_p25p2_decode_audio_allowed(&opts, &st, 0, 0) == 1);
+
+    p25_sm_on_release(&opts, &st);
+    p25_patch_add_wgid(&st, 1404, 1405);
+    before = st.p25_sm_tune_count;
+    opts.p25_is_tuned = 0;
+    p25_sm_on_group_grant(&opts, &st, ch, /*svc*/ 0x00, /*tg*/ 1404, /*src*/ 2404);
+    rc |= expect_true("patch no policy match blocked by allowlist", st.p25_sm_tune_count == before);
+
     // Explicit mode blocks remain enforced.
     rc |= expect_true("seed group B", seed_exact(&st, 1102, "B", "BLOCK", 0, 0) == 0);
     before = st.p25_sm_tune_count;
@@ -251,6 +293,20 @@ main(void) {
     before = st.p25_sm_tune_count;
     p25_sm_on_group_grant(&opts, &st, ch, /*svc*/ 0x00, /*tg*/ 1202, /*src*/ 2202);
     rc |= expect_true("high preempt candidate tuned", st.p25_sm_tune_count == before + 1);
+
+    // Patch-member priority/preempt displaces using the matched member policy, not the OTA SG's default priority.
+    p25_sm_on_release(&opts, &st);
+    rc |= expect_true("seed patch active base", seed_exact(&st, 1500, "A", "PATCH-ACTIVE", 80, 0) == 0);
+    rc |= expect_true("seed patch member preempt", seed_exact(&st, 1502, "A", "PATCH-PREEMPT", 95, 1) == 0);
+    p25_patch_add_wgid(&st, 1501, 1502);
+    before = st.p25_sm_tune_count;
+    opts.p25_is_tuned = 0;
+    p25_sm_on_group_grant(&opts, &st, ch, /*svc*/ 0x00, /*tg*/ 1500, /*src*/ 2500);
+    rc |= expect_true("patch preempt active tuned", st.p25_sm_tune_count == before + 1);
+    before = st.p25_sm_tune_count;
+    p25_sm_on_group_grant(&opts, &st, ch, /*svc*/ 0x00, /*tg*/ 1501, /*src*/ 2501);
+    rc |= expect_true("patch member preempt tunes", st.p25_sm_tune_count == before + 1);
+    rc |= expect_true("patch member preempt policy tg", st.p25_policy_tg[0] == 1502U);
 
     (void)dsd_unsetenv("DSD_NEO_TG_PREEMPT_MIN_DWELL_MS");
     (void)dsd_unsetenv("DSD_NEO_TG_PREEMPT_COOLDOWN_MS");

--- a/tests/protocol/p25/test_p25_mbt_decode.c
+++ b/tests/protocol/p25/test_p25_mbt_decode.c
@@ -10,6 +10,7 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm_api.h>
 #include <dsd-neo/protocol/p25/p25p1_pdu_trunking.h>
 #include <stdbool.h>
@@ -39,6 +40,10 @@ static int g_last_indiv_channel;
 static int g_last_indiv_svc;
 static int g_last_indiv_dst;
 static int g_last_indiv_src;
+static int g_last_group_channel;
+static int g_last_group_svc;
+static int g_last_group_tg;
+static int g_last_group_src;
 
 static void
 sm_noop_init(dsd_opts* opts, dsd_state* state) {
@@ -50,11 +55,11 @@ static void
 sm_noop_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
     (void)opts;
     (void)state;
-    (void)channel;
-    (void)svc_bits;
-    (void)tg;
-    (void)src;
     g_group_grant_count++;
+    g_last_group_channel = channel;
+    g_last_group_svc = svc_bits;
+    g_last_group_tg = tg;
+    g_last_group_src = src;
 }
 
 static void
@@ -116,6 +121,10 @@ reset_indiv_grants(void) {
     g_last_indiv_svc = 0;
     g_last_indiv_dst = 0;
     g_last_indiv_src = 0;
+    g_last_group_channel = 0;
+    g_last_group_svc = 0;
+    g_last_group_tg = 0;
+    g_last_group_src = 0;
 }
 
 // Additional stubs referenced by linked objects (rigctl/rtl streaming)
@@ -318,6 +327,33 @@ build_ambtc_base(uint8_t* mbt, uint8_t opcode, uint8_t blocks, uint32_t header_a
 }
 
 static void
+build_ambtc_group_voice(uint8_t* mbt, uint8_t svc, uint16_t channelt, uint16_t channelr, uint16_t group,
+                        uint32_t source) {
+    build_ambtc_base(mbt, 0x00, 0x01, source);
+    mbt[8] = svc;
+    mbt[14] = (uint8_t)(channelt >> 8);
+    mbt[15] = (uint8_t)(channelt & 0xFFU);
+    mbt[16] = (uint8_t)(channelr >> 8);
+    mbt[17] = (uint8_t)(channelr & 0xFFU);
+    mbt[18] = (uint8_t)(group >> 8);
+    mbt[19] = (uint8_t)(group & 0xFFU);
+}
+
+static void
+build_ambtc_mfid90_group_regroup(uint8_t* mbt, uint8_t svc, uint16_t channelt, uint16_t channelr, uint16_t group,
+                                 uint32_t source) {
+    build_ambtc_base(mbt, 0x02, 0x01, source);
+    mbt[2] = 0x90;
+    mbt[8] = svc;
+    mbt[12] = (uint8_t)(channelt >> 8);
+    mbt[13] = (uint8_t)(channelt & 0xFFU);
+    mbt[14] = (uint8_t)(channelr >> 8);
+    mbt[15] = (uint8_t)(channelr & 0xFFU);
+    mbt[16] = (uint8_t)(group >> 8);
+    mbt[17] = (uint8_t)(group & 0xFFU);
+}
+
+static void
 build_ambtc_unit_answer(uint8_t* mbt) {
     build_ambtc_base(mbt, 0x05, 0x01, 0x0ABCDE);
     mbt[8] = 0x82;
@@ -514,6 +550,42 @@ main(void) {
     rc |= expect_eq_long("p25_cc_freq", cc, want_freq);
     rc |= expect_eq_long("p2_wacn", wacn, 0xABCDE);
     rc |= expect_eq_int("p2_sysid", sysid, 0x123);
+
+    // AMBTC Group Voice Channel Grant: patched SG dispatches when TG hold matches only a member WGID.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        uint8_t grant[48];
+        init_private_trunking(&opts, &state);
+        seed_fdma_iden(&state, 1);
+        state.tg_hold = 0x3333;
+        p25_patch_add_wgid(&state, 0x2222, 0x3333);
+        build_ambtc_group_voice(grant, 0x00, 0x100A, 0x100A, 0x2222, 0x010203);
+        reset_indiv_grants();
+        p25_decode_pdu_trunking(&opts, &state, grant);
+        rc |= expect_eq_int("mbt group patch member hold count", g_group_grant_count, 1);
+        rc |= expect_eq_int("mbt group patch member hold channel", g_last_group_channel, 0x100A);
+        rc |= expect_eq_int("mbt group patch member hold tg", g_last_group_tg, 0x2222);
+        rc |= expect_eq_int("mbt group patch member hold src", g_last_group_src, 0x010203);
+    }
+
+    // MFID90 Group Regroup Grant: patched SG dispatches when TG hold matches only a member WGID.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        uint8_t grant[48];
+        init_private_trunking(&opts, &state);
+        seed_fdma_iden(&state, 1);
+        state.tg_hold = 0x4444;
+        p25_patch_add_wgid(&state, 0x5555, 0x4444);
+        build_ambtc_mfid90_group_regroup(grant, 0x00, 0x100A, 0x100B, 0x5555, 0x010204);
+        reset_indiv_grants();
+        p25_decode_pdu_trunking(&opts, &state, grant);
+        rc |= expect_eq_int("mbt mfid90 patch member hold count", g_group_grant_count, 1);
+        rc |= expect_eq_int("mbt mfid90 patch member hold channel", g_last_group_channel, 0x100A);
+        rc |= expect_eq_int("mbt mfid90 patch member hold tg", g_last_group_tg, 0x5555);
+        rc |= expect_eq_int("mbt mfid90 patch member hold src", g_last_group_src, 0x010204);
+    }
 
     // AMBTC Unit-to-Unit Voice Channel Grant (0x04): resolved FDMA channel dispatches one private grant.
     {

--- a/tests/protocol/p25/test_p25_mbt_decode.c
+++ b/tests/protocol/p25/test_p25_mbt_decode.c
@@ -17,6 +17,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -242,6 +243,18 @@ expect_not_contains_text(const char* tag, const char* text, const char* needle) 
         return 1;
     }
     return 0;
+}
+
+static int
+expect_enc_tg_cache_contains(const char* tag, const dsd_state* state, uint32_t tg) {
+    time_t now = time(NULL);
+    for (int i = 0; i < DSD_P25_ENC_TG_CACHE_DEPTH; i++) {
+        if (state->p25_enc_tg_cache_tg[i] == tg && state->p25_enc_tg_cache_until[i] > now) {
+            return 0;
+        }
+    }
+    DSD_FPRINTF(stderr, "%s: missing active encrypted TG cache entry for %u\n", tag, tg);
+    return 1;
 }
 
 static void
@@ -585,6 +598,44 @@ main(void) {
         rc |= expect_eq_int("mbt mfid90 patch member hold channel", g_last_group_channel, 0x100A);
         rc |= expect_eq_int("mbt mfid90 patch member hold tg", g_last_group_tg, 0x5555);
         rc |= expect_eq_int("mbt mfid90 patch member hold src", g_last_group_src, 0x010204);
+    }
+
+    // Encrypted AMBTC group grants still arm lockout/cache policy when their channel is unresolved.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        uint8_t grant[48];
+        init_private_trunking(&opts, &state);
+        opts.trunk_tune_enc_calls = 0;
+        opts.p25_retune_backoff_s = 5.0;
+        build_ambtc_group_voice(grant, 0x40, 0x200A, 0x200A, 0x2345, 0x010205);
+        reset_indiv_grants();
+        p25_decode_pdu_trunking(&opts, &state, grant);
+        rc |= expect_eq_int("mbt group unresolved enc no grant", g_group_grant_count, 0);
+        rc |= expect_enc_tg_cache_contains("mbt group unresolved enc cache", &state, 0x2345);
+        rc |= expect_eq_long("mbt group unresolved enc lasttg", (long)state.lasttg, 0x2345);
+        rc |= expect_eq_int("mbt group unresolved enc svc valid", state.p25_service_options_valid[0], 1);
+        rc |= expect_eq_int("mbt group unresolved enc svc stored", state.dmr_so, 0x40);
+    }
+
+    // Encrypted MFID90 regroup grants keep the same policy side effects when the CC is unknown.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        uint8_t grant[48];
+        init_private_trunking(&opts, &state);
+        seed_fdma_iden(&state, 1);
+        state.p25_cc_freq = 0;
+        opts.trunk_tune_enc_calls = 0;
+        opts.p25_retune_backoff_s = 5.0;
+        build_ambtc_mfid90_group_regroup(grant, 0x40, 0x100A, 0x100B, 0x3456, 0x010206);
+        reset_indiv_grants();
+        p25_decode_pdu_trunking(&opts, &state, grant);
+        rc |= expect_eq_int("mbt mfid90 no cc enc no grant", g_group_grant_count, 0);
+        rc |= expect_enc_tg_cache_contains("mbt mfid90 no cc enc cache", &state, 0x3456);
+        rc |= expect_eq_long("mbt mfid90 no cc enc lasttg", (long)state.lasttg, 0x3456);
+        rc |= expect_eq_int("mbt mfid90 no cc enc svc valid", state.p25_service_options_valid[0], 1);
+        rc |= expect_eq_int("mbt mfid90 no cc enc svc stored", state.dmr_so, 0x40);
     }
 
     // AMBTC Unit-to-Unit Voice Channel Grant (0x04): resolved FDMA channel dispatches one private grant.

--- a/tests/protocol/p25/test_p25_p1_pdu_private_allowlist.c
+++ b/tests/protocol/p25/test_p25_p1_pdu_private_allowlist.c
@@ -265,6 +265,16 @@ p25_sm_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bit
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_sm_apply_group_grant_policy(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
+    (void)channel;
+    (void)src;
+    if (opts && state && opts->p25_trunk == 1 && opts->trunk_tune_enc_calls == 0 && (svc_bits & 0x40) && tg > 0) {
+        p25_emit_enc_lockout_once(opts, state, 0, tg, svc_bits);
+    }
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 p25_sm_on_indiv_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src) {
     (void)channel;
     (void)svc_bits;

--- a/tests/protocol/p25/test_p25_p1_tsbk_handlers.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_handlers.c
@@ -39,6 +39,7 @@ static int g_add_wuid_count;
 static int g_remove_wgid_count;
 static int g_update_count;
 static int g_kas_count;
+static int g_clear_count;
 static int g_seed_count;
 static int g_grant_count;
 static int g_mac_count;
@@ -48,6 +49,7 @@ static uint32_t g_last_wuid;
 static int g_last_update_patch;
 static int g_last_update_active;
 static int g_last_key;
+static int g_last_alg;
 static int g_last_ssn;
 static int g_last_grant_channel;
 static int g_last_grant_svc;
@@ -128,12 +130,36 @@ p25_patch_remove_wuid(dsd_state* state, int sgid, uint32_t wuid) {
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_patch_clear_sg(dsd_state* state, int sgid) {
+    (void)state;
+    g_clear_count++;
+    g_last_sg = sgid;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_patch_prepare_grg_update(dsd_state* state, int sgid, int is_patch, int active, int ssn) {
+    (void)state;
+    (void)ssn;
+    g_update_count++;
+    g_last_sg = sgid;
+    g_last_update_patch = is_patch;
+    g_last_update_active = active;
+    if (!active) {
+        g_clear_count++;
+        return 0;
+    }
+    return 1;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 p25_patch_set_kas(dsd_state* state, int sgid, int key, int alg, int ssn) {
     (void)state;
-    (void)alg;
     g_kas_count++;
     g_last_sg = sgid;
     g_last_key = key;
+    g_last_alg = alg;
     g_last_ssn = ssn;
 }
 
@@ -356,6 +382,7 @@ reset_calls(void) {
     g_remove_wgid_count = 0;
     g_update_count = 0;
     g_kas_count = 0;
+    g_clear_count = 0;
     g_seed_count = 0;
     g_grant_count = 0;
     g_mac_count = 0;
@@ -365,6 +392,7 @@ reset_calls(void) {
     g_last_update_patch = 0;
     g_last_update_active = 0;
     g_last_key = 0;
+    g_last_alg = 0;
     g_last_ssn = 0;
     g_last_grant_channel = 0;
     g_last_grant_svc = 0;
@@ -1085,26 +1113,71 @@ test_mfid_a4_patch_and_simulselect_paths(void) {
     int rc = 0;
     rc |= expect_int("a4 patch adds wgid", g_add_wgid_count, 1);
     rc |= expect_int("a4 patch sg", g_last_sg, 0x1234);
-    rc |= expect_int("a4 patch wgid", g_last_wgid, 0x010203);
+    rc |= expect_int("a4 patch wgid", g_last_wgid, 0x0203);
     rc |= expect_int("a4 patch update count", g_update_count, 1);
     rc |= expect_int("a4 patch is_patch", g_last_update_patch, 1);
     rc |= expect_int("a4 patch active", g_last_update_active, 1);
     rc |= expect_int("a4 patch kas key", g_last_key, 0xBEEF);
+    rc |= expect_int("a4 patch kas alg", g_last_alg, 0x01);
     rc |= expect_int("a4 patch kas ssn", g_last_ssn, 7);
 
     tsbk[2] = (uint8_t)((0x4 << 5) | 0x05);
     reset_calls();
     tsbk_handle_mfid_a4(&state, tsbk);
-    rc |= expect_int("a4 simulselect adds wuid", g_add_wuid_count, 1);
-    rc |= expect_int("a4 simulselect wuid", (int)g_last_wuid, 0x010203);
+    rc |= expect_int("a4 inactive clears", g_clear_count, 1);
+    rc |= expect_int("a4 inactive does not add wuid", g_add_wuid_count, 0);
     rc |= expect_int("a4 simulselect is_patch", g_last_update_patch, 0);
     rc |= expect_int("a4 simulselect inactive", g_last_update_active, 0);
-    rc |= expect_int("a4 simulselect ssn", g_last_ssn, 5);
+    rc |= expect_int("a4 inactive no kas", g_kas_count, 0);
+
+    tsbk[2] = (uint8_t)((0x1 << 5) | 0x06);
+    reset_calls();
+    tsbk_handle_mfid_a4(&state, tsbk);
+    rc |= expect_int("a4 active wuid adds", g_add_wuid_count, 1);
+    rc |= expect_int("a4 active wuid", (int)g_last_wuid, 0x010203);
+    rc |= expect_int("a4 active wuid ssn", g_last_ssn, 6);
 
     tsbk[0] = 0x31;
     reset_calls();
     tsbk_handle_mfid_a4(&state, tsbk);
     rc |= expect_int("a4 non-op ignored", g_add_wgid_count + g_add_wuid_count + g_update_count + g_kas_count, 0);
+    return rc;
+}
+
+static int
+test_mfid90_extended_function_supergroup_state(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    uint8_t tsbk[TSBK_BYTES_PER_BLOCK] = {0};
+    int rc = 0;
+
+    tsbk[2] = 0x02;
+    tsbk[3] = 0x00;
+    tsbk[4] = 0x00;
+    tsbk[5] = 0x12;
+    tsbk[6] = 0x34;
+    tsbk[7] = 0x01;
+    tsbk[8] = 0x02;
+    tsbk[9] = 0x03;
+    reset_calls();
+    tsbk_handle_mfid90_extended_function(&state, tsbk);
+    rc |= expect_int("mfid90 ext create update", g_update_count, 1);
+    rc |= expect_int("mfid90 ext create sg", g_last_sg, 0x1234);
+    rc |= expect_int("mfid90 ext create wuid count", g_add_wuid_count, 1);
+    rc |= expect_int("mfid90 ext create wuid", (int)g_last_wuid, 0x010203);
+
+    tsbk[3] = 0x01;
+    reset_calls();
+    tsbk_handle_mfid90_extended_function(&state, tsbk);
+    rc |= expect_int("mfid90 ext cancel clear", g_clear_count, 1);
+    rc |= expect_int("mfid90 ext cancel no add", g_add_wuid_count, 0);
+    rc |= expect_int("mfid90 ext cancel sg", g_last_sg, 0x1234);
+
+    tsbk[2] = 0x00;
+    tsbk[3] = 0x7F;
+    reset_calls();
+    tsbk_handle_mfid90_extended_function(&state, tsbk);
+    rc |= expect_int("mfid90 ext class0 metadata only", g_update_count + g_clear_count + g_add_wuid_count, 0);
     return rc;
 }
 
@@ -1451,6 +1524,7 @@ main(void) {
     rc |= test_standard_osp_data_channel_metadata_and_dispatch();
     rc |= test_mfid90_regroup_add_delete();
     rc |= test_mfid_a4_patch_and_simulselect_paths();
+    rc |= test_mfid90_extended_function_supergroup_state();
     rc |= test_mfid90_grant_seeds_trunk_state();
     rc |= test_mfid90_grant_update_trunk_dispatch();
     rc |= test_mfid90_queued_and_deny_callbacks();

--- a/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
@@ -359,6 +359,21 @@ p25_patch_remove_wgid(dsd_state* state, int sg, int wgid) {
 }
 
 void
+p25_patch_clear_sg(dsd_state* state, int sg) {
+    (void)state;
+    (void)sg;
+}
+
+int
+p25_patch_prepare_grg_update(dsd_state* state, int sg, int is_patch, int active, int ssn) {
+    (void)state;
+    (void)sg;
+    (void)is_patch;
+    (void)ssn;
+    return active ? 1 : 0;
+}
+
+void
 p25_patch_set_kas(dsd_state* state, int sg, int kas, int algid, int ssn) {
     (void)state;
     (void)sg;

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -8,9 +8,12 @@
  * Asserts trunking tune side-effects via test shim capture.
  */
 
+#include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm_api.h>
 #include <dsd-neo/protocol/p25/p25_vpdu.h>
@@ -146,6 +149,15 @@ expect_not_contains(const char* tag, const char* text, const char* needle) {
         return 1;
     }
     return 0;
+}
+
+static int
+seed_policy_group(dsd_state* st, uint32_t tg, const char* mode, const char* name) {
+    dsd_tg_policy_entry row;
+    if (dsd_tg_policy_make_exact_entry(tg, mode, name, DSD_TG_POLICY_SOURCE_IMPORTED, &row) != 0) {
+        return -1;
+    }
+    return dsd_tg_policy_append_exact(st, &row);
 }
 
 static int
@@ -1121,6 +1133,46 @@ main(void) {
         rc |= expect_eq_long("0x80 service options valid", state.p25_service_options_valid[0], 1);
         rc |= expect_eq_long("0x80 emergency state", state.p25_call_emergency[0], 1);
         rc |= expect_contains("0x80 call banner", state.call_string[0], "Emergency");
+    }
+
+    // Case D5e2: first regroup voice-user metadata preserves the patch-member policy target from the grant.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        opts.trunk_use_allow_list = 1;
+        state.synctype = DSD_SYNC_P25P2_POS;
+        state.currentslot = 0;
+        state.lasttg = 0x2222;
+        state.lastsrc = 0x010101;
+
+        rc |= expect_eq_long("0x80 policy seed member", seed_policy_group(&state, 0x1234, "A", "PATCH-MEMBER"), 0);
+        p25_patch_add_wgid(&state, 0x3456, 0x1234);
+        state.p25_policy_tg[0] = 0x1234;
+
+        MAC[1] = 0x80;
+        MAC[2] = 0x90;
+        MAC[3] = 0x00;
+        MAC[4] = 0x34;
+        MAC[5] = 0x56;
+        MAC[6] = 0x01;
+        MAC[7] = 0x02;
+        MAC[8] = 0x03;
+
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_eq_long("0x80 policy member last tg", state.lasttg, 0x3456);
+        rc |= expect_eq_long("0x80 policy member preserved", state.p25_policy_tg[0], 0x1234);
+        rc |= expect_eq_long("0x80 policy member audio", dsd_p25p2_decode_audio_allowed(&opts, &state, 0, 0), 1);
+
+        state.p25_policy_tg[0] = 0x7777;
+        MAC[4] = 0x45;
+        MAC[5] = 0x67;
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_eq_long("0x80 stale policy clears", state.p25_policy_tg[0], 0);
+
+        dsd_state_ext_free_all(&state);
     }
 
     // Case D5f: MFID90 0xA0 extended voice-user messages store service options.

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -149,6 +149,42 @@ expect_not_contains(const char* tag, const char* text, const char* needle) {
 }
 
 static int
+find_patch_idx(const dsd_state* st, uint16_t sgid) {
+    for (int i = 0; i < st->p25_patch_count && i < 8; i++) {
+        if (st->p25_patch_sgid[i] == sgid) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static int
+patch_has_wgid(const dsd_state* st, int idx, uint16_t wgid) {
+    if (!st || idx < 0 || idx >= 8) {
+        return 0;
+    }
+    for (int i = 0; i < st->p25_patch_wgid_count[idx] && i < 8; i++) {
+        if (st->p25_patch_wgid[idx][i] == wgid) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+patch_has_wuid(const dsd_state* st, int idx, uint32_t wuid) {
+    if (!st || idx < 0 || idx >= 8) {
+        return 0;
+    }
+    for (int i = 0; i < st->p25_patch_wuid_count[idx] && i < 8; i++) {
+        if (st->p25_patch_wuid[idx][i] == wuid) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
 read_capture_file(const char* path, char* out, size_t out_sz) {
     if (!path || !out || out_sz == 0) {
         return -1;
@@ -349,6 +385,169 @@ run_standard_regroup_voice_user_nonstandard_guard_case(void) {
     return rc;
 }
 
+static int
+test_harris_a4_grg_state_management(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    unsigned long long int MAC[24] = {0};
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    state.currentslot = 0;
+
+    MAC[1] = 0xB0;
+    MAC[2] = 0xA4;
+    MAC[3] = 0x11;
+    MAC[4] = (unsigned long long)((0x3 << 5) | 0x09); // active WGID patch, SSN 9
+    MAC[5] = 0x12;
+    MAC[6] = 0x34;
+    MAC[7] = 0xBE;
+    MAC[8] = 0xEF;
+    MAC[9] = 0x84;
+    MAC[10] = 0x11;
+    MAC[11] = 0x11;
+    MAC[12] = 0x00;
+    MAC[13] = 0x00;
+    MAC[14] = 0x22;
+    MAC[15] = 0x22;
+    MAC[16] = 0x33;
+    MAC[17] = 0x33;
+    process_MAC_VPDU(&opts, &state, 1, MAC);
+
+    int idx = find_patch_idx(&state, 0x1234);
+    rc |= expect_true("harris a4 wgid sg exists", idx >= 0);
+    if (idx >= 0) {
+        rc |= expect_eq_long("harris a4 wgid active", state.p25_patch_active[idx], 1);
+        rc |= expect_eq_long("harris a4 wgid patch", state.p25_patch_is_patch[idx], 1);
+        rc |= expect_eq_long("harris a4 wgid count", state.p25_patch_wgid_count[idx], 3);
+        rc |= expect_true("harris a4 wgid 1111", patch_has_wgid(&state, idx, 0x1111));
+        rc |= expect_true("harris a4 wgid 2222", patch_has_wgid(&state, idx, 0x2222));
+        rc |= expect_true("harris a4 wgid 3333", patch_has_wgid(&state, idx, 0x3333));
+        rc |= expect_eq_long("harris a4 key", state.p25_patch_key[idx], 0xBEEF);
+        rc |= expect_eq_long("harris a4 alg", state.p25_patch_alg[idx], 0x84);
+        rc |= expect_eq_long("harris a4 ssn", state.p25_patch_ssn[idx], 9);
+    }
+
+    DSD_MEMSET(MAC, 0, sizeof MAC);
+    MAC[1] = 0xB0;
+    MAC[2] = 0xA4;
+    MAC[3] = 0x0B;
+    MAC[4] = (unsigned long long)((0x3 << 5) | 0x0A); // SSN replacement
+    MAC[5] = 0x12;
+    MAC[6] = 0x34;
+    MAC[7] = 0xBE;
+    MAC[8] = 0xEF;
+    MAC[9] = 0x89;
+    MAC[10] = 0x44;
+    MAC[11] = 0x44;
+    process_MAC_VPDU(&opts, &state, 1, MAC);
+    idx = find_patch_idx(&state, 0x1234);
+    rc |= expect_true("harris a4 replacement sg exists", idx >= 0);
+    if (idx >= 0) {
+        rc |= expect_eq_long("harris a4 replacement count", state.p25_patch_wgid_count[idx], 1);
+        rc |= expect_true("harris a4 replacement new member", patch_has_wgid(&state, idx, 0x4444));
+        rc |= expect_true("harris a4 replacement stale member cleared", !patch_has_wgid(&state, idx, 0x1111));
+        rc |= expect_eq_long("harris a4 replacement alg", state.p25_patch_alg[idx], 0x89);
+        rc |= expect_eq_long("harris a4 replacement ssn", state.p25_patch_ssn[idx], 10);
+    }
+
+    DSD_MEMSET(MAC, 0, sizeof MAC);
+    MAC[1] = 0xB0;
+    MAC[2] = 0xA4;
+    MAC[3] = 0x0B;
+    MAC[4] = (unsigned long long)((0x2 << 5) | 0x0A); // inactive WGID command
+    MAC[5] = 0x12;
+    MAC[6] = 0x34;
+    MAC[7] = 0xBE;
+    MAC[8] = 0xEF;
+    MAC[9] = 0x89;
+    MAC[10] = 0x55;
+    MAC[11] = 0x55;
+    process_MAC_VPDU(&opts, &state, 1, MAC);
+    idx = find_patch_idx(&state, 0x1234);
+    rc |= expect_true("harris a4 inactive sg exists", idx >= 0);
+    if (idx >= 0) {
+        rc |= expect_eq_long("harris a4 inactive clears active", state.p25_patch_active[idx], 0);
+        rc |= expect_eq_long("harris a4 inactive clears members", state.p25_patch_wgid_count[idx], 0);
+        rc |= expect_eq_long("harris a4 inactive clears key", state.p25_patch_key_valid[idx], 0);
+    }
+
+    DSD_MEMSET(MAC, 0, sizeof MAC);
+    MAC[1] = 0xB0;
+    MAC[2] = 0xA4;
+    MAC[3] = 0x0E;
+    MAC[4] = (unsigned long long)((0x1 << 5) | 0x03); // active WUID patch, SSN 3
+    MAC[5] = 0x22;
+    MAC[6] = 0x22;
+    MAC[7] = 0x12;
+    MAC[8] = 0x34;
+    MAC[9] = 0x01;
+    MAC[10] = 0x02;
+    MAC[11] = 0x03;
+    MAC[12] = 0x00;
+    MAC[13] = 0x00;
+    MAC[14] = 0x00;
+    process_MAC_VPDU(&opts, &state, 1, MAC);
+    idx = find_patch_idx(&state, 0x2222);
+    rc |= expect_true("harris a4 wuid sg exists", idx >= 0);
+    if (idx >= 0) {
+        rc |= expect_eq_long("harris a4 wuid count ignores zero", state.p25_patch_wuid_count[idx], 1);
+        rc |= expect_true("harris a4 wuid member", patch_has_wuid(&state, idx, 0x010203));
+        rc |= expect_eq_long("harris a4 wuid key", state.p25_patch_key[idx], 0x1234);
+        rc |= expect_eq_long("harris a4 wuid ssn", state.p25_patch_ssn[idx], 3);
+    }
+
+    return rc;
+}
+
+static int
+test_motorola_extended_function_supergroup_state(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    unsigned long long int MAC[24] = {0};
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    MAC[1] = 0x84;
+    MAC[2] = 0x90;
+    MAC[4] = 0x02;
+    MAC[5] = 0x00;
+    MAC[6] = 0x00;
+    MAC[7] = 0x12;
+    MAC[8] = 0x34;
+    MAC[9] = 0x01;
+    MAC[10] = 0x02;
+    MAC[11] = 0x03;
+    process_MAC_VPDU(&opts, &state, 0, MAC);
+
+    int idx = find_patch_idx(&state, 0x1234);
+    rc |= expect_true("moto ext create sg exists", idx >= 0);
+    if (idx >= 0) {
+        rc |= expect_eq_long("moto ext create active", state.p25_patch_active[idx], 1);
+        rc |= expect_eq_long("moto ext create wuid count", state.p25_patch_wuid_count[idx], 1);
+        rc |= expect_true("moto ext create wuid", patch_has_wuid(&state, idx, 0x010203));
+    }
+
+    MAC[5] = 0x01;
+    process_MAC_VPDU(&opts, &state, 0, MAC);
+    idx = find_patch_idx(&state, 0x1234);
+    rc |= expect_true("moto ext cancel sg exists", idx >= 0);
+    if (idx >= 0) {
+        rc |= expect_eq_long("moto ext cancel inactive", state.p25_patch_active[idx], 0);
+        rc |= expect_eq_long("moto ext cancel clears wuid", state.p25_patch_wuid_count[idx], 0);
+    }
+
+    DSD_MEMSET(&state, 0, sizeof state);
+    MAC[4] = 0x00;
+    MAC[5] = 0x7F;
+    process_MAC_VPDU(&opts, &state, 0, MAC);
+    rc |= expect_eq_long("moto ext class0 metadata only", state.p25_patch_count, 0);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -359,6 +558,9 @@ main(void) {
     const int iden = 1, type = 1, tdma = 0, spac = 100; // 100*125 = 12.5 kHz
     const long base = 170200000;                        // 170200000*5 = 851,000,000 Hz
     const long cc = 851000000;                          // non-zero CC freq enables tuning
+
+    rc |= test_harris_a4_grg_state_management();
+    rc |= test_motorola_extended_function_supergroup_state();
 
     // Case A: MFID 0x90, opcode A3 (Group Regroup Channel Grant - Implicit)
     {

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -811,7 +811,46 @@ main(void) {
         rc |= expect_eq_long("0xC0 service options valid", state.p25_service_options_valid[0], 1);
     }
 
-    // Case D5a: MFID90 0xA3 propagates service options and source.
+    // Case D5a: patched-supergroup grants dispatch to the SM even when TG hold matches only a member WGID.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        opts.trunk_tune_enc_calls = 1;
+        state.p25_cc_freq = cc;
+        state.tg_hold = 0x3333;
+        seed_fdma_iden(&state, iden, type, base, spac);
+        p25_patch_add_wgid(&state, 0x2222, 0x3333);
+
+        MAC[1] = 0xC0;
+        MAC[2] = 0x23;
+        MAC[3] = 0x10;
+        MAC[4] = 0x0C;
+        MAC[5] = 0x10;
+        MAC[6] = 0x0D;
+        MAC[7] = 0x22;
+        MAC[8] = 0x22;
+        MAC[9] = 0x01;
+        MAC[10] = 0x02;
+        MAC[11] = 0x03;
+
+        reset_group_grant_capture();
+        p25_sm_api api = {0};
+        api.on_group_grant = sm_on_group_grant_capture;
+        p25_sm_set_api(&api);
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        p25_sm_reset_api();
+
+        rc |= expect_eq_long("0xC0 patch member hold dispatch", g_group_grant_called, 1);
+        rc |= expect_eq_long("0xC0 patch member hold tg", g_group_grant_tg, 0x2222);
+        rc |= expect_eq_long("0xC0 patch member hold src", g_group_grant_src, 0x010203);
+    }
+
+    // Case D5b: MFID90 0xA3 propagates service options and source.
     {
         static dsd_opts opts;
         static dsd_state state;
@@ -851,7 +890,7 @@ main(void) {
         rc |= expect_eq_long("0xA3 emergency state", state.p25_call_emergency[0], 1);
     }
 
-    // Case D5b: MFID90 0xA4 propagates service options, source, and CHAN-R cache.
+    // Case D5c: MFID90 0xA4 propagates service options, source, and CHAN-R cache.
     {
         static dsd_opts opts;
         static dsd_state state;
@@ -1048,15 +1087,11 @@ main(void) {
         MAC[10] = 0x02;
         MAC[11] = 0x03;
 
-        reset_group_grant_capture();
-        p25_sm_api api = {0};
-        api.on_group_grant = sm_on_group_grant_capture;
-        p25_sm_set_api(&api);
         process_MAC_VPDU(&opts, &state, 0, MAC);
-        p25_sm_reset_api();
 
-        rc |= expect_eq_long("0xA3 encrypted blocked capture", g_group_grant_called, 0);
         rc |= expect_true("0xA3 encrypted blocked no tune", opts.p25_is_tuned == 0);
+        rc |= expect_eq_long("0xA3 encrypted cache tg", state.p25_enc_tg_cache_tg[0], 0x2222);
+        rc |= expect_true("0xA3 encrypted cache armed", state.p25_enc_tg_cache_until[0] > time(NULL));
         rc |= expect_contains("0xA3 encrypted active", state.active_channel[0], "MFID90 Active Ch: 100A");
     }
 

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -507,6 +507,7 @@ test_sacch_end_idle_active_hangtime_dispatch(void) {
     state.p25_p2_audio_allowed[1] = 1;
     state.p25_p2_enc_lockout_muted[1] = 1;
     state.p25_call_is_packet[1] = 1;
+    state.p25_policy_tg[1] = 0x5678;
     DSD_SNPRINTF(state.call_string[1], sizeof(state.call_string[1]), "%s", "packet");
     pack_payload_from_mac(payload, 180, mac, 0x3, 0, 0);
 
@@ -517,6 +518,7 @@ test_sacch_end_idle_active_hangtime_dispatch(void) {
     rc |= expect_int("sacch idle burst", (int)state.dmrburstR, 24);
     rc |= expect_int("sacch idle gate clear", state.p25_p2_audio_allowed[1], 0);
     rc |= expect_int("sacch idle packet clear", state.p25_call_is_packet[1], 0);
+    rc |= expect_int("sacch idle policy clear", (int)state.p25_policy_tg[1], 0);
     rc |= expect_int("sacch idle mute clear", state.p25_p2_enc_lockout_muted[1], 0);
     rc |= expect_int("sacch idle call blank", strncmp(state.call_string[1], P25P2_EMPTY_CALL_STRING, 21), 0);
 

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -275,11 +275,13 @@ test_slot_ptt_and_end_helpers(void) {
     state.p25_p2_enc_lockout_muted[0] = 1;
     state.fourv_counter[0] = 9;
     state.voice_counter[0] = 7;
+    state.p25_policy_tg[0] = 0x5678;
     fill_mac(mac, 0x84, 0x2468, 0x010203, 0x1234);
 
     p25p2_xcch_handle_ptt_slot(&opts, &state, mac, 0, 0);
     rc |= expect_int("slot0 lastsrc", state.lastsrc, 0x010203);
     rc |= expect_int("slot0 lasttg", state.lasttg, 0x1234);
+    rc |= expect_int("slot0 policy tg preserved", (int)state.p25_policy_tg[0], 0x5678);
     rc |= expect_int("slot0 algid", state.payload_algid, 0x84);
     rc |= expect_int("slot0 keyid", state.payload_keyid, 0x2468);
     rc |= expect_u64("slot0 mi", state.payload_miP, 0x1122334455667788ULL);

--- a/tests/protocol/p25/test_p25_patch_tracking.c
+++ b/tests/protocol/p25/test_p25_patch_tracking.c
@@ -132,9 +132,11 @@ test_guard_replacement_and_policy_edges(void) {
 
     DSD_MEMSET(&st, 0, sizeof st);
     st.p25_patch_count = 8;
+    time_t base = time(NULL);
     for (int i = 0; i < 8; i++) {
         st.p25_patch_sgid[i] = (uint16_t)(100 + i);
-        st.p25_patch_last_update[i] = (time_t)(1000 + i);
+        st.p25_patch_last_update[i] = base - (8 - i);
+        st.p25_patch_active[i] = 1;
         st.p25_patch_wgid_count[i] = 1;
         st.p25_patch_key_valid[i] = 1;
     }
@@ -144,6 +146,40 @@ test_guard_replacement_and_policy_edges(void) {
     rc |= expect_eq_int("replacement clears wgid count", st.p25_patch_wgid_count[0], 0);
     rc |= expect_eq_int("replacement clears key valid", st.p25_patch_key_valid[0], 0);
     rc |= expect_eq_int("replacement stores simulselect", st.p25_patch_is_patch[0], 0);
+
+    DSD_MEMSET(&st, 0, sizeof st);
+    st.p25_patch_count = 8;
+    base = time(NULL);
+    for (int i = 0; i < 8; i++) {
+        st.p25_patch_sgid[i] = (uint16_t)(200 + i);
+        st.p25_patch_active[i] = 1;
+        st.p25_patch_last_update[i] = base - (8 - i);
+        st.p25_patch_wgid_count[i] = 1;
+        st.p25_patch_wgid[i][0] = (uint16_t)(300 + i);
+    }
+    p25_patch_clear_sg(&st, 205);
+    p25_patch_update(&st, 299, 1, 1);
+    rc |= expect_eq_int("inactive slot reused count", st.p25_patch_count, 8);
+    rc |= expect_true("inactive slot reused new sg", find_idx(&st, 299) >= 0);
+    rc |= expect_true("inactive slot reuse preserves active oldest", find_idx(&st, 200) >= 0);
+    int reused = find_idx(&st, 299);
+    if (reused >= 0) {
+        rc |= expect_eq_int("inactive slot reused clears members", st.p25_patch_wgid_count[reused], 0);
+        rc |= expect_eq_int("inactive slot reused active", st.p25_patch_active[reused], 1);
+    }
+
+    DSD_MEMSET(&st, 0, sizeof st);
+    st.p25_patch_count = 8;
+    base = time(NULL);
+    for (int i = 0; i < 8; i++) {
+        st.p25_patch_sgid[i] = (uint16_t)(400 + i);
+        st.p25_patch_active[i] = 1;
+        st.p25_patch_last_update[i] = base;
+    }
+    p25_patch_update(&st, 499, 1, 0);
+    rc |= expect_eq_int("inactive full table does not evict count", st.p25_patch_count, 8);
+    rc |= expect_true("inactive full table preserves active oldest", find_idx(&st, 400) >= 0);
+    rc |= expect_true("inactive full table skips new inactive", find_idx(&st, 499) < 0);
 
     DSD_MEMSET(&st, 0, sizeof st);
     p25_patch_update(&st, 10, 1, 1);

--- a/tests/protocol/p25/test_p25_patch_tracking.c
+++ b/tests/protocol/p25/test_p25_patch_tracking.c
@@ -188,6 +188,38 @@ test_guard_replacement_and_policy_edges(void) {
     rc |= expect_eq_int("nonclear tg policy", p25_patch_tg_key_is_clear(&st, 0x2345), 0);
     rc |= expect_eq_int("nonclear sg policy", p25_patch_sg_key_is_clear(&st, 69), 0);
 
+    DSD_MEMSET(&st, 0, sizeof st);
+    rc |= expect_eq_int("prepare active returns process", p25_patch_prepare_grg_update(&st, 500, 1, 1, 3), 1);
+    p25_patch_add_wgid(&st, 500, 100);
+    p25_patch_set_kas(&st, 500, 0x2222, 0x84, 3);
+    rc |= expect_eq_int("prepare same ssn returns process", p25_patch_prepare_grg_update(&st, 500, 1, 1, 3), 1);
+    p25_patch_add_wgid(&st, 500, 101);
+    int idx500 = find_idx(&st, 500);
+    rc |= expect_true("prepare same ssn keeps sg", idx500 >= 0);
+    if (idx500 >= 0) {
+        rc |= expect_eq_int("prepare same ssn accumulates", st.p25_patch_wgid_count[idx500], 2);
+    }
+    rc |= expect_eq_int("prepare changed ssn returns process", p25_patch_prepare_grg_update(&st, 500, 1, 1, 4), 1);
+    p25_patch_add_wgid(&st, 500, 102);
+    p25_patch_set_kas(&st, 500, 0x3333, 0x89, 4);
+    idx500 = find_idx(&st, 500);
+    rc |= expect_true("prepare changed ssn keeps sg", idx500 >= 0);
+    if (idx500 >= 0) {
+        uint16_t members[8] = {0};
+        rc |= expect_eq_int("prepare changed ssn clears old", st.p25_patch_wgid_count[idx500], 1);
+        rc |= expect_eq_int("prepare changed ssn new member", st.p25_patch_wgid[idx500][0], 102);
+        rc |= expect_eq_int("collect active count", p25_patch_collect_active_wgids(&st, 500, members, 8), 1);
+        rc |= expect_eq_int("collect active member", members[0], 102);
+    }
+    rc |= expect_eq_int("prepare inactive suppresses members", p25_patch_prepare_grg_update(&st, 500, 1, 0, 4), 0);
+    idx500 = find_idx(&st, 500);
+    rc |= expect_true("prepare inactive keeps record", idx500 >= 0);
+    if (idx500 >= 0) {
+        rc |= expect_eq_int("prepare inactive clears active", st.p25_patch_active[idx500], 0);
+        rc |= expect_eq_int("prepare inactive clears count", st.p25_patch_wgid_count[idx500], 0);
+        rc |= expect_eq_int("prepare inactive clears key valid", st.p25_patch_key_valid[idx500], 0);
+    }
+
     return rc;
 }
 


### PR DESCRIPTION
## Summary
- Add patch-aware P25 grant policy so active supergroup calls can match hold, allowlist, priority, and preempt rules through active WGID members while tuning the granted supergroup.
- Carry the matched policy talkgroup through P25 media and record gates, with cleanup when slot targets change or calls release.
- Tighten Harris A4 GRG_EXENC state handling for P1 TSBK and P2 MAC, including active/inactive commands, SSN replacement, variable WGID/WUID lengths, zero-target suppression, and KID/ALG/SSN storage.
- Add Motorola extended-function supergroup create/cancel handling for P1 TSBK and P2 MAC, plus regression coverage.

## Impact
This improves P25 patched call following and reduces stale regroup membership across Harris and Motorola regroup paths without changing CLI options or external file formats.

## Validation
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure` (490/490)
- `cmake --build --preset dev-debug -j --target dsd-neo_test_p25_grant_policy dsd-neo_test_p25_p2_vpdu_grants dsd-neo_test_p25_patch_tracking`
- `ctest --preset dev-debug --output-on-failure -R 'P25_GRANT_POLICY|P25_P2_VPDU_GRANTS|P25_PATCH_TRACKING'`
- Pre-push hook passed: clang-format, clang-tidy, cppcheck, IWYU, GCC fanalyzer, Semgrep, and Lizard