### PR TITLE
p25: flush P25P2 tail audio on hangtime

### DIFF
--- a/include/dsd-neo/core/audio.h
+++ b/include/dsd-neo/core/audio.h
@@ -175,6 +175,8 @@ int dsd_dmr_apply_forced_algid(dsd_state* state);
 
 /** @brief Flush partially buffered P25p2 SS18 audio on call end/release. */
 void dsd_p25p2_flush_partial_audio(dsd_opts* opts, dsd_state* state);
+/** @brief Flush partially buffered P25p2 SS18 audio for one slot while preserving the other slot. */
+void dsd_p25p2_flush_partial_audio_slot(dsd_opts* opts, dsd_state* state, int slot);
 
 /** @brief Talkgroup/whitelist/TG-hold gating for mono mix (enc flags 0=unmuted,1=muted). */
 int dsd_audio_group_gate_mono(const dsd_opts* opts, const dsd_state* state, unsigned long tg, int enc_in, int* enc_out);

--- a/src/core/audio/dsd_audio2.c
+++ b/src/core/audio/dsd_audio2.c
@@ -715,6 +715,49 @@ dsd_p25p2_flush_partial_audio(dsd_opts* opts, dsd_state* state) {
     state->voice_counter[1] = 0;
 }
 
+void
+dsd_p25p2_flush_partial_audio_slot(dsd_opts* opts, dsd_state* state, int slot) {
+    if (!opts || !state || slot < 0 || slot > 1) {
+        return;
+    }
+    // This helper is specifically for the short/int16 P25p2 SS18 path.
+    if (opts->floating_point != 0 || opts->pulse_digi_rate_out != 8000) {
+        return;
+    }
+
+    const int other = slot ^ 1;
+    int has_slot = (slot == 0) ? p25p2_s16_frames_have_audio(state->s_l4) : p25p2_s16_frames_have_audio(state->s_r4);
+    if (!has_slot) {
+        return;
+    }
+
+    short saved_other[18][160];
+    int saved_other_counter = state->voice_counter[other];
+    int saved_other_allowed = state->p25_p2_audio_allowed[other];
+
+    if (other == 0) {
+        DSD_MEMCPY(saved_other, state->s_l4, sizeof(saved_other));
+        DSD_MEMSET(state->s_l4, 0, sizeof(state->s_l4));
+    } else {
+        DSD_MEMCPY(saved_other, state->s_r4, sizeof(saved_other));
+        DSD_MEMSET(state->s_r4, 0, sizeof(state->s_r4));
+    }
+
+    state->p25_p2_audio_allowed[slot] = 1;
+    state->p25_p2_audio_allowed[other] = 0;
+
+    playSynthesizedVoiceSS18(opts, state);
+
+    state->voice_counter[slot] = 0;
+    state->voice_counter[other] = saved_other_counter;
+    state->p25_p2_audio_allowed[other] = saved_other_allowed;
+    if (other == 0) {
+        DSD_MEMCPY(state->s_l4, saved_other, sizeof(saved_other));
+    } else {
+        DSD_MEMCPY(state->s_r4, saved_other, sizeof(saved_other));
+    }
+}
+
 //NOTE: Tones produce ringing sound when put through the hpf_d, may want to look into tweaking it,
 //or looking for a way to store is_tone by glancing at ambe_d values and not running hpf_d on them
 

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -256,7 +256,7 @@ p25p2_xcch_close_slot_mbe_out(dsd_opts* opts, dsd_state* state, int slot) {
 }
 
 static void
-p25p2_xcch_flush_partial_audio_on_hangtime(dsd_opts* opts, dsd_state* state) {
+p25p2_xcch_flush_partial_audio_on_hangtime(dsd_opts* opts, dsd_state* state, int slot) {
     int audio_allowed[2];
 
     if (!opts || !state) {
@@ -269,7 +269,7 @@ p25p2_xcch_flush_partial_audio_on_hangtime(dsd_opts* opts, dsd_state* state) {
     // Flush before MAC_HANGTIME changes burst 21 to 22; SS18 single-slot
     // duplication uses those active burst hints. Unlike release, hangtime stays
     // on the VC, so restore the existing audio gates after the flush.
-    dsd_p25p2_flush_partial_audio(opts, state);
+    dsd_p25p2_flush_partial_audio_slot(opts, state, slot);
 
     state->p25_p2_audio_allowed[0] = audio_allowed[0];
     state->p25_p2_audio_allowed[1] = audio_allowed[1];
@@ -277,7 +277,7 @@ p25p2_xcch_flush_partial_audio_on_hangtime(dsd_opts* opts, dsd_state* state) {
 
 static void
 p25p2_xcch_handle_mac_hangtime_slot(dsd_opts* opts, dsd_state* state, int slot) {
-    p25p2_xcch_flush_partial_audio_on_hangtime(opts, state);
+    p25p2_xcch_flush_partial_audio_on_hangtime(opts, state, slot);
     p25p2_xcch_set_slot_burst(state, slot, 22);
     p25p2_xcch_close_slot_mbe_out(opts, state, slot);
 }

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -256,6 +256,33 @@ p25p2_xcch_close_slot_mbe_out(dsd_opts* opts, dsd_state* state, int slot) {
 }
 
 static void
+p25p2_xcch_flush_partial_audio_on_hangtime(dsd_opts* opts, dsd_state* state) {
+    int audio_allowed[2];
+
+    if (!opts || !state) {
+        return;
+    }
+
+    audio_allowed[0] = state->p25_p2_audio_allowed[0];
+    audio_allowed[1] = state->p25_p2_audio_allowed[1];
+
+    // Flush before MAC_HANGTIME changes burst 21 to 22; SS18 single-slot
+    // duplication uses those active burst hints. Unlike release, hangtime stays
+    // on the VC, so restore the existing audio gates after the flush.
+    dsd_p25p2_flush_partial_audio(opts, state);
+
+    state->p25_p2_audio_allowed[0] = audio_allowed[0];
+    state->p25_p2_audio_allowed[1] = audio_allowed[1];
+}
+
+static void
+p25p2_xcch_handle_mac_hangtime_slot(dsd_opts* opts, dsd_state* state, int slot) {
+    p25p2_xcch_flush_partial_audio_on_hangtime(opts, state);
+    p25p2_xcch_set_slot_burst(state, slot, 22);
+    p25p2_xcch_close_slot_mbe_out(opts, state, slot);
+}
+
+static void
 p25p2_xcch_blank_slot_call_string(dsd_state* state, int slot) {
     DSD_SNPRINTF(state->call_string[slot], sizeof(state->call_string[slot]), "%s", P25P2_EMPTY_CALL_STRING);
 }
@@ -606,15 +633,9 @@ p25p2_xcch_handle_sacch_mac_active(dsd_opts* opts, dsd_state* state, uint8_t slo
 static void
 p25p2_xcch_handle_sacch_mac_hangtime(dsd_opts* opts, dsd_state* state, unsigned long long int smac[24]) {
     if (state->currentslot == 1) {
-        state->dmrburstL = 22;
-        if (opts->mbe_out_f != NULL) {
-            closeMbeOutFile(opts, state);
-        }
+        p25p2_xcch_handle_mac_hangtime_slot(opts, state, 0);
     } else {
-        state->dmrburstR = 22;
-        if (opts->mbe_out_fR != NULL) {
-            closeMbeOutFileR(opts, state);
-        }
+        p25p2_xcch_handle_mac_hangtime_slot(opts, state, 1);
     }
 
     DSD_FPRINTF(stderr, " MAC_HANGTIME ");
@@ -700,15 +721,9 @@ p25p2_xcch_handle_facch_mac_active(dsd_opts* opts, dsd_state* state, uint8_t slo
 static void
 p25p2_xcch_handle_facch_mac_hangtime(dsd_opts* opts, dsd_state* state, unsigned long long int fmac[24]) {
     if (state->currentslot == 0) {
-        state->dmrburstL = 22;
-        if (opts->mbe_out_f != NULL) {
-            closeMbeOutFile(opts, state);
-        }
+        p25p2_xcch_handle_mac_hangtime_slot(opts, state, 0);
     } else {
-        state->dmrburstR = 22;
-        if (opts->mbe_out_fR != NULL) {
-            closeMbeOutFileR(opts, state);
-        }
+        p25p2_xcch_handle_mac_hangtime_slot(opts, state, 1);
     }
 
     DSD_FPRINTF(stderr, " MAC_HANGTIME ");

--- a/tests/protocol/p25/test_p25_p2_mixer_gate.c
+++ b/tests/protocol/p25/test_p25_p2_mixer_gate.c
@@ -393,6 +393,80 @@ run_ss18_partial_flush_guard_case(void) {
 }
 
 static int
+run_ss18_partial_flush_slot_case(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.floating_point = 0;
+    opts.pulse_digi_rate_out = 8000;
+    opts.slot1_on = 1;
+    opts.slot2_on = 1;
+    st.dmrburstL = 21;
+    st.dmrburstR = 21;
+    st.s_l4[0][0] = 321;
+    st.s_r4[0][0] = -654;
+    st.voice_counter[0] = 7;
+    st.voice_counter[1] = 8;
+    st.p25_p2_audio_allowed[0] = 1;
+    st.p25_p2_audio_allowed[1] = 1;
+
+    dsd_p25p2_flush_partial_audio_slot(&opts, &st, 0);
+
+    short out[160 * 2] = {0};
+    const size_t expected_bytes = (size_t)160 * 2U * sizeof(out[0]);
+    rc |= expect_eq("partial slot flush captured calls", g_audio_capture_calls >= 1, 1);
+    int copied = copy_capture_bytes("partial slot flush captured bytes", out, expected_bytes);
+    rc |= copied;
+    if (copied == 0) {
+        rc |= expect_eq("partial slot flush left sample", out[0], 321);
+        rc |= expect_eq("partial slot flush masks right sample", out[1], 0);
+    }
+    rc |= expect_eq("partial slot flush allowed left", st.p25_p2_audio_allowed[0], 1);
+    rc |= expect_eq("partial slot flush allowed right preserved", st.p25_p2_audio_allowed[1], 1);
+    rc |= expect_eq("partial slot flush voice counter left", st.voice_counter[0], 0);
+    rc |= expect_eq("partial slot flush voice counter right preserved", st.voice_counter[1], 8);
+    rc |= expect_eq("partial slot flush clears left frames", short_18_blocks_are_clear(st.s_l4), 1);
+    rc |= expect_eq("partial slot flush preserves right sample", st.s_r4[0][0], -654);
+
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    st.dmrburstL = 21;
+    st.dmrburstR = 21;
+    st.s_l4[0][0] = 111;
+    st.s_r4[0][0] = -222;
+    st.voice_counter[0] = 3;
+    st.voice_counter[1] = 4;
+    st.p25_p2_audio_allowed[0] = 1;
+    st.p25_p2_audio_allowed[1] = 1;
+
+    dsd_p25p2_flush_partial_audio_slot(&opts, &st, 1);
+
+    short out2[160 * 2] = {0};
+    rc |= expect_eq("partial slot flush right captured calls", g_audio_capture_calls >= 1, 1);
+    copied = copy_capture_bytes("partial slot flush right captured bytes", out2, expected_bytes);
+    rc |= copied;
+    if (copied == 0) {
+        rc |= expect_eq("partial slot flush masks left sample", out2[0], 0);
+        rc |= expect_eq("partial slot flush right sample", out2[1], -222);
+    }
+    rc |= expect_eq("partial slot flush left allowed preserved", st.p25_p2_audio_allowed[0], 1);
+    rc |= expect_eq("partial slot flush right allowed", st.p25_p2_audio_allowed[1], 1);
+    rc |= expect_eq("partial slot flush left counter preserved", st.voice_counter[0], 3);
+    rc |= expect_eq("partial slot flush right counter", st.voice_counter[1], 0);
+    rc |= expect_eq("partial slot flush preserves left sample", st.s_l4[0][0], 111);
+    rc |= expect_eq("partial slot flush clears right frames", short_18_blocks_are_clear(st.s_r4), 1);
+    return rc;
+}
+
+static int
 run_short_mono_playback_case(void) {
     static dsd_opts opts;
     static dsd_state st;
@@ -730,6 +804,7 @@ main(void) {
                                      /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 1ULL);
     rc |= run_ss18_partial_flush_case();
     rc |= run_ss18_partial_flush_guard_case();
+    rc |= run_ss18_partial_flush_slot_case();
     rc |= run_short_mono_playback_case();
     rc |= run_float_mono_playback_case();
     rc |= run_short_stereo_fdma_playback_case();

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -42,6 +42,7 @@ static int g_flush_burst_l;
 static int g_flush_burst_r;
 static int g_flush_gate_l;
 static int g_flush_gate_r;
+static int g_flush_slot;
 static int g_flush_close_l_count;
 static int g_flush_close_r_count;
 static int g_ring_reset_count[2];
@@ -196,6 +197,31 @@ dsd_p25p2_flush_partial_audio(dsd_opts* opts, dsd_state* state) {
     DSD_MEMSET(state->s_r4, 0, sizeof(state->s_r4));
 }
 
+void
+dsd_p25p2_flush_partial_audio_slot(dsd_opts* opts, dsd_state* state, int slot) {
+    (void)opts;
+    g_flush_count++;
+    g_flush_slot = slot;
+
+    if (!state || slot < 0 || slot > 1) {
+        return;
+    }
+
+    g_flush_burst_l = (int)state->dmrburstL;
+    g_flush_burst_r = (int)state->dmrburstR;
+    g_flush_gate_l = state->p25_p2_audio_allowed[0];
+    g_flush_gate_r = state->p25_p2_audio_allowed[1];
+    g_flush_close_l_count = g_close_l_count;
+    g_flush_close_r_count = g_close_r_count;
+
+    state->voice_counter[slot] = 0;
+    if (slot == 0) {
+        DSD_MEMSET(state->s_l4, 0, sizeof(state->s_l4));
+    } else {
+        DSD_MEMSET(state->s_r4, 0, sizeof(state->s_r4));
+    }
+}
+
 #include "../../../src/protocol/p25/phase2/p25p2_xcch.c"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -223,6 +249,7 @@ reset_stubs(void) {
     g_flush_burst_r = -1;
     g_flush_gate_l = -1;
     g_flush_gate_r = -1;
+    g_flush_slot = -1;
     g_flush_close_l_count = -1;
     g_flush_close_r_count = -1;
     DSD_MEMSET(g_ring_reset_count, 0, sizeof(g_ring_reset_count));
@@ -581,9 +608,13 @@ test_sacch_end_idle_active_hangtime_dispatch(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&opts, 0, sizeof(opts));
     state.currentslot = 0;
+    state.dmrburstL = 21;
     state.dmrburstR = 21;
+    state.p25_p2_audio_allowed[0] = 1;
     state.p25_p2_audio_allowed[1] = 1;
+    state.voice_counter[0] = 5;
     state.voice_counter[1] = 1;
+    state.s_l4[0][0] = 456;
     state.s_r4[0][0] = -123;
     opts.pulse_digi_rate_out = 8000;
     opts.mbe_out_fR = (FILE*)0x1;
@@ -593,13 +624,17 @@ test_sacch_end_idle_active_hangtime_dispatch(void) {
     rc |= expect_int("sacch hangtime vpdu", g_vpdu_count, 1);
     rc |= expect_int("sacch hangtime vpdu type", g_vpdu_type, 1);
     rc |= expect_int("sacch hangtime flush", g_flush_count, 1);
+    rc |= expect_int("sacch hangtime flush slot", g_flush_slot, 1);
     rc |= expect_int("sacch hangtime flush before burst", g_flush_burst_r, 21);
     rc |= expect_int("sacch hangtime flush before close", g_flush_close_r_count, 0);
     rc |= expect_int("sacch hangtime flush sees gate", g_flush_gate_r, 1);
     rc |= expect_int("sacch hangtime burst right", (int)state.dmrburstR, 22);
     rc |= expect_int("sacch hangtime close right", g_close_r_count, 1);
     rc |= expect_int("sacch hangtime gate preserved", state.p25_p2_audio_allowed[1], 1);
+    rc |= expect_int("sacch hangtime other gate preserved", state.p25_p2_audio_allowed[0], 1);
+    rc |= expect_int("sacch hangtime other voice counter preserved", state.voice_counter[0], 5);
     rc |= expect_int("sacch hangtime voice counter reset", state.voice_counter[1], 0);
+    rc |= expect_int("sacch hangtime other sample preserved", state.s_l4[0][0], 456);
     rc |= expect_int("sacch hangtime sample cleared", state.s_r4[0][0], 0);
 
     return rc;
@@ -677,9 +712,13 @@ test_facch_active_end_hangtime_and_invalid_slot_guards(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&opts, 0, sizeof(opts));
     state.currentslot = 1;
+    state.dmrburstL = 21;
     state.dmrburstR = 21;
+    state.p25_p2_audio_allowed[0] = 1;
     state.p25_p2_audio_allowed[1] = 1;
+    state.voice_counter[0] = 4;
     state.voice_counter[1] = 1;
+    state.s_l4[0][0] = -345;
     state.s_r4[0][0] = 234;
     opts.pulse_digi_rate_out = 8000;
     opts.mbe_out_fR = (FILE*)0x1;
@@ -689,13 +728,17 @@ test_facch_active_end_hangtime_and_invalid_slot_guards(void) {
     rc |= expect_int("facch hangtime vpdu", g_vpdu_count, 1);
     rc |= expect_int("facch hangtime vpdu type", g_vpdu_type, 0);
     rc |= expect_int("facch hangtime flush", g_flush_count, 1);
+    rc |= expect_int("facch hangtime flush slot", g_flush_slot, 1);
     rc |= expect_int("facch hangtime flush before burst", g_flush_burst_r, 21);
     rc |= expect_int("facch hangtime flush before close", g_flush_close_r_count, 0);
     rc |= expect_int("facch hangtime flush sees gate", g_flush_gate_r, 1);
     rc |= expect_int("facch hangtime burst right", (int)state.dmrburstR, 22);
     rc |= expect_int("facch hangtime close right", g_close_r_count, 1);
     rc |= expect_int("facch hangtime gate preserved", state.p25_p2_audio_allowed[1], 1);
+    rc |= expect_int("facch hangtime other gate preserved", state.p25_p2_audio_allowed[0], 1);
+    rc |= expect_int("facch hangtime other voice counter preserved", state.voice_counter[0], 4);
     rc |= expect_int("facch hangtime voice counter reset", state.voice_counter[1], 0);
+    rc |= expect_int("facch hangtime other sample preserved", state.s_l4[0][0], -345);
     rc |= expect_int("facch hangtime sample cleared", state.s_r4[0][0], 0);
 
     return rc;

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -37,6 +37,13 @@ static int g_enc_keyid[2];
 static int g_enc_tg[2];
 static int g_close_l_count;
 static int g_close_r_count;
+static int g_flush_count;
+static int g_flush_burst_l;
+static int g_flush_burst_r;
+static int g_flush_gate_l;
+static int g_flush_gate_r;
+static int g_flush_close_l_count;
+static int g_flush_close_r_count;
 static int g_ring_reset_count[2];
 static int g_lfsr_count[2];
 static uint64_t g_now_ns;
@@ -165,6 +172,30 @@ closeMbeOutFileR(dsd_opts* opts, dsd_state* state) {
     opts->mbe_out_fR = NULL;
 }
 
+void
+dsd_p25p2_flush_partial_audio(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    g_flush_count++;
+
+    if (!state) {
+        return;
+    }
+
+    g_flush_burst_l = (int)state->dmrburstL;
+    g_flush_burst_r = (int)state->dmrburstR;
+    g_flush_gate_l = state->p25_p2_audio_allowed[0];
+    g_flush_gate_r = state->p25_p2_audio_allowed[1];
+    g_flush_close_l_count = g_close_l_count;
+    g_flush_close_r_count = g_close_r_count;
+
+    state->p25_p2_audio_allowed[0] = 0;
+    state->p25_p2_audio_allowed[1] = 0;
+    state->voice_counter[0] = 0;
+    state->voice_counter[1] = 0;
+    DSD_MEMSET(state->s_l4, 0, sizeof(state->s_l4));
+    DSD_MEMSET(state->s_r4, 0, sizeof(state->s_r4));
+}
+
 #include "../../../src/protocol/p25/phase2/p25p2_xcch.c"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -187,6 +218,13 @@ reset_stubs(void) {
     DSD_MEMSET(g_enc_tg, 0, sizeof(g_enc_tg));
     g_close_l_count = 0;
     g_close_r_count = 0;
+    g_flush_count = 0;
+    g_flush_burst_l = -1;
+    g_flush_burst_r = -1;
+    g_flush_gate_l = -1;
+    g_flush_gate_r = -1;
+    g_flush_close_l_count = -1;
+    g_flush_close_r_count = -1;
     DSD_MEMSET(g_ring_reset_count, 0, sizeof(g_ring_reset_count));
     DSD_MEMSET(g_lfsr_count, 0, sizeof(g_lfsr_count));
     g_now_ns = 0;
@@ -543,14 +581,26 @@ test_sacch_end_idle_active_hangtime_dispatch(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&opts, 0, sizeof(opts));
     state.currentslot = 0;
+    state.dmrburstR = 21;
+    state.p25_p2_audio_allowed[1] = 1;
+    state.voice_counter[1] = 1;
+    state.s_r4[0][0] = -123;
+    opts.pulse_digi_rate_out = 8000;
     opts.mbe_out_fR = (FILE*)0x1;
     pack_payload_from_mac(payload, 180, mac, 0x6, 0, 0);
 
     process_SACCH_MAC_PDU(&opts, &state, payload);
     rc |= expect_int("sacch hangtime vpdu", g_vpdu_count, 1);
     rc |= expect_int("sacch hangtime vpdu type", g_vpdu_type, 1);
+    rc |= expect_int("sacch hangtime flush", g_flush_count, 1);
+    rc |= expect_int("sacch hangtime flush before burst", g_flush_burst_r, 21);
+    rc |= expect_int("sacch hangtime flush before close", g_flush_close_r_count, 0);
+    rc |= expect_int("sacch hangtime flush sees gate", g_flush_gate_r, 1);
     rc |= expect_int("sacch hangtime burst right", (int)state.dmrburstR, 22);
     rc |= expect_int("sacch hangtime close right", g_close_r_count, 1);
+    rc |= expect_int("sacch hangtime gate preserved", state.p25_p2_audio_allowed[1], 1);
+    rc |= expect_int("sacch hangtime voice counter reset", state.voice_counter[1], 0);
+    rc |= expect_int("sacch hangtime sample cleared", state.s_r4[0][0], 0);
 
     return rc;
 }
@@ -627,14 +677,26 @@ test_facch_active_end_hangtime_and_invalid_slot_guards(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&opts, 0, sizeof(opts));
     state.currentslot = 1;
+    state.dmrburstR = 21;
+    state.p25_p2_audio_allowed[1] = 1;
+    state.voice_counter[1] = 1;
+    state.s_r4[0][0] = 234;
+    opts.pulse_digi_rate_out = 8000;
     opts.mbe_out_fR = (FILE*)0x1;
     pack_payload_from_mac(payload, 156, mac, 0x6, 0, 0);
 
     process_FACCH_MAC_PDU(&opts, &state, payload);
     rc |= expect_int("facch hangtime vpdu", g_vpdu_count, 1);
     rc |= expect_int("facch hangtime vpdu type", g_vpdu_type, 0);
+    rc |= expect_int("facch hangtime flush", g_flush_count, 1);
+    rc |= expect_int("facch hangtime flush before burst", g_flush_burst_r, 21);
+    rc |= expect_int("facch hangtime flush before close", g_flush_close_r_count, 0);
+    rc |= expect_int("facch hangtime flush sees gate", g_flush_gate_r, 1);
     rc |= expect_int("facch hangtime burst right", (int)state.dmrburstR, 22);
     rc |= expect_int("facch hangtime close right", g_close_r_count, 1);
+    rc |= expect_int("facch hangtime gate preserved", state.p25_p2_audio_allowed[1], 1);
+    rc |= expect_int("facch hangtime voice counter reset", state.voice_counter[1], 0);
+    rc |= expect_int("facch hangtime sample cleared", state.s_r4[0][0], 0);
 
     return rc;
 }


### PR DESCRIPTION
## Summary

Flush partial P25 Phase 2 SS18 int16 audio when SACCH or FACCH reports `MAC_HANGTIME`, before changing the active burst marker to hangtime or closing MBE output. The hangtime path stays on the voice channel, so the existing per-slot audio gates are restored after the flush.

## Root Cause

Motorola Phase 2 systems can emit `MAC_HANGTIME` before the final `MAC_END_PTT`. The decoder buffered decoded tail audio in partial `s_l4`/`s_r4` SS18 blocks, but hangtime previously only changed burst state to `22` and closed MBE output. The tail audio was not flushed until the later release path.

## Impact

This plays the final buffered audio at hangtime instead of delaying it until PTT release, while preserving the existing release-time flush for systems that go straight to `MAC_END_PTT`.

## Tests

- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure -R '^(P25_P2_XCCH_HELPERS|P25_P2_MIXER_GATE|P25_P2_RELEASE_PARTIAL_AUDIO|P25_P2_AUDIO_GATING|RUNTIME_P25_P2_AUDIO_RING)$'`
- pre-push checks: clang-format, clang-tidy, cppcheck, IWYU, GCC analyzer, Semgrep, Lizard