### PR TITLE
p25: suppress stale P2 grants after EOT

### DIFF
--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -129,7 +129,17 @@ typedef struct {
     int vc_tg;
     int vc_src;
     int vc_is_tdma;          // 1 if TDMA channel, 0 if single-carrier
+    int vc_is_group;         // 1 for group call, 0 for individual call
     int vc_cqpsk_retry_done; // 1 once we retried VC tune with alternate CQPSK DSP mode for this grant
+
+    // Recently ended TDMA call; used to ignore immediate stale post-EOT grants.
+    long recent_end_freq_hz;
+    int recent_end_channel;
+    int recent_end_tg;
+    int recent_end_src;
+    int recent_end_slot;
+    int recent_end_is_group;
+    double recent_end_until_m;
 
     // Per-slot activity (index 0 = left/P1, index 1 = right)
     p25_sm_slot_ctx_t slots[2];

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -45,6 +45,7 @@ static void p25_sm_diagf(dsd_opts* opts, const dsd_state* state, const p25_sm_ct
 static atomic_int g_p25_sm_release_lock = 0;
 
 #define P25_FAILED_VC_RETUNE_BACKOFF_DEFAULT_S 10.0
+#define P25_RECENT_END_GRANT_SUPPRESS_S        1.5
 
 static inline double
 now_monotonic(void) {
@@ -941,6 +942,7 @@ p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_eve
     ctx->vc_tg = target_id;
     ctx->vc_src = ev->src;
     ctx->vc_is_tdma = is_tdma_channel(state, ev->channel);
+    ctx->vc_is_group = ev->is_group ? 1 : 0;
     ctx->t_tune_m = now_m;
     ctx->t_voice_m = 0.0;
     ctx->vc_cqpsk_retry_done = 0;
@@ -948,6 +950,50 @@ p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_eve
         // Clear any stale one-shot VC CQPSK override from a previous attempt.
         state->p25_vc_cqpsk_override = -1;
     }
+}
+
+static void
+p25_recent_end_clear(p25_sm_ctx_t* ctx) {
+    if (!ctx) {
+        return;
+    }
+    ctx->recent_end_freq_hz = 0;
+    ctx->recent_end_channel = 0;
+    ctx->recent_end_tg = 0;
+    ctx->recent_end_src = 0;
+    ctx->recent_end_slot = -1;
+    ctx->recent_end_is_group = 0;
+    ctx->recent_end_until_m = 0.0;
+}
+
+static int
+p25_recent_end_source_matches(int ended_src, int grant_src) {
+    return ended_src <= 0 || grant_src <= 0 || ended_src == grant_src;
+}
+
+static void
+p25_recent_end_record(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, double now_m) {
+    if (!ctx || !ctx->vc_is_tdma || ctx->vc_freq_hz <= 0 || ctx->vc_tg <= 0) {
+        return;
+    }
+
+    int ended_slot = (slot >= 0 && slot <= 1) ? slot : channel_slot(state, ctx->vc_channel);
+    if (ended_slot < 0 || ended_slot > 1) {
+        return;
+    }
+
+    ctx->recent_end_freq_hz = ctx->vc_freq_hz;
+    ctx->recent_end_channel = ctx->vc_channel;
+    ctx->recent_end_tg = ctx->vc_tg;
+    ctx->recent_end_src = ctx->vc_src;
+    ctx->recent_end_slot = ended_slot;
+    ctx->recent_end_is_group = ctx->vc_is_group;
+    ctx->recent_end_until_m = now_m + P25_RECENT_END_GRANT_SUPPRESS_S;
+
+    p25_sm_diagf(opts, state, ctx, "grant_recent_end_arm",
+                 "ch=0x%04X freq=%ld slot=%d tg=%d src=%d seconds=%.3f until_m=%.3f", ctx->recent_end_channel & 0xFFFF,
+                 ctx->recent_end_freq_hz, ctx->recent_end_slot, ctx->recent_end_tg, ctx->recent_end_src,
+                 P25_RECENT_END_GRANT_SUPPRESS_S, ctx->recent_end_until_m);
 }
 
 static int
@@ -1191,6 +1237,32 @@ typedef struct {
     double now_m;
 } p25_grant_route_ctx_t;
 
+static int
+p25_grant_recent_end_blocked(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev,
+                             const p25_grant_route_ctx_t* grant) {
+    if (!ctx || !ev || !grant || ctx->state != P25_SM_ON_CC || ctx->recent_end_until_m <= 0.0) {
+        return 0;
+    }
+
+    if (grant->now_m >= ctx->recent_end_until_m) {
+        p25_recent_end_clear(ctx);
+        return 0;
+    }
+
+    if (ctx->recent_end_freq_hz != grant->freq || ctx->recent_end_slot != grant->slot
+        || ctx->recent_end_tg != grant->target_id || ctx->recent_end_is_group != (ev->is_group ? 1 : 0)
+        || !p25_recent_end_source_matches(ctx->recent_end_src, ev->src)) {
+        return 0;
+    }
+
+    p25_sm_diagf(opts, state, ctx, "grant_recent_end_skip",
+                 "ch=0x%04X recent_ch=0x%04X freq=%ld slot=%d target=%d ota_tg=%d src=%d until_m=%.3f",
+                 ev->channel & 0xFFFF, ctx->recent_end_channel & 0xFFFF, grant->freq, grant->slot, grant->target_id,
+                 ev->tg, ev->src, ctx->recent_end_until_m);
+    sm_log(opts, state, "grant-recent-end-skip");
+    return 1;
+}
+
 static void
 p25_grant_log_freq(dsd_opts* opts, const dsd_state* state, const p25_sm_ctx_t* ctx, const p25_sm_event_t* ev, long freq,
                    const p25_freq_trace_t* freq_trace) {
@@ -1263,6 +1335,10 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     }
 
     if (!p25_grant_prepare_route(ctx, opts, state, ev, &decision, &grant)) {
+        return;
+    }
+
+    if (p25_grant_recent_end_blocked(ctx, opts, state, ev, &grant)) {
         return;
     }
 
@@ -1400,6 +1476,7 @@ p25_voice_end_try_explicit_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state*
     int other = slot ^ 1;
     if (p25_voice_end_can_release_explicit(ctx, other)) {
         // All active slots terminated - release immediately like P25P1 Call Termination
+        p25_recent_end_record(ctx, opts, state, slot, now_monotonic());
         do_release(ctx, opts, state, "call-end", 0);
     }
 }
@@ -1578,6 +1655,7 @@ p25_release_clear_context(p25_sm_ctx_t* ctx) {
     ctx->vc_channel = 0;
     ctx->vc_tg = 0;
     ctx->vc_src = 0;
+    ctx->vc_is_group = 0;
     ctx->t_tune_m = 0.0;
     ctx->t_voice_m = 0.0;
     ctx->release_count++;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -972,7 +972,7 @@ p25_recent_end_source_matches(int ended_src, int grant_src) {
 }
 
 static void
-p25_recent_end_record(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, double now_m) {
+p25_recent_end_record(p25_sm_ctx_t* ctx, dsd_opts* opts, const dsd_state* state, int slot, double now_m) {
     if (!ctx || !ctx->vc_is_tdma || ctx->vc_freq_hz <= 0 || ctx->vc_tg <= 0) {
         return;
     }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -966,11 +966,6 @@ p25_recent_end_clear(p25_sm_ctx_t* ctx) {
     ctx->recent_end_until_m = 0.0;
 }
 
-static int
-p25_recent_end_source_matches(int ended_src, int grant_src) {
-    return ended_src <= 0 || grant_src <= 0 || ended_src == grant_src;
-}
-
 static void
 p25_recent_end_record(p25_sm_ctx_t* ctx, dsd_opts* opts, const dsd_state* state, int slot, double now_m) {
     if (!ctx || !ctx->vc_is_tdma || ctx->vc_freq_hz <= 0 || ctx->vc_tg <= 0) {
@@ -1249,16 +1244,20 @@ p25_grant_recent_end_blocked(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state
         return 0;
     }
 
-    if (ctx->recent_end_freq_hz != grant->freq || ctx->recent_end_slot != grant->slot
-        || ctx->recent_end_tg != grant->target_id || ctx->recent_end_is_group != (ev->is_group ? 1 : 0)
-        || !p25_recent_end_source_matches(ctx->recent_end_src, ev->src)) {
+    if (!is_tdma_channel(state, ev->channel) || grant->slot < 0 || grant->slot > 1) {
+        return 0;
+    }
+
+    if (ctx->recent_end_freq_hz != grant->freq || ctx->recent_end_tg != grant->target_id
+        || ctx->recent_end_is_group != (ev->is_group ? 1 : 0)) {
         return 0;
     }
 
     p25_sm_diagf(opts, state, ctx, "grant_recent_end_skip",
-                 "ch=0x%04X recent_ch=0x%04X freq=%ld slot=%d target=%d ota_tg=%d src=%d until_m=%.3f",
-                 ev->channel & 0xFFFF, ctx->recent_end_channel & 0xFFFF, grant->freq, grant->slot, grant->target_id,
-                 ev->tg, ev->src, ctx->recent_end_until_m);
+                 "ch=0x%04X recent_ch=0x%04X freq=%ld slot=%d recent_slot=%d target=%d ota_tg=%d src=%d "
+                 "recent_src=%d until_m=%.3f",
+                 ev->channel & 0xFFFF, ctx->recent_end_channel & 0xFFFF, grant->freq, grant->slot, ctx->recent_end_slot,
+                 grant->target_id, ev->tg, ev->src, ctx->recent_end_src, ctx->recent_end_until_m);
     sm_log(opts, state, "grant-recent-end-skip");
     return 1;
 }

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -540,6 +540,19 @@ p25p2_xcch_validate_facch_crc(const dsd_state* state, const int payload[156], co
 }
 
 static void
+p25p2_xcch_refresh_lcch_cc_sync(const dsd_opts* opts, dsd_state* state, int err) {
+    if (!state || state->p2_is_lcch != 1 || err != 0) {
+        return;
+    }
+    if (opts && (opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1)) {
+        return;
+    }
+
+    state->last_cc_sync_time = time(NULL);
+    state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
+}
+
+static void
 p25p2_xcch_handle_sacch_mac_signal(dsd_opts* opts, dsd_state* state, unsigned long long int smac[24], int err) {
     DSD_FPRINTF(stderr, " MAC_SIGNAL ");
     if (err != 0) {
@@ -751,6 +764,7 @@ process_SACCH_MAC_PDU(dsd_opts* opts, dsd_state* state, int payload[180]) {
     if (abort_processing) {
         return;
     }
+    p25p2_xcch_refresh_lcch_cc_sync(opts, state, err);
 
     switch (opcode) {
         case 0x0: p25p2_xcch_handle_sacch_mac_signal(opts, state, smac, err); break;

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -516,6 +516,27 @@ test_sacch_dispatch_and_lcch_crc_abort(void) {
     rc |= expect_int("lcch crc abort resets ring", g_ring_reset_count[1], 1);
     rc |= expect_int("lcch crc abort no vpdu", g_vpdu_count, 0);
 
+    reset_stubs();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    fill_mac(mac, 0x80, 0x2222, 0x030405, 0x3456);
+    pack_payload_from_mac(payload, 180, mac, 0x0, 0, 0);
+    state.currentslot = 0;
+    state.p2_is_lcch = 1;
+
+    process_SACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("lcch cc sync timestamp", state.last_cc_sync_time_m > 0.0 ? 1 : 0, 1);
+
+    reset_stubs();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    state.p2_is_lcch = 1;
+    opts.p25_is_tuned = 1;
+
+    process_SACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("voice-tuned lcch no cc timestamp", state.last_cc_sync_time_m == 0.0 ? 1 : 0, 1);
+
     return rc;
 }
 

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -152,8 +152,9 @@ main(void) {
     st.p25_chan_tdma_explicit[id] = 2; // TDMA known
 
     // Two channels mapping to the same RF: low bit selects slot
-    int ch_slot0 = (id << 12) | 0x0002; // slot 0
-    int ch_slot1 = (id << 12) | 0x0003; // slot 1 (same RF)
+    int ch_slot0 = (id << 12) | 0x0002;      // slot 0
+    int ch_slot1 = (id << 12) | 0x0003;      // slot 1 (same RF)
+    int ch_next_slot0 = (id << 12) | 0x0004; // slot 0 on next RF
 
     p25_sm_ctx_t ctx;
     p25_sm_init_ctx(&ctx, &opts, &st);
@@ -267,9 +268,14 @@ main(void) {
     p25_sm_event(&eot_ctx, &eot_opts, &eot_st, &stale_update);
     rc |= expect_true("same-slot recent end grant skipped", g_tune_to_freq_calls == 1 && eot_opts.p25_is_tuned == 0);
 
-    p25_sm_event_t other_slot_update = p25_sm_ev_group_grant(ch_slot0, 0, 3001, 0, P25_SM_SVC_UNKNOWN);
+    p25_sm_event_t other_slot_update = p25_sm_ev_group_grant(ch_slot0, 0, 3001, 6002, P25_SM_SVC_UNKNOWN);
     p25_sm_event(&eot_ctx, &eot_opts, &eot_st, &other_slot_update);
-    rc |= expect_true("opposite-slot recent end grant allowed",
+    rc |=
+        expect_true("opposite-slot recent end grant skipped", g_tune_to_freq_calls == 1 && eot_opts.p25_is_tuned == 0);
+
+    p25_sm_event_t different_rf_update = p25_sm_ev_group_grant(ch_next_slot0, 0, 3001, 6002, P25_SM_SVC_UNKNOWN);
+    p25_sm_event(&eot_ctx, &eot_opts, &eot_st, &different_rf_update);
+    rc |= expect_true("different-rf recent end grant allowed",
                       g_tune_to_freq_calls == 2 && eot_opts.p25_is_tuned == 1 && eot_ctx.state == P25_SM_TUNED);
 
     static dsd_opts eot_other_opts;
@@ -295,6 +301,30 @@ main(void) {
     rc |= expect_true("different-tg recent end grant allowed", g_tune_to_freq_calls == 2
                                                                    && eot_other_opts.p25_is_tuned == 1
                                                                    && eot_other_ctx.state == P25_SM_TUNED);
+
+    static dsd_opts eot_expired_opts;
+    static dsd_state eot_expired_st;
+    DSD_MEMSET(&eot_expired_opts, 0, sizeof eot_expired_opts);
+    DSD_MEMSET(&eot_expired_st, 0, sizeof eot_expired_st);
+    eot_expired_opts.p25_trunk = 1;
+    eot_expired_opts.trunk_tune_group_calls = 1;
+    eot_expired_st.p25_cc_freq = 851000000;
+    eot_expired_st.p25_chan_iden = id;
+    eot_expired_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+    eot_expired_st.p25_chan_tdma_explicit[id] = 2;
+
+    p25_sm_ctx_t eot_expired_ctx;
+    p25_sm_init_ctx(&eot_expired_ctx, &eot_expired_opts, &eot_expired_st);
+    g_tune_to_freq_calls = 0;
+    g_return_to_cc_calls = 0;
+    p25_sm_event(&eot_expired_ctx, &eot_expired_opts, &eot_expired_st, &eot_grant);
+    p25_sm_event(&eot_expired_ctx, &eot_expired_opts, &eot_expired_st, &eot_ptt);
+    p25_sm_event(&eot_expired_ctx, &eot_expired_opts, &eot_expired_st, &eot_end);
+    eot_expired_ctx.recent_end_until_m = dsd_time_now_monotonic_s() - 0.001;
+    p25_sm_event(&eot_expired_ctx, &eot_expired_opts, &eot_expired_st, &stale_update);
+    rc |=
+        expect_true("expired recent end grant allowed", g_tune_to_freq_calls == 2 && eot_expired_opts.p25_is_tuned == 1
+                                                            && eot_expired_ctx.state == P25_SM_TUNED);
 
     // 8) A transient return-to-CC failure during grant timeout must not record
     // a failed VC until the retry is accepted.
@@ -349,6 +379,7 @@ main(void) {
     g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
     dsd_state_ext_free_all(&eot_other_st);
+    dsd_state_ext_free_all(&eot_expired_st);
     dsd_state_ext_free_all(&eot_st);
     dsd_state_ext_free_all(&forced_st);
     dsd_state_ext_free_all(&st);

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -231,7 +231,72 @@ main(void) {
                                                   && forced_st.p25_retune_block_slot == 1
                                                   && forced_st.p25_retune_block_until > time(NULL));
 
-    // 7) A transient return-to-CC failure during grant timeout must not record
+    // 7) A normal explicit P25P2 EOT suppresses stale same-call grant updates briefly.
+    static dsd_opts eot_opts;
+    static dsd_state eot_st;
+    DSD_MEMSET(&eot_opts, 0, sizeof eot_opts);
+    DSD_MEMSET(&eot_st, 0, sizeof eot_st);
+    eot_opts.p25_trunk = 1;
+    eot_opts.trunk_tune_group_calls = 1;
+    eot_opts.trunk_hangtime = 0.2f;
+    eot_st.p25_cc_freq = 851000000;
+    eot_st.p25_chan_iden = id;
+    eot_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+    eot_st.p25_chan_tdma_explicit[id] = 2;
+
+    p25_sm_ctx_t eot_ctx;
+    p25_sm_init_ctx(&eot_ctx, &eot_opts, &eot_st);
+    g_last_tuned_vc = 0;
+    g_tune_to_freq_calls = 0;
+    g_return_to_cc_calls = 0;
+    p25_sm_event_t eot_grant = p25_sm_ev_group_grant(ch_slot1, 0, 3001, 5001, 0);
+    p25_sm_event(&eot_ctx, &eot_opts, &eot_st, &eot_grant);
+    rc |= expect_true("eot initial tune",
+                      eot_st.p25_sm_tune_count == 1 && eot_opts.p25_is_tuned == 1 && g_tune_to_freq_calls == 1);
+
+    p25_sm_event_t eot_ptt = p25_sm_ev_ptt(1);
+    p25_sm_event(&eot_ctx, &eot_opts, &eot_st, &eot_ptt);
+    p25_sm_event_t eot_end = p25_sm_ev_end(1);
+    p25_sm_event(&eot_ctx, &eot_opts, &eot_st, &eot_end);
+    rc |= expect_true("eot returned",
+                      eot_opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1 && eot_ctx.state == P25_SM_ON_CC);
+    rc |= expect_true("eot no failed-vc backoff",
+                      eot_st.p25_retune_block_until == 0 && eot_st.p25_retune_block_freq == 0);
+
+    p25_sm_event_t stale_update = p25_sm_ev_group_grant(ch_slot1, 0, 3001, 0, P25_SM_SVC_UNKNOWN);
+    p25_sm_event(&eot_ctx, &eot_opts, &eot_st, &stale_update);
+    rc |= expect_true("same-slot recent end grant skipped", g_tune_to_freq_calls == 1 && eot_opts.p25_is_tuned == 0);
+
+    p25_sm_event_t other_slot_update = p25_sm_ev_group_grant(ch_slot0, 0, 3001, 0, P25_SM_SVC_UNKNOWN);
+    p25_sm_event(&eot_ctx, &eot_opts, &eot_st, &other_slot_update);
+    rc |= expect_true("opposite-slot recent end grant allowed",
+                      g_tune_to_freq_calls == 2 && eot_opts.p25_is_tuned == 1 && eot_ctx.state == P25_SM_TUNED);
+
+    static dsd_opts eot_other_opts;
+    static dsd_state eot_other_st;
+    DSD_MEMSET(&eot_other_opts, 0, sizeof eot_other_opts);
+    DSD_MEMSET(&eot_other_st, 0, sizeof eot_other_st);
+    eot_other_opts.p25_trunk = 1;
+    eot_other_opts.trunk_tune_group_calls = 1;
+    eot_other_st.p25_cc_freq = 851000000;
+    eot_other_st.p25_chan_iden = id;
+    eot_other_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+    eot_other_st.p25_chan_tdma_explicit[id] = 2;
+
+    p25_sm_ctx_t eot_other_ctx;
+    p25_sm_init_ctx(&eot_other_ctx, &eot_other_opts, &eot_other_st);
+    g_tune_to_freq_calls = 0;
+    g_return_to_cc_calls = 0;
+    p25_sm_event(&eot_other_ctx, &eot_other_opts, &eot_other_st, &eot_grant);
+    p25_sm_event(&eot_other_ctx, &eot_other_opts, &eot_other_st, &eot_ptt);
+    p25_sm_event(&eot_other_ctx, &eot_other_opts, &eot_other_st, &eot_end);
+    p25_sm_event_t different_tg_update = p25_sm_ev_group_grant(ch_slot1, 0, 3002, 0, P25_SM_SVC_UNKNOWN);
+    p25_sm_event(&eot_other_ctx, &eot_other_opts, &eot_other_st, &different_tg_update);
+    rc |= expect_true("different-tg recent end grant allowed", g_tune_to_freq_calls == 2
+                                                                   && eot_other_opts.p25_is_tuned == 1
+                                                                   && eot_other_ctx.state == P25_SM_TUNED);
+
+    // 8) A transient return-to-CC failure during grant timeout must not record
     // a failed VC until the retry is accepted.
     static const dsd_trunk_tune_result transient_returns[] = {
         DSD_TRUNK_TUNE_RESULT_DEFERRED,
@@ -283,6 +348,8 @@ main(void) {
     }
     g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
+    dsd_state_ext_free_all(&eot_other_st);
+    dsd_state_ext_free_all(&eot_st);
     dsd_state_ext_free_all(&forced_st);
     dsd_state_ext_free_all(&st);
 


### PR DESCRIPTION
## Summary

- Suppress immediate same TG/frequency/slot P25P2 grant updates after explicit TDMA EOT so Motorola systems stay on the control channel instead of bouncing back to the just-ended voice channel.
- Refresh P25P2 LCCH control-channel activity timestamps after good CRCs while parked on CC.
- Add regression coverage for the recent-EOT grant suppressor and LCCH CC-sync refresh behavior.

Root cause: explicit P25P2 call-end release returned to CC successfully, but the trunk SM accepted a same-call post-EOT grant update immediately afterward. Motorola systems appear to emit that update pattern more readily than the Harris system tested.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / none. Protocol.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [ ] `ctest --preset dev-debug --output-on-failure`
- [ ] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes

Additional focused checks:

- [x] `ctest --preset dev-debug --output-on-failure -R 'P25_RETUNE_BACKOFF_SLOT|P25_P2_XCCH_HELPERS'`
- [x] `ctest --preset dev-debug --output-on-failure -R 'P25_SM|P25_RETUNE_BACKOFF_SLOT|P25_P2_XCCH_HELPERS'`
- [x] Pre-push clang-format, clang-tidy, cppcheck strict, IWYU strict, and lizard checks

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: none expected.
- Compatibility or packaging impact: none expected.