### PR TITLE
p25: follow data channel grants

### DIFF
--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -78,16 +78,17 @@ typedef enum {
 
 typedef struct {
     p25_sm_event_type_e type;
-    int slot;     // 0 or 1 for TDMA, -1 for P1/N/A
-    int channel;  // 16-bit channel number (for GRANT)
-    long freq_hz; // Frequency in Hz (for GRANT)
-    int tg;       // Talkgroup (for GRANT, 0 if individual)
-    int src;      // Source RID (for GRANT)
-    int dst;      // Destination RID (for individual GRANT)
-    int svc_bits; // Service options (for GRANT), or P25_SM_SVC_UNKNOWN when absent
-    int is_group; // 1 for group grant, 0 for individual
-    int algid;    // Algorithm ID (for ENC event)
-    int keyid;    // Key ID (for ENC event)
+    int slot;               // 0 or 1 for TDMA, -1 for P1/N/A
+    int channel;            // 16-bit channel number (for GRANT)
+    long freq_hz;           // Frequency in Hz (for GRANT)
+    int tg;                 // Talkgroup (for GRANT, 0 if individual)
+    int src;                // Source RID (for GRANT)
+    int dst;                // Destination RID (for individual GRANT)
+    int svc_bits;           // Service options (for GRANT), or P25_SM_SVC_UNKNOWN when absent
+    int data_call_override; // 0=infer from svc_bits, 1=force data, -1=force non-data
+    int is_group;           // 1 for group grant, 0 for individual
+    int algid;              // Algorithm ID (for ENC event)
+    int keyid;              // Key ID (for ENC event)
 } p25_sm_event_t;
 
 /* ============================================================================
@@ -381,6 +382,18 @@ void p25_sm_init(dsd_opts* opts, dsd_state* state);
 void p25_sm_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src);
 
 /**
+ * @brief Handle a group data channel grant (explicit data policy form).
+ *
+ * @param opts Decoder options.
+ * @param state Decoder state.
+ * @param channel Data channel number.
+ * @param svc_bits Service options associated with the grant, or P25_SM_SVC_UNKNOWN when absent.
+ * @param tg Talkgroup.
+ * @param src Source RID.
+ */
+void p25_sm_on_group_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src);
+
+/**
  * @brief Apply group grant policy side effects without attempting route/tune.
  *
  * Use when a decoder has a valid group grant but cannot yet resolve or follow
@@ -407,6 +420,18 @@ void p25_sm_apply_group_grant_policy(dsd_opts* opts, dsd_state* state, int chann
  * @param src Source RID.
  */
 void p25_sm_on_indiv_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src);
+
+/**
+ * @brief Handle an individual data channel grant (explicit data policy form).
+ *
+ * @param opts Decoder options.
+ * @param state Decoder state.
+ * @param channel Data channel number.
+ * @param svc_bits Service options associated with the grant, or P25_SM_SVC_UNKNOWN when absent.
+ * @param dst Destination RID.
+ * @param src Source RID.
+ */
+void p25_sm_on_indiv_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src);
 
 /**
  * @brief Handle an explicit release/end-of-call indication.
@@ -501,6 +526,20 @@ p25_sm_ev_indiv_grant(int channel, long freq_hz, int dst, int src, int svc_bits)
     ev.src = src;
     ev.svc_bits = svc_bits;
     ev.is_group = 0;
+    return ev;
+}
+
+static inline p25_sm_event_t
+p25_sm_ev_group_data_grant(int channel, long freq_hz, int tg, int src, int svc_bits) {
+    p25_sm_event_t ev = p25_sm_ev_group_grant(channel, freq_hz, tg, src, svc_bits);
+    ev.data_call_override = 1;
+    return ev;
+}
+
+static inline p25_sm_event_t
+p25_sm_ev_indiv_data_grant(int channel, long freq_hz, int dst, int src, int svc_bits) {
+    p25_sm_event_t ev = p25_sm_ev_indiv_grant(channel, freq_hz, dst, src, svc_bits);
+    ev.data_call_override = 1;
     return ev;
 }
 

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -85,10 +85,10 @@ typedef struct {
     int src;                // Source RID (for GRANT)
     int dst;                // Destination RID (for individual GRANT)
     int svc_bits;           // Service options (for GRANT), or P25_SM_SVC_UNKNOWN when absent
-    int data_call_override; // 0=infer from svc_bits, 1=force data, -1=force non-data
     int is_group;           // 1 for group grant, 0 for individual
     int algid;              // Algorithm ID (for ENC event)
     int keyid;              // Key ID (for ENC event)
+    int data_call_override; // 0=infer from svc_bits, 1=force data, -1=force non-data
 } p25_sm_event_t;
 
 /* ============================================================================

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -130,6 +130,7 @@ typedef struct {
     int vc_tg;
     int vc_src;
     int vc_is_tdma;          // 1 if TDMA channel, 0 if single-carrier
+    int vc_data_call;        // 1 if the accepted grant is data, 0 if voice
     int vc_cqpsk_retry_done; // 1 once we retried VC tune with alternate CQPSK DSP mode for this grant
 
     // Per-slot activity (index 0 = left/P1, index 1 = right)

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm_api.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm_api.h
@@ -17,6 +17,8 @@ typedef struct p25_sm_api {
     void (*init)(dsd_opts* opts, dsd_state* state);
     void (*on_group_grant)(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src);
     void (*on_indiv_grant)(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src);
+    void (*on_group_data_grant)(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src);
+    void (*on_indiv_data_grant)(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src);
     void (*on_release)(dsd_opts* opts, dsd_state* state);
     void (*on_neighbor_update)(dsd_opts* opts, dsd_state* state, const long* freqs, int count);
     int (*next_cc_candidate)(dsd_state* state, long* out_freq);

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm_api.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm_api.h
@@ -17,14 +17,14 @@ typedef struct p25_sm_api {
     void (*init)(dsd_opts* opts, dsd_state* state);
     void (*on_group_grant)(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src);
     void (*on_indiv_grant)(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src);
-    void (*on_group_data_grant)(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src);
-    void (*on_indiv_data_grant)(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src);
     void (*on_release)(dsd_opts* opts, dsd_state* state);
     void (*on_neighbor_update)(dsd_opts* opts, dsd_state* state, const long* freqs, int count);
     int (*next_cc_candidate)(dsd_state* state, long* out_freq);
     void (*tick)(dsd_opts* opts, dsd_state* state);
     void (*on_queued_response)(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target);
     void (*on_deny_response)(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target);
+    void (*on_group_data_grant)(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src);
+    void (*on_indiv_data_grant)(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src);
 } p25_sm_api;
 
 void p25_sm_set_api(const p25_sm_api* api);

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -522,7 +522,13 @@ p25_grant_eval_ctx_from_event(const p25_sm_event_t* ev) {
     }
     ctx.svc_valid = p25_sm_svc_bits_valid(ev->svc_bits);
     ctx.svc = ctx.svc_valid ? ev->svc_bits : 0;
-    ctx.data_call = (ctx.svc_valid && SVC_IS_DATA(ctx.svc)) ? 1 : 0;
+    if (ev->data_call_override > 0) {
+        ctx.data_call = 1;
+    } else if (ev->data_call_override < 0) {
+        ctx.data_call = 0;
+    } else {
+        ctx.data_call = (ctx.svc_valid && SVC_IS_DATA(ctx.svc)) ? 1 : 0;
+    }
     ctx.encrypted_call = (ctx.svc_valid && SVC_IS_ENC(ctx.svc)) ? 1 : 0;
     ctx.is_indiv = !ev->is_group;
     ctx.tg = ctx.is_indiv ? ev->dst : ev->tg;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -815,7 +815,8 @@ p25_grant_track_src_tg(dsd_state* state, const p25_sm_event_t* ev, const p25_gra
 }
 
 static int
-grant_allowed(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, dsd_tg_policy_decision* out_decision) {
+grant_allowed(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, dsd_tg_policy_decision* out_decision,
+              p25_grant_eval_ctx_t* out_eval_ctx) {
     p25_grant_eval_ctx_t eval_ctx;
     dsd_tg_policy_decision decision;
     if (!opts || !state || !ev) {
@@ -833,10 +834,16 @@ grant_allowed(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, dsd_tg
         if (out_decision) {
             *out_decision = decision;
         }
+        if (out_eval_ctx) {
+            *out_eval_ctx = eval_ctx;
+        }
         return 0;
     }
 
     if (p25_grant_transient_enc_cache_blocks(opts, state, &eval_ctx)) {
+        if (out_eval_ctx) {
+            *out_eval_ctx = eval_ctx;
+        }
         return 0;
     }
 
@@ -847,6 +854,9 @@ grant_allowed(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, dsd_tg
 
     if (out_decision) {
         *out_decision = decision;
+    }
+    if (out_eval_ctx) {
+        *out_eval_ctx = eval_ctx;
     }
     return 1;
 }
@@ -947,7 +957,7 @@ p25_grant_clear_slot_state(p25_sm_ctx_t* ctx) {
 
 static void
 p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_event_t* ev, long freq, int target_id,
-                           double now_m) {
+                           const p25_grant_eval_ctx_t* eval_ctx, double now_m) {
     if (!ctx || !ev) {
         return;
     }
@@ -956,6 +966,7 @@ p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_eve
     ctx->vc_tg = target_id;
     ctx->vc_src = ev->src;
     ctx->vc_is_tdma = is_tdma_channel(state, ev->channel);
+    ctx->vc_data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
     ctx->t_tune_m = now_m;
     ctx->t_voice_m = 0.0;
     ctx->vc_cqpsk_retry_done = 0;
@@ -1063,13 +1074,15 @@ p25_grant_debug_log_tdma(const dsd_opts* opts, const dsd_state* state, const p25
 static int
 p25_grant_handle_duplicate(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state,
                            const dsd_tg_policy_call_route* route, const dsd_tg_policy_decision* decision, long freq,
-                           int target_id, double now_m) {
-    if (ctx->state != P25_SM_TUNED || ctx->vc_freq_hz != freq || ctx->vc_tg != target_id) {
+                           int target_id, const p25_grant_eval_ctx_t* eval_ctx, double now_m) {
+    int data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
+    if (ctx->state != P25_SM_TUNED || ctx->vc_freq_hz != freq || ctx->vc_tg != target_id
+        || ctx->vc_data_call != data_call) {
         return 0;
     }
     (void)dsd_tg_policy_note_active_call(state, route, decision, now_m);
-    p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_duplicate", "freq=%ld tg=%d target=%d slot=%d", freq, ctx->vc_tg,
-                 target_id, route->slot);
+    p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_duplicate", "freq=%ld tg=%d target=%d slot=%d data=%d", freq,
+                 ctx->vc_tg, target_id, route->slot, data_call);
     sm_log(opts, state, "grant-same-freq");
     return 1;
 }
@@ -1267,13 +1280,15 @@ p25_grant_prepare_route(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* stat
 static void
 handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev) {
     dsd_tg_policy_decision decision;
+    p25_grant_eval_ctx_t eval_ctx;
     p25_grant_route_ctx_t grant;
     if (!ctx || !ev || !opts || !state) {
         return;
     }
+    DSD_MEMSET(&eval_ctx, 0, sizeof(eval_ctx));
 
     // Check grant policy
-    if (!grant_allowed(opts, state, ev, &decision)) {
+    if (!grant_allowed(opts, state, ev, &decision, &eval_ctx)) {
         return;
     }
 
@@ -1283,7 +1298,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
 
     // Skip if already tuned to same frequency AND same TG (avoid bounce on duplicate grants)
     // Different TG/call type should still trigger a new tune
-    if (p25_grant_handle_duplicate(ctx, opts, state, &grant.route, &decision, grant.freq, grant.target_id,
+    if (p25_grant_handle_duplicate(ctx, opts, state, &grant.route, &decision, grant.freq, grant.target_id, &eval_ctx,
                                    grant.now_m)) {
         p25_grant_store_policy_tg(state, ev, grant.slot, &decision);
         return;
@@ -1298,7 +1313,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     if (!p25_grant_try_tune_vc(ctx, ev, opts, state, grant.freq, grant.slot, &grant.ted_sps)) {
         return;
     }
-    p25_grant_store_vc_context(ctx, state, ev, grant.freq, grant.target_id, grant.now_m);
+    p25_grant_store_vc_context(ctx, state, ev, grant.freq, grant.target_id, &eval_ctx, grant.now_m);
     p25_grant_clear_slot_state(ctx);
     p25_grant_clear_replaced_policy_tg(state, grant.slot, grant.clear_policy_slot_only);
     p25_grant_store_policy_tg(state, ev, grant.slot, &decision);
@@ -1310,9 +1325,9 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     (void)dsd_tg_policy_note_active_call(state, &grant.route, &decision, grant.now_m);
     p25_sm_diagf(opts, state, ctx, "grant_accept",
                  "ch=0x%04X freq=%ld slot=%d target=%d ota_tg=%d src=%d needs_retune=%d "
-                 "prio=%d preempt=%d",
+                 "prio=%d preempt=%d data=%d",
                  ev->channel & 0xFFFF, grant.freq, grant.slot, grant.target_id, ev->tg, ev->src, grant.needs_retune,
-                 decision.priority, decision.preempt_requested);
+                 decision.priority, decision.preempt_requested, eval_ctx.data_call);
 
     set_state(ctx, opts, state, P25_SM_TUNED, "grant");
 }
@@ -1325,7 +1340,7 @@ p25_sm_apply_group_grant_policy(dsd_opts* opts, dsd_state* state, int channel, i
 
     p25_sm_event_t ev = p25_sm_ev_group_grant(channel, 0, tg, src, svc_bits);
     dsd_tg_policy_decision decision;
-    if (grant_allowed(opts, state, &ev, &decision)) {
+    if (grant_allowed(opts, state, &ev, &decision, NULL)) {
         p25_sm_diagf(opts, state, NULL, "grant_policy_only", "ch=0x%04X tg=%d src=%d svc=0x%02X policy_tg=%u",
                      channel & 0xFFFF, tg, src, svc_bits & 0xFF, decision.target_id);
     }
@@ -1567,9 +1582,9 @@ p25_release_return_to_cc_accepted(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
     }
 
     *out_tune_start_m = now_monotonic();
-    p25_sm_diagf(opts, state, ctx, "release_cc_attempt", "freq=%ld ch=0x%04X tg=%d force=%d tdma=%d",
+    p25_sm_diagf(opts, state, ctx, "release_cc_attempt", "freq=%ld ch=0x%04X tg=%d force=%d tdma=%d data=%d",
                  state ? ((state->p25_cc_freq != 0) ? state->p25_cc_freq : state->trunk_cc_freq) : 0,
-                 ctx->vc_channel & 0xFFFF, ctx->vc_tg, had_force_release, ctx->vc_is_tdma);
+                 ctx->vc_channel & 0xFFFF, ctx->vc_tg, had_force_release, ctx->vc_is_tdma, ctx->vc_data_call);
     dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_return_to_cc(opts, state);
     if (dsd_trunk_tune_result_is_ok(tune_result)) {
         p25_sm_diagf(opts, state, ctx, "release_cc_result", "result=%s tune_start_m=%.3f",
@@ -1593,6 +1608,7 @@ p25_release_clear_context(p25_sm_ctx_t* ctx) {
     ctx->vc_channel = 0;
     ctx->vc_tg = 0;
     ctx->vc_src = 0;
+    ctx->vc_data_call = 0;
     ctx->t_tune_m = 0.0;
     ctx->t_voice_m = 0.0;
     ctx->release_count++;
@@ -1632,6 +1648,11 @@ static void
 p25_arm_failed_vc_retune_backoff(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
     if (!ctx || !state || ctx->vc_freq_hz <= 0 || ctx->t_voice_m > 0.0 || ctx->slots[0].voice_active
         || ctx->slots[1].voice_active) {
+        return;
+    }
+    if (ctx->vc_data_call) {
+        p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_backoff_skip", "reason=data-grant ch=0x%04X freq=%ld",
+                     ctx->vc_channel & 0xFFFF, ctx->vc_freq_hz);
         return;
     }
 
@@ -2310,7 +2331,7 @@ p25_sm_tick_tuned_wait_voice(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state
     double dt_tune = now_m - ctx->t_tune_m;
     p25_sm_tick_try_cqpsk_retry(ctx, opts, state, now_m, dt_tune);
     if (dt_tune >= grant_timeout) {
-        do_release(ctx, opts, state, "grant-timeout", 1);
+        do_release(ctx, opts, state, "grant-timeout", ctx->vc_data_call ? 0 : 1);
     }
 }
 

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -654,9 +654,14 @@ p25_grant_apply_clear_override(const dsd_opts* opts, const dsd_state* state, p25
     }
 }
 
+static int
+p25_grant_uses_voice_enc_cache(const p25_grant_eval_ctx_t* eval_ctx) {
+    return (eval_ctx && !eval_ctx->data_call) ? 1 : 0;
+}
+
 static void
 p25_grant_clear_transient_cache_if_clear(dsd_state* state, const p25_grant_eval_ctx_t* eval_ctx) {
-    if (!state || !eval_ctx || eval_ctx->is_indiv || eval_ctx->tg <= 0) {
+    if (!state || !eval_ctx || !p25_grant_uses_voice_enc_cache(eval_ctx) || eval_ctx->is_indiv || eval_ctx->tg <= 0) {
         return;
     }
     if ((eval_ctx->svc_valid && !eval_ctx->encrypted_call) || eval_ctx->enc_override_clear) {
@@ -675,6 +680,9 @@ p25_grant_patch_clear_key(const dsd_state* state, const p25_grant_eval_ctx_t* ev
 static int
 p25_grant_transient_enc_cache_blocks(dsd_opts* opts, dsd_state* state, const p25_grant_eval_ctx_t* eval_ctx) {
     if (!opts || !state || !eval_ctx || eval_ctx->is_indiv || eval_ctx->tg <= 0 || opts->trunk_tune_enc_calls != 0) {
+        return 0;
+    }
+    if (!p25_grant_uses_voice_enc_cache(eval_ctx)) {
         return 0;
     }
     if (eval_ctx->svc_valid) {
@@ -788,7 +796,8 @@ p25_grant_handle_policy_block(dsd_opts* opts, dsd_state* state, const p25_grant_
                  eval_ctx->svc, eval_ctx->data_call, eval_ctx->encrypted_call, eval_ctx->is_indiv,
                  decision->block_reasons);
     sm_log(opts, state, grant_block_log_tag(eval_ctx->is_indiv, decision->block_reasons));
-    if (!eval_ctx->is_indiv && eval_ctx->tg > 0 && (decision->block_reasons & DSD_TG_POLICY_BLOCK_ENCRYPTED_DISABLED)) {
+    if (p25_grant_uses_voice_enc_cache(eval_ctx) && !eval_ctx->is_indiv && eval_ctx->tg > 0
+        && (decision->block_reasons & DSD_TG_POLICY_BLOCK_ENCRYPTED_DISABLED)) {
         p25_emit_enc_lockout_once(opts, state, 0, eval_ctx->tg, eval_ctx->svc);
     }
     return 1;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1248,9 +1248,10 @@ p25_grant_should_clear_slot_only(const p25_sm_ctx_t* ctx, const dsd_state* state
 
 static int
 p25_grant_prepare_route(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev,
-                        const dsd_tg_policy_decision* decision, p25_grant_route_ctx_t* out) {
+                        const dsd_tg_policy_decision* decision, const p25_grant_eval_ctx_t* eval_ctx,
+                        p25_grant_route_ctx_t* out) {
     p25_freq_trace_t freq_trace;
-    if (!ctx || !opts || !state || !ev || !decision || !out) {
+    if (!ctx || !opts || !state || !ev || !decision || !eval_ctx || !out) {
         return 0;
     }
     DSD_MEMSET(out, 0, sizeof(*out));
@@ -1263,7 +1264,7 @@ p25_grant_prepare_route(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* stat
 
     out->now_m = now_monotonic();
     out->slot = channel_slot(state, ev->channel);
-    if (p25_grant_retune_blocked(opts, state, out->freq, out->slot, ev->channel)) {
+    if (!eval_ctx->data_call && p25_grant_retune_blocked(opts, state, out->freq, out->slot, ev->channel)) {
         return 0;
     }
     out->needs_retune = (ctx->state == P25_SM_TUNED && ctx->vc_freq_hz != 0 && ctx->vc_freq_hz != out->freq) ? 1 : 0;
@@ -1292,7 +1293,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
         return;
     }
 
-    if (!p25_grant_prepare_route(ctx, opts, state, ev, &decision, &grant)) {
+    if (!p25_grant_prepare_route(ctx, opts, state, ev, &decision, &eval_ctx, &grant)) {
         return;
     }
 

--- a/src/protocol/p25/p25_trunk_sm_wrappers.c
+++ b/src/protocol/p25/p25_trunk_sm_wrappers.c
@@ -112,6 +112,12 @@ p25_sm_on_group_grant_default(dsd_opts* opts, dsd_state* state, int channel, int
     p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);
 }
 
+static void
+p25_sm_on_group_data_grant_default(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
+    p25_sm_event_t ev = p25_sm_ev_group_data_grant(channel, 0, tg, src, svc_bits);
+    p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);
+}
+
 void
 p25_sm_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
     p25_sm_api api = p25_sm_get_api();
@@ -122,9 +128,29 @@ p25_sm_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bit
     p25_sm_on_group_grant_default(opts, state, channel, svc_bits, tg, src);
 }
 
+void
+p25_sm_on_group_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
+    p25_sm_api api = p25_sm_get_api();
+    if (api.on_group_data_grant) {
+        api.on_group_data_grant(opts, state, channel, svc_bits, tg, src);
+        return;
+    }
+    if (api.on_group_grant) {
+        api.on_group_grant(opts, state, channel, svc_bits, tg, src);
+        return;
+    }
+    p25_sm_on_group_data_grant_default(opts, state, channel, svc_bits, tg, src);
+}
+
 static void
 p25_sm_on_indiv_grant_default(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src) {
     p25_sm_event_t ev = p25_sm_ev_indiv_grant(channel, 0, dst, src, svc_bits);
+    p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);
+}
+
+static void
+p25_sm_on_indiv_data_grant_default(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src) {
+    p25_sm_event_t ev = p25_sm_ev_indiv_data_grant(channel, 0, dst, src, svc_bits);
     p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);
 }
 
@@ -136,6 +162,20 @@ p25_sm_on_indiv_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bit
         return;
     }
     p25_sm_on_indiv_grant_default(opts, state, channel, svc_bits, dst, src);
+}
+
+void
+p25_sm_on_indiv_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src) {
+    p25_sm_api api = p25_sm_get_api();
+    if (api.on_indiv_data_grant) {
+        api.on_indiv_data_grant(opts, state, channel, svc_bits, dst, src);
+        return;
+    }
+    if (api.on_indiv_grant) {
+        api.on_indiv_grant(opts, state, channel, svc_bits, dst, src);
+        return;
+    }
+    p25_sm_on_indiv_data_grant_default(opts, state, channel, svc_bits, dst, src);
 }
 
 static void

--- a/src/protocol/p25/phase1/p25p1_pdu_trunking.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_trunking.c
@@ -640,7 +640,8 @@ p25_handle_mbt_roaming_address(const uint8_t* mpdu_byte, uint8_t opcode) {
 }
 
 static void DSD_ATTR_USED
-p25_handle_mbt_individual_data_channel_grant(const uint8_t* mpdu_byte, size_t mpdu_len) {
+p25_handle_mbt_individual_data_channel_grant(dsd_opts* opts, dsd_state* state, const uint8_t* mpdu_byte,
+                                             size_t mpdu_len) {
     int has_uplink = mpdu_len >= 26U;
     uint8_t svc = mpdu_byte[8];
     uint32_t source = p25_mbt_u24(mpdu_byte, 3U);
@@ -651,6 +652,7 @@ p25_handle_mbt_individual_data_channel_grant(const uint8_t* mpdu_byte, size_t mp
     uint32_t target = p25_mbt_u24(mpdu_byte, 19U);
     uint16_t channelt = p25_mbt_u16(mpdu_byte, 22U);
     uint16_t channelr = has_uplink ? p25_mbt_u16(mpdu_byte, 24U) : 0xFFFFU;
+    long int freq = 0;
 
     DSD_FPRINTF(stderr, "%s", KYEL);
     DSD_FPRINTF(stderr, "\n Individual Data Channel Grant MBT - Obsolete");
@@ -659,20 +661,46 @@ p25_handle_mbt_individual_data_channel_grant(const uint8_t* mpdu_byte, size_t mp
     if (has_uplink) {
         DSD_FPRINTF(stderr, " CHAN-R [%04X]", channelr);
     }
+
+    freq = process_channel_to_freq(opts, state, channelt);
+    if (has_uplink) {
+        (void)process_channel_to_freq(opts, state, channelr);
+    }
+
+    dsd_tg_policy_decision decision;
+    if (dsd_tg_policy_evaluate_private_call(opts, state, source, target, (svc & 0x40) ? 1 : 0, 1,
+                                            DSD_TG_POLICY_PRIVATE_ALLOWLIST_UNKNOWN_BLOCK,
+                                            DSD_TG_POLICY_HOLD_COMPAT_GRANT, &decision)
+            != 0
+        || !decision.tune_allowed) {
+        return;
+    }
+
+    if (p25p1_pdu_can_tune_grant(opts, state, freq)) {
+        p25_sm_on_indiv_data_grant(opts, state, channelt, svc, (int)target, (int)source);
+    }
 }
 
 static void DSD_ATTR_USED
-p25_handle_mbt_group_data_channel_grant(const uint8_t* mpdu_byte) {
+p25_handle_mbt_group_data_channel_grant(dsd_opts* opts, dsd_state* state, const uint8_t* mpdu_byte) {
     uint8_t svc = mpdu_byte[8];
     uint32_t source = p25_mbt_u24(mpdu_byte, 3U);
     uint16_t channelt = p25_mbt_u16(mpdu_byte, 14U);
     uint16_t channelr = p25_mbt_u16(mpdu_byte, 16U);
     uint16_t group = p25_mbt_u16(mpdu_byte, 18U);
+    long int freq = 0;
 
     DSD_FPRINTF(stderr, "%s", KYEL);
     DSD_FPRINTF(stderr, "\n Group Data Channel Grant MBT - Obsolete");
     DSD_FPRINTF(stderr, " SVC [%02X] SRC [%u] CHAN-T [%04X] CHAN-R [%04X] Group [%d][%04X]", svc, source, channelt,
                 channelr, group, group);
+
+    freq = process_channel_to_freq(opts, state, channelt);
+    (void)process_channel_to_freq(opts, state, channelr);
+
+    if (p25p1_pdu_can_tune_grant(opts, state, freq)) {
+        p25_sm_on_group_data_grant(opts, state, channelt, svc, (int)group, (int)source);
+    }
 }
 
 static int DSD_ATTR_USED
@@ -1099,19 +1127,20 @@ p25_handle_mbt_voice_service_opcode(dsd_opts* opts, dsd_state* state, const uint
 }
 
 static int
-p25_handle_mbt_data_service_opcode(const uint8_t* mpdu_byte, size_t mpdu_len, const p25p1_mbt_fields* fields) {
+p25_handle_mbt_data_service_opcode(dsd_opts* opts, dsd_state* state, const uint8_t* mpdu_byte, size_t mpdu_len,
+                                   const p25p1_mbt_fields* fields) {
     switch (fields->opcode) {
         case 0x10:
             if (!p25_mbt_require_len(fields, mpdu_len, 24U, "Individual Data Channel Grant")) {
                 return 1;
             }
-            p25_handle_mbt_individual_data_channel_grant(mpdu_byte, mpdu_len);
+            p25_handle_mbt_individual_data_channel_grant(opts, state, mpdu_byte, mpdu_len);
             return 1;
         case 0x11:
             if (!p25_mbt_require_len(fields, mpdu_len, 20U, "Group Data Channel Grant")) {
                 return 1;
             }
-            p25_handle_mbt_group_data_channel_grant(mpdu_byte);
+            p25_handle_mbt_group_data_channel_grant(opts, state, mpdu_byte);
             return 1;
         default: return 0;
     }
@@ -1187,7 +1216,7 @@ p25_handle_mbt_standard_opcode(dsd_opts* opts, dsd_state* state, const uint8_t* 
     if (p25_handle_mbt_voice_service_opcode(opts, state, mpdu_byte, mpdu_len, fields)) {
         return 1;
     }
-    if (p25_handle_mbt_data_service_opcode(mpdu_byte, mpdu_len, fields)) {
+    if (p25_handle_mbt_data_service_opcode(opts, state, mpdu_byte, mpdu_len, fields)) {
         return 1;
     }
     if (p25_handle_mbt_command_metadata_opcode(mpdu_byte, mpdu_len, fields)) {

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -283,6 +283,15 @@ tsbk_u24(const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK], int offset) {
 }
 
 static int
+tsbk_can_tune_data_grant(const dsd_opts* opts, dsd_state* state, long int freq) {
+    if (!opts || !state || opts->p25_trunk != 1 || opts->p25_is_tuned != 0 || freq == 0) {
+        return 0;
+    }
+    p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
+    return state->p25_cc_freq != 0;
+}
+
+static int
 tsbk_handle_individual_data_channel_grant(dsd_opts* opts, dsd_state* state,
                                           const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK]) {
     uint16_t channel = tsbk_u16(tsbk_byte, 2);
@@ -294,7 +303,7 @@ tsbk_handle_individual_data_channel_grant(dsd_opts* opts, dsd_state* state,
     if (channel != 0) {
         freq = process_channel_to_freq(opts, state, channel);
     }
-    if (opts && opts->p25_trunk == 1 && channel != 0 && freq != 0) {
+    if (opts && state && opts->p25_trunk == 1 && channel != 0 && freq != 0) {
         dsd_tg_policy_decision decision;
         if (dsd_tg_policy_evaluate_private_call(opts, state, (uint32_t)source, (uint32_t)target, 0, 1,
                                                 DSD_TG_POLICY_PRIVATE_ALLOWLIST_UNKNOWN_BLOCK,
@@ -303,8 +312,9 @@ tsbk_handle_individual_data_channel_grant(dsd_opts* opts, dsd_state* state,
             || !decision.tune_allowed) {
             return 1;
         }
-        p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
-        p25_sm_on_indiv_data_grant(opts, state, channel, P25_SM_SVC_UNKNOWN, target, source);
+        if (tsbk_can_tune_data_grant(opts, state, freq)) {
+            p25_sm_on_indiv_data_grant(opts, state, channel, P25_SM_SVC_UNKNOWN, target, source);
+        }
     }
     return 1;
 }
@@ -322,8 +332,7 @@ tsbk_handle_group_data_channel_grant(dsd_opts* opts, dsd_state* state, const uin
     if (channel != 0) {
         freq = process_channel_to_freq(opts, state, channel);
     }
-    if (opts && opts->p25_trunk == 1 && channel != 0 && freq != 0) {
-        p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
+    if (channel != 0 && tsbk_can_tune_data_grant(opts, state, freq)) {
         p25_sm_on_group_data_grant(opts, state, channel, svc_bits, group, src);
     }
     return 1;

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -282,68 +282,92 @@ tsbk_u24(const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK], int offset) {
 }
 
 static int
-tsbk_handle_standard_osp_data_channel(const dsd_opts* opts, dsd_state* state,
-                                      const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK]) {
+tsbk_handle_individual_data_channel_grant(dsd_opts* opts, dsd_state* state,
+                                          const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK]) {
+    uint16_t channel = tsbk_u16(tsbk_byte, 2);
+    int target = tsbk_u24(tsbk_byte, 4);
+    int source = tsbk_u24(tsbk_byte, 7);
+    long int freq = 0;
+    DSD_FPRINTF(stderr, "\n Individual Data Channel Grant - Obsolete");
+    DSD_FPRINTF(stderr, "\n  CHAN [%04X] Target [%d] Source [%d]", channel, target, source);
+    if (channel != 0) {
+        freq = process_channel_to_freq(opts, state, channel);
+    }
+    if (opts && opts->p25_trunk == 1 && channel != 0 && freq != 0) {
+        p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
+        p25_sm_on_indiv_data_grant(opts, state, channel, P25_SM_SVC_UNKNOWN, target, source);
+    }
+    return 1;
+}
+
+static int
+tsbk_handle_group_data_channel_grant(dsd_opts* opts, dsd_state* state, const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK]) {
+    uint8_t svc_bits = tsbk_byte[2];
+    uint16_t channel = tsbk_u16(tsbk_byte, 3);
+    uint16_t group = tsbk_u16(tsbk_byte, 5);
+    int src = tsbk_u24(tsbk_byte, 7);
+    long int freq = 0;
+    DSD_FPRINTF(stderr, "\n Group Data Channel Grant - Obsolete");
+    DSD_FPRINTF(stderr, "\n  SVC [%02X] CHAN [%04X] Group [%d][%04X] Source [%d]", svc_bits, channel, group, group,
+                src);
+    if (channel != 0) {
+        freq = process_channel_to_freq(opts, state, channel);
+    }
+    if (opts && opts->p25_trunk == 1 && channel != 0 && freq != 0) {
+        p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
+        p25_sm_on_group_data_grant(opts, state, channel, svc_bits, group, src);
+    }
+    return 1;
+}
+
+static int
+tsbk_handle_group_data_channel_announcement(const dsd_opts* opts, dsd_state* state,
+                                            const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK]) {
+    uint16_t channel_a = tsbk_u16(tsbk_byte, 2);
+    uint16_t group_a = tsbk_u16(tsbk_byte, 4);
+    uint16_t channel_b = tsbk_u16(tsbk_byte, 6);
+    uint16_t group_b = tsbk_u16(tsbk_byte, 8);
+    DSD_FPRINTF(stderr, "\n Group Data Channel Announcement - Obsolete");
+    DSD_FPRINTF(stderr, "\n  CHAN-A [%04X] Group-A [%d][%04X] CHAN-B [%04X] Group-B [%d][%04X]", channel_a, group_a,
+                group_a, channel_b, group_b, group_b);
+    if (channel_a != 0) {
+        (void)process_channel_to_freq(opts, state, channel_a);
+    }
+    if (channel_b != 0) {
+        (void)process_channel_to_freq(opts, state, channel_b);
+    }
+    return 1;
+}
+
+static int
+tsbk_handle_group_data_channel_announcement_explicit(const dsd_opts* opts, dsd_state* state,
+                                                     const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK]) {
+    uint8_t svc = tsbk_byte[2];
+    uint8_t reserved = tsbk_byte[3];
+    uint16_t channel_t = tsbk_u16(tsbk_byte, 4);
+    uint16_t channel_r = tsbk_u16(tsbk_byte, 6);
+    uint16_t group = tsbk_u16(tsbk_byte, 8);
+    DSD_FPRINTF(stderr, "\n Group Data Channel Announcement Explicit - Obsolete");
+    DSD_FPRINTF(stderr, "\n  SVC [%02X] RES [%02X] CHAN-T [%04X] CHAN-R [%04X] Group [%d][%04X]", svc, reserved,
+                channel_t, channel_r, group, group);
+    if (channel_t != 0) {
+        (void)process_channel_to_freq(opts, state, channel_t);
+    }
+    if (channel_r != 0) {
+        (void)process_channel_to_freq(opts, state, channel_r);
+    }
+    return 1;
+}
+
+static int
+tsbk_handle_standard_osp_data_channel(dsd_opts* opts, dsd_state* state, const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK]) {
     uint8_t opcode = (uint8_t)(tsbk_byte[0] & 0x3F);
 
     switch (opcode) {
-        case 0x10: {
-            uint16_t channel = tsbk_u16(tsbk_byte, 2);
-            int target = tsbk_u24(tsbk_byte, 4);
-            int source = tsbk_u24(tsbk_byte, 7);
-            DSD_FPRINTF(stderr, "\n Individual Data Channel Grant - Obsolete");
-            DSD_FPRINTF(stderr, "\n  CHAN [%04X] Target [%d] Source [%d]", channel, target, source);
-            if (channel != 0) {
-                (void)process_channel_to_freq(opts, state, channel);
-            }
-            return 1;
-        }
-        case 0x11: {
-            uint8_t svc = tsbk_byte[2];
-            uint16_t channel = tsbk_u16(tsbk_byte, 3);
-            uint16_t group = tsbk_u16(tsbk_byte, 5);
-            int source = tsbk_u24(tsbk_byte, 7);
-            DSD_FPRINTF(stderr, "\n Group Data Channel Grant - Obsolete");
-            DSD_FPRINTF(stderr, "\n  SVC [%02X] CHAN [%04X] Group [%d][%04X] Source [%d]", svc, channel, group, group,
-                        source);
-            if (channel != 0) {
-                (void)process_channel_to_freq(opts, state, channel);
-            }
-            return 1;
-        }
-        case 0x12: {
-            uint16_t channel_a = tsbk_u16(tsbk_byte, 2);
-            uint16_t group_a = tsbk_u16(tsbk_byte, 4);
-            uint16_t channel_b = tsbk_u16(tsbk_byte, 6);
-            uint16_t group_b = tsbk_u16(tsbk_byte, 8);
-            DSD_FPRINTF(stderr, "\n Group Data Channel Announcement - Obsolete");
-            DSD_FPRINTF(stderr, "\n  CHAN-A [%04X] Group-A [%d][%04X] CHAN-B [%04X] Group-B [%d][%04X]", channel_a,
-                        group_a, group_a, channel_b, group_b, group_b);
-            if (channel_a != 0) {
-                (void)process_channel_to_freq(opts, state, channel_a);
-            }
-            if (channel_b != 0) {
-                (void)process_channel_to_freq(opts, state, channel_b);
-            }
-            return 1;
-        }
-        case 0x13: {
-            uint8_t svc = tsbk_byte[2];
-            uint8_t reserved = tsbk_byte[3];
-            uint16_t channel_t = tsbk_u16(tsbk_byte, 4);
-            uint16_t channel_r = tsbk_u16(tsbk_byte, 6);
-            uint16_t group = tsbk_u16(tsbk_byte, 8);
-            DSD_FPRINTF(stderr, "\n Group Data Channel Announcement Explicit - Obsolete");
-            DSD_FPRINTF(stderr, "\n  SVC [%02X] RES [%02X] CHAN-T [%04X] CHAN-R [%04X] Group [%d][%04X]", svc, reserved,
-                        channel_t, channel_r, group, group);
-            if (channel_t != 0) {
-                (void)process_channel_to_freq(opts, state, channel_t);
-            }
-            if (channel_r != 0) {
-                (void)process_channel_to_freq(opts, state, channel_r);
-            }
-            return 1;
-        }
+        case 0x10: return tsbk_handle_individual_data_channel_grant(opts, state, tsbk_byte);
+        case 0x11: return tsbk_handle_group_data_channel_grant(opts, state, tsbk_byte);
+        case 0x12: return tsbk_handle_group_data_channel_announcement(opts, state, tsbk_byte);
+        case 0x13: return tsbk_handle_group_data_channel_announcement_explicit(opts, state, tsbk_byte);
         default: break;
     }
     return 0;

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -15,6 +15,7 @@
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/protocol/p25/p25.h>
 #include <dsd-neo/protocol/p25/p25_12.h>
 #include <dsd-neo/protocol/p25/p25_callsign.h>
@@ -294,6 +295,14 @@ tsbk_handle_individual_data_channel_grant(dsd_opts* opts, dsd_state* state,
         freq = process_channel_to_freq(opts, state, channel);
     }
     if (opts && opts->p25_trunk == 1 && channel != 0 && freq != 0) {
+        dsd_tg_policy_decision decision;
+        if (dsd_tg_policy_evaluate_private_call(opts, state, (uint32_t)source, (uint32_t)target, 0, 1,
+                                                DSD_TG_POLICY_PRIVATE_ALLOWLIST_UNKNOWN_BLOCK,
+                                                DSD_TG_POLICY_HOLD_COMPAT_GRANT, &decision)
+                != 0
+            || !decision.tune_allowed) {
+            return 1;
+        }
         p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
         p25_sm_on_indiv_data_grant(opts, state, channel, P25_SM_SVC_UNKNOWN, target, source);
     }

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -283,6 +283,11 @@ tsbk_u24(const uint8_t tsbk_byte[TSBK_BYTES_PER_BLOCK], int offset) {
 }
 
 static int
+tsbk_channel_is_present(uint16_t channel) {
+    return channel != 0xFFFFU;
+}
+
+static int
 tsbk_can_tune_data_grant(const dsd_opts* opts, dsd_state* state, long int freq) {
     if (!opts || !state || opts->p25_trunk != 1 || opts->p25_is_tuned != 0 || freq == 0) {
         return 0;
@@ -300,10 +305,10 @@ tsbk_handle_individual_data_channel_grant(dsd_opts* opts, dsd_state* state,
     long int freq = 0;
     DSD_FPRINTF(stderr, "\n Individual Data Channel Grant - Obsolete");
     DSD_FPRINTF(stderr, "\n  CHAN [%04X] Target [%d] Source [%d]", channel, target, source);
-    if (channel != 0) {
+    if (tsbk_channel_is_present(channel)) {
         freq = process_channel_to_freq(opts, state, channel);
     }
-    if (opts && state && opts->p25_trunk == 1 && channel != 0 && freq != 0) {
+    if (opts && state && opts->p25_trunk == 1 && tsbk_channel_is_present(channel) && freq != 0) {
         dsd_tg_policy_decision decision;
         if (dsd_tg_policy_evaluate_private_call(opts, state, (uint32_t)source, (uint32_t)target, 0, 1,
                                                 DSD_TG_POLICY_PRIVATE_ALLOWLIST_UNKNOWN_BLOCK,
@@ -329,10 +334,10 @@ tsbk_handle_group_data_channel_grant(dsd_opts* opts, dsd_state* state, const uin
     DSD_FPRINTF(stderr, "\n Group Data Channel Grant - Obsolete");
     DSD_FPRINTF(stderr, "\n  SVC [%02X] CHAN [%04X] Group [%d][%04X] Source [%d]", svc_bits, channel, group, group,
                 src);
-    if (channel != 0) {
+    if (tsbk_channel_is_present(channel)) {
         freq = process_channel_to_freq(opts, state, channel);
     }
-    if (channel != 0 && tsbk_can_tune_data_grant(opts, state, freq)) {
+    if (tsbk_channel_is_present(channel) && tsbk_can_tune_data_grant(opts, state, freq)) {
         p25_sm_on_group_data_grant(opts, state, channel, svc_bits, group, src);
     }
     return 1;

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -391,7 +391,11 @@ p25p2_mac_handle_indiv(const struct p25p2_mac_result* res, dsd_opts* opts, dsd_s
         || !decision.tune_allowed) {
         return;
     }
-    p25_sm_on_indiv_grant(opts, state, channel, svc_bits, target, source);
+    if (policy_data_override > 0) {
+        p25_sm_on_indiv_data_grant(opts, state, channel, svc_bits, target, source);
+    } else {
+        p25_sm_on_indiv_grant(opts, state, channel, svc_bits, target, source);
+    }
 }
 
 static inline void

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -281,6 +281,46 @@ main(void) {
     p25_sm_on_indiv_grant(&opts, &st, ch, /*svc*/ 0x00, /*dst*/ 9001, /*src*/ 9002);
     rc |= expect_true("private unknown allowed in allow-list", st.p25_sm_tune_count == before + 1);
 
+    // Explicit data grant wrappers force data-call policy without rewriting service bits.
+    {
+        static dsd_opts data_opts;
+        static dsd_state data_st;
+        DSD_MEMSET(&data_opts, 0, sizeof data_opts);
+        DSD_MEMSET(&data_st, 0, sizeof data_st);
+        data_opts.p25_trunk = 1;
+        data_opts.trunk_tune_group_calls = 1;
+        data_opts.trunk_tune_private_calls = 1;
+        data_opts.trunk_tune_data_calls = 0;
+        data_opts.trunk_tune_enc_calls = 1;
+        data_st.p25_cc_freq = 851000000;
+        seed_fdma_iden(&data_st, id);
+        p25_sm_init(&data_opts, &data_st);
+
+        before = data_st.p25_sm_tune_count;
+        p25_sm_on_group_data_grant(&data_opts, &data_st, ch, /*svc*/ 0x00, /*tg*/ 3100, /*src*/ 4100);
+        rc |= expect_true("group data clear svc blocked when data disabled", data_st.p25_sm_tune_count == before);
+        p25_sm_on_indiv_data_grant(&data_opts, &data_st, ch, P25_SM_SVC_UNKNOWN, /*dst*/ 3101, /*src*/ 4101);
+        rc |= expect_true("indiv data unknown svc blocked when data disabled", data_st.p25_sm_tune_count == before);
+
+        data_opts.trunk_tune_data_calls = 1;
+        data_opts.p25_is_tuned = 0;
+        p25_sm_on_group_data_grant(&data_opts, &data_st, ch, /*svc*/ 0x00, /*tg*/ 3102, /*src*/ 4102);
+        rc |= expect_true("group data clear svc tunes when data enabled", data_st.p25_sm_tune_count == before + 1);
+        p25_sm_on_release(&data_opts, &data_st);
+        data_opts.p25_is_tuned = 0;
+        before = data_st.p25_sm_tune_count;
+        p25_sm_on_indiv_data_grant(&data_opts, &data_st, ch, P25_SM_SVC_UNKNOWN, /*dst*/ 3103, /*src*/ 4103);
+        rc |= expect_true("indiv data unknown svc tunes when data enabled", data_st.p25_sm_tune_count == before + 1);
+
+        p25_sm_on_release(&data_opts, &data_st);
+        data_opts.trunk_tune_enc_calls = 0;
+        data_opts.p25_is_tuned = 0;
+        before = data_st.p25_sm_tune_count;
+        p25_sm_on_group_data_grant(&data_opts, &data_st, ch, /*svc*/ 0x40, /*tg*/ 3104, /*src*/ 4104);
+        rc |= expect_true("group data raw enc bit blocks when enc disabled", data_st.p25_sm_tune_count == before);
+        p25_sm_init(&opts, &st);
+    }
+
     // Priority preemption: preempt-flagged low-priority candidate does not displace.
     rc |= expect_true("seed active high", seed_exact(&st, 1200, "A", "ACTIVE-HIGH", 80, 0) == 0);
     rc |= expect_true("seed candidate low preempt", seed_exact(&st, 1201, "A", "CAND-LOW", 10, 1) == 0);

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -318,6 +318,32 @@ main(void) {
         before = data_st.p25_sm_tune_count;
         p25_sm_on_group_data_grant(&data_opts, &data_st, ch, /*svc*/ 0x40, /*tg*/ 3104, /*src*/ 4104);
         rc |= expect_true("group data raw enc bit blocks when enc disabled", data_st.p25_sm_tune_count == before);
+        rc |=
+            expect_true("group data raw enc bit does not arm voice enc cache", enc_tg_cache_is_absent(&data_st, 3104U));
+        p25_sm_on_group_grant(&data_opts, &data_st, ch, P25_SM_SVC_UNKNOWN, /*tg*/ 3104, /*src*/ 4105);
+        rc |= expect_true("svc-less voice grant not skipped after encrypted data grant",
+                          data_st.p25_sm_tune_count == before + 1);
+        p25_sm_on_release(&data_opts, &data_st);
+
+        p25_emit_enc_lockout_once(&data_opts, &data_st, 0, 3105, /*svc*/ 0x40);
+        rc |= expect_true("seed transient voice enc cache", !enc_tg_cache_is_absent(&data_st, 3105U));
+        before = data_st.p25_sm_tune_count;
+        data_opts.p25_is_tuned = 0;
+        p25_sm_on_group_data_grant(&data_opts, &data_st, ch, P25_SM_SVC_UNKNOWN, /*tg*/ 3105, /*src*/ 4106);
+        rc |= expect_true("svc-less group data grant ignores voice enc cache", data_st.p25_sm_tune_count == before + 1);
+        rc |= expect_true("svc-less group data grant preserves voice enc cache",
+                          !enc_tg_cache_is_absent(&data_st, 3105U));
+        p25_sm_on_release(&data_opts, &data_st);
+
+        data_opts.trunk_tune_data_calls = 0;
+        data_opts.p25_is_tuned = 0;
+        before = data_st.p25_sm_tune_count;
+        p25_sm_on_group_data_grant(&data_opts, &data_st, ch, /*svc*/ 0x00, /*tg*/ 3105, /*src*/ 4107);
+        rc |= expect_true("clear group data grant blocked when data disabled", data_st.p25_sm_tune_count == before);
+        rc |= expect_true("clear group data grant preserves voice enc cache", !enc_tg_cache_is_absent(&data_st, 3105U));
+        p25_sm_on_group_grant(&data_opts, &data_st, ch, P25_SM_SVC_UNKNOWN, /*tg*/ 3105, /*src*/ 4108);
+        rc |= expect_true("svc-less voice grant still skipped after clear data grant",
+                          data_st.p25_sm_tune_count == before);
         p25_sm_init(&opts, &st);
     }
 

--- a/tests/protocol/p25/test_p25_mbt_decode.c
+++ b/tests/protocol/p25/test_p25_mbt_decode.c
@@ -37,6 +37,8 @@ int p25_decode_pdu_trunking_bounded(dsd_opts* opts, dsd_state* state, const uint
 
 static int g_indiv_grant_count;
 static int g_group_grant_count;
+static int g_indiv_data_grant_count;
+static int g_group_data_grant_count;
 static int g_last_indiv_channel;
 static int g_last_indiv_svc;
 static int g_last_indiv_dst;
@@ -45,6 +47,14 @@ static int g_last_group_channel;
 static int g_last_group_svc;
 static int g_last_group_tg;
 static int g_last_group_src;
+static int g_last_indiv_data_channel;
+static int g_last_indiv_data_svc;
+static int g_last_indiv_data_dst;
+static int g_last_indiv_data_src;
+static int g_last_group_data_channel;
+static int g_last_group_data_svc;
+static int g_last_group_data_tg;
+static int g_last_group_data_src;
 
 static void
 sm_noop_init(dsd_opts* opts, dsd_state* state) {
@@ -72,6 +82,28 @@ sm_noop_on_indiv_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bi
     g_last_indiv_svc = svc_bits;
     g_last_indiv_dst = dst;
     g_last_indiv_src = src;
+}
+
+static void
+sm_noop_on_group_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
+    (void)opts;
+    (void)state;
+    g_group_data_grant_count++;
+    g_last_group_data_channel = channel;
+    g_last_group_data_svc = svc_bits;
+    g_last_group_data_tg = tg;
+    g_last_group_data_src = src;
+}
+
+static void
+sm_noop_on_indiv_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src) {
+    (void)opts;
+    (void)state;
+    g_indiv_data_grant_count++;
+    g_last_indiv_data_channel = channel;
+    g_last_indiv_data_svc = svc_bits;
+    g_last_indiv_data_dst = dst;
+    g_last_indiv_data_src = src;
 }
 
 static void
@@ -107,6 +139,8 @@ sm_noop_api(void) {
     api.init = sm_noop_init;
     api.on_group_grant = sm_noop_on_group_grant;
     api.on_indiv_grant = sm_noop_on_indiv_grant;
+    api.on_group_data_grant = sm_noop_on_group_data_grant;
+    api.on_indiv_data_grant = sm_noop_on_indiv_data_grant;
     api.on_release = sm_noop_on_release;
     api.on_neighbor_update = sm_noop_on_neighbor_update;
     api.next_cc_candidate = sm_noop_next_cc_candidate;
@@ -118,6 +152,8 @@ static void
 reset_indiv_grants(void) {
     g_indiv_grant_count = 0;
     g_group_grant_count = 0;
+    g_indiv_data_grant_count = 0;
+    g_group_data_grant_count = 0;
     g_last_indiv_channel = 0;
     g_last_indiv_svc = 0;
     g_last_indiv_dst = 0;
@@ -126,6 +162,14 @@ reset_indiv_grants(void) {
     g_last_group_svc = 0;
     g_last_group_tg = 0;
     g_last_group_src = 0;
+    g_last_indiv_data_channel = 0;
+    g_last_indiv_data_svc = 0;
+    g_last_indiv_data_dst = 0;
+    g_last_indiv_data_src = 0;
+    g_last_group_data_channel = 0;
+    g_last_group_data_svc = 0;
+    g_last_group_data_tg = 0;
+    g_last_group_data_src = 0;
 }
 
 // Additional stubs referenced by linked objects (rigctl/rtl streaming)
@@ -873,7 +917,7 @@ main(void) {
         rc |= expect_contains_text("mbt 0x37 msn", out, "MSN [5] FINAL [1] ADDR-A [ABCDE.234]");
     }
 
-    // Obsolete AMBTC data grants are metadata-only and do not trigger voice grant callbacks.
+    // Obsolete AMBTC data grants dispatch only through the explicit data-grant callbacks.
     {
         uint8_t meta[48];
         char out[4096];
@@ -882,8 +926,13 @@ main(void) {
         if (capture_mbt_output("p25_mbt_data_0x10", meta, sizeof meta, out, sizeof out) != 0) {
             return 118;
         }
-        rc |= expect_eq_int("mbt 0x10 no indiv grant", g_indiv_grant_count, 0);
+        rc |= expect_eq_int("mbt 0x10 no voice indiv grant", g_indiv_grant_count, 0);
         rc |= expect_eq_int("mbt 0x10 no group grant", g_group_grant_count, 0);
+        rc |= expect_eq_int("mbt 0x10 data indiv grant", g_indiv_data_grant_count, 1);
+        rc |= expect_eq_int("mbt 0x10 data channel", g_last_indiv_data_channel, 0x100A);
+        rc |= expect_eq_int("mbt 0x10 data svc preserved", g_last_indiv_data_svc, 0x04);
+        rc |= expect_eq_int("mbt 0x10 data dst", g_last_indiv_data_dst, 0x0ABCDE);
+        rc |= expect_eq_int("mbt 0x10 data src", g_last_indiv_data_src, 0x012345);
         rc |= expect_contains_text("mbt 0x10 label", out, "Individual Data Channel Grant MBT - Obsolete");
         rc |= expect_contains_text("mbt 0x10 channel", out, "CHAN-T [100A] CHAN-R [1010]");
         rc |= expect_contains_text("mbt 0x10 target", out, "TO [703710]");
@@ -893,7 +942,12 @@ main(void) {
             return 119;
         }
         rc |= expect_eq_int("mbt 0x11 no indiv grant", g_indiv_grant_count, 0);
-        rc |= expect_eq_int("mbt 0x11 no group grant", g_group_grant_count, 0);
+        rc |= expect_eq_int("mbt 0x11 no voice group grant", g_group_grant_count, 0);
+        rc |= expect_eq_int("mbt 0x11 data group grant", g_group_data_grant_count, 1);
+        rc |= expect_eq_int("mbt 0x11 data channel", g_last_group_data_channel, 0x100A);
+        rc |= expect_eq_int("mbt 0x11 data svc preserved", g_last_group_data_svc, 0x04);
+        rc |= expect_eq_int("mbt 0x11 data tg", g_last_group_data_tg, 0x1234);
+        rc |= expect_eq_int("mbt 0x11 data src", g_last_group_data_src, 0x012345);
         rc |= expect_contains_text("mbt 0x11 label", out, "Group Data Channel Grant MBT - Obsolete");
         rc |= expect_contains_text("mbt 0x11 channel", out, "CHAN-T [100A] CHAN-R [1010]");
         rc |= expect_contains_text("mbt 0x11 group", out, "Group [4660][1234]");

--- a/tests/protocol/p25/test_p25_p1_pdu_private_allowlist.c
+++ b/tests/protocol/p25/test_p25_p1_pdu_private_allowlist.c
@@ -275,6 +275,12 @@ p25_sm_apply_group_grant_policy(dsd_opts* opts, dsd_state* state, int channel, i
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_sm_on_group_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
+    p25_sm_on_group_grant(opts, state, channel, svc_bits, tg, src);
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 p25_sm_on_indiv_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src) {
     (void)channel;
     (void)svc_bits;
@@ -285,6 +291,12 @@ p25_sm_on_indiv_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bit
     }
     state->p25_sm_tune_count++;
     opts->p25_is_tuned = 1;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_sm_on_indiv_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src) {
+    p25_sm_on_indiv_grant(opts, state, channel, svc_bits, dst, src);
 }
 
 void

--- a/tests/protocol/p25/test_p25_p1_tsbk_handlers.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_handlers.c
@@ -1056,6 +1056,7 @@ test_standard_osp_data_channel_metadata_and_dispatch(void) {
     opts.trunk_tune_private_calls = 1;
     opts.trunk_tune_data_calls = 1;
     opts.trunk_tune_enc_calls = 1;
+    state.p25_cc_freq = 851000000;
 
     tsbk[0] = 0x10;
     tsbk[2] = 0x10;
@@ -1159,6 +1160,63 @@ test_standard_osp_data_channel_metadata_and_dispatch(void) {
     tsbk_dispatch_message(&opts, &state, &ctx, 0, 0, 0, pdu);
     rc |= expect_int("osp data dispatch suppresses mac bridge", g_mac_count, 0);
     rc |= expect_int("osp data dispatch resolves channels", g_process_channel_count, 2);
+
+    return rc;
+}
+
+static int
+test_standard_osp_data_grants_require_control_channel(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t tsbk[TSBK_BYTES_PER_BLOCK] = {0};
+    char out[2048];
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.p25_trunk = 1;
+    opts.trunk_tune_private_calls = 1;
+    opts.trunk_tune_data_calls = 1;
+    opts.trunk_tune_enc_calls = 1;
+
+    tsbk[0] = 0x10;
+    tsbk[2] = 0x10;
+    tsbk[3] = 0x01;
+    tsbk[4] = 0x01;
+    tsbk[5] = 0x02;
+    tsbk[6] = 0x03;
+    tsbk[7] = 0x04;
+    tsbk[8] = 0x05;
+    tsbk[9] = 0x06;
+    reset_calls();
+    g_channel_freq = 851012500;
+    if (capture_standard_osp_data_output(&opts, &state, tsbk, out, sizeof(out)) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("osp individual data unknown cc label", out, "Individual Data Channel Grant - Obsolete");
+    rc |= expect_int("osp individual data unknown cc seeds", g_seed_count, 1);
+    rc |= expect_int("osp individual data unknown cc no callback", g_indiv_data_grant_count, 0);
+    rc |= expect_int("osp individual data unknown cc resolves channel", g_process_channel_count, 1);
+
+    DSD_MEMSET(tsbk, 0, sizeof(tsbk));
+    tsbk[0] = 0x11;
+    tsbk[2] = 0x90;
+    tsbk[3] = 0x10;
+    tsbk[4] = 0x02;
+    tsbk[5] = 0x12;
+    tsbk[6] = 0x34;
+    tsbk[7] = 0x01;
+    tsbk[8] = 0x23;
+    tsbk[9] = 0x45;
+    reset_calls();
+    g_channel_freq = 851012500;
+    if (capture_standard_osp_data_output(&opts, &state, tsbk, out, sizeof(out)) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("osp group data unknown cc label", out, "Group Data Channel Grant - Obsolete");
+    rc |= expect_int("osp group data unknown cc seeds", g_seed_count, 1);
+    rc |= expect_int("osp group data unknown cc no callback", g_group_data_grant_count, 0);
+    rc |= expect_int("osp group data unknown cc resolves channel", g_process_channel_count, 1);
 
     return rc;
 }
@@ -1660,6 +1718,7 @@ main(void) {
     rc |= test_crc_candidate_selection_and_fallback();
     rc |= test_standard_isp_metadata_logging_and_no_retune();
     rc |= test_standard_osp_data_channel_metadata_and_dispatch();
+    rc |= test_standard_osp_data_grants_require_control_channel();
     rc |= test_standard_osp_individual_data_allowlist_blocks_unknown();
     rc |= test_mfid90_regroup_add_delete();
     rc |= test_mfid_a4_patch_and_simulselect_paths();

--- a/tests/protocol/p25/test_p25_p1_tsbk_handlers.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_handlers.c
@@ -42,6 +42,8 @@ static int g_kas_count;
 static int g_clear_count;
 static int g_seed_count;
 static int g_grant_count;
+static int g_group_data_grant_count;
+static int g_indiv_data_grant_count;
 static int g_mac_count;
 static int g_last_sg;
 static int g_last_wgid;
@@ -55,6 +57,14 @@ static int g_last_grant_channel;
 static int g_last_grant_svc;
 static int g_last_grant_tg;
 static int g_last_grant_src;
+static int g_last_group_data_grant_channel;
+static int g_last_group_data_grant_svc;
+static int g_last_group_data_grant_tg;
+static int g_last_group_data_grant_src;
+static int g_last_indiv_data_grant_channel;
+static int g_last_indiv_data_grant_svc;
+static int g_last_indiv_data_grant_dst;
+static int g_last_indiv_data_grant_src;
 static int g_neighbor_update_count;
 static int g_neighbor_update_last_count;
 static long g_neighbor_update_last_freq;
@@ -199,6 +209,30 @@ p25_sm_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bit
     g_last_grant_svc = svc_bits;
     g_last_grant_tg = tg;
     g_last_grant_src = src;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_sm_on_group_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
+    (void)opts;
+    (void)state;
+    g_group_data_grant_count++;
+    g_last_group_data_grant_channel = channel;
+    g_last_group_data_grant_svc = svc_bits;
+    g_last_group_data_grant_tg = tg;
+    g_last_group_data_grant_src = src;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+p25_sm_on_indiv_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src) {
+    (void)opts;
+    (void)state;
+    g_indiv_data_grant_count++;
+    g_last_indiv_data_grant_channel = channel;
+    g_last_indiv_data_grant_svc = svc_bits;
+    g_last_indiv_data_grant_dst = dst;
+    g_last_indiv_data_grant_src = src;
 }
 
 void
@@ -385,6 +419,8 @@ reset_calls(void) {
     g_clear_count = 0;
     g_seed_count = 0;
     g_grant_count = 0;
+    g_group_data_grant_count = 0;
+    g_indiv_data_grant_count = 0;
     g_mac_count = 0;
     g_last_sg = 0;
     g_last_wgid = 0;
@@ -398,6 +434,14 @@ reset_calls(void) {
     g_last_grant_svc = 0;
     g_last_grant_tg = 0;
     g_last_grant_src = 0;
+    g_last_group_data_grant_channel = 0;
+    g_last_group_data_grant_svc = 0;
+    g_last_group_data_grant_tg = 0;
+    g_last_group_data_grant_src = 0;
+    g_last_indiv_data_grant_channel = 0;
+    g_last_indiv_data_grant_svc = 0;
+    g_last_indiv_data_grant_dst = 0;
+    g_last_indiv_data_grant_src = 0;
     g_neighbor_update_count = 0;
     g_neighbor_update_last_count = 0;
     g_neighbor_update_last_freq = 0;
@@ -968,6 +1012,7 @@ test_standard_osp_data_channel_metadata_and_dispatch(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     reset_calls();
     g_channel_freq = 851012500;
+    opts.p25_trunk = 1;
 
     tsbk[0] = 0x10;
     tsbk[2] = 0x10;
@@ -985,6 +1030,11 @@ test_standard_osp_data_channel_metadata_and_dispatch(void) {
     rc |= expect_contains("osp individual data channel", out, "CHAN [1001]");
     rc |= expect_contains("osp individual data target", out, "Target [66051]");
     rc |= expect_contains("osp individual data source", out, "Source [263430]");
+    rc |= expect_int("osp individual data grant count", g_indiv_data_grant_count, 1);
+    rc |= expect_int("osp individual data grant channel", g_last_indiv_data_grant_channel, 0x1001);
+    rc |= expect_int("osp individual data grant svc unknown", g_last_indiv_data_grant_svc, P25_SM_SVC_UNKNOWN);
+    rc |= expect_int("osp individual data grant dst", g_last_indiv_data_grant_dst, 66051);
+    rc |= expect_int("osp individual data grant src", g_last_indiv_data_grant_src, 263430);
 
     DSD_MEMSET(tsbk, 0, sizeof(tsbk));
     tsbk[0] = 0x11;
@@ -1002,6 +1052,11 @@ test_standard_osp_data_channel_metadata_and_dispatch(void) {
     rc |= expect_contains("osp group data label", out, "Group Data Channel Grant - Obsolete");
     rc |= expect_contains("osp group data service", out, "SVC [90]");
     rc |= expect_contains("osp group data group", out, "Group [4660][1234]");
+    rc |= expect_int("osp group data grant count", g_group_data_grant_count, 1);
+    rc |= expect_int("osp group data grant channel", g_last_group_data_grant_channel, 0x1002);
+    rc |= expect_int("osp group data grant svc raw", g_last_group_data_grant_svc, 0x90);
+    rc |= expect_int("osp group data grant tg", g_last_group_data_grant_tg, 0x1234);
+    rc |= expect_int("osp group data grant src", g_last_group_data_grant_src, 0x012345);
 
     DSD_MEMSET(tsbk, 0, sizeof(tsbk));
     tsbk[0] = 0x12;
@@ -1036,7 +1091,9 @@ test_standard_osp_data_channel_metadata_and_dispatch(void) {
     rc |= expect_contains("osp group explicit label", out, "Group Data Channel Announcement Explicit - Obsolete");
     rc |= expect_contains("osp group explicit channels", out, "CHAN-T [1005] CHAN-R [1006]");
     rc |= expect_int("osp data channel frequency lookups", g_process_channel_count, 6);
-    rc |= expect_int("osp data channel no grant callbacks", g_grant_count, 0);
+    rc |= expect_int("osp data channel no voice grant callbacks", g_grant_count, 0);
+    rc |= expect_int("osp data channel no extra group data callbacks", g_group_data_grant_count, 1);
+    rc |= expect_int("osp data channel no extra indiv data callbacks", g_indiv_data_grant_count, 1);
     rc |= expect_int("osp data channel no mac callbacks", g_mac_count, 0);
     rc |= expect_int("osp data channel no active text", state.active_channel[0][0], 0);
 

--- a/tests/protocol/p25/test_p25_p1_tsbk_handlers.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_handlers.c
@@ -1222,6 +1222,69 @@ test_standard_osp_data_grants_require_control_channel(void) {
 }
 
 static int
+test_standard_osp_data_grants_allow_channel_zero(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t tsbk[TSBK_BYTES_PER_BLOCK] = {0};
+    char out[2048];
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.p25_trunk = 1;
+    opts.trunk_tune_private_calls = 1;
+    opts.trunk_tune_data_calls = 1;
+    opts.trunk_tune_enc_calls = 1;
+    state.p25_cc_freq = 851000000;
+
+    tsbk[0] = 0x10;
+    tsbk[4] = 0x01;
+    tsbk[5] = 0x02;
+    tsbk[6] = 0x03;
+    tsbk[7] = 0x04;
+    tsbk[8] = 0x05;
+    tsbk[9] = 0x06;
+    reset_calls();
+    g_channel_freq = 851012500;
+    if (capture_standard_osp_data_output(&opts, &state, tsbk, out, sizeof(out)) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("osp individual data channel zero label", out, "Individual Data Channel Grant - Obsolete");
+    rc |= expect_contains("osp individual data channel zero field", out, "CHAN [0000]");
+    rc |= expect_int("osp individual data channel zero resolves channel", g_process_channel_count, 1);
+    rc |= expect_int("osp individual data channel zero lookup value", g_last_process_channel, 0);
+    rc |= expect_int("osp individual data channel zero callback", g_indiv_data_grant_count, 1);
+    rc |= expect_int("osp individual data channel zero callback channel", g_last_indiv_data_grant_channel, 0);
+    rc |= expect_int("osp individual data channel zero dst", g_last_indiv_data_grant_dst, 0x010203);
+    rc |= expect_int("osp individual data channel zero src", g_last_indiv_data_grant_src, 0x040506);
+
+    DSD_MEMSET(tsbk, 0, sizeof(tsbk));
+    tsbk[0] = 0x11;
+    tsbk[2] = 0x90;
+    tsbk[5] = 0x12;
+    tsbk[6] = 0x34;
+    tsbk[7] = 0x01;
+    tsbk[8] = 0x23;
+    tsbk[9] = 0x45;
+    reset_calls();
+    g_channel_freq = 851012500;
+    if (capture_standard_osp_data_output(&opts, &state, tsbk, out, sizeof(out)) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("osp group data channel zero label", out, "Group Data Channel Grant - Obsolete");
+    rc |= expect_contains("osp group data channel zero field", out, "CHAN [0000]");
+    rc |= expect_int("osp group data channel zero resolves channel", g_process_channel_count, 1);
+    rc |= expect_int("osp group data channel zero lookup value", g_last_process_channel, 0);
+    rc |= expect_int("osp group data channel zero callback", g_group_data_grant_count, 1);
+    rc |= expect_int("osp group data channel zero callback channel", g_last_group_data_grant_channel, 0);
+    rc |= expect_int("osp group data channel zero svc", g_last_group_data_grant_svc, 0x90);
+    rc |= expect_int("osp group data channel zero tg", g_last_group_data_grant_tg, 0x1234);
+    rc |= expect_int("osp group data channel zero src", g_last_group_data_grant_src, 0x012345);
+
+    return rc;
+}
+
+static int
 test_standard_osp_individual_data_allowlist_blocks_unknown(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -1719,6 +1782,7 @@ main(void) {
     rc |= test_standard_isp_metadata_logging_and_no_retune();
     rc |= test_standard_osp_data_channel_metadata_and_dispatch();
     rc |= test_standard_osp_data_grants_require_control_channel();
+    rc |= test_standard_osp_data_grants_allow_channel_zero();
     rc |= test_standard_osp_individual_data_allowlist_blocks_unknown();
     rc |= test_mfid90_regroup_add_delete();
     rc |= test_mfid_a4_patch_and_simulselect_paths();

--- a/tests/protocol/p25/test_p25_p1_tsbk_handlers.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_handlers.c
@@ -15,6 +15,7 @@
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/platform/timing.h>
 #include <dsd-neo/protocol/p25/p25_12.h>
 #include <dsd-neo/protocol/p25/p25_callsign.h>
@@ -405,6 +406,45 @@ void
 rotate_symbol_out_file(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_tg_policy_evaluate_private_call(const dsd_opts* opts, const dsd_state* state, uint32_t src, uint32_t dst,
+                                    int encrypted, int data_call, dsd_tg_policy_private_allowlist_mode allowlist_mode,
+                                    dsd_tg_policy_hold_behavior hold_behavior, dsd_tg_policy_decision* out) {
+    (void)state;
+    (void)hold_behavior;
+    if (!out) {
+        return -1;
+    }
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->target_id = dst;
+    out->source_id = src;
+    out->encrypted = encrypted;
+    out->data_call = data_call;
+    out->tune_allowed = 1;
+    out->audio_allowed = 1;
+    out->record_allowed = 1;
+    out->stream_allowed = 1;
+    out->match = DSD_TG_POLICY_MATCH_NONE;
+    if (opts && opts->trunk_tune_private_calls == 0) {
+        out->tune_allowed = 0;
+        out->block_reasons |= DSD_TG_POLICY_BLOCK_PRIVATE_DISABLED;
+    }
+    if (opts && data_call && opts->trunk_tune_data_calls == 0) {
+        out->tune_allowed = 0;
+        out->block_reasons |= DSD_TG_POLICY_BLOCK_DATA_DISABLED;
+    }
+    if (opts && encrypted && opts->trunk_tune_enc_calls == 0) {
+        out->tune_allowed = 0;
+        out->block_reasons |= DSD_TG_POLICY_BLOCK_ENCRYPTED_DISABLED;
+    }
+    if (opts && opts->trunk_use_allow_list == 1 && allowlist_mode == DSD_TG_POLICY_PRIVATE_ALLOWLIST_UNKNOWN_BLOCK) {
+        out->tune_allowed = 0;
+        out->block_reasons |= DSD_TG_POLICY_BLOCK_ALLOWLIST;
+    }
+    return 0;
 }
 
 #include "../../../src/protocol/p25/phase1/p25p1_tsbk.c"
@@ -1013,6 +1053,9 @@ test_standard_osp_data_channel_metadata_and_dispatch(void) {
     reset_calls();
     g_channel_freq = 851012500;
     opts.p25_trunk = 1;
+    opts.trunk_tune_private_calls = 1;
+    opts.trunk_tune_data_calls = 1;
+    opts.trunk_tune_enc_calls = 1;
 
     tsbk[0] = 0x10;
     tsbk[2] = 0x10;
@@ -1116,6 +1159,44 @@ test_standard_osp_data_channel_metadata_and_dispatch(void) {
     tsbk_dispatch_message(&opts, &state, &ctx, 0, 0, 0, pdu);
     rc |= expect_int("osp data dispatch suppresses mac bridge", g_mac_count, 0);
     rc |= expect_int("osp data dispatch resolves channels", g_process_channel_count, 2);
+
+    return rc;
+}
+
+static int
+test_standard_osp_individual_data_allowlist_blocks_unknown(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t tsbk[TSBK_BYTES_PER_BLOCK] = {0};
+    char out[2048];
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_calls();
+    g_channel_freq = 851012500;
+    opts.p25_trunk = 1;
+    opts.trunk_tune_private_calls = 1;
+    opts.trunk_tune_data_calls = 1;
+    opts.trunk_tune_enc_calls = 1;
+    opts.trunk_use_allow_list = 1;
+
+    tsbk[0] = 0x10;
+    tsbk[2] = 0x10;
+    tsbk[3] = 0x01;
+    tsbk[4] = 0x01;
+    tsbk[5] = 0x02;
+    tsbk[6] = 0x03;
+    tsbk[7] = 0x04;
+    tsbk[8] = 0x05;
+    tsbk[9] = 0x06;
+    if (capture_standard_osp_data_output(&opts, &state, tsbk, out, sizeof(out)) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("osp individual data allowlist label", out, "Individual Data Channel Grant - Obsolete");
+    rc |= expect_int("osp individual data allowlist no seed", g_seed_count, 0);
+    rc |= expect_int("osp individual data allowlist no callback", g_indiv_data_grant_count, 0);
+    rc |= expect_int("osp individual data allowlist still resolves channel", g_process_channel_count, 1);
 
     return rc;
 }
@@ -1579,6 +1660,7 @@ main(void) {
     rc |= test_crc_candidate_selection_and_fallback();
     rc |= test_standard_isp_metadata_logging_and_no_retune();
     rc |= test_standard_osp_data_channel_metadata_and_dispatch();
+    rc |= test_standard_osp_individual_data_allowlist_blocks_unknown();
     rc |= test_mfid90_regroup_add_delete();
     rc |= test_mfid_a4_patch_and_simulselect_paths();
     rc |= test_mfid90_extended_function_supergroup_state();

--- a/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
@@ -263,6 +263,26 @@ p25_sm_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bit
 }
 
 void
+p25_sm_on_group_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
+    (void)opts;
+    (void)state;
+    (void)channel;
+    (void)svc_bits;
+    (void)tg;
+    (void)src;
+}
+
+void
+p25_sm_on_indiv_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src) {
+    (void)opts;
+    (void)state;
+    (void)channel;
+    (void)svc_bits;
+    (void)dst;
+    (void)src;
+}
+
+void
 p25_sm_on_queued_response(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target) {
     (void)opts;
     (void)state;

--- a/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
+++ b/tests/protocol/p25/test_p25_p1_tsbk_sequence.c
@@ -9,6 +9,7 @@
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/platform/timing.h>
 #include <dsd-neo/protocol/p25/p25.h>
 #include <dsd-neo/protocol/p25/p25_callsign.h>
@@ -280,6 +281,44 @@ p25_sm_on_indiv_data_grant(dsd_opts* opts, dsd_state* state, int channel, int sv
     (void)svc_bits;
     (void)dst;
     (void)src;
+}
+
+int
+dsd_tg_policy_evaluate_private_call(const dsd_opts* opts, const dsd_state* state, uint32_t src, uint32_t dst,
+                                    int encrypted, int data_call, dsd_tg_policy_private_allowlist_mode allowlist_mode,
+                                    dsd_tg_policy_hold_behavior hold_behavior, dsd_tg_policy_decision* out) {
+    (void)state;
+    (void)hold_behavior;
+    if (!out) {
+        return -1;
+    }
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->target_id = dst;
+    out->source_id = src;
+    out->encrypted = encrypted;
+    out->data_call = data_call;
+    out->tune_allowed = 1;
+    out->audio_allowed = 1;
+    out->record_allowed = 1;
+    out->stream_allowed = 1;
+    out->match = DSD_TG_POLICY_MATCH_NONE;
+    if (opts && opts->trunk_tune_private_calls == 0) {
+        out->tune_allowed = 0;
+        out->block_reasons |= DSD_TG_POLICY_BLOCK_PRIVATE_DISABLED;
+    }
+    if (opts && data_call && opts->trunk_tune_data_calls == 0) {
+        out->tune_allowed = 0;
+        out->block_reasons |= DSD_TG_POLICY_BLOCK_DATA_DISABLED;
+    }
+    if (opts && encrypted && opts->trunk_tune_enc_calls == 0) {
+        out->tune_allowed = 0;
+        out->block_reasons |= DSD_TG_POLICY_BLOCK_ENCRYPTED_DISABLED;
+    }
+    if (opts && opts->trunk_use_allow_list == 1 && allowlist_mode == DSD_TG_POLICY_PRIVATE_ALLOWLIST_UNKNOWN_BLOCK) {
+        out->tune_allowed = 0;
+        out->block_reasons |= DSD_TG_POLICY_BLOCK_ALLOWLIST;
+    }
+    return 0;
 }
 
 void

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -216,6 +216,11 @@ static int g_group_grant_channel = -1;
 static int g_group_grant_svc = -1;
 static int g_group_grant_tg = -1;
 static int g_group_grant_src = -1;
+static int g_indiv_data_grant_called = 0;
+static int g_indiv_data_grant_channel = -1;
+static int g_indiv_data_grant_svc = -1;
+static int g_indiv_data_grant_dst = -1;
+static int g_indiv_data_grant_src = -1;
 
 static void
 sm_on_group_grant_capture(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
@@ -229,12 +234,28 @@ sm_on_group_grant_capture(dsd_opts* opts, dsd_state* state, int channel, int svc
 }
 
 static void
+sm_on_indiv_data_grant_capture(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src) {
+    (void)opts;
+    (void)state;
+    g_indiv_data_grant_called++;
+    g_indiv_data_grant_channel = channel;
+    g_indiv_data_grant_svc = svc_bits;
+    g_indiv_data_grant_dst = dst;
+    g_indiv_data_grant_src = src;
+}
+
+static void
 reset_group_grant_capture(void) {
     g_group_grant_called = 0;
     g_group_grant_channel = -1;
     g_group_grant_svc = -1;
     g_group_grant_tg = -1;
     g_group_grant_src = -1;
+    g_indiv_data_grant_called = 0;
+    g_indiv_data_grant_channel = -1;
+    g_indiv_data_grant_svc = -1;
+    g_indiv_data_grant_dst = -1;
+    g_indiv_data_grant_src = -1;
 }
 
 static void
@@ -2060,6 +2081,122 @@ main(void) {
         rc |= expect_eq_long("0x48 telephone svc", state.dmr_so, 0x93);
         rc |= expect_eq_long("0x48 telephone emergency", state.p25_call_emergency[0], 1);
         rc |= expect_eq_long("0x48 telephone packet", state.p25_call_is_packet[0], 1);
+    }
+
+    // Case S0: explicit SNDCP data grants use the data-grant SM surface and respect data tuning policy.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        opts.trunk_tune_private_calls = 1;
+        opts.trunk_tune_enc_calls = 1;
+        opts.trunk_tune_data_calls = 0;
+        state.p25_cc_freq = 851000000;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+
+        MAC[1] = 0x54;
+        MAC[2] = 0x22;
+        MAC[3] = 0x10;
+        MAC[4] = 0x0A;
+        MAC[5] = 0x10;
+        MAC[6] = 0x0B;
+        MAC[7] = 0x03;
+        MAC[8] = 0x04;
+        MAC[9] = 0x05;
+
+        reset_group_grant_capture();
+        p25_sm_api api = {0};
+        api.on_indiv_data_grant = sm_on_indiv_data_grant_capture;
+        p25_sm_set_api(&api);
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_eq_long("0x54 data disabled no callback", g_indiv_data_grant_called, 0);
+
+        opts.trunk_tune_data_calls = 1;
+        reset_group_grant_capture();
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        p25_sm_reset_api();
+        rc |= expect_eq_long("0x54 data callback", g_indiv_data_grant_called, 1);
+        rc |= expect_eq_long("0x54 data callback channel", g_indiv_data_grant_channel, 0x100A);
+        rc |= expect_eq_long("0x54 data callback svc", g_indiv_data_grant_svc, P25_SM_SVC_UNKNOWN);
+        rc |= expect_eq_long("0x54 data callback dst", g_indiv_data_grant_dst, 0x030405);
+        rc |= expect_eq_long("0x54 data callback src", g_indiv_data_grant_src, 0);
+    }
+
+    // Case S1: L3Harris data grants also use the data-grant SM surface.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        opts.trunk_tune_private_calls = 1;
+        opts.trunk_tune_enc_calls = 1;
+        opts.trunk_tune_data_calls = 1;
+        state.p25_cc_freq = 851000000;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+
+        p25_sm_api api = {0};
+        api.on_indiv_data_grant = sm_on_indiv_data_grant_capture;
+        p25_sm_set_api(&api);
+
+        MAC[1] = 0xA0;
+        MAC[2] = 0xA4;
+        MAC[3] = 0x09;
+        MAC[4] = 0x00;
+        MAC[5] = 0x10;
+        MAC[6] = 0x0A;
+        MAC[7] = 0x03;
+        MAC[8] = 0x04;
+        MAC[9] = 0x05;
+
+        reset_group_grant_capture();
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        rc |= expect_eq_long("Harris A0 data callback", g_indiv_data_grant_called, 1);
+        rc |= expect_eq_long("Harris A0 data channel", g_indiv_data_grant_channel, 0x100A);
+        rc |= expect_eq_long("Harris A0 data dst", g_indiv_data_grant_dst, 0x030405);
+        rc |= expect_eq_long("Harris A0 data src", g_indiv_data_grant_src, 0);
+
+        DSD_MEMSET(MAC, 0, sizeof MAC);
+        MAC[1] = 0xAC;
+        MAC[2] = 0xA4;
+        MAC[3] = 0x0C;
+        MAC[4] = 0x00;
+        MAC[5] = 0x10;
+        MAC[6] = 0x0A;
+        MAC[7] = 0x03;
+        MAC[8] = 0x04;
+        MAC[9] = 0x05;
+        MAC[10] = 0x98;
+        MAC[11] = 0x04;
+        MAC[12] = 0x18;
+
+        reset_group_grant_capture();
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        p25_sm_reset_api();
+        rc |= expect_eq_long("Harris AC data callback", g_indiv_data_grant_called, 1);
+        rc |= expect_eq_long("Harris AC data channel", g_indiv_data_grant_channel, 0x100A);
+        rc |= expect_eq_long("Harris AC data dst", g_indiv_data_grant_dst, 0x030405);
+        rc |= expect_eq_long("Harris AC data src", g_indiv_data_grant_src, 0x980418);
     }
 
     // Case S: explicit SNDCP data grants update data-channel state in playback

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -123,6 +123,19 @@ expect_true(const char* tag, int cond) {
     return 0;
 }
 
+static int
+retune_backoff_empty(const dsd_state* state) {
+    if (!state || state->p25_retune_block_until != 0 || state->p25_retune_block_freq != 0) {
+        return 0;
+    }
+    for (int i = 0; i < DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH; i++) {
+        if (state->p25_retune_block_history_until[i] != 0 || state->p25_retune_block_history_freq[i] != 0) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -231,7 +244,77 @@ main(void) {
                                                   && forced_st.p25_retune_block_slot == 1
                                                   && forced_st.p25_retune_block_until > time(NULL));
 
-    // 7) A transient return-to-CC failure during grant timeout must not record
+    // 7) Data grants time out and forced-release without arming failed-voice backoff.
+    static dsd_opts data_opts;
+    static dsd_state data_st;
+    DSD_MEMSET(&data_opts, 0, sizeof data_opts);
+    DSD_MEMSET(&data_st, 0, sizeof data_st);
+    data_opts.p25_trunk = 1;
+    data_opts.trunk_tune_group_calls = 1;
+    data_opts.trunk_tune_data_calls = 1;
+    data_opts.trunk_hangtime = 0.2f;
+    data_opts.p25_grant_voice_to_s = 0.5;
+    data_opts.p25_retune_backoff_s = 2.0;
+    data_st.p25_cc_freq = 851000000;
+    data_st.p25_chan_iden = id;
+    data_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+    data_st.p25_chan_tdma_explicit[id] = 2;
+
+    p25_sm_ctx_t data_ctx;
+    p25_sm_init_ctx(&data_ctx, &data_opts, &data_st);
+    g_last_tuned_vc = 0;
+    g_tune_to_freq_calls = 0;
+    g_return_to_cc_calls = 0;
+    p25_sm_event_t data_ev_slot1 = p25_sm_ev_group_data_grant(ch_slot1, 0, 1001, 2002, P25_SM_SVC_UNKNOWN);
+    p25_sm_event(&data_ctx, &data_opts, &data_st, &data_ev_slot1);
+    rc |= expect_true("data initial tune", data_st.p25_sm_tune_count == 1 && data_opts.p25_is_tuned == 1
+                                               && g_tune_to_freq_calls == 1 && data_ctx.vc_data_call == 1);
+
+    data_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    data_ctx.t_voice_m = 0.0;
+    p25_sm_tick_ctx(&data_ctx, &data_opts, &data_st);
+    rc |= expect_true("data returned",
+                      data_opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1 && data_ctx.state == P25_SM_ON_CC);
+    rc |= expect_true("data timeout does not arm backoff", retune_backoff_empty(&data_st));
+
+    p25_sm_event(&data_ctx, &data_opts, &data_st, &ev_slot1);
+    rc |= expect_true("voice grant after data timeout allowed",
+                      g_tune_to_freq_calls == 2 && data_opts.p25_is_tuned == 1 && data_ctx.vc_data_call == 0);
+
+    static dsd_opts data_forced_opts;
+    static dsd_state data_forced_st;
+    DSD_MEMSET(&data_forced_opts, 0, sizeof data_forced_opts);
+    DSD_MEMSET(&data_forced_st, 0, sizeof data_forced_st);
+    data_forced_opts.p25_trunk = 1;
+    data_forced_opts.trunk_tune_group_calls = 1;
+    data_forced_opts.trunk_tune_data_calls = 1;
+    data_forced_opts.trunk_hangtime = 0.2f;
+    data_forced_opts.p25_grant_voice_to_s = 10.0;
+    data_forced_opts.p25_retune_backoff_s = 2.0;
+    data_forced_st.p25_cc_freq = 851000000;
+    data_forced_st.p25_chan_iden = id;
+    data_forced_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+    data_forced_st.p25_chan_tdma_explicit[id] = 2;
+
+    p25_sm_ctx_t data_forced_ctx;
+    p25_sm_init_ctx(&data_forced_ctx, &data_forced_opts, &data_forced_st);
+    g_last_tuned_vc = 0;
+    g_tune_to_freq_calls = 0;
+    g_return_to_cc_calls = 0;
+    p25_sm_event(&data_forced_ctx, &data_forced_opts, &data_forced_st, &data_ev_slot1);
+    rc |= expect_true("forced data initial tune", data_forced_st.p25_sm_tune_count == 1
+                                                      && data_forced_opts.p25_is_tuned == 1 && g_tune_to_freq_calls == 1
+                                                      && data_forced_ctx.vc_data_call == 1);
+
+    data_forced_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    data_forced_ctx.t_voice_m = 0.0;
+    data_forced_st.p25_sm_force_release = 1;
+    p25_sm_release(&data_forced_ctx, &data_forced_opts, &data_forced_st, "explicit-data-release");
+    rc |= expect_true("forced data returned", data_forced_opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1
+                                                  && data_forced_ctx.state == P25_SM_ON_CC);
+    rc |= expect_true("forced data does not arm backoff", retune_backoff_empty(&data_forced_st));
+
+    // 8) A transient return-to-CC failure during grant timeout must not record
     // a failed VC until the retry is accepted.
     static const dsd_trunk_tune_result transient_returns[] = {
         DSD_TRUNK_TUNE_RESULT_DEFERRED,
@@ -283,6 +366,8 @@ main(void) {
     }
     g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
+    dsd_state_ext_free_all(&data_forced_st);
+    dsd_state_ext_free_all(&data_st);
     dsd_state_ext_free_all(&forced_st);
     dsd_state_ext_free_all(&st);
 

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -11,6 +11,7 @@
  *   immediately (no backoff).
  * - Multiple failed VC/slot pairs remain blocked concurrently instead of the
  *   newest failure replacing the previous one.
+ * - Explicit data grants bypass stale failed-voice backoff on the same slot.
  */
 
 #include <dsd-neo/core/dsd_time.h>
@@ -314,7 +315,46 @@ main(void) {
                                                   && data_forced_ctx.state == P25_SM_ON_CC);
     rc |= expect_true("forced data does not arm backoff", retune_backoff_empty(&data_forced_st));
 
-    // 8) A transient return-to-CC failure during grant timeout must not record
+    // 8) A stale failed-voice backoff must not suppress an explicit data grant
+    // on the same TDMA channel/slot.
+    static dsd_opts mixed_opts;
+    static dsd_state mixed_st;
+    DSD_MEMSET(&mixed_opts, 0, sizeof mixed_opts);
+    DSD_MEMSET(&mixed_st, 0, sizeof mixed_st);
+    mixed_opts.p25_trunk = 1;
+    mixed_opts.trunk_tune_group_calls = 1;
+    mixed_opts.trunk_tune_data_calls = 1;
+    mixed_opts.trunk_hangtime = 0.2f;
+    mixed_opts.p25_grant_voice_to_s = 0.5;
+    mixed_opts.p25_retune_backoff_s = 2.0;
+    mixed_st.p25_cc_freq = 851000000;
+    mixed_st.p25_chan_iden = id;
+    mixed_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+    mixed_st.p25_chan_tdma_explicit[id] = 2;
+
+    p25_sm_ctx_t mixed_ctx;
+    p25_sm_init_ctx(&mixed_ctx, &mixed_opts, &mixed_st);
+    g_last_tuned_vc = 0;
+    g_tune_to_freq_calls = 0;
+    g_return_to_cc_calls = 0;
+    p25_sm_event(&mixed_ctx, &mixed_opts, &mixed_st, &ev_slot1);
+    rc |= expect_true("mixed voice initial tune", mixed_st.p25_sm_tune_count == 1 && mixed_opts.p25_is_tuned == 1
+                                                      && g_tune_to_freq_calls == 1 && mixed_ctx.vc_data_call == 0);
+
+    mixed_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    mixed_ctx.t_voice_m = 0.0;
+    p25_sm_tick_ctx(&mixed_ctx, &mixed_opts, &mixed_st);
+    rc |= expect_true("mixed voice returned",
+                      mixed_opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1 && mixed_ctx.state == P25_SM_ON_CC);
+    rc |= expect_true("mixed voice backoff armed", mixed_st.p25_retune_block_freq == g_last_tuned_vc
+                                                       && mixed_st.p25_retune_block_slot == 1
+                                                       && mixed_st.p25_retune_block_until > time(NULL));
+
+    p25_sm_event(&mixed_ctx, &mixed_opts, &mixed_st, &data_ev_slot1);
+    rc |= expect_true("data grant bypasses voice backoff",
+                      g_tune_to_freq_calls == 2 && mixed_opts.p25_is_tuned == 1 && mixed_ctx.vc_data_call == 1);
+
+    // 9) A transient return-to-CC failure during grant timeout must not record
     // a failed VC until the retry is accepted.
     static const dsd_trunk_tune_result transient_returns[] = {
         DSD_TRUNK_TUNE_RESULT_DEFERRED,
@@ -366,6 +406,7 @@ main(void) {
     }
     g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
+    dsd_state_ext_free_all(&mixed_st);
     dsd_state_ext_free_all(&data_forced_st);
     dsd_state_ext_free_all(&data_st);
     dsd_state_ext_free_all(&forced_st);

--- a/tests/protocol/p25/test_p25_sm_api_override.c
+++ b/tests/protocol/p25/test_p25_sm_api_override.c
@@ -23,6 +23,8 @@ void p25_sm_on_release(dsd_opts* opts, dsd_state* state);
 void p25_sm_on_neighbor_update(dsd_opts* opts, dsd_state* state, const long* freqs, int count);
 int p25_sm_next_cc_candidate(dsd_state* state, long* out_freq);
 void p25_sm_tick(dsd_opts* opts, dsd_state* state);
+void p25_sm_on_queued_response(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target);
+void p25_sm_on_deny_response(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target);
 
 static int g_init_calls;
 static int g_group_calls;
@@ -33,6 +35,8 @@ static int g_release_calls;
 static int g_neighbor_calls;
 static int g_next_calls;
 static int g_tick_calls;
+static int g_queued_calls;
+static int g_deny_calls;
 
 static dsd_opts* g_last_opts;
 static dsd_state* g_last_state;
@@ -61,6 +65,14 @@ static const long* g_last_neighbor_freqs;
 static int g_last_neighbor_count;
 
 static long* g_last_out_freq;
+
+static int g_last_queued_svc_type;
+static int g_last_queued_reason_code;
+static int g_last_queued_target;
+
+static int g_last_deny_svc_type;
+static int g_last_deny_reason_code;
+static int g_last_deny_target;
 
 static void
 fake_init(dsd_opts* opts, dsd_state* state) {
@@ -145,6 +157,26 @@ fake_tick(dsd_opts* opts, dsd_state* state) {
     g_tick_calls++;
     g_last_opts = opts;
     g_last_state = state;
+}
+
+static void
+fake_on_queued_response(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target) {
+    g_queued_calls++;
+    g_last_opts = opts;
+    g_last_state = state;
+    g_last_queued_svc_type = svc_type;
+    g_last_queued_reason_code = reason_code;
+    g_last_queued_target = target;
+}
+
+static void
+fake_on_deny_response(dsd_opts* opts, dsd_state* state, int svc_type, int reason_code, int target) {
+    g_deny_calls++;
+    g_last_opts = opts;
+    g_last_state = state;
+    g_last_deny_svc_type = svc_type;
+    g_last_deny_reason_code = reason_code;
+    g_last_deny_target = target;
 }
 
 static int
@@ -307,6 +339,61 @@ main(void) {
         DSD_FPRINTF(stderr, "watchdog thread did not tick: calls=%d\n", g_tick_calls);
         rc |= 1;
     }
+
+    p25_sm_reset_api();
+    g_group_calls = 0;
+    g_indiv_calls = 0;
+    g_group_data_calls = 0;
+    g_indiv_data_calls = 0;
+    g_release_calls = 0;
+    g_neighbor_calls = 0;
+    g_next_calls = 0;
+    g_tick_calls = 0;
+    g_queued_calls = 0;
+    g_deny_calls = 0;
+    out_freq = 0;
+
+    p25_sm_api legacy_positional_api = {
+        fake_init,
+        fake_on_group_grant,
+        fake_on_indiv_grant,
+        fake_on_release,
+        fake_on_neighbor_update,
+        fake_next_cc_candidate,
+        fake_tick,
+        fake_on_queued_response,
+        fake_on_deny_response,
+        NULL,
+        NULL,
+    };
+    p25_sm_set_api(&legacy_positional_api);
+
+    p25_sm_on_release(opts, state);
+    rc |= expect_eq_int("legacy_positional_release", g_release_calls, 1);
+    p25_sm_on_neighbor_update(opts, state, freqs, 1);
+    rc |= expect_eq_int("legacy_positional_neighbor", g_neighbor_calls, 1);
+    rc |= expect_eq_int("legacy_positional_neighbor_count", g_last_neighbor_count, 1);
+    ok = p25_sm_next_cc_candidate(state, &out_freq);
+    rc |= expect_eq_int("legacy_positional_next_ok", ok, 1);
+    rc |= expect_eq_long("legacy_positional_next_freq", out_freq, 424242);
+    p25_sm_tick(opts, state);
+    rc |= expect_eq_int("legacy_positional_tick", g_tick_calls, 1);
+    p25_sm_on_queued_response(opts, state, 1, 2, 3);
+    rc |= expect_eq_int("legacy_positional_queued", g_queued_calls, 1);
+    rc |= expect_eq_int("legacy_positional_queued_svc", g_last_queued_svc_type, 1);
+    rc |= expect_eq_int("legacy_positional_queued_reason", g_last_queued_reason_code, 2);
+    rc |= expect_eq_int("legacy_positional_queued_target", g_last_queued_target, 3);
+    p25_sm_on_deny_response(opts, state, 4, 5, 6);
+    rc |= expect_eq_int("legacy_positional_deny", g_deny_calls, 1);
+    rc |= expect_eq_int("legacy_positional_deny_svc", g_last_deny_svc_type, 4);
+    rc |= expect_eq_int("legacy_positional_deny_reason", g_last_deny_reason_code, 5);
+    rc |= expect_eq_int("legacy_positional_deny_target", g_last_deny_target, 6);
+    p25_sm_on_group_data_grant(opts, state, 13, 0xDE, 1300, 1400);
+    rc |= expect_eq_int("legacy_positional_group_data_falls_back", g_group_calls, 1);
+    rc |= expect_eq_int("legacy_positional_group_data_cb_unset", g_group_data_calls, 0);
+    p25_sm_on_indiv_data_grant(opts, state, 14, 0xF0, 1500, 1600);
+    rc |= expect_eq_int("legacy_positional_indiv_data_falls_back", g_indiv_calls, 1);
+    rc |= expect_eq_int("legacy_positional_indiv_data_cb_unset", g_indiv_data_calls, 0);
 
     return rc;
 }

--- a/tests/protocol/p25/test_p25_sm_api_override.c
+++ b/tests/protocol/p25/test_p25_sm_api_override.c
@@ -17,6 +17,8 @@
 void p25_sm_init(dsd_opts* opts, dsd_state* state);
 void p25_sm_on_group_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src);
 void p25_sm_on_indiv_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src);
+void p25_sm_on_group_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src);
+void p25_sm_on_indiv_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src);
 void p25_sm_on_release(dsd_opts* opts, dsd_state* state);
 void p25_sm_on_neighbor_update(dsd_opts* opts, dsd_state* state, const long* freqs, int count);
 int p25_sm_next_cc_candidate(dsd_state* state, long* out_freq);
@@ -25,6 +27,8 @@ void p25_sm_tick(dsd_opts* opts, dsd_state* state);
 static int g_init_calls;
 static int g_group_calls;
 static int g_indiv_calls;
+static int g_group_data_calls;
+static int g_indiv_data_calls;
 static int g_release_calls;
 static int g_neighbor_calls;
 static int g_next_calls;
@@ -42,6 +46,16 @@ static int g_last_indiv_channel;
 static int g_last_indiv_svc_bits;
 static int g_last_indiv_dst;
 static int g_last_indiv_src;
+
+static int g_last_group_data_channel;
+static int g_last_group_data_svc_bits;
+static int g_last_group_data_tg;
+static int g_last_group_data_src;
+
+static int g_last_indiv_data_channel;
+static int g_last_indiv_data_svc_bits;
+static int g_last_indiv_data_dst;
+static int g_last_indiv_data_src;
 
 static const long* g_last_neighbor_freqs;
 static int g_last_neighbor_count;
@@ -75,6 +89,28 @@ fake_on_indiv_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits,
     g_last_indiv_svc_bits = svc_bits;
     g_last_indiv_dst = dst;
     g_last_indiv_src = src;
+}
+
+static void
+fake_on_group_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int tg, int src) {
+    g_group_data_calls++;
+    g_last_opts = opts;
+    g_last_state = state;
+    g_last_group_data_channel = channel;
+    g_last_group_data_svc_bits = svc_bits;
+    g_last_group_data_tg = tg;
+    g_last_group_data_src = src;
+}
+
+static void
+fake_on_indiv_data_grant(dsd_opts* opts, dsd_state* state, int channel, int svc_bits, int dst, int src) {
+    g_indiv_data_calls++;
+    g_last_opts = opts;
+    g_last_state = state;
+    g_last_indiv_data_channel = channel;
+    g_last_indiv_data_svc_bits = svc_bits;
+    g_last_indiv_data_dst = dst;
+    g_last_indiv_data_src = src;
 }
 
 static void
@@ -159,6 +195,8 @@ main(void) {
     api.init = fake_init;
     api.on_group_grant = fake_on_group_grant;
     api.on_indiv_grant = fake_on_indiv_grant;
+    api.on_group_data_grant = fake_on_group_data_grant;
+    api.on_indiv_data_grant = fake_on_indiv_data_grant;
     api.on_release = fake_on_release;
     api.on_neighbor_update = fake_on_neighbor_update;
     api.next_cc_candidate = fake_next_cc_candidate;
@@ -183,6 +221,39 @@ main(void) {
     rc |= expect_eq_int("indiv_svc_bits", g_last_indiv_svc_bits, 0x34);
     rc |= expect_eq_int("indiv_dst", g_last_indiv_dst, 300);
     rc |= expect_eq_int("indiv_src", g_last_indiv_src, 400);
+
+    p25_sm_on_group_data_grant(opts, state, 9, 0x56, 500, 600);
+    rc |= expect_eq_int("group_data_calls", g_group_data_calls, 1);
+    rc |= expect_eq_int("group_data_channel", g_last_group_data_channel, 9);
+    rc |= expect_eq_int("group_data_svc_bits", g_last_group_data_svc_bits, 0x56);
+    rc |= expect_eq_int("group_data_tg", g_last_group_data_tg, 500);
+    rc |= expect_eq_int("group_data_src", g_last_group_data_src, 600);
+    rc |= expect_eq_int("group_legacy_not_used_for_data_when_data_cb_exists", g_group_calls, 1);
+
+    p25_sm_on_indiv_data_grant(opts, state, 10, 0x78, 700, 800);
+    rc |= expect_eq_int("indiv_data_calls", g_indiv_data_calls, 1);
+    rc |= expect_eq_int("indiv_data_channel", g_last_indiv_data_channel, 10);
+    rc |= expect_eq_int("indiv_data_svc_bits", g_last_indiv_data_svc_bits, 0x78);
+    rc |= expect_eq_int("indiv_data_dst", g_last_indiv_data_dst, 700);
+    rc |= expect_eq_int("indiv_data_src", g_last_indiv_data_src, 800);
+    rc |= expect_eq_int("indiv_legacy_not_used_for_data_when_data_cb_exists", g_indiv_calls, 1);
+
+    api.on_group_data_grant = NULL;
+    api.on_indiv_data_grant = NULL;
+    p25_sm_set_api(&api);
+    p25_sm_on_group_data_grant(opts, state, 11, 0x9A, 900, 1000);
+    rc |= expect_eq_int("group_data_legacy_fallback_calls", g_group_calls, 2);
+    rc |= expect_eq_int("group_data_legacy_fallback_channel", g_last_group_channel, 11);
+    rc |= expect_eq_int("group_data_legacy_fallback_svc", g_last_group_svc_bits, 0x9A);
+    rc |= expect_eq_int("group_data_legacy_fallback_tg", g_last_group_tg, 900);
+    rc |= expect_eq_int("group_data_legacy_fallback_src", g_last_group_src, 1000);
+
+    p25_sm_on_indiv_data_grant(opts, state, 12, 0xBC, 1100, 1200);
+    rc |= expect_eq_int("indiv_data_legacy_fallback_calls", g_indiv_calls, 2);
+    rc |= expect_eq_int("indiv_data_legacy_fallback_channel", g_last_indiv_channel, 12);
+    rc |= expect_eq_int("indiv_data_legacy_fallback_svc", g_last_indiv_svc_bits, 0xBC);
+    rc |= expect_eq_int("indiv_data_legacy_fallback_dst", g_last_indiv_dst, 1100);
+    rc |= expect_eq_int("indiv_data_legacy_fallback_src", g_last_indiv_src, 1200);
 
     p25_sm_on_release(opts, state);
     rc |= expect_eq_int("release_calls", g_release_calls, 1);

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -149,6 +149,14 @@ init_basic(dsd_opts* o, dsd_state* s) {
 
 int
 main(void) {
+    p25_sm_event_t legacy_group_grant = {
+        P25_SM_EV_GRANT, -1, 0x1234, 851500000L, 1000, 123, 0, P25_SM_SVC_UNKNOWN, 1, 0x80, 0x1234, 0,
+    };
+    assert(legacy_group_grant.is_group == 1);
+    assert(legacy_group_grant.algid == 0x80);
+    assert(legacy_group_grant.keyid == 0x1234);
+    assert(legacy_group_grant.data_call_override == 0);
+
     static dsd_opts opts;
     static dsd_state st;
     install_trunk_tuning_hooks();


### PR DESCRIPTION
## Summary
- Add explicit P25 data-grant state-machine and API paths that preserve raw service option bytes.
- Route true P1 TSBK/AMBTC data grants and P2 SNDCP/Harris data grants through the data policy path.
- Keep data announcements and existing voice/Motorola activity behavior outside grant-following changes.

## Validation
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug -R "P25_(MBT_DECODE|P1_TSBK_HANDLERS|SM_API_OVERRIDE|P1_TSBK_SEQUENCE|P2_VPDU_GRANTS|P1_PDU_PRIVATE_ALLOWLIST|GRANT_POLICY)$" --output-on-failure`
- `ctest --preset dev-debug --output-on-failure`
- Pre-push hook passed: clang-format, clang-tidy, cppcheck, IWYU, GCC analyzer, Semgrep, Lizard