### PR TITLE
p25: preserve TDMA same-carrier slot state

### DIFF
--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -89,6 +89,7 @@ typedef struct {
     int algid;              // Algorithm ID (for ENC event)
     int keyid;              // Key ID (for ENC event)
     int data_call_override; // 0=infer from svc_bits, 1=force data, -1=force non-data
+    double observed_m;      // Optional monotonic timestamp when the event was observed
 } p25_sm_event_t;
 
 /* ============================================================================
@@ -326,6 +327,11 @@ void p25_sm_emit_end(dsd_opts* opts, dsd_state* state, int slot);
  * @brief Emit IDLE event for a slot.
  */
 void p25_sm_emit_idle(dsd_opts* opts, dsd_state* state, int slot);
+
+/**
+ * @brief Emit IDLE event with a previously captured monotonic observation timestamp.
+ */
+void p25_sm_emit_idle_at(dsd_opts* opts, dsd_state* state, int slot, double observed_m);
 
 /**
  * @brief Emit TDU (P1 terminator) event.
@@ -584,6 +590,13 @@ p25_sm_ev_idle(int slot) {
     p25_sm_event_t ev = {0};
     ev.type = P25_SM_EV_IDLE;
     ev.slot = slot;
+    return ev;
+}
+
+static inline p25_sm_event_t
+p25_sm_ev_idle_at(int slot, double observed_m) {
+    p25_sm_event_t ev = p25_sm_ev_idle(slot);
+    ev.observed_m = observed_m;
     return ev;
 }
 

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -281,6 +281,19 @@ void p25_sm_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const c
 int p25_sm_audio_allowed(const p25_sm_ctx_t* ctx, const dsd_state* state, int slot);
 
 /**
+ * @brief Check whether a TDMA slot has an accepted grant newer than a captured event time.
+ *
+ * Decoders use this after processing a MAC payload but before clearing IDLE
+ * slot metadata, so grants carried inside the IDLE payload can keep their
+ * policy and service context.
+ *
+ * @param slot Slot index (0 or 1).
+ * @param observed_m Monotonic timestamp captured before payload processing.
+ * @return 1 if the global state machine has a newer active grant for the slot, 0 otherwise.
+ */
+int p25_sm_slot_grant_newer_than(int slot, double observed_m);
+
+/**
  * @brief Update audio gating for a slot based on current encryption state.
  *
  * Called when encryption parameters are received to update allow_audio.

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -111,6 +111,17 @@ typedef struct {
     int algid;            // Current algorithm ID for this slot
     int keyid;            // Current key ID for this slot
     int tg;               // Current talkgroup for this slot
+    int grant_active;     // 1 if this TDMA slot has an accepted grant context
+    long freq_hz;         // Accepted grant RF frequency
+    int channel;          // Accepted grant channel number
+    int target_id;        // Policy-selected target ID, or OTA target when no policy remap
+    int ota_tg;           // OTA talkgroup for group grants
+    int src;              // Source RID
+    int dst;              // Destination RID for individual grants
+    int is_group;         // 1 for group call, 0 for individual/private
+    int data_call;        // 1 for data grant, 0 for voice
+    int svc_bits;         // Service options, or P25_SM_SVC_UNKNOWN when absent
+    double last_grant_m;  // Monotonic timestamp of last accepted grant for this slot
 } p25_sm_slot_ctx_t;
 
 /* ============================================================================

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1032,6 +1032,18 @@ p25_grant_store_slot_context(p25_sm_ctx_t* ctx, const p25_sm_event_t* ev, long f
 }
 
 static void
+p25_grant_refresh_reused_carrier_watchdogs(dsd_state* state, double now_m) {
+    if (!state) {
+        return;
+    }
+    time_t now = time(NULL);
+    state->last_vc_sync_time = now;
+    state->p25_last_vc_tune_time = now;
+    state->last_vc_sync_time_m = now_m;
+    state->p25_last_vc_tune_time_m = now_m;
+}
+
+static void
 p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_event_t* ev, long freq, int target_id,
                            const p25_grant_eval_ctx_t* eval_ctx, double now_m, int slot, int reused_carrier) {
     if (!ctx || !ev) {
@@ -1049,8 +1061,11 @@ p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_eve
     if (!reused_carrier || ctx->t_tune_m <= 0.0 || data_call) {
         ctx->t_tune_m = now_m;
     }
-    if (!reused_carrier || ctx->t_voice_m <= 0.0) {
+    if (!reused_carrier || ctx->t_voice_m <= 0.0 || data_call) {
         ctx->t_voice_m = 0.0;
+    }
+    if (reused_carrier) {
+        p25_grant_refresh_reused_carrier_watchdogs(state, now_m);
     }
     if (!reused_carrier) {
         ctx->vc_cqpsk_retry_done = 0;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1223,8 +1223,7 @@ p25_grant_slot_duplicate_matches(const p25_sm_slot_ctx_t* slot_ctx, const dsd_tg
     if (!slot_ctx || !route) {
         return 0;
     }
-    if (slot_ctx->freq_hz != freq || slot_ctx->channel != route->channel || slot_ctx->target_id != target_id
-        || slot_ctx->data_call != data_call) {
+    if (slot_ctx->freq_hz != freq || slot_ctx->target_id != target_id || slot_ctx->data_call != data_call) {
         return 0;
     }
     return (slot_ctx->grant_active || slot_ctx->last_active_m > 0.0) ? 1 : 0;
@@ -1255,6 +1254,8 @@ p25_grant_refresh_duplicate_slot(p25_sm_ctx_t* ctx, dsd_state* state, const dsd_
         (!slot_ctx->grant_active && slot_ctx->last_active_m > 0.0 && !slot_ctx->voice_active) ? 1 : 0;
 
     slot_ctx->grant_active = 1;
+    slot_ctx->freq_hz = route->freq_hz;
+    slot_ctx->channel = route->channel;
     slot_ctx->last_grant_m = now_m;
     if (hangtime_refresh && !data_call) {
         slot_ctx->last_active_m = 0.0;
@@ -1285,6 +1286,10 @@ p25_grant_handle_duplicate(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* s
     }
 
     p25_grant_refresh_duplicate_slot(ctx, state, route, now_m, data_call);
+    if (data_call) {
+        ctx->t_tune_m = now_m;
+        ctx->t_voice_m = 0.0;
+    }
     p25_grant_refresh_reused_carrier_watchdogs(state, now_m);
     (void)dsd_tg_policy_note_active_call(state, route, decision, now_m);
     p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_duplicate", "freq=%ld tg=%d target=%d slot=%d data=%d", freq,

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2203,14 +2203,47 @@ p25_sm_init_ctx(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
                  ctx->config.hangtime_s, ctx->config.grant_timeout_s, ctx->expected_cc_nac);
 }
 
+static int
+p25_sm_vc_sync_slot(const p25_sm_ctx_t* ctx, const dsd_state* state, int slot) {
+    if (!ctx) {
+        return -1;
+    }
+    if (slot >= 0 && slot <= 1) {
+        return slot;
+    }
+    if (!ctx->vc_is_tdma) {
+        return 0;
+    }
+    if (state && state->p25_p2_active_slot >= 0 && state->p25_p2_active_slot <= 1) {
+        return state->p25_p2_active_slot;
+    }
+
+    int candidate = -1;
+    for (int s = 0; s < 2; s++) {
+        if (!ctx->slots[s].grant_active || ctx->slots[s].data_call) {
+            continue;
+        }
+        if (candidate >= 0) {
+            return -1;
+        }
+        candidate = s;
+    }
+    return candidate;
+}
+
 static void
-p25_sm_handle_vc_sync_event(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
+p25_sm_handle_vc_sync_event(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, int slot) {
     if (!ctx || ctx->state != P25_SM_TUNED) {
         return;
     }
-    ctx->t_voice_m = now_monotonic();
-    p25_sm_diagf((dsd_opts*)opts, state, ctx, "vc_sync", "freq=%ld ch=0x%04X tg=%d tdma=%d", ctx->vc_freq_hz,
-                 ctx->vc_channel & 0xFFFF, ctx->vc_tg, ctx->vc_is_tdma);
+    double now_m = now_monotonic();
+    int sync_slot = p25_sm_vc_sync_slot(ctx, state, slot);
+    ctx->t_voice_m = now_m;
+    if (sync_slot >= 0 && sync_slot <= 1 && ctx->slots[sync_slot].grant_active && !ctx->slots[sync_slot].data_call) {
+        ctx->slots[sync_slot].last_active_m = now_m;
+    }
+    p25_sm_diagf((dsd_opts*)opts, state, ctx, "vc_sync", "freq=%ld ch=0x%04X tg=%d tdma=%d slot=%d", ctx->vc_freq_hz,
+                 ctx->vc_channel & 0xFFFF, ctx->vc_tg, ctx->vc_is_tdma, sync_slot);
 #ifdef USE_RADIO
     /* Learn successful TDMA VC acquisition only for the OP25-style CQPSK timing
      * chain. */
@@ -2270,8 +2303,7 @@ p25_sm_handle_event_cc_sync(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* 
 
 static void
 p25_sm_handle_event_vc_sync(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev) {
-    (void)ev;
-    p25_sm_handle_vc_sync_event(ctx, opts, state);
+    p25_sm_handle_vc_sync_event(ctx, opts, state, ev ? ev->slot : -1);
 }
 
 static void

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -987,8 +987,12 @@ p25_grant_clear_policy_slot(dsd_state* state, int slot) {
 }
 
 static int
-p25_grant_slot_matches_moved_target(const p25_sm_slot_ctx_t* slot_ctx, const p25_sm_event_t* ev, int target_id) {
+p25_grant_slot_matches_moved_target(const p25_sm_slot_ctx_t* slot_ctx, const p25_sm_event_t* ev, int target_id,
+                                    int data_call) {
     if (!slot_ctx || !ev || !slot_ctx->grant_active || slot_ctx->target_id != target_id) {
+        return 0;
+    }
+    if (slot_ctx->data_call != (data_call ? 1 : 0)) {
         return 0;
     }
 
@@ -1002,13 +1006,13 @@ p25_grant_slot_matches_moved_target(const p25_sm_slot_ctx_t* slot_ctx, const p25
 
 static void
 p25_grant_clear_moved_target_slots(p25_sm_ctx_t* ctx, dsd_state* state, int keep_slot, const p25_sm_event_t* ev,
-                                   int target_id, long freq) {
+                                   int target_id, long freq, int data_call) {
     if (!ctx || !ev || target_id <= 0) {
         return;
     }
     for (int s = 0; s < 2; s++) {
         const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[s];
-        if (s == keep_slot || !p25_grant_slot_matches_moved_target(slot_ctx, ev, target_id)) {
+        if (s == keep_slot || !p25_grant_slot_matches_moved_target(slot_ctx, ev, target_id, data_call)) {
             continue;
         }
         if (slot_ctx->freq_hz == freq && slot_ctx->channel == ev->channel) {
@@ -1483,7 +1487,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     if (!p25_grant_try_tune_vc(ctx, ev, opts, state, grant.freq, grant.slot, grant.reused_carrier, &grant.ted_sps)) {
         return;
     }
-    p25_grant_clear_moved_target_slots(ctx, state, grant.slot, ev, grant.target_id, grant.freq);
+    p25_grant_clear_moved_target_slots(ctx, state, grant.slot, ev, grant.target_id, grant.freq, eval_ctx.data_call);
     if (grant.clear_policy_slot_only) {
         p25_grant_clear_one_slot_state(ctx, grant.slot);
     } else {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1597,6 +1597,15 @@ p25_voice_end_can_release_explicit(const p25_sm_ctx_t* ctx, int other) {
     return ctx->slots[other].voice_active ? 0 : 1;
 }
 
+static int
+p25_voice_end_preserve_recent_idle_grant(const p25_sm_ctx_t* ctx, int slot, int is_explicit_end, double observed_m) {
+    if (!ctx || slot < 0 || slot > 1 || is_explicit_end || observed_m <= 0.0) {
+        return 0;
+    }
+    const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
+    return (slot_ctx->grant_active && slot_ctx->last_grant_m > observed_m) ? 1 : 0;
+}
+
 static void
 p25_voice_end_try_explicit_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, int is_explicit_end) {
     if (!is_explicit_end || ctx->state != P25_SM_TUNED || !opts || !state) {
@@ -1623,17 +1632,21 @@ p25_voice_end_try_explicit_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state*
 }
 
 static void
-handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, const char* why, int is_explicit_end) {
+handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, const char* why, int is_explicit_end,
+                 double observed_m) {
     if (!ctx) {
         return;
     }
 
     int s = (slot >= 0 && slot <= 1) ? slot : 0;
+    int preserve_recent_grant = p25_voice_end_preserve_recent_idle_grant(ctx, s, is_explicit_end, observed_m);
 
     // Mark voice inactive but keep last_active_m for hangtime tracking
     ctx->slots[s].voice_active = 0;
-    ctx->slots[s].grant_active = 0;
-    if (state) {
+    if (!preserve_recent_grant) {
+        ctx->slots[s].grant_active = 0;
+    }
+    if (state && !preserve_recent_grant) {
         (void)dsd_tg_policy_clear_active_call(state, ctx->vc_is_tdma ? s : -1);
     }
 
@@ -2377,20 +2390,19 @@ p25_sm_handle_event_active(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* s
 static void
 p25_sm_handle_event_end(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev) {
     // MAC_END_PTT is an explicit call termination - trigger immediate release check.
-    handle_voice_end(ctx, (dsd_opts*)opts, state, ev->slot, "end", 1);
+    handle_voice_end(ctx, (dsd_opts*)opts, state, ev->slot, "end", 1, ev->observed_m);
 }
 
 static void
 p25_sm_handle_event_idle(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev) {
     // MAC_IDLE may occur during brief gaps - use hangtime, not immediate release.
-    handle_voice_end(ctx, (dsd_opts*)opts, state, ev->slot, "idle", 0);
+    handle_voice_end(ctx, (dsd_opts*)opts, state, ev->slot, "idle", 0, ev->observed_m);
 }
 
 static void
 p25_sm_handle_event_tdu(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev) {
-    (void)ev;
     // P1 terminator - explicit call end, trigger immediate release check.
-    handle_voice_end(ctx, (dsd_opts*)opts, state, 0, "tdu", 1);
+    handle_voice_end(ctx, (dsd_opts*)opts, state, 0, "tdu", 1, ev ? ev->observed_m : 0.0);
 }
 
 static void
@@ -2835,6 +2847,12 @@ p25_sm_emit_end(dsd_opts* opts, dsd_state* state, int slot) {
 void
 p25_sm_emit_idle(dsd_opts* opts, dsd_state* state, int slot) {
     p25_sm_event_t ev = p25_sm_ev_idle(slot);
+    p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);
+}
+
+void
+p25_sm_emit_idle_at(dsd_opts* opts, dsd_state* state, int slot, double observed_m) {
+    p25_sm_event_t ev = p25_sm_ev_idle_at(slot, observed_m);
     p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);
 }
 

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1669,6 +1669,19 @@ p25_sm_has_pending_voice_grant(const p25_sm_ctx_t* ctx, const dsd_state* state) 
     return p25_sm_slot_waiting_for_voice(ctx, state, 0) || p25_sm_slot_waiting_for_voice(ctx, state, 1);
 }
 
+static int
+p25_sm_has_pending_data_grant(const p25_sm_ctx_t* ctx) {
+    if (!ctx || !ctx->vc_is_tdma) {
+        return 0;
+    }
+    for (int s = 0; s < 2; s++) {
+        if (ctx->slots[s].grant_active && ctx->slots[s].data_call) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static double
 p25_sm_pending_voice_grant_timeout_start_m(const p25_sm_ctx_t* ctx, const dsd_state* state) {
     double latest_grant_m = 0.0;
@@ -2677,7 +2690,7 @@ p25_sm_tick_tuned(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double no
         ctx->t_voice_m = now_m;
         return;
     }
-    if (ctx->t_voice_m > 0.0 && p25_sm_has_pending_voice_grant(ctx, state)) {
+    if (ctx->t_voice_m > 0.0 && (p25_sm_has_pending_voice_grant(ctx, state) || p25_sm_has_pending_data_grant(ctx))) {
         ctx->t_voice_m = 0.0;
     }
     if (ctx->t_voice_m > 0.0) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -35,8 +35,8 @@
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/platform/platform.h"
 
-static void do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason,
-                       int arm_failed_vc_backoff_on_accept);
+static int do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason,
+                      int arm_failed_vc_backoff_on_accept);
 static void p25_sm_diagf(dsd_opts* opts, const dsd_state* state, const p25_sm_ctx_t* ctx, const char* event,
                          const char* format, ...) DSD_ATTR_FORMAT(printf, 5, 6);
 
@@ -927,8 +927,7 @@ p25_grant_preempt_active_call_if_needed(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
     }
     log_preempt_decision(ctx, opts, state, route, decision, "policy-allow", 1);
     sm_log(opts, state, "grant-preempt-accept");
-    do_release(ctx, opts, state, "grant-preempt", 0);
-    return 1;
+    return do_release(ctx, opts, state, "grant-preempt", 0);
 }
 
 static void
@@ -1598,6 +1597,46 @@ handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, 
     p25_voice_end_try_explicit_release(ctx, opts, state, s, is_explicit_end);
 }
 
+static int
+p25_sm_slot_waiting_for_voice(const p25_sm_ctx_t* ctx, const dsd_state* state, int slot) {
+    if (!ctx || slot < 0 || slot > 1) {
+        return 0;
+    }
+    const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
+    if (!slot_ctx->grant_active || slot_ctx->data_call || slot_ctx->voice_active || slot_ctx->last_active_m > 0.0) {
+        return 0;
+    }
+    if (state && state->p25_p2_audio_allowed[slot]) {
+        return 0;
+    }
+    return 1;
+}
+
+static int
+p25_sm_has_pending_voice_grant(const p25_sm_ctx_t* ctx, const dsd_state* state) {
+    if (!ctx || !ctx->vc_is_tdma) {
+        return 0;
+    }
+    return p25_sm_slot_waiting_for_voice(ctx, state, 0) || p25_sm_slot_waiting_for_voice(ctx, state, 1);
+}
+
+static double
+p25_sm_pending_voice_grant_timeout_start_m(const p25_sm_ctx_t* ctx, const dsd_state* state) {
+    double latest_grant_m = 0.0;
+    if (!ctx || !ctx->vc_is_tdma) {
+        return 0.0;
+    }
+    for (int s = 0; s < 2; s++) {
+        if (!p25_sm_slot_waiting_for_voice(ctx, state, s)) {
+            continue;
+        }
+        if (ctx->slots[s].last_grant_m > latest_grant_m) {
+            latest_grant_m = ctx->slots[s].last_grant_m;
+        }
+    }
+    return latest_grant_m;
+}
+
 static void
 handle_cc_sync(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
     if (!ctx) {
@@ -1829,12 +1868,6 @@ p25_arm_failed_vc_retune_backoff(const p25_sm_ctx_t* ctx, const dsd_opts* opts, 
         || ctx->slots[1].voice_active) {
         return;
     }
-    if (ctx->vc_data_call) {
-        p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_backoff_skip", "reason=data-grant ch=0x%04X freq=%ld",
-                     ctx->vc_channel & 0xFFFF, ctx->vc_freq_hz);
-        return;
-    }
-
     double backoff_s = p25_failed_vc_retune_backoff_s(opts);
     time_t backoff_wall = p25_backoff_wall_seconds(backoff_s);
     if (backoff_wall <= 0) {
@@ -1844,6 +1877,11 @@ p25_arm_failed_vc_retune_backoff(const p25_sm_ctx_t* ctx, const dsd_opts* opts, 
     time_t until = time(NULL) + backoff_wall;
     int armed_slots = p25_arm_failed_vc_retune_slot_backoffs(ctx, opts, state, backoff_s, until);
     if (armed_slots == 0) {
+        if (ctx->vc_data_call) {
+            p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_backoff_skip", "reason=data-grant ch=0x%04X freq=%ld",
+                         ctx->vc_channel & 0xFFFF, ctx->vc_freq_hz);
+            return;
+        }
         p25_arm_failed_vc_retune_fallback_backoff(ctx, opts, state, backoff_s, until);
     }
     sm_log(opts, state, "grant-vc-backoff-arm");
@@ -1886,20 +1924,20 @@ p25_release_clear_decoder_state(dsd_opts* opts, dsd_state* state) {
     }
 }
 
-static void
+static int
 do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason,
            int arm_failed_vc_backoff_on_accept) {
     double tune_start_m = 0.0;
     int had_force_release = 0;
     if (!ctx) {
-        return;
+        return 0;
     }
 
     // Avoid double-return-to-CC thrash if multiple callers attempt to release at
     // nearly the same time (e.g., explicit call termination + watchdog tick).
     int expected = 0;
     if (!atomic_compare_exchange_strong(&g_p25_sm_release_lock, &expected, 1)) {
-        return;
+        return 0;
     }
 
     if (state) {
@@ -1912,7 +1950,7 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
         p25_sm_diagf(opts, state, ctx, "release_skip", "reason=%s opts_tuned=%d", reason ? reason : "none",
                      opts ? ((opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1) ? 1 : 0) : 0);
         atomic_store(&g_p25_sm_release_lock, 0);
-        return;
+        return 0;
     }
 
     p25_sm_diagf(opts, state, ctx, "release_request", "reason=%s force=%d arm_backoff=%d", reason ? reason : "none",
@@ -1923,7 +1961,7 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
     // can retry through the same state machine instead of pretending the tuner moved.
     if (!p25_release_return_to_cc_accepted(ctx, opts, state, had_force_release, &tune_start_m)) {
         atomic_store(&g_p25_sm_release_lock, 0);
-        return;
+        return 0;
     }
 
     if (had_force_release || arm_failed_vc_backoff_on_accept) {
@@ -1938,6 +1976,7 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
     set_state(ctx, opts, state, P25_SM_ON_CC, "release->cc");
 
     atomic_store(&g_p25_sm_release_lock, 0);
+    return 1;
 }
 
 /* ============================================================================
@@ -2502,13 +2541,25 @@ p25_sm_tick_try_cqpsk_retry(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state,
 
 static void
 p25_sm_tick_tuned_wait_voice(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m, double grant_timeout) {
-    if (!ctx || ctx->t_tune_m <= 0.0) {
+    double dt_tune = 0.0;
+    double timeout_start_m = 0.0;
+    if (!ctx) {
         return;
     }
-    double dt_tune = now_m - ctx->t_tune_m;
-    p25_sm_tick_try_cqpsk_retry(ctx, opts, state, now_m, dt_tune);
-    if (dt_tune >= grant_timeout) {
-        do_release(ctx, opts, state, "grant-timeout", ctx->vc_data_call ? 0 : 1);
+    if (ctx->t_tune_m > 0.0) {
+        dt_tune = now_m - ctx->t_tune_m;
+        p25_sm_tick_try_cqpsk_retry(ctx, opts, state, now_m, dt_tune);
+    }
+
+    timeout_start_m = p25_sm_pending_voice_grant_timeout_start_m(ctx, state);
+    if (ctx->t_tune_m > 0.0 && (timeout_start_m <= 0.0 || ctx->t_tune_m < timeout_start_m)) {
+        timeout_start_m = ctx->t_tune_m;
+    }
+    if (timeout_start_m <= 0.0) {
+        return;
+    }
+    if ((now_m - timeout_start_m) >= grant_timeout) {
+        do_release(ctx, opts, state, "grant-timeout", 1);
     }
 }
 
@@ -2521,6 +2572,9 @@ p25_sm_tick_tuned(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double no
     if (ctx->slots[0].voice_active || ctx->slots[1].voice_active) {
         ctx->t_voice_m = now_m;
         return;
+    }
+    if (ctx->t_voice_m > 0.0 && p25_sm_has_pending_voice_grant(ctx, state)) {
+        ctx->t_voice_m = 0.0;
     }
     if (ctx->t_voice_m > 0.0) {
         p25_sm_tick_tuned_check_hangtime(ctx, opts, state, now_m, hangtime);

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -932,14 +932,40 @@ p25_grant_preempt_active_call_if_needed(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
 }
 
 static void
-p25_sm_clear_slot_activity(p25_sm_ctx_t* ctx) {
-    if (!ctx) {
+p25_sm_clear_one_slot_activity(p25_sm_ctx_t* ctx, int slot) {
+    if (!ctx || slot < 0 || slot > 1) {
         return;
     }
-    for (int s = 0; s < 2; s++) {
-        ctx->slots[s].voice_active = 0;
-        ctx->slots[s].last_active_m = 0.0;
+    ctx->slots[slot].voice_active = 0;
+    ctx->slots[slot].last_active_m = 0.0;
+}
+
+static void
+p25_sm_clear_slot_activity(p25_sm_ctx_t* ctx) {
+    p25_sm_clear_one_slot_activity(ctx, 0);
+    p25_sm_clear_one_slot_activity(ctx, 1);
+}
+
+static void
+p25_grant_clear_one_slot_state(p25_sm_ctx_t* ctx, int slot) {
+    if (!ctx || slot < 0 || slot > 1) {
+        return;
     }
+    p25_sm_clear_one_slot_activity(ctx, slot);
+    ctx->slots[slot].algid = 0;
+    ctx->slots[slot].keyid = 0;
+    ctx->slots[slot].tg = 0;
+    ctx->slots[slot].grant_active = 0;
+    ctx->slots[slot].freq_hz = 0;
+    ctx->slots[slot].channel = 0;
+    ctx->slots[slot].target_id = 0;
+    ctx->slots[slot].ota_tg = 0;
+    ctx->slots[slot].src = 0;
+    ctx->slots[slot].dst = 0;
+    ctx->slots[slot].is_group = 0;
+    ctx->slots[slot].data_call = 0;
+    ctx->slots[slot].svc_bits = P25_SM_SVC_UNKNOWN;
+    ctx->slots[slot].last_grant_m = 0.0;
 }
 
 static void
@@ -947,17 +973,68 @@ p25_grant_clear_slot_state(p25_sm_ctx_t* ctx) {
     if (!ctx) {
         return;
     }
-    p25_sm_clear_slot_activity(ctx);
     for (int s = 0; s < 2; s++) {
-        ctx->slots[s].algid = 0;
-        ctx->slots[s].keyid = 0;
-        ctx->slots[s].tg = 0;
+        p25_grant_clear_one_slot_state(ctx, s);
     }
 }
 
 static void
+p25_grant_clear_policy_slot(dsd_state* state, int slot) {
+    if (!state || slot < 0 || slot > 1) {
+        return;
+    }
+    (void)dsd_tg_policy_clear_active_call(state, slot);
+    state->p25_policy_tg[slot] = 0;
+}
+
+static void
+p25_grant_clear_moved_target_slots(p25_sm_ctx_t* ctx, dsd_state* state, int keep_slot, int target_id, long freq,
+                                   int channel) {
+    if (!ctx || target_id <= 0) {
+        return;
+    }
+    for (int s = 0; s < 2; s++) {
+        p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[s];
+        if (s == keep_slot || !slot_ctx->grant_active || slot_ctx->target_id != target_id) {
+            continue;
+        }
+        if (slot_ctx->freq_hz == freq && slot_ctx->channel == channel) {
+            continue;
+        }
+        p25_grant_clear_one_slot_state(ctx, s);
+        p25_grant_clear_policy_slot(state, s);
+        if (state) {
+            state->p25_p2_audio_allowed[s] = 0;
+            state->p25_p2_enc_lockout_muted[s] = 0;
+            p25_p2_audio_ring_reset(state, s);
+        }
+    }
+}
+
+static void
+p25_grant_store_slot_context(p25_sm_ctx_t* ctx, const p25_sm_event_t* ev, long freq, int target_id,
+                             const p25_grant_eval_ctx_t* eval_ctx, int slot, double now_m) {
+    if (!ctx || !ev || slot < 0 || slot > 1) {
+        return;
+    }
+    p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
+    slot_ctx->grant_active = 1;
+    slot_ctx->freq_hz = freq;
+    slot_ctx->channel = ev->channel;
+    slot_ctx->target_id = target_id;
+    slot_ctx->ota_tg = ev->is_group ? ev->tg : 0;
+    slot_ctx->src = ev->src;
+    slot_ctx->dst = ev->dst;
+    slot_ctx->is_group = ev->is_group ? 1 : 0;
+    slot_ctx->data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
+    slot_ctx->svc_bits = ev->svc_bits;
+    slot_ctx->last_grant_m = now_m;
+    slot_ctx->tg = target_id;
+}
+
+static void
 p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_event_t* ev, long freq, int target_id,
-                           const p25_grant_eval_ctx_t* eval_ctx, double now_m) {
+                           const p25_grant_eval_ctx_t* eval_ctx, double now_m, int slot, int reused_carrier) {
     if (!ctx || !ev) {
         return;
     }
@@ -968,9 +1045,14 @@ p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_eve
     ctx->vc_is_tdma = is_tdma_channel(state, ev->channel);
     ctx->vc_data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
     ctx->t_tune_m = now_m;
-    ctx->t_voice_m = 0.0;
-    ctx->vc_cqpsk_retry_done = 0;
-    if (state) {
+    if (!reused_carrier || ctx->t_voice_m <= 0.0) {
+        ctx->t_voice_m = 0.0;
+    }
+    if (!reused_carrier) {
+        ctx->vc_cqpsk_retry_done = 0;
+    }
+    p25_grant_store_slot_context(ctx, ev, freq, target_id, eval_ctx, slot, now_m);
+    if (state && !reused_carrier) {
         // Clear any stale one-shot VC CQPSK override from a previous attempt.
         state->p25_vc_cqpsk_override = -1;
     }
@@ -1031,8 +1113,21 @@ p25_grant_profile_snapshot_restore(dsd_state* state, const p25_grant_profile_sna
 
 static int
 p25_grant_try_tune_vc(const p25_sm_ctx_t* ctx, const p25_sm_event_t* ev, dsd_opts* opts, dsd_state* state, long freq,
-                      int slot, int* out_ted_sps) {
+                      int slot, int reused_carrier, int* out_ted_sps) {
     const int vc_is_tdma = is_tdma_channel(state, ev->channel);
+    if (reused_carrier) {
+        if (state && vc_is_tdma) {
+            state->p25_p2_active_slot = slot;
+            state->rf_mod = 1;
+        }
+        if (out_ted_sps) {
+            *out_ted_sps = state ? state->samplesPerSymbol : 0;
+        }
+        p25_sm_diagf(opts, state, ctx, "grant_tune_reuse", "ch=0x%04X freq=%ld slot=%d tdma=%d tg=%d src=%d dst=%d",
+                     ev->channel & 0xFFFF, freq, slot, vc_is_tdma, ev->tg, ev->src, ev->dst);
+        return 1;
+    }
+
     p25_grant_profile_snapshot_t snapshot = p25_grant_profile_snapshot_capture(state);
     const int ted_sps = p25_grant_configure_channel_profile_for_tdma(vc_is_tdma, opts, state, slot);
     p25_sm_diagf(opts, state, ctx, "grant_tune_attempt",
@@ -1076,10 +1171,19 @@ p25_grant_handle_duplicate(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_st
                            const dsd_tg_policy_call_route* route, const dsd_tg_policy_decision* decision, long freq,
                            int target_id, const p25_grant_eval_ctx_t* eval_ctx, double now_m) {
     int data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
-    if (ctx->state != P25_SM_TUNED || ctx->vc_freq_hz != freq || ctx->vc_tg != target_id
-        || ctx->vc_data_call != data_call) {
+    if (!ctx || !route || ctx->state != P25_SM_TUNED || ctx->vc_freq_hz != freq) {
         return 0;
     }
+    if (route->slot >= 0 && route->slot <= 1) {
+        const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[route->slot];
+        if (!slot_ctx->grant_active || slot_ctx->freq_hz != freq || slot_ctx->channel != route->channel
+            || slot_ctx->target_id != target_id || slot_ctx->data_call != data_call) {
+            return 0;
+        }
+    } else if (ctx->vc_tg != target_id || ctx->vc_data_call != data_call) {
+        return 0;
+    }
+
     (void)dsd_tg_policy_note_active_call(state, route, decision, now_m);
     p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_duplicate", "freq=%ld tg=%d target=%d slot=%d data=%d", freq,
                  ctx->vc_tg, target_id, route->slot, data_call);
@@ -1214,6 +1318,7 @@ typedef struct {
     int target_id;
     int needs_retune;
     int clear_policy_slot_only;
+    int reused_carrier;
     int ted_sps;
     long freq;
     double now_m;
@@ -1269,6 +1374,7 @@ p25_grant_prepare_route(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* stat
     }
     out->needs_retune = (ctx->state == P25_SM_TUNED && ctx->vc_freq_hz != 0 && ctx->vc_freq_hz != out->freq) ? 1 : 0;
     out->clear_policy_slot_only = p25_grant_should_clear_slot_only(ctx, state, ev, out->freq, out->slot);
+    out->reused_carrier = out->clear_policy_slot_only;
     out->target_id = p25_grant_target_id(ev, decision);
     p25_grant_fill_route(&out->route, ev, out->freq, out->slot, out->needs_retune, out->target_id);
     return 1;
@@ -1311,24 +1417,32 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
 
     p25_grant_seed_cc_before_vc_tune(ctx, opts, state, grant.now_m);
 
-    if (!p25_grant_try_tune_vc(ctx, ev, opts, state, grant.freq, grant.slot, &grant.ted_sps)) {
+    if (!p25_grant_try_tune_vc(ctx, ev, opts, state, grant.freq, grant.slot, grant.reused_carrier, &grant.ted_sps)) {
         return;
     }
-    p25_grant_store_vc_context(ctx, state, ev, grant.freq, grant.target_id, &eval_ctx, grant.now_m);
-    p25_grant_clear_slot_state(ctx);
+    p25_grant_clear_moved_target_slots(ctx, state, grant.slot, grant.target_id, grant.freq, ev->channel);
+    if (grant.clear_policy_slot_only) {
+        p25_grant_clear_one_slot_state(ctx, grant.slot);
+    } else {
+        p25_grant_clear_slot_state(ctx);
+    }
     p25_grant_clear_replaced_policy_tg(state, grant.slot, grant.clear_policy_slot_only);
+    p25_grant_store_vc_context(ctx, state, ev, grant.freq, grant.target_id, &eval_ctx, grant.now_m, grant.slot,
+                               grant.reused_carrier);
     p25_grant_store_policy_tg(state, ev, grant.slot, &decision);
-    ctx->tune_count++;
+    if (!grant.reused_carrier) {
+        ctx->tune_count++;
+        state->p25_sm_tune_count++;
+    }
     ctx->grant_count++;
     p25_grant_debug_log_tdma(opts, state, ctx, ev, grant.freq, grant.ted_sps);
 
-    state->p25_sm_tune_count++;
     (void)dsd_tg_policy_note_active_call(state, &grant.route, &decision, grant.now_m);
     p25_sm_diagf(opts, state, ctx, "grant_accept",
                  "ch=0x%04X freq=%ld slot=%d target=%d ota_tg=%d src=%d needs_retune=%d "
-                 "prio=%d preempt=%d data=%d",
+                 "prio=%d preempt=%d data=%d reused_carrier=%d",
                  ev->channel & 0xFFFF, grant.freq, grant.slot, grant.target_id, ev->tg, ev->src, grant.needs_retune,
-                 decision.priority, decision.preempt_requested, eval_ctx.data_call);
+                 decision.priority, decision.preempt_requested, eval_ctx.data_call, grant.reused_carrier);
 
     set_state(ctx, opts, state, P25_SM_TUNED, "grant");
 }
@@ -1404,6 +1518,9 @@ p25_voice_end_can_release_explicit(const p25_sm_ctx_t* ctx, int other) {
     if (!ctx->vc_is_tdma) {
         return 1;
     }
+    if (other >= 0 && other <= 1 && ctx->slots[other].grant_active) {
+        return 0;
+    }
     if (ctx->slots[other].last_active_m <= 0.0) {
         return 1;
     }
@@ -1445,6 +1562,7 @@ handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, 
 
     // Mark voice inactive but keep last_active_m for hangtime tracking
     ctx->slots[s].voice_active = 0;
+    ctx->slots[s].grant_active = 0;
     if (state) {
         (void)dsd_tg_policy_clear_active_call(state, ctx->vc_is_tdma ? s : -1);
     }
@@ -1664,12 +1782,30 @@ p25_arm_failed_vc_retune_backoff(const p25_sm_ctx_t* ctx, const dsd_opts* opts, 
     }
 
     time_t until = time(NULL) + backoff_wall;
-    state->p25_retune_block_freq = ctx->vc_freq_hz;
-    state->p25_retune_block_slot = channel_slot(state, ctx->vc_channel);
-    state->p25_retune_block_until = until;
-    p25_retune_block_remember_failure(state, ctx->vc_freq_hz, state->p25_retune_block_slot, until);
-    p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_backoff_arm", "ch=0x%04X freq=%ld slot=%d seconds=%.3f until=%ld",
-                 ctx->vc_channel & 0xFFFF, ctx->vc_freq_hz, state->p25_retune_block_slot, backoff_s, (long)until);
+    int armed_slots = 0;
+    for (int s = 0; s < 2; s++) {
+        const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[s];
+        if (!slot_ctx->grant_active || slot_ctx->data_call || slot_ctx->freq_hz <= 0 || slot_ctx->channel <= 0) {
+            continue;
+        }
+        state->p25_retune_block_freq = slot_ctx->freq_hz;
+        state->p25_retune_block_slot = s;
+        state->p25_retune_block_until = until;
+        p25_retune_block_remember_failure(state, slot_ctx->freq_hz, s, until);
+        p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_backoff_arm",
+                     "ch=0x%04X freq=%ld slot=%d seconds=%.3f until=%ld", slot_ctx->channel & 0xFFFF, slot_ctx->freq_hz,
+                     s, backoff_s, (long)until);
+        armed_slots++;
+    }
+    if (armed_slots == 0) {
+        state->p25_retune_block_freq = ctx->vc_freq_hz;
+        state->p25_retune_block_slot = channel_slot(state, ctx->vc_channel);
+        state->p25_retune_block_until = until;
+        p25_retune_block_remember_failure(state, ctx->vc_freq_hz, state->p25_retune_block_slot, until);
+        p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_backoff_arm",
+                     "ch=0x%04X freq=%ld slot=%d seconds=%.3f until=%ld", ctx->vc_channel & 0xFFFF, ctx->vc_freq_hz,
+                     state->p25_retune_block_slot, backoff_s, (long)until);
+    }
     sm_log(opts, state, "grant-vc-backoff-arm");
     if (opts && opts->verbose > 1) {
         DSD_FPRINTF(stderr, "\n[P25 SM] grant-vc-backoff-arm ch=0x%04X freq=%ld slot=%d %.3fs\n",

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1643,6 +1643,16 @@ p25_sm_pending_voice_grant_timeout_start_m(const p25_sm_ctx_t* ctx, const dsd_st
 }
 
 static void
+p25_enc_lockout_clear_slot_grant(p25_sm_ctx_t* ctx, dsd_state* state, int slot) {
+    if (!ctx || !state || slot < 0 || slot > 1) {
+        return;
+    }
+    ctx->slots[slot].grant_active = 0;
+    (void)dsd_tg_policy_clear_active_call(state, ctx->vc_is_tdma ? slot : -1);
+    state->p25_policy_tg[slot] = 0;
+}
+
+static void
 handle_cc_sync(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
     if (!ctx) {
         return;
@@ -1716,11 +1726,7 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
     // Clear voice activity indicator to prevent audio routing logic from
     // treating this locked-out slot as having active voice
     ctx->slots[slot].voice_active = 0;
-    ctx->slots[slot].grant_active = 0;
-    (void)dsd_tg_policy_clear_active_call(state, ctx->vc_is_tdma ? slot : -1);
-    if (ctx->vc_is_tdma) {
-        state->p25_policy_tg[slot] = 0;
-    }
+    p25_enc_lockout_clear_slot_grant(ctx, state, slot);
     if (slot == 0) {
         state->dmrburstL = 0;
         // Reset voice counters to prevent stale state from affecting later calls

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -987,6 +987,19 @@ p25_grant_clear_policy_slot(dsd_state* state, int slot) {
 }
 
 static int
+p25_grant_slot_call_identity_matches(const p25_sm_slot_ctx_t* slot_ctx, const p25_sm_event_t* ev) {
+    if (!slot_ctx || !ev) {
+        return 0;
+    }
+
+    const int is_group = ev->is_group ? 1 : 0;
+    if (slot_ctx->is_group != is_group) {
+        return 0;
+    }
+    return is_group ? (slot_ctx->ota_tg == ev->tg) : (slot_ctx->dst == ev->dst);
+}
+
+static int
 p25_grant_slot_matches_moved_target(const p25_sm_slot_ctx_t* slot_ctx, const p25_sm_event_t* ev, int target_id,
                                     int data_call) {
     if (!slot_ctx || !ev || !slot_ctx->grant_active || slot_ctx->target_id != target_id) {
@@ -996,12 +1009,7 @@ p25_grant_slot_matches_moved_target(const p25_sm_slot_ctx_t* slot_ctx, const p25
         return 0;
     }
 
-    const int is_group = ev->is_group ? 1 : 0;
-    if (slot_ctx->is_group != is_group) {
-        return 0;
-    }
-
-    return is_group ? (slot_ctx->ota_tg == ev->tg) : (slot_ctx->dst == ev->dst);
+    return p25_grant_slot_call_identity_matches(slot_ctx, ev);
 }
 
 static void
@@ -1218,12 +1226,15 @@ p25_grant_decoder_tuned_to_freq(const dsd_opts* opts, const dsd_state* state, lo
 }
 
 static int
-p25_grant_slot_duplicate_matches(const p25_sm_slot_ctx_t* slot_ctx, const dsd_tg_policy_call_route* route, long freq,
-                                 int target_id, int data_call) {
-    if (!slot_ctx || !route) {
+p25_grant_slot_duplicate_matches(const p25_sm_slot_ctx_t* slot_ctx, const p25_sm_event_t* ev,
+                                 const dsd_tg_policy_call_route* route, long freq, int target_id, int data_call) {
+    if (!slot_ctx || !ev || !route) {
         return 0;
     }
     if (slot_ctx->freq_hz != freq || slot_ctx->target_id != target_id || slot_ctx->data_call != data_call) {
+        return 0;
+    }
+    if (!p25_grant_slot_call_identity_matches(slot_ctx, ev)) {
         return 0;
     }
     return (slot_ctx->grant_active || slot_ctx->last_active_m > 0.0) ? 1 : 0;
@@ -1269,16 +1280,16 @@ p25_grant_refresh_duplicate_slot(p25_sm_ctx_t* ctx, dsd_state* state, const dsd_
 }
 
 static int
-p25_grant_handle_duplicate(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state,
+p25_grant_handle_duplicate(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev,
                            const dsd_tg_policy_call_route* route, const dsd_tg_policy_decision* decision, long freq,
                            int target_id, const p25_grant_eval_ctx_t* eval_ctx, double now_m) {
     int data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
-    if (!ctx || !route || ctx->state != P25_SM_TUNED || ctx->vc_freq_hz != freq
+    if (!ctx || !ev || !route || ctx->state != P25_SM_TUNED || ctx->vc_freq_hz != freq
         || !p25_grant_decoder_tuned_to_freq(opts, state, freq)) {
         return 0;
     }
     if (route->slot >= 0 && route->slot <= 1) {
-        if (!p25_grant_slot_duplicate_matches(&ctx->slots[route->slot], route, freq, target_id, data_call)) {
+        if (!p25_grant_slot_duplicate_matches(&ctx->slots[route->slot], ev, route, freq, target_id, data_call)) {
             return 0;
         }
     } else if (!p25_grant_fallback_duplicate_matches(ctx, target_id, data_call)) {
@@ -1510,10 +1521,10 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
         return;
     }
 
-    // Skip if already tuned to same frequency AND same TG (avoid bounce on duplicate grants)
-    // Different TG/call type should still trigger a new tune
-    if (p25_grant_handle_duplicate(ctx, opts, state, &grant.route, &decision, grant.freq, grant.target_id, &eval_ctx,
-                                   grant.now_m)) {
+    // Skip only true duplicate grants; same-RF grants for a different call context
+    // still need normal grant handling so the slot context is replaced.
+    if (p25_grant_handle_duplicate(ctx, opts, state, ev, &grant.route, &decision, grant.freq, grant.target_id,
+                                   &eval_ctx, grant.now_m)) {
         p25_grant_store_policy_tg(state, ev, grant.slot, &decision);
         return;
     }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1223,8 +1223,11 @@ p25_grant_slot_duplicate_matches(const p25_sm_slot_ctx_t* slot_ctx, const dsd_tg
     if (!slot_ctx || !route) {
         return 0;
     }
-    return slot_ctx->grant_active && slot_ctx->freq_hz == freq && slot_ctx->channel == route->channel
-           && slot_ctx->target_id == target_id && slot_ctx->data_call == data_call;
+    if (slot_ctx->freq_hz != freq || slot_ctx->channel != route->channel || slot_ctx->target_id != target_id
+        || slot_ctx->data_call != data_call) {
+        return 0;
+    }
+    return (slot_ctx->grant_active || slot_ctx->last_active_m > 0.0) ? 1 : 0;
 }
 
 static int
@@ -1233,7 +1236,39 @@ p25_grant_fallback_duplicate_matches(const p25_sm_ctx_t* ctx, int target_id, int
 }
 
 static int
-p25_grant_handle_duplicate(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state,
+p25_grant_other_slot_voice_active(const p25_sm_ctx_t* ctx, int slot) {
+    if (!ctx || slot < 0 || slot > 1) {
+        return 0;
+    }
+    return ctx->slots[slot ^ 1].voice_active ? 1 : 0;
+}
+
+static void
+p25_grant_refresh_duplicate_slot(p25_sm_ctx_t* ctx, dsd_state* state, const dsd_tg_policy_call_route* route,
+                                 double now_m, int data_call) {
+    if (!ctx || !route || route->slot < 0 || route->slot > 1) {
+        return;
+    }
+
+    p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[route->slot];
+    const int hangtime_refresh =
+        (!slot_ctx->grant_active && slot_ctx->last_active_m > 0.0 && !slot_ctx->voice_active) ? 1 : 0;
+
+    slot_ctx->grant_active = 1;
+    slot_ctx->last_grant_m = now_m;
+    if (hangtime_refresh && !data_call) {
+        slot_ctx->last_active_m = 0.0;
+        if (!p25_grant_other_slot_voice_active(ctx, route->slot)) {
+            ctx->t_voice_m = 0.0;
+        }
+    }
+    if (state && ctx->vc_is_tdma) {
+        state->p25_p2_active_slot = route->slot;
+    }
+}
+
+static int
+p25_grant_handle_duplicate(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state,
                            const dsd_tg_policy_call_route* route, const dsd_tg_policy_decision* decision, long freq,
                            int target_id, const p25_grant_eval_ctx_t* eval_ctx, double now_m) {
     int data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
@@ -1249,6 +1284,8 @@ p25_grant_handle_duplicate(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_st
         return 0;
     }
 
+    p25_grant_refresh_duplicate_slot(ctx, state, route, now_m, data_call);
+    p25_grant_refresh_reused_carrier_watchdogs(state, now_m);
     (void)dsd_tg_policy_note_active_call(state, route, decision, now_m);
     p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_duplicate", "freq=%ld tg=%d target=%d slot=%d data=%d", freq,
                  ctx->vc_tg, target_id, route->slot, data_call);
@@ -2815,6 +2852,21 @@ p25_sm_get_ctx(void) {
         g_sm_initialized = 1;
     }
     return &g_sm_ctx;
+}
+
+int
+p25_sm_slot_grant_newer_than(int slot, double observed_m) {
+    if (slot < 0 || slot > 1 || observed_m <= 0.0) {
+        return 0;
+    }
+
+    const p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    if (!ctx) {
+        return 0;
+    }
+
+    const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
+    return (slot_ctx->grant_active && slot_ctx->last_grant_m > observed_m) ? 1 : 0;
 }
 
 /* ============================================================================

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2550,7 +2550,7 @@ p25_sm_tick_tuned_wait_voice(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state
     }
 
     timeout_start_m = p25_sm_pending_voice_grant_timeout_start_m(ctx, state);
-    if (ctx->t_tune_m > 0.0 && (timeout_start_m <= 0.0 || ctx->t_tune_m < timeout_start_m)) {
+    if (ctx->t_tune_m > timeout_start_m) {
         timeout_start_m = ctx->t_tune_m;
     }
     if (timeout_start_m <= 0.0) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1975,7 +1975,7 @@ p25_arm_failed_vc_retune_backoff(const p25_sm_ctx_t* ctx, const dsd_opts* opts, 
         if (p25_vc_has_observed_voice(ctx)) {
             return;
         }
-        if (ctx->vc_data_call) {
+        if (ctx->vc_data_call || p25_sm_has_pending_data_grant(ctx)) {
             p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_backoff_skip", "reason=data-grant ch=0x%04X freq=%ld",
                          ctx->vc_channel & 0xFFFF, ctx->vc_freq_hz);
             return;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1167,6 +1167,21 @@ p25_grant_debug_log_tdma(const dsd_opts* opts, const dsd_state* state, const p25
 }
 
 static int
+p25_grant_slot_duplicate_matches(const p25_sm_slot_ctx_t* slot_ctx, const dsd_tg_policy_call_route* route, long freq,
+                                 int target_id, int data_call) {
+    if (!slot_ctx || !route) {
+        return 0;
+    }
+    return slot_ctx->grant_active && slot_ctx->freq_hz == freq && slot_ctx->channel == route->channel
+           && slot_ctx->target_id == target_id && slot_ctx->data_call == data_call;
+}
+
+static int
+p25_grant_fallback_duplicate_matches(const p25_sm_ctx_t* ctx, int target_id, int data_call) {
+    return ctx && ctx->vc_tg == target_id && ctx->vc_data_call == data_call;
+}
+
+static int
 p25_grant_handle_duplicate(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state,
                            const dsd_tg_policy_call_route* route, const dsd_tg_policy_decision* decision, long freq,
                            int target_id, const p25_grant_eval_ctx_t* eval_ctx, double now_m) {
@@ -1175,12 +1190,10 @@ p25_grant_handle_duplicate(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_st
         return 0;
     }
     if (route->slot >= 0 && route->slot <= 1) {
-        const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[route->slot];
-        if (!slot_ctx->grant_active || slot_ctx->freq_hz != freq || slot_ctx->channel != route->channel
-            || slot_ctx->target_id != target_id || slot_ctx->data_call != data_call) {
+        if (!p25_grant_slot_duplicate_matches(&ctx->slots[route->slot], route, freq, target_id, data_call)) {
             return 0;
         }
-    } else if (ctx->vc_tg != target_id || ctx->vc_data_call != data_call) {
+    } else if (!p25_grant_fallback_duplicate_matches(ctx, target_id, data_call)) {
         return 0;
     }
 
@@ -1766,6 +1779,48 @@ p25_retune_block_remember_failure(dsd_state* state, long freq, int slot, time_t 
     state->p25_retune_block_history_until[replace_idx] = until;
 }
 
+static int
+p25_backoff_slot_context_valid(const p25_sm_slot_ctx_t* slot_ctx) {
+    return slot_ctx && slot_ctx->grant_active && !slot_ctx->data_call && slot_ctx->freq_hz > 0 && slot_ctx->channel > 0;
+}
+
+static void
+p25_arm_failed_vc_retune_slot_backoff(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state,
+                                      const p25_sm_slot_ctx_t* slot_ctx, int slot, double backoff_s, time_t until) {
+    state->p25_retune_block_freq = slot_ctx->freq_hz;
+    state->p25_retune_block_slot = slot;
+    state->p25_retune_block_until = until;
+    p25_retune_block_remember_failure(state, slot_ctx->freq_hz, slot, until);
+    p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_backoff_arm", "ch=0x%04X freq=%ld slot=%d seconds=%.3f until=%ld",
+                 slot_ctx->channel & 0xFFFF, slot_ctx->freq_hz, slot, backoff_s, (long)until);
+}
+
+static int
+p25_arm_failed_vc_retune_slot_backoffs(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state,
+                                       double backoff_s, time_t until) {
+    int armed_slots = 0;
+    for (int s = 0; s < 2; s++) {
+        const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[s];
+        if (!p25_backoff_slot_context_valid(slot_ctx)) {
+            continue;
+        }
+        p25_arm_failed_vc_retune_slot_backoff(ctx, opts, state, slot_ctx, s, backoff_s, until);
+        armed_slots++;
+    }
+    return armed_slots;
+}
+
+static void
+p25_arm_failed_vc_retune_fallback_backoff(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state,
+                                          double backoff_s, time_t until) {
+    state->p25_retune_block_freq = ctx->vc_freq_hz;
+    state->p25_retune_block_slot = channel_slot(state, ctx->vc_channel);
+    state->p25_retune_block_until = until;
+    p25_retune_block_remember_failure(state, ctx->vc_freq_hz, state->p25_retune_block_slot, until);
+    p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_backoff_arm", "ch=0x%04X freq=%ld slot=%d seconds=%.3f until=%ld",
+                 ctx->vc_channel & 0xFFFF, ctx->vc_freq_hz, state->p25_retune_block_slot, backoff_s, (long)until);
+}
+
 static void
 p25_arm_failed_vc_retune_backoff(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
     if (!ctx || !state || ctx->vc_freq_hz <= 0 || ctx->t_voice_m > 0.0 || ctx->slots[0].voice_active
@@ -1785,29 +1840,9 @@ p25_arm_failed_vc_retune_backoff(const p25_sm_ctx_t* ctx, const dsd_opts* opts, 
     }
 
     time_t until = time(NULL) + backoff_wall;
-    int armed_slots = 0;
-    for (int s = 0; s < 2; s++) {
-        const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[s];
-        if (!slot_ctx->grant_active || slot_ctx->data_call || slot_ctx->freq_hz <= 0 || slot_ctx->channel <= 0) {
-            continue;
-        }
-        state->p25_retune_block_freq = slot_ctx->freq_hz;
-        state->p25_retune_block_slot = s;
-        state->p25_retune_block_until = until;
-        p25_retune_block_remember_failure(state, slot_ctx->freq_hz, s, until);
-        p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_backoff_arm",
-                     "ch=0x%04X freq=%ld slot=%d seconds=%.3f until=%ld", slot_ctx->channel & 0xFFFF, slot_ctx->freq_hz,
-                     s, backoff_s, (long)until);
-        armed_slots++;
-    }
+    int armed_slots = p25_arm_failed_vc_retune_slot_backoffs(ctx, opts, state, backoff_s, until);
     if (armed_slots == 0) {
-        state->p25_retune_block_freq = ctx->vc_freq_hz;
-        state->p25_retune_block_slot = channel_slot(state, ctx->vc_channel);
-        state->p25_retune_block_until = until;
-        p25_retune_block_remember_failure(state, ctx->vc_freq_hz, state->p25_retune_block_slot, until);
-        p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_backoff_arm",
-                     "ch=0x%04X freq=%ld slot=%d seconds=%.3f until=%ld", ctx->vc_channel & 0xFFFF, ctx->vc_freq_hz,
-                     state->p25_retune_block_slot, backoff_s, (long)until);
+        p25_arm_failed_vc_retune_fallback_backoff(ctx, opts, state, backoff_s, until);
     }
     sm_log(opts, state, "grant-vc-backoff-arm");
     if (opts && opts->verbose > 1) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -986,18 +986,32 @@ p25_grant_clear_policy_slot(dsd_state* state, int slot) {
     state->p25_policy_tg[slot] = 0;
 }
 
+static int
+p25_grant_slot_matches_moved_target(const p25_sm_slot_ctx_t* slot_ctx, const p25_sm_event_t* ev, int target_id) {
+    if (!slot_ctx || !ev || !slot_ctx->grant_active || slot_ctx->target_id != target_id) {
+        return 0;
+    }
+
+    const int is_group = ev->is_group ? 1 : 0;
+    if (slot_ctx->is_group != is_group) {
+        return 0;
+    }
+
+    return is_group ? (slot_ctx->ota_tg == ev->tg) : (slot_ctx->dst == ev->dst);
+}
+
 static void
-p25_grant_clear_moved_target_slots(p25_sm_ctx_t* ctx, dsd_state* state, int keep_slot, int target_id, long freq,
-                                   int channel) {
-    if (!ctx || target_id <= 0) {
+p25_grant_clear_moved_target_slots(p25_sm_ctx_t* ctx, dsd_state* state, int keep_slot, const p25_sm_event_t* ev,
+                                   int target_id, long freq) {
+    if (!ctx || !ev || target_id <= 0) {
         return;
     }
     for (int s = 0; s < 2; s++) {
         const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[s];
-        if (s == keep_slot || !slot_ctx->grant_active || slot_ctx->target_id != target_id) {
+        if (s == keep_slot || !p25_grant_slot_matches_moved_target(slot_ctx, ev, target_id)) {
             continue;
         }
-        if (slot_ctx->freq_hz == freq && slot_ctx->channel == channel) {
+        if (slot_ctx->freq_hz == freq && slot_ctx->channel == ev->channel) {
             continue;
         }
         p25_grant_clear_one_slot_state(ctx, s);
@@ -1454,7 +1468,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     if (!p25_grant_try_tune_vc(ctx, ev, opts, state, grant.freq, grant.slot, grant.reused_carrier, &grant.ted_sps)) {
         return;
     }
-    p25_grant_clear_moved_target_slots(ctx, state, grant.slot, grant.target_id, grant.freq, ev->channel);
+    p25_grant_clear_moved_target_slots(ctx, state, grant.slot, ev, grant.target_id, grant.freq);
     if (grant.clear_policy_slot_only) {
         p25_grant_clear_one_slot_state(ctx, grant.slot);
     } else {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1042,8 +1042,11 @@ p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_eve
     ctx->vc_tg = target_id;
     ctx->vc_src = ev->src;
     ctx->vc_is_tdma = is_tdma_channel(state, ev->channel);
-    ctx->vc_data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
-    if (!reused_carrier || ctx->t_tune_m <= 0.0) {
+    const int data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
+    ctx->vc_data_call = data_call;
+    // Data grants do not use per-slot pending voice timing, so reused carrier
+    // data grants need their own timeout window.
+    if (!reused_carrier || ctx->t_tune_m <= 0.0 || data_call) {
         ctx->t_tune_m = now_m;
     }
     if (!reused_carrier || ctx->t_voice_m <= 0.0) {
@@ -1713,6 +1716,11 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
     // Clear voice activity indicator to prevent audio routing logic from
     // treating this locked-out slot as having active voice
     ctx->slots[slot].voice_active = 0;
+    ctx->slots[slot].grant_active = 0;
+    (void)dsd_tg_policy_clear_active_call(state, ctx->vc_is_tdma ? slot : -1);
+    if (ctx->vc_is_tdma) {
+        state->p25_policy_tg[slot] = 0;
+    }
     if (slot == 0) {
         state->dmrburstL = 0;
         // Reset voice counters to prevent stale state from affecting later calls

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1942,6 +1942,11 @@ p25_arm_failed_vc_retune_slot_backoffs(const p25_sm_ctx_t* ctx, const dsd_opts* 
     return armed_slots;
 }
 
+static int
+p25_vc_has_observed_voice(const p25_sm_ctx_t* ctx) {
+    return (ctx && (ctx->t_voice_m > 0.0 || ctx->slots[0].voice_active || ctx->slots[1].voice_active)) ? 1 : 0;
+}
+
 static void
 p25_arm_failed_vc_retune_fallback_backoff(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state,
                                           double backoff_s, time_t until) {
@@ -1955,8 +1960,7 @@ p25_arm_failed_vc_retune_fallback_backoff(const p25_sm_ctx_t* ctx, const dsd_opt
 
 static void
 p25_arm_failed_vc_retune_backoff(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
-    if (!ctx || !state || ctx->vc_freq_hz <= 0 || ctx->t_voice_m > 0.0 || ctx->slots[0].voice_active
-        || ctx->slots[1].voice_active) {
+    if (!ctx || !state || ctx->vc_freq_hz <= 0) {
         return;
     }
     double backoff_s = p25_failed_vc_retune_backoff_s(opts);
@@ -1968,6 +1972,9 @@ p25_arm_failed_vc_retune_backoff(const p25_sm_ctx_t* ctx, const dsd_opts* opts, 
     time_t until = time(NULL) + backoff_wall;
     int armed_slots = p25_arm_failed_vc_retune_slot_backoffs(ctx, opts, state, backoff_s, until);
     if (armed_slots == 0) {
+        if (p25_vc_has_observed_voice(ctx)) {
+            return;
+        }
         if (ctx->vc_data_call) {
             p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_backoff_skip", "reason=data-grant ch=0x%04X freq=%ld",
                          ctx->vc_channel & 0xFFFF, ctx->vc_freq_hz);

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1427,6 +1427,8 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     if (!p25_grant_preempt_active_call_if_needed(ctx, opts, state, &grant.route, &decision, grant.now_m)) {
         return;
     }
+    grant.clear_policy_slot_only = p25_grant_should_clear_slot_only(ctx, state, ev, grant.freq, grant.slot);
+    grant.reused_carrier = grant.clear_policy_slot_only;
 
     p25_grant_seed_cc_before_vc_tune(ctx, opts, state, grant.now_m);
 
@@ -1781,7 +1783,7 @@ p25_retune_block_remember_failure(dsd_state* state, long freq, int slot, time_t 
 
 static int
 p25_backoff_slot_context_valid(const p25_sm_slot_ctx_t* slot_ctx) {
-    return slot_ctx && slot_ctx->grant_active && !slot_ctx->data_call && slot_ctx->freq_hz > 0 && slot_ctx->channel > 0;
+    return slot_ctx && slot_ctx->grant_active && !slot_ctx->data_call && slot_ctx->freq_hz > 0;
 }
 
 static void

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -994,7 +994,7 @@ p25_grant_clear_moved_target_slots(p25_sm_ctx_t* ctx, dsd_state* state, int keep
         return;
     }
     for (int s = 0; s < 2; s++) {
-        p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[s];
+        const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[s];
         if (s == keep_slot || !slot_ctx->grant_active || slot_ctx->target_id != target_id) {
             continue;
         }
@@ -1518,7 +1518,10 @@ p25_voice_end_can_release_explicit(const p25_sm_ctx_t* ctx, int other) {
     if (!ctx->vc_is_tdma) {
         return 1;
     }
-    if (other >= 0 && other <= 1 && ctx->slots[other].grant_active) {
+    if (other < 0 || other > 1) {
+        return 1;
+    }
+    if (ctx->slots[other].grant_active) {
         return 0;
     }
     if (ctx->slots[other].last_active_m <= 0.0) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2541,14 +2541,12 @@ p25_sm_tick_try_cqpsk_retry(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state,
 
 static void
 p25_sm_tick_tuned_wait_voice(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m, double grant_timeout) {
-    double dt_tune = 0.0;
     double timeout_start_m = 0.0;
     if (!ctx) {
         return;
     }
     if (ctx->t_tune_m > 0.0) {
-        dt_tune = now_m - ctx->t_tune_m;
-        p25_sm_tick_try_cqpsk_retry(ctx, opts, state, now_m, dt_tune);
+        p25_sm_tick_try_cqpsk_retry(ctx, opts, state, now_m, now_m - ctx->t_tune_m);
     }
 
     timeout_start_m = p25_sm_pending_voice_grant_timeout_start_m(ctx, state);

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2861,10 +2861,6 @@ p25_sm_slot_grant_newer_than(int slot, double observed_m) {
     }
 
     const p25_sm_ctx_t* ctx = p25_sm_get_ctx();
-    if (!ctx) {
-        return 0;
-    }
-
     const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
     return (slot_ctx->grant_active && slot_ctx->last_grant_m > observed_m) ? 1 : 0;
 }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1200,6 +1200,20 @@ p25_grant_debug_log_tdma(const dsd_opts* opts, const dsd_state* state, const p25
 }
 
 static int
+p25_grant_decoder_tuned_to_freq(const dsd_opts* opts, const dsd_state* state, long freq) {
+    if (!opts || !state || freq <= 0) {
+        return 0;
+    }
+    if (opts->p25_is_tuned != 1 && opts->trunk_is_tuned != 1) {
+        return 0;
+    }
+    return (state->p25_vc_freq[0] == freq || state->p25_vc_freq[1] == freq || state->trunk_vc_freq[0] == freq
+            || state->trunk_vc_freq[1] == freq)
+               ? 1
+               : 0;
+}
+
+static int
 p25_grant_slot_duplicate_matches(const p25_sm_slot_ctx_t* slot_ctx, const dsd_tg_policy_call_route* route, long freq,
                                  int target_id, int data_call) {
     if (!slot_ctx || !route) {
@@ -1219,7 +1233,8 @@ p25_grant_handle_duplicate(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_st
                            const dsd_tg_policy_call_route* route, const dsd_tg_policy_decision* decision, long freq,
                            int target_id, const p25_grant_eval_ctx_t* eval_ctx, double now_m) {
     int data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
-    if (!ctx || !route || ctx->state != P25_SM_TUNED || ctx->vc_freq_hz != freq) {
+    if (!ctx || !route || ctx->state != P25_SM_TUNED || ctx->vc_freq_hz != freq
+        || !p25_grant_decoder_tuned_to_freq(opts, state, freq)) {
         return 0;
     }
     if (route->slot >= 0 && route->slot <= 1) {
@@ -1386,13 +1401,13 @@ p25_grant_log_freq(dsd_opts* opts, const dsd_state* state, const p25_sm_ctx_t* c
 }
 
 static int
-p25_grant_should_clear_slot_only(const p25_sm_ctx_t* ctx, const dsd_state* state, const p25_sm_event_t* ev, long freq,
-                                 int slot) {
+p25_grant_should_clear_slot_only(const p25_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state,
+                                 const p25_sm_event_t* ev, long freq, int slot) {
     if (!ctx || !state || !ev || slot < 0 || slot > 1) {
         return 0;
     }
     return (ctx->state == P25_SM_TUNED && ctx->vc_freq_hz == freq && ctx->vc_is_tdma
-            && is_tdma_channel(state, ev->channel))
+            && p25_grant_decoder_tuned_to_freq(opts, state, freq) && is_tdma_channel(state, ev->channel))
                ? 1
                : 0;
 }
@@ -1419,7 +1434,7 @@ p25_grant_prepare_route(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* stat
         return 0;
     }
     out->needs_retune = (ctx->state == P25_SM_TUNED && ctx->vc_freq_hz != 0 && ctx->vc_freq_hz != out->freq) ? 1 : 0;
-    out->clear_policy_slot_only = p25_grant_should_clear_slot_only(ctx, state, ev, out->freq, out->slot);
+    out->clear_policy_slot_only = p25_grant_should_clear_slot_only(ctx, opts, state, ev, out->freq, out->slot);
     out->reused_carrier = out->clear_policy_slot_only;
     out->target_id = p25_grant_target_id(ev, decision);
     p25_grant_fill_route(&out->route, ev, out->freq, out->slot, out->needs_retune, out->target_id);
@@ -1460,7 +1475,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     if (!p25_grant_preempt_active_call_if_needed(ctx, opts, state, &grant.route, &decision, grant.now_m)) {
         return;
     }
-    grant.clear_policy_slot_only = p25_grant_should_clear_slot_only(ctx, state, ev, grant.freq, grant.slot);
+    grant.clear_policy_slot_only = p25_grant_should_clear_slot_only(ctx, opts, state, ev, grant.freq, grant.slot);
     grant.reused_carrier = grant.clear_policy_slot_only;
 
     p25_grant_seed_cc_before_vc_tune(ctx, opts, state, grant.now_m);
@@ -1681,6 +1696,17 @@ p25_enc_lockout_clear_slot_grant(p25_sm_ctx_t* ctx, dsd_state* state, int slot) 
     state->p25_policy_tg[slot] = 0;
 }
 
+static int
+p25_enc_lockout_other_slot_active(const p25_sm_ctx_t* ctx, const dsd_state* state, int other) {
+    if (!ctx || !state || other < 0 || other > 1) {
+        return 0;
+    }
+    return (ctx->slots[other].voice_active || ctx->slots[other].grant_active || state->p25_p2_audio_allowed[other]
+            || (state->p25_p2_audio_ring_count[other] > 0))
+               ? 1
+               : 0;
+}
+
 static void
 handle_cc_sync(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
     if (!ctx) {
@@ -1774,8 +1800,7 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
 
     // Check if opposite slot is active - only release if both slots are quiet
     int other = slot ^ 1;
-    int other_active = ctx->slots[other].voice_active || state->p25_p2_audio_allowed[other]
-                       || (state->p25_p2_audio_ring_count[other] > 0);
+    int other_active = p25_enc_lockout_other_slot_active(ctx, state, other);
 
     if (!other_active) {
         do_release(ctx, opts, state, "enc-lockout", 0);

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1043,7 +1043,9 @@ p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_eve
     ctx->vc_src = ev->src;
     ctx->vc_is_tdma = is_tdma_channel(state, ev->channel);
     ctx->vc_data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
-    ctx->t_tune_m = now_m;
+    if (!reused_carrier || ctx->t_tune_m <= 0.0) {
+        ctx->t_tune_m = now_m;
+    }
     if (!reused_carrier || ctx->t_voice_m <= 0.0) {
         ctx->t_voice_m = 0.0;
     }
@@ -1821,8 +1823,12 @@ p25_retune_block_remember_failure(dsd_state* state, long freq, int slot, time_t 
 }
 
 static int
-p25_backoff_slot_context_valid(const p25_sm_slot_ctx_t* slot_ctx) {
-    return slot_ctx && slot_ctx->grant_active && !slot_ctx->data_call && slot_ctx->freq_hz > 0;
+p25_backoff_slot_context_valid(const p25_sm_ctx_t* ctx, const dsd_state* state, int slot) {
+    if (!ctx || slot < 0 || slot > 1) {
+        return 0;
+    }
+    const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
+    return p25_sm_slot_waiting_for_voice(ctx, state, slot) && slot_ctx->freq_hz > 0;
 }
 
 static void
@@ -1842,7 +1848,7 @@ p25_arm_failed_vc_retune_slot_backoffs(const p25_sm_ctx_t* ctx, const dsd_opts* 
     int armed_slots = 0;
     for (int s = 0; s < 2; s++) {
         const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[s];
-        if (!p25_backoff_slot_context_valid(slot_ctx)) {
+        if (!p25_backoff_slot_context_valid(ctx, state, s)) {
             continue;
         }
         p25_arm_failed_vc_retune_slot_backoff(ctx, opts, state, slot_ctx, s, backoff_s, until);

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -563,7 +563,7 @@ p25p2_vpdu_has_cc_context(const dsd_opts* opts, dsd_state* state) {
 }
 
 static int
-p25p2_vpdu_current_carrier_matches(const dsd_opts* opts, dsd_state* state, long int freq) {
+p25p2_vpdu_current_carrier_matches(const dsd_opts* opts, const dsd_state* state, long int freq) {
     if (!opts || !state || freq == 0 || (opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0)) {
         return 0;
     }

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -552,14 +552,39 @@ p25p2_vpdu_opcode_is_vendor_partition(int opcode) {
 }
 
 static int
-p25p2_vpdu_can_tune(const dsd_opts* opts, dsd_state* state, long int freq) {
-    if (!opts || !state || opts->p25_trunk != 1 || opts->p25_is_tuned != 0 || freq == 0) {
+p25p2_vpdu_has_cc_context(const dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state || opts->p25_trunk != 1) {
         return 0;
     }
     if (state->trunk_cc_freq > 0 || state->p2_is_lcch == 1 || DSD_SYNC_IS_P25P1(state->synctype)) {
         p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
     }
     return state->p25_cc_freq != 0;
+}
+
+static int
+p25p2_vpdu_current_carrier_matches(const dsd_opts* opts, dsd_state* state, long int freq) {
+    if (!opts || !state || freq == 0 || (opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0)) {
+        return 0;
+    }
+    if (state->p25_vc_freq[0] == freq || state->p25_vc_freq[1] == freq || state->trunk_vc_freq[0] == freq
+        || state->trunk_vc_freq[1] == freq) {
+        return 1;
+    }
+
+    const p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    return (ctx && ctx->state == P25_SM_TUNED && ctx->vc_freq_hz == freq) ? 1 : 0;
+}
+
+static int
+p25p2_vpdu_can_dispatch_grant(const dsd_opts* opts, dsd_state* state, long int freq) {
+    if (freq == 0 || !p25p2_vpdu_has_cc_context(opts, state)) {
+        return 0;
+    }
+    if (opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0) {
+        return 1;
+    }
+    return p25p2_vpdu_current_carrier_matches(opts, state, freq);
 }
 
 static void
@@ -723,11 +748,14 @@ static int
 p25p2_vpdu_try_group_candidate(const struct p25p2_mac_result* mac_res, dsd_opts* opts, dsd_state* state,
                                const p25p2_vpdu_group_candidate* candidate, const p25p2_vpdu_candidate_policy* policy) {
     int tuned = 0;
+    int was_tuned = (opts && (opts->p25_is_tuned != 0 || opts->trunk_is_tuned != 0)) ? 1 : 0;
     p25p2_vpdu_print_group_label(state, (uint32_t)candidate->group);
-    if (p25p2_vpdu_can_tune(opts, state, candidate->freq)) {
+    if (p25p2_vpdu_can_dispatch_grant(opts, state, candidate->freq)) {
         p25p2_mac_handle(mac_res, opts, state, candidate->channel, candidate->svc_bits, candidate->group, /*src*/ 0,
                          policy->policy_encrypted_override, policy->policy_data_override, policy->emit_enc_lockout);
-        tuned = (policy->stop_on_tune && opts->p25_is_tuned != 0) ? 1 : 0;
+        tuned = (policy->stop_on_tune && !was_tuned && opts && (opts->p25_is_tuned != 0 || opts->trunk_is_tuned != 0))
+                    ? 1
+                    : 0;
     }
     p25p2_vpdu_update_playback_if_match(opts, state, candidate->group, candidate->freq);
     return tuned;
@@ -1028,7 +1056,7 @@ p25p2_vpdu_handle_group_explicit_grant(const struct p25p2_mac_result* mac_res, d
     p25p2_vpdu_set_active_group_single(state, grant->channelt, grant->group);
     p25p2_vpdu_print_group_label(state, (uint32_t)grant->group);
 
-    if (p25p2_vpdu_can_tune(opts, state, freq_t)) {
+    if (p25p2_vpdu_can_dispatch_grant(opts, state, freq_t)) {
         p25p2_mac_handle(mac_res, opts, state, grant->channelt, grant->svc, grant->group, grant->source,
                          /*policy_encrypted*/ -1,
                          /*policy_data*/ -1, /*emit_enc_lockout*/ 1);
@@ -1139,7 +1167,7 @@ p25p2_vpdu_iter_block_01(p25p2_vpdu_ctx* ctx) {
 
         p25p2_vpdu_print_group_label(state, (uint32_t)sgroup);
 
-        if (p25p2_vpdu_can_tune(opts, state, freq)) {
+        if (p25p2_vpdu_can_dispatch_grant(opts, state, freq)) {
             p25p2_mac_handle(&mac_res, opts, state, channel, svc, sgroup, source, /*policy_encrypted*/ -1,
                              /*policy_data*/ -1, /*emit_enc_lockout*/ 1);
         }
@@ -1197,7 +1225,7 @@ p25p2_vpdu_iter_block_02(p25p2_vpdu_ctx* ctx) {
 
         p25p2_vpdu_print_group_label(state, (uint32_t)sgroup);
 
-        if (p25p2_vpdu_can_tune(opts, state, freq)) {
+        if (p25p2_vpdu_can_dispatch_grant(opts, state, freq)) {
             p25p2_mac_handle(&mac_res, opts, state, channel, svc, sgroup, source, /*policy_encrypted*/ -1,
                              /*policy_data*/ -1, /*emit_enc_lockout*/ 1);
         }
@@ -1312,7 +1340,7 @@ p25p2_vpdu_iter_block_04(p25p2_vpdu_ctx* ctx) {
         p25p2_vpdu_set_active_group_single(state, channel, group);
         p25p2_vpdu_print_group_label(state, (uint32_t)group);
 
-        if (p25p2_vpdu_can_tune(opts, state, freq)) {
+        if (p25p2_vpdu_can_dispatch_grant(opts, state, freq)) {
             p25p2_mac_handle(&mac_res, opts, state, channel, svc, group, source, /*policy_encrypted*/ -1,
                              /*policy_data*/ -1, /*emit_enc_lockout*/ 1);
         }
@@ -1377,7 +1405,7 @@ p25p2_vpdu_iter_block_05(p25p2_vpdu_ctx* ctx) {
         state->last_active_time = time(NULL);
 
         p25p2_vpdu_print_group_label(state, target);
-        if (p25p2_vpdu_can_tune(opts, state, freq)) {
+        if (p25p2_vpdu_can_dispatch_grant(opts, state, freq)) {
             p25p2_mac_handle_indiv(&mac_res, opts, state, channel, svc, (int)target, /*src*/ 0,
                                    /*policy_encrypted*/ -1, /*policy_data*/ -1);
         }
@@ -1432,7 +1460,7 @@ p25p2_vpdu_handle_unit_to_unit_grant_abbreviated(p25p2_vpdu_ctx* ctx, int opcode
         p25p2_vpdu_print_group_label(state, (uint32_t)target);
     }
 
-    if (p25p2_vpdu_can_tune(opts, state, freq)) {
+    if (p25p2_vpdu_can_dispatch_grant(opts, state, freq)) {
         int policy_encrypted = (opts->trunk_tune_enc_calls == 0) ? 1 : 0;
         p25p2_mac_handle_indiv(&mac_res, opts, state, channel, P25_SM_SVC_UNKNOWN, target, source, policy_encrypted,
                                /*policy_data*/ 0);
@@ -1479,7 +1507,7 @@ p25p2_vpdu_handle_unit_to_unit_grant_extended(p25p2_vpdu_ctx* ctx, int opcode) {
         p25p2_vpdu_print_group_label(state, (uint32_t)target);
     }
 
-    if (p25p2_vpdu_can_tune(opts, state, freq)) {
+    if (p25p2_vpdu_can_dispatch_grant(opts, state, freq)) {
         int policy_encrypted = (opts->trunk_tune_enc_calls == 0) ? 1 : 0;
         p25p2_mac_handle_indiv(&mac_res, opts, state, channelt, P25_SM_SVC_UNKNOWN, target, source, policy_encrypted,
                                /*policy_data*/ 0);
@@ -1834,7 +1862,7 @@ p25p2_vpdu_iter_block_11(p25p2_vpdu_ctx* ctx) {
         }
         state->last_active_time = time(NULL);
 
-        if (p25p2_vpdu_can_tune(opts, state, freq)) {
+        if (p25p2_vpdu_can_dispatch_grant(opts, state, freq)) {
             const int policy_encrypted = (opts->trunk_tune_enc_calls == 0) ? 1 : 0;
             p25p2_mac_handle_indiv(&mac_res, opts, state, channelt, P25_SM_SVC_UNKNOWN, (int)target, /*src*/ 0,
                                    policy_encrypted, /*policy_data*/ 1);
@@ -5027,7 +5055,7 @@ p25p2_vpdu_handle_harris_data_channel_grant(p25p2_vpdu_ctx* ctx, int opcode) {
     }
     state->last_active_time = time(NULL);
 
-    if (p25p2_vpdu_can_tune(opts, state, freq)) {
+    if (p25p2_vpdu_can_dispatch_grant(opts, state, freq)) {
         int policy_encrypted = (opts->trunk_tune_enc_calls == 0) ? 1 : 0;
         p25p2_mac_handle_indiv(ctx->mac_res, opts, state, channel, P25_SM_SVC_UNKNOWN, target, source, policy_encrypted,
                                /*policy_data*/ 1);
@@ -5317,7 +5345,7 @@ p25p2_vpdu_handle_multifrag_unit_to_unit_grant(p25p2_vpdu_ctx* ctx, int is_servi
     p25p2_vpdu_multifrag_set_active(state, "%s Active Ch: %04X%s TGT: %d SRC: %d; ",
                                     is_service_grant ? "UU-SVC-L" : "UU-UP-L", channelt, suffix, target, source);
 
-    if (opts->trunk_tune_private_calls && p25p2_vpdu_can_tune(opts, state, freq)) {
+    if (opts->trunk_tune_private_calls && p25p2_vpdu_can_dispatch_grant(opts, state, freq)) {
         p25p2_mac_handle_indiv(ctx->mac_res, opts, state, channelt, svc, target, source, /*policy_encrypted*/ -1,
                                /*policy_data*/ -1);
     }

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -587,6 +587,8 @@ p25p2_xcch_handle_sacch_mac_end(dsd_opts* opts, dsd_state* state, uint8_t slot) 
 
 static void
 p25p2_xcch_handle_sacch_mac_idle(dsd_opts* opts, dsd_state* state, uint8_t slot, unsigned long long int smac[24]) {
+    double idle_observed_m = dsd_time_now_monotonic_s();
+
     p25p2_xcch_set_slot_burst(state, slot, 24);
 
     DSD_FPRINTF(stderr, " MAC_IDLE ");
@@ -594,7 +596,7 @@ p25p2_xcch_handle_sacch_mac_idle(dsd_opts* opts, dsd_state* state, uint8_t slot,
     process_MAC_VPDU(opts, state, 1, smac);
     DSD_FPRINTF(stderr, "%s", KNRM);
 
-    p25_sm_emit_idle(opts, state, slot);
+    p25_sm_emit_idle_at(opts, state, slot, idle_observed_m);
     state->p25_p2_enc_lockout_muted[slot] = 0;
     p25p2_xcch_blank_slot_call_string(state, slot);
     p25p2_xcch_set_slot_audio_allowed(state, slot, 0);
@@ -682,6 +684,8 @@ p25p2_xcch_handle_facch_mac_idle(dsd_opts* opts, dsd_state* state, uint8_t slot,
         return;
     }
 
+    double idle_observed_m = dsd_time_now_monotonic_s();
+
     p25p2_xcch_reset_idle_slot_facch(state, slot);
 
     DSD_FPRINTF(stderr, " MAC_IDLE ");
@@ -690,7 +694,7 @@ p25p2_xcch_handle_facch_mac_idle(dsd_opts* opts, dsd_state* state, uint8_t slot,
     DSD_FPRINTF(stderr, "%s", KNRM);
 
     p25p2_xcch_blank_slot_call_string(state, slot);
-    p25_sm_emit_idle(opts, state, slot);
+    p25_sm_emit_idle_at(opts, state, slot, idle_observed_m);
     p25p2_xcch_set_slot_audio_allowed(state, slot, 0);
     p25_p2_audio_ring_reset(state, slot);
 }

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -288,6 +288,23 @@ p25p2_xcch_blank_slot_call_string(dsd_state* state, int slot) {
 }
 
 static void
+p25p2_xcch_clear_sacch_idle_metadata_if_stale(dsd_state* state, uint8_t slot, double idle_observed_m) {
+    if (p25_sm_slot_grant_newer_than(slot, idle_observed_m)) {
+        return;
+    }
+
+    p25p2_xcch_blank_slot_call_string(state, slot);
+    state->p25_policy_tg[slot & 1] = 0;
+    state->p25_call_is_packet[slot] = 0;
+    state->p25_service_options_valid[slot] = 0;
+    if (slot == 0) {
+        state->dmr_so = 0;
+    } else {
+        state->dmr_soR = 0;
+    }
+}
+
+static void
 p25p2_xcch_clear_slot_keys(dsd_state* state, int slot) {
     if (state->keyloader != 1) {
         return;
@@ -598,16 +615,8 @@ p25p2_xcch_handle_sacch_mac_idle(dsd_opts* opts, dsd_state* state, uint8_t slot,
 
     p25_sm_emit_idle_at(opts, state, slot, idle_observed_m);
     state->p25_p2_enc_lockout_muted[slot] = 0;
-    p25p2_xcch_blank_slot_call_string(state, slot);
+    p25p2_xcch_clear_sacch_idle_metadata_if_stale(state, slot, idle_observed_m);
     p25p2_xcch_set_slot_audio_allowed(state, slot, 0);
-    state->p25_policy_tg[slot & 1] = 0;
-    state->p25_call_is_packet[slot] = 0;
-    state->p25_service_options_valid[slot] = 0;
-    if (slot == 0) {
-        state->dmr_so = 0;
-    } else {
-        state->dmr_soR = 0;
-    }
 }
 
 static void

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -288,13 +288,17 @@ p25p2_xcch_blank_slot_call_string(dsd_state* state, int slot) {
 }
 
 static void
-p25p2_xcch_clear_sacch_idle_metadata_if_stale(dsd_state* state, uint8_t slot, double idle_observed_m) {
+p25p2_xcch_clear_idle_metadata_if_stale(dsd_state* state, uint8_t slot, double idle_observed_m, int clear_slot_ids) {
     if (p25_sm_slot_grant_newer_than(slot, idle_observed_m)) {
         return;
     }
 
     p25p2_xcch_blank_slot_call_string(state, slot);
-    state->p25_policy_tg[slot & 1] = 0;
+    if (clear_slot_ids) {
+        p25p2_xcch_clear_slot_ids(state, slot);
+    } else {
+        state->p25_policy_tg[slot & 1] = 0;
+    }
     state->p25_call_is_packet[slot] = 0;
     state->p25_service_options_valid[slot] = 0;
     if (slot == 0) {
@@ -493,15 +497,6 @@ p25p2_xcch_reset_idle_slot_facch(dsd_state* state, int slot) {
     p25p2_xcch_set_slot_burst(state, slot, 24);
     state->fourv_counter[slot] = 0;
     state->voice_counter[slot] = 0;
-
-    if (slot == 0) {
-        state->lastsrc = 0;
-        state->lasttg = 0;
-    } else {
-        state->lastsrcR = 0;
-        state->lasttgR = 0;
-    }
-    state->p25_policy_tg[slot & 1] = 0;
 }
 
 static int
@@ -615,7 +610,7 @@ p25p2_xcch_handle_sacch_mac_idle(dsd_opts* opts, dsd_state* state, uint8_t slot,
 
     p25_sm_emit_idle_at(opts, state, slot, idle_observed_m);
     state->p25_p2_enc_lockout_muted[slot] = 0;
-    p25p2_xcch_clear_sacch_idle_metadata_if_stale(state, slot, idle_observed_m);
+    p25p2_xcch_clear_idle_metadata_if_stale(state, slot, idle_observed_m, 0);
     p25p2_xcch_set_slot_audio_allowed(state, slot, 0);
 }
 
@@ -702,8 +697,8 @@ p25p2_xcch_handle_facch_mac_idle(dsd_opts* opts, dsd_state* state, uint8_t slot,
     process_MAC_VPDU(opts, state, 0, fmac);
     DSD_FPRINTF(stderr, "%s", KNRM);
 
-    p25p2_xcch_blank_slot_call_string(state, slot);
     p25_sm_emit_idle_at(opts, state, slot, idle_observed_m);
+    p25p2_xcch_clear_idle_metadata_if_stale(state, slot, idle_observed_m, 1);
     p25p2_xcch_set_slot_audio_allowed(state, slot, 0);
     p25_p2_audio_ring_reset(state, slot);
 }

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -32,6 +32,11 @@
 
 static const char* P25P2_EMPTY_CALL_STRING = "                     ";
 
+typedef struct {
+    int lasttg;
+    int lastsrc;
+} p25p2_xcch_slot_ids_snapshot;
+
 static int
 p25p2_xcch_slot_valid(uint8_t slot) {
     return slot <= 1;
@@ -291,11 +296,33 @@ p25p2_xcch_blank_slot_call_string(dsd_state* state, int slot) {
 }
 
 static void
-p25p2_xcch_clear_idle_metadata_if_stale(dsd_state* state, uint8_t slot, double idle_observed_m, int clear_slot_ids) {
+p25p2_xcch_snapshot_slot_ids(const dsd_state* state, uint8_t slot, p25p2_xcch_slot_ids_snapshot* snapshot) {
+    if (!state || !snapshot || !p25p2_xcch_slot_valid(slot)) {
+        return;
+    }
+
+    snapshot->lasttg = p25p2_xcch_get_slot_tg(state, slot);
+    snapshot->lastsrc = p25p2_xcch_get_slot_src(state, slot);
+}
+
+static void
+p25p2_xcch_clear_slot_call_ids(dsd_state* state, uint8_t slot) {
     if (!state || !p25p2_xcch_slot_valid(slot)) {
         return;
     }
-    if (p25_sm_slot_grant_newer_than(slot, idle_observed_m)) {
+
+    if (slot == 0) {
+        state->lastsrc = 0;
+        state->lasttg = 0;
+    } else {
+        state->lastsrcR = 0;
+        state->lasttgR = 0;
+    }
+}
+
+static void
+p25p2_xcch_clear_slot_idle_metadata(dsd_state* state, uint8_t slot, int clear_slot_ids) {
+    if (!state || !p25p2_xcch_slot_valid(slot)) {
         return;
     }
 
@@ -311,6 +338,35 @@ p25p2_xcch_clear_idle_metadata_if_stale(dsd_state* state, uint8_t slot, double i
         state->dmr_so = 0;
     } else {
         state->dmr_soR = 0;
+    }
+}
+
+static void
+p25p2_xcch_clear_idle_metadata_if_stale(dsd_state* state, uint8_t slot, double idle_observed_m, int clear_slot_ids) {
+    if (!state || !p25p2_xcch_slot_valid(slot)) {
+        return;
+    }
+    if (p25_sm_slot_grant_newer_than(slot, idle_observed_m)) {
+        return;
+    }
+
+    p25p2_xcch_clear_slot_idle_metadata(state, slot, clear_slot_ids);
+}
+
+static void
+p25p2_xcch_restore_slot_ids_for_new_grant(dsd_state* state, uint8_t slot, double idle_observed_m,
+                                          const p25p2_xcch_slot_ids_snapshot* snapshot) {
+    if (!state || !snapshot || !p25p2_xcch_slot_valid(slot) || !p25_sm_slot_grant_newer_than(slot, idle_observed_m)) {
+        return;
+    }
+
+    if (p25p2_xcch_get_slot_tg(state, slot) == 0 && p25p2_xcch_get_slot_src(state, slot) == 0) {
+        p25p2_xcch_set_slot_tg(state, slot, snapshot->lasttg);
+        if (slot == 0) {
+            state->lastsrc = snapshot->lastsrc;
+        } else {
+            state->lastsrcR = snapshot->lastsrc;
+        }
     }
 }
 
@@ -690,13 +746,17 @@ p25p2_xcch_handle_facch_mac_end(dsd_opts* opts, dsd_state* state, uint8_t slot) 
 
 static void
 p25p2_xcch_handle_facch_mac_idle(dsd_opts* opts, dsd_state* state, uint8_t slot, unsigned long long int fmac[24]) {
+    p25p2_xcch_slot_ids_snapshot idle_ids = {0};
+
     if (!p25p2_xcch_slot_valid(slot)) {
         return;
     }
 
     double idle_observed_m = dsd_time_now_monotonic_s();
 
+    p25p2_xcch_snapshot_slot_ids(state, slot, &idle_ids);
     p25p2_xcch_reset_idle_slot_facch(state, slot);
+    p25p2_xcch_clear_slot_call_ids(state, slot);
 
     DSD_FPRINTF(stderr, " MAC_IDLE ");
     DSD_FPRINTF(stderr, "%s", KYEL);
@@ -705,6 +765,7 @@ p25p2_xcch_handle_facch_mac_idle(dsd_opts* opts, dsd_state* state, uint8_t slot,
 
     p25_sm_emit_idle_at(opts, state, slot, idle_observed_m);
     p25p2_xcch_clear_idle_metadata_if_stale(state, slot, idle_observed_m, 1);
+    p25p2_xcch_restore_slot_ids_for_new_grant(state, slot, idle_observed_m, &idle_ids);
     p25p2_xcch_set_slot_audio_allowed(state, slot, 0);
     p25_p2_audio_ring_reset(state, slot);
 }

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -284,11 +284,17 @@ p25p2_xcch_handle_mac_hangtime_slot(dsd_opts* opts, dsd_state* state, int slot) 
 
 static void
 p25p2_xcch_blank_slot_call_string(dsd_state* state, int slot) {
+    if (!state || slot < 0 || slot > 1) {
+        return;
+    }
     DSD_SNPRINTF(state->call_string[slot], sizeof(state->call_string[slot]), "%s", P25P2_EMPTY_CALL_STRING);
 }
 
 static void
 p25p2_xcch_clear_idle_metadata_if_stale(dsd_state* state, uint8_t slot, double idle_observed_m, int clear_slot_ids) {
+    if (!state || !p25p2_xcch_slot_valid(slot)) {
+        return;
+    }
     if (p25_sm_slot_grant_newer_than(slot, idle_observed_m)) {
         return;
     }

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -445,6 +445,45 @@ main(void) {
                           dual_ctx->slots[1].grant_active && dual_ctx->slots[1].target_id == 1701);
     }
 
+    // Group TG IDs and individual RID destinations are separate namespaces.
+    {
+        static dsd_opts namespace_opts;
+        static dsd_state namespace_st;
+        DSD_MEMSET(&namespace_opts, 0, sizeof namespace_opts);
+        DSD_MEMSET(&namespace_st, 0, sizeof namespace_st);
+        namespace_opts.p25_trunk = 1;
+        namespace_opts.trunk_tune_group_calls = 1;
+        namespace_opts.trunk_tune_private_calls = 1;
+        namespace_opts.trunk_tune_data_calls = 1;
+        namespace_opts.trunk_tune_enc_calls = 1;
+        namespace_opts.trunk_use_allow_list = 1;
+        namespace_st.p25_cc_freq = 851000000;
+        seed_tdma_iden(&namespace_st, id);
+        p25_sm_init(&namespace_opts, &namespace_st);
+
+        rc |= expect_true("seed namespace group", seed_exact(&namespace_st, 1234, "A", "GROUP-SAME-RID", 0, 0) == 0);
+        p25_sm_on_indiv_grant(&namespace_opts, &namespace_st, 0x100A, /*svc*/ 0x00, /*dst*/ 1234, /*src*/ 4234);
+        p25_sm_ctx_t* namespace_ctx = p25_sm_get_ctx();
+        unsigned namespace_tunes_after_private = namespace_st.p25_sm_tune_count;
+        rc |= expect_true("namespace private slot0 stored",
+                          namespace_ctx->slots[0].grant_active && namespace_ctx->slots[0].target_id == 1234
+                              && namespace_ctx->slots[0].is_group == 0 && namespace_ctx->slots[0].dst == 1234);
+        namespace_ctx->slots[0].voice_active = 1;
+        namespace_ctx->slots[0].last_active_m = 1.0;
+        namespace_st.p25_p2_audio_allowed[0] = 1;
+
+        p25_sm_on_group_grant(&namespace_opts, &namespace_st, 0x100B, /*svc*/ 0x00, /*tg*/ 1234, /*src*/ 5234);
+        rc |= expect_true("namespace group same-carrier no retune",
+                          namespace_st.p25_sm_tune_count == namespace_tunes_after_private);
+        rc |= expect_true("namespace private slot preserved",
+                          namespace_ctx->slots[0].grant_active && namespace_ctx->slots[0].voice_active == 1
+                              && namespace_ctx->slots[0].target_id == 1234 && namespace_ctx->slots[0].is_group == 0
+                              && namespace_ctx->slots[0].dst == 1234);
+        rc |= expect_true("namespace group slot stored",
+                          namespace_ctx->slots[1].grant_active && namespace_ctx->slots[1].target_id == 1234
+                              && namespace_ctx->slots[1].is_group == 1 && namespace_ctx->slots[1].ota_tg == 1234);
+    }
+
     (void)dsd_unsetenv("DSD_NEO_TG_PREEMPT_MIN_DWELL_MS");
     (void)dsd_unsetenv("DSD_NEO_TG_PREEMPT_COOLDOWN_MS");
 

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -407,10 +407,42 @@ main(void) {
         p25_patch_add_wgid(&dual_st, 1601, 1602);
 
         p25_sm_on_group_grant(&dual_opts, &dual_st, 0x100B, /*svc*/ 0x00, /*tg*/ 1601, /*src*/ 2601);
+        p25_sm_ctx_t* dual_ctx = p25_sm_get_ctx();
+        unsigned dual_tunes_after_slot1 = dual_st.p25_sm_tune_count;
         rc |= expect_true("dual slot1 policy tg stored", dual_st.p25_policy_tg[1] == 1602U);
+        rc |= expect_true("dual slot1 grant context",
+                          dual_ctx->slots[1].grant_active && dual_ctx->slots[1].target_id == 1602);
+        dual_ctx->slots[1].voice_active = 1;
+        dual_ctx->slots[1].last_active_m = 1.0;
+        dual_st.p25_p2_audio_allowed[1] = 1;
+
         p25_sm_on_group_grant(&dual_opts, &dual_st, 0x100A, /*svc*/ 0x00, /*tg*/ 1501, /*src*/ 2600);
+        rc |= expect_true("dual slot0 same-carrier no retune", dual_st.p25_sm_tune_count == dual_tunes_after_slot1);
+        rc |= expect_true("dual slot0 same-carrier active slot", dual_st.p25_p2_active_slot == 0);
         rc |= expect_true("dual slot0 policy tg stored", dual_st.p25_policy_tg[0] == 1502U);
         rc |= expect_true("dual slot1 policy tg preserved", dual_st.p25_policy_tg[1] == 1602U);
+        rc |= expect_true("dual slot1 active preserved",
+                          dual_ctx->slots[1].voice_active == 1 && dual_ctx->slots[1].target_id == 1602);
+        rc |= expect_true("dual slot0 grant context",
+                          dual_ctx->slots[0].grant_active && dual_ctx->slots[0].target_id == 1502);
+
+        rc |= expect_true("seed same-slot replacement", seed_exact(&dual_st, 1701, "A", "SLOT0-REPL", 0, 0) == 0);
+        p25_sm_on_group_grant(&dual_opts, &dual_st, 0x100A, /*svc*/ 0x00, /*tg*/ 1701, /*src*/ 2701);
+        rc |= expect_true("dual same-slot replacement no retune", dual_st.p25_sm_tune_count == dual_tunes_after_slot1);
+        rc |= expect_true("dual same-slot replacement target",
+                          dual_ctx->slots[0].grant_active && dual_ctx->slots[0].target_id == 1701);
+        rc |= expect_true("dual same-slot preserves other slot",
+                          dual_ctx->slots[1].voice_active == 1 && dual_ctx->slots[1].target_id == 1602);
+
+        dual_ctx->slots[1].voice_active = 0;
+        dual_ctx->slots[1].last_active_m = 0.0;
+        dual_st.p25_p2_audio_allowed[1] = 0;
+        p25_sm_on_group_grant(&dual_opts, &dual_st, 0x100B, /*svc*/ 0x00, /*tg*/ 1701, /*src*/ 2702);
+        rc |= expect_true("dual moved target no retune", dual_st.p25_sm_tune_count == dual_tunes_after_slot1);
+        rc |= expect_true("dual moved target active slot", dual_st.p25_p2_active_slot == 1);
+        rc |= expect_true("dual moved target clears old slot", dual_ctx->slots[0].grant_active == 0);
+        rc |= expect_true("dual moved target stores new slot",
+                          dual_ctx->slots[1].grant_active && dual_ctx->slots[1].target_id == 1701);
     }
 
     (void)dsd_unsetenv("DSD_NEO_TG_PREEMPT_MIN_DWELL_MS");

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -268,6 +268,16 @@ seed_fdma_iden(dsd_state* state, int iden, int type, long base, int spac) {
     state->p25_chan_tdma_explicit[iden] = 1;
 }
 
+static void
+seed_tdma_iden(dsd_state* state, int iden, int type, long base, int spac) {
+    state->p25_iden_tdma[iden].base_freq = base;
+    state->p25_iden_tdma[iden].chan_type = type;
+    state->p25_iden_tdma[iden].chan_spac = spac;
+    state->p25_iden_tdma[iden].trust = 2;
+    state->p25_iden_tdma[iden].populated = 1;
+    state->p25_chan_tdma_explicit[iden] = 2;
+}
+
 static int
 run_standard_regroup_voice_user_case(int mfid, int slot, const char* tag) {
     static dsd_opts opts;
@@ -1364,6 +1374,54 @@ main(void) {
         process_MAC_VPDU(&opts, &state, 0, MAC);
         rc |= expect_true("0x40 blocked by backoff", opts.p25_is_tuned == 0);
         rc |= expect_eq_long("0x40 blocked vc", state.p25_vc_freq[0], 0);
+    }
+
+    // Case E2: same-carrier TDMA grants decoded on a VC MAC still reach the state machine.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        const int tdma_iden = 2;
+        const int ch_slot1 = (tdma_iden << 12) | 0x0003;
+        const long vc_freq = 851012500;
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        opts.trunk_tune_enc_calls = 1;
+        opts.p25_is_tuned = 1;
+        opts.trunk_is_tuned = 1;
+        state.p25_cc_freq = cc;
+        state.p25_vc_freq[0] = vc_freq;
+        state.p25_vc_freq[1] = vc_freq;
+        state.trunk_vc_freq[0] = vc_freq;
+        state.trunk_vc_freq[1] = vc_freq;
+        seed_tdma_iden(&state, tdma_iden, /*type*/ 3, base, spac);
+
+        MAC[1] = 0x40; // Group Voice Channel Grant
+        MAC[2] = 0x00; // svc
+        MAC[3] = (unsigned long long int)((ch_slot1 >> 8) & 0xFF);
+        MAC[4] = (unsigned long long int)(ch_slot1 & 0xFF);
+        MAC[5] = 0x23;
+        MAC[6] = 0x45; // group
+        MAC[7] = 0x00;
+        MAC[8] = 0x00;
+        MAC[9] = 0x07; // source
+
+        reset_group_grant_capture();
+        p25_sm_api api = {0};
+        api.on_group_grant = sm_on_group_grant_capture;
+        p25_sm_set_api(&api);
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        p25_sm_reset_api();
+
+        rc |= expect_eq_long("0x40 tuned same-carrier dispatch", g_group_grant_called, 1);
+        rc |= expect_eq_long("0x40 tuned same-carrier channel", g_group_grant_channel, ch_slot1);
+        rc |= expect_eq_long("0x40 tuned same-carrier tg", g_group_grant_tg, 0x2345);
+        rc |= expect_eq_long("0x40 tuned same-carrier src", g_group_grant_src, 7);
+        rc |= expect_true("0x40 tuned same-carrier remains tuned", opts.p25_is_tuned == 1 && opts.trunk_is_tuned == 1);
     }
 
     // Case F: first live VPDU grant seeds an unknown CC from the current RTL tuner.

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -465,9 +465,14 @@ test_facch_public_dispatch_and_crc_gates(void) {
     reset_stubs();
     DSD_MEMSET(&state, 0, sizeof(state));
     state.currentslot = 1;
+    state.lastsrcR = 0x010203;
     state.lasttgR = 77;
     state.p25_p2_audio_allowed[1] = 1;
     state.p25_p2_audio_ring_count[1] = 3;
+    state.p25_call_is_packet[1] = 1;
+    state.p25_policy_tg[1] = 0x5678;
+    state.p25_service_options_valid[1] = 1;
+    state.dmr_soR = 0x52;
     DSD_SNPRINTF(state.call_string[1], sizeof(state.call_string[1]), "%s", "unit call");
     pack_payload_from_mac(payload, 156, mac, 0x3, 0, 0);
 
@@ -475,10 +480,45 @@ test_facch_public_dispatch_and_crc_gates(void) {
     rc |= expect_int("facch idle emitted", g_idle_count[1], 1);
     rc |= expect_int("facch idle vpdu", g_vpdu_count, 1);
     rc |= expect_int("facch idle vpdu type", g_vpdu_type, 0);
+    rc |= expect_int("facch idle src clear", state.lastsrcR, 0);
     rc |= expect_int("facch idle tg clear", state.lasttgR, 0);
     rc |= expect_int("facch idle gate clear", state.p25_p2_audio_allowed[1], 0);
     rc |= expect_int("facch idle ring reset", g_ring_reset_count[1], 1);
+    rc |= expect_int("facch idle packet clear", state.p25_call_is_packet[1], 0);
+    rc |= expect_int("facch idle policy clear", (int)state.p25_policy_tg[1], 0);
+    rc |= expect_int("facch idle service valid clear", state.p25_service_options_valid[1], 0);
+    rc |= expect_int("facch idle service clear", state.dmr_soR, 0);
     rc |= expect_int("facch idle call blank", strncmp(state.call_string[1], P25P2_EMPTY_CALL_STRING, 21), 0);
+
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    state.currentslot = 1;
+    state.lastsrcR = 0x010204;
+    state.lasttgR = 0x2468;
+    state.p25_p2_audio_allowed[1] = 1;
+    state.p25_p2_audio_ring_count[1] = 5;
+    state.p25_call_is_packet[1] = 1;
+    state.p25_policy_tg[1] = 0x6789;
+    state.p25_service_options_valid[1] = 1;
+    state.dmr_soR = 0x93;
+    state.p25_p2_enc_lockout_muted[1] = 1;
+    g_slot_grant_newer[1] = 1;
+    DSD_SNPRINTF(state.call_string[1], sizeof(state.call_string[1]), "%s", "grant");
+    pack_payload_from_mac(payload, 156, mac, 0x3, 0, 0);
+
+    process_FACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("facch idle grant emitted", g_idle_count[1], 1);
+    rc |= expect_int("facch idle grant gate clear", state.p25_p2_audio_allowed[1], 0);
+    rc |= expect_int("facch idle grant ring reset", g_ring_reset_count[1], 1);
+    rc |= expect_int("facch idle grant src preserved", state.lastsrcR, 0x010204);
+    rc |= expect_int("facch idle grant tg preserved", state.lasttgR, 0x2468);
+    rc |= expect_int("facch idle grant packet preserved", state.p25_call_is_packet[1], 1);
+    rc |= expect_int("facch idle grant policy preserved", (int)state.p25_policy_tg[1], 0x6789);
+    rc |= expect_int("facch idle grant service valid preserved", state.p25_service_options_valid[1], 1);
+    rc |= expect_int("facch idle grant service preserved", state.dmr_soR, 0x93);
+    rc |= expect_int("facch idle grant mute clear", state.p25_p2_enc_lockout_muted[1], 0);
+    rc |= expect_int("facch idle grant call preserved", strncmp(state.call_string[1], "grant", 5), 0);
 
     reset_stubs();
     DSD_MEMSET(&state, 0, sizeof(state));

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -740,11 +740,14 @@ test_facch_active_end_hangtime_and_invalid_slot_guards(void) {
     p25p2_xcch_handle_facch_mac_end(&opts, &state, 2);
     p25p2_xcch_handle_facch_mac_idle(&opts, &state, 2, mac);
     p25p2_xcch_handle_facch_mac_active(&opts, &state, 2, mac);
+    DSD_SNPRINTF(state.call_string[0], sizeof(state.call_string[0]), "%s", "left call");
+    p25p2_xcch_clear_idle_metadata_if_stale(&state, 2, dsd_time_now_monotonic_s(), 1);
     rc |= expect_int("facch invalid no end", g_end_count[0] + g_end_count[1], 0);
     rc |= expect_int("facch invalid no idle", g_idle_count[0] + g_idle_count[1], 0);
     rc |= expect_int("facch invalid no active", g_active_count[0] + g_active_count[1], 0);
     rc |= expect_int("facch invalid no vpdu", g_vpdu_count, 0);
     rc |= expect_int("facch invalid no burst left", (int)state.dmrburstL, 0);
+    rc |= expect_int("facch invalid idle metadata guard", strncmp(state.call_string[0], "left call", 9), 0);
 
     reset_stubs();
     DSD_MEMSET(&state, 0, sizeof(state));

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -47,6 +47,7 @@ static int g_flush_close_l_count;
 static int g_flush_close_r_count;
 static int g_ring_reset_count[2];
 static int g_lfsr_count[2];
+static int g_slot_grant_newer[2];
 static uint64_t g_now_ns;
 
 uint64_t
@@ -151,6 +152,15 @@ void
 p25_sm_emit_idle_at(dsd_opts* opts, dsd_state* state, int slot, double observed_m) {
     (void)observed_m;
     p25_sm_emit_idle(opts, state, slot);
+}
+
+int
+p25_sm_slot_grant_newer_than(int slot, double observed_m) {
+    (void)observed_m;
+    if (slot < 0 || slot > 1) {
+        return 0;
+    }
+    return g_slot_grant_newer[slot] ? 1 : 0;
 }
 
 void
@@ -260,6 +270,7 @@ reset_stubs(void) {
     g_flush_close_r_count = -1;
     DSD_MEMSET(g_ring_reset_count, 0, sizeof(g_ring_reset_count));
     DSD_MEMSET(g_lfsr_count, 0, sizeof(g_lfsr_count));
+    DSD_MEMSET(g_slot_grant_newer, 0, sizeof(g_slot_grant_newer));
     g_now_ns = 0;
 }
 
@@ -579,6 +590,8 @@ test_sacch_end_idle_active_hangtime_dispatch(void) {
     state.p25_p2_enc_lockout_muted[1] = 1;
     state.p25_call_is_packet[1] = 1;
     state.p25_policy_tg[1] = 0x5678;
+    state.p25_service_options_valid[1] = 1;
+    state.dmr_soR = 0x52;
     DSD_SNPRINTF(state.call_string[1], sizeof(state.call_string[1]), "%s", "packet");
     pack_payload_from_mac(payload, 180, mac, 0x3, 0, 0);
 
@@ -590,8 +603,33 @@ test_sacch_end_idle_active_hangtime_dispatch(void) {
     rc |= expect_int("sacch idle gate clear", state.p25_p2_audio_allowed[1], 0);
     rc |= expect_int("sacch idle packet clear", state.p25_call_is_packet[1], 0);
     rc |= expect_int("sacch idle policy clear", (int)state.p25_policy_tg[1], 0);
+    rc |= expect_int("sacch idle service valid clear", state.p25_service_options_valid[1], 0);
+    rc |= expect_int("sacch idle service clear", state.dmr_soR, 0);
     rc |= expect_int("sacch idle mute clear", state.p25_p2_enc_lockout_muted[1], 0);
     rc |= expect_int("sacch idle call blank", strncmp(state.call_string[1], P25P2_EMPTY_CALL_STRING, 21), 0);
+
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    state.p25_p2_audio_allowed[1] = 1;
+    state.p25_p2_enc_lockout_muted[1] = 1;
+    state.p25_call_is_packet[1] = 1;
+    state.p25_policy_tg[1] = 0x6789;
+    state.p25_service_options_valid[1] = 1;
+    state.dmr_soR = 0x93;
+    g_slot_grant_newer[1] = 1;
+    DSD_SNPRINTF(state.call_string[1], sizeof(state.call_string[1]), "%s", "grant");
+    pack_payload_from_mac(payload, 180, mac, 0x3, 0, 0);
+
+    process_SACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("sacch idle grant emitted", g_idle_count[1], 1);
+    rc |= expect_int("sacch idle grant gate clear", state.p25_p2_audio_allowed[1], 0);
+    rc |= expect_int("sacch idle grant packet preserved", state.p25_call_is_packet[1], 1);
+    rc |= expect_int("sacch idle grant policy preserved", (int)state.p25_policy_tg[1], 0x6789);
+    rc |= expect_int("sacch idle grant service valid preserved", state.p25_service_options_valid[1], 1);
+    rc |= expect_int("sacch idle grant service preserved", state.dmr_soR, 0x93);
+    rc |= expect_int("sacch idle grant mute clear", state.p25_p2_enc_lockout_muted[1], 0);
+    rc |= expect_int("sacch idle grant call preserved", strncmp(state.call_string[1], "grant", 5), 0);
 
     reset_stubs();
     DSD_MEMSET(&state, 0, sizeof(state));

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -148,6 +148,12 @@ p25_sm_emit_idle(dsd_opts* opts, dsd_state* state, int slot) {
 }
 
 void
+p25_sm_emit_idle_at(dsd_opts* opts, dsd_state* state, int slot, double observed_m) {
+    (void)observed_m;
+    p25_sm_emit_idle(opts, state, slot);
+}
+
+void
 p25_sm_emit_enc(dsd_opts* opts, dsd_state* state, int slot, int algid, int keyid, int tg) {
     (void)opts;
     (void)state;

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -27,6 +27,9 @@ static int g_crc12_result;
 static int g_crc16_result;
 static int g_vpdu_count;
 static int g_vpdu_type;
+static int g_vpdu_entry_lasttg[2];
+static int g_vpdu_entry_lastsrc[2];
+static int g_vpdu_grant_newer_slot;
 static unsigned long long int g_vpdu_mac[24];
 static int g_ptt_count[2];
 static int g_active_count[2];
@@ -74,11 +77,19 @@ crc16_lb_bridge(const int* payload, int len) {
 void
 process_MAC_VPDU(dsd_opts* opts, dsd_state* state, int type, unsigned long long int mac[24]) {
     (void)opts;
-    (void)state;
     g_vpdu_count++;
     g_vpdu_type = type;
+    if (state) {
+        g_vpdu_entry_lasttg[0] = state->lasttg;
+        g_vpdu_entry_lasttg[1] = state->lasttgR;
+        g_vpdu_entry_lastsrc[0] = state->lastsrc;
+        g_vpdu_entry_lastsrc[1] = state->lastsrcR;
+    }
     for (int i = 0; i < 24; i++) {
         g_vpdu_mac[i] = mac[i];
+    }
+    if (g_vpdu_grant_newer_slot >= 0 && g_vpdu_grant_newer_slot <= 1) {
+        g_slot_grant_newer[g_vpdu_grant_newer_slot] = 1;
     }
 }
 
@@ -250,6 +261,11 @@ reset_stubs(void) {
     g_crc16_result = 0;
     g_vpdu_count = 0;
     g_vpdu_type = -1;
+    g_vpdu_entry_lasttg[0] = -1;
+    g_vpdu_entry_lasttg[1] = -1;
+    g_vpdu_entry_lastsrc[0] = -1;
+    g_vpdu_entry_lastsrc[1] = -1;
+    g_vpdu_grant_newer_slot = -1;
     DSD_MEMSET(g_vpdu_mac, 0, sizeof(g_vpdu_mac));
     DSD_MEMSET(g_ptt_count, 0, sizeof(g_ptt_count));
     DSD_MEMSET(g_active_count, 0, sizeof(g_active_count));
@@ -481,6 +497,8 @@ test_facch_public_dispatch_and_crc_gates(void) {
     rc |= expect_int("facch idle emitted", g_idle_count[1], 1);
     rc |= expect_int("facch idle vpdu", g_vpdu_count, 1);
     rc |= expect_int("facch idle vpdu type", g_vpdu_type, 0);
+    rc |= expect_int("facch idle vpdu entry src clear", g_vpdu_entry_lastsrc[1], 0);
+    rc |= expect_int("facch idle vpdu entry tg clear", g_vpdu_entry_lasttg[1], 0);
     rc |= expect_int("facch idle src clear", state.lastsrcR, 0);
     rc |= expect_int("facch idle tg clear", state.lasttgR, 0);
     rc |= expect_int("facch idle gate clear", state.p25_p2_audio_allowed[1], 0);
@@ -504,12 +522,14 @@ test_facch_public_dispatch_and_crc_gates(void) {
     state.p25_service_options_valid[1] = 1;
     state.dmr_soR = 0x93;
     state.p25_p2_enc_lockout_muted[1] = 1;
-    g_slot_grant_newer[1] = 1;
+    g_vpdu_grant_newer_slot = 1;
     DSD_SNPRINTF(state.call_string[1], sizeof(state.call_string[1]), "%s", "grant");
     pack_payload_from_mac(payload, 156, mac, 0x3, 0, 0);
 
     process_FACCH_MAC_PDU(&opts, &state, payload);
     rc |= expect_int("facch idle grant emitted", g_idle_count[1], 1);
+    rc |= expect_int("facch idle grant vpdu entry src clear", g_vpdu_entry_lastsrc[1], 0);
+    rc |= expect_int("facch idle grant vpdu entry tg clear", g_vpdu_entry_lasttg[1], 0);
     rc |= expect_int("facch idle grant gate clear", state.p25_p2_audio_allowed[1], 0);
     rc |= expect_int("facch idle grant ring reset", g_ring_reset_count[1], 1);
     rc |= expect_int("facch idle grant src preserved", state.lastsrcR, 0x010204);

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -7,6 +7,7 @@
  */
 
 #include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/safe_api.h>

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -905,6 +905,48 @@ main(void) {
         dsd_state_ext_free_all(&repeat_st);
     }
 
+    // 13c) A same-slot group TG and private RID can have the same numeric
+    // target ID; they must not collapse into one duplicate grant context.
+    {
+        static dsd_opts collision_opts;
+        static dsd_state collision_st;
+        DSD_MEMSET(&collision_opts, 0, sizeof collision_opts);
+        DSD_MEMSET(&collision_st, 0, sizeof collision_st);
+        collision_opts.p25_trunk = 1;
+        collision_opts.trunk_tune_group_calls = 1;
+        collision_opts.trunk_tune_private_calls = 1;
+        collision_opts.trunk_hangtime = 0.2f;
+        collision_opts.p25_grant_voice_to_s = 0.8;
+        collision_opts.p25_retune_backoff_s = 2.0;
+        collision_st.p25_cc_freq = 851000000;
+        collision_st.p25_chan_iden = id;
+        collision_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+        collision_st.p25_chan_tdma_explicit[id] = 2;
+
+        p25_sm_ctx_t collision_ctx;
+        p25_sm_init_ctx(&collision_ctx, &collision_opts, &collision_st);
+        g_last_tuned_vc = 0;
+        g_tune_to_freq_calls = 0;
+        g_return_to_cc_calls = 0;
+        p25_sm_event_t private_grant = p25_sm_ev_indiv_grant(ch_slot0, 0, 3661, 4661, 0);
+        p25_sm_event_t group_grant = p25_sm_ev_group_grant(ch_slot0, 0, 3661, 5661, 0);
+
+        p25_sm_event(&collision_ctx, &collision_opts, &collision_st, &private_grant);
+        rc |= expect_true("namespace private tuned", g_tune_to_freq_calls == 1 && collision_opts.p25_is_tuned == 1
+                                                         && collision_ctx.slots[0].grant_active
+                                                         && !collision_ctx.slots[0].is_group
+                                                         && collision_ctx.slots[0].dst == 3661);
+
+        p25_sm_event(&collision_ctx, &collision_opts, &collision_st, &group_grant);
+        rc |= expect_true("namespace group replaces private",
+                          g_tune_to_freq_calls == 1 && collision_ctx.state == P25_SM_TUNED
+                              && collision_ctx.slots[0].grant_active && collision_ctx.slots[0].is_group
+                              && collision_ctx.slots[0].target_id == 3661 && collision_ctx.slots[0].ota_tg == 3661
+                              && collision_ctx.slots[0].dst == 0 && collision_ctx.vc_src == 5661);
+
+        dsd_state_ext_free_all(&collision_st);
+    }
+
     // 14) A forced release after one TDMA slot produced voice still records a
     // pending grant on the other slot that never produced audio.
     {

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -513,7 +513,79 @@ main(void) {
         dsd_state_ext_free_all(&mixed_data_st);
     }
 
-    // 10) When one slot ends while the other slot has a pending voice grant,
+    // 10) When one slot ends while the other slot has a pending data grant,
+    // the data grant stays on the refreshed grant-timeout path rather than
+    // inheriting the ended slot's hangtime.
+    {
+        static dsd_opts pending_data_opts;
+        static dsd_state pending_data_st;
+        DSD_MEMSET(&pending_data_opts, 0, sizeof pending_data_opts);
+        DSD_MEMSET(&pending_data_st, 0, sizeof pending_data_st);
+        pending_data_opts.p25_trunk = 1;
+        pending_data_opts.trunk_tune_group_calls = 1;
+        pending_data_opts.trunk_tune_data_calls = 1;
+        pending_data_opts.trunk_hangtime = 0.2f;
+        pending_data_opts.p25_grant_voice_to_s = 0.8;
+        pending_data_opts.p25_retune_backoff_s = 2.0;
+        pending_data_st.p25_cc_freq = 851000000;
+        pending_data_st.p25_chan_iden = id;
+        pending_data_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+        pending_data_st.p25_chan_tdma_explicit[id] = 2;
+
+        p25_sm_ctx_t pending_data_ctx;
+        p25_sm_init_ctx(&pending_data_ctx, &pending_data_opts, &pending_data_st);
+        g_last_tuned_vc = 0;
+        g_tune_to_freq_calls = 0;
+        g_return_to_cc_calls = 0;
+        p25_sm_event_t pending_data_voice_slot0 = p25_sm_ev_group_grant(ch_slot0, 0, 3501, 4501, 0);
+        p25_sm_event_t pending_data_slot1 = p25_sm_ev_group_data_grant(ch_slot1, 0, 3502, 4502, P25_SM_SVC_UNKNOWN);
+        p25_sm_event_t pending_data_ptt_slot0 = p25_sm_ev_ptt(0);
+        p25_sm_event_t pending_data_end_slot0 = p25_sm_ev_end(0);
+
+        p25_sm_event(&pending_data_ctx, &pending_data_opts, &pending_data_st, &pending_data_voice_slot0);
+        rc |= expect_true("pending data initial tune", g_tune_to_freq_calls == 1 && pending_data_opts.p25_is_tuned == 1
+                                                           && pending_data_ctx.slots[0].grant_active);
+        p25_sm_event(&pending_data_ctx, &pending_data_opts, &pending_data_st, &pending_data_ptt_slot0);
+        pending_data_st.p25_p2_audio_allowed[0] = 1;
+        rc |= expect_true("pending data voice active", pending_data_ctx.slots[0].voice_active == 1);
+
+        p25_sm_event(&pending_data_ctx, &pending_data_opts, &pending_data_st, &pending_data_slot1);
+        rc |= expect_true("pending data same-carrier accepted",
+                          g_tune_to_freq_calls == 1 && pending_data_ctx.vc_data_call == 1
+                              && pending_data_ctx.slots[1].grant_active && pending_data_ctx.slots[1].data_call
+                              && pending_data_ctx.slots[0].voice_active);
+
+        p25_sm_tick_ctx(&pending_data_ctx, &pending_data_opts, &pending_data_st);
+        rc |= expect_true("pending data voice tick retained", pending_data_opts.p25_is_tuned == 1
+                                                                  && g_return_to_cc_calls == 0
+                                                                  && pending_data_ctx.t_voice_m > 0.0);
+        p25_sm_event(&pending_data_ctx, &pending_data_opts, &pending_data_st, &pending_data_end_slot0);
+        rc |= expect_true("pending data blocks explicit voice release",
+                          pending_data_opts.p25_is_tuned == 1 && g_return_to_cc_calls == 0
+                              && pending_data_ctx.state == P25_SM_TUNED && pending_data_ctx.slots[0].grant_active == 0
+                              && pending_data_ctx.slots[1].grant_active && pending_data_ctx.slots[1].data_call);
+
+        double now_m = dsd_time_now_monotonic_s();
+        pending_data_ctx.t_voice_m = now_m - 1.0;
+        pending_data_ctx.t_tune_m = now_m - 0.2;
+        p25_sm_tick_ctx(&pending_data_ctx, &pending_data_opts, &pending_data_st);
+        rc |= expect_true("pending data not released on ended-slot hangtime",
+                          pending_data_opts.p25_is_tuned == 1 && g_return_to_cc_calls == 0
+                              && pending_data_ctx.state == P25_SM_TUNED && pending_data_ctx.t_voice_m == 0.0
+                              && pending_data_ctx.slots[1].grant_active);
+
+        now_m = dsd_time_now_monotonic_s();
+        pending_data_ctx.t_tune_m = now_m - 1.0;
+        p25_sm_tick_ctx(&pending_data_ctx, &pending_data_opts, &pending_data_st);
+        rc |= expect_true("pending data grant timeout returned", pending_data_opts.p25_is_tuned == 0
+                                                                     && g_return_to_cc_calls == 1
+                                                                     && pending_data_ctx.state == P25_SM_ON_CC);
+        rc |= expect_true("pending data timeout does not arm backoff", retune_backoff_empty(&pending_data_st));
+
+        dsd_state_ext_free_all(&pending_data_st);
+    }
+
+    // 11) When one slot ends while the other slot has a pending voice grant,
     // the pending grant stays on the grant-timeout path rather than inheriting
     // the ended slot's hangtime.
     {
@@ -584,7 +656,7 @@ main(void) {
         dsd_state_ext_free_all(&pending_st);
     }
 
-    // 11) A transient return-to-CC failure during grant timeout must not record
+    // 12) A transient return-to-CC failure during grant timeout must not record
     // a failed VC until the retry is accepted.
     static const dsd_trunk_tune_result transient_returns[] = {
         DSD_TRUNK_TUNE_RESULT_DEFERRED,

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -479,15 +479,14 @@ main(void) {
         rc |= expect_true("mixed data voice tune", g_tune_to_freq_calls == 1 && mixed_data_opts.p25_is_tuned == 1
                                                        && mixed_data_ctx.slots[0].grant_active
                                                        && mixed_data_ctx.vc_data_call == 0);
-        p25_sm_event(&mixed_data_ctx, &mixed_data_opts, &mixed_data_st, &mixed_data_slot1);
-        rc |= expect_true("mixed data same-carrier no retune", g_tune_to_freq_calls == 1
-                                                                   && mixed_data_ctx.vc_data_call == 1
-                                                                   && mixed_data_ctx.slots[1].data_call);
-
         double stale_grant_m = dsd_time_now_monotonic_s() - 1.0;
         mixed_data_ctx.t_tune_m = stale_grant_m;
         mixed_data_ctx.t_voice_m = 0.0;
         mixed_data_ctx.slots[0].last_grant_m = stale_grant_m;
+        p25_sm_event(&mixed_data_ctx, &mixed_data_opts, &mixed_data_st, &mixed_data_slot1);
+        rc |= expect_true("mixed data same-carrier no retune",
+                          g_tune_to_freq_calls == 1 && mixed_data_ctx.vc_data_call == 1
+                              && mixed_data_ctx.slots[1].data_call && mixed_data_ctx.t_tune_m == stale_grant_m);
         p25_sm_tick_ctx(&mixed_data_ctx, &mixed_data_opts, &mixed_data_st);
         rc |= expect_true("mixed data returned", mixed_data_opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1
                                                      && mixed_data_ctx.state == P25_SM_ON_CC);
@@ -551,6 +550,8 @@ main(void) {
                                                                 && pending_ctx.state == P25_SM_ON_CC);
         rc |= expect_true("pending grant timeout backoff",
                           retune_backoff_history_has_slot(&pending_st, g_last_tuned_vc, 1));
+        rc |= expect_true("active slot not marked failed",
+                          !retune_backoff_history_has_slot(&pending_st, g_last_tuned_vc, 0));
 
         dsd_state_ext_free_all(&pending_st);
     }

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -211,6 +211,8 @@ main(void) {
     // Two channels mapping to the same RF: low bit selects slot
     int ch_slot0 = (id << 12) | 0x0002; // slot 0
     int ch_slot1 = (id << 12) | 0x0003; // slot 1 (same RF)
+    int alt_id = 3;
+    int ch_slot0_alt_id = (alt_id << 12) | 0x0002; // slot 0, same RF via a different IDEN
 
     p25_sm_ctx_t ctx;
     p25_sm_init_ctx(&ctx, &opts, &st);
@@ -367,6 +369,17 @@ main(void) {
     p25_sm_event(&data_ctx, &data_opts, &data_st, &data_ev_slot1);
     rc |= expect_true("data initial tune", data_st.p25_sm_tune_count == 1 && data_opts.p25_is_tuned == 1
                                                && g_tune_to_freq_calls == 1 && data_ctx.vc_data_call == 1);
+
+    double stale_data_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    data_ctx.t_tune_m = stale_data_tune_m;
+    data_ctx.t_voice_m = 0.0;
+    p25_sm_event(&data_ctx, &data_opts, &data_st, &data_ev_slot1);
+    rc |= expect_true("data duplicate refreshed tune timer", g_tune_to_freq_calls == 1 && g_return_to_cc_calls == 0
+                                                                 && data_opts.p25_is_tuned == 1
+                                                                 && data_ctx.t_tune_m > stale_data_tune_m);
+    p25_sm_tick_ctx(&data_ctx, &data_opts, &data_st);
+    rc |= expect_true("data duplicate avoids stale timeout",
+                      data_opts.p25_is_tuned == 1 && g_return_to_cc_calls == 0 && data_ctx.state == P25_SM_TUNED);
 
     data_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
     data_ctx.t_voice_m = 0.0;
@@ -851,6 +864,8 @@ main(void) {
         repeat_st.p25_chan_iden = id;
         repeat_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
         repeat_st.p25_chan_tdma_explicit[id] = 2;
+        repeat_st.p25_iden_tdma[alt_id] = st.p25_iden_tdma[id];
+        repeat_st.p25_chan_tdma_explicit[alt_id] = 2;
 
         p25_sm_ctx_t repeat_ctx;
         p25_sm_init_ctx(&repeat_ctx, &repeat_opts, &repeat_st);
@@ -859,6 +874,7 @@ main(void) {
         g_return_to_cc_calls = 0;
 
         p25_sm_event_t repeat_grant = p25_sm_ev_group_grant(ch_slot0, 0, 3461, 4461, 0);
+        p25_sm_event_t repeat_alt_id_grant = p25_sm_ev_group_grant(ch_slot0_alt_id, 0, 3461, 4461, 0);
         p25_sm_event_t repeat_ptt = p25_sm_ev_ptt(0);
         p25_sm_event_t repeat_idle = p25_sm_ev_idle(0);
 
@@ -877,13 +893,14 @@ main(void) {
                               && repeat_ctx.slots[0].last_active_m > 0.0 && repeat_ctx.t_voice_m > 0.0);
         double old_last_grant_m = repeat_ctx.slots[0].last_grant_m;
 
-        p25_sm_event(&repeat_ctx, &repeat_opts, &repeat_st, &repeat_grant);
-        rc |= expect_true("repeat hangtime grant accepted",
+        p25_sm_event(&repeat_ctx, &repeat_opts, &repeat_st, &repeat_alt_id_grant);
+        rc |= expect_true("repeat hangtime alt id grant accepted",
                           g_tune_to_freq_calls == 1 && g_return_to_cc_calls == 0 && repeat_opts.p25_is_tuned == 1
                               && repeat_ctx.state == P25_SM_TUNED && repeat_ctx.slots[0].grant_active);
-        rc |= expect_true("repeat hangtime grant refreshed", repeat_ctx.slots[0].last_grant_m > old_last_grant_m
-                                                                 && repeat_ctx.slots[0].last_active_m == 0.0
-                                                                 && repeat_ctx.t_voice_m == 0.0);
+        rc |= expect_true("repeat hangtime alt id grant refreshed",
+                          repeat_ctx.slots[0].last_grant_m > old_last_grant_m
+                              && repeat_ctx.slots[0].channel == ch_slot0_alt_id
+                              && repeat_ctx.slots[0].last_active_m == 0.0 && repeat_ctx.t_voice_m == 0.0);
 
         dsd_state_ext_free_all(&repeat_st);
     }

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -449,8 +449,9 @@ main(void) {
     rc |= expect_true("data grant bypasses voice backoff",
                       g_tune_to_freq_calls == 2 && mixed_opts.p25_is_tuned == 1 && mixed_ctx.vc_data_call == 1);
 
-    // 9) A same-carrier data grant must not hide a pending failed voice grant
-    // on the other TDMA slot when the carrier returns to the CC.
+    // 9) A same-carrier data grant gets a fresh timeout window without hiding a
+    // pending failed voice grant on the other TDMA slot when the carrier returns
+    // to the CC.
     {
         static dsd_opts mixed_data_opts;
         static dsd_state mixed_data_st;
@@ -484,9 +485,14 @@ main(void) {
         mixed_data_ctx.t_voice_m = 0.0;
         mixed_data_ctx.slots[0].last_grant_m = stale_grant_m;
         p25_sm_event(&mixed_data_ctx, &mixed_data_opts, &mixed_data_st, &mixed_data_slot1);
-        rc |= expect_true("mixed data same-carrier no retune",
+        rc |= expect_true("mixed data same-carrier refreshes timeout",
                           g_tune_to_freq_calls == 1 && mixed_data_ctx.vc_data_call == 1
-                              && mixed_data_ctx.slots[1].data_call && mixed_data_ctx.t_tune_m == stale_grant_m);
+                              && mixed_data_ctx.slots[1].data_call && mixed_data_ctx.t_tune_m > stale_grant_m);
+        p25_sm_tick_ctx(&mixed_data_ctx, &mixed_data_opts, &mixed_data_st);
+        rc |= expect_true("mixed data timeout window retained", mixed_data_opts.p25_is_tuned == 1
+                                                                    && g_return_to_cc_calls == 0
+                                                                    && mixed_data_ctx.state == P25_SM_TUNED);
+        mixed_data_ctx.t_tune_m = stale_grant_m;
         p25_sm_tick_ctx(&mixed_data_ctx, &mixed_data_opts, &mixed_data_st);
         rc |= expect_true("mixed data returned", mixed_data_opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1
                                                      && mixed_data_ctx.state == P25_SM_ON_CC);

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -481,13 +481,24 @@ main(void) {
                                                        && mixed_data_ctx.slots[0].grant_active
                                                        && mixed_data_ctx.vc_data_call == 0);
         double stale_grant_m = dsd_time_now_monotonic_s() - 1.0;
+        time_t stale_grant_wall = time(NULL) - 10;
         mixed_data_ctx.t_tune_m = stale_grant_m;
-        mixed_data_ctx.t_voice_m = 0.0;
+        mixed_data_ctx.t_voice_m = stale_grant_m;
         mixed_data_ctx.slots[0].last_grant_m = stale_grant_m;
+        mixed_data_st.last_vc_sync_time = stale_grant_wall;
+        mixed_data_st.p25_last_vc_tune_time = stale_grant_wall;
+        mixed_data_st.last_vc_sync_time_m = stale_grant_m;
+        mixed_data_st.p25_last_vc_tune_time_m = stale_grant_m;
         p25_sm_event(&mixed_data_ctx, &mixed_data_opts, &mixed_data_st, &mixed_data_slot1);
         rc |= expect_true("mixed data same-carrier refreshes timeout",
                           g_tune_to_freq_calls == 1 && mixed_data_ctx.vc_data_call == 1
                               && mixed_data_ctx.slots[1].data_call && mixed_data_ctx.t_tune_m > stale_grant_m);
+        rc |= expect_true("mixed data clears stale voice hangtime", mixed_data_ctx.t_voice_m == 0.0);
+        rc |= expect_true("mixed data refreshes vc watchdogs",
+                          mixed_data_st.last_vc_sync_time > stale_grant_wall
+                              && mixed_data_st.p25_last_vc_tune_time > stale_grant_wall
+                              && mixed_data_st.last_vc_sync_time_m > stale_grant_m
+                              && mixed_data_st.p25_last_vc_tune_time_m > stale_grant_m);
         p25_sm_tick_ctx(&mixed_data_ctx, &mixed_data_opts, &mixed_data_st);
         rc |= expect_true("mixed data timeout window retained", mixed_data_opts.p25_is_tuned == 1
                                                                     && g_return_to_cc_calls == 0
@@ -534,9 +545,20 @@ main(void) {
         rc |= expect_true("pending initial tune", g_tune_to_freq_calls == 1 && pending_opts.p25_is_tuned == 1);
         p25_sm_event(&pending_ctx, &pending_opts, &pending_st, &ptt_slot0);
         pending_st.p25_p2_audio_allowed[0] = 1;
+        double stale_watchdog_m = dsd_time_now_monotonic_s() - 3.0;
+        time_t stale_watchdog_wall = time(NULL) - 10;
+        pending_st.last_vc_sync_time = stale_watchdog_wall;
+        pending_st.p25_last_vc_tune_time = stale_watchdog_wall;
+        pending_st.last_vc_sync_time_m = stale_watchdog_m;
+        pending_st.p25_last_vc_tune_time_m = stale_watchdog_m;
         p25_sm_event(&pending_ctx, &pending_opts, &pending_st, &pending_voice_slot1);
         rc |= expect_true("pending same-carrier grant", g_tune_to_freq_calls == 1 && pending_ctx.slots[1].grant_active
                                                             && pending_ctx.slots[1].voice_active == 0);
+        rc |= expect_true("pending same-carrier refreshes vc watchdogs",
+                          pending_st.last_vc_sync_time > stale_watchdog_wall
+                              && pending_st.p25_last_vc_tune_time > stale_watchdog_wall
+                              && pending_st.last_vc_sync_time_m > stale_watchdog_m
+                              && pending_st.p25_last_vc_tune_time_m > stale_watchdog_m);
         p25_sm_event(&pending_ctx, &pending_opts, &pending_st, &end_slot0);
 
         double now_m = dsd_time_now_monotonic_s();

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -18,6 +18,8 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdbool.h>
@@ -137,6 +139,31 @@ retune_backoff_empty(const dsd_state* state) {
     return 1;
 }
 
+static int
+retune_backoff_history_has_slot(const dsd_state* state, long freq, int slot) {
+    if (!state || freq <= 0) {
+        return 0;
+    }
+    for (int i = 0; i < DSD_P25_RETUNE_BLOCK_HISTORY_DEPTH; i++) {
+        if (state->p25_retune_block_history_freq[i] == freq && state->p25_retune_block_history_slot[i] == slot
+            && state->p25_retune_block_history_until[i] > time(NULL)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+seed_exact(dsd_state* st, uint32_t id, const char* mode, const char* name, int priority, int preempt) {
+    dsd_tg_policy_entry row;
+    if (dsd_tg_policy_make_exact_entry(id, mode, name, DSD_TG_POLICY_SOURCE_IMPORTED, &row) != 0) {
+        return 1;
+    }
+    row.priority = priority;
+    row.preempt = preempt ? 1u : 0u;
+    return dsd_tg_policy_upsert_exact(st, &row, DSD_TG_POLICY_UPSERT_REPLACE_FIRST);
+}
+
 int
 main(void) {
     int rc = 0;
@@ -209,6 +236,60 @@ main(void) {
     rc |= expect_true("first failed slot still blocked", g_tune_to_freq_calls == 2 && opts.p25_is_tuned == 0);
     p25_sm_event(&ctx, &opts, &st, &ev_slot0);
     rc |= expect_true("second failed slot blocked", g_tune_to_freq_calls == 2 && opts.p25_is_tuned == 0);
+
+    // 5b) Channel 0 is a valid IDEN 0 TDMA slot. When both slots on the same
+    // RF fail together, channel 0/slot 0 must remain in the per-slot backoff.
+    {
+        static dsd_opts zero_opts;
+        static dsd_state zero_st;
+        DSD_MEMSET(&zero_opts, 0, sizeof zero_opts);
+        DSD_MEMSET(&zero_st, 0, sizeof zero_st);
+        zero_opts.p25_trunk = 1;
+        zero_opts.trunk_tune_group_calls = 1;
+        zero_opts.trunk_hangtime = 0.2f;
+        zero_opts.p25_grant_voice_to_s = 0.5;
+        zero_opts.p25_retune_backoff_s = 2.0;
+        zero_st.p25_cc_freq = 851000000;
+        zero_st.p25_chan_iden = 0;
+        zero_st.p25_iden_tdma[0].base_freq = 851000000 / 5;
+        zero_st.p25_iden_tdma[0].chan_type = 3;
+        zero_st.p25_iden_tdma[0].chan_spac = 100;
+        zero_st.p25_iden_tdma[0].trust = 2;
+        zero_st.p25_iden_tdma[0].populated = 1;
+        zero_st.p25_chan_tdma_explicit[0] = 2;
+
+        p25_sm_ctx_t zero_ctx;
+        p25_sm_init_ctx(&zero_ctx, &zero_opts, &zero_st);
+        g_last_tuned_vc = 0;
+        g_tune_to_freq_calls = 0;
+        g_return_to_cc_calls = 0;
+
+        p25_sm_event_t zero_ev_slot1 = p25_sm_ev_group_grant(0x0001, 0, 3001, 4001, 0);
+        p25_sm_event_t zero_ev_slot0 = p25_sm_ev_group_grant(0x0000, 0, 3000, 4000, 0);
+        p25_sm_event(&zero_ctx, &zero_opts, &zero_st, &zero_ev_slot1);
+        rc |= expect_true("zero channel initial tune", g_tune_to_freq_calls == 1 && zero_opts.p25_is_tuned == 1);
+        p25_sm_event(&zero_ctx, &zero_opts, &zero_st, &zero_ev_slot0);
+        rc |= expect_true("zero channel same-carrier no retune", g_tune_to_freq_calls == 1);
+        rc |= expect_true("zero channel both slots active",
+                          zero_ctx.slots[0].grant_active && zero_ctx.slots[1].grant_active);
+
+        zero_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+        zero_ctx.t_voice_m = 0.0;
+        p25_sm_tick_ctx(&zero_ctx, &zero_opts, &zero_st);
+        rc |= expect_true("zero channel returned",
+                          zero_opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1 && zero_ctx.state == P25_SM_ON_CC);
+        rc |= expect_true("zero channel slot0 backoff remembered",
+                          retune_backoff_history_has_slot(&zero_st, g_last_tuned_vc, 0));
+        rc |= expect_true("zero channel slot1 backoff remembered",
+                          retune_backoff_history_has_slot(&zero_st, g_last_tuned_vc, 1));
+
+        p25_sm_event(&zero_ctx, &zero_opts, &zero_st, &zero_ev_slot0);
+        rc |= expect_true("zero channel slot0 blocked", g_tune_to_freq_calls == 1 && zero_opts.p25_is_tuned == 0);
+        p25_sm_event(&zero_ctx, &zero_opts, &zero_st, &zero_ev_slot1);
+        rc |= expect_true("zero channel slot1 blocked", g_tune_to_freq_calls == 1 && zero_opts.p25_is_tuned == 0);
+
+        dsd_state_ext_free_all(&zero_st);
+    }
 
     // 6) A decoder/frame-sync forced release before grant timeout still records
     // the failed VC because no voice was observed.
@@ -405,6 +486,57 @@ main(void) {
         dsd_state_ext_free_all(&transient_st);
     }
     g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+
+    // 10) Same-carrier preemption releases to the CC first. The replacement
+    // grant must retune the VC instead of reusing a carrier that is no longer tuned.
+    {
+        static dsd_opts preempt_opts;
+        static dsd_state preempt_st;
+        DSD_MEMSET(&preempt_opts, 0, sizeof preempt_opts);
+        DSD_MEMSET(&preempt_st, 0, sizeof preempt_st);
+        preempt_opts.p25_trunk = 1;
+        preempt_opts.trunk_tune_group_calls = 1;
+        preempt_opts.trunk_hangtime = 0.2f;
+        preempt_opts.p25_retune_backoff_s = 2.0;
+        preempt_st.p25_cc_freq = 851000000;
+        preempt_st.p25_chan_iden = id;
+        preempt_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+        preempt_st.p25_chan_tdma_explicit[id] = 2;
+
+        rc |= expect_true("seed preempt active", seed_exact(&preempt_st, 4001, "A", "PREEMPT-ACTIVE", 10, 0) == 0);
+        rc |=
+            expect_true("seed preempt candidate", seed_exact(&preempt_st, 4002, "A", "PREEMPT-CANDIDATE", 90, 1) == 0);
+        (void)dsd_setenv("DSD_NEO_TG_PREEMPT_MIN_DWELL_MS", "0", 1);
+        (void)dsd_setenv("DSD_NEO_TG_PREEMPT_COOLDOWN_MS", "0", 1);
+
+        p25_sm_ctx_t preempt_ctx;
+        p25_sm_init_ctx(&preempt_ctx, &preempt_opts, &preempt_st);
+        g_last_tuned_vc = 0;
+        g_tune_to_freq_calls = 0;
+        g_return_to_cc_calls = 0;
+        p25_sm_event_t preempt_active = p25_sm_ev_group_grant(ch_slot0, 0, 4001, 5001, 0);
+        p25_sm_event_t preempt_candidate = p25_sm_ev_group_grant(ch_slot0, 0, 4002, 5002, 0);
+
+        p25_sm_event(&preempt_ctx, &preempt_opts, &preempt_st, &preempt_active);
+        rc |= expect_true("preempt active tuned", g_tune_to_freq_calls == 1 && preempt_opts.p25_is_tuned == 1
+                                                      && preempt_ctx.state == P25_SM_TUNED);
+        preempt_ctx.slots[0].voice_active = 1;
+        preempt_ctx.slots[0].last_active_m = dsd_time_now_monotonic_s();
+        preempt_ctx.t_voice_m = preempt_ctx.slots[0].last_active_m;
+        preempt_st.p25_p2_audio_allowed[0] = 1;
+
+        p25_sm_event(&preempt_ctx, &preempt_opts, &preempt_st, &preempt_candidate);
+        rc |= expect_true("preempt returned to cc first", g_return_to_cc_calls == 1);
+        rc |= expect_true("preempt retuned vc", g_tune_to_freq_calls == 2 && preempt_opts.p25_is_tuned == 1
+                                                    && preempt_st.p25_sm_tune_count == 2);
+        rc |= expect_true("preempt replacement active", preempt_ctx.state == P25_SM_TUNED && preempt_ctx.vc_tg == 4002
+                                                            && preempt_ctx.slots[0].grant_active
+                                                            && preempt_ctx.slots[0].target_id == 4002);
+
+        (void)dsd_unsetenv("DSD_NEO_TG_PREEMPT_MIN_DWELL_MS");
+        (void)dsd_unsetenv("DSD_NEO_TG_PREEMPT_COOLDOWN_MS");
+        dsd_state_ext_free_all(&preempt_st);
+    }
 
     dsd_state_ext_free_all(&mixed_st);
     dsd_state_ext_free_all(&data_forced_st);

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -772,7 +772,70 @@ main(void) {
         dsd_state_ext_free_all(&pending_st);
     }
 
-    // 13) A forced release after one TDMA slot produced voice still records a
+    // 13) A grant accepted from a MAC_IDLE payload must survive the following
+    // idle event so the other slot's explicit end cannot release the VC early.
+    {
+        static dsd_opts idle_payload_opts;
+        static dsd_state idle_payload_st;
+        DSD_MEMSET(&idle_payload_opts, 0, sizeof idle_payload_opts);
+        DSD_MEMSET(&idle_payload_st, 0, sizeof idle_payload_st);
+        idle_payload_opts.p25_trunk = 1;
+        idle_payload_opts.trunk_tune_group_calls = 1;
+        idle_payload_opts.trunk_hangtime = 0.2f;
+        idle_payload_opts.p25_grant_voice_to_s = 0.8;
+        idle_payload_opts.p25_retune_backoff_s = 2.0;
+        idle_payload_st.p25_cc_freq = 851000000;
+        idle_payload_st.p25_chan_iden = id;
+        idle_payload_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+        idle_payload_st.p25_chan_tdma_explicit[id] = 2;
+
+        p25_sm_ctx_t idle_payload_ctx;
+        p25_sm_init_ctx(&idle_payload_ctx, &idle_payload_opts, &idle_payload_st);
+        g_last_tuned_vc = 0;
+        g_tune_to_freq_calls = 0;
+        g_return_to_cc_calls = 0;
+        p25_sm_event_t active_slot0 = p25_sm_ev_group_grant(ch_slot0, 0, 3451, 4451, 0);
+        p25_sm_event_t ptt_slot0 = p25_sm_ev_ptt(0);
+        p25_sm_event_t payload_grant_slot1 = p25_sm_ev_group_grant(ch_slot1, 0, 3452, 4452, 0);
+        p25_sm_event_t end_slot0 = p25_sm_ev_end(0);
+
+        p25_sm_event(&idle_payload_ctx, &idle_payload_opts, &idle_payload_st, &active_slot0);
+        rc |=
+            expect_true("idle-payload initial tune", g_tune_to_freq_calls == 1 && idle_payload_opts.p25_is_tuned == 1);
+        p25_sm_event(&idle_payload_ctx, &idle_payload_opts, &idle_payload_st, &ptt_slot0);
+        idle_payload_st.p25_p2_audio_allowed[0] = 1;
+
+        double idle_observed_m = dsd_time_now_monotonic_s() - 1.0;
+        p25_sm_event(&idle_payload_ctx, &idle_payload_opts, &idle_payload_st, &payload_grant_slot1);
+        rc |= expect_true("idle-payload same-carrier grant", g_tune_to_freq_calls == 1
+                                                                 && idle_payload_ctx.slots[1].grant_active
+                                                                 && idle_payload_ctx.slots[1].voice_active == 0);
+
+        p25_sm_event_t idle_slot1 = p25_sm_ev_idle_at(1, idle_observed_m);
+        p25_sm_event(&idle_payload_ctx, &idle_payload_opts, &idle_payload_st, &idle_slot1);
+        rc |= expect_true("idle-payload grant survives idle",
+                          idle_payload_ctx.slots[1].grant_active && idle_payload_ctx.slots[1].voice_active == 0);
+
+        p25_sm_event(&idle_payload_ctx, &idle_payload_opts, &idle_payload_st, &end_slot0);
+        rc |= expect_true("idle-payload pending grant blocks explicit release",
+                          idle_payload_opts.p25_is_tuned == 1 && g_return_to_cc_calls == 0
+                              && idle_payload_ctx.state == P25_SM_TUNED && idle_payload_ctx.slots[1].grant_active);
+
+        double now_m = dsd_time_now_monotonic_s();
+        idle_payload_ctx.t_voice_m = 0.0;
+        idle_payload_ctx.t_tune_m = now_m - 1.0;
+        idle_payload_ctx.slots[1].last_grant_m = idle_payload_ctx.t_tune_m;
+        p25_sm_tick_ctx(&idle_payload_ctx, &idle_payload_opts, &idle_payload_st);
+        rc |= expect_true("idle-payload grant timeout returned", idle_payload_opts.p25_is_tuned == 0
+                                                                     && g_return_to_cc_calls == 1
+                                                                     && idle_payload_ctx.state == P25_SM_ON_CC);
+        rc |= expect_true("idle-payload slot backoff",
+                          retune_backoff_history_has_slot(&idle_payload_st, g_last_tuned_vc, 1));
+
+        dsd_state_ext_free_all(&idle_payload_st);
+    }
+
+    // 14) A forced release after one TDMA slot produced voice still records a
     // pending grant on the other slot that never produced audio.
     {
         static dsd_opts forced_pending_opts;
@@ -824,7 +887,7 @@ main(void) {
         dsd_state_ext_free_all(&forced_pending_st);
     }
 
-    // 14) A transient return-to-CC failure during grant timeout must not record
+    // 15) A transient return-to-CC failure during grant timeout must not record
     // a failed VC until the retry is accepted.
     static const dsd_trunk_tune_result transient_returns[] = {
         DSD_TRUNK_TUNE_RESULT_DEFERRED,
@@ -876,7 +939,7 @@ main(void) {
     }
     g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
-    // 15) Same-carrier preemption releases to the CC first. The replacement
+    // 16) Same-carrier preemption releases to the CC first. The replacement
     // grant must retune the VC instead of reusing a carrier that is no longer tuned.
     {
         static dsd_opts preempt_opts;

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -12,6 +12,8 @@
  * - Multiple failed VC/slot pairs remain blocked concurrently instead of the
  *   newest failure replacing the previous one.
  * - Explicit data grants bypass stale failed-voice backoff on the same slot.
+ * - Remaining per-slot data grants keep a canceled same-carrier voice grant
+ *   from arming failed-voice fallback backoff.
  */
 
 #include <dsd-neo/core/dsd_time.h>
@@ -583,6 +585,71 @@ main(void) {
         rc |= expect_true("pending data timeout does not arm backoff", retune_backoff_empty(&pending_data_st));
 
         dsd_state_ext_free_all(&pending_data_st);
+    }
+
+    // 10b) If a data grant remains active on one TDMA slot after a later
+    // same-carrier voice grant on the other slot is canceled before PTT, the
+    // data-only timeout must not arm failed-voice fallback backoff for that
+    // canceled voice slot.
+    {
+        static dsd_opts data_after_cancel_opts;
+        static dsd_state data_after_cancel_st;
+        DSD_MEMSET(&data_after_cancel_opts, 0, sizeof data_after_cancel_opts);
+        DSD_MEMSET(&data_after_cancel_st, 0, sizeof data_after_cancel_st);
+        data_after_cancel_opts.p25_trunk = 1;
+        data_after_cancel_opts.trunk_tune_group_calls = 1;
+        data_after_cancel_opts.trunk_tune_data_calls = 1;
+        data_after_cancel_opts.trunk_hangtime = 0.2f;
+        data_after_cancel_opts.p25_grant_voice_to_s = 0.8;
+        data_after_cancel_opts.p25_retune_backoff_s = 2.0;
+        data_after_cancel_st.p25_cc_freq = 851000000;
+        data_after_cancel_st.p25_chan_iden = id;
+        data_after_cancel_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+        data_after_cancel_st.p25_chan_tdma_explicit[id] = 2;
+
+        p25_sm_ctx_t data_after_cancel_ctx;
+        p25_sm_init_ctx(&data_after_cancel_ctx, &data_after_cancel_opts, &data_after_cancel_st);
+        g_last_tuned_vc = 0;
+        g_tune_to_freq_calls = 0;
+        g_return_to_cc_calls = 0;
+        p25_sm_event_t data_after_cancel_data = p25_sm_ev_group_data_grant(ch_slot1, 0, 3651, 4651, P25_SM_SVC_UNKNOWN);
+        p25_sm_event_t data_after_cancel_voice = p25_sm_ev_group_grant(ch_slot0, 0, 3652, 4652, 0);
+        p25_sm_event_t data_after_cancel_end = p25_sm_ev_end(0);
+
+        p25_sm_event(&data_after_cancel_ctx, &data_after_cancel_opts, &data_after_cancel_st, &data_after_cancel_data);
+        rc |= expect_true("data-after-cancel data tuned", g_tune_to_freq_calls == 1
+                                                              && data_after_cancel_opts.p25_is_tuned == 1
+                                                              && data_after_cancel_ctx.slots[1].grant_active
+                                                              && data_after_cancel_ctx.slots[1].data_call);
+
+        p25_sm_event(&data_after_cancel_ctx, &data_after_cancel_opts, &data_after_cancel_st, &data_after_cancel_voice);
+        rc |=
+            expect_true("data-after-cancel voice same-carrier",
+                        g_tune_to_freq_calls == 1 && data_after_cancel_ctx.vc_data_call == 0
+                            && data_after_cancel_ctx.slots[0].grant_active && !data_after_cancel_ctx.slots[0].data_call
+                            && data_after_cancel_ctx.slots[1].grant_active && data_after_cancel_ctx.slots[1].data_call);
+
+        p25_sm_event(&data_after_cancel_ctx, &data_after_cancel_opts, &data_after_cancel_st, &data_after_cancel_end);
+        rc |= expect_true("data-after-cancel data remains", data_after_cancel_opts.p25_is_tuned == 1
+                                                                && g_return_to_cc_calls == 0
+                                                                && data_after_cancel_ctx.slots[0].grant_active == 0
+                                                                && data_after_cancel_ctx.slots[1].grant_active
+                                                                && data_after_cancel_ctx.slots[1].data_call);
+
+        data_after_cancel_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+        data_after_cancel_ctx.t_voice_m = 0.0;
+        p25_sm_tick_ctx(&data_after_cancel_ctx, &data_after_cancel_opts, &data_after_cancel_st);
+        rc |= expect_true("data-after-cancel returned", data_after_cancel_opts.p25_is_tuned == 0
+                                                            && g_return_to_cc_calls == 1
+                                                            && data_after_cancel_ctx.state == P25_SM_ON_CC);
+        rc |= expect_true("data-after-cancel no fallback backoff", retune_backoff_empty(&data_after_cancel_st));
+
+        p25_sm_event(&data_after_cancel_ctx, &data_after_cancel_opts, &data_after_cancel_st, &data_after_cancel_voice);
+        rc |= expect_true("data-after-cancel follow-up voice allowed", g_tune_to_freq_calls == 2
+                                                                           && data_after_cancel_opts.p25_is_tuned == 1
+                                                                           && data_after_cancel_ctx.vc_data_call == 0);
+
+        dsd_state_ext_free_all(&data_after_cancel_st);
     }
 
     // 11) A same-target data grant on the opposite TDMA slot must not clear an

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -153,6 +153,20 @@ retune_backoff_history_has_slot(const dsd_state* state, long freq, int slot) {
     return 0;
 }
 
+static void
+age_pending_grants(p25_sm_ctx_t* ctx, double age_s) {
+    if (!ctx) {
+        return;
+    }
+    double stale_m = dsd_time_now_monotonic_s() - age_s;
+    ctx->t_tune_m = stale_m;
+    for (int s = 0; s < 2; s++) {
+        if (ctx->slots[s].grant_active && !ctx->slots[s].data_call) {
+            ctx->slots[s].last_grant_m = stale_m;
+        }
+    }
+}
+
 static int
 seed_exact(dsd_state* st, uint32_t id, const char* mode, const char* name, int priority, int preempt) {
     dsd_tg_policy_entry row;
@@ -205,7 +219,7 @@ main(void) {
     rc |= expect_true("initial tune", st.p25_sm_tune_count == 1 && opts.p25_is_tuned == 1 && g_tune_to_freq_calls == 1);
 
     // 2) Let the grant timeout without any voice/VC sync; this arms backoff for slot 1.
-    ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    age_pending_grants(&ctx, 1.0);
     ctx.t_voice_m = 0.0;
     p25_sm_tick_ctx(&ctx, &opts, &st);
     rc |= expect_true("returned", opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1 && ctx.state == P25_SM_ON_CC);
@@ -223,7 +237,7 @@ main(void) {
 
     // 5) When the second slot also fails before voice, both recent failures
     // should remain blocked. This catches single-entry backoff regressions.
-    ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    age_pending_grants(&ctx, 1.0);
     ctx.t_voice_m = 0.0;
     p25_sm_tick_ctx(&ctx, &opts, &st);
     rc |= expect_true("second returned",
@@ -273,7 +287,7 @@ main(void) {
         rc |= expect_true("zero channel both slots active",
                           zero_ctx.slots[0].grant_active && zero_ctx.slots[1].grant_active);
 
-        zero_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+        age_pending_grants(&zero_ctx, 1.0);
         zero_ctx.t_voice_m = 0.0;
         p25_sm_tick_ctx(&zero_ctx, &zero_opts, &zero_st);
         rc |= expect_true("zero channel returned",
@@ -316,7 +330,7 @@ main(void) {
     rc |= expect_true("forced initial tune",
                       forced_st.p25_sm_tune_count == 1 && forced_opts.p25_is_tuned == 1 && g_tune_to_freq_calls == 1);
 
-    forced_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    age_pending_grants(&forced_ctx, 1.0);
     forced_ctx.t_voice_m = 0.0;
     forced_st.p25_sm_force_release = 1;
     p25_sm_release(&forced_ctx, &forced_opts, &forced_st, "explicit-release");
@@ -422,7 +436,7 @@ main(void) {
     rc |= expect_true("mixed voice initial tune", mixed_st.p25_sm_tune_count == 1 && mixed_opts.p25_is_tuned == 1
                                                       && g_tune_to_freq_calls == 1 && mixed_ctx.vc_data_call == 0);
 
-    mixed_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+    age_pending_grants(&mixed_ctx, 1.0);
     mixed_ctx.t_voice_m = 0.0;
     p25_sm_tick_ctx(&mixed_ctx, &mixed_opts, &mixed_st);
     rc |= expect_true("mixed voice returned",
@@ -574,7 +588,7 @@ main(void) {
             expect_true("transient initial tune", transient_st.p25_sm_tune_count == 1
                                                       && transient_opts.p25_is_tuned == 1 && g_tune_to_freq_calls == 1);
 
-        transient_ctx.t_tune_m = dsd_time_now_monotonic_s() - 1.0;
+        age_pending_grants(&transient_ctx, 1.0);
         transient_ctx.t_voice_m = 0.0;
         p25_sm_tick_ctx(&transient_ctx, &transient_opts, &transient_st);
         rc |= expect_true("transient return preserved vc", transient_opts.p25_is_tuned == 1 && g_return_to_cc_calls == 1

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -835,6 +835,59 @@ main(void) {
         dsd_state_ext_free_all(&idle_payload_st);
     }
 
+    // 13b) A repeat of the same same-carrier grant during IDLE hangtime is a
+    // refresh of the retained slot context, not a preemption candidate.
+    {
+        static dsd_opts repeat_opts;
+        static dsd_state repeat_st;
+        DSD_MEMSET(&repeat_opts, 0, sizeof repeat_opts);
+        DSD_MEMSET(&repeat_st, 0, sizeof repeat_st);
+        repeat_opts.p25_trunk = 1;
+        repeat_opts.trunk_tune_group_calls = 1;
+        repeat_opts.trunk_hangtime = 2.0f;
+        repeat_opts.p25_grant_voice_to_s = 0.8;
+        repeat_opts.p25_retune_backoff_s = 2.0;
+        repeat_st.p25_cc_freq = 851000000;
+        repeat_st.p25_chan_iden = id;
+        repeat_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+        repeat_st.p25_chan_tdma_explicit[id] = 2;
+
+        p25_sm_ctx_t repeat_ctx;
+        p25_sm_init_ctx(&repeat_ctx, &repeat_opts, &repeat_st);
+        g_last_tuned_vc = 0;
+        g_tune_to_freq_calls = 0;
+        g_return_to_cc_calls = 0;
+
+        p25_sm_event_t repeat_grant = p25_sm_ev_group_grant(ch_slot0, 0, 3461, 4461, 0);
+        p25_sm_event_t repeat_ptt = p25_sm_ev_ptt(0);
+        p25_sm_event_t repeat_idle = p25_sm_ev_idle(0);
+
+        p25_sm_event(&repeat_ctx, &repeat_opts, &repeat_st, &repeat_grant);
+        rc |= expect_true("repeat initial tune", g_tune_to_freq_calls == 1 && repeat_opts.p25_is_tuned == 1
+                                                     && repeat_ctx.slots[0].grant_active);
+        p25_sm_event(&repeat_ctx, &repeat_opts, &repeat_st, &repeat_ptt);
+        repeat_st.p25_p2_audio_allowed[0] = 1;
+        rc |= expect_true("repeat voice active",
+                          repeat_ctx.slots[0].voice_active && repeat_ctx.slots[0].last_active_m > 0.0);
+
+        p25_sm_event(&repeat_ctx, &repeat_opts, &repeat_st, &repeat_idle);
+        repeat_st.p25_p2_audio_allowed[0] = 0;
+        rc |= expect_true("repeat idle retained hangtime",
+                          !repeat_ctx.slots[0].grant_active && !repeat_ctx.slots[0].voice_active
+                              && repeat_ctx.slots[0].last_active_m > 0.0 && repeat_ctx.t_voice_m > 0.0);
+        double old_last_grant_m = repeat_ctx.slots[0].last_grant_m;
+
+        p25_sm_event(&repeat_ctx, &repeat_opts, &repeat_st, &repeat_grant);
+        rc |= expect_true("repeat hangtime grant accepted",
+                          g_tune_to_freq_calls == 1 && g_return_to_cc_calls == 0 && repeat_opts.p25_is_tuned == 1
+                              && repeat_ctx.state == P25_SM_TUNED && repeat_ctx.slots[0].grant_active);
+        rc |= expect_true("repeat hangtime grant refreshed", repeat_ctx.slots[0].last_grant_m > old_last_grant_m
+                                                                 && repeat_ctx.slots[0].last_active_m == 0.0
+                                                                 && repeat_ctx.t_voice_m == 0.0);
+
+        dsd_state_ext_free_all(&repeat_st);
+    }
+
     // 14) A forced release after one TDMA slot produced voice still records a
     // pending grant on the other slot that never produced audio.
     {

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -705,7 +705,59 @@ main(void) {
         dsd_state_ext_free_all(&pending_st);
     }
 
-    // 13) A transient return-to-CC failure during grant timeout must not record
+    // 13) A forced release after one TDMA slot produced voice still records a
+    // pending grant on the other slot that never produced audio.
+    {
+        static dsd_opts forced_pending_opts;
+        static dsd_state forced_pending_st;
+        DSD_MEMSET(&forced_pending_opts, 0, sizeof forced_pending_opts);
+        DSD_MEMSET(&forced_pending_st, 0, sizeof forced_pending_st);
+        forced_pending_opts.p25_trunk = 1;
+        forced_pending_opts.trunk_tune_group_calls = 1;
+        forced_pending_opts.trunk_hangtime = 0.2f;
+        forced_pending_opts.p25_grant_voice_to_s = 10.0;
+        forced_pending_opts.p25_retune_backoff_s = 2.0;
+        forced_pending_st.p25_cc_freq = 851000000;
+        forced_pending_st.p25_chan_iden = id;
+        forced_pending_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+        forced_pending_st.p25_chan_tdma_explicit[id] = 2;
+
+        p25_sm_ctx_t forced_pending_ctx;
+        p25_sm_init_ctx(&forced_pending_ctx, &forced_pending_opts, &forced_pending_st);
+        g_last_tuned_vc = 0;
+        g_tune_to_freq_calls = 0;
+        g_return_to_cc_calls = 0;
+        p25_sm_event_t forced_pending_active = p25_sm_ev_group_grant(ch_slot0, 0, 3701, 4701, 0);
+        p25_sm_event_t forced_pending_waiting = p25_sm_ev_group_grant(ch_slot1, 0, 3702, 4702, 0);
+        p25_sm_event_t forced_pending_ptt = p25_sm_ev_ptt(0);
+
+        p25_sm_event(&forced_pending_ctx, &forced_pending_opts, &forced_pending_st, &forced_pending_active);
+        rc |= expect_true("forced-pending initial tune", g_tune_to_freq_calls == 1
+                                                             && forced_pending_opts.p25_is_tuned == 1
+                                                             && forced_pending_ctx.slots[0].grant_active);
+        p25_sm_event(&forced_pending_ctx, &forced_pending_opts, &forced_pending_st, &forced_pending_ptt);
+        forced_pending_st.p25_p2_audio_allowed[0] = 1;
+        rc |= expect_true("forced-pending voice observed",
+                          forced_pending_ctx.t_voice_m > 0.0 && forced_pending_ctx.slots[0].voice_active == 1);
+
+        p25_sm_event(&forced_pending_ctx, &forced_pending_opts, &forced_pending_st, &forced_pending_waiting);
+        rc |= expect_true("forced-pending same-carrier accepted", g_tune_to_freq_calls == 1
+                                                                      && forced_pending_ctx.slots[1].grant_active
+                                                                      && forced_pending_ctx.slots[1].voice_active == 0);
+
+        forced_pending_st.p25_sm_force_release = 1;
+        p25_sm_release(&forced_pending_ctx, &forced_pending_opts, &forced_pending_st, "forced-pending-release");
+        rc |= expect_true("forced-pending returned", forced_pending_opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1
+                                                         && forced_pending_ctx.state == P25_SM_ON_CC);
+        rc |= expect_true("forced-pending slot1 backoff",
+                          retune_backoff_history_has_slot(&forced_pending_st, g_last_tuned_vc, 1));
+        rc |= expect_true("forced-pending active slot not failed",
+                          !retune_backoff_history_has_slot(&forced_pending_st, g_last_tuned_vc, 0));
+
+        dsd_state_ext_free_all(&forced_pending_st);
+    }
+
+    // 14) A transient return-to-CC failure during grant timeout must not record
     // a failed VC until the retry is accepted.
     static const dsd_trunk_tune_result transient_returns[] = {
         DSD_TRUNK_TUNE_RESULT_DEFERRED,
@@ -757,7 +809,7 @@ main(void) {
     }
     g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
-    // 14) Same-carrier preemption releases to the CC first. The replacement
+    // 15) Same-carrier preemption releases to the CC first. The replacement
     // grant must retune the VC instead of reusing a carrier that is no longer tuned.
     {
         static dsd_opts preempt_opts;

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -435,7 +435,113 @@ main(void) {
     rc |= expect_true("data grant bypasses voice backoff",
                       g_tune_to_freq_calls == 2 && mixed_opts.p25_is_tuned == 1 && mixed_ctx.vc_data_call == 1);
 
-    // 9) A transient return-to-CC failure during grant timeout must not record
+    // 9) A same-carrier data grant must not hide a pending failed voice grant
+    // on the other TDMA slot when the carrier returns to the CC.
+    {
+        static dsd_opts mixed_data_opts;
+        static dsd_state mixed_data_st;
+        DSD_MEMSET(&mixed_data_opts, 0, sizeof mixed_data_opts);
+        DSD_MEMSET(&mixed_data_st, 0, sizeof mixed_data_st);
+        mixed_data_opts.p25_trunk = 1;
+        mixed_data_opts.trunk_tune_group_calls = 1;
+        mixed_data_opts.trunk_tune_data_calls = 1;
+        mixed_data_opts.trunk_hangtime = 0.2f;
+        mixed_data_opts.p25_grant_voice_to_s = 0.5;
+        mixed_data_opts.p25_retune_backoff_s = 2.0;
+        mixed_data_st.p25_cc_freq = 851000000;
+        mixed_data_st.p25_chan_iden = id;
+        mixed_data_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+        mixed_data_st.p25_chan_tdma_explicit[id] = 2;
+
+        p25_sm_ctx_t mixed_data_ctx;
+        p25_sm_init_ctx(&mixed_data_ctx, &mixed_data_opts, &mixed_data_st);
+        g_last_tuned_vc = 0;
+        g_tune_to_freq_calls = 0;
+        g_return_to_cc_calls = 0;
+        p25_sm_event_t mixed_voice_slot0 = p25_sm_ev_group_grant(ch_slot0, 0, 3301, 4301, 0);
+        p25_sm_event_t mixed_data_slot1 = p25_sm_ev_group_data_grant(ch_slot1, 0, 3302, 4302, P25_SM_SVC_UNKNOWN);
+
+        p25_sm_event(&mixed_data_ctx, &mixed_data_opts, &mixed_data_st, &mixed_voice_slot0);
+        rc |= expect_true("mixed data voice tune", g_tune_to_freq_calls == 1 && mixed_data_opts.p25_is_tuned == 1
+                                                       && mixed_data_ctx.slots[0].grant_active
+                                                       && mixed_data_ctx.vc_data_call == 0);
+        p25_sm_event(&mixed_data_ctx, &mixed_data_opts, &mixed_data_st, &mixed_data_slot1);
+        rc |= expect_true("mixed data same-carrier no retune", g_tune_to_freq_calls == 1
+                                                                   && mixed_data_ctx.vc_data_call == 1
+                                                                   && mixed_data_ctx.slots[1].data_call);
+
+        double stale_grant_m = dsd_time_now_monotonic_s() - 1.0;
+        mixed_data_ctx.t_tune_m = stale_grant_m;
+        mixed_data_ctx.t_voice_m = 0.0;
+        mixed_data_ctx.slots[0].last_grant_m = stale_grant_m;
+        p25_sm_tick_ctx(&mixed_data_ctx, &mixed_data_opts, &mixed_data_st);
+        rc |= expect_true("mixed data returned", mixed_data_opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1
+                                                     && mixed_data_ctx.state == P25_SM_ON_CC);
+        rc |= expect_true("mixed data voice slot backoff",
+                          retune_backoff_history_has_slot(&mixed_data_st, g_last_tuned_vc, 0));
+
+        dsd_state_ext_free_all(&mixed_data_st);
+    }
+
+    // 10) When one slot ends while the other slot has a pending voice grant,
+    // the pending grant stays on the grant-timeout path rather than inheriting
+    // the ended slot's hangtime.
+    {
+        static dsd_opts pending_opts;
+        static dsd_state pending_st;
+        DSD_MEMSET(&pending_opts, 0, sizeof pending_opts);
+        DSD_MEMSET(&pending_st, 0, sizeof pending_st);
+        pending_opts.p25_trunk = 1;
+        pending_opts.trunk_tune_group_calls = 1;
+        pending_opts.trunk_hangtime = 0.2f;
+        pending_opts.p25_grant_voice_to_s = 0.8;
+        pending_opts.p25_retune_backoff_s = 2.0;
+        pending_st.p25_cc_freq = 851000000;
+        pending_st.p25_chan_iden = id;
+        pending_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+        pending_st.p25_chan_tdma_explicit[id] = 2;
+
+        p25_sm_ctx_t pending_ctx;
+        p25_sm_init_ctx(&pending_ctx, &pending_opts, &pending_st);
+        g_last_tuned_vc = 0;
+        g_tune_to_freq_calls = 0;
+        g_return_to_cc_calls = 0;
+        p25_sm_event_t pending_active_slot0 = p25_sm_ev_group_grant(ch_slot0, 0, 3401, 4401, 0);
+        p25_sm_event_t pending_voice_slot1 = p25_sm_ev_group_grant(ch_slot1, 0, 3402, 4402, 0);
+        p25_sm_event_t ptt_slot0 = p25_sm_ev_ptt(0);
+        p25_sm_event_t end_slot0 = p25_sm_ev_end(0);
+
+        p25_sm_event(&pending_ctx, &pending_opts, &pending_st, &pending_active_slot0);
+        rc |= expect_true("pending initial tune", g_tune_to_freq_calls == 1 && pending_opts.p25_is_tuned == 1);
+        p25_sm_event(&pending_ctx, &pending_opts, &pending_st, &ptt_slot0);
+        pending_st.p25_p2_audio_allowed[0] = 1;
+        p25_sm_event(&pending_ctx, &pending_opts, &pending_st, &pending_voice_slot1);
+        rc |= expect_true("pending same-carrier grant", g_tune_to_freq_calls == 1 && pending_ctx.slots[1].grant_active
+                                                            && pending_ctx.slots[1].voice_active == 0);
+        p25_sm_event(&pending_ctx, &pending_opts, &pending_st, &end_slot0);
+
+        double now_m = dsd_time_now_monotonic_s();
+        pending_ctx.t_voice_m = now_m - 1.0;
+        pending_ctx.t_tune_m = now_m - 0.2;
+        pending_ctx.slots[1].last_grant_m = pending_ctx.t_tune_m;
+        p25_sm_tick_ctx(&pending_ctx, &pending_opts, &pending_st);
+        rc |= expect_true("pending grant not released on ended-slot hangtime",
+                          pending_opts.p25_is_tuned == 1 && g_return_to_cc_calls == 0
+                              && pending_ctx.state == P25_SM_TUNED && pending_ctx.slots[1].grant_active);
+
+        now_m = dsd_time_now_monotonic_s();
+        pending_ctx.t_tune_m = now_m - 1.0;
+        pending_ctx.slots[1].last_grant_m = pending_ctx.t_tune_m;
+        p25_sm_tick_ctx(&pending_ctx, &pending_opts, &pending_st);
+        rc |= expect_true("pending grant timeout returned", pending_opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1
+                                                                && pending_ctx.state == P25_SM_ON_CC);
+        rc |= expect_true("pending grant timeout backoff",
+                          retune_backoff_history_has_slot(&pending_st, g_last_tuned_vc, 1));
+
+        dsd_state_ext_free_all(&pending_st);
+    }
+
+    // 11) A transient return-to-CC failure during grant timeout must not record
     // a failed VC until the retry is accepted.
     static const dsd_trunk_tune_result transient_returns[] = {
         DSD_TRUNK_TUNE_RESULT_DEFERRED,
@@ -487,7 +593,7 @@ main(void) {
     }
     g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
-    // 10) Same-carrier preemption releases to the CC first. The replacement
+    // 12) Same-carrier preemption releases to the CC first. The replacement
     // grant must retune the VC instead of reusing a carrier that is no longer tuned.
     {
         static dsd_opts preempt_opts;
@@ -532,6 +638,60 @@ main(void) {
         rc |= expect_true("preempt replacement active", preempt_ctx.state == P25_SM_TUNED && preempt_ctx.vc_tg == 4002
                                                             && preempt_ctx.slots[0].grant_active
                                                             && preempt_ctx.slots[0].target_id == 4002);
+
+        static const dsd_trunk_tune_result preempt_release_failures[] = {
+            DSD_TRUNK_TUNE_RESULT_DEFERRED,
+            DSD_TRUNK_TUNE_RESULT_FAILED,
+        };
+        for (size_t i = 0; i < sizeof(preempt_release_failures) / sizeof(preempt_release_failures[0]); i++) {
+            static dsd_opts failed_preempt_opts;
+            static dsd_state failed_preempt_st;
+            DSD_MEMSET(&failed_preempt_opts, 0, sizeof failed_preempt_opts);
+            DSD_MEMSET(&failed_preempt_st, 0, sizeof failed_preempt_st);
+            failed_preempt_opts.p25_trunk = 1;
+            failed_preempt_opts.trunk_tune_group_calls = 1;
+            failed_preempt_opts.trunk_hangtime = 0.2f;
+            failed_preempt_opts.p25_retune_backoff_s = 2.0;
+            failed_preempt_st.p25_cc_freq = 851000000;
+            failed_preempt_st.p25_chan_iden = id;
+            failed_preempt_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+            failed_preempt_st.p25_chan_tdma_explicit[id] = 2;
+
+            rc |= expect_true("seed failed-preempt active",
+                              seed_exact(&failed_preempt_st, 4101, "A", "PREEMPT-FAIL-ACTIVE", 10, 0) == 0);
+            rc |= expect_true("seed failed-preempt candidate",
+                              seed_exact(&failed_preempt_st, 4102, "A", "PREEMPT-FAIL-CAND", 90, 1) == 0);
+
+            p25_sm_ctx_t failed_preempt_ctx;
+            p25_sm_init_ctx(&failed_preempt_ctx, &failed_preempt_opts, &failed_preempt_st);
+            g_last_tuned_vc = 0;
+            g_tune_to_freq_calls = 0;
+            g_return_to_cc_calls = 0;
+            g_return_to_cc_result = preempt_release_failures[i];
+
+            p25_sm_event_t failed_preempt_active = p25_sm_ev_group_grant(ch_slot0, 0, 4101, 5101, 0);
+            p25_sm_event_t failed_preempt_candidate = p25_sm_ev_group_grant(ch_slot0, 0, 4102, 5102, 0);
+            p25_sm_event(&failed_preempt_ctx, &failed_preempt_opts, &failed_preempt_st, &failed_preempt_active);
+            rc |= expect_true("failed-preempt active tuned", g_tune_to_freq_calls == 1
+                                                                 && failed_preempt_opts.p25_is_tuned == 1
+                                                                 && failed_preempt_ctx.state == P25_SM_TUNED);
+            failed_preempt_ctx.slots[0].voice_active = 1;
+            failed_preempt_ctx.slots[0].last_active_m = dsd_time_now_monotonic_s();
+            failed_preempt_ctx.t_voice_m = failed_preempt_ctx.slots[0].last_active_m;
+            failed_preempt_st.p25_p2_audio_allowed[0] = 1;
+
+            p25_sm_event(&failed_preempt_ctx, &failed_preempt_opts, &failed_preempt_st, &failed_preempt_candidate);
+            rc |= expect_true("failed-preempt attempted release", g_return_to_cc_calls == 1);
+            rc |= expect_true("failed-preempt did not reuse carrier",
+                              g_tune_to_freq_calls == 1 && failed_preempt_st.p25_sm_tune_count == 1
+                                  && failed_preempt_ctx.vc_tg == 4101 && failed_preempt_ctx.slots[0].target_id == 4101);
+            rc |= expect_true("failed-preempt preserved active call",
+                              failed_preempt_opts.p25_is_tuned == 1 && failed_preempt_ctx.state == P25_SM_TUNED
+                                  && failed_preempt_ctx.slots[0].voice_active == 1);
+
+            dsd_state_ext_free_all(&failed_preempt_st);
+        }
+        g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
         (void)dsd_unsetenv("DSD_NEO_TG_PREEMPT_MIN_DWELL_MS");
         (void)dsd_unsetenv("DSD_NEO_TG_PREEMPT_COOLDOWN_MS");

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -585,7 +585,56 @@ main(void) {
         dsd_state_ext_free_all(&pending_data_st);
     }
 
-    // 11) When one slot ends while the other slot has a pending voice grant,
+    // 11) A same-target data grant on the opposite TDMA slot must not clear an
+    // active voice slot for that target.
+    {
+        static dsd_opts same_target_opts;
+        static dsd_state same_target_st;
+        DSD_MEMSET(&same_target_opts, 0, sizeof same_target_opts);
+        DSD_MEMSET(&same_target_st, 0, sizeof same_target_st);
+        same_target_opts.p25_trunk = 1;
+        same_target_opts.trunk_tune_group_calls = 1;
+        same_target_opts.trunk_tune_data_calls = 1;
+        same_target_opts.trunk_hangtime = 0.2f;
+        same_target_opts.p25_grant_voice_to_s = 0.8;
+        same_target_opts.p25_retune_backoff_s = 2.0;
+        same_target_st.p25_cc_freq = 851000000;
+        same_target_st.p25_chan_iden = id;
+        same_target_st.p25_iden_tdma[id] = st.p25_iden_tdma[id];
+        same_target_st.p25_chan_tdma_explicit[id] = 2;
+
+        p25_sm_ctx_t same_target_ctx;
+        p25_sm_init_ctx(&same_target_ctx, &same_target_opts, &same_target_st);
+        g_last_tuned_vc = 0;
+        g_tune_to_freq_calls = 0;
+        g_return_to_cc_calls = 0;
+        p25_sm_event_t same_target_voice = p25_sm_ev_group_grant(ch_slot0, 0, 3601, 4601, 0);
+        p25_sm_event_t same_target_data = p25_sm_ev_group_data_grant(ch_slot1, 0, 3601, 4602, P25_SM_SVC_UNKNOWN);
+        p25_sm_event_t same_target_ptt = p25_sm_ev_ptt(0);
+
+        p25_sm_event(&same_target_ctx, &same_target_opts, &same_target_st, &same_target_voice);
+        rc |= expect_true("same-target voice tuned", g_tune_to_freq_calls == 1 && same_target_opts.p25_is_tuned == 1
+                                                         && same_target_ctx.slots[0].grant_active
+                                                         && same_target_ctx.slots[0].target_id == 3601
+                                                         && !same_target_ctx.slots[0].data_call);
+        p25_sm_event(&same_target_ctx, &same_target_opts, &same_target_st, &same_target_ptt);
+        same_target_st.p25_p2_audio_allowed[0] = 1;
+        rc |= expect_true("same-target voice active", same_target_ctx.slots[0].voice_active == 1);
+
+        p25_sm_event(&same_target_ctx, &same_target_opts, &same_target_st, &same_target_data);
+        rc |= expect_true("same-target data accepted", g_tune_to_freq_calls == 1 && same_target_ctx.vc_data_call == 1
+                                                           && same_target_ctx.slots[1].grant_active
+                                                           && same_target_ctx.slots[1].data_call
+                                                           && same_target_ctx.slots[1].target_id == 3601);
+        rc |= expect_true("same-target voice slot retained", same_target_ctx.slots[0].grant_active
+                                                                 && same_target_ctx.slots[0].voice_active
+                                                                 && same_target_ctx.slots[0].target_id == 3601
+                                                                 && same_target_st.p25_p2_audio_allowed[0] == 1);
+
+        dsd_state_ext_free_all(&same_target_st);
+    }
+
+    // 12) When one slot ends while the other slot has a pending voice grant,
     // the pending grant stays on the grant-timeout path rather than inheriting
     // the ended slot's hangtime.
     {
@@ -656,7 +705,7 @@ main(void) {
         dsd_state_ext_free_all(&pending_st);
     }
 
-    // 12) A transient return-to-CC failure during grant timeout must not record
+    // 13) A transient return-to-CC failure during grant timeout must not record
     // a failed VC until the retry is accepted.
     static const dsd_trunk_tune_result transient_returns[] = {
         DSD_TRUNK_TUNE_RESULT_DEFERRED,
@@ -708,7 +757,7 @@ main(void) {
     }
     g_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
-    // 12) Same-carrier preemption releases to the CC first. The replacement
+    // 14) Same-carrier preemption releases to the CC first. The replacement
     // grant must retune the VC instead of reusing a carrier that is no longer tuned.
     {
         static dsd_opts preempt_opts;

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -147,6 +147,25 @@ init_basic(dsd_opts* o, dsd_state* s) {
     p25_sm_init(o, s);
 }
 
+static void
+setup_tdma_iden(dsd_state* s, int id) {
+    s->p25_chan_iden = id;
+    s->p25_iden_tdma[id].base_freq = 851000000 / 5;
+    s->p25_iden_tdma[id].chan_type = 3;
+    s->p25_iden_tdma[id].chan_spac = 100;
+    s->p25_iden_tdma[id].trust = 2;
+    s->p25_iden_tdma[id].populated = 1;
+    s->p25_chan_tdma_explicit[id] = 2;
+}
+
+static void
+clear_decoder_vc_tune_state(dsd_opts* opts, dsd_state* state) {
+    opts->p25_is_tuned = 0;
+    opts->trunk_is_tuned = 0;
+    state->p25_vc_freq[0] = state->p25_vc_freq[1] = 0;
+    state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = 0;
+}
+
 int
 main(void) {
     p25_sm_event_t legacy_group_grant = {
@@ -756,8 +775,83 @@ main(void) {
     assert(ctx18.state == P25_SM_ON_CC);
     assert(g_result_tune_to_cc_calls == cc_calls_before_seeded_release_tick);
 
+    // 20) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
+    static dsd_opts o19a;
+    static dsd_state s19a;
+    DSD_MEMSET(&o19a, 0, sizeof(o19a));
+    DSD_MEMSET(&s19a, 0, sizeof(s19a));
+    o19a.p25_trunk = 1;
+    o19a.trunk_tune_group_calls = 1;
+    s19a.p25_cc_freq = 851000000;
+    setup_tdma_iden(&s19a, 2);
+    const int tdma_slot0_ch = (2 << 12) | 0x0000;
+    const int tdma_slot1_ch = (2 << 12) | 0x0001;
+    p25_sm_event_t same_tg_slot0 = p25_sm_ev_group_grant(tdma_slot0_ch, 0, 3101, 4101, 0);
+    p25_sm_event_t moved_tg_slot1 = p25_sm_ev_group_grant(tdma_slot1_ch, 0, 3102, 4102, 0);
+    p25_sm_ctx_t ctx19a;
+    p25_sm_init_ctx(&ctx19a, &o19a, &s19a);
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_result_tune_to_freq_calls = 0;
+
+    p25_sm_event(&ctx19a, &o19a, &s19a, &same_tg_slot0);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(ctx19a.state == P25_SM_TUNED);
+    assert(o19a.p25_is_tuned == 1);
+
+    clear_decoder_vc_tune_state(&o19a, &s19a);
+    p25_sm_event(&ctx19a, &o19a, &s19a, &same_tg_slot0);
+    assert(g_result_tune_to_freq_calls == 2);
+    assert(o19a.p25_is_tuned == 1);
+    assert(ctx19a.state == P25_SM_TUNED);
+
+    clear_decoder_vc_tune_state(&o19a, &s19a);
+    p25_sm_event(&ctx19a, &o19a, &s19a, &moved_tg_slot1);
+    assert(g_result_tune_to_freq_calls == 3);
+    assert(o19a.p25_is_tuned == 1);
+    assert(ctx19a.state == P25_SM_TUNED);
+    assert(ctx19a.slots[1].grant_active == 1);
+
+    // 21) ENC lockout must keep a clear opposite-slot grant pending on the same TDMA carrier.
+    static dsd_opts o19b;
+    static dsd_state s19b;
+    DSD_MEMSET(&o19b, 0, sizeof(o19b));
+    DSD_MEMSET(&s19b, 0, sizeof(s19b));
+    o19b.p25_trunk = 1;
+    o19b.p25_is_tuned = 1;
+    o19b.trunk_is_tuned = 1;
+    o19b.trunk_tune_enc_calls = 0;
+    s19b.p25_cc_freq = 851000000;
+    s19b.p25_vc_freq[0] = s19b.p25_vc_freq[1] = 851000000;
+    s19b.trunk_vc_freq[0] = s19b.trunk_vc_freq[1] = 851000000;
+    setup_tdma_iden(&s19b, 2);
+
+    p25_sm_ctx_t ctx19b;
+    p25_sm_init_ctx(&ctx19b, &o19b, &s19b);
+    ctx19b.state = P25_SM_TUNED;
+    ctx19b.vc_is_tdma = 1;
+    ctx19b.vc_freq_hz = 851000000;
+    ctx19b.vc_channel = tdma_slot0_ch;
+    ctx19b.vc_tg = 5101;
+    ctx19b.slots[1].grant_active = 1;
+    ctx19b.slots[1].freq_hz = 851000000;
+    ctx19b.slots[1].channel = tdma_slot1_ch;
+    ctx19b.slots[1].target_id = 5102;
+    ctx19b.slots[1].last_grant_m = dsd_time_now_monotonic_s();
+    s19b.p25_p2_audio_allowed[0] = 1;
+
+    p25_sm_event_t enc_slot0 = p25_sm_ev_enc(0, 0x84, 0x1234, 5101);
+    g_result_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_result_return_to_cc_calls = 0;
+    p25_sm_event(&ctx19b, &o19b, &s19b, &enc_slot0);
+    assert(g_result_return_to_cc_calls == 0);
+    assert(o19b.p25_is_tuned == 1);
+    assert(ctx19b.state == P25_SM_TUNED);
+    assert(ctx19b.slots[1].grant_active == 1);
+    assert(s19b.p25_p2_audio_allowed[0] == 0);
+    assert(s19b.p25_p2_enc_lockout_muted[0] == 1);
+
 #ifdef USE_RADIO
-    // 20) A failed CQPSK retry must roll back the one-shot override and TDMA timing.
+    // 22) A failed CQPSK retry must roll back the one-shot override and TDMA timing.
     static dsd_opts o19;
     static dsd_state s19;
     DSD_MEMSET(&o19, 0, sizeof(o19));
@@ -805,7 +899,7 @@ main(void) {
     assert(ctx19.state == P25_SM_TUNED);
     g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
 
-    // 21) A successful CQPSK retry refreshes the TDMA grant timeout window.
+    // 23) A successful CQPSK retry refreshes the TDMA grant timeout window.
     static dsd_opts o20;
     static dsd_state s20;
     DSD_MEMSET(&o20, 0, sizeof(o20));

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -804,6 +804,55 @@ main(void) {
     assert(s19.symbolCenter == tuned_center);
     assert(ctx19.state == P25_SM_TUNED);
     g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+
+    // 21) A successful CQPSK retry refreshes the TDMA grant timeout window.
+    static dsd_opts o20;
+    static dsd_state s20;
+    DSD_MEMSET(&o20, 0, sizeof(o20));
+    DSD_MEMSET(&s20, 0, sizeof(s20));
+    o20.p25_trunk = 1;
+    o20.trunk_tune_group_calls = 1;
+    o20.audio_in_type = AUDIO_IN_RTL;
+    o20.trunk_hangtime = 5.0f;
+    o20.p25_grant_voice_to_s = 0.8;
+    o20.p25_retune_backoff_s = 2.0;
+    s20.p25_cc_freq = 851000000;
+    s20.trunk_cc_freq = 851000000;
+    s20.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s20.p25_iden_fdma[id9].chan_type = 1;
+    s20.p25_iden_fdma[id9].chan_spac = 100;
+    s20.p25_iden_fdma[id9].trust = 2;
+    s20.p25_iden_fdma[id9].populated = 1;
+    s20.p25_chan_tdma_explicit[id9] = 2;
+    s20.p25_vc_cqpsk_pref = -1;
+    (void)dsd_unsetenv("DSD_NEO_CQPSK");
+    dsd_neo_config_init(&o20);
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+
+    p25_sm_ctx_t ctx20;
+    p25_sm_init_ctx(&ctx20, &o20, &s20);
+    g_result_tune_to_freq_calls = 0;
+    g_result_return_to_cc_calls = 0;
+    p25_sm_event(&ctx20, &o20, &s20, &ev9);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(ctx20.state == P25_SM_TUNED);
+    assert(ctx20.vc_is_tdma == 1);
+    assert(o20.p25_is_tuned == 1);
+
+    s20.p25_vc_cqpsk_override = 0;
+    const double stale_grant_m = dsd_time_now_monotonic_s() - 0.85;
+    ctx20.t_tune_m = stale_grant_m;
+    ctx20.t_voice_m = 0.0;
+    ctx20.slots[0].last_grant_m = stale_grant_m;
+    p25_sm_tick_ctx(&ctx20, &o20, &s20);
+    assert(g_result_tune_to_freq_calls == 2);
+    assert(g_result_return_to_cc_calls == 0);
+    assert(ctx20.vc_cqpsk_retry_done == 1);
+    assert(ctx20.t_tune_m > stale_grant_m);
+    assert(ctx20.state == P25_SM_TUNED);
+    assert(o20.p25_is_tuned == 1);
+    assert(ctx20.slots[0].grant_active == 1);
+    assert(s20.p25_retune_block_until == 0);
 #endif
 
     install_trunk_tuning_hooks();

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -169,7 +169,7 @@ clear_decoder_vc_tune_state(dsd_opts* opts, dsd_state* state) {
 int
 main(void) {
     p25_sm_event_t legacy_group_grant = {
-        P25_SM_EV_GRANT, -1, 0x1234, 851500000L, 1000, 123, 0, P25_SM_SVC_UNKNOWN, 1, 0x80, 0x1234, 0,
+        P25_SM_EV_GRANT, -1, 0x1234, 851500000L, 1000, 123, 0, P25_SM_SVC_UNKNOWN, 1, 0x80, 0x1234, 0, 0.0,
     };
     assert(legacy_group_grant.is_group == 1);
     assert(legacy_group_grant.algid == 0x80);

--- a/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
+++ b/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
@@ -357,12 +357,18 @@ matrix_send_initial_grant(matrix_fixture* fixture, const matrix_mode_case* mode,
 static void
 matrix_age_tuned_timers(matrix_fixture* fixture) {
     double now_m = dsd_time_now_monotonic_s();
-    fixture->ctx.t_tune_m = now_m - 1.0;
-    fixture->ctx.t_voice_m = now_m - 1.0;
+    double stale_m = now_m - 1.0;
+    fixture->ctx.t_tune_m = stale_m;
+    fixture->ctx.t_voice_m = stale_m;
     fixture->state->last_vc_sync_time = time(NULL) - 1;
-    fixture->state->last_vc_sync_time_m = now_m - 1.0;
+    fixture->state->last_vc_sync_time_m = stale_m;
     fixture->state->p25_last_vc_tune_time = time(NULL) - 1;
-    fixture->state->p25_last_vc_tune_time_m = now_m - 1.0;
+    fixture->state->p25_last_vc_tune_time_m = stale_m;
+    for (int s = 0; s < 2; s++) {
+        if (fixture->ctx.slots[s].last_grant_m > 0.0) {
+            fixture->ctx.slots[s].last_grant_m = stale_m;
+        }
+    }
 }
 
 static void

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -350,6 +350,56 @@ test_tdma_partial_end_stays_tuned(void) {
     return 0;
 }
 
+// Test: P25P2 TDMA - an armed grant on the other slot keeps the carrier until
+// that slot ends or times out, even if it has not produced PTT/ACTIVE yet.
+static int
+test_tdma_pending_other_slot_blocks_release(void) {
+    reset_test_state();
+    g_state.trunk_chan_map[0x1234] = 851500000;
+    g_state.trunk_chan_map[0x1235] = 851500000;
+    g_state.p25_chan_tdma_explicit[1] = 2;
+
+    p25_sm_ctx_t ctx;
+    p25_sm_init_ctx(&ctx, &g_opts, &g_state);
+
+    p25_sm_event_t ev = p25_sm_ev_group_grant(0x1234, 851500000, 1000, 123, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    ev = p25_sm_ev_group_grant(0x1235, 851500000, 1001, 124, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+
+    if (!ctx.slots[1].grant_active || ctx.slots[1].target_id != 1001) {
+        DSD_FPRINTF(stderr, "FAIL: Expected slot 1 pending grant context\n");
+        return 1;
+    }
+
+    ev = p25_sm_ev_ptt(0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    g_state.p25_p2_audio_allowed[0] = 1;
+
+    ev = p25_sm_ev_end(0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+
+    if (ctx.state != P25_SM_TUNED) {
+        DSD_FPRINTF(stderr, "FAIL: Expected TUNED while slot 1 has a pending grant, got %s\n",
+                    p25_sm_state_name(ctx.state));
+        return 1;
+    }
+    if (ctx.slots[0].grant_active != 0 || ctx.slots[1].grant_active != 1) {
+        DSD_FPRINTF(stderr, "FAIL: Expected only slot 1 grant context after slot 0 END\n");
+        return 1;
+    }
+
+    ev = p25_sm_ev_end(1);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.state != P25_SM_ON_CC) {
+        DSD_FPRINTF(stderr, "FAIL: Expected ON_CC after both slot grant contexts ended, got %s\n",
+                    p25_sm_state_name(ctx.state));
+        return 1;
+    }
+
+    return 0;
+}
+
 // Test: P25P2 TDMA - END on single-slot call releases immediately
 // This tests the bug fix where calls on only one slot were waiting for
 // the full hangtime (10s forced release) instead of releasing on MAC_END_PTT.
@@ -528,6 +578,7 @@ main(void) {
     fail += test_audio_allowed();
     fail += test_sacch_slot_mapping();
     fail += test_tdma_partial_end_stays_tuned();
+    fail += test_tdma_pending_other_slot_blocks_release();
     fail += test_tdma_single_slot_end_releases();
     fail += test_tdma_enc_respects_media_policy();
 

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -400,6 +400,49 @@ test_tdma_pending_other_slot_blocks_release(void) {
     return 0;
 }
 
+// Test: P25P2 TDMA - an encrypted locked-out slot clears its grant context so
+// the opposite slot can release immediately on explicit END.
+static int
+test_tdma_enc_lockout_slot_does_not_block_release(void) {
+    reset_test_state();
+    g_opts.trunk_tune_enc_calls = 0;
+    g_state.trunk_chan_map[0x1234] = 851500000;
+    g_state.trunk_chan_map[0x1235] = 851500000;
+    g_state.p25_chan_tdma_explicit[1] = 2;
+
+    p25_sm_ctx_t ctx;
+    p25_sm_init_ctx(&ctx, &g_opts, &g_state);
+
+    p25_sm_event_t ev = p25_sm_ev_group_grant(0x1234, 851500000, 1000, 123, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    ev = p25_sm_ev_group_grant(0x1235, 851500000, 1001, 124, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    ev = p25_sm_ev_ptt(0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    ev = p25_sm_ev_ptt(1);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    g_state.p25_p2_audio_allowed[0] = 1;
+    g_state.p25_p2_audio_allowed[1] = 1;
+
+    ev = p25_sm_ev_enc(1, 0x84, 0x1234, 1001);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+
+    if (ctx.state != P25_SM_TUNED || ctx.slots[1].grant_active != 0 || ctx.slots[1].voice_active != 0) {
+        DSD_FPRINTF(stderr, "FAIL: Expected encrypted slot 1 to mute without keeping an active grant\n");
+        return 1;
+    }
+
+    ev = p25_sm_ev_end(0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.state != P25_SM_ON_CC) {
+        DSD_FPRINTF(stderr, "FAIL: Expected ON_CC after clear slot END with encrypted slot muted, got %s\n",
+                    p25_sm_state_name(ctx.state));
+        return 1;
+    }
+
+    return 0;
+}
+
 // Test: P25P2 TDMA - END on single-slot call releases immediately
 // This tests the bug fix where calls on only one slot were waiting for
 // the full hangtime (10s forced release) instead of releasing on MAC_END_PTT.
@@ -579,6 +622,7 @@ main(void) {
     fail += test_sacch_slot_mapping();
     fail += test_tdma_partial_end_stays_tuned();
     fail += test_tdma_pending_other_slot_blocks_release();
+    fail += test_tdma_enc_lockout_slot_does_not_block_release();
     fail += test_tdma_single_slot_end_releases();
     fail += test_tdma_enc_respects_media_policy();
 


### PR DESCRIPTION
## Summary

- Track accepted P25P2 TDMA grants per slot so same-carrier grants update only the affected slot.
- Reuse the existing TDMA RF carrier for same-frequency grants while preserving other-slot call state, policy state, audio gates, and active-slot diagnostics.
- Keep pending other-slot grant context from forcing an early CC return, and remember failed VC retune backoff per slot.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: none from the listed categories; protocol call-following behavior changed.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [ ] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes
- [ ] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes
- [x] `tools/lizard.sh`
- [x] Pre-push guardrails: install destination check, secret/workflow/dependency pin checks, clang-format, clang-tidy, cppcheck, IWYU, and lizard

## Risk

- Security/dependency impact: none expected.
- CLI/UI behavior impact: P25P2 same-carrier dual-slot call following preserves active and pending slot state instead of bouncing back to the control channel early.
- Compatibility or packaging impact: none expected.
