### PR TITLE
p25: guard radio-only helpers in non-radio builds

### DIFF
--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -939,11 +939,13 @@ p25_sm_clear_one_slot_activity(p25_sm_ctx_t* ctx, int slot) {
     ctx->slots[slot].last_active_m = 0.0;
 }
 
+#ifdef USE_RADIO
 static void
 p25_sm_clear_slot_activity(p25_sm_ctx_t* ctx) {
     p25_sm_clear_one_slot_activity(ctx, 0);
     p25_sm_clear_one_slot_activity(ctx, 1);
 }
+#endif
 
 static void
 p25_grant_clear_one_slot_state(p25_sm_ctx_t* ctx, int slot) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -21,7 +21,9 @@
 #include <dsd-neo/runtime/p25_optional_hooks.h>
 #include <dsd-neo/runtime/p25_p2_audio_ring.h>
 #include <dsd-neo/runtime/rigctl_query_hooks.h>
+#ifdef USE_RADIO
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#endif
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>


### PR DESCRIPTION
## Summary

Fixes the Linux backend matrix `neither` configuration, where both RTL-SDR and SoapySDR are disabled.

The P25 trunking state machine had a helper and RTL metrics include that are only used by radio-enabled CQPSK retry paths. In non-radio builds, `p25_sm_clear_slot_activity` became unused, and warnings-as-errors failed the build. This change guards the helper and metrics include behind `USE_RADIO`, matching their call sites.

## Validation

- `cmake --preset dev-debug -DDSD_ENABLE_RTLSDR=OFF -DDSD_ENABLE_SOAPYSDR=OFF`
- `cmake --build --preset dev-debug --target dsd-neo_proto_p25 -j`
- `cmake --build --preset dev-debug -j`
- pre-push hook: install target check, guardrails, clang-format, clang-tidy, cppcheck, IWYU, GCC fanalyzer, Semgrep, Lizard