### PR TITLE
p25: block grants until CC reacquires

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -303,13 +303,15 @@ struct dsd_state {
     long int p25_cc_freq;   //cc freq from net_stat
     long int trunk_cc_freq; //protocol-agnostic alias (kept in sync with p25_cc_freq)
     unsigned long long int edacs_site_id;
-    time_t last_cc_sync_time; //use this to start hunting for CC after signal lost
-    time_t last_vc_sync_time; //flag for voice activity bursts, tune back on con+ after more than x seconds no voice
+    time_t last_cc_sync_time;    //use this to start hunting for CC after signal lost
+    time_t p25_last_cc_msg_time; //last decoded P25 control-channel message
+    time_t last_vc_sync_time;    //flag for voice activity bursts, tune back on con+ after more than x seconds no voice
     // Timestamp of last tune to a VC (used to provide a short startup grace
     // window so we don't bounce back to CC before MAC_PTT/ACTIVE/audio arrives)
     time_t p25_last_vc_tune_time;
     // Monotonic twins for SM timing (seconds)
     double last_cc_sync_time_m;
+    double p25_last_cc_msg_time_m;
     double last_vc_sync_time_m;
     double p25_last_vc_tune_time_m;
     time_t rtl_fsk_reacquire_last_sync_time;

--- a/include/dsd-neo/engine/trunk_tuning.h
+++ b/include/dsd-neo/engine/trunk_tuning.h
@@ -17,6 +17,7 @@
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,7 +26,14 @@ extern "C" {
 dsd_trunk_tune_result dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
 dsd_trunk_tune_result dsd_engine_trunk_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
 dsd_trunk_tune_result dsd_engine_return_to_cc(dsd_opts* opts, dsd_state* state);
+dsd_trunk_tune_result dsd_engine_trunk_tune_to_freq_request(dsd_opts* opts, dsd_state* state, long int freq,
+                                                            int ted_sps, uint64_t request_id);
+dsd_trunk_tune_result dsd_engine_trunk_tune_to_cc_request(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
+                                                          uint64_t request_id);
+dsd_trunk_tune_result dsd_engine_return_to_cc_request(dsd_opts* opts, dsd_state* state, uint64_t request_id);
 dsd_trunk_tune_result dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
+dsd_trunk_tune_result dsd_engine_scan_tune_to_freq_with_id(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
+                                                           uint64_t* out_request_id);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/io/control.h
+++ b/include/dsd-neo/io/control.h
@@ -22,7 +22,8 @@ extern "C" {
 
 /**
  * @brief Tune the configured control backend without trunking bookkeeping.
- * @return 0 on success, 1 when an RTL request is deferred, or a negative error/timeout code.
+ * @return 0 on success, 1 when an RTL request is deferred, or a negative error/timeout code. An RTL timeout leaves an
+ *         accepted request active and retains its target in opts->rtlsdr_center_freq.
  */
 int io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq);
 void resumeScan(dsd_opts* opts, dsd_state* state);

--- a/include/dsd-neo/io/control.h
+++ b/include/dsd-neo/io/control.h
@@ -20,6 +20,10 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Tune the configured control backend without trunking bookkeeping.
+ * @return 0 on success, 1 when an RTL request is deferred, or a negative error/timeout code.
+ */
 int io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq);
 void resumeScan(dsd_opts* opts, dsd_state* state);
 void openSerial(dsd_opts* opts, dsd_state* state);

--- a/include/dsd-neo/io/rtl_stream.h
+++ b/include/dsd-neo/io/rtl_stream.h
@@ -77,6 +77,16 @@ class RtlSdrOrchestrator {
     int tune(uint32_t center_freq_hz);
 
     /**
+     * @brief Tune to a new center frequency with a caller completion token.
+     * @param center_freq_hz Frequency in Hz.
+     * @param token Non-zero token forwarded to the registered completion callback.
+     * @return 0 when completed, 1 when deferred, or a negative error/timeout code.
+     * A timeout leaves an accepted request active; its terminal result is
+     * delivered through the registered completion callback.
+     */
+    int tune_tagged(uint32_t center_freq_hz, uint64_t token);
+
+    /**
      * @brief Publish an absolute live PPM request against the stream snapshot.
      * @param ppm Requested correction in PPM; clamped by the runtime helper.
      * @return 0 on success, <0 on error.

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -445,6 +445,12 @@ int rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samp
                                              uint32_t* out_generation_before, uint32_t* out_generation_after);
 
 /**
+ * @brief Verify an untagged timeout blocks queued output until controller completion.
+ */
+int rtl_stream_test_untagged_timeout_read_gate(size_t queued_samples, int* out_read_while_pending,
+                                               size_t* out_used_while_pending, int* out_read_after_completion);
+
+/**
  * @brief Seed output/cache counts, clear output, and report the resulting state.
  */
 int rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size_t* out_used_after,

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -445,7 +445,7 @@ int rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samp
                                              uint32_t* out_generation_before, uint32_t* out_generation_after);
 
 /**
- * @brief Verify an untagged timeout invalidates stale reads and stays gated through failure.
+ * @brief Verify an untagged timeout invalidates stale reads and reopens after terminal completion.
  */
 int rtl_stream_test_untagged_timeout_read_gate(size_t queued_samples, int* out_read_while_pending,
                                                size_t* out_used_while_pending, int* out_read_after_failed_completion,

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -49,6 +49,19 @@ typedef enum DSD_ATTR_PACKED rtl_stream_tune_result {
     RTL_STREAM_TUNE_TIMEOUT = -2,
 } rtl_stream_tune_result;
 
+/**
+ * @brief Completion notification for a tagged RTL tune request.
+ *
+ * The callback runs on the RTL controller thread after the hardware/DSP
+ * reconfigure and configured output drain have completed. Implementations
+ * must not block or call back into the RTL tuning API.
+ *
+ * @param token Caller-provided token from rtl_stream_tune_tagged().
+ * @param result Final result of the coalesced controller request.
+ * @param user_data Opaque pointer supplied at registration time.
+ */
+typedef void (*rtl_stream_tune_completion_callback)(uint64_t token, rtl_stream_tune_result result, void* user_data);
+
 /* Lifecycle */
 /**
  * @brief Create a new RTL-SDR stream context from an immutable options snapshot.
@@ -113,6 +126,36 @@ int rtl_stream_destroy(RtlSdrContext* ctx);
  * @return rtl_stream_tune_result: 0 on success, 1 when deferred, negative on error/timeout.
  */
 int rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz);
+
+/**
+ * @brief Tune to a new center frequency and tag its asynchronous completion.
+ *
+ * A queued tagged tune owns its controller request until completion. Another
+ * tune with a different token, including an untagged tune, is deferred instead
+ * of replacing that request. Untagged queued work may still be upgraded to a
+ * tagged request. A token of zero is reserved for untagged requests and is
+ * rejected by this entry point.
+ *
+ * @param ctx Stream context.
+ * @param center_freq_hz New center frequency in Hz.
+ * @param token Non-zero caller token returned unchanged to the completion callback.
+ * @return rtl_stream_tune_result: 0 on success, 1 when deferred, negative on error/timeout.
+ */
+int rtl_stream_tune_tagged(RtlSdrContext* ctx, uint32_t center_freq_hz, uint64_t token);
+
+/**
+ * @brief Register the process-wide tagged tune completion callback.
+ *
+ * Replaces any prior registration. Pass NULL to clear the callback. Replacement
+ * and unregistration wait for invocations of the previous callback to finish,
+ * so its user_data may be released after this function returns. A completion
+ * callback must not call this function or another RTL tuning entry point.
+ *
+ * @param callback Completion callback, or NULL to unregister.
+ * @param user_data Opaque callback context.
+ */
+void rtl_stream_register_tune_completion_callback(rtl_stream_tune_completion_callback callback, void* user_data);
+
 /**
  * @brief Publish a live RTL PPM request and assign it a fresh request generation.
  *
@@ -457,6 +500,17 @@ int rtl_stream_test_retune_profile_request_binding(int* out_first_profile, int* 
 int rtl_stream_test_retune_profile_coalesced_no_profile(int* out_profile, uint32_t* out_profile_freq_hz,
                                                         uint32_t* out_manual_freq_hz, uint32_t* out_request_id,
                                                         uint32_t* out_coalesced_request_id);
+
+/**
+ * @brief Exercise tagged/untagged queued-retune ownership and completion.
+ *
+ * The helper seeds queued output so tests can verify callback publication
+ * happens after the output generation boundary. A zero token simulates an
+ * untagged request; a queued tagged request rejects a different owner.
+ */
+int rtl_stream_test_tagged_completion_boundary(uint64_t first_token, uint64_t second_token, size_t queued_samples,
+                                               uint64_t* out_coalesced_token, uint32_t* out_generation_before,
+                                               uint32_t* out_generation_after);
 
 /**
  * @brief Verify queued retune gain settings are copied onto their scheduled request.

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -489,6 +489,15 @@ int rtl_stream_test_mode_policy_matrix(int* out_values, size_t count);
 int rtl_stream_test_fsk_profile_policy_matrix(int* out_profiles, size_t count);
 
 /**
+ * @brief Acknowledge the submit generation of a replay span discarded by the demodulator.
+ *
+ * Returns the resulting monotonic consume generation. This models the
+ * generation side of a RESET/rewind boundary after the discarded span has
+ * emptied the input ring.
+ */
+uint64_t rtl_stream_test_replay_acknowledge_discarded_span(uint64_t submitted_gen, uint64_t consumed_gen);
+
+/**
  * @brief Seed output/cache state, request FSK reacquire, and consume pending reset.
  */
 int rtl_stream_test_fsk_reacquire(int output_kind, size_t queued_samples, int cached_symbols, size_t* out_used_after,

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -445,10 +445,12 @@ int rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samp
                                              uint32_t* out_generation_before, uint32_t* out_generation_after);
 
 /**
- * @brief Verify an untagged timeout blocks queued output until controller completion.
+ * @brief Verify an untagged timeout invalidates stale reads and stays gated through failure.
  */
 int rtl_stream_test_untagged_timeout_read_gate(size_t queued_samples, int* out_read_while_pending,
-                                               size_t* out_used_while_pending, int* out_read_after_completion);
+                                               size_t* out_used_while_pending, int* out_read_after_failed_completion,
+                                               int* out_read_after_recovery, uint32_t* out_generation_before,
+                                               uint32_t* out_generation_after_gate);
 
 /**
  * @brief Seed output/cache counts, clear output, and report the resulting state.

--- a/include/dsd-neo/protocol/p25/p25_cc_activity.h
+++ b/include/dsd-neo/protocol/p25/p25_cc_activity.h
@@ -13,6 +13,7 @@
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
 #include <time.h>
 
 #ifdef __cplusplus

--- a/include/dsd-neo/protocol/p25/p25_cc_activity.h
+++ b/include/dsd-neo/protocol/p25/p25_cc_activity.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file
+ * @brief P25 control-channel activity timestamp helpers.
+ */
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_PROTOCOL_P25_P25_CC_ACTIVITY_H
+#define DSD_NEO_INCLUDE_DSD_NEO_PROTOCOL_P25_P25_CC_ACTIVITY_H
+
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Mark a decoded P25 control-channel message.
+ *
+ * This is stricter than generic frame sync/tune timestamps: call it only after
+ * a validated P25 control-channel block or LCCH MAC has decoded.
+ *
+ * @param opts Decoder options.
+ * @param state Decoder state.
+ * @param source Short diagnostic source label.
+ */
+static inline void
+p25_sm_note_cc_activity(const dsd_opts* opts, dsd_state* state, const char* source) {
+    (void)opts;
+    (void)source;
+    if (!state) {
+        return;
+    }
+    const time_t now = time(NULL);
+    const double now_m = dsd_time_now_monotonic_s();
+    state->last_cc_sync_time = now;
+    state->last_cc_sync_time_m = now_m;
+    state->p25_last_cc_msg_time = now;
+    state->p25_last_cc_msg_time_m = now_m;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DSD_NEO_INCLUDE_DSD_NEO_PROTOCOL_P25_P25_CC_ACTIVITY_H

--- a/include/dsd-neo/protocol/p25/p25_sm_watchdog.h
+++ b/include/dsd-neo/protocol/p25/p25_sm_watchdog.h
@@ -42,7 +42,15 @@ void p25_sm_try_tick(dsd_opts* opts, dsd_state* state);
  */
 int p25_sm_tick_guard_try_enter(void);
 
-/** @brief Leave a critical section entered by p25_sm_tick_guard_try_enter(). */
+/**
+ * @brief Enter the critical section shared with P25 SM and trunk-scan ticks.
+ *
+ * This blocking form is intended for frame dispatch, which must complete
+ * against one tuner target and one restored scan snapshot.
+ */
+void p25_sm_tick_guard_enter(void);
+
+/** @brief Leave a critical section entered by either guard entry function. */
 void p25_sm_tick_guard_leave(void);
 
 /**

--- a/include/dsd-neo/protocol/p25/p25_sm_watchdog.h
+++ b/include/dsd-neo/protocol/p25/p25_sm_watchdog.h
@@ -45,8 +45,8 @@ int p25_sm_tick_guard_try_enter(void);
 /**
  * @brief Enter the critical section shared with P25 SM and trunk-scan ticks.
  *
- * This blocking form is intended for frame dispatch, which must complete
- * against one tuner target and one restored scan snapshot.
+ * This blocking form is intended for work that must not overlap a tick, such
+ * as frame dispatch against one tuner target or a tuner lifecycle transition.
  */
 void p25_sm_tick_guard_enter(void);
 

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -149,13 +149,15 @@ typedef struct {
     p25_sm_slot_ctx_t slots[2];
 
     // Timing
-    double t_tune_m;     // Monotonic time of last VC tune
-    double t_voice_m;    // Monotonic time of last voice activity
-    double t_hangtime_m; // Monotonic time hangtime started
-    double t_cc_sync_m;  // Monotonic time of last CC sync
-    double t_cc_tune_m;  // Monotonic time of last CC tune awaiting decode
-    double t_hunt_try_m; // Monotonic time of last CC candidate attempt
-    int cc_sync_pending; // 1 until a CC tune is followed by decoded CC sync
+    double t_tune_m;             // Monotonic time of last VC tune
+    double t_voice_m;            // Monotonic time of last voice activity
+    double t_hangtime_m;         // Monotonic time hangtime started
+    double t_cc_sync_m;          // Monotonic time of last CC sync
+    double t_cc_tune_m;          // Monotonic time of last CC tune awaiting decode
+    double t_hunt_try_m;         // Monotonic time of last CC candidate attempt
+    uint64_t cc_tune_request_id; // Runtime request awaiting asynchronous tune completion
+    int cc_tune_pending;         // 1 while the tuner/output pipeline is still changing channels
+    int cc_sync_pending;         // 1 until a completed CC tune is followed by decoded CC sync
 
     // Statistics (for debugging/UI)
     uint32_t tune_count;
@@ -219,22 +221,36 @@ void p25_sm_event(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25
 void p25_sm_seed_cc_from_current_tuner_if_unknown(const dsd_opts* opts, dsd_state* state);
 
 /**
- * @brief Restart a pending CC acquisition after an accepted external retune.
+ * @brief Start CC acquisition after a completed external retune.
  *
- * This is a no-op unless the context is already awaiting decoded CC activity.
- * It refreshes the acquisition baseline and returns a hunting context to
- * ON_CC so the normal acquisition watchdog grants the new tune its full grace
- * period.
+ * Refreshes the acquisition baseline and returns the context to ON_CC so the
+ * normal acquisition watchdog grants the completed tune its full grace period.
  *
  * @param ctx State machine context.
  * @param opts Decoder options.
  * @param state Decoder state.
- * @param tune_start_m Monotonic timestamp captured after retune acceptance.
+ * @param tune_start_m Monotonic timestamp captured after retune completion.
  * @param source Short diagnostic source label.
- * @return 1 when pending acquisition was restarted, 0 otherwise.
+ * @return 1 when acquisition was started, 0 otherwise.
  */
 int p25_sm_restart_pending_cc_acquisition(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double tune_start_m,
                                           const char* source);
+
+/**
+ * @brief Hold CC acquisition until an exact asynchronous retune completes.
+ *
+ * No acquisition deadline begins until the supplied request completes, even
+ * for a previously synchronized parked context.
+ *
+ * @param ctx State machine context.
+ * @param opts Decoder options.
+ * @param state Decoder state.
+ * @param request_id Runtime tune request being awaited.
+ * @param source Short diagnostic source label.
+ * @return 1 when the pending tune was recorded, 0 on invalid input.
+ */
+int p25_sm_await_pending_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, uint64_t request_id,
+                                 const char* source);
 
 /**
  * @brief Periodic tick for timeout-based transitions.

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -153,7 +153,9 @@ typedef struct {
     double t_voice_m;    // Monotonic time of last voice activity
     double t_hangtime_m; // Monotonic time hangtime started
     double t_cc_sync_m;  // Monotonic time of last CC sync
+    double t_cc_tune_m;  // Monotonic time of last CC tune awaiting decode
     double t_hunt_try_m; // Monotonic time of last CC candidate attempt
+    int cc_sync_pending; // 1 until a CC tune is followed by decoded CC sync
 
     // Statistics (for debugging/UI)
     uint32_t tune_count;

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -209,13 +209,32 @@ void p25_sm_event(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25
  * behavior. The generic trunk CC alias is preferred when it is already known.
  * Otherwise the tuner is sampled only while legacy tune flags indicate the
  * decoder is parked on the control channel; voice-channel tunes are ignored.
- * Live P25 Phase 2 sync seeds a TDMA CC modulation hint; live P25 Phase 1 sync
- * clears any stale TDMA CC hint.
+ * Live P25 Phase 2 LCCH context seeds a TDMA CC modulation hint; ordinary
+ * Phase 2 traffic sync leaves the hint unchanged. Live P25 Phase 1 sync clears
+ * any stale TDMA CC hint.
  *
  * @param opts Decoder options.
  * @param state Decoder state.
  */
 void p25_sm_seed_cc_from_current_tuner_if_unknown(const dsd_opts* opts, dsd_state* state);
+
+/**
+ * @brief Restart a pending CC acquisition after an accepted external retune.
+ *
+ * This is a no-op unless the context is already awaiting decoded CC activity.
+ * It refreshes the acquisition baseline and returns a hunting context to
+ * ON_CC so the normal acquisition watchdog grants the new tune its full grace
+ * period.
+ *
+ * @param ctx State machine context.
+ * @param opts Decoder options.
+ * @param state Decoder state.
+ * @param tune_start_m Monotonic timestamp captured after retune acceptance.
+ * @param source Short diagnostic source label.
+ * @return 1 when pending acquisition was restarted, 0 otherwise.
+ */
+int p25_sm_restart_pending_cc_acquisition(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double tune_start_m,
+                                          const char* source);
 
 /**
  * @brief Periodic tick for timeout-based transitions.

--- a/include/dsd-neo/runtime/trunk_tuning_hooks.h
+++ b/include/dsd-neo/runtime/trunk_tuning_hooks.h
@@ -93,6 +93,17 @@ uint64_t dsd_trunk_tuning_request_begin(void);
 void dsd_trunk_tuning_requests_reset(void);
 
 /**
+ * @brief Retire terminal failed requests after correlated recovery is abandoned.
+ *
+ * Mode-exit paths call this after trunking ownership has been released so a
+ * failed request cannot keep the process-wide frame gate closed indefinitely.
+ * In-flight requests are left untouched; a later successful completion still
+ * establishes a tuner boundary, while a later failure may be retired by a
+ * subsequent call.
+ */
+void dsd_trunk_tuning_retire_failed_requests(void);
+
+/**
  * @brief Publish backend completion for an exact tune transition.
  *
  * Successful completion commits the generation after the owner has marked its
@@ -122,7 +133,8 @@ void dsd_trunk_tuning_request_mark_ready(uint64_t request_id);
  * Failure normally clears the transition without publishing a completed
  * generation; callers must first restore or replace any staged decoder state.
  * A safety gate inherited from bounded-history recovery remains closed until a
- * later successful tune. Stale and duplicate request IDs are ignored.
+ * later successful tune or explicit mode-exit retirement. Stale and duplicate
+ * request IDs are ignored.
  *
  * @param request_id Request ID returned by dsd_trunk_tuning_request_begin().
  * @param result Terminal result; PENDING is ignored.

--- a/include/dsd-neo/runtime/trunk_tuning_hooks.h
+++ b/include/dsd-neo/runtime/trunk_tuning_hooks.h
@@ -161,6 +161,18 @@ dsd_trunk_tune_result dsd_trunk_tuning_request_status(uint64_t request_id, doubl
  */
 int dsd_trunk_tuning_frame_is_current(uint64_t frame_generation);
 
+/**
+ * @brief Test whether a collected frame may be dispatched for the active mode.
+ *
+ * When no trunking or trunk-scan tuner owns frame dispatch, terminal failed
+ * requests are retired before checking the generation. In-flight requests
+ * remain gated until their backend publishes a terminal result.
+ *
+ * @param frame_generation Tune generation captured before frame sync.
+ * @param tune_owner_active Non-zero while trunking or trunk scan owns tuning.
+ */
+int dsd_trunk_tuning_frame_is_dispatchable(uint64_t frame_generation, int tune_owner_active);
+
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
 dsd_trunk_tune_result dsd_trunk_tuning_hook_return_to_cc(dsd_opts* opts, dsd_state* state);

--- a/include/dsd-neo/runtime/trunk_tuning_hooks.h
+++ b/include/dsd-neo/runtime/trunk_tuning_hooks.h
@@ -152,7 +152,8 @@ int dsd_trunk_tuning_frame_is_current(uint64_t frame_generation);
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
 dsd_trunk_tune_result dsd_trunk_tuning_hook_return_to_cc(dsd_opts* opts, dsd_state* state);
-/* The _with_id wrappers return zero when dispatching through a legacy result hook. */
+/* When both hook variants are installed, the _with_id wrappers use the request-aware hook when an output pointer is
+ * supplied. They return zero when dispatching through a legacy result hook. */
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_freq_with_id(dsd_opts* opts, dsd_state* state, long int freq,
                                                                  int ted_sps, uint64_t* out_request_id);
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_cc_with_id(dsd_opts* opts, dsd_state* state, long int freq,

--- a/include/dsd-neo/runtime/trunk_tuning_hooks.h
+++ b/include/dsd-neo/runtime/trunk_tuning_hooks.h
@@ -17,6 +17,7 @@
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,6 +43,25 @@ typedef struct {
 } dsd_trunk_tuning_hooks;
 
 void dsd_trunk_tuning_hooks_set(dsd_trunk_tuning_hooks hooks);
+
+/**
+ * @brief Return the generation of accepted trunk-tuning changes.
+ *
+ * Frame decoders can snapshot this value before collecting a frame and verify
+ * it again before dispatch, preventing work from an earlier trunk target from
+ * mutating state restored for a newer target. Runtime hook wrappers and direct
+ * trunk-scan retunes publish this generation.
+ */
+uint64_t dsd_trunk_tuning_generation(void);
+
+/**
+ * @brief Advance the tuner generation after an accepted direct retune.
+ *
+ * Hook wrappers do this automatically for successful and pending results.
+ * Direct retune paths that do not pass through a hook wrapper must call this
+ * once the tuner has accepted the request.
+ */
+void dsd_trunk_tuning_generation_advance(void);
 
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);

--- a/include/dsd-neo/runtime/trunk_tuning_hooks.h
+++ b/include/dsd-neo/runtime/trunk_tuning_hooks.h
@@ -27,7 +27,7 @@ typedef enum {
     DSD_TRUNK_TUNE_RESULT_OK = 0,
     /* No hardware retune was scheduled yet; callers should retry without advancing state. */
     DSD_TRUNK_TUNE_RESULT_DEFERRED = 1,
-    /* Retune was accepted but completion is asynchronous; callers should commit intended state. */
+    /* Retune was accepted but remains in flight; intended state may be staged, but is not completed. */
     DSD_TRUNK_TUNE_RESULT_PENDING = 2,
     DSD_TRUNK_TUNE_RESULT_FAILED = -1,
     DSD_TRUNK_TUNE_RESULT_TIMEOUT = -2,
@@ -40,36 +40,119 @@ typedef struct {
     dsd_trunk_tune_result (*tune_to_freq_result)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
     dsd_trunk_tune_result (*tune_to_cc_result)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
     dsd_trunk_tune_result (*return_to_cc_result)(dsd_opts* opts, dsd_state* state);
+    dsd_trunk_tune_result (*tune_to_freq_request)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
+                                                  uint64_t request_id);
+    dsd_trunk_tune_result (*tune_to_cc_request)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
+                                                uint64_t request_id);
+    dsd_trunk_tune_result (*return_to_cc_request)(dsd_opts* opts, dsd_state* state, uint64_t request_id);
 } dsd_trunk_tuning_hooks;
 
 void dsd_trunk_tuning_hooks_set(dsd_trunk_tuning_hooks hooks);
 
 /**
- * @brief Return the generation of accepted trunk-tuning changes.
+ * @brief Return the generation of completed trunk-tuning changes.
  *
  * Frame decoders can snapshot this value before collecting a frame and verify
  * it again before dispatch, preventing work from an earlier trunk target from
  * mutating state restored for a newer target. Runtime hook wrappers and direct
- * trunk-scan retunes publish this generation.
+ * trunk-scan retunes publish this generation only after completion.
  */
 uint64_t dsd_trunk_tuning_generation(void);
 
 /**
- * @brief Advance the tuner generation after an accepted direct retune.
+ * @brief Advance the tuner generation after a completed direct retune.
  *
- * Hook wrappers do this automatically for successful and pending results.
- * Direct retune paths that do not pass through a hook wrapper must call this
- * once the tuner has accepted the request.
+ * Hook wrappers do this automatically for completed results. Direct retune
+ * paths that do not pass through a hook wrapper must call this only after the
+ * tuner and output pipeline have completed the request.
  */
 void dsd_trunk_tuning_generation_advance(void);
+
+/**
+ * @brief Begin a correlated tune transition and close the frame-dispatch gate.
+ *
+ * Hook wrappers call this automatically. Direct asynchronous tune paths may
+ * use the returned request ID to publish their exact completion later.
+ *
+ * @return Non-zero request ID for the new transition.
+ */
+uint64_t dsd_trunk_tuning_request_begin(void);
+
+/**
+ * @brief Publish backend completion for an exact tune transition.
+ *
+ * Successful completion commits the generation after the owner has marked its
+ * staged decoder state ready. A failed asynchronous completion remains gated
+ * until the owner rolls back the state or a newer successful tune replaces it.
+ *
+ * @param request_id Request ID returned by dsd_trunk_tuning_request_begin().
+ * @param result Terminal backend result; PENDING is ignored.
+ */
+void dsd_trunk_tuning_request_publish(uint64_t request_id, dsd_trunk_tune_result result);
+
+/**
+ * @brief Mark staged decoder state ready for asynchronous tune completion.
+ *
+ * A backend completion that races ahead of its requesting thread remains
+ * gated until this call confirms that the matching decoder state has been
+ * committed. Hook wrappers call this automatically for PENDING results.
+ *
+ * @param request_id Request ID returned by dsd_trunk_tuning_request_begin().
+ */
+void dsd_trunk_tuning_request_mark_ready(uint64_t request_id);
+
+/**
+ * @brief Publish the terminal result for an exact tune transition.
+ *
+ * A successful completion advances the completed generation exactly once.
+ * Failure normally clears the transition without publishing a completed
+ * generation; callers must first restore or replace any staged decoder state.
+ * A safety gate inherited from bounded-history recovery remains closed until a
+ * later successful tune. Stale and duplicate request IDs are ignored.
+ *
+ * @param request_id Request ID returned by dsd_trunk_tuning_request_begin().
+ * @param result Terminal result; PENDING is ignored.
+ */
+void dsd_trunk_tuning_request_complete(uint64_t request_id, dsd_trunk_tune_result result);
+
+/** @brief Return the newest unresolved request ID (in flight or awaiting recovery), or zero when ready. */
+uint64_t dsd_trunk_tuning_pending_request(void);
+
+/**
+ * @brief Query the correlated state of a tune request.
+ *
+ * @param request_id Request ID to query.
+ * @param out_completed_m Optional completed monotonic timestamp in seconds.
+ * @return PENDING while in flight or awaiting owner readiness, the terminal
+ *         result when known, or FAILED when the request is no longer retained.
+ */
+dsd_trunk_tune_result dsd_trunk_tuning_request_status(uint64_t request_id, double* out_completed_m);
+
+/**
+ * @brief Test whether a collected frame still belongs to a completed tune.
+ *
+ * Equal generations are deliberately rejected while any retune is pending.
+ */
+int dsd_trunk_tuning_frame_is_current(uint64_t frame_generation);
 
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
 dsd_trunk_tune_result dsd_trunk_tuning_hook_return_to_cc(dsd_opts* opts, dsd_state* state);
+dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_freq_with_id(dsd_opts* opts, dsd_state* state, long int freq,
+                                                                 int ted_sps, uint64_t* out_request_id);
+dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_cc_with_id(dsd_opts* opts, dsd_state* state, long int freq,
+                                                               int ted_sps, uint64_t* out_request_id);
+dsd_trunk_tune_result dsd_trunk_tuning_hook_return_to_cc_with_id(dsd_opts* opts, dsd_state* state,
+                                                                 uint64_t* out_request_id);
 
 static inline int
 dsd_trunk_tune_result_is_ok(dsd_trunk_tune_result result) {
     return result == DSD_TRUNK_TUNE_RESULT_OK || result == DSD_TRUNK_TUNE_RESULT_PENDING;
+}
+
+static inline int
+dsd_trunk_tune_result_is_complete(dsd_trunk_tune_result result) {
+    return result == DSD_TRUNK_TUNE_RESULT_OK;
 }
 
 #ifdef __cplusplus

--- a/include/dsd-neo/runtime/trunk_tuning_hooks.h
+++ b/include/dsd-neo/runtime/trunk_tuning_hooks.h
@@ -37,9 +37,12 @@ typedef struct {
     void (*tune_to_freq)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
     void (*tune_to_cc)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
     void (*return_to_cc)(dsd_opts* opts, dsd_state* state);
+    /* Legacy result hooks cannot receive a request ID. A PENDING result remains
+     * accepted but uncorrelated: it advances the generation without gating. */
     dsd_trunk_tune_result (*tune_to_freq_result)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
     dsd_trunk_tune_result (*tune_to_cc_result)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
     dsd_trunk_tune_result (*return_to_cc_result)(dsd_opts* opts, dsd_state* state);
+    /* Request-aware hooks must use request_id when publishing asynchronous completion. */
     dsd_trunk_tune_result (*tune_to_freq_request)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
                                                   uint64_t request_id);
     dsd_trunk_tune_result (*tune_to_cc_request)(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
@@ -50,12 +53,14 @@ typedef struct {
 void dsd_trunk_tuning_hooks_set(dsd_trunk_tuning_hooks hooks);
 
 /**
- * @brief Return the generation of completed trunk-tuning changes.
+ * @brief Return the generation of accepted trunk-tuning boundaries.
  *
  * Frame decoders can snapshot this value before collecting a frame and verify
  * it again before dispatch, preventing work from an earlier trunk target from
- * mutating state restored for a newer target. Runtime hook wrappers and direct
- * trunk-scan retunes publish this generation only after completion.
+ * mutating state restored for a newer target. Correlated hook wrappers and
+ * direct trunk-scan retunes publish this generation only after completion.
+ * Legacy result hooks also publish on an accepted PENDING result because they
+ * have no completion channel; those hooks remain deliberately ungated.
  */
 uint64_t dsd_trunk_tuning_generation(void);
 
@@ -77,6 +82,15 @@ void dsd_trunk_tuning_generation_advance(void);
  * @return Non-zero request ID for the new transition.
  */
 uint64_t dsd_trunk_tuning_request_begin(void);
+
+/**
+ * @brief Clear correlated request history at a quiescent runtime boundary.
+ *
+ * Engine lifecycle code calls this after the previous tuner backend has
+ * stopped and before a new decode run begins. Stale completion callbacks are
+ * ignored after the reset. Do not call while an active run owns tune requests.
+ */
+void dsd_trunk_tuning_requests_reset(void);
 
 /**
  * @brief Publish backend completion for an exact tune transition.
@@ -138,6 +152,7 @@ int dsd_trunk_tuning_frame_is_current(uint64_t frame_generation);
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps);
 dsd_trunk_tune_result dsd_trunk_tuning_hook_return_to_cc(dsd_opts* opts, dsd_state* state);
+/* The _with_id wrappers return zero when dispatching through a legacy result hook. */
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_freq_with_id(dsd_opts* opts, dsd_state* state, long int freq,
                                                                  int ted_sps, uint64_t* out_request_id);
 dsd_trunk_tune_result dsd_trunk_tuning_hook_tune_to_cc_with_id(dsd_opts* opts, dsd_state* state, long int freq,

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -1708,23 +1708,38 @@ try_manual_candidate_cycle(dsd_opts* opts, dsd_state* state) {
 
 static int
 apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
-    if (state->lcn_freq_count <= 0) {
+    const int lcn_capacity = (int)(sizeof(state->trunk_lcn_freq) / sizeof(state->trunk_lcn_freq[0]));
+    int count = state->lcn_freq_count;
+    if (count <= 0) {
         return UI_CMD_APPLY_COMPLETED;
+    }
+    if (count > lcn_capacity) {
+        count = lcn_capacity;
     }
 
     int next = state->lcn_freq_roll;
-    if (next < 0 || next >= state->lcn_freq_count) {
+    if (next < 0 || next >= count) {
         next = 0;
     }
-    if (next != 0 && state->trunk_lcn_freq[next - 1] == state->trunk_lcn_freq[next]) {
+    const int start = next;
+    long freq = 0;
+    for (int examined = 0; examined < count; examined++) {
+        freq = state->trunk_lcn_freq[next];
+        if (freq != 0 && (next == 0 || state->trunk_lcn_freq[next - 1] != freq)) {
+            break;
+        }
         next++;
-        if (next >= state->lcn_freq_count) {
+        if (next >= count) {
             next = 0;
         }
+        freq = 0;
     }
 
-    const long freq = state->trunk_lcn_freq[next];
     if (freq == 0) {
+        state->lcn_freq_roll = start + 1;
+        if (state->lcn_freq_roll >= count) {
+            state->lcn_freq_roll = 0;
+        }
         return UI_CMD_APPLY_COMPLETED;
     }
     if (!request_manual_tune(opts, state, freq, "Channel cycle")) {

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -291,6 +291,19 @@ ui_cmd_apply_status_from_service_rc(int rc) {
     return UI_CMD_APPLY_FAILED;
 }
 
+#ifdef USE_RADIO
+static int
+ui_cmd_apply_status_from_tune_rc(int rc) {
+    if (rc == RTL_STREAM_TUNE_TIMEOUT) {
+        /* The controller accepted the tune and will publish its terminal
+         * result after the synchronous wait expires. Command completion here
+         * means the request was accepted, not that hardware already moved. */
+        return UI_CMD_APPLY_COMPLETED;
+    }
+    return ui_cmd_apply_status_from_service_rc(rc);
+}
+#endif
+
 struct UiVisibilityToggleSpec {
     int cmd_id;
     size_t opts_offset;
@@ -1012,9 +1025,11 @@ ui_cmd_handle_rtl_set_freq(dsd_opts* opts, dsd_state* state, const struct dsd_ap
     int result = UI_CMD_APPLY_COMPLETED;
     if (state && ui_cmd_parse_u32_payload(c, &v)) {
         int rc = svc_rtl_set_freq(opts, state, v);
-        result = ui_cmd_apply_status_from_service_rc(rc);
+        result = ui_cmd_apply_status_from_tune_rc(rc);
         if (rc == 0) {
             ui_set_toast(state, 3, "Applied: RTL frequency -> %u Hz", v);
+        } else if (rc == RTL_STREAM_TUNE_TIMEOUT) {
+            ui_set_toast(state, 3, "Accepted: RTL frequency -> %u Hz (pending)", v);
         } else if (ui_rc_is_not_supported(rc)) {
             ui_set_toast(state, 3, "Unsupported: frequency control not available on active backend");
         } else {

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -3384,7 +3384,12 @@ apply_cmd_legacy_lockout_slot(dsd_opts* opts, dsd_state* state, const struct dsd
                     opts->group_in_file);
     }
 
-    return apply_lockout_decoder_transition(opts, state);
+    const int transition_status = apply_lockout_decoder_transition(opts, state);
+    if (transition_status == UI_CMD_APPLY_FAILED) {
+        LOG_WARNING("User lockout for TG %d was applied, but the return-to-CC cleanup tune was not accepted.\n", tg);
+        ui_set_toast(state, 4, "TG %d locked out; return-to-CC tune failed", tg);
+    }
+    return UI_CMD_APPLY_COMPLETED;
 }
 
 static int

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -1576,6 +1576,22 @@ current_cc_freq(const dsd_state* state) {
     return (state->trunk_cc_freq != 0) ? state->trunk_cc_freq : state->p25_cc_freq;
 }
 
+static int
+manual_tune_result_is_accepted(int result) {
+    return result == RTL_STREAM_TUNE_OK || result == RTL_STREAM_TUNE_TIMEOUT;
+}
+
+static int
+request_manual_tune(dsd_opts* opts, dsd_state* state, long int freq, const char* action) {
+    const int result = io_control_set_freq(opts, state, freq);
+    if (manual_tune_result_is_accepted(result)) {
+        return 1;
+    }
+    LOG_WARNING("%s tune to %ld Hz was not accepted (result=%d); preserving decoder state\n",
+                action ? action : "Manual", freq, result);
+    return 0;
+}
+
 static void
 reset_call_tracking(dsd_opts* opts, dsd_state* state, int clear_trunk_vc) {
     DSD_MEMSET(state->nxdn_sacch_frame_segment, 1, sizeof(state->nxdn_sacch_frame_segment));
@@ -1632,6 +1648,104 @@ mark_cc_sync(dsd_state* state, int include_monotonic) {
     if (include_monotonic) {
         state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
     }
+}
+
+static int
+apply_manual_return_to_cc(dsd_opts* opts, dsd_state* state) {
+    if (!state) {
+        return UI_CMD_APPLY_COMPLETED;
+    }
+    if (opts->p25_trunk != 1 || (state->trunk_cc_freq == 0 && state->p25_cc_freq == 0)) {
+        return UI_CMD_APPLY_COMPLETED;
+    }
+
+    const long freq = current_cc_freq(state);
+    if (!request_manual_tune(opts, state, freq, "Return-to-CC")) {
+        return UI_CMD_APPLY_FAILED;
+    }
+    reset_call_tracking(opts, state, 1);
+    mark_cc_sync(state, 1);
+    set_cc_symbol_timing(opts, state, 0);
+    LOG_INFO("User Activated Return to CC\n");
+    return UI_CMD_APPLY_COMPLETED;
+}
+
+static int
+apply_lockout_decoder_transition(dsd_opts* opts, dsd_state* state) {
+    long cc_freq = 0;
+    if (opts->p25_trunk == 1) {
+        cc_freq = current_cc_freq(state);
+        if (!request_manual_tune(opts, state, cc_freq, "Lockout return-to-CC")) {
+            return UI_CMD_APPLY_FAILED;
+        }
+    }
+
+    reset_call_tracking(opts, state, 1);
+    if (opts->p25_trunk == 1) {
+        noCarrier(opts, state);
+        state->trunk_cc_freq = cc_freq;
+    }
+    mark_cc_sync(state, 0);
+    set_cc_symbol_timing(opts, state, 1);
+    return UI_CMD_APPLY_COMPLETED;
+}
+
+static int
+try_manual_candidate_cycle(dsd_opts* opts, dsd_state* state) {
+    long cand = 0;
+    if (opts->p25_prefer_candidates != 1 || !p25_sm_next_cc_candidate(state, &cand)) {
+        return UI_CMD_APPLY_UNHANDLED;
+    }
+    if (!request_manual_tune(opts, state, cand, "Candidate cycle")) {
+        return UI_CMD_APPLY_FAILED;
+    }
+
+    reset_call_tracking(opts, state, 0);
+    LOG_INFO("Candidate Cycle: tuning to %.06lf MHz\n", (double)cand / 1000000);
+    mark_cc_sync(state, 1);
+    return UI_CMD_APPLY_COMPLETED;
+}
+
+static int
+apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
+    if (state->lcn_freq_count <= 0) {
+        return UI_CMD_APPLY_COMPLETED;
+    }
+
+    int next = state->lcn_freq_roll;
+    if (next < 0 || next >= state->lcn_freq_count) {
+        next = 0;
+    }
+    if (next != 0 && state->trunk_lcn_freq[next - 1] == state->trunk_lcn_freq[next]) {
+        next++;
+        if (next >= state->lcn_freq_count) {
+            next = 0;
+        }
+    }
+
+    const long freq = state->trunk_lcn_freq[next];
+    if (freq == 0) {
+        return UI_CMD_APPLY_COMPLETED;
+    }
+    if (!request_manual_tune(opts, state, freq, "Channel cycle")) {
+        return UI_CMD_APPLY_FAILED;
+    }
+
+    reset_call_tracking(opts, state, 0);
+    LOG_INFO("Channel Cycle: tuning to %.06lf MHz\n", (double)freq / 1000000);
+    state->lcn_freq_roll = next + 1;
+    mark_cc_sync(state, 1);
+    set_cc_symbol_timing(opts, state, 0);
+    return UI_CMD_APPLY_COMPLETED;
+}
+
+static int
+apply_manual_channel_cycle(dsd_opts* opts, dsd_state* state) {
+    const int candidate_status = try_manual_candidate_cycle(opts, state);
+    if (candidate_status != UI_CMD_APPLY_UNHANDLED) {
+        return candidate_status;
+    }
+    return apply_manual_lcn_cycle(opts, state);
 }
 
 #ifdef USE_RADIO
@@ -3179,18 +3293,7 @@ apply_cmd_legacy_trunk_controls(dsd_opts* opts, dsd_state* state, const struct d
                 ui_set_toast(state, 4, "Rigctl connect failed: %s:%d", opts->rigctlhostname, opts->rigctlportno);
             }
             return 1;
-        case DSD_APP_CMD_RETURN_CC:
-            if (!state) {
-                return 1;
-            }
-            if (opts->p25_trunk == 1 && (state->trunk_cc_freq != 0 || state->p25_cc_freq != 0)) {
-                reset_call_tracking(opts, state, 1);
-                io_control_set_freq(opts, state, current_cc_freq(state));
-                mark_cc_sync(state, 1);
-                set_cc_symbol_timing(opts, state, 0);
-                LOG_INFO("User Activated Return to CC\n");
-            }
-            return 1;
+        case DSD_APP_CMD_RETURN_CC: return apply_manual_return_to_cc(opts, state);
         case DSD_APP_CMD_SIM_NOCAR:
             if (!state) {
                 return 1;
@@ -3251,16 +3354,7 @@ apply_cmd_legacy_lockout_slot(dsd_opts* opts, dsd_state* state, const struct dsd
                     opts->group_in_file);
     }
 
-    reset_call_tracking(opts, state, 1);
-    if (opts->p25_trunk == 1) {
-        noCarrier(opts, state);
-        long f = current_cc_freq(state);
-        io_control_set_freq(opts, state, f);
-        state->trunk_cc_freq = f;
-    }
-    mark_cc_sync(state, 0);
-    set_cc_symbol_timing(opts, state, 1);
-    return 1;
+    return apply_lockout_decoder_transition(opts, state);
 }
 
 static int
@@ -3313,35 +3407,11 @@ apply_cmd_legacy_channel_cycle(dsd_opts* opts, dsd_state* state, const struct ds
     if (c->id != DSD_APP_CMD_CHANNEL_CYCLE) {
         return 0;
     }
+    if (!state) {
+        return 1;
+    }
     if (opts->use_rigctl == 1 || opts->audio_in_type == AUDIO_IN_RTL) {
-        reset_call_tracking(opts, state, 0);
-        if (opts->p25_prefer_candidates == 1) {
-            long cand = 0;
-            if (p25_sm_next_cc_candidate(state, &cand)) {
-                io_control_set_freq(opts, state, cand);
-                LOG_INFO("Candidate Cycle: tuning to %.06lf MHz\n", (double)cand / 1000000);
-                mark_cc_sync(state, 1);
-                return 1;
-            }
-        }
-        if (state->lcn_freq_roll >= state->lcn_freq_count) {
-            state->lcn_freq_roll = 0;
-        }
-        if (state->lcn_freq_roll != 0
-            && state->trunk_lcn_freq[state->lcn_freq_roll - 1] == state->trunk_lcn_freq[state->lcn_freq_roll]) {
-            state->lcn_freq_roll++;
-            if (state->lcn_freq_roll >= state->lcn_freq_count) {
-                state->lcn_freq_roll = 0;
-            }
-        }
-        if (state->trunk_lcn_freq[state->lcn_freq_roll] != 0) {
-            io_control_set_freq(opts, state, state->trunk_lcn_freq[state->lcn_freq_roll]);
-            LOG_INFO("Channel Cycle: tuning to %.06lf MHz\n",
-                     (double)state->trunk_lcn_freq[state->lcn_freq_roll] / 1000000);
-        }
-        state->lcn_freq_roll++;
-        mark_cc_sync(state, 1);
-        set_cc_symbol_timing(opts, state, 0);
+        return apply_manual_channel_cycle(opts, state);
     }
     return 1;
 }

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -1690,7 +1690,7 @@ apply_lockout_decoder_transition(dsd_opts* opts, dsd_state* state) {
     long cc_freq = 0;
     if (opts->p25_trunk == 1) {
         cc_freq = current_cc_freq(state);
-        if (!request_manual_tune(opts, state, cc_freq, "Lockout return-to-CC")) {
+        if (cc_freq != 0 && !request_manual_tune(opts, state, cc_freq, "Lockout return-to-CC")) {
             return UI_CMD_APPLY_FAILED;
         }
     }

--- a/src/app_control/menu_services.c
+++ b/src/app_control/menu_services.c
@@ -19,6 +19,7 @@
 #include <dsd-neo/io/udp_socket_connect.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/log.h>
 #include <stdint.h>
@@ -629,6 +630,13 @@ svc_rtl_restart(dsd_opts* opts, dsd_state* state) {
     if (!opts || !state) {
         return -1;
     }
+    int result = 0;
+
+    /* Tagged P25 retunes hold this guard through their synchronous wait and
+     * orchestrator bookkeeping. Quiesce them before destroying the stream's
+     * wait primitives or replacing the context they use. */
+    p25_sm_tick_guard_enter();
+
     /* Stop and destroy any existing stream context. */
     if (state->rtl_ctx) {
         rtl_stream_soft_stop(state->rtl_ctx);
@@ -642,17 +650,22 @@ svc_rtl_restart(dsd_opts* opts, dsd_state* state) {
        so changes take effect as soon as the user confirms the setting. */
     if (opts->audio_in_type == AUDIO_IN_RTL) {
         if (rtl_stream_create_mirrored(opts, &state->rtl_ctx) < 0) {
-            return -1;
+            result = -1;
+            goto done;
         }
         if (rtl_stream_start(state->rtl_ctx) < 0) {
             rtl_stream_destroy(state->rtl_ctx);
             state->rtl_ctx = NULL;
-            return -1;
+            result = -1;
+            goto done;
         }
         opts->rtl_started = 1;
         opts->rtl_needs_restart = 0;
     }
-    return 0;
+
+done:
+    p25_sm_tick_guard_leave();
+    return result;
 }
 
 int

--- a/src/core/time/dsd_time_state.c
+++ b/src/core/time/dsd_time_state.c
@@ -34,6 +34,8 @@ dsd_clear_cc_sync(dsd_state* state) {
     }
     state->last_cc_sync_time = 0;
     state->last_cc_sync_time_m = 0.0;
+    state->p25_last_cc_msg_time = 0;
+    state->p25_last_cc_msg_time_m = 0.0;
 }
 
 void

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -917,6 +917,8 @@ init_state_p25_and_trunk_defaults(dsd_state* state) {
 
     //values displayed in ncurses terminal
     state->p25_cc_freq = 0;
+    state->p25_last_cc_msg_time = 0;
+    state->p25_last_cc_msg_time_m = 0.0;
     state->p25_vc_freq[0] = 0;
     state->p25_vc_freq[1] = 0;
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -84,6 +84,9 @@ void codec2_destroy(struct CODEC2* codec2_state);
 // Local caches to avoid redundant device I/O in hot paths
 static long int s_last_rigctl_freq = -1;
 static int s_last_rigctl_bw = -12345;
+static uint64_t s_no_carrier_generic_recovery_request_id = 0U;
+static const dsd_state* s_no_carrier_generic_recovery_state = NULL;
+static long s_no_carrier_generic_recovery_cc = 0;
 #ifdef USE_RADIO
 static uint32_t s_last_rtl_freq = 0;
 #endif
@@ -92,6 +95,10 @@ static void
 reset_device_io_caches(void) {
     s_last_rigctl_freq = -1;
     s_last_rigctl_bw = -12345;
+    s_no_carrier_generic_recovery_request_id = 0U;
+    s_no_carrier_generic_recovery_state = NULL;
+    s_no_carrier_generic_recovery_cc = 0;
+    dsd_trunk_tuning_requests_reset();
 #ifdef USE_RADIO
     s_last_rtl_freq = 0;
 #endif
@@ -1476,6 +1483,14 @@ no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, in
     }
 
     *helper_attempted = 1;
+    if (!p25_sm_tick_guard_try_enter()) {
+        if (helper_result) {
+            *helper_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+        }
+        return 0;
+    }
+    /* The watchdog owns this same context. Keep the selected CC, tagged retune,
+     * and request handoff atomic even when the tuner wait blocks. */
     const long old_p25_cc_freq = state->p25_cc_freq;
     const long old_trunk_cc_freq = state->trunk_cc_freq;
     no_carrier_sync_selected_control_channel(state, cc, p25_return, clear_generic_p25_alias);
@@ -1500,13 +1515,95 @@ no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, in
             state->p25_cc_freq = old_p25_cc_freq;
             state->trunk_cc_freq = old_trunk_cc_freq;
         }
+        p25_sm_tick_guard_leave();
         return 0;
     }
 
     no_carrier_sync_helper_tune_cache(opts, state, cc);
     state->edacs_tuned_lcn = -1;
     state->dmr_rest_channel = -1;
+    p25_sm_tick_guard_leave();
     return 1;
+}
+
+static int
+no_carrier_accept_generic_gate_recovery(const dsd_opts* opts, dsd_state* state, long cc) {
+    s_no_carrier_generic_recovery_request_id = 0U;
+    s_no_carrier_generic_recovery_state = NULL;
+    s_no_carrier_generic_recovery_cc = 0;
+    no_carrier_sync_helper_tune_cache(opts, state, cc);
+    state->edacs_tuned_lcn = -1;
+    state->dmr_rest_channel = -1;
+    return 1;
+}
+
+static int
+no_carrier_try_generic_gate_recovery(dsd_opts* opts, dsd_state* state, long cc, int p25_return,
+                                     int clear_generic_p25_alias, int* helper_attempted) {
+    if (p25_return) {
+        return 0;
+    }
+
+    if (s_no_carrier_generic_recovery_request_id != 0U) {
+        const dsd_trunk_tune_result status =
+            dsd_trunk_tuning_request_status(s_no_carrier_generic_recovery_request_id, NULL);
+        *helper_attempted = 1;
+        if (status == DSD_TRUNK_TUNE_RESULT_PENDING) {
+            return 0;
+        }
+        const uint64_t unresolved_request_id = dsd_trunk_tuning_pending_request();
+        if (unresolved_request_id == 0U) {
+            if (s_no_carrier_generic_recovery_state == state && s_no_carrier_generic_recovery_cc == cc) {
+                return no_carrier_accept_generic_gate_recovery(opts, state, cc);
+            }
+            /* The old target completed, but decoder ownership moved while it
+             * was in flight. Establish a fresh boundary for the current CC. */
+        }
+        if (unresolved_request_id != 0U
+            && dsd_trunk_tuning_request_status(unresolved_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_PENDING) {
+            return 0;
+        }
+    } else {
+        const uint64_t unresolved_request_id = dsd_trunk_tuning_pending_request();
+        if (unresolved_request_id == 0U) {
+            return 0;
+        }
+        *helper_attempted = 1;
+        if (dsd_trunk_tuning_request_status(unresolved_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_PENDING) {
+            /* Do not replace correlated work with an untagged legacy return.
+             * Its completion will either open the gate or make this path retry
+             * with a newer correlated request. */
+            return 0;
+        }
+    }
+
+    *helper_attempted = 1;
+    const int old_p25_is_tuned = opts->p25_is_tuned;
+    const int old_trunk_is_tuned = opts->trunk_is_tuned;
+    const long old_p25_cc_freq = state->p25_cc_freq;
+    const long old_trunk_cc_freq = state->trunk_cc_freq;
+    no_carrier_sync_selected_control_channel(state, cc, 0, clear_generic_p25_alias);
+
+    uint64_t tune_request_id = 0U;
+    const dsd_trunk_tune_result tune_result = no_carrier_return_to_cc_correlated(opts, state, &tune_request_id);
+    s_no_carrier_generic_recovery_request_id = tune_request_id;
+    s_no_carrier_generic_recovery_state = state;
+    s_no_carrier_generic_recovery_cc = cc;
+    if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        opts->p25_is_tuned = old_p25_is_tuned;
+        opts->trunk_is_tuned = old_trunk_is_tuned;
+        no_carrier_sync_helper_tune_cache(opts, state, cc);
+        return 0;
+    }
+    if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+        if (tune_result != DSD_TRUNK_TUNE_RESULT_DEFERRED) {
+            state->p25_cc_freq = old_p25_cc_freq;
+            state->trunk_cc_freq = old_trunk_cc_freq;
+        }
+        return 0;
+    }
+
+    return no_carrier_accept_generic_gate_recovery(opts, state, cc);
 }
 
 static int
@@ -1597,11 +1694,19 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
     if (cc != 0) {
         int p25_helper_attempted = 0;
         dsd_trunk_tune_result p25_helper_result = DSD_TRUNK_TUNE_RESULT_OK;
+        int generic_helper_attempted = 0;
         if (no_carrier_try_helper_return_to_cc(opts, state, cc, p25_return, clear_generic_p25_alias,
                                                &p25_helper_attempted, &p25_helper_result)) {
             no_carrier_enable_p25_cc_slots_if_known(opts, state);
             accepted_cc_return = 1;
-        } else if (no_carrier_apply_legacy_cc_return(opts, state, cc, p25_helper_attempted)) {
+        } else if (no_carrier_helper_result_is_deferred(p25_helper_attempted, p25_helper_result)) {
+            /* Another P25 transition owns the guard; leave the staged
+             * voice state intact so the main loop can retry safely. */
+        } else if (no_carrier_try_generic_gate_recovery(opts, state, cc, p25_return, clear_generic_p25_alias,
+                                                        &generic_helper_attempted)) {
+            accepted_cc_return = 1;
+        } else if (!generic_helper_attempted
+                   && no_carrier_apply_legacy_cc_return(opts, state, cc, p25_helper_attempted)) {
             no_carrier_sync_selected_control_channel(state, cc, p25_return, clear_generic_p25_alias);
             accepted_cc_return = 1;
             state->edacs_tuned_lcn = -1;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2026,6 +2026,14 @@ no_carrier_reset_p25_metrics_and_cache(dsd_state* state) {
 }
 
 static void
+no_carrier_retire_inactive_tune_failures(const dsd_opts* opts) {
+    if (!opts || opts->p25_trunk == 1 || opts->trunk_enable == 1 || opts->trunk_scan_enabled == 1) {
+        return;
+    }
+    dsd_trunk_tuning_retire_failed_requests();
+}
+
+static void
 no_carrier_clear_stale_follow_state_if_needed(dsd_opts* opts, dsd_state* state, time_t now) {
     const int trunking_enabled = (opts->p25_trunk == 1 || opts->trunk_enable == 1) ? 1 : 0;
     const int voice_tuned = (opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1) ? 1 : 0;
@@ -2138,6 +2146,8 @@ no_carrier_reset_m17_and_sample_buffers(dsd_state* state) {
 void
 noCarrier(dsd_opts* opts, dsd_state* state) {
     const time_t now = time(NULL);
+
+    no_carrier_retire_inactive_tune_failures(opts);
 
 #ifdef USE_RADIO
     maybe_request_rtl_fsk_reacquire_on_no_sync(opts, state, now);

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2142,10 +2142,14 @@ live_scanner_update_thresholds(dsd_state* state, int* last_max, int* last_min) {
 }
 
 static void
-live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_max, int* last_min) {
+live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_max, int* last_min,
+                                   uint64_t* frame_tune_generation) {
     while (state->synctype != DSD_SYNC_NONE) {
-        dsd_runtime_pump_controls(opts, state);
-        processFrame(opts, state);
+        p25_sm_tick_guard_enter();
+        if (!frame_tune_generation || *frame_tune_generation == dsd_trunk_tuning_generation()) {
+            processFrame(opts, state);
+        }
+        p25_sm_tick_guard_leave();
         dsd_trunk_scan_hook_tick(opts, state);
 
 #ifdef TRACE_DSD
@@ -2153,6 +2157,9 @@ live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_m
 #endif
 
         dsd_runtime_pump_controls(opts, state);
+        if (frame_tune_generation) {
+            *frame_tune_generation = dsd_trunk_tuning_generation();
+        }
         state->synctype = getFrameSync(opts, state);
         live_scanner_update_thresholds(state, last_max, last_min);
     }
@@ -2162,6 +2169,7 @@ static void
 live_scanner_main_loop(dsd_opts* opts, dsd_state* state) {
     int last_max = INT_MIN;
     int last_min = INT_MAX;
+    uint64_t frame_tune_generation;
 
     while (!exitflag) {
         dsd_runtime_pump_controls(opts, state);
@@ -2170,9 +2178,10 @@ live_scanner_main_loop(dsd_opts* opts, dsd_state* state) {
         dsd_runtime_pump_controls(opts, state);
 
         noCarrier(opts, state);
+        frame_tune_generation = dsd_trunk_tuning_generation();
         state->synctype = getFrameSync(opts, state);
         live_scanner_update_thresholds(state, &last_max, &last_min);
-        live_scanner_process_synced_frames(opts, state, &last_max, &last_min);
+        live_scanner_process_synced_frames(opts, state, &last_max, &last_min, &frame_tune_generation);
     }
 }
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2025,12 +2025,16 @@ no_carrier_reset_p25_metrics_and_cache(dsd_state* state) {
     no_carrier_reset_p25_cc_cache(state);
 }
 
+static int
+engine_trunk_tuning_owner_active(const dsd_opts* opts) {
+    return opts && (opts->p25_trunk == 1 || opts->trunk_enable == 1 || opts->trunk_scan_enabled == 1);
+}
+
 static void
 no_carrier_retire_inactive_tune_failures(const dsd_opts* opts) {
-    if (!opts || opts->p25_trunk == 1 || opts->trunk_enable == 1 || opts->trunk_scan_enabled == 1) {
-        return;
+    if (!engine_trunk_tuning_owner_active(opts)) {
+        dsd_trunk_tuning_retire_failed_requests();
     }
-    dsd_trunk_tuning_retire_failed_requests();
 }
 
 static void
@@ -2312,7 +2316,11 @@ live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_m
                                    uint64_t* frame_tune_generation) {
     while (state->synctype != DSD_SYNC_NONE) {
         p25_sm_tick_guard_enter();
-        if (!frame_tune_generation || dsd_trunk_tuning_frame_is_current(*frame_tune_generation)) {
+        const uint64_t dispatch_generation =
+            frame_tune_generation ? *frame_tune_generation : dsd_trunk_tuning_generation();
+        const int frame_dispatchable =
+            dsd_trunk_tuning_frame_is_dispatchable(dispatch_generation, engine_trunk_tuning_owner_active(opts));
+        if (!frame_tune_generation || frame_dispatchable) {
             processFrame(opts, state);
         }
         p25_sm_tick_guard_leave();

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1235,22 +1235,22 @@ no_carrier_tune_rigctl_if_needed(const dsd_opts* opts, long int freq) {
     }
 }
 
-static void
-no_carrier_tune_rtl_if_needed(const dsd_opts* opts, dsd_state* state, uint32_t rf) {
 #ifdef USE_RADIO
+static int
+no_carrier_tune_rtl_if_needed(const dsd_opts* opts, dsd_state* state, uint32_t rf) {
     if (opts->audio_in_type != AUDIO_IN_RTL || !state->rtl_ctx) {
-        return;
+        return 1;
     }
     if (rf != s_last_rtl_freq) {
-        rtl_stream_tune(state->rtl_ctx, rf);
+        int tune_result = rtl_stream_tune(state->rtl_ctx, rf);
+        if (tune_result == RTL_STREAM_TUNE_DEFERRED) {
+            return 0;
+        }
         s_last_rtl_freq = rf;
     }
-#else
-    UNUSED(opts);
-    UNUSED(state);
-    UNUSED(rf);
-#endif
+    return 1;
 }
+#endif
 
 static void
 no_carrier_step_scanner_mode_if_needed(const dsd_opts* opts, dsd_state* state, time_t now) {
@@ -1267,7 +1267,11 @@ no_carrier_step_scanner_mode_if_needed(const dsd_opts* opts, dsd_state* state, t
     if (freq != 0) {
         no_carrier_tune_rigctl_if_needed(opts, freq);
         if (opts->audio_in_type == AUDIO_IN_RTL) {
-            no_carrier_tune_rtl_if_needed(opts, state, (uint32_t)freq);
+#ifdef USE_RADIO
+            if (!no_carrier_tune_rtl_if_needed(opts, state, (uint32_t)freq)) {
+                return;
+            }
+#endif
         }
     }
     state->lcn_freq_roll++;
@@ -1620,8 +1624,10 @@ no_carrier_apply_legacy_cc_return(const dsd_opts* opts, dsd_state* state, long c
     }
     if (opts->audio_in_type == AUDIO_IN_RTL) {
         if (!helper_attempted) {
-            no_carrier_tune_rtl_if_needed(opts, state, (uint32_t)cc);
 #ifdef USE_RADIO
+            if (!no_carrier_tune_rtl_if_needed(opts, state, (uint32_t)cc)) {
+                return 0;
+            }
             state->dmr_rest_channel = -1;
 #endif
             return 1;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1557,11 +1557,12 @@ no_carrier_try_generic_gate_recovery(dsd_opts* opts, dsd_state* state, long cc, 
         }
         const uint64_t unresolved_request_id = dsd_trunk_tuning_pending_request();
         if (unresolved_request_id == 0U) {
-            if (s_no_carrier_generic_recovery_state == state && s_no_carrier_generic_recovery_cc == cc) {
+            if (status == DSD_TRUNK_TUNE_RESULT_OK && s_no_carrier_generic_recovery_state == state
+                && s_no_carrier_generic_recovery_cc == cc) {
                 return no_carrier_accept_generic_gate_recovery(opts, state, cc);
             }
-            /* The old target completed, but decoder ownership moved while it
-             * was in flight. Establish a fresh boundary for the current CC. */
+            /* The old target failed or decoder ownership moved while it was
+             * in flight. Establish a fresh boundary for the current CC. */
         }
         if (unresolved_request_id != 0U
             && dsd_trunk_tuning_request_status(unresolved_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_PENDING) {

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1444,6 +1444,26 @@ no_carrier_clear_voice_tune_state(dsd_opts* opts, dsd_state* state) {
     state->p25_call_is_packet[1] = 0;
 }
 
+static dsd_trunk_tune_result
+no_carrier_return_to_cc_correlated(dsd_opts* opts, dsd_state* state, uint64_t* out_request_id) {
+    const uint64_t request_id = dsd_trunk_tuning_request_begin();
+    if (out_request_id) {
+        *out_request_id = request_id;
+    }
+    if (request_id == 0U) {
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
+    }
+
+    dsd_trunk_tune_result result = dsd_engine_return_to_cc_request(opts, state, request_id);
+    if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        dsd_trunk_tuning_request_mark_ready(request_id);
+        dsd_trunk_tune_result status = dsd_trunk_tuning_request_status(request_id, NULL);
+        return status == DSD_TRUNK_TUNE_RESULT_OK ? status : result;
+    }
+    dsd_trunk_tuning_request_complete(request_id, result);
+    return dsd_trunk_tuning_request_status(request_id, NULL);
+}
+
 static int
 no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, int p25_return,
                                    int clear_generic_p25_alias, int* helper_attempted,
@@ -1460,7 +1480,18 @@ no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, in
     const long old_trunk_cc_freq = state->trunk_cc_freq;
     no_carrier_sync_selected_control_channel(state, cc, p25_return, clear_generic_p25_alias);
 
-    dsd_trunk_tune_result tune_result = dsd_engine_return_to_cc(opts, state);
+    uint64_t tune_request_id = 0U;
+    dsd_trunk_tune_result tune_result = no_carrier_return_to_cc_correlated(opts, state, &tune_request_id);
+    if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        (void)p25_sm_await_pending_cc_tune(p25_sm_get_ctx(), opts, state, tune_request_id, "no-carrier");
+    } else if (tune_result == DSD_TRUNK_TUNE_RESULT_OK) {
+        double completed_m = 0.0;
+        (void)dsd_trunk_tuning_request_status(tune_request_id, &completed_m);
+        if (completed_m <= 0.0) {
+            completed_m = dsd_time_now_monotonic_s();
+        }
+        (void)p25_sm_restart_pending_cc_acquisition(p25_sm_get_ctx(), opts, state, completed_m, "no-carrier");
+    }
     if (helper_result) {
         *helper_result = tune_result;
     }
@@ -2146,7 +2177,7 @@ live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_m
                                    uint64_t* frame_tune_generation) {
     while (state->synctype != DSD_SYNC_NONE) {
         p25_sm_tick_guard_enter();
-        if (!frame_tune_generation || *frame_tune_generation == dsd_trunk_tuning_generation()) {
+        if (!frame_tune_generation || dsd_trunk_tuning_frame_is_current(*frame_tune_generation)) {
             processFrame(opts, state);
         }
         p25_sm_tick_guard_leave();

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -85,6 +85,7 @@ void codec2_destroy(struct CODEC2* codec2_state);
 static long int s_last_rigctl_freq = -1;
 static int s_last_rigctl_bw = -12345;
 static uint64_t s_no_carrier_generic_recovery_request_id = 0U;
+static uint64_t s_no_carrier_generic_recovery_expected_generation = 0U;
 static const dsd_state* s_no_carrier_generic_recovery_state = NULL;
 static long s_no_carrier_generic_recovery_cc = 0;
 #ifdef USE_RADIO
@@ -92,12 +93,18 @@ static uint32_t s_last_rtl_freq = 0;
 #endif
 
 static void
+no_carrier_clear_generic_recovery_tracking(void) {
+    s_no_carrier_generic_recovery_request_id = 0U;
+    s_no_carrier_generic_recovery_expected_generation = 0U;
+    s_no_carrier_generic_recovery_state = NULL;
+    s_no_carrier_generic_recovery_cc = 0;
+}
+
+static void
 reset_device_io_caches(void) {
     s_last_rigctl_freq = -1;
     s_last_rigctl_bw = -12345;
-    s_no_carrier_generic_recovery_request_id = 0U;
-    s_no_carrier_generic_recovery_state = NULL;
-    s_no_carrier_generic_recovery_cc = 0;
+    no_carrier_clear_generic_recovery_tracking();
     dsd_trunk_tuning_requests_reset();
 #ifdef USE_RADIO
     s_last_rtl_freq = 0;
@@ -1531,10 +1538,15 @@ no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, in
 }
 
 static int
+no_carrier_generic_recovery_is_current(const dsd_state* state, long cc, dsd_trunk_tune_result status) {
+    return status == DSD_TRUNK_TUNE_RESULT_OK && s_no_carrier_generic_recovery_state == state
+           && s_no_carrier_generic_recovery_cc == cc
+           && s_no_carrier_generic_recovery_expected_generation == dsd_trunk_tuning_generation();
+}
+
+static int
 no_carrier_accept_generic_gate_recovery(const dsd_opts* opts, dsd_state* state, long cc) {
-    s_no_carrier_generic_recovery_request_id = 0U;
-    s_no_carrier_generic_recovery_state = NULL;
-    s_no_carrier_generic_recovery_cc = 0;
+    no_carrier_clear_generic_recovery_tracking();
     no_carrier_sync_helper_tune_cache(opts, state, cc);
     state->edacs_tuned_lcn = -1;
     state->dmr_rest_channel = -1;
@@ -1557,12 +1569,11 @@ no_carrier_try_generic_gate_recovery(dsd_opts* opts, dsd_state* state, long cc, 
         }
         const uint64_t unresolved_request_id = dsd_trunk_tuning_pending_request();
         if (unresolved_request_id == 0U) {
-            if (status == DSD_TRUNK_TUNE_RESULT_OK && s_no_carrier_generic_recovery_state == state
-                && s_no_carrier_generic_recovery_cc == cc) {
+            if (no_carrier_generic_recovery_is_current(state, cc, status)) {
                 return no_carrier_accept_generic_gate_recovery(opts, state, cc);
             }
-            /* The old target failed or decoder ownership moved while it was
-             * in flight. Establish a fresh boundary for the current CC. */
+            /* The old target failed, changed, or was superseded by a newer
+             * completed tune. Establish a fresh boundary for the current CC. */
         }
         if (unresolved_request_id != 0U
             && dsd_trunk_tuning_request_status(unresolved_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_PENDING) {
@@ -1589,9 +1600,11 @@ no_carrier_try_generic_gate_recovery(dsd_opts* opts, dsd_state* state, long cc, 
     const long old_trunk_cc_freq = state->trunk_cc_freq;
     no_carrier_sync_selected_control_channel(state, cc, 0, clear_generic_p25_alias);
 
+    const uint64_t tune_generation = dsd_trunk_tuning_generation();
     uint64_t tune_request_id = 0U;
     const dsd_trunk_tune_result tune_result = no_carrier_return_to_cc_correlated(opts, state, &tune_request_id);
     s_no_carrier_generic_recovery_request_id = tune_request_id;
+    s_no_carrier_generic_recovery_expected_generation = tune_request_id != 0U ? tune_generation + 1U : 0U;
     s_no_carrier_generic_recovery_state = state;
     s_no_carrier_generic_recovery_cc = cc;
     if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING) {

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -1542,6 +1542,11 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
         return -1;
     }
 
+    if (rt->target.type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
+        // A parked pending context predates this physical retune. Restart it in
+        // ON_CC so the acquisition watchdog honors the refreshed grace period.
+        (void)p25_sm_restart_pending_cc_acquisition(&rt->p25_ctx, opts, state, trunk_scan_now_m(), "scan-retune");
+    }
     rt->retry_until_m = 0.0;
     LOG_NOTICE("Trunk scan target '%s' at %ld Hz\n", rt->target.id, trunk_scan_retune_freq(state, &rt->target));
     return 0;

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -1698,23 +1698,68 @@ trunk_scan_tick_active_target_sm(dsd_opts* opts, dsd_state* state, dsd_trunk_sca
     }
 }
 
+/* Return 1 when the P25 SM already recovered, 0 while it still owns recovery,
+ * and -1 when no P25 recovery superseded the failed coordinator request. */
+static int
+trunk_scan_reconcile_p25_retune_recovery(dsd_trunk_scan_target_runtime* rt, uint64_t failed_request_id) {
+    if (!rt || rt->target.type != DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
+        return -1;
+    }
+
+    if (rt->p25_ctx.cc_tune_pending) {
+        const uint64_t sm_request_id = rt->p25_ctx.cc_tune_request_id;
+        if (sm_request_id == failed_request_id) {
+            /* The coordinator observed the backend result first. Leave the
+             * request with the P25 SM so its next tick owns recovery. */
+            return 0;
+        }
+        if (sm_request_id > failed_request_id) {
+            rt->tune_request_id = sm_request_id;
+            rt->tune_pending = 1;
+            LOG_INFO("Trunk scan target '%s' adopted P25 recovery retune request %llu\n", rt->target.id,
+                     (unsigned long long)sm_request_id);
+            return 0;
+        }
+    }
+
+    const p25_sm_state_e sm_state = p25_sm_get_state(&rt->p25_ctx);
+    if (sm_state == P25_SM_ON_CC || sm_state == P25_SM_TUNED) {
+        /* A replacement tune completed synchronously (or was decoded and
+         * followed) before the coordinator revisited the failed request. */
+        rt->tune_request_id = 0U;
+        rt->tune_pending = 0;
+        rt->retry_until_m = 0.0;
+        rt->idle_since_m = -1.0;
+        return 1;
+    }
+    return -1;
+}
+
 static int
 trunk_scan_resolve_pending_retune(dsd_state* state, dsd_trunk_scan_target_runtime* rt, double now_m) {
     if (!rt || !rt->tune_pending) {
         return 1;
     }
-    dsd_trunk_tune_result result = dsd_trunk_tuning_request_status(rt->tune_request_id, NULL);
+    const uint64_t request_id = rt->tune_request_id;
+    dsd_trunk_tune_result result = dsd_trunk_tuning_request_status(request_id, NULL);
     if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
         return 0;
     }
 
-    rt->tune_request_id = 0U;
-    rt->tune_pending = 0;
     if (result == DSD_TRUNK_TUNE_RESULT_OK) {
+        rt->tune_request_id = 0U;
+        rt->tune_pending = 0;
         rt->idle_since_m = -1.0;
         return 1;
     }
 
+    const int p25_recovery = trunk_scan_reconcile_p25_retune_recovery(rt, request_id);
+    if (p25_recovery >= 0) {
+        return p25_recovery;
+    }
+
+    rt->tune_request_id = 0U;
+    rt->tune_pending = 0;
     rt->retry_until_m = now_m + 2.0;
     LOG_WARNING("Trunk scan target '%s' asynchronous retune failed; cooling down briefly\n", rt->target.id);
     (void)state;

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -185,6 +185,8 @@ typedef struct {
     double idle_since_m;
     double retry_until_m;
     double last_allowed_activity_m;
+    uint64_t tune_request_id;
+    int tune_pending;
 } dsd_trunk_scan_target_runtime;
 
 typedef struct {
@@ -1501,19 +1503,25 @@ trunk_scan_retune_freq(const dsd_state* state, const dsd_trunk_scan_target* targ
 }
 
 static dsd_trunk_tune_result
-trunk_scan_retune_active(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_target_runtime* rt) {
+trunk_scan_retune_active(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_target_runtime* rt,
+                         uint64_t* out_request_id) {
+    if (out_request_id) {
+        *out_request_id = 0U;
+    }
     const long int freq = trunk_scan_retune_freq(state, &rt->target);
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
         state->p25_cc_freq = freq;
         state->trunk_cc_freq = freq;
-        return dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, trunk_scan_p25_cc_sps(opts, state));
+        return dsd_trunk_tuning_hook_tune_to_cc_with_id(opts, state, freq, trunk_scan_p25_cc_sps(opts, state),
+                                                        out_request_id);
     }
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK) {
         state->p25_cc_freq = 0;
         state->trunk_cc_freq = freq;
-        return dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, trunk_scan_dmr_sps(opts, state));
+        return dsd_trunk_tuning_hook_tune_to_cc_with_id(opts, state, freq, trunk_scan_dmr_sps(opts, state),
+                                                        out_request_id);
     }
-    return dsd_engine_scan_tune_to_freq(opts, state, freq, trunk_scan_dmr_sps(opts, state));
+    return dsd_engine_scan_tune_to_freq_with_id(opts, state, freq, trunk_scan_dmr_sps(opts, state), out_request_id);
 }
 
 static int
@@ -1535,7 +1543,8 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
     double now_m = trunk_scan_now_m();
     rt->parked_since_m = now_m;
     rt->idle_since_m = now_m;
-    dsd_trunk_tune_result tune_result = trunk_scan_retune_active(opts, state, rt);
+    uint64_t tune_request_id = 0U;
+    dsd_trunk_tune_result tune_result = trunk_scan_retune_active(opts, state, rt, &tune_request_id);
     if (!dsd_trunk_tune_result_is_ok(tune_result)) {
         rt->retry_until_m = now_m + 2.0;
         LOG_WARNING("Trunk scan target '%s' retune failed; cooling down briefly\n", rt->target.id);
@@ -1543,9 +1552,22 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
     }
 
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
-        // A parked pending context predates this physical retune. Restart it in
-        // ON_CC so the acquisition watchdog honors the refreshed grace period.
-        (void)p25_sm_restart_pending_cc_acquisition(&rt->p25_ctx, opts, state, trunk_scan_now_m(), "scan-retune");
+        if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+            (void)p25_sm_await_pending_cc_tune(&rt->p25_ctx, opts, state, tune_request_id, "scan-retune");
+        } else {
+            double completed_m = 0.0;
+            (void)dsd_trunk_tuning_request_status(tune_request_id, &completed_m);
+            if (completed_m <= 0.0) {
+                completed_m = trunk_scan_now_m();
+            }
+            (void)p25_sm_restart_pending_cc_acquisition(&rt->p25_ctx, opts, state, completed_m, "scan-retune");
+        }
+    } else if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        rt->tune_request_id = tune_request_id;
+        rt->tune_pending = 1;
+    } else {
+        rt->tune_request_id = 0U;
+        rt->tune_pending = 0;
     }
     rt->retry_until_m = 0.0;
     LOG_NOTICE("Trunk scan target '%s' at %ld Hz\n", rt->target.id, trunk_scan_retune_freq(state, &rt->target));
@@ -1603,8 +1625,12 @@ trunk_scan_retry_active_if_due(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_
 static int
 trunk_scan_active_is_held(const dsd_opts* opts, const dsd_trunk_scan_coord* coord) {
     const dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    if (rt->tune_pending) {
+        return 1;
+    }
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
-        return (opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1 || p25_sm_get_state(&rt->p25_ctx) == P25_SM_TUNED);
+        return (rt->p25_ctx.cc_tune_pending || opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1
+                || p25_sm_get_state(&rt->p25_ctx) == P25_SM_TUNED);
     }
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK) {
         return (opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1 || dmr_sm_get_state(&rt->dmr_ctx) == DMR_SM_TUNED);
@@ -1666,11 +1692,45 @@ trunk_scan_tick_active_target_sm(dsd_opts* opts, dsd_state* state, dsd_trunk_sca
     }
 }
 
+static int
+trunk_scan_resolve_pending_retune(dsd_state* state, dsd_trunk_scan_target_runtime* rt, double now_m) {
+    if (!rt || !rt->tune_pending) {
+        return 1;
+    }
+    dsd_trunk_tune_result result = dsd_trunk_tuning_request_status(rt->tune_request_id, NULL);
+    if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        return 0;
+    }
+
+    rt->tune_request_id = 0U;
+    rt->tune_pending = 0;
+    if (result == DSD_TRUNK_TUNE_RESULT_OK) {
+        rt->idle_since_m = -1.0;
+        return 1;
+    }
+
+    rt->retry_until_m = now_m + 2.0;
+    LOG_WARNING("Trunk scan target '%s' asynchronous retune failed; cooling down briefly\n", rt->target.id);
+    (void)state;
+    return -1;
+}
+
 static void
 trunk_scan_tick_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord) {
     double now_m = trunk_scan_now_m();
-    trunk_scan_retry_active_if_due(opts, state, coord, now_m);
     dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    int pending_status = trunk_scan_resolve_pending_retune(state, rt, now_m);
+    if (pending_status == 0) {
+        return;
+    }
+    if (pending_status < 0) {
+        if (coord->count > 1) {
+            trunk_scan_advance(opts, state, coord);
+        }
+        return;
+    }
+    trunk_scan_retry_active_if_due(opts, state, coord, now_m);
+    rt = &coord->targets[coord->active];
     trunk_scan_tick_active_target_sm(opts, state, rt);
     if (trunk_scan_active_is_held(opts, coord)) {
         rt->idle_since_m = -1.0;

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -1552,7 +1552,7 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
     }
 
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
-        if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING && tune_request_id != 0U) {
             (void)p25_sm_await_pending_cc_tune(&rt->p25_ctx, opts, state, tune_request_id, "scan-retune");
         } else {
             double completed_m = 0.0;
@@ -1562,7 +1562,7 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
             }
             (void)p25_sm_restart_pending_cc_acquisition(&rt->p25_ctx, opts, state, completed_m, "scan-retune");
         }
-    } else if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+    } else if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING && tune_request_id != 0U) {
         rt->tune_request_id = tune_request_id;
         rt->tune_pending = 1;
     } else {

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -1554,7 +1554,13 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
         if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING && tune_request_id != 0U) {
             (void)p25_sm_await_pending_cc_tune(&rt->p25_ctx, opts, state, tune_request_id, "scan-retune");
+            /* The P25 SM can observe completion before the scan coordinator's
+             * next tick. Track the same request here so dwell still restarts. */
+            rt->tune_request_id = tune_request_id;
+            rt->tune_pending = 1;
         } else {
+            rt->tune_request_id = 0U;
+            rt->tune_pending = 0;
             double completed_m = 0.0;
             (void)dsd_trunk_tuning_request_status(tune_request_id, &completed_m);
             if (completed_m <= 0.0) {

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -57,10 +57,12 @@ typedef struct {
     long p25_cc_eval_freq;
     double p25_cc_eval_start_m;
     time_t last_cc_sync_time;
+    time_t p25_last_cc_msg_time;
     time_t last_vc_sync_time;
     time_t p25_last_vc_tune_time;
     time_t last_t3_tune_time;
     double last_cc_sync_time_m;
+    double p25_last_cc_msg_time_m;
     double last_vc_sync_time_m;
     double p25_last_vc_tune_time_m;
     double last_t3_tune_time_m;
@@ -1056,10 +1058,12 @@ trunk_scan_restore_dmr_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot*
 static void
 trunk_scan_save_timing_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot* snapshot) {
     snapshot->last_cc_sync_time = state->last_cc_sync_time;
+    snapshot->p25_last_cc_msg_time = state->p25_last_cc_msg_time;
     snapshot->last_vc_sync_time = state->last_vc_sync_time;
     snapshot->p25_last_vc_tune_time = state->p25_last_vc_tune_time;
     snapshot->last_t3_tune_time = state->last_t3_tune_time;
     snapshot->last_cc_sync_time_m = state->last_cc_sync_time_m;
+    snapshot->p25_last_cc_msg_time_m = state->p25_last_cc_msg_time_m;
     snapshot->last_vc_sync_time_m = state->last_vc_sync_time_m;
     snapshot->p25_last_vc_tune_time_m = state->p25_last_vc_tune_time_m;
     snapshot->last_t3_tune_time_m = state->last_t3_tune_time_m;
@@ -1068,10 +1072,12 @@ trunk_scan_save_timing_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot*
 static void
 trunk_scan_restore_timing_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot* snapshot) {
     state->last_cc_sync_time = snapshot->last_cc_sync_time;
+    state->p25_last_cc_msg_time = snapshot->p25_last_cc_msg_time;
     state->last_vc_sync_time = snapshot->last_vc_sync_time;
     state->p25_last_vc_tune_time = snapshot->p25_last_vc_tune_time;
     state->last_t3_tune_time = snapshot->last_t3_tune_time;
     state->last_cc_sync_time_m = snapshot->last_cc_sync_time_m;
+    state->p25_last_cc_msg_time_m = snapshot->p25_last_cc_msg_time_m;
     state->last_vc_sync_time_m = snapshot->last_vc_sync_time_m;
     state->p25_last_vc_tune_time_m = snapshot->p25_last_vc_tune_time_m;
     state->last_t3_tune_time_m = snapshot->last_t3_tune_time_m;

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -345,6 +345,7 @@ dsd_engine_tune_with_backend(const dsd_opts* opts, dsd_state* state, long int fr
     return DSD_TRUNK_TUNE_RESULT_FAILED;
 #else
     (void)state;
+    (void)request_id;
     return DSD_TRUNK_TUNE_RESULT_FAILED;
 #endif
 }

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -621,6 +621,9 @@ dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, in
         return result;
     }
 
+    // Unlike trunking tune requests, conventional scan retunes do not pass
+    // through a runtime hook wrapper, so publish their accepted generation here.
+    dsd_trunk_tuning_generation_advance();
     dsd_frame_sync_reset_mod_state();
     state->last_cc_sync_time = time(NULL);
     state->last_cc_sync_time_m = dsd_time_now_monotonic_s();

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -300,7 +300,7 @@ dsd_engine_update_vc_tune_state(dsd_opts* opts, dsd_state* state, long int freq)
 }
 
 static dsd_trunk_tune_result
-dsd_engine_tune_with_backend(const dsd_opts* opts, dsd_state* state, long int freq) {
+dsd_engine_tune_with_backend(const dsd_opts* opts, dsd_state* state, long int freq, uint64_t request_id) {
     if (opts->use_rigctl == 1) {
         if (opts->setmod_bw != 0) {
             if (!SetModulation(opts->rigctl_sockfd, opts->setmod_bw)) {
@@ -323,7 +323,8 @@ dsd_engine_tune_with_backend(const dsd_opts* opts, dsd_state* state, long int fr
     }
 #ifdef USE_RADIO
     if (state->rtl_ctx) {
-        int rc = rtl_stream_tune(state->rtl_ctx, (uint32_t)freq);
+        int rc = request_id != 0U ? rtl_stream_tune_tagged(state->rtl_ctx, (uint32_t)freq, request_id)
+                                  : rtl_stream_tune(state->rtl_ctx, (uint32_t)freq);
         if (rc == RTL_STREAM_TUNE_OK) {
             return DSD_TRUNK_TUNE_RESULT_OK;
         }
@@ -430,7 +431,7 @@ dsd_engine_log_queued_ted_override(const dsd_opts* opts, const dsd_state* state,
  * @param state Decoder state to reset.
  */
 dsd_trunk_tune_result
-dsd_engine_return_to_cc(dsd_opts* opts, dsd_state* state) {
+dsd_engine_return_to_cc_request(dsd_opts* opts, dsd_state* state, uint64_t request_id) {
     dsd_trunk_tune_result tune_result = DSD_TRUNK_TUNE_RESULT_OK;
     if (!opts || !state) {
         return DSD_TRUNK_TUNE_RESULT_FAILED;
@@ -445,7 +446,7 @@ dsd_engine_return_to_cc(dsd_opts* opts, dsd_state* state) {
     const int trunk_enabled = (opts->trunk_enable == 1 || opts->p25_trunk == 1);
     if (trunk_enabled && cc != 0) {
         const int cc_sps = dsd_engine_compute_cc_sps(opts, state);
-        tune_result = dsd_engine_trunk_tune_to_cc(opts, state, cc, cc_sps);
+        tune_result = dsd_engine_trunk_tune_to_cc_request(opts, state, cc, cc_sps, request_id);
         if (!dsd_trunk_tune_result_is_ok(tune_result)) {
             return tune_result;
         }
@@ -456,6 +457,11 @@ dsd_engine_return_to_cc(dsd_opts* opts, dsd_state* state) {
     /* Keep symbol timing aligned with the current control-channel mode. */
     dsd_engine_apply_cc_symbol_timing(opts, state);
     return tune_result;
+}
+
+dsd_trunk_tune_result
+dsd_engine_return_to_cc(dsd_opts* opts, dsd_state* state) {
+    return dsd_engine_return_to_cc_request(opts, state, 0U);
 }
 
 /**
@@ -470,7 +476,8 @@ dsd_engine_return_to_cc(dsd_opts* opts, dsd_state* state) {
  * @param ted_sps TED samples-per-symbol to set (0 = no override).
  */
 dsd_trunk_tune_result
-dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+dsd_engine_trunk_tune_to_freq_request(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
+                                      uint64_t request_id) {
     dsd_trunk_tune_result result = DSD_TRUNK_TUNE_RESULT_OK;
 #ifdef USE_RADIO
     dsd_engine_rtl_profile_snapshot rtl_snapshot;
@@ -517,7 +524,7 @@ dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, i
 #endif
 
     dsd_engine_maybe_drain_audio(opts, state);
-    result = dsd_engine_tune_with_backend(opts, state, freq);
+    result = dsd_engine_tune_with_backend(opts, state, freq, request_id);
     if (!dsd_trunk_tune_result_is_ok(result)) {
 #ifdef USE_RADIO
         dsd_engine_rtl_profile_snapshot_restore(state, &rtl_snapshot);
@@ -542,6 +549,11 @@ dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, i
     return result;
 }
 
+dsd_trunk_tune_result
+dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    return dsd_engine_trunk_tune_to_freq_request(opts, state, freq, ted_sps, 0U);
+}
+
 /**
  * @brief Tune to a P25 control channel candidate without marking as tuned.
  *
@@ -555,7 +567,7 @@ dsd_engine_trunk_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, i
  *        pass the CC SPS (4 for P25P2 TDMA CC, 5 for P25P1 CC).
  */
 dsd_trunk_tune_result
-dsd_engine_trunk_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+dsd_engine_trunk_tune_to_cc_request(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps, uint64_t request_id) {
     dsd_trunk_tune_result result = DSD_TRUNK_TUNE_RESULT_OK;
 #ifdef USE_RADIO
     dsd_engine_rtl_profile_snapshot rtl_snapshot;
@@ -578,7 +590,7 @@ dsd_engine_trunk_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int
         dsd_engine_prepare_cc_rtl_chain(opts, state, freq, ted_sps);
 #endif
     }
-    result = dsd_engine_tune_with_backend(opts, state, freq);
+    result = dsd_engine_tune_with_backend(opts, state, freq, request_id);
     if (!dsd_trunk_tune_result_is_ok(result)) {
 #ifdef USE_RADIO
         dsd_engine_rtl_profile_snapshot_restore(state, &rtl_snapshot);
@@ -595,13 +607,31 @@ dsd_engine_trunk_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int
 }
 
 dsd_trunk_tune_result
-dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+dsd_engine_trunk_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    return dsd_engine_trunk_tune_to_cc_request(opts, state, freq, ted_sps, 0U);
+}
+
+dsd_trunk_tune_result
+dsd_engine_scan_tune_to_freq_with_id(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
+                                     uint64_t* out_request_id) {
     dsd_trunk_tune_result result = DSD_TRUNK_TUNE_RESULT_OK;
+    uint64_t tune_request_id = 0U;
 #ifdef USE_RADIO
     dsd_engine_rtl_profile_snapshot rtl_snapshot;
 #endif
+    if (out_request_id) {
+        *out_request_id = 0U;
+    }
     if (!opts || !state || freq <= 0) {
         return DSD_TRUNK_TUNE_RESULT_FAILED;
+    }
+
+    tune_request_id = dsd_trunk_tuning_request_begin();
+    if (tune_request_id == 0U) {
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
+    }
+    if (out_request_id) {
+        *out_request_id = tune_request_id;
     }
 #ifndef USE_RADIO
     (void)ted_sps;
@@ -613,17 +643,15 @@ dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, in
 #endif
 
     dsd_engine_maybe_drain_audio(opts, state);
-    result = dsd_engine_tune_with_backend(opts, state, freq);
+    result = dsd_engine_tune_with_backend(opts, state, freq, tune_request_id);
     if (!dsd_trunk_tune_result_is_ok(result)) {
 #ifdef USE_RADIO
         dsd_engine_rtl_profile_snapshot_restore(state, &rtl_snapshot);
 #endif
+        dsd_trunk_tuning_request_complete(tune_request_id, result);
         return result;
     }
 
-    // Unlike trunking tune requests, conventional scan retunes do not pass
-    // through a runtime hook wrapper, so publish their accepted generation here.
-    dsd_trunk_tuning_generation_advance();
     dsd_frame_sync_reset_mod_state();
     state->last_cc_sync_time = time(NULL);
     state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
@@ -631,5 +659,18 @@ dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, in
     state->last_vc_sync_time_m = 0.0;
     opts->p25_is_tuned = 0;
     opts->trunk_is_tuned = 0;
+    if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        dsd_trunk_tuning_request_mark_ready(tune_request_id);
+        if (dsd_trunk_tuning_request_status(tune_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_OK) {
+            result = DSD_TRUNK_TUNE_RESULT_OK;
+        }
+    } else {
+        dsd_trunk_tuning_request_complete(tune_request_id, result);
+    }
     return result;
+}
+
+dsd_trunk_tune_result
+dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    return dsd_engine_scan_tune_to_freq_with_id(opts, state, freq, ted_sps, NULL);
 }

--- a/src/engine/trunk_tuning_hooks_install.c
+++ b/src/engine/trunk_tuning_hooks_install.c
@@ -4,15 +4,39 @@
  */
 
 #include <dsd-neo/engine/trunk_tuning.h>
+#ifdef USE_RADIO
+#include <dsd-neo/io/rtl_stream_c.h>
+#endif
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include "engine_hooks_install.h"
+
+#ifdef USE_RADIO
+static void
+dsd_engine_rtl_tune_completion(uint64_t request_id, rtl_stream_tune_result result, void* user_data) {
+    (void)user_data;
+    dsd_trunk_tune_result tune_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    switch (result) {
+        case RTL_STREAM_TUNE_OK: tune_result = DSD_TRUNK_TUNE_RESULT_OK; break;
+        case RTL_STREAM_TUNE_DEFERRED: tune_result = DSD_TRUNK_TUNE_RESULT_DEFERRED; break;
+        case RTL_STREAM_TUNE_TIMEOUT: tune_result = DSD_TRUNK_TUNE_RESULT_TIMEOUT; break;
+        case RTL_STREAM_TUNE_FAILED:
+        default: tune_result = DSD_TRUNK_TUNE_RESULT_FAILED; break;
+    }
+    dsd_trunk_tuning_request_publish(request_id, tune_result);
+}
+#endif
 
 void
 dsd_engine_trunk_tuning_hooks_install(void) {
     dsd_trunk_tuning_hooks hooks = {0};
-    hooks.tune_to_freq_result = dsd_engine_trunk_tune_to_freq;
-    hooks.tune_to_cc_result = dsd_engine_trunk_tune_to_cc;
-    hooks.return_to_cc_result = dsd_engine_return_to_cc;
+    hooks.tune_to_freq_request = dsd_engine_trunk_tune_to_freq_request;
+    hooks.tune_to_cc_request = dsd_engine_trunk_tune_to_cc_request;
+    hooks.return_to_cc_request = dsd_engine_return_to_cc_request;
     dsd_trunk_tuning_hooks_set(hooks);
+#ifdef USE_RADIO
+    rtl_stream_register_tune_completion_callback(dsd_engine_rtl_tune_completion, NULL);
+#endif
 }

--- a/src/engine/trunk_tuning_hooks_install.c
+++ b/src/engine/trunk_tuning_hooks_install.c
@@ -32,6 +32,9 @@ dsd_engine_rtl_tune_completion(uint64_t request_id, rtl_stream_tune_result resul
 void
 dsd_engine_trunk_tuning_hooks_install(void) {
     dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_freq_result = dsd_engine_trunk_tune_to_freq;
+    hooks.tune_to_cc_result = dsd_engine_trunk_tune_to_cc;
+    hooks.return_to_cc_result = dsd_engine_return_to_cc;
     hooks.tune_to_freq_request = dsd_engine_trunk_tune_to_freq_request;
     hooks.tune_to_cc_request = dsd_engine_trunk_tune_to_cc_request;
     hooks.return_to_cc_request = dsd_engine_return_to_cc_request;

--- a/src/io/control/dsd_rigctl.c
+++ b/src/io/control/dsd_rigctl.c
@@ -494,7 +494,7 @@ dsd_rigctl_test_rtl_udp_tune(dsd_opts* opts, dsd_state* state, long int frequenc
  * @param opts Decoder options with tuning configuration.
  * @param state Decoder state (required for RTL tuning, may be NULL for rigctl-only).
  * @param freq Target frequency in Hz.
- * @return 0 on success, -1 on error.
+ * @return 0 on success, 1 when an RTL tune is deferred, or a negative error/timeout code.
  */
 int
 io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
@@ -507,9 +507,6 @@ io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
 
     LOG_INFO("io_control: tune to %ld Hz\n", freq);
 
-    // Update cached frequency for display/tracking
-    opts->rtlsdr_center_freq = (uint32_t)freq;
-
     if (opts->use_rigctl == 1) {
         if (opts->setmod_bw != 0) {
             SetModulation(opts->rigctl_sockfd, opts->setmod_bw);
@@ -518,9 +515,14 @@ io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
     } else if (opts->audio_in_type == AUDIO_IN_RTL) {
 #ifdef USE_RADIO
         if (state && state->rtl_ctx) {
-            rtl_stream_tune(state->rtl_ctx, (uint32_t)freq);
+            int tune_result = rtl_stream_tune(state->rtl_ctx, (uint32_t)freq);
+            if (tune_result != RTL_STREAM_TUNE_OK) {
+                return tune_result;
+            }
         }
 #endif
     }
+    // Update cached frequency only after the selected backend accepts the request.
+    opts->rtlsdr_center_freq = (uint32_t)freq;
     return 0;
 }

--- a/src/io/control/dsd_rigctl.c
+++ b/src/io/control/dsd_rigctl.c
@@ -501,6 +501,7 @@ io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
     if (!opts || freq <= 0) {
         return -1;
     }
+    uint32_t applied_freq = (uint32_t)freq;
 #ifndef USE_RADIO
     (void)state;
 #endif
@@ -519,10 +520,16 @@ io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
             if (tune_result != RTL_STREAM_TUNE_OK) {
                 return tune_result;
             }
+            // Untagged controller requests can coalesce, so cache the target
+            // that actually completed rather than this caller's requested one.
+            uint32_t controller_freq = 0U;
+            if (rtl_stream_get_last_applied_freq(&controller_freq) == 0 && controller_freq != 0U) {
+                applied_freq = controller_freq;
+            }
         }
 #endif
     }
     // Update cached frequency only after the selected backend accepts the request.
-    opts->rtlsdr_center_freq = (uint32_t)freq;
+    opts->rtlsdr_center_freq = applied_freq;
     return 0;
 }

--- a/src/io/control/dsd_rigctl.c
+++ b/src/io/control/dsd_rigctl.c
@@ -494,7 +494,8 @@ dsd_rigctl_test_rtl_udp_tune(dsd_opts* opts, dsd_state* state, long int frequenc
  * @param opts Decoder options with tuning configuration.
  * @param state Decoder state (required for RTL tuning, may be NULL for rigctl-only).
  * @param freq Target frequency in Hz.
- * @return 0 on success, 1 when an RTL tune is deferred, or a negative error/timeout code.
+ * @return 0 on success, 1 when an RTL tune is deferred, or a negative error/timeout code. An RTL timeout leaves an
+ *         accepted request active and retains its target in opts->rtlsdr_center_freq.
  */
 int
 io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
@@ -518,6 +519,11 @@ io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
         if (state && state->rtl_ctx) {
             int tune_result = rtl_stream_tune(state->rtl_ctx, (uint32_t)freq);
             if (tune_result != RTL_STREAM_TUNE_OK) {
+                if (tune_result == RTL_STREAM_TUNE_TIMEOUT) {
+                    // The untagged controller request remains accepted and may
+                    // complete after the synchronous wait expires.
+                    opts->rtlsdr_center_freq = applied_freq;
+                }
                 return tune_result;
             }
             // Untagged controller requests can coalesce, so cache the target

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -2068,6 +2068,14 @@ replay_handle_empty_read(struct rtl_device* s, uint64_t* complex_written, uint64
         replay_handle_eof_sequence(s);
         return 0;
     }
+    /* A rewind is a replay timeline boundary just like RESET. Do not restore
+     * the initial capture state while the demodulator still owns samples from
+     * the completed pass; the reconfigure callback would otherwise purge that
+     * work and a short fast-mode capture could loop without ever publishing
+     * output. */
+    if (!replay_wait_for_event_boundary_drain(s)) {
+        return 0;
+    }
     if (dsd_iq_replay_rewind(s->replay_src) != DSD_IQ_OK) {
         return 0;
     }

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -722,14 +722,35 @@ rtl_replay_on_input_drained(void* user) {
     safe_cond_signal(&output.ready, &output.ready_m);
 }
 
+static uint64_t
+replay_acknowledge_consumed_generation(std::atomic<uint64_t>* last_consume_gen, uint64_t consumed_gen) {
+    if (!last_consume_gen) {
+        return 0U;
+    }
+
+    uint64_t acknowledged = last_consume_gen->load(std::memory_order_acquire);
+    while (acknowledged < consumed_gen
+           && !last_consume_gen->compare_exchange_weak(acknowledged, consumed_gen, std::memory_order_release,
+                                                       std::memory_order_acquire)) {}
+    return acknowledged < consumed_gen ? consumed_gen : acknowledged;
+}
+
+#if defined(DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS)
+extern "C" uint64_t
+rtl_stream_test_replay_acknowledge_discarded_span(uint64_t submitted_gen, uint64_t consumed_gen) {
+    std::atomic<uint64_t> acknowledged{consumed_gen};
+    return replay_acknowledge_consumed_generation(&acknowledged, submitted_gen);
+}
+#endif
+
 static void
 replay_note_input_purge_consumed(void) {
     if (!stream_is_replay_active() || !g_stream) {
         return;
     }
 
-    uint64_t consumed_gen = g_stream->replay_last_submit_gen.load(std::memory_order_acquire);
-    g_stream->replay_last_consume_gen.store(consumed_gen, std::memory_order_release);
+    uint64_t submitted_gen = g_stream->replay_last_submit_gen.load(std::memory_order_acquire);
+    uint64_t consumed_gen = replay_acknowledge_consumed_generation(&g_stream->replay_last_consume_gen, submitted_gen);
     if (!g_stream->replay_input_eof.load(std::memory_order_acquire) || input_ring_used(&input_ring) != 0U) {
         return;
     }
@@ -3105,7 +3126,7 @@ demod_update_replay_drain_state(int replay_active, uint64_t consumed_gen) {
     if (!replay_active || !g_stream) {
         return;
     }
-    g_stream->replay_last_consume_gen.store(consumed_gen, std::memory_order_release);
+    uint64_t consumed_at = replay_acknowledge_consumed_generation(&g_stream->replay_last_consume_gen, consumed_gen);
     if (g_stream->replay_demod_drained.load(std::memory_order_acquire)) {
         return;
     }
@@ -3120,7 +3141,6 @@ demod_update_replay_drain_state(int replay_active, uint64_t consumed_gen) {
             dsd_mutex_unlock(&g_stream->replay_eof_m);
         }
     }
-    uint64_t consumed_at = g_stream->replay_last_consume_gen.load(std::memory_order_acquire);
     uint64_t eof_gen = g_stream->replay_last_submit_gen_at_eof.load(std::memory_order_acquire);
     if (input_drained && consumed_at >= eof_gen) {
         g_stream->replay_demod_drained.store(1, std::memory_order_release);
@@ -3131,6 +3151,21 @@ demod_update_replay_drain_state(int replay_active, uint64_t consumed_gen) {
         }
         safe_cond_signal(&output.ready, &output.ready_m);
     }
+}
+
+static void
+demod_discard_iteration_input(DemodInputSpan* span) {
+    demod_input_span_commit_reserved(span);
+    if (!stream_is_replay_active() || !g_stream) {
+        return;
+    }
+
+    /* Rewind/RESET boundaries wait for both an empty ring and the submitted
+     * generation to be acknowledged. A controller gate can discard the final
+     * reserved span, so publish that consumption even though it produced no
+     * demodulated output. */
+    uint64_t submitted_gen = g_stream->replay_last_submit_gen.load(std::memory_order_acquire);
+    demod_update_replay_drain_state(1, submitted_gen);
 }
 
 static void
@@ -3300,16 +3335,17 @@ demod_prepare_iteration_input(struct demod_state* d, int is_rtltcp_input, DemodI
         return 0;
     }
     if (!demod_enter_processing_block(&controller)) {
-        demod_input_span_commit_reserved(span);
+        demod_discard_iteration_input(span);
         return 0;
     }
     if (!demod_prepare_input_block(d, span)) {
+        demod_discard_iteration_input(span);
         demod_leave_processing_block(&controller);
         return 0;
     }
     if (controller.retune_in_progress.load(std::memory_order_acquire)
         || g_ring_purge_pending.load(std::memory_order_acquire)) {
-        demod_input_span_commit_direct(span);
+        demod_discard_iteration_input(span);
         demod_leave_processing_block(&controller);
         return 0;
     }
@@ -3318,19 +3354,19 @@ demod_prepare_iteration_input(struct demod_state* d, int is_rtltcp_input, DemodI
     float input_max_abs = 0.0f;
     iq_block_abs_stats(span->input_block, span->got, &input_mean_abs, &input_max_abs, &input_pairs);
     if (retune_settle_should_discard(d, input_mean_abs, input_max_abs, input_pairs)) {
-        demod_input_span_commit_direct(span);
+        demod_discard_iteration_input(span);
         demod_leave_processing_block(&controller);
         return 0;
     }
     *retune_diag = demod_capture_retune_diag(input_mean_abs, input_max_abs, input_pairs);
     demod_autogain_update(d, input_mean_abs, input_max_abs);
     if (!controller.cold_start_ready.load(std::memory_order_acquire)) {
-        demod_input_span_commit_direct(span);
+        demod_discard_iteration_input(span);
         demod_leave_processing_block(&controller);
         return 0;
     }
     if (controller.retune_in_progress.load(std::memory_order_acquire)) {
-        demod_input_span_commit_direct(span);
+        demod_discard_iteration_input(span);
         demod_leave_processing_block(&controller);
         return 0;
     }

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <chrono>
 #include <cmath>
+#include <condition_variable>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/power.h>
@@ -54,12 +55,14 @@
 #include <dsd-neo/runtime/unicode.h>
 #include <errno.h>
 #include <limits.h>
+#include <memory>
 #include <mutex>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <utility>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -221,8 +224,10 @@ struct controller_state {
     dsd_cond_t hop{};
     dsd_mutex_t hop_m{};
     /* Marshalled retune request from external threads (UDP/API). */
+    int manual_retunes_accepting = 0;
     std::atomic<int> manual_retune_pending{0};
     uint32_t manual_retune_freq = 0U;
+    uint64_t manual_retune_token = 0U;
     RtlRetuneProfile manual_retune_profile{};
     /* Marshalled PPM correction updates stay on the controller thread so
      * device controls remain serialized with retunes/hops. */
@@ -278,6 +283,24 @@ static struct dongle_state dongle;
 static struct output_state output;
 static struct output_state monitor_output;
 static struct controller_state controller;
+
+namespace {
+struct RtlTuneCompletionRegistration {
+    RtlTuneCompletionRegistration(rtl_stream_tune_completion_callback callback_in, void* user_data_in)
+        : callback(callback_in), user_data(user_data_in) {}
+
+    rtl_stream_tune_completion_callback callback;
+    void* user_data;
+    std::mutex in_flight_mutex;
+    std::condition_variable idle;
+    size_t in_flight = 0U;
+};
+} // namespace
+
+static std::mutex g_tune_completion_callback_mutex;
+static std::mutex g_tune_completion_callback_update_mutex;
+static std::shared_ptr<RtlTuneCompletionRegistration> g_tune_completion_registration;
+static thread_local const RtlTuneCompletionRegistration* g_active_tune_completion_registration = nullptr;
 static struct input_ring_state input_ring;
 static dsd_iq_capture_writer* g_iq_capture_writer = NULL;
 /* Controller can request a ring purge; consumer/demod performs the discard safely. */
@@ -4063,12 +4086,19 @@ namespace {
 struct ControllerRetuneWork {
     int manual_pending = 0;
     uint32_t manual_freq_hz = 0U;
+    uint64_t manual_token = 0U;
     RtlRetuneProfile manual_profile{};
     int requested_ppm = 0;
     uint32_t requested_ppm_request_id = 0U;
     int ppm_pending = 0;
     int current_ppm = 0;
     int ppm_changed = 0;
+};
+
+struct ControllerRetuneCancellation {
+    int pending = 0;
+    uint32_t request_id = 0U;
+    uint64_t token = 0U;
 };
 } // namespace
 
@@ -4089,6 +4119,7 @@ controller_wait_for_retune_work(struct controller_state* s, ControllerRetuneWork
     }
     work->manual_pending = 0;
     work->manual_freq_hz = 0;
+    work->manual_token = 0U;
     rtl_stream_clear_retune_profile(&work->manual_profile);
     dsd_mutex_lock(&s->hop_m);
     while (!s->manual_retune_pending.load(std::memory_order_acquire)
@@ -4103,7 +4134,10 @@ controller_wait_for_retune_work(struct controller_state* s, ControllerRetuneWork
     work->manual_pending = s->manual_retune_pending.exchange(0, std::memory_order_acq_rel);
     if (work->manual_pending) {
         work->manual_freq_hz = s->manual_retune_freq;
+        work->manual_token = s->manual_retune_token;
         work->manual_profile = s->manual_retune_profile;
+        s->manual_retune_freq = 0U;
+        s->manual_retune_token = 0U;
         rtl_stream_clear_retune_profile(&s->manual_retune_profile);
     }
     work->requested_ppm = s->pending_ppm_error.load(std::memory_order_acquire);
@@ -4177,6 +4211,96 @@ controller_manual_retune_completion_result(int retune_rc, int reconfigured, uint
     return RTL_STREAM_TUNE_FAILED;
 }
 
+static void
+rtl_stream_publish_tune_completion(uint64_t token, int result) {
+    if (token == 0U) {
+        return;
+    }
+    std::shared_ptr<RtlTuneCompletionRegistration> registration;
+    {
+        std::lock_guard<std::mutex> lock(g_tune_completion_callback_mutex);
+        registration = g_tune_completion_registration;
+        if (registration) {
+            std::lock_guard<std::mutex> in_flight_lock(registration->in_flight_mutex);
+            registration->in_flight++;
+        }
+    }
+    if (!registration) {
+        return;
+    }
+
+    const RtlTuneCompletionRegistration* previous_registration = g_active_tune_completion_registration;
+    g_active_tune_completion_registration = registration.get();
+    registration->callback(token, static_cast<rtl_stream_tune_result>(result), registration->user_data);
+    g_active_tune_completion_registration = previous_registration;
+
+    {
+        std::lock_guard<std::mutex> in_flight_lock(registration->in_flight_mutex);
+        registration->in_flight--;
+        if (registration->in_flight == 0U) {
+            registration->idle.notify_all();
+        }
+    }
+}
+
+static void
+controller_finish_manual_retune(struct controller_state* s, const ControllerRetuneWork* work, int result,
+                                int drain_output) {
+    if (!s || !work) {
+        return;
+    }
+    if (drain_output) {
+        drain_output_on_retune();
+    }
+    rtl_stream_publish_tune_completion(work->manual_token, result);
+    controller_signal_manual_retune_complete(s, result);
+}
+
+static ControllerRetuneCancellation
+controller_detach_queued_manual_retune(struct controller_state* s) {
+    ControllerRetuneCancellation cancelled = {};
+    if (!s) {
+        return cancelled;
+    }
+
+    dsd_mutex_lock(&s->hop_m);
+    s->manual_retunes_accepting = 0;
+    cancelled.pending = s->manual_retune_pending.exchange(0, std::memory_order_acq_rel);
+    if (cancelled.pending) {
+        cancelled.request_id = s->retune_request_id.load(std::memory_order_acquire);
+        cancelled.token = s->manual_retune_token;
+        s->manual_retune_freq = 0U;
+        s->manual_retune_token = 0U;
+        rtl_stream_clear_retune_profile(&s->manual_retune_profile);
+    }
+    dsd_mutex_unlock(&s->hop_m);
+    return cancelled;
+}
+
+static void
+controller_wake_retune_waiters(struct controller_state* s) {
+    if (!s) {
+        return;
+    }
+    dsd_mutex_lock(&s->retune_done_m);
+    dsd_cond_broadcast(&s->retune_done_cond);
+    dsd_mutex_unlock(&s->retune_done_m);
+}
+
+static void
+controller_finish_cancelled_manual_retune(struct controller_state* s, const ControllerRetuneCancellation* cancelled) {
+    if (!s || !cancelled || !cancelled->pending) {
+        return;
+    }
+    uint32_t next_completion_id = s->retune_complete_id.load(std::memory_order_acquire) + 1U;
+    if (next_completion_id != cancelled->request_id) {
+        LOG_ERROR("Cancelled retune completion out of order: request=%u next=%u.\n", cancelled->request_id,
+                  next_completion_id);
+    }
+    rtl_stream_publish_tune_completion(cancelled->token, RTL_STREAM_TUNE_FAILED);
+    controller_signal_manual_retune_complete(s, RTL_STREAM_TUNE_FAILED);
+}
+
 static int
 controller_process_manual_retune(struct controller_state* s, const ControllerRetuneWork* work) {
     if (!s || !work || !work->manual_pending) {
@@ -4195,10 +4319,7 @@ controller_process_manual_retune(struct controller_state* s, const ControllerRet
     uint32_t applied_freq_hz = s->last_applied_freq_hz.load(std::memory_order_acquire);
     int completion_result =
         controller_manual_retune_completion_result(retune_rc, reconfigured, target_hz, applied_freq_hz);
-    controller_signal_manual_retune_complete(s, completion_result);
-    if (retune_rc == 0 || reconfigured) {
-        drain_output_on_retune();
-    }
+    controller_finish_manual_retune(s, work, completion_result, retune_rc == 0 || reconfigured);
     if (retune_rc != 0 && completion_result == RTL_STREAM_TUNE_OK) {
         LOG_NOTICE("Retune applied with warning: %u Hz (rc=%d).\n", target_hz, retune_rc);
     } else if (retune_rc != 0) {
@@ -4836,8 +4957,10 @@ controller_init(struct controller_state* s) {
     s->wb_mode = 0;
     dsd_cond_init(&s->hop);
     dsd_mutex_init(&s->hop_m);
+    s->manual_retunes_accepting = 1;
     s->manual_retune_pending.store(0);
     s->manual_retune_freq = 0;
+    s->manual_retune_token = 0U;
     rtl_stream_clear_retune_profile(&s->manual_retune_profile);
     s->ppm_change_pending.store(0);
     s->pending_ppm_error.store(0);
@@ -4945,23 +5068,33 @@ setup_initial_freq_and_rate(dsd_opts* opts) {
 /**
  * @brief Enqueue a manual retune on the controller thread and return its request ID.
  *
- * Coalesces callers when a retune is already pending (controller has not yet
- * consumed the request) so that completion IDs track the number of retunes
- * actually executed. This prevents synchronous waiters from timing out when
- * multiple retune requests arrive faster than the controller loop can service
- * them.
+ * Coalesces compatible callers when a retune is already pending (controller
+ * has not yet consumed the request) so completion IDs track the number of
+ * retunes actually executed. A queued tagged request rejects a different
+ * owner instead of losing its completion token.
  *
  * @param target_freq_hz Desired center frequency in Hz.
- * @return Request ID that will be completed once the queued retune finishes.
+ * @return Request ID completed after the queued retune, or zero when deferred.
  */
 static uint32_t
-schedule_manual_retune_on_controller(struct controller_state* s, uint32_t target_freq_hz) {
+schedule_manual_retune_on_controller(struct controller_state* s, uint32_t target_freq_hz, uint64_t caller_token = 0U) {
     if (!s) {
         return 0U;
     }
+    if (s == &controller && g_stream && !g_stream->controller_thread_started.load(std::memory_order_acquire)) {
+        return 0U;
+    }
     dsd_mutex_lock(&s->hop_m);
+    if (!s->manual_retunes_accepting) {
+        dsd_mutex_unlock(&s->hop_m);
+        return 0U;
+    }
     uint32_t request_id = s->retune_request_id.load(std::memory_order_acquire);
     int pending = s->manual_retune_pending.load(std::memory_order_acquire);
+    if (pending && s->manual_retune_token != 0U && s->manual_retune_token != caller_token) {
+        dsd_mutex_unlock(&s->hop_m);
+        return 0U;
+    }
     if (!pending) {
         request_id = s->retune_request_id.fetch_add(1, std::memory_order_acq_rel) + 1;
         s->manual_retune_pending.store(1, std::memory_order_release);
@@ -4969,6 +5102,7 @@ schedule_manual_retune_on_controller(struct controller_state* s, uint32_t target
     }
     /* Update/override target frequency even when coalescing into an existing pending retune. */
     s->manual_retune_freq = target_freq_hz;
+    s->manual_retune_token = caller_token;
     (void)rtl_stream_take_pending_retune_profile(&s->manual_retune_profile, request_id, target_freq_hz);
     dsd_cond_signal(&s->hop);
     dsd_mutex_unlock(&s->hop_m);
@@ -4978,6 +5112,11 @@ schedule_manual_retune_on_controller(struct controller_state* s, uint32_t target
 static uint32_t
 schedule_manual_retune(uint32_t target_freq_hz) {
     return schedule_manual_retune_on_controller(&controller, target_freq_hz);
+}
+
+static uint32_t
+schedule_manual_retune_tagged(uint32_t target_freq_hz, uint64_t caller_token) {
+    return schedule_manual_retune_on_controller(&controller, target_freq_hz, caller_token);
 }
 
 static void
@@ -6224,6 +6363,7 @@ dsd_rtl_stream_open(dsd_opts* opts) {
 extern "C" void
 dsd_rtl_stream_close(void) {
     LOG_INFO("cleaning up...\n");
+    ControllerRetuneCancellation cancelled_retune = {};
     rtl_stream_bump_output_generation();
     if (g_stream) {
         g_stream->replay_forced_stop.store(1, std::memory_order_release);
@@ -6232,6 +6372,10 @@ dsd_rtl_stream_close(void) {
             dsd_opts* mutable_opts = const_cast<dsd_opts*>(g_stream->opts);
             mutable_opts->iq_replay_active = 0;
         }
+    }
+    if (g_stream) {
+        cancelled_retune = controller_detach_queued_manual_retune(&controller);
+        controller_wake_retune_waiters(&controller);
     }
     LOG_INFO("Output ring: write_timeouts=%llu read_timeouts=%llu\n", (unsigned long long)output.write_timeouts.load(),
              (unsigned long long)output.read_timeouts.load());
@@ -6266,6 +6410,7 @@ dsd_rtl_stream_close(void) {
         dsd_thread_join(controller.thread);
         g_stream->controller_thread_started.store(0, std::memory_order_release);
     }
+    controller_finish_cancelled_manual_retune(&controller, &cancelled_retune);
     stream_close_capture_writer();
 
     rtl_demod_cleanup(&demod);
@@ -6292,6 +6437,7 @@ dsd_rtl_stream_close(void) {
 extern "C" int
 dsd_rtl_stream_soft_stop(void) {
     LOG_INFO("soft stopping...\n");
+    ControllerRetuneCancellation cancelled_retune = {};
     rtl_stream_bump_output_generation();
     if (g_stream) {
         g_stream->replay_forced_stop.store(1, std::memory_order_release);
@@ -6300,6 +6446,10 @@ dsd_rtl_stream_soft_stop(void) {
             dsd_opts* mutable_opts = const_cast<dsd_opts*>(g_stream->opts);
             mutable_opts->iq_replay_active = 0;
         }
+    }
+    if (g_stream) {
+        cancelled_retune = controller_detach_queued_manual_retune(&controller);
+        controller_wake_retune_waiters(&controller);
     }
     if (g_udp_ctrl) {
         udp_control_stop(g_udp_ctrl);
@@ -6328,6 +6478,7 @@ dsd_rtl_stream_soft_stop(void) {
         dsd_thread_join(controller.thread);
         g_stream->controller_thread_started.store(0, std::memory_order_release);
     }
+    controller_finish_cancelled_manual_retune(&controller, &cancelled_retune);
     stream_close_capture_writer();
 
     rtl_demod_cleanup(&demod);
@@ -7505,12 +7656,17 @@ rtl_stream_tune_apply_completion_result(int rc, int completion, uint32_t request
 }
 
 static int
-rtl_stream_tune_wait_for_completion(uint32_t request_id, uint32_t requested_freq) {
+rtl_stream_tune_wait_for_completion(uint32_t request_id, uint32_t requested_freq, int tagged_request) {
     int rc = RTL_STREAM_TUNE_OK;
     int completion = RTL_STREAM_TUNE_OK;
     const uint64_t deadline_ns = dsd_time_monotonic_ns() + 500000000ULL;
     dsd_mutex_lock(&controller.retune_done_m);
     while (controller.retune_complete_id.load(std::memory_order_acquire) < request_id) {
+        if (!tagged_request && (exitflag || (g_stream && g_stream->should_exit.load(std::memory_order_acquire)))) {
+            rtl_stream_log_tune_warning(requested_freq, "shutdown");
+            rc = RTL_STREAM_TUNE_FAILED;
+            break;
+        }
         uint64_t now_ns = dsd_time_monotonic_ns();
         if (now_ns >= deadline_ns) {
             rtl_stream_log_tune_warning(requested_freq, "timeout");
@@ -7526,11 +7682,6 @@ rtl_stream_tune_wait_for_completion(uint32_t request_id, uint32_t requested_freq
         if (wait_rc != 0) {
             continue;
         }
-        if (exitflag || (g_stream && g_stream->should_exit.load(std::memory_order_relaxed))) {
-            rtl_stream_log_tune_warning(requested_freq, "shutdown");
-            rc = RTL_STREAM_TUNE_FAILED;
-            break;
-        }
     }
     if (rc == RTL_STREAM_TUNE_OK
         && !controller_load_retune_completion_result_locked(&controller, request_id, &completion)) {
@@ -7539,11 +7690,6 @@ rtl_stream_tune_wait_for_completion(uint32_t request_id, uint32_t requested_freq
     }
     dsd_mutex_unlock(&controller.retune_done_m);
     return rtl_stream_tune_apply_completion_result(rc, completion, requested_freq);
-}
-
-static int
-rtl_stream_tune_result_needs_output_drain(int rc) {
-    return rc == RTL_STREAM_TUNE_OK || rc == RTL_STREAM_TUNE_TIMEOUT;
 }
 
 static void
@@ -7580,8 +7726,11 @@ rtl_stream_tune_reconcile_result(dsd_opts* opts, uint32_t requested_freq, int rc
     }
 }
 
-extern "C" int
-dsd_rtl_stream_tune(dsd_opts* opts, long int frequency) {
+static int
+rtl_stream_tune_impl(dsd_opts* opts, long int frequency, uint64_t caller_token) {
+    if (!opts) {
+        return RTL_STREAM_TUNE_FAILED;
+    }
     if (stream_is_replay_active()) {
         static std::atomic<uint64_t> s_last_notice_ns{0};
         uint64_t now_ns = dsd_time_monotonic_ns();
@@ -7600,25 +7749,64 @@ dsd_rtl_stream_tune(dsd_opts* opts, long int frequency) {
         LOG_INFO("\nTuning to %ld Hz.", frequency);
     }
     uint32_t requested_freq = (uint32_t)frequency;
-    opts->rtlsdr_center_freq = frequency;
-    store_dongle_frequency(requested_freq);
 
     /* Enqueue retune, coalescing with any already-pending request so completion IDs
      * stay aligned with the number of retunes the controller will actually execute. */
-    uint32_t my_request_id = schedule_manual_retune(requested_freq);
+    uint32_t my_request_id = (caller_token != 0U) ? schedule_manual_retune_tagged(requested_freq, caller_token)
+                                                  : schedule_manual_retune(requested_freq);
+    if (my_request_id == 0U) {
+        return RTL_STREAM_TUNE_DEFERRED;
+    }
+    opts->rtlsdr_center_freq = frequency;
 
     if (opts->payload == 1) {
         LOG_INFO(" (Center Frequency: %u Hz.) \n", requested_freq);
     }
 
-    int rc = rtl_stream_tune_wait_for_completion(my_request_id, requested_freq);
+    int rc = rtl_stream_tune_wait_for_completion(my_request_id, requested_freq, caller_token != 0U);
 
     rtl_stream_tune_reconcile_result(opts, requested_freq, rc);
-    if (rtl_stream_tune_result_needs_output_drain(rc)) {
-        /* Honor drain/clear policy for API-triggered tunes and accepted-but-pending timeout paths. */
-        drain_output_on_retune();
-    }
     return rc;
+}
+
+extern "C" int
+dsd_rtl_stream_tune(dsd_opts* opts, long int frequency) {
+    return rtl_stream_tune_impl(opts, frequency, 0U);
+}
+
+extern "C" int
+dsd_rtl_stream_tune_tagged(dsd_opts* opts, long int frequency, uint64_t token) {
+    if (token == 0U) {
+        return RTL_STREAM_TUNE_FAILED;
+    }
+    return rtl_stream_tune_impl(opts, frequency, token);
+}
+
+extern "C" void
+dsd_rtl_stream_register_tune_completion_callback(rtl_stream_tune_completion_callback callback, void* user_data) {
+    /* Serialize replacement through prior-registration quiescence so a later
+     * registrar cannot overtake one that is still waiting on an older callback. */
+    std::lock_guard<std::mutex> update_lock(g_tune_completion_callback_update_mutex);
+    std::shared_ptr<RtlTuneCompletionRegistration> replacement;
+    if (callback) {
+        replacement = std::make_shared<RtlTuneCompletionRegistration>(callback, user_data);
+    }
+
+    std::shared_ptr<RtlTuneCompletionRegistration> previous;
+    {
+        std::lock_guard<std::mutex> lock(g_tune_completion_callback_mutex);
+        previous = std::move(g_tune_completion_registration);
+        g_tune_completion_registration = std::move(replacement);
+    }
+
+    /* A completion callback must not register or unregister callbacks. Avoid
+     * self-deadlock if a client violates that contract; the current callback
+     * still owns its user_data until it returns. */
+    if (!previous || g_active_tune_completion_registration == previous.get()) {
+        return;
+    }
+    std::unique_lock<std::mutex> in_flight_lock(previous->in_flight_mutex);
+    previous->idle.wait(in_flight_lock, [&previous] { return previous->in_flight == 0U; });
 }
 
 #if defined(DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS)
@@ -7782,9 +7970,10 @@ dsd_rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samp
     dsd_rtl_stream_metrics_hook_symbol_cache_pending_delta(cached_symbols);
 
     *out_generation_before = dsd_rtl_stream_output_generation();
-    if (rtl_stream_tune_result_needs_output_drain(tune_result)) {
-        drain_output_on_retune();
-    }
+    /* Tune callers never own this boundary, including after a synchronous
+     * wait timeout. The controller drains output before it publishes the
+     * terminal completion for the queued request. */
+    (void)tune_result;
     *out_generation_after = dsd_rtl_stream_output_generation();
     *out_used_after = ring_used(&output);
     *out_cache_pending_after = dsd_rtl_stream_metrics_hook_symbol_cache_pending();
@@ -8648,6 +8837,159 @@ dsd_rtl_stream_test_fsk_reacquire(int output_kind, size_t queued_samples, int ca
     fsk_reacquire_test_reset_output_state();
     fsk_reacquire_test_cleanup_output_ring(initialized_output);
     return 0;
+}
+
+static int
+rtl_stream_tagged_completion_test_args_valid(uint64_t first_token, uint64_t second_token,
+                                             const uint64_t* out_coalesced_token, const uint32_t* out_generation_before,
+                                             const uint32_t* out_generation_after) {
+    return (first_token != 0U || second_token != 0U) && out_coalesced_token && out_generation_before
+           && out_generation_after;
+}
+
+static int
+rtl_stream_tagged_completion_test_result_valid(uint64_t first_token, uint64_t second_token, uint32_t first_request_id,
+                                               uint32_t second_request_id, uint64_t completed_token,
+                                               int completion_found, int completion_result) {
+    const int second_is_conflict = first_token != 0U && first_token != second_token;
+    const uint32_t expected_second_request_id = second_is_conflict ? 0U : first_request_id;
+    const uint64_t expected_token = second_is_conflict ? first_token : second_token;
+    return first_request_id != 0U && second_request_id == expected_second_request_id
+           && completed_token == expected_token && completion_found && completion_result == RTL_STREAM_TUNE_OK;
+}
+
+extern "C" int
+dsd_rtl_stream_test_tagged_completion_boundary(uint64_t first_token, uint64_t second_token, size_t queued_samples,
+                                               uint64_t* out_coalesced_token, uint32_t* out_generation_before,
+                                               uint32_t* out_generation_after) {
+    if (!rtl_stream_tagged_completion_test_args_valid(first_token, second_token, out_coalesced_token,
+                                                      out_generation_before, out_generation_after)) {
+        return -1;
+    }
+
+    int initialized_output = 0;
+    int prepare_rc = fsk_reacquire_test_prepare_output_ring(queued_samples, &initialized_output);
+    if (prepare_rc != 0) {
+        fsk_reacquire_test_cleanup_output_ring(initialized_output);
+        return prepare_rc;
+    }
+
+    controller_state test_controller = {};
+    controller_init(&test_controller);
+    uint32_t first_request_id = schedule_manual_retune_on_controller(&test_controller, 855000000U, first_token);
+    uint32_t second_request_id = schedule_manual_retune_on_controller(&test_controller, 851000000U, second_token);
+    ControllerRetuneWork work = {};
+    if (!controller_wait_for_retune_work(&test_controller, &work) || !work.manual_pending) {
+        controller_cleanup(&test_controller);
+        fsk_reacquire_test_cleanup_output_ring(initialized_output);
+        return -2;
+    }
+
+    ring_clear(&output);
+    output.tail.store(0U, std::memory_order_release);
+    output.head.store(queued_samples, std::memory_order_release);
+    *out_coalesced_token = work.manual_token;
+    *out_generation_before = dsd_rtl_stream_output_generation();
+    controller_finish_manual_retune(&test_controller, &work, RTL_STREAM_TUNE_OK, 1);
+    *out_generation_after = dsd_rtl_stream_output_generation();
+
+    int completion_result = RTL_STREAM_TUNE_FAILED;
+    dsd_mutex_lock(&test_controller.retune_done_m);
+    int completion_found =
+        controller_load_retune_completion_result_locked(&test_controller, first_request_id, &completion_result);
+    dsd_mutex_unlock(&test_controller.retune_done_m);
+
+    controller_cleanup(&test_controller);
+    ring_clear(&output);
+    fsk_reacquire_test_cleanup_output_ring(initialized_output);
+    if (!rtl_stream_tagged_completion_test_result_valid(first_token, second_token, first_request_id, second_request_id,
+                                                        work.manual_token, completion_found, completion_result)) {
+        return -3;
+    }
+    return 0;
+}
+
+extern "C" int
+dsd_rtl_stream_test_cancel_queued_tagged_retune(uint64_t token, int* out_pending_after, int* out_completion_result) {
+    if (token == 0U || !out_pending_after || !out_completion_result) {
+        return -1;
+    }
+
+    controller_state test_controller = {};
+    controller_init(&test_controller);
+    uint32_t request_id = schedule_manual_retune_on_controller(&test_controller, 855000000U, token);
+    ControllerRetuneCancellation cancelled = controller_detach_queued_manual_retune(&test_controller);
+    uint32_t rejected_request_id = schedule_manual_retune_on_controller(&test_controller, 851000000U, token + 1U);
+    *out_pending_after = test_controller.manual_retune_pending.load(std::memory_order_acquire);
+    controller_finish_cancelled_manual_retune(&test_controller, &cancelled);
+
+    int completion_found = 0;
+    dsd_mutex_lock(&test_controller.retune_done_m);
+    completion_found =
+        controller_load_retune_completion_result_locked(&test_controller, request_id, out_completion_result);
+    dsd_mutex_unlock(&test_controller.retune_done_m);
+    controller_cleanup(&test_controller);
+
+    return (request_id != 0U && cancelled.pending && cancelled.request_id == request_id && rejected_request_id == 0U
+            && completion_found)
+               ? 0
+               : -2;
+}
+
+extern "C" int
+dsd_rtl_stream_test_cancel_queued_tagged_retune_order(uint64_t active_token, uint64_t queued_token,
+                                                      int* out_active_result, int* out_cancelled_result) {
+    if (active_token == 0U || queued_token == 0U || active_token == queued_token || !out_active_result
+        || !out_cancelled_result) {
+        return -1;
+    }
+
+    controller_state test_controller = {};
+    controller_init(&test_controller);
+    uint32_t active_request_id = schedule_manual_retune_on_controller(&test_controller, 855000000U, active_token);
+    ControllerRetuneWork active = {};
+    if (!controller_wait_for_retune_work(&test_controller, &active) || !active.manual_pending) {
+        controller_cleanup(&test_controller);
+        return -2;
+    }
+    uint32_t queued_request_id = schedule_manual_retune_on_controller(&test_controller, 851000000U, queued_token);
+    ControllerRetuneCancellation cancelled = controller_detach_queued_manual_retune(&test_controller);
+    uint32_t rejected_request_id = schedule_manual_retune_on_controller(&test_controller, 852000000U, queued_token);
+
+    controller_finish_manual_retune(&test_controller, &active, RTL_STREAM_TUNE_OK, 0);
+    controller_finish_cancelled_manual_retune(&test_controller, &cancelled);
+
+    int active_found = 0;
+    int cancelled_found = 0;
+    dsd_mutex_lock(&test_controller.retune_done_m);
+    active_found =
+        controller_load_retune_completion_result_locked(&test_controller, active_request_id, out_active_result);
+    cancelled_found =
+        controller_load_retune_completion_result_locked(&test_controller, queued_request_id, out_cancelled_result);
+    dsd_mutex_unlock(&test_controller.retune_done_m);
+    controller_cleanup(&test_controller);
+
+    return (active_request_id != 0U && queued_request_id == active_request_id + 1U && cancelled.pending
+            && cancelled.request_id == queued_request_id && rejected_request_id == 0U && active_found
+            && cancelled_found)
+               ? 0
+               : -3;
+}
+
+extern "C" int
+dsd_rtl_stream_test_tune_completion_callback_registered(void) {
+    std::lock_guard<std::mutex> lock(g_tune_completion_callback_mutex);
+    return g_tune_completion_registration ? 1 : 0;
+}
+
+extern "C" int
+dsd_rtl_stream_test_retune_without_controller_rejected(void) {
+    RtlSdrInternals* previous_stream = g_stream;
+    g_cqpsk_toggle_test_stream.controller_thread_started.store(0, std::memory_order_release);
+    g_stream = &g_cqpsk_toggle_test_stream;
+    uint32_t request_id = schedule_manual_retune_on_controller(&controller, 855000000U, UINT64_C(0x1234));
+    g_stream = previous_stream;
+    return request_id == 0U ? 1 : 0;
 }
 
 extern "C" int

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -4200,7 +4200,7 @@ controller_signal_manual_retune_complete(struct controller_state* s, int result)
     controller_store_retune_completion_result_locked(s, request_id, result);
     s->retune_complete_id.store(request_id, std::memory_order_release);
     uint32_t gated_request_id = s->untagged_timeout_gate_request_id.load(std::memory_order_acquire);
-    if (gated_request_id != 0U && request_id >= gated_request_id) {
+    if (result == RTL_STREAM_TUNE_OK && gated_request_id != 0U && request_id >= gated_request_id) {
         s->untagged_timeout_gate_request_id.store(0U, std::memory_order_release);
     }
     dsd_cond_broadcast(&s->retune_done_cond);
@@ -4214,12 +4214,22 @@ controller_gate_untagged_timeout(struct controller_state* s, uint32_t request_id
     }
 
     /* Preserve a newer gate if multiple untagged callers time out while
-     * requests are queued. The active-reader handshake guarantees that once
-     * this function returns, no pre-gate read can still reach its caller. */
+     * requests are queued. Advancing the output generation invalidates both
+     * decoder-owned caches and a read that has copied samples but has not yet
+     * completed its consumer-side handoff. The active-reader handshake then
+     * waits for any in-progress ring copy to leave the shared output. */
     uint32_t gated_request_id = s->untagged_timeout_gate_request_id.load(std::memory_order_acquire);
-    while ((gated_request_id == 0U || request_id > gated_request_id)
-           && !s->untagged_timeout_gate_request_id.compare_exchange_weak(
-               gated_request_id, request_id, std::memory_order_acq_rel, std::memory_order_acquire)) {}
+    int gate_advanced = 0;
+    while (gated_request_id == 0U || request_id > gated_request_id) {
+        if (s->untagged_timeout_gate_request_id.compare_exchange_weak(
+                gated_request_id, request_id, std::memory_order_acq_rel, std::memory_order_acquire)) {
+            gate_advanced = 1;
+            break;
+        }
+    }
+    if (gate_advanced) {
+        rtl_stream_bump_output_generation();
+    }
     rtl_stream_signal_output_waiters(g_stream && g_stream->output ? g_stream->output : &output);
     while (s->live_output_read_active.load(std::memory_order_acquire)) {
         dsd_sleep_ms(1);
@@ -6745,6 +6755,14 @@ rtl_stream_read_live_available(struct controller_state* s, struct output_state* 
         got = 0;
     }
     s->live_output_read_active.fetch_sub(1, std::memory_order_acq_rel);
+    /* The timeout thread may install its gate after the pre-release checks but
+     * before observing the reader count reach zero. Reject that handoff here;
+     * the orchestrator also validates this generation after the call returns. */
+    *out_gated = s->untagged_timeout_gate_request_id.load(std::memory_order_acquire) != 0U;
+    generation_after = g_rtl_output_generation.load(std::memory_order_acquire);
+    if (*out_gated || generation_after != generation_before) {
+        got = 0;
+    }
     return got;
 }
 
@@ -8076,8 +8094,11 @@ dsd_rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samp
 
 extern "C" int
 dsd_rtl_stream_test_untagged_timeout_read_gate(size_t queued_samples, int* out_read_while_pending,
-                                               size_t* out_used_while_pending, int* out_read_after_completion) {
-    if (queued_samples == 0U || !out_read_while_pending || !out_used_while_pending || !out_read_after_completion) {
+                                               size_t* out_used_while_pending, int* out_read_after_failed_completion,
+                                               int* out_read_after_recovery, uint32_t* out_generation_before,
+                                               uint32_t* out_generation_after_gate) {
+    if (queued_samples == 0U || !out_read_while_pending || !out_used_while_pending || !out_read_after_failed_completion
+        || !out_read_after_recovery || !out_generation_before || !out_generation_after_gate) {
         return -1;
     }
 
@@ -8095,20 +8116,32 @@ dsd_rtl_stream_test_untagged_timeout_read_gate(size_t queued_samples, int* out_r
     test_output.tail.store(0U, std::memory_order_release);
     test_output.head.store(queued_samples, std::memory_order_release);
 
+    *out_generation_before = dsd_rtl_stream_output_generation();
     controller_gate_untagged_timeout(&test_controller, 1U);
+    *out_generation_after_gate = dsd_rtl_stream_output_generation();
     float sample = 0.0f;
     int gated = 0;
     *out_read_while_pending = rtl_stream_read_live_available(&test_controller, &test_output, &sample, 1U, &gated);
     *out_used_while_pending = ring_used(&test_output);
 
+    controller_signal_manual_retune_complete(&test_controller, RTL_STREAM_TUNE_FAILED);
+    int gated_after_failure = 0;
+    *out_read_after_failed_completion =
+        rtl_stream_read_live_available(&test_controller, &test_output, &sample, 1U, &gated_after_failure);
+
+    /* A successful controller boundary drains the stale ring before reopening
+     * reads. Seed one replacement sample to verify that fresh output is live. */
+    ring_clear(&test_output);
+    test_output.tail.store(0U, std::memory_order_release);
+    test_output.head.store(1U, std::memory_order_release);
     controller_signal_manual_retune_complete(&test_controller, RTL_STREAM_TUNE_OK);
-    int gated_after_completion = 0;
-    *out_read_after_completion =
-        rtl_stream_read_live_available(&test_controller, &test_output, &sample, 1U, &gated_after_completion);
+    int gated_after_recovery = 0;
+    *out_read_after_recovery =
+        rtl_stream_read_live_available(&test_controller, &test_output, &sample, 1U, &gated_after_recovery);
 
     controller_cleanup(&test_controller);
     output_cleanup(&test_output);
-    return (gated && !gated_after_completion) ? 0 : -3;
+    return (gated && gated_after_failure && !gated_after_recovery) ? 0 : -3;
 }
 
 extern "C" int

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -3388,7 +3388,6 @@ static DSD_THREAD_RETURN_TYPE
         rtl_monitor_side_tap_process(d);
         demod_log_retune_diag_block(d, span.got, &retune_diag);
         demod_input_span_release_direct(d, &span);
-        demod_update_replay_drain_state(replay_active, consumed_gen);
         uint64_t perf_metrics_ns = demod_metrics_process(d, perf_on);
         if (d->exit_flag) {
             exitflag = 1;
@@ -3397,6 +3396,11 @@ static DSD_THREAD_RETURN_TYPE
         uint64_t perf_output_start_ns = perf_on ? rtl_perf_now_ns() : 0ULL;
         size_t perf_output_samples =
             controller.retune_in_progress.load(std::memory_order_acquire) ? 0U : demod_write_output_block(d, o);
+        /* A replay generation is consumed only after its demodulated output is
+         * committed. RESET/rewind boundaries use this generation to avoid
+         * entering the reconfigure gate between DSP processing and the output
+         * write, which would silently discard every pass of a short loop. */
+        demod_update_replay_drain_state(replay_active, consumed_gen);
         demod_perf_log_block(perf_on, perf_output_start_ns, perf_full_demod_ns, perf_metrics_ns, span.got,
                              perf_output_samples, d);
         demod_leave_processing_block(&controller);
@@ -3881,6 +3885,16 @@ replay_wait_for_input_purge_applied(void) {
     while (g_ring_purge_pending.load(std::memory_order_acquire) && !exitflag
            && !(g_stream && g_stream->should_exit.load(std::memory_order_acquire))
            && dsd_time_monotonic_ns() < deadline_ns) {
+        /* Replay callbacks run on the sole producer after the controller has
+         * waited for demod processing to go idle. If the ring is already
+         * empty, there is no consumer-owned tail to advance and no producer
+         * reservation that can race this acknowledgement. Waking a consumer
+         * blocked on an empty-ring predicate cannot make it observe the purge,
+         * so complete it here instead of paying the full timeout every loop. */
+        if (input_ring_used(&input_ring) == 0U && g_ring_purge_pending.exchange(0, std::memory_order_acq_rel)) {
+            replay_note_input_purge_consumed();
+            break;
+        }
         safe_cond_signal(&input_ring.ready, &input_ring.ready_m);
         dsd_sleep_ms(1);
     }
@@ -3923,6 +3937,11 @@ rtl_replay_on_reset_event(const dsd_iq_event* event, void* user) {
     uint32_t previous_center_hz = controller.last_applied_freq_hz.load(std::memory_order_acquire);
     int previous_rate_out_hz = demod.rate_out;
     DemodRetuneResetReason reset_reason = retune_reset_reason_from_name(event->reason);
+    /* Replay data before a RESET is already fully demodulated. Preserve that
+     * ordered output before the reconfigure gate clears the ring; otherwise a
+     * short fast-mode loop can continually erase its own output before the
+     * consumer gets scheduled. */
+    drain_output_on_retune();
     store_dongle_frequency(capture_hz);
     store_dongle_rate(event->sample_rate_hz);
     controller_enter_reconfigure_gate(&controller);
@@ -3931,7 +3950,6 @@ rtl_replay_on_reset_event(const dsd_iq_event* event, void* user) {
                                     previous_center_hz, previous_rate_out_hz, NULL);
     controller_end_reconfigure(&controller);
     replay_wait_for_input_purge_applied();
-    drain_output_on_retune();
     g_replay_event_last_reset_reason.store((int)reset_reason, std::memory_order_release);
     g_replay_event_last_frequency_hz.store(center_hz, std::memory_order_release);
     g_replay_event_reset_count.fetch_add(1U, std::memory_order_acq_rel);
@@ -3943,12 +3961,14 @@ rtl_replay_on_loop_restart(const dsd_iq_replay_config* cfg, void* user) {
     if (!cfg) {
         return;
     }
+    /* Rewind is an ordered replay boundary. Let the consumer take the final
+     * output from this pass before restoring the capture's initial settings. */
+    drain_output_on_retune();
     controller_enter_reconfigure_gate(&controller);
     controller_request_input_purge();
     (void)controller_apply_replay_settings(&controller, g_stream ? g_stream->opts : NULL, cfg);
     controller_end_reconfigure(&controller);
     replay_wait_for_input_purge_applied();
-    drain_output_on_retune();
     g_replay_loop_restart_last_frequency_hz.store(controller.last_applied_freq_hz.load(std::memory_order_acquire),
                                                   std::memory_order_release);
     g_replay_loop_restart_count.fetch_add(1U, std::memory_order_acq_rel);
@@ -4200,7 +4220,12 @@ controller_signal_manual_retune_complete(struct controller_state* s, int result)
     controller_store_retune_completion_result_locked(s, request_id, result);
     s->retune_complete_id.store(request_id, std::memory_order_release);
     uint32_t gated_request_id = s->untagged_timeout_gate_request_id.load(std::memory_order_acquire);
-    if (result == RTL_STREAM_TUNE_OK && gated_request_id != 0U && request_id >= gated_request_id) {
+    /* Every terminal completion closes the timed-out request's read gate. A
+     * failed apply has already restored the prior capture settings and crossed
+     * the controller reconfigure/output boundary before completion is
+     * published, so retaining the gate cannot protect any additional state and
+     * would permanently block legacy decoder-driven tune paths. */
+    if (gated_request_id != 0U && request_id >= gated_request_id) {
         s->untagged_timeout_gate_request_id.store(0U, std::memory_order_release);
     }
     dsd_cond_broadcast(&s->retune_done_cond);
@@ -8125,12 +8150,19 @@ dsd_rtl_stream_test_untagged_timeout_read_gate(size_t queued_samples, int* out_r
     *out_used_while_pending = ring_used(&test_output);
 
     controller_signal_manual_retune_complete(&test_controller, RTL_STREAM_TUNE_FAILED);
+    /* A failed controller apply has restored the previous capture state and
+     * cleared the pre-apply output boundary. Model fresh output produced after
+     * that recovery rather than exposing the pre-timeout samples. */
+    ring_clear(&test_output);
+    test_output.tail.store(0U, std::memory_order_release);
+    test_output.head.store(1U, std::memory_order_release);
     int gated_after_failure = 0;
     *out_read_after_failed_completion =
         rtl_stream_read_live_available(&test_controller, &test_output, &sample, 1U, &gated_after_failure);
 
-    /* A successful controller boundary drains the stale ring before reopening
-     * reads. Seed one replacement sample to verify that fresh output is live. */
+    /* A later timed-out request can install a fresh gate. Its successful
+     * controller boundary reopens reads for replacement output. */
+    controller_gate_untagged_timeout(&test_controller, 2U);
     ring_clear(&test_output);
     test_output.tail.store(0U, std::memory_order_release);
     test_output.head.store(1U, std::memory_order_release);
@@ -8141,7 +8173,7 @@ dsd_rtl_stream_test_untagged_timeout_read_gate(size_t queued_samples, int* out_r
 
     controller_cleanup(&test_controller);
     output_cleanup(&test_output);
-    return (gated && gated_after_failure && !gated_after_recovery) ? 0 : -3;
+    return (gated && !gated_after_failure && !gated_after_recovery) ? 0 : -3;
 }
 
 extern "C" int

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -265,6 +265,10 @@ struct controller_state {
     /* Request ID for matching completion signals to requests (prevents stale wakeups) */
     std::atomic<uint32_t> retune_request_id{0U};
     std::atomic<uint32_t> retune_complete_id{0U};
+    /* Untagged calls have no asynchronous callback. If their synchronous wait
+     * times out, keep consumer reads closed until this request completes. */
+    std::atomic<uint32_t> untagged_timeout_gate_request_id{0U};
+    std::atomic<int> live_output_read_active{0};
     uint32_t retune_complete_result_ids[kRetuneCompletionResultSlots]{};
     int retune_complete_results[kRetuneCompletionResultSlots]{};
     /* Last center frequency successfully applied by the controller thread. */
@@ -4195,8 +4199,31 @@ controller_signal_manual_retune_complete(struct controller_state* s, int result)
     uint32_t request_id = s->retune_complete_id.load(std::memory_order_acquire) + 1U;
     controller_store_retune_completion_result_locked(s, request_id, result);
     s->retune_complete_id.store(request_id, std::memory_order_release);
+    uint32_t gated_request_id = s->untagged_timeout_gate_request_id.load(std::memory_order_acquire);
+    if (gated_request_id != 0U && request_id >= gated_request_id) {
+        s->untagged_timeout_gate_request_id.store(0U, std::memory_order_release);
+    }
     dsd_cond_broadcast(&s->retune_done_cond);
     dsd_mutex_unlock(&s->retune_done_m);
+}
+
+static void
+controller_gate_untagged_timeout(struct controller_state* s, uint32_t request_id) {
+    if (!s || request_id == 0U) {
+        return;
+    }
+
+    /* Preserve a newer gate if multiple untagged callers time out while
+     * requests are queued. The active-reader handshake guarantees that once
+     * this function returns, no pre-gate read can still reach its caller. */
+    uint32_t gated_request_id = s->untagged_timeout_gate_request_id.load(std::memory_order_acquire);
+    while ((gated_request_id == 0U || request_id > gated_request_id)
+           && !s->untagged_timeout_gate_request_id.compare_exchange_weak(
+               gated_request_id, request_id, std::memory_order_acq_rel, std::memory_order_acquire)) {}
+    rtl_stream_signal_output_waiters(g_stream && g_stream->output ? g_stream->output : &output);
+    while (s->live_output_read_active.load(std::memory_order_acquire)) {
+        dsd_sleep_ms(1);
+    }
 }
 
 static int
@@ -4981,6 +5008,8 @@ controller_init(struct controller_state* s) {
     s->retune_done_flag.store(0);
     s->retune_request_id.store(0);
     s->retune_complete_id.store(0);
+    s->untagged_timeout_gate_request_id.store(0);
+    s->live_output_read_active.store(0);
     controller_clear_retune_completion_results(s);
     s->last_applied_freq_hz.store(0, std::memory_order_release);
     s->reconfigure_seq.store(0, std::memory_order_release);
@@ -6695,6 +6724,62 @@ rtl_stream_replay_mark_output_drained(void) {
 }
 
 static int
+rtl_stream_read_live_available(struct controller_state* s, struct output_state* outp, float* out, size_t count,
+                               int* out_gated) {
+    if (!s || !outp || !out_gated) {
+        return -1;
+    }
+
+    *out_gated = s->untagged_timeout_gate_request_id.load(std::memory_order_acquire) != 0U;
+    if (*out_gated) {
+        return 0;
+    }
+
+    s->live_output_read_active.fetch_add(1, std::memory_order_acq_rel);
+    uint32_t generation_before = g_rtl_output_generation.load(std::memory_order_acquire);
+    *out_gated = s->untagged_timeout_gate_request_id.load(std::memory_order_acquire) != 0U;
+    int got = *out_gated ? 0 : ring_read_available(outp, out, count);
+    uint32_t generation_after = g_rtl_output_generation.load(std::memory_order_acquire);
+    *out_gated = s->untagged_timeout_gate_request_id.load(std::memory_order_acquire) != 0U;
+    if (*out_gated || generation_after != generation_before) {
+        got = 0;
+    }
+    s->live_output_read_active.fetch_sub(1, std::memory_order_acq_rel);
+    return got;
+}
+
+static int
+rtl_stream_read_live_samples(float* out, size_t count) {
+    for (;;) {
+        if (!output.buffer || exitflag || (g_stream && g_stream->should_exit.load(std::memory_order_acquire))) {
+            return -1;
+        }
+
+        int gated = 0;
+        int got = rtl_stream_read_live_available(&controller, &output, out, count, &gated);
+        if (got != 0) {
+            return got;
+        }
+
+        if (gated) {
+            dsd_mutex_lock(&controller.retune_done_m);
+            if (controller.untagged_timeout_gate_request_id.load(std::memory_order_acquire) != 0U) {
+                (void)dsd_cond_timedwait(&controller.retune_done_cond, &controller.retune_done_m, 10);
+            }
+            dsd_mutex_unlock(&controller.retune_done_m);
+            continue;
+        }
+
+        dsd_mutex_lock(&output.ready_m);
+        int wait_rc = dsd_cond_timedwait(&output.ready, &output.ready_m, 10);
+        dsd_mutex_unlock(&output.ready_m);
+        if (wait_rc != 0) {
+            output.read_timeouts.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+}
+
+static int
 rtl_stream_read_live(float* out, size_t count, dsd_opts* opts, const dsd_state* state) {
     sync_requested_ppm_after_failed_apply(opts);
     auto_ppm_maybe_adjust(opts, state);
@@ -6702,7 +6787,7 @@ rtl_stream_read_live(float* out, size_t count, dsd_opts* opts, const dsd_state* 
 
     int perf_on = rtl_perf_enabled();
     uint64_t perf_read_start_ns = perf_on ? rtl_perf_now_ns() : 0ULL;
-    int got = ring_read_batch(&output, out, count);
+    int got = rtl_stream_read_live_samples(out, count);
     if (got <= 0) {
         return -1;
     }
@@ -7670,6 +7755,9 @@ rtl_stream_tune_wait_for_completion(uint32_t request_id, uint32_t requested_freq
         uint64_t now_ns = dsd_time_monotonic_ns();
         if (now_ns >= deadline_ns) {
             rtl_stream_log_tune_warning(requested_freq, "timeout");
+            if (!tagged_request) {
+                controller_gate_untagged_timeout(&controller, request_id);
+            }
             rc = RTL_STREAM_TUNE_TIMEOUT;
             break;
         }
@@ -7984,6 +8072,43 @@ dsd_rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samp
         output_cleanup(&output);
     }
     return 0;
+}
+
+extern "C" int
+dsd_rtl_stream_test_untagged_timeout_read_gate(size_t queued_samples, int* out_read_while_pending,
+                                               size_t* out_used_while_pending, int* out_read_after_completion) {
+    if (queued_samples == 0U || !out_read_while_pending || !out_used_while_pending || !out_read_after_completion) {
+        return -1;
+    }
+
+    output_state test_output = {};
+    output_init(&test_output);
+    if (!test_output.buffer || queued_samples >= test_output.capacity) {
+        if (test_output.buffer) {
+            output_cleanup(&test_output);
+        }
+        return -2;
+    }
+
+    controller_state test_controller = {};
+    controller_init(&test_controller);
+    test_output.tail.store(0U, std::memory_order_release);
+    test_output.head.store(queued_samples, std::memory_order_release);
+
+    controller_gate_untagged_timeout(&test_controller, 1U);
+    float sample = 0.0f;
+    int gated = 0;
+    *out_read_while_pending = rtl_stream_read_live_available(&test_controller, &test_output, &sample, 1U, &gated);
+    *out_used_while_pending = ring_used(&test_output);
+
+    controller_signal_manual_retune_complete(&test_controller, RTL_STREAM_TUNE_OK);
+    int gated_after_completion = 0;
+    *out_read_after_completion =
+        rtl_stream_read_live_available(&test_controller, &test_output, &sample, 1U, &gated_after_completion);
+
+    controller_cleanup(&test_controller);
+    output_cleanup(&test_output);
+    return (gated && !gated_after_completion) ? 0 : -3;
 }
 
 extern "C" int

--- a/src/io/radio/rtl_stream.cpp
+++ b/src/io/radio/rtl_stream.cpp
@@ -25,6 +25,7 @@ extern "C" {
 int dsd_rtl_stream_open(dsd_opts* opts);
 void dsd_rtl_stream_close(void);
 int dsd_rtl_stream_read(float* out, size_t count, dsd_opts* opts, const dsd_state* state);
+uint32_t dsd_rtl_stream_output_generation(void);
 int dsd_rtl_stream_tune(dsd_opts* opts, long int frequency);
 int dsd_rtl_stream_tune_tagged(dsd_opts* opts, long int frequency, uint64_t token);
 unsigned int dsd_rtl_stream_output_rate(void);
@@ -217,14 +218,20 @@ RtlSdrOrchestrator::read(float* out, size_t count, int& out_got) {
         last_error_code_ = -2;
         return last_error_code_;
     }
-    int got = dsd_rtl_stream_read(out, count, opts_, nullptr);
-    if (got < 0) {
-        last_error_code_ = got;
-        return got;
+    for (;;) {
+        const uint32_t generation_before = dsd_rtl_stream_output_generation();
+        int got = dsd_rtl_stream_read(out, count, opts_, nullptr);
+        if (got < 0) {
+            last_error_code_ = got;
+            return got;
+        }
+        if (dsd_rtl_stream_output_generation() != generation_before) {
+            continue;
+        }
+        out_got = got;
+        last_error_code_ = 0;
+        return 0;
     }
-    out_got = got;
-    last_error_code_ = 0;
-    return 0;
 }
 
 /**

--- a/src/io/radio/rtl_stream.cpp
+++ b/src/io/radio/rtl_stream.cpp
@@ -14,6 +14,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/io/rtl_stream.h>
+#include <dsd-neo/io/rtl_stream_c.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -25,6 +26,7 @@ int dsd_rtl_stream_open(dsd_opts* opts);
 void dsd_rtl_stream_close(void);
 int dsd_rtl_stream_read(float* out, size_t count, dsd_opts* opts, const dsd_state* state);
 int dsd_rtl_stream_tune(dsd_opts* opts, long int frequency);
+int dsd_rtl_stream_tune_tagged(dsd_opts* opts, long int frequency, uint64_t token);
 unsigned int dsd_rtl_stream_output_rate(void);
 int dsd_rtl_stream_soft_stop(void);
 int rtl_stream_request_ppm(dsd_opts* opts, int ppm);
@@ -155,6 +157,25 @@ RtlSdrOrchestrator::tune(uint32_t center_freq_hz) {
     }
     last_error_code_ = 0;
     return 0;
+}
+
+int
+RtlSdrOrchestrator::tune_tagged(uint32_t center_freq_hz, uint64_t token) {
+    if (!started_) {
+        last_error_code_ = -1;
+        return last_error_code_;
+    }
+    if (!opts_) {
+        last_error_code_ = -2;
+        return last_error_code_;
+    }
+    if (token == 0U) {
+        last_error_code_ = RTL_STREAM_TUNE_FAILED;
+        return last_error_code_;
+    }
+    int rc = dsd_rtl_stream_tune_tagged(opts_, (long int)center_freq_hz, token);
+    last_error_code_ = rc;
+    return rc;
 }
 
 int

--- a/src/io/radio/rtl_stream.cpp
+++ b/src/io/radio/rtl_stream.cpp
@@ -218,6 +218,7 @@ RtlSdrOrchestrator::read(float* out, size_t count, int& out_got) {
         last_error_code_ = -2;
         return last_error_code_;
     }
+    const bool replay_active = opts_->iq_replay_active != 0;
     for (;;) {
         const uint32_t generation_before = dsd_rtl_stream_output_generation();
         int got = dsd_rtl_stream_read(out, count, opts_, nullptr);
@@ -225,7 +226,14 @@ RtlSdrOrchestrator::read(float* out, size_t count, int& out_got) {
             last_error_code_ = got;
             return got;
         }
-        if (dsd_rtl_stream_output_generation() != generation_before) {
+        /* Replay RESET/rewind boundaries wait for the submitted demod
+         * generation before advancing the timeline. The final pre-boundary
+         * output batch is therefore valid even when the replay thread advances
+         * the output generation immediately after the read. Retrying that
+         * batch can starve forever on a short looping capture. Live retunes do
+         * not have this ordering guarantee and must still reject a stale
+         * handoff. */
+        if (!replay_active && dsd_rtl_stream_output_generation() != generation_before) {
             continue;
         }
         out_got = got;

--- a/src/io/radio/rtl_stream_c.cpp
+++ b/src/io/radio/rtl_stream_c.cpp
@@ -76,6 +76,7 @@ int dsd_rtl_stream_get_auto_ppm(void);
 int dsd_rtl_stream_set_rtltcp_autotune(int onoff);
 int dsd_rtl_stream_get_rtltcp_autotune(void);
 int dsd_rtl_stream_get_last_applied_freq(uint32_t* out_freq_hz);
+void dsd_rtl_stream_register_tune_completion_callback(rtl_stream_tune_completion_callback callback, void* user_data);
 /* Eye-based SNR fallback */
 double dsd_rtl_stream_estimate_snr_c4fm_eye(void);
 double dsd_rtl_stream_estimate_snr_qpsk_const(void);
@@ -123,6 +124,9 @@ int dsd_rtl_stream_test_retune_profile_request_binding(int* out_first_profile, i
 int dsd_rtl_stream_test_retune_profile_coalesced_no_profile(int* out_profile, uint32_t* out_profile_freq_hz,
                                                             uint32_t* out_manual_freq_hz, uint32_t* out_request_id,
                                                             uint32_t* out_coalesced_request_id);
+int dsd_rtl_stream_test_tagged_completion_boundary(uint64_t first_token, uint64_t second_token, size_t queued_samples,
+                                                   uint64_t* out_coalesced_token, uint32_t* out_generation_before,
+                                                   uint32_t* out_generation_after);
 int dsd_rtl_stream_test_retune_profile_gain_binding(int* out_gain_is_set, int* out_gain_tenth_db, int* out_gain_is_auto,
                                                     int* out_autogain_is_set, int* out_autogain_on);
 int dsd_rtl_stream_test_get_replay_state(rtl_stream_test_replay_state* out_state);
@@ -253,6 +257,19 @@ rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz) {
     return ctx->stream->tune(center_freq_hz);
 }
 
+extern "C" int
+rtl_stream_tune_tagged(RtlSdrContext* ctx, uint32_t center_freq_hz, uint64_t token) {
+    if (!ctx || !ctx->stream || token == 0U) {
+        return RTL_STREAM_TUNE_FAILED;
+    }
+    return ctx->stream->tune_tagged(center_freq_hz, token);
+}
+
+extern "C" void
+rtl_stream_register_tune_completion_callback(rtl_stream_tune_completion_callback callback, void* user_data) {
+    dsd_rtl_stream_register_tune_completion_callback(callback, user_data);
+}
+
 #if defined(DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS)
 extern "C" int
 rtl_stream_test_request_retune(const RtlSdrContext* ctx, uint32_t freq_hz, int timeout_ms) {
@@ -351,6 +368,14 @@ rtl_stream_test_retune_profile_coalesced_no_profile(int* out_profile, uint32_t* 
                                                     uint32_t* out_coalesced_request_id) {
     return dsd_rtl_stream_test_retune_profile_coalesced_no_profile(out_profile, out_profile_freq_hz, out_manual_freq_hz,
                                                                    out_request_id, out_coalesced_request_id);
+}
+
+extern "C" int
+rtl_stream_test_tagged_completion_boundary(uint64_t first_token, uint64_t second_token, size_t queued_samples,
+                                           uint64_t* out_coalesced_token, uint32_t* out_generation_before,
+                                           uint32_t* out_generation_after) {
+    return dsd_rtl_stream_test_tagged_completion_boundary(
+        first_token, second_token, queued_samples, out_coalesced_token, out_generation_before, out_generation_after);
 }
 
 extern "C" int

--- a/src/io/radio/rtl_stream_c.cpp
+++ b/src/io/radio/rtl_stream_c.cpp
@@ -101,6 +101,8 @@ int dsd_rtl_stream_test_retune_output_pending(size_t queued_samples, int cached_
 int dsd_rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samples, int cached_symbols,
                                                  size_t* out_used_after, int* out_cache_pending_after,
                                                  uint32_t* out_generation_before, uint32_t* out_generation_after);
+int dsd_rtl_stream_test_untagged_timeout_read_gate(size_t queued_samples, int* out_read_while_pending,
+                                                   size_t* out_used_while_pending, int* out_read_after_completion);
 int dsd_rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size_t* out_used_after,
                                      int* out_cache_pending_after, uint32_t* out_generation_before,
                                      uint32_t* out_generation_after);
@@ -300,6 +302,13 @@ rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samples,
     return dsd_rtl_stream_test_tune_result_output_drain(tune_result, queued_samples, cached_symbols, out_used_after,
                                                         out_cache_pending_after, out_generation_before,
                                                         out_generation_after);
+}
+
+extern "C" int
+rtl_stream_test_untagged_timeout_read_gate(size_t queued_samples, int* out_read_while_pending,
+                                           size_t* out_used_while_pending, int* out_read_after_completion) {
+    return dsd_rtl_stream_test_untagged_timeout_read_gate(queued_samples, out_read_while_pending,
+                                                          out_used_while_pending, out_read_after_completion);
 }
 
 extern "C" int

--- a/src/io/radio/rtl_stream_c.cpp
+++ b/src/io/radio/rtl_stream_c.cpp
@@ -102,7 +102,10 @@ int dsd_rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_
                                                  size_t* out_used_after, int* out_cache_pending_after,
                                                  uint32_t* out_generation_before, uint32_t* out_generation_after);
 int dsd_rtl_stream_test_untagged_timeout_read_gate(size_t queued_samples, int* out_read_while_pending,
-                                                   size_t* out_used_while_pending, int* out_read_after_completion);
+                                                   size_t* out_used_while_pending,
+                                                   int* out_read_after_failed_completion, int* out_read_after_recovery,
+                                                   uint32_t* out_generation_before,
+                                                   uint32_t* out_generation_after_gate);
 int dsd_rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size_t* out_used_after,
                                      int* out_cache_pending_after, uint32_t* out_generation_before,
                                      uint32_t* out_generation_after);
@@ -306,9 +309,12 @@ rtl_stream_test_tune_result_output_drain(int tune_result, size_t queued_samples,
 
 extern "C" int
 rtl_stream_test_untagged_timeout_read_gate(size_t queued_samples, int* out_read_while_pending,
-                                           size_t* out_used_while_pending, int* out_read_after_completion) {
-    return dsd_rtl_stream_test_untagged_timeout_read_gate(queued_samples, out_read_while_pending,
-                                                          out_used_while_pending, out_read_after_completion);
+                                           size_t* out_used_while_pending, int* out_read_after_failed_completion,
+                                           int* out_read_after_recovery, uint32_t* out_generation_before,
+                                           uint32_t* out_generation_after_gate) {
+    return dsd_rtl_stream_test_untagged_timeout_read_gate(
+        queued_samples, out_read_while_pending, out_used_while_pending, out_read_after_failed_completion,
+        out_read_after_recovery, out_generation_before, out_generation_after_gate);
 }
 
 extern "C" int

--- a/src/protocol/p25/p25_sm_watchdog.c
+++ b/src/protocol/p25/p25_sm_watchdog.c
@@ -34,6 +34,13 @@ p25_sm_tick_guard_try_enter(void) {
 }
 
 void
+p25_sm_tick_guard_enter(void) {
+    while (!p25_sm_tick_guard_try_enter()) {
+        dsd_sleep_ms(1U);
+    }
+}
+
+void
 p25_sm_tick_guard_leave(void) {
     atomic_store(&g_p25_sm_tick_lock, 0);
 }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -13,7 +13,6 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/platform/atomic_compat.h>
-#include <dsd-neo/protocol/p25/p25_cc_activity.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_frequency.h>
 #include <dsd-neo/protocol/p25/p25_sm_ui.h>

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -309,6 +309,8 @@ p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
     if (!ctx) {
         return;
     }
+    ctx->cc_tune_request_id = 0U;
+    ctx->cc_tune_pending = 0;
     ctx->t_cc_sync_m = tune_start_m;
     if (state) {
         if (state->last_cc_sync_time_m <= 0.0 || state->last_cc_sync_time_m < tune_start_m) {
@@ -327,6 +329,45 @@ p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
                  "source=%s tune_start_m=%.3f tune_m=%.3f last_cc_m=%.3f decoded_cc_m=%.3f",
                  source ? source : "unknown", tune_start_m, ctx->t_cc_tune_m, state ? state->last_cc_sync_time_m : 0.0,
                  state ? state->p25_last_cc_msg_time_m : 0.0);
+}
+
+static void
+p25_sm_wait_for_cc_tune_completion(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, uint64_t request_id,
+                                   const char* source) {
+    if (!ctx) {
+        return;
+    }
+    ctx->cc_tune_request_id = request_id;
+    ctx->cc_tune_pending = 1;
+    ctx->t_cc_tune_m = 0.0;
+    ctx->cc_sync_pending = 1;
+    if (state && state->p25_cc_eval_freq != 0) {
+        state->p25_cc_eval_start_m = 0.0;
+    }
+    p25_sm_diagf(opts, state, ctx, "cc_tune_pending", "source=%s request=%llu eval_freq=%ld",
+                 source ? source : "unknown", (unsigned long long)ctx->cc_tune_request_id,
+                 state ? state->p25_cc_eval_freq : 0);
+}
+
+static void
+p25_sm_start_cc_acquisition_for_result(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state,
+                                       dsd_trunk_tune_result tune_result, uint64_t request_id, double tune_start_m,
+                                       const char* source) {
+    if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        p25_sm_wait_for_cc_tune_completion(ctx, opts, state, request_id, source);
+        return;
+    }
+    if (request_id != 0U) {
+        double completed_m = 0.0;
+        if (dsd_trunk_tuning_request_status(request_id, &completed_m) == DSD_TRUNK_TUNE_RESULT_OK
+            && completed_m > 0.0) {
+            tune_start_m = completed_m;
+        }
+    }
+    p25_sm_start_cc_grace_after_tune(ctx, opts, state, tune_start_m, source);
+    if (state && state->p25_cc_eval_freq != 0) {
+        state->p25_cc_eval_start_m = ctx->t_cc_tune_m;
+    }
 }
 
 static int
@@ -365,6 +406,8 @@ p25_sm_cancel_pending_cc_acquisition(p25_sm_ctx_t* ctx) {
     if (!ctx) {
         return;
     }
+    ctx->cc_tune_request_id = 0U;
+    ctx->cc_tune_pending = 0;
     ctx->t_cc_tune_m = 0.0;
     ctx->cc_sync_pending = 0;
 }
@@ -484,10 +527,50 @@ set_state(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, p25_sm_stat
     sm_log(opts, state, reason);
 }
 
+/* Return 1 after successful completion, 0 while still pending, and -1 on failure. */
+static int
+p25_sm_resolve_pending_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
+    if (!ctx || !ctx->cc_tune_pending) {
+        return 1;
+    }
+
+    double completed_m = 0.0;
+    const uint64_t request_id = ctx->cc_tune_request_id;
+    dsd_trunk_tune_result result = dsd_trunk_tuning_request_status(request_id, &completed_m);
+    if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        return 0;
+    }
+
+    ctx->cc_tune_request_id = 0U;
+    ctx->cc_tune_pending = 0;
+    if (result == DSD_TRUNK_TUNE_RESULT_OK) {
+        if (completed_m <= 0.0) {
+            completed_m = now_monotonic();
+        }
+        p25_sm_start_cc_grace_after_tune(ctx, opts, state, completed_m, "async-complete");
+        if (state && state->p25_cc_eval_freq != 0) {
+            state->p25_cc_eval_start_m = ctx->t_cc_tune_m;
+        }
+        p25_sm_diagf(opts, state, ctx, "cc_tune_complete", "request=%llu completed_m=%.3f",
+                     (unsigned long long)request_id, completed_m);
+        set_state(ctx, opts, state, P25_SM_ON_CC, "cc-tune-complete");
+        return 1;
+    }
+
+    ctx->t_cc_tune_m = 0.0;
+    ctx->t_cc_sync_m = completed_m > 0.0 ? completed_m : now_monotonic();
+    ctx->cc_sync_pending = 0;
+    ctx->t_hunt_try_m = 0.0;
+    p25_sm_diagf(opts, state, ctx, "cc_tune_complete", "request=%llu result=%s", (unsigned long long)request_id,
+                 p25_tune_result_name(result));
+    set_state(ctx, opts, state, P25_SM_HUNTING, "cc-tune-failed");
+    return -1;
+}
+
 int
 p25_sm_restart_pending_cc_acquisition(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double tune_start_m,
                                       const char* source) {
-    if (!ctx || !ctx->cc_sync_pending) {
+    if (!ctx) {
         return 0;
     }
     const char* reason = source ? source : "external-retune";
@@ -498,6 +581,19 @@ p25_sm_restart_pending_cc_acquisition(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_sta
     if (state && state->p25_cc_eval_freq != 0) {
         state->p25_cc_eval_start_m = ctx->t_cc_tune_m;
     }
+    ctx->t_hunt_try_m = 0.0;
+    set_state(ctx, opts, state, P25_SM_ON_CC, reason);
+    return 1;
+}
+
+int
+p25_sm_await_pending_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, uint64_t request_id,
+                             const char* source) {
+    if (!ctx || request_id == 0U) {
+        return 0;
+    }
+    const char* reason = source ? source : "external-retune";
+    p25_sm_wait_for_cc_tune_completion(ctx, opts, state, request_id, reason);
     ctx->t_hunt_try_m = 0.0;
     set_state(ctx, opts, state, P25_SM_ON_CC, reason);
     return 1;
@@ -1142,6 +1238,23 @@ p25_grant_refresh_reused_carrier_watchdogs(dsd_state* state, double now_m) {
 }
 
 static void
+p25_grant_commit_decoder_tune(dsd_opts* opts, dsd_state* state, long freq) {
+    if (!opts || !state || freq <= 0) {
+        return;
+    }
+    const time_t now = time(NULL);
+    const double now_m = now_monotonic();
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    state->p25_vc_freq[0] = state->p25_vc_freq[1] = freq;
+    state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = freq;
+    state->last_vc_sync_time = now;
+    state->p25_last_vc_tune_time = now;
+    state->last_vc_sync_time_m = now_m;
+    state->p25_last_vc_tune_time_m = now_m;
+}
+
+static void
 p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_event_t* ev, long freq, int target_id,
                            const p25_grant_eval_ctx_t* eval_ctx, double now_m, int slot, int reused_carrier) {
     if (!ctx || !ev) {
@@ -1252,6 +1365,7 @@ p25_grant_try_tune_vc(const p25_sm_ctx_t* ctx, const p25_sm_event_t* ev, dsd_opt
                  vc_is_tdma, ted_sps, ev->tg, ev->src, ev->dst);
     dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_freq(opts, state, freq, ted_sps);
     if (dsd_trunk_tune_result_is_ok(tune_result)) {
+        p25_grant_commit_decoder_tune(opts, state, freq);
         *out_ted_sps = ted_sps;
         p25_sm_diagf(opts, state, ctx, "grant_tune_result", "ch=0x%04X freq=%ld slot=%d tdma=%d sps=%d result=%s",
                      ev->channel & 0xFFFF, freq, slot, vc_is_tdma, ted_sps, p25_tune_result_name(tune_result));
@@ -1580,8 +1694,18 @@ p25_grant_prepare_route(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* stat
 static int
 p25_grant_blocked_by_pending_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev,
                                 const p25_grant_route_ctx_t* grant) {
-    if (!ctx || !ev || !grant || !ctx->cc_sync_pending) {
+    if (!ctx || !ev || !grant || (!ctx->cc_tune_pending && !ctx->cc_sync_pending)) {
         return 0;
+    }
+    if (ctx->cc_tune_pending) {
+        int tune_status = p25_sm_resolve_pending_cc_tune(ctx, opts, state);
+        if (tune_status <= 0) {
+            p25_sm_diagf(opts, state, ctx, "grant_cc_pending",
+                         "ch=0x%04X freq=%ld slot=%d tg=%d src=%d request=%llu tune_pending=%d", ev->channel & 0xFFFF,
+                         grant->freq, grant->slot, ev->tg, ev->src, (unsigned long long)ctx->cc_tune_request_id,
+                         ctx->cc_tune_pending);
+            return 1;
+        }
     }
     (void)p25_sm_refresh_cc_sync_from_state(ctx, opts, state, "grant");
     if (!ctx->cc_sync_pending) {
@@ -2031,7 +2155,8 @@ p25_release_ctx_is_stale(const p25_sm_ctx_t* ctx, const dsd_opts* opts, const ds
 
 static int
 p25_release_return_to_cc_accepted(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int had_force_release,
-                                  double* out_tune_start_m) {
+                                  double* out_tune_start_m, dsd_trunk_tune_result* out_tune_result,
+                                  uint64_t* out_request_id) {
     if (ctx->vc_is_tdma && opts && state) {
         dsd_p25_optional_hook_p25p2_flush_partial_audio(opts, state);
     }
@@ -2042,7 +2167,10 @@ p25_release_return_to_cc_accepted(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
                  state ? ((state->p25_cc_freq != 0) ? state->p25_cc_freq : state->trunk_cc_freq) : 0,
                  ctx->vc_channel & 0xFFFF, ctx->vc_tg, had_force_release, ctx->vc_is_tdma, ctx->vc_data_call,
                  state ? state->p25_cc_is_tdma : 0, cc_ted_sps(opts, state));
-    dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_return_to_cc(opts, state);
+    dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_return_to_cc_with_id(opts, state, out_request_id);
+    if (out_tune_result) {
+        *out_tune_result = tune_result;
+    }
     if (dsd_trunk_tune_result_is_ok(tune_result)) {
         p25_sm_diagf(opts, state, ctx, "release_cc_result", "result=%s tune_start_m=%.3f",
                      p25_tune_result_name(tune_result), *out_tune_start_m);
@@ -2220,6 +2348,8 @@ static int
 p25_release_locked(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason,
                    int arm_failed_vc_backoff_on_accept) {
     double tune_start_m = 0.0;
+    dsd_trunk_tune_result tune_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    uint64_t tune_request_id = 0U;
     int had_force_release = 0;
     if (state) {
         had_force_release = (state->p25_sm_force_release != 0) ? 1 : 0;
@@ -2240,7 +2370,8 @@ p25_release_locked(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const ch
 
     // Return to CC. On failure/defer, leave VC state untouched so the watchdog
     // can retry through the same state machine instead of pretending the tuner moved.
-    if (!p25_release_return_to_cc_accepted(ctx, opts, state, had_force_release, &tune_start_m)) {
+    if (!p25_release_return_to_cc_accepted(ctx, opts, state, had_force_release, &tune_start_m, &tune_result,
+                                           &tune_request_id)) {
         atomic_store(&g_p25_sm_release_lock, 0);
         return 0;
     }
@@ -2251,7 +2382,7 @@ p25_release_locked(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const ch
 
     p25_release_clear_context(ctx);
     p25_release_clear_decoder_state(opts, state);
-    p25_sm_start_cc_grace_after_tune(ctx, opts, state, tune_start_m, "release");
+    p25_sm_start_cc_acquisition_for_result(ctx, opts, state, tune_result, tune_request_id, tune_start_m, "release");
 
     // Transition to ON_CC state
     set_state(ctx, opts, state, P25_SM_ON_CC, "release->cc");
@@ -2389,7 +2520,9 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
                      "source=current-site-candidate freq=%ld sps=%d in_cand=%d in_lcn=%d in_neighbor=%d", cand, sps,
                      p25_diag_freq_in_current_site_candidates(state, cand), p25_diag_freq_in_lcn_list(state, cand),
                      p25_diag_freq_in_neighbors(state, cand));
-        dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, cand, sps);
+        uint64_t tune_request_id = 0U;
+        dsd_trunk_tune_result tune_result =
+            dsd_trunk_tuning_hook_tune_to_cc_with_id(opts, state, cand, sps, &tune_request_id);
         if (!dsd_trunk_tune_result_is_ok(tune_result)) {
             p25_sm_diagf(opts, state, ctx, "hunt_tune_result", "source=current-site-candidate freq=%ld result=%s", cand,
                          p25_tune_result_name(tune_result));
@@ -2400,8 +2533,8 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
         p25_sm_diagf(opts, state, ctx, "hunt_tune_result", "source=current-site-candidate freq=%ld result=%s", cand,
                      p25_tune_result_name(tune_result));
         state->p25_cc_eval_freq = cand;
-        state->p25_cc_eval_start_m = now_m;
-        p25_sm_start_cc_grace_after_tune(ctx, opts, state, now_m, "hunt-cand");
+        state->p25_cc_eval_start_m = 0.0;
+        p25_sm_start_cc_acquisition_for_result(ctx, opts, state, tune_result, tune_request_id, now_m, "hunt-cand");
         set_state(ctx, opts, state, P25_SM_ON_CC, "hunt-cand");
         sm_log(opts, state, "hunt-cand-tune");
         return;
@@ -2414,7 +2547,9 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
                      "source=%s freq=%ld sps=%d in_cand=%d in_lcn=%d in_neighbor=%d", source, cand, sps,
                      p25_diag_freq_in_current_site_candidates(state, cand), p25_diag_freq_in_lcn_list(state, cand),
                      p25_diag_freq_in_neighbors(state, cand));
-        dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, cand, sps);
+        uint64_t tune_request_id = 0U;
+        dsd_trunk_tune_result tune_result =
+            dsd_trunk_tuning_hook_tune_to_cc_with_id(opts, state, cand, sps, &tune_request_id);
         if (!dsd_trunk_tune_result_is_ok(tune_result)) {
             p25_sm_diagf(opts, state, ctx, "hunt_tune_result", "source=%s freq=%ld result=%s", source, cand,
                          p25_tune_result_name(tune_result));
@@ -2424,7 +2559,7 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
         }
         p25_sm_diagf(opts, state, ctx, "hunt_tune_result", "source=%s freq=%ld result=%s", source, cand,
                      p25_tune_result_name(tune_result));
-        p25_sm_start_cc_grace_after_tune(ctx, opts, state, now_m, "hunt-lcn");
+        p25_sm_start_cc_acquisition_for_result(ctx, opts, state, tune_result, tune_request_id, now_m, "hunt-lcn");
         set_state(ctx, opts, state, P25_SM_ON_CC, "hunt-lcn");
         sm_log(opts, state, "hunt-lcn-tune");
         return;
@@ -2728,6 +2863,9 @@ p25_sm_tick_on_cc_is_lost(const p25_sm_ctx_t* ctx, const dsd_state* state, doubl
     if (!ctx) {
         return 0;
     }
+    if (ctx->cc_tune_pending) {
+        return 0;
+    }
     if (ctx->cc_sync_pending && ctx->t_cc_tune_m > 0.0) {
         const double acquire_grace = p25_sm_cc_acquire_grace_s(cc_grace);
         if ((now_m - ctx->t_cc_tune_m) > acquire_grace) {
@@ -2757,6 +2895,20 @@ p25_sm_tick_on_cc_is_lost(const p25_sm_ctx_t* ctx, const dsd_state* state, doubl
 static void
 p25_sm_tick_on_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m, double cc_grace) {
     int acquire_timeout = 0;
+    int tune_status = p25_sm_resolve_pending_cc_tune(ctx, opts, state);
+    if (tune_status == 0) {
+        return;
+    }
+    if (tune_status < 0) {
+        if (state && state->p25_cc_eval_freq != 0) {
+            dsd_trunk_cc_candidates_set_cooldown(state, state->p25_cc_eval_freq, now_m + 10.0);
+            state->p25_cc_eval_freq = 0;
+            state->p25_cc_eval_start_m = 0.0;
+        }
+        ctx->t_hunt_try_m = now_m;
+        try_next_cc(ctx, opts, state, now_m);
+        return;
+    }
     p25_sm_tick_on_cc_sync_from_state(ctx, opts, state);
     if (p25_sm_tick_on_cc_nac_mismatch(ctx, opts, state, now_m)) {
         return;
@@ -2953,6 +3105,20 @@ p25_sm_tick_tuned(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double no
 static void
 p25_sm_tick_hunting(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
     if (!ctx) {
+        return;
+    }
+    int tune_status = p25_sm_resolve_pending_cc_tune(ctx, opts, state);
+    if (tune_status == 0 || (tune_status > 0 && ctx->state == P25_SM_ON_CC)) {
+        return;
+    }
+    if (tune_status < 0) {
+        if (state && state->p25_cc_eval_freq != 0) {
+            dsd_trunk_cc_candidates_set_cooldown(state, state->p25_cc_eval_freq, now_m + 10.0);
+            state->p25_cc_eval_freq = 0;
+            state->p25_cc_eval_start_m = 0.0;
+        }
+        ctx->t_hunt_try_m = now_m;
+        try_next_cc(ctx, opts, state, now_m);
         return;
     }
     const double decoded_after_m = ctx->cc_sync_pending ? ctx->t_cc_tune_m : ctx->t_cc_sync_m;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -317,9 +317,12 @@ p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
             state->last_cc_sync_time = time(NULL);
             state->last_cc_sync_time_m = tune_start_m;
         }
-        if (state->last_cc_sync_time_m > ctx->t_cc_sync_m) {
-            // CC retune hooks update this as tune metadata before any CC frame decodes.
-            // Absorb that timestamp now so the next watchdog tick does not relatch NAC from it.
+        if (state->last_cc_sync_time_m > ctx->t_cc_sync_m
+            && state->last_cc_sync_time_m > state->p25_last_cc_msg_time_m) {
+            // Absorb only tune metadata that is newer than decoded CC activity.
+            // A block decoded before asynchronous completion is resolved writes
+            // both timestamps; keeping the tune boundary intact lets that block
+            // satisfy the strict decoded-after-tune check below.
             ctx->t_cc_sync_m = state->last_cc_sync_time_m;
         }
     }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -224,9 +224,9 @@ p25_sm_seed_cc_modulation_from_current_sync(dsd_state* state) {
     if (!state) {
         return;
     }
-    if (DSD_SYNC_IS_P25P2(state->synctype)) {
-        state->p25_cc_is_tdma = 1;
-    } else if (DSD_SYNC_IS_P25P1(state->synctype)) {
+    // P25P2 sync is often a traffic-channel MAC on mixed FDMA-CC/P2-VC systems;
+    // only explicit CC-status messages should promote the CC to TDMA timing.
+    if (DSD_SYNC_IS_P25P1(state->synctype)) {
         state->p25_cc_is_tdma = 0;
     }
 }
@@ -318,6 +318,8 @@ p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, dsd_state* state, double tun
             ctx->t_cc_sync_m = state->last_cc_sync_time_m;
         }
     }
+    ctx->t_cc_tune_m = ctx->t_cc_sync_m;
+    ctx->cc_sync_pending = 1;
 }
 
 // Determine if channel is TDMA based on IDEN hints.
@@ -1800,6 +1802,8 @@ handle_cc_sync(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
         return;
     }
     ctx->t_cc_sync_m = now_monotonic();
+    ctx->t_cc_tune_m = 0.0;
+    ctx->cc_sync_pending = 0;
     p25_sm_set_expected_cc_nac(ctx, state, 1);
     p25_sm_diagf((dsd_opts*)opts, state, ctx, "cc_sync", "expected_nac=0x%03X nac=0x%03X last_cc_m=%.3f",
                  ctx->expected_cc_nac, state ? state->nac : 0, state ? state->last_cc_sync_time_m : 0.0);
@@ -1915,9 +1919,11 @@ p25_release_return_to_cc_accepted(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
     }
 
     *out_tune_start_m = now_monotonic();
-    p25_sm_diagf(opts, state, ctx, "release_cc_attempt", "freq=%ld ch=0x%04X tg=%d force=%d tdma=%d data=%d",
+    p25_sm_diagf(opts, state, ctx, "release_cc_attempt",
+                 "freq=%ld ch=0x%04X tg=%d force=%d tdma=%d data=%d cc_tdma=%d cc_sps=%d",
                  state ? ((state->p25_cc_freq != 0) ? state->p25_cc_freq : state->trunk_cc_freq) : 0,
-                 ctx->vc_channel & 0xFFFF, ctx->vc_tg, had_force_release, ctx->vc_is_tdma, ctx->vc_data_call);
+                 ctx->vc_channel & 0xFFFF, ctx->vc_tg, had_force_release, ctx->vc_is_tdma, ctx->vc_data_call,
+                 state ? state->p25_cc_is_tdma : 0, cc_ted_sps(opts, state));
     dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_return_to_cc(opts, state);
     if (dsd_trunk_tune_result_is_ok(tune_result)) {
         p25_sm_diagf(opts, state, ctx, "release_cc_result", "result=%s tune_start_m=%.3f",
@@ -2517,10 +2523,23 @@ p25_sm_tick_on_cc_sync_from_state(p25_sm_ctx_t* ctx, const dsd_state* state) {
     }
     if (state && state->last_cc_sync_time_m > ctx->t_cc_sync_m) {
         ctx->t_cc_sync_m = state->last_cc_sync_time_m;
+        if (ctx->cc_sync_pending && ctx->t_cc_sync_m > ctx->t_cc_tune_m) {
+            ctx->t_cc_tune_m = 0.0;
+            ctx->cc_sync_pending = 0;
+        }
         p25_sm_set_expected_cc_nac(ctx, state, 1);
     } else {
         p25_sm_set_expected_cc_nac(ctx, state, 0);
     }
+}
+
+static double
+p25_sm_cc_acquire_grace_s(double cc_grace) {
+    const double acquire_grace_s = 2.0;
+    if (cc_grace <= 0.0) {
+        return 0.0;
+    }
+    return (cc_grace < acquire_grace_s) ? cc_grace : acquire_grace_s;
 }
 
 static int
@@ -2579,10 +2598,23 @@ p25_sm_tick_on_cc_eval_cooldown(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_sta
 }
 
 static int
-p25_sm_tick_on_cc_is_lost(const p25_sm_ctx_t* ctx, const dsd_state* state, double now_m, double cc_grace) {
+p25_sm_tick_on_cc_is_lost(const p25_sm_ctx_t* ctx, const dsd_state* state, double now_m, double cc_grace,
+                          int* out_acquire_timeout) {
     double cc_ts = 0.0;
+    if (out_acquire_timeout) {
+        *out_acquire_timeout = 0;
+    }
     if (!ctx) {
         return 0;
+    }
+    if (ctx->cc_sync_pending && ctx->t_cc_tune_m > 0.0) {
+        const double acquire_grace = p25_sm_cc_acquire_grace_s(cc_grace);
+        if ((now_m - ctx->t_cc_tune_m) > acquire_grace) {
+            if (out_acquire_timeout) {
+                *out_acquire_timeout = 1;
+            }
+            return 1;
+        }
     }
     cc_ts = ctx->t_cc_sync_m;
     if (state) {
@@ -2603,16 +2635,31 @@ p25_sm_tick_on_cc_is_lost(const p25_sm_ctx_t* ctx, const dsd_state* state, doubl
 
 static void
 p25_sm_tick_on_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m, double cc_grace) {
+    int acquire_timeout = 0;
     p25_sm_tick_on_cc_sync_from_state(ctx, state);
     if (p25_sm_tick_on_cc_nac_mismatch(ctx, opts, state, now_m)) {
         return;
     }
     p25_sm_tick_on_cc_eval_cooldown(ctx, opts, state, now_m);
-    if (!p25_sm_tick_on_cc_is_lost(ctx, state, now_m, cc_grace)) {
+    if (!p25_sm_tick_on_cc_is_lost(ctx, state, now_m, cc_grace, &acquire_timeout)) {
         return;
     }
-    p25_sm_diagf(opts, state, ctx, "cc_lost", "reason=timeout cc_grace=%.3f last_cc_m=%.3f now_m=%.3f", cc_grace,
-                 state ? state->last_cc_sync_time_m : 0.0, now_m);
+    if (acquire_timeout) {
+        p25_sm_diagf(opts, state, ctx, "cc_lost",
+                     "reason=acquire-timeout acquire_grace=%.3f cc_grace=%.3f tune_m=%.3f last_cc_m=%.3f now_m=%.3f",
+                     p25_sm_cc_acquire_grace_s(cc_grace), cc_grace, ctx ? ctx->t_cc_tune_m : 0.0,
+                     state ? state->last_cc_sync_time_m : 0.0, now_m);
+        if (state && state->p25_cc_eval_freq != 0) {
+            dsd_trunk_cc_candidates_set_cooldown(state, state->p25_cc_eval_freq, now_m + 10.0);
+            p25_sm_diagf(opts, state, ctx, "hunt_candidate_cooldown", "freq=%ld seconds=10.000 reason=acquire-timeout",
+                         state->p25_cc_eval_freq);
+            state->p25_cc_eval_freq = 0;
+            state->p25_cc_eval_start_m = 0.0;
+        }
+    } else {
+        p25_sm_diagf(opts, state, ctx, "cc_lost", "reason=timeout cc_grace=%.3f last_cc_m=%.3f now_m=%.3f", cc_grace,
+                     state ? state->last_cc_sync_time_m : 0.0, now_m);
+    }
     set_state(ctx, opts, state, P25_SM_HUNTING, "cc-lost");
     ctx->t_hunt_try_m = now_m;
     try_next_cc(ctx, opts, state, now_m);

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -13,6 +13,7 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/platform/atomic_compat.h>
+#include <dsd-neo/protocol/p25/p25_cc_activity.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_frequency.h>
 #include <dsd-neo/protocol/p25/p25_sm_ui.h>
@@ -302,7 +303,8 @@ p25_sm_set_expected_cc_nac(p25_sm_ctx_t* ctx, const dsd_state* state, int replac
 }
 
 static void
-p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, dsd_state* state, double tune_start_m) {
+p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double tune_start_m,
+                                 const char* source) {
     if (!ctx) {
         return;
     }
@@ -320,19 +322,36 @@ p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, dsd_state* state, double tun
     }
     ctx->t_cc_tune_m = ctx->t_cc_sync_m;
     ctx->cc_sync_pending = 1;
+    p25_sm_diagf(opts, state, ctx, "cc_acquire_start",
+                 "source=%s tune_start_m=%.3f tune_m=%.3f last_cc_m=%.3f decoded_cc_m=%.3f",
+                 source ? source : "unknown", tune_start_m, ctx->t_cc_tune_m, state ? state->last_cc_sync_time_m : 0.0,
+                 state ? state->p25_last_cc_msg_time_m : 0.0);
 }
 
 static int
-p25_sm_refresh_cc_sync_from_state(p25_sm_ctx_t* ctx, const dsd_state* state) {
+p25_sm_refresh_cc_sync_from_state(p25_sm_ctx_t* ctx, dsd_opts* opts, const dsd_state* state, const char* trigger) {
     if (!ctx) {
+        return 0;
+    }
+    if (ctx->cc_sync_pending) {
+        const double decoded_cc_m = state ? state->p25_last_cc_msg_time_m : 0.0;
+        if (decoded_cc_m > ctx->t_cc_tune_m) {
+            const double tune_m = ctx->t_cc_tune_m;
+            ctx->t_cc_sync_m = decoded_cc_m;
+            ctx->t_cc_tune_m = 0.0;
+            ctx->cc_sync_pending = 0;
+            p25_sm_set_expected_cc_nac(ctx, state, 1);
+            p25_sm_diagf(opts, state, ctx, "cc_reacquired",
+                         "source=%s decoded_cc_m=%.3f tune_m=%.3f last_cc_m=%.3f expected_nac=0x%03X",
+                         trigger ? trigger : "state", decoded_cc_m, tune_m, state ? state->last_cc_sync_time_m : 0.0,
+                         ctx->expected_cc_nac);
+            return 1;
+        }
+        p25_sm_set_expected_cc_nac(ctx, state, 0);
         return 0;
     }
     if (state && state->last_cc_sync_time_m > ctx->t_cc_sync_m) {
         ctx->t_cc_sync_m = state->last_cc_sync_time_m;
-        if (ctx->cc_sync_pending && ctx->t_cc_sync_m > ctx->t_cc_tune_m) {
-            ctx->t_cc_tune_m = 0.0;
-            ctx->cc_sync_pending = 0;
-        }
         p25_sm_set_expected_cc_nac(ctx, state, 1);
         return 1;
     }
@@ -1449,7 +1468,14 @@ p25_grant_seed_cc_before_vc_tune(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_st
         return;
     }
 
-    p25_sm_start_cc_grace_after_tune(ctx, state, now_m);
+    if (state->last_cc_sync_time_m <= 0.0 || state->last_cc_sync_time_m < now_m) {
+        state->last_cc_sync_time = time(NULL);
+        state->last_cc_sync_time_m = now_m;
+    }
+    ctx->t_cc_sync_m =
+        (state->p25_last_cc_msg_time_m > 0.0) ? state->p25_last_cc_msg_time_m : state->last_cc_sync_time_m;
+    ctx->t_cc_tune_m = 0.0;
+    ctx->cc_sync_pending = 0;
     p25_sm_set_expected_cc_nac(ctx, state, 0);
     set_state(ctx, opts, state, P25_SM_ON_CC, "grant-cc-seed");
 }
@@ -1528,14 +1554,15 @@ p25_grant_blocked_by_pending_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* st
     if (!ctx || !ev || !grant || ctx->state != P25_SM_ON_CC || !ctx->cc_sync_pending) {
         return 0;
     }
-    (void)p25_sm_refresh_cc_sync_from_state(ctx, state);
+    (void)p25_sm_refresh_cc_sync_from_state(ctx, opts, state, "grant");
     if (!ctx->cc_sync_pending) {
         return 0;
     }
 
     p25_sm_diagf(opts, state, ctx, "grant_cc_pending",
-                 "ch=0x%04X freq=%ld slot=%d tg=%d src=%d tune_m=%.3f last_cc_m=%.3f", ev->channel & 0xFFFF,
-                 grant->freq, grant->slot, ev->tg, ev->src, ctx->t_cc_tune_m, state ? state->last_cc_sync_time_m : 0.0);
+                 "ch=0x%04X freq=%ld slot=%d tg=%d src=%d tune_m=%.3f last_cc_m=%.3f decoded_cc_m=%.3f",
+                 ev->channel & 0xFFFF, grant->freq, grant->slot, ev->tg, ev->src, ctx->t_cc_tune_m,
+                 state ? state->last_cc_sync_time_m : 0.0, state ? state->p25_last_cc_msg_time_m : 0.0);
     return 1;
 }
 
@@ -1839,14 +1866,23 @@ handle_cc_sync(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
     if (!ctx) {
         return;
     }
-    ctx->t_cc_sync_m = now_monotonic();
-    ctx->t_cc_tune_m = 0.0;
-    ctx->cc_sync_pending = 0;
-    p25_sm_set_expected_cc_nac(ctx, state, 1);
-    p25_sm_diagf((dsd_opts*)opts, state, ctx, "cc_sync", "expected_nac=0x%03X nac=0x%03X last_cc_m=%.3f",
-                 ctx->expected_cc_nac, state ? state->nac : 0, state ? state->last_cc_sync_time_m : 0.0);
+    const double now_m = now_monotonic();
+    if (state) {
+        state->last_cc_sync_time = time(NULL);
+        state->last_cc_sync_time_m = now_m;
+    }
+    if (ctx->cc_sync_pending) {
+        (void)p25_sm_refresh_cc_sync_from_state(ctx, (dsd_opts*)opts, state, "sm-event");
+    } else {
+        ctx->t_cc_sync_m = state ? state->last_cc_sync_time_m : now_m;
+        p25_sm_set_expected_cc_nac(ctx, state, 1);
+    }
+    p25_sm_diagf((dsd_opts*)opts, state, ctx, "cc_sync",
+                 "pending=%d expected_nac=0x%03X nac=0x%03X last_cc_m=%.3f decoded_cc_m=%.3f", ctx->cc_sync_pending,
+                 ctx->expected_cc_nac, state ? state->nac : 0, state ? state->last_cc_sync_time_m : 0.0,
+                 state ? state->p25_last_cc_msg_time_m : 0.0);
 
-    if (ctx->state == P25_SM_IDLE || ctx->state == P25_SM_HUNTING) {
+    if (!ctx->cc_sync_pending && (ctx->state == P25_SM_IDLE || ctx->state == P25_SM_HUNTING)) {
         set_state(ctx, opts, state, P25_SM_ON_CC, "cc-sync");
     }
 }
@@ -2182,7 +2218,7 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
 
     p25_release_clear_context(ctx);
     p25_release_clear_decoder_state(opts, state);
-    p25_sm_start_cc_grace_after_tune(ctx, state, tune_start_m);
+    p25_sm_start_cc_grace_after_tune(ctx, opts, state, tune_start_m, "release");
 
     // Transition to ON_CC state
     set_state(ctx, opts, state, P25_SM_ON_CC, "release->cc");
@@ -2306,7 +2342,7 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
                      p25_tune_result_name(tune_result));
         state->p25_cc_eval_freq = cand;
         state->p25_cc_eval_start_m = now_m;
-        p25_sm_start_cc_grace_after_tune(ctx, state, now_m);
+        p25_sm_start_cc_grace_after_tune(ctx, opts, state, now_m, "hunt-cand");
         set_state(ctx, opts, state, P25_SM_ON_CC, "hunt-cand");
         sm_log(opts, state, "hunt-cand-tune");
         return;
@@ -2329,7 +2365,7 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
         }
         p25_sm_diagf(opts, state, ctx, "hunt_tune_result", "source=%s freq=%ld result=%s", source, cand,
                      p25_tune_result_name(tune_result));
-        p25_sm_start_cc_grace_after_tune(ctx, state, now_m);
+        p25_sm_start_cc_grace_after_tune(ctx, opts, state, now_m, "hunt-lcn");
         set_state(ctx, opts, state, P25_SM_ON_CC, "hunt-lcn");
         sm_log(opts, state, "hunt-lcn-tune");
         return;
@@ -2555,8 +2591,8 @@ p25_sm_tick_handle_forced_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* 
 }
 
 static void
-p25_sm_tick_on_cc_sync_from_state(p25_sm_ctx_t* ctx, const dsd_state* state) {
-    (void)p25_sm_refresh_cc_sync_from_state(ctx, state);
+p25_sm_tick_on_cc_sync_from_state(p25_sm_ctx_t* ctx, dsd_opts* opts, const dsd_state* state) {
+    (void)p25_sm_refresh_cc_sync_from_state(ctx, opts, state, "tick");
 }
 
 static double
@@ -2662,7 +2698,7 @@ p25_sm_tick_on_cc_is_lost(const p25_sm_ctx_t* ctx, const dsd_state* state, doubl
 static void
 p25_sm_tick_on_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m, double cc_grace) {
     int acquire_timeout = 0;
-    p25_sm_tick_on_cc_sync_from_state(ctx, state);
+    p25_sm_tick_on_cc_sync_from_state(ctx, opts, state);
     if (p25_sm_tick_on_cc_nac_mismatch(ctx, opts, state, now_m)) {
         return;
     }
@@ -2672,9 +2708,10 @@ p25_sm_tick_on_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double no
     }
     if (acquire_timeout) {
         p25_sm_diagf(opts, state, ctx, "cc_lost",
-                     "reason=acquire-timeout acquire_grace=%.3f cc_grace=%.3f tune_m=%.3f last_cc_m=%.3f now_m=%.3f",
+                     "reason=acquire-timeout acquire_grace=%.3f cc_grace=%.3f tune_m=%.3f last_cc_m=%.3f "
+                     "decoded_cc_m=%.3f now_m=%.3f",
                      p25_sm_cc_acquire_grace_s(cc_grace), cc_grace, ctx ? ctx->t_cc_tune_m : 0.0,
-                     state ? state->last_cc_sync_time_m : 0.0, now_m);
+                     state ? state->last_cc_sync_time_m : 0.0, state ? state->p25_last_cc_msg_time_m : 0.0, now_m);
         if (state && state->p25_cc_eval_freq != 0) {
             dsd_trunk_cc_candidates_set_cooldown(state, state->p25_cc_eval_freq, now_m + 10.0);
             p25_sm_diagf(opts, state, ctx, "hunt_candidate_cooldown", "freq=%ld seconds=10.000 reason=acquire-timeout",
@@ -2683,8 +2720,9 @@ p25_sm_tick_on_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double no
             state->p25_cc_eval_start_m = 0.0;
         }
     } else {
-        p25_sm_diagf(opts, state, ctx, "cc_lost", "reason=timeout cc_grace=%.3f last_cc_m=%.3f now_m=%.3f", cc_grace,
-                     state ? state->last_cc_sync_time_m : 0.0, now_m);
+        p25_sm_diagf(opts, state, ctx, "cc_lost",
+                     "reason=timeout cc_grace=%.3f last_cc_m=%.3f decoded_cc_m=%.3f now_m=%.3f", cc_grace,
+                     state ? state->last_cc_sync_time_m : 0.0, state ? state->p25_last_cc_msg_time_m : 0.0, now_m);
     }
     set_state(ctx, opts, state, P25_SM_HUNTING, "cc-lost");
     ctx->t_hunt_try_m = now_m;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -224,9 +224,11 @@ p25_sm_seed_cc_modulation_from_current_sync(dsd_state* state) {
     if (!state) {
         return;
     }
-    // P25P2 sync is often a traffic-channel MAC on mixed FDMA-CC/P2-VC systems;
-    // only explicit CC-status messages should promote the CC to TDMA timing.
-    if (DSD_SYNC_IS_P25P1(state->synctype)) {
+    // Ordinary P25P2 sync is often a traffic-channel MAC on mixed FDMA-CC/P2-VC
+    // systems. Only LCCH context proves that the seeded CC uses TDMA timing.
+    if (state->p2_is_lcch == 1) {
+        state->p25_cc_is_tdma = 1;
+    } else if (DSD_SYNC_IS_P25P1(state->synctype)) {
         state->p25_cc_is_tdma = 0;
     }
 }
@@ -471,6 +473,22 @@ set_state(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, p25_sm_stat
     p25_sm_diagf((dsd_opts*)opts, state, ctx, "state", "old=%s new=%s reason=%s", p25_sm_state_name(old),
                  p25_sm_state_name(new_state), reason ? reason : "none");
     sm_log(opts, state, reason);
+}
+
+int
+p25_sm_restart_pending_cc_acquisition(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double tune_start_m,
+                                      const char* source) {
+    if (!ctx || !ctx->cc_sync_pending) {
+        return 0;
+    }
+    const char* reason = source ? source : "external-retune";
+    if (tune_start_m <= 0.0) {
+        tune_start_m = now_monotonic();
+    }
+    p25_sm_start_cc_grace_after_tune(ctx, opts, state, tune_start_m, reason);
+    ctx->t_hunt_try_m = 0.0;
+    set_state(ctx, opts, state, P25_SM_ON_CC, reason);
+    return 1;
 }
 
 /* ============================================================================
@@ -2922,6 +2940,12 @@ p25_sm_tick_tuned(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double no
 static void
 p25_sm_tick_hunting(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
     if (!ctx) {
+        return;
+    }
+    const double decoded_after_m = ctx->cc_sync_pending ? ctx->t_cc_tune_m : ctx->t_cc_sync_m;
+    if (state && state->p25_last_cc_msg_time_m > decoded_after_m
+        && p25_sm_refresh_cc_sync_from_state(ctx, opts, state, "hunt-tick")) {
+        set_state(ctx, opts, state, P25_SM_ON_CC, "cc-activity");
         return;
     }
     if (ctx->t_hunt_try_m <= 0.0 || (now_m - ctx->t_hunt_try_m) >= CC_HUNT_INTERVAL_S) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -353,7 +353,7 @@ static void
 p25_sm_start_cc_acquisition_for_result(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state,
                                        dsd_trunk_tune_result tune_result, uint64_t request_id, double tune_start_m,
                                        const char* source) {
-    if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+    if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING && request_id != 0U) {
         p25_sm_wait_for_cc_tune_completion(ctx, opts, state, request_id, source);
         return;
     }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -360,6 +360,15 @@ p25_sm_refresh_cc_sync_from_state(p25_sm_ctx_t* ctx, dsd_opts* opts, const dsd_s
     return 0;
 }
 
+static void
+p25_sm_cancel_pending_cc_acquisition(p25_sm_ctx_t* ctx) {
+    if (!ctx) {
+        return;
+    }
+    ctx->t_cc_tune_m = 0.0;
+    ctx->cc_sync_pending = 0;
+}
+
 // Determine if channel is TDMA based on IDEN hints.
 // Uses bitmask semantics for p25_chan_tdma_explicit[iden]:
 //   bit0 (0x01) = has FDMA/non-TDMA entry
@@ -486,6 +495,9 @@ p25_sm_restart_pending_cc_acquisition(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_sta
         tune_start_m = now_monotonic();
     }
     p25_sm_start_cc_grace_after_tune(ctx, opts, state, tune_start_m, reason);
+    if (state && state->p25_cc_eval_freq != 0) {
+        state->p25_cc_eval_start_m = ctx->t_cc_tune_m;
+    }
     ctx->t_hunt_try_m = 0.0;
     set_state(ctx, opts, state, P25_SM_ON_CC, reason);
     return 1;
@@ -1631,6 +1643,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     if (!p25_grant_try_tune_vc(ctx, ev, opts, state, grant.freq, grant.slot, grant.reused_carrier, &grant.ted_sps)) {
         return;
     }
+    p25_sm_cancel_pending_cc_acquisition(ctx);
     p25_grant_clear_moved_target_slots(ctx, state, grant.slot, ev, grant.target_id, grant.freq, eval_ctx.data_call);
     if (grant.clear_policy_slot_only) {
         p25_grant_clear_one_slot_state(ctx, grant.slot);

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -322,6 +322,24 @@ p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, dsd_state* state, double tun
     ctx->cc_sync_pending = 1;
 }
 
+static int
+p25_sm_refresh_cc_sync_from_state(p25_sm_ctx_t* ctx, const dsd_state* state) {
+    if (!ctx) {
+        return 0;
+    }
+    if (state && state->last_cc_sync_time_m > ctx->t_cc_sync_m) {
+        ctx->t_cc_sync_m = state->last_cc_sync_time_m;
+        if (ctx->cc_sync_pending && ctx->t_cc_sync_m > ctx->t_cc_tune_m) {
+            ctx->t_cc_tune_m = 0.0;
+            ctx->cc_sync_pending = 0;
+        }
+        p25_sm_set_expected_cc_nac(ctx, state, 1);
+        return 1;
+    }
+    p25_sm_set_expected_cc_nac(ctx, state, 0);
+    return 0;
+}
+
 // Determine if channel is TDMA based on IDEN hints.
 // Uses bitmask semantics for p25_chan_tdma_explicit[iden]:
 //   bit0 (0x01) = has FDMA/non-TDMA entry
@@ -1504,6 +1522,23 @@ p25_grant_prepare_route(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* stat
     return 1;
 }
 
+static int
+p25_grant_blocked_by_pending_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev,
+                                const p25_grant_route_ctx_t* grant) {
+    if (!ctx || !ev || !grant || ctx->state != P25_SM_ON_CC || !ctx->cc_sync_pending) {
+        return 0;
+    }
+    (void)p25_sm_refresh_cc_sync_from_state(ctx, state);
+    if (!ctx->cc_sync_pending) {
+        return 0;
+    }
+
+    p25_sm_diagf(opts, state, ctx, "grant_cc_pending",
+                 "ch=0x%04X freq=%ld slot=%d tg=%d src=%d tune_m=%.3f last_cc_m=%.3f", ev->channel & 0xFFFF,
+                 grant->freq, grant->slot, ev->tg, ev->src, ctx->t_cc_tune_m, state ? state->last_cc_sync_time_m : 0.0);
+    return 1;
+}
+
 /* ============================================================================
  * Event Handlers
  * ============================================================================ */
@@ -1524,6 +1559,9 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     }
 
     if (!p25_grant_prepare_route(ctx, opts, state, ev, &decision, &eval_ctx, &grant)) {
+        return;
+    }
+    if (p25_grant_blocked_by_pending_cc(ctx, opts, state, ev, &grant)) {
         return;
     }
 
@@ -2518,19 +2556,7 @@ p25_sm_tick_handle_forced_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* 
 
 static void
 p25_sm_tick_on_cc_sync_from_state(p25_sm_ctx_t* ctx, const dsd_state* state) {
-    if (!ctx) {
-        return;
-    }
-    if (state && state->last_cc_sync_time_m > ctx->t_cc_sync_m) {
-        ctx->t_cc_sync_m = state->last_cc_sync_time_m;
-        if (ctx->cc_sync_pending && ctx->t_cc_sync_m > ctx->t_cc_tune_m) {
-            ctx->t_cc_tune_m = 0.0;
-            ctx->cc_sync_pending = 0;
-        }
-        p25_sm_set_expected_cc_nac(ctx, state, 1);
-    } else {
-        p25_sm_set_expected_cc_nac(ctx, state, 0);
-    }
+    (void)p25_sm_refresh_cc_sync_from_state(ctx, state);
 }
 
 static double

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -313,16 +313,16 @@ p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
     ctx->cc_tune_pending = 0;
     ctx->t_cc_sync_m = tune_start_m;
     if (state) {
+        const double decoded_cc_m = state->p25_last_cc_msg_time_m;
         if (state->last_cc_sync_time_m <= 0.0 || state->last_cc_sync_time_m < tune_start_m) {
             state->last_cc_sync_time = time(NULL);
             state->last_cc_sync_time_m = tune_start_m;
         }
-        if (state->last_cc_sync_time_m > ctx->t_cc_sync_m
-            && state->last_cc_sync_time_m > state->p25_last_cc_msg_time_m) {
-            // Absorb only tune metadata that is newer than decoded CC activity.
-            // A block decoded before asynchronous completion is resolved writes
-            // both timestamps; keeping the tune boundary intact lets that block
-            // satisfy the strict decoded-after-tune check below.
+        if (state->last_cc_sync_time_m > ctx->t_cc_sync_m && decoded_cc_m <= tune_start_m) {
+            // Absorb a newer raw-sync timestamp only when no decoded CC block
+            // already proves activity after the tune boundary. A block decoded
+            // before asynchronous completion is resolved must remain eligible
+            // to satisfy the strict decoded-after-tune check below.
             ctx->t_cc_sync_m = state->last_cc_sync_time_m;
         }
     }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2411,8 +2411,18 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
     // Only public release paths normalize externally cleared decoder state;
     // internal timeout paths retain their CC-return and failed-grant backoff behavior.
     if (recover_stale_ctx && p25_release_ctx_is_stale(ctx, opts, state)) {
+        const uint32_t tune_count = ctx->tune_count;
+        const uint32_t grant_count = ctx->grant_count;
         p25_sm_diagf(opts, state, ctx, "release_stale_reset", "reason=%s", reason ? reason : "none");
+        p25_release_clear_context(ctx);
+        const uint32_t release_count = ctx->release_count;
+        const uint32_t cc_return_count = ctx->cc_return_count;
+        p25_release_clear_decoder_state(opts, state);
         p25_sm_init_ctx(ctx, opts, state);
+        ctx->tune_count = tune_count;
+        ctx->release_count = release_count;
+        ctx->grant_count = grant_count;
+        ctx->cc_return_count = cc_return_count;
         atomic_store(&g_p25_sm_release_lock, 0);
         return 1;
     }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -38,7 +38,7 @@
 #include "dsd-neo/platform/platform.h"
 
 static int do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason,
-                      int arm_failed_vc_backoff_on_accept);
+                      int arm_failed_vc_backoff_on_accept, int recover_stale_ctx);
 static void p25_sm_diagf(dsd_opts* opts, const dsd_state* state, const p25_sm_ctx_t* ctx, const char* event,
                          const char* format, ...) DSD_ATTR_FORMAT(printf, 5, 6);
 
@@ -967,7 +967,7 @@ p25_grant_preempt_active_call_if_needed(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
     }
     log_preempt_decision(ctx, opts, state, route, decision, "policy-allow", 1);
     sm_log(opts, state, "grant-preempt-accept");
-    return do_release(ctx, opts, state, "grant-preempt", 0);
+    return do_release(ctx, opts, state, "grant-preempt", 0, 0);
 }
 
 static void
@@ -1550,11 +1550,14 @@ p25_grant_prepare_route(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* stat
 static int
 p25_grant_blocked_by_pending_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev,
                                 const p25_grant_route_ctx_t* grant) {
-    if (!ctx || !ev || !grant || ctx->state != P25_SM_ON_CC || !ctx->cc_sync_pending) {
+    if (!ctx || !ev || !grant || !ctx->cc_sync_pending) {
         return 0;
     }
     (void)p25_sm_refresh_cc_sync_from_state(ctx, opts, state, "grant");
     if (!ctx->cc_sync_pending) {
+        if (ctx->state == P25_SM_HUNTING) {
+            set_state(ctx, opts, state, P25_SM_ON_CC, "grant-cc-reacquired");
+        }
         return 0;
     }
 
@@ -1750,7 +1753,7 @@ p25_voice_end_try_explicit_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state*
     int other = slot ^ 1;
     if (p25_voice_end_can_release_explicit(ctx, other)) {
         // All active slots terminated - release immediately like P25P1 Call Termination
-        do_release(ctx, opts, state, "call-end", 0);
+        do_release(ctx, opts, state, "call-end", 0, 0);
     }
 }
 
@@ -1967,7 +1970,7 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
     int other_active = p25_enc_lockout_other_slot_active(ctx, state, other);
 
     if (!other_active) {
-        do_release(ctx, opts, state, "enc-lockout", 0);
+        do_release(ctx, opts, state, "enc-lockout", 0, 0);
     } else {
         p25_sm_diagf(opts, state, ctx, "enc_lockout_slot_only", "slot=%d other=%d", slot, other);
         sm_log(opts, state, "enc-lockout-slot-only");
@@ -1982,6 +1985,17 @@ static int
 p25_release_should_return_to_cc(const p25_sm_ctx_t* ctx, const dsd_opts* opts) {
     const int opts_tuned = (opts && (opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1)) ? 1 : 0;
     return (ctx && (ctx->state == P25_SM_TUNED || opts_tuned)) ? 1 : 0;
+}
+
+static int
+p25_release_ctx_is_stale(const p25_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state) {
+    const int opts_tuned = (opts && (opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1)) ? 1 : 0;
+    const int state_has_vc = (state
+                              && (state->p25_vc_freq[0] != 0 || state->p25_vc_freq[1] != 0
+                                  || state->trunk_vc_freq[0] != 0 || state->trunk_vc_freq[1] != 0))
+                                 ? 1
+                                 : 0;
+    return (ctx && ctx->state == P25_SM_TUNED && !opts_tuned && !state_has_vc) ? 1 : 0;
 }
 
 static int
@@ -2172,21 +2186,10 @@ p25_release_clear_decoder_state(dsd_opts* opts, dsd_state* state) {
 }
 
 static int
-do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason,
-           int arm_failed_vc_backoff_on_accept) {
+p25_release_locked(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason,
+                   int arm_failed_vc_backoff_on_accept) {
     double tune_start_m = 0.0;
     int had_force_release = 0;
-    if (!ctx) {
-        return 0;
-    }
-
-    // Avoid double-return-to-CC thrash if multiple callers attempt to release at
-    // nearly the same time (e.g., explicit call termination + watchdog tick).
-    int expected = 0;
-    if (!atomic_compare_exchange_strong(&g_p25_sm_release_lock, &expected, 1)) {
-        return 0;
-    }
-
     if (state) {
         had_force_release = (state->p25_sm_force_release != 0) ? 1 : 0;
         // Clear any pending forced-release request; we're handling teardown now.
@@ -2224,6 +2227,32 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
 
     atomic_store(&g_p25_sm_release_lock, 0);
     return 1;
+}
+
+static int
+do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason, int arm_failed_vc_backoff_on_accept,
+           int recover_stale_ctx) {
+    if (!ctx) {
+        return 0;
+    }
+
+    // Avoid double-return-to-CC thrash if multiple callers attempt to release at
+    // nearly the same time (e.g., explicit call termination + watchdog tick).
+    int expected = 0;
+    if (!atomic_compare_exchange_strong(&g_p25_sm_release_lock, &expected, 1)) {
+        return 0;
+    }
+
+    // Only public release paths normalize externally cleared decoder state;
+    // internal timeout paths retain their CC-return and failed-grant backoff behavior.
+    if (recover_stale_ctx && p25_release_ctx_is_stale(ctx, opts, state)) {
+        p25_sm_diagf(opts, state, ctx, "release_stale_reset", "reason=%s", reason ? reason : "none");
+        p25_sm_init_ctx(ctx, opts, state);
+        atomic_store(&g_p25_sm_release_lock, 0);
+        return 1;
+    }
+
+    return p25_release_locked(ctx, opts, state, reason, arm_failed_vc_backoff_on_accept);
 }
 
 /* ============================================================================
@@ -2582,7 +2611,7 @@ p25_sm_tick_handle_forced_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* 
         return 0;
     }
     if (ctx->state == P25_SM_TUNED) {
-        do_release(ctx, opts, state, "release-forced", 0);
+        do_release(ctx, opts, state, "release-forced", 0, 0);
     } else {
         state->p25_sm_force_release = 0;
     }
@@ -2755,7 +2784,7 @@ p25_sm_tick_tuned_check_hangtime(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
     dt_voice = now_m - ctx->t_voice_m;
     effective_hangtime = p25_sm_effective_hangtime(state, hangtime);
     if (dt_voice >= effective_hangtime) {
-        do_release(ctx, opts, state, "hangtime-expired", 0);
+        do_release(ctx, opts, state, "hangtime-expired", 0, 0);
     }
 }
 
@@ -2866,7 +2895,7 @@ p25_sm_tick_tuned_wait_voice(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state
         return;
     }
     if ((now_m - timeout_start_m) >= grant_timeout) {
-        do_release(ctx, opts, state, "grant-timeout", 1);
+        do_release(ctx, opts, state, "grant-timeout", 1, 0);
     }
 }
 
@@ -3051,7 +3080,7 @@ p25_sm_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* 
     if (!ctx) {
         ctx = p25_sm_get_ctx();
     }
-    do_release(ctx, opts, state, reason ? reason : "explicit-release", 0);
+    do_release(ctx, opts, state, reason ? reason : "explicit-release", 0, 1);
 }
 
 int

--- a/src/protocol/p25/p25_trunk_sm_wrappers.c
+++ b/src/protocol/p25/p25_trunk_sm_wrappers.c
@@ -11,7 +11,6 @@
  */
 
 #include <dsd-neo/core/dsd_time.h>
-#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
@@ -181,18 +180,7 @@ p25_sm_on_indiv_data_grant(dsd_opts* opts, dsd_state* state, int channel, int sv
 
 static void
 p25_sm_on_release_default(dsd_opts* opts, dsd_state* state) {
-    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
-    const int opts_tuned = (opts && (opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1)) ? 1 : 0;
-    const int state_has_vc = (state
-                              && (state->p25_vc_freq[0] != 0 || state->p25_vc_freq[1] != 0
-                                  || state->trunk_vc_freq[0] != 0 || state->trunk_vc_freq[1] != 0))
-                                 ? 1
-                                 : 0;
-    if (ctx && ctx->state == P25_SM_TUNED && !opts_tuned && !state_has_vc) {
-        p25_sm_init_ctx(ctx, opts, state);
-        return;
-    }
-    p25_sm_release(ctx, opts, state, "explicit-release");
+    p25_sm_release(p25_sm_get_ctx(), opts, state, "explicit-release");
 }
 
 void

--- a/src/protocol/p25/p25_trunk_sm_wrappers.c
+++ b/src/protocol/p25/p25_trunk_sm_wrappers.c
@@ -11,6 +11,7 @@
  */
 
 #include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
@@ -180,7 +181,18 @@ p25_sm_on_indiv_data_grant(dsd_opts* opts, dsd_state* state, int channel, int sv
 
 static void
 p25_sm_on_release_default(dsd_opts* opts, dsd_state* state) {
-    p25_sm_release(p25_sm_get_ctx(), opts, state, "explicit-release");
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    const int opts_tuned = (opts && (opts->p25_is_tuned == 1 || opts->trunk_is_tuned == 1)) ? 1 : 0;
+    const int state_has_vc = (state
+                              && (state->p25_vc_freq[0] != 0 || state->p25_vc_freq[1] != 0
+                                  || state->trunk_vc_freq[0] != 0 || state->trunk_vc_freq[1] != 0))
+                                 ? 1
+                                 : 0;
+    if (ctx && ctx->state == P25_SM_TUNED && !opts_tuned && !state_has_vc) {
+        p25_sm_init_ctx(ctx, opts, state);
+        return;
+    }
+    p25_sm_release(ctx, opts, state, "explicit-release");
 }
 
 void

--- a/src/protocol/p25/phase1/p25p1_pdu_trunking.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_trunking.c
@@ -16,6 +16,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/protocol/p25/p25_cc_activity.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_frequency.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
@@ -1247,6 +1248,8 @@ p25_decode_pdu_trunking_bounded(dsd_opts* opts, dsd_state* state, const uint8_t*
         (void)p25_handle_mbt_inbound_opcode(mpdu_byte, mpdu_len, &fields);
         return 0;
     }
+
+    p25_sm_note_cc_activity(opts, state, "p25p1-mbt");
 
     if (p25_mbt_has_unsupported_survey_format(&fields)) {
         DSD_FPRINTF(stderr, " - broadcast format %02X not handled", fields.fmt);

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -11,7 +11,6 @@
  *-----------------------------------------------------------------------------*/
 
 #include <dsd-neo/core/dibit.h>
-#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -152,7 +152,7 @@ tsbk_decode_block(dsd_opts* opts, dsd_state* state, int* skipdibit, tsbk_decode_
 }
 
 static void
-tsbk_update_fec_counters(dsd_opts* opts, dsd_state* state, int err) {
+tsbk_update_fec_counters(const dsd_opts* opts, dsd_state* state, int err) {
     if (err == 0) {
         p25_sm_note_cc_activity(opts, state, "p25p1-tsbk");
         state->p25_p1_fec_ok++;

--- a/src/protocol/p25/phase1/p25p1_tsbk.c
+++ b/src/protocol/p25/phase1/p25p1_tsbk.c
@@ -19,6 +19,7 @@
 #include <dsd-neo/protocol/p25/p25.h>
 #include <dsd-neo/protocol/p25/p25_12.h>
 #include <dsd-neo/protocol/p25/p25_callsign.h>
+#include <dsd-neo/protocol/p25/p25_cc_activity.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_crc.h>
 #include <dsd-neo/protocol/p25/p25_frequency.h>
@@ -151,11 +152,9 @@ tsbk_decode_block(dsd_opts* opts, dsd_state* state, int* skipdibit, tsbk_decode_
 }
 
 static void
-tsbk_update_fec_counters(dsd_state* state, int err) {
+tsbk_update_fec_counters(dsd_opts* opts, dsd_state* state, int err) {
     if (err == 0) {
-        // Refresh CC activity on any good TSBK decode to avoid premature hunting.
-        state->last_cc_sync_time = time(NULL);
-        state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
+        p25_sm_note_cc_activity(opts, state, "p25p1-tsbk");
         state->p25_p1_fec_ok++;
 #ifdef USE_RTLSDR
         dsd_rtl_stream_metrics_hook_p25p1_ber_update(1, 0);
@@ -1088,7 +1087,7 @@ processTSBK(dsd_opts* opts, dsd_state* state) {
         DSD_MEMSET(PDU, 0, sizeof(PDU));
 
         int err = tsbk_decode_block(opts, state, &skipdibit, &ctx);
-        tsbk_update_fec_counters(state, err);
+        tsbk_update_fec_counters(opts, state, err);
 
         int MFID = ctx.tsbk_byte[1];
         int protectbit = (ctx.tsbk_byte[0] >> 6) & 0x1;

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -556,10 +556,10 @@ p25p2_vpdu_has_cc_context(const dsd_opts* opts, dsd_state* state) {
     if (!opts || !state || opts->p25_trunk != 1) {
         return 0;
     }
-    if (state->trunk_cc_freq > 0 || DSD_SYNC_IS_P25P1(state->synctype)) {
+    if (state->trunk_cc_freq > 0 || state->p2_is_lcch == 1 || DSD_SYNC_IS_P25P1(state->synctype)) {
         p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
     }
-    return (state->p25_cc_freq != 0 || state->p2_is_lcch == 1) ? 1 : 0;
+    return state->p25_cc_freq != 0;
 }
 
 static int

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -556,10 +556,10 @@ p25p2_vpdu_has_cc_context(const dsd_opts* opts, dsd_state* state) {
     if (!opts || !state || opts->p25_trunk != 1) {
         return 0;
     }
-    if (state->trunk_cc_freq > 0 || state->p2_is_lcch == 1 || DSD_SYNC_IS_P25P1(state->synctype)) {
+    if (state->trunk_cc_freq > 0 || DSD_SYNC_IS_P25P1(state->synctype)) {
         p25_sm_seed_cc_from_current_tuner_if_unknown(opts, state);
     }
-    return state->p25_cc_freq != 0;
+    return (state->p25_cc_freq != 0 || state->p2_is_lcch == 1) ? 1 : 0;
 }
 
 static int

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -15,6 +15,7 @@
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/p25/p25_cc_activity.h>
 #include <dsd-neo/protocol/p25/p25_crc.h>
 #include <dsd-neo/protocol/p25/p25_lfsr.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
@@ -590,6 +591,10 @@ p25p2_xcch_validate_sacch_crc(const dsd_opts* opts, dsd_state* state, const int 
             }
             state->p2_is_lcch = 0;
             *abort_processing = 1;
+        }
+
+        if (err == 0) {
+            p25_sm_note_cc_activity(opts, state, "p25p2-lcch");
         }
     }
 

--- a/src/runtime/trunk_tuning_hooks.c
+++ b/src/runtime/trunk_tuning_hooks.c
@@ -407,7 +407,7 @@ dsd_trunk_tuning_hook_tune_to_freq_with_id(dsd_opts* opts, dsd_state* state, lon
     if (out_request_id) {
         *out_request_id = 0U;
     }
-    if (g_trunk_tuning_hooks.tune_to_freq_result && !g_trunk_tuning_hooks.tune_to_freq_request) {
+    if (g_trunk_tuning_hooks.tune_to_freq_result && (!g_trunk_tuning_hooks.tune_to_freq_request || !out_request_id)) {
         return dsd_trunk_tuning_note_legacy_result(
             g_trunk_tuning_hooks.tune_to_freq_result(opts, state, freq, ted_sps));
     }
@@ -440,7 +440,7 @@ dsd_trunk_tuning_hook_tune_to_cc_with_id(dsd_opts* opts, dsd_state* state, long 
     if (out_request_id) {
         *out_request_id = 0U;
     }
-    if (g_trunk_tuning_hooks.tune_to_cc_result && !g_trunk_tuning_hooks.tune_to_cc_request) {
+    if (g_trunk_tuning_hooks.tune_to_cc_result && (!g_trunk_tuning_hooks.tune_to_cc_request || !out_request_id)) {
         return dsd_trunk_tuning_note_legacy_result(g_trunk_tuning_hooks.tune_to_cc_result(opts, state, freq, ted_sps));
     }
     const uint64_t request_id = dsd_trunk_tuning_request_begin();
@@ -471,7 +471,7 @@ dsd_trunk_tuning_hook_return_to_cc_with_id(dsd_opts* opts, dsd_state* state, uin
     if (out_request_id) {
         *out_request_id = 0U;
     }
-    if (g_trunk_tuning_hooks.return_to_cc_result && !g_trunk_tuning_hooks.return_to_cc_request) {
+    if (g_trunk_tuning_hooks.return_to_cc_result && (!g_trunk_tuning_hooks.return_to_cc_request || !out_request_id)) {
         return dsd_trunk_tuning_note_legacy_result(g_trunk_tuning_hooks.return_to_cc_result(opts, state));
     }
     const uint64_t request_id = dsd_trunk_tuning_request_begin();

--- a/src/runtime/trunk_tuning_hooks.c
+++ b/src/runtime/trunk_tuning_hooks.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/platform/atomic_compat.h>
+#include <dsd-neo/platform/timing.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <time.h>
@@ -16,6 +17,120 @@
 
 static dsd_trunk_tuning_hooks g_trunk_tuning_hooks = {0};
 static dsd_atomic_u64 g_trunk_tuning_generation = {1U};
+static dsd_atomic_u64 g_trunk_tuning_next_request = {0U};
+static atomic_int g_trunk_tuning_request_lock = 0;
+static atomic_int g_trunk_tuning_unresolved_count = 0;
+
+#define DSD_TRUNK_TUNING_REQUEST_HISTORY 64
+
+typedef enum {
+    DSD_TRUNK_TUNING_REQUEST_FREE = 0,
+    DSD_TRUNK_TUNING_REQUEST_PENDING,
+    DSD_TRUNK_TUNING_REQUEST_FAILED_GATED,
+    DSD_TRUNK_TUNING_REQUEST_FINISHED,
+} dsd_trunk_tuning_request_state;
+
+typedef struct {
+    uint64_t request_id;
+    uint64_t completed_m_ns;
+    dsd_trunk_tune_result result;
+    dsd_trunk_tuning_request_state state;
+    int inherited_failure_gate;
+    int backend_complete;
+    int owner_ready;
+} dsd_trunk_tuning_request_record;
+
+static dsd_trunk_tuning_request_record g_trunk_tuning_requests[DSD_TRUNK_TUNING_REQUEST_HISTORY] = {{0}};
+
+static void
+dsd_trunk_tuning_requests_lock(void) {
+    int expected = 0;
+    while (!atomic_compare_exchange_strong(&g_trunk_tuning_request_lock, &expected, 1)) {
+        expected = 0;
+    }
+}
+
+static void
+dsd_trunk_tuning_requests_unlock(void) {
+    atomic_store(&g_trunk_tuning_request_lock, 0);
+}
+
+static dsd_trunk_tuning_request_record*
+dsd_trunk_tuning_request_find_locked(uint64_t request_id) {
+    for (int i = 0; i < DSD_TRUNK_TUNING_REQUEST_HISTORY; i++) {
+        if (g_trunk_tuning_requests[i].request_id == request_id
+            && g_trunk_tuning_requests[i].state != DSD_TRUNK_TUNING_REQUEST_FREE) {
+            return &g_trunk_tuning_requests[i];
+        }
+    }
+    return NULL;
+}
+
+static dsd_trunk_tuning_request_record*
+dsd_trunk_tuning_request_slot_locked(int* out_inherited_failure_gate) {
+    dsd_trunk_tuning_request_record* oldest_finished = NULL;
+    dsd_trunk_tuning_request_record* oldest_failed = NULL;
+    if (out_inherited_failure_gate) {
+        *out_inherited_failure_gate = 0;
+    }
+    for (int i = 0; i < DSD_TRUNK_TUNING_REQUEST_HISTORY; i++) {
+        dsd_trunk_tuning_request_record* record = &g_trunk_tuning_requests[i];
+        if (record->state == DSD_TRUNK_TUNING_REQUEST_FREE) {
+            return record;
+        }
+        if (record->state == DSD_TRUNK_TUNING_REQUEST_FINISHED
+            && (!oldest_finished || record->request_id < oldest_finished->request_id)) {
+            oldest_finished = record;
+        }
+        if (record->state == DSD_TRUNK_TUNING_REQUEST_FAILED_GATED
+            && (!oldest_failed || record->request_id < oldest_failed->request_id)) {
+            oldest_failed = record;
+        }
+    }
+    if (oldest_finished) {
+        return oldest_finished;
+    }
+    if (oldest_failed && out_inherited_failure_gate) {
+        *out_inherited_failure_gate = 1;
+    }
+    return oldest_failed;
+}
+
+static void
+dsd_trunk_tuning_retire_failed_requests_locked(uint64_t successful_request_id) {
+    for (int i = 0; i < DSD_TRUNK_TUNING_REQUEST_HISTORY; i++) {
+        dsd_trunk_tuning_request_record* record = &g_trunk_tuning_requests[i];
+        if (record->state == DSD_TRUNK_TUNING_REQUEST_FAILED_GATED && record->request_id < successful_request_id) {
+            record->state = DSD_TRUNK_TUNING_REQUEST_FINISHED;
+            (void)atomic_fetch_add(&g_trunk_tuning_unresolved_count, -1);
+        }
+    }
+}
+
+static void
+dsd_trunk_tuning_finish_success_locked(dsd_trunk_tuning_request_record* record) {
+    if (!record || record->state != DSD_TRUNK_TUNING_REQUEST_PENDING) {
+        return;
+    }
+    const uint64_t request_id = record->request_id;
+    dsd_trunk_tuning_generation_advance();
+    record->state = DSD_TRUNK_TUNING_REQUEST_FINISHED;
+    (void)atomic_fetch_add(&g_trunk_tuning_unresolved_count, -1);
+    dsd_trunk_tuning_retire_failed_requests_locked(request_id);
+}
+
+static void
+dsd_trunk_tuning_finish_rolled_back_locked(dsd_trunk_tuning_request_record* record) {
+    if (!record || record->state == DSD_TRUNK_TUNING_REQUEST_FINISHED) {
+        return;
+    }
+    if (record->inherited_failure_gate) {
+        record->state = DSD_TRUNK_TUNING_REQUEST_FAILED_GATED;
+        return;
+    }
+    record->state = DSD_TRUNK_TUNING_REQUEST_FINISHED;
+    (void)atomic_fetch_add(&g_trunk_tuning_unresolved_count, -1);
+}
 
 uint64_t
 dsd_trunk_tuning_generation(void) {
@@ -27,12 +142,190 @@ dsd_trunk_tuning_generation_advance(void) {
     (void)dsd_atomic_u64_fetch_add_release(&g_trunk_tuning_generation, 1U);
 }
 
-static dsd_trunk_tune_result
-dsd_trunk_tuning_note_result(dsd_trunk_tune_result result) {
-    if (dsd_trunk_tune_result_is_ok(result)) {
-        dsd_trunk_tuning_generation_advance();
+uint64_t
+dsd_trunk_tuning_request_begin(void) {
+    uint64_t request_id = 0U;
+    do {
+        request_id = dsd_atomic_u64_fetch_add_release(&g_trunk_tuning_next_request, 1U) + 1U;
+    } while (request_id == 0U);
+
+    dsd_trunk_tuning_requests_lock();
+    int inherited_failure_gate = 0;
+    dsd_trunk_tuning_request_record* record = dsd_trunk_tuning_request_slot_locked(&inherited_failure_gate);
+    if (!record) {
+        dsd_trunk_tuning_requests_unlock();
+        return 0U;
     }
+    record->request_id = request_id;
+    record->completed_m_ns = 0U;
+    record->result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    record->state = DSD_TRUNK_TUNING_REQUEST_PENDING;
+    record->inherited_failure_gate = inherited_failure_gate;
+    record->backend_complete = 0;
+    record->owner_ready = 0;
+    if (!inherited_failure_gate) {
+        (void)atomic_fetch_add(&g_trunk_tuning_unresolved_count, 1);
+    }
+    dsd_trunk_tuning_requests_unlock();
+    return request_id;
+}
+
+void
+dsd_trunk_tuning_request_publish(uint64_t request_id, dsd_trunk_tune_result result) {
+    if (request_id == 0U || result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        return;
+    }
+
+    dsd_trunk_tuning_requests_lock();
+    dsd_trunk_tuning_request_record* record = dsd_trunk_tuning_request_find_locked(request_id);
+    if (!record || record->state != DSD_TRUNK_TUNING_REQUEST_PENDING) {
+        dsd_trunk_tuning_requests_unlock();
+        return;
+    }
+    record->result = result;
+    record->completed_m_ns = dsd_time_monotonic_ns();
+    record->backend_complete = 1;
+    if (dsd_trunk_tune_result_is_complete(result)) {
+        if (record->owner_ready) {
+            dsd_trunk_tuning_finish_success_locked(record);
+        }
+    } else {
+        record->state = DSD_TRUNK_TUNING_REQUEST_FAILED_GATED;
+    }
+    dsd_trunk_tuning_requests_unlock();
+}
+
+void
+dsd_trunk_tuning_request_mark_ready(uint64_t request_id) {
+    if (request_id == 0U) {
+        return;
+    }
+
+    dsd_trunk_tuning_requests_lock();
+    dsd_trunk_tuning_request_record* record = dsd_trunk_tuning_request_find_locked(request_id);
+    if (record && record->state == DSD_TRUNK_TUNING_REQUEST_PENDING) {
+        record->owner_ready = 1;
+        if (record->backend_complete && dsd_trunk_tune_result_is_complete(record->result)) {
+            dsd_trunk_tuning_finish_success_locked(record);
+        }
+    }
+    dsd_trunk_tuning_requests_unlock();
+}
+
+void
+dsd_trunk_tuning_request_complete(uint64_t request_id, dsd_trunk_tune_result result) {
+    if (request_id == 0U || result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        return;
+    }
+
+    dsd_trunk_tuning_requests_lock();
+    dsd_trunk_tuning_request_record* record = dsd_trunk_tuning_request_find_locked(request_id);
+    if (!record || record->state == DSD_TRUNK_TUNING_REQUEST_FINISHED) {
+        dsd_trunk_tuning_requests_unlock();
+        return;
+    }
+    record->owner_ready = 1;
+    if (record->state == DSD_TRUNK_TUNING_REQUEST_FAILED_GATED) {
+        /* A backend failure raced the owner return. Only an owner rollback can
+         * retire it; a committed owner state must remain gated for recovery. */
+        if (!dsd_trunk_tune_result_is_complete(result)) {
+            dsd_trunk_tuning_finish_rolled_back_locked(record);
+        }
+        dsd_trunk_tuning_requests_unlock();
+        return;
+    }
+
+    if (!record->backend_complete) {
+        record->result = result;
+        record->completed_m_ns = dsd_time_monotonic_ns();
+        record->backend_complete = 1;
+        if (dsd_trunk_tune_result_is_complete(result)) {
+            dsd_trunk_tuning_finish_success_locked(record);
+        } else {
+            dsd_trunk_tuning_finish_rolled_back_locked(record);
+        }
+        dsd_trunk_tuning_requests_unlock();
+        return;
+    }
+
+    const int backend_committed = dsd_trunk_tune_result_is_complete(record->result);
+    const int owner_committed = dsd_trunk_tune_result_is_complete(result);
+    if (backend_committed && owner_committed) {
+        dsd_trunk_tuning_finish_success_locked(record);
+    } else if (!backend_committed && !owner_committed) {
+        dsd_trunk_tuning_finish_rolled_back_locked(record);
+    } else {
+        /* Hardware and decoder ownership disagree. Preserve the frame gate
+         * until a newer successful request establishes a coherent boundary. */
+        if (!owner_committed) {
+            record->result = result;
+        }
+        record->state = DSD_TRUNK_TUNING_REQUEST_FAILED_GATED;
+    }
+    dsd_trunk_tuning_requests_unlock();
+}
+
+uint64_t
+dsd_trunk_tuning_pending_request(void) {
+    uint64_t newest_request_id = 0U;
+    dsd_trunk_tuning_requests_lock();
+    for (int i = 0; i < DSD_TRUNK_TUNING_REQUEST_HISTORY; i++) {
+        const dsd_trunk_tuning_request_record* record = &g_trunk_tuning_requests[i];
+        if ((record->state == DSD_TRUNK_TUNING_REQUEST_PENDING
+             || record->state == DSD_TRUNK_TUNING_REQUEST_FAILED_GATED)
+            && record->request_id > newest_request_id) {
+            newest_request_id = record->request_id;
+        }
+    }
+    dsd_trunk_tuning_requests_unlock();
+    return newest_request_id;
+}
+
+dsd_trunk_tune_result
+dsd_trunk_tuning_request_status(uint64_t request_id, double* out_completed_m) {
+    if (out_completed_m) {
+        *out_completed_m = 0.0;
+    }
+    if (request_id == 0U) {
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
+    }
+
+    dsd_trunk_tuning_requests_lock();
+    const dsd_trunk_tuning_request_record* record = dsd_trunk_tuning_request_find_locked(request_id);
+    dsd_trunk_tune_result result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    if (record) {
+        result = record->state == DSD_TRUNK_TUNING_REQUEST_PENDING ? DSD_TRUNK_TUNE_RESULT_PENDING : record->result;
+        if (out_completed_m && record->completed_m_ns != 0U) {
+            *out_completed_m = (double)record->completed_m_ns / 1e9;
+        }
+    }
+    dsd_trunk_tuning_requests_unlock();
     return result;
+}
+
+int
+dsd_trunk_tuning_frame_is_current(uint64_t frame_generation) {
+    if (atomic_load(&g_trunk_tuning_unresolved_count) != 0) {
+        return 0;
+    }
+    if (frame_generation != dsd_trunk_tuning_generation()) {
+        return 0;
+    }
+    if (atomic_load(&g_trunk_tuning_unresolved_count) != 0) {
+        return 0;
+    }
+    return frame_generation == dsd_trunk_tuning_generation();
+}
+
+static dsd_trunk_tune_result
+dsd_trunk_tuning_note_result(uint64_t request_id, dsd_trunk_tune_result result) {
+    if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        dsd_trunk_tuning_request_mark_ready(request_id);
+        dsd_trunk_tune_result status = dsd_trunk_tuning_request_status(request_id, NULL);
+        return status == DSD_TRUNK_TUNE_RESULT_OK ? status : result;
+    }
+    dsd_trunk_tuning_request_complete(request_id, result);
+    return dsd_trunk_tuning_request_status(request_id, NULL);
 }
 
 static dsd_trunk_tune_result
@@ -89,37 +382,89 @@ dsd_trunk_tuning_hooks_set(dsd_trunk_tuning_hooks hooks) {
 }
 
 dsd_trunk_tune_result
-dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+dsd_trunk_tuning_hook_tune_to_freq_with_id(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
+                                           uint64_t* out_request_id) {
+    const uint64_t request_id = dsd_trunk_tuning_request_begin();
+    if (out_request_id) {
+        *out_request_id = request_id;
+    }
+    if (request_id == 0U) {
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
+    }
+    if (g_trunk_tuning_hooks.tune_to_freq_request) {
+        return dsd_trunk_tuning_note_result(
+            request_id, g_trunk_tuning_hooks.tune_to_freq_request(opts, state, freq, ted_sps, request_id));
+    }
     if (g_trunk_tuning_hooks.tune_to_freq_result) {
-        return dsd_trunk_tuning_note_result(g_trunk_tuning_hooks.tune_to_freq_result(opts, state, freq, ted_sps));
+        return dsd_trunk_tuning_note_result(request_id,
+                                            g_trunk_tuning_hooks.tune_to_freq_result(opts, state, freq, ted_sps));
     }
     if (g_trunk_tuning_hooks.tune_to_freq) {
         g_trunk_tuning_hooks.tune_to_freq(opts, state, freq, ted_sps);
-        return dsd_trunk_tuning_note_result(DSD_TRUNK_TUNE_RESULT_OK);
+        return dsd_trunk_tuning_note_result(request_id, DSD_TRUNK_TUNE_RESULT_OK);
     }
-    return dsd_trunk_tuning_note_result(dsd_trunk_tuning_fallback_tune_to_freq(opts, state, freq, ted_sps));
+    return dsd_trunk_tuning_note_result(request_id, dsd_trunk_tuning_fallback_tune_to_freq(opts, state, freq, ted_sps));
+}
+
+dsd_trunk_tune_result
+dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    return dsd_trunk_tuning_hook_tune_to_freq_with_id(opts, state, freq, ted_sps, NULL);
+}
+
+dsd_trunk_tune_result
+dsd_trunk_tuning_hook_tune_to_cc_with_id(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
+                                         uint64_t* out_request_id) {
+    const uint64_t request_id = dsd_trunk_tuning_request_begin();
+    if (out_request_id) {
+        *out_request_id = request_id;
+    }
+    if (request_id == 0U) {
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
+    }
+    if (g_trunk_tuning_hooks.tune_to_cc_request) {
+        return dsd_trunk_tuning_note_result(
+            request_id, g_trunk_tuning_hooks.tune_to_cc_request(opts, state, freq, ted_sps, request_id));
+    }
+    if (g_trunk_tuning_hooks.tune_to_cc_result) {
+        return dsd_trunk_tuning_note_result(request_id,
+                                            g_trunk_tuning_hooks.tune_to_cc_result(opts, state, freq, ted_sps));
+    }
+    if (g_trunk_tuning_hooks.tune_to_cc) {
+        g_trunk_tuning_hooks.tune_to_cc(opts, state, freq, ted_sps);
+        return dsd_trunk_tuning_note_result(request_id, DSD_TRUNK_TUNE_RESULT_OK);
+    }
+    return dsd_trunk_tuning_note_result(request_id, dsd_trunk_tuning_fallback_tune_to_cc(opts, state, freq, ted_sps));
 }
 
 dsd_trunk_tune_result
 dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
-    if (g_trunk_tuning_hooks.tune_to_cc_result) {
-        return dsd_trunk_tuning_note_result(g_trunk_tuning_hooks.tune_to_cc_result(opts, state, freq, ted_sps));
+    return dsd_trunk_tuning_hook_tune_to_cc_with_id(opts, state, freq, ted_sps, NULL);
+}
+
+dsd_trunk_tune_result
+dsd_trunk_tuning_hook_return_to_cc_with_id(dsd_opts* opts, dsd_state* state, uint64_t* out_request_id) {
+    const uint64_t request_id = dsd_trunk_tuning_request_begin();
+    if (out_request_id) {
+        *out_request_id = request_id;
     }
-    if (g_trunk_tuning_hooks.tune_to_cc) {
-        g_trunk_tuning_hooks.tune_to_cc(opts, state, freq, ted_sps);
-        return dsd_trunk_tuning_note_result(DSD_TRUNK_TUNE_RESULT_OK);
+    if (request_id == 0U) {
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
     }
-    return dsd_trunk_tuning_note_result(dsd_trunk_tuning_fallback_tune_to_cc(opts, state, freq, ted_sps));
+    if (g_trunk_tuning_hooks.return_to_cc_request) {
+        return dsd_trunk_tuning_note_result(request_id,
+                                            g_trunk_tuning_hooks.return_to_cc_request(opts, state, request_id));
+    }
+    if (g_trunk_tuning_hooks.return_to_cc_result) {
+        return dsd_trunk_tuning_note_result(request_id, g_trunk_tuning_hooks.return_to_cc_result(opts, state));
+    }
+    if (g_trunk_tuning_hooks.return_to_cc) {
+        g_trunk_tuning_hooks.return_to_cc(opts, state);
+        return dsd_trunk_tuning_note_result(request_id, DSD_TRUNK_TUNE_RESULT_OK);
+    }
+    return dsd_trunk_tuning_note_result(request_id, dsd_trunk_tuning_fallback_return_to_cc(opts, state));
 }
 
 dsd_trunk_tune_result
 dsd_trunk_tuning_hook_return_to_cc(dsd_opts* opts, dsd_state* state) {
-    if (g_trunk_tuning_hooks.return_to_cc_result) {
-        return dsd_trunk_tuning_note_result(g_trunk_tuning_hooks.return_to_cc_result(opts, state));
-    }
-    if (g_trunk_tuning_hooks.return_to_cc) {
-        g_trunk_tuning_hooks.return_to_cc(opts, state);
-        return dsd_trunk_tuning_note_result(DSD_TRUNK_TUNE_RESULT_OK);
-    }
-    return dsd_trunk_tuning_note_result(dsd_trunk_tuning_fallback_return_to_cc(opts, state));
+    return dsd_trunk_tuning_hook_return_to_cc_with_id(opts, state, NULL);
 }

--- a/src/runtime/trunk_tuning_hooks.c
+++ b/src/runtime/trunk_tuning_hooks.c
@@ -6,13 +6,34 @@
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/platform/atomic_compat.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
 #include <time.h>
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 
 static dsd_trunk_tuning_hooks g_trunk_tuning_hooks = {0};
+static dsd_atomic_u64 g_trunk_tuning_generation = {1U};
+
+uint64_t
+dsd_trunk_tuning_generation(void) {
+    return dsd_atomic_u64_load_acquire(&g_trunk_tuning_generation);
+}
+
+void
+dsd_trunk_tuning_generation_advance(void) {
+    (void)dsd_atomic_u64_fetch_add_release(&g_trunk_tuning_generation, 1U);
+}
+
+static dsd_trunk_tune_result
+dsd_trunk_tuning_note_result(dsd_trunk_tune_result result) {
+    if (dsd_trunk_tune_result_is_ok(result)) {
+        dsd_trunk_tuning_generation_advance();
+    }
+    return result;
+}
 
 static dsd_trunk_tune_result
 dsd_trunk_tuning_fallback_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
@@ -70,35 +91,35 @@ dsd_trunk_tuning_hooks_set(dsd_trunk_tuning_hooks hooks) {
 dsd_trunk_tune_result
 dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     if (g_trunk_tuning_hooks.tune_to_freq_result) {
-        return g_trunk_tuning_hooks.tune_to_freq_result(opts, state, freq, ted_sps);
+        return dsd_trunk_tuning_note_result(g_trunk_tuning_hooks.tune_to_freq_result(opts, state, freq, ted_sps));
     }
     if (g_trunk_tuning_hooks.tune_to_freq) {
         g_trunk_tuning_hooks.tune_to_freq(opts, state, freq, ted_sps);
-        return DSD_TRUNK_TUNE_RESULT_OK;
+        return dsd_trunk_tuning_note_result(DSD_TRUNK_TUNE_RESULT_OK);
     }
-    return dsd_trunk_tuning_fallback_tune_to_freq(opts, state, freq, ted_sps);
+    return dsd_trunk_tuning_note_result(dsd_trunk_tuning_fallback_tune_to_freq(opts, state, freq, ted_sps));
 }
 
 dsd_trunk_tune_result
 dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     if (g_trunk_tuning_hooks.tune_to_cc_result) {
-        return g_trunk_tuning_hooks.tune_to_cc_result(opts, state, freq, ted_sps);
+        return dsd_trunk_tuning_note_result(g_trunk_tuning_hooks.tune_to_cc_result(opts, state, freq, ted_sps));
     }
     if (g_trunk_tuning_hooks.tune_to_cc) {
         g_trunk_tuning_hooks.tune_to_cc(opts, state, freq, ted_sps);
-        return DSD_TRUNK_TUNE_RESULT_OK;
+        return dsd_trunk_tuning_note_result(DSD_TRUNK_TUNE_RESULT_OK);
     }
-    return dsd_trunk_tuning_fallback_tune_to_cc(opts, state, freq, ted_sps);
+    return dsd_trunk_tuning_note_result(dsd_trunk_tuning_fallback_tune_to_cc(opts, state, freq, ted_sps));
 }
 
 dsd_trunk_tune_result
 dsd_trunk_tuning_hook_return_to_cc(dsd_opts* opts, dsd_state* state) {
     if (g_trunk_tuning_hooks.return_to_cc_result) {
-        return g_trunk_tuning_hooks.return_to_cc_result(opts, state);
+        return dsd_trunk_tuning_note_result(g_trunk_tuning_hooks.return_to_cc_result(opts, state));
     }
     if (g_trunk_tuning_hooks.return_to_cc) {
         g_trunk_tuning_hooks.return_to_cc(opts, state);
-        return DSD_TRUNK_TUNE_RESULT_OK;
+        return dsd_trunk_tuning_note_result(DSD_TRUNK_TUNE_RESULT_OK);
     }
-    return dsd_trunk_tuning_fallback_return_to_cc(opts, state);
+    return dsd_trunk_tuning_note_result(dsd_trunk_tuning_fallback_return_to_cc(opts, state));
 }

--- a/src/runtime/trunk_tuning_hooks.c
+++ b/src/runtime/trunk_tuning_hooks.c
@@ -181,6 +181,23 @@ dsd_trunk_tuning_requests_reset(void) {
 }
 
 void
+dsd_trunk_tuning_retire_failed_requests(void) {
+    if (atomic_load(&g_trunk_tuning_unresolved_count) == 0) {
+        return;
+    }
+
+    dsd_trunk_tuning_requests_lock();
+    for (int i = 0; i < DSD_TRUNK_TUNING_REQUEST_HISTORY; i++) {
+        dsd_trunk_tuning_request_record* record = &g_trunk_tuning_requests[i];
+        if (record->state == DSD_TRUNK_TUNING_REQUEST_FAILED_GATED) {
+            record->state = DSD_TRUNK_TUNING_REQUEST_FINISHED;
+            (void)atomic_fetch_add(&g_trunk_tuning_unresolved_count, -1);
+        }
+    }
+    dsd_trunk_tuning_requests_unlock();
+}
+
+void
 dsd_trunk_tuning_request_publish(uint64_t request_id, dsd_trunk_tune_result result) {
     if (request_id == 0U || result == DSD_TRUNK_TUNE_RESULT_PENDING) {
         return;

--- a/src/runtime/trunk_tuning_hooks.c
+++ b/src/runtime/trunk_tuning_hooks.c
@@ -344,6 +344,14 @@ dsd_trunk_tuning_frame_is_current(uint64_t frame_generation) {
     return frame_generation == dsd_trunk_tuning_generation();
 }
 
+int
+dsd_trunk_tuning_frame_is_dispatchable(uint64_t frame_generation, int tune_owner_active) {
+    if (!tune_owner_active) {
+        dsd_trunk_tuning_retire_failed_requests();
+    }
+    return dsd_trunk_tuning_frame_is_current(frame_generation);
+}
+
 static dsd_trunk_tune_result
 dsd_trunk_tuning_note_result(uint64_t request_id, dsd_trunk_tune_result result) {
     if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {

--- a/src/runtime/trunk_tuning_hooks.c
+++ b/src/runtime/trunk_tuning_hooks.c
@@ -171,6 +171,16 @@ dsd_trunk_tuning_request_begin(void) {
 }
 
 void
+dsd_trunk_tuning_requests_reset(void) {
+    dsd_trunk_tuning_requests_lock();
+    for (int i = 0; i < DSD_TRUNK_TUNING_REQUEST_HISTORY; i++) {
+        g_trunk_tuning_requests[i] = (dsd_trunk_tuning_request_record){0};
+    }
+    atomic_store(&g_trunk_tuning_unresolved_count, 0);
+    dsd_trunk_tuning_requests_unlock();
+}
+
+void
 dsd_trunk_tuning_request_publish(uint64_t request_id, dsd_trunk_tune_result result) {
     if (request_id == 0U || result == DSD_TRUNK_TUNE_RESULT_PENDING) {
         return;
@@ -329,6 +339,16 @@ dsd_trunk_tuning_note_result(uint64_t request_id, dsd_trunk_tune_result result) 
 }
 
 static dsd_trunk_tune_result
+dsd_trunk_tuning_note_legacy_result(dsd_trunk_tune_result result) {
+    /* Legacy result hooks cannot receive a request ID, so a PENDING result is
+     * intentionally uncorrelated and must not close the global frame gate. */
+    if (dsd_trunk_tune_result_is_ok(result)) {
+        dsd_trunk_tuning_generation_advance();
+    }
+    return result;
+}
+
+static dsd_trunk_tune_result
 dsd_trunk_tuning_fallback_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     (void)ted_sps;
     if (!opts || !state || freq <= 0) {
@@ -384,6 +404,13 @@ dsd_trunk_tuning_hooks_set(dsd_trunk_tuning_hooks hooks) {
 dsd_trunk_tune_result
 dsd_trunk_tuning_hook_tune_to_freq_with_id(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
                                            uint64_t* out_request_id) {
+    if (out_request_id) {
+        *out_request_id = 0U;
+    }
+    if (g_trunk_tuning_hooks.tune_to_freq_result && !g_trunk_tuning_hooks.tune_to_freq_request) {
+        return dsd_trunk_tuning_note_legacy_result(
+            g_trunk_tuning_hooks.tune_to_freq_result(opts, state, freq, ted_sps));
+    }
     const uint64_t request_id = dsd_trunk_tuning_request_begin();
     if (out_request_id) {
         *out_request_id = request_id;
@@ -394,10 +421,6 @@ dsd_trunk_tuning_hook_tune_to_freq_with_id(dsd_opts* opts, dsd_state* state, lon
     if (g_trunk_tuning_hooks.tune_to_freq_request) {
         return dsd_trunk_tuning_note_result(
             request_id, g_trunk_tuning_hooks.tune_to_freq_request(opts, state, freq, ted_sps, request_id));
-    }
-    if (g_trunk_tuning_hooks.tune_to_freq_result) {
-        return dsd_trunk_tuning_note_result(request_id,
-                                            g_trunk_tuning_hooks.tune_to_freq_result(opts, state, freq, ted_sps));
     }
     if (g_trunk_tuning_hooks.tune_to_freq) {
         g_trunk_tuning_hooks.tune_to_freq(opts, state, freq, ted_sps);
@@ -414,6 +437,12 @@ dsd_trunk_tuning_hook_tune_to_freq(dsd_opts* opts, dsd_state* state, long int fr
 dsd_trunk_tune_result
 dsd_trunk_tuning_hook_tune_to_cc_with_id(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
                                          uint64_t* out_request_id) {
+    if (out_request_id) {
+        *out_request_id = 0U;
+    }
+    if (g_trunk_tuning_hooks.tune_to_cc_result && !g_trunk_tuning_hooks.tune_to_cc_request) {
+        return dsd_trunk_tuning_note_legacy_result(g_trunk_tuning_hooks.tune_to_cc_result(opts, state, freq, ted_sps));
+    }
     const uint64_t request_id = dsd_trunk_tuning_request_begin();
     if (out_request_id) {
         *out_request_id = request_id;
@@ -424,10 +453,6 @@ dsd_trunk_tuning_hook_tune_to_cc_with_id(dsd_opts* opts, dsd_state* state, long 
     if (g_trunk_tuning_hooks.tune_to_cc_request) {
         return dsd_trunk_tuning_note_result(
             request_id, g_trunk_tuning_hooks.tune_to_cc_request(opts, state, freq, ted_sps, request_id));
-    }
-    if (g_trunk_tuning_hooks.tune_to_cc_result) {
-        return dsd_trunk_tuning_note_result(request_id,
-                                            g_trunk_tuning_hooks.tune_to_cc_result(opts, state, freq, ted_sps));
     }
     if (g_trunk_tuning_hooks.tune_to_cc) {
         g_trunk_tuning_hooks.tune_to_cc(opts, state, freq, ted_sps);
@@ -443,6 +468,12 @@ dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq
 
 dsd_trunk_tune_result
 dsd_trunk_tuning_hook_return_to_cc_with_id(dsd_opts* opts, dsd_state* state, uint64_t* out_request_id) {
+    if (out_request_id) {
+        *out_request_id = 0U;
+    }
+    if (g_trunk_tuning_hooks.return_to_cc_result && !g_trunk_tuning_hooks.return_to_cc_request) {
+        return dsd_trunk_tuning_note_legacy_result(g_trunk_tuning_hooks.return_to_cc_result(opts, state));
+    }
     const uint64_t request_id = dsd_trunk_tuning_request_begin();
     if (out_request_id) {
         *out_request_id = request_id;
@@ -453,9 +484,6 @@ dsd_trunk_tuning_hook_return_to_cc_with_id(dsd_opts* opts, dsd_state* state, uin
     if (g_trunk_tuning_hooks.return_to_cc_request) {
         return dsd_trunk_tuning_note_result(request_id,
                                             g_trunk_tuning_hooks.return_to_cc_request(opts, state, request_id));
-    }
-    if (g_trunk_tuning_hooks.return_to_cc_result) {
-        return dsd_trunk_tuning_note_result(request_id, g_trunk_tuning_hooks.return_to_cc_result(opts, state));
     }
     if (g_trunk_tuning_hooks.return_to_cc) {
         g_trunk_tuning_hooks.return_to_cc(opts, state);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3216,6 +3216,16 @@ else()
         PRIVATE ${_DSD_RUNTIME_CONFIG_APPLY_LIBS} ${LIBS} dsd-neo_test_support
     )
 endif()
+if(NOT APPLE AND NOT WIN32 AND (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang"))
+    target_compile_definitions(
+        dsd-neo_test_app_command_queue
+        PRIVATE DSD_NEO_TEST_IO_CONTROL_WRAP
+    )
+    target_link_options(
+        dsd-neo_test_app_command_queue
+        PRIVATE "LINKER:--wrap=io_control_set_freq"
+    )
+endif()
 add_test(NAME APP_COMMAND_QUEUE COMMAND dsd-neo_test_app_command_queue)
 
 set(_DSD_BOOTSTRAP_FIXTURE_DIR

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2956,6 +2956,7 @@ if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
             "-Wl,--wrap=rtl_stream_prepare_retune_profile_for_target_with_gain"
             "-Wl,--wrap=rtl_stream_request_fsk_reacquire"
             "-Wl,--wrap=rtl_stream_tune"
+            "-Wl,--wrap=rtl_stream_tune_tagged"
             ${LIBS}
             dsd-neo_feature_radio
             dsd-neo_test_support

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2957,6 +2957,7 @@ if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
             "-Wl,--wrap=rtl_stream_request_fsk_reacquire"
             "-Wl,--wrap=rtl_stream_tune"
             "-Wl,--wrap=rtl_stream_tune_tagged"
+            "-Wl,--wrap=p25_sm_await_pending_cc_tune"
             ${LIBS}
             dsd-neo_feature_radio
             dsd-neo_test_support

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6500,7 +6500,7 @@ add_executable(
 )
 target_compile_definitions(
     dsd-neo_test_io_rigctl_control
-    PRIVATE DSD_NEO_TEST_HOOKS
+    PRIVATE DSD_NEO_TEST_HOOKS USE_RADIO
 )
 target_include_directories(
     dsd-neo_test_io_rigctl_control

--- a/tests/core/test_core_init_state.c
+++ b/tests/core/test_core_init_state.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/p25_cqpsk_dibit.h>
 #include <dsd-neo/core/state.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -88,6 +89,8 @@ main(void) {
     state->ess_b_llr[1][95] = 123;
     state->fourv_counter[0] = 2;
     state->p25_p1_soft_hamming_ok = 77U;
+    state->p25_last_cc_msg_time = 1234567890;
+    state->p25_last_cc_msg_time_m = 12345.5;
     state->K = 42;
     state->R = 0x1234567891ULL;
     state->RR = 0x1234567892ULL;
@@ -245,6 +248,13 @@ main(void) {
         freeState(state);
         free(state);
         return 12;
+    }
+    if (state->p25_last_cc_msg_time != 0 || !isfinite(state->p25_last_cc_msg_time_m)
+        || fabs(state->p25_last_cc_msg_time_m) > 1e-12) {
+        DSD_FPRINTF(stderr, "initState did not clear P25 decoded control-channel timestamps\n");
+        freeState(state);
+        free(state);
+        return 27;
     }
     for (int i = 0; i < 2; i++) {
         if (state->p25_mac_frag[i].active != 0U || state->p25_mac_frag[i].opcode != 0U

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -617,6 +617,35 @@ main(void) {
     reset_rtl_profile_fakes();
     opts->audio_in_type = AUDIO_IN_RTL;
     opts->scanner_mode = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->trunk_lcn_freq[0] = 773456250;
+    state->lcn_freq_count = 1;
+    state->lcn_freq_roll = 0;
+    state->last_cc_sync_time = time(NULL) - 11;
+    const time_t deferred_scan_time = state->last_cc_sync_time;
+    g_rtl_tune_result = RTL_STREAM_TUNE_DEFERRED;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("rtl-scanner-deferred-attempt", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 773456250U);
+    rc |= expect_true("rtl-scanner-deferred-keeps-candidate", state->lcn_freq_roll == 0);
+    rc |= expect_true("rtl-scanner-deferred-keeps-deadline", state->last_cc_sync_time == deferred_scan_time);
+
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    noCarrier(opts, state);
+
+    rc |= expect_true("rtl-scanner-deferred-retries", g_rtl_tune_calls == 2 && g_rtl_tune_freq == 773456250U);
+    rc |= expect_true("rtl-scanner-retry-advances-candidate", state->lcn_freq_roll == 1);
+    rc |= expect_true("rtl-scanner-retry-restarts-deadline", state->last_cc_sync_time > deferred_scan_time);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    reset_rtl_profile_fakes();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->scanner_mode = 1;
     opts->p25_trunk = 1;
     opts->trunk_enable = 1;
     opts->p25_is_tuned = 1;

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
@@ -42,6 +43,37 @@ static int
 fake_rtl_fsk_output_kind(void) {
     return RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
 }
+#endif
+
+#if defined(DSD_NEO_TEST_RTL_WRAP)
+static int g_check_p25_tick_guard = 0;
+static int g_p25_tick_guard_held_during_tune = 0;
+static int g_p25_tick_guard_held_during_context_update = 0;
+
+static int
+p25_tick_guard_is_held(void) {
+    if (!p25_sm_tick_guard_try_enter()) {
+        return 1;
+    }
+    p25_sm_tick_guard_leave();
+    return 0;
+}
+
+// GNU ld --wrap entry points must keep the reserved __real_* and __wrap_* names.
+// NOLINTBEGIN(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+int __real_p25_sm_await_pending_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, uint64_t request_id,
+                                        const char* source);
+
+int
+__wrap_p25_sm_await_pending_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, uint64_t request_id,
+                                    const char* source) {
+    if (g_check_p25_tick_guard) {
+        g_p25_tick_guard_held_during_context_update = p25_tick_guard_is_held();
+    }
+    return __real_p25_sm_await_pending_cc_tune(ctx, opts, state, request_id, source);
+}
+
+// NOLINTEND(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
 #endif
 
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
@@ -88,6 +120,9 @@ reset_rtl_profile_fakes(void) {
     g_pending_channel_profile = 0;
     g_pending_ted_sps = 0;
     g_pending_ted_override = 0;
+    g_check_p25_tick_guard = 0;
+    g_p25_tick_guard_held_during_tune = 0;
+    g_p25_tick_guard_held_during_context_update = 0;
 }
 
 // GNU ld --wrap entry points must keep the reserved __wrap_* symbol names.
@@ -207,6 +242,9 @@ __wrap_rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz) {
 int
 __wrap_rtl_stream_tune_tagged(RtlSdrContext* ctx, uint32_t center_freq_hz, uint64_t token) {
     g_rtl_tune_token = token;
+    if (g_check_p25_tick_guard) {
+        g_p25_tick_guard_held_during_tune = p25_tick_guard_is_held();
+    }
     return __wrap_rtl_stream_tune(ctx, center_freq_hz);
 }
 
@@ -451,6 +489,40 @@ main(void) {
         return 1;
     }
 
+    // noCarrier can run from control pumping inside guarded frame dispatch.
+    // Guard contention must defer the P25 return without blocking or clearing
+    // the voice state, then allow the next main-loop pass to complete it.
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    state->p25_cc_freq = 769868750;
+    state->trunk_cc_freq = 769868750;
+    state->lastsynctype = DSD_SYNC_P25P1_POS;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->p25_vc_freq[0] = 771056250;
+    state->p25_vc_freq[1] = 771056250;
+
+    int preheld_guard = p25_sm_tick_guard_try_enter();
+    rc |= expect_true("p25-nocarrier-contention-setup", preheld_guard == 1);
+    if (preheld_guard) {
+        noCarrier(opts, state);
+        rc |= expect_true("p25-nocarrier-contention-preserves-state",
+                          opts->p25_is_tuned == 1 && opts->trunk_is_tuned == 1 && state->p25_vc_freq[0] == 771056250
+                              && state->p25_vc_freq[1] == 771056250);
+        p25_sm_tick_guard_leave();
+    }
+
+    noCarrier(opts, state);
+    rc |= expect_true("p25-nocarrier-contention-retries",
+                      opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0 && state->p25_vc_freq[0] == 0);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {
@@ -509,14 +581,23 @@ main(void) {
     state->p25_vc_freq[0] = state->p25_vc_freq[1] = 771056250;
     p25_sm_ctx_t* pending_ctx = p25_sm_get_ctx();
     p25_sm_init_ctx(pending_ctx, opts, state);
+    g_check_p25_tick_guard = 1;
 
     noCarrier(opts, state);
+    g_check_p25_tick_guard = 0;
 
     uint64_t pending_request_id = pending_ctx->cc_tune_request_id;
     rc |= expect_true("p25-rtl-nocarrier-pending-tagged",
                       g_rtl_tune_calls == 1 && g_rtl_tune_token != 0U && pending_request_id == g_rtl_tune_token);
     rc |= expect_true("p25-rtl-nocarrier-pending-holds-acquisition",
                       pending_ctx->cc_tune_pending == 1 && pending_ctx->t_cc_tune_m == 0.0);
+    rc |= expect_true("p25-rtl-nocarrier-pending-serializes-tune", g_p25_tick_guard_held_during_tune == 1);
+    rc |= expect_true("p25-rtl-nocarrier-pending-serializes-context", g_p25_tick_guard_held_during_context_update == 1);
+    int guard_released = p25_sm_tick_guard_try_enter();
+    rc |= expect_true("p25-rtl-nocarrier-pending-releases-guard", guard_released == 1);
+    if (guard_released) {
+        p25_sm_tick_guard_leave();
+    }
     rc |= expect_true("p25-rtl-nocarrier-pending-closes-frame-gate",
                       !dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
 
@@ -915,6 +996,102 @@ main(void) {
     rc |= expect_true("dmr-rtl-nocarrier-keeps-generic-profile",
                       g_rtl_symbol_rate_hz == 6000 && g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_WIDE);
 
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    // A failed asynchronous generic voice tune keeps dispatch gated until a
+    // correlated CC recovery establishes a newer coherent tuner boundary.
+    reset_rtl_profile_fakes();
+    g_rtl_tune_result = RTL_STREAM_TUNE_TIMEOUT;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_WIDE;
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 0;
+    opts->trunk_enable = 1;
+    opts->p25_is_tuned = 0;
+    opts->trunk_is_tuned = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 769868750;
+    state->trunk_cc_freq = 936000000;
+    state->lastsynctype = DSD_SYNC_NXDN_POS;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->trunk_vc_freq[0] = 936500000;
+    state->trunk_vc_freq[1] = 936500000;
+
+    const uint64_t failed_generation = dsd_trunk_tuning_generation();
+    rc |= expect_true("generic-rtl-recovery-clean-gate", dsd_trunk_tuning_frame_is_current(failed_generation));
+    const uint64_t failed_request_id = dsd_trunk_tuning_request_begin();
+    dsd_trunk_tuning_request_mark_ready(failed_request_id);
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("generic-rtl-recovery-pending-suppresses-legacy",
+                      failed_request_id != 0U && g_rtl_tune_calls == 0 && opts->trunk_is_tuned == 1
+                          && dsd_trunk_tuning_request_status(failed_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_PENDING);
+    dsd_trunk_tuning_request_publish(failed_request_id, DSD_TRUNK_TUNE_RESULT_FAILED);
+    rc |= expect_true("generic-rtl-recovery-seeds-failed-gate",
+                      dsd_trunk_tuning_request_status(failed_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_FAILED
+                          && !dsd_trunk_tuning_frame_is_current(failed_generation));
+
+    noCarrier(opts, state);
+
+    const uint64_t recovery_request_id = g_rtl_tune_token;
+    rc |=
+        expect_true("generic-rtl-recovery-retune-is-correlated",
+                    g_rtl_tune_calls == 1 && g_rtl_tune_freq == 936000000U && recovery_request_id > failed_request_id);
+    rc |= expect_true("generic-rtl-recovery-holds-retry-state",
+                      opts->trunk_is_tuned == 1 && state->trunk_vc_freq[0] == 0 && state->trunk_cc_freq == 936000000
+                          && state->p25_cc_freq == 0);
+    rc |= expect_true("generic-rtl-recovery-remains-gated-while-pending",
+                      dsd_trunk_tuning_request_status(recovery_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_PENDING
+                          && !dsd_trunk_tuning_frame_is_current(failed_generation));
+    rc |=
+        expect_true("generic-rtl-recovery-preserves-profile", g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_WIDE);
+
+    dsd_trunk_tuning_request_publish(recovery_request_id, DSD_TRUNK_TUNE_RESULT_FAILED);
+    rc |= expect_true("generic-rtl-recovery-failure-stays-gated",
+                      dsd_trunk_tuning_request_status(recovery_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_FAILED
+                          && !dsd_trunk_tuning_frame_is_current(failed_generation));
+
+    noCarrier(opts, state);
+
+    const uint64_t retry_request_id = g_rtl_tune_token;
+    rc |= expect_true("generic-rtl-recovery-failure-retries-correlated",
+                      g_rtl_tune_calls == 2 && retry_request_id > recovery_request_id
+                          && dsd_trunk_tuning_request_status(retry_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_PENDING
+                          && opts->trunk_is_tuned == 1);
+
+    dsd_trunk_tuning_request_publish(retry_request_id, DSD_TRUNK_TUNE_RESULT_OK);
+    const uint64_t first_recovery_generation = dsd_trunk_tuning_generation();
+    rc |= expect_true("generic-rtl-recovery-success-retires-failed-gate",
+                      first_recovery_generation == failed_generation + 1U && dsd_trunk_tuning_pending_request() == 0U
+                          && dsd_trunk_tuning_frame_is_current(first_recovery_generation));
+
+    // A target switch while the recovery was in flight must establish a new
+    // boundary instead of accepting the old completion for the current CC.
+    state->trunk_cc_freq = 937000000;
+    noCarrier(opts, state);
+
+    const uint64_t switched_request_id = g_rtl_tune_token;
+    rc |= expect_true("generic-rtl-recovery-target-switch-retunes",
+                      g_rtl_tune_calls == 3 && g_rtl_tune_freq == 937000000U && switched_request_id > retry_request_id
+                          && dsd_trunk_tuning_request_status(switched_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_PENDING
+                          && !dsd_trunk_tuning_frame_is_current(first_recovery_generation));
+
+    dsd_trunk_tuning_request_publish(switched_request_id, DSD_TRUNK_TUNE_RESULT_OK);
+    const uint64_t recovery_generation = dsd_trunk_tuning_generation();
+    rc |= expect_true("generic-rtl-recovery-target-switch-commits",
+                      recovery_generation == failed_generation + 2U && dsd_trunk_tuning_pending_request() == 0U
+                          && dsd_trunk_tuning_frame_is_current(recovery_generation));
+
+    noCarrier(opts, state);
+    rc |= expect_true("generic-rtl-recovery-success-commits-without-retune",
+                      g_rtl_tune_calls == 3 && opts->trunk_is_tuned == 0 && state->trunk_vc_freq[0] == 0
+                          && state->trunk_cc_freq == 937000000);
+
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {
         return 1;

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -10,8 +10,10 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -45,6 +47,7 @@ fake_rtl_fsk_output_kind(void) {
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
 static int g_rtl_tune_calls = 0;
 static uint32_t g_rtl_tune_freq = 0;
+static uint64_t g_rtl_tune_token = 0U;
 static int g_rtl_tune_result = RTL_STREAM_TUNE_OK;
 static int g_rtl_output_rate = 48000;
 static int g_rtl_cqpsk_enable = 0;
@@ -67,6 +70,7 @@ static void
 reset_rtl_profile_fakes(void) {
     g_rtl_tune_calls = 0;
     g_rtl_tune_freq = 0;
+    g_rtl_tune_token = 0U;
     g_rtl_tune_result = RTL_STREAM_TUNE_OK;
     g_rtl_output_rate = 48000;
     g_rtl_cqpsk_enable = 1;
@@ -198,6 +202,12 @@ __wrap_rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz) {
         apply_pending_profile(center_freq_hz);
     }
     return g_rtl_tune_result;
+}
+
+int
+__wrap_rtl_stream_tune_tagged(RtlSdrContext* ctx, uint32_t center_freq_hz, uint64_t token) {
+    g_rtl_tune_token = token;
+    return __wrap_rtl_stream_tune(ctx, center_freq_hz);
 }
 
 int
@@ -473,7 +483,8 @@ main(void) {
 
     noCarrier(opts, state);
 
-    rc |= expect_true("p25-rtl-nocarrier-cc-retune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769868750U);
+    rc |= expect_true("p25-rtl-nocarrier-cc-retune",
+                      g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769868750U && g_rtl_tune_token != 0U);
     rc |= expect_true("p25-rtl-nocarrier-syncs-selected-cc",
                       state->p25_cc_freq == 769868750 && state->trunk_cc_freq == 769868750);
     rc |= expect_true("p25-rtl-nocarrier-cc-profile-rate", g_rtl_symbol_rate_hz == 4800);
@@ -484,6 +495,38 @@ main(void) {
     rc |= expect_true("p25-rtl-nocarrier-reenables-slots", opts->slot1_on == 1 && opts->slot2_on == 1);
     rc |= expect_true("p25-rtl-nocarrier-clear-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
     rc |= expect_true("p25-rtl-nocarrier-clear-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0);
+
+    // A controller wait timeout keeps frame dispatch closed and starts the CC
+    // acquisition window only after the exact tagged request completes.
+    reset_rtl_profile_fakes();
+    g_rtl_tune_result = RTL_STREAM_TUNE_TIMEOUT;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    state->p25_cc_freq = 769868750;
+    state->trunk_cc_freq = 769868750;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->p25_vc_freq[0] = state->p25_vc_freq[1] = 771056250;
+    p25_sm_ctx_t* pending_ctx = p25_sm_get_ctx();
+    p25_sm_init_ctx(pending_ctx, opts, state);
+
+    noCarrier(opts, state);
+
+    uint64_t pending_request_id = pending_ctx->cc_tune_request_id;
+    rc |= expect_true("p25-rtl-nocarrier-pending-tagged",
+                      g_rtl_tune_calls == 1 && g_rtl_tune_token != 0U && pending_request_id == g_rtl_tune_token);
+    rc |= expect_true("p25-rtl-nocarrier-pending-holds-acquisition",
+                      pending_ctx->cc_tune_pending == 1 && pending_ctx->t_cc_tune_m == 0.0);
+    rc |= expect_true("p25-rtl-nocarrier-pending-closes-frame-gate",
+                      !dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
+
+    dsd_trunk_tuning_request_complete(pending_request_id, DSD_TRUNK_TUNE_RESULT_OK);
+    p25_sm_tick_ctx(pending_ctx, opts, state);
+    rc |= expect_true("p25-rtl-nocarrier-completion-starts-acquisition",
+                      pending_ctx->cc_tune_pending == 0 && pending_ctx->t_cc_tune_m > 0.0);
+    rc |= expect_true("p25-rtl-nocarrier-completion-opens-frame-gate",
+                      dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
 
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -48,7 +48,6 @@ fake_rtl_fsk_output_kind(void) {
 
 #if defined(DSD_NEO_TEST_RTL_WRAP)
 static int g_check_p25_tick_guard = 0;
-static int g_p25_tick_guard_held_during_tune = 0;
 static int g_p25_tick_guard_held_during_context_update = 0;
 
 static int
@@ -78,6 +77,7 @@ __wrap_p25_sm_await_pending_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state
 #endif
 
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
+static int g_p25_tick_guard_held_during_tune = 0;
 static int g_rtl_tune_calls = 0;
 static uint32_t g_rtl_tune_freq = 0;
 static uint64_t g_rtl_tune_token = 0U;

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -1084,6 +1084,14 @@ main(void) {
                       dsd_trunk_tuning_request_status(recovery_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_FAILED
                           && !dsd_trunk_tuning_frame_is_current(failed_generation));
 
+    // A newer unrelated success can retire the failed gate, but it must not
+    // make the failed saved recovery request acceptable for this control channel.
+    const uint64_t unrelated_request_id = dsd_trunk_tuning_request_begin();
+    dsd_trunk_tuning_request_complete(unrelated_request_id, DSD_TRUNK_TUNE_RESULT_OK);
+    rc |= expect_true("generic-rtl-recovery-unrelated-success-opens-gate",
+                      unrelated_request_id > recovery_request_id && dsd_trunk_tuning_pending_request() == 0U
+                          && dsd_trunk_tuning_frame_is_current(failed_generation + 1U));
+
     noCarrier(opts, state);
 
     const uint64_t retry_request_id = g_rtl_tune_token;
@@ -1095,7 +1103,7 @@ main(void) {
     dsd_trunk_tuning_request_publish(retry_request_id, DSD_TRUNK_TUNE_RESULT_OK);
     const uint64_t first_recovery_generation = dsd_trunk_tuning_generation();
     rc |= expect_true("generic-rtl-recovery-success-retires-failed-gate",
-                      first_recovery_generation == failed_generation + 1U && dsd_trunk_tuning_pending_request() == 0U
+                      first_recovery_generation == failed_generation + 2U && dsd_trunk_tuning_pending_request() == 0U
                           && dsd_trunk_tuning_frame_is_current(first_recovery_generation));
 
     // A target switch while the recovery was in flight must establish a new
@@ -1112,7 +1120,7 @@ main(void) {
     dsd_trunk_tuning_request_publish(switched_request_id, DSD_TRUNK_TUNE_RESULT_OK);
     const uint64_t recovery_generation = dsd_trunk_tuning_generation();
     rc |= expect_true("generic-rtl-recovery-target-switch-commits",
-                      recovery_generation == failed_generation + 2U && dsd_trunk_tuning_pending_request() == 0U
+                      recovery_generation == failed_generation + 3U && dsd_trunk_tuning_pending_request() == 0U
                           && dsd_trunk_tuning_frame_is_current(recovery_generation));
 
     noCarrier(opts, state);

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -1171,6 +1171,21 @@ main(void) {
     }
 #endif
 
+    // Leaving trunking retires terminal correlated failures so scanner/manual
+    // modes cannot inherit a process-wide frame-dispatch gate. In-flight
+    // requests remain gated until their backend publishes a terminal result.
+    const uint64_t inactive_generation = dsd_trunk_tuning_generation();
+    const uint64_t inactive_failed_request = dsd_trunk_tuning_request_begin();
+    dsd_trunk_tuning_request_publish(inactive_failed_request, DSD_TRUNK_TUNE_RESULT_FAILED);
+    rc |= expect_true("inactive-trunking-seeds-failed-gate",
+                      inactive_failed_request != 0U && dsd_trunk_tuning_pending_request() == inactive_failed_request
+                          && !dsd_trunk_tuning_frame_is_current(inactive_generation));
+    opts->scanner_mode = 1;
+    noCarrier(opts, state);
+    rc |= expect_true("inactive-trunking-retires-failed-gate",
+                      dsd_trunk_tuning_pending_request() == 0U && dsd_trunk_tuning_generation() == inactive_generation
+                          && dsd_trunk_tuning_frame_is_current(inactive_generation));
+
     // Trunk scan keeps long-lived discovery state across carrier gaps. The test
     // keeps DMR confidence and P25 control-channel candidates populated while
     // still requiring transient P25 frame metrics to be reset.

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -9,6 +9,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/engine/frame_processing.h>
+#include <dsd-neo/engine/trunk_tuning.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
@@ -1123,12 +1124,47 @@ main(void) {
                       recovery_generation == failed_generation + 3U && dsd_trunk_tuning_pending_request() == 0U
                           && dsd_trunk_tuning_frame_is_current(recovery_generation));
 
+    // A legacy VC tune after recovery completion supersedes the saved request.
+    // The next no-carrier pass must issue a new correlated CC return instead
+    // of clearing VC state while the hardware remains on the newer target.
+    dsd_trunk_tuning_hooks legacy_vc_hooks = {0};
+    legacy_vc_hooks.tune_to_freq_result = dsd_engine_trunk_tune_to_freq;
+    dsd_trunk_tuning_hooks_set(legacy_vc_hooks);
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    const long superseding_vc_freq = 937500000;
+    rc |= expect_true("generic-rtl-recovery-newer-legacy-vc-tune",
+                      dsd_trunk_tuning_hook_tune_to_freq(opts, state, superseding_vc_freq, 0)
+                          == DSD_TRUNK_TUNE_RESULT_OK);
+    const uint64_t superseding_vc_generation = dsd_trunk_tuning_generation();
+    rc |= expect_true("generic-rtl-recovery-newer-legacy-vc-owns-generation",
+                      g_rtl_tune_calls == 4 && g_rtl_tune_freq == (uint32_t)superseding_vc_freq
+                          && superseding_vc_generation == recovery_generation + 1U && opts->trunk_is_tuned == 1);
+
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time_m = dsd_time_now_monotonic_s() - 11.0;
+    g_rtl_tune_result = RTL_STREAM_TUNE_TIMEOUT;
     noCarrier(opts, state);
-    rc |= expect_true("generic-rtl-recovery-success-commits-without-retune",
-                      g_rtl_tune_calls == 3 && opts->trunk_is_tuned == 0 && state->trunk_vc_freq[0] == 0
+
+    const uint64_t superseding_recovery_request_id = g_rtl_tune_token;
+    rc |= expect_true(
+        "generic-rtl-recovery-superseded-success-retunes",
+        g_rtl_tune_calls == 5 && g_rtl_tune_freq == 937000000U && superseding_recovery_request_id > switched_request_id
+            && dsd_trunk_tuning_request_status(superseding_recovery_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_PENDING
+            && opts->trunk_is_tuned == 1);
+
+    dsd_trunk_tuning_request_publish(superseding_recovery_request_id, DSD_TRUNK_TUNE_RESULT_OK);
+    const uint64_t superseding_recovery_generation = dsd_trunk_tuning_generation();
+    rc |= expect_true("generic-rtl-recovery-superseded-recovery-commits",
+                      superseding_recovery_generation == superseding_vc_generation + 1U
+                          && dsd_trunk_tuning_pending_request() == 0U);
+
+    noCarrier(opts, state);
+    rc |= expect_true("generic-rtl-recovery-current-success-commits-without-retune",
+                      g_rtl_tune_calls == 5 && opts->trunk_is_tuned == 0 && state->trunk_vc_freq[0] == 0
                           && state->trunk_cc_freq == 937000000);
 
     g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {
         return 1;

--- a/tests/engine/test_engine_synced_trunk_scan_tick.c
+++ b/tests/engine/test_engine_synced_trunk_scan_tick.c
@@ -12,6 +12,7 @@
 #include <dsd-neo/runtime/exitflag.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -28,6 +29,7 @@ static int g_get_frame_sync_calls = 0;
 static int g_outer_tick_calls = 0;
 static int g_synced_tick_calls = 0;
 static int g_process_frame_guard_failures = 0;
+static uint64_t g_pending_tune_request = 0U;
 
 void
 printFrameInfo(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
@@ -60,11 +62,15 @@ __wrap_getFrameSync(dsd_opts* opts, dsd_state* state) {
     (void)state;
     g_get_frame_sync_calls++;
     if (g_get_frame_sync_calls == 1) {
-        // Simulate an accepted retune while work for the old tuner generation
-        // is still being assembled. That frame must not reach processFrame().
-        dsd_trunk_tuning_generation_advance();
+        // Frames assembled before and during an asynchronous retune must stay
+        // blocked even though their completed generation still compares equal.
+        g_pending_tune_request = dsd_trunk_tuning_request_begin();
+    } else if (g_get_frame_sync_calls == 3) {
+        // Completion while a frame is being assembled advances the generation;
+        // that frame is stale too. Only the next freshly collected frame is valid.
+        dsd_trunk_tuning_request_complete(g_pending_tune_request, DSD_TRUNK_TUNE_RESULT_OK);
     }
-    if (g_get_frame_sync_calls <= 3) {
+    if (g_get_frame_sync_calls <= 4) {
         return DSD_SYNC_P25P1_POS;
     }
     dsd_exitflag_store(1);
@@ -122,8 +128,9 @@ main(void) {
         DSD_FPRINTF(stderr, "engine run failed rc=%d\n", rc);
         test_rc = 1;
     }
-    if (g_process_frame_calls != 2) {
-        DSD_FPRINTF(stderr, "stale tune-generation frame was not discarded calls=%d\n", g_process_frame_calls);
+    if (g_process_frame_calls != 1) {
+        DSD_FPRINTF(stderr, "pending/stale tune-generation frames were not discarded calls=%d\n",
+                    g_process_frame_calls);
         test_rc = 1;
     }
     if (g_process_frame_guard_failures != 0) {

--- a/tests/engine/test_engine_synced_trunk_scan_tick.c
+++ b/tests/engine/test_engine_synced_trunk_scan_tick.c
@@ -30,6 +30,8 @@ static int g_outer_tick_calls = 0;
 static int g_synced_tick_calls = 0;
 static int g_process_frame_guard_failures = 0;
 static uint64_t g_pending_tune_request = 0U;
+static uint64_t g_failed_tune_request = 0U;
+static int g_failed_gate_seen = 0;
 
 void
 printFrameInfo(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
@@ -69,8 +71,23 @@ __wrap_getFrameSync(dsd_opts* opts, dsd_state* state) {
         // Completion while a frame is being assembled advances the generation;
         // that frame is stale too. Only the next freshly collected frame is valid.
         dsd_trunk_tuning_request_complete(g_pending_tune_request, DSD_TRUNK_TUNE_RESULT_OK);
+    } else if (g_get_frame_sync_calls == 5) {
+        // Start another correlated tune while trunking owns dispatch, then
+        // leave it pending across the next continuously synchronized frame.
+        opts->p25_trunk = 1;
+        opts->trunk_enable = 1;
+        g_failed_tune_request = dsd_trunk_tuning_request_begin();
+        dsd_trunk_tuning_request_mark_ready(g_failed_tune_request);
+    } else if (g_get_frame_sync_calls == 6) {
+        // A terminal failure must be retired on this actual mode-exit path.
+        // The synchronized loop will not call noCarrier() before dispatching
+        // this or the following conventional frame.
+        dsd_trunk_tuning_request_publish(g_failed_tune_request, DSD_TRUNK_TUNE_RESULT_FAILED);
+        g_failed_gate_seen = !dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation());
+        opts->p25_trunk = 0;
+        opts->trunk_enable = 0;
     }
-    if (g_get_frame_sync_calls <= 4) {
+    if (g_get_frame_sync_calls <= 7) {
         return DSD_SYNC_P25P1_POS;
     }
     dsd_exitflag_store(1);
@@ -128,9 +145,14 @@ main(void) {
         DSD_FPRINTF(stderr, "engine run failed rc=%d\n", rc);
         test_rc = 1;
     }
-    if (g_process_frame_calls != 1) {
+    if (g_process_frame_calls != 3) {
         DSD_FPRINTF(stderr, "pending/stale tune-generation frames were not discarded calls=%d\n",
                     g_process_frame_calls);
+        test_rc = 1;
+    }
+    if (!g_failed_gate_seen || g_failed_tune_request == 0U || dsd_trunk_tuning_pending_request() != 0U
+        || !dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation())) {
+        DSD_FPRINTF(stderr, "inactive synchronized mode did not retire the terminal failed tune gate\n");
         test_rc = 1;
     }
     if (g_process_frame_guard_failures != 0) {

--- a/tests/engine/test_engine_synced_trunk_scan_tick.c
+++ b/tests/engine/test_engine_synced_trunk_scan_tick.c
@@ -8,8 +8,10 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/engine/engine.h>
+#include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/runtime/exitflag.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -25,6 +27,7 @@ static int g_process_frame_calls = 0;
 static int g_get_frame_sync_calls = 0;
 static int g_outer_tick_calls = 0;
 static int g_synced_tick_calls = 0;
+static int g_process_frame_guard_failures = 0;
 
 void
 printFrameInfo(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
@@ -43,6 +46,10 @@ void
 processFrame(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
     (void)opts;
     (void)state;
+    if (p25_sm_tick_guard_try_enter()) {
+        g_process_frame_guard_failures++;
+        p25_sm_tick_guard_leave();
+    }
     g_process_frame_calls++;
 }
 
@@ -52,6 +59,11 @@ __wrap_getFrameSync(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
     g_get_frame_sync_calls++;
+    if (g_get_frame_sync_calls == 1) {
+        // Simulate an accepted retune while work for the old tuner generation
+        // is still being assembled. That frame must not reach processFrame().
+        dsd_trunk_tuning_generation_advance();
+    }
     if (g_get_frame_sync_calls <= 3) {
         return DSD_SYNC_P25P1_POS;
     }
@@ -110,8 +122,13 @@ main(void) {
         DSD_FPRINTF(stderr, "engine run failed rc=%d\n", rc);
         test_rc = 1;
     }
-    if (g_process_frame_calls == 0) {
-        DSD_FPRINTF(stderr, "stubbed synced frames were not processed\n");
+    if (g_process_frame_calls != 2) {
+        DSD_FPRINTF(stderr, "stale tune-generation frame was not discarded calls=%d\n", g_process_frame_calls);
+        test_rc = 1;
+    }
+    if (g_process_frame_guard_failures != 0) {
+        DSD_FPRINTF(stderr, "frame processing did not own the SM/scan guard failures=%d\n",
+                    g_process_frame_guard_failures);
         test_rc = 1;
     }
     if (g_outer_tick_calls == 0) {

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -73,6 +73,7 @@ static int g_trunk_scan_saved_autogain_on = 0;
 static int g_trunk_scan_active_p25_cqpsk_is_set = 0;
 static int g_trunk_scan_active_p25_cqpsk_enable = 0;
 static int g_runtime_config_is_set = 0;
+static int g_tune_generation_advance_calls = 0;
 static dsdneoRuntimeConfig g_runtime_config;
 
 void
@@ -98,6 +99,12 @@ int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 p25_sm_in_tick(void) {
     return 0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_trunk_tuning_generation_advance(void) {
+    g_tune_generation_advance_calls++;
 }
 
 void
@@ -479,6 +486,20 @@ main(void) {
     assert(dsd_engine_trunk_tune_to_freq(opts, state, 853600000, 16) == DSD_TRUNK_TUNE_RESULT_OK);
     assert(g_frame_sync_reset_calls == 1);
     assert(g_p25p2_frame_reset_calls == 1);
+
+    /* Direct conventional scan retunes publish a new generation only after
+     * the backend accepts the target. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    opts->use_rigctl = 1;
+    g_tune_generation_advance_calls = 0;
+    g_setfreq_result = true;
+    assert(dsd_engine_scan_tune_to_freq(opts, state, 853700000, 0) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_tune_generation_advance_calls == 1);
+    g_setfreq_result = false;
+    assert(dsd_engine_scan_tune_to_freq(opts, state, 853800000, 0) == DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(g_tune_generation_advance_calls == 1);
 
 #ifdef USE_RADIO
     /* RTL audio retuned by rigctl has no native RTL controller boundary, so the

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -74,6 +74,8 @@ static int g_trunk_scan_active_p25_cqpsk_is_set = 0;
 static int g_trunk_scan_active_p25_cqpsk_enable = 0;
 static int g_runtime_config_is_set = 0;
 static int g_tune_generation_advance_calls = 0;
+static uint64_t g_tune_request_next = 0U;
+static uint64_t g_tune_request_pending = 0U;
 static dsdneoRuntimeConfig g_runtime_config;
 
 void
@@ -105,6 +107,47 @@ void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_trunk_tuning_generation_advance(void) {
     g_tune_generation_advance_calls++;
+}
+
+uint64_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_trunk_tuning_request_begin(void) {
+    g_tune_request_pending = ++g_tune_request_next;
+    return g_tune_request_pending;
+}
+
+uint64_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_trunk_tuning_pending_request(void) {
+    return g_tune_request_pending;
+}
+
+dsd_trunk_tune_result
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_trunk_tuning_request_status(uint64_t request_id, double* out_completed_m) {
+    if (out_completed_m) {
+        *out_completed_m = 0.0;
+    }
+    return request_id != 0U && request_id == g_tune_request_pending ? DSD_TRUNK_TUNE_RESULT_PENDING
+                                                                    : DSD_TRUNK_TUNE_RESULT_FAILED;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_trunk_tuning_request_complete(uint64_t request_id, dsd_trunk_tune_result result) {
+    if (request_id == 0U || request_id != g_tune_request_pending || result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        return;
+    }
+    g_tune_request_pending = 0U;
+    if (result == DSD_TRUNK_TUNE_RESULT_OK) {
+        dsd_trunk_tuning_generation_advance();
+    }
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_trunk_tuning_request_mark_ready(uint64_t request_id) {
+    (void)request_id;
 }
 
 void
@@ -197,6 +240,12 @@ rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz) {
         apply_pending_retune_profile(center_freq_hz);
     }
     return g_rtl_tune_result;
+}
+
+int
+rtl_stream_tune_tagged(RtlSdrContext* ctx, uint32_t center_freq_hz, uint64_t token) {
+    (void)token;
+    return rtl_stream_tune(ctx, center_freq_hz);
 }
 
 void
@@ -488,7 +537,7 @@ main(void) {
     assert(g_p25p2_frame_reset_calls == 1);
 
     /* Direct conventional scan retunes publish a new generation only after
-     * the backend accepts the target. */
+     * the backend completes the target. */
     DSD_MEMSET(opts, 0, sizeof(*opts));
     DSD_MEMSET(state, 0, sizeof(*state));
     opts->audio_in_type = AUDIO_IN_PULSE;
@@ -502,6 +551,17 @@ main(void) {
     assert(g_tune_generation_advance_calls == 1);
 
 #ifdef USE_RADIO
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    g_rtl_tune_result = RTL_STREAM_TUNE_TIMEOUT;
+    assert(dsd_engine_scan_tune_to_freq(opts, state, 853900000, 0) == DSD_TRUNK_TUNE_RESULT_PENDING);
+    assert(g_tune_generation_advance_calls == 1);
+    assert(g_tune_request_pending != 0U);
+    dsd_trunk_tuning_request_complete(g_tune_request_pending, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_tune_generation_advance_calls == 2);
+
     /* RTL audio retuned by rigctl has no native RTL controller boundary, so the
      * queued P25 VC demod profile must be applied after SetFreq succeeds. */
     DSD_MEMSET(opts, 0, sizeof(*opts));

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -1904,12 +1904,26 @@ test_p25_pending_retune_holds_scan_dwell(void) {
 
     if (ctx && ctx->cc_tune_request_id != 0U) {
         dsd_trunk_tuning_request_complete(ctx->cc_tune_request_id, DSD_TRUNK_TUNE_RESULT_OK);
+        /* This fixture stubs the P25 SM, so model the live-loop ordering where
+         * its tick observes completion before the scan coordinator runs. */
         (void)p25_sm_restart_pending_cc_acquisition(ctx, &opts, &state, 2.0, "test-complete");
     }
+    if (ctx && ctx->cc_tune_pending) {
+        DSD_FPRINTF(stderr, "P25 tick did not resolve completed scan retune\n");
+        test_rc = 1;
+    }
     g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
-    dsd_engine_trunk_scan_test_set_now(2.10);
+    dsd_engine_trunk_scan_test_set_now(10.0);
     dsd_engine_trunk_scan_tick(&opts, &state);
-    dsd_engine_trunk_scan_test_set_now(2.36);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || g_counting_tune_to_cc_calls != 1) {
+        DSD_FPRINTF(stderr, "P25 pending completion consumed scan dwell active=%zu calls=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), g_counting_tune_to_cc_calls);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(10.20);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    dsd_engine_trunk_scan_test_set_now(10.26);
     dsd_engine_trunk_scan_tick(&opts, &state);
     if (dsd_engine_trunk_scan_active_index(&state) != 1 || g_counting_tune_to_cc_calls != 2) {
         DSD_FPRINTF(stderr, "scan dwell did not restart after pending completion active=%zu calls=%d\n",

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -79,6 +79,25 @@ p25_sm_init_ctx(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
 }
 
 int
+p25_sm_restart_pending_cc_acquisition(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double tune_start_m,
+                                      const char* source) {
+    (void)opts;
+    (void)source;
+    if (!ctx || !ctx->cc_sync_pending) {
+        return 0;
+    }
+    ctx->state = P25_SM_ON_CC;
+    ctx->t_cc_sync_m = tune_start_m;
+    ctx->t_cc_tune_m = tune_start_m;
+    ctx->t_hunt_try_m = 0.0;
+    if (state) {
+        state->last_cc_sync_time_m = tune_start_m;
+        state->p25_sm_mode = DSD_P25_SM_MODE_ON_CC;
+    }
+    return 1;
+}
+
+int
 p25_sm_tick_guard_try_enter(void) {
     g_p25_tick_guard_enter_calls++;
     if (!g_p25_tick_guard_available) {
@@ -1329,6 +1348,71 @@ test_p25_target_switch_resyncs_sm_mode(void) {
     if (dsd_engine_trunk_scan_active_index(&state) != 0 || state.p25_sm_mode != DSD_P25_SM_MODE_HUNTING) {
         DSD_FPRINTF(stderr, "restored P25 scan target SM mode invalid active=%zu mode=%d\n",
                     dsd_engine_trunk_scan_active_index(&state), state.p25_sm_mode);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_engine_trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_p25_scan_retune_restarts_pending_cc_acquisition(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,p25-trunk,851000000,,250,,\n"
+                             "b,p25-trunk,852000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    dsd_engine_trunk_scan_test_set_now(1.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    p25_sm_ctx_t* first_ctx = (p25_sm_ctx_t*)dsd_engine_trunk_scan_active_p25_ctx();
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0 || !first_ctx) {
+        DSD_FPRINTF(stderr, "pending CC timer scan init failed rc=%d active=%zu ctx=%p err=%s\n", rc,
+                    dsd_engine_trunk_scan_active_index(&state), (void*)first_ctx, err);
+        test_rc = 1;
+    } else {
+        first_ctx->state = P25_SM_HUNTING;
+        first_ctx->cc_sync_pending = 1;
+        first_ctx->t_cc_sync_m = 1.0;
+        first_ctx->t_cc_tune_m = 1.0;
+        first_ctx->t_hunt_try_m = 0.5;
+        state.p25_sm_mode = DSD_P25_SM_MODE_HUNTING;
+        state.p25_last_cc_msg_time_m = 0.75;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(1.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1) {
+        DSD_FPRINTF(stderr, "pending CC timer scan did not rotate away from first target\n");
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(4.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    p25_sm_ctx_t* restored_ctx = (p25_sm_ctx_t*)dsd_engine_trunk_scan_active_p25_ctx();
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || !restored_ctx || restored_ctx->cc_sync_pending != 1
+        || restored_ctx->state != P25_SM_ON_CC || restored_ctx->t_cc_sync_m != 4.0 || restored_ctx->t_cc_tune_m != 4.0
+        || restored_ctx->t_hunt_try_m != 0.0 || state.p25_sm_mode != DSD_P25_SM_MODE_ON_CC
+        || state.p25_last_cc_msg_time_m != 0.75) {
+        DSD_FPRINTF(stderr,
+                    "pending CC timer did not restart after retune active=%zu ctx=%p state=%d pending=%d sync=%.3f "
+                    "tune=%.3f hunt=%.3f mode=%d decoded=%.3f\n",
+                    dsd_engine_trunk_scan_active_index(&state), (void*)restored_ctx,
+                    restored_ctx ? (int)restored_ctx->state : -1, restored_ctx ? restored_ctx->cc_sync_pending : -1,
+                    restored_ctx ? restored_ctx->t_cc_sync_m : -1.0, restored_ctx ? restored_ctx->t_cc_tune_m : -1.0,
+                    restored_ctx ? restored_ctx->t_hunt_try_m : -1.0, state.p25_sm_mode, state.p25_last_cc_msg_time_m);
         test_rc = 1;
     }
 
@@ -2816,6 +2900,7 @@ main(void) {
     rc |= test_p25_targets_seed_valid_control_channel_timing();
     rc |= test_p25_nac_state_isolated_per_target();
     rc |= test_p25_target_switch_resyncs_sm_mode();
+    rc |= test_p25_scan_retune_restarts_pending_cc_acquisition();
     rc |= test_mixed_target_switch_resets_dmr_demod_profile();
     rc |= test_conventional_activity_hold_and_allowlist_block();
     rc |= test_conventional_activity_encrypted_lockout_does_not_hold();

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -21,6 +21,7 @@
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <limits.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -1440,12 +1441,14 @@ test_p25_scan_retune_restarts_pending_cc_acquisition(void) {
     dsd_engine_trunk_scan_test_set_now(4.0);
     dsd_engine_trunk_scan_tick(&opts, &state);
     p25_sm_ctx_t* restored_ctx = (p25_sm_ctx_t*)dsd_engine_trunk_scan_active_p25_ctx();
+    const double timestamp_epsilon_s = 1.0e-9;
     if (dsd_engine_trunk_scan_active_index(&state) != 0 || !restored_ctx || restored_ctx->cc_sync_pending != 1
         || restored_ctx->state != P25_SM_ON_CC || restored_ctx->t_cc_sync_m <= 1.0
-        || restored_ctx->t_cc_tune_m != restored_ctx->t_cc_sync_m || restored_ctx->t_hunt_try_m != 0.0
-        || state.p25_sm_mode != DSD_P25_SM_MODE_ON_CC || state.p25_cc_freq != 853000000
-        || state.trunk_cc_freq != 853000000 || state.p25_cc_eval_freq != 853000000
-        || state.p25_cc_eval_start_m != restored_ctx->t_cc_tune_m || state.p25_last_cc_msg_time_m != 0.75) {
+        || !(fabs(restored_ctx->t_cc_tune_m - restored_ctx->t_cc_sync_m) <= timestamp_epsilon_s)
+        || restored_ctx->t_hunt_try_m != 0.0 || state.p25_sm_mode != DSD_P25_SM_MODE_ON_CC
+        || state.p25_cc_freq != 853000000 || state.trunk_cc_freq != 853000000 || state.p25_cc_eval_freq != 853000000
+        || !(fabs(state.p25_cc_eval_start_m - restored_ctx->t_cc_tune_m) <= timestamp_epsilon_s)
+        || state.p25_last_cc_msg_time_m != 0.75) {
         DSD_FPRINTF(stderr,
                     "pending CC timer did not restart after retune active=%zu ctx=%p state=%d pending=%d sync=%.3f "
                     "tune=%.3f hunt=%.3f mode=%d cc=%ld trunk_cc=%ld eval_freq=%ld eval_start=%.3f decoded=%.3f\n",

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -1851,6 +1851,12 @@ counting_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps
     return g_counting_tune_to_cc_result;
 }
 
+static dsd_trunk_tune_result
+counting_tune_to_cc_request(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps, uint64_t request_id) {
+    (void)request_id;
+    return counting_tune_to_cc(opts, state, freq, ted_sps);
+}
+
 static int
 test_p25_pending_retune_holds_scan_dwell(void) {
     char dir[DSD_TEST_PATH_MAX];
@@ -1868,7 +1874,7 @@ test_p25_pending_retune_holds_scan_dwell(void) {
     DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
 
     dsd_trunk_tuning_hooks hooks = {0};
-    hooks.tune_to_cc_result = counting_tune_to_cc;
+    hooks.tune_to_cc_request = counting_tune_to_cc_request;
     dsd_trunk_tuning_hooks_set(hooks);
     g_counting_tune_to_cc_calls = 0;
     g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
@@ -1933,7 +1939,7 @@ test_generic_pending_retune_holds_and_recovers(void) {
     DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
 
     dsd_trunk_tuning_hooks hooks = {0};
-    hooks.tune_to_cc_result = counting_tune_to_cc;
+    hooks.tune_to_cc_request = counting_tune_to_cc_request;
     dsd_trunk_tuning_hooks_set(hooks);
     g_counting_tune_to_cc_calls = 0;
     g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
@@ -1967,6 +1973,54 @@ test_generic_pending_retune_holds_and_recovers(void) {
         DSD_FPRINTF(stderr, "generic async failure did not recover active=%zu calls=%d pending=%llu\n",
                     dsd_engine_trunk_scan_active_index(&state), g_counting_tune_to_cc_calls,
                     (unsigned long long)dsd_trunk_tuning_pending_request());
+        test_rc = 1;
+    }
+
+    DSD_MEMSET(&hooks, 0, sizeof hooks);
+    dsd_trunk_tuning_hooks_set(hooks);
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_engine_trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_legacy_pending_retune_does_not_hold_scan(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,dmr-trunk,451000000,,250,,\n"
+                             "b,dmr-trunk,452000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_cc_result = counting_tune_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+    g_counting_tune_to_cc_calls = 0;
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+
+    char err[256] = {0};
+    dsd_engine_trunk_scan_test_set_now(1.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_trunk_tuning_pending_request() != 0U || g_counting_tune_to_cc_calls != 1) {
+        DSD_FPRINTF(stderr, "legacy pending scan init failed rc=%d pending=%llu calls=%d err=%s\n", rc,
+                    (unsigned long long)dsd_trunk_tuning_pending_request(), g_counting_tune_to_cc_calls, err);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(2.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1 || g_counting_tune_to_cc_calls != 2) {
+        DSD_FPRINTF(stderr, "legacy pending retune held scan active=%zu calls=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), g_counting_tune_to_cc_calls);
         test_rc = 1;
     }
 
@@ -3079,6 +3133,7 @@ main(void) {
     rc |= test_dmr_trunk_sm_timeout_releases_scan_hold();
     rc |= test_p25_pending_retune_holds_scan_dwell();
     rc |= test_generic_pending_retune_holds_and_recovers();
+    rc |= test_legacy_pending_retune_does_not_hold_scan();
     rc |= test_p25_targets_pass_cc_sps_to_retune_paths();
     rc |= test_p25_targets_use_rtl_output_rate_for_retune_sps();
     rc |= test_channel_map_sequence_advances_on_equal_count_target_switches();

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -1940,6 +1940,168 @@ test_p25_pending_retune_holds_scan_dwell(void) {
 }
 
 static int
+test_p25_pending_retune_adopts_sm_retry(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,p25-trunk,851000000,,250,,\n"
+                             "b,p25-trunk,852000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+    dsd_trunk_tuning_requests_reset();
+
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_cc_request = counting_tune_to_cc_request;
+    dsd_trunk_tuning_hooks_set(hooks);
+    g_counting_tune_to_cc_calls = 0;
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+
+    char err[256] = {0};
+    dsd_engine_trunk_scan_test_set_now(1.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    p25_sm_ctx_t* ctx = (p25_sm_ctx_t*)dsd_engine_trunk_scan_active_p25_ctx();
+    const uint64_t failed_request_id = ctx ? ctx->cc_tune_request_id : 0U;
+    if (rc != 0 || !ctx || !ctx->cc_tune_pending || failed_request_id == 0U || g_counting_tune_to_cc_calls != 1) {
+        DSD_FPRINTF(stderr, "P25 recovery adoption init failed rc=%d ctx=%p request=%llu calls=%d err=%s\n", rc,
+                    (void*)ctx, (unsigned long long)failed_request_id, g_counting_tune_to_cc_calls, err);
+        test_rc = 1;
+    }
+    if (!ctx) {
+        DSD_MEMSET(&hooks, 0, sizeof hooks);
+        dsd_trunk_tuning_hooks_set(hooks);
+        dsd_engine_trunk_scan_shutdown(&opts, &state);
+        dsd_engine_trunk_scan_test_clear_now();
+        dsd_trunk_tuning_requests_reset();
+        cleanup_paths(dir, target_path, NULL);
+        return 1;
+    }
+
+    dsd_trunk_tuning_request_publish(failed_request_id, DSD_TRUNK_TUNE_RESULT_FAILED);
+    const uint64_t retry_request_id = dsd_trunk_tuning_request_begin();
+    if (retry_request_id == 0U) {
+        DSD_FPRINTF(stderr, "P25 recovery adoption could not allocate retry request\n");
+        test_rc = 1;
+    } else {
+        dsd_trunk_tuning_request_mark_ready(retry_request_id);
+        ctx->cc_tune_request_id = retry_request_id;
+        ctx->cc_tune_pending = 1;
+        ctx->cc_sync_pending = 1;
+        ctx->state = P25_SM_ON_CC;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(2.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || g_counting_tune_to_cc_calls != 1 || !ctx->cc_tune_pending
+        || ctx->cc_tune_request_id != retry_request_id) {
+        DSD_FPRINTF(stderr, "scan did not adopt P25 retry active=%zu calls=%d pending=%d request=%llu/%llu\n",
+                    dsd_engine_trunk_scan_active_index(&state), g_counting_tune_to_cc_calls, ctx->cc_tune_pending,
+                    (unsigned long long)ctx->cc_tune_request_id, (unsigned long long)retry_request_id);
+        test_rc = 1;
+    }
+
+    dsd_trunk_tuning_request_publish(retry_request_id, DSD_TRUNK_TUNE_RESULT_OK);
+    (void)p25_sm_restart_pending_cc_acquisition(ctx, &opts, &state, 2.1, "test-sm-recovery");
+    dsd_engine_trunk_scan_test_set_now(2.1);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || g_counting_tune_to_cc_calls != 1 || ctx->cc_tune_pending) {
+        DSD_FPRINTF(stderr, "adopted P25 retry completion advanced scan active=%zu calls=%d pending=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), g_counting_tune_to_cc_calls, ctx->cc_tune_pending);
+        test_rc = 1;
+    }
+
+    DSD_MEMSET(&hooks, 0, sizeof hooks);
+    dsd_trunk_tuning_hooks_set(hooks);
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_engine_trunk_scan_test_clear_now();
+    dsd_trunk_tuning_requests_reset();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_p25_pending_retune_preserves_completed_sm_recovery(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,p25-trunk,851000000,,250,,\n"
+                             "b,p25-trunk,852000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+    dsd_trunk_tuning_requests_reset();
+
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_cc_request = counting_tune_to_cc_request;
+    dsd_trunk_tuning_hooks_set(hooks);
+    g_counting_tune_to_cc_calls = 0;
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+
+    char err[256] = {0};
+    dsd_engine_trunk_scan_test_set_now(1.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    p25_sm_ctx_t* ctx = (p25_sm_ctx_t*)dsd_engine_trunk_scan_active_p25_ctx();
+    const uint64_t failed_request_id = ctx ? ctx->cc_tune_request_id : 0U;
+    if (rc != 0 || !ctx || failed_request_id == 0U || g_counting_tune_to_cc_calls != 1) {
+        DSD_FPRINTF(stderr, "P25 completed recovery init failed rc=%d ctx=%p request=%llu calls=%d err=%s\n", rc,
+                    (void*)ctx, (unsigned long long)failed_request_id, g_counting_tune_to_cc_calls, err);
+        test_rc = 1;
+    }
+    if (!ctx) {
+        DSD_MEMSET(&hooks, 0, sizeof hooks);
+        dsd_trunk_tuning_hooks_set(hooks);
+        dsd_engine_trunk_scan_shutdown(&opts, &state);
+        dsd_engine_trunk_scan_test_clear_now();
+        dsd_trunk_tuning_requests_reset();
+        cleanup_paths(dir, target_path, NULL);
+        return 1;
+    }
+
+    dsd_trunk_tuning_request_publish(failed_request_id, DSD_TRUNK_TUNE_RESULT_FAILED);
+    const uint64_t retry_request_id = dsd_trunk_tuning_request_begin();
+    double retry_completed_m = 0.0;
+    if (retry_request_id == 0U) {
+        DSD_FPRINTF(stderr, "P25 completed recovery could not allocate retry request\n");
+        test_rc = 1;
+    } else {
+        dsd_trunk_tuning_request_mark_ready(retry_request_id);
+        dsd_trunk_tuning_request_publish(retry_request_id, DSD_TRUNK_TUNE_RESULT_OK);
+        (void)dsd_trunk_tuning_request_status(retry_request_id, &retry_completed_m);
+        (void)p25_sm_restart_pending_cc_acquisition(ctx, &opts, &state, retry_completed_m, "test-sm-recovery");
+    }
+
+    dsd_engine_trunk_scan_test_set_now(2.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || g_counting_tune_to_cc_calls != 1
+        || ctx->state != P25_SM_ON_CC || ctx->cc_tune_pending) {
+        DSD_FPRINTF(stderr, "completed P25 recovery was abandoned active=%zu calls=%d state=%d pending=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), g_counting_tune_to_cc_calls, (int)ctx->state,
+                    ctx->cc_tune_pending);
+        test_rc = 1;
+    }
+
+    DSD_MEMSET(&hooks, 0, sizeof hooks);
+    dsd_trunk_tuning_hooks_set(hooks);
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_engine_trunk_scan_test_clear_now();
+    dsd_trunk_tuning_requests_reset();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
 test_generic_pending_retune_holds_and_recovers(void) {
     char dir[DSD_TEST_PATH_MAX];
     char target_path[DSD_TEST_PATH_MAX];
@@ -3149,6 +3311,8 @@ main(void) {
     rc |= test_protocol_hooks_only_expose_matching_target_contexts();
     rc |= test_dmr_trunk_sm_timeout_releases_scan_hold();
     rc |= test_p25_pending_retune_holds_scan_dwell();
+    rc |= test_p25_pending_retune_adopts_sm_retry();
+    rc |= test_p25_pending_retune_preserves_completed_sm_recovery();
     rc |= test_generic_pending_retune_holds_and_recovers();
     rc |= test_legacy_pending_retune_does_not_hold_scan();
     rc |= test_p25_targets_pass_cc_sps_to_retune_paths();

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -91,6 +91,9 @@ p25_sm_restart_pending_cc_acquisition(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_sta
     ctx->t_cc_tune_m = tune_start_m;
     ctx->t_hunt_try_m = 0.0;
     if (state) {
+        if (state->p25_cc_eval_freq != 0) {
+            state->p25_cc_eval_start_m = ctx->t_cc_tune_m;
+        }
         state->last_cc_sync_time_m = tune_start_m;
         state->p25_sm_mode = DSD_P25_SM_MODE_ON_CC;
     }
@@ -1389,6 +1392,10 @@ test_p25_scan_retune_restarts_pending_cc_acquisition(void) {
         first_ctx->t_cc_tune_m = 1.0;
         first_ctx->t_hunt_try_m = 0.5;
         state.p25_sm_mode = DSD_P25_SM_MODE_HUNTING;
+        state.p25_cc_freq = 853000000;
+        state.trunk_cc_freq = 853000000;
+        state.p25_cc_eval_freq = 853000000;
+        state.p25_cc_eval_start_m = 1.0;
         state.p25_last_cc_msg_time_m = 0.75;
     }
 
@@ -1405,14 +1412,17 @@ test_p25_scan_retune_restarts_pending_cc_acquisition(void) {
     if (dsd_engine_trunk_scan_active_index(&state) != 0 || !restored_ctx || restored_ctx->cc_sync_pending != 1
         || restored_ctx->state != P25_SM_ON_CC || restored_ctx->t_cc_sync_m != 4.0 || restored_ctx->t_cc_tune_m != 4.0
         || restored_ctx->t_hunt_try_m != 0.0 || state.p25_sm_mode != DSD_P25_SM_MODE_ON_CC
-        || state.p25_last_cc_msg_time_m != 0.75) {
+        || state.p25_cc_freq != 853000000 || state.trunk_cc_freq != 853000000 || state.p25_cc_eval_freq != 853000000
+        || state.p25_cc_eval_start_m != 4.0 || state.p25_last_cc_msg_time_m != 0.75) {
         DSD_FPRINTF(stderr,
                     "pending CC timer did not restart after retune active=%zu ctx=%p state=%d pending=%d sync=%.3f "
-                    "tune=%.3f hunt=%.3f mode=%d decoded=%.3f\n",
+                    "tune=%.3f hunt=%.3f mode=%d cc=%ld trunk_cc=%ld eval_freq=%ld eval_start=%.3f decoded=%.3f\n",
                     dsd_engine_trunk_scan_active_index(&state), (void*)restored_ctx,
                     restored_ctx ? (int)restored_ctx->state : -1, restored_ctx ? restored_ctx->cc_sync_pending : -1,
                     restored_ctx ? restored_ctx->t_cc_sync_m : -1.0, restored_ctx ? restored_ctx->t_cc_tune_m : -1.0,
-                    restored_ctx ? restored_ctx->t_hunt_try_m : -1.0, state.p25_sm_mode, state.p25_last_cc_msg_time_m);
+                    restored_ctx ? restored_ctx->t_hunt_try_m : -1.0, state.p25_sm_mode, state.p25_cc_freq,
+                    state.trunk_cc_freq, state.p25_cc_eval_freq, state.p25_cc_eval_start_m,
+                    state.p25_last_cc_msg_time_m);
         test_rc = 1;
     }
 

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -83,10 +83,12 @@ p25_sm_restart_pending_cc_acquisition(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_sta
                                       const char* source) {
     (void)opts;
     (void)source;
-    if (!ctx || !ctx->cc_sync_pending) {
+    if (!ctx) {
         return 0;
     }
     ctx->state = P25_SM_ON_CC;
+    ctx->cc_tune_request_id = 0U;
+    ctx->cc_tune_pending = 0;
     ctx->t_cc_sync_m = tune_start_m;
     ctx->t_cc_tune_m = tune_start_m;
     ctx->t_hunt_try_m = 0.0;
@@ -95,6 +97,26 @@ p25_sm_restart_pending_cc_acquisition(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_sta
             state->p25_cc_eval_start_m = ctx->t_cc_tune_m;
         }
         state->last_cc_sync_time_m = tune_start_m;
+        state->p25_sm_mode = DSD_P25_SM_MODE_ON_CC;
+    }
+    return 1;
+}
+
+int
+p25_sm_await_pending_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, uint64_t request_id,
+                             const char* source) {
+    (void)opts;
+    (void)source;
+    if (!ctx || request_id == 0U) {
+        return 0;
+    }
+    ctx->state = P25_SM_ON_CC;
+    ctx->cc_tune_request_id = request_id;
+    ctx->cc_tune_pending = 1;
+    ctx->cc_sync_pending = 1;
+    ctx->t_cc_tune_m = 0.0;
+    if (state) {
+        state->p25_cc_eval_start_m = 0.0;
         state->p25_sm_mode = DSD_P25_SM_MODE_ON_CC;
     }
     return 1;
@@ -157,6 +179,15 @@ dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, in
     opts->trunk_is_tuned = 0;
     state->last_cc_sync_time_m = dsd_engine_trunk_scan_active_index(state) == (size_t)-1 ? 0.0 : 1.0;
     return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+dsd_trunk_tune_result
+dsd_engine_scan_tune_to_freq_with_id(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
+                                     uint64_t* out_request_id) {
+    if (out_request_id) {
+        *out_request_id = 0U;
+    }
+    return dsd_engine_scan_tune_to_freq(opts, state, freq, ted_sps);
 }
 
 int
@@ -1348,8 +1379,8 @@ test_p25_target_switch_resyncs_sm_mode(void) {
 
     dsd_engine_trunk_scan_test_set_now(0.52);
     dsd_engine_trunk_scan_tick(&opts, &state);
-    if (dsd_engine_trunk_scan_active_index(&state) != 0 || state.p25_sm_mode != DSD_P25_SM_MODE_HUNTING) {
-        DSD_FPRINTF(stderr, "restored P25 scan target SM mode invalid active=%zu mode=%d\n",
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || state.p25_sm_mode != DSD_P25_SM_MODE_ON_CC) {
+        DSD_FPRINTF(stderr, "retuned P25 scan target SM mode invalid active=%zu mode=%d\n",
                     dsd_engine_trunk_scan_active_index(&state), state.p25_sm_mode);
         test_rc = 1;
     }
@@ -1410,10 +1441,11 @@ test_p25_scan_retune_restarts_pending_cc_acquisition(void) {
     dsd_engine_trunk_scan_tick(&opts, &state);
     p25_sm_ctx_t* restored_ctx = (p25_sm_ctx_t*)dsd_engine_trunk_scan_active_p25_ctx();
     if (dsd_engine_trunk_scan_active_index(&state) != 0 || !restored_ctx || restored_ctx->cc_sync_pending != 1
-        || restored_ctx->state != P25_SM_ON_CC || restored_ctx->t_cc_sync_m != 4.0 || restored_ctx->t_cc_tune_m != 4.0
-        || restored_ctx->t_hunt_try_m != 0.0 || state.p25_sm_mode != DSD_P25_SM_MODE_ON_CC
-        || state.p25_cc_freq != 853000000 || state.trunk_cc_freq != 853000000 || state.p25_cc_eval_freq != 853000000
-        || state.p25_cc_eval_start_m != 4.0 || state.p25_last_cc_msg_time_m != 0.75) {
+        || restored_ctx->state != P25_SM_ON_CC || restored_ctx->t_cc_sync_m <= 1.0
+        || restored_ctx->t_cc_tune_m != restored_ctx->t_cc_sync_m || restored_ctx->t_hunt_try_m != 0.0
+        || state.p25_sm_mode != DSD_P25_SM_MODE_ON_CC || state.p25_cc_freq != 853000000
+        || state.trunk_cc_freq != 853000000 || state.p25_cc_eval_freq != 853000000
+        || state.p25_cc_eval_start_m != restored_ctx->t_cc_tune_m || state.p25_last_cc_msg_time_m != 0.75) {
         DSD_FPRINTF(stderr,
                     "pending CC timer did not restart after retune active=%zu ctx=%p state=%d pending=%d sync=%.3f "
                     "tune=%.3f hunt=%.3f mode=%d cc=%ld trunk_cc=%ld eval_freq=%ld eval_start=%.3f decoded=%.3f\n",
@@ -1801,6 +1833,7 @@ static int g_counting_tune_to_cc_calls = 0;
 static int g_counting_tune_to_cc_failures_remaining = 0;
 static int g_counting_tune_to_cc_ted_sps = 0;
 static long int g_counting_tune_to_cc_freq = 0;
+static dsd_trunk_tune_result g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
 static dsd_trunk_tune_result
 counting_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
@@ -1815,7 +1848,134 @@ counting_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps
     if (state) {
         state->trunk_cc_freq = freq;
     }
-    return DSD_TRUNK_TUNE_RESULT_OK;
+    return g_counting_tune_to_cc_result;
+}
+
+static int
+test_p25_pending_retune_holds_scan_dwell(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,p25-trunk,851000000,,250,,\n"
+                             "b,p25-trunk,852000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_cc_result = counting_tune_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+    g_counting_tune_to_cc_calls = 0;
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+
+    char err[256] = {0};
+    dsd_engine_trunk_scan_test_set_now(1.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    p25_sm_ctx_t* ctx = (p25_sm_ctx_t*)dsd_engine_trunk_scan_active_p25_ctx();
+    if (rc != 0 || !ctx || !ctx->cc_tune_pending || ctx->cc_tune_request_id == 0U || g_counting_tune_to_cc_calls != 1) {
+        DSD_FPRINTF(stderr, "pending scan init failed rc=%d ctx=%p pending=%d request=%llu calls=%d err=%s\n", rc,
+                    (void*)ctx, ctx ? ctx->cc_tune_pending : -1,
+                    (unsigned long long)(ctx ? ctx->cc_tune_request_id : 0U), g_counting_tune_to_cc_calls, err);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(2.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || g_counting_tune_to_cc_calls != 1) {
+        DSD_FPRINTF(stderr, "pending P25 retune did not hold scan dwell active=%zu calls=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), g_counting_tune_to_cc_calls);
+        test_rc = 1;
+    }
+
+    if (ctx && ctx->cc_tune_request_id != 0U) {
+        dsd_trunk_tuning_request_complete(ctx->cc_tune_request_id, DSD_TRUNK_TUNE_RESULT_OK);
+        (void)p25_sm_restart_pending_cc_acquisition(ctx, &opts, &state, 2.0, "test-complete");
+    }
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    dsd_engine_trunk_scan_test_set_now(2.10);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    dsd_engine_trunk_scan_test_set_now(2.36);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1 || g_counting_tune_to_cc_calls != 2) {
+        DSD_FPRINTF(stderr, "scan dwell did not restart after pending completion active=%zu calls=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), g_counting_tune_to_cc_calls);
+        test_rc = 1;
+    }
+
+    DSD_MEMSET(&hooks, 0, sizeof hooks);
+    dsd_trunk_tuning_hooks_set(hooks);
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_engine_trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_generic_pending_retune_holds_and_recovers(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,dmr-trunk,451000000,,250,,\n"
+                             "b,dmr-trunk,452000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_cc_result = counting_tune_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+    g_counting_tune_to_cc_calls = 0;
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+
+    char err[256] = {0};
+    dsd_engine_trunk_scan_test_set_now(1.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    uint64_t request_id = dsd_trunk_tuning_pending_request();
+    if (rc != 0 || request_id == 0U || g_counting_tune_to_cc_calls != 1) {
+        DSD_FPRINTF(stderr, "generic pending scan init failed rc=%d request=%llu calls=%d err=%s\n", rc,
+                    (unsigned long long)request_id, g_counting_tune_to_cc_calls, err);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_test_set_now(2.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || g_counting_tune_to_cc_calls != 1) {
+        DSD_FPRINTF(stderr, "generic pending retune did not hold scan active=%zu calls=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), g_counting_tune_to_cc_calls);
+        test_rc = 1;
+    }
+
+    dsd_trunk_tuning_request_publish(request_id, DSD_TRUNK_TUNE_RESULT_FAILED);
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    dsd_engine_trunk_scan_test_set_now(2.10);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1 || g_counting_tune_to_cc_calls != 2
+        || dsd_trunk_tuning_pending_request() != 0U
+        || !dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation())) {
+        DSD_FPRINTF(stderr, "generic async failure did not recover active=%zu calls=%d pending=%llu\n",
+                    dsd_engine_trunk_scan_active_index(&state), g_counting_tune_to_cc_calls,
+                    (unsigned long long)dsd_trunk_tuning_pending_request());
+        test_rc = 1;
+    }
+
+    DSD_MEMSET(&hooks, 0, sizeof hooks);
+    dsd_trunk_tuning_hooks_set(hooks);
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_engine_trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
 }
 
 static int
@@ -2917,6 +3077,8 @@ main(void) {
     rc |= test_state_ext_cleanup_clears_scan_hooks();
     rc |= test_protocol_hooks_only_expose_matching_target_contexts();
     rc |= test_dmr_trunk_sm_timeout_releases_scan_hold();
+    rc |= test_p25_pending_retune_holds_scan_dwell();
+    rc |= test_generic_pending_retune_holds_and_recovers();
     rc |= test_p25_targets_pass_cc_sps_to_retune_paths();
     rc |= test_p25_targets_use_rtl_output_rate_for_retune_sps();
     rc |= test_channel_map_sequence_advances_on_equal_count_target_switches();

--- a/tests/io/test_io_rigctl_control.c
+++ b/tests/io/test_io_rigctl_control.c
@@ -13,6 +13,8 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/io/control.h>
 #include <dsd-neo/io/rigctl_client.h>
+#include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/io/rtl_stream_fwd.h>
 #include <dsd-neo/platform/sockets.h>
 #include <dsd-neo/platform/timing.h>
 #include <dsd-neo/runtime/config.h>
@@ -55,6 +57,9 @@ static int g_sendto_count;
 static unsigned char g_last_sendto_payload[8];
 static size_t g_last_sendto_len;
 static int g_last_sendto_port;
+static int g_rtl_tune_calls;
+static uint32_t g_rtl_tune_freq;
+static int g_rtl_tune_result;
 static dsdneoRuntimeConfig g_config;
 
 bool dsd_rigctl_test_get_signal_level(dsd_socket_t sockfd, double* dB);
@@ -85,8 +90,19 @@ reset_stubs(void) {
     DSD_MEMSET(g_last_sendto_payload, 0, sizeof(g_last_sendto_payload));
     g_last_sendto_len = 0;
     g_last_sendto_port = 0;
+    g_rtl_tune_calls = 0;
+    g_rtl_tune_freq = 0U;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
     DSD_MEMSET(&g_config, 0, sizeof(g_config));
     g_config.rigctl_rcvtimeo_ms = 1500;
+}
+
+int
+rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz) {
+    (void)ctx;
+    g_rtl_tune_calls++;
+    g_rtl_tune_freq = center_freq_hz;
+    return g_rtl_tune_result;
 }
 
 static void
@@ -345,6 +361,30 @@ test_io_control_set_freq_validation_and_rigctl_dispatch(void) {
 }
 
 static int
+test_io_control_set_freq_propagates_rtl_deferred(void) {
+    reset_stubs();
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtlsdr_center_freq = 851000000U;
+    state.rtl_ctx = (RtlSdrContext*)&state;
+    g_rtl_tune_result = RTL_STREAM_TUNE_DEFERRED;
+
+    assert(io_control_set_freq(&opts, &state, 851075000L) == RTL_STREAM_TUNE_DEFERRED);
+    assert(g_rtl_tune_calls == 1);
+    assert(g_rtl_tune_freq == 851075000U);
+    assert(opts.rtlsdr_center_freq == 851000000U);
+
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    assert(io_control_set_freq(&opts, &state, 851075000L) == RTL_STREAM_TUNE_OK);
+    assert(g_rtl_tune_calls == 2);
+    assert(opts.rtlsdr_center_freq == 851075000U);
+    return 0;
+}
+
+static int
 test_signal_and_squelch_helpers(void) {
     reset_stubs();
     double value = -999.0;
@@ -454,6 +494,7 @@ main(void) {
     rc |= test_setmodulation_fallback_and_cache();
     rc |= test_get_current_freq_parses_first_line_and_errors();
     rc |= test_io_control_set_freq_validation_and_rigctl_dispatch();
+    rc |= test_io_control_set_freq_propagates_rtl_deferred();
     rc |= test_signal_and_squelch_helpers();
     rc |= test_signal_level_average_tolerates_failed_samples();
     rc |= test_legacy_udp_tune_payload_and_cache();

--- a/tests/io/test_io_rigctl_control.c
+++ b/tests/io/test_io_rigctl_control.c
@@ -416,6 +416,26 @@ test_io_control_set_freq_caches_applied_rtl_frequency(void) {
 }
 
 static int
+test_io_control_set_freq_retains_accepted_rtl_timeout_target(void) {
+    reset_stubs();
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtlsdr_center_freq = 851000000U;
+    state.rtl_ctx = (RtlSdrContext*)&state;
+    g_rtl_tune_result = RTL_STREAM_TUNE_TIMEOUT;
+    g_rtl_last_applied_freq = 851000000U;
+
+    assert(io_control_set_freq(&opts, &state, 851125000L) == RTL_STREAM_TUNE_TIMEOUT);
+    assert(g_rtl_tune_calls == 1);
+    assert(g_rtl_tune_freq == 851125000U);
+    assert(opts.rtlsdr_center_freq == 851125000U);
+    return 0;
+}
+
+static int
 test_signal_and_squelch_helpers(void) {
     reset_stubs();
     double value = -999.0;
@@ -527,6 +547,7 @@ main(void) {
     rc |= test_io_control_set_freq_validation_and_rigctl_dispatch();
     rc |= test_io_control_set_freq_propagates_rtl_deferred();
     rc |= test_io_control_set_freq_caches_applied_rtl_frequency();
+    rc |= test_io_control_set_freq_retains_accepted_rtl_timeout_target();
     rc |= test_signal_and_squelch_helpers();
     rc |= test_signal_level_average_tolerates_failed_samples();
     rc |= test_legacy_udp_tune_payload_and_cache();

--- a/tests/io/test_io_rigctl_control.c
+++ b/tests/io/test_io_rigctl_control.c
@@ -60,6 +60,7 @@ static int g_last_sendto_port;
 static int g_rtl_tune_calls;
 static uint32_t g_rtl_tune_freq;
 static int g_rtl_tune_result;
+static uint32_t g_rtl_last_applied_freq;
 static dsdneoRuntimeConfig g_config;
 
 bool dsd_rigctl_test_get_signal_level(dsd_socket_t sockfd, double* dB);
@@ -93,6 +94,7 @@ reset_stubs(void) {
     g_rtl_tune_calls = 0;
     g_rtl_tune_freq = 0U;
     g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_last_applied_freq = 0U;
     DSD_MEMSET(&g_config, 0, sizeof(g_config));
     g_config.rigctl_rcvtimeo_ms = 1500;
 }
@@ -103,6 +105,15 @@ rtl_stream_tune(RtlSdrContext* ctx, uint32_t center_freq_hz) {
     g_rtl_tune_calls++;
     g_rtl_tune_freq = center_freq_hz;
     return g_rtl_tune_result;
+}
+
+int
+rtl_stream_get_last_applied_freq(uint32_t* out_freq_hz) {
+    if (!out_freq_hz) {
+        return -1;
+    }
+    *out_freq_hz = g_rtl_last_applied_freq;
+    return 0;
 }
 
 static void
@@ -378,9 +389,29 @@ test_io_control_set_freq_propagates_rtl_deferred(void) {
     assert(opts.rtlsdr_center_freq == 851000000U);
 
     g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_last_applied_freq = 851075000U;
     assert(io_control_set_freq(&opts, &state, 851075000L) == RTL_STREAM_TUNE_OK);
     assert(g_rtl_tune_calls == 2);
     assert(opts.rtlsdr_center_freq == 851075000U);
+    return 0;
+}
+
+static int
+test_io_control_set_freq_caches_applied_rtl_frequency(void) {
+    reset_stubs();
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtlsdr_center_freq = 851000000U;
+    state.rtl_ctx = (RtlSdrContext*)&state;
+    g_rtl_last_applied_freq = 851100000U;
+
+    assert(io_control_set_freq(&opts, &state, 851075000L) == RTL_STREAM_TUNE_OK);
+    assert(g_rtl_tune_calls == 1);
+    assert(g_rtl_tune_freq == 851075000U);
+    assert(opts.rtlsdr_center_freq == 851100000U);
     return 0;
 }
 
@@ -495,6 +526,7 @@ main(void) {
     rc |= test_get_current_freq_parses_first_line_and_errors();
     rc |= test_io_control_set_freq_validation_and_rigctl_dispatch();
     rc |= test_io_control_set_freq_propagates_rtl_deferred();
+    rc |= test_io_control_set_freq_caches_applied_rtl_frequency();
     rc |= test_signal_and_squelch_helpers();
     rc |= test_signal_level_average_tolerates_failed_samples();
     rc |= test_legacy_udp_tune_payload_and_cache();

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -272,14 +272,21 @@ main(void) {
     failed |= expect_generation_eq("timeout tune defers output generation", generation_before, generation_after);
 
     int read_while_pending = -1;
-    int read_after_completion = -1;
+    int read_after_failed_completion = -1;
+    int read_after_recovery = -1;
     size_t used_while_pending = 0U;
+    generation_before = 0U;
+    generation_after = 0U;
     rc = rtl_stream_test_untagged_timeout_read_gate(5U, &read_while_pending, &used_while_pending,
-                                                    &read_after_completion);
+                                                    &read_after_failed_completion, &read_after_recovery,
+                                                    &generation_before, &generation_after);
     failed |= expect_int_eq("untagged timeout read gate helper rc", rc, 0);
     failed |= expect_int_eq("untagged timeout blocks queued output", read_while_pending, 0);
     failed |= expect_size_eq("untagged timeout preserves queued output", used_while_pending, 5U);
-    failed |= expect_int_eq("untagged completion reopens queued output", read_after_completion, 1);
+    failed |= expect_generation_changed("untagged timeout invalidates handed-off samples", generation_before,
+                                        generation_after);
+    failed |= expect_int_eq("failed untagged completion keeps output gated", read_after_failed_completion, 0);
+    failed |= expect_int_eq("successful recovery reopens queued output", read_after_recovery, 1);
 
     cache_pending = -1;
     rc = rtl_stream_test_tune_result_output_drain(RTL_STREAM_TUNE_DEFERRED, 5U, 3, &used_after, &cache_pending,

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -271,6 +271,16 @@ main(void) {
     failed |= expect_int_eq("timeout tune leaves cache for controller boundary", cache_pending, 3);
     failed |= expect_generation_eq("timeout tune defers output generation", generation_before, generation_after);
 
+    int read_while_pending = -1;
+    int read_after_completion = -1;
+    size_t used_while_pending = 0U;
+    rc = rtl_stream_test_untagged_timeout_read_gate(5U, &read_while_pending, &used_while_pending,
+                                                    &read_after_completion);
+    failed |= expect_int_eq("untagged timeout read gate helper rc", rc, 0);
+    failed |= expect_int_eq("untagged timeout blocks queued output", read_while_pending, 0);
+    failed |= expect_size_eq("untagged timeout preserves queued output", used_while_pending, 5U);
+    failed |= expect_int_eq("untagged completion reopens queued output", read_after_completion, 1);
+
     cache_pending = -1;
     rc = rtl_stream_test_tune_result_output_drain(RTL_STREAM_TUNE_DEFERRED, 5U, 3, &used_after, &cache_pending,
                                                   &generation_before, &generation_after);

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -7,7 +7,10 @@
 #error "DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS must be enabled for this test."
 #endif
 
+#include <atomic>
+#include <chrono>
 #include <cmath>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -15,6 +18,8 @@
 #include <dsd-neo/io/iq_types.h>
 #include <dsd-neo/io/rtl_device.h>
 #include <dsd-neo/io/rtl_stream_c.h>
+#include <mutex>
+#include <thread>
 #include "dsd-neo/core/safe_api.h"
 
 extern "C" uint64_t rtl_device_test_coalesce_capture_mute_duration(uint64_t* pending_bytes, uint64_t duration_bytes,
@@ -89,6 +94,69 @@ dsd_rtl_stream_test_capture_settings_failure_restore(uint32_t* out_full_freq_hz,
                                                      uint32_t* out_partial_rate_hz, int* out_partial_rate_out_hz);
 extern "C" int dsd_rtl_stream_test_ppm_store_if_applied(int ppm_rc, int requested_ppm, int* out_ppm_error);
 extern "C" int dsd_rtl_stream_test_retune_completion_result_binding(int* out_first_result, int* out_second_result);
+extern "C" int dsd_rtl_stream_test_cancel_queued_tagged_retune(uint64_t token, int* out_pending_after,
+                                                               int* out_completion_result);
+extern "C" int dsd_rtl_stream_test_cancel_queued_tagged_retune_order(uint64_t active_token, uint64_t queued_token,
+                                                                     int* out_active_result, int* out_cancelled_result);
+extern "C" int dsd_rtl_stream_test_tune_completion_callback_registered(void);
+extern "C" int dsd_rtl_stream_test_retune_without_controller_rejected(void);
+
+namespace {
+struct TaggedTuneCompletionState {
+    int calls;
+    uint64_t token;
+    rtl_stream_tune_result result;
+    uint32_t output_generation;
+};
+
+static void
+tagged_tune_completion(uint64_t token, rtl_stream_tune_result result, void* user_data) {
+    auto* state = static_cast<TaggedTuneCompletionState*>(user_data);
+    if (!state) {
+        return;
+    }
+    state->calls++;
+    state->token = token;
+    state->result = result;
+    state->output_generation = rtl_stream_output_generation();
+}
+
+struct BlockingTuneCompletionState {
+    std::mutex mutex;
+    std::condition_variable ready;
+    bool entered = false;
+    bool release = false;
+    int calls = 0;
+};
+
+static void
+blocking_tune_completion(uint64_t token, rtl_stream_tune_result result, void* user_data) {
+    (void)token;
+    (void)result;
+    auto* state = static_cast<BlockingTuneCompletionState*>(user_data);
+    std::unique_lock<std::mutex> lock(state->mutex);
+    state->calls++;
+    state->entered = true;
+    state->ready.notify_all();
+    state->ready.wait(lock, [state] { return state->release; });
+}
+
+struct OrderedTuneCompletionState {
+    int calls = 0;
+    uint64_t tokens[2] = {};
+    rtl_stream_tune_result results[2] = {};
+};
+
+static void
+ordered_tune_completion(uint64_t token, rtl_stream_tune_result result, void* user_data) {
+    auto* state = static_cast<OrderedTuneCompletionState*>(user_data);
+    if (state->calls < 2) {
+        state->tokens[state->calls] = token;
+        state->results[state->calls] = result;
+    }
+    state->calls++;
+}
+} // namespace
 
 static int
 expect_int_eq(const char* label, int got, int want) {
@@ -103,6 +171,15 @@ static int
 expect_size_eq(const char* label, size_t got, size_t want) {
     if (got != want) {
         DSD_FPRINTF(stderr, "FAIL: %s got=%zu want=%zu\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_u64_eq(const char* label, uint64_t got, uint64_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "FAIL: %s got=%llu want=%llu\n", label, (unsigned long long)got, (unsigned long long)want);
         return 1;
     }
     return 0;
@@ -190,9 +267,9 @@ main(void) {
     rc = rtl_stream_test_tune_result_output_drain(RTL_STREAM_TUNE_TIMEOUT, 5U, 3, &used_after, &cache_pending,
                                                   &generation_before, &generation_after);
     failed |= expect_int_eq("timeout tune drain helper rc", rc, 0);
-    failed |= expect_size_eq("timeout tune drains queued output", used_after, 0U);
-    failed |= expect_int_eq("timeout tune clears cached symbols", cache_pending, 0);
-    failed |= expect_generation_changed("timeout tune bumps output generation", generation_before, generation_after);
+    failed |= expect_size_eq("timeout tune leaves output for controller boundary", used_after, 5U);
+    failed |= expect_int_eq("timeout tune leaves cache for controller boundary", cache_pending, 3);
+    failed |= expect_generation_eq("timeout tune defers output generation", generation_before, generation_after);
 
     cache_pending = -1;
     rc = rtl_stream_test_tune_result_output_drain(RTL_STREAM_TUNE_DEFERRED, 5U, 3, &used_after, &cache_pending,
@@ -239,6 +316,144 @@ main(void) {
     failed |= expect_int_eq("retune completion result binding helper rc", rc, 0);
     failed |= expect_int_eq("first completion keeps failed result", first_completion_result, RTL_STREAM_TUNE_FAILED);
     failed |= expect_int_eq("second completion keeps ok result", second_completion_result, RTL_STREAM_TUNE_OK);
+
+    TaggedTuneCompletionState tagged_completion = {};
+    uint64_t coalesced_token = 0U;
+    rtl_stream_register_tune_completion_callback(tagged_tune_completion, &tagged_completion);
+    rc = rtl_stream_test_tagged_completion_boundary(UINT64_C(0x1111222233334444), UINT64_C(0xAAAABBBBCCCCDDDD), 5U,
+                                                    &coalesced_token, &generation_before, &generation_after);
+    rtl_stream_register_tune_completion_callback(nullptr, nullptr);
+    failed |= expect_int_eq("tagged completion boundary helper rc", rc, 0);
+    failed |= expect_u64_eq("conflicting tagged tune keeps owner", coalesced_token, UINT64_C(0x1111222233334444));
+    failed |= expect_int_eq("conflicting tagged tune publishes owner completion", tagged_completion.calls, 1);
+    failed |= expect_u64_eq("tagged owner callback token", tagged_completion.token, UINT64_C(0x1111222233334444));
+    failed |= expect_int_eq("tagged owner callback result", tagged_completion.result, RTL_STREAM_TUNE_OK);
+    failed |=
+        expect_generation_changed("completion follows output generation boundary", generation_before, generation_after);
+    failed |= expect_generation_eq("callback observes drained output generation", tagged_completion.output_generation,
+                                   generation_after);
+
+    tagged_completion = {};
+    coalesced_token = UINT64_MAX;
+    rtl_stream_register_tune_completion_callback(tagged_tune_completion, &tagged_completion);
+    rc = rtl_stream_test_tagged_completion_boundary(UINT64_C(0x1020304050607080), 0U, 5U, &coalesced_token,
+                                                    &generation_before, &generation_after);
+    rtl_stream_register_tune_completion_callback(nullptr, nullptr);
+    failed |= expect_int_eq("untagged conflict boundary helper rc", rc, 0);
+    failed |= expect_u64_eq("untagged conflict keeps tagged owner", coalesced_token, UINT64_C(0x1020304050607080));
+    failed |= expect_int_eq("untagged conflict publishes owner completion", tagged_completion.calls, 1);
+    failed |= expect_u64_eq("untagged conflict callback token", tagged_completion.token, UINT64_C(0x1020304050607080));
+    failed |= expect_int_eq("untagged conflict callback result", tagged_completion.result, RTL_STREAM_TUNE_OK);
+    failed |= expect_generation_changed("untagged conflict drains owner output", generation_before, generation_after);
+    failed |= expect_generation_eq("untagged conflict callback follows output boundary",
+                                   tagged_completion.output_generation, generation_after);
+
+    tagged_completion = {};
+    coalesced_token = 0U;
+    rtl_stream_register_tune_completion_callback(tagged_tune_completion, &tagged_completion);
+    rc = rtl_stream_test_tagged_completion_boundary(0U, UINT64_C(0x5566778899AABBCC), 5U, &coalesced_token,
+                                                    &generation_before, &generation_after);
+    rtl_stream_register_tune_completion_callback(nullptr, nullptr);
+    failed |= expect_int_eq("tagged upgrade boundary helper rc", rc, 0);
+    failed |= expect_u64_eq("tagged request upgrades untagged work", coalesced_token, UINT64_C(0x5566778899AABBCC));
+    failed |= expect_int_eq("tagged upgrade publishes one completion", tagged_completion.calls, 1);
+    failed |= expect_u64_eq("tagged upgrade callback token", tagged_completion.token, UINT64_C(0x5566778899AABBCC));
+    failed |= expect_int_eq("tagged upgrade callback result", tagged_completion.result, RTL_STREAM_TUNE_OK);
+    failed |= expect_generation_changed("tagged upgrade drains output", generation_before, generation_after);
+    failed |= expect_generation_eq("tagged upgrade callback follows output boundary",
+                                   tagged_completion.output_generation, generation_after);
+
+    tagged_completion = {};
+    int pending_after_cancel = -1;
+    int cancelled_completion_result = RTL_STREAM_TUNE_OK;
+    rtl_stream_register_tune_completion_callback(tagged_tune_completion, &tagged_completion);
+    rc = dsd_rtl_stream_test_cancel_queued_tagged_retune(UINT64_C(0xCAFEBABE11223344), &pending_after_cancel,
+                                                         &cancelled_completion_result);
+    rtl_stream_register_tune_completion_callback(nullptr, nullptr);
+    failed |= expect_int_eq("queued tagged cancellation helper rc", rc, 0);
+    failed |= expect_int_eq("queued tagged cancellation clears pending work", pending_after_cancel, 0);
+    failed |= expect_int_eq("queued tagged cancellation records failed result", cancelled_completion_result,
+                            RTL_STREAM_TUNE_FAILED);
+    failed |= expect_int_eq("queued tagged cancellation publishes once", tagged_completion.calls, 1);
+    failed |= expect_u64_eq("queued tagged cancellation preserves token", tagged_completion.token,
+                            UINT64_C(0xCAFEBABE11223344));
+    failed |=
+        expect_int_eq("queued tagged cancellation callback result", tagged_completion.result, RTL_STREAM_TUNE_FAILED);
+
+    OrderedTuneCompletionState ordered_completion = {};
+    int active_completion_result = RTL_STREAM_TUNE_FAILED;
+    cancelled_completion_result = RTL_STREAM_TUNE_OK;
+    rtl_stream_register_tune_completion_callback(ordered_tune_completion, &ordered_completion);
+    rc = dsd_rtl_stream_test_cancel_queued_tagged_retune_order(UINT64_C(0x1010101010101010),
+                                                               UINT64_C(0x2020202020202020), &active_completion_result,
+                                                               &cancelled_completion_result);
+    rtl_stream_register_tune_completion_callback(nullptr, nullptr);
+    failed |= expect_int_eq("active and queued cancellation order helper rc", rc, 0);
+    failed |= expect_int_eq("active request keeps its completion result", active_completion_result, RTL_STREAM_TUNE_OK);
+    failed |= expect_int_eq("queued request keeps its cancellation result", cancelled_completion_result,
+                            RTL_STREAM_TUNE_FAILED);
+    failed |= expect_int_eq("ordered cancellation publishes both completions", ordered_completion.calls, 2);
+    failed |= expect_u64_eq("active completion retains first token", ordered_completion.tokens[0],
+                            UINT64_C(0x1010101010101010));
+    failed |= expect_int_eq("active completion is successful", ordered_completion.results[0], RTL_STREAM_TUNE_OK);
+    failed |= expect_u64_eq("cancelled completion retains queued token", ordered_completion.tokens[1],
+                            UINT64_C(0x2020202020202020));
+    failed |= expect_int_eq("queued completion failed", ordered_completion.results[1], RTL_STREAM_TUNE_FAILED);
+    failed |= expect_int_eq("retune without controller is rejected",
+                            dsd_rtl_stream_test_retune_without_controller_rejected(), 1);
+
+    BlockingTuneCompletionState blocking_completion = {};
+    std::atomic<int> unregister_returned{0};
+    int blocking_publish_rc = -1;
+    uint64_t blocking_token = 0U;
+    uint32_t blocking_generation_before = 0U;
+    uint32_t blocking_generation_after = 0U;
+    rtl_stream_register_tune_completion_callback(blocking_tune_completion, &blocking_completion);
+    std::thread publisher([&] {
+        blocking_publish_rc = rtl_stream_test_tagged_completion_boundary(
+            UINT64_C(0x3030303030303030), UINT64_C(0x3030303030303030), 5U, &blocking_token,
+            &blocking_generation_before, &blocking_generation_after);
+    });
+    bool callback_entered = false;
+    {
+        std::unique_lock<std::mutex> lock(blocking_completion.mutex);
+        callback_entered = blocking_completion.ready.wait_for(
+            lock, std::chrono::seconds(1), [&blocking_completion] { return blocking_completion.entered; });
+        if (!callback_entered) {
+            blocking_completion.release = true;
+        }
+    }
+    blocking_completion.ready.notify_all();
+    failed |= expect_int_eq("blocking completion callback entered", callback_entered ? 1 : 0, 1);
+    if (callback_entered) {
+        std::thread unregister_thread([&] {
+            rtl_stream_register_tune_completion_callback(nullptr, nullptr);
+            unregister_returned.store(1, std::memory_order_release);
+        });
+        int callback_still_registered = 1;
+        for (int i = 0; i < 1000 && callback_still_registered; i++) {
+            callback_still_registered = dsd_rtl_stream_test_tune_completion_callback_registered();
+            if (callback_still_registered) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+        }
+        failed |= expect_int_eq("unregister removes callback before waiting", callback_still_registered, 0);
+        failed |= expect_int_eq("unregister waits for in-flight callback",
+                                unregister_returned.load(std::memory_order_acquire), 0);
+        {
+            std::lock_guard<std::mutex> lock(blocking_completion.mutex);
+            blocking_completion.release = true;
+        }
+        blocking_completion.ready.notify_all();
+        unregister_thread.join();
+        failed |= expect_int_eq("unregister returns after callback exits",
+                                unregister_returned.load(std::memory_order_acquire), 1);
+    } else {
+        rtl_stream_register_tune_completion_callback(nullptr, nullptr);
+    }
+    publisher.join();
+    failed |= expect_int_eq("blocking completion publish helper rc", blocking_publish_rc, 0);
+    failed |= expect_int_eq("blocking completion invoked once", blocking_completion.calls, 1);
 
     uint32_t full_restore_freq_hz = 0U;
     uint32_t full_restore_rate_hz = 0U;

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -285,7 +285,7 @@ main(void) {
     failed |= expect_size_eq("untagged timeout preserves queued output", used_while_pending, 5U);
     failed |= expect_generation_changed("untagged timeout invalidates handed-off samples", generation_before,
                                         generation_after);
-    failed |= expect_int_eq("failed untagged completion keeps output gated", read_after_failed_completion, 0);
+    failed |= expect_int_eq("failed untagged completion reopens recovered output", read_after_failed_completion, 1);
     failed |= expect_int_eq("successful recovery reopens queued output", read_after_recovery, 1);
 
     cache_pending = -1;

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -786,6 +786,12 @@ main(void) {
                             rtl_device_test_replay_event_boundary_drained(2U, 3U, 3U), 0);
     failed |= expect_int_eq("reset event waits for reserved demod generation",
                             rtl_device_test_replay_event_boundary_drained(0U, 3U, 2U), 0);
+    uint64_t discarded_span_consumed = rtl_stream_test_replay_acknowledge_discarded_span(3U, 2U);
+    failed |= expect_u64_eq("discarded replay span acknowledges submit generation", discarded_span_consumed, 3U);
+    failed |= expect_int_eq("rewind boundary accepts acknowledged discarded span",
+                            rtl_device_test_replay_event_boundary_drained(0U, 3U, discarded_span_consumed), 1);
+    failed |= expect_u64_eq("discarded replay acknowledgment remains monotonic",
+                            rtl_stream_test_replay_acknowledge_discarded_span(3U, 4U), 4U);
     failed |=
         expect_int_eq("reset event boundary drained", rtl_device_test_replay_event_boundary_drained(0U, 3U, 3U), 1);
 

--- a/tests/io/test_io_rtl_stream_orchestrator.cpp
+++ b/tests/io/test_io_rtl_stream_orchestrator.cpp
@@ -7,6 +7,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/io/rtl_stream.h>
 #include <memory>
+#include <stdint.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -32,6 +33,7 @@ struct StubState {
     dsd_opts* last_unregistered_active;
     dsd_opts* last_unregistered_caller;
     long int last_tune_hz;
+    uint64_t last_tune_token;
     size_t last_read_count;
 };
 
@@ -114,6 +116,15 @@ dsd_rtl_stream_tune(dsd_opts* opts, long int frequency) {
     g_stub.tune_calls++;
     g_stub.last_open_opts = opts;
     g_stub.last_tune_hz = frequency;
+    return g_stub.tune_rc;
+}
+
+extern "C" int
+dsd_rtl_stream_tune_tagged(dsd_opts* opts, long int frequency, uint64_t token) {
+    g_stub.tune_calls++;
+    g_stub.last_open_opts = opts;
+    g_stub.last_tune_hz = frequency;
+    g_stub.last_tune_token = token;
     return g_stub.tune_rc;
 }
 
@@ -233,6 +244,8 @@ test_start_failure_and_prestart_errors(void) {
     rc |= expect_int_eq("failed start does not soft stop", g_stub.soft_stop_calls, 0);
     rc |= expect_int_eq("prestart tune rejected", stream.tune(851000000U), -1);
     rc |= expect_int_eq("prestart tune does not call legacy tune", g_stub.tune_calls, 0);
+    rc |= expect_int_eq("prestart tagged tune rejected", stream.tune_tagged(851000000U, 41U), -1);
+    rc |= expect_int_eq("prestart tagged tune does not call legacy tune", g_stub.tune_calls, 0);
 
     float sample = 0.0f;
     int got = 123;
@@ -257,6 +270,14 @@ test_tune_read_and_ppm_error_propagation(void) {
     g_stub.tune_rc = 0;
     rc |= expect_int_eq("tune success clears last error", stream.tune(851025000U), 0);
     rc |= expect_int_eq("tune success last error", stream.last_error_code(), 0);
+    rc |= expect_int_eq("tagged tune rejects zero token", stream.tune_tagged(851037500U, 0U), -1);
+    rc |= expect_int_eq("tagged tune forwards result", stream.tune_tagged(851050000U, UINT64_C(0x123456789ABC)), 0);
+    rc |= expect_int_eq("tagged tune records frequency", (int)g_stub.last_tune_hz, 851050000);
+    if (g_stub.last_tune_token != UINT64_C(0x123456789ABC)) {
+        DSD_FPRINTF(stderr, "tagged tune token: got=%llu want=%llu\n", (unsigned long long)g_stub.last_tune_token,
+                    (unsigned long long)UINT64_C(0x123456789ABC));
+        rc = 1;
+    }
 
     float samples[4] = {};
     int got = 0;

--- a/tests/io/test_io_rtl_stream_orchestrator.cpp
+++ b/tests/io/test_io_rtl_stream_orchestrator.cpp
@@ -18,6 +18,8 @@ struct StubState {
     int tune_rc;
     int read_rc;
     unsigned int output_rate;
+    uint32_t output_generation;
+    int invalidate_first_read;
     int requested_ppm;
     int open_calls;
     int soft_stop_calls;
@@ -43,6 +45,7 @@ static void
 reset_stubs(void) {
     g_stub = {};
     g_stub.output_rate = 48000U;
+    g_stub.output_generation = 1U;
 }
 
 static std::unique_ptr<dsd_opts>
@@ -108,7 +111,15 @@ dsd_rtl_stream_read(float* out, size_t count, dsd_opts* opts, const dsd_state* s
     g_stub.read_calls++;
     g_stub.last_open_opts = opts;
     g_stub.last_read_count = count;
+    if (g_stub.invalidate_first_read && g_stub.read_calls == 1) {
+        g_stub.output_generation++;
+    }
     return g_stub.read_rc;
+}
+
+extern "C" uint32_t
+dsd_rtl_stream_output_generation(void) {
+    return g_stub.output_generation;
 }
 
 extern "C" int
@@ -285,6 +296,14 @@ test_tune_read_and_ppm_error_propagation(void) {
     rc |= expect_int_eq("read success", stream.read(samples, 4U, got), 0);
     rc |= expect_int_eq("read returns got count", got, 3);
     rc |= expect_int_eq("read records count", (int)g_stub.last_read_count, 4);
+
+    g_stub.read_calls = 0;
+    g_stub.invalidate_first_read = 1;
+    rc |= expect_int_eq("read retries an invalidated handoff", stream.read(samples, 4U, got), 0);
+    rc |= expect_int_eq("invalidated handoff reads a fresh batch", g_stub.read_calls, 2);
+    rc |= expect_int_eq("fresh handoff returns got count", got, 3);
+    g_stub.invalidate_first_read = 0;
+
     g_stub.read_rc = -9;
     rc |= expect_int_eq("read propagates failure", stream.read(samples, 4U, got), -9);
     rc |= expect_int_eq("read failure last error", stream.last_error_code(), -9);

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -6,6 +6,7 @@
 /* Verify policy-backed P25 grant filtering behavior in the trunk SM path. */
 
 #include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
@@ -15,6 +16,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -70,6 +72,19 @@ seed_exact(dsd_state* st, uint32_t id, const char* mode, const char* name, int p
     row.priority = priority;
     row.preempt = preempt ? 1u : 0u;
     return dsd_tg_policy_upsert_exact(st, &row, DSD_TG_POLICY_UPSERT_REPLACE_FIRST);
+}
+
+static void
+mark_cc_reacquired(dsd_state* st) {
+    if (!st) {
+        return;
+    }
+    double now_m = dsd_time_now_monotonic_s();
+    if (now_m <= st->last_cc_sync_time_m) {
+        now_m = st->last_cc_sync_time_m + 0.001;
+    }
+    st->last_cc_sync_time = time(NULL);
+    st->last_cc_sync_time_m = now_m;
 }
 
 static void
@@ -151,6 +166,7 @@ main(void) {
 
     // Active patch members can satisfy grant policy while the OTA target remains the supergroup.
     p25_sm_on_release(&opts, &st);
+    mark_cc_reacquired(&st);
     opts.trunk_use_allow_list = 0;
     st.tg_hold = 1401;
     p25_patch_add_wgid(&st, 1400, 1401);
@@ -168,6 +184,7 @@ main(void) {
     st.tg_hold = 0;
 
     p25_sm_on_release(&opts, &st);
+    mark_cc_reacquired(&st);
     opts.trunk_use_allow_list = 1;
     rc |= expect_true("seed patch member allow", seed_exact(&st, 1403, "A", "PATCH-MEMBER", 0, 0) == 0);
     p25_patch_add_wgid(&st, 1402, 1403);
@@ -183,6 +200,7 @@ main(void) {
     rc |= expect_true("patch member allowlist p2 media gate", dsd_p25p2_decode_audio_allowed(&opts, &st, 0, 0) == 1);
 
     p25_sm_on_release(&opts, &st);
+    mark_cc_reacquired(&st);
     p25_patch_add_wgid(&st, 1404, 1405);
     before = st.p25_sm_tune_count;
     opts.p25_is_tuned = 0;
@@ -205,6 +223,7 @@ main(void) {
     // Runtime encrypted-call lockout must not persist as a TG policy block.
     rc |= expect_true("seed mixed-mode group", seed_exact(&st, 1104, "A", "MIXED", 0, 0) == 0);
     p25_sm_on_release(&opts, &st);
+    mark_cc_reacquired(&st);
     opts.trunk_tune_enc_calls = 0;
     opts.p25_is_tuned = 0;
     before = st.p25_sm_tune_count;
@@ -236,6 +255,7 @@ main(void) {
 
         p25_emit_enc_lockout_once(&cache_opts, &cache_st, 0, 1300, /*svc*/ 0);
         p25_sm_on_release(&cache_opts, &cache_st);
+        mark_cc_reacquired(&cache_st);
         before = cache_st.p25_sm_tune_count;
         cache_opts.p25_is_tuned = 0;
         p25_sm_on_group_grant(&cache_opts, &cache_st, ch, P25_SM_SVC_UNKNOWN, /*tg*/ 1300, /*src*/ 2301);
@@ -249,6 +269,7 @@ main(void) {
         rc |= expect_true("explicit clear grant clears transient enc cache", enc_tg_cache_is_absent(&cache_st, 1300U));
         rc |= expect_true("explicit clear grant does not add TG policy", tg_policy_is_absent(&cache_st, 1300U));
         p25_sm_on_release(&cache_opts, &cache_st);
+        mark_cc_reacquired(&cache_st);
         p25_sm_init(&opts, &st);
     }
 
@@ -262,6 +283,7 @@ main(void) {
 
     // TG 0 is evaluated like any other exact ID.
     p25_sm_on_release(&opts, &st);
+    mark_cc_reacquired(&st);
     opts.p25_is_tuned = 0;
     rc |= expect_true("seed tg0 A", seed_exact(&st, 0, "A", "ZERO-ALLOW", 0, 0) == 0);
     before = st.p25_sm_tune_count;
@@ -276,6 +298,7 @@ main(void) {
 
     // SM private-grant path keeps unknown private IDs allowed under allow-list mode.
     p25_sm_on_release(&opts, &st);
+    mark_cc_reacquired(&st);
     before = st.p25_sm_tune_count;
     opts.p25_is_tuned = 0;
     p25_sm_on_indiv_grant(&opts, &st, ch, /*svc*/ 0x00, /*dst*/ 9001, /*src*/ 9002);
@@ -307,12 +330,14 @@ main(void) {
         p25_sm_on_group_data_grant(&data_opts, &data_st, ch, /*svc*/ 0x00, /*tg*/ 3102, /*src*/ 4102);
         rc |= expect_true("group data clear svc tunes when data enabled", data_st.p25_sm_tune_count == before + 1);
         p25_sm_on_release(&data_opts, &data_st);
+        mark_cc_reacquired(&data_st);
         data_opts.p25_is_tuned = 0;
         before = data_st.p25_sm_tune_count;
         p25_sm_on_indiv_data_grant(&data_opts, &data_st, ch, P25_SM_SVC_UNKNOWN, /*dst*/ 3103, /*src*/ 4103);
         rc |= expect_true("indiv data unknown svc tunes when data enabled", data_st.p25_sm_tune_count == before + 1);
 
         p25_sm_on_release(&data_opts, &data_st);
+        mark_cc_reacquired(&data_st);
         data_opts.trunk_tune_enc_calls = 0;
         data_opts.p25_is_tuned = 0;
         before = data_st.p25_sm_tune_count;
@@ -324,6 +349,7 @@ main(void) {
         rc |= expect_true("svc-less voice grant not skipped after encrypted data grant",
                           data_st.p25_sm_tune_count == before + 1);
         p25_sm_on_release(&data_opts, &data_st);
+        mark_cc_reacquired(&data_st);
 
         p25_emit_enc_lockout_once(&data_opts, &data_st, 0, 3105, /*svc*/ 0x40);
         rc |= expect_true("seed transient voice enc cache", !enc_tg_cache_is_absent(&data_st, 3105U));
@@ -334,6 +360,7 @@ main(void) {
         rc |= expect_true("svc-less group data grant preserves voice enc cache",
                           !enc_tg_cache_is_absent(&data_st, 3105U));
         p25_sm_on_release(&data_opts, &data_st);
+        mark_cc_reacquired(&data_st);
 
         data_opts.trunk_tune_data_calls = 0;
         data_opts.p25_is_tuned = 0;
@@ -351,6 +378,7 @@ main(void) {
     rc |= expect_true("seed active high", seed_exact(&st, 1200, "A", "ACTIVE-HIGH", 80, 0) == 0);
     rc |= expect_true("seed candidate low preempt", seed_exact(&st, 1201, "A", "CAND-LOW", 10, 1) == 0);
     p25_sm_on_release(&opts, &st);
+    mark_cc_reacquired(&st);
     before = st.p25_sm_tune_count;
     opts.p25_is_tuned = 0;
     p25_sm_on_group_grant(&opts, &st, ch, /*svc*/ 0x00, /*tg*/ 1200, /*src*/ 2200);
@@ -373,6 +401,7 @@ main(void) {
 
     // Patch-member priority/preempt displaces using the matched member policy, not the OTA SG's default priority.
     p25_sm_on_release(&opts, &st);
+    mark_cc_reacquired(&st);
     rc |= expect_true("seed patch active base", seed_exact(&st, 1500, "A", "PATCH-ACTIVE", 80, 0) == 0);
     rc |= expect_true("seed patch member preempt", seed_exact(&st, 1502, "A", "PATCH-PREEMPT", 95, 1) == 0);
     p25_patch_add_wgid(&st, 1501, 1502);

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -85,6 +85,8 @@ mark_cc_reacquired(dsd_state* st) {
     }
     st->last_cc_sync_time = time(NULL);
     st->last_cc_sync_time_m = now_m;
+    st->p25_last_cc_msg_time = st->last_cc_sync_time;
+    st->p25_last_cc_msg_time_m = now_m;
 }
 
 static void

--- a/tests/protocol/p25/test_p25_options_gating.c
+++ b/tests/protocol/p25/test_p25_options_gating.c
@@ -8,12 +8,14 @@
  * Ensures trunk_tune_group_calls / trunk_tune_private_calls disable tuning.
  */
 
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -127,6 +129,19 @@ seed_exact(dsd_state* st, uint32_t id, const char* mode, const char* name) {
     return dsd_tg_policy_upsert_exact(st, &row, DSD_TG_POLICY_UPSERT_REPLACE_FIRST);
 }
 
+static void
+mark_cc_reacquired(dsd_state* st) {
+    if (!st) {
+        return;
+    }
+    double now_m = dsd_time_now_monotonic_s();
+    if (now_m <= st->last_cc_sync_time_m) {
+        now_m = st->last_cc_sync_time_m + 0.001;
+    }
+    st->last_cc_sync_time = time(NULL);
+    st->last_cc_sync_time_m = now_m;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -175,6 +190,7 @@ main(void) {
     process_MAC_VPDU(&opts, &st, 0, MAC);
     rc |= expect_true("group allowed tunes", st.p25_sm_tune_count == before + 1);
     p25_sm_on_release(&opts, &st);
+    mark_cc_reacquired(&st);
     opts.p25_is_tuned = 0;
 
     // Case C: private grant gating — reuse MAC with private opcode mapping
@@ -209,6 +225,7 @@ main(void) {
 
     // Case D: helper-path private allow-list behavior: unknown private IDs block.
     p25_sm_on_release(&opts, &st);
+    mark_cc_reacquired(&st);
     opts.p25_is_tuned = 0;
     opts.trunk_use_allow_list = 1;
     opts.trunk_tune_private_calls = 1;

--- a/tests/protocol/p25/test_p25_options_gating.c
+++ b/tests/protocol/p25/test_p25_options_gating.c
@@ -140,6 +140,8 @@ mark_cc_reacquired(dsd_state* st) {
     }
     st->last_cc_sync_time = time(NULL);
     st->last_cc_sync_time_m = now_m;
+    st->p25_last_cc_msg_time = st->last_cc_sync_time;
+    st->p25_last_cc_msg_time_m = now_m;
 }
 
 int

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -1424,7 +1424,7 @@ main(void) {
         rc |= expect_true("0x40 tuned same-carrier remains tuned", opts.p25_is_tuned == 1 && opts.trunk_is_tuned == 1);
     }
 
-    // Case F: first live VPDU grant seeds an unknown CC from the current RTL tuner.
+    // Case F: an LCCH VPDU grant can dispatch without promoting the current tuner to CC.
     {
         static dsd_opts opts;
         static dsd_state state;
@@ -1439,6 +1439,7 @@ main(void) {
         opts.rtlsdr_center_freq = (uint32_t)cc;
         state.synctype = DSD_SYNC_P25P2_POS;
         state.p2_is_lcch = 1;
+        state.p25_cc_is_tdma = 2;
         state.p25_iden_fdma[iden].base_freq = base;
         state.p25_iden_fdma[iden].chan_type = type;
         state.p25_iden_fdma[iden].chan_spac = spac;
@@ -1457,11 +1458,12 @@ main(void) {
         MAC[9] = 0x02; // source
 
         process_MAC_VPDU(&opts, &state, 0, MAC);
-        rc |= expect_true("0x40 seeded CC tuned", opts.p25_is_tuned == 1);
-        rc |= expect_eq_long("0x40 seeded CC", state.p25_cc_freq, cc);
-        rc |= expect_eq_long("0x40 seeded trunk CC", state.trunk_cc_freq, cc);
-        rc |= expect_true("0x40 seeded TDMA CC hint", state.p25_cc_is_tdma == 1);
-        rc |= expect_eq_long("0x40 seeded vc", state.p25_vc_freq[0], 851125000);
+        rc |= expect_true("0x40 LCCH grant tuned", opts.p25_is_tuned == 1);
+        rc |= expect_eq_long("0x40 LCCH grant did not seed CC", state.p25_cc_freq, 0);
+        rc |= expect_eq_long("0x40 LCCH grant did not seed trunk CC", state.trunk_cc_freq, 0);
+        rc |= expect_eq_long("0x40 LCCH grant did not seed LCN0", state.trunk_lcn_freq[0], 0);
+        rc |= expect_true("0x40 LCCH grant preserves CC modulation hint", state.p25_cc_is_tdma == 2);
+        rc |= expect_eq_long("0x40 LCCH grant vc", state.p25_vc_freq[0], 851125000);
     }
 
     // Case G: traffic-channel MACs must not learn the current VC tuner frequency as the CC.

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -1424,7 +1424,7 @@ main(void) {
         rc |= expect_true("0x40 tuned same-carrier remains tuned", opts.p25_is_tuned == 1 && opts.trunk_is_tuned == 1);
     }
 
-    // Case F: an LCCH VPDU grant can dispatch without promoting the current tuner to CC.
+    // Case F: an LCCH VPDU grant seeds the current tuner as a recoverable CC before retuning.
     {
         static dsd_opts opts;
         static dsd_state state;
@@ -1459,11 +1459,55 @@ main(void) {
 
         process_MAC_VPDU(&opts, &state, 0, MAC);
         rc |= expect_true("0x40 LCCH grant tuned", opts.p25_is_tuned == 1);
-        rc |= expect_eq_long("0x40 LCCH grant did not seed CC", state.p25_cc_freq, 0);
-        rc |= expect_eq_long("0x40 LCCH grant did not seed trunk CC", state.trunk_cc_freq, 0);
-        rc |= expect_eq_long("0x40 LCCH grant did not seed LCN0", state.trunk_lcn_freq[0], 0);
+        rc |= expect_eq_long("0x40 LCCH grant seeded CC", state.p25_cc_freq, cc);
+        rc |= expect_eq_long("0x40 LCCH grant seeded trunk CC", state.trunk_cc_freq, cc);
+        rc |= expect_eq_long("0x40 LCCH grant seeded LCN0", state.trunk_lcn_freq[0], cc);
         rc |= expect_true("0x40 LCCH grant preserves CC modulation hint", state.p25_cc_is_tdma == 2);
         rc |= expect_eq_long("0x40 LCCH grant vc", state.p25_vc_freq[0], 851125000);
+    }
+
+    // Case F2: an LCCH grant without a known or discoverable CC return target must not dispatch.
+    {
+        static dsd_opts opts;
+        static dsd_state state;
+        unsigned long long int MAC[24] = {0};
+        DSD_MEMSET(&opts, 0, sizeof opts);
+        DSD_MEMSET(&state, 0, sizeof state);
+        p25_sm_on_release(&opts, &state);
+
+        opts.p25_trunk = 1;
+        opts.trunk_tune_group_calls = 1;
+        state.synctype = DSD_SYNC_P25P2_POS;
+        state.p2_is_lcch = 1;
+        state.p25_iden_fdma[iden].base_freq = base;
+        state.p25_iden_fdma[iden].chan_type = type;
+        state.p25_iden_fdma[iden].chan_spac = spac;
+        state.p25_iden_fdma[iden].trust = 2;
+        state.p25_iden_fdma[iden].populated = 1;
+        state.p25_chan_tdma_explicit[iden] = 1;
+
+        MAC[1] = 0x40; // Group Voice Channel Grant
+        MAC[2] = 0x00; // svc
+        MAC[3] = 0x10;
+        MAC[4] = 0x0A; // channel 0x100A -> 851.125 MHz
+        MAC[5] = 0x12;
+        MAC[6] = 0x34; // group
+        MAC[7] = 0x00;
+        MAC[8] = 0x00;
+        MAC[9] = 0x02; // source
+
+        reset_group_grant_capture();
+        p25_sm_api api = {0};
+        api.on_group_grant = sm_on_group_grant_capture;
+        p25_sm_set_api(&api);
+        process_MAC_VPDU(&opts, &state, 0, MAC);
+        p25_sm_reset_api();
+
+        rc |= expect_eq_long("0x40 unseeded LCCH grant not dispatched", g_group_grant_called, 0);
+        rc |= expect_true("0x40 unseeded LCCH grant not tuned", opts.p25_is_tuned == 0 && opts.trunk_is_tuned == 0);
+        rc |= expect_eq_long("0x40 unseeded LCCH no p25 CC", state.p25_cc_freq, 0);
+        rc |= expect_eq_long("0x40 unseeded LCCH no trunk CC", state.trunk_cc_freq, 0);
+        rc |= expect_eq_long("0x40 unseeded LCCH no vc", state.p25_vc_freq[0], 0);
     }
 
     // Case G: traffic-channel MACs must not learn the current VC tuner frequency as the CC.

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -1462,7 +1462,7 @@ main(void) {
         rc |= expect_eq_long("0x40 LCCH grant seeded CC", state.p25_cc_freq, cc);
         rc |= expect_eq_long("0x40 LCCH grant seeded trunk CC", state.trunk_cc_freq, cc);
         rc |= expect_eq_long("0x40 LCCH grant seeded LCN0", state.trunk_lcn_freq[0], cc);
-        rc |= expect_true("0x40 LCCH grant preserves CC modulation hint", state.p25_cc_is_tdma == 2);
+        rc |= expect_true("0x40 LCCH grant marks TDMA CC", state.p25_cc_is_tdma == 1);
         rc |= expect_eq_long("0x40 LCCH grant vc", state.p25_vc_freq[0], 851125000);
     }
 

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -1117,6 +1117,16 @@ main(void) {
         rc |= expect_true("preempt replacement active", preempt_ctx.state == P25_SM_TUNED && preempt_ctx.vc_tg == 4002
                                                             && preempt_ctx.slots[0].grant_active
                                                             && preempt_ctx.slots[0].target_id == 4002);
+        rc |= expect_true("preempt canceled cc acquisition",
+                          preempt_ctx.cc_sync_pending == 0 && preempt_ctx.t_cc_tune_m == 0.0);
+
+        // A duplicate carried by VC signaling must still refresh the accepted
+        // call after the immediate replacement tune.
+        preempt_ctx.slots[0].last_grant_m = 0.0;
+        p25_sm_event(&preempt_ctx, &preempt_opts, &preempt_st, &preempt_candidate);
+        rc |= expect_true("preempt duplicate grant refreshed", preempt_ctx.slots[0].last_grant_m > 0.0
+                                                                   && g_tune_to_freq_calls == 2
+                                                                   && preempt_ctx.state == P25_SM_TUNED);
 
         static const dsd_trunk_tune_result preempt_release_failures[] = {
             DSD_TRUNK_TUNE_RESULT_DEFERRED,

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -169,6 +169,19 @@ age_pending_grants(p25_sm_ctx_t* ctx, double age_s) {
     }
 }
 
+static void
+mark_cc_reacquired(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    double now_m = dsd_time_now_monotonic_s();
+    if (now_m <= state->last_cc_sync_time_m) {
+        now_m = state->last_cc_sync_time_m + 0.001;
+    }
+    state->last_cc_sync_time = time(NULL);
+    state->last_cc_sync_time_m = now_m;
+}
+
 static int
 seed_exact(dsd_state* st, uint32_t id, const char* mode, const char* name, int priority, int preempt) {
     dsd_tg_policy_entry row;
@@ -229,6 +242,7 @@ main(void) {
     rc |= expect_true("returned", opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1 && ctx.state == P25_SM_ON_CC);
     rc |= expect_true("backoff armed", st.p25_retune_block_freq == g_last_tuned_vc && st.p25_retune_block_slot == 1
                                            && st.p25_retune_block_until > time(NULL));
+    mark_cc_reacquired(&st);
 
     // 3) Same-slot repeat grant on the same RF should be blocked during backoff.
     p25_sm_event(&ctx, &opts, &st, &ev_slot1);
@@ -249,6 +263,7 @@ main(void) {
     rc |=
         expect_true("second backoff armed", st.p25_retune_block_freq == g_last_tuned_vc && st.p25_retune_block_slot == 0
                                                 && st.p25_retune_block_until > time(NULL));
+    mark_cc_reacquired(&st);
 
     p25_sm_event(&ctx, &opts, &st, &ev_slot1);
     rc |= expect_true("first failed slot still blocked", g_tune_to_freq_calls == 2 && opts.p25_is_tuned == 0);
@@ -300,6 +315,7 @@ main(void) {
                           retune_backoff_history_has_slot(&zero_st, g_last_tuned_vc, 0));
         rc |= expect_true("zero channel slot1 backoff remembered",
                           retune_backoff_history_has_slot(&zero_st, g_last_tuned_vc, 1));
+        mark_cc_reacquired(&zero_st);
 
         p25_sm_event(&zero_ctx, &zero_opts, &zero_st, &zero_ev_slot0);
         rc |= expect_true("zero channel slot0 blocked", g_tune_to_freq_calls == 1 && zero_opts.p25_is_tuned == 0);
@@ -387,6 +403,7 @@ main(void) {
     rc |= expect_true("data returned",
                       data_opts.p25_is_tuned == 0 && g_return_to_cc_calls == 1 && data_ctx.state == P25_SM_ON_CC);
     rc |= expect_true("data timeout does not arm backoff", retune_backoff_empty(&data_st));
+    mark_cc_reacquired(&data_st);
 
     p25_sm_event(&data_ctx, &data_opts, &data_st, &ev_slot1);
     rc |= expect_true("voice grant after data timeout allowed",
@@ -459,6 +476,7 @@ main(void) {
     rc |= expect_true("mixed voice backoff armed", mixed_st.p25_retune_block_freq == g_last_tuned_vc
                                                        && mixed_st.p25_retune_block_slot == 1
                                                        && mixed_st.p25_retune_block_until > time(NULL));
+    mark_cc_reacquired(&mixed_st);
 
     p25_sm_event(&mixed_ctx, &mixed_opts, &mixed_st, &data_ev_slot1);
     rc |= expect_true("data grant bypasses voice backoff",
@@ -656,6 +674,7 @@ main(void) {
                                                             && g_return_to_cc_calls == 1
                                                             && data_after_cancel_ctx.state == P25_SM_ON_CC);
         rc |= expect_true("data-after-cancel no fallback backoff", retune_backoff_empty(&data_after_cancel_st));
+        mark_cc_reacquired(&data_after_cancel_st);
 
         p25_sm_event(&data_after_cancel_ctx, &data_after_cancel_opts, &data_after_cancel_st, &data_after_cancel_voice);
         rc |= expect_true("data-after-cancel follow-up voice allowed", g_tune_to_freq_calls == 2

--- a/tests/protocol/p25/test_p25_retune_backoff_slot.c
+++ b/tests/protocol/p25/test_p25_retune_backoff_slot.c
@@ -180,6 +180,8 @@ mark_cc_reacquired(dsd_state* state) {
     }
     state->last_cc_sync_time = time(NULL);
     state->last_cc_sync_time_m = now_m;
+    state->p25_last_cc_msg_time = state->last_cc_sync_time;
+    state->p25_last_cc_msg_time_m = now_m;
 }
 
 static int

--- a/tests/protocol/p25/test_p25_sm_cand_cooldown.c
+++ b/tests/protocol/p25/test_p25_sm_cand_cooldown.c
@@ -78,6 +78,27 @@ main(void) {
     g_last_tuned_cc = 0;
     p25_sm_tick(&o, &st);
     assert(g_last_tuned_cc == B);
+
+    static dsd_opts o2;
+    static dsd_state st2;
+    init_basic(&o2, &st2);
+    (void)dsd_trunk_cc_candidates_add(&st2, A, 0);
+    (void)dsd_trunk_cc_candidates_add(&st2, B, 0);
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    double pending_m = dsd_time_now_monotonic_s() - 2.5;
+    ctx->state = P25_SM_ON_CC;
+    ctx->config.cc_grace_s = 5.0;
+    ctx->t_cc_sync_m = pending_m;
+    ctx->t_cc_tune_m = pending_m;
+    ctx->cc_sync_pending = 1;
+    st2.last_cc_sync_time_m = pending_m;
+    st2.p25_cc_eval_freq = A;
+    st2.p25_cc_eval_start_m = pending_m;
+
+    g_last_tuned_cc = 0;
+    p25_sm_tick(&o2, &st2);
+    assert(g_last_tuned_cc == B);
     return 0;
 }
 

--- a/tests/protocol/p25/test_p25_sm_cand_cooldown.c
+++ b/tests/protocol/p25/test_p25_sm_cand_cooldown.c
@@ -13,6 +13,7 @@
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <math.h>
 #include <stdint.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -68,6 +69,7 @@ init_basic(dsd_opts* o, dsd_state* s) {
 
 int
 main(void) {
+    const double timestamp_epsilon_s = 1.0e-9;
     static dsd_opts o;
     static dsd_state st;
     install_trunk_tuning_hooks();
@@ -154,7 +156,7 @@ main(void) {
     assert(ctx->cc_tune_pending == 0);
     assert(ctx->cc_sync_pending == 1);
     assert(ctx->t_cc_tune_m > 0.0);
-    assert(st3.p25_cc_eval_start_m == ctx->t_cc_tune_m);
+    assert(fabs(st3.p25_cc_eval_start_m - ctx->t_cc_tune_m) <= timestamp_epsilon_s);
 
     // Only the post-completion acquisition window can fail A and advance to B.
     pending_m = dsd_time_now_monotonic_s() - 2.5;
@@ -212,7 +214,7 @@ main(void) {
     assert(ctx->cc_tune_pending == 0);
     assert(ctx->cc_tune_request_id == 0U);
     assert(ctx->t_cc_tune_m > 0.0);
-    assert(st4.p25_cc_eval_start_m == ctx->t_cc_tune_m);
+    assert(fabs(st4.p25_cc_eval_start_m - ctx->t_cc_tune_m) <= timestamp_epsilon_s);
     assert(dsd_trunk_tuning_pending_request() == 0U);
     assert(dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
     return 0;

--- a/tests/protocol/p25/test_p25_sm_cand_cooldown.c
+++ b/tests/protocol/p25/test_p25_sm_cand_cooldown.c
@@ -36,10 +36,16 @@ trunk_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
 }
 
 static dsd_trunk_tune_result
-trunk_tune_to_cc_result(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+trunk_tune_to_cc_request(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps, uint64_t request_id) {
+    (void)request_id;
     trunk_tune_to_cc(opts, state, freq, ted_sps);
     g_tune_to_cc_calls++;
     return g_tune_to_cc_result;
+}
+
+static dsd_trunk_tune_result
+trunk_tune_to_cc_legacy_result(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    return trunk_tune_to_cc_request(opts, state, freq, ted_sps, 0U);
 }
 
 static void
@@ -118,7 +124,7 @@ main(void) {
     (void)dsd_trunk_cc_candidates_add(&st3, B, 0);
     st3.last_cc_sync_time_m = dsd_time_now_monotonic_s() - 10.0;
     dsd_trunk_tuning_hooks pending_hooks = {0};
-    pending_hooks.tune_to_cc_result = trunk_tune_to_cc_result;
+    pending_hooks.tune_to_cc_request = trunk_tune_to_cc_request;
     dsd_trunk_tuning_hooks_set(pending_hooks);
     g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
     g_tune_to_cc_calls = 0;
@@ -185,6 +191,28 @@ main(void) {
     uint64_t recovery_request = dsd_trunk_tuning_request_begin();
     assert(recovery_request > failed_request);
     dsd_trunk_tuning_request_complete(recovery_request, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
+
+    // Legacy PENDING hooks are accepted without a correlation ID or wait state.
+    static dsd_opts o4;
+    static dsd_state st4;
+    init_basic(&o4, &st4);
+    (void)dsd_trunk_cc_candidates_add(&st4, A, 0);
+    st4.last_cc_sync_time_m = dsd_time_now_monotonic_s() - 10.0;
+    dsd_trunk_tuning_hooks legacy_hooks = {0};
+    legacy_hooks.tune_to_cc_result = trunk_tune_to_cc_legacy_result;
+    dsd_trunk_tuning_hooks_set(legacy_hooks);
+    g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    g_tune_to_cc_calls = 0;
+
+    p25_sm_tick(&o4, &st4);
+    ctx = p25_sm_get_ctx();
+    assert(g_tune_to_cc_calls == 1);
+    assert(ctx->cc_tune_pending == 0);
+    assert(ctx->cc_tune_request_id == 0U);
+    assert(ctx->t_cc_tune_m > 0.0);
+    assert(st4.p25_cc_eval_start_m == ctx->t_cc_tune_m);
     assert(dsd_trunk_tuning_pending_request() == 0U);
     assert(dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
     return 0;

--- a/tests/protocol/p25/test_p25_sm_cand_cooldown.c
+++ b/tests/protocol/p25/test_p25_sm_cand_cooldown.c
@@ -13,6 +13,7 @@
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -23,6 +24,8 @@
 #endif
 
 static long g_last_tuned_cc = 0;
+static int g_tune_to_cc_calls = 0;
+static dsd_trunk_tune_result g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
 void
 trunk_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) { // NOLINT(misc-use-internal-linkage)
@@ -30,6 +33,13 @@ trunk_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     (void)state;
     (void)ted_sps;
     g_last_tuned_cc = freq;
+}
+
+static dsd_trunk_tune_result
+trunk_tune_to_cc_result(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    trunk_tune_to_cc(opts, state, freq, ted_sps);
+    g_tune_to_cc_calls++;
+    return g_tune_to_cc_result;
 }
 
 static void
@@ -99,6 +109,84 @@ main(void) {
     g_last_tuned_cc = 0;
     p25_sm_tick(&o2, &st2);
     assert(g_last_tuned_cc == B);
+
+    // A controller timeout is an in-flight tune, not the start of CC acquisition.
+    static dsd_opts o3;
+    static dsd_state st3;
+    init_basic(&o3, &st3);
+    (void)dsd_trunk_cc_candidates_add(&st3, A, 0);
+    (void)dsd_trunk_cc_candidates_add(&st3, B, 0);
+    st3.last_cc_sync_time_m = dsd_time_now_monotonic_s() - 10.0;
+    dsd_trunk_tuning_hooks pending_hooks = {0};
+    pending_hooks.tune_to_cc_result = trunk_tune_to_cc_result;
+    dsd_trunk_tuning_hooks_set(pending_hooks);
+    g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    g_tune_to_cc_calls = 0;
+    g_last_tuned_cc = 0;
+
+    p25_sm_tick(&o3, &st3);
+    ctx = p25_sm_get_ctx();
+    assert(g_tune_to_cc_calls == 1);
+    assert(g_last_tuned_cc == A);
+    assert(ctx->cc_tune_pending == 1);
+    assert(ctx->cc_tune_request_id != 0U);
+    assert(ctx->t_cc_tune_m == 0.0);
+    assert(st3.p25_cc_eval_freq == A);
+    assert(st3.p25_cc_eval_start_m == 0.0);
+
+    // Repeated watchdog ticks cannot cool A or queue B before completion.
+    p25_sm_tick(&o3, &st3);
+    p25_sm_tick(&o3, &st3);
+    assert(g_tune_to_cc_calls == 1);
+    assert(ctx->cc_tune_pending == 1);
+    assert(ctx->t_cc_tune_m == 0.0);
+
+    uint64_t pending_request = ctx->cc_tune_request_id;
+    dsd_trunk_tuning_request_complete(pending_request, DSD_TRUNK_TUNE_RESULT_OK);
+    p25_sm_tick(&o3, &st3);
+    assert(g_tune_to_cc_calls == 1);
+    assert(ctx->cc_tune_pending == 0);
+    assert(ctx->cc_sync_pending == 1);
+    assert(ctx->t_cc_tune_m > 0.0);
+    assert(st3.p25_cc_eval_start_m == ctx->t_cc_tune_m);
+
+    // Only the post-completion acquisition window can fail A and advance to B.
+    pending_m = dsd_time_now_monotonic_s() - 2.5;
+    ctx->t_cc_sync_m = pending_m;
+    ctx->t_cc_tune_m = pending_m;
+    st3.last_cc_sync_time_m = pending_m;
+    st3.p25_cc_eval_start_m = pending_m;
+    p25_sm_tick(&o3, &st3);
+    assert(g_tune_to_cc_calls == 2);
+    assert(g_last_tuned_cc == B);
+
+    // A terminal asynchronous failure stays gated while the SM selects a
+    // replacement target.
+    uint64_t failed_request = ctx->cc_tune_request_id;
+    assert(failed_request != 0U);
+    const double stale_decoded_m = dsd_time_now_monotonic_s() - 10.0;
+    st3.p25_last_cc_msg_time_m = stale_decoded_m;
+    g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    dsd_trunk_tuning_request_publish(failed_request, DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(!dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
+    p25_sm_tick(&o3, &st3);
+    assert(g_tune_to_cc_calls == 3);
+    assert(ctx->state == P25_SM_HUNTING);
+    assert(ctx->cc_sync_pending == 0);
+    assert(ctx->t_cc_sync_m > stale_decoded_m);
+    assert(dsd_trunk_tuning_pending_request() == failed_request);
+    assert(!dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
+
+    // Stale decoded activity cannot masquerade as acquisition after failure.
+    p25_sm_tick(&o3, &st3);
+    assert(ctx->state == P25_SM_HUNTING);
+
+    // A later successful replacement commits the new target and reopens dispatch.
+    uint64_t recovery_request = dsd_trunk_tuning_request_begin();
+    assert(recovery_request > failed_request);
+    dsd_trunk_tuning_request_complete(recovery_request, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
     return 0;
 }
 

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -1445,6 +1445,79 @@ main(void) {
     assert(ctx23.state == P25_SM_ON_CC);
     g_result_hook_commits_decoder_state = 1;
 
+    // 32) Externally cleared tune state still needs the complete decoder-side
+    // release teardown, but it must not issue another CC retune or reset stats.
+    static dsd_opts o24;
+    static dsd_state s24;
+    DSD_MEMSET(&o24, 0, sizeof(o24));
+    DSD_MEMSET(&s24, 0, sizeof(s24));
+    o24.p25_trunk = 1;
+    s24.p25_cc_freq = 851000000;
+    s24.trunk_cc_freq = 851000000;
+    s24.last_cc_sync_time_m = dsd_time_now_monotonic_s();
+
+    p25_sm_ctx_t ctx24;
+    p25_sm_init_ctx(&ctx24, &o24, &s24);
+    ctx24.state = P25_SM_TUNED;
+    ctx24.vc_freq_hz = 851125000;
+    ctx24.vc_channel = ch9;
+    ctx24.vc_tg = 6201;
+    ctx24.slots[0].grant_active = 1;
+    ctx24.slots[0].tg = 6201;
+    ctx24.tune_count = 23;
+    ctx24.release_count = 29;
+    ctx24.grant_count = 30;
+    ctx24.cc_return_count = 31;
+    s24.p25_sm_release_count = 37;
+    s24.p25_p2_audio_allowed[0] = 1;
+    s24.p25_p2_audio_allowed[1] = 1;
+    s24.p25_p2_active_slot = 0;
+    s24.payload_algid = 0x80;
+    s24.payload_algidR = 0x81;
+    s24.payload_keyid = 0x1234;
+    s24.payload_keyidR = 0x5678;
+    s24.dmr_so = 0x40;
+    s24.dmr_soR = 0x41;
+    s24.p25_service_options_valid[0] = 1;
+    s24.p25_service_options_valid[1] = 1;
+    s24.p25_p2_enc_lockout_muted[0] = 1;
+    s24.p25_p2_enc_lockout_muted[1] = 1;
+    s24.p25_policy_tg[0] = 6201;
+    s24.p25_policy_tg[1] = 6202;
+
+    dsd_tg_policy_call_route active_route = {6201U, 7201U, 851125000L, 1, 0, 0};
+    dsd_tg_policy_decision active_decision = {0};
+    active_decision.priority = 10;
+    active_decision.tune_allowed = 1;
+    assert(dsd_tg_policy_note_active_call(&s24, &active_route, &active_decision, 1.0) == 0);
+    dsd_tg_policy_call_route candidate_route = {6202U, 7202U, 851250000L, 2, 0, 1};
+    dsd_tg_policy_decision candidate_decision = {0};
+    candidate_decision.priority = 20;
+    candidate_decision.tune_allowed = 1;
+    candidate_decision.preempt_requested = 1;
+    assert(dsd_tg_policy_should_preempt(&o24, &s24, &candidate_route, &candidate_decision, 10.0) == 1);
+
+    g_result_return_to_cc_calls = 0;
+    p25_sm_release(&ctx24, &o24, &s24, "external-return-stale-context");
+    assert(g_result_return_to_cc_calls == 0);
+    assert(ctx24.state == P25_SM_ON_CC);
+    assert(ctx24.vc_freq_hz == 0 && ctx24.vc_channel == 0 && ctx24.vc_tg == 0);
+    assert(ctx24.slots[0].grant_active == 0);
+    assert(ctx24.tune_count == 23);
+    assert(ctx24.release_count == 30);
+    assert(ctx24.grant_count == 30);
+    assert(ctx24.cc_return_count == 32);
+    assert(s24.p25_sm_release_count == 38);
+    assert(s24.p25_p2_audio_allowed[0] == 0 && s24.p25_p2_audio_allowed[1] == 0);
+    assert(s24.p25_p2_active_slot == -1);
+    assert(s24.payload_algid == 0 && s24.payload_algidR == 0);
+    assert(s24.payload_keyid == 0 && s24.payload_keyidR == 0);
+    assert(s24.dmr_so == 0 && s24.dmr_soR == 0);
+    assert(s24.p25_service_options_valid[0] == 0 && s24.p25_service_options_valid[1] == 0);
+    assert(s24.p25_p2_enc_lockout_muted[0] == 0 && s24.p25_p2_enc_lockout_muted[1] == 0);
+    assert(s24.p25_policy_tg[0] == 0 && s24.p25_policy_tg[1] == 0);
+    assert(dsd_tg_policy_should_preempt(&o24, &s24, &candidate_route, &candidate_decision, 10.0) == 0);
+
     install_trunk_tuning_hooks();
 
     DSD_FPRINTF(stderr, "P25 SM core tests passed\n");

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -607,6 +607,7 @@ main(void) {
     o14b.audio_in_type = AUDIO_IN_RTL;
     o14b.rtlsdr_center_freq = 851012500U;
     s14b.synctype = DSD_SYNC_P25P2_POS;
+    s14b.p25_cc_is_tdma = 2;
     s14b.p25_iden_fdma[id9].base_freq = 851000000 / 5;
     s14b.p25_iden_fdma[id9].chan_type = 1;
     s14b.p25_iden_fdma[id9].chan_spac = 100;
@@ -623,7 +624,7 @@ main(void) {
     assert(s14b.p25_cc_freq == 851012500);
     assert(s14b.trunk_cc_freq == 851012500);
     assert(s14b.trunk_lcn_freq[0] == 851012500);
-    assert(s14b.p25_cc_is_tdma == 1);
+    assert(s14b.p25_cc_is_tdma == 2);
     assert(o14b.p25_is_tuned == 0);
     assert(s14b.p25_sm_tune_count == 0);
     assert(ctx14b.state == P25_SM_ON_CC);
@@ -775,7 +776,34 @@ main(void) {
     assert(ctx18.state == P25_SM_ON_CC);
     assert(g_result_tune_to_cc_calls == cc_calls_before_seeded_release_tick);
 
-    // 20) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
+    // 20) A CC retune that does not produce decoded CC activity should hunt before full stale-CC grace.
+    static dsd_opts o18b;
+    static dsd_state s18b;
+    DSD_MEMSET(&o18b, 0, sizeof(o18b));
+    DSD_MEMSET(&s18b, 0, sizeof(s18b));
+    o18b.p25_trunk = 1;
+    o18b.p25_prefer_candidates = 1;
+    s18b.p25_cc_freq = 851000000;
+    s18b.trunk_cc_freq = 851000000;
+    (void)dsd_trunk_cc_candidates_add(&s18b, 852000000, 0);
+    p25_sm_ctx_t ctx18b;
+    p25_sm_init_ctx(&ctx18b, &o18b, &s18b);
+    ctx18b.config.cc_grace_s = 5.0;
+    const double pending_cc_tune_m = dsd_time_now_monotonic_s() - 2.5;
+    ctx18b.t_cc_sync_m = pending_cc_tune_m;
+    ctx18b.t_cc_tune_m = pending_cc_tune_m;
+    ctx18b.cc_sync_pending = 1;
+    s18b.last_cc_sync_time = time(NULL) - 3;
+    s18b.last_cc_sync_time_m = pending_cc_tune_m;
+    g_result_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_result_tune_to_cc_calls = 0;
+    g_last_tuned_cc = 0;
+    p25_sm_tick_ctx(&ctx18b, &o18b, &s18b);
+    assert(g_result_tune_to_cc_calls == 1);
+    assert(g_last_tuned_cc == 852000000);
+    assert(ctx18b.state == P25_SM_ON_CC);
+
+    // 21) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
     static dsd_opts o19a;
     static dsd_state s19a;
     DSD_MEMSET(&o19a, 0, sizeof(o19a));

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -18,6 +18,7 @@
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/rigctl_query_hooks.h>
+#include <math.h>
 #ifdef USE_RADIO
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #endif
@@ -963,7 +964,7 @@ main(void) {
     assert(ctx18c.state == P25_SM_ON_CC);
     assert(ctx18c.cc_sync_pending == 0);
     assert(ctx18c.t_cc_tune_m == 0.0);
-    assert(ctx18c.t_cc_sync_m == s18c.p25_last_cc_msg_time_m);
+    assert(fabs(ctx18c.t_cc_sync_m - s18c.p25_last_cc_msg_time_m) <= cc_sync_epsilon_s);
 
     g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
     p25_sm_event(&ctx18c, &o18c, &s18c, &ev9);
@@ -999,12 +1000,12 @@ main(void) {
     assert(p25_sm_restart_pending_cc_acquisition(&ctx18d, &o18d, &s18d, external_cc_tune_m, "test-retune") == 1);
     assert(ctx18d.state == P25_SM_ON_CC);
     assert(ctx18d.cc_sync_pending == 1);
-    assert(ctx18d.t_cc_sync_m == external_cc_tune_m);
-    assert(ctx18d.t_cc_tune_m == external_cc_tune_m);
+    assert(fabs(ctx18d.t_cc_sync_m - external_cc_tune_m) <= cc_sync_epsilon_s);
+    assert(fabs(ctx18d.t_cc_tune_m - external_cc_tune_m) <= cc_sync_epsilon_s);
     assert(ctx18d.t_hunt_try_m == 0.0);
     assert(s18d.p25_sm_mode == DSD_P25_SM_MODE_ON_CC);
-    assert(s18d.last_cc_sync_time_m == external_cc_tune_m);
-    assert(s18d.p25_last_cc_msg_time_m == external_decoded_cc_m);
+    assert(fabs(s18d.last_cc_sync_time_m - external_cc_tune_m) <= cc_sync_epsilon_s);
+    assert(fabs(s18d.p25_last_cc_msg_time_m - external_decoded_cc_m) <= cc_sync_epsilon_s);
 
     // 24) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
     static dsd_opts o19a;

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -24,6 +24,7 @@
 #endif
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -1012,7 +1013,47 @@ main(void) {
     assert(fabs(s18d.last_cc_sync_time_m - external_cc_tune_m) <= cc_sync_epsilon_s);
     assert(fabs(s18d.p25_last_cc_msg_time_m - external_decoded_cc_m) <= cc_sync_epsilon_s);
 
-    // 24) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
+    // 24) The first decoded grant after asynchronous completion must satisfy CC reacquisition.
+    static dsd_opts o18e;
+    static dsd_state s18e;
+    DSD_MEMSET(&o18e, 0, sizeof(o18e));
+    DSD_MEMSET(&s18e, 0, sizeof(s18e));
+    o18e.p25_trunk = 1;
+    o18e.trunk_tune_group_calls = 1;
+    s18e.p25_cc_freq = 851000000;
+    s18e.trunk_cc_freq = 851000000;
+    s18e.p25_iden_fdma[id9] = s9.p25_iden_fdma[id9];
+    s18e.p25_chan_tdma_explicit[id9] = 1;
+    p25_sm_ctx_t ctx18e;
+    p25_sm_init_ctx(&ctx18e, &o18e, &s18e);
+    ctx18e.state = P25_SM_ON_CC;
+    s18e.p25_sm_mode = DSD_P25_SM_MODE_ON_CC;
+
+    const uint64_t early_grant_request_id = dsd_trunk_tuning_request_begin();
+    assert(early_grant_request_id != 0U);
+    dsd_trunk_tuning_request_mark_ready(early_grant_request_id);
+    assert(p25_sm_await_pending_cc_tune(&ctx18e, &o18e, &s18e, early_grant_request_id, "test-early-grant") == 1);
+    dsd_trunk_tuning_request_publish(early_grant_request_id, DSD_TRUNK_TUNE_RESULT_OK);
+
+    double early_grant_completion_m = 0.0;
+    assert(dsd_trunk_tuning_request_status(early_grant_request_id, &early_grant_completion_m)
+           == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(early_grant_completion_m > 0.0);
+    const double early_grant_decoded_m = early_grant_completion_m + 0.001;
+    s18e.last_cc_sync_time = time(NULL);
+    s18e.last_cc_sync_time_m = early_grant_decoded_m;
+    s18e.p25_last_cc_msg_time = s18e.last_cc_sync_time;
+    s18e.p25_last_cc_msg_time_m = early_grant_decoded_m;
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_result_tune_to_freq_calls = 0;
+
+    p25_sm_event(&ctx18e, &o18e, &s18e, &ev9);
+    assert(ctx18e.cc_tune_pending == 0);
+    assert(ctx18e.cc_sync_pending == 0);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(ctx18e.state == P25_SM_TUNED);
+
+    // 25) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
     static dsd_opts o19a;
     static dsd_state s19a;
     DSD_MEMSET(&o19a, 0, sizeof(o19a));
@@ -1048,7 +1089,7 @@ main(void) {
     assert(ctx19a.state == P25_SM_TUNED);
     assert(ctx19a.slots[1].grant_active == 1);
 
-    // 25) ENC lockout must keep a clear opposite-slot grant pending on the same TDMA carrier.
+    // 26) ENC lockout must keep a clear opposite-slot grant pending on the same TDMA carrier.
     static dsd_opts o19b;
     static dsd_state s19b;
     DSD_MEMSET(&o19b, 0, sizeof(o19b));
@@ -1088,7 +1129,7 @@ main(void) {
     assert(s19b.p25_p2_enc_lockout_muted[0] == 1);
 
 #ifdef USE_RADIO
-    // 26) A failed CQPSK retry must roll back the one-shot override and TDMA timing.
+    // 27) A failed CQPSK retry must roll back the one-shot override and TDMA timing.
     static dsd_opts o19;
     static dsd_state s19;
     DSD_MEMSET(&o19, 0, sizeof(o19));
@@ -1136,7 +1177,7 @@ main(void) {
     assert(ctx19.state == P25_SM_TUNED);
     g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
 
-    // 27) A successful CQPSK retry refreshes the TDMA grant timeout window.
+    // 28) A successful CQPSK retry refreshes the TDMA grant timeout window.
     static dsd_opts o20;
     static dsd_state s20;
     DSD_MEMSET(&o20, 0, sizeof(o20));
@@ -1186,7 +1227,7 @@ main(void) {
     assert(s20.p25_retune_block_until == 0);
 #endif
 
-    // 28) A concurrent stale-context release must not reset a release already in progress.
+    // 29) A concurrent stale-context release must not reset a release already in progress.
     static dsd_opts o21;
     static dsd_state s21;
     DSD_MEMSET(&o21, 0, sizeof(o21));
@@ -1308,7 +1349,7 @@ main(void) {
         return 1;
     }
 
-    // 29) Hardware-only legacy VC hooks still receive their return callback.
+    // 30) Hardware-only legacy VC hooks still receive their return callback.
     install_trunk_tuning_hooks();
     static dsd_opts o22;
     static dsd_state s22;
@@ -1336,7 +1377,7 @@ main(void) {
     assert(g_return_to_cc_called == 1);
     assert(ctx22.state == P25_SM_ON_CC);
 
-    // 30) Result hooks may control hardware without duplicating decoder bookkeeping.
+    // 31) Result hooks may control hardware without duplicating decoder bookkeeping.
     install_result_tuning_hooks();
     static dsd_opts o23;
     static dsd_state s23;

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -46,6 +46,7 @@ static dsd_trunk_tune_result g_result_return_to_cc_result = DSD_TRUNK_TUNE_RESUL
 static int g_result_tune_to_freq_calls = 0;
 static int g_result_tune_to_cc_calls = 0;
 static int g_result_return_to_cc_calls = 0;
+static int g_result_hook_commits_decoder_state = 1;
 static long g_rigctl_current_freq = 0;
 static atomic_int g_release_hook_block = 0;
 static dsd_mutex_t g_release_hook_mutex;
@@ -99,7 +100,7 @@ trunk_tune_to_freq_result(dsd_opts* opts, dsd_state* state, long int freq, int t
     (void)ted_sps;
     g_result_tune_to_freq_calls++;
     g_last_tuned_vc = freq;
-    if (g_result_tune_to_freq_result == DSD_TRUNK_TUNE_RESULT_OK) {
+    if (g_result_tune_to_freq_result == DSD_TRUNK_TUNE_RESULT_OK && g_result_hook_commits_decoder_state) {
         if (opts) {
             opts->p25_is_tuned = 1;
             opts->trunk_is_tuned = 1;
@@ -1306,6 +1307,61 @@ main(void) {
                     release_mutex_destroy_rc);
         return 1;
     }
+
+    // 29) Hardware-only legacy VC hooks still receive their return callback.
+    install_trunk_tuning_hooks();
+    static dsd_opts o22;
+    static dsd_state s22;
+    DSD_MEMSET(&o22, 0, sizeof(o22));
+    DSD_MEMSET(&s22, 0, sizeof(s22));
+    o22.p25_trunk = 1;
+    o22.trunk_tune_group_calls = 1;
+    s22.p25_cc_freq = 851000000;
+    s22.trunk_cc_freq = 851000000;
+    s22.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s22.p25_iden_fdma[id9].chan_type = 1;
+    s22.p25_iden_fdma[id9].chan_spac = 100;
+    s22.p25_iden_fdma[id9].trust = 2;
+    s22.p25_iden_fdma[id9].populated = 1;
+    s22.p25_chan_tdma_explicit[id9] = 1;
+    p25_sm_ctx_t ctx22;
+    p25_sm_init_ctx(&ctx22, &o22, &s22);
+    g_return_to_cc_called = 0;
+    p25_sm_event(&ctx22, &o22, &s22, &ev9);
+    assert(ctx22.state == P25_SM_TUNED);
+    assert(o22.p25_is_tuned == 1 && o22.trunk_is_tuned == 1);
+    assert(s22.p25_vc_freq[0] == ctx22.vc_freq_hz && s22.trunk_vc_freq[0] == ctx22.vc_freq_hz);
+    assert(s22.last_vc_sync_time_m > 0.0 && s22.p25_last_vc_tune_time_m > 0.0);
+    p25_sm_release(&ctx22, &o22, &s22, "legacy-hook-release");
+    assert(g_return_to_cc_called == 1);
+    assert(ctx22.state == P25_SM_ON_CC);
+
+    // 30) Result hooks may control hardware without duplicating decoder bookkeeping.
+    install_result_tuning_hooks();
+    static dsd_opts o23;
+    static dsd_state s23;
+    DSD_MEMSET(&o23, 0, sizeof(o23));
+    DSD_MEMSET(&s23, 0, sizeof(s23));
+    o23.p25_trunk = 1;
+    o23.trunk_tune_group_calls = 1;
+    s23.p25_cc_freq = 851000000;
+    s23.trunk_cc_freq = 851000000;
+    s23.p25_iden_fdma[id9] = s22.p25_iden_fdma[id9];
+    s23.p25_chan_tdma_explicit[id9] = 1;
+    p25_sm_ctx_t ctx23;
+    p25_sm_init_ctx(&ctx23, &o23, &s23);
+    g_result_hook_commits_decoder_state = 0;
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_result_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_result_return_to_cc_calls = 0;
+    p25_sm_event(&ctx23, &o23, &s23, &ev9);
+    assert(ctx23.state == P25_SM_TUNED);
+    assert(o23.p25_is_tuned == 1 && o23.trunk_is_tuned == 1);
+    assert(s23.p25_vc_freq[0] == ctx23.vc_freq_hz && s23.trunk_vc_freq[0] == ctx23.vc_freq_hz);
+    p25_sm_release(&ctx23, &o23, &s23, "result-hook-release");
+    assert(g_result_return_to_cc_calls == 1);
+    assert(ctx23.state == P25_SM_ON_CC);
+    g_result_hook_commits_decoder_state = 1;
 
     install_trunk_tuning_hooks();
 

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -902,7 +902,8 @@ main(void) {
     assert(g_last_tuned_cc == 852000000);
     assert(ctx18b.state == P25_SM_ON_CC);
 
-    // 22) HUNTING must keep grants blocked until decoded CC activity proves reacquisition.
+    // 22) HUNTING must keep grants blocked until decoded CC activity proves reacquisition,
+    // then recover even when that activity is not a grant.
     static dsd_opts o18c;
     static dsd_state s18c;
     DSD_MEMSET(&o18c, 0, sizeof(o18c));
@@ -947,13 +948,27 @@ main(void) {
     assert(ctx18c.state == P25_SM_HUNTING);
     assert(ctx18c.cc_sync_pending == 1);
 
+    int cc_calls_before_hunt_recovery = g_result_tune_to_cc_calls;
+    p25_sm_tick_ctx(&ctx18c, &o18c, &s18c);
+    assert(g_result_tune_to_cc_calls == cc_calls_before_hunt_recovery);
+    assert(ctx18c.state == P25_SM_HUNTING);
+    assert(ctx18c.cc_sync_pending == 1);
+
     s18c.p25_last_cc_msg_time = time(NULL);
     s18c.p25_last_cc_msg_time_m = hunting_pending_tune_m + 0.25;
+    ctx18c.t_hunt_try_m = 0.0;
+    p25_sm_tick_ctx(&ctx18c, &o18c, &s18c);
+    assert(g_result_tune_to_cc_calls == cc_calls_before_hunt_recovery);
+    assert(g_result_tune_to_freq_calls == 0);
+    assert(ctx18c.state == P25_SM_ON_CC);
+    assert(ctx18c.cc_sync_pending == 0);
+    assert(ctx18c.t_cc_tune_m == 0.0);
+    assert(ctx18c.t_cc_sync_m == s18c.p25_last_cc_msg_time_m);
+
     g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
     p25_sm_event(&ctx18c, &o18c, &s18c, &ev9);
     assert(g_result_tune_to_freq_calls == 1);
     assert(ctx18c.state == P25_SM_ON_CC);
-    assert(ctx18c.cc_sync_pending == 0);
 
     g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
     p25_sm_event(&ctx18c, &o18c, &s18c, &ev9);
@@ -961,7 +976,37 @@ main(void) {
     assert(ctx18c.state == P25_SM_TUNED);
     g_result_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
-    // 23) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
+    // 23) An accepted external CC retune restarts pending acquisition in ON_CC.
+    static dsd_opts o18d;
+    static dsd_state s18d;
+    DSD_MEMSET(&o18d, 0, sizeof(o18d));
+    DSD_MEMSET(&s18d, 0, sizeof(s18d));
+    o18d.p25_trunk = 1;
+    s18d.p25_cc_freq = 851000000;
+    s18d.trunk_cc_freq = 851000000;
+    p25_sm_ctx_t ctx18d;
+    p25_sm_init_ctx(&ctx18d, &o18d, &s18d);
+    const double external_cc_tune_m = 100.0;
+    const double external_decoded_cc_m = external_cc_tune_m - 2.0;
+    ctx18d.state = P25_SM_HUNTING;
+    ctx18d.cc_sync_pending = 1;
+    ctx18d.t_cc_sync_m = external_cc_tune_m - 3.0;
+    ctx18d.t_cc_tune_m = external_cc_tune_m - 3.0;
+    ctx18d.t_hunt_try_m = external_cc_tune_m - 1.0;
+    s18d.p25_sm_mode = DSD_P25_SM_MODE_HUNTING;
+    s18d.last_cc_sync_time_m = external_cc_tune_m - 3.0;
+    s18d.p25_last_cc_msg_time_m = external_decoded_cc_m;
+    assert(p25_sm_restart_pending_cc_acquisition(&ctx18d, &o18d, &s18d, external_cc_tune_m, "test-retune") == 1);
+    assert(ctx18d.state == P25_SM_ON_CC);
+    assert(ctx18d.cc_sync_pending == 1);
+    assert(ctx18d.t_cc_sync_m == external_cc_tune_m);
+    assert(ctx18d.t_cc_tune_m == external_cc_tune_m);
+    assert(ctx18d.t_hunt_try_m == 0.0);
+    assert(s18d.p25_sm_mode == DSD_P25_SM_MODE_ON_CC);
+    assert(s18d.last_cc_sync_time_m == external_cc_tune_m);
+    assert(s18d.p25_last_cc_msg_time_m == external_decoded_cc_m);
+
+    // 24) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
     static dsd_opts o19a;
     static dsd_state s19a;
     DSD_MEMSET(&o19a, 0, sizeof(o19a));
@@ -997,7 +1042,7 @@ main(void) {
     assert(ctx19a.state == P25_SM_TUNED);
     assert(ctx19a.slots[1].grant_active == 1);
 
-    // 24) ENC lockout must keep a clear opposite-slot grant pending on the same TDMA carrier.
+    // 25) ENC lockout must keep a clear opposite-slot grant pending on the same TDMA carrier.
     static dsd_opts o19b;
     static dsd_state s19b;
     DSD_MEMSET(&o19b, 0, sizeof(o19b));
@@ -1037,7 +1082,7 @@ main(void) {
     assert(s19b.p25_p2_enc_lockout_muted[0] == 1);
 
 #ifdef USE_RADIO
-    // 25) A failed CQPSK retry must roll back the one-shot override and TDMA timing.
+    // 26) A failed CQPSK retry must roll back the one-shot override and TDMA timing.
     static dsd_opts o19;
     static dsd_state s19;
     DSD_MEMSET(&o19, 0, sizeof(o19));
@@ -1085,7 +1130,7 @@ main(void) {
     assert(ctx19.state == P25_SM_TUNED);
     g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
 
-    // 26) A successful CQPSK retry refreshes the TDMA grant timeout window.
+    // 27) A successful CQPSK retry refreshes the TDMA grant timeout window.
     static dsd_opts o20;
     static dsd_state s20;
     DSD_MEMSET(&o20, 0, sizeof(o20));
@@ -1135,7 +1180,7 @@ main(void) {
     assert(s20.p25_retune_block_until == 0);
 #endif
 
-    // 27) A concurrent stale-context release must not reset a release already in progress.
+    // 28) A concurrent stale-context release must not reset a release already in progress.
     static dsd_opts o21;
     static dsd_state s21;
     DSD_MEMSET(&o21, 0, sizeof(o21));

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -776,7 +776,49 @@ main(void) {
     assert(ctx18.state == P25_SM_ON_CC);
     assert(g_result_tune_to_cc_calls == cc_calls_before_seeded_release_tick);
 
-    // 20) A CC retune that does not produce decoded CC activity should hunt before full stale-CC grace.
+    // 20) Grants observed before decoded CC activity after a CC retune must not pull us back to a VC.
+    static dsd_opts o18aa;
+    static dsd_state s18aa;
+    DSD_MEMSET(&o18aa, 0, sizeof(o18aa));
+    DSD_MEMSET(&s18aa, 0, sizeof(s18aa));
+    o18aa.p25_trunk = 1;
+    o18aa.trunk_tune_group_calls = 1;
+    s18aa.p25_cc_freq = 851000000;
+    s18aa.trunk_cc_freq = 851000000;
+    s18aa.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s18aa.p25_iden_fdma[id9].chan_type = 1;
+    s18aa.p25_iden_fdma[id9].chan_spac = 100;
+    s18aa.p25_iden_fdma[id9].trust = 2;
+    s18aa.p25_iden_fdma[id9].populated = 1;
+    s18aa.p25_chan_tdma_explicit[id9] = 1;
+    p25_sm_ctx_t ctx18aa;
+    p25_sm_init_ctx(&ctx18aa, &o18aa, &s18aa);
+    const double pending_grant_cc_tune_m = dsd_time_now_monotonic_s();
+    ctx18aa.state = P25_SM_ON_CC;
+    ctx18aa.t_cc_sync_m = pending_grant_cc_tune_m - 0.25;
+    ctx18aa.t_cc_tune_m = pending_grant_cc_tune_m;
+    ctx18aa.cc_sync_pending = 1;
+    s18aa.last_cc_sync_time_m = pending_grant_cc_tune_m - 0.10;
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_result_tune_to_freq_calls = 0;
+    p25_sm_event(&ctx18aa, &o18aa, &s18aa, &ev9);
+    assert(g_result_tune_to_freq_calls == 0);
+    assert(ctx18aa.state == P25_SM_ON_CC);
+    assert(ctx18aa.cc_sync_pending == 1);
+
+    s18aa.last_cc_sync_time_m = pending_grant_cc_tune_m;
+    p25_sm_event(&ctx18aa, &o18aa, &s18aa, &ev9);
+    assert(g_result_tune_to_freq_calls == 0);
+    assert(ctx18aa.state == P25_SM_ON_CC);
+    assert(ctx18aa.cc_sync_pending == 1);
+
+    s18aa.last_cc_sync_time_m = pending_grant_cc_tune_m + 0.25;
+    p25_sm_event(&ctx18aa, &o18aa, &s18aa, &ev9);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(ctx18aa.state == P25_SM_TUNED);
+    assert(ctx18aa.cc_sync_pending == 0);
+
+    // 21) A CC retune that does not produce decoded CC activity should hunt before full stale-CC grace.
     static dsd_opts o18b;
     static dsd_state s18b;
     DSD_MEMSET(&o18b, 0, sizeof(o18b));
@@ -803,7 +845,7 @@ main(void) {
     assert(g_last_tuned_cc == 852000000);
     assert(ctx18b.state == P25_SM_ON_CC);
 
-    // 21) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
+    // 22) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
     static dsd_opts o19a;
     static dsd_state s19a;
     DSD_MEMSET(&o19a, 0, sizeof(o19a));
@@ -839,7 +881,7 @@ main(void) {
     assert(ctx19a.state == P25_SM_TUNED);
     assert(ctx19a.slots[1].grant_active == 1);
 
-    // 21) ENC lockout must keep a clear opposite-slot grant pending on the same TDMA carrier.
+    // 23) ENC lockout must keep a clear opposite-slot grant pending on the same TDMA carrier.
     static dsd_opts o19b;
     static dsd_state s19b;
     DSD_MEMSET(&o19b, 0, sizeof(o19b));
@@ -879,7 +921,7 @@ main(void) {
     assert(s19b.p25_p2_enc_lockout_muted[0] == 1);
 
 #ifdef USE_RADIO
-    // 22) A failed CQPSK retry must roll back the one-shot override and TDMA timing.
+    // 24) A failed CQPSK retry must roll back the one-shot override and TDMA timing.
     static dsd_opts o19;
     static dsd_state s19;
     DSD_MEMSET(&o19, 0, sizeof(o19));
@@ -927,7 +969,7 @@ main(void) {
     assert(ctx19.state == P25_SM_TUNED);
     g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
 
-    // 23) A successful CQPSK retry refreshes the TDMA grant timeout window.
+    // 25) A successful CQPSK retry refreshes the TDMA grant timeout window.
     static dsd_opts o20;
     static dsd_state s20;
     DSD_MEMSET(&o20, 0, sizeof(o20));

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -11,7 +11,10 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/platform/atomic_compat.h>
+#include <dsd-neo/platform/platform.h>
 #include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/platform/threading.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/rigctl_query_hooks.h>
@@ -43,6 +46,15 @@ static int g_result_tune_to_freq_calls = 0;
 static int g_result_tune_to_cc_calls = 0;
 static int g_result_return_to_cc_calls = 0;
 static long g_rigctl_current_freq = 0;
+static atomic_int g_release_hook_block = 0;
+static dsd_mutex_t g_release_hook_mutex;
+static dsd_cond_t g_release_hook_cond;
+static int g_release_hook_entered = 0;
+
+typedef struct {
+    dsd_opts* opts;
+    dsd_state* state;
+} release_thread_args;
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
@@ -114,10 +126,43 @@ trunk_tune_to_cc_result(dsd_opts* opts, dsd_state* state, long int freq, int ted
 
 static dsd_trunk_tune_result
 return_to_cc_result(dsd_opts* opts, dsd_state* state) {
-    (void)opts;
-    (void)state;
     g_result_return_to_cc_calls++;
+    if (atomic_load(&g_release_hook_block)) {
+        int sync_rc = 0;
+        if (opts) {
+            opts->p25_is_tuned = 0;
+            opts->trunk_is_tuned = 0;
+        }
+        if (state) {
+            state->p25_vc_freq[0] = state->p25_vc_freq[1] = 0;
+            state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = 0;
+        }
+        sync_rc = dsd_mutex_lock(&g_release_hook_mutex);
+        if (sync_rc != 0) {
+            atomic_store(&g_release_hook_block, 0);
+            return DSD_TRUNK_TUNE_RESULT_FAILED;
+        }
+        g_release_hook_entered = 1;
+        sync_rc = dsd_cond_signal(&g_release_hook_cond);
+        while (sync_rc == 0 && atomic_load(&g_release_hook_block)) {
+            sync_rc = dsd_cond_wait(&g_release_hook_cond, &g_release_hook_mutex);
+        }
+        if (dsd_mutex_unlock(&g_release_hook_mutex) != 0 || sync_rc != 0) {
+            atomic_store(&g_release_hook_block, 0);
+            return DSD_TRUNK_TUNE_RESULT_FAILED;
+        }
+    }
     return g_result_return_to_cc_result;
+}
+
+static DSD_THREAD_RETURN_TYPE
+#if DSD_PLATFORM_WIN_NATIVE
+    __stdcall
+#endif
+    release_wrapper_thread(void* arg) {
+    release_thread_args* args = (release_thread_args*)arg;
+    p25_sm_on_release(args ? args->opts : NULL, args ? args->state : NULL);
+    DSD_THREAD_RETURN;
 }
 
 static void
@@ -857,7 +902,66 @@ main(void) {
     assert(g_last_tuned_cc == 852000000);
     assert(ctx18b.state == P25_SM_ON_CC);
 
-    // 22) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
+    // 22) HUNTING must keep grants blocked until decoded CC activity proves reacquisition.
+    static dsd_opts o18c;
+    static dsd_state s18c;
+    DSD_MEMSET(&o18c, 0, sizeof(o18c));
+    DSD_MEMSET(&s18c, 0, sizeof(s18c));
+    o18c.p25_trunk = 1;
+    o18c.trunk_tune_group_calls = 1;
+    s18c.p25_cc_freq = 851000000;
+    s18c.trunk_cc_freq = 851000000;
+    s18c.p25_iden_fdma[id9].base_freq = 851000000 / 5;
+    s18c.p25_iden_fdma[id9].chan_type = 1;
+    s18c.p25_iden_fdma[id9].chan_spac = 100;
+    s18c.p25_iden_fdma[id9].trust = 2;
+    s18c.p25_iden_fdma[id9].populated = 1;
+    s18c.p25_chan_tdma_explicit[id9] = 1;
+    p25_sm_ctx_t ctx18c;
+    p25_sm_init_ctx(&ctx18c, &o18c, &s18c);
+    ctx18c.config.cc_grace_s = 5.0;
+    const double hunting_pending_tune_m = dsd_time_now_monotonic_s() - 2.5;
+    ctx18c.t_cc_sync_m = hunting_pending_tune_m;
+    ctx18c.t_cc_tune_m = hunting_pending_tune_m;
+    ctx18c.cc_sync_pending = 1;
+    s18c.last_cc_sync_time = time(NULL) - 3;
+    s18c.last_cc_sync_time_m = hunting_pending_tune_m;
+    s18c.p25_last_cc_msg_time_m = hunting_pending_tune_m - 0.25;
+    g_result_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    g_result_tune_to_cc_calls = 0;
+    p25_sm_tick_ctx(&ctx18c, &o18c, &s18c);
+    assert(g_result_tune_to_cc_calls == 1);
+    assert(ctx18c.state == P25_SM_HUNTING);
+    assert(ctx18c.cc_sync_pending == 1);
+
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_result_tune_to_freq_calls = 0;
+    p25_sm_event(&ctx18c, &o18c, &s18c, &ev9);
+    assert(g_result_tune_to_freq_calls == 0);
+    assert(ctx18c.state == P25_SM_HUNTING);
+    assert(ctx18c.cc_sync_pending == 1);
+
+    s18c.last_cc_sync_time_m = hunting_pending_tune_m + 0.25;
+    p25_sm_event(&ctx18c, &o18c, &s18c, &ev9);
+    assert(g_result_tune_to_freq_calls == 0);
+    assert(ctx18c.state == P25_SM_HUNTING);
+    assert(ctx18c.cc_sync_pending == 1);
+
+    s18c.p25_last_cc_msg_time = time(NULL);
+    s18c.p25_last_cc_msg_time_m = hunting_pending_tune_m + 0.25;
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    p25_sm_event(&ctx18c, &o18c, &s18c, &ev9);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(ctx18c.state == P25_SM_ON_CC);
+    assert(ctx18c.cc_sync_pending == 0);
+
+    g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
+    p25_sm_event(&ctx18c, &o18c, &s18c, &ev9);
+    assert(g_result_tune_to_freq_calls == 2);
+    assert(ctx18c.state == P25_SM_TUNED);
+    g_result_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+
+    // 23) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
     static dsd_opts o19a;
     static dsd_state s19a;
     DSD_MEMSET(&o19a, 0, sizeof(o19a));
@@ -893,7 +997,7 @@ main(void) {
     assert(ctx19a.state == P25_SM_TUNED);
     assert(ctx19a.slots[1].grant_active == 1);
 
-    // 23) ENC lockout must keep a clear opposite-slot grant pending on the same TDMA carrier.
+    // 24) ENC lockout must keep a clear opposite-slot grant pending on the same TDMA carrier.
     static dsd_opts o19b;
     static dsd_state s19b;
     DSD_MEMSET(&o19b, 0, sizeof(o19b));
@@ -933,7 +1037,7 @@ main(void) {
     assert(s19b.p25_p2_enc_lockout_muted[0] == 1);
 
 #ifdef USE_RADIO
-    // 24) A failed CQPSK retry must roll back the one-shot override and TDMA timing.
+    // 25) A failed CQPSK retry must roll back the one-shot override and TDMA timing.
     static dsd_opts o19;
     static dsd_state s19;
     DSD_MEMSET(&o19, 0, sizeof(o19));
@@ -981,7 +1085,7 @@ main(void) {
     assert(ctx19.state == P25_SM_TUNED);
     g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
 
-    // 25) A successful CQPSK retry refreshes the TDMA grant timeout window.
+    // 26) A successful CQPSK retry refreshes the TDMA grant timeout window.
     static dsd_opts o20;
     static dsd_state s20;
     DSD_MEMSET(&o20, 0, sizeof(o20));
@@ -1030,6 +1134,128 @@ main(void) {
     assert(ctx20.slots[0].grant_active == 1);
     assert(s20.p25_retune_block_until == 0);
 #endif
+
+    // 27) A concurrent stale-context release must not reset a release already in progress.
+    static dsd_opts o21;
+    static dsd_state s21;
+    DSD_MEMSET(&o21, 0, sizeof(o21));
+    DSD_MEMSET(&s21, 0, sizeof(s21));
+    o21.p25_trunk = 1;
+    o21.p25_is_tuned = 1;
+    o21.trunk_is_tuned = 1;
+    s21.p25_cc_freq = 851000000;
+    s21.trunk_cc_freq = 851000000;
+    s21.p25_vc_freq[0] = s21.p25_vc_freq[1] = 851125000;
+    s21.trunk_vc_freq[0] = s21.trunk_vc_freq[1] = 851125000;
+
+    p25_sm_ctx_t* release_ctx = p25_sm_get_ctx();
+    p25_sm_init_ctx(release_ctx, &o21, &s21);
+    release_ctx->state = P25_SM_TUNED;
+    release_ctx->vc_freq_hz = 851125000;
+    release_ctx->vc_channel = ch9;
+    release_ctx->vc_tg = 6101;
+    release_ctx->tune_count = 41;
+    release_ctx->release_count = 13;
+    release_ctx->cc_return_count = 17;
+    release_ctx->config.cc_grace_s = 9.0;
+
+    int release_sync_rc = dsd_mutex_init(&g_release_hook_mutex);
+    if (release_sync_rc != 0) {
+        DSD_FPRINTF(stderr, "release race mutex init failed: %d\n", release_sync_rc);
+        return 1;
+    }
+    release_sync_rc = dsd_cond_init(&g_release_hook_cond);
+    if (release_sync_rc != 0) {
+        DSD_FPRINTF(stderr, "release race condition init failed: %d\n", release_sync_rc);
+        (void)dsd_mutex_destroy(&g_release_hook_mutex);
+        return 1;
+    }
+    g_release_hook_entered = 0;
+    g_result_return_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    g_result_return_to_cc_calls = 0;
+    atomic_store(&g_release_hook_block, 1);
+
+    release_thread_args release_args = {&o21, &s21};
+    dsd_thread_t release_thread;
+    release_sync_rc = dsd_thread_create(&release_thread, release_wrapper_thread, &release_args);
+    if (release_sync_rc != 0) {
+        DSD_FPRINTF(stderr, "release race thread create failed: %d\n", release_sync_rc);
+        atomic_store(&g_release_hook_block, 0);
+        (void)dsd_cond_destroy(&g_release_hook_cond);
+        (void)dsd_mutex_destroy(&g_release_hook_mutex);
+        return 1;
+    }
+    release_sync_rc = dsd_mutex_lock(&g_release_hook_mutex);
+    if (release_sync_rc != 0) {
+        DSD_FPRINTF(stderr, "release race mutex lock failed: %d\n", release_sync_rc);
+        atomic_store(&g_release_hook_block, 0);
+        (void)dsd_cond_signal(&g_release_hook_cond);
+        (void)dsd_thread_join(release_thread);
+        (void)dsd_cond_destroy(&g_release_hook_cond);
+        (void)dsd_mutex_destroy(&g_release_hook_mutex);
+        return 1;
+    }
+    int release_wait_rc = 0;
+    while (!g_release_hook_entered && release_wait_rc == 0) {
+        release_wait_rc = dsd_cond_timedwait(&g_release_hook_cond, &g_release_hook_mutex, 10000);
+    }
+    if (release_wait_rc != 0 || !g_release_hook_entered) {
+        DSD_FPRINTF(stderr, "release race hook wait failed: %d\n", release_wait_rc);
+        atomic_store(&g_release_hook_block, 0);
+        (void)dsd_cond_signal(&g_release_hook_cond);
+        (void)dsd_mutex_unlock(&g_release_hook_mutex);
+        (void)dsd_thread_join(release_thread);
+        (void)dsd_cond_destroy(&g_release_hook_cond);
+        (void)dsd_mutex_destroy(&g_release_hook_mutex);
+        return 1;
+    }
+    release_sync_rc = dsd_mutex_unlock(&g_release_hook_mutex);
+    if (release_sync_rc != 0) {
+        DSD_FPRINTF(stderr, "release race mutex unlock failed: %d\n", release_sync_rc);
+        atomic_store(&g_release_hook_block, 0);
+        (void)dsd_cond_signal(&g_release_hook_cond);
+        (void)dsd_thread_join(release_thread);
+        (void)dsd_cond_destroy(&g_release_hook_cond);
+        (void)dsd_mutex_destroy(&g_release_hook_mutex);
+        return 1;
+    }
+
+    p25_sm_on_release(&o21, &s21);
+    assert(g_result_return_to_cc_calls == 1);
+    assert(release_ctx->state == P25_SM_TUNED);
+    assert(release_ctx->tune_count == 41);
+    assert(release_ctx->release_count == 13);
+    assert(release_ctx->cc_return_count == 17);
+    assert(release_ctx->config.cc_grace_s == 9.0);
+
+    release_sync_rc = dsd_mutex_lock(&g_release_hook_mutex);
+    atomic_store(&g_release_hook_block, 0);
+    int release_signal_rc = dsd_cond_signal(&g_release_hook_cond);
+    int release_unlock_rc = (release_sync_rc == 0) ? dsd_mutex_unlock(&g_release_hook_mutex) : release_sync_rc;
+    int release_join_rc = dsd_thread_join(release_thread);
+    if (release_sync_rc != 0 || release_signal_rc != 0 || release_unlock_rc != 0 || release_join_rc != 0) {
+        DSD_FPRINTF(stderr, "release race resume failed: lock=%d signal=%d unlock=%d join=%d\n", release_sync_rc,
+                    release_signal_rc, release_unlock_rc, release_join_rc);
+        (void)dsd_cond_destroy(&g_release_hook_cond);
+        (void)dsd_mutex_destroy(&g_release_hook_mutex);
+        return 1;
+    }
+
+    assert(g_result_return_to_cc_calls == 1);
+    assert(release_ctx->state == P25_SM_ON_CC);
+    assert(release_ctx->cc_sync_pending == 1);
+    assert(release_ctx->t_cc_tune_m > 0.0);
+    assert(release_ctx->tune_count == 41);
+    assert(release_ctx->release_count == 14);
+    assert(release_ctx->cc_return_count == 18);
+    assert(release_ctx->config.cc_grace_s == 9.0);
+    int release_cond_destroy_rc = dsd_cond_destroy(&g_release_hook_cond);
+    int release_mutex_destroy_rc = dsd_mutex_destroy(&g_release_hook_mutex);
+    if (release_cond_destroy_rc != 0 || release_mutex_destroy_rc != 0) {
+        DSD_FPRINTF(stderr, "release race sync destroy failed: cond=%d mutex=%d\n", release_cond_destroy_rc,
+                    release_mutex_destroy_rc);
+        return 1;
+    }
 
     install_trunk_tuning_hooks();
 

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -1309,7 +1309,7 @@ main(void) {
     atomic_store(&g_release_hook_block, 1);
 
     release_thread_args release_args = {&o21, &s21};
-    dsd_thread_t release_thread;
+    dsd_thread_t release_thread = (dsd_thread_t)0;
     release_sync_rc = dsd_thread_create(&release_thread, release_wrapper_thread, &release_args);
     if (release_sync_rc != 0) {
         DSD_FPRINTF(stderr, "release race thread create failed: %d\n", release_sync_rc);

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -995,6 +995,8 @@ main(void) {
     ctx18d.t_cc_tune_m = external_cc_tune_m - 3.0;
     ctx18d.t_hunt_try_m = external_cc_tune_m - 1.0;
     s18d.p25_sm_mode = DSD_P25_SM_MODE_HUNTING;
+    s18d.p25_cc_eval_freq = 852000000;
+    s18d.p25_cc_eval_start_m = external_cc_tune_m - 3.0;
     s18d.last_cc_sync_time_m = external_cc_tune_m - 3.0;
     s18d.p25_last_cc_msg_time_m = external_decoded_cc_m;
     assert(p25_sm_restart_pending_cc_acquisition(&ctx18d, &o18d, &s18d, external_cc_tune_m, "test-retune") == 1);
@@ -1004,6 +1006,8 @@ main(void) {
     assert(fabs(ctx18d.t_cc_tune_m - external_cc_tune_m) <= cc_sync_epsilon_s);
     assert(ctx18d.t_hunt_try_m == 0.0);
     assert(s18d.p25_sm_mode == DSD_P25_SM_MODE_ON_CC);
+    assert(s18d.p25_cc_eval_freq == 852000000);
+    assert(fabs(s18d.p25_cc_eval_start_m - ctx18d.t_cc_tune_m) <= cc_sync_epsilon_s);
     assert(fabs(s18d.last_cc_sync_time_m - external_cc_tune_m) <= cc_sync_epsilon_s);
     assert(fabs(s18d.p25_last_cc_msg_time_m - external_decoded_cc_m) <= cc_sync_epsilon_s);
 

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -814,6 +814,18 @@ main(void) {
 
     s18aa.last_cc_sync_time_m = pending_grant_cc_tune_m + 0.25;
     p25_sm_event(&ctx18aa, &o18aa, &s18aa, &ev9);
+    assert(g_result_tune_to_freq_calls == 0);
+    assert(ctx18aa.state == P25_SM_ON_CC);
+    assert(ctx18aa.cc_sync_pending == 1);
+
+    p25_sm_event(&ctx18aa, &o18aa, &s18aa, &(p25_sm_event_t){.type = P25_SM_EV_CC_SYNC});
+    assert(g_result_tune_to_freq_calls == 0);
+    assert(ctx18aa.state == P25_SM_ON_CC);
+    assert(ctx18aa.cc_sync_pending == 1);
+
+    s18aa.p25_last_cc_msg_time = time(NULL);
+    s18aa.p25_last_cc_msg_time_m = pending_grant_cc_tune_m + 0.25;
+    p25_sm_event(&ctx18aa, &o18aa, &s18aa, &ev9);
     assert(g_result_tune_to_freq_calls == 1);
     assert(ctx18aa.state == P25_SM_TUNED);
     assert(ctx18aa.cc_sync_pending == 0);

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -1053,6 +1053,47 @@ main(void) {
     assert(g_result_tune_to_freq_calls == 1);
     assert(ctx18e.state == P25_SM_TUNED);
 
+    // A later raw frame sync must not move the tune boundary past decoded CC
+    // activity that arrived after asynchronous completion but before SM resolution.
+    static dsd_opts o18f;
+    static dsd_state s18f;
+    DSD_MEMSET(&o18f, 0, sizeof(o18f));
+    DSD_MEMSET(&s18f, 0, sizeof(s18f));
+    o18f.p25_trunk = 1;
+    s18f.p25_cc_freq = 851000000;
+    s18f.trunk_cc_freq = 851000000;
+    p25_sm_ctx_t ctx18f;
+    p25_sm_init_ctx(&ctx18f, &o18f, &s18f);
+    ctx18f.state = P25_SM_ON_CC;
+    s18f.p25_sm_mode = DSD_P25_SM_MODE_ON_CC;
+
+    const uint64_t decoded_before_resolution_request_id = dsd_trunk_tuning_request_begin();
+    assert(decoded_before_resolution_request_id != 0U);
+    dsd_trunk_tuning_request_mark_ready(decoded_before_resolution_request_id);
+    assert(p25_sm_await_pending_cc_tune(&ctx18f, &o18f, &s18f, decoded_before_resolution_request_id,
+                                        "test-decoded-before-resolution")
+           == 1);
+    dsd_trunk_tuning_request_publish(decoded_before_resolution_request_id, DSD_TRUNK_TUNE_RESULT_OK);
+
+    double decoded_before_resolution_completion_m = 0.0;
+    assert(
+        dsd_trunk_tuning_request_status(decoded_before_resolution_request_id, &decoded_before_resolution_completion_m)
+        == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(decoded_before_resolution_completion_m > 0.0);
+    const double decoded_before_resolution_m = decoded_before_resolution_completion_m + 0.001;
+    const double later_raw_sync_m = decoded_before_resolution_m + 0.001;
+    s18f.p25_last_cc_msg_time = time(NULL);
+    s18f.p25_last_cc_msg_time_m = decoded_before_resolution_m;
+    s18f.last_cc_sync_time = s18f.p25_last_cc_msg_time;
+    s18f.last_cc_sync_time_m = later_raw_sync_m;
+
+    p25_sm_tick_ctx(&ctx18f, &o18f, &s18f);
+    assert(ctx18f.cc_tune_pending == 0);
+    assert(ctx18f.cc_sync_pending == 0);
+    assert(ctx18f.t_cc_tune_m == 0.0);
+    assert(fabs(ctx18f.t_cc_sync_m - decoded_before_resolution_m) <= cc_sync_epsilon_s);
+    assert(ctx18f.state == P25_SM_ON_CC);
+
     // 25) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
     static dsd_opts o19a;
     static dsd_state s19a;

--- a/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
+++ b/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
@@ -20,6 +20,7 @@
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -407,6 +408,15 @@ matrix_drive_to_cc(matrix_fixture* fixture, const matrix_mode_case* mode, const 
     }
 
     int rc = 0;
+    if (fixture->ctx.cc_tune_pending) {
+        const uint64_t request_id = fixture->ctx.cc_tune_request_id;
+        rc |= matrix_expect(request_id != 0U && fixture->ctx.t_cc_tune_m == 0.0, mode->name, flow->name, script->name,
+                            "pending return holds acquisition timer");
+        dsd_trunk_tuning_request_complete(request_id, DSD_TRUNK_TUNE_RESULT_OK);
+        p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+        rc |= matrix_expect(fixture->ctx.cc_tune_pending == 0 && fixture->ctx.t_cc_tune_m > 0.0, mode->name, flow->name,
+                            script->name, "completed return starts acquisition timer");
+    }
     rc |= matrix_expect(fixture->ctx.state == P25_SM_ON_CC, mode->name, flow->name, script->name, "returned to ON_CC");
     rc |= matrix_expect(fixture->opts->p25_is_tuned == 0 && fixture->opts->trunk_is_tuned == 0, mode->name, flow->name,
                         script->name, "tuned flags cleared");
@@ -732,6 +742,16 @@ matrix_run_cc_hunt_case(const matrix_mode_case* mode, dsd_trunk_tune_result firs
                             "accepted cc hunt returns ON_CC");
         rc |= matrix_expect(fixture->state->p25_cc_eval_freq == candidate, mode->name, "cc-hunt", result_name,
                             "accepted candidate is under evaluation");
+        if (first_result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+            const uint64_t request_id = fixture->ctx.cc_tune_request_id;
+            rc |=
+                matrix_expect(fixture->ctx.cc_tune_pending == 1 && request_id != 0U && fixture->ctx.t_cc_tune_m == 0.0,
+                              mode->name, "cc-hunt", result_name, "pending hunt holds acquisition timer");
+            dsd_trunk_tuning_request_complete(request_id, DSD_TRUNK_TUNE_RESULT_OK);
+            p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);
+            rc |= matrix_expect(fixture->ctx.cc_tune_pending == 0 && fixture->ctx.t_cc_tune_m > 0.0, mode->name,
+                                "cc-hunt", result_name, "completed hunt starts acquisition timer");
+        }
         return rc;
     }
 

--- a/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
+++ b/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
@@ -207,12 +207,30 @@ matrix_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) 
     return result;
 }
 
+static dsd_trunk_tune_result
+matrix_tune_to_freq_request(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps, uint64_t request_id) {
+    (void)request_id;
+    return matrix_tune_to_freq(opts, state, freq, ted_sps);
+}
+
+static dsd_trunk_tune_result
+matrix_return_to_cc_request(dsd_opts* opts, dsd_state* state, uint64_t request_id) {
+    (void)request_id;
+    return matrix_return_to_cc(opts, state);
+}
+
+static dsd_trunk_tune_result
+matrix_tune_to_cc_request(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps, uint64_t request_id) {
+    (void)request_id;
+    return matrix_tune_to_cc(opts, state, freq, ted_sps);
+}
+
 static void
 matrix_install_hooks(void) {
     dsd_trunk_tuning_hooks hooks = {0};
-    hooks.tune_to_freq_result = matrix_tune_to_freq;
-    hooks.return_to_cc_result = matrix_return_to_cc;
-    hooks.tune_to_cc_result = matrix_tune_to_cc;
+    hooks.tune_to_freq_request = matrix_tune_to_freq_request;
+    hooks.return_to_cc_request = matrix_return_to_cc_request;
+    hooks.tune_to_cc_request = matrix_tune_to_cc_request;
     dsd_trunk_tuning_hooks_set(hooks);
 }
 

--- a/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
+++ b/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
@@ -285,6 +285,8 @@ matrix_setup_fixture(matrix_fixture* fixture, const matrix_mode_case* mode) {
     fixture->state->trunk_cc_freq = MATRIX_BASE_CC_HZ;
     fixture->state->last_cc_sync_time = time(NULL);
     fixture->state->last_cc_sync_time_m = now_m;
+    fixture->state->p25_last_cc_msg_time = fixture->state->last_cc_sync_time;
+    fixture->state->p25_last_cc_msg_time_m = now_m;
     fixture->state->nac = 0x293;
     fixture->state->p2_cc = 0x293;
     fixture->state->synctype = mode->synctype;
@@ -377,6 +379,8 @@ matrix_stale_cc_timers(matrix_fixture* fixture) {
     fixture->ctx.t_cc_sync_m = now_m - 10.0;
     fixture->state->last_cc_sync_time = time(NULL) - 10;
     fixture->state->last_cc_sync_time_m = now_m - 10.0;
+    fixture->state->p25_last_cc_msg_time = fixture->state->last_cc_sync_time;
+    fixture->state->p25_last_cc_msg_time_m = now_m - 10.0;
 }
 
 static void
@@ -390,6 +394,8 @@ matrix_mark_cc_reacquired(matrix_fixture* fixture) {
     }
     fixture->state->last_cc_sync_time = time(NULL);
     fixture->state->last_cc_sync_time_m = now_m;
+    fixture->state->p25_last_cc_msg_time = fixture->state->last_cc_sync_time;
+    fixture->state->p25_last_cc_msg_time_m = now_m;
 }
 
 static int
@@ -711,6 +717,8 @@ matrix_run_cc_hunt_case(const matrix_mode_case* mode, dsd_trunk_tune_result firs
     (void)dsd_trunk_cc_candidates_add(fixture->state, candidate, 0);
     fixture->state->last_cc_sync_time = time(NULL) - 10;
     fixture->state->last_cc_sync_time_m = now_m - 10.0;
+    fixture->state->p25_last_cc_msg_time = fixture->state->last_cc_sync_time;
+    fixture->state->p25_last_cc_msg_time_m = now_m - 10.0;
     fixture->ctx.t_cc_sync_m = now_m - 10.0;
 
     p25_sm_tick_ctx(&fixture->ctx, fixture->opts, fixture->state);

--- a/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
+++ b/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
@@ -379,6 +379,19 @@ matrix_stale_cc_timers(matrix_fixture* fixture) {
     fixture->state->last_cc_sync_time_m = now_m - 10.0;
 }
 
+static void
+matrix_mark_cc_reacquired(matrix_fixture* fixture) {
+    if (!fixture || !fixture->state) {
+        return;
+    }
+    double now_m = dsd_time_now_monotonic_s();
+    if (now_m <= fixture->state->last_cc_sync_time_m) {
+        now_m = fixture->state->last_cc_sync_time_m + 0.001;
+    }
+    fixture->state->last_cc_sync_time = time(NULL);
+    fixture->state->last_cc_sync_time_m = now_m;
+}
+
 static int
 matrix_drive_to_cc(matrix_fixture* fixture, const matrix_mode_case* mode, const matrix_flow_case* flow,
                    const matrix_return_script* script) {
@@ -410,6 +423,7 @@ matrix_drive_to_cc(matrix_fixture* fixture, const matrix_mode_case* mode, const 
                         "post-return tick remains ON_CC");
     rc |= matrix_expect(g_hooks.cc_calls == cc_calls_before_post_return_tick, mode->name, flow->name, script->name,
                         "post-return tick does not hunt CC");
+    matrix_mark_cc_reacquired(fixture);
     return rc;
 }
 

--- a/tests/runtime/test_runtime_trunk_tuning_hooks.c
+++ b/tests/runtime/test_runtime_trunk_tuning_hooks.c
@@ -289,6 +289,28 @@ main(void) {
     assert(dsd_trunk_tuning_generation() == tune_generation);
     assert(dsd_trunk_tuning_frame_is_current(tune_generation));
 
+    uint64_t mode_exit_failure = dsd_trunk_tuning_request_begin();
+    assert(mode_exit_failure != 0U);
+    dsd_trunk_tuning_request_publish(mode_exit_failure, DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tuning_pending_request() == mode_exit_failure);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    dsd_trunk_tuning_retire_failed_requests();
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
+    uint64_t mode_exit_pending = dsd_trunk_tuning_request_begin();
+    assert(mode_exit_pending != 0U);
+    dsd_trunk_tuning_request_mark_ready(mode_exit_pending);
+    dsd_trunk_tuning_retire_failed_requests();
+    assert(dsd_trunk_tuning_pending_request() == mode_exit_pending);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    dsd_trunk_tuning_request_publish(mode_exit_pending, DSD_TRUNK_TUNE_RESULT_FAILED);
+    dsd_trunk_tuning_retire_failed_requests();
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
     uint64_t older_request = dsd_trunk_tuning_request_begin();
     uint64_t newer_request = dsd_trunk_tuning_request_begin();
     assert(older_request != 0U && newer_request > older_request);

--- a/tests/runtime/test_runtime_trunk_tuning_hooks.c
+++ b/tests/runtime/test_runtime_trunk_tuning_hooks.c
@@ -20,6 +20,8 @@ static long int g_last_freq = 0;
 static long int g_last_cc_freq = 0;
 static int g_last_ted_sps = -1;
 static dsd_trunk_tune_result g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+static dsd_trunk_tune_result g_tune_to_cc_request_result = DSD_TRUNK_TUNE_RESULT_OK;
+static uint64_t g_last_request_id = 0U;
 
 static void
 fake_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
@@ -50,6 +52,25 @@ static dsd_trunk_tune_result
 fake_tune_to_cc_result(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     fake_tune_to_cc(opts, state, freq, ted_sps);
     return g_tune_to_cc_result;
+}
+
+static dsd_trunk_tune_result
+fake_tune_to_freq_result(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    fake_tune_to_freq(opts, state, freq, ted_sps);
+    return g_tune_to_cc_result;
+}
+
+static dsd_trunk_tune_result
+fake_return_to_cc_result(dsd_opts* opts, dsd_state* state) {
+    fake_return_to_cc(opts, state);
+    return g_tune_to_cc_result;
+}
+
+static dsd_trunk_tune_result
+fake_tune_to_cc_request(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps, uint64_t request_id) {
+    fake_tune_to_cc(opts, state, freq, ted_sps);
+    g_last_request_id = request_id;
+    return g_tune_to_cc_request_result;
 }
 
 int
@@ -117,29 +138,63 @@ main(void) {
     assert(dsd_trunk_tuning_generation() == tune_generation);
 
     hooks = (dsd_trunk_tuning_hooks){0};
+    hooks.tune_to_freq_result = fake_tune_to_freq_result;
     hooks.tune_to_cc_result = fake_tune_to_cc_result;
+    hooks.return_to_cc_result = fake_return_to_cc_result;
     dsd_trunk_tuning_hooks_set(hooks);
     g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
     tune_generation = dsd_trunk_tuning_generation();
     assert(dsd_trunk_tuning_frame_is_current(tune_generation));
-    assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851600000, 0) == DSD_TRUNK_TUNE_RESULT_PENDING);
+    uint64_t pending_request = UINT64_MAX;
+    assert(dsd_trunk_tuning_hook_tune_to_freq_with_id(&opts, &state, 851600000, 0, &pending_request)
+           == DSD_TRUNK_TUNE_RESULT_PENDING);
+    assert(pending_request == 0U);
+    tune_generation++;
     assert(dsd_trunk_tuning_generation() == tune_generation);
-    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
-    uint64_t pending_request = dsd_trunk_tuning_pending_request();
-    assert(pending_request != 0U);
-    assert(dsd_trunk_tuning_request_status(pending_request, NULL) == DSD_TRUNK_TUNE_RESULT_PENDING);
-
-    dsd_trunk_tuning_request_complete(pending_request, DSD_TRUNK_TUNE_RESULT_OK);
-    assert(dsd_trunk_tuning_pending_request() == 0U);
-    assert(dsd_trunk_tuning_generation() == tune_generation + 1U);
-    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
-    tune_generation = dsd_trunk_tuning_generation();
     assert(dsd_trunk_tuning_frame_is_current(tune_generation));
-    double completed_m = 0.0;
-    assert(dsd_trunk_tuning_request_status(pending_request, &completed_m) == DSD_TRUNK_TUNE_RESULT_OK);
-    assert(completed_m > 0.0);
-    dsd_trunk_tuning_request_complete(pending_request, DSD_TRUNK_TUNE_RESULT_OK);
+    pending_request = UINT64_MAX;
+    assert(dsd_trunk_tuning_hook_tune_to_cc_with_id(&opts, &state, 851600000, 0, &pending_request)
+           == DSD_TRUNK_TUNE_RESULT_PENDING);
+    assert(pending_request == 0U);
+    tune_generation++;
     assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+    pending_request = UINT64_MAX;
+    assert(dsd_trunk_tuning_hook_return_to_cc_with_id(&opts, &state, &pending_request)
+           == DSD_TRUNK_TUNE_RESULT_PENDING);
+    assert(pending_request == 0U);
+    tune_generation++;
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
+    g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851650000, 0) == DSD_TRUNK_TUNE_RESULT_OK);
+    tune_generation++;
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
+    hooks = (dsd_trunk_tuning_hooks){0};
+    hooks.tune_to_cc_request = fake_tune_to_cc_request;
+    dsd_trunk_tuning_hooks_set(hooks);
+    g_tune_to_cc_request_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    g_last_request_id = 0U;
+    assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851700000, 0) == DSD_TRUNK_TUNE_RESULT_PENDING);
+    assert(g_last_request_id != 0U);
+    assert(dsd_trunk_tuning_pending_request() == g_last_request_id);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    dsd_trunk_tuning_request_publish(g_last_request_id, DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tuning_request_status(g_last_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tuning_pending_request() == g_last_request_id);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    uint64_t wrapper_recovery_request = dsd_trunk_tuning_request_begin();
+    assert(wrapper_recovery_request > g_last_request_id);
+    dsd_trunk_tuning_request_complete(wrapper_recovery_request, DSD_TRUNK_TUNE_RESULT_OK);
+    tune_generation++;
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
 
     uint64_t early_completion = dsd_trunk_tuning_request_begin();
     assert(early_completion != 0U);
@@ -249,11 +304,25 @@ main(void) {
     assert(dsd_trunk_tuning_generation() == tune_generation);
     assert(dsd_trunk_tuning_frame_is_current(tune_generation));
 
+    hooks = (dsd_trunk_tuning_hooks){0};
+    hooks.tune_to_cc_result = fake_tune_to_cc_result;
+    dsd_trunk_tuning_hooks_set(hooks);
     g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
     tune_generation = dsd_trunk_tuning_generation();
     assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851700000, 0) == DSD_TRUNK_TUNE_RESULT_DEFERRED);
     assert(dsd_trunk_tuning_generation() == tune_generation);
     assert(dsd_trunk_tuning_pending_request() == 0U);
+
+    uint64_t abandoned_request = dsd_trunk_tuning_request_begin();
+    assert(abandoned_request != 0U);
+    dsd_trunk_tuning_request_mark_ready(abandoned_request);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    dsd_trunk_tuning_requests_reset();
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+    dsd_trunk_tuning_request_publish(abandoned_request, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
 
     assert(dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_OK));
     assert(dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_PENDING));

--- a/tests/runtime/test_runtime_trunk_tuning_hooks.c
+++ b/tests/runtime/test_runtime_trunk_tuning_hooks.c
@@ -294,7 +294,9 @@ main(void) {
     dsd_trunk_tuning_request_publish(mode_exit_failure, DSD_TRUNK_TUNE_RESULT_FAILED);
     assert(dsd_trunk_tuning_pending_request() == mode_exit_failure);
     assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
-    dsd_trunk_tuning_retire_failed_requests();
+    assert(!dsd_trunk_tuning_frame_is_dispatchable(tune_generation, 1));
+    assert(dsd_trunk_tuning_pending_request() == mode_exit_failure);
+    assert(dsd_trunk_tuning_frame_is_dispatchable(tune_generation, 0));
     assert(dsd_trunk_tuning_pending_request() == 0U);
     assert(dsd_trunk_tuning_generation() == tune_generation);
     assert(dsd_trunk_tuning_frame_is_current(tune_generation));
@@ -302,11 +304,11 @@ main(void) {
     uint64_t mode_exit_pending = dsd_trunk_tuning_request_begin();
     assert(mode_exit_pending != 0U);
     dsd_trunk_tuning_request_mark_ready(mode_exit_pending);
-    dsd_trunk_tuning_retire_failed_requests();
+    assert(!dsd_trunk_tuning_frame_is_dispatchable(tune_generation, 0));
     assert(dsd_trunk_tuning_pending_request() == mode_exit_pending);
     assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
     dsd_trunk_tuning_request_publish(mode_exit_pending, DSD_TRUNK_TUNE_RESULT_FAILED);
-    dsd_trunk_tuning_retire_failed_requests();
+    assert(dsd_trunk_tuning_frame_is_dispatchable(tune_generation, 0));
     assert(dsd_trunk_tuning_pending_request() == 0U);
     assert(dsd_trunk_tuning_generation() == tune_generation);
     assert(dsd_trunk_tuning_frame_is_current(tune_generation));

--- a/tests/runtime/test_runtime_trunk_tuning_hooks.c
+++ b/tests/runtime/test_runtime_trunk_tuning_hooks.c
@@ -175,6 +175,29 @@ main(void) {
     assert(dsd_trunk_tuning_generation() == tune_generation);
     assert(dsd_trunk_tuning_frame_is_current(tune_generation));
 
+    hooks.tune_to_cc_request = fake_tune_to_cc_request;
+    dsd_trunk_tuning_hooks_set(hooks);
+    g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    g_tune_to_cc_request_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    g_last_request_id = 0U;
+    assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851675000, 0) == DSD_TRUNK_TUNE_RESULT_PENDING);
+    tune_generation++;
+    assert(g_last_request_id == 0U);
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
+    pending_request = 0U;
+    assert(dsd_trunk_tuning_hook_tune_to_cc_with_id(&opts, &state, 851700000, 0, &pending_request)
+           == DSD_TRUNK_TUNE_RESULT_PENDING);
+    assert(pending_request != 0U && g_last_request_id == pending_request);
+    assert(dsd_trunk_tuning_pending_request() == pending_request);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    dsd_trunk_tuning_request_publish(pending_request, DSD_TRUNK_TUNE_RESULT_FAILED);
+    dsd_trunk_tuning_request_complete(pending_request, DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
     hooks = (dsd_trunk_tuning_hooks){0};
     hooks.tune_to_cc_request = fake_tune_to_cc_request;
     dsd_trunk_tuning_hooks_set(hooks);

--- a/tests/runtime/test_runtime_trunk_tuning_hooks.c
+++ b/tests/runtime/test_runtime_trunk_tuning_hooks.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -17,6 +18,7 @@ static int g_return_to_cc_calls = 0;
 static long int g_last_freq = 0;
 static long int g_last_cc_freq = 0;
 static int g_last_ted_sps = -1;
+static dsd_trunk_tune_result g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
 static void
 fake_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
@@ -43,6 +45,12 @@ fake_return_to_cc(dsd_opts* opts, dsd_state* state) {
     g_return_to_cc_calls++;
 }
 
+static dsd_trunk_tune_result
+fake_tune_to_cc_result(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    fake_tune_to_cc(opts, state, freq, ted_sps);
+    return g_tune_to_cc_result;
+}
+
 int
 main(void) {
     dsd_trunk_tuning_hooks hooks = {0};
@@ -63,17 +71,23 @@ main(void) {
     g_last_cc_freq = 0;
     g_last_ted_sps = -1;
 
+    uint64_t tune_generation = dsd_trunk_tuning_generation();
     assert(dsd_trunk_tuning_hook_tune_to_freq(&opts, &state, 852000000, 123) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_generation() == tune_generation + 1U);
+    tune_generation = dsd_trunk_tuning_generation();
     assert(g_tune_to_freq_calls == 1);
     assert(g_last_freq == 852000000);
     assert(g_last_ted_sps == 123);
 
     assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851000000, 456) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_generation() == tune_generation + 1U);
+    tune_generation = dsd_trunk_tuning_generation();
     assert(g_tune_to_cc_calls == 1);
     assert(g_last_cc_freq == 851000000);
     assert(g_last_ted_sps == 456);
 
     assert(dsd_trunk_tuning_hook_return_to_cc(&opts, &state) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_generation() == tune_generation + 1U);
     assert(g_return_to_cc_calls == 1);
 
     // Verify fallback behavior when hooks are not installed
@@ -93,9 +107,26 @@ main(void) {
     assert(state.p25_vc_freq[0] == 0);
     assert(state.trunk_vc_freq[0] == 0);
 
+    tune_generation = dsd_trunk_tuning_generation();
     assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851500000, 0) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_generation() == tune_generation + 1U);
     assert(state.trunk_cc_freq == 851500000);
+    tune_generation = dsd_trunk_tuning_generation();
     assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 0, 0) == DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+
+    hooks = (dsd_trunk_tuning_hooks){0};
+    hooks.tune_to_cc_result = fake_tune_to_cc_result;
+    dsd_trunk_tuning_hooks_set(hooks);
+    g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    tune_generation = dsd_trunk_tuning_generation();
+    assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851600000, 0) == DSD_TRUNK_TUNE_RESULT_PENDING);
+    assert(dsd_trunk_tuning_generation() == tune_generation + 1U);
+    g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    tune_generation = dsd_trunk_tuning_generation();
+    assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851700000, 0) == DSD_TRUNK_TUNE_RESULT_DEFERRED);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+
     assert(dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_OK));
     assert(dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_PENDING));
     assert(!dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_DEFERRED));

--- a/tests/runtime/test_runtime_trunk_tuning_hooks.c
+++ b/tests/runtime/test_runtime_trunk_tuning_hooks.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -120,18 +121,147 @@ main(void) {
     dsd_trunk_tuning_hooks_set(hooks);
     g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
     tune_generation = dsd_trunk_tuning_generation();
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
     assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851600000, 0) == DSD_TRUNK_TUNE_RESULT_PENDING);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    uint64_t pending_request = dsd_trunk_tuning_pending_request();
+    assert(pending_request != 0U);
+    assert(dsd_trunk_tuning_request_status(pending_request, NULL) == DSD_TRUNK_TUNE_RESULT_PENDING);
+
+    dsd_trunk_tuning_request_complete(pending_request, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_pending_request() == 0U);
     assert(dsd_trunk_tuning_generation() == tune_generation + 1U);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    tune_generation = dsd_trunk_tuning_generation();
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+    double completed_m = 0.0;
+    assert(dsd_trunk_tuning_request_status(pending_request, &completed_m) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(completed_m > 0.0);
+    dsd_trunk_tuning_request_complete(pending_request, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+
+    uint64_t early_completion = dsd_trunk_tuning_request_begin();
+    assert(early_completion != 0U);
+    dsd_trunk_tuning_request_publish(early_completion, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_request_status(early_completion, NULL) == DSD_TRUNK_TUNE_RESULT_PENDING);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    dsd_trunk_tuning_request_mark_ready(early_completion);
+    tune_generation++;
+    assert(dsd_trunk_tuning_request_status(early_completion, NULL) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
+    uint64_t ready_before_completion = dsd_trunk_tuning_request_begin();
+    assert(ready_before_completion != 0U);
+    dsd_trunk_tuning_request_mark_ready(ready_before_completion);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    dsd_trunk_tuning_request_publish(ready_before_completion, DSD_TRUNK_TUNE_RESULT_OK);
+    tune_generation++;
+    assert(dsd_trunk_tuning_request_status(ready_before_completion, NULL) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
+    uint64_t backend_commit_owner_rollback = dsd_trunk_tuning_request_begin();
+    assert(backend_commit_owner_rollback != 0U);
+    dsd_trunk_tuning_request_publish(backend_commit_owner_rollback, DSD_TRUNK_TUNE_RESULT_OK);
+    dsd_trunk_tuning_request_complete(backend_commit_owner_rollback, DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tuning_request_status(backend_commit_owner_rollback, NULL) == DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_pending_request() == backend_commit_owner_rollback);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    uint64_t mismatch_recovery = dsd_trunk_tuning_request_begin();
+    dsd_trunk_tuning_request_complete(mismatch_recovery, DSD_TRUNK_TUNE_RESULT_OK);
+    tune_generation++;
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
+    uint64_t backend_rollback_owner_commit = dsd_trunk_tuning_request_begin();
+    assert(backend_rollback_owner_commit != 0U);
+    dsd_trunk_tuning_request_publish(backend_rollback_owner_commit, DSD_TRUNK_TUNE_RESULT_FAILED);
+    dsd_trunk_tuning_request_complete(backend_rollback_owner_commit, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_request_status(backend_rollback_owner_commit, NULL) == DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_pending_request() == backend_rollback_owner_commit);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    mismatch_recovery = dsd_trunk_tuning_request_begin();
+    dsd_trunk_tuning_request_complete(mismatch_recovery, DSD_TRUNK_TUNE_RESULT_OK);
+    tune_generation++;
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
+    uint64_t stale_request = dsd_trunk_tuning_request_begin();
+    uint64_t latest_request = dsd_trunk_tuning_request_begin();
+    assert(stale_request != 0U && latest_request != 0U && stale_request != latest_request);
+    dsd_trunk_tuning_request_complete(stale_request, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_trunk_tuning_pending_request() == latest_request);
+    assert(dsd_trunk_tuning_generation() == tune_generation + 1U);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    tune_generation = dsd_trunk_tuning_generation();
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    dsd_trunk_tuning_request_publish(latest_request, DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tuning_pending_request() == latest_request);
+    assert(dsd_trunk_tuning_request_status(latest_request, NULL) == DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    dsd_trunk_tuning_request_complete(latest_request, DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
+    uint64_t older_request = dsd_trunk_tuning_request_begin();
+    uint64_t newer_request = dsd_trunk_tuning_request_begin();
+    assert(older_request != 0U && newer_request > older_request);
+    dsd_trunk_tuning_request_publish(newer_request, DSD_TRUNK_TUNE_RESULT_FAILED);
+    dsd_trunk_tuning_request_complete(older_request, DSD_TRUNK_TUNE_RESULT_OK);
+    tune_generation++;
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_pending_request() == newer_request);
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    dsd_trunk_tuning_request_complete(newer_request, DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
+    uint64_t failed_request = dsd_trunk_tuning_request_begin();
+    assert(failed_request != 0U);
+    dsd_trunk_tuning_request_publish(failed_request, DSD_TRUNK_TUNE_RESULT_FAILED);
+    uint64_t recovery_request = dsd_trunk_tuning_request_begin();
+    assert(recovery_request > failed_request);
+    dsd_trunk_tuning_request_complete(recovery_request, DSD_TRUNK_TUNE_RESULT_OK);
+    tune_generation++;
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
+    for (int i = 0; i < 64; i++) {
+        uint64_t failed_id = dsd_trunk_tuning_request_begin();
+        assert(failed_id != 0U);
+        dsd_trunk_tuning_request_publish(failed_id, DSD_TRUNK_TUNE_RESULT_FAILED);
+    }
+    assert(!dsd_trunk_tuning_frame_is_current(tune_generation));
+    recovery_request = dsd_trunk_tuning_request_begin();
+    assert(recovery_request != 0U);
+    dsd_trunk_tuning_request_complete(recovery_request, DSD_TRUNK_TUNE_RESULT_OK);
+    tune_generation++;
+    assert(dsd_trunk_tuning_pending_request() == 0U);
+    assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_frame_is_current(tune_generation));
+
     g_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
     tune_generation = dsd_trunk_tuning_generation();
     assert(dsd_trunk_tuning_hook_tune_to_cc(&opts, &state, 851700000, 0) == DSD_TRUNK_TUNE_RESULT_DEFERRED);
     assert(dsd_trunk_tuning_generation() == tune_generation);
+    assert(dsd_trunk_tuning_pending_request() == 0U);
 
     assert(dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_OK));
     assert(dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_PENDING));
     assert(!dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_DEFERRED));
     assert(!dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_TIMEOUT));
     assert(!dsd_trunk_tune_result_is_ok(DSD_TRUNK_TUNE_RESULT_FAILED));
+    assert(dsd_trunk_tune_result_is_complete(DSD_TRUNK_TUNE_RESULT_OK));
+    assert(!dsd_trunk_tune_result_is_complete(DSD_TRUNK_TUNE_RESULT_PENDING));
 
     return 0;
 }

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1076,10 +1076,12 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
 
     init_test_context(&opts, &state);
     seed_active_p25_voice(&opts, &state, 855000000L, 856000000L, 3201);
-    state.lcn_freq_count = 2;
+    state.lcn_freq_count = 4;
     state.lcn_freq_roll = 0;
-    state.trunk_lcn_freq[0] = 857000000L;
-    state.trunk_lcn_freq[1] = 858000000L;
+    state.trunk_lcn_freq[0] = 0L;
+    state.trunk_lcn_freq[1] = 857000000L;
+    state.trunk_lcn_freq[2] = 0L;
+    state.trunk_lcn_freq[3] = 858000000L;
     reset_io_control_tune_stub(RTL_STREAM_TUNE_DEFERRED);
     token = 0;
     rc |= expect_int("deferred channel cycle queued", dsd_app_command_action_tracked(DSD_APP_CMD_CHANNEL_CYCLE, &token),
@@ -1100,11 +1102,27 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("accepted channel cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_command_status("accepted channel cycle completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
-    rc |= expect_int("accepted channel cycle advances roll", state.lcn_freq_roll, 1);
+    rc |= expect_int("accepted channel cycle skips empty entry", state.lcn_freq_roll, 2);
     rc |= expect_int("accepted channel cycle clears tuned", opts.p25_is_tuned, 0);
     rc |= expect_int("accepted channel cycle clears TG", state.lasttg, 0);
     rc |= expect_true("accepted channel cycle clears P25 VC", state.p25_vc_freq[0] == 0L);
     rc |= expect_true("accepted channel cycle refreshes CC sync", state.last_cc_sync_time_m > 42.0);
+
+    token = 0;
+    rc |= expect_int("later channel cycle queued", dsd_app_command_action_tracked(DSD_APP_CMD_CHANNEL_CYCLE, &token),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("later channel cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_command_status("later channel cycle completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
+    rc |= expect_true("later channel cycle reaches frequency after empty entry", g_io_control_tune_freq == 858000000L);
+    rc |= expect_int("later channel cycle advances past second frequency", state.lcn_freq_roll, 4);
+
+    token = 0;
+    rc |= expect_int("wrapped channel cycle queued", dsd_app_command_action_tracked(DSD_APP_CMD_CHANNEL_CYCLE, &token),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("wrapped channel cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_command_status("wrapped channel cycle completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
+    rc |= expect_true("wrapped channel cycle skips leading empty entry", g_io_control_tune_freq == 857000000L);
+    rc |= expect_int("wrapped channel cycle advances from recovered entry", state.lcn_freq_roll, 2);
     freeState(&state);
 
     reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1028,6 +1028,7 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     static dsd_state state;
     dsd_app_command_token token = 0;
 
+#ifdef USE_RADIO
     init_test_context(&opts, &state);
     reset_io_control_tune_stub(RTL_STREAM_TUNE_TIMEOUT);
     rc |= expect_int("accepted RTL frequency timeout queued",
@@ -1039,6 +1040,7 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
                       strstr(state.ui_msg, "Accepted: RTL frequency -> 851500000 Hz (pending)") != NULL);
     rc |= expect_int("accepted RTL frequency timeout tune calls", g_io_control_tune_calls, 1);
     freeState(&state);
+#endif
 
     init_test_context(&opts, &state);
     seed_active_p25_voice(&opts, &state, 851000000L, 852000000L, 1201);

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -12,6 +12,7 @@
 #include <dsd-neo/core/init.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/runtime/config.h>
 #include <stdint.h>
@@ -22,6 +23,34 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+
+#ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
+static int g_io_control_tune_result = RTL_STREAM_TUNE_OK;
+static int g_io_control_tune_calls = 0;
+static long int g_io_control_tune_freq = 0;
+
+// GNU ld --wrap entry points must keep the reserved __wrap_* symbol name.
+// NOLINTBEGIN(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+int __wrap_io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq);
+
+int
+__wrap_io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
+    (void)opts;
+    (void)state;
+    g_io_control_tune_calls++;
+    g_io_control_tune_freq = freq;
+    return g_io_control_tune_result;
+}
+
+// NOLINTEND(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+
+static void
+reset_io_control_tune_stub(int result) {
+    g_io_control_tune_result = result;
+    g_io_control_tune_calls = 0;
+    g_io_control_tune_freq = 0;
+}
+#endif
 
 static int
 expect_int(const char* tag, int got, int want) {
@@ -973,6 +1002,116 @@ test_io_and_legacy_state_commands(void) {
     return rc;
 }
 
+#ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
+static void
+seed_active_p25_voice(dsd_opts* opts, dsd_state* state, long cc_freq, long vc_freq, int tg) {
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->p25_trunk = 1;
+    opts->p25_is_tuned = 1;
+    opts->trunk_is_tuned = 1;
+    state->p25_cc_freq = cc_freq;
+    state->trunk_cc_freq = cc_freq;
+    state->p25_vc_freq[0] = state->p25_vc_freq[1] = vc_freq;
+    state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = vc_freq;
+    state->lasttg = tg;
+    state->lastsrc = tg + 1;
+    state->last_cc_sync_time = 123;
+    state->last_cc_sync_time_m = 42.0;
+    state->samplesPerSymbol = 7;
+    state->symbolCenter = 3;
+}
+
+static int
+test_manual_tune_commands_commit_only_after_acceptance(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    dsd_app_command_token token = 0;
+
+    init_test_context(&opts, &state);
+    seed_active_p25_voice(&opts, &state, 851000000L, 852000000L, 1201);
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_DEFERRED);
+    rc |= expect_int("deferred return-to-CC queued", dsd_app_command_action_tracked(DSD_APP_CMD_RETURN_CC, &token),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("deferred return-to-CC drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_command_status("deferred return-to-CC failed", token, DSD_APP_COMMAND_RESULT_FAILED);
+    rc |= expect_int("deferred return-to-CC tune calls", g_io_control_tune_calls, 1);
+    rc |= expect_true("deferred return-to-CC frequency", g_io_control_tune_freq == 851000000L);
+    rc |= expect_int("deferred return-to-CC keeps P25 tuned", opts.p25_is_tuned, 1);
+    rc |= expect_int("deferred return-to-CC keeps trunk tuned", opts.trunk_is_tuned, 1);
+    rc |= expect_int("deferred return-to-CC keeps TG", state.lasttg, 1201);
+    rc |= expect_true("deferred return-to-CC keeps VC", state.p25_vc_freq[0] == 852000000L);
+    rc |= expect_true("deferred return-to-CC keeps CC sync", state.last_cc_sync_time_m == 42.0);
+    rc |= expect_int("deferred return-to-CC keeps SPS", state.samplesPerSymbol, 7);
+
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_TIMEOUT);
+    token = 0;
+    rc |= expect_int("accepted timeout return-to-CC queued",
+                     dsd_app_command_action_tracked(DSD_APP_CMD_RETURN_CC, &token), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("accepted timeout return-to-CC drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_command_status("accepted timeout return-to-CC completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
+    rc |= expect_int("accepted timeout clears P25 tuned", opts.p25_is_tuned, 0);
+    rc |= expect_int("accepted timeout clears trunk tuned", opts.trunk_is_tuned, 0);
+    rc |= expect_int("accepted timeout clears TG", state.lasttg, 0);
+    rc |= expect_true("accepted timeout clears VC", state.p25_vc_freq[0] == 0L);
+    rc |= expect_true("accepted timeout refreshes CC sync", state.last_cc_sync_time_m > 42.0);
+    freeState(&state);
+
+    init_test_context(&opts, &state);
+    seed_active_p25_voice(&opts, &state, 853000000L, 854000000L, 2201);
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_DEFERRED);
+    token = 0;
+    rc |= expect_int("deferred lockout queued", dsd_app_command_set_u8_tracked(DSD_APP_CMD_LOCKOUT_SLOT, 0U, &token),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("deferred lockout drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_command_status("deferred lockout tune failed", token, DSD_APP_COMMAND_RESULT_FAILED);
+    rc |= expect_int("deferred lockout tune calls", g_io_control_tune_calls, 1);
+    rc |= expect_int("deferred lockout keeps P25 tuned", opts.p25_is_tuned, 1);
+    rc |= expect_int("deferred lockout keeps trunk tuned", opts.trunk_is_tuned, 1);
+    rc |= expect_int("deferred lockout keeps TG", state.lasttg, 2201);
+    rc |= expect_true("deferred lockout keeps VC", state.p25_vc_freq[0] == 854000000L);
+    rc |= expect_true("deferred lockout keeps CC sync", state.last_cc_sync_time_m == 42.0);
+    rc |= expect_int("deferred lockout keeps SPS", state.samplesPerSymbol, 7);
+    freeState(&state);
+
+    init_test_context(&opts, &state);
+    seed_active_p25_voice(&opts, &state, 855000000L, 856000000L, 3201);
+    state.lcn_freq_count = 2;
+    state.lcn_freq_roll = 0;
+    state.trunk_lcn_freq[0] = 857000000L;
+    state.trunk_lcn_freq[1] = 858000000L;
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_DEFERRED);
+    token = 0;
+    rc |= expect_int("deferred channel cycle queued", dsd_app_command_action_tracked(DSD_APP_CMD_CHANNEL_CYCLE, &token),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("deferred channel cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_command_status("deferred channel cycle failed", token, DSD_APP_COMMAND_RESULT_FAILED);
+    rc |= expect_int("deferred channel cycle tune calls", g_io_control_tune_calls, 1);
+    rc |= expect_true("deferred channel cycle frequency", g_io_control_tune_freq == 857000000L);
+    rc |= expect_int("deferred channel cycle keeps roll", state.lcn_freq_roll, 0);
+    rc |= expect_int("deferred channel cycle keeps tuned", opts.p25_is_tuned, 1);
+    rc |= expect_int("deferred channel cycle keeps TG", state.lasttg, 3201);
+    rc |= expect_true("deferred channel cycle keeps VC", state.p25_vc_freq[0] == 856000000L);
+    rc |= expect_true("deferred channel cycle keeps CC sync", state.last_cc_sync_time_m == 42.0);
+
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    token = 0;
+    rc |= expect_int("accepted channel cycle queued", dsd_app_command_action_tracked(DSD_APP_CMD_CHANNEL_CYCLE, &token),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("accepted channel cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_command_status("accepted channel cycle completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
+    rc |= expect_int("accepted channel cycle advances roll", state.lcn_freq_roll, 1);
+    rc |= expect_int("accepted channel cycle clears tuned", opts.p25_is_tuned, 0);
+    rc |= expect_int("accepted channel cycle clears TG", state.lasttg, 0);
+    rc |= expect_true("accepted channel cycle clears P25 VC", state.p25_vc_freq[0] == 0L);
+    rc |= expect_true("accepted channel cycle refreshes CC sync", state.last_cc_sync_time_m > 42.0);
+    freeState(&state);
+
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    return rc;
+}
+#endif
+
 int
 main(void) {
     int rc = 0;
@@ -983,6 +1122,9 @@ main(void) {
     rc |= test_key_and_runtime_state_commands();
     rc |= test_file_network_and_import_commands();
     rc |= test_io_and_legacy_state_commands();
+#ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
+    rc |= test_manual_tune_commands_commit_only_after_acceptance();
+#endif
     if (rc == 0) {
         printf("DSD_APP_CMD_QUEUE: OK\n");
     }

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1029,6 +1029,18 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     dsd_app_command_token token = 0;
 
     init_test_context(&opts, &state);
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_TIMEOUT);
+    rc |= expect_int("accepted RTL frequency timeout queued",
+                     dsd_app_command_set_u32_tracked(DSD_APP_CMD_RTL_SET_FREQ, 851500000U, &token),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("accepted RTL frequency timeout drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_command_status("accepted RTL frequency timeout completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
+    rc |= expect_true("accepted RTL frequency timeout reports pending",
+                      strstr(state.ui_msg, "Accepted: RTL frequency -> 851500000 Hz (pending)") != NULL);
+    rc |= expect_int("accepted RTL frequency timeout tune calls", g_io_control_tune_calls, 1);
+    freeState(&state);
+
+    init_test_context(&opts, &state);
     seed_active_p25_voice(&opts, &state, 851000000L, 852000000L, 1201);
     reset_io_control_tune_stub(RTL_STREAM_TUNE_DEFERRED);
     rc |= expect_int("deferred return-to-CC queued", dsd_app_command_action_tracked(DSD_APP_CMD_RETURN_CC, &token),

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1089,6 +1089,25 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     freeState(&state);
 
     init_test_context(&opts, &state);
+    seed_active_p25_voice(&opts, &state, 0L, 854500000L, 2202);
+    state.carrier = 1;
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_DEFERRED);
+    token = 0;
+    rc |= expect_int("no-CC lockout queued", dsd_app_command_set_u8_tracked(DSD_APP_CMD_LOCKOUT_SLOT, 0U, &token),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("no-CC lockout drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_command_status("no-CC lockout completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
+    rc |= expect_int("no-CC lockout skips tune", g_io_control_tune_calls, 0);
+    rc |= expect_int("no-CC lockout clears P25 tuned", opts.p25_is_tuned, 0);
+    rc |= expect_int("no-CC lockout clears trunk tuned", opts.trunk_is_tuned, 0);
+    rc |= expect_int("no-CC lockout clears TG", state.lasttg, 0);
+    rc |= expect_true("no-CC lockout clears P25 VC", state.p25_vc_freq[0] == 0L);
+    rc |= expect_true("no-CC lockout clears trunk VC", state.trunk_vc_freq[0] == 0L);
+    rc |= expect_int("no-CC lockout runs no-carrier cleanup", state.carrier, 0);
+    rc |= expect_true("no-CC lockout keeps CC unknown", state.trunk_cc_freq == 0L && state.p25_cc_freq == 0L);
+    freeState(&state);
+
+    init_test_context(&opts, &state);
     seed_active_p25_voice(&opts, &state, 855000000L, 856000000L, 3201);
     state.lcn_freq_count = 4;
     state.lcn_freq_roll = 0;

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -12,6 +12,7 @@
 #include <dsd-neo/core/init.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/runtime/config.h>
@@ -1078,7 +1079,7 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     rc |= expect_int("deferred lockout queued", dsd_app_command_set_u8_tracked(DSD_APP_CMD_LOCKOUT_SLOT, 0U, &token),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("deferred lockout drained", dsd_app_drain_cmds(&opts, &state), 1);
-    rc |= expect_command_status("deferred lockout tune failed", token, DSD_APP_COMMAND_RESULT_FAILED);
+    rc |= expect_command_status("deferred lockout policy completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
     rc |= expect_int("deferred lockout tune calls", g_io_control_tune_calls, 1);
     rc |= expect_int("deferred lockout keeps P25 tuned", opts.p25_is_tuned, 1);
     rc |= expect_int("deferred lockout keeps trunk tuned", opts.trunk_is_tuned, 1);
@@ -1086,6 +1087,16 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     rc |= expect_true("deferred lockout keeps VC", state.p25_vc_freq[0] == 854000000L);
     rc |= expect_true("deferred lockout keeps CC sync", state.last_cc_sync_time_m == 42.0);
     rc |= expect_int("deferred lockout keeps SPS", state.samplesPerSymbol, 7);
+    char lockout_mode[8] = {0};
+    char lockout_name[50] = {0};
+    rc |= expect_int("deferred lockout policy installed",
+                     dsd_tg_policy_lookup_label(&state, 2201U, lockout_mode, sizeof(lockout_mode), lockout_name,
+                                                sizeof(lockout_name)),
+                     1);
+    rc |= expect_str("deferred lockout policy mode", lockout_mode, "B");
+    rc |= expect_str("deferred lockout policy name", lockout_name, "LOCKOUT");
+    rc |= expect_true("deferred lockout reports cleanup separately",
+                      strstr(state.ui_msg, "TG 2201 locked out; return-to-CC tune failed") != NULL);
     freeState(&state);
 
     init_test_context(&opts, &state);

--- a/tests/ui/test_ui_menu_services.c
+++ b/tests/ui/test_ui_menu_services.c
@@ -23,6 +23,7 @@
 #include <dsd-neo/io/udp_socket_connect.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/runtime/call_alert.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/log.h>
@@ -224,31 +225,76 @@ io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
     return -1;
 }
 
+static int g_p25_tick_guard_depth = 0;
+static int g_p25_tick_guard_enter_calls = 0;
+static int g_p25_tick_guard_leave_calls = 0;
+static int g_p25_tick_guard_errors = 0;
+static int g_rtl_lifecycle_outside_guard = 0;
+static int g_rtl_soft_stop_calls = 0;
+static int g_rtl_destroy_calls = 0;
+static int g_rtl_create_calls = 0;
+static int g_rtl_start_calls = 0;
+static int g_rtl_create_result = -1;
+static int g_rtl_start_result = -1;
+
+void
+p25_sm_tick_guard_enter(void) {
+    g_p25_tick_guard_enter_calls++;
+    if (g_p25_tick_guard_depth != 0) {
+        g_p25_tick_guard_errors++;
+    }
+    g_p25_tick_guard_depth++;
+}
+
+void
+p25_sm_tick_guard_leave(void) {
+    g_p25_tick_guard_leave_calls++;
+    if (g_p25_tick_guard_depth != 1) {
+        g_p25_tick_guard_errors++;
+    }
+    g_p25_tick_guard_depth--;
+}
+
+static void
+note_rtl_lifecycle_call(void) {
+    if (g_p25_tick_guard_depth != 1) {
+        g_rtl_lifecycle_outside_guard++;
+    }
+}
+
 int
 rtl_stream_soft_stop(RtlSdrContext* ctx) {
     (void)ctx;
+    note_rtl_lifecycle_call();
+    g_rtl_soft_stop_calls++;
     return 0;
 }
 
 int
 rtl_stream_destroy(RtlSdrContext* ctx) {
     (void)ctx;
+    note_rtl_lifecycle_call();
+    g_rtl_destroy_calls++;
     return 0;
 }
 
 int
 rtl_stream_create_mirrored(dsd_opts* opts, RtlSdrContext** out_ctx) {
     (void)opts;
+    note_rtl_lifecycle_call();
+    g_rtl_create_calls++;
     if (out_ctx) {
-        *out_ctx = NULL;
+        *out_ctx = g_rtl_create_result == 0 ? (RtlSdrContext*)out_ctx : NULL;
     }
-    return -1;
+    return g_rtl_create_result;
 }
 
 int
 rtl_stream_start(RtlSdrContext* ctx) {
     (void)ctx;
-    return -1;
+    note_rtl_lifecycle_call();
+    g_rtl_start_calls++;
+    return g_rtl_start_result;
 }
 
 int
@@ -552,6 +598,65 @@ test_payload_symbol_and_pulse_state(void) {
 }
 
 #ifdef USE_RADIO
+static void
+reset_rtl_restart_stubs(void) {
+    g_p25_tick_guard_depth = 0;
+    g_p25_tick_guard_enter_calls = 0;
+    g_p25_tick_guard_leave_calls = 0;
+    g_p25_tick_guard_errors = 0;
+    g_rtl_lifecycle_outside_guard = 0;
+    g_rtl_soft_stop_calls = 0;
+    g_rtl_destroy_calls = 0;
+    g_rtl_create_calls = 0;
+    g_rtl_start_calls = 0;
+    g_rtl_create_result = -1;
+    g_rtl_start_result = -1;
+}
+
+static int
+test_rtl_restart_quiesces_p25_retunes(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_rtl_restart_stubs();
+
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtl_started = 1;
+    opts.rtl_needs_restart = 1;
+    state.rtl_ctx = (RtlSdrContext*)&state;
+
+    rc |= expect_int("guarded rtl restart reports create failure", svc_rtl_restart(&opts, &state), -1);
+    rc |= expect_int("rtl restart enters P25 tune guard", g_p25_tick_guard_enter_calls, 1);
+    rc |= expect_int("rtl restart leaves P25 tune guard", g_p25_tick_guard_leave_calls, 1);
+    rc |= expect_int("rtl restart balances P25 tune guard", g_p25_tick_guard_depth, 0);
+    rc |= expect_int("rtl restart uses P25 tune guard correctly", g_p25_tick_guard_errors, 0);
+    rc |= expect_int("rtl lifecycle stays inside P25 tune guard", g_rtl_lifecycle_outside_guard, 0);
+    rc |= expect_int("guarded rtl restart soft stops old stream", g_rtl_soft_stop_calls, 1);
+    rc |= expect_int("guarded rtl restart destroys old stream", g_rtl_destroy_calls, 1);
+    rc |= expect_int("guarded rtl restart attempts replacement", g_rtl_create_calls, 1);
+    rc |= expect_int("guarded rtl restart does not start failed replacement", g_rtl_start_calls, 0);
+    rc |= expect_int("failed guarded rtl restart clears context", state.rtl_ctx == NULL, 1);
+
+    reset_rtl_restart_stubs();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_in_type = AUDIO_IN_RTL;
+    g_rtl_create_result = 0;
+    g_rtl_start_result = -1;
+
+    rc |= expect_int("guarded rtl restart reports start failure", svc_rtl_restart(&opts, &state), -1);
+    rc |= expect_int("start failure leaves P25 tune guard", g_p25_tick_guard_leave_calls, 1);
+    rc |= expect_int("start failure balances P25 tune guard", g_p25_tick_guard_depth, 0);
+    rc |= expect_int("start failure lifecycle stays guarded", g_rtl_lifecycle_outside_guard, 0);
+    rc |= expect_int("start failure destroys replacement", g_rtl_destroy_calls, 1);
+    rc |= expect_int("start failure clears replacement context", state.rtl_ctx == NULL, 1);
+
+    reset_rtl_restart_stubs();
+    return rc;
+}
+
 static int
 test_rtl_service_option_contracts(void) {
     int rc = 0;
@@ -671,6 +776,7 @@ main(void) {
     rc |= test_p2_trunking_and_slot_controls();
     rc |= test_payload_symbol_and_pulse_state();
 #ifdef USE_RADIO
+    rc |= test_rtl_restart_quiesces_p25_retunes();
     rc |= test_rtl_service_option_contracts();
 #endif
     rc |= test_file_network_and_import_failure_contracts();


### PR DESCRIPTION
## Summary

- Prevent P25 grants from retuning to a voice channel while a control-channel retune is still awaiting decoded CC sync.
- Treat control-channel tuning hook timestamps as acquisition markers, not decoded CC confirmation; the grant block only lifts once the CC sync timestamp advances past the retune marker.
- Update P25 regression coverage and release fixtures to model decoded CC reacquisition before accepting later grants.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: network/radio input.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

Extra guardrails: the P25-focused suite, trunk retune/scan tests, and full preflight checks were run before opening this PR.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [ ] `ctest --preset dev-debug --output-on-failure`
- [x] `ctest --preset dev-debug --output-on-failure -R '^P25_'`
- [x] `ctest --preset dev-debug --output-on-failure -R 'ENGINE_TRUNK_RETUNE_REGRESSION|ENGINE_TRUNK_SCAN'`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes

## Risk

- Security/dependency impact: none expected; no dependency or workflow changes.
- CLI/UI behavior impact: P25 trunk following should remain on the control channel until decoded CC activity confirms reacquisition after a CC retune, instead of immediately following stale/new grants.
- Compatibility or packaging impact: none expected.