### PR TITLE
dsp: fix full auto frame sync

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -248,7 +248,23 @@ Notes
 
 Notes
 
-- All frame types are auto-detectable with `-fa` (multi-rate SPS hunting).
+- `-fa` enables the complete digital candidate set and hunts these profiles in order, skipping any profile that has no
+  enabled candidate:
+
+  | Hunt profile | Symbol rate | Levels | Enabled candidates |
+  | --- | ---: | ---: | --- |
+  | 0 | 4800 | 4 | P25 Phase 1 (C4FM/CQPSK), DMR, NXDN96, YSF, M17 |
+  | 1 | 2400 | 4 | NXDN48, dPMR |
+  | 2 | 9600 | 2 | ProVoice, EDACS |
+  | 3 | 6000 | 4 | P25 Phase 2 (CQPSK), X2-TDMA |
+  | 4 | 4800 | 2 | D-STAR |
+
+  A detected sync locks the active rate, level count, timing, and RTL-family channel profile. Passive analog monitoring
+  (`-fA`) and already-framed M17 UDP input (`-fU`) are not frame-sync hunt candidates.
+- The three Auto entry points intentionally differ: CLI `-fa` installs the complete matrix above; config
+  `decode = "auto"` preserves the protocol flags established during initialization or by the current overlay; and the
+  interactive Auto choice preserves the current candidate set. This lets configs and interactive setup retain a
+  deliberately narrowed scanner while `-fa` remains the explicit full-search preset.
 - In TCP PCM mode, SPS hunting still runs when no signal is present, but repeated idle `Sync: no sync` and `SPS hunt`
   console diagnostics are suppressed.
 - P25p2 on a single frequency may require `-X` (below) if MAC_SIGNAL is missing.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -182,7 +182,9 @@ Windows console runs:
 - `--rdio-api-delete-after-upload` Delete the per-call WAV after a successful API-only upload
 - `-r <files>` Play saved MBE files
 - `-c <file>` Save symbol captures to a .bin file
-- `--symbol-capture-format <soft|legacy>` Select symbol capture format. `soft` is the default and preserves dibit reliability, bit LLRs, and raw symbol values for replay; `legacy` writes the historical one-byte hard dibit stream.
+- `--symbol-capture-format <soft|legacy>` Select symbol capture format. `soft` is the default and preserves dibit
+  reliability, bit LLRs, and raw symbol values for replay; `legacy` writes the historical one-byte hard dibit stream.
+  Neither format stores the NXDN symbol rate, so NXDN capture replay requires `-fi` or `-fn` instead of `-fa`.
 - `-d <dir>` Save raw MBE vocoder frames in this folder
 - `-J <file>` Append event log output
 - `--frame-log <file>` Append frame-level one-line timestamped traces

--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -508,6 +508,25 @@ Supported values: `auto`, `p25p1`, `p25p2`, `dmr`, `nxdn48`, `nxdn96`,
 Compatibility aliases are also accepted: `p25p1_only`, `p25p2_only`,
 `edacs`, `provoice`, and `analog_monitor`.
 
+`decode = "auto"` preserves the protocol candidates already established by
+initialization and any active configuration/profile overlay; it does not replace
+them with the CLI full-search preset. Interactive Auto has the same preservation
+semantics. In contrast, CLI `-fa` explicitly enables every digital candidate in
+the five-profile hunt matrix:
+
+| Hunt profile | Symbol rate | Levels | Candidates |
+| --- | ---: | ---: | --- |
+| 0 | 4800 | 4 | P25 Phase 1 (C4FM/CQPSK), DMR, NXDN96, YSF, M17 |
+| 1 | 2400 | 4 | NXDN48, dPMR |
+| 2 | 9600 | 2 | ProVoice, EDACS |
+| 3 | 6000 | 4 | P25 Phase 2 (CQPSK), X2-TDMA |
+| 4 | 4800 | 2 | D-STAR |
+
+Profiles without an enabled candidate are skipped. A successful sync retains
+the active rate, level count, symbol timing, and RTL-family channel profile.
+Passive analog monitoring and already-framed M17 UDP input are outside this
+frame-sync hunt.
+
 The optional `demod` key selects a demodulator path (`auto`, `c4fm`, `gfsk`,
 `qpsk`). When set, it locks demodulator selection similarly to the `-m*`
 CLI modulation options.

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -143,7 +143,7 @@ trunking/scanner to be enabled, and RTL controls require RTL input).
 | `{` / `}` | RTL PPM down/up |
 | `i` | Toggle inversion |
 | `m` | Cycle modulation optimization mode |
-| `M` | Toggle P25 Phase 2 modulation helper |
+| `M` | Toggle and retain the P25 Phase 2 C4FM/QPSK modulation selection |
 | `F` | Toggle aggressive sync/CRC relax helpers |
 | `D` | DMR reset (useful when a system goes off the rails) |
 | `A` | Toggle ProVoice ESK mask (ProVoice modes) |

--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -143,8 +143,9 @@ struct dsd_opts {
     int mod_gfsk;
     /* Legacy/manual -m3 P25p2 C4FM path; keeps its 10-SPS timing eligible for P25p2 sync. */
     int mod_p25p2_c4fm;
-    /* When set by CLI (-mc/-mg/-mq/-m2/-m3), pin demod path and disable
-       auto modulation switching/overrides. 0=auto (default), 1=locked. */
+    /* When set by an explicit modulation selection (CLI -mc/-mg/-mq/-m2/-m3 or the
+       interactive P25p2 helper), pin the demod path and disable auto modulation
+       switching/overrides. 0=auto (default), 1=locked. */
     int mod_cli_lock;
     int inverted_x2tdma;
     int inverted_dmr;

--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -143,6 +143,8 @@ struct dsd_opts {
     int mod_gfsk;
     /* Legacy/manual -m3 P25p2 C4FM path; keeps its 10-SPS timing eligible for P25p2 sync. */
     int mod_p25p2_c4fm;
+    /* P25p2-specific -m2/M selection; pins the strict matcher to the 6000-symbol profile. */
+    int mod_p25p2_profile_lock;
     /* When set by an explicit modulation selection (CLI -mc/-mg/-mq/-m2/-m3 or the
        interactive P25p2 helper), pin the demod path and disable auto modulation
        switching/overrides. 0=auto (default), 1=locked. */

--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -141,7 +141,9 @@ struct dsd_opts {
     int mod_c4fm;
     int mod_qpsk;
     int mod_gfsk;
-    /* When set by CLI (-mc/-mg/-mq/-m2), pin demod path and disable
+    /* Legacy/manual -m3 P25p2 C4FM path; keeps its 10-SPS timing eligible for P25p2 sync. */
+    int mod_p25p2_c4fm;
+    /* When set by CLI (-mc/-mg/-mq/-m2/-m3), pin demod path and disable
        auto modulation switching/overrides. 0=auto (default), 1=locked. */
     int mod_cli_lock;
     int inverted_x2tdma;

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -60,11 +60,12 @@ int dsd_frame_sync_test_sps_hunt_profile_rate(int profile_index);
 int dsd_frame_sync_test_sps_hunt_profile_levels(int profile_index);
 int dsd_frame_sync_test_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* state);
 void dsd_frame_sync_test_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx);
+void dsd_frame_sync_test_ensure_enabled_sps_profile(const dsd_opts* opts, dsd_state* state);
 void dsd_frame_sync_test_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state);
 int dsd_frame_sync_test_history_window(const char* symbols, int symbol_count, int window_length, char* out,
                                        int out_size);
 int dsd_frame_sync_test_try_protocol_matches(dsd_opts* opts, dsd_state* state, const char* symbols, int symbol_count);
-int dsd_frame_sync_test_active_profile_modulation(const dsd_state* state);
+int dsd_frame_sync_test_active_profile_modulation(const dsd_opts* opts, const dsd_state* state);
 int dsd_frame_sync_test_should_skip_snr_or_power_gate(const dsd_opts* opts, const dsd_state* state);
 double dsd_frame_sync_test_elapsed_seconds(double nowm, time_t now, double mono_stamp, time_t wall_stamp);
 void dsd_frame_sync_test_p25_slot_activity(const dsd_opts* opts, const dsd_state* state, time_t now, double nowm,
@@ -81,7 +82,7 @@ void dsd_frame_sync_test_reset_p25_trunk_tick_state(void);
 void dsd_frame_sync_test_maybe_tick_p25_trunk_sm(dsd_opts* opts, dsd_state* state, time_t now);
 #ifdef USE_RADIO
 int dsd_frame_sync_test_rtl_profile_for_sps_index(const dsd_opts* opts, const dsd_state* state, int profile_index);
-double dsd_frame_sync_test_active_profile_snr_db(const dsd_state* state);
+double dsd_frame_sync_test_active_profile_snr_db(const dsd_opts* opts, const dsd_state* state);
 #endif
 #endif
 

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -19,10 +19,32 @@
 extern "C" {
 #endif
 
+/** @brief Stable indices stored in @c dsd_state::sps_hunt_idx. */
+typedef enum {
+    DSD_FRAME_SYNC_SPS_PROFILE_4800_4 = 0,
+    DSD_FRAME_SYNC_SPS_PROFILE_2400_4 = 1,
+    DSD_FRAME_SYNC_SPS_PROFILE_9600_2 = 2,
+    DSD_FRAME_SYNC_SPS_PROFILE_6000_4 = 3,
+    DSD_FRAME_SYNC_SPS_PROFILE_4800_2 = 4,
+    DSD_FRAME_SYNC_SPS_PROFILE_COUNT = 5,
+} dsd_frame_sync_sps_profile_index;
+
+/** @brief NXDN air-interface variant selected by frame-sync profile matching. */
+typedef enum {
+    DSD_NXDN_VARIANT_NONE = 0,
+    DSD_NXDN_VARIANT_48 = 48,
+    DSD_NXDN_VARIANT_96 = 96,
+} dsd_nxdn_variant;
+
 /**
  * @brief Reset modulation auto-detect state used by frame sync.
  */
 void dsd_frame_sync_reset_mod_state(void);
+
+/**
+ * @brief Return the NXDN variant selected by the enabled mode and active SPS hunt profile.
+ */
+dsd_nxdn_variant dsd_frame_sync_active_nxdn_variant(const dsd_opts* opts, const dsd_state* state);
 
 /**
  * @brief Return non-zero when alternate-protocol sync should be suppressed during active P25 trunking.

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -87,6 +87,8 @@ void dsd_frame_sync_test_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state
 int dsd_frame_sync_test_history_window(const char* symbols, int symbol_count, int window_length, char* out,
                                        int out_size);
 int dsd_frame_sync_test_try_protocol_matches(dsd_opts* opts, dsd_state* state, const char* symbols, int symbol_count);
+int dsd_frame_sync_test_eval_window(dsd_opts* opts, dsd_state* state, const char* symbols, const float* levels,
+                                    int symbol_count);
 int dsd_frame_sync_test_active_profile_modulation(const dsd_opts* opts, const dsd_state* state);
 int dsd_frame_sync_test_should_skip_snr_or_power_gate(const dsd_opts* opts, const dsd_state* state);
 double dsd_frame_sync_test_elapsed_seconds(double nowm, time_t now, double mono_stamp, time_t wall_stamp);

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -55,10 +55,17 @@ void printFrameSync(const dsd_opts* opts, const dsd_state* state, const char* fr
                     const char* modulation);
 
 #ifdef DSD_NEO_TEST_HOOKS
-int dsd_frame_sync_test_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* state, const int* sym_rate_cycle,
-                                            const int* levels_cycle, int cycle_count);
-void dsd_frame_sync_test_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx,
-                                                const int* sym_rate_cycle, const int* levels_cycle);
+int dsd_frame_sync_test_sps_hunt_profile_count(void);
+int dsd_frame_sync_test_sps_hunt_profile_rate(int profile_index);
+int dsd_frame_sync_test_sps_hunt_profile_levels(int profile_index);
+int dsd_frame_sync_test_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* state);
+void dsd_frame_sync_test_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx);
+void dsd_frame_sync_test_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state);
+int dsd_frame_sync_test_history_window(const char* symbols, int symbol_count, int window_length, char* out,
+                                       int out_size);
+int dsd_frame_sync_test_try_protocol_matches(dsd_opts* opts, dsd_state* state, const char* symbols, int symbol_count);
+int dsd_frame_sync_test_active_profile_modulation(const dsd_state* state);
+int dsd_frame_sync_test_should_skip_snr_or_power_gate(const dsd_opts* opts, const dsd_state* state);
 double dsd_frame_sync_test_elapsed_seconds(double nowm, time_t now, double mono_stamp, time_t wall_stamp);
 void dsd_frame_sync_test_p25_slot_activity(const dsd_opts* opts, const dsd_state* state, time_t now, double nowm,
                                            double mac_hold, double ring_hold, double dt, int* left_active,
@@ -73,9 +80,8 @@ void dsd_frame_sync_test_auto_switch_modulation(const dsd_opts* opts, dsd_state*
 void dsd_frame_sync_test_reset_p25_trunk_tick_state(void);
 void dsd_frame_sync_test_maybe_tick_p25_trunk_sm(dsd_opts* opts, dsd_state* state, time_t now);
 #ifdef USE_RADIO
-int dsd_frame_sync_test_rtl_profile_for_symbol_rate(const dsd_opts* opts, const dsd_state* state, int sym_rate_hz,
-                                                    int preferred_levels);
-int dsd_frame_sync_test_rtl_levels_for_symbol_rate(const dsd_opts* opts, int sym_rate_hz, int preferred_levels);
+int dsd_frame_sync_test_rtl_profile_for_sps_index(const dsd_opts* opts, const dsd_state* state, int profile_index);
+double dsd_frame_sync_test_active_profile_snr_db(const dsd_state* state);
 #endif
 #endif
 

--- a/include/dsd-neo/runtime/rtl_stream_metrics_hooks.h
+++ b/include/dsd-neo/runtime/rtl_stream_metrics_hooks.h
@@ -44,6 +44,7 @@ typedef struct {
     void (*p25p2_err_update)(int slot, int facch_ok, int facch_err, int sacch_ok, int sacch_err, int voice_err);
     int (*stream_active)(void);
     int (*input_level)(dsd_input_level_snapshot* out);
+    int (*apply_demod_profile)(int cqpsk_enable, int symbol_rate_hz, int levels, int channel_profile, int ted_sps);
 } dsd_rtl_stream_metrics_hooks;
 
 typedef enum DSD_ATTR_PACKED dsd_rtl_stream_channel_profile {
@@ -64,6 +65,15 @@ uint32_t dsd_rtl_stream_metrics_hook_stream_generation(void);
 int dsd_rtl_stream_metrics_hook_stream_active(void);
 int dsd_rtl_stream_metrics_hook_input_level(dsd_input_level_snapshot* out);
 int dsd_rtl_stream_metrics_hook_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profile);
+/**
+ * @brief Synchronize the RTL demodulator family, symbol profile, and timing recovery rate.
+ *
+ * The engine implementation applies the family transition before updating TED timing and the
+ * symbol/channel profile. When the complete transition hook is unavailable, the wrapper falls
+ * back to the symbol-profile hook so non-RTL test and embedding configurations remain usable.
+ */
+int dsd_rtl_stream_metrics_hook_apply_demod_profile(int cqpsk_enable, int symbol_rate_hz, int levels,
+                                                    int channel_profile, int ted_sps);
 int dsd_rtl_stream_metrics_hook_cqpsk_status(int* out_cqpsk_enable, int* out_cqpsk_timing_active);
 int dsd_rtl_stream_metrics_hook_cqpsk_timing_bias(void);
 double dsd_rtl_stream_metrics_hook_snr_bias_evm(void);

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -18,15 +18,19 @@
 #include "dsd-neo/core/state_fwd.h"
 
 static int
-ui_modulation_demod_rate(const dsd_state* state) {
+ui_modulation_demod_rate(const dsd_opts* opts, const dsd_state* state) {
+    int demod_rate = dsd_opts_current_input_timing_rate(opts);
 #ifdef USE_RADIO
-    if (state && state->rtl_ctx) {
-        return (int)rtl_stream_output_rate(state->rtl_ctx);
+    if (opts && opts->audio_in_type == AUDIO_IN_RTL && state && state->rtl_ctx) {
+        const int rtl_rate = (int)rtl_stream_output_rate(state->rtl_ctx);
+        if (rtl_rate > 0) {
+            demod_rate = rtl_rate;
+        }
     }
 #else
     (void)state;
 #endif
-    return 0;
+    return demod_rate;
 }
 
 #ifdef USE_RADIO
@@ -91,7 +95,7 @@ static int
 ui_handle_mod_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     (void)c;
     const int leaving_p25p2_helper = opts->mod_p25p2_c4fm == 1 || opts->mod_p25p2_profile_lock == 1;
-    const int sps = dsd_opts_compute_sps_rate(opts, 4800, ui_modulation_demod_rate(state));
+    const int sps = dsd_opts_compute_sps_rate(opts, 4800, ui_modulation_demod_rate(opts, state));
     opts->mod_p25p2_c4fm = 0;
     opts->mod_p25p2_profile_lock = 0;
     state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
@@ -123,7 +127,7 @@ static int
 ui_handle_mod_p2_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     (void)c;
     // P25P2 TDMA: 6000 sym/s - compute SPS from actual demod rate
-    int sps = dsd_opts_compute_sps_rate(opts, 6000, ui_modulation_demod_rate(state));
+    int sps = dsd_opts_compute_sps_rate(opts, 6000, ui_modulation_demod_rate(opts, state));
     int center = dsd_opts_symbol_center(sps);
     opts->mod_p25p2_c4fm = 0;
     opts->mod_p25p2_profile_lock = 1;

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -93,6 +93,8 @@ ui_handle_mod_p2_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
     int center = dsd_opts_symbol_center(sps);
     state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
     state->sps_hunt_counter = 0;
+    /* The hotkey is an explicit selection; acquisition must not restore auto QPSK. */
+    opts->mod_cli_lock = 1;
     if (state->rf_mod == 0) {
         opts->mod_c4fm = 0;
         opts->mod_qpsk = 1;

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -17,7 +17,46 @@
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
+static int
+ui_modulation_demod_rate(const dsd_state* state) {
 #ifdef USE_RADIO
+    if (state && state->rtl_ctx) {
+        return (int)rtl_stream_output_rate(state->rtl_ctx);
+    }
+#else
+    (void)state;
+#endif
+    return 0;
+}
+
+#ifdef USE_RADIO
+static int
+ui_uses_wide_4800_profile(const dsd_opts* opts) {
+    return opts && (opts->frame_dmr == 1 || opts->frame_nxdn96 == 1 || opts->frame_ysf == 1 || opts->frame_m17 == 1);
+}
+
+static int
+ui_rtl_channel_profile(const dsd_opts* opts, int symbol_rate_hz, int cqpsk) {
+    if (cqpsk) {
+        return RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
+    }
+    if (symbol_rate_hz == 4800 && !ui_uses_wide_4800_profile(opts)) {
+        return RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+    }
+    return RTL_STREAM_CHANNEL_PROFILE_12K5;
+}
+
+static void
+ui_apply_rtl_demod_profile(const dsd_opts* opts, const dsd_state* state, int symbol_rate_hz, int sps) {
+    if (!opts || !state || opts->audio_in_type != AUDIO_IN_RTL || !state->rtl_ctx) {
+        return;
+    }
+    const int cqpsk = state->rf_mod == 1;
+    rtl_stream_toggle_cqpsk(cqpsk);
+    rtl_stream_clear_ted_sps_override();
+    rtl_stream_set_ted_sps_no_override(sps);
+    (void)rtl_stream_set_symbol_profile(symbol_rate_hz, 4, ui_rtl_channel_profile(opts, symbol_rate_hz, cqpsk));
+}
 #endif
 
 static int
@@ -51,6 +90,8 @@ ui_handle_invert_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
 static int
 ui_handle_mod_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     (void)c;
+    const int leaving_p25p2_helper = opts->mod_p25p2_c4fm == 1 || opts->mod_p25p2_profile_lock == 1;
+    const int sps = dsd_opts_compute_sps_rate(opts, 4800, ui_modulation_demod_rate(state));
     opts->mod_p25p2_c4fm = 0;
     opts->mod_p25p2_profile_lock = 0;
     state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
@@ -60,23 +101,20 @@ ui_handle_mod_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_comm
         opts->mod_qpsk = 1;
         opts->mod_gfsk = 0;
         state->rf_mod = 1;
-        // P25P1 QPSK: 4800 sym/s - compute SPS from actual demod rate
-#ifdef USE_RADIO
-        int demod_rate = 0;
-        if (state->rtl_ctx) {
-            demod_rate = (int)rtl_stream_output_rate(state->rtl_ctx);
-        }
-#else
-        int demod_rate = 0;
-#endif
-        state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, 4800, demod_rate);
-        state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
     } else {
         opts->mod_c4fm = 1;
         opts->mod_qpsk = 0;
         opts->mod_gfsk = 0;
         state->rf_mod = 0;
-        // Keep current symbol timing unless other code adjusts it
+    }
+    state->samplesPerSymbol = sps;
+    state->symbolCenter = dsd_opts_symbol_center(sps);
+#ifdef USE_RADIO
+    ui_apply_rtl_demod_profile(opts, state, 4800, sps);
+#endif
+    if (leaving_p25p2_helper) {
+        /* Release the helper lock only after decoder timing and any RTL backend agree on profile 0. */
+        opts->mod_cli_lock = 0;
     }
     return 1;
 }
@@ -85,15 +123,7 @@ static int
 ui_handle_mod_p2_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     (void)c;
     // P25P2 TDMA: 6000 sym/s - compute SPS from actual demod rate
-#ifdef USE_RADIO
-    int demod_rate = 0;
-    if (state->rtl_ctx) {
-        demod_rate = (int)rtl_stream_output_rate(state->rtl_ctx);
-    }
-#else
-    int demod_rate = 0;
-#endif
-    int sps = dsd_opts_compute_sps_rate(opts, 6000, demod_rate);
+    int sps = dsd_opts_compute_sps_rate(opts, 6000, ui_modulation_demod_rate(state));
     int center = dsd_opts_symbol_center(sps);
     opts->mod_p25p2_c4fm = 0;
     opts->mod_p25p2_profile_lock = 1;
@@ -115,14 +145,7 @@ ui_handle_mod_p2_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
         state->symbolCenter = center;
     }
 #ifdef USE_RADIO
-    if (opts->audio_in_type == AUDIO_IN_RTL && state->rtl_ctx) {
-        int cqpsk = state->rf_mod == 1;
-        int channel_profile = cqpsk ? RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK : RTL_STREAM_CHANNEL_PROFILE_12K5;
-        rtl_stream_toggle_cqpsk(cqpsk);
-        rtl_stream_clear_ted_sps_override();
-        rtl_stream_set_ted_sps_no_override(sps);
-        (void)rtl_stream_set_symbol_profile(6000, 4, channel_profile);
-    }
+    ui_apply_rtl_demod_profile(opts, state, 6000, sps);
 #endif
     /* Lock only after the decoder and any RTL backend share the P25p2 profile. */
     opts->mod_cli_lock = 1;

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -110,8 +110,11 @@ ui_handle_mod_p2_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
     }
 #ifdef USE_RADIO
     if (opts->audio_in_type == AUDIO_IN_RTL && state->rtl_ctx) {
-        int channel_profile =
-            state->rf_mod == 1 ? RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK : RTL_STREAM_CHANNEL_PROFILE_12K5;
+        int cqpsk = state->rf_mod == 1;
+        int channel_profile = cqpsk ? RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK : RTL_STREAM_CHANNEL_PROFILE_12K5;
+        rtl_stream_toggle_cqpsk(cqpsk);
+        rtl_stream_clear_ted_sps_override();
+        rtl_stream_set_ted_sps_no_override(sps);
         (void)rtl_stream_set_symbol_profile(6000, 4, channel_profile);
     }
 #endif

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -51,6 +51,10 @@ ui_handle_invert_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
 static int
 ui_handle_mod_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     (void)c;
+    opts->mod_p25p2_c4fm = 0;
+    opts->mod_p25p2_profile_lock = 0;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state->sps_hunt_counter = 0;
     if (state->rf_mod == 0) {
         opts->mod_c4fm = 0;
         opts->mod_qpsk = 1;
@@ -91,6 +95,8 @@ ui_handle_mod_p2_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
 #endif
     int sps = dsd_opts_compute_sps_rate(opts, 6000, demod_rate);
     int center = dsd_opts_symbol_center(sps);
+    opts->mod_p25p2_c4fm = 0;
+    opts->mod_p25p2_profile_lock = 1;
     state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
     state->sps_hunt_counter = 0;
     if (state->rf_mod == 0) {

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -93,8 +93,6 @@ ui_handle_mod_p2_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
     int center = dsd_opts_symbol_center(sps);
     state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
     state->sps_hunt_counter = 0;
-    /* The hotkey is an explicit selection; acquisition must not restore auto QPSK. */
-    opts->mod_cli_lock = 1;
     if (state->rf_mod == 0) {
         opts->mod_c4fm = 0;
         opts->mod_qpsk = 1;
@@ -110,6 +108,15 @@ ui_handle_mod_p2_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
         state->samplesPerSymbol = sps;
         state->symbolCenter = center;
     }
+#ifdef USE_RADIO
+    if (opts->audio_in_type == AUDIO_IN_RTL && state->rtl_ctx) {
+        int channel_profile =
+            state->rf_mod == 1 ? RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK : RTL_STREAM_CHANNEL_PROFILE_12K5;
+        (void)rtl_stream_set_symbol_profile(6000, 4, channel_profile);
+    }
+#endif
+    /* Lock only after the decoder and any RTL backend share the P25p2 profile. */
+    opts->mod_cli_lock = 1;
     return 1;
 }
 

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -7,6 +7,7 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <stdint.h>
 #include <string.h>
@@ -90,6 +91,8 @@ ui_handle_mod_p2_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
 #endif
     int sps = dsd_opts_compute_sps_rate(opts, 6000, demod_rate);
     int center = dsd_opts_symbol_center(sps);
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+    state->sps_hunt_counter = 0;
     if (state->rf_mod == 0) {
         opts->mod_c4fm = 0;
         opts->mod_qpsk = 1;

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -25,6 +25,7 @@
 #include <dsd-neo/crypto/dmr_keystream.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/engine/frame_processing.h>
+#include <dsd-neo/io/control.h>
 #include <dsd-neo/io/rigctl_client.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/io/udp_input.h>
@@ -1628,16 +1629,18 @@ current_demod_rate(const dsd_opts* opts, const dsd_state* state) {
 
 static int
 cc_symbol_rate(const dsd_state* state, int fdma_only) {
-    if (fdma_only) {
-        // In FDMA-only retune paths, keep existing SPS unless CC type is explicitly FDMA.
-        return state->p25_cc_is_tdma == 0 ? 4800 : 0;
+    if (state->p25_cc_is_tdma == 0) {
+        return 4800;
     }
-    return state->p25_cc_is_tdma == 1 ? 6000 : 4800;
+    if (!fdma_only && state->p25_cc_is_tdma == 1) {
+        return 6000;
+    }
+    // Keep the retune profile-neutral unless the P25 CC type is known and allowed by the action.
+    return 0;
 }
 
 static void
-set_cc_symbol_timing(const dsd_opts* opts, dsd_state* state, int fdma_only) {
-    const int sym_rate = cc_symbol_rate(state, fdma_only);
+set_cc_symbol_timing(const dsd_opts* opts, dsd_state* state, int sym_rate) {
     if (sym_rate == 0) {
         return;
     }
@@ -1648,15 +1651,24 @@ set_cc_symbol_timing(const dsd_opts* opts, dsd_state* state, int fdma_only) {
 }
 
 static int
-request_manual_cc_tune(dsd_opts* opts, dsd_state* state, long int freq, int fdma_only, const char* action) {
-    const int sym_rate = cc_symbol_rate(state, fdma_only);
-    const int ted_sps = sym_rate > 0 ? dsd_opts_compute_sps_rate(opts, sym_rate, current_demod_rate(opts, state)) : 0;
-    const dsd_trunk_tune_result result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, ted_sps);
-    if (dsd_trunk_tune_result_is_ok(result)) {
+request_manual_tune(dsd_opts* opts, dsd_state* state, long int freq, int p25_cc_symbol_rate, const char* action) {
+    int result = 0;
+    int accepted = 0;
+    if (p25_cc_symbol_rate != 0) {
+        const int ted_sps = dsd_opts_compute_sps_rate(opts, p25_cc_symbol_rate, current_demod_rate(opts, state));
+        const dsd_trunk_tune_result cc_result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, ted_sps);
+        result = (int)cc_result;
+        accepted = dsd_trunk_tune_result_is_ok(cc_result);
+    } else {
+        /* Generic LCN actions and unknown CC types must not stage a P25 RTL profile. */
+        result = io_control_set_freq(opts, state, freq);
+        accepted = result == RTL_STREAM_TUNE_OK || result == RTL_STREAM_TUNE_TIMEOUT;
+    }
+    if (accepted) {
         return 1;
     }
     LOG_WARNING("%s tune to %ld Hz was not accepted (result=%d); preserving decoder state\n",
-                action ? action : "Manual", freq, (int)result);
+                action ? action : "Manual", freq, result);
     return 0;
 }
 
@@ -1678,12 +1690,13 @@ apply_manual_return_to_cc(dsd_opts* opts, dsd_state* state) {
     }
 
     const long freq = current_cc_freq(state);
-    if (!request_manual_cc_tune(opts, state, freq, 0, "Return-to-CC")) {
+    const int sym_rate = cc_symbol_rate(state, 0);
+    if (!request_manual_tune(opts, state, freq, sym_rate, "Return-to-CC")) {
         return UI_CMD_APPLY_FAILED;
     }
     reset_call_tracking(opts, state, 1);
     mark_cc_sync(state, 1);
-    set_cc_symbol_timing(opts, state, 0);
+    set_cc_symbol_timing(opts, state, sym_rate);
     LOG_INFO("User Activated Return to CC\n");
     return UI_CMD_APPLY_COMPLETED;
 }
@@ -1691,9 +1704,10 @@ apply_manual_return_to_cc(dsd_opts* opts, dsd_state* state) {
 static int
 apply_lockout_decoder_transition(dsd_opts* opts, dsd_state* state) {
     long cc_freq = 0;
+    const int sym_rate = cc_symbol_rate(state, 1);
     if (opts->p25_trunk == 1) {
         cc_freq = current_cc_freq(state);
-        if (cc_freq != 0 && !request_manual_cc_tune(opts, state, cc_freq, 1, "Lockout return-to-CC")) {
+        if (cc_freq != 0 && !request_manual_tune(opts, state, cc_freq, sym_rate, "Lockout return-to-CC")) {
             return UI_CMD_APPLY_FAILED;
         }
     }
@@ -1704,7 +1718,7 @@ apply_lockout_decoder_transition(dsd_opts* opts, dsd_state* state) {
         state->trunk_cc_freq = cc_freq;
     }
     mark_cc_sync(state, 0);
-    set_cc_symbol_timing(opts, state, 1);
+    set_cc_symbol_timing(opts, state, sym_rate);
     return UI_CMD_APPLY_COMPLETED;
 }
 
@@ -1714,14 +1728,15 @@ try_manual_candidate_cycle(dsd_opts* opts, dsd_state* state) {
     if (opts->p25_prefer_candidates != 1 || !p25_sm_next_cc_candidate(state, &cand)) {
         return UI_CMD_APPLY_UNHANDLED;
     }
-    if (!request_manual_cc_tune(opts, state, cand, 0, "Candidate cycle")) {
+    const int sym_rate = cc_symbol_rate(state, 0);
+    if (!request_manual_tune(opts, state, cand, sym_rate, "Candidate cycle")) {
         return UI_CMD_APPLY_FAILED;
     }
 
     reset_call_tracking(opts, state, 0);
     LOG_INFO("Candidate Cycle: tuning to %.06lf MHz\n", (double)cand / 1000000);
     mark_cc_sync(state, 1);
-    set_cc_symbol_timing(opts, state, 0);
+    set_cc_symbol_timing(opts, state, sym_rate);
     return UI_CMD_APPLY_COMPLETED;
 }
 
@@ -1761,7 +1776,7 @@ apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
         }
         return UI_CMD_APPLY_COMPLETED;
     }
-    if (!request_manual_cc_tune(opts, state, freq, 0, "Channel cycle")) {
+    if (!request_manual_tune(opts, state, freq, 0, "Channel cycle")) {
         return UI_CMD_APPLY_FAILED;
     }
 
@@ -1769,7 +1784,6 @@ apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
     LOG_INFO("Channel Cycle: tuning to %.06lf MHz\n", (double)freq / 1000000);
     state->lcn_freq_roll = next + 1;
     mark_cc_sync(state, 1);
-    set_cc_symbol_timing(opts, state, 0);
     return UI_CMD_APPLY_COMPLETED;
 }
 

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -23,6 +23,7 @@
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/core/time_format.h>
 #include <dsd-neo/crypto/dmr_keystream.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/io/control.h>
 #include <dsd-neo/io/rigctl_client.h>
@@ -1655,6 +1656,8 @@ set_cc_symbol_timing(const dsd_opts* opts, dsd_state* state, int fdma_only) {
     }
     state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, sym_rate, current_demod_rate(opts, state));
     state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
+    state->sps_hunt_idx = sym_rate == 6000 ? DSD_FRAME_SYNC_SPS_PROFILE_6000_4 : DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state->sps_hunt_counter = 0;
 }
 
 static void
@@ -1718,6 +1721,7 @@ try_manual_candidate_cycle(dsd_opts* opts, dsd_state* state) {
     reset_call_tracking(opts, state, 0);
     LOG_INFO("Candidate Cycle: tuning to %.06lf MHz\n", (double)cand / 1000000);
     mark_cc_sync(state, 1);
+    set_cc_symbol_timing(opts, state, 0);
     return UI_CMD_APPLY_COMPLETED;
 }
 

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -25,7 +25,6 @@
 #include <dsd-neo/crypto/dmr_keystream.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/engine/frame_processing.h>
-#include <dsd-neo/io/control.h>
 #include <dsd-neo/io/rigctl_client.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/io/udp_input.h>
@@ -41,6 +40,7 @@
 #include <dsd-neo/runtime/freq_parse.h>
 #include <dsd-neo/runtime/log.h>
 #include <dsd-neo/runtime/telemetry.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <sndfile.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -1592,22 +1592,6 @@ current_cc_freq(const dsd_state* state) {
     return (state->trunk_cc_freq != 0) ? state->trunk_cc_freq : state->p25_cc_freq;
 }
 
-static int
-manual_tune_result_is_accepted(int result) {
-    return result == RTL_STREAM_TUNE_OK || result == RTL_STREAM_TUNE_TIMEOUT;
-}
-
-static int
-request_manual_tune(dsd_opts* opts, dsd_state* state, long int freq, const char* action) {
-    const int result = io_control_set_freq(opts, state, freq);
-    if (manual_tune_result_is_accepted(result)) {
-        return 1;
-    }
-    LOG_WARNING("%s tune to %ld Hz was not accepted (result=%d); preserving decoder state\n",
-                action ? action : "Manual", freq, result);
-    return 0;
-}
-
 static void
 reset_call_tracking(dsd_opts* opts, dsd_state* state, int clear_trunk_vc) {
     DSD_MEMSET(state->nxdn_sacch_frame_segment, 1, sizeof(state->nxdn_sacch_frame_segment));
@@ -1642,22 +1626,38 @@ current_demod_rate(const dsd_opts* opts, const dsd_state* state) {
     return dsd_opts_current_input_timing_rate(opts);
 }
 
-static void
-set_cc_symbol_timing(const dsd_opts* opts, dsd_state* state, int fdma_only) {
-    int sym_rate = 0;
+static int
+cc_symbol_rate(const dsd_state* state, int fdma_only) {
     if (fdma_only) {
         // In FDMA-only retune paths, keep existing SPS unless CC type is explicitly FDMA.
-        if (state->p25_cc_is_tdma != 0) {
-            return;
-        }
-        sym_rate = 4800;
-    } else {
-        sym_rate = (state->p25_cc_is_tdma == 1) ? 6000 : 4800;
+        return state->p25_cc_is_tdma == 0 ? 4800 : 0;
+    }
+    return state->p25_cc_is_tdma == 1 ? 6000 : 4800;
+}
+
+static void
+set_cc_symbol_timing(const dsd_opts* opts, dsd_state* state, int fdma_only) {
+    const int sym_rate = cc_symbol_rate(state, fdma_only);
+    if (sym_rate == 0) {
+        return;
     }
     state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, sym_rate, current_demod_rate(opts, state));
     state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
     state->sps_hunt_idx = sym_rate == 6000 ? DSD_FRAME_SYNC_SPS_PROFILE_6000_4 : DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
     state->sps_hunt_counter = 0;
+}
+
+static int
+request_manual_cc_tune(dsd_opts* opts, dsd_state* state, long int freq, int fdma_only, const char* action) {
+    const int sym_rate = cc_symbol_rate(state, fdma_only);
+    const int ted_sps = sym_rate > 0 ? dsd_opts_compute_sps_rate(opts, sym_rate, current_demod_rate(opts, state)) : 0;
+    const dsd_trunk_tune_result result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, ted_sps);
+    if (dsd_trunk_tune_result_is_ok(result)) {
+        return 1;
+    }
+    LOG_WARNING("%s tune to %ld Hz was not accepted (result=%d); preserving decoder state\n",
+                action ? action : "Manual", freq, (int)result);
+    return 0;
 }
 
 static void
@@ -1678,7 +1678,7 @@ apply_manual_return_to_cc(dsd_opts* opts, dsd_state* state) {
     }
 
     const long freq = current_cc_freq(state);
-    if (!request_manual_tune(opts, state, freq, "Return-to-CC")) {
+    if (!request_manual_cc_tune(opts, state, freq, 0, "Return-to-CC")) {
         return UI_CMD_APPLY_FAILED;
     }
     reset_call_tracking(opts, state, 1);
@@ -1693,7 +1693,7 @@ apply_lockout_decoder_transition(dsd_opts* opts, dsd_state* state) {
     long cc_freq = 0;
     if (opts->p25_trunk == 1) {
         cc_freq = current_cc_freq(state);
-        if (cc_freq != 0 && !request_manual_tune(opts, state, cc_freq, "Lockout return-to-CC")) {
+        if (cc_freq != 0 && !request_manual_cc_tune(opts, state, cc_freq, 1, "Lockout return-to-CC")) {
             return UI_CMD_APPLY_FAILED;
         }
     }
@@ -1714,7 +1714,7 @@ try_manual_candidate_cycle(dsd_opts* opts, dsd_state* state) {
     if (opts->p25_prefer_candidates != 1 || !p25_sm_next_cc_candidate(state, &cand)) {
         return UI_CMD_APPLY_UNHANDLED;
     }
-    if (!request_manual_tune(opts, state, cand, "Candidate cycle")) {
+    if (!request_manual_cc_tune(opts, state, cand, 0, "Candidate cycle")) {
         return UI_CMD_APPLY_FAILED;
     }
 
@@ -1761,7 +1761,7 @@ apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
         }
         return UI_CMD_APPLY_COMPLETED;
     }
-    if (!request_manual_tune(opts, state, freq, "Channel cycle")) {
+    if (!request_manual_cc_tune(opts, state, freq, 0, "Channel cycle")) {
         return UI_CMD_APPLY_FAILED;
     }
 

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -20,6 +20,7 @@
 #include <dsd-neo/core/frontend_types.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/core/time_format.h>
 #include <dsd-neo/crypto/dmr_keystream.h>
@@ -1628,7 +1629,25 @@ current_demod_rate(const dsd_opts* opts, const dsd_state* state) {
 }
 
 static int
-cc_symbol_rate(const dsd_state* state, int fdma_only) {
+cc_has_active_p25_context(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state || (opts->frame_p25p1 != 1 && opts->frame_p25p2 != 1)) {
+        return 0;
+    }
+    if (state->synctype != DSD_SYNC_NONE) {
+        return DSD_SYNC_IS_P25(state->synctype) ? 1 : 0;
+    }
+    if (state->lastsynctype != DSD_SYNC_NONE) {
+        return DSD_SYNC_IS_P25(state->lastsynctype) ? 1 : 0;
+    }
+    /* A P25 voice tune remains authoritative while frame sync is temporarily absent. */
+    return opts->p25_is_tuned == 1 && (state->p25_vc_freq[0] != 0 || state->p25_vc_freq[1] != 0);
+}
+
+static int
+cc_symbol_rate(const dsd_opts* opts, const dsd_state* state, int fdma_only) {
+    if (!cc_has_active_p25_context(opts, state)) {
+        return 0;
+    }
     if (state->p25_cc_is_tdma == 0) {
         return 4800;
     }
@@ -1690,7 +1709,7 @@ apply_manual_return_to_cc(dsd_opts* opts, dsd_state* state) {
     }
 
     const long freq = current_cc_freq(state);
-    const int sym_rate = cc_symbol_rate(state, 0);
+    const int sym_rate = cc_symbol_rate(opts, state, 0);
     if (!request_manual_tune(opts, state, freq, sym_rate, "Return-to-CC")) {
         return UI_CMD_APPLY_FAILED;
     }
@@ -1704,7 +1723,7 @@ apply_manual_return_to_cc(dsd_opts* opts, dsd_state* state) {
 static int
 apply_lockout_decoder_transition(dsd_opts* opts, dsd_state* state) {
     long cc_freq = 0;
-    const int sym_rate = cc_symbol_rate(state, 1);
+    const int sym_rate = cc_symbol_rate(opts, state, 1);
     if (opts->p25_trunk == 1) {
         cc_freq = current_cc_freq(state);
         if (cc_freq != 0 && !request_manual_tune(opts, state, cc_freq, sym_rate, "Lockout return-to-CC")) {
@@ -1728,7 +1747,7 @@ try_manual_candidate_cycle(dsd_opts* opts, dsd_state* state) {
     if (opts->p25_prefer_candidates != 1 || !p25_sm_next_cc_candidate(state, &cand)) {
         return UI_CMD_APPLY_UNHANDLED;
     }
-    const int sym_rate = cc_symbol_rate(state, 0);
+    const int sym_rate = cc_symbol_rate(opts, state, 0);
     if (!request_manual_tune(opts, state, cand, sym_rate, "Candidate cycle")) {
         return UI_CMD_APPLY_FAILED;
     }

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -159,6 +159,7 @@ init_opts_decoder_and_input_defaults(dsd_opts* opts) {
     opts->mod_c4fm = 1;
     opts->mod_qpsk = 0;
     opts->mod_gfsk = 0;
+    opts->mod_p25p2_c4fm = 0;
     opts->mod_cli_lock = 0;    // by default, allow auto modulation selection
     opts->inverted_x2tdma = 1; // most transmitter + scanner + sound card combinations show inverted signals for this
     opts->inverted_dmr = 0; // most transmitter + scanner + sound card combinations show non-inverted signals for this

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -160,6 +160,7 @@ init_opts_decoder_and_input_defaults(dsd_opts* opts) {
     opts->mod_qpsk = 0;
     opts->mod_gfsk = 0;
     opts->mod_p25p2_c4fm = 0;
+    opts->mod_p25p2_profile_lock = 0;
     opts->mod_cli_lock = 0;    // by default, allow auto modulation selection
     opts->inverted_x2tdma = 1; // most transmitter + scanner + sound card combinations show inverted signals for this
     opts->inverted_dmr = 0; // most transmitter + scanner + sound card combinations show non-inverted signals for this

--- a/src/dsp/CMakeLists.txt
+++ b/src/dsp/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(
         dsd_symbol.c
         frame_sync_level.c
         dsd_frame_sync.c
+        frame_sync_profile.c
         frame_sync_policy.c
         sync_hamming.c
         dmr_sync.c

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -61,12 +61,12 @@
 #endif
 
 enum {
-    FRAME_SYNC_SPS_PROFILE_4800_4 = 0,
-    FRAME_SYNC_SPS_PROFILE_2400_4 = 1,
-    FRAME_SYNC_SPS_PROFILE_9600_2 = 2,
-    FRAME_SYNC_SPS_PROFILE_6000_4 = 3,
-    FRAME_SYNC_SPS_PROFILE_4800_2 = 4,
-    FRAME_SYNC_SPS_PROFILE_COUNT = 5,
+    FRAME_SYNC_SPS_PROFILE_4800_4 = DSD_FRAME_SYNC_SPS_PROFILE_4800_4,
+    FRAME_SYNC_SPS_PROFILE_2400_4 = DSD_FRAME_SYNC_SPS_PROFILE_2400_4,
+    FRAME_SYNC_SPS_PROFILE_9600_2 = DSD_FRAME_SYNC_SPS_PROFILE_9600_2,
+    FRAME_SYNC_SPS_PROFILE_6000_4 = DSD_FRAME_SYNC_SPS_PROFILE_6000_4,
+    FRAME_SYNC_SPS_PROFILE_4800_2 = DSD_FRAME_SYNC_SPS_PROFILE_4800_2,
+    FRAME_SYNC_SPS_PROFILE_COUNT = DSD_FRAME_SYNC_SPS_PROFILE_COUNT,
     FRAME_SYNC_HISTORY_CAPACITY = 48,
 };
 
@@ -2810,14 +2810,16 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
 
     const frame_sync_sps_profile* profile = frame_sync_sps_profile_for_index(next_idx);
     const int profile_changed = next_idx != state->sps_hunt_idx;
-    const int force_binary_modulation = !opts->mod_cli_lock && profile->levels == 2 && state->rf_mod != 2;
-    if (!profile_changed && !force_binary_modulation) {
+    const int profile_default_modulation = profile->levels == 2 ? 2 : 0;
+    const int normalize_profile_modulation =
+        !opts->mod_cli_lock && state->rf_mod != profile_default_modulation && (profile_changed || profile->levels == 2);
+    if (!profile_changed && !normalize_profile_modulation) {
         return;
     }
 
     state->sps_hunt_idx = next_idx;
-    if (force_binary_modulation) {
-        state->rf_mod = 2;
+    if (normalize_profile_modulation) {
+        state->rf_mod = profile_default_modulation;
     }
     dsd_frame_sync_reset_mod_state();
 

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -189,22 +189,29 @@ rtl_maybe_update_active_sps_profile(const dsd_opts* opts, const dsd_state* state
 }
 #endif
 
+static int
+frame_sync_current_demod_rate(const dsd_opts* opts, const dsd_state* state) {
+    int demod_rate = dsd_opts_current_input_timing_rate(opts);
+#ifdef USE_RADIO
+    if (opts && state && opts->audio_in_type == AUDIO_IN_RTL && state->rtl_ctx) {
+        int rtl_demod_rate = (int)dsd_rtl_stream_metrics_hook_output_rate_hz();
+        if (rtl_demod_rate > 0) {
+            demod_rate = rtl_demod_rate;
+        }
+    }
+#else
+    UNUSED(state);
+#endif
+    return demod_rate;
+}
+
 static inline void
 dmr_set_symbol_timing(const dsd_opts* opts, dsd_state* state) {
     if (!opts || !state) {
         return;
     }
 
-    int demod_rate = dsd_opts_current_input_timing_rate(opts);
-#ifdef USE_RADIO
-    if (opts->audio_in_type == AUDIO_IN_RTL && state->rtl_ctx) {
-        int rtl_demod_rate = (int)dsd_rtl_stream_metrics_hook_output_rate_hz();
-        if (rtl_demod_rate > 0) {
-            demod_rate = rtl_demod_rate;
-        }
-    }
-#endif
-
+    int demod_rate = frame_sync_current_demod_rate(opts, state);
     state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, 4800, demod_rate);
     state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
 #ifdef USE_RADIO
@@ -369,7 +376,7 @@ frame_sync_match_profile_active(const frame_sync_match_ctx* ctx, int profile_ind
 }
 
 static int frame_sync_cqpsk_4level_enabled(const dsd_opts* opts, const dsd_state* state);
-static int frame_sync_active_profile_modulation(const dsd_state* state);
+static int frame_sync_active_profile_modulation(const dsd_opts* opts, const dsd_state* state);
 
 static inline void
 frame_sync_set_basic_lock(frame_sync_match_ctx* ctx) {
@@ -1082,8 +1089,8 @@ frame_sync_try_m17(frame_sync_match_ctx* ctx) {
 static inline void
 frame_sync_prepare_dmr_sync(frame_sync_match_ctx* ctx) {
     frame_sync_set_basic_lock(ctx);
-    dmr_set_symbol_timing(ctx->opts, ctx->state);
     frame_sync_maybe_force_dmr_gfsk(ctx->opts, ctx->state);
+    dmr_set_symbol_timing(ctx->opts, ctx->state);
 }
 
 static int
@@ -1916,7 +1923,7 @@ frame_sync_maybe_auto_switch_modulation(const dsd_opts* opts, dsd_state* state, 
         return;
     }
 
-    int want_mod = frame_sync_active_profile_modulation(state);
+    int want_mod = frame_sync_active_profile_modulation(opts, state);
     want_mod = frame_sync_bias_want_mod_with_snr(state, want_mod);
     want_mod = frame_sync_override_want_mod_with_hamming(opts, state, want_mod);
     frame_sync_update_mod_votes(want_mod);
@@ -2277,7 +2284,7 @@ frame_sync_window_levels(const dsd_opts* opts, dsd_state* state, frame_sync_runt
     qsort(rt->lbuf2, rt->t_max, sizeof(float), comp);
     dsd_frame_sync_estimate_sorted_window_levels(rt->lbuf2, rt->t_max, &rt->lmin, &rt->lmax);
 
-    if (state->rf_mod == 1) {
+    if (frame_sync_active_profile_modulation(opts, state) == 1) {
         dsd_state_push_minmax_window(state, opts->msize, rt->lmin, rt->lmax);
         state->center = ((state->max) + (state->min)) / 2.0f;
         state->maxref = (state->max) * 0.80F;
@@ -2289,13 +2296,16 @@ frame_sync_window_levels(const dsd_opts* opts, dsd_state* state, frame_sync_runt
 }
 
 static int
-frame_sync_active_profile_modulation(const dsd_state* state) {
+frame_sync_active_profile_modulation(const dsd_opts* opts, const dsd_state* state) {
+    const frame_sync_sps_profile* profile =
+        frame_sync_sps_profile_for_index(state ? state->sps_hunt_idx : FRAME_SYNC_SPS_PROFILE_4800_4);
+    if ((!opts || !opts->mod_cli_lock) && profile->levels == 2) {
+        return 2;
+    }
     if (state && state->rf_mod == 1) {
         return 1;
     }
-    const frame_sync_sps_profile* profile =
-        frame_sync_sps_profile_for_index(state ? state->sps_hunt_idx : FRAME_SYNC_SPS_PROFILE_4800_4);
-    if (profile->levels == 2 || (state && state->rf_mod == 2)) {
+    if (state && state->rf_mod == 2) {
         return 2;
     }
     return 0;
@@ -2303,8 +2313,8 @@ frame_sync_active_profile_modulation(const dsd_state* state) {
 
 #ifdef USE_RADIO
 static double
-frame_sync_active_profile_snr_db(const dsd_state* state) {
-    switch (frame_sync_active_profile_modulation(state)) {
+frame_sync_active_profile_snr_db(const dsd_opts* opts, const dsd_state* state) {
+    switch (frame_sync_active_profile_modulation(opts, state)) {
         case 1: return dsd_rtl_stream_metrics_hook_snr_cqpsk_db();
         case 2: return dsd_rtl_stream_metrics_hook_snr_gfsk_db();
         default: return dsd_rtl_stream_metrics_hook_snr_c4fm_db();
@@ -2314,12 +2324,12 @@ frame_sync_active_profile_snr_db(const dsd_state* state) {
 
 static int
 frame_sync_should_skip_snr_or_power_gate(const dsd_opts* opts, const dsd_state* state) {
-    const int active_modulation = frame_sync_active_profile_modulation(state);
+    const int active_modulation = frame_sync_active_profile_modulation(opts, state);
 #ifdef USE_RADIO
     {
         const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
         if (cfg && cfg->snr_sql_is_set) {
-            double snr_db = frame_sync_active_profile_snr_db(state);
+            double snr_db = frame_sync_active_profile_snr_db(opts, state);
             if (snr_db > -150.0 && snr_db < (double)cfg->snr_sql_db) {
                 return 1;
             }
@@ -2671,8 +2681,8 @@ dsd_frame_sync_test_try_protocol_matches(dsd_opts* opts, dsd_state* state, const
 }
 
 int
-dsd_frame_sync_test_active_profile_modulation(const dsd_state* state) {
-    return frame_sync_active_profile_modulation(state);
+dsd_frame_sync_test_active_profile_modulation(const dsd_opts* opts, const dsd_state* state) {
+    return frame_sync_active_profile_modulation(opts, state);
 }
 
 int
@@ -2682,8 +2692,8 @@ dsd_frame_sync_test_should_skip_snr_or_power_gate(const dsd_opts* opts, const ds
 
 #ifdef USE_RADIO
 double
-dsd_frame_sync_test_active_profile_snr_db(const dsd_state* state) {
-    return frame_sync_active_profile_snr_db(state);
+dsd_frame_sync_test_active_profile_snr_db(const dsd_opts* opts, const dsd_state* state) {
+    return frame_sync_active_profile_snr_db(opts, state);
 }
 #endif
 #endif
@@ -2756,36 +2766,37 @@ dsd_frame_sync_test_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* s
 
 static void
 frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx) {
-    if (!opts || !state || next_idx < 0 || next_idx >= FRAME_SYNC_SPS_PROFILE_COUNT
-        || next_idx == state->sps_hunt_idx) {
+    if (!opts || !state || next_idx < 0 || next_idx >= FRAME_SYNC_SPS_PROFILE_COUNT) {
         return;
     }
-    state->sps_hunt_idx = next_idx;
-    dsd_frame_sync_reset_mod_state();
+
     const frame_sync_sps_profile* profile = frame_sync_sps_profile_for_index(next_idx);
-
-#ifdef USE_RADIO
-    int demod_rate = 0;
-    if (opts->audio_in_type == AUDIO_IN_RTL && state->rtl_ctx) {
-        demod_rate = (int)dsd_rtl_stream_metrics_hook_output_rate_hz();
+    const int profile_changed = next_idx != state->sps_hunt_idx;
+    const int force_binary_modulation = !opts->mod_cli_lock && profile->levels == 2 && state->rf_mod != 2;
+    if (!profile_changed && !force_binary_modulation) {
+        return;
     }
-    if (demod_rate <= 0) {
-        demod_rate = dsd_opts_current_input_timing_rate(opts);
-    }
-#else
-    int demod_rate = dsd_opts_current_input_timing_rate(opts);
-#endif
 
-    int sym_rate = profile->symbol_rate_hz;
-    state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, sym_rate, demod_rate);
-    state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
+    state->sps_hunt_idx = next_idx;
+    if (force_binary_modulation) {
+        state->rf_mod = 2;
+    }
+    dsd_frame_sync_reset_mod_state();
+
+    if (profile_changed) {
+        int demod_rate = frame_sync_current_demod_rate(opts, state);
+        int sym_rate = profile->symbol_rate_hz;
+        state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, sym_rate, demod_rate);
+        state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
+        if (opts->verbose > 1 && !dsd_frame_sync_suppress_tcp_no_signal_console(opts, state)) {
+            DSD_FPRINTF(stderr, "SPS hunt: trying %d sps (sym=%d, demod=%d)\n", state->samplesPerSymbol, sym_rate,
+                        demod_rate);
+        }
+    }
+
 #ifdef USE_RADIO
     rtl_maybe_update_sps_profile(opts, state, profile);
 #endif
-    if (opts->verbose > 1 && !dsd_frame_sync_suppress_tcp_no_signal_console(opts, state)) {
-        DSD_FPRINTF(stderr, "SPS hunt: trying %d sps (sym=%d, demod=%d)\n", state->samplesPerSymbol, sym_rate,
-                    demod_rate);
-    }
 }
 
 #ifdef DSD_NEO_TEST_HOOKS
@@ -2795,9 +2806,47 @@ dsd_frame_sync_test_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* stat
 }
 #endif
 
+static int
+frame_sync_sps_profile_matching_timing(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state || state->samplesPerSymbol <= 0) {
+        return -1;
+    }
+
+    const int demod_rate = frame_sync_current_demod_rate(opts, state);
+    int matching_profile = -1;
+    for (int profile_index = 0; profile_index < FRAME_SYNC_SPS_PROFILE_COUNT; profile_index++) {
+        if (!frame_sync_sps_profile_has_candidate(opts, profile_index)) {
+            continue;
+        }
+        const frame_sync_sps_profile* profile = frame_sync_sps_profile_for_index(profile_index);
+        const int expected_sps = dsd_opts_compute_sps_rate(opts, profile->symbol_rate_hz, demod_rate);
+        if (expected_sps != state->samplesPerSymbol) {
+            continue;
+        }
+        if (profile_index == state->sps_hunt_idx) {
+            return profile_index;
+        }
+        if (matching_profile >= 0) {
+            /* 4800-symbol profiles can share timing; keep the existing level selection when timing is ambiguous. */
+            return -1;
+        }
+        matching_profile = profile_index;
+    }
+    return matching_profile;
+}
+
 static void
 frame_sync_ensure_enabled_sps_profile(const dsd_opts* opts, dsd_state* state) {
-    if (!opts || !state || frame_sync_sps_profile_has_candidate(opts, state->sps_hunt_idx)) {
+    if (!opts || !state) {
+        return;
+    }
+
+    const int timing_profile = frame_sync_sps_profile_matching_timing(opts, state);
+    if (timing_profile >= 0 && timing_profile != state->sps_hunt_idx) {
+        frame_sync_apply_sps_hunt_profile(opts, state, timing_profile);
+    }
+    if (frame_sync_sps_profile_has_candidate(opts, state->sps_hunt_idx)) {
+        frame_sync_apply_sps_hunt_profile(opts, state, state->sps_hunt_idx);
         return;
     }
     for (int profile_index = 0; profile_index < FRAME_SYNC_SPS_PROFILE_COUNT; profile_index++) {
@@ -2807,6 +2856,13 @@ frame_sync_ensure_enabled_sps_profile(const dsd_opts* opts, dsd_state* state) {
         }
     }
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_frame_sync_test_ensure_enabled_sps_profile(const dsd_opts* opts, dsd_state* state) {
+    frame_sync_ensure_enabled_sps_profile(opts, state);
+}
+#endif
 
 static void
 frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -2311,12 +2311,12 @@ frame_sync_materialize_ready_windows(frame_sync_runtime_ctx* rt) {
 
 static void
 frame_sync_window_levels(const dsd_opts* opts, dsd_state* state, frame_sync_runtime_ctx* rt) {
-    int i;
-    for (i = 0; i < rt->t_max; i++) {
+    const int level_count = rt->level_count;
+    for (int i = 0; i < level_count; i++) {
         rt->lbuf2[i] = rt->lbuf[i];
     }
-    qsort(rt->lbuf2, rt->t_max, sizeof(float), comp);
-    dsd_frame_sync_estimate_sorted_window_levels(rt->lbuf2, rt->t_max, &rt->lmin, &rt->lmax);
+    qsort(rt->lbuf2, level_count, sizeof(float), comp);
+    dsd_frame_sync_estimate_sorted_window_levels(rt->lbuf2, level_count, &rt->lmin, &rt->lmax);
 
     if (frame_sync_active_profile_modulation(opts, state) == 1) {
         dsd_state_push_minmax_window(state, opts->msize, rt->lmin, rt->lmax);
@@ -2330,10 +2330,31 @@ frame_sync_window_levels(const dsd_opts* opts, dsd_state* state, frame_sync_runt
 }
 
 static int
+frame_sync_active_profile_is_gfsk_only(const dsd_opts* opts, int profile_index) {
+    if (!opts) {
+        return 0;
+    }
+
+    switch (profile_index) {
+        case FRAME_SYNC_SPS_PROFILE_4800_4: {
+            const int has_gfsk = opts->frame_dmr == 1 || opts->frame_nxdn96 == 1 || opts->frame_m17 == 1;
+            const int has_other_modulation = opts->frame_p25p1 == 1 || opts->frame_ysf == 1;
+            return has_gfsk && !has_other_modulation;
+        }
+        case FRAME_SYNC_SPS_PROFILE_2400_4: return opts->frame_nxdn48 == 1 || opts->frame_dpmr == 1;
+        default: return 0;
+    }
+}
+
+static int
 frame_sync_active_profile_modulation(const dsd_opts* opts, const dsd_state* state) {
-    const frame_sync_sps_profile* profile =
-        frame_sync_sps_profile_for_index(state ? state->sps_hunt_idx : FRAME_SYNC_SPS_PROFILE_4800_4);
-    if ((!opts || !opts->mod_cli_lock) && profile->levels == 2) {
+    int profile_index = state ? state->sps_hunt_idx : FRAME_SYNC_SPS_PROFILE_4800_4;
+    if (profile_index < 0 || profile_index >= FRAME_SYNC_SPS_PROFILE_COUNT) {
+        profile_index = FRAME_SYNC_SPS_PROFILE_4800_4;
+    }
+    const frame_sync_sps_profile* profile = frame_sync_sps_profile_for_index(profile_index);
+    if ((!opts || !opts->mod_cli_lock)
+        && (profile->levels == 2 || frame_sync_active_profile_is_gfsk_only(opts, profile_index))) {
         return 2;
     }
     if (state && state->rf_mod == 1) {
@@ -2626,7 +2647,9 @@ frame_sync_debug_sync_window(dsd_opts* opts, dsd_state* state, const frame_sync_
 
 static int
 frame_sync_eval_window(dsd_opts* opts, dsd_state* state, frame_sync_runtime_ctx* rt, time_t now, double nowm) {
-    if (rt->level_count >= rt->t_max) {
+    /* Some matchers accept windows shorter than the profile's level ring. Estimate
+     * from every sample gathered so far before one of those matchers can return. */
+    if (rt->level_count > 0) {
         frame_sync_window_levels(opts, state, rt);
     }
     frame_sync_materialize_ready_windows(rt);
@@ -2712,6 +2735,27 @@ dsd_frame_sync_test_try_protocol_matches(dsd_opts* opts, dsd_state* state, const
         .synctest48 = rt.synctest48,
     };
     return frame_sync_try_protocol_matches(&match_ctx);
+}
+
+int
+dsd_frame_sync_test_eval_window(dsd_opts* opts, dsd_state* state, const char* symbols, const float* levels,
+                                int symbol_count) {
+    if (!opts || !state || !symbols || !levels || symbol_count < 0) {
+        return DSD_SYNC_NONE;
+    }
+
+    frame_sync_runtime_ctx rt;
+    frame_sync_runtime_init(&rt, opts, state);
+    for (int i = 0; i < symbol_count; i++) {
+        rt.lbuf[rt.lidx] = levels[i];
+        if (rt.level_count < rt.t_max) {
+            rt.level_count++;
+        }
+        rt.lidx = (rt.lidx + 1) % rt.t_max;
+        frame_sync_history_push(&rt, symbols[i]);
+    }
+    rt.synctest_pos = symbol_count > 0 ? symbol_count - 1 : 0;
+    return frame_sync_eval_window(opts, state, &rt, 0, 0.0);
 }
 
 int

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -28,7 +28,6 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/p25_cqpsk_dibit.h>
 #include <dsd-neo/core/state.h>
-#include <dsd-neo/core/string_utils.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/time_format.h>
@@ -60,6 +59,34 @@
 #include <dsd-neo/core/power.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #endif
+
+enum {
+    FRAME_SYNC_SPS_PROFILE_4800_4 = 0,
+    FRAME_SYNC_SPS_PROFILE_2400_4 = 1,
+    FRAME_SYNC_SPS_PROFILE_9600_2 = 2,
+    FRAME_SYNC_SPS_PROFILE_6000_4 = 3,
+    FRAME_SYNC_SPS_PROFILE_4800_2 = 4,
+    FRAME_SYNC_SPS_PROFILE_COUNT = 5,
+    FRAME_SYNC_HISTORY_CAPACITY = 48,
+};
+
+typedef struct {
+    int symbol_rate_hz;
+    int levels;
+} frame_sync_sps_profile;
+
+/* Keep this order in sync with dsd_state::sps_hunt_idx. */
+static const frame_sync_sps_profile k_frame_sync_sps_profiles[FRAME_SYNC_SPS_PROFILE_COUNT] = {
+    {4800, 4}, {2400, 4}, {9600, 2}, {6000, 4}, {4800, 2},
+};
+
+static const frame_sync_sps_profile*
+frame_sync_sps_profile_for_index(int index) {
+    if (index < 0 || index >= FRAME_SYNC_SPS_PROFILE_COUNT) {
+        return &k_frame_sync_sps_profiles[FRAME_SYNC_SPS_PROFILE_4800_4];
+    }
+    return &k_frame_sync_sps_profiles[index];
+}
 
 static int
 frame_sync_opts_has_4800_four_level_mode(const dsd_opts* opts) {
@@ -112,16 +139,6 @@ dmr_best_sync_hamming(const char* window, const char** out_name) {
 }
 
 static int
-rtl_opts_has_any_four_level_mode(const dsd_opts* opts) {
-    if (!opts) {
-        return 0;
-    }
-    return (opts->frame_p25p1 == 1 || opts->frame_p25p2 == 1 || opts->frame_dmr == 1 || opts->frame_nxdn48 == 1
-            || opts->frame_nxdn96 == 1 || opts->frame_x2tdma == 1 || opts->frame_ysf == 1 || opts->frame_dpmr == 1
-            || opts->frame_m17 == 1);
-}
-
-static int
 rtl_opts_has_4800_wide_four_level_mode(const dsd_opts* opts) {
     if (!opts) {
         return 0;
@@ -130,124 +147,45 @@ rtl_opts_has_4800_wide_four_level_mode(const dsd_opts* opts) {
 }
 
 static int
-rtl_p25_profile_for_state(const dsd_state* state) {
-    return (state && state->rf_mod == 1) ? DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK
-                                         : DSD_RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
-}
-
-static int
-rtl_fallback_profile_for_symbol_rate(int sym_rate_hz) {
-    if (sym_rate_hz == 2400) {
+rtl_profile_for_sps_profile(const dsd_opts* opts, const dsd_state* state, const frame_sync_sps_profile* profile) {
+    if (!profile) {
+        return DSD_RTL_STREAM_CHANNEL_PROFILE_WIDE;
+    }
+    if (profile->symbol_rate_hz == 2400 || (profile->symbol_rate_hz == 4800 && profile->levels == 2)) {
         return DSD_RTL_STREAM_CHANNEL_PROFILE_6K25;
     }
-    if (sym_rate_hz == 9600) {
+    if (profile->symbol_rate_hz == 9600) {
         return DSD_RTL_STREAM_CHANNEL_PROFILE_PROVOICE;
     }
-    return DSD_RTL_STREAM_CHANNEL_PROFILE_WIDE;
-}
-
-static int
-rtl_profile_for_explicit_symbol_rate(const dsd_opts* opts, int sym_rate_hz, int preferred_levels) {
-    if (sym_rate_hz == 4800 && preferred_levels == 2 && opts->frame_dstar == 1) {
-        return DSD_RTL_STREAM_CHANNEL_PROFILE_6K25;
-    }
-    if (sym_rate_hz == 9600 && opts->frame_provoice == 1) {
-        return DSD_RTL_STREAM_CHANNEL_PROFILE_PROVOICE;
-    }
-    if (sym_rate_hz == 2400 && (opts->frame_nxdn48 == 1 || opts->frame_dpmr == 1)) {
-        return DSD_RTL_STREAM_CHANNEL_PROFILE_6K25;
-    }
-    if (sym_rate_hz == 6000 && opts->frame_p25p2 == 1) {
+    if (state && state->rf_mod == 1) {
         return DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
     }
-    if (sym_rate_hz == 6000 && opts->frame_x2tdma == 1) {
+    if (profile->symbol_rate_hz == 6000 || (state && state->rf_mod == 2)
+        || rtl_opts_has_4800_wide_four_level_mode(opts)) {
         return DSD_RTL_STREAM_CHANNEL_PROFILE_12K5;
     }
-    return -1;
-}
-
-static int
-rtl_profile_for_enabled_protocols(const dsd_opts* opts, const dsd_state* state) {
-    if (rtl_opts_has_4800_wide_four_level_mode(opts)) {
-        return DSD_RTL_STREAM_CHANNEL_PROFILE_12K5;
-    }
-    if (opts->frame_p25p1 == 1 || opts->frame_p25p2 == 1) {
-        return rtl_p25_profile_for_state(state);
-    }
-    if (opts->frame_nxdn48 == 1 || opts->frame_dpmr == 1 || opts->frame_dstar == 1) {
-        return DSD_RTL_STREAM_CHANNEL_PROFILE_6K25;
-    }
-    if (opts->frame_x2tdma == 1) {
-        return DSD_RTL_STREAM_CHANNEL_PROFILE_12K5;
-    }
-    if (opts->frame_provoice == 1) {
-        return DSD_RTL_STREAM_CHANNEL_PROFILE_PROVOICE;
-    }
-    return -1;
-}
-
-static int
-rtl_profile_for_symbol_rate(const dsd_opts* opts, const dsd_state* state, int sym_rate_hz, int preferred_levels) {
-    if (opts) {
-        int profile = rtl_profile_for_explicit_symbol_rate(opts, sym_rate_hz, preferred_levels);
-        if (profile >= 0) {
-            return profile;
-        }
-        profile = rtl_profile_for_enabled_protocols(opts, state);
-        if (profile >= 0) {
-            return profile;
-        }
-    }
-    return rtl_fallback_profile_for_symbol_rate(sym_rate_hz);
-}
-
-static int
-rtl_levels_for_symbol_rate(const dsd_opts* opts, int sym_rate_hz, int preferred_levels) {
-    if (preferred_levels == 2 || preferred_levels == 4) {
-        return preferred_levels;
-    }
-    if (!opts) {
-        return 4;
-    }
-    if (sym_rate_hz == 9600 && opts->frame_provoice == 1) {
-        return 2;
-    }
-    if (sym_rate_hz == 4800 && opts->frame_dstar == 1 && !frame_sync_opts_has_4800_four_level_mode(opts)) {
-        return 2;
-    }
-    if ((opts->frame_dstar == 1 || opts->frame_provoice == 1) && !rtl_opts_has_any_four_level_mode(opts)) {
-        return 2;
-    }
-    return 4;
+    return DSD_RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
 }
 
 #ifdef DSD_NEO_TEST_HOOKS
 int
-dsd_frame_sync_test_rtl_profile_for_symbol_rate(const dsd_opts* opts, const dsd_state* state, int sym_rate_hz,
-                                                int preferred_levels) {
-    return rtl_profile_for_symbol_rate(opts, state, sym_rate_hz, preferred_levels);
-}
-
-int
-dsd_frame_sync_test_rtl_levels_for_symbol_rate(const dsd_opts* opts, int sym_rate_hz, int preferred_levels) {
-    return rtl_levels_for_symbol_rate(opts, sym_rate_hz, preferred_levels);
+dsd_frame_sync_test_rtl_profile_for_sps_index(const dsd_opts* opts, const dsd_state* state, int profile_index) {
+    return rtl_profile_for_sps_profile(opts, state, frame_sync_sps_profile_for_index(profile_index));
 }
 #endif
 
 static void
-rtl_maybe_update_symbol_profile_with_hint(const dsd_opts* opts, const dsd_state* state, int sym_rate_hz,
-                                          int preferred_levels) {
-    if (!opts || !state || opts->audio_in_type != AUDIO_IN_RTL || !state->rtl_ctx || sym_rate_hz <= 0) {
+rtl_maybe_update_sps_profile(const dsd_opts* opts, const dsd_state* state, const frame_sync_sps_profile* profile) {
+    if (!opts || !state || !profile || opts->audio_in_type != AUDIO_IN_RTL || !state->rtl_ctx) {
         return;
     }
-    (void)dsd_rtl_stream_metrics_hook_set_symbol_profile(
-        sym_rate_hz, rtl_levels_for_symbol_rate(opts, sym_rate_hz, preferred_levels),
-        rtl_profile_for_symbol_rate(opts, state, sym_rate_hz, preferred_levels));
+    (void)dsd_rtl_stream_metrics_hook_set_symbol_profile(profile->symbol_rate_hz, profile->levels,
+                                                         rtl_profile_for_sps_profile(opts, state, profile));
 }
 
 static void
-rtl_maybe_update_symbol_profile(const dsd_opts* opts, const dsd_state* state, int sym_rate_hz) {
-    rtl_maybe_update_symbol_profile_with_hint(opts, state, sym_rate_hz, 0);
+rtl_maybe_update_active_sps_profile(const dsd_opts* opts, const dsd_state* state) {
+    rtl_maybe_update_sps_profile(opts, state, frame_sync_sps_profile_for_index(state->sps_hunt_idx));
 }
 #endif
 
@@ -270,7 +208,7 @@ dmr_set_symbol_timing(const dsd_opts* opts, dsd_state* state) {
     state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, 4800, demod_rate);
     state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
 #ifdef USE_RADIO
-    rtl_maybe_update_symbol_profile(opts, state, 4800);
+    rtl_maybe_update_active_sps_profile(opts, state);
 #endif
 }
 
@@ -373,6 +311,17 @@ printFrameSync(const dsd_opts* opts, const dsd_state* state, const char* framety
     /* stack buffer; no free */
 }
 
+enum {
+    FRAME_SYNC_WINDOW_8 = 1u << 0,
+    FRAME_SYNC_WINDOW_10 = 1u << 1,
+    FRAME_SYNC_WINDOW_12 = 1u << 2,
+    FRAME_SYNC_WINDOW_16 = 1u << 3,
+    FRAME_SYNC_WINDOW_20 = 1u << 4,
+    FRAME_SYNC_WINDOW_24 = 1u << 5,
+    FRAME_SYNC_WINDOW_32 = 1u << 6,
+    FRAME_SYNC_WINDOW_48 = 1u << 7,
+};
+
 typedef struct {
     dsd_opts* opts;
     dsd_state* state;
@@ -381,8 +330,8 @@ typedef struct {
     int synctest_pos;
     float lmax;
     float lmin;
+    unsigned int ready_windows;
     char* modulation;
-    char* synctest_p;
     char* synctest;
     char* synctest8;
     char* synctest10;
@@ -393,7 +342,34 @@ typedef struct {
     char* synctest48;
 } frame_sync_match_ctx;
 
+static unsigned int
+frame_sync_window_flag(int length) {
+    switch (length) {
+        case 8: return FRAME_SYNC_WINDOW_8;
+        case 10: return FRAME_SYNC_WINDOW_10;
+        case 12: return FRAME_SYNC_WINDOW_12;
+        case 16: return FRAME_SYNC_WINDOW_16;
+        case 20: return FRAME_SYNC_WINDOW_20;
+        case 24: return FRAME_SYNC_WINDOW_24;
+        case 32: return FRAME_SYNC_WINDOW_32;
+        case 48: return FRAME_SYNC_WINDOW_48;
+        default: return 0;
+    }
+}
+
+static int
+frame_sync_match_window_ready(const frame_sync_match_ctx* ctx, int length) {
+    const unsigned int flag = frame_sync_window_flag(length);
+    return ctx && flag != 0 && (ctx->ready_windows & flag) != 0;
+}
+
+static int
+frame_sync_match_profile_active(const frame_sync_match_ctx* ctx, int profile_index) {
+    return ctx && ctx->state && ctx->state->sps_hunt_idx == profile_index;
+}
+
 static int frame_sync_cqpsk_4level_enabled(const dsd_opts* opts, const dsd_state* state);
+static int frame_sync_active_profile_modulation(const dsd_state* state);
 
 static inline void
 frame_sync_set_basic_lock(frame_sync_match_ctx* ctx) {
@@ -651,6 +627,12 @@ frame_sync_accept_p25p2(frame_sync_match_ctx* ctx, int synctype, int inverted, c
                         int set_last_before_info, frame_sync_p25_center_mode_t center_mode) {
     dsd_opts* opts = ctx->opts;
     dsd_state* state = ctx->state;
+    if (!opts->mod_cli_lock) {
+        state->rf_mod = 1;
+#ifdef USE_RADIO
+        rtl_maybe_update_active_sps_profile(opts, state);
+#endif
+    }
     frame_sync_set_basic_lock(ctx);
     opts->inverted_p2 = inverted;
     if (set_last_before_info) {
@@ -670,9 +652,41 @@ frame_sync_accept_p25p2(frame_sync_match_ctx* ctx, int synctype, int inverted, c
     }
 }
 
+#ifdef USE_RADIO
+static int
+frame_sync_try_rotated_p25(frame_sync_match_ctx* ctx, const char* symbols, const char* pattern, int pattern_len,
+                           int synctype, int inverted, const char* label, int phase2, int set_last_before_info) {
+    const dsd_opts* opts = ctx->opts;
+    const dsd_state* state = ctx->state;
+    uint8_t map_idx = DSD_P25_CQPSK_DIBIT_MAP_IDENTITY;
+    if (!frame_sync_cqpsk_4level_enabled(opts, state)
+        || !frame_sync_find_rotated_p25_cqpsk_map(symbols, pattern, &map_idx)) {
+        return DSD_SYNC_NONE;
+    }
+
+    frame_sync_p25_cqpsk_raw_fit_t fit = {0.0f, 0.0f};
+    dsd_warm_start_result_t center_result = frame_sync_fit_p25_cqpsk_raw_sync(ctx, symbols, pattern_len, &fit);
+    if (frame_sync_p25_cqpsk_map_requires_center_fit(map_idx) && center_result != DSD_WARM_START_OK) {
+        return DSD_SYNC_NONE;
+    }
+
+    frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
+    if (phase2) {
+        frame_sync_accept_p25p2(ctx, synctype, inverted, label, set_last_before_info, FRAME_SYNC_P25_CENTER_SKIP);
+    } else {
+        frame_sync_accept_p25p1(ctx, synctype, label, FRAME_SYNC_P25_CENTER_SKIP);
+    }
+    if (center_result == DSD_WARM_START_OK) {
+        frame_sync_apply_p25_cqpsk_raw_fit(ctx, &fit);
+    }
+    return synctype;
+}
+#endif
+
 static int
 frame_sync_try_p25p1(frame_sync_match_ctx* ctx) {
-    if (ctx->opts->frame_p25p1 != 1) {
+    if (ctx->opts->frame_p25p1 != 1 || !frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_4800_4)
+        || !frame_sync_match_window_ready(ctx, 24)) {
         return DSD_SYNC_NONE;
     }
 
@@ -689,93 +703,54 @@ frame_sync_try_p25p1(frame_sync_match_ctx* ctx) {
     }
 
 #ifdef USE_RADIO
-    const dsd_opts* opts = ctx->opts;
-    const dsd_state* state = ctx->state;
-    uint8_t map_idx = DSD_P25_CQPSK_DIBIT_MAP_IDENTITY;
-    if (frame_sync_cqpsk_4level_enabled(opts, state)
-        && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest, P25P1_SYNC, &map_idx)) {
-        frame_sync_p25_cqpsk_raw_fit_t fit = {0.0f, 0.0f};
-        dsd_warm_start_result_t center_result = frame_sync_fit_p25_cqpsk_raw_sync(ctx, ctx->synctest, 24, &fit);
-        if (frame_sync_p25_cqpsk_map_requires_center_fit(map_idx) && center_result != DSD_WARM_START_OK) {
-            return DSD_SYNC_NONE;
-        }
-        frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
-        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_POS, "+P25p1", FRAME_SYNC_P25_CENTER_SKIP);
-        if (center_result == DSD_WARM_START_OK) {
-            frame_sync_apply_p25_cqpsk_raw_fit(ctx, &fit);
-        }
-        return DSD_SYNC_P25P1_POS;
+    int sync_type =
+        frame_sync_try_rotated_p25(ctx, ctx->synctest, P25P1_SYNC, 24, DSD_SYNC_P25P1_POS, 0, "+P25p1", 0, 0);
+    if (sync_type != DSD_SYNC_NONE) {
+        return sync_type;
     }
-
-    if (frame_sync_cqpsk_4level_enabled(opts, state)
-        && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest, INV_P25P1_SYNC, &map_idx)) {
-        frame_sync_p25_cqpsk_raw_fit_t fit = {0.0f, 0.0f};
-        dsd_warm_start_result_t center_result = frame_sync_fit_p25_cqpsk_raw_sync(ctx, ctx->synctest, 24, &fit);
-        if (frame_sync_p25_cqpsk_map_requires_center_fit(map_idx) && center_result != DSD_WARM_START_OK) {
-            return DSD_SYNC_NONE;
-        }
-        frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
-        frame_sync_accept_p25p1(ctx, DSD_SYNC_P25P1_NEG, "-P25p1 ", FRAME_SYNC_P25_CENTER_SKIP);
-        if (center_result == DSD_WARM_START_OK) {
-            frame_sync_apply_p25_cqpsk_raw_fit(ctx, &fit);
-        }
-        return DSD_SYNC_P25P1_NEG;
-    }
-#endif
-
+    return frame_sync_try_rotated_p25(ctx, ctx->synctest, INV_P25P1_SYNC, 24, DSD_SYNC_P25P1_NEG, 0, "-P25p1 ", 0, 0);
+#else
     return DSD_SYNC_NONE;
+#endif
+}
+
+static int
+frame_sync_accept_x2tdma(frame_sync_match_ctx* ctx, int synctype, const char* label, int marks_first_frame) {
+    const dsd_opts* opts = ctx->opts;
+    dsd_state* state = ctx->state;
+    frame_sync_set_basic_lock(ctx);
+    DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "X2-TDMA");
+    if (opts->errorbars == 1) {
+        printFrameSync(opts, state, label, ctx->synctest_pos + 1, ctx->modulation);
+    }
+    if (marks_first_frame && state->lastsynctype != synctype) {
+        state->firstframe = 1;
+    }
+    state->lastsynctype = synctype;
+    dsd_sync_warm_start_thresholds_outer_only(opts, state, 24);
+    return synctype;
 }
 
 static int
 frame_sync_try_x2tdma(frame_sync_match_ctx* ctx) {
     const dsd_opts* opts = ctx->opts;
-    dsd_state* state = ctx->state;
-    if (opts->frame_x2tdma != 1) {
+    if (opts->frame_x2tdma != 1 || !frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_6000_4)
+        || !frame_sync_match_window_ready(ctx, 24)) {
         return DSD_SYNC_NONE;
     }
 
     if ((strcmp(ctx->synctest, X2TDMA_BS_DATA_SYNC) == 0) || (strcmp(ctx->synctest, X2TDMA_MS_DATA_SYNC) == 0)) {
-        frame_sync_set_basic_lock(ctx);
-        DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "X2-TDMA");
         if (opts->inverted_x2tdma == 0) {
-            if (opts->errorbars == 1) {
-                printFrameSync(opts, state, "+X2-TDMA ", ctx->synctest_pos + 1, ctx->modulation);
-            }
-            state->lastsynctype = DSD_SYNC_X2TDMA_DATA_POS;
-            dsd_sync_warm_start_thresholds_outer_only(opts, state, 24);
-            return DSD_SYNC_X2TDMA_DATA_POS;
+            return frame_sync_accept_x2tdma(ctx, DSD_SYNC_X2TDMA_DATA_POS, "+X2-TDMA ", 0);
         }
-        if (opts->errorbars == 1) {
-            printFrameSync(opts, state, "-X2-TDMA ", ctx->synctest_pos + 1, ctx->modulation);
-        }
-        if (state->lastsynctype != DSD_SYNC_X2TDMA_VOICE_NEG) {
-            state->firstframe = 1;
-        }
-        state->lastsynctype = DSD_SYNC_X2TDMA_VOICE_NEG;
-        dsd_sync_warm_start_thresholds_outer_only(opts, state, 24);
-        return DSD_SYNC_X2TDMA_VOICE_NEG;
+        return frame_sync_accept_x2tdma(ctx, DSD_SYNC_X2TDMA_VOICE_NEG, "-X2-TDMA ", 1);
     }
 
     if ((strcmp(ctx->synctest, X2TDMA_BS_VOICE_SYNC) == 0) || (strcmp(ctx->synctest, X2TDMA_MS_VOICE_SYNC) == 0)) {
-        frame_sync_set_basic_lock(ctx);
-        DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "X2-TDMA");
         if (opts->inverted_x2tdma == 0) {
-            if (opts->errorbars == 1) {
-                printFrameSync(opts, state, "+X2-TDMA ", ctx->synctest_pos + 1, ctx->modulation);
-            }
-            if (state->lastsynctype != DSD_SYNC_X2TDMA_VOICE_POS) {
-                state->firstframe = 1;
-            }
-            state->lastsynctype = DSD_SYNC_X2TDMA_VOICE_POS;
-            dsd_sync_warm_start_thresholds_outer_only(opts, state, 24);
-            return DSD_SYNC_X2TDMA_VOICE_POS;
+            return frame_sync_accept_x2tdma(ctx, DSD_SYNC_X2TDMA_VOICE_POS, "+X2-TDMA ", 1);
         }
-        if (opts->errorbars == 1) {
-            printFrameSync(opts, state, "-X2-TDMA ", ctx->synctest_pos + 1, ctx->modulation);
-        }
-        state->lastsynctype = DSD_SYNC_X2TDMA_DATA_NEG;
-        dsd_sync_warm_start_thresholds_outer_only(opts, state, 24);
-        return DSD_SYNC_X2TDMA_DATA_NEG;
+        return frame_sync_accept_x2tdma(ctx, DSD_SYNC_X2TDMA_DATA_NEG, "-X2-TDMA ", 0);
     }
 
     return DSD_SYNC_NONE;
@@ -785,8 +760,8 @@ static int
 frame_sync_try_ysf(frame_sync_match_ctx* ctx) {
     dsd_opts* opts = ctx->opts;
     dsd_state* state = ctx->state;
-    dsd_strncpy_s(ctx->synctest20, 21, (ctx->synctest_p - 19), 20);
-    if (opts->frame_ysf != 1 || dsd_frame_sync_suppress_p25_alt_sync(opts, state)) {
+    if (opts->frame_ysf != 1 || !frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_4800_4)
+        || !frame_sync_match_window_ready(ctx, 20) || dsd_frame_sync_suppress_p25_alt_sync(opts, state)) {
         return DSD_SYNC_NONE;
     }
 
@@ -813,8 +788,8 @@ frame_sync_try_ysf(frame_sync_match_ctx* ctx) {
 
 static int
 frame_sync_try_p25p2(frame_sync_match_ctx* ctx) {
-    dsd_strncpy_s(ctx->synctest20, 21, (ctx->synctest_p - 19), 20);
-    if (ctx->opts->frame_p25p2 != 1) {
+    if (ctx->opts->frame_p25p2 != 1 || !frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_6000_4)
+        || !frame_sync_match_window_ready(ctx, 20)) {
         return DSD_SYNC_NONE;
     }
 
@@ -831,50 +806,23 @@ frame_sync_try_p25p2(frame_sync_match_ctx* ctx) {
     }
 
 #ifdef USE_RADIO
-    const dsd_opts* opts = ctx->opts;
-    const dsd_state* state = ctx->state;
-    uint8_t map_idx = DSD_P25_CQPSK_DIBIT_MAP_IDENTITY;
-    if (frame_sync_cqpsk_4level_enabled(opts, state)
-        && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest20, P25P2_SYNC, &map_idx)) {
-        frame_sync_p25_cqpsk_raw_fit_t fit = {0.0f, 0.0f};
-        dsd_warm_start_result_t center_result = frame_sync_fit_p25_cqpsk_raw_sync(ctx, ctx->synctest20, 20, &fit);
-        if (frame_sync_p25_cqpsk_map_requires_center_fit(map_idx) && center_result != DSD_WARM_START_OK) {
-            return DSD_SYNC_NONE;
-        }
-        frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
-        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_POS, 0, "+P25p2", 1, FRAME_SYNC_P25_CENTER_SKIP);
-        if (center_result == DSD_WARM_START_OK) {
-            frame_sync_apply_p25_cqpsk_raw_fit(ctx, &fit);
-        }
-        return DSD_SYNC_P25P2_POS;
+    int sync_type =
+        frame_sync_try_rotated_p25(ctx, ctx->synctest20, P25P2_SYNC, 20, DSD_SYNC_P25P2_POS, 0, "+P25p2", 1, 1);
+    if (sync_type != DSD_SYNC_NONE) {
+        return sync_type;
     }
-
-    if (frame_sync_cqpsk_4level_enabled(opts, state)
-        && frame_sync_find_rotated_p25_cqpsk_map(ctx->synctest20, INV_P25P2_SYNC, &map_idx)) {
-        frame_sync_p25_cqpsk_raw_fit_t fit = {0.0f, 0.0f};
-        dsd_warm_start_result_t center_result = frame_sync_fit_p25_cqpsk_raw_sync(ctx, ctx->synctest20, 20, &fit);
-        if (frame_sync_p25_cqpsk_map_requires_center_fit(map_idx) && center_result != DSD_WARM_START_OK) {
-            return DSD_SYNC_NONE;
-        }
-        frame_sync_set_p25_cqpsk_dibit_map(ctx, map_idx);
-        frame_sync_accept_p25p2(ctx, DSD_SYNC_P25P2_NEG, 1, "-P25p2", 0, FRAME_SYNC_P25_CENTER_SKIP);
-        if (center_result == DSD_WARM_START_OK) {
-            frame_sync_apply_p25_cqpsk_raw_fit(ctx, &fit);
-        }
-        return DSD_SYNC_P25P2_NEG;
-    }
-#endif
-
+    return frame_sync_try_rotated_p25(ctx, ctx->synctest20, INV_P25P2_SYNC, 20, DSD_SYNC_P25P2_NEG, 1, "-P25p2", 1, 0);
+#else
     return DSD_SYNC_NONE;
+#endif
 }
 
 static int
 frame_sync_try_dpmr(frame_sync_match_ctx* ctx) {
     const dsd_opts* opts = ctx->opts;
     dsd_state* state = ctx->state;
-    dsd_strncpy_s(ctx->synctest, 25, (ctx->synctest_p - 23), 24);
-    dsd_strncpy_s(ctx->synctest12, 13, (ctx->synctest_p - 11), 12);
-    if (opts->frame_dpmr != 1) {
+    if (opts->frame_dpmr != 1 || !frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_2400_4)
+        || !frame_sync_match_window_ready(ctx, 12)) {
         return DSD_SYNC_NONE;
     }
 
@@ -907,8 +855,14 @@ static int
 frame_sync_try_m17_preamble(frame_sync_match_ctx* ctx, int ham_pre, int ham_piv) {
     const dsd_opts* opts = ctx->opts;
     dsd_state* state = ctx->state;
+    /* An 8-symbol one-error preamble is ambiguous with several 4800/4 sync prefixes.
+     * Keep the legacy tolerance in forced M17 mode, but require the exact marker
+     * when the full profile has other candidates. */
+    const int other_4800_candidate =
+        opts->frame_p25p1 == 1 || opts->frame_dmr == 1 || opts->frame_nxdn96 == 1 || opts->frame_ysf == 1;
+    const int max_hamming = other_4800_candidate ? 0 : 1;
 
-    if (ham_pre <= 1) {
+    if (ham_pre <= max_hamming) {
         state->m17_polarity = 1;
         printFrameSync(opts, state, "+M17 PREAMBLE", ctx->synctest_pos + 1, ctx->modulation);
         frame_sync_set_basic_lock(ctx);
@@ -918,7 +872,7 @@ frame_sync_try_m17_preamble(frame_sync_match_ctx* ctx, int ham_pre, int ham_piv)
         return DSD_SYNC_M17_PRE_POS;
     }
 
-    if (ham_piv <= 1) {
+    if (ham_piv <= max_hamming) {
         state->m17_polarity = 2;
         printFrameSync(opts, state, "-M17 PREAMBLE", ctx->synctest_pos + 1, ctx->modulation);
         frame_sync_set_basic_lock(ctx);
@@ -1088,12 +1042,11 @@ static int
 frame_sync_try_m17(frame_sync_match_ctx* ctx) {
     const dsd_opts* opts = ctx->opts;
     const dsd_state* state = ctx->state;
-    if (opts->frame_m17 != 1) {
+    if (opts->frame_m17 != 1 || !frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_4800_4)
+        || !frame_sync_match_window_ready(ctx, 8)) {
         return DSD_SYNC_NONE;
     }
 
-    dsd_strncpy_s(ctx->synctest16, 17, (ctx->synctest_p - 15), 16);
-    dsd_strncpy_s(ctx->synctest8, 9, (ctx->synctest_p - 7), 8);
     int ham_pre = dsd_sync_hamming_distance(ctx->synctest8, M17_PRE, 8);
     int ham_piv = dsd_sync_hamming_distance(ctx->synctest8, M17_PIV, 8);
     int ham_lsf = dsd_sync_hamming_distance(ctx->synctest8, M17_LSF, 8);
@@ -1344,7 +1297,8 @@ frame_sync_try_dmr_dm_ts2_voice(frame_sync_match_ctx* ctx) {
 
 static int
 frame_sync_try_dmr(frame_sync_match_ctx* ctx) {
-    if (ctx->opts->frame_dmr != 1) {
+    if (ctx->opts->frame_dmr != 1 || !frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_4800_4)
+        || !frame_sync_match_window_ready(ctx, 24)) {
         return DSD_SYNC_NONE;
     }
 
@@ -1380,59 +1334,72 @@ frame_sync_try_dmr(frame_sync_match_ctx* ctx) {
 }
 
 static int
-frame_sync_try_provoice(frame_sync_match_ctx* ctx) {
+frame_sync_symbols_match_either(const char* symbols, const char* pattern_a, const char* pattern_b) {
+    return strcmp(symbols, pattern_a) == 0 || strcmp(symbols, pattern_b) == 0;
+}
+
+static int
+frame_sync_accept_provoice(frame_sync_match_ctx* ctx, int synctype, const char* label, int always_print) {
+    const dsd_opts* opts = ctx->opts;
+    dsd_state* state = ctx->state;
+    frame_sync_note_cc_sync(ctx);
+    frame_sync_set_basic_lock(ctx);
+    DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "ProVoice ");
+    if (always_print || opts->errorbars == 1) {
+        printFrameSync(opts, state, label, ctx->synctest_pos + 1, ctx->modulation);
+    }
+    state->lastsynctype = synctype;
+    dsd_sync_warm_start_thresholds_outer_only(opts, state, 32);
+    return synctype;
+}
+
+static int
+frame_sync_accept_edacs(frame_sync_match_ctx* ctx, int synctype, const char* label) {
+    const dsd_opts* opts = ctx->opts;
+    dsd_state* state = ctx->state;
+    dsd_mark_cc_sync(state);
+    frame_sync_set_basic_lock(ctx);
+    printFrameSync(opts, state, label, ctx->synctest_pos + 1, ctx->modulation);
+    state->lastsynctype = synctype;
+    dsd_sync_warm_start_thresholds_outer_only(opts, state, 48);
+    return synctype;
+}
+
+static void
+frame_sync_handle_edacs_dotting(frame_sync_match_ctx* ctx) {
     dsd_opts* opts = ctx->opts;
     dsd_state* state = ctx->state;
-    if (opts->frame_provoice != 1) {
+    if (opts->p25_trunk == 1 && opts->p25_is_tuned == 1) {
+        printFrameSync(opts, state, " EDACS  DOTTING SEQUENCE: ", ctx->synctest_pos + 1, ctx->modulation);
+        dsd_frame_sync_hook_eot_cc(opts, state);
+    }
+}
+
+static int
+frame_sync_try_provoice(frame_sync_match_ctx* ctx) {
+    const dsd_opts* opts = ctx->opts;
+    if (opts->frame_provoice != 1 || !frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_9600_2)) {
         return DSD_SYNC_NONE;
     }
 
-    dsd_strncpy_s(ctx->synctest32, 33, (ctx->synctest_p - 31), 32);
-    dsd_strncpy_s(ctx->synctest48, 49, (ctx->synctest_p - 47), 48);
-    if ((strcmp(ctx->synctest32, PROVOICE_SYNC) == 0) || (strcmp(ctx->synctest32, PROVOICE_EA_SYNC) == 0)) {
-        frame_sync_note_cc_sync(ctx);
-        frame_sync_set_basic_lock(ctx);
-        DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "ProVoice ");
-        if (opts->errorbars == 1) {
-            printFrameSync(opts, state, "+PV   ", ctx->synctest_pos + 1, ctx->modulation);
+    if (frame_sync_match_window_ready(ctx, 32)) {
+        if (frame_sync_symbols_match_either(ctx->synctest32, PROVOICE_SYNC, PROVOICE_EA_SYNC)) {
+            return frame_sync_accept_provoice(ctx, DSD_SYNC_PROVOICE_POS, "+PV   ", 0);
         }
-        state->lastsynctype = DSD_SYNC_PROVOICE_POS;
-        dsd_sync_warm_start_thresholds_outer_only(opts, state, 32);
-        return DSD_SYNC_PROVOICE_POS;
+        if (frame_sync_symbols_match_either(ctx->synctest32, INV_PROVOICE_SYNC, INV_PROVOICE_EA_SYNC)) {
+            return frame_sync_accept_provoice(ctx, DSD_SYNC_PROVOICE_NEG, "-PV   ", 1);
+        }
     }
 
-    if ((strcmp(ctx->synctest32, INV_PROVOICE_SYNC) == 0) || (strcmp(ctx->synctest32, INV_PROVOICE_EA_SYNC) == 0)) {
-        frame_sync_note_cc_sync(ctx);
-        frame_sync_set_basic_lock(ctx);
-        DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "ProVoice ");
-        printFrameSync(opts, state, "-PV   ", ctx->synctest_pos + 1, ctx->modulation);
-        state->lastsynctype = DSD_SYNC_PROVOICE_NEG;
-        dsd_sync_warm_start_thresholds_outer_only(opts, state, 32);
-        return DSD_SYNC_PROVOICE_NEG;
-    }
-
-    if (strcmp(ctx->synctest48, EDACS_SYNC) == 0) {
-        dsd_mark_cc_sync(state);
-        frame_sync_set_basic_lock(ctx);
-        printFrameSync(opts, state, "-EDACS", ctx->synctest_pos + 1, ctx->modulation);
-        state->lastsynctype = DSD_SYNC_EDACS_NEG;
-        dsd_sync_warm_start_thresholds_outer_only(opts, state, 48);
-        return DSD_SYNC_EDACS_NEG;
-    }
-
-    if (strcmp(ctx->synctest48, INV_EDACS_SYNC) == 0) {
-        dsd_mark_cc_sync(state);
-        frame_sync_set_basic_lock(ctx);
-        printFrameSync(opts, state, "+EDACS", ctx->synctest_pos + 1, ctx->modulation);
-        state->lastsynctype = DSD_SYNC_EDACS_POS;
-        dsd_sync_warm_start_thresholds_outer_only(opts, state, 48);
-        return DSD_SYNC_EDACS_POS;
-    }
-
-    if ((strcmp(ctx->synctest48, DOTTING_SEQUENCE_A) == 0) || (strcmp(ctx->synctest48, DOTTING_SEQUENCE_B) == 0)) {
-        if (opts->p25_trunk == 1 && opts->p25_is_tuned == 1) {
-            printFrameSync(opts, state, " EDACS  DOTTING SEQUENCE: ", ctx->synctest_pos + 1, ctx->modulation);
-            dsd_frame_sync_hook_eot_cc(opts, state);
+    if (frame_sync_match_window_ready(ctx, 48)) {
+        if (strcmp(ctx->synctest48, EDACS_SYNC) == 0) {
+            return frame_sync_accept_edacs(ctx, DSD_SYNC_EDACS_NEG, "-EDACS");
+        }
+        if (strcmp(ctx->synctest48, INV_EDACS_SYNC) == 0) {
+            return frame_sync_accept_edacs(ctx, DSD_SYNC_EDACS_POS, "+EDACS");
+        }
+        if (frame_sync_symbols_match_either(ctx->synctest48, DOTTING_SEQUENCE_A, DOTTING_SEQUENCE_B)) {
+            frame_sync_handle_edacs_dotting(ctx);
         }
     }
 
@@ -1443,7 +1410,8 @@ static int
 frame_sync_try_dstar(frame_sync_match_ctx* ctx) {
     const dsd_opts* opts = ctx->opts;
     dsd_state* state = ctx->state;
-    if (opts->frame_dstar != 1 || dsd_frame_sync_suppress_p25_alt_sync(opts, state)) {
+    if (opts->frame_dstar != 1 || !frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_4800_2)
+        || !frame_sync_match_window_ready(ctx, 24) || dsd_frame_sync_suppress_p25_alt_sync(opts, state)) {
         return DSD_SYNC_NONE;
     }
 
@@ -1495,43 +1463,47 @@ frame_sync_try_dstar(frame_sync_match_ctx* ctx) {
 }
 
 static int
+frame_sync_nxdn_sync_type(const char* symbols) {
+    static const char* const positive_patterns[] = {"3131331131", "3331331131", "3131331111", "3331331111",
+                                                    "3131311131"};
+    static const char* const negative_patterns[] = {"1313113313", "1113113313", "1313113333", "1113113333",
+                                                    "1313133313"};
+    for (size_t i = 0; i < sizeof(positive_patterns) / sizeof(positive_patterns[0]); i++) {
+        if (strcmp(symbols, positive_patterns[i]) == 0) {
+            return DSD_SYNC_NXDN_POS;
+        }
+        if (strcmp(symbols, negative_patterns[i]) == 0) {
+            return DSD_SYNC_NXDN_NEG;
+        }
+    }
+    return DSD_SYNC_NONE;
+}
+
+static int
 frame_sync_try_nxdn(frame_sync_match_ctx* ctx) {
     const dsd_opts* opts = ctx->opts;
     dsd_state* state = ctx->state;
-    if ((opts->frame_nxdn96 != 1) && (opts->frame_nxdn48 != 1)) {
+    const int nxdn_profile_enabled =
+        (opts->frame_nxdn96 == 1 && frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_4800_4))
+        || (opts->frame_nxdn48 == 1 && frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_2400_4));
+    if (!nxdn_profile_enabled || !frame_sync_match_window_ready(ctx, 10)) {
         return DSD_SYNC_NONE;
     }
 
-    dsd_strncpy_s(ctx->synctest10, 11, (ctx->synctest_p - 9), 10);
-    if ((strcmp(ctx->synctest10, "3131331131") == 0) || (strcmp(ctx->synctest10, "3331331131") == 0)
-        || (strcmp(ctx->synctest10, "3131331111") == 0) || (strcmp(ctx->synctest10, "3331331111") == 0)
-        || (strcmp(ctx->synctest10, "3131311131") == 0)) {
-        state->offset = ctx->synctest_pos;
-        state->max = ((state->max) + ctx->lmax) / 2;
-        state->min = ((state->min) + ctx->lmin) / 2;
-        if (state->lastsynctype == DSD_SYNC_NXDN_POS) {
-            frame_sync_note_cc_sync(ctx);
-            dsd_sync_warm_start_thresholds_outer_only(opts, state, 10);
-            return DSD_SYNC_NXDN_POS;
-        }
-        state->lastsynctype = DSD_SYNC_NXDN_POS;
+    const int synctype = frame_sync_nxdn_sync_type(ctx->synctest10);
+    if (synctype == DSD_SYNC_NONE) {
         return DSD_SYNC_NONE;
     }
 
-    if ((strcmp(ctx->synctest10, "1313113313") == 0) || (strcmp(ctx->synctest10, "1113113313") == 0)
-        || (strcmp(ctx->synctest10, "1313113333") == 0) || (strcmp(ctx->synctest10, "1113113333") == 0)
-        || (strcmp(ctx->synctest10, "1313133313") == 0)) {
-        state->offset = ctx->synctest_pos;
-        state->max = ((state->max) + ctx->lmax) / 2;
-        state->min = ((state->min) + ctx->lmin) / 2;
-        if (state->lastsynctype == DSD_SYNC_NXDN_NEG) {
-            frame_sync_note_cc_sync(ctx);
-            dsd_sync_warm_start_thresholds_outer_only(opts, state, 10);
-            return DSD_SYNC_NXDN_NEG;
-        }
-        state->lastsynctype = DSD_SYNC_NXDN_NEG;
+    state->offset = ctx->synctest_pos;
+    state->max = ((state->max) + ctx->lmax) / 2;
+    state->min = ((state->min) + ctx->lmin) / 2;
+    if (state->lastsynctype == synctype) {
+        frame_sync_note_cc_sync(ctx);
+        dsd_sync_warm_start_thresholds_outer_only(opts, state, 10);
+        return synctype;
     }
-
+    state->lastsynctype = synctype;
     return DSD_SYNC_NONE;
 }
 
@@ -1543,10 +1515,10 @@ frame_sync_pvconv_decode_addrs(const frame_sync_match_ctx* ctx, char one_symbol,
     for (int bit = 0; bit < 8; bit++) {
         *tx_addr = (uint8_t)(*tx_addr << 1);
         *rx_addr = (uint8_t)(*rx_addr << 1);
-        if (*(ctx->synctest_p - 15 + bit) == one_symbol) {
+        if (ctx->synctest16[bit] == one_symbol) {
             *tx_addr = (uint8_t)(*tx_addr + 1);
         }
-        if (*(ctx->synctest_p - 7 + bit) == one_symbol) {
+        if (ctx->synctest16[8 + bit] == one_symbol) {
             *rx_addr = (uint8_t)(*rx_addr + 1);
         }
     }
@@ -1556,13 +1528,12 @@ static int
 frame_sync_try_provoice_conventional(frame_sync_match_ctx* ctx) {
     const dsd_opts* opts = ctx->opts;
     dsd_state* state = ctx->state;
-    if (opts->frame_provoice != 1) {
+    if (opts->frame_provoice != 1 || !frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_9600_2)
+        || !frame_sync_match_window_ready(ctx, 32)) {
         return DSD_SYNC_NONE;
     }
 
-    DSD_MEMSET(ctx->synctest32, 0, 33);
-    dsd_strncpy_s(ctx->synctest32, 33, (ctx->synctest_p - 31), 16);
-    if (strcmp(ctx->synctest32, INV_PROVOICE_CONV_SHORT) == 0) {
+    if (strncmp(ctx->synctest32, INV_PROVOICE_CONV_SHORT, 16) == 0) {
         if (state->lastsynctype == DSD_SYNC_PROVOICE_NEG) {
             frame_sync_set_basic_lock(ctx);
             DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "ProVoice ");
@@ -1583,7 +1554,7 @@ frame_sync_try_provoice_conventional(frame_sync_match_ctx* ctx) {
         return DSD_SYNC_NONE;
     }
 
-    if (strcmp(ctx->synctest32, PROVOICE_CONV_SHORT) == 0) {
+    if (strncmp(ctx->synctest32, PROVOICE_CONV_SHORT, 16) == 0) {
         if (state->lastsynctype == DSD_SYNC_PROVOICE_POS) {
             frame_sync_set_basic_lock(ctx);
             DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "ProVoice ");
@@ -1650,13 +1621,17 @@ frame_sync_try_protocol_matches(frame_sync_match_ctx* ctx) {
         return sync_type;
     }
 
-    if (ctx->opts->frame_provoice == 1) {
-        sync_type = frame_sync_try_provoice(ctx);
-    } else if (ctx->opts->frame_dstar == 1) {
-        sync_type = frame_sync_try_dstar(ctx);
-    } else if (ctx->opts->frame_nxdn96 == 1 || ctx->opts->frame_nxdn48 == 1) {
-        sync_type = frame_sync_try_nxdn(ctx);
+    sync_type = frame_sync_try_provoice(ctx);
+    if (sync_type != DSD_SYNC_NONE) {
+        return sync_type;
     }
+
+    sync_type = frame_sync_try_dstar(ctx);
+    if (sync_type != DSD_SYNC_NONE) {
+        return sync_type;
+    }
+
+    sync_type = frame_sync_try_nxdn(ctx);
     if (sync_type != DSD_SYNC_NONE) {
         return sync_type;
     }
@@ -1708,27 +1683,29 @@ frame_sync_apply_cli_mod_lock(const dsd_opts* opts, dsd_state* state) {
 
 static int
 frame_sync_select_t_max(const dsd_opts* opts, const dsd_state* state) {
-    if (opts->frame_nxdn48 == 1 || opts->frame_nxdn96 == 1) {
-        return 10;
+    switch (state->sps_hunt_idx) {
+        case FRAME_SYNC_SPS_PROFILE_2400_4: return 12;
+        case FRAME_SYNC_SPS_PROFILE_6000_4:
+            if (state->rf_mod == 1 && opts->frame_p25p2 == 1) {
+                return 19;
+            }
+            return 24;
+        case FRAME_SYNC_SPS_PROFILE_4800_4:
+            if (DSD_SYNC_IS_YSF(state->lastsynctype)) {
+                return 20;
+            }
+            return 24;
+        default: return 24;
     }
-    if (opts->frame_dpmr == 1) {
-        return 12;
-    }
-    if (opts->frame_m17 == 1) {
-        return 8;
-    }
-    if (DSD_SYNC_IS_YSF(state->lastsynctype)) {
-        return 20;
-    }
-    if (DSD_SYNC_IS_P25P2(state->lastsynctype) || (state->p25_p2_active_slot >= 0 && opts->frame_p25p2 == 1)) {
-        return 19;
-    }
-    return 24;
 }
 
 static inline void
-frame_sync_update_symbol_ring(const dsd_opts* opts, dsd_state* state, float symbol, float* lbuf, int* lidx, int t_max) {
+frame_sync_update_symbol_ring(const dsd_opts* opts, dsd_state* state, float symbol, float* lbuf, int* lidx,
+                              int* level_count, int t_max) {
     lbuf[*lidx] = symbol;
+    if (*level_count < t_max) {
+        (*level_count)++;
+    }
     state->sbuf[state->sidx] = symbol;
     if (*lidx == (t_max - 1)) {
         *lidx = 0;
@@ -1745,6 +1722,9 @@ frame_sync_update_symbol_ring(const dsd_opts* opts, dsd_state* state, float symb
 static int
 frame_sync_bias_want_mod_with_snr(const dsd_state* state, int want_mod) {
 #ifdef USE_RADIO
+    if (want_mod == 2) {
+        return want_mod;
+    }
     double snr_c = dsd_rtl_stream_metrics_hook_snr_c4fm_db();
     double snr_q = dsd_rtl_stream_metrics_hook_snr_cqpsk_db();
     if (snr_c <= -50.0) {
@@ -1808,23 +1788,41 @@ frame_sync_ham_for_mod(int mod, int ham_c4fm, int ham_qpsk, int ham_gfsk) {
 }
 
 static int
-frame_sync_override_want_mod_with_hamming(const dsd_opts* opts, int want_mod) {
+frame_sync_c4fm_ham_candidate_enabled(const dsd_opts* opts, const dsd_state* state) {
+    return state->sps_hunt_idx == FRAME_SYNC_SPS_PROFILE_4800_4 && opts->frame_p25p1 == 1;
+}
+
+static int
+frame_sync_qpsk_ham_candidate_enabled(const dsd_opts* opts, const dsd_state* state) {
+    return (state->sps_hunt_idx == FRAME_SYNC_SPS_PROFILE_4800_4 && opts->frame_p25p1 == 1)
+           || (state->sps_hunt_idx == FRAME_SYNC_SPS_PROFILE_6000_4 && opts->frame_p25p2 == 1);
+}
+
+static int
+frame_sync_gfsk_ham_candidate_enabled(const dsd_opts* opts, const dsd_state* state) {
+    return (state->sps_hunt_idx == FRAME_SYNC_SPS_PROFILE_4800_4 && (opts->frame_dmr == 1 || opts->frame_nxdn96 == 1))
+           || (state->sps_hunt_idx == FRAME_SYNC_SPS_PROFILE_2400_4
+               && (opts->frame_nxdn48 == 1 || opts->frame_dpmr == 1))
+           || frame_sync_sps_profile_for_index(state->sps_hunt_idx)->levels == 2;
+}
+
+static int
+frame_sync_override_want_mod_with_hamming(const dsd_opts* opts, const dsd_state* state, int want_mod) {
     int ham_c4fm = frame_sync_decay_recent_ham(&g_ham_c4fm_recent);
     int ham_qpsk = frame_sync_decay_recent_ham(&g_ham_qpsk_recent);
     int ham_gfsk = frame_sync_decay_recent_ham(&g_ham_gfsk_recent);
 
     int best_mod = want_mod;
     int best_ham = frame_sync_ham_for_mod(want_mod, ham_c4fm, ham_qpsk, ham_gfsk);
-    if (ham_c4fm < best_ham) {
+    if (frame_sync_c4fm_ham_candidate_enabled(opts, state) && ham_c4fm < best_ham) {
         best_ham = ham_c4fm;
         best_mod = 0;
     }
-    int qpsk_enabled = (opts->frame_p25p1 == 1 || opts->frame_p25p2 == 1);
-    if (qpsk_enabled && ham_qpsk < best_ham) {
+    if (frame_sync_qpsk_ham_candidate_enabled(opts, state) && ham_qpsk < best_ham) {
         best_ham = ham_qpsk;
         best_mod = 1;
     }
-    if (ham_gfsk < best_ham) {
+    if (frame_sync_gfsk_ham_candidate_enabled(opts, state) && ham_gfsk < best_ham) {
         best_ham = ham_gfsk;
         best_mod = 2;
     }
@@ -1881,7 +1879,7 @@ frame_sync_decide_mod_switch(const dsd_state* state, int want_mod) {
 }
 
 static void
-frame_sync_apply_mod_switch(dsd_state* state, int do_switch) {
+frame_sync_apply_mod_switch(const dsd_opts* opts, dsd_state* state, int do_switch) {
     if (do_switch < 0) {
         return;
     }
@@ -1891,6 +1889,11 @@ frame_sync_apply_mod_switch(dsd_state* state, int do_switch) {
         atomic_store(&g_qpsk_dwell_enter_ms, 0);
     }
     state->rf_mod = do_switch;
+#ifdef USE_RADIO
+    rtl_maybe_update_active_sps_profile(opts, state);
+#else
+    UNUSED(opts);
+#endif
     atomic_store(&g_ham_c4fm_recent, 24);
     atomic_store(&g_ham_qpsk_recent, 24);
     atomic_store(&g_ham_gfsk_recent, 24);
@@ -1898,8 +1901,10 @@ frame_sync_apply_mod_switch(dsd_state* state, int do_switch) {
 
 static void
 frame_sync_maybe_auto_switch_modulation(const dsd_opts* opts, dsd_state* state, int t_max, int* lastt) {
-    if (*lastt != t_max) {
+    if (*lastt < t_max) {
         (*lastt)++;
+    }
+    if (*lastt < t_max) {
         return;
     }
 
@@ -1911,11 +1916,11 @@ frame_sync_maybe_auto_switch_modulation(const dsd_opts* opts, dsd_state* state, 
         return;
     }
 
-    int want_mod = state->rf_mod;
+    int want_mod = frame_sync_active_profile_modulation(state);
     want_mod = frame_sync_bias_want_mod_with_snr(state, want_mod);
-    want_mod = frame_sync_override_want_mod_with_hamming(opts, want_mod);
+    want_mod = frame_sync_override_want_mod_with_hamming(opts, state, want_mod);
     frame_sync_update_mod_votes(want_mod);
-    frame_sync_apply_mod_switch(state, frame_sync_decide_mod_switch(state, want_mod));
+    frame_sync_apply_mod_switch(opts, state, frame_sync_decide_mod_switch(state, want_mod));
 }
 
 #ifdef DSD_NEO_TEST_HOOKS
@@ -2164,7 +2169,11 @@ typedef struct {
     int synctest_pos;
     int lastt;
     int lidx;
+    int level_count;
     int t_max;
+    int history_head;
+    int history_count;
+    unsigned int ready_windows;
     float symbol;
     float lmin;
     float lmax;
@@ -2177,21 +2186,20 @@ typedef struct {
     char synctest8[9];
     char synctest16[17];
     char modulation[8];
-    char* synctest_p;
-    char synctest_buf[10240];
+    char symbol_history[FRAME_SYNC_HISTORY_CAPACITY];
     float lbuf[48];
     float lbuf2[48];
 } frame_sync_runtime_ctx;
 
 static void
 frame_sync_runtime_init(frame_sync_runtime_ctx* rt, const dsd_opts* opts, const dsd_state* state) {
-    rt->t = 0;
-    rt->synctest_pos = 0;
-    rt->lastt = 0;
-    rt->lidx = 0;
+    DSD_MEMSET(rt, 0, sizeof(*rt));
     rt->t_max = frame_sync_select_t_max(opts, state);
-    DSD_MEMSET(rt->lbuf, 0, sizeof(rt->lbuf));
-    DSD_MEMSET(rt->lbuf2, 0, sizeof(rt->lbuf2));
+    if (rt->t_max < 1 || rt->t_max > (int)(sizeof(rt->lbuf) / sizeof(rt->lbuf[0]))) {
+        rt->t_max = 24;
+    }
+    rt->lmin = state->min;
+    rt->lmax = state->max;
     rt->synctest[24] = 0;
     rt->synctest12[12] = 0;
     rt->synctest10[10] = 0;
@@ -2201,7 +2209,63 @@ frame_sync_runtime_init(frame_sync_runtime_ctx* rt, const dsd_opts* opts, const 
     rt->synctest8[8] = 0;
     rt->synctest16[16] = 0;
     rt->modulation[7] = 0;
-    rt->synctest_p = rt->synctest_buf + 10;
+}
+
+static void
+frame_sync_history_push(frame_sync_runtime_ctx* rt, char symbol) {
+    rt->symbol_history[rt->history_head] = symbol;
+    rt->history_head = (rt->history_head + 1) % FRAME_SYNC_HISTORY_CAPACITY;
+    if (rt->history_count < FRAME_SYNC_HISTORY_CAPACITY) {
+        rt->history_count++;
+    }
+}
+
+static int
+frame_sync_history_materialize(const frame_sync_runtime_ctx* rt, int length, char* out, size_t out_size) {
+    if (!rt || !out || length <= 0 || length > FRAME_SYNC_HISTORY_CAPACITY || out_size <= (size_t)length
+        || rt->history_count < length) {
+        return 0;
+    }
+
+    int index = rt->history_head - length;
+    if (index < 0) {
+        index += FRAME_SYNC_HISTORY_CAPACITY;
+    }
+    for (int i = 0; i < length; i++) {
+        out[i] = rt->symbol_history[index];
+        index = (index + 1) % FRAME_SYNC_HISTORY_CAPACITY;
+    }
+    out[length] = '\0';
+    return 1;
+}
+
+static void
+frame_sync_materialize_ready_windows(frame_sync_runtime_ctx* rt) {
+    rt->ready_windows = 0;
+    if (frame_sync_history_materialize(rt, 8, rt->synctest8, sizeof(rt->synctest8))) {
+        rt->ready_windows |= FRAME_SYNC_WINDOW_8;
+    }
+    if (frame_sync_history_materialize(rt, 10, rt->synctest10, sizeof(rt->synctest10))) {
+        rt->ready_windows |= FRAME_SYNC_WINDOW_10;
+    }
+    if (frame_sync_history_materialize(rt, 12, rt->synctest12, sizeof(rt->synctest12))) {
+        rt->ready_windows |= FRAME_SYNC_WINDOW_12;
+    }
+    if (frame_sync_history_materialize(rt, 16, rt->synctest16, sizeof(rt->synctest16))) {
+        rt->ready_windows |= FRAME_SYNC_WINDOW_16;
+    }
+    if (frame_sync_history_materialize(rt, 20, rt->synctest20, sizeof(rt->synctest20))) {
+        rt->ready_windows |= FRAME_SYNC_WINDOW_20;
+    }
+    if (frame_sync_history_materialize(rt, 24, rt->synctest, sizeof(rt->synctest))) {
+        rt->ready_windows |= FRAME_SYNC_WINDOW_24;
+    }
+    if (frame_sync_history_materialize(rt, 32, rt->synctest32, sizeof(rt->synctest32))) {
+        rt->ready_windows |= FRAME_SYNC_WINDOW_32;
+    }
+    if (frame_sync_history_materialize(rt, 48, rt->synctest48, sizeof(rt->synctest48))) {
+        rt->ready_windows |= FRAME_SYNC_WINDOW_48;
+    }
 }
 
 static void
@@ -2225,28 +2289,44 @@ frame_sync_window_levels(const dsd_opts* opts, dsd_state* state, frame_sync_runt
 }
 
 static int
-frame_sync_should_skip_snr_or_power_gate(const dsd_opts* opts) {
-    int is_gfsk_mode =
-        (opts->frame_nxdn48 == 1 || opts->frame_nxdn96 == 1 || opts->frame_dpmr == 1 || opts->frame_m17 == 1);
+frame_sync_active_profile_modulation(const dsd_state* state) {
+    if (state && state->rf_mod == 1) {
+        return 1;
+    }
+    const frame_sync_sps_profile* profile =
+        frame_sync_sps_profile_for_index(state ? state->sps_hunt_idx : FRAME_SYNC_SPS_PROFILE_4800_4);
+    if (profile->levels == 2 || (state && state->rf_mod == 2)) {
+        return 2;
+    }
+    return 0;
+}
+
+#ifdef USE_RADIO
+static double
+frame_sync_active_profile_snr_db(const dsd_state* state) {
+    switch (frame_sync_active_profile_modulation(state)) {
+        case 1: return dsd_rtl_stream_metrics_hook_snr_cqpsk_db();
+        case 2: return dsd_rtl_stream_metrics_hook_snr_gfsk_db();
+        default: return dsd_rtl_stream_metrics_hook_snr_c4fm_db();
+    }
+}
+#endif
+
+static int
+frame_sync_should_skip_snr_or_power_gate(const dsd_opts* opts, const dsd_state* state) {
+    const int active_modulation = frame_sync_active_profile_modulation(state);
 #ifdef USE_RADIO
     {
         const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
         if (cfg && cfg->snr_sql_is_set) {
-            double snr_db = -200.0;
-            if (opts->frame_p25p1 == 1) {
-                snr_db = dsd_rtl_stream_metrics_hook_snr_c4fm_db();
-            } else if (opts->frame_p25p2 == 1) {
-                snr_db = dsd_rtl_stream_metrics_hook_snr_cqpsk_db();
-            } else if (is_gfsk_mode) {
-                snr_db = dsd_rtl_stream_metrics_hook_snr_gfsk_db();
-            }
+            double snr_db = frame_sync_active_profile_snr_db(state);
             if (snr_db > -150.0 && snr_db < (double)cfg->snr_sql_db) {
                 return 1;
             }
         }
     }
 #endif
-    if (opts->audio_in_type == AUDIO_IN_RTL && opts->rtl_pwr < opts->rtl_squelch_level && is_gfsk_mode) {
+    if (opts->audio_in_type == AUDIO_IN_RTL && opts->rtl_pwr < opts->rtl_squelch_level && active_modulation == 2) {
         return 1;
     }
     return 0;
@@ -2266,14 +2346,15 @@ frame_sync_hamming_distance_pattern(const char* symbols, const char* pattern, in
 }
 
 static void
-frame_sync_update_c4fm_hamming(const dsd_opts* opts, const char* synctest) {
-    if (!(opts->frame_p25p1 == 1 && !opts->mod_cli_lock)) {
+frame_sync_update_c4fm_hamming(const dsd_opts* opts, const dsd_state* state, const frame_sync_runtime_ctx* rt) {
+    if (!(opts->frame_p25p1 == 1 && !opts->mod_cli_lock) || state->sps_hunt_idx != FRAME_SYNC_SPS_PROFILE_4800_4
+        || (rt->ready_windows & FRAME_SYNC_WINDOW_24) == 0) {
         return;
     }
     int ham_norm = 0;
     int ham_inv = 0;
     for (int k = 0; k < 24; k++) {
-        int d = (unsigned char)synctest[k] - '0';
+        int d = (unsigned char)rt->synctest[k] - '0';
         int expect_n = P25P1_SYNC[k] - '0';
         int expect_i = INV_P25P1_SYNC[k] - '0';
         if (d != expect_n) {
@@ -2291,21 +2372,29 @@ frame_sync_update_c4fm_hamming(const dsd_opts* opts, const char* synctest) {
 }
 
 static void
-frame_sync_update_qpsk_hamming(const dsd_opts* opts, const char* synctest, const char* synctest20) {
+frame_sync_update_qpsk_hamming(const dsd_opts* opts, const dsd_state* state, const frame_sync_runtime_ctx* rt) {
     if (!((opts->frame_p25p1 == 1 || opts->frame_p25p2 == 1) && !opts->mod_cli_lock)) {
         return;
     }
 
     int best_qpsk_ham = 24;
-    if (opts->frame_p25p1 == 1) {
-        best_qpsk_ham = dsd_qpsk_sync_hamming_with_remaps(synctest, P25P1_SYNC, INV_P25P1_SYNC, 24);
+    int compared = 0;
+    if (state->sps_hunt_idx == FRAME_SYNC_SPS_PROFILE_4800_4 && opts->frame_p25p1 == 1
+        && (rt->ready_windows & FRAME_SYNC_WINDOW_24) != 0) {
+        best_qpsk_ham = dsd_qpsk_sync_hamming_with_remaps(rt->synctest, P25P1_SYNC, INV_P25P1_SYNC, 24);
+        compared = 1;
     }
-    if (opts->frame_p25p2 == 1) {
-        int ham_p2 = dsd_qpsk_sync_hamming_with_remaps(synctest20, P25P2_SYNC, INV_P25P2_SYNC, 20);
+    if (state->sps_hunt_idx == FRAME_SYNC_SPS_PROFILE_6000_4 && opts->frame_p25p2 == 1
+        && (rt->ready_windows & FRAME_SYNC_WINDOW_20) != 0) {
+        int ham_p2 = dsd_qpsk_sync_hamming_with_remaps(rt->synctest20, P25P2_SYNC, INV_P25P2_SYNC, 20);
         int ham_p2_scaled = (ham_p2 * 24 + 19) / 20;
-        if (ham_p2_scaled < best_qpsk_ham || opts->frame_p25p1 == 0) {
+        if (ham_p2_scaled < best_qpsk_ham || !compared) {
             best_qpsk_ham = ham_p2_scaled;
         }
+        compared = 1;
+    }
+    if (!compared) {
+        return;
     }
     int ham_qpsk_cur = atomic_load(&g_ham_qpsk_recent);
     if (best_qpsk_ham < ham_qpsk_cur) {
@@ -2327,18 +2416,51 @@ frame_sync_best_ham_for_patterns(const char* symbols, const char* const patterns
 }
 
 static int
-frame_sync_best_nxdn_scaled_ham(frame_sync_runtime_ctx* rt, int best_start) {
-    DSD_STRNCPY(rt->synctest10, (rt->synctest_p - 9), 10);
+frame_sync_best_nxdn_scaled_ham(const char* symbols10, int best_start) {
     const char* nxdn_patterns[] = {"3131331131", "1313113313"};
     int best = best_start;
     for (int p = 0; p < 2; p++) {
-        int ham = frame_sync_hamming_distance_pattern(rt->synctest10, nxdn_patterns[p], 10);
+        int ham = frame_sync_hamming_distance_pattern(symbols10, nxdn_patterns[p], 10);
         int scaled_ham = (ham * 24 + 9) / 10;
         if (scaled_ham < best) {
             best = scaled_ham;
         }
     }
     return best;
+}
+
+static int
+frame_sync_dmr_gfsk_ham(const dsd_opts* opts, const dsd_state* state, const frame_sync_runtime_ctx* rt) {
+    if (state->sps_hunt_idx != FRAME_SYNC_SPS_PROFILE_4800_4 || opts->frame_dmr != 1
+        || (rt->ready_windows & FRAME_SYNC_WINDOW_24) == 0) {
+        return 24;
+    }
+    const char* dmr_patterns[] = {DMR_BS_DATA_SYNC, DMR_BS_VOICE_SYNC, DMR_MS_DATA_SYNC, DMR_MS_VOICE_SYNC};
+    return frame_sync_best_ham_for_patterns(rt->synctest, dmr_patterns, 4, 24, 24);
+}
+
+static int
+frame_sync_dpmr_gfsk_ham(const dsd_opts* opts, const dsd_state* state, const frame_sync_runtime_ctx* rt) {
+    if (state->sps_hunt_idx != FRAME_SYNC_SPS_PROFILE_2400_4 || opts->frame_dpmr != 1
+        || (rt->ready_windows & FRAME_SYNC_WINDOW_24) == 0) {
+        return 24;
+    }
+    const char* dpmr_patterns[] = {DPMR_FRAME_SYNC_1, DPMR_FRAME_SYNC_4, INV_DPMR_FRAME_SYNC_1, INV_DPMR_FRAME_SYNC_4};
+    return frame_sync_best_ham_for_patterns(rt->synctest, dpmr_patterns, 4, 24, 24);
+}
+
+static int
+frame_sync_nxdn_gfsk_ham(const dsd_opts* opts, const dsd_state* state, const frame_sync_runtime_ctx* rt) {
+    if ((rt->ready_windows & FRAME_SYNC_WINDOW_10) == 0) {
+        return 24;
+    }
+    if (state->sps_hunt_idx == FRAME_SYNC_SPS_PROFILE_4800_4 && opts->frame_nxdn96 == 1) {
+        return frame_sync_best_nxdn_scaled_ham(rt->synctest10, 24);
+    }
+    if (state->sps_hunt_idx == FRAME_SYNC_SPS_PROFILE_2400_4 && opts->frame_nxdn48 == 1) {
+        return frame_sync_best_nxdn_scaled_ham(rt->synctest10, 24);
+    }
+    return 24;
 }
 
 #ifdef DSD_NEO_TEST_HOOKS
@@ -2355,35 +2477,24 @@ dsd_frame_sync_test_best_ham_for_patterns(const char* symbols, const char* const
 
 int
 dsd_frame_sync_test_best_nxdn_scaled_ham(const char* symbols10, int best_start) {
-    frame_sync_runtime_ctx rt;
-    DSD_MEMSET(&rt, 0, sizeof(rt));
-    if (symbols10) {
-        DSD_STRNCPY(rt.synctest_buf, symbols10, 10);
-    }
-    rt.synctest_p = rt.synctest_buf + 9;
-    return frame_sync_best_nxdn_scaled_ham(&rt, best_start);
+    return symbols10 ? frame_sync_best_nxdn_scaled_ham(symbols10, best_start) : best_start;
 }
 #endif
 
 static void
-frame_sync_update_gfsk_hamming(const dsd_opts* opts, frame_sync_runtime_ctx* rt) {
-    if (!((opts->frame_dmr == 1 || opts->frame_nxdn48 == 1 || opts->frame_nxdn96 == 1 || opts->frame_dpmr == 1)
-          && !opts->mod_cli_lock)) {
+frame_sync_update_gfsk_hamming(const dsd_opts* opts, const dsd_state* state, const frame_sync_runtime_ctx* rt) {
+    if (opts->mod_cli_lock) {
         return;
     }
 
-    int best_gfsk_ham = 24;
-    if (opts->frame_dmr == 1) {
-        const char* dmr_patterns[] = {DMR_BS_DATA_SYNC, DMR_BS_VOICE_SYNC, DMR_MS_DATA_SYNC, DMR_MS_VOICE_SYNC};
-        best_gfsk_ham = frame_sync_best_ham_for_patterns(rt->synctest, dmr_patterns, 4, 24, best_gfsk_ham);
+    int best_gfsk_ham = frame_sync_dmr_gfsk_ham(opts, state, rt);
+    int candidate_ham = frame_sync_dpmr_gfsk_ham(opts, state, rt);
+    if (candidate_ham < best_gfsk_ham) {
+        best_gfsk_ham = candidate_ham;
     }
-    if (opts->frame_dpmr == 1) {
-        const char* dpmr_patterns[] = {DPMR_FRAME_SYNC_1, DPMR_FRAME_SYNC_4, INV_DPMR_FRAME_SYNC_1,
-                                       INV_DPMR_FRAME_SYNC_4};
-        best_gfsk_ham = frame_sync_best_ham_for_patterns(rt->synctest, dpmr_patterns, 4, 24, best_gfsk_ham);
-    }
-    if (opts->frame_nxdn48 == 1 || opts->frame_nxdn96 == 1) {
-        best_gfsk_ham = frame_sync_best_nxdn_scaled_ham(rt, best_gfsk_ham);
+    candidate_ham = frame_sync_nxdn_gfsk_ham(opts, state, rt);
+    if (candidate_ham < best_gfsk_ham) {
+        best_gfsk_ham = candidate_ham;
     }
     int ham_gfsk_cur = atomic_load(&g_ham_gfsk_recent);
     if (best_gfsk_ham < ham_gfsk_cur) {
@@ -2471,18 +2582,20 @@ frame_sync_debug_sync_window(dsd_opts* opts, dsd_state* state, const frame_sync_
 
 static int
 frame_sync_eval_window(dsd_opts* opts, dsd_state* state, frame_sync_runtime_ctx* rt, time_t now, double nowm) {
-    frame_sync_window_levels(opts, state, rt);
-    if (frame_sync_should_skip_snr_or_power_gate(opts)) {
+    if (rt->level_count >= rt->t_max) {
+        frame_sync_window_levels(opts, state, rt);
+    }
+    frame_sync_materialize_ready_windows(rt);
+    if (frame_sync_should_skip_snr_or_power_gate(opts, state)) {
         return DSD_SYNC_NONE;
     }
 
-    DSD_STRNCPY(rt->synctest, (rt->synctest_p - 23), 24);
-    DSD_STRNCPY(rt->synctest20, (rt->synctest_p - 19), 20);
-
-    frame_sync_debug_sync_window(opts, state, rt);
-    frame_sync_update_c4fm_hamming(opts, rt->synctest);
-    frame_sync_update_qpsk_hamming(opts, rt->synctest, rt->synctest20);
-    frame_sync_update_gfsk_hamming(opts, rt);
+    if ((rt->ready_windows & FRAME_SYNC_WINDOW_24) != 0) {
+        frame_sync_debug_sync_window(opts, state, rt);
+    }
+    frame_sync_update_c4fm_hamming(opts, state, rt);
+    frame_sync_update_qpsk_hamming(opts, state, rt);
+    frame_sync_update_gfsk_hamming(opts, state, rt);
 
     frame_sync_match_ctx match_ctx = {
         .opts = opts,
@@ -2492,8 +2605,8 @@ frame_sync_eval_window(dsd_opts* opts, dsd_state* state, frame_sync_runtime_ctx*
         .synctest_pos = rt->synctest_pos,
         .lmax = rt->lmax,
         .lmin = rt->lmin,
+        .ready_windows = rt->ready_windows,
         .modulation = rt->modulation,
-        .synctest_p = rt->synctest_p,
         .synctest = rt->synctest,
         .synctest8 = rt->synctest8,
         .synctest10 = rt->synctest10,
@@ -2506,59 +2619,150 @@ frame_sync_eval_window(dsd_opts* opts, dsd_state* state, frame_sync_runtime_ctx*
     return frame_sync_try_protocol_matches(&match_ctx);
 }
 
+#ifdef DSD_NEO_TEST_HOOKS
+int
+dsd_frame_sync_test_history_window(const char* symbols, int symbol_count, int window_length, char* out, int out_size) {
+    if (!symbols || symbol_count < 0 || !out || out_size < 0) {
+        return 0;
+    }
+    static dsd_opts opts;
+    static dsd_state state;
+    frame_sync_runtime_ctx rt;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    frame_sync_runtime_init(&rt, &opts, &state);
+    for (int i = 0; i < symbol_count; i++) {
+        frame_sync_history_push(&rt, symbols[i]);
+    }
+    return frame_sync_history_materialize(&rt, window_length, out, (size_t)out_size);
+}
+
+int
+dsd_frame_sync_test_try_protocol_matches(dsd_opts* opts, dsd_state* state, const char* symbols, int symbol_count) {
+    if (!opts || !state || !symbols || symbol_count < 0) {
+        return DSD_SYNC_NONE;
+    }
+    frame_sync_runtime_ctx rt;
+    frame_sync_runtime_init(&rt, opts, state);
+    for (int i = 0; i < symbol_count; i++) {
+        frame_sync_history_push(&rt, symbols[i]);
+    }
+    frame_sync_materialize_ready_windows(&rt);
+    frame_sync_match_ctx match_ctx = {
+        .opts = opts,
+        .state = state,
+        .now = 0,
+        .nowm = 0.0,
+        .synctest_pos = symbol_count > 0 ? symbol_count - 1 : 0,
+        .lmax = state->max,
+        .lmin = state->min,
+        .ready_windows = rt.ready_windows,
+        .modulation = rt.modulation,
+        .synctest = rt.synctest,
+        .synctest8 = rt.synctest8,
+        .synctest10 = rt.synctest10,
+        .synctest12 = rt.synctest12,
+        .synctest16 = rt.synctest16,
+        .synctest20 = rt.synctest20,
+        .synctest32 = rt.synctest32,
+        .synctest48 = rt.synctest48,
+    };
+    return frame_sync_try_protocol_matches(&match_ctx);
+}
+
+int
+dsd_frame_sync_test_active_profile_modulation(const dsd_state* state) {
+    return frame_sync_active_profile_modulation(state);
+}
+
+int
+dsd_frame_sync_test_should_skip_snr_or_power_gate(const dsd_opts* opts, const dsd_state* state) {
+    return frame_sync_should_skip_snr_or_power_gate(opts, state);
+}
+
+#ifdef USE_RADIO
+double
+dsd_frame_sync_test_active_profile_snr_db(const dsd_state* state) {
+    return frame_sync_active_profile_snr_db(state);
+}
+#endif
+#endif
+
 static void
 frame_sync_advance_sync_window(dsd_opts* opts, dsd_state* state, frame_sync_runtime_ctx* rt) {
     if (rt->synctest_pos < 10200) {
         rt->synctest_pos++;
-        rt->synctest_p++;
         return;
     }
     rt->synctest_pos = 0;
-    rt->synctest_p = rt->synctest_buf;
     dsd_frame_sync_hook_no_carrier(opts, state);
 }
 
 static int
-frame_sync_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* state, const int* sym_rate_cycle,
-                               const int* levels_cycle, int cycle_count) {
-    int has_4800_four_level = frame_sync_opts_has_4800_four_level_mode(opts);
-    int has_4800_binary = (opts->frame_dstar == 1);
-    int has_2400 = (opts->frame_nxdn48 == 1 || opts->frame_dpmr == 1);
-    int has_9600 = (opts->frame_provoice == 1);
-    int has_6000 = (opts->frame_p25p2 == 1 || opts->frame_x2tdma == 1);
-
-    int next_idx = (state->sps_hunt_idx + 1) % cycle_count;
-    for (int tries = 0; tries < cycle_count; tries++) {
-        int sym_rate = sym_rate_cycle[next_idx];
-        int skip =
-            (sym_rate == 2400 && !has_2400) || (sym_rate == 9600 && !has_9600) || (sym_rate == 6000 && !has_6000);
-        if (sym_rate == 4800) {
-            int levels = levels_cycle[next_idx];
-            skip = skip || ((levels == 2) ? !has_4800_binary : !has_4800_four_level);
-        }
-        if (!skip) {
-            break;
-        }
-        next_idx = (next_idx + 1) % cycle_count;
+frame_sync_sps_profile_has_candidate(const dsd_opts* opts, int profile_index) {
+    if (!opts) {
+        return 0;
     }
-    return next_idx;
+    switch (profile_index) {
+        case FRAME_SYNC_SPS_PROFILE_4800_4: return frame_sync_opts_has_4800_four_level_mode(opts);
+        case FRAME_SYNC_SPS_PROFILE_2400_4: return opts->frame_nxdn48 == 1 || opts->frame_dpmr == 1;
+        case FRAME_SYNC_SPS_PROFILE_9600_2: return opts->frame_provoice == 1;
+        case FRAME_SYNC_SPS_PROFILE_6000_4: return opts->frame_p25p2 == 1 || opts->frame_x2tdma == 1;
+        case FRAME_SYNC_SPS_PROFILE_4800_2: return opts->frame_dstar == 1;
+        default: return 0;
+    }
+}
+
+static int
+frame_sync_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state) {
+        return FRAME_SYNC_SPS_PROFILE_4800_4;
+    }
+    int current = state->sps_hunt_idx;
+    if (current < 0 || current >= FRAME_SYNC_SPS_PROFILE_COUNT) {
+        current = FRAME_SYNC_SPS_PROFILE_4800_4;
+    }
+    int next_idx = (current + 1) % FRAME_SYNC_SPS_PROFILE_COUNT;
+    for (int tries = 0; tries < FRAME_SYNC_SPS_PROFILE_COUNT; tries++) {
+        if (frame_sync_sps_profile_has_candidate(opts, next_idx)) {
+            return next_idx;
+        }
+        next_idx = (next_idx + 1) % FRAME_SYNC_SPS_PROFILE_COUNT;
+    }
+    return current;
 }
 
 #ifdef DSD_NEO_TEST_HOOKS
 int
-dsd_frame_sync_test_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* state, const int* sym_rate_cycle,
-                                        const int* levels_cycle, int cycle_count) {
-    return frame_sync_sps_hunt_next_index(opts, state, sym_rate_cycle, levels_cycle, cycle_count);
+dsd_frame_sync_test_sps_hunt_profile_count(void) {
+    return FRAME_SYNC_SPS_PROFILE_COUNT;
+}
+
+int
+dsd_frame_sync_test_sps_hunt_profile_rate(int profile_index) {
+    return frame_sync_sps_profile_for_index(profile_index)->symbol_rate_hz;
+}
+
+int
+dsd_frame_sync_test_sps_hunt_profile_levels(int profile_index) {
+    return frame_sync_sps_profile_for_index(profile_index)->levels;
+}
+
+int
+dsd_frame_sync_test_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* state) {
+    return frame_sync_sps_hunt_next_index(opts, state);
 }
 #endif
 
 static void
-frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx, const int* sym_rate_cycle,
-                                  const int* levels_cycle) {
-    if (next_idx == state->sps_hunt_idx) {
+frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx) {
+    if (!opts || !state || next_idx < 0 || next_idx >= FRAME_SYNC_SPS_PROFILE_COUNT
+        || next_idx == state->sps_hunt_idx) {
         return;
     }
     state->sps_hunt_idx = next_idx;
+    dsd_frame_sync_reset_mod_state();
+    const frame_sync_sps_profile* profile = frame_sync_sps_profile_for_index(next_idx);
 
 #ifdef USE_RADIO
     int demod_rate = 0;
@@ -2569,15 +2773,14 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
         demod_rate = dsd_opts_current_input_timing_rate(opts);
     }
 #else
-    UNUSED(levels_cycle);
     int demod_rate = dsd_opts_current_input_timing_rate(opts);
 #endif
 
-    int sym_rate = sym_rate_cycle[next_idx];
+    int sym_rate = profile->symbol_rate_hz;
     state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, sym_rate, demod_rate);
     state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
 #ifdef USE_RADIO
-    rtl_maybe_update_symbol_profile_with_hint(opts, state, sym_rate, levels_cycle[next_idx]);
+    rtl_maybe_update_sps_profile(opts, state, profile);
 #endif
     if (opts->verbose > 1 && !dsd_frame_sync_suppress_tcp_no_signal_console(opts, state)) {
         DSD_FPRINTF(stderr, "SPS hunt: trying %d sps (sym=%d, demod=%d)\n", state->samplesPerSymbol, sym_rate,
@@ -2587,11 +2790,23 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
 
 #ifdef DSD_NEO_TEST_HOOKS
 void
-dsd_frame_sync_test_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx,
-                                           const int* sym_rate_cycle, const int* levels_cycle) {
-    frame_sync_apply_sps_hunt_profile(opts, state, next_idx, sym_rate_cycle, levels_cycle);
+dsd_frame_sync_test_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx) {
+    frame_sync_apply_sps_hunt_profile(opts, state, next_idx);
 }
 #endif
+
+static void
+frame_sync_ensure_enabled_sps_profile(const dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state || frame_sync_sps_profile_has_candidate(opts, state->sps_hunt_idx)) {
+        return;
+    }
+    for (int profile_index = 0; profile_index < FRAME_SYNC_SPS_PROFILE_COUNT; profile_index++) {
+        if (frame_sync_sps_profile_has_candidate(opts, profile_index)) {
+            frame_sync_apply_sps_hunt_profile(opts, state, profile_index);
+            return;
+        }
+    }
+}
 
 static void
 frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
@@ -2604,12 +2819,16 @@ frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
     }
     state->sps_hunt_counter = 0;
 
-    static const int sym_rate_cycle[] = {4800, 2400, 9600, 6000, 4800};
-    static const int levels_cycle[] = {4, 4, 2, 4, 2};
-    const int cycle_count = (int)(sizeof(sym_rate_cycle) / sizeof(sym_rate_cycle[0]));
-    int next_idx = frame_sync_sps_hunt_next_index(opts, state, sym_rate_cycle, levels_cycle, cycle_count);
-    frame_sync_apply_sps_hunt_profile(opts, state, next_idx, sym_rate_cycle, levels_cycle);
+    int next_idx = frame_sync_sps_hunt_next_index(opts, state);
+    frame_sync_apply_sps_hunt_profile(opts, state, next_idx);
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_frame_sync_test_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
+    frame_sync_no_sync_sps_hunt(opts, state);
+}
+#endif
 
 static double
 frame_sync_elapsed_seconds(double nowm, time_t now, double mono_stamp, time_t wall_stamp) {
@@ -2713,6 +2932,7 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
     const double nowm = dsd_time_now_monotonic_s();
     frame_sync_maybe_tick_p25_trunk_sm(opts, state, now);
     frame_sync_apply_cli_mod_lock(opts, state);
+    frame_sync_ensure_enabled_sps_profile(opts, state);
 
     frame_sync_runtime_ctx rt;
     frame_sync_runtime_init(&rt, opts, state);
@@ -2730,12 +2950,12 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
         }
 
         rt.symbol = getSymbol(opts, state, 0);
-        frame_sync_update_symbol_ring(opts, state, rt.symbol, rt.lbuf, &rt.lidx, rt.t_max);
+        frame_sync_update_symbol_ring(opts, state, rt.symbol, rt.lbuf, &rt.lidx, &rt.level_count, rt.t_max);
         frame_sync_maybe_auto_switch_modulation(opts, state, rt.t_max, &rt.lastt);
         rt.dibit = frame_sync_process_dibit_and_payload(opts, state, rt.symbol);
-        *rt.synctest_p = (char)('0' + (rt.dibit & 0x3));
+        frame_sync_history_push(&rt, (char)('0' + (rt.dibit & 0x3)));
 
-        if (rt.t >= rt.t_max) {
+        if (rt.history_count >= 8) {
             int sync_type = frame_sync_eval_window(opts, state, &rt, now, nowm);
             if (sync_type != DSD_SYNC_NONE) {
                 return sync_type;

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -372,7 +372,14 @@ frame_sync_match_window_ready(const frame_sync_match_ctx* ctx, int length) {
 
 static int
 frame_sync_match_profile_active(const frame_sync_match_ctx* ctx, int profile_index) {
-    return ctx && ctx->state && ctx->state->sps_hunt_idx == profile_index;
+    if (!ctx || !ctx->opts || !ctx->state) {
+        return 0;
+    }
+    /* Stored symbols cannot be revisited after an SPS hunt profile advances. */
+    if (ctx->opts->audio_in_type == AUDIO_IN_SYMBOL_BIN || ctx->opts->audio_in_type == AUDIO_IN_SYMBOL_FLT) {
+        return 1;
+    }
+    return ctx->state->sps_hunt_idx == profile_index;
 }
 
 static int frame_sync_cqpsk_4level_enabled(const dsd_opts* opts, const dsd_state* state);
@@ -2765,6 +2772,24 @@ dsd_frame_sync_test_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* s
 #endif
 
 static void
+frame_sync_apply_sps_profile_timing(const dsd_opts* opts, dsd_state* state, const frame_sync_sps_profile* profile) {
+    /* Locked modulation modes may also carry manual timing, notably the experimental -m3 path. */
+    if (opts->mod_cli_lock && state->samplesPerSymbol > 0 && state->symbolCenter >= 0
+        && state->symbolCenter < state->samplesPerSymbol) {
+        return;
+    }
+
+    int demod_rate = frame_sync_current_demod_rate(opts, state);
+    int sym_rate = profile->symbol_rate_hz;
+    state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, sym_rate, demod_rate);
+    state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
+    if (opts->verbose > 1 && !dsd_frame_sync_suppress_tcp_no_signal_console(opts, state)) {
+        DSD_FPRINTF(stderr, "SPS hunt: trying %d sps (sym=%d, demod=%d)\n", state->samplesPerSymbol, sym_rate,
+                    demod_rate);
+    }
+}
+
+static void
 frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx) {
     if (!opts || !state || next_idx < 0 || next_idx >= FRAME_SYNC_SPS_PROFILE_COUNT) {
         return;
@@ -2784,14 +2809,7 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
     dsd_frame_sync_reset_mod_state();
 
     if (profile_changed) {
-        int demod_rate = frame_sync_current_demod_rate(opts, state);
-        int sym_rate = profile->symbol_rate_hz;
-        state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, sym_rate, demod_rate);
-        state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
-        if (opts->verbose > 1 && !dsd_frame_sync_suppress_tcp_no_signal_console(opts, state)) {
-            DSD_FPRINTF(stderr, "SPS hunt: trying %d sps (sym=%d, demod=%d)\n", state->samplesPerSymbol, sym_rate,
-                        demod_rate);
-        }
+        frame_sync_apply_sps_profile_timing(opts, state, profile);
     }
 
 #ifdef USE_RADIO
@@ -2814,6 +2832,8 @@ frame_sync_sps_profile_matching_timing(const dsd_opts* opts, const dsd_state* st
 
     const int demod_rate = frame_sync_current_demod_rate(opts, state);
     int matching_profile = -1;
+    int matching_level_profile = -1;
+    const int current_levels = frame_sync_sps_profile_for_index(state->sps_hunt_idx)->levels;
     for (int profile_index = 0; profile_index < FRAME_SYNC_SPS_PROFILE_COUNT; profile_index++) {
         if (!frame_sync_sps_profile_has_candidate(opts, profile_index)) {
             continue;
@@ -2826,13 +2846,15 @@ frame_sync_sps_profile_matching_timing(const dsd_opts* opts, const dsd_state* st
         if (profile_index == state->sps_hunt_idx) {
             return profile_index;
         }
-        if (matching_profile >= 0) {
-            /* 4800-symbol profiles can share timing; keep the existing level selection when timing is ambiguous. */
-            return -1;
+        if (matching_profile < 0) {
+            matching_profile = profile_index;
         }
-        matching_profile = profile_index;
+        if (matching_level_profile < 0 && profile->levels == current_levels) {
+            /* Shared-rate profiles can have identical timing; retain the current symbol-level selection. */
+            matching_level_profile = profile_index;
+        }
     }
-    return matching_profile;
+    return matching_level_profile >= 0 ? matching_level_profile : matching_profile;
 }
 
 static void

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -3010,9 +3010,14 @@ frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
     }
     state->sps_hunt_counter = 0;
 
-    /* An explicit modulation lock pins the demodulator, not protocol gates that share its timing. */
-    int next_idx = preserve_modulation ? frame_sync_sps_hunt_next_index_matching_timing(opts, state)
-                                       : frame_sync_sps_hunt_next_index(opts, state);
+    /* Generic modulation locks retain their demodulator while rotating equal-timing protocol gates. A P25p2-specific
+     * selection instead pins profile 3 because rounded low-rate timing cannot identify the requested matcher gate. */
+    const int pin_p25p2_profile = preserve_modulation && opts->mod_p25p2_profile_lock == 1 && opts->frame_p25p2 == 1
+                                  && state->sps_hunt_idx == FRAME_SYNC_SPS_PROFILE_6000_4;
+    int next_idx = pin_p25p2_profile
+                       ? FRAME_SYNC_SPS_PROFILE_6000_4
+                       : (preserve_modulation ? frame_sync_sps_hunt_next_index_matching_timing(opts, state)
+                                              : frame_sync_sps_hunt_next_index(opts, state));
     frame_sync_apply_sps_hunt_profile(opts, state, next_idx, preserve_modulation);
 }
 

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -884,12 +884,20 @@ frame_sync_try_m17_preamble(frame_sync_match_ctx* ctx, int ham_pre, int ham_piv)
     dsd_state* state = ctx->state;
     /* An 8-symbol one-error preamble is ambiguous with several 4800/4 sync prefixes.
      * Keep the legacy tolerance in forced M17 mode, but require the exact marker
-     * when the full profile has other candidates. */
+     * when the full profile has other candidates. D-STAR starts with an exact M17
+     * marker, so require a second marker before accepting M17 when D-STAR is enabled. */
     const int other_4800_candidate =
         opts->frame_p25p1 == 1 || opts->frame_dmr == 1 || opts->frame_nxdn96 == 1 || opts->frame_ysf == 1;
     const int max_hamming = other_4800_candidate ? 0 : 1;
+    const int require_repeated_marker = opts->frame_dstar == 1;
+    const int repeated_pre = !require_repeated_marker
+                             || (frame_sync_match_window_ready(ctx, 16)
+                                 && dsd_sync_hamming_distance(ctx->synctest16, M17_PRE, 8) <= max_hamming);
+    const int repeated_piv = !require_repeated_marker
+                             || (frame_sync_match_window_ready(ctx, 16)
+                                 && dsd_sync_hamming_distance(ctx->synctest16, M17_PIV, 8) <= max_hamming);
 
-    if (ham_pre <= max_hamming) {
+    if (ham_pre <= max_hamming && repeated_pre) {
         state->m17_polarity = 1;
         printFrameSync(opts, state, "+M17 PREAMBLE", ctx->synctest_pos + 1, ctx->modulation);
         frame_sync_set_basic_lock(ctx);
@@ -899,7 +907,7 @@ frame_sync_try_m17_preamble(frame_sync_match_ctx* ctx, int ham_pre, int ham_piv)
         return DSD_SYNC_M17_PRE_POS;
     }
 
-    if (ham_piv <= max_hamming) {
+    if (ham_piv <= max_hamming && repeated_piv) {
         state->m17_polarity = 2;
         printFrameSync(opts, state, "-M17 PREAMBLE", ctx->synctest_pos + 1, ctx->modulation);
         frame_sync_set_basic_lock(ctx);
@@ -1510,9 +1518,15 @@ static int
 frame_sync_try_nxdn(frame_sync_match_ctx* ctx) {
     const dsd_opts* opts = ctx->opts;
     dsd_state* state = ctx->state;
-    const int nxdn_profile_enabled =
-        (opts->frame_nxdn96 == 1 && frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_4800_4))
-        || (opts->frame_nxdn48 == 1 && frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_2400_4));
+    int nxdn_profile_enabled = 0;
+    if (opts->audio_in_type == AUDIO_IN_SYMBOL_BIN || opts->audio_in_type == AUDIO_IN_SYMBOL_FLT) {
+        /* Symbol captures carry no rate metadata, so an enabled variant must be unambiguous. */
+        nxdn_profile_enabled = (opts->frame_nxdn48 == 1) != (opts->frame_nxdn96 == 1);
+    } else {
+        nxdn_profile_enabled =
+            (opts->frame_nxdn96 == 1 && frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_4800_4))
+            || (opts->frame_nxdn48 == 1 && frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_2400_4));
+    }
     if (!nxdn_profile_enabled || !frame_sync_match_window_ready(ctx, 10)) {
         return DSD_SYNC_NONE;
     }
@@ -2803,7 +2817,7 @@ frame_sync_apply_sps_profile_timing(const dsd_opts* opts, dsd_state* state, cons
 }
 
 static void
-frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx) {
+frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx, int preserve_modulation) {
     if (!opts || !state || next_idx < 0 || next_idx >= FRAME_SYNC_SPS_PROFILE_COUNT) {
         return;
     }
@@ -2811,8 +2825,9 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
     const frame_sync_sps_profile* profile = frame_sync_sps_profile_for_index(next_idx);
     const int profile_changed = next_idx != state->sps_hunt_idx;
     const int profile_default_modulation = profile->levels == 2 ? 2 : 0;
-    const int normalize_profile_modulation =
-        !opts->mod_cli_lock && state->rf_mod != profile_default_modulation && (profile_changed || profile->levels == 2);
+    const int normalize_profile_modulation = !preserve_modulation && !opts->mod_cli_lock
+                                             && state->rf_mod != profile_default_modulation
+                                             && (profile_changed || profile->levels == 2);
     if (!profile_changed && !normalize_profile_modulation) {
         return;
     }
@@ -2835,7 +2850,7 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
 #ifdef DSD_NEO_TEST_HOOKS
 void
 dsd_frame_sync_test_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx) {
-    frame_sync_apply_sps_hunt_profile(opts, state, next_idx);
+    frame_sync_apply_sps_hunt_profile(opts, state, next_idx, 0);
 }
 #endif
 
@@ -2880,15 +2895,16 @@ frame_sync_ensure_enabled_sps_profile(const dsd_opts* opts, dsd_state* state) {
 
     const int timing_profile = frame_sync_sps_profile_matching_timing(opts, state);
     if (timing_profile >= 0 && timing_profile != state->sps_hunt_idx) {
-        frame_sync_apply_sps_hunt_profile(opts, state, timing_profile);
+        /* Presets may select both timing and modulation before frame sync starts. */
+        frame_sync_apply_sps_hunt_profile(opts, state, timing_profile, 1);
     }
     if (frame_sync_sps_profile_has_candidate(opts, state->sps_hunt_idx)) {
-        frame_sync_apply_sps_hunt_profile(opts, state, state->sps_hunt_idx);
+        frame_sync_apply_sps_hunt_profile(opts, state, state->sps_hunt_idx, 0);
         return;
     }
     for (int profile_index = 0; profile_index < FRAME_SYNC_SPS_PROFILE_COUNT; profile_index++) {
         if (frame_sync_sps_profile_has_candidate(opts, profile_index)) {
-            frame_sync_apply_sps_hunt_profile(opts, state, profile_index);
+            frame_sync_apply_sps_hunt_profile(opts, state, profile_index, 0);
             return;
         }
     }
@@ -2913,7 +2929,7 @@ frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
     state->sps_hunt_counter = 0;
 
     int next_idx = frame_sync_sps_hunt_next_index(opts, state);
-    frame_sync_apply_sps_hunt_profile(opts, state, next_idx);
+    frame_sync_apply_sps_hunt_profile(opts, state, next_idx, 0);
 }
 
 #ifdef DSD_NEO_TEST_HOOKS

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -382,6 +382,19 @@ frame_sync_match_profile_active(const frame_sync_match_ctx* ctx, int profile_ind
     return ctx->state->sps_hunt_idx == profile_index;
 }
 
+static int
+frame_sync_p25p2_profile_active(const frame_sync_match_ctx* ctx) {
+    if (frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_6000_4)) {
+        return 1;
+    }
+    if (!ctx || !ctx->opts || !ctx->state) {
+        return 0;
+    }
+    /* -m3 deliberately retains 10-SPS C4FM timing, which otherwise maps to profile 0. */
+    return ctx->opts->mod_p25p2_c4fm == 1 && ctx->opts->mod_cli_lock && ctx->opts->mod_c4fm == 1
+           && ctx->opts->mod_qpsk == 0 && ctx->opts->mod_gfsk == 0 && ctx->state->rf_mod == 0;
+}
+
 static int frame_sync_cqpsk_4level_enabled(const dsd_opts* opts, const dsd_state* state);
 static int frame_sync_active_profile_modulation(const dsd_opts* opts, const dsd_state* state);
 
@@ -802,7 +815,7 @@ frame_sync_try_ysf(frame_sync_match_ctx* ctx) {
 
 static int
 frame_sync_try_p25p2(frame_sync_match_ctx* ctx) {
-    if (ctx->opts->frame_p25p2 != 1 || !frame_sync_match_profile_active(ctx, FRAME_SYNC_SPS_PROFILE_6000_4)
+    if (ctx->opts->frame_p25p2 != 1 || !frame_sync_p25p2_profile_active(ctx)
         || !frame_sync_match_window_ready(ctx, 20)) {
         return DSD_SYNC_NONE;
     }

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -3000,8 +3000,8 @@ dsd_frame_sync_test_ensure_enabled_sps_profile(const dsd_opts* opts, dsd_state* 
 
 static void
 frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
-    const int gfsk_cli_lock = opts->mod_cli_lock && opts->mod_gfsk == 1 && opts->mod_c4fm == 0 && opts->mod_qpsk == 0;
-    if (state->carrier != 0 || (opts->mod_cli_lock && !gfsk_cli_lock)) {
+    const int preserve_modulation = opts->mod_cli_lock ? 1 : 0;
+    if (state->carrier != 0) {
         return;
     }
     state->sps_hunt_counter++;
@@ -3010,10 +3010,10 @@ frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
     }
     state->sps_hunt_counter = 0;
 
-    /* A GFSK lock pins the demodulator, not protocol gates that share the selected timing. */
-    int next_idx = gfsk_cli_lock ? frame_sync_sps_hunt_next_index_matching_timing(opts, state)
-                                 : frame_sync_sps_hunt_next_index(opts, state);
-    frame_sync_apply_sps_hunt_profile(opts, state, next_idx, gfsk_cli_lock);
+    /* An explicit modulation lock pins the demodulator, not protocol gates that share its timing. */
+    int next_idx = preserve_modulation ? frame_sync_sps_hunt_next_index_matching_timing(opts, state)
+                                       : frame_sync_sps_hunt_next_index(opts, state);
+    frame_sync_apply_sps_hunt_profile(opts, state, next_idx, preserve_modulation);
 }
 
 #ifdef DSD_NEO_TEST_HOOKS

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -2830,6 +2830,33 @@ frame_sync_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* state) {
     return current;
 }
 
+static int
+frame_sync_sps_hunt_next_index_matching_timing(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state) {
+        return FRAME_SYNC_SPS_PROFILE_4800_4;
+    }
+
+    int current = state->sps_hunt_idx;
+    if (current < 0 || current >= FRAME_SYNC_SPS_PROFILE_COUNT) {
+        current = FRAME_SYNC_SPS_PROFILE_4800_4;
+    }
+    if (state->samplesPerSymbol <= 0) {
+        return current;
+    }
+
+    const int demod_rate = frame_sync_current_demod_rate(opts, state);
+    int next_idx = (current + 1) % FRAME_SYNC_SPS_PROFILE_COUNT;
+    for (int tries = 0; tries < FRAME_SYNC_SPS_PROFILE_COUNT; tries++) {
+        const frame_sync_sps_profile* profile = frame_sync_sps_profile_for_index(next_idx);
+        const int expected_sps = dsd_opts_compute_sps_rate(opts, profile->symbol_rate_hz, demod_rate);
+        if (frame_sync_sps_profile_has_candidate(opts, next_idx) && expected_sps == state->samplesPerSymbol) {
+            return next_idx;
+        }
+        next_idx = (next_idx + 1) % FRAME_SYNC_SPS_PROFILE_COUNT;
+    }
+    return current;
+}
+
 #ifdef DSD_NEO_TEST_HOOKS
 int
 dsd_frame_sync_test_sps_hunt_profile_count(void) {
@@ -2973,7 +3000,8 @@ dsd_frame_sync_test_ensure_enabled_sps_profile(const dsd_opts* opts, dsd_state* 
 
 static void
 frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
-    if (!(state->carrier == 0 && !opts->mod_cli_lock)) {
+    const int gfsk_cli_lock = opts->mod_cli_lock && opts->mod_gfsk == 1 && opts->mod_c4fm == 0 && opts->mod_qpsk == 0;
+    if (state->carrier != 0 || (opts->mod_cli_lock && !gfsk_cli_lock)) {
         return;
     }
     state->sps_hunt_counter++;
@@ -2982,8 +3010,10 @@ frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
     }
     state->sps_hunt_counter = 0;
 
-    int next_idx = frame_sync_sps_hunt_next_index(opts, state);
-    frame_sync_apply_sps_hunt_profile(opts, state, next_idx, 0);
+    /* A GFSK lock pins the demodulator, not protocol gates that share the selected timing. */
+    int next_idx = gfsk_cli_lock ? frame_sync_sps_hunt_next_index_matching_timing(opts, state)
+                                 : frame_sync_sps_hunt_next_index(opts, state);
+    frame_sync_apply_sps_hunt_profile(opts, state, next_idx, gfsk_cli_lock);
 }
 
 #ifdef DSD_NEO_TEST_HOOKS

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -97,6 +97,8 @@ frame_sync_opts_has_4800_four_level_mode(const dsd_opts* opts) {
             || opts->frame_m17 == 1);
 }
 
+static int frame_sync_current_demod_rate(const dsd_opts* opts, const dsd_state* state);
+
 #ifdef USE_RADIO
 static int
 dmr_best_sync_hamming(const char* window, const char** out_name) {
@@ -175,17 +177,19 @@ dsd_frame_sync_test_rtl_profile_for_sps_index(const dsd_opts* opts, const dsd_st
 #endif
 
 static void
-rtl_maybe_update_sps_profile(const dsd_opts* opts, const dsd_state* state, const frame_sync_sps_profile* profile) {
+rtl_maybe_apply_demod_profile(const dsd_opts* opts, const dsd_state* state, const frame_sync_sps_profile* profile) {
     if (!opts || !state || !profile || opts->audio_in_type != AUDIO_IN_RTL || !state->rtl_ctx) {
         return;
     }
-    (void)dsd_rtl_stream_metrics_hook_set_symbol_profile(profile->symbol_rate_hz, profile->levels,
-                                                         rtl_profile_for_sps_profile(opts, state, profile));
+    const int ted_sps =
+        dsd_opts_compute_sps_rate(opts, profile->symbol_rate_hz, frame_sync_current_demod_rate(opts, state));
+    (void)dsd_rtl_stream_metrics_hook_apply_demod_profile(state->rf_mod == 1, profile->symbol_rate_hz, profile->levels,
+                                                          rtl_profile_for_sps_profile(opts, state, profile), ted_sps);
 }
 
 static void
-rtl_maybe_update_active_sps_profile(const dsd_opts* opts, const dsd_state* state) {
-    rtl_maybe_update_sps_profile(opts, state, frame_sync_sps_profile_for_index(state->sps_hunt_idx));
+rtl_maybe_apply_active_demod_profile(const dsd_opts* opts, const dsd_state* state) {
+    rtl_maybe_apply_demod_profile(opts, state, frame_sync_sps_profile_for_index(state->sps_hunt_idx));
 }
 #endif
 
@@ -215,7 +219,7 @@ dmr_set_symbol_timing(const dsd_opts* opts, dsd_state* state) {
     state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, 4800, demod_rate);
     state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
 #ifdef USE_RADIO
-    rtl_maybe_update_active_sps_profile(opts, state);
+    rtl_maybe_apply_active_demod_profile(opts, state);
 #endif
 }
 
@@ -658,7 +662,7 @@ frame_sync_accept_p25p2(frame_sync_match_ctx* ctx, int synctype, int inverted, c
     if (!opts->mod_cli_lock) {
         state->rf_mod = 1;
 #ifdef USE_RADIO
-        rtl_maybe_update_active_sps_profile(opts, state);
+        rtl_maybe_apply_active_demod_profile(opts, state);
 #endif
     }
     frame_sync_set_basic_lock(ctx);
@@ -1940,7 +1944,7 @@ frame_sync_apply_mod_switch(const dsd_opts* opts, dsd_state* state, int do_switc
     }
     state->rf_mod = do_switch;
 #ifdef USE_RADIO
-    rtl_maybe_update_active_sps_profile(opts, state);
+    rtl_maybe_apply_active_demod_profile(opts, state);
 #else
     UNUSED(opts);
 #endif
@@ -2924,7 +2928,7 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
     }
 
 #ifdef USE_RADIO
-    rtl_maybe_update_sps_profile(opts, state, profile);
+    rtl_maybe_apply_demod_profile(opts, state, profile);
 #endif
 }
 
@@ -3011,11 +3015,15 @@ frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
     state->sps_hunt_counter = 0;
 
     /* Generic modulation locks retain their demodulator while rotating equal-timing protocol gates. A P25p2-specific
-     * selection instead pins profile 3 because rounded low-rate timing cannot identify the requested matcher gate. */
-    const int pin_p25p2_profile = preserve_modulation && opts->mod_p25p2_profile_lock == 1 && opts->frame_p25p2 == 1
-                                  && state->sps_hunt_idx == FRAME_SYNC_SPS_PROFILE_6000_4;
-    int next_idx = pin_p25p2_profile
-                       ? FRAME_SYNC_SPS_PROFILE_6000_4
+     * lock retains whichever P25 profile was selected explicitly by the helper or by a CC retune. This keeps a known
+     * FDMA return on profile 0 even when 4800 and 6000 symbols/s round to the same timing. */
+    const int pin_selected_p25_profile = preserve_modulation && opts->mod_p25p2_profile_lock == 1
+                                         && opts->frame_p25p2 == 1
+                                         && (state->sps_hunt_idx == FRAME_SYNC_SPS_PROFILE_4800_4
+                                             || state->sps_hunt_idx == FRAME_SYNC_SPS_PROFILE_6000_4)
+                                         && frame_sync_sps_profile_has_candidate(opts, state->sps_hunt_idx);
+    int next_idx = pin_selected_p25_profile
+                       ? state->sps_hunt_idx
                        : (preserve_modulation ? frame_sync_sps_hunt_next_index_matching_timing(opts, state)
                                               : frame_sync_sps_hunt_next_index(opts, state));
     frame_sync_apply_sps_hunt_profile(opts, state, next_idx, preserve_modulation);

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -396,6 +396,7 @@ frame_sync_p25p2_profile_active(const frame_sync_match_ctx* ctx) {
 }
 
 static int frame_sync_cqpsk_4level_enabled(const dsd_opts* opts, const dsd_state* state);
+static int frame_sync_profile_uses_gfsk_exclusively(const dsd_opts* opts, int profile_index);
 static int frame_sync_active_profile_modulation(const dsd_opts* opts, const dsd_state* state);
 
 static inline void
@@ -1760,10 +1761,17 @@ frame_sync_update_symbol_ring(const dsd_opts* opts, dsd_state* state, float symb
     }
 }
 
-static int
-frame_sync_bias_want_mod_with_snr(const dsd_state* state, int want_mod) {
 #ifdef USE_RADIO
-    if (want_mod == 2) {
+static int
+frame_sync_should_bypass_c4fm_qpsk_snr_bias(const dsd_opts* opts, const dsd_state* state, int want_mod) {
+    return want_mod == 2 && frame_sync_profile_uses_gfsk_exclusively(opts, state->sps_hunt_idx);
+}
+#endif
+
+static int
+frame_sync_bias_want_mod_with_snr(const dsd_opts* opts, const dsd_state* state, int want_mod) {
+#ifdef USE_RADIO
+    if (frame_sync_should_bypass_c4fm_qpsk_snr_bias(opts, state, want_mod)) {
         return want_mod;
     }
     double snr_c = dsd_rtl_stream_metrics_hook_snr_c4fm_db();
@@ -1802,6 +1810,7 @@ frame_sync_bias_want_mod_with_snr(const dsd_state* state, int want_mod) {
         return 1;
     }
 #else
+    UNUSED(opts);
     UNUSED(state);
 #endif
     return want_mod;
@@ -1958,7 +1967,7 @@ frame_sync_maybe_auto_switch_modulation(const dsd_opts* opts, dsd_state* state, 
     }
 
     int want_mod = frame_sync_active_profile_modulation(opts, state);
-    want_mod = frame_sync_bias_want_mod_with_snr(state, want_mod);
+    want_mod = frame_sync_bias_want_mod_with_snr(opts, state, want_mod);
     want_mod = frame_sync_override_want_mod_with_hamming(opts, state, want_mod);
     frame_sync_update_mod_votes(want_mod);
     frame_sync_apply_mod_switch(opts, state, frame_sync_decide_mod_switch(state, want_mod));
@@ -2330,7 +2339,10 @@ frame_sync_window_levels(const dsd_opts* opts, dsd_state* state, frame_sync_runt
 }
 
 static int
-frame_sync_active_profile_is_gfsk_only(const dsd_opts* opts, int profile_index) {
+frame_sync_profile_uses_gfsk_exclusively(const dsd_opts* opts, int profile_index) {
+    if (frame_sync_sps_profile_for_index(profile_index)->levels == 2) {
+        return 1;
+    }
     if (!opts) {
         return 0;
     }
@@ -2352,9 +2364,7 @@ frame_sync_active_profile_modulation(const dsd_opts* opts, const dsd_state* stat
     if (profile_index < 0 || profile_index >= FRAME_SYNC_SPS_PROFILE_COUNT) {
         profile_index = FRAME_SYNC_SPS_PROFILE_4800_4;
     }
-    const frame_sync_sps_profile* profile = frame_sync_sps_profile_for_index(profile_index);
-    if ((!opts || !opts->mod_cli_lock)
-        && (profile->levels == 2 || frame_sync_active_profile_is_gfsk_only(opts, profile_index))) {
+    if ((!opts || !opts->mod_cli_lock) && frame_sync_profile_uses_gfsk_exclusively(opts, profile_index)) {
         return 2;
     }
     if (state && state->rf_mod == 1) {
@@ -2381,7 +2391,7 @@ static int
 frame_sync_should_skip_snr_or_power_gate(const dsd_opts* opts, const dsd_state* state) {
     const int active_modulation = frame_sync_active_profile_modulation(opts, state);
 #ifdef USE_RADIO
-    {
+    if (opts->audio_in_type == AUDIO_IN_RTL) {
         const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
         if (cfg && cfg->snr_sql_is_set) {
             double snr_db = frame_sync_active_profile_snr_db(opts, state);

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -27,6 +27,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/dmr_sync.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/dsp/sps_filters.h>
 #include <dsd-neo/dsp/symbol.h>
 #include <dsd-neo/dsp/symbol_levels.h>
@@ -73,6 +74,8 @@ void dsd_symbol_test_select_window(int rf_mod, int synctype, int lastsynctype, i
 int dsd_symbol_test_adjust_timing_index(int samples_per_symbol, int symbol_center, int rf_mod, int jitter,
                                         int have_sync, int symbol_span, int start_i, int* jitter_after);
 int dsd_symbol_test_is_m17_sync(int lastsynctype);
+float dsd_symbol_test_apply_matched_filter(const dsd_opts* opts, const dsd_state* state, float sample,
+                                           int rtl_symbol_rate_output, int cqpsk_symbol_rate);
 unsigned int dsd_symbol_test_convert_analog_block_to_i16(const float* input, short* output, unsigned int count);
 #ifdef USE_RADIO
 int dsd_symbol_test_rtl_cache_and_center_contract(int out_values[10]);
@@ -304,12 +307,19 @@ symbol_apply_matched_filter(const dsd_opts* opts, const dsd_state* state, float 
     if (DSD_SYNC_IS_P25P1(state->lastsynctype)) {
         return p25_filter(sample, state->samplesPerSymbol);
     }
-    if (DSD_SYNC_IS_DPMR(state->lastsynctype) || DSD_SYNC_IS_NXDN(state->lastsynctype)) {
-        if (opts->frame_nxdn48 == 1) {
-            return nxdn_filter(sample, state->samplesPerSymbol);
-        }
+    if (DSD_SYNC_IS_DPMR(state->lastsynctype)) {
         if (opts->frame_dpmr == 1) {
             return dpmr_filter(sample, state->samplesPerSymbol);
+        }
+        return sample;
+    }
+    if (DSD_SYNC_IS_NXDN(state->lastsynctype)) {
+        const dsd_nxdn_variant variant = dsd_frame_sync_active_nxdn_variant(opts, state);
+        if (variant == DSD_NXDN_VARIANT_48) {
+            return nxdn_filter(sample, state->samplesPerSymbol);
+        }
+        if (variant != DSD_NXDN_VARIANT_96) {
+            return sample;
         }
         if (state->samplesPerSymbol == 8) {
             return sample;
@@ -318,6 +328,14 @@ symbol_apply_matched_filter(const dsd_opts* opts, const dsd_state* state, float 
     }
     return sample;
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+float
+dsd_symbol_test_apply_matched_filter(const dsd_opts* opts, const dsd_state* state, float sample,
+                                     int rtl_symbol_rate_output, int cqpsk_symbol_rate) {
+    return symbol_apply_matched_filter(opts, state, sample, rtl_symbol_rate_output, cqpsk_symbol_rate);
+}
+#endif
 
 static inline float
 symbol_apply_sync_clip(const dsd_state* state, int have_sync, float sample) {

--- a/src/dsp/frame_sync_profile.c
+++ b/src/dsp/frame_sync_profile.c
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: ISC
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+dsd_nxdn_variant
+dsd_frame_sync_active_nxdn_variant(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts) {
+        return DSD_NXDN_VARIANT_NONE;
+    }
+
+    const int nxdn48_enabled = opts->frame_nxdn48 == 1;
+    const int nxdn96_enabled = opts->frame_nxdn96 == 1;
+    if (nxdn48_enabled && !nxdn96_enabled) {
+        return DSD_NXDN_VARIANT_48;
+    }
+    if (nxdn96_enabled && !nxdn48_enabled) {
+        return DSD_NXDN_VARIANT_96;
+    }
+    if (!state || !nxdn48_enabled || !nxdn96_enabled) {
+        return DSD_NXDN_VARIANT_NONE;
+    }
+    if (state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_2400_4) {
+        return DSD_NXDN_VARIANT_48;
+    }
+    if (state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4) {
+        return DSD_NXDN_VARIANT_96;
+    }
+    return DSD_NXDN_VARIANT_NONE;
+}

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1696,6 +1696,8 @@ no_carrier_apply_p25_cc_symbolrate(dsd_opts* opts, dsd_state* state) {
     }
     state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, sym_rate, no_carrier_current_demod_rate(opts, state));
     state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
+    state->sps_hunt_idx = sym_rate == 6000 ? DSD_FRAME_SYNC_SPS_PROFILE_6000_4 : DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state->sps_hunt_counter = 0;
     no_carrier_enable_p25_cc_slots(opts);
 }
 

--- a/src/engine/rtl_stream_metrics_hooks_install.c
+++ b/src/engine/rtl_stream_metrics_hooks_install.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+#include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <stddef.h>
 
@@ -21,7 +22,10 @@ rtl_stream_metrics_cqpsk_timing_bias(void) {
 static int
 rtl_stream_metrics_apply_demod_profile(int cqpsk_enable, int symbol_rate_hz, int levels, int channel_profile,
                                        int ted_sps) {
-    rtl_stream_toggle_cqpsk(cqpsk_enable);
+    const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
+    if (!cfg || !cfg->cqpsk_is_set) {
+        rtl_stream_toggle_cqpsk(cqpsk_enable);
+    }
     rtl_stream_clear_ted_sps_override();
     if (ted_sps > 0) {
         rtl_stream_set_ted_sps_no_override(ted_sps);

--- a/src/engine/rtl_stream_metrics_hooks_install.c
+++ b/src/engine/rtl_stream_metrics_hooks_install.c
@@ -17,6 +17,17 @@ static int
 rtl_stream_metrics_cqpsk_timing_bias(void) {
     return rtl_stream_cqpsk_timing_bias(NULL);
 }
+
+static int
+rtl_stream_metrics_apply_demod_profile(int cqpsk_enable, int symbol_rate_hz, int levels, int channel_profile,
+                                       int ted_sps) {
+    rtl_stream_toggle_cqpsk(cqpsk_enable);
+    rtl_stream_clear_ted_sps_override();
+    if (ted_sps > 0) {
+        rtl_stream_set_ted_sps_no_override(ted_sps);
+    }
+    return rtl_stream_set_symbol_profile(symbol_rate_hz, levels, channel_profile);
+}
 #endif
 
 void
@@ -28,6 +39,7 @@ dsd_engine_rtl_stream_metrics_hooks_install(void) {
     hooks.symbol_profile = rtl_stream_get_symbol_profile_full;
     hooks.stream_generation = rtl_stream_output_generation;
     hooks.set_symbol_profile = rtl_stream_set_symbol_profile;
+    hooks.apply_demod_profile = rtl_stream_metrics_apply_demod_profile;
     hooks.cqpsk_status = rtl_stream_get_cqpsk_status;
     hooks.cqpsk_timing_bias = rtl_stream_metrics_cqpsk_timing_bias;
     hooks.snr_bias_evm = rtl_stream_get_snr_bias_evm;

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/engine/trunk_scan.h>
 #ifdef USE_RADIO
 #include <dsd-neo/io/rtl_stream_c.h>
@@ -1266,6 +1267,9 @@ trunk_scan_apply_target_demod(const dsd_opts* opts, dsd_state* state, const dsd_
         return;
     }
     if (trunk_scan_target_is_p25(target)) {
+        state->sps_hunt_idx =
+            state->p25_cc_is_tdma == 1 ? DSD_FRAME_SYNC_SPS_PROFILE_6000_4 : DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+        state->sps_hunt_counter = 0;
         int p25_sps = trunk_scan_p25_cc_sps(opts, state);
         state->samplesPerSymbol = p25_sps;
         state->symbolCenter = dsd_opts_symbol_center(p25_sps);
@@ -1281,6 +1285,8 @@ trunk_scan_apply_target_demod(const dsd_opts* opts, dsd_state* state, const dsd_
     if (!trunk_scan_target_is_dmr(target)) {
         return;
     }
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state->sps_hunt_counter = 0;
     int dmr_sps = trunk_scan_dmr_sps(opts, state);
     state->samplesPerSymbol = dmr_sps;
     state->symbolCenter = dsd_opts_symbol_center(dmr_sps);

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -202,6 +202,8 @@ typedef struct {
     int saved_mod_c4fm;
     int saved_mod_qpsk;
     int saved_mod_gfsk;
+    int saved_mod_p25p2_c4fm;
+    int saved_mod_p25p2_profile_lock;
     int saved_mod_cli_lock;
     int saved_rtl_gain_value;
     int saved_tuner_autogain_on;
@@ -1304,6 +1306,8 @@ trunk_scan_restore_saved_mod_gain_opts(dsd_opts* opts, const dsd_trunk_scan_coor
     opts->mod_c4fm = coord->saved_mod_c4fm;
     opts->mod_qpsk = coord->saved_mod_qpsk;
     opts->mod_gfsk = coord->saved_mod_gfsk;
+    opts->mod_p25p2_c4fm = coord->saved_mod_p25p2_c4fm;
+    opts->mod_p25p2_profile_lock = coord->saved_mod_p25p2_profile_lock;
     opts->mod_cli_lock = coord->saved_mod_cli_lock;
     opts->rtl_gain_value = coord->saved_rtl_gain_value;
 }
@@ -1313,6 +1317,8 @@ trunk_scan_apply_target_mod_opts(dsd_opts* opts, const dsd_trunk_scan_target* ta
     if (!opts || !target || target->modulation == DSD_TRUNK_SCAN_MODULATION_UNSET) {
         return;
     }
+    opts->mod_p25p2_c4fm = 0;
+    opts->mod_p25p2_profile_lock = 0;
     switch (target->modulation) {
         case DSD_TRUNK_SCAN_MODULATION_AUTO:
             if (target->type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
@@ -1676,6 +1682,8 @@ trunk_scan_capture_saved_opts(dsd_trunk_scan_coord* coord, const dsd_opts* opts)
     coord->saved_mod_c4fm = opts->mod_c4fm;
     coord->saved_mod_qpsk = opts->mod_qpsk;
     coord->saved_mod_gfsk = opts->mod_gfsk;
+    coord->saved_mod_p25p2_c4fm = opts->mod_p25p2_c4fm;
+    coord->saved_mod_p25p2_profile_lock = opts->mod_p25p2_profile_lock;
     coord->saved_mod_cli_lock = opts->mod_cli_lock;
     coord->saved_rtl_gain_value = opts->rtl_gain_value;
 #ifdef USE_RADIO

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -59,6 +59,15 @@ dsd_engine_compute_cc_sps(const dsd_opts* opts, const dsd_state* state) {
 }
 
 static void DSD_ATTR_USED
+dsd_engine_select_p25_sps_profile(dsd_state* state, int is_tdma) {
+    if (!state) {
+        return;
+    }
+    state->sps_hunt_idx = is_tdma ? DSD_FRAME_SYNC_SPS_PROFILE_6000_4 : DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state->sps_hunt_counter = 0;
+}
+
+static void DSD_ATTR_USED
 dsd_engine_apply_cc_symbol_timing(const dsd_opts* opts, dsd_state* state) {
     if (!opts || !state || state->p25_cc_freq == 0) {
         return;
@@ -67,6 +76,7 @@ dsd_engine_apply_cc_symbol_timing(const dsd_opts* opts, dsd_state* state) {
     state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, sym_rate, dsd_engine_current_demod_rate(opts, state));
     state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
     state->rf_mod = (state->p25_cc_is_tdma == 1) ? 1 : ((opts->mod_qpsk == 1) ? 1 : 0);
+    dsd_engine_select_p25_sps_profile(state, state->p25_cc_is_tdma == 1);
 }
 
 static void DSD_ATTR_USED
@@ -535,6 +545,9 @@ dsd_engine_trunk_tune_to_freq_request(dsd_opts* opts, dsd_state* state, long int
 
     // Reset modulation auto-detect state (ham tracking, vote counters) after a
     // confirmed tune so the decoder and tuner state do not diverge on failure.
+    if (opts->p25_trunk == 1) {
+        dsd_engine_select_p25_sps_profile(state, state->p25_p2_active_slot != -1);
+    }
     dsd_frame_sync_reset_mod_state();
 
     // Reset P25P2 frame processing state when tuning to a voice channel.
@@ -599,6 +612,9 @@ dsd_engine_trunk_tune_to_cc_request(dsd_opts* opts, dsd_state* state, long int f
         return result;
     }
     // Reset modulation auto-detect state for fresh acquisition after a confirmed tune.
+    if (opts->p25_trunk == 1) {
+        dsd_engine_select_p25_sps_profile(state, state->p25_cc_is_tdma == 1);
+    }
     dsd_frame_sync_reset_mod_state();
     // Do not set p25_is_tuned/trunk_is_tuned here; this is a CC hunt action.
     state->trunk_cc_freq = (long int)freq;

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -67,6 +67,12 @@ dsd_engine_select_p25_sps_profile(dsd_state* state, int is_tdma) {
     state->sps_hunt_counter = 0;
 }
 
+static int
+dsd_engine_is_p25_profile_retune(const dsd_opts* opts, int ted_sps) {
+    /* Legacy -T also sets p25_trunk for non-P25 protocols, whose generic retunes do not carry P25 timing. */
+    return opts && opts->p25_trunk == 1 && ted_sps > 0;
+}
+
 static void DSD_ATTR_USED
 dsd_engine_apply_cc_symbol_timing(const dsd_opts* opts, dsd_state* state) {
     if (!opts || !state || state->p25_cc_freq == 0) {
@@ -545,7 +551,7 @@ dsd_engine_trunk_tune_to_freq_request(dsd_opts* opts, dsd_state* state, long int
 
     // Reset modulation auto-detect state (ham tracking, vote counters) after a
     // confirmed tune so the decoder and tuner state do not diverge on failure.
-    if (opts->p25_trunk == 1) {
+    if (dsd_engine_is_p25_profile_retune(opts, ted_sps)) {
         dsd_engine_select_p25_sps_profile(state, state->p25_p2_active_slot != -1);
     }
     dsd_frame_sync_reset_mod_state();
@@ -612,7 +618,7 @@ dsd_engine_trunk_tune_to_cc_request(dsd_opts* opts, dsd_state* state, long int f
         return result;
     }
     // Reset modulation auto-detect state for fresh acquisition after a confirmed tune.
-    if (opts->p25_trunk == 1) {
+    if (dsd_engine_is_p25_profile_retune(opts, ted_sps)) {
         dsd_engine_select_p25_sps_profile(state, state->p25_cc_is_tdma == 1);
     }
     dsd_frame_sync_reset_mod_state();

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -26,6 +26,7 @@
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/crypto/aes.h>
 #include <dsd-neo/crypto/des.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
 #include <dsd-neo/protocol/nxdn/nxdn_alias_decode.h>
 #include <dsd-neo/protocol/nxdn/nxdn_deperm.h>
@@ -2165,7 +2166,7 @@ nxdn_vcall_load_key(const dsd_opts* opts, dsd_state* state, const struct nxdn_vc
     if (state->keyloader != 1) {
         return;
     }
-    if (info->cipher_type == 1U && opts->frame_nxdn48 == 1 && opts->frame_nxdn96 == 0) {
+    if (info->cipher_type == 1U && dsd_frame_sync_active_nxdn_variant(opts, state) == DSD_NXDN_VARIANT_48) {
         if (state->rkey_array[info->key_id] != 0) {
             state->R = state->rkey_array[info->key_id];
         } else if (state->rkey_array[info->destination_id] != 0) {

--- a/src/protocol/nxdn/nxdn_frame.c
+++ b/src/protocol/nxdn/nxdn_frame.c
@@ -329,7 +329,7 @@ nxdn_print_lich_debug_payload(const dsd_opts* opts, const nxdn_frame_ctx* ctx) {
 
 static void
 nxdn_print_idas_sync_banner(const dsd_opts* opts, const dsd_state* state, const nxdn_frame_ctx* ctx) {
-    if (opts->frame_nxdn48 == 1) {
+    if (dsd_frame_sync_active_nxdn_variant(opts, state) == DSD_NXDN_VARIANT_48) {
         printFrameSync(opts, state, "IDAS D ", 0, "-");
     }
     nxdn_print_lich_debug_payload(opts, ctx);
@@ -337,7 +337,7 @@ nxdn_print_idas_sync_banner(const dsd_opts* opts, const dsd_state* state, const 
 
 static void
 nxdn_print_dcr_sync_banner(const dsd_opts* opts, const dsd_state* state, const nxdn_frame_ctx* ctx) {
-    if (opts->frame_nxdn48 == 1) {
+    if (dsd_frame_sync_active_nxdn_variant(opts, state) == DSD_NXDN_VARIANT_48) {
         printFrameSync(opts, state, "JPN DCR", 0, "-");
     }
     nxdn_print_lich_debug_payload(opts, ctx);
@@ -345,7 +345,7 @@ nxdn_print_dcr_sync_banner(const dsd_opts* opts, const dsd_state* state, const n
 
 static void
 nxdn_print_normal_sync_banner(const dsd_opts* opts, const dsd_state* state, const nxdn_frame_ctx* ctx) {
-    if (opts->frame_nxdn48 == 1) {
+    if (dsd_frame_sync_active_nxdn_variant(opts, state) == DSD_NXDN_VARIANT_48) {
         printFrameSync(opts, state, "NXDN48 ", 0, "-");
     } else {
         printFrameSync(opts, state, "NXDN96 ", 0, "-");
@@ -619,10 +619,11 @@ nxdn_process_voice_and_mbe(dsd_opts* opts, dsd_state* state, const nxdn_frame_ct
     if (opts->mbe_out_f == NULL) {
         return;
     }
-    if (opts->frame_nxdn96 == 1 && (time(NULL) - state->last_vc_sync_time) > 1) {
+    const dsd_nxdn_variant variant = dsd_frame_sync_active_nxdn_variant(opts, state);
+    if (variant == DSD_NXDN_VARIANT_96 && (time(NULL) - state->last_vc_sync_time) > 1) {
         closeMbeOutFile(opts, state);
     }
-    if (opts->frame_nxdn48 == 1) {
+    if (variant == DSD_NXDN_VARIANT_48) {
         closeMbeOutFile(opts, state);
     }
 }

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -2396,6 +2396,7 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
         }                                                                                                              \
         case 'm':                                                                                                      \
             opts->mod_p25p2_c4fm = 0;                                                                                  \
+            opts->mod_p25p2_profile_lock = 0;                                                                          \
             if (optarg[0] == 'a') {                                                                                    \
                 opts->mod_c4fm = 1;                                                                                    \
                 opts->mod_qpsk = 1;                                                                                    \
@@ -2432,6 +2433,7 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                 state->samplesPerSymbol = 8;                                                                           \
                 state->symbolCenter = 3;                                                                               \
                 state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;                                               \
+                opts->mod_p25p2_profile_lock = 1;                                                                      \
                 opts->mod_cli_lock = 1;                                                                                \
                 cli_decode_timing_seen = 1;                                                                            \
                 cli_decode_timing_source = CLI_TIMING_SOURCE_MANUAL;                                                   \

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -12,6 +12,7 @@
 #include <dsd-neo/core/string_utils.h>
 #include <dsd-neo/crypto/dmr_keystream.h>
 #include <dsd-neo/crypto/ecdsa.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/io/iq_capture.h>
 #include <dsd-neo/io/iq_replay.h>
 #include <dsd-neo/platform/audio.h>
@@ -2430,6 +2431,7 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                 state->rf_mod = 1;                                                                                     \
                 state->samplesPerSymbol = 8;                                                                           \
                 state->symbolCenter = 3;                                                                               \
+                state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;                                               \
                 opts->mod_cli_lock = 1;                                                                                \
                 cli_decode_timing_seen = 1;                                                                            \
                 cli_decode_timing_source = CLI_TIMING_SOURCE_MANUAL;                                                   \
@@ -2443,6 +2445,7 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                 state->rf_mod = 0;                                                                                     \
                 state->samplesPerSymbol = 10;                                                                          \
                 state->symbolCenter = 4;                                                                               \
+                state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;                                               \
                 opts->mod_p25p2_c4fm = 1;                                                                              \
                 opts->mod_cli_lock = 1;                                                                                \
                 cli_decode_timing_seen = 1;                                                                            \
@@ -2457,6 +2460,7 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                 state->rf_mod = 0;                                                                                     \
                 state->samplesPerSymbol = 8;                                                                           \
                 state->symbolCenter = 3;                                                                               \
+                state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;                                               \
                 opts->mod_cli_lock = 0;                                                                                \
                 cli_decode_timing_seen = 1;                                                                            \
                 cli_decode_timing_source = CLI_TIMING_SOURCE_MANUAL;                                                   \

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -2394,6 +2394,7 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
             break;                                                                                                     \
         }                                                                                                              \
         case 'm':                                                                                                      \
+            opts->mod_p25p2_c4fm = 0;                                                                                  \
             if (optarg[0] == 'a') {                                                                                    \
                 opts->mod_c4fm = 1;                                                                                    \
                 opts->mod_qpsk = 1;                                                                                    \
@@ -2442,6 +2443,7 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                 state->rf_mod = 0;                                                                                     \
                 state->samplesPerSymbol = 10;                                                                          \
                 state->symbolCenter = 4;                                                                               \
+                opts->mod_p25p2_c4fm = 1;                                                                              \
                 opts->mod_cli_lock = 1;                                                                                \
                 cli_decode_timing_seen = 1;                                                                            \
                 cli_decode_timing_source = CLI_TIMING_SOURCE_MANUAL;                                                   \

--- a/src/runtime/config_user.cpp
+++ b/src/runtime/config_user.cpp
@@ -1148,6 +1148,8 @@ apply_demod_mode(dsd_opts* opts, dsd_state* state, int mod_c4fm, int mod_qpsk, i
     opts->mod_c4fm = mod_c4fm;
     opts->mod_qpsk = mod_qpsk;
     opts->mod_gfsk = mod_gfsk;
+    opts->mod_p25p2_c4fm = 0;
+    opts->mod_p25p2_profile_lock = 0;
     opts->mod_cli_lock = mod_cli_lock;
     state->rf_mod = rf_mod;
 }

--- a/src/runtime/rtl_stream_metrics_hooks.c
+++ b/src/runtime/rtl_stream_metrics_hooks.c
@@ -90,6 +90,18 @@ dsd_rtl_stream_metrics_hook_set_symbol_profile(int symbol_rate_hz, int levels, i
 }
 
 int
+dsd_rtl_stream_metrics_hook_apply_demod_profile(int cqpsk_enable, int symbol_rate_hz, int levels, int channel_profile,
+                                                int ted_sps) {
+    if (g_rtl_stream_metrics_hooks.apply_demod_profile) {
+        return g_rtl_stream_metrics_hooks.apply_demod_profile(cqpsk_enable, symbol_rate_hz, levels, channel_profile,
+                                                              ted_sps);
+    }
+    (void)cqpsk_enable;
+    (void)ted_sps;
+    return dsd_rtl_stream_metrics_hook_set_symbol_profile(symbol_rate_hz, levels, channel_profile);
+}
+
+int
 dsd_rtl_stream_metrics_hook_cqpsk_status(int* out_cqpsk_enable, int* out_cqpsk_timing_active) {
     if (g_rtl_stream_metrics_hooks.cqpsk_status) {
         return g_rtl_stream_metrics_hooks.cqpsk_status(out_cqpsk_enable, out_cqpsk_timing_active);

--- a/src/ui/terminal/menu_labels.c
+++ b/src/ui/terminal/menu_labels.c
@@ -79,7 +79,7 @@ ui_current_mod(const void* v) {
     UiCtx* c = (UiCtx*)v;
     int mod = -1;
 
-    // Honor CLI-locked demod selection when present
+    // Honor an explicitly locked demod selection when present
     if (c && c->opts && c->opts->mod_cli_lock) {
         if (c->opts->mod_qpsk) {
             mod = 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1041,6 +1041,7 @@ add_test(NAME NXDN_MESSAGE_CRC32 COMMAND dsd-neo_test_nxdn_message_crc32)
 add_executable(
     dsd-neo_test_nxdn_element_bounds
     protocol/nxdn/test_nxdn_element_bounds.c
+    ${PROJECT_SOURCE_DIR}/src/dsp/frame_sync_profile.c
 )
 target_include_directories(
     dsd-neo_test_nxdn_element_bounds

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3242,7 +3242,9 @@ if(NOT APPLE AND NOT WIN32 AND (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang"))
     )
     target_link_options(
         dsd-neo_test_app_command_queue
-        PRIVATE "LINKER:--wrap=io_control_set_freq"
+        PRIVATE
+            "LINKER:--wrap=dsd_trunk_tuning_hook_tune_to_cc"
+            "LINKER:--wrap=io_control_set_freq"
     )
 endif()
 add_test(NAME APP_COMMAND_QUEUE COMMAND dsd-neo_test_app_command_queue)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1294,6 +1294,24 @@ target_include_directories(
 add_test(NAME APP_CONTROL_ACTIONS COMMAND dsd-neo_test_app_control_actions)
 
 add_executable(
+    dsd-neo_test_app_control_actions_rtl
+    ui/test_ui_radio_actions_rtl.c
+    ${PROJECT_SOURCE_DIR}/src/app_control/actions/actions_radio.c
+)
+target_compile_definitions(
+    dsd-neo_test_app_control_actions_rtl
+    PRIVATE USE_RADIO
+)
+target_include_directories(
+    dsd-neo_test_app_control_actions_rtl
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/app_control
+)
+add_test(
+    NAME APP_CONTROL_ACTIONS_RTL
+    COMMAND dsd-neo_test_app_control_actions_rtl
+)
+
+add_executable(
     dsd-neo_test_ui_menu_services
     ui/test_ui_menu_services.c
     ${PROJECT_SOURCE_DIR}/src/app_control/menu_services.c

--- a/tests/dsp/test_dsp_symbol_replay.c
+++ b/tests/dsp/test_dsp_symbol_replay.c
@@ -15,6 +15,8 @@
 #include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/dsp/sps_filters.h>
 #include <dsd-neo/dsp/symbol.h>
 #include <dsd-neo/dsp/symbol_levels.h>
 #include <dsd-neo/io/rigctl_client.h>
@@ -42,6 +44,8 @@ void dsd_symbol_test_select_window(int rf_mod, int synctype, int lastsynctype, i
 int dsd_symbol_test_adjust_timing_index(int samples_per_symbol, int symbol_center, int rf_mod, int jitter,
                                         int have_sync, int symbol_span, int start_i, int* jitter_after);
 int dsd_symbol_test_is_m17_sync(int lastsynctype);
+float dsd_symbol_test_apply_matched_filter(const dsd_opts* opts, const dsd_state* state, float sample,
+                                           int rtl_symbol_rate_output, int cqpsk_symbol_rate);
 unsigned int dsd_symbol_test_convert_analog_block_to_i16(const float* input, short* output, unsigned int count);
 #ifdef USE_RADIO
 int dsd_symbol_test_rtl_cache_and_center_contract(int out_values[10]);
@@ -475,6 +479,44 @@ test_symbol_helper_analog_i16_conversion_contract(void) {
 }
 
 static void
+test_symbol_matched_filter_uses_active_nxdn_variant(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    const float sample = 1.0f;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.use_cosine_filter = 1;
+    opts.frame_nxdn48 = 1;
+    opts.frame_nxdn96 = 1;
+    state.lastsynctype = DSD_SYNC_NXDN_POS;
+    state.samplesPerSymbol = 10;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+
+    init_rrc_filter_memory();
+    const float expected_nxdn96 = dmr_filter(sample, state.samplesPerSymbol);
+    init_rrc_filter_memory();
+    const float actual_nxdn96 = dsd_symbol_test_apply_matched_filter(&opts, &state, sample, 0, 0);
+    assert(fabsf(actual_nxdn96 - expected_nxdn96) < 1e-6f);
+
+    state.samplesPerSymbol = 20;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    init_rrc_filter_memory();
+    const float expected_nxdn48 = nxdn_filter(sample, state.samplesPerSymbol);
+    init_rrc_filter_memory();
+    const float actual_nxdn48 = dsd_symbol_test_apply_matched_filter(&opts, &state, sample, 0, 0);
+    assert(fabsf(actual_nxdn48 - expected_nxdn48) < 1e-6f);
+
+    opts.frame_dpmr = 1;
+    state.lastsynctype = DSD_SYNC_DPMR_FS1_POS;
+    init_rrc_filter_memory();
+    const float expected_dpmr = dpmr_filter(sample, state.samplesPerSymbol);
+    init_rrc_filter_memory();
+    const float actual_dpmr = dsd_symbol_test_apply_matched_filter(&opts, &state, sample, 0, 0);
+    assert(fabsf(actual_dpmr - expected_dpmr) < 1e-6f);
+}
+
+static void
 test_symbol_helper_rtl_cache_and_center_contract(void) {
 #ifdef USE_RADIO
     int values[10] = {0};
@@ -534,6 +576,7 @@ main(void) {
     test_float_symbol_replay_eof_sets_exitflag();
     test_symbol_helper_window_sync_and_timing_contracts();
     test_symbol_helper_analog_i16_conversion_contract();
+    test_symbol_matched_filter_uses_active_nxdn_variant();
     test_symbol_helper_rtl_cache_and_center_contract();
     return 0;
 }

--- a/tests/dsp/test_frame_sync_dmr_wav_rate.c
+++ b/tests/dsp/test_frame_sync_dmr_wav_rate.c
@@ -272,6 +272,16 @@ init_common_wav_opts_state(dsd_opts* opts, dsd_state* state) {
     state->maxref = 2.4f;
 }
 
+static void
+set_profile_timing(const dsd_opts* opts, dsd_state* state, int profile_index) {
+    static const int symbol_rates[] = {4800, 2400, 9600, 6000, 4800};
+    const int profile_count = (int)(sizeof(symbol_rates) / sizeof(symbol_rates[0]));
+    const int safe_profile_index = (profile_index >= 0 && profile_index < profile_count) ? profile_index : 0;
+    const int demod_rate = dsd_opts_current_input_timing_rate(opts);
+    state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, symbol_rates[safe_profile_index], demod_rate);
+    state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
+}
+
 static int
 run_symbol_sync_case(const SymbolSyncCase* tc) {
     static dsd_opts opts;
@@ -286,6 +296,7 @@ run_symbol_sync_case(const SymbolSyncCase* tc) {
     opts.inverted_x2tdma = tc->inverted_x2tdma;
     opts.inverted_dpmr = tc->inverted_dpmr;
     state.sps_hunt_idx = tc->profile_index;
+    set_profile_timing(&opts, &state, tc->profile_index);
     state.lastsynctype = tc->initial_lastsynctype;
     g_symbol_index = 0U;
     g_sync_pattern = tc->pattern;
@@ -657,6 +668,7 @@ run_nxdn_two_pass_case(const char* label, const char* pattern, int frame_nxdn48,
     }
 
     state.sps_hunt_idx = frame_nxdn48 ? 1 : (frame_nxdn96 ? 0 : state.sps_hunt_idx);
+    set_profile_timing(&opts, &state, state.sps_hunt_idx);
     dsd_frame_sync_reset_mod_state();
 
     g_symbol_index = 0U;

--- a/tests/dsp/test_frame_sync_dmr_wav_rate.c
+++ b/tests/dsp/test_frame_sync_dmr_wav_rate.c
@@ -207,6 +207,7 @@ init_state_buffers(dsd_state* state) {
 typedef struct {
     const char* label;
     const char* pattern;
+    const char* expected_ftype;
     int frame_dmr;
     int frame_dstar;
     int frame_provoice;
@@ -217,9 +218,9 @@ typedef struct {
     int frame_nxdn96;
     int inverted_x2tdma;
     int inverted_dpmr;
+    int profile_index;
     int initial_lastsynctype;
     int expected_sync;
-    const char* expected_ftype;
     int expected_inverted_ysf;
 } SymbolSyncCase;
 
@@ -246,6 +247,17 @@ init_common_wav_opts_state(dsd_opts* opts, dsd_state* state) {
     opts->mod_gfsk = 1;
     opts->msize = 1;
     opts->ssize = 128;
+    opts->frame_dstar = 1;
+    opts->frame_x2tdma = 1;
+    opts->frame_p25p1 = 1;
+    opts->frame_p25p2 = 1;
+    opts->frame_nxdn48 = 1;
+    opts->frame_nxdn96 = 1;
+    opts->frame_dmr = 1;
+    opts->frame_dpmr = 1;
+    opts->frame_provoice = 1;
+    opts->frame_ysf = 1;
+    opts->frame_m17 = 1;
 
     state->rf_mod = 2;
     state->samplesPerSymbol = 20;
@@ -271,16 +283,9 @@ run_symbol_sync_case(const SymbolSyncCase* tc) {
         return 1;
     }
 
-    opts.frame_dmr = tc->frame_dmr;
-    opts.frame_dstar = tc->frame_dstar;
-    opts.frame_provoice = tc->frame_provoice;
-    opts.frame_x2tdma = tc->frame_x2tdma;
-    opts.frame_ysf = tc->frame_ysf;
-    opts.frame_dpmr = tc->frame_dpmr;
-    opts.frame_nxdn48 = tc->frame_nxdn48;
-    opts.frame_nxdn96 = tc->frame_nxdn96;
     opts.inverted_x2tdma = tc->inverted_x2tdma;
     opts.inverted_dpmr = tc->inverted_dpmr;
+    state.sps_hunt_idx = tc->profile_index;
     state.lastsynctype = tc->initial_lastsynctype;
     g_symbol_index = 0U;
     g_sync_pattern = tc->pattern;
@@ -484,9 +489,34 @@ static int
 run_wav_protocol_sync_matrix(void) {
     static const SymbolSyncCase cases[] = {
         {
+            .label = "P25 Phase 1 positive",
+            .pattern = P25P1_SYNC,
+            .expected_sync = DSD_SYNC_P25P1_POS,
+            .expected_ftype = "P25 Phase 1",
+        },
+        {
+            .label = "P25 Phase 1 negative",
+            .pattern = INV_P25P1_SYNC,
+            .expected_sync = DSD_SYNC_P25P1_NEG,
+            .expected_ftype = "P25 Phase 1",
+        },
+        {
+            .label = "P25 Phase 2 positive",
+            .pattern = P25P2_SYNC,
+            .profile_index = 3,
+            .expected_sync = DSD_SYNC_P25P2_POS,
+        },
+        {
+            .label = "P25 Phase 2 negative",
+            .pattern = INV_P25P2_SYNC,
+            .profile_index = 3,
+            .expected_sync = DSD_SYNC_P25P2_NEG,
+        },
+        {
             .label = "DSTAR voice positive",
             .pattern = DSTAR_SYNC,
             .frame_dstar = 1,
+            .profile_index = 4,
             .expected_sync = DSD_SYNC_DSTAR_VOICE_POS,
             .expected_ftype = "DSTAR ",
         },
@@ -494,6 +524,7 @@ run_wav_protocol_sync_matrix(void) {
             .label = "DSTAR voice negative",
             .pattern = INV_DSTAR_SYNC,
             .frame_dstar = 1,
+            .profile_index = 4,
             .expected_sync = DSD_SYNC_DSTAR_VOICE_NEG,
             .expected_ftype = "DSTAR ",
         },
@@ -501,6 +532,7 @@ run_wav_protocol_sync_matrix(void) {
             .label = "DSTAR header positive",
             .pattern = DSTAR_HD,
             .frame_dstar = 1,
+            .profile_index = 4,
             .expected_sync = DSD_SYNC_DSTAR_HD_POS,
             .expected_ftype = "DSTAR_HD ",
         },
@@ -508,6 +540,7 @@ run_wav_protocol_sync_matrix(void) {
             .label = "DSTAR header negative",
             .pattern = INV_DSTAR_HD,
             .frame_dstar = 1,
+            .profile_index = 4,
             .expected_sync = DSD_SYNC_DSTAR_HD_NEG,
             .expected_ftype = " DSTAR_HD",
         },
@@ -515,6 +548,7 @@ run_wav_protocol_sync_matrix(void) {
             .label = "ProVoice positive",
             .pattern = PROVOICE_SYNC,
             .frame_provoice = 1,
+            .profile_index = 2,
             .expected_sync = DSD_SYNC_PROVOICE_POS,
             .expected_ftype = "ProVoice ",
         },
@@ -522,6 +556,7 @@ run_wav_protocol_sync_matrix(void) {
             .label = "ProVoice negative",
             .pattern = INV_PROVOICE_SYNC,
             .frame_provoice = 1,
+            .profile_index = 2,
             .expected_sync = DSD_SYNC_PROVOICE_NEG,
             .expected_ftype = "ProVoice ",
         },
@@ -529,12 +564,14 @@ run_wav_protocol_sync_matrix(void) {
             .label = "EDACS positive",
             .pattern = INV_EDACS_SYNC,
             .frame_provoice = 1,
+            .profile_index = 2,
             .expected_sync = DSD_SYNC_EDACS_POS,
         },
         {
             .label = "EDACS negative",
             .pattern = EDACS_SYNC,
             .frame_provoice = 1,
+            .profile_index = 2,
             .expected_sync = DSD_SYNC_EDACS_NEG,
         },
     };
@@ -553,6 +590,7 @@ run_wav_protocol_extended_sync_matrix(void) {
             .label = "X2-TDMA BS data",
             .pattern = X2TDMA_BS_DATA_SYNC,
             .frame_x2tdma = 1,
+            .profile_index = 3,
             .expected_sync = DSD_SYNC_X2TDMA_DATA_POS,
             .expected_ftype = "X2-TDMA",
         },
@@ -561,6 +599,7 @@ run_wav_protocol_extended_sync_matrix(void) {
             .pattern = X2TDMA_BS_VOICE_SYNC,
             .frame_x2tdma = 1,
             .inverted_x2tdma = 1,
+            .profile_index = 3,
             .expected_sync = DSD_SYNC_X2TDMA_DATA_NEG,
             .expected_ftype = "X2-TDMA",
         },
@@ -584,6 +623,7 @@ run_wav_protocol_extended_sync_matrix(void) {
             .label = "dPMR FS2 positive",
             .pattern = DPMR_FRAME_SYNC_2,
             .frame_dpmr = 1,
+            .profile_index = 1,
             .expected_sync = DSD_SYNC_DPMR_FS2_POS,
             .expected_ftype = "dPMR ",
         },
@@ -592,6 +632,7 @@ run_wav_protocol_extended_sync_matrix(void) {
             .pattern = INV_DPMR_FRAME_SYNC_2,
             .frame_dpmr = 1,
             .inverted_dpmr = 1,
+            .profile_index = 1,
             .expected_sync = DSD_SYNC_DPMR_FS2_NEG,
             .expected_ftype = "dPMR ",
         },
@@ -615,8 +656,7 @@ run_nxdn_two_pass_case(const char* label, const char* pattern, int frame_nxdn48,
         return 1;
     }
 
-    opts.frame_nxdn48 = frame_nxdn48;
-    opts.frame_nxdn96 = frame_nxdn96;
+    state.sps_hunt_idx = frame_nxdn48 ? 1 : (frame_nxdn96 ? 0 : state.sps_hunt_idx);
     dsd_frame_sync_reset_mod_state();
 
     g_symbol_index = 0U;

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -268,6 +268,32 @@ test_sps_hunt_profile_updates_timing(void) {
     assert(state.rf_mod == 2);
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DSTAR_SYNC, 24) == DSD_SYNC_DSTAR_VOICE_POS);
 
+    /* -mc likewise preserves the C4FM demodulator while exposing D-STAR's
+     * same-rate binary matcher gate. */
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_dmr = 1;
+    opts.frame_dstar = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_c4fm = 1;
+    state.rf_mod = 0;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) - 1;
+    state.samplesPerSymbol = 10;
+    state.symbolCenter = 4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    dsd_frame_sync_test_no_sync_sps_hunt(&opts, &state);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_2);
+    assert(state.sps_hunt_counter == 0);
+    assert(state.samplesPerSymbol == 10);
+    assert(state.symbolCenter == 4);
+    assert(state.rf_mod == 0);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DSTAR_SYNC, 24) == DSD_SYNC_DSTAR_VOICE_POS);
+
     reset(&opts, &state);
     opts.audio_in_type = AUDIO_IN_WAV;
     opts.wav_sample_rate = 96000;

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -13,7 +13,9 @@
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/platform/sockets.h>
+#include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/frame_sync_hooks.h>
 #ifdef USE_RADIO
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
@@ -589,6 +591,26 @@ test_m17_auto_preamble_disambiguation_preserves_forced_tolerance(void) {
 }
 
 static void
+test_short_m17_window_estimates_levels_without_warm_start_history(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    float levels[8];
+
+    reset(&opts, &state);
+    opts.frame_m17 = 1;
+    opts.msize = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    for (int i = 0; i < 8; i++) {
+        levels[i] = M17_PRE[i] == '3' ? -3.0f : 3.0f;
+    }
+
+    assert(state.dmr_sample_history == NULL);
+    assert(dsd_frame_sync_test_eval_window(&opts, &state, M17_PRE, levels, 8) == DSD_SYNC_M17_PRE_POS);
+    assert(fabsf(state.min - (-1.5f)) < 0.0001f);
+    assert(fabsf(state.max - 1.5f) < 0.0001f);
+}
+
+static void
 test_m17_preamble_requires_context_when_dstar_is_enabled(void) {
     static const char* const dstar_patterns[] = {DSTAR_SYNC, INV_DSTAR_SYNC, DSTAR_HD, INV_DSTAR_HD};
     static const char repeated_pre[] = M17_PRE M17_PRE;
@@ -983,6 +1005,54 @@ test_active_profile_metrics_power_gate_and_votes(void) {
 }
 
 static void
+test_nxdn_only_profiles_use_gfsk_snr_gate(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    install_fake_snr_hooks();
+    (void)dsd_setenv("DSD_NEO_SNR_SQL_DB", "10", 1);
+    dsd_neo_config_init(NULL);
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 0;
+    g_snr_c4fm = 0.0;
+    g_snr_gfsk = 20.0;
+    assert(dsd_frame_sync_test_active_profile_modulation(&opts, &state) == 2);
+    assert(dsd_frame_sync_test_active_profile_snr_db(&opts, &state) == 20.0);
+    assert(dsd_frame_sync_test_should_skip_snr_or_power_gate(&opts, &state) == 0);
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_nxdn48 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    state.rf_mod = 0;
+    assert(dsd_frame_sync_test_active_profile_modulation(&opts, &state) == 2);
+    assert(dsd_frame_sync_test_active_profile_snr_db(&opts, &state) == 20.0);
+    assert(dsd_frame_sync_test_should_skip_snr_or_power_gate(&opts, &state) == 0);
+
+    g_snr_c4fm = 20.0;
+    g_snr_gfsk = 0.0;
+    assert(dsd_frame_sync_test_should_skip_snr_or_power_gate(&opts, &state) == 1);
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_p25p1 = 1;
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 0;
+    assert(dsd_frame_sync_test_active_profile_modulation(&opts, &state) == 0);
+    assert(dsd_frame_sync_test_active_profile_snr_db(&opts, &state) == 20.0);
+    assert(dsd_frame_sync_test_should_skip_snr_or_power_gate(&opts, &state) == 0);
+
+    (void)dsd_unsetenv("DSD_NEO_SNR_SQL_DB");
+    dsd_neo_config_init(NULL);
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+}
+
+static void
 test_modulation_snr_fallback_votes_and_dwell(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -1114,6 +1184,7 @@ main(void) {
     test_symbol_replay_requires_explicit_nxdn_variant();
     test_manual_p25p2_c4fm_bypasses_profile_gating();
     test_m17_auto_preamble_disambiguation_preserves_forced_tolerance();
+    test_short_m17_window_estimates_levels_without_warm_start_history();
     test_m17_preamble_requires_context_when_dstar_is_enabled();
     test_elapsed_seconds_prefers_monotonic_then_wall_time();
     test_p25_slot_activity_honors_ring_and_hangtime();
@@ -1124,6 +1195,7 @@ main(void) {
     test_rtl_sps_profiles_apply_and_lock_on_sync();
     test_dmr_sync_applies_gfsk_rtl_profile();
     test_active_profile_metrics_power_gate_and_votes();
+    test_nxdn_only_profiles_use_gfsk_snr_gate();
     test_modulation_snr_fallback_votes_and_dwell();
     test_modulation_cli_lock_prevents_votes();
     test_hamming_override_can_select_qpsk();

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -354,6 +354,61 @@ test_binary_profiles_override_unlocked_qpsk(void) {
 }
 
 static void
+test_four_level_profiles_reset_inherited_modulation(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dstar = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state.rf_mod = 2;
+    dsd_frame_sync_test_apply_sps_hunt_profile(&opts, &state, DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(state.rf_mod == 0);
+
+    reset(&opts, &state);
+    opts.frame_p25p2 = 1;
+    opts.frame_provoice = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_9600_2;
+    state.rf_mod = 2;
+    dsd_frame_sync_test_apply_sps_hunt_profile(&opts, &state, DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    assert(state.rf_mod == 0);
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 2;
+    dsd_frame_sync_test_apply_sps_hunt_profile(&opts, &state, DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(state.rf_mod == 2);
+}
+
+static void
+test_nxdn_variant_follows_active_profile(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    assert(dsd_frame_sync_active_nxdn_variant(&opts, &state) == DSD_NXDN_VARIANT_NONE);
+    assert(dsd_frame_sync_active_nxdn_variant(NULL, &state) == DSD_NXDN_VARIANT_NONE);
+
+    opts.frame_nxdn48 = 1;
+    assert(dsd_frame_sync_active_nxdn_variant(&opts, NULL) == DSD_NXDN_VARIANT_48);
+    opts.frame_nxdn48 = 0;
+    opts.frame_nxdn96 = 1;
+    assert(dsd_frame_sync_active_nxdn_variant(&opts, NULL) == DSD_NXDN_VARIANT_96);
+
+    opts.frame_nxdn48 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    assert(dsd_frame_sync_active_nxdn_variant(&opts, &state) == DSD_NXDN_VARIANT_96);
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    assert(dsd_frame_sync_active_nxdn_variant(&opts, &state) == DSD_NXDN_VARIANT_48);
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    assert(dsd_frame_sync_active_nxdn_variant(&opts, &state) == DSD_NXDN_VARIANT_NONE);
+}
+
+static void
 test_bounded_symbol_history_readiness_and_wrap(void) {
     static const int window_lengths[] = {8, 10, 12, 16, 20, 24, 32, 48};
     char symbols[80];
@@ -934,6 +989,8 @@ main(void) {
     test_sps_hunt_profile_updates_timing();
     test_sps_hunt_reconciles_external_timing();
     test_binary_profiles_override_unlocked_qpsk();
+    test_four_level_profiles_reset_inherited_modulation();
+    test_nxdn_variant_follows_active_profile();
     test_bounded_symbol_history_readiness_and_wrap();
     test_provoice_candidate_does_not_shadow_dstar_or_nxdn();
     test_symbol_replay_bypasses_sps_profile_gating();

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -320,6 +320,28 @@ test_sps_hunt_profile_updates_timing(void) {
     assert(state.sps_hunt_counter == 0);
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_P25P2_POS);
 
+    /* A known FDMA CC retune supersedes the P25p2 helper's original profile choice. */
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtl_dsp_bw_khz = 16;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_qpsk = 1;
+    opts.mod_p25p2_profile_lock = 1;
+    state.rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) - 1;
+    state.samplesPerSymbol = dsd_opts_compute_sps_rate(&opts, 4800, 0);
+    state.symbolCenter = dsd_opts_symbol_center(state.samplesPerSymbol);
+    state.min = -3.0f;
+    state.max = 3.0f;
+    assert(dsd_opts_compute_sps_rate(&opts, 6000, 0) == state.samplesPerSymbol);
+    dsd_frame_sync_test_no_sync_sps_hunt(&opts, &state);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(state.sps_hunt_counter == 0);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P1_SYNC, 24) == DSD_SYNC_P25P1_POS);
+
     reset(&opts, &state);
     opts.audio_in_type = AUDIO_IN_RTL;
     opts.rtl_dsp_bw_khz = 16;
@@ -832,6 +854,8 @@ static int g_profile_set_calls = 0;
 static int g_profile_rate = 0;
 static int g_profile_levels = 0;
 static int g_profile_channel = 0;
+static int g_profile_cqpsk = 0;
+static int g_profile_ted_sps = 0;
 
 static double
 fake_snr_c4fm_db(void) {
@@ -864,12 +888,24 @@ fake_output_rate_hz(void) {
 }
 
 static int
-fake_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profile) {
+fake_apply_demod_profile(int cqpsk_enable, int symbol_rate_hz, int levels, int channel_profile, int ted_sps) {
     g_profile_set_calls++;
+    g_profile_cqpsk = cqpsk_enable;
     g_profile_rate = symbol_rate_hz;
     g_profile_levels = levels;
     g_profile_channel = channel_profile;
+    g_profile_ted_sps = ted_sps;
     return 0;
+}
+
+static void
+reset_fake_profile_capture(void) {
+    g_profile_set_calls = 0;
+    g_profile_cqpsk = -1;
+    g_profile_rate = 0;
+    g_profile_levels = 0;
+    g_profile_channel = 0;
+    g_profile_ted_sps = 0;
 }
 
 static void
@@ -896,6 +932,8 @@ install_fake_snr_hooks(void) {
         .snr_cqpsk_db = fake_snr_cqpsk_db,
         .snr_gfsk_db = fake_snr_gfsk_db,
         .snr_qpsk_const_db = fake_snr_qpsk_const_db,
+        .output_rate_hz = fake_output_rate_hz,
+        .apply_demod_profile = fake_apply_demod_profile,
     };
     dsd_rtl_stream_metrics_hooks_set(&hooks);
 }
@@ -960,10 +998,10 @@ test_rtl_p25p2_timing_reconciliation_preserves_cqpsk(void) {
 
     dsd_rtl_stream_metrics_hooks hooks = {
         .output_rate_hz = fake_output_rate_hz,
-        .set_symbol_profile = fake_set_symbol_profile,
+        .apply_demod_profile = fake_apply_demod_profile,
     };
     dsd_rtl_stream_metrics_hooks_set(&hooks);
-    g_profile_set_calls = 0;
+    reset_fake_profile_capture();
 
     dsd_frame_sync_test_ensure_enabled_sps_profile(&opts, &state);
     assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
@@ -972,6 +1010,45 @@ test_rtl_p25p2_timing_reconciliation_preserves_cqpsk(void) {
     assert(g_profile_rate == 6000);
     assert(g_profile_levels == 4);
     assert(g_profile_channel == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    assert(g_profile_cqpsk == 1);
+    assert(g_profile_ted_sps == 8);
+
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+}
+
+static void
+test_unlocked_rtl_p25p2_sync_switches_demod_family(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int fake_rtl_context;
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_p25p2 = 1;
+    state.rf_mod = 0;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.p2_wacn = 1;
+    state.p2_cc = 1;
+    state.p2_sysid = 1;
+
+    dsd_rtl_stream_metrics_hooks hooks = {
+        .output_rate_hz = fake_output_rate_hz,
+        .apply_demod_profile = fake_apply_demod_profile,
+    };
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+    reset_fake_profile_capture();
+
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_P25P2_POS);
+    assert(state.rf_mod == 1);
+    assert(g_profile_set_calls == 1);
+    assert(g_profile_cqpsk == 1);
+    assert(g_profile_rate == 6000);
+    assert(g_profile_levels == 4);
+    assert(g_profile_channel == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    assert(g_profile_ted_sps == 8);
 
     dsd_rtl_stream_metrics_hooks_set(NULL);
 }
@@ -1009,10 +1086,10 @@ test_rtl_sps_profiles_apply_and_lock_on_sync(void) {
 
     dsd_rtl_stream_metrics_hooks hooks = {
         .output_rate_hz = fake_output_rate_hz,
-        .set_symbol_profile = fake_set_symbol_profile,
+        .apply_demod_profile = fake_apply_demod_profile,
     };
     dsd_rtl_stream_metrics_hooks_set(&hooks);
-    g_profile_set_calls = 0;
+    reset_fake_profile_capture();
 
     for (int profile_index = 0; profile_index < 5; profile_index++) {
         state.sps_hunt_idx = (profile_index + 1) % 5;
@@ -1057,13 +1134,10 @@ test_dmr_sync_applies_gfsk_rtl_profile(void) {
 
     dsd_rtl_stream_metrics_hooks hooks = {
         .output_rate_hz = fake_output_rate_hz,
-        .set_symbol_profile = fake_set_symbol_profile,
+        .apply_demod_profile = fake_apply_demod_profile,
     };
     dsd_rtl_stream_metrics_hooks_set(&hooks);
-    g_profile_set_calls = 0;
-    g_profile_rate = 0;
-    g_profile_levels = 0;
-    g_profile_channel = 0;
+    reset_fake_profile_capture();
 
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DMR_BS_DATA_SYNC, 24) == DSD_SYNC_DMR_BS_DATA_POS);
     assert(state.rf_mod == 2);
@@ -1071,6 +1145,8 @@ test_dmr_sync_applies_gfsk_rtl_profile(void) {
     assert(g_profile_rate == 4800);
     assert(g_profile_levels == 4);
     assert(g_profile_channel == DSD_RTL_STREAM_CHANNEL_PROFILE_12K5);
+    assert(g_profile_cqpsk == 0);
+    assert(g_profile_ted_sps == 10);
 
     dsd_rtl_stream_metrics_hooks_set(NULL);
 }
@@ -1141,6 +1217,7 @@ static void
 test_mixed_profile_snr_recovers_from_gfsk(void) {
     static dsd_opts opts;
     static dsd_state state;
+    static int fake_rtl_context;
     int lastt = 24;
     int c4fm_votes = -1;
     int qpsk_votes = -1;
@@ -1152,9 +1229,11 @@ test_mixed_profile_snr_recovers_from_gfsk(void) {
     opts.frame_dmr = 1;
     state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
     state.rf_mod = 2;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
     set_fake_snr(0.0, -100.0, 20.0, -100.0);
     install_fake_snr_hooks();
     dsd_frame_sync_reset_mod_state();
+    reset_fake_profile_capture();
 
     dsd_frame_sync_test_auto_switch_modulation(&opts, &state, 24, &lastt);
     dsd_frame_sync_test_get_mod_votes(&c4fm_votes, &qpsk_votes, &gfsk_votes);
@@ -1162,10 +1241,17 @@ test_mixed_profile_snr_recovers_from_gfsk(void) {
     assert(c4fm_votes == 0);
     assert(qpsk_votes == 1);
     assert(gfsk_votes == 0);
+    assert(g_profile_set_calls == 0);
 
     lastt = 24;
     dsd_frame_sync_test_auto_switch_modulation(&opts, &state, 24, &lastt);
     assert(state.rf_mod == 1);
+    assert(g_profile_set_calls == 1);
+    assert(g_profile_cqpsk == 1);
+    assert(g_profile_rate == 4800);
+    assert(g_profile_levels == 4);
+    assert(g_profile_channel == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    assert(g_profile_ted_sps == 10);
 
     reset(&opts, &state);
     opts.audio_in_type = AUDIO_IN_RTL;
@@ -1425,6 +1511,7 @@ main(void) {
 #ifdef USE_RADIO
     test_rtl_symbol_profile_selection();
     test_rtl_p25p2_timing_reconciliation_preserves_cqpsk();
+    test_unlocked_rtl_p25p2_sync_switches_demod_family();
     test_rtl_sps_profiles_apply_and_lock_on_sync();
     test_dmr_sync_applies_gfsk_rtl_profile();
     test_active_profile_metrics_power_gate_and_votes();

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -283,6 +283,23 @@ test_sps_hunt_reconciles_external_timing(void) {
     state.p2_sysid = 1;
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_P25P2_POS);
 
+    /* The normal -f2 preset selects QPSK and 6000-rate timing without a CLI modulation lock. */
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    opts.frame_p25p2 = 1;
+    opts.mod_qpsk = 1;
+    state.rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.samplesPerSymbol = dsd_opts_compute_sps_rate(&opts, 6000, 48000);
+    state.symbolCenter = dsd_opts_symbol_center(state.samplesPerSymbol);
+
+    dsd_frame_sync_test_ensure_enabled_sps_profile(&opts, &state);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    assert(state.rf_mod == 1);
+    assert(dsd_frame_sync_test_active_profile_modulation(&opts, &state) == 1);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_P25P2_POS);
+
     reset(&opts, &state);
     opts.audio_in_type = AUDIO_IN_WAV;
     opts.wav_sample_rate = 48000;
@@ -481,6 +498,39 @@ test_symbol_replay_bypasses_sps_profile_gating(void) {
 }
 
 static void
+test_symbol_replay_requires_explicit_nxdn_variant(void) {
+    static const int symbol_input_types[] = {AUDIO_IN_SYMBOL_BIN, AUDIO_IN_SYMBOL_FLT};
+    static dsd_opts opts;
+    static dsd_state state;
+
+    for (size_t i = 0; i < sizeof(symbol_input_types) / sizeof(symbol_input_types[0]); i++) {
+        reset(&opts, &state);
+        opts.audio_in_type = symbol_input_types[i];
+        opts.frame_nxdn48 = 1;
+        opts.frame_nxdn96 = 1;
+        state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+        assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+        assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+
+        reset(&opts, &state);
+        opts.audio_in_type = symbol_input_types[i];
+        opts.frame_nxdn48 = 1;
+        state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+        assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+        assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NXDN_POS);
+        assert(dsd_frame_sync_active_nxdn_variant(&opts, &state) == DSD_NXDN_VARIANT_48);
+
+        reset(&opts, &state);
+        opts.audio_in_type = symbol_input_types[i];
+        opts.frame_nxdn96 = 1;
+        state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+        assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+        assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NXDN_POS);
+        assert(dsd_frame_sync_active_nxdn_variant(&opts, &state) == DSD_NXDN_VARIANT_96);
+    }
+}
+
+static void
 test_manual_p25p2_c4fm_bypasses_profile_gating(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -536,6 +586,39 @@ test_m17_auto_preamble_disambiguation_preserves_forced_tolerance(void) {
     state.max = 3.0f;
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, one_error_preamble, 8) == DSD_SYNC_NONE);
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, M17_PRE, 8) == DSD_SYNC_M17_PRE_POS);
+}
+
+static void
+test_m17_preamble_requires_context_when_dstar_is_enabled(void) {
+    static const char* const dstar_patterns[] = {DSTAR_SYNC, INV_DSTAR_SYNC, DSTAR_HD, INV_DSTAR_HD};
+    static const char repeated_pre[] = M17_PRE M17_PRE;
+    static const char repeated_piv[] = M17_PIV M17_PIV;
+    static dsd_opts opts;
+    static dsd_state state;
+
+    for (size_t pattern_index = 0; pattern_index < sizeof(dstar_patterns) / sizeof(dstar_patterns[0]);
+         pattern_index++) {
+        for (int symbol_count = 8; symbol_count <= 24; symbol_count++) {
+            reset(&opts, &state);
+            opts.frame_m17 = 1;
+            opts.frame_dstar = 1;
+            state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+            assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, dstar_patterns[pattern_index], symbol_count)
+                   == DSD_SYNC_NONE);
+        }
+    }
+
+    reset(&opts, &state);
+    opts.frame_m17 = 1;
+    opts.frame_dstar = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, repeated_pre, 16) == DSD_SYNC_M17_PRE_POS);
+
+    reset(&opts, &state);
+    opts.frame_m17 = 1;
+    opts.frame_dstar = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, repeated_piv, 16) == DSD_SYNC_M17_PRE_NEG);
 }
 
 static void
@@ -702,6 +785,40 @@ test_rtl_symbol_profile_selection(void) {
 
     reset(&opts, &state);
     assert(dsd_frame_sync_test_rtl_profile_for_sps_index(&opts, &state, 1) == DSD_RTL_STREAM_CHANNEL_PROFILE_6K25);
+}
+
+static void
+test_rtl_p25p2_timing_reconciliation_preserves_cqpsk(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int fake_rtl_context;
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_p25p2 = 1;
+    opts.mod_qpsk = 1;
+    state.rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.samplesPerSymbol = dsd_opts_compute_sps_rate(&opts, 6000, 48000);
+    state.symbolCenter = dsd_opts_symbol_center(state.samplesPerSymbol);
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+
+    dsd_rtl_stream_metrics_hooks hooks = {
+        .output_rate_hz = fake_output_rate_hz,
+        .set_symbol_profile = fake_set_symbol_profile,
+    };
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+    g_profile_set_calls = 0;
+
+    dsd_frame_sync_test_ensure_enabled_sps_profile(&opts, &state);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    assert(state.rf_mod == 1);
+    assert(g_profile_set_calls == 1);
+    assert(g_profile_rate == 6000);
+    assert(g_profile_levels == 4);
+    assert(g_profile_channel == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+
+    dsd_rtl_stream_metrics_hooks_set(NULL);
 }
 
 static void
@@ -994,13 +1111,16 @@ main(void) {
     test_bounded_symbol_history_readiness_and_wrap();
     test_provoice_candidate_does_not_shadow_dstar_or_nxdn();
     test_symbol_replay_bypasses_sps_profile_gating();
+    test_symbol_replay_requires_explicit_nxdn_variant();
     test_manual_p25p2_c4fm_bypasses_profile_gating();
     test_m17_auto_preamble_disambiguation_preserves_forced_tolerance();
+    test_m17_preamble_requires_context_when_dstar_is_enabled();
     test_elapsed_seconds_prefers_monotonic_then_wall_time();
     test_p25_slot_activity_honors_ring_and_hangtime();
     test_hamming_helpers_find_best_patterns();
 #ifdef USE_RADIO
     test_rtl_symbol_profile_selection();
+    test_rtl_p25p2_timing_reconciliation_preserves_cqpsk();
     test_rtl_sps_profiles_apply_and_lock_on_sync();
     test_dmr_sync_applies_gfsk_rtl_profile();
     test_active_profile_metrics_power_gate_and_votes();

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -294,6 +294,48 @@ test_sps_hunt_profile_updates_timing(void) {
     assert(state.rf_mod == 0);
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DSTAR_SYNC, 24) == DSD_SYNC_DSTAR_VOICE_POS);
 
+    /* At 16 kHz, 4800 and 6000 symbols/s both round to 3 SPS. Generic demodulator
+     * locks still rotate gates, but the profile-specific -m2/M selection must not. */
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtl_dsp_bw_khz = 16;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_qpsk = 1;
+    opts.mod_p25p2_profile_lock = 1;
+    state.rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) - 1;
+    state.samplesPerSymbol = dsd_opts_compute_sps_rate(&opts, 6000, 0);
+    state.symbolCenter = dsd_opts_symbol_center(state.samplesPerSymbol);
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.p2_wacn = 1;
+    state.p2_cc = 1;
+    state.p2_sysid = 1;
+    assert(dsd_opts_compute_sps_rate(&opts, 4800, 0) == state.samplesPerSymbol);
+    dsd_frame_sync_test_no_sync_sps_hunt(&opts, &state);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    assert(state.sps_hunt_counter == 0);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_P25P2_POS);
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtl_dsp_bw_khz = 16;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_qpsk = 1;
+    state.rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) - 1;
+    state.samplesPerSymbol = dsd_opts_compute_sps_rate(&opts, 6000, 0);
+    state.symbolCenter = dsd_opts_symbol_center(state.samplesPerSymbol);
+    dsd_frame_sync_test_no_sync_sps_hunt(&opts, &state);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(state.sps_hunt_counter == 0);
+
     reset(&opts, &state);
     opts.audio_in_type = AUDIO_IN_WAV;
     opts.wav_sample_rate = 96000;

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/platform/sockets.h>
@@ -19,6 +20,7 @@
 #endif
 #include <math.h>
 #include <stdint.h>
+#include <string.h>
 #include <time.h>
 
 #include "dsd-neo/core/dibit.h"
@@ -160,42 +162,49 @@ reset(dsd_opts* opts, dsd_state* state) {
 
 static void
 test_sps_hunt_skips_disabled_protocol_rates(void) {
-    static const int sym_rate_cycle[] = {4800, 2400, 9600, 6000, 4800};
-    static const int levels_cycle[] = {4, 4, 2, 4, 2};
-    static const int cycle_count = (int)(sizeof(sym_rate_cycle) / sizeof(sym_rate_cycle[0]));
     static dsd_opts opts;
     static dsd_state state;
+
+    static const int expected_rates[] = {4800, 2400, 9600, 6000, 4800};
+    static const int expected_levels[] = {4, 4, 2, 4, 2};
+    assert(dsd_frame_sync_test_sps_hunt_profile_count() == 5);
+    for (int i = 0; i < 5; i++) {
+        assert(dsd_frame_sync_test_sps_hunt_profile_rate(i) == expected_rates[i]);
+        assert(dsd_frame_sync_test_sps_hunt_profile_levels(i) == expected_levels[i]);
+    }
 
     reset(&opts, &state);
     opts.frame_dstar = 1;
     state.sps_hunt_idx = 3;
-    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state, sym_rate_cycle, levels_cycle, cycle_count) == 4);
+    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state) == 4);
 
     reset(&opts, &state);
     opts.frame_dmr = 1;
     state.sps_hunt_idx = 4;
-    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state, sym_rate_cycle, levels_cycle, cycle_count) == 0);
+    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state) == 0);
 
     reset(&opts, &state);
     opts.frame_nxdn48 = 1;
     state.sps_hunt_idx = 0;
-    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state, sym_rate_cycle, levels_cycle, cycle_count) == 1);
+    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state) == 1);
 
     reset(&opts, &state);
     opts.frame_provoice = 1;
     state.sps_hunt_idx = 1;
-    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state, sym_rate_cycle, levels_cycle, cycle_count) == 2);
+    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state) == 2);
 
     reset(&opts, &state);
     opts.frame_p25p2 = 1;
     state.sps_hunt_idx = 2;
-    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state, sym_rate_cycle, levels_cycle, cycle_count) == 3);
+    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state) == 3);
+
+    reset(&opts, &state);
+    state.sps_hunt_idx = 2;
+    assert(dsd_frame_sync_test_sps_hunt_next_index(&opts, &state) == 2);
 }
 
 static void
 test_sps_hunt_profile_updates_timing(void) {
-    static const int sym_rate_cycle[] = {4800, 2400, 9600, 6000, 4800};
-    static const int levels_cycle[] = {4, 4, 2, 4, 2};
     static dsd_opts opts;
     static dsd_state state;
 
@@ -203,20 +212,108 @@ test_sps_hunt_profile_updates_timing(void) {
     opts.audio_in_type = AUDIO_IN_WAV;
     opts.wav_sample_rate = 96000;
     opts.wav_decimator = 48000;
-    state.sps_hunt_idx = 0;
+    for (int profile_index = 0; profile_index < dsd_frame_sync_test_sps_hunt_profile_count(); profile_index++) {
+        state.sps_hunt_idx = (profile_index + 1) % dsd_frame_sync_test_sps_hunt_profile_count();
+        state.samplesPerSymbol = -1;
+        state.symbolCenter = -1;
+        dsd_frame_sync_test_apply_sps_hunt_profile(&opts, &state, profile_index);
+        int symbol_rate = dsd_frame_sync_test_sps_hunt_profile_rate(profile_index);
+        int expected_sps = dsd_opts_compute_sps_rate(&opts, symbol_rate, dsd_opts_current_input_timing_rate(&opts));
+        assert(state.sps_hunt_idx == profile_index);
+        assert(state.samplesPerSymbol == expected_sps);
+        assert(state.symbolCenter == dsd_opts_symbol_center(expected_sps));
+
+        dsd_frame_sync_test_apply_sps_hunt_profile(&opts, &state, profile_index);
+        assert(state.samplesPerSymbol == expected_sps);
+        assert(state.symbolCenter == dsd_opts_symbol_center(expected_sps));
+    }
+
+    reset(&opts, &state);
+    opts.frame_dstar = 1;
+    opts.mod_cli_lock = 1;
+    state.sps_hunt_idx = 4;
+    state.sps_hunt_counter = 100;
     state.samplesPerSymbol = 10;
     state.symbolCenter = 4;
+    dsd_frame_sync_test_no_sync_sps_hunt(&opts, &state);
+    assert(state.sps_hunt_idx == 4);
+    assert(state.samplesPerSymbol == 10);
+    assert(state.symbolCenter == 4);
+}
 
-    dsd_frame_sync_test_apply_sps_hunt_profile(&opts, &state, 1, sym_rate_cycle, levels_cycle);
-    int expected_sps = dsd_opts_compute_sps_rate(&opts, sym_rate_cycle[1], dsd_opts_current_input_timing_rate(&opts));
-    assert(state.sps_hunt_idx == 1);
-    assert(state.samplesPerSymbol == expected_sps);
-    assert(state.symbolCenter == dsd_opts_symbol_center(expected_sps));
+static void
+test_bounded_symbol_history_readiness_and_wrap(void) {
+    static const int window_lengths[] = {8, 10, 12, 16, 20, 24, 32, 48};
+    char symbols[80];
+    char out[49];
+    for (int i = 0; i < (int)sizeof(symbols); i++) {
+        symbols[i] = (char)('0' + (i & 3));
+    }
 
-    dsd_frame_sync_test_apply_sps_hunt_profile(&opts, &state, 1, sym_rate_cycle, levels_cycle);
-    assert(state.sps_hunt_idx == 1);
-    assert(state.samplesPerSymbol == expected_sps);
-    assert(state.symbolCenter == dsd_opts_symbol_center(expected_sps));
+    for (size_t i = 0; i < sizeof(window_lengths) / sizeof(window_lengths[0]); i++) {
+        const int length = window_lengths[i];
+        DSD_MEMSET(out, 'x', sizeof(out));
+        assert(dsd_frame_sync_test_history_window(symbols, length - 1, length, out, (int)sizeof(out)) == 0);
+        assert(dsd_frame_sync_test_history_window(symbols, length, length, out, (int)sizeof(out)) == 1);
+        assert(memcmp(out, symbols, (size_t)length) == 0);
+        assert(out[length] == '\0');
+
+        assert(dsd_frame_sync_test_history_window(symbols, (int)sizeof(symbols), length, out, (int)sizeof(out)) == 1);
+        assert(memcmp(out, symbols + sizeof(symbols) - (size_t)length, (size_t)length) == 0);
+        assert(out[length] == '\0');
+    }
+}
+
+static void
+test_provoice_candidate_does_not_shadow_dstar_or_nxdn(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_provoice = 1;
+    opts.frame_dstar = 1;
+    opts.frame_nxdn48 = 1;
+    state.sps_hunt_idx = 4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DSTAR_SYNC, 24) == DSD_SYNC_DSTAR_VOICE_POS);
+
+    reset(&opts, &state);
+    opts.frame_provoice = 1;
+    opts.frame_dstar = 1;
+    opts.frame_nxdn48 = 1;
+    state.sps_hunt_idx = 1;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NXDN_POS);
+}
+
+static void
+test_m17_auto_preamble_disambiguation_preserves_forced_tolerance(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    char one_error_preamble[9];
+    DSD_MEMCPY(one_error_preamble, M17_PRE, sizeof(one_error_preamble));
+    one_error_preamble[0] = one_error_preamble[0] == '1' ? '3' : '1';
+
+    reset(&opts, &state);
+    opts.frame_m17 = 1;
+    state.sps_hunt_idx = 0;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, one_error_preamble, 8) == DSD_SYNC_M17_PRE_POS);
+
+    reset(&opts, &state);
+    opts.frame_m17 = 1;
+    opts.frame_dmr = 1;
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = 0;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, one_error_preamble, 8) == DSD_SYNC_NONE);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, M17_PRE, 8) == DSD_SYNC_M17_PRE_POS);
 }
 
 static void
@@ -268,8 +365,13 @@ test_hamming_helpers_find_best_patterns(void) {
 static double g_snr_c4fm = -100.0;
 static double g_snr_c4fm_eye = -100.0;
 static double g_snr_cqpsk = -100.0;
+static double g_snr_gfsk = -100.0;
 static double g_snr_qpsk_const = -100.0;
 static int g_frame_sync_tick_calls = 0;
+static int g_profile_set_calls = 0;
+static int g_profile_rate = 0;
+static int g_profile_levels = 0;
+static int g_profile_channel = 0;
 
 static double
 fake_snr_c4fm_db(void) {
@@ -287,8 +389,27 @@ fake_snr_cqpsk_db(void) {
 }
 
 static double
+fake_snr_gfsk_db(void) {
+    return g_snr_gfsk;
+}
+
+static double
 fake_snr_qpsk_const_db(void) {
     return g_snr_qpsk_const;
+}
+
+static unsigned int
+fake_output_rate_hz(void) {
+    return 48000U;
+}
+
+static int
+fake_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profile) {
+    g_profile_set_calls++;
+    g_profile_rate = symbol_rate_hz;
+    g_profile_levels = levels;
+    g_profile_channel = channel_profile;
+    return 0;
 }
 
 static void
@@ -303,6 +424,7 @@ set_fake_snr(double c4fm, double c4fm_eye, double cqpsk, double qpsk_const) {
     g_snr_c4fm = c4fm;
     g_snr_c4fm_eye = c4fm_eye;
     g_snr_cqpsk = cqpsk;
+    g_snr_gfsk = -100.0;
     g_snr_qpsk_const = qpsk_const;
 }
 
@@ -312,6 +434,7 @@ install_fake_snr_hooks(void) {
         .snr_c4fm_db = fake_snr_c4fm_db,
         .snr_c4fm_eye_db = fake_snr_c4fm_eye_db,
         .snr_cqpsk_db = fake_snr_cqpsk_db,
+        .snr_gfsk_db = fake_snr_gfsk_db,
         .snr_qpsk_const_db = fake_snr_qpsk_const_db,
     };
     dsd_rtl_stream_metrics_hooks_set(&hooks);
@@ -324,55 +447,157 @@ test_rtl_symbol_profile_selection(void) {
 
     reset(&opts, &state);
     opts.frame_dstar = 1;
-    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 4800, 2)
-           == DSD_RTL_STREAM_CHANNEL_PROFILE_6K25);
-    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(&opts, 4800, 0) == 2);
-    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(&opts, 4800, 4) == 4);
+    assert(dsd_frame_sync_test_rtl_profile_for_sps_index(&opts, &state, 4) == DSD_RTL_STREAM_CHANNEL_PROFILE_6K25);
 
     reset(&opts, &state);
     opts.frame_provoice = 1;
-    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 9600, 0)
-           == DSD_RTL_STREAM_CHANNEL_PROFILE_PROVOICE);
-    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(&opts, 9600, 0) == 2);
-    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 4800, 0)
-           == DSD_RTL_STREAM_CHANNEL_PROFILE_PROVOICE);
-    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(&opts, 4800, 0) == 2);
+    assert(dsd_frame_sync_test_rtl_profile_for_sps_index(&opts, &state, 2) == DSD_RTL_STREAM_CHANNEL_PROFILE_PROVOICE);
 
     reset(&opts, &state);
     opts.frame_dstar = 1;
     opts.frame_dmr = 1;
-    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 4800, 0)
-           == DSD_RTL_STREAM_CHANNEL_PROFILE_12K5);
-    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(&opts, 4800, 0) == 4);
+    assert(dsd_frame_sync_test_rtl_profile_for_sps_index(&opts, &state, 0) == DSD_RTL_STREAM_CHANNEL_PROFILE_12K5);
 
     reset(&opts, &state);
     opts.frame_p25p2 = 1;
     state.rf_mod = 1;
-    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 6000, 0)
-           == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    assert(dsd_frame_sync_test_rtl_profile_for_sps_index(&opts, &state, 3) == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
 
     reset(&opts, &state);
     opts.frame_x2tdma = 1;
-    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 6000, 0)
-           == DSD_RTL_STREAM_CHANNEL_PROFILE_12K5);
+    assert(dsd_frame_sync_test_rtl_profile_for_sps_index(&opts, &state, 3) == DSD_RTL_STREAM_CHANNEL_PROFILE_12K5);
 
     reset(&opts, &state);
     opts.frame_dmr = 1;
-    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 4800, 0)
-           == DSD_RTL_STREAM_CHANNEL_PROFILE_12K5);
+    assert(dsd_frame_sync_test_rtl_profile_for_sps_index(&opts, &state, 0) == DSD_RTL_STREAM_CHANNEL_PROFILE_12K5);
 
     reset(&opts, &state);
     opts.frame_p25p1 = 1;
     state.rf_mod = 0;
-    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 4800, 0)
-           == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
+    assert(dsd_frame_sync_test_rtl_profile_for_sps_index(&opts, &state, 0) == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
     state.rf_mod = 1;
-    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(&opts, &state, 4800, 0)
-           == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    assert(dsd_frame_sync_test_rtl_profile_for_sps_index(&opts, &state, 0) == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
 
-    assert(dsd_frame_sync_test_rtl_profile_for_symbol_rate(NULL, NULL, 2400, 0) == DSD_RTL_STREAM_CHANNEL_PROFILE_6K25);
-    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(NULL, 4800, 0) == 4);
-    assert(dsd_frame_sync_test_rtl_levels_for_symbol_rate(NULL, 4800, 2) == 2);
+    reset(&opts, &state);
+    assert(dsd_frame_sync_test_rtl_profile_for_sps_index(&opts, &state, 1) == DSD_RTL_STREAM_CHANNEL_PROFILE_6K25);
+}
+
+static void
+test_rtl_sps_profiles_apply_and_lock_on_sync(void) {
+    static const int expected_rates[] = {4800, 2400, 9600, 6000, 4800};
+    static const int expected_levels[] = {4, 4, 2, 4, 2};
+    static const int expected_channels[] = {
+        DSD_RTL_STREAM_CHANNEL_PROFILE_12K5,     DSD_RTL_STREAM_CHANNEL_PROFILE_6K25,
+        DSD_RTL_STREAM_CHANNEL_PROFILE_PROVOICE, DSD_RTL_STREAM_CHANNEL_PROFILE_12K5,
+        DSD_RTL_STREAM_CHANNEL_PROFILE_6K25,
+    };
+    static dsd_opts opts;
+    static dsd_state state;
+    static int fake_rtl_context;
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_dstar = 1;
+    opts.frame_x2tdma = 1;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_nxdn48 = 1;
+    opts.frame_nxdn96 = 1;
+    opts.frame_dmr = 1;
+    opts.frame_dpmr = 1;
+    opts.frame_provoice = 1;
+    opts.frame_ysf = 1;
+    opts.frame_m17 = 1;
+    state.rf_mod = 2;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.min = -3.0f;
+    state.max = 3.0f;
+
+    dsd_rtl_stream_metrics_hooks hooks = {
+        .output_rate_hz = fake_output_rate_hz,
+        .set_symbol_profile = fake_set_symbol_profile,
+    };
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+    g_profile_set_calls = 0;
+
+    for (int profile_index = 0; profile_index < 5; profile_index++) {
+        state.sps_hunt_idx = (profile_index + 1) % 5;
+        dsd_frame_sync_test_apply_sps_hunt_profile(&opts, &state, profile_index);
+        assert(state.sps_hunt_idx == profile_index);
+        assert(g_profile_rate == expected_rates[profile_index]);
+        assert(g_profile_levels == expected_levels[profile_index]);
+        assert(g_profile_channel == expected_channels[profile_index]);
+        assert(state.samplesPerSymbol == dsd_opts_compute_sps_rate(&opts, expected_rates[profile_index], 48000));
+    }
+    assert(g_profile_set_calls == 5);
+
+    const int locked_sps = state.samplesPerSymbol;
+    const int locked_center = state.symbolCenter;
+    const int calls_before_sync = g_profile_set_calls;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DSTAR_SYNC, 24) == DSD_SYNC_DSTAR_VOICE_POS);
+    assert(state.sps_hunt_idx == 4);
+    assert(state.samplesPerSymbol == locked_sps);
+    assert(state.symbolCenter == locked_center);
+    assert(g_profile_set_calls == calls_before_sync);
+    assert(g_profile_rate == 4800);
+    assert(g_profile_levels == 2);
+    assert(g_profile_channel == DSD_RTL_STREAM_CHANNEL_PROFILE_6K25);
+
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+}
+
+static void
+test_active_profile_metrics_power_gate_and_votes(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int lastt = 24;
+    int c4fm_votes = -1;
+    int qpsk_votes = -1;
+    int gfsk_votes = -1;
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtl_pwr = 0.25;
+    opts.rtl_squelch_level = 0.5;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_dstar = 1;
+    opts.frame_dmr = 1;
+    opts.frame_nxdn48 = 1;
+    opts.frame_nxdn96 = 1;
+    opts.frame_dpmr = 1;
+    g_snr_c4fm = 101.0;
+    g_snr_cqpsk = 102.0;
+    g_snr_gfsk = 103.0;
+    install_fake_snr_hooks();
+
+    state.sps_hunt_idx = 0;
+    state.rf_mod = 0;
+    assert(dsd_frame_sync_test_active_profile_modulation(&state) == 0);
+    assert(dsd_frame_sync_test_active_profile_snr_db(&state) == 101.0);
+    assert(dsd_frame_sync_test_should_skip_snr_or_power_gate(&opts, &state) == 0);
+
+    state.rf_mod = 1;
+    assert(dsd_frame_sync_test_active_profile_modulation(&state) == 1);
+    assert(dsd_frame_sync_test_active_profile_snr_db(&state) == 102.0);
+    assert(dsd_frame_sync_test_should_skip_snr_or_power_gate(&opts, &state) == 0);
+
+    state.sps_hunt_idx = 4;
+    state.rf_mod = 0;
+    assert(dsd_frame_sync_test_active_profile_modulation(&state) == 2);
+    assert(dsd_frame_sync_test_active_profile_snr_db(&state) == 103.0);
+    assert(dsd_frame_sync_test_should_skip_snr_or_power_gate(&opts, &state) == 1);
+
+    opts.audio_in_type = AUDIO_IN_WAV;
+    dsd_frame_sync_reset_mod_state();
+    dsd_frame_sync_test_auto_switch_modulation(&opts, &state, 24, &lastt);
+    dsd_frame_sync_test_get_mod_votes(&c4fm_votes, &qpsk_votes, &gfsk_votes);
+    assert(state.rf_mod == 2);
+    assert(c4fm_votes == 0);
+    assert(qpsk_votes == 0);
+    assert(gfsk_votes == 1);
+
+    dsd_rtl_stream_metrics_hooks_set(NULL);
 }
 
 static void
@@ -497,11 +722,16 @@ int
 main(void) {
     test_sps_hunt_skips_disabled_protocol_rates();
     test_sps_hunt_profile_updates_timing();
+    test_bounded_symbol_history_readiness_and_wrap();
+    test_provoice_candidate_does_not_shadow_dstar_or_nxdn();
+    test_m17_auto_preamble_disambiguation_preserves_forced_tolerance();
     test_elapsed_seconds_prefers_monotonic_then_wall_time();
     test_p25_slot_activity_honors_ring_and_hangtime();
     test_hamming_helpers_find_best_patterns();
 #ifdef USE_RADIO
     test_rtl_symbol_profile_selection();
+    test_rtl_sps_profiles_apply_and_lock_on_sync();
+    test_active_profile_metrics_power_gate_and_votes();
     test_modulation_snr_fallback_votes_and_dwell();
     test_modulation_cli_lock_prevents_votes();
     test_hamming_override_can_select_qpsk();

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -242,6 +242,85 @@ test_sps_hunt_profile_updates_timing(void) {
 }
 
 static void
+test_sps_hunt_reconciles_external_timing(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_dmr = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_qpsk = 1;
+    state.rf_mod = 1;
+    state.sps_hunt_idx = 0;
+    state.samplesPerSymbol = dsd_opts_compute_sps_rate(&opts, 6000, 48000);
+    state.symbolCenter = dsd_opts_symbol_center(state.samplesPerSymbol);
+
+    dsd_frame_sync_test_ensure_enabled_sps_profile(&opts, &state);
+    assert(state.sps_hunt_idx == 3);
+    assert(state.samplesPerSymbol == 8);
+    assert(state.symbolCenter == 3);
+    assert(state.rf_mod == 1);
+    state.p2_wacn = 1;
+    state.p2_cc = 1;
+    state.p2_sysid = 1;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_P25P2_POS);
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    state.sps_hunt_idx = 0;
+    state.samplesPerSymbol = 7;
+    state.symbolCenter = 3;
+    dsd_frame_sync_test_ensure_enabled_sps_profile(&opts, &state);
+    assert(state.sps_hunt_idx == 0);
+    assert(state.samplesPerSymbol == 7);
+    assert(state.symbolCenter == 3);
+}
+
+static void
+test_binary_profiles_override_unlocked_qpsk(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_provoice = 1;
+    state.sps_hunt_idx = 0;
+    state.rf_mod = 1;
+    dsd_frame_sync_test_apply_sps_hunt_profile(&opts, &state, 2);
+    assert(state.sps_hunt_idx == 2);
+    assert(state.rf_mod == 2);
+    assert(dsd_frame_sync_test_active_profile_modulation(&opts, &state) == 2);
+
+    reset(&opts, &state);
+    opts.frame_dstar = 1;
+    state.sps_hunt_idx = 4;
+    state.samplesPerSymbol = 10;
+    state.symbolCenter = 4;
+    state.rf_mod = 1;
+    dsd_frame_sync_test_ensure_enabled_sps_profile(&opts, &state);
+    assert(state.sps_hunt_idx == 4);
+    assert(state.rf_mod == 2);
+    assert(dsd_frame_sync_test_active_profile_modulation(&opts, &state) == 2);
+
+    reset(&opts, &state);
+    opts.frame_dstar = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_qpsk = 1;
+    state.sps_hunt_idx = 0;
+    state.rf_mod = 1;
+    dsd_frame_sync_test_apply_sps_hunt_profile(&opts, &state, 4);
+    assert(state.sps_hunt_idx == 4);
+    assert(state.rf_mod == 1);
+    assert(dsd_frame_sync_test_active_profile_modulation(&opts, &state) == 1);
+}
+
+static void
 test_bounded_symbol_history_readiness_and_wrap(void) {
     static const int window_lengths[] = {8, 10, 12, 16, 20, 24, 32, 48};
     char symbols[80];
@@ -547,6 +626,41 @@ test_rtl_sps_profiles_apply_and_lock_on_sync(void) {
 }
 
 static void
+test_dmr_sync_applies_gfsk_rtl_profile(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int fake_rtl_context;
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_dmr = 1;
+    state.sps_hunt_idx = 0;
+    state.rf_mod = 1;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.min = -3.0f;
+    state.max = 3.0f;
+
+    dsd_rtl_stream_metrics_hooks hooks = {
+        .output_rate_hz = fake_output_rate_hz,
+        .set_symbol_profile = fake_set_symbol_profile,
+    };
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+    g_profile_set_calls = 0;
+    g_profile_rate = 0;
+    g_profile_levels = 0;
+    g_profile_channel = 0;
+
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DMR_BS_DATA_SYNC, 24) == DSD_SYNC_DMR_BS_DATA_POS);
+    assert(state.rf_mod == 2);
+    assert(g_profile_set_calls == 1);
+    assert(g_profile_rate == 4800);
+    assert(g_profile_levels == 4);
+    assert(g_profile_channel == DSD_RTL_STREAM_CHANNEL_PROFILE_12K5);
+
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+}
+
+static void
 test_active_profile_metrics_power_gate_and_votes(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -573,20 +687,28 @@ test_active_profile_metrics_power_gate_and_votes(void) {
 
     state.sps_hunt_idx = 0;
     state.rf_mod = 0;
-    assert(dsd_frame_sync_test_active_profile_modulation(&state) == 0);
-    assert(dsd_frame_sync_test_active_profile_snr_db(&state) == 101.0);
+    assert(dsd_frame_sync_test_active_profile_modulation(&opts, &state) == 0);
+    assert(dsd_frame_sync_test_active_profile_snr_db(&opts, &state) == 101.0);
     assert(dsd_frame_sync_test_should_skip_snr_or_power_gate(&opts, &state) == 0);
 
     state.rf_mod = 1;
-    assert(dsd_frame_sync_test_active_profile_modulation(&state) == 1);
-    assert(dsd_frame_sync_test_active_profile_snr_db(&state) == 102.0);
+    assert(dsd_frame_sync_test_active_profile_modulation(&opts, &state) == 1);
+    assert(dsd_frame_sync_test_active_profile_snr_db(&opts, &state) == 102.0);
     assert(dsd_frame_sync_test_should_skip_snr_or_power_gate(&opts, &state) == 0);
 
     state.sps_hunt_idx = 4;
-    state.rf_mod = 0;
-    assert(dsd_frame_sync_test_active_profile_modulation(&state) == 2);
-    assert(dsd_frame_sync_test_active_profile_snr_db(&state) == 103.0);
+    state.rf_mod = 1;
+    assert(dsd_frame_sync_test_active_profile_modulation(&opts, &state) == 2);
+    assert(dsd_frame_sync_test_active_profile_snr_db(&opts, &state) == 103.0);
     assert(dsd_frame_sync_test_should_skip_snr_or_power_gate(&opts, &state) == 1);
+
+    opts.mod_cli_lock = 1;
+    opts.mod_qpsk = 1;
+    assert(dsd_frame_sync_test_active_profile_modulation(&opts, &state) == 1);
+    assert(dsd_frame_sync_test_active_profile_snr_db(&opts, &state) == 102.0);
+    assert(dsd_frame_sync_test_should_skip_snr_or_power_gate(&opts, &state) == 0);
+    opts.mod_cli_lock = 0;
+    opts.mod_qpsk = 0;
 
     opts.audio_in_type = AUDIO_IN_WAV;
     dsd_frame_sync_reset_mod_state();
@@ -722,6 +844,8 @@ int
 main(void) {
     test_sps_hunt_skips_disabled_protocol_rates();
     test_sps_hunt_profile_updates_timing();
+    test_sps_hunt_reconciles_external_timing();
+    test_binary_profiles_override_unlocked_qpsk();
     test_bounded_symbol_history_readiness_and_wrap();
     test_provoice_candidate_does_not_shadow_dstar_or_nxdn();
     test_m17_auto_preamble_disambiguation_preserves_forced_tolerance();
@@ -731,6 +855,7 @@ main(void) {
 #ifdef USE_RADIO
     test_rtl_symbol_profile_selection();
     test_rtl_sps_profiles_apply_and_lock_on_sync();
+    test_dmr_sync_applies_gfsk_rtl_profile();
     test_active_profile_metrics_power_gate_and_votes();
     test_modulation_snr_fallback_votes_and_dwell();
     test_modulation_cli_lock_prevents_votes();

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -426,6 +426,38 @@ test_symbol_replay_bypasses_sps_profile_gating(void) {
 }
 
 static void
+test_manual_p25p2_c4fm_bypasses_profile_gating(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 96000;
+    opts.frame_dstar = 1;
+    opts.frame_x2tdma = 1;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_dmr = 1;
+    opts.frame_ysf = 1;
+    opts.mod_c4fm = 1;
+    opts.mod_cli_lock = 1;
+    state.sps_hunt_idx = 0;
+    state.samplesPerSymbol = 20;
+    state.symbolCenter = 8;
+    state.min = -3.0f;
+    state.max = 3.0f;
+
+    dsd_frame_sync_test_ensure_enabled_sps_profile(&opts, &state);
+    assert(state.sps_hunt_idx == 0);
+    assert(state.samplesPerSymbol == 20);
+    assert(state.symbolCenter == 8);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_NONE);
+
+    opts.mod_p25p2_c4fm = 1;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_P25P2_POS);
+}
+
+static void
 test_m17_auto_preamble_disambiguation_preserves_forced_tolerance(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -905,6 +937,7 @@ main(void) {
     test_bounded_symbol_history_readiness_and_wrap();
     test_provoice_candidate_does_not_shadow_dstar_or_nxdn();
     test_symbol_replay_bypasses_sps_profile_gating();
+    test_manual_p25p2_c4fm_bypasses_profile_gating();
     test_m17_auto_preamble_disambiguation_preserves_forced_tolerance();
     test_elapsed_seconds_prefers_monotonic_then_wall_time();
     test_p25_slot_activity_honors_ring_and_hangtime();

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -302,6 +302,27 @@ test_sps_hunt_reconciles_external_timing(void) {
     assert(dsd_frame_sync_test_active_profile_modulation(&opts, &state) == 1);
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_P25P2_POS);
 
+    /* Manual -m2 carries profile 3 explicitly because low input rates can round
+     * the 4800- and 6000-symbol timings to the same samples-per-symbol value. */
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 11025;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_dmr = 1;
+    opts.frame_ysf = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_qpsk = 1;
+    state.rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+    state.samplesPerSymbol = dsd_opts_compute_sps_rate(&opts, 6000, 11025);
+    state.symbolCenter = dsd_opts_symbol_center(state.samplesPerSymbol);
+
+    assert(dsd_opts_compute_sps_rate(&opts, 4800, 11025) == state.samplesPerSymbol);
+    dsd_frame_sync_test_ensure_enabled_sps_profile(&opts, &state);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_P25P2_POS);
+
     reset(&opts, &state);
     opts.audio_in_type = AUDIO_IN_WAV;
     opts.wav_sample_rate = 48000;
@@ -1005,6 +1026,105 @@ test_active_profile_metrics_power_gate_and_votes(void) {
 }
 
 static void
+test_mixed_profile_snr_recovers_from_gfsk(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int lastt = 24;
+    int c4fm_votes = -1;
+    int qpsk_votes = -1;
+    int gfsk_votes = -1;
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_p25p1 = 1;
+    opts.frame_dmr = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 2;
+    set_fake_snr(0.0, -100.0, 20.0, -100.0);
+    install_fake_snr_hooks();
+    dsd_frame_sync_reset_mod_state();
+
+    dsd_frame_sync_test_auto_switch_modulation(&opts, &state, 24, &lastt);
+    dsd_frame_sync_test_get_mod_votes(&c4fm_votes, &qpsk_votes, &gfsk_votes);
+    assert(state.rf_mod == 2);
+    assert(c4fm_votes == 0);
+    assert(qpsk_votes == 1);
+    assert(gfsk_votes == 0);
+
+    lastt = 24;
+    dsd_frame_sync_test_auto_switch_modulation(&opts, &state, 24, &lastt);
+    assert(state.rf_mod == 1);
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_dmr = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 2;
+    lastt = 24;
+    dsd_frame_sync_reset_mod_state();
+    dsd_frame_sync_test_auto_switch_modulation(&opts, &state, 24, &lastt);
+    dsd_frame_sync_test_get_mod_votes(&c4fm_votes, &qpsk_votes, &gfsk_votes);
+    assert(state.rf_mod == 2);
+    assert(c4fm_votes == 0);
+    assert(qpsk_votes == 0);
+    assert(gfsk_votes == 1);
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_dstar = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state.rf_mod = 2;
+    lastt = 24;
+    dsd_frame_sync_reset_mod_state();
+    dsd_frame_sync_test_auto_switch_modulation(&opts, &state, 24, &lastt);
+    dsd_frame_sync_test_get_mod_votes(&c4fm_votes, &qpsk_votes, &gfsk_votes);
+    assert(state.rf_mod == 2);
+    assert(c4fm_votes == 0);
+    assert(qpsk_votes == 0);
+    assert(gfsk_votes == 1);
+
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+}
+
+static void
+test_snr_squelch_only_applies_to_rtl_input(void) {
+    static const int non_radio_inputs[] = {
+        AUDIO_IN_WAV, AUDIO_IN_TCP, AUDIO_IN_UDP, AUDIO_IN_SYMBOL_BIN, AUDIO_IN_SYMBOL_FLT,
+    };
+    static dsd_opts opts;
+    static dsd_state state;
+
+    set_fake_snr(-100.0, -100.0, -100.0, -100.0);
+    install_fake_snr_hooks();
+    (void)dsd_setenv("DSD_NEO_SNR_SQL_DB", "10", 1);
+    dsd_neo_config_init(NULL);
+
+    for (size_t i = 0; i < sizeof(non_radio_inputs) / sizeof(non_radio_inputs[0]); i++) {
+        reset(&opts, &state);
+        opts.audio_in_type = non_radio_inputs[i];
+        opts.frame_dmr = 1;
+        opts.mod_cli_lock = 1;
+        opts.mod_gfsk = 1;
+        state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+        state.rf_mod = 2;
+        assert(dsd_frame_sync_test_should_skip_snr_or_power_gate(&opts, &state) == 0);
+    }
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_dmr = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_gfsk = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 2;
+    assert(dsd_frame_sync_test_should_skip_snr_or_power_gate(&opts, &state) == 1);
+
+    (void)dsd_unsetenv("DSD_NEO_SNR_SQL_DB");
+    dsd_neo_config_init(NULL);
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+}
+
+static void
 test_nxdn_only_profiles_use_gfsk_snr_gate(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -1195,6 +1315,8 @@ main(void) {
     test_rtl_sps_profiles_apply_and_lock_on_sync();
     test_dmr_sync_applies_gfsk_rtl_profile();
     test_active_profile_metrics_power_gate_and_votes();
+    test_mixed_profile_snr_recovers_from_gfsk();
+    test_snr_squelch_only_applies_to_rtl_input();
     test_nxdn_only_profiles_use_gfsk_snr_gate();
     test_modulation_snr_fallback_votes_and_dwell();
     test_modulation_cli_lock_prevents_votes();

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -242,6 +242,32 @@ test_sps_hunt_profile_updates_timing(void) {
     assert(state.samplesPerSymbol == 10);
     assert(state.symbolCenter == 4);
 
+    /* -mg keeps the GFSK demodulator locked while alternating same-timing
+     * four-level and binary gates, so D-STAR remains reachable. */
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_dmr = 1;
+    opts.frame_dstar = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_gfsk = 1;
+    state.rf_mod = 2;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) - 1;
+    state.samplesPerSymbol = 10;
+    state.symbolCenter = 4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    dsd_frame_sync_test_no_sync_sps_hunt(&opts, &state);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_2);
+    assert(state.sps_hunt_counter == 0);
+    assert(state.samplesPerSymbol == 10);
+    assert(state.symbolCenter == 4);
+    assert(state.rf_mod == 2);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DSTAR_SYNC, 24) == DSD_SYNC_DSTAR_VOICE_POS);
+
     reset(&opts, &state);
     opts.audio_in_type = AUDIO_IN_WAV;
     opts.wav_sample_rate = 96000;

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -612,6 +612,24 @@ test_manual_p25p2_c4fm_bypasses_profile_gating(void) {
 }
 
 static void
+test_locked_p25p2_c4fm_survives_sync(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_p25p2 = 1;
+    opts.mod_c4fm = 1;
+    opts.mod_cli_lock = 1;
+    state.rf_mod = 0;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_P25P2_POS);
+    assert(state.rf_mod == 0);
+}
+
+static void
 test_m17_auto_preamble_disambiguation_preserves_forced_tolerance(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -1329,6 +1347,7 @@ main(void) {
     test_symbol_replay_bypasses_sps_profile_gating();
     test_symbol_replay_requires_explicit_nxdn_variant();
     test_manual_p25p2_c4fm_bypasses_profile_gating();
+    test_locked_p25p2_c4fm_survives_sync();
     test_m17_auto_preamble_disambiguation_preserves_forced_tolerance();
     test_short_m17_window_estimates_levels_without_warm_start_history();
     test_m17_preamble_requires_context_when_dstar_is_enabled();

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -239,6 +239,20 @@ test_sps_hunt_profile_updates_timing(void) {
     assert(state.sps_hunt_idx == 4);
     assert(state.samplesPerSymbol == 10);
     assert(state.symbolCenter == 4);
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 96000;
+    opts.frame_p25p2 = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_c4fm = 1;
+    state.sps_hunt_idx = 0;
+    state.samplesPerSymbol = 20;
+    state.symbolCenter = 8;
+    dsd_frame_sync_test_ensure_enabled_sps_profile(&opts, &state);
+    assert(state.sps_hunt_idx == 3);
+    assert(state.samplesPerSymbol == 20);
+    assert(state.symbolCenter == 8);
 }
 
 static void
@@ -281,6 +295,25 @@ test_sps_hunt_reconciles_external_timing(void) {
     assert(state.sps_hunt_idx == 0);
     assert(state.samplesPerSymbol == 7);
     assert(state.symbolCenter == 3);
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_dmr = 1;
+    opts.frame_dstar = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_c4fm = 1;
+    state.rf_mod = 0;
+    state.sps_hunt_idx = 3;
+    state.samplesPerSymbol = 10;
+    state.symbolCenter = 4;
+    dsd_frame_sync_test_ensure_enabled_sps_profile(&opts, &state);
+    assert(state.sps_hunt_idx == 0);
+    assert(state.samplesPerSymbol == 10);
+    assert(state.symbolCenter == 4);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P1_SYNC, 24) == DSD_SYNC_P25P1_POS);
 }
 
 static void
@@ -367,6 +400,29 @@ test_provoice_candidate_does_not_shadow_dstar_or_nxdn(void) {
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
     assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NXDN_POS);
+}
+
+static void
+test_symbol_replay_bypasses_sps_profile_gating(void) {
+    static const int symbol_input_types[] = {AUDIO_IN_SYMBOL_BIN, AUDIO_IN_SYMBOL_FLT};
+    static dsd_opts opts;
+    static dsd_state state;
+
+    for (size_t i = 0; i < sizeof(symbol_input_types) / sizeof(symbol_input_types[0]); i++) {
+        reset(&opts, &state);
+        opts.audio_in_type = symbol_input_types[i];
+        opts.frame_p25p2 = 1;
+        state.sps_hunt_idx = 0;
+        state.min = -3.0f;
+        state.max = 3.0f;
+        assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_P25P2_POS);
+    }
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.frame_p25p2 = 1;
+    state.sps_hunt_idx = 0;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_NONE);
 }
 
 static void
@@ -848,6 +904,7 @@ main(void) {
     test_binary_profiles_override_unlocked_qpsk();
     test_bounded_symbol_history_readiness_and_wrap();
     test_provoice_candidate_does_not_shadow_dstar_or_nxdn();
+    test_symbol_replay_bypasses_sps_profile_gating();
     test_m17_auto_preamble_disambiguation_preserves_forced_tolerance();
     test_elapsed_seconds_prefers_monotonic_then_wall_time();
     test_p25_slot_activity_honors_ring_and_hangtime();

--- a/tests/dsp/test_frame_sync_m17.c
+++ b/tests/dsp/test_frame_sync_m17.c
@@ -290,6 +290,16 @@ init_m17_sync_case(dsd_opts* opts, dsd_state* state, int* fake_rtl_context) {
     }
 
     opts->audio_in_type = AUDIO_IN_RTL;
+    opts->frame_dstar = 1;
+    opts->frame_x2tdma = 1;
+    opts->frame_p25p1 = 1;
+    opts->frame_p25p2 = 1;
+    opts->frame_nxdn48 = 1;
+    opts->frame_nxdn96 = 1;
+    opts->frame_dmr = 1;
+    opts->frame_dpmr = 1;
+    opts->frame_provoice = 1;
+    opts->frame_ysf = 1;
     opts->frame_m17 = 1;
     opts->mod_cli_lock = 1;
     opts->mod_gfsk = 1;

--- a/tests/dsp/test_frame_sync_m17.c
+++ b/tests/dsp/test_frame_sync_m17.c
@@ -383,17 +383,21 @@ run_m17_two_step_case(const char* first_pattern, int first_expected, const char*
 int
 main(void) {
     int rc = 0;
-    rc |= run_m17_two_step_case(M17_PRE, DSD_SYNC_M17_PRE_POS, M17_LSF, DSD_SYNC_M17_LSF_POS, "M17 preamble to LSF");
+    rc |= run_m17_two_step_case(M17_PRE M17_PRE, DSD_SYNC_M17_PRE_POS, M17_LSF, DSD_SYNC_M17_LSF_POS,
+                                "M17 preamble to LSF");
     rc |= run_m17_sync_case(DSD_SYNC_M17_LSF_POS, 1U, M17_STR, DSD_SYNC_M17_STR_POS, "M17 LSF to stream");
     rc |= run_m17_sync_case(DSD_SYNC_M17_LSF_POS, 1U, M17_PKT, DSD_SYNC_M17_PKT_POS, "M17 LSF to packet");
-    rc |= run_m17_two_step_case(M17_PRE, DSD_SYNC_M17_PRE_POS, M17_BRT, DSD_SYNC_M17_BRT_POS, "M17 preamble to BERT");
+    rc |= run_m17_two_step_case(M17_PRE M17_PRE, DSD_SYNC_M17_PRE_POS, M17_BRT, DSD_SYNC_M17_BRT_POS,
+                                "M17 preamble to BERT");
     rc |= run_m17_sync_case(DSD_SYNC_M17_BRT_POS, 1U, M17_BRT, DSD_SYNC_M17_BRT_POS, "M17 BERT to BERT");
     rc |= run_m17_sync_case(DSD_SYNC_M17_STR_POS, 1U, M17_STR, DSD_SYNC_M17_STR_POS, "M17 stream to stream");
     rc |= run_m17_sync_case(DSD_SYNC_M17_PKT_POS, 1U, M17_PKT, DSD_SYNC_M17_PKT_POS, "M17 packet to packet");
     rc |= run_m17_sync_case(DSD_SYNC_M17_STR_POS, 1U, M17_EOT, DSD_SYNC_M17_EOT_POS, "M17 stream to EOT");
     rc |= run_m17_sync_case(DSD_SYNC_NONE, 0U, M17_EOT, -1, "M17 rejects cold EOT");
-    rc |= run_m17_two_step_case(M17_PRE, DSD_SYNC_M17_PRE_POS, M17_STR, -1, "M17 rejects stream after preamble");
-    rc |= run_m17_two_step_case(M17_PRE, DSD_SYNC_M17_PRE_POS, M17_PKT, -1, "M17 rejects packet after preamble");
+    rc |=
+        run_m17_two_step_case(M17_PRE M17_PRE, DSD_SYNC_M17_PRE_POS, M17_STR, -1, "M17 rejects stream after preamble");
+    rc |=
+        run_m17_two_step_case(M17_PRE M17_PRE, DSD_SYNC_M17_PRE_POS, M17_PKT, -1, "M17 rejects packet after preamble");
     return rc;
 }
 

--- a/tests/dsp/test_frame_sync_p25p2_rtl.c
+++ b/tests/dsp/test_frame_sync_p25p2_rtl.c
@@ -380,8 +380,17 @@ run_p25_sync_case(const char* pattern, int frame_p25p1, int frame_p25p2, int exp
     }
 
     opts.audio_in_type = AUDIO_IN_RTL;
-    opts.frame_p25p1 = frame_p25p1;
-    opts.frame_p25p2 = frame_p25p2;
+    opts.frame_dstar = 1;
+    opts.frame_x2tdma = 1;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_nxdn48 = 1;
+    opts.frame_nxdn96 = 1;
+    opts.frame_dmr = 1;
+    opts.frame_dpmr = 1;
+    opts.frame_provoice = 1;
+    opts.frame_ysf = 1;
+    opts.frame_m17 = 1;
     opts.mod_cli_lock = 1;
     opts.mod_qpsk = 1;
     opts.p25_trunk = 1;
@@ -389,6 +398,7 @@ run_p25_sync_case(const char* pattern, int frame_p25p1, int frame_p25p2, int exp
     opts.ssize = 36;
 
     state.rf_mod = 1;
+    state.sps_hunt_idx = frame_p25p2 ? 3 : (frame_p25p1 ? 0 : state.sps_hunt_idx);
     state.p25_p2_active_slot = 1;
     state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
     state.center = 0.0f;

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -8,6 +8,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/trunk_tuning.h>
 #include <dsd-neo/io/rtl_stream_c.h>
@@ -553,6 +554,8 @@ main(void) {
     state->samplesPerSymbol = 8;
     state->symbolCenter = 3;
     state->rf_mod = 1;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state->sps_hunt_counter = 23;
 
     noCarrier(opts, state);
 
@@ -565,6 +568,8 @@ main(void) {
     rc |= expect_true("p25-rtl-nocarrier-cc-profile-ted", g_rtl_ted_sps == 20 && g_rtl_ted_sps_override == 0);
     rc |= expect_true("p25-rtl-nocarrier-dynamic-symbol-timing",
                       state->samplesPerSymbol == 20 && state->symbolCenter == 9);
+    rc |= expect_true("p25-rtl-nocarrier-selects-four-level-profile",
+                      state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4 && state->sps_hunt_counter == 0);
     rc |= expect_true("p25-rtl-nocarrier-reenables-slots", opts->slot1_on == 1 && opts->slot2_on == 1);
     rc |= expect_true("p25-rtl-nocarrier-clear-tuned", opts->p25_is_tuned == 0 && opts->trunk_is_tuned == 0);
     rc |= expect_true("p25-rtl-nocarrier-clear-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0);

--- a/tests/engine/test_engine_rtl_stream_metrics_hooks_install.c
+++ b/tests/engine/test_engine_rtl_stream_metrics_hooks_install.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <dsd-neo/core/input_level.h>
 #include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -39,6 +40,7 @@ static int g_p25p1_ber_calls;
 static int g_p25p2_err_calls;
 static int g_stream_active_calls;
 static int g_input_level_calls;
+static dsdneoRuntimeConfig g_runtime_config;
 
 static int g_last_symbol_rate;
 static int g_last_symbol_levels;
@@ -58,6 +60,11 @@ static int g_last_p25p2_facch_err;
 static int g_last_p25p2_sacch_ok;
 static int g_last_p25p2_sacch_err;
 static int g_last_p25p2_voice_err;
+
+const dsdneoRuntimeConfig*
+dsd_neo_get_config(void) {
+    return &g_runtime_config;
+}
 
 unsigned int
 dsd_rtl_stream_output_rate(void) {
@@ -268,6 +275,22 @@ main(void) {
     assert(g_last_symbol_levels == 4);
     assert(g_last_symbol_profile == 5);
     assert(g_symbol_profile_order == 4);
+
+    g_runtime_config.cqpsk_is_set = 1;
+    g_runtime_config.cqpsk_enable = 0;
+    g_family_calls = 0;
+    assert(dsd_rtl_stream_metrics_hook_apply_demod_profile(1, 6000, 4, 5, 8) == 7);
+    assert(g_family_calls == 0);
+    assert(g_ted_clear_calls == 2);
+    assert(g_ted_set_calls == 2);
+    assert(g_set_symbol_profile_calls == 3);
+
+    g_runtime_config.cqpsk_enable = 1;
+    assert(dsd_rtl_stream_metrics_hook_apply_demod_profile(0, 4800, 4, 3, 10) == 7);
+    assert(g_family_calls == 0);
+    assert(g_ted_clear_calls == 3);
+    assert(g_ted_set_calls == 3);
+    assert(g_set_symbol_profile_calls == 4);
 
     int cqpsk_enable = -1;
     int cqpsk_timing = -1;

--- a/tests/engine/test_engine_rtl_stream_metrics_hooks_install.c
+++ b/tests/engine/test_engine_rtl_stream_metrics_hooks_install.c
@@ -23,6 +23,9 @@ static int g_output_kind_calls;
 static int g_symbol_profile_calls;
 static int g_generation_calls;
 static int g_set_symbol_profile_calls;
+static int g_family_calls;
+static int g_ted_clear_calls;
+static int g_ted_set_calls;
 static int g_cqpsk_status_calls;
 static int g_cqpsk_timing_bias_calls;
 static int g_snr_bias_calls;
@@ -40,6 +43,13 @@ static int g_input_level_calls;
 static int g_last_symbol_rate;
 static int g_last_symbol_levels;
 static int g_last_symbol_profile;
+static int g_last_cqpsk_enable;
+static int g_last_ted_sps;
+static int g_apply_order;
+static int g_family_order;
+static int g_ted_clear_order;
+static int g_ted_set_order;
+static int g_symbol_profile_order;
 static int g_last_p25p1_ok;
 static int g_last_p25p1_err;
 static int g_last_p25p2_slot;
@@ -85,10 +95,31 @@ rtl_stream_output_generation(void) {
 int
 rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profile) {
     ++g_set_symbol_profile_calls;
+    g_symbol_profile_order = ++g_apply_order;
     g_last_symbol_rate = symbol_rate_hz;
     g_last_symbol_levels = levels;
     g_last_symbol_profile = channel_profile;
     return 7;
+}
+
+void
+rtl_stream_toggle_cqpsk(int onoff) {
+    ++g_family_calls;
+    g_family_order = ++g_apply_order;
+    g_last_cqpsk_enable = onoff;
+}
+
+void
+rtl_stream_clear_ted_sps_override(void) {
+    ++g_ted_clear_calls;
+    g_ted_clear_order = ++g_apply_order;
+}
+
+void
+rtl_stream_set_ted_sps_no_override(int sps) {
+    ++g_ted_set_calls;
+    g_ted_set_order = ++g_apply_order;
+    g_last_ted_sps = sps;
 }
 
 int
@@ -214,6 +245,29 @@ main(void) {
     assert(g_last_symbol_rate == 4800);
     assert(g_last_symbol_levels == 2);
     assert(g_last_symbol_profile == 4);
+
+    g_family_calls = 0;
+    g_ted_clear_calls = 0;
+    g_ted_set_calls = 0;
+    g_apply_order = 0;
+    g_family_order = 0;
+    g_ted_clear_order = 0;
+    g_ted_set_order = 0;
+    g_symbol_profile_order = 0;
+    assert(dsd_rtl_stream_metrics_hook_apply_demod_profile(1, 6000, 4, 5, 8) == 7);
+    assert(g_family_calls == 1);
+    assert(g_last_cqpsk_enable == 1);
+    assert(g_family_order == 1);
+    assert(g_ted_clear_calls == 1);
+    assert(g_ted_clear_order == 2);
+    assert(g_ted_set_calls == 1);
+    assert(g_last_ted_sps == 8);
+    assert(g_ted_set_order == 3);
+    assert(g_set_symbol_profile_calls == 2);
+    assert(g_last_symbol_rate == 6000);
+    assert(g_last_symbol_levels == 4);
+    assert(g_last_symbol_profile == 5);
+    assert(g_symbol_profile_order == 4);
 
     int cqpsk_enable = -1;
     int cqpsk_timing = -1;

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -537,6 +537,28 @@ main(void) {
     assert(g_frame_sync_reset_calls == 1);
     assert(g_p25p2_frame_reset_calls == 1);
 
+    /* Legacy -T keeps p25_trunk set for NXDN, but protocol-agnostic retunes
+     * carry no P25 TED timing and must preserve the active NXDN48 profile. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    opts->use_rigctl = 1;
+    opts->p25_trunk = 1;
+    opts->trunk_enable = 1;
+    opts->frame_nxdn48 = 1;
+    state->p25_p2_active_slot = -1;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    state->sps_hunt_counter = 17;
+    g_setfreq_result = true;
+    assert(dsd_engine_trunk_tune_to_cc(opts, state, 451000000, 0) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_2400_4);
+    assert(state->sps_hunt_counter == 17);
+
+    state->sps_hunt_counter = 23;
+    assert(dsd_engine_trunk_tune_to_freq(opts, state, 451500000, 0) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_2400_4);
+    assert(state->sps_hunt_counter == 23);
+
     /* Direct conventional scan retunes publish a new generation only after
      * the backend completes the target. */
     DSD_MEMSET(opts, 0, sizeof(*opts));

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -14,6 +14,7 @@
 #include <assert.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/engine/trunk_tuning.h>
 #include <dsd-neo/io/rigctl_client.h>
 #include <dsd-neo/io/rtl_stream_c.h>
@@ -573,6 +574,8 @@ main(void) {
     state->rf_mod = 1;
     state->p25_p2_active_slot = 0;
     state->p25_vc_cqpsk_override = 1;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state->sps_hunt_counter = 11;
     g_setfreq_calls = 0;
     g_last_setfreq_hz = 0;
     g_setfreq_result = true;
@@ -594,6 +597,8 @@ main(void) {
     assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
     assert(g_rtl_ted_sps == 8);
     assert(g_rtl_ted_sps_override == 8);
+    assert(state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    assert(state->sps_hunt_counter == 0);
 #endif
 
     /* If the frequency command itself fails, the decoder must not advance state
@@ -742,6 +747,8 @@ main(void) {
     state->rf_mod = 1;
     state->p25_p2_active_slot = 0;
     state->p25_vc_cqpsk_override = 1;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state->sps_hunt_counter = 11;
     g_rtl_tune_result = RTL_STREAM_TUNE_TIMEOUT;
     g_rtl_cqpsk_enable = 0;
     g_rtl_symbol_rate_hz = 4800;
@@ -756,6 +763,8 @@ main(void) {
     assert(opts->trunk_is_tuned == 1);
     assert(state->trunk_vc_freq[0] == 855000000);
     assert(state->p25_vc_cqpsk_override == -1);
+    assert(state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    assert(state->sps_hunt_counter == 0);
     assert(g_rtl_cqpsk_enable == 0);
     assert(g_rtl_symbol_rate_hz == 4800);
     assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
@@ -780,6 +789,8 @@ main(void) {
     state->rf_mod = 0;
     state->p25_cc_is_tdma = 1;
     state->trunk_cc_freq = 851000000;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state->sps_hunt_counter = 13;
     g_rtl_tune_result = RTL_STREAM_TUNE_TIMEOUT;
     g_rtl_cqpsk_enable = 0;
     g_rtl_symbol_rate_hz = 4800;
@@ -792,6 +803,8 @@ main(void) {
     assert(dsd_engine_trunk_tune_to_cc(opts, state, 852000000, 4) == DSD_TRUNK_TUNE_RESULT_PENDING);
     assert(state->rf_mod == 1);
     assert(state->trunk_cc_freq == 852000000);
+    assert(state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    assert(state->sps_hunt_counter == 0);
     assert(g_rtl_cqpsk_enable == 0);
     assert(g_rtl_symbol_rate_hz == 4800);
     assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
@@ -930,6 +943,8 @@ main(void) {
     state->p25_cc_is_tdma = 0;
     state->p25_p2_active_slot = 0;
     state->rf_mod = 1;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state->sps_hunt_counter = 19;
     g_rtl_tune_result = RTL_STREAM_TUNE_OK;
     g_rtl_cqpsk_enable = 1;
     g_rtl_symbol_rate_hz = 6000;
@@ -944,6 +959,8 @@ main(void) {
     assert(opts->p25_is_tuned == 0);
     assert(state->rf_mod == 1);
     assert(state->samplesPerSymbol == 10);
+    assert(state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(state->sps_hunt_counter == 0);
     assert(g_rtl_pending_active == 0);
     assert(g_rtl_cqpsk_enable == 1);
     assert(g_rtl_symbol_rate_hz == 4800);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -9,6 +9,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/engine/trunk_scan.h>
 #include <dsd-neo/engine/trunk_tuning.h>
 #include <dsd-neo/io/rtl_stream_c.h>
@@ -2653,6 +2654,56 @@ test_locked_demod_mode_preserved_when_seeding_targets(void) {
 }
 
 static int
+test_target_retunes_select_four_level_sps_profile(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation\n";
+    if (make_temp_dir(dir, sizeof dir) != 0
+        || write_targets_file_with_header(dir, header,
+                                          "p25,p25-trunk,851000000,,250,,P25 forced,c4fm\n"
+                                          "dmr,dmr-trunk,452000000,,250,,DMR forced,gfsk\n",
+                                          target_path, sizeof target_path)
+               != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state.sps_hunt_counter = 17;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    dsd_engine_trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0
+        || state.sps_hunt_idx != DSD_FRAME_SYNC_SPS_PROFILE_4800_4 || state.sps_hunt_counter != 0) {
+        DSD_FPRINTF(stderr, "P25 target retained stale SPS profile rc=%d active=%zu profile=%d counter=%d err=%s\n", rc,
+                    dsd_engine_trunk_scan_active_index(&state), state.sps_hunt_idx, state.sps_hunt_counter, err);
+        test_rc = 1;
+    }
+
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state.sps_hunt_counter = 23;
+    dsd_engine_trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1 || state.sps_hunt_idx != DSD_FRAME_SYNC_SPS_PROFILE_4800_4
+        || state.sps_hunt_counter != 0) {
+        DSD_FPRINTF(stderr, "DMR target retained stale SPS profile active=%zu profile=%d counter=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), state.sps_hunt_idx, state.sps_hunt_counter);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_engine_trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
 test_per_target_modulation_overrides_global_lock(void) {
     char dir[DSD_TEST_PATH_MAX];
     char target_path[DSD_TEST_PATH_MAX];
@@ -3321,6 +3372,7 @@ main(void) {
     rc |= test_p25_retune_backoff_state_isolated_per_target();
     rc |= test_trunk_targets_reuse_restored_control_channel();
     rc |= test_locked_demod_mode_preserved_when_seeding_targets();
+    rc |= test_target_retunes_select_four_level_sps_profile();
     rc |= test_per_target_modulation_overrides_global_lock();
     rc |= test_active_p25_cqpsk_request_tracks_target_modulation();
     rc |= test_per_target_rtl_gain_overrides_and_restores_global_default();

--- a/tests/protocol/nxdn/test_nxdn_element_bounds.c
+++ b/tests/protocol/nxdn/test_nxdn_element_bounds.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -1334,6 +1335,41 @@ test_vcall_des_keyloader_and_iv_signal(void) {
 }
 
 static int
+test_vcall_scrambler_keyloader_uses_active_nxdn48_profile(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    uint8_t bits[96];
+    const uint8_t key_id = 0x2AU;
+    const uint64_t scrambler_key = 0x5A5AU;
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
+        free(state);
+        free(opts);
+        return 1;
+    }
+    DSD_MEMSET(bits, 0, sizeof(bits));
+
+    opts->frame_nxdn48 = 1;
+    opts->frame_nxdn96 = 1;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    state->keyloader = 1;
+    state->rkey_array[key_id] = scrambler_key;
+    write_vcall_fields(bits, 0x01U, 0x20U, 1U, 2U, 0x1234U, 0x4567U, 1U, key_id);
+    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+
+    int rc = 0;
+    rc |= expect_int("vcall-scrambler-active-variant", dsd_frame_sync_active_nxdn_variant(opts, state),
+                     DSD_NXDN_VARIANT_48);
+    rc |= expect_int("vcall-scrambler-cipher", state->nxdn_cipher_type, 1);
+    rc |= expect_u64("vcall-scrambler-key", (uint64_t)state->R, scrambler_key);
+    rc |= expect_int("vcall-scrambler-unmutes-loaded-key", state->dmr_encL, 0);
+
+    free(state);
+    free(opts);
+    return rc;
+}
+
+static int
 test_vcall_aes_keyloader_and_iv_signal(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
@@ -1562,6 +1598,7 @@ main(void) {
     rc |= test_arib_vcall_uses_shifted_fields();
     rc |= test_bad_crc_encrypted_vcall_records_metadata();
     rc |= test_vcall_des_keyloader_and_iv_signal();
+    rc |= test_vcall_scrambler_keyloader_uses_active_nxdn48_profile();
     rc |= test_vcall_aes_keyloader_and_iv_signal();
     rc |= test_arib_tx_release_uses_shifted_fields_and_clears_call();
     rc |= test_assignment_group_grant_anchors_tunes_and_loads_scrambler();

--- a/tests/protocol/nxdn/test_nxdn_frame_routing.c
+++ b/tests/protocol/nxdn/test_nxdn_frame_routing.c
@@ -17,6 +17,8 @@
 #include <dsd-neo/protocol/nxdn/nxdn_voice.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
+#include <time.h>
 
 static dsd_opts g_opts;
 static dsd_state g_state;
@@ -43,6 +45,8 @@ static uint8_t g_last_facch_bit;
 static uint8_t g_last_facch_reliab;
 static uint8_t g_last_cac_bit;
 static uint8_t g_last_cac_reliab;
+static dsd_nxdn_variant g_active_nxdn_variant;
+static char g_last_frame_type[16];
 
 static int
 expect_int(const char* label, int got, int want) {
@@ -57,6 +61,15 @@ static int
 expect_u64(const char* label, unsigned long long got, unsigned long long want) {
     if (got != want) {
         DSD_FPRINTF(stderr, "%s: got %llu want %llu\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_string(const char* label, const char* got, const char* want) {
+    if (strcmp(got, want) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", label, got, want);
         return 1;
     }
     return 0;
@@ -89,6 +102,8 @@ reset_state(void) {
     g_last_facch_reliab = 0;
     g_last_cac_bit = 0;
     g_last_cac_reliab = 0;
+    g_active_nxdn_variant = DSD_NXDN_VARIANT_NONE;
+    g_last_frame_type[0] = '\0';
 }
 
 static void
@@ -145,14 +160,21 @@ dsd_time_monotonic_ns(void) {
     return 42000000000ULL;
 }
 
+dsd_nxdn_variant
+dsd_frame_sync_active_nxdn_variant(const dsd_opts* opts, const dsd_state* state) {
+    (void)opts;
+    (void)state;
+    return g_active_nxdn_variant;
+}
+
 void
 printFrameSync(const dsd_opts* opts, const dsd_state* state, const char* frametype, int offset,
                const char* modulation) {
     (void)opts;
     (void)state;
-    (void)frametype;
     (void)offset;
     (void)modulation;
+    DSD_SNPRINTF(g_last_frame_type, sizeof(g_last_frame_type), "%s", frametype);
 }
 
 void
@@ -401,6 +423,24 @@ test_public_frame_entry_lich_collection(void) {
 
     reset_state();
     g_opts.frame_nxdn48 = 1;
+    g_opts.frame_nxdn96 = 1;
+    g_state.lastsynctype = DSD_SYNC_NXDN_POS;
+    g_active_nxdn_variant = DSD_NXDN_VARIANT_96;
+    prepare_frame_stream(0x01U, 0);
+    nxdn_frame(&g_opts, &g_state);
+    rc |= expect_string("full-auto NXDN96 banner", g_last_frame_type, "NXDN96 ");
+
+    reset_state();
+    g_opts.frame_nxdn48 = 1;
+    g_opts.frame_nxdn96 = 1;
+    g_state.lastsynctype = DSD_SYNC_NXDN_POS;
+    g_active_nxdn_variant = DSD_NXDN_VARIANT_48;
+    prepare_frame_stream(0x01U, 0);
+    nxdn_frame(&g_opts, &g_state);
+    rc |= expect_string("full-auto NXDN48 banner", g_last_frame_type, "NXDN48 ");
+
+    reset_state();
+    g_opts.frame_nxdn48 = 1;
     prepare_frame_stream(0x08U, 0);
     nxdn_frame(&g_opts, &g_state);
     rc |= expect_int("frame special parity accepted", g_sacch2_calls, 1);
@@ -456,12 +496,18 @@ test_lfsr_and_scanner_state(void) {
     rc |= expect_int("voice opens mbe file route", route(0x32U, bits, reliab), 1);
     rc |= expect_int("voice opened mbe file", g_opts.mbe_out_f == stdout, 1);
     g_opts.frame_nxdn48 = 1;
+    g_active_nxdn_variant = DSD_NXDN_VARIANT_48;
     rc |= expect_int("nxdn48 data closes mbe file route", route(0x01U, bits, reliab), 1);
     rc |= expect_int("nxdn48 data closed mbe file", g_opts.mbe_out_f == NULL, 1);
 
     reset_state();
     g_opts.mbe_out_f = stdout;
+    g_opts.frame_nxdn48 = 1;
     g_opts.frame_nxdn96 = 1;
+    g_active_nxdn_variant = DSD_NXDN_VARIANT_96;
+    g_state.last_vc_sync_time = time(NULL);
+    rc |= expect_int("full-auto NXDN96 recent data keeps mbe file route", route(0x01U, bits, reliab), 1);
+    rc |= expect_int("full-auto NXDN96 recent data keeps mbe file", g_opts.mbe_out_f == stdout, 1);
     g_state.last_vc_sync_time = 0;
     rc |= expect_int("nxdn96 stale data closes mbe file route", route(0x01U, bits, reliab), 1);
     rc |= expect_int("nxdn96 stale data closed mbe file", g_opts.mbe_out_f == NULL, 1);

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -5265,8 +5265,8 @@ test_m2_low_rate_preserves_p25p2_profile(void) {
         DSD_FPRINTF(stderr, "standalone -m2 should preserve the default frame candidates\n");
         test_rc = 1;
     }
-    if (!(opts->mod_cli_lock == 1 && opts->mod_qpsk == 1 && opts->mod_c4fm == 0 && opts->mod_gfsk == 0
-          && state->rf_mod == 1)) {
+    if (!(opts->mod_cli_lock == 1 && opts->mod_p25p2_profile_lock == 1 && opts->mod_qpsk == 1 && opts->mod_c4fm == 0
+          && opts->mod_gfsk == 0 && state->rf_mod == 1)) {
         DSD_FPRINTF(stderr, "standalone -m2 did not retain the manual P25p2 QPSK mode\n");
         test_rc = 1;
     }

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -5229,6 +5229,59 @@ test_s_8000_keeps_valid_symbol_timing_for_provoice(void) {
 }
 
 static int
+test_standalone_m3_marks_manual_p25p2_c4fm_path(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "-m3";
+    char arg2[] = "-s";
+    char arg3[] = "96000";
+    char* argv[] = {arg0, arg1, arg2, arg3, NULL};
+
+    int argc_effective = 0;
+    int exit_rc = -1;
+    int rc = dsd_parse_args(4, argv, opts, state, &argc_effective, &exit_rc);
+    if (rc != DSD_PARSE_CONTINUE) {
+        DSD_FPRINTF(stderr, "expected rc=%d, got %d (exit_rc=%d)\n", DSD_PARSE_CONTINUE, rc, exit_rc);
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    int test_rc = 0;
+    if (!(opts->frame_p25p1 == 1 && opts->frame_p25p2 == 1 && opts->frame_dmr == 1 && opts->frame_ysf == 1)) {
+        DSD_FPRINTF(stderr, "standalone -m3 should preserve the default frame candidates\n");
+        test_rc = 1;
+    }
+    if (!(opts->mod_p25p2_c4fm == 1 && opts->mod_cli_lock == 1 && opts->mod_c4fm == 1 && opts->mod_qpsk == 0
+          && opts->mod_gfsk == 0 && state->rf_mod == 0)) {
+        DSD_FPRINTF(stderr, "standalone -m3 did not retain the manual P25p2 C4FM mode\n");
+        test_rc = 1;
+    }
+    if (state->samplesPerSymbol != 20 || state->symbolCenter != 8) {
+        DSD_FPRINTF(stderr, "expected standalone -m3 timing to rescale to 20/8 at 96 kHz, got sps=%d center=%d\n",
+                    state->samplesPerSymbol, state->symbolCenter);
+        test_rc = 1;
+    }
+
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
 test_m3_override_survives_file_rate_rescale_after_f2(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
@@ -6094,6 +6147,7 @@ main(void) {
     rc |= test_bootstrap_config_file_rate_survives_cli_provoice_preset();
     rc |= test_bootstrap_compact_s_rate_override_clears_config_file_rate();
     rc |= test_s_8000_keeps_valid_symbol_timing_for_provoice();
+    rc |= test_standalone_m3_marks_manual_p25p2_c4fm_path();
     rc |= test_m3_override_survives_file_rate_rescale_after_f2();
     rc |= test_bootstrap_config_file_rate_rescales_manual_m3_override();
     rc |= test_bootstrap_cli_pulse_override_ignores_config_file_rate_timing();

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -11,6 +11,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/crypto/ecdsa.h>
 #include <dsd-neo/crypto/pc5.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/io/iq_types.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/platform/posix_compat.h>
@@ -5229,6 +5230,61 @@ test_s_8000_keeps_valid_symbol_timing_for_provoice(void) {
 }
 
 static int
+test_m2_low_rate_preserves_p25p2_profile(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+
+    initOpts(opts);
+    initState(state);
+
+    char arg0[] = "dsd-neo";
+    char arg1[] = "-m2";
+    char arg2[] = "-s";
+    char arg3[] = "11025";
+    char* argv[] = {arg0, arg1, arg2, arg3, NULL};
+
+    int argc_effective = 0;
+    int exit_rc = -1;
+    int rc = dsd_parse_args(4, argv, opts, state, &argc_effective, &exit_rc);
+    if (rc != DSD_PARSE_CONTINUE) {
+        DSD_FPRINTF(stderr, "expected rc=%d, got %d (exit_rc=%d)\n", DSD_PARSE_CONTINUE, rc, exit_rc);
+        freeState(state);
+        free(opts);
+        free(state);
+        return 1;
+    }
+
+    int test_rc = 0;
+    if (!(opts->frame_p25p1 == 1 && opts->frame_p25p2 == 1 && opts->frame_dmr == 1 && opts->frame_ysf == 1)) {
+        DSD_FPRINTF(stderr, "standalone -m2 should preserve the default frame candidates\n");
+        test_rc = 1;
+    }
+    if (!(opts->mod_cli_lock == 1 && opts->mod_qpsk == 1 && opts->mod_c4fm == 0 && opts->mod_gfsk == 0
+          && state->rf_mod == 1)) {
+        DSD_FPRINTF(stderr, "standalone -m2 did not retain the manual P25p2 QPSK mode\n");
+        test_rc = 1;
+    }
+    if (state->samplesPerSymbol != 2 || state->symbolCenter != 0
+        || state->sps_hunt_idx != DSD_FRAME_SYNC_SPS_PROFILE_6000_4) {
+        DSD_FPRINTF(stderr, "expected low-rate -m2 timing/profile 2/0/%d, got %d/%d/%d\n",
+                    DSD_FRAME_SYNC_SPS_PROFILE_6000_4, state->samplesPerSymbol, state->symbolCenter,
+                    state->sps_hunt_idx);
+        test_rc = 1;
+    }
+
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
+static int
 test_standalone_m3_marks_manual_p25p2_c4fm_path(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
@@ -6147,6 +6203,7 @@ main(void) {
     rc |= test_bootstrap_config_file_rate_survives_cli_provoice_preset();
     rc |= test_bootstrap_compact_s_rate_override_clears_config_file_rate();
     rc |= test_s_8000_keeps_valid_symbol_timing_for_provoice();
+    rc |= test_m2_low_rate_preserves_p25p2_profile();
     rc |= test_standalone_m3_marks_manual_p25p2_c4fm_path();
     rc |= test_m3_override_survives_file_rate_rescale_after_f2();
     rc |= test_bootstrap_config_file_rate_rescales_manual_m3_override();

--- a/tests/runtime/test_runtime_config_apply.cpp
+++ b/tests/runtime/test_runtime_config_apply.cpp
@@ -29,6 +29,7 @@
 #endif
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/synctype_ids.h>
 #ifdef USE_RADIO
 #include <dsd-neo/io/rtl_stream_c.h>
 #endif
@@ -2223,8 +2224,11 @@ test_return_cc_uses_pulse_rate_not_stale_file_rate(void) {
     opts->pulse_digi_rate_in = 48000;
     opts->wav_sample_rate = 96000;
     opts->p25_trunk = 1;
+    opts->frame_p25p1 = 1;
     state->trunk_cc_freq = 851012500;
     state->p25_cc_is_tdma = 0;
+    state->synctype = DSD_SYNC_P25P1_POS;
+    state->lastsynctype = DSD_SYNC_P25P1_POS;
     state->samplesPerSymbol = 20;
     state->symbolCenter = 9;
 

--- a/tests/runtime/test_runtime_decode_mode.c
+++ b/tests/runtime/test_runtime_decode_mode.c
@@ -41,6 +41,32 @@ test_auto_profile_differences(void) {
 
     DSD_MEMSET(&opts, 0, sizeof opts);
     DSD_MEMSET(&state, 0, sizeof state);
+    opts.frame_p25p2 = 1;
+    opts.frame_nxdn48 = 1;
+    opts.frame_dstar = 0;
+    opts.frame_provoice = 0;
+    opts.pulse_digi_out_channels = 3;
+    state.rf_mod = 2;
+    state.samplesPerSymbol = 17;
+    state.symbolCenter = 7;
+    state.sps_hunt_idx = 3;
+    if (dsd_apply_decode_mode_preset(DSDCFG_MODE_AUTO, DSD_DECODE_PRESET_PROFILE_CONFIG, &opts, &state) != 0) {
+        DSD_FPRINTF(stderr, "config AUTO apply failed\n");
+        return 1;
+    }
+    if (!(opts.frame_p25p2 == 1 && opts.frame_nxdn48 == 1 && opts.frame_dstar == 0 && opts.frame_provoice == 0
+          && opts.pulse_digi_out_channels == 3 && state.rf_mod == 2 && state.samplesPerSymbol == 17
+          && state.symbolCenter == 7 && state.sps_hunt_idx == 3)) {
+        DSD_FPRINTF(stderr, "config AUTO should preserve initialized protocol, modulation, and timing state\n");
+        return 1;
+    }
+    if (strcmp(opts.output_name, "AUTO") != 0) {
+        DSD_FPRINTF(stderr, "config AUTO output_name mismatch: %s\n", opts.output_name);
+        return 1;
+    }
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
     opts.frame_dstar = 0;
     opts.frame_dmr = 0;
     opts.frame_ysf = 0;

--- a/tests/runtime/test_runtime_rtl_stream_metrics_hooks.c
+++ b/tests/runtime/test_runtime_rtl_stream_metrics_hooks.c
@@ -16,6 +16,7 @@ static int g_symbol_profile_calls = 0;
 static int g_stream_generation_calls = 0;
 static int g_stream_active_calls = 0;
 static int g_set_symbol_profile_calls = 0;
+static int g_apply_demod_profile_calls = 0;
 static int g_cqpsk_status_calls = 0;
 static int g_cqpsk_timing_bias_calls = 0;
 static int g_snr_bias_calls = 0;
@@ -35,6 +36,11 @@ static int g_p25p1_err_delta = 0;
 static int g_set_symbol_rate_hz = 0;
 static int g_set_symbol_levels = 0;
 static int g_set_symbol_channel_profile = 0;
+static int g_apply_cqpsk_enable = 0;
+static int g_apply_symbol_rate_hz = 0;
+static int g_apply_symbol_levels = 0;
+static int g_apply_symbol_channel_profile = 0;
+static int g_apply_ted_sps = 0;
 
 static int g_p25p2_slot = 0;
 static int g_p25p2_facch_ok_delta = 0;
@@ -89,6 +95,17 @@ fake_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profile) {
     g_set_symbol_levels = levels;
     g_set_symbol_channel_profile = channel_profile;
     return 6;
+}
+
+static int
+fake_apply_demod_profile(int cqpsk_enable, int symbol_rate_hz, int levels, int channel_profile, int ted_sps) {
+    g_apply_demod_profile_calls++;
+    g_apply_cqpsk_enable = cqpsk_enable;
+    g_apply_symbol_rate_hz = symbol_rate_hz;
+    g_apply_symbol_levels = levels;
+    g_apply_symbol_channel_profile = channel_profile;
+    g_apply_ted_sps = ted_sps;
+    return 8;
 }
 
 static int
@@ -222,6 +239,7 @@ main(void) {
     assert(input_level.source == DSD_INPUT_LEVEL_SOURCE_UNKNOWN);
     assert(input_level.sample_count == 0U);
     assert(dsd_rtl_stream_metrics_hook_set_symbol_profile(2400, 2, 1) == 0);
+    assert(dsd_rtl_stream_metrics_hook_apply_demod_profile(1, 6000, 4, 5, 8) == 0);
 
     int cqpsk = -1;
     int timing = -1;
@@ -259,6 +277,7 @@ main(void) {
     g_stream_generation_calls = 0;
     g_stream_active_calls = 0;
     g_set_symbol_profile_calls = 0;
+    g_apply_demod_profile_calls = 0;
     g_cqpsk_status_calls = 0;
     g_cqpsk_timing_bias_calls = 0;
     g_snr_bias_calls = 0;
@@ -274,6 +293,11 @@ main(void) {
     g_set_symbol_rate_hz = 0;
     g_set_symbol_levels = 0;
     g_set_symbol_channel_profile = 0;
+    g_apply_cqpsk_enable = 0;
+    g_apply_symbol_rate_hz = 0;
+    g_apply_symbol_levels = 0;
+    g_apply_symbol_channel_profile = 0;
+    g_apply_ted_sps = 0;
 
     dsd_rtl_stream_metrics_hooks hooks = {0};
     hooks.output_rate_hz = fake_output_rate_hz;
@@ -282,6 +306,7 @@ main(void) {
     hooks.stream_generation = fake_stream_generation;
     hooks.stream_active = fake_stream_active;
     hooks.set_symbol_profile = fake_set_symbol_profile;
+    hooks.apply_demod_profile = fake_apply_demod_profile;
     hooks.cqpsk_status = fake_cqpsk_status;
     hooks.cqpsk_timing_bias = fake_cqpsk_timing_bias;
     hooks.snr_bias_evm = fake_snr_bias_evm;
@@ -326,6 +351,14 @@ main(void) {
     assert(g_set_symbol_rate_hz == 6000);
     assert(g_set_symbol_levels == 4);
     assert(g_set_symbol_channel_profile == 5);
+
+    assert(dsd_rtl_stream_metrics_hook_apply_demod_profile(1, 6000, 4, 5, 8) == 8);
+    assert(g_apply_demod_profile_calls == 1);
+    assert(g_apply_cqpsk_enable == 1);
+    assert(g_apply_symbol_rate_hz == 6000);
+    assert(g_apply_symbol_levels == 4);
+    assert(g_apply_symbol_channel_profile == 5);
+    assert(g_apply_ted_sps == 8);
 
     // Out-parameter hooks must report both call counts and returned values.
     cqpsk = timing = 0;

--- a/tests/ui/test_ui_cmd_actions.c
+++ b/tests/ui/test_ui_cmd_actions.c
@@ -387,12 +387,15 @@ test_radio_actions(void) {
     dispatch_one(dsd_app_actions_radio, &opts, &state, &cmd);
     rc |= expect_int("mod p2 toggle selects qpsk", opts.mod_qpsk, 1);
     rc |= expect_int("mod p2 toggle sets rf_mod", state.rf_mod, 1);
+    rc |= expect_int("mod p2 toggle locks explicit qpsk", opts.mod_cli_lock, 1);
     rc |= expect_int("mod p2 toggle qpsk sps", state.samplesPerSymbol, 8);
     rc |= expect_int("mod p2 toggle qpsk center", state.symbolCenter, 3);
     rc |= expect_int("mod p2 toggle selects profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
     rc |= expect_int("mod p2 toggle resets profile dwell", state.sps_hunt_counter, 0);
+    opts.mod_cli_lock = 0;
     dispatch_one(dsd_app_actions_radio, &opts, &state, &cmd);
     rc |= expect_int("mod p2 toggle returns c4fm", opts.mod_c4fm, 1);
+    rc |= expect_int("mod p2 toggle locks explicit c4fm", opts.mod_cli_lock, 1);
     rc |= expect_int("mod p2 toggle p25p2 sps", state.samplesPerSymbol, 8);
     rc |= expect_int("mod p2 toggle p25p2 center", state.symbolCenter, 3);
 

--- a/tests/ui/test_ui_cmd_actions.c
+++ b/tests/ui/test_ui_cmd_actions.c
@@ -381,6 +381,25 @@ test_radio_actions(void) {
     rc |= expect_int("mod toggle clears qpsk", opts.mod_qpsk, 0);
     rc |= expect_int("mod toggle clears rf_mod", state.rf_mod, 0);
 
+    /* The generic hotkey must leave D-STAR's same-rate binary gate immediately. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.mod_gfsk = 1;
+    opts.mod_p25p2_c4fm = 1;
+    opts.mod_p25p2_profile_lock = 1;
+    state.rf_mod = 2;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state.sps_hunt_counter = 9;
+    dispatch_one(dsd_app_actions_radio, &opts, &state, &cmd);
+    rc |= expect_int("generic mod toggle returns c4fm", opts.mod_c4fm, 1);
+    rc |= expect_int("generic mod toggle selects four-level profile", state.sps_hunt_idx,
+                     DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    rc |= expect_int("generic mod toggle resets profile dwell", state.sps_hunt_counter, 0);
+    rc |= expect_int("generic mod toggle clears p25p2 c4fm mode", opts.mod_p25p2_c4fm, 0);
+    rc |= expect_int("generic mod toggle clears p25p2 profile lock", opts.mod_p25p2_profile_lock, 0);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
     state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
     state.sps_hunt_counter = 11;
     cmd.id = DSD_APP_CMD_MOD_P2_TOGGLE;
@@ -388,6 +407,7 @@ test_radio_actions(void) {
     rc |= expect_int("mod p2 toggle selects qpsk", opts.mod_qpsk, 1);
     rc |= expect_int("mod p2 toggle sets rf_mod", state.rf_mod, 1);
     rc |= expect_int("mod p2 toggle locks explicit qpsk", opts.mod_cli_lock, 1);
+    rc |= expect_int("mod p2 toggle locks p25p2 profile", opts.mod_p25p2_profile_lock, 1);
     rc |= expect_int("mod p2 toggle qpsk sps", state.samplesPerSymbol, 8);
     rc |= expect_int("mod p2 toggle qpsk center", state.symbolCenter, 3);
     rc |= expect_int("mod p2 toggle selects profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_6000_4);

--- a/tests/ui/test_ui_cmd_actions.c
+++ b/tests/ui/test_ui_cmd_actions.c
@@ -11,6 +11,7 @@
 #include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -380,16 +381,34 @@ test_radio_actions(void) {
     rc |= expect_int("mod toggle clears qpsk", opts.mod_qpsk, 0);
     rc |= expect_int("mod toggle clears rf_mod", state.rf_mod, 0);
 
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.sps_hunt_counter = 11;
     cmd.id = DSD_APP_CMD_MOD_P2_TOGGLE;
     dispatch_one(dsd_app_actions_radio, &opts, &state, &cmd);
     rc |= expect_int("mod p2 toggle selects qpsk", opts.mod_qpsk, 1);
     rc |= expect_int("mod p2 toggle sets rf_mod", state.rf_mod, 1);
     rc |= expect_int("mod p2 toggle qpsk sps", state.samplesPerSymbol, 8);
     rc |= expect_int("mod p2 toggle qpsk center", state.symbolCenter, 3);
+    rc |= expect_int("mod p2 toggle selects profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    rc |= expect_int("mod p2 toggle resets profile dwell", state.sps_hunt_counter, 0);
     dispatch_one(dsd_app_actions_radio, &opts, &state, &cmd);
     rc |= expect_int("mod p2 toggle returns c4fm", opts.mod_c4fm, 1);
     rc |= expect_int("mod p2 toggle p25p2 sps", state.samplesPerSymbol, 8);
     rc |= expect_int("mod p2 toggle p25p2 center", state.symbolCenter, 3);
+
+    /* At low rates P25P1 and P25P2 can round to the same SPS, so the explicit
+     * profile selection—not timing inference—must carry the hotkey choice. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.rtl_dsp_bw_khz = 16;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.sps_hunt_counter = 7;
+    dispatch_one(dsd_app_actions_radio, &opts, &state, &cmd);
+    rc |= expect_int("low-rate mod p2 toggle sps", state.samplesPerSymbol, 3);
+    rc |= expect_int("low-rate mod p2 toggle profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    rc |= expect_int("low-rate mod p2 toggle dwell", state.sps_hunt_counter, 0);
 
     return rc;
 }

--- a/tests/ui/test_ui_cmd_actions.c
+++ b/tests/ui/test_ui_cmd_actions.c
@@ -398,6 +398,19 @@ test_radio_actions(void) {
     rc |= expect_int("generic mod toggle clears p25p2 c4fm mode", opts.mod_p25p2_c4fm, 0);
     rc |= expect_int("generic mod toggle clears p25p2 profile lock", opts.mod_p25p2_profile_lock, 0);
 
+    /* Generic modulation transitions must retain timing from the active PCM source. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 96000;
+    opts.rtl_dsp_bw_khz = 48;
+    opts.mod_qpsk = 1;
+    state.rf_mod = 1;
+    dispatch_one(dsd_app_actions_radio, &opts, &state, &cmd);
+    rc |= expect_int("96k WAV generic toggle returns c4fm", opts.mod_c4fm, 1);
+    rc |= expect_int("96k WAV generic toggle timing", state.samplesPerSymbol, 20);
+    rc |= expect_int("96k WAV generic toggle center", state.symbolCenter, 9);
+
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
     state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
@@ -423,6 +436,7 @@ test_radio_actions(void) {
      * profile selection—not timing inference—must carry the hotkey choice. */
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
+    opts.audio_in_type = AUDIO_IN_RTL;
     opts.rtl_dsp_bw_khz = 16;
     opts.frame_p25p1 = 1;
     opts.frame_p25p2 = 1;

--- a/tests/ui/test_ui_cmd_actions.c
+++ b/tests/ui/test_ui_cmd_actions.c
@@ -433,6 +433,21 @@ test_radio_actions(void) {
     rc |= expect_int("low-rate mod p2 toggle profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
     rc |= expect_int("low-rate mod p2 toggle dwell", state.sps_hunt_counter, 0);
 
+    /* The generic modulation hotkey fully exits the P25p2 helper. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    cmd.id = DSD_APP_CMD_MOD_P2_TOGGLE;
+    dispatch_one(dsd_app_actions_radio, &opts, &state, &cmd);
+    cmd.id = DSD_APP_CMD_MOD_TOGGLE;
+    dispatch_one(dsd_app_actions_radio, &opts, &state, &cmd);
+    rc |= expect_int("generic toggle exits p25p2 helper lock", opts.mod_cli_lock, 0);
+    rc |= expect_int("generic toggle exits p25p2 helper profile lock", opts.mod_p25p2_profile_lock, 0);
+    rc |= expect_int("generic toggle exits p25p2 c4fm helper", opts.mod_p25p2_c4fm, 0);
+    rc |= expect_int("generic toggle restores p25p1 profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    rc |= expect_int("generic toggle restores p25p1 timing", state.samplesPerSymbol, 10);
+    rc |= expect_int("generic toggle restores p25p1 center", state.symbolCenter, 4);
+    rc |= expect_int("generic toggle restores c4fm", state.rf_mod, 0);
+
     return rc;
 }
 

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -13,6 +13,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/runtime/config.h>
@@ -1020,6 +1021,8 @@ seed_active_p25_voice(dsd_opts* opts, dsd_state* state, long cc_freq, long vc_fr
     state->last_cc_sync_time_m = 42.0;
     state->samplesPerSymbol = 7;
     state->symbolCenter = 3;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state->sps_hunt_counter = 17;
 }
 
 static int
@@ -1058,6 +1061,8 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     rc |= expect_true("deferred return-to-CC keeps VC", state.p25_vc_freq[0] == 852000000L);
     rc |= expect_true("deferred return-to-CC keeps CC sync", state.last_cc_sync_time_m == 42.0);
     rc |= expect_int("deferred return-to-CC keeps SPS", state.samplesPerSymbol, 7);
+    rc |= expect_int("deferred return-to-CC keeps SPS profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_4800_2);
+    rc |= expect_int("deferred return-to-CC keeps SPS hunt counter", state.sps_hunt_counter, 17);
 
     reset_io_control_tune_stub(RTL_STREAM_TUNE_TIMEOUT);
     token = 0;
@@ -1070,6 +1075,8 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     rc |= expect_int("accepted timeout clears TG", state.lasttg, 0);
     rc |= expect_true("accepted timeout clears VC", state.p25_vc_freq[0] == 0L);
     rc |= expect_true("accepted timeout refreshes CC sync", state.last_cc_sync_time_m > 42.0);
+    rc |= expect_int("accepted timeout selects P25 SPS profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    rc |= expect_int("accepted timeout resets SPS hunt counter", state.sps_hunt_counter, 0);
     freeState(&state);
 
     init_test_context(&opts, &state);
@@ -1151,6 +1158,9 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     rc |= expect_int("accepted channel cycle clears TG", state.lasttg, 0);
     rc |= expect_true("accepted channel cycle clears P25 VC", state.p25_vc_freq[0] == 0L);
     rc |= expect_true("accepted channel cycle refreshes CC sync", state.last_cc_sync_time_m > 42.0);
+    rc |= expect_int("accepted channel cycle selects P25 SPS profile", state.sps_hunt_idx,
+                     DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    rc |= expect_int("accepted channel cycle resets SPS hunt counter", state.sps_hunt_counter, 0);
 
     token = 0;
     rc |= expect_int("later channel cycle queued", dsd_app_command_action_tracked(DSD_APP_CMD_CHANNEL_CYCLE, &token),

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -12,6 +12,7 @@
 #include <dsd-neo/core/init.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/io/rtl_stream_c.h>
@@ -1036,6 +1037,7 @@ static void
 seed_active_p25_voice(dsd_opts* opts, dsd_state* state, long cc_freq, long vc_freq, int tg) {
     opts->audio_in_type = AUDIO_IN_RTL;
     opts->p25_trunk = 1;
+    opts->frame_p25p1 = 1;
     opts->p25_is_tuned = 1;
     opts->trunk_is_tuned = 1;
     state->p25_cc_freq = cc_freq;
@@ -1046,6 +1048,8 @@ seed_active_p25_voice(dsd_opts* opts, dsd_state* state, long cc_freq, long vc_fr
     state->lastsrc = tg + 1;
     state->last_cc_sync_time = 123;
     state->last_cc_sync_time_m = 42.0;
+    state->synctype = DSD_SYNC_P25P1_POS;
+    state->lastsynctype = DSD_SYNC_P25P1_POS;
     state->samplesPerSymbol = 7;
     state->symbolCenter = 3;
     state->p25_cc_is_tdma = 0;
@@ -1113,6 +1117,32 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     rc |= expect_int("accepted timeout used profile-aware CC tune", g_cc_tune_calls, 1);
     rc |= expect_int("accepted timeout profile was staged before commit", g_cc_profile_at_tune,
                      DSD_FRAME_SYNC_SPS_PROFILE_4800_2);
+    freeState(&state);
+
+    init_test_context(&opts, &state);
+    seed_active_p25_voice(&opts, &state, 852500000L, 853500000L, 1202);
+    opts.frame_nxdn48 = 1;
+    state.synctype = DSD_SYNC_NXDN_POS;
+    state.lastsynctype = DSD_SYNC_NXDN_POS;
+    state.p25_cc_is_tdma = 1;
+    state.samplesPerSymbol = 20;
+    state.symbolCenter = 9;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    state.sps_hunt_counter = 29;
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_TIMEOUT);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
+    token = 0;
+    rc |= expect_int("generic return-to-CC queued", dsd_app_command_action_tracked(DSD_APP_CMD_RETURN_CC, &token),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("generic return-to-CC drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_command_status("generic return-to-CC completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
+    rc |= expect_int("generic return-to-CC raw tune calls", g_io_control_tune_calls, 1);
+    rc |= expect_true("generic return-to-CC frequency", g_io_control_tune_freq == 852500000L);
+    rc |= expect_int("generic return-to-CC CC tune calls", g_cc_tune_calls, 0);
+    rc |= expect_int("generic return-to-CC keeps SPS", state.samplesPerSymbol, 20);
+    rc |= expect_int("generic return-to-CC keeps symbol center", state.symbolCenter, 9);
+    rc |= expect_int("generic return-to-CC keeps SPS profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_2400_4);
+    rc |= expect_int("generic return-to-CC keeps SPS hunt counter", state.sps_hunt_counter, 29);
     freeState(&state);
 
     init_test_context(&opts, &state);

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1143,7 +1143,32 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     freeState(&state);
 
     init_test_context(&opts, &state);
-    seed_active_p25_voice(&opts, &state, 0L, 854500000L, 2202);
+    seed_active_p25_voice(&opts, &state, 853500000L, 854500000L, 2202);
+    state.p25_cc_is_tdma = 2;
+    state.samplesPerSymbol = 8;
+    state.symbolCenter = 3;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+    state.sps_hunt_counter = 19;
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_TIMEOUT);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_DEFERRED);
+    token = 0;
+    rc |=
+        expect_int("profile-neutral lockout queued",
+                   dsd_app_command_set_u8_tracked(DSD_APP_CMD_LOCKOUT_SLOT, 0U, &token), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("profile-neutral lockout drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_command_status("profile-neutral lockout completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
+    rc |= expect_int("profile-neutral lockout raw tune calls", g_io_control_tune_calls, 1);
+    rc |= expect_true("profile-neutral lockout frequency", g_io_control_tune_freq == 853500000L);
+    rc |= expect_int("profile-neutral lockout CC tune calls", g_cc_tune_calls, 0);
+    rc |= expect_int("profile-neutral lockout keeps SPS", state.samplesPerSymbol, 8);
+    rc |= expect_int("profile-neutral lockout keeps symbol center", state.symbolCenter, 3);
+    rc |=
+        expect_int("profile-neutral lockout keeps SPS profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    rc |= expect_int("profile-neutral lockout keeps SPS hunt counter", state.sps_hunt_counter, 19);
+    freeState(&state);
+
+    init_test_context(&opts, &state);
+    seed_active_p25_voice(&opts, &state, 0L, 854500000L, 2203);
     state.carrier = 1;
     reset_io_control_tune_stub(RTL_STREAM_TUNE_DEFERRED);
     reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_DEFERRED);
@@ -1171,14 +1196,16 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     state.trunk_lcn_freq[1] = 857000000L;
     state.trunk_lcn_freq[2] = 0L;
     state.trunk_lcn_freq[3] = 858000000L;
-    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_DEFERRED);
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_DEFERRED);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
     token = 0;
     rc |= expect_int("deferred channel cycle queued", dsd_app_command_action_tracked(DSD_APP_CMD_CHANNEL_CYCLE, &token),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("deferred channel cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_command_status("deferred channel cycle failed", token, DSD_APP_COMMAND_RESULT_FAILED);
-    rc |= expect_int("deferred channel cycle tune calls", g_cc_tune_calls, 1);
-    rc |= expect_true("deferred channel cycle frequency", g_cc_tune_freq == 857000000L);
+    rc |= expect_int("deferred channel cycle raw tune calls", g_io_control_tune_calls, 1);
+    rc |= expect_true("deferred channel cycle frequency", g_io_control_tune_freq == 857000000L);
+    rc |= expect_int("deferred channel cycle CC tune calls", g_cc_tune_calls, 0);
     rc |= expect_int("deferred channel cycle keeps roll", state.lcn_freq_roll, 0);
     rc |= expect_int("deferred channel cycle keeps tuned", opts.p25_is_tuned, 1);
     rc |= expect_int("deferred channel cycle keeps TG", state.lasttg, 3201);
@@ -1189,7 +1216,8 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     state.symbolCenter = 3;
     state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
     state.sps_hunt_counter = 23;
-    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_TIMEOUT);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_DEFERRED);
     token = 0;
     rc |= expect_int("accepted channel cycle queued", dsd_app_command_action_tracked(DSD_APP_CMD_CHANNEL_CYCLE, &token),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
@@ -1200,19 +1228,20 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     rc |= expect_int("accepted channel cycle clears TG", state.lasttg, 0);
     rc |= expect_true("accepted channel cycle clears P25 VC", state.p25_vc_freq[0] == 0L);
     rc |= expect_true("accepted channel cycle refreshes CC sync", state.last_cc_sync_time_m > 42.0);
-    rc |= expect_int("accepted channel cycle selects P25 SPS profile", state.sps_hunt_idx,
-                     DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
-    rc |= expect_int("accepted channel cycle resets SPS hunt counter", state.sps_hunt_counter, 0);
-    rc |= expect_int("accepted channel cycle TED SPS", g_cc_tune_ted_sps, 10);
-    rc |= expect_int("accepted channel cycle profile staged before commit", g_cc_profile_at_tune,
-                     DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    rc |= expect_int("accepted channel cycle uses raw tune", g_io_control_tune_calls, 1);
+    rc |= expect_true("accepted channel cycle frequency", g_io_control_tune_freq == 857000000L);
+    rc |= expect_int("accepted channel cycle skips CC tune", g_cc_tune_calls, 0);
+    rc |= expect_int("accepted channel cycle keeps SPS", state.samplesPerSymbol, 8);
+    rc |= expect_int("accepted channel cycle keeps symbol center", state.symbolCenter, 3);
+    rc |= expect_int("accepted channel cycle keeps SPS profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    rc |= expect_int("accepted channel cycle keeps SPS hunt counter", state.sps_hunt_counter, 23);
 
     token = 0;
     rc |= expect_int("later channel cycle queued", dsd_app_command_action_tracked(DSD_APP_CMD_CHANNEL_CYCLE, &token),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("later channel cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_command_status("later channel cycle completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
-    rc |= expect_true("later channel cycle reaches frequency after empty entry", g_cc_tune_freq == 858000000L);
+    rc |= expect_true("later channel cycle reaches frequency after empty entry", g_io_control_tune_freq == 858000000L);
     rc |= expect_int("later channel cycle advances past second frequency", state.lcn_freq_roll, 4);
 
     token = 0;
@@ -1220,7 +1249,7 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("wrapped channel cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_command_status("wrapped channel cycle completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
-    rc |= expect_true("wrapped channel cycle skips leading empty entry", g_cc_tune_freq == 857000000L);
+    rc |= expect_true("wrapped channel cycle skips leading empty entry", g_io_control_tune_freq == 857000000L);
     rc |= expect_int("wrapped channel cycle advances from recovered entry", state.lcn_freq_roll, 2);
     freeState(&state);
 

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -17,6 +17,7 @@
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -30,10 +31,17 @@
 static int g_io_control_tune_result = RTL_STREAM_TUNE_OK;
 static int g_io_control_tune_calls = 0;
 static long int g_io_control_tune_freq = 0;
+static dsd_trunk_tune_result g_cc_tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+static int g_cc_tune_calls = 0;
+static long int g_cc_tune_freq = 0;
+static int g_cc_tune_ted_sps = 0;
+static int g_cc_profile_at_tune = -1;
 
 // GNU ld --wrap entry points must keep the reserved __wrap_* symbol name.
 // NOLINTBEGIN(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
 int __wrap_io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq);
+dsd_trunk_tune_result __wrap_dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq,
+                                                              int ted_sps);
 
 int
 __wrap_io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
@@ -44,6 +52,16 @@ __wrap_io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
     return g_io_control_tune_result;
 }
 
+dsd_trunk_tune_result
+__wrap_dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    (void)opts;
+    g_cc_tune_calls++;
+    g_cc_tune_freq = freq;
+    g_cc_tune_ted_sps = ted_sps;
+    g_cc_profile_at_tune = state ? state->sps_hunt_idx : -1;
+    return g_cc_tune_result;
+}
+
 // NOLINTEND(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
 
 static void
@@ -51,6 +69,15 @@ reset_io_control_tune_stub(int result) {
     g_io_control_tune_result = result;
     g_io_control_tune_calls = 0;
     g_io_control_tune_freq = 0;
+}
+
+static void
+reset_cc_tune_stub(dsd_trunk_tune_result result) {
+    g_cc_tune_result = result;
+    g_cc_tune_calls = 0;
+    g_cc_tune_freq = 0;
+    g_cc_tune_ted_sps = 0;
+    g_cc_profile_at_tune = -1;
 }
 #endif
 
@@ -1021,6 +1048,7 @@ seed_active_p25_voice(dsd_opts* opts, dsd_state* state, long cc_freq, long vc_fr
     state->last_cc_sync_time_m = 42.0;
     state->samplesPerSymbol = 7;
     state->symbolCenter = 3;
+    state->p25_cc_is_tdma = 0;
     state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
     state->sps_hunt_counter = 17;
 }
@@ -1048,13 +1076,18 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
 
     init_test_context(&opts, &state);
     seed_active_p25_voice(&opts, &state, 851000000L, 852000000L, 1201);
-    reset_io_control_tune_stub(RTL_STREAM_TUNE_DEFERRED);
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_DEFERRED);
     rc |= expect_int("deferred return-to-CC queued", dsd_app_command_action_tracked(DSD_APP_CMD_RETURN_CC, &token),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("deferred return-to-CC drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_command_status("deferred return-to-CC failed", token, DSD_APP_COMMAND_RESULT_FAILED);
-    rc |= expect_int("deferred return-to-CC tune calls", g_io_control_tune_calls, 1);
-    rc |= expect_true("deferred return-to-CC frequency", g_io_control_tune_freq == 851000000L);
+    rc |= expect_int("deferred return-to-CC CC tune calls", g_cc_tune_calls, 1);
+    rc |= expect_int("deferred return-to-CC raw tune calls", g_io_control_tune_calls, 0);
+    rc |= expect_true("deferred return-to-CC frequency", g_cc_tune_freq == 851000000L);
+    rc |= expect_int("deferred return-to-CC TED SPS", g_cc_tune_ted_sps, 10);
+    rc |= expect_int("deferred return-to-CC profile staged before commit", g_cc_profile_at_tune,
+                     DSD_FRAME_SYNC_SPS_PROFILE_4800_2);
     rc |= expect_int("deferred return-to-CC keeps P25 tuned", opts.p25_is_tuned, 1);
     rc |= expect_int("deferred return-to-CC keeps trunk tuned", opts.trunk_is_tuned, 1);
     rc |= expect_int("deferred return-to-CC keeps TG", state.lasttg, 1201);
@@ -1064,7 +1097,7 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     rc |= expect_int("deferred return-to-CC keeps SPS profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_4800_2);
     rc |= expect_int("deferred return-to-CC keeps SPS hunt counter", state.sps_hunt_counter, 17);
 
-    reset_io_control_tune_stub(RTL_STREAM_TUNE_TIMEOUT);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_PENDING);
     token = 0;
     rc |= expect_int("accepted timeout return-to-CC queued",
                      dsd_app_command_action_tracked(DSD_APP_CMD_RETURN_CC, &token), DSD_APP_COMMAND_SUBMIT_QUEUED);
@@ -1077,17 +1110,20 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     rc |= expect_true("accepted timeout refreshes CC sync", state.last_cc_sync_time_m > 42.0);
     rc |= expect_int("accepted timeout selects P25 SPS profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
     rc |= expect_int("accepted timeout resets SPS hunt counter", state.sps_hunt_counter, 0);
+    rc |= expect_int("accepted timeout used profile-aware CC tune", g_cc_tune_calls, 1);
+    rc |= expect_int("accepted timeout profile was staged before commit", g_cc_profile_at_tune,
+                     DSD_FRAME_SYNC_SPS_PROFILE_4800_2);
     freeState(&state);
 
     init_test_context(&opts, &state);
     seed_active_p25_voice(&opts, &state, 853000000L, 854000000L, 2201);
-    reset_io_control_tune_stub(RTL_STREAM_TUNE_DEFERRED);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_DEFERRED);
     token = 0;
     rc |= expect_int("deferred lockout queued", dsd_app_command_set_u8_tracked(DSD_APP_CMD_LOCKOUT_SLOT, 0U, &token),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("deferred lockout drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_command_status("deferred lockout policy completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
-    rc |= expect_int("deferred lockout tune calls", g_io_control_tune_calls, 1);
+    rc |= expect_int("deferred lockout tune calls", g_cc_tune_calls, 1);
     rc |= expect_int("deferred lockout keeps P25 tuned", opts.p25_is_tuned, 1);
     rc |= expect_int("deferred lockout keeps trunk tuned", opts.trunk_is_tuned, 1);
     rc |= expect_int("deferred lockout keeps TG", state.lasttg, 2201);
@@ -1110,12 +1146,14 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     seed_active_p25_voice(&opts, &state, 0L, 854500000L, 2202);
     state.carrier = 1;
     reset_io_control_tune_stub(RTL_STREAM_TUNE_DEFERRED);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_DEFERRED);
     token = 0;
     rc |= expect_int("no-CC lockout queued", dsd_app_command_set_u8_tracked(DSD_APP_CMD_LOCKOUT_SLOT, 0U, &token),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("no-CC lockout drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_command_status("no-CC lockout completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
-    rc |= expect_int("no-CC lockout skips tune", g_io_control_tune_calls, 0);
+    rc |= expect_int("no-CC lockout skips raw tune", g_io_control_tune_calls, 0);
+    rc |= expect_int("no-CC lockout skips CC tune", g_cc_tune_calls, 0);
     rc |= expect_int("no-CC lockout clears P25 tuned", opts.p25_is_tuned, 0);
     rc |= expect_int("no-CC lockout clears trunk tuned", opts.trunk_is_tuned, 0);
     rc |= expect_int("no-CC lockout clears TG", state.lasttg, 0);
@@ -1133,21 +1171,25 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     state.trunk_lcn_freq[1] = 857000000L;
     state.trunk_lcn_freq[2] = 0L;
     state.trunk_lcn_freq[3] = 858000000L;
-    reset_io_control_tune_stub(RTL_STREAM_TUNE_DEFERRED);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_DEFERRED);
     token = 0;
     rc |= expect_int("deferred channel cycle queued", dsd_app_command_action_tracked(DSD_APP_CMD_CHANNEL_CYCLE, &token),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("deferred channel cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_command_status("deferred channel cycle failed", token, DSD_APP_COMMAND_RESULT_FAILED);
-    rc |= expect_int("deferred channel cycle tune calls", g_io_control_tune_calls, 1);
-    rc |= expect_true("deferred channel cycle frequency", g_io_control_tune_freq == 857000000L);
+    rc |= expect_int("deferred channel cycle tune calls", g_cc_tune_calls, 1);
+    rc |= expect_true("deferred channel cycle frequency", g_cc_tune_freq == 857000000L);
     rc |= expect_int("deferred channel cycle keeps roll", state.lcn_freq_roll, 0);
     rc |= expect_int("deferred channel cycle keeps tuned", opts.p25_is_tuned, 1);
     rc |= expect_int("deferred channel cycle keeps TG", state.lasttg, 3201);
     rc |= expect_true("deferred channel cycle keeps VC", state.p25_vc_freq[0] == 856000000L);
     rc |= expect_true("deferred channel cycle keeps CC sync", state.last_cc_sync_time_m == 42.0);
 
-    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    state.samplesPerSymbol = 8;
+    state.symbolCenter = 3;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+    state.sps_hunt_counter = 23;
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
     token = 0;
     rc |= expect_int("accepted channel cycle queued", dsd_app_command_action_tracked(DSD_APP_CMD_CHANNEL_CYCLE, &token),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
@@ -1161,13 +1203,16 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     rc |= expect_int("accepted channel cycle selects P25 SPS profile", state.sps_hunt_idx,
                      DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
     rc |= expect_int("accepted channel cycle resets SPS hunt counter", state.sps_hunt_counter, 0);
+    rc |= expect_int("accepted channel cycle TED SPS", g_cc_tune_ted_sps, 10);
+    rc |= expect_int("accepted channel cycle profile staged before commit", g_cc_profile_at_tune,
+                     DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
 
     token = 0;
     rc |= expect_int("later channel cycle queued", dsd_app_command_action_tracked(DSD_APP_CMD_CHANNEL_CYCLE, &token),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("later channel cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_command_status("later channel cycle completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
-    rc |= expect_true("later channel cycle reaches frequency after empty entry", g_io_control_tune_freq == 858000000L);
+    rc |= expect_true("later channel cycle reaches frequency after empty entry", g_cc_tune_freq == 858000000L);
     rc |= expect_int("later channel cycle advances past second frequency", state.lcn_freq_roll, 4);
 
     token = 0;
@@ -1175,11 +1220,12 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("wrapped channel cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_command_status("wrapped channel cycle completed", token, DSD_APP_COMMAND_RESULT_COMPLETED);
-    rc |= expect_true("wrapped channel cycle skips leading empty entry", g_io_control_tune_freq == 857000000L);
+    rc |= expect_true("wrapped channel cycle skips leading empty entry", g_cc_tune_freq == 857000000L);
     rc |= expect_int("wrapped channel cycle advances from recovered entry", state.lcn_freq_roll, 2);
     freeState(&state);
 
     reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
     return rc;
 }
 #endif

--- a/tests/ui/test_ui_radio_actions_rtl.c
+++ b/tests/ui/test_ui_radio_actions_rtl.c
@@ -25,6 +25,19 @@ static int g_profile_rate;
 static int g_profile_levels;
 static int g_channel_profile;
 static int g_lock_at_profile_apply;
+static int g_apply_order;
+static int g_family_calls;
+static int g_family_cqpsk;
+static int g_family_order;
+static int g_lock_at_family_apply;
+static int g_ted_clear_calls;
+static int g_ted_clear_order;
+static int g_lock_at_ted_clear;
+static int g_ted_calls;
+static int g_ted_sps;
+static int g_ted_order;
+static int g_lock_at_ted_apply;
+static int g_profile_order;
 
 int
 rtl_stream_adjust_ppm(dsd_opts* opts, int delta) {
@@ -46,8 +59,32 @@ rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profil
     g_profile_rate = symbol_rate_hz;
     g_profile_levels = levels;
     g_channel_profile = channel_profile;
+    g_profile_order = ++g_apply_order;
     g_lock_at_profile_apply = g_profile_opts ? g_profile_opts->mod_cli_lock : -1;
     return 0;
+}
+
+void
+rtl_stream_toggle_cqpsk(int onoff) {
+    g_family_calls++;
+    g_family_cqpsk = onoff ? 1 : 0;
+    g_family_order = ++g_apply_order;
+    g_lock_at_family_apply = g_profile_opts ? g_profile_opts->mod_cli_lock : -1;
+}
+
+void
+rtl_stream_clear_ted_sps_override(void) {
+    g_ted_clear_calls++;
+    g_ted_clear_order = ++g_apply_order;
+    g_lock_at_ted_clear = g_profile_opts ? g_profile_opts->mod_cli_lock : -1;
+}
+
+void
+rtl_stream_set_ted_sps_no_override(int sps) {
+    g_ted_calls++;
+    g_ted_sps = sps;
+    g_ted_order = ++g_apply_order;
+    g_lock_at_ted_apply = g_profile_opts ? g_profile_opts->mod_cli_lock : -1;
 }
 
 static int
@@ -77,6 +114,19 @@ reset_profile_capture(const dsd_opts* opts) {
     g_profile_levels = 0;
     g_channel_profile = -1;
     g_lock_at_profile_apply = -1;
+    g_apply_order = 0;
+    g_family_calls = 0;
+    g_family_cqpsk = -1;
+    g_family_order = 0;
+    g_lock_at_family_apply = -1;
+    g_ted_clear_calls = 0;
+    g_ted_clear_order = 0;
+    g_lock_at_ted_clear = -1;
+    g_ted_calls = 0;
+    g_ted_sps = 0;
+    g_ted_order = 0;
+    g_lock_at_ted_apply = -1;
+    g_profile_order = 0;
 }
 
 static int
@@ -96,10 +146,22 @@ test_p25p2_toggle_applies_rtl_profile_before_lock(void) {
     reset_profile_capture(&opts);
 
     rc |= expect_int("p25p2 qpsk dispatch", dispatch_one(&opts, &state, &cmd), 1);
+    rc |= expect_int("p25p2 qpsk family call", g_family_calls, 1);
+    rc |= expect_int("p25p2 qpsk family", g_family_cqpsk, 1);
+    rc |= expect_int("p25p2 qpsk family order", g_family_order, 1);
+    rc |= expect_int("p25p2 qpsk family precedes lock", g_lock_at_family_apply, 0);
+    rc |= expect_int("p25p2 qpsk TED override clear", g_ted_clear_calls, 1);
+    rc |= expect_int("p25p2 qpsk TED override clear order", g_ted_clear_order, 2);
+    rc |= expect_int("p25p2 qpsk TED override clear precedes lock", g_lock_at_ted_clear, 0);
+    rc |= expect_int("p25p2 qpsk TED call", g_ted_calls, 1);
+    rc |= expect_int("p25p2 qpsk TED SPS", g_ted_sps, 8);
+    rc |= expect_int("p25p2 qpsk TED order", g_ted_order, 3);
+    rc |= expect_int("p25p2 qpsk TED precedes lock", g_lock_at_ted_apply, 0);
     rc |= expect_int("p25p2 qpsk profile call", g_profile_calls, 1);
     rc |= expect_int("p25p2 qpsk profile rate", g_profile_rate, 6000);
     rc |= expect_int("p25p2 qpsk profile levels", g_profile_levels, 4);
     rc |= expect_int("p25p2 qpsk channel profile", g_channel_profile, RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    rc |= expect_int("p25p2 qpsk profile order", g_profile_order, 4);
     rc |= expect_int("p25p2 qpsk profile precedes lock", g_lock_at_profile_apply, 0);
     rc |= expect_int("p25p2 qpsk enables lock", opts.mod_cli_lock, 1);
     rc |= expect_int("p25p2 qpsk selects hunt profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
@@ -107,10 +169,22 @@ test_p25p2_toggle_applies_rtl_profile_before_lock(void) {
     opts.mod_cli_lock = 0;
     reset_profile_capture(&opts);
     rc |= expect_int("p25p2 c4fm dispatch", dispatch_one(&opts, &state, &cmd), 1);
+    rc |= expect_int("p25p2 c4fm family call", g_family_calls, 1);
+    rc |= expect_int("p25p2 c4fm family", g_family_cqpsk, 0);
+    rc |= expect_int("p25p2 c4fm family order", g_family_order, 1);
+    rc |= expect_int("p25p2 c4fm family precedes lock", g_lock_at_family_apply, 0);
+    rc |= expect_int("p25p2 c4fm TED override clear", g_ted_clear_calls, 1);
+    rc |= expect_int("p25p2 c4fm TED override clear order", g_ted_clear_order, 2);
+    rc |= expect_int("p25p2 c4fm TED override clear precedes lock", g_lock_at_ted_clear, 0);
+    rc |= expect_int("p25p2 c4fm TED call", g_ted_calls, 1);
+    rc |= expect_int("p25p2 c4fm TED SPS", g_ted_sps, 8);
+    rc |= expect_int("p25p2 c4fm TED order", g_ted_order, 3);
+    rc |= expect_int("p25p2 c4fm TED precedes lock", g_lock_at_ted_apply, 0);
     rc |= expect_int("p25p2 c4fm profile call", g_profile_calls, 1);
     rc |= expect_int("p25p2 c4fm profile rate", g_profile_rate, 6000);
     rc |= expect_int("p25p2 c4fm profile levels", g_profile_levels, 4);
     rc |= expect_int("p25p2 c4fm channel profile", g_channel_profile, RTL_STREAM_CHANNEL_PROFILE_12K5);
+    rc |= expect_int("p25p2 c4fm profile order", g_profile_order, 4);
     rc |= expect_int("p25p2 c4fm profile precedes lock", g_lock_at_profile_apply, 0);
     rc |= expect_int("p25p2 c4fm enables lock", opts.mod_cli_lock, 1);
 
@@ -133,6 +207,9 @@ test_p25p2_toggle_ignores_non_rtl_input(void) {
     reset_profile_capture(&opts);
 
     rc |= expect_int("non-rtl p25p2 dispatch", dispatch_one(&opts, &state, &cmd), 1);
+    rc |= expect_int("non-rtl p25p2 family calls", g_family_calls, 0);
+    rc |= expect_int("non-rtl p25p2 TED override clears", g_ted_clear_calls, 0);
+    rc |= expect_int("non-rtl p25p2 TED calls", g_ted_calls, 0);
     rc |= expect_int("non-rtl p25p2 profile calls", g_profile_calls, 0);
     rc |= expect_int("non-rtl p25p2 enables lock", opts.mod_cli_lock, 1);
     return rc;

--- a/tests/ui/test_ui_radio_actions_rtl.c
+++ b/tests/ui/test_ui_radio_actions_rtl.c
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/* RTL-specific contracts for terminal UI radio command actions. */
+
+#include <dsd-neo/app_control/commands.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/io/rtl_stream_fwd.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "command_dispatch.h"
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static const dsd_opts* g_profile_opts;
+static int g_profile_calls;
+static int g_profile_rate;
+static int g_profile_levels;
+static int g_channel_profile;
+static int g_lock_at_profile_apply;
+
+int
+rtl_stream_adjust_ppm(dsd_opts* opts, int delta) {
+    if (!opts) {
+        return -1;
+    }
+    opts->rtlsdr_ppm_error += delta;
+    return 0;
+}
+
+uint32_t
+rtl_stream_output_rate(const RtlSdrContext* ctx) {
+    return ctx ? 48000U : 0U;
+}
+
+int
+rtl_stream_set_symbol_profile(int symbol_rate_hz, int levels, int channel_profile) {
+    g_profile_calls++;
+    g_profile_rate = symbol_rate_hz;
+    g_profile_levels = levels;
+    g_channel_profile = channel_profile;
+    g_lock_at_profile_apply = g_profile_opts ? g_profile_opts->mod_cli_lock : -1;
+    return 0;
+}
+
+static int
+expect_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+dispatch_one(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* cmd) {
+    for (const struct dsd_app_command_reg* r = dsd_app_actions_radio; r && r->fn; r++) {
+        if (r->id == cmd->id) {
+            return r->fn(opts, state, cmd);
+        }
+    }
+    return 0;
+}
+
+static void
+reset_profile_capture(const dsd_opts* opts) {
+    g_profile_opts = opts;
+    g_profile_calls = 0;
+    g_profile_rate = 0;
+    g_profile_levels = 0;
+    g_channel_profile = -1;
+    g_lock_at_profile_apply = -1;
+}
+
+static int
+test_p25p2_toggle_applies_rtl_profile_before_lock(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    struct dsd_app_command cmd;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&cmd, 0, sizeof(cmd));
+
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.rtl_ctx = (RtlSdrContext*)&state;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    cmd.id = DSD_APP_CMD_MOD_P2_TOGGLE;
+    reset_profile_capture(&opts);
+
+    rc |= expect_int("p25p2 qpsk dispatch", dispatch_one(&opts, &state, &cmd), 1);
+    rc |= expect_int("p25p2 qpsk profile call", g_profile_calls, 1);
+    rc |= expect_int("p25p2 qpsk profile rate", g_profile_rate, 6000);
+    rc |= expect_int("p25p2 qpsk profile levels", g_profile_levels, 4);
+    rc |= expect_int("p25p2 qpsk channel profile", g_channel_profile, RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    rc |= expect_int("p25p2 qpsk profile precedes lock", g_lock_at_profile_apply, 0);
+    rc |= expect_int("p25p2 qpsk enables lock", opts.mod_cli_lock, 1);
+    rc |= expect_int("p25p2 qpsk selects hunt profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+
+    opts.mod_cli_lock = 0;
+    reset_profile_capture(&opts);
+    rc |= expect_int("p25p2 c4fm dispatch", dispatch_one(&opts, &state, &cmd), 1);
+    rc |= expect_int("p25p2 c4fm profile call", g_profile_calls, 1);
+    rc |= expect_int("p25p2 c4fm profile rate", g_profile_rate, 6000);
+    rc |= expect_int("p25p2 c4fm profile levels", g_profile_levels, 4);
+    rc |= expect_int("p25p2 c4fm channel profile", g_channel_profile, RTL_STREAM_CHANNEL_PROFILE_12K5);
+    rc |= expect_int("p25p2 c4fm profile precedes lock", g_lock_at_profile_apply, 0);
+    rc |= expect_int("p25p2 c4fm enables lock", opts.mod_cli_lock, 1);
+
+    return rc;
+}
+
+static int
+test_p25p2_toggle_ignores_non_rtl_input(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    struct dsd_app_command cmd;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&cmd, 0, sizeof(cmd));
+
+    opts.audio_in_type = AUDIO_IN_PULSE;
+    state.rtl_ctx = (RtlSdrContext*)&state;
+    cmd.id = DSD_APP_CMD_MOD_P2_TOGGLE;
+    reset_profile_capture(&opts);
+
+    rc |= expect_int("non-rtl p25p2 dispatch", dispatch_one(&opts, &state, &cmd), 1);
+    rc |= expect_int("non-rtl p25p2 profile calls", g_profile_calls, 0);
+    rc |= expect_int("non-rtl p25p2 enables lock", opts.mod_cli_lock, 1);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_p25p2_toggle_applies_rtl_profile_before_lock();
+    rc |= test_p25p2_toggle_ignores_non_rtl_input();
+    if (rc == 0) {
+        DSD_FPRINTF(stderr, "APP CONTROL RTL ACTION TESTS PASSED\n");
+    }
+    return rc;
+}

--- a/tests/ui/test_ui_radio_actions_rtl.c
+++ b/tests/ui/test_ui_radio_actions_rtl.c
@@ -193,6 +193,47 @@ test_p25p2_toggle_applies_rtl_profile_before_lock(void) {
 }
 
 static int
+test_generic_toggle_restores_rtl_after_p25p2_helper(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    struct dsd_app_command cmd;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&cmd, 0, sizeof(cmd));
+
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.rtl_ctx = (RtlSdrContext*)&state;
+    cmd.id = DSD_APP_CMD_MOD_P2_TOGGLE;
+    reset_profile_capture(&opts);
+    rc |= expect_int("p25p2 helper setup dispatch", dispatch_one(&opts, &state, &cmd), 1);
+
+    cmd.id = DSD_APP_CMD_MOD_TOGGLE;
+    reset_profile_capture(&opts);
+    rc |= expect_int("generic helper exit dispatch", dispatch_one(&opts, &state, &cmd), 1);
+    rc |= expect_int("generic helper exit family call", g_family_calls, 1);
+    rc |= expect_int("generic helper exit family", g_family_cqpsk, 0);
+    rc |= expect_int("generic helper exit family order", g_family_order, 1);
+    rc |= expect_int("generic helper exit family retains lock during transition", g_lock_at_family_apply, 1);
+    rc |= expect_int("generic helper exit TED override clear", g_ted_clear_calls, 1);
+    rc |= expect_int("generic helper exit TED override clear order", g_ted_clear_order, 2);
+    rc |= expect_int("generic helper exit TED call", g_ted_calls, 1);
+    rc |= expect_int("generic helper exit TED SPS", g_ted_sps, 10);
+    rc |= expect_int("generic helper exit TED order", g_ted_order, 3);
+    rc |= expect_int("generic helper exit profile call", g_profile_calls, 1);
+    rc |= expect_int("generic helper exit profile rate", g_profile_rate, 4800);
+    rc |= expect_int("generic helper exit profile levels", g_profile_levels, 4);
+    rc |= expect_int("generic helper exit channel profile", g_channel_profile, RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
+    rc |= expect_int("generic helper exit profile order", g_profile_order, 4);
+    rc |= expect_int("generic helper exit releases lock", opts.mod_cli_lock, 0);
+    rc |= expect_int("generic helper exit clears profile pin", opts.mod_p25p2_profile_lock, 0);
+    rc |= expect_int("generic helper exit selects profile 0", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    rc |= expect_int("generic helper exit decoder SPS", state.samplesPerSymbol, 10);
+    rc |= expect_int("generic helper exit decoder center", state.symbolCenter, 4);
+    return rc;
+}
+
+static int
 test_p25p2_toggle_ignores_non_rtl_input(void) {
     int rc = 0;
     static dsd_opts opts;
@@ -220,6 +261,7 @@ int
 main(void) {
     int rc = 0;
     rc |= test_p25p2_toggle_applies_rtl_profile_before_lock();
+    rc |= test_generic_toggle_restores_rtl_after_p25p2_helper();
     rc |= test_p25p2_toggle_ignores_non_rtl_input();
     if (rc == 0) {
         DSD_FPRINTF(stderr, "APP CONTROL RTL ACTION TESTS PASSED\n");

--- a/tests/ui/test_ui_radio_actions_rtl.c
+++ b/tests/ui/test_ui_radio_actions_rtl.c
@@ -164,6 +164,7 @@ test_p25p2_toggle_applies_rtl_profile_before_lock(void) {
     rc |= expect_int("p25p2 qpsk profile order", g_profile_order, 4);
     rc |= expect_int("p25p2 qpsk profile precedes lock", g_lock_at_profile_apply, 0);
     rc |= expect_int("p25p2 qpsk enables lock", opts.mod_cli_lock, 1);
+    rc |= expect_int("p25p2 qpsk pins profile", opts.mod_p25p2_profile_lock, 1);
     rc |= expect_int("p25p2 qpsk selects hunt profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
 
     opts.mod_cli_lock = 0;


### PR DESCRIPTION
## Summary

- Centralize the five SPS hunt profiles and keep every enabled protocol reachable under `-fa`.
- Replace recent-window pointer arithmetic with bounded 48-symbol history and profile-aware matcher readiness.
- Select timing, RTL settings, modulation metrics, power gating, and voting from the active hunt profile.
- Add regressions for the full protocol matrix, history boundaries, profile cycling, Auto entry points, and ProVoice shadowing.
- Document the five-profile matrix and the intentional CLI/config/interactive Auto distinctions.

Closes #227.

## Root Cause And Impact

The ProVoice/EDACS, D-STAR, and NXDN matchers were connected by an `else if` chain. With full auto enabling ProVoice, a nonmatching ProVoice candidate prevented the later D-STAR and NXDN matchers from running. Protocol-option precedence also selected modulation metrics and gating independently of the active SPS hunt profile.

This change evaluates enabled matchers independently in the existing priority order and makes history, timing, modulation, and RTL behavior follow the active profile. Forced modes and existing matcher priority remain intact, while config and interactive Auto continue to preserve their current candidate sets. There are no production CLI, config schema, installed API, or packaging changes.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: none.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope; no suppressions were added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` (490/490 passed)
- [x] `tools/preflight_ci.sh`
- [x] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `ctest --preset asan-ubsan-debug --output-on-failure` (490/490 passed)
- [x] `tools/cmake_format_check.sh` for CMake changes (not applicable; no CMake changes)
- [x] `tools/zizmor.sh` for workflow changes (not applicable; no workflow changes)
- [x] `tools/osv_scan.sh` for dependency input changes (not applicable; no dependency changes)
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes (not applicable; no workflow or release changes)

## Risk

- Security/dependency impact: None.
- CLI/UI behavior impact: `-fa` now reaches the complete enabled digital matrix; no option syntax changes. Config and interactive Auto preserve their existing candidate-set semantics.
- Compatibility or packaging impact: None; production structures, installed APIs, config schema, and packaging remain unchanged.
