### PR TITLE
ci: synchronize CodeQL and Docker action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
       timezone: "America/Chicago"
     cooldown:
       default-days: 7
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
+      docker-actions:
+        patterns:
+          - "docker/*"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,14 +40,14 @@ jobs:
 
       - name: Initialize CodeQL
         if: matrix.build-mode == ''
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Initialize CodeQL with build mode
         if: matrix.build-mode != ''
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -98,4 +98,4 @@ jobs:
         run: cmake --build --preset dev-debug -j
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4

--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('.gitleaks.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: .gitleaks.sarif
 
@@ -198,7 +198,7 @@ jobs:
       - name: Upload zizmor SARIF
         if: always() && hashFiles('.zizmor.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: .zizmor.sarif
 
@@ -247,7 +247,7 @@ jobs:
       - name: Upload OSV SARIF
         if: always() && hashFiles('.osv-scanner.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: .osv-scanner.sarif
 

--- a/.github/workflows/linux-appimage.yaml
+++ b/.github/workflows/linux-appimage.yaml
@@ -49,7 +49,7 @@ jobs:
         # Only run on trusted contexts (not forked PRs), otherwise the
         # `secrets` context is unavailable and would error.
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         continue-on-error: true
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -58,7 +58,7 @@ jobs:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
       - name: Enable QEMU for cross-arch containers
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
         with:
           platforms: all
       - name: Ensure binfmt for aarch64 is registered

--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -456,7 +456,7 @@ jobs:
       - name: Upload Semgrep SARIF
         if: always() && hashFiles('.semgrep.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: .semgrep.sarif
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload Scorecard SARIF
         if: always() && hashFiles('scorecard.sarif') != ''
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: scorecard.sarif
 


### PR DESCRIPTION
## Summary

- Update every `github/codeql-action` consumer to the same v4.37.0 commit so init, analysis, and SARIF upload cannot drift across incompatible patch versions.
- Update `docker/login-action` to v4.4.0 and `docker/setup-qemu-action` to v4.2.0.
- Group future CodeQL and Docker GitHub Actions updates in Dependabot.
- Consolidate the dependency updates proposed by #232, #233, #234, #235, and #236.

The failing Dependabot PRs updated individual CodeQL action components independently. That split left init, analysis, and SARIF upload on different patch versions, producing compatibility failures. Keeping the action family on one commit and grouping future updates prevents that version skew.

## Review

- [ ] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: workflow / dependency.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] No parser, decoder, file input, network/radio input, allocator, or thread behavior changed.
- [x] Workflow and dependency changes received extra scrutiny.
- [x] No static-analysis suppressions were added.
- [x] No raw memory/string/formatting APIs, third-party includes, shell execution, or workflow permissions were added.

## Tests And Guardrails

- [ ] `cmake --build --preset dev-debug -j`
- [ ] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh --base origin/main`
- [ ] `tools/quality_preflight.sh --base origin/main` — workflow, security, formatting, and scan-build stages passed; the optional fuzz build stopped on a local static `libstdc++` linker incompatibility unrelated to these YAML-only changes.
- [x] `tools/cmake_format_check.sh`
- [x] `tools/zizmor.sh`
- [x] `tools/osv_scan.sh`
- [x] Secret-redaction and workflow pin guardrails
- [x] Workflow lint, shell lint, Semgrep, and changed-file secret scan
- [x] `git diff --check`

## Risk

- Security/dependency impact: action references remain pinned to full verified commit SHAs; future related updates are grouped.
- CLI/UI behavior impact: none.
- Compatibility or packaging impact: none; runtime and package contents are unchanged.
