### PR TITLE
p25: preserve full grace on CC returns

### DIFF
--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -53,6 +53,12 @@ typedef enum {
     P25_SM_HUNTING,  // Lost CC, searching candidates
 } p25_sm_state_e;
 
+typedef enum {
+    P25_SM_CC_ACQUISITION_NONE = 0,
+    P25_SM_CC_ACQUISITION_RETURN,
+    P25_SM_CC_ACQUISITION_HUNT_PROBE,
+} p25_sm_cc_acquisition_origin_e;
+
 enum {
     // Grant decoder sentinel for opcodes that do not carry service options.
     // Passing svc_bits=0 explicitly clears the service option.
@@ -100,7 +106,7 @@ typedef struct {
 typedef struct {
     double hangtime_s;      // Hangtime after voice ends (default 2.0s)
     double grant_timeout_s; // Max wait for voice after grant (default 3.0s)
-    double cc_grace_s;      // Wait before CC hunting (default 5.0s)
+    double cc_grace_s;      // CC acquisition/loss grace; active hunt probes are capped at 2.0s
 } p25_sm_config_t;
 
 /* ============================================================================
@@ -161,6 +167,7 @@ typedef struct {
     uint64_t cc_tune_request_id; // Runtime request awaiting asynchronous tune completion
     int cc_tune_pending;         // 1 while the tuner/output pipeline is still changing channels
     int cc_sync_pending;         // 1 until a completed CC tune is followed by decoded CC sync
+    p25_sm_cc_acquisition_origin_e cc_acquisition_origin; // Origin of pending decoded-CC acquisition
 
     // Statistics (for debugging/UI)
     uint32_t tune_count;
@@ -227,7 +234,9 @@ void p25_sm_seed_cc_from_current_tuner_if_unknown(const dsd_opts* opts, dsd_stat
  * @brief Start CC acquisition after a completed external retune.
  *
  * Refreshes the acquisition baseline and returns the context to ON_CC so the
- * normal acquisition watchdog grants the completed tune its full grace period.
+ * normal acquisition watchdog grants the completed tune its full configured
+ * grace period. The two-second acquisition bound applies only to active hunt
+ * probes initiated by the state machine.
  *
  * @param ctx State machine context.
  * @param opts Decoder options.
@@ -243,7 +252,9 @@ int p25_sm_restart_pending_cc_acquisition(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd
  * @brief Hold CC acquisition until an exact asynchronous retune completes.
  *
  * No acquisition deadline begins until the supplied request completes, even
- * for a previously synchronized parked context.
+ * for a previously synchronized parked context. After completion, external
+ * returns receive the full configured grace period; the two-second bound
+ * applies only to active hunt probes initiated by the state machine.
  *
  * @param ctx State machine context.
  * @param opts Decoder options.

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -49,6 +49,7 @@ static void p25_sm_diagf(dsd_opts* opts, const dsd_state* state, const p25_sm_ct
 static atomic_int g_p25_sm_release_lock = 0;
 
 #define P25_FAILED_VC_RETUNE_BACKOFF_DEFAULT_S 10.0
+#define P25_CC_HUNT_ACQUIRE_GRACE_S            2.0
 
 static const char*
 p25_tune_result_name(dsd_trunk_tune_result result) {
@@ -60,6 +61,28 @@ p25_tune_result_name(dsd_trunk_tune_result result) {
         case DSD_TRUNK_TUNE_RESULT_TIMEOUT: return "timeout";
         default: return "unknown";
     }
+}
+
+static const char*
+p25_sm_cc_acquisition_origin_name(p25_sm_cc_acquisition_origin_e origin) {
+    switch (origin) {
+        case P25_SM_CC_ACQUISITION_NONE: return "none";
+        case P25_SM_CC_ACQUISITION_RETURN: return "return";
+        case P25_SM_CC_ACQUISITION_HUNT_PROBE: return "hunt-probe";
+        default: return "unknown";
+    }
+}
+
+static double
+p25_sm_cc_acquire_grace_s(const p25_sm_ctx_t* ctx, double cc_grace) {
+    if (cc_grace <= 0.0) {
+        return 0.0;
+    }
+    if (ctx && ctx->cc_acquisition_origin == P25_SM_CC_ACQUISITION_HUNT_PROBE
+        && cc_grace > P25_CC_HUNT_ACQUIRE_GRACE_S) {
+        return P25_CC_HUNT_ACQUIRE_GRACE_S;
+    }
+    return cc_grace;
 }
 
 static long
@@ -302,12 +325,13 @@ p25_sm_set_expected_cc_nac(p25_sm_ctx_t* ctx, const dsd_state* state, int replac
 
 static void
 p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double tune_start_m,
-                                 const char* source) {
+                                 const char* source, p25_sm_cc_acquisition_origin_e origin) {
     if (!ctx) {
         return;
     }
     ctx->cc_tune_request_id = 0U;
     ctx->cc_tune_pending = 0;
+    ctx->cc_acquisition_origin = origin;
     ctx->t_cc_sync_m = tune_start_m;
     if (state) {
         const double decoded_cc_m = state->p25_last_cc_msg_time_m;
@@ -326,35 +350,39 @@ p25_sm_start_cc_grace_after_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
     ctx->t_cc_tune_m = ctx->t_cc_sync_m;
     ctx->cc_sync_pending = 1;
     p25_sm_diagf(opts, state, ctx, "cc_acquire_start",
-                 "source=%s tune_start_m=%.3f tune_m=%.3f last_cc_m=%.3f decoded_cc_m=%.3f",
-                 source ? source : "unknown", tune_start_m, ctx->t_cc_tune_m, state ? state->last_cc_sync_time_m : 0.0,
-                 state ? state->p25_last_cc_msg_time_m : 0.0);
+                 "source=%s origin=%s effective_grace=%.3f tune_start_m=%.3f tune_m=%.3f last_cc_m=%.3f "
+                 "decoded_cc_m=%.3f",
+                 source ? source : "unknown", p25_sm_cc_acquisition_origin_name(origin),
+                 p25_sm_cc_acquire_grace_s(ctx, ctx->config.cc_grace_s), tune_start_m, ctx->t_cc_tune_m,
+                 state ? state->last_cc_sync_time_m : 0.0, state ? state->p25_last_cc_msg_time_m : 0.0);
 }
 
 static void
 p25_sm_wait_for_cc_tune_completion(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, uint64_t request_id,
-                                   const char* source) {
+                                   const char* source, p25_sm_cc_acquisition_origin_e origin) {
     if (!ctx) {
         return;
     }
     ctx->cc_tune_request_id = request_id;
     ctx->cc_tune_pending = 1;
+    ctx->cc_acquisition_origin = origin;
     ctx->t_cc_tune_m = 0.0;
     ctx->cc_sync_pending = 1;
     if (state && state->p25_cc_eval_freq != 0) {
         state->p25_cc_eval_start_m = 0.0;
     }
-    p25_sm_diagf(opts, state, ctx, "cc_tune_pending", "source=%s request=%llu eval_freq=%ld",
-                 source ? source : "unknown", (unsigned long long)ctx->cc_tune_request_id,
-                 state ? state->p25_cc_eval_freq : 0);
+    p25_sm_diagf(opts, state, ctx, "cc_tune_pending",
+                 "source=%s origin=%s effective_grace=%.3f request=%llu eval_freq=%ld", source ? source : "unknown",
+                 p25_sm_cc_acquisition_origin_name(origin), p25_sm_cc_acquire_grace_s(ctx, ctx->config.cc_grace_s),
+                 (unsigned long long)ctx->cc_tune_request_id, state ? state->p25_cc_eval_freq : 0);
 }
 
 static void
 p25_sm_start_cc_acquisition_for_result(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state,
                                        dsd_trunk_tune_result tune_result, uint64_t request_id, double tune_start_m,
-                                       const char* source) {
+                                       const char* source, p25_sm_cc_acquisition_origin_e origin) {
     if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING && request_id != 0U) {
-        p25_sm_wait_for_cc_tune_completion(ctx, opts, state, request_id, source);
+        p25_sm_wait_for_cc_tune_completion(ctx, opts, state, request_id, source, origin);
         return;
     }
     if (request_id != 0U) {
@@ -364,7 +392,7 @@ p25_sm_start_cc_acquisition_for_result(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_st
             tune_start_m = completed_m;
         }
     }
-    p25_sm_start_cc_grace_after_tune(ctx, opts, state, tune_start_m, source);
+    p25_sm_start_cc_grace_after_tune(ctx, opts, state, tune_start_m, source, origin);
     if (state && state->p25_cc_eval_freq != 0) {
         state->p25_cc_eval_start_m = ctx->t_cc_tune_m;
     }
@@ -379,14 +407,16 @@ p25_sm_refresh_cc_sync_from_state(p25_sm_ctx_t* ctx, dsd_opts* opts, const dsd_s
         const double decoded_cc_m = state ? state->p25_last_cc_msg_time_m : 0.0;
         if (decoded_cc_m > ctx->t_cc_tune_m) {
             const double tune_m = ctx->t_cc_tune_m;
+            const p25_sm_cc_acquisition_origin_e origin = ctx->cc_acquisition_origin;
             ctx->t_cc_sync_m = decoded_cc_m;
             ctx->t_cc_tune_m = 0.0;
             ctx->cc_sync_pending = 0;
+            ctx->cc_acquisition_origin = P25_SM_CC_ACQUISITION_NONE;
             p25_sm_set_expected_cc_nac(ctx, state, 1);
             p25_sm_diagf(opts, state, ctx, "cc_reacquired",
-                         "source=%s decoded_cc_m=%.3f tune_m=%.3f last_cc_m=%.3f expected_nac=0x%03X",
-                         trigger ? trigger : "state", decoded_cc_m, tune_m, state ? state->last_cc_sync_time_m : 0.0,
-                         ctx->expected_cc_nac);
+                         "source=%s origin=%s decoded_cc_m=%.3f tune_m=%.3f last_cc_m=%.3f expected_nac=0x%03X",
+                         trigger ? trigger : "state", p25_sm_cc_acquisition_origin_name(origin), decoded_cc_m, tune_m,
+                         state ? state->last_cc_sync_time_m : 0.0, ctx->expected_cc_nac);
             return 1;
         }
         p25_sm_set_expected_cc_nac(ctx, state, 0);
@@ -410,6 +440,7 @@ p25_sm_cancel_pending_cc_acquisition(p25_sm_ctx_t* ctx) {
     ctx->cc_tune_pending = 0;
     ctx->t_cc_tune_m = 0.0;
     ctx->cc_sync_pending = 0;
+    ctx->cc_acquisition_origin = P25_SM_CC_ACQUISITION_NONE;
 }
 
 // Determine if channel is TDMA based on IDEN hints.
@@ -541,18 +572,21 @@ p25_sm_resolve_pending_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* sta
         return 0;
     }
 
+    const p25_sm_cc_acquisition_origin_e origin = ctx->cc_acquisition_origin;
     ctx->cc_tune_request_id = 0U;
     ctx->cc_tune_pending = 0;
     if (result == DSD_TRUNK_TUNE_RESULT_OK) {
         if (completed_m <= 0.0) {
             completed_m = dsd_time_now_monotonic_s();
         }
-        p25_sm_start_cc_grace_after_tune(ctx, opts, state, completed_m, "async-complete");
+        p25_sm_start_cc_grace_after_tune(ctx, opts, state, completed_m, "async-complete", origin);
         if (state && state->p25_cc_eval_freq != 0) {
             state->p25_cc_eval_start_m = ctx->t_cc_tune_m;
         }
-        p25_sm_diagf(opts, state, ctx, "cc_tune_complete", "request=%llu completed_m=%.3f",
-                     (unsigned long long)request_id, completed_m);
+        p25_sm_diagf(opts, state, ctx, "cc_tune_complete",
+                     "request=%llu origin=%s effective_grace=%.3f completed_m=%.3f", (unsigned long long)request_id,
+                     p25_sm_cc_acquisition_origin_name(origin), p25_sm_cc_acquire_grace_s(ctx, ctx->config.cc_grace_s),
+                     completed_m);
         set_state(ctx, opts, state, P25_SM_ON_CC, "cc-tune-complete");
         return 1;
     }
@@ -560,8 +594,10 @@ p25_sm_resolve_pending_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* sta
     ctx->t_cc_tune_m = 0.0;
     ctx->t_cc_sync_m = completed_m > 0.0 ? completed_m : dsd_time_now_monotonic_s();
     ctx->cc_sync_pending = 0;
+    ctx->cc_acquisition_origin = P25_SM_CC_ACQUISITION_NONE;
     ctx->t_hunt_try_m = 0.0;
-    p25_sm_diagf(opts, state, ctx, "cc_tune_complete", "request=%llu result=%s", (unsigned long long)request_id,
+    p25_sm_diagf(opts, state, ctx, "cc_tune_complete", "request=%llu origin=%s result=%s",
+                 (unsigned long long)request_id, p25_sm_cc_acquisition_origin_name(origin),
                  p25_tune_result_name(result));
     set_state(ctx, opts, state, P25_SM_HUNTING, "cc-tune-failed");
     return -1;
@@ -577,7 +613,7 @@ p25_sm_restart_pending_cc_acquisition(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_sta
     if (tune_start_m <= 0.0) {
         tune_start_m = dsd_time_now_monotonic_s();
     }
-    p25_sm_start_cc_grace_after_tune(ctx, opts, state, tune_start_m, reason);
+    p25_sm_start_cc_grace_after_tune(ctx, opts, state, tune_start_m, reason, P25_SM_CC_ACQUISITION_RETURN);
     if (state && state->p25_cc_eval_freq != 0) {
         state->p25_cc_eval_start_m = ctx->t_cc_tune_m;
     }
@@ -593,7 +629,7 @@ p25_sm_await_pending_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state
         return 0;
     }
     const char* reason = source ? source : "external-retune";
-    p25_sm_wait_for_cc_tune_completion(ctx, opts, state, request_id, reason);
+    p25_sm_wait_for_cc_tune_completion(ctx, opts, state, request_id, reason, P25_SM_CC_ACQUISITION_RETURN);
     ctx->t_hunt_try_m = 0.0;
     set_state(ctx, opts, state, P25_SM_ON_CC, reason);
     return 1;
@@ -1744,6 +1780,7 @@ p25_grant_seed_cc_before_vc_tune(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_st
         (state->p25_last_cc_msg_time_m > 0.0) ? state->p25_last_cc_msg_time_m : state->last_cc_sync_time_m;
     ctx->t_cc_tune_m = 0.0;
     ctx->cc_sync_pending = 0;
+    ctx->cc_acquisition_origin = P25_SM_CC_ACQUISITION_NONE;
     p25_sm_set_expected_cc_nac(ctx, state, 0);
     set_state(ctx, opts, state, P25_SM_ON_CC, "grant-cc-seed");
 }
@@ -2581,7 +2618,8 @@ p25_release_locked(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const ch
 
     p25_release_clear_context(ctx);
     p25_release_clear_decoder_state(opts, state);
-    p25_sm_start_cc_acquisition_for_result(ctx, opts, state, tune_result, tune_request_id, tune_start_m, "release");
+    p25_sm_start_cc_acquisition_for_result(ctx, opts, state, tune_result, tune_request_id, tune_start_m, "release",
+                                           P25_SM_CC_ACQUISITION_RETURN);
 
     // Transition to ON_CC state
     set_state(ctx, opts, state, P25_SM_ON_CC, "release->cc");
@@ -2737,7 +2775,8 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
                      p25_tune_result_name(tune_result));
         state->p25_cc_eval_freq = cand;
         state->p25_cc_eval_start_m = 0.0;
-        p25_sm_start_cc_acquisition_for_result(ctx, opts, state, tune_result, tune_request_id, now_m, "hunt-cand");
+        p25_sm_start_cc_acquisition_for_result(ctx, opts, state, tune_result, tune_request_id, now_m, "hunt-cand",
+                                               P25_SM_CC_ACQUISITION_HUNT_PROBE);
         set_state(ctx, opts, state, P25_SM_ON_CC, "hunt-cand");
         sm_log(opts, state, "hunt-cand-tune");
         return;
@@ -2761,7 +2800,8 @@ try_next_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
         }
         p25_sm_diagf(opts, state, ctx, "hunt_tune_result", "source=%s freq=%ld result=%s", source, cand,
                      p25_tune_result_name(tune_result));
-        p25_sm_start_cc_acquisition_for_result(ctx, opts, state, tune_result, tune_request_id, now_m, "hunt-lcn");
+        p25_sm_start_cc_acquisition_for_result(ctx, opts, state, tune_result, tune_request_id, now_m, "hunt-lcn",
+                                               P25_SM_CC_ACQUISITION_HUNT_PROBE);
         set_state(ctx, opts, state, P25_SM_ON_CC, "hunt-lcn");
         sm_log(opts, state, "hunt-lcn-tune");
         return;
@@ -3003,15 +3043,6 @@ p25_sm_tick_on_cc_sync_from_state(p25_sm_ctx_t* ctx, dsd_opts* opts, const dsd_s
     (void)p25_sm_refresh_cc_sync_from_state(ctx, opts, state, "tick");
 }
 
-static double
-p25_sm_cc_acquire_grace_s(double cc_grace) {
-    const double acquire_grace_s = 2.0;
-    if (cc_grace <= 0.0) {
-        return 0.0;
-    }
-    return (cc_grace < acquire_grace_s) ? cc_grace : acquire_grace_s;
-}
-
 static int
 p25_sm_tick_on_cc_nac_mismatch(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
     if (!ctx || !state || !p25_sm_valid_nac_int(ctx->expected_cc_nac) || !p25_sm_valid_nac_int(state->nac)) {
@@ -3081,7 +3112,7 @@ p25_sm_tick_on_cc_is_lost(const p25_sm_ctx_t* ctx, const dsd_state* state, doubl
         return 0;
     }
     if (ctx->cc_sync_pending && ctx->t_cc_tune_m > 0.0) {
-        const double acquire_grace = p25_sm_cc_acquire_grace_s(cc_grace);
+        const double acquire_grace = p25_sm_cc_acquire_grace_s(ctx, cc_grace);
         if ((now_m - ctx->t_cc_tune_m) > acquire_grace) {
             if (out_acquire_timeout) {
                 *out_acquire_timeout = 1;
@@ -3132,11 +3163,13 @@ p25_sm_tick_on_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double no
         return;
     }
     if (acquire_timeout) {
+        const p25_sm_cc_acquisition_origin_e origin = ctx->cc_acquisition_origin;
         p25_sm_diagf(opts, state, ctx, "cc_lost",
-                     "reason=acquire-timeout acquire_grace=%.3f cc_grace=%.3f tune_m=%.3f last_cc_m=%.3f "
-                     "decoded_cc_m=%.3f now_m=%.3f",
-                     p25_sm_cc_acquire_grace_s(cc_grace), cc_grace, ctx ? ctx->t_cc_tune_m : 0.0,
-                     state ? state->last_cc_sync_time_m : 0.0, state ? state->p25_last_cc_msg_time_m : 0.0, now_m);
+                     "reason=acquire-timeout origin=%s effective_grace=%.3f cc_grace=%.3f tune_m=%.3f "
+                     "last_cc_m=%.3f decoded_cc_m=%.3f now_m=%.3f",
+                     p25_sm_cc_acquisition_origin_name(origin), p25_sm_cc_acquire_grace_s(ctx, cc_grace), cc_grace,
+                     ctx->t_cc_tune_m, state ? state->last_cc_sync_time_m : 0.0,
+                     state ? state->p25_last_cc_msg_time_m : 0.0, now_m);
         if (state && state->p25_cc_eval_freq != 0) {
             dsd_trunk_cc_candidates_set_cooldown(state, state->p25_cc_eval_freq, now_m + 10.0);
             p25_sm_diagf(opts, state, ctx, "hunt_candidate_cooldown", "freq=%ld seconds=10.000 reason=acquire-timeout",

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -3080,6 +3080,10 @@ p25_sm_tick_on_cc_eval_cooldown(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_sta
     if (!ctx || !state || state->p25_cc_eval_freq == 0) {
         return;
     }
+    // Return acquisition owns the longer deadline and applies cooldown on timeout.
+    if (ctx->cc_sync_pending && ctx->t_cc_tune_m > 0.0 && ctx->cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN) {
+        return;
+    }
     eval_dt = (state->p25_cc_eval_start_m > 0.0) ? (now_m - state->p25_cc_eval_start_m) : 0.0;
     if (eval_dt < eval_window_s) {
         return;

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -661,6 +661,8 @@ main(void) {
     rc |= expect_true("p25-rtl-nocarrier-reenables-slots", opts->slot1_on == 1 && opts->slot2_on == 1);
     rc |= expect_true("p25-rtl-nocarrier-clear-tuned", opts->trunk_is_tuned == 0);
     rc |= expect_true("p25-rtl-nocarrier-clear-vc", state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0);
+    rc |= expect_true("p25-rtl-nocarrier-uses-return-grace",
+                      p25_sm_get_ctx()->cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN);
 
     // A controller wait timeout remains correlated until the controller
     // publishes the physical retune result.
@@ -684,6 +686,7 @@ main(void) {
     rc |= expect_true(
         "p25-rtl-nocarrier-timeout-waits-for-completion",
         pending_ctx->cc_tune_pending == 1 && pending_ctx->t_cc_tune_m == 0.0 && pending_cc_request_id != 0U
+            && pending_ctx->cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN
             && dsd_trunk_tuning_request_status(pending_cc_request_id, NULL) == DSD_TRUNK_TUNE_RESULT_PENDING);
     rc |= expect_true("p25-rtl-nocarrier-timeout-serializes-tune", g_p25_tick_guard_held_during_tune == 1);
     int guard_released = p25_sm_tick_guard_try_enter();
@@ -696,7 +699,8 @@ main(void) {
     dsd_trunk_tuning_request_publish(pending_cc_request_id, DSD_TRUNK_TUNE_RESULT_OK);
     p25_sm_tick_ctx(pending_ctx, opts, state);
     rc |= expect_true("p25-rtl-nocarrier-completion-starts-acquisition",
-                      pending_ctx->cc_tune_pending == 0 && pending_ctx->t_cc_tune_m > 0.0);
+                      pending_ctx->cc_tune_pending == 0 && pending_ctx->t_cc_tune_m > 0.0
+                          && pending_ctx->cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN);
     rc |= expect_true("p25-rtl-nocarrier-completion-opens-frame-gate",
                       dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
     g_rtl_tune_result = RTL_STREAM_TUNE_OK;

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -93,6 +93,8 @@ p25_sm_restart_pending_cc_acquisition(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_sta
     ctx->state = P25_SM_ON_CC;
     ctx->cc_tune_request_id = 0U;
     ctx->cc_tune_pending = 0;
+    ctx->cc_sync_pending = 1;
+    ctx->cc_acquisition_origin = P25_SM_CC_ACQUISITION_RETURN;
     ctx->t_cc_sync_m = tune_start_m;
     ctx->t_cc_tune_m = tune_start_m;
     ctx->t_hunt_try_m = 0.0;
@@ -118,6 +120,7 @@ p25_sm_await_pending_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state
     ctx->cc_tune_request_id = request_id;
     ctx->cc_tune_pending = 1;
     ctx->cc_sync_pending = 1;
+    ctx->cc_acquisition_origin = P25_SM_CC_ACQUISITION_RETURN;
     ctx->t_cc_tune_m = 0.0;
     if (state) {
         state->p25_cc_eval_start_m = 0.0;
@@ -1434,6 +1437,7 @@ test_p25_scan_retune_restarts_pending_cc_acquisition(void) {
     const double timestamp_epsilon_s = 1.0e-9;
     if (dsd_engine_trunk_scan_active_index(&state) != 0 || !restored_ctx || restored_ctx->cc_sync_pending != 1
         || restored_ctx->state != P25_SM_ON_CC || restored_ctx->t_cc_sync_m <= 1.0
+        || restored_ctx->cc_acquisition_origin != P25_SM_CC_ACQUISITION_RETURN
         || !(fabs(restored_ctx->t_cc_tune_m - restored_ctx->t_cc_sync_m) <= timestamp_epsilon_s)
         || restored_ctx->t_hunt_try_m != 0.0 || state.p25_sm_mode != DSD_P25_SM_MODE_ON_CC
         || state.p25_cc_freq != 853000000 || state.trunk_cc_freq != 853000000 || state.p25_cc_eval_freq != 853000000

--- a/tests/protocol/p25/test_p25_sm_cand_cooldown.c
+++ b/tests/protocol/p25/test_p25_sm_cand_cooldown.c
@@ -14,6 +14,7 @@
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <math.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -108,6 +109,68 @@ main(void) {
     g_last_tuned_cc = 0;
     p25_sm_tick_ctx(p25_sm_get_ctx(), &o2, &st2);
     assert(g_last_tuned_cc == B);
+    assert(ctx->cc_acquisition_origin == P25_SM_CC_ACQUISITION_HUNT_PROBE);
+
+    // A candidate carried into a normal return must remain eligible for the
+    // full return grace, then clear without cooldown after decoded CC activity.
+    static dsd_opts o_return;
+    static dsd_state st_return;
+    init_basic(&o_return, &st_return);
+    (void)dsd_trunk_cc_candidates_add(&st_return, A, 0, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE);
+    ctx = p25_sm_get_ctx();
+    ctx->config.cc_grace_s = 5.0;
+    st_return.p25_cc_eval_freq = A;
+    const double return_tune_m = dsd_time_now_monotonic_s() - 4.0;
+    st_return.p25_last_cc_msg_time_m = return_tune_m - 0.25;
+    assert(p25_sm_restart_pending_cc_acquisition(ctx, &o_return, &st_return, return_tune_m, "test-return") == 1);
+    assert(fabs(st_return.p25_cc_eval_start_m - ctx->t_cc_tune_m) <= timestamp_epsilon_s);
+
+    const dsd_trunk_cc_candidates* return_candidates = dsd_trunk_cc_candidates_peek(&st_return);
+    assert(return_candidates != NULL);
+    assert(return_candidates->count == 1);
+    assert(return_candidates->cool_until[0] == 0.0);
+    g_last_tuned_cc = 0;
+    p25_sm_tick_ctx(ctx, &o_return, &st_return);
+    assert(g_last_tuned_cc == 0);
+    assert(ctx->state == P25_SM_ON_CC);
+    assert(ctx->cc_sync_pending == 1);
+    assert(ctx->cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN);
+    assert(st_return.p25_cc_eval_freq == A);
+    assert(return_candidates->cool_until[0] == 0.0);
+
+    const double decoded_return_m = dsd_time_now_monotonic_s();
+    st_return.last_cc_sync_time_m = decoded_return_m;
+    st_return.p25_last_cc_msg_time_m = decoded_return_m;
+    p25_sm_tick_ctx(ctx, &o_return, &st_return);
+    assert(ctx->cc_sync_pending == 0);
+    assert(ctx->cc_acquisition_origin == P25_SM_CC_ACQUISITION_NONE);
+    assert(st_return.p25_cc_eval_freq == 0);
+    assert(return_candidates->cool_until[0] == 0.0);
+
+    // A return that exhausts its full grace still cools the failed candidate
+    // and advances to the next hunt probe.
+    static dsd_opts o_return_timeout;
+    static dsd_state st_return_timeout;
+    init_basic(&o_return_timeout, &st_return_timeout);
+    (void)dsd_trunk_cc_candidates_add(&st_return_timeout, A, 0, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE);
+    (void)dsd_trunk_cc_candidates_add(&st_return_timeout, B, 0, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE);
+    ctx = p25_sm_get_ctx();
+    ctx->config.cc_grace_s = 5.0;
+    st_return_timeout.p25_cc_eval_freq = A;
+    const double expired_return_m = dsd_time_now_monotonic_s() - 5.5;
+    st_return_timeout.p25_last_cc_msg_time_m = expired_return_m - 0.25;
+    assert(p25_sm_restart_pending_cc_acquisition(ctx, &o_return_timeout, &st_return_timeout, expired_return_m,
+                                                 "test-return-timeout")
+           == 1);
+
+    const dsd_trunk_cc_candidates* expired_candidates = dsd_trunk_cc_candidates_peek(&st_return_timeout);
+    assert(expired_candidates != NULL);
+    assert(expired_candidates->count == 2);
+    g_last_tuned_cc = 0;
+    p25_sm_tick_ctx(ctx, &o_return_timeout, &st_return_timeout);
+    assert(g_last_tuned_cc == B);
+    assert(expired_candidates->cool_until[0] > dsd_time_now_monotonic_s());
+    assert(st_return_timeout.p25_cc_eval_freq == B);
     assert(ctx->cc_acquisition_origin == P25_SM_CC_ACQUISITION_HUNT_PROBE);
 
     // A controller timeout is an in-flight tune, not the start of CC acquisition.

--- a/tests/protocol/p25/test_p25_sm_cand_cooldown.c
+++ b/tests/protocol/p25/test_p25_sm_cand_cooldown.c
@@ -100,6 +100,7 @@ main(void) {
     ctx->t_cc_sync_m = pending_m;
     ctx->t_cc_tune_m = pending_m;
     ctx->cc_sync_pending = 1;
+    ctx->cc_acquisition_origin = P25_SM_CC_ACQUISITION_HUNT_PROBE;
     st2.last_cc_sync_time_m = pending_m;
     st2.p25_cc_eval_freq = A;
     st2.p25_cc_eval_start_m = pending_m;
@@ -107,6 +108,7 @@ main(void) {
     g_last_tuned_cc = 0;
     p25_sm_tick_ctx(p25_sm_get_ctx(), &o2, &st2);
     assert(g_last_tuned_cc == B);
+    assert(ctx->cc_acquisition_origin == P25_SM_CC_ACQUISITION_HUNT_PROBE);
 
     // A controller timeout is an in-flight tune, not the start of CC acquisition.
     static dsd_opts o3;
@@ -129,6 +131,7 @@ main(void) {
     assert(ctx->cc_tune_pending == 1);
     assert(ctx->cc_tune_request_id != 0U);
     assert(ctx->t_cc_tune_m == 0.0);
+    assert(ctx->cc_acquisition_origin == P25_SM_CC_ACQUISITION_HUNT_PROBE);
     assert(st3.p25_cc_eval_freq == A);
     assert(st3.p25_cc_eval_start_m == 0.0);
 
@@ -146,6 +149,7 @@ main(void) {
     assert(ctx->cc_tune_pending == 0);
     assert(ctx->cc_sync_pending == 1);
     assert(ctx->t_cc_tune_m > 0.0);
+    assert(ctx->cc_acquisition_origin == P25_SM_CC_ACQUISITION_HUNT_PROBE);
     assert(fabs(st3.p25_cc_eval_start_m - ctx->t_cc_tune_m) <= timestamp_epsilon_s);
 
     // Only the post-completion acquisition window can fail A and advance to B.
@@ -171,6 +175,7 @@ main(void) {
     assert(g_tune_to_cc_calls == 3);
     assert(ctx->state == P25_SM_HUNTING);
     assert(ctx->cc_sync_pending == 0);
+    assert(ctx->cc_acquisition_origin == P25_SM_CC_ACQUISITION_NONE);
     assert(ctx->t_cc_sync_m > stale_decoded_m);
     assert(dsd_trunk_tuning_pending_request() == failed_request);
     assert(!dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -812,11 +812,47 @@ main(void) {
     assert(ctx18.state == P25_SM_ON_CC);
     assert(o18.trunk_is_tuned == 0);
     assert(s18.last_cc_sync_time_m > stale_seed_cc_sync_m);
+    assert(ctx18.cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN);
 
     int cc_calls_before_seeded_release_tick = g_result_tune_to_cc_calls;
+    int vc_calls_before_seeded_release_tick = g_result_tune_to_freq_calls;
+    const double seeded_return_tune_m = dsd_time_now_monotonic_s() - 2.5;
+    ctx18.t_cc_sync_m = seeded_return_tune_m;
+    ctx18.t_cc_tune_m = seeded_return_tune_m;
+    s18.last_cc_sync_time_m = seeded_return_tune_m;
+    s18.p25_last_cc_msg_time_m = seeded_return_tune_m - 0.25;
+    p25_sm_event(&ctx18, &o18, &s18, &ev9);
+    assert(g_result_tune_to_freq_calls == vc_calls_before_seeded_release_tick);
+    assert(ctx18.state == P25_SM_ON_CC);
+    assert(ctx18.cc_sync_pending == 1);
     p25_sm_tick_ctx(&ctx18, &o18, &s18);
     assert(ctx18.state == P25_SM_ON_CC);
     assert(g_result_tune_to_cc_calls == cc_calls_before_seeded_release_tick);
+    assert(ctx18.cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN);
+
+    s18.last_cc_sync_time = time(NULL);
+    s18.last_cc_sync_time_m = seeded_return_tune_m + 0.25;
+    s18.p25_last_cc_msg_time = s18.last_cc_sync_time;
+    s18.p25_last_cc_msg_time_m = seeded_return_tune_m + 0.25;
+    p25_sm_event(&ctx18, &o18, &s18, &ev9);
+    assert(g_result_tune_to_freq_calls == vc_calls_before_seeded_release_tick + 1);
+    assert(ctx18.state == P25_SM_TUNED);
+    assert(ctx18.cc_sync_pending == 0);
+    assert(ctx18.cc_acquisition_origin == P25_SM_CC_ACQUISITION_NONE);
+
+    p25_sm_release(&ctx18, &o18, &s18, "seeded-release-timeout");
+    assert(g_result_return_to_cc_calls == 2);
+    assert(ctx18.cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN);
+    const double expired_seeded_return_m = dsd_time_now_monotonic_s() - 5.5;
+    ctx18.t_cc_sync_m = expired_seeded_return_m;
+    ctx18.t_cc_tune_m = expired_seeded_return_m;
+    s18.last_cc_sync_time_m = expired_seeded_return_m;
+    s18.p25_last_cc_msg_time_m = expired_seeded_return_m - 0.25;
+    g_result_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    p25_sm_tick_ctx(&ctx18, &o18, &s18);
+    assert(g_result_tune_to_cc_calls == cc_calls_before_seeded_release_tick + 1);
+    assert(ctx18.state == P25_SM_HUNTING);
+    g_result_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
     // 20) Grants observed before decoded CC activity after a CC retune must not pull us back to a VC.
     static dsd_opts o18aa;
@@ -840,6 +876,7 @@ main(void) {
     ctx18aa.t_cc_sync_m = pending_grant_cc_tune_m - 0.25;
     ctx18aa.t_cc_tune_m = pending_grant_cc_tune_m;
     ctx18aa.cc_sync_pending = 1;
+    ctx18aa.cc_acquisition_origin = P25_SM_CC_ACQUISITION_RETURN;
     s18aa.last_cc_sync_time_m = pending_grant_cc_tune_m - 0.10;
     g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_OK;
     g_result_tune_to_freq_calls = 0;
@@ -872,7 +909,7 @@ main(void) {
     assert(ctx18aa.state == P25_SM_TUNED);
     assert(ctx18aa.cc_sync_pending == 0);
 
-    // 21) A CC retune that does not produce decoded CC activity should hunt before full stale-CC grace.
+    // 21) An active hunt probe without decoded CC activity should advance before full stale-CC grace.
     static dsd_opts o18b;
     static dsd_state s18b;
     DSD_MEMSET(&o18b, 0, sizeof(o18b));
@@ -889,6 +926,7 @@ main(void) {
     ctx18b.t_cc_sync_m = pending_cc_tune_m;
     ctx18b.t_cc_tune_m = pending_cc_tune_m;
     ctx18b.cc_sync_pending = 1;
+    ctx18b.cc_acquisition_origin = P25_SM_CC_ACQUISITION_HUNT_PROBE;
     s18b.last_cc_sync_time = time(NULL) - 3;
     s18b.last_cc_sync_time_m = pending_cc_tune_m;
     g_result_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
@@ -898,6 +936,7 @@ main(void) {
     assert(g_result_tune_to_cc_calls == 1);
     assert(g_last_tuned_cc == 852000000);
     assert(ctx18b.state == P25_SM_ON_CC);
+    assert(ctx18b.cc_acquisition_origin == P25_SM_CC_ACQUISITION_HUNT_PROBE);
 
     // 22) HUNTING must keep grants blocked until decoded CC activity proves reacquisition,
     // then recover even when that activity is not a grant.
@@ -922,6 +961,7 @@ main(void) {
     ctx18c.t_cc_sync_m = hunting_pending_tune_m;
     ctx18c.t_cc_tune_m = hunting_pending_tune_m;
     ctx18c.cc_sync_pending = 1;
+    ctx18c.cc_acquisition_origin = P25_SM_CC_ACQUISITION_HUNT_PROBE;
     s18c.last_cc_sync_time = time(NULL) - 3;
     s18c.last_cc_sync_time_m = hunting_pending_tune_m;
     s18c.p25_last_cc_msg_time_m = hunting_pending_tune_m - 0.25;
@@ -960,6 +1000,7 @@ main(void) {
     assert(ctx18c.state == P25_SM_ON_CC);
     assert(ctx18c.cc_sync_pending == 0);
     assert(ctx18c.t_cc_tune_m == 0.0);
+    assert(ctx18c.cc_acquisition_origin == P25_SM_CC_ACQUISITION_NONE);
     assert(fabs(ctx18c.t_cc_sync_m - s18c.p25_last_cc_msg_time_m) <= cc_sync_epsilon_s);
 
     g_result_tune_to_freq_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
@@ -998,6 +1039,7 @@ main(void) {
     assert(p25_sm_restart_pending_cc_acquisition(&ctx18d, &o18d, &s18d, external_cc_tune_m, "test-retune") == 1);
     assert(ctx18d.state == P25_SM_ON_CC);
     assert(ctx18d.cc_sync_pending == 1);
+    assert(ctx18d.cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN);
     assert(fabs(ctx18d.t_cc_sync_m - external_cc_tune_m) <= cc_sync_epsilon_s);
     assert(fabs(ctx18d.t_cc_tune_m - external_cc_tune_m) <= cc_sync_epsilon_s);
     assert(ctx18d.t_hunt_try_m == 0.0);
@@ -1027,6 +1069,7 @@ main(void) {
     assert(early_grant_request_id != 0U);
     dsd_trunk_tuning_request_mark_ready(early_grant_request_id);
     assert(p25_sm_await_pending_cc_tune(&ctx18e, &o18e, &s18e, early_grant_request_id, "test-early-grant") == 1);
+    assert(ctx18e.cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN);
     dsd_trunk_tuning_request_publish(early_grant_request_id, DSD_TRUNK_TUNE_RESULT_OK);
 
     double early_grant_completion_m = 0.0;
@@ -1044,6 +1087,7 @@ main(void) {
     p25_sm_event(&ctx18e, &o18e, &s18e, &ev9);
     assert(ctx18e.cc_tune_pending == 0);
     assert(ctx18e.cc_sync_pending == 0);
+    assert(ctx18e.cc_acquisition_origin == P25_SM_CC_ACQUISITION_NONE);
     assert(g_result_tune_to_freq_calls == 1);
     assert(ctx18e.state == P25_SM_TUNED);
 
@@ -1067,6 +1111,7 @@ main(void) {
     assert(p25_sm_await_pending_cc_tune(&ctx18f, &o18f, &s18f, decoded_before_resolution_request_id,
                                         "test-decoded-before-resolution")
            == 1);
+    assert(ctx18f.cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN);
     dsd_trunk_tuning_request_publish(decoded_before_resolution_request_id, DSD_TRUNK_TUNE_RESULT_OK);
 
     double decoded_before_resolution_completion_m = 0.0;
@@ -1085,8 +1130,90 @@ main(void) {
     assert(ctx18f.cc_tune_pending == 0);
     assert(ctx18f.cc_sync_pending == 0);
     assert(ctx18f.t_cc_tune_m == 0.0);
+    assert(ctx18f.cc_acquisition_origin == P25_SM_CC_ACQUISITION_NONE);
     assert(fabs(ctx18f.t_cc_sync_m - decoded_before_resolution_m) <= cc_sync_epsilon_s);
     assert(ctx18f.state == P25_SM_ON_CC);
+
+    // An asynchronously completed external return also receives the full configured grace.
+    static dsd_opts o18g;
+    static dsd_state s18g;
+    DSD_MEMSET(&o18g, 0, sizeof(o18g));
+    DSD_MEMSET(&s18g, 0, sizeof(s18g));
+    o18g.trunk_enable = 1;
+    s18g.p25_cc_freq = 851000000;
+    s18g.trunk_cc_freq = 851000000;
+    p25_sm_ctx_t ctx18g;
+    p25_sm_init_ctx(&ctx18g, &o18g, &s18g);
+    ctx18g.config.cc_grace_s = 5.0;
+
+    const uint64_t async_return_request_id = dsd_trunk_tuning_request_begin();
+    assert(async_return_request_id != 0U);
+    dsd_trunk_tuning_request_mark_ready(async_return_request_id);
+    assert(p25_sm_await_pending_cc_tune(&ctx18g, &o18g, &s18g, async_return_request_id, "test-async-return") == 1);
+    assert(ctx18g.cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN);
+    dsd_trunk_tuning_request_publish(async_return_request_id, DSD_TRUNK_TUNE_RESULT_OK);
+    p25_sm_tick_ctx(&ctx18g, &o18g, &s18g);
+    assert(ctx18g.cc_tune_pending == 0);
+    assert(ctx18g.cc_sync_pending == 1);
+    assert(ctx18g.cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN);
+
+    const double async_return_tune_m = dsd_time_now_monotonic_s() - 2.5;
+    ctx18g.t_cc_sync_m = async_return_tune_m;
+    ctx18g.t_cc_tune_m = async_return_tune_m;
+    s18g.last_cc_sync_time_m = async_return_tune_m;
+    s18g.p25_last_cc_msg_time_m = async_return_tune_m - 0.25;
+    g_result_tune_to_cc_calls = 0;
+    p25_sm_tick_ctx(&ctx18g, &o18g, &s18g);
+    assert(g_result_tune_to_cc_calls == 0);
+    assert(ctx18g.state == P25_SM_ON_CC);
+    assert(ctx18g.cc_sync_pending == 1);
+
+    // Configured grace values below the hunt cap, including zero, remain authoritative.
+    static dsd_opts o18h;
+    static dsd_state s18h;
+    DSD_MEMSET(&o18h, 0, sizeof(o18h));
+    DSD_MEMSET(&s18h, 0, sizeof(s18h));
+    o18h.trunk_enable = 1;
+    s18h.p25_cc_freq = 851000000;
+    s18h.trunk_cc_freq = 851000000;
+    p25_sm_ctx_t ctx18h;
+    p25_sm_init_ctx(&ctx18h, &o18h, &s18h);
+    ctx18h.config.cc_grace_s = 1.0;
+    assert(p25_sm_restart_pending_cc_acquisition(&ctx18h, &o18h, &s18h, dsd_time_now_monotonic_s(), "test-short-return")
+           == 1);
+    const double short_return_tune_m = dsd_time_now_monotonic_s() - 1.5;
+    ctx18h.t_cc_sync_m = short_return_tune_m;
+    ctx18h.t_cc_tune_m = short_return_tune_m;
+    s18h.last_cc_sync_time_m = short_return_tune_m;
+    s18h.p25_last_cc_msg_time_m = short_return_tune_m - 0.25;
+    g_result_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    g_result_tune_to_cc_calls = 0;
+    p25_sm_tick_ctx(&ctx18h, &o18h, &s18h);
+    assert(g_result_tune_to_cc_calls == 1);
+    assert(ctx18h.state == P25_SM_HUNTING);
+
+    static dsd_opts o18i;
+    static dsd_state s18i;
+    DSD_MEMSET(&o18i, 0, sizeof(o18i));
+    DSD_MEMSET(&s18i, 0, sizeof(s18i));
+    o18i.trunk_enable = 1;
+    s18i.p25_cc_freq = 851000000;
+    s18i.trunk_cc_freq = 851000000;
+    p25_sm_ctx_t ctx18i;
+    p25_sm_init_ctx(&ctx18i, &o18i, &s18i);
+    ctx18i.config.cc_grace_s = 0.0;
+    assert(p25_sm_restart_pending_cc_acquisition(&ctx18i, &o18i, &s18i, dsd_time_now_monotonic_s(), "test-zero-return")
+           == 1);
+    const double zero_return_tune_m = dsd_time_now_monotonic_s() - 0.1;
+    ctx18i.t_cc_sync_m = zero_return_tune_m;
+    ctx18i.t_cc_tune_m = zero_return_tune_m;
+    s18i.last_cc_sync_time_m = zero_return_tune_m;
+    s18i.p25_last_cc_msg_time_m = zero_return_tune_m - 0.05;
+    g_result_tune_to_cc_calls = 0;
+    p25_sm_tick_ctx(&ctx18i, &o18i, &s18i);
+    assert(g_result_tune_to_cc_calls == 1);
+    assert(ctx18i.state == P25_SM_HUNTING);
+    g_result_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
 
     // 25) Stale SM context after a no-carrier VC clear must not skip the next same-RF tune.
     static dsd_opts o19a;

--- a/tests/protocol/p25/test_p25_sm_diag_log.c
+++ b/tests/protocol/p25/test_p25_sm_diag_log.c
@@ -198,10 +198,14 @@ main(void) {
     rc |= expect_contains(output, "event=grant_tune_result");
     rc |= expect_contains(output, "result=ok");
     rc |= expect_contains(output, "event=release_cc_result");
+    rc |= expect_contains(output, "origin=return");
+    rc |= expect_contains(output, "effective_grace=5.000");
     rc |= expect_contains(output, "event=cc_lost");
     rc |= expect_contains(output, "reason=timeout");
     rc |= expect_contains(output, "event=hunt_tune_attempt");
     rc |= expect_contains(output, "source=current-site-candidate");
+    rc |= expect_contains(output, "origin=hunt-probe");
+    rc |= expect_contains(output, "effective_grace=2.000");
     rc |= expect_contains(output, "freq=852000000");
 
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});

--- a/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
+++ b/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
@@ -418,6 +418,8 @@ matrix_drive_to_cc(matrix_fixture* fixture, const matrix_mode_case* mode, const 
                             script->name, "completed return starts acquisition timer");
     }
     rc |= matrix_expect(fixture->ctx.state == P25_SM_ON_CC, mode->name, flow->name, script->name, "returned to ON_CC");
+    rc |= matrix_expect(fixture->ctx.cc_acquisition_origin == P25_SM_CC_ACQUISITION_RETURN, mode->name, flow->name,
+                        script->name, "return uses full-grace acquisition origin");
     rc |=
         matrix_expect(fixture->opts->trunk_is_tuned == 0, mode->name, flow->name, script->name, "tuned flags cleared");
     rc |= matrix_expect(fixture->state->p25_vc_freq[0] == 0 && fixture->state->p25_vc_freq[1] == 0, mode->name,
@@ -741,6 +743,8 @@ matrix_run_cc_hunt_case(const matrix_mode_case* mode, dsd_trunk_tune_result firs
     if (dsd_trunk_tune_result_is_ok(first_result)) {
         rc |= matrix_expect(fixture->ctx.state == P25_SM_ON_CC, mode->name, "cc-hunt", result_name,
                             "accepted cc hunt returns ON_CC");
+        rc |= matrix_expect(fixture->ctx.cc_acquisition_origin == P25_SM_CC_ACQUISITION_HUNT_PROBE, mode->name,
+                            "cc-hunt", result_name, "accepted cc hunt uses probe acquisition origin");
         rc |= matrix_expect(fixture->state->p25_cc_eval_freq == candidate, mode->name, "cc-hunt", result_name,
                             "accepted candidate is under evaluation");
         if (first_result == DSD_TRUNK_TUNE_RESULT_PENDING) {


### PR DESCRIPTION
## Summary

- Preserve the configured P25 control-channel grace period for normal returns from voice channels, no-carrier recovery, and external retunes.
- Retain the two-second acquisition bound for active hunt probes so bad candidates continue to advance and cool down promptly.
- Track acquisition origin across synchronous and asynchronous tuner completion and report the origin and effective grace in diagnostics.

## Root Cause

The post-tune acquisition watchdog applied `min(cc_grace_s, 2.0)` to every pending control-channel acquisition. That hunt-oriented bound also covered successful returns to the known primary control channel, causing a normal five-second return window to enter hunting after roughly two seconds and redundantly retune the same frequency.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented. This is a narrow state-machine change with focused regression coverage and sanitizer validation.
- [x] High-risk areas touched are marked: none.
- [x] Outside review was requested when available, or unavailability is documented. This draft is open for maintainer review.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New protocol behavior includes focused tests for synchronous and asynchronous returns, hunt probes, short and zero grace values, no-carrier recovery, and trunk-scan dwell restoration.
- [x] Protocol changes received extra scrutiny around grant gating, tune completion, candidate cooldowns, and existing NAC mismatch behavior.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. No suppressions were added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j 2`
- [x] `ctest --preset dev-debug --output-on-failure -j 2` — 460 passed
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` — not required for this narrow change
- [ ] `tools/cmake_format_check.sh` — no CMake changes
- [ ] `tools/zizmor.sh` — no workflow changes
- [ ] `tools/osv_scan.sh` — no dependency changes
- [x] The pre-push gate ran secret-redaction, workflow-pin, download-pin, and vcpkg-overlay guardrails
- [x] `cmake --build --preset asan-ubsan-debug -j 2`
- [x] ASan/UBSan P25 and affected engine regression set — 109 passed
- [ ] Live Motorola-system diagnostic validation — requires system access

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: none; diagnostics now include acquisition origin and effective grace.
- Compatibility or packaging impact: none; no public function signatures, options, or environment variables changed.
