### PR TITLE
p25: restore encrypted voice frame logging

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,7 +107,7 @@ Tip: If paths or names contain spaces, wrap them in single quotes.
 - `--frontend terminal` Use the terminal UI (`-N` is the supported short alias)
 - `--frontend native` remains accepted and maps to headless mode. The retired native provider was a non-rendering
   scaffold; this keeps existing invocations working without restoring its provider/threading layer.
-- `-Z` Log MBE/PDU payloads to the console (verbose)
+- `-Z` Log MBE/PDU payloads to the console (verbose), including encrypted P25 voice frames when media is gated
 - `--frame-log <file>` Append one-line timestamped frame traces (separate from event log)
 - `--p25-sm-log <file>` Append one-line P25 state-machine decision diagnostics (separate from stdout/stderr, event log, and frame log)
 - `-O` List PulseAudio input sources and output sinks

--- a/include/dsd-neo/core/vocoder.h
+++ b/include/dsd-neo/core/vocoder.h
@@ -41,6 +41,13 @@ void processMbeFrame(dsd_opts* opts, dsd_state* state, char imbe_fr[8][23], char
                      char imbe7100_fr[7][24]);
 void processMbeFrameSoft(dsd_opts* opts, dsd_state* state, dsd_vocoder_soft_bit imbe_fr[8][23],
                          dsd_vocoder_soft_bit ambe_fr[4][24], dsd_vocoder_soft_bit imbe7100_fr[7][24]);
+
+/** Decode and log one soft IMBE frame without synthesizing or emitting media. */
+void dsd_mbe_log_imbe_soft_frame(dsd_opts* opts, dsd_state* state, dsd_vocoder_soft_bit imbe_fr[8][23]);
+
+/** Decode and log one soft AMBE frame without synthesizing or emitting media. */
+void dsd_mbe_log_ambe_soft_frame(dsd_opts* opts, dsd_state* state, dsd_vocoder_soft_bit ambe_fr[4][24]);
+
 void playMbeFiles(dsd_opts* opts, dsd_state* state, int argc, char** argv);
 
 /** Purge queued/working audio and vocoder history for one logical voice slot. */

--- a/src/core/vocoder/dsd_mbe.c
+++ b/src/core/vocoder/dsd_mbe.c
@@ -187,6 +187,34 @@ decode_ambe2450_frame(int* errs, int* errs2, char ambe_fr[4][24], dsd_vocoder_so
     return store_decode_result(ret, errs, errs2, result) >= 0;
 }
 
+void
+dsd_mbe_log_imbe_soft_frame(dsd_opts* opts, dsd_state* state, dsd_vocoder_soft_bit imbe_fr[8][23]) {
+    if (!state || !imbe_fr || !dsd_frame_detail_enabled(opts)) {
+        return;
+    }
+
+    char imbe_d[88] = {0};
+    mbe_process_result result;
+    if (decode_imbe7200_frame(state, NULL, imbe_fr, imbe_d, &result)) {
+        PrintIMBEData(opts, state, imbe_d);
+    }
+}
+
+void
+dsd_mbe_log_ambe_soft_frame(dsd_opts* opts, dsd_state* state, dsd_vocoder_soft_bit ambe_fr[4][24]) {
+    if (!state || !ambe_fr || !dsd_frame_detail_enabled(opts)) {
+        return;
+    }
+
+    int* errs = state->currentslot == 1 ? &state->errsR : &state->errs;
+    int* errs2 = state->currentslot == 1 ? &state->errs2R : &state->errs2;
+    char ambe_d[49] = {0};
+    mbe_process_result result;
+    if (decode_ambe2450_frame(errs, errs2, NULL, ambe_fr, ambe_d, &result)) {
+        PrintAMBEData(opts, state, ambe_d);
+    }
+}
+
 static void
 update_p25_p1_voice_err_hist(dsd_state* state) {
     int len = state->p25_p1_voice_err_hist_len > 0 ? state->p25_p1_voice_err_hist_len : 50;

--- a/src/protocol/p25/phase1/p25p1_ldu.c
+++ b/src/protocol/p25/phase1/p25p1_ldu.c
@@ -76,6 +76,7 @@ process_imbe_or_skip_non_standard(dsd_opts* opts, dsd_state* state, char imbe_fr
         return;
     }
     if (!p25_crypto_audio_permitted(opts, state, 0)) {
+        dsd_mbe_log_imbe_soft_frame(opts, state, imbe_soft_fr);
         DSD_MEMSET(state->audio_out_temp_buf, 0, sizeof(state->audio_out_temp_buf));
         return;
     }

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -960,6 +960,7 @@ p25p2_decode_and_store_voice_frame(dsd_opts* opts, dsd_state* state, dsd_vocoder
         return;
     }
     if (!p25_crypto_audio_permitted(opts, state, slot) || !state->p25_p2_audio_allowed[slot]) {
+        dsd_mbe_log_ambe_soft_frame(opts, state, ambe_soft);
         p25p2_zero_voice_frame(state, frame_index);
         return;
     }

--- a/tests/core/test_core_frame_log.c
+++ b/tests/core/test_core_frame_log.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/core/frame.h>
 #include <dsd-neo/core/init.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/vocoder.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -188,6 +189,62 @@ test_payload_detail_helpers_write_structured_frame_log(void) {
     }
     if (strstr(buf, "FRAME AMBE slot=2 data=FFFFFFFFFFFF80 err=[C] [D]") == NULL) {
         DSD_FPRINTF(stderr, "AMBE frame-log payload mismatch: %s\n", buf);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_gated_soft_voice_helpers_log_without_media_processing(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    initOpts(&opts);
+
+    char path[DSD_TEST_PATH_MAX];
+    int fd = dsd_test_mkstemp(path, sizeof path, "dsdneo_gated_voice_frame_log");
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "dsd_test_mkstemp failed: %s\n", strerror(errno));
+        return 1;
+    }
+    (void)dsd_close(fd);
+
+    DSD_SNPRINTF(opts.frame_log_file, sizeof opts.frame_log_file, "%s", path);
+    opts.frame_log_file[sizeof opts.frame_log_file - 1] = '\0';
+
+    dsd_vocoder_soft_bit imbe_soft[8][23] = {{{0}}};
+    dsd_vocoder_soft_bit ambe_soft[4][24] = {{{0}}};
+    for (int row = 0; row < 8; row++) {
+        for (int bit = 0; bit < 23; bit++) {
+            imbe_soft[row][bit].reliability = 255;
+        }
+    }
+    for (int row = 0; row < 4; row++) {
+        for (int bit = 0; bit < 24; bit++) {
+            ambe_soft[row][bit].reliability = 255;
+        }
+    }
+
+    state.p25vc = 7;
+    state.audio_out_temp_buf[0] = 0.25F;
+    dsd_mbe_log_imbe_soft_frame(&opts, &state, imbe_soft);
+    state.currentslot = 1;
+    dsd_mbe_log_ambe_soft_frame(&opts, &state, ambe_soft);
+    dsd_frame_log_close(&opts);
+
+    char buf[1024];
+    int rc = read_text_file(path, buf, sizeof buf);
+    (void)remove(path);
+    if (rc != 0) {
+        return 1;
+    }
+    if (strstr(buf, "FRAME IMBE slot=1") == NULL || strstr(buf, "FRAME AMBE slot=2") == NULL) {
+        DSD_FPRINTF(stderr, "gated soft voice frame log mismatch: %s\n", buf);
+        return 1;
+    }
+    if (state.p25vc != 7 || state.audio_out_temp_buf[0] != 0.25F) {
+        DSD_FPRINTF(stderr, "gated soft voice logging changed media state\n");
         return 1;
     }
     return 0;
@@ -536,6 +593,9 @@ main(void) {
         return 1;
     }
     if (test_payload_detail_helpers_write_structured_frame_log() != 0) {
+        return 1;
+    }
+    if (test_gated_soft_voice_helpers_log_without_media_processing() != 0) {
         return 1;
     }
 #if !defined(_WIN32)

--- a/tests/protocol/p25/test_p25_p1_ldu_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_ldu_helpers.c
@@ -36,6 +36,7 @@ static int g_dibit_sequence_len;
 static int g_dibit_sequence[80];
 static int g_open_mbe_calls;
 static int g_vocoder_calls;
+static int g_imbe_log_calls;
 static dsd_vocoder_soft_bit g_last_imbe_soft[8][23];
 static int g_hard_hamming_result;
 static int g_soft_hamming_result;
@@ -87,6 +88,16 @@ processMbeFrameSoft(dsd_opts* opts, dsd_state* state, dsd_vocoder_soft_bit imbe_
     (void)imbe7100_fr;
     g_vocoder_calls++;
     DSD_MEMCPY(g_last_imbe_soft, imbe_fr, sizeof(g_last_imbe_soft));
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_mbe_log_imbe_soft_frame(dsd_opts* opts, dsd_state* state, dsd_vocoder_soft_bit imbe_fr[8][23]) {
+    (void)state;
+    (void)imbe_fr;
+    if (opts && (opts->payload == 1 || opts->frame_log_file[0] != '\0')) {
+        g_imbe_log_calls++;
+    }
 }
 
 void
@@ -298,6 +309,7 @@ test_ldu_imbe_skip_and_encryption_flag(void) {
 
     g_vocoder_calls = 0;
     g_open_mbe_calls = 0;
+    g_imbe_log_calls = 0;
     process_imbe_or_skip_non_standard(&opts, &state, imbe_fr, imbe_soft_fr);
     int rc = 0;
     rc |= expect_int("non-standard c0 skipped", g_vocoder_calls, 0);
@@ -307,7 +319,15 @@ test_ldu_imbe_skip_and_encryption_flag(void) {
     process_imbe_or_skip_non_standard(&opts, &state, imbe_fr, imbe_soft_fr);
     rc |= expect_int("pending crypto does not open recording", g_open_mbe_calls, 0);
     rc |= expect_int("pending crypto does not dispatch vocoder", g_vocoder_calls, 0);
+    rc |= expect_int("pending crypto without detail does not log IMBE", g_imbe_log_calls, 0);
 
+    opts.payload = 1;
+    process_imbe_or_skip_non_standard(&opts, &state, imbe_fr, imbe_soft_fr);
+    rc |= expect_int("pending crypto payload detail logs IMBE", g_imbe_log_calls, 1);
+    rc |= expect_int("pending crypto payload detail keeps recording closed", g_open_mbe_calls, 0);
+    rc |= expect_int("pending crypto payload detail bypasses vocoder", g_vocoder_calls, 0);
+
+    opts.payload = 0;
     opts.unmute_encrypted_p25 = 1;
     process_imbe_or_skip_non_standard(&opts, &state, imbe_fr, imbe_soft_fr);
     rc |= expect_int("explicit P25 unmute dispatches pending crypto", g_vocoder_calls, 1);

--- a/tests/protocol/p25/test_p25_p2_2v_first_frame_gate.c
+++ b/tests/protocol/p25/test_p25_p2_2v_first_frame_gate.c
@@ -240,6 +240,7 @@ skipDibit(dsd_opts* opts, dsd_state* state, int count) {
 static int g_mbe_calls = 0;
 static int g_mbe_hard_calls = 0;
 static int g_mbe_soft_calls = 0;
+static int g_ambe_log_calls = 0;
 static int g_mbe_algid[2];
 static int g_mbe_keyid[2];
 
@@ -271,6 +272,15 @@ processMbeFrameSoft(dsd_opts* opts, dsd_state* state, dsd_vocoder_soft_bit imbe_
     g_mbe_soft_calls++;
 }
 
+void
+dsd_mbe_log_ambe_soft_frame(dsd_opts* opts, dsd_state* state, dsd_vocoder_soft_bit ambe_fr[4][24]) {
+    (void)state;
+    (void)ambe_fr;
+    if (opts && (opts->payload == 1 || opts->frame_log_file[0] != '\0')) {
+        g_ambe_log_calls++;
+    }
+}
+
 static int
 expect_eq(const char* tag, int got, int want) {
     if (got != want) {
@@ -295,6 +305,7 @@ reset_mbe_calls(void) {
     g_mbe_calls = 0;
     g_mbe_hard_calls = 0;
     g_mbe_soft_calls = 0;
+    g_ambe_log_calls = 0;
     DSD_MEMSET(g_mbe_algid, 0, sizeof(g_mbe_algid));
     DSD_MEMSET(g_mbe_keyid, 0, sizeof(g_mbe_keyid));
     g_open_mbe_calls[0] = 0;
@@ -343,6 +354,17 @@ main(void) {
     rc |= expect_eq("slot0 gated: mbe calls", g_mbe_calls, 0);
     rc |= expect_eq("slot0 gated: soft mbe calls", g_mbe_soft_calls, 0);
     rc |= expect_eq("slot0 gated: hard mbe calls", g_mbe_hard_calls, 0);
+    rc |= expect_eq("slot0 gated: AMBE log calls", g_ambe_log_calls, 0);
+
+    // Payload diagnostics remain available while encrypted media stays gated.
+    reset_state(&opts, &st);
+    opts.payload = 1;
+    st.currentslot = 0;
+    st.p25_p2_audio_allowed[0] = 0;
+    reset_mbe_calls();
+    process_2V(&opts, &st);
+    rc |= expect_eq("slot0 gated detail: mbe calls", g_mbe_calls, 0);
+    rc |= expect_eq("slot0 gated detail: AMBE log calls", g_ambe_log_calls, 2);
 
     // Slot 0: audio allowed -> expect 2 MBE calls (both 2V subframes decoded)
     reset_state(&opts, &st);

--- a/tests/protocol/p25/test_p25_p2_reliability.c
+++ b/tests/protocol/p25/test_p25_p2_reliability.c
@@ -206,6 +206,14 @@ processMbeFrameSoft(dsd_opts* opts, dsd_state* state, dsd_vocoder_soft_bit imbe_
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_mbe_log_ambe_soft_frame(dsd_opts* opts, dsd_state* state, dsd_vocoder_soft_bit ambe_fr[4][24]) {
+    (void)opts;
+    (void)state;
+    (void)ambe_fr;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 LFSRP(dsd_state* state) {
     (void)state;
     g_lfsrp_calls++;


### PR DESCRIPTION
## Summary

- Restore IMBE/AMBE payload diagnostics for encrypted P25 Phase 1 and Phase 2 voice frames when media output is gated.
- Add diagnostic-only soft-frame helpers so `-Z` and `--frame-log` retain visibility without synthesizing audio, opening recordings, or incrementing voice counters.
- Add focused regression coverage for both P25 phases and document the behavior.

The regression was caused by encrypted-media gate returns occurring before the existing vocoder path emitted frame diagnostics.

Fixes #242

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: crypto gate integration; no cryptographic algorithm or key-handling changes.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

The line-scoped `misc-use-internal-linkage` suppressions apply only to test stubs that must satisfy externally linked production symbols.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes
- [ ] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes

All 460 CTest cases pass. The push guardrails also passed the changed-path static-analysis checks.

## Risk

- Security/dependency impact: none; encrypted-media and recording gates remain enforced, with no crypto or key-handling changes.
- CLI/UI behavior impact: `-Z` and `--frame-log` again show gated encrypted P25 IMBE/AMBE payload diagnostics; encrypted audio remains muted by default.
- Compatibility or packaging impact: none.
