### PR TITLE
release: prepare 2.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(dsd-neo VERSION 2.3.0 LANGUAGES C CXX)
+project(dsd-neo VERSION 2.4.0 LANGUAGES C CXX)
 if(POLICY CMP0083)
     cmake_policy(SET CMP0083 NEW)
 endif()

--- a/include/dsd-neo/protocol/nxdn/nxdn_const.h
+++ b/include/dsd-neo/protocol/nxdn/nxdn_const.h
@@ -3,6 +3,10 @@
  * @file
  * @brief NXDN protocol constants and lookup tables.
  */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_PROTOCOL_NXDN_NXDN_CONST_H_
+#define DSD_NEO_INCLUDE_DSD_NEO_PROTOCOL_NXDN_NXDN_CONST_H_
+
 #include <stdint.h>
 // Portions Below from Osmocom OP25
 // NXDN Encoder (C) Copyright 2019 Max H. Parke KA1RBI
@@ -67,3 +71,5 @@ static const uint16_t PERM_12_29[] = {
     309, 321, 333, 345, 10,  22,  34,  46,  58,  70,  82,  94,  106, 118, 130, 142, 154, 166, 178, 190, 202, 214,
     226, 238, 250, 262, 274, 286, 298, 310, 322, 334, 346, 11,  23,  35,  47,  59,  71,  83,  95,  107, 119, 131,
     143, 155, 167, 179, 191, 203, 215, 227, 239, 251, 263, 275, 287, 299, 311, 323, 335, 347};
+
+#endif /* DSD_NEO_INCLUDE_DSD_NEO_PROTOCOL_NXDN_NXDN_CONST_H_ */

--- a/tests/protocol/nxdn/nxdn_const_reinclude.h
+++ b/tests/protocol/nxdn/nxdn_const_reinclude.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DSD_NEO_TESTS_PROTOCOL_NXDN_NXDN_CONST_REINCLUDE_H_
+#define DSD_NEO_TESTS_PROTOCOL_NXDN_NXDN_CONST_REINCLUDE_H_
+
+#include <dsd-neo/protocol/nxdn/nxdn_const.h>
+
+#endif /* DSD_NEO_TESTS_PROTOCOL_NXDN_NXDN_CONST_REINCLUDE_H_ */

--- a/tests/protocol/nxdn/test_nxdn_deperm_primitives.c
+++ b/tests/protocol/nxdn/test_nxdn_deperm_primitives.c
@@ -20,6 +20,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "nxdn_const_reinclude.h" // IWYU pragma: keep
 #include "nxdn_internal.h"
 
 static int

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "dsd-neo",
-  "version-string": "2.3.0",
+  "version-string": "2.4.0",
   "builtin-baseline": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3",
   "description": "Digital Speech Decoder: DSD-neo",
   "homepage": "https://github.com/arancormonk/dsd-neo",


### PR DESCRIPTION
## Summary

- bump the project and vcpkg versions to 2.4.0
- add the missing NXDN constants header guard reported by CodeQL alert 1706
- add a compile-time repeated-inclusion regression

## Impact

Prepares the 2.4.0 release and makes repeated inclusion of the NXDN constants header safe.

## Validation

- `cmake --preset dev-debug`
- `cmake --build --preset dev-debug -j`
- `ctest --preset dev-debug --output-on-failure` (460/460 passed)
- `tools/cmake_format_check.sh`
- repository pre-push audits