### PR TITLE
ui: optimize event history snapshots

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -58,7 +58,7 @@
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "BUILD_TESTING": "OFF",
         "DSD_ENABLE_LTO": "OFF",
-        "DSD_ENABLE_FAST_MATH": "ON",
+        "DSD_ENABLE_FAST_MATH": "OFF",
         "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG -fno-omit-frame-pointer",
         "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O2 -g -DNDEBUG -fno-omit-frame-pointer"
       }

--- a/include/dsd-neo/core/events.h
+++ b/include/dsd-neo/core/events.h
@@ -28,6 +28,18 @@ void init_event_history(Event_History_I* event_struct, uint8_t start, uint8_t st
 void push_event_history(Event_History_I* event_struct);
 
 static inline void
+dsd_event_history_mark_dirty(Event_History_I* event_struct) {
+    if (event_struct == NULL) {
+        return;
+    }
+
+    event_struct->revision++;
+    if (event_struct->revision == 0U) {
+        event_struct->revision = 1U;
+    }
+}
+
+static inline void
 dsd_event_history_item_set_metadata(Event_History* item, dsd_event_severity severity, dsd_event_category category) {
     if (item == NULL) {
         return;

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -144,6 +144,7 @@ typedef struct {
 //event history for number of each items above
 typedef struct Event_History_I {
     Event_History Event_History_Items[255];
+    uint64_t revision;
 } Event_History_I;
 
 //new audio filter stuff from: https://github.com/NedSimao/FilteringLibrary

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -2871,6 +2871,7 @@ apply_cmd_lockout_slot(dsd_opts* opts, dsd_state* state, const struct dsd_app_co
     DSD_SNPRINTF(state->event_history_s[eh_slot].Event_History_Items[0].internal_str,
                  sizeof state->event_history_s[eh_slot].Event_History_Items[0].internal_str,
                  "Target: %d; has been locked out; User Lock Out.", tg);
+    dsd_event_history_mark_dirty(&state->event_history_s[eh_slot]);
     watchdog_event_current(opts, state, eh_slot);
     DSD_SNPRINTF(state->call_string[eh_slot], sizeof state->call_string[eh_slot], "%s",
                  "                     "); // 21 spaces
@@ -2965,6 +2966,7 @@ ui_cmd_handle_symcap_save(dsd_opts* opts, dsd_state* state, const struct dsd_app
         watchdog_event_datacall(opts, state, 0xFFFFFF, 0xFFFFFF, event_str, 0);
         dsd_event_history_item_set_metadata(&state->event_history_s[0].Event_History_Items[0], DSD_EVENT_SEVERITY_INFO,
                                             DSD_EVENT_CATEGORY_SYSTEM);
+        dsd_event_history_mark_dirty(&state->event_history_s[0]);
         state->lastsrc = 0;
         watchdog_event_history(opts, state, 0);
         watchdog_event_current(opts, state, 0);
@@ -2986,6 +2988,7 @@ ui_cmd_handle_symcap_stop(dsd_opts* opts, dsd_state* state, const struct dsd_app
             watchdog_event_datacall(opts, state, 0xFFFFFF, 0xFFFFFF, event_str, 0);
             dsd_event_history_item_set_metadata(&state->event_history_s[0].Event_History_Items[0],
                                                 DSD_EVENT_SEVERITY_INFO, DSD_EVENT_CATEGORY_SYSTEM);
+            dsd_event_history_mark_dirty(&state->event_history_s[0]);
             state->lastsrc = 0;
             watchdog_event_history(opts, state, 0);
             watchdog_event_current(opts, state, 0);

--- a/src/app_control/snapshot_internal.h
+++ b/src/app_control/snapshot_internal.h
@@ -9,6 +9,10 @@
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 
+#ifdef DSD_NEO_TEST_HOOKS
+#include <stdint.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -21,6 +25,16 @@ void dsd_app_telemetry_publish_snapshot(const dsd_state* state);
 void dsd_app_telemetry_publish_opts_snapshot(const dsd_opts* opts);
 
 void dsd_app_request_redraw(void);
+
+#ifdef DSD_NEO_TEST_HOOKS
+typedef struct {
+    uint64_t source_to_published[2];
+    uint64_t published_to_consumer[2];
+} dsd_app_snapshot_event_history_copy_counts;
+
+void dsd_app_snapshot_test_reset_event_history_copy_counts(void);
+void dsd_app_snapshot_test_get_event_history_copy_counts(dsd_app_snapshot_event_history_copy_counts* counts);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/app_control/ui_snapshot.c
+++ b/src/app_control/ui_snapshot.c
@@ -11,7 +11,6 @@
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <string.h>
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "snapshot_internal.h"
@@ -28,9 +27,20 @@ static dsd_mutex_t g_mu;
 static atomic_int g_mu_init = 0;
 static unsigned long long g_pub_seq = 0;
 static unsigned long long g_consume_seq = 0;
-static unsigned long long g_pub_eh_seq = 0;
-static unsigned long long g_consume_eh_seq = 0;
+static uint64_t g_pub_eh_seq[2] = {0};
+static uint64_t g_consume_eh_seq[2] = {0};
+static uint64_t g_pub_eh_source_revision[2] = {0};
+static const Event_History_I* g_pub_eh_source = NULL;
 static int g_pub_eh_present = 0;
+
+#ifdef DSD_NEO_TEST_HOOKS
+static dsd_app_snapshot_event_history_copy_counts g_eh_copy_counts;
+#define UI_SNAPSHOT_COUNT_SOURCE_COPY(slot)   g_eh_copy_counts.source_to_published[(slot)]++
+#define UI_SNAPSHOT_COUNT_CONSUMER_COPY(slot) g_eh_copy_counts.published_to_consumer[(slot)]++
+#else
+#define UI_SNAPSHOT_COUNT_SOURCE_COPY(slot)   ((void)(slot))
+#define UI_SNAPSHOT_COUNT_CONSUMER_COPY(slot) ((void)(slot))
+#endif
 
 #define UI_SNAPSHOT_FIELD_END(field) (offsetof(dsd_state, field) + sizeof(((dsd_state*)0)->field))
 #define UI_SNAPSHOT_COPY_RANGE(dst, src, first, last)                                                                  \
@@ -114,85 +124,6 @@ ui_snapshot_copy_render_state(dsd_state* dst, const dsd_state* src) {
     UI_SNAPSHOT_COPY_RANGE(dst, src, vertex_ks_count, ui_msg);
 }
 
-static int
-ui_event_history_item_equal(const Event_History* lhs, const Event_History* rhs) {
-    if (lhs == NULL || rhs == NULL) {
-        return 0;
-    }
-
-    const int scalar_checks[] = {
-        lhs->write == rhs->write,
-        lhs->color_pair == rhs->color_pair,
-        lhs->severity == rhs->severity,
-        lhs->category == rhs->category,
-        lhs->systype == rhs->systype,
-        lhs->subtype == rhs->subtype,
-        lhs->sys_id1 == rhs->sys_id1,
-        lhs->sys_id2 == rhs->sys_id2,
-        lhs->sys_id3 == rhs->sys_id3,
-        lhs->sys_id4 == rhs->sys_id4,
-        lhs->sys_id5 == rhs->sys_id5,
-        lhs->gi == rhs->gi,
-        lhs->enc == rhs->enc,
-        lhs->enc_alg == rhs->enc_alg,
-        lhs->enc_key == rhs->enc_key,
-        lhs->mi == rhs->mi,
-        lhs->svc == rhs->svc,
-        lhs->source_id == rhs->source_id,
-        lhs->target_id == rhs->target_id,
-        lhs->channel == rhs->channel,
-        lhs->event_time == rhs->event_time,
-    };
-    const size_t scalar_count = sizeof(scalar_checks) / sizeof(scalar_checks[0]);
-    for (size_t i = 0; i < scalar_count; i++) {
-        if (!scalar_checks[i]) {
-            return 0;
-        }
-    }
-
-    struct UiByteSpan {
-        const void* left;
-        const void* right;
-        size_t size;
-    };
-    const struct UiByteSpan spans[] = {
-        {lhs->src_str, rhs->src_str, sizeof(lhs->src_str)},
-        {lhs->tgt_str, rhs->tgt_str, sizeof(lhs->tgt_str)},
-        {lhs->t_name, rhs->t_name, sizeof(lhs->t_name)},
-        {lhs->s_name, rhs->s_name, sizeof(lhs->s_name)},
-        {lhs->t_mode, rhs->t_mode, sizeof(lhs->t_mode)},
-        {lhs->s_mode, rhs->s_mode, sizeof(lhs->s_mode)},
-        {lhs->pdu, rhs->pdu, sizeof(lhs->pdu)},
-        {lhs->sysid_string, rhs->sysid_string, sizeof(lhs->sysid_string)},
-        {lhs->alias, rhs->alias, sizeof(lhs->alias)},
-        {lhs->gps_s, rhs->gps_s, sizeof(lhs->gps_s)},
-        {lhs->text_message, rhs->text_message, sizeof(lhs->text_message)},
-        {lhs->event_string, rhs->event_string, sizeof(lhs->event_string)},
-        {lhs->internal_str, rhs->internal_str, sizeof(lhs->internal_str)},
-    };
-    const size_t span_count = sizeof(spans) / sizeof(spans[0]);
-    for (size_t i = 0; i < span_count; i++) {
-        if (memcmp(spans[i].left, spans[i].right, spans[i].size) != 0) {
-            return 0;
-        }
-    }
-    return 1;
-}
-
-static int
-ui_event_history_slot_equal(const Event_History_I* lhs, const Event_History_I* rhs) {
-    if (lhs == NULL || rhs == NULL) {
-        return 0;
-    }
-    const size_t count = sizeof(lhs->Event_History_Items) / sizeof(lhs->Event_History_Items[0]);
-    for (size_t i = 0; i < count; i++) {
-        if (!ui_event_history_item_equal(&lhs->Event_History_Items[i], &rhs->Event_History_Items[i])) {
-            return 0;
-        }
-    }
-    return 1;
-}
-
 static void
 ensure_mu_init(void) {
     int expected = 0;
@@ -200,6 +131,27 @@ ensure_mu_init(void) {
         dsd_mutex_init(&g_mu);
     }
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_app_snapshot_test_reset_event_history_copy_counts(void) {
+    ensure_mu_init();
+    dsd_mutex_lock(&g_mu);
+    DSD_MEMSET(&g_eh_copy_counts, 0, sizeof(g_eh_copy_counts));
+    dsd_mutex_unlock(&g_mu);
+}
+
+void
+dsd_app_snapshot_test_get_event_history_copy_counts(dsd_app_snapshot_event_history_copy_counts* counts) {
+    if (counts == NULL) {
+        return;
+    }
+    ensure_mu_init();
+    dsd_mutex_lock(&g_mu);
+    *counts = g_eh_copy_counts;
+    dsd_mutex_unlock(&g_mu);
+}
+#endif
 
 void
 dsd_app_telemetry_publish_snapshot(const dsd_state* state) {
@@ -210,27 +162,23 @@ dsd_app_telemetry_publish_snapshot(const dsd_state* state) {
     dsd_mutex_lock(&g_mu);
     ui_snapshot_copy_render_state(&g_pub, state);
     ui_snapshot_copy_trunk_cc_candidates(&g_pub, state, &g_pub_cc_candidates);
-    // Deep copy pointer-backed UI data (event history for 2 slots) only when changed.
-    // Event history storage is zero-initialized and copied as a whole slot.
+    // Deep copy pointer-backed UI data (event history for 2 slots) only when its revision changes.
     if (state->event_history_s != NULL) {
-        int eh_changed = g_pub_eh_present ? 0 : 1;
-        if (!g_have || !ui_event_history_slot_equal(&g_pub_eh[0], &state->event_history_s[0])) {
-            DSD_MEMCPY(&g_pub_eh[0], &state->event_history_s[0], sizeof(Event_History_I));
-            eh_changed = 1;
+        const int force_copy = !g_have || !g_pub_eh_present || g_pub_eh_source != state->event_history_s;
+        for (size_t slot = 0; slot < 2U; slot++) {
+            const uint64_t source_revision = state->event_history_s[slot].revision;
+            if (force_copy || g_pub_eh_source_revision[slot] != source_revision) {
+                DSD_MEMCPY(&g_pub_eh[slot], &state->event_history_s[slot], sizeof(Event_History_I));
+                g_pub_eh_source_revision[slot] = source_revision;
+                g_pub_eh_seq[slot]++;
+                UI_SNAPSHOT_COUNT_SOURCE_COPY(slot);
+            }
         }
-        if (!g_have || !ui_event_history_slot_equal(&g_pub_eh[1], &state->event_history_s[1])) {
-            DSD_MEMCPY(&g_pub_eh[1], &state->event_history_s[1], sizeof(Event_History_I));
-            eh_changed = 1;
-        }
-        if (eh_changed) {
-            g_pub_eh_seq++;
-        }
+        g_pub_eh_source = state->event_history_s;
         g_pub_eh_present = 1;
         g_pub.event_history_s = g_pub_eh;
     } else {
-        if (g_pub_eh_present) {
-            g_pub_eh_seq++;
-        }
+        g_pub_eh_source = NULL;
         g_pub_eh_present = 0;
         g_pub.event_history_s = NULL;
     }
@@ -254,10 +202,12 @@ dsd_app_get_latest_snapshot(void) {
     }
     // Deep copy event history only when the published history changed.
     if (g_pub.event_history_s != NULL) {
-        if (g_consume_eh_seq != g_pub_eh_seq) {
-            DSD_MEMCPY(&g_consume_eh[0], &g_pub_eh[0], sizeof(Event_History_I));
-            DSD_MEMCPY(&g_consume_eh[1], &g_pub_eh[1], sizeof(Event_History_I));
-            g_consume_eh_seq = g_pub_eh_seq;
+        for (size_t slot = 0; slot < 2U; slot++) {
+            if (g_consume_eh_seq[slot] != g_pub_eh_seq[slot]) {
+                DSD_MEMCPY(&g_consume_eh[slot], &g_pub_eh[slot], sizeof(Event_History_I));
+                g_consume_eh_seq[slot] = g_pub_eh_seq[slot];
+                UI_SNAPSHOT_COUNT_CONSUMER_COPY(slot);
+            }
         }
         g_consume.event_history_s = g_consume_eh;
     } else {

--- a/src/core/file/dsd_file.c
+++ b/src/core/file/dsd_file.c
@@ -911,6 +911,7 @@ rotate_symbol_out_file(dsd_opts* opts, dsd_state* state) {
             watchdog_event_datacall(opts, state, 0xFFFFFF, 0xFFFFFF, event_str, 0);
             dsd_event_history_item_set_metadata(&state->event_history_s[0].Event_History_Items[0],
                                                 DSD_EVENT_SEVERITY_INFO, DSD_EVENT_CATEGORY_SYSTEM);
+            dsd_event_history_mark_dirty(&state->event_history_s[0]);
             state->lastsrc =
                 0; //this could wipe a call, but usually on TDMA cc's, slot 1 is the control channel, so may never be set when this is run
             watchdog_event_history(opts, state, 0);
@@ -1900,6 +1901,7 @@ sdrtrunk_json_handle_time(const char* token, char** str_saveptr, dsd_state* stat
     (void)dsd_parse_long_strict(time_str, 10, 0L, LONG_MAX, &event_seconds);
     time_t event_time = (time_t)event_seconds;
     state->event_history_s[0].Event_History_Items[0].event_time = event_time;
+    dsd_event_history_mark_dirty(&state->event_history_s[0]);
 
     char timestr[9];
     char datestr[11];

--- a/src/core/gps/dsd_gps.c
+++ b/src/core/gps/dsd_gps.c
@@ -167,6 +167,7 @@ lip_store_state_strings(dsd_state* state, int slot, const lip_state_strings* gps
 
     DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].gps_s,
                  sizeof state->event_history_s[slot].Event_History_Items[0].gps_s, "%s", state->dmr_embedded_gps[slot]);
+    dsd_event_history_mark_dirty(&state->event_history_s[slot]);
 }
 
 static void DSD_ATTR_USED
@@ -359,6 +360,7 @@ nmea_store_and_report(const dsd_opts* opts, dsd_state* state, int slot, uint32_t
     DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].gps_s,
                  sizeof state->event_history_s[slot].Event_History_Items[0].gps_s, "(%f%s, %f%s)", latitude, deg_glyph,
                  longitude, deg_glyph);
+    dsd_event_history_mark_dirty(&state->event_history_s[slot]);
 
     int speed_int = (int)speed_kph;
     int azimuth = (type == 2) ? (int)cog : 0;
@@ -543,6 +545,7 @@ nmea_harris(const dsd_opts* opts, dsd_state* state, const uint8_t* input, uint32
         DSD_SNPRINTF(state->event_history_s[slot_idx].Event_History_Items[0].gps_s,
                      sizeof state->event_history_s[slot_idx].Event_History_Items[0].gps_s, "%s",
                      state->dmr_embedded_gps[slot_idx]);
+        dsd_event_history_mark_dirty(&state->event_history_s[slot_idx]);
     }
 
     // save to LRRP report for mapping/logging
@@ -584,6 +587,7 @@ dmr_embedded_gps_store_clear_fix(const dsd_opts* opts, dsd_state* state, uint8_t
         DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].gps_s,
                      sizeof state->event_history_s[slot].Event_History_Items[0].gps_s, "%s",
                      state->dmr_embedded_gps[slot]);
+        dsd_event_history_mark_dirty(&state->event_history_s[slot]);
     }
     gps_write_lrrp_compact(opts, src, fix->lat_sf * fix->latitude, fix->lon_sf * fix->longitude, 0, 0);
 }
@@ -754,6 +758,7 @@ apx_embedded_gps(const dsd_opts* opts, dsd_state* state, const uint8_t lc_bits[]
                 DSD_SNPRINTF(state->event_history_s[slot_idx].Event_History_Items[0].gps_s,
                              sizeof state->event_history_s[slot_idx].Event_History_Items[0].gps_s, "%s",
                              state->dmr_embedded_gps[slot_idx]);
+                dsd_event_history_mark_dirty(&state->event_history_s[slot_idx]);
             }
 
             //save to LRRP report for mapping/logging
@@ -850,6 +855,10 @@ nmea_sentence_checker(const dsd_opts* opts, dsd_state* state, const uint8_t* inp
         nmea_print_invalid_reason(start_value, end_value, checksum_calc, checksum_ext);
     }
 
+    if (have_events) {
+        dsd_event_history_mark_dirty(&state->event_history_s[slot_idx]);
+    }
+
     state->dmr_lrrp_source[slot_idx] = 0U;
     state->dmr_lrrp_target[slot_idx] = 0U;
     return valid;
@@ -908,6 +917,7 @@ nxdn_gps_report(const dsd_opts* opts, dsd_state* state, const uint8_t* input, ui
         DSD_SNPRINTF(state->event_history_s[0].Event_History_Items[0].gps_s,
                      sizeof(state->event_history_s[0].Event_History_Items[0].gps_s), "(%.6f%s, %.6f%s)", latitude,
                      deg_glyph, longitude, deg_glyph);
+        dsd_event_history_mark_dirty(&state->event_history_s[0]);
 
         uint32_t source = (uint32_t)state->dmr_lrrp_source[0];
         uint32_t target = (uint32_t)state->dmr_lrrp_target[0];

--- a/src/core/util/dsd_alias.c
+++ b/src/core/util/dsd_alias.c
@@ -15,6 +15,7 @@
 
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/embedded_alias.h>
+#include <dsd-neo/core/events.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/string_utils.h>
 #include <dsd-neo/core/talkgroup_policy.h>
@@ -463,6 +464,7 @@ apx_embedded_alias_dump(const dsd_opts* opts, dsd_state* state, uint8_t slot, ui
     if (current_call_match) {
         DSD_SNPRINTF(state->event_history_s[slot_idx].Event_History_Items[0].alias,
                      sizeof(state->event_history_s[slot_idx].Event_History_Items[0].alias), "%s; %s", str, fqs);
+        dsd_event_history_mark_dirty(&state->event_history_s[slot_idx]);
     }
 
     if (current_call_match
@@ -808,6 +810,7 @@ l3h_embedded_alias_decode_internal(const dsd_opts* opts, dsd_state* state, uint8
     if (current_call_match) {
         DSD_SNPRINTF(state->event_history_s[slot_idx].Event_History_Items[0].alias,
                      sizeof(state->event_history_s[slot_idx].Event_History_Items[0].alias), "%s", str);
+        dsd_event_history_mark_dirty(&state->event_history_s[slot_idx]);
         if (save_policy) {
             // The Duke Energy system may relay two src values, may be a good idea to pick one and stick with it
             l3h_alias_append_policy_row(opts, state, tsrc, ttg, str);
@@ -848,6 +851,7 @@ tait_iso7_embedded_alias_decode(const dsd_opts* opts, dsd_state* state, uint8_t 
     if (state->event_history_s[slot].Event_History_Items[0].source_id == rid) {
         DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].alias,
                      sizeof(state->event_history_s[slot].Event_History_Items[0].alias), "%s", alias);
+        dsd_event_history_mark_dirty(&state->event_history_s[slot]);
     }
 
     if (rid != 0) {
@@ -1113,6 +1117,7 @@ dmr_talker_alias_lc_decode(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8
     if (state->event_history_s[slot].Event_History_Items[0].source_id == source) {
         DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].alias,
                      sizeof(state->event_history_s[slot].Event_History_Items[0].alias), "%s; ", alias_string);
+        dsd_event_history_mark_dirty(&state->event_history_s[slot]);
     }
     DSD_SNPRINTF(state->generic_talker_alias[slot], sizeof(state->generic_talker_alias[slot]), "Talker Alias: %s; ",
                  alias_string);

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -50,6 +50,10 @@ copy_str_field(char* dst, const char* src, size_t cap) {
 //init each event history struct passed into here
 void
 init_event_history(Event_History_I* event_struct, uint8_t start, uint8_t stop) {
+    if (event_struct == NULL || start >= stop) {
+        return;
+    }
+
     for (uint8_t i = start; i < stop; i++) {
         event_struct->Event_History_Items[i].write = 0;
         event_struct->Event_History_Items[i].color_pair = 4;
@@ -87,10 +91,14 @@ init_event_history(Event_History_I* event_struct, uint8_t start, uint8_t stop) {
         event_struct->Event_History_Items[i].event_string[0] = '\0';
         event_struct->Event_History_Items[i].internal_str[0] = '\0';
     }
+    dsd_event_history_mark_dirty(event_struct);
 }
 
 void
 push_event_history(Event_History_I* event_struct) {
+    if (event_struct == NULL) {
+        return;
+    }
 
     //Fixed, had it going in the wrong direction first time
     for (uint8_t i = 254; i >= 1; i--) {
@@ -147,6 +155,7 @@ push_event_history(Event_History_I* event_struct) {
                        event_struct->Event_History_Items[i - 1].internal_str,
                        sizeof event_struct->Event_History_Items[i].internal_str);
     }
+    dsd_event_history_mark_dirty(event_struct);
 }
 
 void
@@ -495,7 +504,7 @@ watchdog_event_build_edacs_sup_str(uint16_t svc_opts, int use_underscore, char* 
 }
 
 static void
-watchdog_event_set_ysf_text_message(dsd_state* state, Event_History_I* event_struct) {
+watchdog_event_set_ysf_text_message(dsd_state* state, Event_History* item) {
     char ysf_emp[21][21];
     DSD_MEMSET(ysf_emp, 0, sizeof(ysf_emp));
 
@@ -504,15 +513,15 @@ watchdog_event_set_ysf_text_message(dsd_state* state, Event_History_I* event_str
         for (uint8_t i = 4; i < 8; i++) {
             for (uint8_t j = 0; j < 20; j++) {
                 if (state->ysf_txt[i][j] != 0x2A) {
-                    event_struct->Event_History_Items[0].text_message[k++] = state->ysf_txt[i][j];
+                    item->text_message[k++] = state->ysf_txt[i][j];
                 } else {
-                    event_struct->Event_History_Items[0].text_message[k++] = 0x20;
+                    item->text_message[k++] = 0x20;
                 }
             }
-            event_struct->Event_History_Items[0].text_message[k] = 0;
+            item->text_message[k] = 0;
         }
     } else {
-        event_struct->Event_History_Items[0].text_message[0] = '\0';
+        item->text_message[0] = '\0';
     }
 }
 
@@ -642,9 +651,9 @@ watchdog_event_current_apply_nxdn(const dsd_state* state, watchdog_event_current
 }
 
 static void
-watchdog_event_current_apply_ysf(dsd_state* state, Event_History_I* event_struct, watchdog_event_current_ctx* ctx) {
+watchdog_event_current_apply_ysf(dsd_state* state, Event_History* item, watchdog_event_current_ctx* ctx) {
     ctx->source_id = watchdog_event_source_ysf(state);
-    watchdog_event_set_ysf_text_message(state, event_struct);
+    watchdog_event_set_ysf_text_message(state, item);
 
     DSD_SNPRINTF(ctx->sysid_string, sizeof(ctx->sysid_string), "%s", "YSF");
     watchdog_event_set_sanitized_ascii_id(ctx->src_str, sizeof(ctx->src_str), state->ysf_src, 10);
@@ -714,14 +723,14 @@ watchdog_event_current_apply_edacs(const dsd_opts* opts, dsd_state* state, watch
 }
 
 static void
-watchdog_event_current_apply_slot0_overrides(const dsd_opts* opts, dsd_state* state, Event_History_I* event_struct,
+watchdog_event_current_apply_slot0_overrides(const dsd_opts* opts, dsd_state* state, Event_History* item,
                                              watchdog_event_current_ctx* ctx) {
     if (DSD_SYNC_IS_NXDN(state->lastsynctype)) {
         watchdog_event_current_apply_nxdn(state, ctx);
     }
 
     if (DSD_SYNC_IS_YSF(state->lastsynctype)) {
-        watchdog_event_current_apply_ysf(state, event_struct, ctx);
+        watchdog_event_current_apply_ysf(state, item, ctx);
     }
 
     if (watchdog_event_is_m17_sync(state->lastsynctype)) {
@@ -760,48 +769,41 @@ watchdog_event_current_load_labels(const dsd_state* state, watchdog_event_curren
 }
 
 static void
-watchdog_event_current_update_item(const dsd_opts* opts, dsd_state* state, uint8_t slot, Event_History_I* event_struct,
-                                   const watchdog_event_current_ctx* ctx) {
-    event_struct->Event_History_Items[0].write = 0;
-    dsd_event_history_item_set_metadata(&event_struct->Event_History_Items[0], ctx->severity, ctx->category);
+watchdog_event_current_update_item(const dsd_opts* opts, dsd_state* state, uint8_t slot, Event_History* item,
+                                   const watchdog_event_current_ctx* ctx, time_t now) {
+    item->write = 0;
+    dsd_event_history_item_set_metadata(item, ctx->severity, ctx->category);
     if (state->lastsynctype != DSD_SYNC_NONE) {
-        event_struct->Event_History_Items[0].systype = state->lastsynctype;
+        item->systype = state->lastsynctype;
     } else {
-        event_struct->Event_History_Items[0].systype = 39;
+        item->systype = 39;
     }
-    event_struct->Event_History_Items[0].subtype = ctx->subtype;
-    event_struct->Event_History_Items[0].gi = state->gi[slot];
-    event_struct->Event_History_Items[0].sys_id1 = ctx->sys_id1;
-    event_struct->Event_History_Items[0].sys_id2 = ctx->sys_id2;
-    event_struct->Event_History_Items[0].sys_id3 = ctx->sys_id3;
-    event_struct->Event_History_Items[0].sys_id4 = ctx->sys_id4;
-    event_struct->Event_History_Items[0].sys_id5 = ctx->sys_id5;
-    event_struct->Event_History_Items[0].enc = ctx->enc;
-    event_struct->Event_History_Items[0].enc_alg = ctx->alg_id;
-    event_struct->Event_History_Items[0].enc_key = ctx->key_id;
-    event_struct->Event_History_Items[0].mi = ctx->mi;
-    event_struct->Event_History_Items[0].svc = ctx->svc_opts;
-    event_struct->Event_History_Items[0].source_id = ctx->source_id;
-    event_struct->Event_History_Items[0].target_id = ctx->target_id;
-    event_struct->Event_History_Items[0].channel = ctx->channel;
+    item->subtype = ctx->subtype;
+    item->gi = state->gi[slot];
+    item->sys_id1 = ctx->sys_id1;
+    item->sys_id2 = ctx->sys_id2;
+    item->sys_id3 = ctx->sys_id3;
+    item->sys_id4 = ctx->sys_id4;
+    item->sys_id5 = ctx->sys_id5;
+    item->enc = ctx->enc;
+    item->enc_alg = ctx->alg_id;
+    item->enc_key = ctx->key_id;
+    item->mi = ctx->mi;
+    item->svc = ctx->svc_opts;
+    item->source_id = ctx->source_id;
+    item->target_id = ctx->target_id;
+    item->channel = ctx->channel;
     if (opts->playfiles == 0) {
-        event_struct->Event_History_Items[0].event_time = time(NULL);
+        item->event_time = now;
     }
 
-    DSD_SNPRINTF(event_struct->Event_History_Items[0].sysid_string,
-                 sizeof(event_struct->Event_History_Items[0].sysid_string), "%s", ctx->sysid_string);
-    DSD_SNPRINTF(event_struct->Event_History_Items[0].src_str, sizeof(event_struct->Event_History_Items[0].src_str),
-                 "%s", ctx->src_str);
-    DSD_SNPRINTF(event_struct->Event_History_Items[0].tgt_str, sizeof(event_struct->Event_History_Items[0].tgt_str),
-                 "%s", ctx->tgt_str);
-    DSD_SNPRINTF(event_struct->Event_History_Items[0].t_name, sizeof(event_struct->Event_History_Items[0].t_name), "%s",
-                 ctx->t_name);
-    DSD_SNPRINTF(event_struct->Event_History_Items[0].s_name, sizeof(event_struct->Event_History_Items[0].s_name), "%s",
-                 ctx->s_name);
-    DSD_SNPRINTF(event_struct->Event_History_Items[0].t_mode, sizeof(event_struct->Event_History_Items[0].t_mode), "%s",
-                 ctx->t_mode);
-    DSD_SNPRINTF(event_struct->Event_History_Items[0].s_mode, sizeof(event_struct->Event_History_Items[0].s_mode), "%s",
-                 ctx->s_mode);
+    DSD_SNPRINTF(item->sysid_string, sizeof(item->sysid_string), "%s", ctx->sysid_string);
+    DSD_SNPRINTF(item->src_str, sizeof(item->src_str), "%s", ctx->src_str);
+    DSD_SNPRINTF(item->tgt_str, sizeof(item->tgt_str), "%s", ctx->tgt_str);
+    DSD_SNPRINTF(item->t_name, sizeof(item->t_name), "%s", ctx->t_name);
+    DSD_SNPRINTF(item->s_name, sizeof(item->s_name), "%s", ctx->s_name);
+    DSD_SNPRINTF(item->t_mode, sizeof(item->t_mode), "%s", ctx->t_mode);
+    DSD_SNPRINTF(item->s_mode, sizeof(item->s_mode), "%s", ctx->s_mode);
 }
 
 static void
@@ -1035,12 +1037,14 @@ watchdog_event_current_append_policy_labels(const watchdog_event_current_ctx* ct
 void
 watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) {
     Event_History_I* event_struct = &state->event_history_s[slot];
+    Event_History candidate;
+    DSD_MEMCPY(&candidate, &event_struct->Event_History_Items[0], sizeof(candidate));
 
     watchdog_event_current_ctx ctx;
     watchdog_event_current_init_base(state, slot, &ctx);
 
     if (slot == 0) {
-        watchdog_event_current_apply_slot0_overrides(opts, state, event_struct, &ctx);
+        watchdog_event_current_apply_slot0_overrides(opts, state, &candidate, &ctx);
     }
 
     watchdog_event_current_normalize_p25_crypto(state, slot, &ctx);
@@ -1054,7 +1058,7 @@ watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) {
     (void)dsd_format_local_datetime(now, DSD_LOCAL_DATETIME_TIME_COLON, timestr, sizeof timestr);
     (void)dsd_format_local_datetime(now, DSD_LOCAL_DATETIME_DATE_HYPHEN, datestr, sizeof datestr);
 
-    watchdog_event_current_update_item(opts, state, slot, event_struct, &ctx);
+    watchdog_event_current_update_item(opts, state, slot, &candidate, &ctx, now);
 
     char event_string[2000];
     DSD_MEMSET(event_string, 0, sizeof(event_string));
@@ -1062,8 +1066,14 @@ watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) {
                                               sizeof(event_string));
     watchdog_event_current_append_policy_labels(&ctx, event_string, sizeof(event_string));
 
-    DSD_SNPRINTF(event_struct->Event_History_Items[0].event_string,
-                 sizeof(event_struct->Event_History_Items[0].event_string), "%s", event_string);
+    DSD_SNPRINTF(candidate.event_string, sizeof(candidate.event_string), "%s", event_string);
+
+    // The candidate starts as an exact byte copy of the current row, so padding bytes remain identical.
+    // NOLINTNEXTLINE(bugprone-suspicious-memory-comparison,cert-exp42-c,cert-flp37-c)
+    if (memcmp(&candidate, &event_struct->Event_History_Items[0], sizeof(candidate)) != 0) {
+        DSD_MEMCPY(&event_struct->Event_History_Items[0], &candidate, sizeof(candidate));
+        dsd_event_history_mark_dirty(event_struct);
+    }
 
     /* stack buffers; no free */
 }
@@ -1094,6 +1104,7 @@ watchdog_event_status(dsd_state* state, const char* status_string, uint8_t slot)
     (void)dsd_format_local_datetime(now, DSD_LOCAL_DATETIME_DATE_HYPHEN, datestr, sizeof datestr);
 
     DSD_SNPRINTF(item->event_string, sizeof item->event_string, "%s %s %s", datestr, timestr, status_string);
+    dsd_event_history_mark_dirty(event_struct);
 }
 
 void
@@ -1131,6 +1142,7 @@ watchdog_event_datacall(dsd_opts* opts, dsd_state* state, uint32_t src, uint32_t
     DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].event_string,
                  sizeof state->event_history_s[slot].Event_History_Items[0].event_string, "%s",
                  event_string); // could change this to a strncpy to prevent potential overflow
+    dsd_event_history_mark_dirty(&state->event_history_s[slot]);
 
     dsd_frame_logf(opts, "FRAME DATA slot=%d src=%u dst=%u %s", slot + 1, src, dst, data_string ? data_string : "");
 

--- a/src/protocol/dmr/dmr_block.c
+++ b/src/protocol/dmr/dmr_block.c
@@ -951,6 +951,7 @@ dmr_udt_finalize(dmr_udt_ctx* ctx) {
         ctx->state->lastsrcR = ctx->udt_source;
         ctx->state->lasttgR = ctx->udt_target;
     }
+    dsd_event_history_mark_dirty(&ctx->state->event_history_s[ctx->slot]);
     watchdog_event_datacall(ctx->opts, ctx->state, ctx->udt_source, ctx->udt_target, ctx->udt_string, ctx->slot);
     if (ctx->slot == 0) {
         ctx->state->lastsrc = 0;
@@ -1198,6 +1199,7 @@ dmr_block_type1_handle_mnis_payload(dmr_block_assembler_ctx* ctx, uint16_t len, 
         DSD_SNPRINTF(ctx->state->event_history_s[ctx->slot].Event_History_Items[0].gps_s,
                      sizeof(ctx->state->event_history_s[ctx->slot].Event_History_Items[0].gps_s), "%s",
                      ctx->state->dmr_lrrp_gps[ctx->slot]);
+        dsd_event_history_mark_dirty(&ctx->state->event_history_s[ctx->slot]);
     }
 
     if (mnis_type != 0x11 && mnis_type != 0x01) {

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -712,6 +712,7 @@ dmr_flco_apply_enc_lockout(dmr_flco_ctx* ctx) {
         DSD_SNPRINTF(ctx->state->event_history_s[ctx->slot].Event_History_Items[0].internal_str,
                      sizeof(ctx->state->event_history_s[ctx->slot].Event_History_Items[0].internal_str),
                      "Target: %d; has been locked out; Encryption Lock Out Enabled.", ctx->target);
+        dsd_event_history_mark_dirty(&ctx->state->event_history_s[ctx->slot]);
         watchdog_event_current(ctx->opts, ctx->state, ctx->slot);
     }
     dmr_flco_emit_enc_lockout_action(ctx, gm, gn);

--- a/src/protocol/dmr/dmr_pdu.c
+++ b/src/protocol/dmr/dmr_pdu.c
@@ -102,6 +102,9 @@ utf16_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input) 
     //add elipses to indicate this is possibly truncated
 
     //debug
+    if (wr == 1) {
+        dsd_event_history_mark_dirty(&state->event_history_s[slot]);
+    }
 }
 
 void
@@ -138,6 +141,9 @@ utf8_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input) {
     }
 
     //add elipses to indicate this is possibly truncated
+    if (wr == 1) {
+        dsd_event_history_mark_dirty(&state->event_history_s[slot]);
+    }
 }
 
 void
@@ -158,6 +164,7 @@ dmr_sd_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* DMR_PD
                      state->dmr_lrrp_gps[slot]);
         dsd_event_history_item_set_metadata(&state->event_history_s[slot].Event_History_Items[0],
                                             DSD_EVENT_SEVERITY_INFO, DSD_EVENT_CATEGORY_DATA);
+        dsd_event_history_mark_dirty(&state->event_history_s[slot]);
     } else {
         if (len >= (127 * 18)) {
             len = 127 * 18; //sanity check of sorts, prevent extra long line print outs in the console
@@ -526,6 +533,7 @@ decode_ip_pdu_handle_udp_service_core(dsd_opts* opts, dsd_state* state, uint8_t 
             dmr_lrrp(opts, state, payload_len, src24, dst24, payload, 1);
             dsd_event_history_item_set_metadata(&state->event_history_s[slot].Event_History_Items[0],
                                                 DSD_EVENT_SEVERITY_INFO, DSD_EVENT_CATEGORY_DATA);
+            dsd_event_history_mark_dirty(&state->event_history_s[slot]);
             return 1;
         case 4004:
             DSD_FPRINTF(stderr, "XCMP;");
@@ -533,6 +541,7 @@ decode_ip_pdu_handle_udp_service_core(dsd_opts* opts, dsd_state* state, uint8_t 
                          dst24);
             dsd_event_history_item_set_metadata(&state->event_history_s[slot].Event_History_Items[0],
                                                 DSD_EVENT_SEVERITY_INFO, DSD_EVENT_CATEGORY_DATA);
+            dsd_event_history_mark_dirty(&state->event_history_s[slot]);
             return 1;
         case 4005: {
             DSD_FPRINTF(stderr, "ARS;");

--- a/src/protocol/dstar/dstar_slow_data.c
+++ b/src/protocol/dstar/dstar_slow_data.c
@@ -5,6 +5,7 @@
 
 #include <dsd-neo/core/bit_packing.h>
 
+#include <dsd-neo/core/events.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/protocol/dstar/dstar.h>
@@ -317,6 +318,7 @@ dstar_sd_handle_aprs(dsd_state* state, const uint8_t* sd_bytes) {
     if (start == -1) {
         DSD_SNPRINTF(state->event_history_s[0].Event_History_Items[0].gps_s,
                      sizeof(state->event_history_s[0].Event_History_Items[0].gps_s), "%s", state->dstar_gps);
+        dsd_event_history_mark_dirty(&state->event_history_s[0]);
         return;
     }
 
@@ -324,6 +326,7 @@ dstar_sd_handle_aprs(dsd_state* state, const uint8_t* sd_bytes) {
     dstar_sd_print_aprs_lon(state, aprs, &start, temp, tempa);
     DSD_SNPRINTF(state->event_history_s[0].Event_History_Items[0].gps_s,
                  sizeof(state->event_history_s[0].Event_History_Items[0].gps_s), "%s", state->dstar_gps);
+    dsd_event_history_mark_dirty(&state->event_history_s[0]);
 }
 
 static void
@@ -334,6 +337,7 @@ dstar_sd_handle_text_message(dsd_state* state, dstar_sd_ctx* ctx) {
     DSD_MEMCPY(state->dstar_txt, ctx->strt, sizeof(ctx->strt));
     DSD_SNPRINTF(state->event_history_s[0].Event_History_Items[0].text_message,
                  sizeof(state->event_history_s[0].Event_History_Items[0].text_message), "%s", state->dstar_txt);
+    dsd_event_history_mark_dirty(&state->event_history_s[0]);
 }
 
 static void

--- a/src/protocol/nxdn/nxdn_alias_decode.c
+++ b/src/protocol/nxdn/nxdn_alias_decode.c
@@ -5,6 +5,7 @@
 
 #include <dsd-neo/core/bit_packing.h>
 
+#include <dsd-neo/core/events.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/protocol/nxdn/nxdn_alias_decode.h>
@@ -44,6 +45,7 @@ nxdn_alias_publish(dsd_state* state, const char* alias) {
     if (state->event_history_s != NULL) {
         DSD_SNPRINTF(state->event_history_s[0].Event_History_Items[0].alias,
                      sizeof(state->event_history_s[0].Event_History_Items[0].alias), "%s; ", alias);
+        dsd_event_history_mark_dirty(&state->event_history_s[0]);
     }
 }
 

--- a/src/protocol/nxdn/nxdn_deperm.c
+++ b/src/protocol/nxdn/nxdn_deperm.c
@@ -24,6 +24,7 @@
  */
 
 #include <dsd-neo/core/bit_packing.h>
+#include <dsd-neo/core/events.h>
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
@@ -363,6 +364,7 @@ nxdn_handle_dcr_csm_alias(const dsd_opts* opts, dsd_state* state, const uint8_t*
         if (state->event_history_s != NULL) {
             DSD_SNPRINTF(state->event_history_s[0].Event_History_Items[0].alias,
                          sizeof(state->event_history_s[0].Event_History_Items[0].alias), "%s; ", csm_alias);
+            dsd_event_history_mark_dirty(&state->event_history_s[0]);
         }
     } else if (opts->payload == 1) {
         DSD_FPRINTF(stderr, "\n Call Sign Memory: decode error; ");
@@ -726,6 +728,7 @@ nxdn_update_sacch2_identity_state(dsd_state* state, const struct nxdn_sacch2_fie
     DSD_SNPRINTF(state->generic_talker_alias[0], sizeof(state->generic_talker_alias[0]), "%s", "JPN DCR");
     DSD_SNPRINTF(state->event_history_s[0].Event_History_Items[0].alias,
                  sizeof(state->event_history_s[0].Event_History_Items[0].alias), "%s; ", "JPN DCR");
+    dsd_event_history_mark_dirty(&state->event_history_s[0]);
     if (fields->sf_fb) {
         state->payload_miN = 0;
     }

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -1076,6 +1076,7 @@ static void
 nxdn_dcall_watchdog(dsd_opts* opts, dsd_state* state, const char* event_text) {
     DSD_SNPRINTF(state->event_history_s[0].Event_History_Items[0].text_message,
                  sizeof(state->event_history_s[0].Event_History_Items[0].text_message), "%s", event_text);
+    dsd_event_history_mark_dirty(&state->event_history_s[0]);
     const uint32_t source = (uint32_t)state->dmr_lrrp_source[0];
     const uint32_t target = (uint32_t)state->dmr_lrrp_target[0];
     char comp_string[128];
@@ -2224,6 +2225,7 @@ nxdn_vcall_run_enc_lockout(dsd_opts* opts, dsd_state* state, const struct nxdn_v
         DSD_SNPRINTF(state->event_history_s[0].Event_History_Items[0].internal_str,
                      sizeof(state->event_history_s[0].Event_History_Items[0].internal_str),
                      "Target: %d; has been locked out; Encryption Lock Out Enabled.", info->destination_id);
+        dsd_event_history_mark_dirty(&state->event_history_s[0]);
         watchdog_event_current(opts, state, 0);
     }
 

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -7,6 +7,7 @@
 
 #include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/events.h>
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
@@ -4489,6 +4490,7 @@ p25_emit_enc_lockout_once_typed(dsd_opts* opts, dsd_state* state, uint8_t slot, 
     if (eh) {
         DSD_SNPRINTF(eh->Event_History_Items[0].internal_str, sizeof eh->Event_History_Items[0].internal_str,
                      "Target: %d; has been locked out; Encryption Lock Out Enabled.", target);
+        dsd_event_history_mark_dirty(eh);
         dsd_p25_optional_hook_watchdog_event_current(opts, state, (uint8_t)(slot & 1));
         if (strncmp(eh->Event_History_Items[1].internal_str, eh->Event_History_Items[0].internal_str,
                     sizeof eh->Event_History_Items[0].internal_str)

--- a/src/protocol/p25/phase1/p25p1_pdu_data.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_data.c
@@ -913,6 +913,7 @@ p25_store_lrrp_text_for_history(dsd_state* state) {
     DSD_SNPRINTF(state->dmr_lrrp_gps[0], cap, "LRRP: %.*s", (int)maxcpy, src);
     DSD_SNPRINTF(state->event_history_s[0].Event_History_Items[0].gps_s,
                  sizeof(state->event_history_s[0].Event_History_Items[0].gps_s), "%s", state->dmr_lrrp_gps[0]);
+    dsd_event_history_mark_dirty(&state->event_history_s[0]);
 }
 
 static void

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1956,6 +1956,10 @@ target_include_directories(
     dsd-neo_test_app_control_snapshot_event_history
     PRIVATE ${PROJECT_SOURCE_DIR}/include
 )
+target_compile_definitions(
+    dsd-neo_test_app_control_snapshot_event_history
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
 target_link_libraries(
     dsd-neo_test_app_control_snapshot_event_history
     PRIVATE dsd-neo_platform

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -15,6 +15,7 @@
 #include <dsd-neo/protocol/edacs/edacs_afs.h>
 #include <dsd-neo/runtime/call_alert.h>
 #include <stdarg.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,6 +25,11 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+
+_Static_assert(offsetof(Event_History_I, revision) == sizeof(Event_History) * 255U,
+               "event history revision must follow the existing items");
+_Static_assert(sizeof(Event_History_I) == sizeof(Event_History) * 255U + sizeof(uint64_t),
+               "event history revision must add exactly eight bytes");
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -133,6 +139,15 @@ expect_int(const char* label, int got, int want) {
 }
 
 static int
+expect_u64(const char* label, uint64_t got, uint64_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %llu want %llu\n", label, (unsigned long long)got, (unsigned long long)want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
 expect_has_substr(const char* label, const char* haystack, const char* needle) {
     if (haystack == NULL || needle == NULL || strstr(haystack, needle) == NULL) {
         DSD_FPRINTF(stderr, "%s: missing '%s' in '%s'\n", label, needle ? needle : "<null>",
@@ -167,6 +182,65 @@ append_policy_label(dsd_state* state, uint32_t id, const char* mode, const char*
         return -1;
     }
     return dsd_tg_policy_append_exact(state, &row);
+}
+
+static int
+test_event_history_revision_primitives(void) {
+    static Event_History_I histories[2];
+    DSD_MEMSET(histories, 0, sizeof(histories));
+
+    int rc = 0;
+    init_event_history(&histories[0], 3, 3);
+    rc |= expect_u64("empty init leaves revision unchanged", histories[0].revision, 0U);
+
+    init_event_history(&histories[0], 0, 1);
+    rc |= expect_u64("non-empty init advances revision", histories[0].revision, 1U);
+    rc |= expect_int("init sets default color", histories[0].Event_History_Items[0].color_pair, 4);
+    rc |= expect_int("init sets neutral systype", histories[0].Event_History_Items[0].systype, -1);
+    rc |= expect_u64("slot revisions are independent after init", histories[1].revision, 0U);
+
+    histories[0].Event_History_Items[0].source_id = 1234U;
+    push_event_history(&histories[0]);
+    rc |= expect_u64("push advances revision once", histories[0].revision, 2U);
+    rc |= expect_int("push copies the head row", (int)histories[0].Event_History_Items[1].source_id, 1234);
+
+    dsd_event_history_mark_dirty(&histories[1]);
+    rc |= expect_u64("explicit mark advances selected slot", histories[1].revision, 1U);
+    rc |= expect_u64("explicit mark leaves other slot unchanged", histories[0].revision, 2U);
+    dsd_event_history_mark_dirty(NULL);
+
+    histories[1].revision = UINT64_MAX;
+    dsd_event_history_mark_dirty(&histories[1]);
+    rc |= expect_u64("revision wrap skips zero", histories[1].revision, 1U);
+    return rc;
+}
+
+static int
+test_watchdog_current_marks_only_semantic_changes(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.playfiles = 1;
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.lastsrc = 1234U;
+    state.lasttg = 5678U;
+    state.dmr_color_code = 1U;
+    state.gi[0] = 0;
+
+    const uint64_t initial_revision = event_history[0].revision;
+    watchdog_event_current(&opts, &state, 0);
+    const uint64_t first_revision = event_history[0].revision;
+
+    int rc = expect_u64("first watchdog update advances revision", first_revision, initial_revision + 1U);
+    watchdog_event_current(&opts, &state, 0);
+    rc |= expect_u64("identical watchdog update leaves revision unchanged", event_history[0].revision, first_revision);
+
+    state.lastsrc = 4321U;
+    watchdog_event_current(&opts, &state, 0);
+    rc |= expect_u64("semantic watchdog update advances revision", event_history[0].revision, first_revision + 1U);
+    rc |= expect_u64("watchdog slot update leaves other slot unchanged", event_history[1].revision, 1U);
+    return rc;
 }
 
 static int
@@ -859,6 +933,8 @@ int
 main(void) {
     int rc = 0;
 
+    rc |= test_event_history_revision_primitives();
+    rc |= test_watchdog_current_marks_only_semantic_changes();
     rc |= test_end_only_data_call_does_not_emit_voice_end_alert();
     rc |= test_data_only_data_call_emits_one_data_alert();
     rc |= test_data_call_emits_frame_log_record();

--- a/tests/protocol/dmr/test_dmr_embedded_gps_position_error.c
+++ b/tests/protocol/dmr/test_dmr_embedded_gps_position_error.c
@@ -198,11 +198,13 @@ test_packed_nmea_formats(dsd_opts* opts, dsd_state* st) {
         DSD_MEMSET(st->dmr_embedded_gps[0], 0, sizeof st->dmr_embedded_gps[0]);
         DSD_MEMSET(st->event_history_s[0].Event_History_Items[0].gps_s, 0,
                    sizeof st->event_history_s[0].Event_History_Items[0].gps_s);
+        const uint64_t revision = st->event_history_s[0].revision;
         nmea_iec_61162_1(opts, st, bits, 900001U, 2);
 
         rc |= expect_has_substr(st->dmr_embedded_gps[0], "41.500000", "nmea-iec-lat");
         rc |= expect_has_substr(st->dmr_embedded_gps[0], "87.250000", "nmea-iec-lon");
         rc |= expect_has_substr(st->event_history_s[0].Event_History_Items[0].gps_s, "41.500000", "nmea-iec-event-lat");
+        rc |= expect_i("nmea-iec-history-revision", st->event_history_s[0].revision == revision + 1U, 1);
     }
 
     {

--- a/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
@@ -513,10 +513,15 @@ main(void) {
         reset_spies();
         const uint8_t text[] = {'A', 'B', 'C'};
         st.event_history_s[0].Event_History_Items[0].text_message[0] = '\0';
+        const uint64_t revision = st.event_history_s[0].revision;
         utf8_to_text(&st, 1, (uint16_t)sizeof text, text);
         if (strcmp(st.event_history_s[0].Event_History_Items[0].text_message, "ABC") != 0) {
             DSD_FPRINTF(stderr, "utf8 text append: got '%s'\n",
                         st.event_history_s[0].Event_History_Items[0].text_message);
+            rc |= 1;
+        }
+        if (st.event_history_s[0].revision != revision + 1U) {
+            DSD_FPRINTF(stderr, "utf8 text append did not advance history revision once\n");
             rc |= 1;
         }
     }

--- a/tests/protocol/dmr/test_dmr_talker_alias_header_len.c
+++ b/tests/protocol/dmr/test_dmr_talker_alias_header_len.c
@@ -113,9 +113,14 @@ test_direct_dmr_alias_decoders(dsd_opts* opts, dsd_state* st) {
     value_to_bits_msb(st->dmr_pdu_sf[0], 14, sizeof(st->dmr_pdu_sf[0]), '7', 7);
     st->lastsrc = 700001u;
     st->event_history_s[0].Event_History_Items[0].source_id = st->lastsrc;
+    const uint64_t slot0_revision = st->event_history_s[0].revision;
     dmr_talker_alias_lc_decode(opts, st, 0, 0, 7, 3);
     rc |= expect_str(st->generic_talker_alias[0], "Talker Alias: K,7; ", "iso7 generic alias");
     rc |= expect_str(st->event_history_s[0].Event_History_Items[0].alias, "K,7; ", "iso7 event alias");
+    if (st->event_history_s[0].revision != slot0_revision + 1U) {
+        DSD_FPRINTF(stderr, "iso7 event alias did not advance history revision once\n");
+        rc = 1;
+    }
     if (st->generic_talker_alias_src[0] != (uint32_t)st->lastsrc) {
         DSD_FPRINTF(stderr, "iso7 generic alias source mismatch\n");
         rc = 1;
@@ -127,9 +132,14 @@ test_direct_dmr_alias_decoders(dsd_opts* opts, dsd_state* st) {
     value_to_bits_msb(st->dmr_pdu_sf[1], 32, sizeof(st->dmr_pdu_sf[1]), 0x0100U, 16);
     st->lastsrcR = 700002u;
     st->event_history_s[1].Event_History_Items[0].source_id = st->lastsrcR;
+    const uint64_t slot1_revision = st->event_history_s[1].revision;
     dmr_talker_alias_lc_decode(opts, st, 1, 1, 16, 3);
     rc |= expect_str(st->generic_talker_alias[1], "Talker Alias: A *; ", "utf16 generic alias");
     rc |= expect_str(st->event_history_s[1].Event_History_Items[0].alias, "A *; ", "utf16 event alias");
+    if (st->event_history_s[1].revision != slot1_revision + 1U) {
+        DSD_FPRINTF(stderr, "utf16 event alias did not advance history revision once\n");
+        rc = 1;
+    }
     if (st->generic_talker_alias_src[1] != (uint32_t)st->lastsrcR) {
         DSD_FPRINTF(stderr, "utf16 generic alias source mismatch\n");
         rc = 1;

--- a/tests/protocol/dstar/test_dstar_header_utils.c
+++ b/tests/protocol/dstar/test_dstar_header_utils.c
@@ -237,11 +237,13 @@ test_slow_data_text_keeps_byte_after_marker(void) {
     bytes[7] = 'G';
 
     pack_slow_data_bytes(bytes, bits);
+    const uint64_t revision = history[0].revision;
     processDSTAR_SD(&opts, &state, bits);
 
     assert(state.dstar_txt[5] == 'E');
     assert(state.dstar_txt[6] == ' ');
     assert(state.dstar_txt[7] == 'G');
+    assert(history[0].revision == revision + 1U);
     free(history);
 }
 
@@ -290,11 +292,13 @@ test_slow_data_aprs_latitude_uses_compacted_direction(void) {
     set_compacted_slow_data_bytes(bytes, compact);
 
     pack_slow_data_bytes(bytes, bits);
+    const uint64_t revision = history[0].revision;
     processDSTAR_SD(&opts, &state, bits);
 
     assert(strstr(state.dstar_gps, "Lat: 41d 30m 59s N ") != NULL);
     assert(strstr(state.dstar_gps, "Lon: 087d 30m 15s W ") != NULL);
     assert(strcmp(state.event_history_s[0].Event_History_Items[0].gps_s, state.dstar_gps) == 0);
+    assert(history[0].revision == revision + 1U);
     free(history);
 }
 

--- a/tests/protocol/nxdn/test_nxdn_deperm_primitives.c
+++ b/tests/protocol/nxdn/test_nxdn_deperm_primitives.c
@@ -504,6 +504,7 @@ test_sacch2_state_update(void) {
     rc |= expect_int("sacch2-single-last-rid", state.nxdn_last_rid, 777);
     rc |= expect_str("sacch2-single-alias", state.generic_talker_alias[0], "JPN DCR");
     rc |= expect_str("sacch2-single-event-alias", histories[0].Event_History_Items[0].alias, "JPN DCR; ");
+    rc |= expect_int("sacch2-single-event-revision", (int)histories[0].revision, 1);
     rc |= expect_int("sacch2-single-cipher", state.nxdn_cipher_type, 1);
     rc |= expect_int("sacch2-single-enc-lockout", state.dmr_encL, 1);
 
@@ -615,6 +616,7 @@ test_pich_tch_dcr_csm_alias_state(void) {
     nxdn_handle_pich_tch(&opts, &state, trellis, m_data, 0x123U, 0x123U, 0x08U);
     rc |= expect_str("pich-csm-alias", state.generic_talker_alias[0], "CSM 123456789");
     rc |= expect_str("pich-csm-event-alias", histories[0].Event_History_Items[0].alias, "CSM 123456789; ");
+    rc |= expect_int("pich-csm-event-revision", (int)histories[0].revision, 1);
 
     DSD_SNPRINTF(state.generic_talker_alias[0], sizeof(state.generic_talker_alias[0]), "%s", "KEEP");
     DSD_SNPRINTF(histories[0].Event_History_Items[0].alias, sizeof(histories[0].Event_History_Items[0].alias), "%s",

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -353,11 +353,15 @@ main(void) {
     // 3) ENC lockout once (SM helper)
     static dsd_opts o4;
     static dsd_state s4;
+    static Event_History_I s4_history[2];
     init_basic(&o4, &s4);
+    DSD_MEMSET(s4_history, 0, sizeof(s4_history));
+    s4.event_history_s = s4_history;
     s4.payload_algid = 0x84;
     s4.payload_keyid = 0x1234;
     s4.payload_miP = 0x1122334455667788ULL;
     p25_emit_enc_lockout_once_typed(&o4, &s4, 0, 1234, 0x40, 1);
+    assert(s4_history[0].revision == 1U);
     assert(s4.payload_algid == 0x84);
     assert(s4.payload_keyid == 0x1234);
     assert(s4.payload_miP == 0x1122334455667788ULL);

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -848,6 +848,7 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     init_test_context(&opts, &state);
     seed_active_p25_voice(&opts, &state, 853000000L, 854000000L, 2201);
     reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_DEFERRED);
+    const uint64_t lockout_history_revision = state.event_history_s[0].revision;
     rc |= expect_int("deferred lockout queued", dsd_app_command_set_u8(DSD_APP_CMD_LOCKOUT_SLOT, 0U),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("deferred lockout drained", dsd_app_drain_cmds(&opts, &state), 1);
@@ -865,6 +866,8 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
                      1);
     rc |= expect_str("deferred lockout policy mode", lockout_mode, "B");
     rc |= expect_str("deferred lockout policy name", lockout_name, "LOCKOUT");
+    rc |= expect_true("deferred lockout advances event history revision",
+                      state.event_history_s[0].revision > lockout_history_revision);
     rc |= expect_true("deferred lockout reports cleanup separately",
                       strstr(state.ui_msg, "TG 2201 locked out; return-to-CC tune failed") != NULL);
     freeState(&state);

--- a/tests/ui/test_ui_snapshot_event_history.c
+++ b/tests/ui/test_ui_snapshot_event_history.c
@@ -26,6 +26,25 @@ assert_slot_tail(const dsd_state* snap, uint32_t slot0_src, uint32_t slot1_src) 
 }
 
 static void
+mark_history(Event_History_I* history) {
+    history->revision++;
+    if (history->revision == 0U) {
+        history->revision = 1U;
+    }
+}
+
+static void
+assert_history_copy_counts(uint64_t source_slot0, uint64_t source_slot1, uint64_t consumer_slot0,
+                           uint64_t consumer_slot1) {
+    dsd_app_snapshot_event_history_copy_counts counts;
+    dsd_app_snapshot_test_get_event_history_copy_counts(&counts);
+    assert(counts.source_to_published[0] == source_slot0);
+    assert(counts.source_to_published[1] == source_slot1);
+    assert(counts.published_to_consumer[0] == consumer_slot0);
+    assert(counts.published_to_consumer[1] == consumer_slot1);
+}
+
+static void
 assert_render_fields(const dsd_state* snap) {
     dsd_tg_policy_lookup lookup;
     assert(snap != NULL);
@@ -77,8 +96,10 @@ int
 main(void) {
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
     Event_History_I* history = (Event_History_I*)calloc(2U, sizeof(*history));
-    if (!state || !history) {
+    Event_History_I* replacement = (Event_History_I*)calloc(2U, sizeof(*replacement));
+    if (!state || !history || !replacement) {
         DSD_FPRINTF(stderr, "allocation failed\n");
+        free(replacement);
         free(history);
         free(state);
         return 1;
@@ -127,7 +148,10 @@ main(void) {
     history[1].Event_History_Items[1].source_id = 456U;
     DSD_SNPRINTF(history[0].Event_History_Items[1].src_str, sizeof history[0].Event_History_Items[1].src_str, "%s",
                  "RADIO-123");
+    mark_history(&history[0]);
+    mark_history(&history[1]);
 
+    dsd_app_snapshot_test_reset_event_history_copy_counts();
     dsd_app_telemetry_publish_snapshot(state);
     history[0].Event_History_Items[1].source_id = 999U;
     DSD_SNPRINTF(history[0].Event_History_Items[1].src_str, sizeof history[0].Event_History_Items[1].src_str, "%s",
@@ -141,21 +165,68 @@ main(void) {
     assert(strcmp(snap->event_history_s[0].Event_History_Items[1].src_str, "RADIO-123") == 0);
     assert_render_fields(snap);
     assert_cc_candidates(snap);
+    assert_history_copy_counts(1U, 1U, 1U, 1U);
 
-    // Updating non-head history rows must refresh the deep-copied snapshot.
+    // Repeated publications with unchanged revisions do not copy either history slot.
+    dsd_app_snapshot_test_reset_event_history_copy_counts();
+    dsd_app_telemetry_publish_snapshot(state);
+    assert_slot_tail(dsd_app_get_latest_snapshot(), 123U, 456U);
+    assert_history_copy_counts(0U, 0U, 0U, 0U);
+
+    // A slot-0-only mutation copies only slot 0 at both snapshot stages.
     history[0].Event_History_Items[1].source_id = 789U;
+    mark_history(&history[0]);
+    dsd_app_snapshot_test_reset_event_history_copy_counts();
+    dsd_app_telemetry_publish_snapshot(state);
+    assert_slot_tail(dsd_app_get_latest_snapshot(), 789U, 456U);
+    assert_history_copy_counts(1U, 0U, 1U, 0U);
+
+    // Slot 1 advances independently from slot 0.
     history[1].Event_History_Items[1].source_id = 987U;
+    mark_history(&history[1]);
+    dsd_app_snapshot_test_reset_event_history_copy_counts();
     dsd_app_telemetry_publish_snapshot(state);
     assert_slot_tail(dsd_app_get_latest_snapshot(), 789U, 987U);
+    assert_history_copy_counts(0U, 1U, 0U, 1U);
 
-    // A reset-like clear with unchanged head rows must also be reflected.
-    DSD_MEMSET(history, 0, 2U * sizeof(*history));
+    // Resetting both histories publishes both cleared slots.
+    DSD_MEMSET(history[0].Event_History_Items, 0, sizeof(history[0].Event_History_Items));
+    DSD_MEMSET(history[1].Event_History_Items, 0, sizeof(history[1].Event_History_Items));
+    mark_history(&history[0]);
+    mark_history(&history[1]);
+    dsd_app_snapshot_test_reset_event_history_copy_counts();
     dsd_app_telemetry_publish_snapshot(state);
     assert_slot_tail(dsd_app_get_latest_snapshot(), 0U, 0U);
+    assert_history_copy_counts(1U, 1U, 1U, 1U);
 
+    // Present-to-null does not copy stale backing storage.
     state->event_history_s = NULL;
+    dsd_app_snapshot_test_reset_event_history_copy_counts();
     dsd_app_telemetry_publish_snapshot(state);
     assert(dsd_app_get_latest_snapshot()->event_history_s == NULL);
+    assert_history_copy_counts(0U, 0U, 0U, 0U);
+
+    // Null-to-present forces both slots, regardless of their last observed revisions.
+    history[0].Event_History_Items[1].source_id = 111U;
+    history[1].Event_History_Items[1].source_id = 222U;
+    mark_history(&history[0]);
+    mark_history(&history[1]);
+    state->event_history_s = history;
+    dsd_app_snapshot_test_reset_event_history_copy_counts();
+    dsd_app_telemetry_publish_snapshot(state);
+    assert_slot_tail(dsd_app_get_latest_snapshot(), 111U, 222U);
+    assert_history_copy_counts(1U, 1U, 1U, 1U);
+
+    // Replacing the source pointer forces both slots even when revisions coincide.
+    replacement[0].revision = history[0].revision;
+    replacement[1].revision = history[1].revision;
+    replacement[0].Event_History_Items[1].source_id = 333U;
+    replacement[1].Event_History_Items[1].source_id = 444U;
+    state->event_history_s = replacement;
+    dsd_app_snapshot_test_reset_event_history_copy_counts();
+    dsd_app_telemetry_publish_snapshot(state);
+    assert_slot_tail(dsd_app_get_latest_snapshot(), 333U, 444U);
+    assert_history_copy_counts(1U, 1U, 1U, 1U);
 
     assert(dsd_tg_policy_make_exact_entry(7777U, "B", "POLICY-ONLY", DSD_TG_POLICY_SOURCE_IMPORTED, &entry) == 0);
     assert(dsd_tg_policy_append_exact(state, &entry) == 0);
@@ -168,6 +239,7 @@ main(void) {
 
     puts("UI_SNAPSHOT_EVENT_HISTORY: OK");
     dsd_state_ext_free_all(state);
+    free(replacement);
     free(history);
     free(state);
     return 0;


### PR DESCRIPTION
## Summary

- Add a per-slot `Event_History_I` revision and null-safe dirty marker, then mark every production history writer after each logical update.
- Replace the 50 ms two-slot, 255-row snapshot comparison with independent revision-driven source-to-published and published-to-consumer copies.
- Limit `watchdog_event_current()` change detection to one local head-row candidate so identical updates do not advance the revision.
- Add deterministic copy counters and focused regression coverage for initialization, wraparound, writer enrichment, snapshot isolation, null/pointer transitions, and independent slot updates.
- Fix clean Clang `perf-profile` builds by disabling fast-math in that preset; clean configure/build now succeeds.

The root cause of the snapshot hotspot was the absence of a cheap mutation generation, which forced every telemetry publication to compare both complete histories. The clean Clang profile failure came from applying fast-math to code that intentionally validates non-finite values under warnings-as-errors.

The UI cadence, history capacity, rendering, snapshot lifetime, and DSP behavior are unchanged. A history slot is copied only when its payload revision changes or its backing source transitions/replaces.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: none; protocol decoding is unchanged and protocol edits only mark completed history enrichment.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests. No new input path was added; focused history-writer and snapshot tests were added.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny. Affected protocol enrichment paths have revision assertions.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` — 460/460 passed
- [x] `tools/preflight_ci.sh`
- [x] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes
- [x] `tools/zizmor.sh` for workflow changes
- [x] `tools/osv_scan.sh` for dependency input changes
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes
- [x] Full `asan-ubsan-debug` suite — 460/460 passed
- [x] Scan-build — no bugs found
- [x] Fuzz-ASan smoke — all targets completed 1,000 runs
- [x] Clean Clang `perf-profile` configure and build
- [x] Live RTL workload — clean soft stop, 0 audio errors
- [x] `perf record` — 1,697 samples, 0 lost; the full-history comparison hotspot is absent
- [x] `perf stat` — 1,853.54 ms task-clock over 37.774 seconds elapsed

## Risk

- Security/dependency impact: None; no dependencies, credentials, crypto, or security policy changed.
- CLI/UI behavior impact: UI output and refresh cadence are unchanged. Snapshot copies now occur independently per changed history slot.
- Compatibility or packaging impact: `Event_History_I` intentionally grows by eight bytes; linked components must be rebuilt together. The fast-math change applies only to `perf-profile`.
