### PR TITLE
dsp: optimize fixed half-band SIMD kernels

### DIFF
--- a/src/dsp/simd_fir_avx2.cpp
+++ b/src/dsp/simd_fir_avx2.cpp
@@ -53,6 +53,7 @@ simd_hb_decim2_real_avx2(const float* in, int in_len, float* out, float* hist, c
 #include <cstring>
 #include <immintrin.h>
 #include <vector>
+#include <xmmintrin.h>
 #include "dsd-neo/core/safe_api.h"
 
 // NOLINTBEGIN(portability-simd-intrinsics)
@@ -65,6 +66,16 @@ namespace {
 struct ComplexIq {
     float i;
     float q;
+};
+
+struct HbComplexBoundary {
+    const float* in;
+    int ch_len;
+    const float* hist_i;
+    const float* hist_q;
+    int hist_len;
+    float last_i;
+    float last_q;
 };
 
 static inline void
@@ -246,6 +257,140 @@ update_real_history(const float* in, int in_len, float* hist, int hist_len) {
     DSD_MEMCPY(hist + keep, in, (size_t)in_len * sizeof(float));
 }
 
+/*
+ * Load four complex samples at indices base, base+2, base+4, and base+6.
+ * Each source load is contiguous and unaligned; the shuffle first selects the
+ * even complex pair from each 128-bit lane and the 64-bit permutation restores
+ * sample order across the lanes.
+ */
+static inline __m256
+load_iq_stride2_4(const float* base) {
+    const __m256 lo = _mm256_loadu_ps(base);
+    const __m256 hi = _mm256_loadu_ps(base + 8);
+    const __m256 selected = _mm256_shuffle_ps(lo, hi, _MM_SHUFFLE(1, 0, 1, 0));
+    return _mm256_castpd_ps(_mm256_permute4x64_pd(_mm256_castps_pd(selected), 0xD8));
+}
+
+static inline ComplexIq
+load_hb_complex_boundary(const HbComplexBoundary& source, int rel) {
+    if (rel < 0) {
+        const int hist_idx = source.hist_len + rel;
+        return {source.hist_i[hist_idx], source.hist_q[hist_idx]};
+    }
+    if (rel < source.ch_len) {
+        return {source.in[rel << 1], source.in[(rel << 1) + 1]};
+    }
+    return {source.last_i, source.last_q};
+}
+
+template <int SideIndex, int SideCount>
+struct HbComplexFixedScalarSide {
+    static inline void
+    apply(const HbComplexBoundary& source, const float* taps, int center_rel, float& acc_i, float& acc_q) {
+        constexpr int even_tap = SideIndex << 1;
+        constexpr int center = (SideCount << 1) - 1;
+        const float coefficient = taps[even_tap];
+        if (coefficient != 0.0f) {
+            constexpr int distance = center - even_tap;
+            const ComplexIq minus = load_hb_complex_boundary(source, center_rel - distance);
+            const ComplexIq plus = load_hb_complex_boundary(source, center_rel + distance);
+            acc_i += coefficient * (minus.i + plus.i);
+            acc_q += coefficient * (minus.q + plus.q);
+        }
+        HbComplexFixedScalarSide<SideIndex + 1, SideCount>::apply(source, taps, center_rel, acc_i, acc_q);
+    }
+};
+
+template <int SideCount>
+struct HbComplexFixedScalarSide<SideCount, SideCount> {
+    static inline void
+    apply(const HbComplexBoundary&, const float*, int, float&, float&) {}
+};
+
+template <int TapsLen>
+static inline ComplexIq
+hb_complex_fixed_accumulate_scalar(const HbComplexBoundary& source, const float* taps, int n) {
+    constexpr int center = (TapsLen - 1) >> 1;
+    constexpr int side_count = (center + 1) >> 1;
+    const int center_rel = n << 1;
+    const ComplexIq center_sample = {source.in[center_rel << 1], source.in[(center_rel << 1) + 1]};
+    ComplexIq acc = {taps[center] * center_sample.i, taps[center] * center_sample.q};
+    HbComplexFixedScalarSide<0, side_count>::apply(source, taps, center_rel, acc.i, acc.q);
+    return acc;
+}
+
+template <int SideIndex, int SideCount>
+struct HbComplexFixedVectorSide {
+    static inline void
+    apply(const float* center_base, const float* taps, __m256& acc0, __m256& acc1) {
+        constexpr int even_tap = SideIndex << 1;
+        constexpr int center = (SideCount << 1) - 1;
+        constexpr int distance_floats = (center - even_tap) << 1;
+        const float coefficient = taps[even_tap];
+        if (coefficient != 0.0f) {
+            const float* minus = center_base - distance_floats;
+            const float* plus = center_base + distance_floats;
+            const __m256 sum0 = _mm256_add_ps(load_iq_stride2_4(minus), load_iq_stride2_4(plus));
+            const __m256 sum1 = _mm256_add_ps(load_iq_stride2_4(minus + 16), load_iq_stride2_4(plus + 16));
+            const __m256 tap = _mm256_set1_ps(coefficient);
+            acc0 = _mm256_fmadd_ps(tap, sum0, acc0);
+            acc1 = _mm256_fmadd_ps(tap, sum1, acc1);
+        }
+        HbComplexFixedVectorSide<SideIndex + 1, SideCount>::apply(center_base, taps, acc0, acc1);
+    }
+};
+
+template <int SideCount>
+struct HbComplexFixedVectorSide<SideCount, SideCount> {
+    static inline void
+    apply(const float*, const float*, __m256&, __m256&) {}
+};
+
+template <int TapsLen>
+static int
+hb_complex_decim2_fixed(const float* in, int ch_len, float* out, const float* hist_i, const float* hist_q,
+                        const float* taps, float last_i, float last_q) {
+    static_assert(TapsLen == 15 || TapsLen == 31, "fixed half-band kernel supports 15 or 31 taps");
+    constexpr int center = (TapsLen - 1) >> 1;
+    constexpr int side_count = (center + 1) >> 1;
+    const int out_ch_len = ch_len >> 1;
+    const HbComplexBoundary source = {in, ch_len, hist_i, hist_q, TapsLen - 1, last_i, last_q};
+
+    int n = 0;
+
+    /* Prefix outputs reach into the split history and stay on the scalar boundary path. */
+    for (; n < out_ch_len && (n << 1) < center; n++) {
+        const ComplexIq acc = hb_complex_fixed_accumulate_scalar<TapsLen>(source, taps, n);
+        out[n << 1] = acc.i;
+        out[(n << 1) + 1] = acc.q;
+    }
+
+    /*
+     * Eight outputs use two YMM accumulators. The final side-tap helper loads
+     * through center_rel + center + 15, including the unused samples within
+     * its second contiguous load, so guard that complete footprint.
+     */
+    for (; n + 7 < out_ch_len && (n << 1) + center + 15 < ch_len; n += 8) {
+        const float* center_base = in + (n << 2);
+        const __m256 center_tap = _mm256_set1_ps(taps[center]);
+        __m256 acc0 = _mm256_fmadd_ps(center_tap, load_iq_stride2_4(center_base), _mm256_setzero_ps());
+        __m256 acc1 = _mm256_fmadd_ps(center_tap, load_iq_stride2_4(center_base + 16), _mm256_setzero_ps());
+
+        HbComplexFixedVectorSide<0, side_count>::apply(center_base, taps, acc0, acc1);
+        _mm256_storeu_ps(out + (n << 1), acc0);
+        _mm256_storeu_ps(out + ((n + 4) << 1), acc1);
+    }
+
+    /* Vector remainder and repeated-last-sample suffix preserve scalar edge behavior. */
+    for (; n < out_ch_len; n++) {
+        const ComplexIq acc = hb_complex_fixed_accumulate_scalar<TapsLen>(source, taps, n);
+        out[n << 1] = acc.i;
+        out[(n << 1) + 1] = acc.q;
+    }
+
+    return out_ch_len << 1;
+}
+
 } // namespace
 
 /**
@@ -308,8 +453,8 @@ simd_fir_complex_apply_avx2(const float* in, int in_len, float* out, float* hist
 
 /**
  * AVX2+FMA complex half-band decimator by 2.
- * Processes 4 output samples (8 floats) at a time.
- * Uses pre-concatenated scratch buffer to eliminate branching in hot loop.
+ * The fixed 15- and 31-tap kernels process 8 complex outputs directly from
+ * the input; other odd tap counts retain the scratch-backed 4-output kernel.
  */
 extern "C" int
 simd_hb_decim2_complex_avx2(const float* in, int in_len, float* out, float* hist_i, float* hist_q, const float* taps,
@@ -323,6 +468,17 @@ simd_hb_decim2_complex_avx2(const float* in, int in_len, float* out, float* hist
         return 0;
     }
     const int out_ch_len = ch_len >> 1;
+
+    if (taps_len == 15 || taps_len == 31) {
+        const float last_i = in[in_len - 2];
+        const float last_q = in[in_len - 1];
+        const int out_len = taps_len == 15
+                                ? hb_complex_decim2_fixed<15>(in, ch_len, out, hist_i, hist_q, taps, last_i, last_q)
+                                : hb_complex_decim2_fixed<31>(in, ch_len, out, hist_i, hist_q, taps, last_i, last_q);
+        update_iq_history(in, ch_len, hist_i, hist_q, taps_len - 1);
+        _mm256_zeroupper();
+        return out_len;
+    }
 
     const int center = (taps_len - 1) >> 1;
     const int left_len = taps_len - 1;

--- a/src/dsp/simd_fir_neon.cpp
+++ b/src/dsp/simd_fir_neon.cpp
@@ -17,6 +17,21 @@
 
 namespace {
 
+struct ComplexIq {
+    float i;
+    float q;
+};
+
+struct HbComplexBoundary {
+    const float* in;
+    int ch_len;
+    const float* hist_i;
+    const float* hist_q;
+    int hist_len;
+    float last_i;
+    float last_q;
+};
+
 static thread_local std::vector<float> tls_scratch_iq;
 static thread_local std::vector<float> tls_scratch_real;
 
@@ -101,6 +116,139 @@ update_real_history(const float* in, int in_len, float* hist, int hist_len) {
     const int need = hist_len - in_len;
     DSD_MEMMOVE(hist, hist + in_len, (size_t)need * sizeof(float));
     DSD_MEMCPY(hist + need, in, (size_t)in_len * sizeof(float));
+}
+
+/* Load complex samples at indices base and base+2 from contiguous unaligned loads. */
+static inline float32x4_t
+load_iq_stride2_2(const float* base) {
+    const float32x4_t lo = vld1q_f32(base);
+    const float32x4_t hi = vld1q_f32(base + 4);
+    return vcombine_f32(vget_low_f32(lo), vget_low_f32(hi));
+}
+
+static inline ComplexIq
+load_hb_complex_boundary(const HbComplexBoundary& source, int rel) {
+    if (rel < 0) {
+        const int hist_idx = source.hist_len + rel;
+        return {source.hist_i[hist_idx], source.hist_q[hist_idx]};
+    }
+    if (rel < source.ch_len) {
+        return {source.in[rel << 1], source.in[(rel << 1) + 1]};
+    }
+    return {source.last_i, source.last_q};
+}
+
+template <int SideIndex, int SideCount>
+struct HbComplexFixedScalarSide {
+    static inline void
+    apply(const HbComplexBoundary& source, const float* taps, int center_rel, float& acc_i, float& acc_q) {
+        constexpr int even_tap = SideIndex << 1;
+        constexpr int center = (SideCount << 1) - 1;
+        const float coefficient = taps[even_tap];
+        if (coefficient != 0.0f) {
+            constexpr int distance = center - even_tap;
+            const ComplexIq minus = load_hb_complex_boundary(source, center_rel - distance);
+            const ComplexIq plus = load_hb_complex_boundary(source, center_rel + distance);
+            acc_i += coefficient * (minus.i + plus.i);
+            acc_q += coefficient * (minus.q + plus.q);
+        }
+        HbComplexFixedScalarSide<SideIndex + 1, SideCount>::apply(source, taps, center_rel, acc_i, acc_q);
+    }
+};
+
+template <int SideCount>
+struct HbComplexFixedScalarSide<SideCount, SideCount> {
+    static inline void
+    apply(const HbComplexBoundary&, const float*, int, float&, float&) {}
+};
+
+template <int TapsLen>
+static inline ComplexIq
+hb_complex_fixed_accumulate_scalar(const HbComplexBoundary& source, const float* taps, int n) {
+    constexpr int center = (TapsLen - 1) >> 1;
+    constexpr int side_count = (center + 1) >> 1;
+    const int center_rel = n << 1;
+    const ComplexIq center_sample = {source.in[center_rel << 1], source.in[(center_rel << 1) + 1]};
+    ComplexIq acc = {taps[center] * center_sample.i, taps[center] * center_sample.q};
+    HbComplexFixedScalarSide<0, side_count>::apply(source, taps, center_rel, acc.i, acc.q);
+    return acc;
+}
+
+template <int SideIndex, int SideCount>
+struct HbComplexFixedVectorSide {
+    static inline void
+    apply(const float* center_base, const float* taps, float32x4_t& acc0, float32x4_t& acc1) {
+        constexpr int even_tap = SideIndex << 1;
+        constexpr int center = (SideCount << 1) - 1;
+        constexpr int distance_floats = (center - even_tap) << 1;
+        const float coefficient = taps[even_tap];
+        if (coefficient != 0.0f) {
+            const float* minus = center_base - distance_floats;
+            const float* plus = center_base + distance_floats;
+            const float32x4_t sum0 = vaddq_f32(load_iq_stride2_2(minus), load_iq_stride2_2(plus));
+            const float32x4_t sum1 = vaddq_f32(load_iq_stride2_2(minus + 8), load_iq_stride2_2(plus + 8));
+            const float32x4_t tap = vdupq_n_f32(coefficient);
+            acc0 = vfmaq_f32(acc0, tap, sum0);
+            acc1 = vfmaq_f32(acc1, tap, sum1);
+        }
+        HbComplexFixedVectorSide<SideIndex + 1, SideCount>::apply(center_base, taps, acc0, acc1);
+    }
+};
+
+template <int SideCount>
+struct HbComplexFixedVectorSide<SideCount, SideCount> {
+    static inline void
+    apply(const float*, const float*, float32x4_t&, float32x4_t&) {}
+};
+
+template <int TapsLen>
+static int
+hb_complex_decim2_fixed(const float* in, int ch_len, float* out, const float* hist_i, const float* hist_q,
+                        const float* taps, float last_i, float last_q) {
+    static_assert(TapsLen == 15 || TapsLen == 31, "fixed half-band kernel supports 15 or 31 taps");
+    constexpr int center = (TapsLen - 1) >> 1;
+    constexpr int side_count = (center + 1) >> 1;
+    const int out_ch_len = ch_len >> 1;
+    const HbComplexBoundary source = {in, ch_len, hist_i, hist_q, TapsLen - 1, last_i, last_q};
+
+    int n = 0;
+    for (; n < out_ch_len && (n << 1) < center; n++) {
+        const ComplexIq acc = hb_complex_fixed_accumulate_scalar<TapsLen>(source, taps, n);
+        out[n << 1] = acc.i;
+        out[(n << 1) + 1] = acc.q;
+    }
+
+    /* Four outputs use two NEON accumulators; guard each helper's complete load footprint. */
+    for (; n + 3 < out_ch_len && (n << 1) + center + 7 < ch_len; n += 4) {
+        const float* center_base = in + (n << 2);
+        const float32x4_t center_tap = vdupq_n_f32(taps[center]);
+        float32x4_t acc0 = vmulq_f32(center_tap, load_iq_stride2_2(center_base));
+        float32x4_t acc1 = vmulq_f32(center_tap, load_iq_stride2_2(center_base + 8));
+
+        HbComplexFixedVectorSide<0, side_count>::apply(center_base, taps, acc0, acc1);
+        vst1q_f32(out + (n << 1), acc0);
+        vst1q_f32(out + ((n + 2) << 1), acc1);
+    }
+
+    for (; n < out_ch_len; n++) {
+        const ComplexIq acc = hb_complex_fixed_accumulate_scalar<TapsLen>(source, taps, n);
+        out[n << 1] = acc.i;
+        out[(n << 1) + 1] = acc.q;
+    }
+
+    return out_ch_len << 1;
+}
+
+static int
+hb_complex_decim2_fixed_dispatch(const float* in, int ch_len, float* out, float* hist_i, float* hist_q,
+                                 const float* taps, int taps_len) {
+    const float last_i = in[(ch_len - 1) << 1];
+    const float last_q = in[((ch_len - 1) << 1) + 1];
+    const int out_len = taps_len == 15
+                            ? hb_complex_decim2_fixed<15>(in, ch_len, out, hist_i, hist_q, taps, last_i, last_q)
+                            : hb_complex_decim2_fixed<31>(in, ch_len, out, hist_i, hist_q, taps, last_i, last_q);
+    update_complex_history(in, ch_len, hist_i, hist_q, taps_len - 1);
+    return out_len;
 }
 
 } /* namespace */
@@ -195,7 +343,8 @@ simd_fir_complex_apply_neon(const float* in, int in_len, float* out, float* hist
 
 /**
  * NEON complex half-band decimator by 2.
- * Processes 2 output samples (4 floats) at a time.
+ * Fixed 15- and 31-tap kernels process 4 complex outputs directly; other odd
+ * tap counts retain the scratch-backed 2-output kernel.
  */
 extern "C" int
 simd_hb_decim2_complex_neon(const float* in, int in_len, float* out, float* hist_i, float* hist_q, const float* taps,
@@ -203,13 +352,15 @@ simd_hb_decim2_complex_neon(const float* in, int in_len, float* out, float* hist
     if (taps_len < 3 || (taps_len & 1) == 0) {
         return 0;
     }
-
     int ch_len = in_len >> 1;
     if (ch_len <= 0) {
         return 0;
     }
     int out_ch_len = ch_len >> 1;
 
+    if (taps_len == 15 || taps_len == 31) {
+        return hb_complex_decim2_fixed_dispatch(in, ch_len, out, hist_i, hist_q, taps, taps_len);
+    }
     const int center = (taps_len - 1) >> 1;
     const int left_len = taps_len - 1;
     const int pad = center + 2;

--- a/src/dsp/simd_fir_sse2.cpp
+++ b/src/dsp/simd_fir_sse2.cpp
@@ -20,6 +20,21 @@
 
 namespace {
 
+struct ComplexIq {
+    float i;
+    float q;
+};
+
+struct HbComplexBoundary {
+    const float* in;
+    int ch_len;
+    const float* hist_i;
+    const float* hist_q;
+    int hist_len;
+    float last_i;
+    float last_q;
+};
+
 static thread_local std::vector<float> tls_scratch_iq;
 static thread_local std::vector<float> tls_scratch_real;
 
@@ -104,6 +119,139 @@ update_real_history(const float* in, int in_len, float* hist, int hist_len) {
     const int need = hist_len - in_len;
     DSD_MEMMOVE(hist, hist + in_len, (size_t)need * sizeof(float));
     DSD_MEMCPY(hist + need, in, (size_t)in_len * sizeof(float));
+}
+
+/* Load complex samples at indices base and base+2 from contiguous unaligned loads. */
+static inline __m128
+load_iq_stride2_2(const float* base) {
+    const __m128 lo = _mm_loadu_ps(base);
+    const __m128 hi = _mm_loadu_ps(base + 4);
+    return _mm_movelh_ps(lo, hi);
+}
+
+static inline ComplexIq
+load_hb_complex_boundary(const HbComplexBoundary& source, int rel) {
+    if (rel < 0) {
+        const int hist_idx = source.hist_len + rel;
+        return {source.hist_i[hist_idx], source.hist_q[hist_idx]};
+    }
+    if (rel < source.ch_len) {
+        return {source.in[rel << 1], source.in[(rel << 1) + 1]};
+    }
+    return {source.last_i, source.last_q};
+}
+
+template <int SideIndex, int SideCount>
+struct HbComplexFixedScalarSide {
+    static inline void
+    apply(const HbComplexBoundary& source, const float* taps, int center_rel, float& acc_i, float& acc_q) {
+        constexpr int even_tap = SideIndex << 1;
+        constexpr int center = (SideCount << 1) - 1;
+        const float coefficient = taps[even_tap];
+        if (coefficient != 0.0f) {
+            constexpr int distance = center - even_tap;
+            const ComplexIq minus = load_hb_complex_boundary(source, center_rel - distance);
+            const ComplexIq plus = load_hb_complex_boundary(source, center_rel + distance);
+            acc_i += coefficient * (minus.i + plus.i);
+            acc_q += coefficient * (minus.q + plus.q);
+        }
+        HbComplexFixedScalarSide<SideIndex + 1, SideCount>::apply(source, taps, center_rel, acc_i, acc_q);
+    }
+};
+
+template <int SideCount>
+struct HbComplexFixedScalarSide<SideCount, SideCount> {
+    static inline void
+    apply(const HbComplexBoundary&, const float*, int, float&, float&) {}
+};
+
+template <int TapsLen>
+static inline ComplexIq
+hb_complex_fixed_accumulate_scalar(const HbComplexBoundary& source, const float* taps, int n) {
+    constexpr int center = (TapsLen - 1) >> 1;
+    constexpr int side_count = (center + 1) >> 1;
+    const int center_rel = n << 1;
+    const ComplexIq center_sample = {source.in[center_rel << 1], source.in[(center_rel << 1) + 1]};
+    ComplexIq acc = {taps[center] * center_sample.i, taps[center] * center_sample.q};
+    HbComplexFixedScalarSide<0, side_count>::apply(source, taps, center_rel, acc.i, acc.q);
+    return acc;
+}
+
+template <int SideIndex, int SideCount>
+struct HbComplexFixedVectorSide {
+    static inline void
+    apply(const float* center_base, const float* taps, __m128& acc0, __m128& acc1) {
+        constexpr int even_tap = SideIndex << 1;
+        constexpr int center = (SideCount << 1) - 1;
+        constexpr int distance_floats = (center - even_tap) << 1;
+        const float coefficient = taps[even_tap];
+        if (coefficient != 0.0f) {
+            const float* minus = center_base - distance_floats;
+            const float* plus = center_base + distance_floats;
+            const __m128 sum0 = _mm_add_ps(load_iq_stride2_2(minus), load_iq_stride2_2(plus));
+            const __m128 sum1 = _mm_add_ps(load_iq_stride2_2(minus + 8), load_iq_stride2_2(plus + 8));
+            const __m128 tap = _mm_set1_ps(coefficient);
+            acc0 = _mm_add_ps(acc0, _mm_mul_ps(tap, sum0));
+            acc1 = _mm_add_ps(acc1, _mm_mul_ps(tap, sum1));
+        }
+        HbComplexFixedVectorSide<SideIndex + 1, SideCount>::apply(center_base, taps, acc0, acc1);
+    }
+};
+
+template <int SideCount>
+struct HbComplexFixedVectorSide<SideCount, SideCount> {
+    static inline void
+    apply(const float*, const float*, __m128&, __m128&) {}
+};
+
+template <int TapsLen>
+static int
+hb_complex_decim2_fixed(const float* in, int ch_len, float* out, const float* hist_i, const float* hist_q,
+                        const float* taps, float last_i, float last_q) {
+    static_assert(TapsLen == 15 || TapsLen == 31, "fixed half-band kernel supports 15 or 31 taps");
+    constexpr int center = (TapsLen - 1) >> 1;
+    constexpr int side_count = (center + 1) >> 1;
+    const int out_ch_len = ch_len >> 1;
+    const HbComplexBoundary source = {in, ch_len, hist_i, hist_q, TapsLen - 1, last_i, last_q};
+
+    int n = 0;
+    for (; n < out_ch_len && (n << 1) < center; n++) {
+        const ComplexIq acc = hb_complex_fixed_accumulate_scalar<TapsLen>(source, taps, n);
+        out[n << 1] = acc.i;
+        out[(n << 1) + 1] = acc.q;
+    }
+
+    /* Four outputs use two XMM accumulators; guard each helper's complete load footprint. */
+    for (; n + 3 < out_ch_len && (n << 1) + center + 7 < ch_len; n += 4) {
+        const float* center_base = in + (n << 2);
+        const __m128 center_tap = _mm_set1_ps(taps[center]);
+        __m128 acc0 = _mm_mul_ps(center_tap, load_iq_stride2_2(center_base));
+        __m128 acc1 = _mm_mul_ps(center_tap, load_iq_stride2_2(center_base + 8));
+
+        HbComplexFixedVectorSide<0, side_count>::apply(center_base, taps, acc0, acc1);
+        _mm_storeu_ps(out + (n << 1), acc0);
+        _mm_storeu_ps(out + ((n + 2) << 1), acc1);
+    }
+
+    for (; n < out_ch_len; n++) {
+        const ComplexIq acc = hb_complex_fixed_accumulate_scalar<TapsLen>(source, taps, n);
+        out[n << 1] = acc.i;
+        out[(n << 1) + 1] = acc.q;
+    }
+
+    return out_ch_len << 1;
+}
+
+static int
+hb_complex_decim2_fixed_dispatch(const float* in, int ch_len, float* out, float* hist_i, float* hist_q,
+                                 const float* taps, int taps_len) {
+    const float last_i = in[(ch_len - 1) << 1];
+    const float last_q = in[((ch_len - 1) << 1) + 1];
+    const int out_len = taps_len == 15
+                            ? hb_complex_decim2_fixed<15>(in, ch_len, out, hist_i, hist_q, taps, last_i, last_q)
+                            : hb_complex_decim2_fixed<31>(in, ch_len, out, hist_i, hist_q, taps, last_i, last_q);
+    update_complex_history(in, ch_len, hist_i, hist_q, taps_len - 1);
+    return out_len;
 }
 
 } /* namespace */
@@ -198,7 +346,8 @@ simd_fir_complex_apply_sse2(const float* in, int in_len, float* out, float* hist
 
 /**
  * SSE2 complex half-band decimator by 2.
- * Processes 2 output samples (4 floats) at a time.
+ * Fixed 15- and 31-tap kernels process 4 complex outputs directly; other odd
+ * tap counts retain the scratch-backed 2-output kernel.
  */
 extern "C" int
 simd_hb_decim2_complex_sse2(const float* in, int in_len, float* out, float* hist_i, float* hist_q, const float* taps,
@@ -206,13 +355,15 @@ simd_hb_decim2_complex_sse2(const float* in, int in_len, float* out, float* hist
     if (taps_len < 3 || (taps_len & 1) == 0) {
         return 0;
     }
-
     int ch_len = in_len >> 1;
     if (ch_len <= 0) {
         return 0;
     }
     int out_ch_len = ch_len >> 1;
 
+    if (taps_len == 15 || taps_len == 31) {
+        return hb_complex_decim2_fixed_dispatch(in, ch_len, out, hist_i, hist_q, taps, taps_len);
+    }
     const int center = (taps_len - 1) >> 1;
     const int left_len = taps_len - 1;
     const int pad = center + 2;

--- a/tests/dsp/bench_dsp.cpp
+++ b/tests/dsp/bench_dsp.cpp
@@ -41,6 +41,11 @@
 #include <vector>
 #include "dsd-neo/core/safe_api.h"
 
+#if defined(__x86_64__) || defined(_M_X64)
+extern "C" int simd_hb_decim2_complex_sse2(const float* in, int in_len, float* out, float* hist_i, float* hist_q,
+                                           const float* taps, int taps_len);
+#endif
+
 extern "C" int
 dsd_rtl_stream_should_exit(void) {
     return 0;
@@ -603,13 +608,120 @@ bench_fir(const BenchOptions& opts) {
         return out[0] + out[kInLen - 1] + hist_i[0] + hist_q[0];
     });
 
-    std::vector<float> hb_hist_i(HB_TAPS - 1, 0.0f);
-    std::vector<float> hb_hist_q(HB_TAPS - 1, 0.0f);
-    ran += run_case(opts, "simd_hb_decim2_complex", "pair", (double)kPairs, [&]() -> float {
-        int got = simd_hb_decim2_complex(in.data(), kInLen, out.data(), hb_hist_i.data(), hb_hist_q.data(), hb_q15_taps,
-                                         HB_TAPS);
-        return out[0] + out[(got > 0) ? got - 1 : 0] + (float)got;
-    });
+    std::vector<float> hb15_hist_i(HB_TAPS - 1, 0.0f);
+    std::vector<float> hb15_hist_q(HB_TAPS - 1, 0.0f);
+    BenchMeta hb15_meta;
+    hb15_meta.tap_count = HB_TAPS;
+    hb15_meta.variant = "fixed";
+    ran += run_case(
+        opts, "simd_hb_decim2_complex_15tap", "pair", (double)kPairs,
+        [&]() -> float {
+            int got = simd_hb_decim2_complex(in.data(), kInLen, out.data(), hb15_hist_i.data(), hb15_hist_q.data(),
+                                             hb_q15_taps, HB_TAPS);
+            return out[0] + out[(got > 0) ? got - 1 : 0] + (float)got;
+        },
+        &hb15_meta);
+
+    std::vector<float> hb31_hist_i(30, 0.0f);
+    std::vector<float> hb31_hist_q(30, 0.0f);
+    BenchMeta hb31_meta;
+    hb31_meta.tap_count = 31;
+    hb31_meta.variant = "fixed";
+    ran += run_case(
+        opts, "simd_hb_decim2_complex_31tap", "pair", (double)kPairs,
+        [&]() -> float {
+            int got = simd_hb_decim2_complex(in.data(), kInLen, out.data(), hb31_hist_i.data(), hb31_hist_q.data(),
+                                             hb31_q15_taps, 31);
+            return out[0] + out[(got > 0) ? got - 1 : 0] + (float)got;
+        },
+        &hb31_meta);
+
+    constexpr int kCascadeStages = 5;
+    constexpr int kCascadePairs = 8192;
+    constexpr int kCascadeInLen = kCascadePairs * 2;
+    std::vector<float> cascade_in(kCascadeInLen);
+    std::vector<float> cascade_work_a(kCascadeInLen);
+    std::vector<float> cascade_work_b(kCascadeInLen);
+    std::vector<float> cascade_hist_i[kCascadeStages];
+    std::vector<float> cascade_hist_q[kCascadeStages];
+    fill_noise(&cascade_in, 0x5A17u);
+    for (int stage = 0; stage < kCascadeStages; stage++) {
+        const int hist_len = (stage == 0) ? 30 : HB_TAPS - 1;
+        cascade_hist_i[stage].resize((size_t)hist_len, 0.0f);
+        cascade_hist_q[stage].resize((size_t)hist_len, 0.0f);
+    }
+    BenchMeta cascade_meta;
+    cascade_meta.rate_hz = 1536000;
+    cascade_meta.profile = "rtl_1536k_to_48k";
+    cascade_meta.variant = "31/15/15/15/15";
+    ran += run_case(
+        opts, "simd_hb_decim2_complex_5stage_32x", "input_pair", (double)kCascadePairs,
+        [&]() -> float {
+            const float* src = cascade_in.data();
+            float* dst = cascade_work_a.data();
+            int in_len = kCascadeInLen;
+            for (int stage = 0; stage < kCascadeStages; stage++) {
+                const float* stage_taps = (stage == 0) ? hb31_q15_taps : hb_q15_taps;
+                const int taps_len = (stage == 0) ? 31 : HB_TAPS;
+                const int got = simd_hb_decim2_complex(src, in_len, dst, cascade_hist_i[stage].data(),
+                                                       cascade_hist_q[stage].data(), stage_taps, taps_len);
+                src = dst;
+                in_len = got;
+                dst = (dst == cascade_work_a.data()) ? cascade_work_b.data() : cascade_work_a.data();
+            }
+            return src[0] + src[(in_len > 0) ? in_len - 1 : 0] + cascade_hist_i[0][0] + (float)in_len;
+        },
+        &cascade_meta);
+
+#if defined(__x86_64__) || defined(_M_X64)
+    std::vector<float> sse15_hist_i(HB_TAPS - 1, 0.0f);
+    std::vector<float> sse15_hist_q(HB_TAPS - 1, 0.0f);
+    ran += run_case(
+        opts, "simd_hb_decim2_complex_sse2_15tap", "pair", (double)kPairs,
+        [&]() -> float {
+            int got = simd_hb_decim2_complex_sse2(in.data(), kInLen, out.data(), sse15_hist_i.data(),
+                                                  sse15_hist_q.data(), hb_q15_taps, HB_TAPS);
+            return out[0] + out[(got > 0) ? got - 1 : 0] + (float)got;
+        },
+        &hb15_meta);
+
+    std::vector<float> sse31_hist_i(30, 0.0f);
+    std::vector<float> sse31_hist_q(30, 0.0f);
+    ran += run_case(
+        opts, "simd_hb_decim2_complex_sse2_31tap", "pair", (double)kPairs,
+        [&]() -> float {
+            int got = simd_hb_decim2_complex_sse2(in.data(), kInLen, out.data(), sse31_hist_i.data(),
+                                                  sse31_hist_q.data(), hb31_q15_taps, 31);
+            return out[0] + out[(got > 0) ? got - 1 : 0] + (float)got;
+        },
+        &hb31_meta);
+
+    std::vector<float> sse_cascade_hist_i[kCascadeStages];
+    std::vector<float> sse_cascade_hist_q[kCascadeStages];
+    for (int stage = 0; stage < kCascadeStages; stage++) {
+        const int hist_len = (stage == 0) ? 30 : HB_TAPS - 1;
+        sse_cascade_hist_i[stage].resize((size_t)hist_len, 0.0f);
+        sse_cascade_hist_q[stage].resize((size_t)hist_len, 0.0f);
+    }
+    ran += run_case(
+        opts, "simd_hb_decim2_complex_sse2_5stage_32x", "input_pair", (double)kCascadePairs,
+        [&]() -> float {
+            const float* src = cascade_in.data();
+            float* dst = cascade_work_a.data();
+            int in_len = kCascadeInLen;
+            for (int stage = 0; stage < kCascadeStages; stage++) {
+                const float* stage_taps = (stage == 0) ? hb31_q15_taps : hb_q15_taps;
+                const int taps_len = (stage == 0) ? 31 : HB_TAPS;
+                const int got = simd_hb_decim2_complex_sse2(src, in_len, dst, sse_cascade_hist_i[stage].data(),
+                                                            sse_cascade_hist_q[stage].data(), stage_taps, taps_len);
+                src = dst;
+                in_len = got;
+                dst = (dst == cascade_work_a.data()) ? cascade_work_b.data() : cascade_work_a.data();
+            }
+            return src[0] + src[(in_len > 0) ? in_len - 1 : 0] + sse_cascade_hist_i[0][0] + (float)in_len;
+        },
+        &cascade_meta);
+#endif
 
     std::vector<float> real_in(kInLen);
     std::vector<float> real_out(kInLen / 2);

--- a/tests/dsp/test_dsp_simd_fir.cpp
+++ b/tests/dsp/test_dsp_simd_fir.cpp
@@ -15,11 +15,14 @@
  * Covers edge cases: small blocks, odd lengths, history continuity, alignment.
  */
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <dsd-neo/dsp/halfband.h>
 #include <dsd-neo/dsp/simd_fir.h>
+#include <memory>
+#include <vector>
 #include "dsd-neo/core/safe_api.h"
 #include "dsp/simd_fir_internal.h"
 
@@ -367,6 +370,330 @@ test_direct_backend_invalid_guards(const char* name, complex_fir_backend_fn fir_
     std::printf("  PASS\n");
     return 0;
 }
+
+#if defined(__x86_64__) || defined(_M_X64) || defined(__aarch64__) || defined(__arm64) || defined(_M_ARM64)            \
+    || defined(_M_ARM64EC)
+
+namespace {
+enum class FixedBufferMode : uint8_t { Aligned, Unaligned, ExactSize };
+} // namespace
+
+static const char*
+fixed_buffer_mode_name(FixedBufferMode mode) {
+    switch (mode) {
+        case FixedBufferMode::Aligned: return "aligned";
+        case FixedBufferMode::Unaligned: return "unaligned";
+        case FixedBufferMode::ExactSize: return "exact-size";
+    }
+    return "unknown";
+}
+
+static float*
+fixed_test_buffer(std::vector<float>* storage, int count, FixedBufferMode mode) {
+    if (mode == FixedBufferMode::ExactSize) {
+        storage->resize((size_t)count);
+        return storage->data();
+    }
+
+    storage->resize((size_t)count + 16U);
+    void* buffer = storage->data();
+    size_t space = storage->size() * sizeof(float);
+    const size_t required = ((size_t)count + 1U) * sizeof(float);
+    float* aligned = static_cast<float*>(std::align(32U, required, buffer, space));
+    return (mode == FixedBufferMode::Unaligned) ? aligned + 1 : aligned;
+}
+
+template <int TapsLen>
+static void
+make_synthetic_halfband_taps(float* taps) {
+    const int center = (TapsLen - 1) >> 1;
+    for (int k = 0; k < TapsLen; k++) {
+        taps[k] = 0.0f;
+    }
+    for (int e = 0; e < center; e += 2) {
+        const float sign = ((e >> 1) & 1) ? -1.0f : 1.0f;
+        const float value = sign * (0.004f + 0.001f * (float)(e + 1));
+        taps[e] = value;
+        taps[TapsLen - 1 - e] = value;
+    }
+    taps[center] = 0.47f;
+}
+
+template <int TapsLen>
+static int
+run_direct_fixed_hb_case(const char* backend, complex_hb_backend_fn fn, const float* taps, const char* tap_name,
+                         int ch_len, FixedBufferMode mode) {
+    const int in_len = ch_len << 1;
+    const int hist_len = TapsLen - 1;
+    const int out_capacity = std::max(ch_len, 2);
+    constexpr float kOutputSentinel = 12345.0f;
+
+    std::vector<float> in_storage;
+    std::vector<float> out_storage;
+    std::vector<float> hist_i_storage;
+    std::vector<float> hist_q_storage;
+    float* in = fixed_test_buffer(&in_storage, in_len, mode);
+    float* out_simd = fixed_test_buffer(&out_storage, out_capacity, mode);
+    float* hist_i_simd = fixed_test_buffer(&hist_i_storage, hist_len, mode);
+    float* hist_q_simd = fixed_test_buffer(&hist_q_storage, hist_len, mode);
+
+    std::vector<float> out_ref((size_t)out_capacity, kOutputSentinel);
+    std::vector<float> hist_i_ref((size_t)hist_len);
+    std::vector<float> hist_q_ref((size_t)hist_len);
+
+    for (int k = 0; k < in_len; k++) {
+        in[k] = (float)(((k * 37 + ch_len * 11) % 257) - 128) * (1.0f / 91.0f);
+    }
+    /* Make the repeated suffix conspicuous, including for odd complex block sizes. */
+    in[in_len - 2] = 8.25f + 0.001f * (float)ch_len;
+    in[in_len - 1] = -6.75f - 0.002f * (float)ch_len;
+    for (int k = 0; k < hist_len; k++) {
+        hist_i_simd[k] = hist_i_ref[(size_t)k] = -1.25f + 0.031f * (float)k;
+        hist_q_simd[k] = hist_q_ref[(size_t)k] = 0.875f - 0.027f * (float)k;
+    }
+    std::fill(out_simd, out_simd + out_capacity, kOutputSentinel);
+
+    const int len_simd = fn(in, in_len, out_simd, hist_i_simd, hist_q_simd, taps, TapsLen);
+    const int len_ref =
+        simd_hb_decim2_complex_scalar(in, in_len, out_ref.data(), hist_i_ref.data(), hist_q_ref.data(), taps, TapsLen);
+    const int expected_len = (ch_len >> 1) << 1;
+
+    if (len_simd != expected_len || len_simd != len_ref) {
+        DSD_FPRINTF(stderr, "  FAIL: %s %s %d-tap size %d length %d/%d (expected %d)\n", backend,
+                    fixed_buffer_mode_name(mode), TapsLen, ch_len, len_simd, len_ref, expected_len);
+        return 1;
+    }
+    if (!arrays_close(out_simd, out_ref.data(), len_simd, kTolerance)) {
+        DSD_FPRINTF(stderr, "  FAIL: %s %s %s %d-tap size %d output mismatch\n", backend, fixed_buffer_mode_name(mode),
+                    tap_name, TapsLen, ch_len);
+        return 1;
+    }
+    if (len_simd == 0 && out_simd[0] != kOutputSentinel) {
+        DSD_FPRINTF(stderr, "  FAIL: %s %s %d-tap zero-output block mutated output\n", backend,
+                    fixed_buffer_mode_name(mode), TapsLen);
+        return 1;
+    }
+    if (!arrays_close(hist_i_simd, hist_i_ref.data(), hist_len, 0.0f)
+        || !arrays_close(hist_q_simd, hist_q_ref.data(), hist_len, 0.0f)) {
+        DSD_FPRINTF(stderr, "  FAIL: %s %s %s %d-tap size %d history mismatch\n", backend, fixed_buffer_mode_name(mode),
+                    tap_name, TapsLen, ch_len);
+        return 1;
+    }
+    return 0;
+}
+
+template <int TapsLen>
+static int
+test_direct_fixed_hb_tap_count(const char* backend, complex_hb_backend_fn fn, const float* canonical_taps,
+                               int vector_load_tail) {
+    alignas(64) float synthetic_taps[TapsLen];
+    make_synthetic_halfband_taps<TapsLen>(synthetic_taps);
+
+    const int sizes[] = {1, 2, 7, 15, 30, 31, 32, 33, 47, 48, 49, 65, 8192, 8193};
+    const float* tap_sets[] = {canonical_taps, synthetic_taps};
+    const char* tap_names[] = {"canonical", "synthetic"};
+    const FixedBufferMode modes[] = {FixedBufferMode::Aligned, FixedBufferMode::Unaligned};
+
+    for (int tap_set = 0; tap_set < 2; tap_set++) {
+        for (FixedBufferMode mode : modes) {
+            for (int ch_len : sizes) {
+                if (run_direct_fixed_hb_case<TapsLen>(backend, fn, tap_sets[tap_set], tap_names[tap_set], ch_len, mode)
+                    != 0) {
+                    return 1;
+                }
+            }
+        }
+    }
+
+    /* The first legal vector block ends exactly at the allocation boundary. */
+    constexpr int center = (TapsLen - 1) >> 1;
+    constexpr int first_vector_n = (center + 1) >> 1;
+    const int exact_vector_ch_len = (first_vector_n << 1) + center + vector_load_tail + 1;
+    for (int tap_set = 0; tap_set < 2; tap_set++) {
+        if (run_direct_fixed_hb_case<TapsLen>(backend, fn, tap_sets[tap_set], tap_names[tap_set], exact_vector_ch_len,
+                                              FixedBufferMode::ExactSize)
+            != 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+template <int TapsLen>
+static int
+test_direct_fixed_hb_stream(const char* backend, complex_hb_backend_fn fn, const float* taps) {
+    constexpr int hist_len = TapsLen - 1;
+    const int block_sizes[] = {1, 31, 48, 17, 8193, 2, 65, 32};
+    std::vector<float> hist_i_simd(hist_len);
+    std::vector<float> hist_q_simd(hist_len);
+    std::vector<float> hist_i_ref(hist_len);
+    std::vector<float> hist_q_ref(hist_len);
+
+    for (int k = 0; k < hist_len; k++) {
+        hist_i_simd[(size_t)k] = hist_i_ref[(size_t)k] = 2.0f - 0.041f * (float)k;
+        hist_q_simd[(size_t)k] = hist_q_ref[(size_t)k] = -1.0f + 0.037f * (float)k;
+    }
+
+    int stream_offset = 0;
+    for (int ch_len : block_sizes) {
+        const int in_len = ch_len << 1;
+        std::vector<float> in((size_t)in_len);
+        std::vector<float> out_simd((size_t)std::max(ch_len, 2), 23456.0f);
+        std::vector<float> out_ref((size_t)std::max(ch_len, 2), 23456.0f);
+        for (int k = 0; k < in_len; k++) {
+            in[(size_t)k] = (float)(((stream_offset + k * 19) % 311) - 155) * (1.0f / 73.0f);
+        }
+        in[(size_t)in_len - 2] = 4.5f + 0.01f * (float)ch_len;
+        in[(size_t)in_len - 1] = -3.75f - 0.02f * (float)ch_len;
+        stream_offset += in_len;
+
+        const int len_simd =
+            fn(in.data(), in_len, out_simd.data(), hist_i_simd.data(), hist_q_simd.data(), taps, TapsLen);
+        const int len_ref = simd_hb_decim2_complex_scalar(in.data(), in_len, out_ref.data(), hist_i_ref.data(),
+                                                          hist_q_ref.data(), taps, TapsLen);
+        if (len_simd != len_ref || !arrays_close(out_simd.data(), out_ref.data(), len_simd, kTolerance)
+            || !arrays_close(hist_i_simd.data(), hist_i_ref.data(), hist_len, 0.0f)
+            || !arrays_close(hist_q_simd.data(), hist_q_ref.data(), hist_len, 0.0f)) {
+            DSD_FPRINTF(stderr, "  FAIL: %s %d-tap variable stream block size %d mismatch\n", backend, TapsLen, ch_len);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+test_direct_generic_23tap_hb(const char* backend, complex_hb_backend_fn fn) {
+    constexpr int taps_len = 23;
+    constexpr int hist_len = taps_len - 1;
+    constexpr int ch_len = 127;
+    alignas(64) float taps[taps_len];
+    make_synthetic_halfband_taps<taps_len>(taps);
+    std::vector<float> in((size_t)ch_len * 2U);
+    std::vector<float> out_simd(ch_len);
+    std::vector<float> out_ref(ch_len);
+    std::vector<float> hist_i_simd(hist_len);
+    std::vector<float> hist_q_simd(hist_len);
+    std::vector<float> hist_i_ref(hist_len);
+    std::vector<float> hist_q_ref(hist_len);
+
+    for (int k = 0; k < ch_len * 2; k++) {
+        in[(size_t)k] = (float)((k * 29) % 101 - 50) * 0.025f;
+    }
+    for (int k = 0; k < hist_len; k++) {
+        hist_i_simd[(size_t)k] = hist_i_ref[(size_t)k] = 0.03f * (float)(k - 9);
+        hist_q_simd[(size_t)k] = hist_q_ref[(size_t)k] = -0.02f * (float)(k + 3);
+    }
+
+    const int len_simd =
+        fn(in.data(), ch_len * 2, out_simd.data(), hist_i_simd.data(), hist_q_simd.data(), taps, taps_len);
+    const int len_ref = simd_hb_decim2_complex_scalar(in.data(), ch_len * 2, out_ref.data(), hist_i_ref.data(),
+                                                      hist_q_ref.data(), taps, taps_len);
+    if (len_simd != len_ref || !arrays_close(out_simd.data(), out_ref.data(), len_simd, kTolerance)
+        || !arrays_close(hist_i_simd.data(), hist_i_ref.data(), hist_len, 0.0f)
+        || !arrays_close(hist_q_simd.data(), hist_q_ref.data(), hist_len, 0.0f)) {
+        DSD_FPRINTF(stderr, "  FAIL: %s generic 23-tap fallback mismatch\n", backend);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_direct_hb_cascade(const char* backend, complex_hb_backend_fn fn) {
+    constexpr int stages = 5;
+    constexpr int input_pairs = 8192;
+    const int tap_lengths[stages] = {31, 15, 15, 15, 15};
+    const float* tap_sets[stages] = {hb31_q15_taps, hb_q15_taps, hb_q15_taps, hb_q15_taps, hb_q15_taps};
+    std::vector<float> current_simd((size_t)input_pairs * 2U);
+    std::vector<float> current_ref((size_t)input_pairs * 2U);
+    std::vector<float> hist_i_simd[stages];
+    std::vector<float> hist_q_simd[stages];
+    std::vector<float> hist_i_ref[stages];
+    std::vector<float> hist_q_ref[stages];
+
+    for (int k = 0; k < input_pairs * 2; k++) {
+        current_simd[(size_t)k] = current_ref[(size_t)k] = (float)((k * 43) % 509 - 254) * (1.0f / 127.0f);
+    }
+    for (int stage = 0; stage < stages; stage++) {
+        const int hist_len = tap_lengths[stage] - 1;
+        hist_i_simd[stage].resize((size_t)hist_len);
+        hist_q_simd[stage].resize((size_t)hist_len);
+        hist_i_ref[stage].resize((size_t)hist_len);
+        hist_q_ref[stage].resize((size_t)hist_len);
+        for (int k = 0; k < hist_len; k++) {
+            hist_i_simd[stage][(size_t)k] = hist_i_ref[stage][(size_t)k] =
+                0.1f * (float)(stage + 1) + 0.007f * (float)k;
+            hist_q_simd[stage][(size_t)k] = hist_q_ref[stage][(size_t)k] =
+                -0.2f * (float)(stage + 1) - 0.005f * (float)k;
+        }
+    }
+
+    for (int stage = 0; stage < stages; stage++) {
+        std::vector<float> next_simd(current_simd.size() / 2U);
+        std::vector<float> next_ref(current_ref.size() / 2U);
+        const int taps_len = tap_lengths[stage];
+        const int hist_len = taps_len - 1;
+        const int len_simd = fn(current_simd.data(), (int)current_simd.size(), next_simd.data(),
+                                hist_i_simd[stage].data(), hist_q_simd[stage].data(), tap_sets[stage], taps_len);
+        const int len_ref = simd_hb_decim2_complex_scalar(current_ref.data(), (int)current_ref.size(), next_ref.data(),
+                                                          hist_i_ref[stage].data(), hist_q_ref[stage].data(),
+                                                          tap_sets[stage], taps_len);
+        bool histories_exact = true;
+        const int input_pairs = (int)current_simd.size() >> 1;
+        for (int k = 0; k < hist_len; k++) {
+            const int rel = input_pairs - hist_len + k;
+            histories_exact = histories_exact && hist_i_simd[stage][(size_t)k] == current_simd[(size_t)rel * 2U]
+                              && hist_q_simd[stage][(size_t)k] == current_simd[(size_t)rel * 2U + 1U]
+                              && hist_i_ref[stage][(size_t)k] == current_ref[(size_t)rel * 2U]
+                              && hist_q_ref[stage][(size_t)k] == current_ref[(size_t)rel * 2U + 1U];
+        }
+        if (len_simd != len_ref || len_simd != (int)next_simd.size()
+            || !arrays_close(next_simd.data(), next_ref.data(), len_simd, kTolerance) || !histories_exact
+            || !arrays_close(hist_i_simd[stage].data(), hist_i_ref[stage].data(), hist_len, kTolerance)
+            || !arrays_close(hist_q_simd[stage].data(), hist_q_ref[stage].data(), hist_len, kTolerance)) {
+            DSD_FPRINTF(stderr, "  FAIL: %s five-stage cascade mismatch at stage %d\n", backend, stage);
+            return 1;
+        }
+        current_simd.swap(next_simd);
+        current_ref.swap(next_ref);
+    }
+    return 0;
+}
+
+static int
+test_direct_fixed_hb_kernels(const char* backend, complex_hb_backend_fn fn, int vector_load_tail) {
+    std::printf("Testing direct %s fixed complex HB kernels...\n", backend);
+
+    if (test_direct_fixed_hb_tap_count<15>(backend, fn, hb_q15_taps, vector_load_tail) != 0
+        || test_direct_fixed_hb_tap_count<31>(backend, fn, hb31_q15_taps, vector_load_tail) != 0
+        || test_direct_fixed_hb_stream<15>(backend, fn, hb_q15_taps) != 0
+        || test_direct_fixed_hb_stream<31>(backend, fn, hb31_q15_taps) != 0
+        || test_direct_generic_23tap_hb(backend, fn) != 0 || test_direct_hb_cascade(backend, fn) != 0) {
+        return 1;
+    }
+
+    /* Invalid float lengths must not touch the fixed-kernel histories. */
+    alignas(64) float in[1] = {7.0f};
+    alignas(64) float out[2] = {19.0f, 23.0f};
+    alignas(64) float hist_i[30];
+    alignas(64) float hist_q[30];
+    alignas(64) float hist_i_before[30];
+    alignas(64) float hist_q_before[30];
+    for (int k = 0; k < 30; k++) {
+        hist_i[k] = hist_i_before[k] = (float)(k + 1);
+        hist_q[k] = hist_q_before[k] = (float)(-k - 1);
+    }
+    const int len = fn(in, 1, out, hist_i, hist_q, hb31_q15_taps, 31);
+    if (len != 0 || out[0] != 19.0f || out[1] != 23.0f || !arrays_close(hist_i, hist_i_before, 30, 0.0f)
+        || !arrays_close(hist_q, hist_q_before, 30, 0.0f)) {
+        DSD_FPRINTF(stderr, "  FAIL: %s fixed-kernel invalid guard mutated state\n", backend);
+        return 1;
+    }
+
+    std::printf("  PASS\n");
+    return 0;
+}
+
+#endif
 
 /* Test 63-tap symmetric FIR (channel LPF style) */
 static int
@@ -894,6 +1221,11 @@ main(void) {
     failures += test_direct_complex_fir_backend("sse2", simd_fir_complex_apply_sse2);
     failures += test_direct_complex_hb_backend("sse2", simd_hb_decim2_complex_sse2);
     failures += test_direct_real_hb_backend("sse2", simd_hb_decim2_real_sse2);
+    failures += test_direct_backend_tail_mix("sse2", simd_fir_complex_apply_sse2, simd_hb_decim2_complex_sse2,
+                                             simd_hb_decim2_real_sse2);
+    failures += test_direct_backend_invalid_guards("sse2", simd_fir_complex_apply_sse2, simd_hb_decim2_complex_sse2,
+                                                   simd_hb_decim2_real_sse2);
+    failures += test_direct_fixed_hb_kernels("sse2", simd_hb_decim2_complex_sse2, 7);
 #if defined(DSD_NEO_TEST_HAVE_AVX2_IMPL)
     if (dsd_neo_cpu_has_avx2_with_os_support()) {
         failures += test_direct_complex_fir_backend("avx2", simd_fir_complex_apply_avx2);
@@ -903,6 +1235,7 @@ main(void) {
                                                  simd_hb_decim2_real_avx2);
         failures += test_direct_backend_invalid_guards("avx2", simd_fir_complex_apply_avx2, simd_hb_decim2_complex_avx2,
                                                        simd_hb_decim2_real_avx2);
+        failures += test_direct_fixed_hb_kernels("avx2", simd_hb_decim2_complex_avx2, 15);
     } else {
         std::printf("Skipping direct AVX2 backend tests: CPU/OS AVX2+FMA support unavailable\n");
     }
@@ -913,6 +1246,11 @@ main(void) {
     failures += test_direct_complex_fir_backend("neon", simd_fir_complex_apply_neon);
     failures += test_direct_complex_hb_backend("neon", simd_hb_decim2_complex_neon);
     failures += test_direct_real_hb_backend("neon", simd_hb_decim2_real_neon);
+    failures += test_direct_backend_tail_mix("neon", simd_fir_complex_apply_neon, simd_hb_decim2_complex_neon,
+                                             simd_hb_decim2_real_neon);
+    failures += test_direct_backend_invalid_guards("neon", simd_fir_complex_apply_neon, simd_hb_decim2_complex_neon,
+                                                   simd_hb_decim2_real_neon);
+    failures += test_direct_fixed_hb_kernels("neon", simd_hb_decim2_complex_neon, 7);
 #endif
 
     if (failures > 0) {


### PR DESCRIPTION
## Summary

- add fixed 15- and 31-tap complex half-band decimators for AVX2, SSE2, and NEON
- process the vector interior directly from input with complete load-footprint guards
- keep scalar boundary handling for history-dependent prefixes, repeated-last suffixes, and vector remainders
- preserve the scratch-backed generic SIMD path for other odd tap counts, including 23 taps
- add explicit 15/31-tap benchmarks and a realistic 8192-complex-input, five-stage 32× cascade benchmark
- expand direct-backend coverage for alignment, short/odd blocks, history continuity, tail extension, invalid inputs, and the 31/15/15/15/15 cascade

## Why

The 1.536 MS/s to 48 kHz RTL path uses one 31-tap stage followed by four 15-tap stages. The generic SIMD kernels copied the full interleaved input into scratch storage and scalar-packed decimated complex samples before doing relatively little half-band arithmetic. Fixed-size kernels can instead load alternating complex samples directly and fully unroll the side taps while retaining the existing phase, output sizing, history layout, and edge behavior.

## Performance

Five-repeat median comparisons on the x86 host:

| Case | AVX2 reduction | SSE2 reduction |
| --- | ---: | ---: |
| 15 tap | 65.7% | 61.7% |
| 31 tap | 61.9% | 58.4% |
| five-stage 32× cascade | 63.2% | 59.6% |

Instruction counts fell by roughly 75% for AVX2 and 67–68% for SSE2 in the targeted cases. No unrelated DSP benchmark exceeded the 5% regression threshold. NEON timing is intentionally omitted because emulation is not representative of physical ARM performance.

## Validation

- `ctest --preset dev-debug --output-on-failure`: 460/460 passed
- focused ASan/UBSan SIMD FIR suite: passed
- AArch64 warning-as-error cross-build and full SIMD FIR suite under QEMU: passed
- `tools/preflight_ci.sh`: passed
- exact-sized, aligned, and deliberately unaligned input/output/history buffers
- canonical and synthetic 15/31-tap coefficient arrays
- variable multi-block streams, zero-output blocks, last-sample extension, invalid guards, and generic 23-tap fallback
- stage-by-stage scalar comparison for the five-stage cascade

Physical NEON hardware timing and the live RTL/P25 capture run remain to be confirmed on suitable hardware.