### PR TITLE
rtl: fuse CU8 level moments into ingest

### DIFF
--- a/docs/dsp-benchmarking.md
+++ b/docs/dsp-benchmarking.md
@@ -68,6 +68,10 @@ The benchmark target includes:
 The RTL benchmark target includes:
 
 - CU8 ingest into the input ring for contiguous and wrap-around reservations.
+- Standalone CU8 integer-level reduction at the 16 KiB default block size and
+  256 KiB maximum block size.
+- Production-equivalent CU8 ingest plus level reduction at both block sizes,
+  with benchmark-only `separate` cases retained as the unfused-pass baseline.
 - CS16 ingest conversion for Soapy-style signed sample input.
 - Post-demod spectrum snapshot updates used by the UI/metrics path.
 - 512-sample direct-output batch reads.
@@ -95,6 +99,12 @@ Focused comparisons are usually more useful than all-case runs:
 python3 tools/dsp_bench_compare.py /tmp/dsd-main.csv /tmp/dsd-candidate.csv --filter cqpsk
 python3 tools/dsp_bench_compare.py /tmp/dsd-main.csv /tmp/dsd-candidate.csv --filter channel_lpf
 ```
+
+For CU8 ingest work, capture five-repeat CSV medians for the matching
+`rtl_ingest_u8_metrics_separate_*` and `rtl_ingest_u8_metrics_fused_*` cases.
+The 16 KiB cases represent the normal live block and the 256 KiB cases exercise
+the maximum supported benchmark block. Treat differences below roughly 5% as
+inconclusive unless repeated runs and hardware counters agree.
 
 Use `items_per_second` when throughput is easier to read:
 
@@ -128,6 +138,8 @@ working directory. `DSD_NEO_RTL_PERF_INTERVAL_MS` controls the aggregation
 window and is clamped to 100-60000 ms. CSV rows include ring fill, cumulative
 input drops, ingest timing, `full_demod()` timing, post-demod metrics timing,
 output-write timing, consumer-read timing, SNR, CFO, and carrier lock snapshots.
+For CU8 sources, `ingest_ns` includes the integer level reduction fused into
+widening, rotation, pending-buffer copies, and dropped-tail accounting.
 
 Use live CSV to decide which synthetic cases deserve focused before/after runs.
 For example, high `post_metrics_ns` points at `rtl_metrics_spectrum_*`, while

--- a/include/dsd-neo/core/input_level.h
+++ b/include/dsd-neo/core/input_level.h
@@ -50,6 +50,23 @@ typedef struct dsd_input_level_snapshot {
     time_t updated;
 } dsd_input_level_snapshot;
 
+/**
+ * @brief Exact integer moments for unsigned 8-bit interleaved I/Q bytes.
+ *
+ * CU8 level snapshots intentionally treat every I and Q byte as one sample.
+ * Keeping the raw moments in integers lets capture paths collect them while
+ * widening or copying data and defer floating-point normalization until a
+ * complete source block is ready to publish.
+ */
+typedef struct dsd_input_level_cu8_moments {
+    uint64_t count;
+    uint64_t sum;
+    uint64_t sum_sq;
+    uint64_t clipped;
+    uint8_t min_sample;
+    uint8_t max_sample;
+} dsd_input_level_cu8_moments;
+
 typedef enum DSD_ATTR_PACKED dsd_input_level_notify_mask {
     DSD_INPUT_LEVEL_NOTIFY_LOW = 1U << 0U,
     DSD_INPUT_LEVEL_NOTIFY_HOT = 1U << 1U,
@@ -69,6 +86,13 @@ int dsd_input_level_metrics_from_pcm_i16(const int16_t* samples, size_t count, s
                                          dsd_input_level_source source, dsd_input_level_snapshot* out);
 int dsd_input_level_metrics_from_pcm_f32_i16_scale(const float* samples, size_t count, size_t step,
                                                    dsd_input_level_source source, dsd_input_level_snapshot* out);
+void dsd_input_level_cu8_moments_reset(dsd_input_level_cu8_moments* moments);
+int dsd_input_level_cu8_moments_merge(dsd_input_level_cu8_moments* moments, const dsd_input_level_cu8_moments* add);
+int dsd_input_level_cu8_moments_accumulate(dsd_input_level_cu8_moments* moments, const uint8_t* samples, size_t count);
+int dsd_input_level_cu8_moments_finalize(const dsd_input_level_cu8_moments* moments, dsd_input_level_source source,
+                                         dsd_input_level_snapshot* out);
+int dsd_input_level_metrics_from_cu8_moments(const dsd_input_level_cu8_moments* moments, dsd_input_level_source source,
+                                             dsd_input_level_snapshot* out);
 int dsd_input_level_metrics_from_cu8(const uint8_t* samples, size_t count, dsd_input_level_source source,
                                      dsd_input_level_snapshot* out);
 int dsd_input_level_metrics_from_cs16(const int16_t* samples, size_t count, dsd_input_level_source source,

--- a/include/dsd-neo/dsp/simd_widen.h
+++ b/include/dsd-neo/dsp/simd_widen.h
@@ -14,6 +14,8 @@
 #ifndef DSD_NEO_SIMD_WIDEN_H
 #define DSD_NEO_SIMD_WIDEN_H
 
+#include <dsd-neo/core/input_level.h>
+
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -50,6 +52,16 @@ typedef void (*dsd_neo_widen_rot_fn)(const unsigned char*, float*, uint32_t);
 void widen_u8_to_f32_bias127(const unsigned char* src, float* dst, uint32_t len);
 
 /**
+ * @brief Widen CU8 bytes and accumulate their exact raw integer moments.
+ *
+ * The conversion is identical to widen_u8_to_f32_bias127(). Moments are
+ * collected from the unmodified source bytes and merged into @p moments once
+ * per call.
+ */
+void widen_u8_to_f32_bias127_moments(const unsigned char* src, float* dst, uint32_t len,
+                                     dsd_input_level_cu8_moments* moments);
+
+/**
  * @brief Rotate 90° (IQ) and widen u8→float centered at 127.5 with explicit phase.
  *
  * Applies the `j^n` sequence starting at `phase & 3`, where phase 0 leaves the
@@ -67,6 +79,15 @@ void widen_u8_to_f32_bias127(const unsigned char* src, float* dst, uint32_t len)
  * @return Next rotation phase after processing the available I/Q pairs.
  */
 uint32_t widen_rotate90_u8_to_f32_bias127_phase(const unsigned char* src, float* dst, uint32_t len, uint32_t phase);
+
+/**
+ * @brief Rotate/widen CU8 pairs and accumulate pre-rotation integer moments.
+ *
+ * As with the conversion-only API, only complete I/Q pairs are processed.
+ * Moments therefore cover `floor(len / 2) * 2` source bytes.
+ */
+uint32_t widen_rotate90_u8_to_f32_bias127_phase_moments(const unsigned char* src, float* dst, uint32_t len,
+                                                        uint32_t phase, dsd_input_level_cu8_moments* moments);
 
 #ifdef __cplusplus
 }

--- a/src/dsp/simd_widen.cpp
+++ b/src/dsp/simd_widen.cpp
@@ -12,6 +12,7 @@
  * for downstream float processing.
  */
 
+#include <dsd-neo/core/input_level.h>
 #include <dsd-neo/dsp/simd_widen.h>
 
 #include <atomic>
@@ -42,29 +43,51 @@ apply_j4_rotation_f32(float in_i, float in_q, uint32_t phase, float* out_i, floa
 }
 
 using widen_rot_phase_fn = uint32_t (*)(const unsigned char*, float*, uint32_t, uint32_t);
+using widen_moments_fn = void (*)(const unsigned char*, float*, uint32_t, dsd_input_level_cu8_moments*);
+using widen_rot_phase_moments_fn = uint32_t (*)(const unsigned char*, float*, uint32_t, uint32_t,
+                                                dsd_input_level_cu8_moments*);
 
 #if defined(__x86_64__) || defined(_M_X64)
+extern "C" void widen_u8_to_f32_bias127_moments_sse2(const unsigned char* src, float* dst, uint32_t len,
+                                                     dsd_input_level_cu8_moments* moments);
 extern "C" uint32_t widen_rotate90_u8_to_f32_bias127_phase_sse2(const unsigned char* src, float* dst, uint32_t len,
                                                                 uint32_t phase);
+extern "C" uint32_t widen_rotate90_u8_to_f32_bias127_phase_moments_sse2(const unsigned char* src, float* dst,
+                                                                        uint32_t len, uint32_t phase,
+                                                                        dsd_input_level_cu8_moments* moments);
 #if defined(DSD_NEO_DSP_HAVE_AVX2_IMPL) && DSD_NEO_X86_AVX2_RUNTIME_PROBE_SUPPORTED
+extern "C" void widen_u8_to_f32_bias127_moments_avx2(const unsigned char* src, float* dst, uint32_t len,
+                                                     dsd_input_level_cu8_moments* moments);
 extern "C" uint32_t widen_rotate90_u8_to_f32_bias127_phase_avx2(const unsigned char* src, float* dst, uint32_t len,
                                                                 uint32_t phase);
+extern "C" uint32_t widen_rotate90_u8_to_f32_bias127_phase_moments_avx2(const unsigned char* src, float* dst,
+                                                                        uint32_t len, uint32_t phase,
+                                                                        dsd_input_level_cu8_moments* moments);
 #endif
 #endif
 
 #if defined(__aarch64__) || defined(__arm64) || defined(_M_ARM64) || defined(_M_ARM64EC)
+extern "C" void widen_u8_to_f32_bias127_moments_neon(const unsigned char* src, float* dst, uint32_t len,
+                                                     dsd_input_level_cu8_moments* moments);
 extern "C" uint32_t widen_rotate90_u8_to_f32_bias127_phase_neon(const unsigned char* src, float* dst, uint32_t len,
                                                                 uint32_t phase);
+extern "C" uint32_t widen_rotate90_u8_to_f32_bias127_phase_moments_neon(const unsigned char* src, float* dst,
+                                                                        uint32_t len, uint32_t phase,
+                                                                        dsd_input_level_cu8_moments* moments);
 #endif
 
+static void widen_u8_to_f32_bias127_moments_scalar(const unsigned char* src, float* dst, uint32_t len,
+                                                   dsd_input_level_cu8_moments* moments);
 static uint32_t widen_rotate90_u8_to_f32_bias127_phase_scalar(const unsigned char* src, float* dst, uint32_t len,
                                                               uint32_t phase);
-#ifdef DSD_NEO_TEST_HOOKS
-extern "C" uint32_t dsd_test_widen_rotate90_u8_to_f32_bias127_phase_scalar(const unsigned char* src, float* dst,
-                                                                           uint32_t len, uint32_t phase);
-#endif
+static uint32_t widen_rotate90_u8_to_f32_bias127_phase_moments_scalar(const unsigned char* src, float* dst,
+                                                                      uint32_t len, uint32_t phase,
+                                                                      dsd_input_level_cu8_moments* moments);
 
 static widen_rot_phase_fn g_widen_rot_phase_impl = widen_rotate90_u8_to_f32_bias127_phase_scalar;
+static widen_moments_fn g_widen_moments_impl = widen_u8_to_f32_bias127_moments_scalar;
+static widen_rot_phase_moments_fn g_widen_rot_phase_moments_impl =
+    widen_rotate90_u8_to_f32_bias127_phase_moments_scalar;
 static std::atomic<int> g_widen_init_done{0};
 
 static void
@@ -81,57 +104,133 @@ simd_widen_init_dispatch(void) {
 #if defined(DSD_NEO_DSP_HAVE_AVX2_IMPL) && DSD_NEO_X86_AVX2_RUNTIME_PROBE_SUPPORTED
     if (dsd_neo_cpu_has_avx2_with_os_support()) {
         g_widen_rot_phase_impl = widen_rotate90_u8_to_f32_bias127_phase_avx2;
+        g_widen_moments_impl = widen_u8_to_f32_bias127_moments_avx2;
+        g_widen_rot_phase_moments_impl = widen_rotate90_u8_to_f32_bias127_phase_moments_avx2;
     } else
 #endif
     {
         g_widen_rot_phase_impl = widen_rotate90_u8_to_f32_bias127_phase_sse2;
+        g_widen_moments_impl = widen_u8_to_f32_bias127_moments_sse2;
+        g_widen_rot_phase_moments_impl = widen_rotate90_u8_to_f32_bias127_phase_moments_sse2;
     }
 #elif defined(__aarch64__) || defined(__arm64) || defined(_M_ARM64) || defined(_M_ARM64EC)
     g_widen_rot_phase_impl = widen_rotate90_u8_to_f32_bias127_phase_neon;
+    g_widen_moments_impl = widen_u8_to_f32_bias127_moments_neon;
+    g_widen_rot_phase_moments_impl = widen_rotate90_u8_to_f32_bias127_phase_moments_neon;
 #endif
 
     g_widen_init_done.store(2, std::memory_order_release);
 }
 
+static inline void
+accumulate_cu8_local(dsd_input_level_cu8_moments* local, unsigned char sample) {
+    local->sum += (uint64_t)sample;
+    local->sum_sq += (uint64_t)sample * (uint64_t)sample;
+    local->clipped += (sample <= 1U || sample >= 254U) ? 1U : 0U;
+    if (sample < local->min_sample) {
+        local->min_sample = sample;
+    }
+    if (sample > local->max_sample) {
+        local->max_sample = sample;
+    }
+}
+
 void
 widen_u8_to_f32_bias127(const unsigned char* src, float* dst, uint32_t len) {
-    if (!src || !dst || len == 0) {
+    if (!src || !dst || len == 0U) {
         return;
     }
     const float inv = 1.0f / 127.5f;
     for (uint32_t i = 0; i < len; i++) {
-        float v = ((float)src[i] - 127.5f) * inv;
-        dst[i] = v;
+        dst[i] = ((float)src[i] - 127.5f) * inv;
     }
 }
 
+static void
+widen_u8_to_f32_bias127_moments_scalar(const unsigned char* src, float* dst, uint32_t len,
+                                       dsd_input_level_cu8_moments* moments) {
+    if (!src || !dst || !moments || len == 0U) {
+        return;
+    }
+    dsd_input_level_cu8_moments local;
+    dsd_input_level_cu8_moments_reset(&local);
+    local.count = len;
+    const float inv = 1.0f / 127.5f;
+    for (uint32_t i = 0; i < len; i++) {
+        const unsigned char sample = src[i];
+        dst[i] = ((float)sample - 127.5f) * inv;
+        accumulate_cu8_local(&local, sample);
+    }
+    (void)dsd_input_level_cu8_moments_merge(moments, &local);
+}
+
 static uint32_t
-widen_rotate90_u8_to_f32_bias127_phase_scalar(const unsigned char* src, float* dst, uint32_t len, uint32_t phase) {
+widen_rotate90_u8_to_f32_bias127_phase_moments_scalar(const unsigned char* src, float* dst, uint32_t len,
+                                                      uint32_t phase, dsd_input_level_cu8_moments* moments) {
     uint32_t cur_phase = phase & 3U;
-    if (!src || !dst || len < 2) {
+    if (!src || !dst || len < 2U) {
         return cur_phase;
     }
 
     const float inv = 1.0f / 127.5f;
-    uint32_t pairs = len >> 1;
+    const uint32_t pairs = len >> 1;
+    dsd_input_level_cu8_moments local;
+    if (moments) {
+        dsd_input_level_cu8_moments_reset(&local);
+        local.count = (uint64_t)pairs * 2U;
+    }
     for (uint32_t n = 0; n < pairs; n++) {
-        uint32_t idx = n << 1;
-        float i_raw = ((float)src[idx + 0] - 127.5f) * inv;
-        float q_raw = ((float)src[idx + 1] - 127.5f) * inv;
-        apply_j4_rotation_f32(i_raw, q_raw, cur_phase, &dst[idx + 0], &dst[idx + 1]);
+        const uint32_t idx = n << 1;
+        const unsigned char in_i = src[idx + 0U];
+        const unsigned char in_q = src[idx + 1U];
+        const float i_raw = ((float)in_i - 127.5f) * inv;
+        const float q_raw = ((float)in_q - 127.5f) * inv;
+        apply_j4_rotation_f32(i_raw, q_raw, cur_phase, &dst[idx + 0U], &dst[idx + 1U]);
+        if (moments) {
+            accumulate_cu8_local(&local, in_i);
+            accumulate_cu8_local(&local, in_q);
+        }
         cur_phase = (cur_phase + 1U) & 3U;
     }
-
+    if (moments) {
+        (void)dsd_input_level_cu8_moments_merge(moments, &local);
+    }
     return cur_phase;
 }
 
+static uint32_t
+widen_rotate90_u8_to_f32_bias127_phase_scalar(const unsigned char* src, float* dst, uint32_t len, uint32_t phase) {
+    return widen_rotate90_u8_to_f32_bias127_phase_moments_scalar(src, dst, len, phase, nullptr);
+}
+
 #ifdef DSD_NEO_TEST_HOOKS
+extern "C" void
+dsd_test_widen_u8_to_f32_bias127_moments_scalar(const unsigned char* src, float* dst, uint32_t len,
+                                                dsd_input_level_cu8_moments* moments) {
+    widen_u8_to_f32_bias127_moments_scalar(src, dst, len, moments);
+}
+
 extern "C" uint32_t
 dsd_test_widen_rotate90_u8_to_f32_bias127_phase_scalar(const unsigned char* src, float* dst, uint32_t len,
                                                        uint32_t phase) {
     return widen_rotate90_u8_to_f32_bias127_phase_scalar(src, dst, len, phase);
 }
+
+extern "C" uint32_t
+dsd_test_widen_rotate90_u8_to_f32_bias127_phase_moments_scalar(const unsigned char* src, float* dst, uint32_t len,
+                                                               uint32_t phase, dsd_input_level_cu8_moments* moments) {
+    return widen_rotate90_u8_to_f32_bias127_phase_moments_scalar(src, dst, len, phase, moments);
+}
 #endif
+
+void
+widen_u8_to_f32_bias127_moments(const unsigned char* src, float* dst, uint32_t len,
+                                dsd_input_level_cu8_moments* moments) {
+    if (g_widen_init_done.load(std::memory_order_acquire) != 2) {
+        simd_widen_init_dispatch();
+    }
+    g_widen_moments_impl(src, dst, len, moments);
+}
 
 uint32_t
 widen_rotate90_u8_to_f32_bias127_phase(const unsigned char* src, float* dst, uint32_t len, uint32_t phase) {
@@ -139,4 +238,13 @@ widen_rotate90_u8_to_f32_bias127_phase(const unsigned char* src, float* dst, uin
         simd_widen_init_dispatch();
     }
     return g_widen_rot_phase_impl(src, dst, len, phase);
+}
+
+uint32_t
+widen_rotate90_u8_to_f32_bias127_phase_moments(const unsigned char* src, float* dst, uint32_t len, uint32_t phase,
+                                               dsd_input_level_cu8_moments* moments) {
+    if (g_widen_init_done.load(std::memory_order_acquire) != 2) {
+        simd_widen_init_dispatch();
+    }
+    return g_widen_rot_phase_moments_impl(src, dst, len, phase, moments);
 }

--- a/src/dsp/simd_widen_avx2.cpp
+++ b/src/dsp/simd_widen_avx2.cpp
@@ -4,14 +4,34 @@
  */
 
 #include <cstdint>
+#include "dsd-neo/core/input_level.h"
 #include "dsd-neo/core/safe_api.h"
 
 #if defined(__clang_analyzer__)
+extern "C" void
+widen_u8_to_f32_bias127_moments_avx2(const unsigned char* src, float* dst, uint32_t len,
+                                     dsd_input_level_cu8_moments* moments) {
+    (void)src;
+    (void)dst;
+    (void)len;
+    (void)moments;
+}
+
 extern "C" uint32_t
 widen_rotate90_u8_to_f32_bias127_phase_avx2(const unsigned char* src, float* dst, uint32_t len, uint32_t phase) {
     (void)src;
     (void)dst;
     (void)len;
+    return phase & 3U;
+}
+
+extern "C" uint32_t
+widen_rotate90_u8_to_f32_bias127_phase_moments_avx2(const unsigned char* src, float* dst, uint32_t len, uint32_t phase,
+                                                    dsd_input_level_cu8_moments* moments) {
+    (void)src;
+    (void)dst;
+    (void)len;
+    (void)moments;
     return phase & 3U;
 }
 #else
@@ -106,7 +126,128 @@ rotate_pair_scalar(float in_i, float in_q, uint32_t phase, float* out_i, float* 
     }
 }
 
+static inline unsigned int
+popcount_u32(unsigned int value) {
+    unsigned int count = 0U;
+    while (value != 0U) {
+        value &= value - 1U;
+        count++;
+    }
+    return count;
+}
+
+static inline void
+accumulate_scalar(dsd_input_level_cu8_moments* local, unsigned char sample) {
+    local->sum += (uint64_t)sample;
+    local->sum_sq += (uint64_t)sample * (uint64_t)sample;
+    local->clipped += (sample <= 1U || sample >= 254U) ? 1U : 0U;
+    if (sample < local->min_sample) {
+        local->min_sample = sample;
+    }
+    if (sample > local->max_sample) {
+        local->max_sample = sample;
+    }
+}
+
+static inline void
+reduce32_u8_avx2(__m256i bytes, dsd_input_level_cu8_moments* local, __m256i* min_bytes, __m256i* max_bytes) {
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256i ones = _mm256_set1_epi8(1);
+    const __m256i high254 = _mm256_set1_epi8((char)0xfe);
+    const __m256i high255 = _mm256_set1_epi8((char)0xff);
+
+    const __m256i sums = _mm256_sad_epu8(bytes, zero);
+    alignas(32) uint64_t sum_lanes[4];
+    _mm256_store_si256(reinterpret_cast<__m256i*>(sum_lanes), sums);
+    for (unsigned int lane = 0U; lane < 4U; lane++) {
+        local->sum += sum_lanes[lane];
+    }
+
+    const __m128i lo_bytes = _mm256_castsi256_si128(bytes);
+    const __m128i hi_bytes = _mm256_extracti128_si256(bytes, 1);
+    const __m256i lo_words = _mm256_cvtepu8_epi16(lo_bytes);
+    const __m256i hi_words = _mm256_cvtepu8_epi16(hi_bytes);
+    const __m256i sq_lo = _mm256_madd_epi16(lo_words, lo_words);
+    const __m256i sq_hi = _mm256_madd_epi16(hi_words, hi_words);
+    alignas(32) uint32_t sq_lanes[16];
+    _mm256_store_si256(reinterpret_cast<__m256i*>(sq_lanes), sq_lo);
+    _mm256_store_si256(reinterpret_cast<__m256i*>(sq_lanes + 8), sq_hi);
+    for (unsigned int lane = 0U; lane < 16U; lane++) {
+        local->sum_sq += sq_lanes[lane];
+    }
+
+    __m256i clipped = _mm256_or_si256(_mm256_cmpeq_epi8(bytes, zero), _mm256_cmpeq_epi8(bytes, ones));
+    clipped = _mm256_or_si256(clipped, _mm256_cmpeq_epi8(bytes, high254));
+    clipped = _mm256_or_si256(clipped, _mm256_cmpeq_epi8(bytes, high255));
+    local->clipped += popcount_u32((unsigned int)_mm256_movemask_epi8(clipped));
+
+    *min_bytes = _mm256_min_epu8(*min_bytes, bytes);
+    *max_bytes = _mm256_max_epu8(*max_bytes, bytes);
+}
+
+static inline void
+merge_vector_extrema(__m256i min_bytes, __m256i max_bytes, dsd_input_level_cu8_moments* local) {
+    alignas(32) unsigned char mins[32];
+    alignas(32) unsigned char maxes[32];
+    _mm256_store_si256(reinterpret_cast<__m256i*>(mins), min_bytes);
+    _mm256_store_si256(reinterpret_cast<__m256i*>(maxes), max_bytes);
+    for (unsigned int lane = 0U; lane < 32U; lane++) {
+        if (mins[lane] < local->min_sample) {
+            local->min_sample = mins[lane];
+        }
+        if (maxes[lane] > local->max_sample) {
+            local->max_sample = maxes[lane];
+        }
+    }
+}
+
+static inline void
+rotate8_store_avx2(const unsigned char* src, float* dst, uint32_t phase) {
+    const __m256 vals = widen8_u8_to_f32_bias127_avx2(src);
+    __m128 lo = _mm256_castps256_ps128(vals);
+    __m128 hi = _mm256_extractf128_ps(vals, 1);
+    lo = apply_phase2_sse(lo, phase);
+    hi = apply_phase2_sse(hi, (phase + 2U) & 3U);
+    __m256 rotated = _mm256_castps128_ps256(lo);
+    rotated = _mm256_insertf128_ps(rotated, hi, 1);
+    _mm256_storeu_ps(dst, rotated);
+}
+
 } /* namespace */
+
+extern "C" void
+widen_u8_to_f32_bias127_moments_avx2(const unsigned char* src, float* dst, uint32_t len,
+                                     dsd_input_level_cu8_moments* moments) {
+    if (!src || !dst || !moments || len == 0U) {
+        return;
+    }
+
+    dsd_input_level_cu8_moments local;
+    dsd_input_level_cu8_moments_reset(&local);
+    local.count = len;
+    __m256i min_bytes = _mm256_set1_epi8((char)0xff);
+    __m256i max_bytes = _mm256_setzero_si256();
+    uint32_t i = 0U;
+    for (; i + 31U < len; i += 32U) {
+        const __m256i bytes = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + i));
+        reduce32_u8_avx2(bytes, &local, &min_bytes, &max_bytes);
+        _mm256_storeu_ps(dst + i + 0U, widen8_u8_to_f32_bias127_avx2(src + i + 0U));
+        _mm256_storeu_ps(dst + i + 8U, widen8_u8_to_f32_bias127_avx2(src + i + 8U));
+        _mm256_storeu_ps(dst + i + 16U, widen8_u8_to_f32_bias127_avx2(src + i + 16U));
+        _mm256_storeu_ps(dst + i + 24U, widen8_u8_to_f32_bias127_avx2(src + i + 24U));
+    }
+    if (i != 0U) {
+        merge_vector_extrema(min_bytes, max_bytes, &local);
+    }
+    const float inv = 1.0f / 127.5f;
+    for (; i < len; i++) {
+        const unsigned char sample = src[i];
+        dst[i] = ((float)sample - 127.5f) * inv;
+        accumulate_scalar(&local, sample);
+    }
+    (void)dsd_input_level_cu8_moments_merge(moments, &local);
+    _mm256_zeroupper();
+}
 
 extern "C" uint32_t
 widen_rotate90_u8_to_f32_bias127_phase_avx2(const unsigned char* src, float* dst, uint32_t len, uint32_t phase) {
@@ -148,6 +289,51 @@ widen_rotate90_u8_to_f32_bias127_phase_avx2(const unsigned char* src, float* dst
         cur_phase = (cur_phase + 1U) & 3U;
     }
 
+    _mm256_zeroupper();
+    return cur_phase;
+}
+
+extern "C" uint32_t
+widen_rotate90_u8_to_f32_bias127_phase_moments_avx2(const unsigned char* src, float* dst, uint32_t len, uint32_t phase,
+                                                    dsd_input_level_cu8_moments* moments) {
+    uint32_t cur_phase = phase & 3U;
+    if (!src || !dst || !moments || len < 2U) {
+        return cur_phase;
+    }
+
+    const uint32_t pairs = len >> 1;
+    dsd_input_level_cu8_moments local;
+    dsd_input_level_cu8_moments_reset(&local);
+    local.count = (uint64_t)pairs * 2U;
+    __m256i min_bytes = _mm256_set1_epi8((char)0xff);
+    __m256i max_bytes = _mm256_setzero_si256();
+    uint32_t n = 0U;
+    for (; n + 15U < pairs; n += 16U) {
+        const uint32_t idx = n << 1;
+        const __m256i bytes = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + idx));
+        reduce32_u8_avx2(bytes, &local, &min_bytes, &max_bytes);
+        for (uint32_t group = 0U; group < 4U; group++) {
+            rotate8_store_avx2(src + idx + group * 8U, dst + idx + group * 8U, cur_phase);
+        }
+    }
+    if (n != 0U) {
+        merge_vector_extrema(min_bytes, max_bytes, &local);
+    }
+
+    const float inv = 1.0f / 127.5f;
+    for (; n < pairs; n++) {
+        const uint32_t idx = n << 1;
+        const unsigned char in_i = src[idx + 0U];
+        const unsigned char in_q = src[idx + 1U];
+        const float i_raw = ((float)in_i - 127.5f) * inv;
+        const float q_raw = ((float)in_q - 127.5f) * inv;
+        rotate_pair_scalar(i_raw, q_raw, cur_phase, &dst[idx + 0U], &dst[idx + 1U]);
+        accumulate_scalar(&local, in_i);
+        accumulate_scalar(&local, in_q);
+        cur_phase = (cur_phase + 1U) & 3U;
+    }
+
+    (void)dsd_input_level_cu8_moments_merge(moments, &local);
     _mm256_zeroupper();
     return cur_phase;
 }

--- a/src/dsp/simd_widen_avx2.cpp
+++ b/src/dsp/simd_widen_avx2.cpp
@@ -153,8 +153,8 @@ static inline void
 reduce32_u8_avx2(__m256i bytes, dsd_input_level_cu8_moments* local, __m256i* min_bytes, __m256i* max_bytes) {
     const __m256i zero = _mm256_setzero_si256();
     const __m256i ones = _mm256_set1_epi8(1);
-    const __m256i high254 = _mm256_set1_epi8((char)0xfe);
-    const __m256i high255 = _mm256_set1_epi8((char)0xff);
+    const __m256i high254 = _mm256_set1_epi8(-2);
+    const __m256i high255 = _mm256_set1_epi8(-1);
 
     const __m256i sums = _mm256_sad_epu8(bytes, zero);
     alignas(32) uint64_t sum_lanes[4];
@@ -225,7 +225,7 @@ widen_u8_to_f32_bias127_moments_avx2(const unsigned char* src, float* dst, uint3
     dsd_input_level_cu8_moments local;
     dsd_input_level_cu8_moments_reset(&local);
     local.count = len;
-    __m256i min_bytes = _mm256_set1_epi8((char)0xff);
+    __m256i min_bytes = _mm256_set1_epi8(-1);
     __m256i max_bytes = _mm256_setzero_si256();
     uint32_t i = 0U;
     for (; i + 31U < len; i += 32U) {
@@ -305,7 +305,7 @@ widen_rotate90_u8_to_f32_bias127_phase_moments_avx2(const unsigned char* src, fl
     dsd_input_level_cu8_moments local;
     dsd_input_level_cu8_moments_reset(&local);
     local.count = (uint64_t)pairs * 2U;
-    __m256i min_bytes = _mm256_set1_epi8((char)0xff);
+    __m256i min_bytes = _mm256_set1_epi8(-1);
     __m256i max_bytes = _mm256_setzero_si256();
     uint32_t n = 0U;
     for (; n + 15U < pairs; n += 16U) {

--- a/src/dsp/simd_widen_neon.cpp
+++ b/src/dsp/simd_widen_neon.cpp
@@ -5,7 +5,8 @@
 
 #include <arm_neon.h>
 #include <cstdint>
-#include <cstring>
+#include "dsd-neo/core/input_level.h"
+#include "dsd-neo/core/safe_api.h"
 
 namespace {
 
@@ -73,7 +74,69 @@ rotate_pair_scalar(float in_i, float in_q, uint32_t phase, float* out_i, float* 
     }
 }
 
+static inline void
+accumulate_scalar(dsd_input_level_cu8_moments* local, unsigned char sample) {
+    local->sum += (uint64_t)sample;
+    local->sum_sq += (uint64_t)sample * (uint64_t)sample;
+    local->clipped += (sample <= 1U || sample >= 254U) ? 1U : 0U;
+    if (sample < local->min_sample) {
+        local->min_sample = sample;
+    }
+    if (sample > local->max_sample) {
+        local->max_sample = sample;
+    }
+}
+
+static inline void
+reduce16_u8_neon(uint8x16_t bytes, dsd_input_level_cu8_moments* local, uint8x16_t* min_bytes, uint8x16_t* max_bytes) {
+    local->sum += vaddlvq_u8(bytes);
+    const uint16x8_t sq_lo = vmull_u8(vget_low_u8(bytes), vget_low_u8(bytes));
+    const uint16x8_t sq_hi = vmull_u8(vget_high_u8(bytes), vget_high_u8(bytes));
+    local->sum_sq += (uint64_t)vaddlvq_u16(sq_lo) + (uint64_t)vaddlvq_u16(sq_hi);
+
+    uint8x16_t clipped = vorrq_u8(vceqq_u8(bytes, vdupq_n_u8(0U)), vceqq_u8(bytes, vdupq_n_u8(1U)));
+    clipped = vorrq_u8(clipped, vceqq_u8(bytes, vdupq_n_u8(254U)));
+    clipped = vorrq_u8(clipped, vceqq_u8(bytes, vdupq_n_u8(255U)));
+    local->clipped += vaddlvq_u8(vshrq_n_u8(clipped, 7));
+    *min_bytes = vminq_u8(*min_bytes, bytes);
+    *max_bytes = vmaxq_u8(*max_bytes, bytes);
+}
+
 } /* namespace */
+
+extern "C" void
+widen_u8_to_f32_bias127_moments_neon(const unsigned char* src, float* dst, uint32_t len,
+                                     dsd_input_level_cu8_moments* moments) {
+    if (!src || !dst || !moments || len == 0U) {
+        return;
+    }
+
+    dsd_input_level_cu8_moments local;
+    dsd_input_level_cu8_moments_reset(&local);
+    local.count = len;
+    uint8x16_t min_bytes = vdupq_n_u8(255U);
+    uint8x16_t max_bytes = vdupq_n_u8(0U);
+    uint32_t i = 0U;
+    for (; i + 15U < len; i += 16U) {
+        const uint8x16_t bytes = vld1q_u8(src + i);
+        reduce16_u8_neon(bytes, &local, &min_bytes, &max_bytes);
+        vst1q_f32(dst + i + 0U, widen4_u8_to_f32_bias127_neon(src + i + 0U));
+        vst1q_f32(dst + i + 4U, widen4_u8_to_f32_bias127_neon(src + i + 4U));
+        vst1q_f32(dst + i + 8U, widen4_u8_to_f32_bias127_neon(src + i + 8U));
+        vst1q_f32(dst + i + 12U, widen4_u8_to_f32_bias127_neon(src + i + 12U));
+    }
+    if (i != 0U) {
+        local.min_sample = vminvq_u8(min_bytes);
+        local.max_sample = vmaxvq_u8(max_bytes);
+    }
+    const float inv = 1.0f / 127.5f;
+    for (; i < len; i++) {
+        const unsigned char sample = src[i];
+        dst[i] = ((float)sample - 127.5f) * inv;
+        accumulate_scalar(&local, sample);
+    }
+    (void)dsd_input_level_cu8_moments_merge(moments, &local);
+}
 
 extern "C" uint32_t
 widen_rotate90_u8_to_f32_bias127_phase_neon(const unsigned char* src, float* dst, uint32_t len, uint32_t phase) {
@@ -102,5 +165,53 @@ widen_rotate90_u8_to_f32_bias127_phase_neon(const unsigned char* src, float* dst
         cur_phase = (cur_phase + 1U) & 3U;
     }
 
+    return cur_phase;
+}
+
+extern "C" uint32_t
+widen_rotate90_u8_to_f32_bias127_phase_moments_neon(const unsigned char* src, float* dst, uint32_t len, uint32_t phase,
+                                                    dsd_input_level_cu8_moments* moments) {
+    uint32_t cur_phase = phase & 3U;
+    if (!src || !dst || !moments || len < 2U) {
+        return cur_phase;
+    }
+
+    const uint32_t pairs = len >> 1;
+    dsd_input_level_cu8_moments local;
+    dsd_input_level_cu8_moments_reset(&local);
+    local.count = (uint64_t)pairs * 2U;
+    uint8x16_t min_bytes = vdupq_n_u8(255U);
+    uint8x16_t max_bytes = vdupq_n_u8(0U);
+    uint32_t n = 0U;
+    for (; n + 7U < pairs; n += 8U) {
+        const uint32_t idx = n << 1;
+        const uint8x16_t bytes = vld1q_u8(src + idx);
+        reduce16_u8_neon(bytes, &local, &min_bytes, &max_bytes);
+        for (uint32_t group = 0U; group < 4U; group++) {
+            const uint32_t off = idx + group * 4U;
+            const float32x4_t vals = widen4_u8_to_f32_bias127_neon(src + off);
+            vst1q_f32(dst + off, apply_phase2_neon(vals, cur_phase));
+            cur_phase = (cur_phase + 2U) & 3U;
+        }
+    }
+    if (n != 0U) {
+        local.min_sample = vminvq_u8(min_bytes);
+        local.max_sample = vmaxvq_u8(max_bytes);
+    }
+
+    const float inv = 1.0f / 127.5f;
+    for (; n < pairs; n++) {
+        const uint32_t idx = n << 1;
+        const unsigned char in_i = src[idx + 0U];
+        const unsigned char in_q = src[idx + 1U];
+        const float i_raw = ((float)in_i - 127.5f) * inv;
+        const float q_raw = ((float)in_q - 127.5f) * inv;
+        rotate_pair_scalar(i_raw, q_raw, cur_phase, &dst[idx + 0U], &dst[idx + 1U]);
+        accumulate_scalar(&local, in_i);
+        accumulate_scalar(&local, in_q);
+        cur_phase = (cur_phase + 1U) & 3U;
+    }
+
+    (void)dsd_input_level_cu8_moments_merge(moments, &local);
     return cur_phase;
 }

--- a/src/dsp/simd_widen_sse2.cpp
+++ b/src/dsp/simd_widen_sse2.cpp
@@ -109,8 +109,8 @@ static inline void
 reduce16_u8_sse2(__m128i bytes, dsd_input_level_cu8_moments* local, __m128i* min_bytes, __m128i* max_bytes) {
     const __m128i zero = _mm_setzero_si128();
     const __m128i ones = _mm_set1_epi8(1);
-    const __m128i high254 = _mm_set1_epi8((char)0xfe);
-    const __m128i high255 = _mm_set1_epi8((char)0xff);
+    const __m128i high254 = _mm_set1_epi8(-2);
+    const __m128i high255 = _mm_set1_epi8(-1);
 
     const __m128i sums = _mm_sad_epu8(bytes, zero);
     alignas(16) uint64_t sum_lanes[2];
@@ -165,7 +165,7 @@ widen_u8_to_f32_bias127_moments_sse2(const unsigned char* src, float* dst, uint3
     dsd_input_level_cu8_moments local;
     dsd_input_level_cu8_moments_reset(&local);
     local.count = len;
-    __m128i min_bytes = _mm_set1_epi8((char)0xff);
+    __m128i min_bytes = _mm_set1_epi8(-1);
     __m128i max_bytes = _mm_setzero_si128();
     uint32_t i = 0U;
     for (; i + 15U < len; i += 16U) {
@@ -230,7 +230,7 @@ widen_rotate90_u8_to_f32_bias127_phase_moments_sse2(const unsigned char* src, fl
     dsd_input_level_cu8_moments local;
     dsd_input_level_cu8_moments_reset(&local);
     local.count = (uint64_t)pairs * 2U;
-    __m128i min_bytes = _mm_set1_epi8((char)0xff);
+    __m128i min_bytes = _mm_set1_epi8(-1);
     __m128i max_bytes = _mm_setzero_si128();
     uint32_t n = 0U;
     for (; n + 7U < pairs; n += 8U) {

--- a/src/dsp/simd_widen_sse2.cpp
+++ b/src/dsp/simd_widen_sse2.cpp
@@ -7,6 +7,7 @@
 #include <emmintrin.h>
 #include <mmintrin.h>
 #include <xmmintrin.h>
+#include "dsd-neo/core/input_level.h"
 #include "dsd-neo/core/safe_api.h"
 
 // NOLINTBEGIN(portability-simd-intrinsics)
@@ -81,7 +82,111 @@ rotate_pair_scalar(float in_i, float in_q, uint32_t phase, float* out_i, float* 
     }
 }
 
+static inline unsigned int
+popcount_u16(unsigned int value) {
+    unsigned int count = 0U;
+    while (value != 0U) {
+        value &= value - 1U;
+        count++;
+    }
+    return count;
+}
+
+static inline void
+accumulate_scalar(dsd_input_level_cu8_moments* local, unsigned char sample) {
+    local->sum += (uint64_t)sample;
+    local->sum_sq += (uint64_t)sample * (uint64_t)sample;
+    local->clipped += (sample <= 1U || sample >= 254U) ? 1U : 0U;
+    if (sample < local->min_sample) {
+        local->min_sample = sample;
+    }
+    if (sample > local->max_sample) {
+        local->max_sample = sample;
+    }
+}
+
+static inline void
+reduce16_u8_sse2(__m128i bytes, dsd_input_level_cu8_moments* local, __m128i* min_bytes, __m128i* max_bytes) {
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ones = _mm_set1_epi8(1);
+    const __m128i high254 = _mm_set1_epi8((char)0xfe);
+    const __m128i high255 = _mm_set1_epi8((char)0xff);
+
+    const __m128i sums = _mm_sad_epu8(bytes, zero);
+    alignas(16) uint64_t sum_lanes[2];
+    _mm_store_si128(reinterpret_cast<__m128i*>(sum_lanes), sums);
+    local->sum += sum_lanes[0] + sum_lanes[1];
+
+    const __m128i lo = _mm_unpacklo_epi8(bytes, zero);
+    const __m128i hi = _mm_unpackhi_epi8(bytes, zero);
+    const __m128i sq_lo = _mm_madd_epi16(lo, lo);
+    const __m128i sq_hi = _mm_madd_epi16(hi, hi);
+    alignas(16) uint32_t sq_lanes[8];
+    _mm_store_si128(reinterpret_cast<__m128i*>(sq_lanes), sq_lo);
+    _mm_store_si128(reinterpret_cast<__m128i*>(sq_lanes + 4), sq_hi);
+    for (unsigned int lane = 0U; lane < 8U; lane++) {
+        local->sum_sq += sq_lanes[lane];
+    }
+
+    __m128i clipped = _mm_or_si128(_mm_cmpeq_epi8(bytes, zero), _mm_cmpeq_epi8(bytes, ones));
+    clipped = _mm_or_si128(clipped, _mm_cmpeq_epi8(bytes, high254));
+    clipped = _mm_or_si128(clipped, _mm_cmpeq_epi8(bytes, high255));
+    local->clipped += popcount_u16((unsigned int)_mm_movemask_epi8(clipped));
+
+    *min_bytes = _mm_min_epu8(*min_bytes, bytes);
+    *max_bytes = _mm_max_epu8(*max_bytes, bytes);
+}
+
+static inline void
+merge_vector_extrema(__m128i min_bytes, __m128i max_bytes, dsd_input_level_cu8_moments* local) {
+    alignas(16) unsigned char mins[16];
+    alignas(16) unsigned char maxes[16];
+    _mm_store_si128(reinterpret_cast<__m128i*>(mins), min_bytes);
+    _mm_store_si128(reinterpret_cast<__m128i*>(maxes), max_bytes);
+    for (unsigned int lane = 0U; lane < 16U; lane++) {
+        if (mins[lane] < local->min_sample) {
+            local->min_sample = mins[lane];
+        }
+        if (maxes[lane] > local->max_sample) {
+            local->max_sample = maxes[lane];
+        }
+    }
+}
+
 } /* namespace */
+
+extern "C" void
+widen_u8_to_f32_bias127_moments_sse2(const unsigned char* src, float* dst, uint32_t len,
+                                     dsd_input_level_cu8_moments* moments) {
+    if (!src || !dst || !moments || len == 0U) {
+        return;
+    }
+
+    dsd_input_level_cu8_moments local;
+    dsd_input_level_cu8_moments_reset(&local);
+    local.count = len;
+    __m128i min_bytes = _mm_set1_epi8((char)0xff);
+    __m128i max_bytes = _mm_setzero_si128();
+    uint32_t i = 0U;
+    for (; i + 15U < len; i += 16U) {
+        const __m128i bytes = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + i));
+        reduce16_u8_sse2(bytes, &local, &min_bytes, &max_bytes);
+        _mm_storeu_ps(dst + i + 0U, widen4_u8_to_f32_bias127_sse2(src + i + 0U));
+        _mm_storeu_ps(dst + i + 4U, widen4_u8_to_f32_bias127_sse2(src + i + 4U));
+        _mm_storeu_ps(dst + i + 8U, widen4_u8_to_f32_bias127_sse2(src + i + 8U));
+        _mm_storeu_ps(dst + i + 12U, widen4_u8_to_f32_bias127_sse2(src + i + 12U));
+    }
+    if (i != 0U) {
+        merge_vector_extrema(min_bytes, max_bytes, &local);
+    }
+    const float inv = 1.0f / 127.5f;
+    for (; i < len; i++) {
+        const unsigned char sample = src[i];
+        dst[i] = ((float)sample - 127.5f) * inv;
+        accumulate_scalar(&local, sample);
+    }
+    (void)dsd_input_level_cu8_moments_merge(moments, &local);
+}
 
 extern "C" uint32_t
 widen_rotate90_u8_to_f32_bias127_phase_sse2(const unsigned char* src, float* dst, uint32_t len, uint32_t phase) {
@@ -110,6 +215,53 @@ widen_rotate90_u8_to_f32_bias127_phase_sse2(const unsigned char* src, float* dst
         cur_phase = (cur_phase + 1U) & 3U;
     }
 
+    return cur_phase;
+}
+
+extern "C" uint32_t
+widen_rotate90_u8_to_f32_bias127_phase_moments_sse2(const unsigned char* src, float* dst, uint32_t len, uint32_t phase,
+                                                    dsd_input_level_cu8_moments* moments) {
+    uint32_t cur_phase = phase & 3U;
+    if (!src || !dst || !moments || len < 2U) {
+        return cur_phase;
+    }
+
+    const uint32_t pairs = len >> 1;
+    dsd_input_level_cu8_moments local;
+    dsd_input_level_cu8_moments_reset(&local);
+    local.count = (uint64_t)pairs * 2U;
+    __m128i min_bytes = _mm_set1_epi8((char)0xff);
+    __m128i max_bytes = _mm_setzero_si128();
+    uint32_t n = 0U;
+    for (; n + 7U < pairs; n += 8U) {
+        const uint32_t idx = n << 1;
+        const __m128i bytes = _mm_loadu_si128(reinterpret_cast<const __m128i*>(src + idx));
+        reduce16_u8_sse2(bytes, &local, &min_bytes, &max_bytes);
+        for (uint32_t group = 0U; group < 4U; group++) {
+            const uint32_t off = idx + group * 4U;
+            const __m128 vals = widen4_u8_to_f32_bias127_sse2(src + off);
+            _mm_storeu_ps(dst + off, apply_phase2_sse2(vals, cur_phase));
+            cur_phase = (cur_phase + 2U) & 3U;
+        }
+    }
+    if (n != 0U) {
+        merge_vector_extrema(min_bytes, max_bytes, &local);
+    }
+
+    const float inv = 1.0f / 127.5f;
+    for (; n < pairs; n++) {
+        const uint32_t idx = n << 1;
+        const unsigned char in_i = src[idx + 0U];
+        const unsigned char in_q = src[idx + 1U];
+        const float i_raw = ((float)in_i - 127.5f) * inv;
+        const float q_raw = ((float)in_q - 127.5f) * inv;
+        rotate_pair_scalar(i_raw, q_raw, cur_phase, &dst[idx + 0U], &dst[idx + 1U]);
+        accumulate_scalar(&local, in_i);
+        accumulate_scalar(&local, in_q);
+        cur_phase = (cur_phase + 1U) & 3U;
+    }
+
+    (void)dsd_input_level_cu8_moments_merge(moments, &local);
     return cur_phase;
 }
 

--- a/src/io/radio/rtl_device.cpp
+++ b/src/io/radio/rtl_device.cpp
@@ -492,17 +492,43 @@ rtl_get_u8_transform_policy(const struct rtl_device* s, int* out_fs4_active, int
 
 /* Persisted IQ metadata and the live transform policy may select the two-pass
  * CU8 transform. New captures use the combined bias-127.5 transform by default. */
+static inline void
+rtl_cu8_moments_add_sample(dsd_input_level_cu8_moments* moments, unsigned char sample) {
+    if (!moments) {
+        return;
+    }
+    moments->count++;
+    moments->sum += (uint64_t)sample;
+    moments->sum_sq += (uint64_t)sample * (uint64_t)sample;
+    moments->clipped += (sample <= 1U || sample >= 254U) ? 1U : 0U;
+    if (sample < moments->min_sample) {
+        moments->min_sample = sample;
+    }
+    if (sample > moments->max_sample) {
+        moments->max_sample = sample;
+    }
+}
+
 static uint32_t
-rtl_apply_two_pass_cu8_rotation(unsigned char* buf, uint32_t len, uint32_t phase) {
+rtl_apply_two_pass_cu8_rotation(unsigned char* buf, uint32_t len, uint32_t phase,
+                                dsd_input_level_cu8_moments* moments) {
     uint32_t cur_phase = phase & 3U;
     if (!buf || len < 2U) {
         return cur_phase;
     }
-    uint32_t pairs = len >> 1;
+    dsd_input_level_cu8_moments local;
+    if (moments) {
+        dsd_input_level_cu8_moments_reset(&local);
+    }
+    const uint32_t pairs = len >> 1;
     for (uint32_t n = 0; n < pairs; n++) {
-        uint32_t idx = n << 1;
-        unsigned char in_i = buf[idx];
-        unsigned char in_q = buf[idx + 1U];
+        const uint32_t idx = n << 1;
+        const unsigned char in_i = buf[idx];
+        const unsigned char in_q = buf[idx + 1U];
+        if (moments) {
+            rtl_cu8_moments_add_sample(&local, in_i);
+            rtl_cu8_moments_add_sample(&local, in_q);
+        }
         switch (cur_phase) {
             case 0: break;
             case 1:
@@ -520,6 +546,12 @@ rtl_apply_two_pass_cu8_rotation(unsigned char* buf, uint32_t len, uint32_t phase
         }
         cur_phase = (cur_phase + 1U) & 3U;
     }
+    if (moments && (len & 1U) != 0U) {
+        rtl_cu8_moments_add_sample(&local, buf[len - 1U]);
+    }
+    if (moments) {
+        (void)dsd_input_level_cu8_moments_merge(moments, &local);
+    }
     return cur_phase;
 }
 
@@ -536,16 +568,20 @@ rtl_widen_two_pass_cu8(const unsigned char* src, float* dst, uint32_t len) {
 
 static inline int
 rtl_process_u8_chunk(const struct rtl_device* s, unsigned char* src, float* dst, size_t len, int fs4_shift_active,
-                     int combine_rotate_active, int use_two_pass, int* phase) {
+                     int combine_rotate_active, int use_two_pass, int* phase, dsd_input_level_cu8_moments* moments) {
     if (!s || !src || !dst || len == 0) {
         return phase ? *phase : 0;
     }
     int cur_phase = phase ? (*phase & 3) : 0;
     if (fs4_shift_active && combine_rotate_active) {
-        cur_phase = (int)widen_rotate90_u8_to_f32_bias127_phase(src, dst, (uint32_t)len, (uint32_t)cur_phase);
+        cur_phase = moments ? (int)widen_rotate90_u8_to_f32_bias127_phase_moments(src, dst, (uint32_t)len,
+                                                                                  (uint32_t)cur_phase, moments)
+                            : (int)widen_rotate90_u8_to_f32_bias127_phase(src, dst, (uint32_t)len, (uint32_t)cur_phase);
     } else if (use_two_pass) {
-        cur_phase = (int)rtl_apply_two_pass_cu8_rotation(src, (uint32_t)len, (uint32_t)cur_phase);
+        cur_phase = (int)rtl_apply_two_pass_cu8_rotation(src, (uint32_t)len, (uint32_t)cur_phase, moments);
         rtl_widen_two_pass_cu8(src, dst, (uint32_t)len);
+    } else if (moments) {
+        widen_u8_to_f32_bias127_moments(src, dst, (uint32_t)len, moments);
     } else {
         widen_u8_to_f32_bias127(src, dst, (uint32_t)len);
     }
@@ -691,9 +727,14 @@ struct rtl_u8_write_cursor {
     int fs4_shift_active;
     int combine_rotate_active;
     int use_two_pass;
+    dsd_input_level_cu8_moments* moments;
 };
 
 } // namespace
+
+#ifdef DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS
+static std::atomic<int> g_rtl_test_force_u8_generation_stale{0};
+#endif
 
 static inline void
 rtl_write_u8_reserved_segment(const struct rtl_device* s, const rtl_u8_write_cursor* cursor, float* dst,
@@ -709,7 +750,10 @@ rtl_write_u8_reserved_segment(const struct rtl_device* s, const rtl_u8_write_cur
     size_t from_prefix = 0U;
     if (prefix != 0U) {
         rtl_process_u8_chunk(s, pair, dst, 2U, cursor->fs4_shift_active, cursor->combine_rotate_active,
-                             cursor->use_two_pass, cursor->phase);
+                             cursor->use_two_pass, cursor->phase, NULL);
+        if (cursor->moments) {
+            (void)dsd_input_level_cu8_moments_accumulate(cursor->moments, cursor->src + *cursor->done, prefix);
+        }
         *cursor->done += prefix;
         *cursor->need -= prefix;
         from_prefix = 2U;
@@ -717,7 +761,7 @@ rtl_write_u8_reserved_segment(const struct rtl_device* s, const rtl_u8_write_cur
     if (produced_bytes > from_prefix) {
         size_t body = produced_bytes - from_prefix;
         rtl_process_u8_chunk(s, cursor->src + *cursor->done, dst + from_prefix, body, cursor->fs4_shift_active,
-                             cursor->combine_rotate_active, cursor->use_two_pass, cursor->phase);
+                             cursor->combine_rotate_active, cursor->use_two_pass, cursor->phase, cursor->moments);
         *cursor->done += body;
         *cursor->need -= body;
     }
@@ -748,9 +792,42 @@ struct rtl_u8_finalize_state {
     int count_full_reserve;
     int ring_exhausted;
     int generation_stale;
+    dsd_input_level_cu8_moments* moments;
+};
+
+struct rtl_u8_perf_state {
+    int enabled;
+    uint64_t start_ns;
+    uint64_t drops_before;
 };
 
 } // namespace
+
+static inline void
+rtl_finalize_u8_ring_exhaustion(struct rtl_device* s, const rtl_u8_finalize_state* final_state) {
+    if (final_state->moments && final_state->need > 0U) {
+        (void)dsd_input_level_cu8_moments_accumulate(final_state->moments, final_state->src + final_state->done,
+                                                     final_state->need);
+    }
+    size_t dropped =
+        rtl_drop_u8_bytes_preserve_alignment(final_state->src + final_state->done, final_state->need,
+                                             final_state->carry, final_state->phase, final_state->fs4_shift_active);
+    rtl_accumulate_ring_drops(s->input_ring, dropped);
+    if (final_state->count_full_reserve) {
+        s->reserve_full_events++;
+    }
+}
+
+static inline void
+rtl_finalize_u8_trailing_carry(const rtl_u8_finalize_state* final_state) {
+    if (final_state->need != 1U || final_state->done >= final_state->len || final_state->carry->valid) {
+        return;
+    }
+    if (final_state->moments) {
+        (void)dsd_input_level_cu8_moments_accumulate(final_state->moments, final_state->src + final_state->done, 1U);
+    }
+    rtl_capture_u8_byte_carry_save(final_state->carry, final_state->src[final_state->done]);
+}
 
 static inline void
 rtl_finalize_u8_ring_write(struct rtl_device* s, const rtl_u8_finalize_state* final_state) {
@@ -760,36 +837,54 @@ rtl_finalize_u8_ring_write(struct rtl_device* s, const rtl_u8_finalize_state* fi
 
     if (final_state->generation_stale) {
         rtl_clear_capture_alignment_after_discard(s, final_state->carry);
-    } else if (final_state->ring_exhausted) {
-        size_t dropped =
-            rtl_drop_u8_bytes_preserve_alignment(final_state->src + final_state->done, final_state->need,
-                                                 final_state->carry, final_state->phase, final_state->fs4_shift_active);
-        rtl_accumulate_ring_drops(s->input_ring, dropped);
-        if (final_state->count_full_reserve) {
-            s->reserve_full_events++;
-        }
-    } else if (final_state->need == 1U && final_state->done < final_state->len && !final_state->carry->valid) {
-        rtl_capture_u8_byte_carry_save(final_state->carry, final_state->src[final_state->done]);
+        return;
+    }
+    if (final_state->ring_exhausted) {
+        rtl_finalize_u8_ring_exhaustion(s, final_state);
+    } else {
+        rtl_finalize_u8_trailing_carry(final_state);
     }
 
-    if (!final_state->generation_stale) {
-        s->iq_byte_carry = *final_state->carry;
-        if (final_state->fs4_shift_active) {
-            s->rot_phase = *final_state->phase;
-        }
+    s->iq_byte_carry = *final_state->carry;
+    if (final_state->fs4_shift_active) {
+        s->rot_phase = *final_state->phase;
     }
+}
+
+static inline rtl_u8_perf_state
+rtl_u8_perf_begin(const struct rtl_device* s) {
+    rtl_u8_perf_state perf = {};
+    perf.enabled = rtl_perf_enabled();
+    if (perf.enabled) {
+        perf.start_ns = dsd_time_monotonic_ns();
+        perf.drops_before = s->input_ring->producer_drops.load(std::memory_order_relaxed);
+    }
+    return perf;
+}
+
+static inline void
+rtl_u8_perf_end(const struct rtl_device* s, const rtl_u8_perf_state* perf, size_t done) {
+    if (!perf->enabled) {
+        return;
+    }
+    uint64_t drops_after = s->input_ring->producer_drops.load(std::memory_order_relaxed);
+    uint64_t drops_delta = (drops_after >= perf->drops_before) ? (drops_after - perf->drops_before) : 0ULL;
+    rtl_perf_record_ingest(dsd_time_monotonic_ns() - perf->start_ns, done, drops_delta);
+}
+
+static inline int
+rtl_u8_write_result(int ring_exhausted, int generation_stale) {
+    return generation_stale ? 2 : ring_exhausted;
 }
 
 static int
 rtl_write_u8_to_ring(struct rtl_device* s, unsigned char* src, size_t len, int fs4_shift_active, int use_two_pass,
-                     int combine_rotate_active, int count_full_reserve) {
+                     int combine_rotate_active, int count_full_reserve, dsd_input_level_cu8_moments* moments) {
     if (!s || !s->input_ring || !src || len == 0) {
         return 0;
     }
 
-    int perf_on = rtl_perf_enabled();
-    uint64_t perf_t0 = perf_on ? dsd_time_monotonic_ns() : 0ULL;
-    uint64_t perf_drops_before = perf_on ? s->input_ring->producer_drops.load(std::memory_order_relaxed) : 0ULL;
+    rtl_u8_perf_state perf = rtl_u8_perf_begin(s);
     size_t done = 0;
     size_t need = len;
     int phase = s->rot_phase & 3;
@@ -818,11 +913,19 @@ rtl_write_u8_to_ring(struct rtl_device* s, unsigned char* src, size_t len, int f
         }
 
         rtl_u8_write_cursor cursor = {
-            src, &done, &need, &carry, &phase, fs4_shift_active, combine_rotate_active, use_two_pass};
+            src, &done, &need, &carry, &phase, fs4_shift_active, combine_rotate_active, use_two_pass, moments};
         rtl_write_u8_reserved_segment(s, &cursor, p1, w1);
         rtl_write_u8_reserved_segment(s, &cursor, p2, w2);
 
+#ifdef DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS
+        if (g_rtl_test_force_u8_generation_stale.exchange(0, std::memory_order_acq_rel) != 0) {
+            input_ring_request_discard(s->input_ring);
+        }
+#endif
         if (!input_ring_discard_generation_matches(s->input_ring, discard_generation)) {
+            if (moments && need > 0U) {
+                (void)dsd_input_level_cu8_moments_accumulate(moments, src + done, need);
+            }
             generation_stale =
                 rtl_handle_u8_ring_generation_stale(s, src, done, need, &carry, &phase, fs4_shift_active, produced);
             break;
@@ -831,14 +934,11 @@ rtl_write_u8_to_ring(struct rtl_device* s, unsigned char* src, size_t len, int f
     }
 
     rtl_u8_finalize_state final_state = {
-        src, len, done, need, &carry, &phase, fs4_shift_active, count_full_reserve, ring_exhausted, generation_stale};
+        src,    len, done, need, &carry, &phase, fs4_shift_active, count_full_reserve, ring_exhausted, generation_stale,
+        moments};
     rtl_finalize_u8_ring_write(s, &final_state);
-    if (perf_on) {
-        uint64_t drops_after = s->input_ring->producer_drops.load(std::memory_order_relaxed);
-        uint64_t drops_delta = (drops_after >= perf_drops_before) ? (drops_after - perf_drops_before) : 0ULL;
-        rtl_perf_record_ingest(dsd_time_monotonic_ns() - perf_t0, done, drops_delta);
-    }
-    return generation_stale ? 2 : ring_exhausted;
+    rtl_u8_perf_end(s, &perf, done);
+    return rtl_u8_write_result(ring_exhausted, generation_stale);
 }
 
 static inline void
@@ -855,12 +955,12 @@ rtl_u8_input_level_source(const struct rtl_device* s) {
 }
 
 static inline void
-rtl_publish_cu8_input_level(const struct rtl_device* s, const uint8_t* samples, size_t count) {
+rtl_publish_cu8_input_level_moments(const struct rtl_device* s, const dsd_input_level_cu8_moments* moments) {
     dsd_input_level_snapshot snapshot;
-    if (!s || !samples || count == 0U) {
+    if (!s || !moments || moments->count == 0U) {
         return;
     }
-    if (dsd_input_level_metrics_from_cu8(samples, count, rtl_u8_input_level_source(s), &snapshot) == 0) {
+    if (dsd_input_level_cu8_moments_finalize(moments, rtl_u8_input_level_source(s), &snapshot) == 0) {
         rtl_stream_input_level_publish(&snapshot);
     }
 }
@@ -1430,7 +1530,7 @@ static int replay_handle_empty_read(struct rtl_device* s, uint64_t* complex_writ
                                     uint32_t* event_cursor);
 static int replay_convert_block_to_f32(const struct rtl_device* s, const uint8_t* raw_block, size_t out_bytes,
                                        float* f32_block, size_t f32_cap, int* phase, int* have_carry,
-                                       uint8_t* carry_byte);
+                                       uint8_t* carry_byte, dsd_input_level_cu8_moments* moments);
 
 static inline int
 replay_submit_chunk_inputs_valid(const struct rtl_device* s, const float* src, const size_t* out_grant_f32,
@@ -1593,14 +1693,22 @@ replay_thread_process_block(struct rtl_device* s, uint8_t* raw_block, size_t raw
 
     dsd_input_level_snapshot input_level;
     DSD_MEMSET(&input_level, 0, sizeof(input_level));
+    dsd_input_level_cu8_moments moments;
+    dsd_input_level_cu8_moments_reset(&moments);
+    const int is_cu8 = s->replay_cfg.format == DSD_IQ_FORMAT_CU8;
     int have_input_level =
-        (rtl_prepare_replay_input_level_snapshot(s, raw_block, out_bytes, f32_block, raw_block_bytes, &input_level)
-         == 0);
+        !is_cu8
+        && (rtl_prepare_replay_input_level_snapshot(s, raw_block, out_bytes, f32_block, raw_block_bytes, &input_level)
+            == 0);
 
     int produced = replay_convert_block_to_f32(s, raw_block, out_bytes, f32_block, raw_block_bytes, io->phase,
-                                               io->have_carry, io->carry_byte);
+                                               io->have_carry, io->carry_byte, is_cu8 ? &moments : NULL);
     if (produced <= 0) {
         return 2;
+    }
+    if (is_cu8) {
+        have_input_level =
+            dsd_input_level_cu8_moments_finalize(&moments, rtl_u8_input_level_source(s), &input_level) == 0;
     }
     if (have_input_level) {
         rtl_stream_input_level_publish(&input_level);
@@ -1658,7 +1766,8 @@ replay_enqueue_f32_no_drop(struct rtl_device* s, const float* src, size_t float_
 
 static int
 replay_convert_cu8_to_f32(const struct rtl_device* s, const uint8_t* in, size_t in_bytes, float* out_f32,
-                          size_t out_cap_f32, int* io_phase, int* io_have_carry, uint8_t* io_carry_byte) {
+                          size_t out_cap_f32, int* io_phase, int* io_have_carry, uint8_t* io_carry_byte,
+                          dsd_input_level_cu8_moments* moments) {
     if (!s || !in || !out_f32 || !io_phase || !io_have_carry || !io_carry_byte) {
         return -1;
     }
@@ -1676,7 +1785,10 @@ replay_convert_cu8_to_f32(const struct rtl_device* s, const uint8_t* in, size_t 
         uint8_t pair[2];
         pair[0] = *io_carry_byte;
         pair[1] = in[0];
-        rtl_process_u8_chunk(s, pair, out_f32 + out_pos, 2U, fs4_active, combine_active, use_two_pass, io_phase);
+        rtl_process_u8_chunk(s, pair, out_f32 + out_pos, 2U, fs4_active, combine_active, use_two_pass, io_phase, NULL);
+        if (moments) {
+            (void)dsd_input_level_cu8_moments_accumulate(moments, in, 1U);
+        }
         out_pos += 2U;
         consumed = 1U;
         *io_have_carry = 0;
@@ -1689,12 +1801,15 @@ replay_convert_cu8_to_f32(const struct rtl_device* s, const uint8_t* in, size_t 
             return -1;
         }
         rtl_process_u8_chunk(s, const_cast<unsigned char*>(in + consumed), out_f32 + out_pos, aligned, fs4_active,
-                             combine_active, use_two_pass, io_phase);
+                             combine_active, use_two_pass, io_phase, moments);
         out_pos += aligned;
         consumed += aligned;
     }
 
     if (consumed < in_bytes) {
+        if (moments) {
+            (void)dsd_input_level_cu8_moments_accumulate(moments, in + consumed, 1U);
+        }
         *io_carry_byte = in[consumed];
         *io_have_carry = 1;
     }
@@ -2072,12 +2187,14 @@ replay_handle_empty_read(struct rtl_device* s, uint64_t* complex_written, uint64
 
 static int
 replay_convert_block_to_f32(const struct rtl_device* s, const uint8_t* raw_block, size_t out_bytes, float* f32_block,
-                            size_t f32_cap, int* phase, int* have_carry, uint8_t* carry_byte) {
+                            size_t f32_cap, int* phase, int* have_carry, uint8_t* carry_byte,
+                            dsd_input_level_cu8_moments* moments) {
     if (!s) {
         return -1;
     }
     if (s->replay_cfg.format == DSD_IQ_FORMAT_CU8) {
-        return replay_convert_cu8_to_f32(s, raw_block, out_bytes, f32_block, f32_cap, phase, have_carry, carry_byte);
+        return replay_convert_cu8_to_f32(s, raw_block, out_bytes, f32_block, f32_cap, phase, have_carry, carry_byte,
+                                         moments);
     }
     if (s->replay_cfg.format == DSD_IQ_FORMAT_CF32) {
         return replay_convert_cf32_to_f32(s, raw_block, out_bytes, f32_block, f32_cap, phase);
@@ -2138,7 +2255,7 @@ rtl_device_test_replay_convert_block(const rtl_device_test_replay_convert_block_
     int have_carry = request->start_have_carry;
     uint8_t carry_byte = request->start_carry_byte;
     int rc = replay_convert_block_to_f32(&dev, request->raw_block, request->raw_bytes, scratch, request->out_cap_f32,
-                                         &phase, &have_carry, &carry_byte);
+                                         &phase, &have_carry, &carry_byte, NULL);
     size_t copy_count =
         rtl_device_test_replay_convert_copy_count(rc, out_f32_count, sizeof(scratch) / sizeof(scratch[0]));
     DSD_MEMCPY(out_f32, scratch, copy_count * sizeof(float));
@@ -2278,9 +2395,11 @@ rtlsdr_callback(unsigned char* buf, uint32_t len, void* ctx) {
         return;
     }
     rtl_submit_capture_bytes(s, buf, len);
-    rtl_publish_cu8_input_level(s, buf, len);
+    dsd_input_level_cu8_moments moments;
+    dsd_input_level_cu8_moments_reset(&moments);
     /* Convert incoming u8 I/Q and write directly into input ring without extra copy. */
-    rtl_write_u8_to_ring(s, buf, len, fs4_shift_active, use_two_pass, combine_rotate_active, 0);
+    rtl_write_u8_to_ring(s, buf, len, fs4_shift_active, use_two_pass, combine_rotate_active, 0, &moments);
+    rtl_publish_cu8_input_level_moments(s, &moments);
 }
 
 /**
@@ -3653,9 +3772,30 @@ rtl_tcp_ensure_pending_capacity(struct rtl_device* s, size_t needed) {
     return 1;
 }
 
+static void
+rtl_tcp_copy_cu8_with_moments(unsigned char* dst, const unsigned char* src, size_t len,
+                              dsd_input_level_cu8_moments* moments) {
+    if (!dst || !src || len == 0U) {
+        return;
+    }
+    if (!moments) {
+        DSD_MEMCPY(dst, src, len);
+        return;
+    }
+
+    dsd_input_level_cu8_moments local;
+    dsd_input_level_cu8_moments_reset(&local);
+    for (size_t i = 0U; i < len; i++) {
+        const unsigned char sample = src[i];
+        dst[i] = sample;
+        rtl_cu8_moments_add_sample(&local, sample);
+    }
+    (void)dsd_input_level_cu8_moments_merge(moments, &local);
+}
+
 static size_t
 rtl_tcp_fill_pending_slice(struct rtl_device* s, const unsigned char* u8, size_t len, size_t slice,
-                           const struct rtl_u8_transform_policy_state* policy) {
+                           const struct rtl_u8_transform_policy_state* policy, dsd_input_level_cu8_moments* moments) {
     if (!s || !u8 || !policy || s->tcp_pending_len == 0U) {
         return 0U;
     }
@@ -3663,15 +3803,18 @@ rtl_tcp_fill_pending_slice(struct rtl_device* s, const unsigned char* u8, size_t
     size_t missing = (slice > s->tcp_pending_len) ? (slice - s->tcp_pending_len) : 0U;
     size_t take = (missing < len) ? missing : len;
     if (take > 0U && rtl_tcp_ensure_pending_capacity(s, slice) && s->tcp_pending_cap >= (s->tcp_pending_len + take)) {
-        DSD_MEMCPY(s->tcp_pending + s->tcp_pending_len, u8, take);
+        rtl_tcp_copy_cu8_with_moments(s->tcp_pending + s->tcp_pending_len, u8, take, moments);
         s->tcp_pending_len += take;
         consumed += take;
     }
     if (s->tcp_pending_len == slice) {
         int ring_status = rtl_write_u8_to_ring(s, s->tcp_pending, slice, policy->fs4_shift_active, policy->use_two_pass,
-                                               policy->combine_rotate_active, 1);
+                                               policy->combine_rotate_active, 1, NULL);
         s->tcp_pending_len = 0U;
         if (ring_status == 2) {
+            if (moments && take < len) {
+                (void)dsd_input_level_cu8_moments_accumulate(moments, u8 + take, len - take);
+            }
             return len;
         }
     }
@@ -3680,15 +3823,19 @@ rtl_tcp_fill_pending_slice(struct rtl_device* s, const unsigned char* u8, size_t
 
 static void
 rtl_tcp_process_full_slices(struct rtl_device* s, unsigned char* u8, size_t len, size_t slice,
-                            const struct rtl_u8_transform_policy_state* policy, size_t* io_consumed) {
+                            const struct rtl_u8_transform_policy_state* policy, size_t* io_consumed,
+                            dsd_input_level_cu8_moments* moments) {
     if (!s || !u8 || !policy || !io_consumed || slice == 0U) {
         return;
     }
     while ((len - *io_consumed) >= slice) {
         int ring_status = rtl_write_u8_to_ring(s, u8 + *io_consumed, slice, policy->fs4_shift_active,
-                                               policy->use_two_pass, policy->combine_rotate_active, 1);
+                                               policy->use_two_pass, policy->combine_rotate_active, 1, moments);
         *io_consumed += slice;
         if (ring_status == 2) {
+            if (moments && *io_consumed < len) {
+                (void)dsd_input_level_cu8_moments_accumulate(moments, u8 + *io_consumed, len - *io_consumed);
+            }
             *io_consumed = len;
             s->tcp_pending_len = 0U;
             break;
@@ -3700,31 +3847,36 @@ rtl_tcp_process_full_slices(struct rtl_device* s, unsigned char* u8, size_t len,
 }
 
 static void
-rtl_tcp_store_remainder(struct rtl_device* s, const unsigned char* data, size_t rem, int fs4_shift_active) {
+rtl_tcp_store_remainder(struct rtl_device* s, const unsigned char* data, size_t rem, int fs4_shift_active,
+                        dsd_input_level_cu8_moments* moments) {
     if (!s || !data || rem == 0U) {
         return;
     }
     if (!rtl_tcp_ensure_pending_capacity(s, rem)) {
+        if (moments) {
+            (void)dsd_input_level_cu8_moments_accumulate(moments, data, rem);
+        }
         (void)rtl_drop_u8_bytes_preserve_alignment(data, rem, &s->iq_byte_carry, &s->rot_phase, fs4_shift_active);
         return;
     }
-    DSD_MEMCPY(s->tcp_pending, data, rem);
+    rtl_tcp_copy_cu8_with_moments(s->tcp_pending, data, rem, moments);
     s->tcp_pending_len = rem;
 }
 
 static void
 rtl_tcp_reassemble_and_submit(struct rtl_device* s, unsigned char* u8, uint32_t len,
-                              const struct rtl_u8_transform_policy_state* policy) {
+                              const struct rtl_u8_transform_policy_state* policy,
+                              dsd_input_level_cu8_moments* moments) {
     if (!s || !u8 || !policy) {
         return;
     }
     const size_t slice = (s->buf_len > 0 ? (size_t)s->buf_len : 16384U);
-    size_t consumed = rtl_tcp_fill_pending_slice(s, u8, len, slice, policy);
+    size_t consumed = rtl_tcp_fill_pending_slice(s, u8, len, slice, policy, moments);
     if (consumed < len) {
-        rtl_tcp_process_full_slices(s, u8, len, slice, policy, &consumed);
+        rtl_tcp_process_full_slices(s, u8, len, slice, policy, &consumed, moments);
     }
     if (consumed < len) {
-        rtl_tcp_store_remainder(s, u8 + consumed, len - consumed, policy->fs4_shift_active);
+        rtl_tcp_store_remainder(s, u8 + consumed, len - consumed, policy->fs4_shift_active, moments);
     }
 }
 
@@ -3939,8 +4091,10 @@ static DSD_THREAD_RETURN_TYPE
 
         rtl_tcp_account_input_stats(s, len);
         rtl_submit_capture_bytes(s, st.u8, len);
-        rtl_publish_cu8_input_level(s, st.u8, len);
-        rtl_tcp_reassemble_and_submit(s, st.u8, len, &policy);
+        dsd_input_level_cu8_moments moments;
+        dsd_input_level_cu8_moments_reset(&moments);
+        rtl_tcp_reassemble_and_submit(s, st.u8, len, &policy, &moments);
+        rtl_publish_cu8_input_level_moments(s, &moments);
         rtl_tcp_periodic_maintenance(s, &st);
     }
 
@@ -6331,8 +6485,8 @@ rtl_device_test_u8_odd_carry_bridge(size_t* out_used, int* out_phase, int* out_c
 
     unsigned char first[] = {129U};
     unsigned char second[] = {128U, 126U};
-    *out_first_status = rtl_write_u8_to_ring(&dev, first, sizeof(first), 1, 0, 1, 0);
-    *out_second_status = rtl_write_u8_to_ring(&dev, second, sizeof(second), 1, 0, 1, 0);
+    *out_first_status = rtl_write_u8_to_ring(&dev, first, sizeof(first), 1, 0, 1, 0, NULL);
+    *out_second_status = rtl_write_u8_to_ring(&dev, second, sizeof(second), 1, 0, 1, 0, NULL);
     *out_used = input_ring_used(&ring);
     *out_phase = dev.rot_phase;
     *out_carry_valid = dev.iq_byte_carry.valid ? 1 : 0;
@@ -6360,7 +6514,7 @@ rtl_device_test_u8_full_ring_drop(size_t* out_used, uint64_t* out_drops, uint64_
     dev.rot_phase = 0;
 
     unsigned char input[] = {130U, 127U, 129U, 126U, 128U, 125U};
-    *out_status = rtl_write_u8_to_ring(&dev, input, sizeof(input), 1, 0, 1, 1);
+    *out_status = rtl_write_u8_to_ring(&dev, input, sizeof(input), 1, 0, 1, 1, NULL);
     *out_used = input_ring_used(&ring);
     *out_drops = ring.producer_drops.load(std::memory_order_acquire);
     *out_full_events = dev.reserve_full_events;
@@ -6395,7 +6549,7 @@ rtl_device_test_u8_generation_stale_drop(uint64_t* out_drops, int* out_phase, in
     size_t produced = 2U;
     *out_status = rtl_handle_u8_ring_generation_stale(&dev, input, done, need, &carry, &phase, 1, produced);
 
-    rtl_u8_finalize_state final_state = {input, sizeof(input), done, need, &carry, &phase, 1, 0, 0, 1};
+    rtl_u8_finalize_state final_state = {input, sizeof(input), done, need, &carry, &phase, 1, 0, 0, 1, NULL};
     rtl_finalize_u8_ring_write(&dev, &final_state);
 
     *out_drops = ring.producer_drops.load(std::memory_order_acquire);
@@ -6404,6 +6558,115 @@ rtl_device_test_u8_generation_stale_drop(uint64_t* out_drops, int* out_phase, in
     *out_local_carry_valid = carry.valid ? 1 : 0;
 
     input_ring_destroy(&ring);
+    return 0;
+}
+
+static int
+rtl_device_test_collect_write_moments(unsigned char* input, size_t input_len, size_t ring_capacity, size_t start_index,
+                                      int use_two_pass, int force_stale, dsd_input_level_cu8_moments* out) {
+    if (!input || input_len == 0U || !out || ring_capacity < 3U || start_index >= ring_capacity) {
+        return -1;
+    }
+    input_ring_state ring{};
+    if (input_ring_init(&ring, ring_capacity) != 0) {
+        return -2;
+    }
+    ring.head.store(start_index, std::memory_order_relaxed);
+    ring.tail.store(start_index, std::memory_order_relaxed);
+
+    rtl_device dev{};
+    dev.input_ring = &ring;
+    dev.backend = RTL_BACKEND_USB;
+    dsd_input_level_cu8_moments_reset(out);
+    if (force_stale) {
+        g_rtl_test_force_u8_generation_stale.store(1, std::memory_order_release);
+    }
+    (void)rtl_write_u8_to_ring(&dev, input, input_len, 1, use_two_pass, use_two_pass ? 0 : 1, 1, out);
+    g_rtl_test_force_u8_generation_stale.store(0, std::memory_order_release);
+    input_ring_destroy(&ring);
+    return 0;
+}
+
+extern "C" int
+rtl_device_test_u8_moment_accounting(dsd_input_level_cu8_moments* out, size_t out_count) {
+    if (!out || out_count < 9U) {
+        return -1;
+    }
+
+    unsigned char contiguous[] = {0U, 1U, 2U, 128U, 254U, 255U};
+    unsigned char wrapped[] = {0U, 1U, 2U, 128U, 254U, 255U};
+    unsigned char full[] = {0U, 1U, 2U, 128U, 254U, 255U};
+    unsigned char stale[] = {0U, 1U, 2U, 128U, 254U, 255U};
+    if (rtl_device_test_collect_write_moments(contiguous, sizeof(contiguous), 10U, 0U, 0, 0, &out[0]) != 0
+        || rtl_device_test_collect_write_moments(wrapped, sizeof(wrapped), 10U, 8U, 0, 0, &out[1]) != 0) {
+        return -2;
+    }
+
+    input_ring_state odd_ring{};
+    if (input_ring_init(&odd_ring, 16U) != 0) {
+        return -2;
+    }
+    rtl_device odd_dev{};
+    odd_dev.input_ring = &odd_ring;
+    odd_dev.backend = RTL_BACKEND_USB;
+    unsigned char odd_first[] = {3U};
+    unsigned char odd_second[] = {4U, 5U};
+    dsd_input_level_cu8_moments_reset(&out[2]);
+    dsd_input_level_cu8_moments_reset(&out[3]);
+    (void)rtl_write_u8_to_ring(&odd_dev, odd_first, sizeof(odd_first), 1, 0, 1, 0, &out[2]);
+    (void)rtl_write_u8_to_ring(&odd_dev, odd_second, sizeof(odd_second), 1, 0, 1, 0, &out[3]);
+    input_ring_destroy(&odd_ring);
+
+    if (rtl_device_test_collect_write_moments(full, sizeof(full), 3U, 0U, 0, 0, &out[4]) != 0
+        || rtl_device_test_collect_write_moments(stale, sizeof(stale), 5U, 0U, 0, 1, &out[5]) != 0) {
+        return -2;
+    }
+
+    input_ring_state tcp_ring{};
+    if (input_ring_init(&tcp_ring, 32U) != 0) {
+        return -2;
+    }
+    rtl_device tcp_dev{};
+    tcp_dev.input_ring = &tcp_ring;
+    tcp_dev.backend = RTL_BACKEND_TCP;
+    tcp_dev.buf_len = 4;
+    tcp_dev.tcp_pending = static_cast<unsigned char*>(malloc(4U));
+    if (!tcp_dev.tcp_pending) {
+        input_ring_destroy(&tcp_ring);
+        return -2;
+    }
+    tcp_dev.tcp_pending_cap = 4U;
+    tcp_dev.tcp_pending_len = 2U;
+    tcp_dev.tcp_pending[0] = 91U;
+    tcp_dev.tcp_pending[1] = 92U;
+    unsigned char tcp_input[] = {0U, 255U, 1U, 2U, 3U, 4U, 254U, 253U, 128U};
+    rtl_u8_transform_policy_state policy{1, 1, 0};
+    dsd_input_level_cu8_moments_reset(&out[6]);
+    rtl_tcp_reassemble_and_submit(&tcp_dev, tcp_input, (uint32_t)sizeof(tcp_input), &policy, &out[6]);
+    free(tcp_dev.tcp_pending);
+    input_ring_destroy(&tcp_ring);
+
+    const uint8_t replay_raw[] = {0U, 1U, 254U, 255U};
+    for (int historical = 0; historical <= 1; historical++) {
+        rtl_device replay_dev{};
+        replay_dev.backend = RTL_BACKEND_IQ_REPLAY;
+        replay_dev.replay_cfg.format = DSD_IQ_FORMAT_CU8;
+        replay_dev.replay_fs4_shift_enabled = 1;
+        replay_dev.replay_historical_cu8_two_pass = historical;
+        uint8_t mutable_raw[sizeof(replay_raw)];
+        DSD_MEMCPY(mutable_raw, replay_raw, sizeof(replay_raw));
+        float converted[sizeof(replay_raw) + 1U] = {};
+        int phase = 0;
+        int have_carry = 1;
+        uint8_t carry_byte = 77U;
+        dsd_input_level_cu8_moments_reset(&out[7U + (size_t)historical]);
+        int produced = replay_convert_cu8_to_f32(&replay_dev, mutable_raw, sizeof(mutable_raw), converted,
+                                                 sizeof(converted) / sizeof(converted[0]), &phase, &have_carry,
+                                                 &carry_byte, &out[7U + (size_t)historical]);
+        if (produced <= 0) {
+            return -2;
+        }
+    }
     return 0;
 }
 

--- a/src/runtime/input_level.c
+++ b/src/runtime/input_level.c
@@ -228,37 +228,123 @@ dsd_input_level_metrics_from_pcm_f32_i16_scale(const float* samples, size_t coun
     return 0;
 }
 
+static int
+input_level_cu8_moments_valid(const dsd_input_level_cu8_moments* moments) {
+    if (!moments || moments->count == 0U || moments->clipped > moments->count
+        || moments->min_sample > moments->max_sample) {
+        return 0;
+    }
+    if ((moments->count <= UINT64_MAX / 255U && moments->sum > moments->count * 255U)
+        || (moments->count <= UINT64_MAX / 65025U && moments->sum_sq > moments->count * 65025U)) {
+        return 0;
+    }
+    return 1;
+}
+
+int
+dsd_input_level_cu8_moments_merge(dsd_input_level_cu8_moments* moments, const dsd_input_level_cu8_moments* add) {
+    if (!moments || !input_level_cu8_moments_valid(add)) {
+        return -1;
+    }
+
+    dsd_input_level_cu8_moments next = *moments;
+    if (next.count == 0U) {
+        next = *add;
+    } else {
+        if (!input_level_cu8_moments_valid(&next) || UINT64_MAX - next.count < add->count
+            || UINT64_MAX - next.sum < add->sum || UINT64_MAX - next.sum_sq < add->sum_sq
+            || UINT64_MAX - next.clipped < add->clipped) {
+            return -1;
+        }
+        next.count += add->count;
+        next.sum += add->sum;
+        next.sum_sq += add->sum_sq;
+        next.clipped += add->clipped;
+        if (add->min_sample < next.min_sample) {
+            next.min_sample = add->min_sample;
+        }
+        if (add->max_sample > next.max_sample) {
+            next.max_sample = add->max_sample;
+        }
+    }
+    *moments = next;
+    return 0;
+}
+
+void
+dsd_input_level_cu8_moments_reset(dsd_input_level_cu8_moments* moments) {
+    if (!moments) {
+        return;
+    }
+    moments->count = 0U;
+    moments->sum = 0U;
+    moments->sum_sq = 0U;
+    moments->clipped = 0U;
+    moments->min_sample = UINT8_MAX;
+    moments->max_sample = 0U;
+}
+
+int
+dsd_input_level_cu8_moments_accumulate(dsd_input_level_cu8_moments* moments, const uint8_t* samples, size_t count) {
+    if (!moments || !samples || count == 0U || count > UINT64_MAX / 65025U) {
+        return -1;
+    }
+
+    dsd_input_level_cu8_moments add;
+    dsd_input_level_cu8_moments_reset(&add);
+    add.count = (uint64_t)count;
+    for (size_t i = 0U; i < count; i++) {
+        const uint8_t sample = samples[i];
+        add.sum += (uint64_t)sample;
+        add.sum_sq += (uint64_t)sample * (uint64_t)sample;
+        add.clipped += (sample <= 1U || sample >= 254U) ? 1U : 0U;
+        if (sample < add.min_sample) {
+            add.min_sample = sample;
+        }
+        if (sample > add.max_sample) {
+            add.max_sample = sample;
+        }
+    }
+    return dsd_input_level_cu8_moments_merge(moments, &add);
+}
+
+int
+dsd_input_level_cu8_moments_finalize(const dsd_input_level_cu8_moments* moments, dsd_input_level_source source,
+                                     dsd_input_level_snapshot* out) {
+    if (!out || !input_level_cu8_moments_valid(moments)) {
+        return -1;
+    }
+
+    const double count = (double)moments->count;
+    const double mean = (double)moments->sum / count;
+    double variance = (double)moments->sum_sq / count - mean * mean;
+    if (variance < 0.0) {
+        variance = 0.0;
+    }
+    const double full_scale = 127.5;
+    const double low_peak = full_scale - (double)moments->min_sample;
+    const double high_peak = (double)moments->max_sample - full_scale;
+    const double peak = ((low_peak > high_peak) ? low_peak : high_peak) / full_scale;
+    const double mean_power = variance / (full_scale * full_scale);
+    input_level_fill(out, source, mean_power, peak, moments->clipped, moments->count);
+    return 0;
+}
+
+int
+dsd_input_level_metrics_from_cu8_moments(const dsd_input_level_cu8_moments* moments, dsd_input_level_source source,
+                                         dsd_input_level_snapshot* out) {
+    return dsd_input_level_cu8_moments_finalize(moments, source, out);
+}
+
 int
 dsd_input_level_metrics_from_cu8(const uint8_t* samples, size_t count, dsd_input_level_source source,
                                  dsd_input_level_snapshot* out) {
-    if (!out || !samples || count == 0U) {
+    dsd_input_level_cu8_moments moments;
+    dsd_input_level_cu8_moments_reset(&moments);
+    if (!out || dsd_input_level_cu8_moments_accumulate(&moments, samples, count) != 0) {
         return -1;
     }
-    double p = 0.0;
-    double t = 0.0;
-    double peak = 0.0;
-    uint64_t clipped = 0U;
-    const double scale = 1.0 / 127.5;
-    for (size_t i = 0U; i < count; i++) {
-        const uint8_t sample = samples[i];
-        const double s = ((double)sample - 127.5) * scale;
-        const double a = fabs(s);
-        if (a > peak) {
-            peak = a;
-        }
-        if (sample <= 1U || sample >= 254U) {
-            clipped++;
-        }
-        t += s;
-        p += s * s;
-    }
-    double mean_power = p - ((t * t) / (double)count);
-    if (mean_power < 0.0) {
-        mean_power = 0.0;
-    }
-    mean_power /= (double)count;
-    input_level_fill(out, source, mean_power, peak, clipped, (uint64_t)count);
-    return 0;
+    return dsd_input_level_cu8_moments_finalize(&moments, source, out);
 }
 
 int

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4754,6 +4754,13 @@ target_link_libraries(
     dsd-neo_test_dsp_simd_widen
     PRIVATE dsd-neo_dsp_private_test_support
 )
+get_target_property(_dsd_neo_widen_dsp_sources dsd-neo_dsp SOURCES)
+if(_dsd_neo_widen_dsp_sources MATCHES "simd_widen_avx2\\.cpp")
+    target_compile_definitions(
+        dsd-neo_test_dsp_simd_widen
+        PRIVATE DSD_NEO_TEST_HAVE_AVX2_IMPL=1
+    )
+endif()
 add_test(NAME DSP_SIMD_WIDEN COMMAND dsd-neo_test_dsp_simd_widen)
 
 add_executable(dsd-neo_test_dsp_simd_fir dsp/test_dsp_simd_fir.cpp)

--- a/tests/dsp/test_dsp_simd_widen.cpp
+++ b/tests/dsp/test_dsp_simd_widen.cpp
@@ -9,21 +9,45 @@
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "dsd-neo/core/input_level.h"
 #include "dsd-neo/core/safe_api.h"
 #include "io/radio/rtl_capture_phase.h"
 
 #if defined(__x86_64__) || defined(_M_X64)
+extern "C" void widen_u8_to_f32_bias127_moments_sse2(const unsigned char* src, float* dst, uint32_t len,
+                                                     dsd_input_level_cu8_moments* moments);
 extern "C" uint32_t widen_rotate90_u8_to_f32_bias127_phase_sse2(const unsigned char* src, float* dst, uint32_t len,
                                                                 uint32_t phase);
+extern "C" uint32_t widen_rotate90_u8_to_f32_bias127_phase_moments_sse2(const unsigned char* src, float* dst,
+                                                                        uint32_t len, uint32_t phase,
+                                                                        dsd_input_level_cu8_moments* moments);
+#if defined(DSD_NEO_TEST_HAVE_AVX2_IMPL)
+#include "dsp/simd_x86_cpu.h"
+extern "C" void widen_u8_to_f32_bias127_moments_avx2(const unsigned char* src, float* dst, uint32_t len,
+                                                     dsd_input_level_cu8_moments* moments);
+extern "C" uint32_t widen_rotate90_u8_to_f32_bias127_phase_moments_avx2(const unsigned char* src, float* dst,
+                                                                        uint32_t len, uint32_t phase,
+                                                                        dsd_input_level_cu8_moments* moments);
+#endif
 #endif
 
 #if defined(__aarch64__) || defined(__arm64) || defined(_M_ARM64) || defined(_M_ARM64EC)
+extern "C" void widen_u8_to_f32_bias127_moments_neon(const unsigned char* src, float* dst, uint32_t len,
+                                                     dsd_input_level_cu8_moments* moments);
 extern "C" uint32_t widen_rotate90_u8_to_f32_bias127_phase_neon(const unsigned char* src, float* dst, uint32_t len,
                                                                 uint32_t phase);
+extern "C" uint32_t widen_rotate90_u8_to_f32_bias127_phase_moments_neon(const unsigned char* src, float* dst,
+                                                                        uint32_t len, uint32_t phase,
+                                                                        dsd_input_level_cu8_moments* moments);
 #endif
 
+extern "C" void dsd_test_widen_u8_to_f32_bias127_moments_scalar(const unsigned char* src, float* dst, uint32_t len,
+                                                                dsd_input_level_cu8_moments* moments);
 extern "C" uint32_t dsd_test_widen_rotate90_u8_to_f32_bias127_phase_scalar(const unsigned char* src, float* dst,
                                                                            uint32_t len, uint32_t phase);
+extern "C" uint32_t
+dsd_test_widen_rotate90_u8_to_f32_bias127_phase_moments_scalar(const unsigned char* src, float* dst, uint32_t len,
+                                                               uint32_t phase, dsd_input_level_cu8_moments* moments);
 
 static int
 arrays_close(const float* a, const float* b, int n, float tol) {
@@ -96,6 +120,83 @@ process_rot_widen_chunk_with_carry(const unsigned char* src, size_t len, float* 
 }
 
 using widen_backend_fn = unsigned int (*)(const unsigned char*, float*, unsigned int, unsigned int);
+using widen_moments_backend_fn = void (*)(const unsigned char*, float*, unsigned int, dsd_input_level_cu8_moments*);
+using widen_rot_moments_backend_fn = unsigned int (*)(const unsigned char*, float*, unsigned int, unsigned int,
+                                                      dsd_input_level_cu8_moments*);
+
+static int
+moments_equal(const dsd_input_level_cu8_moments* lhs, const dsd_input_level_cu8_moments* rhs) {
+    return lhs->count == rhs->count && lhs->sum == rhs->sum && lhs->sum_sq == rhs->sum_sq
+           && lhs->clipped == rhs->clipped && lhs->min_sample == rhs->min_sample && lhs->max_sample == rhs->max_sample;
+}
+
+static void
+seed_moments(dsd_input_level_cu8_moments* moments) {
+    const unsigned char seed[] = {17U, 254U, 99U};
+    dsd_input_level_cu8_moments_reset(moments);
+    (void)dsd_input_level_cu8_moments_accumulate(moments, seed, sizeof(seed));
+}
+
+static int
+test_plain_moments_backend(const char* name, widen_moments_backend_fn fn) {
+    unsigned char src[256];
+    float dst_full[256] = {0};
+    float dst_split[256] = {0};
+    float ref[256] = {0};
+    for (unsigned int i = 0U; i < 256U; i++) {
+        src[i] = (unsigned char)i;
+    }
+    widen_u8_to_f32_bias127(src, ref, 256U);
+
+    dsd_input_level_cu8_moments full;
+    dsd_input_level_cu8_moments split;
+    dsd_input_level_cu8_moments expected;
+    seed_moments(&full);
+    seed_moments(&split);
+    seed_moments(&expected);
+    (void)dsd_input_level_cu8_moments_accumulate(&expected, src, sizeof(src));
+
+    fn(src, dst_full, 256U, &full);
+    fn(src, dst_split, 95U, &split);
+    fn(src + 95U, dst_split + 95U, 161U, &split);
+    if (!arrays_close(dst_full, ref, 256, 1e-6f) || !arrays_close(dst_split, ref, 256, 1e-6f)
+        || !moments_equal(&full, &expected) || !moments_equal(&split, &expected)) {
+        DSD_FPRINTF(stderr, "%s output or moments: mismatch\n", name);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_rotated_moments_backend(const char* name, widen_rot_moments_backend_fn fn) {
+    unsigned char src[256];
+    float dst_full[256] = {0};
+    float dst_split[256] = {0};
+    float ref[256] = {0};
+    for (unsigned int i = 0U; i < 256U; i++) {
+        src[i] = (unsigned char)i;
+    }
+
+    const unsigned int expected_phase = dsd_test_widen_rotate90_u8_to_f32_bias127_phase_scalar(src, ref, 256U, 3U);
+    dsd_input_level_cu8_moments full;
+    dsd_input_level_cu8_moments split;
+    dsd_input_level_cu8_moments expected;
+    seed_moments(&full);
+    seed_moments(&split);
+    seed_moments(&expected);
+    (void)dsd_input_level_cu8_moments_accumulate(&expected, src, sizeof(src));
+
+    const unsigned int full_phase = fn(src, dst_full, 256U, 3U, &full);
+    unsigned int split_phase = fn(src, dst_split, 94U, 3U, &split);
+    split_phase = fn(src + 94U, dst_split + 94U, 162U, split_phase, &split);
+    if (full_phase != expected_phase || split_phase != expected_phase || !arrays_close(dst_full, ref, 256, 1e-6f)
+        || !arrays_close(dst_split, ref, 256, 1e-6f) || !moments_equal(&full, &expected)
+        || !moments_equal(&split, &expected)) {
+        DSD_FPRINTF(stderr, "%s output, phase, or moments: mismatch\n", name);
+        return 1;
+    }
+    return 0;
+}
 
 static int
 test_rotate_widen_backend(const char* name, widen_backend_fn fn) {
@@ -333,6 +434,44 @@ main(void) {
 
 #if defined(__aarch64__) || defined(__arm64) || defined(_M_ARM64) || defined(_M_ARM64EC)
     if (test_rotate_widen_backend("SIMD rotate+widen NEON", widen_rotate90_u8_to_f32_bias127_phase_neon) != 0) {
+        return 1;
+    }
+#endif
+
+    if (test_plain_moments_backend("SIMD widen+moments scalar", dsd_test_widen_u8_to_f32_bias127_moments_scalar) != 0
+        || test_rotated_moments_backend("SIMD rotate+widen+moments scalar",
+                                        dsd_test_widen_rotate90_u8_to_f32_bias127_phase_moments_scalar)
+               != 0
+        || test_plain_moments_backend("SIMD widen+moments dispatch", widen_u8_to_f32_bias127_moments) != 0
+        || test_rotated_moments_backend("SIMD rotate+widen+moments dispatch",
+                                        widen_rotate90_u8_to_f32_bias127_phase_moments)
+               != 0) {
+        return 1;
+    }
+
+#if defined(__x86_64__) || defined(_M_X64)
+    if (test_plain_moments_backend("SIMD widen+moments SSE2", widen_u8_to_f32_bias127_moments_sse2) != 0
+        || test_rotated_moments_backend("SIMD rotate+widen+moments SSE2",
+                                        widen_rotate90_u8_to_f32_bias127_phase_moments_sse2)
+               != 0) {
+        return 1;
+    }
+#if defined(DSD_NEO_TEST_HAVE_AVX2_IMPL)
+    if (dsd_neo_cpu_has_avx2_with_os_support()
+        && (test_plain_moments_backend("SIMD widen+moments AVX2", widen_u8_to_f32_bias127_moments_avx2) != 0
+            || test_rotated_moments_backend("SIMD rotate+widen+moments AVX2",
+                                            widen_rotate90_u8_to_f32_bias127_phase_moments_avx2)
+                   != 0)) {
+        return 1;
+    }
+#endif
+#endif
+
+#if defined(__aarch64__) || defined(__arm64) || defined(_M_ARM64) || defined(_M_ARM64EC)
+    if (test_plain_moments_backend("SIMD widen+moments NEON", widen_u8_to_f32_bias127_moments_neon) != 0
+        || test_rotated_moments_backend("SIMD rotate+widen+moments NEON",
+                                        widen_rotate90_u8_to_f32_bias127_phase_moments_neon)
+               != 0) {
         return 1;
     }
 #endif

--- a/tests/io/bench_rtl.cpp
+++ b/tests/io/bench_rtl.cpp
@@ -22,6 +22,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <dsd-neo/core/input_level.h>
 #include <dsd-neo/dsp/simd_widen.h>
 #include <dsd-neo/io/rtl_metrics.h>
 #include <dsd-neo/platform/threading.h>
@@ -225,12 +226,15 @@ reset_ring_at(input_ring_state* ring, size_t index) {
 }
 
 static uint32_t
-process_u8_chunk(const unsigned char* src, float* dst, size_t len, uint32_t phase) {
-    return widen_rotate90_u8_to_f32_bias127_phase(src, dst, (uint32_t)len, phase);
+process_u8_chunk(const unsigned char* src, float* dst, size_t len, uint32_t phase,
+                 dsd_input_level_cu8_moments* moments) {
+    return moments ? widen_rotate90_u8_to_f32_bias127_phase_moments(src, dst, (uint32_t)len, phase, moments)
+                   : widen_rotate90_u8_to_f32_bias127_phase(src, dst, (uint32_t)len, phase);
 }
 
 static float
-ingest_u8_block(input_ring_state* ring, const unsigned char* src, size_t len, size_t start_index, uint32_t* phase) {
+ingest_u8_block(input_ring_state* ring, const unsigned char* src, size_t len, size_t start_index, uint32_t* phase,
+                dsd_input_level_cu8_moments* moments) {
     reset_ring_at(ring, start_index);
     float *p1 = NULL, *p2 = NULL;
     size_t n1 = 0, n2 = 0;
@@ -246,10 +250,10 @@ ingest_u8_block(input_ring_state* ring, const unsigned char* src, size_t len, si
     size_t w2 = (n2 < rem) ? n2 : rem;
 
     if (w1 > 0U) {
-        *phase = process_u8_chunk(src, p1, w1, *phase);
+        *phase = process_u8_chunk(src, p1, w1, *phase, moments);
     }
     if (w2 > 0U) {
-        *phase = process_u8_chunk(src + w1, p2, w2, *phase);
+        *phase = process_u8_chunk(src + w1, p2, w2, *phase, moments);
     }
     input_ring_commit(ring, w1 + w2);
     return (p1 ? p1[0] : 0.0f)
@@ -257,6 +261,46 @@ ingest_u8_block(input_ring_state* ring, const unsigned char* src, size_t len, si
               : (p1 && w1 > 0U) ? p1[w1 - 1U]
                                 : 0.0f)
            + (float)(*phase);
+}
+
+static float
+cu8_snapshot_checksum(const dsd_input_level_snapshot* snapshot) {
+    return snapshot ? (float)(snapshot->rms_dbfs + snapshot->peak_dbfs + snapshot->clip_pct)
+                          + (float)(snapshot->sample_count & 0xffffU)
+                    : 0.0f;
+}
+
+static float
+measure_cu8_integer_metrics(const unsigned char* src, size_t len) {
+    dsd_input_level_cu8_moments moments;
+    dsd_input_level_snapshot snapshot;
+    dsd_input_level_cu8_moments_reset(&moments);
+    if (dsd_input_level_cu8_moments_accumulate(&moments, src, len) != 0
+        || dsd_input_level_cu8_moments_finalize(&moments, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, &snapshot) != 0) {
+        return -1.0f;
+    }
+    return cu8_snapshot_checksum(&snapshot) + (float)(moments.sum & 0xffU);
+}
+
+static float
+ingest_u8_with_separate_metrics(input_ring_state* ring, const unsigned char* src, size_t len, uint32_t* phase) {
+    dsd_input_level_snapshot snapshot;
+    if (dsd_input_level_metrics_from_cu8(src, len, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, &snapshot) != 0) {
+        return -1.0f;
+    }
+    return ingest_u8_block(ring, src, len, 0U, phase, NULL) + cu8_snapshot_checksum(&snapshot);
+}
+
+static float
+ingest_u8_with_fused_metrics(input_ring_state* ring, const unsigned char* src, size_t len, uint32_t* phase) {
+    dsd_input_level_cu8_moments moments;
+    dsd_input_level_snapshot snapshot;
+    dsd_input_level_cu8_moments_reset(&moments);
+    float checksum = ingest_u8_block(ring, src, len, 0U, phase, &moments);
+    if (dsd_input_level_cu8_moments_finalize(&moments, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, &snapshot) != 0) {
+        return -1.0f;
+    }
+    return checksum + cu8_snapshot_checksum(&snapshot);
 }
 
 static float
@@ -311,16 +355,52 @@ bench_rtl_ingest(const BenchOptions& opts) {
 
     uint32_t combined_phase = 0;
     ran += run_case(opts, "rtl_ingest_u8_combined_contig", "byte", (double)kBytes,
-                    [&]() -> float { return ingest_u8_block(&ring, u8.data(), kBytes, 0U, &combined_phase); });
+                    [&]() -> float { return ingest_u8_block(&ring, u8.data(), kBytes, 0U, &combined_phase, NULL); });
 
     uint32_t wrap_phase = 0;
-    ran += run_case(opts, "rtl_ingest_u8_combined_wrap", "byte", (double)kBytes,
-                    [&]() -> float { return ingest_u8_block(&ring, u8.data(), kBytes, kWrapStart, &wrap_phase); });
+    ran += run_case(opts, "rtl_ingest_u8_combined_wrap", "byte", (double)kBytes, [&]() -> float {
+        return ingest_u8_block(&ring, u8.data(), kBytes, kWrapStart, &wrap_phase, NULL);
+    });
 
     ran += run_case(opts, "rtl_ingest_cs16_contig", "sample", (double)kBytes,
                     [&]() -> float { return ingest_cs16_block(&ring, cs16.data(), kBytes / 2U, 0U); });
 
     input_ring_destroy(&ring);
+
+    constexpr size_t kMaxBytes = static_cast<size_t>(256U) * 1024U;
+    constexpr size_t kMaxRingCap = kMaxBytes + 513U;
+    std::vector<unsigned char> u8_max(kMaxBytes);
+    fill_cu8(&u8_max, 0x89abcdefu);
+    input_ring_state max_ring;
+    if (input_ring_init(&max_ring, kMaxRingCap) != 0) {
+        DSD_FPRINTF(stderr, "maximum input_ring_init failed\n");
+        return ran;
+    }
+
+    ran += run_case(opts, "rtl_cu8_integer_metrics_16k", "byte", (double)u8.size(),
+                    [&]() -> float { return measure_cu8_integer_metrics(u8.data(), u8.size()); });
+    ran += run_case(opts, "rtl_cu8_integer_metrics_256k", "byte", (double)u8_max.size(),
+                    [&]() -> float { return measure_cu8_integer_metrics(u8_max.data(), u8_max.size()); });
+
+    uint32_t separate_phase_16k = 0U;
+    ran += run_case(opts, "rtl_ingest_u8_metrics_separate_16k", "byte", (double)u8.size(), [&]() -> float {
+        return ingest_u8_with_separate_metrics(&max_ring, u8.data(), u8.size(), &separate_phase_16k);
+    });
+    uint32_t fused_phase_16k = 0U;
+    ran += run_case(opts, "rtl_ingest_u8_metrics_fused_16k", "byte", (double)u8.size(), [&]() -> float {
+        return ingest_u8_with_fused_metrics(&max_ring, u8.data(), u8.size(), &fused_phase_16k);
+    });
+
+    uint32_t separate_phase_256k = 0U;
+    ran += run_case(opts, "rtl_ingest_u8_metrics_separate_256k", "byte", (double)u8_max.size(), [&]() -> float {
+        return ingest_u8_with_separate_metrics(&max_ring, u8_max.data(), u8_max.size(), &separate_phase_256k);
+    });
+    uint32_t fused_phase_256k = 0U;
+    ran += run_case(opts, "rtl_ingest_u8_metrics_fused_256k", "byte", (double)u8_max.size(), [&]() -> float {
+        return ingest_u8_with_fused_metrics(&max_ring, u8_max.data(), u8_max.size(), &fused_phase_256k);
+    });
+
+    input_ring_destroy(&max_ring);
     return ran;
 }
 

--- a/tests/io/test_io_input_level_metrics.c
+++ b/tests/io/test_io_input_level_metrics.c
@@ -9,6 +9,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "dsd-neo/core/safe_api.h"
+
 static void
 classify(dsd_input_level_snapshot* snapshot) {
     dsd_input_level_classify(snapshot, -40.0);
@@ -95,6 +97,137 @@ test_cu8_metrics(void) {
 }
 
 static void
+assert_cu8_moments_equal(const dsd_input_level_cu8_moments* lhs, const dsd_input_level_cu8_moments* rhs) {
+    assert(lhs != NULL);
+    assert(rhs != NULL);
+    assert(lhs->count == rhs->count);
+    assert(lhs->sum == rhs->sum);
+    assert(lhs->sum_sq == rhs->sum_sq);
+    assert(lhs->clipped == rhs->clipped);
+    assert(lhs->min_sample == rhs->min_sample);
+    assert(lhs->max_sample == rhs->max_sample);
+}
+
+static void
+test_cu8_integer_moments(void) {
+    uint8_t all_values[256];
+    for (size_t i = 0U; i < sizeof(all_values); i++) {
+        all_values[i] = (uint8_t)i;
+    }
+
+    dsd_input_level_cu8_moments one_shot;
+    dsd_input_level_cu8_moments_reset(&one_shot);
+    assert(one_shot.count == 0U);
+    assert(one_shot.sum == 0U);
+    assert(one_shot.sum_sq == 0U);
+    assert(one_shot.clipped == 0U);
+    assert(one_shot.min_sample == UINT8_MAX);
+    assert(one_shot.max_sample == 0U);
+    assert(dsd_input_level_cu8_moments_accumulate(&one_shot, all_values, sizeof(all_values)) == 0);
+    assert(one_shot.count == 256U);
+    assert(one_shot.sum == 32640U);
+    assert(one_shot.sum_sq == 5559680U);
+    assert(one_shot.clipped == 4U);
+    assert(one_shot.min_sample == 0U);
+    assert(one_shot.max_sample == 255U);
+
+    dsd_input_level_cu8_moments incremental;
+    dsd_input_level_cu8_moments_reset(&incremental);
+    assert(dsd_input_level_cu8_moments_accumulate(&incremental, all_values, 73U) == 0);
+    assert(dsd_input_level_cu8_moments_accumulate(&incremental, all_values + 73U, 1U) == 0);
+    assert(dsd_input_level_cu8_moments_accumulate(&incremental, all_values + 74U, 182U) == 0);
+    assert_cu8_moments_equal(&incremental, &one_shot);
+
+    const uint8_t clipping_edges[] = {0U, 1U, 2U, 253U, 254U, 255U};
+    dsd_input_level_cu8_moments edges;
+    dsd_input_level_cu8_moments_reset(&edges);
+    assert(dsd_input_level_cu8_moments_accumulate(&edges, clipping_edges, sizeof(clipping_edges)) == 0);
+    assert(edges.clipped == 4U);
+    assert(edges.min_sample == 0U);
+    assert(edges.max_sample == 255U);
+
+    dsd_input_level_snapshot snapshot;
+    assert(dsd_input_level_cu8_moments_finalize(&one_shot, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, &snapshot) == 0);
+    const double mean = 127.5;
+    const double variance = 5559680.0 / 256.0 - mean * mean;
+    const double expected_rms = 10.0 * log10(variance / (127.5 * 127.5));
+    assert(snapshot.source == DSD_INPUT_LEVEL_SOURCE_RTL_CU8);
+    assert(snapshot.sample_count == 256U);
+    assert(fabs(snapshot.rms_dbfs - expected_rms) < 1e-12);
+    assert(fabs(snapshot.peak_dbfs) < 1e-12);
+    assert(fabs(snapshot.clip_pct - 1.5625) < 1e-12);
+
+    dsd_input_level_snapshot alias_snapshot;
+    assert(dsd_input_level_metrics_from_cu8_moments(&one_shot, DSD_INPUT_LEVEL_SOURCE_RTL_TCP_CU8, &alias_snapshot)
+           == 0);
+    assert(alias_snapshot.source == DSD_INPUT_LEVEL_SOURCE_RTL_TCP_CU8);
+    assert(alias_snapshot.sample_count == snapshot.sample_count);
+    assert(alias_snapshot.rms_dbfs == snapshot.rms_dbfs);
+    assert(alias_snapshot.peak_dbfs == snapshot.peak_dbfs);
+    assert(alias_snapshot.clip_pct == snapshot.clip_pct);
+
+    uint8_t constant[32];
+    DSD_MEMSET(constant, 128, sizeof(constant));
+    dsd_input_level_cu8_moments dc;
+    dsd_input_level_cu8_moments_reset(&dc);
+    assert(dsd_input_level_cu8_moments_accumulate(&dc, constant, sizeof(constant)) == 0);
+    assert(dsd_input_level_cu8_moments_finalize(&dc, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, &snapshot) == 0);
+    assert(snapshot.rms_dbfs == -120.0);
+    assert(fabs(snapshot.peak_dbfs - (20.0 * log10(0.5 / 127.5))) < 1e-12);
+    assert(snapshot.clip_pct == 0.0);
+
+    for (size_t i = 0U; i < sizeof(constant); i++) {
+        constant[i] = (i & 1U) ? 136U : 120U;
+    }
+    dsd_input_level_cu8_moments_reset(&dc);
+    assert(dsd_input_level_cu8_moments_accumulate(&dc, constant, sizeof(constant)) == 0);
+    assert(dsd_input_level_cu8_moments_finalize(&dc, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, &snapshot) == 0);
+    assert(fabs(snapshot.rms_dbfs - (10.0 * log10(64.0 / (127.5 * 127.5)))) < 1e-12);
+}
+
+static void
+test_cu8_moment_guards_and_overflow(void) {
+    const uint8_t sample = 255U;
+    dsd_input_level_cu8_moments moments;
+    dsd_input_level_cu8_moments_reset(&moments);
+    dsd_input_level_cu8_moments before = moments;
+    dsd_input_level_snapshot snapshot;
+
+    assert(dsd_input_level_cu8_moments_accumulate(NULL, &sample, 1U) == -1);
+    assert(dsd_input_level_cu8_moments_accumulate(&moments, NULL, 1U) == -1);
+    assert(dsd_input_level_cu8_moments_accumulate(&moments, &sample, 0U) == -1);
+    assert_cu8_moments_equal(&moments, &before);
+    assert(dsd_input_level_cu8_moments_finalize(NULL, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, &snapshot) == -1);
+    assert(dsd_input_level_cu8_moments_finalize(&moments, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, &snapshot) == -1);
+    assert(dsd_input_level_cu8_moments_finalize(&moments, DSD_INPUT_LEVEL_SOURCE_RTL_CU8, NULL) == -1);
+
+    moments.count = UINT64_MAX;
+    moments.sum = 255U;
+    moments.sum_sq = 65025U;
+    moments.clipped = 1U;
+    moments.min_sample = 255U;
+    moments.max_sample = 255U;
+    before = moments;
+    assert(dsd_input_level_cu8_moments_accumulate(&moments, &sample, 1U) == -1);
+    assert_cu8_moments_equal(&moments, &before);
+
+    dsd_input_level_cu8_moments add;
+    dsd_input_level_cu8_moments_reset(&add);
+    assert(dsd_input_level_cu8_moments_accumulate(&add, &sample, 1U) == 0);
+    moments.count = 1U;
+    moments.sum = UINT64_MAX;
+    moments.sum_sq = UINT64_MAX;
+    moments.clipped = 1U;
+    moments.min_sample = 255U;
+    moments.max_sample = 255U;
+    before = moments;
+    assert(dsd_input_level_cu8_moments_merge(&moments, &add) == -1);
+    assert_cu8_moments_equal(&moments, &before);
+    assert(dsd_input_level_cu8_moments_merge(NULL, &add) == -1);
+    assert(dsd_input_level_cu8_moments_merge(&moments, NULL) == -1);
+}
+
+static void
 test_cs16_metrics(void) {
     int16_t hot[1000] = {0};
     hot[10] = 32000;
@@ -149,6 +282,8 @@ main(void) {
     test_pcm_i16_metrics_with_step_and_guards();
     test_pcm_f32_i16_scale_metrics_nonfinite_and_guards();
     test_cu8_metrics();
+    test_cu8_integer_moments();
+    test_cu8_moment_guards_and_overflow();
     test_cs16_metrics();
     test_cf32_metrics();
     return 0;

--- a/tests/io/test_io_rtl_retune_prepare.cpp
+++ b/tests/io/test_io_rtl_retune_prepare.cpp
@@ -40,6 +40,7 @@ extern "C" int rtl_device_test_u8_full_ring_drop(size_t* out_used, uint64_t* out
                                                  int* out_phase, int* out_status);
 extern "C" int rtl_device_test_u8_generation_stale_drop(uint64_t* out_drops, int* out_phase, int* out_dev_carry_valid,
                                                         int* out_local_carry_valid, int* out_status);
+extern "C" int rtl_device_test_u8_moment_accounting(dsd_input_level_cu8_moments* out, size_t out_count);
 extern "C" int rtl_device_test_replay_input_level_snapshot(int format, int backend, const char* capture_stage,
                                                            size_t raw_bytes, size_t scratch_cap_f32, int* out_rc,
                                                            int* out_source, uint64_t* out_count);
@@ -94,6 +95,26 @@ static int
 expect_u64_eq(const char* label, uint64_t got, uint64_t want) {
     if (got != want) {
         DSD_FPRINTF(stderr, "FAIL: %s got=%llu want=%llu\n", label, (unsigned long long)got, (unsigned long long)want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_cu8_moments(const char* label, const dsd_input_level_cu8_moments* got, const uint8_t* raw, size_t raw_count) {
+    dsd_input_level_cu8_moments want;
+    dsd_input_level_cu8_moments_reset(&want);
+    if (!got || dsd_input_level_cu8_moments_accumulate(&want, raw, raw_count) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s invalid test input\n", label);
+        return 1;
+    }
+    if (got->count != want.count || got->sum != want.sum || got->sum_sq != want.sum_sq || got->clipped != want.clipped
+        || got->min_sample != want.min_sample || got->max_sample != want.max_sample) {
+        DSD_FPRINTF(stderr, "FAIL: %s got={%llu,%llu,%llu,%llu,%u,%u} want={%llu,%llu,%llu,%llu,%u,%u}\n", label,
+                    (unsigned long long)got->count, (unsigned long long)got->sum, (unsigned long long)got->sum_sq,
+                    (unsigned long long)got->clipped, (unsigned int)got->min_sample, (unsigned int)got->max_sample,
+                    (unsigned long long)want.count, (unsigned long long)want.sum, (unsigned long long)want.sum_sq,
+                    (unsigned long long)want.clipped, (unsigned int)want.min_sample, (unsigned int)want.max_sample);
         return 1;
     }
     return 0;
@@ -860,6 +881,33 @@ main(void) {
     failed |= expect_int_eq("u8 stale-generation advances phase over aligned remainder", u8_phase, 1);
     failed |= expect_int_eq("u8 stale-generation clears device carry", stale_dev_carry_valid, 0);
     failed |= expect_int_eq("u8 stale-generation clears local carry", stale_local_carry_valid, 0);
+
+    dsd_input_level_cu8_moments path_moments[9] = {};
+    rc = rtl_device_test_u8_moment_accounting(path_moments, sizeof(path_moments) / sizeof(path_moments[0]));
+    failed |= expect_int_eq("u8 moment accounting helper rc", rc, 0);
+    const uint8_t common_raw[] = {0U, 1U, 2U, 128U, 254U, 255U};
+    const uint8_t odd_first_raw[] = {3U};
+    const uint8_t odd_second_raw[] = {4U, 5U};
+    const uint8_t tcp_raw[] = {0U, 255U, 1U, 2U, 3U, 4U, 254U, 253U, 128U};
+    const uint8_t replay_raw[] = {0U, 1U, 254U, 255U};
+    if (rc == 0) {
+        failed |= expect_cu8_moments("u8 contiguous ring moments", &path_moments[0], common_raw, sizeof(common_raw));
+        failed |= expect_cu8_moments("u8 wrapped ring moments", &path_moments[1], common_raw, sizeof(common_raw));
+        failed |=
+            expect_cu8_moments("u8 odd first-block moments", &path_moments[2], odd_first_raw, sizeof(odd_first_raw));
+        failed |= expect_cu8_moments("u8 odd second-block excludes old carry", &path_moments[3], odd_second_raw,
+                                     sizeof(odd_second_raw));
+        failed |=
+            expect_cu8_moments("u8 full-ring dropped tail moments", &path_moments[4], common_raw, sizeof(common_raw));
+        failed |= expect_cu8_moments("u8 stale-generation skipped tail moments", &path_moments[5], common_raw,
+                                     sizeof(common_raw));
+        failed |=
+            expect_cu8_moments("rtl-tcp pending/direct/remainder moments", &path_moments[6], tcp_raw, sizeof(tcp_raw));
+        failed |= expect_cu8_moments("modern replay excludes old carry and includes tail", &path_moments[7], replay_raw,
+                                     sizeof(replay_raw));
+        failed |= expect_cu8_moments("legacy replay uses raw pre-rotation bytes", &path_moments[8], replay_raw,
+                                     sizeof(replay_raw));
+    }
 
     /*
      * Miscellaneous RTL helper contracts are pure formatting/alignment rules:


### PR DESCRIPTION
## Summary

- Replace per-byte floating-point CU8 level scans with exact integer moments and defer normalization until snapshot finalization.
- Fuse moment collection into scalar, SSE2, AVX2, and NEON widening/rotation, plus RTL USB, RTL-TCP, and CU8 replay ingest paths.
- Preserve post-mute, pre-transform snapshot boundaries across odd carries, pending reassembly, wrapped rings, and dropped data.
- Add focused API, SIMD, ingest-seam, replay, benchmark, and documentation coverage.

## Why

CU8 level metrics previously reread each source block in a separate floating-point pass. That duplicated memory traffic and conversion work already performed while widening, rotating, or copying input. Collecting exact raw moments during those existing passes reduces ingest cost without changing snapshot meaning, clipping thresholds, classification, demodulation, or non-CU8 behavior.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: network/radio input.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] All changed code has been read, understood, and adapted to DSD-neo conventions.
- [x] The non-trivial commit includes a DCO sign-off.

## Quality Review

- [x] Network/radio input changes include focused tests.
- [x] Runtime and IO changes received extra scrutiny.
- [x] No new static-analysis suppressions were added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` — 460/460 passed
- [ ] `tools/preflight_ci.sh` — broader quality preflight was run instead
- [x] `tools/quality_preflight.sh`
- [x] `tools/cmake_format_check.sh`
- [x] Full ASan/UBSan CTest suite — 460/460 passed
- [x] Focused CTests: `CORE_INPUT_LEVEL`, `IO_INPUT_LEVEL_METRICS`, `DSP_SIMD_WIDEN`, `IO_RTL_RETUNE_PREPARE`, `IO_RTL_REPLAY_EOF_AND_CF32`, and `IO_RTL_PERF`
- [x] Workflow, dependency, and release-specific guardrails are not applicable; those inputs were not changed.

Five-repeat benchmark medians:

- 16 KiB metrics plus ingest: 16,325 ns separate versus 3,268 ns fused, approximately 80% faster.
- 256 KiB metrics plus ingest: 258,298 ns separate versus 54,238 ns fused, approximately 79% faster.
- Separate and fused checksums matched at both sizes.

A 30-second live RTL run processed 89,341,952 CU8 bytes across 5,453 ingest blocks with zero input drops and zero ingest drops. The optimized `perf-profile` build also completed. Hardware-counter sampling was not collected because the host did not have the `perf` executable installed.

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: none expected; thresholds and displayed metric semantics are unchanged.
- Compatibility or packaging impact: the existing CU8 metrics API remains source-compatible, with additive public moment APIs. No packaging changes.
