### PR TITLE
p25: compact list-Viterbi survivors

### DIFF
--- a/docs/dsp-benchmarking.md
+++ b/docs/dsp-benchmarking.md
@@ -1,7 +1,8 @@
-# DSP and RTL Benchmarking
+# DSP, RTL, and Protocol Benchmarking
 
-DSD-neo keeps DSP and RTL performance probes opt-in. They are meant to measure
-proposed architecture changes before changing production behavior.
+DSD-neo keeps DSP, RTL, and targeted protocol performance probes opt-in. They
+are meant to measure proposed architecture changes before changing production
+behavior.
 
 ## Build
 
@@ -18,6 +19,12 @@ For RTL ingest and live-pipeline support cases, build the RTL benchmark too:
 cmake --build --preset perf-bench --target dsd-neo_bench_rtl -j
 ```
 
+For the P25 Phase 1 1/2-rate list decoder, build the protocol benchmark:
+
+```sh
+cmake --build --preset perf-bench --target dsd-neo_bench_p25_12 -j
+```
+
 The preset uses `RelWithDebInfo`, fast math, frame pointers, and tests enabled.
 It keeps LTO and native CPU tuning off so results are easier to compare across
 machines.
@@ -29,6 +36,7 @@ Run all synthetic benchmark cases:
 ```sh
 build/perf-bench/tests/dsd-neo_bench_dsp --iters 3000 --repeat 5
 build/perf-bench/tests/dsd-neo_bench_rtl --iters 3000 --repeat 5
+build/perf-bench/tests/dsd-neo_bench_p25_12 --iters 3000 --repeat 5
 ```
 
 Run one case and emit CSV:
@@ -38,6 +46,8 @@ build/perf-bench/tests/dsd-neo_bench_dsp \
   --case full_demod_cqpsk_p25p1 --iters 3000 --repeat 5 --format csv
 build/perf-bench/tests/dsd-neo_bench_rtl \
   --case rtl_ingest_u8_combined_wrap --iters 3000 --repeat 5 --format csv
+build/perf-bench/tests/dsd-neo_bench_p25_12 \
+  --case p25_12_list_marginal --iters 3000 --repeat 5 --format csv
 ```
 
 List available cases:
@@ -45,6 +55,7 @@ List available cases:
 ```sh
 build/perf-bench/tests/dsd-neo_bench_dsp --list
 build/perf-bench/tests/dsd-neo_bench_rtl --list
+build/perf-bench/tests/dsd-neo_bench_p25_12 --list
 ```
 
 Useful options:
@@ -76,6 +87,10 @@ The RTL benchmark target includes:
 - Post-demod spectrum snapshot updates used by the UI/metrics path.
 - 512-sample direct-output batch reads.
 
+The P25 list-decoder benchmark includes clean high-confidence, marginal/noisy,
+and equal-metric tie-heavy inputs. It reports each complete 49-symbol decode as
+one call and uses the same CSV timing columns as the DSP and RTL benchmarks.
+
 Channel LPF CSV rows include `rate_hz`, `profile`, `tap_count`, and `variant`
 metadata so tap-count and profile changes can be compared directly.
 
@@ -86,11 +101,14 @@ Keep benchmark CSV files outside the repository, for example under `/tmp`:
 ```sh
 build/perf-bench/tests/dsd-neo_bench_dsp --iters 3000 --repeat 5 --format csv > /tmp/dsd-main.csv
 build/perf-bench/tests/dsd-neo_bench_rtl --iters 3000 --repeat 5 --format csv > /tmp/dsd-rtl-main.csv
+build/perf-bench/tests/dsd-neo_bench_p25_12 --iters 3000 --repeat 5 --format csv > /tmp/dsd-p25-main.csv
 # switch branch or apply a patch
 build/perf-bench/tests/dsd-neo_bench_dsp --iters 3000 --repeat 5 --format csv > /tmp/dsd-candidate.csv
 build/perf-bench/tests/dsd-neo_bench_rtl --iters 3000 --repeat 5 --format csv > /tmp/dsd-rtl-candidate.csv
+build/perf-bench/tests/dsd-neo_bench_p25_12 --iters 3000 --repeat 5 --format csv > /tmp/dsd-p25-candidate.csv
 python3 tools/dsp_bench_compare.py /tmp/dsd-main.csv /tmp/dsd-candidate.csv
 python3 tools/dsp_bench_compare.py /tmp/dsd-rtl-main.csv /tmp/dsd-rtl-candidate.csv
+python3 tools/dsp_bench_compare.py /tmp/dsd-p25-main.csv /tmp/dsd-p25-candidate.csv --metric median_ns_per_call
 ```
 
 Focused comparisons are usually more useful than all-case runs:

--- a/src/protocol/p25/p25_12.c
+++ b/src/protocol/p25/p25_12.c
@@ -26,17 +26,14 @@ p25_llr_bit_cost(int16_t llr, int expected_bit) {
     return (llr > 0) ? (uint32_t)llr : 0U;
 }
 
-typedef struct {
-    uint8_t valid;
-    uint32_t metric;
-    uint8_t states[49];
-} p25_12_path_t;
+enum { P25_12_N_SYMS = 49, P25_12_N_ST = 4 };
 
 static void
-p25_12_insert_path(p25_12_path_t paths[P25_12_MAX_CANDIDATES], const p25_12_path_t* candidate) {
+p25_12_insert_survivor(uint32_t metrics[P25_12_MAX_CANDIDATES], uint8_t backptrs[P25_12_MAX_CANDIDATES],
+                       uint32_t candidate_metric, uint8_t candidate_backptr) {
     int insert_at = -1;
     for (int i = 0; i < P25_12_MAX_CANDIDATES; i++) {
-        if (!paths[i].valid || candidate->metric < paths[i].metric) {
+        if (candidate_metric < metrics[i]) {
             insert_at = i;
             break;
         }
@@ -45,13 +42,24 @@ p25_12_insert_path(p25_12_path_t paths[P25_12_MAX_CANDIDATES], const p25_12_path
         return;
     }
     for (int i = P25_12_MAX_CANDIDATES - 1; i > insert_at; i--) {
-        paths[i] = paths[i - 1];
+        metrics[i] = metrics[i - 1];
+        backptrs[i] = backptrs[i - 1];
     }
-    paths[insert_at] = *candidate;
+    metrics[insert_at] = candidate_metric;
+    backptrs[insert_at] = candidate_backptr;
 }
 
 static void
-p25_12_pack_path_bytes(const uint8_t states[49], uint8_t out[12]) {
+p25_12_reset_metrics(uint32_t metrics[P25_12_N_ST][P25_12_MAX_CANDIDATES]) {
+    for (int state = 0; state < P25_12_N_ST; state++) {
+        for (int rank = 0; rank < P25_12_MAX_CANDIDATES; rank++) {
+            metrics[state][rank] = UINT32_MAX;
+        }
+    }
+}
+
+static void
+p25_12_pack_path_bytes(const uint8_t states[P25_12_N_SYMS], uint8_t out[12]) {
     for (int i = 0; i < 12; i++) {
         out[i] = (uint8_t)((states[(i * 4) + 0] << 6) | (states[(i * 4) + 1] << 4) | (states[(i * 4) + 2] << 2)
                            | states[(i * 4) + 3]);
@@ -101,28 +109,41 @@ p25_12_symbol_cost(const int16_t* llr_dei, int base, uint8_t expect) {
 }
 
 static void
-p25_12_expand_paths_for_symbol(p25_12_path_t curr[P25_12_MAX_CANDIDATES], p25_12_path_t prev[P25_12_MAX_CANDIDATES],
-                               const int16_t* llr_dei, int sym_idx, int st_prev, int st_next) {
+p25_12_expand_survivors_for_symbol(uint32_t curr_metric[P25_12_MAX_CANDIDATES],
+                                   uint8_t curr_backptr[P25_12_MAX_CANDIDATES],
+                                   const uint32_t prev_metric[P25_12_MAX_CANDIDATES], const int16_t* llr_dei,
+                                   int sym_idx, int st_prev, int st_next) {
     int base = sym_idx * 4;
     uint8_t expect = p25_dtm[(st_prev << 2) | st_next] & 0xF;
     uint32_t cost = p25_12_symbol_cost(llr_dei, base, expect);
 
     for (int rank = 0; rank < P25_12_MAX_CANDIDATES; rank++) {
-        if (!prev[rank].valid) {
+        if (prev_metric[rank] == UINT32_MAX) {
             continue;
         }
-        p25_12_path_t candidate = prev[rank];
-        candidate.metric += cost;
-        candidate.states[sym_idx] = (uint8_t)st_next;
-        p25_12_insert_path(curr, &candidate);
+        uint32_t candidate_metric = prev_metric[rank] + cost;
+        uint8_t candidate_backptr = (uint8_t)((st_prev << 3) | rank);
+        p25_12_insert_survivor(curr_metric, curr_backptr, candidate_metric, candidate_backptr);
+    }
+}
+
+static void
+p25_12_traceback(const uint8_t* backptr, int final_state, int final_rank, uint8_t states[P25_12_N_SYMS]) {
+    int state = final_state;
+    int rank = final_rank;
+    for (int sym_idx = P25_12_N_SYMS; sym_idx > 0;) {
+        sym_idx--;
+        states[sym_idx] = (uint8_t)state;
+        size_t backptr_index = (((size_t)sym_idx * P25_12_N_ST + (size_t)state) * P25_12_MAX_CANDIDATES) + (size_t)rank;
+        uint8_t predecessor = backptr[backptr_index];
+        state = (predecessor >> 3) & 0x3;
+        rank = predecessor & 0x7;
     }
 }
 
 int
 p25_12_soft_llr_list(const uint8_t* input, const int16_t* bit_llr196, p25_12_candidate_t* candidates,
                      int max_candidates) {
-    enum { N_SYMS = 49, N_ST = 4 };
-
     (void)input;
     if (bit_llr196 == NULL || candidates == NULL || max_candidates <= 0) {
         return 0;
@@ -139,33 +160,42 @@ p25_12_soft_llr_list(const uint8_t* input, const int16_t* bit_llr196, p25_12_can
         llr_dei[(p * 2) + 1] = bit_llr196[(i * 2) + 1];
     }
 
-    p25_12_path_t prev[N_ST][P25_12_MAX_CANDIDATES];
-    p25_12_path_t curr[N_ST][P25_12_MAX_CANDIDATES];
-    DSD_MEMSET(prev, 0, sizeof(prev));
-    for (int st = 0; st < N_ST; st++) {
-        prev[st][0].valid = 1;
-        prev[st][0].metric = (st == 0) ? 0U : 256U;
+    uint32_t metric_a[P25_12_N_ST][P25_12_MAX_CANDIDATES];
+    uint32_t metric_b[P25_12_N_ST][P25_12_MAX_CANDIDATES];
+    p25_12_reset_metrics(metric_a);
+    p25_12_reset_metrics(metric_b);
+    uint32_t (*prev_metric)[P25_12_MAX_CANDIDATES] = metric_a;
+    uint32_t (*curr_metric)[P25_12_MAX_CANDIDATES] = metric_b;
+    uint8_t backptr[P25_12_N_SYMS][P25_12_N_ST][P25_12_MAX_CANDIDATES];
+    DSD_MEMSET(backptr, 0, sizeof(backptr));
+    for (int st = 0; st < P25_12_N_ST; st++) {
+        prev_metric[st][0] = (st == 0) ? 0U : 256U;
     }
 
-    for (int i = 0; i < N_SYMS; i++) {
-        DSD_MEMSET(curr, 0, sizeof(curr));
-        for (int st_prev = 0; st_prev < N_ST; st_prev++) {
-            for (int st_next = 0; st_next < N_ST; st_next++) {
-                p25_12_expand_paths_for_symbol(curr[st_next], prev[st_prev], llr_dei, i, st_prev, st_next);
+    for (int i = 0; i < P25_12_N_SYMS; i++) {
+        p25_12_reset_metrics(curr_metric);
+        for (int st_prev = 0; st_prev < P25_12_N_ST; st_prev++) {
+            for (int st_next = 0; st_next < P25_12_N_ST; st_next++) {
+                p25_12_expand_survivors_for_symbol(curr_metric[st_next], backptr[i][st_next], prev_metric[st_prev],
+                                                   llr_dei, i, st_prev, st_next);
             }
         }
-        DSD_MEMCPY(prev, curr, sizeof(prev));
+        uint32_t (*swap_metric)[P25_12_MAX_CANDIDATES] = prev_metric;
+        prev_metric = curr_metric;
+        curr_metric = swap_metric;
     }
 
     int out_count = 0;
-    for (int st = 0; st < N_ST; st++) {
+    for (int st = 0; st < P25_12_N_ST; st++) {
         for (int rank = 0; rank < P25_12_MAX_CANDIDATES; rank++) {
-            if (!prev[st][rank].valid) {
+            if (prev_metric[st][rank] == UINT32_MAX) {
                 continue;
             }
+            uint8_t states[P25_12_N_SYMS];
             uint8_t bytes[12];
-            p25_12_pack_path_bytes(prev[st][rank].states, bytes);
-            p25_12_insert_candidate(candidates, &out_count, max_candidates, bytes, prev[st][rank].metric);
+            p25_12_traceback(&backptr[0][0][0], st, rank, states);
+            p25_12_pack_path_bytes(states, bytes);
+            p25_12_insert_candidate(candidates, &out_count, max_candidates, bytes, prev_metric[st][rank]);
         }
     }
     return out_count;

--- a/src/protocol/p25/p25_12.c
+++ b/src/protocol/p25/p25_12.c
@@ -128,14 +128,14 @@ p25_12_expand_survivors_for_symbol(uint32_t curr_metric[P25_12_MAX_CANDIDATES],
 }
 
 static void
-p25_12_traceback(const uint8_t* backptr, int final_state, int final_rank, uint8_t states[P25_12_N_SYMS]) {
+p25_12_traceback(uint8_t backptr[P25_12_N_SYMS][P25_12_N_ST][P25_12_MAX_CANDIDATES], int final_state, int final_rank,
+                 uint8_t states[P25_12_N_SYMS]) {
     int state = final_state;
     int rank = final_rank;
     for (int sym_idx = P25_12_N_SYMS; sym_idx > 0;) {
         sym_idx--;
         states[sym_idx] = (uint8_t)state;
-        size_t backptr_index = (((size_t)sym_idx * P25_12_N_ST + (size_t)state) * P25_12_MAX_CANDIDATES) + (size_t)rank;
-        uint8_t predecessor = backptr[backptr_index];
+        uint8_t predecessor = backptr[sym_idx][state][rank];
         state = (predecessor >> 3) & 0x3;
         rank = predecessor & 0x7;
     }
@@ -193,7 +193,7 @@ p25_12_soft_llr_list(const uint8_t* input, const int16_t* bit_llr196, p25_12_can
             }
             uint8_t states[P25_12_N_SYMS];
             uint8_t bytes[12];
-            p25_12_traceback(&backptr[0][0][0], st, rank, states);
+            p25_12_traceback(backptr, st, rank, states);
             p25_12_pack_path_bytes(states, bytes);
             p25_12_insert_candidate(candidates, &out_count, max_candidates, bytes, prev_metric[st][rank]);
         }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3336,6 +3336,17 @@ target_include_directories(
 target_link_libraries(dsd-neo_test_p25_12_list PRIVATE dsd-neo_proto_p25)
 add_test(NAME P25_12_LIST COMMAND dsd-neo_test_p25_12_list)
 
+add_executable(
+    dsd-neo_bench_p25_12
+    EXCLUDE_FROM_ALL
+    protocol/p25/bench_p25_12.cpp
+)
+target_include_directories(
+    dsd-neo_bench_p25_12
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(dsd-neo_bench_p25_12 PRIVATE dsd-neo_proto_p25)
+
 add_executable(dsd-neo_test_p25_mbf34 protocol/p25/test_p25_mbf34.c)
 target_include_directories(
     dsd-neo_test_p25_mbf34

--- a/tests/protocol/p25/bench_p25_12.cpp
+++ b/tests/protocol/p25/bench_p25_12.cpp
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Opt-in microbenchmark for the P25 Phase 1 1/2-rate list decoder.
+ */
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <dsd-neo/protocol/p25/p25_12.h>
+#include <stdint.h>
+#include <vector>
+#include "dsd-neo/core/safe_api.h"
+
+namespace {
+
+volatile double g_bench_sink = 0.0;
+
+enum class OutputFormat : uint8_t { Text, Csv };
+
+struct BenchOptions {
+    int iterations = 2000;
+    int warmup = 8;
+    int repeat = 1;
+    const char* case_filter = NULL;
+    OutputFormat format = OutputFormat::Text;
+    int list_cases = 0;
+};
+
+struct BenchStats {
+    double min_ns_per_call = 0.0;
+    double mean_ns_per_call = 0.0;
+    double median_ns_per_call = 0.0;
+    double median_ns_per_item = 0.0;
+    double items_per_second = 0.0;
+    double checksum = 0.0;
+};
+
+static const uint8_t k_reference_dibits[98] = {
+    0U, 1U, 2U, 1U, 0U, 2U, 3U, 1U, 3U, 0U, 2U, 2U, 0U, 2U, 0U, 0U, 0U, 3U, 1U, 1U, 3U, 3U, 0U, 0U, 1U,
+    1U, 1U, 3U, 0U, 1U, 3U, 0U, 2U, 1U, 0U, 3U, 2U, 2U, 3U, 3U, 0U, 0U, 1U, 1U, 0U, 2U, 2U, 0U, 3U, 1U,
+    0U, 0U, 1U, 0U, 3U, 2U, 3U, 0U, 2U, 0U, 2U, 1U, 1U, 2U, 0U, 0U, 0U, 2U, 0U, 1U, 1U, 1U, 2U, 2U, 3U,
+    1U, 1U, 1U, 3U, 0U, 3U, 2U, 1U, 2U, 0U, 2U, 1U, 3U, 0U, 0U, 3U, 3U, 2U, 1U, 3U, 0U, 1U, 0U,
+};
+
+static void
+print_usage(const char* argv0) {
+    std::printf("Usage: %s [--iters N] [--warmup N] [--repeat N] [--case NAME] [--format text|csv] [--list]\n", argv0);
+}
+
+static int
+parse_positive_int(const char* value, int fallback) {
+    if (value == NULL) {
+        return fallback;
+    }
+    char* end = NULL;
+    long parsed = std::strtol(value, &end, 10);
+    if (end == value || *end != '\0' || parsed <= 0 || parsed > INT32_MAX) {
+        return fallback;
+    }
+    return (int)parsed;
+}
+
+static int
+parse_non_negative_int(const char* value, int fallback) {
+    if (value == NULL) {
+        return fallback;
+    }
+    char* end = NULL;
+    long parsed = std::strtol(value, &end, 10);
+    if (end == value || *end != '\0' || parsed < 0 || parsed > INT32_MAX) {
+        return fallback;
+    }
+    return (int)parsed;
+}
+
+static BenchOptions
+parse_options(int argc, char** argv) {
+    BenchOptions opts;
+    for (int i = 1; i < argc; i++) {
+        if (std::strcmp(argv[i], "--iters") == 0 && i + 1 < argc) {
+            opts.iterations = parse_positive_int(argv[++i], opts.iterations);
+        } else if (std::strcmp(argv[i], "--warmup") == 0 && i + 1 < argc) {
+            opts.warmup = parse_non_negative_int(argv[++i], opts.warmup);
+        } else if (std::strcmp(argv[i], "--repeat") == 0 && i + 1 < argc) {
+            opts.repeat = parse_positive_int(argv[++i], opts.repeat);
+        } else if (std::strcmp(argv[i], "--case") == 0 && i + 1 < argc) {
+            opts.case_filter = argv[++i];
+            if (std::strcmp(opts.case_filter, "all") == 0) {
+                opts.case_filter = NULL;
+            }
+        } else if (std::strcmp(argv[i], "--format") == 0 && i + 1 < argc) {
+            const char* format = argv[++i];
+            opts.format = (std::strcmp(format, "csv") == 0) ? OutputFormat::Csv : OutputFormat::Text;
+        } else if (std::strcmp(argv[i], "--list") == 0) {
+            opts.list_cases = 1;
+        } else if (std::strcmp(argv[i], "--help") == 0 || std::strcmp(argv[i], "-h") == 0) {
+            print_usage(argv[0]);
+            std::exit(0);
+        }
+    }
+    return opts;
+}
+
+static double
+median_of(std::vector<double> values) {
+    if (values.empty()) {
+        return 0.0;
+    }
+    std::sort(values.begin(), values.end());
+    size_t middle = values.size() / 2U;
+    if ((values.size() & 1U) != 0U) {
+        return values[middle];
+    }
+    return 0.5 * (values[middle - 1U] + values[middle]);
+}
+
+static void
+make_clean_llr(int16_t bit_llr[196]) {
+    for (int i = 0; i < 98; i++) {
+        bit_llr[(i * 2) + 0] = ((k_reference_dibits[i] >> 1) & 1U) ? 200 : -200;
+        bit_llr[(i * 2) + 1] = (k_reference_dibits[i] & 1U) ? 200 : -200;
+    }
+}
+
+static void
+make_marginal_llr(int16_t bit_llr[196]) {
+    uint32_t seed = 0x8BADF00DU;
+    for (int i = 0; i < 196; i++) {
+        seed = (seed * 1664525U) + 1013904223U;
+        int dibit_index = i / 2;
+        int bit_index = i & 1;
+        int expected =
+            bit_index == 0 ? ((k_reference_dibits[dibit_index] >> 1) & 1U) : (k_reference_dibits[dibit_index] & 1U);
+        int16_t magnitude = (int16_t)(1U + ((seed >> 24) % 96U));
+        if ((i % 13) == 0) {
+            expected ^= 1;
+        }
+        bit_llr[i] = expected ? magnitude : (int16_t)-magnitude;
+    }
+}
+
+static double
+decode_checksum(const int16_t bit_llr[196]) {
+    p25_12_candidate_t candidates[P25_12_MAX_CANDIDATES];
+    int count = p25_12_soft_llr_list(NULL, bit_llr, candidates, P25_12_MAX_CANDIDATES);
+    double checksum = (double)count;
+    for (int candidate = 0; candidate < count; candidate++) {
+        checksum += (double)candidates[candidate].metric;
+        for (int byte_index = 0; byte_index < 12; byte_index++) {
+            checksum += (double)candidates[candidate].bytes[byte_index] * (double)(byte_index + 1);
+        }
+    }
+    return checksum;
+}
+
+static void
+print_result(const BenchOptions& opts, const char* name, const BenchStats& stats) {
+    constexpr double kTrellisSymbols = 49.0;
+    if (opts.format == OutputFormat::Csv) {
+        std::printf("%s,%d,%d,%d,%.0f,trellis_symbol,%.3f,%.3f,%.3f,%.6f,%.3f,%.9e\n", name, opts.repeat,
+                    opts.iterations, opts.warmup, kTrellisSymbols, stats.median_ns_per_call, stats.min_ns_per_call,
+                    stats.mean_ns_per_call, stats.median_ns_per_item, stats.items_per_second, stats.checksum);
+        return;
+    }
+    std::printf("%-28s repeat=%2d median=%9.2f us/call min=%9.2f mean=%9.2f ns/symbol=%9.3f checksum=% .6e\n", name,
+                opts.repeat, stats.median_ns_per_call / 1000.0, stats.min_ns_per_call / 1000.0,
+                stats.mean_ns_per_call / 1000.0, stats.median_ns_per_item, stats.checksum);
+}
+
+static int
+run_case(const BenchOptions& opts, const char* name, const int16_t bit_llr[196]) {
+    if (opts.case_filter != NULL && std::strcmp(opts.case_filter, name) != 0) {
+        return 0;
+    }
+    if (opts.list_cases) {
+        std::printf("%s\n", name);
+        return 1;
+    }
+
+    std::vector<double> ns_per_call;
+    ns_per_call.reserve((size_t)opts.repeat);
+    double checksum = 0.0;
+    for (int repeat = 0; repeat < opts.repeat; repeat++) {
+        for (int i = 0; i < opts.warmup; i++) {
+            checksum += decode_checksum(bit_llr);
+        }
+        auto start = std::chrono::steady_clock::now();
+        for (int i = 0; i < opts.iterations; i++) {
+            checksum += decode_checksum(bit_llr);
+        }
+        auto end = std::chrono::steady_clock::now();
+        double elapsed_ns = (double)std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+        ns_per_call.push_back(elapsed_ns / (double)opts.iterations);
+    }
+
+    BenchStats stats;
+    stats.checksum = checksum;
+    stats.min_ns_per_call = *std::min_element(ns_per_call.begin(), ns_per_call.end());
+    for (double value : ns_per_call) {
+        stats.mean_ns_per_call += value;
+    }
+    stats.mean_ns_per_call /= (double)ns_per_call.size();
+    stats.median_ns_per_call = median_of(ns_per_call);
+    stats.median_ns_per_item = stats.median_ns_per_call / 49.0;
+    stats.items_per_second = 1000000000.0 / stats.median_ns_per_item;
+
+    g_bench_sink += checksum;
+    print_result(opts, name, stats);
+    return 1;
+}
+
+} // namespace
+
+int
+main(int argc, char** argv) {
+    BenchOptions opts = parse_options(argc, argv);
+    int16_t clean_llr[196];
+    int16_t marginal_llr[196];
+    int16_t tie_llr[196];
+    make_clean_llr(clean_llr);
+    make_marginal_llr(marginal_llr);
+    DSD_MEMSET(tie_llr, 0, sizeof(tie_llr));
+
+    if (opts.format == OutputFormat::Text && !opts.list_cases) {
+        std::printf("DSD-neo P25 1/2-rate list-decoder benchmark\n");
+        std::printf("iterations=%d warmup=%d repeat=%d\n\n", opts.iterations, opts.warmup, opts.repeat);
+    } else if (opts.format == OutputFormat::Csv && !opts.list_cases) {
+        std::printf("case,repeat,iterations,warmup,work_items,item_unit,median_ns_per_call,min_ns_per_call,"
+                    "mean_ns_per_call,median_ns_per_item,items_per_second,checksum\n");
+    }
+
+    int ran = 0;
+    ran += run_case(opts, "p25_12_list_clean", clean_llr);
+    ran += run_case(opts, "p25_12_list_marginal", marginal_llr);
+    ran += run_case(opts, "p25_12_list_ties", tie_llr);
+    if (ran == 0) {
+        DSD_FPRINTF(stderr, "No benchmark case matched. Use --list to see available cases.\n");
+        return 2;
+    }
+    return (g_bench_sink == -1.0) ? 1 : 0;
+}

--- a/tests/protocol/p25/test_p25_12_list.c
+++ b/tests/protocol/p25/test_p25_12_list.c
@@ -3,6 +3,7 @@
  * Focused tests for the P25 Phase 1 1/2-rate soft-decision list decoder.
  */
 
+#include <dsd-neo/fec/trellis34.h>
 #include <dsd-neo/protocol/p25/p25_12.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -31,6 +32,226 @@ set_dibit_llr_magnitude(const uint8_t dibits[98], int16_t bit_llr[196], int dibi
     bit_llr[(dibit_index * 2) + 1] = (dibits[dibit_index] & 1) ? magnitude : (int16_t)-magnitude;
 }
 
+enum { P25_12_REF_N_SYMS = 49, P25_12_REF_N_ST = 4 };
+
+static const uint8_t k_p25_12_ref_dtm[16] = {2U, 12U, 1U, 15U, 14U, 0U, 13U, 3U, 9U, 7U, 10U, 4U, 5U, 11U, 6U, 8U};
+
+typedef struct {
+    uint8_t valid;
+    uint32_t metric;
+    uint8_t states[P25_12_REF_N_SYMS];
+} p25_12_ref_path_t;
+
+static uint32_t
+p25_12_ref_llr_bit_cost(int16_t llr, int expected_bit) {
+    if (expected_bit) {
+        return (llr < 0) ? (uint32_t)(-llr) : 0U;
+    }
+    return (llr > 0) ? (uint32_t)llr : 0U;
+}
+
+static void
+p25_12_ref_insert_path(p25_12_ref_path_t paths[P25_12_MAX_CANDIDATES], const p25_12_ref_path_t* candidate) {
+    int insert_at = -1;
+    for (int i = 0; i < P25_12_MAX_CANDIDATES; i++) {
+        if (!paths[i].valid || candidate->metric < paths[i].metric) {
+            insert_at = i;
+            break;
+        }
+    }
+    if (insert_at < 0) {
+        return;
+    }
+    for (int i = P25_12_MAX_CANDIDATES - 1; i > insert_at; i--) {
+        paths[i] = paths[i - 1];
+    }
+    paths[insert_at] = *candidate;
+}
+
+static uint32_t
+p25_12_ref_symbol_cost(const int16_t llr_dei[196], int base, uint8_t expect) {
+    return p25_12_ref_llr_bit_cost(llr_dei[base + 0], (expect >> 3) & 1)
+           + p25_12_ref_llr_bit_cost(llr_dei[base + 1], (expect >> 2) & 1)
+           + p25_12_ref_llr_bit_cost(llr_dei[base + 2], (expect >> 1) & 1)
+           + p25_12_ref_llr_bit_cost(llr_dei[base + 3], expect & 1);
+}
+
+static void
+p25_12_ref_expand_paths(p25_12_ref_path_t curr[P25_12_MAX_CANDIDATES], p25_12_ref_path_t prev[P25_12_MAX_CANDIDATES],
+                        const int16_t llr_dei[196], int sym_idx, int st_prev, int st_next) {
+    int base = sym_idx * 4;
+    uint8_t expect = k_p25_12_ref_dtm[(st_prev << 2) | st_next] & 0xFU;
+    uint32_t cost = p25_12_ref_symbol_cost(llr_dei, base, expect);
+
+    for (int rank = 0; rank < P25_12_MAX_CANDIDATES; rank++) {
+        if (!prev[rank].valid) {
+            continue;
+        }
+        p25_12_ref_path_t candidate = prev[rank];
+        candidate.metric += cost;
+        candidate.states[sym_idx] = (uint8_t)st_next;
+        p25_12_ref_insert_path(curr, &candidate);
+    }
+}
+
+static void
+p25_12_ref_pack_path(const uint8_t states[P25_12_REF_N_SYMS], uint8_t out[12]) {
+    for (int i = 0; i < 12; i++) {
+        out[i] = (uint8_t)((states[(i * 4) + 0] << 6) | (states[(i * 4) + 1] << 4) | (states[(i * 4) + 2] << 2)
+                           | states[(i * 4) + 3]);
+    }
+}
+
+static int
+p25_12_ref_candidate_exists(const p25_12_candidate_t* candidates, int count, const uint8_t bytes[12]) {
+    for (int i = 0; i < count; i++) {
+        if (memcmp(candidates[i].bytes, bytes, 12) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static void
+p25_12_ref_insert_candidate(p25_12_candidate_t* candidates, int* count, int max_candidates, const uint8_t bytes[12],
+                            uint32_t metric) {
+    if (p25_12_ref_candidate_exists(candidates, *count, bytes)) {
+        return;
+    }
+    int insert_at = *count;
+    for (int i = 0; i < *count; i++) {
+        if (metric < candidates[i].metric) {
+            insert_at = i;
+            break;
+        }
+    }
+    if (*count < max_candidates) {
+        (*count)++;
+    } else if (insert_at >= max_candidates) {
+        return;
+    }
+    for (int i = *count - 1; i > insert_at; i--) {
+        candidates[i] = candidates[i - 1];
+    }
+    DSD_MEMCPY(candidates[insert_at].bytes, bytes, 12);
+    candidates[insert_at].metric = metric;
+}
+
+static int
+p25_12_ref_list(const int16_t bit_llr196[196], p25_12_candidate_t* candidates, int max_candidates) {
+    if (bit_llr196 == NULL || candidates == NULL || max_candidates <= 0) {
+        return 0;
+    }
+    if (max_candidates > P25_12_MAX_CANDIDATES) {
+        max_candidates = P25_12_MAX_CANDIDATES;
+    }
+
+    int16_t llr_dei[196];
+    DSD_MEMSET(llr_dei, 0, sizeof(llr_dei));
+    for (int i = 0; i < 98; i++) {
+        int p = dsd_trellis_interleave_98[i];
+        llr_dei[(p * 2) + 0] = bit_llr196[(i * 2) + 0];
+        llr_dei[(p * 2) + 1] = bit_llr196[(i * 2) + 1];
+    }
+
+    p25_12_ref_path_t prev[P25_12_REF_N_ST][P25_12_MAX_CANDIDATES];
+    p25_12_ref_path_t curr[P25_12_REF_N_ST][P25_12_MAX_CANDIDATES];
+    DSD_MEMSET(prev, 0, sizeof(prev));
+    for (int st = 0; st < P25_12_REF_N_ST; st++) {
+        prev[st][0].valid = 1U;
+        prev[st][0].metric = (st == 0) ? 0U : 256U;
+    }
+
+    for (int sym_idx = 0; sym_idx < P25_12_REF_N_SYMS; sym_idx++) {
+        DSD_MEMSET(curr, 0, sizeof(curr));
+        for (int st_prev = 0; st_prev < P25_12_REF_N_ST; st_prev++) {
+            for (int st_next = 0; st_next < P25_12_REF_N_ST; st_next++) {
+                p25_12_ref_expand_paths(curr[st_next], prev[st_prev], llr_dei, sym_idx, st_prev, st_next);
+            }
+        }
+        DSD_MEMCPY(prev, curr, sizeof(prev));
+    }
+
+    int out_count = 0;
+    for (int st = 0; st < P25_12_REF_N_ST; st++) {
+        for (int rank = 0; rank < P25_12_MAX_CANDIDATES; rank++) {
+            if (!prev[st][rank].valid) {
+                continue;
+            }
+            uint8_t bytes[12];
+            p25_12_ref_pack_path(prev[st][rank].states, bytes);
+            p25_12_ref_insert_candidate(candidates, &out_count, max_candidates, bytes, prev[st][rank].metric);
+        }
+    }
+    return out_count;
+}
+
+static int
+p25_12_compare_reference(const char* label, const int16_t bit_llr[196], int max_candidates) {
+    p25_12_candidate_t expected[P25_12_MAX_CANDIDATES];
+    p25_12_candidate_t actual[P25_12_MAX_CANDIDATES];
+    DSD_MEMSET(expected, 0, sizeof(expected));
+    DSD_MEMSET(actual, 0, sizeof(actual));
+
+    int expected_count = p25_12_ref_list(bit_llr, expected, max_candidates);
+    int actual_count = p25_12_soft_llr_list(NULL, bit_llr, actual, max_candidates);
+    if (actual_count != expected_count) {
+        DSD_FPRINTF(stderr, "%s count mismatch max=%d actual=%d expected=%d\n", label, max_candidates, actual_count,
+                    expected_count);
+        return 1;
+    }
+    for (int i = 0; i < actual_count; i++) {
+        if (actual[i].metric != expected[i].metric || memcmp(actual[i].bytes, expected[i].bytes, 12) != 0) {
+            DSD_FPRINTF(stderr, "%s candidate mismatch max=%d index=%d metric=%u/%u\n", label, max_candidates, i,
+                        actual[i].metric, expected[i].metric);
+            return 1;
+        }
+        for (int j = 0; j < i; j++) {
+            if (memcmp(actual[i].bytes, actual[j].bytes, 12) == 0) {
+                DSD_FPRINTF(stderr, "%s duplicate candidate max=%d index=%d/%d\n", label, max_candidates, j, i);
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+static void
+p25_12_fill_seeded_llr(int16_t bit_llr[196], uint32_t seed) {
+    for (int i = 0; i < 196; i++) {
+        seed = (seed * 1664525U) + 1013904223U;
+        int32_t value = (int32_t)((seed >> 16) & 0xFFFFU) - 32768;
+        bit_llr[i] = (int16_t)value;
+    }
+    bit_llr[0] = INT16_MIN;
+    bit_llr[1] = INT16_MAX;
+    bit_llr[2] = 0;
+}
+
+static int
+p25_12_test_exact_equivalence(const int16_t clean_llr[196], const int16_t noisy_llr[196]) {
+    static const int limits[] = {1, 2, 3, 4, 5, 6, 7, P25_12_MAX_CANDIDATES, P25_12_MAX_CANDIDATES + 3};
+    int16_t zero_llr[196];
+    int16_t seeded_llr[196];
+    DSD_MEMSET(zero_llr, 0, sizeof(zero_llr));
+
+    for (size_t i = 0; i < sizeof(limits) / sizeof(limits[0]); i++) {
+        int max_candidates = limits[i];
+        if (p25_12_compare_reference("clean", clean_llr, max_candidates) != 0
+            || p25_12_compare_reference("noisy", noisy_llr, max_candidates) != 0
+            || p25_12_compare_reference("ties", zero_llr, max_candidates) != 0) {
+            return 1;
+        }
+        for (uint32_t seed_idx = 0; seed_idx < 8U; seed_idx++) {
+            p25_12_fill_seeded_llr(seeded_llr, 0xC001D00DU ^ (seed_idx * 0x9E3779B9U));
+            if (p25_12_compare_reference("seeded", seeded_llr, max_candidates) != 0) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
 int
 main(void) {
     const uint8_t payload[12] = {0x96, 0x2C, 0x11, 0x84, 0x7E, 0xA0, 0x39, 0x55, 0xC3, 0x08, 0xF1, 0x6B};
@@ -39,9 +260,15 @@ main(void) {
     dibits_to_llr(k_reference_dibits, bit_llr, 200);
 
     p25_12_candidate_t list[P25_12_MAX_CANDIDATES];
-    if (p25_12_soft_llr_list(k_reference_dibits, NULL, list, P25_12_MAX_CANDIDATES) != 0
+    p25_12_candidate_t guard_list[P25_12_MAX_CANDIDATES];
+    p25_12_candidate_t guard_before[P25_12_MAX_CANDIDATES];
+    DSD_MEMSET(guard_list, 0xA5, sizeof(guard_list));
+    DSD_MEMCPY(guard_before, guard_list, sizeof(guard_before));
+    if (p25_12_soft_llr_list(k_reference_dibits, NULL, guard_list, P25_12_MAX_CANDIDATES) != 0
         || p25_12_soft_llr_list(k_reference_dibits, bit_llr, NULL, P25_12_MAX_CANDIDATES) != 0
-        || p25_12_soft_llr_list(k_reference_dibits, bit_llr, list, 0) != 0) {
+        || p25_12_soft_llr_list(k_reference_dibits, bit_llr, guard_list, 0) != 0
+        || p25_12_soft_llr_list(k_reference_dibits, bit_llr, guard_list, -1) != 0
+        || memcmp(guard_list, guard_before, sizeof(guard_list)) != 0) {
         DSD_FPRINTF(stderr, "P25 1/2 list guard failed\n");
         return 1;
     }
@@ -71,6 +298,8 @@ main(void) {
     noisy_dibits[9] ^= 1U;
     dibits_to_llr(noisy_dibits, bit_llr, 200);
     set_dibit_llr_magnitude(noisy_dibits, bit_llr, 9, 10);
+    int16_t noisy_llr[196];
+    DSD_MEMCPY(noisy_llr, bit_llr, sizeof(noisy_llr));
 
     DSD_MEMSET(list, 0, sizeof(list));
     list_count = p25_12_soft_llr_list(noisy_dibits, bit_llr, list, P25_12_MAX_CANDIDATES);
@@ -91,6 +320,12 @@ main(void) {
     if (memcmp(best, list[0].bytes, sizeof(best)) != 0) {
         DSD_FPRINTF(stderr, "noisy P25 1/2 single/list best mismatch\n");
         return 2;
+    }
+
+    int16_t clean_llr[196];
+    dibits_to_llr(k_reference_dibits, clean_llr, 200);
+    if (p25_12_test_exact_equivalence(clean_llr, noisy_llr) != 0) {
+        return 3;
     }
 
     DSD_FPRINTF(stderr, "P25 1/2-rate LLR list tests OK\n");


### PR DESCRIPTION
## Summary

- Replace full-path copying during P25 Phase 1 1/2-rate list-Viterbi expansion with compact survivor metrics and backpointers.
- Reconstruct candidate paths after the forward pass while preserving metrics, ordering, tie behavior, deduplication, and the existing API.
- Add exact legacy-equivalence regression coverage plus an opt-in protocol benchmark and usage documentation.

## Why

Profiling showed the list decoder repeatedly copying and sorting 60-byte path structures during every trellis step. The forward pass only needs each survivor's metric and predecessor, so retaining the full state history creates avoidable memory traffic and sorting work.

## Impact

The optimized benchmark improved complete list-decode time on the profiling host:

| Case | Before | After | Change |
| --- | ---: | ---: | ---: |
| Clean | 49,957 ns/call | 26,976 ns/call | -46.0% |
| Marginal | 50,616 ns/call | 29,349 ns/call | -42.0% |
| Tie-heavy | 42,427 ns/call | 26,841 ns/call | -36.7% |

Callgrind instructions for the clean decoder call fell from 1,786,874 to 1,324,650, a 25.9% reduction.

## Validation

- `cmake --build --preset dev-debug -j`
- `ctest --test-dir build/dev-debug -R '^P25' --output-on-failure -j4` — 96/96 passed
- `ctest --test-dir build/asan-ubsan-debug -R '^P25_12_LIST$' --output-on-failure`
- `tools/preflight_ci.sh`
- Live RTL run using the supplied receiver command: 47 telemetry samples, zero input drops, zero ingest drops, and clean shutdown
