### PR TITLE
dmr: decode rate-3/4 defined short data

### DIFF
--- a/include/dsd-neo/core/audio.h
+++ b/include/dsd-neo/core/audio.h
@@ -208,6 +208,8 @@ void beeper(dsd_opts* opts, dsd_state* state, int lr, int id, int ad, int len);
 
 /** @brief Open input audio device based on opts. Returns 0 on success. */
 int openAudioInDevice(dsd_opts* opts, dsd_state* state);
+/** @brief Close all input resources owned by the active input device. */
+void closeAudioInDevice(dsd_opts* opts);
 
 /** @brief Parse audio input device string and update opts. */
 void parse_audio_input_string(dsd_opts* opts, char* input);

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -592,6 +592,8 @@ struct dsd_state {
     uint8_t data_header_format[2];  //collect format of data header (conf or unconf) per slot
     uint8_t data_header_sap[2];     //collect sap info per slot
     uint8_t data_p_head[2];         //flag for dmr proprietary header to follow
+    uint8_t data_header_dd_format[2];   //transient per-slot DMR Defined Data format
+    uint8_t data_header_bit_padding[2]; //transient per-slot DMR short-data padding in bits
 
     //new stuff below here
     uint8_t data_conf_data[2];   //flag for confirmed data blocks per slot

--- a/src/core/audio/dsd_audio.c
+++ b/src/core/audio/dsd_audio.c
@@ -27,6 +27,7 @@
 #include <dsd-neo/platform/audio.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/platform/sockets.h>
 #include <dsd-neo/runtime/log.h>
 #include <dsd-neo/runtime/net_audio_input_hooks.h>
 #include <dsd-neo/runtime/udp_audio_hooks.h>
@@ -878,6 +879,10 @@ closeAudioInDevice(dsd_opts* opts) {
 
     closeAudioInput(opts);
     dsd_audio_release_input_sources(opts);
+    if (opts->tcp_sockfd != DSD_INVALID_SOCKET) {
+        dsd_socket_close(opts->tcp_sockfd);
+        opts->tcp_sockfd = DSD_INVALID_SOCKET;
+    }
 }
 
 static void

--- a/src/core/audio/dsd_audio.c
+++ b/src/core/audio/dsd_audio.c
@@ -870,6 +870,16 @@ dsd_audio_release_input_sources(dsd_opts* opts) {
     dsd_opts_reset_pcm_input_state(opts);
 }
 
+void
+closeAudioInDevice(dsd_opts* opts) {
+    if (opts == NULL) {
+        return;
+    }
+
+    closeAudioInput(opts);
+    dsd_audio_release_input_sources(opts);
+}
+
 static void
 dsd_audio_reset_symbol_replay_pacing(dsd_state* state) {
     if (!state) {

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -802,6 +802,10 @@ init_state_protocol_defaults_b(dsd_state* state) {
     state->data_block_counter[1] = 1;
     state->data_p_head[0] = 0;
     state->data_p_head[1] = 0;
+    state->data_header_dd_format[0] = 0;
+    state->data_header_dd_format[1] = 0;
+    state->data_header_bit_padding[0] = 0;
+    state->data_header_bit_padding[1] = 0;
     state->data_block_poc[0] = 0;
     state->data_block_poc[1] = 0;
     state->data_byte_ctr[0] = 0;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1934,6 +1934,10 @@ no_carrier_reset_dmr_data_blocks(dsd_state* state) {
     state->data_block_counter[1] = 1;
     state->data_p_head[0] = 0;
     state->data_p_head[1] = 0;
+    state->data_header_dd_format[0] = 0;
+    state->data_header_dd_format[1] = 0;
+    state->data_header_bit_padding[0] = 0;
+    state->data_header_bit_padding[1] = 0;
     state->data_block_poc[0] = 0;
     state->data_block_poc[1] = 0;
     state->data_byte_ctr[0] = 0;
@@ -2560,7 +2564,7 @@ dsd_engine_cleanup(dsd_opts* opts, dsd_state* state) {
     dsd_engine_cleanup_print_stats(state);
 
     closeAudioOutput(opts);
-    closeAudioInput(opts);
+    closeAudioInDevice(opts);
     dsd_audio_cleanup();
 
     dsd_state_ext_free_all(state);

--- a/src/protocol/dmr/CMakeLists.txt
+++ b/src/protocol/dmr/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(
         dmr_le.c
         dmr_ms.c
         dmr_pdu.c
+        dmr_text.c
         dmr_pi.c
         dmr_utils.c
 )

--- a/src/protocol/dmr/dmr_34_viterbi.c
+++ b/src/protocol/dmr/dmr_34_viterbi.c
@@ -15,6 +15,7 @@
 #include <dsd-neo/fec/trellis34.h>
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/protocol/dmr/r34_viterbi.h>
+#include "dmr_r34_internal.h"
 
 enum { R34_T = 49, R34_S = 8, R34_K = 32 };
 
@@ -132,19 +133,6 @@ static void
 r34_metric_init_2d(int metric[R34_S][R34_K]) {
     r34_metric_reset_2d(metric);
     metric[0][0] = 0;
-}
-
-static void
-r34_select_end_state(const int metric_prev[R34_S], int* best_s) {
-    int best_m = metric_prev[0];
-    int best = 0;
-    for (int s = 1; s < R34_S; s++) {
-        if (metric_prev[s] < best_m) {
-            best_m = metric_prev[s];
-            best = s;
-        }
-    }
-    *best_s = best;
 }
 
 static void
@@ -330,14 +318,12 @@ r34_run_viterbi_list(uint8_t nibs[R34_T], uint8_t rhi[R34_T], uint8_t rlo[R34_T]
 static int
 r34_collect_final_indices(int metric_prev[R34_S][R34_K], r34_cand_idx idx[R34_S * R34_K]) {
     int idx_n = 0;
-    for (int s = 0; s < R34_S; s++) {
-        for (int r = 0; r < R34_K; r++) {
-            if (metric_prev[s][r] < R34_INF) {
-                idx[idx_n].metric = metric_prev[s][r];
-                idx[idx_n].state = (uint8_t)s;
-                idx[idx_n].rank = (uint8_t)r;
-                idx_n++;
-            }
+    for (int r = 0; r < R34_K; r++) {
+        if (metric_prev[0][r] < R34_INF) {
+            idx[idx_n].metric = metric_prev[0][r];
+            idx[idx_n].state = 0;
+            idx[idx_n].rank = (uint8_t)r;
+            idx_n++;
         }
     }
     return idx_n;
@@ -386,15 +372,12 @@ dmr_r34_viterbi_decode(const uint8_t* dibits98, uint8_t out_bytes18[18]) {
     int metric_prev[R34_S];
     uint8_t backptr[R34_T][R34_S];
     uint8_t states[R34_T];
-    int best_s = 0;
 
     r34_prepare_nibbles(dibits98, nibs);
     r34_map_nibbles_to_points(nibs, obs_point);
     r34_run_viterbi_hard(obs_point, metric_prev, backptr);
 
-    r34_select_end_state(metric_prev, &best_s);
-
-    r34_traceback_states(backptr, best_s, states);
+    r34_traceback_states(backptr, 0, states);
     r34_pack_states_to_bytes(states, out_bytes18);
 
     return 0;
@@ -413,16 +396,50 @@ dmr_r34_viterbi_decode_soft(const uint8_t* dibits98, const uint8_t* reliab98, ui
     int metric_prev[R34_S];
     uint8_t backptr[R34_T][R34_S];
     uint8_t states[R34_T];
-    int best_s = 0;
 
     r34_prepare_nibbles(dibits98, nibs);
     r34_prepare_reliability_weights(reliab98, rhi, rlo, 1);
     r34_run_viterbi_soft(nibs, rhi, rlo, metric_prev, backptr);
 
-    r34_select_end_state(metric_prev, &best_s);
-
-    r34_traceback_states(backptr, best_s, states);
+    r34_traceback_states(backptr, 0, states);
     r34_pack_states_to_bytes(states, out_bytes18);
+    return 0;
+}
+
+int
+dmr_r34_candidate_metric(const uint8_t* dibits98, const uint8_t* reliab98, const uint8_t bytes18[18], int* out_metric) {
+    if (dibits98 == NULL || bytes18 == NULL || out_metric == NULL) {
+        return -1;
+    }
+
+    uint8_t nibs[R34_T];
+    uint8_t rhi[R34_T];
+    uint8_t rlo[R34_T];
+    uint8_t states[R34_T];
+    int metric = 0;
+
+    r34_prepare_nibbles(dibits98, nibs);
+    r34_prepare_reliability_weights(reliab98, rhi, rlo, reliab98 != NULL);
+
+    for (size_t group = 0; group < 6U; group++) {
+        const size_t byte_index = group * 3U;
+        uint32_t packed = ((uint32_t)bytes18[byte_index] << 16) | ((uint32_t)bytes18[byte_index + 1U] << 8)
+                          | (uint32_t)bytes18[byte_index + 2U];
+        for (size_t item = 0; item < 8U; item++) {
+            states[group * 8U + item] = (uint8_t)((packed >> (21U - (item * 3U))) & 0x7U);
+        }
+    }
+    states[48] = 0;
+
+    for (int t = 0; t < R34_T; t++) {
+        uint8_t previous = (t == 0) ? 0 : states[t - 1];
+        uint8_t next = states[t];
+        uint8_t point = dsd_trellis34_fsm[(previous * R34_S) + next];
+        uint8_t expected_nibble = dsd_trellis34_inverse_constellation[point];
+        metric += r34_weighted_nibble_cost(expected_nibble, nibs[t], rhi[t], rlo[t]);
+    }
+
+    *out_metric = metric;
     return 0;
 }
 

--- a/src/protocol/dmr/dmr_block.c
+++ b/src/protocol/dmr/dmr_block.c
@@ -563,6 +563,7 @@ void
 dmr_dheader(dsd_opts* opts, dsd_state* state, uint8_t dheader[], uint8_t dheader_bits[], uint32_t CRCCorrect,
             uint32_t IrrecoverableErrors) {
     uint8_t slot = state->currentslot;
+    uint8_t inherited_poc = state->data_block_poc[slot];
     dmr_dheader_fields f;
     DSD_MEMSET(&f, 0, sizeof(f));
     dmr_clear_superframe_slot(state, slot);
@@ -590,6 +591,8 @@ dmr_dheader(dsd_opts* opts, dsd_state* state, uint8_t dheader[], uint8_t dheader
     }
     if (f.dpf == 2 || f.dpf == 3) {
         state->data_block_poc[slot] = f.poc;
+    } else if (f.dpf == 15) {
+        state->data_block_poc[slot] = inherited_poc;
     }
 
     state->data_header_format[slot] = f.dpf;

--- a/src/protocol/dmr/dmr_block.c
+++ b/src/protocol/dmr/dmr_block.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "dmr_block_crypto.h"
+#include "dmr_pdu_internal.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -192,7 +193,7 @@ dmr_dheader_parse_fields(const dsd_state* state, const uint8_t dheader_bits[], d
     f->r_class = (uint8_t)convert_bits_into_output(&dheader_bits[72], 2);
     f->r_type = (uint8_t)convert_bits_into_output(&dheader_bits[74], 3);
     f->r_status = (uint8_t)convert_bits_into_output(&dheader_bits[77], 3);
-    f->s_ab_fin = (uint8_t)((s_ab_msb << 2) | s_ab_lsb);
+    f->s_ab_fin = (uint8_t)((s_ab_msb << 4) | s_ab_lsb);
     f->s_source_port = (uint8_t)convert_bits_into_output(&dheader_bits[64], 3);
     f->s_dest_port = (uint8_t)convert_bits_into_output(&dheader_bits[67], 3);
     f->s_status_precoded = (uint8_t)convert_bits_into_output(&dheader_bits[70], 10);
@@ -354,6 +355,8 @@ dmr_dheader_handle_short_data(dsd_state* state, uint8_t slot, const dmr_dheader_
         state->data_header_blocks[slot] = f->s_ab_fin;
     }
     if (f->dpf == 13) {
+        state->data_header_dd_format[slot] = f->dd_format;
+        state->data_header_bit_padding[slot] = f->sd_bp;
         DSD_FPRINTF(stderr, "\n  SD:D [DD_HEAD] - SAP %02d [%s] - BLOCKS %02d - DD %02X - PADb %d - FMT %02X [%s]",
                     f->sap, f->sap_string, f->s_ab_fin, f->dd_format, f->sd_bp, f->dd_format, f->sddd_string);
     }
@@ -362,6 +365,7 @@ dmr_dheader_handle_short_data(dsd_state* state, uint8_t slot, const dmr_dheader_
             DSD_FPRINTF(stderr, "\n  SD:S/P [SP_HEAD] - SAP %02d [%s] - SP %02d - DP %02d - S/P %02X", f->sap,
                         f->sap_string, f->s_source_port, f->s_dest_port, f->s_status_precoded);
         } else {
+            state->data_header_bit_padding[slot] = f->sd_bp;
             DSD_FPRINTF(stderr,
                         "\n  SD:RAW [R_HEAD] - SAP %02d [%s] - BLOCKS %02d - SP %02d - DP %02d - SARQ %d - FMF %d - "
                         "PDb %d",
@@ -531,6 +535,8 @@ dmr_dheader_reset_irrecoverable(dsd_state* state, uint8_t slot) {
     state->data_block_counter[slot] = 1;
     state->data_header_blocks[slot] = 1;
     state->data_header_format[slot] = 7;
+    state->data_header_dd_format[slot] = 0;
+    state->data_header_bit_padding[slot] = 0;
 }
 
 static void
@@ -561,6 +567,9 @@ dmr_dheader(dsd_opts* opts, dsd_state* state, uint8_t dheader[], uint8_t dheader
     DSD_MEMSET(&f, 0, sizeof(f));
     dmr_clear_superframe_slot(state, slot);
     state->data_block_counter[slot] = 1;
+    state->data_header_dd_format[slot] = 0;
+    state->data_header_bit_padding[slot] = 0;
+    state->data_block_poc[slot] = 0;
     if (IrrecoverableErrors != 0) {
         dmr_dheader_reset_irrecoverable(state, slot);
         DSD_FPRINTF(stderr, "%s", KNRM);
@@ -578,6 +587,8 @@ dmr_dheader(dsd_opts* opts, dsd_state* state, uint8_t dheader[], uint8_t dheader
     if (f.dpf != 15) {
         state->dmr_lrrp_source[slot] = f.source;
         state->dmr_lrrp_target[slot] = f.target;
+    }
+    if (f.dpf == 2 || f.dpf == 3) {
         state->data_block_poc[slot] = f.poc;
     }
 
@@ -1266,7 +1277,8 @@ dmr_block_type1_handle_sap(dmr_block_assembler_ctx* ctx, int offset) {
     if (sap == 4) {
         decode_ip_pdu(ctx->opts, ctx->state, len, ctx->state->dmr_pdu_sf[ctx->slot]);
     } else if (sap == 10) {
-        dmr_sd_pdu(ctx->opts, ctx->state, len, ctx->state->dmr_pdu_sf[ctx->slot]);
+        dmr_sd_pdu_process(ctx->opts, ctx->state, len, ctx->state->dmr_pdu_sf[ctx->slot],
+                           (uint8_t)(ctx->crc_correct != 0U));
     } else if (sap == 2 || sap == 3) {
         dmr_udp_comp_pdu(ctx->opts, ctx->state, len, ctx->state->dmr_pdu_sf[ctx->slot]);
     } else if (sap == 1 && ctx->state->dmr_pdu_sf[ctx->slot][1] == 0x10) {
@@ -1319,6 +1331,8 @@ dmr_block_type1_clear_header_state(dmr_block_assembler_ctx* ctx) {
     ctx->state->data_header_valid[ctx->slot] = 0;
     ctx->state->data_conf_data[ctx->slot] = 0;
     ctx->state->data_block_poc[ctx->slot] = 0;
+    ctx->state->data_header_dd_format[ctx->slot] = 0;
+    ctx->state->data_header_bit_padding[ctx->slot] = 0;
     ctx->state->data_byte_ctr[ctx->slot] = 0;
     ctx->state->data_ks_start[ctx->slot] = 0;
 }
@@ -1522,6 +1536,8 @@ dmr_block_assembler_reset_type1(dmr_block_assembler_ctx* ctx) {
     ctx->state->data_conf_data[ctx->slot] = 0;
     ctx->state->data_p_head[ctx->slot] = 0;
     ctx->state->data_block_poc[ctx->slot] = 0;
+    ctx->state->data_header_dd_format[ctx->slot] = 0;
+    ctx->state->data_header_bit_padding[ctx->slot] = 0;
     ctx->state->data_byte_ctr[ctx->slot] = 0;
     ctx->state->data_ks_start[ctx->slot] = 0;
     ctx->state->udt_uab_reserved[ctx->slot] = 0;
@@ -1537,6 +1553,8 @@ dmr_block_assembler_reset_type2(dmr_block_assembler_ctx* ctx) {
     ctx->state->data_header_valid[ctx->slot] = 0;
     ctx->state->data_conf_data[ctx->slot] = 0;
     ctx->state->data_p_head[ctx->slot] = 0;
+    ctx->state->data_header_dd_format[ctx->slot] = 0;
+    ctx->state->data_header_bit_padding[ctx->slot] = 0;
     ctx->state->udt_uab_reserved[ctx->slot] = 0;
 }
 
@@ -1580,6 +1598,8 @@ dmr_reset_blocks(dsd_opts* opts, dsd_state* state) {
     state->data_block_counter[0] = 1;
     state->data_block_counter[1] = 1;
     DSD_MEMSET(state->data_block_poc, 0, sizeof(state->data_block_poc));
+    DSD_MEMSET(state->data_header_dd_format, 0, sizeof(state->data_header_dd_format));
+    DSD_MEMSET(state->data_header_bit_padding, 0, sizeof(state->data_header_bit_padding));
     DSD_MEMSET(state->data_byte_ctr, 0, sizeof(state->data_byte_ctr));
     DSD_MEMSET(state->udt_uab_reserved, 0, sizeof(state->udt_uab_reserved));
     DSD_MEMSET(state->data_ks_start, 0, sizeof(state->data_ks_start));

--- a/src/protocol/dmr/dmr_bs.c
+++ b/src/protocol/dmr/dmr_bs.c
@@ -116,13 +116,21 @@ reset_dmr_bs_loop_buffers(dmr_bs_ctx* ctx) {
     DSD_MEMSET(ctx->syncdata, 0, sizeof(ctx->syncdata));
 }
 
+static int
+read_dmr_bs_stream_dibit(dsd_opts* opts, dsd_state* state, int payload_index) {
+    dsd_dibit_soft_t soft;
+    int dibit = getDibitSoft(opts, state, &soft);
+    state->dmr_stereo_payload[payload_index] = dibit;
+    state->dmr_stereo_reliab[payload_index] = soft.reliability;
+    return dibit;
+}
+
 static void
 read_dmr_bs_ambe_segment_stream(dsd_opts* opts, dsd_state* state, char frame[4][24], int payload_offset,
                                 int dibit_count, int interleave_offset, char* redundancy_out) {
     for (int i = 0; i < dibit_count; i++) {
         const dsd_ambe_2450_dibit_map_entry* map = &dsd_ambe_2450_dibit_map[interleave_offset + i];
-        int dibit = get_dibit_and_analog_signal(opts, state, NULL);
-        state->dmr_stereo_payload[payload_offset + i] = dibit;
+        int dibit = read_dmr_bs_stream_dibit(opts, state, payload_offset + i);
         if (redundancy_out != NULL) {
             redundancy_out[i] = (char)dibit;
         }
@@ -145,8 +153,7 @@ unpack_dmr_bs_ambe_segment_from_payload(const dsd_state* state, char frame[4][24
 static void
 read_dmr_bs_sync_segment(dsd_opts* opts, dsd_state* state, dmr_bs_ctx* ctx) {
     for (int i = 0; i < 24; i++) {
-        int dibit = get_dibit_and_analog_signal(opts, state, NULL);
-        state->dmr_stereo_payload[i + 66] = dibit;
+        int dibit = read_dmr_bs_stream_dibit(opts, state, i + 66);
         ctx->sync[i] = (dibit | 1) + 48;
         ctx->syncdata[((size_t)2 * i)] = (1 & (dibit >> 1));
         ctx->syncdata[((size_t)2 * i) + 1] = (1 & dibit);
@@ -176,8 +183,7 @@ extract_dmr_bs_sync_from_payload(const dsd_state* state, int payload_offset, cha
 static int
 collect_dmr_bs_cach_and_tact(dsd_opts* opts, dsd_state* state, dmr_bs_ctx* ctx) {
     for (int i = 0; i < 12; i++) {
-        int dibit = get_dibit_and_analog_signal(opts, state, NULL);
-        state->dmr_stereo_payload[i] = dibit;
+        int dibit = read_dmr_bs_stream_dibit(opts, state, i);
         ctx->cachdata[dmr_cach_interleave[((size_t)i * 2)]] = (1 & (dibit >> 1));
         ctx->cachdata[dmr_cach_interleave[((size_t)i * 2) + 1]] = (1 & dibit);
     }

--- a/src/protocol/dmr/dmr_data.c
+++ b/src/protocol/dmr/dmr_data.c
@@ -24,7 +24,6 @@
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
 #include <dsd-neo/runtime/colors.h>
-#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -71,120 +70,43 @@ dmr_data_sync_init_ctx(dmr_data_sync_ctx* ctx, dsd_opts* opts, dsd_state* state)
 static int
 dmr_data_read_cached_dibit(dmr_data_sync_ctx* ctx, int stereo_idx, int advance_rel, uint8_t* rel_value,
                            uint8_t rel_default) {
-    int dibit = *ctx->dibit_p;
-    ctx->dibit_p++;
-    if (advance_rel) {
-        if (ctx->soft_p) {
-            if (rel_value != NULL) {
-                *rel_value = ctx->soft_p->reliability;
-            }
-            ctx->soft_p++;
-        } else if (rel_value != NULL) {
-            *rel_value = rel_default;
-        }
-    }
-    if (ctx->opts->inverted_dmr == 1) {
-        dibit ^= 2;
-    }
+    int dibit;
+    uint8_t reliability = rel_default;
+
     if (ctx->state->dmr_stereo == 1) {
         dibit = (int)ctx->state->dmr_stereo_payload[stereo_idx];
+        reliability = ctx->state->dmr_stereo_reliab[stereo_idx];
     } else {
+        dibit = *ctx->dibit_p;
+        ctx->dibit_p++;
+        if (advance_rel != 0 && ctx->soft_p != NULL) {
+            reliability = ctx->soft_p->reliability;
+            ctx->soft_p++;
+        }
+        if (ctx->opts->inverted_dmr == 1) {
+            dibit ^= 2;
+        }
         ctx->state->dmr_stereo_payload[stereo_idx] = dibit;
+        if (advance_rel != 0) {
+            ctx->state->dmr_stereo_reliab[stereo_idx] = reliability;
+        }
+    }
+    if (advance_rel != 0 && rel_value != NULL) {
+        *rel_value = reliability;
     }
     return dibit;
-}
-
-static int
-dmr_data_compute_rel_base(const dsd_state* state, int symbol) {
-    int rel = 0;
-    if (symbol > state->umid) {
-        int span = state->max - state->umid;
-        if (span < 1) {
-            span = 1;
-        }
-        rel = (symbol - state->umid) * 255 / span;
-    } else if (symbol > state->center) {
-        int d1 = symbol - state->center;
-        int d2 = state->umid - symbol;
-        int span = state->umid - state->center;
-        if (span < 1) {
-            span = 1;
-        }
-        int m = d1 < d2 ? d1 : d2;
-        rel = (m * 510) / span;
-    } else if (symbol >= state->lmid) {
-        int d1 = state->center - symbol;
-        int d2 = symbol - state->lmid;
-        int span = state->center - state->lmid;
-        if (span < 1) {
-            span = 1;
-        }
-        int m = d1 < d2 ? d1 : d2;
-        rel = (m * 510) / span;
-    } else {
-        int span = state->lmid - state->min;
-        if (span < 1) {
-            span = 1;
-        }
-        rel = (state->lmid - symbol) * 255 / span;
-    }
-    if (rel < 0) {
-        rel = 0;
-    }
-    if (rel > 255) {
-        rel = 255;
-    }
-    return rel;
-}
-
-static int
-dmr_data_apply_radio_scale(int rel) {
-#ifdef USE_RADIO
-    double snr_db = dsd_rtl_stream_metrics_hook_snr_c4fm_db();
-    if (snr_db < -50.0) {
-        snr_db = dsd_rtl_stream_metrics_hook_snr_c4fm_eye_db();
-    }
-    int w256 = 0;
-    if (snr_db > -13.0) {
-        if (snr_db >= 12.0) {
-            w256 = 255;
-        } else {
-            double w = (snr_db + 13.0) / 25.0;
-            if (w < 0.0) {
-                w = 0.0;
-            }
-            if (w > 1.0) {
-                w = 1.0;
-            }
-            w256 = (int)(w * 255.0 + 0.5);
-        }
-    }
-    int scale_num = 204 + (w256 >> 2);
-    int scaled = (rel * scale_num) >> 8;
-    if (scaled > 255) {
-        scaled = 255;
-    }
-    if (scaled < 0) {
-        scaled = 0;
-    }
-    rel = scaled;
-#endif
-    return rel;
 }
 
 static int
 dmr_data_read_live_dibit(dmr_data_sync_ctx* ctx, int stereo_idx, uint8_t* rel_value) {
     int dibit;
     if (ctx->state->dmr_stereo == 0) {
-        int symbol = 0;
-        int rel;
-        dibit = get_dibit_and_analog_signal(ctx->opts, ctx->state, &symbol);
+        dsd_dibit_soft_t soft;
+        dibit = getDibitSoft(ctx->opts, ctx->state, &soft);
         ctx->state->dmr_stereo_payload[stereo_idx] = dibit;
-        rel = dmr_data_compute_rel_base(ctx->state, symbol);
-        rel = dmr_data_apply_radio_scale(rel);
-        ctx->state->dmr_stereo_reliab[stereo_idx] = (uint8_t)rel;
+        ctx->state->dmr_stereo_reliab[stereo_idx] = soft.reliability;
         if (rel_value != NULL) {
-            *rel_value = (uint8_t)rel;
+            *rel_value = soft.reliability;
         }
     } else {
         dibit = (int)ctx->state->dmr_stereo_payload[stereo_idx];

--- a/src/protocol/dmr/dmr_dburst.c
+++ b/src/protocol/dmr/dmr_dburst.c
@@ -512,7 +512,8 @@ dmr_dburst_pick_trellis_payload(dmr_data_burst_ctx* ctx, const uint8_t tdibits[9
     if (ctx->reliab98 != NULL && dmr_r34_viterbi_decode_soft(tdibits, ctx->reliab98, decoded) == 0) {
         dmr_dburst_trellis_add_candidate(ctx, tdibits, candidates, R34_POOL_CAPACITY, &candidate_count, decoded);
     }
-    if (dmr_r34_viterbi_decode_list(tdibits, ctx->reliab98, list, R34_LIST_CAPACITY, &list_count) == 0) {
+    if ((ctx->state->data_conf_data[ctx->slot] == 1 || ctx->reliab98 == NULL)
+        && dmr_r34_viterbi_decode_list(tdibits, ctx->reliab98, list, R34_LIST_CAPACITY, &list_count) == 0) {
         for (int i = 0; i < list_count; i++) {
             dmr_dburst_trellis_add_candidate(ctx, tdibits, candidates, R34_POOL_CAPACITY, &candidate_count,
                                              list[i].bytes18);

--- a/src/protocol/dmr/dmr_dburst.c
+++ b/src/protocol/dmr/dmr_dburst.c
@@ -29,7 +29,9 @@
 #include <dsd-neo/runtime/colors.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include "dmr_dburst_profile.h"
+#include "dmr_r34_internal.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -410,78 +412,119 @@ dmr_dburst_trellis_candidate_metrics(dmr_data_burst_ctx* ctx, const uint8_t byte
 }
 
 static int
-dmr_dburst_trellis_choose_candidate_index(dmr_data_burst_ctx* ctx, const dmr_r34_candidate* list, int list_n) {
+dmr_dburst_trellis_lower_metric(const dmr_r34_candidate* candidates, int current, int candidate) {
+    if (current < 0 || candidates[candidate].metric < candidates[current].metric) {
+        return candidate;
+    }
+    return current;
+}
+
+static int
+dmr_dburst_trellis_choose_candidate_index(dmr_data_burst_ctx* ctx, const dmr_r34_candidate* candidates,
+                                          int candidate_count) {
     const int have_expected_dbsn = ctx->state->data_dbsn_have[ctx->slot] != 0;
     const uint8_t expected_dbsn = ctx->state->data_dbsn_expected[ctx->slot];
     int best_crc_dbsn = -1;
-    int best_dbsn = -1;
     int best_crc = -1;
+    int best_dbsn = -1;
+    int best_any = -1;
     int ci;
 
-    for (ci = 0; ci < list_n; ci++) {
+    for (ci = 0; ci < candidate_count; ci++) {
         uint8_t cand_dbsn = 0;
         int cand_crc_ok = 0;
-        dmr_dburst_trellis_candidate_metrics(ctx, list[ci].bytes18, &cand_dbsn, &cand_crc_ok);
+        dmr_dburst_trellis_candidate_metrics(ctx, candidates[ci].bytes18, &cand_dbsn, &cand_crc_ok);
+        best_any = dmr_dburst_trellis_lower_metric(candidates, best_any, ci);
 
         if (have_expected_dbsn && cand_dbsn == expected_dbsn) {
-            if (best_dbsn < 0) {
-                best_dbsn = ci;
-            }
             if (cand_crc_ok) {
-                best_crc_dbsn = ci;
-                break;
+                best_crc_dbsn = dmr_dburst_trellis_lower_metric(candidates, best_crc_dbsn, ci);
+            } else {
+                best_dbsn = dmr_dburst_trellis_lower_metric(candidates, best_dbsn, ci);
             }
         }
 
-        if (cand_crc_ok && best_crc < 0) {
-            best_crc = ci;
+        if (cand_crc_ok) {
+            best_crc = dmr_dburst_trellis_lower_metric(candidates, best_crc, ci);
         }
     }
 
     if (best_crc_dbsn >= 0) {
         return best_crc_dbsn;
     }
-    if (best_dbsn >= 0) {
-        return best_dbsn;
-    }
     if (best_crc >= 0) {
         return best_crc;
     }
-    return 0;
+    if (best_dbsn >= 0) {
+        return best_dbsn;
+    }
+    return best_any;
 }
 
 static void
-dmr_dburst_pick_trellis_payload(dmr_data_burst_ctx* ctx, uint8_t tdibits[98], uint8_t trellis_return[18]) {
-    uint8_t trellis_soft[18];
-    uint8_t trellis_hard[18];
-    int have_soft = 0;
-    int have_hard = 0;
-
-    DSD_MEMSET(trellis_soft, 0, sizeof(trellis_soft));
-    DSD_MEMSET(trellis_hard, 0, sizeof(trellis_hard));
-
-    if (ctx->reliab98 != NULL && dmr_r34_viterbi_decode_soft(tdibits, ctx->reliab98, trellis_soft) == 0) {
-        have_soft = 1;
-    }
-    if (dmr_r34_viterbi_decode(tdibits, trellis_hard) == 0) {
-        have_hard = 1;
-    }
-    if (ctx->opts->audio_in_type == AUDIO_IN_SYMBOL_BIN && have_hard) {
-        DSD_MEMCPY(trellis_return, trellis_hard, 18);
+dmr_dburst_trellis_add_candidate(const dmr_data_burst_ctx* ctx, const uint8_t tdibits[98],
+                                 dmr_r34_candidate candidates[], int capacity, int* candidate_count,
+                                 const uint8_t bytes18[18]) {
+    if (*candidate_count >= capacity) {
         return;
     }
-
-    if (ctx->state->data_conf_data[ctx->slot] == 1) {
-        dmr_r34_candidate list[256];
-        int list_n = 0;
-        if (dmr_r34_viterbi_decode_list(tdibits, ctx->reliab98, list, 256, &list_n) == 0 && list_n > 0) {
-            int chosen_i = dmr_dburst_trellis_choose_candidate_index(ctx, list, list_n);
-            DSD_MEMCPY(trellis_return, list[chosen_i].bytes18, 18);
+    for (int i = 0; i < *candidate_count; i++) {
+        if (memcmp(candidates[i].bytes18, bytes18, 18) == 0) {
             return;
         }
     }
 
-    DSD_MEMCPY(trellis_return, have_soft ? trellis_soft : trellis_hard, 18);
+    int metric = 0;
+    if (dmr_r34_candidate_metric(tdibits, ctx->reliab98, bytes18, &metric) != 0) {
+        return;
+    }
+    candidates[*candidate_count].metric = metric;
+    DSD_MEMCPY(candidates[*candidate_count].bytes18, bytes18, 18);
+    (*candidate_count)++;
+}
+
+static int
+dmr_dburst_trellis_lowest_metric_index(const dmr_r34_candidate candidates[], int candidate_count) {
+    int best = -1;
+    for (int i = 0; i < candidate_count; i++) {
+        best = dmr_dburst_trellis_lower_metric(candidates, best, i);
+    }
+    return best;
+}
+
+static void
+dmr_dburst_pick_trellis_payload(dmr_data_burst_ctx* ctx, const uint8_t tdibits[98], uint8_t trellis_return[18]) {
+    enum { R34_LIST_CAPACITY = 32, R34_POOL_CAPACITY = R34_LIST_CAPACITY + 2 };
+
+    dmr_r34_candidate candidates[R34_POOL_CAPACITY];
+    dmr_r34_candidate list[R34_LIST_CAPACITY];
+    uint8_t decoded[18];
+    int candidate_count = 0;
+    int list_count = 0;
+
+    DSD_MEMSET(candidates, 0, sizeof(candidates));
+    DSD_MEMSET(list, 0, sizeof(list));
+    DSD_MEMSET(decoded, 0, sizeof(decoded));
+
+    if (dmr_r34_viterbi_decode(tdibits, decoded) == 0) {
+        dmr_dburst_trellis_add_candidate(ctx, tdibits, candidates, R34_POOL_CAPACITY, &candidate_count, decoded);
+    }
+    if (ctx->reliab98 != NULL && dmr_r34_viterbi_decode_soft(tdibits, ctx->reliab98, decoded) == 0) {
+        dmr_dburst_trellis_add_candidate(ctx, tdibits, candidates, R34_POOL_CAPACITY, &candidate_count, decoded);
+    }
+    if (dmr_r34_viterbi_decode_list(tdibits, ctx->reliab98, list, R34_LIST_CAPACITY, &list_count) == 0) {
+        for (int i = 0; i < list_count; i++) {
+            dmr_dburst_trellis_add_candidate(ctx, tdibits, candidates, R34_POOL_CAPACITY, &candidate_count,
+                                             list[i].bytes18);
+        }
+    }
+
+    int chosen = (ctx->state->data_conf_data[ctx->slot] == 1)
+                     ? dmr_dburst_trellis_choose_candidate_index(ctx, candidates, candidate_count)
+                     : dmr_dburst_trellis_lowest_metric_index(candidates, candidate_count);
+    if (chosen >= 0) {
+        DSD_MEMCPY(trellis_return, candidates[chosen].bytes18, 18);
+    }
 }
 
 static void

--- a/src/protocol/dmr/dmr_ms.c
+++ b/src/protocol/dmr/dmr_ms.c
@@ -425,6 +425,11 @@ dmrMSData(dsd_opts* opts, dsd_state* state) {
     int i;
     int dibit;
     const int* dibit_p;
+    const dsd_dibit_soft_t* soft_p = NULL;
+
+    if (state->dmr_soft_buf != NULL && state->dmr_soft_p != NULL && state->dmr_soft_p >= state->dmr_soft_buf + 90) {
+        soft_p = state->dmr_soft_p - 90;
+    }
 
     //CACH + First Half Payload + Sync = 12 + 54 + 24
     dibit_p = state->dmr_payload_p - 90;
@@ -436,14 +441,17 @@ dmrMSData(dsd_opts* opts, dsd_state* state) {
             dibit = (dibit ^ 2) & 3;
         }
         state->dmr_stereo_payload[i] = dibit;
+        state->dmr_stereo_reliab[i] = soft_p != NULL ? soft_p[i].reliability : 200U;
     }
 
     for (i = 0; i < 54; i++) {
-        dibit = get_dibit_and_analog_signal(opts, state, NULL);
+        dsd_dibit_soft_t soft;
+        dibit = getDibitSoft(opts, state, &soft);
         if (opts->inverted_dmr == 1) {
             dibit = (dibit ^ 2) & 3;
         }
         state->dmr_stereo_payload[i + 90] = dibit;
+        state->dmr_stereo_reliab[i + 90] = soft.reliability;
     }
 
     DSD_FPRINTF(stderr, "%s ", timestr);

--- a/src/protocol/dmr/dmr_pdu.c
+++ b/src/protocol/dmr/dmr_pdu.c
@@ -28,6 +28,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include "dmr_pdu_internal.h"
+#include "dmr_text.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -146,39 +148,111 @@ utf8_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input) {
     }
 }
 
+static void
+dmr_sd_pdu_store_text(dsd_state* state, uint8_t slot, const char* text) {
+    Event_History* item = &state->event_history_s[slot].Event_History_Items[0];
+    DSD_SNPRINTF(item->text_message, sizeof(item->text_message), "%s", text != NULL ? text : "");
+    dsd_event_history_item_set_metadata(item, DSD_EVENT_SEVERITY_INFO, DSD_EVENT_CATEGORY_DATA);
+    dsd_event_history_mark_dirty(&state->event_history_s[slot]);
+}
+
+static void
+dmr_sd_pdu_print_raw(const uint8_t* dmr_pdu, uint16_t len) {
+    DSD_FPRINTF(stderr, "\n Short Data Raw: ");
+    for (uint16_t i = 0; i < len; i++) {
+        DSD_FPRINTF(stderr, "[%02X]", dmr_pdu[i]);
+    }
+}
+
+static void
+dmr_sd_pdu_copy_location(const dsd_opts* opts, dsd_state* state, uint8_t slot, uint16_t len, const uint8_t* dmr_pdu) {
+    dmr_locn(opts, state, len, dmr_pdu);
+    DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].gps_s,
+                 sizeof(state->event_history_s[slot].Event_History_Items[0].gps_s), "%s", state->dmr_lrrp_gps[slot]);
+    dsd_event_history_item_set_metadata(&state->event_history_s[slot].Event_History_Items[0], DSD_EVENT_SEVERITY_INFO,
+                                        DSD_EVENT_CATEGORY_DATA);
+    dsd_event_history_mark_dirty(&state->event_history_s[slot]);
+}
+
+static void
+dmr_sd_pdu_append_result_flags(char* summary, size_t summary_size, const dmr_text_result* result) {
+    if (result->malformed) {
+        dsd_append(summary, summary_size, "malformed input replaced; ");
+    }
+    if (result->truncated) {
+        dsd_append(summary, summary_size, "display truncated; ");
+    }
+}
+
 void
-dmr_sd_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* DMR_PDU) {
-
-    uint8_t slot = state->currentslot;
-    uint16_t offset = 0; //sanity check of sorts, prevent extra long line print outs in the console
-    if (len > 23) {
-        offset = 23;
+dmr_sd_pdu_process(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* dmr_pdu, uint8_t packet_crc_valid) {
+    if (opts == NULL || state == NULL || (dmr_pdu == NULL && len != 0U)) {
+        return;
     }
 
-    if (state->data_header_format[state->currentslot] == 13) //only short data: defined format (testing)
-    {
-        utf8_to_text(state, 0, len - offset, DMR_PDU + offset);
-        dmr_locn(opts, state, len, DMR_PDU);
-        DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].gps_s,
-                     sizeof(state->event_history_s[slot].Event_History_Items[0].gps_s), "%s",
-                     state->dmr_lrrp_gps[slot]);
-        dsd_event_history_item_set_metadata(&state->event_history_s[slot].Event_History_Items[0],
-                                            DSD_EVENT_SEVERITY_INFO, DSD_EVENT_CATEGORY_DATA);
-        dsd_event_history_mark_dirty(&state->event_history_s[slot]);
-    } else {
-        if (len >= (127 * 18)) {
-            len = 127 * 18; //sanity check of sorts, prevent extra long line print outs in the console
-        }
-        utf8_to_text(state, 0, len, DMR_PDU); //generic catch-all to see if anything relevant is there
-    }
-
-    //dump to event history
+    uint8_t slot = (uint8_t)(state->currentslot & 1U);
     uint32_t source = state->dmr_lrrp_source[slot];
     uint32_t target = state->dmr_lrrp_target[slot];
-    char comp_string[500];
-    DSD_MEMSET(comp_string, 0, sizeof(comp_string));
-    DSD_SNPRINTF(comp_string, sizeof(comp_string), "Short Data SRC: %d; TGT: %d; ", source, target);
-    watchdog_event_datacall(opts, state, source, target, comp_string, slot);
+    char summary[2300];
+    DSD_MEMSET(summary, 0, sizeof(summary));
+    DSD_SNPRINTF(summary, sizeof(summary), "Short Data SRC: %u; TGT: %u; ", source, target);
+    dmr_sd_pdu_store_text(state, slot, "");
+
+    if (state->data_header_format[slot] == 13U) {
+        uint8_t dd_format = state->data_header_dd_format[slot];
+        if (dd_format >= 0x12U && dd_format <= 0x18U) {
+            size_t payload_len = 0U;
+            dmr_text_result result;
+            if (dmr_short_data_payload_bytes((size_t)len * 8U, state->data_header_bit_padding[slot], &payload_len)
+                != 0) {
+                DSD_FPRINTF(stderr, "\n Short Data Text: invalid bit padding (%u bits)",
+                            state->data_header_bit_padding[slot]);
+                char detail[96];
+                DSD_SNPRINTF(detail, sizeof(detail), "declared %s; invalid/non-byte-aligned padding; ",
+                             dmr_defined_data_encoding_name(dd_format));
+                dsd_append(summary, sizeof(summary), detail);
+            } else {
+                (void)dmr_decode_defined_short_data(dd_format, dmr_pdu, payload_len, packet_crc_valid, &result);
+                if (result.compatibility) {
+                    DSD_FPRINTF(stderr, "\n Short Data Text (declared UTF-32; decoded UTF-16BE compatibility): %s",
+                                result.text);
+                } else {
+                    DSD_FPRINTF(stderr, "\n Short Data Text (declared %s; decoded %s): %s", result.declared_encoding,
+                                result.effective_encoding, result.text);
+                }
+                dmr_sd_pdu_store_text(state, slot, result.text);
+                char detail[160];
+                DSD_SNPRINTF(detail, sizeof(detail), "declared %s; decoded %s; ", result.declared_encoding,
+                             result.effective_encoding);
+                dsd_append(summary, sizeof(summary), detail);
+                dmr_sd_pdu_append_result_flags(summary, sizeof(summary), &result);
+                dsd_append(summary, sizeof(summary), "Text: ");
+                dsd_append(summary, sizeof(summary), result.text);
+                dsd_append(summary, sizeof(summary), "; ");
+            }
+        } else {
+            char detail[96];
+            DSD_SNPRINTF(detail, sizeof(detail), "DD format 0x%02X; raw/unsupported encoding; ", dd_format);
+            dsd_append(summary, sizeof(summary), detail);
+            dmr_sd_pdu_print_raw(dmr_pdu, len);
+            dmr_sd_pdu_copy_location(opts, state, slot, len, dmr_pdu);
+        }
+    } else {
+        uint16_t bounded_len = len;
+        if (bounded_len >= (127U * 18U)) {
+            bounded_len = 127U * 18U;
+        }
+        utf8_to_text(state, 0, bounded_len, dmr_pdu);
+        dsd_append(summary, sizeof(summary), "raw short-data payload; ");
+    }
+
+    watchdog_event_datacall(opts, state, source, target, summary, slot);
+}
+
+void
+dmr_sd_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* DMR_PDU) {
+    /* Public compatibility entry point: strict decoding only, with no CRC-proven transmitter workaround. */
+    dmr_sd_pdu_process(opts, state, len, DMR_PDU, 0U);
 }
 
 //reading ETSI, seems like these aren't compressed, just that they are preset indexed values on the radio

--- a/src/protocol/dmr/dmr_pdu_internal.h
+++ b/src/protocol/dmr/dmr_pdu_internal.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: ISC
+/* Protocol-internal DMR PDU entry points. */
+
+#ifndef DSD_NEO_SRC_PROTOCOL_DMR_DMR_PDU_INTERNAL_H_
+#define DSD_NEO_SRC_PROTOCOL_DMR_DMR_PDU_INTERNAL_H_
+
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_fwd.h>
+
+#include <stdint.h>
+
+void dmr_sd_pdu_process(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* dmr_pdu,
+                        uint8_t packet_crc_valid);
+
+#endif /* DSD_NEO_SRC_PROTOCOL_DMR_DMR_PDU_INTERNAL_H_ */

--- a/src/protocol/dmr/dmr_r34_internal.h
+++ b/src/protocol/dmr/dmr_r34_internal.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Protocol-internal helpers for DMR rate 3/4 decoding.
+ */
+
+#ifndef DSD_NEO_SRC_PROTOCOL_DMR_DMR_R34_INTERNAL_H_
+#define DSD_NEO_SRC_PROTOCOL_DMR_DMR_R34_INTERNAL_H_
+
+#include <stdint.h>
+
+/*
+ * Score a decoded 18-byte payload against the received dibits. The implied
+ * encoder path starts in state zero and includes the terminating zero tribit.
+ * Reliability may be NULL, in which case every received dibit has weight one.
+ */
+int dmr_r34_candidate_metric(const uint8_t* dibits98, const uint8_t* reliab98, const uint8_t bytes18[18],
+                             int* out_metric);
+
+#endif /* DSD_NEO_SRC_PROTOCOL_DMR_DMR_R34_INTERNAL_H_ */

--- a/src/protocol/dmr/dmr_text.c
+++ b/src/protocol/dmr/dmr_text.c
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Bounded, locale-independent Unicode rendering for DMR Defined Short Data.
+ */
+
+#include "dmr_text.h"
+
+#include <dsd-neo/core/safe_api.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+    dmr_text_result* result;
+    size_t length;
+    uint8_t stopped;
+} dmr_text_builder;
+
+const char*
+dmr_defined_data_encoding_name(uint8_t dd_format) {
+    switch (dd_format) {
+        case 0x12: return "UTF-8";
+        case 0x13: return "UTF-16";
+        case 0x14: return "UTF-16BE";
+        case 0x15: return "UTF-16LE";
+        case 0x16: return "UTF-32";
+        case 0x17: return "UTF-32BE";
+        case 0x18: return "UTF-32LE";
+        default: return "unsupported";
+    }
+}
+
+static int
+dmr_text_is_control(uint32_t scalar) {
+    return scalar < 0x20U || (scalar >= 0x7FU && scalar <= 0x9FU);
+}
+
+static int
+dmr_text_is_scalar(uint32_t scalar) {
+    return scalar <= 0x10FFFFU && !(scalar >= 0xD800U && scalar <= 0xDFFFU);
+}
+
+static size_t
+dmr_text_encode_utf8(uint32_t scalar, uint8_t encoded[4]) {
+    if (scalar <= 0x7FU) {
+        encoded[0] = (uint8_t)scalar;
+        return 1U;
+    }
+    if (scalar <= 0x7FFU) {
+        encoded[0] = (uint8_t)(0xC0U | (scalar >> 6));
+        encoded[1] = (uint8_t)(0x80U | (scalar & 0x3FU));
+        return 2U;
+    }
+    if (scalar <= 0xFFFFU) {
+        encoded[0] = (uint8_t)(0xE0U | (scalar >> 12));
+        encoded[1] = (uint8_t)(0x80U | ((scalar >> 6) & 0x3FU));
+        encoded[2] = (uint8_t)(0x80U | (scalar & 0x3FU));
+        return 3U;
+    }
+    encoded[0] = (uint8_t)(0xF0U | (scalar >> 18));
+    encoded[1] = (uint8_t)(0x80U | ((scalar >> 12) & 0x3FU));
+    encoded[2] = (uint8_t)(0x80U | ((scalar >> 6) & 0x3FU));
+    encoded[3] = (uint8_t)(0x80U | (scalar & 0x3FU));
+    return 4U;
+}
+
+static void
+dmr_text_remove_last_scalar(dmr_text_builder* builder) {
+    if (builder->length == 0U) {
+        return;
+    }
+    size_t start = builder->length - 1U;
+    while (start > 0U && (((uint8_t)builder->result->text[start] & 0xC0U) == 0x80U)) {
+        start--;
+    }
+    builder->length = start;
+    builder->result->text[start] = '\0';
+}
+
+static void
+dmr_text_append_ellipsis(dmr_text_builder* builder) {
+    static const uint8_t ellipsis[] = {0xE2U, 0x80U, 0xA6U};
+    const size_t limit = sizeof(builder->result->text) - 1U;
+    while (builder->length + sizeof(ellipsis) > limit && builder->length > 0U) {
+        dmr_text_remove_last_scalar(builder);
+    }
+    if (builder->length + sizeof(ellipsis) <= limit) {
+        for (size_t i = 0; i < sizeof(ellipsis); i++) {
+            builder->result->text[builder->length++] = (char)ellipsis[i];
+        }
+        builder->result->text[builder->length] = '\0';
+    }
+}
+
+static void
+dmr_text_append_scalar(dmr_text_builder* builder, uint32_t scalar) {
+    if (builder->stopped || builder->result->truncated) {
+        return;
+    }
+    if (scalar == 0U) {
+        builder->stopped = 1U;
+        return;
+    }
+
+    if (!dmr_text_is_control(scalar)) {
+        builder->result->has_content = 1U;
+    }
+    if (scalar == 0x09U || scalar == 0x0AU || scalar == 0x0DU) {
+        scalar = 0x20U;
+    } else if (dmr_text_is_control(scalar)) {
+        scalar = 0xFFFDU;
+    }
+
+    uint8_t encoded[4];
+    size_t encoded_len = dmr_text_encode_utf8(scalar, encoded);
+    const size_t limit = sizeof(builder->result->text) - 1U;
+    if (builder->length + encoded_len > limit) {
+        builder->result->truncated = 1U;
+        dmr_text_append_ellipsis(builder);
+        return;
+    }
+    for (size_t i = 0; i < encoded_len; i++) {
+        builder->result->text[builder->length++] = (char)encoded[i];
+    }
+    builder->result->text[builder->length] = '\0';
+}
+
+static void
+dmr_text_append_malformed(dmr_text_builder* builder) {
+    builder->result->malformed = 1U;
+    dmr_text_append_scalar(builder, 0xFFFDU);
+}
+
+static size_t
+dmr_text_utf8_lead(uint8_t first, uint32_t* scalar) {
+    if (first <= 0x7FU) {
+        *scalar = first;
+        return 1U;
+    }
+    if (first >= 0xC2U && first <= 0xDFU) {
+        *scalar = (uint32_t)(first & 0x1FU);
+        return 2U;
+    }
+    if (first >= 0xE0U && first <= 0xEFU) {
+        *scalar = (uint32_t)(first & 0x0FU);
+        return 3U;
+    }
+    if (first >= 0xF0U && first <= 0xF4U) {
+        *scalar = (uint32_t)(first & 0x07U);
+        return 4U;
+    }
+    return 0U;
+}
+
+static int
+dmr_text_utf8_second_is_valid(uint8_t first, uint8_t second) {
+    if ((second & 0xC0U) != 0x80U) {
+        return 0;
+    }
+    if (first == 0xE0U && second < 0xA0U) {
+        return 0;
+    }
+    if (first == 0xEDU && second > 0x9FU) {
+        return 0;
+    }
+    if (first == 0xF0U && second < 0x90U) {
+        return 0;
+    }
+    if (first == 0xF4U && second > 0x8FU) {
+        return 0;
+    }
+    return 1;
+}
+
+static int
+dmr_text_utf8_sequence_is_valid(const uint8_t* input, size_t input_len, size_t offset, size_t count) {
+    if (count > input_len - offset) {
+        return 0;
+    }
+    if (count == 1U) {
+        return 1;
+    }
+    if (!dmr_text_utf8_second_is_valid(input[offset], input[offset + 1U])) {
+        return 0;
+    }
+    for (size_t j = 2U; j < count; j++) {
+        if ((input[offset + j] & 0xC0U) != 0x80U) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static uint32_t
+dmr_text_utf8_finish_scalar(const uint8_t* input, size_t offset, size_t count, uint32_t scalar) {
+    for (size_t j = 1U; j < count; j++) {
+        scalar = (scalar << 6) | (uint32_t)(input[offset + j] & 0x3FU);
+    }
+    return scalar;
+}
+
+static void
+dmr_text_decode_utf8(const uint8_t* input, size_t input_len, dmr_text_builder* builder) {
+    size_t i = 0U;
+    if (input_len >= 3U && input[0] == 0xEFU && input[1] == 0xBBU && input[2] == 0xBFU) {
+        i = 3U;
+    }
+
+    while (i < input_len) {
+        uint8_t first = input[i];
+        uint32_t scalar = 0U;
+        size_t count = dmr_text_utf8_lead(first, &scalar);
+        if (count == 0U || !dmr_text_utf8_sequence_is_valid(input, input_len, i, count)) {
+            dmr_text_append_malformed(builder);
+            i++;
+            continue;
+        }
+        scalar = dmr_text_utf8_finish_scalar(input, i, count, scalar);
+        dmr_text_append_scalar(builder, scalar);
+        i += count;
+    }
+}
+
+static uint16_t
+dmr_text_read_u16(const uint8_t* input, int little_endian) {
+    if (little_endian) {
+        return (uint16_t)((uint16_t)input[0] | ((uint16_t)input[1] << 8));
+    }
+    return (uint16_t)(((uint16_t)input[0] << 8) | (uint16_t)input[1]);
+}
+
+static uint32_t
+dmr_text_read_u32(const uint8_t* input, int little_endian) {
+    if (little_endian) {
+        return (uint32_t)input[0] | ((uint32_t)input[1] << 8) | ((uint32_t)input[2] << 16) | ((uint32_t)input[3] << 24);
+    }
+    return ((uint32_t)input[0] << 24) | ((uint32_t)input[1] << 16) | ((uint32_t)input[2] << 8) | (uint32_t)input[3];
+}
+
+static size_t
+dmr_text_utf16_bom_offset(const uint8_t* input, size_t input_len, int detect_bom, int* little_endian) {
+    if (!detect_bom || input_len < 2U) {
+        return 0U;
+    }
+    if (input[0] == 0xFEU && input[1] == 0xFFU) {
+        *little_endian = 0;
+        return 2U;
+    }
+    if (input[0] == 0xFFU && input[1] == 0xFEU) {
+        *little_endian = 1;
+        return 2U;
+    }
+    return 0U;
+}
+
+static int
+dmr_text_utf16_is_high_surrogate(uint16_t value) {
+    return value >= 0xD800U && value <= 0xDBFFU;
+}
+
+static int
+dmr_text_utf16_is_low_surrogate(uint16_t value) {
+    return value >= 0xDC00U && value <= 0xDFFFU;
+}
+
+static int
+dmr_text_utf16_decode_pair(const uint8_t* input, size_t input_len, size_t offset, int little_endian, uint16_t first,
+                           uint32_t* scalar) {
+    if (input_len - offset < 2U) {
+        return 0;
+    }
+    uint16_t second = dmr_text_read_u16(input + offset, little_endian);
+    if (!dmr_text_utf16_is_low_surrogate(second)) {
+        return 0;
+    }
+    *scalar = 0x10000U + (((uint32_t)first - 0xD800U) << 10) + ((uint32_t)second - 0xDC00U);
+    return 1;
+}
+
+static void
+dmr_text_decode_utf16(const uint8_t* input, size_t input_len, int little_endian, int detect_bom,
+                      dmr_text_builder* builder) {
+    size_t i = dmr_text_utf16_bom_offset(input, input_len, detect_bom, &little_endian);
+
+    while (i + 1U < input_len) {
+        uint16_t first = dmr_text_read_u16(input + i, little_endian);
+        i += 2U;
+        if (dmr_text_utf16_is_high_surrogate(first)) {
+            uint32_t scalar = 0U;
+            if (dmr_text_utf16_decode_pair(input, input_len, i, little_endian, first, &scalar)) {
+                dmr_text_append_scalar(builder, scalar);
+                i += 2U;
+            } else {
+                dmr_text_append_malformed(builder);
+            }
+        } else if (dmr_text_utf16_is_low_surrogate(first)) {
+            dmr_text_append_malformed(builder);
+        } else {
+            dmr_text_append_scalar(builder, first);
+        }
+    }
+    if (i != input_len) {
+        dmr_text_append_malformed(builder);
+    }
+}
+
+static void
+dmr_text_decode_utf32(const uint8_t* input, size_t input_len, int little_endian, int detect_bom,
+                      dmr_text_builder* builder) {
+    size_t i = 0U;
+    if (detect_bom && input_len >= 4U) {
+        if (input[0] == 0x00U && input[1] == 0x00U && input[2] == 0xFEU && input[3] == 0xFFU) {
+            little_endian = 0;
+            i = 4U;
+        } else if (input[0] == 0xFFU && input[1] == 0xFEU && input[2] == 0x00U && input[3] == 0x00U) {
+            little_endian = 1;
+            i = 4U;
+        }
+    }
+
+    while (i + 3U < input_len) {
+        uint32_t scalar = dmr_text_read_u32(input + i, little_endian);
+        if (dmr_text_is_scalar(scalar)) {
+            dmr_text_append_scalar(builder, scalar);
+        } else {
+            dmr_text_append_malformed(builder);
+        }
+        i += 4U;
+    }
+    if (i != input_len) {
+        dmr_text_append_malformed(builder);
+    }
+}
+
+static void
+dmr_text_result_init(uint8_t dd_format, dmr_text_result* result) {
+    DSD_MEMSET(result, 0, sizeof(*result));
+    result->declared_encoding = dmr_defined_data_encoding_name(dd_format);
+    result->effective_encoding = result->declared_encoding;
+    result->supported = (uint8_t)(dd_format >= 0x12U && dd_format <= 0x18U);
+}
+
+static void
+dmr_text_decode_format(uint8_t dd_format, const uint8_t* input, size_t input_len, dmr_text_result* result) {
+    dmr_text_builder builder = {.result = result, .length = 0U, .stopped = 0U};
+    switch (dd_format) {
+        case 0x12: dmr_text_decode_utf8(input, input_len, &builder); break;
+        case 0x13: dmr_text_decode_utf16(input, input_len, 0, 1, &builder); break;
+        case 0x14: dmr_text_decode_utf16(input, input_len, 0, 0, &builder); break;
+        case 0x15: dmr_text_decode_utf16(input, input_len, 1, 0, &builder); break;
+        case 0x16: dmr_text_decode_utf32(input, input_len, 0, 1, &builder); break;
+        case 0x17: dmr_text_decode_utf32(input, input_len, 0, 0, &builder); break;
+        case 0x18: dmr_text_decode_utf32(input, input_len, 1, 0, &builder); break;
+        default: break;
+    }
+}
+
+int
+dmr_decode_defined_short_data(uint8_t dd_format, const uint8_t* input, size_t input_len, int packet_crc_valid,
+                              dmr_text_result* result) {
+    if (result == NULL || (input == NULL && input_len != 0U)) {
+        return -1;
+    }
+    dmr_text_result_init(dd_format, result);
+    if (!result->supported) {
+        return 0;
+    }
+
+    dmr_text_decode_format(dd_format, input, input_len, result);
+    if (dd_format == 0x16U && packet_crc_valid && result->malformed) {
+        dmr_text_result compatibility;
+        dmr_text_result_init(0x14U, &compatibility);
+        dmr_text_decode_format(0x14U, input, input_len, &compatibility);
+        if (!compatibility.malformed && compatibility.has_content) {
+            *result = compatibility;
+            result->declared_encoding = dmr_defined_data_encoding_name(0x16U);
+            result->effective_encoding = "UTF-16BE compatibility";
+            result->compatibility = 1U;
+        }
+    }
+    return 0;
+}
+
+int
+dmr_short_data_payload_bytes(size_t assembled_bits, uint8_t bit_padding, size_t* payload_bytes) {
+    if (payload_bytes == NULL || (size_t)bit_padding > assembled_bits) {
+        return -1;
+    }
+    size_t payload_bits = assembled_bits - (size_t)bit_padding;
+    if ((payload_bits & 7U) != 0U) {
+        return -1;
+    }
+    *payload_bytes = payload_bits / 8U;
+    return 0;
+}

--- a/src/protocol/dmr/dmr_text.h
+++ b/src/protocol/dmr/dmr_text.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Protocol-internal DMR Defined Short Data text decoding.
+ */
+
+#ifndef DSD_NEO_SRC_PROTOCOL_DMR_DMR_TEXT_H_
+#define DSD_NEO_SRC_PROTOCOL_DMR_DMR_TEXT_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+enum { DMR_TEXT_RESULT_CAPACITY = 2000 };
+
+typedef struct {
+    char text[DMR_TEXT_RESULT_CAPACITY];
+    const char* declared_encoding;
+    const char* effective_encoding;
+    uint8_t supported;
+    uint8_t malformed;
+    uint8_t truncated;
+    uint8_t compatibility;
+    uint8_t has_content;
+} dmr_text_result;
+
+const char* dmr_defined_data_encoding_name(uint8_t dd_format);
+
+/* Convert a complete byte-oriented short-data span to UTF-8. */
+int dmr_decode_defined_short_data(uint8_t dd_format, const uint8_t* input, size_t input_len, int packet_crc_valid,
+                                  dmr_text_result* result);
+
+/* Remove protocol bit padding and require a byte-aligned Unicode span. */
+int dmr_short_data_payload_bytes(size_t assembled_bits, uint8_t bit_padding, size_t* payload_bytes);
+
+#endif /* DSD_NEO_SRC_PROTOCOL_DMR_DMR_TEXT_H_ */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5065,6 +5065,28 @@ target_include_directories(
 add_test(NAME DMR_DATA_SYNC COMMAND dsd-neo_test_dmr_data_sync)
 
 add_executable(
+    dsd-neo_test_dmr_text
+    protocol/dmr/test_dmr_text.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
+)
+target_include_directories(
+    dsd-neo_test_dmr_text
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/protocol/dmr
+)
+add_test(NAME DMR_TEXT COMMAND dsd-neo_test_dmr_text)
+
+add_executable(
+    dsd-neo_test_dmr_discussion_231
+    protocol/dmr/test_dmr_discussion_231.c
+)
+target_include_directories(
+    dsd-neo_test_dmr_discussion_231
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/protocol/dmr
+)
+target_link_libraries(dsd-neo_test_dmr_discussion_231 PRIVATE dsd-neo_proto_dmr)
+add_test(NAME DMR_DISCUSSION_231 COMMAND dsd-neo_test_dmr_discussion_231)
+
+add_executable(
     dsd-neo_test_dmr_ms_data
     protocol/dmr/test_dmr_ms_data.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ms.c
@@ -5217,7 +5239,7 @@ add_test(NAME DMR_R34_NOISE COMMAND dsd-neo_test_dmr_r34_noise)
 add_executable(dsd-neo_test_dmr_r34_list protocol/dmr/test_dmr_r34_list.c)
 target_include_directories(
     dsd-neo_test_dmr_r34_list
-    PRIVATE ${PROJECT_SOURCE_DIR}/include
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/protocol/dmr
 )
 target_link_libraries(dsd-neo_test_dmr_r34_list PRIVATE dsd-neo_proto_dmr)
 add_test(NAME DMR_R34_LIST COMMAND dsd-neo_test_dmr_r34_list)
@@ -5296,6 +5318,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_time_fallback
     protocol/dmr/test_dmr_lrrp_time_fallback.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
 target_include_directories(
     dsd-neo_test_dmr_lrrp_time_fallback
@@ -5320,6 +5343,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_time_valid
     protocol/dmr/test_dmr_lrrp_time_valid.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
 target_include_directories(
     dsd-neo_test_dmr_lrrp_time_valid
@@ -5341,6 +5365,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_token_alignment
     protocol/dmr/test_dmr_lrrp_token_alignment.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
 target_include_directories(
     dsd-neo_test_dmr_lrrp_token_alignment
@@ -5364,6 +5389,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_response_token_lengths
     protocol/dmr/test_dmr_lrrp_response_token_lengths.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
 target_include_directories(
     dsd-neo_test_dmr_lrrp_response_token_lengths
@@ -5387,6 +5413,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_resync_prefix
     protocol/dmr/test_dmr_lrrp_resync_prefix.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
 target_include_directories(
     dsd-neo_test_dmr_lrrp_resync_prefix
@@ -5410,6 +5437,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_position_token_precedence
     protocol/dmr/test_dmr_lrrp_position_token_precedence.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
 target_include_directories(
     dsd-neo_test_dmr_lrrp_position_token_precedence
@@ -5434,6 +5462,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_crc_gating
     protocol/dmr/test_dmr_lrrp_crc_gating.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
 target_include_directories(
     dsd-neo_test_dmr_lrrp_crc_gating
@@ -5455,6 +5484,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_ip_udp_lengths
     protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
 target_include_directories(
     dsd-neo_test_dmr_lrrp_ip_udp_lengths
@@ -5497,6 +5527,7 @@ add_executable(
     dsd-neo_test_dmr_locn_time_fallback
     protocol/dmr/test_dmr_locn_time_fallback.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
 target_include_directories(
     dsd-neo_test_dmr_locn_time_fallback

--- a/tests/core/test_core_audio_input_rate.c
+++ b/tests/core/test_core_audio_input_rate.c
@@ -573,12 +573,10 @@ test_open_audio_in_device_extensionless_raw_uses_headless_rate(void) {
     rc |= expect_int_eq("extensionless raw clears throttle", state->use_throttle, 0);
     rc |= expect_true("extensionless raw clears replay deadline", state->symbol_replay_next_deadline_ns == 0);
 
-    if (opts->audio_in_file) {
-        sf_close(opts->audio_in_file);
-        opts->audio_in_file = NULL;
-    }
-    free(opts->audio_in_file_info);
-    opts->audio_in_file_info = NULL;
+    closeAudioInDevice(opts);
+    rc |= expect_true("device close releases extensionless raw file", opts->audio_in_file == NULL);
+    rc |= expect_true("device close releases extensionless raw metadata", opts->audio_in_file_info == NULL);
+    closeAudioInDevice(opts);
     free(state);
     free_opts(opts);
     (void)remove(path);

--- a/tests/core/test_core_audio_input_rate.c
+++ b/tests/core/test_core_audio_input_rate.c
@@ -12,14 +12,40 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if !DSD_PLATFORM_WIN_NATIVE
+#include <sys/socket.h>
+#endif
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/dsp/resampler.h"
 #include "dsd-neo/platform/file_compat.h"
+#include "dsd-neo/platform/platform.h"
 #include "dsd-neo/platform/posix_compat.h"
+#include "dsd-neo/platform/sockets.h"
+#include "dsd-neo/runtime/net_audio_input_hooks.h"
 #include "test_support.h"
+
+static tcp_input_ctx* g_expected_tcp_input_ctx = NULL;
+static dsd_socket_t g_expected_tcp_sockfd = DSD_INVALID_SOCKET;
+static int g_tcp_input_open_calls = 0;
+static int g_tcp_input_close_calls = 0;
+
+static tcp_input_ctx*
+test_tcp_input_open(dsd_socket_t sockfd, int samplerate) {
+    if (sockfd == g_expected_tcp_sockfd && samplerate == 48000) {
+        g_tcp_input_open_calls++;
+    }
+    return g_expected_tcp_input_ctx;
+}
+
+static void
+test_tcp_input_close(tcp_input_ctx* ctx) {
+    if (ctx == g_expected_tcp_input_ctx) {
+        g_tcp_input_close_calls++;
+    }
+}
 
 static int
 expect_true(const char* label, int cond) {
@@ -55,7 +81,11 @@ alloc_state(void) {
 
 static dsd_opts*
 alloc_opts(void) {
-    return (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    if (opts) {
+        opts->tcp_sockfd = DSD_INVALID_SOCKET;
+    }
+    return opts;
 }
 
 static void
@@ -584,6 +614,73 @@ test_open_audio_in_device_extensionless_raw_uses_headless_rate(void) {
 }
 
 static int
+test_tcp_input_open_and_close_socket_ownership(void) {
+    if (dsd_socket_init() != 0) {
+        DSD_FPRINTF(stderr, "FAIL: socket init\n");
+        return 1;
+    }
+
+    dsd_socket_t sockfd = dsd_socket_create(AF_INET, SOCK_STREAM, 0);
+    if (sockfd == DSD_INVALID_SOCKET) {
+        DSD_FPRINTF(stderr, "FAIL: TCP socket create\n");
+        dsd_socket_cleanup();
+        return 1;
+    }
+
+    dsd_opts* opts = alloc_opts();
+    if (!opts) {
+        DSD_FPRINTF(stderr, "FAIL: alloc opts\n");
+        dsd_socket_close(sockfd);
+        dsd_socket_cleanup();
+        return 1;
+    }
+    dsd_state* state = alloc_state();
+    if (!state) {
+        DSD_FPRINTF(stderr, "FAIL: alloc state\n");
+        free_opts(opts);
+        dsd_socket_close(sockfd);
+        dsd_socket_cleanup();
+        return 1;
+    }
+
+    int fake_tcp_input_ctx = 0;
+    g_expected_tcp_input_ctx = (tcp_input_ctx*)&fake_tcp_input_ctx;
+    g_expected_tcp_sockfd = sockfd;
+    g_tcp_input_open_calls = 0;
+    g_tcp_input_close_calls = 0;
+    dsd_net_audio_input_hooks_set(
+        (dsd_net_audio_input_hooks){.tcp_open = test_tcp_input_open, .tcp_close = test_tcp_input_close});
+
+    opts->audio_in_type = AUDIO_IN_TCP;
+    opts->tcp_sockfd = sockfd;
+    opts->wav_sample_rate = 48000;
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "tcp:127.0.0.1:7355");
+
+    int rc = expect_int_eq("TCP input opens with staged socket", openAudioInDevice(opts, state), 0);
+    rc |= expect_int_eq("TCP input wrapper receives staged socket", g_tcp_input_open_calls, 1);
+    rc |= expect_true("TCP input open preserves socket ownership", opts->tcp_sockfd == sockfd);
+    rc |= expect_true("TCP input socket remains open", dsd_socket_set_recv_timeout(sockfd, 1) == 0);
+    rc |= expect_true("TCP input open stores wrapper context", opts->tcp_in_ctx == g_expected_tcp_input_ctx);
+
+    closeAudioInDevice(opts);
+    rc |= expect_int_eq("device close releases TCP input context once", g_tcp_input_close_calls, 1);
+    rc |= expect_true("device close clears TCP input context", opts->tcp_in_ctx == NULL);
+    rc |= expect_true("device close invalidates TCP socket", opts->tcp_sockfd == DSD_INVALID_SOCKET);
+    rc |= expect_true("device close closes TCP socket descriptor", dsd_socket_close(sockfd) != 0);
+
+    closeAudioInDevice(opts);
+    rc |= expect_int_eq("repeated device close does not re-close TCP input context", g_tcp_input_close_calls, 1);
+
+    dsd_net_audio_input_hooks_set((dsd_net_audio_input_hooks){0});
+    g_expected_tcp_input_ctx = NULL;
+    g_expected_tcp_sockfd = DSD_INVALID_SOCKET;
+    free(state);
+    free_opts(opts);
+    dsd_socket_cleanup();
+    return rc;
+}
+
+static int
 test_headerless_wav_suffix_falls_back_to_raw_pcm(void) {
     const short samples[] = {1234, -2345, 3456, -4567};
     char path[DSD_TEST_PATH_MAX] = {0};
@@ -886,6 +983,7 @@ main(void) {
     rc |= test_source_effective_input_rate_classifier();
     rc |= test_current_input_timing_rate_prefers_active_backend();
     rc |= test_open_audio_in_device_extensionless_raw_uses_headless_rate();
+    rc |= test_tcp_input_open_and_close_socket_ownership();
     rc |= test_headerless_wav_suffix_falls_back_to_raw_pcm();
     rc |= test_rifx_wav_suffix_uses_container_metadata();
     rc |= test_rf64_wav_suffix_uses_container_metadata();

--- a/tests/core/test_core_audio_input_rate.c
+++ b/tests/core/test_core_audio_input_rate.c
@@ -31,6 +31,7 @@ static tcp_input_ctx* g_expected_tcp_input_ctx = NULL;
 static dsd_socket_t g_expected_tcp_sockfd = DSD_INVALID_SOCKET;
 static int g_tcp_input_open_calls = 0;
 static int g_tcp_input_close_calls = 0;
+static int g_tcp_input_ctx_sentinel = 0;
 
 static tcp_input_ctx*
 test_tcp_input_open(dsd_socket_t sockfd, int samplerate) {
@@ -643,8 +644,7 @@ test_tcp_input_open_and_close_socket_ownership(void) {
         return 1;
     }
 
-    int fake_tcp_input_ctx = 0;
-    g_expected_tcp_input_ctx = (tcp_input_ctx*)&fake_tcp_input_ctx;
+    g_expected_tcp_input_ctx = (tcp_input_ctx*)&g_tcp_input_ctx_sentinel;
     g_expected_tcp_sockfd = sockfd;
     g_tcp_input_open_calls = 0;
     g_tcp_input_close_calls = 0;

--- a/tests/core/test_core_init_state.c
+++ b/tests/core/test_core_init_state.c
@@ -89,6 +89,10 @@ main(void) {
     state->ess_b[0][95] = 1;
     state->ess_b_llr[1][95] = 123;
     state->fourv_counter[0] = 2;
+    state->data_header_dd_format[0] = 0x16U;
+    state->data_header_dd_format[1] = 0x18U;
+    state->data_header_bit_padding[0] = 16U;
+    state->data_header_bit_padding[1] = 7U;
     state->p25_p1_soft_hamming_ok = 77U;
     state->p25_last_cc_msg_time = 1234567890;
     state->p25_last_cc_msg_time_m = 12345.5;
@@ -249,6 +253,13 @@ main(void) {
         freeState(state);
         free(state);
         return 12;
+    }
+    if (state->data_header_dd_format[0] != 0U || state->data_header_dd_format[1] != 0U
+        || state->data_header_bit_padding[0] != 0U || state->data_header_bit_padding[1] != 0U) {
+        DSD_FPRINTF(stderr, "initState did not clear transient DMR short-data metadata\n");
+        freeState(state);
+        free(state);
+        return 28;
     }
     if (state->p25_last_cc_msg_time != 0 || !isfinite(state->p25_last_cc_msg_time_m)
         || fabs(state->p25_last_cc_msg_time_m) > 1e-12) {

--- a/tests/engine/test_engine_cleanup_audio.c
+++ b/tests/engine/test_engine_cleanup_audio.c
@@ -8,6 +8,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/engine/engine.h>
 #include <dsd-neo/platform/audio.h>
+#include <sndfile.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "../../src/platform/audio_stream_internal.h"
@@ -76,6 +77,8 @@ main(void) {
     opts->audio_out_streamR = (dsd_audio_stream*)calloc(1, sizeof(*opts->audio_out_streamR));
     opts->audio_raw_out = (dsd_audio_stream*)calloc(1, sizeof(*opts->audio_raw_out));
     opts->audio_in_stream = (dsd_audio_stream*)calloc(1, sizeof(*opts->audio_in_stream));
+    // File input metadata outlives its libsndfile handle when playback reaches EOF.
+    opts->audio_in_file_info = (SF_INFO*)calloc(1, sizeof(*opts->audio_in_file_info));
 
     dsd_engine_cleanup(opts, state);
 
@@ -83,6 +86,7 @@ main(void) {
     rc |= expect_true("audio_out_streamR-null", opts->audio_out_streamR == NULL);
     rc |= expect_true("audio_raw_out-null", opts->audio_raw_out == NULL);
     rc |= expect_true("audio_in_stream-null", opts->audio_in_stream == NULL);
+    rc |= expect_true("audio_in_file_info-null", opts->audio_in_file_info == NULL);
 
     free_test_runtime(opts, state);
     opts = NULL;

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -304,6 +304,10 @@ main(void) {
     state->p25_crypto_state[1] = DSD_P25_CRYPTO_DECRYPTABLE;
     state->p25_p2_audio_allowed[0] = 1;
     state->p25_p2_audio_allowed[1] = 1;
+    state->data_header_dd_format[0] = 0x16U;
+    state->data_header_dd_format[1] = 0x18U;
+    state->data_header_bit_padding[0] = 16U;
+    state->data_header_bit_padding[1] = 7U;
 
     noCarrier(opts, state);
 
@@ -322,6 +326,9 @@ main(void) {
                                                         && state->p25_crypto_state[1] == DSD_P25_CRYPTO_UNKNOWN);
     rc |= expect_true("p25-crypto-audio-gates-reset",
                       state->p25_p2_audio_allowed[0] == 0 && state->p25_p2_audio_allowed[1] == 0);
+    rc |= expect_true("dmr-short-data-metadata-reset",
+                      state->data_header_dd_format[0] == 0U && state->data_header_dd_format[1] == 0U
+                          && state->data_header_bit_padding[0] == 0U && state->data_header_bit_padding[1] == 0U);
 
     for (int i = 0; i < 200; i++) {
         if (state->dmr_payload_buf[i] != 0) {

--- a/tests/protocol/dmr/test_dmr_bs_sync_times.c
+++ b/tests/protocol/dmr/test_dmr_bs_sync_times.c
@@ -51,6 +51,7 @@ static unsigned int g_ui_redraw_calls;
 static unsigned int g_history_calls[2];
 static unsigned int g_current_calls[2];
 static unsigned int g_data_sync_calls;
+static uint8_t g_data_sync_reliability[144];
 static unsigned int g_data_burst_calls;
 static uint8_t g_data_burst_last;
 static unsigned int g_debug_dump_calls;
@@ -94,6 +95,7 @@ reset_spies(void) {
     g_current_calls[0] = 0;
     g_current_calls[1] = 0;
     g_data_sync_calls = 0;
+    DSD_MEMSET(g_data_sync_reliability, 0, sizeof(g_data_sync_reliability));
     g_data_burst_calls = 0;
     g_data_burst_last = 0;
     g_debug_dump_calls = 0;
@@ -183,6 +185,24 @@ get_dibit_and_analog_signal(dsd_opts* opts, dsd_state* state, int* out_analog_si
     (void)out_analog_signal;
     if (g_dibit_index >= sizeof(g_dibits)) {
         return 0;
+    }
+    return g_dibits[g_dibit_index++] & 0x3U;
+}
+
+int
+getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
+    (void)opts;
+    (void)state;
+    if (g_dibit_index >= sizeof(g_dibits)) {
+        if (out_soft != NULL) {
+            DSD_MEMSET(out_soft, 0, sizeof(*out_soft));
+        }
+        return 0;
+    }
+    if (out_soft != NULL) {
+        out_soft->reliability = (uint8_t)((g_dibit_index % 251U) + 1U);
+        out_soft->llr[0] = 0;
+        out_soft->llr[1] = 0;
     }
     return g_dibits[g_dibit_index++] & 0x3U;
 }
@@ -315,7 +335,7 @@ csi72_ambe2_codeword_keystream(dsd_state* state, char ambe_fr[4][24]) {
 void
 dmr_data_sync(dsd_opts* opts, dsd_state* state) {
     (void)opts;
-    (void)state;
+    DSD_MEMCPY(g_data_sync_reliability, state->dmr_stereo_reliab, sizeof(g_data_sync_reliability));
     g_data_sync_calls++;
 }
 
@@ -567,6 +587,10 @@ test_bs_data_sync_closes_slot_file_and_resets_error_state(void) {
     dmrBS(&opts, &state);
 
     assert(g_data_sync_calls == 1U);
+    assert(g_data_sync_reliability[0] == 1U);
+    assert(g_data_sync_reliability[60] == 61U);
+    assert(g_data_sync_reliability[95] == 96U);
+    assert(g_data_sync_reliability[143] == 144U);
     assert(g_close_right_calls == 1U);
     assert(opts.mbe_out_fR == NULL);
     assert(g_process_mbe_calls == 0U);

--- a/tests/protocol/dmr/test_dmr_data_sync.c
+++ b/tests/protocol/dmr/test_dmr_data_sync.c
@@ -33,8 +33,8 @@ static int g_reset_calls;
 static int g_skip_calls;
 static int g_handler_slot;
 static int g_live_dibit_index;
-static int g_live_symbols[64];
 static int g_live_dibits[64];
+static uint8_t g_live_reliability[64];
 static int g_cach_calls;
 static int g_debug_format_calls;
 static uint8_t g_handler_burst;
@@ -61,8 +61,8 @@ reset_fixture(void) {
     g_handler_burst = 0;
     g_confidence_result = DMR_CONFIDENCE_LOCKED;
     for (size_t i = 0; i < 64U; i++) {
-        g_live_symbols[i] = 0;
         g_live_dibits[i] = 0;
+        g_live_reliability[i] = 0;
     }
     DSD_MEMSET(g_handler_info, 0, sizeof(g_handler_info));
     DSD_MEMSET(g_handler_reliab, 0, sizeof(g_handler_reliab));
@@ -99,15 +99,17 @@ Golay_20_8_decode(unsigned char* rx_bits) {
 
 int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-get_dibit_and_analog_signal(dsd_opts* opts, dsd_state* state, int* out_analog_signal) {
+getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
     (void)opts;
     (void)state;
     int index = g_live_dibit_index;
     if (index >= (int)(sizeof(g_live_dibits) / sizeof(g_live_dibits[0]))) {
         index = (int)(sizeof(g_live_dibits) / sizeof(g_live_dibits[0])) - 1;
     }
-    if (out_analog_signal != NULL) {
-        *out_analog_signal = g_live_symbols[index];
+    if (out_soft != NULL) {
+        out_soft->reliability = g_live_reliability[index];
+        out_soft->llr[0] = (int16_t)g_live_reliability[index];
+        out_soft->llr[1] = (int16_t)g_live_reliability[index];
     }
     g_live_dibit_index++;
     return g_live_dibits[index] & 3;
@@ -216,10 +218,10 @@ prepare_state(dsd_state* state, int payload[90], dsd_dibit_soft_t soft[90]) {
 }
 
 static void
-prepare_live_symbols(int symbol, int dibit) {
+prepare_live_symbols(uint8_t reliability, int dibit) {
     for (size_t i = 0; i < 64U; i++) {
-        g_live_symbols[i] = symbol;
         g_live_dibits[i] = dibit;
+        g_live_reliability[i] = reliability;
     }
 }
 
@@ -247,8 +249,8 @@ test_data_sync_dispatches_burst_and_reliability(void) {
     assert(state.dmrburstR == 7U);
     assert(strcmp(state.slot1light, " slot1 ") == 0);
     assert(strcmp(state.slot2light, "[slot2]") == 0);
-    assert(g_handler_reliab[0] == reliab[12].reliability);
-    assert(g_handler_reliab[48] == reliab[60].reliability);
+    assert(g_handler_reliab[0] == state.dmr_stereo_reliab[12]);
+    assert(g_handler_reliab[48] == state.dmr_stereo_reliab[60]);
     assert(g_handler_reliab[49] == state.dmr_stereo_reliab[95]);
     assert(g_handler_reliab[97] == state.dmr_stereo_reliab[143]);
     assert(g_cach_calls == 1);
@@ -289,7 +291,7 @@ test_golay_failure_resets_and_skips_live_tail(void) {
     state.center = 20;
     state.umid = 30;
     state.max = 40;
-    prepare_live_symbols(40, 3);
+    prepare_live_symbols(40U, 3);
 
     dmr_data_sync(&opts, &state);
 
@@ -316,14 +318,17 @@ test_live_second_half_reliability_and_debug_output(void) {
     state.umid = 30;
     state.max = 40;
     opts.dmr_debug_burst = 1;
-    prepare_live_symbols(40, 3);
+    prepare_live_symbols(173U, 3);
 
     dmr_data_sync(&opts, &state);
 
     assert(g_handler_calls == 1);
     assert(g_handler_burst == 7U);
-    assert(g_handler_reliab[49] == 255U);
-    assert(g_handler_reliab[97] == 255U);
+    assert(g_handler_reliab[49] == 173U);
+    assert(g_handler_reliab[97] == 173U);
+    assert(state.dmr_stereo_reliab[90] == 173U);
+    assert(state.dmr_stereo_reliab[95] == 173U);
+    assert(state.dmr_stereo_reliab[143] == 173U);
     assert(g_skip_calls == 66);
     assert(g_live_dibit_index == 54);
     assert(g_debug_format_calls == 1);
@@ -331,7 +336,7 @@ test_live_second_half_reliability_and_debug_output(void) {
 }
 
 static uint8_t
-run_live_reliability_symbol(int symbol) {
+run_live_reliability(uint8_t reliability) {
     static dsd_opts opts;
     static dsd_state state;
     static int payload[90];
@@ -345,7 +350,7 @@ run_live_reliability_symbol(int symbol) {
     state.center = 20;
     state.umid = 30;
     state.max = 40;
-    prepare_live_symbols(symbol, 3);
+    prepare_live_symbols(reliability, 3);
 
     dmr_data_sync(&opts, &state);
 
@@ -355,10 +360,10 @@ run_live_reliability_symbol(int symbol) {
 }
 
 static void
-test_live_reliability_interpolation_bands(void) {
-    assert(run_live_reliability_symbol(25) == 255U);
-    assert(run_live_reliability_symbol(15) == 255U);
-    assert(run_live_reliability_symbol(5) == 127U);
+test_live_reliability_is_forwarded_unscaled(void) {
+    assert(run_live_reliability(25U) == 25U);
+    assert(run_live_reliability(128U) == 128U);
+    assert(run_live_reliability(241U) == 241U);
 }
 
 static void
@@ -402,7 +407,7 @@ test_confidence_pending_and_reject_gate_dispatch(void) {
     state.center = 20;
     state.umid = 30;
     state.max = 40;
-    prepare_live_symbols(40, 3);
+    prepare_live_symbols(40U, 3);
     g_confidence_result = DMR_CONFIDENCE_PENDING;
 
     dmr_data_sync(&opts, &state);
@@ -463,7 +468,7 @@ main(void) {
     test_cach_failure_resets_without_dispatch();
     test_golay_failure_resets_and_skips_live_tail();
     test_live_second_half_reliability_and_debug_output();
-    test_live_reliability_interpolation_bands();
+    test_live_reliability_is_forwarded_unscaled();
     test_direct_mode_sync_overrides_cach_slot();
     test_confidence_pending_and_reject_gate_dispatch();
     test_connect_plus_idle_bursts_clear_tuned_sync_times();

--- a/tests/protocol/dmr/test_dmr_dburst_profile.c
+++ b/tests/protocol/dmr/test_dmr_dburst_profile.c
@@ -44,6 +44,7 @@ static int g_r34_soft_status;
 static int g_r34_hard_status;
 static int g_r34_list_status;
 static int g_r34_list_count;
+static int g_r34_list_calls;
 static int g_r34_hard_metric;
 static int g_r34_soft_metric;
 static uint8_t g_r34_soft_bytes[18];
@@ -74,6 +75,7 @@ reset_handler_counters(void) {
     g_r34_hard_status = 0;
     g_r34_list_status = -1;
     g_r34_list_count = 0;
+    g_r34_list_calls = 0;
     g_r34_hard_metric = 100;
     g_r34_soft_metric = 50;
     DSD_MEMSET(g_r34_soft_bytes, 0, sizeof(g_r34_soft_bytes));
@@ -177,6 +179,7 @@ dmr_r34_viterbi_decode_list(const uint8_t* dibits, const uint8_t* reliab, dmr_r3
                             int* out_count) {
     (void)dibits;
     (void)reliab;
+    g_r34_list_calls++;
     if (out != NULL && max_candidates > 0) {
         int count = g_r34_list_count;
         if (count > max_candidates) {
@@ -612,6 +615,7 @@ test_trellis_candidate_and_fallback_paths(void) {
     write_confirmed_crc9_bytes(g_r34_candidates[1].bytes18, 9U, 0x1FFU);
     dmr_data_burst_handler(&opts, &state, info, 0x08U, reliab);
     rc |= expect_u8("r34c-list-crc-records-pass", state.data_block_crc_valid[1][6], 1U);
+    rc |= expect_u8("r34c-list-decoder-used", (uint8_t)g_r34_list_calls, 1U);
     rc |= expect_u8("r34c-list-updates-dbsn", state.data_dbsn_expected[1], 10U);
     rc |= expect_u8("r34c-list-dispatches", (uint8_t)g_block_assembler_calls, 1U);
     rc |= expect_u8("r34c-list-block-len", g_block_assembler_last_len, 16U);
@@ -620,6 +624,7 @@ test_trellis_candidate_and_fallback_paths(void) {
     DSD_MEMSET(reliab, 13, sizeof(reliab));
     g_r34_soft_bytes[2] = 0xA5U;
     dmr_data_burst_handler(&opts, &state, info, 0x08U, reliab);
+    rc |= expect_u8("r34u-soft-skips-list-decoder", (uint8_t)g_r34_list_calls, 0U);
     rc |= expect_u8("r34u-soft-fallback-dispatches", (uint8_t)g_block_assembler_calls, 1U);
     rc |= expect_u8("r34u-soft-fallback-len", g_block_assembler_last_len, 18U);
     rc |= expect_u8("r34u-soft-fallback-payload", g_block_assembler_last_bytes[2], 0xA5U);

--- a/tests/protocol/dmr/test_dmr_dburst_profile.c
+++ b/tests/protocol/dmr/test_dmr_dburst_profile.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "dmr_dburst_profile.h"
+#include "dmr_r34_internal.h"
 #include "dsd-neo/core/safe_api.h"
 
 static int g_pi_calls;
@@ -43,6 +44,8 @@ static int g_r34_soft_status;
 static int g_r34_hard_status;
 static int g_r34_list_status;
 static int g_r34_list_count;
+static int g_r34_hard_metric;
+static int g_r34_soft_metric;
 static uint8_t g_r34_soft_bytes[18];
 static uint8_t g_r34_hard_bytes[18];
 static dmr_r34_candidate g_r34_candidates[4];
@@ -71,6 +74,8 @@ reset_handler_counters(void) {
     g_r34_hard_status = 0;
     g_r34_list_status = -1;
     g_r34_list_count = 0;
+    g_r34_hard_metric = 100;
+    g_r34_soft_metric = 50;
     DSD_MEMSET(g_r34_soft_bytes, 0, sizeof(g_r34_soft_bytes));
     DSD_MEMSET(g_r34_hard_bytes, 0, sizeof(g_r34_hard_bytes));
     DSD_MEMSET(g_r34_candidates, 0, sizeof(g_r34_candidates));
@@ -183,6 +188,32 @@ dmr_r34_viterbi_decode_list(const uint8_t* dibits, const uint8_t* reliab, dmr_r3
         *out_count = g_r34_list_count;
     }
     return g_r34_list_status;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_r34_candidate_metric(const uint8_t* dibits, const uint8_t* reliab, const uint8_t bytes18[18], int* out_metric) {
+    (void)dibits;
+    (void)reliab;
+    if (bytes18 == NULL || out_metric == NULL) {
+        return -1;
+    }
+    if (memcmp(bytes18, g_r34_hard_bytes, 18U) == 0) {
+        *out_metric = g_r34_hard_metric;
+        return 0;
+    }
+    if (memcmp(bytes18, g_r34_soft_bytes, 18U) == 0) {
+        *out_metric = g_r34_soft_metric;
+        return 0;
+    }
+    for (int i = 0; i < g_r34_list_count; i++) {
+        if (memcmp(bytes18, g_r34_candidates[i].bytes18, 18U) == 0) {
+            *out_metric = g_r34_candidates[i].metric;
+            return 0;
+        }
+    }
+    *out_metric = 1000;
+    return 0;
 }
 
 void
@@ -402,6 +433,7 @@ test_handler_dispatch_paths(void) {
     static dsd_opts opts;
     static dsd_state state;
     uint8_t info[196];
+    uint8_t reliab[98];
 
     prepare_handler_state(&opts, &state, info, 0x03U, 0U, 1U, 0);
     dmr_data_burst_handler(&opts, &state, info, 0x03U, NULL);
@@ -437,13 +469,14 @@ test_handler_dispatch_paths(void) {
     rc |= expect_u8("udtc-block-len", g_block_assembler_last_len, 10U);
 
     prepare_handler_state(&opts, &state, info, 0x08U, 0U, 1U, AUDIO_IN_SYMBOL_BIN);
+    DSD_MEMSET(reliab, 17, sizeof(reliab));
     g_r34_hard_bytes[0] = 0x42U;
     g_r34_soft_bytes[0] = 0x99U;
-    dmr_data_burst_handler(&opts, &state, info, 0x08U, NULL);
+    dmr_data_burst_handler(&opts, &state, info, 0x08U, reliab);
     rc |= expect_u8("r34u-block-call", (uint8_t)g_block_assembler_calls, 1U);
     rc |= expect_u8("r34u-block-burst", g_block_assembler_last_burst, 0x08U);
     rc |= expect_u8("r34u-block-len", g_block_assembler_last_len, 18U);
-    rc |= expect_u8("r34u-symbol-replay-uses-canonical-hard-decoder", g_block_assembler_last_bytes[0], 0x42U);
+    rc |= expect_u8("r34u-symbol-replay-uses-unified-soft-candidate", g_block_assembler_last_bytes[0], 0x99U);
 
     prepare_handler_state(&opts, &state, info, 0x0AU, 0U, 1U, 0);
     dmr_data_burst_handler(&opts, &state, info, 0x0AU, NULL);
@@ -590,6 +623,41 @@ test_trellis_candidate_and_fallback_paths(void) {
     rc |= expect_u8("r34u-soft-fallback-dispatches", (uint8_t)g_block_assembler_calls, 1U);
     rc |= expect_u8("r34u-soft-fallback-len", g_block_assembler_last_len, 18U);
     rc |= expect_u8("r34u-soft-fallback-payload", g_block_assembler_last_bytes[2], 0xA5U);
+
+    prepare_handler_state(&opts, &state, info, 0x08U, 1U, 1U, 0);
+    state.data_dbsn_have[1] = 1U;
+    state.data_dbsn_expected[1] = 9U;
+    state.data_block_counter[1] = 7U;
+    DSD_MEMSET(reliab, 19, sizeof(reliab));
+    write_confirmed_crc9_bytes(g_r34_hard_bytes, 9U, 0x1FFU);
+    g_r34_hard_bytes[2] = 0xA1U;
+    g_r34_hard_metric = 120;
+    write_confirmed_crc9_bytes(g_r34_soft_bytes, 9U, 0U);
+    g_r34_soft_bytes[2] = 0xB2U;
+    g_r34_soft_metric = 1;
+    g_r34_list_status = 0;
+    g_r34_list_count = 1;
+    write_confirmed_crc9_bytes(g_r34_candidates[0].bytes18, 9U, 0U);
+    g_r34_candidates[0].bytes18[2] = 0xC3U;
+    g_r34_candidates[0].metric = 0;
+    dmr_data_burst_handler(&opts, &state, info, 0x08U, reliab);
+    rc |= expect_u8("r34c-valid-hard-candidate-crc", state.data_block_crc_valid[1][7], 1U);
+    rc |= expect_u8("r34c-valid-hard-candidate-retained", g_block_assembler_last_bytes[0], 0xA1U);
+
+    prepare_handler_state(&opts, &state, info, 0x08U, 1U, 1U, 0);
+    state.data_dbsn_have[1] = 1U;
+    state.data_dbsn_expected[1] = 9U;
+    state.data_block_counter[1] = 8U;
+    DSD_MEMSET(reliab, 23, sizeof(reliab));
+    write_confirmed_crc9_bytes(g_r34_hard_bytes, 9U, 0U);
+    g_r34_hard_bytes[2] = 0xD1U;
+    g_r34_hard_metric = 1;
+    write_confirmed_crc9_bytes(g_r34_soft_bytes, 3U, 0x1FFU);
+    g_r34_soft_bytes[2] = 0xD2U;
+    g_r34_soft_metric = 200;
+    dmr_data_burst_handler(&opts, &state, info, 0x08U, reliab);
+    rc |= expect_u8("r34c-crc-valid-outranks-expected-dbsn", g_block_assembler_last_bytes[0], 0xD2U);
+    rc |= expect_u8("r34c-nonexpected-valid-crc-recorded", state.data_block_crc_valid[1][8], 1U);
     return rc;
 }
 

--- a/tests/protocol/dmr/test_dmr_discussion_231.c
+++ b/tests/protocol/dmr/test_dmr_discussion_231.c
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Compact protocol fixture derived from the 12.5 kHz WAV attached to
+ * GitHub Discussion #231. The source recording is intentionally not vendored.
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
+#include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "dmr_text.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+typedef struct {
+    uint8_t dibits[98];
+    uint8_t reliability[98];
+} discussion_231_r34_block;
+
+static const discussion_231_r34_block k_blocks[5] = {
+    {
+        {
+            0U, 2U, 0U, 1U, 0U, 1U, 0U, 2U, 0U, 3U, 3U, 2U, 0U, 1U, 0U, 2U, 0U, 2U, 0U, 2U, 3U, 1U, 0U, 2U, 3U,
+            2U, 0U, 2U, 0U, 3U, 3U, 3U, 3U, 1U, 0U, 2U, 1U, 3U, 0U, 0U, 0U, 2U, 0U, 2U, 2U, 2U, 3U, 2U, 3U, 1U,
+            3U, 2U, 0U, 2U, 2U, 2U, 2U, 3U, 0U, 2U, 0U, 2U, 2U, 2U, 1U, 3U, 0U, 2U, 3U, 3U, 0U, 2U, 2U, 3U, 3U,
+            0U, 0U, 2U, 0U, 2U, 1U, 1U, 2U, 3U, 0U, 2U, 1U, 3U, 3U, 3U, 2U, 3U, 0U, 2U, 0U, 2U, 0U, 0U,
+        },
+        {
+            174U, 111U, 194U, 203U, 160U, 141U, 156U, 184U, 186U, 126U, 200U, 120U, 171U, 169U, 131U, 154U, 169U,
+            198U, 131U, 148U, 200U, 121U, 167U, 190U, 168U, 116U, 198U, 180U, 181U, 132U, 192U, 189U, 180U, 77U,
+            73U,  105U, 203U, 176U, 173U, 136U, 139U, 153U, 182U, 188U, 151U, 193U, 184U, 149U, 146U, 203U, 165U,
+            125U, 171U, 200U, 196U, 138U, 167U, 203U, 185U, 143U, 174U, 128U, 144U, 58U,  203U, 196U, 184U, 167U,
+            103U, 203U, 164U, 200U, 196U, 176U, 192U, 87U,  137U, 153U, 188U, 164U, 169U, 193U, 104U, 203U, 200U,
+            116U, 203U, 184U, 133U, 203U, 160U, 203U, 192U, 157U, 199U, 171U, 179U, 185U,
+        },
+    },
+    {
+        {
+            0U, 2U, 0U, 2U, 0U, 1U, 0U, 2U, 0U, 2U, 3U, 1U, 0U, 1U, 0U, 2U, 1U, 3U, 0U, 2U, 0U, 1U, 0U, 2U, 2U,
+            2U, 0U, 2U, 3U, 3U, 0U, 0U, 0U, 2U, 0U, 2U, 0U, 3U, 3U, 0U, 3U, 1U, 0U, 2U, 2U, 2U, 0U, 0U, 3U, 1U,
+            2U, 3U, 0U, 2U, 3U, 3U, 1U, 3U, 0U, 2U, 0U, 2U, 2U, 2U, 1U, 0U, 0U, 2U, 3U, 3U, 2U, 2U, 0U, 2U, 3U,
+            2U, 0U, 2U, 2U, 2U, 3U, 3U, 2U, 3U, 0U, 2U, 2U, 2U, 3U, 3U, 2U, 3U, 0U, 2U, 1U, 3U, 2U, 3U,
+        },
+        {
+            193U, 157U, 124U, 196U, 127U, 160U, 166U, 189U, 124U, 119U, 203U, 127U, 172U, 157U, 102U, 98U,  203U,
+            185U, 164U, 172U, 178U, 172U, 142U, 164U, 185U, 151U, 178U, 200U, 141U, 203U, 170U, 153U, 137U, 133U,
+            200U, 176U, 164U, 107U, 203U, 184U, 172U, 137U, 167U, 176U, 125U, 202U, 126U, 180U, 134U, 203U, 150U,
+            203U, 161U, 172U, 95U,  203U, 203U, 196U, 201U, 129U, 168U, 131U, 164U, 96U,  199U, 199U, 184U, 188U,
+            141U, 203U, 166U, 160U, 173U, 184U, 171U, 114U, 184U, 202U, 180U, 158U, 130U, 203U, 195U, 195U, 139U,
+            197U, 189U, 151U, 121U, 203U, 178U, 203U, 188U, 94U,  203U, 203U, 186U, 203U,
+        },
+    },
+    {
+        {
+            0U, 2U, 2U, 2U, 3U, 1U, 0U, 2U, 0U, 2U, 0U, 2U, 0U, 1U, 0U, 2U, 1U, 2U, 2U, 2U, 0U, 1U, 0U, 2U, 0U,
+            2U, 3U, 1U, 3U, 3U, 2U, 0U, 0U, 2U, 0U, 2U, 2U, 2U, 3U, 0U, 3U, 1U, 0U, 2U, 0U, 2U, 1U, 2U, 0U, 2U,
+            3U, 2U, 3U, 3U, 1U, 2U, 1U, 3U, 0U, 2U, 3U, 3U, 0U, 3U, 0U, 2U, 0U, 2U, 0U, 2U, 3U, 2U, 1U, 3U, 2U,
+            0U, 0U, 2U, 0U, 2U, 3U, 3U, 2U, 3U, 0U, 2U, 0U, 2U, 1U, 0U, 3U, 2U, 0U, 2U, 2U, 2U, 3U, 3U,
+        },
+        {
+            156U, 86U,  176U, 168U, 203U, 74U,  114U, 175U, 192U, 188U, 174U, 173U, 173U, 158U, 102U, 112U, 194U,
+            203U, 194U, 139U, 161U, 193U, 173U, 196U, 97U,  108U, 203U, 162U, 123U, 203U, 125U, 160U, 175U, 184U,
+            149U, 167U, 123U, 158U, 203U, 192U, 178U, 126U, 122U, 157U, 201U, 125U, 203U, 139U, 157U, 169U, 164U,
+            95U,  93U,  203U, 203U, 124U, 203U, 203U, 202U, 141U, 86U,  203U, 170U, 200U, 183U, 153U, 183U, 149U,
+            186U, 172U, 122U, 50U,  203U, 163U, 157U, 117U, 145U, 149U, 189U, 188U, 125U, 203U, 184U, 203U, 189U,
+            151U, 188U, 148U, 172U, 160U, 139U, 97U,  183U, 195U, 166U, 179U, 147U, 203U,
+        },
+    },
+    {
+        {
+            0U, 2U, 3U, 3U, 0U, 1U, 0U, 2U, 0U, 3U, 3U, 2U, 0U, 1U, 0U, 2U, 0U, 2U, 3U, 2U, 0U, 1U, 0U, 2U, 1U,
+            2U, 3U, 1U, 2U, 2U, 3U, 0U, 3U, 1U, 0U, 2U, 3U, 3U, 3U, 0U, 0U, 2U, 0U, 2U, 0U, 2U, 2U, 1U, 3U, 1U,
+            3U, 1U, 0U, 2U, 0U, 3U, 2U, 3U, 0U, 2U, 0U, 2U, 0U, 3U, 1U, 3U, 0U, 2U, 3U, 3U, 1U, 3U, 0U, 2U, 3U,
+            1U, 0U, 2U, 0U, 2U, 1U, 1U, 1U, 0U, 0U, 2U, 0U, 2U, 3U, 3U, 2U, 3U, 0U, 2U, 2U, 2U, 1U, 0U,
+        },
+        {
+            160U, 106U, 75U,  203U, 90U,  165U, 139U, 166U, 198U, 136U, 203U, 121U, 162U, 193U, 157U, 177U, 141U,
+            168U, 179U, 120U, 165U, 184U, 145U, 167U, 129U, 92U,  203U, 171U, 168U, 132U, 203U, 173U, 203U, 168U,
+            198U, 142U, 203U, 169U, 203U, 98U,  137U, 166U, 174U, 194U, 131U, 153U, 113U, 183U, 121U, 203U, 196U,
+            102U, 110U, 144U, 193U, 182U, 199U, 203U, 188U, 105U, 121U, 66U,  97U,  203U, 203U, 203U, 184U, 128U,
+            70U,  203U, 199U, 149U, 123U, 168U, 178U, 78U,  88U,  139U, 187U, 164U, 165U, 188U, 203U, 142U, 164U,
+            150U, 188U, 192U, 129U, 203U, 195U, 203U, 169U, 177U, 184U, 107U, 191U, 188U,
+        },
+    },
+    {
+        {
+            0U, 2U, 3U, 1U, 0U, 1U, 0U, 2U, 3U, 2U, 1U, 0U, 0U, 1U, 0U, 2U, 1U, 3U, 0U, 2U, 1U, 2U, 1U, 0U, 2U,
+            3U, 3U, 2U, 1U, 2U, 0U, 3U, 3U, 1U, 0U, 2U, 0U, 3U, 2U, 1U, 0U, 2U, 0U, 2U, 3U, 1U, 2U, 0U, 3U, 0U,
+            2U, 2U, 0U, 2U, 1U, 2U, 2U, 3U, 0U, 2U, 3U, 3U, 1U, 3U, 2U, 0U, 0U, 2U, 3U, 1U, 0U, 0U, 2U, 0U, 1U,
+            0U, 0U, 2U, 1U, 3U, 0U, 0U, 2U, 3U, 0U, 2U, 2U, 2U, 3U, 3U, 0U, 2U, 3U, 1U, 1U, 0U, 1U, 1U,
+        },
+        {
+            109U, 41U,  155U, 168U, 166U, 187U, 186U, 149U, 181U, 128U, 163U, 181U, 192U, 141U, 69U,  55U,  203U,
+            203U, 179U, 87U,  203U, 129U, 203U, 179U, 137U, 203U, 153U, 66U,  203U, 191U, 184U, 141U, 203U, 90U,
+            94U,  149U, 185U, 145U, 118U, 152U, 145U, 202U, 108U, 98U,  203U, 180U, 178U, 200U, 155U, 192U, 163U,
+            98U,  166U, 117U, 203U, 168U, 154U, 203U, 196U, 156U, 94U,  203U, 192U, 140U, 135U, 166U, 183U, 144U,
+            203U, 156U, 196U, 183U, 189U, 107U, 203U, 144U, 123U, 80U,  203U, 196U, 173U, 146U, 121U, 203U, 157U,
+            200U, 188U, 164U, 147U, 203U, 111U, 141U, 199U, 94U,  203U, 191U, 153U, 203U,
+        },
+    },
+};
+
+static const uint8_t k_assembled_pdu[80] = {
+    0x00U, 0x68U, 0x00U, 0x65U, 0x00U, 0x6CU, 0x00U, 0x6FU, 0x00U, 0x20U, 0x00U, 0x69U, 0x00U, 0x20U, 0x00U, 0x61U,
+    0x00U, 0x6DU, 0x00U, 0x20U, 0x00U, 0x6AU, 0x00U, 0x75U, 0x00U, 0x6EU, 0x00U, 0x69U, 0x00U, 0x6FU, 0x00U, 0x72U,
+    0x00U, 0x2CU, 0x00U, 0x20U, 0x00U, 0x69U, 0x00U, 0x74U, 0x00U, 0x73U, 0x00U, 0x20U, 0x00U, 0x61U, 0x00U, 0x20U,
+    0x00U, 0x74U, 0x00U, 0x65U, 0x00U, 0x78U, 0x00U, 0x74U, 0x00U, 0x20U, 0x00U, 0x6DU, 0x00U, 0x65U, 0x00U, 0x73U,
+    0x00U, 0x73U, 0x00U, 0x61U, 0x00U, 0x67U, 0x00U, 0x65U, 0x00U, 0x2EU, 0x00U, 0x00U, 0x7BU, 0x17U, 0x9AU, 0x5FU,
+};
+
+static void
+build_info_bits(const uint8_t dibits[98], uint8_t info[196]) {
+    for (size_t i = 0U; i < 98U; i++) {
+        info[i * 2U] = (uint8_t)((dibits[i] >> 1U) & 1U);
+        info[(i * 2U) + 1U] = (uint8_t)(dibits[i] & 1U);
+    }
+}
+
+static void
+pack_crc32_bits(const uint8_t bytes[80], uint8_t bits[640]) {
+    for (size_t i = 0U, j = 0U; i < 80U; i += 2U, j += 16U) {
+        for (size_t bit = 0U; bit < 8U; bit++) {
+            bits[j + bit] = (uint8_t)((bytes[i + 1U] >> (7U - bit)) & 1U);
+            bits[j + 8U + bit] = (uint8_t)((bytes[i] >> (7U - bit)) & 1U);
+        }
+    }
+}
+
+static void
+test_capture_blocks_through_live_decoder(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    uint8_t info[196];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+    state.event_history_s = history;
+    state.currentslot = 0U;
+    state.data_header_valid[0] = 1U;
+    state.data_header_format[0] = 13U;
+    state.data_header_sap[0] = 10U;
+    state.data_header_blocks[0] = 5U;
+    state.data_block_counter[0] = 1U;
+    state.data_conf_data[0] = 1U;
+    state.data_header_dd_format[0] = 0x16U;
+    state.data_header_bit_padding[0] = 16U;
+    state.dmr_lrrp_source[0] = 31U;
+    state.dmr_lrrp_target[0] = 2515U;
+    opts.aggressive_framesync = 1;
+
+    for (size_t block = 0U; block < 5U; block++) {
+        build_info_bits(k_blocks[block].dibits, info);
+        dmr_data_burst_handler(&opts, &state, info, 0x08U, k_blocks[block].reliability);
+        assert(state.data_block_crc_valid[0][block + 1U] == 1U);
+        if (block < 4U) {
+            assert(memcmp(state.dmr_pdu_sf[0], k_assembled_pdu, (block + 1U) * 16U) == 0);
+        }
+    }
+
+    assert(strcmp(history[0].Event_History_Items[0].text_message, "helo i am junior, its a text message.") == 0);
+    assert(strstr(history[0].Event_History_Items[0].event_string, "declared UTF-32; decoded UTF-16BE compatibility")
+           != NULL);
+    assert(state.data_header_valid[0] == 0U);
+    assert(state.data_header_dd_format[0] == 0U);
+    assert(state.data_header_bit_padding[0] == 0U);
+}
+
+static void
+test_capture_packet_crc_padding_and_text(void) {
+    uint8_t crc_bits[640];
+    DSD_MEMSET(crc_bits, 0, sizeof(crc_bits));
+    pack_crc32_bits(k_assembled_pdu, crc_bits);
+    uint32_t extracted = ((uint32_t)k_assembled_pdu[76] << 24U) | ((uint32_t)k_assembled_pdu[77] << 16U)
+                         | ((uint32_t)k_assembled_pdu[78] << 8U) | (uint32_t)k_assembled_pdu[79];
+    assert(ComputeCrc32Bit(crc_bits, 608U) == extracted);
+
+    size_t payload_bytes = 0U;
+    assert(dmr_short_data_payload_bytes((sizeof k_assembled_pdu - 4U) * 8U, 16U, &payload_bytes) == 0);
+    assert(payload_bytes == 74U);
+    dmr_text_result result;
+    assert(dmr_decode_defined_short_data(0x16U, k_assembled_pdu, payload_bytes, 1, &result) == 0);
+    assert(result.compatibility == 1U);
+    assert(strcmp(result.text, "helo i am junior, its a text message.") == 0);
+}
+
+int
+main(void) {
+    test_capture_blocks_through_live_decoder();
+    test_capture_packet_crc_padding_and_text();
+    puts("DMR_DISCUSSION_231: OK");
+    return 0;
+}

--- a/tests/protocol/dmr/test_dmr_ms_data.c
+++ b/tests/protocol/dmr/test_dmr_ms_data.c
@@ -38,6 +38,8 @@ static int g_data_sync_stereo;
 static int g_data_sync_ms_mode;
 static int g_data_sync_directmode;
 static int g_data_sync_payload[144];
+static uint8_t g_data_sync_reliability[144];
+static dsd_dibit_soft_t g_cached_soft[90];
 static int g_mark_vc_sync_calls;
 static int g_fopen_private_calls;
 static int g_process_mbe_calls;
@@ -88,6 +90,8 @@ reset_fixture(void) {
     g_sm_tick_calls = 0;
     DSD_MEMSET(g_stream, 0, sizeof(g_stream));
     DSD_MEMSET(g_data_sync_payload, 0, sizeof(g_data_sync_payload));
+    DSD_MEMSET(g_data_sync_reliability, 0, sizeof(g_data_sync_reliability));
+    DSD_MEMSET(g_cached_soft, 0, sizeof(g_cached_soft));
 }
 
 int
@@ -98,6 +102,19 @@ get_dibit_and_analog_signal(dsd_opts* opts, dsd_state* state, int* out_analog_si
     (void)out_analog_signal;
     assert(g_stream_index < (sizeof(g_stream) / sizeof(g_stream[0])));
     return g_stream[g_stream_index++] & 3;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
+    const size_t index = g_stream_index;
+    int dibit = get_dibit_and_analog_signal(opts, state, NULL);
+    if (out_soft != NULL) {
+        out_soft->reliability = (uint8_t)(150U + (index % 80U));
+        out_soft->llr[0] = (int16_t)out_soft->reliability;
+        out_soft->llr[1] = (int16_t)out_soft->reliability;
+    }
+    return dibit;
 }
 
 void
@@ -130,6 +147,7 @@ dmr_data_sync(dsd_opts* opts, dsd_state* state) {
     assert(strcmp(state->slot1light, "") == 0);
     assert(strcmp(state->slot2light, "") == 0);
     DSD_MEMCPY(g_data_sync_payload, state->dmr_stereo_payload, sizeof(g_data_sync_payload));
+    DSD_MEMCPY(g_data_sync_reliability, state->dmr_stereo_reliab, sizeof(g_data_sync_reliability));
 }
 
 bool
@@ -343,8 +361,11 @@ prepare_state(dsd_state* state, int payload[90]) {
     DSD_MEMSET(state, 0, sizeof(*state));
     for (size_t i = 0; i < 90U; i++) {
         payload[i] = (int)(i & 3U);
+        g_cached_soft[i].reliability = (uint8_t)(40U + i);
     }
     state->dmr_payload_p = payload + 90;
+    state->dmr_soft_buf = g_cached_soft;
+    state->dmr_soft_p = g_cached_soft + 90;
     state->dmr_color_code = 16;
     state->dmr_stereo = 7;
     state->dmr_ms_mode = 8;
@@ -387,6 +408,10 @@ test_ms_data_collects_payload_and_cleans_state(void) {
     assert(g_data_sync_payload[89] == payload[89]);
     assert(g_data_sync_payload[90] == g_stream[0]);
     assert(g_data_sync_payload[143] == g_stream[53]);
+    assert(g_data_sync_reliability[0] == g_cached_soft[0].reliability);
+    assert(g_data_sync_reliability[89] == g_cached_soft[89].reliability);
+    assert(g_data_sync_reliability[90] == 150U);
+    assert(g_data_sync_reliability[143] == 203U);
     for (size_t i = 0; i < 144U; i++) {
         assert(state.dmr_stereo_payload[i] == 1);
     }

--- a/tests/protocol/dmr/test_dmr_r34_list.c
+++ b/tests/protocol/dmr/test_dmr_r34_list.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include "dmr_r34_internal.h"
 #include "dmr_r34_reference_vectors.h"
 #include "dsd-neo/core/safe_api.h"
 
@@ -73,6 +74,49 @@ test_candidate_list_retains_clean_payload_after_single_dibit_error(void) {
 }
 
 static void
+test_all_decoders_require_zero_flushing_state(void) {
+    static const uint8_t expected_hard[18] = {
+        0x02U, 0x55U, 0x0BU, 0x35U, 0x0FU, 0x9FU, 0x83U, 0x82U, 0x35U,
+        0xDAU, 0x49U, 0xFBU, 0x52U, 0xACU, 0xE4U, 0x64U, 0x5BU, 0xA0U,
+    };
+    static const uint8_t expected_soft[18] = {
+        0x02U, 0x55U, 0x0BU, 0x35U, 0x0FU, 0x9FU, 0x83U, 0x82U, 0x35U,
+        0xDAU, 0x49U, 0xFBU, 0x52U, 0xACU, 0xE4U, 0x64U, 0x5AU, 0x28U,
+    };
+    static const uint8_t expected_list[18] = {
+        0x02U, 0x55U, 0x0BU, 0x35U, 0x0FU, 0x9FU, 0x83U, 0x82U, 0x35U,
+        0xDAU, 0x49U, 0xFBU, 0x52U, 0xACU, 0xE4U, 0x64U, 0x5AU, 0x0AU,
+    };
+    const dmr_r34_reference_vector* reference = &k_dmr_r34_reference_vectors[0];
+    uint8_t hard_dibits[98];
+    uint8_t soft_dibits[98];
+    uint8_t reliability[98];
+    uint8_t decoded[18];
+    dmr_r34_candidate candidates[16];
+    int count = 0;
+
+    DSD_MEMCPY(hard_dibits, reference->dibits, sizeof(hard_dibits));
+    hard_dibits[73] = 2U; /* Makes an unterminated state-4 path cheaper than the required state-0 path. */
+    assert(dmr_r34_viterbi_decode(hard_dibits, decoded) == 0);
+    assert(memcmp(decoded, expected_hard, sizeof(decoded)) == 0);
+
+    DSD_MEMCPY(soft_dibits, reference->dibits, sizeof(soft_dibits));
+    soft_dibits[48] = 0U; /* Likewise favors state 4 under the weighted branch metric. */
+    DSD_MEMSET(reliability, 200, sizeof(reliability));
+    assert(dmr_r34_viterbi_decode_soft(soft_dibits, reliability, decoded) == 0);
+    assert(memcmp(decoded, expected_soft, sizeof(decoded)) == 0);
+
+    assert(dmr_r34_viterbi_decode_list(soft_dibits, reliability, candidates, 16, &count) == 0);
+    assert(count == 16);
+    assert(memcmp(candidates[0].bytes18, expected_list, sizeof(expected_list)) == 0);
+    for (int i = 0; i < count; i++) {
+        int forced_metric = -1;
+        assert(dmr_r34_candidate_metric(soft_dibits, reliability, candidates[i].bytes18, &forced_metric) == 0);
+        assert(candidates[i].metric == forced_metric);
+    }
+}
+
+static void
 test_invalid_arguments_are_rejected(void) {
     uint8_t dibits[98] = {0};
     dmr_r34_candidate candidates[2];
@@ -89,6 +133,7 @@ main(void) {
     test_clean_payload_is_first_candidate();
     test_weighted_clean_payload_is_first_candidate();
     test_candidate_list_retains_clean_payload_after_single_dibit_error();
+    test_all_decoders_require_zero_flushing_state();
     test_invalid_arguments_are_rejected();
     printf("DMR_R34_LIST: OK\n");
     return 0;

--- a/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
+++ b/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
@@ -41,6 +41,7 @@ static uint8_t g_decode_ip_first_byte;
 static unsigned int g_sd_pdu_calls;
 static uint16_t g_sd_pdu_last_len;
 static uint8_t g_sd_pdu_first_byte;
+static uint8_t g_sd_pdu_crc_valid;
 static unsigned int g_udp_comp_calls;
 static uint16_t g_udp_comp_last_len;
 static uint8_t g_udp_comp_first_byte;
@@ -231,6 +232,17 @@ dmr_sd_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, uint8_t* DMR_PDU) {
     g_sd_pdu_calls++;
     g_sd_pdu_last_len = len;
     g_sd_pdu_first_byte = DMR_PDU ? DMR_PDU[0] : 0U;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_sd_pdu_process(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* dmr_pdu, uint8_t packet_crc_valid) {
+    (void)opts;
+    (void)state;
+    g_sd_pdu_calls++;
+    g_sd_pdu_last_len = len;
+    g_sd_pdu_first_byte = dmr_pdu ? dmr_pdu[0] : 0U;
+    g_sd_pdu_crc_valid = packet_crc_valid;
 }
 
 void
@@ -474,6 +486,7 @@ reset_datacall_spy(void) {
     g_sd_pdu_calls = 0;
     g_sd_pdu_last_len = 0;
     g_sd_pdu_first_byte = 0;
+    g_sd_pdu_crc_valid = 0;
     g_udp_comp_calls = 0;
     g_udp_comp_last_len = 0;
     g_udp_comp_first_byte = 0;
@@ -504,6 +517,10 @@ test_reset_blocks_restores_integer_defaults(void) {
     state.data_header_blocks[1] = 45;
     state.data_header_format[0] = 2;
     state.data_header_format[1] = 3;
+    state.data_header_dd_format[0] = 0x16U;
+    state.data_header_dd_format[1] = 0x18U;
+    state.data_header_bit_padding[0] = 7U;
+    state.data_header_bit_padding[1] = 15U;
     state.data_dbsn_have[0] = 1;
     state.data_dbsn_expected[0] = 9;
 
@@ -515,6 +532,10 @@ test_reset_blocks_restores_integer_defaults(void) {
     assert(state.data_header_blocks[1] == 1);
     assert(state.data_header_format[0] == 7);
     assert(state.data_header_format[1] == 7);
+    assert(state.data_header_dd_format[0] == 0U);
+    assert(state.data_header_dd_format[1] == 0U);
+    assert(state.data_header_bit_padding[0] == 0U);
+    assert(state.data_header_bit_padding[1] == 0U);
     assert(state.data_dbsn_have[0] == 0);
     assert(state.data_dbsn_expected[0] == 0);
 }
@@ -553,6 +574,8 @@ test_udt_iso7_single_block_dispatches_text_event(void) {
     assert(g_datacall_last_slot == 0U);
     assert(strstr(g_datacall_last_text, "ISO7 Text") != NULL);
     assert(strstr(state.event_history_s[0].Event_History_Items[0].text_message, "HELLO") != NULL);
+    assert(state.data_header_dd_format[0] == 0U);
+    assert(state.data_header_bit_padding[0] == 0U);
     assert(state.lastsrc == 0);
     assert(state.lasttg == 0);
     assert(state.data_header_valid[0] == 0);
@@ -752,6 +775,7 @@ test_crc_valid_type1_pdu_dispatches_short_data_and_udp_saps(void) {
     assert(g_sd_pdu_calls == 1U);
     assert(g_sd_pdu_last_len == 20U);
     assert(g_sd_pdu_first_byte == 0x83U);
+    assert(g_sd_pdu_crc_valid == 1U);
     assert(g_decode_ip_calls == 0U);
     assert(g_udp_comp_calls == 0U);
 
@@ -894,6 +918,8 @@ test_irrecoverable_header_resets_data_state(void) {
     state.data_block_counter[1] = 9;
     state.data_header_blocks[1] = 9;
     state.data_header_format[1] = 2;
+    state.data_header_dd_format[1] = 0x16U;
+    state.data_header_bit_padding[1] = 23U;
     DSD_SNPRINTF(state.dmr_lrrp_gps[1], sizeof(state.dmr_lrrp_gps[1]), "%s", "stale gps");
 
     dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/0, /*IrrecoverableErrors=*/1);
@@ -904,6 +930,8 @@ test_irrecoverable_header_resets_data_state(void) {
     assert(state.data_block_counter[1] == 1);
     assert(state.data_header_blocks[1] == 1);
     assert(state.data_header_format[1] == 7);
+    assert(state.data_header_dd_format[1] == 0U);
+    assert(state.data_header_bit_padding[1] == 0U);
     assert(strcmp(state.dmr_lrrp_gps[1], "") == 0);
 }
 
@@ -970,7 +998,7 @@ test_short_data_defined_sets_blocks_and_confirmed_flag(void) {
     set_bits(bits, 2, 1U, 2);  // S_AB high bits
     set_bits(bits, 4, 13U, 4); // DPF=13, short data defined
     set_bits(bits, 8, 10U, 4); // SAP=short data
-    set_bits(bits, 12, 1U, 4); // S_AB low bits: total blocks 5
+    set_bits(bits, 12, 1U, 4); // S_AB low bits: total blocks 17
     set_bits(bits, 16, 0x010203U, 24);
     set_bits(bits, 40, 0x040506U, 24);
     set_bits(bits, 64, 18U, 6); // DD format UTF-8
@@ -980,10 +1008,54 @@ test_short_data_defined_sets_blocks_and_confirmed_flag(void) {
 
     assert(state.data_header_format[0] == 13);
     assert(state.data_header_sap[0] == 10);
-    assert(state.data_header_blocks[0] == 5);
+    assert(state.data_header_blocks[0] == 17);
+    assert(state.data_header_dd_format[0] == 0x12U);
+    assert(state.data_header_bit_padding[0] == 7U);
+    assert(state.data_block_poc[0] == 0U);
     assert(state.data_conf_data[0] == 1);
     assert(strstr(state.dmr_lrrp_gps[0], "Short DT") != NULL);
     assert(strstr(state.dmr_lrrp_gps[0], "- RSP REQ") != NULL);
+}
+
+static void
+test_short_data_raw_padding_and_packet_poc_isolation(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t dheader[12];
+    uint8_t bits[196];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(dheader, 0, sizeof(dheader));
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    state.currentslot = 0;
+    opts.aggressive_framesync = 1;
+
+    set_bits(bits, 4, 14U, 4); // DPF=14, raw short data
+    set_bits(bits, 8, 10U, 4);
+    set_bits(bits, 12, 3U, 4); // appended blocks, not POC
+    set_bits(bits, 72, 11U, 8);
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
+    assert(state.data_header_blocks[0] == 3U);
+    assert(state.data_header_bit_padding[0] == 11U);
+    assert(state.data_header_dd_format[0] == 0U);
+    assert(state.data_block_poc[0] == 0U);
+
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    set_bits(bits, 4, 2U, 4);  // DPF=2 packet data
+    set_bits(bits, 12, 9U, 4); // POC
+    set_bits(bits, 65, 1U, 7);
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
+    assert(state.data_block_poc[0] == 9U);
+    assert(state.data_header_dd_format[0] == 0U);
+    assert(state.data_header_bit_padding[0] == 0U);
+
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    set_bits(bits, 4, 3U, 4);  // DPF=3 packet data
+    set_bits(bits, 12, 6U, 4); // POC
+    set_bits(bits, 65, 1U, 7);
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
+    assert(state.data_block_poc[0] == 6U);
 }
 
 static void
@@ -1048,6 +1120,7 @@ main(int argc, char** argv) {
     test_irrecoverable_header_resets_data_state();
     rc |= test_response_header_reports_nack_reason();
     test_short_data_defined_sets_blocks_and_confirmed_flag();
+    test_short_data_raw_padding_and_packet_poc_isolation();
     test_motorola_encryption_header_updates_payload_state();
 
     static dsd_opts opts;
@@ -1085,11 +1158,17 @@ main(int argc, char** argv) {
 
     // Strict (aggressive) mode: should NOT accept when CRC fails
     opts.aggressive_framesync = 1;
+    state.data_header_dd_format[0] = 0x16U;
+    state.data_header_bit_padding[0] = 16U;
+    state.data_block_poc[0] = 7U;
     uint8_t before_format = state.data_header_format[state.currentslot];
     uint8_t before_sap = state.data_header_sap[state.currentslot];
     dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/0, /*IrrecoverableErrors=*/0);
     assert(state.data_header_format[state.currentslot] == before_format); // unchanged
     assert(state.data_header_sap[state.currentslot] == before_sap);
+    assert(state.data_header_dd_format[0] == 0U);
+    assert(state.data_header_bit_padding[0] == 0U);
+    assert(state.data_block_poc[0] == 0U);
 
     // Relaxed mode: should accept header despite CRC failure
     DSD_MEMSET(&state, 0, sizeof(state));

--- a/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
+++ b/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
@@ -1056,6 +1056,18 @@ test_short_data_raw_padding_and_packet_poc_isolation(void) {
     set_bits(bits, 65, 1U, 7);
     dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
     assert(state.data_block_poc[0] == 6U);
+
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    set_bits(bits, 4, 15U, 4); // DPF=15 proprietary extension
+    set_bits(bits, 8, 0x77U, 8);
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
+    assert(state.data_block_poc[0] == 6U);
+
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    set_bits(bits, 4, 14U, 4); // A new non-proprietary header must not inherit packet POC.
+    set_bits(bits, 12, 1U, 4);
+    dmr_dheader(&opts, &state, dheader, bits, /*CRCCorrect=*/1, /*IrrecoverableErrors=*/0);
+    assert(state.data_block_poc[0] == 0U);
 }
 
 static void

--- a/tests/protocol/dmr/test_dmr_text.c
+++ b/tests/protocol/dmr/test_dmr_text.c
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "dmr_text.h"
+#include "dsd-neo/core/safe_api.h"
+
+static void
+expect_text(uint8_t format, const uint8_t* input, size_t input_len, int crc_valid, const char* expected, int malformed,
+            int compatibility) {
+    dmr_text_result result;
+    assert(dmr_decode_defined_short_data(format, input, input_len, crc_valid, &result) == 0);
+    assert(result.supported == 1U);
+    if (strcmp(result.text, expected) != 0) {
+        DSD_FPRINTF(stderr, "format 0x%02X text mismatch: got '%s', expected '%s'\n", format, result.text, expected);
+    }
+    assert(strcmp(result.text, expected) == 0);
+    assert(result.malformed == (uint8_t)malformed);
+    assert(result.compatibility == (uint8_t)compatibility);
+}
+
+static void
+test_utf8_and_controls(void) {
+    static const uint8_t multilingual[] = {
+        0xEFU, 0xBBU, 0xBFU, 'A', 0xCEU, 0xA9U, 0xF0U, 0x9FU, 0x98U, 0x80U,
+    };
+    static const uint8_t controls[] = {
+        'A', 0x09U, 'B', 0x0AU, 'C', 0x0DU, 'D', 0xC2U, 0x85U, 'E', 0x00U, 'Z',
+    };
+    static const uint8_t malformed[] = {0xC0U, 0xAFU, 'A'};
+
+    expect_text(0x12U, multilingual, sizeof(multilingual), 0, "A\xCE\xA9\xF0\x9F\x98\x80", 0, 0);
+    expect_text(0x12U, controls, sizeof(controls), 0,
+                "A B C D\xEF\xBF\xBD"
+                "E",
+                0, 0);
+
+    dmr_text_result result;
+    assert(dmr_decode_defined_short_data(0x12U, malformed, sizeof(malformed), 0, &result) == 0);
+    assert(result.malformed == 1U);
+    assert(strstr(result.text, "\xEF\xBF\xBD") != NULL);
+}
+
+static void
+test_utf16_byte_order_and_validation(void) {
+    static const uint8_t default_be[] = {0x00U, 0x41U, 0x03U, 0xA9U, 0xD8U, 0x3DU, 0xDEU, 0x00U};
+    static const uint8_t bom_le[] = {0xFFU, 0xFEU, 0x42U, 0x00U};
+    static const uint8_t explicit_be[] = {0x4FU, 0x60U, 0x59U, 0x7DU};
+    static const uint8_t explicit_le[] = {0x60U, 0x4FU, 0x7DU, 0x59U};
+    static const uint8_t explicit_be_bom[] = {0xFEU, 0xFFU, 0x00U, 0x41U};
+    static const uint8_t malformed[] = {0xD8U, 0x00U, 0x00U, 0x41U, 0xDCU, 0x00U, 0xFFU};
+
+    expect_text(0x13U, default_be, sizeof(default_be), 0, "A\xCE\xA9\xF0\x9F\x98\x80", 0, 0);
+    expect_text(0x13U, bom_le, sizeof(bom_le), 0, "B", 0, 0);
+    expect_text(0x14U, explicit_be, sizeof(explicit_be), 0, "\xE4\xBD\xA0\xE5\xA5\xBD", 0, 0);
+    expect_text(0x15U, explicit_le, sizeof(explicit_le), 0, "\xE4\xBD\xA0\xE5\xA5\xBD", 0, 0);
+    expect_text(0x14U, explicit_be_bom, sizeof(explicit_be_bom), 0,
+                "\xEF\xBB\xBF"
+                "A",
+                0, 0);
+
+    dmr_text_result result;
+    assert(dmr_decode_defined_short_data(0x14U, malformed, sizeof(malformed), 0, &result) == 0);
+    assert(result.malformed == 1U);
+    assert(strstr(result.text, "\xEF\xBF\xBD") != NULL);
+}
+
+static void
+test_utf32_byte_order_and_validation(void) {
+    static const uint8_t default_be[] = {0x00U, 0x00U, 0x00U, 0x41U, 0x00U, 0x01U, 0xF6U, 0x00U};
+    static const uint8_t bom_le[] = {0xFFU, 0xFEU, 0x00U, 0x00U, 0x42U, 0x00U, 0x00U, 0x00U};
+    static const uint8_t explicit_be[] = {0x00U, 0x00U, 0x03U, 0xA9U};
+    static const uint8_t explicit_le[] = {0xA9U, 0x03U, 0x00U, 0x00U};
+    static const uint8_t explicit_le_bom[] = {0xFFU, 0xFEU, 0x00U, 0x00U, 0x41U, 0x00U, 0x00U, 0x00U};
+    static const uint8_t malformed[] = {0x00U, 0x11U, 0x00U, 0x00U, 0x00U, 0x00U, 0xD8U, 0x00U, 0xFFU};
+
+    expect_text(0x16U, default_be, sizeof(default_be), 0, "A\xF0\x9F\x98\x80", 0, 0);
+    expect_text(0x16U, bom_le, sizeof(bom_le), 0, "B", 0, 0);
+    expect_text(0x17U, explicit_be, sizeof(explicit_be), 0, "\xCE\xA9", 0, 0);
+    expect_text(0x18U, explicit_le, sizeof(explicit_le), 0, "\xCE\xA9", 0, 0);
+    expect_text(0x18U, explicit_le_bom, sizeof(explicit_le_bom), 0,
+                "\xEF\xBB\xBF"
+                "A",
+                0, 0);
+
+    dmr_text_result result;
+    assert(dmr_decode_defined_short_data(0x17U, malformed, sizeof(malformed), 0, &result) == 0);
+    assert(result.malformed == 1U);
+    assert(strstr(result.text, "\xEF\xBF\xBD") != NULL);
+}
+
+static void
+test_padding_and_truncation(void) {
+    size_t payload_bytes = 0U;
+    assert(dmr_short_data_payload_bytes(80U, 16U, &payload_bytes) == 0);
+    assert(payload_bytes == 8U);
+    assert(dmr_short_data_payload_bytes(80U, 7U, &payload_bytes) == -1);
+    assert(dmr_short_data_payload_bytes(8U, 9U, &payload_bytes) == -1);
+    assert(dmr_short_data_payload_bytes(8U, 0U, NULL) == -1);
+
+    uint8_t input[2100];
+    for (size_t i = 0U; i < sizeof(input); i += 3U) {
+        input[i] = 0xE2U;
+        input[i + 1U] = 0x82U;
+        input[i + 2U] = 0xACU;
+    }
+    dmr_text_result result;
+    assert(dmr_decode_defined_short_data(0x12U, input, sizeof(input), 0, &result) == 0);
+    assert(result.truncated == 1U);
+    size_t output_len = strlen(result.text);
+    assert(output_len <= (DMR_TEXT_RESULT_CAPACITY - 1U));
+    assert((output_len % 3U) == 0U);
+    assert(output_len >= 3U);
+    assert(memcmp(result.text + output_len - 3U, "\xE2\x80\xA6", 3U) == 0);
+    for (size_t i = 0U; i + 3U < output_len; i += 3U) {
+        assert(memcmp(result.text + i, "\xE2\x82\xAC", 3U) == 0);
+    }
+}
+
+static void
+test_utf32_compatibility_fallback(void) {
+    static const char message[] = "helo i am junior, its a text message.";
+    uint8_t issue_payload[(sizeof(message) - 1U) * 2U];
+    for (size_t i = 0U; i < sizeof(message) - 1U; i++) {
+        issue_payload[i * 2U] = 0U;
+        issue_payload[(i * 2U) + 1U] = (uint8_t)message[i];
+    }
+
+    dmr_text_result result;
+    assert(dmr_decode_defined_short_data(0x16U, issue_payload, sizeof(issue_payload), 1, &result) == 0);
+    assert(result.compatibility == 1U);
+    assert(strcmp(result.declared_encoding, "UTF-32") == 0);
+    assert(strcmp(result.effective_encoding, "UTF-16BE compatibility") == 0);
+    assert(strcmp(result.text, message) == 0);
+
+    assert(dmr_decode_defined_short_data(0x16U, issue_payload, sizeof(issue_payload), 0, &result) == 0);
+    assert(result.compatibility == 0U);
+    assert(result.malformed == 1U);
+
+    static const uint8_t valid_utf32[] = {0x00U, 0x00U, 0x00U, 0x41U};
+    assert(dmr_decode_defined_short_data(0x16U, valid_utf32, sizeof(valid_utf32), 1, &result) == 0);
+    assert(result.compatibility == 0U);
+    assert(result.malformed == 0U);
+    assert(strcmp(result.text, "A") == 0);
+
+    static const uint8_t invalid_utf16_candidate[] = {0x00U, 0x00U, 0xD8U, 0x00U};
+    assert(dmr_decode_defined_short_data(0x16U, invalid_utf16_candidate, sizeof(invalid_utf16_candidate), 1, &result)
+           == 0);
+    assert(result.compatibility == 0U);
+    assert(result.malformed == 1U);
+}
+
+static void
+test_unsupported_and_invalid_arguments(void) {
+    dmr_text_result result;
+    assert(dmr_decode_defined_short_data(0x11U, NULL, 0U, 0, &result) == 0);
+    assert(result.supported == 0U);
+    assert(strcmp(result.text, "") == 0);
+    assert(dmr_decode_defined_short_data(0x12U, NULL, 1U, 0, &result) == -1);
+    assert(dmr_decode_defined_short_data(0x12U, NULL, 0U, 0, NULL) == -1);
+}
+
+int
+main(void) {
+    test_utf8_and_controls();
+    test_utf16_byte_order_and_validation();
+    test_utf32_byte_order_and_validation();
+    test_padding_and_truncation();
+    test_utf32_compatibility_fallback();
+    test_unsupported_and_invalid_arguments();
+    puts("DMR_TEXT: OK");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Preserve all 98 live/cached Rate-3/4 soft metrics, require zero-state trellis termination, and choose deduplicated hard/soft/list candidates by CRC9, DBSN, and a common weighted metric.
- Correct Defined Short Data block counts, metadata lifetime, padding, and POC isolation; add validated UTF-8/UTF-16/UTF-32 rendering plus the narrow CRC-gated UTF-16BE compatibility path required by the affected radio.
- Add compact protocol fixtures derived from [Discussion #231](https://github.com/arancormonk/dsd-neo/discussions/231), focused decoder/header/text tests, and release WAV input metadata during shutdown to fix the leak exposed by sanitizer replay.

The three supplied recordings now each produce four complete messages, with all five confirmed blocks passing CRC9 and the assembled packet passing CRC32:

`helo i am junior, its a text message.`

The output is labeled `declared UTF-32; decoded UTF-16BE compatibility` when the strictly bounded workaround is used. No recordings or generated symbol captures are included in this change.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: parser / radio input.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, runtime, and file-input changes received extra scrutiny.
- [x] No static-analysis suppressions were added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` — 462/462 passed
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes — no workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes — no dependency changes
- [x] Secret, workflow-pin, download-pin, and vcpkg-overlay guardrails passed in pre-push checks.

Additional validation:

- `ctest --preset asan-ubsan-debug --output-on-failure` — 462/462 passed
- All three WAVs replayed under ASan/LSan/UBSan with leak detection and halt-on-error enabled.
- Each replay produced 20 valid Rate-3/4 confirmed blocks and four exact decoded messages.
- Focused fixture verifies five CRC9-valid blocks, packet CRC32, padding removal, and compatibility-labeled text rendering.

## Risk

- Security/dependency impact: No dependency or workflow changes. Unicode input is length-bounded and validated before rendering.
- CLI/UI behavior impact: Defined Short Data text is now complete and includes declared/effective encoding in logs and event history.
- Compatibility or packaging impact: Existing public decoder signatures remain unchanged. Unsupported DD formats retain raw diagnostic behavior; the mislabeled UTF-32 fallback requires valid packet CRC32 and structurally invalid strict UTF-32.
