### PR TITLE
p25: quarantine clear crypto conflicts

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -46,6 +46,13 @@ typedef enum DSD_ATTR_PACKED {
     DSD_P25_CRYPTO_BLOCKED = 4,
 } dsd_p25_crypto_state;
 
+/** Phase 1 traffic crypto tuple awaiting corroboration against clear service options. */
+typedef struct {
+    uint16_t keyid;
+    uint8_t algid;
+    uint8_t active;
+} dsd_p25_p1_crypto_conflict_state;
+
 /** Phase 2 ESS identity change held until boundary voice has drained. */
 typedef struct {
     uint64_t mi;
@@ -693,6 +700,8 @@ struct dsd_state {
     int p25_p1_identity_pending;
     // Definitive Phase 1 HDU crypto arrived after the last authoritative LCW identity.
     int p25_p1_hdu_crypto_fresh;
+    // One non-clear HDU/LDU2 tuple contradicted explicit-clear Phase 1 service options.
+    dsd_p25_p1_crypto_conflict_state p25_p1_crypto_conflict;
     // Sticky Phase 2 media rejection, cleared only after the slot receives an accepted assignment/activity.
     int p25_p2_media_rejected[2];
     // ESS identity changes staged until the paired-timeslot audio drain completes.

--- a/include/dsd-neo/protocol/p25/p25_crypto.h
+++ b/include/dsd-neo/protocol/p25/p25_crypto.h
@@ -50,6 +50,20 @@ p25_crypto_companion_suppressed(const dsd_state* state, int slot) {
            || state->p25_crypto_state[slot] == DSD_P25_CRYPTO_BLOCKED;
 }
 
+/** Return non-zero only when non-clear metadata has completed classification. */
+static inline int
+p25_crypto_metadata_is_confirmed_encrypted(const dsd_state* state, int slot) {
+    if (!state || slot < 0 || slot > 1) {
+        return 0;
+    }
+    const int algid = slot == 0 ? state->payload_algid : state->payload_algidR;
+    if (algid == 0 || algid == 0x80 || (slot == 0 && state->p25_p1_crypto_conflict.active)) {
+        return 0;
+    }
+    return state->p25_crypto_state[slot] == DSD_P25_CRYPTO_DECRYPTABLE
+           || state->p25_crypto_state[slot] == DSD_P25_CRYPTO_BLOCKED;
+}
+
 /**
  * Return non-zero when a P25 voice frame may reach the vocoder.
  *
@@ -64,6 +78,9 @@ p25_crypto_audio_permitted(const dsd_opts* opts, const dsd_state* state, int slo
         return 0;
     }
     if (slot == 0 && state->p25_p1_identity_pending) {
+        return 0;
+    }
+    if (slot == 0 && state->p25_p1_crypto_conflict.active) {
         return 0;
     }
     if (p25_crypto_audio_ready(state, slot)) {
@@ -83,10 +100,19 @@ void p25_crypto_begin_voice_call(dsd_state* state, dsd_p25_crypto_phase phase, i
 void p25_crypto_mark_encrypted_pending(dsd_state* state, int slot);
 
 /**
+ * Quarantine a retained Phase 1 tuple that contradicts explicit-clear service
+ * options. Returns non-zero while the tuple is awaiting another HDU/LDU2
+ * observation.
+ */
+int p25_crypto_p1_defer_clear_conflict(dsd_state* state, int svc_bits);
+
+/**
  * Resolve definitive HDU/LDU2/MAC_PTT/ESS crypto metadata.
  *
  * Imported key material for @p keyid is activated before decryptability is
  * tested. ALGID 0 remains non-definitive; only ALGID 0x80 confirms clear voice.
+ * A Phase 1 non-clear tuple that contradicts explicit-clear service options
+ * remains pending until another FEC-accepted tuple repeats the ALGID and KID.
  */
 dsd_p25_crypto_state p25_crypto_resolve(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_phase phase, int slot,
                                         int algid, int keyid, uint64_t mi, int talkgroup);

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -109,6 +109,7 @@ typedef struct {
     int data_call_override;                     // 0=infer from svc_bits, 1=force data, -1=force non-data
     int identity_valid;                         // 1 when PTT/ACTIVE carries a decoded call identity
     int facch;                                  // 1 when END was decoded from valid FACCH
+    int crypto_new_epoch;                       // 1 when CRYPTO_PENDING must start a fresh deadline
     double observed_m;                          // Optional monotonic timestamp when the event was observed
 } p25_sm_event_t;
 
@@ -534,6 +535,9 @@ void p25_sm_emit_enc(dsd_opts* opts, dsd_state* state, int slot, int algid, int 
  */
 void p25_sm_emit_crypto_pending(dsd_opts* opts, dsd_state* state, int slot);
 
+/** Emit a pending indication that explicitly starts a new classification deadline. */
+void p25_sm_emit_crypto_pending_epoch(dsd_opts* opts, dsd_state* state, int slot);
+
 /**
  * @brief Apply group grant policy side effects without attempting route/tune.
  *
@@ -741,6 +745,13 @@ p25_sm_ev_crypto_pending(int slot) {
     p25_sm_event_t ev = {0};
     ev.type = P25_SM_EV_CRYPTO_PENDING;
     ev.slot = slot;
+    return ev;
+}
+
+static inline p25_sm_event_t
+p25_sm_ev_crypto_pending_epoch(int slot) {
+    p25_sm_event_t ev = p25_sm_ev_crypto_pending(slot);
+    ev.crypto_new_epoch = 1;
     return ev;
 }
 

--- a/src/core/file/dsd_file.c
+++ b/src/core/file/dsd_file.c
@@ -1795,6 +1795,18 @@ sdrtrunk_json_log_keystream_ready(const dsd_opts* opts, uint8_t ks_available, ui
     }
 }
 
+static void
+sdrtrunk_json_classify_p25_crypto(dsd_state* state, const sdrtrunk_json_context* ctx) {
+    if (!DSD_SYNC_IS_P25(state->lastsynctype) || ctx->alg_id == 0) {
+        return;
+    }
+    if (ctx->alg_id == 0x80) {
+        state->p25_crypto_state[0] = DSD_P25_CRYPTO_CLEAR;
+        return;
+    }
+    state->p25_crypto_state[0] = ctx->ks_available ? DSD_P25_CRYPTO_DECRYPTABLE : DSD_P25_CRYPTO_BLOCKED;
+}
+
 static int
 sdrtrunk_json_handle_mi(dsd_opts* opts, dsd_state* state, const char* token, char** str_saveptr,
                         sdrtrunk_json_context* ctx) {
@@ -1825,6 +1837,7 @@ sdrtrunk_json_handle_mi(dsd_opts* opts, dsd_state* state, const char* token, cha
     }
 
     ctx->ks_available = sdrtrunk_json_build_keystreams(opts, state, ctx, iv_str);
+    sdrtrunk_json_classify_p25_crypto(state, ctx);
     sdrtrunk_json_log_keystream_ready(opts, ctx->ks_available, ctx->alg_id);
     ctx->ks_idx = 0;
     ctx->imbe_counter = 0;

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -22,6 +22,7 @@
 #include <dsd-neo/core/time_format.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/protocol/edacs/edacs_afs.h>
+#include <dsd-neo/protocol/p25/p25_crypto.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -619,7 +620,8 @@ watchdog_event_current_normalize_p25_crypto(const dsd_state* state, uint8_t slot
         ctx->enc = 0;
     }
 
-    if (watchdog_event_p25_algid_is_encrypted(ctx->alg_id) && watchdog_event_p25_has_current_voice_alg(state)) {
+    if (watchdog_event_p25_algid_is_encrypted(ctx->alg_id) && watchdog_event_p25_has_current_voice_alg(state)
+        && p25_crypto_metadata_is_confirmed_encrypted(state, slot & 1U)) {
         ctx->enc = 1;
         return;
     }
@@ -1036,6 +1038,10 @@ watchdog_event_current_append_policy_labels(const watchdog_event_current_ctx* ct
 
 void
 watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot) {
+    if (!opts || !state || !state->event_history_s || slot > 1U) {
+        return;
+    }
+
     Event_History_I* event_struct = &state->event_history_s[slot];
     Event_History candidate;
     DSD_MEMCPY(&candidate, &event_struct->Event_History_Items[0], sizeof(candidate));

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -876,6 +876,7 @@ init_state_p25_and_trunk_defaults(dsd_state* state) {
     state->p25_p2_active_slot = -1;
     state->p25_p1_identity_pending = 0;
     state->p25_p1_hdu_crypto_fresh = 0;
+    DSD_MEMSET(&state->p25_p1_crypto_conflict, 0, sizeof(state->p25_p1_crypto_conflict));
     DSD_MEMSET(state->p25_p2_media_rejected, 0, sizeof(state->p25_p2_media_rejected));
     DSD_MEMSET(state->p25_mac_frag, 0, sizeof(state->p25_mac_frag));
     state->p25_cc_is_tdma =

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -131,6 +131,7 @@ dsd_engine_reset_return_to_cc_state(dsd_opts* opts, dsd_state* state) {
     state->p25_p2_audio_allowed[1] = 0;
     state->p25_crypto_state[0] = DSD_P25_CRYPTO_UNKNOWN;
     state->p25_crypto_state[1] = DSD_P25_CRYPTO_UNKNOWN;
+    DSD_MEMSET(&state->p25_p1_crypto_conflict, 0, sizeof(state->p25_p1_crypto_conflict));
     DSD_MEMSET(state->p25_p2_rekey, 0, sizeof(state->p25_p2_rekey));
     state->p25_call_is_packet[0] = 0;
     state->p25_call_is_packet[1] = 0;

--- a/src/protocol/p25/p25_crypto.c
+++ b/src/protocol/p25/p25_crypto.c
@@ -252,6 +252,8 @@ p25_crypto_begin_voice_call(dsd_state* state, dsd_p25_crypto_phase phase, int sl
     if (phase == DSD_P25_CRYPTO_PHASE1) {
         slot = 0;
         state->p25_p1_hdu_crypto_fresh = 0;
+        state->dmr_so = svc_bits >= 0 ? (unsigned int)svc_bits : 0U;
+        state->p25_service_options_valid[0] = svc_bits >= 0 ? 1U : 0U;
     }
 
     DSD_MEMSET(&state->p25_p2_rekey[slot], 0, sizeof(state->p25_p2_rekey[slot]));

--- a/src/protocol/p25/p25_crypto.c
+++ b/src/protocol/p25/p25_crypto.c
@@ -246,10 +246,12 @@ p25_crypto_begin_voice_call(dsd_state* state, dsd_p25_crypto_phase phase, int sl
     if (!state || !p25_crypto_slot_valid(slot) || (phase != DSD_P25_CRYPTO_PHASE1 && phase != DSD_P25_CRYPTO_PHASE2)) {
         return;
     }
+    // The conflict record is Phase 1-only. A new call in either phase must not
+    // inherit it from a retained carrier or a missed terminator.
+    p25_crypto_p1_clear_conflict(state);
     if (phase == DSD_P25_CRYPTO_PHASE1) {
         slot = 0;
         state->p25_p1_hdu_crypto_fresh = 0;
-        p25_crypto_p1_clear_conflict(state);
     }
 
     DSD_MEMSET(&state->p25_p2_rekey[slot], 0, sizeof(state->p25_p2_rekey[slot]));
@@ -302,10 +304,10 @@ p25_crypto_resolve(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_phase phase,
     }
     slot = phase == DSD_P25_CRYPTO_PHASE1 ? 0 : slot;
 
-    if (phase == DSD_P25_CRYPTO_PHASE1 && state->p25_p1_identity_pending) {
-        // A new retained-carrier transmission cannot inherit a candidate from
-        // the preceding call. Its LCW will decide whether this observation is
-        // contradictory after identity becomes authoritative.
+    if (phase == DSD_P25_CRYPTO_PHASE2 || state->p25_p1_identity_pending) {
+        // Phase 2 cannot inherit a Phase 1-only quarantine. Likewise, a new
+        // retained-carrier Phase 1 transmission must wait for its own LCW to
+        // decide whether this observation is contradictory.
         p25_crypto_p1_clear_conflict(state);
     }
 
@@ -333,7 +335,11 @@ p25_crypto_resolve(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_phase phase,
                                               : p25_crypto_classify_metadata(state, phase, slot, algid);
     p25_crypto_apply_resolution(opts, state, phase, slot, algid, keyid, mi, talkgroup, &previous, resolved);
     if (defer_clear_conflict && opts) {
-        p25_sm_emit_crypto_pending(opts, state, slot);
+        if (previous.state == DSD_P25_CRYPTO_ENCRYPTED_PENDING) {
+            p25_sm_emit_crypto_pending(opts, state, slot);
+        } else {
+            p25_sm_emit_crypto_pending_epoch(opts, state, slot);
+        }
     }
     return resolved;
 }

--- a/src/protocol/p25/p25_crypto.c
+++ b/src/protocol/p25/p25_crypto.c
@@ -155,6 +155,48 @@ p25_crypto_capture_snapshot(const dsd_state* state, int slot) {
     return snapshot;
 }
 
+static void
+p25_crypto_p1_clear_conflict(dsd_state* state) {
+    if (state) {
+        DSD_MEMSET(&state->p25_p1_crypto_conflict, 0, sizeof(state->p25_p1_crypto_conflict));
+    }
+}
+
+static int
+p25_crypto_p1_has_explicit_clear_service(const dsd_state* state) {
+    return state && state->p25_service_options_valid[0] != 0 && (state->dmr_so & 0x40U) == 0;
+}
+
+static int
+p25_crypto_p1_conflict_matches(const dsd_state* state, int algid, int keyid) {
+    return state && state->p25_p1_crypto_conflict.active && state->p25_p1_crypto_conflict.algid == (uint8_t)algid
+           && state->p25_p1_crypto_conflict.keyid == (uint16_t)keyid;
+}
+
+static void
+p25_crypto_p1_arm_conflict(dsd_state* state, int algid, int keyid) {
+    if (!state) {
+        return;
+    }
+    state->p25_p1_crypto_conflict.active = 1U;
+    state->p25_p1_crypto_conflict.algid = (uint8_t)algid;
+    state->p25_p1_crypto_conflict.keyid = (uint16_t)keyid;
+}
+
+static int
+p25_crypto_p1_reconcile_clear_conflict(dsd_state* state, int algid, int keyid) {
+    if (algid == 0x80 || state->p25_p1_identity_pending || !p25_crypto_p1_has_explicit_clear_service(state)
+        || p25_crypto_p1_conflict_matches(state, algid, keyid)) {
+        // A matching resolver observation corroborates the tuple. Clear
+        // metadata and non-conflicting service contexts also retire it.
+        p25_crypto_p1_clear_conflict(state);
+        return 0;
+    }
+
+    p25_crypto_p1_arm_conflict(state, algid, keyid);
+    return 1;
+}
+
 static dsd_p25_crypto_state
 p25_crypto_resolve_algid_zero(dsd_state* state, int slot) {
     const dsd_p25_crypto_state current = state->p25_crypto_state[slot];
@@ -194,7 +236,7 @@ p25_crypto_apply_resolution(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_pha
     }
     p25_crypto_set_state(state, slot, resolved);
 
-    if (algid != 0x80 && opts) {
+    if ((resolved == DSD_P25_CRYPTO_DECRYPTABLE || resolved == DSD_P25_CRYPTO_BLOCKED) && opts) {
         p25_sm_emit_enc(opts, state, slot, algid, keyid, talkgroup);
     }
 }
@@ -207,6 +249,7 @@ p25_crypto_begin_voice_call(dsd_state* state, dsd_p25_crypto_phase phase, int sl
     if (phase == DSD_P25_CRYPTO_PHASE1) {
         slot = 0;
         state->p25_p1_hdu_crypto_fresh = 0;
+        p25_crypto_p1_clear_conflict(state);
     }
 
     DSD_MEMSET(&state->p25_p2_rekey[slot], 0, sizeof(state->p25_p2_rekey[slot]));
@@ -239,6 +282,18 @@ p25_crypto_mark_encrypted_pending(dsd_state* state, int slot) {
     dsd_mbe_purge_slot_audio(state, slot);
 }
 
+int
+p25_crypto_p1_defer_clear_conflict(dsd_state* state, int svc_bits) {
+    if (!state || svc_bits < 0 || (svc_bits & 0x40) != 0 || state->payload_algid == 0 || state->payload_algid == 0x80) {
+        return 0;
+    }
+
+    p25_crypto_p1_arm_conflict(state, state->payload_algid, state->payload_keyid);
+    p25_crypto_set_state(state, 0, DSD_P25_CRYPTO_ENCRYPTED_PENDING);
+    dsd_mbe_purge_slot_audio(state, 0);
+    return 1;
+}
+
 dsd_p25_crypto_state
 p25_crypto_resolve(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_phase phase, int slot, int algid, int keyid,
                    uint64_t mi, int talkgroup) {
@@ -246,6 +301,13 @@ p25_crypto_resolve(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_phase phase,
         return DSD_P25_CRYPTO_UNKNOWN;
     }
     slot = phase == DSD_P25_CRYPTO_PHASE1 ? 0 : slot;
+
+    if (phase == DSD_P25_CRYPTO_PHASE1 && state->p25_p1_identity_pending) {
+        // A new retained-carrier transmission cannot inherit a candidate from
+        // the preceding call. Its LCW will decide whether this observation is
+        // contradictory after identity becomes authoritative.
+        p25_crypto_p1_clear_conflict(state);
+    }
 
     if (algid == 0) {
         return p25_crypto_resolve_algid_zero(state, slot);
@@ -257,12 +319,22 @@ p25_crypto_resolve(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_phase phase,
     const p25_crypto_snapshot previous = p25_crypto_capture_snapshot(state, slot);
     p25_crypto_store_metadata(state, slot, algid, keyid, mi);
 
-    if (algid != 0x80 && state->keyloader == 1) {
+    int defer_clear_conflict = 0;
+    if (phase == DSD_P25_CRYPTO_PHASE1) {
+        defer_clear_conflict = p25_crypto_p1_reconcile_clear_conflict(state, algid, keyid);
+    }
+
+    if (!defer_clear_conflict && algid != 0x80 && state->keyloader == 1) {
         keyring_activate_slot(opts, state, slot);
     }
 
-    const dsd_p25_crypto_state resolved = p25_crypto_classify_metadata(state, phase, slot, algid);
+    const dsd_p25_crypto_state resolved = defer_clear_conflict
+                                              ? DSD_P25_CRYPTO_ENCRYPTED_PENDING
+                                              : p25_crypto_classify_metadata(state, phase, slot, algid);
     p25_crypto_apply_resolution(opts, state, phase, slot, algid, keyid, mi, talkgroup, &previous, resolved);
+    if (defer_clear_conflict && opts) {
+        p25_sm_emit_crypto_pending(opts, state, slot);
+    }
     return resolved;
 }
 

--- a/src/protocol/p25/p25_crypto_state.c
+++ b/src/protocol/p25/p25_crypto_state.c
@@ -20,6 +20,7 @@ p25_crypto_reset_slot(dsd_state* state, int slot) {
         state->payload_keyid = 0;
         state->payload_miP = 0ULL;
         state->p25_p1_hdu_crypto_fresh = 0;
+        DSD_MEMSET(&state->p25_p1_crypto_conflict, 0, sizeof(state->p25_p1_crypto_conflict));
     } else {
         state->payload_algidR = 0;
         state->payload_keyidR = 0;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -57,6 +57,7 @@ static void p25_voice_release_or_preserve_companion(p25_sm_ctx_t* ctx, dsd_opts*
                                                     const char* release_reason, const char* slot_diag,
                                                     const char* slot_log);
 static void handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev);
+static void handle_crypto_pending(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev);
 #ifdef USE_RADIO
 static int p25_sm_hold_release_for_vc_cqpsk_reacquire(p25_sm_ctx_t* ctx, dsd_opts* opts, const dsd_state* state,
                                                       const char* reason, double now_m);
@@ -2745,6 +2746,11 @@ p25_voice_start_finish_p1_identity(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state*
     if (state->payload_algid == 0) {
         return 1;
     }
+    if (p25_crypto_p1_defer_clear_conflict(state, call_ev->svc_bits)) {
+        p25_sm_event_t pending = p25_sm_ev_crypto_pending(0);
+        handle_crypto_pending(ctx, opts, state, &pending);
+        return 1;
+    }
     if (state->p25_crypto_state[0] == DSD_P25_CRYPTO_BLOCKED) {
         const int target = call_ev->is_group ? call_ev->tg : call_ev->dst;
         p25_sm_event_t enc = p25_sm_ev_enc(0, state->payload_algid, state->payload_keyid, target);
@@ -3474,6 +3480,14 @@ handle_crypto_pending(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const
     p25_crypto_mark_encrypted_pending(state, slot);
     if (state->p25_crypto_state[slot] != DSD_P25_CRYPTO_ENCRYPTED_PENDING) {
         return;
+    }
+
+    if (!ctx->vc_is_tdma && slot == 0 && state->p25_p1_crypto_conflict.active) {
+        const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[0];
+        const int target = slot_ctx->is_group ? slot_ctx->ota_tg : slot_ctx->dst;
+        p25_sm_diagf(opts, state, ctx, "crypto_conflict_deferred",
+                     "slot=0 algid=0x%02X keyid=0x%04X svc=0x%02X target=%d", state->payload_algid,
+                     state->payload_keyid, slot_ctx->svc_bits, target);
     }
 
     ctx->slots[slot].voice_active = 0;
@@ -4766,8 +4780,15 @@ p25_sm_crypto_slot_expired(const p25_sm_ctx_t* ctx, const dsd_state* state, int 
     return started_m > 0.0 && (now_m - started_m) >= grant_timeout;
 }
 
-static void
+static int
 p25_sm_block_expired_crypto_slot(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot) {
+    if (!ctx->vc_is_tdma && slot == 0 && state->p25_p1_crypto_conflict.active) {
+        ctx->slots[slot].voice_active = 0;
+        p25_sm_diagf(opts, state, ctx, "crypto_conflict_timeout", "slot=0 algid=0x%02X keyid=0x%04X freq=%ld tg=%d",
+                     state->payload_algid, state->payload_keyid, ctx->vc_freq_hz, ctx->vc_tg);
+        sm_log(opts, state, "crypto-conflict-timeout");
+        return 1;
+    }
     p25_crypto_block_pending(state, slot);
     ctx->slots[slot].voice_active = 0;
     if (ctx->vc_is_tdma) {
@@ -4776,6 +4797,7 @@ p25_sm_block_expired_crypto_slot(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
     p25_sm_diagf(opts, state, ctx, "crypto_classification_timeout", "slot=%d freq=%ld tg=%d", slot, ctx->vc_freq_hz,
                  ctx->vc_tg);
     sm_log(opts, state, "crypto-classify-timeout");
+    return 0;
 }
 
 static int
@@ -4800,6 +4822,7 @@ p25_sm_tick_crypto_classification(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* 
 
     int expired[2] = {0, 0};
     int expired_any = 0;
+    int conflict_expired = 0;
     const int slot_count = ctx->vc_is_tdma ? 2 : 1;
     for (int slot = 0; slot < slot_count; slot++) {
         if (!p25_sm_crypto_slot_expired(ctx, state, slot, now_m, grant_timeout)) {
@@ -4808,7 +4831,7 @@ p25_sm_tick_crypto_classification(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* 
 
         expired[slot] = 1;
         expired_any = 1;
-        p25_sm_block_expired_crypto_slot(ctx, opts, state, slot);
+        conflict_expired |= p25_sm_block_expired_crypto_slot(ctx, opts, state, slot);
     }
 
     if (!expired_any) {
@@ -4818,7 +4841,7 @@ p25_sm_tick_crypto_classification(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* 
         return 0;
     }
 
-    do_release(ctx, opts, state, "grant-timeout", 0);
+    do_release(ctx, opts, state, conflict_expired ? "crypto-conflict-timeout" : "grant-timeout", 0);
     return 1;
 }
 

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2717,14 +2717,17 @@ p25_voice_start_has_current_p1_crypto(const p25_sm_ctx_t* ctx, const dsd_state* 
     // A definitive ALGID is safe to retain within the current identity, after
     // an explicit boundary, or when a fresh HDU proves it belongs to the
     // transmission that is now occupying a carrier with a missed terminator.
+    // An armed clear-service conflict is also definitive metadata even though
+    // its classification remains pending corroboration.
     return state->payload_algid != 0
-           && (p25_crypto_audio_ready(state, 0) || state->p25_crypto_state[0] == DSD_P25_CRYPTO_BLOCKED);
+           && (p25_crypto_audio_ready(state, 0) || state->p25_crypto_state[0] == DSD_P25_CRYPTO_BLOCKED
+               || state->p25_p1_crypto_conflict.active);
 }
 
 static int
 p25_voice_start_should_preserve_p1_crypto(const p25_sm_ctx_t* ctx, const dsd_state* state, int slot,
                                           const p25_sm_event_t* input, const p25_voice_start_changes_t* changes) {
-    if (!input || !changes || !p25_voice_start_has_current_p1_crypto(ctx, state, slot)) {
+    if (!state || !input || !changes || !p25_voice_start_has_current_p1_crypto(ctx, state, slot)) {
         return 0;
     }
 

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -4831,7 +4831,9 @@ static int
 p25_sm_recover_expired_followed_p1_conflict(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m,
                                             double grant_timeout) {
     if (!ctx || !opts || !state || opts->trunk_tune_enc_calls == 0 || ctx->vc_is_tdma
-        || !state->p25_p1_crypto_conflict.active || !p25_sm_crypto_slot_expired(ctx, state, 0, now_m, grant_timeout)) {
+        || !state->p25_p1_crypto_conflict.active
+        || !p25_grant_service_options_are_explicit_clear(ctx->slots[0].svc_bits)
+        || !p25_sm_crypto_slot_expired(ctx, state, 0, now_m, grant_timeout)) {
         return 0;
     }
 

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2771,7 +2771,13 @@ p25_voice_start_update_crypto(p25_sm_ctx_t* ctx, dsd_state* state, int slot, int
     const int force_clear = eval_ctx && eval_ctx->enc_override_clear;
     const int pending_p1_identity = p25_p1_identity_is_pending(ctx, state, slot);
     if (changes->preserve_crypto_classification && !force_clear) {
-        ctx->slots[slot].crypto_attempt_m = 0.0;
+        if (state && state->p25_p1_crypto_conflict.active) {
+            if (ctx->slots[slot].crypto_attempt_m <= 0.0) {
+                ctx->slots[slot].crypto_attempt_m = now_m;
+            }
+        } else {
+            ctx->slots[slot].crypto_attempt_m = 0.0;
+        }
         return;
     }
     if (!changes->new_epoch && !changes->service_changed && !force_clear && !pending_p1_identity) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2747,7 +2747,7 @@ p25_voice_start_finish_p1_identity(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state*
         return 1;
     }
     if (p25_crypto_p1_defer_clear_conflict(state, call_ev->svc_bits)) {
-        p25_sm_event_t pending = p25_sm_ev_crypto_pending(0);
+        p25_sm_event_t pending = p25_sm_ev_crypto_pending_epoch(0);
         handle_crypto_pending(ctx, opts, state, &pending);
         return 1;
     }
@@ -3468,6 +3468,11 @@ handle_cc_sync(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
     }
 }
 
+static int
+p25_crypto_pending_deadline_reused(const p25_sm_event_t* ev, dsd_p25_crypto_state previous, double crypto_attempt_m) {
+    return ev && !ev->crypto_new_epoch && previous == DSD_P25_CRYPTO_ENCRYPTED_PENDING && crypto_attempt_m > 0.0;
+}
+
 static void
 handle_crypto_pending(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev) {
     if (!ctx || !state || !ev || ev->slot < 0 || ev->slot > 1) {
@@ -3491,7 +3496,7 @@ handle_crypto_pending(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const
     }
 
     ctx->slots[slot].voice_active = 0;
-    if (previous == DSD_P25_CRYPTO_ENCRYPTED_PENDING && ctx->slots[slot].crypto_attempt_m > 0.0) {
+    if (p25_crypto_pending_deadline_reused(ev, previous, ctx->slots[slot].crypto_attempt_m)) {
         return;
     }
 
@@ -4814,9 +4819,41 @@ p25_sm_expired_slot_has_active_companion(const p25_sm_ctx_t* ctx, const dsd_stat
 }
 
 static int
+p25_sm_recover_expired_followed_p1_conflict(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m,
+                                            double grant_timeout) {
+    if (!ctx || !opts || !state || opts->trunk_tune_enc_calls == 0 || ctx->vc_is_tdma
+        || !state->p25_p1_crypto_conflict.active || !p25_sm_crypto_slot_expired(ctx, state, 0, now_m, grant_timeout)) {
+        return 0;
+    }
+
+    const int algid = state->payload_algid;
+    const int keyid = state->payload_keyid;
+    const int resume_voice = ctx->slots[0].grant_active && ctx->t_voice_m > 0.0;
+    p25_crypto_begin_voice_call(state, DSD_P25_CRYPTO_PHASE1, 0, ctx->slots[0].svc_bits, 1);
+    ctx->slots[0].crypto_attempt_m = 0.0;
+    if (resume_voice) {
+        ctx->slots[0].voice_active = 1;
+        ctx->slots[0].last_active_m = now_m;
+        ctx->t_voice_m = now_m;
+        ctx->t_hangtime_m = 0.0;
+    }
+    p25_sm_diagf(opts, state, ctx, "crypto_conflict_timeout",
+                 "slot=0 algid=0x%02X keyid=0x%04X freq=%ld tg=%d action=resume-clear", algid, keyid, ctx->vc_freq_hz,
+                 ctx->vc_tg);
+    sm_log(opts, state, "crypto-conflict-timeout-clear");
+    return 1;
+}
+
+static int
 p25_sm_tick_crypto_classification(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m,
                                   double grant_timeout) {
-    if (!ctx || !opts || !state || opts->trunk_tune_enc_calls != 0) {
+    if (!ctx || !opts || !state) {
+        return 0;
+    }
+    if (p25_sm_recover_expired_followed_p1_conflict(ctx, opts, state, now_m, grant_timeout)) {
+        return 0;
+    }
+    if (opts->trunk_tune_enc_calls != 0) {
         return 0;
     }
 
@@ -5099,6 +5136,12 @@ p25_sm_emit_enc(dsd_opts* opts, dsd_state* state, int slot, int algid, int keyid
 void
 p25_sm_emit_crypto_pending(dsd_opts* opts, dsd_state* state, int slot) {
     p25_sm_event_t ev = p25_sm_ev_crypto_pending(slot);
+    p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);
+}
+
+void
+p25_sm_emit_crypto_pending_epoch(dsd_opts* opts, dsd_state* state, int slot) {
+    p25_sm_event_t ev = p25_sm_ev_crypto_pending_epoch(slot);
     p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);
 }
 

--- a/src/protocol/p25/phase1/p25p1_ldu1.c
+++ b/src/protocol/p25/phase1/p25p1_ldu1.c
@@ -423,7 +423,7 @@ p25p1_ldu1_softid_finalize_alias(const dsd_opts* opts, dsd_state* state, int k) 
     if (tsrc != 0) {
         const char* mode = "D";
         dsd_tg_policy_entry alias_entry;
-        if (state->payload_algid != 0x80 && opts->trunk_tune_enc_calls == 0 && state->R == 0) {
+        if (p25_crypto_metadata_is_confirmed_encrypted(state, 0) && opts->trunk_tune_enc_calls == 0 && state->R == 0) {
             mode = "DE";
         }
         if (dsd_tg_policy_make_exact_entry((uint32_t)tsrc, mode, str, DSD_TG_POLICY_SOURCE_RUNTIME_ALIAS, &alias_entry)

--- a/src/protocol/p25/phase1/p25p1_ldu2.c
+++ b/src/protocol/p25/phase1/p25p1_ldu2.c
@@ -432,7 +432,7 @@ ldu2_maybe_finalize_lsd_alias(const dsd_opts* opts, dsd_state* state) {
     if (tsrc != 0) {
         const char* mode = "D";
         dsd_tg_policy_entry alias_entry;
-        if (state->payload_algid != 0x80 && opts->trunk_tune_enc_calls == 0 && state->R == 0) {
+        if (p25_crypto_metadata_is_confirmed_encrypted(state, 0) && opts->trunk_tune_enc_calls == 0 && state->R == 0) {
             mode = "DE";
         }
         if (dsd_tg_policy_make_exact_entry((uint32_t)tsrc, mode, str, DSD_TG_POLICY_SOURCE_RUNTIME_ALIAS, &alias_entry)

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -851,6 +851,7 @@ test_p25_and_dmr_current_append_security_flags(void) {
     state.nac = 0x293;
     state.payload_algid = 0x84U;
     state.payload_keyid = 0x2222U;
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_BLOCKED;
     state.dmr_so = 0x80U;
     state.p25_service_options_valid[0] = 1;
     watchdog_event_current(&opts, &state, 0);
@@ -920,12 +921,35 @@ test_p25_and_dmr_current_append_security_flags(void) {
     state.nac = 0x293;
     state.payload_algid = 0x84U;
     state.payload_keyid = 0x2222U;
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_BLOCKED;
     state.dmr_so = 0;
     watchdog_event_current(&opts, &state, 0);
     item = &state.event_history_s[0].Event_History_Items[0];
     rc |= expect_has_substr("p25 validated voice alg renders", item->event_string, "ENC; ALG: 84; KID: 2222;");
     rc |= expect_int("p25 validated voice alg marks encrypted", item->enc, 1);
     rc |= expect_int("p25 validated voice alg kept", item->enc_alg, 0x84);
+
+    reset_fixture(&opts, &state, event_history);
+    state.lastsynctype = DSD_SYNC_P25P1_POS;
+    state.lastp25type = 2;
+    state.lastsrc = 4009646U;
+    state.lasttg = 3069U;
+    state.gi[0] = 0;
+    state.nac = 0x798;
+    state.payload_algid = 0xA0U;
+    state.payload_keyid = 0x0064U;
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_ENCRYPTED_PENDING;
+    state.p25_p1_crypto_conflict.active = 1U;
+    state.p25_p1_crypto_conflict.algid = 0xA0U;
+    state.p25_p1_crypto_conflict.keyid = 0x0064U;
+    state.dmr_so = 0x04U;
+    state.p25_service_options_valid[0] = 1;
+    watchdog_event_current(&opts, &state, 0);
+    item = &state.event_history_s[0].Event_History_Items[0];
+    rc |= expect_no_substr("p25 pending conflict stays clear", item->event_string, "ENC;");
+    rc |= expect_no_substr("p25 pending conflict omits candidate alg", item->event_string, "ALG:");
+    rc |= expect_int("p25 pending conflict event remains clear", item->enc, 0);
+    rc |= expect_int("p25 pending conflict event clears alg", item->enc_alg, 0);
     return rc;
 }
 

--- a/tests/core/test_core_init_state.c
+++ b/tests/core/test_core_init_state.c
@@ -107,6 +107,9 @@ main(void) {
     state->payload_keyidR = 0x5678;
     state->p25_crypto_state[0] = DSD_P25_CRYPTO_BLOCKED;
     state->p25_p1_hdu_crypto_fresh = 1;
+    state->p25_p1_crypto_conflict.active = 1U;
+    state->p25_p1_crypto_conflict.algid = 0xA0U;
+    state->p25_p1_crypto_conflict.keyid = 0x0064U;
     state->p25_policy_tg[0] = 0x1234U;
     state->p25_policy_tg[1] = 0x5678U;
     state->p25_mac_frag[0].active = 1U;
@@ -174,7 +177,9 @@ main(void) {
         || state->payload_miP != 0ULL || state->payload_algid != 0 || state->payload_algidR != 0
         || state->payload_keyid != 0 || state->payload_keyidR != 0
         || state->p25_crypto_state[0] != DSD_P25_CRYPTO_UNKNOWN || state->p25_crypto_state[1] != DSD_P25_CRYPTO_UNKNOWN
-        || state->p25_p1_hdu_crypto_fresh != 0 || state->p25_policy_tg[0] != 0U || state->p25_policy_tg[1] != 0U) {
+        || state->p25_p1_hdu_crypto_fresh != 0 || state->p25_p1_crypto_conflict.active != 0U
+        || state->p25_p1_crypto_conflict.algid != 0U || state->p25_p1_crypto_conflict.keyid != 0U
+        || state->p25_policy_tg[0] != 0U || state->p25_policy_tg[1] != 0U) {
         DSD_FPRINTF(stderr, "initState did not clear payload crypto metadata\n");
         freeState(state);
         free(state);

--- a/tests/core/test_core_mbe_file_io.c
+++ b/tests/core/test_core_mbe_file_io.c
@@ -652,6 +652,34 @@ test_sdrtrunk_json_encryption_metadata_updates_payload_state(void) {
 }
 
 static int
+test_sdrtrunk_json_p25p2_encryption_metadata_updates_event(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    static const char json[] =
+        "{\"version\":\"2\",\"protocol\":\"APCO25-PHASE2\",\"call_type\":\"GROUP\",\"encrypted\":\"true\","
+        "\"encryption_algorithm\":\"132\",\"encryption_key_id\":\"8738\","
+        "\"encryption_mi\":\"0011223344556677\",\"to\":\"55\",\"from\":\"66\",\"time\":\"1700000000000\"}";
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    DSD_MEMSET(history, 0, sizeof history);
+    opts.playfiles = 1;
+    state.event_history_s = history;
+
+    rc |= run_sdrtrunk_json(json, &opts, &state);
+    const Event_History* item = &history[0].Event_History_Items[0];
+    rc |= expect_int("sdrtrunk p25p2 crypto state", state.p25_crypto_state[0], DSD_P25_CRYPTO_BLOCKED);
+    rc |= expect_int("sdrtrunk p25p2 event encrypted", item->enc, 1);
+    rc |= expect_int("sdrtrunk p25p2 event algid", item->enc_alg, 0x84);
+    rc |= expect_u16("sdrtrunk p25p2 event key id", item->enc_key, 0x2222);
+    rc |= expect_u64("sdrtrunk p25p2 event mi", item->mi, 0x0011223344556677ULL);
+
+    return rc;
+}
+
+static int
 test_sdrtrunk_json_invalid_numeric_fields_reset_to_zero(void) {
     int rc = 0;
     static dsd_opts opts;
@@ -1790,6 +1818,7 @@ main(void) {
     rc |= test_parse_raw_user_string_guards_and_bounds();
     rc |= test_sdrtrunk_json_metadata_protocols_and_time();
     rc |= test_sdrtrunk_json_encryption_metadata_updates_payload_state();
+    rc |= test_sdrtrunk_json_p25p2_encryption_metadata_updates_event();
     rc |= test_sdrtrunk_json_invalid_numeric_fields_reset_to_zero();
     rc |= test_sdrtrunk_json_protocol_opens_and_closes_mbe_out_file();
     rc |= test_sdrtrunk_json_hex_voice_writes_unencrypted_mbe_records();

--- a/tests/protocol/p25/test_p25_crypto_state.c
+++ b/tests/protocol/p25/test_p25_crypto_state.c
@@ -174,11 +174,11 @@ test_phase1_clear_conflict_requires_corroboration(void) {
     reset_fixture(&opts, &state);
     opts.unmute_encrypted_p25 = 1;
 
-    p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE1, 0, 0x04, 0);
-    state.dmr_so = 0x04;
-    state.p25_service_options_valid[0] = 1;
-
     int rc = 0;
+    p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE1, 0, 0x04, 0);
+    rc |= expect_int("P1 begin stores clear grant service", state.dmr_so, 0x04);
+    rc |= expect_int("P1 begin marks grant service valid", state.p25_service_options_valid[0], 1);
+
     rc |= expect_int(
         "first clear-conflict tuple stays pending",
         p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE1, 0, 0xA0, 0x0064, UINT64_C(0x0102030405060708), 3069),
@@ -212,8 +212,6 @@ test_phase1_clear_conflict_requires_corroboration(void) {
                      1);
 
     p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE1, 0, 0x04, 0);
-    state.dmr_so = 0x04;
-    state.p25_service_options_valid[0] = 1;
     (void)p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE1, 0, 0xA0, 0x0064, UINT64_C(0x3132333435363738), 3069);
     rc |= expect_int(
         "clear ALGID resolves quarantined tuple",
@@ -222,8 +220,6 @@ test_phase1_clear_conflict_requires_corroboration(void) {
     rc |= expect_int("clear ALGID clears candidate", state.p25_p1_crypto_conflict.active, 0);
 
     p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE1, 0, 0x04, 0);
-    state.dmr_so = 0x04;
-    state.p25_service_options_valid[0] = 1;
     state.p25_p1_identity_pending = 1;
     rc |= expect_int(
         "identity-pending tuple remains authoritative until LCW",
@@ -269,6 +265,10 @@ test_phase1_clear_conflict_requires_corroboration(void) {
     rc |= expect_int("Phase 2 resolve retired retained P1 candidate", state.p25_p1_crypto_conflict.active, 0);
     rc |= expect_int("Phase 2 clear audio survives retained P1 candidate", p25_crypto_audio_permitted(&opts, &state, 0),
                      1);
+
+    p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE1, 0, -1, 0);
+    rc |= expect_int("unknown P1 service clears stale grant bits", state.dmr_so, 0);
+    rc |= expect_int("unknown P1 service clears validity", state.p25_service_options_valid[0], 0);
     return rc;
 }
 

--- a/tests/protocol/p25/test_p25_crypto_state.c
+++ b/tests/protocol/p25/test_p25_crypto_state.c
@@ -168,6 +168,85 @@ test_begin_and_sticky_unknown(void) {
 }
 
 static int
+test_phase1_clear_conflict_requires_corroboration(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_fixture(&opts, &state);
+    opts.unmute_encrypted_p25 = 1;
+
+    p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE1, 0, 0x04, 0);
+    state.dmr_so = 0x04;
+    state.p25_service_options_valid[0] = 1;
+
+    int rc = 0;
+    rc |= expect_int(
+        "first clear-conflict tuple stays pending",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE1, 0, 0xA0, 0x0064, UINT64_C(0x0102030405060708), 3069),
+        DSD_P25_CRYPTO_ENCRYPTED_PENDING);
+    rc |= expect_int("first clear-conflict tuple arms candidate", state.p25_p1_crypto_conflict.active, 1);
+    rc |= expect_int("clear-conflict candidate ALGID", state.p25_p1_crypto_conflict.algid, 0xA0);
+    rc |= expect_int("clear-conflict candidate KID", state.p25_p1_crypto_conflict.keyid, 0x0064);
+    rc |= expect_int("pending conflict is not confirmed", p25_crypto_metadata_is_confirmed_encrypted(&state, 0), 0);
+    rc |=
+        expect_int("pending conflict overrides explicit audio unmute", p25_crypto_audio_permitted(&opts, &state, 0), 0);
+
+    rc |= expect_int("ALGID zero does not confirm conflict",
+                     p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE1, 0, 0, 0, 0, 3069),
+                     DSD_P25_CRYPTO_ENCRYPTED_PENDING);
+    rc |= expect_int("ALGID zero preserves conflict candidate", state.p25_p1_crypto_conflict.active, 1);
+
+    rc |= expect_int(
+        "different tuple replaces conflict candidate",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE1, 0, 0x84, 0x1234, UINT64_C(0x1112131415161718), 3069),
+        DSD_P25_CRYPTO_ENCRYPTED_PENDING);
+    rc |= expect_int("replacement candidate ALGID", state.p25_p1_crypto_conflict.algid, 0x84);
+    rc |= expect_int("replacement candidate KID", state.p25_p1_crypto_conflict.keyid, 0x1234);
+
+    rc |= expect_int(
+        "matching second tuple confirms encryption",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE1, 0, 0x84, 0x1234, UINT64_C(0x2122232425262728), 3069),
+        DSD_P25_CRYPTO_BLOCKED);
+    rc |= expect_int("confirmed tuple clears candidate", state.p25_p1_crypto_conflict.active, 0);
+    rc |= expect_int("confirmed tuple is encrypted", p25_crypto_metadata_is_confirmed_encrypted(&state, 0), 1);
+    rc |= expect_int("confirmed blocked tuple restores configured unmute", p25_crypto_audio_permitted(&opts, &state, 0),
+                     1);
+
+    p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE1, 0, 0x04, 0);
+    state.dmr_so = 0x04;
+    state.p25_service_options_valid[0] = 1;
+    (void)p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE1, 0, 0xA0, 0x0064, UINT64_C(0x3132333435363738), 3069);
+    rc |= expect_int(
+        "clear ALGID resolves quarantined tuple",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE1, 0, 0x80, 0, UINT64_C(0x4142434445464748), 3069),
+        DSD_P25_CRYPTO_CLEAR);
+    rc |= expect_int("clear ALGID clears candidate", state.p25_p1_crypto_conflict.active, 0);
+
+    p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE1, 0, 0x04, 0);
+    state.dmr_so = 0x04;
+    state.p25_service_options_valid[0] = 1;
+    state.p25_p1_identity_pending = 1;
+    rc |= expect_int(
+        "identity-pending tuple remains authoritative until LCW",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE1, 0, 0xA0, 0x0064, UINT64_C(0x5152535455565758), 3069),
+        DSD_P25_CRYPTO_BLOCKED);
+    rc |= expect_int("identity-pending tuple does not use stale clear service", state.p25_p1_crypto_conflict.active, 0);
+    state.p25_p1_identity_pending = 0;
+    rc |= expect_int("accepted clear LCW defers retained tuple", p25_crypto_p1_defer_clear_conflict(&state, 0x04), 1);
+    rc |= expect_int("retained tuple becomes pending", state.p25_crypto_state[0], DSD_P25_CRYPTO_ENCRYPTED_PENDING);
+
+    p25_crypto_reset_slot(&state, 0);
+    rc |= expect_int("slot reset clears conflict", state.p25_p1_crypto_conflict.active, 0);
+    state.dmr_so = 0x04;
+    state.p25_service_options_valid[0] = 1;
+    rc |= expect_int(
+        "Phase 2 bypasses Phase 1 conflict policy",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE2, 0, 0xA0, 0x0064, UINT64_C(0x6162636465666768), 3069),
+        DSD_P25_CRYPTO_BLOCKED);
+    rc |= expect_int("Phase 2 leaves P1 candidate clear", state.p25_p1_crypto_conflict.active, 0);
+    return rc;
+}
+
+static int
 test_algorithm_and_manual_key_resolution(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -439,6 +518,7 @@ main(void) {
     rc |= test_explicit_audio_unmute_respects_lockout();
     rc |= test_phase1_resolution_does_not_override_phase2_gate();
     rc |= test_begin_and_sticky_unknown();
+    rc |= test_phase1_clear_conflict_requires_corroboration();
     rc |= test_algorithm_and_manual_key_resolution();
     rc |= test_imported_key_activation_is_slot_aware();
     rc |= test_slot_local_transition_purge_and_mi_refresh();

--- a/tests/protocol/p25/test_p25_crypto_state.c
+++ b/tests/protocol/p25/test_p25_crypto_state.c
@@ -243,6 +243,32 @@ test_phase1_clear_conflict_requires_corroboration(void) {
         p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE2, 0, 0xA0, 0x0064, UINT64_C(0x6162636465666768), 3069),
         DSD_P25_CRYPTO_BLOCKED);
     rc |= expect_int("Phase 2 leaves P1 candidate clear", state.p25_p1_crypto_conflict.active, 0);
+
+    state.p25_p1_crypto_conflict.active = 1U;
+    state.p25_p1_crypto_conflict.algid = 0xA0U;
+    state.p25_p1_crypto_conflict.keyid = 0x0064U;
+    state.R = UINT64_C(0x0102030405060708);
+    p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE2, 0, 0x40, 0);
+    rc |= expect_int("Phase 2 begin clears retained P1 candidate", state.p25_p1_crypto_conflict.active, 0);
+    rc |= expect_int(
+        "Phase 2 decryptable tuple after retained candidate",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE2, 0, 0x81, 0x1001, UINT64_C(0x7172737475767778), 3069),
+        DSD_P25_CRYPTO_DECRYPTABLE);
+    rc |= expect_int("Phase 2 metadata is not suppressed by retained P1 candidate",
+                     p25_crypto_metadata_is_confirmed_encrypted(&state, 0), 1);
+    rc |= expect_int("Phase 2 decryptable audio is not suppressed by retained P1 candidate",
+                     p25_crypto_audio_permitted(&opts, &state, 0), 1);
+
+    state.p25_p1_crypto_conflict.active = 1U;
+    state.p25_p1_crypto_conflict.algid = 0x84U;
+    state.p25_p1_crypto_conflict.keyid = 0x1234U;
+    rc |= expect_int(
+        "Phase 2 resolve clears retained P1 candidate without begin",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, UINT64_C(0x8182838485868788), 3069),
+        DSD_P25_CRYPTO_CLEAR);
+    rc |= expect_int("Phase 2 resolve retired retained P1 candidate", state.p25_p1_crypto_conflict.active, 0);
+    rc |= expect_int("Phase 2 clear audio survives retained P1 candidate", p25_crypto_audio_permitted(&opts, &state, 0),
+                     1);
     return rc;
 }
 

--- a/tests/protocol/p25/test_p25_p1_ldu1_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_ldu1_helpers.c
@@ -699,6 +699,7 @@ test_ldu1_softid_alias_state(void) {
     state.dmr_alias_block_len[0] = 2;
     state.lastsrc = 2468;
     state.payload_algid = 0xAA;
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_BLOCKED;
     opts.trunk_tune_enc_calls = 0;
     ctx.lsd_hex1 = 0x19;
     ctx.lsd_hex2 = 0x7F;
@@ -711,6 +712,27 @@ test_ldu1_softid_alias_state(void) {
     rc |= expect_int("softid encrypted policy upserts", g_policy_upsert_calls, 2);
     rc |= expect_cstr("softid encrypted no-key mode", g_last_policy_mode, "DE");
     rc |= expect_cstr("softid invalid alias name empty", g_last_policy_name, "");
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&ctx, 0, sizeof(ctx));
+    reset_hook_counters();
+    state.dmr_alias_format[0] = 0x02;
+    state.dmr_alias_block_len[0] = 2;
+    state.lastsrc = 3069;
+    state.payload_algid = 0xA0;
+    state.payload_keyid = 0x0064;
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_ENCRYPTED_PENDING;
+    state.p25_p1_crypto_conflict.active = 1U;
+    state.p25_p1_crypto_conflict.algid = 0xA0U;
+    state.p25_p1_crypto_conflict.keyid = 0x0064U;
+    opts.trunk_tune_enc_calls = 0;
+    ctx.lsd_hex1 = 0x41;
+    ctx.lsd_hex2 = 0x42;
+    ctx.lsd1_okay = 1;
+    ctx.lsd2_okay = 1;
+    p25p1_ldu1_handle_softid(&opts, &state, &ctx);
+    rc |= expect_cstr("softid pending conflict remains clear mode", g_last_policy_mode, "D");
 
     DSD_MEMSET(&state, 0, sizeof(state));
     DSD_MEMSET(&ctx, 0, sizeof(ctx));

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -792,6 +792,33 @@ test_p1_follow_mode_expires_clear_conflict(void) {
 }
 
 static int
+test_p1_follow_mode_does_not_clear_conflict_after_encrypted_lcw(void) {
+    p25_sm_ctx_t ctx;
+    if (setup_p1_retained_clear_conflict(&ctx, 1) != 0) {
+        return 1;
+    }
+
+    p25_sm_event_t ev = p25_sm_ev_active_call(0, 3069, 0, 4009646, 1, 0x44);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.slots[0].svc_bits != 0x44 || g_state.dmr_so != 0x44 || !g_state.p25_service_options_valid[0]
+        || !g_state.p25_p1_crypto_conflict.active || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_ENCRYPTED_PENDING) {
+        DSD_FPRINTF(stderr, "FAIL: Encrypted LCW did not replace the clear conflict service options\n");
+        return 1;
+    }
+
+    ctx.slots[0].crypto_attempt_m = dsd_time_now_monotonic_s() - ctx.config.grant_timeout_s - 0.1;
+    p25_sm_tick_ctx(&ctx, &g_opts, &g_state);
+    if (ctx.state != P25_SM_TUNED || g_return_requests != 0 || !ctx.slots[0].grant_active
+        || !g_state.p25_p1_crypto_conflict.active || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_ENCRYPTED_PENDING
+        || g_state.payload_algid != 0xA0 || g_state.payload_keyid != 0x0064
+        || p25_crypto_audio_permitted(&g_opts, &g_state, 0)) {
+        DSD_FPRINTF(stderr, "FAIL: Conflict timeout reopened explicitly encrypted Phase 1 service as clear\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
 test_p1_clear_conflict_restarts_deadline(void) {
     reset_test_state();
     g_opts.trunk_tune_enc_calls = 0;
@@ -2087,6 +2114,7 @@ main(void) {
     fail += test_p1_retained_hdu_defers_lockout_attribution();
     fail += test_p1_clear_identity_quarantines_conflicting_hdu();
     fail += test_p1_follow_mode_expires_clear_conflict();
+    fail += test_p1_follow_mode_does_not_clear_conflict_after_encrypted_lcw();
     fail += test_p1_clear_conflict_restarts_deadline();
     fail += test_p1_grant_hdu_conflict_survives_first_active();
     fail += test_p1_follow_mode_preserves_grant_conflict_deadline();

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -885,6 +885,49 @@ test_p1_grant_hdu_conflict_survives_first_active(void) {
 }
 
 static int
+test_p1_follow_mode_preserves_grant_conflict_deadline(void) {
+    reset_test_state();
+    g_opts.trunk_tune_enc_calls = 1;
+    g_state.trunk_chan_map[0x1234] = 851500000;
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    p25_sm_init_ctx(ctx, &g_opts, &g_state);
+    p25_sm_event_t ev = p25_sm_ev_group_grant(0x1234, 851500000, 3069, 4009646, 0x04);
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+
+    g_state.p25_p1_hdu_crypto_fresh = 1;
+    if (p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE1, 0, 0xA0, 0x0064, UINT64_C(0x0102030405060708),
+                           3069)
+            != DSD_P25_CRYPTO_ENCRYPTED_PENDING
+        || !g_state.p25_p1_crypto_conflict.active || ctx->slots[0].crypto_attempt_m <= 0.0) {
+        DSD_FPRINTF(stderr, "FAIL: Encrypted-follow fixture did not start the grant conflict deadline\n");
+        return 1;
+    }
+    const double started_m = ctx->slots[0].crypto_attempt_m;
+
+    ev = p25_sm_ev_active(0);
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+    if (ctx->state != P25_SM_TUNED || !ctx->slots[0].voice_active || !ctx->slots[0].grant_active
+        || !g_state.p25_p1_crypto_conflict.active || fabs(ctx->slots[0].crypto_attempt_m - started_m) > 1.0e-9
+        || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_ENCRYPTED_PENDING
+        || p25_crypto_audio_permitted(&g_opts, &g_state, 0) || g_return_requests != 0) {
+        DSD_FPRINTF(stderr, "FAIL: First ACTIVE lost the encrypted-follow grant conflict deadline\n");
+        return 1;
+    }
+
+    ctx->slots[0].crypto_attempt_m = dsd_time_now_monotonic_s() - ctx->config.grant_timeout_s - 0.1;
+    p25_sm_tick_ctx(ctx, &g_opts, &g_state);
+    if (ctx->state != P25_SM_TUNED || !ctx->slots[0].voice_active || !ctx->slots[0].grant_active
+        || g_state.p25_p1_crypto_conflict.active || ctx->slots[0].crypto_attempt_m > 0.0
+        || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_CLEAR || !p25_crypto_audio_permitted(&g_opts, &g_state, 0)
+        || g_return_requests != 0) {
+        DSD_FPRINTF(stderr, "FAIL: Encrypted-follow grant conflict did not recover as clear at its deadline\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
 test_p1_pending_identity_restarts_crypto_without_hdu(void) {
     reset_test_state();
     g_state.trunk_chan_map[0x1234] = 851500000;
@@ -2046,6 +2089,7 @@ main(void) {
     fail += test_p1_follow_mode_expires_clear_conflict();
     fail += test_p1_clear_conflict_restarts_deadline();
     fail += test_p1_grant_hdu_conflict_survives_first_active();
+    fail += test_p1_follow_mode_preserves_grant_conflict_deadline();
     fail += test_p1_pending_identity_restarts_crypto_without_hdu();
     fail += test_identified_followup_without_service_restarts_crypto_pending();
     fail += test_missed_end_identity_change_without_service_restarts_crypto_pending();

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -547,6 +547,7 @@ test_p1_fresh_hdu_survives_missed_terminator(void) {
     const int keyid = 0x5678;
     const uint64_t mi = UINT64_C(0x1112131415161718);
     g_state.p25_call_emergency[0] = 1;
+    g_state.p25_p1_identity_pending = 1;
     g_state.p25_p1_hdu_crypto_fresh = 1;
     if (p25_crypto_resolve(NULL, &g_state, DSD_P25_CRYPTO_PHASE1, 0, algid, keyid, mi, 2000)
         != DSD_P25_CRYPTO_DECRYPTABLE) {
@@ -668,6 +669,104 @@ test_p1_retained_hdu_defers_lockout_attribution(void) {
     if (ctx.state != P25_SM_ON_CC || g_return_requests != 1 || g_state.p25_p1_identity_pending
         || encrypted_call_cache_has(1000U, 1) || !encrypted_call_cache_has(2000U, 1)) {
         DSD_FPRINTF(stderr, "FAIL: Deferred Phase 1 HDU lockout was not attributed to the accepted identity\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+setup_p1_retained_clear_conflict(p25_sm_ctx_t* ctx) {
+    reset_test_state();
+    g_opts.trunk_tune_enc_calls = 0;
+    g_state.trunk_chan_map[0x1234] = 851500000;
+
+    p25_sm_init_ctx(ctx, &g_opts, &g_state);
+    p25_sm_event_t ev = p25_sm_ev_group_grant(0x1234, 851500000, 3069, 0, P25_SM_SVC_UNKNOWN);
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+    ev = p25_sm_ev_active_call(0, 3069, 0, 4009646, 1, 0x04);
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+    ev = p25_sm_ev_tdu();
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+
+    if (!g_state.p25_p1_identity_pending
+        || p25_crypto_resolve(NULL, &g_state, DSD_P25_CRYPTO_PHASE1, 0, 0xA0, 0x0064, UINT64_C(0x0102030405060708),
+                              3069)
+               != DSD_P25_CRYPTO_BLOCKED) {
+        DSD_FPRINTF(stderr, "FAIL: Clear-conflict fixture did not retain blocked HDU metadata\n");
+        return 1;
+    }
+
+    ev = p25_sm_ev_enc(0, 0xA0, 0x0064, 3069);
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+    if (ctx->state != P25_SM_TUNED || g_return_requests != 0 || encrypted_call_cache_has(3069U, 1)) {
+        DSD_FPRINTF(stderr, "FAIL: Anonymous conflicting HDU was not deferred\n");
+        return 1;
+    }
+
+    ev = p25_sm_ev_active_call(0, 3069, 0, 4009646, 1, 0x04);
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+    if (ctx->state != P25_SM_TUNED || !ctx->slots[0].grant_active || g_return_requests != 0
+        || encrypted_call_cache_has(3069U, 1) || !g_state.p25_p1_crypto_conflict.active
+        || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_ENCRYPTED_PENDING || ctx->slots[0].crypto_attempt_m <= 0.0
+        || p25_crypto_audio_permitted(&g_opts, &g_state, 0)) {
+        DSD_FPRINTF(stderr, "FAIL: Clear LCW did not quarantine conflicting retained HDU metadata\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_p1_clear_identity_quarantines_conflicting_hdu(void) {
+    p25_sm_ctx_t ctx;
+    if (setup_p1_retained_clear_conflict(&ctx) != 0) {
+        return 1;
+    }
+
+    p25_sm_event_t ev = p25_sm_ev_active_call(0, 3069, 0, 4009646, 1, 0x04);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (!g_state.p25_p1_crypto_conflict.active || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_ENCRYPTED_PENDING
+        || g_return_requests != 0 || encrypted_call_cache_has(3069U, 1)) {
+        DSD_FPRINTF(stderr, "FAIL: Repeated clear LCW incorrectly corroborated crypto metadata\n");
+        return 1;
+    }
+
+    if (p25_crypto_resolve(NULL, &g_state, DSD_P25_CRYPTO_PHASE1, 0, 0x80, 0, UINT64_C(0x1112131415161718), 3069)
+        != DSD_P25_CRYPTO_CLEAR) {
+        DSD_FPRINTF(stderr, "FAIL: Definitive clear metadata did not resolve quarantined conflict\n");
+        return 1;
+    }
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.state != P25_SM_TUNED || !ctx.slots[0].voice_active || g_state.p25_p1_crypto_conflict.active
+        || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_CLEAR || g_return_requests != 0
+        || encrypted_call_cache_has(3069U, 1) || !p25_crypto_audio_permitted(&g_opts, &g_state, 0)) {
+        DSD_FPRINTF(stderr, "FAIL: Clear metadata did not restore quarantined Phase 1 call\n");
+        return 1;
+    }
+
+    if (setup_p1_retained_clear_conflict(&ctx) != 0) {
+        return 1;
+    }
+    if (p25_crypto_resolve(NULL, &g_state, DSD_P25_CRYPTO_PHASE1, 0, 0xA0, 0x0064, UINT64_C(0x2122232425262728), 3069)
+        != DSD_P25_CRYPTO_BLOCKED) {
+        DSD_FPRINTF(stderr, "FAIL: Matching second tuple did not confirm encryption\n");
+        return 1;
+    }
+    ev = p25_sm_ev_enc(0, 0xA0, 0x0064, 3069);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.state != P25_SM_ON_CC || g_return_requests != 1 || g_state.p25_p1_crypto_conflict.active
+        || !encrypted_call_cache_has(3069U, 1)) {
+        DSD_FPRINTF(stderr, "FAIL: Corroborated Phase 1 encryption did not retain lockout behavior\n");
+        return 1;
+    }
+
+    if (setup_p1_retained_clear_conflict(&ctx) != 0) {
+        return 1;
+    }
+    ctx.slots[0].crypto_attempt_m = dsd_time_now_monotonic_s() - ctx.config.grant_timeout_s - 0.1;
+    p25_sm_tick_ctx(&ctx, &g_opts, &g_state);
+    if (ctx.state != P25_SM_ON_CC || g_return_requests != 1 || encrypted_call_cache_has(3069U, 1)
+        || g_state.p25_p1_crypto_conflict.active) {
+        DSD_FPRINTF(stderr, "FAIL: Unconfirmed Phase 1 conflict timeout produced encrypted-call side effects\n");
         return 1;
     }
     return 0;
@@ -1831,6 +1930,7 @@ main(void) {
     fail += test_p1_fresh_hdu_survives_missed_terminator();
     fail += test_p1_retained_hdu_waits_for_identity();
     fail += test_p1_retained_hdu_defers_lockout_attribution();
+    fail += test_p1_clear_identity_quarantines_conflicting_hdu();
     fail += test_p1_pending_identity_restarts_crypto_without_hdu();
     fail += test_identified_followup_without_service_restarts_crypto_pending();
     fail += test_missed_end_identity_change_without_service_restarts_crypto_pending();

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -837,6 +837,54 @@ test_p1_clear_conflict_restarts_deadline(void) {
 }
 
 static int
+test_p1_grant_hdu_conflict_survives_first_active(void) {
+    reset_test_state();
+    g_opts.trunk_tune_enc_calls = 0;
+    g_state.trunk_chan_map[0x1234] = 851500000;
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    p25_sm_init_ctx(ctx, &g_opts, &g_state);
+    p25_sm_event_t ev = p25_sm_ev_group_grant(0x1234, 851500000, 3069, 4009646, 0x04);
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+    if (ctx->state != P25_SM_TUNED || g_state.dmr_so != 0x04 || !g_state.p25_service_options_valid[0]
+        || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_CLEAR) {
+        DSD_FPRINTF(stderr, "FAIL: Clear Phase 1 grant did not retain service options for HDU reconciliation\n");
+        return 1;
+    }
+
+    const int algid = 0xA0;
+    const int keyid = 0x0064;
+    const uint64_t mi = UINT64_C(0x0102030405060708);
+    g_state.p25_p1_hdu_crypto_fresh = 1;
+    if (p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE1, 0, algid, keyid, mi, 3069)
+            != DSD_P25_CRYPTO_ENCRYPTED_PENDING
+        || !g_state.p25_p1_crypto_conflict.active || ctx->slots[0].crypto_attempt_m <= 0.0) {
+        DSD_FPRINTF(stderr, "FAIL: Conflicting HDU did not enter Phase 1 quarantine after a clear grant\n");
+        return 1;
+    }
+
+    ev = p25_sm_ev_active(0);
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+    if (ctx->state != P25_SM_TUNED || ctx->slots[0].voice_active || !ctx->slots[0].grant_active
+        || !g_state.p25_p1_crypto_conflict.active || !g_state.p25_p1_hdu_crypto_fresh
+        || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_ENCRYPTED_PENDING || g_state.payload_algid != algid
+        || g_state.payload_keyid != keyid || g_state.payload_miP != mi
+        || p25_crypto_audio_permitted(&g_opts, &g_state, 0) || g_return_requests != 0
+        || encrypted_call_cache_has(3069U, 1)) {
+        DSD_FPRINTF(stderr, "FAIL: First anonymous ACTIVE discarded the quarantined HDU tuple\n");
+        return 1;
+    }
+
+    if (p25_crypto_resolve(NULL, &g_state, DSD_P25_CRYPTO_PHASE1, 0, algid, keyid, UINT64_C(0x1112131415161718), 3069)
+            != DSD_P25_CRYPTO_BLOCKED
+        || g_state.p25_p1_crypto_conflict.active) {
+        DSD_FPRINTF(stderr, "FAIL: Preserved HDU tuple did not await matching corroboration\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
 test_p1_pending_identity_restarts_crypto_without_hdu(void) {
     reset_test_state();
     g_state.trunk_chan_map[0x1234] = 851500000;
@@ -1997,6 +2045,7 @@ main(void) {
     fail += test_p1_clear_identity_quarantines_conflicting_hdu();
     fail += test_p1_follow_mode_expires_clear_conflict();
     fail += test_p1_clear_conflict_restarts_deadline();
+    fail += test_p1_grant_hdu_conflict_survives_first_active();
     fail += test_p1_pending_identity_restarts_crypto_without_hdu();
     fail += test_identified_followup_without_service_restarts_crypto_pending();
     fail += test_missed_end_identity_change_without_service_restarts_crypto_pending();

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -675,9 +675,9 @@ test_p1_retained_hdu_defers_lockout_attribution(void) {
 }
 
 static int
-setup_p1_retained_clear_conflict(p25_sm_ctx_t* ctx) {
+setup_p1_retained_clear_conflict(p25_sm_ctx_t* ctx, int follow_encrypted) {
     reset_test_state();
-    g_opts.trunk_tune_enc_calls = 0;
+    g_opts.trunk_tune_enc_calls = follow_encrypted;
     g_state.trunk_chan_map[0x1234] = 851500000;
 
     p25_sm_init_ctx(ctx, &g_opts, &g_state);
@@ -718,7 +718,7 @@ setup_p1_retained_clear_conflict(p25_sm_ctx_t* ctx) {
 static int
 test_p1_clear_identity_quarantines_conflicting_hdu(void) {
     p25_sm_ctx_t ctx;
-    if (setup_p1_retained_clear_conflict(&ctx) != 0) {
+    if (setup_p1_retained_clear_conflict(&ctx, 0) != 0) {
         return 1;
     }
 
@@ -743,7 +743,7 @@ test_p1_clear_identity_quarantines_conflicting_hdu(void) {
         return 1;
     }
 
-    if (setup_p1_retained_clear_conflict(&ctx) != 0) {
+    if (setup_p1_retained_clear_conflict(&ctx, 0) != 0) {
         return 1;
     }
     if (p25_crypto_resolve(NULL, &g_state, DSD_P25_CRYPTO_PHASE1, 0, 0xA0, 0x0064, UINT64_C(0x2122232425262728), 3069)
@@ -759,7 +759,7 @@ test_p1_clear_identity_quarantines_conflicting_hdu(void) {
         return 1;
     }
 
-    if (setup_p1_retained_clear_conflict(&ctx) != 0) {
+    if (setup_p1_retained_clear_conflict(&ctx, 0) != 0) {
         return 1;
     }
     ctx.slots[0].crypto_attempt_m = dsd_time_now_monotonic_s() - ctx.config.grant_timeout_s - 0.1;
@@ -767,6 +767,70 @@ test_p1_clear_identity_quarantines_conflicting_hdu(void) {
     if (ctx.state != P25_SM_ON_CC || g_return_requests != 1 || encrypted_call_cache_has(3069U, 1)
         || g_state.p25_p1_crypto_conflict.active) {
         DSD_FPRINTF(stderr, "FAIL: Unconfirmed Phase 1 conflict timeout produced encrypted-call side effects\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_p1_follow_mode_expires_clear_conflict(void) {
+    p25_sm_ctx_t ctx;
+    if (setup_p1_retained_clear_conflict(&ctx, 1) != 0) {
+        return 1;
+    }
+
+    ctx.slots[0].crypto_attempt_m = dsd_time_now_monotonic_s() - ctx.config.grant_timeout_s - 0.1;
+    p25_sm_tick_ctx(&ctx, &g_opts, &g_state);
+    if (ctx.state != P25_SM_TUNED || g_return_requests != 0 || !ctx.slots[0].grant_active || !ctx.slots[0].voice_active
+        || ctx.slots[0].crypto_attempt_m > 0.0 || g_state.p25_p1_crypto_conflict.active
+        || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_CLEAR || g_state.payload_algid != 0
+        || g_state.payload_keyid != 0 || !p25_crypto_audio_permitted(&g_opts, &g_state, 0)) {
+        DSD_FPRINTF(stderr, "FAIL: Encrypted-follow mode did not expire and release a clear conflict\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_p1_clear_conflict_restarts_deadline(void) {
+    reset_test_state();
+    g_opts.trunk_tune_enc_calls = 0;
+    g_state.trunk_chan_map[0x1234] = 851500000;
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    p25_sm_init_ctx(ctx, &g_opts, &g_state);
+    p25_sm_event_t ev = p25_sm_ev_group_grant(0x1234, 851500000, 3069, 4009646, 0x04);
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+    ev = p25_sm_ev_active_call(0, 3069, 0, 4009646, 1, 0x04);
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+    g_state.dmr_so = 0x04;
+    g_state.p25_service_options_valid[0] = 1;
+
+    if (p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE1, 0, 0xA0, 0x0064, UINT64_C(0x0102030405060708),
+                           3069)
+            != DSD_P25_CRYPTO_ENCRYPTED_PENDING
+        || ctx->slots[0].crypto_attempt_m <= 0.0) {
+        DSD_FPRINTF(stderr, "FAIL: Initial clear conflict did not start a classification deadline\n");
+        return 1;
+    }
+    if (p25_crypto_resolve(NULL, &g_state, DSD_P25_CRYPTO_PHASE1, 0, 0x80, 0, UINT64_C(0x1112131415161718), 3069)
+        != DSD_P25_CRYPTO_CLEAR) {
+        DSD_FPRINTF(stderr, "FAIL: Clear recovery did not retire the initial conflict epoch\n");
+        return 1;
+    }
+
+    const double stale_deadline_m = dsd_time_now_monotonic_s() - ctx->config.grant_timeout_s - 0.1;
+    ctx->slots[0].crypto_attempt_m = stale_deadline_m;
+    if (p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE1, 0, 0xA0, 0x0064, UINT64_C(0x2122232425262728),
+                           3069)
+            != DSD_P25_CRYPTO_ENCRYPTED_PENDING
+        || ctx->slots[0].crypto_attempt_m <= stale_deadline_m + ctx->config.grant_timeout_s) {
+        DSD_FPRINTF(stderr, "FAIL: Fresh clear conflict reused the preceding epoch deadline\n");
+        return 1;
+    }
+    p25_sm_tick_ctx(ctx, &g_opts, &g_state);
+    if (ctx->state != P25_SM_TUNED || g_return_requests != 0 || !g_state.p25_p1_crypto_conflict.active) {
+        DSD_FPRINTF(stderr, "FAIL: Fresh clear conflict expired immediately after clear recovery\n");
         return 1;
     }
     return 0;
@@ -1931,6 +1995,8 @@ main(void) {
     fail += test_p1_retained_hdu_waits_for_identity();
     fail += test_p1_retained_hdu_defers_lockout_attribution();
     fail += test_p1_clear_identity_quarantines_conflicting_hdu();
+    fail += test_p1_follow_mode_expires_clear_conflict();
+    fail += test_p1_clear_conflict_restarts_deadline();
     fail += test_p1_pending_identity_restarts_crypto_without_hdu();
     fail += test_identified_followup_without_service_restarts_crypto_pending();
     fail += test_missed_end_identity_change_without_service_restarts_crypto_pending();


### PR DESCRIPTION
## Summary

- Quarantine a single non-clear P25 Phase 1 HDU/LDU2 tuple when authoritative LCW service options identify the call as clear.
- Require a second matching ALGID/KID observation before entering confirmed encryption lockout or applying cache, history, and learned-alias side effects.
- Keep audio hard-muted while metadata is contradictory, then release an unconfirmed candidate on clear recovery or timeout.
- Preserve the existing Phase 2 path and the existing behavior for confirmed encrypted calls.

## Root Cause

A FEC-accepted Phase 1 crypto tuple could be classified as blocked before the current transmission's authoritative identity arrived. When a later LCW identified that transmission with clear service options, the retained tuple was reapplied as definitive encryption. That emitted an encrypted-call event, cached the talkgroup as encrypted, and changed history and alias policy even though the LCW said the call was clear.

## Behavioral Impact

Clear talkgroups are no longer blacklisted or displayed as encrypted because of one contradictory Phase 1 tuple. A genuinely encrypted call with contradictory clear service options still reaches the existing lockout path after a second matching tuple. ALGID 0x80 restores clear handling immediately, and unresolved conflicts expire without promoting or caching encryption.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human. Pending review on this draft.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented. Pending human review; the broader quality gate is recorded below.
- [x] High-risk areas touched are marked: crypto / radio input.
- [ ] Outside review was requested when available, or unavailability is documented. No reviewer has been requested yet.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions. No copied or bulk-written code is included.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. No suppressions were added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` — 462/462 passed
- [x] `tools/preflight_ci.sh`
- [x] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes — passed through the quality gate; no CMake files changed
- [x] `tools/zizmor.sh` for workflow changes — passed through the quality gate; no workflow files changed
- [x] `tools/osv_scan.sh` for dependency input changes — passed through the quality gate; no dependency inputs changed
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes — not applicable; no workflow or release files changed

## Risk

- Security/dependency impact: No dependency, cipher, or key-handling changes. Ambiguous media remains hard-muted until the metadata conflict resolves.
- CLI/UI behavior impact: Prevents false encrypted history entries and talkgroup lockout; adds deferred/timeout diagnostics for contradictory Phase 1 metadata.
- Compatibility or packaging impact: No configuration or packaging changes. The concrete `dsd_state` layout gains one small Phase 1 conflict record, so consumers using that internal state layout must rebuild.
