### PR TITLE
ui: color event history by neutral metadata

### DIFF
--- a/include/dsd-neo/core/events.h
+++ b/include/dsd-neo/core/events.h
@@ -129,6 +129,16 @@ int dsd_event_state_copy_snapshot_incremental(dsd_state* dst, const dsd_state* s
                                               const uint64_t source_revisions[2], int force_copy, uint8_t copied[2]);
 int dsd_event_state_copy_snapshot(dsd_state* dst, const dsd_state* src, Event_History_I event_history[2]);
 void watchdog_event_status(dsd_state* state, const char* status_string, uint8_t slot);
+/**
+ * Commit a data/control notice using neutral event metadata.
+ *
+ * Only DSD_EVENT_CATEGORY_DATA and DSD_EVENT_CATEGORY_CONTROL are accepted.
+ * Invalid categories are rejected without changing event history.
+ */
+int dsd_event_emit_data_notice_classified(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                          const dsd_call_observation* observation, dsd_event_category category,
+                                          const char* notice);
+/** Commit a data notice. Equivalent to dsd_event_emit_data_notice_classified() with the DATA category. */
 int dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
                                const char* notice);
 /** Commit a data notice with GPS owned by the new event, leaving the active row's staged payload unchanged. */

--- a/include/dsd-neo/core/events.h
+++ b/include/dsd-neo/core/events.h
@@ -138,10 +138,19 @@ void watchdog_event_status(dsd_state* state, const char* status_string, uint8_t 
 int dsd_event_emit_data_notice_classified(dsd_opts* opts, dsd_state* state, uint8_t slot,
                                           const dsd_call_observation* observation, dsd_event_category category,
                                           const char* notice);
+/**
+ * Commit a data/control notice with GPS owned by the new event, leaving the active row's staged payload unchanged.
+ *
+ * Only DSD_EVENT_CATEGORY_DATA and DSD_EVENT_CATEGORY_CONTROL are accepted.
+ * Invalid categories or a NULL GPS value are rejected without changing event history.
+ */
+int dsd_event_emit_data_notice_classified_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                                   const dsd_call_observation* observation, dsd_event_category category,
+                                                   const char* notice, const char* gps);
 /** Commit a data notice. Equivalent to dsd_event_emit_data_notice_classified() with the DATA category. */
 int dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
                                const char* notice);
-/** Commit a data notice with GPS owned by the new event, leaving the active row's staged payload unchanged. */
+/** Commit a data notice with GPS. Equivalent to the classified GPS API with the DATA category. */
 int dsd_event_emit_data_notice_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,
                                         const dsd_call_observation* observation, const char* notice, const char* gps);
 /** Commit an informational system notice without attributing it to radio traffic. */

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -1377,10 +1377,21 @@ dsd_event_clear_data_payload(Event_History* item) {
 }
 
 static int
-dsd_event_emit_data_notice_impl(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
-                                const char* notice, const char* gps, int consume_staged_payload) {
+dsd_event_data_notice_args_valid(const dsd_opts* opts, const dsd_state* state, uint8_t slot,
+                                 const dsd_call_observation* observation, dsd_event_category category,
+                                 const char* notice) {
     if (opts == NULL || state == NULL || state->event_history_s == NULL || observation == NULL || notice == NULL
         || slot > 1U || observation->slot != slot || observation->kind != DSD_CALL_KIND_DATA) {
+        return 0;
+    }
+    return category == DSD_EVENT_CATEGORY_DATA || category == DSD_EVENT_CATEGORY_CONTROL;
+}
+
+static int
+dsd_event_emit_data_notice_impl(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
+                                dsd_event_category category, const char* notice, const char* gps,
+                                int consume_staged_payload) {
+    if (!dsd_event_data_notice_args_valid(opts, state, slot, observation, category, notice)) {
         return -1;
     }
 
@@ -1394,7 +1405,7 @@ dsd_event_emit_data_notice_impl(dsd_opts* opts, dsd_state* state, uint8_t slot, 
 
     Event_History* item = &event_struct->Event_History_Items[0];
     item->write = 1;
-    dsd_event_history_item_set_metadata(item, DSD_EVENT_SEVERITY_INFO, DSD_EVENT_CATEGORY_DATA);
+    dsd_event_history_item_set_metadata(item, DSD_EVENT_SEVERITY_INFO, category);
     item->systype = observation->protocol;
     item->subtype = DSD_EVENT_SUBTYPE_EXPLICIT_DATA;
     item->gi = -1;
@@ -1436,9 +1447,16 @@ dsd_event_emit_data_notice_impl(dsd_opts* opts, dsd_state* state, uint8_t slot, 
 }
 
 int
+dsd_event_emit_data_notice_classified(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                      const dsd_call_observation* observation, dsd_event_category category,
+                                      const char* notice) {
+    return dsd_event_emit_data_notice_impl(opts, state, slot, observation, category, notice, NULL, 1);
+}
+
+int
 dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
                            const char* notice) {
-    return dsd_event_emit_data_notice_impl(opts, state, slot, observation, notice, NULL, 1);
+    return dsd_event_emit_data_notice_classified(opts, state, slot, observation, DSD_EVENT_CATEGORY_DATA, notice);
 }
 
 int
@@ -1447,7 +1465,7 @@ dsd_event_emit_data_notice_with_gps(dsd_opts* opts, dsd_state* state, uint8_t sl
     if (gps == NULL) {
         return -1;
     }
-    return dsd_event_emit_data_notice_impl(opts, state, slot, observation, notice, gps, 0);
+    return dsd_event_emit_data_notice_impl(opts, state, slot, observation, DSD_EVENT_CATEGORY_DATA, notice, gps, 0);
 }
 
 int

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -1460,12 +1460,20 @@ dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const
 }
 
 int
-dsd_event_emit_data_notice_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,
-                                    const dsd_call_observation* observation, const char* notice, const char* gps) {
+dsd_event_emit_data_notice_classified_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                               const dsd_call_observation* observation, dsd_event_category category,
+                                               const char* notice, const char* gps) {
     if (gps == NULL) {
         return -1;
     }
-    return dsd_event_emit_data_notice_impl(opts, state, slot, observation, DSD_EVENT_CATEGORY_DATA, notice, gps, 0);
+    return dsd_event_emit_data_notice_impl(opts, state, slot, observation, category, notice, gps, 0);
+}
+
+int
+dsd_event_emit_data_notice_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                    const dsd_call_observation* observation, const char* notice, const char* gps) {
+    return dsd_event_emit_data_notice_classified_with_gps(opts, state, slot, observation, DSD_EVENT_CATEGORY_DATA,
+                                                          notice, gps);
 }
 
 int

--- a/src/protocol/dmr/dmr_block.c
+++ b/src/protocol/dmr/dmr_block.c
@@ -1228,6 +1228,11 @@ dmr_block_type1_print_mnis_type(uint8_t mnis_type) {
     }
 }
 
+static dsd_event_category
+dmr_block_type1_mnis_event_category(uint8_t mnis_type) {
+    return (mnis_type == 0x33U || mnis_type == 0x88U) ? DSD_EVENT_CATEGORY_CONTROL : DSD_EVENT_CATEGORY_DATA;
+}
+
 static void
 dmr_block_type1_handle_mnis_payload(dmr_block_assembler_ctx* ctx, uint16_t len, uint8_t mnis_type, int offset,
                                     uint32_t msrc, uint32_t mdst) {
@@ -1256,13 +1261,15 @@ dmr_block_type1_handle_mnis_payload(dmr_block_assembler_ctx* ctx, uint16_t len, 
         const dsd_call_observation observation = dsd_call_observation_data(
             ctx->state->lastsynctype, ctx->slot, (uint64_t)ctx->state->dmr_lrrp_source[ctx->slot],
             (uint64_t)ctx->state->dmr_lrrp_target[ctx->slot]);
-        (void)dsd_event_emit_data_notice(ctx->opts, ctx->state, ctx->slot, &observation, mnis_str);
+        (void)dsd_event_emit_data_notice_classified(ctx->opts, ctx->state, ctx->slot, &observation,
+                                                    dmr_block_type1_mnis_event_category(mnis_type), mnis_str);
     } else if (mnis_type == 0x11 || mnis_type == 0x01) {
         const dsd_call_observation observation = dsd_call_observation_data(
             ctx->state->lastsynctype, ctx->slot, (uint64_t)ctx->state->dmr_lrrp_source[ctx->slot],
             (uint64_t)ctx->state->dmr_lrrp_target[ctx->slot]);
-        (void)dsd_event_emit_data_notice(ctx->opts, ctx->state, ctx->slot, &observation,
-                                         ctx->state->dmr_lrrp_gps[ctx->slot]);
+        (void)dsd_event_emit_data_notice_classified(ctx->opts, ctx->state, ctx->slot, &observation,
+                                                    dmr_block_type1_mnis_event_category(mnis_type),
+                                                    ctx->state->dmr_lrrp_gps[ctx->slot]);
     }
 }
 

--- a/src/protocol/dmr/dmr_pdu.c
+++ b/src/protocol/dmr/dmr_pdu.c
@@ -647,7 +647,7 @@ decode_ip_pdu_handle_udp_service_core(dsd_opts* opts, dsd_state* state, uint8_t 
                          dst24);
             dsd_event_history_transaction_begin(state, &transaction);
             dsd_event_history_item_set_metadata(&state->event_history_s[slot].Event_History_Items[0],
-                                                DSD_EVENT_SEVERITY_INFO, DSD_EVENT_CATEGORY_DATA);
+                                                DSD_EVENT_SEVERITY_INFO, DSD_EVENT_CATEGORY_CONTROL);
             dsd_event_history_mark_dirty(&state->event_history_s[slot]);
             dsd_event_history_transaction_end(&transaction);
             return 1;
@@ -829,6 +829,21 @@ decode_ip_pdu_dispatch(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t p
     DSD_FPRINTF(stderr, "Unknown IP Protocol: %02X;", prot);
 }
 
+static dsd_event_category
+decode_ip_pdu_event_category(uint8_t protocol, uint16_t dst_port) {
+    if (protocol != 0x11U) {
+        return DSD_EVENT_CATEGORY_DATA;
+    }
+
+    switch (dst_port) {
+        case 4004U:
+        case 4005U:
+        case 4009U:
+        case 9361U: return DSD_EVENT_CATEGORY_CONTROL;
+        default: return DSD_EVENT_CATEGORY_DATA;
+    }
+}
+
 //IP PDU header decode and port forward to appropriate decoder
 int
 decode_ip_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, uint8_t* input) {
@@ -890,7 +905,9 @@ decode_ip_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, uint8_t* input) {
     decode_ip_pdu_dispatch(opts, state, slot, prot, src24, dst24, effective_len, ip_header_len, input);
 
     const dsd_call_observation observation = dsd_call_observation_data(state->lastsynctype, slot, src24, dst24);
-    return dsd_event_emit_data_notice(opts, state, slot, &observation, state->dmr_lrrp_gps[slot]) == 0;
+    const dsd_event_category category = decode_ip_pdu_event_category(prot, dst_port);
+    return dsd_event_emit_data_notice_classified(opts, state, slot, &observation, category, state->dmr_lrrp_gps[slot])
+           == 0;
 }
 
 typedef struct {

--- a/src/protocol/dmr/dmr_pdu.c
+++ b/src/protocol/dmr/dmr_pdu.c
@@ -315,6 +315,24 @@ dmr_udp_comp_port_idx_desc(uint16_t pid) {
     return "Manufacturer Specific";
 }
 
+static int
+dmr_udp_is_control_service_port(uint16_t port) {
+    switch (port) {
+        case 4004U:
+        case 4005U:
+        case 4009U:
+        case 9361U: return 1;
+        default: return 0;
+    }
+}
+
+static dsd_event_category
+dmr_udp_event_category(uint16_t src_port, uint16_t dst_port) {
+    return dmr_udp_is_control_service_port(src_port) || dmr_udp_is_control_service_port(dst_port)
+               ? DSD_EVENT_CATEGORY_CONTROL
+               : DSD_EVENT_CATEGORY_DATA;
+}
+
 static uint16_t
 dmr_udp_comp_resolve_port_ptr(const uint8_t* pdu, uint16_t len, uint16_t* spid, uint16_t* dpid) {
     uint16_t ptr = 5;
@@ -407,11 +425,12 @@ dmr_udp_comp_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* 
     DSD_SNPRINTF(comp_string, sizeof(comp_string), "IPC: %d; OP: %d; SRC: %d:%d (%s):(%s); DST: %d:%d (%s):(%s); ",
                  ipid, opcode, said, spid, src_idx_desc, src_port_desc, daid, dpid, dst_idx_desc, dst_port_desc);
     const dsd_call_observation observation = dsd_call_observation_data(state->lastsynctype, slot, said, daid);
+    const dsd_event_category category = dmr_udp_event_category(spid, dpid);
     if (has_gps) {
-        (void)dsd_event_emit_data_notice_with_gps(opts, state, slot, &observation, comp_string,
-                                                  state->dmr_embedded_gps[slot]);
+        (void)dsd_event_emit_data_notice_classified_with_gps(opts, state, slot, &observation, category, comp_string,
+                                                             state->dmr_embedded_gps[slot]);
     } else {
-        (void)dsd_event_emit_data_notice(opts, state, slot, &observation, comp_string);
+        (void)dsd_event_emit_data_notice_classified(opts, state, slot, &observation, category, comp_string);
     }
 }
 
@@ -830,18 +849,11 @@ decode_ip_pdu_dispatch(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t p
 }
 
 static dsd_event_category
-decode_ip_pdu_event_category(uint8_t protocol, uint16_t dst_port) {
+decode_ip_pdu_event_category(uint8_t protocol, uint16_t src_port, uint16_t dst_port) {
     if (protocol != 0x11U) {
         return DSD_EVENT_CATEGORY_DATA;
     }
-
-    switch (dst_port) {
-        case 4004U:
-        case 4005U:
-        case 4009U:
-        case 9361U: return DSD_EVENT_CATEGORY_CONTROL;
-        default: return DSD_EVENT_CATEGORY_DATA;
-    }
+    return dmr_udp_event_category(src_port, dst_port);
 }
 
 //IP PDU header decode and port forward to appropriate decoder
@@ -905,7 +917,7 @@ decode_ip_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, uint8_t* input) {
     decode_ip_pdu_dispatch(opts, state, slot, prot, src24, dst24, effective_len, ip_header_len, input);
 
     const dsd_call_observation observation = dsd_call_observation_data(state->lastsynctype, slot, src24, dst24);
-    const dsd_event_category category = decode_ip_pdu_event_category(prot, dst_port);
+    const dsd_event_category category = decode_ip_pdu_event_category(prot, src_port, dst_port);
     return dsd_event_emit_data_notice_classified(opts, state, slot, &observation, category, state->dmr_lrrp_gps[slot])
            == 0;
 }

--- a/src/protocol/p25/phase1/p25p1_pdu_data.c
+++ b/src/protocol/p25/phase1/p25p1_pdu_data.c
@@ -795,6 +795,30 @@ typedef struct {
     int data_notice_emitted;
 } P25PduDecodeStatus;
 
+static dsd_event_category
+p25_pdu_event_category(uint8_t fmt, uint8_t sap) {
+    if (fmt == 3U) {
+        return DSD_EVENT_CATEGORY_DATA;
+    }
+
+    switch (sap) {
+        case 3U:
+        case 6U:
+        case 29U:
+        case 32U:
+        case 33U:
+        case 34U:
+        case 37U:
+        case 38U:
+        case 39U:
+        case 40U:
+        case 41U:
+        case 61U:
+        case 63U: return DSD_EVENT_CATEGORY_CONTROL;
+        default: return DSD_EVENT_CATEGORY_DATA;
+    }
+}
+
 static P25PduDataFields
 p25_read_pdu_data_fields(const uint8_t* input) {
     P25PduDataFields pdu;
@@ -1018,6 +1042,7 @@ p25_decode_pdu_data(dsd_opts* opts, dsd_state* state, uint8_t* input, int len) {
     if (!status.data_notice_emitted) {
         const dsd_call_observation observation =
             dsd_call_observation_data(state->lastsynctype, 0U, pdu.source_id, pdu.target_id);
-        (void)dsd_event_emit_data_notice(opts, state, 0U, &observation, state->dmr_lrrp_gps[0]);
+        (void)dsd_event_emit_data_notice_classified(opts, state, 0U, &observation,
+                                                    p25_pdu_event_category(pdu.fmt, pdu.sap), state->dmr_lrrp_gps[0]);
     }
 }

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -1460,17 +1460,27 @@ ui_history_clamp_line_size(const ui_history_render_ctx* ctx, int prefix_len) {
     return line_size;
 }
 
-static void
+static short
 ui_history_color_pair_for_event(const Event_History* item) {
-    short color_pair = 4;
-    if (item != NULL) {
-        if (item->severity != DSD_EVENT_SEVERITY_UNKNOWN || item->category != DSD_EVENT_CATEGORY_UNKNOWN) {
-            color_pair = 4;
-        } else if (item->color_pair != 0) {
-            color_pair = (short)item->color_pair;
-        }
+    if (item == NULL) {
+        return 4;
     }
-    attron(COLOR_PAIR(color_pair));
+
+    if (item->severity == DSD_EVENT_SEVERITY_UNKNOWN && item->category == DSD_EVENT_CATEGORY_UNKNOWN) {
+        return item->color_pair != 0U ? (short)item->color_pair : 4;
+    }
+    if (item->severity == DSD_EVENT_SEVERITY_ERROR) {
+        return 2;
+    }
+    if (item->severity == DSD_EVENT_SEVERITY_WARNING) {
+        return 1;
+    }
+
+    switch (item->category) {
+        case DSD_EVENT_CATEGORY_VOICE: return 3;
+        case DSD_EVENT_CATEGORY_CONTROL: return 1;
+        default: return 4;
+    }
 }
 
 static void
@@ -1497,7 +1507,7 @@ ui_history_print_event_summary(const Event_History* item, const char* line_prefi
     DSD_MEMCPY(text_string, compact_string, text_size);
     text_string[text_size] = '\0';
     printw("%s", line_prefix);
-    ui_history_color_pair_for_event(item);
+    attron(COLOR_PAIR(ui_history_color_pair_for_event(item)));
     printw("%s\n", text_string);
     attron(COLOR_PAIR(4));
 }

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -664,6 +664,22 @@ test_data_notice_with_gps_owns_payload_without_consuming_active_row(void) {
     rc |= expect_int("explicit GPS preserves active PDU", current->pdu[0], 0xAB);
     rc |= expect_str_eq("explicit GPS preserves active text", current->text_message, "active call text");
     rc |= expect_str_eq("explicit GPS preserves active GPS", current->gps_s, "active call GPS");
+
+    reset_fixture(&opts, &state, event_history);
+    active = &event_history[0].Event_History_Items[0];
+    active->pdu[0] = 0xCDU;
+    DSD_SNPRINTF(active->text_message, sizeof(active->text_message), "%s", "control-active text");
+    assert(dsd_event_emit_data_notice_classified_with_gps(&opts, &state, 0U, &observation, DSD_EVENT_CATEGORY_CONTROL,
+                                                          "Control GPS;", "42.000000 -88.000000")
+           == 0);
+
+    committed = &event_history[0].Event_History_Items[1];
+    current = &event_history[0].Event_History_Items[0];
+    rc |= expect_int("classified GPS event category", committed->category, DSD_EVENT_CATEGORY_CONTROL);
+    rc |= expect_str_eq("classified GPS event payload", committed->gps_s, "42.000000 -88.000000");
+    rc |= expect_int("classified GPS event does not inherit active PDU", committed->pdu[0], 0);
+    rc |= expect_int("classified GPS preserves active PDU", current->pdu[0], 0xCD);
+    rc |= expect_str_eq("classified GPS preserves active text", current->text_message, "control-active text");
     return rc;
 }
 

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -293,6 +293,44 @@ expect_str_eq(const char* label, const char* got, const char* want) {
 }
 
 static int
+event_history_item_equal(const Event_History* lhs, const Event_History* rhs) {
+    return lhs->write == rhs->write && lhs->color_pair == rhs->color_pair && lhs->severity == rhs->severity
+           && lhs->category == rhs->category && lhs->systype == rhs->systype && lhs->subtype == rhs->subtype
+           && lhs->sys_id1 == rhs->sys_id1 && lhs->sys_id2 == rhs->sys_id2 && lhs->sys_id3 == rhs->sys_id3
+           && lhs->sys_id4 == rhs->sys_id4 && lhs->sys_id5 == rhs->sys_id5 && lhs->gi == rhs->gi && lhs->enc == rhs->enc
+           && lhs->enc_alg == rhs->enc_alg && lhs->enc_key == rhs->enc_key && lhs->mi == rhs->mi && lhs->svc == rhs->svc
+           && lhs->source_id == rhs->source_id && lhs->target_id == rhs->target_id
+           && memcmp(lhs->src_str, rhs->src_str, sizeof lhs->src_str) == 0
+           && memcmp(lhs->tgt_str, rhs->tgt_str, sizeof lhs->tgt_str) == 0
+           && memcmp(lhs->t_name, rhs->t_name, sizeof lhs->t_name) == 0
+           && memcmp(lhs->s_name, rhs->s_name, sizeof lhs->s_name) == 0
+           && memcmp(lhs->t_mode, rhs->t_mode, sizeof lhs->t_mode) == 0
+           && memcmp(lhs->s_mode, rhs->s_mode, sizeof lhs->s_mode) == 0 && lhs->channel == rhs->channel
+           && lhs->event_time == rhs->event_time && memcmp(lhs->pdu, rhs->pdu, sizeof lhs->pdu) == 0
+           && memcmp(lhs->sysid_string, rhs->sysid_string, sizeof lhs->sysid_string) == 0
+           && memcmp(lhs->alias, rhs->alias, sizeof lhs->alias) == 0
+           && memcmp(lhs->gps_s, rhs->gps_s, sizeof lhs->gps_s) == 0
+           && memcmp(lhs->text_message, rhs->text_message, sizeof lhs->text_message) == 0
+           && memcmp(lhs->event_string, rhs->event_string, sizeof lhs->event_string) == 0
+           && memcmp(lhs->internal_str, rhs->internal_str, sizeof lhs->internal_str) == 0;
+}
+
+static int
+event_histories_equal(const Event_History_I lhs[2], const Event_History_I rhs[2]) {
+    for (size_t slot = 0U; slot < 2U; slot++) {
+        if (lhs[slot].revision != rhs[slot].revision) {
+            return 0;
+        }
+        for (size_t item = 0U; item < 255U; item++) {
+            if (!event_history_item_equal(&lhs[slot].Event_History_Items[item], &rhs[slot].Event_History_Items[item])) {
+                return 0;
+            }
+        }
+    }
+    return 1;
+}
+
+static int
 append_policy_label(dsd_state* state, uint32_t id, const char* mode, const char* name) {
     dsd_tg_policy_entry row;
     if (dsd_tg_policy_make_exact_entry(id, mode, name, DSD_TG_POLICY_SOURCE_IMPORTED, &row) != 0) {
@@ -515,6 +553,85 @@ test_data_notice_preserves_decoded_payload_fields(void) {
     rc |= expect_int("staged data PDU is cleared from current row", current->pdu[0], 0);
     rc |= expect_int("staged data text is cleared from current row", current->text_message[0], '\0');
     rc |= expect_int("staged data GPS is cleared from current row", current->gps_s[0], '\0');
+    return rc;
+}
+
+static int
+test_classified_control_notice_preserves_data_notice_behavior(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_DATA;
+
+    Event_History* decoded = &event_history[0].Event_History_Items[0];
+    decoded->pdu[0] = 0x56U;
+    decoded->pdu[1] = 0x78U;
+    DSD_SNPRINTF(decoded->text_message, sizeof(decoded->text_message), "%s", "registration payload");
+    DSD_SNPRINTF(decoded->gps_s, sizeof(decoded->gps_s), "%s", "staged location");
+    const uint64_t revision_before = event_history[0].revision;
+
+    const dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_DMR_BS_DATA_POS, 0U, 1234U, 5678U);
+    assert(
+        dsd_event_emit_data_notice_classified(&opts, &state, 0U, &observation, DSD_EVENT_CATEGORY_CONTROL, "MNIS ARS;")
+        == 0);
+
+    const Event_History* committed = &event_history[0].Event_History_Items[1];
+    const Event_History* current = &event_history[0].Event_History_Items[0];
+    int rc = 0;
+    rc |= expect_int("classified control category", committed->category, DSD_EVENT_CATEGORY_CONTROL);
+    rc |= expect_int("classified control severity", committed->severity, DSD_EVENT_SEVERITY_INFO);
+    rc |= expect_int("classified control source", (int)committed->source_id, 1234);
+    rc |= expect_int("classified control target", (int)committed->target_id, 5678);
+    rc |= expect_int("classified control first payload byte", committed->pdu[0], 0x56);
+    rc |= expect_int("classified control second payload byte", committed->pdu[1], 0x78);
+    rc |= expect_str_eq("classified control text payload", committed->text_message, "registration payload");
+    rc |= expect_str_eq("classified control GPS payload", committed->gps_s, "staged location");
+    rc |= expect_has_substr("classified control notice", committed->event_string, "MNIS ARS;");
+    rc |= expect_int("classified control clears staged PDU", current->pdu[0], 0);
+    rc |= expect_int("classified control clears staged text", current->text_message[0], '\0');
+    rc |= expect_int("classified control clears staged GPS", current->gps_s[0], '\0');
+    rc |= expect_u64("classified control revision behavior", event_history[0].revision, revision_before + 3U);
+    rc |= expect_int("classified control emits data alert", g_beeper_count, 1);
+    rc |= expect_int("classified control uses data tone", g_last_beeper_id, 80);
+    rc |= expect_int("classified control emits frame log", g_frame_log_count, 1);
+    rc |= expect_has_substr("classified control frame log text", g_last_frame_log, "MNIS ARS;");
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+static int
+test_classified_data_notice_rejects_invalid_categories_without_mutation(void) {
+    static const dsd_event_category invalid_categories[] = {
+        DSD_EVENT_CATEGORY_UNKNOWN,
+        DSD_EVENT_CATEGORY_STATUS,
+        DSD_EVENT_CATEGORY_VOICE,
+        DSD_EVENT_CATEGORY_SYSTEM,
+    };
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    static Event_History_I before[2];
+    reset_fixture(&opts, &state, event_history);
+
+    event_history[0].Event_History_Items[0].pdu[0] = 0xABU;
+    DSD_SNPRINTF(event_history[0].Event_History_Items[0].text_message,
+                 sizeof(event_history[0].Event_History_Items[0].text_message), "%s", "staged text");
+    DSD_MEMCPY(before, event_history, sizeof(before));
+    const dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_DMR_BS_DATA_POS, 0U, 1234U, 5678U);
+
+    int rc = 0;
+    for (size_t i = 0U; i < sizeof(invalid_categories) / sizeof(invalid_categories[0]); i++) {
+        rc |= expect_int("invalid classified category rejected",
+                         dsd_event_emit_data_notice_classified(&opts, &state, 0U, &observation, invalid_categories[i],
+                                                               "Rejected notice;"),
+                         -1);
+        rc |= expect_int("invalid classified category leaves history unchanged",
+                         event_histories_equal(before, event_history), 1);
+    }
+    rc |= expect_int("invalid classified category emits no alert", g_beeper_count, 0);
+    rc |= expect_int("invalid classified category emits no frame log", g_frame_log_count, 0);
+    dsd_state_ext_free_all(&state);
     return rc;
 }
 
@@ -1380,6 +1497,35 @@ test_canonical_call_lifecycle_is_epoch_driven(void) {
 }
 
 static int
+test_canonical_voice_category_is_protocol_neutral(void) {
+    static const int protocols[] = {
+        DSD_SYNC_P25P1_POS, DSD_SYNC_P25P2_POS,        DSD_SYNC_DMR_BS_VOICE_POS, DSD_SYNC_DMR_MS_VOICE,
+        DSD_SYNC_NXDN_POS,  DSD_SYNC_X2TDMA_VOICE_POS, DSD_SYNC_PROVOICE_POS,     DSD_SYNC_EDACS_POS,
+        DSD_SYNC_YSF_POS,   DSD_SYNC_DSTAR_VOICE_POS,  DSD_SYNC_DPMR_FS1_POS,     DSD_SYNC_M17_STR_POS,
+    };
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+
+    int rc = 0;
+    for (size_t i = 0U; i < sizeof(protocols) / sizeof(protocols[0]); i++) {
+        reset_fixture(&opts, &state, event_history);
+        rc |= expect_int("canonical voice starts",
+                         observe_test_call(&state, 0U, protocols[i], DSD_CALL_KIND_GROUP_VOICE, 1000U + i, 2000U + i,
+                                           0U, 0U, DSD_CALL_BOUNDARY_BEGIN),
+                         1);
+        watchdog_event_current(&opts, &state, 0U);
+
+        const Event_History* current = &event_history[0].Event_History_Items[0];
+        rc |= expect_int("canonical voice protocol metadata", current->systype, protocols[i]);
+        rc |= expect_int("canonical voice severity metadata", current->severity, DSD_EVENT_SEVERITY_INFO);
+        rc |= expect_int("canonical voice category metadata", current->category, DSD_EVENT_CATEGORY_VOICE);
+    }
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+static int
 test_provisional_voice_identity_does_not_commit_zero_row(void) {
     static const int protocols[] = {
         DSD_SYNC_P25P1_POS,       DSD_SYNC_P25P2_POS,    DSD_SYNC_DMR_BS_VOICE_POS,
@@ -1418,6 +1564,8 @@ test_provisional_voice_identity_does_not_commit_zero_row(void) {
         const Event_History* prior = &event_history[0].Event_History_Items[1];
         rc |= expect_int("specialized current row has target", (int)current->target_id, (int)(1000U + i));
         rc |= expect_int("specialized current row has source", (int)current->source_id, (int)(2000U + i));
+        rc |= expect_int("canonical voice row has protocol-neutral category", current->category,
+                         DSD_EVENT_CATEGORY_VOICE);
         rc |= expect_int("specialization does not commit provisional row", prior->event_string[0], '\0');
         rc |= expect_int("specialization does not repeat start alert", g_beeper_count, 1);
 
@@ -1689,6 +1837,8 @@ main(void) {
     rc |= test_data_only_data_call_emits_one_data_alert();
     rc |= test_data_call_emits_frame_log_record();
     rc |= test_data_notice_preserves_decoded_payload_fields();
+    rc |= test_classified_control_notice_preserves_data_notice_behavior();
+    rc |= test_classified_data_notice_rejects_invalid_categories_without_mutation();
     rc |= test_data_notice_with_gps_owns_payload_without_consuming_active_row();
     rc |= test_system_notice_is_not_attributed_as_radio_data();
     rc |= test_status_event_is_not_data_call_or_frame_log();
@@ -1710,6 +1860,7 @@ main(void) {
     rc |= test_edacs_ea_mode_current_event_and_unknown_lid();
     rc |= test_p25_and_dmr_current_append_security_flags();
     rc |= test_canonical_call_lifecycle_is_epoch_driven();
+    rc |= test_canonical_voice_category_is_protocol_neutral();
     rc |= test_provisional_voice_identity_does_not_commit_zero_row();
     rc |= test_new_canonical_epoch_commits_prior_canonical_call();
     rc |= test_late_source_enriches_matching_canonical_call();

--- a/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
@@ -106,11 +106,19 @@ dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const
 }
 
 int
-dsd_event_emit_data_notice_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,
-                                    const dsd_call_observation* observation, const char* notice, const char* gps) {
-    (void)dsd_event_emit_data_notice(opts, state, slot, observation, notice);
+dsd_event_emit_data_notice_classified_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                               const dsd_call_observation* observation, dsd_event_category category,
+                                               const char* notice, const char* gps) {
+    (void)dsd_event_emit_data_notice_classified(opts, state, slot, observation, category, notice);
     DSD_SNPRINTF(g_datacall_gps, sizeof(g_datacall_gps), "%s", gps ? gps : "");
     return 0;
+}
+
+int
+dsd_event_emit_data_notice_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                    const dsd_call_observation* observation, const char* notice, const char* gps) {
+    return dsd_event_emit_data_notice_classified_with_gps(opts, state, slot, observation, DSD_EVENT_CATEGORY_DATA,
+                                                          notice, gps);
 }
 
 int
@@ -474,6 +482,27 @@ build_compressed_udp_lip_with_extended_src_port(uint8_t* out, size_t cap) {
     return 10U;
 }
 
+static size_t
+build_compressed_udp_extended_port(uint8_t* out, size_t cap, uint16_t port, uint8_t extended_source, uint8_t peer_pid,
+                                   uint8_t include_payload) {
+    const size_t len = include_payload ? 8U : 7U;
+    if (cap < len || peer_pid == 0U || peer_pid > 0x7FU) {
+        return 0;
+    }
+    DSD_MEMSET(out, 0, cap);
+    out[0] = 0x00;
+    out[1] = 0x7C;
+    out[2] = 0x10;
+    out[3] = extended_source ? 0U : peer_pid;
+    out[4] = extended_source ? peer_pid : 0U;
+    out[5] = (uint8_t)(port >> 8);
+    out[6] = (uint8_t)(port & 0xFFU);
+    if (include_payload) {
+        out[7] = 0xA5U;
+    }
+    return len;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -534,6 +563,13 @@ main(void) {
         decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
         rc |= expect_has_substr(st.dmr_lrrp_gps[0], "P25 Atlas SRC(IP): 1.2.3.4; DST(IP): 5.6.7.8;", "atlas9361 label");
         rc |= expect_category(g_datacall_category, DSD_EVENT_CATEGORY_CONTROL, "atlas9361 category");
+
+        reset_spies();
+        plen = build_ipv4_udp_empty_payload(pkt, sizeof pkt, 65000U);
+        pkt[20] = (uint8_t)(9361U >> 8);
+        pkt[21] = (uint8_t)(9361U & 0xFFU);
+        decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
+        rc |= expect_category(g_datacall_category, DSD_EVENT_CATEGORY_CONTROL, "atlas9361 source category");
     }
 
     // Shared P25 Tier 2 location service remains packet data.
@@ -589,6 +625,7 @@ main(void) {
         }
         rc |= expect_has_substr(g_datacall_text, "SRC: 1:1", "compressed source summary");
         rc |= expect_has_substr(g_datacall_text, "DST: 2:63", "compressed destination summary");
+        rc |= expect_category(g_datacall_category, DSD_EVENT_CATEGORY_DATA, "compressed text category");
     }
 
     // Case 8: compressed UDP with an extended source port should dispatch bounded LIP bits once.
@@ -603,9 +640,45 @@ main(void) {
         }
         rc |= expect_has_substr(g_datacall_text, "SRC: 11:2", "compressed extended source summary");
         rc |= expect_has_substr(g_datacall_gps, "41.500000", "compressed LIP event GPS");
+        rc |= expect_category(g_datacall_category, DSD_EVENT_CATEGORY_DATA, "compressed LIP category");
     }
 
-    // Case 9: compressed UDP guards short/null PDUs without emitting datacalls.
+    // Case 9: compressed UDP classifies supported control services at either endpoint.
+    {
+        static const struct {
+            uint16_t port;
+            dsd_event_category category;
+        } cases[] = {
+            {4004U, DSD_EVENT_CATEGORY_CONTROL}, {4005U, DSD_EVENT_CATEGORY_CONTROL},
+            {4009U, DSD_EVENT_CATEGORY_CONTROL}, {9361U, DSD_EVENT_CATEGORY_CONTROL},
+            {4008U, DSD_EVENT_CATEGORY_DATA},
+        };
+
+        for (size_t i = 0U; i < sizeof(cases) / sizeof(cases[0]); i++) {
+            for (uint8_t extended_source = 0U; extended_source <= 1U; extended_source++) {
+                reset_spies();
+                size_t plen =
+                    build_compressed_udp_extended_port(pkt, sizeof pkt, cases[i].port, extended_source, 63U, 0U);
+                st.currentslot = 0;
+                dmr_udp_comp_pdu(&opts, &st, (uint16_t)plen, pkt);
+                rc |= expect_category(g_datacall_category, cases[i].category,
+                                      extended_source ? "compressed source service category"
+                                                      : "compressed destination service category");
+            }
+        }
+    }
+
+    // Case 10: classified compressed UDP GPS preserves the endpoint-derived category.
+    {
+        reset_spies();
+        size_t plen = build_compressed_udp_extended_port(pkt, sizeof pkt, 4005U, 1U, 2U, 1U);
+        st.currentslot = 0;
+        dmr_udp_comp_pdu(&opts, &st, (uint16_t)plen, pkt);
+        rc |= expect_category(g_datacall_category, DSD_EVENT_CATEGORY_CONTROL, "compressed control GPS category");
+        rc |= expect_has_substr(g_datacall_gps, "41.500000", "compressed control GPS payload");
+    }
+
+    // Case 11: compressed UDP guards short/null PDUs without emitting datacalls.
     {
         reset_spies();
         dmr_udp_comp_pdu(&opts, &st, 4, pkt);
@@ -616,7 +689,7 @@ main(void) {
         }
     }
 
-    // Case 10: generic short data emits source/target datacall metadata without requiring LOCN parsing.
+    // Case 12: generic short data emits source/target datacall metadata without requiring LOCN parsing.
     {
         reset_spies();
         const uint8_t text[] = {'H', 'E', 'L', 'L', 'O'};
@@ -633,7 +706,7 @@ main(void) {
         rc |= expect_has_substr(g_datacall_text, "Short Data SRC: 1234; TGT: 5678;", "short data summary");
     }
 
-    // Case 11: UDP application service ports update GPS/event summaries by service kind.
+    // Case 13: UDP application service ports classify either endpoint by service kind.
     {
         const struct {
             const char* tag;
@@ -657,10 +730,18 @@ main(void) {
             decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
             rc |= expect_has_substr(st.dmr_lrrp_gps[0], cases[i].tag, "udp service label");
             rc |= expect_category(g_datacall_category, cases[i].category, "udp service category");
+
+            reset_spies();
+            plen = build_ipv4_udp_payload(pkt, sizeof pkt, 65000U, NULL, 0U);
+            pkt[20] = (uint8_t)(cases[i].port >> 8);
+            pkt[21] = (uint8_t)(cases[i].port & 0xFFU);
+            st.dmr_lrrp_gps[0][0] = '\0';
+            decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
+            rc |= expect_category(g_datacall_category, cases[i].category, "udp source service category");
         }
     }
 
-    // Case 12: UDP/4007 TMS acknowledgment and UTF-16 text take distinct state paths.
+    // Case 14: UDP/4007 TMS acknowledgment and UTF-16 text take distinct state paths.
     {
         reset_spies();
         const uint8_t ack_payload[] = {0x00, 0x05, 0x01, 0x00, 0x00};
@@ -680,7 +761,7 @@ main(void) {
         rc |= expect_has_substr(st.event_history_s[0].Event_History_Items[0].text_message, "OK", "tms text payload");
     }
 
-    // Case 13: unknown UDP and truncated UDP headers emit bounded datacall summaries.
+    // Case 15: unknown UDP and truncated UDP headers emit bounded datacall summaries.
     {
         reset_spies();
         size_t plen = build_ipv4_udp_payload(pkt, sizeof pkt, 65000U, NULL, 0U);
@@ -701,7 +782,7 @@ main(void) {
         }
     }
 
-    // Case 14: ICMP destination-unreachable with an attached IPv4 message recursively decodes the attachment.
+    // Case 16: ICMP destination-unreachable with an attached IPv4 message recursively decodes the attachment.
     {
         reset_spies();
         size_t plen = build_ipv4_icmp_attached_udp_service(pkt, sizeof pkt, 4008U);
@@ -715,7 +796,7 @@ main(void) {
         }
     }
 
-    // Case 15: malformed TMS address length is bounded and reported as truncated.
+    // Case 17: malformed TMS address length is bounded and reported as truncated.
     {
         reset_spies();
         const uint8_t malformed_addr_payload[] = {0x00, 0x08, 0x00, 0x04, 0x00};

--- a/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
@@ -37,6 +37,7 @@ static unsigned int g_datacall_calls;
 static uint32_t g_datacall_src;
 static uint32_t g_datacall_dst;
 static uint8_t g_datacall_slot;
+static dsd_event_category g_datacall_category;
 static char g_datacall_text[512];
 static char g_datacall_gps[256];
 
@@ -47,6 +48,7 @@ reset_spies(void) {
     g_datacall_src = 0;
     g_datacall_dst = 0;
     g_datacall_slot = 0;
+    g_datacall_category = DSD_EVENT_CATEGORY_UNKNOWN;
     DSD_MEMSET(g_datacall_text, 0, sizeof(g_datacall_text));
     DSD_MEMSET(g_datacall_gps, 0, sizeof(g_datacall_gps));
 }
@@ -83,16 +85,24 @@ decode_cellocator(dsd_opts* opts, dsd_state* state, uint8_t* input, int len) {
 }
 
 int
-dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
-                           const char* notice) {
+dsd_event_emit_data_notice_classified(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                      const dsd_call_observation* observation, dsd_event_category category,
+                                      const char* notice) {
     (void)opts;
     (void)state;
     g_datacall_calls++;
     g_datacall_src = observation->ota_source_id;
     g_datacall_dst = observation->ota_target_id;
     g_datacall_slot = slot;
+    g_datacall_category = category;
     DSD_SNPRINTF(g_datacall_text, sizeof(g_datacall_text), "%s", notice ? notice : "");
     return 0;
+}
+
+int
+dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
+                           const char* notice) {
+    return dsd_event_emit_data_notice_classified(opts, state, slot, observation, DSD_EVENT_CATEGORY_DATA, notice);
 }
 
 int
@@ -130,6 +140,15 @@ static int
 expect_nonempty(const char* buf, const char* tag) {
     if (!buf || buf[0] == '\0') {
         DSD_FPRINTF(stderr, "%s: empty output\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_category(dsd_event_category got, dsd_event_category want, const char* tag) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: category got %d want %d\n", tag, (int)got, (int)want);
         return 1;
     }
     return 0;
@@ -481,6 +500,7 @@ main(void) {
         decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
         rc |= expect_nonempty(st.dmr_lrrp_gps[0], "ihl=5 decoded");
         rc |= expect_has_substr(st.dmr_lrrp_gps[0], " km/h 90", "ihl=5 has speed+heading");
+        rc |= expect_category(g_datacall_category, DSD_EVENT_CATEGORY_DATA, "udp4001 LRRP category");
     }
 
     // Case 2: IPv4 options present (IHL=6). Decoder must honor IHL to locate UDP.
@@ -491,6 +511,7 @@ main(void) {
         decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
         rc |= expect_nonempty(st.dmr_lrrp_gps[0], "ihl=6 decoded");
         rc |= expect_has_substr(st.dmr_lrrp_gps[0], " km/h 90", "ihl=6 has speed+heading");
+        rc |= expect_category(g_datacall_category, DSD_EVENT_CATEGORY_DATA, "udp4001 options category");
     }
 
     // Case 3: Vertex TMS on UDP/5007 should not trim valid text when data_block_poc is non-zero.
@@ -512,6 +533,17 @@ main(void) {
         st.dmr_lrrp_gps[0][0] = '\0';
         decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
         rc |= expect_has_substr(st.dmr_lrrp_gps[0], "P25 Atlas SRC(IP): 1.2.3.4; DST(IP): 5.6.7.8;", "atlas9361 label");
+        rc |= expect_category(g_datacall_category, DSD_EVENT_CATEGORY_CONTROL, "atlas9361 category");
+    }
+
+    // Shared P25 Tier 2 location service remains packet data.
+    {
+        reset_spies();
+        size_t plen = build_ipv4_udp_empty_payload(pkt, sizeof pkt, 49198);
+        st.dmr_lrrp_gps[0][0] = '\0';
+        decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
+        rc |= expect_has_substr(st.dmr_lrrp_gps[0], "P25 Tier 2 LOCN SRC(IP):", "location49198 label");
+        rc |= expect_category(g_datacall_category, DSD_EVENT_CATEGORY_DATA, "location49198 category");
     }
 
     // Case 5: Short/empty UDP TMS payload should be reported as truncated, not indexed past the payload.
@@ -604,11 +636,14 @@ main(void) {
     // Case 11: UDP application service ports update GPS/event summaries by service kind.
     {
         const struct {
-            uint16_t port;
             const char* tag;
+            uint16_t port;
+            dsd_event_category category;
         } cases[] = {
-            {4005U, "ARS SRC:"},        {4008U, "Telemetry SRC:"}, {4009U, "OTAP SRC:"},
-            {4012U, "Batt. Man. SRC:"}, {4013U, "JTS SRC:"},       {4069U, "SCADA SRC:"},
+            {"XCMP SRC:", 4004U, DSD_EVENT_CATEGORY_CONTROL},    {"ARS SRC:", 4005U, DSD_EVENT_CATEGORY_CONTROL},
+            {"Telemetry SRC:", 4008U, DSD_EVENT_CATEGORY_DATA},  {"OTAP SRC:", 4009U, DSD_EVENT_CATEGORY_CONTROL},
+            {"Batt. Man. SRC:", 4012U, DSD_EVENT_CATEGORY_DATA}, {"JTS SRC:", 4013U, DSD_EVENT_CATEGORY_DATA},
+            {"SCADA SRC:", 4069U, DSD_EVENT_CATEGORY_DATA},
         };
 
         const uint8_t ars_payload[] = {'A', 'R', 'S', 0};
@@ -621,6 +656,7 @@ main(void) {
             st.dmr_lrrp_gps[0][0] = '\0';
             decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
             rc |= expect_has_substr(st.dmr_lrrp_gps[0], cases[i].tag, "udp service label");
+            rc |= expect_category(g_datacall_category, cases[i].category, "udp service category");
         }
     }
 

--- a/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
+++ b/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
@@ -50,6 +50,7 @@ static unsigned int g_datacall_calls;
 static uint32_t g_datacall_last_src;
 static uint32_t g_datacall_last_dst;
 static uint8_t g_datacall_last_slot;
+static dsd_event_category g_datacall_last_category;
 static char g_datacall_last_text[256];
 static char g_datacall_last_gps[256];
 static unsigned int g_lip_calls;
@@ -97,16 +98,24 @@ dsd_event_sync_slot(dsd_opts* opts, dsd_state* state, uint8_t slot) {
 }
 
 int
-dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
-                           const char* notice) {
+dsd_event_emit_data_notice_classified(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                      const dsd_call_observation* observation, dsd_event_category category,
+                                      const char* notice) {
     (void)opts;
     (void)state;
     g_datacall_calls++;
     g_datacall_last_src = observation->ota_source_id;
     g_datacall_last_dst = observation->ota_target_id;
     g_datacall_last_slot = slot;
+    g_datacall_last_category = category;
     DSD_SNPRINTF(g_datacall_last_text, sizeof(g_datacall_last_text), "%s", notice ? notice : "");
     return 0;
+}
+
+int
+dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
+                           const char* notice) {
+    return dsd_event_emit_data_notice_classified(opts, state, slot, observation, DSD_EVENT_CATEGORY_DATA, notice);
 }
 
 int
@@ -502,6 +511,7 @@ reset_datacall_spy(void) {
     g_datacall_last_src = 0;
     g_datacall_last_dst = 0;
     g_datacall_last_slot = 0;
+    g_datacall_last_category = DSD_EVENT_CATEGORY_UNKNOWN;
     DSD_MEMSET(g_datacall_last_text, 0, sizeof(g_datacall_last_text));
     DSD_MEMSET(g_datacall_last_gps, 0, sizeof(g_datacall_last_gps));
     g_lip_calls = 0;
@@ -756,10 +766,13 @@ static void
 run_type1_pdu_for_sap(uint8_t sap, const uint8_t block[12]) {
     static dsd_opts opts;
     static dsd_state state;
+    static Event_History_I history[2];
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
 
     opts.aggressive_framesync = 1;
+    state.event_history_s = history;
     state.currentslot = 0;
     state.data_header_valid[0] = 1;
     state.data_header_blocks[0] = 1;
@@ -771,6 +784,29 @@ run_type1_pdu_for_sap(uint8_t sap, const uint8_t block[12]) {
     uint8_t mutable_block[12];
     DSD_MEMCPY(mutable_block, block, sizeof(mutable_block));
     dmr_block_assembler(&opts, &state, mutable_block, (uint8_t)sizeof(mutable_block), 0, 1);
+}
+
+static void
+test_type1_mnis_classifies_decoded_service(void) {
+    static const struct {
+        uint8_t mnis_type;
+        dsd_event_category category;
+    } cases[] = {
+        {0x01U, DSD_EVENT_CATEGORY_DATA},
+        {0x11U, DSD_EVENT_CATEGORY_DATA},
+        {0x33U, DSD_EVENT_CATEGORY_CONTROL},
+        {0x88U, DSD_EVENT_CATEGORY_CONTROL},
+    };
+
+    for (size_t i = 0U; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        uint8_t block[12] = {0};
+        block[1] = 0x10U;
+        block[4] = cases[i].mnis_type;
+        append_type1_crc32(block, sizeof(block));
+        run_type1_pdu_for_sap(1U, block);
+        assert(g_datacall_calls == 1U);
+        assert(g_datacall_last_category == cases[i].category);
+    }
 }
 
 static void
@@ -1133,6 +1169,7 @@ main(int argc, char** argv) {
     test_udt_binary_addressing_reserved_and_slot1_paths();
     test_crc_valid_type1_pdu_dispatches_in_strict_mode();
     test_crc_valid_type1_pdu_dispatches_short_data_and_udp_saps();
+    test_type1_mnis_classifies_decoded_service();
     test_type1_encrypted_notice_reports_missing_key();
     test_type2_rejects_out_of_bounds_aggregate_length();
     int rc = test_data_header_prints_fsn_and_final_flag();

--- a/tests/protocol/p25/test_p25_p1_pdu_es_ext.c
+++ b/tests/protocol/p25/test_p25_p1_pdu_es_ext.c
@@ -44,21 +44,31 @@ static int g_datacall_count;
 static int g_history_count;
 static uint32_t g_datacall_src;
 static uint32_t g_datacall_dst;
+static dsd_event_category g_datacall_category;
 static char g_datacall_text[256];
 
 // Stubs required by linked decoder units
 int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
-                           const char* notice) {
+dsd_event_emit_data_notice_classified(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                      const dsd_call_observation* observation, dsd_event_category category,
+                                      const char* notice) {
     (void)opts;
     (void)state;
     (void)slot;
     g_datacall_count++;
     g_datacall_src = observation->ota_source_id;
     g_datacall_dst = observation->ota_target_id;
+    g_datacall_category = category;
     DSD_SNPRINTF(g_datacall_text, sizeof(g_datacall_text), "%s", notice ? notice : "");
     return 0;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
+                           const char* notice) {
+    return dsd_event_emit_data_notice_classified(opts, state, slot, observation, DSD_EVENT_CATEGORY_DATA, notice);
 }
 
 void
@@ -553,6 +563,10 @@ main(void) {
     // Expect aux_sap=32 (RegAuth) after ES header
     if (sap != 32) {
         DSD_FPRINTF(stderr, "expected SAP 32 after ES header, got %d\n", sap);
+        rc = 1;
+    }
+    if (g_datacall_category != DSD_EVENT_CATEGORY_CONTROL) {
+        DSD_FPRINTF(stderr, "expected SAP 32 control category, got %d\n", (int)g_datacall_category);
         rc = 1;
     }
     (void)remove(cap.path);

--- a/tests/protocol/p25/test_p25_p1_pdu_json.c
+++ b/tests/protocol/p25/test_p25_p1_pdu_json.c
@@ -9,6 +9,7 @@
 
 #include <dsd-neo/core/bit_packing.h>
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_fwd.h>
 
 #include <errno.h>
@@ -17,6 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "test_support.h"
 
@@ -37,12 +39,16 @@ void p25_test_p1_pdu_data_decode(const unsigned char* input, int len);
 
 static int g_utf8_calls = 0;
 static int g_data_notice_calls = 0;
+static int g_control_notice_calls = 0;
+static int g_data_category_notice_calls = 0;
+static dsd_event_category g_last_data_notice_category = DSD_EVENT_CATEGORY_UNKNOWN;
 
 // Stubs referenced by PDU data path
 int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
-                           const char* notice) {
+dsd_event_emit_data_notice_classified(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                      const dsd_call_observation* observation, dsd_event_category category,
+                                      const char* notice) {
     (void)opts;
     (void)state;
     (void)observation->ota_source_id;
@@ -50,7 +56,20 @@ dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const
     (void)notice;
     (void)slot;
     g_data_notice_calls++;
+    g_last_data_notice_category = category;
+    if (category == DSD_EVENT_CATEGORY_CONTROL) {
+        g_control_notice_calls++;
+    } else if (category == DSD_EVENT_CATEGORY_DATA) {
+        g_data_category_notice_calls++;
+    }
     return 0;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
+                           const char* notice) {
+    return dsd_event_emit_data_notice_classified(opts, state, slot, observation, DSD_EVENT_CATEGORY_DATA, notice);
 }
 
 void
@@ -157,6 +176,42 @@ expect_str_contains(const char* tag, const char* hay, const char* needle) {
         return 1;
     }
     return 0;
+}
+
+static int
+test_p25_sap_category_matrix(void) {
+    static const struct {
+        uint8_t sap;
+        dsd_event_category category;
+    } cases[] = {
+        {3U, DSD_EVENT_CATEGORY_CONTROL},  {6U, DSD_EVENT_CATEGORY_CONTROL},  {29U, DSD_EVENT_CATEGORY_CONTROL},
+        {32U, DSD_EVENT_CATEGORY_CONTROL}, {33U, DSD_EVENT_CATEGORY_CONTROL}, {34U, DSD_EVENT_CATEGORY_CONTROL},
+        {37U, DSD_EVENT_CATEGORY_CONTROL}, {38U, DSD_EVENT_CATEGORY_CONTROL}, {39U, DSD_EVENT_CATEGORY_CONTROL},
+        {40U, DSD_EVENT_CATEGORY_CONTROL}, {41U, DSD_EVENT_CATEGORY_CONTROL}, {61U, DSD_EVENT_CATEGORY_CONTROL},
+        {63U, DSD_EVENT_CATEGORY_CONTROL}, {48U, DSD_EVENT_CATEGORY_DATA},    {4U, DSD_EVENT_CATEGORY_DATA},
+    };
+
+    int rc = 0;
+    for (size_t i = 0U; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        uint8_t pdu[64];
+        DSD_MEMSET(pdu, 0, sizeof(pdu));
+        pdu[0] = 0x10U;
+        pdu[1] = cases[i].sap;
+        pdu[6] = 0x01U;
+        const int notices_before = g_data_notice_calls;
+        p25_test_p1_pdu_data_decode(pdu, 32);
+        if (g_data_notice_calls != notices_before + 1) {
+            DSD_FPRINTF(stderr, "SAP %u notice count: got %d want %d\n", (unsigned)cases[i].sap, g_data_notice_calls,
+                        notices_before + 1);
+            rc = 1;
+        }
+        if (g_last_data_notice_category != cases[i].category) {
+            DSD_FPRINTF(stderr, "SAP %u category: got %d want %d\n", (unsigned)cases[i].sap,
+                        (int)g_last_data_notice_category, (int)cases[i].category);
+            rc = 1;
+        }
+    }
+    return rc;
 }
 
 static int
@@ -371,6 +426,9 @@ main(void) {
     }
 
     // Case 9: SAP 4 packet data with the optional 2-octet SNDCP packet header.
+    const int primary_utf8_calls = g_utf8_calls;
+    rc |= test_p25_sap_category_matrix();
+
     {
         uint8_t pdu[96];
         DSD_MEMSET(pdu, 0, sizeof(pdu));
@@ -433,8 +491,10 @@ main(void) {
     rc |= expect_str_contains("SAP6 reject output", buf, "IPv4 Not Supported");
     rc |= expect_str_contains("SAP6 deactivate output", buf, "Deactivate:This NSAPI");
     rc |= expect_str_contains("SAP48 NMEA output", buf, "$GPRMC,123519");
-    rc |= expect_eq_int("SAP48 NMEA avoids UTF8 fallback", g_utf8_calls, 0);
-    rc |= expect_eq_int("one data notice per PDU", g_data_notice_calls, 9);
+    rc |= expect_eq_int("SAP48 NMEA avoids UTF8 fallback", primary_utf8_calls, 0);
+    rc |= expect_eq_int("one data notice per PDU", g_data_notice_calls, 24);
+    rc |= expect_eq_int("P25 control SAP notices", g_control_notice_calls, 19);
+    rc |= expect_eq_int("P25 packet/location data notices", g_data_category_notice_calls, 5);
     free(buf);
 
     (void)remove(cap.path);

--- a/tests/test_support/data_event_gps_shim.c
+++ b/tests/test_support/data_event_gps_shim.c
@@ -19,8 +19,17 @@ dsd_event_emit_data_notice_classified(dsd_opts* opts, dsd_state* state, uint8_t 
 }
 
 int
-dsd_event_emit_data_notice_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,
-                                    const dsd_call_observation* observation, const char* notice, const char* gps) {
+dsd_event_emit_data_notice_classified_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                               const dsd_call_observation* observation, dsd_event_category category,
+                                               const char* notice, const char* gps) {
+    (void)category;
     (void)gps;
     return dsd_event_emit_data_notice(opts, state, slot, observation, notice);
+}
+
+int
+dsd_event_emit_data_notice_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                    const dsd_call_observation* observation, const char* notice, const char* gps) {
+    return dsd_event_emit_data_notice_classified_with_gps(opts, state, slot, observation, DSD_EVENT_CATEGORY_DATA,
+                                                          notice, gps);
 }

--- a/tests/test_support/data_event_gps_shim.c
+++ b/tests/test_support/data_event_gps_shim.c
@@ -7,7 +7,16 @@
 #include <dsd-neo/core/events.h>
 #include <stdint.h>
 #include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state.h"
 #include "dsd-neo/core/state_fwd.h"
+
+int
+dsd_event_emit_data_notice_classified(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                      const dsd_call_observation* observation, dsd_event_category category,
+                                      const char* notice) {
+    (void)category;
+    return dsd_event_emit_data_notice(opts, state, slot, observation, notice);
+}
 
 int
 dsd_event_emit_data_notice_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -724,6 +724,49 @@ test_history_and_sort_helpers(void) {
 }
 
 static void
+test_history_color_pair_policy(void) {
+    static const struct {
+        uint8_t severity;
+        uint8_t category;
+        uint8_t legacy_pair;
+        short expected_pair;
+    } cases[] = {
+        {DSD_EVENT_SEVERITY_UNKNOWN, DSD_EVENT_CATEGORY_UNKNOWN, 0U, 4},
+        {DSD_EVENT_SEVERITY_UNKNOWN, DSD_EVENT_CATEGORY_UNKNOWN, 7U, 7},
+        {DSD_EVENT_SEVERITY_DEBUG, DSD_EVENT_CATEGORY_UNKNOWN, 3U, 4},
+        {DSD_EVENT_SEVERITY_INFO, DSD_EVENT_CATEGORY_UNKNOWN, 3U, 4},
+        {DSD_EVENT_SEVERITY_UNKNOWN, DSD_EVENT_CATEGORY_STATUS, 2U, 4},
+        {DSD_EVENT_SEVERITY_UNKNOWN, DSD_EVENT_CATEGORY_VOICE, 2U, 3},
+        {DSD_EVENT_SEVERITY_UNKNOWN, DSD_EVENT_CATEGORY_DATA, 2U, 4},
+        {DSD_EVENT_SEVERITY_UNKNOWN, DSD_EVENT_CATEGORY_CONTROL, 2U, 1},
+        {DSD_EVENT_SEVERITY_UNKNOWN, DSD_EVENT_CATEGORY_SYSTEM, 2U, 4},
+        {DSD_EVENT_SEVERITY_INFO, DSD_EVENT_CATEGORY_VOICE, 2U, 3},
+        {DSD_EVENT_SEVERITY_DEBUG, DSD_EVENT_CATEGORY_CONTROL, 2U, 1},
+        {DSD_EVENT_SEVERITY_WARNING, DSD_EVENT_CATEGORY_UNKNOWN, 3U, 1},
+        {DSD_EVENT_SEVERITY_WARNING, DSD_EVENT_CATEGORY_VOICE, 3U, 1},
+        {DSD_EVENT_SEVERITY_WARNING, DSD_EVENT_CATEGORY_DATA, 3U, 1},
+        {DSD_EVENT_SEVERITY_ERROR, DSD_EVENT_CATEGORY_UNKNOWN, 3U, 2},
+        {DSD_EVENT_SEVERITY_ERROR, DSD_EVENT_CATEGORY_CONTROL, 3U, 2},
+        {DSD_EVENT_SEVERITY_ERROR, DSD_EVENT_CATEGORY_SYSTEM, 3U, 2},
+        {UINT8_MAX, DSD_EVENT_CATEGORY_VOICE, 3U, 3},
+        {UINT8_MAX, UINT8_MAX, 3U, 4},
+        {DSD_EVENT_SEVERITY_INFO, UINT8_MAX, 3U, 4},
+        {DSD_EVENT_SEVERITY_WARNING, UINT8_MAX, 3U, 1},
+        {DSD_EVENT_SEVERITY_ERROR, UINT8_MAX, 3U, 2},
+    };
+
+    assert(ui_history_color_pair_for_event(NULL) == 4);
+    for (size_t i = 0U; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        Event_History item;
+        DSD_MEMSET(&item, 0, sizeof(item));
+        item.severity = cases[i].severity;
+        item.category = cases[i].category;
+        item.color_pair = cases[i].legacy_pair;
+        assert(ui_history_color_pair_for_event(&item) == cases[i].expected_pair);
+    }
+}
+
+static void
 test_history_viewport_helpers(void) {
     int draw_footer = 1;
     ui_history_render_ctx ctx;
@@ -1130,6 +1173,7 @@ main(void) {
     test_demod_symbol_rate_helpers();
     test_input_level_policy();
     test_history_and_sort_helpers();
+    test_history_color_pair_policy();
     test_history_viewport_helpers();
     test_hytera_key_format_helper();
     test_edacs_tree_update_helpers();


### PR DESCRIPTION
## Summary

- Color terminal event-history summaries from protocol-neutral severity and category metadata: errors red, warnings/control yellow, voice green, and data/status/system cyan.
- Add a classified data-notice API for `DATA` and `CONTROL` while preserving the existing data and GPS notice behavior, payload ownership, alerts, logs, revisions, and event layout.
- Classify DMR ARS/XCMP/OTAP, shared Atlas registration, and P25 control/management SAPs as control events while keeping LRRP/LOCN and ordinary packet data classified as data.
- Add core, DMR, P25, canonical-call, and terminal policy regression coverage.

This implements the event-history color policy requested in [discussion #152](https://github.com/arancormonk/dsd-neo/discussions/152#discussioncomment-17759913). Previously, event summaries lacked a metadata-driven color policy and packet notices were emitted through a data-only interface, so registration and control events could not be distinguished without coupling protocol code to terminal color IDs.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: parser / network input.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. No suppressions were added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` (466/466 passed)
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes — not run; this is a scoped metadata/classification change covered by focused parser tests and the full preflight analysis.
- [ ] `tools/cmake_format_check.sh` for CMake changes — not applicable; no CMake files changed.
- [ ] `tools/zizmor.sh` for workflow changes — not applicable; no workflow files changed.
- [ ] `tools/osv_scan.sh` for dependency input changes — not applicable; no dependency inputs changed.
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes (run by preflight).

## Risk

- Security/dependency impact: None.
- CLI/UI behavior impact: Only the primary terminal event-history summary line changes color according to fixed metadata precedence; detail lines and monochrome rendering remain unchanged.
- Compatibility or packaging impact: The public API change is additive, the existing data-notice function remains source-compatible, and `Event_History` layout is unchanged. No packaging impact.