### PR TITLE
p25: harden phase 2 PTT and lockout handling

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -329,8 +329,10 @@ Notes
   - P25 Talk Complete, TDU, TDULC, MAC_END_PTT, MAC_IDLE, and MAC_HANGTIME mark a transmission boundary. They close
     that slot's media and start or refresh the traffic-carrier inactivity timer without returning to the control
     channel. A follow-up PTT/ACTIVE on the retained carrier opens a clean call epoch without retuning.
-    Immediate identical Phase 2 MAC_PTT retransmissions within one second are coalesced into the active epoch;
-    a changed PTT, a later copy, or any intervening accepted boundary still opens a genuine follow-up epoch.
+    Immediate matching Phase 2 MAC_PTT retransmissions within one second are coalesced into the active epoch. Clear
+    calls are matched by their source/target identity because their MI and KID fields do not delimit a call; encrypted
+    calls retain exact crypto and identity matching. A later copy or any intervening accepted boundary still opens a
+    genuine follow-up epoch.
   - P25 returns immediately only for an explicit network/channel release, policy or encryption rejection, manual
     release, or physical carrier/sync loss. Otherwise the configured hang time expires before control-channel return.
   - `--p25-sm-log` distinguishes `transmission_end`, `traffic_hang`, `traffic_reuse`, `hang_expired`, and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -329,6 +329,8 @@ Notes
   - P25 Talk Complete, TDU, TDULC, MAC_END_PTT, MAC_IDLE, and MAC_HANGTIME mark a transmission boundary. They close
     that slot's media and start or refresh the traffic-carrier inactivity timer without returning to the control
     channel. A follow-up PTT/ACTIVE on the retained carrier opens a clean call epoch without retuning.
+    Immediate identical Phase 2 MAC_PTT retransmissions within one second are coalesced into the active epoch;
+    a changed PTT, a later copy, or any intervening accepted boundary still opens a genuine follow-up epoch.
   - P25 returns immediately only for an explicit network/channel release, policy or encryption rejection, manual
     release, or physical carrier/sync loss. Otherwise the configured hang time expires before control-channel return.
   - `--p25-sm-log` distinguishes `transmission_end`, `traffic_hang`, `traffic_reuse`, `hang_expired`, and

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -63,6 +63,8 @@ enum {
     // Grant decoder sentinel for opcodes that do not carry service options.
     // Passing svc_bits=0 explicitly clears the service option.
     P25_SM_SVC_UNKNOWN = -1,
+    // Exact MAC_PTT octets 1-17, excluding the SACCH/FACCH transport header.
+    P25_SM_PTT_SIGNATURE_BYTES = 17,
 };
 
 typedef enum {
@@ -95,22 +97,24 @@ typedef enum {
 
 typedef struct {
     p25_sm_event_type_e type;
-    int slot;                                   // 0 or 1 for TDMA, -1 for P1/N/A
-    int channel;                                // 16-bit channel number (for GRANT)
-    long freq_hz;                               // Frequency in Hz (for GRANT)
-    int tg;                                     // Talkgroup (for GRANT/PTT/END, 0 if individual or unavailable)
-    int src;                                    // Source RID (for GRANT/PTT/END, 0 if unavailable)
-    int dst;                                    // Destination RID (for individual GRANT)
-    int svc_bits;                               // Service options (for GRANT), or P25_SM_SVC_UNKNOWN when absent
-    int is_group;                               // 1 for group grant, 0 for individual
-    p25_sm_grant_provenance_e grant_provenance; // Initial assignment or continuing assignment update
-    int algid;                                  // Algorithm ID (for ENC event)
-    int keyid;                                  // Key ID (for ENC event)
-    int data_call_override;                     // 0=infer from svc_bits, 1=force data, -1=force non-data
-    int identity_valid;                         // 1 when PTT/ACTIVE carries a decoded call identity
-    int facch;                                  // 1 when END was decoded from valid FACCH
-    int crypto_new_epoch;                       // 1 when CRYPTO_PENDING must start a fresh deadline
-    double observed_m;                          // Optional monotonic timestamp when the event was observed
+    int slot;                                          // 0 or 1 for TDMA, -1 for P1/N/A
+    int channel;                                       // 16-bit channel number (for GRANT)
+    long freq_hz;                                      // Frequency in Hz (for GRANT)
+    int tg;                                            // Talkgroup (for GRANT/PTT/END, 0 if individual or unavailable)
+    int src;                                           // Source RID (for GRANT/PTT/END, 0 if unavailable)
+    int dst;                                           // Destination RID (for individual GRANT)
+    int svc_bits;                                      // Service options (for GRANT), or P25_SM_SVC_UNKNOWN when absent
+    int is_group;                                      // 1 for group grant, 0 for individual
+    p25_sm_grant_provenance_e grant_provenance;        // Initial assignment or continuing assignment update
+    int algid;                                         // Algorithm ID (for ENC event)
+    int keyid;                                         // Key ID (for ENC event)
+    int data_call_override;                            // 0=infer from svc_bits, 1=force data, -1=force non-data
+    int identity_valid;                                // 1 when PTT/ACTIVE carries a decoded call identity
+    int facch;                                         // 1 when PTT/END was decoded from valid FACCH
+    int crypto_new_epoch;                              // 1 when CRYPTO_PENDING must start a fresh deadline
+    double observed_m;                                 // Optional monotonic timestamp when the event was observed
+    uint8_t ptt_signature[P25_SM_PTT_SIGNATURE_BYTES]; // Optional exact MAC octets 1-17 for PTT
+    int ptt_signature_valid;                           // 1 when ptt_signature and observed_m are authoritative
 } p25_sm_event_t;
 
 /* ============================================================================
@@ -154,6 +158,9 @@ typedef struct {
     double facch_end_m;      // Monotonic timestamp of the first qualifying FACCH END_PTT
     int facch_end_tg;        // Identity carried by the qualifying FACCH END_PTT
     int facch_end_src;
+    uint8_t ptt_signature[P25_SM_PTT_SIGNATURE_BYTES]; // Last accepted raw P25P2 MAC_PTT signature
+    double ptt_last_seen_m;                            // Last observation of that PTT, including retransmissions
+    int ptt_signature_valid;                           // 1 while no accepted call boundary/replacement intervened
 } p25_sm_slot_ctx_t;
 
 typedef struct {

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -438,6 +438,9 @@ int p25_sm_slot_grant_newer_than(int slot, double observed_m);
 
 /**
  * @brief Emit PTT event for a slot.
+ *
+ * Trunk-follow mode rejects the event unless the state machine owns an active
+ * traffic-channel assignment. Conventional decoding does not require one.
  * @return 1 when downstream media handling may proceed; 0 when the event was rejected.
  */
 int p25_sm_emit_ptt(dsd_opts* opts, dsd_state* state, int slot);
@@ -447,7 +450,8 @@ int p25_sm_emit_ptt(dsd_opts* opts, dsd_state* state, int slot);
  *
  * The state machine reopens the call epoch from the retained carrier
  * assignment, re-evaluates policy/crypto, and never invokes the tuner for an
- * accepted identity on the current carrier.
+ * accepted identity on the current carrier. Trunk-follow mode rejects the
+ * event when no traffic-channel assignment is active.
  * @return 1 when downstream media handling may proceed; 0 when the event was rejected.
  */
 int p25_sm_emit_ptt_call(dsd_opts* opts, dsd_state* state, int slot, int tg, int dst, int src, int is_group,
@@ -455,12 +459,17 @@ int p25_sm_emit_ptt_call(dsd_opts* opts, dsd_state* state, int slot, int tg, int
 
 /**
  * @brief Emit ACTIVE event for a slot.
+ *
+ * Trunk-follow mode rejects the event unless the state machine owns an active
+ * traffic-channel assignment. Conventional decoding does not require one.
  * @return 1 when downstream media handling may proceed; 0 when the event was rejected.
  */
 int p25_sm_emit_active(dsd_opts* opts, dsd_state* state, int slot);
 
 /**
  * @brief Emit an ACTIVE event carrying an authoritative in-band call identity.
+ *
+ * Trunk-follow mode rejects the event when no traffic-channel assignment is active.
  * @return 1 when downstream media handling may proceed; 0 when the event was rejected.
  */
 int p25_sm_emit_active_call(dsd_opts* opts, dsd_state* state, int slot, int tg, int dst, int src, int is_group,

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -5545,6 +5545,28 @@ p25_sm_emit_end_call_at(dsd_opts* opts, dsd_state* state, int slot, int tg, int 
     return accepted;
 }
 
+void
+p25_sm_emit_mac_release(dsd_opts* opts, dsd_state* state, int slot, double observed_m) {
+    if (slot < 0 || slot > 1) {
+        return;
+    }
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    if (!ctx->initialized) {
+        p25_sm_init_ctx(ctx, opts, state);
+    }
+
+    const double ended_m = observed_m > 0.0 ? observed_m : dsd_time_now_monotonic_s();
+    p25_ptt_marker_invalidate(ctx, slot);
+    ctx->slots[slot].voice_active = 0;
+    ctx->slots[slot].last_active_m = 0.0;
+    ctx->slots[slot].last_stop_m = ended_m;
+    if (state) {
+        (void)dsd_tg_policy_clear_active_call(state, ctx->vc_is_tdma ? slot : -1);
+    }
+    p25_call_end_slot(opts, state, slot, ended_m);
+    p25_sm_update_ui_mode(ctx, state);
+}
+
 int
 p25_sm_emit_facch_end_call_at(dsd_opts* opts, dsd_state* state, int slot, int tg, int src, double observed_m) {
     if (slot < 0 || slot > 1) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -84,6 +84,8 @@ static atomic_int g_p25_sm_release_lock = 0;
 #define P25_VC_CQPSK_REACQUIRE_HOLD_S          0.75
 #define P25_VC_CQPSK_REACQUIRE_NO_SYNC_PASSES  3U
 #define P25_PTT_RETRANSMIT_WINDOW_S            1.0
+#define P25_PTT_SIGNATURE_ALGID_INDEX          9
+#define P25_PTT_SIGNATURE_IDENTITY_INDEX       12
 
 static void
 p25_ptt_marker_invalidate(p25_sm_ctx_t* ctx, int slot) {
@@ -2631,14 +2633,36 @@ p25_voice_slot_epoch_active(const p25_sm_slot_ctx_t* slot_ctx) {
 }
 
 static int
-p25_ptt_signature_matches(const uint8_t lhs[P25_SM_PTT_SIGNATURE_BYTES],
-                          const uint8_t rhs[P25_SM_PTT_SIGNATURE_BYTES]) {
-    for (int i = 0; i < P25_SM_PTT_SIGNATURE_BYTES; i++) {
+p25_ptt_signature_range_matches(const uint8_t lhs[P25_SM_PTT_SIGNATURE_BYTES],
+                                const uint8_t rhs[P25_SM_PTT_SIGNATURE_BYTES], int first) {
+    for (int i = first; i < P25_SM_PTT_SIGNATURE_BYTES; i++) {
         if (lhs[i] != rhs[i]) {
             return 0;
         }
     }
     return 1;
+}
+
+static int
+p25_ptt_signature_algid_is_clear(uint8_t algid) {
+    return algid == 0x00U || algid == 0x80U;
+}
+
+static int
+p25_ptt_signature_matches(const uint8_t lhs[P25_SM_PTT_SIGNATURE_BYTES],
+                          const uint8_t rhs[P25_SM_PTT_SIGNATURE_BYTES]) {
+    const uint8_t lhs_algid = lhs[P25_PTT_SIGNATURE_ALGID_INDEX];
+    const uint8_t rhs_algid = rhs[P25_PTT_SIGNATURE_ALGID_INDEX];
+    const int lhs_clear = p25_ptt_signature_algid_is_clear(lhs_algid);
+    const int rhs_clear = p25_ptt_signature_algid_is_clear(rhs_algid);
+
+    if (lhs_clear || rhs_clear) {
+        // MI and KID do not delimit a clear call. Some systems vary those
+        // fields across redundant MAC_PTT copies, so compare the normalized
+        // clear classification and the authoritative source/target identity.
+        return lhs_clear && rhs_clear && p25_ptt_signature_range_matches(lhs, rhs, P25_PTT_SIGNATURE_IDENTITY_INDEX);
+    }
+    return p25_ptt_signature_range_matches(lhs, rhs, 0);
 }
 
 static int

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -83,6 +83,18 @@ static atomic_int g_p25_sm_release_lock = 0;
 #define P25_VC_CQPSK_REACQUIRE_MIN_REMAINING_S 1.0
 #define P25_VC_CQPSK_REACQUIRE_HOLD_S          0.75
 #define P25_VC_CQPSK_REACQUIRE_NO_SYNC_PASSES  3U
+#define P25_PTT_RETRANSMIT_WINDOW_S            1.0
+
+static void
+p25_ptt_marker_invalidate(p25_sm_ctx_t* ctx, int slot) {
+    if (!ctx || slot < 0 || slot > 1) {
+        return;
+    }
+    p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
+    DSD_MEMSET(slot_ctx->ptt_signature, 0, sizeof(slot_ctx->ptt_signature));
+    slot_ctx->ptt_last_seen_m = 0.0;
+    slot_ctx->ptt_signature_valid = 0;
+}
 
 static const char*
 p25_tune_result_name(dsd_trunk_tune_result result) {
@@ -1507,6 +1519,7 @@ p25_sm_clear_one_slot_activity(p25_sm_ctx_t* ctx, int slot) {
     if (!ctx || slot < 0 || slot > 1) {
         return;
     }
+    p25_ptt_marker_invalidate(ctx, slot);
     ctx->slots[slot].voice_active = 0;
     ctx->slots[slot].last_active_m = 0.0;
     ctx->slots[slot].last_start_m = 0.0;
@@ -2618,6 +2631,67 @@ p25_voice_slot_epoch_active(const p25_sm_slot_ctx_t* slot_ctx) {
 }
 
 static int
+p25_ptt_signature_matches(const uint8_t lhs[P25_SM_PTT_SIGNATURE_BYTES],
+                          const uint8_t rhs[P25_SM_PTT_SIGNATURE_BYTES]) {
+    for (int i = 0; i < P25_SM_PTT_SIGNATURE_BYTES; i++) {
+        if (lhs[i] != rhs[i]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int
+p25_ptt_marker_matches(const p25_sm_ctx_t* ctx, int slot, const p25_sm_event_t* ev, double observed_m,
+                       double* out_elapsed_s) {
+    if (out_elapsed_s) {
+        *out_elapsed_s = 0.0;
+    }
+    if (!ctx || !ev || slot < 0 || slot > 1 || ev->type != P25_SM_EV_PTT || !ev->ptt_signature_valid
+        || ev->observed_m <= 0.0) {
+        return 0;
+    }
+
+    const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
+    if (!slot_ctx->ptt_signature_valid || slot_ctx->ptt_last_seen_m <= 0.0
+        || !p25_ptt_signature_matches(slot_ctx->ptt_signature, ev->ptt_signature)) {
+        return 0;
+    }
+
+    const double elapsed_s = observed_m - slot_ctx->ptt_last_seen_m;
+    if (elapsed_s < 0.0 || elapsed_s > P25_PTT_RETRANSMIT_WINDOW_S) {
+        return 0;
+    }
+    if (out_elapsed_s) {
+        *out_elapsed_s = elapsed_s;
+    }
+    return 1;
+}
+
+static int
+p25_voice_ptt_is_retransmission(const p25_sm_ctx_t* ctx, int slot, const p25_sm_event_t* ev, double observed_m,
+                                double* out_elapsed_s) {
+    return ctx && ctx->vc_is_tdma && slot >= 0 && slot <= 1 && p25_voice_slot_epoch_active(&ctx->slots[slot])
+           && p25_ptt_marker_matches(ctx, slot, ev, observed_m, out_elapsed_s);
+}
+
+static void
+p25_voice_accept_ptt_marker(p25_sm_ctx_t* ctx, int slot, const p25_sm_event_t* ev, double observed_m) {
+    if (!ctx || !ev || slot < 0 || slot > 1 || ev->type != P25_SM_EV_PTT) {
+        return;
+    }
+    if (!ev->ptt_signature_valid || ev->observed_m <= 0.0) {
+        p25_ptt_marker_invalidate(ctx, slot);
+        return;
+    }
+
+    p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
+    DSD_MEMCPY(slot_ctx->ptt_signature, ev->ptt_signature, sizeof(slot_ctx->ptt_signature));
+    slot_ctx->ptt_last_seen_m = observed_m;
+    slot_ctx->ptt_signature_valid = 1;
+}
+
+static int
 p25_voice_start_follows_completed_epoch(const p25_sm_slot_ctx_t* slot_ctx) {
     return slot_ctx && slot_ctx->last_start_m > 0.0 && !p25_voice_slot_epoch_active(slot_ctx);
 }
@@ -2643,8 +2717,8 @@ p25_voice_start_is_p2_ptt(const p25_sm_ctx_t* ctx, const p25_sm_event_t* ev) {
 
 static int
 p25_voice_start_begins_new_epoch(const p25_sm_ctx_t* ctx, const p25_sm_slot_ctx_t* slot_ctx,
-                                 const p25_sm_event_t* input, const p25_sm_event_t* call_ev) {
-    return p25_voice_start_is_p2_ptt(ctx, input) || !p25_voice_slot_epoch_active(slot_ctx)
+                                 const p25_sm_event_t* input, const p25_sm_event_t* call_ev, int ptt_retransmit) {
+    return (p25_voice_start_is_p2_ptt(ctx, input) && !ptt_retransmit) || !p25_voice_slot_epoch_active(slot_ctx)
            || p25_voice_start_target_changed(slot_ctx, call_ev) || p25_voice_start_source_changed(slot_ctx, call_ev);
 }
 
@@ -2766,12 +2840,12 @@ p25_p1_hdu_crypto_consume_identity(const p25_sm_ctx_t* ctx, dsd_state* state, co
 
 static p25_voice_start_changes_t
 p25_voice_start_classify_changes(const p25_sm_ctx_t* ctx, const p25_sm_slot_ctx_t* slot_ctx,
-                                 const p25_sm_event_t* input, const p25_sm_event_t* call_ev) {
+                                 const p25_sm_event_t* input, const p25_sm_event_t* call_ev, int ptt_retransmit) {
     p25_voice_start_changes_t changes = {0};
     const int learned_source = !p25_source_id_known(slot_ctx->src) && p25_source_id_known(call_ev->src);
 
     changes.service_changed = p25_voice_start_service_changed(slot_ctx, call_ev);
-    changes.new_epoch = p25_voice_start_begins_new_epoch(ctx, slot_ctx, input, call_ev);
+    changes.new_epoch = p25_voice_start_begins_new_epoch(ctx, slot_ctx, input, call_ev, ptt_retransmit);
     changes.requires_update = changes.new_epoch || changes.service_changed || learned_source;
     return changes;
 }
@@ -2867,6 +2941,9 @@ p25_voice_start_commit_identity(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* st
     p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
     const int logical_slot = ctx->vc_is_tdma ? slot : 0;
 
+    if (changes->new_epoch) {
+        p25_ptt_marker_invalidate(ctx, slot);
+    }
     if (changes->new_epoch && slot_ctx->voice_active) {
         (void)dsd_tg_policy_clear_active_call(state, ctx->vc_is_tdma ? slot : -1);
         if (changes->preserve_crypto_classification) {
@@ -2898,7 +2975,7 @@ p25_voice_start_commit_identity(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* st
 
 static int
 p25_voice_start_apply_identity(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot,
-                               const p25_sm_event_t* input, double now_m, int* out_new_epoch) {
+                               const p25_sm_event_t* input, double now_m, int ptt_retransmit, int* out_new_epoch) {
     p25_sm_event_t call_ev;
     if (out_new_epoch) {
         *out_new_epoch = !ctx->slots[slot].voice_active;
@@ -2918,7 +2995,8 @@ p25_voice_start_apply_identity(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* sta
     }
 
     const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
-    p25_voice_start_changes_t changes = p25_voice_start_classify_changes(ctx, slot_ctx, input, &call_ev);
+    p25_voice_start_changes_t changes =
+        p25_voice_start_classify_changes(ctx, slot_ctx, input, &call_ev, ptt_retransmit);
     if (pending_p1_identity) {
         changes.requires_update = 1;
     }
@@ -3017,6 +3095,30 @@ p25_voice_start_wait_for_classification(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
 }
 
 static int
+p25_voice_start_apply_event(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, const p25_sm_event_t* ev,
+                            double now_m, int* out_new_epoch) {
+    double ptt_elapsed_s = 0.0;
+    const int ptt_retransmit = p25_voice_ptt_is_retransmission(ctx, slot, ev, now_m, &ptt_elapsed_s);
+    if (!p25_voice_start_apply_identity(ctx, opts, state, slot, ev, now_m, ptt_retransmit, out_new_epoch)) {
+        if (state && ctx->vc_is_tdma) {
+            state->p25_p2_media_rejected[slot] = 1;
+            state->p25_p2_audio_allowed[slot] = 0;
+        }
+        return 0;
+    }
+
+    p25_voice_accept_ptt_marker(ctx, slot, ev, now_m);
+    if (ptt_retransmit) {
+        p25_sm_diagf(opts, state, ctx, "ptt_retransmit", "slot=%d tg=%d src=%d elapsed=%.3f provenance=%s", slot,
+                     ev->tg, ev->src, ptt_elapsed_s, ev->facch ? "facch" : "sacch");
+    }
+    if (state && ctx->vc_is_tdma) {
+        state->p25_p2_media_rejected[slot] = 0;
+    }
+    return 1;
+}
+
+static int
 handle_voice_start(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, const char* why) {
     if (!ctx || !ev) {
         return 0;
@@ -3025,18 +3127,11 @@ handle_voice_start(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p2
         return 1;
     }
 
-    double now_m = dsd_time_now_monotonic_s();
+    double now_m = ev->observed_m > 0.0 ? ev->observed_m : dsd_time_now_monotonic_s();
     int s = (ev->slot >= 0 && ev->slot <= 1) ? ev->slot : 0;
     int new_epoch = !ctx->slots[s].voice_active;
-    if (!p25_voice_start_apply_identity(ctx, opts, state, s, ev, now_m, &new_epoch)) {
-        if (state && ctx->vc_is_tdma) {
-            state->p25_p2_media_rejected[s] = 1;
-            state->p25_p2_audio_allowed[s] = 0;
-        }
+    if (!p25_voice_start_apply_event(ctx, opts, state, s, ev, now_m, &new_epoch)) {
         return 0;
-    }
-    if (state && ctx->vc_is_tdma) {
-        state->p25_p2_media_rejected[s] = 0;
     }
     const int reused = ctx->vc_activity_seen && new_epoch;
     if (new_epoch) {
@@ -3290,6 +3385,7 @@ handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, 
         return 0;
     }
 
+    p25_ptt_marker_invalidate(ctx, s);
     const double now_m = dsd_time_now_monotonic_s();
     const int ended_tg = p25_voice_end_event_tg(ctx, state, s, ev);
     const int ended_src = p25_voice_end_event_src(ctx, state, s, ev);
@@ -3463,6 +3559,7 @@ p25_voice_clear_slot_grant(p25_sm_ctx_t* ctx, dsd_state* state, int slot) {
     if (!ctx || !state || slot < 0 || slot > 1) {
         return;
     }
+    p25_ptt_marker_invalidate(ctx, slot);
     ctx->slots[slot].grant_active = 0;
     ctx->slots[slot].crypto_attempt_m = 0.0;
     (void)dsd_tg_policy_clear_active_call(state, ctx->vc_is_tdma ? slot : -1);
@@ -5270,15 +5367,15 @@ p25_sm_conventional_resolve_call(const dsd_state* state, const p25_sm_event_t* e
     return p25_sm_conventional_anonymous_call(state, slot, call);
 }
 
-static void
-p25_sm_publish_conventional_voice(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev) {
+static int
+p25_sm_publish_conventional_voice(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, int ptt_retransmit) {
     if (!state || !ev) {
-        return;
+        return 0;
     }
     const int slot = p25_sm_conventional_slot(ev);
     p25_sm_conventional_call_t call = {0};
     if (!p25_sm_conventional_resolve_call(state, ev, slot, &call)) {
-        return;
+        return 0;
     }
     const int has_service_metadata = p25_sm_svc_bits_valid(ev->svc_bits);
     const int service_options = has_service_metadata ? ev->svc_bits : 0;
@@ -5296,13 +5393,63 @@ p25_sm_publish_conventional_voice(dsd_opts* opts, dsd_state* state, const p25_sm
         .has_service_metadata = (uint8_t)has_service_metadata,
     };
     dsd_call_boundary boundary = DSD_CALL_BOUNDARY_CONTINUE;
-    if (ev->identity_valid && ev->type == P25_SM_EV_PTT) {
+    if (ev->identity_valid && ev->type == P25_SM_EV_PTT && !ptt_retransmit) {
         boundary = DSD_CALL_BOUNDARY_BEGIN;
     }
     (void)dsd_call_state_observe(state, &observation, boundary);
     p25_call_publish_crypto(opts, state, slot, 0.0);
     (void)dsd_call_state_update_media(state, (uint8_t)slot, 1, 0.0);
     dsd_event_sync_slot(opts, state, (uint8_t)slot);
+    return 1;
+}
+
+static int
+p25_sm_conventional_ptt_is_retransmission(const p25_sm_ctx_t* ctx, const dsd_state* state, const p25_sm_event_t* ev,
+                                          double observed_m, double* out_elapsed_s) {
+    if (!ctx || !state || !ev || ev->type != P25_SM_EV_PTT || !ev->ptt_signature_valid || ev->slot < 0
+        || ev->slot > 1) {
+        return 0;
+    }
+    dsd_call_snapshot call;
+    if (dsd_call_state_get(state, (uint8_t)ev->slot, &call) <= 0 || call.phase != DSD_CALL_PHASE_ACTIVE
+        || !DSD_SYNC_IS_P25P2(call.protocol)) {
+        return 0;
+    }
+    return p25_ptt_marker_matches(ctx, ev->slot, ev, observed_m, out_elapsed_s);
+}
+
+static void
+p25_sm_note_conventional_ptt(p25_sm_ctx_t* ctx, dsd_opts* opts, const dsd_state* state, const p25_sm_event_t* ev,
+                             int slot, double observed_m, int ptt_retransmit, double ptt_elapsed_s) {
+    p25_voice_accept_ptt_marker(ctx, slot, ev, observed_m);
+    if (ptt_retransmit) {
+        p25_sm_diagf(opts, state, ctx, "ptt_retransmit", "slot=%d tg=%d src=%d elapsed=%.3f provenance=%s", slot,
+                     ev->tg, ev->src, ptt_elapsed_s, ev->facch ? "facch" : "sacch");
+    }
+}
+
+static void
+p25_sm_invalidate_conventional_replacement(p25_sm_ctx_t* ctx, const dsd_state* state, int slot,
+                                           const dsd_call_snapshot* call_before, int had_call_before) {
+    dsd_call_snapshot call_after;
+    if (had_call_before && dsd_call_state_get(state, (uint8_t)slot, &call_after) > 0
+        && call_after.epoch != call_before->epoch) {
+        p25_ptt_marker_invalidate(ctx, slot);
+    }
+}
+
+static void
+p25_sm_finish_conventional_voice(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev,
+                                 int slot, double observed_m, int ptt_retransmit, double ptt_elapsed_s,
+                                 const dsd_call_snapshot* call_before, int had_call_before) {
+    if (!p25_sm_publish_conventional_voice(opts, state, ev, ptt_retransmit)) {
+        return;
+    }
+    if (ev->type == P25_SM_EV_PTT) {
+        p25_sm_note_conventional_ptt(ctx, opts, state, ev, slot, observed_m, ptt_retransmit, ptt_elapsed_s);
+        return;
+    }
+    p25_sm_invalidate_conventional_replacement(ctx, state, slot, call_before, had_call_before);
 }
 
 static int
@@ -5312,9 +5459,18 @@ p25_sm_emit_voice_start_event(dsd_opts* opts, dsd_state* state, const p25_sm_eve
         p25_sm_init_ctx(ctx, opts, state);
     }
     const int trunk_assignment_active = ctx->state == P25_SM_TUNED;
+    const double observed_m = ev->observed_m > 0.0 ? ev->observed_m : dsd_time_now_monotonic_s();
+    double ptt_elapsed_s = 0.0;
+    const int ptt_retransmit = !trunk_assignment_active
+                               && p25_sm_conventional_ptt_is_retransmission(ctx, state, ev, observed_m, &ptt_elapsed_s);
+    dsd_call_snapshot call_before = {0};
+    const int conventional_slot = p25_sm_conventional_slot(ev);
+    const int had_call_before =
+        !trunk_assignment_active && state && dsd_call_state_get(state, (uint8_t)conventional_slot, &call_before) > 0;
     const int accepted = handle_voice_start(ctx, opts, state, ev, why);
     if (accepted && !trunk_assignment_active) {
-        p25_sm_publish_conventional_voice(opts, state, ev);
+        p25_sm_finish_conventional_voice(ctx, opts, state, ev, conventional_slot, observed_m, ptt_retransmit,
+                                         ptt_elapsed_s, &call_before, had_call_before);
     }
     return accepted;
 }
@@ -5328,6 +5484,20 @@ p25_sm_emit_ptt(dsd_opts* opts, dsd_state* state, int slot) {
 int
 p25_sm_emit_ptt_call(dsd_opts* opts, dsd_state* state, int slot, int tg, int dst, int src, int is_group, int svc_bits) {
     p25_sm_event_t ev = p25_sm_ev_ptt_call(slot, tg, dst, src, is_group, svc_bits);
+    return p25_sm_emit_voice_start_event(opts, state, &ev, "ptt");
+}
+
+int
+p25_sm_emit_ptt_call_metadata(dsd_opts* opts, dsd_state* state, int slot, int tg, int dst, int src, int is_group,
+                              int svc_bits, const uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES], double observed_m,
+                              int facch) {
+    p25_sm_event_t ev = p25_sm_ev_ptt_call(slot, tg, dst, src, is_group, svc_bits);
+    if (signature && observed_m > 0.0) {
+        DSD_MEMCPY(ev.ptt_signature, signature, sizeof(ev.ptt_signature));
+        ev.ptt_signature_valid = 1;
+    }
+    ev.observed_m = observed_m;
+    ev.facch = facch ? 1 : 0;
     return p25_sm_emit_voice_start_event(opts, state, &ev, "ptt");
 }
 
@@ -5346,10 +5516,12 @@ p25_sm_emit_active_call(dsd_opts* opts, dsd_state* state, int slot, int tg, int 
 
 void
 p25_sm_emit_end(dsd_opts* opts, dsd_state* state, int slot) {
-    const int trunk_assignment_active = p25_sm_get_ctx()->state == P25_SM_TUNED;
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    const int trunk_assignment_active = ctx->state == P25_SM_TUNED;
     p25_sm_event_t ev = p25_sm_ev_end(slot);
-    p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);
+    p25_sm_event(ctx, opts, state, &ev);
     if (!trunk_assignment_active) {
+        p25_ptt_marker_invalidate(ctx, slot);
         p25_call_end_slot(opts, state, slot, 0.0);
     }
 }
@@ -5367,6 +5539,7 @@ p25_sm_emit_end_call_at(dsd_opts* opts, dsd_state* state, int slot, int tg, int 
     const int trunk_assignment_active = ctx->state == P25_SM_TUNED;
     const int accepted = handle_voice_end(ctx, opts, state, slot, "end", 1, 1, &ev);
     if (!trunk_assignment_active && accepted) {
+        p25_ptt_marker_invalidate(ctx, slot);
         p25_call_end_slot(opts, state, slot, observed_m);
     }
     return accepted;
@@ -5385,6 +5558,7 @@ p25_sm_emit_facch_end_call_at(dsd_opts* opts, dsd_state* state, int slot, int tg
     const int trunk_assignment_active = ctx->state == P25_SM_TUNED;
     const int result = handle_facch_voice_end(ctx, opts, state, &ev);
     if (!trunk_assignment_active && result != P25_SM_END_IGNORED) {
+        p25_ptt_marker_invalidate(ctx, slot);
         p25_call_end_slot(opts, state, slot, observed_m);
     }
     return result;
@@ -5392,40 +5566,48 @@ p25_sm_emit_facch_end_call_at(dsd_opts* opts, dsd_state* state, int slot, int tg
 
 void
 p25_sm_emit_idle(dsd_opts* opts, dsd_state* state, int slot) {
-    const int trunk_assignment_active = p25_sm_get_ctx()->state == P25_SM_TUNED;
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    const int trunk_assignment_active = ctx->state == P25_SM_TUNED;
     p25_sm_event_t ev = p25_sm_ev_idle(slot);
-    p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);
+    p25_sm_event(ctx, opts, state, &ev);
     if (!trunk_assignment_active) {
+        p25_ptt_marker_invalidate(ctx, slot);
         p25_call_end_slot(opts, state, slot, 0.0);
     }
 }
 
 void
 p25_sm_emit_idle_at(dsd_opts* opts, dsd_state* state, int slot, double observed_m) {
-    const int trunk_assignment_active = p25_sm_get_ctx()->state == P25_SM_TUNED;
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    const int trunk_assignment_active = ctx->state == P25_SM_TUNED;
     p25_sm_event_t ev = p25_sm_ev_idle_at(slot, observed_m);
-    p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);
+    p25_sm_event(ctx, opts, state, &ev);
     if (!trunk_assignment_active) {
+        p25_ptt_marker_invalidate(ctx, slot);
         p25_call_end_slot(opts, state, slot, observed_m);
     }
 }
 
 void
 p25_sm_emit_hangtime(dsd_opts* opts, dsd_state* state, int slot) {
-    const int trunk_assignment_active = p25_sm_get_ctx()->state == P25_SM_TUNED;
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    const int trunk_assignment_active = ctx->state == P25_SM_TUNED;
     p25_sm_event_t ev = p25_sm_ev_hangtime(slot);
-    p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);
+    p25_sm_event(ctx, opts, state, &ev);
     if (!trunk_assignment_active) {
+        p25_ptt_marker_invalidate(ctx, slot);
         p25_call_end_slot(opts, state, slot, 0.0);
     }
 }
 
 void
 p25_sm_emit_tdu(dsd_opts* opts, dsd_state* state) {
-    const int trunk_assignment_active = p25_sm_get_ctx()->state == P25_SM_TUNED;
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    const int trunk_assignment_active = ctx->state == P25_SM_TUNED;
     p25_sm_event_t ev = p25_sm_ev_tdu();
-    p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);
+    p25_sm_event(ctx, opts, state, &ev);
     if (!trunk_assignment_active) {
+        p25_ptt_marker_invalidate(ctx, 0);
         p25_call_end_slot(opts, state, 0, 0.0);
     }
 }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -5477,10 +5477,20 @@ p25_sm_finish_conventional_voice(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
 }
 
 static int
+p25_sm_voice_start_lacks_trunk_assignment(const p25_sm_ctx_t* ctx, const dsd_opts* opts) {
+    return ctx && opts && opts->trunk_enable == 1 && ctx->state != P25_SM_TUNED;
+}
+
+static int
 p25_sm_emit_voice_start_event(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, const char* why) {
     p25_sm_ctx_t* ctx = p25_sm_get_ctx();
     if (!ctx->initialized) {
         p25_sm_init_ctx(ctx, opts, state);
+    }
+    if (p25_sm_voice_start_lacks_trunk_assignment(ctx, opts)) {
+        p25_sm_diagf(opts, state, ctx, "voice_start_ignored", "reason=no-trunk-assignment kind=%s slot=%d tg=%d src=%d",
+                     why, ev->slot, ev->tg, ev->src);
+        return 0;
     }
     const int trunk_assignment_active = ctx->state == P25_SM_TUNED;
     const double observed_m = ev->observed_m > 0.0 ? ev->observed_m : dsd_time_now_monotonic_s();

--- a/src/protocol/p25/p25_trunk_sm_internal.h
+++ b/src/protocol/p25/p25_trunk_sm_internal.h
@@ -24,6 +24,11 @@ void p25_sm_note_encrypted_call_typed(dsd_opts* opts, dsd_state* state, int targ
 int p25_sm_emit_ptt_call_metadata(dsd_opts* opts, dsd_state* state, int slot, int tg, int dst, int src, int is_group,
                                   int svc_bits, const uint8_t signature[17], double observed_m, int facch);
 
+/**
+ * Apply a per-slot MAC Release boundary without releasing a retained carrier.
+ */
+void p25_sm_emit_mac_release(dsd_opts* opts, dsd_state* state, int slot, double observed_m);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/protocol/p25/p25_trunk_sm_internal.h
+++ b/src/protocol/p25/p25_trunk_sm_internal.h
@@ -19,7 +19,8 @@ void p25_sm_note_encrypted_call_typed(dsd_opts* opts, dsd_state* state, int targ
 
 /**
  * Emit a decoded P25P2 MAC_PTT with the raw metadata needed to coalesce
- * equivalent SACCH/FACCH retransmissions.
+ * equivalent SACCH/FACCH retransmissions. Trunk-follow mode rejects the event
+ * when no traffic-channel assignment is active.
  */
 int p25_sm_emit_ptt_call_metadata(dsd_opts* opts, dsd_state* state, int slot, int tg, int dst, int src, int is_group,
                                   int svc_bits, const uint8_t signature[17], double observed_m, int facch);

--- a/src/protocol/p25/p25_trunk_sm_internal.h
+++ b/src/protocol/p25/p25_trunk_sm_internal.h
@@ -9,12 +9,20 @@
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void p25_sm_note_encrypted_call_typed(dsd_opts* opts, dsd_state* state, int target, int is_group);
+
+/**
+ * Emit a decoded P25P2 MAC_PTT with the raw metadata needed to coalesce
+ * equivalent SACCH/FACCH retransmissions.
+ */
+int p25_sm_emit_ptt_call_metadata(dsd_opts* opts, dsd_state* state, int slot, int tg, int dst, int src, int is_group,
+                                  int svc_bits, const uint8_t signature[17], double observed_m, int facch);
 
 #ifdef __cplusplus
 }

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -134,8 +134,8 @@ p25p2_vpdu_is_encrypted_probe(const dsd_opts* opts, int service_options) {
 }
 
 static int
-p25p2_vpdu_voice_has_live_provenance(const dsd_opts* opts, const dsd_state* state) {
-    if (!state || state->p2_is_lcch == 1) {
+p25p2_vpdu_voice_has_live_provenance(const dsd_opts* opts, const dsd_state* state, int slot) {
+    if (!state || state->p2_is_lcch == 1 || slot < 0 || slot > 1) {
         return 0;
     }
     if (!opts || opts->trunk_enable != 1) {
@@ -143,7 +143,8 @@ p25p2_vpdu_voice_has_live_provenance(const dsd_opts* opts, const dsd_state* stat
     }
 
     const p25_sm_ctx_t* sm = p25_sm_get_ctx();
-    return opts->trunk_is_tuned == 1 && sm && sm->state == P25_SM_TUNED;
+    return opts->trunk_is_tuned == 1 && sm && sm->state == P25_SM_TUNED && sm->slots[slot].grant_active
+           && !sm->slots[slot].data_call;
 }
 
 static void
@@ -167,7 +168,7 @@ p25p2_vpdu_observe_voice(dsd_opts* opts, dsd_state* state, int slot, dsd_call_ki
                          uint64_t source, int service_options) {
     if (!state || slot < 0 || slot > 1 || target == 0U
         || (kind != DSD_CALL_KIND_GROUP_VOICE && kind != DSD_CALL_KIND_PRIVATE_VOICE)
-        || !p25p2_vpdu_voice_has_live_provenance(opts, state)) {
+        || !p25p2_vpdu_voice_has_live_provenance(opts, state, slot)) {
         return 0;
     }
     const uint16_t svc = service_options >= 0 ? (uint16_t)service_options : 0U;

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -133,6 +133,19 @@ p25p2_vpdu_is_encrypted_probe(const dsd_opts* opts, int service_options) {
            && opts->trunk_is_tuned == 1 && opts->trunk_tune_enc_calls == 0;
 }
 
+static int
+p25p2_vpdu_voice_has_live_provenance(const dsd_opts* opts, const dsd_state* state) {
+    if (!state || state->p2_is_lcch == 1) {
+        return 0;
+    }
+    if (!opts || opts->trunk_enable != 1) {
+        return 1;
+    }
+
+    const p25_sm_ctx_t* sm = p25_sm_get_ctx();
+    return opts->trunk_is_tuned == 1 && sm && sm->state == P25_SM_TUNED;
+}
+
 static void
 p25p2_vpdu_update_voice_crypto(dsd_state* state, int slot, int service_options, int began, int encrypted_probe) {
     if (service_options < 0 || encrypted_probe) {
@@ -149,12 +162,13 @@ p25p2_vpdu_update_voice_crypto(dsd_state* state, int slot, int service_options, 
     }
 }
 
-static void
+static int
 p25p2_vpdu_observe_voice(dsd_opts* opts, dsd_state* state, int slot, dsd_call_kind kind, uint64_t target,
                          uint64_t source, int service_options) {
     if (!state || slot < 0 || slot > 1 || target == 0U
-        || (kind != DSD_CALL_KIND_GROUP_VOICE && kind != DSD_CALL_KIND_PRIVATE_VOICE)) {
-        return;
+        || (kind != DSD_CALL_KIND_GROUP_VOICE && kind != DSD_CALL_KIND_PRIVATE_VOICE)
+        || !p25p2_vpdu_voice_has_live_provenance(opts, state)) {
+        return 0;
     }
     const uint16_t svc = service_options >= 0 ? (uint16_t)service_options : 0U;
     const dsd_call_observation observation = {
@@ -178,6 +192,7 @@ p25p2_vpdu_observe_voice(dsd_opts* opts, dsd_state* state, int slot, dsd_call_ki
     if (began >= 0 && opts) {
         dsd_event_sync_slot(opts, state, (uint8_t)slot);
     }
+    return began >= 0;
 }
 
 static int
@@ -2865,13 +2880,16 @@ p25p2_vpdu_iter_block_35(p25p2_vpdu_ctx* ctx) {
         DSD_FPRINTF(stderr, "\n VCH %d - Super Group %d SRC %d ", slot + 1, gr, src);
         p25p2_vpdu_print_svc_with_slot_state(opts, state, slot, svc, /*set_packet_bit*/ 0);
         DSD_FPRINTF(stderr, "MFID90 Group Regroup Voice");
-        p25p2_vpdu_store_slot_svc(state, slot, svc);
-        p25p2_vpdu_observe_voice(opts, state, slot, DSD_CALL_KIND_GROUP_VOICE, (uint64_t)(uint32_t)gr,
-                                 (uint64_t)(uint32_t)src, svc);
+        const int live_voice = p25p2_vpdu_observe_voice(opts, state, slot, DSD_CALL_KIND_GROUP_VOICE,
+                                                        (uint64_t)(uint32_t)gr, (uint64_t)(uint32_t)src, svc);
+        if (live_voice) {
+            p25p2_vpdu_store_slot_svc(state, slot, svc);
+        }
         // Treat observed Super Group activity as an active patch (vendor-specific signaling may differ)
         p25_patch_update(state, gr, /*is_patch*/ 1, /*active*/ 1);
 
-        if ((svc & 0x40) && opts->trunk_enable == 1 && opts->trunk_is_tuned == 1 && opts->trunk_tune_enc_calls == 0) {
+        if (live_voice && (svc & 0x40) && opts->trunk_enable == 1 && opts->trunk_is_tuned == 1
+            && opts->trunk_tune_enc_calls == 0) {
             p25p2_vpdu_handle_group_voice_enc_fallback(opts, state, slot, gr);
         }
     }
@@ -2908,9 +2926,11 @@ p25p2_vpdu_iter_block_36(p25p2_vpdu_ctx* ctx) {
         DSD_FPRINTF(stderr, "\n VCH %d - Super Group %d SRC %d ", slot + 1, gr, src);
         p25p2_vpdu_print_svc_with_slot_state(opts, state, slot, svc, /*set_packet_bit*/ 0);
         DSD_FPRINTF(stderr, "MFID90 Group Regroup Voice");
-        p25p2_vpdu_store_slot_svc(state, slot, svc);
-        p25p2_vpdu_observe_voice(opts, state, slot, DSD_CALL_KIND_GROUP_VOICE, (uint64_t)(uint32_t)gr,
-                                 (uint64_t)(uint32_t)src, svc);
+        const int live_voice = p25p2_vpdu_observe_voice(opts, state, slot, DSD_CALL_KIND_GROUP_VOICE,
+                                                        (uint64_t)(uint32_t)gr, (uint64_t)(uint32_t)src, svc);
+        if (live_voice) {
+            p25p2_vpdu_store_slot_svc(state, slot, svc);
+        }
         p25_patch_update(state, gr, /*is_patch*/ 1, /*active*/ 1);
 
         uint32_t mfid90_wacn = (MAC[10 + len_a] << 16) | (MAC[11 + len_a] << 8) | (MAC[12 + len_a] & 0xF0);
@@ -2921,7 +2941,8 @@ p25p2_vpdu_iter_block_36(p25p2_vpdu_ctx* ctx) {
         if (src != 0 && gr != 0) {
             p25_ga_add(state, (uint32_t)src, (uint16_t)gr);
         }
-        if ((svc & 0x40) && opts->trunk_enable == 1 && opts->trunk_is_tuned == 1 && opts->trunk_tune_enc_calls == 0) {
+        if (live_voice && (svc & 0x40) && opts->trunk_enable == 1 && opts->trunk_is_tuned == 1
+            && opts->trunk_tune_enc_calls == 0) {
             p25p2_vpdu_handle_group_voice_enc_fallback(opts, state, slot, gr);
         }
     }
@@ -3375,19 +3396,22 @@ p25p2_vpdu_iter_block_45(p25p2_vpdu_ctx* ctx) {
         }
 
         DSD_FPRINTF(stderr, "\n VCH %d - TG: %d; SRC: %d; ", slot + 1, gr, src);
-        state->p25_p2_last_mac_active[slot] = time(NULL);
         if (MAC[1 + len_a] == 0x21) {
             DSD_FPRINTF(stderr, "SUID: %08llX-%08d; ", src_suid >> 24, src);
         }
 
         p25p2_vpdu_print_svc_with_slot_state(opts, state, slot_idx, svc, /*set_packet_bit*/ 0);
         DSD_FPRINTF(stderr, " Group Voice");
-        p25p2_vpdu_store_slot_svc(state, slot, svc);
-        p25p2_vpdu_observe_voice(opts, state, slot, DSD_CALL_KIND_GROUP_VOICE, (uint64_t)(uint32_t)gr,
-                                 (uint64_t)(uint32_t)src, svc);
+        const int live_voice = p25p2_vpdu_observe_voice(opts, state, slot, DSD_CALL_KIND_GROUP_VOICE,
+                                                        (uint64_t)(uint32_t)gr, (uint64_t)(uint32_t)src, svc);
+        if (live_voice) {
+            state->p25_p2_last_mac_active[slot] = time(NULL);
+            p25p2_vpdu_store_slot_svc(state, slot, svc);
+        }
         DSD_FPRINTF(stderr, (MAC[1 + len_a] == 0x21) ? " - Extended " : " - Abbreviated ");
 
-        if ((svc & 0x40) && opts->trunk_enable == 1 && opts->trunk_is_tuned == 1 && opts->trunk_tune_enc_calls == 0) {
+        if (live_voice && (svc & 0x40) && opts->trunk_enable == 1 && opts->trunk_is_tuned == 1
+            && opts->trunk_tune_enc_calls == 0) {
             p25p2_vpdu_handle_group_voice_enc_fallback(opts, state, slot, gr);
         }
     }
@@ -3430,18 +3454,21 @@ p25p2_vpdu_iter_block_46(p25p2_vpdu_ctx* ctx) {
         }
 
         DSD_FPRINTF(stderr, "\n VCH %d - TGT: %d; SRC %d; ", slot + 1, gr, src);
-        state->p25_p2_last_mac_active[slot] = time(NULL);
         if (MAC[1 + len_a] == 0x22) {
             DSD_FPRINTF(stderr, "SUID: %08llX-%08d; ", src_suid >> 24, src);
         }
 
         p25p2_vpdu_print_svc_no_state(opts, svc);
         DSD_FPRINTF(stderr, " Unit to Unit Voice");
-        p25p2_vpdu_store_slot_svc(state, slot, svc);
-        p25p2_vpdu_observe_voice(opts, state, slot, DSD_CALL_KIND_PRIVATE_VOICE, (uint64_t)(uint32_t)gr,
-                                 (uint64_t)(uint32_t)src, svc);
+        const int live_voice = p25p2_vpdu_observe_voice(opts, state, slot, DSD_CALL_KIND_PRIVATE_VOICE,
+                                                        (uint64_t)(uint32_t)gr, (uint64_t)(uint32_t)src, svc);
+        if (live_voice) {
+            state->p25_p2_last_mac_active[slot] = time(NULL);
+            p25p2_vpdu_store_slot_svc(state, slot, svc);
+        }
 
-        if ((svc & 0x40) && opts->trunk_enable == 1 && opts->trunk_is_tuned == 1 && opts->trunk_tune_enc_calls == 0) {
+        if (live_voice && (svc & 0x40) && opts->trunk_enable == 1 && opts->trunk_is_tuned == 1
+            && opts->trunk_tune_enc_calls == 0) {
             p25_sm_emit_crypto_pending(opts, state, slot & 1);
         }
     }
@@ -4351,9 +4378,10 @@ p25p2_vpdu_handle_telephone_interconnect_voice_user(p25p2_vpdu_ctx* ctx) {
     DSD_FPRINTF(stderr, "\n Telephone Interconnect Voice Channel User");
     DSD_FPRINTF(stderr, "\n  SVC [%02X] Target [%d] Timer [%0.1fs]", svc, target, (double)timer / 10.0);
     p25p2_vpdu_print_svc_with_slot_state(ctx->opts, state, slot_idx, svc, /*set_packet_bit*/ 0);
-    p25p2_vpdu_store_slot_svc(state, slot_idx, svc);
-    p25p2_vpdu_observe_voice(ctx->opts, state, slot_idx, DSD_CALL_KIND_PRIVATE_VOICE, (uint64_t)(uint32_t)target, 0U,
-                             svc);
+    if (p25p2_vpdu_observe_voice(ctx->opts, state, slot_idx, DSD_CALL_KIND_PRIVATE_VOICE, (uint64_t)(uint32_t)target,
+                                 0U, svc)) {
+        p25p2_vpdu_store_slot_svc(state, slot_idx, svc);
+    }
     p25p2_vpdu_publish_activityf(state, 0U, DSD_CALL_KIND_PRIVATE_VOICE, (uint64_t)target, 0U, 0U, 0, (uint16_t)svc,
                                  "TELE Target: %d Timer: %.1fs; ", target, (double)timer / 10.0);
 }
@@ -4891,12 +4919,13 @@ p25p2_vpdu_handle_standard_group_regroup_voice_user_abbreviated(p25p2_vpdu_ctx* 
 
     DSD_FPRINTF(stderr, "\n VCH %d - Super Group %d SRC %d Standard Group Regroup Voice", slot + 1, supergroup, source);
 
-    state->p25_p2_last_mac_active[slot] = time(NULL);
-    state->p25_p2_last_mac_active_m[slot] = dsd_time_now_monotonic_s();
     if (supergroup != 0) {
         p25_patch_update(state, supergroup, /*is_patch*/ 1, /*active*/ 1);
-        p25p2_vpdu_observe_voice(ctx->opts, state, slot, DSD_CALL_KIND_GROUP_VOICE, (uint64_t)(uint32_t)supergroup,
-                                 (uint64_t)(uint32_t)source, -1);
+        if (p25p2_vpdu_observe_voice(ctx->opts, state, slot, DSD_CALL_KIND_GROUP_VOICE, (uint64_t)(uint32_t)supergroup,
+                                     (uint64_t)(uint32_t)source, -1)) {
+            state->p25_p2_last_mac_active[slot] = time(NULL);
+            state->p25_p2_last_mac_active_m[slot] = dsd_time_now_monotonic_s();
+        }
     }
 }
 

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -42,6 +42,7 @@
 #include "../p25_cc_update.h"
 #include "../p25_extended_function.h"
 #include "../p25_response_reason.h"
+#include "../p25_trunk_sm_internal.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -3327,9 +3328,7 @@ p25p2_vpdu_iter_block_44(p25p2_vpdu_ctx* ctx) {
 
         dsd_p25p2_flush_partial_audio_slot(opts, state, released_slot);
         p25p2_vpdu_gate_slot_audio(state, eslot);
-        if (dsd_call_state_end(state, released_slot, dsd_time_now_monotonic_s()) > 0) {
-            dsd_event_sync_slot(opts, state, released_slot);
-        }
+        p25_sm_emit_mac_release(opts, state, released_slot, dsd_time_now_monotonic_s());
         p25_crypto_reset_slot(state, released_slot);
         other_audio = p25p2_vpdu_other_slot_audio_with_history(state, eslot, mac_hold, voice_hold);
         if (!other_audio) {

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -30,6 +30,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <time.h>
+#include "../p25_trunk_sm_internal.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/secret_redaction.h"
@@ -79,6 +80,13 @@ p25p2_xcch_src_from_mac(const unsigned long long int mac[24]) {
 static int
 p25p2_xcch_tg_from_mac(const unsigned long long int mac[24]) {
     return (int)((mac[16] << 8) | mac[17]);
+}
+
+static void
+p25p2_xcch_ptt_signature(const unsigned long long int mac[24], uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES]) {
+    for (int i = 0; i < P25_SM_PTT_SIGNATURE_BYTES; i++) {
+        signature[i] = (uint8_t)(mac[i + 1] & 0xFFULL);
+    }
 }
 
 static int
@@ -499,14 +507,19 @@ p25p2_xcch_handle_sacch_mac_signal(dsd_opts* opts, dsd_state* state, unsigned lo
 static void
 p25p2_xcch_handle_sacch_mac_ptt(dsd_opts* opts, dsd_state* state, uint8_t slot, int mac_offset, int res,
                                 const unsigned long long int smac[24]) {
+    const double ptt_observed_m = dsd_time_now_monotonic_s();
+    uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES];
+    p25p2_xcch_ptt_signature(smac, signature);
+
     DSD_FPRINTF(stderr, " MAC_PTT ");
     DSD_FPRINTF(stderr, "%s", KGRN);
 
     state->p25_p2_last_mac_active[slot] = time(NULL);
-    state->p25_p2_last_mac_active_m[slot] = dsd_time_now_monotonic_s();
+    state->p25_p2_last_mac_active_m[slot] = ptt_observed_m;
 
-    if (!p25_sm_emit_ptt_call(opts, state, slot, p25p2_xcch_tg_from_mac(smac), 0, (int)p25p2_xcch_src_from_mac(smac), 1,
-                              P25_SM_SVC_UNKNOWN)) {
+    if (!p25_sm_emit_ptt_call_metadata(opts, state, slot, p25p2_xcch_tg_from_mac(smac), 0,
+                                       (int)p25p2_xcch_src_from_mac(smac), 1, P25_SM_SVC_UNKNOWN, signature,
+                                       ptt_observed_m, 0)) {
         // A companion slot can keep the traffic carrier tuned after this slot
         // is rejected. Preserve the denied identity so a later ESS decision
         // cannot evaluate the preceding allowed call and reopen audio.
@@ -607,11 +620,19 @@ p25p2_xcch_handle_sacch_mac_hangtime(dsd_opts* opts, dsd_state* state, unsigned 
 static void
 p25p2_xcch_handle_facch_mac_ptt(dsd_opts* opts, dsd_state* state, uint8_t slot, int mac_offset, int res,
                                 const unsigned long long int fmac[24]) {
+    const double ptt_observed_m = dsd_time_now_monotonic_s();
+    uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES];
+    p25p2_xcch_ptt_signature(fmac, signature);
+
     DSD_FPRINTF(stderr, " MAC_PTT  ");
     DSD_FPRINTF(stderr, "%s", KGRN);
 
-    if (!p25_sm_emit_ptt_call(opts, state, slot, p25p2_xcch_tg_from_mac(fmac), 0, (int)p25p2_xcch_src_from_mac(fmac), 1,
-                              P25_SM_SVC_UNKNOWN)) {
+    state->p25_p2_last_mac_active[slot] = time(NULL);
+    state->p25_p2_last_mac_active_m[slot] = ptt_observed_m;
+
+    if (!p25_sm_emit_ptt_call_metadata(opts, state, slot, p25p2_xcch_tg_from_mac(fmac), 0,
+                                       (int)p25p2_xcch_src_from_mac(fmac), 1, P25_SM_SVC_UNKNOWN, signature,
+                                       ptt_observed_m, 1)) {
         DSD_FPRINTF(stderr, "%s", KNRM);
         return;
     }

--- a/tests/protocol/p25/test_p25_p2_vpdu_core.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_core.c
@@ -221,6 +221,70 @@ put_u24_ull(unsigned long long int* mac, int pos, unsigned value) {
     mac[pos + 2] = (unsigned long long int)(value & 0xFFU);
 }
 
+static int
+test_lcch_voice_user_does_not_reopen_call(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    unsigned long long int MAC[24] = {0};
+    int rc = 0;
+
+    MAC[1] = 0x01; // Group Voice Channel User, abbreviated
+    MAC[2] = 0x44; // Encrypted, priority 4
+    put_u16_ull(MAC, 3, 20601U);
+    put_u24_ull(MAC, 5, 618620U);
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    opts.trunk_enable = 1;
+    opts.trunk_is_tuned = 0;
+    state.currentslot = 0;
+    state.p2_is_lcch = 1;
+    state.synctype = DSD_SYNC_P25P2_POS;
+    state.dmr_so = 0x12U;
+    const dsd_call_observation ended = {
+        .protocol = DSD_SYNC_P25P2_POS,
+        .slot = 0U,
+        .kind = DSD_CALL_KIND_GROUP_VOICE,
+        .ota_target_id = 20601U,
+        .policy_target_id = 20601U,
+        .ota_source_id = 618620U,
+    };
+    rc |= expect_true("lcch voice fixture begin", dsd_call_state_observe(&state, &ended, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    rc |= expect_true("lcch voice fixture end", dsd_call_state_end(&state, 0U, 0.0) > 0);
+
+    dsd_call_snapshot before = {0};
+    rc |= expect_true("lcch voice fixture snapshot", dsd_call_state_get(&state, 0U, &before) > 0);
+    process_MAC_VPDU(&opts, &state, 0 /* FACCH */, MAC);
+
+    dsd_call_snapshot after = {0};
+    rc |= expect_true("lcch voice canonical preserved", dsd_call_state_get(&state, 0U, &after) > 0);
+    rc |= expect_eq_long("lcch voice phase preserved", after.phase, DSD_CALL_PHASE_ENDED);
+    rc |= expect_eq_long("lcch voice revision preserved", (long)after.revision, (long)before.revision);
+    rc |= expect_eq_long("lcch voice epoch preserved", (long)after.epoch, (long)before.epoch);
+    rc |= expect_eq_long("lcch voice service preserved", state.dmr_so, 0x12);
+    rc |= expect_eq_long("lcch voice crypto preserved", state.p25_crypto_state[0], DSD_P25_CRYPTO_UNKNOWN);
+    rc |= expect_eq_long("lcch voice timestamp preserved", state.p25_p2_last_mac_active[0], 0);
+    rc |= expect_eq_long("lcch marker reset", state.p2_is_lcch, 0);
+    dsd_state_ext_free_all(&state);
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    state.currentslot = 0;
+    state.synctype = DSD_SYNC_P25P2_POS;
+    process_MAC_VPDU(&opts, &state, 0 /* FACCH */, MAC);
+
+    dsd_call_snapshot conventional = {0};
+    rc |= expect_true("conventional voice canonical call", dsd_call_state_get(&state, 0U, &conventional) > 0);
+    rc |= expect_eq_long("conventional voice phase", conventional.phase, DSD_CALL_PHASE_ACTIVE);
+    rc |= expect_eq_long("conventional voice target", (long)conventional.ota_target_id, 20601);
+    rc |= expect_eq_long("conventional voice source", (long)conventional.ota_source_id, 618620);
+    rc |= expect_eq_long("conventional voice service", state.dmr_so, 0x44);
+    rc |= expect_true("conventional voice timestamp", state.p25_p2_last_mac_active[0] != 0);
+    dsd_state_ext_free_all(&state);
+
+    return rc;
+}
+
 static void
 put_fqid_tail_ull(unsigned long long int* mac, int pos, unsigned wacn, unsigned sysid, unsigned source) {
     mac[pos + 0] = (unsigned long long int)((wacn >> 12) & 0xFFU);
@@ -1608,6 +1672,8 @@ run_cases(void) {
     rc |= run_deferred_sccb_resolution_case();
     rc |= run_deferred_adjacent_wacn_resolution_case();
     rc |= run_sccb_full_cache_preservation_case();
+
+    rc |= test_lcch_voice_user_does_not_reopen_call();
 
     // Case 14: extended private voice (0x22) derives source from the SUID tail.
     {

--- a/tests/protocol/p25/test_p25_p2_vpdu_enc_flush.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_enc_flush.c
@@ -146,6 +146,8 @@ main(void) {
     sm->state = P25_SM_TUNED;
     sm->vc_is_tdma = 1;
     sm->vc_freq_hz = 851500000;
+    sm->slots[0].grant_active = 1;
+    sm->slots[0].freq_hz = sm->vc_freq_hz;
 
     // Scenario 1: other slot active. ENC should gate only current slot and not release.
     st.currentslot = 0;             // so VPDU slot=0 for FACCH

--- a/tests/protocol/p25/test_p25_p2_vpdu_enc_flush.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_enc_flush.c
@@ -10,8 +10,8 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
-#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/protocol/p25/p25_crypto.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/protocol/p25/p25_vpdu.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
@@ -121,19 +121,6 @@ seed_policy_group(dsd_state* st, uint32_t id, const char* mode, const char* name
         return 1;
     }
     return dsd_tg_policy_append_exact(st, &row);
-}
-
-static int
-seed_group_call(dsd_state* state, uint8_t slot, uint64_t target) {
-    const dsd_call_observation observation = {
-        .protocol = DSD_SYNC_P25P2_POS,
-        .slot = slot,
-        .kind = DSD_CALL_KIND_GROUP_VOICE,
-        .ota_target_id = target,
-        .policy_target_id = target,
-        .observed_m = 1.0,
-    };
-    return dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0;
 }
 
 int
@@ -256,7 +243,8 @@ main(void) {
     rc |= expect_eq("clear regroup member ring preserved", st.p25_p2_audio_ring_count[0], 2);
 
     // Scenario 5: MAC Release drains a short int16 tail while crypto readiness
-    // is still authoritative, before the slot is gated and reset.
+    // is still authoritative, invalidates the released slot's PTT marker, and
+    // permits an identical follow-up PTT while the companion retains the carrier.
     DSD_MEMSET(MAC, 0, sizeof MAC);
     MAC[1] = 0x31;
     opts.trunk_is_tuned = 1;
@@ -264,13 +252,45 @@ main(void) {
     opts.audio_out_type = 8;
     opts.floating_point = 0;
     opts.pulse_digi_rate_out = 8000;
+    opts.trunk_tune_group_calls = 1;
+    opts.trunk_tune_enc_calls = 1;
     opts.slot1_on = 1;
     opts.slot2_on = 1;
     st.currentslot = 0;
-    rc |= expect_eq("MAC Release seed active call", seed_group_call(&st, 0U, 0x2222), 1);
-    rc |= expect_eq("MAC Release seed active companion", seed_group_call(&st, 1U, 0x3333), 1);
-    dsd_event_sync_slot(&opts, &st, 0U);
-    dsd_event_sync_slot(&opts, &st, 1U);
+    p25_crypto_reset_slot(&st, 0);
+    p25_crypto_reset_slot(&st, 1);
+    p25_sm_ctx_t* sm = p25_sm_get_ctx();
+    p25_sm_init_ctx(sm, &opts, &st);
+    sm->state = P25_SM_TUNED;
+    sm->vc_is_tdma = 1;
+    sm->vc_freq_hz = 851500000;
+    const double first_ptt_m = dsd_time_now_monotonic_s();
+    for (int slot = 0; slot < 2; slot++) {
+        sm->slots[slot].grant_active = 1;
+        sm->slots[slot].freq_hz = sm->vc_freq_hz;
+        sm->slots[slot].channel = 0x1234 | slot;
+        sm->slots[slot].target_id = slot == 0 ? 0x2222 : 0x3333;
+        sm->slots[slot].ota_tg = sm->slots[slot].target_id;
+        sm->slots[slot].src = slot + 1;
+        sm->slots[slot].is_group = 1;
+        sm->slots[slot].svc_bits = 0;
+        sm->slots[slot].last_grant_m = first_ptt_m;
+    }
+    const uint8_t release_ptt_signature[P25_SM_PTT_SIGNATURE_BYTES] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x99, 0x80, 0x12, 0x34, 0x00, 0x00, 0x01, 0x22, 0x22,
+    };
+    p25_sm_event_t release_ptt = p25_sm_ev_ptt_call(0, 0x2222, 0, 1, 1, 0);
+    DSD_MEMCPY(release_ptt.ptt_signature, release_ptt_signature, sizeof(release_ptt.ptt_signature));
+    release_ptt.ptt_signature_valid = 1;
+    release_ptt.observed_m = first_ptt_m;
+    p25_sm_event(sm, &opts, &st, &release_ptt);
+    p25_sm_event_t companion_active = p25_sm_ev_active_call(1, 0x3333, 0, 2, 1, 0);
+    companion_active.observed_m = first_ptt_m;
+    p25_sm_event(sm, &opts, &st, &companion_active);
+    dsd_call_snapshot released_call = {0};
+    rc |= expect_eq("MAC Release seed active call",
+                    dsd_call_state_get(&st, 0U, &released_call) > 0 && released_call.phase == DSD_CALL_PHASE_ACTIVE, 1);
+    const uint64_t released_epoch = released_call.epoch;
     st.dmrburstL = 21;
     st.dmrburstR = 21;
     st.p25_crypto_state[0] = DSD_P25_CRYPTO_CLEAR;
@@ -292,12 +312,21 @@ main(void) {
     rc |= expect_eq("MAC Release tail drained", st.s_l4[0][0], 0);
     rc |= expect_eq("MAC Release crypto reset after flush", st.p25_crypto_state[0], DSD_P25_CRYPTO_UNKNOWN);
     rc |= expect_eq("MAC Release retains active companion", g_return_to_cc_called, 0);
+    rc |= expect_eq("MAC Release invalidates released PTT marker", sm->slots[0].ptt_signature_valid, 0);
+    rc |= expect_eq("MAC Release clears released slot activity", sm->slots[0].voice_active, 0);
+    rc |= expect_eq("MAC Release preserves released slot assignment", sm->slots[0].grant_active, 1);
     dsd_call_context_snapshot call_context;
     rc |= expect_eq("MAC Release copies call context", dsd_call_context_copy_snapshot(&st, &call_context), 1);
     rc |= expect_eq("MAC Release ends released slot", call_context.calls.slots[0].phase, DSD_CALL_PHASE_ENDED);
     rc |= expect_eq("MAC Release finalizes released event", call_context.events[0].ended_committed, 1);
     rc |= expect_eq("MAC Release keeps companion active", call_context.calls.slots[1].phase, DSD_CALL_PHASE_ACTIVE);
     rc |= expect_eq("MAC Release leaves companion event open", call_context.events[1].ended_committed, 0);
+
+    release_ptt.observed_m = first_ptt_m + 0.5;
+    p25_sm_event(sm, &opts, &st, &release_ptt);
+    rc |= expect_eq("MAC Release follow-up copies call", dsd_call_state_get(&st, 0U, &released_call) > 0, 1);
+    rc |= expect_eq("MAC Release follow-up reopens call", released_call.phase, DSD_CALL_PHASE_ACTIVE);
+    rc |= expect_eq("MAC Release follow-up starts new epoch", released_call.epoch == released_epoch + 1U, 1);
 
     dsd_udp_audio_hooks_set((dsd_udp_audio_hooks){0});
     dsd_state_ext_free_all(&st);

--- a/tests/protocol/p25/test_p25_p2_vpdu_enc_flush.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_enc_flush.c
@@ -141,6 +141,11 @@ main(void) {
     opts.trunk_enable = 1;
     opts.trunk_is_tuned = 1;
     opts.trunk_tune_enc_calls = 0;
+    p25_sm_ctx_t* sm = p25_sm_get_ctx();
+    p25_sm_init_ctx(sm, &opts, &st);
+    sm->state = P25_SM_TUNED;
+    sm->vc_is_tdma = 1;
+    sm->vc_freq_hz = 851500000;
 
     // Scenario 1: other slot active. ENC should gate only current slot and not release.
     st.currentslot = 0;             // so VPDU slot=0 for FACCH
@@ -259,7 +264,7 @@ main(void) {
     st.currentslot = 0;
     p25_crypto_reset_slot(&st, 0);
     p25_crypto_reset_slot(&st, 1);
-    p25_sm_ctx_t* sm = p25_sm_get_ctx();
+    sm = p25_sm_get_ctx();
     p25_sm_init_ctx(sm, &opts, &st);
     sm->state = P25_SM_TUNED;
     sm->vc_is_tdma = 1;

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -286,6 +286,7 @@ run_standard_regroup_voice_user_case(int mfid, int slot, const char* tag) {
     p25_sm_init_ctx(sm, &opts, &state);
     sm->state = P25_SM_TUNED;
     sm->vc_is_tdma = 1;
+    sm->slots[slot].grant_active = 1;
     process_MAC_VPDU(&opts, &state, 0, MAC);
 
     DSD_SNPRINTF(label, sizeof label, "%s no grant dispatch", tag);
@@ -324,6 +325,77 @@ run_standard_regroup_voice_user_case(int mfid, int slot, const char* tag) {
     rc |= expect_eq_long(label, (long)call.ota_target_id, 0x3456);
     DSD_SNPRINTF(label, sizeof label, "%s source", tag);
     rc |= expect_eq_long(label, (long)call.ota_source_id, 0x010203);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+static int
+test_rejected_tdma_slot_voice_user_does_not_reopen_call(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    unsigned long long int MAC[24] = {0};
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+    opts.trunk_enable = 1;
+    opts.trunk_is_tuned = 1;
+    opts.trunk_tune_enc_calls = 1;
+    state.currentslot = 0;
+    state.synctype = DSD_SYNC_P25P2_POS;
+    state.dmr_so = 0x12U;
+    rc |= expect_true("rejected-slot voice user seed slot0",
+                      seed_voice_call(&state, 0U, DSD_CALL_KIND_GROUP_VOICE, 20601U, 20601U, 618620U, 0x12U));
+    rc |= expect_true("rejected-slot voice user end slot0", dsd_call_state_end(&state, 0U, 0.0) > 0);
+    rc |= expect_true("rejected-slot voice user seed companion",
+                      seed_voice_call(&state, 1U, DSD_CALL_KIND_GROUP_VOICE, 20700U, 20700U, 618621U, 0x20U));
+
+    dsd_call_snapshot slot0_before = {0};
+    dsd_call_snapshot slot1_before = {0};
+    rc |= expect_true("rejected-slot voice user snapshot slot0", copy_call(&state, 0U, &slot0_before));
+    rc |= expect_true("rejected-slot voice user snapshot slot1", copy_call(&state, 1U, &slot1_before));
+
+    p25_sm_ctx_t* sm = p25_sm_get_ctx();
+    p25_sm_init_ctx(sm, &opts, &state);
+    sm->state = P25_SM_TUNED;
+    sm->vc_is_tdma = 1;
+    sm->vc_freq_hz = 851500000;
+    sm->slots[0].grant_active = 0;
+    sm->slots[1].grant_active = 1;
+    sm->slots[1].freq_hz = sm->vc_freq_hz;
+    sm->slots[1].target_id = 20700;
+    sm->slots[1].ota_tg = 20700;
+    sm->slots[1].is_group = 1;
+
+    MAC[1] = 0x01; // Group Voice Channel User, abbreviated
+    MAC[2] = 0x44; // Encrypted, priority 4
+    MAC[3] = 0x50;
+    MAC[4] = 0x79; // TG 20601
+    MAC[5] = 0x09;
+    MAC[6] = 0x70;
+    MAC[7] = 0x7C; // SRC 618620
+    process_MAC_VPDU(&opts, &state, 0, MAC);
+
+    dsd_call_snapshot slot0_after = {0};
+    dsd_call_snapshot slot1_after = {0};
+    rc |= expect_true("rejected-slot voice user preserved slot0", copy_call(&state, 0U, &slot0_after));
+    rc |= expect_true("rejected-slot voice user preserved companion", copy_call(&state, 1U, &slot1_after));
+    rc |= expect_eq_long("rejected-slot voice user slot0 phase", slot0_after.phase, DSD_CALL_PHASE_ENDED);
+    rc |= expect_eq_long("rejected-slot voice user slot0 revision", (long)slot0_after.revision,
+                         (long)slot0_before.revision);
+    rc |= expect_eq_long("rejected-slot voice user slot0 epoch", (long)slot0_after.epoch, (long)slot0_before.epoch);
+    rc |= expect_eq_long("rejected-slot voice user slot0 service", slot0_after.service_options,
+                         slot0_before.service_options);
+    rc |= expect_eq_long("rejected-slot voice user companion revision", (long)slot1_after.revision,
+                         (long)slot1_before.revision);
+    rc |= expect_eq_long("rejected-slot voice user carrier stays tuned", sm->state, P25_SM_TUNED);
+    rc |= expect_eq_long("rejected-slot voice user rejected grant stays clear", sm->slots[0].grant_active, 0);
+    rc |= expect_eq_long("rejected-slot voice user companion grant remains", sm->slots[1].grant_active, 1);
+    rc |= expect_eq_long("rejected-slot voice user service state preserved", state.dmr_so, 0x12);
+    rc |= expect_eq_long("rejected-slot voice user crypto state preserved", state.p25_crypto_state[0],
+                         DSD_P25_CRYPTO_UNKNOWN);
+    rc |= expect_eq_long("rejected-slot voice user timestamp preserved", state.p25_p2_last_mac_active[0], 0);
 
     dsd_state_ext_free_all(&state);
     return rc;
@@ -1357,6 +1429,7 @@ main(void) {
 
     rc |= run_standard_regroup_voice_user_case(0x00, 0, "0x90/mfid00");
     rc |= run_standard_regroup_voice_user_case(0x01, 1, "0x90/mfid01");
+    rc |= test_rejected_tdma_slot_voice_user_does_not_reopen_call();
     rc |= run_standard_regroup_voice_user_nonstandard_guard_case();
 
     // Case D6: Group Affiliation Response 0x68 accepts on low GAV bits, not status bits 5-6.

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -282,11 +282,14 @@ run_standard_regroup_voice_user_case(int mfid, int slot, const char* tag) {
     MAC[6] = 0x02;
     MAC[7] = 0x03;
 
-    p25_sm_init_ctx(p25_sm_get_ctx(), &opts, &state);
+    p25_sm_ctx_t* sm = p25_sm_get_ctx();
+    p25_sm_init_ctx(sm, &opts, &state);
+    sm->state = P25_SM_TUNED;
+    sm->vc_is_tdma = 1;
     process_MAC_VPDU(&opts, &state, 0, MAC);
 
     DSD_SNPRINTF(label, sizeof label, "%s no grant dispatch", tag);
-    rc |= expect_eq_long(label, p25_sm_get_ctx()->grant_count, 0);
+    rc |= expect_eq_long(label, sm->grant_count, 0);
     DSD_SNPRINTF(label, sizeof label, "%s no retune", tag);
     rc |= expect_eq_long(label, opts.trunk_is_tuned, 1);
     dsd_call_snapshot call = {0};

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -962,7 +962,7 @@ test_rejected_voice_events_keep_media_closed(void) {
     state.p25_p2_audio_allowed[1] = 1;
     state.dmrburstL = 21;
     g_voice_event_accept = 0;
-    fill_mac(mac, 0x80, 0, 303, 1001);
+    fill_mac(mac, 0x84, 0x2468, 303, 1001);
 
     p25p2_xcch_handle_sacch_mac_ptt(&opts, &state, 0, 0, 0, mac);
     rc |= expect_int("rejected sacch ptt emitted", g_ptt_count[0], 1);
@@ -970,6 +970,11 @@ test_rejected_voice_events_keep_media_closed(void) {
     rc |= expect_int("rejected sacch ptt gate closed", state.p25_p2_audio_allowed[0], 0);
     rc |= expect_int("rejected sacch ptt companion gate preserved", state.p25_p2_audio_allowed[1], 1);
     rc |= expect_int("rejected sacch ptt burst cleared", (int)state.dmrburstL, 0);
+    rc |= expect_int("rejected sacch ptt no crypto", g_enc_count[0], 0);
+    rc |= expect_int("rejected sacch ptt no lfsr", g_lfsr_count[0], 0);
+    rc |= expect_int("rejected sacch ptt no algid", state.payload_algid, 0);
+    rc |= expect_int("rejected sacch ptt no keyid", state.payload_keyid, 0);
+    rc |= expect_u64("rejected sacch ptt no mi", state.payload_miP, 0U);
 
     reset_stubs();
     DSD_MEMSET(&state, 0, sizeof(state));
@@ -978,7 +983,7 @@ test_rejected_voice_events_keep_media_closed(void) {
     state.p25_p2_audio_allowed[1] = 1;
     state.dmrburstR = 21;
     g_voice_event_accept = 0;
-    fill_mac(mac, 0x80, 0, 404, 2001);
+    fill_mac(mac, 0x84, 0x1357, 404, 2001);
 
     p25p2_xcch_handle_facch_mac_ptt(&opts, &state, 1, 0, 0, mac);
     rc |= expect_int("rejected facch ptt emitted", g_ptt_count[1], 1);
@@ -986,6 +991,11 @@ test_rejected_voice_events_keep_media_closed(void) {
     rc |= expect_int("rejected facch ptt companion gate preserved", state.p25_p2_audio_allowed[0], 1);
     rc |= expect_int("rejected facch ptt gate closed", state.p25_p2_audio_allowed[1], 0);
     rc |= expect_int("rejected facch ptt burst cleared", (int)state.dmrburstR, 0);
+    rc |= expect_int("rejected facch ptt no crypto", g_enc_count[1], 0);
+    rc |= expect_int("rejected facch ptt no lfsr", g_lfsr_count[1], 0);
+    rc |= expect_int("rejected facch ptt no algid", state.payload_algidR, 0);
+    rc |= expect_int("rejected facch ptt no keyid", state.payload_keyidR, 0);
+    rc |= expect_u64("rejected facch ptt no mi", state.payload_miN, 0U);
 
     reset_stubs();
     DSD_MEMSET(&state, 0, sizeof(state));

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -24,6 +24,7 @@
 #include <dsd-neo/runtime/p25_p2_audio_ring.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "../../../src/protocol/p25/p25_trunk_sm_internal.h"
 
 static int g_audio_allow;
 static int g_crc12_result;
@@ -36,6 +37,11 @@ static int g_vpdu_grant_newer_slot;
 static int g_vpdu_enc_pending_slot;
 static unsigned long long int g_vpdu_mac[24];
 static int g_ptt_count[2];
+static uint8_t g_ptt_signatures[8][P25_SM_PTT_SIGNATURE_BYTES];
+static int g_ptt_metadata_count;
+static int g_ptt_metadata_slot[8];
+static int g_ptt_metadata_facch[8];
+static double g_ptt_metadata_observed_m[8];
 static int g_active_count[2];
 static int g_voice_event_accept;
 static int g_active_tg[2];
@@ -223,6 +229,23 @@ p25_sm_emit_ptt_call(dsd_opts* opts, dsd_state* state, int slot, int tg, int dst
         (void)dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN);
     }
     return accepted;
+}
+
+int
+p25_sm_emit_ptt_call_metadata(dsd_opts* opts, dsd_state* state, int slot, int tg, int dst, int src, int is_group,
+                              int svc_bits, const uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES], double observed_m,
+                              int facch) {
+    if (g_ptt_metadata_count < 8) {
+        const int index = g_ptt_metadata_count;
+        if (signature) {
+            DSD_MEMCPY(g_ptt_signatures[index], signature, sizeof(g_ptt_signatures[index]));
+        }
+        g_ptt_metadata_slot[index] = slot;
+        g_ptt_metadata_facch[index] = facch;
+        g_ptt_metadata_observed_m[index] = observed_m;
+    }
+    g_ptt_metadata_count++;
+    return p25_sm_emit_ptt_call(opts, state, slot, tg, dst, src, is_group, svc_bits);
 }
 
 int
@@ -489,6 +512,11 @@ reset_stubs(void) {
     g_vpdu_enc_pending_slot = -1;
     DSD_MEMSET(g_vpdu_mac, 0, sizeof(g_vpdu_mac));
     DSD_MEMSET(g_ptt_count, 0, sizeof(g_ptt_count));
+    DSD_MEMSET(g_ptt_signatures, 0, sizeof(g_ptt_signatures));
+    g_ptt_metadata_count = 0;
+    DSD_MEMSET(g_ptt_metadata_slot, 0, sizeof(g_ptt_metadata_slot));
+    DSD_MEMSET(g_ptt_metadata_facch, 0, sizeof(g_ptt_metadata_facch));
+    DSD_MEMSET(g_ptt_metadata_observed_m, 0, sizeof(g_ptt_metadata_observed_m));
     DSD_MEMSET(g_active_count, 0, sizeof(g_active_count));
     g_voice_event_accept = 1;
     DSD_MEMSET(g_active_tg, 0, sizeof(g_active_tg));
@@ -540,6 +568,19 @@ expect_u64(const char* label, unsigned long long int got, unsigned long long int
     if (got != want) {
         DSD_FPRINTF(stderr, "FAIL: %s got 0x%016llX want 0x%016llX\n", label, got, want);
         return 1;
+    }
+    return 0;
+}
+
+static int
+expect_signature(const char* label, const uint8_t got[P25_SM_PTT_SIGNATURE_BYTES],
+                 const unsigned long long int mac[24]) {
+    for (int i = 0; i < P25_SM_PTT_SIGNATURE_BYTES; i++) {
+        const uint8_t want = (uint8_t)(mac[i + 1] & 0xFFULL);
+        if (got[i] != want) {
+            DSD_FPRINTF(stderr, "FAIL: %s byte %d got 0x%02X want 0x%02X\n", label, i, got[i], want);
+            return 1;
+        }
     }
     return 0;
 }
@@ -799,6 +840,58 @@ test_facch_public_dispatch_and_crc_gates(void) {
     process_FACCH_MAC_PDU(&opts, &state, payload);
     rc |= expect_int("facch crc abort no vpdu", g_vpdu_count, 0);
     rc |= expect_int("facch crc abort no gate", state.p25_p2_audio_allowed[1], 0);
+    rc |= expect_int("facch crc abort no ptt marker", g_ptt_metadata_count, 0);
+
+    return rc;
+}
+
+static int
+test_ptt_signature_transport_equivalence_and_repeat_processing(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    unsigned long long int mac[24];
+    int sacch_payload[180];
+    int facch_payload[156];
+    int rc = 0;
+
+    reset_stubs();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    fill_mac(mac, 0x84, 0x2468, 0x010203, 0x1234);
+    pack_payload_from_mac(sacch_payload, 180, mac, 0x1, 0, 0);
+    pack_payload_from_mac(facch_payload, 156, mac, 0x1, 0, 0);
+    state.A1[1] = 1;
+    state.A2[1] = 2;
+    state.A3[1] = 3;
+    state.A4[1] = 4;
+    state.aes_key_loaded[1] = 1;
+    state.aes_key_segments[1] = 4U;
+
+    state.currentslot = 0;
+    process_SACCH_MAC_PDU(&opts, &state, sacch_payload);
+    process_SACCH_MAC_PDU(&opts, &state, sacch_payload);
+    state.currentslot = 1;
+    process_FACCH_MAC_PDU(&opts, &state, facch_payload);
+    process_FACCH_MAC_PDU(&opts, &state, facch_payload);
+
+    rc |= expect_int("all PTT copies emitted", g_ptt_metadata_count, 4);
+    for (int i = 0; i < 4; i++) {
+        char label[64];
+        DSD_SNPRINTF(label, sizeof(label), "PTT signature copy %d", i);
+        rc |= expect_signature(label, g_ptt_signatures[i], mac);
+        rc |= expect_int("PTT metadata slot isolation", g_ptt_metadata_slot[i], 1);
+        if (g_ptt_metadata_observed_m[i] <= 0.0) {
+            DSD_FPRINTF(stderr, "FAIL: PTT metadata copy %d has no monotonic observation\n", i);
+            rc = 1;
+        }
+    }
+    rc |= expect_int("SACCH provenance first", g_ptt_metadata_facch[0], 0);
+    rc |= expect_int("SACCH provenance repeat", g_ptt_metadata_facch[1], 0);
+    rc |= expect_int("FACCH provenance first", g_ptt_metadata_facch[2], 1);
+    rc |= expect_int("FACCH provenance repeat", g_ptt_metadata_facch[3], 1);
+    rc |= expect_int("every PTT copy reaches crypto handling", g_enc_count[1], 4);
+    rc |= expect_int("every PTT copy reaches audio setup", g_lfsr_count[1], 4);
+    rc |= expect_int("repeated PTT leaves audio permitted", state.p25_p2_audio_allowed[1], 1);
 
     return rc;
 }
@@ -825,6 +918,14 @@ test_sacch_dispatch_and_lcch_crc_abort(void) {
     rc |= expect_int("sacch opposite slot tg", (int)call.ota_target_id, 0x3456);
     rc |= expect_int("sacch ptt emitted", g_ptt_count[1], 1);
     rc |= expect_int("sacch last active stamped", state.p25_p2_last_mac_active_m[1] > 0.0 ? 1 : 0, 1);
+
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    g_crc12_result = 1;
+    pack_payload_from_mac(payload, 180, mac, 0x1, 0, 0);
+    process_SACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("sacch crc abort no ptt marker", g_ptt_metadata_count, 0);
 
     reset_stubs();
     DSD_MEMSET(&state, 0, sizeof(state));
@@ -1428,6 +1529,7 @@ main(void) {
 
     rc |= test_slot_ptt_and_end_helpers();
     rc |= test_facch_public_dispatch_and_crc_gates();
+    rc |= test_ptt_signature_transport_equivalence_and_repeat_processing();
     rc |= test_sacch_dispatch_and_lcch_crc_abort();
     rc |= test_rejected_voice_events_keep_media_closed();
     rc |= test_sacch_end_idle_active_hangtime_dispatch();

--- a/tests/protocol/p25/test_p25_sm_diag_log.c
+++ b/tests/protocol/p25/test_p25_sm_diag_log.c
@@ -278,6 +278,18 @@ main(void) {
     p25_sm_event_t slot1_grant = p25_sm_ev_group_grant((2 << 12) | 11, 0, 3456, 7890, 0);
     p25_sm_event(&slot_ctx, &slot_opts, &slot_state, &slot0_grant);
     p25_sm_event(&slot_ctx, &slot_opts, &slot_state, &slot1_grant);
+    const uint8_t ptt_signature[P25_SM_PTT_SIGNATURE_BYTES] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x99, 0x80, 0x12, 0x34, 0x00, 0x1A, 0x85, 0x09, 0x29,
+    };
+    const double ptt_m = dsd_time_now_monotonic_s() - 1.0;
+    p25_sm_event_t slot0_ptt = p25_sm_ev_ptt_call(0, 2345, 0, 6789, 1, 0);
+    DSD_MEMCPY(slot0_ptt.ptt_signature, ptt_signature, sizeof(slot0_ptt.ptt_signature));
+    slot0_ptt.ptt_signature_valid = 1;
+    slot0_ptt.observed_m = ptt_m;
+    p25_sm_event(&slot_ctx, &slot_opts, &slot_state, &slot0_ptt);
+    slot0_ptt.observed_m = ptt_m + 0.5;
+    slot0_ptt.facch = 1;
+    p25_sm_event(&slot_ctx, &slot_opts, &slot_state, &slot0_ptt);
     slot_state.p25_p2_audio_allowed[1] = 1;
     p25_sm_event_t slot1_active = p25_sm_ev_active(1);
     p25_sm_event(&slot_ctx, &slot_opts, &slot_state, &slot1_active);
@@ -338,6 +350,8 @@ main(void) {
     rc |= expect_contains(output, "reason=frame-sync-no-sync");
 #endif
     rc |= expect_contains(output, "event=voice_activity");
+    rc |= expect_contains(output, "event=ptt_retransmit");
+    rc |= expect_contains(output, "slot=0 tg=2345 src=6789 elapsed=0.500 provenance=facch");
     rc |= expect_contains(output, "kind=active slot=1");
     rc |= expect_contains(output, "target=3456 tg=3456 src=7890 grant=1");
     rc |= expect_contains(output, "event=voice_end_ignored");

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -472,8 +472,13 @@ test_raw_ptt_retransmissions_coalesce_history(void) {
     }
     dsd_event_sync_slot(&g_opts, &g_state, 0U);
 
+    signature[0] ^= 0x01U;  // Clear-call MI is not an epoch discriminator.
+    signature[8] ^= 0x02U;  // The remaining crypto synchronization octet is also non-authoritative.
+    signature[10] ^= 0x04U; // Neither is the clear-call KID.
     ev = raw_ptt_event(0, 1000, 123, signature, first_m + 0.2, 0);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    signature[7] ^= 0x08U;
+    signature[11] ^= 0x10U;
     ev = raw_ptt_event(0, 1000, 123, signature, first_m + 1.2, 1);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
     if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.epoch != 1U
@@ -482,7 +487,7 @@ test_raw_ptt_retransmissions_coalesce_history(void) {
         || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_CLEAR || g_state.payload_algid != 0x80
         || strcmp(g_state.generic_talker_alias[0], "RETX-ALIAS") != 0
         || event_history[0].Event_History_Items[1].event_string[0] != '\0') {
-        DSD_FPRINTF(stderr, "FAIL: Identical PTTs inside the inclusive window rotated or cleared the active epoch\n");
+        DSD_FPRINTF(stderr, "FAIL: Matching clear PTTs inside the inclusive window rotated or cleared the epoch\n");
         return 1;
     }
 
@@ -522,7 +527,7 @@ test_raw_ptt_signature_changes_open_epochs(void) {
     start_tdma_fixture(&ctx, 0);
 
     uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES];
-    make_ptt_signature(signature, UINT64_C(0x0102030405060708), 0x80, 0x1111, 123, 1000);
+    make_ptt_signature(signature, UINT64_C(0x0102030405060708), 0x84, 0x1111, 123, 1000);
     const double first_m = dsd_time_now_monotonic_s() - 10.0;
     p25_sm_event_t ev = raw_ptt_event(0, 1000, 123, signature, first_m, 0);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
@@ -542,7 +547,7 @@ test_raw_ptt_signature_changes_open_epochs(void) {
         return 1;
     }
 
-    signature[9] = 0x84U; // ALGID
+    signature[9] = 0x89U; // ALGID
     ev = raw_ptt_event(0, 1000, 123, signature, first_m + 0.2, 1);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
     expected_epoch++;

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -10,6 +10,7 @@
 
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/events.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
@@ -22,6 +23,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include "../../../src/protocol/p25/p25_trunk_sm_internal.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_ext.h"
@@ -114,6 +116,44 @@ canonical_call_set_service(uint8_t slot, uint16_t service_options) {
         .observed_m = dsd_time_now_monotonic_s(),
     };
     return dsd_call_state_observe(&g_state, &observation, DSD_CALL_BOUNDARY_CONTINUE) >= 0;
+}
+
+static void
+make_ptt_signature(uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES], uint64_t mi, int algid, int keyid, int src, int tg) {
+    for (int i = 0; i < 8; i++) {
+        signature[i] = (uint8_t)((mi >> (56 - i * 8)) & UINT64_C(0xFF));
+    }
+    signature[8] = 0x99U;
+    signature[9] = (uint8_t)algid;
+    signature[10] = (uint8_t)((keyid >> 8) & 0xFF);
+    signature[11] = (uint8_t)(keyid & 0xFF);
+    signature[12] = (uint8_t)((src >> 16) & 0xFF);
+    signature[13] = (uint8_t)((src >> 8) & 0xFF);
+    signature[14] = (uint8_t)(src & 0xFF);
+    signature[15] = (uint8_t)((tg >> 8) & 0xFF);
+    signature[16] = (uint8_t)(tg & 0xFF);
+}
+
+static p25_sm_event_t
+raw_ptt_event(int slot, int tg, int src, const uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES], double observed_m,
+              int facch) {
+    p25_sm_event_t ev = p25_sm_ev_ptt_call(slot, tg, 0, src, 1, 0);
+    DSD_MEMCPY(ev.ptt_signature, signature, sizeof(ev.ptt_signature));
+    ev.ptt_signature_valid = 1;
+    ev.observed_m = observed_m;
+    ev.facch = facch ? 1 : 0;
+    return ev;
+}
+
+static void
+start_tdma_fixture(p25_sm_ctx_t* ctx, int second_slot) {
+    g_state.trunk_chan_map[0x1234] = 851500000;
+    g_state.trunk_chan_map[0x1235] = 851500000;
+    g_state.p25_chan_tdma_explicit[1] = 2;
+    p25_sm_init_ctx(ctx, &g_opts, &g_state);
+    p25_sm_event_t grant = p25_sm_ev_group_grant(second_slot ? 0x1235 : 0x1234, 851500000, second_slot ? 2000 : 1000,
+                                                 second_slot ? 456 : 123, 0);
+    p25_sm_event(ctx, &g_opts, &g_state, &grant);
 }
 
 static int
@@ -395,6 +435,309 @@ test_same_identity_ptt_starts_new_epoch_after_missed_end(void) {
     if (!ctx.slots[0].voice_active || fabs(ctx.slots[0].last_start_m - followup_start_m) > 1.0e-9
         || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_CLEAR) {
         DSD_FPRINTF(stderr, "FAIL: Repeated same-identity ACTIVE opened another epoch\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_raw_ptt_retransmissions_coalesce_history(void) {
+    static Event_History_I event_history[2];
+    reset_test_state();
+    DSD_MEMSET(event_history, 0, sizeof(event_history));
+    init_event_history(&event_history[0], 0, 255);
+    init_event_history(&event_history[1], 0, 255);
+    g_state.event_history_s = event_history;
+
+    p25_sm_ctx_t ctx;
+    start_tdma_fixture(&ctx, 0);
+    uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES];
+    const uint64_t mi = UINT64_C(0x0102030405060708);
+    make_ptt_signature(signature, mi, 0x80, 0x2468, 123, 1000);
+    const double first_m = dsd_time_now_monotonic_s() - 10.0;
+    p25_sm_event_t ev = raw_ptt_event(0, 1000, 123, signature, first_m, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+
+    dsd_call_snapshot call;
+    if (!canonical_call_is(0U, DSD_CALL_PHASE_ACTIVE, DSD_CALL_KIND_GROUP_VOICE, 1000, 123)
+        || dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.epoch != 1U || !ctx.slots[0].ptt_signature_valid) {
+        DSD_FPRINTF(stderr, "FAIL: Raw PTT retransmission fixture did not open its first epoch\n");
+        return 1;
+    }
+    const double first_start_m = ctx.slots[0].last_start_m;
+    if (p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0x2468, mi, 1000) != DSD_P25_CRYPTO_CLEAR
+        || dsd_event_enrich_alias(&g_state, 0U, call.epoch, "RETX-ALIAS") <= 0) {
+        DSD_FPRINTF(stderr, "FAIL: Raw PTT retransmission fixture did not seed crypto/alias metadata\n");
+        return 1;
+    }
+    dsd_event_sync_slot(&g_opts, &g_state, 0U);
+
+    ev = raw_ptt_event(0, 1000, 123, signature, first_m + 0.2, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    ev = raw_ptt_event(0, 1000, 123, signature, first_m + 1.2, 1);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.epoch != 1U
+        || fabs(ctx.slots[0].last_start_m - first_start_m) > 1.0e-9
+        || fabs(ctx.slots[0].ptt_last_seen_m - (first_m + 1.2)) > 1.0e-9
+        || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_CLEAR || g_state.payload_algid != 0x80
+        || strcmp(g_state.generic_talker_alias[0], "RETX-ALIAS") != 0
+        || event_history[0].Event_History_Items[1].event_string[0] != '\0') {
+        DSD_FPRINTF(stderr, "FAIL: Identical PTTs inside the inclusive window rotated or cleared the active epoch\n");
+        return 1;
+    }
+
+    ev = p25_sm_ev_end_call_at(0, 1000, 123, first_m + 1.3);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.slots[0].ptt_signature_valid || dsd_call_state_get(&g_state, 0U, &call) <= 0
+        || call.phase != DSD_CALL_PHASE_ENDED || call.epoch != 1U
+        || event_history[0].Event_History_Items[1].target_id != 1000U
+        || strcmp(event_history[0].Event_History_Items[1].alias, "RETX-ALIAS") != 0
+        || event_history[0].Event_History_Items[2].event_string[0] != '\0') {
+        DSD_FPRINTF(stderr, "FAIL: Retransmitted PTT epoch did not commit exactly one enriched history row\n");
+        return 1;
+    }
+
+    ev = raw_ptt_event(0, 1000, 123, signature, first_m + 1.4, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.phase != DSD_CALL_PHASE_ACTIVE || call.epoch != 2U) {
+        DSD_FPRINTF(stderr, "FAIL: Accepted END did not permit an immediate same-signature epoch\n");
+        return 1;
+    }
+    const double boundary_start_m = ctx.slots[0].last_start_m;
+    ev = raw_ptt_event(0, 1000, 123, signature, first_m + 2.400001, 1);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.epoch != 3U
+        || ctx.slots[0].last_start_m <= boundary_start_m
+        || event_history[0].Event_History_Items[1].target_id != 1000U) {
+        DSD_FPRINTF(stderr, "FAIL: Post-window identical PTT did not open and record a separate epoch\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_raw_ptt_signature_changes_open_epochs(void) {
+    reset_test_state();
+    p25_sm_ctx_t ctx;
+    start_tdma_fixture(&ctx, 0);
+
+    uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES];
+    make_ptt_signature(signature, UINT64_C(0x0102030405060708), 0x80, 0x1111, 123, 1000);
+    const double first_m = dsd_time_now_monotonic_s() - 10.0;
+    p25_sm_event_t ev = raw_ptt_event(0, 1000, 123, signature, first_m, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+
+    dsd_call_snapshot call;
+    if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.epoch != 1U) {
+        return 1;
+    }
+    uint64_t expected_epoch = call.epoch;
+
+    signature[0] ^= 0x01U; // MI
+    ev = raw_ptt_event(0, 1000, 123, signature, first_m + 0.1, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    expected_epoch++;
+    if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.epoch != expected_epoch) {
+        DSD_FPRINTF(stderr, "FAIL: Changed MI did not open a new PTT epoch\n");
+        return 1;
+    }
+
+    signature[9] = 0x84U; // ALGID
+    ev = raw_ptt_event(0, 1000, 123, signature, first_m + 0.2, 1);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    expected_epoch++;
+    if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.epoch != expected_epoch) {
+        DSD_FPRINTF(stderr, "FAIL: Changed ALGID did not open a new PTT epoch\n");
+        return 1;
+    }
+
+    signature[10] ^= 0x01U; // KID
+    ev = raw_ptt_event(0, 1000, 123, signature, first_m + 0.3, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    expected_epoch++;
+    if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.epoch != expected_epoch) {
+        DSD_FPRINTF(stderr, "FAIL: Changed KID did not open a new PTT epoch\n");
+        return 1;
+    }
+
+    signature[14] = 124U; // Source identity
+    ev = raw_ptt_event(0, 1000, 124, signature, first_m + 0.4, 1);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    expected_epoch++;
+    if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.epoch != expected_epoch || call.ota_source_id != 124U) {
+        DSD_FPRINTF(stderr, "FAIL: Changed PTT identity did not open a new epoch\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_raw_ptt_boundary_invalidation(void) {
+    const p25_sm_event_type_e boundaries[] = {P25_SM_EV_END, P25_SM_EV_IDLE, P25_SM_EV_HANGTIME};
+    for (size_t i = 0; i < sizeof(boundaries) / sizeof(boundaries[0]); i++) {
+        reset_test_state();
+        p25_sm_ctx_t ctx;
+        start_tdma_fixture(&ctx, 0);
+        uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES];
+        make_ptt_signature(signature, UINT64_C(0x1112131415161718), 0x80, 0, 123, 1000);
+        const double first_m = dsd_time_now_monotonic_s() - 10.0;
+        p25_sm_event_t ev = raw_ptt_event(0, 1000, 123, signature, first_m, 0);
+        p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+
+        if (boundaries[i] == P25_SM_EV_END) {
+            ev = p25_sm_ev_end_call_at(0, 1000, 123, first_m + 0.1);
+        } else if (boundaries[i] == P25_SM_EV_IDLE) {
+            ev = p25_sm_ev_idle_at(0, first_m + 0.1);
+        } else {
+            ev = p25_sm_ev_hangtime(0);
+            ev.observed_m = first_m + 0.1;
+        }
+        p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+        if (ctx.slots[0].ptt_signature_valid) {
+            DSD_FPRINTF(stderr, "FAIL: Accepted boundary %d retained its PTT marker\n", (int)boundaries[i]);
+            return 1;
+        }
+
+        ev = raw_ptt_event(0, 1000, 123, signature, first_m + 0.2, 1);
+        p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+        dsd_call_snapshot call;
+        if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.phase != DSD_CALL_PHASE_ACTIVE || call.epoch != 2U) {
+            DSD_FPRINTF(stderr, "FAIL: Boundary %d suppressed an immediate same-signature PTT\n", (int)boundaries[i]);
+            return 1;
+        }
+    }
+
+    reset_test_state();
+    p25_sm_ctx_t ctx;
+    start_tdma_fixture(&ctx, 0);
+    uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES];
+    make_ptt_signature(signature, UINT64_C(0x2122232425262728), 0x80, 0, 123, 1000);
+    const double first_m = dsd_time_now_monotonic_s() - 10.0;
+    p25_sm_event_t ev = raw_ptt_event(0, 1000, 123, signature, first_m, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    p25_sm_release(&ctx, &g_opts, &g_state, "ptt-marker-test");
+    if (ctx.slots[0].ptt_signature_valid || ctx.state != P25_SM_ON_CC) {
+        DSD_FPRINTF(stderr, "FAIL: Retune/release retained a PTT marker\n");
+        return 1;
+    }
+    start_tdma_fixture(&ctx, 0);
+    ev = raw_ptt_event(0, 1000, 123, signature, first_m + 0.1, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    dsd_call_snapshot call;
+    if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.phase != DSD_CALL_PHASE_ACTIVE || call.epoch != 2U) {
+        DSD_FPRINTF(stderr, "FAIL: Retune did not permit an immediate same-signature PTT\n");
+        return 1;
+    }
+
+    reset_test_state();
+    start_tdma_fixture(&ctx, 0);
+    make_ptt_signature(signature, UINT64_C(0x4142434445464748), 0x80, 0, 123, 1000);
+    ev = raw_ptt_event(0, 1000, 123, signature, first_m, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    ev = p25_sm_ev_end_call_at(0, 9999, 999, first_m + 0.1);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (!ctx.slots[0].ptt_signature_valid) {
+        DSD_FPRINTF(stderr, "FAIL: Rejected stale boundary invalidated the PTT marker\n");
+        return 1;
+    }
+    ev = raw_ptt_event(0, 1000, 123, signature, first_m + 0.2, 1);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.epoch != 1U) {
+        DSD_FPRINTF(stderr, "FAIL: Rejected stale boundary broke retransmission coalescing\n");
+        return 1;
+    }
+
+    reset_test_state();
+    start_tdma_fixture(&ctx, 0);
+    ctx.slots[0].svc_bits = P25_SM_SVC_UNKNOWN;
+    make_ptt_signature(signature, UINT64_C(0x5152535455565758), 0x80, 0, 123, 1000);
+    ev = raw_ptt_event(0, 1000, 123, signature, first_m, 0);
+    ev.svc_bits = P25_SM_SVC_UNKNOWN;
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    p25_sm_event_t reassignment = p25_sm_ev_group_grant(0x1234, 851500000, 2000, 456, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &reassignment);
+    if (ctx.slots[0].target_id != 2000 || ctx.slots[0].ptt_signature_valid) {
+        DSD_FPRINTF(stderr, "FAIL: Accepted call reassignment did not invalidate the PTT marker\n");
+        return 1;
+    }
+    make_ptt_signature(signature, UINT64_C(0x5152535455565758), 0x80, 0, 456, 2000);
+    ev = raw_ptt_event(0, 2000, 456, signature, first_m + 0.1, 1);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.phase != DSD_CALL_PHASE_ACTIVE || call.epoch != 2U) {
+        DSD_FPRINTF(stderr, "FAIL: Reassignment suppressed an immediate replacement-call PTT\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_raw_ptt_markers_are_slot_local(void) {
+    reset_test_state();
+    p25_sm_ctx_t ctx;
+    start_tdma_fixture(&ctx, 0);
+    p25_sm_event_t grant = p25_sm_ev_group_grant(0x1235, 851500000, 2000, 456, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &grant);
+
+    uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES];
+    make_ptt_signature(signature, UINT64_C(0x3132333435363738), 0x80, 0, 123, 1000);
+    const double first_m = dsd_time_now_monotonic_s() - 10.0;
+    p25_sm_event_t ev = raw_ptt_event(0, 1000, 123, signature, first_m, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    ev = raw_ptt_event(1, 2000, 456, signature, first_m + 0.1, 1);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    const double slot0_start_m = ctx.slots[0].last_start_m;
+    const double slot1_start_m = ctx.slots[1].last_start_m;
+
+    ev = raw_ptt_event(0, 1000, 123, signature, first_m + 0.2, 1);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (!ctx.slots[0].ptt_signature_valid || !ctx.slots[1].ptt_signature_valid
+        || fabs(ctx.slots[0].last_start_m - slot0_start_m) > 1.0e-9
+        || fabs(ctx.slots[1].last_start_m - slot1_start_m) > 1.0e-9
+        || fabs(ctx.slots[0].ptt_last_seen_m - (first_m + 0.2)) > 1.0e-9
+        || fabs(ctx.slots[1].ptt_last_seen_m - (first_m + 0.1)) > 1.0e-9) {
+        DSD_FPRINTF(stderr, "FAIL: Identical PTT markers leaked across TDMA slots\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_conventional_raw_ptt_retransmissions_coalesce(void) {
+    reset_test_state();
+    g_opts.trunk_enable = 0;
+    g_state.p25_cc_freq = 0;
+    g_state.synctype = DSD_SYNC_P25P2_POS;
+    g_state.lastsynctype = DSD_SYNC_P25P2_POS;
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    p25_sm_init_ctx(ctx, &g_opts, &g_state);
+
+    uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES];
+    make_ptt_signature(signature, UINT64_C(0x6162636465666768), 0x80, 0, 123, 1000);
+    const double first_m = dsd_time_now_monotonic_s() - 10.0;
+    if (!p25_sm_emit_ptt_call_metadata(&g_opts, &g_state, 0, 1000, 0, 123, 1, P25_SM_SVC_UNKNOWN, signature, first_m,
+                                       0)) {
+        return 1;
+    }
+    dsd_call_snapshot call;
+    if (dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.phase != DSD_CALL_PHASE_ACTIVE || call.epoch != 1U
+        || !ctx->slots[0].ptt_signature_valid) {
+        DSD_FPRINTF(stderr, "FAIL: Conventional raw PTT did not start its first Phase 2 epoch\n");
+        return 1;
+    }
+
+    if (!p25_sm_emit_ptt_call_metadata(&g_opts, &g_state, 0, 1000, 0, 123, 1, P25_SM_SVC_UNKNOWN, signature,
+                                       first_m + 0.5, 1)
+        || dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.epoch != 1U
+        || fabs(ctx->slots[0].ptt_last_seen_m - (first_m + 0.5)) > 1.0e-9) {
+        DSD_FPRINTF(stderr, "FAIL: Conventional identical raw PTT rotated the active Phase 2 epoch\n");
+        return 1;
+    }
+
+    if (!p25_sm_emit_end_call_at(&g_opts, &g_state, 0, 1000, 123, first_m + 0.6) || ctx->slots[0].ptt_signature_valid
+        || !p25_sm_emit_ptt_call_metadata(&g_opts, &g_state, 0, 1000, 0, 123, 1, P25_SM_SVC_UNKNOWN, signature,
+                                          first_m + 0.7, 0)
+        || dsd_call_state_get(&g_state, 0U, &call) <= 0 || call.phase != DSD_CALL_PHASE_ACTIVE || call.epoch != 2U) {
+        DSD_FPRINTF(stderr, "FAIL: Conventional Phase 2 END did not delimit the raw PTT epochs\n");
         return 1;
     }
     return 0;
@@ -2280,6 +2623,11 @@ main(void) {
     fail += test_authoritative_group_replaces_private_identity();
     fail += test_inband_zero_source_preserves_grant_identity();
     fail += test_same_identity_ptt_starts_new_epoch_after_missed_end();
+    fail += test_raw_ptt_retransmissions_coalesce_history();
+    fail += test_raw_ptt_signature_changes_open_epochs();
+    fail += test_raw_ptt_boundary_invalidation();
+    fail += test_raw_ptt_markers_are_slot_local();
+    fail += test_conventional_raw_ptt_retransmissions_coalesce();
     fail += test_source_less_identity_change_does_not_inherit_rid();
     fail += test_p2_resolved_crypto_survives_pending_active();
     fail += test_pending_crypto_uses_classification_deadline();

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -749,6 +749,71 @@ test_conventional_raw_ptt_retransmissions_coalesce(void) {
 }
 
 static int
+test_trunked_late_voice_is_rejected_after_encryption_lockout(void) {
+    static Event_History_I event_history[2];
+    reset_test_state();
+    DSD_MEMSET(event_history, 0, sizeof(event_history));
+    init_event_history(&event_history[0], 0, 255);
+    init_event_history(&event_history[1], 0, 255);
+    g_state.event_history_s = event_history;
+    g_opts.trunk_tune_enc_calls = 0;
+    g_state.trunk_chan_map[0x1234] = 851500000;
+    g_state.p25_chan_tdma_explicit[1] = 2;
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    p25_sm_init_ctx(ctx, &g_opts, &g_state);
+    p25_sm_event_t ev = p25_sm_ev_group_grant(0x1234, 851500000, 20601, 618620, 0);
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+
+    uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES];
+    const uint64_t mi = UINT64_C(0xE83FF2906EA8F0D1);
+    const double first_m = dsd_time_now_monotonic_s();
+    make_ptt_signature(signature, mi, 0x84, 0x026C, 618620, 20601);
+    if (!p25_sm_emit_ptt_call_metadata(&g_opts, &g_state, 0, 20601, 0, 618620, 1, P25_SM_SVC_UNKNOWN, signature,
+                                       first_m, 0)
+        || p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x84, 0x026C, mi, 20601)
+               != DSD_P25_CRYPTO_BLOCKED) {
+        DSD_FPRINTF(stderr, "FAIL: Late encrypted PTT fixture did not reach lockout\n");
+        return 1;
+    }
+
+    dsd_call_snapshot locked_call = {0};
+    if (ctx->state != P25_SM_ON_CC || g_opts.trunk_is_tuned != 0 || g_return_requests != 1
+        || dsd_call_state_get(&g_state, 0U, &locked_call) <= 0 || locked_call.phase != DSD_CALL_PHASE_ENDED
+        || locked_call.ota_target_id != 20601U || locked_call.ota_source_id != 618620U || ctx->slots[0].grant_active
+        || ctx->slots[0].voice_active || ctx->slots[0].ptt_signature_valid || g_state.payload_algid != 0
+        || g_state.payload_keyid != 0 || g_state.payload_miP != 0U
+        || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_UNKNOWN || g_state.p25_p2_audio_allowed[0] != 0) {
+        DSD_FPRINTF(stderr, "FAIL: Encryption lockout did not leave an ended call on the control channel\n");
+        return 1;
+    }
+
+    const uint64_t history_revision = event_history[0].revision;
+    if (p25_sm_emit_ptt_call_metadata(&g_opts, &g_state, 0, 20601, 0, 618620, 1, P25_SM_SVC_UNKNOWN, signature,
+                                      first_m + 0.1, 1)
+            != 0
+        || p25_sm_emit_active_call(&g_opts, &g_state, 0, 20601, 0, 618620, 1, 0x40) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: Late trunked voice was accepted without a traffic assignment\n");
+        return 1;
+    }
+
+    dsd_call_snapshot after_late_voice = {0};
+    if (dsd_call_state_get(&g_state, 0U, &after_late_voice) <= 0 || after_late_voice.revision != locked_call.revision
+        || after_late_voice.epoch != locked_call.epoch || after_late_voice.phase != DSD_CALL_PHASE_ENDED
+        || after_late_voice.crypto != locked_call.crypto || after_late_voice.algid != locked_call.algid
+        || after_late_voice.kid != locked_call.kid || after_late_voice.mi != locked_call.mi
+        || event_history[0].revision != history_revision || ctx->state != P25_SM_ON_CC || g_opts.trunk_is_tuned != 0
+        || g_return_requests != 1 || ctx->slots[0].grant_active || ctx->slots[0].voice_active
+        || ctx->slots[0].ptt_signature_valid || g_state.payload_algid != 0 || g_state.payload_keyid != 0
+        || g_state.payload_miP != 0U || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_UNKNOWN
+        || g_state.p25_p2_audio_allowed[0] != 0) {
+        DSD_FPRINTF(stderr, "FAIL: Late trunked voice reopened or mutated the locked-out call\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
 test_source_less_identity_change_does_not_inherit_rid(void) {
     const struct {
         int tg;
@@ -2633,6 +2698,7 @@ main(void) {
     fail += test_raw_ptt_boundary_invalidation();
     fail += test_raw_ptt_markers_are_slot_local();
     fail += test_conventional_raw_ptt_retransmissions_coalesce();
+    fail += test_trunked_late_voice_is_rejected_after_encryption_lockout();
     fail += test_source_less_identity_change_does_not_inherit_rid();
     fail += test_p2_resolved_crypto_survives_pending_active();
     fail += test_pending_crypto_uses_classification_deadline();


### PR DESCRIPTION
## Summary

- Coalesce CRC-valid P25 Phase 2 `MAC_PTT` retransmissions with an exact per-slot signature over MAC octets 1–17 and an inclusive one-second observation window.
- Require a live state-machine-owned traffic-channel assignment before trunk-follow PTT, ACTIVE, or VPDU voice-user observations can mutate call, media, or crypto state.
- Prevent late or buffered traffic-channel messages after an encrypted-call lockout from reopening the ended call while the tuner is idle on the control channel.
- Preserve conventional decoding behavior and retain patch, affiliation, and recent-activity signaling that does not claim a live voice call.
- Invalidate retransmission markers at accepted call boundaries, assignment replacement, retune, release, and reset; changed payloads and post-window PTTs still begin new epochs.
- Add `ptt_retransmit` and `voice_start_ignored` diagnostics plus focused XCCH, VPDU, state-machine, crypto, and history regressions.

## Root Cause

The P25 Phase 2 lifecycle had two related boundary gaps. First, repeated SACCH/FACCH copies of the same valid `MAC_PTT` lacked raw-PDU identity and an observation window, so each copy could be interpreted as a new call begin. Second, encryption lockout correctly ended the call and returned the tuner to the control channel, but a late PTT could enter the state machine's conventional fallback when it was no longer tuned, while VPDU voice-user messages could update canonical call state directly. Either path could republish the ended encrypted call as active and restore crypto metadata despite there being no traffic-channel assignment.

## User Impact

Repeated P25P2 PTTs now remain in the current call epoch without duplicate history rows, alerts, call boundaries, or WAV rotation. After an encrypted call is locked out and the receiver returns to the control channel, late traffic-channel voice messages are ignored for live-call state, so the UI remains idle instead of showing a phantom active encrypted call. Genuine follow-up transmissions still open new epochs after an observable boundary, signature change, reassignment, retune/reset, or a gap longer than one second. Conventional decoding remains supported without a trunk assignment.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk area touched: parser/protocol call lifecycle.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] New and modified code was read and adapted to DSD-neo conventions.
- [x] Non-trivial commits include DCO sign-off.

## Quality Review

- [x] Radio-input and protocol changes include focused tests.
- [x] Protocol lifecycle changes received extra scrutiny around stale boundaries, slot isolation, crypto state, traffic-channel provenance, and history ownership.
- [x] No static-analysis suppressions were added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j 2`
- [x] `ctest --preset dev-debug --output-on-failure` — 466/466 passed
- [x] Focused P25 XCCH, VPDU, state-machine, crypto-lockout, and event-history tests
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` — not run; the change was validated with focused regressions, the complete debug suite, and the normal preflight guardrails.
- [ ] `tools/cmake_format_check.sh` — not applicable; no CMake changes.
- [ ] `tools/zizmor.sh` — not applicable; no workflow changes.
- [ ] `tools/osv_scan.sh` — not applicable; no dependency changes.

## Risk

- Security/dependency impact: None.
- CLI/UI behavior impact: No interface changes; event history no longer duplicates immediate P25P2 PTT copies, and trunk-follow UI state no longer reopens a locked-out call without a traffic-channel assignment.
- Compatibility or packaging impact: None. Conventional voice observations remain valid without a trunk assignment; trunk-follow voice starts now require live state-machine ownership of the traffic channel.