### PR TITLE
Fix out-of-bounds unpack lengths in P25 and DMR, unblock AVX-512 builds

### DIFF
--- a/src/protocol/dmr/dmr_block.c
+++ b/src/protocol/dmr/dmr_block.c
@@ -1096,11 +1096,17 @@ dmr_block_type1_complete(const dmr_block_assembler_ctx* ctx) {
 
 static void
 dmr_block_type1_append_bytes(dmr_block_assembler_ctx* ctx, uint16_t* ctr_out) {
+    // data_byte_ctr only resets when a PDU completes, so a block counter that never reaches
+    // data_header_blocks lets it run past the superframe. Saturate rather than walk off the end.
+    const uint16_t cap = (uint16_t)sizeof(ctx->state->dmr_pdu_sf[ctx->slot]);
     uint16_t ctr = ctx->state->data_byte_ctr[ctx->slot];
-    for (int i = 0; i < ctx->block_len; i++) {
+    if (ctr > cap) {
+        ctr = cap;
+    }
+    for (int i = 0; i < ctx->block_len && ctr < cap; i++) {
         ctx->state->dmr_pdu_sf[ctx->slot][ctr++] = ctx->block_bytes[i];
     }
-    ctx->state->data_byte_ctr[ctx->slot] += ctx->block_len;
+    ctx->state->data_byte_ctr[ctx->slot] = ctr;
     *ctr_out = ctr;
 }
 
@@ -1148,6 +1154,14 @@ dmr_block_type1_pack_crc_bits(const dsd_state* state, uint8_t slot, uint8_t bloc
 static void
 dmr_block_type1_update_crc(dmr_block_assembler_ctx* ctx, uint16_t ctr, int offset) {
     uint8_t slot_idx = (ctx->slot >= 2) ? 1 : ctx->slot;
+
+    // Bound the byte count by whichever is tighter: the stored superframe or the bit buffer.
+    const uint16_t src_cap = (uint16_t)sizeof(ctx->state->dmr_pdu_sf[slot_idx]);
+    const uint16_t bits_cap = (uint16_t)(sizeof(ctx->dmr_pdu_sf_bits) / 8U);
+    const uint16_t cap = (src_cap < bits_cap) ? src_cap : bits_cap;
+    if (ctr > cap) {
+        ctr = cap;
+    }
 
     unpack_byte_array_into_bit_array(ctx->state->dmr_pdu_sf[slot_idx], ctx->dmr_pdu_sf_bits, ctr);
     ctx->crc_extracted = dmr_block_type1_extract_crc32(ctx->state, slot_idx, ctr);

--- a/src/protocol/dmr/dmr_dburst.c
+++ b/src/protocol/dmr/dmr_dburst.c
@@ -297,16 +297,24 @@ dmr_dburst_handle_bptc_crc(dmr_data_burst_ctx* ctx) {
 static void
 dmr_dburst_copy_bptc_outputs(dmr_data_burst_ctx* ctx) {
     uint32_t i;
+    // Bound the copy by the source remainder and the unpacked bit buffer so the span stays
+    // provable locally rather than relying on the burst profile table.
+    const uint8_t src_cap = (uint8_t)sizeof(ctx->bptc_data_bytes);
+    const uint8_t start = (ctx->pdu_start < src_cap) ? ctx->pdu_start : src_cap;
+    const uint8_t dst_cap = (uint8_t)(sizeof(ctx->bptc_data_bits) / 8U);
     uint8_t max_bytes = ctx->pdu_len;
-    uint8_t avail = (uint8_t)(sizeof(ctx->bptc_data_bytes) - ctx->pdu_start);
+    uint8_t avail = (uint8_t)(src_cap - start);
     if (max_bytes > avail) {
         max_bytes = avail;
     }
+    if (max_bytes > dst_cap) {
+        max_bytes = dst_cap;
+    }
 
-    unpack_byte_array_into_bit_array(ctx->bptc_data_bytes + ctx->pdu_start, ctx->bptc_data_bits, max_bytes);
+    unpack_byte_array_into_bit_array(ctx->bptc_data_bytes + start, ctx->bptc_data_bits, max_bytes);
 
     for (i = 0; i < max_bytes; i++) {
-        ctx->dmr_pdu[i] = ctx->bptc_data_bytes[i + ctx->pdu_start];
+        ctx->dmr_pdu[i] = ctx->bptc_data_bytes[i + start];
     }
     for (i = 0; i < ((uint32_t)max_bytes * 8U); i++) {
         ctx->dmr_pdu_bits[i] = ctx->bptc_data_bits[i];
@@ -590,7 +598,18 @@ dmr_dburst_handle_trellis(dmr_data_burst_ctx* ctx) {
     dmr_dburst_trellis_update_confirmed_crc(ctx);
 
     DSD_MEMSET(ctx->dmr_pdu_bits, 0, sizeof(ctx->dmr_pdu_bits));
-    unpack_byte_array_into_bit_array(trellis_return + ctx->pdu_start, ctx->dmr_pdu_bits, ctx->pdu_len);
+    // Same bounding as the BPTC path: keep the span within trellis_return and dmr_pdu_bits.
+    const uint8_t tr_cap = (uint8_t)sizeof(trellis_return);
+    const uint8_t start = (ctx->pdu_start < tr_cap) ? ctx->pdu_start : tr_cap;
+    const uint8_t bits_cap = (uint8_t)(sizeof(ctx->dmr_pdu_bits) / 8U);
+    uint8_t take = (uint8_t)(tr_cap - start);
+    if (take > ctx->pdu_len) {
+        take = ctx->pdu_len;
+    }
+    if (take > bits_cap) {
+        take = bits_cap;
+    }
+    unpack_byte_array_into_bit_array(trellis_return + start, ctx->dmr_pdu_bits, take);
 }
 
 static void

--- a/src/protocol/nxdn/nxdn_alias_decode.c
+++ b/src/protocol/nxdn/nxdn_alias_decode.c
@@ -239,22 +239,32 @@ nxdn_alias_valid_arib_segment(uint8_t seg_num, uint8_t seg_total) {
 static int
 nxdn_alias_arib_pack_and_validate(const dsd_state* state, uint8_t seg_total, uint8_t packed[24], size_t* packed_len) {
     DSD_MEMSET(packed, 0, 24U);
-    *packed_len = (size_t)seg_total * 6U;
+    // Callers validate seg_total; restate the bound so packed[] and crc_bits[] stay in range even
+    // if that ever changes. Track the length locally: packed[] and *packed_len are both
+    // caller-owned, so reloading *packed_len after writing packed[] would lose the bound.
+    const size_t max_segments = sizeof(state->nxdn_alias_arib_segments) / sizeof(state->nxdn_alias_arib_segments[0]);
+    if (seg_total == 0U || (size_t)seg_total > max_segments) {
+        return 0;
+    }
+    const size_t packed_bytes = (size_t)seg_total * 6U;
+    *packed_len = packed_bytes;
     for (size_t s = 0U; s < (size_t)seg_total; s++) {
         DSD_MEMCPY(&packed[s * 6U], state->nxdn_alias_arib_segments[s], 6U);
     }
-    if (*packed_len < 4U) {
+    if (packed_bytes < 4U) {
         return 0;
     }
-    const size_t crc_byte_count = *packed_len - 4U;
+    const size_t crc_byte_count = packed_bytes - 4U;
     uint8_t crc_bits[20U * 8U];
-    unpack_byte_array_into_bit_array(packed, crc_bits, (int)crc_byte_count);
+    // Unpack the buffer's fixed capacity: only crc_byte_count * 8 bits are consumed below, and a
+    // variable length here lets the vectorizer speculate stores past crc_bits.
+    unpack_byte_array_into_bit_array(packed, crc_bits, (int)(sizeof(crc_bits) / 8U));
     uint32_t crc32_have = nxdn_alias_read_u32_be(&packed[crc_byte_count]);
     uint32_t crc32_want = nxdn_crc32_bits(crc_bits, crc_byte_count * 8U);
     if (crc32_have != crc32_want) {
         return 0;
     }
-    *packed_len -= 4U;
+    *packed_len = crc_byte_count;
     return 1;
 }
 

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -2045,6 +2045,10 @@ p25p2_vpdu_iter_block_19(p25p2_vpdu_ctx* ctx) {
         for (int bi = 0; bi < 24 && (len_a + bi) < 24; bi++) {
             bytes[bi] = (uint8_t)MAC[len_a + bi];
         }
+        // len is an unvalidated over-the-air octet; bytes + 1 spans only sizeof(bytes) - 1 octets.
+        if (len > (uint8_t)(sizeof(bytes) - 1U)) {
+            len = (uint8_t)(sizeof(bytes) - 1U);
+        }
         unpack_byte_array_into_bit_array(bytes + 1, mac_bits, len);
         DSD_FPRINTF(stderr, "\n MFID90 (Moto) Talker Alias Header");
         apx_embedded_alias_header_phase2(opts, state, state->currentslot, mac_bits);
@@ -2082,6 +2086,10 @@ p25p2_vpdu_iter_block_20(p25p2_vpdu_ctx* ctx) {
         DSD_MEMSET(bytes, 0, sizeof(bytes));
         for (int bi = 0; bi < 24 && (len_a + bi) < 24; bi++) {
             bytes[bi] = (uint8_t)MAC[len_a + bi];
+        }
+        // len is an unvalidated over-the-air octet; bytes + 1 spans only sizeof(bytes) - 1 octets.
+        if (len > (uint8_t)(sizeof(bytes) - 1U)) {
+            len = (uint8_t)(sizeof(bytes) - 1U);
         }
         unpack_byte_array_into_bit_array(bytes + 1, mac_bits, len);
         DSD_FPRINTF(stderr, "\n MFID90 (Moto) Talker Alias Blocks");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5205,6 +5205,23 @@ target_link_libraries(dsd-neo_test_dmr_discussion_231 PRIVATE dsd-neo_proto_dmr)
 add_test(NAME DMR_DISCUSSION_231 COMMAND dsd-neo_test_dmr_discussion_231)
 
 add_executable(
+    dsd-neo_test_dmr_block_type1_bounds
+    protocol/dmr/test_dmr_block_type1_bounds.c
+)
+target_include_directories(
+    dsd-neo_test_dmr_block_type1_bounds
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/protocol/dmr
+)
+target_link_libraries(
+    dsd-neo_test_dmr_block_type1_bounds
+    PRIVATE dsd-neo_proto_dmr
+)
+add_test(
+    NAME DMR_BLOCK_TYPE1_BOUNDS
+    COMMAND dsd-neo_test_dmr_block_type1_bounds
+)
+
+add_executable(
     dsd-neo_test_dmr_ms_data
     protocol/dmr/test_dmr_ms_data.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ms.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4091,6 +4091,22 @@ target_include_directories(
 target_link_libraries(dsd-neo_test_p25_p2_mixer_gate PRIVATE dsd-neo_core)
 add_test(NAME P25_P2_MIXER_GATE COMMAND dsd-neo_test_p25_p2_mixer_gate)
 
+add_executable(
+    dsd-neo_test_p25_p2_ta_len_bounds
+    protocol/p25/test_p25_p2_ta_len_bounds.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p2_ta_len_bounds
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/tests/protocol/p25
+)
+target_link_libraries(
+    dsd-neo_test_p25_p2_ta_len_bounds
+    PRIVATE dsd-neo_proto_p25 dsd-neo_test_support
+)
+add_test(NAME P25_P2_TA_LEN_BOUNDS COMMAND dsd-neo_test_p25_p2_ta_len_bounds)
+
 # Additional targeted coverage tests
 add_executable(
     dsd-neo_test_p25_p2_vpdu_core
@@ -4253,6 +4269,7 @@ set(_DSD_NEO_P25_SHIM_TEST_TARGETS
     dsd-neo_test_p25_p1_tsbk_vpdu
     dsd-neo_test_p25_p1_tsbk_clamp
     dsd-neo_test_p25_p2_aach_cach_map
+    dsd-neo_test_p25_p2_ta_len_bounds
     dsd-neo_test_p25_p2_vpdu_core
     dsd-neo_test_p25_p2_vpdu_grants
     dsd-neo_test_p25_p2_vpdu_sequence

--- a/tests/protocol/dmr/test_dmr_block_type1_bounds.c
+++ b/tests/protocol/dmr/test_dmr_block_type1_bounds.c
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2025 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Regression tests for DMR type-1 block assembly bounds.
+ *
+ * data_byte_ctr only resets when a PDU completes (data_block_counter reaches
+ * data_header_blocks). A burst sequence that resets the block counter without the
+ * byte counter - the MBCH path does exactly that - lets the byte counter keep
+ * climbing, and the append walked past dmr_pdu_sf[slot] while the CRC pass unpacked
+ * the same oversized count into the stack-local dmr_pdu_sf_bits. These tests pin the
+ * saturation behaviour.
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static int
+expect_eq_u32(const char* tag, uint32_t got, uint32_t want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %u want %u\n", tag, (unsigned)got, (unsigned)want);
+        return 1;
+    }
+    return 0;
+}
+
+/* Seed a slot mid-PDU so the append path runs without the completion reset firing. */
+static void
+seed_incomplete_pdu(dsd_state* state, uint16_t byte_ctr) {
+    state->currentslot = 0;
+    state->data_byte_ctr[0] = byte_ctr;
+    state->data_header_valid[0] = 1;
+    state->data_block_counter[0] = 1;
+    state->data_header_blocks[0] = 9; /* != data_block_counter, so the PDU stays open */
+    state->data_conf_data[0] = 0;
+    state->data_header_format[0] = 7;
+    state->data_header_sap[0] = 0;
+}
+
+int
+main(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (opts == NULL || state == NULL) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "allocation failed\n");
+        return 1;
+    }
+
+    uint8_t block[24];
+    for (int i = 0; i < 24; i++) {
+        block[i] = (uint8_t)(0x40 + i);
+    }
+
+    const uint16_t cap = (uint16_t)sizeof(state->dmr_pdu_sf[0]);
+    int rc = 0;
+
+    /* Normal append must be untouched by the bound. */
+    seed_incomplete_pdu(state, 0);
+    dmr_block_assembler(opts, state, block, 12, 0x06, 1);
+    rc |= expect_eq_u32("normal append", state->data_byte_ctr[0], 12U);
+
+    /* An append that would straddle the end of the superframe stops at the boundary. */
+    seed_incomplete_pdu(state, (uint16_t)(cap - 4U));
+    dmr_block_assembler(opts, state, block, 12, 0x06, 1);
+    rc |= expect_eq_u32("straddling append saturates", state->data_byte_ctr[0], cap);
+
+    /* A counter already past the superframe must not append or advance further. */
+    seed_incomplete_pdu(state, 60000U);
+    dmr_block_assembler(opts, state, block, 12, 0x06, 1);
+    rc |= expect_eq_u32("desynchronised counter saturates", state->data_byte_ctr[0], cap);
+
+    /* Repeated bursts keep saturating rather than wrapping the uint16 counter. */
+    for (int i = 0; i < 64; i++) {
+        state->data_block_counter[0] = 1;
+        state->data_header_blocks[0] = 9;
+        state->data_header_valid[0] = 1;
+        dmr_block_assembler(opts, state, block, 24, 0x06, 1);
+        if (state->data_byte_ctr[0] > cap) {
+            DSD_FPRINTF(stderr, "burst %d: byte ctr %u exceeds cap %u\n", i, (unsigned)state->data_byte_ctr[0],
+                        (unsigned)cap);
+            rc = 1;
+            break;
+        }
+    }
+
+    free(opts);
+    free(state);
+
+    if (rc != 0) {
+        DSD_FPRINTF(stderr, "DMR_BLOCK_TYPE1_BOUNDS: FAIL\n");
+        return 1;
+    }
+    DSD_FPRINTF(stderr, "DMR_BLOCK_TYPE1_BOUNDS: PASS\n");
+    return 0;
+}

--- a/tests/protocol/p25/test_p25_p2_ta_len_bounds.c
+++ b/tests/protocol/p25/test_p25_p2_ta_len_bounds.c
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2025 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Regression tests for P25 Phase 2 Motorola talker-alias length handling.
+ *
+ * The alias header (opcode 0x91) and alias block (opcode 0x95) handlers unpack a
+ * packet-derived length octet into a fixed 24-octet staging buffer. An unclamped
+ * length overran both the source buffer and the 192-byte bit destination
+ * (GHSA-vqjv-vjrv-g9gf). These tests feed a malformed maximal length and assert
+ * the unpack stays inside the staging buffer, while a well-formed length is
+ * still unpacked in full.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+/* Staging buffer in the handlers is uint8_t[24]; bytes + 1 leaves 23 readable octets. */
+#define TA_STAGING_OCTETS    24
+#define TA_MAX_UNPACK_OCTETS (TA_STAGING_OCTETS - 1)
+#define TA_BIT_CAPACITY      (TA_STAGING_OCTETS * 8)
+
+// Test shim
+void p25_test_process_mac_vpdu_ex(int type, const unsigned char* mac_bytes, int mac_len, int is_lcch, int currentslot);
+
+static int g_alias_calls;
+static uint8_t g_alias_bits[TA_BIT_CAPACITY];
+
+static void
+capture_alias_bits(const uint8_t* lc_bits) {
+    g_alias_calls++;
+    for (int i = 0; i < TA_BIT_CAPACITY; i++) {
+        g_alias_bits[i] = lc_bits[i];
+    }
+}
+
+// Stubs referenced by the MAC VPDU path
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+apx_embedded_alias_header_phase2(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t* lc_bits) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    capture_alias_bits(lc_bits);
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+apx_embedded_alias_blocks_phase2(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t* lc_bits) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    capture_alias_bits(lc_bits);
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+l3h_embedded_alias_decode(dsd_opts* opts, dsd_state* state, uint8_t slot, int16_t len, uint8_t* input) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)len;
+    (void)input;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nmea_harris(dsd_opts* opts, dsd_state* state, uint8_t* input, uint32_t src, int slot) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)src;
+    (void)slot;
+}
+
+static int
+expect_eq_int(const char* tag, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+/* Build a talker-alias PDU: opcode/MFID 0x90, then a length octet, then filler. */
+static void
+build_alias_mac(unsigned char mac[TA_STAGING_OCTETS], unsigned char opcode, unsigned char len_octet) {
+    DSD_MEMSET(mac, 0, TA_STAGING_OCTETS);
+    mac[0] = 0x00;
+    mac[1] = opcode;
+    mac[2] = 0x90;
+    mac[3] = len_octet;
+    for (int i = 4; i < TA_STAGING_OCTETS; i++) {
+        mac[i] = (unsigned char)(0xA0u | (unsigned)(i & 0x0F));
+    }
+}
+
+/*
+ * Verify the captured bits are the MSB-first unpacking of mac[1 .. 1 + expect_octets - 1]
+ * and that every bit past that span is untouched.
+ */
+static int
+check_unpacked(const char* tag, const unsigned char mac[TA_STAGING_OCTETS], int expect_octets) {
+    int rc = 0;
+    for (int i = 0; i < expect_octets; i++) {
+        const unsigned char octet = mac[1 + i];
+        for (int bit = 0; bit < 8; bit++) {
+            const int want = (octet >> (7 - bit)) & 1;
+            const int got = g_alias_bits[(i * 8) + bit];
+            if (got != want) {
+                DSD_FPRINTF(stderr, "%s: octet %d bit %d got %d want %d\n", tag, i, bit, got, want);
+                rc = 1;
+            }
+        }
+    }
+    for (int i = expect_octets * 8; i < TA_BIT_CAPACITY; i++) {
+        if (g_alias_bits[i] != 0) {
+            DSD_FPRINTF(stderr, "%s: bit %d written past unpacked span\n", tag, i);
+            rc = 1;
+        }
+    }
+    return rc;
+}
+
+/* A maximal length octet must be clamped to the staging buffer instead of overrunning it. */
+static int
+test_malformed_length_is_clamped(unsigned char opcode, const char* tag) {
+    unsigned char mac[TA_STAGING_OCTETS];
+    build_alias_mac(mac, opcode, 0xFF);
+
+    g_alias_calls = 0;
+    DSD_MEMSET(g_alias_bits, 0, sizeof(g_alias_bits));
+    p25_test_process_mac_vpdu_ex(0, mac, TA_STAGING_OCTETS, 0, 0);
+
+    int rc = expect_eq_int(tag, g_alias_calls, 1);
+    rc |= check_unpacked(tag, mac, TA_MAX_UNPACK_OCTETS);
+    return rc;
+}
+
+/* A well-formed length must still be unpacked in full. */
+static int
+test_normal_length_unchanged(unsigned char opcode, const char* tag) {
+    const unsigned char len_octet = 0x11; /* 17 octets, the value seen on air */
+    unsigned char mac[TA_STAGING_OCTETS];
+    build_alias_mac(mac, opcode, len_octet);
+
+    g_alias_calls = 0;
+    DSD_MEMSET(g_alias_bits, 0, sizeof(g_alias_bits));
+    p25_test_process_mac_vpdu_ex(0, mac, TA_STAGING_OCTETS, 0, 0);
+
+    int rc = expect_eq_int(tag, g_alias_calls, 1);
+    rc |= check_unpacked(tag, mac, (int)len_octet);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_malformed_length_is_clamped(0x91, "alias header clamp");
+    rc |= test_malformed_length_is_clamped(0x95, "alias blocks clamp");
+    rc |= test_normal_length_unchanged(0x91, "alias header normal");
+    rc |= test_normal_length_unchanged(0x95, "alias blocks normal");
+
+    if (rc != 0) {
+        DSD_FPRINTF(stderr, "P25_P2_TA_LEN_BOUNDS: FAIL\n");
+        return 1;
+    }
+    DSD_FPRINTF(stderr, "P25_P2_TA_LEN_BOUNDS: PASS\n");
+    return 0;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
## Summary

Three related fixes around `unpack_byte_array_into_bit_array()`, which reads `len`
octets and writes `len * 8` bytes with no internal bounds checking. Two call sites
passed it an unvalidated length; a third set of sites were safe but not provably so,
which broke `-Werror` builds on AVX-512 hardware.

## P25 Phase 2 talker alias (`bee14e9d`)

A Motorola talker-alias MAC PDU (opcode `0x91`/`0x95`, MFID `0x90`) carries a length
octet that reached the unpack helper unvalidated. A length above 23 ran off the
24-octet staging buffer, and past 24 off the 192-byte bit destination as well. Both
buffers are on the stack.

Note that the MAC parser masks this same octet with `& 0x3F` when deriving the
segment length, but the two alias handlers used it unmasked, so the full 0–255 range
reached the helper.

Reported via GHSA-vqjv-vjrv-g9gf.

## DMR type-1 block assembly (`40151630`)

`data_byte_ctr` is only cleared when a PDU completes, i.e. when `data_block_counter`
reaches `data_header_blocks`. The MBCH burst restarts the block counter without
clearing the byte counter, leaving the two desynchronised so the byte counter keeps
climbing across subsequent data bursts.

Nothing bounded the result: the append wrote past the 3072-byte superframe row, and
on completion the CRC pass handed the same oversized count to the unpack helper,
targeting a 24768-byte stack buffer.

This fix bounds the buffers. The underlying counter desynchronisation on the MBCH
path is left alone deliberately — resetting the byte counter there is arguably the
correct protocol behaviour, but that changes MBCH decoding semantics and wants a
reference capture to validate against. The bounds make the path safe either way.

## AVX-512 build (`a13eda95`)

GCC 16 rejects the tree with `-Werror=stringop-overflow` when the target has AVX-512
(`-march=x86-64-v4`, which `-march=native` selects on such hardware). The vectorizer
widens the unpack loop into 32-byte stores and cannot see that the lengths are
bounded by a burst profile table or a caller-side segment check, so it speculates
stores past the destination. This is what blocks the AUR `dsd-neo-git` package from
linking; it does not reproduce on non-AVX-512 hosts, which is why it has looked
unreproducible.

The spans in `dmr_dburst.c` and `nxdn_alias_decode.c` are safe today, but only
provable by reasoning across functions. They now state their bounds at the unpack
itself. Two details worth knowing for future occurrences: reloading a length through
a caller-owned pointer loses the bound because it may alias the buffer being written,
and a variable length lets the vectorizer speculate where a compile-time-constant
capacity does not.

## Testing

- `P25_P2_TA_LEN_BOUNDS` — drives a maximal malformed length through the real MAC VPDU
  path and asserts a well-formed length still unpacks in full. Trips AddressSanitizer
  without the clamp.
- `DMR_BLOCK_TYPE1_BOUNDS` — drives `dmr_block_assembler()` with a desynchronised
  counter. Reports 3080 and 60012 against a 3072-byte row without the fix.
- Full suite: 468/468 pass in `dev-debug` and under `asan-ubsan-debug`.
- `tools/preflight_ci.sh` clean.
- Release + LTO + `-Werror` at `-march=x86-64-v4` now builds clean (previously 41
  diagnostics across two destination buffers).
