### PR TITLE
tests: suppress false static-assert diagnostics

### DIFF
--- a/tests/io/test_io_rtl_perf.cpp
+++ b/tests/io/test_io_rtl_perf.cpp
@@ -4,6 +4,9 @@
  * aggregate counters over an interval, write CSV rows, and reset on shutdown.
  */
 
+// LLVM 22/GCC 16 misclassifies these runtime test oracles as compile-time assertions.
+// NOLINTBEGIN(cert-dcl03-c,misc-static-assert)
+
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
@@ -156,3 +159,5 @@ main(void) {
     reset_fixture();
     return 0;
 }
+
+// NOLINTEND(cert-dcl03-c,misc-static-assert)

--- a/tests/runtime/test_runtime_log.cpp
+++ b/tests/runtime/test_runtime_log.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
 // invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// LLVM 22/GCC 16 misclassifies these runtime test oracles as compile-time assertions.
+// NOLINTBEGIN(cert-dcl03-c,misc-static-assert)
 // NOLINTBEGIN(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-unix.Errno,misc-use-internal-linkage)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
@@ -141,3 +143,4 @@ main(void) {
 }
 
 // NOLINTEND(bugprone-unsafe-functions,cert-msc24-c,cert-msc33-c,clang-analyzer-unix.Errno,misc-use-internal-linkage)
+// NOLINTEND(cert-dcl03-c,misc-static-assert)

--- a/tests/runtime/test_runtime_mem.cpp
+++ b/tests/runtime/test_runtime_mem.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
 // invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// LLVM 22/GCC 16 misclassifies these runtime test oracles as compile-time assertions.
+// NOLINTBEGIN(cert-dcl03-c,misc-static-assert)
 // NOLINTBEGIN(bugprone-implicit-widening-of-multiplication-result)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
@@ -47,3 +49,4 @@ main(void) {
 }
 
 // NOLINTEND(bugprone-implicit-widening-of-multiplication-result)
+// NOLINTEND(cert-dcl03-c,misc-static-assert)

--- a/tests/runtime/test_runtime_rt_sched.cpp
+++ b/tests/runtime/test_runtime_rt_sched.cpp
@@ -3,6 +3,9 @@
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+// LLVM 22/GCC 16 misclassifies these runtime test oracles as compile-time assertions.
+// NOLINTBEGIN(cert-dcl03-c,misc-static-assert)
+
 #define DSD_NEO_TEST_HOOKS 1
 
 #include <cassert>
@@ -184,3 +187,5 @@ main(void) {
     test_public_call_success_and_failure_paths();
     return 0;
 }
+
+// NOLINTEND(cert-dcl03-c,misc-static-assert)

--- a/tests/runtime/test_runtime_worker_pool.cpp
+++ b/tests/runtime/test_runtime_worker_pool.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
 // invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
+// LLVM 22/GCC 16 misclassifies these runtime test oracles as compile-time assertions.
+// NOLINTBEGIN(cert-dcl03-c,misc-static-assert)
 // NOLINTBEGIN(misc-use-internal-linkage)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
@@ -110,3 +112,4 @@ main(void) {
 }
 
 // NOLINTEND(misc-use-internal-linkage)
+// NOLINTEND(cert-dcl03-c,misc-static-assert)


### PR DESCRIPTION
## Summary

- Suppress LLVM 22/GCC 16 false `cert-dcl03-c` and `misc-static-assert` diagnostics only around the five affected C++ runtime-test fixtures.
- Preserve the runtime `assert()` test oracles and keep the checks enabled for the rest of the tree.
- Fix the clang-tidy failure from [run 30230126567](https://github.com/arancormonk/dsd-neo/actions/runs/30230126567/job/89867286455).

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented. Not broad or high risk.
- [x] High-risk areas touched are marked: none.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions. No copied or generated code.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests. No such behavior changes.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny. Test-only suppression change; affected runtime and IO tests were executed.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] Exact Arch toolchain run with LLVM 22.1.8 on all five changed translation units
- [x] Built `dsd-neo_test_io_rtl_perf`, `dsd-neo_test_runtime_log`, `dsd-neo_test_runtime_mem`, `dsd-neo_test_runtime_rt_sched`, and `dsd-neo_test_runtime_worker_pool`
- [x] `ctest --preset dev-debug --output-on-failure -R '^(IO_RTL_PERF|RUNTIME_LOG|RUNTIME_MEM|RUNTIME_RT_SCHED|RUNTIME_WORKER_POOL)$'`
- [x] `tools/preflight_ci.sh --base origin/main`
- [ ] `tools/quality_preflight.sh` — not needed for this narrow test-only suppression
- [ ] `tools/cmake_format_check.sh` — no CMake changes
- [ ] `tools/zizmor.sh` — no workflow changes
- [ ] `tools/osv_scan.sh` — no dependency changes
- [x] Repository security guardrails ran through `tools/preflight_ci.sh`

## Risk

- Security/dependency impact: None.
- CLI/UI behavior impact: None.
- Compatibility or packaging impact: None.
