### PR TITLE
events: stop reacquired transmissions duplicating history rows

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -199,6 +199,12 @@ Windows console runs:
 - `--p25-sm-log <file>` Append P25 state-machine health and frequency-decision traces. Grant traces identify initial
   assignments versus updates; post-call stale-update handling reports guard, validation-probe, and activity outcomes.
 
+Per-call WAVs are written per *segment*, not per history row. When sync is lost mid-transmission and the same call is
+reacquired within the reacquisition window, the Activity history keeps one row for the whole transmission while each
+segment still closes, names, and exports its own recording. A flapping call therefore appears as one history row
+referencing several recordings and several rdio uploads. Empty segments (44-byte WAVs) are deleted rather than exported,
+so brief flaps cost nothing.
+
 For rdio-scanner API uploads that should not persist on disk, use API-only mode with a RAM-backed per-call WAV directory
 and post-upload deletion, for example `-7 /dev/shm/dsd-neo-rdio -P --rdio-mode api --rdio-api-delete-after-upload`.
 Rdio API uploads do not follow HTTP redirects; use the final trusted HTTP/HTTPS endpoint directly.

--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -359,6 +359,10 @@ small subset is exposed as config keys for convenience (for example
 | `end` | BOOL | Deprecated read alias for `voice_end` | `true` |
 | `data` | BOOL | Beep when a data call is logged | `true` |
 
+A transmission the decoder loses and regains is one call, so it beeps `voice_start` once at the
+start and `voice_end` once at the end. The end alert is held for roughly half a second after sync
+is lost, since the call may still resume; a terminator alerts immediately.
+
 **[recording] section:**
 | Key | Type | Description | Default |
 |-----|------|-------------|---------|

--- a/docs/iq-capture-replay.md
+++ b/docs/iq-capture-replay.md
@@ -77,6 +77,24 @@ Replay uses `min(data_bytes, actual_file_size)` rounded down to sample alignment
 interrupted capture never finalized metadata (`data_bytes == 0`), replay falls back to the actual file size and still
 rounds down to sample alignment. Zero effective bytes are rejected for `--iq-replay`.
 
+## Replay Pacing And Decode-Time Windows
+
+`--iq-replay-rate realtime` pins the replay thread to `start + samples_written / sample_rate`, so air time and wall
+clock advance together. The default `fast` mode applies no pacing at all: throughput is bounded only by ring
+backpressure and decode speed, so a capture's worth of air time completes in considerably less wall-clock time.
+
+That matters because there is currently **no decode-derived clock** in the decoder. Protocol layers time call state
+against `dsd_time_now_monotonic_s()` (wall-clock monotonic), and any call site that passes `observed_m = 0.0` falls
+back to the same source. Under `fast` replay every wall-clock-measured interval in the canonical call state is
+therefore compressed relative to the air time it is meant to describe:
+
+- Gaps look shorter than they were, so the call reacquisition window (`DSD_CALL_REACQUIRE_GAP_S`, which decides
+  whether a sync-loss-interrupted transmission is one history row or two) coalesces more readily than it would live.
+- Hangtime and staleness timers in the trunking state machines expire later in air-time terms than they would live.
+
+Use `--iq-replay-rate realtime` when reproducing or asserting on any of that timing. The same caveat applies to
+non-`.bin` file input under `-r`/WAV replay, which is likewise unthrottled; only `.bin` symbol-capture replay is paced.
+
 ## Operational Limits
 
 - `--iq-capture` and `--iq-replay` are mutually exclusive in one invocation.

--- a/include/dsd-neo/core/call_state.h
+++ b/include/dsd-neo/core/call_state.h
@@ -264,7 +264,16 @@ int dsd_call_state_update_crypto(dsd_state* state, uint8_t slot, const dsd_call_
 /** Update crypto metadata on an existing active or retained ended epoch. */
 int dsd_call_state_update_retained_crypto(dsd_state* state, uint8_t slot, const dsd_call_crypto_update* update);
 int dsd_call_state_update_media(dsd_state* state, uint8_t slot, int media_active, double observed_m);
-/** End the active epoch, recording why it ended. */
+/**
+ * End the active epoch, recording why it ended.
+ *
+ * Returns non-zero when the call state changed -- either the epoch was ended, or an already
+ * sync-loss-ended epoch had its reason tightened to DSD_CALL_END_EXPLICIT by a terminator that
+ * decoded after the fade. The latter leaves ended_m untouched. Callers that gate
+ * dsd_event_sync_slot() on this result therefore let the event layer see the retracted
+ * reacquisition permission; callers that need "an active call was ended" specifically must
+ * check DSD_CALL_PHASE_ACTIVE themselves beforehand.
+ */
 int dsd_call_state_end_ex(dsd_state* state, uint8_t slot, double observed_m, dsd_call_end_reason reason);
 /** End the active epoch as a deliberate teardown (DSD_CALL_END_EXPLICIT). */
 int dsd_call_state_end(dsd_state* state, uint8_t slot, double observed_m);

--- a/include/dsd-neo/core/call_state.h
+++ b/include/dsd-neo/core/call_state.h
@@ -213,7 +213,12 @@ typedef struct {
      * 1 + (push_seq - committed_seq), so interleaved notice pushes cannot make
      * the merge target the wrong row. */
     uint64_t committed_seq;
-    /* Render inputs captured when committed_seq's row was pushed. */
+    /* Render inputs as they stood when the staged row was last rendered. Captured with the row's
+     * content rather than at commit time: a row is sometimes committed only once the decoder has
+     * already moved on to the next call, and by then the live values describe that call. */
+    dsd_call_event_render_env staged_env;
+    /* Render inputs belonging to committed_seq's row, promoted from staged_env when it was
+     * pushed. */
     dsd_call_event_render_env committed_env;
     uint8_t committed_valid;
     uint8_t ended_committed;

--- a/include/dsd-neo/core/call_state.h
+++ b/include/dsd-neo/core/call_state.h
@@ -147,11 +147,20 @@ typedef struct {
 /** Event bookkeeping paired with one canonical call slot. */
 typedef struct {
     uint64_t epoch;
-    uint8_t ended_committed;
     uint64_t notice_epoch;
     uint64_t notice_target_id;
+    /* Identity of the row most recently committed for this slot, used to drop a
+     * commit that only repeats the transmission already in history. */
+    double commit_m;
+    uint32_t commit_source_id;
+    uint32_t commit_target_id;
+    uint8_t ended_committed;
     uint8_t notice_kind;
     uint8_t notice_handled;
+    int8_t commit_protocol;
+    int8_t commit_gi;
+    uint8_t commit_category;
+    uint8_t commit_valid;
 } dsd_call_event_lifecycle_snapshot;
 
 /**

--- a/include/dsd-neo/core/call_state.h
+++ b/include/dsd-neo/core/call_state.h
@@ -50,6 +50,18 @@ typedef enum {
     DSD_CALL_CRYPTO_DECRYPTABLE,
 } dsd_call_crypto_state;
 
+/**
+ * Why a call epoch ended.
+ *
+ * Only DSD_CALL_END_SYNC_LOSS permits the next epoch on the slot to be treated as the same
+ * transmission being reacquired. EXPLICIT is the default so an unconverted call site produces a
+ * second history row -- a duplicate is recoverable, a deleted transmission is not.
+ */
+typedef enum {
+    DSD_CALL_END_EXPLICIT = 0,  /**< Terminator, EOT, release, teardown, or retune. */
+    DSD_CALL_END_SYNC_LOSS = 1, /**< Carrier or sync lost; the transmission may still resume. */
+} dsd_call_end_reason;
+
 typedef enum {
     DSD_CALL_BOUNDARY_CONTINUE = 0, /**< Merge compatible observations into the active call epoch. */
     /**
@@ -123,6 +135,7 @@ typedef struct {
     uint8_t algid;
     uint8_t audio_permitted;
     uint8_t media_active;
+    uint8_t end_reason; /**< dsd_call_end_reason; meaningful only while phase is DSD_CALL_PHASE_ENDED. */
     char source_text[DSD_CALL_IDENTITY_TEXT_SIZE];
     char target_text[DSD_CALL_IDENTITY_TEXT_SIZE];
     char route_text[DSD_CALL_ROUTE_COUNT][DSD_CALL_IDENTITY_TEXT_SIZE];
@@ -149,21 +162,18 @@ typedef struct {
     uint64_t epoch;
     uint64_t notice_epoch;
     uint64_t notice_target_id;
-    /* Epoch reopened by a CONTINUE after the prior epoch ended. Only this
-     * reacquisition may coalesce with the row most recently committed. */
+    /* Epoch that reopened a sync-loss-ended epoch describing the same call. Only
+     * this reacquisition may merge into the row most recently committed. */
     uint64_t reacquired_epoch;
-    /* Identity of the row most recently committed for this slot, used to drop a
-     * commit that only repeats the transmission already in history. */
-    double commit_m;
-    uint32_t commit_source_id;
-    uint32_t commit_target_id;
+    /* Value of Event_History_I::push_seq right after this slot's last voice
+     * commit reached history. The retained row's current depth is
+     * 1 + (push_seq - committed_seq), so interleaved notice pushes cannot make
+     * the merge target the wrong row. */
+    uint64_t committed_seq;
+    uint8_t committed_valid;
     uint8_t ended_committed;
     uint8_t notice_kind;
     uint8_t notice_handled;
-    int8_t commit_protocol;
-    int8_t commit_gi;
-    uint8_t commit_category;
-    uint8_t commit_valid;
 } dsd_call_event_lifecycle_snapshot;
 
 /**
@@ -200,6 +210,9 @@ int dsd_call_state_update_crypto(dsd_state* state, uint8_t slot, const dsd_call_
 /** Update crypto metadata on an existing active or retained ended epoch. */
 int dsd_call_state_update_retained_crypto(dsd_state* state, uint8_t slot, const dsd_call_crypto_update* update);
 int dsd_call_state_update_media(dsd_state* state, uint8_t slot, int media_active, double observed_m);
+/** End the active epoch, recording why it ended. */
+int dsd_call_state_end_ex(dsd_state* state, uint8_t slot, double observed_m, dsd_call_end_reason reason);
+/** End the active epoch as a deliberate teardown (DSD_CALL_END_EXPLICIT). */
 int dsd_call_state_end(dsd_state* state, uint8_t slot, double observed_m);
 int dsd_call_state_get(const dsd_state* state, uint8_t slot, dsd_call_snapshot* out);
 int dsd_call_state_copy_snapshot(const dsd_state* state, dsd_call_state_snapshot* out);

--- a/include/dsd-neo/core/call_state.h
+++ b/include/dsd-neo/core/call_state.h
@@ -149,6 +149,9 @@ typedef struct {
     uint64_t epoch;
     uint64_t notice_epoch;
     uint64_t notice_target_id;
+    /* Epoch reopened by a CONTINUE after the prior epoch ended. Only this
+     * reacquisition may coalesce with the row most recently committed. */
+    uint64_t reacquired_epoch;
     /* Identity of the row most recently committed for this slot, used to drop a
      * commit that only repeats the transmission already in history. */
     double commit_m;

--- a/include/dsd-neo/core/call_state.h
+++ b/include/dsd-neo/core/call_state.h
@@ -62,6 +62,14 @@ typedef enum {
     DSD_CALL_END_SYNC_LOSS = 1, /**< Carrier or sync lost; the transmission may still resume. */
 } dsd_call_end_reason;
 
+/**
+ * Seconds after a sync-loss end within which the next epoch describing the same call is read as
+ * that transmission being reacquired rather than a new one. Also how long a VOICE_END alert is
+ * held before the transmission is declared over. Rationale, residual risks and the replay-timing
+ * caveat are documented at the point of use in src/core/util/call_state.c.
+ */
+#define DSD_CALL_REACQUIRE_GAP_S 0.5
+
 typedef enum {
     DSD_CALL_BOUNDARY_CONTINUE = 0, /**< Merge compatible observations into the active call epoch. */
     /**
@@ -157,30 +165,76 @@ typedef struct {
     dsd_recent_activity_entry entries[DSD_RECENT_ACTIVITY_COUNT];
 } dsd_recent_activity_snapshot;
 
+/**
+ * Live decoder inputs the per-protocol event builders read but a history row does not carry.
+ *
+ * Captured when a row is committed and replayed when that row is re-rendered, so a merged
+ * transmission is described by the system context it was decoded under rather than whatever the
+ * decoder has retuned to since. Everything else a builder needs already lives on the row.
+ */
+typedef struct {
+    uint16_t nxdn_grant_chan;
+    long nxdn_grant_freq;
+    unsigned int mfid;
+    int ea_mode;
+    int edacs_a_bits;
+    int edacs_f_bits;
+    int edacs_s_bits;
+    int edacs_a_shift;
+    int edacs_f_shift;
+    int edacs_a_mask;
+    int edacs_f_mask;
+    int edacs_s_mask;
+} dsd_call_event_render_env;
+
 /** Event bookkeeping paired with one canonical call slot. */
 typedef struct {
     uint64_t epoch;
     uint64_t notice_epoch;
     uint64_t notice_target_id;
     /* Epoch that reopened a sync-loss-ended epoch describing the same call. Only
-     * this reacquisition may merge into the row most recently committed. */
+     * this reacquisition may merge into the row most recently committed.
+     *
+     * Never cleared when an unrelated epoch begins: the comparison is epoch-exact
+     * and epoch ids only increase, so a stale value cannot match. Clearing it early
+     * would disarm a reacquisition whose staged row has not been flushed yet, and
+     * that row would then commit as a duplicate. */
     uint64_t reacquired_epoch;
+    /* The sync-loss-ended epoch that reacquired_epoch reopened. A merge is only
+     * legitimate into the row that epoch itself committed, so the event layer pairs
+     * this against committed_epoch before folding anything. */
+    uint64_t reacquired_from_epoch;
+    /* The epoch whose row committed_seq locates. Both the reacquisition merge and
+     * dsd_event_enrich_epoch() are epoch-scoped: an epoch that ends without pushing
+     * a row leaves this pointing at an older epoch, and neither may act on it. */
+    uint64_t committed_epoch;
     /* Value of Event_History_I::push_seq right after this slot's last voice
      * commit reached history. The retained row's current depth is
      * 1 + (push_seq - committed_seq), so interleaved notice pushes cannot make
      * the merge target the wrong row. */
     uint64_t committed_seq;
+    /* Render inputs captured when committed_seq's row was pushed. */
+    dsd_call_event_render_env committed_env;
     uint8_t committed_valid;
     uint8_t ended_committed;
     uint8_t notice_kind;
     uint8_t notice_handled;
+    /* A sync-loss end may still be reacquired, so its VOICE_END alert is held until the
+     * reacquisition window closes. Stamped with the monotonic deadline to beep at. */
+    uint8_t end_alert_pending;
+    double end_alert_due_m;
 } dsd_call_event_lifecycle_snapshot;
 
 /**
  * Complete canonical call context for runtime context switching.
  *
- * Restoring this snapshot preserves event commit bookkeeping while keeping
- * epoch allocation monotonic within the destination state.
+ * Restoring this snapshot keeps epoch allocation monotonic within the destination
+ * state but deliberately drops event commit bookkeeping: the event history is
+ * global while this context is per trunk-scan target, so a commit reference or a
+ * pending reacquisition carried across a hop would describe another target's row.
+ * dsd_call_context_restore_snapshot() invalidates both, and downgrades a retained
+ * sync-loss end so the first call on the new target cannot be read as a
+ * reacquisition of the old one.
  */
 typedef struct {
     dsd_call_state_snapshot calls;

--- a/include/dsd-neo/core/events.h
+++ b/include/dsd-neo/core/events.h
@@ -124,6 +124,14 @@ int dsd_event_emit_call_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, c
 int dsd_event_emit_call_notice_nonfinalizing(dsd_opts* opts, dsd_state* state, uint8_t slot,
                                              const dsd_call_snapshot* call, const char* detail);
 int dsd_event_history_copy_snapshot(const dsd_state* state, Event_History_I out[2]);
+/**
+ * Clear every history row on both slots and the per-slot commit bookkeeping with it.
+ *
+ * Callers must not hold an event-history transaction: this opens its own. Clearing the rows
+ * without clearing the bookkeeping would leave a reacquired transmission trying to merge into
+ * a row that no longer exists.
+ */
+void dsd_event_history_reset(dsd_state* state);
 /* Copy telemetry atomically, copying history slots only when forced or when their source revision changed. */
 int dsd_event_state_copy_snapshot_incremental(dsd_state* dst, const dsd_state* src, Event_History_I event_history[2],
                                               const uint64_t source_revisions[2], int force_copy, uint8_t copied[2]);

--- a/include/dsd-neo/core/events.h
+++ b/include/dsd-neo/core/events.h
@@ -125,6 +125,15 @@ int dsd_event_emit_call_notice_nonfinalizing(dsd_opts* opts, dsd_state* state, u
                                              const dsd_call_snapshot* call, const char* detail);
 int dsd_event_history_copy_snapshot(const dsd_state* state, Event_History_I out[2]);
 /**
+ * Retire any VOICE_END alert still being held open against a possible reacquisition, on both
+ * slots, without waiting for its deadline.
+ *
+ * For callers that know no further audio can arrive -- shutdown being the only one today. The
+ * per-frame drain in dsd_event_sync_slot() only fires once the reacquisition window has elapsed,
+ * so an end armed in the last half second before exit would otherwise never be heard.
+ */
+void dsd_event_flush_pending_alerts(dsd_opts* opts, dsd_state* state);
+/**
  * Clear every history row on both slots and the per-slot commit bookkeeping with it.
  *
  * Callers must not hold an event-history transaction: this opens its own. Clearing the rows

--- a/include/dsd-neo/core/events.h
+++ b/include/dsd-neo/core/events.h
@@ -114,7 +114,8 @@ dsd_event_history_item_set_message(Event_History* item, dsd_event_severity sever
     }
 }
 
-void write_event_to_log_file(const dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite, char* event_string);
+void write_event_to_log_file(const dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite,
+                             const char* event_string);
 void watchdog_event_history(dsd_opts* opts, dsd_state* state, uint8_t slot);
 void watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8_t slot);
 void dsd_event_sync_slot(dsd_opts* opts, dsd_state* state, uint8_t slot);

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -160,6 +160,10 @@ typedef struct {
 typedef struct Event_History_I {
     Event_History Event_History_Items[255];
     uint64_t revision;
+    // Count of push_event_history() calls on this slot. Every push -- call commits,
+    // data and system notices, the startup banner -- shifts the ring by one, so a
+    // row's depth can be recovered as 1 + (push_seq - the push_seq it was pushed at).
+    uint64_t push_seq;
 } Event_History_I;
 
 //new audio filter stuff from: https://github.com/NedSimao/FilteringLibrary

--- a/include/dsd-neo/protocol/edacs/edacs_afs.h
+++ b/include/dsd-neo/protocol/edacs/edacs_afs.h
@@ -20,6 +20,15 @@ extern "C" {
 int getAfsString(const dsd_state* state, char* buffer, int a, int f, int s);
 int getAfsStringLength(const dsd_state* state);
 
+/**
+ * As above, but driven by explicit AFS bit widths instead of the live decoder state.
+ *
+ * Lets a caller that captured the widths earlier reproduce the exact string it rendered then,
+ * even if the decoder has since been reconfigured.
+ */
+int getAfsStringFromBits(int a_bits, int f_bits, int s_bits, char* buffer, int a, int f, int s);
+int getAfsStringLengthFromBits(int a_bits, int f_bits, int s_bits);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dsd-neo/runtime/p25_optional_hooks.h
+++ b/include/dsd-neo/runtime/p25_optional_hooks.h
@@ -27,7 +27,7 @@ extern "C" {
 typedef struct {
     void (*watchdog_event_current)(const dsd_opts* opts, dsd_state* state, uint8_t slot);
     void (*write_event_to_log_file)(const dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite,
-                                    char* event_string);
+                                    const char* event_string);
     void (*push_event_history)(Event_History_I* event_struct);
     void (*init_event_history)(Event_History_I* event_struct, uint8_t start, uint8_t stop);
     void (*p25p2_flush_partial_audio)(dsd_opts* opts, dsd_state* state);
@@ -37,7 +37,7 @@ void dsd_p25_optional_hooks_set(dsd_p25_optional_hooks hooks);
 
 void dsd_p25_optional_hook_watchdog_event_current(dsd_opts* opts, dsd_state* state, uint8_t slot);
 void dsd_p25_optional_hook_write_event_to_log_file(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite,
-                                                   char* event_string);
+                                                   const char* event_string);
 void dsd_p25_optional_hook_push_event_history(Event_History_I* event_struct);
 void dsd_p25_optional_hook_init_event_history(Event_History_I* event_struct, uint8_t start, uint8_t stop);
 void dsd_p25_optional_hook_p25p2_flush_partial_audio(dsd_opts* opts, dsd_state* state);

--- a/src/app_control/menu_services.c
+++ b/src/app_control/menu_services.c
@@ -184,15 +184,7 @@ svc_lrrp_disable(dsd_opts* opts) {
 
 void
 svc_reset_event_history(dsd_state* state) {
-    if (!state || !state->event_history_s) {
-        return;
-    }
-    dsd_event_history_transaction transaction;
-    dsd_event_history_transaction_begin(state, &transaction);
-    for (uint8_t i = 0; i < 2; i++) {
-        init_event_history(&state->event_history_s[i], 0, 255);
-    }
-    dsd_event_history_transaction_end(&transaction);
+    dsd_event_history_reset(state);
 }
 
 void

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -611,6 +611,21 @@ dsd_call_state_end_ex(dsd_state* state, uint8_t slot, double observed_m, dsd_cal
     // that fire while unsynced do not re-stamp ended_m: the reacquisition gap
     // stays anchored at the first end.
     if (snapshot->epoch == 0U || snapshot->phase != DSD_CALL_PHASE_ACTIVE) {
+        // One exception: a terminator or EOT decoded after sync loss already ended the epoch is
+        // positive evidence that the transmission is over, and it must be able to retract the
+        // reacquisition permission that end granted. The fade is often the last thing heard
+        // before the terminator that explains it, so without this a second PTT on the same
+        // identity inside the gap folds into the terminated call's row. Only this one direction
+        // is allowed, and ended_m is deliberately left alone: the reason changes, the moment the
+        // transmission stopped does not.
+        if (snapshot->epoch != 0U && snapshot->phase == DSD_CALL_PHASE_ENDED
+            && snapshot->end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS && reason == DSD_CALL_END_EXPLICIT) {
+            snapshot->end_reason = (uint8_t)DSD_CALL_END_EXPLICIT;
+            snapshot->revision = call_state_next_nonzero(snapshot->revision);
+            ext->calls.revision = call_state_next_nonzero(ext->calls.revision);
+            dsd_call_state_ext_unlock(ext);
+            return 1;
+        }
         dsd_call_state_ext_unlock(ext);
         return 0;
     }

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -4,6 +4,7 @@
  */
 
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/platform/atomic_compat.h>
@@ -131,9 +132,14 @@ dsd_call_state_ensure(dsd_state* state) {
     return dsd_call_state_ext_get(state, 1) != NULL ? 1 : 0;
 }
 
+// The fallback deliberately matches the resolution of the clock every caller supplies. Endpoints
+// that pass observed_m all derive it from dsd_time_now_monotonic_s(), so truncating the fallback to
+// whole milliseconds would let an end stamped at ns precision compare as later than a reopen that
+// really followed it -- and call_state_reacquires_ended_epoch() would reject a legitimate
+// reacquisition that landed inside the same millisecond.
 static double
 call_state_observed_m(double observed_m) {
-    return observed_m > 0.0 ? observed_m : (double)dsd_time_monotonic_ms() / 1000.0;
+    return observed_m > 0.0 ? observed_m : dsd_time_now_monotonic_s();
 }
 
 static uint64_t
@@ -299,8 +305,17 @@ call_state_observation_changes_identity(const dsd_call_snapshot* current, const 
         && current->ota_source_id != observation->ota_source_id) {
         return 1;
     }
+    // Route text is compared here rather than only where reacquisition consults it: both
+    // call_state_observation_has_identity() and call_state_snapshot_has_identity() already count
+    // it as identity, so leaving it out made it the one anchor no contradiction could ever reject.
+    // A route-only D-STAR or YSF snapshot would then match every later observation. Like the other
+    // text fields it only reports a contradiction when both sides are known, so a repeater pair
+    // that has not decoded yet -- or one reset to spaces, which normalizes to empty -- is not a
+    // change.
     return call_state_known_text_changed(current->source_text, observation->source_text)
-           || call_state_known_text_changed(current->target_text, observation->target_text);
+           || call_state_known_text_changed(current->target_text, observation->target_text)
+           || call_state_known_text_changed(current->route_text[0], observation->route_text[0])
+           || call_state_known_text_changed(current->route_text[1], observation->route_text[1]);
 }
 
 static int
@@ -729,6 +744,11 @@ dsd_call_state_invalidate_event_lifecycle(dsd_call_event_lifecycle* lifecycle) {
     // a transmission the operator can no longer see.
     lifecycle->end_alert_pending = 0U;
     lifecycle->end_alert_due_m = 0.0;
+    // Both halves of the env pair go, matching the epoch-change path in dsd_events.c. A row staged
+    // directly by a protocol never passes through the renderer, so a surviving staged_env would be
+    // promoted into committed_env when that row commits and a later merge would re-render against
+    // a decoder context from before this invalidation.
+    DSD_MEMSET(&lifecycle->staged_env, 0, sizeof(lifecycle->staged_env));
     DSD_MEMSET(&lifecycle->committed_env, 0, sizeof(lifecycle->committed_env));
 }
 

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -278,16 +278,11 @@ call_state_begin_specializes_provisional_voice(const dsd_call_snapshot* current,
     return dsd_call_state_protocol_family(current->protocol) == dsd_call_state_protocol_family(observation->protocol);
 }
 
+// True when the observation names a different call than the one the slot holds.
+// An absent field on either side is not a change: protocols fill identity in
+// over several bursts, and a partial re-description must not fork the epoch.
 static int
-call_state_observation_begins_epoch(const dsd_call_snapshot* current, const dsd_call_observation* observation,
-                                    dsd_call_boundary boundary) {
-    if (current->phase != DSD_CALL_PHASE_ACTIVE) {
-        return 1;
-    }
-    if (boundary == DSD_CALL_BOUNDARY_BEGIN
-        && !call_state_begin_specializes_provisional_voice(current, observation, boundary)) {
-        return 1;
-    }
+call_state_observation_changes_identity(const dsd_call_snapshot* current, const dsd_call_observation* observation) {
     if (current->protocol != DSD_SYNC_NONE && observation->protocol != DSD_SYNC_NONE
         && dsd_call_state_protocol_family(current->protocol) != dsd_call_state_protocol_family(observation->protocol)) {
         return 1;
@@ -306,6 +301,22 @@ call_state_observation_begins_epoch(const dsd_call_snapshot* current, const dsd_
     }
     return call_state_known_text_changed(current->source_text, observation->source_text)
            || call_state_known_text_changed(current->target_text, observation->target_text);
+}
+
+static int
+call_state_observation_begins_epoch(const dsd_call_snapshot* current, const dsd_call_observation* observation,
+                                    dsd_call_boundary boundary) {
+    if (current->phase != DSD_CALL_PHASE_ACTIVE) {
+        return 1;
+    }
+    // An explicit BEGIN is positive per-transmission evidence (a PTT, a grant, a
+    // voice header) and always opens an epoch. Callers that repeat a header for
+    // the transmission already running must observe a CONTINUE instead.
+    if (boundary == DSD_CALL_BOUNDARY_BEGIN
+        && !call_state_begin_specializes_provisional_voice(current, observation, boundary)) {
+        return 1;
+    }
+    return call_state_observation_changes_identity(current, observation);
 }
 
 static void
@@ -365,8 +376,8 @@ dsd_call_state_observe(dsd_state* state, const dsd_call_observation* observation
     }
     dsd_call_state_ext_lock(ext);
     dsd_call_snapshot* snapshot = &ext->calls.slots[observation->slot];
-    const int begins_epoch = call_state_observation_begins_epoch(snapshot, observation, boundary);
     const double now_m = call_state_observed_m(observation->observed_m);
+    const int begins_epoch = call_state_observation_begins_epoch(snapshot, observation, boundary);
     if (begins_epoch) {
         DSD_MEMSET(snapshot, 0, sizeof(*snapshot));
         ext->epoch_sequence[observation->slot] = call_state_next_nonzero(ext->epoch_sequence[observation->slot]);

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -339,8 +339,21 @@ call_state_observation_begins_epoch(const dsd_call_snapshot* current, const dsd_
  * and coalescing is correspondingly more eager. Documented in docs/iq-capture-replay.md; use
  * --iq-replay-rate realtime to reproduce live timing. If an air-time clock is ever added, route
  * it through call_state_observed_m() rather than introducing a second clock here.
+ *
+ * The constant itself is DSD_CALL_REACQUIRE_GAP_S in <dsd-neo/core/call_state.h>; the event layer
+ * needs it to know how long to hold a VOICE_END alert open.
  */
-#define DSD_CALL_REACQUIRE_GAP_S 0.5
+
+// True when the slot names a call concretely enough for "the same call" to mean anything.
+// call_state_observation_changes_identity() only reports a *contradiction*, so a snapshot that
+// never learned an identity is compatible with every observation; reacquisition needs a positive
+// anchor or it would coalesce two unrelated transmissions.
+static int
+call_state_snapshot_has_identity(const dsd_call_snapshot* current) {
+    return call_state_effective_target_snapshot(current) != 0U || current->ota_source_id != 0U
+           || call_state_text_is_known(current->source_text) || call_state_text_is_known(current->target_text)
+           || call_state_text_is_known(current->route_text[0]) || call_state_text_is_known(current->route_text[1]);
+}
 
 // True when this observation reopens an epoch that sync loss ended moments ago while describing
 // the same call -- one transmission the decoder lost and regained, not two transmissions. The
@@ -352,6 +365,12 @@ static int
 call_state_reacquires_ended_epoch(const dsd_call_snapshot* current, const dsd_call_observation* observation,
                                   double now_m) {
     if (current->phase != DSD_CALL_PHASE_ENDED || current->end_reason != (uint8_t)DSD_CALL_END_SYNC_LOSS) {
+        return 0;
+    }
+    // The ending epoch must name a call. Without this an identity-less provisional epoch -- the
+    // shape mark_vocoder_call_media() opens before any header decodes -- matches everything, and
+    // the next unrelated call on the slot would be folded into its row.
+    if (!call_state_snapshot_has_identity(current)) {
         return 0;
     }
     if (call_state_observation_changes_identity(current, observation)) {
@@ -462,9 +481,15 @@ dsd_call_state_observe(dsd_state* state, const dsd_call_observation* observation
         if (reacquires_ended_epoch) {
             call_state_seed_reacquired_snapshot(snapshot, &previous);
             ext->events[observation->slot].reacquired_epoch = snapshot->epoch;
-        } else {
-            ext->events[observation->slot].reacquired_epoch = 0U;
+            // Which epoch was reopened. Whether a history row may actually be merged is the event
+            // layer's call -- it pairs this against the epoch its committed row belongs to -- but
+            // the identity seeding and the suppressed START above are canonical either way.
+            ext->events[observation->slot].reacquired_from_epoch = previous.epoch;
         }
+        // reacquired_epoch is deliberately not cleared here. It is compared against the epoch it
+        // names, and epoch ids only increase, so a stale value can never match a later epoch.
+        // Clearing it would disarm a reacquisition whose staged row is still waiting to flush,
+        // and that row would then be committed a second time.
         ext->events[observation->slot].ended_committed = 0U;
         ext->events[observation->slot].notice_epoch = 0U;
         ext->events[observation->slot].notice_target_id = 0U;
@@ -696,8 +721,22 @@ dsd_call_context_restore_snapshot(dsd_state* state, const dsd_call_context_snaps
         // itself is global, so a commit reference carried across a hop would point one
         // target's merge at another target's row. Invalidate rather than relocate.
         ext->events[slot].committed_seq = 0U;
+        ext->events[slot].committed_epoch = 0U;
         ext->events[slot].committed_valid = 0U;
         ext->events[slot].reacquired_epoch = 0U;
+        ext->events[slot].reacquired_from_epoch = 0U;
+        // Clearing the commit reference blocks the row merge but not the rest of reacquisition:
+        // the monotonic clock is global, so a slot saved mid-fade would still satisfy the gap
+        // test on the new target and suppress the first call's VOICE_START alert while seeding
+        // it with the old target's identity. A restored end is a hop, never a resumable fade.
+        if (ext->calls.slots[slot].phase == DSD_CALL_PHASE_ENDED) {
+            ext->calls.slots[slot].end_reason = (uint8_t)DSD_CALL_END_EXPLICIT;
+        }
+        // A held VOICE_END belongs to the target being left. Its deadline is on the global
+        // monotonic clock, so carrying it across would fire it against whatever call the new
+        // target happens to be running.
+        ext->events[slot].end_alert_pending = 0U;
+        ext->events[slot].end_alert_due_m = 0.0;
     }
     dsd_call_state_ext_unlock(ext);
     return 1;

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -378,10 +378,15 @@ dsd_call_state_observe(dsd_state* state, const dsd_call_observation* observation
     dsd_call_snapshot* snapshot = &ext->calls.slots[observation->slot];
     const double now_m = call_state_observed_m(observation->observed_m);
     const int begins_epoch = call_state_observation_begins_epoch(snapshot, observation, boundary);
+    const int reacquires_ended_epoch =
+        begins_epoch && snapshot->phase == DSD_CALL_PHASE_ENDED && boundary == DSD_CALL_BOUNDARY_CONTINUE;
     if (begins_epoch) {
         DSD_MEMSET(snapshot, 0, sizeof(*snapshot));
         ext->epoch_sequence[observation->slot] = call_state_next_nonzero(ext->epoch_sequence[observation->slot]);
         snapshot->epoch = ext->epoch_sequence[observation->slot];
+        if (reacquires_ended_epoch) {
+            ext->events[observation->slot].reacquired_epoch = snapshot->epoch;
+        }
         snapshot->slot = observation->slot;
         snapshot->protocol = DSD_SYNC_NONE;
         snapshot->crypto = DSD_CALL_CRYPTO_UNKNOWN;

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -319,6 +319,76 @@ call_state_observation_begins_epoch(const dsd_call_snapshot* current, const dsd_
     return call_state_observation_changes_identity(current, observation);
 }
 
+/*
+ * Seconds after a sync-loss end within which the next epoch describing the same call is
+ * treated as that transmission being reacquired rather than a new one.
+ *
+ * This is a backstop, not the discriminator: DSD_CALL_END_SYNC_LOSS plus an unchanged identity
+ * carry the decision, and the window only bounds a pathological gap. The anchor already sits
+ * after the no-sync timeout (~1800 symbols, dsd_frame_sync.c -- about 0.4 s at 4800 sym/s), so
+ * the tolerated air gap is effectively that timeout plus this window.
+ *
+ * Residual and accepted: an operator who un-keys during the fade and re-keys the same TG/SRC
+ * inside the window coalesces. That end really was a sync loss and the identity really does
+ * match, so time is the only discriminator left; the short window keeps it rare.
+ *
+ * Measured on whatever timeline the endpoints supply through call_state_observed_m(). No
+ * decode-derived clock exists today -- every non-zero observed_m in the tree ultimately comes
+ * from dsd_time_now_monotonic_s(), and callers that pass 0.0 get the same wall clock -- so under
+ * unpaced replay (--iq-replay-rate fast, the default) gaps appear shorter than they were on air
+ * and coalescing is correspondingly more eager. Documented in docs/iq-capture-replay.md; use
+ * --iq-replay-rate realtime to reproduce live timing. If an air-time clock is ever added, route
+ * it through call_state_observed_m() rather than introducing a second clock here.
+ */
+#define DSD_CALL_REACQUIRE_GAP_S 0.5
+
+// True when this observation reopens an epoch that sync loss ended moments ago while describing
+// the same call -- one transmission the decoder lost and regained, not two transmissions. The
+// boundary token is deliberately not consulted: the paths that reopen mid-transmission (the
+// vocoder's per-frame media mark, a DMR Voice LC Header arriving after the gap, M17's stream
+// mark, the P25p1 ESS ensure-call) all pass BEGIN, while P25 Phase 2 and the other re-announcing
+// protocols pass CONTINUE. Both must arm.
+static int
+call_state_reacquires_ended_epoch(const dsd_call_snapshot* current, const dsd_call_observation* observation,
+                                  double now_m) {
+    if (current->phase != DSD_CALL_PHASE_ENDED || current->end_reason != (uint8_t)DSD_CALL_END_SYNC_LOSS) {
+        return 0;
+    }
+    if (call_state_observation_changes_identity(current, observation)) {
+        return 0;
+    }
+    return current->ended_m > 0.0 && now_m >= current->ended_m
+           && (now_m - current->ended_m) <= DSD_CALL_REACQUIRE_GAP_S;
+}
+
+// Carry the ending call's identity and metadata into the reopened epoch. Without this the UI and
+// the staged history row blank out across the gap and have to relearn everything the previous
+// segment already decoded.
+static void
+call_state_seed_reacquired_snapshot(dsd_call_snapshot* snapshot, const dsd_call_snapshot* previous) {
+    snapshot->ota_source_id = previous->ota_source_id;
+    snapshot->ota_target_id = previous->ota_target_id;
+    snapshot->policy_target_id = previous->policy_target_id;
+    DSD_MEMCPY(snapshot->source_text, previous->source_text, sizeof(snapshot->source_text));
+    DSD_MEMCPY(snapshot->target_text, previous->target_text, sizeof(snapshot->target_text));
+    DSD_MEMCPY(snapshot->route_text, previous->route_text, sizeof(snapshot->route_text));
+    snapshot->kind = previous->kind;
+    snapshot->protocol = previous->protocol;
+    snapshot->channel = previous->channel;
+    snapshot->frequency_hz = previous->frequency_hz;
+    snapshot->crypto = previous->crypto;
+    snapshot->algid = previous->algid;
+    snapshot->kid = previous->kid;
+    snapshot->mi = previous->mi;
+    snapshot->service_options = previous->service_options;
+    snapshot->has_service_metadata = previous->has_service_metadata;
+    snapshot->emergency = previous->emergency;
+    snapshot->priority = previous->priority;
+    // audio_permitted and started_m are deliberately not carried: the reacquired segment
+    // re-earns audio from the next crypto update exactly as it does today, and started_m stays
+    // the reopen instant so per-segment durations remain the segment's own.
+}
+
 static void
 call_state_apply_text(char dst[DSD_CALL_IDENTITY_TEXT_SIZE], const char* src) {
     char normalized[DSD_CALL_IDENTITY_TEXT_SIZE];
@@ -378,19 +448,23 @@ dsd_call_state_observe(dsd_state* state, const dsd_call_observation* observation
     dsd_call_snapshot* snapshot = &ext->calls.slots[observation->slot];
     const double now_m = call_state_observed_m(observation->observed_m);
     const int begins_epoch = call_state_observation_begins_epoch(snapshot, observation, boundary);
-    const int reacquires_ended_epoch =
-        begins_epoch && snapshot->phase == DSD_CALL_PHASE_ENDED && boundary == DSD_CALL_BOUNDARY_CONTINUE;
+    // Evaluated before the memset below: the ending snapshot is the comparison target.
+    const int reacquires_ended_epoch = begins_epoch && call_state_reacquires_ended_epoch(snapshot, observation, now_m);
     if (begins_epoch) {
+        const dsd_call_snapshot previous = *snapshot;
         DSD_MEMSET(snapshot, 0, sizeof(*snapshot));
         ext->epoch_sequence[observation->slot] = call_state_next_nonzero(ext->epoch_sequence[observation->slot]);
         snapshot->epoch = ext->epoch_sequence[observation->slot];
-        if (reacquires_ended_epoch) {
-            ext->events[observation->slot].reacquired_epoch = snapshot->epoch;
-        }
         snapshot->slot = observation->slot;
         snapshot->protocol = DSD_SYNC_NONE;
         snapshot->crypto = DSD_CALL_CRYPTO_UNKNOWN;
         snapshot->started_m = now_m;
+        if (reacquires_ended_epoch) {
+            call_state_seed_reacquired_snapshot(snapshot, &previous);
+            ext->events[observation->slot].reacquired_epoch = snapshot->epoch;
+        } else {
+            ext->events[observation->slot].reacquired_epoch = 0U;
+        }
         ext->events[observation->slot].ended_committed = 0U;
         ext->events[observation->slot].notice_epoch = 0U;
         ext->events[observation->slot].notice_target_id = 0U;
@@ -498,7 +572,7 @@ dsd_call_state_update_media(dsd_state* state, uint8_t slot, int media_active, do
 }
 
 int
-dsd_call_state_end(dsd_state* state, uint8_t slot, double observed_m) {
+dsd_call_state_end_ex(dsd_state* state, uint8_t slot, double observed_m, dsd_call_end_reason reason) {
     if (!state || slot >= DSD_CALL_STATE_SLOT_COUNT) {
         return -1;
     }
@@ -508,11 +582,15 @@ dsd_call_state_end(dsd_state* state, uint8_t slot, double observed_m) {
     }
     dsd_call_state_ext_lock(ext);
     dsd_call_snapshot* snapshot = &ext->calls.slots[slot];
+    // Ending an already-ended epoch is a no-op, so the repeated noCarrier() calls
+    // that fire while unsynced do not re-stamp ended_m: the reacquisition gap
+    // stays anchored at the first end.
     if (snapshot->epoch == 0U || snapshot->phase != DSD_CALL_PHASE_ACTIVE) {
         dsd_call_state_ext_unlock(ext);
         return 0;
     }
     snapshot->phase = DSD_CALL_PHASE_ENDED;
+    snapshot->end_reason = (uint8_t)reason;
     snapshot->media_active = 0U;
     snapshot->audio_permitted = 0U;
     snapshot->ended_m = call_state_observed_m(observed_m);
@@ -521,6 +599,11 @@ dsd_call_state_end(dsd_state* state, uint8_t slot, double observed_m) {
     ext->calls.revision = call_state_next_nonzero(ext->calls.revision);
     dsd_call_state_ext_unlock(ext);
     return 1;
+}
+
+int
+dsd_call_state_end(dsd_state* state, uint8_t slot, double observed_m) {
+    return dsd_call_state_end_ex(state, slot, observed_m, DSD_CALL_END_EXPLICIT);
 }
 
 int
@@ -609,6 +692,12 @@ dsd_call_context_restore_snapshot(dsd_state* state, const dsd_call_context_snaps
         if (ext->epoch_sequence[slot] < snapshot->calls.slots[slot].epoch) {
             ext->epoch_sequence[slot] = snapshot->calls.slots[slot].epoch;
         }
+        // The lifecycle is saved and restored per trunk-scan target while the event history
+        // itself is global, so a commit reference carried across a hop would point one
+        // target's merge at another target's row. Invalidate rather than relocate.
+        ext->events[slot].committed_seq = 0U;
+        ext->events[slot].committed_valid = 0U;
+        ext->events[slot].reacquired_epoch = 0U;
     }
     dsd_call_state_ext_unlock(ext);
     return 1;

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -715,6 +715,23 @@ dsd_call_context_copy_snapshot(const dsd_state* state, dsd_call_context_snapshot
     return 1;
 }
 
+void
+dsd_call_state_invalidate_event_lifecycle(dsd_call_event_lifecycle* lifecycle) {
+    if (lifecycle == NULL) {
+        return;
+    }
+    lifecycle->committed_seq = 0U;
+    lifecycle->committed_epoch = 0U;
+    lifecycle->committed_valid = 0U;
+    lifecycle->reacquired_epoch = 0U;
+    lifecycle->reacquired_from_epoch = 0U;
+    // A held VOICE_END describes a row that is going away. Firing it later would beep the end of
+    // a transmission the operator can no longer see.
+    lifecycle->end_alert_pending = 0U;
+    lifecycle->end_alert_due_m = 0.0;
+    DSD_MEMSET(&lifecycle->committed_env, 0, sizeof(lifecycle->committed_env));
+}
+
 int
 dsd_call_context_restore_snapshot(dsd_state* state, const dsd_call_context_snapshot* snapshot) {
     if (!state || !snapshot) {
@@ -733,25 +750,18 @@ dsd_call_context_restore_snapshot(dsd_state* state, const dsd_call_context_snaps
             ext->epoch_sequence[slot] = snapshot->calls.slots[slot].epoch;
         }
         // The lifecycle is saved and restored per trunk-scan target while the event history
-        // itself is global, so a commit reference carried across a hop would point one
-        // target's merge at another target's row. Invalidate rather than relocate.
-        ext->events[slot].committed_seq = 0U;
-        ext->events[slot].committed_epoch = 0U;
-        ext->events[slot].committed_valid = 0U;
-        ext->events[slot].reacquired_epoch = 0U;
-        ext->events[slot].reacquired_from_epoch = 0U;
+        // itself is global, so a commit reference -- or a VOICE_END held on the global monotonic
+        // clock -- carried across a hop would describe one target's row while the other target is
+        // running. Invalidate rather than relocate.
+        dsd_call_state_invalidate_event_lifecycle(&ext->events[slot]);
         // Clearing the commit reference blocks the row merge but not the rest of reacquisition:
         // the monotonic clock is global, so a slot saved mid-fade would still satisfy the gap
         // test on the new target and suppress the first call's VOICE_START alert while seeding
         // it with the old target's identity. A restored end is a hop, never a resumable fade.
+        // This lives on the call snapshot rather than the lifecycle, so it stays here.
         if (ext->calls.slots[slot].phase == DSD_CALL_PHASE_ENDED) {
             ext->calls.slots[slot].end_reason = (uint8_t)DSD_CALL_END_EXPLICIT;
         }
-        // A held VOICE_END belongs to the target being left. Its deadline is on the global
-        // monotonic clock, so carrying it across would fire it against whatever call the new
-        // target happens to be running.
-        ext->events[slot].end_alert_pending = 0U;
-        ext->events[slot].end_alert_due_m = 0.0;
     }
     dsd_call_state_ext_unlock(ext);
     return 1;

--- a/src/core/util/call_state_internal.h
+++ b/src/core/util/call_state_internal.h
@@ -23,4 +23,24 @@ const dsd_call_state_ext* dsd_call_state_ext_peek(const dsd_state* state);
 void dsd_call_state_ext_lock(const dsd_call_state_ext* ext);
 void dsd_call_state_ext_unlock(const dsd_call_state_ext* ext);
 
+/**
+ * Drop every reference this lifecycle holds into the event history, including a VOICE_END alert
+ * still being held open.
+ *
+ * Two callers invalidate a lifecycle for the same underlying reason -- the rows it points at are
+ * no longer the rows it was describing. dsd_event_history_reset() clears the ring outright, and
+ * dsd_call_context_restore_snapshot() hops to another trunk-scan target while the ring stays
+ * global. Both must forget the commit reference, the pending reacquisition and the held alert
+ * together; leaving any one of them behind lets the next segment merge into, enrich, or beep for
+ * a row that no longer exists. Callers must hold the call-state mutex.
+ *
+ * Deliberately not cleared: epoch, ended_committed and the notice markers. Those record which
+ * call the slot has already rendered, not which row it landed in, and both callers still have
+ * that call in hand -- a context restore carries it across alongside the call snapshot, and a
+ * history reset leaves the live call untouched. Clearing them would make an ended-but-retained
+ * call look unrendered and commit it a second time. The end-reason downgrade a context restore
+ * performs lives on the call snapshot rather than the lifecycle, so it stays at that call site.
+ */
+void dsd_call_state_invalidate_event_lifecycle(dsd_call_event_lifecycle* lifecycle);
+
 #endif /* DSD_NEO_SRC_CORE_UTIL_CALL_STATE_INTERNAL_H_ */

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -225,10 +225,12 @@ write_event_to_log_file(const dsd_opts* opts, dsd_state* state, uint8_t slot, ui
                                    &state->event_history_s[slot].Event_History_Items[0], NULL);
 }
 
-// Only the two-slot protocols annotate their log lines with a slot number.
+// Only the two-slot protocols annotate their log lines with a slot number. X2-TDMA belongs here for
+// the same reason the other two do: it carries two timeslots and its callers attribute every
+// observation through state->currentslot, so a log line without the annotation is ambiguous.
 static uint8_t
 watchdog_event_should_write_systype(int systype) {
-    return (DSD_SYNC_IS_DMR_BS(systype) || DSD_SYNC_IS_P25P2(systype)) ? 1u : 0u;
+    return (DSD_SYNC_IS_DMR_BS(systype) || DSD_SYNC_IS_P25P2(systype) || DSD_SYNC_IS_X2TDMA(systype)) ? 1u : 0u;
 }
 
 static uint8_t
@@ -1202,6 +1204,29 @@ watchdog_event_current_build_event_dmr(const watchdog_event_current_ctx* ctx, co
     }
 }
 
+// The ALG/KID annotation carried by the protocols that use P25-style ESS. A row persists only the
+// derived enc flag, so a merged row that lost the live classification still reports encryption.
+static void
+watchdog_event_append_ess_crypto(const watchdog_event_current_ctx* ctx, char* event_string, size_t event_size) {
+    if (ctx->alg_id != 0 && ctx->alg_id != 0x80) {
+        char ess_str[30];
+        DSD_SNPRINTF(ess_str, sizeof(ess_str), "ENC; ALG: %02X; KID: %04X; ", ctx->alg_id, ctx->key_id);
+        watchdog_event_str_append(event_string, event_size, ess_str);
+    } else if (ctx->crypto == DSD_CALL_CRYPTO_ENCRYPTED_PENDING || ctx->crypto == DSD_CALL_CRYPTO_ENCRYPTED
+               || ctx->enc) {
+        watchdog_event_str_append(event_string, event_size, "ENC; ");
+    }
+}
+
+static void
+watchdog_event_append_call_kind(const watchdog_event_current_ctx* ctx, char* event_string, size_t event_size) {
+    if (ctx->kind == DSD_CALL_KIND_GROUP_VOICE) {
+        watchdog_event_str_append(event_string, event_size, "Group; ");
+    } else if (ctx->kind == DSD_CALL_KIND_PRIVATE_VOICE) {
+        watchdog_event_str_append(event_string, event_size, "Private; ");
+    }
+}
+
 static void
 watchdog_event_current_build_event_p25(const watchdog_event_current_ctx* ctx, const char* datestr, const char* timestr,
                                        const char* sys_string, char* event_string, size_t event_size) {
@@ -1214,22 +1239,27 @@ watchdog_event_current_build_event_p25(const watchdog_event_current_ctx* ctx, co
                      sys_string, ctx->target_id, ctx->source_id, ctx->sys_id3);
     }
 
-    if (ctx->alg_id != 0 && ctx->alg_id != 0x80) {
-        char ess_str[30];
-        DSD_SNPRINTF(ess_str, sizeof(ess_str), "ENC; ALG: %02X; KID: %04X; ", ctx->alg_id, ctx->key_id);
-        watchdog_event_str_append(event_string, event_size, ess_str);
-    } else if (ctx->crypto == DSD_CALL_CRYPTO_ENCRYPTED_PENDING || ctx->crypto == DSD_CALL_CRYPTO_ENCRYPTED
-               || ctx->enc) {
-        watchdog_event_str_append(event_string, event_size, "ENC; ");
-    }
+    watchdog_event_append_ess_crypto(ctx, event_string, event_size);
     if (ctx->svc_opts & 0x80) {
         watchdog_event_str_append(event_string, event_size, "Emergency; ");
     }
-    if (ctx->kind == DSD_CALL_KIND_GROUP_VOICE) {
-        watchdog_event_str_append(event_string, event_size, "Group; ");
-    } else if (ctx->kind == DSD_CALL_KIND_PRIVATE_VOICE) {
-        watchdog_event_str_append(event_string, event_size, "Private; ");
-    }
+    watchdog_event_append_call_kind(ctx, event_string, event_size);
+}
+
+// X2-TDMA parses no call identity: the link control it collects is never decoded into a talkgroup
+// or a source, so those fields stay zero for the life of the call. The row still has to exist --
+// without one the transmission is absent from history and from the log entirely, and the operator
+// has no record that the slot carried voice at all. Deliberately not routed through the P25
+// builder despite the shared ESS crypto model: X2-TDMA has no NAC, and rendering "NAC: 000" would
+// assert something the decoder never read.
+static void
+watchdog_event_current_build_event_x2tdma(const watchdog_event_current_ctx* ctx, const char* datestr,
+                                          const char* timestr, const char* sys_string, char* event_string,
+                                          size_t event_size) {
+    DSD_SNPRINTF(event_string, event_size, "%s %s %s TGT: %08d; SRC: %08d; ", datestr, timestr, sys_string,
+                 ctx->target_id, ctx->source_id);
+    watchdog_event_append_ess_crypto(ctx, event_string, event_size);
+    watchdog_event_append_call_kind(ctx, event_string, event_size);
 }
 
 static void
@@ -1289,6 +1319,8 @@ watchdog_event_current_build_event_string(const watchdog_event_current_ctx* ctx,
         watchdog_event_current_build_event_dmr(ctx, datestr, timestr, sys_string, event_string, event_size);
     } else if (DSD_SYNC_IS_P25(ctx->protocol)) {
         watchdog_event_current_build_event_p25(ctx, datestr, timestr, sys_string, event_string, event_size);
+    } else if (DSD_SYNC_IS_X2TDMA(ctx->protocol)) {
+        watchdog_event_current_build_event_x2tdma(ctx, datestr, timestr, sys_string, event_string, event_size);
     } else if (DSD_SYNC_IS_NXDN(ctx->protocol)) {
         watchdog_event_current_build_event_nxdn(ctx, datestr, timestr, sys_string, event_string, event_size);
     }
@@ -1500,9 +1532,9 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
         if (deferred_end) {
             // Armed only where a row reached history, which is what makes this the same rule the
             // FINAL disposition follows: its alert is emitted inside the commit above, so it too
-            // cannot fire for a staged row with nothing in it. A protocol that renders no event
-            // string -- X2-TDMA has no builder -- would otherwise beep the end of a transmission
-            // the operator never saw.
+            // cannot fire for a staged row with nothing in it. A signal that renders no event
+            // string -- one never classified into a protocol with a builder -- would otherwise beep
+            // the end of a transmission the operator never saw.
             lifecycle->end_alert_pending = 1U;
             // Deliberately the local monotonic clock rather than call->ended_m: the deadline is
             // only ever compared against this same clock, and ended_m carries whatever timeline

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -1559,6 +1559,22 @@ dsd_event_sync_slot(dsd_opts* opts, dsd_state* state, uint8_t slot) {
     dsd_call_state_ext_unlock(ext);
 }
 
+void
+dsd_event_flush_pending_alerts(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state || !state->event_history_s) {
+        return;
+    }
+    dsd_call_state_ext* ext = dsd_call_state_ext_get(state, 0);
+    if (!ext) {
+        return;
+    }
+    dsd_call_state_ext_lock(ext);
+    for (uint8_t slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
+        watchdog_event_flush_pending_end_alert(opts, state, slot, &ext->events[slot], 1);
+    }
+    dsd_call_state_ext_unlock(ext);
+}
+
 static void
 watchdog_event_lock_if_present(const dsd_call_state_ext* ext) {
     if (ext) {
@@ -1764,14 +1780,15 @@ dsd_event_history_reset(dsd_state* state) {
     // The transaction already holds the call-state mutex that guards ext->events, so the rows
     // and the bookkeeping that points into them are cleared together.
     dsd_call_state_ext* ext = dsd_call_state_ext_get(state, 0);
-    for (uint8_t slot = 0; slot < 2U; slot++) {
+    for (uint8_t slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
         init_event_history(&state->event_history_s[slot], 0, 255);
         if (ext != NULL) {
-            ext->events[slot].committed_seq = 0U;
-            ext->events[slot].committed_epoch = 0U;
-            ext->events[slot].committed_valid = 0U;
-            ext->events[slot].reacquired_epoch = 0U;
-            ext->events[slot].reacquired_from_epoch = 0U;
+            // epoch and ended_committed are deliberately left alone. They say which call the slot
+            // has already finished rendering, not which row it landed in: clearing them would
+            // make an ended-but-still-retained call look unrendered, and the next sync pass would
+            // commit it all over again -- resurrecting, in a freshly cleared history, the very row
+            // the operator just deleted.
+            dsd_call_state_invalidate_event_lifecycle(&ext->events[slot]);
         }
     }
     dsd_event_history_transaction_end(&transaction);

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -331,6 +331,9 @@ watchdog_event_commit_repeats_previous(const dsd_call_event_lifecycle* lifecycle
     if (lifecycle == NULL || item == NULL || !lifecycle->commit_valid) {
         return 0;
     }
+    if (lifecycle->epoch == 0U || lifecycle->reacquired_epoch != lifecycle->epoch) {
+        return 0;
+    }
     if (item->category != DSD_EVENT_CATEGORY_VOICE || lifecycle->commit_category != DSD_EVENT_CATEGORY_VOICE) {
         return 0;
     }
@@ -354,7 +357,12 @@ watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History
     const Event_History* staged = &event_struct->Event_History_Items[0];
     const double now_m = watchdog_event_now_m();
     if (watchdog_event_commit_repeats_previous(lifecycle, staged, now_m)) {
+        // The row is already in history, but this epoch can contain newly
+        // recorded audio. Finalize it before clearing the staged metadata so
+        // the next call cannot inherit the reacquired call's samples.
+        watchdog_event_rotate_wav_if_needed(opts, event_struct, slot);
         init_event_history(event_struct, 0, 1);
+        watchdog_event_reset_post_push(state);
         return 0;
     }
     watchdog_event_note_commit(lifecycle, staged, now_m);

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -13,6 +13,7 @@
 
 #include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
@@ -266,23 +267,37 @@ watchdog_event_maybe_beep_call_end(dsd_opts* opts, dsd_state* state, uint8_t slo
     }
 }
 
+/** How a commit should treat the end-of-call side effects. */
+typedef enum {
+    /** Not an end-of-call commit: no WAV rotation, no VOICE_END alert. */
+    DSD_EVENT_END_NONE = 0,
+    /** The transmission is over: rotate the WAV and alert now. */
+    DSD_EVENT_END_FINAL,
+    /**
+     * Sync was lost and the transmission may still resume. Rotate the WAV -- each segment keeps
+     * its own recording -- but hold the VOICE_END alert until the reacquisition window closes,
+     * so a flapping call does not announce its end partway through.
+     */
+    DSD_EVENT_END_DEFERRED,
+} dsd_event_end_disposition;
+
 static void
 watchdog_event_handle_source_transition_ex(dsd_opts* opts, dsd_state* state, Event_History_I* event_struct,
                                            uint8_t slot, uint8_t swrite, int last_event_is_data,
-                                           int reset_slot_identity, int call_end_side_effects) {
+                                           int reset_slot_identity, dsd_event_end_disposition end_disposition) {
     if (opts->event_out_file[0] != 0) {
         write_event_to_log_file(opts, state, slot, swrite, event_struct->Event_History_Items[0].event_string);
     }
 
     event_struct->Event_History_Items[0].write = 1;
-    if (call_end_side_effects) {
+    if (end_disposition != DSD_EVENT_END_NONE) {
         watchdog_event_rotate_wav_if_needed(opts, event_struct, slot);
     }
     push_event_history(event_struct);
     init_event_history(event_struct, 0, 1);
     (void)reset_slot_identity;
     watchdog_event_reset_post_push(state);
-    if (call_end_side_effects) {
+    if (end_disposition == DSD_EVENT_END_FINAL) {
         watchdog_event_maybe_beep_call_end(opts, state, slot, last_event_is_data);
     }
 }
@@ -291,7 +306,43 @@ static void
 watchdog_event_handle_source_transition(dsd_opts* opts, dsd_state* state, Event_History_I* event_struct, uint8_t slot,
                                         uint8_t swrite, int last_event_is_data, int reset_slot_identity) {
     watchdog_event_handle_source_transition_ex(opts, state, event_struct, slot, swrite, last_event_is_data,
-                                               reset_slot_identity, 1);
+                                               reset_slot_identity, DSD_EVENT_END_FINAL);
+}
+
+// Emit a VOICE_END alert that was held open across a possible reacquisition. `force` retires it
+// immediately -- used when a genuinely new call is about to start on the slot, so the previous
+// transmission's END is heard before the new one's START rather than interrupting it.
+static void
+watchdog_event_flush_pending_end_alert(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                       dsd_call_event_lifecycle* lifecycle, int force) {
+    if (lifecycle == NULL || !lifecycle->end_alert_pending) {
+        return;
+    }
+    if (!force && dsd_time_now_monotonic_s() < lifecycle->end_alert_due_m) {
+        return;
+    }
+    lifecycle->end_alert_pending = 0U;
+    lifecycle->end_alert_due_m = 0.0;
+    watchdog_event_maybe_beep_call_end(opts, state, slot, 0);
+}
+
+// Snapshot the live decoder inputs the per-protocol builders read directly. Taken once per render
+// so a row can later be rebuilt against the same values, rather than against a decoder that has
+// retuned, changed manufacturer feature id, or been reconfigured since.
+static void
+watchdog_event_capture_render_env(const dsd_state* state, uint8_t slot, dsd_call_event_render_env* env) {
+    env->mfid = slot == 0U ? state->dmr_fid : state->dmr_fidR;
+    env->nxdn_grant_chan = state->nxdn_grant_chan;
+    env->nxdn_grant_freq = state->nxdn_grant_freq;
+    env->ea_mode = state->ea_mode;
+    env->edacs_a_bits = state->edacs_a_bits;
+    env->edacs_f_bits = state->edacs_f_bits;
+    env->edacs_s_bits = state->edacs_s_bits;
+    env->edacs_a_shift = state->edacs_a_shift;
+    env->edacs_f_shift = state->edacs_f_shift;
+    env->edacs_a_mask = state->edacs_a_mask;
+    env->edacs_f_mask = state->edacs_f_mask;
+    env->edacs_s_mask = state->edacs_s_mask;
 }
 
 // Depth of the row this slot last committed, or 0 when it can no longer be located.
@@ -315,12 +366,40 @@ watchdog_event_text_is_empty(const char* text) {
     return text == NULL || text[0] == '\0';
 }
 
+// Identity and label fields: a later segment only fills a blank. These describe who the call is,
+// and the first segment that decoded them is as authoritative as any later one.
 static void
 watchdog_event_merge_text(char* retained, const char* staged, size_t cap) {
     if (watchdog_event_text_is_empty(retained) && !watchdog_event_text_is_empty(staged)) {
         DSD_SNPRINTF(retained, cap, "%s", staged);
     }
 }
+
+// Progressive fields: the newest decode supersedes. A talker alias arrives over several blocks and
+// each one extends it, a later LRRP report is a fresher position, and the newest notice detail is
+// the one that just fired. Returns non-zero when the retained value actually changed, so the
+// caller can log what the merge added. Keeping the longer alias covers the case where a segment
+// re-starts the alias from scratch and only decodes a prefix before sync drops again.
+static int
+watchdog_event_merge_text_progressive(char* retained, const char* staged, size_t cap, int keep_longer) {
+    if (watchdog_event_text_is_empty(staged) || strncmp(retained, staged, cap) == 0) {
+        return 0;
+    }
+    if (keep_longer && strnlen(staged, cap) <= strnlen(retained, cap)) {
+        return 0;
+    }
+    DSD_SNPRINTF(retained, cap, "%s", staged);
+    return 1;
+}
+
+// Optional per-row detail the normal commit path writes as its own event-log line. Tracked across
+// a merge so the continuation can report exactly what the reacquired segment contributed.
+typedef struct {
+    uint8_t alias;
+    uint8_t gps;
+    uint8_t text_message;
+    uint8_t internal;
+} watchdog_event_merge_added;
 
 // Rank crypto knowledge so a later segment can upgrade the retained row but never
 // downgrade it: a segment that decoded the PI/ESS header knows more than the late-entry
@@ -333,12 +412,35 @@ watchdog_event_crypto_rank(const Event_History* item) {
     return item->enc_alg != 0U ? 3 : 2;
 }
 
-// Fold the staged row into the row already in history: this is the same transmission, and
-// everything the reacquired segment learned -- a late-decoded SRC, an alias, GPS, a text
-// message, the crypto header that finally arrived -- has to survive. Only ever adds
-// information; a known value is never replaced by an unknown one.
+// System identity: the numeric ids drive both the rendered string and every structured consumer,
+// so they have to come across. A late-entry first segment renders a placeholder ("P25_000",
+// "DMR_CC_0") from all-zero ids, which is non-empty and would otherwise block the string forever
+// -- so the string follows whenever the ids themselves were upgraded.
 static void
-watchdog_event_merge_staged_into(Event_History* retained, const Event_History* staged) {
+watchdog_event_merge_system_identity(Event_History* retained, const Event_History* staged) {
+    int sys_ids_upgraded = 0;
+    uint32_t* retained_sys[5] = {&retained->sys_id1, &retained->sys_id2, &retained->sys_id3, &retained->sys_id4,
+                                 &retained->sys_id5};
+    const uint32_t staged_sys[5] = {staged->sys_id1, staged->sys_id2, staged->sys_id3, staged->sys_id4,
+                                    staged->sys_id5};
+    for (size_t i = 0; i < 5U; i++) {
+        if (*retained_sys[i] == 0U && staged_sys[i] != 0U) {
+            *retained_sys[i] = staged_sys[i];
+            sys_ids_upgraded = 1;
+        }
+    }
+    if (sys_ids_upgraded) {
+        (void)watchdog_event_merge_text_progressive(retained->sysid_string, staged->sysid_string,
+                                                    sizeof(retained->sysid_string), 0);
+        return;
+    }
+    watchdog_event_merge_text(retained->sysid_string, staged->sysid_string, sizeof(retained->sysid_string));
+}
+
+// Scalar identity a later segment may only fill in, never overwrite: the first segment that
+// decoded a value is as authoritative as any later one.
+static void
+watchdog_event_merge_identity_fields(Event_History* retained, const Event_History* staged) {
     if (retained->source_id == 0U && staged->source_id != 0U) {
         retained->source_id = staged->source_id;
     }
@@ -351,55 +453,103 @@ watchdog_event_merge_staged_into(Event_History* retained, const Event_History* s
     if (retained->gi < 0 && staged->gi >= 0) {
         retained->gi = staged->gi;
     }
+    if (retained->svc == 0U && staged->svc != 0U) {
+        retained->svc = staged->svc;
+    }
     watchdog_event_merge_text(retained->src_str, staged->src_str, sizeof(retained->src_str));
     watchdog_event_merge_text(retained->tgt_str, staged->tgt_str, sizeof(retained->tgt_str));
     watchdog_event_merge_text(retained->t_name, staged->t_name, sizeof(retained->t_name));
     watchdog_event_merge_text(retained->s_name, staged->s_name, sizeof(retained->s_name));
     watchdog_event_merge_text(retained->t_mode, staged->t_mode, sizeof(retained->t_mode));
     watchdog_event_merge_text(retained->s_mode, staged->s_mode, sizeof(retained->s_mode));
-    watchdog_event_merge_text(retained->sysid_string, staged->sysid_string, sizeof(retained->sysid_string));
-    watchdog_event_merge_text(retained->alias, staged->alias, sizeof(retained->alias));
-    watchdog_event_merge_text(retained->gps_s, staged->gps_s, sizeof(retained->gps_s));
-    watchdog_event_merge_text(retained->text_message, staged->text_message, sizeof(retained->text_message));
-    watchdog_event_merge_text(retained->internal_str, staged->internal_str, sizeof(retained->internal_str));
+}
+
+// Fold the staged row into the row already in history: this is the same transmission, and
+// everything the reacquired segment learned -- a late-decoded SRC, the system identifiers, an
+// alias, GPS, a text message, the crypto header that finally arrived -- has to survive.
+// Identity is fill-if-blank; progressive detail is superseded by the newer decode.
+static void
+watchdog_event_merge_staged_into(Event_History* retained, const Event_History* staged,
+                                 watchdog_event_merge_added* added) {
+    DSD_MEMSET(added, 0, sizeof(*added));
+    watchdog_event_merge_identity_fields(retained, staged);
+    watchdog_event_merge_system_identity(retained, staged);
+
+    added->alias =
+        (uint8_t)watchdog_event_merge_text_progressive(retained->alias, staged->alias, sizeof(retained->alias), 1);
+    added->gps =
+        (uint8_t)watchdog_event_merge_text_progressive(retained->gps_s, staged->gps_s, sizeof(retained->gps_s), 0);
+    added->text_message = (uint8_t)watchdog_event_merge_text_progressive(retained->text_message, staged->text_message,
+                                                                         sizeof(retained->text_message), 0);
+    added->internal = (uint8_t)watchdog_event_merge_text_progressive(retained->internal_str, staged->internal_str,
+                                                                     sizeof(retained->internal_str), 0);
     if (watchdog_event_crypto_rank(staged) > watchdog_event_crypto_rank(retained)) {
         retained->enc = staged->enc;
         retained->enc_alg = staged->enc_alg;
         retained->enc_key = staged->enc_key;
         retained->mi = staged->mi;
     }
-    if (retained->svc == 0U && staged->svc != 0U) {
-        retained->svc = staged->svc;
-    }
-    // Regenerated by the caller from the merged fields; leaving the first segment's string
-    // would hide a merged crypto or identity change from the UI and the event log.
-    retained->event_string[0] = '\0';
+    // event_string is left alone here. The caller re-renders it from the merged fields, and that
+    // render needs the existing string: it is the fallback source for the row's date/time prefix
+    // when no stamped event_time is available. A failed render therefore keeps what was displayed
+    // rather than blanking a committed row.
 }
 
-// The first segment already logged its line. A merge that materially changed the rendered row
-// gets a continuation line in the same shape as the " Talker Alias:" / " GPS:" lines; a merge
-// that changed nothing user-visible stays silent.
+// The first segment already logged its line, so a merge appends a continuation rather than a new
+// entry. It carries the same slot annotation and the same optional-detail lines a normal commit
+// writes through write_event_to_log_file(), so a reader can attribute the continuation to a slot
+// and nothing a reacquired segment decoded is visible in the UI but missing from the log.
 static void
-watchdog_event_log_merge_continuation(const dsd_opts* opts, const char* event_string) {
-    if (opts->event_out_file[0] == '\0' || event_string[0] == '\0') {
+watchdog_event_log_merge_continuation(const dsd_opts* opts, uint8_t slot, uint8_t swrite, const Event_History* retained,
+                                      const char* event_string, const watchdog_event_merge_added* added,
+                                      int rendered_changed) {
+    if (opts->event_out_file[0] == '\0') {
+        return;
+    }
+    if (!rendered_changed && !added->alias && !added->gps && !added->text_message && !added->internal) {
         return;
     }
     FILE* event_log_file = dsd_fopen_private(opts->event_out_file, "a");
     if (event_log_file == NULL) {
         return;
     }
-    DSD_FPRINTF(event_log_file, " Reacquired: %s \n", event_string);
+    if (rendered_changed && event_string[0] != '\0') {
+        DSD_FPRINTF(event_log_file, " Reacquired: %s ", event_string);
+        if (swrite == 1) {
+            DSD_FPRINTF(event_log_file, "Slot %d; ", slot + 1);
+        }
+        DSD_FPRINTF(event_log_file, "\n");
+    }
+    if (added->text_message) {
+        DSD_FPRINTF(event_log_file, "%s \n", retained->text_message);
+    }
+    if (added->alias) {
+        DSD_FPRINTF(event_log_file, " Talker Alias: %s \n", retained->alias);
+    }
+    if (added->gps) {
+        DSD_FPRINTF(event_log_file, " GPS: %s \n", retained->gps_s);
+    }
+    if (added->internal) {
+        DSD_FPRINTF(event_log_file, " DSD-neo: %s \n", retained->internal_str);
+    }
     fflush(event_log_file);
     fclose(event_log_file);
 }
 
 // True when the staged row may be folded into the row already committed for this slot: the
 // canonical layer flagged this epoch as one sync-loss-interrupted transmission being
-// reacquired, and both rows are voice. A data staged row never merges into a voice row.
+// reacquired, that row is the one the interrupted epoch itself committed, and both rows are
+// voice. A data staged row never merges into a voice row.
 static int
 watchdog_event_staged_row_merges(const Event_History_I* event_struct, const dsd_call_event_lifecycle* lifecycle,
                                  const Event_History* staged, uint8_t retained_index) {
     if (lifecycle == NULL || lifecycle->epoch == 0U || lifecycle->reacquired_epoch != lifecycle->epoch) {
+        return 0;
+    }
+    // The reopened epoch may have ended without ever pushing a row -- it staged nothing, or a
+    // reset intervened -- in which case committed_epoch still names something older. Folding into
+    // that would put this transmission inside an unrelated call's row, so commit a new one.
+    if (!lifecycle->committed_valid || lifecycle->committed_epoch != lifecycle->reacquired_from_epoch) {
         return 0;
     }
     if (retained_index == 0U || staged->category != DSD_EVENT_CATEGORY_VOICE) {
@@ -408,46 +558,57 @@ watchdog_event_staged_row_merges(const Event_History_I* event_struct, const dsd_
     return event_struct->Event_History_Items[retained_index].category == DSD_EVENT_CATEGORY_VOICE;
 }
 
-// Rebuild the merged row's user-legible string from its now-complete fields. Defined below,
-// beside the per-protocol builders it reuses.
-static void watchdog_event_rerender_row(const dsd_state* state, uint8_t slot, Event_History* item);
+// Rebuild the merged row's user-legible string from its now-complete fields. Returns non-zero
+// when a string could be produced. Defined below, beside the per-protocol builders it reuses.
+static int watchdog_event_rerender_row(const dsd_call_event_render_env* env, Event_History* item);
 
 // Commit the staged row, or merge it into the row this slot already committed when the
 // canonical layer says the two are the same transmission. Returns non-zero when a new row
 // reached history.
 static int
 watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History_I* event_struct, uint8_t slot,
-                                 dsd_call_event_lifecycle* lifecycle, int last_event_is_data, int reset_slot_identity) {
+                                 dsd_call_event_lifecycle* lifecycle, int last_event_is_data, int reset_slot_identity,
+                                 dsd_event_end_disposition end_disposition) {
     const Event_History* staged = &event_struct->Event_History_Items[0];
     const uint8_t retained_index = watchdog_event_committed_row_index(event_struct, lifecycle);
     if (watchdog_event_staged_row_merges(event_struct, lifecycle, staged, retained_index)) {
         Event_History* retained = &event_struct->Event_History_Items[retained_index];
         char rendered_before[sizeof(retained->event_string)];
         copy_str_field(rendered_before, retained->event_string, sizeof(rendered_before));
-        watchdog_event_merge_staged_into(retained, staged);
-        watchdog_event_rerender_row(state, slot, retained);
-        if (retained->event_string[0] == '\0') {
-            // No builder covers this protocol, so keep what the row already displayed rather
-            // than blanking a committed row.
-            copy_str_field(retained->event_string, rendered_before, sizeof(retained->event_string));
-        } else if (strncmp(retained->event_string, rendered_before, sizeof(rendered_before)) != 0) {
-            watchdog_event_log_merge_continuation(opts, retained->event_string);
-        }
+        watchdog_event_merge_added added;
+        watchdog_event_merge_staged_into(retained, staged, &added);
+        // Re-render against the environment the row was committed under, not the live decoder.
+        // A protocol with no builder, or a row with no recoverable timestamp, keeps its string.
+        const int rerendered = watchdog_event_rerender_row(&lifecycle->committed_env, retained);
+        const int rendered_changed =
+            rerendered && strncmp(retained->event_string, rendered_before, sizeof(rendered_before)) != 0;
+        watchdog_event_log_merge_continuation(opts, slot, watchdog_event_should_write_slot(state), retained,
+                                              retained->event_string, &added, rendered_changed);
         dsd_event_history_mark_dirty(event_struct);
-        // Rotate before the staged row is cleared: close_and_rename_wav_file() reads its
-        // rename metadata from Items[0]. Each segment therefore keeps its own recording;
-        // leaving the file open would let it absorb the next transmission's audio and be
-        // exported under that call's metadata instead.
-        watchdog_event_rotate_wav_if_needed(opts, event_struct, slot);
+        // The merged row is now this epoch's row too, so late enrichment for the reacquired
+        // epoch resolves to it and the next segment in the chain has a valid merge target.
+        lifecycle->committed_epoch = lifecycle->epoch;
+        if (end_disposition != DSD_EVENT_END_NONE) {
+            // Rotate before the staged row is cleared: close_and_rename_wav_file() reads its
+            // rename metadata from Items[0]. Each segment therefore keeps its own recording;
+            // leaving the file open would let it absorb the next transmission's audio and be
+            // exported under that call's metadata instead.
+            watchdog_event_rotate_wav_if_needed(opts, event_struct, slot);
+        }
+        if (end_disposition == DSD_EVENT_END_FINAL) {
+            watchdog_event_maybe_beep_call_end(opts, state, slot, last_event_is_data);
+        }
         init_event_history(event_struct, 0, 1);
         watchdog_event_reset_post_push(state);
         return 0;
     }
-    watchdog_event_handle_source_transition(opts, state, event_struct, slot, watchdog_event_should_write_slot(state),
-                                            last_event_is_data, reset_slot_identity);
+    watchdog_event_handle_source_transition_ex(opts, state, event_struct, slot, watchdog_event_should_write_slot(state),
+                                               last_event_is_data, reset_slot_identity, end_disposition);
     if (lifecycle != NULL) {
         lifecycle->committed_seq = event_struct->push_seq;
+        lifecycle->committed_epoch = lifecycle->epoch;
         lifecycle->committed_valid = 1U;
+        watchdog_event_capture_render_env(state, slot, &lifecycle->committed_env);
     }
     return 1;
 }
@@ -508,7 +669,7 @@ watchdog_event_history_authoritative(dsd_opts* opts, dsd_state* state, uint8_t s
     const int promotes_current = lifecycle->epoch == 0U && watchdog_event_history_matches_call(current, call);
     if (has_content && !promotes_current) {
         (void)watchdog_event_commit_staged_row(opts, state, event_struct, slot, lifecycle,
-                                               watchdog_event_is_data_event(current), 0);
+                                               watchdog_event_is_data_event(current), 0, DSD_EVENT_END_FINAL);
     } else if (has_content) {
         init_event_history(event_struct, 0, 1);
     }
@@ -520,8 +681,17 @@ watchdog_event_history_authoritative(dsd_opts* opts, dsd_state* state, uint8_t s
     lifecycle->notice_kind = DSD_CALL_KIND_UNKNOWN;
     lifecycle->notice_handled = 0U;
     // A reacquired segment is the same transmission resuming, not a new one: beeping START
-    // again would leave a flapping call with several STARTs against its single END.
+    // again would leave a flapping call with several STARTs against its single END. It also
+    // means the previous segment's held VOICE_END was premature, so it is simply dropped.
     const int reacquired = lifecycle->reacquired_epoch == call->epoch;
+    if (reacquired) {
+        lifecycle->end_alert_pending = 0U;
+        lifecycle->end_alert_due_m = 0.0;
+    } else {
+        // A different call is taking the slot. Retire any held END now so the operator hears it
+        // before this call's START rather than partway into it.
+        watchdog_event_flush_pending_end_alert(opts, state, slot, lifecycle, 1);
+    }
     if (call->phase == DSD_CALL_PHASE_ACTIVE && call->kind != DSD_CALL_KIND_DATA && !reacquired
         && dsd_call_alert_event_enabled(opts->call_alert, opts->call_alert_events, DSD_CALL_ALERT_EVENT_VOICE_START)) {
         beeper(opts, state, slot, 40, 86, 3);
@@ -585,7 +755,9 @@ typedef struct {
     char s_mode[200];
     uint16_t svc_opts;
     uint8_t subtype;
-    uint8_t mfid;
+    /* Live decoder inputs the builders below still need. Captured alongside the committed row
+     * so a re-render reproduces the context the row was built under. */
+    dsd_call_event_render_env env;
     uint32_t sys_id1;
     uint32_t sys_id2;
     uint32_t sys_id3;
@@ -696,7 +868,7 @@ watchdog_event_current_init_base(const dsd_state* state, uint8_t slot, const dsd
     ctx->protocol = DSD_SYNC_NONE;
     ctx->kind = DSD_CALL_KIND_UNKNOWN;
     ctx->subtype = slot == 0U ? state->dmrburstL : state->dmrburstR;
-    ctx->mfid = slot == 0U ? state->dmr_fid : state->dmr_fidR;
+    watchdog_event_capture_render_env(state, slot, &ctx->env);
 
     if (!call || call->epoch == 0U) {
         return;
@@ -923,13 +1095,13 @@ watchdog_event_current_build_event_dpmr(const watchdog_event_current_ctx* ctx, c
 }
 
 static void
-watchdog_event_current_build_event_edacs(const dsd_state* state, const watchdog_event_current_ctx* ctx,
-                                         const char* datestr, const char* timestr, const char* sys_string,
-                                         char* event_string, size_t event_size) {
+watchdog_event_current_build_event_edacs(const watchdog_event_current_ctx* ctx, const char* datestr,
+                                         const char* timestr, const char* sys_string, char* event_string,
+                                         size_t event_size) {
     char sup_str[200];
     watchdog_event_build_edacs_sup_str(ctx->svc_opts, 0, sup_str, sizeof(sup_str));
 
-    if (state->ea_mode == 1) {
+    if (ctx->env.ea_mode == 1) {
         DSD_SNPRINTF(event_string, event_size, "%s %s %s TGT: %07d; SRC: %07d; LCN: %02d; SITE: %d:%d.%04X; %s;",
                      datestr, timestr, sys_string, ctx->target_id, ctx->source_id, ctx->channel, ctx->sys_id1,
                      ctx->sys_id2, ctx->sys_id3, sup_str);
@@ -937,11 +1109,11 @@ watchdog_event_current_build_event_edacs(const dsd_state* state, const watchdog_
     }
 
     int afs = (int)ctx->target_id;
-    int a = (afs >> state->edacs_a_shift) & state->edacs_a_mask;
-    int f = (afs >> state->edacs_f_shift) & state->edacs_f_mask;
-    int s = afs & state->edacs_s_mask;
+    int a = (afs >> ctx->env.edacs_a_shift) & ctx->env.edacs_a_mask;
+    int f = (afs >> ctx->env.edacs_f_shift) & ctx->env.edacs_f_mask;
+    int s = afs & ctx->env.edacs_s_mask;
     char afs_str[8];
-    getAfsString((dsd_state*)state, afs_str, a, f, s);
+    getAfsStringFromBits(ctx->env.edacs_a_bits, ctx->env.edacs_f_bits, ctx->env.edacs_s_bits, afs_str, a, f, s);
 
     char lid_str[20];
     DSD_MEMSET(lid_str, 0, sizeof(lid_str));
@@ -991,7 +1163,7 @@ watchdog_event_current_build_event_dmr(const watchdog_event_current_ctx* ctx, co
         watchdog_event_str_append(event_string, event_size, "Private; ");
     }
 
-    if (ctx->mfid == 0x10) {
+    if (ctx->env.mfid == 0x10) {
         if (ctx->svc_opts & 0x30) {
             watchdog_event_str_append(event_string, event_size, "TXI; ");
         }
@@ -1033,9 +1205,8 @@ watchdog_event_current_build_event_p25(const watchdog_event_current_ctx* ctx, co
 }
 
 static void
-watchdog_event_current_build_event_nxdn(const dsd_state* state, const watchdog_event_current_ctx* ctx,
-                                        const char* datestr, const char* timestr, const char* sys_string,
-                                        char* event_string, size_t event_size) {
+watchdog_event_current_build_event_nxdn(const watchdog_event_current_ctx* ctx, const char* datestr, const char* timestr,
+                                        const char* sys_string, char* event_string, size_t event_size) {
     if (ctx->sys_id1) {
         DSD_SNPRINTF(event_string, event_size, "%s %s %s TGT: %08d; SRC: %08d; RAN: %02d; SYS: %d.%d; ", datestr,
                      timestr, sys_string, ctx->target_id, ctx->source_id, ctx->sys_id3, ctx->sys_id2, ctx->sys_id1);
@@ -1044,13 +1215,13 @@ watchdog_event_current_build_event_nxdn(const dsd_state* state, const watchdog_e
                      sys_string, ctx->target_id, ctx->source_id, ctx->sys_id3);
     }
 
-    if (state->nxdn_grant_chan != 0) {
+    if (ctx->env.nxdn_grant_chan != 0) {
         char ch_str[96];
-        if (state->nxdn_grant_freq != 0) {
-            DSD_SNPRINTF(ch_str, sizeof(ch_str), "CH: %u; FREQ: %.6lf MHz; ", state->nxdn_grant_chan,
-                         (double)state->nxdn_grant_freq / 1000000.0);
+        if (ctx->env.nxdn_grant_freq != 0) {
+            DSD_SNPRINTF(ch_str, sizeof(ch_str), "CH: %u; FREQ: %.6lf MHz; ", ctx->env.nxdn_grant_chan,
+                         (double)ctx->env.nxdn_grant_freq / 1000000.0);
         } else {
-            DSD_SNPRINTF(ch_str, sizeof(ch_str), "CH: %u; ", state->nxdn_grant_chan);
+            DSD_SNPRINTF(ch_str, sizeof(ch_str), "CH: %u; ", ctx->env.nxdn_grant_chan);
         }
         watchdog_event_str_append(event_string, event_size, ch_str);
     }
@@ -1071,10 +1242,13 @@ watchdog_event_current_build_event_nxdn(const dsd_state* state, const watchdog_e
     }
 }
 
+// Every builder renders purely from ctx -- the identity and metadata copied off the call or the
+// row, plus the render env captured with it. Nothing here reads live decoder state, so the same
+// ctx always produces the same string no matter when it is rebuilt.
 static void
-watchdog_event_current_build_event_string(const dsd_state* state, const watchdog_event_current_ctx* ctx,
-                                          const char* datestr, const char* timestr, const char* sys_string,
-                                          char* event_string, size_t event_size) {
+watchdog_event_current_build_event_string(const watchdog_event_current_ctx* ctx, const char* datestr,
+                                          const char* timestr, const char* sys_string, char* event_string,
+                                          size_t event_size) {
     if (DSD_SYNC_IS_YSF(ctx->protocol) || DSD_SYNC_IS_DSTAR(ctx->protocol)) {
         watchdog_event_current_build_event_text_ids(ctx, datestr, timestr, sys_string, event_string, event_size);
     } else if (DSD_SYNC_IS_M17(ctx->protocol)) {
@@ -1082,13 +1256,13 @@ watchdog_event_current_build_event_string(const dsd_state* state, const watchdog
     } else if (DSD_SYNC_IS_DPMR(ctx->protocol)) {
         watchdog_event_current_build_event_dpmr(ctx, datestr, timestr, sys_string, event_string, event_size);
     } else if (DSD_SYNC_IS_EDACS(ctx->protocol)) {
-        watchdog_event_current_build_event_edacs(state, ctx, datestr, timestr, sys_string, event_string, event_size);
+        watchdog_event_current_build_event_edacs(ctx, datestr, timestr, sys_string, event_string, event_size);
     } else if (DSD_SYNC_IS_DMR(ctx->protocol)) {
         watchdog_event_current_build_event_dmr(ctx, datestr, timestr, sys_string, event_string, event_size);
     } else if (DSD_SYNC_IS_P25(ctx->protocol)) {
         watchdog_event_current_build_event_p25(ctx, datestr, timestr, sys_string, event_string, event_size);
     } else if (DSD_SYNC_IS_NXDN(ctx->protocol)) {
-        watchdog_event_current_build_event_nxdn(state, ctx, datestr, timestr, sys_string, event_string, event_size);
+        watchdog_event_current_build_event_nxdn(ctx, datestr, timestr, sys_string, event_string, event_size);
     }
 }
 
@@ -1122,13 +1296,13 @@ watchdog_event_row_kind(const Event_History* item) {
     return DSD_CALL_KIND_VOICE;
 }
 
-// Rebuild the render context from a history row rather than from a live call snapshot. Used
-// when a reacquired segment merges into a row already in history: the row's fields have just
-// gained information and its event_string has to say so. Protocol metadata is read back from
-// the row instead of re-derived, so this cannot disturb live per-slot state the way
-// watchdog_event_current_apply_protocol_metadata() would.
+// Rebuild the render context from a history row plus the environment captured when that row was
+// committed. Used when a reacquired segment merges into a row already in history: the row's
+// fields have just gained information and its event_string has to say so. Nothing is read from
+// live decoder state, so a retune or a manufacturer-id change between the commit and the merge
+// cannot rewrite the row with a context the call never ran under.
 static void
-watchdog_event_ctx_from_row(const dsd_state* state, uint8_t slot, const Event_History* item,
+watchdog_event_ctx_from_row(const dsd_call_event_render_env* env, const Event_History* item,
                             watchdog_event_current_ctx* ctx) {
     DSD_MEMSET(ctx, 0, sizeof(*ctx));
     ctx->severity = (dsd_event_severity)item->severity;
@@ -1138,7 +1312,7 @@ watchdog_event_ctx_from_row(const dsd_state* state, uint8_t slot, const Event_Hi
     ctx->protocol = (int)item->systype;
     ctx->kind = watchdog_event_row_kind(item);
     ctx->subtype = (uint8_t)item->subtype;
-    ctx->mfid = slot == 0U ? state->dmr_fid : state->dmr_fidR;
+    ctx->env = *env;
     ctx->source_id = item->source_id;
     ctx->target_id = item->target_id;
     ctx->svc_opts = item->svc;
@@ -1163,24 +1337,65 @@ watchdog_event_ctx_from_row(const dsd_state* state, uint8_t slot, const Event_Hi
     ctx->s_name_loaded = item->s_name[0] != '\0' ? 1U : 0U;
 }
 
-static void
-watchdog_event_rerender_row(const dsd_state* state, uint8_t slot, Event_History* item) {
-    watchdog_event_current_ctx ctx;
-    watchdog_event_ctx_from_row(state, slot, item, &ctx);
+static int
+watchdog_event_char_is_digit(char c) {
+    return c >= '0' && c <= '9';
+}
 
+// Recover the "YYYY-MM-DD HH:MM:SS " prefix every builder emits, straight from the string the row
+// is already displaying. Needed because item->event_time is only stamped when reading live audio:
+// under --playfiles it is supplied by the replay timeline instead (dsd_file.c) and is legitimately
+// 0 when that timeline carries no timestamp. Formatting 0 would stamp the row 1970-01-01, so the
+// prefix it already renders is the only trustworthy source. Returns non-zero on a clean parse.
+static int
+watchdog_event_row_datetime(const Event_History* item, char* datestr, size_t datestr_size, char* timestr,
+                            size_t timestr_size) {
+    if (item->event_time > 0) {
+        (void)dsd_format_local_datetime(item->event_time, DSD_LOCAL_DATETIME_TIME_COLON, timestr, timestr_size);
+        (void)dsd_format_local_datetime(item->event_time, DSD_LOCAL_DATETIME_DATE_HYPHEN, datestr, datestr_size);
+        return 1;
+    }
+
+    // "YYYY-MM-DD HH:MM:SS": separators at offsets 4, 7, 10, 13, 16; digits everywhere else.
+    static const char kSeparators[19] = {0, 0, 0, 0, '-', 0, 0, '-', 0, 0, ' ', 0, 0, ':', 0, 0, ':', 0, 0};
+    const char* s = item->event_string;
+    if (datestr_size < 11U || timestr_size < 9U || strnlen(s, sizeof(item->event_string)) < 19U) {
+        return 0;
+    }
+    for (size_t i = 0; i < 19U; i++) {
+        if (kSeparators[i] != 0 ? s[i] != kSeparators[i] : !watchdog_event_char_is_digit(s[i])) {
+            return 0;
+        }
+    }
+    DSD_SNPRINTF(datestr, 11U, "%s", s);
+    DSD_SNPRINTF(timestr, 9U, "%s", s + 11);
+    return 1;
+}
+
+static int
+watchdog_event_rerender_row(const dsd_call_event_render_env* env, Event_History* item) {
     char timestr[9];
     char datestr[11];
     // The row's own timestamp, not the merge instant: it still describes the transmission
-    // that opened at the first commit.
-    (void)dsd_format_local_datetime(item->event_time, DSD_LOCAL_DATETIME_TIME_COLON, timestr, sizeof timestr);
-    (void)dsd_format_local_datetime(item->event_time, DSD_LOCAL_DATETIME_DATE_HYPHEN, datestr, sizeof datestr);
+    // that opened at the first commit. Without a trustworthy one, leave the row as it stands
+    // rather than restamping it with an invented time.
+    if (!watchdog_event_row_datetime(item, datestr, sizeof datestr, timestr, sizeof timestr)) {
+        return 0;
+    }
+
+    watchdog_event_current_ctx ctx;
+    watchdog_event_ctx_from_row(env, item, &ctx);
 
     char event_string[2000];
     DSD_MEMSET(event_string, 0, sizeof(event_string));
-    watchdog_event_current_build_event_string(state, &ctx, datestr, timestr, dsd_synctype_to_string(ctx.protocol),
+    watchdog_event_current_build_event_string(&ctx, datestr, timestr, dsd_synctype_to_string(ctx.protocol),
                                               event_string, sizeof(event_string));
     watchdog_event_current_append_policy_labels(&ctx, event_string, sizeof(event_string));
+    if (event_string[0] == '\0') {
+        return 0;
+    }
     DSD_SNPRINTF(item->event_string, sizeof(item->event_string), "%s", event_string);
+    return 1;
 }
 
 static int
@@ -1215,14 +1430,30 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
     if (call->phase != DSD_CALL_PHASE_ENDED || lifecycle->epoch != call->epoch || lifecycle->ended_committed) {
         return;
     }
+    // A sync-loss end may be the middle of a transmission rather than its end, so its VOICE_END
+    // alert is held until the reacquisition window closes. Each further segment re-arms it, and
+    // the alert lands once the call really has stopped flapping. An explicit terminator is
+    // unambiguous and alerts immediately.
+    const int deferred_end =
+        call->end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS && call->kind != DSD_CALL_KIND_DATA
+        && dsd_call_alert_event_enabled(opts->call_alert, opts->call_alert_events, DSD_CALL_ALERT_EVENT_VOICE_END);
+    const dsd_event_end_disposition disposition = deferred_end ? DSD_EVENT_END_DEFERRED : DSD_EVENT_END_FINAL;
     if (watchdog_event_item_has_content(&event_struct->Event_History_Items[0])) {
         // Either outcome puts this epoch's information into history -- a new row, or merged
         // into the row the interrupted transmission already owns. The empty-staged-row branch
         // has nothing to commit; enrichment resolves that case by push sequence and declines.
         (void)watchdog_event_commit_staged_row((dsd_opts*)opts, state, event_struct, slot, lifecycle,
-                                               call->kind == DSD_CALL_KIND_DATA, 1);
+                                               call->kind == DSD_CALL_KIND_DATA, 1, disposition);
     } else {
         init_event_history(event_struct, 0, 1);
+    }
+    if (deferred_end) {
+        lifecycle->end_alert_pending = 1U;
+        // Deliberately the local monotonic clock rather than call->ended_m: the deadline is only
+        // ever compared against this same clock, and ended_m carries whatever timeline the caller
+        // supplied. In production the two coincide; keeping both endpoints on one clock means a
+        // caller-supplied timeline can never make the alert fire early.
+        lifecycle->end_alert_due_m = dsd_time_now_monotonic_s() + DSD_CALL_REACQUIRE_GAP_S;
     }
     lifecycle->ended_committed = 1U;
 }
@@ -1265,8 +1496,7 @@ watchdog_event_current_impl(const dsd_opts* opts, dsd_state* state, uint8_t slot
 
     char event_string[2000];
     DSD_MEMSET(event_string, 0, sizeof(event_string));
-    watchdog_event_current_build_event_string(state, &ctx, datestr, timestr, sys_string, event_string,
-                                              sizeof(event_string));
+    watchdog_event_current_build_event_string(&ctx, datestr, timestr, sys_string, event_string, sizeof(event_string));
     watchdog_event_current_append_policy_labels(&ctx, event_string, sizeof(event_string));
 
     DSD_SNPRINTF(candidate.event_string, sizeof(candidate.event_string), "%s", event_string);
@@ -1305,6 +1535,9 @@ dsd_event_sync_slot(dsd_opts* opts, dsd_state* state, uint8_t slot) {
     dsd_call_event_lifecycle* lifecycle = &ext->events[slot];
     watchdog_event_history_impl(opts, state, slot, call, lifecycle);
     watchdog_event_current_impl(opts, state, slot, call, lifecycle, 1);
+    // This runs on every frame-sync pass, so it is also where a VOICE_END alert held open across
+    // a possible reacquisition is finally emitted once that window has closed with no resumption.
+    watchdog_event_flush_pending_end_alert(opts, state, slot, lifecycle, 0);
     dsd_call_state_ext_unlock(ext);
 }
 
@@ -1400,14 +1633,19 @@ dsd_event_emit_call_notice_impl(dsd_opts* opts, dsd_state* state, uint8_t slot, 
     DSD_SNPRINTF(event_struct->Event_History_Items[0].internal_str,
                  sizeof(event_struct->Event_History_Items[0].internal_str), "%s", detail);
     dsd_event_history_mark_dirty(event_struct);
-    watchdog_event_handle_source_transition_ex(opts, state, event_struct, slot, watchdog_event_should_write_slot(state),
-                                               call->kind == DSD_CALL_KIND_DATA, finalize_call, finalize_call);
+    // Routed through the commit path rather than pushing directly: a notice raised during a
+    // reacquired segment -- P25 encryption first detected after the gap, say -- describes the
+    // transmission that is already in history, so it has to fold into that row. Pushing here
+    // unconditionally would give one transmission two rows and leave the first one orphaned.
+    // The commit path keeps the notice detail: internal_str is merged progressively, so the
+    // detail that just fired supersedes whatever the row carried.
+    (void)watchdog_event_commit_staged_row(opts, state, event_struct, slot, canonical_lifecycle,
+                                           call->kind == DSD_CALL_KIND_DATA, finalize_call,
+                                           finalize_call ? DSD_EVENT_END_FINAL : DSD_EVENT_END_NONE);
     watchdog_event_notice_mark_handled(lifecycle, call);
     if (canonical_lifecycle != NULL) {
-        // This push carried the canonical epoch's row into history, so it becomes the row a
-        // reacquired segment merges into and the row enrichment targets.
-        canonical_lifecycle->committed_seq = event_struct->push_seq;
-        canonical_lifecycle->committed_valid = 1U;
+        // committed_seq/committed_epoch are maintained by the commit path itself; only the
+        // end-of-epoch marker is this function's to set.
         if (call->phase == DSD_CALL_PHASE_ENDED) {
             canonical_lifecycle->ended_committed = 1U;
         }
@@ -1451,16 +1689,22 @@ dsd_event_enrich_epoch(dsd_state* state, uint8_t slot, uint64_t epoch, const cha
         dsd_call_state_ext_unlock(ext);
         return 0;
     }
-    // While the epoch is still staging, enrichment belongs on row 0. Once its row has been
-    // committed the row has to be located by push sequence: an interleaved data or system
-    // notice pushes it deeper than index 1.
+    // Once this epoch's row has been committed the row has to be located by push sequence: an
+    // interleaved data or system notice pushes it deeper than index 1. The test is on
+    // committed_epoch rather than the lifecycle's current epoch, so an epoch that never pushed a
+    // row of its own cannot enrich an older epoch's row that committed_seq still points at.
     uint8_t history_index = 0U;
-    if (lifecycle->epoch == epoch && lifecycle->ended_committed) {
+    if (lifecycle->committed_valid && lifecycle->committed_epoch == epoch) {
         history_index = watchdog_event_committed_row_index(&state->event_history_s[slot], lifecycle);
         if (history_index == 0U) {
             dsd_call_state_ext_unlock(ext);
             return 0;
         }
+    } else if (lifecycle->epoch == epoch && lifecycle->ended_committed) {
+        // Committed but not locatable (the row aged out of the ring, or a context restore
+        // invalidated the reference). Enriching row 0 would write into an unrelated staged row.
+        dsd_call_state_ext_unlock(ext);
+        return 0;
     }
     Event_History* item = &state->event_history_s[slot].Event_History_Items[history_index];
     if (kind == DSD_EVENT_ENRICH_ALIAS) {
@@ -1506,8 +1750,10 @@ dsd_event_history_reset(dsd_state* state) {
         init_event_history(&state->event_history_s[slot], 0, 255);
         if (ext != NULL) {
             ext->events[slot].committed_seq = 0U;
+            ext->events[slot].committed_epoch = 0U;
             ext->events[slot].committed_valid = 0U;
             ext->events[slot].reacquired_epoch = 0U;
+            ext->events[slot].reacquired_from_epoch = 0U;
         }
     }
     dsd_event_history_transaction_end(&transaction);

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -1157,6 +1157,18 @@ watchdog_event_current_build_event_edacs(const watchdog_event_current_ctx* ctx, 
                  sys_string, afs_str, afs, lid_str, ctx->channel, ctx->sys_id1, sup_str);
 }
 
+// The Group/Private annotation, shared by every builder that renders one. Kept in one place so a
+// new dsd_call_kind, or a change to either token, cannot be applied to some protocols and missed on
+// others.
+static void
+watchdog_event_append_call_kind(const watchdog_event_current_ctx* ctx, char* event_string, size_t event_size) {
+    if (ctx->kind == DSD_CALL_KIND_GROUP_VOICE) {
+        watchdog_event_str_append(event_string, event_size, "Group; ");
+    } else if (ctx->kind == DSD_CALL_KIND_PRIVATE_VOICE) {
+        watchdog_event_str_append(event_string, event_size, "Private; ");
+    }
+}
+
 static void
 watchdog_event_current_build_event_dmr(const watchdog_event_current_ctx* ctx, const char* datestr, const char* timestr,
                                        const char* sys_string, char* event_string, size_t event_size) {
@@ -1187,11 +1199,7 @@ watchdog_event_current_build_event_dmr(const watchdog_event_current_ctx* ctx, co
         watchdog_event_str_append(event_string, event_size, "OVCM; ");
     }
 
-    if (ctx->kind == DSD_CALL_KIND_GROUP_VOICE) {
-        watchdog_event_str_append(event_string, event_size, "Group; ");
-    } else if (ctx->kind == DSD_CALL_KIND_PRIVATE_VOICE) {
-        watchdog_event_str_append(event_string, event_size, "Private; ");
-    }
+    watchdog_event_append_call_kind(ctx, event_string, event_size);
 
     if (ctx->env.mfid == 0x10) {
         if (ctx->svc_opts & 0x30) {
@@ -1215,15 +1223,6 @@ watchdog_event_append_ess_crypto(const watchdog_event_current_ctx* ctx, char* ev
     } else if (ctx->crypto == DSD_CALL_CRYPTO_ENCRYPTED_PENDING || ctx->crypto == DSD_CALL_CRYPTO_ENCRYPTED
                || ctx->enc) {
         watchdog_event_str_append(event_string, event_size, "ENC; ");
-    }
-}
-
-static void
-watchdog_event_append_call_kind(const watchdog_event_current_ctx* ctx, char* event_string, size_t event_size) {
-    if (ctx->kind == DSD_CALL_KIND_GROUP_VOICE) {
-        watchdog_event_str_append(event_string, event_size, "Group; ");
-    } else if (ctx->kind == DSD_CALL_KIND_PRIVATE_VOICE) {
-        watchdog_event_str_append(event_string, event_size, "Private; ");
     }
 }
 
@@ -1293,11 +1292,7 @@ watchdog_event_current_build_event_nxdn(const watchdog_event_current_ctx* ctx, c
         watchdog_event_str_append(event_string, event_size, ess_str);
     }
 
-    if (ctx->kind == DSD_CALL_KIND_GROUP_VOICE) {
-        watchdog_event_str_append(event_string, event_size, "Group; ");
-    } else if (ctx->kind == DSD_CALL_KIND_PRIVATE_VOICE) {
-        watchdog_event_str_append(event_string, event_size, "Private; ");
-    }
+    watchdog_event_append_call_kind(ctx, event_string, event_size);
 }
 
 // Every builder renders purely from ctx -- the identity and metadata copied off the call or the

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -1409,19 +1409,19 @@ watchdog_event_char_is_digit(char c) {
 }
 
 // Recover the "YYYY-MM-DD HH:MM:SS " prefix every builder emits, straight from the string the row
-// is already displaying. Needed because item->event_time is only stamped when reading live audio:
-// under --playfiles it is supplied by the replay timeline instead (dsd_file.c) and is legitimately
-// 0 when that timeline carries no timestamp. Formatting 0 would stamp the row 1970-01-01, so the
-// prefix it already renders is the only trustworthy source. Returns non-zero on a clean parse.
+// is already displaying, and only fall back to item->event_time when that string carries no
+// parseable prefix -- a row a protocol staged directly rather than rendering.
+//
+// The displayed string is preferred rather than the stamp because the two are not always the same
+// clock. Every builder renders the prefix from time(NULL), but watchdog_event_current_update_item()
+// only stamps event_time when opts->playfiles == 0; under --playfiles over an sdrtrunk recording it
+// is left as the recording's own timestamp instead (dsd_file.c). Formatting the stamp there would
+// rewrite a committed row's visible date and time to a value none of its siblings use, purely
+// because it was merged -- and would make the re-render report a change on every merge. Stamped or
+// not, a merge must never restamp the row. Returns non-zero on success.
 static int
 watchdog_event_row_datetime(const Event_History* item, char* datestr, size_t datestr_size, char* timestr,
                             size_t timestr_size) {
-    if (item->event_time > 0) {
-        (void)dsd_format_local_datetime(item->event_time, DSD_LOCAL_DATETIME_TIME_COLON, timestr, timestr_size);
-        (void)dsd_format_local_datetime(item->event_time, DSD_LOCAL_DATETIME_DATE_HYPHEN, datestr, datestr_size);
-        return 1;
-    }
-
     // "YYYY-MM-DD HH:MM:SS": separators at offsets 4, 7, 10, 13, 16; digits everywhere else.
     static const char k_watchdog_event_datetime_separators[19] = {0,   0, 0, 0,   '-', 0, 0,   '-', 0, 0,
                                                                   ' ', 0, 0, ':', 0,   0, ':', 0,   0};
@@ -1432,18 +1432,33 @@ watchdog_event_row_datetime(const Event_History* item, char* datestr, size_t dat
     // widening one must not copy more of the timestamp than the field itself.
     enum { k_datestr_len = 11U, k_timestr_len = 9U };
 
-    if (datestr_size < k_datestr_len || timestr_size < k_timestr_len || strnlen(s, sizeof(item->event_string)) < 19U) {
+    if (datestr_size < k_datestr_len || timestr_size < k_timestr_len) {
         return 0;
     }
-    for (size_t i = 0; i < 19U; i++) {
-        if (k_watchdog_event_datetime_separators[i] != 0 ? s[i] != k_watchdog_event_datetime_separators[i]
-                                                         : !watchdog_event_char_is_digit(s[i])) {
-            return 0;
+    if (strnlen(s, sizeof(item->event_string)) >= 19U) {
+        int parsed = 1;
+        for (size_t i = 0; i < 19U; i++) {
+            if (k_watchdog_event_datetime_separators[i] != 0 ? s[i] != k_watchdog_event_datetime_separators[i]
+                                                             : !watchdog_event_char_is_digit(s[i])) {
+                parsed = 0;
+                break;
+            }
+        }
+        if (parsed) {
+            DSD_SNPRINTF(datestr, 11U, "%s", s);
+            DSD_SNPRINTF(timestr, 9U, "%s", s + 11);
+            return 1;
         }
     }
-    DSD_SNPRINTF(datestr, 11U, "%s", s);
-    DSD_SNPRINTF(timestr, 9U, "%s", s + 11);
-    return 1;
+
+    // No prefix to preserve. A stamp is better than nothing; a zero one would render 1970-01-01,
+    // so leave the row alone instead.
+    if (item->event_time > 0) {
+        (void)dsd_format_local_datetime(item->event_time, DSD_LOCAL_DATETIME_TIME_COLON, timestr, timestr_size);
+        (void)dsd_format_local_datetime(item->event_time, DSD_LOCAL_DATETIME_DATE_HYPHEN, datestr, datestr_size);
+        return 1;
+    }
+    return 0;
 }
 
 static int

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -340,8 +340,11 @@ watchdog_event_flush_pending_end_alert(dsd_opts* opts, dsd_state* state, uint8_t
 }
 
 // Snapshot the live decoder inputs the per-protocol builders read directly. Taken once per render
-// so a row can later be rebuilt against the same values, rather than against a decoder that has
-// retuned, changed manufacturer feature id, or been reconfigured since.
+// -- with the row's content, not when that row is eventually pushed -- so a row can later be
+// rebuilt against the same values, rather than against a decoder that has retuned, changed
+// manufacturer feature id, or been reconfigured since. A staged row is sometimes committed only
+// after the canonical layer has opened the next call, by which point the live values describe
+// that call rather than the one the row is about.
 static void
 watchdog_event_capture_render_env(const dsd_state* state, uint8_t slot, dsd_call_event_render_env* env) {
     env->mfid = slot == 0U ? state->dmr_fid : state->dmr_fidR;
@@ -621,7 +624,10 @@ watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History
         lifecycle->committed_seq = event_struct->push_seq;
         lifecycle->committed_epoch = lifecycle->epoch;
         lifecycle->committed_valid = 1U;
-        watchdog_event_capture_render_env(state, slot, &lifecycle->committed_env);
+        // Promoted from the render, not re-read from the decoder: this commit may be running
+        // because the epoch changed, in which case the live values already describe the incoming
+        // call rather than the row being pushed.
+        lifecycle->committed_env = lifecycle->staged_env;
     }
     return 1;
 }
@@ -689,6 +695,10 @@ watchdog_event_history_authoritative(dsd_opts* opts, dsd_state* state, uint8_t s
 
     lifecycle->epoch = call->epoch;
     lifecycle->ended_committed = 0U;
+    // Set after the commit above, which belongs to the outgoing epoch. Rows staged directly by a
+    // protocol never pass through the renderer, so without this they would inherit whichever
+    // environment the previous epoch's last render left behind.
+    DSD_MEMSET(&lifecycle->staged_env, 0, sizeof(lifecycle->staged_env));
     lifecycle->notice_epoch = 0U;
     lifecycle->notice_target_id = 0U;
     lifecycle->notice_kind = DSD_CALL_KIND_UNKNOWN;
@@ -1330,6 +1340,12 @@ watchdog_event_ctx_from_row(const dsd_call_event_render_env* env, const Event_Hi
     ctx->target_id = item->target_id;
     ctx->svc_opts = item->svc;
     ctx->enc = item->enc;
+    // A row persists only the derived flag, so the classification is rebuilt from it rather than
+    // left at UNKNOWN. The P25 builder tests crypto and enc together; leaving crypto zero made
+    // its first two disjuncts dead on every merged row, so any future classification that set
+    // crypto without setting enc would have dropped the encryption marker from a merged row while
+    // the unmerged path still showed it.
+    ctx->crypto = item->enc ? DSD_CALL_CRYPTO_ENCRYPTED : DSD_CALL_CRYPTO_UNKNOWN;
     ctx->alg_id = item->enc_alg;
     ctx->key_id = item->enc_key;
     ctx->mi = item->mi;
@@ -1515,6 +1531,12 @@ watchdog_event_current_impl(const dsd_opts* opts, dsd_state* state, uint8_t slot
     DSD_SNPRINTF(candidate.event_string, sizeof(candidate.event_string), "%s", event_string);
 
     watchdog_event_commit_candidate(event_struct, &candidate);
+    // The staged row and the decoder inputs that produced it are captured together, so whenever
+    // that row is committed -- now, or on a later pass once the epoch has already changed -- it
+    // carries the environment it was actually rendered under.
+    if (lifecycle != NULL) {
+        watchdog_event_capture_render_env(state, slot, &lifecycle->staged_env);
+    }
     watchdog_event_finalize_ended(opts, state, slot, effective_call, lifecycle, event_struct, finalize_ended);
 
     /* stack buffers; no free */

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -22,7 +22,6 @@
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/core/time_format.h>
 #include <dsd-neo/platform/file_compat.h>
-#include <dsd-neo/platform/timing.h>
 #include <dsd-neo/protocol/edacs/edacs_afs.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -39,10 +38,6 @@ enum {
     DSD_EVENT_SUBTYPE_DMR_DATA_BURST = 6,
     DSD_EVENT_SUBTYPE_EXPLICIT_DATA = INT8_MAX,
 };
-
-// Seconds within which a repeated voice commit is treated as the transmission
-// already in history rather than a new one.
-#define DSD_EVENT_COMMIT_REPEAT_WINDOW_S 1.0
 
 // Safe bounded copy helper that tolerates potential overlap
 static inline void
@@ -163,6 +158,7 @@ push_event_history(Event_History_I* event_struct) {
                        event_struct->Event_History_Items[i - 1].internal_str,
                        sizeof event_struct->Event_History_Items[i].internal_str);
     }
+    event_struct->push_seq++;
     dsd_event_history_mark_dirty(event_struct);
 }
 
@@ -298,76 +294,161 @@ watchdog_event_handle_source_transition(dsd_opts* opts, dsd_state* state, Event_
                                                reset_slot_identity, 1);
 }
 
-static double
-watchdog_event_now_m(void) {
-    return (double)dsd_time_monotonic_ms() / 1000.0;
+// Depth of the row this slot last committed, or 0 when it can no longer be located.
+// push_event_history() copies row 0 into row 1, so immediately after a commit the row
+// sits at index 1 and every push since -- including interleaved data or system notices --
+// has pushed it one deeper.
+static uint8_t
+watchdog_event_committed_row_index(const Event_History_I* event_struct, const dsd_call_event_lifecycle* lifecycle) {
+    if (event_struct == NULL || lifecycle == NULL || !lifecycle->committed_valid) {
+        return 0U;
+    }
+    if (event_struct->push_seq < lifecycle->committed_seq) {
+        return 0U;
+    }
+    const uint64_t depth = 1U + (event_struct->push_seq - lifecycle->committed_seq);
+    return depth <= 254U ? (uint8_t)depth : 0U;
+}
+
+static int
+watchdog_event_text_is_empty(const char* text) {
+    return text == NULL || text[0] == '\0';
 }
 
 static void
-watchdog_event_note_commit(dsd_call_event_lifecycle* lifecycle, const Event_History* item, double now_m) {
-    if (lifecycle == NULL || item == NULL) {
+watchdog_event_merge_text(char* retained, const char* staged, size_t cap) {
+    if (watchdog_event_text_is_empty(retained) && !watchdog_event_text_is_empty(staged)) {
+        DSD_SNPRINTF(retained, cap, "%s", staged);
+    }
+}
+
+// Rank crypto knowledge so a later segment can upgrade the retained row but never
+// downgrade it: a segment that decoded the PI/ESS header knows more than the late-entry
+// segment that had to assume clear.
+static int
+watchdog_event_crypto_rank(const Event_History* item) {
+    if (item->enc == 0U) {
+        return item->enc_alg != 0U ? 1 : 0;
+    }
+    return item->enc_alg != 0U ? 3 : 2;
+}
+
+// Fold the staged row into the row already in history: this is the same transmission, and
+// everything the reacquired segment learned -- a late-decoded SRC, an alias, GPS, a text
+// message, the crypto header that finally arrived -- has to survive. Only ever adds
+// information; a known value is never replaced by an unknown one.
+static void
+watchdog_event_merge_staged_into(Event_History* retained, const Event_History* staged) {
+    if (retained->source_id == 0U && staged->source_id != 0U) {
+        retained->source_id = staged->source_id;
+    }
+    if (retained->target_id == 0U && staged->target_id != 0U) {
+        retained->target_id = staged->target_id;
+    }
+    if (retained->channel == 0U && staged->channel != 0U) {
+        retained->channel = staged->channel;
+    }
+    if (retained->gi < 0 && staged->gi >= 0) {
+        retained->gi = staged->gi;
+    }
+    watchdog_event_merge_text(retained->src_str, staged->src_str, sizeof(retained->src_str));
+    watchdog_event_merge_text(retained->tgt_str, staged->tgt_str, sizeof(retained->tgt_str));
+    watchdog_event_merge_text(retained->t_name, staged->t_name, sizeof(retained->t_name));
+    watchdog_event_merge_text(retained->s_name, staged->s_name, sizeof(retained->s_name));
+    watchdog_event_merge_text(retained->t_mode, staged->t_mode, sizeof(retained->t_mode));
+    watchdog_event_merge_text(retained->s_mode, staged->s_mode, sizeof(retained->s_mode));
+    watchdog_event_merge_text(retained->sysid_string, staged->sysid_string, sizeof(retained->sysid_string));
+    watchdog_event_merge_text(retained->alias, staged->alias, sizeof(retained->alias));
+    watchdog_event_merge_text(retained->gps_s, staged->gps_s, sizeof(retained->gps_s));
+    watchdog_event_merge_text(retained->text_message, staged->text_message, sizeof(retained->text_message));
+    watchdog_event_merge_text(retained->internal_str, staged->internal_str, sizeof(retained->internal_str));
+    if (watchdog_event_crypto_rank(staged) > watchdog_event_crypto_rank(retained)) {
+        retained->enc = staged->enc;
+        retained->enc_alg = staged->enc_alg;
+        retained->enc_key = staged->enc_key;
+        retained->mi = staged->mi;
+    }
+    if (retained->svc == 0U && staged->svc != 0U) {
+        retained->svc = staged->svc;
+    }
+    // Regenerated by the caller from the merged fields; leaving the first segment's string
+    // would hide a merged crypto or identity change from the UI and the event log.
+    retained->event_string[0] = '\0';
+}
+
+// The first segment already logged its line. A merge that materially changed the rendered row
+// gets a continuation line in the same shape as the " Talker Alias:" / " GPS:" lines; a merge
+// that changed nothing user-visible stays silent.
+static void
+watchdog_event_log_merge_continuation(const dsd_opts* opts, const char* event_string) {
+    if (opts->event_out_file[0] == '\0' || event_string[0] == '\0') {
         return;
     }
-    lifecycle->commit_m = now_m;
-    lifecycle->commit_protocol = item->systype;
-    lifecycle->commit_category = item->category;
-    lifecycle->commit_gi = item->gi;
-    lifecycle->commit_source_id = item->source_id;
-    lifecycle->commit_target_id = item->target_id;
-    lifecycle->commit_valid = 1U;
+    FILE* event_log_file = dsd_fopen_private(opts->event_out_file, "a");
+    if (event_log_file == NULL) {
+        return;
+    }
+    DSD_FPRINTF(event_log_file, " Reacquired: %s \n", event_string);
+    fflush(event_log_file);
+    fclose(event_log_file);
 }
 
-// One transmission can be closed and reopened several times: sync loss ends the
-// canonical call, the next burst that decodes opens a fresh epoch, and the end
-// of that epoch commits the same voice row again. Repeated headers do the same
-// on protocols that re-announce a running call. Drop a voice commit that only
-// restates the row committed moments ago for the same slot -- the transmission
-// is already in history, and a second copy is the duplicate users see.
-// Bounded by time so a genuine re-key still gets its own row, and limited to
-// voice so data and control notices are never coalesced.
+// True when the staged row may be folded into the row already committed for this slot: the
+// canonical layer flagged this epoch as one sync-loss-interrupted transmission being
+// reacquired, and both rows are voice. A data staged row never merges into a voice row.
 static int
-watchdog_event_commit_repeats_previous(const dsd_call_event_lifecycle* lifecycle, const Event_History* item,
-                                       double now_m) {
-    if (lifecycle == NULL || item == NULL || !lifecycle->commit_valid) {
+watchdog_event_staged_row_merges(const Event_History_I* event_struct, const dsd_call_event_lifecycle* lifecycle,
+                                 const Event_History* staged, uint8_t retained_index) {
+    if (lifecycle == NULL || lifecycle->epoch == 0U || lifecycle->reacquired_epoch != lifecycle->epoch) {
         return 0;
     }
-    if (lifecycle->epoch == 0U || lifecycle->reacquired_epoch != lifecycle->epoch) {
+    if (retained_index == 0U || staged->category != DSD_EVENT_CATEGORY_VOICE) {
         return 0;
     }
-    if (item->category != DSD_EVENT_CATEGORY_VOICE || lifecycle->commit_category != DSD_EVENT_CATEGORY_VOICE) {
-        return 0;
-    }
-    if (item->source_id == 0U && item->target_id == 0U) {
-        return 0;
-    }
-    if (item->systype != lifecycle->commit_protocol || item->gi != lifecycle->commit_gi) {
-        return 0;
-    }
-    if (item->source_id != lifecycle->commit_source_id || item->target_id != lifecycle->commit_target_id) {
-        return 0;
-    }
-    return now_m >= lifecycle->commit_m && (now_m - lifecycle->commit_m) <= DSD_EVENT_COMMIT_REPEAT_WINDOW_S;
+    return event_struct->Event_History_Items[retained_index].category == DSD_EVENT_CATEGORY_VOICE;
 }
 
-// Commit the staged row unless it merely repeats the previous commit. Returns
-// non-zero when the row reached history.
+// Rebuild the merged row's user-legible string from its now-complete fields. Defined below,
+// beside the per-protocol builders it reuses.
+static void watchdog_event_rerender_row(const dsd_state* state, uint8_t slot, Event_History* item);
+
+// Commit the staged row, or merge it into the row this slot already committed when the
+// canonical layer says the two are the same transmission. Returns non-zero when a new row
+// reached history.
 static int
 watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History_I* event_struct, uint8_t slot,
                                  dsd_call_event_lifecycle* lifecycle, int last_event_is_data, int reset_slot_identity) {
     const Event_History* staged = &event_struct->Event_History_Items[0];
-    const double now_m = watchdog_event_now_m();
-    if (watchdog_event_commit_repeats_previous(lifecycle, staged, now_m)) {
-        // The row is already in history, but this epoch can contain newly
-        // recorded audio. Finalize it before clearing the staged metadata so
-        // the next call cannot inherit the reacquired call's samples.
+    const uint8_t retained_index = watchdog_event_committed_row_index(event_struct, lifecycle);
+    if (watchdog_event_staged_row_merges(event_struct, lifecycle, staged, retained_index)) {
+        Event_History* retained = &event_struct->Event_History_Items[retained_index];
+        char rendered_before[sizeof(retained->event_string)];
+        copy_str_field(rendered_before, retained->event_string, sizeof(rendered_before));
+        watchdog_event_merge_staged_into(retained, staged);
+        watchdog_event_rerender_row(state, slot, retained);
+        if (retained->event_string[0] == '\0') {
+            // No builder covers this protocol, so keep what the row already displayed rather
+            // than blanking a committed row.
+            copy_str_field(retained->event_string, rendered_before, sizeof(retained->event_string));
+        } else if (strncmp(retained->event_string, rendered_before, sizeof(rendered_before)) != 0) {
+            watchdog_event_log_merge_continuation(opts, retained->event_string);
+        }
+        dsd_event_history_mark_dirty(event_struct);
+        // Rotate before the staged row is cleared: close_and_rename_wav_file() reads its
+        // rename metadata from Items[0]. Each segment therefore keeps its own recording;
+        // leaving the file open would let it absorb the next transmission's audio and be
+        // exported under that call's metadata instead.
         watchdog_event_rotate_wav_if_needed(opts, event_struct, slot);
         init_event_history(event_struct, 0, 1);
         watchdog_event_reset_post_push(state);
         return 0;
     }
-    watchdog_event_note_commit(lifecycle, staged, now_m);
     watchdog_event_handle_source_transition(opts, state, event_struct, slot, watchdog_event_should_write_slot(state),
                                             last_event_is_data, reset_slot_identity);
+    if (lifecycle != NULL) {
+        lifecycle->committed_seq = event_struct->push_seq;
+        lifecycle->committed_valid = 1U;
+    }
     return 1;
 }
 
@@ -438,7 +519,10 @@ watchdog_event_history_authoritative(dsd_opts* opts, dsd_state* state, uint8_t s
     lifecycle->notice_target_id = 0U;
     lifecycle->notice_kind = DSD_CALL_KIND_UNKNOWN;
     lifecycle->notice_handled = 0U;
-    if (call->phase == DSD_CALL_PHASE_ACTIVE && call->kind != DSD_CALL_KIND_DATA
+    // A reacquired segment is the same transmission resuming, not a new one: beeping START
+    // again would leave a flapping call with several STARTs against its single END.
+    const int reacquired = lifecycle->reacquired_epoch == call->epoch;
+    if (call->phase == DSD_CALL_PHASE_ACTIVE && call->kind != DSD_CALL_KIND_DATA && !reacquired
         && dsd_call_alert_event_enabled(opts->call_alert, opts->call_alert_events, DSD_CALL_ALERT_EVENT_VOICE_START)) {
         beeper(opts, state, slot, 40, 86, 3);
     }
@@ -1024,6 +1108,81 @@ watchdog_event_current_append_policy_labels(const watchdog_event_current_ctx* ct
     }
 }
 
+// Recover the render kind a row was built from. watchdog_event_current_update_item() folds kind
+// down to gi, and the per-protocol builders only ever test for group or private, so anything
+// else maps back to plain voice.
+static dsd_call_kind
+watchdog_event_row_kind(const Event_History* item) {
+    if (item->gi == 0) {
+        return DSD_CALL_KIND_GROUP_VOICE;
+    }
+    if (item->gi == 1) {
+        return DSD_CALL_KIND_PRIVATE_VOICE;
+    }
+    return DSD_CALL_KIND_VOICE;
+}
+
+// Rebuild the render context from a history row rather than from a live call snapshot. Used
+// when a reacquired segment merges into a row already in history: the row's fields have just
+// gained information and its event_string has to say so. Protocol metadata is read back from
+// the row instead of re-derived, so this cannot disturb live per-slot state the way
+// watchdog_event_current_apply_protocol_metadata() would.
+static void
+watchdog_event_ctx_from_row(const dsd_state* state, uint8_t slot, const Event_History* item,
+                            watchdog_event_current_ctx* ctx) {
+    DSD_MEMSET(ctx, 0, sizeof(*ctx));
+    ctx->severity = (dsd_event_severity)item->severity;
+    ctx->category = (dsd_event_category)item->category;
+    // Synctype ids are stored signed and negative sentinels are meaningful, so the widening
+    // must sign-extend; the cast is explicit to say so.
+    ctx->protocol = (int)item->systype;
+    ctx->kind = watchdog_event_row_kind(item);
+    ctx->subtype = (uint8_t)item->subtype;
+    ctx->mfid = slot == 0U ? state->dmr_fid : state->dmr_fidR;
+    ctx->source_id = item->source_id;
+    ctx->target_id = item->target_id;
+    ctx->svc_opts = item->svc;
+    ctx->enc = item->enc;
+    ctx->alg_id = item->enc_alg;
+    ctx->key_id = item->enc_key;
+    ctx->mi = item->mi;
+    ctx->channel = item->channel;
+    ctx->sys_id1 = item->sys_id1;
+    ctx->sys_id2 = item->sys_id2;
+    ctx->sys_id3 = item->sys_id3;
+    ctx->sys_id4 = item->sys_id4;
+    ctx->sys_id5 = item->sys_id5;
+    DSD_SNPRINTF(ctx->sysid_string, sizeof(ctx->sysid_string), "%s", item->sysid_string);
+    DSD_SNPRINTF(ctx->src_str, sizeof(ctx->src_str), "%s", item->src_str);
+    DSD_SNPRINTF(ctx->tgt_str, sizeof(ctx->tgt_str), "%s", item->tgt_str);
+    DSD_SNPRINTF(ctx->t_name, sizeof(ctx->t_name), "%s", item->t_name);
+    DSD_SNPRINTF(ctx->s_name, sizeof(ctx->s_name), "%s", item->s_name);
+    DSD_SNPRINTF(ctx->t_mode, sizeof(ctx->t_mode), "%s", item->t_mode);
+    DSD_SNPRINTF(ctx->s_mode, sizeof(ctx->s_mode), "%s", item->s_mode);
+    ctx->t_name_loaded = item->t_name[0] != '\0' ? 1U : 0U;
+    ctx->s_name_loaded = item->s_name[0] != '\0' ? 1U : 0U;
+}
+
+static void
+watchdog_event_rerender_row(const dsd_state* state, uint8_t slot, Event_History* item) {
+    watchdog_event_current_ctx ctx;
+    watchdog_event_ctx_from_row(state, slot, item, &ctx);
+
+    char timestr[9];
+    char datestr[11];
+    // The row's own timestamp, not the merge instant: it still describes the transmission
+    // that opened at the first commit.
+    (void)dsd_format_local_datetime(item->event_time, DSD_LOCAL_DATETIME_TIME_COLON, timestr, sizeof timestr);
+    (void)dsd_format_local_datetime(item->event_time, DSD_LOCAL_DATETIME_DATE_HYPHEN, datestr, sizeof datestr);
+
+    char event_string[2000];
+    DSD_MEMSET(event_string, 0, sizeof(event_string));
+    watchdog_event_current_build_event_string(state, &ctx, datestr, timestr, dsd_synctype_to_string(ctx.protocol),
+                                              event_string, sizeof(event_string));
+    watchdog_event_current_append_policy_labels(&ctx, event_string, sizeof(event_string));
+    DSD_SNPRINTF(item->event_string, sizeof(item->event_string), "%s", event_string);
+}
+
 static int
 watchdog_event_current_args_valid(const dsd_opts* opts, const dsd_state* state, uint8_t slot) {
     return opts != NULL && state != NULL && state->event_history_s != NULL && slot <= 1U;
@@ -1057,6 +1216,9 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
         return;
     }
     if (watchdog_event_item_has_content(&event_struct->Event_History_Items[0])) {
+        // Either outcome puts this epoch's information into history -- a new row, or merged
+        // into the row the interrupted transmission already owns. The empty-staged-row branch
+        // has nothing to commit; enrichment resolves that case by push sequence and declines.
         (void)watchdog_event_commit_staged_row((dsd_opts*)opts, state, event_struct, slot, lifecycle,
                                                call->kind == DSD_CALL_KIND_DATA, 1);
     } else {
@@ -1241,8 +1403,14 @@ dsd_event_emit_call_notice_impl(dsd_opts* opts, dsd_state* state, uint8_t slot, 
     watchdog_event_handle_source_transition_ex(opts, state, event_struct, slot, watchdog_event_should_write_slot(state),
                                                call->kind == DSD_CALL_KIND_DATA, finalize_call, finalize_call);
     watchdog_event_notice_mark_handled(lifecycle, call);
-    if (canonical_lifecycle != NULL && call->phase == DSD_CALL_PHASE_ENDED) {
-        canonical_lifecycle->ended_committed = 1U;
+    if (canonical_lifecycle != NULL) {
+        // This push carried the canonical epoch's row into history, so it becomes the row a
+        // reacquired segment merges into and the row enrichment targets.
+        canonical_lifecycle->committed_seq = event_struct->push_seq;
+        canonical_lifecycle->committed_valid = 1U;
+        if (call->phase == DSD_CALL_PHASE_ENDED) {
+            canonical_lifecycle->ended_committed = 1U;
+        }
     }
     watchdog_event_unlock_if_present(ext);
     return 1;
@@ -1283,7 +1451,17 @@ dsd_event_enrich_epoch(dsd_state* state, uint8_t slot, uint64_t epoch, const cha
         dsd_call_state_ext_unlock(ext);
         return 0;
     }
-    const uint8_t history_index = lifecycle->epoch == epoch && lifecycle->ended_committed ? 1U : 0U;
+    // While the epoch is still staging, enrichment belongs on row 0. Once its row has been
+    // committed the row has to be located by push sequence: an interleaved data or system
+    // notice pushes it deeper than index 1.
+    uint8_t history_index = 0U;
+    if (lifecycle->epoch == epoch && lifecycle->ended_committed) {
+        history_index = watchdog_event_committed_row_index(&state->event_history_s[slot], lifecycle);
+        if (history_index == 0U) {
+            dsd_call_state_ext_unlock(ext);
+            return 0;
+        }
+    }
     Event_History* item = &state->event_history_s[slot].Event_History_Items[history_index];
     if (kind == DSD_EVENT_ENRICH_ALIAS) {
         DSD_SNPRINTF(item->alias, sizeof(item->alias), "%s", value);
@@ -1311,6 +1489,28 @@ dsd_event_enrich_gps(dsd_state* state, uint8_t slot, uint64_t epoch, const char*
 int
 dsd_event_enrich_text(dsd_state* state, uint8_t slot, uint64_t epoch, const char* text) {
     return dsd_event_enrich_epoch(state, slot, epoch, text, DSD_EVENT_ENRICH_TEXT);
+}
+
+void
+dsd_event_history_reset(dsd_state* state) {
+    if (state == NULL || state->event_history_s == NULL) {
+        return;
+    }
+    (void)dsd_call_state_ensure(state);
+    dsd_event_history_transaction transaction;
+    dsd_event_history_transaction_begin(state, &transaction);
+    // The transaction already holds the call-state mutex that guards ext->events, so the rows
+    // and the bookkeeping that points into them are cleared together.
+    dsd_call_state_ext* ext = dsd_call_state_ext_get(state, 0);
+    for (uint8_t slot = 0; slot < 2U; slot++) {
+        init_event_history(&state->event_history_s[slot], 0, 255);
+        if (ext != NULL) {
+            ext->events[slot].committed_seq = 0U;
+            ext->events[slot].committed_valid = 0U;
+            ext->events[slot].reacquired_epoch = 0U;
+        }
+    }
+    dsd_event_history_transaction_end(&transaction);
 }
 
 int

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -22,6 +22,7 @@
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/core/time_format.h>
 #include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/timing.h>
 #include <dsd-neo/protocol/edacs/edacs_afs.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -38,6 +39,10 @@ enum {
     DSD_EVENT_SUBTYPE_DMR_DATA_BURST = 6,
     DSD_EVENT_SUBTYPE_EXPLICIT_DATA = INT8_MAX,
 };
+
+// Seconds within which a repeated voice commit is treated as the transmission
+// already in history rather than a new one.
+#define DSD_EVENT_COMMIT_REPEAT_WINDOW_S 1.0
 
 // Safe bounded copy helper that tolerates potential overlap
 static inline void
@@ -293,6 +298,71 @@ watchdog_event_handle_source_transition(dsd_opts* opts, dsd_state* state, Event_
                                                reset_slot_identity, 1);
 }
 
+static double
+watchdog_event_now_m(void) {
+    return (double)dsd_time_monotonic_ms() / 1000.0;
+}
+
+static void
+watchdog_event_note_commit(dsd_call_event_lifecycle* lifecycle, const Event_History* item, double now_m) {
+    if (lifecycle == NULL || item == NULL) {
+        return;
+    }
+    lifecycle->commit_m = now_m;
+    lifecycle->commit_protocol = item->systype;
+    lifecycle->commit_category = item->category;
+    lifecycle->commit_gi = item->gi;
+    lifecycle->commit_source_id = item->source_id;
+    lifecycle->commit_target_id = item->target_id;
+    lifecycle->commit_valid = 1U;
+}
+
+// One transmission can be closed and reopened several times: sync loss ends the
+// canonical call, the next burst that decodes opens a fresh epoch, and the end
+// of that epoch commits the same voice row again. Repeated headers do the same
+// on protocols that re-announce a running call. Drop a voice commit that only
+// restates the row committed moments ago for the same slot -- the transmission
+// is already in history, and a second copy is the duplicate users see.
+// Bounded by time so a genuine re-key still gets its own row, and limited to
+// voice so data and control notices are never coalesced.
+static int
+watchdog_event_commit_repeats_previous(const dsd_call_event_lifecycle* lifecycle, const Event_History* item,
+                                       double now_m) {
+    if (lifecycle == NULL || item == NULL || !lifecycle->commit_valid) {
+        return 0;
+    }
+    if (item->category != DSD_EVENT_CATEGORY_VOICE || lifecycle->commit_category != DSD_EVENT_CATEGORY_VOICE) {
+        return 0;
+    }
+    if (item->source_id == 0U && item->target_id == 0U) {
+        return 0;
+    }
+    if (item->systype != lifecycle->commit_protocol || item->gi != lifecycle->commit_gi) {
+        return 0;
+    }
+    if (item->source_id != lifecycle->commit_source_id || item->target_id != lifecycle->commit_target_id) {
+        return 0;
+    }
+    return now_m >= lifecycle->commit_m && (now_m - lifecycle->commit_m) <= DSD_EVENT_COMMIT_REPEAT_WINDOW_S;
+}
+
+// Commit the staged row unless it merely repeats the previous commit. Returns
+// non-zero when the row reached history.
+static int
+watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History_I* event_struct, uint8_t slot,
+                                 dsd_call_event_lifecycle* lifecycle, int last_event_is_data, int reset_slot_identity) {
+    const Event_History* staged = &event_struct->Event_History_Items[0];
+    const double now_m = watchdog_event_now_m();
+    if (watchdog_event_commit_repeats_previous(lifecycle, staged, now_m)) {
+        init_event_history(event_struct, 0, 1);
+        return 0;
+    }
+    watchdog_event_note_commit(lifecycle, staged, now_m);
+    watchdog_event_handle_source_transition(opts, state, event_struct, slot, watchdog_event_should_write_slot(state),
+                                            last_event_is_data, reset_slot_identity);
+    return 1;
+}
+
 static int
 watchdog_event_call_is_authoritative(const dsd_call_snapshot* call, const dsd_call_event_lifecycle* lifecycle) {
     if (call == NULL || call->epoch == 0U) {
@@ -348,9 +418,8 @@ watchdog_event_history_authoritative(dsd_opts* opts, dsd_state* state, uint8_t s
     const int has_content = watchdog_event_item_has_content(current);
     const int promotes_current = lifecycle->epoch == 0U && watchdog_event_history_matches_call(current, call);
     if (has_content && !promotes_current) {
-        const int is_data = watchdog_event_is_data_event(current);
-        watchdog_event_handle_source_transition(opts, state, event_struct, slot,
-                                                watchdog_event_should_write_slot(state), is_data, 0);
+        (void)watchdog_event_commit_staged_row(opts, state, event_struct, slot, lifecycle,
+                                               watchdog_event_is_data_event(current), 0);
     } else if (has_content) {
         init_event_history(event_struct, 0, 1);
     }
@@ -980,9 +1049,8 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
         return;
     }
     if (watchdog_event_item_has_content(&event_struct->Event_History_Items[0])) {
-        watchdog_event_handle_source_transition((dsd_opts*)opts, state, event_struct, slot,
-                                                watchdog_event_should_write_slot(state),
-                                                call->kind == DSD_CALL_KIND_DATA, 1);
+        (void)watchdog_event_commit_staged_row((dsd_opts*)opts, state, event_struct, slot, lifecycle,
+                                               call->kind == DSD_CALL_KIND_DATA, 1);
     } else {
         init_event_history(event_struct, 0, 1);
     }

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -309,6 +309,19 @@ watchdog_event_handle_source_transition(dsd_opts* opts, dsd_state* state, Event_
                                                reset_slot_identity, DSD_EVENT_END_FINAL);
 }
 
+// True when the epoch this slot holds a VOICE_END for has since been positively terminated: a
+// terminator or EOT decoded after the sync-loss end and tightened the reason to EXPLICIT. The
+// reacquisition window is what the alert was waiting on, and that permission is now retracted,
+// so there is nothing left to wait for.
+static int
+watchdog_event_end_is_positively_terminated(const dsd_call_snapshot* call, const dsd_call_event_lifecycle* lifecycle) {
+    if (call == NULL || lifecycle == NULL || !lifecycle->end_alert_pending) {
+        return 0;
+    }
+    return call->phase == DSD_CALL_PHASE_ENDED && call->epoch != 0U && call->epoch == lifecycle->epoch
+           && call->end_reason == (uint8_t)DSD_CALL_END_EXPLICIT;
+}
+
 // Emit a VOICE_END alert that was held open across a possible reacquisition. `force` retires it
 // immediately -- used when a genuinely new call is about to start on the slot, so the previous
 // transmission's END is heard before the new one's START rather than interrupting it.
@@ -1537,7 +1550,12 @@ dsd_event_sync_slot(dsd_opts* opts, dsd_state* state, uint8_t slot) {
     watchdog_event_current_impl(opts, state, slot, call, lifecycle, 1);
     // This runs on every frame-sync pass, so it is also where a VOICE_END alert held open across
     // a possible reacquisition is finally emitted once that window has closed with no resumption.
-    watchdog_event_flush_pending_end_alert(opts, state, slot, lifecycle, 0);
+    // A terminator that decoded after the sync-loss end retracts the reacquisition permission by
+    // tightening the reason to EXPLICIT; the hold has nothing left to wait for, so it retires now
+    // rather than a further half second later. Read from canonical state rather than signalled
+    // from it: call_state.c does not know the event layer exists.
+    watchdog_event_flush_pending_end_alert(opts, state, slot, lifecycle,
+                                           watchdog_event_end_is_positively_terminated(call, lifecycle));
     dsd_call_state_ext_unlock(ext);
 }
 

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -163,41 +163,66 @@ push_event_history(Event_History_I* event_struct) {
     dsd_event_history_mark_dirty(event_struct);
 }
 
-void
-write_event_to_log_file(const dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite,
-                        char* event_string) //pass completed event string here that is in the struct
-{
+// Optional per-row detail written as its own event-log line. Tracked across a merge so a
+// continuation can report exactly what the reacquired segment contributed.
+typedef struct {
+    uint8_t alias;
+    uint8_t gps;
+    uint8_t text_message;
+    uint8_t internal;
+} watchdog_event_merge_added;
 
-    //open log file
-    FILE* event_log_file;
-    event_log_file = dsd_fopen_private(opts->event_out_file, "a");
-
-    if (event_log_file != NULL) {
-        DSD_FPRINTF(event_log_file, "%s ", event_string);
+// One event-log entry: the rendered line, then whichever optional detail lines apply. A row's
+// first commit and a reacquired segment's continuation are the same entry shape, so they share
+// one writer and the log format keeps a single source of truth.
+//
+// `event_string` NULL suppresses the rendered line, for a continuation that only has new detail
+// to report. `prefix` marks the entry as a continuation. `selection` limits the detail lines to
+// what the caller just learned; NULL writes every non-empty one.
+static void
+watchdog_event_write_log_entry(const dsd_opts* opts, uint8_t slot, uint8_t swrite, const char* prefix,
+                               const char* event_string, const Event_History* row,
+                               const watchdog_event_merge_added* selection) {
+    if (opts->event_out_file[0] == '\0') {
+        return;
+    }
+    FILE* event_log_file = dsd_fopen_private(opts->event_out_file, "a");
+    if (event_log_file == NULL) {
+        return;
+    }
+    if (event_string != NULL) {
+        DSD_FPRINTF(event_log_file, "%s%s ", prefix != NULL ? prefix : "", event_string);
         if (swrite == 1) {
             DSD_FPRINTF(event_log_file, "Slot %d; ", slot + 1);
         }
         DSD_FPRINTF(event_log_file, "\n");
-
-        if (state->event_history_s[slot].Event_History_Items[0].text_message[0] != '\0') {
-            DSD_FPRINTF(event_log_file, "%s \n", state->event_history_s[slot].Event_History_Items[0].text_message);
-        }
-        if (state->event_history_s[slot].Event_History_Items[0].alias[0] != '\0') {
-            DSD_FPRINTF(event_log_file, " Talker Alias: %s \n",
-                        state->event_history_s[slot].Event_History_Items[0].alias);
-        }
-        if (state->event_history_s[slot].Event_History_Items[0].gps_s[0] != '\0') {
-            DSD_FPRINTF(event_log_file, " GPS: %s \n", state->event_history_s[slot].Event_History_Items[0].gps_s);
-        }
-        if (state->event_history_s[slot].Event_History_Items[0].internal_str[0] != '\0') {
-            DSD_FPRINTF(event_log_file, " DSD-neo: %s \n",
-                        state->event_history_s[slot].Event_History_Items[0].internal_str);
-        }
-
-        //flush and close log file
-        fflush(event_log_file);
-        fclose(event_log_file);
     }
+    if (selection != NULL ? selection->text_message != 0U : row->text_message[0] != '\0') {
+        DSD_FPRINTF(event_log_file, "%s \n", row->text_message);
+    }
+    if (selection != NULL ? selection->alias != 0U : row->alias[0] != '\0') {
+        DSD_FPRINTF(event_log_file, " Talker Alias: %s \n", row->alias);
+    }
+    if (selection != NULL ? selection->gps != 0U : row->gps_s[0] != '\0') {
+        DSD_FPRINTF(event_log_file, " GPS: %s \n", row->gps_s);
+    }
+    if (selection != NULL ? selection->internal != 0U : row->internal_str[0] != '\0') {
+        DSD_FPRINTF(event_log_file, " DSD-neo: %s \n", row->internal_str);
+    }
+    fflush(event_log_file);
+    fclose(event_log_file);
+}
+
+void
+write_event_to_log_file(const dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite,
+                        const char* event_string) //pass completed event string here that is in the struct
+{
+    // The rendered line comes from the caller while the optional detail lines come from the
+    // slot's staged row. The two are usually the same row and occasionally are not; preserved as
+    // it stands rather than unified, since callers rely on passing a line for an already-pushed
+    // row.
+    watchdog_event_write_log_entry(opts, slot, swrite, NULL, event_string,
+                                   &state->event_history_s[slot].Event_History_Items[0], NULL);
 }
 
 static uint8_t
@@ -408,15 +433,6 @@ watchdog_event_merge_text_progressive(char* retained, const char* staged, size_t
     return 1;
 }
 
-// Optional per-row detail the normal commit path writes as its own event-log line. Tracked across
-// a merge so the continuation can report exactly what the reacquired segment contributed.
-typedef struct {
-    uint8_t alias;
-    uint8_t gps;
-    uint8_t text_message;
-    uint8_t internal;
-} watchdog_event_merge_added;
-
 // Rank crypto knowledge so a later segment can upgrade the retained row but never
 // downgrade it: a segment that decoded the PI/ESS header knows more than the late-entry
 // segment that had to assume clear.
@@ -512,44 +528,19 @@ watchdog_event_merge_staged_into(Event_History* retained, const Event_History* s
 }
 
 // The first segment already logged its line, so a merge appends a continuation rather than a new
-// entry. It carries the same slot annotation and the same optional-detail lines a normal commit
-// writes through write_event_to_log_file(), so a reader can attribute the continuation to a slot
-// and nothing a reacquired segment decoded is visible in the UI but missing from the log.
+// entry. Same writer as a normal commit, so it carries the same slot annotation and the same
+// optional-detail lines: nothing a reacquired segment decoded is visible in the UI but missing
+// from the log. Only what this segment actually contributed is reported.
 static void
 watchdog_event_log_merge_continuation(const dsd_opts* opts, uint8_t slot, uint8_t swrite, const Event_History* retained,
-                                      const char* event_string, const watchdog_event_merge_added* added,
-                                      int rendered_changed) {
-    if (opts->event_out_file[0] == '\0') {
-        return;
-    }
+                                      const watchdog_event_merge_added* added, int rendered_changed) {
     if (!rendered_changed && !added->alias && !added->gps && !added->text_message && !added->internal) {
         return;
     }
-    FILE* event_log_file = dsd_fopen_private(opts->event_out_file, "a");
-    if (event_log_file == NULL) {
-        return;
-    }
-    if (rendered_changed && event_string[0] != '\0') {
-        DSD_FPRINTF(event_log_file, " Reacquired: %s ", event_string);
-        if (swrite == 1) {
-            DSD_FPRINTF(event_log_file, "Slot %d; ", slot + 1);
-        }
-        DSD_FPRINTF(event_log_file, "\n");
-    }
-    if (added->text_message) {
-        DSD_FPRINTF(event_log_file, "%s \n", retained->text_message);
-    }
-    if (added->alias) {
-        DSD_FPRINTF(event_log_file, " Talker Alias: %s \n", retained->alias);
-    }
-    if (added->gps) {
-        DSD_FPRINTF(event_log_file, " GPS: %s \n", retained->gps_s);
-    }
-    if (added->internal) {
-        DSD_FPRINTF(event_log_file, " DSD-neo: %s \n", retained->internal_str);
-    }
-    fflush(event_log_file);
-    fclose(event_log_file);
+    // A re-render that produced no string, or one identical to what the row already showed, has
+    // nothing new to say; the detail lines below may still.
+    const char* rendered = (rendered_changed && retained->event_string[0] != '\0') ? retained->event_string : NULL;
+    watchdog_event_write_log_entry(opts, slot, swrite, " Reacquired: ", rendered, retained, added);
 }
 
 // True when the staged row may be folded into the row already committed for this slot: the
@@ -575,8 +566,9 @@ watchdog_event_staged_row_merges(const Event_History_I* event_struct, const dsd_
 }
 
 // Rebuild the merged row's user-legible string from its now-complete fields. Returns non-zero
-// when a string could be produced. Defined below, beside the per-protocol builders it reuses.
-static int watchdog_event_rerender_row(const dsd_call_event_render_env* env, Event_History* item);
+// when a string could be produced, and sets *changed when that string differs from the one the
+// row already carried. Defined below, beside the per-protocol builders it reuses.
+static int watchdog_event_rerender_row(const dsd_call_event_render_env* env, Event_History* item, int* changed);
 
 // Commit the staged row, or merge it into the row this slot already committed when the
 // canonical layer says the two are the same transmission. Returns non-zero when a new row
@@ -589,17 +581,14 @@ watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History
     const uint8_t retained_index = watchdog_event_committed_row_index(event_struct, lifecycle);
     if (watchdog_event_staged_row_merges(event_struct, lifecycle, staged, retained_index)) {
         Event_History* retained = &event_struct->Event_History_Items[retained_index];
-        char rendered_before[sizeof(retained->event_string)];
-        copy_str_field(rendered_before, retained->event_string, sizeof(rendered_before));
         watchdog_event_merge_added added;
         watchdog_event_merge_staged_into(retained, staged, &added);
         // Re-render against the environment the row was committed under, not the live decoder.
         // A protocol with no builder, or a row with no recoverable timestamp, keeps its string.
-        const int rerendered = watchdog_event_rerender_row(&lifecycle->committed_env, retained);
-        const int rendered_changed =
-            rerendered && strncmp(retained->event_string, rendered_before, sizeof(rendered_before)) != 0;
-        watchdog_event_log_merge_continuation(opts, slot, watchdog_event_should_write_slot(state), retained,
-                                              retained->event_string, &added, rendered_changed);
+        int rendered_changed = 0;
+        (void)watchdog_event_rerender_row(&lifecycle->committed_env, retained, &rendered_changed);
+        watchdog_event_log_merge_continuation(opts, slot, watchdog_event_should_write_slot(state), retained, &added,
+                                              rendered_changed);
         dsd_event_history_mark_dirty(event_struct);
         // The merged row is now this epoch's row too, so late enrichment for the reacquired
         // epoch resolves to it and the next segment in the chain has a valid merge target.
@@ -1402,9 +1391,12 @@ watchdog_event_row_datetime(const Event_History* item, char* datestr, size_t dat
 }
 
 static int
-watchdog_event_rerender_row(const dsd_call_event_render_env* env, Event_History* item) {
+watchdog_event_rerender_row(const dsd_call_event_render_env* env, Event_History* item, int* changed) {
     char timestr[9];
     char datestr[11];
+    if (changed != NULL) {
+        *changed = 0;
+    }
     // The row's own timestamp, not the merge instant: it still describes the transmission
     // that opened at the first commit. Without a trustworthy one, leave the row as it stands
     // rather than restamping it with an invented time.
@@ -1422,6 +1414,11 @@ watchdog_event_rerender_row(const dsd_call_event_render_env* env, Event_History*
     watchdog_event_current_append_policy_labels(&ctx, event_string, sizeof(event_string));
     if (event_string[0] == '\0') {
         return 0;
+    }
+    // Compared here, against the buffer that already exists, so the caller does not have to keep
+    // a second full-size copy of the row's string alive across the merge.
+    if (changed != NULL) {
+        *changed = strncmp(item->event_string, event_string, sizeof(item->event_string)) != 0;
     }
     DSD_SNPRINTF(item->event_string, sizeof(item->event_string), "%s", event_string);
     return 1;
@@ -1463,9 +1460,12 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
     // alert is held until the reacquisition window closes. Each further segment re-arms it, and
     // the alert lands once the call really has stopped flapping. An explicit terminator is
     // unambiguous and alerts immediately.
-    const int deferred_end =
-        call->end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS && call->kind != DSD_CALL_KIND_DATA
-        && dsd_call_alert_event_enabled(opts->call_alert, opts->call_alert_events, DSD_CALL_ALERT_EVENT_VOICE_END);
+    //
+    // This describes what happened on the air, so it is derived from the air alone. Whether the
+    // operator wants to hear the result is a separate question, answered where the beep is
+    // actually emitted -- folding the alert setting in here would make a disposition that other
+    // side effects hang off silently change with an unrelated preference.
+    const int deferred_end = call->end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS && call->kind != DSD_CALL_KIND_DATA;
     const dsd_event_end_disposition disposition = deferred_end ? DSD_EVENT_END_DEFERRED : DSD_EVENT_END_FINAL;
     if (watchdog_event_item_has_content(&event_struct->Event_History_Items[0])) {
         // Either outcome puts this epoch's information into history -- a new row, or merged
@@ -1591,8 +1591,8 @@ dsd_event_flush_pending_alerts(dsd_opts* opts, dsd_state* state) {
         return;
     }
     dsd_call_state_ext_lock(ext);
-    for (uint8_t slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
-        watchdog_event_flush_pending_end_alert(opts, state, slot, &ext->events[slot], 1);
+    for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
+        watchdog_event_flush_pending_end_alert(opts, state, (uint8_t)slot, &ext->events[slot], 1);
     }
     dsd_call_state_ext_unlock(ext);
 }
@@ -1802,7 +1802,7 @@ dsd_event_history_reset(dsd_state* state) {
     // The transaction already holds the call-state mutex that guards ext->events, so the rows
     // and the bookkeeping that points into them are cleared together.
     dsd_call_state_ext* ext = dsd_call_state_ext_get(state, 0);
-    for (uint8_t slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
+    for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
         init_event_history(&state->event_history_s[slot], 0, 255);
         if (ext != NULL) {
             // epoch and ended_committed are deliberately left alone. They say which call the slot

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -225,9 +225,15 @@ write_event_to_log_file(const dsd_opts* opts, dsd_state* state, uint8_t slot, ui
                                    &state->event_history_s[slot].Event_History_Items[0], NULL);
 }
 
+// Only the two-slot protocols annotate their log lines with a slot number.
+static uint8_t
+watchdog_event_should_write_systype(int systype) {
+    return (DSD_SYNC_IS_DMR_BS(systype) || DSD_SYNC_IS_P25P2(systype)) ? 1u : 0u;
+}
+
 static uint8_t
 watchdog_event_should_write_slot(const dsd_state* state) {
-    return (DSD_SYNC_IS_DMR_BS(state->lastsynctype) || DSD_SYNC_IS_P25P2(state->lastsynctype)) ? 1u : 0u;
+    return watchdog_event_should_write_systype(state->lastsynctype);
 }
 
 static int
@@ -310,9 +316,7 @@ static void
 watchdog_event_handle_source_transition_ex(dsd_opts* opts, dsd_state* state, Event_History_I* event_struct,
                                            uint8_t slot, uint8_t swrite, int last_event_is_data,
                                            int reset_slot_identity, dsd_event_end_disposition end_disposition) {
-    if (opts->event_out_file[0] != 0) {
-        write_event_to_log_file(opts, state, slot, swrite, event_struct->Event_History_Items[0].event_string);
-    }
+    write_event_to_log_file(opts, state, slot, swrite, event_struct->Event_History_Items[0].event_string);
 
     event_struct->Event_History_Items[0].write = 1;
     if (end_disposition != DSD_EVENT_END_NONE) {
@@ -553,10 +557,18 @@ watchdog_event_staged_row_merges(const Event_History_I* event_struct, const dsd_
     if (lifecycle == NULL || lifecycle->epoch == 0U || lifecycle->reacquired_epoch != lifecycle->epoch) {
         return 0;
     }
+    // Two rows are legitimate targets. The row the interrupted epoch committed is the one this
+    // segment is resuming. This epoch's own row is the second: once a commit lands -- a merge, or a
+    // push because the interrupted epoch never got a row of its own -- every later commit in the
+    // same epoch is still the same transmission and belongs in it. Without that case an epoch that
+    // commits twice, as a mid-segment call notice followed by its end does, would push a duplicate.
+    //
     // The reopened epoch may have ended without ever pushing a row -- it staged nothing, or a
-    // reset intervened -- in which case committed_epoch still names something older. Folding into
-    // that would put this transmission inside an unrelated call's row, so commit a new one.
-    if (!lifecycle->committed_valid || lifecycle->committed_epoch != lifecycle->reacquired_from_epoch) {
+    // reset intervened -- in which case committed_epoch names something older than either. Folding
+    // into that would put this transmission inside an unrelated call's row, so commit a new one.
+    if (!lifecycle->committed_valid
+        || (lifecycle->committed_epoch != lifecycle->reacquired_from_epoch
+            && lifecycle->committed_epoch != lifecycle->epoch)) {
         return 0;
     }
     if (retained_index == 0U || staged->category != DSD_EVENT_CATEGORY_VOICE) {
@@ -587,8 +599,12 @@ watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History
         // A protocol with no builder, or a row with no recoverable timestamp, keeps its string.
         int rendered_changed = 0;
         (void)watchdog_event_rerender_row(&lifecycle->committed_env, retained, &rendered_changed);
-        watchdog_event_log_merge_continuation(opts, slot, watchdog_event_should_write_slot(state), retained, &added,
-                                              rendered_changed);
+        // Annotation taken from the row, not from the live decoder: by the time a reacquired
+        // segment merges, lastsynctype may name a system the decoder moved on to, or have been
+        // cleared entirely by no_carrier_reset_decode_state(). The row's own systype is what its
+        // first commit was annotated from, so both halves of one transmission agree in the log.
+        watchdog_event_log_merge_continuation(opts, slot, watchdog_event_should_write_systype(retained->systype),
+                                              retained, &added, rendered_changed);
         dsd_event_history_mark_dirty(event_struct);
         // The merged row is now this epoch's row too, so late enrichment for the reacquired
         // epoch resolves to it and the next segment in the chain has a valid merge target.
@@ -1375,13 +1391,21 @@ watchdog_event_row_datetime(const Event_History* item, char* datestr, size_t dat
     }
 
     // "YYYY-MM-DD HH:MM:SS": separators at offsets 4, 7, 10, 13, 16; digits everywhere else.
-    static const char kSeparators[19] = {0, 0, 0, 0, '-', 0, 0, '-', 0, 0, ' ', 0, 0, ':', 0, 0, ':', 0, 0};
+    static const char k_watchdog_event_datetime_separators[19] = {0,   0, 0, 0,   '-', 0, 0,   '-', 0, 0,
+                                                                  ' ', 0, 0, ':', 0,   0, ':', 0,   0};
     const char* s = item->event_string;
-    if (datestr_size < 11U || timestr_size < 9U || strnlen(s, sizeof(item->event_string)) < 19U) {
+
+    // Field widths of the prefix, including the terminator each is written with -- not the caller's
+    // buffer capacities. The size parameters below only reject a buffer too small to hold a field;
+    // widening one must not copy more of the timestamp than the field itself.
+    enum { k_datestr_len = 11U, k_timestr_len = 9U };
+
+    if (datestr_size < k_datestr_len || timestr_size < k_timestr_len || strnlen(s, sizeof(item->event_string)) < 19U) {
         return 0;
     }
     for (size_t i = 0; i < 19U; i++) {
-        if (kSeparators[i] != 0 ? s[i] != kSeparators[i] : !watchdog_event_char_is_digit(s[i])) {
+        if (k_watchdog_event_datetime_separators[i] != 0 ? s[i] != k_watchdog_event_datetime_separators[i]
+                                                         : !watchdog_event_char_is_digit(s[i])) {
             return 0;
         }
     }
@@ -1473,16 +1497,21 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
         // has nothing to commit; enrichment resolves that case by push sequence and declines.
         (void)watchdog_event_commit_staged_row((dsd_opts*)opts, state, event_struct, slot, lifecycle,
                                                call->kind == DSD_CALL_KIND_DATA, 1, disposition);
+        if (deferred_end) {
+            // Armed only where a row reached history, which is what makes this the same rule the
+            // FINAL disposition follows: its alert is emitted inside the commit above, so it too
+            // cannot fire for a staged row with nothing in it. A protocol that renders no event
+            // string -- X2-TDMA has no builder -- would otherwise beep the end of a transmission
+            // the operator never saw.
+            lifecycle->end_alert_pending = 1U;
+            // Deliberately the local monotonic clock rather than call->ended_m: the deadline is
+            // only ever compared against this same clock, and ended_m carries whatever timeline
+            // the caller supplied. In production the two coincide; keeping both endpoints on one
+            // clock means a caller-supplied timeline can never make the alert fire early.
+            lifecycle->end_alert_due_m = dsd_time_now_monotonic_s() + DSD_CALL_REACQUIRE_GAP_S;
+        }
     } else {
         init_event_history(event_struct, 0, 1);
-    }
-    if (deferred_end) {
-        lifecycle->end_alert_pending = 1U;
-        // Deliberately the local monotonic clock rather than call->ended_m: the deadline is only
-        // ever compared against this same clock, and ended_m carries whatever timeline the caller
-        // supplied. In production the two coincide; keeping both endpoints on one clock means a
-        // caller-supplied timeline can never make the alert fire early.
-        lifecycle->end_alert_due_m = dsd_time_now_monotonic_s() + DSD_CALL_REACQUIRE_GAP_S;
     }
     lifecycle->ended_committed = 1U;
 }
@@ -2007,9 +2036,7 @@ dsd_event_emit_data_notice_impl(dsd_opts* opts, dsd_state* state, uint8_t slot, 
     (void)dsd_format_local_datetime(item->event_time, DSD_LOCAL_DATETIME_DATE_HYPHEN, datestr, sizeof datestr);
     DSD_SNPRINTF(item->event_string, sizeof(item->event_string), "%s %s %s", datestr, timestr, notice);
 
-    if (opts->event_out_file[0] != '\0') {
-        write_event_to_log_file(opts, state, slot, 0U, item->event_string);
-    }
+    write_event_to_log_file(opts, state, slot, 0U, item->event_string);
     push_event_history(event_struct);
     DSD_MEMCPY(&event_struct->Event_History_Items[0], &active, sizeof(active));
     dsd_event_history_mark_dirty(event_struct);
@@ -2083,9 +2110,7 @@ dsd_event_emit_system_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, con
     (void)dsd_format_local_datetime(item->event_time, DSD_LOCAL_DATETIME_DATE_HYPHEN, datestr, sizeof datestr);
     DSD_SNPRINTF(item->event_string, sizeof(item->event_string), "%s %s %s", datestr, timestr, notice);
 
-    if (opts->event_out_file[0] != '\0') {
-        write_event_to_log_file(opts, state, slot, 0U, item->event_string);
-    }
+    write_event_to_log_file(opts, state, slot, 0U, item->event_string);
     push_event_history(event_struct);
     DSD_MEMCPY(&event_struct->Event_History_Items[0], &active, sizeof(active));
     dsd_event_history_mark_dirty(event_struct);

--- a/src/core/util/edacs_afs.c
+++ b/src/core/util/edacs_afs.c
@@ -10,23 +10,28 @@
 #include "dsd-neo/core/state_fwd.h"
 
 static int
-isCustomAfsString(const dsd_state* state) {
-    return state->edacs_a_bits != 4 || state->edacs_f_bits != 4 || state->edacs_s_bits != 3;
+isCustomAfsBits(int a_bits, int f_bits, int s_bits) {
+    return a_bits != 4 || f_bits != 4 || s_bits != 3;
 }
 
 int
-getAfsStringLength(const dsd_state* state) {
-    if (!isCustomAfsString(state)) {
+getAfsStringLengthFromBits(int a_bits, int f_bits, int s_bits) {
+    if (!isCustomAfsBits(a_bits, f_bits, s_bits)) {
         return 6;
     }
 
     int length = 0;
-    length += (state->edacs_a_bits + 2) / 3;
-    length += (state->edacs_f_bits + 2) / 3;
-    length += (state->edacs_s_bits + 2) / 3;
+    length += (a_bits + 2) / 3;
+    length += (f_bits + 2) / 3;
+    length += (s_bits + 2) / 3;
     length += 2;
 
     return length;
+}
+
+int
+getAfsStringLength(const dsd_state* state) {
+    return getAfsStringLengthFromBits(state->edacs_a_bits, state->edacs_f_bits, state->edacs_s_bits);
 }
 
 static int
@@ -59,19 +64,19 @@ edacs_append_decimal_field(char* buffer, size_t buf_len, size_t* printed_chars, 
 }
 
 int
-getAfsString(const dsd_state* state, char* buffer, int a, int f, int s) {
-    if (!isCustomAfsString(state)) {
+getAfsStringFromBits(int a_bits, int f_bits, int s_bits, char* buffer, int a, int f, int s) {
+    if (!isCustomAfsBits(a_bits, f_bits, s_bits)) {
         DSD_SNPRINTF(buffer, 6 + 1, "%02d-%02d%01d", a, f, s);
         return 6;
     }
 
     size_t printed_chars = 0;
-    const size_t need = (size_t)getAfsStringLength(state);
+    const size_t need = (size_t)getAfsStringLengthFromBits(a_bits, f_bits, s_bits);
     const size_t buf_len = need + 1;
 
-    int a_digits = edacs_digits_for_bits(state->edacs_a_bits);
-    int f_digits = edacs_digits_for_bits(state->edacs_f_bits);
-    int s_digits = edacs_digits_for_bits(state->edacs_s_bits);
+    int a_digits = edacs_digits_for_bits(a_bits);
+    int f_digits = edacs_digits_for_bits(f_bits);
+    int s_digits = edacs_digits_for_bits(s_bits);
 
     if (!edacs_append_decimal_field(buffer, buf_len, &printed_chars, a, a_digits, 1)) {
         return 0;
@@ -84,4 +89,9 @@ getAfsString(const dsd_state* state, char* buffer, int a, int f, int s) {
     }
 
     return (int)printed_chars;
+}
+
+int
+getAfsString(const dsd_state* state, char* buffer, int a, int f, int s) {
+    return getAfsStringFromBits(state->edacs_a_bits, state->edacs_f_bits, state->edacs_s_bits, buffer, a, f, s);
 }

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1286,20 +1286,30 @@ no_carrier_step_scanner_mode_if_needed(const dsd_opts* opts, dsd_state* state, t
     }
 
     long int freq = state->trunk_lcn_freq[state->lcn_freq_roll];
+    // Tracks whether the receiver has physically moved yet, so a later leg failing cannot retract a
+    // move that already happened. With both rigctl and an RTL front end configured the rigctl leg
+    // runs first and commits s_last_rigctl_freq; if the RTL tune then fails the scan step is
+    // abandoned, but the radio is no longer on the frequency the open call was decoded from. That
+    // still has to report as a hop or the finalizer ends the call as sync loss and leaves it
+    // reacquirable by whatever decodes next -- on a different frequency.
+    int moved = 0;
     if (freq != 0) {
         if (opts->use_rigctl != 1 && opts->audio_in_type != AUDIO_IN_RTL) {
             return 0;
         }
-        if (opts->use_rigctl == 1 && no_carrier_tune_rigctl_if_needed(opts, freq) != DSD_TRUNK_TUNE_RESULT_OK) {
-            return 0;
+        if (opts->use_rigctl == 1) {
+            if (no_carrier_tune_rigctl_if_needed(opts, freq) != DSD_TRUNK_TUNE_RESULT_OK) {
+                return 0;
+            }
+            moved = 1;
         }
         if (opts->audio_in_type == AUDIO_IN_RTL) {
 #ifdef USE_RADIO
             if (no_carrier_tune_rtl_if_needed(opts, state, (uint32_t)freq) != DSD_TRUNK_TUNE_RESULT_OK) {
-                return 0;
+                return moved;
             }
 #else
-            return 0;
+            return moved;
 #endif
         }
     }

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2526,6 +2526,12 @@ dsd_engine_cleanup(dsd_opts* opts, dsd_state* state) {
     dsd_engine_cleanup_watchdog_snapshots(opts, state);
     noCarrier(opts, state);
     dsd_engine_cleanup_watchdog_snapshots(opts, state);
+    // noCarrier() ended the slots as sync loss, so their VOICE_END alerts are being held against
+    // a reacquisition that can no longer happen. Retire them now, after the pass above has
+    // committed the rows and before audio output closes, or the last transmission of the session
+    // ends silently. Deliberately not inside the snapshot helper: its first call above runs while
+    // calls may still be active.
+    dsd_event_flush_pending_alerts(opts, state);
     dsd_engine_cleanup_close_wavs(opts, state);
     dsd_rdio_upload_shutdown();
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1469,7 +1469,9 @@ static void
 no_carrier_clear_voice_tune_state(dsd_opts* opts, dsd_state* state) {
     const double ended_m = dsd_time_now_monotonic_s();
     for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
-        if (dsd_call_state_end(state, (uint8_t)slot, ended_m) > 0) {
+        // Carrier loss, not a terminator: the transmission may resume on the next
+        // burst that decodes, so the following epoch is allowed to reacquire it.
+        if (dsd_call_state_end_ex(state, (uint8_t)slot, ended_m, DSD_CALL_END_SYNC_LOSS) > 0) {
             dsd_event_sync_slot(opts, state, (uint8_t)slot);
         }
     }
@@ -2100,7 +2102,8 @@ static void
 no_carrier_finalize_canonical_calls(dsd_opts* opts, dsd_state* state) {
     for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
         const uint8_t call_slot = (uint8_t)slot;
-        if (dsd_call_state_end(state, call_slot, 0.0) > 0) {
+        // Sync was lost rather than released; see no_carrier_clear_voice_tune_state().
+        if (dsd_call_state_end_ex(state, call_slot, 0.0, DSD_CALL_END_SYNC_LOSS) > 0) {
             dsd_event_sync_slot(opts, state, call_slot);
         }
     }

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1272,10 +1272,12 @@ no_carrier_tune_rtl_if_needed(const dsd_opts* opts, dsd_state* state, uint32_t r
 }
 #endif
 
-static void
+// Returns non-zero when the scanner actually moved to another frequency, so the caller can end any
+// call still open as an explicit release rather than a sync loss.
+static int
 no_carrier_step_scanner_mode_if_needed(const dsd_opts* opts, dsd_state* state, time_t now) {
     if (opts->scanner_mode != 1 || (now - state->last_cc_sync_time) <= opts->trunk_hangtime) {
-        return;
+        return 0;
     }
 
     no_carrier_reset_nxdn_scan_markers(state);
@@ -1286,24 +1288,26 @@ no_carrier_step_scanner_mode_if_needed(const dsd_opts* opts, dsd_state* state, t
     long int freq = state->trunk_lcn_freq[state->lcn_freq_roll];
     if (freq != 0) {
         if (opts->use_rigctl != 1 && opts->audio_in_type != AUDIO_IN_RTL) {
-            return;
+            return 0;
         }
         if (opts->use_rigctl == 1 && no_carrier_tune_rigctl_if_needed(opts, freq) != DSD_TRUNK_TUNE_RESULT_OK) {
-            return;
+            return 0;
         }
         if (opts->audio_in_type == AUDIO_IN_RTL) {
 #ifdef USE_RADIO
             if (no_carrier_tune_rtl_if_needed(opts, state, (uint32_t)freq) != DSD_TRUNK_TUNE_RESULT_OK) {
-                return;
+                return 0;
             }
 #else
-            return;
+            return 0;
 #endif
         }
     }
     state->lcn_freq_roll++;
     state->last_cc_sync_time = now;
     state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
+    // A zero entry parks on the current frequency rather than retuning, so it is not a hop.
+    return freq != 0;
 }
 
 static int
@@ -1465,13 +1469,14 @@ no_carrier_sync_helper_tune_cache(const dsd_opts* opts, const dsd_state* state, 
 #endif
 }
 
+// `reason` is the caller's: SYNC_LOSS when the carrier simply went away and the transmission may
+// resume on the next burst that decodes, EXPLICIT when the receiver has retuned and whatever was on
+// the old frequency cannot be reacquired here no matter what the next epoch looks like.
 static void
-no_carrier_clear_voice_tune_state(dsd_opts* opts, dsd_state* state) {
+no_carrier_clear_voice_tune_state(dsd_opts* opts, dsd_state* state, dsd_call_end_reason reason) {
     const double ended_m = dsd_time_now_monotonic_s();
     for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
-        // Carrier loss, not a terminator: the transmission may resume on the next
-        // burst that decodes, so the following epoch is allowed to reacquire it.
-        if (dsd_call_state_end_ex(state, (uint8_t)slot, ended_m, DSD_CALL_END_SYNC_LOSS) > 0) {
+        if (dsd_call_state_end_ex(state, (uint8_t)slot, ended_m, reason) > 0) {
             dsd_event_sync_slot(opts, state, (uint8_t)slot);
         }
     }
@@ -1771,7 +1776,12 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
     }
 
     if (accepted_cc_return || clear_failed_helper_state || clear_unreturnable_voice_state) {
-        no_carrier_clear_voice_tune_state(opts, state);
+        // An accepted return actually retuned to the control channel, so any call still open ended
+        // with that hop rather than with the fade that prompted it. The other two paths never
+        // changed frequency -- the helper failed, or there was no control channel to return to --
+        // so for them the carrier loss really is the end reason.
+        no_carrier_clear_voice_tune_state(opts, state,
+                                          accepted_cc_return ? DSD_CALL_END_EXPLICIT : DSD_CALL_END_SYNC_LOSS);
         (void)dsd_recent_activity_clear_all(state);
         state->is_con_plus = 0;
     }
@@ -2098,12 +2108,16 @@ no_carrier_reset_ysf_and_dstar_strings(dsd_state* state) {
     set_spaces(state->dstar_gps, 8);
 }
 
+// `retuned` says whether this noCarrier() pass moved the receiver before reaching here. A call still
+// open across a frequency change did not fade -- it was left behind, and nothing decoded on the new
+// frequency is the same transmission. Reporting that as sync loss would let the next call to appear,
+// within the reacquisition window and on a different channel, be folded into its history row.
 static void
-no_carrier_finalize_canonical_calls(dsd_opts* opts, dsd_state* state) {
+no_carrier_finalize_canonical_calls(dsd_opts* opts, dsd_state* state, int retuned) {
+    const dsd_call_end_reason reason = retuned ? DSD_CALL_END_EXPLICIT : DSD_CALL_END_SYNC_LOSS;
     for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
         const uint8_t call_slot = (uint8_t)slot;
-        // Sync was lost rather than released; see no_carrier_clear_voice_tune_state().
-        if (dsd_call_state_end_ex(state, call_slot, 0.0, DSD_CALL_END_SYNC_LOSS) > 0) {
+        if (dsd_call_state_end_ex(state, call_slot, 0.0, reason) > 0) {
             dsd_event_sync_slot(opts, state, call_slot);
         }
     }
@@ -2170,9 +2184,12 @@ noCarrier(dsd_opts* opts, dsd_state* state) {
     no_carrier_reset_nxdn_scan_markers(state);
 #endif
 
-    no_carrier_step_scanner_mode_if_needed(opts, state, now);
+    // The hop is reported rather than reordered around: the return-to-CC path below ends its own
+    // calls as it retunes, so the finalizer has to know whether the frequency moved out from under
+    // whatever it is about to close.
+    const int scanner_retuned = no_carrier_step_scanner_mode_if_needed(opts, state, now);
     no_carrier_return_to_control_channel_if_needed(opts, state, now);
-    no_carrier_finalize_canonical_calls(opts, state);
+    no_carrier_finalize_canonical_calls(opts, state, scanner_retuned);
     no_carrier_clear_stale_p25_return_hints_after_generic_activity(opts, state);
     no_carrier_reset_dibit_and_dmr_buffers(state);
     no_carrier_close_mbe_outputs_if_needed(opts, state);

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -105,7 +105,12 @@ static void DSD_ATTR_USED
 dsd_engine_reset_return_to_cc_state(dsd_opts* opts, dsd_state* state) {
     const double ended_m = dsd_time_now_monotonic_s();
     for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
-        if (dsd_call_state_end(state, (uint8_t)slot, ended_m) > 0) {
+        // The state machine is leaving this voice channel by decision, not because the carrier
+        // went away, so nothing that follows on the control channel may be read as this
+        // transmission resuming. Spelled out rather than left to the default: the counterpart
+        // cleanup in no_carrier_clear_voice_tune_state() is reached only from noCarrier() and
+        // does classify its ends as sync loss, and the two must differ deliberately.
+        if (dsd_call_state_end_ex(state, (uint8_t)slot, ended_m, DSD_CALL_END_EXPLICIT) > 0) {
             dsd_event_sync_slot(opts, state, (uint8_t)slot);
         }
     }

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -594,6 +594,33 @@ dmr_flco_publish_crypto(const dmr_flco_ctx* ctx) {
     (void)dsd_call_state_update_crypto(ctx->state, ctx->slot, &crypto);
 }
 
+// The voice LC header repeats through the start of a transmission so late
+// entrants can join, and the same LC comes back in every embedded LC. Only the
+// first copy opens a call: an explicit BEGIN on a repeat mints a second epoch,
+// which commits the first epoch's freshly built row as a duplicate event.
+// Anything that re-describes an already-running call of the same identity is
+// a continuation, so the epoch that started the transmission carries it.
+static dsd_call_boundary
+dmr_flco_voice_boundary(const dmr_flco_ctx* ctx, const dsd_call_observation* observation) {
+    if (ctx->type != 1U) {
+        return DSD_CALL_BOUNDARY_CONTINUE;
+    }
+    dsd_call_snapshot current;
+    if (dsd_call_state_get(ctx->state, ctx->slot, &current) <= 0 || current.phase != DSD_CALL_PHASE_ACTIVE) {
+        return DSD_CALL_BOUNDARY_BEGIN;
+    }
+    if (!DSD_SYNC_IS_DMR(current.protocol) || current.kind != observation->kind
+        || current.ota_target_id != observation->ota_target_id) {
+        return DSD_CALL_BOUNDARY_BEGIN;
+    }
+    // A header naming a different talker is the next transmission, not a repeat.
+    if (current.ota_source_id != 0U && observation->ota_source_id != 0U
+        && current.ota_source_id != observation->ota_source_id) {
+        return DSD_CALL_BOUNDARY_BEGIN;
+    }
+    return DSD_CALL_BOUNDARY_CONTINUE;
+}
+
 static void
 dmr_flco_publish_voice(dmr_flco_ctx* ctx) {
     if (ctx->slot >= DSD_CALL_STATE_SLOT_COUNT) {
@@ -613,8 +640,7 @@ dmr_flco_publish_voice(dmr_flco_ctx* ctx) {
         .priority = (uint8_t)(ctx->so & 0x03U),
         .has_service_metadata = 1U,
     };
-    const dsd_call_boundary boundary = ctx->type == 1U ? DSD_CALL_BOUNDARY_BEGIN : DSD_CALL_BOUNDARY_CONTINUE;
-    (void)dsd_call_state_observe(ctx->state, &observation, boundary);
+    (void)dsd_call_state_observe(ctx->state, &observation, dmr_flco_voice_boundary(ctx, &observation));
     dmr_flco_publish_crypto(ctx);
     dsd_event_sync_slot(ctx->opts, ctx->state, ctx->slot);
 }

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -594,33 +594,6 @@ dmr_flco_publish_crypto(const dmr_flco_ctx* ctx) {
     (void)dsd_call_state_update_crypto(ctx->state, ctx->slot, &crypto);
 }
 
-// The voice LC header repeats through the start of a transmission so late
-// entrants can join, and the same LC comes back in every embedded LC. Only the
-// first copy opens a call: an explicit BEGIN on a repeat mints a second epoch,
-// which commits the first epoch's freshly built row as a duplicate event.
-// Anything that re-describes an already-running call of the same identity is
-// a continuation, so the epoch that started the transmission carries it.
-static dsd_call_boundary
-dmr_flco_voice_boundary(const dmr_flco_ctx* ctx, const dsd_call_observation* observation) {
-    if (ctx->type != 1U) {
-        return DSD_CALL_BOUNDARY_CONTINUE;
-    }
-    dsd_call_snapshot current;
-    if (dsd_call_state_get(ctx->state, ctx->slot, &current) <= 0 || current.phase != DSD_CALL_PHASE_ACTIVE) {
-        return DSD_CALL_BOUNDARY_BEGIN;
-    }
-    if (!DSD_SYNC_IS_DMR(current.protocol) || current.kind != observation->kind
-        || current.ota_target_id != observation->ota_target_id) {
-        return DSD_CALL_BOUNDARY_BEGIN;
-    }
-    // A header naming a different talker is the next transmission, not a repeat.
-    if (current.ota_source_id != 0U && observation->ota_source_id != 0U
-        && current.ota_source_id != observation->ota_source_id) {
-        return DSD_CALL_BOUNDARY_BEGIN;
-    }
-    return DSD_CALL_BOUNDARY_CONTINUE;
-}
-
 static void
 dmr_flco_publish_voice(dmr_flco_ctx* ctx) {
     if (ctx->slot >= DSD_CALL_STATE_SLOT_COUNT) {
@@ -640,7 +613,8 @@ dmr_flco_publish_voice(dmr_flco_ctx* ctx) {
         .priority = (uint8_t)(ctx->so & 0x03U),
         .has_service_metadata = 1U,
     };
-    (void)dsd_call_state_observe(ctx->state, &observation, dmr_flco_voice_boundary(ctx, &observation));
+    const dsd_call_boundary boundary = ctx->type == 1U ? DSD_CALL_BOUNDARY_BEGIN : DSD_CALL_BOUNDARY_CONTINUE;
+    (void)dsd_call_state_observe(ctx->state, &observation, boundary);
     dmr_flco_publish_crypto(ctx);
     dsd_event_sync_slot(ctx->opts, ctx->state, ctx->slot);
 }

--- a/src/runtime/p25_optional_hooks.c
+++ b/src/runtime/p25_optional_hooks.c
@@ -25,7 +25,7 @@ dsd_p25_optional_hook_watchdog_event_current(dsd_opts* opts, dsd_state* state, u
 
 void
 dsd_p25_optional_hook_write_event_to_log_file(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite,
-                                              char* event_string) {
+                                              const char* event_string) {
     if (!g_p25_optional_hooks.write_event_to_log_file) {
         return;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3014,6 +3014,7 @@ if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
             "-Wl,--wrap=rtl_stream_get_ted_sps_override"
             "-Wl,--wrap=rtl_stream_output_rate"
             "-Wl,--wrap=rtl_stream_prepare_retune_profile_for_target_with_gain"
+            "-Wl,--wrap=SetFreq"
             "-Wl,--wrap=rtl_stream_request_fsk_reacquire"
             "-Wl,--wrap=rtl_stream_tune"
             "-Wl,--wrap=rtl_stream_tune_tagged"

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -1638,6 +1638,94 @@ test_new_canonical_epoch_commits_prior_canonical_call(void) {
     return rc;
 }
 
+// Count committed rows (index 0 stages the call still in progress).
+static int
+committed_history_rows(const Event_History_I* history) {
+    int rows = 0;
+    for (int i = 1; i < 255; i++) {
+        if (history->Event_History_Items[i].event_string[0] != '\0') {
+            rows++;
+        }
+    }
+    return rows;
+}
+
+// Sync loss ends the canonical call mid-transmission; the next burst that
+// decodes opens a fresh epoch and its end commits the same row again. One
+// transmission must leave one row however many times it is closed and reopened.
+static int
+test_reacquired_transmission_commits_one_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_END;
+
+    for (int pass = 0; pass < 3; pass++) {
+        assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                                 pass == 0 ? DSD_CALL_BOUNDARY_BEGIN : DSD_CALL_BOUNDARY_CONTINUE)
+               >= 0);
+        dsd_event_sync_slot(&opts, &state, 0U);
+        assert(dsd_call_state_end(&state, 0U, 0.0) == 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+    }
+
+    int rc = expect_int("reacquired transmission commits one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_int("reacquired transmission emits one call end alert", g_beeper_count, 1);
+    rc |= expect_int("reacquired transmission keeps committed target",
+                     (int)event_history[0].Event_History_Items[1].target_id, 100);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The repeat guard must not swallow a different talker or a different target.
+static int
+test_changed_identity_still_commits_its_own_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(dsd_call_state_end(&state, 0U, 0.0) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 201U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(dsd_call_state_end(&state, 0U, 0.0) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_int("changed source commits its own row", committed_history_rows(&event_history[0]), 2);
+    rc |= expect_int("newest row carries the new source", (int)event_history[0].Event_History_Items[1].source_id, 201);
+    rc |= expect_int("prior row keeps the first source", (int)event_history[0].Event_History_Items[2].source_id, 200);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// Repeated data notices describe distinct receptions and are never coalesced.
+static int
+test_repeated_data_notices_are_not_coalesced(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    state.lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+
+    assert(emit_test_data_notice(&opts, &state, 300U, 400U, "LRRP SRC: 300; (1.0, 2.0)", 0U) == 0);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(emit_test_data_notice(&opts, &state, 300U, 400U, "LRRP SRC: 300; (1.0, 2.0)", 0U) == 0);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_int("repeated data notices both reach history", committed_history_rows(&event_history[0]), 2);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 static int
 test_late_source_enriches_matching_canonical_call(void) {
     static dsd_opts opts;
@@ -1879,6 +1967,9 @@ main(void) {
     rc |= test_canonical_voice_category_is_protocol_neutral();
     rc |= test_provisional_voice_identity_does_not_commit_zero_row();
     rc |= test_new_canonical_epoch_commits_prior_canonical_call();
+    rc |= test_reacquired_transmission_commits_one_row();
+    rc |= test_changed_identity_still_commits_its_own_row();
+    rc |= test_repeated_data_notices_are_not_coalesced();
     rc |= test_late_source_enriches_matching_canonical_call();
     rc |= test_active_canonical_call_does_not_suppress_explicit_data();
     rc |= test_ended_canonical_call_does_not_suppress_later_data();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -32,8 +32,10 @@
 
 _Static_assert(offsetof(Event_History_I, revision) == sizeof(Event_History) * 255U,
                "event history revision must follow the existing items");
-_Static_assert(sizeof(Event_History_I) == sizeof(Event_History) * 255U + sizeof(uint64_t),
-               "event history revision must add exactly eight bytes");
+_Static_assert(offsetof(Event_History_I, push_seq) == sizeof(Event_History) * 255U + sizeof(uint64_t),
+               "event history push sequence must follow the revision");
+_Static_assert(sizeof(Event_History_I) == sizeof(Event_History) * 255U + (2U * sizeof(uint64_t)),
+               "event history bookkeeping must add exactly two 64-bit counters");
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -225,6 +227,21 @@ observe_test_call(dsd_state* state, uint8_t slot, int protocol, dsd_call_kind ki
     };
     g_observed_m += 0.1;
     return dsd_call_state_observe(state, &observation, boundary);
+}
+
+// End the slot's call on the fixture's own timeline. Every reacquisition assertion is driven
+// through observed_m rather than wall clock, so the window behaves identically under the
+// sanitizer presets and a loaded parallel ctest run.
+static int
+end_test_call(dsd_state* state, uint8_t slot, dsd_call_end_reason reason) {
+    const int rc = dsd_call_state_end_ex(state, slot, g_observed_m, reason);
+    g_observed_m += 0.1;
+    return rc;
+}
+
+static void
+advance_test_clock(double seconds) {
+    g_observed_m += seconds;
 }
 
 static int
@@ -1652,9 +1669,13 @@ committed_history_rows(const Event_History_I* history) {
     return rows;
 }
 
-// Sync loss ends the canonical call mid-transmission; the next burst that
-// decodes opens a fresh epoch and its end commits the same row again. One
-// transmission must leave one row however many times it is closed and reopened.
+// Sync loss ends the canonical call mid-transmission; the next burst that decodes reopens the
+// epoch and its end commits the same row again. One transmission must leave one row however
+// many times it is closed and reopened, and must beep START and END once each.
+//
+// The reopen here carries no identity at all -- the shape of mark_vocoder_call_media(), which
+// observes BEGIN on every MBE frame while no ACTIVE call exists. That path is the most common
+// way a transmission is reacquired, so the arming must not depend on the boundary token.
 static int
 test_reacquired_transmission_commits_one_row(void) {
     static dsd_opts opts;
@@ -1662,31 +1683,72 @@ test_reacquired_transmission_commits_one_row(void) {
     static Event_History_I event_history[2];
     static max_align_t wav_sentinel;
     reset_fixture(&opts, &state, event_history);
-    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_END;
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START | DSD_CALL_ALERT_EVENT_VOICE_END;
     opts.wav_out_f = (SNDFILE*)&wav_sentinel;
     g_open_wav_result = (SNDFILE*)&wav_sentinel;
 
     for (int pass = 0; pass < 3; pass++) {
-        assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
-                                 pass == 0 ? DSD_CALL_BOUNDARY_BEGIN : DSD_CALL_BOUNDARY_CONTINUE)
-               >= 0);
+        if (pass == 0) {
+            assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U,
+                                     0U, DSD_CALL_BOUNDARY_BEGIN)
+                   == 1);
+        } else {
+            // Identity-less voice BEGIN, exactly as the vocoder emits it.
+            assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                                     DSD_CALL_BOUNDARY_BEGIN)
+                   == 1);
+        }
         dsd_event_sync_slot(&opts, &state, 0U);
-        assert(dsd_call_state_end(&state, 0U, 0.0) == 1);
+        assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
         dsd_event_sync_slot(&opts, &state, 0U);
     }
 
     int rc = expect_int("reacquired transmission commits one row", committed_history_rows(&event_history[0]), 1);
-    rc |= expect_int("reacquired transmission emits one call end alert", g_beeper_count, 1);
+    // One START for the first segment plus one END for the merged transmission.
+    rc |= expect_int("reacquired transmission alerts once at each end", g_beeper_count, 2);
     rc |= expect_int("reacquired transmission keeps committed target",
                      (int)event_history[0].Event_History_Items[1].target_id, 100);
+    // The identity-less reopens inherit the ending call's identity instead of blanking it.
+    rc |= expect_int("reacquired transmission keeps committed source",
+                     (int)event_history[0].Event_History_Items[1].source_id, 200);
+    // Rotation lives in the commit path and the rename metadata comes from the staged row, so a
+    // merged transmission is one row referencing one recording per segment.
     rc |= expect_int("each reacquired segment finalizes its WAV", g_close_wav_count, 3);
     rc |= expect_int("each reacquired segment opens a fresh WAV", g_open_wav_count, 3);
     dsd_state_ext_free_all(&state);
     return rc;
 }
 
-// An explicit BEGIN is positive evidence of a distinct transmission even when
-// it repeats the identity that was just committed.
+// The re-announcing protocols (P25 Phase 2, NXDN, dPMR, D-STAR, EDACS, X2-TDMA, DMR embedded
+// LCs) reopen with CONTINUE. They must arm the same way the identity-less BEGIN path does.
+static int
+test_reacquired_transmission_via_continue_commits_one_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_P25P2_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_P25P2_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_int("continue reacquisition commits one row", committed_history_rows(&event_history[0]), 1);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// A deliberate teardown is not a reacquisition. A subscriber double-tapping PTT on the same
+// talkgroup is routine on trunked P25 Phase 2 and DMR, and each press is its own transmission.
 static int
 test_back_to_back_same_identity_calls_commit_two_rows(void) {
     static dsd_opts opts;
@@ -1700,7 +1762,7 @@ test_back_to_back_same_identity_calls_commit_two_rows(void) {
                                  DSD_CALL_BOUNDARY_BEGIN)
                == 1);
         dsd_event_sync_slot(&opts, &state, 0U);
-        assert(dsd_call_state_end(&state, 0U, 0.0) == 1);
+        assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
         dsd_event_sync_slot(&opts, &state, 0U);
     }
 
@@ -1715,7 +1777,35 @@ test_back_to_back_same_identity_calls_commit_two_rows(void) {
     return rc;
 }
 
-// The repeat guard must not swallow a different talker or a different target.
+// A terminator followed by an identity-less reopen inside the window must still commit twice:
+// the transmission that terminated is over, whatever decodes next is new.
+static int
+test_explicit_end_then_identityless_reopen_commits_two_rows(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_int("explicit end never coalesces", committed_history_rows(&event_history[0]), 2);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The merge must not swallow a different talker or a different target.
 static int
 test_changed_identity_still_commits_its_own_row(void) {
     static dsd_opts opts;
@@ -1727,14 +1817,14 @@ test_changed_identity_still_commits_its_own_row(void) {
                              DSD_CALL_BOUNDARY_BEGIN)
            == 1);
     dsd_event_sync_slot(&opts, &state, 0U);
-    assert(dsd_call_state_end(&state, 0U, 0.0) == 1);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
     dsd_event_sync_slot(&opts, &state, 0U);
 
     assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 201U, 0U, 0U,
                              DSD_CALL_BOUNDARY_BEGIN)
            == 1);
     dsd_event_sync_slot(&opts, &state, 0U);
-    assert(dsd_call_state_end(&state, 0U, 0.0) == 1);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
     dsd_event_sync_slot(&opts, &state, 0U);
 
     int rc = expect_int("changed source commits its own row", committed_history_rows(&event_history[0]), 2);
@@ -1744,7 +1834,458 @@ test_changed_identity_still_commits_its_own_row(void) {
     return rc;
 }
 
-// Repeated data notices describe distinct receptions and are never coalesced.
+// A gap wider than the window is two transmissions, whatever ended the first one.
+static int
+test_reacquisition_gap_beyond_window_commits_two_rows(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    advance_test_clock(1.0);
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_int("gap beyond the window commits two rows", committed_history_rows(&event_history[0]), 2);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The window bounds the gap, not the transmission. A reacquired segment that then runs for
+// well over the window is still one transmission.
+static int
+test_reacquired_segment_may_outlast_the_window(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    advance_test_clock(1.2);
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 0);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_int("long reacquired segment commits one row", committed_history_rows(&event_history[0]), 1);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// A badly flapping signal produces many short segments. They belong to one transmission.
+static int
+test_flapping_segments_commit_one_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    for (int pass = 0; pass < 5; pass++) {
+        assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS,
+                                 pass == 0 ? DSD_CALL_KIND_GROUP_VOICE : DSD_CALL_KIND_VOICE, pass == 0 ? 100U : 0U,
+                                 pass == 0 ? 200U : 0U, 0U, 0U, DSD_CALL_BOUNDARY_BEGIN)
+               == 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+        advance_test_clock(0.2);
+        assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+        advance_test_clock(0.1);
+    }
+
+    int rc = expect_int("five flapping segments commit one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_int("flapping transmission keeps its target", (int)event_history[0].Event_History_Items[1].target_id,
+                     100);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// DMR alternates sync polarity burst to burst. Comparing raw synctypes would call that a
+// different call; the store compares protocol families instead.
+static int
+test_dmr_sync_polarity_flip_still_coalesces(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_NEG, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_int("dmr polarity flip commits one row", committed_history_rows(&event_history[0]), 1);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// M17, YSF, D-STAR and dPMR express identity as text and leave the numeric ids at zero. A
+// numeric-only comparison would refuse to coalesce for all four.
+static int
+test_textual_identity_reacquisition_coalesces(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    state.lastsynctype = DSD_SYNC_M17_STR_POS;
+
+    dsd_call_observation observation = {
+        .protocol = DSD_SYNC_M17_STR_POS,
+        .slot = 0U,
+        .kind = DSD_CALL_KIND_VOICE,
+    };
+    DSD_SNPRINTF(observation.source_text, sizeof(observation.source_text), "%s", "N0CALL");
+    DSD_SNPRINTF(observation.target_text, sizeof(observation.target_text), "%s", "BROADCAST");
+
+    for (int pass = 0; pass < 2; pass++) {
+        observation.observed_m = g_observed_m;
+        g_observed_m += 0.1;
+        assert(dsd_call_state_observe(&state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+        assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+    }
+
+    int rc = expect_int("textual identity reacquisition commits one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_str_eq("merged row keeps textual source", event_history[0].Event_History_Items[1].src_str, "N0CALL");
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// Late entry commits a first segment knowing only the talkgroup. When the reacquired segment
+// decodes the source, the surviving row has to carry it -- dropping the second commit would
+// leave a row reading SRC 00000000 forever.
+static int
+test_reacquired_segment_contributes_late_source(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(event_history[0].Event_History_Items[1].source_id == 0U);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 201U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    const Event_History* merged = &event_history[0].Event_History_Items[1];
+    int rc = expect_int("late source merges into one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_int("merged row carries the late source", (int)merged->source_id, 201);
+    rc |= expect_has_substr("merged row renders the late source", merged->event_string, "SRC: 00000201;");
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The PI/ESS header can decode only after the reacquisition. Dropping that commit would leave
+// the sole surviving row marked clear for a call that was encrypted.
+static int
+test_reacquired_segment_contributes_crypto(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(event_history[0].Event_History_Items[1].enc == 0U);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    assert(update_test_crypto(&state, 0U, DSD_CALL_CRYPTO_ENCRYPTED, 0x21U, 0x1234U, 0U) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    const Event_History* merged = &event_history[0].Event_History_Items[1];
+    int rc = expect_int("late crypto merges into one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_int("merged row is marked encrypted", merged->enc, 1);
+    rc |= expect_int("merged row keeps the algorithm", merged->enc_alg, 0x21);
+    rc |= expect_int("merged row keeps the key id", (int)merged->enc_key, 0x1234);
+    rc |= expect_has_substr("merged row renders the crypto", merged->event_string, "ENC; ALG: 21; KID: 1234;");
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// Alias and GPS learned during the reacquired segment must reach the surviving row.
+static int
+test_reacquired_segment_contributes_alias_and_gps(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_call_snapshot reacquired;
+    assert(dsd_call_state_get(&state, 0U, &reacquired) > 0);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(dsd_event_enrich_alias(&state, 0U, reacquired.epoch, "UNIT 12") == 1);
+    assert(dsd_event_enrich_gps(&state, 0U, reacquired.epoch, "lat 1.0 lon 2.0") == 1);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    const Event_History* merged = &event_history[0].Event_History_Items[1];
+    int rc = expect_int("enriched reacquisition commits one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_str_eq("merged row keeps the alias", merged->alias, "UNIT 12");
+    rc |= expect_str_eq("merged row keeps the gps", merged->gps_s, "lat 1.0 lon 2.0");
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// A data notice pushed between the two voice commits shifts the ring. The merge has to find
+// the voice row at its new depth and leave the notice alone.
+static int
+test_interleaved_data_notice_does_not_misdirect_merge(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    // Late entry: the first segment knows the talkgroup only.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    state.lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+    assert(emit_test_data_notice(&opts, &state, 300U, 400U, "LRRP SRC: 300; (1.0, 2.0)", 0U) == 0);
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 201U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    // Row 1 is the notice; row 2 is the voice row the reacquisition merged into.
+    int rc = expect_int("notice plus merged voice leave two rows", committed_history_rows(&event_history[0]), 2);
+    rc |= expect_has_substr("notice row is untouched", event_history[0].Event_History_Items[1].event_string, "LRRP");
+    rc |= expect_int("merged voice row keeps its target", (int)event_history[0].Event_History_Items[2].target_id, 100);
+    rc |=
+        expect_int("merged voice row learned the source", (int)event_history[0].Event_History_Items[2].source_id, 201);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// Clearing Activity history mid-call must not leave the next segment merging into a row that
+// no longer exists: the transmission still has to reach history.
+static int
+test_history_reset_mid_reacquisition_still_commits(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    dsd_event_history_reset(&state);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_int("reset then reacquisition still reaches history", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_int("row after reset keeps its target", (int)event_history[0].Event_History_Items[1].target_id, 100);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// Clearing history also clears the bookkeeping that points into it.
+static int
+test_history_reset_clears_commit_bookkeeping(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(committed_history_rows(&event_history[0]) == 1);
+
+    dsd_event_history_reset(&state);
+
+    int rc = expect_int("reset clears every row", committed_history_rows(&event_history[0]), 0);
+    dsd_call_context_snapshot context;
+    assert(dsd_call_context_copy_snapshot(&state, &context) > 0);
+    rc |= expect_int("reset clears committed_valid", context.events[0].committed_valid, 0);
+    rc |= expect_u64("reset clears committed_seq", context.events[0].committed_seq, 0U);
+    rc |= expect_u64("reset clears reacquired_epoch", context.events[0].reacquired_epoch, 0U);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// A restored context describes a different trunk-scan target while the event history is
+// global, so a commit reference must never survive the hop.
+static int
+test_context_restore_invalidates_commit_bookkeeping(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    dsd_call_context_snapshot saved;
+    assert(dsd_call_context_copy_snapshot(&state, &saved) > 0);
+    assert(saved.events[0].committed_valid == 1U);
+    // The end reason rides along with the snapshot, so a hop cannot turn a sync loss into a
+    // teardown or the other way round.
+    int rc =
+        expect_int("snapshot preserves the end reason", saved.calls.slots[0].end_reason, (int)DSD_CALL_END_SYNC_LOSS);
+
+    assert(dsd_call_context_restore_snapshot(&state, &saved) > 0);
+    dsd_call_context_snapshot restored;
+    assert(dsd_call_context_copy_snapshot(&state, &restored) > 0);
+    rc |= expect_int("restore clears committed_valid", restored.events[0].committed_valid, 0);
+    rc |= expect_u64("restore clears committed_seq", restored.events[0].committed_seq, 0U);
+    rc |= expect_u64("restore clears reacquired_epoch", restored.events[0].reacquired_epoch, 0U);
+    rc |= expect_int("restore keeps the end reason", restored.calls.slots[0].end_reason, (int)DSD_CALL_END_SYNC_LOSS);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The first segment logs its line as usual. A merge that materially changes the rendered row
+// adds a continuation line; a merge that changes nothing user-visible stays silent.
+static int
+test_merge_logs_continuation_only_when_render_changes(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    char path[] = "/tmp/dsd-neo-reacquire-events-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "mkstemp failed for reacquisition event log test\n");
+        return 1;
+    }
+    close(fd);
+    (void)remove(path);
+    DSD_SNPRINTF(opts.event_out_file, sizeof opts.event_out_file, "%s", path);
+
+    // Segment 1 knows the talkgroup only; segment 2 decodes the source, so the render changes.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 201U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    // Segment 3 adds nothing the row does not already say.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 201U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    FILE* f = fopen(path, "rb");
+    if (f == NULL) {
+        (void)remove(path);
+        DSD_FPRINTF(stderr, "reacquisition event log was not created\n");
+        return 1;
+    }
+    char buf[8192];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    fclose(f);
+    (void)remove(path);
+    buf[n] = '\0';
+
+    int reacquired_lines = 0;
+    for (const char* cursor = strstr(buf, " Reacquired: "); cursor != NULL;
+         cursor = strstr(cursor + 1, " Reacquired: ")) {
+        reacquired_lines++;
+    }
+
+    int rc = expect_int("merged transmission commits one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_has_substr("first segment logged its own line", buf, "SRC: 00000000;");
+    rc |= expect_has_substr("continuation reports the learned source", buf, " Reacquired: ");
+    rc |= expect_int("only the informative merge logs a continuation", reacquired_lines, 1);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// Data calls describe distinct receptions and are never coalesced, even when the canonical
+// layer flags the epoch as reacquired.
 static int
 test_repeated_data_notices_are_not_coalesced(void) {
     static dsd_opts opts;
@@ -1753,12 +2294,16 @@ test_repeated_data_notices_are_not_coalesced(void) {
     reset_fixture(&opts, &state, event_history);
     state.lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
 
-    assert(emit_test_data_notice(&opts, &state, 300U, 400U, "LRRP SRC: 300; (1.0, 2.0)", 0U) == 0);
-    dsd_event_sync_slot(&opts, &state, 0U);
-    assert(emit_test_data_notice(&opts, &state, 300U, 400U, "LRRP SRC: 300; (1.0, 2.0)", 0U) == 0);
-    dsd_event_sync_slot(&opts, &state, 0U);
+    for (int pass = 0; pass < 2; pass++) {
+        assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_DATA_POS, DSD_CALL_KIND_DATA, 400U, 300U, 0U, 0U,
+                                 DSD_CALL_BOUNDARY_BEGIN)
+               == 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+        assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+    }
 
-    int rc = expect_int("repeated data notices both reach history", committed_history_rows(&event_history[0]), 2);
+    int rc = expect_int("repeated data calls both reach history", committed_history_rows(&event_history[0]), 2);
     dsd_state_ext_free_all(&state);
     return rc;
 }
@@ -2005,8 +2550,23 @@ main(void) {
     rc |= test_provisional_voice_identity_does_not_commit_zero_row();
     rc |= test_new_canonical_epoch_commits_prior_canonical_call();
     rc |= test_reacquired_transmission_commits_one_row();
+    rc |= test_reacquired_transmission_via_continue_commits_one_row();
     rc |= test_back_to_back_same_identity_calls_commit_two_rows();
+    rc |= test_explicit_end_then_identityless_reopen_commits_two_rows();
     rc |= test_changed_identity_still_commits_its_own_row();
+    rc |= test_reacquisition_gap_beyond_window_commits_two_rows();
+    rc |= test_reacquired_segment_may_outlast_the_window();
+    rc |= test_flapping_segments_commit_one_row();
+    rc |= test_dmr_sync_polarity_flip_still_coalesces();
+    rc |= test_textual_identity_reacquisition_coalesces();
+    rc |= test_reacquired_segment_contributes_late_source();
+    rc |= test_reacquired_segment_contributes_crypto();
+    rc |= test_reacquired_segment_contributes_alias_and_gps();
+    rc |= test_interleaved_data_notice_does_not_misdirect_merge();
+    rc |= test_history_reset_mid_reacquisition_still_commits();
+    rc |= test_history_reset_clears_commit_bookkeeping();
+    rc |= test_context_restore_invalidates_commit_bookkeeping();
+    rc |= test_merge_logs_continuation_only_when_render_changes();
     rc |= test_repeated_data_notices_are_not_coalesced();
     rc |= test_late_source_enriches_matching_canonical_call();
     rc |= test_active_canonical_call_does_not_suppress_explicit_data();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -2538,9 +2538,11 @@ test_reacquired_stage_superseded_by_new_call_still_merges(void) {
 // epoch. A later reacquisition of that empty epoch must not fold into the unrelated row it still
 // names -- the merge target has to be the row the reopened epoch itself committed.
 //
-// X2-TDMA is the vehicle: it has no per-protocol event builder, so its rows render no string and
-// have no content to commit. That makes it the reachable shape of "an epoch that committed
-// nothing", which is otherwise hard to construct.
+// A generic digital sync is the vehicle: no per-protocol builder claims DSD_SYNC_DIGITAL, so its
+// rows render no string and have no content to commit. That makes it the reachable shape of "an
+// epoch that committed nothing", which is otherwise hard to construct. Every protocol the decoder
+// can actually classify has a builder, so an unclassified signal is the only one left that
+// legitimately renders nothing.
 static int
 test_reacquisition_after_uncommitted_epoch_does_not_merge_stale_row(void) {
     static dsd_opts opts;
@@ -2559,7 +2561,7 @@ test_reacquisition_after_uncommitted_epoch_does_not_merge_stale_row(void) {
 
     // Call B renders nothing, so its sync-loss end commits no row and the slot's commit
     // reference still names call A.
-    assert(observe_test_call(&state, 0U, DSD_SYNC_X2TDMA_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 300U, 400U, 0U, 0U,
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DIGITAL, DSD_CALL_KIND_GROUP_VOICE, 300U, 400U, 0U, 0U,
                              DSD_CALL_BOUNDARY_BEGIN)
            == 1);
     dsd_event_sync_slot(&opts, &state, 0U);
@@ -2568,7 +2570,7 @@ test_reacquisition_after_uncommitted_epoch_does_not_merge_stale_row(void) {
     assert(committed_history_rows(&event_history[0]) == 1);
 
     // B is reacquired inside the window. Whatever it contributes must not land in call A's row.
-    assert(observe_test_call(&state, 0U, DSD_SYNC_X2TDMA_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 300U, 400U, 0U, 0U,
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DIGITAL, DSD_CALL_KIND_GROUP_VOICE, 300U, 400U, 0U, 0U,
                              DSD_CALL_BOUNDARY_CONTINUE)
            == 1);
     dsd_call_snapshot reacquired;
@@ -2984,8 +2986,8 @@ test_notice_then_end_in_reacquired_epoch_commits_one_row(void) {
 
 // A sync-loss end whose staged row rendered nothing put no row in history, so there is no
 // transmission for a VOICE_END to be about. The FINAL disposition cannot alert in that case --
-// its beep lives inside the commit -- and the deferred one must not either. X2-TDMA is the
-// concrete case: no builder covers it, so its rows render empty.
+// its beep lives inside the commit -- and the deferred one must not either. An unclassified
+// digital sync is the concrete case: no builder claims it, so its rows render empty.
 static int
 test_contentless_sync_loss_end_arms_no_alert(void) {
     static dsd_opts opts;
@@ -2993,9 +2995,9 @@ test_contentless_sync_loss_end_arms_no_alert(void) {
     static Event_History_I event_history[2];
     reset_fixture(&opts, &state, event_history);
     opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START | DSD_CALL_ALERT_EVENT_VOICE_END;
-    state.lastsynctype = DSD_SYNC_X2TDMA_VOICE_POS;
+    state.lastsynctype = DSD_SYNC_DIGITAL;
 
-    assert(observe_test_call(&state, 0U, DSD_SYNC_X2TDMA_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DIGITAL, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
                              DSD_CALL_BOUNDARY_BEGIN)
            == 1);
     dsd_event_sync_slot(&opts, &state, 0U);
@@ -3011,6 +3013,89 @@ test_contentless_sync_loss_end_arms_no_alert(void) {
     assert(dsd_call_context_copy_snapshot(&state, &context) > 0);
     rc |= expect_int("no VOICE_END is held for a transmission with no row", context.events[0].end_alert_pending, 0);
     rc |= expect_int("nothing beeped past the START", g_beeper_count, start_alerts);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// X2-TDMA voice reached history as an empty row: no builder covered it, so the transmission was
+// absent from the UI and from the log with nothing to say it had happened. It decodes no call
+// identity -- the link control it collects is never parsed into a talkgroup or a source -- so the
+// row reports what the protocol does know: that the slot carried voice, on which timeslot, and
+// whether it was encrypted.
+static int
+test_x2tdma_voice_commits_a_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    state.lastsynctype = DSD_SYNC_X2TDMA_VOICE_POS;
+
+    char path[] = "/tmp/dsd-neo-x2tdma-events-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "mkstemp failed for x2tdma event log test\n");
+        return 1;
+    }
+    close(fd);
+    (void)remove(path);
+    DSD_SNPRINTF(opts.event_out_file, sizeof opts.event_out_file, "%s", path);
+
+    // Slot 1 and identity-less, exactly as x2tdma_voice.c publishes it.
+    assert(observe_test_call(&state, 1U, DSD_SYNC_X2TDMA_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 1U);
+    assert(end_test_call(&state, 1U, DSD_CALL_END_EXPLICIT) == 1);
+    dsd_event_sync_slot(&opts, &state, 1U);
+
+    FILE* f = fopen(path, "rb");
+    if (f == NULL) {
+        (void)remove(path);
+        DSD_FPRINTF(stderr, "x2tdma event log was not created\n");
+        return 1;
+    }
+    char buf[8192];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    fclose(f);
+    (void)remove(path);
+    buf[n] = '\0';
+
+    const Event_History* committed = &event_history[1].Event_History_Items[1];
+    int rc = expect_int("x2tdma voice commits a row", committed_history_rows(&event_history[1]), 1);
+    // The protocol name itself comes from dsd_synctype_to_string(), stubbed here for every
+    // protocol; what matters is that the builder rendered at all rather than leaving the row blank.
+    rc |= expect_int("x2tdma row is not blank", committed->event_string[0] != '\0', 1);
+    // Zeros rather than omitted: the decoder genuinely never read them, and the row shape stays
+    // the same as every other protocol's.
+    rc |= expect_has_substr("x2tdma row reports the unknown identity", committed->event_string, "TGT: 00000000;");
+    // A NAC would be fabricated -- X2-TDMA has none -- so the P25 builder is deliberately not reused.
+    rc |= expect_int("x2tdma row invents no NAC", strstr(committed->event_string, "NAC:") == NULL, 1);
+    // Two-slot, so the log line has to say which timeslot carried the call.
+    rc |= expect_has_substr("x2tdma log line carries the slot annotation", buf, "Slot 2;");
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// Encryption is the one call attribute X2-TDMA does publish, so it has to reach the row.
+static int
+test_x2tdma_encrypted_voice_reports_enc(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    state.lastsynctype = DSD_SYNC_X2TDMA_VOICE_POS;
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_X2TDMA_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    assert(update_test_crypto(&state, 0U, DSD_CALL_CRYPTO_ENCRYPTED, 0x84U, 0x1234U, 0U) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    const Event_History* committed = &event_history[0].Event_History_Items[1];
+    int rc = expect_int("encrypted x2tdma commits a row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_has_substr("x2tdma row reports the algorithm", committed->event_string, "ENC; ALG: 84; KID: 1234;");
     dsd_state_ext_free_all(&state);
     return rc;
 }
@@ -3529,6 +3614,8 @@ main(void) {
     rc |= test_route_identity_reacquisition_still_coalesces();
     rc |= test_observed_fallback_matches_end_site_clock_resolution();
     rc |= test_contentless_sync_loss_end_arms_no_alert();
+    rc |= test_x2tdma_voice_commits_a_row();
+    rc |= test_x2tdma_encrypted_voice_reports_enc();
     rc |= test_reacquired_stage_superseded_by_new_call_still_merges();
     rc |= test_reacquisition_after_uncommitted_epoch_does_not_merge_stale_row();
     rc |= test_reacquired_transmission_via_continue_commits_one_row();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -19,6 +19,7 @@
 #include <dsd-neo/platform/threading.h>
 #include <dsd-neo/protocol/edacs/edacs_afs.h>
 #include <dsd-neo/runtime/call_alert.h>
+#include <math.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -264,6 +265,13 @@ end_test_call(dsd_state* state, uint8_t slot, dsd_call_end_reason reason) {
 static void
 advance_test_clock(double seconds) {
     g_observed_m += seconds;
+}
+
+// "The stamp was not rewritten". The tolerance is far below the smallest step any caller here
+// advances the fixture clock by, so a restamp is still caught.
+static int
+same_instant(double a, double b) {
+    return fabs(a - b) < 1e-9 ? 1 : 0;
 }
 
 static int
@@ -1837,8 +1845,8 @@ test_end_reason_upgrade_is_one_directional(void) {
     assert(dsd_call_state_get(&state, 0U, &after_repeats) == 1);
     rc |= expect_int("explicit end reason survives a later sync loss", (int)after_repeats.end_reason,
                      (int)DSD_CALL_END_EXPLICIT);
-    rc |=
-        expect_int("repeated ends do not restamp ended_m", after_repeats.ended_m == after_explicit.ended_m ? 1 : 0, 1);
+    rc |= expect_int("repeated ends do not restamp ended_m",
+                     same_instant(after_repeats.ended_m, after_explicit.ended_m), 1);
 
     // And the upgrade path itself must not restamp: the moment the transmission stopped is the
     // fade, not the terminator that explained it.
@@ -1853,8 +1861,8 @@ test_end_reason_upgrade_is_one_directional(void) {
     assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
     dsd_call_snapshot after_upgrade;
     assert(dsd_call_state_get(&state, 0U, &after_upgrade) == 1);
-    rc |= expect_int("upgrade keeps ended_m anchored at the fade", after_upgrade.ended_m == after_fade.ended_m ? 1 : 0,
-                     1);
+    rc |= expect_int("upgrade keeps ended_m anchored at the fade",
+                     same_instant(after_upgrade.ended_m, after_fade.ended_m), 1);
 
     dsd_state_ext_free_all(&state);
     return rc;

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -164,15 +164,24 @@ dsd_synctype_to_string(int synctype) {
     return "TEST";
 }
 
+// The event builders render AFS from the bit widths captured with the row, not from live state.
 int
-getAfsString(const dsd_state* state, char* buffer, int a, int f, int s) {
-    UNUSED(state);
+getAfsStringFromBits(int a_bits, int f_bits, int s_bits, char* buffer, int a, int f, int s) {
+    UNUSED(a_bits);
+    UNUSED(f_bits);
+    UNUSED(s_bits);
     return DSD_SNPRINTF(buffer, 7, "%02d-%02d%01d", a, f, s);
 }
 
 int
 dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, char* out, size_t out_size) {
-    UNUSED(timestamp);
+    // An unstamped time really does render as the epoch, so the stub has to say so: rendering a
+    // plausible date for timestamp 0 would hide a row being restamped from an absent event_time.
+    if (timestamp == 0) {
+        const char* epoch = (format == DSD_LOCAL_DATETIME_DATE_HYPHEN) ? "1970-01-01" : "00:00:00";
+        DSD_SNPRINTF(out, out_size, "%s", epoch);
+        return 1;
+    }
     const char* value = (format == DSD_LOCAL_DATETIME_DATE_HYPHEN) ? "2026-04-30" : "00:00:00";
     DSD_SNPRINTF(out, out_size, "%s", value);
     return 1;
@@ -1704,8 +1713,10 @@ test_reacquired_transmission_commits_one_row(void) {
     }
 
     int rc = expect_int("reacquired transmission commits one row", committed_history_rows(&event_history[0]), 1);
-    // One START for the first segment plus one END for the merged transmission.
-    rc |= expect_int("reacquired transmission alerts once at each end", g_beeper_count, 2);
+    // Exactly one START, at the true start of the transmission. No END yet: every end so far was
+    // a sync loss the call could still come back from, so announcing the end mid-transmission
+    // would be wrong. The alert is held until the reacquisition window closes.
+    rc |= expect_int("reacquired transmission alerts START once", g_beeper_count, 1);
     rc |= expect_int("reacquired transmission keeps committed target",
                      (int)event_history[0].Event_History_Items[1].target_id, 100);
     // The identity-less reopens inherit the ending call's identity instead of blanking it.
@@ -1715,6 +1726,52 @@ test_reacquired_transmission_commits_one_row(void) {
     // merged transmission is one row referencing one recording per segment.
     rc |= expect_int("each reacquired segment finalizes its WAV", g_close_wav_count, 3);
     rc |= expect_int("each reacquired segment opens a fresh WAV", g_open_wav_count, 3);
+
+    // A genuinely different call taking the slot proves the transmission really is over, so the
+    // held END is retired first and the new call's START follows it.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 500U, 900U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("held END lands before the next call's START", g_beeper_count, 3);
+    rc |= expect_int("a different call opens its own row", committed_history_rows(&event_history[0]), 1);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The reacquisition test above relies on the ending epoch naming a call. The inverse must not
+// coalesce: an identity-less epoch is compatible with every observation, so if it were allowed to
+// reacquire, the next unrelated call on the slot would be folded into its row and lose its START.
+static int
+test_identityless_ended_epoch_does_not_reacquire(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START;
+
+    // Provisional voice epoch with no identity at all -- mark_vocoder_call_media() before any
+    // header decodes -- ended by sync loss.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    // A completely different call, well inside the reacquisition window.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 500U, 900U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_int("unrelated call after an identity-less end gets its own row",
+                        committed_history_rows(&event_history[0]), 2);
+    rc |=
+        expect_int("unrelated call keeps its own target", (int)event_history[0].Event_History_Items[1].target_id, 500);
+    rc |= expect_int("unrelated call still alerts START", g_beeper_count, 2);
     dsd_state_ext_free_all(&state);
     return rc;
 }
@@ -2181,6 +2238,103 @@ test_history_reset_clears_commit_bookkeeping(void) {
     return rc;
 }
 
+// The reacquisition marker names the epoch it belongs to and must survive until that epoch's
+// staged row is flushed. If a later, different call clears it first, the staged row commits a
+// second time and the reacquired transmission ends up with two rows -- the exact duplicate this
+// whole path exists to prevent.
+static int
+test_reacquired_stage_superseded_by_new_call_still_merges(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    // Segment 1 commits its row.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    // Segment 2 reopens and stages, but is superseded by a different call before it ends.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 500U, 900U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    // Segment 2 folded into segment 1's row; the new call got its own. Two rows, not three.
+    int rc = expect_int("superseded reacquisition does not duplicate", committed_history_rows(&event_history[0]), 2);
+    rc |= expect_int("new call owns the newest row", (int)event_history[0].Event_History_Items[1].target_id, 500);
+    rc |= expect_int("reacquired transmission still owns one row",
+                     (int)event_history[0].Event_History_Items[2].target_id, 100);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// An epoch that ends without pushing a row leaves the commit reference pointing at an older
+// epoch. A later reacquisition of that empty epoch must not fold into the unrelated row it still
+// names -- the merge target has to be the row the reopened epoch itself committed.
+//
+// X2-TDMA is the vehicle: it has no per-protocol event builder, so its rows render no string and
+// have no content to commit. That makes it the reachable shape of "an epoch that committed
+// nothing", which is otherwise hard to construct.
+static int
+test_reacquisition_after_uncommitted_epoch_does_not_merge_stale_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    // Call A is DMR and commits a row.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(committed_history_rows(&event_history[0]) == 1);
+
+    // Call B renders nothing, so its sync-loss end commits no row and the slot's commit
+    // reference still names call A.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_X2TDMA_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 300U, 400U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(committed_history_rows(&event_history[0]) == 1);
+
+    // B is reacquired inside the window. Whatever it contributes must not land in call A's row.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_X2TDMA_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 300U, 400U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_call_snapshot reacquired;
+    assert(dsd_call_state_get(&state, 0U, &reacquired) > 0);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(dsd_event_enrich_alias(&state, 0U, reacquired.epoch, "B UNIT") == 1);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    // Two rows: call A's, and a fresh one for the reacquired B that had nothing to merge into.
+    // Counted by identity rather than by rendered string, since an X2-TDMA row renders none.
+    const Event_History* newest = &event_history[0].Event_History_Items[1];
+    const Event_History* call_a = &event_history[0].Event_History_Items[2];
+    int rc = expect_int("the reacquired segment gets its own row", (int)newest->target_id, 300);
+    rc |= expect_str_eq("the reacquired segment keeps its alias", newest->alias, "B UNIT");
+    // The decisive assertions: call A's row is untouched by a transmission that is not its own.
+    rc |= expect_int("call A keeps its identity", (int)call_a->target_id, 100);
+    rc |= expect_str_eq("call A's row does not absorb the reacquired segment", call_a->alias, "");
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 // A restored context describes a different trunk-scan target while the event history is
 // global, so a commit reference must never survive the hop.
 static int
@@ -2211,7 +2365,13 @@ test_context_restore_invalidates_commit_bookkeeping(void) {
     rc |= expect_int("restore clears committed_valid", restored.events[0].committed_valid, 0);
     rc |= expect_u64("restore clears committed_seq", restored.events[0].committed_seq, 0U);
     rc |= expect_u64("restore clears reacquired_epoch", restored.events[0].reacquired_epoch, 0U);
-    rc |= expect_int("restore keeps the end reason", restored.calls.slots[0].end_reason, (int)DSD_CALL_END_SYNC_LOSS);
+    // Clearing the commit reference blocks the row merge, but reacquisition has two other
+    // effects -- seeding the new epoch with the old identity and suppressing its START alert --
+    // that a bare commit invalidation would not stop. The monotonic clock is global, so a slot
+    // saved mid-fade would still satisfy the gap test against a call on the new target. A
+    // restored end is a hop, never a resumable fade, so it comes back as a deliberate teardown.
+    rc |= expect_int("restore downgrades a sync-loss end to explicit", restored.calls.slots[0].end_reason,
+                     (int)DSD_CALL_END_EXPLICIT);
     dsd_state_ext_free_all(&state);
     return rc;
 }
@@ -2280,6 +2440,257 @@ test_merge_logs_continuation_only_when_render_changes(void) {
     rc |= expect_has_substr("first segment logged its own line", buf, "SRC: 00000000;");
     rc |= expect_has_substr("continuation reports the learned source", buf, " Reacquired: ");
     rc |= expect_int("only the informative merge logs a continuation", reacquired_lines, 1);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// Optional detail a reacquired segment contributes reaches the event log even when it does not
+// change the rendered row -- otherwise it would show in the UI history and be missing from the
+// log. The continuation also carries the slot annotation that every normal commit carries.
+static int
+test_merge_logs_metadata_the_segment_added(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    // Two-slot system, so commits carry a "Slot N;" annotation.
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+
+    char path[] = "/tmp/dsd-neo-reacquire-meta-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "mkstemp failed for reacquisition metadata log test\n");
+        return 1;
+    }
+    close(fd);
+    (void)remove(path);
+    DSD_SNPRINTF(opts.event_out_file, sizeof opts.event_out_file, "%s", path);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    // The reacquired segment adds an alias and a GPS fix but no new identity, so the rendered
+    // row is unchanged and only the metadata lines have anything to report.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_call_snapshot reacquired;
+    assert(dsd_call_state_get(&state, 0U, &reacquired) > 0);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(dsd_event_enrich_alias(&state, 0U, reacquired.epoch, "UNIT 12 FIRE") == 1);
+    assert(dsd_event_enrich_gps(&state, 0U, reacquired.epoch, "lat 3.0 lon 4.0") == 1);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    FILE* f = fopen(path, "rb");
+    if (f == NULL) {
+        (void)remove(path);
+        DSD_FPRINTF(stderr, "reacquisition metadata log was not created\n");
+        return 1;
+    }
+    char buf[8192];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    fclose(f);
+    (void)remove(path);
+    buf[n] = '\0';
+
+    int rc = expect_int("metadata-only merge commits one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_has_substr("merged alias reaches the log", buf, " Talker Alias: UNIT 12 FIRE");
+    rc |= expect_has_substr("merged gps reaches the log", buf, " GPS: lat 3.0 lon 4.0");
+    rc |= expect_str_eq("merged row keeps the alias", event_history[0].Event_History_Items[1].alias, "UNIT 12 FIRE");
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// A partially decoded alias must be upgraded by a later segment that decoded more of it, the way
+// enrichment upgrades a committed row. Filling only blanks would freeze the first fragment.
+static int
+test_merge_upgrades_partial_alias(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_call_snapshot first;
+    assert(dsd_call_state_get(&state, 0U, &first) > 0);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(dsd_event_enrich_alias(&state, 0U, first.epoch, "UNIT") == 1);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(expect_str_eq("first segment logs the partial alias", event_history[0].Event_History_Items[1].alias, "UNIT")
+           == 0);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_call_snapshot second;
+    assert(dsd_call_state_get(&state, 0U, &second) > 0);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(dsd_event_enrich_alias(&state, 0U, second.epoch, "UNIT 12 FIRE") == 1);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_int("alias upgrade commits one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_str_eq("merge takes the fuller alias", event_history[0].Event_History_Items[1].alias, "UNIT 12 FIRE");
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// System identifiers decoded only by a later segment have to reach the merged row. The first
+// segment's placeholder sysid_string is non-empty, so a fill-if-blank merge would strand both
+// the string and the numeric ids that structured consumers read.
+static int
+test_merge_carries_late_system_identifiers(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    // Late entry: no NAC/WACN yet, so the row renders from all-zero system ids.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_P25P1_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(event_history[0].Event_History_Items[1].sys_id1 == 0U);
+
+    // The reacquired segment decodes the network status.
+    state.p2_wacn = 0xBEE00U;
+    state.p2_sysid = 0x123U;
+    state.nac = 0x321U;
+    assert(observe_test_call(&state, 0U, DSD_SYNC_P25P1_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    const Event_History* merged = &event_history[0].Event_History_Items[1];
+    int rc = expect_int("late system identity commits one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_int("merged row gains the wacn", (int)merged->sys_id1, 0xBEE00);
+    rc |= expect_int("merged row gains the sysid", (int)merged->sys_id2, 0x123);
+    rc |= expect_int("merged row gains the nac", (int)merged->sys_id3, 0x321);
+    // The rendered string follows the ids rather than keeping the placeholder.
+    rc |= expect_has_substr("merged row renders the network status", merged->event_string, "NET_STS:");
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// A canonical notice raised during a reacquired segment describes the transmission already in
+// history, so it must fold into that row rather than pushing a second one.
+static int
+test_notice_during_reacquisition_merges(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(committed_history_rows(&event_history[0]) == 1);
+
+    // The segment reopens and only then is the call found to be encrypted.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    dsd_call_snapshot reacquired;
+    assert(dsd_call_state_get(&state, 0U, &reacquired) > 0);
+    assert(dsd_event_emit_call_notice(&opts, &state, 0U, &reacquired, "ENC LO") == 1);
+
+    int rc = expect_int("notice during reacquisition does not duplicate the row",
+                        committed_history_rows(&event_history[0]), 1);
+    rc |= expect_str_eq("merged row carries the notice detail", event_history[0].Event_History_Items[1].internal_str,
+                        "ENC LO");
+    rc |= expect_int("merged row keeps its identity", (int)event_history[0].Event_History_Items[1].target_id, 100);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// A row committed while reading a file may carry no stamped event_time -- the replay timeline
+// supplies it, and it is legitimately absent when that timeline has no timestamp. A merge must
+// then recover the prefix the row already displays rather than restamping it from epoch zero.
+static int
+test_merge_without_event_time_keeps_the_row_timestamp(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.playfiles = 1; // as -r does: event_time is the replay timeline's to set, not the clock's
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(event_history[0].Event_History_Items[1].event_time == 0);
+
+    // Segment 2 learns the source, so the row is re-rendered.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 201U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    const Event_History* merged = &event_history[0].Event_History_Items[1];
+    int rc = expect_int("replayed merge commits one row", committed_history_rows(&event_history[0]), 1);
+    // The stub clock renders 2026-04-30; an event_time of 0 would render 1970-01-01 instead.
+    rc |= expect_has_substr("merged row keeps its original date", merged->event_string, "2026-04-30");
+    rc |= expect_int("merged row still gained the source", (int)merged->source_id, 201);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The per-protocol builders read decoder state the history row does not carry. A merge must
+// re-render against the values captured when the row was committed, not against a decoder that
+// has since retuned -- otherwise a committed row is rewritten with a channel the call never used.
+static int
+test_merge_rerenders_against_committed_environment(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    state.nxdn_grant_chan = 12U;
+    state.nxdn_grant_freq = 851012500;
+    assert(observe_test_call(&state, 0U, DSD_SYNC_NXDN_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(expect_has_substr("first segment renders its granted channel",
+                             event_history[0].Event_History_Items[1].event_string, "CH: 12;")
+           == 0);
+
+    // The trunk SM retunes before the segment is reacquired.
+    state.nxdn_grant_chan = 44U;
+    state.nxdn_grant_freq = 852000000;
+    assert(observe_test_call(&state, 0U, DSD_SYNC_NXDN_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 201U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    const Event_History* merged = &event_history[0].Event_History_Items[1];
+    int rc = expect_int("retuned merge commits one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_has_substr("merged row keeps the channel it was committed under", merged->event_string, "CH: 12;");
+    rc |= expect_int("merged row still gained the source", (int)merged->source_id, 201);
     dsd_state_ext_free_all(&state);
     return rc;
 }
@@ -2550,6 +2961,9 @@ main(void) {
     rc |= test_provisional_voice_identity_does_not_commit_zero_row();
     rc |= test_new_canonical_epoch_commits_prior_canonical_call();
     rc |= test_reacquired_transmission_commits_one_row();
+    rc |= test_identityless_ended_epoch_does_not_reacquire();
+    rc |= test_reacquired_stage_superseded_by_new_call_still_merges();
+    rc |= test_reacquisition_after_uncommitted_epoch_does_not_merge_stale_row();
     rc |= test_reacquired_transmission_via_continue_commits_one_row();
     rc |= test_back_to_back_same_identity_calls_commit_two_rows();
     rc |= test_explicit_end_then_identityless_reopen_commits_two_rows();
@@ -2567,6 +2981,12 @@ main(void) {
     rc |= test_history_reset_clears_commit_bookkeeping();
     rc |= test_context_restore_invalidates_commit_bookkeeping();
     rc |= test_merge_logs_continuation_only_when_render_changes();
+    rc |= test_merge_logs_metadata_the_segment_added();
+    rc |= test_merge_upgrades_partial_alias();
+    rc |= test_merge_carries_late_system_identifiers();
+    rc |= test_notice_during_reacquisition_merges();
+    rc |= test_merge_without_event_time_keeps_the_row_timestamp();
+    rc |= test_merge_rerenders_against_committed_environment();
     rc |= test_repeated_data_notices_are_not_coalesced();
     rc |= test_late_source_enriches_matching_canonical_call();
     rc |= test_active_canonical_call_does_not_suppress_explicit_data();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -120,6 +120,7 @@ canonical_snapshot_reader(void* arg) {
 
 static int g_open_wav_count;
 static int g_close_wav_count;
+static SNDFILE* g_open_wav_result;
 static double g_observed_m;
 
 SNDFILE*
@@ -130,7 +131,7 @@ open_wav_file(char* dir, char* temp_filename, size_t temp_filename_size, uint16_
     UNUSED(sample_rate);
     UNUSED(ext);
     g_open_wav_count++;
-    return NULL;
+    return g_open_wav_result;
 }
 
 SNDFILE*
@@ -203,6 +204,7 @@ reset_fixture(dsd_opts* opts, dsd_state* state, Event_History_I event_history[2]
     g_last_frame_log[0] = '\0';
     g_open_wav_count = 0;
     g_close_wav_count = 0;
+    g_open_wav_result = NULL;
     g_observed_m = 1.0;
 }
 
@@ -1658,8 +1660,11 @@ test_reacquired_transmission_commits_one_row(void) {
     static dsd_opts opts;
     static dsd_state state;
     static Event_History_I event_history[2];
+    static max_align_t wav_sentinel;
     reset_fixture(&opts, &state, event_history);
     opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_END;
+    opts.wav_out_f = (SNDFILE*)&wav_sentinel;
+    g_open_wav_result = (SNDFILE*)&wav_sentinel;
 
     for (int pass = 0; pass < 3; pass++) {
         assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
@@ -1674,6 +1679,38 @@ test_reacquired_transmission_commits_one_row(void) {
     rc |= expect_int("reacquired transmission emits one call end alert", g_beeper_count, 1);
     rc |= expect_int("reacquired transmission keeps committed target",
                      (int)event_history[0].Event_History_Items[1].target_id, 100);
+    rc |= expect_int("each reacquired segment finalizes its WAV", g_close_wav_count, 3);
+    rc |= expect_int("each reacquired segment opens a fresh WAV", g_open_wav_count, 3);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// An explicit BEGIN is positive evidence of a distinct transmission even when
+// it repeats the identity that was just committed.
+static int
+test_back_to_back_same_identity_calls_commit_two_rows(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_END;
+
+    for (int pass = 0; pass < 2; pass++) {
+        assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                                 DSD_CALL_BOUNDARY_BEGIN)
+               == 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+        assert(dsd_call_state_end(&state, 0U, 0.0) == 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+    }
+
+    int rc =
+        expect_int("back-to-back same-identity calls commit two rows", committed_history_rows(&event_history[0]), 2);
+    rc |= expect_int("back-to-back calls each emit a call end alert", g_beeper_count, 2);
+    rc |= expect_int("newest same-identity row keeps target", (int)event_history[0].Event_History_Items[1].target_id,
+                     100);
+    rc |=
+        expect_int("prior same-identity row keeps target", (int)event_history[0].Event_History_Items[2].target_id, 100);
     dsd_state_ext_free_all(&state);
     return rc;
 }
@@ -1968,6 +2005,7 @@ main(void) {
     rc |= test_provisional_voice_identity_does_not_commit_zero_row();
     rc |= test_new_canonical_epoch_commits_prior_canonical_call();
     rc |= test_reacquired_transmission_commits_one_row();
+    rc |= test_back_to_back_same_identity_calls_commit_two_rows();
     rc |= test_changed_identity_still_commits_its_own_row();
     rc |= test_repeated_data_notices_are_not_coalesced();
     rc |= test_late_source_enriches_matching_canonical_call();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -3030,6 +3030,85 @@ test_call_context_snapshot_restores_committed_end(void) {
     return rc;
 }
 
+// A sync-loss VOICE_END is held for the length of the reacquisition window. At shutdown there is
+// no further audio to reacquire with, and the per-frame drain only fires once that window has
+// elapsed, so an end armed in the last half second before exit would never be heard. The
+// force-flush entry point the engine calls after its final snapshot pass has to retire it.
+static int
+test_pending_end_alert_is_flushed_at_shutdown(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START | DSD_CALL_ALERT_EVENT_VOICE_END;
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    // Still held: the deadline is on the monotonic clock and has not passed.
+    int rc = expect_int("sync-loss end is still held before shutdown", g_beeper_count, 1);
+    dsd_event_flush_pending_alerts(&opts, &state);
+    rc |= expect_int("shutdown retires the held END", g_beeper_count, 2);
+    // Idempotent: the engine's cleanup path is not the only thing that may run at exit.
+    dsd_event_flush_pending_alerts(&opts, &state);
+    rc |= expect_int("shutdown flush does not double-beep", g_beeper_count, 2);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// Clearing the event history destroys the rows the lifecycle points at. A VOICE_END held against
+// a reacquisition that will never come must go with them, or it beeps for a transmission the
+// operator can no longer see.
+static int
+test_history_reset_drops_pending_end_alert(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START | DSD_CALL_ALERT_EVENT_VOICE_END;
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    int rc = expect_int("sync-loss end is held before reset", g_beeper_count, 1);
+    rc |= expect_int("sync-loss end committed a row", committed_history_rows(&event_history[0]), 1);
+
+    dsd_event_history_reset(&state);
+    rc |= expect_int("reset clears the rows", committed_history_rows(&event_history[0]), 0);
+
+    // Neither the deadline passing nor an explicit flush may resurrect it.
+    dsd_event_sync_slot(&opts, &state, 0U);
+    dsd_event_flush_pending_alerts(&opts, &state);
+    rc |= expect_int("reset drops the held END with the rows it described", g_beeper_count, 1);
+
+    // The ended call must not be re-rendered into the cleared history either: the row the
+    // operator deleted stays deleted.
+    rc |= expect_int("reset does not resurrect the committed row", committed_history_rows(&event_history[0]), 0);
+
+    // The next call still behaves normally.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 500U, 900U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("call after reset alerts START", g_beeper_count, 2);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("call after reset commits its row", committed_history_rows(&event_history[0]), 1);
+    rc |=
+        expect_int("call after reset keeps its identity", (int)event_history[0].Event_History_Items[1].target_id, 500);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -3071,6 +3150,8 @@ main(void) {
     rc |= test_reacquired_transmission_commits_one_row();
     rc |= test_terminator_after_sync_loss_end_blocks_reacquisition();
     rc |= test_end_reason_upgrade_is_one_directional();
+    rc |= test_pending_end_alert_is_flushed_at_shutdown();
+    rc |= test_history_reset_drops_pending_end_alert();
     rc |= test_identityless_ended_epoch_does_not_reacquire();
     rc |= test_reacquired_stage_superseded_by_new_call_still_merges();
     rc |= test_reacquisition_after_uncommitted_epoch_does_not_merge_stale_row();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -1739,6 +1739,114 @@ test_reacquired_transmission_commits_one_row(void) {
     return rc;
 }
 
+// A DMR fade at the tail of a transmission ends the epoch by sync loss; the terminator that
+// explains it decodes a moment later, after the epoch is already ENDED. That terminator is
+// positive evidence the transmission is over, so it has to retract the reacquisition permission
+// the sync-loss end granted -- otherwise a second PTT on the same identity inside the window
+// (a routine double-tap) folds into the terminated call's row and loses its START. The held
+// VOICE_END must also land at the terminator rather than waiting out the full window.
+static int
+test_terminator_after_sync_loss_end_blocks_reacquisition(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START | DSD_CALL_ALERT_EVENT_VOICE_END;
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    int rc = expect_int("call start alerts once", g_beeper_count, 1);
+
+    // The fade. noCarrier() ends the epoch; the VOICE_END is held because this could still be the
+    // middle of the transmission.
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("sync-loss end holds the END alert", g_beeper_count, 1);
+    rc |= expect_int("sync-loss end commits the row", committed_history_rows(&event_history[0]), 1);
+
+    // The Terminator-with-LC, arriving after the epoch already ended. dmr_flco_prepare_regular_state()
+    // reaches dsd_call_state_end() with the slot in ENDED, so the reason is tightened in place.
+    rc |= expect_int("terminator upgrades an already-ended epoch", end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("terminator retires the held END immediately", g_beeper_count, 2);
+    {
+        dsd_call_snapshot call;
+        assert(dsd_call_state_get(&state, 0U, &call) == 1);
+        rc |= expect_int("terminator leaves the epoch ENDED", (int)call.phase, (int)DSD_CALL_PHASE_ENDED);
+        rc |= expect_int("terminator clears the sync-loss reason", (int)call.end_reason, (int)DSD_CALL_END_EXPLICIT);
+    }
+
+    // Second PTT on the same TG/SRC, well inside DSD_CALL_REACQUIRE_GAP_S. Positive termination
+    // has already been decoded, so this is a new transmission and gets its own row and START.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("post-terminator PTT alerts its own START", g_beeper_count, 3);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("post-terminator PTT commits its own row", committed_history_rows(&event_history[0]), 2);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The upgrade above is one-directional. A sync loss that follows an explicit teardown must not be
+// able to re-arm reacquisition on an epoch that was already positively terminated, and no end
+// reason may restamp ended_m once the epoch is closed -- the repeated noCarrier() calls that fire
+// while unsynced would otherwise walk the reacquisition window forward indefinitely.
+static int
+test_end_reason_upgrade_is_one_directional(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START | DSD_CALL_ALERT_EVENT_VOICE_END;
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
+
+    dsd_call_snapshot after_explicit;
+    assert(dsd_call_state_get(&state, 0U, &after_explicit) == 1);
+
+    // Sync loss reported after the terminator: no-op, exactly as before.
+    int rc =
+        expect_int("sync loss after explicit end is a no-op", end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS), 0);
+    // A repeated terminator is also a no-op: the reason already is EXPLICIT.
+    rc |= expect_int("repeated explicit end is a no-op", end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT), 0);
+
+    dsd_call_snapshot after_repeats;
+    assert(dsd_call_state_get(&state, 0U, &after_repeats) == 1);
+    rc |= expect_int("explicit end reason survives a later sync loss", (int)after_repeats.end_reason,
+                     (int)DSD_CALL_END_EXPLICIT);
+    rc |=
+        expect_int("repeated ends do not restamp ended_m", after_repeats.ended_m == after_explicit.ended_m ? 1 : 0, 1);
+
+    // And the upgrade path itself must not restamp: the moment the transmission stopped is the
+    // fade, not the terminator that explained it.
+    reset_fixture(&opts, &state, event_history);
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_call_snapshot after_fade;
+    assert(dsd_call_state_get(&state, 0U, &after_fade) == 1);
+    advance_test_clock(0.2);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
+    dsd_call_snapshot after_upgrade;
+    assert(dsd_call_state_get(&state, 0U, &after_upgrade) == 1);
+    rc |= expect_int("upgrade keeps ended_m anchored at the fade", after_upgrade.ended_m == after_fade.ended_m ? 1 : 0,
+                     1);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 // The reacquisition test above relies on the ending epoch naming a call. The inverse must not
 // coalesce: an identity-less epoch is compatible with every observation, so if it were allowed to
 // reacquire, the next unrelated call on the slot would be folded into its row and lose its START.
@@ -2961,6 +3069,8 @@ main(void) {
     rc |= test_provisional_voice_identity_does_not_commit_zero_row();
     rc |= test_new_canonical_epoch_commits_prior_canonical_call();
     rc |= test_reacquired_transmission_commits_one_row();
+    rc |= test_terminator_after_sync_loss_end_blocks_reacquisition();
+    rc |= test_end_reason_upgrade_is_one_directional();
     rc |= test_identityless_ended_epoch_does_not_reacquire();
     rc |= test_reacquired_stage_superseded_by_new_call_still_merges();
     rc |= test_reacquisition_after_uncommitted_epoch_does_not_merge_stale_row();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -174,6 +174,11 @@ getAfsStringFromBits(int a_bits, int f_bits, int s_bits, char* buffer, int a, in
     return DSD_SNPRINTF(buffer, 7, "%02d-%02d%01d", a, f, s);
 }
 
+// A stamp standing in for the one a replay timeline supplies (dsd_file.c), distinct from the wall
+// clock the builders render their prefix from. It renders as its own date below so a test can tell
+// which of the two a row was rendered from.
+#define TEST_REPLAY_EVENT_TIME ((time_t)1000000000)
+
 int
 dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, char* out, size_t out_size) {
     // An unstamped time really does render as the epoch, so the stub has to say so: rendering a
@@ -183,6 +188,13 @@ dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, ch
         DSD_SNPRINTF(out, out_size, "%s", epoch);
         return 1;
     }
+    if (timestamp == TEST_REPLAY_EVENT_TIME) {
+        const char* replay = (format == DSD_LOCAL_DATETIME_DATE_HYPHEN) ? "2001-09-09" : "01:46:40";
+        DSD_SNPRINTF(out, out_size, "%s", replay);
+        return 1;
+    }
+    // Everything else is the live wall clock, which the fixture cannot pin; one stable rendering
+    // keeps the prefix assertions deterministic.
     const char* value = (format == DSD_LOCAL_DATETIME_DATE_HYPHEN) ? "2026-04-30" : "00:00:00";
     DSD_SNPRINTF(out, out_size, "%s", value);
     return 1;
@@ -2295,6 +2307,57 @@ test_reacquired_segment_contributes_late_source(void) {
     return rc;
 }
 
+// A merge re-renders the surviving row, and that render has to reuse the timestamp the row is
+// already displaying rather than the stamp beside it -- the two are not always the same clock.
+// Every builder renders the prefix from the wall clock, but watchdog_event_current_update_item()
+// only stamps event_time when opts->playfiles == 0; replaying an sdrtrunk recording leaves it at
+// the recording's own time instead (dsd_file.c). Preferring the stamp would rewrite the row's
+// visible date and time to a value none of its siblings use, purely because it was merged.
+static int
+test_merge_preserves_row_timestamp_under_playfiles(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.playfiles = 1;
+    // What the sdrtrunk JSON reader stamps on the staging row, decades from the wall clock the
+    // prefix is rendered from.
+    event_history[0].Event_History_Items[0].event_time = TEST_REPLAY_EVENT_TIME;
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    const Event_History* committed = &event_history[0].Event_History_Items[1];
+    assert(committed->event_time == TEST_REPLAY_EVENT_TIME);
+    char prefix_before[20];
+    DSD_SNPRINTF(prefix_before, sizeof prefix_before, "%s", committed->event_string);
+
+    // A late source guarantees the merge really does re-render rather than declining to.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 201U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    const Event_History* merged = &event_history[0].Event_History_Items[1];
+    char prefix_after[20];
+    DSD_SNPRINTF(prefix_after, sizeof prefix_after, "%s", merged->event_string);
+
+    int rc = expect_int("playfiles merge commits one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_has_substr("playfiles merge re-rendered the row", merged->event_string, "SRC: 00000201;");
+    rc |= expect_str_eq("merge keeps the row's rendered timestamp", prefix_after, prefix_before);
+    // Pins which of the two clocks survived: the wall clock the row was rendered from, not the
+    // replay stamp sitting beside it.
+    rc |= expect_str_eq("merged row still shows the rendered clock", prefix_after, "2026-04-30 00:00:00");
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 // The PI/ESS header can decode only after the reacquisition. Dropping that commit would leave
 // the sole surviving row marked clear for a call that was encrypted.
 static int
@@ -3628,6 +3691,7 @@ main(void) {
     rc |= test_dmr_sync_polarity_flip_still_coalesces();
     rc |= test_textual_identity_reacquisition_coalesces();
     rc |= test_reacquired_segment_contributes_late_source();
+    rc |= test_merge_preserves_row_timestamp_under_playfiles();
     rc |= test_reacquired_segment_contributes_crypto();
     rc |= test_reacquired_segment_contributes_alias_and_gps();
     rc |= test_interleaved_data_notice_does_not_misdirect_merge();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -6,6 +6,7 @@
 #include <assert.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/constants.h>
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
@@ -1884,6 +1885,119 @@ test_identityless_ended_epoch_does_not_reacquire(void) {
     return rc;
 }
 
+// Route text counts as identity when deciding whether an ended epoch is anchored enough to be
+// reacquired, so it has to count when deciding whether an observation contradicts that epoch too.
+// A late-entry D-STAR call that learned only its repeater pair would otherwise be an anchor nothing
+// could reject, and the next call through a different repeater -- or an identity-less vocoder mark
+// -- would be folded into its row.
+static int
+test_route_only_identity_does_not_reacquire_unrelated_call(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START;
+    state.lastsynctype = DSD_SYNC_DSTAR_VOICE_POS;
+
+    dsd_call_observation observation = {
+        .protocol = DSD_SYNC_DSTAR_VOICE_POS,
+        .slot = 0U,
+        .kind = DSD_CALL_KIND_VOICE,
+    };
+    DSD_SNPRINTF(observation.route_text[0], sizeof(observation.route_text[0]), "%s", "RPT1AAA");
+    DSD_SNPRINTF(observation.route_text[1], sizeof(observation.route_text[1]), "%s", "RPT2AAA");
+    observation.observed_m = g_observed_m;
+    g_observed_m += 0.1;
+    assert(dsd_call_state_observe(&state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(committed_history_rows(&event_history[0]) == 1);
+
+    // A different transmission through a different repeater pair, well inside the window.
+    dsd_call_observation other = observation;
+    DSD_SNPRINTF(other.route_text[0], sizeof(other.route_text[0]), "%s", "RPT1BBB");
+    DSD_SNPRINTF(other.route_text[1], sizeof(other.route_text[1]), "%s", "RPT2BBB");
+    other.observed_m = g_observed_m;
+    g_observed_m += 0.1;
+    assert(dsd_call_state_observe(&state, &other, DSD_CALL_BOUNDARY_BEGIN) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_int("a different route commits its own row", committed_history_rows(&event_history[0]), 2);
+    rc |= expect_int("the second call alerts its own START", g_beeper_count, 2);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The same route that ended is still one transmission resuming, so the anchor must keep working in
+// the direction it was added for. Guards the fix above against being over-applied.
+static int
+test_route_identity_reacquisition_still_coalesces(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    state.lastsynctype = DSD_SYNC_DSTAR_VOICE_POS;
+
+    dsd_call_observation observation = {
+        .protocol = DSD_SYNC_DSTAR_VOICE_POS,
+        .slot = 0U,
+        .kind = DSD_CALL_KIND_VOICE,
+    };
+    DSD_SNPRINTF(observation.route_text[0], sizeof(observation.route_text[0]), "%s", "RPT1AAA");
+    DSD_SNPRINTF(observation.route_text[1], sizeof(observation.route_text[1]), "%s", "RPT2AAA");
+
+    for (int pass = 0; pass < 2; pass++) {
+        observation.observed_m = g_observed_m;
+        g_observed_m += 0.1;
+        assert(dsd_call_state_observe(&state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+        assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+    }
+
+    int rc = expect_int("the same route reacquires into one row", committed_history_rows(&event_history[0]), 1);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The gap test compares an end against a reopen on one clock, but only one side of that comparison
+// reads the clock itself: every production end site passes a timeline derived from
+// dsd_time_now_monotonic_s(), while a reopening observation usually passes 0.0 and takes the
+// fallback. If the fallback truncates to whole milliseconds it can land *behind* an end stamped at
+// nanosecond resolution moments earlier, and the reacquisition is rejected for going backwards --
+// committing a second row and a spurious START for one transmission.
+//
+// Bracketing the fallback between two reads of the same clock catches exactly that: a truncating
+// fallback can fall up to a millisecond below the lower bound, while a full-resolution one can
+// never leave the bracket.
+static int
+test_observed_fallback_matches_end_site_clock_resolution(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    const double before = dsd_time_now_monotonic_s();
+    // observed_m of 0.0 is what the protocol end paths pass, so this takes the fallback.
+    assert(dsd_call_state_end_ex(&state, 0U, 0.0, DSD_CALL_END_SYNC_LOSS) == 1);
+    const double after = dsd_time_now_monotonic_s();
+
+    dsd_call_snapshot ended;
+    assert(dsd_call_state_get(&state, 0U, &ended) > 0);
+    int rc = expect_int("the fallback clock is not behind the end-site clock", ended.ended_m >= before, 1);
+    rc |= expect_int("the fallback clock is not ahead of the end-site clock", ended.ended_m <= after, 1);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 // The re-announcing protocols (P25 Phase 2, NXDN, dPMR, D-STAR, EDACS, X2-TDMA, DMR embedded
 // LCs) reopen with CONTINUE. They must arm the same way the identity-less BEGIN path does.
 static int
@@ -2346,6 +2460,40 @@ test_history_reset_clears_commit_bookkeeping(void) {
     return rc;
 }
 
+// Both halves of the render-environment pair have to go when the lifecycle is invalidated. A row
+// staged directly by a protocol never passes through the renderer, so a staged_env left behind by
+// the reset would be promoted into committed_env when that row commits, and a later merge would
+// re-render the row against a decoder context from before the operator cleared history.
+static int
+test_history_reset_clears_staged_environment(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    state.nxdn_grant_chan = 12U;
+    state.nxdn_grant_freq = 851012500;
+    assert(observe_test_call(&state, 0U, DSD_SYNC_NXDN_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    dsd_call_context_snapshot before;
+    assert(dsd_call_context_copy_snapshot(&state, &before) > 0);
+    assert(before.events[0].staged_env.nxdn_grant_chan == 12U);
+
+    dsd_event_history_reset(&state);
+
+    dsd_call_context_snapshot after;
+    assert(dsd_call_context_copy_snapshot(&state, &after) > 0);
+    int rc =
+        expect_int("reset clears the staged render environment", (int)after.events[0].staged_env.nxdn_grant_chan, 0);
+    rc |= expect_int("reset clears the committed render environment",
+                     (int)after.events[0].committed_env.nxdn_grant_chan, 0);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 // The reacquisition marker names the epoch it belongs to and must survive until that epoch's
 // staged row is flushed. If a later, different call clears it first, the staged row commits a
 // second time and the reacquired transmission ends up with two rows -- the exact duplicate this
@@ -2552,6 +2700,69 @@ test_merge_logs_continuation_only_when_render_changes(void) {
     return rc;
 }
 
+// The slot annotation on a continuation describes the row being continued, so it has to come from
+// that row rather than from the live decoder. A DMR-BS transmission reacquired after the decoder
+// has resynced elsewhere -- or after no_carrier_reset_decode_state() cleared lastsynctype -- would
+// otherwise log its two halves with different annotations.
+static int
+test_merge_continuation_annotates_from_the_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    char path[] = "/tmp/dsd-neo-continuation-slot-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "mkstemp failed for continuation slot test\n");
+        return 1;
+    }
+    close(fd);
+    (void)remove(path);
+    DSD_SNPRINTF(opts.event_out_file, sizeof opts.event_out_file, "%s", path);
+
+    // Slot 1 of a DMR-BS call: the first commit is annotated "Slot 2;".
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    assert(observe_test_call(&state, 1U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 1U);
+    assert(end_test_call(&state, 1U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 1U);
+
+    // The decoder loses the system entirely across the gap, as noCarrier() leaves it.
+    state.lastsynctype = DSD_SYNC_NONE;
+    assert(observe_test_call(&state, 1U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 201U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 1U);
+    assert(end_test_call(&state, 1U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 1U);
+
+    FILE* f = fopen(path, "rb");
+    if (f == NULL) {
+        (void)remove(path);
+        DSD_FPRINTF(stderr, "continuation slot event log was not created\n");
+        return 1;
+    }
+    char buf[8192];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    fclose(f);
+    (void)remove(path);
+    buf[n] = '\0';
+
+    const char* continuation = strstr(buf, " Reacquired: ");
+    int rc = expect_int("the reacquired segment merged into one row", committed_history_rows(&event_history[1]), 1);
+    if (continuation == NULL) {
+        DSD_FPRINTF(stderr, "expected a continuation line in the event log\n");
+        rc |= 1;
+    } else {
+        rc |= expect_has_substr("continuation keeps the row's slot annotation", continuation, "Slot 2;");
+    }
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 // Optional detail a reacquired segment contributes reaches the event log even when it does not
 // change the rendered row -- otherwise it would show in the UI history and be missing from the
 // log. The continuation also carries the slot annotation that every normal commit carries.
@@ -2723,6 +2934,83 @@ test_notice_during_reacquisition_merges(void) {
     rc |= expect_str_eq("merged row carries the notice detail", event_history[0].Event_History_Items[1].internal_str,
                         "ENC LO");
     rc |= expect_int("merged row keeps its identity", (int)event_history[0].Event_History_Items[1].target_id, 100);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The notice above merges and, in doing so, makes the reacquired epoch the owner of the committed
+// row. When that same epoch later ends it commits a second time, and that commit has to land in the
+// row the epoch already owns. Matching only the interrupted epoch's row would reject it and push a
+// duplicate -- one transmission, two history rows, which is what the merge path exists to prevent.
+static int
+test_notice_then_end_in_reacquired_epoch_commits_one_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(committed_history_rows(&event_history[0]) == 1);
+
+    // The segment is reacquired and a notice fires mid-segment, merging into the committed row.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    dsd_call_snapshot reacquired;
+    assert(dsd_call_state_get(&state, 0U, &reacquired) > 0);
+    assert(dsd_event_emit_call_notice_nonfinalizing(&opts, &state, 0U, &reacquired, "ENC LO") == 1);
+    assert(committed_history_rows(&event_history[0]) == 1);
+
+    // The merge cleared the staged row, so the segment keeps decoding and stages it again. Ending
+    // then commits a second time within the one epoch.
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_int("notice then end in one reacquired epoch commits one row",
+                        committed_history_rows(&event_history[0]), 1);
+    rc |= expect_str_eq("surviving row keeps the notice detail", event_history[0].Event_History_Items[1].internal_str,
+                        "ENC LO");
+    rc |= expect_int("surviving row keeps its identity", (int)event_history[0].Event_History_Items[1].target_id, 100);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// A sync-loss end whose staged row rendered nothing put no row in history, so there is no
+// transmission for a VOICE_END to be about. The FINAL disposition cannot alert in that case --
+// its beep lives inside the commit -- and the deferred one must not either. X2-TDMA is the
+// concrete case: no builder covers it, so its rows render empty.
+static int
+test_contentless_sync_loss_end_arms_no_alert(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START | DSD_CALL_ALERT_EVENT_VOICE_END;
+    state.lastsynctype = DSD_SYNC_X2TDMA_VOICE_POS;
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_X2TDMA_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    const int start_alerts = g_beeper_count;
+
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_int("a row that renders nothing commits nothing", committed_history_rows(&event_history[0]), 0);
+    // Asserted on the lifecycle rather than by waiting out the deadline: the alert is held against
+    // the real monotonic clock, which the fixture's timeline does not drive.
+    dsd_call_context_snapshot context;
+    assert(dsd_call_context_copy_snapshot(&state, &context) > 0);
+    rc |= expect_int("no VOICE_END is held for a transmission with no row", context.events[0].end_alert_pending, 0);
+    rc |= expect_int("nothing beeped past the START", g_beeper_count, start_alerts);
     dsd_state_ext_free_all(&state);
     return rc;
 }
@@ -3237,6 +3525,10 @@ main(void) {
     rc |= test_pending_end_alert_is_flushed_at_shutdown();
     rc |= test_history_reset_drops_pending_end_alert();
     rc |= test_identityless_ended_epoch_does_not_reacquire();
+    rc |= test_route_only_identity_does_not_reacquire_unrelated_call();
+    rc |= test_route_identity_reacquisition_still_coalesces();
+    rc |= test_observed_fallback_matches_end_site_clock_resolution();
+    rc |= test_contentless_sync_loss_end_arms_no_alert();
     rc |= test_reacquired_stage_superseded_by_new_call_still_merges();
     rc |= test_reacquisition_after_uncommitted_epoch_does_not_merge_stale_row();
     rc |= test_reacquired_transmission_via_continue_commits_one_row();
@@ -3260,6 +3552,9 @@ main(void) {
     rc |= test_merge_upgrades_partial_alias();
     rc |= test_merge_carries_late_system_identifiers();
     rc |= test_notice_during_reacquisition_merges();
+    rc |= test_notice_then_end_in_reacquired_epoch_commits_one_row();
+    rc |= test_merge_continuation_annotates_from_the_row();
+    rc |= test_history_reset_clears_staged_environment();
     rc |= test_merge_without_event_time_keeps_the_row_timestamp();
     rc |= test_merge_rerenders_against_committed_environment();
     rc |= test_epoch_change_commit_keeps_staged_environment();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -2803,6 +2803,90 @@ test_merge_rerenders_against_committed_environment(void) {
     return rc;
 }
 
+// The test above commits the first segment's row from its own end, while the decoder still
+// describes it. A row is also committed from the other direction -- the next epoch opening finds
+// a staged row and pushes it -- and by then the canonical layer has already moved to the incoming
+// call. Capturing the environment at that moment reads the new call's channel, so the row is
+// re-rendered under a channel the transmission it describes never used.
+static int
+test_epoch_change_commit_keeps_staged_environment(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    state.nxdn_grant_chan = 12U;
+    state.nxdn_grant_freq = 851012500;
+    assert(observe_test_call(&state, 0U, DSD_SYNC_NXDN_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 0U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    // Sync loss with no further pass: the staged row is left for the next epoch to commit, which
+    // is the path watchdog_event_history_authoritative() takes.
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+
+    // The decoder retunes before the segment is reacquired, so the live grant channel now
+    // describes the incoming call rather than the staged row.
+    state.nxdn_grant_chan = 44U;
+    state.nxdn_grant_freq = 852000000;
+    assert(observe_test_call(&state, 0U, DSD_SYNC_NXDN_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 201U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_CONTINUE)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    int rc = expect_has_substr("row committed at the epoch change keeps its own channel",
+                               event_history[0].Event_History_Items[1].event_string, "CH: 12;");
+
+    // Ending the reacquired segment merges it into that row and re-renders it. The environment
+    // the merge renders against is the one captured with the row, not the retuned decoder.
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    const Event_History* merged = &event_history[0].Event_History_Items[1];
+    rc |= expect_int("epoch-change merge commits one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_has_substr("merged row keeps the channel it was staged under", merged->event_string, "CH: 12;");
+    rc |= expect_int("merged row still gained the source", (int)merged->source_id, 201);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// A merged row is re-rendered from its own fields plus the captured environment, and that render
+// has to agree with the one the unmerged path produces. Encryption is the case that matters: a
+// row carries only the derived flag, so the classification the builders also test must be rebuilt
+// from it rather than left unset.
+static int
+test_merged_row_keeps_encryption_marker(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    assert(observe_test_call(&state, 0U, DSD_SYNC_P25P1_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    assert(update_test_crypto(&state, 0U, DSD_CALL_CRYPTO_ENCRYPTED, 0x84U, 0x1234U, 0U) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    int rc = expect_has_substr("first segment marks encryption", event_history[0].Event_History_Items[1].event_string,
+                               "ENC;");
+
+    // Reacquired segment folds into that row and re-renders it.
+    assert(observe_test_call(&state, 0U, DSD_SYNC_P25P1_POS, DSD_CALL_KIND_GROUP_VOICE, 100U, 200U, 0U, 0U,
+                             DSD_CALL_BOUNDARY_BEGIN)
+           == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    assert(end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS) == 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+
+    rc |= expect_int("encrypted reacquisition commits one row", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_has_substr("merged row keeps the encryption marker",
+                            event_history[0].Event_History_Items[1].event_string, "ENC;");
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 // Data calls describe distinct receptions and are never coalesced, even when the canonical
 // layer flags the epoch as reacquired.
 static int
@@ -3178,6 +3262,8 @@ main(void) {
     rc |= test_notice_during_reacquisition_merges();
     rc |= test_merge_without_event_time_keeps_the_row_timestamp();
     rc |= test_merge_rerenders_against_committed_environment();
+    rc |= test_epoch_change_commit_keeps_staged_environment();
+    rc |= test_merged_row_keeps_encryption_marker();
     rc |= test_repeated_data_notices_are_not_coalesced();
     rc |= test_late_source_enriches_matching_canonical_call();
     rc |= test_active_canonical_call_does_not_suppress_explicit_data();

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -20,6 +20,7 @@
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <math.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -230,6 +231,20 @@ int
 __wrap_rtl_stream_request_fsk_reacquire(void) {
     g_rtl_fsk_reacquire_requests++;
     return 1;
+}
+
+// Rigctl needs a success path here, not just the socket-failure one the rest of the file uses:
+// the interesting case is a hop whose rigctl leg lands and whose RTL leg then does not.
+static int g_rigctl_setfreq_ok = 0;
+static int g_rigctl_setfreq_calls = 0;
+static long int g_rigctl_setfreq_freq = 0;
+
+bool
+__wrap_SetFreq(dsd_socket_t sockfd, long int freq) {
+    (void)sockfd;
+    g_rigctl_setfreq_calls++;
+    g_rigctl_setfreq_freq = freq;
+    return g_rigctl_setfreq_ok ? true : false;
 }
 
 // NOLINTEND(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
@@ -618,6 +633,62 @@ main(void) {
     rc |= expect_true("scanner-hop-ends-call", scanned_snapshot.phase == DSD_CALL_PHASE_ENDED);
     rc |=
         expect_true("scanner-hop-ends-call-explicitly", scanned_snapshot.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    // With both backends configured the rigctl leg runs first. If it lands and the RTL leg then
+    // fails, the scan step is abandoned -- but the radio has already moved off the frequency the
+    // open call was decoded from. The end must still be EXPLICIT: reporting sync loss would leave
+    // the call reacquirable by whatever the new frequency happens to carry.
+    opts->scanner_mode = 1;
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->use_rigctl = 1;
+    opts->rigctl_sockfd = DSD_INVALID_SOCKET;
+    opts->setmod_bw = 0;
+    opts->trunk_hangtime = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    // Frequencies no earlier case in this file uses: engine.c caches the last rigctl and RTL tune
+    // in file statics that outlive free_test_runtime(), and a repeat would be skipped as a no-op.
+    state->trunk_lcn_freq[0] = 942012500;
+    state->trunk_lcn_freq[1] = 943012500;
+    state->lcn_freq_count = 2;
+    state->lcn_freq_roll = 0;
+    state->last_cc_sync_time = time(NULL) - 11;
+    const time_t partial_hop_scan_time = state->last_cc_sync_time;
+    g_rigctl_setfreq_ok = 1;
+    g_rigctl_setfreq_calls = 0;
+    g_rtl_tune_result = RTL_STREAM_TUNE_FAILED;
+    g_rtl_tune_calls = 0;
+
+    dsd_call_observation partial_hop_call = {0};
+    partial_hop_call.protocol = DSD_SYNC_NXDN_POS;
+    partial_hop_call.slot = 0U;
+    partial_hop_call.kind = DSD_CALL_KIND_GROUP_VOICE;
+    partial_hop_call.ota_target_id = 7201U;
+    partial_hop_call.policy_target_id = 7201U;
+    partial_hop_call.ota_source_id = 8201U;
+    partial_hop_call.observed_m = 1.0;
+    rc |= expect_true("partial-hop-seeds-call",
+                      dsd_call_state_observe(state, &partial_hop_call, DSD_CALL_BOUNDARY_BEGIN) == 1);
+
+    noCarrier(opts, state);
+
+    dsd_call_snapshot partial_hop_snapshot;
+    rc |= expect_true("partial-hop-moved-rigctl", g_rigctl_setfreq_calls > 0 && g_rigctl_setfreq_freq == 942012500);
+    rc |= expect_true("partial-hop-rtl-failed", g_rtl_tune_calls > 0);
+    // The step itself is still abandoned: the candidate and the deadline are untouched so the next
+    // pass retries this entry rather than skipping it.
+    rc |= expect_true("partial-hop-keeps-candidate", state->lcn_freq_roll == 0);
+    rc |= expect_true("partial-hop-keeps-deadline", state->last_cc_sync_time == partial_hop_scan_time);
+    rc |= expect_true("partial-hop-retains-snapshot", dsd_call_state_get(state, 0U, &partial_hop_snapshot) == 1);
+    rc |= expect_true("partial-hop-ends-call", partial_hop_snapshot.phase == DSD_CALL_PHASE_ENDED);
+    rc |= expect_true("partial-hop-ends-call-explicitly",
+                      partial_hop_snapshot.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+    g_rigctl_setfreq_ok = 0;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
 #endif
 
     free_test_runtime(opts, state);

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -545,6 +545,86 @@ main(void) {
         return 1;
     }
 
+    // An accepted return to the control channel retunes the receiver, so a call still open on the
+    // voice channel was left behind rather than faded. Reporting that as a sync loss would leave it
+    // reacquirable, and the next transmission to appear on the control channel inside the window
+    // would be folded into its history row.
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    state->p25_cc_freq = 0;
+    state->trunk_cc_freq = 936000000;
+    state->lastsynctype = DSD_SYNC_NXDN_POS;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->last_vc_sync_time = time(NULL) - 11;
+    state->trunk_vc_freq[0] = 936500000;
+    state->trunk_vc_freq[1] = 936500000;
+
+    dsd_call_observation retuned_call = {0};
+    retuned_call.protocol = DSD_SYNC_NXDN_POS;
+    retuned_call.slot = 0U;
+    retuned_call.kind = DSD_CALL_KIND_GROUP_VOICE;
+    retuned_call.ota_target_id = 7001U;
+    retuned_call.policy_target_id = 7001U;
+    retuned_call.ota_source_id = 8001U;
+    retuned_call.observed_m = 1.0;
+    rc |=
+        expect_true("cc-return-seeds-call", dsd_call_state_observe(state, &retuned_call, DSD_CALL_BOUNDARY_BEGIN) == 1);
+
+    noCarrier(opts, state);
+
+    dsd_call_snapshot retuned_snapshot;
+    rc |= expect_true("cc-return-retains-snapshot", dsd_call_state_get(state, 0U, &retuned_snapshot) == 1);
+    rc |= expect_true("cc-return-ends-call", retuned_snapshot.phase == DSD_CALL_PHASE_ENDED);
+    rc |= expect_true("cc-return-ends-call-explicitly", retuned_snapshot.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+
+#if defined(DSD_NEO_TEST_RTL_WRAP) && DSD_NEO_TEST_RTL_WRAP
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    // The scanner half of the same rule. noCarrier() steps the scanner before it finalizes calls,
+    // so a hop that succeeds leaves the finalizer closing a call that belongs to the frequency the
+    // receiver just left.
+    opts->scanner_mode = 1;
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_hangtime = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->trunk_lcn_freq[0] = 938012500;
+    state->trunk_lcn_freq[1] = 939012500;
+    state->lcn_freq_count = 2;
+    state->lcn_freq_roll = 0;
+    state->last_cc_sync_time = time(NULL) - 11;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_tune_calls = 0;
+
+    dsd_call_observation scanned_call = {0};
+    scanned_call.protocol = DSD_SYNC_NXDN_POS;
+    scanned_call.slot = 0U;
+    scanned_call.kind = DSD_CALL_KIND_GROUP_VOICE;
+    scanned_call.ota_target_id = 7101U;
+    scanned_call.policy_target_id = 7101U;
+    scanned_call.ota_source_id = 8101U;
+    scanned_call.observed_m = 1.0;
+    rc |= expect_true("scanner-hop-seeds-call",
+                      dsd_call_state_observe(state, &scanned_call, DSD_CALL_BOUNDARY_BEGIN) == 1);
+
+    noCarrier(opts, state);
+
+    dsd_call_snapshot scanned_snapshot;
+    rc |= expect_true("scanner-hop-retuned", g_rtl_tune_calls > 0);
+    rc |= expect_true("scanner-hop-advanced", state->lcn_freq_roll == 1);
+    rc |= expect_true("scanner-hop-retains-snapshot", dsd_call_state_get(state, 0U, &scanned_snapshot) == 1);
+    rc |= expect_true("scanner-hop-ends-call", scanned_snapshot.phase == DSD_CALL_PHASE_ENDED);
+    rc |=
+        expect_true("scanner-hop-ends-call-explicitly", scanned_snapshot.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+#endif
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
     opts->scanner_mode = 1;
     state->trunk_lcn_freq[0] = 938012500;
     state->lcn_freq_count = 1;

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -12,6 +12,7 @@
  */
 
 #include <assert.h>
+#include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
@@ -80,11 +81,18 @@ static int g_runtime_config_is_set = 0;
 
 int
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-dsd_call_state_end(dsd_state* state, uint8_t slot, double observed_m) {
+dsd_call_state_end_ex(dsd_state* state, uint8_t slot, double observed_m, dsd_call_end_reason reason) {
     (void)state;
     (void)slot;
     (void)observed_m;
+    (void)reason;
     return 0;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_call_state_end(dsd_state* state, uint8_t slot, double observed_m) {
+    return dsd_call_state_end_ex(state, slot, observed_m, DSD_CALL_END_EXPLICIT);
 }
 
 void

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -1173,10 +1173,63 @@ test_completed_slco_capacity_plus_hold_returns_to_rest_channel(void) {
     dsd_state_ext_free_all(&state);
 }
 
+// The voice LC header repeats through the start of a transmission for late
+// entry. Only the first copy may open a canonical epoch: a second epoch commits
+// the first one's freshly built row as a duplicate event.
+static void
+test_repeated_voice_lc_header_keeps_one_epoch(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+
+    dsd_test_capture_stderr cap;
+    assert(dsd_test_capture_stderr_begin(&cap, "dmr_flco_repeated_header") == 0);
+
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+
+    dsd_call_snapshot call;
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.phase == DSD_CALL_PHASE_ACTIVE);
+    const uint64_t first_epoch = call.epoch;
+
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.epoch == first_epoch);
+
+    // A header naming a different talker is the next transmission, not a repeat.
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 3003U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.epoch != first_epoch);
+    assert(call.ota_source_id == 3003U);
+    const uint64_t second_epoch = call.epoch;
+
+    // A header after the terminator opens the following transmission.
+    assert(dsd_call_state_end(&state, 0U, 0.0) > 0);
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 3003U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.phase == DSD_CALL_PHASE_ACTIVE);
+    assert(call.epoch != second_epoch);
+
+    assert(dsd_test_capture_stderr_end(&cap) == 0);
+    dsd_state_ext_free_all(&state);
+}
+
 int
 main(void) {
     InitAllFecFunction();
 
+    test_repeated_voice_lc_header_keeps_one_epoch();
     test_flco_output_uses_real_newlines();
     test_ms_direct_flco_reports_internal_slot_one();
     test_single_slot_flco_forces_slot_one_context();

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -34,8 +34,10 @@
 #include "test_support.h"
 
 int
-getAfsString(const dsd_state* state, char* buffer, int a, int f, int s) {
-    (void)state;
+getAfsStringFromBits(int a_bits, int f_bits, int s_bits, char* buffer, int a, int f, int s) {
+    (void)a_bits;
+    (void)f_bits;
+    (void)s_bits;
     return DSD_SNPRINTF(buffer, 16, "%02d-%03d", a, (f * 8) + s);
 }
 

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -1221,8 +1221,26 @@ test_voice_lc_header_starts_epoch_and_embedded_lc_continues(void) {
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
     assert(call.phase == DSD_CALL_PHASE_ACTIVE);
     assert(call.epoch != second_epoch);
+    const uint64_t third_epoch = call.epoch;
+
+    // The same header replayed after a sync-loss end is that transmission being reacquired,
+    // not a new one, so the reopened epoch is tagged for the event layer to merge. The header
+    // passes BEGIN, which is exactly why the tagging cannot depend on the boundary token.
+    assert(dsd_call_state_end_ex(&state, 0U, 0.0, DSD_CALL_END_SYNC_LOSS) > 0);
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.phase == DSD_CALL_PHASE_ACTIVE);
+    assert(call.epoch != third_epoch);
+    assert(call.ota_target_id == 1001U);
+    assert(call.ota_source_id == 2002U);
+    dsd_call_context_snapshot context;
+    assert(dsd_call_context_copy_snapshot(&state, &context) > 0);
+    assert(context.events[0].reacquired_epoch == call.epoch);
 
     assert(dsd_test_capture_stderr_end(&cap) == 0);
+    (void)remove(cap.path);
     dsd_state_ext_free_all(&state);
 }
 

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -1173,11 +1173,11 @@ test_completed_slco_capacity_plus_hold_returns_to_rest_channel(void) {
     dsd_state_ext_free_all(&state);
 }
 
-// The voice LC header repeats through the start of a transmission for late
-// entry. Only the first copy may open a canonical epoch: a second epoch commits
-// the first one's freshly built row as a duplicate event.
+// Each Voice LC Header marks a transmission boundary, including a same-identity
+// re-key after a missed terminator. Embedded LCs re-describe the active call and
+// must remain in its epoch.
 static void
-test_repeated_voice_lc_header_keeps_one_epoch(void) {
+test_voice_lc_header_starts_epoch_and_embedded_lc_continues(void) {
     static dsd_opts opts;
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof(opts));
@@ -1197,25 +1197,26 @@ test_repeated_voice_lc_header_keeps_one_epoch(void) {
     assert(call.phase == DSD_CALL_PHASE_ACTIVE);
     const uint64_t first_epoch = call.epoch;
 
+    // An embedded LC continues the transmission described by the header.
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 3U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.epoch == first_epoch);
+
+    // A new header starts the next transmission even if its identity matches.
     irr = 0;
     build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
     dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
-    assert(call.epoch == first_epoch);
-
-    // A header naming a different talker is the next transmission, not a repeat.
-    irr = 0;
-    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 3003U);
-    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
-    assert(dsd_call_state_get(&state, 0U, &call) > 0);
     assert(call.epoch != first_epoch);
-    assert(call.ota_source_id == 3003U);
+    assert(call.ota_source_id == 2002U);
     const uint64_t second_epoch = call.epoch;
 
     // A header after the terminator opens the following transmission.
     assert(dsd_call_state_end(&state, 0U, 0.0) > 0);
     irr = 0;
-    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 3003U);
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
     dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
     assert(call.phase == DSD_CALL_PHASE_ACTIVE);
@@ -1229,7 +1230,7 @@ int
 main(void) {
     InitAllFecFunction();
 
-    test_repeated_voice_lc_header_keeps_one_epoch();
+    test_voice_lc_header_starts_epoch_and_embedded_lc_continues();
     test_flco_output_uses_real_newlines();
     test_ms_direct_flco_reports_internal_slot_one();
     test_single_slot_flco_forces_slot_one_context();

--- a/tests/protocol/p25/test_p25_p1_hdu_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_hdu_helpers.c
@@ -293,7 +293,7 @@ dsd_p25_optional_hook_watchdog_event_current(dsd_opts* opts, dsd_state* state, u
 
 void
 dsd_p25_optional_hook_write_event_to_log_file(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite,
-                                              char* event_string) {
+                                              const char* event_string) {
     (void)opts;
     (void)state;
     (void)slot;

--- a/tests/protocol/p25/test_p25_p1_ldu2_helpers.c
+++ b/tests/protocol/p25/test_p25_p1_ldu2_helpers.c
@@ -284,7 +284,7 @@ dsd_p25_optional_hook_watchdog_event_current(dsd_opts* opts, dsd_state* state, u
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_p25_optional_hook_write_event_to_log_file(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite,
-                                              char* event_string) {
+                                              const char* event_string) {
     (void)opts;
     (void)state;
     (void)slot;

--- a/tests/runtime/test_runtime_p25_optional_hooks.c
+++ b/tests/runtime/test_runtime_p25_optional_hooks.c
@@ -31,10 +31,11 @@ static const dsd_opts* g_write_opts = NULL;
 static dsd_state* g_write_state = NULL;
 static uint8_t g_write_slot = 0;
 static uint8_t g_write_swrite = 0;
-static char* g_write_event_string = NULL;
+static const char* g_write_event_string = NULL;
 
 static void
-fake_write_event_to_log_file(const dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite, char* event_string) {
+fake_write_event_to_log_file(const dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t swrite,
+                             const char* event_string) {
     g_write_calls++;
     g_write_opts = opts;
     g_write_state = state;

--- a/tests/test_support/call_state_stubs.c
+++ b/tests/test_support/call_state_stubs.c
@@ -190,7 +190,18 @@ dsd_call_state_end_ex(dsd_state* state, uint8_t slot, double observed_m, dsd_cal
     // repeated sync-loss ends that fire while unsynced neither downgrade an explicit terminator's
     // reason nor re-stamp ended_m and slide the reacquisition window. A stub that overwrote them
     // would model the exact bug that guard exists to prevent.
-    if (g_stub_calls[slot].phase != DSD_CALL_PHASE_ACTIVE) {
+    if (g_stub_calls[slot].epoch == 0U || g_stub_calls[slot].phase != DSD_CALL_PHASE_ACTIVE) {
+        // And production's one exception, mirrored for the same reason: a terminator decoded after
+        // sync loss already ended the epoch retracts the reacquisition permission that end granted.
+        // Stub-linked protocol tests drive exactly this path from their terminator handlers, so a
+        // stub that returned 0 here would leave every one of them modelling the pre-retraction
+        // behaviour and silently skipping the event flush that follows.
+        if (g_stub_calls[slot].epoch != 0U && g_stub_calls[slot].phase == DSD_CALL_PHASE_ENDED
+            && g_stub_calls[slot].end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS && reason == DSD_CALL_END_EXPLICIT) {
+            // ended_m is deliberately left alone: the reason changes, the moment does not.
+            g_stub_calls[slot].end_reason = (uint8_t)DSD_CALL_END_EXPLICIT;
+            return 1;
+        }
         return 0;
     }
     g_stub_calls[slot].phase = DSD_CALL_PHASE_ENDED;

--- a/tests/test_support/call_state_stubs.c
+++ b/tests/test_support/call_state_stubs.c
@@ -186,11 +186,20 @@ dsd_call_state_end_ex(dsd_state* state, uint8_t slot, double observed_m, dsd_cal
         return -1;
     }
     stub_select_state(state);
-    const int ended = g_stub_calls[slot].phase == DSD_CALL_PHASE_ACTIVE;
+    // Mirrors the production early-return: ending an already-ended epoch is a no-op, so the
+    // repeated sync-loss ends that fire while unsynced neither downgrade an explicit terminator's
+    // reason nor re-stamp ended_m and slide the reacquisition window. A stub that overwrote them
+    // would model the exact bug that guard exists to prevent.
+    if (g_stub_calls[slot].phase != DSD_CALL_PHASE_ACTIVE) {
+        return 0;
+    }
     g_stub_calls[slot].phase = DSD_CALL_PHASE_ENDED;
     g_stub_calls[slot].end_reason = (uint8_t)reason;
-    (void)observed_m;
-    return ended;
+    // Stamped from the caller's timeline so a stub-linked test can drive the reacquisition
+    // window explicitly. No clock is read here: these targets deliberately link no timing
+    // backend, and a test that wants a window must supply both endpoints itself.
+    g_stub_calls[slot].ended_m = observed_m > 0.0 ? observed_m : 0.0;
+    return 1;
 }
 
 int

--- a/tests/test_support/call_state_stubs.c
+++ b/tests/test_support/call_state_stubs.c
@@ -181,15 +181,21 @@ dsd_call_state_update_media(dsd_state* state, uint8_t slot, int media_active, do
 }
 
 int
-dsd_call_state_end(dsd_state* state, uint8_t slot, double observed_m) {
+dsd_call_state_end_ex(dsd_state* state, uint8_t slot, double observed_m, dsd_call_end_reason reason) {
     if (state == NULL || slot >= DSD_CALL_STATE_SLOT_COUNT) {
         return -1;
     }
     stub_select_state(state);
     const int ended = g_stub_calls[slot].phase == DSD_CALL_PHASE_ACTIVE;
     g_stub_calls[slot].phase = DSD_CALL_PHASE_ENDED;
+    g_stub_calls[slot].end_reason = (uint8_t)reason;
     (void)observed_m;
     return ended;
+}
+
+int
+dsd_call_state_end(dsd_state* state, uint8_t slot, double observed_m) {
+    return dsd_call_state_end_ex(state, slot, observed_m, DSD_CALL_END_EXPLICIT);
 }
 
 int

--- a/tests/ui/test_ui_menu_services.c
+++ b/tests/ui/test_ui_menu_services.c
@@ -195,6 +195,18 @@ init_event_history(Event_History_I* event_struct, uint8_t start, uint8_t stop) {
     }
 }
 
+// Stands in for the core implementation, which also clears the per-slot commit bookkeeping
+// (covered by CORE_CALL_ALERT_HISTORY). This test only asserts the service delegates the reset.
+void
+dsd_event_history_reset(dsd_state* state) {
+    if (!state || !state->event_history_s) {
+        return;
+    }
+    for (uint8_t slot = 0; slot < 2U; slot++) {
+        init_event_history(&state->event_history_s[slot], 0, 255);
+    }
+}
+
 dsd_socket_t
 Connect(char* hostname, int portno) {
     (void)hostname;


### PR DESCRIPTION
## Summary

- Drop a voice event commit that only restates the row committed moments earlier for the same slot, so one transmission leaves one row in Activity history no matter how many times it is closed and reopened.
- Stop DMR minting a canonical epoch per repeated voice LC header: a header that re-describes the call already running on the slot observes a continuation instead of a begin.
- Add regression coverage for the reacquired-transmission shape, the changed-identity negative case, repeated data notices, and the DMR header repeat.

## Why

A single transmission can be closed and reopened several times. Sync loss ends the canonical call mid-transmission, the next burst that decodes opens a fresh epoch, and the end of that epoch commits the same voice row again. Protocols that re-announce a running call do the same -- DMR repeats the voice LC header through the start of a transmission for late entry, and every repeat arrived as an explicit `BEGIN` that minted another epoch. Each spurious epoch pushed the previous epoch's freshly built row through `watchdog_event_history_authoritative()`, so one DMR call left two or three identical rows.

Driving the real core event API with one transmission interrupted twice by sync loss produced three identical rows before this change and one after. Repeated voice LC headers produced one row per repeat before, one row total after.

This is the same duplication class as the Phase 2 hangtime repeats fixed in #260, reaching every protocol whose call can be ended and re-observed. Fixing it at the event-commit layer rather than in `dsd_call_state_observe()` is deliberate: a post-END observation that re-describes the closed call is byte-identical, from the store's vantage point, to one that legitimately opens the next transmission -- YSF FICH fallback, M17 back-to-back packets, and the P25 vPDU paths all depend on reopening. Only the protocol knows which it is, so the store keeps its semantics and history stops recording the same transmission twice.

The existing P25 guards are not redundant and are unchanged. Disabling them with this change in place still fails `P25_SM_UNIFIED_CORE` (a source-less grant repeat must keep the call ended *and* republish crypto onto the retained epoch) and `P25_P2_HANGTIME_EVENTS` (an `ACTIVE`-driven voice start must fold into the running epoch). Those guards govern call phase and crypto routing, not just history rows.

## Scope

`dsd_call_event_lifecycle_snapshot` gains the commit fingerprint, so the guard survives context snapshot and restore. `call_state.c` changes are a refactor only: the identity comparison is extracted as `call_state_observation_changes_identity()` and the `BEGIN` contract is documented; epoch semantics are unchanged.

Data and control notices are excluded from the guard and rows carrying no identity at all are never coalesced, so repeated LRRP, short data, and response header events each still reach history. The one-second window bounds the guard so a genuine re-key on the same talkgroup keeps its own row.

Reported in discussion #152.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: parser (DMR FLCO boundary selection).
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off.

## Quality Review

- [x] Canonical call state and event history changes include focused tests.
- [x] Protocol and runtime changes received extra scrutiny.
- [x] No static-analysis suppressions were added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` -- 474/474 passed
- [x] `tools/preflight_ci.sh` -- clean
- [ ] `tools/quality_preflight.sh` -- not required for this scope
- [ ] `tools/cmake_format_check.sh` -- no CMake changes
- [ ] `tools/zizmor.sh` -- no workflow changes
- [ ] `tools/osv_scan.sh` -- no dependency changes

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: a transmission that the decoder loses and reacquires within a second now shows one Activity row instead of one per reacquisition, and its WAV is no longer rotated mid-transmission. Two genuinely distinct transmissions with identical identity less than a second apart would merge into one row; the window is a named constant if that proves too generous in the field.
- Compatibility or packaging impact: `dsd_call_event_lifecycle_snapshot` grows. It is an in-process runtime structure with no on-disk or wire representation, and field order was chosen to avoid padding.
