### PR TITLE
tests: guard radio-only no-carrier coverage

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3014,7 +3014,7 @@ if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
             "-Wl,--wrap=rtl_stream_get_ted_sps_override"
             "-Wl,--wrap=rtl_stream_output_rate"
             "-Wl,--wrap=rtl_stream_prepare_retune_profile_for_target_with_gain"
-            "-Wl,--wrap=SetFreq"
+            "$<$<BOOL:${DSD_HAS_RADIO}>:-Wl,--wrap=SetFreq>"
             "-Wl,--wrap=rtl_stream_request_fsk_reacquire"
             "-Wl,--wrap=rtl_stream_tune"
             "-Wl,--wrap=rtl_stream_tune_tagged"

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -592,7 +592,7 @@ main(void) {
     rc |= expect_true("cc-return-ends-call", retuned_snapshot.phase == DSD_CALL_PHASE_ENDED);
     rc |= expect_true("cc-return-ends-call-explicitly", retuned_snapshot.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
 
-#if defined(DSD_NEO_TEST_RTL_WRAP) && DSD_NEO_TEST_RTL_WRAP
+#if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP) && DSD_NEO_TEST_RTL_WRAP
     free_test_runtime(opts, state);
     if (init_test_runtime(&opts, &state) != 0) {
         return 1;


### PR DESCRIPTION
## Summary

- compile the radio-specific no-carrier regression cases only when the radio pipeline is available
- enable the `SetFreq` linker wrapper only for radio-enabled test builds

## Root cause

The GNU/Clang test target defines `DSD_NEO_TEST_RTL_WRAP` even for the `backend-matrix (neither)` configuration. A newly added test block checked only that wrapper macro, while the stub globals it uses are declared only with `USE_RADIO`, causing the no-radio build to fail with undeclared identifiers. The associated `--wrap=SetFreq` option also needed the same radio-availability guard to avoid an undefined wrapper at link time.

## Impact

This restores the no-radio backend matrix build without changing production behavior or reducing the radio-enabled regression coverage.

## Validation

- full `dev-debug` build with RTL-SDR and SoapySDR disabled
- `ENGINE_NO_CARRIER_RESET` with radio backends disabled
- `ENGINE_NO_CARRIER_RESET` with RTL-SDR and SoapySDR enabled
- `tools/preflight_ci.sh --base origin/main`