### PR TITLE
ui: align call info slot header columns

### DIFF
--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -171,22 +171,44 @@ ui_demod_symbol_rate_hz(const dsd_opts* opts, const dsd_state* state) {
     return (sample_rate_hz + (state->samplesPerSymbol / 2)) / state->samplesPerSymbol;
 }
 
+/* Burst/DUID labels rendered at the end of the slot header line. Entries carry
+   no padding of their own; the render site owns the column width so every label
+   occupies the same span. */
+#define UI_SLOT_BURST_WIDTH 8
+
 static const char* DMRBusrtTypes[32] = {
-    "PI       ", "VLC      ", "TLC      ", "CSBK     ", "MBCH     ", "MBCC     ", "DATA     ",
-    "R12D     ", "R34D     ", "IDLE     ", "R1_D     ", "ERR      ", "DUID ERR ", "R-S ERR  ",
-    "CRC ERR  ", "NULL     ", "VOICE",     "         ", "INIT     ", "INIT     ",
+    "PI",       //0
+    "VLC",      //1
+    "TLC",      //2
+    "CSBK",     //3
+    "MBCH",     //4
+    "MBCC",     //5
+    "DATA",     //6
+    "R12D",     //7
+    "R34D",     //8
+    "IDLE",     //9
+    "R1_D",     //10
+    "ERR",      //11
+    "DUID ERR", //12
+    "R-S ERR",  //13
+    "CRC ERR",  //14
+    "NULL",     //15
+    "VOICE",    //16
+    "",         //17
+    "INIT",     //18
+    "INIT",     //19
     "PTT",      //20 MAC
     "VOICE",    //21 MAC_ACTIVE
     "HANGTIME", //22 MAC
     "PTT END",  //23 MAC
     "IDLE",     //24 MAC
-    "HDU",
-    "VOICE", //26 LDU1
-    "VOICE", //27 LDU2
-    "TDU/LC",    "TSBK",
-    "SIGNAL", //MAC_SIGNAL
-    "SIGNAL"  //MAC_SIGNAL
-
+    "HDU",      //25
+    "VOICE",    //26 LDU1
+    "VOICE",    //27 LDU2
+    "TDU/LC",   //28
+    "TSBK",     //29
+    "SIGNAL",   //30 MAC_SIGNAL
+    "SIGNAL",   //31 MAC_SIGNAL
 };
 
 static void
@@ -826,7 +848,7 @@ ui_render_scanner_and_reverse_status(const dsd_opts* opts, const dsd_state* stat
     if (opts->scanner_mode == 1) {
         printw("| Scan Mode: ");
         if (state->lcn_freq_roll != 0) {
-            printw(" Frequency: %.06lf Mhz", (double)state->trunk_lcn_freq[state->lcn_freq_roll - 1] / 1000000);
+            printw(" Frequency: %.06lf MHz", (double)state->trunk_lcn_freq[state->lcn_freq_roll - 1] / 1000000);
         }
         printw(" Speed: %.02lf sec \n",
                opts->trunk_hangtime); // default aligned to OP25 (2.0s) unless overridden
@@ -1979,13 +2001,13 @@ ui_render_nxdn_monitor_line(const dsd_opts* opts, const dsd_state* state, int id
         printw(idas ? "Monitoring RTCH2 Channel" : "Monitoring RCCH Channel");
         if (state->trunk_cc_freq != 0 || state->p25_cc_freq != 0) {
             long f = (state->trunk_cc_freq != 0) ? state->trunk_cc_freq : state->p25_cc_freq;
-            printw(" - Frequency: %.06lf Mhz ", (double)f / 1000000);
+            printw(" - Frequency: %.06lf MHz ", (double)f / 1000000);
         }
     } else {
         printw(idas ? "Monitoring RTCH2 Channel" : "Monitoring RTCH Channel");
         if (state->trunk_vc_freq[0] != 0 || state->p25_vc_freq[0] != 0) {
             long f = (state->trunk_vc_freq[0] != 0) ? state->trunk_vc_freq[0] : state->p25_vc_freq[0];
-            printw(" - Frequency: %.06lf Mhz ", (double)f / 1000000);
+            printw(" - Frequency: %.06lf MHz ", (double)f / 1000000);
         }
     }
     printw("\n");
@@ -2451,7 +2473,8 @@ ui_apply_canonical_call_slot(ui_slot_view* slot, const dsd_call_snapshot* call) 
     } else if (call->kind == DSD_CALL_KIND_DATA) {
         kind = "Data";
     }
-    DSD_SNPRINTF(slot->call_banner, sizeof slot->call_banner, " %s%s%s", kind, call->emergency ? " Emergency" : "",
+    // Emergency is carried by the [EM] tag immediately left of the banner; do not repeat it here.
+    DSD_SNPRINTF(slot->call_banner, sizeof slot->call_banner, " %s%s", kind,
                  call->crypto >= DSD_CALL_CRYPTO_ENCRYPTED_PENDING ? " Encrypted" : "");
 }
 
@@ -2498,7 +2521,7 @@ ui_render_p25_dmr_header_dmr_bs(const dsd_state* state) {
     if (state->dmr_rest_channel > 0) {
         printw("Rest LSN: %02d; ", state->dmr_rest_channel);
         if (state->trunk_chan_map[state->dmr_rest_channel] != 0) {
-            printw("Freq: %.06lf Mhz", (double)state->trunk_chan_map[state->dmr_rest_channel] / 1000000);
+            printw("Freq: %.06lf MHz", (double)state->trunk_chan_map[state->dmr_rest_channel] / 1000000);
         }
         return;
     }
@@ -2530,7 +2553,7 @@ ui_render_p25_dmr_header_p25p1(const dsd_opts* opts, dsd_state* state) {
     printw("; RFSS: %lld SITE: %lld ", state->p2_rfssid, state->p2_siteid);
     if (state->trunk_cc_freq != 0 || state->p25_cc_freq != 0) {
         long f = (state->trunk_cc_freq != 0) ? state->trunk_cc_freq : state->p25_cc_freq;
-        printw("FREQ: %.06lf MHz", (double)f / 1000000);
+        printw("Freq: %.06lf MHz", (double)f / 1000000);
     }
     ui_render_p25_talker_alias(state, ui_active_call_source(state, 0U), 0);
 }
@@ -2551,7 +2574,7 @@ ui_render_p25p2_parameter_status(const dsd_state* state) {
     }
     if (state->trunk_cc_freq != 0 || state->p25_cc_freq != 0) {
         long f = (state->trunk_cc_freq != 0) ? state->trunk_cc_freq : state->p25_cc_freq;
-        printw("FREQ: %.06lf MHz", (double)f / 1000000);
+        printw("Freq: %.06lf MHz", (double)f / 1000000);
     }
 }
 
@@ -2598,33 +2621,59 @@ ui_set_slot_render_flags(const dsd_state* state, const ui_slot_view* slot, ui_sl
     flags->show_crypto_status = slot->canonical_p25 || slot->burst == 16 || flags->show_p25_vxtra;
 }
 
+/* Optional call tags ([EM], [PR:n]) and the call banner share one fixed-width
+   column so the burst-type separator lands in the same place on every slot line,
+   whether or not a call carries emergency/priority metadata. Each part supplies
+   its own leading space; the widest content is " [EM][PR:255]" (13) followed by
+   " Private Encrypted" (18). */
+#define UI_SLOT_CALL_STATUS_WIDTH 31
+
+static void
+ui_compose_slot_call_tags(const ui_slot_view* slot, char* out, size_t out_len) {
+    char priority_tag[12] = {0};
+    if (slot->call_priority > 0) {
+        DSD_SNPRINTF(priority_tag, sizeof priority_tag, "[PR:%d]", slot->call_priority);
+    }
+    if (!slot->call_emergency && priority_tag[0] == '\0') {
+        out[0] = '\0';
+        return;
+    }
+    DSD_SNPRINTF(out, out_len, " %s%s", slot->call_emergency ? "[EM]" : "", priority_tag);
+}
+
 static void
 ui_render_slot_header_line(const dsd_state* state, const ui_slot_view* slot, ui_slot_render_flags* flags) {
     printw("| SLOT %d - ", slot->slot_no);
-    const int colored_ids = ui_slot_has_colored_ids(state, slot);
-    if (slot->burst < 16 && colored_ids) {
+    /* Non-voice bursts carrying a resolved TGT/SRC pair render their IDs in the
+       terminated-call colour. Turn-on and turn-off share one predicate so the
+       pair can never leak into the banner, and the section colour is restored on
+       every path rather than only on the highlighted one. */
+    const int highlight_ids = ui_slot_has_colored_ids(state, slot) && slot->burst < 16;
+    if (highlight_ids) {
         attron(COLOR_PAIR(2));
     }
 
     ui_set_slot_render_flags(state, slot, flags);
+    char call_tags[16] = {0};
     if (flags->show_ids) {
-        printw("TGT: [%8i] SRC: [%8i] ", slot->target, slot->source);
-        if (slot->call_emergency) {
-            printw("[EM] ");
-        }
-        if (slot->call_priority > 0) {
-            printw("[PR:%d] ", slot->call_priority);
-        }
+        printw("TGT: [%8i] SRC: [%8i]", slot->target, slot->source);
+        ui_compose_slot_call_tags(slot, call_tags, sizeof call_tags);
+        printw("%s", call_tags);
     } else {
-        printw("TGT: [        ] SRC: [        ] ");
+        printw("TGT: [        ] SRC: [        ]");
     }
 
-    if (slot->burst != 16 && colored_ids) {
+    if (highlight_ids) {
         attroff(COLOR_PAIR(2));
-        attron(COLOR_PAIR(3));
     }
-    printw("%s | ", flags->show_ids ? slot->call_banner : "                     ");
-    printw("%s ", DMRBusrtTypes[slot->burst]);
+    ui_restore_call_info_color(state);
+
+    int banner_width = UI_SLOT_CALL_STATUS_WIDTH - (int)strlen(call_tags);
+    if (banner_width < 0) {
+        banner_width = 0;
+    }
+    printw("%-*.*s | ", banner_width, banner_width, flags->show_ids ? slot->call_banner : "");
+    printw("%-*s ", UI_SLOT_BURST_WIDTH, DMRBusrtTypes[slot->burst]);
     printw("\n");
 }
 

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -105,19 +105,44 @@ waddnstr(WINDOW* win, const char* str, int n) { // NOLINT(misc-use-internal-link
     return 0;
 }
 
+/* Colour-pair trace: "+n" when a pair is switched on, "-n" when switched off, in
+   render order. Lets tests assert that a highlight is balanced and that the
+   section colour is restored before the rest of a line is drawn. */
+static char g_color_trace[256];
+static size_t g_color_trace_len;
+
+static void
+reset_color_trace(void) {
+    DSD_MEMSET(g_color_trace, 0, sizeof(g_color_trace));
+    g_color_trace_len = 0U;
+}
+
+static void
+append_color_trace(char sign, attr_t attrs) {
+    const short pair = (short)PAIR_NUMBER(attrs);
+    if (pair == 0 || g_color_trace_len + 4U >= sizeof(g_color_trace)) {
+        return;
+    }
+    int wrote = DSD_SNPRINTF(g_color_trace + g_color_trace_len, sizeof(g_color_trace) - g_color_trace_len, "%c%d", sign,
+                             (int)pair);
+    if (wrote > 0) {
+        g_color_trace_len += (size_t)wrote;
+    }
+}
+
 int
 wattr_on(WINDOW* win, attr_t attrs, void* opts) { // NOLINT(misc-use-internal-linkage)
     (void)win;
-    (void)attrs;
     (void)opts;
+    append_color_trace('+', attrs);
     return 0;
 }
 
 int
 wattr_off(WINDOW* win, attr_t attrs, void* opts) { // NOLINT(misc-use-internal-linkage)
     (void)win;
-    (void)attrs;
     (void)opts;
+    append_color_trace('-', attrs);
     return 0;
 }
 
@@ -1007,7 +1032,7 @@ test_canonical_p25_slot_and_recent_activity(void) {
     assert_capture_contains("ALG: 0x84 KEY ID: 0x2468 MI: 0x1122334455667788");
     assert(strstr(g_printw_capture, "UNKNOWN") == NULL);
     assert(strstr(g_printw_capture, "ENC?") == NULL);
-    assert(strstr(g_printw_capture, "FREQ:") == NULL);
+    assert(strstr(g_printw_capture, "Freq:") == NULL);
     assert(strstr(g_printw_capture, "[GROUP]") == NULL);
     assert(strstr(g_printw_capture, "P25 VOICE") == NULL);
     assert_capture_contains(" | VOICE");
@@ -1103,6 +1128,134 @@ test_canonical_p25_slot_and_recent_activity(void) {
     free(state);
 }
 
+/* Offset of the separator that precedes the burst/DUID indicator on a slot
+   header line. The whole point of the fixed status column is that this offset
+   does not move when optional call tags or banner text appear. */
+static size_t
+capture_burst_separator_offset(void) {
+    const char* separator = strstr(g_printw_capture, " | ");
+    assert(separator != NULL);
+    return (size_t)(separator - g_printw_capture);
+}
+
+static void
+capture_slot_header_line(dsd_state* state, int slot_index) {
+    ui_slot_view slot = ui_build_slot_view(state, slot_index);
+    ui_slot_render_flags flags = {0};
+    reset_printw_capture();
+    ui_render_slot_header_line(state, &slot, &flags);
+}
+
+static void
+test_slot_header_burst_column_is_fixed(void) {
+    dsd_state* state = (dsd_state*)calloc(1U, sizeof(*state));
+    assert(state != NULL);
+    state->synctype = DSD_SYNC_P25P2_POS;
+    state->lastsynctype = DSD_SYNC_P25P2_POS;
+
+    dsd_call_observation observation = {0};
+    observation.protocol = DSD_SYNC_P25P2_POS;
+    observation.slot = 0U;
+    observation.kind = DSD_CALL_KIND_GROUP_VOICE;
+    observation.ota_target_id = 1201U;
+    observation.policy_target_id = 1201U;
+    observation.ota_source_id = 404U;
+    observation.observed_m = 1.0;
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
+
+    capture_slot_header_line(state, 0);
+    assert_capture_contains(" | VOICE");
+    const size_t baseline_offset = capture_burst_separator_offset();
+
+    // A grant carrying a priority must not push the burst indicator out of column.
+    observation.has_service_metadata = 1U;
+    observation.priority = 3U;
+    observation.observed_m = 1.2;
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_CONTINUE) == 0);
+    capture_slot_header_line(state, 0);
+    assert_capture_contains("[PR:3]");
+    assert_capture_contains(" | VOICE");
+    assert(capture_burst_separator_offset() == baseline_offset);
+
+    // Emergency is reported once, by the [EM] tag; the banner must not repeat it.
+    observation.emergency = 1U;
+    observation.observed_m = 1.4;
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_CONTINUE) == 0);
+    capture_slot_header_line(state, 0);
+    assert_capture_contains("[EM][PR:3]");
+    assert(strstr(g_printw_capture, "Emergency") == NULL);
+    assert(capture_burst_separator_offset() == baseline_offset);
+
+    // A longer banner (encrypted) shares the same column budget.
+    dsd_call_crypto_update crypto = {0};
+    crypto.classification = DSD_CALL_CRYPTO_ENCRYPTED;
+    crypto.algid = 0x84U;
+    crypto.kid = 0x2468U;
+    crypto.observed_m = 1.5;
+    assert(dsd_call_state_update_crypto(state, 0U, &crypto) == 1);
+    capture_slot_header_line(state, 0);
+    assert_capture_contains("Group Encrypted");
+    assert(capture_burst_separator_offset() == baseline_offset);
+
+    // The idle-slot placeholder lands on the same column as a live call.
+    state->dmrburstR = 21;
+    capture_slot_header_line(state, 1);
+    assert_capture_contains("TGT: [        ] SRC: [        ]");
+    assert(capture_burst_separator_offset() == baseline_offset);
+
+    dsd_state_ext_free_all(state);
+    free(state);
+}
+
+static void
+test_slot_header_id_highlight_is_balanced(void) {
+    dsd_state* state = (dsd_state*)calloc(1U, sizeof(*state));
+    assert(state != NULL);
+    state->synctype = DSD_SYNC_P25P2_POS;
+    state->lastsynctype = DSD_SYNC_P25P2_POS;
+    state->carrier = 1;
+
+    dsd_call_observation observation = {0};
+    observation.protocol = DSD_SYNC_P25P2_POS;
+    observation.slot = 0U;
+    observation.kind = DSD_CALL_KIND_GROUP_VOICE;
+    observation.ota_target_id = 1201U;
+    observation.policy_target_id = 1201U;
+    observation.ota_source_id = 404U;
+    observation.observed_m = 1.0;
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
+
+    // Voice burst: IDs are not highlighted, but the section colour is still restored.
+    ui_slot_view slot = ui_build_slot_view(state, 0);
+    assert(slot.burst == 21);
+    ui_slot_render_flags flags = {0};
+    reset_color_trace();
+    ui_render_slot_header_line(state, &slot, &flags);
+    assert(strcmp(g_color_trace, "+3") == 0);
+
+    // Non-voice burst with resolved IDs: the highlight is turned on and off again.
+    dsd_call_observation data_observation = observation;
+    data_observation.kind = DSD_CALL_KIND_DATA;
+    data_observation.ota_target_id = 2202U;
+    data_observation.policy_target_id = 2202U;
+    data_observation.observed_m = 2.0;
+    assert(dsd_call_state_observe(state, &data_observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
+    slot = ui_build_slot_view(state, 0);
+    assert(slot.burst == 6);
+    reset_color_trace();
+    ui_render_slot_header_line(state, &slot, &flags);
+    assert(strcmp(g_color_trace, "+2-2+3") == 0);
+
+    // Without carrier there is nothing to highlight and the idle section colour applies.
+    state->carrier = 0;
+    reset_color_trace();
+    ui_render_slot_header_line(state, &slot, &flags);
+    assert(strcmp(g_color_trace, "+4") == 0);
+
+    dsd_state_ext_free_all(state);
+    free(state);
+}
+
 static void
 test_live_protocol_panels_ignore_ended_call_identity(void) {
     dsd_state* state = (dsd_state*)calloc(1U, sizeof(*state));
@@ -1180,6 +1333,8 @@ main(void) {
     test_patch_and_slot_helpers();
     test_lock_and_protocol_helpers();
     test_canonical_p25_slot_and_recent_activity();
+    test_slot_header_burst_column_is_fixed();
+    test_slot_header_id_highlight_is_balanced();
     test_live_protocol_panels_ignore_ended_call_identity();
     return 0;
 }


### PR DESCRIPTION
## Problem

The `| <burst>` indicator on each `SLOT` line of the Call Info panel sits at a floating column. It was first noticed on P25 calls carrying a priority field, but the priority tag is only one of three causes — everything between `SRC` and the separator was emitted at its natural width.

```
BEFORE — separator lands wherever the content ends
| SLOT 1 - TGT: [    1201] SRC: [     404]  Group | VOICE
| SLOT 1 - TGT: [    1201] SRC: [     404] [PR:3]  Group | VOICE
| SLOT 1 - TGT: [    1201] SRC: [     404] [EM] [PR:3]  Group Emergency | VOICE
| SLOT 2 - TGT: [        ] SRC: [        ]                       | IDLE

AFTER — fixed column
| SLOT 1 - TGT: [    1201] SRC: [     404] Group                          | VOICE
| SLOT 1 - TGT: [    1201] SRC: [     404] [PR:3] Group                   | VOICE
| SLOT 1 - TGT: [    1201] SRC: [     404] [EM][PR:3] Group               | VOICE
| SLOT 2 - TGT: [        ] SRC: [        ]                                | IDLE
```

Contributing causes:

- `[EM]` and `[PR:n]` were appended inline with no width reserved.
- `call_banner` is variable width (`" Data"` = 5 through `" Group Emergency Encrypted"` = 26) while the idle placeholder was a hardcoded 21 spaces, so the separator moved between slots and between call kinds even with no priority present.
- Emergency was rendered twice: the `[EM]` tag *and* `" Emergency"` in the banner.

## Changes

**Slot header column.** Tags and banner now share one fixed-width field (`UI_SLOT_CALL_STATUS_WIDTH`), each part supplies its own leading space, and the banner no longer repeats Emergency. The separator lands on the same column for every slot, call kind, and tag combination.

**Burst label table.** `DMRBusrtTypes` had ad-hoc padding — entries 0–15 and 17–19 were hand-padded to nine columns, 16 and 20–31 were not. The table is now unpadded and the render site owns the width.

**Colour guard.** The terminated-call ID highlight turned `COLOR_PAIR(2)` on for `burst < 16` but off for `burst != 16`, and only restored the section colour on the turn-off branch. Both sides now share one predicate and the restore runs on every path. This closes two gaps: a DMR voice burst (`burst == 16`) previously got no restore at all and inherited whatever pair the preceding section left active, and the no-carrier case never applied the section's idle colour. Paths that already worked are byte-identical, since `colored_ids` implies `carrier == 1`.

**Label and unit casing.** Four sites printed `Mhz` against `MHz` everywhere else. The DMR header labelled the control channel frequency `Freq:` while the P25p1/p2 headers said `FREQ:` for the same value; both are `Freq:` now.

Deliberately left alone: `Frequency:` on the tuned-VC line and the NXDN monitor line. Those label the voice channel rather than the control channel, so the distinct wording carries meaning.

## Testing

- `ctest --preset dev-debug` — 474/474 pass.
- `tools/preflight_ci.sh` — clean.

Two regression tests added to `UI_NCURSES_PRINTER_HELPERS`:

- `test_slot_header_burst_column_is_fixed` asserts the separator offset is byte-identical across plain, `[PR:n]`, `[EM][PR:n]`, encrypted-banner, and idle-placeholder renders, and that the banner no longer repeats `Emergency`.
- `test_slot_header_id_highlight_is_balanced` asserts the exact colour-pair sequence per case (`+3` for a voice burst, `+2-2+3` for a non-voice burst with resolved IDs, `+4` with no carrier). Reverting to the asymmetric guard fails the first case with `-2+3`.

The `wattr_on` / `wattr_off` stubs in the test fixture now record a colour-pair trace to support the second test.

No tracking issue exists for this; happy to open one if that is preferred for a user-visible change.
