### PR TITLE
dmr: keep repeated voice LC headers in one call epoch

### DIFF
--- a/include/dsd-neo/core/call_state.h
+++ b/include/dsd-neo/core/call_state.h
@@ -60,18 +60,29 @@ typedef enum {
  * transmission ended, so an identity-bearing observation after it is the next transmission.
  * EXPLICIT is the default so an unconverted call site produces a second history row -- a
  * duplicate is recoverable, a deleted transmission is not.
+ *
+ * EXPLICIT and TERMINATOR are equally final; they differ only in what they say happened on the
+ * air. The engine ends epochs EXPLICIT on retune and teardown, so an EXPLICIT end is not
+ * evidence a transmission ended over the air -- a keep-or-drop decision about whether the air
+ * carried a real, positively-ended transmission must key on the terminator reasons.
  */
 typedef enum {
-    DSD_CALL_END_EXPLICIT = 0,  /**< Terminator, EOT, release, teardown, or retune. */
+    DSD_CALL_END_EXPLICIT = 0,  /**< Teardown, retune, or an unconverted OTA end site (EOT, release). */
     DSD_CALL_END_SYNC_LOSS = 1, /**< Carrier or sync lost; the transmission may still resume. */
     /**
      * A terminator burst decoded but its link control failed verification (a RAS-masked CRC, a
-     * marginal signal). Ends the call on the strength of the burst type while staying
-     * recoverable, so a voice burst mis-typed as a terminator mid-call heals instead of
+     * protected LC, a marginal signal). Ends the call on the strength of the burst type while
+     * staying recoverable, so a voice burst mis-typed as a terminator mid-call heals instead of
      * splitting the transmission. A second unverified terminator corroborates the end and
-     * tightens it to EXPLICIT.
+     * tightens it to TERMINATOR.
      */
     DSD_CALL_END_UNVERIFIED_TERMINATOR = 2,
+    /**
+     * A terminator whose link control verified: positive, trustworthy over-the-air evidence the
+     * transmission ended. Final like EXPLICIT, but distinguishable from an engine retune so the
+     * event layer can vouch for an audible transmission the terminator closed.
+     */
+    DSD_CALL_END_TERMINATOR = 3,
 } dsd_call_end_reason;
 
 /**
@@ -80,7 +91,17 @@ typedef enum {
  * held before the transmission is declared over. Rationale, residual risks and the replay-timing
  * caveat are documented at the point of use in src/core/util/call_state.c.
  */
-#define DSD_CALL_REACQUIRE_GAP_S 0.5
+#define DSD_CALL_REACQUIRE_GAP_S       0.5
+
+/**
+ * Seconds after an unverified-terminator end within which an identity-less continuation may
+ * heal the epoch. Much tighter than DSD_CALL_REACQUIRE_GAP_S: the heal exists for a voice burst
+ * mis-typed as a terminator, whose per-frame media mark follows within a burst or two, while a
+ * real end followed by a fast re-key can put a new transmission's first decodable voice frame on
+ * the slot well inside the sync-loss window -- and folding that into the terminated call would
+ * hand it the previous call's identity and crypto.
+ */
+#define DSD_CALL_TERMINATOR_HEAL_GAP_S 0.25
 
 typedef enum {
     DSD_CALL_BOUNDARY_CONTINUE = 0, /**< Merge compatible observations into the active call epoch. */
@@ -212,8 +233,9 @@ typedef struct {
      * lifetime: the canonical snapshot clears media_active when the call ends, but the row's
      * keep-or-drop verdict is about whether audio ever ran, not whether it is running now. */
     uint8_t saw_media;
-    /* Whether the epoch's end, as last rendered, was terminator-evidenced (any reason but
-     * SYNC_LOSS). Zero while the call is active or after a bare sync loss. */
+    /* Whether the epoch's end, as last rendered, was terminator-evidenced (TERMINATOR or
+     * UNVERIFIED_TERMINATOR). Zero while the call is active, after a bare sync loss, and after
+     * an engine retune or teardown -- those end EXPLICIT, which says nothing about the air. */
     uint8_t ended_positively;
 } dsd_call_event_render_env;
 
@@ -303,11 +325,11 @@ int dsd_call_state_update_media(dsd_state* state, uint8_t slot, int media_active
  * End the active epoch, recording why it ended.
  *
  * Returns non-zero when the call state changed -- either the epoch was ended, or an already
- * recoverably-ended epoch had its reason tightened to DSD_CALL_END_EXPLICIT: a verified
- * terminator retracts either recoverable reason, and a second unverified terminator corroborates
- * an unverified-terminator end. An unverified terminator alone never tightens a sync-loss end --
- * it is the same fallible evidence the recoverable end exists to distrust. Tightening leaves
- * ended_m untouched. Callers that gate
+ * recoverably-ended epoch had its reason tightened to a final one: a verified terminator or an
+ * EXPLICIT teardown retracts either recoverable reason, and a second unverified terminator
+ * corroborates an unverified-terminator end into DSD_CALL_END_TERMINATOR. An unverified
+ * terminator alone never tightens a sync-loss end -- it is the same fallible evidence the
+ * recoverable end exists to distrust. Tightening leaves ended_m untouched. Callers that gate
  * dsd_event_sync_slot() on this result therefore let the event layer see the retracted
  * reacquisition permission; callers that need "an active call was ended" specifically must
  * check DSD_CALL_PHASE_ACTIVE themselves beforehand.
@@ -315,6 +337,18 @@ int dsd_call_state_update_media(dsd_state* state, uint8_t slot, int media_active
 int dsd_call_state_end_ex(dsd_state* state, uint8_t slot, double observed_m, dsd_call_end_reason reason);
 /** End the active epoch as a deliberate teardown (DSD_CALL_END_EXPLICIT). */
 int dsd_call_state_end(dsd_state* state, uint8_t slot, double observed_m);
+
+/**
+ * Called after dsd_call_state_observe() heals a recoverably-ended epoch, with the ending
+ * snapshot the reopened epoch was seeded from. The canonical layer stays protocol-neutral:
+ * a protocol whose end path tears down live decoder state it would need back on a heal (the
+ * DMR terminator reset clearing the slot's crypto) installs a hook and restores its own
+ * fields, keyed on the snapshot's protocol and epoch. Invoked outside the canonical lock, on
+ * the observing thread. Install once from the decode path before the first heal can occur;
+ * installing NULL removes it.
+ */
+typedef void (*dsd_call_state_reacquire_hook)(dsd_state* state, uint8_t slot, const dsd_call_snapshot* previous);
+void dsd_call_state_set_reacquire_hook(dsd_call_state_reacquire_hook hook);
 int dsd_call_state_get(const dsd_state* state, uint8_t slot, dsd_call_snapshot* out);
 int dsd_call_state_copy_snapshot(const dsd_state* state, dsd_call_state_snapshot* out);
 int dsd_call_state_restore_snapshot(dsd_state* state, const dsd_call_state_snapshot* snapshot);

--- a/include/dsd-neo/core/call_state.h
+++ b/include/dsd-neo/core/call_state.h
@@ -53,13 +53,25 @@ typedef enum {
 /**
  * Why a call epoch ended.
  *
- * Only DSD_CALL_END_SYNC_LOSS permits the next epoch on the slot to be treated as the same
- * transmission being reacquired. EXPLICIT is the default so an unconverted call site produces a
- * second history row -- a duplicate is recoverable, a deleted transmission is not.
+ * Only the recoverable reasons -- DSD_CALL_END_SYNC_LOSS and
+ * DSD_CALL_END_UNVERIFIED_TERMINATOR -- permit the next epoch on the slot to be treated as the
+ * same transmission being reacquired, and the unverified-terminator reason permits it only for
+ * identity-less continuations: the terminator was positive (if fallible) evidence the
+ * transmission ended, so an identity-bearing observation after it is the next transmission.
+ * EXPLICIT is the default so an unconverted call site produces a second history row -- a
+ * duplicate is recoverable, a deleted transmission is not.
  */
 typedef enum {
     DSD_CALL_END_EXPLICIT = 0,  /**< Terminator, EOT, release, teardown, or retune. */
     DSD_CALL_END_SYNC_LOSS = 1, /**< Carrier or sync lost; the transmission may still resume. */
+    /**
+     * A terminator burst decoded but its link control failed verification (a RAS-masked CRC, a
+     * marginal signal). Ends the call on the strength of the burst type while staying
+     * recoverable, so a voice burst mis-typed as a terminator mid-call heals instead of
+     * splitting the transmission. A second unverified terminator corroborates the end and
+     * tightens it to EXPLICIT.
+     */
+    DSD_CALL_END_UNVERIFIED_TERMINATOR = 2,
 } dsd_call_end_reason;
 
 /**
@@ -166,11 +178,16 @@ typedef struct {
 } dsd_recent_activity_snapshot;
 
 /**
- * Live decoder inputs the per-protocol event builders read but a history row does not carry.
+ * Live decoder inputs the per-protocol event builders read but a history row does not carry,
+ * plus the render-time verdicts about the epoch the row describes.
  *
  * Captured when a row is committed and replayed when that row is re-rendered, so a merged
  * transmission is described by the system context it was decoded under rather than whatever the
  * decoder has retuned to since. Everything else a builder needs already lives on the row.
+ *
+ * The verdicts live inside this struct rather than as siblings so every site that clears or
+ * copies the environment carries them automatically; a paired manual update would eventually be
+ * missed and leave a stale verdict vouching for the wrong row.
  */
 typedef struct {
     uint16_t nxdn_grant_chan;
@@ -185,6 +202,19 @@ typedef struct {
     int edacs_a_mask;
     int edacs_f_mask;
     int edacs_s_mask;
+    /* Whether the epoch had named a call when the row was last rendered. Vouches for identity
+     * the row strings never carry -- the route text anchoring a D-STAR or YSF transmission whose
+     * talker callsigns did not decode -- including on the epoch-change commit path where the
+     * canonical snapshot is already gone. Identity only accrues within an epoch, so plain
+     * assignment per render is already sticky. */
+    uint8_t named_call;
+    /* Whether the epoch carried decoded voice media at any render. Sticky for the epoch's
+     * lifetime: the canonical snapshot clears media_active when the call ends, but the row's
+     * keep-or-drop verdict is about whether audio ever ran, not whether it is running now. */
+    uint8_t saw_media;
+    /* Whether the epoch's end, as last rendered, was terminator-evidenced (any reason but
+     * SYNC_LOSS). Zero while the call is active or after a bare sync loss. */
+    uint8_t ended_positively;
 } dsd_call_event_render_env;
 
 /** Event bookkeeping paired with one canonical call slot. */
@@ -217,11 +247,6 @@ typedef struct {
      * content rather than at commit time: a row is sometimes committed only once the decoder has
      * already moved on to the next call, and by then the live values describe that call. */
     dsd_call_event_render_env staged_env;
-    /* Whether the staged row's epoch had named a call when the row was last rendered. Captured
-     * like staged_env so the commit-time decision to keep or drop an identity-less voice row is
-     * the same on every path, including the epoch-change path where the staged row's canonical
-     * snapshot -- and the route text that may be its only identity -- is already gone. */
-    uint8_t staged_named_call;
     /* Render inputs belonging to committed_seq's row, promoted from staged_env when it was
      * pushed. */
     dsd_call_event_render_env committed_env;
@@ -278,8 +303,11 @@ int dsd_call_state_update_media(dsd_state* state, uint8_t slot, int media_active
  * End the active epoch, recording why it ended.
  *
  * Returns non-zero when the call state changed -- either the epoch was ended, or an already
- * sync-loss-ended epoch had its reason tightened to DSD_CALL_END_EXPLICIT by a terminator that
- * decoded after the fade. The latter leaves ended_m untouched. Callers that gate
+ * recoverably-ended epoch had its reason tightened to DSD_CALL_END_EXPLICIT: a verified
+ * terminator retracts either recoverable reason, and a second unverified terminator corroborates
+ * an unverified-terminator end. An unverified terminator alone never tightens a sync-loss end --
+ * it is the same fallible evidence the recoverable end exists to distrust. Tightening leaves
+ * ended_m untouched. Callers that gate
  * dsd_event_sync_slot() on this result therefore let the event layer see the retracted
  * reacquisition permission; callers that need "an active call was ended" specifically must
  * check DSD_CALL_PHASE_ACTIVE themselves beforehand.

--- a/include/dsd-neo/core/call_state.h
+++ b/include/dsd-neo/core/call_state.h
@@ -217,6 +217,11 @@ typedef struct {
      * content rather than at commit time: a row is sometimes committed only once the decoder has
      * already moved on to the next call, and by then the live values describe that call. */
     dsd_call_event_render_env staged_env;
+    /* Whether the staged row's epoch had named a call when the row was last rendered. Captured
+     * like staged_env so the commit-time decision to keep or drop an identity-less voice row is
+     * the same on every path, including the epoch-change path where the staged row's canonical
+     * snapshot -- and the route text that may be its only identity -- is already gone. */
+    uint8_t staged_named_call;
     /* Render inputs belonging to committed_seq's row, promoted from staged_env when it was
      * pushed. */
     dsd_call_event_render_env committed_env;

--- a/include/dsd-neo/core/call_state.h
+++ b/include/dsd-neo/core/call_state.h
@@ -346,6 +346,17 @@ int dsd_call_state_end_ex(dsd_state* state, uint8_t slot, double observed_m, dsd
 int dsd_call_state_end(dsd_state* state, uint8_t slot, double observed_m);
 
 /**
+ * True for the end reasons that leave the epoch reacquirable (DSD_CALL_END_SYNC_LOSS and
+ * DSD_CALL_END_UNVERIFIED_TERMINATOR).
+ *
+ * The canonical predicate behind reacquisition itself, the event layer's held VOICE_END alert,
+ * and a reacquire-hook owner's decision about whether the state it is about to tear down may
+ * still be needed back. Any private mirror of the reason list would silently diverge when a
+ * reason is added, so callers ask here instead of comparing reasons themselves.
+ */
+int dsd_call_state_end_reason_is_recoverable(uint8_t end_reason);
+
+/**
  * Called after dsd_call_state_observe() heals a recoverably-ended epoch, with the ending
  * snapshot the reopened epoch was seeded from. The canonical layer stays protocol-neutral:
  * a protocol whose end path tears down live decoder state it would need back on a heal (the

--- a/include/dsd-neo/core/call_state.h
+++ b/include/dsd-neo/core/call_state.h
@@ -280,6 +280,13 @@ typedef struct {
      * reacquisition window closes. Stamped with the monotonic deadline to beep at. */
     uint8_t end_alert_pending;
     double end_alert_due_m;
+    /* An identity-less voice row whose recoverable end lacks positive end evidence is held
+     * un-committed rather than dropped: a terminator decoding after the fade retracts the
+     * recoverable reason and vouches for the row, and an immediate drop would be irrevocable.
+     * Stamped with the monotonic deadline to give up and drop at -- the same reacquisition
+     * window the canonical layer applies to the end reason. */
+    uint8_t drop_hold_pending;
+    double drop_hold_due_m;
 } dsd_call_event_lifecycle_snapshot;
 
 /**

--- a/include/dsd-neo/core/file_io.h
+++ b/include/dsd-neo/core/file_io.h
@@ -51,6 +51,14 @@ void openSymbolOutFile(dsd_opts* opts, dsd_state* state);
 SNDFILE* close_wav_file(SNDFILE* wav_file);
 SNDFILE* close_and_rename_wav_file(SNDFILE* wav_file, const dsd_opts* opts, const char* wav_out_filename,
                                    const char* dir, const Event_History_I* event_struct);
+/**
+ * As close_and_rename_wav_file(), but with the rdio-scanner export gated by `export_call`.
+ * The event layer's drop path rotates the recording of an epoch that gets no history row or log
+ * line; exporting it would upload audio tagged with all-zero metadata that the operator has
+ * nothing local to correlate against.
+ */
+SNDFILE* close_and_rename_wav_file_ex(SNDFILE* wav_file, const dsd_opts* opts, const char* wav_out_filename,
+                                      const char* dir, const Event_History_I* event_struct, int export_call);
 void closeMbeOutFile(dsd_opts* opts, dsd_state* state);
 void closeMbeOutFileR(dsd_opts* opts, dsd_state* state);
 void closeSymbolOutFile(dsd_opts* opts, dsd_state* state);

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -584,16 +584,18 @@ struct dsd_state {
 
     /* Live slot crypto captured by the DMR terminator handler just before its reset, so the
      * heal of a voice burst mis-typed as a terminator can restore exactly what the vocoder was
-     * decrypting with: the FID the Basic Privacy gates require, and the MI as the superframe
-     * machinery last advanced it (the canonical snapshot's MI can lag it). Indexed by slot;
-     * epoch ties each capture to the ended epoch it belongs to, so a stale stash can never be
-     * applied to a later call. Owned by src/protocol/dmr; the canonical layer never touches it. */
+     * decrypting with. Deliberately limited to what the canonical dsd_call_snapshot cannot
+     * supply -- the FID and service options the Basic Privacy gates require, and the MI as the
+     * superframe machinery last advanced it (the snapshot's MI can lag it); ALGID and key id
+     * are read back from the snapshot the reacquire hook receives, so they have one source of
+     * truth. Indexed by slot; epoch ties each capture to the ended epoch it belongs to, so a
+     * stale stash can never be applied to a later call, and the engine's retune/no-carrier
+     * resets clear dmr_heal_valid alongside the payload crypto so no stash outlives the channel
+     * it was captured on. Owned by src/protocol/dmr; the canonical layer never touches it. */
     unsigned long long int dmr_heal_mi[2];
     unsigned long long int dmr_heal_epoch[2];
     unsigned int dmr_heal_fid[2];
     unsigned int dmr_heal_so[2];
-    int dmr_heal_algid[2];
-    int dmr_heal_keyid[2];
     uint8_t dmr_heal_valid[2];
 
     char slot1light[8];

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -582,6 +582,20 @@ struct dsd_state {
     unsigned int dmr_soR;
     unsigned int dmr_flcoR;
 
+    /* Live slot crypto captured by the DMR terminator handler just before its reset, so the
+     * heal of a voice burst mis-typed as a terminator can restore exactly what the vocoder was
+     * decrypting with: the FID the Basic Privacy gates require, and the MI as the superframe
+     * machinery last advanced it (the canonical snapshot's MI can lag it). Indexed by slot;
+     * epoch ties each capture to the ended epoch it belongs to, so a stale stash can never be
+     * applied to a later call. Owned by src/protocol/dmr; the canonical layer never touches it. */
+    unsigned long long int dmr_heal_mi[2];
+    unsigned long long int dmr_heal_epoch[2];
+    unsigned int dmr_heal_fid[2];
+    unsigned int dmr_heal_so[2];
+    int dmr_heal_algid[2];
+    int dmr_heal_keyid[2];
+    uint8_t dmr_heal_valid[2];
+
     char slot1light[8];
     char slot2light[8];
     int directmode;

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -168,6 +168,7 @@ typedef struct {
     uint8_t ptt_signature[P25_SM_PTT_SIGNATURE_BYTES]; // Last accepted raw P25P2 MAC_PTT signature
     double ptt_last_seen_m;                            // Last observation of that PTT, including retransmissions
     int ptt_signature_valid;                           // 1 while no accepted call boundary/replacement intervened
+    uint64_t ptt_canonical_epoch;                      // Canonical epoch that most recently accepted a MAC_PTT
 } p25_sm_slot_ctx_t;
 
 typedef struct {

--- a/src/core/file/dsd_file.c
+++ b/src/core/file/dsd_file.c
@@ -788,8 +788,8 @@ wav_file_get_size_or_negative(const char* filename) {
 }
 
 SNDFILE*
-close_and_rename_wav_file(SNDFILE* wav_file, const dsd_opts* opts, const char* wav_out_filename, const char* dir,
-                          const Event_History_I* event_struct) {
+close_and_rename_wav_file_ex(SNDFILE* wav_file, const dsd_opts* opts, const char* wav_out_filename, const char* dir,
+                             const Event_History_I* event_struct, int export_call) {
     if (wav_file != NULL) {
         sf_close(wav_file);
     }
@@ -826,7 +826,7 @@ close_and_rename_wav_file(SNDFILE* wav_file, const dsd_opts* opts, const char* w
         return wav_file;
     }
 
-    if (opts && final_size > 44) {
+    if (export_call && opts && final_size > 44) {
         if (dsd_rdio_export_call(opts, event_struct, new_filename) != 0) {
             LOG_WARN("Rdio export failed for %s\n", new_filename);
         }
@@ -834,6 +834,12 @@ close_and_rename_wav_file(SNDFILE* wav_file, const dsd_opts* opts, const char* w
 
     wav_file = NULL;
     return wav_file;
+}
+
+SNDFILE*
+close_and_rename_wav_file(SNDFILE* wav_file, const dsd_opts* opts, const char* wav_out_filename, const char* dir,
+                          const Event_History_I* event_struct) {
+    return close_and_rename_wav_file_ex(wav_file, opts, wav_out_filename, dir, event_struct, 1);
 }
 
 void

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -387,6 +387,17 @@ dsd_call_state_protocol_voice_is_anonymous(int protocol) {
     return DSD_SYNC_IS_X2TDMA(protocol) || DSD_SYNC_IS_PROVOICE(protocol);
 }
 
+// Protocol capability, kept beside voice_is_anonymous for the same reason. D-STAR has no
+// over-the-air end signaling the decoder parses -- a transmission just stops and the carrier
+// fades -- so its epochs only ever end by sync loss or an engine teardown. Requiring
+// terminator-evidenced ends from it would make the event layer's media-plus-terminator vouch
+// structurally unsatisfiable and silently delete every audible identity-less reception; a
+// sync-loss end is the closest thing to a positive end these modes can produce.
+int
+dsd_call_state_protocol_voice_has_terminator(int protocol) {
+    return !DSD_SYNC_IS_DSTAR(protocol);
+}
+
 // Exported through call_state_internal.h: the event layer's decision to hold a VOICE_END alert
 // open keys on the same notion of "may still be reacquired", and a private mirror of the reason
 // list would silently diverge when a reason is added.
@@ -558,9 +569,9 @@ dsd_call_state_observe(dsd_state* state, const dsd_call_observation* observation
     // Evaluated before the memset below: the ending snapshot is the comparison target.
     const int reacquires_ended_epoch = begins_epoch && call_state_reacquires_ended_epoch(snapshot, observation, now_m);
     // Copied out of the locked region for the reacquire hook: the hook runs protocol code and
-    // must not execute under the canonical lock.
+    // must not execute under the canonical lock. Every read is dominated by the begins_epoch
+    // assignment below (reacquires_ended_epoch implies begins_epoch), so no zeroing is needed.
     dsd_call_snapshot previous;
-    DSD_MEMSET(&previous, 0, sizeof(previous));
     if (begins_epoch) {
         previous = *snapshot;
         DSD_MEMSET(snapshot, 0, sizeof(*snapshot));
@@ -836,6 +847,9 @@ dsd_call_state_invalidate_event_lifecycle(dsd_call_event_lifecycle* lifecycle) {
     // a transmission the operator can no longer see.
     lifecycle->end_alert_pending = 0U;
     lifecycle->end_alert_due_m = 0.0;
+    // Same for a held keep-or-drop verdict: the staged row it was waiting to resolve is gone.
+    lifecycle->drop_hold_pending = 0U;
+    lifecycle->drop_hold_due_m = 0.0;
     // Both halves of the env pair go, matching the epoch-change path in dsd_events.c. A row staged
     // directly by a protocol never passes through the renderer, so a surviving staged_env would be
     // promoted into committed_env when that row commits and a later merge would re-render against

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -395,6 +395,24 @@ dsd_call_state_end_reason_is_recoverable(uint8_t end_reason) {
     return end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS || end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR;
 }
 
+// Exported through call_state_internal.h: the event layer's keep-or-drop verdict for identity-less
+// voice rows keys on the same notion of "positively ended over the air", and a private mirror of
+// the reason list would silently diverge when a reason is added.
+int
+dsd_call_state_end_reason_is_terminator(uint8_t end_reason) {
+    return end_reason == (uint8_t)DSD_CALL_END_TERMINATOR || end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR;
+}
+
+// Exported through call_state_internal.h: the event layer holds a VOICE_END alert open for
+// exactly as long as the end may still be reacquired, so the deadline must be selected by the
+// same reason-keyed rule reacquisition itself applies below -- a second copy of the selection
+// would drift the two windows apart.
+double
+dsd_call_state_end_reason_reacquire_gap_s(uint8_t end_reason) {
+    return end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR ? DSD_CALL_TERMINATOR_HEAL_GAP_S
+                                                                     : DSD_CALL_REACQUIRE_GAP_S;
+}
+
 // True when this observation reopens an epoch that a recoverable end closed moments ago while
 // describing the same call -- one transmission the decoder lost and regained, not two
 // transmissions. The boundary token is deliberately not consulted: the paths that reopen
@@ -434,9 +452,7 @@ call_state_reacquires_ended_epoch(const dsd_call_snapshot* current, const dsd_ca
     // decode can put a new transmission's first identity-less media mark on the slot well inside
     // the sync-loss window -- and folding that in would hand the new call the terminated call's
     // identity and crypto.
-    const double gap = current->end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR
-                           ? DSD_CALL_TERMINATOR_HEAL_GAP_S
-                           : DSD_CALL_REACQUIRE_GAP_S;
+    const double gap = dsd_call_state_end_reason_reacquire_gap_s(current->end_reason);
     return current->ended_m > 0.0 && now_m >= current->ended_m && (now_m - current->ended_m) <= gap;
 }
 

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -5,6 +5,7 @@
 
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/platform/atomic_compat.h>
@@ -457,6 +458,49 @@ call_state_seed_reacquired_snapshot(dsd_call_snapshot* snapshot, const dsd_call_
     // the reopen instant so per-segment durations remain the segment's own.
 }
 
+// A DMR voice burst mis-typed as a terminator runs the slot's terminator reset -- clearing the
+// live dmr_so/payload_algid/payload_keyid/payload_mi the vocoder decrypts with -- before the
+// healing media mark reopens the epoch. Nothing on the identity-less reopen path re-signals
+// those fields (a PI header or late-entry rebuild may never come mid-transmission), so without
+// this the healed continuation of an encrypted call plays as noise for its remainder. The ending
+// snapshot retained the call's crypto; copy it back, but only into a slot whose live crypto is
+// entirely cleared -- the post-reset shape -- so fresher signaling is never overwritten.
+typedef struct {
+    unsigned int* so;
+    int* algid;
+    int* keyid;
+    unsigned long long int* mi;
+} call_state_dmr_slot_crypto;
+
+static call_state_dmr_slot_crypto
+call_state_dmr_slot_crypto_fields(dsd_state* state, uint8_t slot) {
+    if (slot == 0U) {
+        return (call_state_dmr_slot_crypto){&state->dmr_so, &state->payload_algid, &state->payload_keyid,
+                                            &state->payload_mi};
+    }
+    return (call_state_dmr_slot_crypto){&state->dmr_soR, &state->payload_algidR, &state->payload_keyidR,
+                                        &state->payload_miR};
+}
+
+static void
+call_state_restore_dmr_slot_crypto(dsd_state* state, uint8_t slot, const dsd_call_snapshot* previous) {
+    if (!DSD_SYNC_IS_DMR(previous->protocol)) {
+        return;
+    }
+    const uint16_t so = previous->has_service_metadata != 0U ? previous->service_options : 0U;
+    if (so == 0U && previous->algid == 0U && previous->kid == 0U && previous->mi == 0U) {
+        return;
+    }
+    const call_state_dmr_slot_crypto live = call_state_dmr_slot_crypto_fields(state, slot);
+    if (*live.so != 0U || *live.algid != 0 || *live.keyid != 0 || *live.mi != 0ULL) {
+        return;
+    }
+    *live.so = so;
+    *live.algid = previous->algid;
+    *live.keyid = previous->kid;
+    *live.mi = previous->mi;
+}
+
 static void
 call_state_apply_text(char dst[DSD_CALL_IDENTITY_TEXT_SIZE], const char* src) {
     char normalized[DSD_CALL_IDENTITY_TEXT_SIZE];
@@ -529,6 +573,7 @@ dsd_call_state_observe(dsd_state* state, const dsd_call_observation* observation
         snapshot->started_m = now_m;
         if (reacquires_ended_epoch) {
             call_state_seed_reacquired_snapshot(snapshot, &previous);
+            call_state_restore_dmr_slot_crypto(state, observation->slot, &previous);
             ext->events[observation->slot].reacquired_epoch = snapshot->epoch;
             // Which epoch was reopened. Whether a history row may actually be merged is the event
             // layer's call -- it pairs this against the epoch its committed row belongs to -- but

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -387,20 +387,35 @@ dsd_call_state_protocol_voice_is_anonymous(int protocol) {
     return DSD_SYNC_IS_X2TDMA(protocol) || DSD_SYNC_IS_PROVOICE(protocol);
 }
 
-// Protocol capability, kept beside voice_is_anonymous for the same reason. D-STAR has no
-// over-the-air end signaling the decoder parses -- a transmission just stops and the carrier
-// fades -- so its epochs only ever end by sync loss or an engine teardown. Requiring
-// terminator-evidenced ends from it would make the event layer's media-plus-terminator vouch
-// structurally unsatisfiable and silently delete every audible identity-less reception; a
-// sync-loss end is the closest thing to a positive end these modes can produce.
+// Protocol capability, kept beside voice_is_anonymous for the same reason. The question this
+// answers is not "does the mode define an end marker" but "can the decoder be relied on to see
+// one", because the event layer's media-plus-terminator vouch deletes an audible identity-less
+// reception whenever the answer is no.
+//
+// D-STAR has no over-the-air end signaling the decoder parses at all -- a transmission just
+// stops and the carrier fades -- so its epochs only ever end by sync loss or an engine teardown.
+// M17, YSF and NXDN do define one, but each sends it exactly once, in the burst most likely to
+// be the one the fade ate, and behind a check that drops it when the burst is damaged: an M17
+// EOT only ends the call with a valid CRC, a YSF tail only with err == 0 on the FICH, and an
+// NXDN release rides a single SACCH. A transmitter that drops carrier a frame early, or one
+// damaged tail burst, leaves a perfectly audible reception with no end marker to show. DMR and
+// P25 stay on the strict side: their end signaling repeats across the hangtime, so a missed
+// terminator is a decode failure rather than the normal case, and dPMR's FS3 end frame is a
+// sync-correlator match rather than a CRC-gated payload.
+//
+// For the lenient modes a sync-loss end is the closest thing to positive end evidence they can
+// produce, so it has to count -- the cost is that their stray-sync noise epochs keep a row,
+// which is the recoverable direction of the trade.
 int
 dsd_call_state_protocol_voice_has_terminator(int protocol) {
-    return !DSD_SYNC_IS_DSTAR(protocol);
+    return !DSD_SYNC_IS_DSTAR(protocol) && !DSD_SYNC_IS_M17(protocol) && !DSD_SYNC_IS_YSF(protocol)
+           && !DSD_SYNC_IS_NXDN(protocol);
 }
 
-// Exported through call_state_internal.h: the event layer's decision to hold a VOICE_END alert
-// open keys on the same notion of "may still be reacquired", and a private mirror of the reason
-// list would silently diverge when a reason is added.
+// Exported through call_state.h: the event layer's decision to hold a VOICE_END alert open, and a
+// reacquire-hook owner's decision about whether the state its end path is tearing down may still
+// be healed back, key on the same notion of "may still be reacquired". A private mirror of the
+// reason list would silently diverge when a reason is added.
 int
 dsd_call_state_end_reason_is_recoverable(uint8_t end_reason) {
     return end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS || end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR;

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -5,7 +5,6 @@
 
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dsd_time.h>
-#include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/platform/atomic_compat.h>
@@ -388,8 +387,11 @@ dsd_call_state_protocol_voice_is_anonymous(int protocol) {
     return DSD_SYNC_IS_X2TDMA(protocol) || DSD_SYNC_IS_PROVOICE(protocol);
 }
 
-static int
-call_state_end_reason_is_recoverable(uint8_t end_reason) {
+// Exported through call_state_internal.h: the event layer's decision to hold a VOICE_END alert
+// open keys on the same notion of "may still be reacquired", and a private mirror of the reason
+// list would silently diverge when a reason is added.
+int
+dsd_call_state_end_reason_is_recoverable(uint8_t end_reason) {
     return end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS || end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR;
 }
 
@@ -402,7 +404,7 @@ call_state_end_reason_is_recoverable(uint8_t end_reason) {
 static int
 call_state_reacquires_ended_epoch(const dsd_call_snapshot* current, const dsd_call_observation* observation,
                                   double now_m) {
-    if (current->phase != DSD_CALL_PHASE_ENDED || !call_state_end_reason_is_recoverable(current->end_reason)) {
+    if (current->phase != DSD_CALL_PHASE_ENDED || !dsd_call_state_end_reason_is_recoverable(current->end_reason)) {
         return 0;
     }
     // An unverified terminator was positive -- if fallible -- evidence the transmission ended,
@@ -426,8 +428,16 @@ call_state_reacquires_ended_epoch(const dsd_call_snapshot* current, const dsd_ca
     if (call_state_observation_changes_identity(current, observation)) {
         return 0;
     }
-    return current->ended_m > 0.0 && now_m >= current->ended_m
-           && (now_m - current->ended_m) <= DSD_CALL_REACQUIRE_GAP_S;
+    // The heal window after an unverified terminator is much tighter than the sync-loss window:
+    // the mis-typed voice burst it exists for is followed by the transmission's next voice frame
+    // within a burst or two, while a real end followed by a fast re-key whose headers fail to
+    // decode can put a new transmission's first identity-less media mark on the slot well inside
+    // the sync-loss window -- and folding that in would hand the new call the terminated call's
+    // identity and crypto.
+    const double gap = current->end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR
+                           ? DSD_CALL_TERMINATOR_HEAL_GAP_S
+                           : DSD_CALL_REACQUIRE_GAP_S;
+    return current->ended_m > 0.0 && now_m >= current->ended_m && (now_m - current->ended_m) <= gap;
 }
 
 // Carry the ending call's identity and metadata into the reopened epoch. Without this the UI and
@@ -458,47 +468,16 @@ call_state_seed_reacquired_snapshot(dsd_call_snapshot* snapshot, const dsd_call_
     // the reopen instant so per-segment durations remain the segment's own.
 }
 
-// A DMR voice burst mis-typed as a terminator runs the slot's terminator reset -- clearing the
-// live dmr_so/payload_algid/payload_keyid/payload_mi the vocoder decrypts with -- before the
-// healing media mark reopens the epoch. Nothing on the identity-less reopen path re-signals
-// those fields (a PI header or late-entry rebuild may never come mid-transmission), so without
-// this the healed continuation of an encrypted call plays as noise for its remainder. The ending
-// snapshot retained the call's crypto; copy it back, but only into a slot whose live crypto is
-// entirely cleared -- the post-reset shape -- so fresher signaling is never overwritten.
-typedef struct {
-    unsigned int* so;
-    int* algid;
-    int* keyid;
-    unsigned long long int* mi;
-} call_state_dmr_slot_crypto;
+// A protocol whose end path tears down live decoder state it needs back on a heal (the DMR
+// terminator reset clearing the slot's crypto) installs this hook and restores its own fields.
+// The canonical layer only reports that a heal happened and hands over the ending snapshot; what
+// was cleared and what is safe to put back is protocol knowledge and stays in the protocol.
+// Written once from the decode path before the first heal can occur, read on the same thread.
+static dsd_call_state_reacquire_hook g_call_state_reacquire_hook = NULL;
 
-static call_state_dmr_slot_crypto
-call_state_dmr_slot_crypto_fields(dsd_state* state, uint8_t slot) {
-    if (slot == 0U) {
-        return (call_state_dmr_slot_crypto){&state->dmr_so, &state->payload_algid, &state->payload_keyid,
-                                            &state->payload_mi};
-    }
-    return (call_state_dmr_slot_crypto){&state->dmr_soR, &state->payload_algidR, &state->payload_keyidR,
-                                        &state->payload_miR};
-}
-
-static void
-call_state_restore_dmr_slot_crypto(dsd_state* state, uint8_t slot, const dsd_call_snapshot* previous) {
-    if (!DSD_SYNC_IS_DMR(previous->protocol)) {
-        return;
-    }
-    const uint16_t so = previous->has_service_metadata != 0U ? previous->service_options : 0U;
-    if (so == 0U && previous->algid == 0U && previous->kid == 0U && previous->mi == 0U) {
-        return;
-    }
-    const call_state_dmr_slot_crypto live = call_state_dmr_slot_crypto_fields(state, slot);
-    if (*live.so != 0U || *live.algid != 0 || *live.keyid != 0 || *live.mi != 0ULL) {
-        return;
-    }
-    *live.so = so;
-    *live.algid = previous->algid;
-    *live.keyid = previous->kid;
-    *live.mi = previous->mi;
+void
+dsd_call_state_set_reacquire_hook(dsd_call_state_reacquire_hook hook) {
+    g_call_state_reacquire_hook = hook;
 }
 
 static void
@@ -562,8 +541,12 @@ dsd_call_state_observe(dsd_state* state, const dsd_call_observation* observation
     const int begins_epoch = call_state_observation_begins_epoch(snapshot, observation, boundary);
     // Evaluated before the memset below: the ending snapshot is the comparison target.
     const int reacquires_ended_epoch = begins_epoch && call_state_reacquires_ended_epoch(snapshot, observation, now_m);
+    // Copied out of the locked region for the reacquire hook: the hook runs protocol code and
+    // must not execute under the canonical lock.
+    dsd_call_snapshot previous;
+    DSD_MEMSET(&previous, 0, sizeof(previous));
     if (begins_epoch) {
-        const dsd_call_snapshot previous = *snapshot;
+        previous = *snapshot;
         DSD_MEMSET(snapshot, 0, sizeof(*snapshot));
         ext->epoch_sequence[observation->slot] = call_state_next_nonzero(ext->epoch_sequence[observation->slot]);
         snapshot->epoch = ext->epoch_sequence[observation->slot];
@@ -573,7 +556,6 @@ dsd_call_state_observe(dsd_state* state, const dsd_call_observation* observation
         snapshot->started_m = now_m;
         if (reacquires_ended_epoch) {
             call_state_seed_reacquired_snapshot(snapshot, &previous);
-            call_state_restore_dmr_slot_crypto(state, observation->slot, &previous);
             ext->events[observation->slot].reacquired_epoch = snapshot->epoch;
             // Which epoch was reopened. Whether a history row may actually be merged is the event
             // layer's call -- it pairs this against the epoch its committed row belongs to -- but
@@ -597,6 +579,9 @@ dsd_call_state_observe(dsd_state* state, const dsd_call_observation* observation
     snapshot->revision = call_state_next_nonzero(snapshot->revision);
     ext->calls.revision = call_state_next_nonzero(ext->calls.revision);
     dsd_call_state_ext_unlock(ext);
+    if (reacquires_ended_epoch && g_call_state_reacquire_hook != NULL) {
+        g_call_state_reacquire_hook(state, observation->slot, &previous);
+    }
     return begins_epoch;
 }
 
@@ -709,21 +694,24 @@ dsd_call_state_end_ex(dsd_state* state, uint8_t slot, double observed_m, dsd_cal
         // recoverable end, must be able to retract the reacquisition permission that end
         // granted. The fade is often the last thing heard before the terminator that explains
         // it, so without this a second PTT on the same identity inside the gap folds into the
-        // terminated call's row. Two strengths of evidence qualify: a verified terminator or
-        // EOT (an EXPLICIT request) retracts either recoverable reason, and a second unverified
+        // terminated call's row. Two strengths of evidence qualify: a verified terminator or an
+        // EXPLICIT teardown retracts either recoverable reason, and a second unverified
         // terminator corroborates an unverified-terminator end -- two independently mis-typed
         // bursts in a row is not a plausible fade. An unverified terminator alone never
         // tightens a sync-loss end: it is the same fallible evidence the recoverable end exists
         // to distrust, and trusting it there would split a faded transmission in two and
-        // release its held VOICE_END early. Only tightening toward EXPLICIT is allowed, and
-        // ended_m is deliberately left alone: the reason changes, the moment the transmission
-        // stopped does not.
-        const int retracts =
-            reason == DSD_CALL_END_EXPLICIT && call_state_end_reason_is_recoverable(snapshot->end_reason);
+        // release its held VOICE_END early. Only tightening toward a final reason is allowed --
+        // TERMINATOR where the evidence was a terminator (verified, or corroborated by repeat),
+        // EXPLICIT for a teardown -- and ended_m is deliberately left alone: the reason
+        // changes, the moment the transmission stopped does not.
+        const int retracts = (reason == DSD_CALL_END_EXPLICIT || reason == DSD_CALL_END_TERMINATOR)
+                             && dsd_call_state_end_reason_is_recoverable(snapshot->end_reason);
         const int corroborates = reason == DSD_CALL_END_UNVERIFIED_TERMINATOR
                                  && snapshot->end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR;
         if (snapshot->epoch != 0U && snapshot->phase == DSD_CALL_PHASE_ENDED && (retracts || corroborates)) {
-            snapshot->end_reason = (uint8_t)DSD_CALL_END_EXPLICIT;
+            snapshot->end_reason = (reason == DSD_CALL_END_TERMINATOR || corroborates)
+                                       ? (uint8_t)DSD_CALL_END_TERMINATOR
+                                       : (uint8_t)DSD_CALL_END_EXPLICIT;
             snapshot->revision = call_state_next_nonzero(snapshot->revision);
             ext->calls.revision = call_state_next_nonzero(ext->calls.revision);
             dsd_call_state_ext_unlock(ext);

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -375,16 +375,45 @@ dsd_call_state_snapshot_has_identity(const dsd_call_snapshot* current) {
            || call_state_text_is_known(current->route_text[0]) || call_state_text_is_known(current->route_text[1]);
 }
 
-// True when this observation reopens an epoch that sync loss ended moments ago while describing
-// the same call -- one transmission the decoder lost and regained, not two transmissions. The
-// boundary token is deliberately not consulted: the paths that reopen mid-transmission (the
-// vocoder's per-frame media mark, a DMR Voice LC Header arriving after the gap, M17's stream
-// mark, the P25p1 ESS ensure-call) all pass BEGIN, while P25 Phase 2 and the other re-announcing
-// protocols pass CONTINUE. Both must arm.
+// Protocol capability, kept in the canonical layer so the event layer never grows its own
+// per-protocol knowledge: these modes never parse their voice traffic into a talkgroup or
+// source, so an identity-less voice epoch is the protocol's whole story -- that the channel
+// carried voice -- not a decode failure. A protocol added here keeps its all-zero rows;
+// everywhere else an identity-less voice epoch must earn its row another way. (EDACS-trunked
+// ProVoice rows carry AFS/LID strings and never present as identity-less; the entry only
+// matters for the standalone mode.)
+int
+dsd_call_state_protocol_voice_is_anonymous(int protocol) {
+    return DSD_SYNC_IS_X2TDMA(protocol) || DSD_SYNC_IS_PROVOICE(protocol);
+}
+
+static int
+call_state_end_reason_is_recoverable(uint8_t end_reason) {
+    return end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS || end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR;
+}
+
+// True when this observation reopens an epoch that a recoverable end closed moments ago while
+// describing the same call -- one transmission the decoder lost and regained, not two
+// transmissions. The boundary token is deliberately not consulted: the paths that reopen
+// mid-transmission (the vocoder's per-frame media mark, a DMR Voice LC Header arriving after the
+// gap, M17's stream mark, the P25p1 ESS ensure-call) all pass BEGIN, while P25 Phase 2 and the
+// other re-announcing protocols pass CONTINUE. Both must arm.
 static int
 call_state_reacquires_ended_epoch(const dsd_call_snapshot* current, const dsd_call_observation* observation,
                                   double now_m) {
-    if (current->phase != DSD_CALL_PHASE_ENDED || current->end_reason != (uint8_t)DSD_CALL_END_SYNC_LOSS) {
+    if (current->phase != DSD_CALL_PHASE_ENDED || !call_state_end_reason_is_recoverable(current->end_reason)) {
+        return 0;
+    }
+    // An unverified terminator was positive -- if fallible -- evidence the transmission ended,
+    // so only identity-less continuations may reopen its epoch: the vocoder's per-frame media
+    // mark that heals a voice burst mis-typed as a terminator arrives within one burst and
+    // carries no identity. An identity-bearing observation after such an end is the next
+    // transmission's header, and folding it in would merge a genuine second PTT on the same
+    // TG/SRC into the terminated call's row. A sync-loss end carries no end evidence at all, so
+    // there the identity-bearing reopen (a DMR Voice LC Header arriving after the gap, M17's
+    // stream mark) stays a reacquisition.
+    if (current->end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR
+        && call_state_observation_has_identity(observation)) {
         return 0;
     }
     // The ending epoch must name a call. Without this an identity-less provisional epoch -- the
@@ -631,15 +660,24 @@ dsd_call_state_end_ex(dsd_state* state, uint8_t slot, double observed_m, dsd_cal
     // that fire while unsynced do not re-stamp ended_m: the reacquisition gap
     // stays anchored at the first end.
     if (snapshot->epoch == 0U || snapshot->phase != DSD_CALL_PHASE_ACTIVE) {
-        // One exception: a terminator or EOT decoded after sync loss already ended the epoch is
-        // positive evidence that the transmission is over, and it must be able to retract the
-        // reacquisition permission that end granted. The fade is often the last thing heard
-        // before the terminator that explains it, so without this a second PTT on the same
-        // identity inside the gap folds into the terminated call's row. Only this one direction
-        // is allowed, and ended_m is deliberately left alone: the reason changes, the moment the
-        // transmission stopped does not.
-        if (snapshot->epoch != 0U && snapshot->phase == DSD_CALL_PHASE_ENDED
-            && snapshot->end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS && reason == DSD_CALL_END_EXPLICIT) {
+        // One exception: positive evidence that the transmission is over, arriving after a
+        // recoverable end, must be able to retract the reacquisition permission that end
+        // granted. The fade is often the last thing heard before the terminator that explains
+        // it, so without this a second PTT on the same identity inside the gap folds into the
+        // terminated call's row. Two strengths of evidence qualify: a verified terminator or
+        // EOT (an EXPLICIT request) retracts either recoverable reason, and a second unverified
+        // terminator corroborates an unverified-terminator end -- two independently mis-typed
+        // bursts in a row is not a plausible fade. An unverified terminator alone never
+        // tightens a sync-loss end: it is the same fallible evidence the recoverable end exists
+        // to distrust, and trusting it there would split a faded transmission in two and
+        // release its held VOICE_END early. Only tightening toward EXPLICIT is allowed, and
+        // ended_m is deliberately left alone: the reason changes, the moment the transmission
+        // stopped does not.
+        const int retracts =
+            reason == DSD_CALL_END_EXPLICIT && call_state_end_reason_is_recoverable(snapshot->end_reason);
+        const int corroborates = reason == DSD_CALL_END_UNVERIFIED_TERMINATOR
+                                 && snapshot->end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR;
+        if (snapshot->epoch != 0U && snapshot->phase == DSD_CALL_PHASE_ENDED && (retracts || corroborates)) {
             snapshot->end_reason = (uint8_t)DSD_CALL_END_EXPLICIT;
             snapshot->revision = call_state_next_nonzero(snapshot->revision);
             ext->calls.revision = call_state_next_nonzero(ext->calls.revision);
@@ -755,8 +793,6 @@ dsd_call_state_invalidate_event_lifecycle(dsd_call_event_lifecycle* lifecycle) {
     // a decoder context from before this invalidation.
     DSD_MEMSET(&lifecycle->staged_env, 0, sizeof(lifecycle->staged_env));
     DSD_MEMSET(&lifecycle->committed_env, 0, sizeof(lifecycle->committed_env));
-    // The staged row this verdict described is going away with the rows above.
-    lifecycle->staged_named_call = 0U;
 }
 
 int

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -306,7 +306,7 @@ call_state_observation_changes_identity(const dsd_call_snapshot* current, const 
         return 1;
     }
     // Route text is compared here rather than only where reacquisition consults it: both
-    // call_state_observation_has_identity() and call_state_snapshot_has_identity() already count
+    // call_state_observation_has_identity() and dsd_call_state_snapshot_has_identity() already count
     // it as identity, so leaving it out made it the one anchor no contradiction could ever reject.
     // A route-only D-STAR or YSF snapshot would then match every later observation. Like the other
     // text fields it only reports a contradiction when both sides are known, so a repeater pair
@@ -362,9 +362,14 @@ call_state_observation_begins_epoch(const dsd_call_snapshot* current, const dsd_
 // True when the slot names a call concretely enough for "the same call" to mean anything.
 // call_state_observation_changes_identity() only reports a *contradiction*, so a snapshot that
 // never learned an identity is compatible with every observation; reacquisition needs a positive
-// anchor or it would coalesce two unrelated transmissions.
-static int
-call_state_snapshot_has_identity(const dsd_call_snapshot* current) {
+// anchor or it would coalesce two unrelated transmissions. Exported through
+// call_state_internal.h: the event layer keys its drop-identity-less-voice-rows decision on the
+// same notion of "named a call", and a private mirror of the field list would silently diverge.
+int
+dsd_call_state_snapshot_has_identity(const dsd_call_snapshot* current) {
+    if (current == NULL) {
+        return 0;
+    }
     return call_state_effective_target_snapshot(current) != 0U || current->ota_source_id != 0U
            || call_state_text_is_known(current->source_text) || call_state_text_is_known(current->target_text)
            || call_state_text_is_known(current->route_text[0]) || call_state_text_is_known(current->route_text[1]);
@@ -385,7 +390,7 @@ call_state_reacquires_ended_epoch(const dsd_call_snapshot* current, const dsd_ca
     // The ending epoch must name a call. Without this an identity-less provisional epoch -- the
     // shape mark_vocoder_call_media() opens before any header decodes -- matches everything, and
     // the next unrelated call on the slot would be folded into its row.
-    if (!call_state_snapshot_has_identity(current)) {
+    if (!dsd_call_state_snapshot_has_identity(current)) {
         return 0;
     }
     if (call_state_observation_changes_identity(current, observation)) {
@@ -750,6 +755,8 @@ dsd_call_state_invalidate_event_lifecycle(dsd_call_event_lifecycle* lifecycle) {
     // a decoder context from before this invalidation.
     DSD_MEMSET(&lifecycle->staged_env, 0, sizeof(lifecycle->staged_env));
     DSD_MEMSET(&lifecycle->committed_env, 0, sizeof(lifecycle->committed_env));
+    // The staged row this verdict described is going away with the rows above.
+    lifecycle->staged_named_call = 0U;
 }
 
 int

--- a/src/core/util/call_state_internal.h
+++ b/src/core/util/call_state_internal.h
@@ -27,6 +27,14 @@ dsd_call_state_ext* dsd_call_state_ext_get(dsd_state* state, int create);
  * whose epoch never named a call (dsd_events.c). NULL-safe.
  */
 int dsd_call_state_snapshot_has_identity(const dsd_call_snapshot* current);
+
+/**
+ * True for protocols whose voice traffic never carries per-call identity (standalone X2-TDMA and
+ * ProVoice), so an all-zero voice row is the protocol's whole story rather than noise. Protocol
+ * capability lives here, beside the identity notion it qualifies, so the event layer's
+ * keep-or-drop decision never grows a private per-protocol list.
+ */
+int dsd_call_state_protocol_voice_is_anonymous(int protocol);
 const dsd_call_state_ext* dsd_call_state_ext_peek(const dsd_state* state);
 void dsd_call_state_ext_lock(const dsd_call_state_ext* ext);
 void dsd_call_state_ext_unlock(const dsd_call_state_ext* ext);

--- a/src/core/util/call_state_internal.h
+++ b/src/core/util/call_state_internal.h
@@ -37,20 +37,19 @@ int dsd_call_state_snapshot_has_identity(const dsd_call_snapshot* current);
 int dsd_call_state_protocol_voice_is_anonymous(int protocol);
 
 /**
- * True for protocols whose voice traffic can signal its own end over the air (a terminator
- * burst, an end frame, an EOT). False for D-STAR, whose transmissions only ever end by sync
- * loss or an engine teardown, so the event layer's keep-or-drop verdict must accept a sync-loss
- * end as the positive end evidence those modes can never produce.
+ * True for protocols whose voice traffic can be relied on to signal its own end over the air:
+ * DMR and P25 repeat their end signaling across the hangtime, and dPMR's FS3 end frame is a
+ * sync-correlator match. False for D-STAR, which has no end signaling at all, and for M17, YSF
+ * and NXDN, whose end marker is one un-repeated CRC- or error-gated burst that a fade or a
+ * single damaged frame routinely costs. The event layer's keep-or-drop verdict must accept a
+ * sync-loss end from the false side as the positive end evidence those modes cannot be counted
+ * on to produce.
  */
 int dsd_call_state_protocol_voice_has_terminator(int protocol);
 
-/**
- * True for the end reasons that leave the epoch reacquirable (SYNC_LOSS and
- * UNVERIFIED_TERMINATOR). The canonical predicate behind both reacquisition (call_state.c) and
- * the event layer's decision to hold a VOICE_END alert open until the window closes
- * (dsd_events.c); a private mirror of the reason list would silently diverge.
- */
-int dsd_call_state_end_reason_is_recoverable(uint8_t end_reason);
+/* dsd_call_state_end_reason_is_recoverable() is declared in <dsd-neo/core/call_state.h>: the
+ * protocol reacquire-hook owners need the same predicate to decide whether state they are about
+ * to tear down may still be healed back, so it is public rather than core-internal. */
 
 /**
  * True for the end reasons that are positive over-the-air evidence a transmission ended (a

--- a/src/core/util/call_state_internal.h
+++ b/src/core/util/call_state_internal.h
@@ -43,6 +43,23 @@ int dsd_call_state_protocol_voice_is_anonymous(int protocol);
  * (dsd_events.c); a private mirror of the reason list would silently diverge.
  */
 int dsd_call_state_end_reason_is_recoverable(uint8_t end_reason);
+
+/**
+ * True for the end reasons that are positive over-the-air evidence a transmission ended (a
+ * terminator burst, verified or not). EXPLICIT is deliberately excluded: the engine ends epochs
+ * EXPLICIT on every retune and teardown, so it says nothing about the air. The canonical
+ * predicate behind the event layer's keep-or-drop verdict for identity-less voice rows
+ * (dsd_events.c); a private mirror of the reason list would silently diverge.
+ */
+int dsd_call_state_end_reason_is_terminator(uint8_t end_reason);
+
+/**
+ * Seconds after an end with this reason within which the epoch may still be reacquired:
+ * DSD_CALL_TERMINATOR_HEAL_GAP_S after an unverified terminator, DSD_CALL_REACQUIRE_GAP_S
+ * otherwise. The event layer holds a VOICE_END alert open for exactly this long, so the deadline
+ * and the reacquisition window it waits on cannot drift apart.
+ */
+double dsd_call_state_end_reason_reacquire_gap_s(uint8_t end_reason);
 const dsd_call_state_ext* dsd_call_state_ext_peek(const dsd_state* state);
 void dsd_call_state_ext_lock(const dsd_call_state_ext* ext);
 void dsd_call_state_ext_unlock(const dsd_call_state_ext* ext);

--- a/src/core/util/call_state_internal.h
+++ b/src/core/util/call_state_internal.h
@@ -19,6 +19,14 @@ typedef struct {
 } dsd_call_state_ext;
 
 dsd_call_state_ext* dsd_call_state_ext_get(dsd_state* state, int create);
+
+/**
+ * True when the snapshot names a call concretely enough for "the same call" to mean anything:
+ * a target or source id, a source/target text, or a route text. The canonical identity notion
+ * shared by reacquisition (call_state.c) and the event layer's decision to drop voice rows
+ * whose epoch never named a call (dsd_events.c). NULL-safe.
+ */
+int dsd_call_state_snapshot_has_identity(const dsd_call_snapshot* current);
 const dsd_call_state_ext* dsd_call_state_ext_peek(const dsd_state* state);
 void dsd_call_state_ext_lock(const dsd_call_state_ext* ext);
 void dsd_call_state_ext_unlock(const dsd_call_state_ext* ext);

--- a/src/core/util/call_state_internal.h
+++ b/src/core/util/call_state_internal.h
@@ -37,6 +37,14 @@ int dsd_call_state_snapshot_has_identity(const dsd_call_snapshot* current);
 int dsd_call_state_protocol_voice_is_anonymous(int protocol);
 
 /**
+ * True for protocols whose voice traffic can signal its own end over the air (a terminator
+ * burst, an end frame, an EOT). False for D-STAR, whose transmissions only ever end by sync
+ * loss or an engine teardown, so the event layer's keep-or-drop verdict must accept a sync-loss
+ * end as the positive end evidence those modes can never produce.
+ */
+int dsd_call_state_protocol_voice_has_terminator(int protocol);
+
+/**
  * True for the end reasons that leave the epoch reacquirable (SYNC_LOSS and
  * UNVERIFIED_TERMINATOR). The canonical predicate behind both reacquisition (call_state.c) and
  * the event layer's decision to hold a VOICE_END alert open until the window closes

--- a/src/core/util/call_state_internal.h
+++ b/src/core/util/call_state_internal.h
@@ -35,6 +35,14 @@ int dsd_call_state_snapshot_has_identity(const dsd_call_snapshot* current);
  * keep-or-drop decision never grows a private per-protocol list.
  */
 int dsd_call_state_protocol_voice_is_anonymous(int protocol);
+
+/**
+ * True for the end reasons that leave the epoch reacquirable (SYNC_LOSS and
+ * UNVERIFIED_TERMINATOR). The canonical predicate behind both reacquisition (call_state.c) and
+ * the event layer's decision to hold a VOICE_END alert open until the window closes
+ * (dsd_events.c); a private mirror of the reason list would silently diverge.
+ */
+int dsd_call_state_end_reason_is_recoverable(uint8_t end_reason);
 const dsd_call_state_ext* dsd_call_state_ext_peek(const dsd_state* state);
 void dsd_call_state_ext_lock(const dsd_call_state_ext* ext);
 void dsd_call_state_ext_unlock(const dsd_call_state_ext* ext);

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -481,10 +481,10 @@ watchdog_event_capture_render_env(const dsd_state* state, uint8_t slot, const ds
     // EXPLICIT is deliberately excluded: the engine ends epochs EXPLICIT on every retune and
     // teardown, so counting it would commit the identity-less noise row this verdict exists to
     // drop whenever the trunker returns to the control channel instead of letting the signal
-    // fade. For protocols with no terminator to decode (D-STAR), a sync-loss end is the closest
-    // thing to positive end evidence the mode can produce; demanding a terminator there would
-    // make the vouch structurally unsatisfiable and delete every audible identity-less
-    // reception.
+    // fade. For protocols whose end marker cannot be relied on -- D-STAR has none, and M17, YSF
+    // and NXDN each send one un-repeated gated burst -- a sync-loss end is the closest thing to
+    // positive end evidence the mode can produce; demanding a terminator there would delete
+    // audible identity-less receptions as a matter of course rather than exceptionally.
     env->ended_positively = (uint8_t)(call != NULL && call->phase == DSD_CALL_PHASE_ENDED
                                       && (dsd_call_state_end_reason_is_terminator(call->end_reason)
                                           || (!dsd_call_state_protocol_voice_has_terminator(call->protocol)
@@ -1667,7 +1667,7 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
     // -- may be the middle of a transmission rather than its end, so its VOICE_END alert is
     // held until the reacquisition window closes. Each further segment re-arms it, and the
     // alert lands once the call really has stopped flapping; a corroborating terminator repeat
-    // tightens the reason to EXPLICIT, which releases the hold at the next sync pass. A
+    // tightens the reason to TERMINATOR, which releases the hold at the next sync pass. A
     // verified terminator is unambiguous and alerts immediately.
     //
     // This describes what happened on the air, so it is derived from the air alone. Whether the

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -302,7 +302,7 @@ watchdog_event_voice_row_is_identityless(const Event_History* item) {
 // The media-plus-terminator arm is what keeps audible traffic on systems where link control
 // rarely verifies (a RAS DMR kerchunk whose embedded LC never reassembled) from vanishing
 // without a row, a log line, or an end alert, while a stray-sync noise epoch -- media but no
-// terminator, ended by sync loss -- still drops.
+// terminator, ended by sync loss or by the engine retuning away -- still drops.
 static int
 watchdog_event_staged_epoch_vouches(const dsd_call_event_render_env* env) {
     return env->named_call != 0U || (env->saw_media != 0U && env->ended_positively != 0U);
@@ -415,8 +415,8 @@ watchdog_event_handle_source_transition(dsd_opts* opts, dsd_state* state, Event_
                                                reset_slot_identity, DSD_EVENT_END_FINAL);
 }
 
-// True when the epoch this slot holds a VOICE_END for has since been positively terminated: a
-// terminator or EOT decoded after the sync-loss end and tightened the reason to EXPLICIT. The
+// True when the epoch this slot holds a VOICE_END for has since had its recoverable end
+// tightened to a final reason: a terminator, EOT, or teardown decoded after the fade. The
 // reacquisition window is what the alert was waiting on, and that permission is now retracted,
 // so there is nothing left to wait for.
 static int
@@ -425,7 +425,7 @@ watchdog_event_end_is_positively_terminated(const dsd_call_snapshot* call, const
         return 0;
     }
     return call->phase == DSD_CALL_PHASE_ENDED && call->epoch != 0U && call->epoch == lifecycle->epoch
-           && call->end_reason == (uint8_t)DSD_CALL_END_EXPLICIT;
+           && !dsd_call_state_end_reason_is_recoverable(call->end_reason);
 }
 
 // Emit a VOICE_END alert that was held open across a possible reacquisition. `force` retires it
@@ -473,8 +473,14 @@ watchdog_event_capture_render_env(const dsd_state* state, uint8_t slot, const ds
     // the epoch-boundary memset of the whole env resets all three.
     env->named_call = (uint8_t)(dsd_call_state_snapshot_has_identity(call) != 0);
     env->saw_media = (uint8_t)(env->saw_media != 0U || (call != NULL && call->media_active != 0U));
+    // Only the terminator reasons are positive over-the-air evidence a transmission ended.
+    // EXPLICIT is deliberately excluded: the engine ends epochs EXPLICIT on every retune and
+    // teardown, so counting it would commit the identity-less noise row this verdict exists to
+    // drop whenever the trunker returns to the control channel instead of letting the signal
+    // fade.
     env->ended_positively = (uint8_t)(call != NULL && call->phase == DSD_CALL_PHASE_ENDED
-                                      && call->end_reason != (uint8_t)DSD_CALL_END_SYNC_LOSS);
+                                      && (call->end_reason == (uint8_t)DSD_CALL_END_TERMINATOR
+                                          || call->end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR));
 }
 
 // Depth of the row this slot last committed, or 0 when it can no longer be located.
@@ -1628,9 +1634,8 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
     // operator wants to hear the result is a separate question, answered where the beep is
     // actually emitted -- folding the alert setting in here would make a disposition that other
     // side effects hang off silently change with an unrelated preference.
-    const int deferred_end = (call->end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS
-                              || call->end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR)
-                             && call->kind != DSD_CALL_KIND_DATA;
+    const int deferred_end =
+        dsd_call_state_end_reason_is_recoverable(call->end_reason) && call->kind != DSD_CALL_KIND_DATA;
     const dsd_event_end_disposition disposition = deferred_end ? DSD_EVENT_END_DEFERRED : DSD_EVENT_END_FINAL;
     if (watchdog_event_item_has_content(&event_struct->Event_History_Items[0])) {
         // A new row, a merge into the row the interrupted transmission already owns, or -- for

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -238,13 +238,23 @@ watchdog_event_should_write_slot(const dsd_state* state) {
     return watchdog_event_should_write_systype(state->lastsynctype);
 }
 
+// Decoded per-transmission detail beyond identity: an alias, a position, a text message, or a
+// notice. One list, shared by watchdog_event_item_has_content() and the identity-less drop check
+// below -- a second private copy of these fields would let a future field pass one check and
+// fail the other, and a row whose only content is that field would then be staged but silently
+// dropped.
+static int
+watchdog_event_row_has_decoded_detail(const Event_History* item) {
+    return item->alias[0] != '\0' || item->gps_s[0] != '\0' || item->text_message[0] != '\0'
+           || item->internal_str[0] != '\0';
+}
+
 static int
 watchdog_event_item_has_content(const Event_History* item) {
     if (item == NULL) {
         return 0;
     }
-    return item->event_string[0] != '\0' || item->text_message[0] != '\0' || item->alias[0] != '\0'
-           || item->gps_s[0] != '\0' || item->internal_str[0] != '\0';
+    return item->event_string[0] != '\0' || watchdog_event_row_has_decoded_detail(item);
 }
 
 // Crypto knowledge is decoded detail: a row whose epoch only ever learned "encrypted, this
@@ -255,7 +265,10 @@ watchdog_event_row_records_crypto(const Event_History* item) {
 }
 
 // Numeric or textual call identity carried by the row itself. System identifiers alone (a color
-// code, a NAC) do not name a call, matching dsd_call_state_snapshot_has_identity().
+// code, a NAC) do not name a call, matching dsd_call_state_snapshot_has_identity(). This is a
+// rescue check only -- it can keep a row, never doom one: renderer-built rows copy these fields
+// from the canonical snapshot, whose named_call verdict is the authoritative gate, so a field
+// this list misses costs nothing as long as the canonical helper counts it.
 static int
 watchdog_event_row_names_call(const Event_History* item) {
     return item->target_id != 0U || item->source_id != 0U || item->src_str[0] != '\0' || item->tgt_str[0] != '\0';
@@ -272,18 +285,27 @@ watchdog_event_voice_row_is_identityless(const Event_History* item) {
     if (item == NULL || item->category != DSD_EVENT_CATEGORY_VOICE) {
         return 0;
     }
-    // X2-TDMA and standalone ProVoice are exempt: neither ever parses its voice traffic into a
-    // talkgroup or source, so an all-zero row is the protocol's whole story -- that the channel
-    // carried voice -- not noise. (EDACS-trunked ProVoice rows carry AFS/LID strings and never
-    // reach the drop; the exemption only matters for the standalone modes.)
-    if (DSD_SYNC_IS_X2TDMA(item->systype) || DSD_SYNC_IS_PROVOICE(item->systype)) {
+    // Protocols whose voice traffic never carries identity keep their all-zero rows; the
+    // capability list lives in the canonical layer beside the identity notion it qualifies.
+    if (dsd_call_state_protocol_voice_is_anonymous(item->systype)) {
         return 0;
     }
     if (watchdog_event_row_records_crypto(item) || watchdog_event_row_names_call(item)) {
         return 0;
     }
-    return item->alias[0] == '\0' && item->gps_s[0] == '\0' && item->text_message[0] == '\0'
-           && item->internal_str[0] == '\0';
+    return !watchdog_event_row_has_decoded_detail(item);
+}
+
+// The staged epoch's render-time verdicts vouch for a row the field checks above cannot: it
+// named a call in ways the row strings never carry (route text), or it was a real transmission
+// on the air even though nothing named it -- decoded voice media ran and a terminator ended it.
+// The media-plus-terminator arm is what keeps audible traffic on systems where link control
+// rarely verifies (a RAS DMR kerchunk whose embedded LC never reassembled) from vanishing
+// without a row, a log line, or an end alert, while a stray-sync noise epoch -- media but no
+// terminator, ended by sync loss -- still drops.
+static int
+watchdog_event_staged_epoch_vouches(const dsd_call_event_render_env* env) {
+    return env->named_call != 0U || (env->saw_media != 0U && env->ended_positively != 0U);
 }
 
 static int
@@ -353,18 +375,25 @@ typedef enum {
     DSD_EVENT_END_DEFERRED,
 } dsd_event_end_disposition;
 
-// Retire the staged row: rotate the WAV when the transmission is over, then clear the row and
-// the per-transmission scratch that fed it. Every path that is done with the staged row --
-// commit, merge, or drop -- ends in this sequence. The rotation must precede the clear:
-// close_and_rename_wav_file() reads its rename metadata from Items[0].
+// Retire the staged row: rotate the WAV when the transmission is over, clear the row and the
+// per-transmission scratch that fed it, then sound the end-of-call alert when a FINAL end asked
+// for one. Every path that is done with the staged row -- commit, merge, or drop -- ends in this
+// sequence; keeping the alert inside it means the end-of-call side effects cannot drift apart
+// across call sites. The rotation must precede the clear: close_and_rename_wav_file() reads its
+// rename metadata from Items[0]. `alert_on_final` is zero only on the drop path, whose rule is
+// that nothing the operator saw is ending.
 static void
 watchdog_event_retire_staged_row(dsd_opts* opts, dsd_state* state, Event_History_I* event_struct, uint8_t slot,
-                                 dsd_event_end_disposition end_disposition) {
+                                 dsd_event_end_disposition end_disposition, int alert_on_final,
+                                 int last_event_is_data) {
     if (end_disposition != DSD_EVENT_END_NONE) {
         watchdog_event_rotate_wav_if_needed(opts, event_struct, slot);
     }
     init_event_history(event_struct, 0, 1);
     watchdog_event_reset_post_push(state);
+    if (alert_on_final && end_disposition == DSD_EVENT_END_FINAL) {
+        watchdog_event_maybe_beep_call_end(opts, state, slot, last_event_is_data);
+    }
 }
 
 static void
@@ -376,10 +405,7 @@ watchdog_event_handle_source_transition_ex(dsd_opts* opts, dsd_state* state, Eve
     event_struct->Event_History_Items[0].write = 1;
     push_event_history(event_struct);
     (void)reset_slot_identity;
-    watchdog_event_retire_staged_row(opts, state, event_struct, slot, end_disposition);
-    if (end_disposition == DSD_EVENT_END_FINAL) {
-        watchdog_event_maybe_beep_call_end(opts, state, slot, last_event_is_data);
-    }
+    watchdog_event_retire_staged_row(opts, state, event_struct, slot, end_disposition, 1, last_event_is_data);
 }
 
 static void
@@ -426,7 +452,8 @@ watchdog_event_flush_pending_end_alert(dsd_opts* opts, dsd_state* state, uint8_t
 // after the canonical layer has opened the next call, by which point the live values describe
 // that call rather than the one the row is about.
 static void
-watchdog_event_capture_render_env(const dsd_state* state, uint8_t slot, dsd_call_event_render_env* env) {
+watchdog_event_capture_render_env(const dsd_state* state, uint8_t slot, const dsd_call_snapshot* call,
+                                  dsd_call_event_render_env* env) {
     env->mfid = slot == 0U ? state->dmr_fid : state->dmr_fidR;
     env->nxdn_grant_chan = state->nxdn_grant_chan;
     env->nxdn_grant_freq = state->nxdn_grant_freq;
@@ -439,6 +466,15 @@ watchdog_event_capture_render_env(const dsd_state* state, uint8_t slot, dsd_call
     env->edacs_a_mask = state->edacs_a_mask;
     env->edacs_f_mask = state->edacs_f_mask;
     env->edacs_s_mask = state->edacs_s_mask;
+    // The epoch verdicts the keep-or-drop decision reads at commit time, captured with the env
+    // so they describe the same render. Identity accrues within an epoch, so plain assignment
+    // is sticky for named_call; media_active is cleared when the call ends, so saw_media must
+    // remember earlier renders itself; the end verdict only exists once the phase is ENDED, and
+    // the epoch-boundary memset of the whole env resets all three.
+    env->named_call = (uint8_t)(dsd_call_state_snapshot_has_identity(call) != 0);
+    env->saw_media = (uint8_t)(env->saw_media != 0U || (call != NULL && call->media_active != 0U));
+    env->ended_positively = (uint8_t)(call != NULL && call->phase == DSD_CALL_PHASE_ENDED
+                                      && call->end_reason != (uint8_t)DSD_CALL_END_SYNC_LOSS);
 }
 
 // Depth of the row this slot last committed, or 0 when it can no longer be located.
@@ -642,17 +678,20 @@ watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History
                                  dsd_call_event_lifecycle* lifecycle, int last_event_is_data, int reset_slot_identity,
                                  dsd_event_end_disposition end_disposition) {
     const Event_History* staged = &event_struct->Event_History_Items[0];
-    // A voice row whose epoch never named a call is dropped rather than committed as
-    // "TGT: 00000000; SRC: 00000000". staged_named_call vouches for identity the row strings
-    // never carry -- the route text anchoring a D-STAR or YSF transmission whose talker
-    // callsigns did not decode -- and, being recorded at render time, gives every commit path
-    // the same verdict, including the epoch-change path where the staged row's canonical
-    // snapshot is already gone. The WAV still rotates: voice frames ran for this epoch, so
-    // leaving the file open would let the noise segment's audio lead the next transmission's
-    // recording. No end alert either -- like the empty-staged-row case, nothing the operator
-    // saw is ending.
-    if (watchdog_event_voice_row_is_identityless(staged) && (lifecycle == NULL || !lifecycle->staged_named_call)) {
-        watchdog_event_retire_staged_row(opts, state, event_struct, slot, end_disposition);
+    // A voice row whose epoch was never anything the operator could name or hear end is dropped
+    // rather than committed as "TGT: 00000000; SRC: 00000000". The staged verdicts -- recorded
+    // at render time, so every commit path gets the same answer, including the epoch-change
+    // path where the staged row's canonical snapshot is already gone -- vouch for what the row
+    // fields cannot: route-text-only identity, or audible media that a terminator positively
+    // ended. Without a lifecycle there are no verdicts to consult, so the row is kept: the
+    // paths that commit without one (a notice for a non-canonical call) stage real traffic,
+    // and a duplicate row is recoverable where a deleted transmission is not. The WAV still
+    // rotates on a drop: voice frames may have run for the epoch, and leaving the file open
+    // would let the noise segment's audio lead the next transmission's recording. No end alert
+    // either -- like the empty-staged-row case, nothing the operator saw is ending.
+    if (watchdog_event_voice_row_is_identityless(staged) && lifecycle != NULL
+        && !watchdog_event_staged_epoch_vouches(&lifecycle->staged_env)) {
+        watchdog_event_retire_staged_row(opts, state, event_struct, slot, end_disposition, 0, last_event_is_data);
         return 0;
     }
     const uint8_t retained_index = watchdog_event_committed_row_index(event_struct, lifecycle);
@@ -676,10 +715,7 @@ watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History
         lifecycle->committed_epoch = lifecycle->epoch;
         // Each segment keeps its own recording; leaving the WAV open would let it absorb the
         // next transmission's audio and be exported under that call's metadata instead.
-        watchdog_event_retire_staged_row(opts, state, event_struct, slot, end_disposition);
-        if (end_disposition == DSD_EVENT_END_FINAL) {
-            watchdog_event_maybe_beep_call_end(opts, state, slot, last_event_is_data);
-        }
+        watchdog_event_retire_staged_row(opts, state, event_struct, slot, end_disposition, 1, last_event_is_data);
         return 1;
     }
     watchdog_event_handle_source_transition_ex(opts, state, event_struct, slot, watchdog_event_should_write_slot(state),
@@ -751,7 +787,7 @@ watchdog_event_history_authoritative(dsd_opts* opts, dsd_state* state, uint8_t s
     const int has_content = watchdog_event_item_has_content(current);
     const int promotes_current = lifecycle->epoch == 0U && watchdog_event_history_matches_call(current, call);
     if (has_content && !promotes_current) {
-        // The staged row belongs to the outgoing epoch; staged_named_call still describes it,
+        // The staged row belongs to the outgoing epoch; the staged verdicts still describe it,
         // so the incoming call's identity cannot vouch for the leftover row.
         (void)watchdog_event_commit_staged_row(opts, state, event_struct, slot, lifecycle,
                                                watchdog_event_is_data_event(current), 0, DSD_EVENT_END_FINAL);
@@ -763,9 +799,8 @@ watchdog_event_history_authoritative(dsd_opts* opts, dsd_state* state, uint8_t s
     lifecycle->ended_committed = 0U;
     // Set after the commit above, which belongs to the outgoing epoch. Rows staged directly by a
     // protocol never pass through the renderer, so without this they would inherit whichever
-    // environment -- and identity verdict -- the previous epoch's last render left behind.
+    // environment -- and epoch verdicts -- the previous epoch's last render left behind.
     DSD_MEMSET(&lifecycle->staged_env, 0, sizeof(lifecycle->staged_env));
-    lifecycle->staged_named_call = 0U;
     lifecycle->notice_epoch = 0U;
     lifecycle->notice_target_id = 0U;
     lifecycle->notice_kind = DSD_CALL_KIND_UNKNOWN;
@@ -958,7 +993,7 @@ watchdog_event_current_init_base(const dsd_state* state, uint8_t slot, const dsd
     ctx->protocol = DSD_SYNC_NONE;
     ctx->kind = DSD_CALL_KIND_UNKNOWN;
     ctx->subtype = slot == 0U ? state->dmrburstL : state->dmrburstR;
-    watchdog_event_capture_render_env(state, slot, &ctx->env);
+    watchdog_event_capture_render_env(state, slot, call, &ctx->env);
 
     if (!call || call->epoch == 0U) {
         return;
@@ -1582,16 +1617,20 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
     if (call->phase != DSD_CALL_PHASE_ENDED || lifecycle->epoch != call->epoch || lifecycle->ended_committed) {
         return;
     }
-    // A sync-loss end may be the middle of a transmission rather than its end, so its VOICE_END
-    // alert is held until the reacquisition window closes. Each further segment re-arms it, and
-    // the alert lands once the call really has stopped flapping. An explicit terminator is
-    // unambiguous and alerts immediately.
+    // A recoverable end -- a sync loss, or a terminator whose link control failed verification
+    // -- may be the middle of a transmission rather than its end, so its VOICE_END alert is
+    // held until the reacquisition window closes. Each further segment re-arms it, and the
+    // alert lands once the call really has stopped flapping; a corroborating terminator repeat
+    // tightens the reason to EXPLICIT, which releases the hold at the next sync pass. A
+    // verified terminator is unambiguous and alerts immediately.
     //
     // This describes what happened on the air, so it is derived from the air alone. Whether the
     // operator wants to hear the result is a separate question, answered where the beep is
     // actually emitted -- folding the alert setting in here would make a disposition that other
     // side effects hang off silently change with an unrelated preference.
-    const int deferred_end = call->end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS && call->kind != DSD_CALL_KIND_DATA;
+    const int deferred_end = (call->end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS
+                              || call->end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR)
+                             && call->kind != DSD_CALL_KIND_DATA;
     const dsd_event_end_disposition disposition = deferred_end ? DSD_EVENT_END_DEFERRED : DSD_EVENT_END_FINAL;
     if (watchdog_event_item_has_content(&event_struct->Event_History_Items[0])) {
         // A new row, a merge into the row the interrupted transmission already owns, or -- for
@@ -1662,14 +1701,12 @@ watchdog_event_current_impl(const dsd_opts* opts, dsd_state* state, uint8_t slot
     DSD_SNPRINTF(candidate.event_string, sizeof(candidate.event_string), "%s", event_string);
 
     watchdog_event_commit_candidate(event_struct, &candidate);
-    // The staged row, the decoder inputs that produced it, and whether its epoch has named a
-    // call are captured together, so whenever that row is committed -- now, or on a later pass
-    // once the epoch has already changed and the snapshot is gone -- it carries the environment
-    // and the identity verdict it was actually rendered under. Identity only accrues within an
-    // epoch, so plain assignment is already sticky.
+    // The staged row, the decoder inputs that produced it, and the epoch verdicts the
+    // keep-or-drop decision reads are captured together, so whenever that row is committed --
+    // now, or on a later pass once the epoch has already changed and the snapshot is gone -- it
+    // carries the environment and the verdicts it was actually rendered under.
     if (lifecycle != NULL) {
-        watchdog_event_capture_render_env(state, slot, &lifecycle->staged_env);
-        lifecycle->staged_named_call = (uint8_t)(dsd_call_state_snapshot_has_identity(effective_call) != 0);
+        watchdog_event_capture_render_env(state, slot, effective_call, &lifecycle->staged_env);
     }
     watchdog_event_finalize_ended(opts, state, slot, effective_call, lifecycle, event_struct, finalize_ended);
 

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -327,21 +327,22 @@ watchdog_event_is_data_event(const Event_History* item) {
 }
 
 static void
-watchdog_event_rotate_wav_if_needed(dsd_opts* opts, const Event_History_I* event_struct, uint8_t slot) {
+watchdog_event_rotate_wav_if_needed(dsd_opts* opts, const Event_History_I* event_struct, uint8_t slot,
+                                    int export_recording) {
     if (opts->static_wav_file != 0) {
         return;
     }
 
     if (slot == 0 && opts->wav_out_f != NULL) {
-        opts->wav_out_f =
-            close_and_rename_wav_file(opts->wav_out_f, opts, opts->wav_out_file, opts->wav_out_dir, event_struct);
+        opts->wav_out_f = close_and_rename_wav_file_ex(opts->wav_out_f, opts, opts->wav_out_file, opts->wav_out_dir,
+                                                       event_struct, export_recording);
         opts->wav_out_f = open_wav_file(opts->wav_out_dir, opts->wav_out_file, sizeof opts->wav_out_file, 8000, 0);
         return;
     }
 
     if (slot == 1 && opts->wav_out_fR != NULL) {
-        opts->wav_out_fR =
-            close_and_rename_wav_file(opts->wav_out_fR, opts, opts->wav_out_fileR, opts->wav_out_dir, event_struct);
+        opts->wav_out_fR = close_and_rename_wav_file_ex(opts->wav_out_fR, opts, opts->wav_out_fileR, opts->wav_out_dir,
+                                                        event_struct, export_recording);
         opts->wav_out_fR = open_wav_file(opts->wav_out_dir, opts->wav_out_fileR, sizeof opts->wav_out_fileR, 8000, 0);
     }
 }
@@ -381,13 +382,16 @@ typedef enum {
 // sequence; keeping the alert inside it means the end-of-call side effects cannot drift apart
 // across call sites. The rotation must precede the clear: close_and_rename_wav_file() reads its
 // rename metadata from Items[0]. `alert_on_final` is zero only on the drop path, whose rule is
-// that nothing the operator saw is ending.
+// that nothing the operator saw is ending -- and for the same reason its rotation skips the
+// rdio-scanner export: the recording of an epoch with no history row or log line would upload
+// under all-zero metadata the operator has nothing local to correlate against. The file itself
+// still rotates so the noise segment's audio cannot lead the next transmission's recording.
 static void
 watchdog_event_retire_staged_row(dsd_opts* opts, dsd_state* state, Event_History_I* event_struct, uint8_t slot,
                                  dsd_event_end_disposition end_disposition, int alert_on_final,
                                  int last_event_is_data) {
     if (end_disposition != DSD_EVENT_END_NONE) {
-        watchdog_event_rotate_wav_if_needed(opts, event_struct, slot);
+        watchdog_event_rotate_wav_if_needed(opts, event_struct, slot, alert_on_final);
     }
     init_event_history(event_struct, 0, 1);
     watchdog_event_reset_post_push(state);
@@ -479,8 +483,7 @@ watchdog_event_capture_render_env(const dsd_state* state, uint8_t slot, const ds
     // drop whenever the trunker returns to the control channel instead of letting the signal
     // fade.
     env->ended_positively = (uint8_t)(call != NULL && call->phase == DSD_CALL_PHASE_ENDED
-                                      && (call->end_reason == (uint8_t)DSD_CALL_END_TERMINATOR
-                                          || call->end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR));
+                                      && dsd_call_state_end_reason_is_terminator(call->end_reason));
 }
 
 // Depth of the row this slot last committed, or 0 when it can no longer be located.
@@ -692,9 +695,11 @@ watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History
     // ended. Without a lifecycle there are no verdicts to consult, so the row is kept: the
     // paths that commit without one (a notice for a non-canonical call) stage real traffic,
     // and a duplicate row is recoverable where a deleted transmission is not. The WAV still
-    // rotates on a drop: voice frames may have run for the epoch, and leaving the file open
-    // would let the noise segment's audio lead the next transmission's recording. No end alert
-    // either -- like the empty-staged-row case, nothing the operator saw is ending.
+    // rotates on a drop -- voice frames may have run for the epoch, and leaving the file open
+    // would let the noise segment's audio lead the next transmission's recording -- but it is
+    // not exported: an upload with all-zero metadata and no local row to correlate against is
+    // an orphan. No end alert either -- like the empty-staged-row case, nothing the operator
+    // saw is ending.
     if (watchdog_event_voice_row_is_identityless(staged) && lifecycle != NULL
         && !watchdog_event_staged_epoch_vouches(&lifecycle->staged_env)) {
         watchdog_event_retire_staged_row(opts, state, event_struct, slot, end_disposition, 0, last_event_is_data);
@@ -1653,8 +1658,11 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
             // Deliberately the local monotonic clock rather than call->ended_m: the deadline is
             // only ever compared against this same clock, and ended_m carries whatever timeline
             // the caller supplied. In production the two coincide; keeping both endpoints on one
-            // clock means a caller-supplied timeline can never make the alert fire early.
-            lifecycle->end_alert_due_m = dsd_time_now_monotonic_s() + DSD_CALL_REACQUIRE_GAP_S;
+            // clock means a caller-supplied timeline can never make the alert fire early. The gap
+            // is selected by end reason -- the same rule reacquisition applies -- so the alert is
+            // not held open past the moment the canonical layer stops accepting a heal.
+            lifecycle->end_alert_due_m =
+                dsd_time_now_monotonic_s() + dsd_call_state_end_reason_reacquire_gap_s(call->end_reason);
         }
     } else {
         init_event_history(event_struct, 0, 1);

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -247,40 +247,43 @@ watchdog_event_item_has_content(const Event_History* item) {
            || item->gps_s[0] != '\0' || item->internal_str[0] != '\0';
 }
 
+// Crypto knowledge is decoded detail: a row whose epoch only ever learned "encrypted, this
+// alg, this key" still records that an encrypted transmission occurred.
+static int
+watchdog_event_row_records_crypto(const Event_History* item) {
+    return item->enc != 0U || item->enc_alg != 0U || item->enc_key != 0U || item->mi != 0U;
+}
+
+// Numeric or textual call identity carried by the row itself. System identifiers alone (a color
+// code, a NAC) do not name a call, matching dsd_call_state_snapshot_has_identity().
+static int
+watchdog_event_row_names_call(const Event_History* item) {
+    return item->target_id != 0U || item->source_id != 0U || item->src_str[0] != '\0' || item->tgt_str[0] != '\0';
+}
+
 // A voice row that never learned who the call was: no numeric or textual call
 // identity and no decoded detail. These render from the provisional epoch a
 // stray voice sync opens before any header decodes, and a committed
-// "TGT: 00000000; SRC: 00000000" row tells the operator nothing. System
-// identifiers alone (a color code, a NAC) do not name a call, mirroring
-// call_state_snapshot_has_identity(). Data and control rows are exempt:
-// repeated LRRP, short data, and response notices are real traffic even when
-// source-less.
+// "TGT: 00000000; SRC: 00000000" row tells the operator nothing. Data and
+// control rows are exempt: repeated LRRP, short data, and response notices are
+// real traffic even when source-less.
 static int
 watchdog_event_voice_row_is_identityless(const Event_History* item) {
     if (item == NULL || item->category != DSD_EVENT_CATEGORY_VOICE) {
         return 0;
     }
-    // X2-TDMA is exempt: it never parses its link control into a talkgroup or source, so an
-    // all-zero row is the protocol's whole story -- that the slot carried voice -- not noise.
-    if (DSD_SYNC_IS_X2TDMA(item->systype)) {
+    // X2-TDMA and standalone ProVoice are exempt: neither ever parses its voice traffic into a
+    // talkgroup or source, so an all-zero row is the protocol's whole story -- that the channel
+    // carried voice -- not noise. (EDACS-trunked ProVoice rows carry AFS/LID strings and never
+    // reach the drop; the exemption only matters for the standalone modes.)
+    if (DSD_SYNC_IS_X2TDMA(item->systype) || DSD_SYNC_IS_PROVOICE(item->systype)) {
         return 0;
     }
-    return item->target_id == 0U && item->source_id == 0U && item->src_str[0] == '\0' && item->tgt_str[0] == '\0'
-           && item->alias[0] == '\0' && item->gps_s[0] == '\0' && item->text_message[0] == '\0'
+    if (watchdog_event_row_records_crypto(item) || watchdog_event_row_names_call(item)) {
+        return 0;
+    }
+    return item->alias[0] == '\0' && item->gps_s[0] == '\0' && item->text_message[0] == '\0'
            && item->internal_str[0] == '\0';
-}
-
-// Mirrors call_state_snapshot_has_identity(): whether the canonical epoch ever named a call.
-// Consulted before dropping an identity-less row because route text -- identity the row strings
-// never carry -- anchors a D-STAR or YSF transmission whose talker callsigns did not decode.
-static int
-watchdog_event_snapshot_names_call(const dsd_call_snapshot* call) {
-    if (call == NULL) {
-        return 0;
-    }
-    return call->ota_target_id != 0U || call->policy_target_id != 0U || call->ota_source_id != 0U
-           || call->source_text[0] != '\0' || call->target_text[0] != '\0' || call->route_text[0][0] != '\0'
-           || call->route_text[1][0] != '\0';
 }
 
 static int
@@ -350,6 +353,20 @@ typedef enum {
     DSD_EVENT_END_DEFERRED,
 } dsd_event_end_disposition;
 
+// Retire the staged row: rotate the WAV when the transmission is over, then clear the row and
+// the per-transmission scratch that fed it. Every path that is done with the staged row --
+// commit, merge, or drop -- ends in this sequence. The rotation must precede the clear:
+// close_and_rename_wav_file() reads its rename metadata from Items[0].
+static void
+watchdog_event_retire_staged_row(dsd_opts* opts, dsd_state* state, Event_History_I* event_struct, uint8_t slot,
+                                 dsd_event_end_disposition end_disposition) {
+    if (end_disposition != DSD_EVENT_END_NONE) {
+        watchdog_event_rotate_wav_if_needed(opts, event_struct, slot);
+    }
+    init_event_history(event_struct, 0, 1);
+    watchdog_event_reset_post_push(state);
+}
+
 static void
 watchdog_event_handle_source_transition_ex(dsd_opts* opts, dsd_state* state, Event_History_I* event_struct,
                                            uint8_t slot, uint8_t swrite, int last_event_is_data,
@@ -357,13 +374,9 @@ watchdog_event_handle_source_transition_ex(dsd_opts* opts, dsd_state* state, Eve
     write_event_to_log_file(opts, state, slot, swrite, event_struct->Event_History_Items[0].event_string);
 
     event_struct->Event_History_Items[0].write = 1;
-    if (end_disposition != DSD_EVENT_END_NONE) {
-        watchdog_event_rotate_wav_if_needed(opts, event_struct, slot);
-    }
     push_event_history(event_struct);
-    init_event_history(event_struct, 0, 1);
     (void)reset_slot_identity;
-    watchdog_event_reset_post_push(state);
+    watchdog_event_retire_staged_row(opts, state, event_struct, slot, end_disposition);
     if (end_disposition == DSD_EVENT_END_FINAL) {
         watchdog_event_maybe_beep_call_end(opts, state, slot, last_event_is_data);
     }
@@ -621,28 +634,25 @@ watchdog_event_staged_row_merges(const Event_History_I* event_struct, const dsd_
 static int watchdog_event_rerender_row(const dsd_call_event_render_env* env, Event_History* item, int* changed);
 
 // Commit the staged row, or merge it into the row this slot already committed when the
-// canonical layer says the two are the same transmission. `staged_call` is the canonical
-// snapshot describing the staged row's epoch, or NULL where that epoch's snapshot is already
-// gone (the epoch-change leftover path). Returns non-zero when the staged row's information
-// reached history -- pushed as a new row or folded into the committed one -- and zero when
-// nothing did.
+// canonical layer says the two are the same transmission. Returns non-zero when the staged
+// row's information reached history -- pushed as a new row or folded into the committed one --
+// and zero when nothing did.
 static int
 watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History_I* event_struct, uint8_t slot,
-                                 dsd_call_event_lifecycle* lifecycle, const dsd_call_snapshot* staged_call,
-                                 int last_event_is_data, int reset_slot_identity,
+                                 dsd_call_event_lifecycle* lifecycle, int last_event_is_data, int reset_slot_identity,
                                  dsd_event_end_disposition end_disposition) {
     const Event_History* staged = &event_struct->Event_History_Items[0];
     // A voice row whose epoch never named a call is dropped rather than committed as
-    // "TGT: 00000000; SRC: 00000000". The WAV still rotates: voice frames ran for this epoch,
-    // so leaving the file open would let the noise segment's audio lead the next
-    // transmission's recording. No end alert either -- like the empty-staged-row case, nothing
-    // the operator saw is ending.
-    if (watchdog_event_voice_row_is_identityless(staged) && !watchdog_event_snapshot_names_call(staged_call)) {
-        if (end_disposition != DSD_EVENT_END_NONE) {
-            watchdog_event_rotate_wav_if_needed(opts, event_struct, slot);
-        }
-        init_event_history(event_struct, 0, 1);
-        watchdog_event_reset_post_push(state);
+    // "TGT: 00000000; SRC: 00000000". staged_named_call vouches for identity the row strings
+    // never carry -- the route text anchoring a D-STAR or YSF transmission whose talker
+    // callsigns did not decode -- and, being recorded at render time, gives every commit path
+    // the same verdict, including the epoch-change path where the staged row's canonical
+    // snapshot is already gone. The WAV still rotates: voice frames ran for this epoch, so
+    // leaving the file open would let the noise segment's audio lead the next transmission's
+    // recording. No end alert either -- like the empty-staged-row case, nothing the operator
+    // saw is ending.
+    if (watchdog_event_voice_row_is_identityless(staged) && (lifecycle == NULL || !lifecycle->staged_named_call)) {
+        watchdog_event_retire_staged_row(opts, state, event_struct, slot, end_disposition);
         return 0;
     }
     const uint8_t retained_index = watchdog_event_committed_row_index(event_struct, lifecycle);
@@ -664,18 +674,12 @@ watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History
         // The merged row is now this epoch's row too, so late enrichment for the reacquired
         // epoch resolves to it and the next segment in the chain has a valid merge target.
         lifecycle->committed_epoch = lifecycle->epoch;
-        if (end_disposition != DSD_EVENT_END_NONE) {
-            // Rotate before the staged row is cleared: close_and_rename_wav_file() reads its
-            // rename metadata from Items[0]. Each segment therefore keeps its own recording;
-            // leaving the file open would let it absorb the next transmission's audio and be
-            // exported under that call's metadata instead.
-            watchdog_event_rotate_wav_if_needed(opts, event_struct, slot);
-        }
+        // Each segment keeps its own recording; leaving the WAV open would let it absorb the
+        // next transmission's audio and be exported under that call's metadata instead.
+        watchdog_event_retire_staged_row(opts, state, event_struct, slot, end_disposition);
         if (end_disposition == DSD_EVENT_END_FINAL) {
             watchdog_event_maybe_beep_call_end(opts, state, slot, last_event_is_data);
         }
-        init_event_history(event_struct, 0, 1);
-        watchdog_event_reset_post_push(state);
         return 1;
     }
     watchdog_event_handle_source_transition_ex(opts, state, event_struct, slot, watchdog_event_should_write_slot(state),
@@ -747,9 +751,9 @@ watchdog_event_history_authoritative(dsd_opts* opts, dsd_state* state, uint8_t s
     const int has_content = watchdog_event_item_has_content(current);
     const int promotes_current = lifecycle->epoch == 0U && watchdog_event_history_matches_call(current, call);
     if (has_content && !promotes_current) {
-        // NULL, not `call`: the staged row belongs to the outgoing epoch, whose snapshot is
-        // gone, and the incoming call's identity must not vouch for it.
-        (void)watchdog_event_commit_staged_row(opts, state, event_struct, slot, lifecycle, NULL,
+        // The staged row belongs to the outgoing epoch; staged_named_call still describes it,
+        // so the incoming call's identity cannot vouch for the leftover row.
+        (void)watchdog_event_commit_staged_row(opts, state, event_struct, slot, lifecycle,
                                                watchdog_event_is_data_event(current), 0, DSD_EVENT_END_FINAL);
     } else if (has_content) {
         init_event_history(event_struct, 0, 1);
@@ -759,8 +763,9 @@ watchdog_event_history_authoritative(dsd_opts* opts, dsd_state* state, uint8_t s
     lifecycle->ended_committed = 0U;
     // Set after the commit above, which belongs to the outgoing epoch. Rows staged directly by a
     // protocol never pass through the renderer, so without this they would inherit whichever
-    // environment the previous epoch's last render left behind.
+    // environment -- and identity verdict -- the previous epoch's last render left behind.
     DSD_MEMSET(&lifecycle->staged_env, 0, sizeof(lifecycle->staged_env));
+    lifecycle->staged_named_call = 0U;
     lifecycle->notice_epoch = 0U;
     lifecycle->notice_target_id = 0U;
     lifecycle->notice_kind = DSD_CALL_KIND_UNKNOWN;
@@ -1593,7 +1598,7 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
         // a voice epoch that never learned an identity -- a drop. The empty-staged-row branch
         // has nothing to commit; enrichment resolves that case by push sequence and declines.
         const int committed = watchdog_event_commit_staged_row((dsd_opts*)opts, state, event_struct, slot, lifecycle,
-                                                               call, call->kind == DSD_CALL_KIND_DATA, 1, disposition);
+                                                               call->kind == DSD_CALL_KIND_DATA, 1, disposition);
         if (deferred_end && committed) {
             // Armed only where a row reached history, which is what makes this the same rule the
             // FINAL disposition follows: its alert is emitted inside the commit above, so it too
@@ -1657,11 +1662,14 @@ watchdog_event_current_impl(const dsd_opts* opts, dsd_state* state, uint8_t slot
     DSD_SNPRINTF(candidate.event_string, sizeof(candidate.event_string), "%s", event_string);
 
     watchdog_event_commit_candidate(event_struct, &candidate);
-    // The staged row and the decoder inputs that produced it are captured together, so whenever
-    // that row is committed -- now, or on a later pass once the epoch has already changed -- it
-    // carries the environment it was actually rendered under.
+    // The staged row, the decoder inputs that produced it, and whether its epoch has named a
+    // call are captured together, so whenever that row is committed -- now, or on a later pass
+    // once the epoch has already changed and the snapshot is gone -- it carries the environment
+    // and the identity verdict it was actually rendered under. Identity only accrues within an
+    // epoch, so plain assignment is already sticky.
     if (lifecycle != NULL) {
         watchdog_event_capture_render_env(state, slot, &lifecycle->staged_env);
+        lifecycle->staged_named_call = (uint8_t)(dsd_call_state_snapshot_has_identity(effective_call) != 0);
     }
     watchdog_event_finalize_ended(opts, state, slot, effective_call, lifecycle, event_struct, finalize_ended);
 
@@ -1821,7 +1829,7 @@ dsd_event_emit_call_notice_impl(dsd_opts* opts, dsd_state* state, uint8_t slot, 
     // unconditionally would give one transmission two rows and leave the first one orphaned.
     // The commit path keeps the notice detail: internal_str is merged progressively, so the
     // detail that just fired supersedes whatever the row carried.
-    (void)watchdog_event_commit_staged_row(opts, state, event_struct, slot, canonical_lifecycle, call,
+    (void)watchdog_event_commit_staged_row(opts, state, event_struct, slot, canonical_lifecycle,
                                            call->kind == DSD_CALL_KIND_DATA, finalize_call,
                                            finalize_call ? DSD_EVENT_END_FINAL : DSD_EVENT_END_NONE);
     watchdog_event_notice_mark_handled(lifecycle, call);

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -247,6 +247,42 @@ watchdog_event_item_has_content(const Event_History* item) {
            || item->gps_s[0] != '\0' || item->internal_str[0] != '\0';
 }
 
+// A voice row that never learned who the call was: no numeric or textual call
+// identity and no decoded detail. These render from the provisional epoch a
+// stray voice sync opens before any header decodes, and a committed
+// "TGT: 00000000; SRC: 00000000" row tells the operator nothing. System
+// identifiers alone (a color code, a NAC) do not name a call, mirroring
+// call_state_snapshot_has_identity(). Data and control rows are exempt:
+// repeated LRRP, short data, and response notices are real traffic even when
+// source-less.
+static int
+watchdog_event_voice_row_is_identityless(const Event_History* item) {
+    if (item == NULL || item->category != DSD_EVENT_CATEGORY_VOICE) {
+        return 0;
+    }
+    // X2-TDMA is exempt: it never parses its link control into a talkgroup or source, so an
+    // all-zero row is the protocol's whole story -- that the slot carried voice -- not noise.
+    if (DSD_SYNC_IS_X2TDMA(item->systype)) {
+        return 0;
+    }
+    return item->target_id == 0U && item->source_id == 0U && item->src_str[0] == '\0' && item->tgt_str[0] == '\0'
+           && item->alias[0] == '\0' && item->gps_s[0] == '\0' && item->text_message[0] == '\0'
+           && item->internal_str[0] == '\0';
+}
+
+// Mirrors call_state_snapshot_has_identity(): whether the canonical epoch ever named a call.
+// Consulted before dropping an identity-less row because route text -- identity the row strings
+// never carry -- anchors a D-STAR or YSF transmission whose talker callsigns did not decode.
+static int
+watchdog_event_snapshot_names_call(const dsd_call_snapshot* call) {
+    if (call == NULL) {
+        return 0;
+    }
+    return call->ota_target_id != 0U || call->policy_target_id != 0U || call->ota_source_id != 0U
+           || call->source_text[0] != '\0' || call->target_text[0] != '\0' || call->route_text[0][0] != '\0'
+           || call->route_text[1][0] != '\0';
+}
+
 static int
 watchdog_event_is_dmr_data_sync(int systype) {
     return systype == DSD_SYNC_DMR_BS_DATA_POS || systype == DSD_SYNC_DMR_BS_DATA_NEG || systype == DSD_SYNC_DMR_MS_DATA
@@ -585,13 +621,30 @@ watchdog_event_staged_row_merges(const Event_History_I* event_struct, const dsd_
 static int watchdog_event_rerender_row(const dsd_call_event_render_env* env, Event_History* item, int* changed);
 
 // Commit the staged row, or merge it into the row this slot already committed when the
-// canonical layer says the two are the same transmission. Returns non-zero when a new row
-// reached history.
+// canonical layer says the two are the same transmission. `staged_call` is the canonical
+// snapshot describing the staged row's epoch, or NULL where that epoch's snapshot is already
+// gone (the epoch-change leftover path). Returns non-zero when the staged row's information
+// reached history -- pushed as a new row or folded into the committed one -- and zero when
+// nothing did.
 static int
 watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History_I* event_struct, uint8_t slot,
-                                 dsd_call_event_lifecycle* lifecycle, int last_event_is_data, int reset_slot_identity,
+                                 dsd_call_event_lifecycle* lifecycle, const dsd_call_snapshot* staged_call,
+                                 int last_event_is_data, int reset_slot_identity,
                                  dsd_event_end_disposition end_disposition) {
     const Event_History* staged = &event_struct->Event_History_Items[0];
+    // A voice row whose epoch never named a call is dropped rather than committed as
+    // "TGT: 00000000; SRC: 00000000". The WAV still rotates: voice frames ran for this epoch,
+    // so leaving the file open would let the noise segment's audio lead the next
+    // transmission's recording. No end alert either -- like the empty-staged-row case, nothing
+    // the operator saw is ending.
+    if (watchdog_event_voice_row_is_identityless(staged) && !watchdog_event_snapshot_names_call(staged_call)) {
+        if (end_disposition != DSD_EVENT_END_NONE) {
+            watchdog_event_rotate_wav_if_needed(opts, event_struct, slot);
+        }
+        init_event_history(event_struct, 0, 1);
+        watchdog_event_reset_post_push(state);
+        return 0;
+    }
     const uint8_t retained_index = watchdog_event_committed_row_index(event_struct, lifecycle);
     if (watchdog_event_staged_row_merges(event_struct, lifecycle, staged, retained_index)) {
         Event_History* retained = &event_struct->Event_History_Items[retained_index];
@@ -623,7 +676,7 @@ watchdog_event_commit_staged_row(dsd_opts* opts, dsd_state* state, Event_History
         }
         init_event_history(event_struct, 0, 1);
         watchdog_event_reset_post_push(state);
-        return 0;
+        return 1;
     }
     watchdog_event_handle_source_transition_ex(opts, state, event_struct, slot, watchdog_event_should_write_slot(state),
                                                last_event_is_data, reset_slot_identity, end_disposition);
@@ -694,7 +747,9 @@ watchdog_event_history_authoritative(dsd_opts* opts, dsd_state* state, uint8_t s
     const int has_content = watchdog_event_item_has_content(current);
     const int promotes_current = lifecycle->epoch == 0U && watchdog_event_history_matches_call(current, call);
     if (has_content && !promotes_current) {
-        (void)watchdog_event_commit_staged_row(opts, state, event_struct, slot, lifecycle,
+        // NULL, not `call`: the staged row belongs to the outgoing epoch, whose snapshot is
+        // gone, and the incoming call's identity must not vouch for it.
+        (void)watchdog_event_commit_staged_row(opts, state, event_struct, slot, lifecycle, NULL,
                                                watchdog_event_is_data_event(current), 0, DSD_EVENT_END_FINAL);
     } else if (has_content) {
         init_event_history(event_struct, 0, 1);
@@ -1534,12 +1589,12 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
     const int deferred_end = call->end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS && call->kind != DSD_CALL_KIND_DATA;
     const dsd_event_end_disposition disposition = deferred_end ? DSD_EVENT_END_DEFERRED : DSD_EVENT_END_FINAL;
     if (watchdog_event_item_has_content(&event_struct->Event_History_Items[0])) {
-        // Either outcome puts this epoch's information into history -- a new row, or merged
-        // into the row the interrupted transmission already owns. The empty-staged-row branch
+        // A new row, a merge into the row the interrupted transmission already owns, or -- for
+        // a voice epoch that never learned an identity -- a drop. The empty-staged-row branch
         // has nothing to commit; enrichment resolves that case by push sequence and declines.
-        (void)watchdog_event_commit_staged_row((dsd_opts*)opts, state, event_struct, slot, lifecycle,
-                                               call->kind == DSD_CALL_KIND_DATA, 1, disposition);
-        if (deferred_end) {
+        const int committed = watchdog_event_commit_staged_row((dsd_opts*)opts, state, event_struct, slot, lifecycle,
+                                                               call, call->kind == DSD_CALL_KIND_DATA, 1, disposition);
+        if (deferred_end && committed) {
             // Armed only where a row reached history, which is what makes this the same rule the
             // FINAL disposition follows: its alert is emitted inside the commit above, so it too
             // cannot fire for a staged row with nothing in it. A signal that renders no event
@@ -1766,7 +1821,7 @@ dsd_event_emit_call_notice_impl(dsd_opts* opts, dsd_state* state, uint8_t slot, 
     // unconditionally would give one transmission two rows and leave the first one orphaned.
     // The commit path keeps the notice detail: internal_str is merged progressively, so the
     // detail that just fired supersedes whatever the row carried.
-    (void)watchdog_event_commit_staged_row(opts, state, event_struct, slot, canonical_lifecycle,
+    (void)watchdog_event_commit_staged_row(opts, state, event_struct, slot, canonical_lifecycle, call,
                                            call->kind == DSD_CALL_KIND_DATA, finalize_call,
                                            finalize_call ? DSD_EVENT_END_FINAL : DSD_EVENT_END_NONE);
     watchdog_event_notice_mark_handled(lifecycle, call);

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -481,9 +481,14 @@ watchdog_event_capture_render_env(const dsd_state* state, uint8_t slot, const ds
     // EXPLICIT is deliberately excluded: the engine ends epochs EXPLICIT on every retune and
     // teardown, so counting it would commit the identity-less noise row this verdict exists to
     // drop whenever the trunker returns to the control channel instead of letting the signal
-    // fade.
+    // fade. For protocols with no terminator to decode (D-STAR), a sync-loss end is the closest
+    // thing to positive end evidence the mode can produce; demanding a terminator there would
+    // make the vouch structurally unsatisfiable and delete every audible identity-less
+    // reception.
     env->ended_positively = (uint8_t)(call != NULL && call->phase == DSD_CALL_PHASE_ENDED
-                                      && dsd_call_state_end_reason_is_terminator(call->end_reason));
+                                      && (dsd_call_state_end_reason_is_terminator(call->end_reason)
+                                          || (!dsd_call_state_protocol_voice_has_terminator(call->protocol)
+                                              && call->end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS)));
 }
 
 // Depth of the row this slot last committed, or 0 when it can no longer be located.
@@ -808,6 +813,11 @@ watchdog_event_history_authoritative(dsd_opts* opts, dsd_state* state, uint8_t s
 
     lifecycle->epoch = call->epoch;
     lifecycle->ended_committed = 0U;
+    // The commit above resolved the outgoing epoch's staged row -- committed or dropped -- so a
+    // hold it left pending is spent, and a stale deadline must not make the incoming epoch's
+    // own keep-or-drop verdict skip its arming step.
+    lifecycle->drop_hold_pending = 0U;
+    lifecycle->drop_hold_due_m = 0.0;
     // Set after the commit above, which belongs to the outgoing epoch. Rows staged directly by a
     // protocol never pass through the renderer, so without this they would inherit whichever
     // environment -- and epoch verdicts -- the previous epoch's last render left behind.
@@ -1619,6 +1629,31 @@ watchdog_event_commit_candidate(Event_History_I* event_struct, const Event_Histo
     }
 }
 
+// Non-zero while the keep-or-drop verdict for the staged row must stay open. An identity-less
+// row that would be dropped is not dropped while its recoverable end can still be explained: a
+// terminator decoding in the hangtime after a fade retracts the end reason, the next render's
+// verdicts then vouch for the row, and the finalize pass -- re-run every sync pass because
+// ended_committed stays clear -- commits it normally. An immediate drop would be irrevocable:
+// the retraction succeeds in the canonical layer but the staged row is already zeroed with
+// nothing left to re-render. The hold expires on the same reason-keyed window reacquisition
+// uses; a window that closes with the end still unexplained falls through to the drop the
+// verdicts already called for.
+static int
+watchdog_event_drop_verdict_held(dsd_call_event_lifecycle* lifecycle, const dsd_call_snapshot* call,
+                                 const Event_History_I* event_struct, int deferred_end) {
+    if (!deferred_end || !watchdog_event_voice_row_is_identityless(&event_struct->Event_History_Items[0])
+        || watchdog_event_staged_epoch_vouches(&lifecycle->staged_env)) {
+        return 0;
+    }
+    const double now_m = dsd_time_now_monotonic_s();
+    if (!lifecycle->drop_hold_pending) {
+        lifecycle->drop_hold_pending = 1U;
+        lifecycle->drop_hold_due_m = now_m + dsd_call_state_end_reason_reacquire_gap_s(call->end_reason);
+        return 1;
+    }
+    return now_m < lifecycle->drop_hold_due_m;
+}
+
 static void
 watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_snapshot* call,
                               dsd_call_event_lifecycle* lifecycle, Event_History_I* event_struct, int finalize_ended) {
@@ -1643,6 +1678,9 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
         dsd_call_state_end_reason_is_recoverable(call->end_reason) && call->kind != DSD_CALL_KIND_DATA;
     const dsd_event_end_disposition disposition = deferred_end ? DSD_EVENT_END_DEFERRED : DSD_EVENT_END_FINAL;
     if (watchdog_event_item_has_content(&event_struct->Event_History_Items[0])) {
+        if (watchdog_event_drop_verdict_held(lifecycle, call, event_struct, deferred_end)) {
+            return;
+        }
         // A new row, a merge into the row the interrupted transmission already owns, or -- for
         // a voice epoch that never learned an identity -- a drop. The empty-staged-row branch
         // has nothing to commit; enrichment resolves that case by push sequence and declines.
@@ -1667,6 +1705,8 @@ watchdog_event_finalize_ended(const dsd_opts* opts, dsd_state* state, uint8_t sl
     } else {
         init_event_history(event_struct, 0, 1);
     }
+    lifecycle->drop_hold_pending = 0U;
+    lifecycle->drop_hold_due_m = 0.0;
     lifecycle->ended_committed = 1U;
 }
 

--- a/src/engine/dispatch/dispatch_dpmr.c
+++ b/src/engine/dispatch/dispatch_dpmr.c
@@ -16,14 +16,18 @@
 #include "dsd-neo/core/state_fwd.h"
 #include "protocol_dispatch_impl.h"
 
+// `reason` distinguishes what the sync that ends the call actually said: the FS3 end-frame sync
+// is positive over-the-air evidence the transmission ended (DSD_CALL_END_TERMINATOR), so the
+// event layer can keep an audible epoch whose header never decoded, while a new header sync
+// preempting a still-open call says nothing about the previous transmission and stays EXPLICIT.
 static void
-dpmr_end_active_call(dsd_opts* opts, dsd_state* state) {
+dpmr_end_active_call(dsd_opts* opts, dsd_state* state, dsd_call_end_reason reason) {
     dsd_call_snapshot call;
     if (dsd_call_state_get(state, 0U, &call) <= 0 || call.phase != DSD_CALL_PHASE_ACTIVE
         || !DSD_SYNC_IS_DPMR(call.protocol)) {
         return;
     }
-    if (dsd_call_state_end(state, 0U, 0.0) > 0) {
+    if (dsd_call_state_end_ex(state, 0U, 0.0, reason) > 0) {
         dsd_event_sync_slot(opts, state, 0U);
     }
 }
@@ -39,7 +43,7 @@ dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state) {
     //dPMR
     if ((state->synctype == DSD_SYNC_DPMR_FS1_POS) || (state->synctype == DSD_SYNC_DPMR_FS1_NEG)) {
         /* dPMR Frame Sync 1 */
-        dpmr_end_active_call(opts, state);
+        dpmr_end_active_call(opts, state, DSD_CALL_END_EXPLICIT);
         DSD_FPRINTF(stderr, "dPMR Frame Sync 1 ");
         if (opts->mbe_out_f != NULL) {
             closeMbeOutFile(opts, state);
@@ -69,14 +73,14 @@ dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state) {
 
     } else if ((state->synctype == DSD_SYNC_DPMR_FS3_POS) || (state->synctype == DSD_SYNC_DPMR_FS3_NEG)) {
         /* dPMR Frame Sync 3 */
-        dpmr_end_active_call(opts, state);
+        dpmr_end_active_call(opts, state, DSD_CALL_END_TERMINATOR);
         DSD_FPRINTF(stderr, "dPMR Frame Sync 3 ");
         if (opts->mbe_out_f != NULL) {
             closeMbeOutFile(opts, state);
         }
     } else if ((state->synctype == DSD_SYNC_DPMR_FS4_POS) || (state->synctype == DSD_SYNC_DPMR_FS4_NEG)) {
         /* dPMR Frame Sync 4 */
-        dpmr_end_active_call(opts, state);
+        dpmr_end_active_call(opts, state, DSD_CALL_END_EXPLICIT);
         DSD_FPRINTF(stderr, "dPMR Frame Sync 4 ");
         if (opts->mbe_out_f != NULL) {
             closeMbeOutFile(opts, state);

--- a/src/engine/dispatch/dispatch_dpmr.c
+++ b/src/engine/dispatch/dispatch_dpmr.c
@@ -20,11 +20,15 @@
 // is positive over-the-air evidence the transmission ended (DSD_CALL_END_TERMINATOR), so the
 // event layer can keep an audible epoch whose header never decoded, while a new header sync
 // preempting a still-open call says nothing about the previous transmission and stays EXPLICIT.
+// The end is offered even when the slot's call has already ended: an FS3 decoding inside the
+// reacquisition window after a sync-loss end must reach dsd_call_state_end_ex()'s retract path
+// so the recoverable end tightens to its final reason -- otherwise the audible epoch's row is
+// dropped despite positive end evidence, and a second PTT inside the window folds into the
+// ended call's row. end_ex() itself no-ops on everything else.
 static void
-dpmr_end_active_call(dsd_opts* opts, dsd_state* state, dsd_call_end_reason reason) {
+dpmr_end_call(dsd_opts* opts, dsd_state* state, dsd_call_end_reason reason) {
     dsd_call_snapshot call;
-    if (dsd_call_state_get(state, 0U, &call) <= 0 || call.phase != DSD_CALL_PHASE_ACTIVE
-        || !DSD_SYNC_IS_DPMR(call.protocol)) {
+    if (dsd_call_state_get(state, 0U, &call) <= 0 || !DSD_SYNC_IS_DPMR(call.protocol)) {
         return;
     }
     if (dsd_call_state_end_ex(state, 0U, 0.0, reason) > 0) {
@@ -43,7 +47,7 @@ dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state) {
     //dPMR
     if ((state->synctype == DSD_SYNC_DPMR_FS1_POS) || (state->synctype == DSD_SYNC_DPMR_FS1_NEG)) {
         /* dPMR Frame Sync 1 */
-        dpmr_end_active_call(opts, state, DSD_CALL_END_EXPLICIT);
+        dpmr_end_call(opts, state, DSD_CALL_END_EXPLICIT);
         DSD_FPRINTF(stderr, "dPMR Frame Sync 1 ");
         if (opts->mbe_out_f != NULL) {
             closeMbeOutFile(opts, state);
@@ -73,14 +77,14 @@ dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state) {
 
     } else if ((state->synctype == DSD_SYNC_DPMR_FS3_POS) || (state->synctype == DSD_SYNC_DPMR_FS3_NEG)) {
         /* dPMR Frame Sync 3 */
-        dpmr_end_active_call(opts, state, DSD_CALL_END_TERMINATOR);
+        dpmr_end_call(opts, state, DSD_CALL_END_TERMINATOR);
         DSD_FPRINTF(stderr, "dPMR Frame Sync 3 ");
         if (opts->mbe_out_f != NULL) {
             closeMbeOutFile(opts, state);
         }
     } else if ((state->synctype == DSD_SYNC_DPMR_FS4_POS) || (state->synctype == DSD_SYNC_DPMR_FS4_NEG)) {
         /* dPMR Frame Sync 4 */
-        dpmr_end_active_call(opts, state, DSD_CALL_END_EXPLICIT);
+        dpmr_end_call(opts, state, DSD_CALL_END_EXPLICIT);
         DSD_FPRINTF(stderr, "dPMR Frame Sync 4 ");
         if (opts->mbe_out_f != NULL) {
             closeMbeOutFile(opts, state);

--- a/src/engine/dispatch/dispatch_m17.c
+++ b/src/engine/dispatch/dispatch_m17.c
@@ -31,7 +31,10 @@ dsd_dispatch_handle_m17(dsd_opts* opts, dsd_state* state) {
 
     if (state->synctype == DSD_SYNC_M17_EOT_POS || state->synctype == DSD_SYNC_M17_EOT_NEG) {
         skipDibit(opts, state, M17_EOT_REMAINING_DIBITS);
-        if (dsd_call_state_end(state, 0U, 0.0) > 0) {
+        // An EOT marker decoded over the air is positive evidence the transmission ended, so the
+        // event layer can keep an audible epoch whose LSF never reassembled; a plain EXPLICIT end
+        // is indistinguishable from an engine retune and would drop that row.
+        if (dsd_call_state_end_ex(state, 0U, 0.0, DSD_CALL_END_TERMINATOR) > 0) {
             dsd_event_sync_slot(opts, state, 0U);
         }
         DSD_MEMSET(state->m17_lsf, 0, sizeof(state->m17_lsf));

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1892,6 +1892,10 @@ no_carrier_reset_voice_and_audio_metrics(dsd_state* state) {
 static void
 no_carrier_reset_payload_and_keystream_state(dsd_state* state) {
     state->dmr_ms_mode = 0;
+    // The DMR heal stash mirrors the payload crypto being cleared below; a stash that outlived
+    // this reset could only ever be misapplied to whatever decodes next.
+    state->dmr_heal_valid[0] = 0;
+    state->dmr_heal_valid[1] = 0;
     state->payload_mi = 0;
     state->payload_miR = 0;
     state->payload_mfid = 0;

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -120,6 +120,10 @@ dsd_engine_reset_return_to_cc_state(dsd_opts* opts, dsd_state* state) {
 
     dmr_reset_blocks(opts, state);
 
+    // The DMR heal stash mirrors the payload crypto being cleared below; hopping back to the
+    // control channel leaves nothing the stash could legitimately be restored onto.
+    state->dmr_heal_valid[0] = 0;
+    state->dmr_heal_valid[1] = 0;
     state->payload_algid = 0;
     state->payload_algidR = 0;
     state->payload_keyid = 0;

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -668,7 +668,10 @@ dmr_flco_publish_voice(dmr_flco_ctx* ctx) {
 // terminator would -- but never tightens a sync-loss end, whose fade the same
 // fallible evidence cannot explain away. The slot's payload crypto and alias
 // state resets either way: keeping it would let the next call on the slot
-// inherit a stale algid/key/MI or half-built alias.
+// inherit a stale algid/key/MI or half-built alias. When the end was a
+// mis-typed voice burst, the canonical reacquisition path restores the
+// retained crypto as the healing media mark reopens the epoch (call_state.c),
+// so an encrypted continuation keeps decrypting.
 static void
 dmr_flco_handle_terminator(dmr_flco_ctx* ctx) {
     const int ended = ctx->CRCCorrect == 1U
@@ -700,8 +703,6 @@ dmr_flco_prepare_regular_state(dmr_flco_ctx* ctx) {
 
     if (ctx->type != 2) {
         dmr_flco_sync_active_call_state(ctx);
-    } else {
-        dmr_flco_handle_terminator(ctx);
     }
 
     if (ctx->restchannel != ctx->state->dmr_rest_channel && ctx->restchannel != -1) {
@@ -1062,6 +1063,18 @@ dmr_flco(dsd_opts* opts, dsd_state* state, uint8_t lc_bits[], uint32_t CRCCorrec
     dmr_flco_detect_special_modes(&ctx);
     ctx.protected_lc = dmr_flco_is_protected(&ctx);
     dmr_flco_print_protected_lc(&ctx);
+
+    // A terminator burst ends the slot's call before any LC-payload gate. The
+    // burst type is FEC-protected separately from the LC, so a protected LC,
+    // an unknown/vendor FID, or an irrecoverable LC still marks the end of the
+    // transmission it follows; leaving those calls to fade into a sync-loss
+    // end would let the next same-identity transmission merge into their row.
+    // Only a cleanly read TD_LC is exempt -- it terminates a data session, not
+    // the slot's voice call -- and it must be cleanly read: a protected or
+    // FEC-failed LC cannot vouch for its own FLCO.
+    if (ctx.type == 2U && !(*ctx.IrrecoverableErrors == 0 && !ctx.protected_lc && ctx.flco == 0x30U)) {
+        dmr_flco_handle_terminator(&ctx);
+    }
 
     if (*ctx.IrrecoverableErrors == 0) {
         if (dmr_flco_handle_no_error_paths(&ctx)) {

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -594,6 +594,37 @@ dmr_flco_publish_crypto(const dmr_flco_ctx* ctx) {
     (void)dsd_call_state_update_crypto(ctx->state, ctx->slot, &crypto);
 }
 
+// The voice LC header repeats through the start of a transmission so late
+// entrants can join, and an explicit BEGIN on each repeat mints another epoch,
+// which commits the previous epoch's freshly built row as a duplicate event.
+// Header repeats can only precede the transmission's first voice superframe,
+// so a header that re-describes the identity already active on a slot that has
+// not yet carried voice media observes a continuation. Once voice has run on
+// the epoch, an identical header is the next transmission -- a same-identity
+// re-key whose terminator was missed -- and still opens its own epoch, as does
+// a header naming a different talker or target or one arriving after the
+// terminator.
+static dsd_call_boundary
+dmr_flco_voice_boundary(const dmr_flco_ctx* ctx, const dsd_call_observation* observation) {
+    if (ctx->type != 1U) {
+        return DSD_CALL_BOUNDARY_CONTINUE;
+    }
+    dsd_call_snapshot current;
+    if (dsd_call_state_get(ctx->state, ctx->slot, &current) <= 0 || current.phase != DSD_CALL_PHASE_ACTIVE
+        || current.media_active != 0U) {
+        return DSD_CALL_BOUNDARY_BEGIN;
+    }
+    if (!DSD_SYNC_IS_DMR(current.protocol) || current.kind != observation->kind
+        || current.ota_target_id != observation->ota_target_id) {
+        return DSD_CALL_BOUNDARY_BEGIN;
+    }
+    if (current.ota_source_id != 0U && observation->ota_source_id != 0U
+        && current.ota_source_id != observation->ota_source_id) {
+        return DSD_CALL_BOUNDARY_BEGIN;
+    }
+    return DSD_CALL_BOUNDARY_CONTINUE;
+}
+
 static void
 dmr_flco_publish_voice(dmr_flco_ctx* ctx) {
     if (ctx->slot >= DSD_CALL_STATE_SLOT_COUNT) {
@@ -613,8 +644,7 @@ dmr_flco_publish_voice(dmr_flco_ctx* ctx) {
         .priority = (uint8_t)(ctx->so & 0x03U),
         .has_service_metadata = 1U,
     };
-    const dsd_call_boundary boundary = ctx->type == 1U ? DSD_CALL_BOUNDARY_BEGIN : DSD_CALL_BOUNDARY_CONTINUE;
-    (void)dsd_call_state_observe(ctx->state, &observation, boundary);
+    (void)dsd_call_state_observe(ctx->state, &observation, dmr_flco_voice_boundary(ctx, &observation));
     dmr_flco_publish_crypto(ctx);
     dsd_event_sync_slot(ctx->opts, ctx->state, ctx->slot);
 }
@@ -637,7 +667,12 @@ dmr_flco_prepare_regular_state(dmr_flco_ctx* ctx) {
         dmr_flco_sync_active_call_state(ctx);
     }
 
-    if (ctx->type == 2) {
+    // Only an RS(12,9)-verified terminator ends the call and clears the slot's
+    // payload state. Ending on an unverified LC lets a mis-typed burst close a
+    // live transmission with the un-recoverable EXPLICIT reason and wipe its
+    // crypto/alias state mid-call; a genuinely missed terminator is instead
+    // picked up by the no-carrier path as a recoverable sync-loss end.
+    if (ctx->type == 2 && ctx->CRCCorrect == 1U) {
         if (dsd_call_state_end(ctx->state, ctx->slot, 0.0) > 0) {
             dsd_event_sync_slot(ctx->opts, ctx->state, ctx->slot);
         }

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -594,18 +594,26 @@ dmr_flco_publish_crypto(const dmr_flco_ctx* ctx) {
     (void)dsd_call_state_update_crypto(ctx->state, ctx->slot, &crypto);
 }
 
+// Longest stretch of repeated voice LC headers still read as one
+// transmission's preamble. Headers repeat only until the first voice
+// superframe (360 ms), so a couple of seconds covers every real preamble
+// while bounding how long an epoch whose voice bursts all failed to decode
+// can keep absorbing same-identity headers as continuations.
+#define DMR_FLCO_HEADER_REPEAT_WINDOW_S 2.0
+
 // The voice LC header repeats through the start of a transmission so late
 // entrants can join, and an explicit BEGIN on each repeat mints another epoch,
 // which commits the previous epoch's freshly built row as a duplicate event.
 // Header repeats can only precede the transmission's first voice superframe,
-// so a header that re-describes the identity already active on a slot that has
-// not yet carried voice media observes a continuation. Once voice has run on
-// the epoch, an identical header is the next transmission -- a same-identity
-// re-key whose terminator was missed -- and still opens its own epoch, as does
-// a header naming a different talker or target or one arriving after the
-// terminator.
+// so a header arriving within the repeat window on a slot that has not yet
+// carried voice media observes a continuation. Once voice has run on the
+// epoch, or the window has passed without a single decodable voice frame, the
+// header is the next transmission -- a same-identity re-key whose terminator
+// was missed -- and opens its own epoch. A header naming a different call
+// still forks: the CONTINUE is advisory, and the canonical comparator inside
+// dsd_call_state_observe() begins a new epoch on any identity contradiction.
 static dsd_call_boundary
-dmr_flco_voice_boundary(const dmr_flco_ctx* ctx, const dsd_call_observation* observation) {
+dmr_flco_voice_boundary(const dmr_flco_ctx* ctx) {
     if (ctx->type != 1U) {
         return DSD_CALL_BOUNDARY_CONTINUE;
     }
@@ -614,12 +622,7 @@ dmr_flco_voice_boundary(const dmr_flco_ctx* ctx, const dsd_call_observation* obs
         || current.media_active != 0U) {
         return DSD_CALL_BOUNDARY_BEGIN;
     }
-    if (!DSD_SYNC_IS_DMR(current.protocol) || current.kind != observation->kind
-        || current.ota_target_id != observation->ota_target_id) {
-        return DSD_CALL_BOUNDARY_BEGIN;
-    }
-    if (current.ota_source_id != 0U && observation->ota_source_id != 0U
-        && current.ota_source_id != observation->ota_source_id) {
+    if (dsd_time_now_monotonic_s() - current.started_m > DMR_FLCO_HEADER_REPEAT_WINDOW_S) {
         return DSD_CALL_BOUNDARY_BEGIN;
     }
     return DSD_CALL_BOUNDARY_CONTINUE;
@@ -644,9 +647,45 @@ dmr_flco_publish_voice(dmr_flco_ctx* ctx) {
         .priority = (uint8_t)(ctx->so & 0x03U),
         .has_service_metadata = 1U,
     };
-    (void)dsd_call_state_observe(ctx->state, &observation, dmr_flco_voice_boundary(ctx, &observation));
+    (void)dsd_call_state_observe(ctx->state, &observation, dmr_flco_voice_boundary(ctx));
     dmr_flco_publish_crypto(ctx);
     dsd_event_sync_slot(ctx->opts, ctx->state, ctx->slot);
+}
+
+// The end reason tracks the terminator's RS(12,9) verdict. A verified
+// terminator ends the call explicitly. An unverified one still ends it -- the
+// burst type is FEC-protected separately from the LC payload, and on RAS
+// systems under the aggressive default every LC fails the masked CRC, so
+// gating the end on the CRC would leave RAS calls active forever -- but with
+// the recoverable sync-loss reason, so a voice burst mis-typed as a terminator
+// mid-call is healed by the very next same-identity observation reacquiring
+// the epoch instead of splitting the transmission in two. On an epoch sync
+// loss already ended, even an unverified terminator is positive evidence the
+// transmission is over, so it tightens the reason to explicit and retracts the
+// reacquisition permission. The slot's payload crypto and alias state resets
+// either way: keeping it would let the next call on the slot inherit a stale
+// algid/key/MI or half-built alias.
+static void
+dmr_flco_handle_terminator(dmr_flco_ctx* ctx) {
+    int ended;
+    if (ctx->CRCCorrect == 1U) {
+        ended = dsd_call_state_end(ctx->state, ctx->slot, 0.0);
+    } else {
+        dsd_call_snapshot current;
+        const int active =
+            dsd_call_state_get(ctx->state, ctx->slot, &current) > 0 && current.phase == DSD_CALL_PHASE_ACTIVE;
+        ended = active ? dsd_call_state_end_ex(ctx->state, ctx->slot, 0.0, DSD_CALL_END_SYNC_LOSS)
+                       : dsd_call_state_end(ctx->state, ctx->slot, 0.0);
+    }
+    if (ended > 0) {
+        dsd_event_sync_slot(ctx->opts, ctx->state, ctx->slot);
+    }
+    if (ctx->state->currentslot == 0) {
+        dmr_flco_reset_td_lc_slot0(ctx);
+    }
+    if (ctx->state->currentslot == 1) {
+        dmr_flco_reset_td_lc_slot1(ctx);
+    }
 }
 
 static int
@@ -665,23 +704,8 @@ dmr_flco_prepare_regular_state(dmr_flco_ctx* ctx) {
 
     if (ctx->type != 2) {
         dmr_flco_sync_active_call_state(ctx);
-    }
-
-    // Only an RS(12,9)-verified terminator ends the call and clears the slot's
-    // payload state. Ending on an unverified LC lets a mis-typed burst close a
-    // live transmission with the un-recoverable EXPLICIT reason and wipe its
-    // crypto/alias state mid-call; a genuinely missed terminator is instead
-    // picked up by the no-carrier path as a recoverable sync-loss end.
-    if (ctx->type == 2 && ctx->CRCCorrect == 1U) {
-        if (dsd_call_state_end(ctx->state, ctx->slot, 0.0) > 0) {
-            dsd_event_sync_slot(ctx->opts, ctx->state, ctx->slot);
-        }
-        if (ctx->state->currentslot == 0) {
-            dmr_flco_reset_td_lc_slot0(ctx);
-        }
-        if (ctx->state->currentslot == 1) {
-            dmr_flco_reset_td_lc_slot1(ctx);
-        }
+    } else {
+        dmr_flco_handle_terminator(ctx);
     }
 
     if (ctx->restchannel != ctx->state->dmr_rest_channel && ctx->restchannel != -1) {

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -657,33 +657,29 @@ dmr_flco_publish_voice(dmr_flco_ctx* ctx) {
 // burst type is FEC-protected separately from the LC payload, and on RAS
 // systems under the aggressive default every LC fails the masked CRC, so
 // gating the end on the CRC would leave RAS calls active forever -- but with
-// the recoverable sync-loss reason, so a voice burst mis-typed as a terminator
-// mid-call is healed by the very next same-identity observation reacquiring
-// the epoch instead of splitting the transmission in two. On an epoch sync
-// loss already ended, even an unverified terminator is positive evidence the
-// transmission is over, so it tightens the reason to explicit and retracts the
-// reacquisition permission. The slot's payload crypto and alias state resets
-// either way: keeping it would let the next call on the slot inherit a stale
-// algid/key/MI or half-built alias.
+// the recoverable unverified-terminator reason, so a voice burst mis-typed as
+// a terminator mid-call is healed by the next identity-less media mark
+// reacquiring the epoch instead of splitting the transmission in two, while a
+// same-identity header inside the gap still opens the next transmission's own
+// epoch. The canonical layer owns what a repeat means on an epoch already
+// ended: a second unverified terminator corroborates an unverified end into
+// EXPLICIT -- which also releases the held VOICE_END alert, so on repeater
+// systems the hangtime repeat alerts within a burst of where a verified
+// terminator would -- but never tightens a sync-loss end, whose fade the same
+// fallible evidence cannot explain away. The slot's payload crypto and alias
+// state resets either way: keeping it would let the next call on the slot
+// inherit a stale algid/key/MI or half-built alias.
 static void
 dmr_flco_handle_terminator(dmr_flco_ctx* ctx) {
-    int ended;
-    if (ctx->CRCCorrect == 1U) {
-        ended = dsd_call_state_end(ctx->state, ctx->slot, 0.0);
-    } else {
-        dsd_call_snapshot current;
-        const int active =
-            dsd_call_state_get(ctx->state, ctx->slot, &current) > 0 && current.phase == DSD_CALL_PHASE_ACTIVE;
-        ended = active ? dsd_call_state_end_ex(ctx->state, ctx->slot, 0.0, DSD_CALL_END_SYNC_LOSS)
-                       : dsd_call_state_end(ctx->state, ctx->slot, 0.0);
-    }
+    const int ended = ctx->CRCCorrect == 1U
+                          ? dsd_call_state_end(ctx->state, ctx->slot, 0.0)
+                          : dsd_call_state_end_ex(ctx->state, ctx->slot, 0.0, DSD_CALL_END_UNVERIFIED_TERMINATOR);
     if (ended > 0) {
         dsd_event_sync_slot(ctx->opts, ctx->state, ctx->slot);
     }
-    if (ctx->state->currentslot == 0) {
+    if (ctx->slot == 0U) {
         dmr_flco_reset_td_lc_slot0(ctx);
-    }
-    if (ctx->state->currentslot == 1) {
+    } else {
         dmr_flco_reset_td_lc_slot1(ctx);
     }
 }

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -652,31 +652,115 @@ dmr_flco_publish_voice(dmr_flco_ctx* ctx) {
     dsd_event_sync_slot(ctx->opts, ctx->state, ctx->slot);
 }
 
-// The end reason tracks the terminator's RS(12,9) verdict. A verified
-// terminator ends the call explicitly. An unverified one still ends it -- the
-// burst type is FEC-protected separately from the LC payload, and on RAS
-// systems under the aggressive default every LC fails the masked CRC, so
-// gating the end on the CRC would leave RAS calls active forever -- but with
-// the recoverable unverified-terminator reason, so a voice burst mis-typed as
-// a terminator mid-call is healed by the next identity-less media mark
-// reacquiring the epoch instead of splitting the transmission in two, while a
-// same-identity header inside the gap still opens the next transmission's own
-// epoch. The canonical layer owns what a repeat means on an epoch already
-// ended: a second unverified terminator corroborates an unverified end into
-// EXPLICIT -- which also releases the held VOICE_END alert, so on repeater
-// systems the hangtime repeat alerts within a burst of where a verified
-// terminator would -- but never tightens a sync-loss end, whose fade the same
-// fallible evidence cannot explain away. The slot's payload crypto and alias
-// state resets either way: keeping it would let the next call on the slot
-// inherit a stale algid/key/MI or half-built alias. When the end was a
-// mis-typed voice burst, the canonical reacquisition path restores the
-// retained crypto as the healing media mark reopens the epoch (call_state.c),
-// so an encrypted continuation keeps decrypting.
+// The heal side of the unverified-terminator end. The terminator reset below clears the live
+// dmr_fid/dmr_so/payload_algid/payload_keyid/payload_mi the vocoder decrypts and gates with;
+// when the "terminator" was really a mis-typed voice burst, the identity-less media mark that
+// reopens the epoch a burst later needs them back, and nothing on that path re-signals them (a
+// PI header or late-entry rebuild may never come mid-transmission). So the handler stashes the
+// live fields -- not the canonical snapshot's copies: the snapshot's MI can lag the superframe
+// machinery's advances, and it never carried the FID the Basic Privacy gates require -- and the
+// canonical layer's reacquire hook restores them when, and only when, the ended epoch itself is
+// healed. The epoch tie plus the all-cleared gate mean a stale stash can never overwrite
+// fresher signaling or leak into a later call.
+typedef struct {
+    unsigned int* fid;
+    unsigned int* so;
+    int* algid;
+    int* keyid;
+    unsigned long long int* mi;
+} dmr_flco_slot_crypto;
+
+static dmr_flco_slot_crypto
+dmr_flco_slot_crypto_fields(dsd_state* state, uint8_t idx) {
+    if (idx == 0U) {
+        return (dmr_flco_slot_crypto){&state->dmr_fid, &state->dmr_so, &state->payload_algid, &state->payload_keyid,
+                                      &state->payload_mi};
+    }
+    return (dmr_flco_slot_crypto){&state->dmr_fidR, &state->dmr_soR, &state->payload_algidR, &state->payload_keyidR,
+                                  &state->payload_miR};
+}
+
+static int
+dmr_flco_slot_crypto_is_clear(const dmr_flco_slot_crypto* live) {
+    return *live->fid == 0U && *live->so == 0U && *live->algid == 0 && *live->keyid == 0 && *live->mi == 0ULL;
+}
+
+static void
+dmr_flco_stash_slot_crypto(dsd_state* state, uint8_t slot, uint64_t epoch) {
+    const uint8_t idx = slot != 0U ? 1U : 0U;
+    const dmr_flco_slot_crypto live = dmr_flco_slot_crypto_fields(state, idx);
+    state->dmr_heal_valid[idx] = 0U;
+    if (dmr_flco_slot_crypto_is_clear(&live)) {
+        return;
+    }
+    state->dmr_heal_fid[idx] = *live.fid;
+    state->dmr_heal_so[idx] = *live.so;
+    state->dmr_heal_algid[idx] = *live.algid;
+    state->dmr_heal_keyid[idx] = *live.keyid;
+    state->dmr_heal_mi[idx] = *live.mi;
+    state->dmr_heal_epoch[idx] = epoch;
+    state->dmr_heal_valid[idx] = 1U;
+}
+
+static void
+dmr_flco_heal_restore(dsd_state* state, uint8_t slot, const dsd_call_snapshot* previous) {
+    if (state == NULL || previous == NULL || slot >= DSD_CALL_STATE_SLOT_COUNT) {
+        return;
+    }
+    const uint8_t idx = slot != 0U ? 1U : 0U;
+    if (!DSD_SYNC_IS_DMR(previous->protocol) || state->dmr_heal_valid[idx] == 0U
+        || state->dmr_heal_epoch[idx] != previous->epoch) {
+        return;
+    }
+    // Only into a slot whose live fields are entirely cleared -- the post-reset shape -- so
+    // fresher signaling (a header that decoded between the reset and the heal) never loses.
+    const dmr_flco_slot_crypto live = dmr_flco_slot_crypto_fields(state, idx);
+    if (!dmr_flco_slot_crypto_is_clear(&live)) {
+        return;
+    }
+    *live.fid = state->dmr_heal_fid[idx];
+    *live.so = state->dmr_heal_so[idx];
+    *live.algid = state->dmr_heal_algid[idx];
+    *live.keyid = state->dmr_heal_keyid[idx];
+    *live.mi = state->dmr_heal_mi[idx];
+    state->dmr_heal_valid[idx] = 0U;
+}
+
+// The end reason tracks how much of the terminator could be read. A terminator whose LC came
+// through FEC-clean, unprotected, and CRC-verified is trustworthy end evidence and ends the
+// call with the final TERMINATOR reason. Anything less ends it with the recoverable
+// unverified-terminator reason: on RAS systems under the aggressive default every LC fails the
+// masked CRC (gating the end on the CRC would leave RAS calls active forever); a garbled LC can
+// pass the 16-bit CRC by chance while its FEC reports irrecoverable errors; and a protected LC
+// hides its own FLCO, so it cannot rule out being a TD_LC that terminates a data session rather
+// than the slot's voice call. In every unverified shape a voice burst mis-typed as a terminator
+// mid-call is healed by the next identity-less media mark reacquiring the epoch instead of
+// splitting the transmission in two, while a same-identity header inside the gap still opens
+// the next transmission's own epoch. The canonical layer owns what a repeat means on an epoch
+// already ended: a second unverified terminator corroborates an unverified end into TERMINATOR
+// -- which also releases the held VOICE_END alert, so on repeater systems the hangtime repeat
+// alerts within a burst of where a verified terminator would -- but never tightens a sync-loss
+// end, whose fade the same fallible evidence cannot explain away. The slot's payload crypto and
+// alias state resets either way: keeping it would let the next call on the slot inherit a stale
+// algid/key/MI or half-built alias. Before an unverified end's reset, the live crypto is
+// stashed so the heal can restore it (dmr_flco_stash_slot_crypto above).
 static void
 dmr_flco_handle_terminator(dmr_flco_ctx* ctx) {
-    const int ended = ctx->CRCCorrect == 1U
-                          ? dsd_call_state_end(ctx->state, ctx->slot, 0.0)
-                          : dsd_call_state_end_ex(ctx->state, ctx->slot, 0.0, DSD_CALL_END_UNVERIFIED_TERMINATOR);
+    const int verified = ctx->CRCCorrect == 1U && *ctx->IrrecoverableErrors == 0 && !ctx->protected_lc;
+    const uint8_t idx = ctx->slot != 0U ? 1U : 0U;
+    if (verified) {
+        // A verified end is final; a heal can never follow it, so no stash may linger to be
+        // matched against some future epoch.
+        ctx->state->dmr_heal_valid[idx] = 0U;
+    } else {
+        dsd_call_snapshot ending;
+        if (dsd_call_state_get(ctx->state, ctx->slot, &ending) > 0 && ending.phase == DSD_CALL_PHASE_ACTIVE) {
+            dmr_flco_stash_slot_crypto(ctx->state, ctx->slot, ending.epoch);
+            dsd_call_state_set_reacquire_hook(dmr_flco_heal_restore);
+        }
+    }
+    const int ended = dsd_call_state_end_ex(ctx->state, ctx->slot, 0.0,
+                                            verified ? DSD_CALL_END_TERMINATOR : DSD_CALL_END_UNVERIFIED_TERMINATOR);
     if (ended > 0) {
         dsd_event_sync_slot(ctx->opts, ctx->state, ctx->slot);
     }
@@ -1071,7 +1155,11 @@ dmr_flco(dsd_opts* opts, dsd_state* state, uint8_t lc_bits[], uint32_t CRCCorrec
     // end would let the next same-identity transmission merge into their row.
     // Only a cleanly read TD_LC is exempt -- it terminates a data session, not
     // the slot's voice call -- and it must be cleanly read: a protected or
-    // FEC-failed LC cannot vouch for its own FLCO.
+    // FEC-failed LC cannot vouch for its own FLCO. Those unreadable shapes
+    // might still be a TD_LC arriving mid-voice-call, which is why the handler
+    // ends them only recoverably: if voice bursts keep coming, the next media
+    // mark heals the epoch and restores the stashed slot crypto, so the cost
+    // of the ambiguity is one burst, not a split call or lost decryption.
     if (ctx.type == 2U && !(*ctx.IrrecoverableErrors == 0 && !ctx.protected_lc && ctx.flco == 0x30U)) {
         dmr_flco_handle_terminator(&ctx);
     }

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -293,6 +293,15 @@ dmr_flco_handle_alias_gps_capplus(dmr_flco_ctx* ctx) {
     dmr_flco_handle_cap_plus(ctx);
 }
 
+// True when the LC payload can vouch for its own contents: FEC came back clean and the payload
+// is not protected. A protected LC's bits -- including its FLCO -- are ciphertext, and an
+// FEC-failed LC may be anything, so every decision keyed on what the LC *says* (as opposed to
+// the burst's separately FEC-protected type) must pass through this one predicate.
+static int
+dmr_flco_lc_readable(const dmr_flco_ctx* ctx) {
+    return *ctx->IrrecoverableErrors == 0 && !ctx->protected_lc;
+}
+
 static int
 dmr_flco_handle_motorola_or_tait(dmr_flco_ctx* ctx) {
     if (ctx->fid == 0x10 && (ctx->flco == 0x08 || ctx->flco == 0x28 || ctx->flco == 0x29)) {
@@ -303,7 +312,9 @@ dmr_flco_handle_motorola_or_tait(dmr_flco_ctx* ctx) {
         return 1;
     }
 
-    if (ctx->type == 2 && ctx->flco == 0x30) {
+    // Readable LC required like the alias/GPS branches above: a protected LC hides its own
+    // FLCO, so a ciphertext 0x30 must not wipe a live data session's reassembly state.
+    if (ctx->type == 2 && ctx->flco == 0x30 && dmr_flco_lc_readable(ctx)) {
         DSD_FPRINTF(stderr, "%s \n", KRED);
         dmr_print_slot_tag(ctx->state);
         DSD_FPRINTF(stderr, " Data Terminator (TD_LC) ");
@@ -500,6 +511,28 @@ dmr_flco_handle_no_error_paths(dmr_flco_ctx* ctx) {
     return 0;
 }
 
+// The per-slot live crypto fields the vocoder decrypts and gates with, mapped once so the
+// terminator reset below and the heal stash/restore further down all walk the same list. A
+// field added to the stash but missed by a reset (or vice versa) would be stashed and healed
+// but never cleared on terminator, leaking one call's crypto into the next.
+typedef struct {
+    unsigned int* fid;
+    unsigned int* so;
+    int* algid;
+    int* keyid;
+    unsigned long long int* mi;
+} dmr_flco_slot_crypto;
+
+static dmr_flco_slot_crypto
+dmr_flco_slot_crypto_fields(dsd_state* state, uint8_t idx) {
+    if (idx == 0U) {
+        return (dmr_flco_slot_crypto){&state->dmr_fid, &state->dmr_so, &state->payload_algid, &state->payload_keyid,
+                                      &state->payload_mi};
+    }
+    return (dmr_flco_slot_crypto){&state->dmr_fidR, &state->dmr_soR, &state->payload_algidR, &state->payload_keyidR,
+                                  &state->payload_miR};
+}
+
 // The terminator reset, split by what the heal can give back. The crypto half is stashed before
 // an unverified end and restored when the epoch heals, so it is safe to clear on every
 // terminator. The metadata half -- the partially assembled talker alias, the dmr_pdu_sf
@@ -507,26 +540,19 @@ dmr_flco_handle_no_error_paths(dmr_flco_ctx* ctx) {
 // really mid-call voice mis-typed as a terminator would permanently lose the transmission's
 // alias, so it is only cleared when the terminator's LC could actually be read.
 static void
-dmr_flco_reset_slot_crypto0(dmr_flco_ctx* ctx) {
-    ctx->state->dmr_fid = 0;
-    ctx->state->dmr_so = 0;
-    ctx->state->payload_algid = 0;
-    ctx->state->payload_mi = 0;
-    ctx->state->payload_keyid = 0;
+dmr_flco_reset_slot_crypto(dmr_flco_ctx* ctx, uint8_t idx) {
+    const dmr_flco_slot_crypto live = dmr_flco_slot_crypto_fields(ctx->state, idx);
+    *live.fid = 0;
+    *live.so = 0;
+    *live.algid = 0;
+    *live.keyid = 0;
+    *live.mi = 0;
     if (ctx->opts->floating_point == 1) {
-        ctx->state->aout_gain = ctx->opts->audio_gain;
-    }
-}
-
-static void
-dmr_flco_reset_slot_crypto1(dmr_flco_ctx* ctx) {
-    ctx->state->dmr_fidR = 0;
-    ctx->state->dmr_soR = 0;
-    ctx->state->payload_algidR = 0;
-    ctx->state->payload_miR = 0;
-    ctx->state->payload_keyidR = 0;
-    if (ctx->opts->floating_point == 1) {
-        ctx->state->aout_gainR = ctx->opts->audio_gain;
+        if (idx == 0U) {
+            ctx->state->aout_gain = ctx->opts->audio_gain;
+        } else {
+            ctx->state->aout_gainR = ctx->opts->audio_gain;
+        }
     }
 }
 
@@ -665,24 +691,6 @@ dmr_flco_publish_voice(dmr_flco_ctx* ctx) {
 // canonical layer's reacquire hook restores them when, and only when, the ended epoch itself is
 // healed. The epoch tie plus the all-cleared gate mean a stale stash can never overwrite
 // fresher signaling or leak into a later call.
-typedef struct {
-    unsigned int* fid;
-    unsigned int* so;
-    int* algid;
-    int* keyid;
-    unsigned long long int* mi;
-} dmr_flco_slot_crypto;
-
-static dmr_flco_slot_crypto
-dmr_flco_slot_crypto_fields(dsd_state* state, uint8_t idx) {
-    if (idx == 0U) {
-        return (dmr_flco_slot_crypto){&state->dmr_fid, &state->dmr_so, &state->payload_algid, &state->payload_keyid,
-                                      &state->payload_mi};
-    }
-    return (dmr_flco_slot_crypto){&state->dmr_fidR, &state->dmr_soR, &state->payload_algidR, &state->payload_keyidR,
-                                  &state->payload_miR};
-}
-
 static int
 dmr_flco_slot_crypto_is_clear(const dmr_flco_slot_crypto* live) {
     return *live->fid == 0U && *live->so == 0U && *live->algid == 0 && *live->keyid == 0 && *live->mi == 0ULL;
@@ -769,8 +777,8 @@ dmr_flco_ensure_heal_hook(void) {
 // the rest of the transmission even after the epoch heals.
 static void
 dmr_flco_handle_terminator(dmr_flco_ctx* ctx) {
-    const int verified = ctx->CRCCorrect == 1U && *ctx->IrrecoverableErrors == 0 && !ctx->protected_lc;
-    const int lc_readable = *ctx->IrrecoverableErrors == 0 && !ctx->protected_lc;
+    const int lc_readable = dmr_flco_lc_readable(ctx);
+    const int verified = ctx->CRCCorrect == 1U && lc_readable;
     const uint8_t idx = ctx->slot != 0U ? 1U : 0U;
     if (verified) {
         // A verified end is final; a heal can never follow it, so no stash may linger to be
@@ -787,11 +795,7 @@ dmr_flco_handle_terminator(dmr_flco_ctx* ctx) {
     if (ended > 0) {
         dsd_event_sync_slot(ctx->opts, ctx->state, ctx->slot);
     }
-    if (ctx->slot == 0U) {
-        dmr_flco_reset_slot_crypto0(ctx);
-    } else {
-        dmr_flco_reset_slot_crypto1(ctx);
-    }
+    dmr_flco_reset_slot_crypto(ctx, idx);
     if (lc_readable) {
         dmr_flco_reset_slot_metadata(ctx, idx);
     }
@@ -1187,7 +1191,7 @@ dmr_flco(dsd_opts* opts, dsd_state* state, uint8_t lc_bits[], uint32_t CRCCorrec
     // ends them only recoverably: if voice bursts keep coming, the next media
     // mark heals the epoch and restores the stashed slot crypto, so the cost
     // of the ambiguity is one burst, not a split call or lost decryption.
-    if (ctx.type == 2U && !(*ctx.IrrecoverableErrors == 0 && !ctx.protected_lc && ctx.flco == 0x30U)) {
+    if (ctx.type == 2U && !(dmr_flco_lc_readable(&ctx) && ctx.flco == 0x30U)) {
         dmr_flco_handle_terminator(&ctx);
     }
 

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -500,8 +500,14 @@ dmr_flco_handle_no_error_paths(dmr_flco_ctx* ctx) {
     return 0;
 }
 
+// The terminator reset, split by what the heal can give back. The crypto half is stashed before
+// an unverified end and restored when the epoch heals, so it is safe to clear on every
+// terminator. The metadata half -- the partially assembled talker alias, the dmr_pdu_sf
+// superframe scratch, and the embedded/LRRP GPS -- has no stash: clearing it on a burst that was
+// really mid-call voice mis-typed as a terminator would permanently lose the transmission's
+// alias, so it is only cleared when the terminator's LC could actually be read.
 static void
-dmr_flco_reset_td_lc_slot0(dmr_flco_ctx* ctx) {
+dmr_flco_reset_slot_crypto0(dmr_flco_ctx* ctx) {
     ctx->state->dmr_fid = 0;
     ctx->state->dmr_so = 0;
     ctx->state->payload_algid = 0;
@@ -510,17 +516,10 @@ dmr_flco_reset_td_lc_slot0(dmr_flco_ctx* ctx) {
     if (ctx->opts->floating_point == 1) {
         ctx->state->aout_gain = ctx->opts->audio_gain;
     }
-    ctx->state->dmr_alias_block_len[0] = 0;
-    ctx->state->dmr_alias_char_size[0] = 0;
-    ctx->state->dmr_alias_format[0] = 0;
-    DSD_SNPRINTF(ctx->state->generic_talker_alias[0], sizeof(ctx->state->generic_talker_alias[0]), "%s", "");
-    DSD_MEMSET(ctx->state->dmr_pdu_sf[0], 0, sizeof(ctx->state->dmr_pdu_sf[0]));
-    ctx->state->dmr_embedded_gps[0][0] = '\0';
-    ctx->state->dmr_lrrp_gps[0][0] = '\0';
 }
 
 static void
-dmr_flco_reset_td_lc_slot1(dmr_flco_ctx* ctx) {
+dmr_flco_reset_slot_crypto1(dmr_flco_ctx* ctx) {
     ctx->state->dmr_fidR = 0;
     ctx->state->dmr_soR = 0;
     ctx->state->payload_algidR = 0;
@@ -529,13 +528,17 @@ dmr_flco_reset_td_lc_slot1(dmr_flco_ctx* ctx) {
     if (ctx->opts->floating_point == 1) {
         ctx->state->aout_gainR = ctx->opts->audio_gain;
     }
-    ctx->state->dmr_alias_block_len[1] = 0;
-    ctx->state->dmr_alias_char_size[1] = 0;
-    ctx->state->dmr_alias_format[1] = 0;
-    DSD_SNPRINTF(ctx->state->generic_talker_alias[1], sizeof(ctx->state->generic_talker_alias[1]), "%s", "");
-    DSD_MEMSET(ctx->state->dmr_pdu_sf[1], 0, sizeof(ctx->state->dmr_pdu_sf[1]));
-    ctx->state->dmr_embedded_gps[1][0] = '\0';
-    ctx->state->dmr_lrrp_gps[1][0] = '\0';
+}
+
+static void
+dmr_flco_reset_slot_metadata(dmr_flco_ctx* ctx, uint8_t idx) {
+    ctx->state->dmr_alias_block_len[idx] = 0;
+    ctx->state->dmr_alias_char_size[idx] = 0;
+    ctx->state->dmr_alias_format[idx] = 0;
+    DSD_SNPRINTF(ctx->state->generic_talker_alias[idx], sizeof(ctx->state->generic_talker_alias[idx]), "%s", "");
+    DSD_MEMSET(ctx->state->dmr_pdu_sf[idx], 0, sizeof(ctx->state->dmr_pdu_sf[idx]));
+    ctx->state->dmr_embedded_gps[idx][0] = '\0';
+    ctx->state->dmr_lrrp_gps[idx][0] = '\0';
 }
 
 static void
@@ -685,6 +688,11 @@ dmr_flco_slot_crypto_is_clear(const dmr_flco_slot_crypto* live) {
     return *live->fid == 0U && *live->so == 0U && *live->algid == 0 && *live->keyid == 0 && *live->mi == 0ULL;
 }
 
+// The stash holds only what the canonical snapshot cannot supply: the FID and service options
+// the Basic Privacy gates require, which the snapshot never carried, and the MI as the
+// superframe machinery last advanced it, which the snapshot's copy can lag. The ALGID and key id
+// are deliberately not duplicated here -- the heal reads them back from the `previous` snapshot
+// the canonical layer hands it, so there is one source of truth for them.
 static void
 dmr_flco_stash_slot_crypto(dsd_state* state, uint8_t slot, uint64_t epoch) {
     const uint8_t idx = slot != 0U ? 1U : 0U;
@@ -695,8 +703,6 @@ dmr_flco_stash_slot_crypto(dsd_state* state, uint8_t slot, uint64_t epoch) {
     }
     state->dmr_heal_fid[idx] = *live.fid;
     state->dmr_heal_so[idx] = *live.so;
-    state->dmr_heal_algid[idx] = *live.algid;
-    state->dmr_heal_keyid[idx] = *live.keyid;
     state->dmr_heal_mi[idx] = *live.mi;
     state->dmr_heal_epoch[idx] = epoch;
     state->dmr_heal_valid[idx] = 1U;
@@ -720,10 +726,24 @@ dmr_flco_heal_restore(dsd_state* state, uint8_t slot, const dsd_call_snapshot* p
     }
     *live.fid = state->dmr_heal_fid[idx];
     *live.so = state->dmr_heal_so[idx];
-    *live.algid = state->dmr_heal_algid[idx];
-    *live.keyid = state->dmr_heal_keyid[idx];
+    *live.algid = (int)previous->algid;
+    *live.keyid = (int)previous->kid;
     *live.mi = state->dmr_heal_mi[idx];
     state->dmr_heal_valid[idx] = 0U;
+}
+
+// Install the heal hook exactly once, per the contract in call_state.h ("Install once from the
+// decode path before the first heal can occur"). The hook slot is a single process-global; a
+// re-install per terminator would be a repeated unsynchronized function-pointer write, and any
+// second protocol adopting the heal pattern would silently steal the slot -- the guard makes
+// that a one-time, first-DMR-decode event instead of a per-burst race surface.
+static void
+dmr_flco_ensure_heal_hook(void) {
+    static int installed = 0;
+    if (!installed) {
+        dsd_call_state_set_reacquire_hook(dmr_flco_heal_restore);
+        installed = 1;
+    }
 }
 
 // The end reason tracks how much of the terminator could be read. A terminator whose LC came
@@ -740,13 +760,17 @@ dmr_flco_heal_restore(dsd_state* state, uint8_t slot, const dsd_call_snapshot* p
 // already ended: a second unverified terminator corroborates an unverified end into TERMINATOR
 // -- which also releases the held VOICE_END alert, so on repeater systems the hangtime repeat
 // alerts within a burst of where a verified terminator would -- but never tightens a sync-loss
-// end, whose fade the same fallible evidence cannot explain away. The slot's payload crypto and
-// alias state resets either way: keeping it would let the next call on the slot inherit a stale
-// algid/key/MI or half-built alias. Before an unverified end's reset, the live crypto is
-// stashed so the heal can restore it (dmr_flco_stash_slot_crypto above).
+// end, whose fade the same fallible evidence cannot explain away. The slot's payload crypto
+// resets either way -- keeping it would let the next call on the slot inherit a stale
+// algid/key/MI, and before an unverified end's reset it is stashed so the heal can restore it
+// (dmr_flco_stash_slot_crypto above). The alias/GPS/superframe metadata has no stash, so it is
+// cleared only when the LC itself was readable: an FEC-failed or protected "terminator" may be a
+// mis-typed mid-call voice burst, and wiping the half-assembled alias there would lose it for
+// the rest of the transmission even after the epoch heals.
 static void
 dmr_flco_handle_terminator(dmr_flco_ctx* ctx) {
     const int verified = ctx->CRCCorrect == 1U && *ctx->IrrecoverableErrors == 0 && !ctx->protected_lc;
+    const int lc_readable = *ctx->IrrecoverableErrors == 0 && !ctx->protected_lc;
     const uint8_t idx = ctx->slot != 0U ? 1U : 0U;
     if (verified) {
         // A verified end is final; a heal can never follow it, so no stash may linger to be
@@ -756,7 +780,6 @@ dmr_flco_handle_terminator(dmr_flco_ctx* ctx) {
         dsd_call_snapshot ending;
         if (dsd_call_state_get(ctx->state, ctx->slot, &ending) > 0 && ending.phase == DSD_CALL_PHASE_ACTIVE) {
             dmr_flco_stash_slot_crypto(ctx->state, ctx->slot, ending.epoch);
-            dsd_call_state_set_reacquire_hook(dmr_flco_heal_restore);
         }
     }
     const int ended = dsd_call_state_end_ex(ctx->state, ctx->slot, 0.0,
@@ -765,9 +788,12 @@ dmr_flco_handle_terminator(dmr_flco_ctx* ctx) {
         dsd_event_sync_slot(ctx->opts, ctx->state, ctx->slot);
     }
     if (ctx->slot == 0U) {
-        dmr_flco_reset_td_lc_slot0(ctx);
+        dmr_flco_reset_slot_crypto0(ctx);
     } else {
-        dmr_flco_reset_td_lc_slot1(ctx);
+        dmr_flco_reset_slot_crypto1(ctx);
+    }
+    if (lc_readable) {
+        dmr_flco_reset_slot_metadata(ctx, idx);
     }
 }
 
@@ -1144,6 +1170,7 @@ dmr_flco(dsd_opts* opts, dsd_state* state, uint8_t lc_bits[], uint32_t CRCCorrec
          uint8_t type) {
     dmr_flco_ctx ctx;
     dmr_flco_ctx_init(&ctx, opts, state, lc_bits, CRCCorrect, IrrecoverableErrors, type);
+    dmr_flco_ensure_heal_hook();
     dmr_flco_detect_special_modes(&ctx);
     ctx.protected_lc = dmr_flco_is_protected(&ctx);
     dmr_flco_print_protected_lc(&ctx);
@@ -1169,7 +1196,11 @@ dmr_flco(dsd_opts* opts, dsd_state* state, uint8_t lc_bits[], uint32_t CRCCorrec
             dmr_flco_finalize(&ctx);
             return;
         }
-    } else if (dmr_flco_handle_irrecoverable_hytera_enhanced(&ctx)) {
+    } else if (ctx.type != 2U && dmr_flco_handle_irrecoverable_hytera_enhanced(&ctx)) {
+        // Gated off terminator bursts: the handler above just ended the call and reset the
+        // slot's crypto for the heal, and letting a Hytera-Enhanced-shaped FEC-failed LC
+        // re-populate payload_algid/keyid/mi here would leave dmr_fid=0 beside a non-zero
+        // ALGID and make dmr_flco_slot_crypto_is_clear() refuse the restore forever.
         dmr_flco_finalize(&ctx);
         return;
     }

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -780,13 +780,17 @@ dmr_flco_handle_terminator(dmr_flco_ctx* ctx) {
     const int lc_readable = dmr_flco_lc_readable(ctx);
     const int verified = ctx->CRCCorrect == 1U && lc_readable;
     const uint8_t idx = ctx->slot != 0U ? 1U : 0U;
-    if (verified) {
-        // A verified end is final; a heal can never follow it, so no stash may linger to be
-        // matched against some future epoch.
-        ctx->state->dmr_heal_valid[idx] = 0U;
-    } else {
+    if (!verified) {
+        // The stash must cover every epoch the reset below can strand: one still active, and
+        // equally one a recoverable end already closed but that may still reacquire. The fade
+        // case is the one that bites -- sync loss ends the epoch, then the terminator that
+        // explains the fade arrives with an unreadable LC. It cannot tighten a sync-loss end,
+        // but its reset still clears the slot, so without a stash a resumption inside the
+        // window comes back with the canonical snapshot claiming encryption and the live
+        // decoder holding no ALGID, key or MI.
         dsd_call_snapshot ending;
-        if (dsd_call_state_get(ctx->state, ctx->slot, &ending) > 0 && ending.phase == DSD_CALL_PHASE_ACTIVE) {
+        if (dsd_call_state_get(ctx->state, ctx->slot, &ending) > 0 && ending.epoch != 0U
+            && (ending.phase == DSD_CALL_PHASE_ACTIVE || dsd_call_state_end_reason_is_recoverable(ending.end_reason))) {
             dmr_flco_stash_slot_crypto(ctx->state, ctx->slot, ending.epoch);
         }
     }
@@ -794,6 +798,15 @@ dmr_flco_handle_terminator(dmr_flco_ctx* ctx) {
                                             verified ? DSD_CALL_END_TERMINATOR : DSD_CALL_END_UNVERIFIED_TERMINATOR);
     if (ended > 0) {
         dsd_event_sync_slot(ctx->opts, ctx->state, ctx->slot);
+    }
+    // A final end -- a verified terminator, or an unverified one corroborated by a repeat -- can
+    // never be followed by a heal, so no stash may linger to be matched against a future epoch.
+    // The epoch counter only grows, but dsd_call_context_restore_snapshot() swaps in another
+    // trunk-scan target's epochs wholesale, so a stale stash can meet an equal epoch number.
+    dsd_call_snapshot settled;
+    if (dsd_call_state_get(ctx->state, ctx->slot, &settled) > 0 && settled.phase == DSD_CALL_PHASE_ENDED
+        && !dsd_call_state_end_reason_is_recoverable(settled.end_reason)) {
+        ctx->state->dmr_heal_valid[idx] = 0U;
     }
     dmr_flco_reset_slot_crypto(ctx, idx);
     if (lc_readable) {

--- a/src/protocol/edacs/edacs-fme.c
+++ b/src/protocol/edacs/edacs-fme.c
@@ -2076,9 +2076,10 @@ eot_cc(dsd_opts* opts, dsd_state* state) {
     // Give the control channel time to cancel the grant before retuning back to it.
     skipDibit(opts, state, 240 * 8);
 
-    //watchdog event at this point
+    //watchdog event at this point. The EOT dotting sequence decoded over the air is positive end
+    //evidence, so the event layer can keep an audible epoch the EOT closed.
     state->lastsynctype = DSD_SYNC_EDACS_NEG;
-    (void)dsd_call_state_end(state, 0U, nowm);
+    (void)dsd_call_state_end_ex(state, 0U, nowm, DSD_CALL_END_TERMINATOR);
     dsd_event_sync_slot(opts, state, 0);
 
     //jump back to CC here

--- a/src/protocol/m17/m17.c
+++ b/src/protocol/m17/m17.c
@@ -1115,7 +1115,9 @@ M17prepareStream(const dsd_opts* opts, dsd_state* state, const uint8_t* m17_bits
 
     uint8_t processed_payload[M17_STREAM_PAYLOAD_BITS];
     (void)m17_dispatch_stream_payload((const dsd_opts*)opts, state, payload, stream_frame_number, processed_payload);
-    if (end != 0U && dsd_call_state_end(state, 0U, 0.0) > 0) {
+    // The stream frame's end-of-stream flag is an over-the-air terminator: it lets the event
+    // layer keep an audible epoch whose LSF never decoded, where EXPLICIT would read as a retune.
+    if (end != 0U && dsd_call_state_end_ex(state, 0U, 0.0, DSD_CALL_END_TERMINATOR) > 0) {
         dsd_event_sync_slot((dsd_opts*)opts, state, 0U);
     }
 }
@@ -3240,7 +3242,8 @@ m17_ip_handle_stream_frame(const dsd_opts* opts, dsd_state* state, const uint8_t
     }
     uint8_t processed_payload[M17_STREAM_PAYLOAD_BITS];
     (void)m17_dispatch_stream_payload_internal(opts, state, payload, stream_frame_number, processed_payload, crc_valid);
-    if (crc_valid && eot != 0U && dsd_call_state_end(state, 0U, 0.0) > 0) {
+    // CRC-verified IP-frame EOT: positive end evidence, like the RF stream's end flag above.
+    if (crc_valid && eot != 0U && dsd_call_state_end_ex(state, 0U, 0.0, DSD_CALL_END_TERMINATOR) > 0) {
         dsd_event_sync_slot((dsd_opts*)opts, state, 0U);
     }
 

--- a/src/protocol/nxdn/nxdn_deperm.c
+++ b/src/protocol/nxdn/nxdn_deperm.c
@@ -741,7 +741,9 @@ nxdn_update_sacch2_identity_state(const dsd_opts* opts, dsd_state* state, const 
         if (dsd_call_state_get(state, 0U, &call) > 0 && call.phase == DSD_CALL_PHASE_ACTIVE) {
             (void)dsd_event_enrich_alias(state, 0U, call.epoch, "JPN DCR");
         }
-    } else if (fields->sf_mes == 0x1EU && dsd_call_state_end(state, 0U, 0.0) > 0) {
+    } else if (fields->sf_mes == 0x1EU && dsd_call_state_end_ex(state, 0U, 0.0, DSD_CALL_END_TERMINATOR) > 0) {
+        // Release signaling decoded over the air: positive end evidence, distinguishable from an
+        // engine retune, so the event layer can keep an audible identity-less epoch it closed.
         dsd_event_sync_slot((dsd_opts*)opts, state, 0U);
     }
     if (fields->sf_fb) {
@@ -1212,9 +1214,11 @@ nxdn_message_type(const dsd_opts* opts, dsd_state* state, uint8_t MessageType) {
     }
     DSD_FPRINTF(stderr, "%s", KNRM);
 
-    //End the canonical call on explicit release or disconnect signaling.
+    //End the canonical call on explicit release or disconnect signaling. CRC-verified release
+    //decoded over the air is positive end evidence -- the terminator reason lets the event layer
+    //keep an audible epoch whose call identity never decoded, where EXPLICIT reads as a retune.
     if (state->NxdnElementsContent.VCallCrcIsGood != 0U && nxdn_message_type_resets_call(MessageType)) {
-        if (dsd_call_state_end(state, 0U, 0.0) > 0) {
+        if (dsd_call_state_end_ex(state, 0U, 0.0, DSD_CALL_END_TERMINATOR) > 0) {
             dsd_event_sync_slot((dsd_opts*)opts, state, 0U);
         }
         nxdn_alias_reset(state);

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -2283,11 +2283,25 @@ nxdn_vcall_run_enc_lockout(dsd_opts* opts, dsd_state* state, const struct nxdn_v
     }
 }
 
+// Release and disconnect variants that reach nxdn_vcall_process. TX_REL_EX (0x07) ends the epoch
+// only here: unlike TX_REL/DISC it deliberately skips the alias/cipher/keyloader resets in
+// nxdn_message_type(), so this is the one site where its end reason is recorded.
+static int
+nxdn_vcall_message_type_is_release(uint8_t message_type) {
+    return message_type == 0x07U || message_type == 0x08U || message_type == 0x11U;
+}
+
 static void
 nxdn_vcall_process(dsd_opts* opts, dsd_state* state, const struct nxdn_vcall_info* info) {
-    if (info->message_type != 0x01U && state->NxdnElementsContent.VCallCrcIsGood != 0U
-        && dsd_call_state_end(state, 0U, 0.0) > 0) {
-        dsd_event_sync_slot(opts, state, 0U);
+    if (info->message_type != 0x01U && state->NxdnElementsContent.VCallCrcIsGood != 0U) {
+        // A CRC-verified release decoded over the air is positive end evidence -- the terminator
+        // reason lets the event layer keep an audible epoch whose call identity never decoded,
+        // where EXPLICIT reads as a retune and drops the row.
+        const dsd_call_end_reason reason =
+            nxdn_vcall_message_type_is_release(info->message_type) ? DSD_CALL_END_TERMINATOR : DSD_CALL_END_EXPLICIT;
+        if (dsd_call_state_end_ex(state, 0U, 0.0, reason) > 0) {
+            dsd_event_sync_slot(opts, state, 0U);
+        }
     }
     nxdn_vcall_print_summary(state, info);
     nxdn_vcall_load_key(opts, state, info);

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -2540,7 +2540,8 @@ nxdn_scch_update_busy_display(dsd_opts* opts, dsd_state* state, const struct nxd
     DSD_FPRINTF(stderr, "%s ", info->gu == 0U ? "Group Call" : "Private Call");
     if (info->rep1 == 31U) {
         DSD_FPRINTF(stderr, "Termination ");
-        if (dsd_call_state_end(state, 0U, 0.0) > 0) {
+        // Channel-update termination signaling: positive over-the-air end evidence.
+        if (dsd_call_state_end_ex(state, 0U, 0.0, DSD_CALL_END_TERMINATOR) > 0) {
             dsd_event_sync_slot(opts, state, 0U);
         }
     } else if (info->rep1 != 0U) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2575,13 +2575,18 @@ p25_call_publish_observation(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_
 }
 
 static void
-p25_call_end_slot(dsd_opts* opts, dsd_state* state, int slot, double observed_m) {
+p25_call_end_slot_ex(dsd_opts* opts, dsd_state* state, int slot, double observed_m, dsd_call_end_reason reason) {
     if (!state || slot < 0 || slot > 1) {
         return;
     }
-    if (dsd_call_state_end(state, (uint8_t)slot, observed_m) > 0 && opts) {
+    if (dsd_call_state_end_ex(state, (uint8_t)slot, observed_m, reason) > 0 && opts) {
         dsd_event_sync_slot(opts, state, (uint8_t)slot);
     }
+}
+
+static void
+p25_call_end_slot(dsd_opts* opts, dsd_state* state, int slot, double observed_m) {
+    p25_call_end_slot_ex(opts, state, slot, observed_m, DSD_CALL_END_EXPLICIT);
 }
 
 static void
@@ -3545,9 +3550,14 @@ p25_voice_end_clear_policy_route(const p25_sm_ctx_t* ctx, dsd_state* state, int 
     (void)dsd_tg_policy_clear_active_call(state, ctx->vc_is_tdma ? slot : -1);
 }
 
+// `end_reason` records what the triggering event actually said about the air:
+// DSD_CALL_END_TERMINATOR for over-the-air end signaling (a MAC_END_PTT, a Phase 1 TDU), so the
+// event layer can keep an audible epoch whose call identity never decoded, and
+// DSD_CALL_END_EXPLICIT for inactivity-driven teardowns (idle, hangtime), which say nothing
+// about how the transmission ended.
 static int
 handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, const char* why, int is_explicit_end,
-                 int arm_stale_regrant_guard, const p25_sm_event_t* ev) {
+                 int arm_stale_regrant_guard, const p25_sm_event_t* ev, dsd_call_end_reason end_reason) {
     if (!ctx) {
         return 0;
     }
@@ -3578,7 +3588,7 @@ handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, 
     p25_voice_end_record(&ctx->slots[s], is_explicit_end, arm_stale_regrant_guard, now_m, ended_tg, ended_src);
     p25_voice_end_clear_policy_route(ctx, state, s, preserve_recent_idle_grant);
     p25_voice_close_slot_media_for_end(ctx, opts, state, s, preserve_recent_idle_grant);
-    p25_call_end_slot(opts, state, s, now_m);
+    p25_call_end_slot_ex(opts, state, s, now_m, end_reason);
     if (state && !ctx->vc_is_tdma && arm_stale_regrant_guard) {
         state->p25_p1_identity_pending = 1;
         state->p25_p1_identity_epoch_started = 0;
@@ -3665,7 +3675,7 @@ handle_facch_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, cons
         return do_release(ctx, opts, state, "facch-double-end", 0) ? P25_SM_END_CHANNEL_RELEASED : P25_SM_END_IGNORED;
     }
 
-    int applied = handle_voice_end(ctx, opts, state, ev->slot, "end", 1, 1, ev);
+    int applied = handle_voice_end(ctx, opts, state, ev->slot, "end", 1, 1, ev, DSD_CALL_END_TERMINATOR);
     if (!applied) {
         return P25_SM_END_IGNORED;
     }
@@ -4518,23 +4528,23 @@ p25_sm_handle_event_end(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* stat
         (void)handle_facch_voice_end(ctx, (dsd_opts*)opts, state, ev);
         return;
     }
-    (void)handle_voice_end(ctx, (dsd_opts*)opts, state, ev->slot, "end", 1, 1, ev);
+    (void)handle_voice_end(ctx, (dsd_opts*)opts, state, ev->slot, "end", 1, 1, ev, DSD_CALL_END_TERMINATOR);
 }
 
 static void
 p25_sm_handle_event_idle(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev) {
     // MAC_IDLE may occur during brief gaps - use hangtime, not immediate release.
-    (void)handle_voice_end(ctx, (dsd_opts*)opts, state, ev->slot, "idle", 0, 0, ev);
+    (void)handle_voice_end(ctx, (dsd_opts*)opts, state, ev->slot, "idle", 0, 0, ev, DSD_CALL_END_EXPLICIT);
 }
 
 static void
 p25_sm_handle_event_tdu(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev) {
-    (void)handle_voice_end(ctx, (dsd_opts*)opts, state, 0, "tdu", 0, 1, ev);
+    (void)handle_voice_end(ctx, (dsd_opts*)opts, state, 0, "tdu", 0, 1, ev, DSD_CALL_END_TERMINATOR);
 }
 
 static void
 p25_sm_handle_event_hangtime(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev) {
-    (void)handle_voice_end(ctx, (dsd_opts*)opts, state, ev->slot, "mac-hangtime", 0, 0, ev);
+    (void)handle_voice_end(ctx, (dsd_opts*)opts, state, ev->slot, "mac-hangtime", 0, 0, ev, DSD_CALL_END_EXPLICIT);
 }
 
 static void
@@ -5742,7 +5752,7 @@ p25_sm_emit_end_call_at(dsd_opts* opts, dsd_state* state, int slot, int tg, int 
     }
     p25_sm_event_t ev = p25_sm_ev_end_call_at(slot, tg, src, observed_m);
     const int trunk_assignment_active = ctx->state == P25_SM_TUNED;
-    const int accepted = handle_voice_end(ctx, opts, state, slot, "end", 1, 1, &ev);
+    const int accepted = handle_voice_end(ctx, opts, state, slot, "end", 1, 1, &ev, DSD_CALL_END_TERMINATOR);
     if (!trunk_assignment_active && accepted) {
         p25_ptt_marker_invalidate(ctx, slot);
         p25_call_end_slot(opts, state, slot, observed_m);

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2584,6 +2584,10 @@ p25_call_end_slot_ex(dsd_opts* opts, dsd_state* state, int slot, double observed
     }
 }
 
+// Teardown/retune wrapper: says nothing about how the transmission ended on the air. Call
+// sites reacting to decoded OTA end signaling (MAC_END_PTT, MAC Release, TDU, FACCH end,
+// LCW termination/EOT) must use p25_call_end_slot_ex with DSD_CALL_END_TERMINATOR so the
+// event layer can keep an audible epoch whose call identity never decoded.
 static void
 p25_call_end_slot(dsd_opts* opts, dsd_state* state, int slot, double observed_m) {
     p25_call_end_slot_ex(opts, state, slot, observed_m, DSD_CALL_END_EXPLICIT);
@@ -5737,7 +5741,7 @@ p25_sm_emit_end(dsd_opts* opts, dsd_state* state, int slot) {
     p25_sm_event(ctx, opts, state, &ev);
     if (!trunk_assignment_active) {
         p25_ptt_marker_invalidate(ctx, slot);
-        p25_call_end_slot(opts, state, slot, 0.0);
+        p25_call_end_slot_ex(opts, state, slot, 0.0, DSD_CALL_END_TERMINATOR);
     }
 }
 
@@ -5755,7 +5759,7 @@ p25_sm_emit_end_call_at(dsd_opts* opts, dsd_state* state, int slot, int tg, int 
     const int accepted = handle_voice_end(ctx, opts, state, slot, "end", 1, 1, &ev, DSD_CALL_END_TERMINATOR);
     if (!trunk_assignment_active && accepted) {
         p25_ptt_marker_invalidate(ctx, slot);
-        p25_call_end_slot(opts, state, slot, observed_m);
+        p25_call_end_slot_ex(opts, state, slot, observed_m, DSD_CALL_END_TERMINATOR);
     }
     return accepted;
 }
@@ -5778,7 +5782,7 @@ p25_sm_emit_mac_release(dsd_opts* opts, dsd_state* state, int slot, double obser
     if (state) {
         (void)dsd_tg_policy_clear_active_call(state, ctx->vc_is_tdma ? slot : -1);
     }
-    p25_call_end_slot(opts, state, slot, ended_m);
+    p25_call_end_slot_ex(opts, state, slot, ended_m, DSD_CALL_END_TERMINATOR);
     p25_sm_update_ui_mode(ctx, state);
 }
 
@@ -5796,7 +5800,7 @@ p25_sm_emit_facch_end_call_at(dsd_opts* opts, dsd_state* state, int slot, int tg
     const int result = handle_facch_voice_end(ctx, opts, state, &ev);
     if (!trunk_assignment_active && result != P25_SM_END_IGNORED) {
         p25_ptt_marker_invalidate(ctx, slot);
-        p25_call_end_slot(opts, state, slot, observed_m);
+        p25_call_end_slot_ex(opts, state, slot, observed_m, DSD_CALL_END_TERMINATOR);
     }
     return result;
 }
@@ -5845,7 +5849,7 @@ p25_sm_emit_tdu(dsd_opts* opts, dsd_state* state) {
     p25_sm_event(ctx, opts, state, &ev);
     if (!trunk_assignment_active) {
         p25_ptt_marker_invalidate(ctx, 0);
-        p25_call_end_slot(opts, state, 0, 0.0);
+        p25_call_end_slot_ex(opts, state, 0, 0.0, DSD_CALL_END_TERMINATOR);
     }
 }
 

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2997,6 +2997,7 @@ typedef struct {
     int requires_update;
     int preserve_crypto_classification;
     int coalesce_canonical_epoch;
+    int ptt_evidence;
 } p25_voice_start_changes_t;
 
 static int
@@ -3022,19 +3023,42 @@ p25_p1_hdu_crypto_consume_identity(const p25_sm_ctx_t* ctx, dsd_state* state, co
     }
 }
 
+// A PTT normally keeps its own canonical epoch: PTT is per-transmission
+// evidence. The exception is the transmission that is already being observed
+// live: a tune that lands so a GVCU/MAC_ACTIVE decodes before one of the
+// transmission-start MAC_PTT repeats begins the canonical epoch from that
+// observation, and letting the first-seen PTT force a second epoch commits
+// the observation epoch's freshly built row as a duplicate event. The PTT may
+// therefore fold into a young matching epoch only while that epoch has not
+// already accepted a PTT of its own -- a second, differently-signed PTT is
+// the next transmission and must begin its own epoch.
+static int
+p25_voice_ptt_start_may_coalesce(const p25_sm_ctx_t* ctx, const dsd_state* state, int slot) {
+    dsd_call_snapshot current;
+    if (dsd_call_state_get(state, (uint8_t)slot, &current) <= 0 || current.phase != DSD_CALL_PHASE_ACTIVE) {
+        return 0;
+    }
+    return ctx->slots[slot].ptt_canonical_epoch != current.epoch;
+}
+
 static p25_voice_start_changes_t
-p25_voice_start_classify_changes(const p25_sm_ctx_t* ctx, const p25_sm_slot_ctx_t* slot_ctx,
-                                 const p25_sm_event_t* input, const p25_sm_event_t* call_ev, int ptt_retransmit) {
+p25_voice_start_classify_changes(const p25_sm_ctx_t* ctx, const dsd_state* state, int slot,
+                                 const p25_sm_slot_ctx_t* slot_ctx, const p25_sm_event_t* input,
+                                 const p25_sm_event_t* call_ev, int ptt_retransmit) {
     p25_voice_start_changes_t changes = {0};
     const int learned_source = !p25_source_id_known(slot_ctx->src) && p25_source_id_known(call_ev->src);
 
     changes.service_changed = p25_voice_start_service_changed(slot_ctx, call_ev);
     changes.new_epoch = p25_voice_start_begins_new_epoch(ctx, slot_ctx, input, call_ev, ptt_retransmit);
     changes.requires_update = changes.new_epoch || changes.service_changed || learned_source;
-    // A PTT is per-transmission evidence and must keep its own canonical
-    // epoch; only an ACTIVE-driven start may fold into the epoch the
-    // traffic-channel observation of the same transmission just began.
-    changes.coalesce_canonical_epoch = input->type == P25_SM_EV_ACTIVE;
+    changes.ptt_evidence = p25_voice_start_is_p2_ptt(ctx, input);
+    // An ACTIVE-driven start may always fold into the epoch the
+    // traffic-channel observation of the same transmission just began. A PTT
+    // may do the same only for an epoch no PTT has claimed yet; identity and
+    // age matching stay with p25_call_begin_coalesces_into_active_epoch().
+    changes.coalesce_canonical_epoch =
+        input->type == P25_SM_EV_ACTIVE
+        || (changes.new_epoch && changes.ptt_evidence && p25_voice_ptt_start_may_coalesce(ctx, state, slot));
     return changes;
 }
 
@@ -3160,6 +3184,17 @@ p25_voice_start_commit_identity(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* st
     p25_voice_start_update_crypto(ctx, state, slot, logical_slot, call_ev, eval_ctx, changes, now_m);
     p25_call_publish_observation(ctx, opts, state, slot, changes->new_epoch, changes->coalesce_canonical_epoch,
                                  P25_CALL_OBS_VOICE_EVIDENCE, now_m);
+    if (changes->ptt_evidence) {
+        // Whether this PTT began the epoch or folded into one an ACTIVE
+        // observation began, the epoch now contains a PTT: the next
+        // differently-signed PTT is the next transmission and must not
+        // coalesce into it. Read back rather than assumed: the publish may
+        // have declined (no assignment target), leaving no epoch to claim.
+        dsd_call_snapshot current;
+        if (dsd_call_state_get(state, (uint8_t)slot, &current) > 0 && current.phase == DSD_CALL_PHASE_ACTIVE) {
+            slot_ctx->ptt_canonical_epoch = current.epoch;
+        }
+    }
 }
 
 static int
@@ -3185,7 +3220,7 @@ p25_voice_start_apply_identity(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* sta
 
     const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
     p25_voice_start_changes_t changes =
-        p25_voice_start_classify_changes(ctx, slot_ctx, input, &call_ev, ptt_retransmit);
+        p25_voice_start_classify_changes(ctx, state, slot, slot_ctx, input, &call_ev, ptt_retransmit);
     if (pending_p1_identity) {
         changes.requires_update = 1;
     }

--- a/src/protocol/ysf/ysf.c
+++ b/src/protocol/ysf/ysf.c
@@ -897,7 +897,10 @@ ysf_update_call_lifecycle(dsd_opts* opts, dsd_state* state, const ysf_fich_info*
 
 static void
 ysf_end_call_lifecycle(dsd_opts* opts, dsd_state* state, const ysf_fich_info* info) {
-    if (info->err == 0 && info->fi == 2U && dsd_call_state_end(state, 0U, 0.0) > 0) {
+    // A FICH-verified communication terminator (FI=2) is positive over-the-air end evidence, so
+    // the event layer can keep an audible epoch whose callsigns never decoded; EXPLICIT would be
+    // indistinguishable from an engine retune and drop that row.
+    if (info->err == 0 && info->fi == 2U && dsd_call_state_end_ex(state, 0U, 0.0, DSD_CALL_END_TERMINATOR) > 0) {
         dsd_event_sync_slot(opts, state, 0U);
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6184,6 +6184,7 @@ if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
             "-Wl,--wrap=watchdog_event_current"
             "-Wl,--wrap=watchdog_event_history"
             "-Wl,--wrap=close_and_rename_wav_file"
+            "-Wl,--wrap=close_and_rename_wav_file_ex"
             "-Wl,--wrap=open_wav_file"
     )
     add_test(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4636,6 +4636,25 @@ add_test(
     COMMAND dsd-neo_test_p25_p2_hangtime_events
 )
 
+# P25p2 ACTIVE-observed transmissions: the first-seen MAC_PTT folds into the
+# ACTIVE-begun canonical epoch instead of force-minting a duplicate event row
+add_executable(
+    dsd-neo_test_p25_p2_active_ptt_epoch
+    protocol/p25/test_p25_p2_active_ptt_epoch.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p2_active_ptt_epoch
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_p25_p2_active_ptt_epoch
+    PRIVATE dsd-neo_proto_p25
+)
+add_test(
+    NAME P25_P2_ACTIVE_PTT_EPOCH
+    COMMAND dsd-neo_test_p25_p2_active_ptt_epoch
+)
+
 # P25 Unified SM tests
 add_executable(
     dsd-neo_test_p25_sm_unified_core

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -1758,6 +1758,104 @@ test_media_terminated_identityless_voice_epoch_commits_row(void) {
     return rc;
 }
 
+static int committed_history_rows(const Event_History_I* history);
+
+// The engine ends epochs EXPLICIT on every retune and teardown --
+// no_carrier_clear_voice_tune_state() fires one each time the trunker returns
+// to the control channel -- so an EXPLICIT end is not evidence a transmission
+// ended over the air. A stray-sync noise epoch that carried media and was then
+// ended by a retune must drop exactly like the faded shape; only the
+// terminator reasons vouch for an identity-less audible row.
+static int
+test_retune_explicit_end_drops_identityless_media_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    int rc = 0;
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+
+    rc |= expect_int("provisional call starts epoch",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                                       DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    rc |= expect_int("voice media runs on the epoch", dsd_call_state_update_media(&state, 0U, 1, g_observed_m), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("retune ends the epoch explicitly", end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("retune-ended noise row does not reach history", committed_history_rows(&event_history[0]), 0);
+
+    // The verified-terminator shape is the one that vouches: same epoch shape,
+    // ended by positive over-the-air evidence, keeps its row.
+    rc |= expect_int("audible epoch starts",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                                       DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    rc |= expect_int("voice media runs again", dsd_call_state_update_media(&state, 0U, 1, g_observed_m), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("verified terminator ends the epoch", end_test_call(&state, 0U, DSD_CALL_END_TERMINATOR), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("terminator-ended audible row reaches history", committed_history_rows(&event_history[0]), 1);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The heal window after an unverified terminator is tighter than the sync-loss
+// reacquisition window: the mis-typed voice burst it exists for is followed by
+// the transmission's next media mark within a burst or two, while a real end
+// followed by a fast re-key whose headers fail to decode can put an
+// identity-less media mark on the slot well inside the sync-loss window -- and
+// folding that in would hand the new call the terminated call's identity (and,
+// in DMR, its restored crypto).
+static int
+test_unverified_terminator_heal_window_is_tight(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    int rc = 0;
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+
+    rc |= expect_int("identified call begins",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 1234U, 5678U,
+                                       0U, 0U, DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    rc |= expect_int("unverified terminator ends it", end_test_call(&state, 0U, DSD_CALL_END_UNVERIFIED_TERMINATOR), 1);
+    // Beyond the heal window but still inside the sync-loss window: proves the
+    // tighter gate is what rejects the reopen.
+    advance_test_clock(0.3);
+    rc |= expect_int("late identity-less continuation begins",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                                       DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    dsd_call_snapshot call;
+    rc |= expect_int("late continuation opens a fresh epoch", dsd_call_state_get(&state, 0U, &call) > 0, 1);
+    rc |= expect_int("fresh epoch is not seeded with the ended call's identity", (int)call.ota_target_id, 0);
+    // Retire the fresh identity-less epoch so the next identified BEGIN opens
+    // its own epoch instead of specializing into it.
+    rc |= expect_int("fresh epoch retires", end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT), 1);
+
+    // Inside the heal window the mis-typed burst still heals.
+    rc |= expect_int("second identified call begins",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 4321U, 8765U,
+                                       0U, 0U, DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    rc |= expect_int("unverified terminator ends the second call",
+                     end_test_call(&state, 0U, DSD_CALL_END_UNVERIFIED_TERMINATOR), 1);
+    rc |= expect_int("prompt identity-less continuation begins",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                                       DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    rc |= expect_int("prompt continuation heals the epoch", dsd_call_state_get(&state, 0U, &call) > 0, 1);
+    rc |= expect_int("healed epoch keeps the terminated call's identity", (int)call.ota_target_id, 4321);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 // A voice epoch whose only decoded knowledge is its crypto -- encrypted, this
 // alg, this key -- is not noise. P25 late entry deliberately opens an
 // identity-less epoch so ESS crypto can attach; when the signal fades before
@@ -3889,6 +3987,8 @@ main(void) {
     rc |= test_provisional_voice_identity_does_not_commit_zero_row();
     rc |= test_identityless_voice_epoch_commits_no_row();
     rc |= test_media_terminated_identityless_voice_epoch_commits_row();
+    rc |= test_retune_explicit_end_drops_identityless_media_row();
+    rc |= test_unverified_terminator_heal_window_is_tight();
     rc |= test_crypto_only_voice_epoch_commits_row();
     rc |= test_route_text_only_row_survives_epoch_change_commit();
     rc |= test_standalone_provoice_zero_id_row_commits();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -1698,6 +1698,103 @@ test_identityless_voice_epoch_commits_no_row(void) {
     return rc;
 }
 
+// A voice epoch whose only decoded knowledge is its crypto -- encrypted, this
+// alg, this key -- is not noise. P25 late entry deliberately opens an
+// identity-less epoch so ESS crypto can attach; when the signal fades before
+// any LC names a talkgroup or source, the record that an encrypted
+// transmission occurred must still reach history.
+static int
+test_crypto_only_voice_epoch_commits_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    int rc = 0;
+    state.lastsynctype = DSD_SYNC_P25P1_POS;
+    rc |= expect_int(
+        "provisional call starts epoch",
+        observe_test_call(&state, 0U, DSD_SYNC_P25P1_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U, DSD_CALL_BOUNDARY_BEGIN),
+        1);
+    rc |= expect_int("crypto attaches to the identity-less epoch",
+                     update_test_crypto(&state, 0U, DSD_CALL_CRYPTO_ENCRYPTED_PENDING, 0x84U, 0x1234U, 0U), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("sync loss ends the epoch", end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("crypto-only row reaches history", event_history[0].Event_History_Items[1].event_string[0] != '\0',
+                     1);
+    rc |= expect_int("row records the algorithm", event_history[0].Event_History_Items[1].enc_alg, 0x84);
+    rc |= expect_int("row records the key id", event_history[0].Event_History_Items[1].enc_key, 0x1234);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// Route text is identity the row strings never carry: a D-STAR transmission
+// where only the repeater pair decoded stages a row whose every checked field
+// is empty. The identity verdict is captured at render time, so the row must
+// survive commit on every path -- including the epoch-change path, where the
+// outgoing epoch's canonical snapshot is already gone.
+static int
+test_route_text_only_row_survives_epoch_change_commit(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    int rc = 0;
+    state.lastsynctype = DSD_SYNC_DSTAR_VOICE_POS;
+    dsd_call_observation route_only = {
+        .protocol = DSD_SYNC_DSTAR_VOICE_POS,
+        .slot = 0U,
+        .kind = DSD_CALL_KIND_VOICE,
+        .observed_m = g_observed_m,
+    };
+    DSD_SNPRINTF(route_only.route_text[0], sizeof route_only.route_text[0], "%s", "RPT1CALL");
+    g_observed_m += 0.1;
+    rc |= expect_int("route-only call begins", dsd_call_state_observe(&state, &route_only, DSD_CALL_BOUNDARY_BEGIN), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("route-only row is staged",
+                     state.event_history_s[0].Event_History_Items[0].event_string[0] != '\0', 1);
+
+    // The next transmission's BEGIN forks the epoch before any terminator, so the leftover row
+    // commits through the epoch-change path.
+    rc |= expect_int("next call begins",
+                     observe_test_call(&state, 0U, DSD_SYNC_DSTAR_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 3333U, 0U, 0U,
+                                       DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("route-only row reaches history", event_history[0].Event_History_Items[1].event_string[0] != '\0',
+                     1);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// Standalone ProVoice never parses its voice traffic into a talkgroup or
+// source, so an all-zero row is the protocol's whole story -- the channel
+// carried voice -- and must keep reaching history exactly as X2-TDMA's rows
+// do. (EDACS-trunked ProVoice rows carry AFS/LID strings and are unaffected.)
+static int
+test_standalone_provoice_zero_id_row_commits(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    int rc = 0;
+    state.lastsynctype = DSD_SYNC_PROVOICE_POS;
+    rc |= expect_int("provoice call starts epoch",
+                     observe_test_call(&state, 0U, DSD_SYNC_PROVOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                                       DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("sync loss ends the epoch", end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("standalone provoice row reaches history",
+                     event_history[0].Event_History_Items[1].event_string[0] != '\0', 1);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 static int
 test_new_canonical_epoch_commits_prior_canonical_call(void) {
     static dsd_opts opts;
@@ -3731,6 +3828,9 @@ main(void) {
     rc |= test_canonical_voice_category_is_protocol_neutral();
     rc |= test_provisional_voice_identity_does_not_commit_zero_row();
     rc |= test_identityless_voice_epoch_commits_no_row();
+    rc |= test_crypto_only_voice_epoch_commits_row();
+    rc |= test_route_text_only_row_survives_epoch_change_commit();
+    rc |= test_standalone_provoice_zero_id_row_commits();
     rc |= test_new_canonical_epoch_commits_prior_canonical_call();
     rc |= test_reacquired_transmission_commits_one_row();
     rc |= test_terminator_after_sync_loss_end_blocks_reacquisition();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -1832,21 +1832,90 @@ test_dropped_identityless_row_rotates_wav_without_export(void) {
     rc |= expect_int("sync loss ends the noise epoch", end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS), 1);
     dsd_event_sync_slot(&opts, &state, 0U);
     rc |= expect_int("dropped row leaves no history", committed_history_rows(&event_history[0]), 0);
-    rc |= expect_int("dropped row still rotates the WAV", g_close_wav_count, 1);
-    rc |= expect_int("dropped row's rotation does not export", g_close_wav_export_count, 0);
-
-    // The committed shape keeps exporting: same rotation path, row reached history.
-    opts.wav_out_f = (SNDFILE*)0x1;
-    g_close_wav_count = 0;
+    // The keep-or-drop verdict is held while the recoverable end could still be explained by a
+    // late terminator, so the WAV has not rotated yet; a new call taking the slot resolves the
+    // hold, and the drop's rotation must not export.
+    rc |= expect_int("keep-or-drop is held while the end may still be explained", g_close_wav_count, 0);
     rc |= expect_int("identified call begins",
                      observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 1234U, 5678U,
                                        0U, 0U, DSD_CALL_BOUNDARY_BEGIN),
                      1);
     dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("held drop resolves when a new call takes the slot", g_close_wav_count, 1);
+    rc |= expect_int("dropped row's rotation does not export", g_close_wav_export_count, 0);
+    rc |= expect_int("resolved drop still leaves no history", committed_history_rows(&event_history[0]), 0);
+
+    // The committed shape keeps exporting: same rotation path, row reached history.
+    opts.wav_out_f = (SNDFILE*)0x1;
+    g_close_wav_count = 0;
     rc |= expect_int("identified call ends", end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT), 1);
     dsd_event_sync_slot(&opts, &state, 0U);
     rc |= expect_int("committed row rotates the WAV", g_close_wav_count, 1);
     rc |= expect_int("committed row's rotation exports", g_close_wav_export_count, 1);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The keep-or-drop verdict for an identity-less audible row must not be irrevocable at the
+// first ended-sync pass: a fade often beats the terminator that explains it, and the hangtime
+// terminator then retracts the sync-loss end to TERMINATOR in the canonical layer. The held
+// verdict re-reads the staged environment on the next pass, sees the end became positive, and
+// commits the row the immediate drop would have deleted with nothing left to re-render.
+static int
+test_terminator_after_fade_rescues_identityless_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    int rc = 0;
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+
+    rc |= expect_int("audible epoch starts",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                                       DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    rc |= expect_int("voice media runs", dsd_call_state_update_media(&state, 0U, 1, g_observed_m), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("carrier fades before the terminator", end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("verdict is held, not dropped", committed_history_rows(&event_history[0]), 0);
+
+    // The hangtime terminator decodes after the fade; a verified terminator retracts the
+    // recoverable end, and the next sync pass commits the row it now vouches for.
+    rc |=
+        expect_int("late terminator retracts the sync-loss end", end_test_call(&state, 0U, DSD_CALL_END_TERMINATOR), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("rescued audible row reaches history", committed_history_rows(&event_history[0]), 1);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// D-STAR has no terminator to decode -- its transmissions only ever end by sync loss or an
+// engine teardown -- so the media-plus-terminator vouch would be structurally unsatisfiable for
+// it. A sync-loss end after audible media must count as the positive end evidence the mode can
+// never produce, keeping the reception's row where a DMR noise epoch's still drops.
+static int
+test_dstar_sync_loss_after_media_keeps_identityless_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    int rc = 0;
+    state.lastsynctype = DSD_SYNC_DSTAR_VOICE_POS;
+
+    rc |= expect_int("identity-less D-STAR epoch starts",
+                     observe_test_call(&state, 0U, DSD_SYNC_DSTAR_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                                       DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    rc |= expect_int("voice media runs", dsd_call_state_update_media(&state, 0U, 1, g_observed_m), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("sync loss ends the reception", end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("audible D-STAR row reaches history", committed_history_rows(&event_history[0]), 1);
 
     dsd_state_ext_free_all(&state);
     return rc;
@@ -4096,6 +4165,8 @@ main(void) {
     rc |= test_media_terminated_identityless_voice_epoch_commits_row();
     rc |= test_retune_explicit_end_drops_identityless_media_row();
     rc |= test_dropped_identityless_row_rotates_wav_without_export();
+    rc |= test_terminator_after_fade_rescues_identityless_row();
+    rc |= test_dstar_sync_loss_after_media_keeps_identityless_row();
     rc |= test_end_alert_deadline_matches_reacquire_window();
     rc |= test_unverified_terminator_heal_window_is_tight();
     rc |= test_crypto_only_voice_epoch_commits_row();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -124,6 +124,7 @@ canonical_snapshot_reader(void* arg) {
 
 static int g_open_wav_count;
 static int g_close_wav_count;
+static int g_close_wav_export_count;
 static SNDFILE* g_open_wav_result;
 static double g_observed_m;
 
@@ -139,14 +140,17 @@ open_wav_file(char* dir, char* temp_filename, size_t temp_filename_size, uint16_
 }
 
 SNDFILE*
-close_and_rename_wav_file(SNDFILE* wav_file, const dsd_opts* opts, const char* wav_out_filename, const char* dir,
-                          const Event_History_I* event_struct) {
+close_and_rename_wav_file_ex(SNDFILE* wav_file, const dsd_opts* opts, const char* wav_out_filename, const char* dir,
+                             const Event_History_I* event_struct, int export_call) {
     UNUSED(wav_file);
     UNUSED(opts);
     UNUSED(wav_out_filename);
     UNUSED(dir);
     UNUSED(event_struct);
     g_close_wav_count++;
+    if (export_call) {
+        g_close_wav_export_count++;
+    }
     return NULL;
 }
 
@@ -1797,6 +1801,109 @@ test_retune_explicit_end_drops_identityless_media_row(void) {
     rc |= expect_int("verified terminator ends the epoch", end_test_call(&state, 0U, DSD_CALL_END_TERMINATOR), 1);
     dsd_event_sync_slot(&opts, &state, 0U);
     rc |= expect_int("terminator-ended audible row reaches history", committed_history_rows(&event_history[0]), 1);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The drop path still rotates the WAV -- leaving it open would let the noise segment's audio
+// lead the next transmission's recording -- but must not export it: the recording of an epoch
+// with no history row or log line would upload to rdio-scanner under all-zero metadata the
+// operator has nothing local to correlate against. A committed row's rotation still exports.
+static int
+test_dropped_identityless_row_rotates_wav_without_export(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    int rc = 0;
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    g_close_wav_count = 0;
+    g_close_wav_export_count = 0;
+
+    opts.wav_out_f = (SNDFILE*)0x1;
+    rc |= expect_int("noise epoch starts",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                                       DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    rc |= expect_int("noise media runs", dsd_call_state_update_media(&state, 0U, 1, g_observed_m), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("sync loss ends the noise epoch", end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("dropped row leaves no history", committed_history_rows(&event_history[0]), 0);
+    rc |= expect_int("dropped row still rotates the WAV", g_close_wav_count, 1);
+    rc |= expect_int("dropped row's rotation does not export", g_close_wav_export_count, 0);
+
+    // The committed shape keeps exporting: same rotation path, row reached history.
+    opts.wav_out_f = (SNDFILE*)0x1;
+    g_close_wav_count = 0;
+    rc |= expect_int("identified call begins",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 1234U, 5678U,
+                                       0U, 0U, DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("identified call ends", end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("committed row rotates the WAV", g_close_wav_count, 1);
+    rc |= expect_int("committed row's rotation exports", g_close_wav_export_count, 1);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// The held VOICE_END deadline must be selected by the same reason-keyed rule the canonical layer
+// applies to reacquisition: an unverified-terminator end stops accepting a heal after
+// DSD_CALL_TERMINATOR_HEAL_GAP_S, so its alert must not be withheld for the full sync-loss
+// window on top of that. Both deadlines are bracketed between two reads of the same clock the
+// arming site uses, so the assertions hold at any scheduler pace.
+static int
+test_end_alert_deadline_matches_reacquire_window(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START | DSD_CALL_ALERT_EVENT_VOICE_END;
+
+    int rc = 0;
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    dsd_call_context_snapshot context;
+
+    // Sync-loss end: held for the full reacquisition gap.
+    rc |= expect_int("identified call begins",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 1234U, 5678U,
+                                       0U, 0U, DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    double before = dsd_time_now_monotonic_s();
+    rc |= expect_int("sync loss ends it", end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    double after = dsd_time_now_monotonic_s();
+    rc |= expect_int("context snapshot copies", dsd_call_context_copy_snapshot(&state, &context) > 0, 1);
+    rc |= expect_int("sync-loss end holds the alert", context.events[0].end_alert_pending, 1);
+    rc |= expect_int("sync-loss deadline is not below its window",
+                     context.events[0].end_alert_due_m >= before + DSD_CALL_REACQUIRE_GAP_S, 1);
+    rc |= expect_int("sync-loss deadline is not above its window",
+                     context.events[0].end_alert_due_m <= after + DSD_CALL_REACQUIRE_GAP_S, 1);
+    dsd_event_flush_pending_alerts(&opts, &state);
+
+    // Unverified-terminator end: held only for the tighter heal gap.
+    rc |= expect_int("second identified call begins",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 4321U, 8765U,
+                                       0U, 0U, DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    before = dsd_time_now_monotonic_s();
+    rc |= expect_int("unverified terminator ends it", end_test_call(&state, 0U, DSD_CALL_END_UNVERIFIED_TERMINATOR), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    after = dsd_time_now_monotonic_s();
+    rc |= expect_int("second context snapshot copies", dsd_call_context_copy_snapshot(&state, &context) > 0, 1);
+    rc |= expect_int("unverified end holds the alert", context.events[0].end_alert_pending, 1);
+    rc |= expect_int("terminator deadline is not below the heal window",
+                     context.events[0].end_alert_due_m >= before + DSD_CALL_TERMINATOR_HEAL_GAP_S, 1);
+    rc |= expect_int("terminator deadline is not above the heal window",
+                     context.events[0].end_alert_due_m <= after + DSD_CALL_TERMINATOR_HEAL_GAP_S, 1);
+    dsd_event_flush_pending_alerts(&opts, &state);
 
     dsd_state_ext_free_all(&state);
     return rc;
@@ -3988,6 +4095,8 @@ main(void) {
     rc |= test_identityless_voice_epoch_commits_no_row();
     rc |= test_media_terminated_identityless_voice_epoch_commits_row();
     rc |= test_retune_explicit_end_drops_identityless_media_row();
+    rc |= test_dropped_identityless_row_rotates_wav_without_export();
+    rc |= test_end_alert_deadline_matches_reacquire_window();
     rc |= test_unverified_terminator_heal_window_is_tight();
     rc |= test_crypto_only_voice_epoch_commits_row();
     rc |= test_route_text_only_row_survives_epoch_change_commit();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -1698,6 +1698,66 @@ test_identityless_voice_epoch_commits_no_row(void) {
     return rc;
 }
 
+// An identity-less voice epoch that carried decoded audio and ended on a
+// terminator is a real transmission, not noise: on a RAS DMR system under the
+// aggressive-framesync default every link control fails the masked CRC, so a
+// short PTT whose embedded LC never reassembled plays audio yet never names a
+// call. Its row must reach history -- as the zero-ID record that a
+// transmission occurred -- and its deferred VOICE_END must fire once the
+// terminator repeat corroborates the end. A media-carrying epoch that merely
+// faded out (sync loss, no terminator) stays droppable: that is the
+// stray-sync noise shape.
+static int
+test_media_terminated_identityless_voice_epoch_commits_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START | DSD_CALL_ALERT_EVENT_VOICE_END;
+
+    int rc = 0;
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+
+    rc |= expect_int("provisional call starts epoch",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                                       DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    rc |= expect_int("voice media runs on the epoch", dsd_call_state_update_media(&state, 0U, 1, g_observed_m), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("terminator ends the epoch unverified",
+                     end_test_call(&state, 0U, DSD_CALL_END_UNVERIFIED_TERMINATOR), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("audible terminated row reaches history",
+                     event_history[0].Event_History_Items[1].event_string[0] != '\0', 1);
+    rc |= expect_int("row records that no one was named", (int)event_history[0].Event_History_Items[1].target_id, 0);
+    dsd_call_context_snapshot context;
+    rc |= expect_int("context snapshot copies", dsd_call_context_copy_snapshot(&state, &context) > 0, 1);
+    rc |= expect_int("recoverable end holds the VOICE_END alert", context.events[0].end_alert_pending, 1);
+    rc |= expect_int("only the start alert has fired", g_beeper_count, 1);
+
+    // The hangtime repeat -- itself unverified on a RAS system -- corroborates the end into
+    // EXPLICIT, releasing the held alert.
+    rc |= expect_int("corroborating terminator tightens the end",
+                     end_test_call(&state, 0U, DSD_CALL_END_UNVERIFIED_TERMINATOR), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("released VOICE_END alert fires", g_beeper_count, 2);
+
+    // A media-carrying epoch that fades out without a terminator is still the
+    // stray-sync noise shape and leaves no row.
+    rc |= expect_int("noise epoch starts",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                                       DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    rc |= expect_int("noise media runs", dsd_call_state_update_media(&state, 0U, 1, g_observed_m), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("sync loss ends the noise epoch", end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("noise row does not reach history", event_history[0].Event_History_Items[2].event_string[0], '\0');
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 // A voice epoch whose only decoded knowledge is its crypto -- encrypted, this
 // alg, this key -- is not noise. P25 late entry deliberately opens an
 // identity-less epoch so ESS crypto can attach; when the signal fades before
@@ -3828,6 +3888,7 @@ main(void) {
     rc |= test_canonical_voice_category_is_protocol_neutral();
     rc |= test_provisional_voice_identity_does_not_commit_zero_row();
     rc |= test_identityless_voice_epoch_commits_no_row();
+    rc |= test_media_terminated_identityless_voice_epoch_commits_row();
     rc |= test_crypto_only_voice_epoch_commits_row();
     rc |= test_route_text_only_row_survives_epoch_change_commit();
     rc |= test_standalone_provoice_zero_id_row_commits();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -1921,6 +1921,53 @@ test_dstar_sync_loss_after_media_keeps_identityless_row(void) {
     return rc;
 }
 
+// M17, YSF and NXDN each define an end marker but send it exactly once, behind a CRC or FICH
+// error check: an M17 stream whose transmitter drops carrier before the EOT, a YSF tail burst
+// whose FICH is corrupt, or a missed NXDN release SACCH all leave an audible reception ending by
+// sync loss. Demanding a terminator there deleted the row, the log line and the end alert and
+// left the rotated WAV an orphan, so a sync-loss end after media must vouch for them the way it
+// does for D-STAR -- while DMR, P25 and dPMR, whose end signaling repeats or rides the sync
+// correlator, keep dropping the same shape as the noise it is.
+static int
+test_unreliable_terminator_modes_keep_audible_identityless_rows(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+
+    static const int lenient[] = {DSD_SYNC_M17_STR_POS, DSD_SYNC_YSF_POS, DSD_SYNC_NXDN_POS};
+    static const int strict[] = {DSD_SYNC_DMR_BS_VOICE_POS, DSD_SYNC_P25P1_POS, DSD_SYNC_DPMR_FS2_POS};
+
+    int rc = 0;
+    for (size_t i = 0; i < sizeof(lenient) / sizeof(lenient[0]); i++) {
+        reset_fixture(&opts, &state, event_history);
+        state.lastsynctype = lenient[i];
+        rc |= expect_int(
+            "identity-less epoch starts",
+            observe_test_call(&state, 0U, lenient[i], DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U, DSD_CALL_BOUNDARY_BEGIN), 1);
+        rc |= expect_int("voice media runs", dsd_call_state_update_media(&state, 0U, 1, g_observed_m), 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+        rc |= expect_int("carrier drops before the end marker", end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS), 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+        rc |= expect_int("audible row survives the missed end marker", committed_history_rows(&event_history[0]), 1);
+        dsd_state_ext_free_all(&state);
+    }
+
+    for (size_t i = 0; i < sizeof(strict) / sizeof(strict[0]); i++) {
+        reset_fixture(&opts, &state, event_history);
+        state.lastsynctype = strict[i];
+        rc |= expect_int(
+            "identity-less epoch starts",
+            observe_test_call(&state, 0U, strict[i], DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U, DSD_CALL_BOUNDARY_BEGIN), 1);
+        rc |= expect_int("voice media runs", dsd_call_state_update_media(&state, 0U, 1, g_observed_m), 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+        rc |= expect_int("sync loss ends the noise epoch", end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS), 1);
+        dsd_event_sync_slot(&opts, &state, 0U);
+        rc |= expect_int("noise row still drops", committed_history_rows(&event_history[0]), 0);
+        dsd_state_ext_free_all(&state);
+    }
+    return rc;
+}
+
 // The held VOICE_END deadline must be selected by the same reason-keyed rule the canonical layer
 // applies to reacquisition: an unverified-terminator end stops accepting a heal after
 // DSD_CALL_TERMINATOR_HEAL_GAP_S, so its alert must not be withheld for the full sync-loss
@@ -4167,6 +4214,7 @@ main(void) {
     rc |= test_dropped_identityless_row_rotates_wav_without_export();
     rc |= test_terminator_after_fade_rescues_identityless_row();
     rc |= test_dstar_sync_loss_after_media_keeps_identityless_row();
+    rc |= test_unreliable_terminator_modes_keep_audible_identityless_rows();
     rc |= test_end_alert_deadline_matches_reacquire_window();
     rc |= test_unverified_terminator_heal_window_is_tight();
     rc |= test_crypto_only_voice_epoch_commits_row();

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -1647,6 +1647,57 @@ test_provisional_voice_identity_does_not_commit_zero_row(void) {
     return rc;
 }
 
+// A voice epoch that ends without ever learning an identity is noise, not a
+// call: a stray voice sync opened it and no header named anyone. Committing it
+// surfaced "TGT: 00000000; SRC: 00000000" rows in Activity history. The drop
+// must not arm the deferred VOICE_END alert either, matching the
+// empty-staged-row rule that an alert needs a row the operator can see, and
+// must leave the following identified call committing normally.
+static int
+test_identityless_voice_epoch_commits_no_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+    opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START | DSD_CALL_ALERT_EVENT_VOICE_END;
+
+    int rc = 0;
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.dmr_color_code = 13;
+
+    rc |= expect_int("provisional call starts epoch",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_VOICE, 0U, 0U, 0U, 0U,
+                                       DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("zero-identity row is staged",
+                     state.event_history_s[0].Event_History_Items[0].event_string[0] != '\0', 1);
+    rc |= expect_int("sync loss ends the epoch", end_test_call(&state, 0U, DSD_CALL_END_SYNC_LOSS), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("identity-less row does not reach history",
+                     event_history[0].Event_History_Items[1].event_string[0], '\0');
+    dsd_call_context_snapshot context;
+    rc |= expect_int("context snapshot copies", dsd_call_context_copy_snapshot(&state, &context) > 0, 1);
+    rc |= expect_int("dropped row arms no end alert", context.events[0].end_alert_pending, 0);
+    rc |= expect_int("dropped row emits only the start alert", g_beeper_count, 1);
+
+    // The next identified call on the slot is unaffected by the drop.
+    rc |= expect_int("identified call begins",
+                     observe_test_call(&state, 0U, DSD_SYNC_DMR_BS_VOICE_POS, DSD_CALL_KIND_GROUP_VOICE, 1234U, 5678U,
+                                       0U, 0U, DSD_CALL_BOUNDARY_BEGIN),
+                     1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("identified call ends", end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT), 1);
+    dsd_event_sync_slot(&opts, &state, 0U);
+    rc |= expect_int("identified row reaches history", (int)event_history[0].Event_History_Items[1].target_id, 1234);
+    rc |= expect_int("only the identified row is in history", event_history[0].Event_History_Items[2].event_string[0],
+                     '\0');
+    rc |= expect_int("identified call emits start and end alerts", g_beeper_count, 3);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 static int
 test_new_canonical_epoch_commits_prior_canonical_call(void) {
     static dsd_opts opts;
@@ -1896,8 +1947,9 @@ test_identityless_ended_epoch_does_not_reacquire(void) {
     assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
     dsd_event_sync_slot(&opts, &state, 0U);
 
-    int rc = expect_int("unrelated call after an identity-less end gets its own row",
-                        committed_history_rows(&event_history[0]), 2);
+    // The identity-less epoch's own row is dropped -- it never named a call -- so only the
+    // unrelated call's row reaches history, un-coalesced and with its own START.
+    int rc = expect_int("only the unrelated call's row reaches history", committed_history_rows(&event_history[0]), 1);
     rc |=
         expect_int("unrelated call keeps its own target", (int)event_history[0].Event_History_Items[1].target_id, 500);
     rc |= expect_int("unrelated call still alerts START", g_beeper_count, 2);
@@ -2076,10 +2128,12 @@ test_back_to_back_same_identity_calls_commit_two_rows(void) {
     return rc;
 }
 
-// A terminator followed by an identity-less reopen inside the window must still commit twice:
-// the transmission that terminated is over, whatever decodes next is new.
+// A terminator followed by an identity-less reopen inside the window: the transmission that
+// terminated is over, and whatever decodes next is a new epoch, never a merge into the ended
+// row. The reopen itself never names a call, so it leaves no row of its own -- the terminated
+// call's row must survive untouched as the only one.
 static int
-test_explicit_end_then_identityless_reopen_commits_two_rows(void) {
+test_explicit_end_then_identityless_reopen_leaves_single_row(void) {
     static dsd_opts opts;
     static dsd_state state;
     static Event_History_I event_history[2];
@@ -2099,7 +2153,9 @@ test_explicit_end_then_identityless_reopen_commits_two_rows(void) {
     assert(end_test_call(&state, 0U, DSD_CALL_END_EXPLICIT) == 1);
     dsd_event_sync_slot(&opts, &state, 0U);
 
-    int rc = expect_int("explicit end never coalesces", committed_history_rows(&event_history[0]), 2);
+    int rc = expect_int("only the terminated call's row is in history", committed_history_rows(&event_history[0]), 1);
+    rc |= expect_int("terminated call's row is not merged into or replaced",
+                     (int)event_history[0].Event_History_Items[1].target_id, 100);
     dsd_state_ext_free_all(&state);
     return rc;
 }
@@ -3674,6 +3730,7 @@ main(void) {
     rc |= test_canonical_call_lifecycle_is_epoch_driven();
     rc |= test_canonical_voice_category_is_protocol_neutral();
     rc |= test_provisional_voice_identity_does_not_commit_zero_row();
+    rc |= test_identityless_voice_epoch_commits_no_row();
     rc |= test_new_canonical_epoch_commits_prior_canonical_call();
     rc |= test_reacquired_transmission_commits_one_row();
     rc |= test_terminator_after_sync_loss_end_blocks_reacquisition();
@@ -3691,7 +3748,7 @@ main(void) {
     rc |= test_reacquisition_after_uncommitted_epoch_does_not_merge_stale_row();
     rc |= test_reacquired_transmission_via_continue_commits_one_row();
     rc |= test_back_to_back_same_identity_calls_commit_two_rows();
-    rc |= test_explicit_end_then_identityless_reopen_commits_two_rows();
+    rc |= test_explicit_end_then_identityless_reopen_leaves_single_row();
     rc |= test_changed_identity_still_commits_its_own_row();
     rc |= test_reacquisition_gap_beyond_window_commits_two_rows();
     rc |= test_reacquired_segment_may_outlast_the_window();

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -770,11 +770,12 @@ test_td_lc_resets_slot_call_privacy_and_alias_state(void) {
 // A terminator whose link control failed RS(12,9) still ends the call -- on
 // RAS systems under the aggressive default every LC fails the masked CRC, so
 // gating the end on the CRC would leave those calls active forever -- but with
-// the recoverable sync-loss reason, so a voice burst mis-typed as a terminator
-// mid-call is healed by the next same-identity observation reacquiring the
-// epoch instead of splitting the transmission in two. The slot's payload
-// crypto and alias state resets either way: keeping it would let the next call
-// on the slot inherit a stale algid/key/MI or half-built alias.
+// the recoverable unverified-terminator reason, so a voice burst mis-typed as
+// a terminator mid-call is healed by the next identity-less media mark
+// reacquiring the epoch instead of splitting the transmission in two. The
+// slot's payload crypto and alias state resets either way: keeping it would
+// let the next call on the slot inherit a stale algid/key/MI or half-built
+// alias.
 static void
 test_unverified_terminator_ends_call_recoverably(void) {
     static dsd_opts opts;
@@ -789,12 +790,12 @@ test_unverified_terminator_ends_call_recoverably(void) {
     assert(irr == 0);
     assert_td_lc_slot_reset(&state, 0U);
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
-    assert(call.end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR);
 
-    // A repeated unverified terminator on the sync-loss-ended epoch is positive
-    // evidence the transmission is over: it tightens the reason to explicit, so
-    // a second PTT on the same identity inside the reacquisition gap cannot
-    // fold into the terminated call's row.
+    // A repeated unverified terminator corroborates the unverified end -- two
+    // independently mis-typed bursts in a row is not a plausible fade -- so the
+    // reason tightens to explicit, which retracts the reacquisition permission
+    // and releases the held VOICE_END alert where the hangtime repeat runs.
     irr = 0;
     build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
     dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
@@ -810,6 +811,96 @@ test_unverified_terminator_ends_call_recoverably(void) {
     dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
     assert(irr == 0);
     assert_td_lc_slot_reset(&state, 0U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+    dsd_state_ext_free_all(&state);
+}
+
+// After an unverified terminator ends the call, what may reopen its epoch
+// depends on what the next observation carries. The identity-less media mark
+// the vocoder emits when a voice burst was mis-typed as a terminator heals the
+// epoch -- same transmission, one row. A same-identity voice LC header inside
+// the reacquisition gap is the next PTT's preamble and must open its own
+// epoch: the terminator was positive evidence the previous transmission
+// ended, and folding the header in would merge two calls into one row.
+static void
+test_unverified_terminator_reopen_depends_on_identity(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_call_snapshot call;
+
+    // Identity-less media mark: heals the epoch in place.
+    seed_td_lc_slot(&opts, &state, 0U);
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR);
+    const uint64_t ended_epoch = call.epoch;
+
+    const dsd_call_observation media_mark = {
+        .protocol = DSD_SYNC_DMR_BS_VOICE_POS,
+        .slot = 0U,
+        .kind = DSD_CALL_KIND_VOICE,
+    };
+    assert(dsd_call_state_observe(&state, &media_mark, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.phase == DSD_CALL_PHASE_ACTIVE);
+    assert(call.epoch != ended_epoch);
+    // Reacquired, not new: the healed epoch keeps the terminated call's identity.
+    assert(call.ota_source_id == 2002U);
+    assert(call.ota_target_id == 1001U);
+
+    // Same-identity header after the unverified end: the next transmission.
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR);
+    const uint64_t second_ended_epoch = call.epoch;
+
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.phase == DSD_CALL_PHASE_ACTIVE);
+    assert(call.epoch != second_ended_epoch);
+    assert(call.ota_source_id == 2002U);
+    // A fresh epoch, not a reacquisition: the new PTT does not merge into the
+    // terminated call's row.
+    dsd_call_context_snapshot context;
+    assert(dsd_call_context_copy_snapshot(&state, &context) > 0);
+    assert(context.events[0].reacquired_epoch != call.epoch);
+    dsd_state_ext_free_all(&state);
+}
+
+// An unverified terminator arriving after a sync loss already ended the epoch
+// is the same fallible evidence the recoverable end exists to distrust: it
+// must not tighten the reason to explicit, or a single corrupt burst mis-typed
+// as a terminator during a fade would retract the reacquisition permission and
+// split the resuming transmission in two.
+static void
+test_unverified_terminator_does_not_tighten_sync_loss_end(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_call_snapshot call;
+
+    seed_td_lc_slot(&opts, &state, 0U);
+    assert(dsd_call_state_end_ex(&state, 0U, 0.0, DSD_CALL_END_SYNC_LOSS) == 1);
+
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.phase == DSD_CALL_PHASE_ENDED);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS);
+
+    // A verified terminator is trustworthy evidence and does retract it.
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
     assert(call.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
     dsd_state_ext_free_all(&state);
@@ -1429,6 +1520,8 @@ main(void) {
     test_stale_headerless_epoch_does_not_absorb_next_header();
     test_repeated_voice_lc_headers_commit_one_history_row();
     test_unverified_terminator_ends_call_recoverably();
+    test_unverified_terminator_reopen_depends_on_identity();
+    test_unverified_terminator_does_not_tighten_sync_loss_end();
     test_flco_output_uses_real_newlines();
     test_ms_direct_flco_reports_internal_slot_one();
     test_single_slot_flco_forces_slot_one_context();

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -766,6 +766,37 @@ test_td_lc_resets_slot_call_privacy_and_alias_state(void) {
     dsd_state_ext_free_all(&state);
 }
 
+// A terminator whose link control failed RS(12,9) must not end the call or wipe
+// the slot's payload state: a mis-typed burst would otherwise close a live
+// transmission with the un-recoverable explicit reason and drop its crypto and
+// alias state mid-call. A genuinely missed terminator is picked up by the
+// no-carrier path as a recoverable sync-loss end instead.
+static void
+test_unverified_terminator_keeps_call_active(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+
+    seed_td_lc_slot(&opts, &state, 0U);
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(irr == 0);
+    assert_call(&state, 0U, DSD_CALL_PHASE_ACTIVE, DSD_CALL_KIND_GROUP_VOICE, 1001U, 2002U);
+    assert(state.payload_algid == 0x22);
+    assert(state.payload_keyid == 0x33);
+    assert(state.payload_mi == 0x123456789AULL);
+    assert(strcmp(state.generic_talker_alias[0], "alias") == 0);
+
+    // The verified terminator still ends the call and resets the slot.
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
+    assert(irr == 0);
+    assert_td_lc_slot_reset(&state, 0U);
+    dsd_state_ext_free_all(&state);
+}
+
 static void
 test_capacity_plus_rest_channel_and_call_class_are_packed_fields(void) {
     static dsd_opts opts;
@@ -1175,11 +1206,15 @@ test_completed_slco_capacity_plus_hold_returns_to_rest_channel(void) {
     dsd_state_ext_free_all(&state);
 }
 
-// Each Voice LC Header marks a transmission boundary, including a same-identity
-// re-key after a missed terminator. Embedded LCs re-describe the active call and
+// The voice LC header repeats through the start of a transmission for late
+// entry, always before the first voice superframe. Repeats that re-describe the
+// running call stay in its epoch; a second epoch would commit the first one's
+// freshly built row as a duplicate event. Once voice media has run, an
+// identical header is a same-identity re-key after a missed terminator and
+// marks a transmission boundary. Embedded LCs re-describe the active call and
 // must remain in its epoch.
 static void
-test_voice_lc_header_starts_epoch_and_embedded_lc_continues(void) {
+test_repeated_voice_lc_header_keeps_one_epoch(void) {
     static dsd_opts opts;
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof(opts));
@@ -1206,13 +1241,32 @@ test_voice_lc_header_starts_epoch_and_embedded_lc_continues(void) {
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
     assert(call.epoch == first_epoch);
 
-    // A new header starts the next transmission even if its identity matches.
+    // A header repeat before any voice media is the same transmission.
     irr = 0;
     build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
     dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
-    assert(call.epoch != first_epoch);
+    assert(call.epoch == first_epoch);
     assert(call.ota_source_id == 2002U);
+
+    // A header naming a different talker is the next transmission, not a repeat.
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 5005U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.epoch != first_epoch);
+    assert(call.ota_source_id == 5005U);
+    const uint64_t talker_epoch = call.epoch;
+
+    // Once the epoch has carried voice media, an identical header is a
+    // same-identity re-key after a missed terminator: a new transmission.
+    assert(dsd_call_state_update_media(&state, 0U, 1, 0.0) > 0);
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 5005U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.epoch != talker_epoch);
+    assert(call.ota_source_id == 5005U);
     const uint64_t second_epoch = call.epoch;
 
     // A header after the terminator opens the following transmission.
@@ -1246,11 +1300,70 @@ test_voice_lc_header_starts_epoch_and_embedded_lc_continues(void) {
     dsd_state_ext_free_all(&state);
 }
 
+// One transmission whose voice LC header repeats must leave exactly one row in
+// event history: the repeats stay in the first epoch instead of each minting an
+// epoch whose change commits the previous epoch's freshly built row again.
+// Reported in discussion #152.
+static void
+test_repeated_voice_lc_headers_commit_one_history_row(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(event_history, 0, sizeof(event_history));
+    state.event_history_s = event_history;
+    init_event_history(&event_history[0], 0, 255);
+    init_event_history(&event_history[1], 0, 255);
+    state.currentslot = 0;
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    state.lastsynctype = DSD_SYNC_DMR_BS_VOICE_POS;
+
+    dsd_test_capture_stderr cap;
+    assert(dsd_test_capture_stderr_begin(&cap, "dmr_flco_one_row") == 0);
+
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    for (int header = 0; header < 3; header++) {
+        irr = 0;
+        build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1001U, 2002U);
+        dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    }
+    for (int emb = 0; emb < 3; emb++) {
+        irr = 0;
+        build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1001U, 2002U);
+        dmr_flco(&opts, &state, bits, 1U, &irr, 3U);
+    }
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
+
+    assert(dsd_test_capture_stderr_end(&cap) == 0);
+    (void)remove(cap.path);
+
+    dsd_call_snapshot call;
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.phase == DSD_CALL_PHASE_ENDED);
+
+    int rows = 0;
+    for (int i = 1; i < 255; i++) {
+        if (event_history[0].Event_History_Items[i].event_string[0] != '\0') {
+            rows++;
+        }
+    }
+    assert(rows == 1);
+    assert(event_history[0].Event_History_Items[1].target_id == 1001U);
+    assert(event_history[0].Event_History_Items[1].source_id == 2002U);
+    dsd_state_ext_free_all(&state);
+}
+
 int
 main(void) {
     InitAllFecFunction();
 
-    test_voice_lc_header_starts_epoch_and_embedded_lc_continues();
+    test_repeated_voice_lc_header_keeps_one_epoch();
+    test_repeated_voice_lc_headers_commit_one_history_row();
+    test_unverified_terminator_keeps_call_active();
     test_flco_output_uses_real_newlines();
     test_ms_direct_flco_reports_internal_slot_one();
     test_single_slot_flco_forces_slot_one_context();

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -10,6 +10,7 @@
 
 #include <assert.h>
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
@@ -766,34 +767,51 @@ test_td_lc_resets_slot_call_privacy_and_alias_state(void) {
     dsd_state_ext_free_all(&state);
 }
 
-// A terminator whose link control failed RS(12,9) must not end the call or wipe
-// the slot's payload state: a mis-typed burst would otherwise close a live
-// transmission with the un-recoverable explicit reason and drop its crypto and
-// alias state mid-call. A genuinely missed terminator is picked up by the
-// no-carrier path as a recoverable sync-loss end instead.
+// A terminator whose link control failed RS(12,9) still ends the call -- on
+// RAS systems under the aggressive default every LC fails the masked CRC, so
+// gating the end on the CRC would leave those calls active forever -- but with
+// the recoverable sync-loss reason, so a voice burst mis-typed as a terminator
+// mid-call is healed by the next same-identity observation reacquiring the
+// epoch instead of splitting the transmission in two. The slot's payload
+// crypto and alias state resets either way: keeping it would let the next call
+// on the slot inherit a stale algid/key/MI or half-built alias.
 static void
-test_unverified_terminator_keeps_call_active(void) {
+test_unverified_terminator_ends_call_recoverably(void) {
     static dsd_opts opts;
     static dsd_state state;
     uint8_t bits[80];
     uint32_t irr = 0;
+    dsd_call_snapshot call;
 
     seed_td_lc_slot(&opts, &state, 0U);
     build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
     dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
     assert(irr == 0);
-    assert_call(&state, 0U, DSD_CALL_PHASE_ACTIVE, DSD_CALL_KIND_GROUP_VOICE, 1001U, 2002U);
-    assert(state.payload_algid == 0x22);
-    assert(state.payload_keyid == 0x33);
-    assert(state.payload_mi == 0x123456789AULL);
-    assert(strcmp(state.generic_talker_alias[0], "alias") == 0);
+    assert_td_lc_slot_reset(&state, 0U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS);
 
-    // The verified terminator still ends the call and resets the slot.
+    // A repeated unverified terminator on the sync-loss-ended epoch is positive
+    // evidence the transmission is over: it tightens the reason to explicit, so
+    // a second PTT on the same identity inside the reacquisition gap cannot
+    // fold into the terminated call's row.
     irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(irr == 0);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.phase == DSD_CALL_PHASE_ENDED);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+
+    // The verified terminator ends explicitly in one step.
+    irr = 0;
+    seed_td_lc_slot(&opts, &state, 0U);
     build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
     dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
     assert(irr == 0);
     assert_td_lc_slot_reset(&state, 0U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
     dsd_state_ext_free_all(&state);
 }
 
@@ -1300,6 +1318,52 @@ test_repeated_voice_lc_header_keeps_one_epoch(void) {
     dsd_state_ext_free_all(&state);
 }
 
+// Header repeats only precede the transmission's first voice superframe, so an
+// active epoch that has gone longer than the repeat window without a single
+// decodable voice frame stops absorbing same-identity headers: the next
+// identical header is a new transmission, not a preamble repeat. Without the
+// bound, a header-only epoch whose voice bursts all failed to decode would
+// swallow a PTT on the same talkgroup minutes later as a continuation.
+static void
+test_stale_headerless_epoch_does_not_absorb_next_header(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+
+    // A header-shaped epoch whose start predates the repeat window, with no
+    // voice media ever marked on it.
+    const dsd_call_observation stale = {
+        .protocol = DSD_SYNC_DMR_BS_VOICE_POS,
+        .slot = 0U,
+        .kind = DSD_CALL_KIND_GROUP_VOICE,
+        .ota_target_id = 1001U,
+        .policy_target_id = 1001U,
+        .ota_source_id = 2002U,
+        .observed_m = dsd_time_now_monotonic_s() - 10.0,
+    };
+    assert(dsd_call_state_observe(&state, &stale, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    dsd_call_snapshot call;
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    const uint64_t stale_epoch = call.epoch;
+
+    dsd_test_capture_stderr cap;
+    assert(dsd_test_capture_stderr_begin(&cap, "dmr_flco_stale_header") == 0);
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    assert(dsd_test_capture_stderr_end(&cap) == 0);
+    (void)remove(cap.path);
+
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.phase == DSD_CALL_PHASE_ACTIVE);
+    assert(call.epoch != stale_epoch);
+    assert(call.ota_source_id == 2002U);
+    dsd_state_ext_free_all(&state);
+}
+
 // One transmission whose voice LC header repeats must leave exactly one row in
 // event history: the repeats stay in the first epoch instead of each minting an
 // epoch whose change commits the previous epoch's freshly built row again.
@@ -1362,8 +1426,9 @@ main(void) {
     InitAllFecFunction();
 
     test_repeated_voice_lc_header_keeps_one_epoch();
+    test_stale_headerless_epoch_does_not_absorb_next_header();
     test_repeated_voice_lc_headers_commit_one_history_row();
-    test_unverified_terminator_keeps_call_active();
+    test_unverified_terminator_ends_call_recoverably();
     test_flco_output_uses_real_newlines();
     test_ms_direct_flco_reports_internal_slot_one();
     test_single_slot_flco_forces_slot_one_context();

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -1024,6 +1024,46 @@ test_data_terminator_does_not_end_voice_call(void) {
     dsd_state_ext_free_all(&state);
 }
 
+// A protected LC hides its own FLCO -- the payload bits are ciphertext -- so a protected
+// terminator burst whose scrambled FLCO happens to decode as 0x30 must not be trusted as a
+// TD_LC: the slot's voice call still ends (recoverably, like every unreadable terminator
+// shape), but a live data session's reassembly state stays intact instead of being wiped on
+// ciphertext.
+static void
+test_protected_td_lc_shape_does_not_wipe_data_session(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_call_snapshot call;
+
+    seed_td_lc_slot(&opts, &state, 0U);
+    state.data_header_format[0] = 2;
+    state.data_header_sap[0] = 4;
+    state.data_header_valid[0] = 1;
+    state.data_conf_data[0] = 1;
+    state.data_block_poc[0] = 3;
+    state.data_byte_ctr[0] = 42;
+    state.data_ks_start[0] = 5;
+
+    build_regular_flco(bits, 0x30U, 0x00U, 0x00U, 0U, 0U);
+    bits[0] = 1; /* pf: the LC payload, including its FLCO, is ciphertext */
+    dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
+    assert(irr == 0);
+
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.phase == DSD_CALL_PHASE_ENDED);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR);
+    assert(state.data_header_format[0] == 2);
+    assert(state.data_header_sap[0] == 4);
+    assert(state.data_header_valid[0] == 1);
+    assert(state.data_conf_data[0] == 1);
+    assert(state.data_block_poc[0] == 3);
+    assert(state.data_byte_ctr[0] == 42);
+    assert(state.data_ks_start[0] == 5);
+    dsd_state_ext_free_all(&state);
+}
+
 // A voice burst mis-typed as a terminator clears the slot's live crypto before
 // the identity-less media mark reopens the epoch, but the terminator handler
 // stashed the live fields first. The heal restores them so the encrypted
@@ -1859,6 +1899,7 @@ main(void) {
     test_unverified_terminator_does_not_tighten_sync_loss_end();
     test_terminator_ends_call_despite_unreadable_lc();
     test_data_terminator_does_not_end_voice_call();
+    test_protected_td_lc_shape_does_not_wipe_data_session();
     test_reacquired_epoch_restores_cleared_slot_crypto();
     test_heal_restores_live_mi_and_basic_privacy_fid();
     test_stale_heal_stash_does_not_leak_into_later_call();

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -1239,6 +1239,76 @@ test_stale_heal_stash_does_not_leak_into_later_call(void) {
     dsd_state_ext_free_all(&state);
 }
 
+// The terminator that explains a fade usually arrives after the fade already ended the epoch by
+// sync loss. It cannot tighten that end, but its reset still clears the slot, so the stash must
+// cover a recoverably-ended epoch and not only an active one: otherwise a resumption inside the
+// window comes back with the snapshot claiming encryption and the vocoder holding nothing.
+static void
+test_terminator_after_sync_loss_end_still_stashes_crypto(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_call_snapshot call;
+
+    // An encrypted call whose crypto reached the canonical snapshot, then a fade.
+    seed_td_lc_slot(&opts, &state, 0U);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    assert(dsd_call_state_end_ex(&state, 0U, 0.0, DSD_CALL_END_SYNC_LOSS) == 1);
+
+    // The FEC-failed terminator that explains the fade: the sync-loss end stands, the slot
+    // resets, and the stash is taken against the still-reacquirable epoch.
+    irr = 1;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS);
+    assert(state.payload_algid == 0);
+    assert(state.payload_mi == 0ULL);
+    assert(state.dmr_heal_valid[0] == 1U);
+
+    // Voice resumes inside the window: the healed epoch decrypts again.
+    const dsd_call_observation media_mark = {
+        .protocol = DSD_SYNC_DMR_BS_VOICE_POS,
+        .slot = 0U,
+        .kind = DSD_CALL_KIND_VOICE,
+    };
+    assert(dsd_call_state_observe(&state, &media_mark, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    assert(state.dmr_so == 0x40U);
+    assert(state.payload_algid == 0x22);
+    assert(state.payload_keyid == 0x33);
+    assert(state.payload_mi == 0x123456789AULL);
+    dsd_state_ext_free_all(&state);
+}
+
+// A stash outlives its usefulness the moment the end becomes final. A verified terminator says
+// so outright; a corroborating repeat tightens an unverified end into TERMINATOR after the stash
+// was already taken, so the stash has to be dropped on the settled reason rather than on the
+// burst that was just read.
+static void
+test_corroborated_terminator_drops_the_heal_stash(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_call_snapshot call;
+
+    seed_td_lc_slot(&opts, &state, 0U);
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(state.dmr_heal_valid[0] == 1U);
+
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_TERMINATOR);
+    assert(state.dmr_heal_valid[0] == 0U);
+    dsd_state_ext_free_all(&state);
+}
+
 // A Hytera-Enhanced-shaped LC (fid 0x68, flco 0x02, valid vendor checksum) arriving as an
 // FEC-failed terminator burst: the terminator transition has already ended the call, stashed
 // the live crypto, and reset the slot, so the Hytera Enhanced handler must not run afterward
@@ -1903,6 +1973,8 @@ main(void) {
     test_reacquired_epoch_restores_cleared_slot_crypto();
     test_heal_restores_live_mi_and_basic_privacy_fid();
     test_stale_heal_stash_does_not_leak_into_later_call();
+    test_terminator_after_sync_loss_end_still_stashes_crypto();
+    test_corroborated_terminator_drops_the_heal_stash();
     test_irrecoverable_hytera_terminator_does_not_repopulate_crypto();
     test_flco_output_uses_real_newlines();
     test_ms_direct_flco_reports_internal_slot_one();

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -906,6 +906,165 @@ test_unverified_terminator_does_not_tighten_sync_loss_end(void) {
     dsd_state_ext_free_all(&state);
 }
 
+// The terminator's burst type is FEC-protected separately from its LC payload,
+// so a terminator whose LC cannot be read -- irrecoverable FEC errors, a
+// protected LC, or an unknown vendor FID whose dispatch returns early -- still
+// ends the slot's call instead of leaving it to fade into a sync-loss end the
+// next same-identity transmission could merge into.
+static void
+test_terminator_ends_call_despite_unreadable_lc(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_call_snapshot call;
+
+    // Irrecoverable LC FEC errors: the burst type alone ends the call, with
+    // the recoverable unverified reason since the CRC could not vouch for it.
+    seed_td_lc_slot(&opts, &state, 0U);
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    irr = 1;
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(irr == 1);
+    assert_td_lc_slot_reset(&state, 0U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR);
+
+    // Protected LC with a verified CRC: an intact terminator, explicit end.
+    irr = 0;
+    seed_td_lc_slot(&opts, &state, 0U);
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    bits[0] = 1U;
+    dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
+    assert(irr == 0);
+    assert_td_lc_slot_reset(&state, 0U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+
+    // Unknown vendor FID: the no-error dispatch returns early for the LC, but
+    // the terminator transition has already run.
+    irr = 0;
+    seed_td_lc_slot(&opts, &state, 0U);
+    build_regular_flco(bits, 0x00U, 0x2AU, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
+    assert(irr == 0);
+    assert_td_lc_slot_reset(&state, 0U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+    dsd_state_ext_free_all(&state);
+}
+
+// A cleanly read TD_LC terminates a data session, not the slot's voice call:
+// the voice call state and its live crypto stay untouched, with or without a
+// verified CRC (RAS masks the CRC on every LC).
+static void
+test_data_terminator_does_not_end_voice_call(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+
+    seed_td_lc_slot(&opts, &state, 0U);
+    build_regular_flco(bits, 0x30U, 0x00U, 0x00U, 0U, 0U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
+    assert(irr == 0);
+    assert_call(&state, 0U, DSD_CALL_PHASE_ACTIVE, DSD_CALL_KIND_GROUP_VOICE, 1001U, 2002U);
+    assert(state.payload_algid == 0x22);
+    assert(state.dmr_so == 0x40U);
+    assert(state.data_header_format[0] == 7);
+
+    irr = 0;
+    build_regular_flco(bits, 0x30U, 0x00U, 0x00U, 0U, 0U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(irr == 0);
+    assert_call(&state, 0U, DSD_CALL_PHASE_ACTIVE, DSD_CALL_KIND_GROUP_VOICE, 1001U, 2002U);
+    assert(state.payload_algid == 0x22);
+    dsd_state_ext_free_all(&state);
+}
+
+// A voice burst mis-typed as a terminator clears the slot's live crypto before
+// the identity-less media mark reopens the epoch, but the ending snapshot
+// retained the call's crypto. Reacquisition copies it back so the healed
+// continuation of an encrypted call keeps decrypting; an epoch that ends for
+// real starts the next call from cleared crypto as before.
+static void
+test_reacquired_epoch_restores_cleared_slot_crypto(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_call_snapshot call;
+
+    // An encrypted call whose crypto reached the canonical snapshot.
+    seed_td_lc_slot(&opts, &state, 0U);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.algid == 0x22U);
+    assert(call.mi == 0x123456789AULL);
+
+    // A CRC-failed terminator -- possibly a mis-typed voice burst -- ends the
+    // call recoverably and runs the slot reset.
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(state.dmr_so == 0U);
+    assert(state.payload_algid == 0);
+    assert(state.payload_mi == 0ULL);
+
+    // The healing media mark reacquires the epoch and restores the decoder's
+    // live slot crypto from the retained snapshot.
+    const dsd_call_observation media_mark = {
+        .protocol = DSD_SYNC_DMR_BS_VOICE_POS,
+        .slot = 0U,
+        .kind = DSD_CALL_KIND_VOICE,
+    };
+    assert(dsd_call_state_observe(&state, &media_mark, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    assert(state.dmr_so == 0x40U);
+    assert(state.payload_algid == 0x22);
+    assert(state.payload_keyid == 0x33);
+    assert(state.payload_mi == 0x123456789AULL);
+
+    // A corroborated end is not recoverable: the media mark opens a fresh
+    // epoch and nothing is restored.
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+    assert(dsd_call_state_observe(&state, &media_mark, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    assert(state.dmr_so == 0U);
+    assert(state.payload_algid == 0);
+    assert(state.payload_mi == 0ULL);
+
+    // Slot 1 restores through the R-side fields.
+    irr = 0;
+    seed_td_lc_slot(&opts, &state, 1U);
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 3003U, 4004U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 3003U, 4004U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(state.dmr_soR == 0U);
+    assert(state.payload_algidR == 0);
+    const dsd_call_observation media_mark_r = {
+        .protocol = DSD_SYNC_DMR_BS_VOICE_POS,
+        .slot = 1U,
+        .kind = DSD_CALL_KIND_VOICE,
+    };
+    assert(dsd_call_state_observe(&state, &media_mark_r, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    assert(state.dmr_soR == 0x40U);
+    assert(state.payload_algidR == 0x44);
+    assert(state.payload_keyidR == 0x55);
+    assert(state.payload_miR == 0xABCDEF0123ULL);
+    dsd_state_ext_free_all(&state);
+}
+
 static void
 test_capacity_plus_rest_channel_and_call_class_are_packed_fields(void) {
     static dsd_opts opts;
@@ -1522,6 +1681,9 @@ main(void) {
     test_unverified_terminator_ends_call_recoverably();
     test_unverified_terminator_reopen_depends_on_identity();
     test_unverified_terminator_does_not_tighten_sync_loss_end();
+    test_terminator_ends_call_despite_unreadable_lc();
+    test_data_terminator_does_not_end_voice_call();
+    test_reacquired_epoch_restores_cleared_slot_crypto();
     test_flco_output_uses_real_newlines();
     test_ms_direct_flco_reports_internal_slot_one();
     test_single_slot_flco_forces_slot_one_context();

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -794,17 +794,20 @@ test_unverified_terminator_ends_call_recoverably(void) {
 
     // A repeated unverified terminator corroborates the unverified end -- two
     // independently mis-typed bursts in a row is not a plausible fade -- so the
-    // reason tightens to explicit, which retracts the reacquisition permission
-    // and releases the held VOICE_END alert where the hangtime repeat runs.
+    // reason tightens to the final terminator reason, which retracts the
+    // reacquisition permission and releases the held VOICE_END alert where the
+    // hangtime repeat runs.
     irr = 0;
     build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
     dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
     assert(irr == 0);
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
     assert(call.phase == DSD_CALL_PHASE_ENDED);
-    assert(call.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_TERMINATOR);
 
-    // The verified terminator ends explicitly in one step.
+    // The verified terminator ends with the final terminator reason in one
+    // step -- not EXPLICIT, which is the engine's retune/teardown reason and
+    // says nothing about the air.
     irr = 0;
     seed_td_lc_slot(&opts, &state, 0U);
     build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
@@ -812,7 +815,7 @@ test_unverified_terminator_ends_call_recoverably(void) {
     assert(irr == 0);
     assert_td_lc_slot_reset(&state, 0U);
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
-    assert(call.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_TERMINATOR);
     dsd_state_ext_free_all(&state);
 }
 
@@ -902,7 +905,7 @@ test_unverified_terminator_does_not_tighten_sync_loss_end(void) {
     build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
     dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
-    assert(call.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_TERMINATOR);
     dsd_state_ext_free_all(&state);
 }
 
@@ -930,7 +933,11 @@ test_terminator_ends_call_despite_unreadable_lc(void) {
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
     assert(call.end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR);
 
-    // Protected LC with a verified CRC: an intact terminator, explicit end.
+    // Protected LC, even with a verified CRC: the FLCO is hidden, so the burst
+    // cannot rule out being a TD_LC that terminates a data session rather than
+    // the slot's voice call. It ends the call only recoverably, so a data
+    // terminator arriving mid-voice-call heals on the next media mark instead
+    // of hard-ending the voice call.
     irr = 0;
     seed_td_lc_slot(&opts, &state, 0U);
     build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
@@ -939,10 +946,11 @@ test_terminator_ends_call_despite_unreadable_lc(void) {
     assert(irr == 0);
     assert_td_lc_slot_reset(&state, 0U);
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
-    assert(call.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR);
 
     // Unknown vendor FID: the no-error dispatch returns early for the LC, but
-    // the terminator transition has already run.
+    // the terminator transition has already run, and the clean unprotected CRC
+    // makes it a verified end.
     irr = 0;
     seed_td_lc_slot(&opts, &state, 0U);
     build_regular_flco(bits, 0x00U, 0x2AU, 0x00U, 1001U, 2002U);
@@ -950,7 +958,7 @@ test_terminator_ends_call_despite_unreadable_lc(void) {
     assert(irr == 0);
     assert_td_lc_slot_reset(&state, 0U);
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
-    assert(call.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_TERMINATOR);
     dsd_state_ext_free_all(&state);
 }
 
@@ -983,10 +991,10 @@ test_data_terminator_does_not_end_voice_call(void) {
 }
 
 // A voice burst mis-typed as a terminator clears the slot's live crypto before
-// the identity-less media mark reopens the epoch, but the ending snapshot
-// retained the call's crypto. Reacquisition copies it back so the healed
-// continuation of an encrypted call keeps decrypting; an epoch that ends for
-// real starts the next call from cleared crypto as before.
+// the identity-less media mark reopens the epoch, but the terminator handler
+// stashed the live fields first. The heal restores them so the encrypted
+// continuation keeps decrypting; an epoch that ends for real starts the next
+// call from cleared crypto as before.
 static void
 test_reacquired_epoch_restores_cleared_slot_crypto(void) {
     static dsd_opts opts;
@@ -1035,7 +1043,7 @@ test_reacquired_epoch_restores_cleared_slot_crypto(void) {
     build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
     dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
-    assert(call.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_TERMINATOR);
     assert(dsd_call_state_observe(&state, &media_mark, DSD_CALL_BOUNDARY_BEGIN) > 0);
     assert(state.dmr_so == 0U);
     assert(state.payload_algid == 0);
@@ -1062,6 +1070,98 @@ test_reacquired_epoch_restores_cleared_slot_crypto(void) {
     assert(state.payload_algidR == 0x44);
     assert(state.payload_keyidR == 0x55);
     assert(state.payload_miR == 0xABCDEF0123ULL);
+    dsd_state_ext_free_all(&state);
+}
+
+// The heal must put back what the vocoder was actually decrypting with, not what the canonical
+// snapshot last recorded. The superframe machinery (the PI/LE LFSR advances) rolls the live MI
+// forward without publishing a canonical crypto update, and the Basic Privacy decrypt gates in
+// dsd_mbe.c key on the slot FID -- which the canonical snapshot never carried at all. A restore
+// sourced from the snapshot resumed with a stale MI (wrong keystream: still noise) and a zero
+// FID (Basic Privacy never re-applied); the stash of the live fields carries both.
+static void
+test_heal_restores_live_mi_and_basic_privacy_fid(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+
+    // Motorola Basic Privacy shape: enc service option set, algid/keyid zero, FID 0x10 gating
+    // the keystream application, and a live MI the superframe machinery has advanced past
+    // whatever crypto signaling last published.
+    seed_td_lc_slot(&opts, &state, 0U);
+    state.dmr_fid = 0x10;
+    state.dmr_so = 0x40;
+    state.payload_algid = 0;
+    state.payload_keyid = 0;
+    state.payload_mi = 0xDEADBEEFULL;
+
+    // A CRC-failed terminator -- possibly a mis-typed voice burst -- ends the call recoverably
+    // and the reset clears every live field, FID included.
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(state.dmr_fid == 0U);
+    assert(state.dmr_so == 0U);
+    assert(state.payload_mi == 0ULL);
+
+    // The healing media mark restores the live capture: advanced MI, gate-bearing FID.
+    const dsd_call_observation media_mark = {
+        .protocol = DSD_SYNC_DMR_BS_VOICE_POS,
+        .slot = 0U,
+        .kind = DSD_CALL_KIND_VOICE,
+    };
+    assert(dsd_call_state_observe(&state, &media_mark, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    assert(state.dmr_fid == 0x10U);
+    assert(state.dmr_so == 0x40U);
+    assert(state.payload_algid == 0);
+    assert(state.payload_keyid == 0);
+    assert(state.payload_mi == 0xDEADBEEFULL);
+    dsd_state_ext_free_all(&state);
+}
+
+// A lingering stash from one call must never be applied to another epoch's heal: the stash is
+// tied to the epoch whose terminator captured it. A later call on the slot that fades into a
+// sync-loss end and heals -- with its live crypto simply never signaled -- gets nothing
+// restored, rather than the previous call's crypto.
+static void
+test_stale_heal_stash_does_not_leak_into_later_call(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_call_snapshot call;
+
+    // Call A: encrypted, ends on an unverified terminator, stashing its crypto.
+    seed_td_lc_slot(&opts, &state, 0U);
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1001U, 2002U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+    assert(state.dmr_heal_valid[0] == 1U);
+
+    // Call B: a new clear call on the slot (identity-bearing, so it can never heal A's
+    // unverified end), which then fades into a sync-loss end and heals identity-lessly.
+    const dsd_call_observation call_b = {
+        .protocol = DSD_SYNC_DMR_BS_VOICE_POS,
+        .slot = 0U,
+        .kind = DSD_CALL_KIND_GROUP_VOICE,
+        .ota_target_id = 7007U,
+        .policy_target_id = 7007U,
+        .ota_source_id = 8008U,
+    };
+    assert(dsd_call_state_observe(&state, &call_b, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    assert(dsd_call_state_end_ex(&state, 0U, 0.0, DSD_CALL_END_SYNC_LOSS) == 1);
+    const dsd_call_observation media_mark = {
+        .protocol = DSD_SYNC_DMR_BS_VOICE_POS,
+        .slot = 0U,
+        .kind = DSD_CALL_KIND_VOICE,
+    };
+    assert(dsd_call_state_observe(&state, &media_mark, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.ota_target_id == 7007U);
+    // A's stash did not leak into B's healed epoch.
+    assert(state.dmr_so == 0U);
+    assert(state.payload_algid == 0);
+    assert(state.payload_mi == 0ULL);
+    assert(state.dmr_fid == 0U);
     dsd_state_ext_free_all(&state);
 }
 
@@ -1684,6 +1784,8 @@ main(void) {
     test_terminator_ends_call_despite_unreadable_lc();
     test_data_terminator_does_not_end_voice_call();
     test_reacquired_epoch_restores_cleared_slot_crypto();
+    test_heal_restores_live_mi_and_basic_privacy_fid();
+    test_stale_heal_stash_does_not_leak_into_later_call();
     test_flco_output_uses_real_newlines();
     test_ms_direct_flco_reports_internal_slot_one();
     test_single_slot_flco_forces_slot_one_context();

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -745,6 +745,39 @@ assert_td_lc_slot_reset(const dsd_state* state, unsigned int slot) {
                 slot == 0U ? 2002U : 4004U);
 }
 
+// A terminator whose LC could not be read (FEC-failed or protected) may really be a mid-call
+// voice burst mis-typed as a terminator. Its crypto reset is stashed for the heal, but the
+// alias/GPS/superframe metadata has no stash -- so the handler must leave it in place, or a
+// healed epoch would print "Invalid Header" for every remaining alias block.
+static void
+assert_td_lc_slot_crypto_reset_metadata_retained(const dsd_state* state, unsigned int slot) {
+    if (slot == 0U) {
+        assert(state->dmr_fid == 0);
+        assert(state->dmr_so == 0);
+        assert(state->payload_algid == 0);
+        assert(state->payload_keyid == 0);
+        assert(state->payload_mi == 0);
+        assert(state->aout_gain == 6.25f);
+    } else {
+        assert(state->dmr_fidR == 0);
+        assert(state->dmr_soR == 0);
+        assert(state->payload_algidR == 0);
+        assert(state->payload_keyidR == 0);
+        assert(state->payload_miR == 0);
+        assert(state->aout_gainR == 6.25f);
+    }
+
+    assert(state->dmr_alias_block_len[slot] == 7);
+    assert(state->dmr_alias_char_size[slot] == 1);
+    assert(state->dmr_alias_format[slot] == 2);
+    assert(strcmp(state->generic_talker_alias[slot], "alias") == 0);
+    assert(state->dmr_pdu_sf[slot][0] == 0x5A);
+    assert(strcmp(state->dmr_embedded_gps[slot], "gps") == 0);
+    assert(strcmp(state->dmr_lrrp_gps[slot], "lrrp") == 0);
+    assert_call(state, (uint8_t)slot, DSD_CALL_PHASE_ENDED, DSD_CALL_KIND_GROUP_VOICE, slot == 0U ? 1001U : 3003U,
+                slot == 0U ? 2002U : 4004U);
+}
+
 static void
 test_td_lc_resets_slot_call_privacy_and_alias_state(void) {
     static dsd_opts opts;
@@ -773,9 +806,10 @@ test_td_lc_resets_slot_call_privacy_and_alias_state(void) {
 // the recoverable unverified-terminator reason, so a voice burst mis-typed as
 // a terminator mid-call is healed by the next identity-less media mark
 // reacquiring the epoch instead of splitting the transmission in two. The
-// slot's payload crypto and alias state resets either way: keeping it would
-// let the next call on the slot inherit a stale algid/key/MI or half-built
-// alias.
+// slot's payload crypto resets either way (stashed first, so the heal can
+// restore it); the alias/GPS metadata is cleared only when the LC itself was
+// readable, since an unreadable "terminator" may be a mis-typed voice burst
+// whose half-built alias the healed epoch still needs.
 static void
 test_unverified_terminator_ends_call_recoverably(void) {
     static dsd_opts opts;
@@ -929,7 +963,7 @@ test_terminator_ends_call_despite_unreadable_lc(void) {
     irr = 1;
     dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
     assert(irr == 1);
-    assert_td_lc_slot_reset(&state, 0U);
+    assert_td_lc_slot_crypto_reset_metadata_retained(&state, 0U);
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
     assert(call.end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR);
 
@@ -944,7 +978,7 @@ test_terminator_ends_call_despite_unreadable_lc(void) {
     bits[0] = 1U;
     dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
     assert(irr == 0);
-    assert_td_lc_slot_reset(&state, 0U);
+    assert_td_lc_slot_crypto_reset_metadata_retained(&state, 0U);
     assert(dsd_call_state_get(&state, 0U, &call) > 0);
     assert(call.end_reason == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR);
 
@@ -1162,6 +1196,48 @@ test_stale_heal_stash_does_not_leak_into_later_call(void) {
     assert(state.payload_algid == 0);
     assert(state.payload_mi == 0ULL);
     assert(state.dmr_fid == 0U);
+    dsd_state_ext_free_all(&state);
+}
+
+// A Hytera-Enhanced-shaped LC (fid 0x68, flco 0x02, valid vendor checksum) arriving as an
+// FEC-failed terminator burst: the terminator transition has already ended the call, stashed
+// the live crypto, and reset the slot, so the Hytera Enhanced handler must not run afterward
+// and re-populate payload_algid/keyid/mi -- that would leave dmr_fid=0 beside a non-zero ALGID,
+// make dmr_flco_slot_crypto_is_clear() refuse the restore, and strand the stash forever.
+static void
+test_irrecoverable_hytera_terminator_does_not_repopulate_crypto(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t bits[80];
+    uint32_t irr = 1;
+
+    seed_td_lc_slot(&opts, &state, 0U);
+    uint8_t bytes[9] = {0x02U, 0x68U, 0x77U, 0x12U, 0x34U, 0x56U, 0x78U, 0x9AU, 0x00U};
+    uint8_t sum = 0U;
+    for (size_t i = 0U; i < 8U; i++) {
+        sum = (uint8_t)(sum + bytes[i]);
+    }
+    bytes[8] = (uint8_t)(0U - sum);
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    for (size_t i = 0U; i < 9U; i++) {
+        write_bits_u64(bits, i * 8U, bytes[i], 8U);
+    }
+
+    dmr_flco(&opts, &state, bits, 0U, &irr, 2U);
+
+    assert_td_lc_slot_crypto_reset_metadata_retained(&state, 0U);
+    assert(state.dmr_heal_valid[0] == 1U);
+
+    // And the heal still restores the stashed crypto when the epoch reopens.
+    const dsd_call_observation media_mark = {
+        .protocol = DSD_SYNC_DMR_BS_VOICE_POS,
+        .slot = 0U,
+        .kind = DSD_CALL_KIND_VOICE,
+    };
+    assert(dsd_call_state_observe(&state, &media_mark, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    assert(state.dmr_fid == 0x68U);
+    assert(state.dmr_so == 0x40U);
+    assert(state.payload_mi == 0x123456789AULL);
     dsd_state_ext_free_all(&state);
 }
 
@@ -1786,6 +1862,7 @@ main(void) {
     test_reacquired_epoch_restores_cleared_slot_crypto();
     test_heal_restores_live_mi_and_basic_privacy_fid();
     test_stale_heal_stash_does_not_leak_into_later_call();
+    test_irrecoverable_hytera_terminator_does_not_repopulate_crypto();
     test_flco_output_uses_real_newlines();
     test_ms_direct_flco_reports_internal_slot_one();
     test_single_slot_flco_forces_slot_one_context();

--- a/tests/protocol/dpmr/test_dpmr_sync_dispatch.c
+++ b/tests/protocol/dpmr/test_dpmr_sync_dispatch.c
@@ -15,6 +15,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -126,6 +127,31 @@ test_dispatch_voice_sync_begins_anonymous_call_and_processes_voice(void) {
     assert(strcmp(state.fsubtype, " VOICE        ") == 0);
 }
 
+// An FS3 end frame decoding after a sync-loss end must still reach the canonical retract path:
+// the recoverable end tightens to TERMINATOR, so the event layer can keep the audible epoch's
+// row and the reacquisition window closes. A phase guard in the dispatch would make the retract
+// path unreachable for dPMR alone among the converted protocols.
+static void
+test_dispatch_end_sync_tightens_sync_loss_end(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    state.synctype = DSD_SYNC_DPMR_FS2_POS;
+    dsd_dispatch_handle_dpmr(&opts, &state);
+
+    assert(dsd_call_state_end_ex(&state, 0U, 0.0, DSD_CALL_END_SYNC_LOSS) > 0);
+
+    state.synctype = DSD_SYNC_DPMR_FS3_POS;
+    dsd_dispatch_handle_dpmr(&opts, &state);
+
+    dsd_call_snapshot call;
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.phase == DSD_CALL_PHASE_ENDED);
+    assert(call.end_reason == (uint8_t)DSD_CALL_END_TERMINATOR);
+}
+
 int
 main(void) {
     test_sync_pattern_lengths();
@@ -133,6 +159,7 @@ main(void) {
     test_synctype_helpers();
     test_dispatch_close_only_syncs();
     test_dispatch_voice_sync_begins_anonymous_call_and_processes_voice();
+    test_dispatch_end_sync_tightens_sync_loss_end();
     printf("DPMR_SYNC_DISPATCH: OK\n");
     return 0;
 }

--- a/tests/protocol/edacs/test_edacs_grant_tune_matrix.c
+++ b/tests/protocol/edacs/test_edacs_grant_tune_matrix.c
@@ -103,6 +103,9 @@ void __wrap_watchdog_event_current(const dsd_opts* opts, dsd_state* state, uint8
 SNDFILE* __wrap_close_and_rename_wav_file(SNDFILE* wav_file, const dsd_opts* opts, const char* wav_out_filename,
                                           const char* dir, const Event_History_I* event_struct);
 // NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+SNDFILE* __wrap_close_and_rename_wav_file_ex(SNDFILE* wav_file, const dsd_opts* opts, const char* wav_out_filename,
+                                             const char* dir, const Event_History_I* event_struct, int export_call);
+// NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
 SNDFILE* __wrap_open_wav_file(char* dir, char* temp_filename, size_t temp_filename_size, uint16_t sample_rate,
                               uint8_t ext);
 
@@ -141,6 +144,14 @@ __wrap_close_and_rename_wav_file(SNDFILE* wav_file, const dsd_opts* opts, const 
     (void)event_struct;
     g_close_wav_count++;
     return NULL;
+}
+
+SNDFILE*
+// NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+__wrap_close_and_rename_wav_file_ex(SNDFILE* wav_file, const dsd_opts* opts, const char* wav_out_filename,
+                                    const char* dir, const Event_History_I* event_struct, int export_call) {
+    (void)export_call;
+    return __wrap_close_and_rename_wav_file(wav_file, opts, wav_out_filename, dir, event_struct);
 }
 
 SNDFILE*

--- a/tests/protocol/m17/test_m17_state_dispatch.c
+++ b/tests/protocol/m17/test_m17_state_dispatch.c
@@ -1384,6 +1384,9 @@ test_ip_stream_bad_crc_does_not_reopen_ended_voice_epoch(void) {
     err |= expect_int("valid voice EOT publishes call", get_m17_call(state, &call), 1);
     err |= expect_int("valid voice EOT ends call", call.phase, DSD_CALL_PHASE_ENDED);
     err |= expect_int("valid voice EOT owns M17 protocol", DSD_SYNC_IS_M17(call.protocol), 1);
+    // Terminator, not EXPLICIT: an over-the-air EOT is positive end evidence, and the event
+    // layer keys its keep-or-drop verdict for identity-less audible rows on that distinction.
+    err |= expect_int("valid voice EOT records terminator end", call.end_reason, (int)DSD_CALL_END_TERMINATOR);
     const uint64_t ended_epoch = call.epoch;
 
     build_ip_stream_frame(ip_frame, lsf_bits, 0xBEEFU, (uint16_t)(M17_REF_STREAM_FN + 1U), 0U, payload_bits);

--- a/tests/protocol/nxdn/test_nxdn_element_bounds.c
+++ b/tests/protocol/nxdn/test_nxdn_element_bounds.c
@@ -735,6 +735,55 @@ test_bad_crc_release_keeps_active_call(void) {
 }
 
 static int
+test_release_ends_call_with_terminator_reason(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    uint8_t bits[96];
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
+        free(state);
+        free(opts);
+        return 1;
+    }
+
+    int rc = 0;
+    // 0x07 TX_REL_EX ends the epoch only via the VCALL release path; 0x08 TX_REL and 0x11 DISC
+    // end it earlier in nxdn_message_type(). All three are CRC-verified over-the-air release
+    // signaling and must record the terminator end reason, not EXPLICIT (a retune/teardown),
+    // or the event layer drops an audible identity-less epoch's row.
+    const uint8_t release_types[] = {0x07U, 0x08U, 0x11U};
+    for (size_t i = 0U; i < sizeof(release_types) / sizeof(release_types[0]); i++) {
+        const dsd_call_observation observation = {
+            .protocol = DSD_SYNC_NXDN_POS,
+            .slot = 0U,
+            .kind = DSD_CALL_KIND_GROUP_VOICE,
+            .ota_target_id = 0x4567U,
+            .policy_target_id = 0x4567U,
+            .ota_source_id = 0x1234U,
+        };
+        assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
+        dsd_call_snapshot before;
+        assert(dsd_call_state_get(state, 0U, &before) == 1);
+
+        DSD_MEMSET(bits, 0, sizeof(bits));
+        set_message_type(bits, release_types[i]);
+        state->NxdnElementsContent.VCallCrcIsGood = 1U;
+        NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+
+        dsd_call_snapshot after;
+        rc |= expect_int("release-terminator-call-present", dsd_call_state_get(state, 0U, &after), 1);
+        rc |= expect_int("release-terminator-call-ended", after.phase, DSD_CALL_PHASE_ENDED);
+        rc |= expect_int("release-terminator-end-reason", after.end_reason, (int)DSD_CALL_END_TERMINATOR);
+        rc |= expect_u64("release-terminator-call-epoch", after.epoch, before.epoch);
+    }
+
+    dsd_state_ext_free_all(state);
+    free(state);
+    free(opts);
+    return rc;
+}
+
+static int
 test_sdcall_header_short_is_ignored(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
@@ -1779,6 +1828,7 @@ main(void) {
     rc |= test_disc_trunk_return_clears_call_state();
     rc |= test_idle_keeps_active_call();
     rc |= test_bad_crc_release_keeps_active_call();
+    rc |= test_release_ends_call_with_terminator_reason();
     rc |= test_sdcall_header_short_is_ignored();
     rc |= test_sdcall_iv_short_type_c_is_ignored();
     rc |= test_sdcall_iv_type_d_min_length_is_accepted();

--- a/tests/protocol/p25/test_p25_p2_active_ptt_epoch.c
+++ b/tests/protocol/p25/test_p25_p2_active_ptt_epoch.c
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * A tune can land so a SACCH GVCU (MAC_ACTIVE) decodes before one of the
+ * transmission-start MAC_PTT repeats. The ACTIVE observation begins the
+ * canonical epoch; the first-seen PTT of the same transmission previously
+ * force-minted a second epoch, committing the observation epoch's freshly
+ * built row as a duplicate event -- surfaced in the field as a same-second
+ * pair of rows for one encrypted call: "ENC" with no ALG/KID from the ended
+ * ACTIVE epoch, then "ENC; ALG; KID" with the lockout notice from the PTT
+ * epoch the lockout finalized. The PTT must fold into the young ACTIVE-begun
+ * epoch, while a second, differently-signed PTT is the next transmission and
+ * must still begin its own epoch.
+ */
+
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/protocol/p25/p25_crypto.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../../../src/protocol/p25/p25_trunk_sm_internal.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#define TEST_TG    21001
+#define TEST_SRC   1011308
+#define TEST_ALGID 0x84
+#define TEST_KEYID 0x2710
+
+static dsd_opts g_opts;
+static dsd_state g_state;
+
+static int
+expect(const char* tag, int cond) {
+    if (!cond) {
+        DSD_FPRINTF(stderr, "FAIL: %s\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static dsd_trunk_tune_result
+test_tune_request(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps, uint64_t request_id) {
+    (void)opts;
+    (void)state;
+    (void)ted_sps;
+    (void)request_id;
+    return freq > 0 ? DSD_TRUNK_TUNE_RESULT_OK : DSD_TRUNK_TUNE_RESULT_FAILED;
+}
+
+static dsd_trunk_tune_result
+test_return_request(dsd_opts* opts, dsd_state* state, uint64_t request_id) {
+    (void)opts;
+    (void)state;
+    (void)request_id;
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static void
+reset_test_state(int tune_enc_calls) {
+    if (g_state.event_history_s != NULL) {
+        free(g_state.event_history_s);
+        g_state.event_history_s = NULL;
+    }
+    dsd_state_ext_free_all(&g_state);
+    DSD_MEMSET(&g_opts, 0, sizeof(g_opts));
+    DSD_MEMSET(&g_state, 0, sizeof(g_state));
+    g_opts.trunk_enable = 1;
+    g_opts.trunk_hangtime = 2.0f;
+    g_opts.trunk_tune_group_calls = 1;
+    g_opts.trunk_tune_enc_calls = tune_enc_calls;
+    g_state.p25_cc_freq = 851000000;
+    g_state.lastsynctype = DSD_SYNC_P25P2_POS;
+    g_state.synctype = DSD_SYNC_P25P2_POS;
+    g_state.event_history_s = calloc(2, sizeof(Event_History_I));
+    if (g_state.event_history_s != NULL) {
+        for (int i = 0; i < 2; i++) {
+            init_event_history(&g_state.event_history_s[i], 0, 255);
+        }
+    }
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
+        .tune_to_freq_request = test_tune_request,
+        .tune_to_cc_request = test_tune_request,
+        .return_to_cc_request = test_return_request,
+    });
+    p25_sm_init_ctx(p25_sm_get_ctx(), &g_opts, &g_state);
+}
+
+static void
+event_ticks(void) {
+    for (int i = 0; i < 3; i++) {
+        watchdog_event_current(&g_opts, &g_state, 0);
+        watchdog_event_history(&g_opts, &g_state, 0);
+    }
+}
+
+static int
+committed_event_count(void) {
+    if (g_state.event_history_s == NULL) {
+        return -1;
+    }
+    int count = 0;
+    for (int i = 1; i < 255; i++) {
+        if (g_state.event_history_s[0].Event_History_Items[i].event_string[0] != '\0') {
+            count++;
+        }
+    }
+    return count;
+}
+
+static int
+committed_events_contain(const char* needle) {
+    if (g_state.event_history_s == NULL) {
+        return 0;
+    }
+    for (int i = 1; i < 255; i++) {
+        if (strstr(g_state.event_history_s[0].Event_History_Items[i].event_string, needle) != NULL) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static uint64_t
+slot0_epoch(void) {
+    dsd_call_snapshot call;
+    return dsd_call_state_get(&g_state, 0U, &call) > 0 ? call.epoch : 0U;
+}
+
+static int
+slot0_phase_is(dsd_call_phase phase) {
+    dsd_call_snapshot call;
+    return dsd_call_state_get(&g_state, 0U, &call) > 0 && call.phase == phase;
+}
+
+static void
+tune_grant(int svc) {
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    g_state.trunk_chan_map[0x1234] = 851500000;
+    g_state.p25_chan_tdma_explicit[1] = 2;
+    g_opts.trunk_is_tuned = 1;
+    p25_sm_event_t grant = p25_sm_ev_group_grant(0x1234, 851500000, TEST_TG, TEST_SRC, svc);
+    p25_sm_event(ctx, &g_opts, &g_state, &grant);
+}
+
+static void
+mac_ptt(uint8_t sig_fill) {
+    uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES];
+    DSD_MEMSET(signature, sig_fill, sizeof(signature));
+    (void)p25_sm_emit_ptt_call_metadata(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC, 1, P25_SM_SVC_UNKNOWN, signature,
+                                        dsd_time_now_monotonic_s(), 0);
+}
+
+static void
+resolve_ess(void) {
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, TEST_ALGID, TEST_KEYID, 0x1111ULL, TEST_TG);
+}
+
+/* The field capture: enc lockout on, tune catches a MAC_ACTIVE before one of
+ * the transmission-start MAC_PTT repeats, the PTT's ESS locks the call out.
+ * One transmission must commit exactly one history row. */
+static int
+test_active_then_ptt_lockout_single_row(void) {
+    int rc = 0;
+    reset_test_state(0);
+    tune_grant(0x00);
+    event_ticks();
+
+    rc |= expect("lockout fixture ACTIVE accepted",
+                 p25_sm_emit_active_call(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC, 1, 0x40) > 0);
+    event_ticks();
+    const uint64_t active_epoch = slot0_epoch();
+    rc |= expect("lockout fixture ACTIVE begins epoch", active_epoch != 0U);
+
+    mac_ptt(0x33U);
+    rc |= expect("first PTT folds into ACTIVE epoch", slot0_epoch() == active_epoch);
+    rc |= expect("first PTT keeps epoch live", slot0_phase_is(DSD_CALL_PHASE_ACTIVE));
+
+    resolve_ess();
+    event_ticks();
+    rc |= expect("lockout ends the transmission", slot0_phase_is(DSD_CALL_PHASE_ENDED));
+
+    /* Remaining PTT repeats and the release follow on the air. */
+    mac_ptt(0x33U);
+    resolve_ess();
+    event_ticks();
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, TEST_TG, TEST_SRC, dsd_time_now_monotonic_s());
+    p25_crypto_reset_slot(&g_state, 0);
+    event_ticks();
+
+    rc |= expect("one transmission commits one row", committed_event_count() == 1);
+    rc |= expect("committed row carries the resolved ALG", committed_events_contain("ALG: 84"));
+    return rc;
+}
+
+/* A differently-signed PTT after the epoch has accepted a PTT is the next
+ * transmission: it must still begin its own canonical epoch. */
+static int
+test_second_ptt_still_begins_new_epoch(void) {
+    int rc = 0;
+    reset_test_state(1);
+    tune_grant(0x00);
+    event_ticks();
+
+    rc |= expect("clear fixture ACTIVE accepted",
+                 p25_sm_emit_active_call(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC, 1, 0x00) > 0);
+    const uint64_t active_epoch = slot0_epoch();
+
+    mac_ptt(0x44U);
+    rc |= expect("clear first PTT folds into ACTIVE epoch", slot0_epoch() == active_epoch);
+
+    /* Same signature repeats stay in the epoch. */
+    mac_ptt(0x44U);
+    rc |= expect("PTT retransmit keeps the epoch", slot0_epoch() == active_epoch);
+
+    /* A new signature is a new transmission even without a decoded END. */
+    mac_ptt(0x55U);
+    rc |= expect("differently-signed PTT begins a new epoch", slot0_epoch() != active_epoch);
+    rc |= expect("new transmission epoch is live", slot0_phase_is(DSD_CALL_PHASE_ACTIVE));
+    return rc;
+}
+
+/* Guard the already-correct paths: a PTT with no preceding ACTIVE observation
+ * still commits exactly one row under enc lockout. */
+static int
+test_ptt_without_active_lockout_single_row(void) {
+    int rc = 0;
+    reset_test_state(0);
+    tune_grant(0x00);
+    event_ticks();
+
+    mac_ptt(0x66U);
+    resolve_ess();
+    event_ticks();
+    mac_ptt(0x66U);
+    resolve_ess();
+    event_ticks();
+
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, TEST_TG, TEST_SRC, dsd_time_now_monotonic_s());
+    p25_crypto_reset_slot(&g_state, 0);
+    event_ticks();
+
+    rc |= expect("ptt-only lockout commits one row", committed_event_count() == 1);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_active_then_ptt_lockout_single_row();
+    rc |= test_second_ptt_still_begins_new_epoch();
+    rc |= test_ptt_without_active_lockout_single_row();
+
+    if (g_state.event_history_s != NULL) {
+        free(g_state.event_history_s);
+        g_state.event_history_s = NULL;
+    }
+    dsd_state_ext_free_all(&g_state);
+
+    if (rc == 0) {
+        DSD_FPRINTF(stderr, "P25 P2 ACTIVE PTT EPOCH: OK\n");
+    }
+    return rc;
+}

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -1587,6 +1587,85 @@ test_conventional_end_is_follower_noop(void) {
 }
 
 static int
+conventional_slot_ended_with_reason(uint8_t slot, dsd_call_end_reason want_reason, const char* label) {
+    dsd_call_snapshot call;
+    if (dsd_call_state_get(&g_state, slot, &call) <= 0 || call.phase != DSD_CALL_PHASE_ENDED
+        || call.end_reason != (uint8_t)want_reason) {
+        DSD_FPRINTF(stderr, "FAIL: Conventional %s end did not record end reason %d\n", label, (int)want_reason);
+        return 1;
+    }
+    return 0;
+}
+
+// Regression: outside P25_SM_TUNED, the emit wrappers finish the canonical call through a
+// fallback that used to hardcode DSD_CALL_END_EXPLICIT. Decoded OTA end signaling
+// (MAC_END_PTT, FACCH end, TDU, LCW termination, MAC Release) must end the epoch with
+// DSD_CALL_END_TERMINATOR so the event layer keeps audible identity-less receptions, while
+// inactivity-driven idle/hangtime ends stay EXPLICIT.
+static int
+test_conventional_ota_end_reasons_are_terminator(void) {
+    reset_test_state();
+    g_opts.trunk_enable = 0;
+    g_state.p25_cc_freq = 0;
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    p25_sm_init_ctx(ctx, &g_opts, &g_state);
+    const double now_m = dsd_time_now_monotonic_s();
+
+    if (!p25_sm_emit_ptt_call(&g_opts, &g_state, 0, 1000, 0, 123, 1, 0)
+        || !p25_sm_emit_end_call_at(&g_opts, &g_state, 0, 1000, 123, now_m)
+        || conventional_slot_ended_with_reason(0U, DSD_CALL_END_TERMINATOR, "MAC_END_PTT")) {
+        return 1;
+    }
+
+    if (!p25_sm_emit_ptt_call(&g_opts, &g_state, 1, 1500, 0, 321, 1, 0)
+        || p25_sm_emit_facch_end_call_at(&g_opts, &g_state, 1, 1500, 321, now_m) != P25_SM_END_APPLIED
+        || conventional_slot_ended_with_reason(1U, DSD_CALL_END_TERMINATOR, "FACCH")) {
+        return 1;
+    }
+
+    if (!p25_sm_emit_ptt_call(&g_opts, &g_state, 0, 2000, 0, 456, 1, 0)) {
+        return 1;
+    }
+    p25_sm_emit_tdu(&g_opts, &g_state);
+    if (conventional_slot_ended_with_reason(0U, DSD_CALL_END_TERMINATOR, "TDU")) {
+        return 1;
+    }
+
+    if (!p25_sm_emit_ptt_call(&g_opts, &g_state, 0, 3000, 0, 789, 1, 0)) {
+        return 1;
+    }
+    p25_sm_emit_end(&g_opts, &g_state, 0);
+    if (conventional_slot_ended_with_reason(0U, DSD_CALL_END_TERMINATOR, "LCW termination")) {
+        return 1;
+    }
+
+    if (!p25_sm_emit_ptt_call(&g_opts, &g_state, 0, 4000, 0, 111, 1, 0)) {
+        return 1;
+    }
+    p25_sm_emit_mac_release(&g_opts, &g_state, 0, dsd_time_now_monotonic_s());
+    if (conventional_slot_ended_with_reason(0U, DSD_CALL_END_TERMINATOR, "MAC Release")) {
+        return 1;
+    }
+
+    if (!p25_sm_emit_ptt_call(&g_opts, &g_state, 0, 5000, 0, 222, 1, 0)) {
+        return 1;
+    }
+    p25_sm_emit_idle(&g_opts, &g_state, 0);
+    if (conventional_slot_ended_with_reason(0U, DSD_CALL_END_EXPLICIT, "idle")) {
+        return 1;
+    }
+
+    if (!p25_sm_emit_ptt_call(&g_opts, &g_state, 0, 6000, 0, 333, 1, 0)) {
+        return 1;
+    }
+    p25_sm_emit_hangtime(&g_opts, &g_state, 0);
+    if (conventional_slot_ended_with_reason(0U, DSD_CALL_END_EXPLICIT, "hangtime")) {
+        return 1;
+    }
+    return 0;
+}
+
+static int
 test_conventional_anonymous_activity_waits_for_identity(void) {
     reset_test_state();
     g_opts.trunk_enable = 0;
@@ -2750,6 +2829,7 @@ main(void) {
     fail += test_identified_followup_without_service_restarts_crypto_pending();
     fail += test_missed_end_identity_change_without_service_restarts_crypto_pending();
     fail += test_conventional_end_is_follower_noop();
+    fail += test_conventional_ota_end_reasons_are_terminator();
     fail += test_conventional_anonymous_activity_waits_for_identity();
     fail += test_conventional_anonymous_activity_preserves_service_options();
     fail += test_conventional_unknown_service_stays_unconfirmed();

--- a/tests/test_support/call_state_stubs.c
+++ b/tests/test_support/call_state_stubs.c
@@ -191,15 +191,25 @@ dsd_call_state_end_ex(dsd_state* state, uint8_t slot, double observed_m, dsd_cal
     // reason nor re-stamp ended_m and slide the reacquisition window. A stub that overwrote them
     // would model the exact bug that guard exists to prevent.
     if (g_stub_calls[slot].epoch == 0U || g_stub_calls[slot].phase != DSD_CALL_PHASE_ACTIVE) {
-        // And production's one exception, mirrored for the same reason: a terminator decoded after
-        // sync loss already ended the epoch retracts the reacquisition permission that end granted.
+        // And production's one exception, mirrored for the same reason: final evidence decoded
+        // after a recoverable end retracts the reacquisition permission that end granted, and a
+        // second unverified terminator corroborates an unverified end into TERMINATOR.
         // Stub-linked protocol tests drive exactly this path from their terminator handlers, so a
         // stub that returned 0 here would leave every one of them modelling the pre-retraction
         // behaviour and silently skipping the event flush that follows.
+        const uint8_t prior = g_stub_calls[slot].end_reason;
+        const int prior_recoverable =
+            prior == (uint8_t)DSD_CALL_END_SYNC_LOSS || prior == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR;
+        const int retracts =
+            (reason == DSD_CALL_END_EXPLICIT || reason == DSD_CALL_END_TERMINATOR) && prior_recoverable;
+        const int corroborates =
+            reason == DSD_CALL_END_UNVERIFIED_TERMINATOR && prior == (uint8_t)DSD_CALL_END_UNVERIFIED_TERMINATOR;
         if (g_stub_calls[slot].epoch != 0U && g_stub_calls[slot].phase == DSD_CALL_PHASE_ENDED
-            && g_stub_calls[slot].end_reason == (uint8_t)DSD_CALL_END_SYNC_LOSS && reason == DSD_CALL_END_EXPLICIT) {
+            && (retracts || corroborates)) {
             // ended_m is deliberately left alone: the reason changes, the moment does not.
-            g_stub_calls[slot].end_reason = (uint8_t)DSD_CALL_END_EXPLICIT;
+            g_stub_calls[slot].end_reason = (reason == DSD_CALL_END_TERMINATOR || corroborates)
+                                                ? (uint8_t)DSD_CALL_END_TERMINATOR
+                                                : (uint8_t)DSD_CALL_END_EXPLICIT;
             return 1;
         }
         return 0;


### PR DESCRIPTION
## Summary

- Restore a boundary check for the DMR voice LC header: a header that re-describes the identity already active on a slot that has not yet carried voice media observes a continuation instead of a begin, so header repeats no longer mint an epoch each and no longer commit the previous epoch's freshly built row as a duplicate.
- Discriminate repeats from re-keys by voice media rather than by identity alone: once voice has run on the epoch, an identical header is a same-identity re-key whose terminator was missed and still opens its own epoch, as does a header naming a different talker or target or one arriving after the terminator.
- Require RS(12,9)-verified link control before a terminator ends the call and clears the slot's payload state. The terminator path only checked the BPTC residual, so a mis-typed burst surviving the Golay and Hamming stages could close a live transmission with the un-recoverable EXPLICIT reason -- splitting its history row and wiping its crypto and alias state mid-call. A genuinely missed terminator is picked up by the no-carrier path as a recoverable sync-loss end.
- Drop voice rows whose epoch never named a call: a stray voice sync opens a provisional epoch, and when it ends without ever learning an identity its staged row committed anyway, surfacing "TGT: 00000000; SRC: 00000000" rows that tell the operator nothing. The canonical snapshot is consulted alongside the row so route-only D-STAR/YSF transmissions keep their rows; X2-TDMA is exempt because an all-zero row is that protocol's whole story; data and control rows (LRRP, short data, responses) are untouched. The dropped epoch still rotates the per-call WAV and arms no VOICE_END alert.

## Why

#271 fixed the sync-loss reacquisition shape of the duplicate-row report in discussion #152, but its final revision removed the DMR header-repeat boundary check to preserve distinct epochs for same-identity re-keys, and the canonical layer's provisional-voice specialization only covers a header arriving on an identity-less epoch. A transmission whose header was decoded two or three times therefore still left two or three identical Activity rows with the same timestamp -- exactly the follow-up report in discussion #152. Driving one transmission with three header copies through the real `dmr_flco()` path produced three rows before this change and one after; the media gate keeps the re-key case from #271's final revision intact. The same report also showed the identity-less "TGT: 00000000" rows from stray voice syncs, addressed by the second commit.

## Testing

- `test_repeated_voice_lc_header_keeps_one_epoch`: header repeats before voice media stay in the epoch; a different talker, a post-media identical header (re-key), a post-terminator header, and the sync-loss reacquisition tag all still fork or tag as before.
- `test_repeated_voice_lc_headers_commit_one_history_row`: one transmission with three header copies, embedded LCs, and a terminator leaves exactly one history row.
- `test_unverified_terminator_keeps_call_active`: a CRC-failed terminator neither ends the call nor wipes payload/alias state; a verified one still does both.
- `test_identityless_voice_epoch_commits_no_row`: an identity-less voice epoch leaves no history row and arms no end alert, and the next identified call commits normally.
- Updated `test_identityless_ended_epoch_does_not_reacquire` and the identity-less-reopen test to the new row counts; route-only reacquisition and X2-TDMA row coverage pass unchanged.
- Full suite: 474/474 pass; `tools/preflight_ci.sh` clean.

Reported in discussion #152.