### PR TITLE
p25: suppress post-END voice-user repeats on P25p2 traffic channels

### DIFF
--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -459,6 +459,24 @@ int p25_sm_slot_grant_newer_than(int slot, double observed_m);
  */
 int p25_sm_voice_user_repeats_recent_end(int slot, int target, int src, double now_m);
 
+/**
+ * @brief Fetch the tuned Phase 1 assignment identity for a pre-identity epoch.
+ *
+ * When ESS crypto resolves on a tuned FDMA traffic channel before any
+ * LCW/voice evidence names the call, the epoch opened to hold the
+ * classification should carry the assignment identity the grant already
+ * established rather than begin identity-less. Only a tuned, non-TDMA,
+ * non-data assignment with a known target qualifies; the conventional
+ * identity-pending flow keeps its identity-less epoch (the following LCW
+ * names that call).
+ *
+ * @param[out] is_group 1 for a group assignment, 0 for a private one.
+ * @param[out] ota_target OTA talkgroup or destination RID of the assignment.
+ * @param[out] policy_target Patch-aware policy target, or 0 when unknown.
+ * @return 1 when a tuned Phase 1 assignment identity was filled, 0 otherwise.
+ */
+int p25_sm_phase1_assignment_identity(int* is_group, uint32_t* ota_target, uint32_t* policy_target);
+
 /* ============================================================================
  * Public API - Convenience Emit Functions (use global singleton)
  * ============================================================================ */

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -460,6 +460,19 @@ int p25_sm_slot_grant_newer_than(int slot, double observed_m);
 int p25_sm_voice_user_repeats_recent_end(int slot, int target, int src, double now_m);
 
 /**
+ * @brief Whether a Phase 1 ESS observation may open a canonical epoch.
+ *
+ * Mirrors the voice-start rule: a trunked receiver with no traffic assignment
+ * is parked on or hunting the control channel, where Phase 1 ESS can only be
+ * noise briefly false-syncing as an LDU. Conventional receivers (trunking
+ * disabled) always qualify.
+ *
+ * @param opts Decoder options (trunking configuration).
+ * @return 1 when an ESS-driven epoch may open, 0 to decline the mint.
+ */
+int p25_sm_phase1_crypto_epoch_allowed(const dsd_opts* opts);
+
+/**
  * @brief Fetch the tuned Phase 1 assignment identity for a pre-identity epoch.
  *
  * When ESS crypto resolves on a tuned FDMA traffic channel before any

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -440,6 +440,25 @@ int p25_sm_vc_reacquire_hold_active(const p25_sm_ctx_t* ctx, const dsd_opts* opt
  */
 int p25_sm_slot_grant_newer_than(int slot, double observed_m);
 
+/**
+ * @brief Check whether a voice-user observation re-describes a call that just ended.
+ *
+ * After an accepted MAC_END_PTT the FNE keeps describing the completed call
+ * for a few bursts: END repeats interleave with SACCH voice-user copies whose
+ * assembly began before the END decoded. A voice user naming the completed
+ * talker (or naming no talker) on the unchanged target inside that short tail
+ * is retention of the ended transmission and must not begin a canonical
+ * epoch. A changed source, or the same identity outside the tail, is fresh
+ * evidence and returns 0.
+ *
+ * @param slot Slot index (0 or 1).
+ * @param target OTA talkgroup for group calls, destination RID for private calls.
+ * @param src Source RID, or 0/unknown when the observation carries none.
+ * @param now_m Monotonic timestamp of the observation.
+ * @return 1 when the observation repeats the recently ended call, 0 otherwise.
+ */
+int p25_sm_voice_user_repeats_recent_end(int slot, int target, int src, double now_m);
+
 /* ============================================================================
  * Public API - Convenience Emit Functions (use global singleton)
  * ============================================================================ */

--- a/src/protocol/p25/p25_crypto.c
+++ b/src/protocol/p25/p25_crypto.c
@@ -204,12 +204,28 @@ p25_crypto_ensure_phase1_call(dsd_state* state) {
     if (frequency_hz == 0) {
         frequency_hz = state->trunk_vc_freq[0];
     }
-    const dsd_call_observation observation = {
+    dsd_call_observation observation = {
         .protocol = p25_crypto_phase1_protocol(state),
         .slot = 0U,
         .kind = DSD_CALL_KIND_VOICE,
         .frequency_hz = frequency_hz,
     };
+    // On a tuned assignment whose ESS resolves before any LCW/voice evidence,
+    // the grant already names this call. Beginning identity-less here splits
+    // the call across two rows when the encryption lockout releases the
+    // channel before an LCW ever decodes: a TGT 0 row carrying the resolved
+    // ALG/KID plus the staged assignment row with pending crypto. The
+    // conventional identity-pending flow keeps the identity-less epoch -- the
+    // LCW that follows names that call, not the retained assignment.
+    int assignment_is_group = 0;
+    uint32_t assignment_target = 0U;
+    uint32_t assignment_policy_target = 0U;
+    if (!state->p25_p1_identity_pending
+        && p25_sm_phase1_assignment_identity(&assignment_is_group, &assignment_target, &assignment_policy_target)) {
+        observation.kind = assignment_is_group ? DSD_CALL_KIND_GROUP_VOICE : DSD_CALL_KIND_PRIVATE_VOICE;
+        observation.ota_target_id = assignment_target;
+        observation.policy_target_id = assignment_policy_target;
+    }
     const int began = dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0;
     if (began && state->p25_p1_identity_pending) {
         state->p25_p1_identity_epoch_started = 1;

--- a/src/protocol/p25/p25_crypto.c
+++ b/src/protocol/p25/p25_crypto.c
@@ -189,11 +189,14 @@ p25_crypto_phase1_ess_continues_ended_call(dsd_state* state) {
 }
 
 static int
-p25_crypto_ensure_phase1_call(dsd_state* state) {
+p25_crypto_ensure_phase1_call(const dsd_opts* opts, dsd_state* state) {
     dsd_call_snapshot call;
     const int active = dsd_call_state_get(state, 0U, &call) > 0 && call.phase == DSD_CALL_PHASE_ACTIVE;
     if (active && DSD_SYNC_IS_P25P1(call.protocol)
         && (!state->p25_p1_identity_pending || state->p25_p1_identity_epoch_started)) {
+        return 0;
+    }
+    if (!p25_sm_phase1_crypto_epoch_allowed(opts)) {
         return 0;
     }
     if (p25_crypto_phase1_ess_continues_ended_call(state)) {
@@ -408,7 +411,7 @@ p25_crypto_apply_resolution(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_pha
     if (reset_stream) {
         p25_crypto_reset_stream_state(state, phase, slot);
     }
-    const int began_phase1_call = phase == DSD_P25_CRYPTO_PHASE1 ? p25_crypto_ensure_phase1_call(state) : 0;
+    const int began_phase1_call = phase == DSD_P25_CRYPTO_PHASE1 ? p25_crypto_ensure_phase1_call(opts, state) : 0;
     p25_crypto_set_state(state, slot, resolved);
     p25_crypto_publish_canonical(opts, state, slot);
     if (began_phase1_call && opts) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2908,6 +2908,17 @@ p25_sm_voice_user_repeats_recent_end(int slot, int target, int src, double now_m
 }
 
 int
+p25_sm_phase1_crypto_epoch_allowed(const dsd_opts* opts) {
+    // Mirrors the voice-start rule: a trunked receiver with no traffic
+    // assignment is parked on (or hunting) the control channel, where a
+    // Phase 1 ESS observation can only be noise briefly false-syncing as an
+    // LDU. Minting an identity-less epoch for it leaves a stale ACTIVE call
+    // that the next real call's teardown flushes as a phantom TGT 0 row.
+    const p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    return !(opts && opts->trunk_enable == 1 && ctx->state != P25_SM_TUNED);
+}
+
+int
 p25_sm_phase1_assignment_identity(int* is_group, uint32_t* ota_target, uint32_t* policy_target) {
     const p25_sm_ctx_t* ctx = p25_sm_get_ctx();
     if (!is_group || !ota_target || !policy_target || ctx->state != P25_SM_TUNED || ctx->vc_is_tdma) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2883,6 +2883,26 @@ p25_sm_voice_user_repeats_recent_end(int slot, int target, int src, double now_m
     return p25_voice_user_repeats_recent_end(&ctx->slots[slot], target, src, now_m);
 }
 
+int
+p25_sm_phase1_assignment_identity(int* is_group, uint32_t* ota_target, uint32_t* policy_target) {
+    const p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    if (!is_group || !ota_target || !policy_target || ctx->state != P25_SM_TUNED || ctx->vc_is_tdma) {
+        return 0;
+    }
+    const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[0];
+    if (!slot_ctx->grant_active || slot_ctx->data_call) {
+        return 0;
+    }
+    const int target = slot_ctx->is_group ? slot_ctx->ota_tg : slot_ctx->dst;
+    if (target <= 0) {
+        return 0;
+    }
+    *is_group = slot_ctx->is_group ? 1 : 0;
+    *ota_target = (uint32_t)target;
+    *policy_target = slot_ctx->target_id > 0 ? (uint32_t)slot_ctx->target_id : 0U;
+    return 1;
+}
+
 static int
 p25_voice_start_target_changed(const p25_sm_slot_ctx_t* slot_ctx, const p25_sm_event_t* ev) {
     if (!slot_ctx || !ev || slot_ctx->is_group != (ev->is_group ? 1 : 0)) {
@@ -3700,11 +3720,15 @@ handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, 
         return 0;
     }
 
-    // The PTT retransmission marker deliberately survives the END: a SACCH
-    // MAC_PTT repeat whose assembly straddled the END is recognized as
+    // The PTT retransmission marker deliberately survives an explicit END: a
+    // SACCH MAC_PTT repeat whose assembly straddled the END is recognized as
     // retention only by matching it (p25_voice_start_suppress_post_end_repeat).
     // Epoch-active gating keeps it inert otherwise, and slot clear/release
-    // still invalidates it.
+    // still invalidates it. Inactivity teardowns have no straddle to
+    // recognize, so they drop the marker as before.
+    if (!is_explicit_end) {
+        p25_ptt_marker_invalidate(ctx, s);
+    }
     const double now_m = dsd_time_now_monotonic_s();
     const int ended_tg = p25_voice_end_event_tg(ctx, state, s, ev);
     const int ended_src = p25_voice_end_event_src(ctx, state, s, ev);

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -95,6 +95,7 @@ static atomic_int g_p25_sm_release_lock = 0;
 #define P25_VC_CQPSK_REACQUIRE_HOLD_S          0.75
 #define P25_VC_CQPSK_REACQUIRE_NO_SYNC_PASSES  3U
 #define P25_PTT_RETRANSMIT_WINDOW_S            1.0
+#define P25_POST_END_VOICE_USER_REPEAT_S       1.0
 #define P25_PTT_SIGNATURE_ALGID_INDEX          9
 #define P25_PTT_SIGNATURE_IDENTITY_INDEX       12
 #define P25_CANONICAL_EPOCH_COALESCE_S         1.0
@@ -2844,6 +2845,38 @@ p25_voice_start_follows_completed_epoch(const p25_sm_slot_ctx_t* slot_ctx) {
     return slot_ctx && slot_ctx->last_start_m > 0.0 && !p25_voice_slot_epoch_active(slot_ctx);
 }
 
+// After an accepted MAC_END_PTT the FNE keeps describing the completed call for a few bursts:
+// END repeats interleave with SACCH voice-user copies whose four-burst assembly began before
+// the END decoded. A voice user naming the completed talker -- or naming no talker -- on the
+// unchanged target inside that tail is retention of the transmission that just ended, and
+// reopening an epoch from it commits a duplicate history row once the phantom epoch dies at
+// hangtime or at the next talker's PTT. The time bound is what the retired identity-only
+// guards lacked: outside the tail, a genuinely ACTIVE-typed voice user re-naming the same
+// talker is the next transmission and still reopens the call. A changed source is fresh
+// evidence and is never suppressed.
+static int
+p25_voice_user_repeats_recent_end(const p25_sm_slot_ctx_t* slot_ctx, int target, int src, double now_m) {
+    if (!slot_ctx || slot_ctx->last_end_m <= 0.0 || target <= 0 || target != slot_ctx->last_end_tg) {
+        return 0;
+    }
+    if (p25_voice_slot_epoch_active(slot_ctx)) {
+        return 0;
+    }
+    if (p25_source_id_known(src) && src != slot_ctx->last_end_src) {
+        return 0;
+    }
+    return now_m >= slot_ctx->last_end_m && (now_m - slot_ctx->last_end_m) <= P25_POST_END_VOICE_USER_REPEAT_S;
+}
+
+int
+p25_sm_voice_user_repeats_recent_end(int slot, int target, int src, double now_m) {
+    const p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    if (slot < 0 || slot > 1 || ctx->state != P25_SM_TUNED || !ctx->vc_is_tdma) {
+        return 0;
+    }
+    return p25_voice_user_repeats_recent_end(&ctx->slots[slot], target, src, now_m);
+}
+
 static int
 p25_voice_start_target_changed(const p25_sm_slot_ctx_t* slot_ctx, const p25_sm_event_t* ev) {
     if (!slot_ctx || !ev || slot_ctx->is_group != (ev->is_group ? 1 : 0)) {
@@ -3342,6 +3375,24 @@ p25_voice_start_apply_event(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state,
     return 1;
 }
 
+// Phase 2 only: the post-END retention tail is a TDMA artifact (END repeats
+// interleaving with the four-burst SACCH assembly). Phase 1's post-TDU
+// same-identity signaling drives its own HDU/LCW crypto machinery and must
+// keep flowing. Retention is still channel activity, so the liveness clock
+// advances, but the hangtime timer keeps running and no epoch reopens.
+static int
+p25_voice_start_suppress_post_end_repeat(p25_sm_ctx_t* ctx, dsd_opts* opts, const dsd_state* state, int slot,
+                                         const p25_sm_event_t* ev, const char* why, double now_m) {
+    if (ev->type != P25_SM_EV_ACTIVE || !ctx->vc_is_tdma
+        || !p25_voice_user_repeats_recent_end(&ctx->slots[slot], ev->is_group ? ev->tg : ev->dst, ev->src, now_m)) {
+        return 0;
+    }
+    p25_sm_note_vc_decode_activity(ctx, opts, state, why, slot, now_m);
+    p25_sm_diagf(opts, state, ctx, "voice_observation_suppressed", "reason=repeats-recent-end slot=%d tg=%d src=%d",
+                 slot, ev->tg, ev->src);
+    return 1;
+}
+
 static int
 handle_voice_start(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, const char* why) {
     if (!ctx || !ev) {
@@ -3353,6 +3404,9 @@ handle_voice_start(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p2
 
     double now_m = ev->observed_m > 0.0 ? ev->observed_m : dsd_time_now_monotonic_s();
     int s = (ev->slot >= 0 && ev->slot <= 1) ? ev->slot : 0;
+    if (p25_voice_start_suppress_post_end_repeat(ctx, opts, state, s, ev, why, now_m)) {
+        return 1;
+    }
     int new_epoch = !ctx->slots[s].voice_active;
     if (!p25_voice_start_apply_event(ctx, opts, state, s, ev, now_m, &new_epoch)) {
         return 0;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -71,8 +71,8 @@ typedef enum {
 } p25_call_obs_provenance;
 
 static void p25_call_publish_observation(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, int slot,
-                                         int new_epoch, int allow_coalesce, p25_call_obs_provenance provenance,
-                                         double observed_m);
+                                         int new_epoch, int allow_coalesce, int continuous_activity,
+                                         p25_call_obs_provenance provenance, double observed_m);
 static void p25_call_end_slot(dsd_opts* opts, dsd_state* state, int slot, double observed_m);
 #ifdef USE_RADIO
 static int p25_sm_hold_release_for_vc_cqpsk_reacquire(p25_sm_ctx_t* ctx, dsd_opts* opts, const dsd_state* state,
@@ -2052,7 +2052,7 @@ p25_grant_handle_duplicate(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* s
     p25_grant_refresh_duplicate_crypto(ctx, state, ev, route, eval_ctx, data_call, now_m);
     const int call_slot = p25_grant_logical_slot(ctx, route->slot);
     if (!data_call && call_slot >= 0 && call_slot <= 1 && ctx->slots[call_slot].voice_active) {
-        p25_call_publish_observation(ctx, opts, state, call_slot, 0, 0, P25_CALL_OBS_ASSIGNMENT_REPEAT, now_m);
+        p25_call_publish_observation(ctx, opts, state, call_slot, 0, 0, 0, P25_CALL_OBS_ASSIGNMENT_REPEAT, now_m);
     }
     if (data_call) {
         ctx->t_tune_m = now_m;
@@ -2464,13 +2464,17 @@ p25_call_kind_from_slot(const p25_sm_slot_ctx_t* slot_ctx) {
 
 static int
 p25_call_begin_coalesces_into_active_epoch(const dsd_state* state, int slot, const dsd_call_observation* observation,
-                                           double observed_m) {
+                                           double observed_m, int continuous_activity) {
     // A voice start raised by MAC_ACTIVE follows the traffic-channel GVCU
     // observation of the same transmission, which already began the canonical
     // epoch moments earlier. Forcing a second epoch would push the first
     // epoch's freshly built row as a duplicate event. Coalesce only into a
     // young matching epoch: an identity reused after the window (missed END
-    // plus a fresh start) still begins its own epoch.
+    // plus a fresh start) still begins its own epoch. Continuously observed
+    // voice extends the window -- a first-seen MAC_PTT can decode several
+    // seconds into a transmission whose GVCU began the epoch, and with no END
+    // between them it names the transmission already on the air, not a fresh
+    // start.
     dsd_call_snapshot current;
     if (dsd_call_state_get(state, (uint8_t)slot, &current) <= 0 || current.phase != DSD_CALL_PHASE_ACTIVE) {
         return 0;
@@ -2492,18 +2496,37 @@ p25_call_begin_coalesces_into_active_epoch(const dsd_state* state, int slot, con
         return 0;
     }
     const double now_m = observed_m > 0.0 ? observed_m : dsd_time_now_monotonic_s();
-    return current.started_m > 0.0 && now_m >= current.started_m
-           && (now_m - current.started_m) <= P25_CANONICAL_EPOCH_COALESCE_S;
+    if (current.started_m <= 0.0 || now_m < current.started_m) {
+        return 0;
+    }
+    return (now_m - current.started_m) <= P25_CANONICAL_EPOCH_COALESCE_S || continuous_activity;
+}
+
+// Whether the slot has decoded voice continuously up to this observation: no
+// END was accepted after the epoch began, and the last voice activity is at
+// most one coalesce window old. A gap means a terminator may have been missed,
+// so an identity reuse past the window must fork its own epoch.
+static int
+p25_call_slot_activity_is_continuous(const p25_sm_slot_ctx_t* slot_ctx, double observed_m) {
+    if (!slot_ctx || !slot_ctx->voice_active || slot_ctx->last_active_m <= 0.0) {
+        return 0;
+    }
+    if (slot_ctx->last_end_m > 0.0 && slot_ctx->last_end_m >= slot_ctx->last_start_m) {
+        return 0;
+    }
+    const double now_m = observed_m > 0.0 ? observed_m : dsd_time_now_monotonic_s();
+    return now_m >= slot_ctx->last_active_m && (now_m - slot_ctx->last_active_m) <= P25_CANONICAL_EPOCH_COALESCE_S;
 }
 
 static dsd_call_boundary
 p25_call_publish_boundary(const p25_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state, int slot,
-                          int new_epoch, int allow_coalesce, const dsd_call_observation* observation,
-                          double observed_m) {
+                          int new_epoch, int allow_coalesce, int continuous_activity,
+                          const dsd_call_observation* observation, double observed_m) {
     if (!new_epoch) {
         return DSD_CALL_BOUNDARY_CONTINUE;
     }
-    if (allow_coalesce && p25_call_begin_coalesces_into_active_epoch(state, slot, observation, observed_m)) {
+    if (allow_coalesce
+        && p25_call_begin_coalesces_into_active_epoch(state, slot, observation, observed_m, continuous_activity)) {
         p25_sm_diagf((dsd_opts*)opts, state, ctx, "canonical_epoch_coalesce", "path=trunk slot=%d tg=%llu src=%llu",
                      slot, (unsigned long long)observation->ota_target_id,
                      (unsigned long long)observation->ota_source_id);
@@ -2532,7 +2555,8 @@ p25_call_observation_retains_ended_call(const dsd_state* state, int slot, p25_ca
 
 static void
 p25_call_publish_observation(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, int slot, int new_epoch,
-                             int allow_coalesce, p25_call_obs_provenance provenance, double observed_m) {
+                             int allow_coalesce, int continuous_activity, p25_call_obs_provenance provenance,
+                             double observed_m) {
     if (!ctx || !state || slot < 0 || slot > 1) {
         return;
     }
@@ -2561,8 +2585,8 @@ p25_call_publish_observation(const p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_
         p25_call_publish_crypto_update(opts, state, slot, observed_m, 1);
         return;
     }
-    const dsd_call_boundary boundary =
-        p25_call_publish_boundary(ctx, opts, state, slot, new_epoch, allow_coalesce, &observation, observed_m);
+    const dsd_call_boundary boundary = p25_call_publish_boundary(ctx, opts, state, slot, new_epoch, allow_coalesce,
+                                                                 continuous_activity, &observation, observed_m);
     const int began = dsd_call_state_observe(state, &observation, boundary);
     if (began >= 0) {
         p25_call_publish_crypto(opts, state, slot, observed_m);
@@ -3056,6 +3080,10 @@ typedef struct {
     int requires_update;
     int preserve_crypto_classification;
     int coalesce_canonical_epoch;
+    // Captured before commit closes slot media: whether voice was decoded
+    // continuously right up to this observation. Extends the coalesce window
+    // for a first-seen PTT naming the transmission already on the air.
+    int continuous_activity;
     int ptt_evidence;
 } p25_voice_start_changes_t;
 
@@ -3118,6 +3146,8 @@ p25_voice_start_classify_changes(const p25_sm_ctx_t* ctx, const dsd_state* state
     changes.coalesce_canonical_epoch =
         input->type == P25_SM_EV_ACTIVE
         || (changes.new_epoch && changes.ptt_evidence && p25_voice_ptt_start_may_coalesce(ctx, state, slot));
+    changes.continuous_activity =
+        p25_call_slot_activity_is_continuous(slot_ctx, input->observed_m > 0.0 ? input->observed_m : 0.0);
     return changes;
 }
 
@@ -3242,7 +3272,7 @@ p25_voice_start_commit_identity(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* st
     (void)dsd_tg_policy_note_active_call(state, &route, decision, now_m);
     p25_voice_start_update_crypto(ctx, state, slot, logical_slot, call_ev, eval_ctx, changes, now_m);
     p25_call_publish_observation(ctx, opts, state, slot, changes->new_epoch, changes->coalesce_canonical_epoch,
-                                 P25_CALL_OBS_VOICE_EVIDENCE, now_m);
+                                 changes->continuous_activity, P25_CALL_OBS_VOICE_EVIDENCE, now_m);
     if (changes->ptt_evidence) {
         // Whether this PTT began the epoch or folded into one an ACTIVE
         // observation began, the epoch now contains a PTT: the next
@@ -3662,7 +3692,12 @@ p25_voice_end_event_tg(const p25_sm_ctx_t* ctx, const dsd_state* state, int slot
 
 static int
 p25_voice_end_event_src(const p25_sm_ctx_t* ctx, const dsd_state* state, int slot, const p25_sm_event_t* ev) {
-    return ev && ev->src > 0 ? ev->src : p25_voice_slot_diag_src(ctx, state, slot);
+    // MAC_END_PTT often names the fixed-network placeholder (0xFFFFFF) rather
+    // than the completed talker. Recording the placeholder as the ended
+    // source made every post-END voice-user copy naming the real talker look
+    // like a changed source, defeating the retention-tail suppression and
+    // reopening the ended call between END repeats.
+    return ev && p25_source_id_known(ev->src) ? ev->src : p25_voice_slot_diag_src(ctx, state, slot);
 }
 
 static void

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -3823,7 +3823,12 @@ p25_facch_end_identity_matches(const p25_sm_slot_ctx_t* slot_ctx, const p25_sm_e
         return 0;
     }
     const int event_tg = ev->tg > 0 ? ev->tg : slot_ctx->last_end_tg;
-    const int event_src = ev->src > 0 ? ev->src : slot_ctx->last_end_src;
+    // MAC_END_PTT repeats often carry the fixed-network placeholder source
+    // (0xFFFFFF) while the recorded end identity resolved the placeholder to
+    // the completed talker (p25_voice_end_event_src). Resolve the event the
+    // same way, or a placeholder-sourced repeat looks like a different talker
+    // and the double-END fast release never fires.
+    const int event_src = p25_source_id_known(ev->src) ? ev->src : slot_ctx->last_end_src;
     if (event_tg != slot_ctx->facch_end_tg) {
         return 0;
     }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2855,8 +2855,14 @@ p25_voice_start_follows_completed_epoch(const p25_sm_slot_ctx_t* slot_ctx) {
 // talker is the next transmission and still reopens the call. A changed source is fresh
 // evidence and is never suppressed.
 static int
+p25_voice_end_repeat_tail_active(const p25_sm_slot_ctx_t* slot_ctx, double now_m) {
+    return slot_ctx && slot_ctx->last_end_m > 0.0 && now_m >= slot_ctx->last_end_m
+           && (now_m - slot_ctx->last_end_m) <= P25_POST_END_VOICE_USER_REPEAT_S;
+}
+
+static int
 p25_voice_user_repeats_recent_end(const p25_sm_slot_ctx_t* slot_ctx, int target, int src, double now_m) {
-    if (!slot_ctx || slot_ctx->last_end_m <= 0.0 || target <= 0 || target != slot_ctx->last_end_tg) {
+    if (!slot_ctx || target <= 0 || target != slot_ctx->last_end_tg) {
         return 0;
     }
     if (p25_voice_slot_epoch_active(slot_ctx)) {
@@ -2865,7 +2871,7 @@ p25_voice_user_repeats_recent_end(const p25_sm_slot_ctx_t* slot_ctx, int target,
     if (p25_source_id_known(src) && src != slot_ctx->last_end_src) {
         return 0;
     }
-    return now_m >= slot_ctx->last_end_m && (now_m - slot_ctx->last_end_m) <= P25_POST_END_VOICE_USER_REPEAT_S;
+    return p25_voice_end_repeat_tail_active(slot_ctx, now_m);
 }
 
 int
@@ -3383,8 +3389,34 @@ p25_voice_start_apply_event(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state,
 static int
 p25_voice_start_suppress_post_end_repeat(p25_sm_ctx_t* ctx, dsd_opts* opts, const dsd_state* state, int slot,
                                          const p25_sm_event_t* ev, const char* why, double now_m) {
-    if (ev->type != P25_SM_EV_ACTIVE || !ctx->vc_is_tdma
-        || !p25_voice_user_repeats_recent_end(&ctx->slots[slot], ev->is_group ? ev->tg : ev->dst, ev->src, now_m)) {
+    if (!ctx->vc_is_tdma) {
+        return 0;
+    }
+    const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
+    int repeats = 0;
+    if (ev->type == P25_SM_EV_ACTIVE) {
+        int target = ev->is_group ? ev->tg : ev->dst;
+        if (target <= 0) {
+            // An identity-less ACTIVE (a live-typed PDU whose MAC payload is
+            // not a voice-user block) would re-fill the retained assignment
+            // identity with unknown service options, so judge it against the
+            // identity it would reopen -- otherwise it resurrects the ended
+            // call as a crypto-pending phantom.
+            target = slot_ctx->is_group ? slot_ctx->ota_tg : slot_ctx->dst;
+        }
+        repeats = p25_voice_user_repeats_recent_end(slot_ctx, target, ev->src, now_m);
+    } else if (ev->type == P25_SM_EV_PTT) {
+        // A SACCH MAC_PTT repeat whose four-burst assembly straddled the END
+        // arrives after the END was accepted, still signed like the marker
+        // the completed transmission refreshed. The END keeps that marker
+        // precisely so this repeat stays recognizable; the next transmission
+        // carries a fresh signature (new MI) or lands outside the one-second
+        // marker and retention windows.
+        double elapsed_s = 0.0;
+        repeats = !p25_voice_slot_epoch_active(slot_ctx) && p25_voice_end_repeat_tail_active(slot_ctx, now_m)
+                  && p25_ptt_marker_matches(ctx, slot, ev, now_m, &elapsed_s);
+    }
+    if (!repeats) {
         return 0;
     }
     p25_sm_note_vc_decode_activity(ctx, opts, state, why, slot, now_m);
@@ -3668,7 +3700,11 @@ handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, 
         return 0;
     }
 
-    p25_ptt_marker_invalidate(ctx, s);
+    // The PTT retransmission marker deliberately survives the END: a SACCH
+    // MAC_PTT repeat whose assembly straddled the END is recognized as
+    // retention only by matching it (p25_voice_start_suppress_post_end_repeat).
+    // Epoch-active gating keeps it inert otherwise, and slot clear/release
+    // still invalidates it.
     const double now_m = dsd_time_now_monotonic_s();
     const int ended_tg = p25_voice_end_event_tg(ctx, state, s, ev);
     const int ended_src = p25_voice_end_event_src(ctx, state, s, ev);

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -197,6 +197,27 @@ p25p2_vpdu_update_voice_crypto(dsd_state* state, int slot, int service_options, 
     }
 }
 
+// A live-typed voice user whose four-burst SACCH assembly straddled the
+// accepted MAC_END_PTT still re-describes the ended transmission. Track the
+// slot -- liveness and crypto classification -- without reopening a canonical
+// epoch, which would commit the ended call's row a second time.
+static int
+p25p2_vpdu_voice_repeats_recent_end(dsd_opts* opts, dsd_state* state, int slot, uint64_t target,
+                                    uint64_t subscriber_source, int service_options) {
+    dsd_call_snapshot current = {0};
+    if (dsd_call_state_get(state, (uint8_t)slot, &current) <= 0 || current.phase != DSD_CALL_PHASE_ENDED
+        || !p25_sm_voice_user_repeats_recent_end(slot, (int)target, (int)subscriber_source,
+                                                 dsd_time_now_monotonic_s())) {
+        return 0;
+    }
+    p25p2_vpdu_update_voice_crypto(state, slot, service_options, 0,
+                                   p25p2_vpdu_is_encrypted_probe(opts, service_options));
+    dsd_p25_sm_logf(
+        opts, "event=voice_observation_suppressed path=p2-vpdu reason=repeats-recent-end slot=%d tg=%llu src=%llu",
+        slot, (unsigned long long)target, (unsigned long long)subscriber_source);
+    return 1;
+}
+
 static int
 p25p2_vpdu_observe_voice(dsd_opts* opts, dsd_state* state, int slot, dsd_call_kind kind, uint64_t target,
                          uint64_t source, int service_options, p25_mac_pdu_type pdu_type) {
@@ -218,6 +239,9 @@ p25p2_vpdu_observe_voice(dsd_opts* opts, dsd_state* state, int slot, dsd_call_ki
         return 1;
     }
     const uint64_t subscriber_source = p25_source_id_is_subscriber(source) ? source : 0U;
+    if (p25p2_vpdu_voice_repeats_recent_end(opts, state, slot, target, subscriber_source, service_options)) {
+        return 1;
+    }
     const uint16_t svc = service_options >= 0 ? (uint16_t)service_options : 0U;
     const dsd_call_observation observation = {
         .protocol = p25p2_vpdu_voice_protocol(state),

--- a/tests/protocol/p25/test_p25_p1_lockout_events.c
+++ b/tests/protocol/p25/test_p25_p1_lockout_events.c
@@ -30,12 +30,14 @@
 #include "dsd-neo/core/state_ext.h"
 #include "dsd-neo/core/state_fwd.h"
 
-#define TEST_TG     57111
-#define TEST_ALGID  0x84
-#define TEST_KEYID  0x023F
-// A talkgroup of its own: the encrypted-call cache that lockouts populate is not
-// cleared by reset_test_state(), so reusing TEST_TG would block a later grant.
-#define TEST_TG_ALT (TEST_TG + 100)
+#define TEST_TG       57111
+#define TEST_ALGID    0x84
+#define TEST_KEYID    0x023F
+// Talkgroups of their own: the encrypted-call cache that lockouts populate is
+// not cleared by reset_test_state(), so reusing TEST_TG would block a later
+// grant.
+#define TEST_TG_ALT   (TEST_TG + 100)
+#define TEST_TG_GRANT (TEST_TG + 200)
 
 static dsd_opts g_opts;
 static dsd_state g_state;
@@ -378,10 +380,40 @@ test_non_matching_lockout_still_records_epoch(void) {
     return rc;
 }
 
+/* A tuned assignment whose HDU ESS resolves before any LCW or voice evidence:
+ * the epoch opened to hold the classification must carry the assignment
+ * identity. Minting identity-less split the call across two rows when the
+ * lockout released the channel before an LCW decoded -- a "TGT: 00000000"
+ * row with the resolved ALG/KID next to the assignment's row with pending
+ * crypto and no ALG. */
+static int
+test_pre_identity_ess_uses_assignment_identity(void) {
+    int rc = 0;
+    reset_test_state();
+    tune_group_grant(TEST_TG_GRANT);
+    rc |= expect("pre-identity fixture tuned", p25_sm_get_ctx()->state == P25_SM_TUNED);
+
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE1, 0, TEST_ALGID, TEST_KEYID, 0x1111ULL,
+                             TEST_TG_GRANT);
+    event_ticks();
+
+    dsd_call_snapshot call;
+    rc |= expect("pre-identity ESS opens the assignment call",
+                 dsd_call_state_get(&g_state, 0U, &call) > 0 && call.ota_target_id == TEST_TG_GRANT);
+    rc |= expect("pre-identity call carries the resolved key", call.algid == TEST_ALGID && call.kid == TEST_KEYID);
+    rc |= expect("lockout released the assignment",
+                 dsd_call_state_get(&g_state, 0U, &call) > 0 && call.phase == DSD_CALL_PHASE_ENDED);
+    rc |= expect("one call commits one row", committed_event_count() == 1);
+    rc |= expect("committed row keeps the assignment target", committed_events_contain("TGT: 00057311"));
+    rc |= expect("no identity-less rows", !committed_events_contain("TGT: 00000000"));
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
     rc |= test_lockout_ess_repeats_do_not_mint_epochs();
+    rc |= test_pre_identity_ess_uses_assignment_identity();
     rc |= test_lockout_ess_window_slides_with_repeats();
     rc |= test_non_matching_lockout_still_records_epoch();
     rc |= test_identity_pending_ess_still_opens_call();

--- a/tests/protocol/p25/test_p25_p1_lockout_events.c
+++ b/tests/protocol/p25/test_p25_p1_lockout_events.c
@@ -209,6 +209,8 @@ static int
 test_identity_pending_ess_still_opens_call(void) {
     int rc = 0;
     reset_test_state();
+    // The TDU flow that arms identity_pending is the conventional receiver's.
+    g_opts.trunk_enable = 0;
 
     begin_identified_call();
     (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE1, 0, TEST_ALGID, TEST_KEYID, 0x1111ULL, TEST_TG);
@@ -247,14 +249,19 @@ test_reused_key_after_new_assignment_opens_call(void) {
 
     p25_sm_ctx_t* ctx = p25_sm_get_ctx();
     ctx->grant_count++;
+    // The fresh assignment has the receiver on its traffic channel.
+    ctx->state = P25_SM_TUNED;
     g_state.p25_p1_identity_pending = 0;
     (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE1, 0, TEST_ALGID, TEST_KEYID, 0x6666ULL, TEST_TG);
     event_ticks();
 
     dsd_call_snapshot call;
-    rc |= expect("reused-key assignment opens call",
-                 dsd_call_state_get(&g_state, 0U, &call) > 0 && call.phase == DSD_CALL_PHASE_ACTIVE);
+    // The stale lockout context must not suppress the mint. On the tuned
+    // assignment the enc lockout may end the fresh epoch synchronously, so
+    // assert the new epoch and its key rather than a live phase.
     rc |= expect("reused-key assignment starts new epoch", slot0_epoch() != ended_epoch);
+    rc |= expect("reused-key epoch records the key",
+                 dsd_call_state_get(&g_state, 0U, &call) > 0 && call.algid == TEST_ALGID && call.kid == TEST_KEYID);
     return rc;
 }
 
@@ -264,6 +271,8 @@ static int
 test_ess_after_cryptoless_end_still_opens_call(void) {
     int rc = 0;
     reset_test_state();
+    // Conventional: a trunked receiver without an assignment declines the mint.
+    g_opts.trunk_enable = 0;
 
     begin_identified_call();
     (void)dsd_call_state_end(&g_state, 0U, 0.0);
@@ -287,6 +296,7 @@ static int
 test_stale_same_key_ess_opens_conventional_call(void) {
     int rc = 0;
     reset_test_state();
+    g_opts.trunk_enable = 0;
 
     begin_identified_call();
     (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE1, 0, TEST_ALGID, TEST_KEYID, 0x1111ULL, TEST_TG);
@@ -409,10 +419,36 @@ test_pre_identity_ess_uses_assignment_identity(void) {
     return rc;
 }
 
+/* ESS observed while a trunked receiver sits on the control channel with no
+ * traffic assignment is noise briefly false-syncing as an LDU. Minting an
+ * identity-less epoch for it leaves a stale ACTIVE call that the next real
+ * call's teardown flushes as a phantom TGT 0 row minutes later. Conventional
+ * receivers keep the mint. */
+static int
+test_cc_noise_ess_does_not_mint_epoch(void) {
+    int rc = 0;
+    reset_test_state();
+    p25_sm_get_ctx()->state = P25_SM_ON_CC;
+
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE1, 0, 0x97, 0x540E, 0x1111ULL, 0);
+    event_ticks();
+    dsd_call_snapshot call;
+    rc |= expect("CC-noise ESS mints no epoch", dsd_call_state_get(&g_state, 0U, &call) <= 0);
+    rc |= expect("CC-noise ESS commits no row", committed_event_count() == 0);
+
+    reset_test_state();
+    g_opts.trunk_enable = 0;
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE1, 0, TEST_ALGID, TEST_KEYID, 0x1111ULL, 0);
+    rc |= expect("conventional ESS still opens a call",
+                 dsd_call_state_get(&g_state, 0U, &call) > 0 && call.phase == DSD_CALL_PHASE_ACTIVE);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
     rc |= test_lockout_ess_repeats_do_not_mint_epochs();
+    rc |= test_cc_noise_ess_does_not_mint_epoch();
     rc |= test_pre_identity_ess_uses_assignment_identity();
     rc |= test_lockout_ess_window_slides_with_repeats();
     rc |= test_non_matching_lockout_still_records_epoch();

--- a/tests/protocol/p25/test_p25_p2_active_ptt_epoch.c
+++ b/tests/protocol/p25/test_p25_p2_active_ptt_epoch.c
@@ -257,12 +257,105 @@ test_ptt_without_active_lockout_single_row(void) {
     return rc;
 }
 
+/* Conversation turnaround: after the accepted MAC_END_PTT, END repeats
+ * interleave with SACCH voice-user copies still naming the completed talker.
+ * Such a copy inside the retention tail must not reopen the ended call --
+ * previously it minted a phantom epoch that committed a duplicate row when
+ * the next talker keyed up. */
+static int
+test_post_end_active_repeat_does_not_reopen(void) {
+    int rc = 0;
+    reset_test_state(1);
+    tune_grant(0x00);
+    event_ticks();
+
+    mac_ptt(0x77U);
+    (void)p25_sm_emit_active_call(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC, 1, 0x00);
+    event_ticks();
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, TEST_TG, TEST_SRC, dsd_time_now_monotonic_s());
+    event_ticks();
+    const uint64_t ended_epoch = slot0_epoch();
+
+    /* Delayed SACCH copy still naming the completed talker. */
+    (void)p25_sm_emit_active_call(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC, 1, 0x00);
+    event_ticks();
+    rc |= expect("post-END repeat does not reopen", slot0_phase_is(DSD_CALL_PHASE_ENDED));
+    rc |= expect("post-END repeat mints no epoch", slot0_epoch() == ended_epoch);
+
+    /* Next talker keys up; their transmission runs and ends. */
+    uint8_t sig[P25_SM_PTT_SIGNATURE_BYTES];
+    DSD_MEMSET(sig, 0x88, sizeof(sig));
+    (void)p25_sm_emit_ptt_call_metadata(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC + 7, 1, P25_SM_SVC_UNKNOWN, sig,
+                                        dsd_time_now_monotonic_s(), 0);
+    (void)p25_sm_emit_active_call(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC + 7, 1, 0x00);
+    event_ticks();
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, TEST_TG, TEST_SRC + 7, dsd_time_now_monotonic_s());
+    event_ticks();
+
+    rc |= expect("two transmissions commit two rows", committed_event_count() == 2);
+    return rc;
+}
+
+/* A different talker inside the tail is fresh evidence: the conversation's
+ * next transmission must not be mistaken for retention. */
+static int
+test_post_end_changed_source_reopens(void) {
+    int rc = 0;
+    reset_test_state(1);
+    tune_grant(0x00);
+    event_ticks();
+
+    mac_ptt(0x99U);
+    event_ticks();
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, TEST_TG, TEST_SRC, dsd_time_now_monotonic_s());
+    event_ticks();
+    const uint64_t ended_epoch = slot0_epoch();
+
+    rc |= expect("changed-source ACTIVE accepted",
+                 p25_sm_emit_active_call(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC + 7, 1, 0x00) > 0);
+    rc |= expect("changed-source ACTIVE reopens", slot0_phase_is(DSD_CALL_PHASE_ACTIVE));
+    rc |= expect("changed-source ACTIVE begins epoch", slot0_epoch() != ended_epoch);
+    return rc;
+}
+
+/* The suppression helper the VPDU observation path shares with the state
+ * machine: same identity inside the tail repeats the ended call; outside the
+ * tail, or with a changed source, it is fresh evidence. */
+static int
+test_repeat_helper_windows(void) {
+    int rc = 0;
+    reset_test_state(1);
+    tune_grant(0x00);
+    event_ticks();
+
+    mac_ptt(0xABU);
+    event_ticks();
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, TEST_TG, TEST_SRC, dsd_time_now_monotonic_s());
+    event_ticks();
+
+    const double now_m = dsd_time_now_monotonic_s();
+    rc |= expect("helper: same identity in tail repeats",
+                 p25_sm_voice_user_repeats_recent_end(0, TEST_TG, TEST_SRC, now_m) == 1);
+    rc |= expect("helper: source-less copy in tail repeats",
+                 p25_sm_voice_user_repeats_recent_end(0, TEST_TG, 0, now_m) == 1);
+    rc |= expect("helper: changed source is fresh",
+                 p25_sm_voice_user_repeats_recent_end(0, TEST_TG, TEST_SRC + 7, now_m) == 0);
+    rc |= expect("helper: changed target is fresh",
+                 p25_sm_voice_user_repeats_recent_end(0, TEST_TG + 1, TEST_SRC, now_m) == 0);
+    rc |= expect("helper: outside the tail is fresh",
+                 p25_sm_voice_user_repeats_recent_end(0, TEST_TG, TEST_SRC, now_m + 1.5) == 0);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
     rc |= test_active_then_ptt_lockout_single_row();
     rc |= test_second_ptt_still_begins_new_epoch();
     rc |= test_ptt_without_active_lockout_single_row();
+    rc |= test_post_end_active_repeat_does_not_reopen();
+    rc |= test_post_end_changed_source_reopens();
+    rc |= test_repeat_helper_windows();
 
     if (g_state.event_history_s != NULL) {
         free(g_state.event_history_s);

--- a/tests/protocol/p25/test_p25_p2_active_ptt_epoch.c
+++ b/tests/protocol/p25/test_p25_p2_active_ptt_epoch.c
@@ -364,6 +364,98 @@ test_post_end_identityless_active_does_not_reopen(void) {
     return rc;
 }
 
+/* MAC_END_PTT often names the fixed-network placeholder (0xFFFFFF) instead of
+ * the completed talker. Recording the placeholder as the ended source made a
+ * post-END voice-user copy naming the real talker look like a changed source,
+ * defeating the retention tail and reopening the ended call between END
+ * repeats -- one transmission, two rows. */
+static int
+test_placeholder_end_src_keeps_tail_guard(void) {
+    int rc = 0;
+    reset_test_state(1);
+    tune_grant(0x00);
+    event_ticks();
+
+    mac_ptt(0xB1U);
+    (void)p25_sm_emit_active_call(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC, 1, 0x00);
+    event_ticks();
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, TEST_TG, 0xFFFFFF, dsd_time_now_monotonic_s());
+    event_ticks();
+    const uint64_t ended_epoch = slot0_epoch();
+
+    rc |= expect("placeholder END records the real talker",
+                 p25_sm_voice_user_repeats_recent_end(0, TEST_TG, TEST_SRC, dsd_time_now_monotonic_s()) == 1);
+
+    /* Delayed SACCH copy still naming the completed talker. */
+    (void)p25_sm_emit_active_call(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC, 1, 0x00);
+    event_ticks();
+    rc |= expect("sourced repeat after placeholder END does not reopen", slot0_phase_is(DSD_CALL_PHASE_ENDED));
+    rc |= expect("sourced repeat after placeholder END mints no epoch", slot0_epoch() == ended_epoch);
+    rc |= expect("placeholder END transmission commits one row", committed_event_count() == 1);
+    return rc;
+}
+
+/* A first-seen MAC_PTT can decode several seconds into a transmission whose
+ * GVCU observation began the epoch. With voice decoded continuously and no
+ * END between them, it names the transmission already on the air and must
+ * fold in; the young-epoch window alone forced a split row. After an activity
+ * gap the same late PTT is a fresh start and still forks. */
+static int
+test_late_first_ptt_folds_into_continuous_epoch(void) {
+    int rc = 0;
+    reset_test_state(1);
+    tune_grant(0x00);
+    event_ticks();
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    const double t0 = dsd_time_now_monotonic_s();
+    p25_sm_event_t ev = p25_sm_ev_active_call(0, TEST_TG, 0, TEST_SRC, 1, 0x00);
+    ev.observed_m = t0;
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+    event_ticks();
+    const uint64_t active_epoch = slot0_epoch();
+    rc |= expect("continuity fixture opens the epoch", active_epoch != 0U && slot0_phase_is(DSD_CALL_PHASE_ACTIVE));
+
+    /* Voice-user copies keep the slot continuously active past the window. */
+    for (int i = 1; i <= 2; i++) {
+        ev = p25_sm_ev_active_call(0, TEST_TG, 0, TEST_SRC, 1, 0x00);
+        ev.observed_m = t0 + (double)i;
+        p25_sm_event(ctx, &g_opts, &g_state, &ev);
+    }
+
+    uint8_t sig[P25_SM_PTT_SIGNATURE_BYTES];
+    DSD_MEMSET(sig, 0xF2, sizeof(sig));
+    (void)p25_sm_emit_ptt_call_metadata(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC, 1, P25_SM_SVC_UNKNOWN, sig,
+                                        t0 + 2.4, 0);
+    event_ticks();
+    rc |= expect("late first PTT folds into the continuous epoch", slot0_epoch() == active_epoch);
+    rc |= expect("late first PTT keeps the epoch live", slot0_phase_is(DSD_CALL_PHASE_ACTIVE));
+
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, TEST_TG, TEST_SRC, t0 + 3.0);
+    event_ticks();
+    rc |= expect("continuous transmission commits one row", committed_event_count() == 1);
+
+    /* Same shape with an activity gap: a missed terminator may hide a fresh
+     * start, so the late PTT must fork its own epoch. */
+    reset_test_state(1);
+    tune_grant(0x00);
+    event_ticks();
+    ctx = p25_sm_get_ctx();
+    const double t1 = dsd_time_now_monotonic_s();
+    ev = p25_sm_ev_active_call(0, TEST_TG, 0, TEST_SRC, 1, 0x00);
+    ev.observed_m = t1;
+    p25_sm_event(ctx, &g_opts, &g_state, &ev);
+    event_ticks();
+    const uint64_t gap_epoch = slot0_epoch();
+
+    DSD_MEMSET(sig, 0xF3, sizeof(sig));
+    (void)p25_sm_emit_ptt_call_metadata(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC, 1, P25_SM_SVC_UNKNOWN, sig,
+                                        t1 + 2.4, 0);
+    event_ticks();
+    rc |= expect("late PTT after an activity gap forks", slot0_epoch() != gap_epoch);
+    return rc;
+}
+
 /* A different talker inside the tail is fresh evidence: the conversation's
  * next transmission must not be mistaken for retention. */
 static int
@@ -424,6 +516,8 @@ main(void) {
     rc |= test_post_end_active_repeat_does_not_reopen();
     rc |= test_post_end_ptt_repeat_does_not_reopen();
     rc |= test_post_end_identityless_active_does_not_reopen();
+    rc |= test_placeholder_end_src_keeps_tail_guard();
+    rc |= test_late_first_ptt_folds_into_continuous_epoch();
     rc |= test_post_end_changed_source_reopens();
     rc |= test_repeat_helper_windows();
 

--- a/tests/protocol/p25/test_p25_p2_active_ptt_epoch.c
+++ b/tests/protocol/p25/test_p25_p2_active_ptt_epoch.c
@@ -296,6 +296,74 @@ test_post_end_active_repeat_does_not_reopen(void) {
     return rc;
 }
 
+/* A SACCH MAC_PTT repeat whose four-burst assembly straddled the accepted END
+ * re-arrives inside the retention tail carrying the signature the completed
+ * transmission already refreshed. It must not reopen the ended call --
+ * previously it force-minted a phantom epoch (the END had invalidated the
+ * retransmission marker) that committed an identical duplicate row. */
+static int
+test_post_end_ptt_repeat_does_not_reopen(void) {
+    int rc = 0;
+    reset_test_state(1);
+    tune_grant(0x00);
+    event_ticks();
+
+    mac_ptt(0xC3U);
+    (void)p25_sm_emit_active_call(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC, 1, 0x00);
+    event_ticks();
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, TEST_TG, TEST_SRC, dsd_time_now_monotonic_s());
+    event_ticks();
+    const uint64_t ended_epoch = slot0_epoch();
+
+    /* Delayed SACCH copy of one of the transmission-start PTT repeats. */
+    mac_ptt(0xC3U);
+    event_ticks();
+    rc |= expect("post-END PTT repeat does not reopen", slot0_phase_is(DSD_CALL_PHASE_ENDED));
+    rc |= expect("post-END PTT repeat mints no epoch", slot0_epoch() == ended_epoch);
+
+    /* The next transmission keys up inside the tail with a fresh signature
+     * (a new MI): that is the conversation continuing, not retention. */
+    uint8_t sig[P25_SM_PTT_SIGNATURE_BYTES];
+    DSD_MEMSET(sig, 0xD4, sizeof(sig));
+    (void)p25_sm_emit_ptt_call_metadata(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC + 7, 1, P25_SM_SVC_UNKNOWN, sig,
+                                        dsd_time_now_monotonic_s(), 0);
+    event_ticks();
+    rc |= expect("fresh-signature PTT reopens", slot0_phase_is(DSD_CALL_PHASE_ACTIVE));
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, TEST_TG, TEST_SRC + 7, dsd_time_now_monotonic_s());
+    event_ticks();
+
+    rc |= expect("two transmissions commit two rows", committed_event_count() == 2);
+    return rc;
+}
+
+/* A live-typed MAC_ACTIVE whose payload carries no decodable voice-user block
+ * emits an identity-less start. Inside the tail it re-fills the retained
+ * assignment identity with unknown service options, reopening the ended call
+ * as a crypto-pending phantom -- the field's trailing "SRC 00000000; ENC"
+ * rows. It must be treated as retention like its identity-bearing siblings. */
+static int
+test_post_end_identityless_active_does_not_reopen(void) {
+    int rc = 0;
+    reset_test_state(1);
+    tune_grant(0x00);
+    event_ticks();
+
+    mac_ptt(0xE5U);
+    (void)p25_sm_emit_active_call(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC, 1, 0x00);
+    event_ticks();
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, TEST_TG, TEST_SRC, dsd_time_now_monotonic_s());
+    event_ticks();
+    const uint64_t ended_epoch = slot0_epoch();
+
+    /* Live-typed PDU with non-voice MAC content inside the retention tail. */
+    (void)p25_sm_emit_active(&g_opts, &g_state, 0);
+    event_ticks();
+    rc |= expect("post-END identity-less ACTIVE does not reopen", slot0_phase_is(DSD_CALL_PHASE_ENDED));
+    rc |= expect("post-END identity-less ACTIVE mints no epoch", slot0_epoch() == ended_epoch);
+    rc |= expect("one transmission commits one row", committed_event_count() == 1);
+    return rc;
+}
+
 /* A different talker inside the tail is fresh evidence: the conversation's
  * next transmission must not be mistaken for retention. */
 static int
@@ -354,6 +422,8 @@ main(void) {
     rc |= test_second_ptt_still_begins_new_epoch();
     rc |= test_ptt_without_active_lockout_single_row();
     rc |= test_post_end_active_repeat_does_not_reopen();
+    rc |= test_post_end_ptt_repeat_does_not_reopen();
+    rc |= test_post_end_identityless_active_does_not_reopen();
     rc |= test_post_end_changed_source_reopens();
     rc |= test_repeat_helper_windows();
 

--- a/tests/protocol/p25/test_p25_p2_hangtime_events.c
+++ b/tests/protocol/p25/test_p25_p2_hangtime_events.c
@@ -157,6 +157,12 @@ test_identity_decode_failure_still_reopens_call(void) {
     end_transmission(TEST_SRC);
     const uint64_t ended_epoch = slot0_epoch();
 
+    // Past the post-END retention tail: inside it an identity-less ACTIVE is
+    // retention of the ended call and must not reopen (covered by
+    // P25_P2_ACTIVE_PTT_EPOCH); after it, a live-typed PDU whose identity
+    // failed to decode is the next transmission arriving.
+    p25_sm_get_ctx()->slots[0].last_end_m = dsd_time_now_monotonic_s() - 1.1;
+
     rc |= expect("anonymous ACTIVE accepted", p25_sm_emit_active(&g_opts, &g_state, 0) > 0);
     rc |= expect("anonymous ACTIVE opens retained assignment", slot0_matches(DSD_CALL_PHASE_ACTIVE, TEST_TG, 0U));
     rc |= expect("anonymous ACTIVE starts epoch", slot0_epoch() != ended_epoch);

--- a/tests/protocol/p25/test_p25_p2_hangtime_events.c
+++ b/tests/protocol/p25/test_p25_p2_hangtime_events.c
@@ -6,7 +6,11 @@
 /*
  * P25 Phase 2 MAC_ACTIVE is positive transmission evidence. Hangtime voice
  * users are filtered by their outer MAC PDU type in the VPDU decoder, so the
- * state machine must not infer hangtime from a recently ended identity.
+ * state machine must not infer hangtime from a recently ended identity --
+ * with one time-bounded exception: inside the short post-END retention tail,
+ * copies still naming the completed talker on the unchanged target re-describe
+ * the transmission that just ended and must not reopen it (see
+ * test_p25_p2_active_ptt_epoch.c).
  */
 
 #include <dsd-neo/core/call_state.h>
@@ -130,6 +134,10 @@ test_same_identity_mac_active_reopens_call(void) {
     transmit_clear(0x11U, TEST_SRC);
     end_transmission(TEST_SRC);
     const uint64_t ended_epoch = slot0_epoch();
+
+    // Past the post-END retention tail: END repeats and delayed SACCH copies
+    // of the ended transmission arrive inside it, a re-keyed talker after it.
+    p25_sm_get_ctx()->slots[0].last_end_m = dsd_time_now_monotonic_s() - 1.1;
 
     rc |= expect("same-source ACTIVE accepted",
                  p25_sm_emit_active_call(&g_opts, &g_state, 0, TEST_TG, 0, TEST_SRC, 1, 0x00) > 0);

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -493,7 +493,9 @@ test_raw_ptt_retransmissions_coalesce_history(void) {
 
     ev = p25_sm_ev_end_call_at(0, 1000, 123, first_m + 1.3);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
-    if (ctx.slots[0].ptt_signature_valid || dsd_call_state_get(&g_state, 0U, &call) <= 0
+    // The marker survives the explicit END so a straddling SACCH PTT repeat
+    // inside the retention tail stays recognizable as retention.
+    if (!ctx.slots[0].ptt_signature_valid || dsd_call_state_get(&g_state, 0U, &call) <= 0
         || call.phase != DSD_CALL_PHASE_ENDED || call.epoch != 1U
         || event_history[0].Event_History_Items[1].target_id != 1000U
         || strcmp(event_history[0].Event_History_Items[1].alias, "RETX-ALIAS") != 0
@@ -598,8 +600,12 @@ test_raw_ptt_boundary_invalidation(void) {
             ev.observed_m = first_m + 0.1;
         }
         p25_sm_event(&ctx, &g_opts, &g_state, &ev);
-        if (ctx.slots[0].ptt_signature_valid) {
-            DSD_FPRINTF(stderr, "FAIL: Accepted boundary %d retained its PTT marker\n", (int)boundaries[i]);
+        // An explicit END keeps the marker so a straddling SACCH PTT repeat
+        // inside its retention tail stays recognizable; inactivity teardowns
+        // have no straddle to recognize and drop it.
+        const int marker_should_survive = boundaries[i] == P25_SM_EV_END;
+        if (ctx.slots[0].ptt_signature_valid != marker_should_survive) {
+            DSD_FPRINTF(stderr, "FAIL: Boundary %d marker handling changed\n", (int)boundaries[i]);
             return 1;
         }
 
@@ -1932,6 +1938,11 @@ test_anonymous_followup_restarts_crypto_pending(void) {
 
     ev = p25_sm_ev_end(0);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    // Past the post-END retention tail: inside it an identity-less ACTIVE is
+    // retention of the ended call and must not reopen (P25_P2_ACTIVE_PTT_EPOCH
+    // covers that); after it, one that fails identity decode is the next
+    // transmission and must not inherit the ended call's clear classification.
+    ctx.slots[0].last_end_m = dsd_time_now_monotonic_s() - 1.1;
     ev = p25_sm_ev_active(0);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
     if (g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_ENCRYPTED_PENDING || ctx.slots[0].svc_bits != P25_SM_SVC_UNKNOWN

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -2598,6 +2598,67 @@ test_tdma_facch_double_end_release(void) {
     return 0;
 }
 
+// Regression: MAC_END_PTT frequently names the fixed-network placeholder
+// source (0xFFFFFF) instead of the completed talker, while the first END now
+// records the talker as the ended source. A placeholder-sourced repeat must
+// resolve to that recorded talker and still qualify the double-END fast
+// release -- otherwise the carrier lingers until hangtime expires after the
+// traffic channel already went quiet.
+static int
+test_tdma_facch_double_end_release_placeholder_src(void) {
+    reset_test_state();
+    g_state.trunk_chan_map[0x1234] = 851500000;
+    g_state.p25_chan_tdma_explicit[1] = 2;
+
+    p25_sm_ctx_t ctx;
+    p25_sm_init_ctx(&ctx, &g_opts, &g_state);
+    p25_sm_event_t ev = p25_sm_ev_group_grant(0x1234, 851500000, 1000, 123, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    ev = p25_sm_ev_ptt_call(0, 1000, 0, 123, 1, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+
+    const double first_m = dsd_time_now_monotonic_s() + 0.01;
+    ev = p25_sm_ev_facch_end_call_at(0, 1000, 0xFFFFFF, first_m);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.state != P25_SM_TUNED || g_return_requests != 0) {
+        DSD_FPRINTF(stderr, "FAIL: First placeholder FACCH END released the carrier\n");
+        return 1;
+    }
+    if (ctx.slots[0].last_end_src != 123) {
+        DSD_FPRINTF(stderr, "FAIL: Placeholder END did not record the talker as the ended source\n");
+        return 1;
+    }
+
+    ev = p25_sm_ev_facch_end_call_at(0, 1000, 0xFFFFFF, first_m + 0.5);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.state != P25_SM_ON_CC || g_return_requests != 1) {
+        DSD_FPRINTF(stderr, "FAIL: Placeholder FACCH END pair did not release exactly once\n");
+        return 1;
+    }
+
+    // A repeat naming a different real talker is fresh evidence, never a
+    // qualifying pair.
+    reset_test_state();
+    g_state.trunk_chan_map[0x1234] = 851500000;
+    g_state.p25_chan_tdma_explicit[1] = 2;
+    p25_sm_init_ctx(&ctx, &g_opts, &g_state);
+    ev = p25_sm_ev_group_grant(0x1234, 851500000, 1000, 123, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    ev = p25_sm_ev_ptt_call(0, 1000, 0, 123, 1, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    const double second_m = dsd_time_now_monotonic_s() + 0.01;
+    ev = p25_sm_ev_facch_end_call_at(0, 1000, 0xFFFFFF, second_m);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    ev = p25_sm_ev_facch_end_call_at(0, 1000, 456, second_m + 0.5);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (g_return_requests != 0) {
+        DSD_FPRINTF(stderr, "FAIL: Different-talker FACCH END qualified the fast release\n");
+        return 1;
+    }
+
+    return 0;
+}
+
 static int
 test_inband_target_change_rechecks_policy(void) {
     reset_test_state();
@@ -2860,6 +2921,7 @@ main(void) {
     fail += test_tdma_single_slot_end_retains_carrier();
     fail += test_tdma_end_identity_and_order_guards();
     fail += test_tdma_facch_double_end_release();
+    fail += test_tdma_facch_double_end_release_placeholder_src();
     fail += test_inband_target_change_rechecks_policy();
     fail += test_inband_policy_reject_preserves_tdma_companion();
     fail += test_inband_policy_reject_releases_after_companion_ended();


### PR DESCRIPTION
## Problem

On busy P25p2 talkgroups, one transmission could produce two identical event-history rows with the same timestamp, and short trailing `SRC: 00000000` rows appeared after some transmissions:

```
|[1] 2026-07-28 22:48:23 P25p2 TGT: 00050061; SRC: 01600001; ... Group; SName: 16DISP_1; Mode: D;
|[1] 2026-07-28 22:48:23 P25p2 TGT: 00050061; SRC: 01600001; ... Group; SName: 16DISP_1; Mode: D;
```

After an accepted MAC_END_PTT the FNE keeps describing the completed call for a few bursts: END repeats interleave with SACCH voice-user copies whose four-burst assembly began before the END decoded. Both the trunk SM ACTIVE path and the vpdu GVCU observation treated those copies as positive evidence of a new transmission and reopened a canonical epoch for the call that just ended. That phantom epoch died at hangtime or at the next talker's PTT and committed a duplicate row. Reproduced in a unit harness: `PTT(A) → ACTIVE(A) → END(A) → delayed ACTIVE(A) → PTT(B)` committed three rows for two transmissions.

## Fix

Treat a voice user naming the completed talker (or naming no talker) on the unchanged target inside a one-second post-END tail as retention: channel liveness still advances and crypto classification is still tracked, but no epoch reopens. The predicate is shared as `p25_sm_voice_user_repeats_recent_end()` so the state machine and the vpdu observation path apply one rule.

The time bound is what the previously retired identity-only guards lacked: outside the tail, a genuinely ACTIVE-typed voice user re-naming the same talker is the next transmission and still reopens the call, and a changed source is never suppressed. The guard is scoped to TDMA voice channels — Phase 1's post-TDU same-identity signaling drives its own HDU/LCW crypto machinery and keeps flowing.

## Testing

- New cases in `P25_P2_ACTIVE_PTT_EPOCH`: a conversation turnaround with a delayed post-END copy commits exactly one row per talker; a changed source inside the tail still reopens; the helper's window edges (source-less copy, changed target, expired tail) are pinned.
- `P25_P2_HANGTIME_EVENTS` backdates its END so its same-identity reopen assertion tests the post-tail behavior it was written for; the PDU-type filtering rationale in the file header is updated to note the time-bounded exception.
- Full suite passes (475/475); `tools/preflight_ci.sh` clean.