### PR TITLE
ui: make the compact view a real scanner layout

### DIFF
--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -78,7 +78,7 @@ trunking/scanner to be enabled, and RTL controls require RTL input).
 | Key | Action |
 |---|---|
 | `q` | Quit |
-| `c` | Toggle compact view |
+| `c` | Toggle compact scanner view |
 | `h` | Cycle history mode |
 | `x` / `X` | Toggle mute |
 | `z` | Toggle payload logging (`-Z`-like) |
@@ -164,3 +164,18 @@ trunking/scanner to be enabled, and RTL controls require RTL input).
 | `s` | Stop playback |
 | `[` / `]` | Event history previous/next |
 | `\\` | Toggle event history slot (or toggle M17 TX in encoder mode) |
+
+## Compact View
+
+Press `c` (or use Menu → UI Display → General → Compact View) to collapse the main screen to a scanner-style
+layout. While active, the header shows a `Compact (c)` indicator and the frame renders only:
+
+- the header banner and any transient status toast;
+- a condensed `Status` block: decoder mode, demod/symbol rate, tuner Busy/Free (when trunking), SNR meter,
+  input level, output mute state, and slot on/off states;
+- the full Call Info section (per-slot TGT/SRC, active channels, tuned frequency, TG HOLD);
+- the event history, which expands into the freed rows.
+
+Suppressed while compact: the Input Output section, visual aids (including any enabled visualizers — their
+toggles are remembered and restored when leaving compact), the detailed Audio Decode section, the optional P25
+sections, and the Channels list. The setting is session-only and is not persisted to the config file.

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -177,5 +177,8 @@ layout. While active, the header shows a `Compact (c)` indicator and the frame r
 - the event history, which expands into the freed rows.
 
 Suppressed while compact: the Input Output section, visual aids (including any enabled visualizers — their
-toggles are remembered and restored when leaving compact), the detailed Audio Decode section, the optional P25
-sections, and the Channels list. The setting is session-only and is not persisted to the config file.
+toggles are remembered and restored when leaving compact; switching one on while compact shows a brief
+"hidden in compact view" toast), the detailed Audio Decode section, the optional P25 sections, and the
+Channels list. The condensed Status block also omits the Voice Error counters and the `CRC/(RAS)` decoder
+indicator from the full Audio Decode section — leave compact view to inspect those. The setting is
+session-only and is not persisted to the config file.

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -2495,6 +2495,7 @@ apply_cmd_basic_a(dsd_opts* opts, dsd_state* state, const struct dsd_app_command
             return 1;
         case DSD_APP_CMD_TOGGLE_COMPACT:
             opts->frontend_terminal_display.terminal_compact = opts->frontend_terminal_display.terminal_compact ? 0 : 1;
+            dsd_telemetry_request_redraw();
             return 1;
         case DSD_APP_CMD_HISTORY_CYCLE:
             (void)dsd_app_frontend_history_cycle_mode();

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -2654,13 +2654,22 @@ apply_cmd_payload_filters(dsd_opts* opts, dsd_state* state, const struct dsd_app
     return ui_cmd_apply_handler_table(k_handlers, sizeof k_handlers / sizeof k_handlers[0], opts, state, c);
 }
 
+/* Visual aids are suppressed while compact view is active; surface a hint when
+   a visualizer is switched on there so the key does not look dead. */
+static void
+ui_toast_visualizer_hidden_if_compact(const dsd_opts* opts, dsd_state* state, uint8_t view_on) {
+    if (view_on && opts->frontend_terminal_display.terminal_compact == 1) {
+        ui_set_toast(state, 3, "Visualizer hidden in compact view (c to exit)");
+    }
+}
+
 static int
 apply_cmd_constellation(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
-    (void)state;
     switch (c->id) {
         case DSD_APP_CMD_CONST_TOGGLE:
             if (opts->audio_in_type == AUDIO_IN_RTL) {
                 opts->frontend_display.constellation = opts->frontend_display.constellation ? 0 : 1;
+                ui_toast_visualizer_hidden_if_compact(opts, state, opts->frontend_display.constellation);
             }
             return 1;
         case DSD_APP_CMD_CONST_NORM_TOGGLE:
@@ -2691,10 +2700,10 @@ apply_cmd_constellation(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
 
 static int
 ui_cmd_handle_eye_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
-    (void)state;
     (void)c;
     if (opts->audio_in_type == AUDIO_IN_RTL) {
         opts->frontend_display.eye_view = opts->frontend_display.eye_view ? 0 : 1;
+        ui_toast_visualizer_hidden_if_compact(opts, state, opts->frontend_display.eye_view);
     }
     return 1;
 }
@@ -2721,20 +2730,20 @@ ui_cmd_handle_eye_color_toggle(dsd_opts* opts, dsd_state* state, const struct ds
 
 static int
 ui_cmd_handle_fsk_hist_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
-    (void)state;
     (void)c;
     if (opts->audio_in_type == AUDIO_IN_RTL) {
         opts->frontend_display.fsk_hist_view = opts->frontend_display.fsk_hist_view ? 0 : 1;
+        ui_toast_visualizer_hidden_if_compact(opts, state, opts->frontend_display.fsk_hist_view);
     }
     return 1;
 }
 
 static int
 ui_cmd_handle_spectrum_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
-    (void)state;
     (void)c;
     if (opts->audio_in_type == AUDIO_IN_RTL) {
         opts->frontend_display.spectrum_view = opts->frontend_display.spectrum_view ? 0 : 1;
+        ui_toast_visualizer_hidden_if_compact(opts, state, opts->frontend_display.spectrum_view);
     }
     return 1;
 }

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -1044,11 +1044,26 @@ ui_render_demod_snr_line(const dsd_opts* opts, const dsd_state* state) {
     printw("\n");
 }
 
+/* In Level is meaningful for non-RTL inputs and RTL C4FM/GFSK modes. Hide only
+   for RTL QPSK where symbols are fixed ±1/±3 from differential demod. */
+static int
+ui_in_level_visible(const dsd_opts* opts, const dsd_state* state) {
+    return opts->audio_in_type != AUDIO_IN_RTL || state->rf_mod != 1;
+}
+
+/* Single-slot rendering applies when stereo decoding is off or a DMR mono
+   override is active; *mono_slot selects the slot whose state is shown
+   (0 -> slot 1, 1 -> slot 2). */
+static int
+ui_single_slot_mode(const dsd_opts* opts, const dsd_state* state, int* mono_slot) {
+    const int dmr_mono_override_active = opts->dmr_mono == 1 && DSD_SYNC_IS_DMR(ncurses_last_synctype);
+    *mono_slot = (dmr_mono_override_active && state->dmr_mono_slot == 1) ? 1 : 0;
+    return opts->dmr_stereo == 0 || dmr_mono_override_active;
+}
+
 static void
 ui_render_audio_decode_levels(const dsd_opts* opts, const dsd_state* state, int level) {
-    /* In Level is meaningful for non-RTL inputs and RTL C4FM/GFSK modes.
-       Hide only for RTL QPSK where symbols are fixed ±1/±3 from differential demod. */
-    if (opts->audio_in_type != AUDIO_IN_RTL || state->rf_mod != 1) {
+    if (ui_in_level_visible(opts, state)) {
         ui_print_kv_line("In Level", "[%02d%%]", level);
     }
     /* Quick hint for output mute toggle */
@@ -1137,10 +1152,9 @@ ui_render_audio_decode_section(dsd_opts* opts, const dsd_state* state, int level
     int is_p25p1_active = DSD_SYNC_IS_P25P1(ncurses_last_synctype);
     int is_p25p2_active = DSD_SYNC_IS_P25P2(ncurses_last_synctype);
     int is_p25_active = is_p25p1_active || is_p25p2_active;
-    const int dmr_mono_override_active = opts->dmr_mono == 1 && DSD_SYNC_IS_DMR(ncurses_last_synctype);
+    int mono_slot = 0;
 
-    if (opts->dmr_stereo == 0 || dmr_mono_override_active) {
-        const int mono_slot = dmr_mono_override_active && state->dmr_mono_slot == 1 ? 1 : 0;
+    if (ui_single_slot_mode(opts, state, &mono_slot)) {
         ui_render_voice_error_single_slot(opts, state, is_p25_active, mono_slot);
     } else {
         ui_render_voice_error_dual_slot(opts, state, is_p25_active);
@@ -1149,7 +1163,7 @@ ui_render_audio_decode_section(dsd_opts* opts, const dsd_state* state, int level
 }
 
 static void
-ui_render_compact_status_line(dsd_opts* opts, const dsd_state* state) {
+ui_render_compact_status_line(const dsd_opts* opts, const dsd_state* state) {
     ui_print_label_pad("Status");
     {
         const char* modlab = (state->rf_mod == 1) ? "QPSK" : (state->rf_mod == 2) ? "GFSK" : "C4FM";
@@ -1164,16 +1178,13 @@ ui_render_compact_status_line(dsd_opts* opts, const dsd_state* state) {
 static void
 ui_render_compact_levels_line(const dsd_opts* opts, const dsd_state* state, int level) {
     ui_print_label_pad("Levels");
-    /* Same visibility rule as ui_render_audio_decode_levels: In Level is not
-       meaningful for RTL QPSK (fixed +/-1,+/-3 differential symbols). */
-    if (opts->audio_in_type != AUDIO_IN_RTL || state->rf_mod != 1) {
+    if (ui_in_level_visible(opts, state)) {
         printw("In [%02d%%]  ", level);
     }
     printw("Out (x) [%s]", (opts->audio_out == 0) ? "Muted" : "On");
 
-    const int dmr_mono_override_active = opts->dmr_mono == 1 && DSD_SYNC_IS_DMR(ncurses_last_synctype);
-    if (opts->dmr_stereo == 0 || dmr_mono_override_active) {
-        const int mono_slot = dmr_mono_override_active && state->dmr_mono_slot == 1 ? 1 : 0;
+    int mono_slot = 0;
+    if (ui_single_slot_mode(opts, state, &mono_slot)) {
         if (mono_slot == 1) {
             printw("  S2 (2) [%s]", (opts->slot2_on == 1) ? "On" : "Off");
         } else {
@@ -1190,7 +1201,7 @@ ui_render_compact_levels_line(const dsd_opts* opts, const dsd_state* state, int 
    sections when compact view is active ('c'): decode mode, tuner state, SNR
    meter, and level/slot basics. Call Info and event history render as usual. */
 static void
-ui_render_compact_status_section(dsd_opts* opts, const dsd_state* state, int level) {
+ui_render_compact_status_section(const dsd_opts* opts, const dsd_state* state, int level) {
     if (opts == NULL || state == NULL) {
         return;
     }

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -1149,6 +1149,62 @@ ui_render_audio_decode_section(dsd_opts* opts, const dsd_state* state, int level
 }
 
 static void
+ui_render_compact_status_line(dsd_opts* opts, const dsd_state* state) {
+    ui_print_label_pad("Status");
+    {
+        const char* modlab = (state->rf_mod == 1) ? "QPSK" : (state->rf_mod == 2) ? "GFSK" : "C4FM";
+        printw("[%s] [%s][%d]", opts->output_name, modlab, ui_demod_symbol_rate_hz(opts, state));
+    }
+    if (opts->trunk_enable == 1) {
+        printw("  Tuner [%s]", (opts->trunk_is_tuned == 1) ? "Busy" : "Free");
+    }
+    printw("\n");
+}
+
+static void
+ui_render_compact_levels_line(const dsd_opts* opts, const dsd_state* state, int level) {
+    ui_print_label_pad("Levels");
+    /* Same visibility rule as ui_render_audio_decode_levels: In Level is not
+       meaningful for RTL QPSK (fixed +/-1,+/-3 differential symbols). */
+    if (opts->audio_in_type != AUDIO_IN_RTL || state->rf_mod != 1) {
+        printw("In [%02d%%]  ", level);
+    }
+    printw("Out (x) [%s]", (opts->audio_out == 0) ? "Muted" : "On");
+
+    const int dmr_mono_override_active = opts->dmr_mono == 1 && DSD_SYNC_IS_DMR(ncurses_last_synctype);
+    if (opts->dmr_stereo == 0 || dmr_mono_override_active) {
+        const int mono_slot = dmr_mono_override_active && state->dmr_mono_slot == 1 ? 1 : 0;
+        if (mono_slot == 1) {
+            printw("  S2 (2) [%s]", (opts->slot2_on == 1) ? "On" : "Off");
+        } else {
+            printw("  S1 (1) [%s]", (opts->slot1_on == 1) ? "On" : "Off");
+        }
+    } else {
+        printw("  S1 (1) [%s]  S2 (2) [%s]", (opts->slot1_on == 1) ? "On" : "Off",
+               (opts->slot2_on == 1) ? "On" : "Off");
+    }
+    printw("\n");
+}
+
+/* Condensed status block shown instead of the Input Output / Audio Decode
+   sections when compact view is active ('c'): decode mode, tuner state, SNR
+   meter, and level/slot basics. Call Info and event history render as usual. */
+static void
+ui_render_compact_status_section(dsd_opts* opts, const dsd_state* state, int level) {
+    if (opts == NULL || state == NULL) {
+        return;
+    }
+    ui_print_header("Status");
+    ui_render_compact_status_line(opts, state);
+    /* The SNR field continues an existing line in the full view; give it a
+       left border when it starts its own line here. */
+    ui_print_lborder();
+    ui_render_demod_snr_line(opts, state);
+    ui_render_compact_levels_line(opts, state, level);
+    ui_print_hr();
+}
+
+static void
 ui_sort_indices_by_last_seen(const time_t* last_seen, int* idxs, int n) {
     for (int i = 0; i < n; i++) {
         int best = i;
@@ -3008,7 +3064,7 @@ ui_render_call_info_and_history(const dsd_opts* opts, dsd_state* state) {
     ui_print_hr();
 
     // Render learned LCNs just under the Call Info section when trunking (toggle in menu)
-    if (opts->frontend_display.show_channels == 1) {
+    if (opts->frontend_display.show_channels == 1 && opts->frontend_terminal_display.terminal_compact == 0) {
         ui_print_learned_lcns(opts, state);
         // fence bottom only when Channels are shown
         ui_print_hr();
@@ -3022,8 +3078,8 @@ ui_render_call_info_and_history(const dsd_opts* opts, dsd_state* state) {
 
 void
 dsd_terminal_render(dsd_opts* opts, dsd_state* state) {
-    /* Guard against null opts. Without opts we cannot render safely. */
-    if (!opts) {
+    /* Guard against null opts/state. Without them we cannot render safely. */
+    if (!opts || !state) {
         return;
     }
     /* Demod path must not touch ncurses. Telemetry is published through
@@ -3038,18 +3094,25 @@ dsd_terminal_render(dsd_opts* opts, dsd_state* state) {
     //Start Printing Section
     erase();
     ui_panel_header_render(opts, state);
-    if (state) {
-        ui_panel_footer_status_render(opts, state);
+    ui_panel_footer_status_render(opts, state);
+
+    const int compact = opts->frontend_terminal_display.terminal_compact == 1;
+
+    if (!compact) {
+        ui_render_input_output_section(opts, state);
+        ui_render_rtl_visual_aids(opts, state);
     }
 
-    ui_render_input_output_section(opts, state);
-    ui_render_rtl_visual_aids(opts, state);
-
+    /* Always compute the input level: it also arms the carrier color pair
+       that Call Info relies on, in compact and full views alike. */
     level = ui_compute_input_level_and_color(opts, state);
 
-    ui_render_audio_decode_section(opts, state, level);
-
-    ui_render_p25_optional_sections(opts, state);
+    if (compact) {
+        ui_render_compact_status_section(opts, state, level);
+    } else {
+        ui_render_audio_decode_section(opts, state, level);
+        ui_render_p25_optional_sections(opts, state);
+    }
 
     ui_render_call_info_and_history(opts, state);
 

--- a/src/ui/terminal/menu_actions.c
+++ b/src/ui/terminal/menu_actions.c
@@ -1189,6 +1189,12 @@ act_toggle_ui_channels(void* v) {
 }
 
 void
+act_toggle_ui_compact(void* v) {
+    UNUSED(v);
+    (void)dsd_app_command_action(DSD_APP_CMD_TOGGLE_COMPACT);
+}
+
+void
 act_toggle_ui_p25_callsign(void* v) {
     UNUSED(v);
     (void)dsd_app_command_action(DSD_APP_CMD_UI_SHOW_P25_CALLSIGN_TOGGLE);

--- a/src/ui/terminal/menu_actions.h
+++ b/src/ui/terminal/menu_actions.h
@@ -161,6 +161,7 @@ void act_toggle_ui_p25_neighbors(void* v);
 void act_toggle_ui_p25_iden(void* v);
 void act_toggle_ui_p25_ccc(void* v);
 void act_toggle_ui_channels(void* v);
+void act_toggle_ui_compact(void* v);
 void act_toggle_ui_p25_callsign(void* v);
 
 // ---- RTL-SDR actions (USE_RADIO only) ----

--- a/src/ui/terminal/menu_items.c
+++ b/src/ui/terminal/menu_items.c
@@ -650,6 +650,10 @@ static const NcMenuItem UI_DISPLAY_GENERAL_ITEMS[] = {
      .label_fn = lbl_ui_channels,
      .help = "Toggle Channels section.",
      .on_select = act_toggle_ui_channels},
+    {.id = "compact",
+     .label_fn = lbl_ui_compact,
+     .help = "Toggle compact scanner view (hotkey: c).",
+     .on_select = act_toggle_ui_compact},
 };
 
 const NcMenuItem UI_DISPLAY_MENU_ITEMS[] = {

--- a/src/ui/terminal/menu_labels.c
+++ b/src/ui/terminal/menu_labels.c
@@ -817,6 +817,14 @@ lbl_ui_channels(const void* v, char* b, size_t n) {
 }
 
 const char*
+lbl_ui_compact(const void* v, char* b, size_t n) {
+    UiCtx* c = (UiCtx*)v;
+    DSD_SNPRINTF(b, n, "Compact View [%s]",
+                 (c && c->opts && c->opts->frontend_terminal_display.terminal_compact) ? "On" : "Off");
+    return b;
+}
+
+const char*
 lbl_ui_p25_callsign(const void* v, char* b, size_t n) {
     UiCtx* c = (UiCtx*)v;
     DSD_SNPRINTF(b, n, "Show P25 Callsign Decode [%s]",

--- a/src/ui/terminal/menu_labels.h
+++ b/src/ui/terminal/menu_labels.h
@@ -106,6 +106,7 @@ const char* lbl_ui_p25_neighbors(const void* v, char* b, size_t n);
 const char* lbl_ui_p25_iden(const void* v, char* b, size_t n);
 const char* lbl_ui_p25_ccc(const void* v, char* b, size_t n);
 const char* lbl_ui_channels(const void* v, char* b, size_t n);
+const char* lbl_ui_compact(const void* v, char* b, size_t n);
 const char* lbl_ui_p25_callsign(const void* v, char* b, size_t n);
 
 // LRRP labels

--- a/src/ui/terminal/panels/header.c
+++ b/src/ui/terminal/panels/header.c
@@ -24,20 +24,14 @@ ui_panel_header_render(const dsd_opts* opts, dsd_state* state) {
         return;
     }
     // header banner
+    attron(COLOR_PAIR(6));
+    ui_print_hr();
     if (opts->frontend_terminal_display.terminal_compact == 1) {
-        ui_print_hr();
-        printw("| Digital Speech Decoder: DSD-neo %s (%s)  | Enter=Menu  q=Quit\n", GIT_TAG, GIT_HASH);
-        ui_print_hr();
+        printw("| Digital Speech Decoder: DSD-neo %s (%s)  | Enter=Menu  q=Quit  | Compact (c)\n", GIT_TAG, GIT_HASH);
     } else {
-        attron(COLOR_PAIR(6));
-        ui_print_hr();
         printw("| Digital Speech Decoder: DSD-neo %s (%s)  | Enter=Menu  q=Quit\n", GIT_TAG, GIT_HASH);
-        ui_print_hr();
-        attroff(COLOR_PAIR(6));
-        attron(COLOR_PAIR(4));
     }
-    // fix color/pair issue when compact and trunking enabled
-    if (opts->frontend_terminal_display.terminal_compact == 1 && opts->trunk_enable == 1) {
-        attron(COLOR_PAIR(4));
-    }
+    ui_print_hr();
+    attroff(COLOR_PAIR(6));
+    attron(COLOR_PAIR(4));
 }

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -745,6 +745,43 @@ test_io_and_state_commands(void) {
     return rc;
 }
 
+static int
+test_compact_visualizer_toast(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    init_test_context(&opts, &state);
+
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frontend_terminal_display.terminal_compact = 1;
+
+    post_empty(DSD_APP_CMD_CONST_TOGGLE);
+    rc |= expect_int("constellation toggle applied", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("constellation enabled", opts.frontend_display.constellation, 1);
+    rc |= expect_contains("constellation compact toast", state.ui_msg, "hidden in compact view");
+
+    /* Switching a visualizer off raises no hint */
+    state.ui_msg[0] = '\0';
+    post_empty(DSD_APP_CMD_CONST_TOGGLE);
+    rc |= expect_int("constellation untoggle applied", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_str("no toast on visualizer off", state.ui_msg, "");
+
+    /* No hint outside compact view */
+    opts.frontend_terminal_display.terminal_compact = 0;
+    post_empty(DSD_APP_CMD_SPECTRUM_TOGGLE);
+    rc |= expect_int("spectrum toggle applied", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_str("no toast in full view", state.ui_msg, "");
+
+    /* Eye view shares the hint path while compact */
+    opts.frontend_terminal_display.terminal_compact = 1;
+    post_empty(DSD_APP_CMD_EYE_TOGGLE);
+    rc |= expect_int("eye toggle applied", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_contains("eye compact toast", state.ui_msg, "hidden in compact view");
+
+    freeState(&state);
+    return rc;
+}
+
 #ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
 static void
 seed_active_p25_voice(dsd_opts* opts, dsd_state* state, long cc_freq, long vc_freq, int tg) {
@@ -1038,6 +1075,7 @@ main(void) {
     rc |= test_key_and_runtime_state_commands();
     rc |= test_file_network_and_import_commands();
     rc |= test_io_and_state_commands();
+    rc |= test_compact_visualizer_toast();
 #ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
     rc |= test_manual_tune_commands_commit_only_after_acceptance();
 #endif

--- a/tests/ui/test_ui_menu_actions.c
+++ b/tests/ui/test_ui_menu_actions.c
@@ -1040,6 +1040,10 @@ test_key_lrrp_and_display_actions(void) {
     rc |= expect_int("ui channels command", g_cmd.id, DSD_APP_CMD_UI_SHOW_CHANNELS_TOGGLE);
 
     reset_capture();
+    act_toggle_ui_compact(&ctx);
+    rc |= expect_int("ui compact command", g_cmd.id, DSD_APP_CMD_TOGGLE_COMPACT);
+
+    reset_capture();
     act_toggle_ui_p25_callsign(&ctx);
     rc |= expect_int("ui callsign command", g_cmd.id, DSD_APP_CMD_UI_SHOW_P25_CALLSIGN_TOGGLE);
 

--- a/tests/ui/test_ui_menu_labels.c
+++ b/tests/ui/test_ui_menu_labels.c
@@ -344,6 +344,9 @@ test_env_config_display_and_key_labels(void) {
     rc |= expect_str("show p25 iden off", lbl_ui_p25_iden(&ctx, b, sizeof(b)), "Show P25 IDEN Plan [Off]");
     rc |= expect_str("show p25 cc candidates off", lbl_ui_p25_ccc(&ctx, b, sizeof(b)), "Show P25 CC Candidates [Off]");
     rc |= expect_str("show channels", lbl_ui_channels(&ctx, b, sizeof(b)), "Show Channels [On]");
+    rc |= expect_str("compact view off", lbl_ui_compact(&ctx, b, sizeof(b)), "Compact View [Off]");
+    opts.frontend_terminal_display.terminal_compact = 1;
+    rc |= expect_str("compact view on", lbl_ui_compact(&ctx, b, sizeof(b)), "Compact View [On]");
     rc |=
         expect_str("show p25 callsign off", lbl_ui_p25_callsign(&ctx, b, sizeof(b)), "Show P25 Callsign Decode [Off]");
 

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -353,6 +353,13 @@ void
 ui_print_lborder_green(void) {} // NOLINT(misc-use-internal-linkage)
 
 void
+ui_print_lborder(void) { // NOLINT(misc-use-internal-linkage)
+    if (g_printw_capture_len < sizeof(g_printw_capture) - 1U) {
+        g_printw_capture[g_printw_capture_len++] = '|';
+    }
+}
+
+void
 ui_panel_header_render(const dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
     (void)opts;
     (void)state;
@@ -680,6 +687,72 @@ test_input_level_policy(void) {
     opts.rtl_dsp_bw_khz = 48;
     state.max = 0.075f;
     assert(ui_compute_input_level_and_color(&opts, &state) == 50);
+}
+
+static void
+test_compact_status_section_rendering(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    /* Null inputs render nothing */
+    reset_printw_capture();
+    ui_render_compact_status_section(NULL, &state, 0);
+    ui_render_compact_status_section(&opts, NULL, 0);
+    assert(g_printw_capture[0] == '\0');
+
+    /* Trunking tuned: Tuner [Busy]; dual-slot shows both slot states */
+    DSD_SNPRINTF(opts.output_name, sizeof(opts.output_name), "AUTO");
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    state.samplesPerSymbol = 10;
+    opts.trunk_enable = 1;
+    opts.trunk_is_tuned = 1;
+    opts.audio_out = 1;
+    opts.dmr_stereo = 1;
+    opts.slot1_on = 1;
+    opts.slot2_on = 0;
+    ncurses_last_synctype = DSD_SYNC_NONE;
+    reset_printw_capture();
+    ui_render_compact_status_section(&opts, &state, 42);
+    assert_capture_contains("[AUTO] [C4FM][4800]");
+    assert_capture_contains("Tuner [Busy]");
+    /* SNR line starts with its own left border in compact view */
+    assert_capture_contains("Tuner [Busy]\n|");
+    assert_capture_contains("In [42%]");
+    assert_capture_contains("Out (x) [On]");
+    assert_capture_contains("S1 (1) [On]");
+    assert_capture_contains("S2 (2) [Off]");
+
+    /* Trunking not tuned: Tuner [Free] */
+    opts.trunk_is_tuned = 0;
+    reset_printw_capture();
+    ui_render_compact_status_section(&opts, &state, 42);
+    assert_capture_contains("Tuner [Free]");
+
+    /* Trunking off: no Tuner field; muted output */
+    opts.trunk_enable = 0;
+    opts.audio_out = 0;
+    reset_printw_capture();
+    ui_render_compact_status_section(&opts, &state, 42);
+    assert(strstr(g_printw_capture, "Tuner [") == NULL);
+    assert_capture_contains("Out (x) [Muted]");
+
+    /* Single-slot mode shows only S1 */
+    opts.dmr_stereo = 0;
+    reset_printw_capture();
+    ui_render_compact_status_section(&opts, &state, 42);
+    assert_capture_contains("S1 (1) [On]");
+    assert(strstr(g_printw_capture, "S2 (2)") == NULL);
+
+    /* RTL QPSK hides In Level (fixed differential symbols) */
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.rf_mod = 1;
+    reset_printw_capture();
+    ui_render_compact_status_section(&opts, &state, 42);
+    assert(strstr(g_printw_capture, "In [") == NULL);
+    assert_capture_contains("[QPSK]");
 }
 
 static void
@@ -1325,6 +1398,7 @@ main(void) {
     test_rtl_auto_ppm_status_rendering();
     test_demod_symbol_rate_helpers();
     test_input_level_policy();
+    test_compact_status_section_rendering();
     test_history_and_sort_helpers();
     test_history_color_pair_policy();
     test_history_viewport_helpers();

--- a/tests/ui/test_ui_panels_header_footer.c
+++ b/tests/ui/test_ui_panels_header_footer.c
@@ -87,7 +87,7 @@ test_header_null_opts_is_noop(void) {
 }
 
 static void
-test_header_compact_renders_without_banner_color(void) {
+test_header_compact_shows_indicator_and_banner_color(void) {
     static dsd_opts opts;
     static dsd_state state;
     DSD_MEMSET(&opts, 0, sizeof opts);
@@ -97,31 +97,15 @@ test_header_compact_renders_without_banner_color(void) {
     reset_calls();
     ui_panel_header_render(&opts, &state);
 
-    assert(g_attron_calls == 0);
-    assert(g_attroff_calls == 0);
+    assert(g_attron_calls == 2);
+    assert(g_attroff_calls == 1);
+    assert(g_last_attroff == COLOR_PAIR(6));
+    assert(g_last_attron == COLOR_PAIR(4));
     assert(g_hr_calls == 2);
     assert(g_printw_calls == 1);
     assert(strstr(g_last_printw, "test-tag") != NULL);
     assert(strstr(g_last_printw, "test-hash") != NULL);
-}
-
-static void
-test_header_compact_trunk_restores_trunk_color(void) {
-    static dsd_opts opts;
-    static dsd_state state;
-    DSD_MEMSET(&opts, 0, sizeof opts);
-    DSD_MEMSET(&state, 0, sizeof state);
-    opts.frontend_terminal_display.terminal_compact = 1;
-    opts.trunk_enable = 1;
-
-    reset_calls();
-    ui_panel_header_render(&opts, &state);
-
-    assert(g_attron_calls == 1);
-    assert(g_last_attron == COLOR_PAIR(4));
-    assert(g_attroff_calls == 0);
-    assert(g_hr_calls == 2);
-    assert(g_printw_calls == 1);
+    assert(strstr(g_last_printw, "Compact (c)") != NULL);
 }
 
 static void
@@ -140,6 +124,7 @@ test_header_full_renders_banner_and_body_colors(void) {
     assert(g_last_attron == COLOR_PAIR(4));
     assert(g_hr_calls == 2);
     assert(g_printw_calls == 1);
+    assert(strstr(g_last_printw, "Compact (c)") == NULL);
 }
 
 static void
@@ -204,8 +189,7 @@ test_footer_expired_toast_clears_snapshot_only(void) {
 int
 main(void) {
     test_header_null_opts_is_noop();
-    test_header_compact_renders_without_banner_color();
-    test_header_compact_trunk_restores_trunk_color();
+    test_header_compact_shows_indicator_and_banner_color();
     test_header_full_renders_banner_and_body_colors();
     test_footer_null_inputs_are_noop();
     test_footer_active_toast_renders_without_clearing();


### PR DESCRIPTION
## Summary

Fixes #93.

The `c` hotkey ("Compact View") toggled `terminal_compact` but was visually a no-op — its only consumer was a color tweak in the header panel, left over from upstream DSD's ASCII-logo compaction, which dsd-neo never had. This repurposes the key into a real compact **scanner view** along the lines suggested in the issue thread: just the basics, with maximum room for call info and history.

## What compact view shows

- Header banner with a `Compact (c)` indicator so the state and exit key are always visible
- Status toast (unchanged)
- A condensed `Status` block: decode mode, demod/symbol rate, tuner Busy/Free (when trunking), SNR meter, input level, output mute, slot on/off states
- The full Call Info section (per-slot TGT/SRC, active channels, tuned frequency, TG HOLD)
- Event history, which automatically expands into the freed rows

Suppressed while compact: Input Output section, visual aids (including enabled visualizers — their toggles are preserved and restore on exit), the detailed Audio Decode block, P25 optional sections, and the Channels list. The carrier color arming still runs unconditionally, so Call Info colors behave identically in both views.

## Also in this change

- The compact toggle now requests a redraw so the frame updates immediately on keypress
- Removed the dead compact color special-casing in `panels/header.c`; the banner now always arms the body color pair
- Hardened the null guard in `dsd_terminal_render` to cover `state` (a null state could previously reach a `strcmp` in the NXDN call-info path)
- New menu item: **Menu → UI Display → General → Compact View [On/Off]**
- Docs: `docs/ui-terminal.md` hotkey row updated and a new "Compact View" section added

The setting is session-only, matching every other display toggle (none are persisted today). `LIMAZULUTWEAKS` builds keep their compact-on default.

## Testing

- New printer-helper tests for the compact Status block (tuner states, RTL-QPSK level suppression, mute, single vs dual slot, SNR line border)
- Header panel tests rewritten for the new indicator/color contract
- Menu label and action coverage for the new item
- Full suite: 476/476 pass; pre-push preflight (clang-format, clang-tidy, cppcheck, Semgrep, Lizard, etc.) green
- Verified interactively against a live P25 control channel
