### PR TITLE
release: set version to 2.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(dsd-neo VERSION 3.0.0 LANGUAGES C CXX)
+project(dsd-neo VERSION 2.5.0 LANGUAGES C CXX)
 if(POLICY CMP0083)
     cmake_policy(SET CMP0083 NEW)
 endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "dsd-neo",
-  "version-string": "3.0.0",
+  "version-string": "2.5.0",
   "builtin-baseline": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3",
   "description": "Digital Speech Decoder: DSD-neo",
   "homepage": "https://github.com/arancormonk/dsd-neo",


### PR DESCRIPTION
## Summary

- set the CMake project version to 2.5.0
- set the vcpkg package version to 2.5.0

## Impact

Release metadata now identifies the project as version 2.5.0.

## Validation

Not run per request; this is a metadata-only change.