### PR TITLE
p25: stop clear calls flapping clear/encrypted under enc lockout

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -53,6 +53,13 @@ typedef struct {
     uint8_t active;
 } dsd_p25_p1_crypto_conflict_state;
 
+/** Phase 2 per-slot ESS crypto tuple awaiting corroboration against clear service context. */
+typedef struct {
+    uint16_t keyid;
+    uint8_t algid;
+    uint8_t active;
+} dsd_p25_p2_crypto_conflict_state;
+
 /** Phase 1 carrier/call epoch whose post-lockout ESS repeats may be ignored. */
 typedef struct {
     uint64_t call_epoch;
@@ -710,6 +717,8 @@ struct dsd_state {
     int p25_p1_hdu_crypto_fresh;
     // One non-clear HDU/LDU2 tuple contradicted explicit-clear Phase 1 service options.
     dsd_p25_p1_crypto_conflict_state p25_p1_crypto_conflict;
+    // One non-clear Phase 2 ESS tuple contradicted explicit-clear service context.
+    dsd_p25_p2_crypto_conflict_state p25_p2_crypto_conflict[2];
     // Exact carrier/canonical epoch ended by Phase 1 encryption lockout.
     dsd_p25_p1_lockout_epoch_state p25_p1_lockout_epoch;
     // Sticky Phase 2 media rejection, cleared only after the slot receives an accepted assignment/activity.

--- a/include/dsd-neo/protocol/p25/p25_crypto.h
+++ b/include/dsd-neo/protocol/p25/p25_crypto.h
@@ -117,14 +117,20 @@ void p25_crypto_clear_phase1_lockout_epoch(dsd_state* state);
  *
  * Imported key material for @p keyid is activated before decryptability is
  * tested. ALGID 0 remains non-definitive; only ALGID 0x80 confirms clear voice.
- * A Phase 1 non-clear tuple that contradicts explicit-clear service options
- * remains pending until another FEC-accepted tuple repeats the ALGID and KID.
+ * A non-clear tuple that contradicts explicit-clear service context remains
+ * pending until another FEC-accepted tuple repeats the ALGID and KID: Phase 1
+ * checks the slot's explicit-clear service options, Phase 2 the canonical
+ * call's explicit-clear service metadata.
  */
 dsd_p25_crypto_state p25_crypto_resolve(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_phase phase, int slot,
                                         int algid, int keyid, uint64_t mi, int talkgroup);
 
-/** Convert a still-pending classification into a silent timeout block. */
-void p25_crypto_block_pending(dsd_state* state, int slot);
+/**
+ * Return a still-pending classification to unclassified after a silent
+ * timeout. The deadline lapsing is absence of evidence, not proof of
+ * encryption, so the slot must not be published as encrypted.
+ */
+void p25_crypto_expire_pending(dsd_state* state, int slot);
 
 /** Reset crypto classification and metadata at a call boundary. */
 void p25_crypto_reset_slot(dsd_state* state, int slot);

--- a/src/protocol/p25/p25_crypto.c
+++ b/src/protocol/p25/p25_crypto.c
@@ -374,6 +374,51 @@ p25_crypto_p1_reconcile_clear_conflict(dsd_state* state, int algid, int keyid) {
     return 1;
 }
 
+static void
+p25_crypto_p2_clear_conflict(dsd_state* state, int slot) {
+    if (state && p25_crypto_slot_valid(slot)) {
+        DSD_MEMSET(&state->p25_p2_crypto_conflict[slot], 0, sizeof(state->p25_p2_crypto_conflict[slot]));
+    }
+}
+
+static int
+p25_crypto_p2_has_explicit_clear_service(const dsd_state* state, int slot) {
+    dsd_call_snapshot call;
+    return state && dsd_call_state_get(state, (uint8_t)slot, &call) > 0 && call.phase == DSD_CALL_PHASE_ACTIVE
+           && DSD_SYNC_IS_P25P2(call.protocol) && call.has_service_metadata != 0U
+           && (call.service_options & 0x40U) == 0;
+}
+
+static int
+p25_crypto_p2_conflict_matches(const dsd_state* state, int slot, int algid, int keyid) {
+    return state && state->p25_p2_crypto_conflict[slot].active
+           && state->p25_p2_crypto_conflict[slot].algid == (uint8_t)algid
+           && state->p25_p2_crypto_conflict[slot].keyid == (uint16_t)keyid;
+}
+
+// Whether a Phase 2 tuple that would classify BLOCKED must wait for a repeat.
+// A single FEC-accepted ESS can still carry an undetected corruption, and a
+// blocked classification ends the call and releases the channel under
+// encryption lockout. When the call's own service context says clear, one
+// contradicting tuple is quarantined until another FEC-accepted ESS repeats
+// the same ALGID and KID (mirroring the Phase 1 clear-conflict rule).
+static int
+p25_crypto_p2_reconcile_clear_conflict(dsd_state* state, int slot, int algid, int keyid) {
+    if (p25_crypto_p2_conflict_matches(state, slot, algid, keyid)) {
+        // A matching second observation corroborates the tuple.
+        p25_crypto_p2_clear_conflict(state, slot);
+        return 0;
+    }
+    if (!p25_crypto_p2_has_explicit_clear_service(state, slot)) {
+        p25_crypto_p2_clear_conflict(state, slot);
+        return 0;
+    }
+    state->p25_p2_crypto_conflict[slot].active = 1U;
+    state->p25_p2_crypto_conflict[slot].algid = (uint8_t)algid;
+    state->p25_p2_crypto_conflict[slot].keyid = (uint16_t)keyid;
+    return 1;
+}
+
 static dsd_p25_crypto_state
 p25_crypto_resolve_algid_zero(dsd_state* state, int slot) {
     const dsd_p25_crypto_state current = state->p25_crypto_state[slot];
@@ -441,6 +486,7 @@ p25_crypto_begin_voice_call(dsd_state* state, dsd_p25_crypto_phase phase, int sl
     }
 
     DSD_MEMSET(&state->p25_p2_rekey[slot], 0, sizeof(state->p25_p2_rekey[slot]));
+    p25_crypto_p2_clear_conflict(state, slot);
     dsd_mbe_purge_slot_audio(state, slot);
     p25_crypto_store_metadata(state, slot, 0, 0, 0ULL);
     p25_crypto_reset_stream_state(state, phase, slot);
@@ -485,6 +531,32 @@ p25_crypto_p1_defer_clear_conflict(dsd_state* state, int svc_bits) {
     return 1;
 }
 
+static dsd_p25_crypto_state
+p25_crypto_p2_apply_blocked_quarantine(dsd_state* state, int slot, int algid, int keyid, dsd_p25_crypto_state resolved,
+                                       int* deferred) {
+    if (resolved == DSD_P25_CRYPTO_BLOCKED) {
+        if (p25_crypto_p2_reconcile_clear_conflict(state, slot, algid, keyid)) {
+            *deferred = 1;
+            return DSD_P25_CRYPTO_ENCRYPTED_PENDING;
+        }
+        return resolved;
+    }
+    p25_crypto_p2_clear_conflict(state, slot);
+    return resolved;
+}
+
+static void
+p25_crypto_emit_deferred_pending(dsd_opts* opts, dsd_state* state, int slot, const p25_crypto_snapshot* previous) {
+    if (!opts) {
+        return;
+    }
+    if (previous->state == DSD_P25_CRYPTO_ENCRYPTED_PENDING) {
+        p25_sm_emit_crypto_pending(opts, state, slot);
+    } else {
+        p25_sm_emit_crypto_pending_epoch(opts, state, slot);
+    }
+}
+
 dsd_p25_crypto_state
 p25_crypto_resolve(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_phase phase, int slot, int algid, int keyid,
                    uint64_t mi, int talkgroup) {
@@ -510,35 +582,38 @@ p25_crypto_resolve(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_phase phase,
     const p25_crypto_snapshot previous = p25_crypto_capture_snapshot(state, slot);
     p25_crypto_store_metadata(state, slot, algid, keyid, mi);
 
-    int defer_clear_conflict = 0;
+    int deferred = 0;
     if (phase == DSD_P25_CRYPTO_PHASE1) {
-        defer_clear_conflict = p25_crypto_p1_reconcile_clear_conflict(state, algid, keyid);
+        deferred = p25_crypto_p1_reconcile_clear_conflict(state, algid, keyid);
     }
 
-    if (!defer_clear_conflict && algid != 0x80 && state->keyloader == 1) {
+    if (!deferred && algid != 0x80 && state->keyloader == 1) {
         keyring_activate_slot(opts, state, slot);
     }
 
-    const dsd_p25_crypto_state resolved = defer_clear_conflict
-                                              ? DSD_P25_CRYPTO_ENCRYPTED_PENDING
-                                              : p25_crypto_classify_metadata(state, phase, slot, algid);
+    dsd_p25_crypto_state resolved =
+        deferred ? DSD_P25_CRYPTO_ENCRYPTED_PENDING : p25_crypto_classify_metadata(state, phase, slot, algid);
+    if (phase == DSD_P25_CRYPTO_PHASE2) {
+        resolved = p25_crypto_p2_apply_blocked_quarantine(state, slot, algid, keyid, resolved, &deferred);
+    }
     p25_crypto_apply_resolution(opts, state, phase, slot, algid, keyid, mi, talkgroup, &previous, resolved);
-    if (defer_clear_conflict && opts) {
-        if (previous.state == DSD_P25_CRYPTO_ENCRYPTED_PENDING) {
-            p25_sm_emit_crypto_pending(opts, state, slot);
-        } else {
-            p25_sm_emit_crypto_pending_epoch(opts, state, slot);
-        }
+    if (deferred) {
+        p25_crypto_emit_deferred_pending(opts, state, slot, &previous);
     }
     return resolved;
 }
 
 void
-p25_crypto_block_pending(dsd_state* state, int slot) {
+p25_crypto_expire_pending(dsd_state* state, int slot) {
     if (!state || !p25_crypto_slot_valid(slot) || state->p25_crypto_state[slot] != DSD_P25_CRYPTO_ENCRYPTED_PENDING) {
         return;
     }
-    p25_crypto_set_state(state, slot, DSD_P25_CRYPTO_BLOCKED);
+    // No FEC-accepted ESS arrived inside the classification window. That is
+    // absence of evidence, not an encryption verdict: publishing BLOCKED here
+    // surfaced clear calls in signal fades as "Encrypted" and primed the
+    // downstream lockout paths with a classification nothing ever observed.
+    p25_crypto_p2_clear_conflict(state, slot);
+    p25_crypto_set_state(state, slot, DSD_P25_CRYPTO_UNKNOWN);
     p25_crypto_publish_canonical(NULL, state, slot);
     dsd_mbe_purge_slot_audio(state, slot);
 }

--- a/src/protocol/p25/p25_crypto_state.c
+++ b/src/protocol/p25/p25_crypto_state.c
@@ -30,6 +30,7 @@ p25_crypto_reset_slot(dsd_state* state, int slot) {
     }
     state->p25_crypto_state[slot] = DSD_P25_CRYPTO_UNKNOWN;
     DSD_MEMSET(&state->p25_p2_rekey[slot], 0, sizeof(state->p25_p2_rekey[slot]));
+    DSD_MEMSET(&state->p25_p2_crypto_conflict[slot], 0, sizeof(state->p25_p2_crypto_conflict[slot]));
     state->p25_p2_audio_allowed[slot] = 0;
 
     if (slot == 0) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1079,15 +1079,19 @@ p25_grant_transient_enc_cache_blocks(dsd_opts* opts, dsd_state* state, const p25
         return 0;
     }
 
-    time_t until = 0;
-    if (p25_enc_tg_cache_refresh_until(now, &until)) {
-        state->p25_enc_tg_cache_until[idx] = until;
-    } else {
-        p25_enc_tg_cache_clear_entry(state, idx);
-        return 0;
+    // Only a grant whose service options prove encryption may extend the
+    // entry. Ambiguous (service-less) updates still skip while the entry
+    // lives, but they carry no evidence: letting them slide the window kept a
+    // falsely-cached clear talkgroup blocked for as long as the control
+    // channel kept announcing its ongoing call.
+    if (eval_ctx->svc_valid && eval_ctx->encrypted_call) {
+        time_t until = 0;
+        if (p25_enc_tg_cache_refresh_until(now, &until)) {
+            state->p25_enc_tg_cache_until[idx] = until;
+        }
     }
     p25_sm_diagf(opts, state, NULL, "grant_enc_cache_skip", "kind=%s target=%d idx=%d until=%ld",
-                 is_group ? "group" : "private", eval_ctx->tg, idx, (long)until);
+                 is_group ? "group" : "private", eval_ctx->tg, idx, (long)state->p25_enc_tg_cache_until[idx]);
     sm_log(opts, state, "grant-enc-cache");
     return 1;
 }
@@ -1995,15 +1999,26 @@ p25_grant_refresh_duplicate_crypto(p25_sm_ctx_t* ctx, dsd_state* state, const p2
     const int previous_svc = slot_ctx->svc_bits;
     const int previous_clear_override = slot_ctx->enc_override_clear;
     const int force_clear = eval_ctx && eval_ctx->enc_override_clear;
-    slot_ctx->svc_bits = ev->svc_bits;
+    // A duplicate without service options carries no classification evidence.
+    // Control channels interleave explicit and implicit updates for one call;
+    // letting the implicit copies demote the retained service bits toggled the
+    // slot between clear and encryption-pending once per update, purging audio
+    // each time.
+    const int svc_known = p25_sm_svc_bits_valid(ev->svc_bits);
+    const int current_svc = svc_known ? ev->svc_bits : previous_svc;
+    if (svc_known) {
+        slot_ctx->svc_bits = ev->svc_bits;
+    }
     slot_ctx->enc_override_clear = force_clear ? 1 : 0;
     if (data_call) {
         return;
     }
 
-    if (p25_grant_duplicate_crypto_needs_restart(previous_svc, ev->svc_bits, previous_clear_override, force_clear,
+    if (p25_grant_duplicate_crypto_needs_restart(previous_svc, current_svc, previous_clear_override, force_clear,
                                                  state->p25_crypto_state[crypto_slot])) {
-        p25_grant_begin_crypto_classification(ctx, state, ev, eval_ctx, route->slot, 0, now_m);
+        p25_sm_event_t crypto_ev = *ev;
+        crypto_ev.svc_bits = current_svc;
+        p25_grant_begin_crypto_classification(ctx, state, &crypto_ev, eval_ctx, route->slot, 0, now_m);
     }
 }
 
@@ -2965,6 +2980,21 @@ p25_voice_start_source_changed(const p25_sm_slot_ctx_t* slot_ctx, const p25_sm_e
 }
 
 static int
+p25_voice_start_assignment_service_is_fresh(const p25_sm_slot_ctx_t* slot_ctx) {
+    // Mirrors the source-freshness rule: the retained service options describe
+    // the next transmission only while a grant re-validates the assignment.
+    // Control channels keep repeating the call's grant (with its clear/enc
+    // service bits) through hangtime, so a completed transmission whose
+    // assignment the CC has re-announced since the stop may classify the next
+    // same-identity transmission from those bits instead of starting every one
+    // encryption-pending and muting clear voice until ESS decodes.
+    if (!slot_ctx) {
+        return 0;
+    }
+    return !p25_voice_start_follows_completed_epoch(slot_ctx) || slot_ctx->last_grant_m > slot_ctx->last_stop_m;
+}
+
+static int
 p25_voice_start_is_p2_ptt(const p25_sm_ctx_t* ctx, const p25_sm_event_t* ev) {
     return ctx && ev && ctx->vc_is_tdma && ev->type == P25_SM_EV_PTT;
 }
@@ -2978,7 +3008,7 @@ p25_voice_start_begins_new_epoch(const p25_sm_ctx_t* ctx, const p25_sm_slot_ctx_
 
 static int
 p25_voice_start_requires_unknown_service(const p25_sm_slot_ctx_t* slot_ctx, const p25_sm_event_t* ev) {
-    return p25_voice_start_follows_completed_epoch(slot_ctx) || p25_voice_start_target_changed(slot_ctx, ev)
+    return !p25_voice_start_assignment_service_is_fresh(slot_ctx) || p25_voice_start_target_changed(slot_ctx, ev)
            || p25_voice_start_source_changed(slot_ctx, ev);
 }
 
@@ -2993,11 +3023,11 @@ p25_voice_start_fill_anonymous_identity(const dsd_state* state, int slot, const 
         out->src = slot_ctx->src;
     }
 
-    // A source-less PTT/ACTIVE after a completed transmission has no service
-    // options for the new epoch. Keep crypto classification pending until
-    // ESS/LCW proves it clear instead of inheriting the preceding epoch.
-    const int follows_completed_epoch = p25_voice_start_follows_completed_epoch(slot_ctx);
-    out->svc_bits = follows_completed_epoch ? P25_SM_SVC_UNKNOWN : slot_ctx->svc_bits;
+    // A source-less PTT/ACTIVE after a completed transmission inherits no
+    // service options from the preceding epoch. Only a grant that re-validated
+    // the assignment since the stop may classify the new epoch; otherwise keep
+    // crypto classification pending until ESS/LCW proves it clear.
+    out->svc_bits = p25_voice_start_assignment_service_is_fresh(slot_ctx) ? slot_ctx->svc_bits : P25_SM_SVC_UNKNOWN;
 }
 
 static void
@@ -5384,7 +5414,10 @@ p25_sm_block_expired_crypto_slot(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
         sm_log(opts, state, "crypto-conflict-timeout");
         return 1;
     }
-    p25_crypto_block_pending(state, slot);
+    // The window lapsing means no FEC-accepted ESS arrived, not that the call
+    // is encrypted. Return the slot to unclassified before releasing so the
+    // canonical call and UI never claim encryption nothing observed.
+    p25_crypto_expire_pending(state, slot);
     ctx->slots[slot].voice_active = 0;
     if (ctx->vc_is_tdma) {
         p25_voice_clear_slot_grant(ctx, state, slot);
@@ -5411,8 +5444,10 @@ p25_sm_expired_slot_has_active_companion(const p25_sm_ctx_t* ctx, const dsd_stat
 static int
 p25_sm_recover_expired_followed_p1_conflict(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m,
                                             double grant_timeout) {
-    if (!ctx || !opts || !state || opts->trunk_tune_enc_calls == 0 || ctx->vc_is_tdma
-        || !state->p25_p1_crypto_conflict.active
+    // Applies under encryption lockout as well: the quarantined tuple never
+    // corroborated against a call whose service options are explicit clear, so
+    // the presumption of clear resumes the call instead of releasing it.
+    if (!ctx || !opts || !state || ctx->vc_is_tdma || !state->p25_p1_crypto_conflict.active
         || !p25_grant_service_options_are_explicit_clear(ctx->slots[0].svc_bits)
         || !p25_sm_crypto_slot_expired(ctx, state, 0, now_m, grant_timeout)) {
         return 0;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2003,22 +2003,26 @@ p25_grant_refresh_duplicate_crypto(p25_sm_ctx_t* ctx, dsd_state* state, const p2
     // Control channels interleave explicit and implicit updates for one call;
     // letting the implicit copies demote the retained service bits toggled the
     // slot between clear and encryption-pending once per update, purging audio
-    // each time.
+    // each time. The regroup clear-key override derives from those same
+    // service options, so an implicit copy may neither grant nor remove it.
     const int svc_known = p25_sm_svc_bits_valid(ev->svc_bits);
     const int current_svc = svc_known ? ev->svc_bits : previous_svc;
+    const int current_clear_override = svc_known ? (force_clear ? 1 : 0) : previous_clear_override;
     if (svc_known) {
         slot_ctx->svc_bits = ev->svc_bits;
     }
-    slot_ctx->enc_override_clear = force_clear ? 1 : 0;
+    slot_ctx->enc_override_clear = current_clear_override;
     if (data_call) {
         return;
     }
 
-    if (p25_grant_duplicate_crypto_needs_restart(previous_svc, current_svc, previous_clear_override, force_clear,
-                                                 state->p25_crypto_state[crypto_slot])) {
+    if (p25_grant_duplicate_crypto_needs_restart(previous_svc, current_svc, previous_clear_override,
+                                                 current_clear_override, state->p25_crypto_state[crypto_slot])) {
         p25_sm_event_t crypto_ev = *ev;
         crypto_ev.svc_bits = current_svc;
-        p25_grant_begin_crypto_classification(ctx, state, &crypto_ev, eval_ctx, route->slot, 0, now_m);
+        p25_grant_eval_ctx_t crypto_eval = eval_ctx ? *eval_ctx : p25_grant_eval_ctx_from_event(&crypto_ev);
+        crypto_eval.enc_override_clear = current_clear_override;
+        p25_grant_begin_crypto_classification(ctx, state, &crypto_ev, &crypto_eval, route->slot, 0, now_m);
     }
 }
 
@@ -2981,17 +2985,15 @@ p25_voice_start_source_changed(const p25_sm_slot_ctx_t* slot_ctx, const p25_sm_e
 
 static int
 p25_voice_start_assignment_service_is_fresh(const p25_sm_slot_ctx_t* slot_ctx) {
-    // Mirrors the source-freshness rule: the retained service options describe
-    // the next transmission only while a grant re-validates the assignment.
-    // Control channels keep repeating the call's grant (with its clear/enc
-    // service bits) through hangtime, so a completed transmission whose
-    // assignment the CC has re-announced since the stop may classify the next
-    // same-identity transmission from those bits instead of starting every one
-    // encryption-pending and muting clear voice until ESS decodes.
-    if (!slot_ctx) {
-        return 0;
-    }
-    return !p25_voice_start_follows_completed_epoch(slot_ctx) || slot_ctx->last_grant_m > slot_ctx->last_stop_m;
+    // The retained service options follow the same freshness rule as the
+    // retained source: they describe the next transmission only while a grant
+    // re-validates the assignment. Control channels keep repeating the call's
+    // grant (with its clear/enc service bits) through hangtime, so a completed
+    // transmission whose assignment the CC has re-announced since the stop may
+    // classify the next same-identity transmission from those bits instead of
+    // starting every one encryption-pending and muting clear voice until ESS
+    // decodes.
+    return p25_voice_start_assignment_source_is_fresh(slot_ctx);
 }
 
 static int

--- a/tests/protocol/p25/test_p25_crypto_state.c
+++ b/tests/protocol/p25/test_p25_crypto_state.c
@@ -512,6 +512,131 @@ test_phase1_clear_conflict_requires_corroboration(void) {
 }
 
 static int
+begin_p2_call(dsd_state* state, uint8_t slot, uint16_t service_options, uint8_t has_service_metadata) {
+    const dsd_call_observation observation = {
+        .protocol = DSD_SYNC_P25P2_POS,
+        .slot = slot,
+        .kind = DSD_CALL_KIND_GROUP_VOICE,
+        .ota_target_id = 50061U,
+        .policy_target_id = 50061U,
+        .ota_source_id = 5200006U,
+        .service_options = service_options,
+        .has_service_metadata = has_service_metadata,
+    };
+    return dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN);
+}
+
+static int
+test_phase2_clear_conflict_requires_corroboration(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_fixture(&opts, &state);
+
+    int rc = 0;
+    rc |= expect_int("seed canonical clear P2 call", begin_p2_call(&state, 0U, 0x04U, 1U), 1);
+    p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE2, 0, 0x04, 0);
+    rc |= expect_int("clear grant classified clear", state.p25_crypto_state[0], DSD_P25_CRYPTO_CLEAR);
+
+    // A single FEC-accepted ESS can still carry an undetected corruption, and
+    // BLOCKED ends the call and releases the channel under encryption lockout.
+    rc |= expect_int(
+        "first non-clear tuple against clear service stays pending",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE2, 0, 0x13, 0x2222, UINT64_C(0x0102030405060708), 50061),
+        DSD_P25_CRYPTO_ENCRYPTED_PENDING);
+    rc |= expect_int("first tuple arms P2 conflict", state.p25_p2_crypto_conflict[0].active, 1);
+    rc |= expect_int("P2 conflict candidate ALGID", state.p25_p2_crypto_conflict[0].algid, 0x13);
+    rc |= expect_int("pending P2 conflict is not confirmed", p25_crypto_metadata_is_confirmed_encrypted(&state, 0), 0);
+
+    // Random corruption keeps producing different tuples and never confirms.
+    rc |= expect_int(
+        "different tuple replaces P2 candidate",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE2, 0, 0x37, 0x3333, UINT64_C(0x1112131415161718), 50061),
+        DSD_P25_CRYPTO_ENCRYPTED_PENDING);
+    rc |= expect_int("replacement P2 candidate ALGID", state.p25_p2_crypto_conflict[0].algid, 0x37);
+
+    // A clear ESS retires the quarantine and reopens audio.
+    rc |=
+        expect_int("clear ALGID resolves quarantined P2 tuple",
+                   p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, 0, 50061), DSD_P25_CRYPTO_CLEAR);
+    rc |= expect_int("clear ALGID clears P2 candidate", state.p25_p2_crypto_conflict[0].active, 0);
+
+    // A genuinely encrypted transmission repeats its tuple every ESS.
+    rc |= expect_int(
+        "first AES tuple stays pending",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE2, 0, 0x84, 0x026C, UINT64_C(0x2122232425262728), 50061),
+        DSD_P25_CRYPTO_ENCRYPTED_PENDING);
+    rc |= expect_int(
+        "matching second AES tuple confirms encryption",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE2, 0, 0x84, 0x026C, UINT64_C(0x3132333435363738), 50061),
+        DSD_P25_CRYPTO_BLOCKED);
+    rc |= expect_int("confirmed tuple clears P2 candidate", state.p25_p2_crypto_conflict[0].active, 0);
+    rc |= expect_int("confirmed P2 tuple is encrypted", p25_crypto_metadata_is_confirmed_encrypted(&state, 0), 1);
+
+    // A decryptable tuple never waits for corroboration.
+    p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE2, 0, 0x04, 0);
+    state.R = UINT64_C(0x0102030405060708);
+    rc |= expect_int(
+        "decryptable tuple bypasses P2 quarantine",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE2, 0, 0x81, 0x1001, UINT64_C(0x4142434445464748), 50061),
+        DSD_P25_CRYPTO_DECRYPTABLE);
+    state.R = 0ULL;
+
+    // Without explicit-clear service metadata a single non-clear tuple remains
+    // authoritative (late entry, encrypted grants, conventional traffic).
+    reset_fixture(&opts, &state);
+    rc |= expect_int("seed service-less P2 call", begin_p2_call(&state, 0U, 0U, 0U), 1);
+    p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE2, 0, -1, 0);
+    rc |= expect_int(
+        "service-less P2 tuple blocks on one observation",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE2, 0, 0x84, 0x026C, UINT64_C(0x5152535455565758), 50061),
+        DSD_P25_CRYPTO_BLOCKED);
+    rc |= expect_int("service-less P2 tuple arms no candidate", state.p25_p2_crypto_conflict[0].active, 0);
+
+    // Slot isolation: a slot 1 quarantine never leaks into slot 0.
+    reset_fixture(&opts, &state);
+    rc |= expect_int("seed canonical clear P2 call on slot 1", begin_p2_call(&state, 1U, 0x04U, 1U), 1);
+    p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE2, 1, 0x04, 0);
+    rc |= expect_int(
+        "slot 1 non-clear tuple stays pending",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE2, 1, 0x13, 0x2222, UINT64_C(0x6162636465666768), 50061),
+        DSD_P25_CRYPTO_ENCRYPTED_PENDING);
+    rc |= expect_int("slot 1 candidate armed", state.p25_p2_crypto_conflict[1].active, 1);
+    rc |= expect_int("slot 0 candidate untouched", state.p25_p2_crypto_conflict[0].active, 0);
+    p25_crypto_reset_slot(&state, 1);
+    rc |= expect_int("slot reset clears P2 candidate", state.p25_p2_crypto_conflict[1].active, 0);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+static int
+test_expire_pending_returns_slot_to_unclassified(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_fixture(&opts, &state);
+    opts.trunk_tune_enc_calls = 0;
+
+    int rc = 0;
+    p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE2, 0, -1, 0);
+    rc |= expect_int("unknown service grant pending", state.p25_crypto_state[0], DSD_P25_CRYPTO_ENCRYPTED_PENDING);
+
+    // The classification window lapsing is absence of evidence, not an
+    // encryption verdict: the slot returns to unclassified, never to blocked.
+    p25_crypto_expire_pending(&state, 0);
+    rc |= expect_int("expired pending returns to unknown", state.p25_crypto_state[0], DSD_P25_CRYPTO_UNKNOWN);
+    rc |= expect_int("expired pending keeps audio gated", p25_crypto_audio_permitted(&opts, &state, 0), 0);
+
+    // Classified slots are untouched.
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_CLEAR;
+    p25_crypto_expire_pending(&state, 0);
+    rc |= expect_int("expire leaves clear classification", state.p25_crypto_state[0], DSD_P25_CRYPTO_CLEAR);
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_BLOCKED;
+    p25_crypto_expire_pending(&state, 0);
+    rc |= expect_int("expire leaves blocked classification", state.p25_crypto_state[0], DSD_P25_CRYPTO_BLOCKED);
+    return rc;
+}
+
+static int
 test_algorithm_and_manual_key_resolution(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -788,6 +913,8 @@ main(void) {
     rc |= test_begin_and_sticky_unknown();
     rc |= test_phase1_negative_clear_conflict_requires_corroboration();
     rc |= test_phase1_clear_conflict_requires_corroboration();
+    rc |= test_phase2_clear_conflict_requires_corroboration();
+    rc |= test_expire_pending_returns_slot_to_unclassified();
     rc |= test_algorithm_and_manual_key_resolution();
     rc |= test_imported_key_activation_is_slot_aware();
     rc |= test_slot_local_transition_purge_and_mi_refresh();

--- a/tests/protocol/p25/test_p25_crypto_state.c
+++ b/tests/protocol/p25/test_p25_crypto_state.c
@@ -633,6 +633,23 @@ test_expire_pending_returns_slot_to_unclassified(void) {
     state.p25_crypto_state[0] = DSD_P25_CRYPTO_BLOCKED;
     p25_crypto_expire_pending(&state, 0);
     rc |= expect_int("expire leaves blocked classification", state.p25_crypto_state[0], DSD_P25_CRYPTO_BLOCKED);
+
+    // An armed quarantine candidate dies with its classification window: the
+    // next transmission must not corroborate against a tuple from the expired
+    // epoch.
+    reset_fixture(&opts, &state);
+    rc |= expect_int("seed clear P2 call before expiry", begin_p2_call(&state, 0U, 0x04U, 1U), 1);
+    p25_crypto_begin_voice_call(&state, DSD_P25_CRYPTO_PHASE2, 0, 0x04, 0);
+    rc |= expect_int(
+        "non-clear tuple quarantined before expiry",
+        p25_crypto_resolve(NULL, &state, DSD_P25_CRYPTO_PHASE2, 0, 0x13, 0x2222, UINT64_C(0x0102030405060708), 50061),
+        DSD_P25_CRYPTO_ENCRYPTED_PENDING);
+    rc |= expect_int("quarantine armed before expiry", state.p25_p2_crypto_conflict[0].active, 1);
+    p25_crypto_expire_pending(&state, 0);
+    rc |= expect_int("expiry returns quarantined slot to unknown", state.p25_crypto_state[0], DSD_P25_CRYPTO_UNKNOWN);
+    rc |= expect_int("expiry clears quarantine candidate", state.p25_p2_crypto_conflict[0].active, 0);
+
+    dsd_state_ext_free_all(&state);
     return rc;
 }
 

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -388,8 +388,11 @@ main(void) {
                                        .svc_bits = P25_SM_SVC_UNKNOWN,
                                        .is_group = 1});
         rc |= expect_true("unknown-svc grant suppressed by blocked-call cache", cache_st.p25_sm_tune_count == before);
-        rc |= expect_true("suppressed grant refreshes blocked-call expiry",
-                          cache_idx >= 0 && cache_st.p25_enc_tg_cache_until[cache_idx] > short_until);
+        // An ambiguous update carries no encryption evidence: it may not slide
+        // the expiry window, or a falsely-cached clear talkgroup stays blocked
+        // for as long as the control channel keeps announcing its call.
+        rc |= expect_true("suppressed ambiguous grant does not extend blocked-call expiry",
+                          cache_idx >= 0 && cache_st.p25_enc_tg_cache_until[cache_idx] == short_until);
         p25_sm_event(p25_sm_get_ctx(), &cache_opts, &cache_st,
                      &(p25_sm_event_t){.type = P25_SM_EV_GRANT,
                                        .slot = -1,
@@ -400,6 +403,8 @@ main(void) {
                                        .is_group = 1});
         rc |= expect_true("explicit encrypted grant suppressed by blocked-call cache",
                           cache_st.p25_sm_tune_count == before);
+        rc |= expect_true("explicit encrypted grant refreshes blocked-call expiry",
+                          cache_idx >= 0 && cache_st.p25_enc_tg_cache_until[cache_idx] > short_until);
         rc |= expect_true("transient enc cache does not add TG policy", tg_policy_is_absent(&cache_st, 1300U));
 
         cache_opts.trunk_is_tuned = 0;

--- a/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
+++ b/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
@@ -326,6 +326,63 @@ test_encrypted_follow_tracks_activity_while_media_is_muted(void) {
     return rc;
 }
 
+static int
+test_new_transmission_inherits_fresh_clear_grant_service(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    setup_tuned_tdma(&opts, &state, &ctx);
+
+    // A transmission completed on slot 0 and the CC re-announced the
+    // assignment (grant update with explicit-clear service options) after the
+    // stop. The retained service bits classify the next transmission clear
+    // instead of starting it encryption-pending and muting clear voice until
+    // an ESS decodes -- the audible chop under encryption lockout in fades.
+    ctx->slots[0].svc_bits = 0x04;
+    ctx->slots[0].last_start_m = 1.0;
+    ctx->slots[0].last_stop_m = 2.0;
+    ctx->slots[0].last_grant_m = 3.0;
+    ctx->slots[0].voice_active = 0;
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_UNKNOWN;
+
+    p25_sm_emit_ptt(&opts, &state, 0);
+
+    int rc = 0;
+    rc |= expect_eq("fresh clear grant: next transmission classified clear", state.p25_crypto_state[0],
+                    DSD_P25_CRYPTO_CLEAR);
+    rc |= expect_eq("fresh clear grant: voice activity accepted", ctx->slots[0].voice_active, 1);
+    rc |= expect_eq("fresh clear grant: no classification deadline", ctx->slots[0].crypto_attempt_m == 0.0, 1);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+static int
+test_new_transmission_without_grant_revalidation_stays_pending(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    setup_tuned_tdma(&opts, &state, &ctx);
+
+    // No grant re-validated the assignment since the stop: the next
+    // transmission may not inherit the preceding epoch's service options and
+    // must wait for ESS/LCW to classify it.
+    ctx->slots[0].svc_bits = 0x04;
+    ctx->slots[0].last_start_m = 1.0;
+    ctx->slots[0].last_stop_m = 3.0;
+    ctx->slots[0].last_grant_m = 2.0;
+    ctx->slots[0].voice_active = 0;
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_UNKNOWN;
+
+    p25_sm_emit_ptt(&opts, &state, 0);
+
+    int rc = 0;
+    rc |= expect_eq("stale grant service: next transmission stays pending", state.p25_crypto_state[0],
+                    DSD_P25_CRYPTO_ENCRYPTED_PENDING);
+    rc |= expect_eq("stale grant service: classification deadline armed", ctx->slots[0].crypto_attempt_m > 0.0, 1);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 int
 main(void) {
     install_trunk_tuning_hooks();
@@ -337,5 +394,7 @@ main(void) {
     rc |= test_clear_regroup_override_survives_voice_burst();
     rc |= test_private_voice_ignores_regroup_clear_key_collision();
     rc |= test_encrypted_follow_tracks_activity_while_media_is_muted();
+    rc |= test_new_transmission_inherits_fresh_clear_grant_service();
+    rc |= test_new_transmission_without_grant_revalidation_stays_pending();
     return rc;
 }

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -1763,6 +1763,24 @@ main(void) {
     assert(s19k.p25_p2_audio_ring_count[0] == 0);
     assert(s19k.s_l4[0][0] == 0);
 
+    // An implicit duplicate (no service options) carries no override evidence
+    // either: it must retain the applied regroup clear override instead of
+    // demoting the classified-clear slot back to encryption-pending and
+    // purging audio on every service-less update.
+    s19k.p25_p2_audio_allowed[0] = 1;
+    s19k.p25_p2_audio_ring_count[0] = 1;
+    s19k.s_l4[0][0] = 654;
+    p25_sm_event_t duplicate_regroup_unknown = p25_sm_ev_group_grant(tdma_slot0_ch, 0, 5701, 6701, P25_SM_SVC_UNKNOWN);
+    p25_sm_event(&ctx19k, &o19k, &s19k, &duplicate_regroup_unknown);
+    assert(g_result_tune_to_freq_calls == 1);
+    assert(ctx19k.grant_count == 1U);
+    assert(ctx19k.slots[0].enc_override_clear == 1);
+    assert(ctx19k.slots[0].svc_bits == 0x40);
+    assert(s19k.p25_crypto_state[0] == DSD_P25_CRYPTO_CLEAR);
+    assert(s19k.p25_p2_audio_allowed[0] == 1);
+    assert(s19k.p25_p2_audio_ring_count[0] == 1);
+    assert(s19k.s_l4[0][0] == 654);
+
     // The same encrypted duplicate must return to pending if KEY=0 is
     // replaced by a non-clear regroup key. Service options alone cannot
     // reveal this transition, so retain and compare override provenance.

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -1649,6 +1649,27 @@ main(void) {
     assert(s19g.p25_p2_audio_ring_count[0] == 1);
     assert(s19g.s_l4[0][0] == 321);
 
+    // An implicit duplicate update (no service options) carries no
+    // classification evidence. Control channels interleave explicit and
+    // implicit updates for one call; the implicit copies must not demote the
+    // retained explicit-clear service bits and knock the classified-clear slot
+    // back to encryption-pending, which muted and purged clear audio once per
+    // update under encryption lockout.
+    p25_sm_event_t duplicate_unknown = p25_sm_ev_group_grant(tdma_slot0_ch, 0, 5501, 6501, P25_SM_SVC_UNKNOWN);
+    p25_sm_event(&ctx19g, &o19g, &s19g, &duplicate_unknown);
+    assert(ctx19g.grant_count == 1U);
+    assert(ctx19g.slots[0].svc_bits == 0x00);
+    assert(s19g.p25_crypto_state[0] == DSD_P25_CRYPTO_CLEAR);
+    assert(s19g.p25_p2_audio_allowed[0] == 1);
+    assert(s19g.p25_p2_audio_ring_count[0] == 1);
+    assert(s19g.s_l4[0][0] == 321);
+
+    // A duplicate whose valid service options genuinely change the
+    // classification (clear -> encrypted) must still restart it.
+    p25_sm_event(&ctx19g, &o19g, &s19g, &duplicate_encrypted);
+    assert(ctx19g.slots[0].svc_bits == 0x40);
+    assert(s19g.p25_crypto_state[0] == DSD_P25_CRYPTO_ENCRYPTED_PENDING);
+
     // A same-route grant update received during active voice must refresh the
     // canonical service metadata even when the clear/encrypted classification
     // does not change and no later ACTIVE event supplies the new options.
@@ -1950,8 +1971,9 @@ main(void) {
     assert(g_result_return_to_cc_calls == 1);
     assert(ctx19f.state == P25_SM_ON_CC);
 
-    // 27) A Phase 2 classification timeout blocks and purges only the
-    // unresolved slot while retaining an active clear companion.
+    // 27) A Phase 2 classification timeout returns only the unresolved slot to
+    // unclassified (never encrypted -- nothing was observed) and purges it
+    // while retaining an active clear companion.
     static dsd_opts o19c;
     static dsd_state s19c;
     DSD_MEMSET(&o19c, 0, sizeof(o19c));
@@ -1991,7 +2013,7 @@ main(void) {
     assert(g_result_return_to_cc_calls == 0);
     assert(ctx19c.slots[0].grant_active == 0);
     assert(ctx19c.slots[1].voice_active == 1);
-    assert(s19c.p25_crypto_state[0] == DSD_P25_CRYPTO_BLOCKED);
+    assert(s19c.p25_crypto_state[0] == DSD_P25_CRYPTO_UNKNOWN);
     assert(s19c.p25_p2_audio_ring_count[0] == 0);
     assert(s19c.p25_p2_audio_ring_count[1] == 3);
     assert(s19c.s_l4[0][0] == 0);
@@ -2036,7 +2058,7 @@ main(void) {
     assert(ctx19i.slots[0].grant_active == 0);
     assert(ctx19i.slots[1].grant_active == 1);
     assert(ctx19i.slots[1].data_call == 1);
-    assert(s19i.p25_crypto_state[0] == DSD_P25_CRYPTO_BLOCKED);
+    assert(s19i.p25_crypto_state[0] == DSD_P25_CRYPTO_UNKNOWN);
     assert(s19i.p25_p2_audio_ring_count[0] == 0);
     assert(s19i.s_l4[0][0] == 0);
 

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -1253,11 +1253,16 @@ test_p1_clear_identity_quarantines_conflicting_hdu(void) {
     if (setup_p1_retained_clear_conflict(&ctx, 0) != 0) {
         return 1;
     }
+    // An unconfirmed conflict expiring under encryption lockout resumes the
+    // presumed-clear call exactly like encrypted-follow mode: the tuple never
+    // corroborated against explicit-clear service options, so releasing the
+    // channel would drop clear voice over a single unrepeated observation.
     ctx.slots[0].crypto_attempt_m = dsd_time_now_monotonic_s() - ctx.config.grant_timeout_s - 0.1;
     p25_sm_tick_ctx(&ctx, &g_opts, &g_state);
-    if (ctx.state != P25_SM_ON_CC || g_return_requests != 1 || encrypted_call_cache_has(3069U, 1)
-        || g_state.p25_p1_crypto_conflict.active) {
-        DSD_FPRINTF(stderr, "FAIL: Unconfirmed Phase 1 conflict timeout produced encrypted-call side effects\n");
+    if (ctx.state != P25_SM_TUNED || g_return_requests != 0 || encrypted_call_cache_has(3069U, 1)
+        || g_state.p25_p1_crypto_conflict.active || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_CLEAR
+        || !p25_crypto_audio_permitted(&g_opts, &g_state, 0)) {
+        DSD_FPRINTF(stderr, "FAIL: Unconfirmed lockout conflict timeout did not resume the presumed-clear call\n");
         return 1;
     }
     return 0;


### PR DESCRIPTION
## Problem

With `--enc-lockout` enabled, clear P25 calls oscillate between clear and encrypted in the UI while the audio cuts in and out. Reproduced live against a P25p2 system (SM decision log + payload capture): one 16-second clear call (svc=0x04) spent much of its airtime in `ENCRYPTED_PENDING`, and the surrounding session racked up 20+ tune/release cycles from misclassified or unclassified clear traffic.

## Root causes (from the SM logs)

1. **Implicit grant updates toggled the classification.** Control channels interleave explicit (svc=0x04) and implicit (service-less) grant updates for one call. The duplicate-grant path overwrote the retained service bits with "unknown," so the next explicit update looked like a classification change — restarting classification and purging audio at ~1 Hz (`p25_grant_refresh_duplicate_crypto`).
2. **Every transmission re-proved "clear" from scratch.** A completed epoch forced the next transmission's service options to unknown, which under lockout begins `ENCRYPTED_PENDING` (muted) until an ESS decodes. In fades, MAC_PTT/ESS_B losses stretched every PTT boundary into a dropout.
3. **The 3 s classification timeout fabricated an encrypted verdict.** A slot still pending when the window lapsed was converted to `BLOCKED` and published as an encrypted call with no ALGID ever observed.
4. **One corrupt ESS could lock out a clear call, and the enc cache never expired.** Phase 2 locked out on a single non-clear ESS observation (CRC12/RS-erasure miscorrections happen at low SNR), and the transient enc TG cache TTL slid forward on every suppressed service-less update, starving the talkgroup while its call continued.

## Fixes

- Service-less duplicate grants carry no classification evidence: keep the retained service bits and never restart classification from them.
- Retained service options stay valid across a transmission boundary when a grant re-validated the assignment since the last stop (same freshness rule the retained source identity uses), so the next same-identity transmission classifies clear immediately.
- Classification timeout returns the slot to `UNKNOWN` (never `BLOCKED`) before release, and the Phase 1 explicit-clear conflict recovery now also runs under lockout.
- Non-clear Phase 2 ESS tuples that contradict explicit-clear service metadata quarantine until a matching tuple repeats (mirrors the Phase 1 clear-conflict rule); only grants whose service options prove encryption extend the enc TG cache entry.

Encrypted-call handling is unchanged where evidence is real: explicit enc grants still lock out at grant time, corroborated ESS tuples lock out within one ESS repeat (~360 ms), and service-less/late-entry traffic still classifies from a single authoritative ESS.

## Validation

- Full CTest suite passes (476/476); `tools/preflight_ci.sh` clean.
- New regressions: implicit-duplicate no-demote and clear→enc restart (`test_p25_sm_core`), fresh-grant service inheritance and stale-grant conservatism at PTT (`test_p25_p2_frame_lockout_sm`), Phase 2 clear-conflict corroboration incl. slot isolation and service-less single-observation behavior (`test_p25_crypto_state`), timeout-to-unclassified (`test_p25_crypto_state`, `test_p25_sm_core`), enc-cache TTL evidence gating (`test_p25_grant_policy`), lockout conflict-timeout resume (`test_p25_sm_unified_core`).
- Live A/B on the same P25p2 system: baseline showed a 15 s pending flap inside one clear call plus per-second clear/pending toggling; with the fix, clear calls show at most one transient classification wait at initial tune, zero classification timeouts, and genuinely encrypted calls (AES-256, svc=0x44) still lock out correctly.