### PR TITLE
dmr: require corroborated privacy-bit evidence before enc lockout

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -598,6 +598,17 @@ struct dsd_state {
     unsigned int dmr_heal_so[2];
     uint8_t dmr_heal_valid[2];
 
+    /* Per-slot DMR encryption-classification hysteresis (src/protocol/dmr/dmr_enc_class.c).
+     * The service-option privacy bit arrives through channels of very different reliability --
+     * a voice LC header behind a 16-bit masked CRC, an embedded LC behind a 5-bit checksum, and
+     * on RAS systems no verifiable CRC at all -- so the classification the enc lockout and the
+     * audio gate act on is corroborated here: strong evidence applies at once, weak evidence
+     * applies tentatively and must repeat before it can flip an established classification or
+     * arm the lockout. Indexed by slot. */
+    uint8_t dmr_enc_class[2];         /* applied classification: 0 none, 1 clear, 2 encrypted */
+    uint8_t dmr_enc_class_est[2];     /* classification corroborated (strong LC or matching repeat) */
+    uint8_t dmr_enc_class_pending[2]; /* quarantined contradicting candidate (0 none, 1 clear, 2 enc) */
+
     char slot1light[8];
     char slot2light[8];
     int directmode;

--- a/include/dsd-neo/protocol/dmr/dmr.h
+++ b/include/dsd-neo/protocol/dmr/dmr.h
@@ -34,6 +34,19 @@ void dmr_data_burst_handler(dsd_opts* opts, dsd_state* state, uint8_t info[196],
                             const uint8_t* reliab98);
 
 void dmr_pi(dsd_opts* opts, dsd_state* state, uint8_t PI_BYTE[], uint32_t CRCCorrect, uint32_t IrrecoverableErrors);
+
+/* Per-slot encryption-classification hysteresis for the DMR service-option privacy bit.
+ * Values stored in dsd_state.dmr_enc_class[]: 0 unclassified, 1 clear, 2 encrypted. */
+enum {
+    DMR_ENC_CLASS_NONE = 0,
+    DMR_ENC_CLASS_CLEAR = 1,
+    DMR_ENC_CLASS_ENC = 2,
+};
+
+unsigned int dmr_enc_class_observe(dsd_state* state, uint8_t slot, unsigned int so, int strong);
+void dmr_enc_class_force(dsd_state* state, uint8_t slot, int encrypted);
+void dmr_enc_class_reset(dsd_state* state, uint8_t slot);
+int dmr_enc_class_established_enc(const dsd_state* state, uint8_t slot);
 void dmr_flco(dsd_opts* opts, dsd_state* state, uint8_t lc_bits[], uint32_t CRCCorrect, uint32_t* IrrecoverableErrors,
               uint8_t type);
 uint8_t dmr_cach(dsd_opts* opts, dsd_state* state, uint8_t cach_bits[25]);

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1896,6 +1896,15 @@ no_carrier_reset_payload_and_keystream_state(dsd_state* state) {
     // this reset could only ever be misapplied to whatever decodes next.
     state->dmr_heal_valid[0] = 0;
     state->dmr_heal_valid[1] = 0;
+    // The live service options and the classification they establish describe the carrier
+    // that just went away; a stale privacy bit would mute the opening bursts of whatever
+    // decodes next until its first LC arrives.
+    state->dmr_so = 0;
+    state->dmr_soR = 0;
+    state->dmr_fid = 0;
+    state->dmr_fidR = 0;
+    dmr_enc_class_reset(state, 0);
+    dmr_enc_class_reset(state, 1);
     state->payload_mi = 0;
     state->payload_miR = 0;
     state->payload_mfid = 0;

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -16,6 +16,7 @@
 #include <dsd-neo/io/rigctl_client.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/platform.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/protocol/dmr/dmr_block.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/protocol/p25/p25p2_frame.h>
@@ -124,6 +125,15 @@ dsd_engine_reset_return_to_cc_state(dsd_opts* opts, dsd_state* state) {
     // control channel leaves nothing the stash could legitimately be restored onto.
     state->dmr_heal_valid[0] = 0;
     state->dmr_heal_valid[1] = 0;
+    // The live service options and the classification they establish belong to the channel
+    // being left; a stale privacy bit here would mute the opening bursts of the next tuned
+    // call until its first LC decodes.
+    state->dmr_so = 0;
+    state->dmr_soR = 0;
+    state->dmr_fid = 0;
+    state->dmr_fidR = 0;
+    dmr_enc_class_reset(state, 0);
+    dmr_enc_class_reset(state, 1);
     state->payload_algid = 0;
     state->payload_algidR = 0;
     state->payload_keyid = 0;

--- a/src/protocol/dmr/CMakeLists.txt
+++ b/src/protocol/dmr/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(
         dmr_trunk_sm.c
         dmr_data.c
         dmr_dburst.c
+        dmr_enc_class.c
         dmr_flco.c
         dmr_hytera.c
         dmr_le.c

--- a/src/protocol/dmr/dmr_enc_class.c
+++ b/src/protocol/dmr/dmr_enc_class.c
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Per-slot hysteresis for the DMR service-option privacy bit.
+ *
+ * The privacy bit reaches the decoder over channels of very different
+ * reliability: a voice LC header behind a 16-bit masked CRC, an embedded LC
+ * behind a 5-bit checksum (a miscorrected BPTC payload passes it roughly one
+ * time in 32), and on RAS systems no verifiable CRC at all. Acting on each
+ * observation directly lets a single corrupt LC mute a clear call, flap the
+ * published classification at the embedded-LC cadence, and -- under
+ * --enc-lockout -- permanently block the talkgroup and force the channel
+ * released. This module makes the applied classification sticky: strong
+ * evidence applies at once, weak evidence applies tentatively and must repeat
+ * before it can flip an established classification, and the lockout only acts
+ * on an established encrypted classification.
+ */
+
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
+#include <stdint.h>
+
+#include "dsd-neo/core/state_fwd.h"
+
+static uint8_t
+dmr_enc_class_slot_index(uint8_t slot) {
+    return (uint8_t)(slot != 0U ? 1U : 0U);
+}
+
+/* Feed one service-option observation for the slot and return the SO byte
+ * with the privacy bit replaced by the retained classification. `strong`
+ * marks evidence trustworthy on its own (a CRC-verified voice LC header or a
+ * checksum-verified PI); weak evidence establishes only by repetition. */
+unsigned int
+dmr_enc_class_observe(dsd_state* state, uint8_t slot, unsigned int so, int strong) {
+    const uint8_t idx = dmr_enc_class_slot_index(slot);
+    const uint8_t obs = (so & 0x40U) != 0U ? DMR_ENC_CLASS_ENC : DMR_ENC_CLASS_CLEAR;
+
+    if (strong) {
+        state->dmr_enc_class[idx] = obs;
+        state->dmr_enc_class_est[idx] = 1U;
+        state->dmr_enc_class_pending[idx] = DMR_ENC_CLASS_NONE;
+    } else if (state->dmr_enc_class[idx] == DMR_ENC_CLASS_NONE) {
+        // First observation of the transmission: apply tentatively so late
+        // entry still classifies immediately, but leave it uncorroborated so
+        // a lone corrupt LC cannot arm the lockout.
+        state->dmr_enc_class[idx] = obs;
+        state->dmr_enc_class_est[idx] = 0U;
+        state->dmr_enc_class_pending[idx] = DMR_ENC_CLASS_NONE;
+    } else if (obs == state->dmr_enc_class[idx]) {
+        // A matching repeat corroborates; embedded LC repeats every 360 ms,
+        // so a real classification establishes within one repeat.
+        state->dmr_enc_class_est[idx] = 1U;
+        state->dmr_enc_class_pending[idx] = DMR_ENC_CLASS_NONE;
+    } else if (state->dmr_enc_class_est[idx] == 0U || state->dmr_enc_class_pending[idx] == obs) {
+        // Contradicting a value that never corroborated, or the second
+        // consecutive contradiction of an established classification: the
+        // newer observation wins (a tentative replacement stays tentative; a
+        // corroborated flip keeps the slot established).
+        state->dmr_enc_class[idx] = obs;
+        state->dmr_enc_class_pending[idx] = DMR_ENC_CLASS_NONE;
+    } else {
+        // Lone contradiction of an established classification: quarantine it
+        // until it repeats, keeping the established bit applied.
+        state->dmr_enc_class_pending[idx] = obs;
+    }
+
+    if (state->dmr_enc_class[idx] == DMR_ENC_CLASS_ENC) {
+        return so | 0x40U;
+    }
+    return so & ~0x40U;
+}
+
+/* Strong out-of-band evidence (a checksum-verified PI header, the heal of an
+ * unverified terminator restoring live crypto): apply and corroborate. */
+void
+dmr_enc_class_force(dsd_state* state, uint8_t slot, int encrypted) {
+    const uint8_t idx = dmr_enc_class_slot_index(slot);
+    state->dmr_enc_class[idx] = encrypted ? DMR_ENC_CLASS_ENC : DMR_ENC_CLASS_CLEAR;
+    state->dmr_enc_class_est[idx] = 1U;
+    state->dmr_enc_class_pending[idx] = DMR_ENC_CLASS_NONE;
+}
+
+void
+dmr_enc_class_reset(dsd_state* state, uint8_t slot) {
+    const uint8_t idx = dmr_enc_class_slot_index(slot);
+    state->dmr_enc_class[idx] = DMR_ENC_CLASS_NONE;
+    state->dmr_enc_class_est[idx] = 0U;
+    state->dmr_enc_class_pending[idx] = DMR_ENC_CLASS_NONE;
+}
+
+int
+dmr_enc_class_established_enc(const dsd_state* state, uint8_t slot) {
+    const uint8_t idx = dmr_enc_class_slot_index(slot);
+    return state->dmr_enc_class[idx] == DMR_ENC_CLASS_ENC && state->dmr_enc_class_est[idx] != 0U;
+}

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -480,6 +480,7 @@ dmr_flco_handle_irrecoverable_hytera_enhanced(dmr_flco_ctx* ctx) {
             ctx->state->payload_keyidR = key;
             ctx->state->payload_miR = mi;
         }
+        dmr_enc_class_force(ctx->state, ctx->slot, 1);
         ctx->opts->dmr_le = 2;
         *ctx->IrrecoverableErrors = 0;
     } else {
@@ -547,6 +548,7 @@ dmr_flco_reset_slot_crypto(dmr_flco_ctx* ctx, uint8_t idx) {
     *live.algid = 0;
     *live.keyid = 0;
     *live.mi = 0;
+    dmr_enc_class_reset(ctx->state, idx);
     if (ctx->opts->floating_point == 1) {
         if (idx == 0U) {
             ctx->state->aout_gain = ctx->opts->audio_gain;
@@ -569,6 +571,16 @@ dmr_flco_reset_slot_metadata(dmr_flco_ctx* ctx, uint8_t idx) {
 
 static void
 dmr_flco_sync_active_call_state(dmr_flco_ctx* ctx) {
+    // The privacy bit is filtered through the per-slot classification hysteresis before it can
+    // reach the live SO the audio gate and the enc lockout act on. Only the voice LC header's
+    // 16-bit masked CRC is strong enough to trust alone: the embedded LC's 5-bit checksum
+    // passes a miscorrected payload roughly one time in 32, and on RAS systems under the
+    // aggressive default the masked CRC never verifies, so those observations must repeat
+    // before they can flip an established classification.
+    if (dmr_slot_is_known(ctx->state)) {
+        const int strong = ctx->type == 1U && ctx->CRCCorrect == 1U;
+        ctx->so = (uint8_t)dmr_enc_class_observe(ctx->state, (uint8_t)(ctx->state->currentslot & 1), ctx->so, strong);
+    }
     if (ctx->state->currentslot == 0) {
         ctx->state->dmr_fid = ctx->fid;
         ctx->state->dmr_so = ctx->so;
@@ -737,6 +749,9 @@ dmr_flco_heal_restore(dsd_state* state, uint8_t slot, const dsd_call_snapshot* p
     *live.algid = (int)previous->algid;
     *live.keyid = (int)previous->kid;
     *live.mi = state->dmr_heal_mi[idx];
+    // The stash held live, already-corroborated signaling; restoring it re-establishes the
+    // classification so the resumed transmission is not re-proved from scratch.
+    dmr_enc_class_force(state, idx, (*live.so & 0x40U) != 0U);
     state->dmr_heal_valid[idx] = 0U;
 }
 
@@ -927,6 +942,18 @@ dmr_flco_apply_enc_lockout(dmr_flco_ctx* ctx) {
     DSD_FPRINTF(stderr, "%s", KRED);
     DSD_FPRINTF(stderr, "Encrypted ");
     if (!(ctx->opts->trunk_enable == 1 && ctx->opts->trunk_tune_enc_calls == 0)) {
+        return;
+    }
+    // A terminator's privacy bit describes the transmission that just ended; blocking the
+    // talkgroup and forcing a release for a call that is already over would only tear down
+    // whatever follows on the channel.
+    if (ctx->type == 2U) {
+        return;
+    }
+    // Blocking the talkgroup is permanent for the session and the forced P_CLEAR release
+    // drops the channel, so only an established (corroborated) encrypted classification may
+    // act -- a lone corrupt LC observing the privacy bit stays quarantined above.
+    if (!dmr_enc_class_established_enc(ctx->state, (uint8_t)(ctx->state->currentslot & 1))) {
         return;
     }
 

--- a/src/protocol/dmr/dmr_pi.c
+++ b/src/protocol/dmr/dmr_pi.c
@@ -68,6 +68,8 @@ dmr_pi_handle_kirisun(dsd_opts* opts, dsd_state* state, const uint8_t pi_byte[])
         state->payload_keyidR = key_hash;
         state->payload_miR = mi;
     }
+    // CRC-verified PI header (gated by the caller): strong classification evidence.
+    dmr_enc_class_force(state, (uint8_t)(state->currentslot & 1), (so & 0x40U) != 0U);
 
     DSD_FPRINTF(stderr, "%s ", KYEL);
     DSD_FPRINTF(stderr, "\n Slot %d", state->currentslot + 1);
@@ -102,24 +104,28 @@ dmr_pi_hytera_print_key(const dsd_state* state, int show_keys) {
 
 static void
 dmr_pi_handle_hytera(dsd_opts* opts, dsd_state* state, const uint8_t pi_byte[]) {
-    if (state->currentslot == 0) {
-        state->dmr_so |= 0x40; //OR the enc bit onto the SO
-        state->payload_algid = pi_byte[0];
-        state->payload_keyid = pi_byte[2];
-        state->payload_mi = dmr_pi_extract_mi40(pi_byte);
-    } else {
-        state->dmr_soR |= 0x40; //OR the enc bit onto the SO
-        state->payload_algidR = pi_byte[0];
-        state->payload_keyidR = pi_byte[2];
-        state->payload_miR = dmr_pi_extract_mi40(pi_byte);
-    }
-
     DSD_FPRINTF(stderr, "%s ", KYEL);
     DSD_FPRINTF(stderr, "\n Slot %d", state->currentslot + 1);
     DSD_FPRINTF(stderr, " DMR PI H- ALG ID: %02X; KEY ID: %02X; MI(40): %02X%02X%02X%02X%02X;", pi_byte[0], pi_byte[2],
                 pi_byte[3], pi_byte[4], pi_byte[5], pi_byte[6], pi_byte[7]);
 
     if (dmr_hytera_checksum(pi_byte, 9U) == pi_byte[9]) {
+        // Only a checksum-verified PI may mutate the live crypto: the caller dispatches on the
+        // MFID byte alone, so an unverified Hytera-shaped PI is exactly one corrupt burst away
+        // from muting a clear call with a fabricated ALGID/MI.
+        if (state->currentslot == 0) {
+            state->dmr_so |= 0x40; //OR the enc bit onto the SO
+            state->payload_algid = pi_byte[0];
+            state->payload_keyid = pi_byte[2];
+            state->payload_mi = dmr_pi_extract_mi40(pi_byte);
+        } else {
+            state->dmr_soR |= 0x40; //OR the enc bit onto the SO
+            state->payload_algidR = pi_byte[0];
+            state->payload_keyidR = pi_byte[2];
+            state->payload_miR = dmr_pi_extract_mi40(pi_byte);
+        }
+        dmr_enc_class_force(state, (uint8_t)(state->currentslot & 1), 1);
+
         DSD_FPRINTF(stderr, " Hytera Enhanced; ");
         dmr_pi_hytera_print_key(state, opts->show_keys);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5454,6 +5454,14 @@ target_include_directories(
 target_link_libraries(dsd-neo_test_dmr_pi_kirisun PRIVATE dsd-neo_proto_dmr)
 add_test(NAME DMR_PI_KIRISUN COMMAND dsd-neo_test_dmr_pi_kirisun)
 
+add_executable(dsd-neo_test_dmr_enc_class protocol/dmr/test_dmr_enc_class.c)
+target_include_directories(
+    dsd-neo_test_dmr_enc_class
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(dsd-neo_test_dmr_enc_class PRIVATE dsd-neo_proto_dmr)
+add_test(NAME DMR_ENC_CLASS COMMAND dsd-neo_test_dmr_enc_class)
+
 add_executable(
     dsd-neo_test_dmr_flco_privacy_modes
     protocol/dmr/test_dmr_flco_privacy_modes.c

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -124,6 +124,13 @@ dmr_reset_blocks(dsd_opts* opts, dsd_state* state) {
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
+dmr_enc_class_reset(dsd_state* state, uint8_t slot) {
+    (void)state;
+    (void)slot;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_frame_sync_reset_mod_state(void) {
     g_frame_sync_reset_calls++;
 }

--- a/tests/protocol/dmr/test_dmr_enc_class.c
+++ b/tests/protocol/dmr/test_dmr_enc_class.c
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Per-slot DMR encryption-classification hysteresis: strong evidence applies
+ * at once, weak evidence applies tentatively and must repeat before it can
+ * establish or flip a classification, and only an established encrypted
+ * classification may arm the enc lockout. Also covers the PI-header paths
+ * that feed the hysteresis as strong evidence, including the Hytera PI
+ * checksum gate.
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_ext.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static dsd_opts s_opts;
+static dsd_state s_state;
+
+static void
+reset_fixture(void) {
+    DSD_MEMSET(&s_opts, 0, sizeof(s_opts));
+    DSD_MEMSET(&s_state, 0, sizeof(s_state));
+}
+
+static void
+test_first_weak_observation_is_tentative(void) {
+    reset_fixture();
+    unsigned int so = dmr_enc_class_observe(&s_state, 0U, 0x40U, 0);
+    assert((so & 0x40U) != 0U);
+    assert(dmr_enc_class_established_enc(&s_state, 0U) == 0);
+
+    // A matching repeat corroborates.
+    so = dmr_enc_class_observe(&s_state, 0U, 0x40U, 0);
+    assert((so & 0x40U) != 0U);
+    assert(dmr_enc_class_established_enc(&s_state, 0U) == 1);
+}
+
+static void
+test_strong_observation_establishes_immediately(void) {
+    reset_fixture();
+    const unsigned int so = dmr_enc_class_observe(&s_state, 0U, 0x40U, 1);
+    assert((so & 0x40U) != 0U);
+    assert(dmr_enc_class_established_enc(&s_state, 0U) == 1);
+}
+
+static void
+test_lone_contradiction_of_established_is_quarantined(void) {
+    reset_fixture();
+    // Established clear via a strong observation.
+    (void)dmr_enc_class_observe(&s_state, 0U, 0x00U, 1);
+
+    // One corrupt embedded LC claiming encryption: the established clear
+    // classification stays applied, so the audio gate does not flap and the
+    // lockout cannot arm.
+    unsigned int so = dmr_enc_class_observe(&s_state, 0U, 0x40U, 0);
+    assert((so & 0x40U) == 0U);
+    assert(dmr_enc_class_established_enc(&s_state, 0U) == 0);
+
+    // A matching clear observation clears the quarantine.
+    so = dmr_enc_class_observe(&s_state, 0U, 0x00U, 0);
+    assert((so & 0x40U) == 0U);
+
+    // Two consecutive contradictions flip the classification: the call
+    // really changed shape.
+    (void)dmr_enc_class_observe(&s_state, 0U, 0x40U, 0);
+    so = dmr_enc_class_observe(&s_state, 0U, 0x40U, 0);
+    assert((so & 0x40U) != 0U);
+    assert(dmr_enc_class_established_enc(&s_state, 0U) == 1);
+}
+
+static void
+test_contradiction_of_tentative_replaces(void) {
+    reset_fixture();
+    // A lone corrupt LC opening a late entry classifies tentatively...
+    (void)dmr_enc_class_observe(&s_state, 0U, 0x40U, 0);
+    // ...and the next (clear) observation replaces it instead of being
+    // quarantined behind a value that never corroborated.
+    unsigned int so = dmr_enc_class_observe(&s_state, 0U, 0x00U, 0);
+    assert((so & 0x40U) == 0U);
+    assert(dmr_enc_class_established_enc(&s_state, 0U) == 0);
+    so = dmr_enc_class_observe(&s_state, 0U, 0x00U, 0);
+    assert((so & 0x40U) == 0U);
+}
+
+static void
+test_strong_contradiction_applies_immediately(void) {
+    reset_fixture();
+    (void)dmr_enc_class_observe(&s_state, 0U, 0x40U, 0);
+    (void)dmr_enc_class_observe(&s_state, 0U, 0x40U, 0);
+    assert(dmr_enc_class_established_enc(&s_state, 0U) == 1);
+
+    // A CRC-verified voice LC header saying clear wins at once.
+    const unsigned int so = dmr_enc_class_observe(&s_state, 0U, 0x00U, 1);
+    assert((so & 0x40U) == 0U);
+    assert(dmr_enc_class_established_enc(&s_state, 0U) == 0);
+}
+
+static void
+test_non_privacy_bits_pass_through(void) {
+    reset_fixture();
+    (void)dmr_enc_class_observe(&s_state, 0U, 0x00U, 1);
+    // Emergency and priority bits are not the classifier's business; only the
+    // privacy bit is filtered.
+    const unsigned int so = dmr_enc_class_observe(&s_state, 0U, 0xC3U, 0);
+    assert((so & 0x80U) != 0U);
+    assert((so & 0x03U) == 0x03U);
+    assert((so & 0x40U) == 0U);
+}
+
+static void
+test_force_and_reset(void) {
+    reset_fixture();
+    dmr_enc_class_force(&s_state, 1U, 1);
+    assert(dmr_enc_class_established_enc(&s_state, 1U) == 1);
+    dmr_enc_class_reset(&s_state, 1U);
+    assert(dmr_enc_class_established_enc(&s_state, 1U) == 0);
+    assert(s_state.dmr_enc_class[1] == DMR_ENC_CLASS_NONE);
+}
+
+static void
+test_slot_isolation(void) {
+    reset_fixture();
+    (void)dmr_enc_class_observe(&s_state, 0U, 0x40U, 1);
+    assert(dmr_enc_class_established_enc(&s_state, 0U) == 1);
+    assert(dmr_enc_class_established_enc(&s_state, 1U) == 0);
+    const unsigned int so = dmr_enc_class_observe(&s_state, 1U, 0x00U, 0);
+    assert((so & 0x40U) == 0U);
+    assert(dmr_enc_class_established_enc(&s_state, 0U) == 1);
+}
+
+static uint8_t
+hytera_additive_checksum(const uint8_t* bytes, size_t length) {
+    uint8_t checksum = 0;
+    for (size_t i = 0; i < length; i++) {
+        checksum = (uint8_t)(checksum + bytes[i]);
+    }
+    return (uint8_t)(0U - checksum);
+}
+
+static void
+test_hytera_pi_checksum_gates_crypto_writes(void) {
+    reset_fixture();
+    s_state.currentslot = 0;
+
+    uint8_t pi[11] = {0x02U, 0x68U, 0x34U, 0x01U, 0x23U, 0x45U, 0x67U, 0x89U, 0xABU, 0x00U, 0x00U};
+
+    // Corrupt checksum: nothing may reach the live crypto or the classifier.
+    pi[9] = (uint8_t)(hytera_additive_checksum(pi, 9U) ^ 0x5AU);
+    dmr_pi(&s_opts, &s_state, pi, 0U, 0U);
+    assert((s_state.dmr_so & 0x40U) == 0U);
+    assert(s_state.payload_algid == 0);
+    assert(s_state.payload_keyid == 0);
+    assert(s_state.payload_mi == 0ULL);
+    assert(dmr_enc_class_established_enc(&s_state, 0U) == 0);
+
+    // Verified checksum: strong evidence, applied and established.
+    pi[9] = hytera_additive_checksum(pi, 9U);
+    dmr_pi(&s_opts, &s_state, pi, 0U, 0U);
+    assert((s_state.dmr_so & 0x40U) != 0U);
+    assert(s_state.payload_algid == 0x02);
+    assert(s_state.payload_keyid == 0x34);
+    assert(s_state.payload_mi == 0x0123456789ULL);
+    assert(dmr_enc_class_established_enc(&s_state, 0U) == 1);
+    dsd_state_ext_free_all(&s_state);
+}
+
+static void
+test_kirisun_pi_establishes_classification(void) {
+    reset_fixture();
+    s_state.currentslot = 1;
+
+    uint8_t pi[11] = {0x36U, 0x0AU, 0x40U, 0x01U, 0x23U, 0x45U, 0x67U, 0x11U, 0x22U, 0x33U, 0x00U};
+    dmr_pi(&s_opts, &s_state, pi, 1U, 0U);
+    assert((s_state.dmr_soR & 0x40U) != 0U);
+    assert(dmr_enc_class_established_enc(&s_state, 1U) == 1);
+    dsd_state_ext_free_all(&s_state);
+}
+
+int
+main(void) {
+    test_first_weak_observation_is_tentative();
+    test_strong_observation_establishes_immediately();
+    test_lone_contradiction_of_established_is_quarantined();
+    test_contradiction_of_tentative_replaces();
+    test_strong_contradiction_applies_immediately();
+    test_non_privacy_bits_pass_through();
+    test_force_and_reset();
+    test_slot_isolation();
+    test_hytera_pi_checksum_gates_crypto_writes();
+    test_kirisun_pi_establishes_classification();
+    return 0;
+}

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -1637,6 +1637,169 @@ test_encrypted_flco_allowed_tuning_skips_lockout_policy(void) {
     dsd_state_ext_free_all(&state);
 }
 
+// The embedded LC's 5-bit checksum passes a miscorrected payload roughly one time in 32, so a
+// lone embedded observation of the privacy bit classifies only tentatively: the slot mutes,
+// but the session-permanent blocking entry and the forced release wait for the matching repeat
+// one superframe (~360 ms) later.
+static void
+test_embedded_lc_enc_requires_corroboration_for_lockout(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_tg_policy_lookup lookup;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+    init_event_history(&history[0], 0, 1);
+    init_event_history(&history[1], 0, 1);
+    state.event_history_s = history;
+    opts.trunk_enable = 1;
+    opts.trunk_tune_enc_calls = 0;
+    state.currentslot = 0;
+
+    build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1234U, 5678U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 3U);
+    assert(irr == 0);
+    assert((state.dmr_so & 0x40U) != 0U);
+    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_NONE);
+
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1234U, 5678U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 3U);
+    assert(irr == 0);
+    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_EXACT);
+    assert(strcmp(lookup.entry.mode, "B") == 0);
+    assert(strcmp(lookup.entry.name, "ENC LO") == 0);
+    dsd_state_ext_free_all(&state);
+}
+
+// A CRC-verified voice LC header established the call clear; one contradicting embedded LC --
+// the exact shape a miscorrected BPTC payload takes -- must not mute the audio, demote the
+// published classification, or arm the lockout. A corroborated contradiction is a real
+// mid-call change and does all three.
+static void
+test_lone_contradicting_emb_does_not_flap_established_clear(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_tg_policy_lookup lookup;
+    dsd_call_snapshot call;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+    init_event_history(&history[0], 0, 1);
+    init_event_history(&history[1], 0, 1);
+    state.event_history_s = history;
+    opts.trunk_enable = 1;
+    opts.trunk_tune_enc_calls = 0;
+    state.currentslot = 0;
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+
+    build_regular_flco(bits, 0x00U, 0x00U, 0x00U, 1234U, 5678U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+    assert(irr == 0);
+    assert((state.dmr_so & 0x40U) == 0U);
+
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1234U, 5678U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 3U);
+    assert(irr == 0);
+    assert((state.dmr_so & 0x40U) == 0U);
+    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_NONE);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.crypto == DSD_CALL_CRYPTO_CLEAR);
+    assert(call.audio_permitted == 1U);
+
+    // The repeat corroborates: the classification flips and the lockout acts.
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1234U, 5678U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 3U);
+    assert(irr == 0);
+    assert((state.dmr_so & 0x40U) != 0U);
+    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_EXACT);
+    assert(strcmp(lookup.entry.mode, "B") == 0);
+    dsd_state_ext_free_all(&state);
+}
+
+// A terminator's privacy bit describes a transmission that already ended; it may print, but it
+// must not block the talkgroup or force a release for whatever follows on the channel.
+static void
+test_terminator_privacy_bit_does_not_lock_out(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_tg_policy_lookup lookup;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+    init_event_history(&history[0], 0, 1);
+    init_event_history(&history[1], 0, 1);
+    state.event_history_s = history;
+    opts.trunk_enable = 1;
+    opts.trunk_tune_enc_calls = 0;
+    state.currentslot = 0;
+
+    build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1234U, 5678U);
+    dmr_flco(&opts, &state, bits, 1U, &irr, 2U);
+    assert(irr == 0);
+    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_NONE);
+    dsd_state_ext_free_all(&state);
+}
+
+// On RAS systems under the aggressive default every LC arrives with the masked CRC failed, so
+// the header is weak evidence too: the first encrypted observation classifies tentatively and
+// the lockout waits for the repeat -- which a real encrypted call supplies within one embedded
+// LC cadence.
+static void
+test_crc_failed_header_enc_requires_repeat_for_lockout(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    uint8_t bits[80];
+    uint32_t irr = 0;
+    dsd_tg_policy_lookup lookup;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+    init_event_history(&history[0], 0, 1);
+    init_event_history(&history[1], 0, 1);
+    state.event_history_s = history;
+    opts.trunk_enable = 1;
+    opts.trunk_tune_enc_calls = 0;
+    state.currentslot = 0;
+
+    build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1234U, 5678U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 1U);
+    assert(irr == 0);
+    assert((state.dmr_so & 0x40U) != 0U);
+    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_NONE);
+
+    irr = 0;
+    build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1234U, 5678U);
+    dmr_flco(&opts, &state, bits, 0U, &irr, 3U);
+    assert(irr == 0);
+    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_EXACT);
+    assert(strcmp(lookup.entry.mode, "B") == 0);
+    dsd_state_ext_free_all(&state);
+}
+
 static void
 test_completed_slco_tier3_site_parameters_update_state(void) {
     static dsd_opts opts;
@@ -1996,6 +2159,10 @@ main(void) {
     test_encrypted_flco_lockout_inserts_policy_and_event_history();
     test_encrypted_flco_lockout_return_keeps_canonical_calls_ended();
     test_encrypted_flco_allowed_tuning_skips_lockout_policy();
+    test_embedded_lc_enc_requires_corroboration_for_lockout();
+    test_lone_contradicting_emb_does_not_flap_established_clear();
+    test_terminator_privacy_bit_does_not_lock_out();
+    test_crc_failed_header_enc_requires_repeat_for_lockout();
     test_completed_slco_tier3_site_parameters_update_state();
     test_completed_slco_activity_uses_each_slot_value();
     test_completed_slco_connect_plus_and_xpt_update_site_state();

--- a/tests/protocol/dmr/test_dmr_pi_kirisun.c
+++ b/tests/protocol/dmr/test_dmr_pi_kirisun.c
@@ -428,6 +428,9 @@ test_pi_hytera_slot0_checksum_key_and_error_paths(void) {
     assert(state.payload_mi == 0x1032547698ULL);
     assert(opts.dmr_le == 2);
 
+    // A checksum-failed Hytera-shaped PI is one corrupt burst away from muting a clear call
+    // with a fabricated ALGID/MI -- the caller dispatches on the MFID byte alone -- so the
+    // failure path may print, but nothing may reach the live crypto.
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
     opts.dmr_le = 1;
@@ -435,10 +438,10 @@ test_pi_hytera_slot0_checksum_key_and_error_paths(void) {
     pi[9] ^= 0x7FU;
     dmr_pi(&opts, &state, pi, 1, 0);
 
-    assert((state.dmr_so & 0x40U) != 0U);
-    assert(state.payload_algid == 0x02);
-    assert(state.payload_keyid == 0x21);
-    assert(state.payload_mi == 0x1032547698ULL);
+    assert((state.dmr_so & 0x40U) == 0U);
+    assert(state.payload_algid == 0);
+    assert(state.payload_keyid == 0);
+    assert(state.payload_mi == 0ULL);
     assert(opts.dmr_le == 1);
 }
 


### PR DESCRIPTION
## Problem

Follow-up to #280, which fixed clear P25 calls flapping clear/encrypted under `--enc-lockout`. Auditing the other trunked protocols for the same defect class found DMR affected by the worst of the four root causes — acting on a single uncorroborated crypto observation — in a more damaging form than P25's:

- `dmr_flco_apply_enc_lockout` fired on each privacy-bit (`SO & 0x40`) observation directly, with **no CRC gate**: the lockout ran even when the LC's CRC failed (the RAS default), and the embedded LC's 5-bit checksum passes a miscorrected BPTC payload roughly one time in 32.
- One bad observation was enough to mute the slot, publish an encrypted classification, insert a **session-permanent** blocking `"B"/ENC LO` TG policy entry (P25 at least used a transient cache with a TTL), and synthesize a P_CLEAR that forced the trunk SM off the channel.
- Because the live SO was fully reassigned from every LC, a lone corrupt embedded LC also flapped an established clear call encrypted-and-back at the embedded-LC cadence (~360 ms), muting and unmuting audio mid-transmission — the same UI/audio flap #280 fixed for P25.
- A Hytera-shaped PI header (dispatched on the MFID byte alone, no CRC required) wrote `dmr_so |= 0x40` and a fabricated ALGID/KEY/MI to the live crypto **before** its checksum was tested; the failure branch only printed.
- The lockout also ran on terminator LCs, force-releasing a call that had already ended, and a stale privacy bit survived the no-carrier/return-to-CC resets, muting the opening bursts of the next tuned call.

## Fixes

New per-slot classification hysteresis (`src/protocol/dmr/dmr_enc_class.c`) between the privacy bit and everything that acts on it:

- **Strong evidence applies immediately**: a CRC-verified voice LC header, a checksum-verified PI header, or the heal of an unverified terminator restoring live crypto. Genuinely encrypted calls still lock out on the first verified LC exactly as before.
- **Weak evidence (embedded LC, CRC-failed LC) applies tentatively** — late entry still classifies from the first observation — but must repeat before it establishes, and a lone observation contradicting an established classification quarantines until a matching repeat (one embedded-LC cadence, mirroring #280's Phase 2 ESS quarantine rule).
- The blocking TG entry and the forced P_CLEAR release act only on an **established encrypted** classification, and never from a terminator LC.
- Hytera PI headers mutate live crypto only after their checksum verifies.
- The no-carrier and return-to-CC resets clear the live service options and classification alongside the payload crypto they already cleared.

## Validation

- Full CTest suite passes (477/477); `tools/preflight_ci.sh` clean.
- New regressions: hysteresis state machine + PI checksum gate (`test_dmr_enc_class`, new); embedded-LC corroboration before lockout, lone-contradiction quarantine of an established clear call (live SO, canonical crypto, and TG policy all steady), terminator no-lockout, CRC-failed-header repeat requirement (`test_dmr_flco_privacy_modes`); the checksum-failed Hytera PI test now asserts the gated behavior (`test_dmr_pi_kirisun`).

Related: #280 (P25 counterpart). An NXDN counterpart PR follows — NXDN shares the single-observation permanent-lockout defect.