### PR TITLE
nxdn: require corroborated cipher evidence before enc lockout

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -554,6 +554,17 @@ struct dsd_state {
     unsigned int nxdn_cipher_type;
     unsigned int nxdn_key;
 
+    /* NXDN cipher-classification hysteresis (src/protocol/nxdn/nxdn_enc_class.c). The cipher
+     * field reaches the decoder from several channels (VCALL, SACCH-2, SCCH) whose FEC/CRC can
+     * accept a miscorrected payload, and under --enc-lockout a single non-clear observation
+     * used to write a session-permanent blocking talkgroup entry and force the channel
+     * released. Observations apply tentatively and must repeat before they can flip an
+     * established classification or arm the lockout; user-forced scrambler modes and the
+     * keyloader apply as authoritative. Values are the observed cipher plus one; 0 = none. */
+    uint8_t nxdn_cipher_class;         /* applied cipher observation + 1; 0 = unclassified */
+    uint8_t nxdn_cipher_class_est;     /* classification corroborated (authoritative or repeat) */
+    uint8_t nxdn_cipher_class_pending; /* quarantined contradicting candidate + 1; 0 = none */
+
     NxdnElementsContent_t NxdnElementsContent;
 
     char ambe_ciphered[49];

--- a/include/dsd-neo/protocol/nxdn/nxdn.h
+++ b/include/dsd-neo/protocol/nxdn/nxdn.h
@@ -14,11 +14,20 @@
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void nxdn_frame(dsd_opts* opts, dsd_state* state);
+
+/* Cipher-classification hysteresis for the NXDN cipher field (values 0..3).
+ * Backed by dsd_state.nxdn_cipher_class*; see src/protocol/nxdn/nxdn_enc_class.c. */
+uint8_t nxdn_cipher_observe(dsd_state* state, uint8_t cipher, int strong);
+void nxdn_cipher_force(dsd_state* state, uint8_t cipher);
+void nxdn_cipher_class_reset(dsd_state* state);
+int nxdn_cipher_established_enc(const dsd_state* state);
 
 #ifdef __cplusplus
 }

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -698,6 +698,11 @@ init_state_protocol_defaults_a(dsd_state* state) {
 
     state->nxdn_last_ran = -1;
     state->nxdn_cipher_type = 0;
+    /* Cleared directly rather than through nxdn_cipher_class_reset(): core must not call into
+     * protocol modules. */
+    state->nxdn_cipher_class = 0;
+    state->nxdn_cipher_class_est = 0;
+    state->nxdn_cipher_class_pending = 0;
     state->nxdn_key = 0;
     state->nxdn_pn95_seed = 228;
     state->payload_miN = 0;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -37,6 +37,7 @@
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
 #include <dsd-neo/protocol/m17/m17.h>
+#include <dsd-neo/protocol/nxdn/nxdn.h>
 #include <dsd-neo/protocol/nxdn/nxdn_convolution.h>
 #include <dsd-neo/protocol/nxdn/nxdn_trunk_diag.h>
 #include <dsd-neo/protocol/p25/p25_crypto.h>
@@ -2012,6 +2013,7 @@ no_carrier_unload_keys_if_needed(dsd_state* state) {
 static void
 no_carrier_reset_dmr_misc_state(dsd_state* state) {
     state->nxdn_cipher_type = 0;
+    nxdn_cipher_class_reset(state);
     DSD_MEMSET(state->dmr_cach_fragment, 1, sizeof(state->dmr_cach_fragment));
     state->dmr_cach_counter = 0;
     DSD_MEMSET(state->dmr_pdu_sf, 0, sizeof(state->dmr_pdu_sf));

--- a/src/protocol/nxdn/CMakeLists.txt
+++ b/src/protocol/nxdn/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(
         nxdn_descramble.c
         nxdn_deperm.c
         nxdn_element.c
+        nxdn_enc_class.c
         nxdn_frame.c
         nxdn_lfsr.c
         nxdn_trunk_diag.c

--- a/src/protocol/nxdn/nxdn_deperm.c
+++ b/src/protocol/nxdn/nxdn_deperm.c
@@ -31,6 +31,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/fec/trellis.h>
+#include <dsd-neo/protocol/nxdn/nxdn.h>
 #include <dsd-neo/protocol/nxdn/nxdn_alias_decode.h>
 #include <dsd-neo/protocol/nxdn/nxdn_const.h>
 #include <dsd-neo/protocol/nxdn/nxdn_convolution.h>
@@ -785,7 +786,9 @@ nxdn_print_sacch2_complete_message(const dsd_opts* opts, dsd_state* state, const
     DSD_FPRINTF(stderr, "UC: %03d; ", user_code);
     if (cipher == 0x01) {
         DSD_FPRINTF(stderr, "Scrambler; ");
-        state->nxdn_cipher_type = 1;
+        // A single CRC-accepted SACCH-2 must not flip the classification the VCALLs
+        // established: hold a contradicting observation until it repeats.
+        state->nxdn_cipher_type = nxdn_cipher_observe(state, 1U, 0);
         if (state->R != 0) {
             char key_text[24];
             DSD_FPRINTF(stderr, "Key: %s; ",
@@ -796,7 +799,7 @@ nxdn_print_sacch2_complete_message(const dsd_opts* opts, dsd_state* state, const
     }
 
     state->dmr_encL = (state->nxdn_cipher_type != 0 && state->R == 0) ? 1 : 0;
-    nxdn_publish_sacch2_crypto(opts, state, fields->sf_mes, cipher);
+    nxdn_publish_sacch2_crypto(opts, state, fields->sf_mes, cipher == 0x01 ? (uint8_t)state->nxdn_cipher_type : cipher);
     const uint8_t mfid = (uint8_t)convert_bits_into_output(state->dmr_pdu_sf[0] + 11, 7U);
     if (mfid != 0) {
         DSD_FPRINTF(stderr, "MFID: %02X; ", mfid);
@@ -1223,6 +1226,7 @@ nxdn_message_type(const dsd_opts* opts, dsd_state* state, uint8_t MessageType) {
         }
         nxdn_alias_reset(state);
         state->nxdn_cipher_type = 0; // Force will reactivate it if needed during voice tx
+        nxdn_cipher_class_reset(state);
         if (state->keyloader == 1) {
             state->R = 0;
         }

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -28,6 +28,7 @@
 #include <dsd-neo/crypto/aes.h>
 #include <dsd-neo/crypto/des.h>
 #include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/protocol/nxdn/nxdn.h>
 #include <dsd-neo/protocol/nxdn/nxdn_alias_decode.h>
 #include <dsd-neo/protocol/nxdn/nxdn_deperm.h>
 #include <dsd-neo/protocol/nxdn/nxdn_lfsr.h>
@@ -415,6 +416,7 @@ nxdn_element_handle_disc(dsd_opts* opts, dsd_state* state, const uint8_t* elemen
         (void)dsd_recent_activity_clear_all(state);
         if (state->M == 0) {
             state->nxdn_cipher_type = 0;
+            nxdn_cipher_class_reset(state);
         }
     }
 }
@@ -1581,7 +1583,7 @@ nxdn_vcall_assgn_load_scrambler_key(const dsd_opts* opts, dsd_state* state, cons
         state->payload_miN = state->R;
     }
     if (state->M == 1) {
-        state->nxdn_cipher_type = 0x1;
+        nxdn_cipher_force(state, 0x1);
     }
 }
 
@@ -2217,15 +2219,23 @@ nxdn_vcall_publish(dsd_opts* opts, dsd_state* state, const struct nxdn_vcall_inf
         .has_service_metadata = 1U,
     };
     (void)dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_CONTINUE);
-    nxdn_vcall_publish_crypto(opts, state, info->cipher_type, info->key_id);
+    // Publish the applied classification, not the raw observation: a quarantined contradiction
+    // must not flap the published crypto any more than it may flap the audio gate.
+    nxdn_vcall_publish_crypto(opts, state, (uint8_t)state->nxdn_cipher_type, (uint8_t)state->nxdn_key);
     dsd_event_sync_slot(opts, state, 0U);
 }
 
 static void
 nxdn_vcall_apply_state(dsd_state* state, const struct nxdn_vcall_info* info) {
     if (info->message_type == 0x01U) {
-        state->nxdn_key = info->key_id;
-        state->nxdn_cipher_type = info->cipher_type;
+        // Only a CRC-verified VCALL may mutate the live cipher, and even then through the
+        // classification hysteresis: trellis miscorrections that survive the short CRCs are
+        // exactly one element away from muting a clear call -- or unmuting an encrypted one --
+        // and, under lockout, permanently blocking the talkgroup.
+        if (state->NxdnElementsContent.VCallCrcIsGood != 0U) {
+            state->nxdn_key = info->key_id;
+            state->nxdn_cipher_type = nxdn_cipher_observe(state, info->cipher_type, 0);
+        }
     } else {
         DSD_SNPRINTF(state->generic_talker_alias[0], sizeof(state->generic_talker_alias[0]), "%s", "");
         nxdn_alias_reset(state);
@@ -2257,6 +2267,13 @@ static void
 nxdn_vcall_run_enc_lockout(dsd_opts* opts, dsd_state* state, const struct nxdn_vcall_info* info) {
     if (opts->trunk_enable != 1 || opts->trunk_tune_enc_calls != 0 || info->message_type != 0x01U
         || state->dmr_encL != 1) {
+        return;
+    }
+    // The blocking talkgroup entry is permanent for the session and the synthesized disconnect
+    // drops the channel, so the lockout acts only on CRC-verified, corroborated evidence: a
+    // lone non-clear observation stays tentative (or quarantined) in the hysteresis above and
+    // must repeat -- one superframe -- before it may lock the talkgroup out.
+    if (state->NxdnElementsContent.VCallCrcIsGood == 0U || !nxdn_cipher_established_enc(state)) {
         return;
     }
 
@@ -2535,7 +2552,7 @@ nxdn_scch_apply_busy_tune(dsd_opts* opts, dsd_state* state, const struct nxdn_sc
             state->R = state->rkey_array[info->id];
         }
         if (state->M == 1) {
-            state->nxdn_cipher_type = 0x1;
+            nxdn_cipher_force(state, 0x1);
         }
     } else if (opts->trunk_enable == 1) {
         nxdn_policy_log_block(opts, is_private_call, info->id, 0, &policy_decision);
@@ -2717,9 +2734,12 @@ nxdn_scch_handle_info1(dsd_opts* opts, dsd_state* state, const struct nxdn_scch_
             DSD_FPRINTF(stderr, "- %s - ", NXDN_Cipher_Type_To_Str(info->cipher));
             DSD_FPRINTF(stderr, "Key ID: %d; ", info->key_id);
         }
-        state->nxdn_cipher_type = info->cipher;
+        // One SCCH observation must not flip the classification the VCALLs established -- in
+        // either direction: a corrupt call option could mute a clear call, or silently unmute
+        // an encrypted one mid-stream. The hysteresis holds it until it repeats.
+        state->nxdn_cipher_type = nxdn_cipher_observe(state, (uint8_t)info->cipher, 0);
         state->nxdn_key = info->key_id;
-        nxdn_vcall_publish_crypto(opts, state, info->cipher, info->key_id);
+        nxdn_vcall_publish_crypto(opts, state, (uint8_t)state->nxdn_cipher_type, info->key_id);
     } else {
         DSD_FPRINTF(stderr, "\n%s ", KYEL);
         DSD_FPRINTF(stderr, "Call IV B: %04llX; ", info->iv_b);

--- a/src/protocol/nxdn/nxdn_enc_class.c
+++ b/src/protocol/nxdn/nxdn_enc_class.c
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Hysteresis for the NXDN cipher field.
+ *
+ * The 2-bit cipher type reaches the decoder from several channels -- VCALL in
+ * SACCH/FACCH/CAC, the DCR SACCH-2 message, and the SCCH call option -- and
+ * each sits behind FEC and a short CRC that can accept a miscorrected payload
+ * at low SNR. Acting on every observation directly let a single corrupt
+ * element mute a clear call (or silently unmute an encrypted one), and under
+ * --enc-lockout write a session-permanent blocking talkgroup entry and force
+ * the channel released -- the same single-observation defect class fixed for
+ * P25 in #280. This module makes the applied cipher sticky: observations
+ * apply tentatively and must repeat before they can flip an established
+ * classification, user-forced scrambler modes apply as authoritative, and the
+ * lockout only acts on an established non-clear classification.
+ *
+ * The class fields store the observed cipher plus one so 0 can mean "no
+ * observation this transmission"; cipher 0 (clear) is a real observed value.
+ */
+
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/nxdn/nxdn.h>
+#include <stdint.h>
+
+#include "dsd-neo/core/state_fwd.h"
+
+/* Feed one cipher observation and return the cipher value to apply. `strong`
+ * marks evidence trustworthy on its own; weak evidence establishes only by
+ * repetition, and a lone contradiction of an established classification is
+ * quarantined until a matching repeat (one superframe cadence). */
+uint8_t
+nxdn_cipher_observe(dsd_state* state, uint8_t cipher, int strong) {
+    const uint8_t obs = (uint8_t)((cipher & 0x03U) + 1U);
+
+    if (strong) {
+        state->nxdn_cipher_class = obs;
+        state->nxdn_cipher_class_est = 1U;
+        state->nxdn_cipher_class_pending = 0U;
+    } else if (state->nxdn_cipher_class == 0U) {
+        // First observation of the transmission: apply tentatively so late
+        // entry still classifies immediately, but leave it uncorroborated so
+        // a lone corrupt element cannot arm the lockout.
+        state->nxdn_cipher_class = obs;
+        state->nxdn_cipher_class_est = 0U;
+        state->nxdn_cipher_class_pending = 0U;
+    } else if (obs == state->nxdn_cipher_class) {
+        // A matching repeat corroborates; VCALL repeats every superframe, so
+        // a real classification establishes within one repeat.
+        state->nxdn_cipher_class_est = 1U;
+        state->nxdn_cipher_class_pending = 0U;
+    } else if (state->nxdn_cipher_class_est == 0U || state->nxdn_cipher_class_pending == obs) {
+        // Contradicting a value that never corroborated, or the second
+        // consecutive contradiction of an established classification: the
+        // newer observation wins (a tentative replacement stays tentative; a
+        // corroborated flip keeps the classification established).
+        state->nxdn_cipher_class = obs;
+        state->nxdn_cipher_class_pending = 0U;
+    } else {
+        // Lone contradiction of an established classification: quarantine it
+        // until it repeats, keeping the established value applied.
+        state->nxdn_cipher_class_pending = obs;
+    }
+
+    return (uint8_t)(state->nxdn_cipher_class - 1U);
+}
+
+/* Authoritative out-of-band evidence (user-forced scrambler mode): apply to
+ * both the live cipher and the classification, corroborated. */
+void
+nxdn_cipher_force(dsd_state* state, uint8_t cipher) {
+    state->nxdn_cipher_type = cipher;
+    state->nxdn_cipher_class = (uint8_t)((cipher & 0x03U) + 1U);
+    state->nxdn_cipher_class_est = 1U;
+    state->nxdn_cipher_class_pending = 0U;
+}
+
+void
+nxdn_cipher_class_reset(dsd_state* state) {
+    state->nxdn_cipher_class = 0U;
+    state->nxdn_cipher_class_est = 0U;
+    state->nxdn_cipher_class_pending = 0U;
+}
+
+int
+nxdn_cipher_established_enc(const dsd_state* state) {
+    return state->nxdn_cipher_class > 1U && state->nxdn_cipher_class_est != 0U;
+}

--- a/src/protocol/nxdn/nxdn_frame.c
+++ b/src/protocol/nxdn/nxdn_frame.c
@@ -409,7 +409,7 @@ nxdn_apply_limazulu_voice_tweak(const dsd_opts* opts, dsd_state* state, const nx
     }
 
     if (state->R != 0 && state->M == 1) {
-        state->nxdn_cipher_type = 0x1;
+        nxdn_cipher_force(state, 0x1);
     }
 
     state->last_cc_sync_time = time(NULL) + 2;
@@ -449,7 +449,7 @@ nxdn_apply_data_frame_lfsr(dsd_state* state) {
 static void
 nxdn_apply_pre_voice_facch1_lfsr(dsd_state* state) {
     if (state->M == 1 && state->R != 0) {
-        state->nxdn_cipher_type = 0x1;
+        nxdn_cipher_force(state, 0x1);
     }
     if (state->nxdn_cipher_type == 0x1 && state->R != 0) {
         if (state->payload_miN == 0) {
@@ -549,7 +549,7 @@ nxdn_process_voice_and_mbe(dsd_opts* opts, dsd_state* state, const nxdn_frame_ct
         state->last_vc_sync_time = time(NULL);
         state->last_vc_sync_time_m = dsd_time_now_monotonic_s();
         if (state->M == 1 && state->R != 0) {
-            state->nxdn_cipher_type = 0x1;
+            nxdn_cipher_force(state, 0x1);
         }
         nxdn_voice(opts, state, ctx->voice, (uint8_t*)ctx->dbuf, (uint8_t*)ctx->dbuf_reliab);
         return;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1071,6 +1071,24 @@ target_link_libraries(
 add_test(NAME NXDN_ELEMENT_BOUNDS COMMAND dsd-neo_test_nxdn_element_bounds)
 
 add_executable(
+    dsd-neo_test_nxdn_enc_class
+    protocol/nxdn/test_nxdn_enc_class.c
+    ${PROJECT_SOURCE_DIR}/src/dsp/frame_sync_profile.c
+)
+target_include_directories(
+    dsd-neo_test_nxdn_enc_class
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_nxdn_enc_class
+    PRIVATE
+        dsd-neo_proto_nxdn
+        dsd-neo_test_call_state_support
+        dsd-neo_test_support
+)
+add_test(NAME NXDN_ENC_CLASS COMMAND dsd-neo_test_nxdn_enc_class)
+
+add_executable(
     dsd-neo_test_nxdn_voice_mapping
     protocol/nxdn/test_nxdn_voice_mapping.c
     ${PROJECT_SOURCE_DIR}/src/protocol/nxdn/nxdn_voice.c

--- a/tests/protocol/nxdn/test_nxdn_element_bounds.c
+++ b/tests/protocol/nxdn/test_nxdn_element_bounds.c
@@ -1402,8 +1402,11 @@ test_bad_crc_encrypted_vcall_records_metadata(void) {
     rc |= expect_int("bad-crc-vcall-key", state->NxdnElementsContent.KeyID, 0x09);
     dsd_call_snapshot call;
     rc |= expect_int("bad-crc-vcall-no-canonical-call", dsd_call_state_get(state, 0U, &call), 0);
-    rc |= expect_int("bad-crc-vcall-cipher-state", state->nxdn_cipher_type, 3);
-    rc |= expect_int("bad-crc-vcall-lockout", state->dmr_encL, 1);
+    // The parse-level metadata above is recorded for display, but a CRC-failed VCALL may not
+    // mutate the live cipher the audio gate and the enc lockout act on: a trellis
+    // miscorrection here was one element away from muting a clear call.
+    rc |= expect_int("bad-crc-vcall-cipher-state", state->nxdn_cipher_type, 0);
+    rc |= expect_int("bad-crc-vcall-lockout", state->dmr_encL, 0);
     free(state);
     free(opts);
     return rc;

--- a/tests/protocol/nxdn/test_nxdn_enc_class.c
+++ b/tests/protocol/nxdn/test_nxdn_enc_class.c
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * NXDN cipher-classification hysteresis: observations apply tentatively and
+ * must repeat before they can flip an established classification or arm the
+ * enc lockout, so a single corrupt VCALL/SACCH-2/SCCH element can no longer
+ * mute a clear call, unmute an encrypted one, or write the session-permanent
+ * blocking talkgroup entry and force the channel released.
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/protocol/nxdn/nxdn.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+void NXDN_Elements_Content_decode(dsd_opts* opts, dsd_state* state, uint8_t CrcCorrect, const uint8_t* ElementsContent,
+                                  size_t elements_bits);
+
+/*
+ * Link stubs for nxdn_element.c entrypoints irrelevant to the classification
+ * paths under test (mirrors test_nxdn_element_bounds.c).
+ */
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_message_type(const dsd_opts* opts, dsd_state* state, uint8_t MessageType) {
+    (void)opts;
+    (void)state;
+    (void)MessageType;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_alias_decode_arib(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+    (void)opts;
+    (void)state;
+    (void)message_bits;
+    (void)crc_ok;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_alias_decode_prop(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+    (void)opts;
+    (void)state;
+    (void)message_bits;
+    (void)crc_ok;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_alias_reset(dsd_state* state) {
+    (void)state;
+}
+
+long int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_channel_to_frequency(dsd_opts* opts, dsd_state* state, uint16_t channel) {
+    (void)opts;
+    (void)state;
+    (void)channel;
+    return 0;
+}
+
+long int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_channel_to_frequency_quiet(dsd_state* state, uint16_t channel) {
+    (void)state;
+    (void)channel;
+    return 0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_gps_report(dsd_opts* opts, dsd_state* state, uint8_t* input, uint32_t src) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)src;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nmea_sentence_checker(dsd_opts* opts, dsd_state* state, uint8_t* input, uint8_t slot, int len_bytes) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)slot;
+    (void)len_bytes;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nxdn_trunk_diag_log_missing_channel_once(const dsd_opts* opts, dsd_state* state, uint16_t channel, const char* label) {
+    (void)opts;
+    (void)state;
+    (void)channel;
+    (void)label;
+}
+
+static void
+write_bits(uint8_t* bits, size_t start, uint64_t value, size_t nbits) {
+    for (size_t i = 0; i < nbits; i++) {
+        bits[start + i] = (uint8_t)((value >> ((nbits - 1U) - i)) & 1U);
+    }
+}
+
+/* VCALL (message type 0x01): body at bit offset 8. */
+static void
+build_vcall(uint8_t bits[96], uint8_t cipher, uint8_t key_id, uint16_t source, uint16_t dest) {
+    DSD_MEMSET(bits, 0, 96U);
+    write_bits(bits, 2U, 0x01U, 6U);  /* message type */
+    write_bits(bits, 8U, 0x00U, 8U);  /* cc option */
+    write_bits(bits, 16U, 0x01U, 3U); /* call type: group */
+    write_bits(bits, 19U, 0x00U, 5U); /* voice call option */
+    write_bits(bits, 24U, source, 16U);
+    write_bits(bits, 40U, dest, 16U);
+    write_bits(bits, 56U, cipher, 2U);
+    write_bits(bits, 58U, key_id, 6U);
+}
+
+static void
+reset_fixture(dsd_opts* opts, dsd_state* state, Event_History_I* history) {
+    dsd_state_ext_free_all(state);
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    DSD_MEMSET(history, 0, sizeof(*history) * 2U);
+    init_event_history(&history[0], 0, 1);
+    init_event_history(&history[1], 0, 1);
+    state->event_history_s = history;
+    opts->trunk_enable = 1;
+    opts->trunk_tune_enc_calls = 0;
+}
+
+/* --- Hysteresis unit coverage ------------------------------------------- */
+
+static void
+test_observe_tentative_then_corroborated(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    assert(nxdn_cipher_observe(&state, 2U, 0) == 2U);
+    assert(nxdn_cipher_established_enc(&state) == 0);
+    assert(nxdn_cipher_observe(&state, 2U, 0) == 2U);
+    assert(nxdn_cipher_established_enc(&state) == 1);
+}
+
+static void
+test_lone_contradiction_is_quarantined_both_directions(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    // Established clear; one non-clear observation is held.
+    (void)nxdn_cipher_observe(&state, 0U, 0);
+    (void)nxdn_cipher_observe(&state, 0U, 0);
+    assert(nxdn_cipher_observe(&state, 1U, 0) == 0U);
+    assert(nxdn_cipher_established_enc(&state) == 0);
+    // A matching clear observation clears the quarantine.
+    assert(nxdn_cipher_observe(&state, 0U, 0) == 0U);
+
+    // Established encrypted; one clear observation must not unmute.
+    nxdn_cipher_class_reset(&state);
+    (void)nxdn_cipher_observe(&state, 3U, 0);
+    (void)nxdn_cipher_observe(&state, 3U, 0);
+    assert(nxdn_cipher_established_enc(&state) == 1);
+    assert(nxdn_cipher_observe(&state, 0U, 0) == 3U);
+    // The corroborated repeat flips it.
+    assert(nxdn_cipher_observe(&state, 0U, 0) == 0U);
+}
+
+static void
+test_contradiction_of_tentative_replaces(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    (void)nxdn_cipher_observe(&state, 2U, 0);
+    assert(nxdn_cipher_observe(&state, 0U, 0) == 0U);
+    assert(nxdn_cipher_established_enc(&state) == 0);
+}
+
+static void
+test_force_and_reset(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    nxdn_cipher_force(&state, 1U);
+    assert(state.nxdn_cipher_type == 1U);
+    assert(nxdn_cipher_established_enc(&state) == 1);
+    nxdn_cipher_class_reset(&state);
+    assert(nxdn_cipher_established_enc(&state) == 0);
+    assert(state.nxdn_cipher_class == 0U);
+}
+
+/* --- VCALL end-to-end through NXDN_Elements_Content_decode --------------- */
+
+static void
+test_vcall_enc_lockout_requires_corroboration(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    uint8_t bits[96];
+    dsd_tg_policy_lookup lookup;
+
+    reset_fixture(&opts, &state, history);
+
+    // First CRC-good non-clear VCALL: classifies (and mutes) tentatively, but
+    // no blocking entry and no forced disconnect.
+    build_vcall(bits, 2U, 5U, 100U, 1234U);
+    NXDN_Elements_Content_decode(&opts, &state, 1U, bits, sizeof(bits));
+    assert(state.nxdn_cipher_type == 2U);
+    assert(state.dmr_encL == 1);
+    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_NONE);
+
+    // The matching repeat corroborates and the lockout acts.
+    build_vcall(bits, 2U, 5U, 100U, 1234U);
+    NXDN_Elements_Content_decode(&opts, &state, 1U, bits, sizeof(bits));
+    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_EXACT);
+    assert(strcmp(lookup.entry.mode, "DE") == 0);
+    assert(strcmp(lookup.entry.name, "ENC LO") == 0);
+    dsd_state_ext_free_all(&state);
+}
+
+static void
+test_crc_failed_vcall_mutates_nothing(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    uint8_t bits[96];
+    dsd_tg_policy_lookup lookup;
+
+    reset_fixture(&opts, &state, history);
+
+    build_vcall(bits, 2U, 5U, 100U, 1234U);
+    NXDN_Elements_Content_decode(&opts, &state, 0U, bits, sizeof(bits));
+    assert(state.nxdn_cipher_type == 0U);
+    assert(state.dmr_encL == 0);
+    assert(nxdn_cipher_established_enc(&state) == 0);
+    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_NONE);
+    dsd_state_ext_free_all(&state);
+}
+
+static void
+test_lone_contradicting_vcall_does_not_flap_established_clear(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    uint8_t bits[96];
+    dsd_tg_policy_lookup lookup;
+    dsd_call_snapshot call;
+
+    reset_fixture(&opts, &state, history);
+
+    // Two clear VCALLs establish the call clear.
+    build_vcall(bits, 0U, 0U, 100U, 1234U);
+    NXDN_Elements_Content_decode(&opts, &state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(&opts, &state, 1U, bits, sizeof(bits));
+    assert(state.nxdn_cipher_type == 0U);
+
+    // A lone corrupt VCALL claiming DES: quarantined -- audio stays open, the
+    // published crypto stays clear, no blocking entry, no forced disconnect.
+    build_vcall(bits, 2U, 5U, 100U, 1234U);
+    NXDN_Elements_Content_decode(&opts, &state, 1U, bits, sizeof(bits));
+    assert(state.nxdn_cipher_type == 0U);
+    assert(state.dmr_encL == 0);
+    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_NONE);
+    assert(dsd_call_state_get(&state, 0U, &call) > 0);
+    assert(call.crypto == DSD_CALL_CRYPTO_CLEAR);
+    assert(call.audio_permitted == 1U);
+
+    // The repeat corroborates a real change: the classification flips and the
+    // lockout acts.
+    build_vcall(bits, 2U, 5U, 100U, 1234U);
+    NXDN_Elements_Content_decode(&opts, &state, 1U, bits, sizeof(bits));
+    assert(state.nxdn_cipher_type == 2U);
+    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
+    assert(lookup.match == DSD_TG_POLICY_MATCH_EXACT);
+    assert(strcmp(lookup.entry.mode, "DE") == 0);
+    dsd_state_ext_free_all(&state);
+}
+
+int
+main(void) {
+    test_observe_tentative_then_corroborated();
+    test_lone_contradiction_is_quarantined_both_directions();
+    test_contradiction_of_tentative_replaces();
+    test_force_and_reset();
+    test_vcall_enc_lockout_requires_corroboration();
+    test_crc_failed_vcall_mutates_nothing();
+    test_lone_contradicting_vcall_does_not_flap_established_clear();
+    printf("NXDN enc class: OK\n");
+    return 0;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/protocol/nxdn/test_nxdn_frame_routing.c
+++ b/tests/protocol/nxdn/test_nxdn_frame_routing.c
@@ -264,6 +264,11 @@ nxdn_deperm_pich_tch_soft(const dsd_opts* opts, dsd_state* state, uint8_t bits[1
 }
 
 void
+nxdn_cipher_force(dsd_state* state, uint8_t cipher) {
+    state->nxdn_cipher_type = cipher;
+}
+
+void
 nxdn_voice(dsd_opts* opts, dsd_state* state, int voice, uint8_t dbuf[182], const uint8_t* dbuf_reliab) {
     (void)opts;
     (void)state;


### PR DESCRIPTION
## Problem

Follow-up to #280 (P25) and #281 (DMR). The same audit that produced #281 found NXDN affected by the single-uncorroborated-observation defect class, again in a more damaging form than P25's:

- `nxdn_vcall_run_enc_lockout` ran on every VCALL-shaped element **outside the CRC gate** the crypto publish already honored, and acted on the **first** non-clear cipher observation: one corrupt element wrote a **session-permanent** blocking `"DE"/ENC LO` talkgroup policy entry (no TTL, nothing ever removes it — P25 at least used a transient cache), synthesized a disconnect, and forced the receiver back to the control channel, starving the talkgroup for the rest of the session.
- `nxdn_vcall_apply_state` wrote the cipher and key to the live state even when the VCALL CRC failed.
- A single CRC-accepted SACCH-2 or SCCH call option could flip `nxdn_cipher_type` against the classification the VCALLs established, with no corroboration and no hysteresis on the audio gate: a corrupt element muted a clear call for up to a superframe — or, in the SCCH case (which assigned unconditionally, including cipher 0), **silently unmuted an encrypted call mid-stream**.

The cipher field reaches the decoder from several channels (VCALL in SACCH/FACCH/CAC, DCR SACCH-2, SCCH) whose FEC and short CRCs can accept a miscorrected payload at low SNR — the exact failure mode #280 documented for P25 ESS.

## Fixes

New cipher-classification hysteresis (`src/protocol/nxdn/nxdn_enc_class.c`) between every over-the-air cipher observation and the live state the audio gate, the published crypto, and the lockout act on:

- Observations apply **tentatively** — late entry still classifies from the first element — but must repeat before they establish, and a lone contradiction of an established classification quarantines until a matching repeat (one superframe cadence, in both directions: no single-element mute of a clear call, no single-element unmute of an encrypted one).
- The lockout entry and forced disconnect act only on a **CRC-verified, established** non-clear classification; genuinely encrypted calls still lock out within one VCALL repeat.
- CRC-failed VCALLs no longer mutate the live cipher or key at all.
- User-forced scrambler modes (`state->M == 1`) apply as authoritative, and the existing epoch resets (TX_REL/DISC, return-to-CC, no-carrier, init) clear the classification alongside the cipher they already cleared.

## Validation

- Full CTest suite passes (477/477); `tools/preflight_ci.sh` clean.
- New regressions: hysteresis state machine including both quarantine directions, VCALL lockout corroboration end-to-end through `NXDN_Elements_Content_decode`, CRC-failed VCALL immutability, and lone-contradiction steadiness of the audio gate, published crypto, and policy table (`test_nxdn_enc_class`, new); the bad-CRC VCALL metadata test now asserts the live cipher stays untouched (`test_nxdn_element_bounds`).

Related: #280 (P25), #281 (DMR). This completes the protocol sweep — EDACS/ProVoice, D-STAR, M17, dPMR, YSF, and X2-TDMA have no trunked enc-lockout path, so no counterpart is needed there.