### PR TITLE
io: shorten post-retune settle mute to stop clipping call starts

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -537,7 +537,9 @@ Capture/retune behavior
 - `DSD_NEO_DISABLE_FS4_SHIFT=1` — disable +fs/4 capture shift
 - `DSD_NEO_OUTPUT_CLEAR_ON_RETUNE=1` — clear output on retune
 - `DSD_NEO_RETUNE_DRAIN_MS=<ms>` — drain time before retune
-- `DSD_NEO_RETUNE_MUTE_MS=<ms>` — input mute around RTL retunes, default 120ms
+- `DSD_NEO_RETUNE_MUTE_MS=<ms>` — input mute around RTL retunes (range 10–1000). By default the pre-retune mute is
+  120ms and the post-retune settle mute is 25ms on local USB tuners (120ms on rtl_tcp/SoapySDR, which buffer stale
+  samples); setting this applies the same value to both windows
 
 RTL‑TCP networking
 

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -1184,7 +1184,7 @@ apply_capture_tuner_bandwidth(uint32_t capture_rate_hz, const dsd_opts* opts, in
 static void constellation_ring_clear(void);
 static void eye_ring_clear(void);
 static void snr_ema_reset(void);
-static void controller_arm_retune_mute(const char* phase);
+static void controller_arm_retune_mute(const char* phase, int post_retune);
 
 namespace {
 
@@ -3636,22 +3636,39 @@ apply_capture_settings(uint32_t center_freq_hz, int ppm_error,
     if (out_ppm_rc) {
         *out_ppm_rc = ppm_rc;
     }
-    controller_arm_retune_mute("program");
+    controller_arm_retune_mute("program", 0);
     return program_capture_frequency_and_rate(center_freq_hz, restore_on_frequency_failure, out_hardware_changed);
 }
 
-static int
-retune_mute_bytes_for_rate(uint32_t sample_rate_hz) {
-    /* Drop the first post-retune callbacks so tuner-settling samples do not
-     * train the freshly reset CQPSK TED/Costas loops or smear the retained FLL
-     * coarse CFO estimate. */
-    uint64_t mute_ms = 120;
-    const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
-    if (cfg && cfg->retune_mute_ms > 0) {
-        mute_ms = (uint64_t)cfg->retune_mute_ms;
+/*
+ * Two retune mute windows guard the demod against tuner-settling samples:
+ * the pre-retune window swallows stale old-frequency bytes still in flight
+ * when a reconfigure starts, while the post-retune (settle) window is armed
+ * after the hardware retune completes and is therefore pure decode dead time
+ * on the new frequency. Local USB tuners lock their PLL within a few
+ * milliseconds, so the settle window stays short to avoid discarding the
+ * start of short transmissions; buffered backends (rtl_tcp, SoapySDR,
+ * replay) can keep delivering pre-retune samples well after the reconfigure
+ * finishes and keep the full window. An explicit DSD_NEO_RETUNE_MUTE_MS
+ * override applies to both windows.
+ */
+static const uint64_t kRetuneMuteDefaultMs = 120;
+static const uint64_t kRetuneSettleMuteDefaultMs = 25;
+
+static uint64_t
+retune_mute_window_ms(int cfg_mute_ms, int cfg_mute_ms_is_set, int post_retune, int buffered_backend) {
+    if (cfg_mute_ms_is_set && cfg_mute_ms > 0) {
+        return (uint64_t)cfg_mute_ms;
     }
+    if (post_retune && !buffered_backend) {
+        return kRetuneSettleMuteDefaultMs;
+    }
+    return kRetuneMuteDefaultMs;
+}
+
+static int
+retune_mute_bytes_for_window(uint32_t sample_rate_hz, uint64_t mute_ms, uint64_t min_bytes) {
     uint64_t bytes = ((uint64_t)sample_rate_hz * 2ULL * mute_ms) / 1000ULL;
-    uint64_t min_bytes = (ACTUAL_BUF_LENGTH > 0) ? (uint64_t)ACTUAL_BUF_LENGTH : (uint64_t)DEFAULT_BUF_LENGTH;
     if (bytes < min_bytes) {
         bytes = min_bytes;
     }
@@ -3661,17 +3678,42 @@ retune_mute_bytes_for_rate(uint32_t sample_rate_hz) {
     return (int)bytes;
 }
 
+static int
+retune_mute_backend_is_buffered(void) {
+    if (stream_is_replay_active()) {
+        return 1;
+    }
+    if (g_stream && g_stream->opts) {
+        if (g_stream->opts->rtltcp_enabled) {
+            return 1;
+        }
+        if (dsd_opts_audio_in_dev_is_soapy_spec(g_stream->opts->audio_in_dev)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+retune_mute_bytes_for_rate(uint32_t sample_rate_hz, int post_retune) {
+    const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
+    uint64_t mute_ms = retune_mute_window_ms(cfg ? cfg->retune_mute_ms : 0, cfg ? cfg->retune_mute_ms_is_set : 0,
+                                             post_retune, retune_mute_backend_is_buffered());
+    uint64_t min_bytes = (ACTUAL_BUF_LENGTH > 0) ? (uint64_t)ACTUAL_BUF_LENGTH : (uint64_t)DEFAULT_BUF_LENGTH;
+    return retune_mute_bytes_for_window(sample_rate_hz, mute_ms, min_bytes);
+}
+
 static void
-controller_arm_retune_mute(const char* phase) {
+controller_arm_retune_mute(const char* phase, int post_retune) {
     uint32_t sample_rate_hz = load_dongle_rate();
     if (!rtl_device_handle || sample_rate_hz == 0) {
         return;
     }
-    int mute_bytes = retune_mute_bytes_for_rate(sample_rate_hz);
+    int mute_bytes = retune_mute_bytes_for_rate(sample_rate_hz, post_retune);
     rtl_device_mute(rtl_device_handle, mute_bytes);
     if (debug_cqpsk_enabled()) {
-        DSD_FPRINTF(stderr, "[RETUNE-MUTE] phase=%s rate=%u bytes=%d\n", phase ? phase : "unknown", sample_rate_hz,
-                    mute_bytes);
+        DSD_FPRINTF(stderr, "[RETUNE-MUTE] phase=%s settle=%d rate=%u bytes=%d\n", phase ? phase : "unknown",
+                    post_retune ? 1 : 0, sample_rate_hz, mute_bytes);
     }
 }
 
@@ -3873,7 +3915,7 @@ static inline void
 controller_prepare_reconfigure_input(void) {
     rtl_device_begin_capture_reconfigure(rtl_device_handle);
     controller_request_input_purge();
-    controller_arm_retune_mute("pre");
+    controller_arm_retune_mute("pre", 0);
 }
 
 static inline void
@@ -3922,7 +3964,7 @@ controller_reconfigure_active_stream_locked(struct controller_state* s, uint32_t
     uint32_t previous_center_freq_hz = s->last_applied_freq_hz.load(std::memory_order_acquire);
     int previous_rate_out_hz = demod.rate_out;
     CaptureSettingsSnapshot previous_capture = capture_settings_snapshot_for_center(previous_center_freq_hz);
-    controller_arm_retune_mute("program");
+    controller_arm_retune_mute("program", 0);
     int hardware_changed = 0;
     int rc = program_capture_frequency_and_rate(center_freq_hz, &previous_capture, &hardware_changed);
     int ppm_changed = (reset_reason == DemodRetuneResetReason::PpmCorrection);
@@ -3932,12 +3974,12 @@ controller_reconfigure_active_stream_locked(struct controller_state* s, uint32_t
     }
     uint32_t finalized_center_freq_hz =
         controller_reconfigure_finalized_center(center_freq_hz, previous_center_freq_hz, rc, hardware_changed);
-    controller_arm_retune_mute("post");
+    controller_arm_retune_mute("post", 1);
     rtl_device_record_capture_retune(rtl_device_handle, finalized_center_freq_hz, load_dongle_frequency(),
                                      load_dongle_rate(), retune_reset_reason_name(reset_reason));
     controller_finalize_reconfigure(s, g_stream ? g_stream->opts : NULL, finalized_center_freq_hz, reset_reason,
                                     previous_center_freq_hz, previous_rate_out_hz, NULL);
-    controller_arm_retune_mute("post-reset");
+    controller_arm_retune_mute("post-reset", 1);
     rtl_device_end_capture_reconfigure(rtl_device_handle);
     if (out_reconfigured) {
         *out_reconfigured = 1;
@@ -3976,7 +4018,7 @@ controller_apply_reconfigure(struct controller_state* s, uint32_t center_freq_hz
         controller_reconfigure_finalized_center(center_freq_hz, previous_center_freq_hz, apply_rc, hardware_changed);
     const RtlRetuneProfile* finalized_profile =
         controller_reconfigure_finalized_profile(retune_profile, center_freq_hz, finalized_center_freq_hz);
-    controller_arm_retune_mute("post");
+    controller_arm_retune_mute("post", 1);
     store_dongle_ppm_error_if_applied(ppm_rc, ppm_error);
     DemodRetuneResetReason reset_reason =
         ppm_changed ? DemodRetuneResetReason::PpmCorrection : DemodRetuneResetReason::FrequencyRetune;
@@ -3984,7 +4026,7 @@ controller_apply_reconfigure(struct controller_state* s, uint32_t center_freq_hz
                                      load_dongle_rate(), retune_reset_reason_name(reset_reason));
     controller_finalize_reconfigure(s, g_stream ? g_stream->opts : NULL, finalized_center_freq_hz, reset_reason,
                                     previous_center_freq_hz, previous_rate_out_hz, finalized_profile);
-    controller_arm_retune_mute("post-reset");
+    controller_arm_retune_mute("post-reset", 1);
     rtl_device_end_capture_reconfigure(rtl_device_handle);
     controller_end_reconfigure(s);
     if (out_reconfigured) {
@@ -8286,6 +8328,13 @@ dsd_rtl_stream_test_capture_settings_failure_restore(uint32_t* out_full_freq_hz,
     controller.edge = outer_edge;
     disable_fs4_shift = outer_disable_fs4_shift;
     return 0;
+}
+
+extern "C" int
+rtl_stream_test_retune_mute_plan(uint32_t sample_rate_hz, int cfg_mute_ms, int cfg_mute_ms_is_set, int post_retune,
+                                 int buffered_backend, uint32_t min_bytes) {
+    uint64_t mute_ms = retune_mute_window_ms(cfg_mute_ms, cfg_mute_ms_is_set, post_retune, buffered_backend);
+    return retune_mute_bytes_for_window(sample_rate_hz, mute_ms, (uint64_t)min_bytes);
 }
 
 extern "C" int

--- a/src/io/radio/rtl_stream_test_support.h
+++ b/src/io/radio/rtl_stream_test_support.h
@@ -31,6 +31,8 @@ int dsd_rtl_stream_test_capture_settings_failure_restore(uint32_t* out_full_freq
                                                          int* out_full_rate_out_hz, uint32_t* out_partial_freq_hz,
                                                          uint32_t* out_partial_rate_hz, int* out_partial_rate_out_hz);
 int dsd_rtl_stream_test_ppm_store_if_applied(int ppm_rc, int requested_ppm, int* out_ppm_error);
+int rtl_stream_test_retune_mute_plan(uint32_t sample_rate_hz, int cfg_mute_ms, int cfg_mute_ms_is_set, int post_retune,
+                                     int buffered_backend, uint32_t min_bytes);
 int dsd_rtl_stream_test_retune_completion_result_binding(int* out_first_result, int* out_second_result);
 int rtl_stream_test_clear_output(size_t queued_samples, int cached_symbols, size_t* out_used_after,
                                  int* out_cache_pending_after, uint32_t* out_generation_before,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7009,6 +7009,29 @@ if(DSD_HAS_RADIO)
     )
 
     add_executable(
+        dsd-neo_test_io_rtl_retune_mute_window
+        io/test_io_rtl_retune_mute_window.cpp
+    )
+    target_include_directories(
+        dsd-neo_test_io_rtl_retune_mute_window
+        PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/io/radio
+    )
+    target_link_libraries(
+        dsd-neo_test_io_rtl_retune_mute_window
+        PRIVATE dsd-neo_io_radio_private_test_support dsd-neo_core
+    )
+    if(DSD_HAS_RTLSDR)
+        target_link_libraries(
+            dsd-neo_test_io_rtl_retune_mute_window
+            PRIVATE ${RTLSDR_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
+        )
+    endif()
+    add_test(
+        NAME IO_RTL_RETUNE_MUTE_WINDOW
+        COMMAND dsd-neo_test_io_rtl_retune_mute_window
+    )
+
+    add_executable(
         dsd-neo_test_io_rtl_replay_retune_reject
         io/test_io_rtl_replay_retune_reject.cpp
     )

--- a/tests/io/test_io_rtl_retune_mute_window.cpp
+++ b/tests/io/test_io_rtl_retune_mute_window.cpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Regression test for the retune mute window sizing.
+ *
+ * The controller arms the input mute several times per retune. The arms that
+ * run after the hardware retune completes ("post"/"post-reset") used to
+ * restart the full pre-retune window, discarding ~120 ms of on-frequency
+ * signal after the tuner had already settled and clipping the start of short
+ * transmissions. The post-retune (settle) window must stay much shorter than
+ * the pre-retune window on local USB tuners, while buffered backends
+ * (rtl_tcp, SoapySDR, replay) and explicit DSD_NEO_RETUNE_MUTE_MS overrides
+ * keep the full window.
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include "dsd-neo/core/safe_api.h"
+#include "rtl_stream_test_support.h"
+
+namespace {
+
+constexpr uint32_t kSampleRateHz = 2400000U;
+constexpr uint32_t kMinBytes = 16384U;
+
+int
+expect_int_eq(const char* label, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "FAIL: %s got=%d want=%d\n", label, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+int
+bytes_for_ms(uint32_t sample_rate_hz, int ms) {
+    return (int)(((uint64_t)sample_rate_hz * 2ULL * (uint64_t)ms) / 1000ULL);
+}
+
+} // namespace
+
+int
+main(void) {
+    int failed = 0;
+
+    /* Default pre-retune window covers in-flight old-frequency samples. */
+    const int pre_default = rtl_stream_test_retune_mute_plan(kSampleRateHz, 0, 0, /*post_retune=*/0,
+                                                             /*buffered_backend=*/0, kMinBytes);
+    failed |= expect_int_eq("default pre-retune window is 120ms", pre_default, bytes_for_ms(kSampleRateHz, 120));
+
+    /* Regression: the post-retune settle window on a local USB tuner must not
+     * restart the full pre-retune window. */
+    const int post_local = rtl_stream_test_retune_mute_plan(kSampleRateHz, 0, 0, /*post_retune=*/1,
+                                                            /*buffered_backend=*/0, kMinBytes);
+    failed |= expect_int_eq("post-retune settle window is 25ms", post_local, bytes_for_ms(kSampleRateHz, 25));
+    failed |= expect_int_eq("settle window is shorter than pre-retune window", post_local < pre_default, 1);
+
+    /* Buffered backends can deliver stale pre-retune samples long after the
+     * reconfigure finishes, so they keep the full window post-retune. */
+    const int post_buffered = rtl_stream_test_retune_mute_plan(kSampleRateHz, 0, 0, /*post_retune=*/1,
+                                                               /*buffered_backend=*/1, kMinBytes);
+    failed |= expect_int_eq("buffered backend keeps full post window", post_buffered, bytes_for_ms(kSampleRateHz, 120));
+
+    /* An explicit DSD_NEO_RETUNE_MUTE_MS override applies to both windows. */
+    const int pre_override = rtl_stream_test_retune_mute_plan(kSampleRateHz, 40, 1, /*post_retune=*/0,
+                                                              /*buffered_backend=*/0, kMinBytes);
+    const int post_override = rtl_stream_test_retune_mute_plan(kSampleRateHz, 40, 1, /*post_retune=*/1,
+                                                               /*buffered_backend=*/0, kMinBytes);
+    failed |= expect_int_eq("override sizes pre window", pre_override, bytes_for_ms(kSampleRateHz, 40));
+    failed |= expect_int_eq("override sizes post window", post_override, bytes_for_ms(kSampleRateHz, 40));
+
+    /* A configured-but-unset (default-populated) value must not defeat the
+     * short settle window. */
+    const int post_unset_default = rtl_stream_test_retune_mute_plan(kSampleRateHz, 120, 0, /*post_retune=*/1,
+                                                                    /*buffered_backend=*/0, kMinBytes);
+    failed |=
+        expect_int_eq("unset config default keeps settle window", post_unset_default, bytes_for_ms(kSampleRateHz, 25));
+
+    /* Every window keeps the one-USB-buffer floor so at least one callback of
+     * garbage is always discarded. */
+    const int floor_bytes = rtl_stream_test_retune_mute_plan(48000U, 0, 0, /*post_retune=*/1,
+                                                             /*buffered_backend=*/0, kMinBytes);
+    failed |= expect_int_eq("settle window keeps buffer floor", floor_bytes, (int)kMinBytes);
+
+    if (failed) {
+        return 1;
+    }
+    DSD_FPRINTF(stderr, "RTL retune mute window tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- The retune mute was re-armed with the full window (default 120 ms) at the `post`/`post-reset` phases, after the hardware retune had already completed. Since local USB tuners lock their PLL within a few milliseconds, nearly the entire window discarded good on-frequency samples, dropping the frame sync/voice header after a grant and clipping (or entirely losing) the start of short transmissions.
- Split the mute into two windows: pre-retune arms (`pre`/`program`) keep the full 120 ms to swallow stale old-frequency samples still in flight; post-retune arms (`post`/`post-reset`) now use a 25 ms settle window on local USB tuners. Buffered backends (rtl_tcp, SoapySDR, replay) keep the full window because they can deliver pre-retune samples well after the reconfigure finishes. An explicit `DSD_NEO_RETUNE_MUTE_MS` still applies to both windows; the one-USB-buffer floor is retained.
- Add the `IO_RTL_RETUNE_MUTE_WINDOW` regression test pinning the sizing policy (settle window shorter than pre-retune, buffered backends unchanged, explicit override applies to both windows, buffer floor kept) and update the `DSD_NEO_RETUNE_MUTE_MS` entry in `docs/cli.md`.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / **network input (RTL capture path)** / none.
- [x] Outside review was requested when available, or unavailability is documented (solo maintainer).
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope (none added).
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` (479/479 pass, including new `IO_RTL_RETUNE_MUTE_WINDOW`)
- [x] `tools/preflight_ci.sh`
- [x] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes (n/a)
- [ ] `tools/osv_scan.sh` for dependency input changes (n/a)
- [ ] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes (n/a)

## Risk

- Security/dependency impact: none; no new APIs or dependencies.
- CLI/UI behavior impact: after trunk/scan retunes on local USB RTL-SDR, decoding starts ~95 ms earlier, preserving the beginning of short transmissions. `DSD_NEO_RETUNE_MUTE_MS` behavior is unchanged when set explicitly. rtl_tcp/SoapySDR/replay behavior is unchanged.
- Compatibility or packaging impact: none.
