### PR TITLE
dmr: detect and decode standalone Reverse Channel bursts

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,7 +7,7 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 - Help: `dsd-neo -h` | UI/logs: `--frontend terminal` (`-N` alias), `-Z` | List devices: `-O`
 - Inputs: `-i pulse | file.wav | rtl[:...] | rtltcp[:...] | soapy[:args[:freq[:gain[:ppm[:bw[:sql[:vol]]]]]]] | tcp[:host[:port]] | udp[:bind_addr[:port]] | m17udp[:bind_addr[:port]] | -`
 - Outputs: `-o pulse | null | udp[:host[:port]] | m17udp[:host[:port]] | -`
-- Record/Logs/Debug: `-6 file.wav`, `-w file.wav`, `-P`, `-7 ./calls`, `-d ./mbe`, `-J events.log`, `--frame-log frames.log`, `--p25-sm-log p25-sm.log`, `-L lrrp.log`, `-Q dsp.bin`, `-c symbols.bin`, `-r *.mbe`, `--dmr-debug-burst`
+- Record/Logs/Debug: `-6 file.wav`, `-w file.wav`, `-P`, `-7 ./calls`, `-d ./mbe`, `-J events.log`, `--frame-log frames.log`, `--p25-sm-log p25-sm.log`, `-L lrrp.log`, `-Q dsp.bin`, `-c symbols.bin`, `-r *.mbe`, `--dmr-debug-burst`, `--dmr-debug-unsynced`
 - IQ capture/replay: `--iq-capture <path>`, `--iq-capture-format cu8|cf32`, `--iq-capture-max-mb <n>`, `--iq-replay <path>`, `--iq-replay-rate fast|realtime`, `--iq-loop`, `--iq-info <path>`
 - Levels/Audio: `-g 0|1..50`, `-n 0..100`, `-nm`, `-8`, `-V 0|1|2|3`, `-z 0|1|2`, `-y`, `-v 0xF`
 - Modes: `-fa | -fs | -fr | -f1 | -f2 | -fd | -fx | -fy | -fz | -fU | -fi | -fn | -fp | -fh | -fH | -fe | -fE | -fm`
@@ -136,28 +136,38 @@ Tip: If paths or names contain spaces, wrap them in single quotes.
 
 ## DMR Burst Debugging
 
-`--dmr-debug-burst` emits one console line to stderr for each synced, fully assembled DMR burst. Use it when
-troubleshooting live DMR decode and you need bracketed post-demod no-CACH payload bytes without enabling verbose `-Z`
-payload logging or changing `-Q` OK-DMRlib structured output.
+`--dmr-debug-burst` emits one console line to stderr for each synced DMR burst. Use it when
+troubleshooting live DMR decode and you need bracketed post-demod payload bytes without enabling verbose `-Z`
+payload logging or changing `-Q` OK-DMRlib structured output. `--dmr-debug-unsynced` complements it with a raw
+dump of demodulated data while no sync has been achieved. Both flags compose and are deliberately CLI-only
+(debug aids are not persisted to the config schema).
 
 Example:
 
 ```sh
-dsd-neo -fs -i rtl:0:450M:26:-2:48:0:2 --dmr-debug-burst
+dsd-neo -fs -i rtl:0:450M:26:-2:48:0:2 --dmr-debug-burst --dmr-debug-unsynced
 ```
 
-Output format:
+Output formats:
 
 ```text
-Debug Demod +Sync slot=<1|2> type=0xNN: [AA][BB]...[CC]
+Debug Demod +Sync slot=<1|2> type=0xNN: [AA][BB]...[CC]   # normal 144-dibit burst (33 bytes, no CACH)
+Debug Demod +Sync RC: [AA][BB]...[CC]                     # standalone Reverse Channel burst (12 bytes)
+Debug Demod -Sync: [AA][BB]...[CC]                        # unsynced demod chunk (36 bytes)
 ```
 
 Notes:
 
-- The dump is DMR-only and only runs for synced 144-dibit bursts.
-- The byte stream is the 33-byte no-CACH payload range also used by `-Q` DMR output.
-- Voice bursts report `type=0x10`; data bursts use the decoded DMR data burst type.
-- The option writes to stderr only. It does not imply `-Q`, `-Z`, symbol capture, or payload file logging.
+- The dump is DMR-only. Normal synced bursts dump the 33-byte no-CACH payload range also used by `-Q` DMR
+  output; voice bursts report `type=0x10`, data bursts use the decoded DMR data burst type.
+- Standalone Reverse Channel (RC) bursts (ETSI TS 102 361-1 clause 6.4.1) are 96-bit/10 ms inbound bursts;
+  their dump is the full burst in over-the-air order, so the RC sync `[77][D5][5F][7D][FD][77]` is visible at
+  the centre as a polarity/alignment check. RC detection and command decode (e.g. `RC: Cease Transmission
+  Request;`) are always on when DMR decoding is enabled; only the hex dump needs `--dmr-debug-burst`.
+- `--dmr-debug-unsynced` prints non-overlapping 144-dibit (36-byte) chunks of raw demod output while hunting
+  for sync. Chunk boundaries are arbitrary and symbol thresholds may still be uncalibrated, so the bytes are
+  best-effort and not aligned to burst boundaries. Expect noise hex on an idle channel.
+- The options write to stderr only. They do not imply `-Q`, `-Z`, symbol capture, or payload file logging.
 
 Windows console runs:
 

--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -213,6 +213,7 @@ struct dsd_opts {
        Off by default; enabled via -F like other protocols. */
     uint8_t dmr_crc_relaxed_default;
     uint8_t dmr_debug_burst;
+    uint8_t dmr_debug_unsynced;
     uint8_t call_alert_events;
     int frame_ysf;
     int inverted_ysf;

--- a/include/dsd-neo/core/sync_patterns.h
+++ b/include/dsd-neo/core/sync_patterns.h
@@ -67,7 +67,12 @@
 #define NXDN_PANDFSW                   "3131133313131331131" /* 19 symbols */
 #define INV_NXDN_PANDFSW               "1313311131313113313" /* 19 symbols */
 
-#define DMR_RESERVED_SYNC              "131331111133133133311313"
+/* MS sourced RC sync 0x77D55F7DFD77 (ETSI TS 102 361-1 Table 9.2) — standalone
+ * 96-bit Reverse Channel burst. The INV variant is its symbol-wise complement
+ * 0xDD7FF5D757DD (the ETSI "Reserved" pattern); it is matched only for
+ * inverted-polarity RC detection, never claimed as RC at normal polarity. */
+#define DMR_MS_RC_SYNC                 "131331111133133133311313"
+#define DMR_MS_RC_SYNC_INV             "313113333311311311133131"
 
 #define DMR_DIRECT_MODE_TS1_DATA_SYNC  "331333313111313133311111"
 #define DMR_DIRECT_MODE_TS1_VOICE_SYNC "113111131333131311133333"

--- a/include/dsd-neo/dsp/dmr_sync.h
+++ b/include/dsd-neo/dsp/dmr_sync.h
@@ -78,6 +78,21 @@ int dmr_resample_on_sync(struct dsd_opts* opts, struct dsd_state* state);
  */
 size_t dmr_debug_format_unsynced(char* out, size_t out_size, const int* dibits, size_t count);
 
+/**
+ * @brief Append `count` dibits as [XX] hex bytes (4 dibits per byte, MSB first).
+ *
+ * Shared tail for the DMR debug-dump formatters (unsynced and RC burst).
+ * Truncates safely: the buffer is always NUL-terminated on return.
+ *
+ * @param out Output buffer
+ * @param out_size Output buffer size in bytes
+ * @param pos Write position to append at (returned unchanged if out of range)
+ * @param dibits Raw dibit values (low 2 bits used)
+ * @param count Number of dibits to append (multiple of 4; remainder dropped)
+ * @return New write position (may exceed what fit if truncated)
+ */
+size_t dmr_debug_append_dibit_bytes(char* out, size_t out_size, size_t pos, const int* dibits, size_t count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dsd-neo/dsp/dmr_sync.h
+++ b/include/dsd-neo/dsp/dmr_sync.h
@@ -16,6 +16,8 @@
 #ifndef DSD_NEO_INCLUDE_DSD_NEO_DSP_DMR_SYNC_H_
 #define DSD_NEO_INCLUDE_DSD_NEO_DSP_DMR_SYNC_H_
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -61,6 +63,20 @@ void dmr_resample_cach(struct dsd_opts* opts, struct dsd_state* state, int sync_
  * @return 0 on success, -1 if sample history unavailable
  */
 int dmr_resample_on_sync(struct dsd_opts* opts, struct dsd_state* state);
+
+/**
+ * @brief Format a run of raw dibits as a "Debug Demod -Sync" hex line.
+ *
+ * Packs 4 dibits per byte (MSB first) with no burst alignment implied; used
+ * by the --dmr-debug-unsynced dump while hunting for sync.
+ *
+ * @param out Output buffer (NUL-terminated on return)
+ * @param out_size Output buffer size in bytes
+ * @param dibits Raw dibit values (low 2 bits used)
+ * @param count Number of dibits to format (multiple of 4; remainder dropped)
+ * @return Number of characters written, or 0 on invalid arguments
+ */
+size_t dmr_debug_format_unsynced(char* out, size_t out_size, const int* dibits, size_t count);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/protocol/dmr/dmr.h
+++ b/include/dsd-neo/protocol/dmr/dmr.h
@@ -79,6 +79,19 @@ void dmr_late_entry_mi_fragment(dsd_opts* opts, dsd_state* state, uint8_t vc, ui
                                 uint8_t ambe_fr2[4][24], uint8_t ambe_fr3[4][24]);
 void dmr_late_entry_mi(dsd_opts* opts, dsd_state* state);
 void dmr_sbrc(const dsd_opts* opts, dsd_state* state, uint8_t power);
+
+/* Standalone Reverse Channel burst (ETSI TS 102 361-1 clause 6.4.1). */
+enum {
+    DMR_RC_DECODE_OK = 0,
+    DMR_RC_DECODE_FEC_ERR = 1,
+    DMR_RC_DECODE_CRC_ERR = 2,
+};
+
+void dmrRC(dsd_opts* opts, dsd_state* state);
+int dmr_rc_decode_pdu(const uint8_t interleaved_bits[32], uint8_t* out_command, uint32_t* out_hex);
+const char* dmr_rc_command_name(uint8_t rc_command);
+void dmr_rc_assemble_bits(const int dibits[48], uint8_t emb_bits[16], uint8_t rc_bits[32]);
+size_t dmr_debug_format_rc_burst(char* out, size_t out_size, const int dibits[48]);
 void LFSR64(dsd_state* state);
 void LFSR128d(dsd_state* state);
 void hytera_enhanced_alg_refresh(dsd_state* state);

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -245,6 +245,7 @@ init_opts_runtime_and_network_defaults(dsd_opts* opts) {
     /* DMR: strict CRC gating by default (use -F to relax, like other protocols). */
     opts->dmr_crc_relaxed_default = 0;
     opts->dmr_debug_burst = 0;
+    opts->dmr_debug_unsynced = 0;
     opts->iq_capture_requested = 0;
     opts->iq_replay_requested = 0;
     opts->iq_replay_loop = 0;

--- a/src/dsp/dmr_sync.c
+++ b/src/dsp/dmr_sync.c
@@ -131,28 +131,16 @@ dmr_resample_on_sync(dsd_opts* opts, dsd_state* state) {
  * ───────────────────────────────────────────────────────────────────────────── */
 
 size_t
-dmr_debug_format_unsynced(char* out, size_t out_size, const int* dibits, size_t count) {
-    if (out == NULL || out_size == 0U || dibits == NULL || count < 4U) {
-        return 0U;
-    }
-
-    int n = DSD_SNPRINTF(out, out_size, "Debug Demod -Sync: ");
-    if (n < 0) {
-        out[0] = '\0';
-        return 0U;
-    }
-    size_t pos = (size_t)n;
-    if (pos >= out_size) {
-        out[out_size - 1U] = '\0';
+dmr_debug_append_dibit_bytes(char* out, size_t out_size, size_t pos, const int* dibits, size_t count) {
+    if (out == NULL || out_size == 0U || pos >= out_size || dibits == NULL) {
         return pos;
     }
-
     for (size_t byte_index = 0; byte_index < count / 4U; byte_index++) {
         uint8_t byte = 0;
         for (size_t d = 0; d < 4U; d++) {
             byte = (uint8_t)((byte << 2) | (dibits[(byte_index * 4U) + d] & 0x03));
         }
-        n = DSD_SNPRINTF(out + pos, out_size - pos, "[%02X]", (unsigned int)byte);
+        const int n = DSD_SNPRINTF(out + pos, out_size - pos, "[%02X]", (unsigned int)byte);
         if (n < 0) {
             out[pos] = '\0';
             return pos;
@@ -163,6 +151,25 @@ dmr_debug_format_unsynced(char* out, size_t out_size, const int* dibits, size_t 
             return pos;
         }
     }
-
     return pos;
+}
+
+size_t
+dmr_debug_format_unsynced(char* out, size_t out_size, const int* dibits, size_t count) {
+    if (out == NULL || out_size == 0U || dibits == NULL || count < 4U) {
+        return 0U;
+    }
+
+    const int n = DSD_SNPRINTF(out, out_size, "Debug Demod -Sync: ");
+    if (n < 0) {
+        out[0] = '\0';
+        return 0U;
+    }
+    size_t pos = (size_t)n;
+    if (pos >= out_size) {
+        out[out_size - 1U] = '\0';
+        return pos;
+    }
+
+    return dmr_debug_append_dibit_bytes(out, out_size, pos, dibits, count);
 }

--- a/src/dsp/dmr_sync.c
+++ b/src/dsp/dmr_sync.c
@@ -17,8 +17,10 @@
 #include <dsd-neo/dsp/dmr_sync.h>
 #include <dsd-neo/dsp/sync_calibration.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
 /* ─────────────────────────────────────────────────────────────────────────────
@@ -122,4 +124,45 @@ dmr_resample_on_sync(dsd_opts* opts, dsd_state* state) {
     dmr_resample_cach(opts, state, 0);
 
     return 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * Unsynced Debug Dump Formatting
+ * ───────────────────────────────────────────────────────────────────────────── */
+
+size_t
+dmr_debug_format_unsynced(char* out, size_t out_size, const int* dibits, size_t count) {
+    if (out == NULL || out_size == 0U || dibits == NULL || count < 4U) {
+        return 0U;
+    }
+
+    int n = DSD_SNPRINTF(out, out_size, "Debug Demod -Sync: ");
+    if (n < 0) {
+        out[0] = '\0';
+        return 0U;
+    }
+    size_t pos = (size_t)n;
+    if (pos >= out_size) {
+        out[out_size - 1U] = '\0';
+        return pos;
+    }
+
+    for (size_t byte_index = 0; byte_index < count / 4U; byte_index++) {
+        uint8_t byte = 0;
+        for (size_t d = 0; d < 4U; d++) {
+            byte = (uint8_t)((byte << 2) | (dibits[(byte_index * 4U) + d] & 0x03));
+        }
+        n = DSD_SNPRINTF(out + pos, out_size - pos, "[%02X]", (unsigned int)byte);
+        if (n < 0) {
+            out[pos] = '\0';
+            return pos;
+        }
+        pos += (size_t)n;
+        if (pos >= out_size) {
+            out[out_size - 1U] = '\0';
+            return pos;
+        }
+    }
+
+    return pos;
 }

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -1323,6 +1323,25 @@ frame_sync_try_dmr_dm_ts2_voice(frame_sync_match_ctx* ctx) {
 }
 
 static int
+frame_sync_try_dmr_rc_data(frame_sync_match_ctx* ctx) {
+    dsd_opts* opts = ctx->opts;
+    dsd_state* state = ctx->state;
+    /* The RC sync has no voice/data complement partner: its symbol-wise
+     * complement is the ETSI-reserved pattern, so it maps to RC only when the
+     * input polarity is inverted and is never claimed at normal polarity. */
+    const char* pattern = (opts->inverted_dmr == 0) ? DMR_MS_RC_SYNC : DMR_MS_RC_SYNC_INV;
+    if (strcmp(ctx->synctest, pattern) != 0) {
+        return DSD_SYNC_NONE;
+    }
+
+    frame_sync_prepare_dmr_sync(ctx);
+    DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "DMR RC");
+    state->lastsynctype = DSD_SYNC_DMR_RC_DATA;
+    dmr_resample_on_sync(opts, state);
+    return DSD_SYNC_DMR_RC_DATA;
+}
+
+static int
 frame_sync_try_dmr(frame_sync_match_ctx* ctx) {
     if (ctx->opts->frame_dmr != 1 || !frame_sync_match_profile_active(ctx, DSD_FRAME_SYNC_SPS_PROFILE_4800_4)
         || !frame_sync_match_window_ready(ctx, 24)) {
@@ -1357,7 +1376,11 @@ frame_sync_try_dmr(frame_sync_match_ctx* ctx) {
     if (sync_type != DSD_SYNC_NONE) {
         return sync_type;
     }
-    return frame_sync_try_dmr_dm_ts2_voice(ctx);
+    sync_type = frame_sync_try_dmr_dm_ts2_voice(ctx);
+    if (sync_type != DSD_SYNC_NONE) {
+        return sync_type;
+    }
+    return frame_sync_try_dmr_rc_data(ctx);
 }
 
 static int
@@ -3041,6 +3064,38 @@ dsd_frame_sync_test_handle_no_sync_timeout(dsd_opts* opts, dsd_state* state, int
 }
 #endif
 
+/* Symbols seen since the last sync or unsynced dump; only the DSP thread
+ * touches it (same pattern as the g_vote_* diagnostics). */
+static unsigned int g_unsynced_dmr_dump_symbols = 0;
+
+/* --dmr-debug-unsynced: while hunting, print the trailing 144 dibits from the
+ * rolling DMR payload buffer as non-overlapping "Debug Demod -Sync" chunks.
+ * Chunk boundaries are arbitrary and thresholds may be uncalibrated; this is a
+ * best-effort raw view of demod output that never achieved sync. */
+static void
+frame_sync_maybe_dump_unsynced_dmr(const dsd_opts* opts, const dsd_state* state) {
+    if (opts->dmr_debug_unsynced == 0 || opts->frame_dmr != 1) {
+        return;
+    }
+    if (opts->audio_in_type != AUDIO_IN_SYMBOL_BIN && opts->audio_in_type != AUDIO_IN_SYMBOL_FLT
+        && state->sps_hunt_idx != DSD_FRAME_SYNC_SPS_PROFILE_4800_4) {
+        return;
+    }
+    if (++g_unsynced_dmr_dump_symbols < 144U) {
+        return;
+    }
+    g_unsynced_dmr_dump_symbols = 0;
+
+    if (state->dmr_payload_buf == NULL || state->dmr_payload_p == NULL
+        || state->dmr_payload_p - state->dmr_payload_buf < 144) {
+        return;
+    }
+    char line[192];
+    if (dmr_debug_format_unsynced(line, sizeof(line), state->dmr_payload_p - 144, 144U) != 0U) {
+        DSD_FPRINTF(stderr, "%s\n", line);
+    }
+}
+
 int
 getFrameSync(dsd_opts* opts, dsd_state* state) {
     if (!opts || !state) {
@@ -3075,9 +3130,11 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
         if (rt.history_count >= 8) {
             int sync_type = frame_sync_eval_window(opts, state, &rt, now, nowm);
             if (sync_type != DSD_SYNC_NONE) {
+                g_unsynced_dmr_dump_symbols = 0;
                 return sync_type;
             }
         }
+        frame_sync_maybe_dump_unsynced_dmr(opts, state);
 
         if (exitflag == 1) {
             dsd_request_shutdown(opts, state);

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -3071,7 +3071,9 @@ static unsigned int g_unsynced_dmr_dump_symbols = 0;
 /* --dmr-debug-unsynced: while hunting, print the trailing 144 dibits from the
  * rolling DMR payload buffer as non-overlapping "Debug Demod -Sync" chunks.
  * Chunk boundaries are arbitrary and thresholds may be uncalibrated; this is a
- * best-effort raw view of demod output that never achieved sync. */
+ * best-effort raw view of demod output that never achieved sync. The first
+ * chunk after the rolling buffer rewinds its write pointer can also span
+ * stale pre-rewind dibits. */
 static void
 frame_sync_maybe_dump_unsynced_dmr(const dsd_opts* opts, const dsd_state* state) {
     if (opts->dmr_debug_unsynced == 0 || opts->frame_dmr != 1) {

--- a/src/engine/dispatch/dispatch_dmr.c
+++ b/src/engine/dispatch/dispatch_dmr.c
@@ -31,8 +31,8 @@ dmr_is_voice_synctype(int synctype) {
 }
 
 static int
-dmr_is_ms_or_rc_data_synctype(int synctype) {
-    return synctype == DSD_SYNC_DMR_MS_DATA || synctype == DSD_SYNC_DMR_RC_DATA;
+dmr_is_ms_data_synctype(int synctype) {
+    return synctype == DSD_SYNC_DMR_MS_DATA;
 }
 
 static void
@@ -102,7 +102,7 @@ dmr_handle_voice(dsd_opts* opts, dsd_state* state) {
 }
 
 static void
-dmr_handle_ms_or_rc_data(dsd_opts* opts, dsd_state* state) {
+dmr_handle_ms_data(dsd_opts* opts, dsd_state* state) {
     dmr_close_mbe_out_if_open(opts, state);
     if (opts->trunk_enable == 0) {
         dmrMSData(opts, state);
@@ -136,6 +136,13 @@ dsd_dispatch_handle_dmr(dsd_opts* opts, dsd_state* state) {
         return;
     }
 
+    /* A standalone RC burst is a one-shot 10 ms event: decode it without
+     * touching slot lights, MBE output files, or per-slot call state. */
+    if (state->synctype == DSD_SYNC_DMR_RC_DATA) {
+        dmrRC(opts, state);
+        return;
+    }
+
     dmr_update_branding(state);
     state->nac = 0;
 
@@ -143,8 +150,8 @@ dsd_dispatch_handle_dmr(dsd_opts* opts, dsd_state* state) {
         dmr_handle_voice(opts, state);
         return;
     }
-    if (dmr_is_ms_or_rc_data_synctype(state->synctype)) {
-        dmr_handle_ms_or_rc_data(opts, state);
+    if (dmr_is_ms_data_synctype(state->synctype)) {
+        dmr_handle_ms_data(opts, state);
         return;
     }
     dmr_handle_other_data(opts, state);

--- a/src/protocol/dmr/CMakeLists.txt
+++ b/src/protocol/dmr/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(
         dmr_le.c
         dmr_ms.c
         dmr_pdu.c
+        dmr_rc.c
         dmr_text.c
         dmr_pi.c
         dmr_utils.c

--- a/src/protocol/dmr/dmr_le.c
+++ b/src/protocol/dmr/dmr_le.c
@@ -433,17 +433,15 @@ dmr_sbrc_print_fec_error(const dsd_opts* opts, const dmr_sbrc_data* data) {
 
 static void
 dmr_sbrc_print_rc_command(const dsd_opts* opts, uint32_t sbrc_hex) {
-    static const char* rc_commands[] = {" RC: Increase Power By One Step;", " RC: Decrease Power By One Step;",
-                                        " RC: Set Power To Highest;",       " RC: Set Power To Lowest;",
-                                        " RC: Cease Transmission Command;", " RC: Cease Transmission Request;"};
     const uint32_t rc_value = sbrc_hex >> 7;
+    const char* name = dmr_rc_command_name((uint8_t)rc_value);
 
     if (opts->payload == 0) {
         DSD_FPRINTF(stderr, "\n");
     }
     DSD_FPRINTF(stderr, "%s", KCYN);
-    if (rc_value < (sizeof(rc_commands) / sizeof(rc_commands[0]))) {
-        DSD_FPRINTF(stderr, "%s", rc_commands[rc_value]);
+    if (name != NULL) {
+        DSD_FPRINTF(stderr, " RC: %s;", name);
     } else {
         DSD_FPRINTF(stderr, " RC: Reserved %02X;", rc_value);
     }

--- a/src/protocol/dmr/dmr_rc.c
+++ b/src/protocol/dmr/dmr_rc.c
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Standalone DMR Reverse Channel (RC) burst handling.
+ *
+ * The standalone RC burst (ETSI TS 102 361-1 V2.6.1, clause 6.4.1) is a
+ * 96-bit / 10 ms inbound burst centred in the 30 ms slot:
+ *
+ *   RC_a(16) | EMB_a(8) | SYNC(48) | EMB_b(8) | RC_b(16)
+ *
+ * The 48-bit SYNC sits at the normal burst-centre position, so the regular
+ * sync correlator detects it (DMR_MS_RC_SYNC). The 32-bit RC PDU carries a
+ * 4-bit RC command plus a 7-bit CRC (mask 0x7A), protected by the Reverse
+ * Channel Single Burst BPTC (clause B.2.2.2). It is used by MSs for TXI
+ * ("cease transmission") and closed-loop power-control signalling
+ * (ETSI TS 102 361-4, table 6.32).
+ */
+
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/time_format.h>
+#include <dsd-neo/fec/block_codes.h>
+#include <dsd-neo/fec/bptc.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
+#include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <dsd-neo/runtime/colors.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+/* Dibit offsets inside the 48-dibit burst window. */
+#define DMR_RC_DIBIT_RC_A   0U  /* 8 dibits */
+#define DMR_RC_DIBIT_EMB_A  8U  /* 4 dibits */
+#define DMR_RC_DIBIT_SYNC   12U /* 24 dibits */
+#define DMR_RC_DIBIT_EMB_B  36U /* 4 dibits */
+#define DMR_RC_DIBIT_RC_B   40U /* 8 dibits */
+#define DMR_RC_DIBIT_COUNT  48U
+#define DMR_RC_CACHED_COUNT 36U /* RC_a + EMB_a + SYNC already demodulated */
+
+int
+dmr_rc_decode_pdu(const uint8_t interleaved_bits[32], uint8_t* out_command, uint32_t* out_hex) {
+    if (interleaved_bits == NULL) {
+        return DMR_RC_DECODE_FEC_ERR;
+    }
+
+    uint8_t in[32];
+    uint8_t out[32];
+    for (int i = 0; i < 32; i++) {
+        in[i] = interleaved_bits[i] & 1U;
+    }
+    DSD_MEMSET(out, 0, sizeof(out));
+
+    /* Reverse Channel Single Burst BPTC: Hamming(16,11,4) row plus odd
+     * column-parity row (ETSI TS 102 361-1 clause B.2.2.2). */
+    const uint32_t irrecoverable = BPTC_16x2_Extract_Data(in, out, 1);
+
+    uint32_t hex = 0;
+    for (int i = 0; i < 11; i++) {
+        hex = (hex << 1) | (out[i] & 1U);
+    }
+    if (out_hex != NULL) {
+        *out_hex = hex;
+    }
+    if (irrecoverable != 0U) {
+        return DMR_RC_DECODE_FEC_ERR;
+    }
+
+    /* Bits 0..3 carry the RC command; bits 4..10 the CRC-7, masked with 0x7A
+     * (ETSI TS 102 361-1 clauses B.3.13 and B.3.12, table B.21). */
+    uint8_t crc_extracted = 0;
+    for (int i = 0; i < 7; i++) {
+        crc_extracted = (uint8_t)((crc_extracted << 1) | (out[i + 4] & 1U));
+    }
+    crc_extracted ^= 0x7AU;
+    const uint8_t crc_computed = crc7(out, 4);
+    if (crc_extracted != crc_computed) {
+        return DMR_RC_DECODE_CRC_ERR;
+    }
+
+    if (out_command != NULL) {
+        *out_command = (uint8_t)(hex >> 7);
+    }
+    return DMR_RC_DECODE_OK;
+}
+
+/* Copy the cached prefix (RC_a + EMB_a + SYNC) and read the 12 trailing
+ * dibits live. Returns 0 if the payload history is too short. */
+static int
+dmr_rc_collect_dibits(dsd_opts* opts, dsd_state* state, int dibits[48]) {
+    if (state->dmr_payload_buf == NULL || state->dmr_payload_p == NULL
+        || state->dmr_payload_p - state->dmr_payload_buf < (ptrdiff_t)DMR_RC_CACHED_COUNT) {
+        return 0;
+    }
+
+    const int* cached = state->dmr_payload_p - DMR_RC_CACHED_COUNT;
+    for (size_t i = 0; i < DMR_RC_CACHED_COUNT; i++) {
+        dibits[i] = cached[i] & 3;
+    }
+    for (size_t i = DMR_RC_CACHED_COUNT; i < DMR_RC_DIBIT_COUNT; i++) {
+        dsd_dibit_soft_t soft;
+        dibits[i] = getDibitSoft(opts, state, &soft) & 3;
+    }
+    if (opts->inverted_dmr == 1) {
+        for (size_t i = 0; i < DMR_RC_DIBIT_COUNT; i++) {
+            dibits[i] = (dibits[i] ^ 2) & 3;
+        }
+    }
+    return 1;
+}
+
+void
+dmr_rc_assemble_bits(const int dibits[48], uint8_t emb_bits[16], uint8_t rc_bits[32]) {
+    for (size_t i = 0; i < 4U; i++) {
+        const int a = dibits[DMR_RC_DIBIT_EMB_A + i];
+        const int b = dibits[DMR_RC_DIBIT_EMB_B + i];
+        emb_bits[i * 2U] = (uint8_t)((a >> 1) & 1);
+        emb_bits[(i * 2U) + 1U] = (uint8_t)(a & 1);
+        emb_bits[8U + (i * 2U)] = (uint8_t)((b >> 1) & 1);
+        emb_bits[8U + (i * 2U) + 1U] = (uint8_t)(b & 1);
+    }
+    for (size_t i = 0; i < 8U; i++) {
+        const int a = dibits[DMR_RC_DIBIT_RC_A + i];
+        const int b = dibits[DMR_RC_DIBIT_RC_B + i];
+        rc_bits[i * 2U] = (uint8_t)((a >> 1) & 1);
+        rc_bits[(i * 2U) + 1U] = (uint8_t)(a & 1);
+        rc_bits[16U + (i * 2U)] = (uint8_t)((b >> 1) & 1);
+        rc_bits[16U + (i * 2U) + 1U] = (uint8_t)(b & 1);
+    }
+}
+
+static void
+dmr_rc_print(const dsd_opts* opts, int emb_ok, const uint8_t emb_bits[16], int rc_err, uint8_t rc_command,
+             uint32_t rc_hex) {
+    char timestr[9];
+    (void)dsd_format_local_datetime(time(NULL), DSD_LOCAL_DATETIME_TIME_COLON, timestr, sizeof timestr);
+    DSD_FPRINTF(stderr, "%s Sync: %cDMR RC ", timestr, (opts->inverted_dmr == 1) ? '-' : '+');
+
+    if (emb_ok == 1) {
+        const uint8_t cc = (uint8_t)((emb_bits[0] << 3) | (emb_bits[1] << 2) | (emb_bits[2] << 1) | (emb_bits[3] << 0));
+        DSD_FPRINTF(stderr, "| Color Code=%02d ", cc);
+    } else {
+        DSD_FPRINTF(stderr, "| Color Code=XX ");
+    }
+
+    if (rc_err == DMR_RC_DECODE_OK) {
+        const char* name = dmr_rc_command_name(rc_command);
+        DSD_FPRINTF(stderr, "%s", KCYN);
+        if (name != NULL) {
+            DSD_FPRINTF(stderr, "| RC: %s;", name);
+        } else {
+            DSD_FPRINTF(stderr, "| RC: Reserved %02X;", rc_command);
+        }
+        DSD_FPRINTF(stderr, "%s", KNRM);
+    } else {
+        DSD_FPRINTF(stderr, "%s", KRED);
+        DSD_FPRINTF(stderr, "| RC %s ERR", (rc_err == DMR_RC_DECODE_FEC_ERR) ? "FEC" : "CRC");
+        DSD_FPRINTF(stderr, "%s", KNRM);
+    }
+
+    if (opts->payload == 1) {
+        const uint8_t pi = emb_bits[4] & 1U;
+        const uint8_t lcss = (uint8_t)((emb_bits[5] << 1) | emb_bits[6]);
+        DSD_FPRINTF(stderr, " | PI=%u LCSS=%u RC PDU=%03X", pi, lcss, (unsigned int)rc_hex);
+    }
+    DSD_FPRINTF(stderr, "\n");
+}
+
+void
+dmrRC(dsd_opts* opts, dsd_state* state) {
+    int dibits[DMR_RC_DIBIT_COUNT];
+    if (dmr_rc_collect_dibits(opts, state, dibits) == 0) {
+        return;
+    }
+
+    uint8_t emb_bits[16];
+    uint8_t rc_bits[32];
+    dmr_rc_assemble_bits(dibits, emb_bits, rc_bits);
+
+    /* EMB is QR(16,7,6): CC(4), PI(1), LCSS(2) + 9 parity bits. */
+    const int emb_ok = QR_16_7_6_decode(emb_bits) ? 1 : 0;
+
+    uint8_t rc_command = 0;
+    uint32_t rc_hex = 0;
+    const int rc_err = dmr_rc_decode_pdu(rc_bits, &rc_command, &rc_hex);
+
+    dmr_rc_print(opts, emb_ok, emb_bits, rc_err, rc_command, rc_hex);
+
+    if (opts->dmr_debug_burst != 0) {
+        char line[192];
+        if (dmr_debug_format_rc_burst(line, sizeof(line), dibits) != 0U) {
+            DSD_FPRINTF(stderr, "%s\n", line);
+        }
+    }
+}

--- a/src/protocol/dmr/dmr_rc.c
+++ b/src/protocol/dmr/dmr_rc.c
@@ -92,7 +92,12 @@ dmr_rc_decode_pdu(const uint8_t interleaved_bits[32], uint8_t* out_command, uint
 }
 
 /* Copy the cached prefix (RC_a + EMB_a + SYNC) and read the 12 trailing
- * dibits live. Returns 0 if the payload history is too short. */
+ * dibits live. Returns 0 if the payload history is too short.
+ *
+ * Caveat: the rolling payload buffer periodically rewinds its write pointer
+ * (dsd_dibit.c); if that happens between sync detection and this read, the
+ * cached prefix can span stale pre-rewind dibits. Worst case is a one-shot
+ * spurious FEC/CRC-error line, so it is not worth restructuring for. */
 static int
 dmr_rc_collect_dibits(dsd_opts* opts, dsd_state* state, int dibits[48]) {
     if (state->dmr_payload_buf == NULL || state->dmr_payload_p == NULL
@@ -166,9 +171,16 @@ dmr_rc_print(const dsd_opts* opts, int emb_ok, const uint8_t emb_bits[16], int r
     }
 
     if (opts->payload == 1) {
-        const uint8_t pi = emb_bits[4] & 1U;
-        const uint8_t lcss = (uint8_t)((emb_bits[5] << 1) | emb_bits[6]);
-        DSD_FPRINTF(stderr, " | PI=%u LCSS=%u RC PDU=%03X", pi, lcss, (unsigned int)rc_hex);
+        /* PI/LCSS come from the EMB codeword: only trustworthy when the
+         * QR(16,7,6) decode succeeded. */
+        if (emb_ok == 1) {
+            const uint8_t pi = emb_bits[4] & 1U;
+            const uint8_t lcss = (uint8_t)((emb_bits[5] << 1) | emb_bits[6]);
+            DSD_FPRINTF(stderr, " | PI=%u LCSS=%u", pi, lcss);
+        } else {
+            DSD_FPRINTF(stderr, " | PI=X LCSS=X");
+        }
+        DSD_FPRINTF(stderr, " RC PDU=%03X", (unsigned int)rc_hex);
     }
     DSD_FPRINTF(stderr, "\n");
 }

--- a/src/protocol/dmr/dmr_utils.c
+++ b/src/protocol/dmr/dmr_utils.c
@@ -116,6 +116,65 @@ dmr_debug_dump_burst(const dsd_opts* opts, const dsd_state* state, uint8_t slot_
     DSD_FPRINTF(stderr, "%s\n", line);
 }
 
+/* Append `count` dibits as [XX] hex bytes (4 dibits per byte, MSB first).
+ * Shared tail for the RC and unsynced debug-dump formatters. */
+static size_t
+dmr_debug_append_dibit_bytes(char* out, size_t out_size, size_t pos, const int* dibits, size_t count) {
+    for (size_t byte_index = 0; byte_index < count / 4U; byte_index++) {
+        uint8_t byte = 0;
+        for (size_t d = 0; d < 4U; d++) {
+            byte = (uint8_t)((byte << 2) | (dibits[(byte_index * 4U) + d] & 0x03));
+        }
+        const int n = DSD_SNPRINTF(out + pos, out_size - pos, "[%02X]", (unsigned int)byte);
+        if (n < 0) {
+            out[pos] = '\0';
+            return pos;
+        }
+        pos += (size_t)n;
+        if (pos >= out_size) {
+            out[out_size - 1U] = '\0';
+            return pos;
+        }
+    }
+    return pos;
+}
+
+size_t
+dmr_debug_format_rc_burst(char* out, size_t out_size, const int dibits[48]) {
+    if (out == NULL || out_size == 0U || dibits == NULL) {
+        return 0U;
+    }
+
+    const int n = DSD_SNPRINTF(out, out_size, "Debug Demod +Sync RC: ");
+    if (n < 0) {
+        out[0] = '\0';
+        return 0U;
+    }
+    size_t pos = (size_t)n;
+    if (pos >= out_size) {
+        out[out_size - 1U] = '\0';
+        return pos;
+    }
+
+    /* Full 96-bit burst in over-the-air order, sync included: the visible
+     * 77 D5 5F 7D FD 77 centre doubles as a polarity/alignment check. */
+    return dmr_debug_append_dibit_bytes(out, out_size, pos, dibits, 48U);
+}
+
+const char*
+dmr_rc_command_name(uint8_t rc_command) {
+    /* ETSI TS 102 361-4 V1.12.1, table 6.32 (superset of TS 102 361-2
+     * table 7.27, which defines only the two cease-transmission values). */
+    static const char* names[] = {
+        "Increase Power By One Step", "Decrease Power By One Step", "Set Power To Highest",
+        "Set Power To Lowest",        "Cease Transmission Command", "Cease Transmission Request",
+    };
+    if (rc_command < (uint8_t)(sizeof(names) / sizeof(names[0]))) {
+        return names[rc_command];
+    }
+    return NULL;
+}
+
 // A Hamming (17,12,3) Check for completed SLC message
 bool
 Hamming17123(uint8_t* d) {

--- a/src/protocol/dmr/dmr_utils.c
+++ b/src/protocol/dmr/dmr_utils.c
@@ -14,6 +14,7 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/dsp/dmr_sync.h>
 #include <dsd-neo/fec/rs_12_9.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
@@ -114,29 +115,6 @@ dmr_debug_dump_burst(const dsd_opts* opts, const dsd_state* state, uint8_t slot_
         return;
     }
     DSD_FPRINTF(stderr, "%s\n", line);
-}
-
-/* Append `count` dibits as [XX] hex bytes (4 dibits per byte, MSB first).
- * Shared tail for the RC and unsynced debug-dump formatters. */
-static size_t
-dmr_debug_append_dibit_bytes(char* out, size_t out_size, size_t pos, const int* dibits, size_t count) {
-    for (size_t byte_index = 0; byte_index < count / 4U; byte_index++) {
-        uint8_t byte = 0;
-        for (size_t d = 0; d < 4U; d++) {
-            byte = (uint8_t)((byte << 2) | (dibits[(byte_index * 4U) + d] & 0x03));
-        }
-        const int n = DSD_SNPRINTF(out + pos, out_size - pos, "[%02X]", (unsigned int)byte);
-        if (n < 0) {
-            out[pos] = '\0';
-            return pos;
-        }
-        pos += (size_t)n;
-        if (pos >= out_size) {
-            out[out_size - 1U] = '\0';
-            return pos;
-        }
-    }
-    return pos;
 }
 
 size_t

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -862,6 +862,10 @@ cli_next_arg(char** argv, int i, int* arg_advance) {
             opts->dmr_debug_burst = 1;                                                                                 \
             continue;                                                                                                  \
         }                                                                                                              \
+        if (strcmp(argv[i], "--dmr-debug-unsynced") == 0) {                                                            \
+            opts->dmr_debug_unsynced = 1;                                                                              \
+            continue;                                                                                                  \
+        }                                                                                                              \
         if (strcmp(argv[i], "--show-keys") == 0) {                                                                     \
             opts->show_keys = 1;                                                                                       \
             continue;                                                                                                  \

--- a/src/runtime/cli/compact.c
+++ b/src/runtime/cli/compact.c
@@ -56,13 +56,10 @@ compact_copy_terminator_tail_or_stop(int start, int argc, char** argv, int* out_
 }
 
 static const char* const k_skip_exact_no_arg[] = {
-    "--auto-ppm",          "--rtltcp-autotune",
-    "--iq-loop",           "--rdio-api-delete-after-upload",
-    "--enc-lockout",       "--enc-follow",
-    "--no-config",         "--print-config",
-    "--interactive-setup", "--dump-config-template",
-    "--strict-config",     "--list-profiles",
-    "--dmr-debug-burst",   "--show-keys",
+    "--auto-ppm",          "--rtltcp-autotune",      "--iq-loop",       "--rdio-api-delete-after-upload",
+    "--enc-lockout",       "--enc-follow",           "--no-config",     "--print-config",
+    "--interactive-setup", "--dump-config-template", "--strict-config", "--list-profiles",
+    "--dmr-debug-burst",   "--dmr-debug-unsynced",   "--show-keys",
 };
 
 static const char* const k_skip_exact_next_any[] = {

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -281,6 +281,11 @@ dsd_cli_usage_section_advanced_decoder_options(void) {
     printf("      --show-keys  Reveal radio keys and keystream material in CLI/status output for this run.\n");
     printf("                   Default output remains redacted.\n");
     printf("\n");
+    printf("      --dmr-debug-burst     Dump each synced DMR burst payload to stderr as hex\n");
+    printf("                            ('Debug Demod +Sync' lines; RC bursts dump all 12 bytes incl. sync).\n");
+    printf("      --dmr-debug-unsynced  While hunting for sync with DMR enabled, dump raw demod output\n");
+    printf("                            to stderr in 36-byte chunks ('Debug Demod -Sync' lines).\n");
+    printf("\n");
 }
 
 static void

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5659,9 +5659,10 @@ target_compile_definitions(
     dsd-neo_test_dmr_relaxed_header_ip
     PRIVATE MBELIB_NO_HEADERS=1
 )
+# dmr_utils.c uses the shared debug hex formatter exported by dsd-neo_dsp.
 target_link_libraries(
     dsd-neo_test_dmr_relaxed_header_ip
-    PRIVATE dsd-neo_test_support
+    PRIVATE dsd-neo_dsp dsd-neo_test_support
 )
 add_test(NAME DMR_RELAXED_HEADER_IP COMMAND dsd-neo_test_dmr_relaxed_header_ip)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5338,6 +5338,15 @@ target_include_directories(
 target_link_libraries(dsd-neo_test_dmr_debug_burst PRIVATE dsd-neo_proto_dmr)
 add_test(NAME DMR_DEBUG_BURST COMMAND dsd-neo_test_dmr_debug_burst)
 
+# Standalone DMR Reverse Channel burst: RC PDU round-trip and dmrRC framing
+add_executable(dsd-neo_test_dmr_rc_burst protocol/dmr/test_dmr_rc_burst.c)
+target_include_directories(
+    dsd-neo_test_dmr_rc_burst
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(dsd-neo_test_dmr_rc_burst PRIVATE dsd-neo_proto_dmr)
+add_test(NAME DMR_RC_BURST COMMAND dsd-neo_test_dmr_rc_burst)
+
 add_executable(
     dsd-neo_test_dmr_dburst_profile
     protocol/dmr/test_dmr_dburst_profile.c

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -715,6 +715,48 @@ test_symbol_replay_bypasses_sps_profile_gating(void) {
 }
 
 static void
+test_dmr_rc_sync_matches_and_respects_polarity(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    /* Normal polarity: the MS RC sync maps to the RC synctype. */
+    reset(&opts, &state);
+    opts.frame_dmr = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DMR_MS_RC_SYNC, 24) == DSD_SYNC_DMR_RC_DATA);
+    assert(state.lastsynctype == DSD_SYNC_DMR_RC_DATA);
+    assert(strcmp(state.ftype, "DMR RC") == 0);
+
+    /* The complement pattern is ETSI-reserved: never claimed as RC at
+     * normal polarity. */
+    reset(&opts, &state);
+    opts.frame_dmr = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DMR_MS_RC_SYNC_INV, 24) == DSD_SYNC_NONE);
+
+    /* Inverted input flips the RC sync into the complement pattern. */
+    reset(&opts, &state);
+    opts.frame_dmr = 1;
+    opts.inverted_dmr = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DMR_MS_RC_SYNC_INV, 24) == DSD_SYNC_DMR_RC_DATA);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DMR_MS_RC_SYNC, 24) == DSD_SYNC_NONE);
+
+    /* No DMR decoding, no RC sync. */
+    reset(&opts, &state);
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DMR_MS_RC_SYNC, 24) == DSD_SYNC_NONE);
+}
+
+static void
 test_symbol_replay_requires_explicit_nxdn_variant(void) {
     static const int symbol_input_types[] = {AUDIO_IN_SYMBOL_BIN, AUDIO_IN_SYMBOL_FLT};
     static dsd_opts opts;
@@ -1576,6 +1618,7 @@ main(void) {
     test_bounded_symbol_history_readiness_and_wrap();
     test_provoice_candidate_does_not_shadow_dstar_or_nxdn();
     test_symbol_replay_bypasses_sps_profile_gating();
+    test_dmr_rc_sync_matches_and_respects_polarity();
     test_symbol_replay_requires_explicit_nxdn_variant();
     test_manual_p25p2_c4fm_bypasses_profile_gating();
     test_locked_p25p2_c4fm_survives_sync();

--- a/tests/protocol/dmr/test_dmr_debug_burst.c
+++ b/tests/protocol/dmr/test_dmr_debug_burst.c
@@ -5,6 +5,7 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -141,6 +142,57 @@ test_formatter_guards_and_truncation(void) {
 }
 
 static int
+test_rc_burst_formatter(void) {
+    /* Reverse Channel burst: RC_a(8) EMB_a(4) SYNC(24) EMB_b(4) RC_b(8)
+     * dibits; the formatter dumps all 12 bytes in over-the-air order so the
+     * RC sync 77 D5 5F 7D FD 77 shows up as bytes 3..8. */
+    int dibits[48];
+    for (int i = 0; i < 48; i++) {
+        dibits[i] = 0;
+    }
+    static const char sync[] = DMR_MS_RC_SYNC;
+    for (int i = 0; i < 24; i++) {
+        dibits[12 + i] = sync[i] - '0';
+    }
+    dibits[0] = 2; /* first byte: dibits 2,0,0,0 -> 0x80 */
+
+    char expected[128];
+    DSD_SNPRINTF(expected, sizeof(expected), "%s",
+                 "Debug Demod +Sync RC: [80][00][00][77][D5][5F][7D][FD][77][00][00][00]");
+
+    char actual[128];
+    size_t n = dmr_debug_format_rc_burst(actual, sizeof(actual), dibits);
+    if (n == 0U) {
+        DSD_FPRINTF(stderr, "dmr_debug_format_rc_burst returned zero\n");
+        return 1;
+    }
+    if (expect_debug_burst_line("rc", actual, expected) != 0) {
+        return 1;
+    }
+
+    char tiny[8] = {'x', 'x', 'x', 'x', 'x', 'x', 'x', '\0'};
+    if (dmr_debug_format_rc_burst(NULL, sizeof(tiny), dibits) != 0U) {
+        DSD_FPRINTF(stderr, "RC NULL output was accepted\n");
+        return 1;
+    }
+    if (dmr_debug_format_rc_burst(tiny, 0U, dibits) != 0U) {
+        DSD_FPRINTF(stderr, "RC zero-sized output was accepted\n");
+        return 1;
+    }
+    if (dmr_debug_format_rc_burst(tiny, sizeof(tiny), NULL) != 0U) {
+        DSD_FPRINTF(stderr, "RC NULL dibits were accepted\n");
+        return 1;
+    }
+    n = dmr_debug_format_rc_burst(tiny, sizeof(tiny), dibits);
+    if (n <= sizeof(tiny) || tiny[sizeof(tiny) - 1U] != '\0') {
+        DSD_FPRINTF(stderr, "RC truncation contract failed n=%zu tail=%d\n", n, (int)tiny[sizeof(tiny) - 1U]);
+        return 1;
+    }
+
+    return 0;
+}
+
+static int
 test_debug_dump_gate_and_enabled_path(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -162,6 +214,7 @@ main(void) {
     rc |= test_state_formatter();
     rc |= test_payload_formatter();
     rc |= test_formatter_guards_and_truncation();
+    rc |= test_rc_burst_formatter();
     rc |= test_debug_dump_gate_and_enabled_path();
     return rc;
 }

--- a/tests/protocol/dmr/test_dmr_rc_burst.c
+++ b/tests/protocol/dmr/test_dmr_rc_burst.c
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Coverage fixtures intentionally use table-driven local encoders and strong
+// stub symbols to exercise the standalone RC burst path in isolation.
+// NOLINTBEGIN(misc-use-internal-linkage)
+/*
+ * Round-trip checks for the standalone DMR Reverse Channel burst
+ * (ETSI TS 102 361-1 clause 6.4.1): RC PDU encode -> dmr_rc_decode_pdu,
+ * burst bit assembly, and the dmrRC handler framing.
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/sync_patterns.h>
+#include <dsd-neo/fec/block_codes.h>
+#include <dsd-neo/fec/bptc.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
+#include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+/* Copies of the parity-check matrices in src/fec/fec.c; every encoder built
+ * from them is sanity-asserted against the in-tree decoder so a transcription
+ * error fails loudly. */
+static const uint8_t k_hamming_16_11_4_h[5][16] = {
+    {1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0}, {0, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0},
+    {0, 0, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0}, {1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 0},
+    {1, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1},
+};
+
+static const uint8_t k_qr_16_7_6_h[9][16] = {
+    {0, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0}, {0, 0, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+    {1, 0, 0, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0}, {0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0},
+    {0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0}, {1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0},
+    {1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0}, {1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0},
+    {1, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+};
+
+/* 4-bit RC command + masked CRC-7 -> 11 info bits, MSB first. */
+static void
+encode_rc_info_bits(uint8_t cmd, uint8_t crc_mask, uint8_t bits[11]) {
+    for (int i = 0; i < 4; i++) {
+        bits[i] = (uint8_t)((cmd >> (3 - i)) & 1);
+    }
+    const uint8_t crc = (uint8_t)(crc7(bits, 4) ^ crc_mask);
+    for (int i = 0; i < 7; i++) {
+        bits[4 + i] = (uint8_t)((crc >> (6 - i)) & 1);
+    }
+}
+
+/* 11 info bits -> 32-bit RC single-burst BPTC matrix: Hamming(16,11,4) row
+ * plus odd column-parity row. */
+static void
+encode_rc_matrix(const uint8_t info[11], uint8_t matrix[32]) {
+    for (int i = 0; i < 11; i++) {
+        matrix[i] = info[i] & 1U;
+    }
+    for (int row = 0; row < 5; row++) {
+        uint8_t p = 0;
+        for (int j = 0; j < 11; j++) {
+            p ^= (uint8_t)(k_hamming_16_11_4_h[row][j] & matrix[j]);
+        }
+        matrix[11 + row] = p;
+    }
+
+    /* Sanity: the composed codeword must round-trip through the in-tree
+     * decoder without correction. */
+    uint8_t rx[16];
+    uint8_t decoded[11];
+    DSD_MEMCPY(rx, matrix, sizeof(rx));
+    assert(Hamming_16_11_4_decode(rx, decoded, 1));
+    for (int i = 0; i < 11; i++) {
+        assert(decoded[i] == info[i]);
+    }
+
+    for (int i = 0; i < 16; i++) {
+        matrix[16 + i] = matrix[i] ^ 1U;
+    }
+}
+
+/* Invert the exact composed de-interleave mapping used by
+ * BPTC_16x2_Extract_Data: DataMatrix[Placement[DeInt[i]]] = In[i]. */
+static void
+interleave_rc_matrix(const uint8_t matrix[32], uint8_t interleaved[32]) {
+    for (int i = 0; i < 32; i++) {
+        interleaved[i] = matrix[DeInterleaveReverseChannelBptcPlacement[DeInterleaveReverseChannelBptc[i]]];
+    }
+}
+
+static void
+encode_rc_pdu(uint8_t cmd, uint8_t crc_mask, uint8_t interleaved[32]) {
+    uint8_t info[11];
+    uint8_t matrix[32];
+    encode_rc_info_bits(cmd, crc_mask, info);
+    encode_rc_matrix(info, matrix);
+    interleave_rc_matrix(matrix, interleaved);
+}
+
+/* CC(4) + PI(1) + LCSS(2) -> QR(16,7,6) encoded EMB, sanity-checked against
+ * the in-tree decoder. */
+static void
+encode_emb(uint8_t cc, uint8_t pi, uint8_t lcss, uint8_t bits[16]) {
+    for (int i = 0; i < 4; i++) {
+        bits[i] = (uint8_t)((cc >> (3 - i)) & 1);
+    }
+    bits[4] = pi & 1U;
+    bits[5] = (uint8_t)((lcss >> 1) & 1);
+    bits[6] = lcss & 1U;
+    for (int row = 0; row < 9; row++) {
+        uint8_t p = 0;
+        for (int j = 0; j < 7; j++) {
+            p ^= (uint8_t)(k_qr_16_7_6_h[row][j] & bits[j]);
+        }
+        bits[7 + row] = p;
+    }
+
+    uint8_t rx[16];
+    DSD_MEMCPY(rx, bits, sizeof(rx));
+    assert(QR_16_7_6_decode(rx));
+    for (int i = 0; i < 7; i++) {
+        assert(rx[i] == bits[i]);
+    }
+}
+
+/* Map an interleaved-bit index back to its RC BPTC matrix position. */
+static int
+interleaved_index_for_matrix_position(int matrix_pos) {
+    for (int i = 0; i < 32; i++) {
+        if (DeInterleaveReverseChannelBptcPlacement[DeInterleaveReverseChannelBptc[i]] == matrix_pos) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static void
+test_rc_pdu_round_trip_all_commands(void) {
+    for (uint8_t cmd = 0; cmd < 16; cmd++) {
+        uint8_t interleaved[32];
+        uint8_t out_cmd = 0xFF;
+        uint32_t out_hex = 0;
+        encode_rc_pdu(cmd, 0x7A, interleaved);
+        assert(dmr_rc_decode_pdu(interleaved, &out_cmd, &out_hex) == DMR_RC_DECODE_OK);
+        assert(out_cmd == cmd);
+        assert((out_hex >> 7) == cmd);
+    }
+}
+
+static void
+test_rc_command_names(void) {
+    assert(strcmp(dmr_rc_command_name(0), "Increase Power By One Step") == 0);
+    assert(strcmp(dmr_rc_command_name(3), "Set Power To Lowest") == 0);
+    assert(strcmp(dmr_rc_command_name(4), "Cease Transmission Command") == 0);
+    assert(strcmp(dmr_rc_command_name(5), "Cease Transmission Request") == 0);
+    for (uint8_t cmd = 6; cmd < 16; cmd++) {
+        assert(dmr_rc_command_name(cmd) == NULL);
+    }
+}
+
+static void
+test_rc_pdu_corrects_single_data_bit_error(void) {
+    uint8_t interleaved[32];
+    uint8_t out_cmd = 0xFF;
+    encode_rc_pdu(5, 0x7A, interleaved);
+
+    /* A flipped info bit (matrix positions 0..10) is corrected by the
+     * Hamming(16,11,4) row and the odd-parity check still passes. */
+    const int idx = interleaved_index_for_matrix_position(0);
+    assert(idx >= 0);
+    interleaved[idx] ^= 1U;
+    assert(dmr_rc_decode_pdu(interleaved, &out_cmd, NULL) == DMR_RC_DECODE_OK);
+    assert(out_cmd == 5);
+}
+
+static void
+test_rc_pdu_rejects_parity_row_error(void) {
+    uint8_t interleaved[32];
+    encode_rc_pdu(4, 0x7A, interleaved);
+
+    /* A flipped parity-row bit (matrix positions 16..31) is not correctable
+     * and must be reported as an FEC failure. */
+    const int idx = interleaved_index_for_matrix_position(20);
+    assert(idx >= 0);
+    interleaved[idx] ^= 1U;
+    assert(dmr_rc_decode_pdu(interleaved, NULL, NULL) == DMR_RC_DECODE_FEC_ERR);
+}
+
+static void
+test_rc_pdu_rejects_wrong_crc_mask(void) {
+    uint8_t interleaved[32];
+    encode_rc_pdu(4, 0x00, interleaved);
+    assert(dmr_rc_decode_pdu(interleaved, NULL, NULL) == DMR_RC_DECODE_CRC_ERR);
+    assert(dmr_rc_decode_pdu(NULL, NULL, NULL) == DMR_RC_DECODE_FEC_ERR);
+}
+
+/* ── dmrRC handler framing ─────────────────────────────────────────────── */
+
+static int g_live_dibits[32];
+static int g_live_count;
+static int g_live_pos;
+
+int
+getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
+    (void)opts;
+    (void)state;
+    if (out_soft != NULL) {
+        out_soft->reliability = 200U;
+    }
+    if (g_live_pos < g_live_count) {
+        return g_live_dibits[g_live_pos++];
+    }
+    return 0;
+}
+
+/* Compose the full 48-dibit RC burst: RC_a(8) EMB_a(4) SYNC(24) EMB_b(4)
+ * RC_b(8), splitting the 32 RC bits and 16 EMB bits around the sync. */
+static void
+build_rc_burst_dibits(uint8_t cmd, uint8_t cc, int dibits[48]) {
+    uint8_t rc_bits[32];
+    uint8_t emb_bits[16];
+    encode_rc_pdu(cmd, 0x7A, rc_bits);
+    encode_emb(cc, /*pi*/ 0, /*lcss single fragment*/ 0, emb_bits);
+
+    for (size_t i = 0; i < 8U; i++) {
+        dibits[i] = (rc_bits[i * 2U] << 1) | rc_bits[(i * 2U) + 1U];
+        dibits[40U + i] = (rc_bits[16U + (i * 2U)] << 1) | rc_bits[16U + (i * 2U) + 1U];
+    }
+    for (size_t i = 0; i < 4U; i++) {
+        dibits[8U + i] = (emb_bits[i * 2U] << 1) | emb_bits[(i * 2U) + 1U];
+        dibits[36U + i] = (emb_bits[8U + (i * 2U)] << 1) | emb_bits[8U + (i * 2U) + 1U];
+    }
+    const char* sync = DMR_MS_RC_SYNC;
+    for (int i = 0; i < 24; i++) {
+        dibits[12 + i] = sync[i] - '0';
+    }
+}
+
+static void
+test_assemble_bits_round_trip(void) {
+    int dibits[48];
+    build_rc_burst_dibits(/*cmd*/ 5, /*cc*/ 7, dibits);
+
+    uint8_t emb_bits[16];
+    uint8_t rc_bits[32];
+    dmr_rc_assemble_bits(dibits, emb_bits, rc_bits);
+
+    uint8_t expected_rc[32];
+    uint8_t expected_emb[16];
+    encode_rc_pdu(5, 0x7A, expected_rc);
+    encode_emb(7, 0, 0, expected_emb);
+    for (int i = 0; i < 32; i++) {
+        assert(rc_bits[i] == expected_rc[i]);
+    }
+    for (int i = 0; i < 16; i++) {
+        assert(emb_bits[i] == expected_emb[i]);
+    }
+
+    uint8_t out_cmd = 0xFF;
+    assert(dmr_rc_decode_pdu(rc_bits, &out_cmd, NULL) == DMR_RC_DECODE_OK);
+    assert(out_cmd == 5);
+}
+
+static void
+run_handler_case(int inverted, uint8_t debug_burst) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int payload_buf[64];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(payload_buf, 0, sizeof(payload_buf));
+
+    int dibits[48];
+    build_rc_burst_dibits(/*cmd*/ 4, /*cc*/ 1, dibits);
+    if (inverted) {
+        for (int i = 0; i < 48; i++) {
+            dibits[i] = (dibits[i] ^ 2) & 3;
+        }
+    }
+
+    for (int i = 0; i < 36; i++) {
+        payload_buf[i] = dibits[i];
+    }
+    g_live_count = 12;
+    g_live_pos = 0;
+    for (int i = 0; i < 12; i++) {
+        g_live_dibits[i] = dibits[36 + i];
+    }
+
+    opts.inverted_dmr = inverted;
+    opts.dmr_debug_burst = debug_burst;
+    state.dmr_payload_buf = payload_buf;
+    state.dmr_payload_p = payload_buf + 36;
+
+    dmrRC(&opts, &state);
+    assert(g_live_pos == 12);
+}
+
+static void
+test_handler_consumes_trailing_dibits(void) {
+    run_handler_case(/*inverted*/ 0, /*debug_burst*/ 0);
+    run_handler_case(/*inverted*/ 0, /*debug_burst*/ 1);
+    run_handler_case(/*inverted*/ 1, /*debug_burst*/ 0);
+}
+
+static void
+test_handler_bails_out_on_short_history(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int payload_buf[64];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(payload_buf, 0, sizeof(payload_buf));
+
+    g_live_count = 12;
+    g_live_pos = 0;
+
+    /* Fewer than 36 cached dibits behind the write pointer: no live reads. */
+    state.dmr_payload_buf = payload_buf;
+    state.dmr_payload_p = payload_buf + 10;
+    dmrRC(&opts, &state);
+    assert(g_live_pos == 0);
+
+    /* No payload buffer at all. */
+    state.dmr_payload_buf = NULL;
+    state.dmr_payload_p = NULL;
+    dmrRC(&opts, &state);
+    assert(g_live_pos == 0);
+}
+
+int
+main(void) {
+    Hamming_16_11_4_init();
+    QR_16_7_6_init();
+
+    test_rc_pdu_round_trip_all_commands();
+    test_rc_command_names();
+    test_rc_pdu_corrects_single_data_bit_error();
+    test_rc_pdu_rejects_parity_row_error();
+    test_rc_pdu_rejects_wrong_crc_mask();
+    test_assemble_bits_round_trip();
+    test_handler_consumes_trailing_dibits();
+    test_handler_bails_out_on_short_history();
+
+    printf("DMR_RC_BURST: OK\n");
+    return 0;
+}
+
+// NOLINTEND(misc-use-internal-linkage)

--- a/tests/protocol/dmr/test_dmr_resample_on_sync.c
+++ b/tests/protocol/dmr/test_dmr_resample_on_sync.c
@@ -23,6 +23,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "dsd-neo/core/safe_api.h"
 
 #define FLOAT_TOL 0.01f
@@ -336,6 +337,41 @@ test_full_resample_on_sync(void) {
     printf("test_full_resample_on_sync: passed\n\n");
 }
 
+static void
+test_unsynced_debug_format(void) {
+    int dibits[144];
+    for (int i = 0; i < 144; i++) {
+        dibits[i] = i & 3;
+    }
+
+    /* Dibits 0..3 = 0,1,2,3 -> 0x1B, repeated for every 4-dibit group. */
+    char expected[256];
+    DSD_SNPRINTF(expected, sizeof(expected), "%s", "Debug Demod -Sync: ");
+    for (int i = 0; i < 36; i++) {
+        const size_t len = strlen(expected);
+        DSD_SNPRINTF(expected + len, sizeof(expected) - len, "%s", "[1B]");
+    }
+
+    char actual[256];
+    size_t n = dmr_debug_format_unsynced(actual, sizeof(actual), dibits, 144U);
+    check_int("unsynced format nonzero", 1, n != 0U);
+    check_int("unsynced format content", 0, strcmp(actual, expected));
+
+    /* Guards: invalid args are rejected. */
+    check_int("unsynced NULL out", 0, (int)dmr_debug_format_unsynced(NULL, sizeof(actual), dibits, 144U));
+    check_int("unsynced zero size", 0, (int)dmr_debug_format_unsynced(actual, 0U, dibits, 144U));
+    check_int("unsynced NULL dibits", 0, (int)dmr_debug_format_unsynced(actual, sizeof(actual), NULL, 144U));
+    check_int("unsynced short count", 0, (int)dmr_debug_format_unsynced(actual, sizeof(actual), dibits, 3U));
+
+    /* Truncation: NUL-terminated, returns would-be length. */
+    char tiny[8];
+    n = dmr_debug_format_unsynced(tiny, sizeof(tiny), dibits, 144U);
+    check_int("unsynced truncation length", 1, n > sizeof(tiny));
+    check_int("unsynced truncation nul", 0, (int)tiny[sizeof(tiny) - 1U]);
+
+    printf("test_unsynced_debug_format: passed\n\n");
+}
+
 int
 main(void) {
     printf("DMR Resample-on-Sync Tests\n");
@@ -345,6 +381,7 @@ main(void) {
     test_history_buffer_wrap();
     test_cach_redigitize();
     test_full_resample_on_sync();
+    test_unsynced_debug_format();
 
     printf("==========================\n");
     printf("Tests: %d, Failures: %d\n", g_test_count, g_fail_count);

--- a/tests/protocol/dmr/test_dmr_sync_dispatch.c
+++ b/tests/protocol/dmr/test_dmr_sync_dispatch.c
@@ -28,6 +28,7 @@ static int data_sync_calls;
 static int ms_bootstrap_calls;
 static int ms_data_calls;
 static int open_left_calls;
+static int rc_calls;
 
 static void
 reset_calls(void) {
@@ -39,6 +40,7 @@ reset_calls(void) {
     ms_bootstrap_calls = 0;
     ms_data_calls = 0;
     open_left_calls = 0;
+    rc_calls = 0;
 }
 
 void
@@ -90,13 +92,21 @@ dmr_data_sync(dsd_opts* opts, dsd_state* state) {
     data_sync_calls++;
 }
 
+void
+dmrRC(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    rc_calls++;
+}
+
 static void
 test_sync_pattern_lengths(void) {
     _Static_assert(sizeof(DMR_BS_DATA_SYNC) == 25U, "DMR_BS_DATA_SYNC length");
     _Static_assert(sizeof(DMR_BS_VOICE_SYNC) == 25U, "DMR_BS_VOICE_SYNC length");
     _Static_assert(sizeof(DMR_MS_DATA_SYNC) == 25U, "DMR_MS_DATA_SYNC length");
     _Static_assert(sizeof(DMR_MS_VOICE_SYNC) == 25U, "DMR_MS_VOICE_SYNC length");
-    _Static_assert(sizeof(DMR_RESERVED_SYNC) == 25U, "DMR_RESERVED_SYNC length");
+    _Static_assert(sizeof(DMR_MS_RC_SYNC) == 25U, "DMR_MS_RC_SYNC length");
+    _Static_assert(sizeof(DMR_MS_RC_SYNC_INV) == 25U, "DMR_MS_RC_SYNC_INV length");
     _Static_assert(sizeof(DMR_DIRECT_MODE_TS1_DATA_SYNC) == 25U, "DMR_DIRECT_MODE_TS1_DATA_SYNC length");
     _Static_assert(sizeof(DMR_DIRECT_MODE_TS1_VOICE_SYNC) == 25U, "DMR_DIRECT_MODE_TS1_VOICE_SYNC length");
     _Static_assert(sizeof(DMR_DIRECT_MODE_TS2_DATA_SYNC) == 25U, "DMR_DIRECT_MODE_TS2_DATA_SYNC length");
@@ -252,13 +262,39 @@ test_ms_data_routes_to_ms_data(void) {
 
     opts.mbe_out_f = stdout;
     opts.mbe_out_fR = stderr;
-    state.synctype = DSD_SYNC_DMR_RC_DATA;
+    state.synctype = DSD_SYNC_DMR_MS_DATA;
     dsd_dispatch_handle_dmr(&opts, &state);
 
     assert(ms_data_calls == 1);
     assert(data_sync_calls == 0);
     assert(close_left_calls == 1);
     assert(close_right_calls == 1);
+}
+
+static void
+test_rc_routes_to_rc_handler(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_calls();
+
+    /* An in-progress recording must survive a one-shot RC burst untouched. */
+    opts.mbe_out_f = stdout;
+    opts.mbe_out_fR = stderr;
+    opts.trunk_enable = 1;
+    state.synctype = DSD_SYNC_DMR_RC_DATA;
+    dsd_dispatch_handle_dmr(&opts, &state);
+
+    assert(rc_calls == 1);
+    assert(ms_data_calls == 0);
+    assert(data_sync_calls == 0);
+    assert(ms_bootstrap_calls == 0);
+    assert(bs_bootstrap_calls == 0);
+    assert(close_left_calls == 0);
+    assert(close_right_calls == 0);
+    assert(opts.mbe_out_f == stdout);
+    assert(opts.mbe_out_fR == stderr);
 }
 
 static void
@@ -296,6 +332,7 @@ main(void) {
     test_trunked_bs_voice_in_mono_mode_defers_mbe_open_to_bs_bootstrap();
     test_stereo_voice_routes_by_synctype();
     test_ms_data_routes_to_ms_data();
+    test_rc_routes_to_rc_handler();
     test_bs_data_routes_to_data_sync();
     printf("DMR_SYNC_DISPATCH: OK\n");
     return 0;

--- a/tests/runtime/test_runtime_cli_compact.c
+++ b/tests/runtime/test_runtime_cli_compact.c
@@ -152,6 +152,25 @@ test_dmr_debug_burst_long_option_is_removed(void) {
 }
 
 static int
+test_dmr_debug_unsynced_long_option_is_removed(void) {
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--dmr-debug-unsynced";
+    char arg2[] = "-fi";
+    char* argv[] = {arg0, arg1, arg2, NULL};
+
+    int new_argc = dsd_cli_compact_args(3, argv);
+    if (new_argc != 2) {
+        DSD_FPRINTF(stderr, "expected new_argc=2, got %d\n", new_argc);
+        return 1;
+    }
+    if (argv[1] == NULL || strcmp(argv[1], "-fi") != 0) {
+        DSD_FPRINTF(stderr, "expected argv[1] to be \"-fi\", got \"%s\"\n", argv[1] ? argv[1] : "(null)");
+        return 1;
+    }
+    return 0;
+}
+
+static int
 test_show_keys_long_option_is_removed(void) {
     char arg0[] = "dsd-neo";
     char arg1[] = "--show-keys";
@@ -371,6 +390,7 @@ main(void) {
     rc |= test_p25_sm_log_consumes_path_and_leaves_short_opts();
     rc |= test_vendor_privacy_long_opts_are_removed();
     rc |= test_dmr_debug_burst_long_option_is_removed();
+    rc |= test_dmr_debug_unsynced_long_option_is_removed();
     rc |= test_show_keys_long_option_is_removed();
     rc |= test_option_terminator_preserves_later_show_keys_argument();
     rc |= test_rtl_udp_control_consumes_port_and_leaves_short_opts();

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -3475,11 +3475,12 @@ test_dmr_debug_burst_long_option_parse(void) {
 
     char arg0[] = "dsd-neo";
     char arg1[] = "--dmr-debug-burst";
-    char* argv[] = {arg0, arg1, NULL};
+    char arg2[] = "--dmr-debug-unsynced";
+    char* argv[] = {arg0, arg1, arg2, NULL};
 
     int argc_effective = 0;
     int exit_rc = -1;
-    int rc = dsd_parse_args(2, argv, opts, state, &argc_effective, &exit_rc);
+    int rc = dsd_parse_args(3, argv, opts, state, &argc_effective, &exit_rc);
     if (rc != DSD_PARSE_CONTINUE) {
         DSD_FPRINTF(stderr, "expected rc=%d, got %d (exit_rc=%d)\n", DSD_PARSE_CONTINUE, rc, exit_rc);
         freeState(state);
@@ -3491,6 +3492,10 @@ test_dmr_debug_burst_long_option_parse(void) {
     int test_rc = 0;
     if (opts->dmr_debug_burst != 1) {
         DSD_FPRINTF(stderr, "expected dmr_debug_burst=1, got %u\n", (unsigned int)opts->dmr_debug_burst);
+        test_rc = 1;
+    }
+    if (opts->dmr_debug_unsynced != 1) {
+        DSD_FPRINTF(stderr, "expected dmr_debug_unsynced=1, got %u\n", (unsigned int)opts->dmr_debug_unsynced);
         test_rc = 1;
     }
     if (opts->payload != 0) {


### PR DESCRIPTION
Closes #153

## Summary

Extends the DMR debug sync facility with detection and full decode of standalone Reverse Channel (RC) bursts — the 96-bit / 10 ms inbound bursts (ETSI TS 102 361-1 V2.6.1, clause 6.4.1) used for TXI "cease transmission" and closed-loop power-control signalling — plus the unsynced demod dump requested in the original thread (#142).

### RC sync detection

- `DMR_RESERVED_SYNC` in `sync_patterns.h` was actually the MS-sourced RC sync `0x77D55F7DFD77` (table 9.2), mislabeled and never matched. It is now `DMR_MS_RC_SYNC` and matched in the DMR frame sync chain whenever DMR decoding is enabled.
- Its symbol-wise complement is exactly the ETSI "Reserved" pattern (`0xDD7FF5D757DD`), added as `DMR_MS_RC_SYNC_INV` and matched only under inverted operation (`-xr`) — mirroring how the voice/data sync pairs swap, and never claimed as RC at normal polarity.
- The previously defined but never produced `DSD_SYNC_DMR_RC_DATA` synctype now routes to a dedicated handler instead of the 144-dibit `dmrMSData()` path.

### RC burst decode (`src/protocol/dmr/dmr_rc.c`)

The burst layout is `RC_a(16) | EMB_a(8) | SYNC(48) | EMB_b(8) | RC_b(16)`, with sync at the normal burst-centre position so the standard correlator finds it. The handler frames the burst from 36 cached dibits plus 12 read live, then decodes:

- EMB (16 bits) via QR(16,7,6): colour code, PI, LCSS.
- RC PDU (32 bits) via the Reverse Channel Single Burst BPTC (clause B.2.2.2: Hamming(16,11,4) row + odd column parity, interleave `i*17 mod 32`), then the 7-bit CRC (`G7 = x^7+x^5+x^2+x+1`) unmasked with `0x7A` (clauses B.3.13/B.3.12).
- The 4-bit RC command per TS 102 361-4 V1.12.1 table 6.32 (power control, Cease Transmission Command/Request).

Output is a one-line console event, e.g. `12:34:56 Sync: +DMR RC | Color Code=01 | RC: Cease Transmission Request;`. The handler deliberately does not touch slot lights, current slot, trunking state, call state, or MBE output files — a 10 ms one-shot event on the alternate channel must not disturb an in-progress call. The RC command name table is shared with the existing embedded-RC path (`dmr_sbrc`).

### Debug dumps

- With `--dmr-debug-burst`, RC bursts dump as `Debug Demod +Sync RC:` followed by all 12 bytes in over-the-air order — the visible `[77][D5][5F][7D][FD][77]` centre doubles as a polarity/alignment check.
- New `--dmr-debug-unsynced` flag dumps non-overlapping 144-dibit (36-byte) `Debug Demod -Sync:` chunks of raw demod output while hunting for sync (best effort; boundaries are arbitrary and thresholds may be uncalibrated). Both flags now have usage text and are documented in `docs/cli.md`; they remain deliberately CLI-only, matching the existing `--dmr-debug-burst` precedent.

## Testing

- New `DMR_RC_BURST`: table-driven encoder (Hamming(16,11,4)/QR(16,7,6) parity from the in-tree H matrices, sanity-asserted against the in-tree decoders; interleave derived by inverting the decoder's composed mapping) round-tripped through `dmr_rc_decode_pdu` for all 16 command values, single-bit error correction, parity-row and CRC-mask rejection; burst bit assembly; handler dibit-consumption and short-history bail-out, including inverted polarity.
- Updated `FRAME_SYNC_INTERNAL_HELPERS` (RC matcher polarity cases), `DMR_SYNC_DISPATCH` (synctype 34 routes to `dmrRC` without closing MBE files), `DMR_DEBUG_BURST` (RC formatter contract), `DMR_RESAMPLE_ON_SYNC` (unsynced formatter), `RUNTIME_CLI_PARSE`/`RUNTIME_CLI_COMPACT` (new flag).
- Full suite passes (481/481), RC tests clean under ASan/UBSan, and `tools/preflight_ci.sh` passes (clang-format, gersemi, clang-tidy, cppcheck, IWYU, semgrep, lizard, guardrails).

Neither sdrtrunk nor dsd-fme frames the standalone RC burst today (both define the pattern but never match it), so field samples are scarce — validation against a TXI-capable system on the MS inbound frequency would be welcome.