### PR TITLE
ci: require android PR builds like windows and macos

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -10,12 +10,10 @@ on:
       - ".*"
       - "**/*.md"
   pull_request:
+    # No paths-ignore here: the Android PR jobs are required status checks, and a
+    # filtered-out workflow never reports them, which would block docs-only PRs.
+    # Keep this in step with windows-ci and macos-ci.
     branches: [main, master]
-    # Two NDK cross builds plus a Qt install is not worth spending on a docs-only
-    # change; keep this in step with the push filter above.
-    paths-ignore:
-      - ".*"
-      - "**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
The Android PR jobs are now required status checks on `main`, alongside the
Windows (`build-native-msvc`) and macOS (`build-portable-dmg`) PR builds:

- `arm64 CLI (NDK cross build)`
- `APK (Qt Quick app)`

This drops `paths-ignore` from `android-ci`'s `pull_request` trigger so those
checks always report. GitHub never posts a check for a workflow that path
filtering skipped, so a docs-only PR would otherwise sit forever with two
pending required contexts and no way to merge. `windows-ci` and `macos-ci`
already omit `paths-ignore` on `pull_request` for the same reason.

The `push` trigger keeps its `.*` / `**/*.md` filter, so main-branch and tag
pushes for docs-only changes still skip the Android builds.

Tradeoff: docs-only PRs now pay for two NDK cross builds plus the Qt install.
That is the same cost the Windows and macOS PR builds already carry as required
checks.
