### PR TITLE
ci: skip AUR update when aur.archlinux.org is in maintenance

### DIFF
--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -752,8 +752,32 @@ jobs:
           chmod 600 "$HOME/.ssh/aur"
           ssh-keyscan -t ed25519 aur.archlinux.org >> "$HOME/.ssh/known_hosts"
 
-      - name: Clone AUR package
+      # aur.archlinux.org gates its SSH git endpoint behind a maintenance flag
+      # (e.g. the 2026 AUR supply-chain incident), which makes every clone fail
+      # with exit 128 and turns main red even though the build is fine. Probe
+      # git-serve first and skip the update when it reports maintenance; any
+      # other probe failure (auth, DNS, host key) still fails the job loudly.
+      - name: Check AUR availability
+        id: aur_up
         if: steps.aur_key.outputs.has_key == 'true'
+        run: |
+          ssh_opts=(-i "$HOME/.ssh/aur" -o IdentitiesOnly=yes -o "UserKnownHostsFile=$HOME/.ssh/known_hosts" -o StrictHostKeyChecking=yes -o BatchMode=yes -o ConnectTimeout=30)
+          probe_out="$(ssh "${ssh_opts[@]}" aur@aur.archlinux.org help 2>&1)" && probe_rc=0 || probe_rc=$?
+          printf '%s\n' "$probe_out"
+          if [ "$probe_rc" -eq 0 ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if printf '%s' "$probe_out" | grep -qi 'down due to maintenance'; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=AUR update skipped::aur.archlinux.org is in maintenance mode; the AUR package was not updated for this run."
+            exit 0
+          fi
+          echo "AUR SSH probe failed with exit $probe_rc for a reason other than maintenance." >&2
+          exit "$probe_rc"
+
+      - name: Clone AUR package
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           aur_ssh_command="ssh -i $HOME/.ssh/aur -o IdentitiesOnly=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o StrictHostKeyChecking=yes"
           GIT_SSH_COMMAND="$aur_ssh_command" git clone ssh://aur@aur.archlinux.org/dsd-neo-git.git aur-package
@@ -761,7 +785,7 @@ jobs:
 
       - name: Compute new pkgver
         id: pkgver
-        if: steps.aur_key.outputs.has_key == 'true'
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           cd "$GITHUB_WORKSPACE"
           ref="origin/main"
@@ -776,7 +800,7 @@ jobs:
           echo "Computed pkgver from $ref ($(git rev-parse --short=7 "$ref")): $new_pkgver"
 
       - name: Validate AUR VCS metadata
-        if: steps.aur_key.outputs.has_key == 'true'
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           set -euo pipefail
           cd aur-package
@@ -803,7 +827,7 @@ jobs:
 
       - name: Check if update needed
         id: check
-        if: steps.aur_key.outputs.has_key == 'true'
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           cd aur-package
           current_pkgver=$(grep -E '^\s*pkgver=' PKGBUILD | sed 's/.*pkgver=//')
@@ -818,7 +842,7 @@ jobs:
           fi
 
       - name: Update PKGBUILD
-        if: steps.aur_key.outputs.has_key == 'true' && steps.check.outputs.needs_update == 'true'
+        if: steps.aur_up.outputs.available == 'true' && steps.check.outputs.needs_update == 'true'
         run: |
           set -euo pipefail
           cd aur-package
@@ -828,7 +852,7 @@ jobs:
           runuser -u "$AUR_MAKEPKG_USER" -- bash -lc "cd '$PWD' && makepkg --printsrcinfo > .SRCINFO"
 
       - name: Commit and push to AUR
-        if: steps.aur_key.outputs.has_key == 'true' && steps.check.outputs.needs_update == 'true'
+        if: steps.aur_up.outputs.available == 'true' && steps.check.outputs.needs_update == 'true'
         run: |
           cd aur-package
           git config user.name "github-actions[bot]"
@@ -899,8 +923,30 @@ jobs:
           chmod 600 "$HOME/.ssh/aur"
           ssh-keyscan -t ed25519 aur.archlinux.org >> "$HOME/.ssh/known_hosts"
 
-      - name: Clone AUR package
+      # Same maintenance gate as update-aur-git. This skip is louder (warning,
+      # not notice) because a tagged release that never reaches the AUR needs
+      # to be pushed by hand once maintenance lifts.
+      - name: Check AUR availability
+        id: aur_up
         if: steps.aur_key.outputs.has_key == 'true'
+        run: |
+          ssh_opts=(-i "$HOME/.ssh/aur" -o IdentitiesOnly=yes -o "UserKnownHostsFile=$HOME/.ssh/known_hosts" -o StrictHostKeyChecking=yes -o BatchMode=yes -o ConnectTimeout=30)
+          probe_out="$(ssh "${ssh_opts[@]}" aur@aur.archlinux.org help 2>&1)" && probe_rc=0 || probe_rc=$?
+          printf '%s\n' "$probe_out"
+          if [ "$probe_rc" -eq 0 ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if printf '%s' "$probe_out" | grep -qi 'down due to maintenance'; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=AUR release update skipped::aur.archlinux.org is in maintenance mode; ${GITHUB_REF_NAME} was NOT published to the AUR. Re-run this job or update the package manually once maintenance lifts."
+            exit 0
+          fi
+          echo "AUR SSH probe failed with exit $probe_rc for a reason other than maintenance." >&2
+          exit "$probe_rc"
+
+      - name: Clone AUR package
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           aur_ssh_command="ssh -i $HOME/.ssh/aur -o IdentitiesOnly=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts -o StrictHostKeyChecking=yes"
           GIT_SSH_COMMAND="$aur_ssh_command" git clone ssh://aur@aur.archlinux.org/dsd-neo.git aur-package
@@ -908,7 +954,7 @@ jobs:
 
       - name: Compute release metadata
         id: release_meta
-        if: steps.aur_key.outputs.has_key == 'true'
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           pkgver="${GITHUB_REF_NAME#v}"
           source_url="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz"
@@ -921,7 +967,7 @@ jobs:
           echo "Computed release metadata: pkgver=$pkgver sha256=$sha256"
 
       - name: Ensure PKGBUILD exists
-        if: steps.aur_key.outputs.has_key == 'true'
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           set -euo pipefail
           cd aur-package
@@ -970,7 +1016,7 @@ jobs:
 
       - name: Check if update needed
         id: check
-        if: steps.aur_key.outputs.has_key == 'true'
+        if: steps.aur_up.outputs.available == 'true'
         run: |
           cd aur-package
           current_pkgver=$(sed -n 's/^pkgver=//p' PKGBUILD | head -n1)
@@ -989,7 +1035,7 @@ jobs:
           fi
 
       - name: Update PKGBUILD
-        if: steps.aur_key.outputs.has_key == 'true' && steps.check.outputs.needs_update == 'true'
+        if: steps.aur_up.outputs.available == 'true' && steps.check.outputs.needs_update == 'true'
         run: |
           set -euo pipefail
           cd aur-package
@@ -1000,14 +1046,14 @@ jobs:
           runuser -u "$AUR_MAKEPKG_USER" -- bash -lc "cd '$PWD' && makepkg --printsrcinfo > .SRCINFO"
 
       - name: Validate AUR release source
-        if: steps.aur_key.outputs.has_key == 'true' && steps.check.outputs.needs_update == 'true'
+        if: steps.aur_up.outputs.available == 'true' && steps.check.outputs.needs_update == 'true'
         run: |
           set -euo pipefail
           cd aur-package
           runuser -u "$AUR_MAKEPKG_USER" -- bash -lc "cd '$PWD' && makepkg --verifysource --nodeps --noconfirm"
 
       - name: Commit and push to AUR
-        if: steps.aur_key.outputs.has_key == 'true' && steps.check.outputs.needs_update == 'true'
+        if: steps.aur_up.outputs.available == 'true' && steps.check.outputs.needs_update == 'true'
         run: |
           cd aur-package
           git config user.name "github-actions[bot]"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Project homepage: https://github.com/arancormonk/dsd-neo
 [![linux-ci](https://github.com/arancormonk/dsd-neo/actions/workflows/linux-ci.yaml/badge.svg)](https://github.com/arancormonk/dsd-neo/actions/workflows/linux-ci.yaml)
 [![windows-ci](https://github.com/arancormonk/dsd-neo/actions/workflows/windows-ci.yaml/badge.svg)](https://github.com/arancormonk/dsd-neo/actions/workflows/windows-ci.yaml)
 [![macos-ci](https://github.com/arancormonk/dsd-neo/actions/workflows/macos-ci.yaml/badge.svg)](https://github.com/arancormonk/dsd-neo/actions/workflows/macos-ci.yaml)
+[![android-ci](https://github.com/arancormonk/dsd-neo/actions/workflows/android-ci.yaml/badge.svg)](https://github.com/arancormonk/dsd-neo/actions/workflows/android-ci.yaml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12978/badge)](https://www.bestpractices.dev/projects/12978)
 [![OpenSSF Baseline](https://www.bestpractices.dev/projects/12978/baseline)](https://www.bestpractices.dev/projects/12978)
 


### PR DESCRIPTION
## Summary

- Skip the AUR update jobs when `aur.archlinux.org` reports maintenance instead of failing the run. Its SSH git endpoint is currently flagged for maintenance, so `git clone ssh://aur@aur.archlinux.org/...` exits 128 and turns `main` red on every push even though all 18 build/test/lint jobs pass. Read-only HTTPS stays up during maintenance, so the outage only shows on the `ssh://` path these jobs use.
- A new `Check AUR availability` step probes git-serve with `ssh aur@aur.archlinux.org help` and gates the clone and everything after it:
  - probe exits 0 → update proceeds unchanged
  - output matches `down due to maintenance` → job skips the update and stays green
  - any other failure → job fails with the ssh exit code
- Auth failures, DNS problems, and host key mismatches still fail loudly; only the maintenance flag is tolerated. The probe runs under the existing `AUR_SSH_PRIVATE_KEY` check, so a missing key leaves the new output unset and downstream steps skip exactly as before.
- `update-aur-release` emits a warning rather than a notice and names the tag, since a tagged release that never reaches the AUR has to be pushed by hand once maintenance lifts.
- Adds the `android-ci` badge to the README, grouped with the other platform CI badges.

First failure was between 2026-07-31 23:22Z (last success) and 2026-08-01 16:13Z; every `update-aur-git` run since has the identical cause.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: **workflow**.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests. — n/a, workflow-only; the probe was exercised directly, see below.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. — none added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification. — no permission changes; the probe adds one read-only `ssh ... help` call and interpolates no GitHub context into `run:`.

## Tests And Guardrails

- [ ] `cmake --build --preset dev-debug -j` — n/a, no source changes.
- [ ] `ctest --preset dev-debug --output-on-failure` — n/a, no source changes.
- [x] `tools/preflight_ci.sh` — via the pre-push hook on this branch.
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes — n/a.
- [x] `tools/zizmor.sh` for workflow changes — no findings.
- [ ] `tools/osv_scan.sh` for dependency input changes — n/a.
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh` — pass. `tools/check_vcpkg_overlay_pins.sh` n/a.

`actionlint` (which runs shellcheck over `run:` blocks) is clean. The probe script was run under the same shell Actions uses (`bash --noprofile --norc -e -o pipefail`) with a stubbed `ssh` for the healthy and auth-failure paths, plus a live call against the AUR:

```
healthy       => exit 0   ; available=true
maintenance   => exit 0   ; available=false + notice/warning
auth failure  => exit 255 ; no output set, job fails
live AUR now  => exit 0   ; available=false + notice/warning
```

## Risk

- Security/dependency impact: none. No new permissions, actions, or downloads; the probe is a read-only `help` call over the existing pinned host key and the same key material the jobs already use. The failure path is unchanged for every non-maintenance error, so a revoked or broken AUR key still fails the job.
- CLI/UI behavior impact: none.
- Compatibility or packaging impact: while the AUR is in maintenance the package is not updated, and the job reports that rather than failing. `update-aur-git` is self-correcting — the next push recomputes `pkgver` and pushes. `update-aur-release` is not, hence the warning naming the tag; a release landing during a maintenance window needs the job re-run or a manual AUR push.
