### PR TITLE
audio: keep a single audible slot in both ears, and drop the dead grant-block lockout notice

### DIFF
--- a/src/core/audio/dsd_audio2.c
+++ b/src/core/audio/dsd_audio2.c
@@ -614,13 +614,18 @@ dsd_dmr_apply_tg_hold_and_slot_preference_ss3(dsd_opts* opts, const dsd_state* s
     }
 }
 
-// As with the SS18 policy below, a muted companion slot with an active voice
-// burst must not hold its channel silent: the muted side is zeroed before the
-// copy, so duplication keeps a locked-out companion call transparent.
+// As with the SS18 policy below, a muted companion slot must not hold its
+// channel silent: the muted side is zeroed before the copy, so duplication
+// keeps a locked-out companion call transparent. The mute flag alone decides
+// it -- an audible slot mid-superframe is not always sitting on burst hint 16,
+// and gating duplication on the hint collapsed those spans into one ear.
 static int
 dsd_ss3_should_copy_right_to_left(const dsd_opts* opts, const dsd_state* state, int encL, int encR) {
     if (encR != 0) {
         return 0;
+    }
+    if (encL != 0) {
+        return 1;
     }
     if (opts->dmr_mono == 1 && DSD_SYNC_IS_DMR(state->synctype) && state->dmr_mono_slot == 1) {
         return 1;
@@ -631,7 +636,7 @@ dsd_ss3_should_copy_right_to_left(const dsd_opts* opts, const dsd_state* state, 
     if (opts->slot_preference == 1 && state->dmrburstR == 16) {
         return 1;
     }
-    if (state->dmrburstR == 16 && (state->dmrburstL != 16 || encL)) {
+    if (state->dmrburstR == 16 && state->dmrburstL != 16) {
         return 1;
     }
     return 0;
@@ -642,6 +647,9 @@ dsd_ss3_should_copy_left_to_right(const dsd_opts* opts, const dsd_state* state, 
     if (encL != 0) {
         return 0;
     }
+    if (encR != 0) {
+        return 1;
+    }
     if (opts->dmr_mono == 1 && DSD_SYNC_IS_DMR(state->synctype) && state->dmr_mono_slot != 1) {
         return 1;
     }
@@ -651,7 +659,7 @@ dsd_ss3_should_copy_left_to_right(const dsd_opts* opts, const dsd_state* state, 
     if (opts->slot_preference == 0 && state->dmrburstL == 16) {
         return 1;
     }
-    if (state->dmrburstL == 16 && (state->dmrburstR != 16 || encR)) {
+    if (state->dmrburstL == 16 && state->dmrburstR != 16) {
         return 1;
     }
     return 0;
@@ -689,10 +697,23 @@ dsd_p25p2_apply_slot_preference_ss18(dsd_opts* opts, const dsd_state* state, uns
 // shows active voice: a muted slot (encryption lockout, group gate) is zeroed
 // before the copy, and holding its channel silent would make an undecodable
 // companion call audibly change the clear call's playback.
+//
+// The mute flags -- not the burst hints -- decide that case. A muted channel
+// carries nothing but zeros, so whenever exactly one channel is audible it must
+// be mirrored regardless of the audible slot's MAC state. Burst hint 21 only
+// means "the last MAC PDU for this slot was MAC_ACTIVE"; a slot sitting on
+// MAC_PTT (20), MAC_HANGTIME (22), MAC_END (23), MAC_IDLE (24), an LCCH marker
+// (30) or a cleared hint still emits voice for the rest of its superframe, and
+// gating duplication on 21 collapsed those spans into one ear. The hints stay
+// in play only to break the tie when both channels are unmuted and just one is
+// actually carrying a voice burst.
 static int
 dsd_ss18_should_copy_right_to_left(const dsd_opts* opts, const dsd_state* state, int encL, int encR) {
     if (encR != 0) {
         return 0;
+    }
+    if (encL != 0) {
+        return 1;
     }
     if (opts->slot1_on == 0 && opts->slot2_on == 1) {
         return 1;
@@ -700,7 +721,7 @@ dsd_ss18_should_copy_right_to_left(const dsd_opts* opts, const dsd_state* state,
     if (opts->slot_preference == 1 && state->dmrburstR == 21) {
         return 1;
     }
-    if (state->dmrburstR == 21 && (state->dmrburstL != 21 || encL)) {
+    if (state->dmrburstR == 21 && state->dmrburstL != 21) {
         return 1;
     }
     return 0;
@@ -711,13 +732,16 @@ dsd_ss18_should_copy_left_to_right(const dsd_opts* opts, const dsd_state* state,
     if (encL != 0) {
         return 0;
     }
+    if (encR != 0) {
+        return 1;
+    }
     if (opts->slot1_on == 1 && opts->slot2_on == 0) {
         return 1;
     }
     if (opts->slot_preference == 0 && state->dmrburstL == 21) {
         return 1;
     }
-    if (state->dmrburstL == 21 && (state->dmrburstR != 21 || encR)) {
+    if (state->dmrburstL == 21 && state->dmrburstR != 21) {
         return 1;
     }
     return 0;

--- a/src/protocol/dmr/dmr_csbk.c
+++ b/src/protocol/dmr/dmr_csbk.c
@@ -927,12 +927,26 @@ dmr_cspdu_pf0_handle_p_protect(const dsd_opts* opts, dsd_state* state, uint8_t c
 }
 
 static int
+dmr_cspdu_pf0_slot_call_active(const dsd_state* state, uint8_t slot) {
+    dsd_call_snapshot call;
+    return dsd_call_state_get(state, slot, &call) > 0 && call.phase == DSD_CALL_PHASE_ACTIVE;
+}
+
+// The companion slot is busy when its canonical call epoch is ACTIVE, not just
+// when its burst hint shows voice: the hint records the last burst decoded, so
+// a slot mid-call can sit on a TLC, data or stale hint between voice bursts,
+// and misreading that as free would force-release the channel out from under
+// the companion call. The hint values stay as corroboration for late entry,
+// where bursts decode before any LC has opened a canonical epoch.
+static int
 dmr_cspdu_pf0_p_clear_from_voice(const dsd_state* state) {
     int clear = 0;
-    if (state->currentslot == 0 && (state->dmrburstR != 16 && state->dmrburstR != 0 && state->dmrburstR != 1)) {
+    if (state->currentslot == 0 && (state->dmrburstR != 16 && state->dmrburstR != 0 && state->dmrburstR != 1)
+        && !dmr_cspdu_pf0_slot_call_active(state, 1U)) {
         clear = 2;
     }
-    if (state->currentslot == 1 && (state->dmrburstL != 16 && state->dmrburstL != 0 && state->dmrburstL != 1)) {
+    if (state->currentslot == 1 && (state->dmrburstL != 16 && state->dmrburstL != 0 && state->dmrburstL != 1)
+        && !dmr_cspdu_pf0_slot_call_active(state, 0U)) {
         clear = 3;
     }
     return clear;
@@ -975,16 +989,19 @@ dmr_cspdu_pf0_p_clear_compute(const dsd_opts* opts, const dsd_state* state) {
     return clear;
 }
 
+// Only the P_CLEAR's own slot goes idle. The companion's burst hint records
+// what that slot last decoded, and this teardown is not an observation of the
+// companion: stomping it mid-call would hand every hint consumer a false
+// "idle" for a slot whose call is still running. A genuinely idle companion
+// re-records 9 from its own idle bursts within a burst period.
 static void
 dmr_cspdu_pf0_p_clear_mark_slots_idle(dsd_state* state) {
     if (state->currentslot == 0) {
         state->dmrburstL = 9;
-        state->dmrburstR = 9;
         (void)dsd_recent_activity_clear(state, 0U);
         return;
     }
     state->dmrburstR = 9;
-    state->dmrburstL = 9;
     (void)dsd_recent_activity_clear(state, 1U);
 }
 

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -896,11 +896,27 @@ dmr_flco_print_emergency_flag(const dmr_flco_ctx* ctx) {
     }
 }
 
+// The canonical call state -- not the slot's burst hint, which only records the
+// last burst decoded -- decides whether the companion slot is mid-call. A slot
+// carrying voice can sit on a VLC/PI/TLC or stale hint between voice bursts,
+// and this action retries on every corroborated LC, so a single misread would
+// synthesize a P_CLEAR that tears the clear companion call down. The voice
+// hint stays as corroboration for late entry, where voice bursts decode before
+// any LC has opened a canonical epoch.
+static int
+dmr_flco_slot_call_active(const dsd_state* state, int slot) {
+    dsd_call_snapshot call;
+    return dsd_call_state_get(state, (uint8_t)slot, &call) > 0 && call.phase == DSD_CALL_PHASE_ACTIVE;
+}
+
 static void
 dmr_flco_emit_enc_lockout_action(dmr_flco_ctx* ctx) {
     int eslot = ctx->state->currentslot & 1;
     int other = eslot ^ 1;
     int other_voice = (other == 0) ? (ctx->state->dmrburstL == 16) : (ctx->state->dmrburstR == 16);
+    if (!other_voice) {
+        other_voice = dmr_flco_slot_call_active(ctx->state, other);
+    }
     if (!other_voice) {
         // Synthesize a P_CLEAR so the trunking layer releases the channel.
         // The bit buffer must span the full 12-octet CSPDU: handlers may read

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1032,6 +1032,18 @@ p25_grant_eval_policy(const dsd_opts* opts, const dsd_state* state, const p25_sm
     return p25_grant_eval_group_policy(opts, state, ev, &policy_ctx, out_decision);
 }
 
+// A blocked grant never arms the encryption-lockout ledger. Grants only carry
+// the service-options encryption bit, which is one uncorroborated observation
+// and, on a simulcast site, one the demodulator can invent; the ledger's
+// contract is that entries come from confirmed undecryptable *voice*
+// (handle_enc), and an encrypted-looking grant is instead admitted as a single
+// silent classification probe by p25_grant_apply_crypto_probe(). That probe is
+// also why DSD_TG_POLICY_BLOCK_ENCRYPTED_DISABLED cannot reach a group voice
+// call here: the probe clears encrypted_call before policy evaluation, and the
+// only survivor -- a data call -- is not a voice call. The emission that used
+// to live here was therefore dead, and it named slot 0 unconditionally, so if
+// it were ever revived a slot-1 target would write its lockout notice over
+// whatever unrelated call slot 0 was carrying.
 static int
 p25_grant_handle_policy_block(dsd_opts* opts, dsd_state* state, const p25_grant_eval_ctx_t* eval_ctx,
                               const dsd_tg_policy_decision* decision) {
@@ -1044,11 +1056,6 @@ p25_grant_handle_policy_block(dsd_opts* opts, dsd_state* state, const p25_grant_
                  eval_ctx->svc, eval_ctx->data_call, eval_ctx->encrypted_call, eval_ctx->is_indiv,
                  decision->block_reasons);
     sm_log(opts, state, grant_block_log_tag(eval_ctx->is_indiv, decision->block_reasons));
-    if (p25_grant_is_voice_call(eval_ctx) && !eval_ctx->is_indiv && eval_ctx->tg > 0
-        && (decision->block_reasons & DSD_TG_POLICY_BLOCK_ENCRYPTED_DISABLED)) {
-        p25_emit_enc_lockout_once_typed(opts, state, 0, eval_ctx->tg, eval_ctx->svc, 1, DSD_ENC_LOCKOUT_ALGID_UNKNOWN,
-                                        0);
-    }
     return 1;
 }
 

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -279,7 +279,6 @@ int16_t p2xllr[1400] = {0}; /* bit LLRs after descramble */
 static int dibit = 0;
 static int vc_counter = 0;
 static int framing_counter = 0;
-static int voice = 0; // If voice in vch 0 or vch 1
 
 static uint64_t isch = 0;
 static int isch_decoded = -1;
@@ -315,7 +314,6 @@ p25_p2_frame_reset(void) {
     ts_counter = 0;
     vc_counter = 0;
     framing_counter = 0;
-    voice = 0;
     dibit = 0;
 
     // Reset bit buffers (stale data from previous channel causes decode failures)
@@ -1124,19 +1122,13 @@ p25p2_frame_vc_grace_s(const dsd_state* state, double fallback) {
     return fallback;
 }
 
-// Re-open a slot's audio gate once its ESS resolved the classification the gate
-// was waiting on. The canonical call state is the authority on whether the slot
-// is in a call: dsd_p25p2_decode_audio_allowed() already requires an ACTIVE
-// epoch for this slot, and MAC_END/MAC_IDLE run p25_crypto_reset_slot(), which
-// drops the classification p25_crypto_audio_permitted() checks just above. The
-// burst hint must not gate it. dmrburstL/R only records the last MAC PDU
-// decoded for the slot, so a slot still mid-call whose hint reads MAC_END (23),
-// MAC_IDLE (24), the LCCH marker (30) or a cleared 0 could never re-open its
-// gate -- and the hint is cleared outright when a slot is torn down, which is
-// exactly the state a classification window leaves behind. The old fallback
-// also read the file-scope `voice` flag, letting one slot's burst decide the
-// other slot's gate. The media-rejection latch above is what keeps a denied
-// identity closed here; that guard is independent of any burst state.
+// Re-open a slot's audio gate once its ESS resolves the classification the
+// gate was waiting on. The canonical call state -- not the slot's burst hint,
+// which only records the last MAC PDU decoded -- decides whether the slot is
+// in a call: dsd_p25p2_decode_audio_allowed() requires an ACTIVE epoch, and
+// MAC_END/MAC_IDLE run p25_crypto_reset_slot(), which drops the classification
+// p25_crypto_audio_permitted() checks just above, so post-transmission states
+// stay closed. The media-rejection latch keeps a denied identity closed here.
 static void
 p25p2_ess_maybe_enable_audio_slot(const dsd_opts* opts, dsd_state* state, int slot, int alg) {
     if (state->p25_p2_media_rejected[slot]) {
@@ -1150,14 +1142,10 @@ p25p2_ess_maybe_enable_audio_slot(const dsd_opts* opts, dsd_state* state, int sl
     if (state->p25_p2_audio_allowed[slot] != 0) {
         return;
     }
-    // Only a resolved classification re-opens the gate. UNKNOWN and
-    // ENCRYPTED_PENDING mean this slot's ESS has not classified yet, and under
-    // follow mode the encrypted-audio unmute override makes
-    // p25_crypto_audio_permitted() above answer yes for them -- that override
-    // exists for audio whose classification is settled, not for an unresolved
-    // probe. The burst-hint test this replaced was enforcing that invariant
-    // only by accident, because a slot awaiting classification also tends to
-    // sit outside MAC_PTT/ACTIVE/HANGTIME.
+    // Only a resolved classification re-opens the gate: under follow mode the
+    // encrypted-audio unmute override makes p25_crypto_audio_permitted() above
+    // answer yes for UNKNOWN/ENCRYPTED_PENDING, but that override exists for
+    // audio whose classification is settled, not for an unresolved probe.
     const dsd_p25_crypto_state crypto = state->p25_crypto_state[slot];
     if (crypto == DSD_P25_CRYPTO_UNKNOWN || crypto == DSD_P25_CRYPTO_ENCRYPTED_PENDING) {
         return;
@@ -1472,7 +1460,6 @@ p25p2_duid_maybe_open_mbe(dsd_opts* opts, dsd_state* state, int slot) {
         return;
     }
 
-    voice = 1;
     p25p2_open_mbe_for_ready_slot(opts, state, slot);
 }
 
@@ -1680,9 +1667,6 @@ p25p2_duid_post_timeslot(dsd_opts* opts, dsd_state* state, int timeslot_index, i
     } else {
         state->currentslot = 0;
     }
-    if (ts_counter & 1) {
-        voice = 0;
-    }
 }
 
 static void DSD_ATTR_USED
@@ -1719,22 +1703,19 @@ p25p2_process_duid(dsd_opts* opts, dsd_state* state) {
         p25p2_duid_clear_idle_state(opts, state, now);
         p25p2_duid_dispatch(opts, state, now, p2_pending_release, &err_counter);
         if (p25p2_duid_should_abort(opts, state, err_counter)) {
-            goto END;
+            return;
         }
 
         p25p2_duid_post_timeslot(opts, state, ts_counter, sacch_status);
     }
 
     p25p2_duid_fallback_release(opts, state);
-END:
-    voice = 0;
 }
 
 void
 processP2(dsd_opts* opts, dsd_state* state) {
     state->dmr_stereo = 1;
     p2_dibit_buffer(opts, state);
-    voice = 0;
 
     //look at our ISCH values and determine location in superframe before running frame scramble
     for (framing_counter = 0; framing_counter < 4; framing_counter++) {

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -1124,8 +1124,21 @@ p25p2_frame_vc_grace_s(const dsd_state* state, double fallback) {
     return fallback;
 }
 
+// Re-open a slot's audio gate once its ESS resolved the classification the gate
+// was waiting on. The canonical call state is the authority on whether the slot
+// is in a call: dsd_p25p2_decode_audio_allowed() already requires an ACTIVE
+// epoch for this slot, and MAC_END/MAC_IDLE run p25_crypto_reset_slot(), which
+// drops the classification p25_crypto_audio_permitted() checks just above. The
+// burst hint must not gate it. dmrburstL/R only records the last MAC PDU
+// decoded for the slot, so a slot still mid-call whose hint reads MAC_END (23),
+// MAC_IDLE (24), the LCCH marker (30) or a cleared 0 could never re-open its
+// gate -- and the hint is cleared outright when a slot is torn down, which is
+// exactly the state a classification window leaves behind. The old fallback
+// also read the file-scope `voice` flag, letting one slot's burst decide the
+// other slot's gate. The media-rejection latch above is what keeps a denied
+// identity closed here; that guard is independent of any burst state.
 static void
-p25p2_ess_maybe_enable_audio_slot(const dsd_opts* opts, dsd_state* state, int slot, int alg, int burst) {
+p25p2_ess_maybe_enable_audio_slot(const dsd_opts* opts, dsd_state* state, int slot, int alg) {
     if (state->p25_p2_media_rejected[slot]) {
         state->p25_p2_audio_allowed[slot] = 0;
         return;
@@ -1137,9 +1150,19 @@ p25p2_ess_maybe_enable_audio_slot(const dsd_opts* opts, dsd_state* state, int sl
     if (state->p25_p2_audio_allowed[slot] != 0) {
         return;
     }
-    int in_call = ((burst >= 20 && burst <= 22) || voice);
-    int allow = in_call && dsd_p25p2_decode_audio_allowed(opts, state, slot, alg);
-    if (allow) {
+    // Only a resolved classification re-opens the gate. UNKNOWN and
+    // ENCRYPTED_PENDING mean this slot's ESS has not classified yet, and under
+    // follow mode the encrypted-audio unmute override makes
+    // p25_crypto_audio_permitted() above answer yes for them -- that override
+    // exists for audio whose classification is settled, not for an unresolved
+    // probe. The burst-hint test this replaced was enforcing that invariant
+    // only by accident, because a slot awaiting classification also tends to
+    // sit outside MAC_PTT/ACTIVE/HANGTIME.
+    const dsd_p25_crypto_state crypto = state->p25_crypto_state[slot];
+    if (crypto == DSD_P25_CRYPTO_UNKNOWN || crypto == DSD_P25_CRYPTO_ENCRYPTED_PENDING) {
+        return;
+    }
+    if (dsd_p25p2_decode_audio_allowed(opts, state, slot, alg)) {
         state->p25_p2_audio_allowed[slot] = 1;
     }
 }
@@ -1148,7 +1171,7 @@ static void
 p25p2_ess_apply_slot0(dsd_opts* opts, dsd_state* state, const p25p2_ess_result* result) {
     (void)p25_crypto_resolve(opts, state, DSD_P25_CRYPTO_PHASE2, 0, result->algid, result->keyid, result->mi,
                              p25p2_active_target(state, 0U));
-    p25p2_ess_maybe_enable_audio_slot(opts, state, 0, state->payload_algid, state->dmrburstL);
+    p25p2_ess_maybe_enable_audio_slot(opts, state, 0, state->payload_algid);
 
     if (state->payload_algid == 0x80 || state->payload_algid == 0x0) {
         return;
@@ -1189,7 +1212,7 @@ static void
 p25p2_ess_apply_slot1(dsd_opts* opts, dsd_state* state, const p25p2_ess_result* result) {
     (void)p25_crypto_resolve(opts, state, DSD_P25_CRYPTO_PHASE2, 1, result->algid, result->keyid, result->mi,
                              p25p2_active_target(state, 1U));
-    p25p2_ess_maybe_enable_audio_slot(opts, state, 1, state->payload_algidR, state->dmrburstR);
+    p25p2_ess_maybe_enable_audio_slot(opts, state, 1, state->payload_algidR);
 
     if (state->payload_algidR == 0x80 || state->payload_algidR == 0x0) {
         return;

--- a/src/protocol/p25/phase2/p25p2_xcch.c
+++ b/src/protocol/p25/phase2/p25p2_xcch.c
@@ -240,9 +240,10 @@ p25p2_xcch_flush_partial_audio_on_hangtime(dsd_opts* opts, dsd_state* state, int
     audio_allowed[0] = state->p25_p2_audio_allowed[0];
     audio_allowed[1] = state->p25_p2_audio_allowed[1];
 
-    // Flush before MAC_HANGTIME changes burst 21 to 22; SS18 single-slot
-    // duplication uses those active burst hints. Unlike release, hangtime stays
-    // on the VC, so restore the existing audio gates after the flush.
+    // Flush before MAC_HANGTIME changes burst 21 to 22, so the flushed
+    // superframe is still attributed to the active transmission. Unlike release,
+    // hangtime stays on the VC, so restore the existing audio gates after the
+    // flush -- the flush helper repoints them at the slot it is draining.
     dsd_p25p2_flush_partial_audio_slot(opts, state, slot);
 
     state->p25_p2_audio_allowed[0] = audio_allowed[0];
@@ -352,16 +353,21 @@ p25p2_xcch_reset_ptt_slot_state(dsd_state* state, int slot) {
     p25p2_xcch_set_slot_drop(state, slot, 256);
 }
 
+// Both callers already dropped a PTT their voice-event emit rejected, so
+// reaching here means MAC_PTT really is the last MAC PDU decoded for this slot.
+// The burst hint records that fact and nothing more, so it is set unconditionally
+// and up front: gating it on the audio decision (as the SACCH caller used to,
+// while the FACCH caller always set it) left a slot whose audio was still
+// waiting on crypto classification sitting on a stale or cleared hint, which
+// every consumer then reads as "not in a call". Downstream teardown -- lockout,
+// policy reject -- clears the hint after this and must keep the last word.
 static void
-p25p2_xcch_handle_ptt_slot(dsd_opts* opts, dsd_state* state, const unsigned long long int mac[24], int slot,
-                           int always_set_burst) {
+p25p2_xcch_handle_ptt_slot(dsd_opts* opts, dsd_state* state, const unsigned long long int mac[24], int slot) {
     uint32_t src = p25p2_xcch_src_from_mac(mac);
     int allow_audio = 0;
 
     p25p2_xcch_reset_ptt_slot_state(state, slot);
-    if (always_set_burst) {
-        p25p2_xcch_set_slot_burst(state, slot, 20);
-    }
+    p25p2_xcch_set_slot_burst(state, slot, 20);
 
     DSD_FPRINTF(stderr, "\n VCH %d - ", slot + 1);
     DSD_FPRINTF(stderr, "TG %d ", p25p2_xcch_get_slot_tg(state, slot));
@@ -373,10 +379,6 @@ p25p2_xcch_handle_ptt_slot(dsd_opts* opts, dsd_state* state, const unsigned long
 
     allow_audio = p25p2_xcch_slot_audio_allowed(opts, state, slot);
     p25p2_xcch_set_slot_audio_allowed(opts, state, slot, allow_audio);
-
-    if (!always_set_burst && allow_audio) {
-        p25p2_xcch_set_slot_burst(state, slot, 20);
-    }
 }
 
 static void
@@ -530,7 +532,7 @@ p25p2_xcch_handle_sacch_mac_ptt(dsd_opts* opts, dsd_state* state, uint8_t slot, 
         DSD_FPRINTF(stderr, "%s", KNRM);
         return;
     }
-    p25p2_xcch_handle_ptt_slot(opts, state, smac, slot, 0);
+    p25p2_xcch_handle_ptt_slot(opts, state, smac, slot);
 
     if (opts->payload == 1) {
         p25p2_xcch_print_payload_dump("MAC_PTT_PAYLOAD_S", mac_offset, res, smac);
@@ -585,6 +587,13 @@ static void
 p25p2_xcch_handle_sacch_mac_active(dsd_opts* opts, dsd_state* state, uint8_t slot, unsigned long long int smac[24]) {
     int allow_audio = 0;
 
+    // Set before the emit below, matching the FACCH path: the hint states that
+    // MAC_ACTIVE was the last MAC PDU decoded for this slot, which is true
+    // whether or not audio is permitted yet, and a rejection downstream still
+    // clears it afterwards. Gating it on allow_audio stranded a slot that was
+    // mid-crypto-classification on a cleared hint.
+    p25p2_xcch_set_slot_burst(state, slot, 21);
+
     DSD_FPRINTF(stderr, " MAC_ACTIVE ");
     DSD_FPRINTF(stderr, "%s", KYEL);
     process_MAC_VPDU(opts, state, 1, P25_MAC_PDU_ACTIVE, smac);
@@ -599,9 +608,6 @@ p25p2_xcch_handle_sacch_mac_active(dsd_opts* opts, dsd_state* state, uint8_t slo
     }
     allow_audio = p25p2_xcch_slot_audio_allowed(opts, state, slot);
     p25p2_xcch_set_slot_audio_allowed(opts, state, slot, allow_audio);
-    if (allow_audio) {
-        p25p2_xcch_set_slot_burst(state, slot, 21);
-    }
 }
 
 static void
@@ -640,7 +646,7 @@ p25p2_xcch_handle_facch_mac_ptt(dsd_opts* opts, dsd_state* state, uint8_t slot, 
         DSD_FPRINTF(stderr, "%s", KNRM);
         return;
     }
-    p25p2_xcch_handle_ptt_slot(opts, state, fmac, slot, 1);
+    p25p2_xcch_handle_ptt_slot(opts, state, fmac, slot);
 
     if (opts->payload == 1) {
         p25p2_xcch_print_payload_dump("MAC_PTT_PAYLOAD_F", mac_offset, res, fmac);

--- a/tests/core/test_core_audio2_helpers.c
+++ b/tests/core/test_core_audio2_helpers.c
@@ -770,6 +770,66 @@ test_dmr_ss3_enc_locked_companion_duplicates_clear_slot(void) {
     return rc;
 }
 
+// The mute flag alone must drive duplication, not the burst hint. dmrburstL/R
+// record the last burst decoded for a slot, so an audible slot keeps emitting
+// voice while its hint reads PI (0), VLC (1), TLC (2), DATA (6), IDLE (9), NULL
+// (15) or the ERR init value (17). Gating the copy on hint 16 collapsed all of
+// those spans into one ear next to a locked-out companion.
+static int
+run_ss3_muted_companion_burst_hint_case(int clear_slot, int clear_burst, int companion_burst) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+    char tag[96];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.slot1_on = 1;
+    opts.slot2_on = 1;
+    opts.slot_preference = 2;
+
+    // The muted companion still holds pre-mute audio, which must never survive
+    // into either channel.
+    if (clear_slot == 0) {
+        state.dmrburstL = clear_burst;
+        state.dmrburstR = companion_burst;
+        state.s_l4[0][0] = 33;
+        state.s_r4[0][0] = -3000;
+    } else {
+        state.dmrburstR = clear_burst;
+        state.dmrburstL = companion_burst;
+        state.s_r4[0][0] = 33;
+        state.s_l4[0][0] = -3000;
+    }
+
+    dsd_dmr_apply_stereo_output_policy_ss3(&opts, &state, (clear_slot == 0) ? 0 : 1, (clear_slot == 0) ? 1 : 0);
+
+    DSD_SNPRINTF(tag, sizeof(tag), "ss3 burst hint clear=%d/%d companion=%d left", clear_slot, clear_burst,
+                 companion_burst);
+    rc |= expect_int(tag, state.s_l4[0][0], 33);
+    DSD_SNPRINTF(tag, sizeof(tag), "ss3 burst hint clear=%d/%d companion=%d right", clear_slot, clear_burst,
+                 companion_burst);
+    rc |= expect_int(tag, state.s_r4[0][0], 33);
+    return rc;
+}
+
+static int
+test_dmr_ss3_muted_companion_burst_hint_matrix(void) {
+    static const int bursts[] = {0, 1, 2, 6, 9, 15, 16, 17};
+    const size_t count = sizeof(bursts) / sizeof(bursts[0]);
+    int rc = 0;
+
+    for (int clear_slot = 0; clear_slot < 2; clear_slot++) {
+        for (size_t clear_idx = 0; clear_idx < count; clear_idx++) {
+            for (size_t companion_idx = 0; companion_idx < count; companion_idx++) {
+                rc |= run_ss3_muted_companion_burst_hint_case(clear_slot, bursts[clear_idx], bursts[companion_idx]);
+            }
+        }
+    }
+    return rc;
+}
+
 static int
 test_p25p2_ss18_slot_preference_and_copy_policy_helpers(void) {
     static dsd_opts opts;
@@ -1248,6 +1308,7 @@ main(void) {
     rc |= test_dmr_slot_mute_and_duplication_helpers();
     rc |= test_dmr_ss3_decrypt_hold_and_copy_policy_helpers();
     rc |= test_dmr_ss3_enc_locked_companion_duplicates_clear_slot();
+    rc |= test_dmr_ss3_muted_companion_burst_hint_matrix();
     rc |= test_p25p2_ss18_slot_preference_and_copy_policy_helpers();
     rc |= test_ss18_partial_superframe_skips_zero_blocks_and_duplicates_clear_slot();
     rc |= test_ss18_keeps_legit_silence_inside_filled_extent();

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -1593,7 +1593,11 @@ test_encrypted_flco_lockout_return_keeps_canonical_calls_ended(void) {
     state.dmrburstL = 16;
     state.dmrburstR = 9;
     seed_voice_call(&state, 0U, DSD_CALL_KIND_GROUP_VOICE, 1234U, 5678U);
+    // The companion slot's call already ended: a companion whose canonical
+    // epoch is still ACTIVE now blocks the forced release (covered by the
+    // preserves-active-companion matrix below).
     seed_voice_call(&state, 1U, DSD_CALL_KIND_GROUP_VOICE, 4321U, 8765U);
+    assert(dsd_call_state_end(&state, 1U, 0.0) > 0);
 
     dmr_sm_init(&opts, &state);
     dmr_sm_get_ctx()->state = DMR_SM_TUNED;
@@ -1612,6 +1616,72 @@ test_encrypted_flco_lockout_return_keeps_canonical_calls_ended(void) {
     assert_call(&state, 0U, DSD_CALL_PHASE_ENDED, DSD_CALL_KIND_GROUP_VOICE, 1234U, 5678U);
     assert_call(&state, 1U, DSD_CALL_PHASE_ENDED, DSD_CALL_KIND_GROUP_VOICE, 4321U, 8765U);
     dsd_state_ext_free_all(&state);
+}
+
+// The lockout's stay-or-release decision must read the companion's canonical
+// call state, not its burst hint: a clear call keeps the canonical epoch
+// ACTIVE while the hint walks through PI (0), VLC (1), TLC (2), DATA (6),
+// IDLE (9), NULL (15), VOICE (16) and the ERR init value (17), and the action
+// retries on every corroborated LC, so any hint misread as "no call" would
+// synthesize a P_CLEAR that tears the clear companion call down.
+static void
+test_encrypted_flco_lockout_preserves_active_companion_call(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    static const unsigned int companion_hints[] = {0U, 1U, 2U, 6U, 9U, 15U, 16U, 17U};
+    uint8_t bits[80];
+
+    for (int eslot = 0; eslot < 2; eslot++) {
+        for (size_t h = 0; h < sizeof(companion_hints) / sizeof(companion_hints[0]); h++) {
+            const int other = eslot ^ 1;
+            uint32_t irr = 0U;
+
+            DSD_MEMSET(&opts, 0, sizeof(opts));
+            DSD_MEMSET(&state, 0, sizeof(state));
+            DSD_MEMSET(history, 0, sizeof(history));
+            init_event_history(&history[0], 0, 1);
+            init_event_history(&history[1], 0, 1);
+            state.event_history_s = history;
+            opts.trunk_enable = 1;
+            opts.trunk_tune_enc_calls = 0;
+            opts.trunk_is_tuned = 1;
+            state.dmr_stereo = 1;
+            state.currentslot = eslot;
+            state.trunk_cc_freq = 851250000L;
+            state.trunk_vc_freq[0] = 852000000L;
+            state.trunk_vc_freq[1] = 852000000L;
+            if (eslot == 0) {
+                state.dmrburstL = 16;
+                state.dmrburstR = companion_hints[h];
+            } else {
+                state.dmrburstR = 16;
+                state.dmrburstL = companion_hints[h];
+            }
+            seed_voice_call(&state, (uint8_t)eslot, DSD_CALL_KIND_GROUP_VOICE, 1234U, 5678U);
+            seed_voice_call(&state, (uint8_t)other, DSD_CALL_KIND_GROUP_VOICE, 4321U, 8765U);
+
+            dmr_sm_init(&opts, &state);
+            dmr_sm_get_ctx()->state = DMR_SM_TUNED;
+            s_return_to_cc_calls = 0;
+            dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
+                .return_to_cc_request = capture_return_to_cc_ending_calls,
+            });
+
+            build_regular_flco(bits, 0x00U, 0x00U, 0x40U, 1234U, 5678U);
+            dmr_flco(&opts, &state, bits, 1U, &irr, 1U);
+            dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+
+            assert(irr == 0U);
+            // The lockout still arms the session ledger...
+            assert(dsd_enc_lockout_entry_active(&state, 1234U, 1));
+            // ...but the channel is retained for the companion's clear call.
+            assert(s_return_to_cc_calls == 0);
+            assert(opts.trunk_is_tuned == 1);
+            assert_call(&state, (uint8_t)other, DSD_CALL_PHASE_ACTIVE, DSD_CALL_KIND_GROUP_VOICE, 4321U, 8765U);
+            dsd_state_ext_free_all(&state);
+        }
+    }
 }
 
 static void
@@ -2202,6 +2272,7 @@ main(void) {
     test_cach_fragment_counter_overflow_resets_fragments();
     test_encrypted_flco_lockout_inserts_policy_and_event_history();
     test_encrypted_flco_lockout_return_keeps_canonical_calls_ended();
+    test_encrypted_flco_lockout_preserves_active_companion_call();
     test_encrypted_flco_allowed_tuning_skips_lockout_policy();
     test_embedded_lc_enc_requires_corroboration_for_lockout();
     test_clear_voice_in_follow_mode_keeps_lockout_entry();

--- a/tests/protocol/dmr/test_dmr_grant_policy.c
+++ b/tests/protocol/dmr/test_dmr_grant_policy.c
@@ -959,11 +959,33 @@ main(void) {
     (void)dsd_recent_activity_publish(&pf0_st, 1U, &slot_two_data, "slot two data channel", 1U);
     build_p_clear(bits, bytes, 0U);
     dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
-    rc |= expect_true("p_clear data clears slot 2 burst state", pf0_st.dmrburstL == 9 && pf0_st.dmrburstR == 9);
+    rc |= expect_true("p_clear data clears slot 2 burst state", pf0_st.dmrburstR == 9);
+    rc |= expect_true("p_clear data leaves companion burst hint alone", pf0_st.dmrburstL == 6);
     rc |= expect_true("p_clear data clears slot 2 activity", recent_activity_is_empty(&pf0_st, 1U));
     rc |= expect_true("p_clear data does not create a call", no_active_call(&pf0_st, 1U));
     rc |= expect_true("p_clear data does not force release", pf0_st.trunk_sm_force_release == 0);
     rc |= expect_true("p_clear data does not return to cc", pf0_st.p25_sm_release_count == 0);
+
+    // A P_CLEAR for one slot must not force-release the channel while the
+    // companion slot's canonical call epoch is ACTIVE, whatever the
+    // companion's burst hint reads: the hint records the last burst decoded,
+    // and a slot mid-call sits on TLC/data/stale values between voice bursts.
+    static const unsigned int companion_hints[] = {2U, 6U, 9U, 15U, 17U};
+    for (size_t h = 0; h < sizeof(companion_hints) / sizeof(companion_hints[0]); h++) {
+        init_env(&pf0_opts, &pf0_st);
+        pf0_opts.trunk_is_tuned = 1;
+        pf0_st.currentslot = 0;
+        pf0_st.dmrburstL = 9;
+        pf0_st.dmrburstR = companion_hints[h];
+        seed_voice_call(&pf0_st, 1U, DSD_CALL_KIND_GROUP_VOICE, 7700U, 8800U);
+        build_p_clear(bits, bytes, 0U);
+        dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+        rc |= expect_true("p_clear active companion does not force release", pf0_st.trunk_sm_force_release == 0);
+        rc |= expect_true("p_clear active companion does not return to cc", pf0_st.p25_sm_release_count == 0);
+        rc |= expect_true("p_clear active companion keeps its burst hint", pf0_st.dmrburstR == companion_hints[h]);
+        rc |= expect_true("p_clear active companion call stays active",
+                          active_call_matches(&pf0_st, 1U, DSD_CALL_KIND_GROUP_VOICE, 7700U, 8800U));
+    }
 
     init_env(&pf0_opts, &pf0_st);
     pf0_st.trunk_chan_map[lpcn] = freq;

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -9,6 +9,7 @@
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/enc_lockout.h>
+#include <dsd-neo/core/events.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
@@ -20,6 +21,8 @@
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -324,6 +327,83 @@ main(void) {
                                    .is_group = 1});
     rc |= expect_true("later clear mixed-mode grant tunes", st.p25_sm_tune_count == before + 1);
     opts.trunk_tune_enc_calls = 1;
+
+    // A grant blocked while a TDMA companion slot carries an unrelated clear
+    // call must leave that slot alone. Blocked grants no longer emit a lockout
+    // notice at all -- the ledger is armed from confirmed voice, not from the
+    // service-options bit -- and the notice they used to emit named slot 0
+    // unconditionally, so a slot-1 target overwrote slot 0's live call row.
+    {
+        static dsd_opts comp_opts;
+        static dsd_state comp_st;
+        DSD_MEMSET(&comp_opts, 0, sizeof comp_opts);
+        DSD_MEMSET(&comp_st, 0, sizeof comp_st);
+        comp_opts.trunk_enable = 1;
+        comp_opts.trunk_tune_group_calls = 1;
+        comp_opts.trunk_tune_enc_calls = 0;
+        comp_opts.trunk_use_allow_list = 1; // makes the unlisted grant below blocked
+        comp_st.p25_cc_freq = 851000000;
+        comp_st.lastsynctype = DSD_SYNC_P25P2_POS;
+        comp_st.synctype = DSD_SYNC_P25P2_POS;
+        seed_tdma_iden(&comp_st, id);
+        comp_st.event_history_s = calloc(2, sizeof(Event_History_I));
+        rc |= expect_true("companion history allocated", comp_st.event_history_s != NULL);
+        if (comp_st.event_history_s != NULL) {
+            for (int i = 0; i < 2; i++) {
+                init_event_history(&comp_st.event_history_s[i], 0, 255);
+            }
+            p25_sm_init_ctx(p25_sm_get_ctx(), &comp_opts, &comp_st);
+
+            const dsd_call_observation clear_call = {
+                .protocol = DSD_SYNC_P25P2_POS,
+                .slot = 0U,
+                .kind = DSD_CALL_KIND_GROUP_VOICE,
+                .ota_target_id = 2000,
+                .policy_target_id = 2000,
+                .ota_source_id = 2400,
+                .observed_m = dsd_time_now_monotonic_s(),
+            };
+            rc |= expect_true("companion clear call seeded",
+                              dsd_call_state_observe(&comp_st, &clear_call, DSD_CALL_BOUNDARY_BEGIN) > 0);
+            for (int i = 0; i < 3; i++) {
+                watchdog_event_current(&comp_opts, &comp_st, 0);
+                watchdog_event_history(&comp_opts, &comp_st, 0);
+            }
+
+            dsd_call_snapshot before_call;
+            rc |= expect_true("companion clear call active", dsd_call_state_get(&comp_st, 0U, &before_call) > 0
+                                                                 && before_call.phase == DSD_CALL_PHASE_ACTIVE);
+            char before_row[sizeof(comp_st.event_history_s[0].Event_History_Items[0].event_string)];
+            DSD_SNPRINTF(before_row, sizeof before_row, "%s",
+                         comp_st.event_history_s[0].Event_History_Items[0].event_string);
+
+            // Encrypted-flagged grant for the companion slot's target. The row
+            // is compared before the next event tick, which would rebuild it
+            // from the canonical call and hide a transient flush.
+            p25_sm_event(p25_sm_get_ctx(), &comp_opts, &comp_st,
+                         &(p25_sm_event_t){.type = P25_SM_EV_GRANT,
+                                           .slot = -1,
+                                           .channel = ch,
+                                           .tg = 2001,
+                                           .src = 2401,
+                                           .svc_bits = 0x40,
+                                           .is_group = 1});
+
+            rc |= expect_true("blocked grant does not arm the ledger", enc_tg_cache_is_absent(&comp_st, 2001U));
+            rc |= expect_true("blocked grant leaves companion event row intact",
+                              strcmp(before_row, comp_st.event_history_s[0].Event_History_Items[0].event_string) == 0);
+            dsd_call_snapshot after_call;
+            rc |= expect_true(
+                "blocked grant leaves companion call active",
+                dsd_call_state_get(&comp_st, 0U, &after_call) > 0 && after_call.phase == DSD_CALL_PHASE_ACTIVE
+                    && after_call.ota_target_id == before_call.ota_target_id && after_call.epoch == before_call.epoch);
+
+            free(comp_st.event_history_s);
+            comp_st.event_history_s = NULL;
+        }
+        dsd_state_ext_free_all(&comp_st);
+        p25_sm_init_ctx(p25_sm_get_ctx(), &opts, &st);
+    }
 
     // A target is probed once, retained only after authoritative crypto
     // metadata proves it cannot be decrypted, and recovered by a clear grant.

--- a/tests/protocol/p25/test_p25_p2_mixer_gate.c
+++ b/tests/protocol/p25/test_p25_p2_mixer_gate.c
@@ -544,6 +544,90 @@ run_ss18_partial_flush_case(void) {
     return rc;
 }
 
+// A muted companion (encryption lockout) must mirror the audible slot in every
+// MAC state that slot can be sitting in, not just MAC_ACTIVE. Burst hint 21
+// only records the last MAC PDU seen for the slot; voice keeps flowing through
+// MAC_PTT (20), MAC_HANGTIME (22), MAC_END (23), MAC_IDLE (24), the LCCH marker
+// (30) and a cleared hint, and gating duplication on 21 dropped the clear call
+// into one ear for those spans.
+static int
+run_ss18_muted_companion_burst_hint_case(int clear_slot, int clear_burst, int companion_burst) {
+    static dsd_opts opts;
+    static dsd_state st;
+    int rc = 0;
+    char tag[96];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&st, 0, sizeof(st));
+    reset_capture();
+
+    opts.audio_out = 1;
+    opts.audio_out_type = 8;
+    opts.floating_point = 0;
+    opts.pulse_digi_rate_out = 8000;
+    opts.slot1_on = 1;
+    opts.slot2_on = 1;
+    opts.trunk_tune_enc_calls = 0;
+    st.synctype = DSD_SYNC_P25P2_POS;
+    st.p25_p2_audio_allowed[clear_slot] = 1;
+    st.p25_p2_audio_allowed[clear_slot ^ 1] = 0;
+    st.p25_crypto_state[clear_slot] = DSD_P25_CRYPTO_CLEAR;
+    st.p25_crypto_state[clear_slot ^ 1] = DSD_P25_CRYPTO_BLOCKED;
+    if (clear_slot == 0) {
+        st.dmrburstL = clear_burst;
+        st.dmrburstR = companion_burst;
+    } else {
+        st.dmrburstR = clear_burst;
+        st.dmrburstL = companion_burst;
+    }
+
+    // Full superframe on the clear slot; the muted slot still holds pre-mute
+    // audio, which must never reach the output.
+    for (int block = 0; block < 18; block++) {
+        for (int i = 0; i < 160; i++) {
+            st.s_l4[block][i] = (clear_slot == 0) ? 100 : -3000;
+            st.s_r4[block][i] = (clear_slot == 1) ? 100 : -3000;
+        }
+    }
+    st.voice_counter[clear_slot] = 18;
+    st.voice_counter[clear_slot ^ 1] = 7; // frozen mid-superframe by the mute
+
+    playSynthesizedVoiceSS18(&opts, &st);
+
+    short out[160 * 2] = {0};
+    const size_t expected_bytes = (size_t)160 * 2U * sizeof(out[0]);
+    DSD_SNPRINTF(tag, sizeof(tag), "ss18 burst hint clear=%d/%d companion=%d captured", clear_slot, clear_burst,
+                 companion_burst);
+    rc |= expect_eq(tag, g_audio_capture_calls, 18);
+    int copied = copy_capture_bytes(tag, out, expected_bytes);
+    rc |= copied;
+    if (copied == 0) {
+        DSD_SNPRINTF(tag, sizeof(tag), "ss18 burst hint clear=%d/%d companion=%d left", clear_slot, clear_burst,
+                     companion_burst);
+        rc |= expect_eq(tag, out[0], 100);
+        DSD_SNPRINTF(tag, sizeof(tag), "ss18 burst hint clear=%d/%d companion=%d right", clear_slot, clear_burst,
+                     companion_burst);
+        rc |= expect_eq(tag, out[1], 100);
+    }
+    return rc;
+}
+
+static int
+run_ss18_muted_companion_burst_hint_matrix(void) {
+    static const int bursts[] = {0, 20, 21, 22, 23, 24, 30};
+    const size_t count = sizeof(bursts) / sizeof(bursts[0]);
+    int rc = 0;
+
+    for (int clear_slot = 0; clear_slot < 2; clear_slot++) {
+        for (size_t clear_idx = 0; clear_idx < count; clear_idx++) {
+            for (size_t companion_idx = 0; companion_idx < count; companion_idx++) {
+                rc |= run_ss18_muted_companion_burst_hint_case(clear_slot, bursts[clear_idx], bursts[companion_idx]);
+            }
+        }
+    }
+    return rc;
+}
+
 static int
 run_ss18_partial_flush_guard_case(void) {
     static dsd_opts opts;
@@ -974,6 +1058,7 @@ main(void) {
                                      /*muted_slot_aes_loaded*/ 0, /*muted_slot_key*/ 1ULL);
     rc |= run_ss18_clear_plus_blocked_hold_case(/*clear_slot*/ 0);
     rc |= run_ss18_clear_plus_blocked_hold_case(/*clear_slot*/ 1);
+    rc |= run_ss18_muted_companion_burst_hint_matrix();
     rc |= run_ss18_partial_flush_case();
     rc |= run_ss18_partial_flush_guard_case();
     rc |= run_ss18_partial_flush_slot_case();

--- a/tests/protocol/p25/test_p25_p2_reliability.c
+++ b/tests/protocol/p25/test_p25_p2_reliability.c
@@ -640,6 +640,73 @@ test_ess_aes_slot1_loaded_key_preserves_audio_gate(void) {
     return 1;
 }
 
+// The ESS gate must re-open a slot's audio from the canonical call state, not
+// from the slot's burst hint. dmrburstL/R only records the last MAC PDU decoded
+// for the slot, so a slot still mid-call whose hint reads MAC_END (23),
+// MAC_IDLE (24), the LCCH marker (30) or a hint cleared by a teardown could
+// never re-open its gate once its ESS resolved the classification it had been
+// waiting on -- and the old fallback read a file-scope voice flag, letting one
+// slot's burst decide the other slot's gate.
+static int
+run_ess_burst_hint_case(int slot, int burst) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    prepare_ess_soft_inputs(&state);
+    reset_ess_stubs();
+    set_p25p2_threshold(64);
+
+    opts.trunk_enable = 1;
+    opts.trunk_is_tuned = 1;
+    opts.trunk_tune_enc_calls = 0;
+    state.currentslot = slot;
+    for (int i = 0; i < 96; i++) {
+        state.ess_b[slot][i] = 0;
+        state.ess_b_llr[slot][i] = 1;
+    }
+    for (int i = 0; i < 168; i++) {
+        ess_a[slot][i] = 0;
+        ess_a_llr[slot][i] = 1;
+    }
+    seed_p25p2_call(&state, (uint8_t)slot, 1234U, 4321U, 0x00U, 0U, 0U);
+    if (slot == 0) {
+        state.dmrburstL = burst;
+    } else {
+        state.dmrburstR = burst;
+    }
+    set_ess_payload_bits(&state, slot, 0x80, 0x0000, 0x0000000000000000ULL);
+
+    p25p2_process_ess(&opts, &state, 0);
+
+    const int gate = state.p25_p2_audio_allowed[slot];
+    const int crypto = (int)state.p25_crypto_state[slot];
+    const unsigned int ess_ok = state.p25_p2_rs_ess_ok;
+    dsd_state_ext_free_all(&state);
+
+    if (gate == 1 && crypto == DSD_P25_CRYPTO_CLEAR && ess_ok == 1) {
+        return 0;
+    }
+    DSD_FPRINTF(stderr, "\n  FAIL slot=%d burst=%d gate=%d crypto=%d ess_ok=%u", slot, burst, gate, crypto, ess_ok);
+    return 1;
+}
+
+static int
+test_ess_opens_audio_gate_for_every_burst_hint(void) {
+    static const int bursts[] = {0, 20, 21, 22, 23, 24, 30};
+    const size_t count = sizeof(bursts) / sizeof(bursts[0]);
+    int rc = 0;
+
+    printf("Test 31: ESS opens the audio gate in every MAC state... ");
+    for (int slot = 0; slot < 2; slot++) {
+        for (size_t i = 0; i < count; i++) {
+            rc |= run_ess_burst_hint_case(slot, bursts[i]);
+        }
+    }
+    printf("%s\n", rc == 0 ? "PASS" : "FAIL");
+    return rc;
+}
+
 static int
 test_ess_allow_list_blocks_clear_audio_gate(void) {
     printf("Test 16: ESS allow-list blocks clear audio gate... ");
@@ -1359,6 +1426,7 @@ main(void) {
     failures += test_ess_soft_failure_counts_once();
     failures += test_ess_des_manual_key_preserves_audio_gate();
     failures += test_ess_aes_slot1_loaded_key_preserves_audio_gate();
+    failures += test_ess_opens_audio_gate_for_every_burst_hint();
     failures += test_ess_allow_list_blocks_clear_audio_gate();
     failures += test_ess_decode_failure_refreshes_existing_crypto_state();
     failures += test_ess_decode_failure_refreshes_existing_aes_state();

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -677,7 +677,7 @@ test_slot_ptt_and_end_helpers(void) {
     seed_call(&state, 0U, DSD_CALL_KIND_GROUP_VOICE, 0x1234U, 0x010203U);
     fill_mac(mac, 0x84, 0x2468, 0x010203, 0x1234);
 
-    p25p2_xcch_handle_ptt_slot(&opts, &state, mac, 0, 0);
+    p25p2_xcch_handle_ptt_slot(&opts, &state, mac, 0);
     rc |= expect_int("slot0 canonical call", dsd_call_state_get(&state, 0U, &call) > 0, 1);
     rc |= expect_int("slot0 source", (int)call.ota_source_id, 0x010203);
     rc |= expect_int("slot0 target", (int)call.ota_target_id, 0x1234);
@@ -701,7 +701,7 @@ test_slot_ptt_and_end_helpers(void) {
     seed_call(&state, 1U, DSD_CALL_KIND_GROUP_VOICE, 0x4567U, 0xAAAAAAU);
     fill_mac(mac, 0x80, 0x1111, 0, 0x4567);
 
-    p25p2_xcch_handle_ptt_slot(&opts, &state, mac, 1, 1);
+    p25p2_xcch_handle_ptt_slot(&opts, &state, mac, 1);
     rc |= expect_int("slot1 canonical call", dsd_call_state_get(&state, 1U, &call) > 0, 1);
     rc |= expect_int("slot1 zero source preserves source", (int)call.ota_source_id, 0xAAAAAA);
     rc |= expect_int("slot1 target", (int)call.ota_target_id, 0x4567);
@@ -719,7 +719,7 @@ test_slot_ptt_and_end_helpers(void) {
     seed_call(&state, 0U, DSD_CALL_KIND_PRIVATE_VOICE, 0xABCDEFU, 0x010203U);
     fill_mac(mac, 0x80, 0, 0x010203, 0x4567);
 
-    p25p2_xcch_handle_ptt_slot(&opts, &state, mac, 0, 1);
+    p25p2_xcch_handle_ptt_slot(&opts, &state, mac, 0);
     rc |= expect_int("private PTT canonical call", dsd_call_state_get(&state, 0U, &call) > 0, 1);
     rc |= expect_int("private PTT destination preserved", (int)call.ota_target_id, 0xABCDEF);
     rc |= expect_int("private PTT source updated", (int)call.ota_source_id, 0x010203);
@@ -1190,6 +1190,29 @@ test_sacch_end_idle_active_hangtime_dispatch(void) {
     rc |= expect_int("sacch active identity src", g_active_src[1], 0x123456);
     rc |= expect_int("sacch active identity group", g_active_is_group[1], 1);
     rc |= expect_int("sacch active identity svc", g_active_svc[1], 0x81);
+
+    // An accepted MAC_ACTIVE whose audio is still denied -- crypto has not
+    // classified, or policy withholds the slot -- must still record the burst
+    // hint. The hint states which MAC PDU was last decoded for the slot, and
+    // consumers (the ESS gate that re-opens audio once classification resolves,
+    // the SS18 tie-break, the UI) read a stale or cleared hint as "not in a
+    // call". Setting it only when audio was already allowed stranded a slot
+    // mid-classification with the gate shut and no way to reopen.
+    reset_stubs();
+    DSD_MEMSET(&state, 0, sizeof(state));
+    g_audio_allow = 0;
+    state.currentslot = 0;
+    seed_call(&state, 1U, DSD_CALL_KIND_GROUP_VOICE, 0x3456U, 0U);
+    state.p25_crypto_state[1] = DSD_P25_CRYPTO_ENCRYPTED_PENDING;
+    g_voice_identity_result = 1;
+    g_voice_identity.tg = 0x4567;
+    g_voice_identity.src = 0x123456;
+    g_voice_identity.is_group = 1;
+    pack_payload_from_mac(payload, 180, mac, 0x4, 0, 0);
+
+    process_SACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("sacch active denied audio still records burst", (int)state.dmrburstR, 21);
+    rc |= expect_int("sacch active denied audio keeps gate closed", state.p25_p2_audio_allowed[1], 0);
 
     reset_stubs();
     DSD_MEMSET(&state, 0, sizeof(state));


### PR DESCRIPTION
## Summary

- With encryption lockout on and an encrypted call locked out on one TDMA slot, the clear call on the other slot still dropped to one channel intermittently. PR #294 relaxed only the *companion* half of the SS18/SS3 duplication predicate; the audible slot still had to be sitting on burst hint `21` (P25p2 MAC_ACTIVE) / `16` (DMR) for the copy to run. Decide it from the mute flags instead, which is what the float FS4 path already did.
- Remove the dead encryption-lockout emission in `p25_grant_handle_policy_block()`. It named slot 0 unconditionally, so a blocked grant for a slot-1 target armed the ledger from one uncorroborated service-options bit *and* wrote its notice over whatever unrelated call slot 0 was carrying.
- Stop the burst hint gating a slot's audio gate on the decode side, which is the same mistake one layer up. `p25p2_ess_maybe_enable_audio_slot()` is what re-opens a slot's audio once its ESS resolves the classification the gate was waiting on, and it required the slot's hint to read 20/21/22 -- so a slot mid-call sitting on MAC_END, MAC_IDLE, the LCCH marker or a hint cleared by a teardown could never re-open, and its fallback read the file-scope `voice` flag, letting one slot's burst decide the other slot's gate. The SACCH MAC_ACTIVE and MAC_PTT handlers then made the hint unreliable in exactly that state: they recorded it only when audio was already permitted, while their FACCH twins always recorded it. With the fallback gone the file-scope `voice` flag had no readers left, so it is deleted outright along with its write sites.

### Why the burst hints were the wrong signal

`dmrburstL/R` record the last MAC PDU seen for a slot, not whether voice is flowing. A slot keeps decoding voice for the rest of its superframe while its hint reads MAC_PTT (20), MAC_HANGTIME (22), MAC_END (23), MAC_IDLE (24), the LCCH marker (30) or a cleared 0. The SACCH MAC_ACTIVE handler also only sets 21 when the slot is audio-allowed, so the hint stays at 20 through a crypto classification window — longer on a simulcast site where ESS decodes fail. In every one of those spans the muted companion's channel stayed digital silence while the clear call played into one ear.

Measured over the full burst matrix against the real `playSynthesizedVoiceSS18`, pre-fix:

```
clear_slot=0 burst_clear=20 burst_enc=21 crypto=BLOCKED -> L=100 R=0    <== one ear
clear_slot=0 burst_clear=21 burst_enc=21 crypto=BLOCKED -> L=100 R=100
clear_slot=0 burst_clear=22 burst_enc=21 crypto=BLOCKED -> L=100 R=0    <== one ear
```

A muted channel is zeroed before the copy, so whenever exactly one channel is audible it must be mirrored. The hints stay in play only to break the tie when both channels are unmuted and just one carries a voice burst.

### Why the decode-side gate uses the canonical call, not the hint

`dsd_p25p2_decode_audio_allowed()` already requires an ACTIVE canonical epoch for the slot, so the burst-hint test added nothing on the positive side and only subtracted MAC states. MAC_END and MAC_IDLE both run `p25_crypto_reset_slot()`, which drops the classification the guard above it checks, so the post-transmission states stay closed without consulting the hint at all. `p25p2_prepare_voice_crypto()` and `p25p2_xcch_slot_audio_allowed()` already trusted `dsd_p25p2_decode_audio_allowed()` alone; the ESS path was the odd one out.

The hint was also enforcing a second, unrelated invariant by accident. In follow mode with the encrypted-audio unmute override, `p25_crypto_audio_permitted()` answers yes for a slot that has not classified yet, and a slot awaiting classification also tends to sit outside 20..22 -- so dropping the hint test alone unmuted an unresolved probe. `P25_P2_2V_FIRST_FRAME_GATE` caught it. That invariant is now stated directly: UNKNOWN and ENCRYPTED_PENDING never re-open the gate, because the override exists for audio whose classification is settled, not for a probe.

On the signaling side the two SACCH handlers disagreed with their own FACCH twins:

```
SACCH MAC_ACTIVE   burst 21 recorded only when allow_audio      <== hint follows a policy decision
FACCH MAC_ACTIVE   burst 21 recorded unconditionally, up front
SACCH MAC_PTT      burst 20 recorded only when allow_audio      <== same
FACCH MAC_PTT      burst 20 recorded unconditionally, up front
```

Both PTT callers already drop a PTT their voice-event emit rejected, so reaching the handler means that MAC PDU really was the last one decoded for the slot. Recording it up front also keeps the ordering right: a downstream teardown (lockout, policy reject) clears the hint after this and keeps the last word, which is what the existing `P25_P2_XCCH_HELPERS` rejected-event cases assert. With both paths uniform the `always_set_burst` parameter is gone.

### Why the lockout emission was deleted rather than repaired

Its guard needs `DSD_TG_POLICY_BLOCK_ENCRYPTED_DISABLED`, and that bit cannot reach a group voice call there: with lockout enabled `p25_grant_apply_crypto_probe()` clears `encrypted_call` before policy evaluation, follow mode never sets the bit at all, and the only survivor — a data call — is excluded by the `p25_grant_is_voice_call()` guard. Verified: an encrypted-flagged group grant under lockout tunes as a probe and leaves the ledger empty.

Repairing the slot would have left an untestable dead path that still armed the ledger from one uncorroborated `svc & 0x40` with no ALGID and no hysteresis — something a simulcast demodulator can invent. The ledger's contract is that entries come from confirmed undecryptable *voice* (`handle_enc`), with an encrypted-looking grant admitted as a single silent classification probe. The `grant_block` diagnostic and log line stay.

The damage it would do if revived, with slot 0 on an active clear call (TG 1000) and a notice emitted for TG 1001:

```
before notice                    slot0.cur="… P25p2 TGT: 00001000; SRC: 00000123; …"
immediately after slot-0 notice  slot0.cur=""                     <== staged row flushed
after the next event tick        slot0.cur="… TGT: 00001000 …"    (rebuilt)
```

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / **crypto** / dependency / network input / none — encryption-lockout policy and P25p2 audio gating.
- [x] Outside review was requested when available, or unavailability is documented — solo maintainer.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope — none added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` — 507/507
- [x] `tools/preflight_ci.sh` — clean (clang-format, clang-tidy, cppcheck, IWYU, GCC analyzer, semgrep, lizard)
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes — no CMake changes
- [ ] `tools/zizmor.sh` for workflow changes — no workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes — no dependency changes
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` — run via pre-push

New regressions:

- `P25_P2_MIXER_GATE` — a 98-case burst matrix over both slot orientations asserts the clear call reaches both channels in every MAC state while the companion is locked out, and that the companion's pre-mute audio is never emitted. Confirmed failing against the pre-fix predicate.
- `CORE_AUDIO2_HELPERS` — a 128-case matrix making the same assertion for the SS3 path, over the burst hints a DMR slot can be sitting on while voice still flows: PI (0), VLC (1), TLC (2), DATA (6), IDLE (9), NULL (15), VOICE (16) and the ERR init value (17). Confirmed failing against the pre-fix predicate for every clear-slot hint other than 16.
- `P25_P2_RELIABILITY` test 31 — a 14-case matrix over both slots asserts a resolved clear ESS opens the slot's audio gate in every MAC state. Confirmed failing against the pre-fix gate for hints 0/23/24/30, passing for 20/21/22.
- `P25_P2_XCCH_HELPERS` — an accepted SACCH MAC_ACTIVE whose audio is denied must still record hint 21 and keep the gate shut. Confirmed failing against the pre-fix conditional.
- `P25_GRANT_POLICY` — a TDMA companion case asserts a blocked grant for another target leaves the ledger empty and leaves slot 0's event row and canonical call untouched. The row must be compared before the next event tick or the rebuild masks the flush.

To correct an earlier claim in this description: the `P25_GRANT_POLICY` case is **not** a tripwire on the deleted emission, and it does not fail against the pre-fix code. Restoring the deleted hunk verbatim leaves it passing, alone and with the whole PR reverted. The reason is the same one that made the emission dead: `p25_grant_apply_crypto_probe()` clears `encrypted_call` before policy evaluation, so `DSD_TG_POLICY_BLOCK_ENCRYPTED_DISABLED` is never set for a voice grant, and the guard the emission sat behind never opens. No test can fail on that line without first disabling the probe. The case is kept as an invariant test for the surrounding behavior — ledger stays empty, slot 0's event row and canonical epoch survive a blocked grant for another target — not as proof the deletion was needed. That proof is the unreachability argument in the code comment.

## Risk

- Security/dependency impact: none. The encryption-lockout mute path itself is unchanged — a locked-out slot is still zeroed at decode time and before every copy, so duplication can only ever mirror the audible slot. Removing the grant-side ledger arming makes lockout strictly more conservative (voice-confirmed only) and does not weaken any existing entry.
- CLI/UI behavior impact: a single audible P25p2/DMR slot is now heard in both channels in every MAC state instead of only during MAC_ACTIVE. Blocked grants no longer emit an "Encryption Lock Out Enabled" history row; that row was only reachable if the probe path were bypassed, and voice-confirmed lockouts still emit it via `handle_enc`.
- Decode-gate impact: a slot whose ESS resolves clear or decryptable now re-opens its audio in any MAC state instead of only during MAC_PTT/ACTIVE/HANGTIME, and a slot's burst hint now reflects its last MAC PDU rather than the audio decision. Neither loosens the crypto gates: an unresolved classification (UNKNOWN/ENCRYPTED_PENDING) is now blocked explicitly rather than by accident, the media-rejection latch and the `p25_crypto_audio_permitted()` check are untouched, and a locked-out slot is still zeroed at decode time.
- Compatibility or packaging impact: none.



