### PR TITLE
p25: keep the clear call intact while lockout suppresses the encrypted companion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(dsd-neo VERSION 2.6.0 LANGUAGES C CXX)
+project(dsd-neo VERSION 2.6.1 LANGUAGES C CXX)
 if(POLICY CMP0083)
     cmake_policy(SET CMP0083 NEW)
 endif()

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -169,6 +169,9 @@ typedef struct {
     double ptt_last_seen_m;                            // Last observation of that PTT, including retransmissions
     int ptt_signature_valid;                           // 1 while no accepted call boundary/replacement intervened
     uint64_t ptt_canonical_epoch;                      // Canonical epoch that most recently accepted a MAC_PTT
+    double last_enc_suppress_m; // Monotonic timestamp of the last enc-lockout suppression action on this slot.
+                                // The suppressed transmission occupies the carrier with no assignment, epoch,
+                                // or audio trace, so this is the only evidence of it that survives the teardown.
 } p25_sm_slot_ctx_t;
 
 typedef struct {

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -613,6 +613,19 @@ void p25_sm_emit_tdu(dsd_opts* opts, dsd_state* state);
 void p25_sm_emit_enc(dsd_opts* opts, dsd_state* state, int slot, int algid, int keyid, int tg);
 
 /**
+ * @brief Note a FEC-accepted ESS repeat of an already-suppressed BLOCKED classification.
+ *
+ * The full ENC event is edge-triggered on the classification transition; this
+ * lightweight note is the per-repeat liveness signal that the locked-out
+ * transmission still occupies its slot. It refreshes the suppression stamp the
+ * release heuristics read and keeps the slot's audio gate closed — it runs no
+ * teardown and no stay-or-release decision. A slot whose lockout action never
+ * ran (no suppression stamp) is left untouched so a stray repeat cannot invent
+ * liveness for an idle slot.
+ */
+void p25_sm_note_enc_suppressed(dsd_opts* opts, dsd_state* state, int slot);
+
+/**
  * @brief Emit an in-band encrypted indication that requires classification.
  *
  * A new transition closes the slot's media gate, clears stale voice activity,

--- a/src/core/audio/dsd_audio2.c
+++ b/src/core/audio/dsd_audio2.c
@@ -15,6 +15,7 @@
 #include <dsd-neo/core/audio_filters.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/constants.h>
+#include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
@@ -747,6 +748,69 @@ dsd_ss18_should_copy_left_to_right(const dsd_opts* opts, const dsd_state* state,
     return 0;
 }
 
+// Diagnostic trace of the P25p2 mixer's audible-slot decision into the
+// --p25-sm-log stream, where it interleaves with the trunk SM's events on the
+// decoder thread's single timeline. Logged only when the decision vector
+// changes, so a steady state costs one comparison per mixer pass and the log
+// records exactly the transitions: which ear went silent, which gate or copy
+// input moved, and what the decode-side state read at that instant.
+static void
+dsd_p25p2_mix_diag(dsd_opts* opts, const dsd_state* state, const char* path, int encL, int encR, int copy_rl,
+                   int copy_lr, unsigned long TGL, unsigned long TGR) {
+    if (!dsd_p25_sm_log_enabled(opts)) {
+        return;
+    }
+
+    enum { MIX_DIAG_FIELDS = 19 };
+
+    static unsigned long prev[MIX_DIAG_FIELDS];
+    static int prev_valid = 0;
+    // Invocation count, deliberately outside the change vector: when a change
+    // does log, run= reveals how many silent (unchanged) mixer passes happened
+    // since the previous line — distinguishing "ran steadily" from "never ran".
+    static unsigned long run_count = 0;
+    run_count++;
+
+    const unsigned long cur[MIX_DIAG_FIELDS] = {(unsigned long)encL,
+                                                (unsigned long)encR,
+                                                (unsigned long)copy_rl,
+                                                (unsigned long)copy_lr,
+                                                (unsigned long)state->p25_p2_audio_allowed[0],
+                                                (unsigned long)state->p25_p2_audio_allowed[1],
+                                                (unsigned long)state->p25_p2_audio_ring_count[0],
+                                                (unsigned long)state->p25_p2_audio_ring_count[1],
+                                                (unsigned long)state->voice_counter[0],
+                                                (unsigned long)state->voice_counter[1],
+                                                (unsigned long)state->dmrburstL,
+                                                (unsigned long)state->dmrburstR,
+                                                (unsigned long)state->p25_crypto_state[0],
+                                                (unsigned long)state->p25_crypto_state[1],
+                                                (unsigned long)opts->slot1_on,
+                                                (unsigned long)opts->slot2_on,
+                                                (unsigned long)opts->slot_preference,
+                                                TGL,
+                                                TGR};
+
+    int changed = !prev_valid;
+    for (int i = 0; i < MIX_DIAG_FIELDS; i++) {
+        if (prev[i] != cur[i]) {
+            changed = 1;
+        }
+        prev[i] = cur[i];
+    }
+    prev_valid = 1;
+    if (!changed) {
+        return;
+    }
+
+    dsd_p25_sm_logf(opts,
+                    "event=audio_mix path=%s run=%lu encL=%lu encR=%lu copy=%s allowed=%lu/%lu ring=%lu/%lu "
+                    "vc=%lu/%lu burst=%lu/%lu crypto=%lu/%lu slot_on=%lu/%lu pref=%lu tgl=%lu tgr=%lu",
+                    path, run_count, cur[0], cur[1], cur[2] ? "rl" : (cur[3] ? "lr" : "none"), cur[4], cur[5], cur[6],
+                    cur[7], cur[8], cur[9], cur[10], cur[11], cur[12], cur[13], cur[14], cur[15], cur[16], cur[17],
+                    cur[18]);
+}
+
 DSD_AUDIO2_INTERNAL void
 dsd_p25p2_apply_stereo_output_policy_ss18(const dsd_opts* opts, dsd_state* state, int encL, int encR) {
     if (encL) {
@@ -957,6 +1021,8 @@ playSynthesizedVoiceFS4(dsd_opts* opts, dsd_state* state) {
     dsd_set_p25p2_slot_mute_flags(state, &encL, &encR);
     dsd_apply_slot_hard_mute_flags(opts, &encL, &encR);
     dsd_apply_dual_tg_audio_gate(opts, state, &encL, &encR);
+    dsd_p25p2_mix_diag(opts, state, "fs4", encL, encR, encL && !encR, !encL && encR, dsd_audio_call_target(state, 0U),
+                       dsd_audio_call_target(state, 1U));
 
     dsd_fs4_pop_gain_frames(opts, state, lf, rf, l_ok, r_ok);
     dsd_fs4_mix_interleaved_frames(lf, rf, encL, encR, l_ok, r_ok, stereo);
@@ -1178,6 +1244,8 @@ playSynthesizedVoiceSS18(dsd_opts* opts, dsd_state* state) {
 
     dsd_p25p2_apply_slot_preference_ss18(opts, state, TGL, TGR);
     dsd_hpf_short_18_if_enabled(opts, state);
+    dsd_p25p2_mix_diag(opts, state, "ss18", encL, encR, dsd_ss18_should_copy_right_to_left(opts, state, encL, encR),
+                       dsd_ss18_should_copy_left_to_right(opts, state, encL, encR), TGL, TGR);
     dsd_p25p2_apply_stereo_output_policy_ss18(opts, state, encL, encR);
 
     //check this last

--- a/src/core/audio/dsd_audio2.c
+++ b/src/core/audio/dsd_audio2.c
@@ -753,7 +753,11 @@ dsd_ss18_should_copy_left_to_right(const dsd_opts* opts, const dsd_state* state,
 // decoder thread's single timeline. Logged only when the decision vector
 // changes, so a steady state costs one comparison per mixer pass and the log
 // records exactly the transitions: which ear went silent, which gate or copy
-// input moved, and what the decode-side state read at that instant.
+// input moved, and what the decode-side state read at that instant. The
+// free-running ring and voice counters advance on nearly every pass while
+// audio flows, so they sit outside the change trigger — their instantaneous
+// values still print on every logged line for context. Function-local
+// statics: single instance, decoder thread only, like the mixers themselves.
 static void
 dsd_p25p2_mix_diag(dsd_opts* opts, const dsd_state* state, const char* path, int encL, int encR, int copy_rl,
                    int copy_lr, unsigned long TGL, unsigned long TGR) {
@@ -761,9 +765,10 @@ dsd_p25p2_mix_diag(dsd_opts* opts, const dsd_state* state, const char* path, int
         return;
     }
 
-    enum { MIX_DIAG_FIELDS = 19 };
+    // cur[] holds the trigger fields first, then the context-only counters.
+    enum { MIX_DIAG_TRIGGER_FIELDS = 15, MIX_DIAG_FIELDS = 19 };
 
-    static unsigned long prev[MIX_DIAG_FIELDS];
+    static unsigned long prev[MIX_DIAG_TRIGGER_FIELDS];
     static int prev_valid = 0;
     // Invocation count, deliberately outside the change vector: when a change
     // does log, run= reveals how many silent (unchanged) mixer passes happened
@@ -777,10 +782,6 @@ dsd_p25p2_mix_diag(dsd_opts* opts, const dsd_state* state, const char* path, int
                                                 (unsigned long)copy_lr,
                                                 (unsigned long)state->p25_p2_audio_allowed[0],
                                                 (unsigned long)state->p25_p2_audio_allowed[1],
-                                                (unsigned long)state->p25_p2_audio_ring_count[0],
-                                                (unsigned long)state->p25_p2_audio_ring_count[1],
-                                                (unsigned long)state->voice_counter[0],
-                                                (unsigned long)state->voice_counter[1],
                                                 (unsigned long)state->dmrburstL,
                                                 (unsigned long)state->dmrburstR,
                                                 (unsigned long)state->p25_crypto_state[0],
@@ -789,10 +790,14 @@ dsd_p25p2_mix_diag(dsd_opts* opts, const dsd_state* state, const char* path, int
                                                 (unsigned long)opts->slot2_on,
                                                 (unsigned long)opts->slot_preference,
                                                 TGL,
-                                                TGR};
+                                                TGR,
+                                                (unsigned long)state->p25_p2_audio_ring_count[0],
+                                                (unsigned long)state->p25_p2_audio_ring_count[1],
+                                                (unsigned long)state->voice_counter[0],
+                                                (unsigned long)state->voice_counter[1]};
 
     int changed = !prev_valid;
-    for (int i = 0; i < MIX_DIAG_FIELDS; i++) {
+    for (int i = 0; i < MIX_DIAG_TRIGGER_FIELDS; i++) {
         if (prev[i] != cur[i]) {
             changed = 1;
         }
@@ -804,8 +809,8 @@ dsd_p25p2_mix_diag(dsd_opts* opts, const dsd_state* state, const char* path, int
     }
 
     dsd_p25_sm_logf(opts,
-                    "event=audio_mix path=%s run=%lu encL=%lu encR=%lu copy=%s allowed=%lu/%lu ring=%lu/%lu "
-                    "vc=%lu/%lu burst=%lu/%lu crypto=%lu/%lu slot_on=%lu/%lu pref=%lu tgl=%lu tgr=%lu",
+                    "event=audio_mix path=%s run=%lu encL=%lu encR=%lu copy=%s allowed=%lu/%lu burst=%lu/%lu "
+                    "crypto=%lu/%lu slot_on=%lu/%lu pref=%lu tgl=%lu tgr=%lu ring=%lu/%lu vc=%lu/%lu",
                     path, run_count, cur[0], cur[1], cur[2] ? "rl" : (cur[3] ? "lr" : "none"), cur[4], cur[5], cur[6],
                     cur[7], cur[8], cur[9], cur[10], cur[11], cur[12], cur[13], cur[14], cur[15], cur[16], cur[17],
                     cur[18]);

--- a/src/protocol/p25/p25_crypto.c
+++ b/src/protocol/p25/p25_crypto.c
@@ -8,6 +8,7 @@
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/keyring.h>
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/vocoder.h>
@@ -437,6 +438,43 @@ p25_crypto_classify_metadata(const dsd_state* state, dsd_p25_crypto_phase phase,
     return p25_crypto_has_complete_key(state, phase, slot, algid) ? DSD_P25_CRYPTO_DECRYPTABLE : DSD_P25_CRYPTO_BLOCKED;
 }
 
+// The ENC event is edge-triggered on the classification transition. A Phase 2
+// ESS repeats every superframe, and each FEC-accepted repeat of a BLOCKED slot
+// used to re-run the full lockout action (~3 Hz for the life of the
+// transmission): re-ending the canonical call, clearing the slot's burst hint,
+// and revisiting stay-or-release inside the companion conversation's talker
+// gaps. Under lockout the repeat carries no new information — MAC_END/MAC_IDLE
+// reset the slot's classification, so every transmission's first BLOCKED
+// resolve is a transition — but it is the liveness proof that the locked-out
+// call still occupies the slot, which the release-hold heuristics consume as a
+// suppression stamp. Hand repeats to that lightweight note instead; the
+// hangtime tick owns releasing an emptied channel once the stamps age out.
+// Phase 1 keeps per-repeat emission: its identity-pending lockout defers
+// inside the handler and relies on a later repeat to fire once the identity
+// resolves. Follow mode (and non-trunked runs) also keep it, because the
+// repeat re-publishes crypto metadata and refreshes the audio gate for calls
+// that stay tuned.
+static int
+p25_crypto_p2_lockout_repeat(const dsd_opts* opts, dsd_p25_crypto_phase phase, const p25_crypto_snapshot* previous,
+                             dsd_p25_crypto_state resolved, int key_identity_changed) {
+    if (phase != DSD_P25_CRYPTO_PHASE2 || resolved != DSD_P25_CRYPTO_BLOCKED
+        || previous->state != DSD_P25_CRYPTO_BLOCKED || key_identity_changed) {
+        return 0;
+    }
+    return opts->trunk_tune_enc_calls == 0 && opts->trunk_enable == 1;
+}
+
+static void
+p25_crypto_emit_enc_or_note(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_phase phase, int slot, int algid,
+                            int keyid, int talkgroup, const p25_crypto_snapshot* previous,
+                            dsd_p25_crypto_state resolved, int key_identity_changed) {
+    if (p25_crypto_p2_lockout_repeat(opts, phase, previous, resolved, key_identity_changed)) {
+        p25_sm_note_enc_suppressed(opts, state, slot);
+        return;
+    }
+    p25_sm_emit_enc(opts, state, slot, algid, keyid, talkgroup);
+}
+
 static void
 p25_crypto_apply_resolution(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_phase phase, int slot, int algid,
                             int keyid, uint64_t mi, int talkgroup, const p25_crypto_snapshot* previous,
@@ -466,7 +504,8 @@ p25_crypto_apply_resolution(dsd_opts* opts, dsd_state* state, dsd_p25_crypto_pha
     }
 
     if ((resolved == DSD_P25_CRYPTO_DECRYPTABLE || resolved == DSD_P25_CRYPTO_BLOCKED) && opts) {
-        p25_sm_emit_enc(opts, state, slot, algid, keyid, talkgroup);
+        p25_crypto_emit_enc_or_note(opts, state, phase, slot, algid, keyid, talkgroup, previous, resolved,
+                                    key_identity_changed);
     }
 }
 

--- a/src/protocol/p25/p25_crypto.c
+++ b/src/protocol/p25/p25_crypto.c
@@ -454,6 +454,16 @@ p25_crypto_classify_metadata(const dsd_state* state, dsd_p25_crypto_phase phase,
 // resolves. Follow mode (and non-trunked runs) also keep it, because the
 // repeat re-publishes crypto metadata and refreshes the audio gate for calls
 // that stay tuned.
+//
+// The repeat identity is deliberately ALG/KID only, not the talkgroup: a
+// target change with no observed MAC boundary is swallowed as a repeat, but
+// the audio stays gated either way, and the next MAC_END/MAC_IDLE resets the
+// classification so the new target's transition fires then. This layer also
+// cannot see whether the trunk SM is actually tuned; when trunking is enabled
+// but the SM is not on a voice channel, repeats used to take the handler's
+// precheck path and re-publish crypto metadata each superframe. Swallowing
+// them there too is accepted: the transition still publishes once per
+// transmission and dsd_event_sync_slot() runs per timeslot regardless.
 static int
 p25_crypto_p2_lockout_repeat(const dsd_opts* opts, dsd_p25_crypto_phase phase, const p25_crypto_snapshot* previous,
                              dsd_p25_crypto_state resolved, int key_identity_changed) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -61,6 +61,7 @@ static void p25_voice_release_or_preserve_companion(p25_sm_ctx_t* ctx, dsd_opts*
                                                     const char* slot_log);
 static void handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev);
 static void handle_crypto_pending(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev);
+static double p25_sm_effective_hangtime(const dsd_state* state, double hangtime);
 
 typedef enum {
     // Positive per-transmission evidence: MAC_PTT / MAC_ACTIVE or an
@@ -3890,6 +3891,26 @@ p25_voice_clear_slot_burst(dsd_state* state, int slot) {
     }
 }
 
+// Whether the companion slot sits inside the hangtime window of a transmission
+// that just ended on it. The retains-carrier check reads exactly that instant
+// as inactive -- MAC_END clears voice_active and the audio gate -- but the
+// window is the SM's promise to bridge a conversation's talker gaps. The
+// companion's own stop timestamp decides it rather than the global hangtime
+// timer, which the locked-out slot's suppressed voice starts re-arm on every
+// repeat and which therefore cannot distinguish the companion's bridged gap
+// from an enc-only carrier that must still release. Once the gap outlives the
+// effective hangtime the caller releases as before, and a companion with no
+// recorded stop (never carried a call, or torn down without an END) never
+// holds at all.
+static int
+p25_voice_companion_gap_within_hangtime(const p25_sm_ctx_t* ctx, const dsd_state* state, int other, double now_m) {
+    const p25_sm_slot_ctx_t* other_ctx = &ctx->slots[other];
+    if (other_ctx->last_stop_m <= 0.0 || now_m < other_ctx->last_stop_m) {
+        return 0;
+    }
+    return (now_m - other_ctx->last_stop_m) < p25_sm_effective_hangtime(state, ctx->config.hangtime_s);
+}
+
 static void
 p25_voice_release_or_preserve_companion(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot,
                                         const char* release_reason, const char* slot_diag, const char* slot_log) {
@@ -4007,6 +4028,30 @@ p25_enc_lockout_target(const p25_sm_slot_ctx_t* slot_ctx, int fallback, int* is_
     return fallback;
 }
 
+// The lockout action re-runs on every FEC-accepted ESS repeat for as long as
+// the locked-out call keeps transmitting, so it revisits stay-or-release well
+// inside the companion conversation's normal talker gaps -- where the
+// retains-carrier check reads the companion as inactive and a release here
+// would tear down the channel the hangtime window is bridging, clipping the
+// head of every following clear transmission. Hold through the companion's
+// unexpired gap; once only the locked-out call remains, the gap outlives the
+// hangtime and the next repeat releases, exactly when the hangtime-expired
+// tick would.
+static void
+p25_enc_lockout_release_or_hold(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot) {
+    const int other = slot ^ 1;
+    const double now_m = dsd_time_now_monotonic_s();
+    if (ctx->vc_is_tdma && !p25_voice_other_slot_active(ctx, state, other)
+        && p25_voice_companion_gap_within_hangtime(ctx, state, other, now_m)) {
+        p25_sm_diagf(opts, state, ctx, "enc_lockout_hangtime_hold", "slot=%d other=%d gap=%.3f", slot, other,
+                     now_m - ctx->slots[other].last_stop_m);
+        sm_log(opts, state, "enc-lockout-hangtime-hold");
+        return;
+    }
+    p25_voice_release_or_preserve_companion(ctx, opts, state, slot, "enc-lockout", "enc_lockout_slot_only",
+                                            "enc-lockout-slot-only");
+}
+
 static void
 handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev) {
     if (!ctx || !ev || !opts || !state) {
@@ -4070,8 +4115,7 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
     ctx->slots[slot].voice_active = 0;
     p25_voice_clear_slot_grant(ctx, state, slot);
     p25_voice_clear_slot_burst(state, slot);
-    p25_voice_release_or_preserve_companion(ctx, opts, state, slot, "enc-lockout", "enc_lockout_slot_only",
-                                            "enc-lockout-slot-only");
+    p25_enc_lockout_release_or_hold(ctx, opts, state, slot);
 
     // Record last, after the slot teardown above. The teardown runs
     // p25_crypto_reset_slot(), which clears the lockout epoch -- recording any

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -3765,11 +3765,12 @@ p25_facch_has_newer_grant(const p25_sm_ctx_t* ctx, double first_end_m) {
 // so to the double-END fast release the carrier looks like it is closing while
 // the site is in fact still transmitting the locked-out call on it, and the
 // ended conversation's next over gets re-granted on this same channel moments
-// later. The suppression action re-runs on every FEC-accepted ESS repeat for
-// as long as that call keeps transmitting, so a stamp fresh within the
-// effective hangtime means "occupied right now" while surviving ESS decode
-// stalls; once the repeats stop, the stamp ages out and the hangtime-expiry
-// tick still owns the release of a genuinely emptied channel.
+// later. The suppression stamp refreshes on every FEC-accepted ESS repeat
+// (via p25_sm_note_enc_suppressed) for as long as that call keeps
+// transmitting, so a stamp fresh within the effective hangtime means
+// "occupied right now" while surviving ESS decode stalls; once the repeats
+// stop, the stamp ages out and the hangtime-expiry tick still owns the
+// release of a genuinely emptied channel.
 static int
 p25_facch_companion_enc_suppressed(const p25_sm_ctx_t* ctx, const dsd_state* state, int slot, double now_m) {
     if (!ctx->vc_is_tdma) {
@@ -4060,15 +4061,15 @@ p25_enc_lockout_target(const p25_sm_slot_ctx_t* slot_ctx, int fallback, int* is_
     return fallback;
 }
 
-// The lockout action re-runs on every FEC-accepted ESS repeat for as long as
-// the locked-out call keeps transmitting, so it revisits stay-or-release well
-// inside the companion conversation's normal talker gaps -- where the
-// retains-carrier check reads the companion as inactive and a release here
-// would tear down the channel the hangtime window is bridging, clipping the
-// head of every following clear transmission. Hold through the companion's
-// unexpired gap; once only the locked-out call remains, the gap outlives the
-// hangtime and the next repeat releases, exactly when the hangtime-expired
-// tick would.
+// The lockout action runs on every classification transition -- each
+// locked-out transmission's first BLOCKED resolve, or a key-identity change
+// -- so it still revisits stay-or-release inside the companion conversation's
+// normal talker gaps, where the retains-carrier check reads the companion as
+// inactive and a release here would tear down the channel the hangtime window
+// is bridging, clipping the head of every following clear transmission. Hold
+// through the companion's unexpired gap; once only the locked-out call
+// remains, the gap outlives the hangtime and the next transition (or the
+// hangtime-expired tick) releases the emptied channel.
 static void
 p25_enc_lockout_release_or_hold(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot) {
     const int other = slot ^ 1;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -1441,6 +1441,7 @@ p25_grant_clear_one_slot_state(p25_sm_ctx_t* ctx, int slot) {
     ctx->slots[slot].facch_end_m = 0.0;
     ctx->slots[slot].facch_end_tg = 0;
     ctx->slots[slot].facch_end_src = 0;
+    ctx->slots[slot].last_enc_suppress_m = 0.0;
 }
 
 static void
@@ -3758,6 +3759,29 @@ p25_facch_has_newer_grant(const p25_sm_ctx_t* ctx, double first_end_m) {
     return 0;
 }
 
+// Whether the companion slot carries a transmission that encryption lockout is
+// actively suppressing. Lockout tears down the suppressed call's assignment,
+// epoch, and audio gate -- everything p25_facch_all_slots_inactive() reads --
+// so to the double-END fast release the carrier looks like it is closing while
+// the site is in fact still transmitting the locked-out call on it, and the
+// ended conversation's next over gets re-granted on this same channel moments
+// later. The suppression action re-runs on every FEC-accepted ESS repeat for
+// as long as that call keeps transmitting, so a stamp fresh within the
+// effective hangtime means "occupied right now" while surviving ESS decode
+// stalls; once the repeats stop, the stamp ages out and the hangtime-expiry
+// tick still owns the release of a genuinely emptied channel.
+static int
+p25_facch_companion_enc_suppressed(const p25_sm_ctx_t* ctx, const dsd_state* state, int slot, double now_m) {
+    if (!ctx->vc_is_tdma) {
+        return 0;
+    }
+    const p25_sm_slot_ctx_t* other_ctx = &ctx->slots[slot ^ 1];
+    if (other_ctx->last_enc_suppress_m <= 0.0 || now_m < other_ctx->last_enc_suppress_m) {
+        return 0;
+    }
+    return (now_m - other_ctx->last_enc_suppress_m) < p25_sm_effective_hangtime(state, ctx->config.hangtime_s);
+}
+
 static int
 handle_facch_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev) {
     if (!ctx || !ev || ev->slot < 0 || ev->slot > 1) {
@@ -3768,9 +3792,17 @@ handle_facch_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, cons
     const double elapsed = observed_m - slot_ctx->facch_end_m;
     if (elapsed >= 0.0 && elapsed <= 1.0 && !p25_facch_has_newer_grant(ctx, slot_ctx->facch_end_m)
         && p25_facch_end_identity_matches(slot_ctx, ev) && p25_facch_all_slots_inactive(ctx, state)) {
-        p25_sm_diagf(opts, state, ctx, "facch_release_hint", "phase=p2 freq=%ld slot=%d tg=%d src=%d elapsed=%.3f",
-                     ctx->vc_freq_hz, ev->slot, slot_ctx->facch_end_tg, slot_ctx->facch_end_src, elapsed);
-        return do_release(ctx, opts, state, "facch-double-end", 0) ? P25_SM_END_CHANNEL_RELEASED : P25_SM_END_IGNORED;
+        if (p25_facch_companion_enc_suppressed(ctx, state, ev->slot, observed_m)) {
+            p25_sm_diagf(opts, state, ctx, "facch_double_end_enc_hold", "phase=p2 freq=%ld slot=%d other=%d gap=%.3f",
+                         ctx->vc_freq_hz, ev->slot, ev->slot ^ 1,
+                         observed_m - ctx->slots[ev->slot ^ 1].last_enc_suppress_m);
+            sm_log(opts, state, "facch-double-end-enc-hold");
+        } else {
+            p25_sm_diagf(opts, state, ctx, "facch_release_hint", "phase=p2 freq=%ld slot=%d tg=%d src=%d elapsed=%.3f",
+                         ctx->vc_freq_hz, ev->slot, slot_ctx->facch_end_tg, slot_ctx->facch_end_src, elapsed);
+            return do_release(ctx, opts, state, "facch-double-end", 0) ? P25_SM_END_CHANNEL_RELEASED
+                                                                       : P25_SM_END_IGNORED;
+        }
     }
 
     int applied = handle_voice_end(ctx, opts, state, ev->slot, "end", 1, 1, ev, DSD_CALL_END_TERMINATOR);
@@ -4115,6 +4147,12 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
     ctx->slots[slot].voice_active = 0;
     p25_voice_clear_slot_grant(ctx, state, slot);
     p25_voice_clear_slot_burst(state, slot);
+    // The locked-out transmission still occupies this slot on the carrier even
+    // though the teardown above erased every assignment and audio trace of it.
+    // Stamped before the release decision: a release wipes the slot context
+    // with the channel, while a hold leaves the stamp for release heuristics
+    // that read an otherwise idle companion as "channel closing".
+    ctx->slots[slot].last_enc_suppress_m = dsd_time_now_monotonic_s();
     p25_enc_lockout_release_or_hold(ctx, opts, state, slot);
 
     // Record last, after the slot teardown above. The teardown runs

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -6053,6 +6053,24 @@ p25_sm_emit_enc(dsd_opts* opts, dsd_state* state, int slot, int algid, int keyid
 }
 
 void
+p25_sm_note_enc_suppressed(dsd_opts* opts, dsd_state* state, int slot) {
+    (void)opts;
+    if (slot < 0 || slot > 1) {
+        return;
+    }
+    // The gate close matches what the per-repeat lockout action used to
+    // re-assert; it holds even when no suppression context exists.
+    if (state) {
+        state->p25_p2_audio_allowed[slot] = 0;
+    }
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    if (!ctx->initialized || ctx->slots[slot].last_enc_suppress_m <= 0.0) {
+        return;
+    }
+    ctx->slots[slot].last_enc_suppress_m = dsd_time_now_monotonic_s();
+}
+
+void
 p25_sm_emit_crypto_pending(dsd_opts* opts, dsd_state* state, int slot) {
     p25_sm_event_t ev = p25_sm_ev_crypto_pending(slot);
     p25_sm_event(p25_sm_get_ctx(), opts, state, &ev);

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -791,6 +791,35 @@ p25p2_active_target(const dsd_state* state, uint8_t slot) {
     return (int)call.ota_target_id;
 }
 
+// Diagnostic trace of decode-side audio gate transitions into the --p25-sm-log
+// stream. The gate decides whether a slot's vocoder output lands in the
+// playback buffers at all, so a flip between mixer passes is invisible to the
+// mixer trace except as silence; this catches it at the decode chokepoints
+// with the state that drove it. Logged only on change.
+static void
+p25p2_audio_gate_diag(dsd_opts* opts, const dsd_state* state, const char* at) {
+    if (!dsd_p25_sm_log_enabled(opts)) {
+        return;
+    }
+    static int prev[8] = {-1, -1, -1, -1, -1, -1, -1, -1};
+    const int cur[8] = {state->p25_p2_audio_allowed[0],  state->p25_p2_audio_allowed[1],
+                        (int)state->p25_crypto_state[0], (int)state->p25_crypto_state[1],
+                        state->p25_p2_media_rejected[0], state->p25_p2_media_rejected[1],
+                        (int)state->dmrburstL,           (int)state->dmrburstR};
+    int changed = 0;
+    for (int i = 0; i < 8; i++) {
+        if (prev[i] != cur[i]) {
+            changed = 1;
+            prev[i] = cur[i];
+        }
+    }
+    if (!changed) {
+        return;
+    }
+    dsd_p25_sm_logf(opts, "event=audio_gate at=%s allowed=%d/%d crypto=%d/%d rejected=%d/%d burst=%d/%d", at, cur[0],
+                    cur[1], cur[2], cur[3], cur[4], cur[5], cur[6], cur[7]);
+}
+
 static void
 p25p2_prepare_voice_crypto(dsd_opts* opts, dsd_state* state) {
     if (!opts || !state) {
@@ -802,6 +831,7 @@ p25p2_prepare_voice_crypto(dsd_opts* opts, dsd_state* state) {
     }
     if (state->p25_p2_media_rejected[slot]) {
         state->p25_p2_audio_allowed[slot] = 0;
+        p25p2_audio_gate_diag(opts, state, "prepare-rejected");
         return;
     }
     const int svc = (slot == 0) ? state->dmr_so : state->dmr_soR;
@@ -812,6 +842,7 @@ p25p2_prepare_voice_crypto(dsd_opts* opts, dsd_state* state) {
         const int alg = (slot == 0) ? state->payload_algid : state->payload_algidR;
         state->p25_p2_audio_allowed[slot] = dsd_p25p2_decode_audio_allowed(opts, state, slot, alg);
     }
+    p25p2_audio_gate_diag(opts, state, "prepare-voice");
 }
 
 static int
@@ -1160,6 +1191,7 @@ p25p2_ess_apply_slot0(dsd_opts* opts, dsd_state* state, const p25p2_ess_result* 
     (void)p25_crypto_resolve(opts, state, DSD_P25_CRYPTO_PHASE2, 0, result->algid, result->keyid, result->mi,
                              p25p2_active_target(state, 0U));
     p25p2_ess_maybe_enable_audio_slot(opts, state, 0, state->payload_algid);
+    p25p2_audio_gate_diag(opts, state, "ess-slot0");
 
     if (state->payload_algid == 0x80 || state->payload_algid == 0x0) {
         return;
@@ -1201,6 +1233,7 @@ p25p2_ess_apply_slot1(dsd_opts* opts, dsd_state* state, const p25p2_ess_result* 
     (void)p25_crypto_resolve(opts, state, DSD_P25_CRYPTO_PHASE2, 1, result->algid, result->keyid, result->mi,
                              p25p2_active_target(state, 1U));
     p25p2_ess_maybe_enable_audio_slot(opts, state, 1, state->payload_algidR);
+    p25p2_audio_gate_diag(opts, state, "ess-slot1");
 
     if (state->payload_algidR == 0x80 || state->payload_algidR == 0x0) {
         return;

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -923,13 +923,20 @@ p25p2_increment_fourv_counter(dsd_state* state) {
     }
 }
 
+// Wrap only the slot this burst writes. The output stage resets both counters
+// after playback, so a companion counter sitting at a full 18 is a completed
+// superframe still waiting for the next odd-boundary output check — zeroing it
+// here discards it unplayed. With a muted lockout call occupying the other
+// slot, that companion burst runs this reset between the clear slot's
+// superframe completing and the output boundary that would have played it,
+// silencing the clear call for its entire transmission; an idle companion
+// (no voice bursts) never triggered it, which is why only shared-channel
+// calls lost audio.
 static void
 p25p2_reset_voice_counters_if_needed(dsd_state* state) {
-    if (state->voice_counter[0] >= 18) {
-        state->voice_counter[0] = 0;
-    }
-    if (state->voice_counter[1] >= 18) {
-        state->voice_counter[1] = 0;
+    const int slot = state->currentslot;
+    if ((slot == 0 || slot == 1) && state->voice_counter[slot] >= 18) {
+        state->voice_counter[slot] = 0;
     }
 }
 

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -795,7 +795,8 @@ p25p2_active_target(const dsd_state* state, uint8_t slot) {
 // stream. The gate decides whether a slot's vocoder output lands in the
 // playback buffers at all, so a flip between mixer passes is invisible to the
 // mixer trace except as silence; this catches it at the decode chokepoints
-// with the state that drove it. Logged only on change.
+// with the state that drove it. Logged only on change. Function-local
+// statics: single instance, decoder thread only, like the decode path.
 static void
 p25p2_audio_gate_diag(dsd_opts* opts, const dsd_state* state, const char* at) {
     if (!dsd_p25_sm_log_enabled(opts)) {

--- a/tests/core/test_core_audio2_helpers.c
+++ b/tests/core/test_core_audio2_helpers.c
@@ -26,6 +26,7 @@
 #include "core/audio/dsd_audio_internal.h"
 #include "dsd-neo/core/audio.h"
 #include "dsd-neo/core/audio_filters.h"
+#include "dsd-neo/core/file_io.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -39,6 +40,20 @@
 void
 dsd_neo_log_write(dsd_neo_log_level_t level, const char* format, ...) {
     (void)level;
+    (void)format;
+}
+
+// The mixer's decision-trace diagnostic writes through the P25 SM log; these
+// helpers link dsd_audio2.c standalone, so stub it disabled.
+int
+dsd_p25_sm_log_enabled(const dsd_opts* opts) {
+    (void)opts;
+    return 0;
+}
+
+void
+dsd_p25_sm_logf(dsd_opts* opts, const char* format, ...) {
+    (void)opts;
     (void)format;
 }
 

--- a/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
+++ b/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
@@ -671,6 +671,48 @@ test_enc_key_identity_change_reemits_lockout(void) {
     return rc;
 }
 
+// SS18 playback triggers when either slot's voice counter completes a full
+// 18-frame superframe, checked only at odd-timeslot output boundaries. A
+// companion voice burst (the muted lockout call) runs between the clear
+// slot's superframe completing and that boundary; its per-burst counter wrap
+// must not zero the clear slot's completed-but-unplayed superframe, or the
+// clear call plays nothing for its entire transmission. The wrap still
+// applies to the burst's own slot.
+static int
+test_companion_voice_burst_preserves_clear_superframe(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    setup_tuned_tdma(&opts, &state, &ctx);
+
+    int rc = 0;
+
+    // Slot 0's clear superframe is complete and awaiting the output boundary;
+    // slot 1 carries the muted locked-out call (BLOCKED, gate closed) and its
+    // burst arrives first.
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_CLEAR;
+    state.p25_p2_audio_allowed[0] = 1;
+    state.p25_crypto_state[1] = DSD_P25_CRYPTO_BLOCKED;
+    state.p25_p2_audio_allowed[1] = 0;
+    state.voice_counter[0] = 18;
+    state.voice_counter[1] = 3;
+    state.currentslot = 1;
+
+    process_2V(&opts, &state);
+    rc |= expect_eq("companion burst: clear superframe preserved", state.voice_counter[0], 18);
+    rc |= expect_eq("companion burst: muted counter frozen", state.voice_counter[1], 3);
+
+    // The wrap still applies to the slot the burst writes: a full counter on
+    // the burst's own slot wraps before its frames store.
+    state.voice_counter[1] = 18;
+    process_2V(&opts, &state);
+    rc |= expect_eq("own slot: full counter wrapped", state.voice_counter[1], 0);
+    rc |= expect_eq("own slot: clear superframe still preserved", state.voice_counter[0], 18);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 // The suppress note must not invent liveness: with no prior lockout action on
 // the slot (no suppression stamp), it leaves the stamp unarmed and only
 // re-asserts the closed gate.
@@ -709,6 +751,7 @@ main(void) {
     rc |= test_facch_double_end_holds_channel_while_companion_enc_suppressed();
     rc |= test_enc_blocked_repeat_edge_triggered_tick_owns_release();
     rc |= test_enc_key_identity_change_reemits_lockout();
+    rc |= test_companion_voice_burst_preserves_clear_superframe();
     rc |= test_note_enc_suppressed_requires_prior_suppression();
     return rc;
 }

--- a/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
+++ b/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
@@ -488,6 +488,68 @@ test_enc_lockout_idle_companion_still_releases(void) {
     return rc;
 }
 
+// The FACCH double-END fast release infers "channel closing" from an
+// otherwise idle companion slot, but encryption lockout erases the suppressed
+// call's assignment, epoch, and audio gate -- everything that check reads --
+// while the site keeps transmitting the locked-out call on the carrier. A
+// double END from the clear conversation must hold the channel while the
+// companion's suppression stamp is fresh, and must still release once the
+// stamp outlives the hangtime.
+static int
+test_facch_double_end_holds_channel_while_companion_enc_suppressed(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    setup_tuned_tdma(&opts, &state, &ctx);
+    ctx->config.hangtime_s = 2.0;
+    state.event_history_s = calloc(2, sizeof(Event_History_I));
+    if (state.event_history_s == NULL) {
+        return 1;
+    }
+    for (int i = 0; i < 2; i++) {
+        init_event_history(&state.event_history_s[i], 0, 255);
+    }
+    g_return_to_cc_called = 0;
+
+    int rc = 0;
+
+    // Clear transmission decoding on slot 0.
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_CLEAR;
+    rc |= expect_eq("clear voice start accepted", p25_sm_emit_active_call(&opts, &state, 0, 1234, 0, 42, 1, 0x00), 1);
+    state.p25_p2_audio_allowed[0] = 1;
+
+    // Slot 1 carries the locked-out encrypted call: its ESS classifies BLOCKED
+    // and the lockout action erases the slot's assignment and audio trace,
+    // leaving only the suppression stamp as evidence the carrier is occupied.
+    (void)p25_crypto_resolve(&opts, &state, DSD_P25_CRYPTO_PHASE2, 1, 0x84, 0x2710, 0x1111222233334444ULL, 5678);
+    rc |= expect_eq("companion suppressed: still tuned", ctx->state == P25_SM_TUNED, 1);
+    rc |= expect_eq("companion suppressed: stamp recorded", ctx->slots[1].last_enc_suppress_m > 0.0, 1);
+
+    // The clear talker un-keys; the FACCH END repeat lands 0.2 s later while
+    // the locked-out call is still transmitting. Reading that repeat as the
+    // channel closing would bounce to the CC and clip the conversation's next
+    // over, which the site re-grants on this same channel moments later.
+    const double end_m = dsd_time_now_monotonic_s();
+    rc |= expect_eq("first facch end applied", p25_sm_emit_facch_end_call_at(&opts, &state, 0, 1234, 42, end_m),
+                    P25_SM_END_APPLIED);
+    state.p25_p2_audio_allowed[0] = 0;
+    (void)p25_sm_emit_facch_end_call_at(&opts, &state, 0, 1234, 42, end_m + 0.2);
+    rc |= expect_eq("double end inside suppression: still tuned", ctx->state == P25_SM_TUNED, 1);
+    rc |= expect_eq("double end inside suppression: no cc return", g_return_to_cc_called, 0);
+    rc |= expect_eq("double end inside suppression: tuner still on vc", opts.trunk_is_tuned, 1);
+
+    // Once the suppression stamp outlives the hangtime -- the locked-out call
+    // stopped repeating -- the same double END releases as before.
+    ctx->slots[1].last_enc_suppress_m = end_m - (ctx->config.hangtime_s + 1.0);
+    (void)p25_sm_emit_facch_end_call_at(&opts, &state, 0, 1234, 42, end_m + 0.4);
+    rc |= expect_eq("double end past suppression: released to cc", g_return_to_cc_called, 1);
+
+    dsd_state_ext_free_all(&state);
+    free(state.event_history_s);
+    state.event_history_s = NULL;
+    return rc;
+}
+
 int
 main(void) {
     install_trunk_tuning_hooks();
@@ -503,5 +565,6 @@ main(void) {
     rc |= test_new_transmission_without_grant_revalidation_stays_pending();
     rc |= test_enc_repeat_holds_channel_through_companion_hangtime();
     rc |= test_enc_lockout_idle_companion_still_releases();
+    rc |= test_facch_double_end_holds_channel_while_companion_enc_suppressed();
     return rc;
 }

--- a/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
+++ b/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
@@ -387,13 +387,14 @@ test_new_transmission_without_grant_revalidation_stays_pending(void) {
     return rc;
 }
 
-// A locked-out encrypted call re-runs its stay-or-release decision on every
-// FEC-accepted ESS repeat (~once per superframe). The companion's clear
-// conversation is a series of transmissions with gaps that MAC_END opens by
-// clearing voice_active and the audio gate -- the exact state the
-// retains-carrier check reads as "inactive". The hangtime window owns those
-// gaps: a repeat inside it must hold the channel, a repeat after it lapses
-// must still release.
+// Every delivered ENC event re-runs the lockout's stay-or-release decision.
+// The crypto layer now edge-triggers delivery, but transitions (a new
+// transmission's first BLOCKED resolve, a key-identity change) still land
+// mid-conversation. The companion's clear conversation is a series of
+// transmissions with gaps that MAC_END opens by clearing voice_active and the
+// audio gate -- the exact state the retains-carrier check reads as
+// "inactive". The hangtime window owns those gaps: an event inside it must
+// hold the channel, an event after it lapses must still release.
 static int
 test_enc_repeat_holds_channel_through_companion_hangtime(void) {
     static dsd_opts opts;
@@ -550,6 +551,146 @@ test_facch_double_end_holds_channel_while_companion_enc_suppressed(void) {
     return rc;
 }
 
+// The crypto layer edge-triggers the ENC event on the classification
+// transition: a FEC-accepted ESS repeat of an already-BLOCKED Phase 2 slot
+// under lockout refreshes the suppression stamp instead of re-running the full
+// lockout action, so it never revisits stay-or-release -- even when the
+// companion's gap has outlived the hangtime. Releasing that emptied channel is
+// the hangtime tick's job.
+static int
+test_enc_blocked_repeat_edge_triggered_tick_owns_release(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    setup_tuned_tdma(&opts, &state, &ctx);
+    ctx->config.hangtime_s = 2.0;
+    state.event_history_s = calloc(2, sizeof(Event_History_I));
+    if (state.event_history_s == NULL) {
+        return 1;
+    }
+    for (int i = 0; i < 2; i++) {
+        init_event_history(&state.event_history_s[i], 0, 255);
+    }
+    g_return_to_cc_called = 0;
+
+    int rc = 0;
+
+    // Clear transmission decoding on slot 0.
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_CLEAR;
+    rc |= expect_eq("clear voice start accepted", p25_sm_emit_active_call(&opts, &state, 0, 1234, 0, 42, 1, 0x00), 1);
+    state.p25_p2_audio_allowed[0] = 1;
+
+    // First BLOCKED resolve is the transition: the full lockout action runs
+    // and arms the suppression stamp; the active companion holds the channel.
+    (void)p25_crypto_resolve(&opts, &state, DSD_P25_CRYPTO_PHASE2, 1, 0x84, 0x2710, 0x1111222233334444ULL, 5678);
+    rc |= expect_eq("transition: slot1 blocked", state.p25_crypto_state[1] == DSD_P25_CRYPTO_BLOCKED, 1);
+    rc |= expect_eq("transition: no cc return", g_return_to_cc_called, 0);
+    const double stamp0 = ctx->slots[1].last_enc_suppress_m;
+    rc |= expect_eq("transition: suppression stamp armed", stamp0 > 0.0, 1);
+
+    // A same-identity repeat refreshes the stamp -- the liveness signal the
+    // FACCH double-END hold reads -- without re-running the lockout action.
+    ctx->slots[1].last_enc_suppress_m = stamp0 - 5.0;
+    (void)p25_crypto_resolve(&opts, &state, DSD_P25_CRYPTO_PHASE2, 1, 0x84, 0x2710, 0x1111222233334444ULL, 5678);
+    rc |= expect_eq("repeat: stamp refreshed", ctx->slots[1].last_enc_suppress_m >= stamp0, 1);
+    rc |= expect_eq("repeat: gate stays closed", state.p25_p2_audio_allowed[1], 0);
+    rc |= expect_eq("repeat: still tuned", ctx->state == P25_SM_TUNED, 1);
+
+    // The clear talker un-keys and the conversation ends for good; age the
+    // slot history and the armed hangtime start past the window.
+    rc |= expect_eq("clear transmission end accepted",
+                    p25_sm_emit_end_call_at(&opts, &state, 0, 1234, 42, dsd_time_now_monotonic_s()), 1);
+    state.p25_p2_audio_allowed[0] = 0;
+    const double past_stop_m = dsd_time_now_monotonic_s() - (ctx->config.hangtime_s + 1.0);
+    ctx->slots[0].last_start_m = past_stop_m - 1.0;
+    ctx->slots[0].last_grant_m = past_stop_m - 1.0;
+    ctx->slots[0].last_stop_m = past_stop_m;
+    ctx->t_hangtime_m = past_stop_m;
+
+    // Pre-fix, this repeat re-ran the lockout action and released the channel
+    // itself. Edge-triggered, it only refreshes the stamp.
+    (void)p25_crypto_resolve(&opts, &state, DSD_P25_CRYPTO_PHASE2, 1, 0x84, 0x2710, 0x1111222233334444ULL, 5678);
+    rc |= expect_eq("aged repeat: no release from the repeat", g_return_to_cc_called, 0);
+    rc |= expect_eq("aged repeat: still tuned", ctx->state == P25_SM_TUNED, 1);
+
+    // The hangtime tick sees an inactive channel whose window lapsed and
+    // releases it.
+    p25_sm_tick_ctx(ctx, &opts, &state);
+    rc |= expect_eq("hangtime tick: released to cc", g_return_to_cc_called, 1);
+
+    dsd_state_ext_free_all(&state);
+    free(state.event_history_s);
+    state.event_history_s = NULL;
+    return rc;
+}
+
+// A key-identity change on an already-BLOCKED slot is a transition, not a
+// repeat: the full ENC event re-fires and its stay-or-release decision sees
+// the companion's lapsed gap, releasing immediately.
+static int
+test_enc_key_identity_change_reemits_lockout(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    setup_tuned_tdma(&opts, &state, &ctx);
+    ctx->config.hangtime_s = 2.0;
+    state.event_history_s = calloc(2, sizeof(Event_History_I));
+    if (state.event_history_s == NULL) {
+        return 1;
+    }
+    for (int i = 0; i < 2; i++) {
+        init_event_history(&state.event_history_s[i], 0, 255);
+    }
+    g_return_to_cc_called = 0;
+
+    int rc = 0;
+
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_CLEAR;
+    rc |= expect_eq("clear voice start accepted", p25_sm_emit_active_call(&opts, &state, 0, 1234, 0, 42, 1, 0x00), 1);
+    state.p25_p2_audio_allowed[0] = 1;
+
+    (void)p25_crypto_resolve(&opts, &state, DSD_P25_CRYPTO_PHASE2, 1, 0x84, 0x2710, 0x1111222233334444ULL, 5678);
+    rc |= expect_eq("transition: no cc return", g_return_to_cc_called, 0);
+
+    rc |= expect_eq("clear transmission end accepted",
+                    p25_sm_emit_end_call_at(&opts, &state, 0, 1234, 42, dsd_time_now_monotonic_s()), 1);
+    state.p25_p2_audio_allowed[0] = 0;
+    const double past_stop_m = dsd_time_now_monotonic_s() - (ctx->config.hangtime_s + 1.0);
+    ctx->slots[0].last_start_m = past_stop_m - 1.0;
+    ctx->slots[0].last_grant_m = past_stop_m - 1.0;
+    ctx->slots[0].last_stop_m = past_stop_m;
+
+    // Same ALGID, new KID: not a repeat. The re-fired lockout action finds the
+    // companion's gap lapsed and releases.
+    (void)p25_crypto_resolve(&opts, &state, DSD_P25_CRYPTO_PHASE2, 1, 0x84, 0x2711, 0x1111222233334444ULL, 5678);
+    rc |= expect_eq("identity change: released to cc", g_return_to_cc_called, 1);
+
+    dsd_state_ext_free_all(&state);
+    free(state.event_history_s);
+    state.event_history_s = NULL;
+    return rc;
+}
+
+// The suppress note must not invent liveness: with no prior lockout action on
+// the slot (no suppression stamp), it leaves the stamp unarmed and only
+// re-asserts the closed gate.
+static int
+test_note_enc_suppressed_requires_prior_suppression(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    setup_tuned_tdma(&opts, &state, &ctx);
+
+    state.p25_p2_audio_allowed[1] = 1;
+    p25_sm_note_enc_suppressed(&opts, &state, 1);
+
+    int rc = 0;
+    rc |= expect_eq("no prior suppression: stamp stays unarmed", ctx->slots[1].last_enc_suppress_m <= 0.0, 1);
+    rc |= expect_eq("no prior suppression: gate closed", state.p25_p2_audio_allowed[1], 0);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
 int
 main(void) {
     install_trunk_tuning_hooks();
@@ -566,5 +707,8 @@ main(void) {
     rc |= test_enc_repeat_holds_channel_through_companion_hangtime();
     rc |= test_enc_lockout_idle_companion_still_releases();
     rc |= test_facch_double_end_holds_channel_while_companion_enc_suppressed();
+    rc |= test_enc_blocked_repeat_edge_triggered_tick_owns_release();
+    rc |= test_enc_key_identity_change_reemits_lockout();
+    rc |= test_note_enc_suppressed_requires_prior_suppression();
     return rc;
 }

--- a/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
+++ b/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
@@ -9,16 +9,20 @@
  */
 
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/events.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/platform/sockets.h>
+#include <dsd-neo/protocol/p25/p25_crypto.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -383,6 +387,107 @@ test_new_transmission_without_grant_revalidation_stays_pending(void) {
     return rc;
 }
 
+// A locked-out encrypted call re-runs its stay-or-release decision on every
+// FEC-accepted ESS repeat (~once per superframe). The companion's clear
+// conversation is a series of transmissions with gaps that MAC_END opens by
+// clearing voice_active and the audio gate -- the exact state the
+// retains-carrier check reads as "inactive". The hangtime window owns those
+// gaps: a repeat inside it must hold the channel, a repeat after it lapses
+// must still release.
+static int
+test_enc_repeat_holds_channel_through_companion_hangtime(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    setup_tuned_tdma(&opts, &state, &ctx);
+    // The zeroed opts request hangtime 0 (immediate release); this case is
+    // about the window itself, so give it the stock op25-aligned value.
+    ctx->config.hangtime_s = 2.0;
+    state.event_history_s = calloc(2, sizeof(Event_History_I));
+    if (state.event_history_s == NULL) {
+        return 1;
+    }
+    for (int i = 0; i < 2; i++) {
+        init_event_history(&state.event_history_s[i], 0, 255);
+    }
+    g_return_to_cc_called = 0;
+
+    int rc = 0;
+
+    // Clear transmission decoding on slot 0.
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_CLEAR;
+    rc |= expect_eq("clear voice start accepted", p25_sm_emit_active_call(&opts, &state, 0, 1234, 0, 42, 1, 0x00), 1);
+    state.p25_p2_audio_allowed[0] = 1;
+
+    // The slot-1 ESS classifies BLOCKED and the lockout action runs; the
+    // active companion holds the channel.
+    (void)p25_crypto_resolve(&opts, &state, DSD_P25_CRYPTO_PHASE2, 1, 0x84, 0x2710, 0x1111222233334444ULL, 5678);
+    rc |= expect_eq("companion active: slot1 blocked", state.p25_crypto_state[1] == DSD_P25_CRYPTO_BLOCKED, 1);
+    rc |= expect_eq("companion active: still tuned", ctx->state == P25_SM_TUNED, 1);
+    rc |= expect_eq("companion active: no cc return", g_return_to_cc_called, 0);
+
+    // The clear talker un-keys; the conversation gap opens well inside the
+    // hangtime window.
+    rc |= expect_eq("clear transmission end accepted",
+                    p25_sm_emit_end_call_at(&opts, &state, 0, 1234, 42, dsd_time_now_monotonic_s()), 1);
+    state.p25_p2_audio_allowed[0] = 0;
+
+    // The locked-out call's next ESS repeat re-runs the lockout action inside
+    // the companion's gap. It must not tear the channel down.
+    p25_sm_emit_enc(&opts, &state, 1, 0x84, 0x2710, 5678);
+    rc |= expect_eq("gap inside hangtime: still tuned", ctx->state == P25_SM_TUNED, 1);
+    rc |= expect_eq("gap inside hangtime: no cc return", g_return_to_cc_called, 0);
+    rc |= expect_eq("gap inside hangtime: tuner still on vc", opts.trunk_is_tuned, 1);
+
+    // Once the companion's gap outlives the hangtime, the repeat releases.
+    // Age the whole slot history together: a grant newer than the stop is a
+    // pending assignment and retains the carrier on its own.
+    const double past_stop_m = dsd_time_now_monotonic_s() - (ctx->config.hangtime_s + 1.0);
+    ctx->slots[0].last_start_m = past_stop_m - 1.0;
+    ctx->slots[0].last_grant_m = past_stop_m - 1.0;
+    ctx->slots[0].last_stop_m = past_stop_m;
+    p25_sm_emit_enc(&opts, &state, 1, 0x84, 0x2710, 5678);
+    rc |= expect_eq("gap past hangtime: released to cc", g_return_to_cc_called, 1);
+
+    dsd_state_ext_free_all(&state);
+    free(state.event_history_s);
+    state.event_history_s = NULL;
+    return rc;
+}
+
+// The lockout release for a carrier whose companion never carried a call (no
+// recorded stop) keeps its immediate release: nothing is waiting out a gap.
+static int
+test_enc_lockout_idle_companion_still_releases(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    setup_tuned_tdma(&opts, &state, &ctx);
+    // Nonzero hangtime proves the release below is not the zero-window case.
+    ctx->config.hangtime_s = 2.0;
+    state.event_history_s = calloc(2, sizeof(Event_History_I));
+    if (state.event_history_s == NULL) {
+        return 1;
+    }
+    for (int i = 0; i < 2; i++) {
+        init_event_history(&state.event_history_s[i], 0, 255);
+    }
+    g_return_to_cc_called = 0;
+
+    // Slot 0 idle with no assignment or call history.
+    ctx->slots[0].grant_active = 0;
+
+    (void)p25_crypto_resolve(&opts, &state, DSD_P25_CRYPTO_PHASE2, 1, 0x84, 0x2710, 0x1111222233334444ULL, 5678);
+
+    int rc = 0;
+    rc |= expect_eq("idle companion: released to cc", g_return_to_cc_called, 1);
+
+    dsd_state_ext_free_all(&state);
+    free(state.event_history_s);
+    state.event_history_s = NULL;
+    return rc;
+}
+
 int
 main(void) {
     install_trunk_tuning_hooks();
@@ -396,5 +501,7 @@ main(void) {
     rc |= test_encrypted_follow_tracks_activity_while_media_is_muted();
     rc |= test_new_transmission_inherits_fresh_clear_grant_service();
     rc |= test_new_transmission_without_grant_revalidation_stays_pending();
+    rc |= test_enc_repeat_holds_channel_through_companion_hangtime();
+    rc |= test_enc_lockout_idle_companion_still_releases();
     return rc;
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "dsd-neo",
-  "version-string": "2.6.0",
+  "version-string": "2.6.1",
   "builtin-baseline": "cd61e1e26a038e82d6550a3ebbe0fbbfe7da78e3",
   "description": "Digital Speech Decoder: DSD-neo",
   "homepage": "https://github.com/arancormonk/dsd-neo",


### PR DESCRIPTION
## Problem

With encryption lockout enabled and a locked-out encrypted call on one TDMA slot, the clear conversation on the other slot kept getting interrupted: the channel tore down around talker changes, the locked-out slot's ALG/KID banner flashed on and off, and — worst — a clear transmission sharing the channel with the encrypted call could play **no audio at all** for its entire duration, with only a short blip at call end.

Field debugging with `--p25-sm-log` (and the audio-path tracing this branch adds) found four cooperating mechanisms. Each commit fixes one, and each fix was validated against a live capture before moving to the next.

## Fixes

**1. Hold the enc-lockout release through the companion's hangtime gap** (`11e27d84`)

`p25_crypto_apply_resolution()` emits the ENC event on every FEC-accepted ESS repeat while a slot stays BLOCKED, so the lockout action re-ran its stay-or-release decision ~once per superframe. The decision used an instantaneous companion check, and a clear conversation is a series of transmissions with gaps that MAC_END_PTT opens by clearing `voice_active` and the audio gate — exactly the state the retains-carrier check reads as "inactive". Within one ESS repeat of every un-key the channel released with reason `enc-lockout`, bypassing the hangtime entirely; every following transmission needed a fresh CC grant and retune.

Now the release holds while the companion sits inside the effective hangtime of its own `last_stop_m`. The global hangtime timer cannot serve here — the locked-out slot's suppressed voice starts re-arm it — so the companion slot's own stop timestamp decides. A companion with no recorded stop keeps the immediate release, and the policy-reject path keeps its immediate release for an ended companion.

**2. Hold the FACCH double-END fast release while lockout suppresses the companion** (`3d1afc14`)

Second mechanism, same symptom: the lockout action tears down the suppressed call's assignment, epoch, and audio gate — everything `p25_facch_all_slots_inactive()` reads — so a FACCH double-END from the clear conversation read the carrier as closing while the site was still transmitting the locked-out call on it, fast-releasing ~120 ms after every un-key. The lockout action now stamps `last_enc_suppress_m` per repeat; the double-END fast path holds while the companion's stamp is fresh within the effective hangtime and falls through to the normal END path. A stale stamp re-arms the fast path, and the hangtime tick still releases a genuinely emptied channel.

**3. Edge-trigger the ENC event on the crypto classification transition** (`191b097f`)

With the releases held, the per-repeat lockout action was still churning at ~3 Hz for the life of every locked-out transmission: re-ending the canonical call, clearing the slot's burst hint, re-syncing its event row, and revisiting stay-or-release. Under lockout a same-identity BLOCKED repeat carries no new information — MAC_END/MAC_IDLE reset the classification, so every transmission's first BLOCKED resolve is a transition — but it is the liveness proof the FACCH hold consumes.

The full ENC event now fires only on the classification transition (state or key-identity change). A Phase 2 same-identity BLOCKED repeat under lockout with trunking active instead calls the new `p25_sm_note_enc_suppressed()`, which refreshes the suppression stamp and re-asserts the closed gate — no teardown, no stay-or-release. Releasing an emptied channel becomes the hangtime tick's job, and it fires at the same instant the boundary repeat used to. Phase 1 keeps per-repeat emission (its identity-pending lockout relies on a later repeat), as do follow mode and non-trunked runs (repeats re-publish crypto metadata).

**4. Trace P25p2 mixer and audio-gate decisions into the SM log** (`01bc4084`)

With the trunk SM provably clean, the remaining silence had to live in the audio path — which nothing recorded. Two change-triggered traces now write into the `--p25-sm-log` stream, interleaved with the SM's events on the decoder thread's single timeline: `event=audio_mix` (both P25p2 mixers: final per-ear mute flags, copy direction, and every input feeding them, plus a `run=` invocation counter outside the change vector that distinguishes "ran steadily" from "never ran") and `event=audio_gate` (decode-side gate transitions with the crypto/media-rejection/burst state that drove them). One comparison per pass when enabled, nothing when off.

**5. Keep a companion voice burst from discarding an unplayed clear superframe** (`052038fd`) — the actual audio silencer

The new trace showed the SS18 mixer never ran a full superframe during a shared-channel clear transmission — only the short end-of-call flush played — while clear-only transmissions mixed normally. SS18 playback triggers when either slot's voice counter completes a full 18-frame superframe, checked only at odd-timeslot output boundaries; `p25p2_reset_voice_counters_if_needed()` ran at the top of **every** voice burst and zeroed **both** slots' counters at ≥ 18. A clear call on slot 0 completes its superframe at an even boundary; the muted companion's next burst on slot 1 then zeroed that completed-but-unplayed superframe before the odd-boundary check could see it — every superframe, for the whole transmission. An idle companion produces no voice bursts and never triggered it (clear-only channels were fine), and a clear call on slot 1 completes right before the odd boundary and escapes — making the failure orientation-dependent and intermittent across sessions.

The reset now wraps only the slot the current burst writes; a companion counter sitting at a full 18 survives to playback, which still resets both counters afterward.

## Testing

- New regressions in `P25_P2_FRAME_LOCKOUT_SM`, each confirmed failing against its pre-fix code:
  - ENC repeat inside the companion's post-END gap holds the channel; aging the companion's history past the hangtime releases (fix 1);
  - a lockout with a companion that never carried a call still releases immediately (fix 1);
  - FACCH double-END holds while the companion's suppression stamp is fresh and releases once it ages out (fix 2);
  - an aged-out companion no longer releases from the ESS repeat itself — the hangtime tick releases the emptied channel; a key-identity change still re-fires the full action; the suppress note cannot invent liveness for an unarmed slot (fix 3);
  - a companion 2V burst against a completed clear superframe preserves the counter while still wrapping its own slot (fix 5, failing pre-fix at "clear superframe preserved: got 0 want 18").
- Full suite: 507/507 pass.
- `tools/preflight_ci.sh` clean (clang-format, gersemi, clang-tidy, cppcheck, IWYU, semgrep, lizard, etc.).
- Each stage validated against live captures of the affected system (`--p25-sm-log`), including the shared-channel enc+clear case that motivated the branch.
