### PR TITLE
android: keep the call log on the latest call, and say when it is not

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -262,9 +262,19 @@ jobs:
       - name: Verify the Qt UI tests are registered
         shell: bash
         run: |
-          set -euxo pipefail
+          set -euo pipefail
           ctest --preset dev-debug -N -L qml | grep -F "UI_QT_QML_CALL_LISTS"
-          ctest --preset dev-debug -N -R '^UI_QT_' | grep -F "Total Tests: 7"
+          # A floor, not an exact count. publish-apk gates on this job, so pinning
+          # the count would fail the release for the act of adding a UI test —
+          # and fail it saying only that a grep matched nothing. Registration
+          # going backwards, which is what this guards, still fails here.
+          min=7
+          registered=$(ctest --preset dev-debug -N -R '^UI_QT_' | sed -n 's/^Total Tests: *//p')
+          echo "UI_QT_* tests registered: ${registered:-none} (floor $min)"
+          if [ "${registered:-0}" -lt "$min" ]; then
+            echo "::error::expected at least $min UI_QT_* tests, found ${registered:-0}"
+            exit 1
+          fi
 
       - name: Build the Qt UI test targets
         shell: bash

--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -132,6 +132,164 @@ jobs:
         shell: bash
         run: ccache --show-stats
 
+  # The app's UI is QML, which the arm64 APK job can build but cannot run. This
+  # job configures the same frontend for the host with the same pinned Qt the APK
+  # ships, and runs the Qt Quick Test suite over the real .qml files plus the Qt
+  # model tests that are otherwise registered only behind DSD_ENABLE_QT_UI and so
+  # have never run anywhere in CI. Only the frontend's test targets are built:
+  # they do not link the decoder, so this stays a short job.
+  qt-ui-tests:
+    name: Qt UI tests (host Qt)
+    runs-on: ubuntu-latest
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Read pinned toolchain versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          source tools/ci-dependency-pins.env
+          echo "ANDROID_QT_VERSION=$ANDROID_QT_VERSION" >> "$GITHUB_ENV"
+
+      # The project's own dependencies, plus the handful of runtime libraries
+      # Qt Gui links even when the platform plugin is offscreen.
+      - name: Install build dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake ninja-build ccache pkg-config git \
+            libsndfile1-dev libpulse-dev libncurses-dev \
+            libusb-1.0-0-dev libfftw3-dev libblas-dev liblapack-dev gfortran \
+            libcodec2-dev librtlsdr-dev libsoapysdr-dev libcurl4-openssl-dev \
+            libgl1-mesa-dev libegl1 libxkbcommon0 libfontconfig1 libdbus-1-3
+
+      - name: Build and install mbelib-neo
+        shell: bash
+        run: |
+          set -euxo pipefail
+          source tools/ci-dependency-pins.env
+          tools/fetch-pinned-git.sh https://github.com/arancormonk/mbelib-neo "$MBELIB_NEO_SHA" /tmp/mbelib-neo
+          cmake -S /tmp/mbelib-neo -B /tmp/mbelib-neo/build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
+            -DCMAKE_INSTALL_PREFIX="$HOME/.local"
+          cmake --build /tmp/mbelib-neo/build -j
+          cmake --install /tmp/mbelib-neo/build
+
+      # Qt is installed with aqtinstall rather than a Qt-installing action: every
+      # action used here must be hash-pinned, transitively, and the available
+      # actions are not.
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: .github/requirements/aqtinstall.txt
+
+      - name: Record the Qt location
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/qt"
+          {
+            echo "QT_INSTALL_ROOT=$root"
+            echo "QT_HOST_ROOT=$root/$ANDROID_QT_VERSION/gcc_64"
+          } >> "$GITHUB_ENV"
+
+      - name: Restore Qt
+        id: qt-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.QT_INSTALL_ROOT }}
+          key: qt-host-${{ env.ANDROID_QT_VERSION }}-linux-aqt3.3.0
+
+      - name: Install Qt (host kit)
+        if: steps.qt-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python -m pip install --require-hashes -r .github/requirements/aqtinstall.txt
+          aqt install-qt linux desktop "$ANDROID_QT_VERSION" linux_gcc_64 -O "$QT_INSTALL_ROOT"
+
+      - name: Verify the Qt kit
+        shell: bash
+        run: |
+          set -euxo pipefail
+          test -x "$QT_HOST_ROOT/bin/qmake"
+          test -f "$QT_HOST_ROOT/lib/cmake/Qt6QuickTest/Qt6QuickTestConfig.cmake"
+
+      - name: Prepare the local dependency environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig:$HOME/.local/lib64/pkgconfig:${PKG_CONFIG_PATH:-}"
+            echo "CMAKE_PREFIX_PATH=$HOME/.local:$QT_HOST_ROOT:${CMAKE_PREFIX_PATH:-}"
+            echo "LD_LIBRARY_PATH=$HOME/.local/lib:$HOME/.local/lib64:${LD_LIBRARY_PATH:-}"
+          } >> "$GITHUB_ENV"
+
+      - name: Restore ccache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-qt-ui-tests-${{ env.ANDROID_QT_VERSION }}-${{ github.sha }}
+          restore-keys: |
+            ccache-qt-ui-tests-${{ env.ANDROID_QT_VERSION }}-
+
+      - name: Initialize ccache
+        shell: bash
+        run: |
+          set -euxo pipefail
+          ccache --zero-stats
+          ccache --set-config=max_size=200M
+          ccache --set-config=compression=true
+
+      - name: Configure (dev-debug, Qt frontend on)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cmake --preset dev-debug \
+            -DDSD_ENABLE_QT_UI=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      # A Qt frontend that stops registering its tests would otherwise read as a
+      # green run with nothing in it.
+      - name: Verify the Qt UI tests are registered
+        shell: bash
+        run: |
+          set -euxo pipefail
+          ctest --preset dev-debug -N -L qml | grep -F "UI_QT_QML_CALL_LISTS"
+          ctest --preset dev-debug -N -R '^UI_QT_' | grep -F "Total Tests: 7"
+
+      - name: Build the Qt UI test targets
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cmake --build --preset dev-debug -j \
+            --target dsd-neo_test_ui_qt_qml \
+            dsd-neo_test_ui_qt_persistence \
+            dsd-neo_test_ui_qt_call_history_model \
+            dsd-neo_test_ui_qt_session_args \
+            dsd-neo_test_ui_qt_call_history_merge \
+            dsd-neo_test_ui_qt_call_line \
+            dsd-neo_test_ui_qt_session_state
+
+      # The QML test carries its own headless environment (offscreen platform,
+      # software renderer) in the CTest registration, so there is nothing to set
+      # here — a developer running ctest locally gets the same run.
+      - name: Test
+        shell: bash
+        run: ctest --preset dev-debug -R '^UI_QT_' --output-on-failure
+
+      - name: Show ccache stats
+        shell: bash
+        run: ccache --show-stats
+
   build-apk:
     name: APK (Qt Quick app)
     runs-on: ubuntu-latest

--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -686,7 +686,11 @@ jobs:
 
   publish-apk:
     name: Publish APK
-    needs: build-apk
+    # Also gated on the UI tests: the APK job proves the QML compiles and packages,
+    # not that the app's screens behave, and a release is the wrong place to find
+    # that out. The cost is that a failure to install the host Qt kit blocks a
+    # publish until it is re-run.
+    needs: [build-apk, qt-ui-tests]
     runs-on: ubuntu-latest
     # An unsigned APK cannot be installed, so a build that could not sign
     # publishes nothing rather than shipping a broken download.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,6 +68,26 @@ Known gaps and caveats:
   depend on wall-clock call-state timers, because `fast` replay compresses them;
   use `--iq-replay-rate realtime` for that.
 
+### Qt frontend and QML screen tests
+
+The `UI_QT_*` cases register only under `-DDSD_ENABLE_QT_UI=ON`. Most of them
+link `Qt6::Core` alone and run anywhere Qt 6 is installed. `UI_QT_QML_CALL_LISTS`
+(CTest label `qml`) is the exception: it drives the real `.qml` screens through Qt
+Quick Test, so it also needs the **QuickTest** module — both its CMake package
+and its QML plugin, which Debian and Ubuntu package separately as
+`qml6-module-qttest`. Both are probed, and the test is left unregistered with a
+configure-time `STATUS` message when either is missing, rather than failing the
+whole project's configure step.
+
+```sh
+cmake --preset dev-debug -DDSD_ENABLE_QT_UI=ON
+cmake --build --preset dev-debug -j --target dsd-neo_test_ui_qt_qml
+ctest --preset dev-debug -L qml --output-on-failure
+```
+
+It carries its own headless environment (offscreen platform, software renderer)
+in the CTest registration, so it needs no window server and no GPU.
+
 ## Continuous Integration
 
 GitHub Actions runs tests and quality checks on pull requests, primary-branch

--- a/include/dsd-neo/core/call_state.h
+++ b/include/dsd-neo/core/call_state.h
@@ -11,6 +11,7 @@
 #ifndef DSD_NEO_INCLUDE_DSD_NEO_CORE_CALL_STATE_H_H
 #define DSD_NEO_INCLUDE_DSD_NEO_CORE_CALL_STATE_H_H
 
+#include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state_fwd.h>
 
 #include <stdint.h>
@@ -133,7 +134,14 @@ typedef struct {
 
 static inline dsd_call_observation
 dsd_call_observation_data(int protocol, uint8_t slot, uint64_t source_id, uint64_t target_id) {
-    dsd_call_observation observation = {0};
+    /* Zeroed rather than `= {0}`: this header is compiled as both C11 and C++14,
+     * and GCC's -Wmissing-field-initializers (via -Wextra, which the analyzer
+     * runs) names every field the brace form leaves out when the translation
+     * unit is C++. Spelling the fields out instead would be positional — C11 has
+     * no designated initializers that C++14 also accepts — and would silently
+     * mis-assign the day a field is reordered. Same device as dsd_opts. */
+    dsd_call_observation observation;
+    DSD_MEMSET(&observation, 0, sizeof observation);
     observation.protocol = protocol;
     observation.slot = slot;
     observation.kind = DSD_CALL_KIND_DATA;

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -43,6 +43,7 @@ qt_add_resources(
         qml/DecodeChip.qml
         qml/EncTag.qml
         qml/FilterPill.qml
+        qml/FollowLatest.qml
         qml/GradientButton.qml
         qml/HistoryScreen.qml
         qml/HomeScreen.qml

--- a/src/ui/qt/app_prefs.cpp
+++ b/src/ui/qt/app_prefs.cpp
@@ -5,7 +5,7 @@
 
 #include "app_prefs.h"
 
-#include <QLatin1StringView>
+#include <QLatin1String>
 #include <QVariant>
 
 namespace dsd_qt {

--- a/src/ui/qt/app_prefs.cpp
+++ b/src/ui/qt/app_prefs.cpp
@@ -5,6 +5,9 @@
 
 #include "app_prefs.h"
 
+#include <QLatin1StringView>
+#include <QVariant>
+
 namespace dsd_qt {
 
 namespace {

--- a/src/ui/qt/call_history_filter.cpp
+++ b/src/ui/qt/call_history_filter.cpp
@@ -5,6 +5,12 @@
 
 #include "call_history_filter.h"
 
+#include <QAbstractListModel>
+#include <QDebug>
+#include <QList>
+#include <QVariant>
+#include <Qt>
+
 #include "call_history_model.h"
 
 namespace dsd_qt {

--- a/src/ui/qt/call_history_filter.h
+++ b/src/ui/qt/call_history_filter.h
@@ -19,8 +19,7 @@
 #include <QObject>
 #include <QSortFilterProxyModel>
 #include <QString>
-#include <QtTypes>
-#include <QtVersionChecks>
+#include <QtGlobal>
 
 namespace dsd_qt {
 

--- a/src/ui/qt/call_history_filter.h
+++ b/src/ui/qt/call_history_filter.h
@@ -16,8 +16,11 @@
 #ifndef DSD_NEO_SRC_UI_QT_CALL_HISTORY_FILTER_H_
 #define DSD_NEO_SRC_UI_QT_CALL_HISTORY_FILTER_H_
 
+#include <QObject>
 #include <QSortFilterProxyModel>
 #include <QString>
+#include <QtTypes>
+#include <QtVersionChecks>
 
 namespace dsd_qt {
 

--- a/src/ui/qt/call_history_model.cpp
+++ b/src/ui/qt/call_history_model.cpp
@@ -10,12 +10,12 @@
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QJsonValue>
-#include <QLatin1StringView>
+#include <QLatin1String>
 #include <QLocale>
 #include <QPair>
 #include <QRegularExpression>
 #include <QVariant>
-#include <QtMinMax>
+#include <QtGlobal>
 #include <algorithm>
 #include <dsd-neo/core/state.h>
 #include <iterator>

--- a/src/ui/qt/call_history_model.cpp
+++ b/src/ui/qt/call_history_model.cpp
@@ -5,17 +5,25 @@
 
 #include "call_history_model.h"
 
-#include <algorithm>
-
+#include <QByteArray>
 #include <QDateTime>
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QJsonValue>
+#include <QLatin1StringView>
 #include <QLocale>
+#include <QPair>
 #include <QRegularExpression>
-
+#include <QVariant>
+#include <QtMinMax>
+#include <algorithm>
 #include <dsd-neo/core/state.h>
+#include <iterator>
+#include <stdint.h>
+#include <utility>
 
 #include "call_history_merge.h"
+#include "dsd-neo/core/state_fwd.h"
 #include "json_store.h"
 
 namespace dsd_qt {

--- a/src/ui/qt/call_history_model.h
+++ b/src/ui/qt/call_history_model.h
@@ -25,11 +25,14 @@
 #include <QHash>
 #include <QJsonArray>
 #include <QList>
+#include <QObject>
 #include <QSettings>
 #include <QString>
+#include <QStringList>
 #include <QThreadPool>
 #include <QTimer>
-
+#include <Qt>
+#include <QtTypes>
 #include <dsd-neo/core/state_fwd.h>
 
 namespace dsd_qt {

--- a/src/ui/qt/call_history_model.h
+++ b/src/ui/qt/call_history_model.h
@@ -32,7 +32,7 @@
 #include <QThreadPool>
 #include <QTimer>
 #include <Qt>
-#include <QtTypes>
+#include <QtGlobal>
 #include <dsd-neo/core/state_fwd.h>
 
 namespace dsd_qt {

--- a/src/ui/qt/command_bridge.cpp
+++ b/src/ui/qt/command_bridge.cpp
@@ -7,6 +7,7 @@
 
 #include <dsd-neo/app_control/commands.h>
 #include <dsd-neo/app_control/history.h>
+#include <stdint.h>
 
 namespace dsd_qt {
 

--- a/src/ui/qt/json_store.cpp
+++ b/src/ui/qt/json_store.cpp
@@ -5,9 +5,12 @@
 
 #include "json_store.h"
 
+#include <QByteArray>
+#include <QChar>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QIODevice>
 #include <QJsonDocument>
 #include <QSaveFile>
 #include <QStandardPaths>

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -11,6 +11,7 @@
 #include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/enc_lockout.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <stdint.h>
@@ -206,6 +207,7 @@ MetricsModel::refresh(const dsd_opts* opts_snapshot, const dsd_state* snapshot) 
      * assume a fresh session's defaults. */
     next.audio_muted = opts_snapshot->audio_out == 0;
     next.held_tg = static_cast<qulonglong>(snapshot->tg_hold);
+    next.enc_lockout_count = dsd_enc_lockout_active_count(snapshot);
 
     /* The engine's command acknowledgement, shown until its own expiry stamp. The
      * timer takes an expired message down without waiting for another publish —

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -5,15 +5,19 @@
 
 #include "metrics_model.h"
 
+#include <QChar>
 #include <QDateTime>
-
+#include <QtMinMax>
 #include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <stdint.h>
 
 #include "call_line.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
 
 namespace dsd_qt {
 

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -7,7 +7,7 @@
 
 #include <QChar>
 #include <QDateTime>
-#include <QtMinMax>
+#include <QtGlobal>
 #include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dsd_time.h>

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -18,7 +18,7 @@
 #include <QObject>
 #include <QString>
 #include <QTimer>
-#include <QtTypes>
+#include <QtGlobal>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -56,6 +56,7 @@ class MetricsModel : public QObject {
     Q_PROPERTY(int slot2CallSeconds READ slot2CallSeconds NOTIFY slot2Changed)
     Q_PROPERTY(bool audioMuted READ audioMuted NOTIFY controlChanged)
     Q_PROPERTY(qulonglong heldTg READ heldTg NOTIFY controlChanged)
+    Q_PROPERTY(int encLockoutCount READ encLockoutCount NOTIFY controlChanged)
     Q_PROPERTY(QString uiMessage READ uiMessage NOTIFY uiMessageChanged)
 
   public:
@@ -227,6 +228,22 @@ class MetricsModel : public QObject {
     }
 
     /**
+     * @brief Targets the encrypted lockout is currently skipping.
+     *
+     * The ledger's size at the current key epoch, which is a count of targets
+     * confirmed undecryptable from voice — not a count of refusals. A control
+     * channel repeats a grant update every few hundred ms for a call in
+     * progress, so counting refused grants reported hundreds where a handful of
+     * transmissions had happened. This exists because a site that is almost
+     * entirely encrypted otherwise presents as a decoder that stopped: the
+     * control channel decodes, every grant is declined, and no call is logged.
+     */
+    int
+    encLockoutCount() const {
+        return m_view.enc_lockout_count;
+    }
+
+    /**
      * @brief The engine's transient command acknowledgement, empty when none.
      *
      * Commands only enqueue a request; this is the engine saying what actually
@@ -311,6 +328,7 @@ class MetricsModel : public QObject {
         bool stream_active = false;
         bool audio_muted = false;
         qulonglong held_tg = 0;
+        int enc_lockout_count = 0;
         QString ui_message;
         SlotCall slot_call[2];
 
@@ -327,7 +345,8 @@ class MetricsModel : public QObject {
 
         bool
         controlEquals(const View& other) const {
-            return audio_muted == other.audio_muted && held_tg == other.held_tg;
+            return audio_muted == other.audio_muted && held_tg == other.held_tg
+                   && enc_lockout_count == other.enc_lockout_count;
         }
     };
 

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -18,7 +18,7 @@
 #include <QObject>
 #include <QString>
 #include <QTimer>
-
+#include <QtTypes>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 

--- a/src/ui/qt/qml/CallRow.qml
+++ b/src/ui/qt/qml/CallRow.qml
@@ -14,7 +14,7 @@ Item {
     property bool enc: false
     property bool showDivider: true
 
-    implicitHeight: 58
+    implicitHeight: Theme.rowHeight
 
     Column {
         anchors.left: parent.left

--- a/src/ui/qt/qml/FollowLatest.qml
+++ b/src/ui/qt/qml/FollowLatest.qml
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+
+// Keeps a newest-first ListView showing its newest row.
+//
+// The lists this guards are newest-first, so the latest call is the top row —
+// and a reader parked at the top expects to keep seeing it as calls land. That
+// has to be asserted: a prepend below the top does not move the view, it moves
+// the content, holding the rows being read still and putting the new call above
+// the viewport. A list left off the top therefore never comes back on its own,
+// and every call after that lands out of sight — the log quietly stops tracking
+// the latest call.
+//
+// Whether the reader is on the latest call is not a mode they manage — it is
+// read off the list where they left it, each time a call lands. Nothing to get
+// stuck, and one flick back to the top resumes it.
+//
+// Declared as a sibling of the list rather than inside it: ListView reparents
+// declared Item children into its contentItem, where they scroll away with the
+// rows.
+Item {
+    id: root
+
+    required property ListView list
+
+    // Nothing to draw and nothing to lay out; only the behaviour below matters.
+    visible: false
+    width: 0
+    height: 0
+
+    // Within a row of the top still counts as being on the latest call: a stray
+    // touch, an overscroll bounce or the keyboard resizing the view leaves the
+    // list a few pixels down, and none of those mean "I am reading further back".
+    readonly property bool atLatest: root.list.contentY - root.list.originY < Theme.rowHeight
+
+    // Set when a call landed while a finger was down, so the top is asserted once
+    // the hand comes off instead of under the press. See the handler below.
+    property bool deferred: false
+
+    // Re-assert the exact top.
+    function pinToLatest() {
+        // Never mid-movement: that is a flick still settling, and yanking it
+        // would fight the reader's hand.
+        if (!root.atLatest || root.list.moving) {
+            root.deferred = false
+            return
+        }
+        // Flickable.moving covers a drag and a flick but not a finger resting on
+        // the list, which is neither. Repositioning under a held press moves the
+        // content away from the press position the Flickable recorded when the
+        // finger went down, and the reader's next drag starts by snapping back to
+        // it — so wait for the release instead.
+        if (touch.active) {
+            root.deferred = true
+            return
+        }
+        root.deferred = false
+        if (root.list.contentY !== root.list.originY)
+            root.list.positionViewAtBeginning()
+    }
+
+    Connections {
+        target: root.list
+
+        // Deferred: inside the signal the view is still applying the model
+        // change, and a position asserted there does not survive it.
+        function onCountChanged() {
+            Qt.callLater(root.pinToLatest)
+        }
+
+        // A drag that starts before the finger lifts is the reader deciding where
+        // to be; the pin they never saw is theirs to drop.
+        function onMovingChanged() {
+            if (root.list.moving)
+                root.deferred = false
+        }
+    }
+
+    // Passive grabs only — PointHandler never takes an exclusive one, so this
+    // neither steals the list's flick nor the rows' taps. Parented to the list so
+    // it sees presses anywhere over the rows.
+    PointHandler {
+        id: touch
+
+        parent: root.list
+
+        onActiveChanged: {
+            if (!touch.active && root.deferred)
+                Qt.callLater(root.pinToLatest)
+        }
+    }
+}

--- a/src/ui/qt/qml/HistoryScreen.qml
+++ b/src/ui/qt/qml/HistoryScreen.qml
@@ -124,34 +124,6 @@ Item {
         enabled: !confirmClear.visible
         model: historyView
 
-        // The log is newest-first, so the latest call is the top row — and a
-        // reader parked at the top keeps it in view as calls land. That has to be
-        // asserted: a prepend below the top does not move the view, it moves the
-        // content, holding the rows being read still and putting the new call
-        // above the viewport. A list left off the top therefore never comes back
-        // on its own, and every call after that lands out of sight — the log
-        // quietly stops tracking the latest call, which is the bug this fixes.
-        //
-        // Whether the reader is on the latest call is not a mode they manage —
-        // it is read off the list where they left it, each time a call lands.
-        // Nothing to get stuck, and one flick back to the top resumes it.
-        //
-        // Within a row of the top still counts as the latest: a stray touch, an
-        // overscroll bounce or the keyboard resizing the view leaves the list a
-        // few pixels down, and none of those mean "I am reading further back".
-        readonly property bool atLatest: contentY - originY < Theme.rowHeight
-
-        // Re-assert the exact top. Never mid-movement: that is a flick still
-        // settling, and yanking it would fight the reader's hand.
-        function pinToLatest() {
-            if (atLatest && !moving && contentY !== originY)
-                positionViewAtBeginning()
-        }
-
-        // Deferred: inside the signal the view is still applying the model
-        // change, and a position asserted there does not survive it.
-        onCountChanged: Qt.callLater(pinToLatest)
-
         section.property: "dayLabel"
         section.delegate: MicroLabel {
             required property string section
@@ -195,6 +167,11 @@ Item {
             rightText: model.timeText
             enc: model.enc
         }
+    }
+
+    // Keeps the newest call in view for a reader parked at the top of the log.
+    FollowLatest {
+        list: logList
     }
 
     // A sibling of the view, not a child: ListView reparents declared children

--- a/src/ui/qt/qml/HistoryScreen.qml
+++ b/src/ui/qt/qml/HistoryScreen.qml
@@ -110,6 +110,9 @@ Item {
     ListView {
         id: logList
 
+        // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
+        objectName: "callLogList"
+
         anchors.top: chrome.bottom
         anchors.topMargin: 8
         anchors.left: parent.left
@@ -233,6 +236,8 @@ Item {
     Rectangle {
         id: latestPill
 
+        objectName: "newCallsPill"
+
         readonly property bool shown: logList.unseen > 0 && !logList.atLatest && logList.count > 0
 
         anchors.horizontalCenter: logList.horizontalCenter
@@ -336,6 +341,8 @@ Item {
         }
 
         Text {
+            objectName: "logEmptyDetail"
+
             width: parent.width
             horizontalAlignment: Text.AlignHCenter
             text: parent.filtered ? parent.hiddenText

--- a/src/ui/qt/qml/HistoryScreen.qml
+++ b/src/ui/qt/qml/HistoryScreen.qml
@@ -121,6 +121,65 @@ Item {
         enabled: !confirmClear.visible
         model: historyView
 
+        // The log is newest-first, so the latest call is the top row — and a
+        // reader parked at the top keeps it in view as calls land. That has to be
+        // asserted: a prepend below the top does not move the view, it moves the
+        // content, holding the rows being read still and putting the new call
+        // above the viewport. A list left off the top therefore never comes back
+        // on its own, and every call after that lands out of sight — the log
+        // quietly stops tracking the latest call, which is the bug this fixes.
+        //
+        // Whether the reader is on the latest call is not a mode they manage —
+        // it is read off the list where they left it, each time a call lands.
+        // Nothing to get stuck, and one flick back to the top resumes it.
+        //
+        // Within a row of the top still counts as the latest: a stray touch, an
+        // overscroll bounce or the keyboard resizing the view leaves the list a
+        // few pixels down, and none of those mean "I am reading further back".
+        readonly property bool atLatest: contentY - originY < Theme.rowHeight
+        // Calls that landed while the reader was away from the top.
+        property int unseen: 0
+        property int lastCount: 0
+
+        // Re-assert the exact top. Never mid-movement: that is a flick still
+        // settling, and yanking it would fight the reader's hand.
+        function pinToLatest() {
+            if (atLatest && !moving && contentY !== originY)
+                positionViewAtBeginning()
+        }
+
+        function jumpToLatest() {
+            positionViewAtBeginning()
+            unseen = 0
+        }
+
+        // Deferred, and every count change goes through here: inside the signal
+        // the view is still applying the model change — count itself still reads
+        // one behind, and a position asserted there does not survive it.
+        // Coalesced calls stay correct because the tally is a delta.
+        function reconcile() {
+            if (atLatest) {
+                unseen = 0
+                pinToLatest()
+            } else if (count > lastCount) {
+                unseen += count - lastCount
+            } else if (count < unseen) {
+                // Trimmed or cleared underneath us; never offer to jump to more
+                // calls than the log still holds.
+                unseen = count
+            }
+            lastCount = count
+        }
+
+        onCountChanged: Qt.callLater(reconcile)
+
+        // A new search or filter is a new question: answer it from the top, and
+        // never count the rows it revealed as calls that just landed.
+        Connections {
+            target: historyView
+            function onFilterChanged() { logList.jumpToLatest() }
+        }
+
         section.property: "dayLabel"
         section.delegate: MicroLabel {
             required property string section
@@ -166,6 +225,84 @@ Item {
         }
     }
 
+    // Says what the reader is missing while they read further back, in the same
+    // mono annunciator voice as the monitor's LIVE pill — a readout of state,
+    // not another chip to choose from. A sibling of the view, not a child: a
+    // declared child is reparented into contentItem and would scroll off with
+    // the rows it is reporting on.
+    Rectangle {
+        id: latestPill
+
+        readonly property bool shown: logList.unseen > 0 && !logList.atLatest && logList.count > 0
+
+        anchors.horizontalCenter: logList.horizontalCenter
+        anchors.top: logList.top
+        anchors.topMargin: 8
+        // The outer capsule is a cut-out in the background colour: it floats over
+        // rows, and a flat design with no shadows needs the gap to keep the row
+        // text under it from running into the label.
+        width: capsule.width + 8
+        height: capsule.height + 8
+        radius: height / 2
+        color: Theme.bg
+        opacity: shown ? 1.0 : 0.0
+        visible: opacity > 0.0
+        enabled: shown && !confirmClear.visible
+
+        Behavior on opacity {
+            NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
+        }
+
+        Rectangle {
+            id: capsule
+
+            anchors.centerIn: parent
+            // 34 high like the filter pills above it: the mono readout says what
+            // this is, but the size has to say it can be tapped.
+            width: latestRow.implicitWidth + 28
+            height: 34
+            radius: height / 2
+            // Opaque: the cyan tint the filter pills lay straight onto the
+            // background has to be blended into a solid fill to cover rows.
+            color: Qt.tint(Theme.panel, Theme.chipSelectedFill)
+            border.width: 1
+            border.color: Theme.cyan
+
+            Row {
+                id: latestRow
+
+                anchors.centerIn: parent
+                spacing: 7
+
+                // Points at where the tap takes you: the top of the log.
+                Caret {
+                    anchors.verticalCenter: parent.verticalCenter
+                    rotation: 180
+                    color: Theme.cyan
+                }
+
+                Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    // "call" is what this screen calls a row everywhere else ("No
+                    // calls yet", "1 logged call is hidden"), notices included.
+                    // Counts are whole strings, never one %n plural — see the
+                    // empty state below for why.
+                    text: logList.unseen === 1 ? qsTr("1 new call")
+                                               : qsTr("%1 new calls").arg(logList.unseen)
+                    font.family: Theme.mono
+                    font.pixelSize: 11
+                    font.letterSpacing: 1.4
+                    font.capitalization: Font.AllUppercase
+                    color: Theme.cyan
+                }
+            }
+        }
+
+        TapHandler {
+            onTapped: logList.jumpToLatest()
+        }
+    }
+
     // A sibling of the view, not a child: ListView reparents declared children
     // into its contentItem, where `parent.count` is undefined and the empty state
     // would never show.
@@ -179,6 +316,14 @@ Item {
         // first must say the calls are hidden, not gone, or the filter pill left
         // active yesterday reads as a decoder that stopped logging.
         readonly property bool filtered: callHistory.count > 0
+        // Each count spelled as a whole sentence rather than one %n plural: the
+        // app installs no QTranslator, and an untranslated %n form substitutes the
+        // number but never picks a plural form — this read "1 logged call(s) are
+        // hidden". Two strings also let the verb agree.
+        readonly property string hiddenText:
+            callHistory.count === 1 ? qsTr("1 logged call is hidden by the search or filters.")
+                                    : qsTr("%1 logged calls are hidden by the search or filters.")
+                                        .arg(callHistory.count)
 
         Text {
             width: parent.width
@@ -193,8 +338,7 @@ Item {
         Text {
             width: parent.width
             horizontalAlignment: Text.AlignHCenter
-            text: parent.filtered ? qsTr("%n logged call(s) are hidden by the search or filters.", "",
-                                         callHistory.count)
+            text: parent.filtered ? parent.hiddenText
                                   : qsTr("Start listening on a system and every call lands here.")
             font.family: Theme.sans
             font.pixelSize: 13

--- a/src/ui/qt/qml/HistoryScreen.qml
+++ b/src/ui/qt/qml/HistoryScreen.qml
@@ -140,9 +140,6 @@ Item {
         // overscroll bounce or the keyboard resizing the view leaves the list a
         // few pixels down, and none of those mean "I am reading further back".
         readonly property bool atLatest: contentY - originY < Theme.rowHeight
-        // Calls that landed while the reader was away from the top.
-        property int unseen: 0
-        property int lastCount: 0
 
         // Re-assert the exact top. Never mid-movement: that is a flick still
         // settling, and yanking it would fight the reader's hand.
@@ -151,37 +148,9 @@ Item {
                 positionViewAtBeginning()
         }
 
-        function jumpToLatest() {
-            positionViewAtBeginning()
-            unseen = 0
-        }
-
-        // Deferred, and every count change goes through here: inside the signal
-        // the view is still applying the model change — count itself still reads
-        // one behind, and a position asserted there does not survive it.
-        // Coalesced calls stay correct because the tally is a delta.
-        function reconcile() {
-            if (atLatest) {
-                unseen = 0
-                pinToLatest()
-            } else if (count > lastCount) {
-                unseen += count - lastCount
-            } else if (count < unseen) {
-                // Trimmed or cleared underneath us; never offer to jump to more
-                // calls than the log still holds.
-                unseen = count
-            }
-            lastCount = count
-        }
-
-        onCountChanged: Qt.callLater(reconcile)
-
-        // A new search or filter is a new question: answer it from the top, and
-        // never count the rows it revealed as calls that just landed.
-        Connections {
-            target: historyView
-            function onFilterChanged() { logList.jumpToLatest() }
-        }
+        // Deferred: inside the signal the view is still applying the model
+        // change, and a position asserted there does not survive it.
+        onCountChanged: Qt.callLater(pinToLatest)
 
         section.property: "dayLabel"
         section.delegate: MicroLabel {
@@ -225,86 +194,6 @@ Item {
             }
             rightText: model.timeText
             enc: model.enc
-        }
-    }
-
-    // Says what the reader is missing while they read further back, in the same
-    // mono annunciator voice as the monitor's LIVE pill — a readout of state,
-    // not another chip to choose from. A sibling of the view, not a child: a
-    // declared child is reparented into contentItem and would scroll off with
-    // the rows it is reporting on.
-    Rectangle {
-        id: latestPill
-
-        objectName: "newCallsPill"
-
-        readonly property bool shown: logList.unseen > 0 && !logList.atLatest && logList.count > 0
-
-        anchors.horizontalCenter: logList.horizontalCenter
-        anchors.top: logList.top
-        anchors.topMargin: 8
-        // The outer capsule is a cut-out in the background colour: it floats over
-        // rows, and a flat design with no shadows needs the gap to keep the row
-        // text under it from running into the label.
-        width: capsule.width + 8
-        height: capsule.height + 8
-        radius: height / 2
-        color: Theme.bg
-        opacity: shown ? 1.0 : 0.0
-        visible: opacity > 0.0
-        enabled: shown && !confirmClear.visible
-
-        Behavior on opacity {
-            NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
-        }
-
-        Rectangle {
-            id: capsule
-
-            anchors.centerIn: parent
-            // 34 high like the filter pills above it: the mono readout says what
-            // this is, but the size has to say it can be tapped.
-            width: latestRow.implicitWidth + 28
-            height: 34
-            radius: height / 2
-            // Opaque: the cyan tint the filter pills lay straight onto the
-            // background has to be blended into a solid fill to cover rows.
-            color: Qt.tint(Theme.panel, Theme.chipSelectedFill)
-            border.width: 1
-            border.color: Theme.cyan
-
-            Row {
-                id: latestRow
-
-                anchors.centerIn: parent
-                spacing: 7
-
-                // Points at where the tap takes you: the top of the log.
-                Caret {
-                    anchors.verticalCenter: parent.verticalCenter
-                    rotation: 180
-                    color: Theme.cyan
-                }
-
-                Text {
-                    anchors.verticalCenter: parent.verticalCenter
-                    // "call" is what this screen calls a row everywhere else ("No
-                    // calls yet", "1 logged call is hidden"), notices included.
-                    // Counts are whole strings, never one %n plural — see the
-                    // empty state below for why.
-                    text: logList.unseen === 1 ? qsTr("1 new call")
-                                               : qsTr("%1 new calls").arg(logList.unseen)
-                    font.family: Theme.mono
-                    font.pixelSize: 11
-                    font.letterSpacing: 1.4
-                    font.capitalization: Font.AllUppercase
-                    color: Theme.cyan
-                }
-            }
-        }
-
-        TapHandler {
-            onTapped: logList.jumpToLatest()
         }
     }
 

--- a/src/ui/qt/qml/HistoryScreen.qml
+++ b/src/ui/qt/qml/HistoryScreen.qml
@@ -174,6 +174,32 @@ Item {
         list: logList
     }
 
+    // A new search or filter is a new question, answered from the top — which is
+    // a different rule from the pin above, not the same one: the pin asks where
+    // the reader left the list and holds their place when they are reading back,
+    // while a filter change makes that place the answer to a question they are no
+    // longer asking. The view keeps its scroll position across the change, so
+    // without this a reader who had scrolled back lands somewhere inside the new
+    // result, with the newest matching calls off-screen above and nothing to say
+    // they are there. It only rights itself when the result is shorter than the
+    // viewport, where the Flickable's own bounds drag it back.
+    //
+    // The pills are the reason this cannot ride on the pin: they are only usable
+    // while no session is running, which is exactly when no call is landing to
+    // fire it.
+    Connections {
+        target: historyView
+
+        // Deferred for the same reason the pin is: inside the signal the view is
+        // still applying the filter's row changes, and a position asserted there
+        // does not survive them. Setting several filters at once (the empty
+        // state's Clear filters button sets four) coalesces into one call, and
+        // repositioning an already-topped list is a no-op either way.
+        function onFilterChanged() {
+            Qt.callLater(logList.positionViewAtBeginning)
+        }
+    }
+
     // A sibling of the view, not a child: ListView reparents declared children
     // into its contentItem, where `parent.count` is undefined and the empty state
     // would never show.

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -509,6 +509,9 @@ Item {
             ListView {
                 id: recentList
 
+                // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
+                objectName: "recentCallsList"
+
                 anchors.top: recentLabel.bottom
                 anchors.topMargin: 10
                 anchors.left: parent.left

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -518,6 +518,25 @@ Item {
                 clip: true
                 model: monitorView
 
+                // Newest-first, and held at the top so the pane keeps showing the
+                // call that just ended. A prepend below the top moves the content,
+                // not the view: it holds the rows being read still and puts the
+                // new call above the viewport, so a pane left scrolled never comes
+                // back on its own. Same rule as the history screen — the top is
+                // re-asserted when a call lands and the pane is at rest within a
+                // row of it — minus the new-calls pill, which four rows have no
+                // room for and which the hero above already covers.
+                readonly property bool atLatest: contentY - originY < Theme.rowHeight
+
+                function pinToLatest() {
+                    if (atLatest && !moving && contentY !== originY)
+                        positionViewAtBeginning()
+                }
+
+                // Deferred: inside the signal the view is still applying the
+                // model change, and a position asserted there does not survive it.
+                onCountChanged: Qt.callLater(pinToLatest)
+
                 delegate: CallRow {
                     width: ListView.view.width
                     name: model.name

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -559,25 +559,6 @@ Item {
                 clip: true
                 model: monitorView
 
-                // Newest-first, and held at the top so the pane keeps showing the
-                // call that just ended. A prepend below the top moves the content,
-                // not the view: it holds the rows being read still and puts the
-                // new call above the viewport, so a pane left scrolled never comes
-                // back on its own. Same rule as the history screen — the top is
-                // re-asserted when a call lands and the pane is at rest within a
-                // row of it — minus the new-calls pill, which four rows have no
-                // room for and which the hero above already covers.
-                readonly property bool atLatest: contentY - originY < Theme.rowHeight
-
-                function pinToLatest() {
-                    if (atLatest && !moving && contentY !== originY)
-                        positionViewAtBeginning()
-                }
-
-                // Deferred: inside the signal the view is still applying the
-                // model change, and a position asserted there does not survive it.
-                onCountChanged: Qt.callLater(pinToLatest)
-
                 delegate: CallRow {
                     width: ListView.view.width
                     name: model.name
@@ -593,6 +574,13 @@ Item {
                     rightText: (screen.ageTick, Util.shortAge(model.when))
                     enc: model.enc
                 }
+            }
+
+            // Same rule as the history log: the pane keeps showing the call that
+            // just ended, minus the new-calls pill, which four rows have no room
+            // for and which the hero above already covers.
+            FollowLatest {
+                list: recentList
             }
 
             // A sibling of the view, not a child: ListView reparents declared

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -494,6 +494,44 @@ Item {
             }
         }
 
+        // Why an empty log can still be a working decoder. On an almost entirely
+        // encrypted site the control channel decodes, every grant is declined and
+        // no call is ever logged, which is indistinguishable from a decoder that
+        // stopped. Outside the strip above and its tuner gate on purpose: this is
+        // decode truth, not tuner truth, and a network source meets it just as
+        // often.
+        //
+        // The ledger's size, not a tally of refusals: a control channel repeats a
+        // grant update every few hundred ms while a call is up, so counting
+        // refused grants read 150 where about a dozen transmissions had happened.
+        // The ledger counts targets, and only from voice confirmed undecryptable.
+        // Magenta, not cyan: cyan is signal health here, magenta is encryption,
+        // same as the ENC tags on the rows below. Hidden at zero, so a site with
+        // no encrypted traffic never carries a permanent 0.
+        Row {
+            // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
+            objectName: "encLockoutRow"
+
+            spacing: 5
+            visible: metrics.encLockoutCount > 0
+
+            Text {
+                text: qsTr("ENC LOCKOUT")
+                font.family: Theme.mono
+                font.pixelSize: 11
+                color: Theme.textSubdued
+            }
+
+            Text {
+                objectName: "encLockoutValue"
+
+                text: metrics.encLockoutCount.toString()
+                font.family: Theme.mono
+                font.pixelSize: 11
+                color: Theme.magenta
+            }
+        }
+
         // Recent calls.
         UiPanel {
             width: parent.width

--- a/src/ui/qt/qml/Theme.qml
+++ b/src/ui/qt/qml/Theme.qml
@@ -52,4 +52,8 @@ QtObject {
     readonly property int screenPadding: 18
     readonly property int cardPadding: 16
     readonly property int gap: 13
+
+    // One call row. Also the slack the call lists allow around the top before
+    // they stop treating the reader as parked on the latest call.
+    readonly property int rowHeight: 58
 }

--- a/src/ui/qt/qt_ui.cpp
+++ b/src/ui/qt/qt_ui.cpp
@@ -5,14 +5,16 @@
 
 #include "qt_ui.h"
 
-#include <QFont>
 #include <QFontDatabase>
-#include <QGuiApplication>
+#include <QLatin1StringView>
+#include <QList>
+#include <QObject>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QQuickStyle>
+#include <QString>
+#include <QStringList>
 #include <QUrl>
-
 #include <dsd-neo/runtime/git_ver.h>
 
 #include "app_prefs.h"

--- a/src/ui/qt/qt_ui.cpp
+++ b/src/ui/qt/qt_ui.cpp
@@ -6,7 +6,7 @@
 #include "qt_ui.h"
 
 #include <QFontDatabase>
-#include <QLatin1StringView>
+#include <QLatin1String>
 #include <QList>
 #include <QObject>
 #include <QQmlApplicationEngine>

--- a/src/ui/qt/saved_systems_model.cpp
+++ b/src/ui/qt/saved_systems_model.cpp
@@ -246,7 +246,10 @@ void
 SavedSystemsModel::load() {
     QList<Row> rows;
     const QJsonArray array = json_store_load_array(QLatin1String(kStoreFileName));
-    for (const QJsonValue& value : array) {
+    // auto, not QJsonValue: iterating a QJsonArray yields a QJsonValueConstRef
+    // proxy, and binding that to a QJsonValue reference converts — copying every
+    // element into a temporary the loop then reads through.
+    for (const auto& value : array) {
         if (!value.isObject()) {
             continue;
         }

--- a/src/ui/qt/saved_systems_model.cpp
+++ b/src/ui/qt/saved_systems_model.cpp
@@ -11,7 +11,7 @@
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QJsonValue>
-#include <QLatin1StringView>
+#include <QLatin1String>
 #include <QMap>
 #include <QMetaType>
 #include <QVariant>

--- a/src/ui/qt/saved_systems_model.cpp
+++ b/src/ui/qt/saved_systems_model.cpp
@@ -5,9 +5,14 @@
 
 #include "saved_systems_model.h"
 
+#include <QByteArray>
 #include <QDateTime>
+#include <QHash>
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QJsonValue>
+#include <QLatin1StringView>
+#include <QMap>
 #include <QMetaType>
 #include <QVariant>
 

--- a/src/ui/qt/saved_systems_model.h
+++ b/src/ui/qt/saved_systems_model.h
@@ -23,7 +23,7 @@
 #include <QVariant>
 #include <QVariantMap>
 #include <Qt>
-#include <QtTypes>
+#include <QtGlobal>
 
 namespace dsd_qt {
 

--- a/src/ui/qt/saved_systems_model.h
+++ b/src/ui/qt/saved_systems_model.h
@@ -18,8 +18,12 @@
 
 #include <QAbstractListModel>
 #include <QList>
+#include <QObject>
 #include <QString>
+#include <QVariant>
 #include <QVariantMap>
+#include <Qt>
+#include <QtTypes>
 
 namespace dsd_qt {
 

--- a/src/ui/qt/session_args.cpp
+++ b/src/ui/qt/session_args.cpp
@@ -5,9 +5,14 @@
 
 #include "session_args.h"
 
+#include <QChar>
+#include <QLatin1StringView>
+#include <QList>
+#include <QMap>
 #include <QMetaType>
 #include <QRegularExpression>
 #include <QVariant>
+#include <Qt>
 
 #include "app_prefs.h"
 

--- a/src/ui/qt/session_args.cpp
+++ b/src/ui/qt/session_args.cpp
@@ -6,7 +6,7 @@
 #include "session_args.h"
 
 #include <QChar>
-#include <QLatin1StringView>
+#include <QLatin1String>
 #include <QList>
 #include <QMap>
 #include <QMetaType>

--- a/src/ui/qt/ui_controller.cpp
+++ b/src/ui/qt/ui_controller.cpp
@@ -5,11 +5,14 @@
 
 #include "ui_controller.h"
 
+#include <Qt>
 #include <dsd-neo/app_control/frontend_runtime.h>
 #include <dsd-neo/app_control/snapshot.h>
 
 #include "call_history_model.h"
 #include "decoder_host.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
 #include "metrics_model.h"
 
 namespace dsd_qt {

--- a/src/ui/qt/ui_controller.h
+++ b/src/ui/qt/ui_controller.h
@@ -24,7 +24,6 @@
 namespace dsd_qt {
 
 class CallHistoryModel;
-class CommandBridge;
 class MetricsModel;
 
 class UiController : public QObject {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2139,51 +2139,88 @@ if(DSD_ENABLE_QT_UI)
 
     # The QML screens themselves, driven by Qt Quick Test: the call lists keep
     # the latest call in view while the reader is parked at the top, hold their
-    # place when the reader is further back, and tally what landed meanwhile.
-    # None of that is visible to a C++ model test — it lives in the view's
-    # reaction to insert signals — and all of it regresses silently.
+    # place when the reader is further back, and leave the view where it is while
+    # a finger is down on it. The monitor's encrypted-lockout reading and the
+    # history screen's hidden-count sentence ride along. None of that is visible
+    # to a C++ model test — it lives in the view's reaction to insert signals and
+    # in binding expressions — and all of it regresses silently.
     #
     # The .qml files are read from src/ui/qt/qml by absolute path rather than
     # through the app's qrc, so the test needs no frontend library, and the
     # production CallHistoryFilterModel is compiled in so the filter under the
-    # views is the real one. QuickTest ships with the same Qt module as Quick,
-    # so requiring it adds no dependency beyond what the frontend already needs.
-    find_package(Qt6 REQUIRED COMPONENTS Gui Qml Quick QuickTest)
-    # The header is listed so AUTOMOC processes its Q_OBJECT classes into their
-    # own generated translation unit, keeping moc output out of the test's.
-    add_executable(
-        dsd-neo_test_ui_qt_qml
-        ui/test_ui_qt_qml_main.cpp
-        ui/qml_test_context.h
-        ${PROJECT_SOURCE_DIR}/src/ui/qt/call_history_filter.cpp
-    )
-    target_include_directories(
-        dsd-neo_test_ui_qt_qml
-        PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/qt
-    )
-    target_link_libraries(
-        dsd-neo_test_ui_qt_qml
-        PRIVATE Qt6::Gui Qt6::Qml Qt6::Quick Qt6::QuickTest
-    )
-    target_compile_definitions(
-        dsd-neo_test_ui_qt_qml
-        PRIVATE
-            QT_NO_KEYWORDS
-            QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/ui/qml"
-            DSD_QML_UI_DIR="${PROJECT_SOURCE_DIR}/src/ui/qt/qml"
-            DSD_QML_FONT_DIR="${PROJECT_SOURCE_DIR}/src/ui/qt/fonts"
-    )
-    set_target_properties(dsd-neo_test_ui_qt_qml PROPERTIES AUTOMOC ON)
-    add_test(NAME UI_QT_QML_CALL_LISTS COMMAND dsd-neo_test_ui_qt_qml)
-    # Headless by construction: no window server and no GPU on a CI runner, and
-    # the software renderer keeps the run off the host's GL stack entirely.
-    set_tests_properties(
-        UI_QT_QML_CALL_LISTS
-        PROPERTIES
-            LABELS qml
-            ENVIRONMENT
-                "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1"
-    )
+    # views is the real one.
+    #
+    # Probed rather than REQUIRED, and in two parts. QuickTest is a test-only Qt
+    # module that distributions package separately from Quick (Debian and Ubuntu
+    # split the QML half out as qml6-module-qttest), and BUILD_TESTING is on in
+    # every dev preset — so a REQUIRED here would turn a missing test module into
+    # a failed configure for the whole project, the CLI included. The QML half is
+    # checked too: `import QtTest` resolves at run time from the plugin directory,
+    # so without it the test would fail with "module QtTest is not installed"
+    # rather than sit out.
+    find_package(Qt6 QUIET COMPONENTS QuickTest)
+    if(Qt6QuickTest_FOUND)
+        find_path(
+            DSD_NEO_QTTEST_QML_DIR
+            NAMES qmldir
+            PATHS "${QT6_INSTALL_PREFIX}/${QT6_INSTALL_QML}/QtTest"
+            NO_DEFAULT_PATH
+            DOC
+                "Directory holding the QtTest QML module, for UI_QT_QML_CALL_LISTS"
+        )
+    endif()
+    if(NOT Qt6QuickTest_FOUND)
+        message(
+            STATUS
+            "UI_QT_QML_CALL_LISTS: skipped, Qt6 QuickTest module not found"
+        )
+    elseif(NOT DSD_NEO_QTTEST_QML_DIR)
+        message(
+            STATUS
+            "UI_QT_QML_CALL_LISTS: skipped, the QtTest QML module is missing from ${QT6_INSTALL_PREFIX}/${QT6_INSTALL_QML} (Debian/Ubuntu: qml6-module-qttest)"
+        )
+    else()
+        find_package(Qt6 REQUIRED COMPONENTS Gui Qml Quick)
+        # The header is listed so AUTOMOC processes its Q_OBJECT classes into
+        # their own generated translation unit, keeping moc output out of the
+        # test's.
+        add_executable(
+            dsd-neo_test_ui_qt_qml
+            ui/test_ui_qt_qml_main.cpp
+            ui/qml_test_context.h
+            ${PROJECT_SOURCE_DIR}/src/ui/qt/call_history_filter.cpp
+        )
+        target_include_directories(
+            dsd-neo_test_ui_qt_qml
+            PRIVATE
+                ${PROJECT_SOURCE_DIR}/include
+                ${PROJECT_SOURCE_DIR}/src/ui/qt
+        )
+        target_link_libraries(
+            dsd-neo_test_ui_qt_qml
+            PRIVATE Qt6::Gui Qt6::Qml Qt6::Quick Qt6::QuickTest
+        )
+        target_compile_definitions(
+            dsd-neo_test_ui_qt_qml
+            PRIVATE
+                QT_NO_KEYWORDS
+                QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/ui/qml"
+                DSD_QML_UI_DIR="${PROJECT_SOURCE_DIR}/src/ui/qt/qml"
+                DSD_QML_FONT_DIR="${PROJECT_SOURCE_DIR}/src/ui/qt/fonts"
+        )
+        set_target_properties(dsd-neo_test_ui_qt_qml PROPERTIES AUTOMOC ON)
+        add_test(NAME UI_QT_QML_CALL_LISTS COMMAND dsd-neo_test_ui_qt_qml)
+        # Headless by construction: no window server and no GPU on a CI runner,
+        # and the software renderer keeps the run off the host's GL stack
+        # entirely.
+        set_tests_properties(
+            UI_QT_QML_CALL_LISTS
+            PROPERTIES
+                LABELS qml
+                ENVIRONMENT
+                    "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1"
+        )
+    endif()
 endif()
 
 add_executable(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2136,6 +2136,54 @@ if(DSD_ENABLE_QT_UI)
     )
     set_target_properties(dsd-neo_test_ui_qt_session_args PROPERTIES AUTOMOC ON)
     add_test(NAME UI_QT_SESSION_ARGS COMMAND dsd-neo_test_ui_qt_session_args)
+
+    # The QML screens themselves, driven by Qt Quick Test: the call lists keep
+    # the latest call in view while the reader is parked at the top, hold their
+    # place when the reader is further back, and tally what landed meanwhile.
+    # None of that is visible to a C++ model test — it lives in the view's
+    # reaction to insert signals — and all of it regresses silently.
+    #
+    # The .qml files are read from src/ui/qt/qml by absolute path rather than
+    # through the app's qrc, so the test needs no frontend library, and the
+    # production CallHistoryFilterModel is compiled in so the filter under the
+    # views is the real one. QuickTest ships with the same Qt module as Quick,
+    # so requiring it adds no dependency beyond what the frontend already needs.
+    find_package(Qt6 REQUIRED COMPONENTS Gui Qml Quick QuickTest)
+    # The header is listed so AUTOMOC processes its Q_OBJECT classes into their
+    # own generated translation unit, keeping moc output out of the test's.
+    add_executable(
+        dsd-neo_test_ui_qt_qml
+        ui/test_ui_qt_qml_main.cpp
+        ui/qml_test_context.h
+        ${PROJECT_SOURCE_DIR}/src/ui/qt/call_history_filter.cpp
+    )
+    target_include_directories(
+        dsd-neo_test_ui_qt_qml
+        PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/qt
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_qt_qml
+        PRIVATE Qt6::Gui Qt6::Qml Qt6::Quick Qt6::QuickTest
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_qt_qml
+        PRIVATE
+            QT_NO_KEYWORDS
+            QUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/ui/qml"
+            DSD_QML_UI_DIR="${PROJECT_SOURCE_DIR}/src/ui/qt/qml"
+            DSD_QML_FONT_DIR="${PROJECT_SOURCE_DIR}/src/ui/qt/fonts"
+    )
+    set_target_properties(dsd-neo_test_ui_qt_qml PROPERTIES AUTOMOC ON)
+    add_test(NAME UI_QT_QML_CALL_LISTS COMMAND dsd-neo_test_ui_qt_qml)
+    # Headless by construction: no window server and no GPU on a CI runner, and
+    # the software renderer keeps the run off the host's GL stack entirely.
+    set_tests_properties(
+        UI_QT_QML_CALL_LISTS
+        PROPERTIES
+            LABELS qml
+            ENVIRONMENT
+                "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1"
+    )
 endif()
 
 add_executable(

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -390,6 +390,8 @@ main(void) {
                                            .is_group = 1});
 
             rc |= expect_true("blocked grant does not arm the ledger", enc_tg_cache_is_absent(&comp_st, 2001U));
+            rc |= expect_true("a grant blocked for another reason leaves the count at zero",
+                              dsd_enc_lockout_active_count(&comp_st) == 0);
             rc |= expect_true("blocked grant leaves companion event row intact",
                               strcmp(before_row, comp_st.event_history_s[0].Event_History_Items[0].event_string) == 0);
             dsd_call_snapshot after_call;
@@ -443,6 +445,12 @@ main(void) {
         rc |= expect_true("blocked probe records crypto evidence",
                           dsd_enc_lockout_lookup(&cache_st, 1300U, 1, &lockout_entry) && lockout_entry.algid == 0x84
                               && lockout_entry.keyid == 0x2714);
+        // What the monitor's ENC LOCKOUT reading shows. It counts targets in the
+        // ledger, so it moves once when a target is confirmed undecryptable and
+        // then holds, however many grants for it the control channel repeats --
+        // counting the refusals instead read 150 on a site that had carried about
+        // a dozen transmissions.
+        rc |= expect_true("confirmed lockout is one active entry", dsd_enc_lockout_active_count(&cache_st) == 1);
         before = cache_st.p25_sm_tune_count;
         cache_opts.trunk_is_tuned = 0;
         p25_sm_event(p25_sm_get_ctx(), &cache_opts, &cache_st,
@@ -454,6 +462,7 @@ main(void) {
                                        .svc_bits = P25_SM_SVC_UNKNOWN,
                                        .is_group = 1});
         rc |= expect_true("unknown-svc grant suppressed by lockout", cache_st.p25_sm_tune_count == before);
+
         p25_sm_event(p25_sm_get_ctx(), &cache_opts, &cache_st,
                      &(p25_sm_event_t){.type = P25_SM_EV_GRANT,
                                        .slot = -1,
@@ -463,6 +472,8 @@ main(void) {
                                        .svc_bits = 0x40,
                                        .is_group = 1});
         rc |= expect_true("explicit encrypted grant suppressed by lockout", cache_st.p25_sm_tune_count == before);
+        rc |= expect_true("repeated grants for one target do not inflate the count",
+                          dsd_enc_lockout_active_count(&cache_st) == 1);
         rc |= expect_true("lockout stays armed with no retry backoff", !enc_call_cache_is_absent(&cache_st, 1300U, 1));
         rc |= expect_true("enc lockout does not add TG policy", tg_policy_is_absent(&cache_st, 1300U));
 

--- a/tests/ui/qml/tst_call_log_follow.qml
+++ b/tests/ui/qml/tst_call_log_follow.qml
@@ -5,11 +5,10 @@ import QtQuick
 import QtTest
 
 // The history screen's call log has to keep the latest call in view while the
-// reader is parked at the top, hold their place when they are reading further
-// back, and say what landed while they were away. The bug this guards against is
-// silent: a ListView prepend below the top moves the content rather than the
-// view, so a list left off the top never returns on its own and every later call
-// arrives above the viewport with nothing on screen to say so.
+// reader is parked at the top, and hold their place when they are reading further
+// back. The bug this guards against is silent: a ListView prepend below the top
+// moves the content rather than the view, so a list left off the top never
+// returns on its own and every later call arrives above the viewport.
 //
 // Positions are set directly rather than flicked. A flick's momentum and its
 // boundary bounce are timing-dependent, and the behaviour under test is keyed on
@@ -34,7 +33,6 @@ Item {
         when: windowShown
 
         property var list: null
-        property var pill: null
 
         function atTop() {
             // Sub-pixel: positionViewAtBeginning can land on -0.0.
@@ -57,9 +55,7 @@ Item {
         function initTestCase() {
             verify(screenLoader.item !== null, "HistoryScreen.qml failed to load")
             tc.list = findChild(screenLoader.item, "callLogList")
-            tc.pill = findChild(screenLoader.item, "newCallsPill")
             verify(tc.list !== null, "the call log list is missing")
-            verify(tc.pill !== null, "the new-calls pill is missing")
         }
 
         function init() {
@@ -70,7 +66,7 @@ Item {
             callHistory.pushMany(24, "TODAY")
             tc.list.positionViewAtBeginning()
             tc.waitForRendering(tc.list)
-            tryVerify(function () { return tc.atTop() && tc.list.unseen === 0 })
+            tryVerify(function () { return tc.atTop() })
         }
 
         function test_01_calls_landing_at_the_top_stay_in_view() {
@@ -88,12 +84,9 @@ Item {
             var newestRow = tc.list.itemAtIndex(0)
             verify(newestRow.y >= tc.list.contentY - 1)
             verify(newestRow.y + newestRow.height <= tc.list.contentY + tc.list.height)
-
-            compare(tc.list.unseen, 0)
-            verify(!tc.pill.shown)
         }
 
-        function test_02_reading_further_back_holds_its_place_and_tallies() {
+        function test_02_reading_further_back_holds_its_place() {
             tc.scrollBack()
             var anchorRow = tc.rowAtViewportTop()
             var anchorName = anchorRow.name
@@ -106,43 +99,21 @@ Item {
 
             callHistory.pushMany(3, "TODAY")
 
-            // One deferred reconcile for three inserts: the tally is a delta, so
-            // coalescing must not lose calls.
-            tryCompare(tc.list, "unseen", 3)
-            verify(tc.pill.shown)
+            // The new calls land above the viewport, out of sight — the whole
+            // reason the list has to be pinned when the reader is at the top.
+            // Waiting on the gap rather than on count: the model count changes
+            // first, before the view has applied the insertions.
+            tryVerify(function () { return tc.list.contentY - tc.list.originY > wasGap })
 
-            // The reader has not been moved.
+            // And the reader has not been moved.
             var stillThere = tc.rowAtViewportTop()
             compare(stillThere.name, anchorName)
             verify(Math.abs((stillThere.y - tc.list.contentY) - anchorScreenY) < 2)
-
-            // And the new calls landed above the viewport, out of sight — the
-            // whole reason the list has to be pinned when the reader is at the top.
-            verify(tc.list.contentY - tc.list.originY > wasGap)
             var newestRow = tc.list.itemAtIndex(0)
             verify(newestRow === null || newestRow.y + newestRow.height <= tc.list.contentY)
         }
 
-        function test_03_the_pill_returns_to_the_latest_call() {
-            tc.scrollBack()
-            var newest = ""
-            for (var i = 0; i < 3; i++) {
-                newest = callHistory.push("TODAY")
-            }
-            tryVerify(function () { return tc.pill.shown })
-
-            mouseClick(tc.pill)
-
-            tryVerify(function () { return tc.atTop() })
-            tryCompare(tc.list, "unseen", 0)
-            verify(!tc.pill.shown)
-            tryVerify(function () {
-                var first = tc.list.itemAtIndex(0)
-                return first !== null && first.name === newest
-            }, 5000, "the pill did not land on the newest call")
-        }
-
-        function test_04_an_offset_inside_one_row_still_counts_as_the_latest() {
+        function test_03_an_offset_inside_one_row_still_counts_as_the_latest() {
             // What a stray touch, an overscroll bounce or the keyboard resizing
             // the view leaves behind. None of it means "I am reading back".
             tc.list.contentY = tc.list.originY + 20
@@ -152,35 +123,9 @@ Item {
             callHistory.push("TODAY")
 
             tryVerify(function () { return tc.atTop() })
-            compare(tc.list.unseen, 0)
-            verify(!tc.pill.shown)
         }
 
-        function test_05_a_filter_change_is_answered_from_the_top() {
-            tc.scrollBack()
-            callHistory.pushMany(3, "TODAY")
-            tryCompare(tc.list, "unseen", 3)
-
-            historyView.filterKind = 1 // clear calls, which is all of them
-
-            tryVerify(function () { return tc.atTop() })
-            tryCompare(tc.list, "unseen", 0)
-            verify(!tc.pill.shown)
-        }
-
-        function test_06_clearing_the_log_leaves_no_stale_tally() {
-            tc.scrollBack()
-            callHistory.pushMany(3, "TODAY")
-            tryCompare(tc.list, "unseen", 3)
-
-            callHistory.clearAll()
-
-            tryCompare(tc.list, "count", 0)
-            tryCompare(tc.list, "unseen", 0)
-            verify(!tc.pill.shown)
-        }
-
-        function test_07_the_hidden_count_reads_as_a_sentence() {
+        function test_04_the_hidden_count_reads_as_a_sentence() {
             // %n plural forms need a translation catalogue the app does not ship,
             // so a %n string renders its own "(s)" and never agrees with its verb.
             var detail = findChild(screenLoader.item, "logEmptyDetail")

--- a/tests/ui/qml/tst_call_log_follow.qml
+++ b/tests/ui/qml/tst_call_log_follow.qml
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import QtTest
+
+// The history screen's call log has to keep the latest call in view while the
+// reader is parked at the top, hold their place when they are reading further
+// back, and say what landed while they were away. The bug this guards against is
+// silent: a ListView prepend below the top moves the content rather than the
+// view, so a list left off the top never returns on its own and every later call
+// arrives above the viewport with nothing on screen to say so.
+//
+// Positions are set directly rather than flicked. A flick's momentum and its
+// boundary bounce are timing-dependent, and the behaviour under test is keyed on
+// where the list came to rest, not on how it got there.
+Item {
+    id: root
+
+    width: 420
+    height: 900
+
+    Loader {
+        id: screenLoader
+
+        anchors.fill: parent
+        source: uiDir + "/HistoryScreen.qml"
+    }
+
+    TestCase {
+        id: tc
+
+        name: "CallLogFollowsLatest"
+        when: windowShown
+
+        property var list: null
+        property var pill: null
+
+        function atTop() {
+            // Sub-pixel: positionViewAtBeginning can land on -0.0.
+            return Math.abs(tc.list.contentY - tc.list.originY) < 1
+        }
+
+        function scrollBack() {
+            // Far enough that the top row is well outside the viewport, which is
+            // what "reading further back" means to the list.
+            tc.list.contentY = tc.list.originY + 400
+            tc.waitForRendering(tc.list)
+        }
+
+        function rowAtViewportTop() {
+            var idx = tc.list.indexAt(tc.list.width / 2, tc.list.contentY + 40)
+            verify(idx >= 0, "no row under the top of the viewport")
+            return tc.list.itemAtIndex(idx)
+        }
+
+        function initTestCase() {
+            verify(screenLoader.item !== null, "HistoryScreen.qml failed to load")
+            tc.list = findChild(screenLoader.item, "callLogList")
+            tc.pill = findChild(screenLoader.item, "newCallsPill")
+            verify(tc.list !== null, "the call log list is missing")
+            verify(tc.pill !== null, "the new-calls pill is missing")
+        }
+
+        function init() {
+            historyView.filterText = ""
+            historyView.filterSystem = ""
+            historyView.filterKind = 0
+            callHistory.clearAll()
+            callHistory.pushMany(24, "TODAY")
+            tc.list.positionViewAtBeginning()
+            tc.waitForRendering(tc.list)
+            tryVerify(function () { return tc.atTop() && tc.list.unseen === 0 })
+        }
+
+        function test_01_calls_landing_at_the_top_stay_in_view() {
+            var newest = ""
+            for (var i = 0; i < 5; i++) {
+                newest = callHistory.push("TODAY")
+            }
+            tryVerify(function () { return tc.atTop() })
+            tryVerify(function () {
+                var first = tc.list.itemAtIndex(0)
+                return first !== null && first.name === newest
+            }, 5000, "the newest call is not the first row")
+
+            // On screen, not merely first: the promise is that the reader sees it.
+            var newestRow = tc.list.itemAtIndex(0)
+            verify(newestRow.y >= tc.list.contentY - 1)
+            verify(newestRow.y + newestRow.height <= tc.list.contentY + tc.list.height)
+
+            compare(tc.list.unseen, 0)
+            verify(!tc.pill.shown)
+        }
+
+        function test_02_reading_further_back_holds_its_place_and_tallies() {
+            tc.scrollBack()
+            var anchorRow = tc.rowAtViewportTop()
+            var anchorName = anchorRow.name
+            var anchorScreenY = anchorRow.y - tc.list.contentY
+            // The gap from the start of the content, which is what the list reads
+            // to decide the reader is not on the latest call. A prepend grows it
+            // by walking originY backwards rather than by moving contentY, so
+            // contentY alone says nothing here.
+            var wasGap = tc.list.contentY - tc.list.originY
+
+            callHistory.pushMany(3, "TODAY")
+
+            // One deferred reconcile for three inserts: the tally is a delta, so
+            // coalescing must not lose calls.
+            tryCompare(tc.list, "unseen", 3)
+            verify(tc.pill.shown)
+
+            // The reader has not been moved.
+            var stillThere = tc.rowAtViewportTop()
+            compare(stillThere.name, anchorName)
+            verify(Math.abs((stillThere.y - tc.list.contentY) - anchorScreenY) < 2)
+
+            // And the new calls landed above the viewport, out of sight — the
+            // whole reason the list has to be pinned when the reader is at the top.
+            verify(tc.list.contentY - tc.list.originY > wasGap)
+            var newestRow = tc.list.itemAtIndex(0)
+            verify(newestRow === null || newestRow.y + newestRow.height <= tc.list.contentY)
+        }
+
+        function test_03_the_pill_returns_to_the_latest_call() {
+            tc.scrollBack()
+            var newest = ""
+            for (var i = 0; i < 3; i++) {
+                newest = callHistory.push("TODAY")
+            }
+            tryVerify(function () { return tc.pill.shown })
+
+            mouseClick(tc.pill)
+
+            tryVerify(function () { return tc.atTop() })
+            tryCompare(tc.list, "unseen", 0)
+            verify(!tc.pill.shown)
+            tryVerify(function () {
+                var first = tc.list.itemAtIndex(0)
+                return first !== null && first.name === newest
+            }, 5000, "the pill did not land on the newest call")
+        }
+
+        function test_04_an_offset_inside_one_row_still_counts_as_the_latest() {
+            // What a stray touch, an overscroll bounce or the keyboard resizing
+            // the view leaves behind. None of it means "I am reading back".
+            tc.list.contentY = tc.list.originY + 20
+            tc.waitForRendering(tc.list)
+            verify(!tc.atTop())
+
+            callHistory.push("TODAY")
+
+            tryVerify(function () { return tc.atTop() })
+            compare(tc.list.unseen, 0)
+            verify(!tc.pill.shown)
+        }
+
+        function test_05_a_filter_change_is_answered_from_the_top() {
+            tc.scrollBack()
+            callHistory.pushMany(3, "TODAY")
+            tryCompare(tc.list, "unseen", 3)
+
+            historyView.filterKind = 1 // clear calls, which is all of them
+
+            tryVerify(function () { return tc.atTop() })
+            tryCompare(tc.list, "unseen", 0)
+            verify(!tc.pill.shown)
+        }
+
+        function test_06_clearing_the_log_leaves_no_stale_tally() {
+            tc.scrollBack()
+            callHistory.pushMany(3, "TODAY")
+            tryCompare(tc.list, "unseen", 3)
+
+            callHistory.clearAll()
+
+            tryCompare(tc.list, "count", 0)
+            tryCompare(tc.list, "unseen", 0)
+            verify(!tc.pill.shown)
+        }
+
+        function test_07_the_hidden_count_reads_as_a_sentence() {
+            // %n plural forms need a translation catalogue the app does not ship,
+            // so a %n string renders its own "(s)" and never agrees with its verb.
+            var detail = findChild(screenLoader.item, "logEmptyDetail")
+            verify(detail !== null, "the empty-state detail line is missing")
+
+            callHistory.clearAll()
+            callHistory.push("TODAY")
+            historyView.filterKind = 2 // encrypted only: hides the clear call
+
+            tryCompare(tc.list, "count", 0)
+            verify(detail.parent.visible, "the empty state is not showing")
+            compare(detail.text.indexOf("(s)"), -1, detail.text)
+            compare(detail.text.indexOf("1 logged call is hidden"), 0, detail.text)
+
+            callHistory.pushMany(3, "TODAY")
+
+            tryVerify(function () { return detail.text.indexOf("4 logged calls are hidden") === 0 },
+                      5000, "the plural form did not follow the count")
+            compare(detail.text.indexOf("(s)"), -1, detail.text)
+        }
+    }
+}

--- a/tests/ui/qml/tst_call_log_follow.qml
+++ b/tests/ui/qml/tst_call_log_follow.qml
@@ -145,6 +145,43 @@ Item {
             tryVerify(function () { return detail.text.indexOf("4 logged calls are hidden") === 0 },
                       5000, "the plural form did not follow the count")
             compare(detail.text.indexOf("(s)"), -1, detail.text)
+
+            // The filter under the list is the production one, so the pill has to
+            // pass a call it accepts, not merely hide the ones it does not: an
+            // encrypted call shows while the four clear ones stay hidden. It is
+            // stamped encrypted after it was logged, which is how a late ENC
+            // header reaches an already-written row.
+            callHistory.pushEncrypted("TODAY")
+
+            tryCompare(tc.list, "count", 1)
+            // On the binding, not on the property: tryCompare polls count by
+            // reading it, while the view emits countChanged on its next layout
+            // pass, which is when the empty state can go away.
+            tryVerify(function () { return !detail.parent.visible }, 5000,
+                      "the empty state is still showing over the encrypted call")
+        }
+
+        // A finger resting on the list is not a drag, so Flickable.moving stays
+        // false throughout. Re-asserting the top under it would move the content
+        // away from the press position the Flickable recorded when the finger went
+        // down, and the reader's next drag would open by snapping back to it.
+        function test_05_a_call_under_a_held_finger_waits_for_the_release() {
+            tc.list.contentY = tc.list.originY + 20
+            tc.waitForRendering(tc.list)
+            verify(!tc.atTop())
+
+            mousePress(tc.list, tc.list.width / 2, 20)
+            callHistory.push("TODAY")
+            // Asserting an absence, so the deferred pin has to be given the event
+            // loop passes it would have needed to run.
+            tc.waitForRendering(tc.list)
+            tc.wait(50)
+            verify(!tc.atTop(), "the list was pinned under a held finger")
+
+            mouseRelease(tc.list, tc.list.width / 2, 20)
+
+            tryVerify(function () { return tc.atTop() }, 5000,
+                      "the deferred pin never ran after the release")
         }
     }
 }

--- a/tests/ui/qml/tst_call_log_follow.qml
+++ b/tests/ui/qml/tst_call_log_follow.qml
@@ -183,5 +183,50 @@ Item {
             tryVerify(function () { return tc.atTop() }, 5000,
                       "the deferred pin never ran after the release")
         }
+
+        // A filter change is not a call landing: it is a new question, and where
+        // the reader had scrolled to is the answer to the old one. The view holds
+        // its scroll position across the change, so without a reposition the
+        // reader lands in the middle of the new result with the newest matching
+        // calls off-screen above and nothing on screen to say they exist.
+        function test_06_a_narrowing_filter_is_answered_from_the_top() {
+            // Enough matching rows that the filtered content still overflows the
+            // viewport. A result shorter than the viewport is dragged back to the
+            // top by the Flickable's own bounds, and would pass with the
+            // reposition deleted.
+            for (var i = 0; i < 20; i++) {
+                callHistory.pushEncrypted("TODAY")
+            }
+            tryCompare(tc.list, "count", 44)
+            tc.list.contentY = tc.list.originY + 1200
+            tc.waitForRendering(tc.list)
+            verify(!tc.atTop())
+
+            historyView.filterKind = 2 // encrypted only: the 20 just pushed
+
+            tryCompare(tc.list, "count", 20)
+            tryVerify(function () { return tc.atTop() }, 5000,
+                      "the filtered log did not open on its newest matching call")
+            // The precondition, asserted rather than assumed: had the result fit
+            // the viewport, the top would prove nothing.
+            verify(tc.list.contentHeight > tc.list.height)
+            var newestRow = tc.list.itemAtIndex(0)
+            verify(newestRow !== null, "the newest matching call has no row")
+            verify(newestRow.y + newestRow.height <= tc.list.contentY + tc.list.height)
+        }
+
+        // The same rule where no row moves at all: the pill cycles onto a filter
+        // every logged call already passes. Nothing is inserted or removed, so the
+        // view's own count never changes and the pin has no signal to fire on —
+        // only the filter change itself can bring the log back.
+        function test_07_a_filter_that_hides_nothing_is_still_answered_from_the_top() {
+            tc.scrollBack()
+
+            historyView.filterKind = 1 // clear calls, which is all of them
+
+            tryVerify(function () { return tc.atTop() }, 5000,
+                      "a filter change that hid no rows left the log where it was")
+            compare(tc.list.count, 24)
+        }
     }
 }

--- a/tests/ui/qml/tst_context_fixture.qml
+++ b/tests/ui/qml/tst_context_fixture.qml
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import QtTest
+
+// The engine-facing context properties are plain maps (see qml_test_context.h),
+// and QML answers a read of a key a map does not carry with `undefined` — no
+// warning, no error. So a screen that grew a binding on a reading the fixture
+// lacks would pass every case in this suite and render `undefined` or NaN on the
+// phone. This is the case that makes that loud.
+TestCase {
+    name: "QmlContextFixtureIsComplete"
+
+    function test_01_the_fixture_carries_every_reading_the_screens_read() {
+        // The two screens the other cases load, plus Theme.qml: the screens pull
+        // it in as a singleton and it reads prefs itself.
+        var missing = testContext.missingContextKeys(["HistoryScreen.qml", "MonitorScreen.qml", "Theme.qml"])
+
+        compare(missing.length, 0,
+                "read by the screens, missing from the fixture: " + missing.join(", "))
+    }
+}

--- a/tests/ui/qml/tst_monitor_recent_calls.qml
+++ b/tests/ui/qml/tst_monitor_recent_calls.qml
@@ -109,5 +109,28 @@ Item {
             verify(!tc.atTop())
             compare(tc.list.itemAtIndex(tc.list.indexAt(tc.list.width / 2, tc.list.contentY + 20)).name, anchorName)
         }
+
+        // Same rule as the history log: a finger resting on the pane is not a
+        // drag, so Flickable.moving stays false for it, and repositioning under
+        // the press would leave the reader's next drag snapping back to where the
+        // finger went down.
+        function test_05_a_call_under_a_held_finger_waits_for_the_release() {
+            tc.list.contentY = tc.list.originY + 20
+            tc.waitForRendering(tc.list)
+            verify(!tc.atTop())
+
+            mousePress(tc.list, tc.list.width / 2, 20)
+            callHistory.push("TODAY")
+            // Asserting an absence, so the deferred pin has to be given the event
+            // loop passes it would have needed to run.
+            tc.waitForRendering(tc.list)
+            tc.wait(50)
+            verify(!tc.atTop(), "the pane was pinned under a held finger")
+
+            mouseRelease(tc.list, tc.list.width / 2, 20)
+
+            tryVerify(function () { return tc.atTop() }, 5000,
+                      "the deferred pin never ran after the release")
+        }
     }
 }

--- a/tests/ui/qml/tst_monitor_recent_calls.qml
+++ b/tests/ui/qml/tst_monitor_recent_calls.qml
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import QtTest
+
+// The monitor's recent-calls pane is the same newest-first list as the history
+// log, and drifts the same way if the top is not re-asserted. It carries no
+// new-calls pill — four rows have no room for one — so what it owes the reader is
+// only this: the call that just ended is on screen, and scrolling back holds.
+Item {
+    id: root
+
+    width: 420
+    height: 900
+
+    Loader {
+        id: screenLoader
+
+        anchors.fill: parent
+        source: uiDir + "/MonitorScreen.qml"
+    }
+
+    TestCase {
+        id: tc
+
+        name: "MonitorRecentCallsFollowsLatest"
+        when: windowShown
+
+        property var list: null
+
+        function atTop() {
+            return Math.abs(tc.list.contentY - tc.list.originY) < 1
+        }
+
+        function initTestCase() {
+            verify(screenLoader.item !== null, "MonitorScreen.qml failed to load")
+            tc.list = findChild(screenLoader.item, "recentCallsList")
+            verify(tc.list !== null, "the recent-calls list is missing")
+        }
+
+        function init() {
+            monitorView.minWhen = 0
+            callHistory.clearAll()
+            callHistory.pushMany(12, "TODAY")
+            tc.list.positionViewAtBeginning()
+            tc.waitForRendering(tc.list)
+            tryVerify(function () { return tc.atTop() })
+        }
+
+        function test_01_the_call_that_just_ended_is_on_screen() {
+            var newest = ""
+            for (var i = 0; i < 4; i++) {
+                newest = callHistory.push("TODAY")
+            }
+            tryVerify(function () { return tc.atTop() })
+            tryVerify(function () {
+                var first = tc.list.itemAtIndex(0)
+                return first !== null && first.name === newest
+            }, 5000, "the newest call is not the first row")
+        }
+
+        function test_02_scrolling_back_holds_the_reader_place() {
+            // The pane is short, so scroll by a couple of rows rather than a screen.
+            tc.list.contentY = tc.list.originY + 150
+            tc.waitForRendering(tc.list)
+            var anchorName = tc.list.itemAtIndex(tc.list.indexAt(tc.list.width / 2, tc.list.contentY + 20)).name
+            // A prepend grows the gap from the start of the content by walking
+            // originY backwards; contentY itself need not move.
+            var wasGap = tc.list.contentY - tc.list.originY
+
+            callHistory.pushMany(2, "TODAY")
+
+            tryVerify(function () { return tc.list.contentY - tc.list.originY > wasGap })
+            verify(!tc.atTop())
+            compare(tc.list.itemAtIndex(tc.list.indexAt(tc.list.width / 2, tc.list.contentY + 20)).name, anchorName)
+        }
+    }
+}

--- a/tests/ui/qml/tst_monitor_recent_calls.qml
+++ b/tests/ui/qml/tst_monitor_recent_calls.qml
@@ -60,7 +60,21 @@ Item {
             }, 5000, "the newest call is not the first row")
         }
 
-        function test_02_scrolling_back_holds_the_reader_place() {
+        // The case that actually needs the pin, and the one measured by hand on a
+        // device: a drag that leaves the pane a fraction of a row down. ListView
+        // holds an exact top by itself, so a test that only ever sits at the top
+        // passes with the pin deleted.
+        function test_02_an_offset_inside_one_row_still_counts_as_the_latest() {
+            tc.list.contentY = tc.list.originY + 20
+            tc.waitForRendering(tc.list)
+            verify(!tc.atTop())
+
+            callHistory.push("TODAY")
+
+            tryVerify(function () { return tc.atTop() })
+        }
+
+        function test_03_scrolling_back_holds_the_reader_place() {
             // The pane is short, so scroll by a couple of rows rather than a screen.
             tc.list.contentY = tc.list.originY + 150
             tc.waitForRendering(tc.list)

--- a/tests/ui/qml/tst_monitor_recent_calls.qml
+++ b/tests/ui/qml/tst_monitor_recent_calls.qml
@@ -74,7 +74,27 @@ Item {
             tryVerify(function () { return tc.atTop() })
         }
 
-        function test_03_scrolling_back_holds_the_reader_place() {
+        // The reading exists so a log that stays empty on an almost entirely
+        // encrypted site does not read as a decoder that stopped. It must appear
+        // once something is locked out and stay out of the way when nothing is.
+        function test_03_the_lockout_count_shows_only_once_something_is_locked_out() {
+            var row = findChild(screenLoader.item, "encLockoutRow")
+            var value = findChild(screenLoader.item, "encLockoutValue")
+            verify(row !== null, "the lockout row is missing")
+            verify(value !== null, "the lockout value is missing")
+
+            testContext.setMetric("encLockoutCount", 0)
+            tryVerify(function () { return !row.visible })
+
+            testContext.setMetric("encLockoutCount", 6)
+            tryVerify(function () { return row.visible })
+            compare(value.text, "6")
+
+            testContext.setMetric("encLockoutCount", 0)
+            tryVerify(function () { return !row.visible })
+        }
+
+        function test_04_scrolling_back_holds_the_reader_place() {
             // The pane is short, so scroll by a couple of rows rather than a screen.
             tc.list.contentY = tc.list.originY + 150
             tc.waitForRendering(tc.list)

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -19,8 +19,15 @@
  * prepends rows on demand — the real store only grows by ingesting a decoder
  * snapshot ring, which is covered by UI_QT_CALL_HISTORY_MODEL instead. The
  * engine-facing objects (metrics, decoderHost, commands, prefs) are plain maps
- * carrying every key the screens read, so a screen that grows a new binding
- * fails here loudly rather than silently rendering `undefined`.
+ * rather than the production QObject models, which is what keeps this test off
+ * the app-control boundary and clear of the engine libraries.
+ *
+ * That last choice gives up one guarantee, and missingContextKeys() buys it back:
+ * reading a key a QVariantMap does not carry yields `undefined` with no warning
+ * and no error, so an incomplete fixture would not fail on its own — a screen
+ * that grew a binding on a reading missing here would pass this suite and render
+ * `undefined` on the phone. tst_context_fixture.qml closes that by checking the
+ * maps against the reads the screens under test actually contain.
  */
 
 #ifndef DSD_NEO_TESTS_UI_QML_TEST_CONTEXT_H_
@@ -28,11 +35,14 @@
 
 #include <QAbstractListModel>
 #include <QDateTime>
+#include <QFile>
 #include <QFontDatabase>
 #include <QHash>
+#include <QIODevice>
 #include <QList>
 #include <QQmlContext>
 #include <QQmlEngine>
+#include <QRegularExpression>
 #include <QString>
 #include <QStringList>
 #include <QVariantMap>
@@ -169,7 +179,13 @@ class CallLogStore : public QAbstractListModel {
         }
     }
 
-    /** @brief Mark the next pushed row encrypted, for the kind filter. */
+    /**
+     * @brief Prepend one call and then stamp it encrypted, for the kind filter.
+     *
+     * Two steps rather than one, because that is the order the real thing happens
+     * in: a row is logged and the ENC header lands on it afterwards. It also puts
+     * the filter's dataChanged path under test, not only its insert path.
+     */
     Q_INVOKABLE void
     pushEncrypted(const QString& dayLabel) {
         push(dayLabel);
@@ -220,6 +236,57 @@ class Setup : public QObject {
         }
     }
 
+    /**
+     * @brief Reads in @p qmlFiles that name a context-property key the fixture lacks.
+     *
+     * Returns "metrics.someReading" style entries, empty when the maps below cover
+     * every read. Exists because a QVariantMap answers an unknown key with
+     * `undefined` rather than an error (see the file comment): without this the
+     * fixture could fall behind the screens silently.
+     *
+     * Literal `name.key` reads only. A key assembled at run time
+     * (`metrics["slot" + n + "TgText"]`) is invisible here and still has to be
+     * added to the maps by hand. Method calls are skipped — `decoderHost.stop()`
+     * is a command, not a reading — and `commands` is left out entirely for the
+     * same reason: every use of it is a call on a user action no case triggers.
+     *
+     * @param qmlFiles File names under src/ui/qt/qml, as the tests load them.
+     */
+    Q_INVOKABLE QStringList
+    missingContextKeys(const QStringList& qmlFiles) const {
+        const QHash<QString, QVariantMap> maps = {{QStringLiteral("metrics"), m_metrics},
+                                                  {QStringLiteral("prefs"), m_prefs},
+                                                  {QStringLiteral("decoderHost"), m_host}};
+        /* Group 3 captures the "(" that marks a call rather than a read. */
+        static const QRegularExpression read(
+            QStringLiteral("\\b(metrics|prefs|decoderHost)\\.([A-Za-z_][A-Za-z0-9_]*)\\s*(\\()?"));
+
+        QStringList missing;
+        for (const QString& name : qmlFiles) {
+            QFile file(QStringLiteral(DSD_QML_UI_DIR "/") + name);
+            if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+                missing.append(name + QStringLiteral(" (unreadable)"));
+                continue;
+            }
+            const QString text = QString::fromUtf8(file.readAll());
+            QRegularExpressionMatchIterator it = read.globalMatch(text);
+            while (it.hasNext()) {
+                const QRegularExpressionMatch match = it.next();
+                if (!match.captured(3).isEmpty()) {
+                    continue;
+                }
+                const QString object = match.captured(1);
+                const QString key = match.captured(2);
+                const QString entry = object + QLatin1Char('.') + key;
+                if (!maps.value(object).contains(key) && !missing.contains(entry)) {
+                    missing.append(entry);
+                }
+            }
+        }
+        missing.sort();
+        return missing;
+    }
+
   public Q_SLOTS:
 
     /**
@@ -261,10 +328,11 @@ class Setup : public QObject {
         prefs[QStringLiteral("appearance")] = 2;
         prefs[QStringLiteral("onboardingDone")] = true;
         prefs[QStringLiteral("backgroundListening")] = false;
+        m_prefs = prefs;
         ctx->setContextProperty(QStringLiteral("prefs"), prefs);
 
-        /* Every key the monitor reads, at rest with no call up: a missing one
-         * would surface as an undefined-property warning instead of a failure. */
+        /* Every key the monitor reads, at rest with no call up. Add to this when a
+         * screen grows a reading — missingContextKeys() is what says so. */
         QVariantMap metrics;
         metrics[QStringLiteral("uiMessage")] = QString();
         metrics[QStringLiteral("audioMuted")] = false;
@@ -298,12 +366,15 @@ class Setup : public QObject {
         host[QStringLiteral("running")] = false;
         host[QStringLiteral("transitioning")] = false;
         host[QStringLiteral("statusText")] = QStringLiteral("idle");
+        m_host = host;
         ctx->setContextProperty(QStringLiteral("decoderHost"), host);
         ctx->setContextProperty(QStringLiteral("commands"), QVariantMap());
     }
 
   private:
     QVariantMap m_metrics;
+    QVariantMap m_prefs;
+    QVariantMap m_host;
     QQmlEngine* m_engine = nullptr;
 };
 

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -203,6 +203,23 @@ class CallLogStore : public QAbstractListModel {
 class Setup : public QObject {
     Q_OBJECT
 
+  public:
+    /**
+     * @brief Change one engine reading and republish it.
+     *
+     * The engine-facing mocks are plain maps, which QML cannot mutate in place;
+     * re-setting the context property is what re-evaluates the bindings that read
+     * it. Exposed to the tests as `testContext` so a case can drive a reading to
+     * a value and back rather than asserting only whatever the fixture started at.
+     */
+    Q_INVOKABLE void
+    setMetric(const QString& key, const QVariant& value) {
+        m_metrics[key] = value;
+        if (m_engine != nullptr) {
+            m_engine->rootContext()->setContextProperty(QStringLiteral("metrics"), m_metrics);
+        }
+    }
+
   public Q_SLOTS:
 
     /**
@@ -270,7 +287,12 @@ class Setup : public QObject {
             metrics[p + QStringLiteral("EncText")] = QString();
             metrics[p + QStringLiteral("TgId")] = 0;
         }
+        // Targets the encrypted lockout is skipping; 0 is the at-rest value.
+        metrics[QStringLiteral("encLockoutCount")] = 0;
+        m_metrics = metrics;
+        m_engine = engine;
         ctx->setContextProperty(QStringLiteral("metrics"), metrics);
+        ctx->setContextProperty(QStringLiteral("testContext"), this);
 
         QVariantMap host;
         host[QStringLiteral("running")] = false;
@@ -279,6 +301,10 @@ class Setup : public QObject {
         ctx->setContextProperty(QStringLiteral("decoderHost"), host);
         ctx->setContextProperty(QStringLiteral("commands"), QVariantMap());
     }
+
+  private:
+    QVariantMap m_metrics;
+    QQmlEngine* m_engine = nullptr;
 };
 
 #endif /* DSD_NEO_TESTS_UI_QML_TEST_CONTEXT_H_ */

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Test doubles and QML context for UI_QT_QML_CALL_LISTS.
+ *
+ * The Q_OBJECT classes live in a header rather than beside main() so AUTOMOC
+ * emits their meta-object code as its own generated translation unit. A
+ * `#include "*.moc"` would pull that generated code into the test's own
+ * translation unit, where the project's clang-tidy configuration would then
+ * analyse moc output nobody can fix.
+ *
+ * What is real here and what is not: the view models are the production
+ * CallHistoryFilterModel, so the filter and its change signalling are under
+ * test. Behind it sits CallLogStore, a stand-in for CallHistoryModel that
+ * prepends rows on demand — the real store only grows by ingesting a decoder
+ * snapshot ring, which is covered by UI_QT_CALL_HISTORY_MODEL instead. The
+ * engine-facing objects (metrics, decoderHost, commands, prefs) are plain maps
+ * carrying every key the screens read, so a screen that grows a new binding
+ * fails here loudly rather than silently rendering `undefined`.
+ */
+
+#ifndef DSD_NEO_TESTS_UI_QML_TEST_CONTEXT_H_
+#define DSD_NEO_TESTS_UI_QML_TEST_CONTEXT_H_
+
+#include <QAbstractListModel>
+#include <QDateTime>
+#include <QFontDatabase>
+#include <QHash>
+#include <QList>
+#include <QQmlContext>
+#include <QQmlEngine>
+#include <QString>
+#include <QStringList>
+#include <QVariantMap>
+#include <QtQuickTest>
+
+#include "call_history_filter.h"
+#include "call_history_model.h"
+
+using dsd_qt::CallHistoryFilterModel;
+using dsd_qt::CallHistoryModel;
+
+/**
+ * @brief Newest-first call log the tests drive directly.
+ *
+ * Same roles and the same newest-first prepend as CallHistoryModel, with
+ * granular insert/reset signals — the screens' scroll behaviour is a reaction to
+ * those signals, so a reset-everything stand-in would test nothing.
+ */
+class CallLogStore : public QAbstractListModel {
+    Q_OBJECT
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(QString sessionLabel READ sessionLabel WRITE setSessionLabel NOTIFY sessionLabelChanged)
+    Q_PROPERTY(QStringList systemLabels READ systemLabels NOTIFY countChanged)
+
+  public:
+    /** @brief One logged row, mirroring CallHistoryModel::Row's visible fields. */
+    struct StoreRow {
+        QString name;
+        qulonglong tg = 0;
+        qulonglong src = 0;
+        bool enc = false;
+        qint64 when = 0;
+        int durationSecs = 4;
+        QString systemName;
+        QString dayLabel;
+        QString timeText;
+        int kind = CallHistoryModel::KindVoice;
+        QString detail;
+    };
+
+    int
+    rowCount(const QModelIndex& parent = QModelIndex()) const override {
+        return parent.isValid() ? 0 : static_cast<int>(m_rows.size());
+    }
+
+    int
+    count() const {
+        return rowCount();
+    }
+
+    QString
+    sessionLabel() const {
+        return m_sessionLabel;
+    }
+
+    void
+    setSessionLabel(const QString& label) {
+        if (label == m_sessionLabel) {
+            return;
+        }
+        m_sessionLabel = label;
+        Q_EMIT sessionLabelChanged();
+    }
+
+    QStringList
+    systemLabels() const {
+        return m_rows.isEmpty() ? QStringList() : QStringList{m_systemName};
+    }
+
+    QVariant
+    data(const QModelIndex& index, int role) const override {
+        if (!index.isValid() || index.row() < 0 || index.row() >= m_rows.size()) {
+            return {};
+        }
+        const StoreRow& row = m_rows.at(index.row());
+        switch (role) {
+            case CallHistoryModel::NameRole: return row.name;
+            case CallHistoryModel::TgRole: return row.tg;
+            case CallHistoryModel::SrcRole: return row.src;
+            case CallHistoryModel::EncRole: return row.enc;
+            case CallHistoryModel::WhenRole: return row.when;
+            case CallHistoryModel::DurationSecsRole: return row.durationSecs;
+            case CallHistoryModel::SystemNameRole: return row.systemName;
+            case CallHistoryModel::DayLabelRole: return row.dayLabel;
+            case CallHistoryModel::TimeTextRole: return row.timeText;
+            case CallHistoryModel::KindRole: return row.kind;
+            case CallHistoryModel::DetailRole: return row.detail;
+            default: return {};
+        }
+    }
+
+    QHash<int, QByteArray>
+    roleNames() const override {
+        return {{CallHistoryModel::NameRole, "name"},
+                {CallHistoryModel::TgRole, "tg"},
+                {CallHistoryModel::SrcRole, "src"},
+                {CallHistoryModel::EncRole, "enc"},
+                {CallHistoryModel::WhenRole, "when"},
+                {CallHistoryModel::DurationSecsRole, "durationSecs"},
+                {CallHistoryModel::SystemNameRole, "systemName"},
+                {CallHistoryModel::DayLabelRole, "dayLabel"},
+                {CallHistoryModel::TimeTextRole, "timeText"},
+                {CallHistoryModel::KindRole, "kind"},
+                {CallHistoryModel::DetailRole, "detail"}};
+    }
+
+    /**
+     * @brief Prepend one clear voice call under @p dayLabel.
+     * @return The row's name, so a test can follow that one row up the list.
+     */
+    Q_INVOKABLE QString
+    push(const QString& dayLabel) {
+        StoreRow row;
+        m_seq++;
+        row.name = QStringLiteral("CALL %1").arg(m_seq, 3, 10, QLatin1Char('0'));
+        row.tg = 1000 + static_cast<qulonglong>(m_seq);
+        row.src = 200000 + static_cast<qulonglong>(m_seq);
+        row.when = m_clock++;
+        row.systemName = m_systemName;
+        row.dayLabel = dayLabel.isEmpty() ? QStringLiteral("TODAY") : dayLabel;
+        row.timeText = QStringLiteral("12:%1").arg(m_seq % 60, 2, 10, QLatin1Char('0'));
+        beginInsertRows(QModelIndex(), 0, 0);
+        m_rows.prepend(row);
+        endInsertRows();
+        Q_EMIT countChanged();
+        return row.name;
+    }
+
+    /** @brief Prepend @p n calls, oldest first, so the list reads newest-first. */
+    Q_INVOKABLE void
+    pushMany(int n, const QString& dayLabel) {
+        for (int i = 0; i < n; i++) {
+            push(dayLabel);
+        }
+    }
+
+    /** @brief Mark the next pushed row encrypted, for the kind filter. */
+    Q_INVOKABLE void
+    pushEncrypted(const QString& dayLabel) {
+        push(dayLabel);
+        m_rows[0].enc = true;
+        const QModelIndex idx = index(0);
+        Q_EMIT dataChanged(idx, idx, {CallHistoryModel::EncRole});
+    }
+
+    Q_INVOKABLE void
+    clearAll() {
+        beginResetModel();
+        m_rows.clear();
+        endResetModel();
+        Q_EMIT countChanged();
+    }
+
+  Q_SIGNALS:
+    void countChanged();
+    void sessionLabelChanged();
+
+  private:
+    QList<StoreRow> m_rows;
+    QString m_systemName = QStringLiteral("Test Site");
+    QString m_sessionLabel = QStringLiteral("Test Site");
+    int m_seq = 0;
+    /* Fixed, ascending stamps: nothing here should depend on the wall clock. */
+    qint64 m_clock = 1'700'000'000;
+};
+
+/** @brief Installs the context the screens expect before any QML is loaded. */
+class Setup : public QObject {
+    Q_OBJECT
+
+  public Q_SLOTS:
+
+    /**
+     * @brief Load the bundled faces once the QGuiApplication exists.
+     *
+     * Not in the constructor: QUICK_TEST_MAIN_WITH_SETUP builds this object
+     * before the application, and QFontDatabase crashes without one.
+     */
+    void
+    applicationAvailable() {
+        for (const QString& file :
+             {QStringLiteral("IBMPlexSans-Regular.ttf"), QStringLiteral("IBMPlexSans-SemiBold.ttf"),
+              QStringLiteral("IBMPlexSans-Bold.ttf"), QStringLiteral("IBMPlexMono-Regular.ttf"),
+              QStringLiteral("IBMPlexMono-Medium.ttf")}) {
+            QFontDatabase::addApplicationFont(QStringLiteral(DSD_QML_FONT_DIR "/") + file);
+        }
+    }
+
+    void
+    qmlEngineAvailable(QQmlEngine* engine) {
+        auto* store = new CallLogStore();
+        auto* historyView = new CallHistoryFilterModel(engine);
+        historyView->setSourceModel(store);
+        auto* monitorView = new CallHistoryFilterModel(engine);
+        monitorView->setSourceModel(store);
+        store->setParent(engine);
+
+        QQmlContext* ctx = engine->rootContext();
+        ctx->setContextProperty(QStringLiteral("uiDir"), QStringLiteral(DSD_QML_UI_DIR));
+        ctx->setContextProperty(QStringLiteral("callHistory"), store);
+        ctx->setContextProperty(QStringLiteral("historyView"), historyView);
+        ctx->setContextProperty(QStringLiteral("monitorView"), monitorView);
+        ctx->setContextProperty(QStringLiteral("sansFontFamily"), QStringLiteral("IBM Plex Sans"));
+        ctx->setContextProperty(QStringLiteral("monoFontFamily"), QStringLiteral("IBM Plex Mono"));
+
+        /* Appearance 2 = dark, so the run does not depend on the host's colour
+         * scheme; the token set is the only thing that reads it. */
+        QVariantMap prefs;
+        prefs[QStringLiteral("appearance")] = 2;
+        prefs[QStringLiteral("onboardingDone")] = true;
+        prefs[QStringLiteral("backgroundListening")] = false;
+        ctx->setContextProperty(QStringLiteral("prefs"), prefs);
+
+        /* Every key the monitor reads, at rest with no call up: a missing one
+         * would surface as an undefined-property warning instead of a failure. */
+        QVariantMap metrics;
+        metrics[QStringLiteral("uiMessage")] = QString();
+        metrics[QStringLiteral("audioMuted")] = false;
+        metrics[QStringLiteral("heldTg")] = 0;
+        metrics[QStringLiteral("carrierLock")] = false;
+        metrics[QStringLiteral("radioInput")] = true;
+        metrics[QStringLiteral("streamActive")] = false;
+        metrics[QStringLiteral("snrValid")] = false;
+        metrics[QStringLiteral("snrDb")] = 0.0;
+        metrics[QStringLiteral("cfoHz")] = 0.0;
+        metrics[QStringLiteral("tunerGainText")] = QStringLiteral("auto");
+        for (int slot = 1; slot <= 2; slot++) {
+            const QString p = QStringLiteral("slot%1").arg(slot);
+            metrics[p + QStringLiteral("CallState")] = 0;
+            metrics[p + QStringLiteral("CallName")] = QString();
+            metrics[p + QStringLiteral("CallEnc")] = false;
+            metrics[p + QStringLiteral("CallSeconds")] = 0;
+            metrics[p + QStringLiteral("TgText")] = QString();
+            metrics[p + QStringLiteral("SrcText")] = QString();
+            metrics[p + QStringLiteral("EncText")] = QString();
+            metrics[p + QStringLiteral("TgId")] = 0;
+        }
+        ctx->setContextProperty(QStringLiteral("metrics"), metrics);
+
+        QVariantMap host;
+        host[QStringLiteral("running")] = false;
+        host[QStringLiteral("transitioning")] = false;
+        host[QStringLiteral("statusText")] = QStringLiteral("idle");
+        ctx->setContextProperty(QStringLiteral("decoderHost"), host);
+        ctx->setContextProperty(QStringLiteral("commands"), QVariantMap());
+    }
+};
+
+#endif /* DSD_NEO_TESTS_UI_QML_TEST_CONTEXT_H_ */

--- a/tests/ui/test_ui_qt_call_history_model.cpp
+++ b/tests/ui/test_ui_qt_call_history_model.cpp
@@ -16,12 +16,18 @@
 #include <QDir>
 #include <QSettings>
 #include <QStandardPaths>
+#include <QString>
 #include <QTemporaryDir>
-
+#include <QVariant>
 #include <dsd-neo/core/state.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
 
 #include "call_history_model.h"
 #include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
 
 using dsd_qt::CallHistoryModel;
 

--- a/tests/ui/test_ui_qt_persistence.cpp
+++ b/tests/ui/test_ui_qt_persistence.cpp
@@ -11,12 +11,18 @@
 #include <QCoreApplication>
 #include <QDir>
 #include <QFile>
+#include <QIODevice>
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QJsonValue>
+#include <QMap>
 #include <QSettings>
 #include <QStandardPaths>
+#include <QString>
 #include <QTemporaryDir>
+#include <QVariant>
 #include <QVariantMap>
+#include <stdio.h>
 
 #include "app_prefs.h"
 #include "dsd-neo/core/safe_api.h"

--- a/tests/ui/test_ui_qt_qml_main.cpp
+++ b/tests/ui/test_ui_qt_qml_main.cpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Qt Quick Test entry point for the QML screens under `src/ui/qt/qml`.
+ *
+ * The screens are loaded from the source tree by absolute path (`uiDir`), not
+ * from the app's qrc: they resolve their sibling components and the Theme
+ * singleton through their own directory either way, and reading the files
+ * directly keeps the test on exactly what ships without linking the frontend's
+ * engine, service and audio stack. The test cases are the `tst_*.qml` files in
+ * `tests/ui/qml`; the context they run against is in qml_test_context.h.
+ */
+
+#include <QtQuickTest>
+
+#include "qml_test_context.h"
+
+QUICK_TEST_MAIN_WITH_SETUP(dsd_neo_qml, Setup)

--- a/tests/ui/test_ui_qt_session_args.cpp
+++ b/tests/ui/test_ui_qt_session_args.cpp
@@ -15,7 +15,7 @@
 #include <QStringList>
 #include <QVariant>
 #include <QVariantMap>
-#include <QtTypes>
+#include <QtGlobal>
 #include <stdio.h>
 
 #include "dsd-neo/core/safe_api.h"

--- a/tests/ui/test_ui_qt_session_args.cpp
+++ b/tests/ui/test_ui_qt_session_args.cpp
@@ -9,8 +9,14 @@
  * in QML-side JavaScript. The bias-tee tri-state matrix is the load-bearing
  * case: a per-system explicit Off must survive an app-wide On. */
 
+#include <QList>
+#include <QMap>
+#include <QString>
 #include <QStringList>
+#include <QVariant>
 #include <QVariantMap>
+#include <QtTypes>
+#include <stdio.h>
 
 #include "dsd-neo/core/safe_api.h"
 #include "session_args.h"

--- a/tools/clang_tidy.sh
+++ b/tools/clang_tidy.sh
@@ -154,6 +154,35 @@ print(
 )
 
 
+# Compiler options GCC accepts and clang rejects outright. clang-tidy parses the
+# recorded command line, so one of these anywhere in it aborts the whole
+# translation unit with clang-diagnostic-error and the file goes unanalyzed.
+# Qt6 puts -mno-direct-extern-access on everything linking Qt when Qt was built
+# with GCC, which is every Qt frontend and Qt test target in this tree.
+# Dropping the flag changes nothing clang-tidy examines: it is a codegen option,
+# and clang-tidy does not generate code.
+GCC_ONLY_ARGS = frozenset({"-mno-direct-extern-access"})
+
+
+def strip_gcc_only_args(entry):
+    """Return a copy of entry with options clang cannot parse removed."""
+    out = dict(entry)
+    args = out.get("arguments")
+    if args:
+        out["arguments"] = [a for a in args if a not in GCC_ONLY_ARGS]
+        return out
+    cmd = out.get("command")
+    if cmd:
+        try:
+            tokens = shlex.split(cmd)
+        except Exception:
+            return out
+        kept = [t for t in tokens if t not in GCC_ONLY_ARGS]
+        if len(kept) != len(tokens):
+            out["command"] = shlex.join(kept)
+    return out
+
+
 def score_entry(rel_path, entry):
     cmd = entry.get("command") or ""
     args = entry.get("arguments")
@@ -238,7 +267,7 @@ if out_dir and not all_commands:
         if not cmds:
             continue
         best = max(cmds, key=lambda e: score_entry(rel, e))
-        selected.append(best)
+        selected.append(strip_gcc_only_args(best))
 
     out_path = out_dir / "compile_commands.json"
     out_path.write_text(json.dumps(selected, indent=2, sort_keys=True) + "\n")

--- a/tools/clang_tidy.sh
+++ b/tools/clang_tidy.sh
@@ -14,10 +14,11 @@ usage() {
 Usage: tools/clang_tidy.sh [--all-commands] [--] [files...]
 
 Options:
-  --all-commands  Use the full compile_commands.json as-is. Note: if a source file
-                  appears multiple times in the compilation database (e.g., built
-                  for multiple targets), clang-tidy may process it multiple times
-                  and its progress counter can exceed the unique file count.
+  --all-commands  Keep every compile command for each file rather than the single
+                  best-scoring one. Note: if a source file appears multiple times
+                  in the compilation database (e.g., built for multiple targets),
+                  clang-tidy may process it multiple times and its progress
+                  counter can exceed the unique file count.
 
 Arguments:
   files...        Optional list of translation units to analyze (e.g., src/foo.c).
@@ -82,11 +83,14 @@ PDB_FILE="$PDB_DIR/compile_commands.json"
 TIDY_PDB_DIR="$PDB_DIR"
 TIDY_PDB_TEMP_DIR=""
 if command -v python3 > /dev/null 2>&1; then
-  if [[ $ALL_COMMANDS -eq 0 ]]; then
-    TIDY_PDB_TEMP_DIR=$(mktemp -d 2> /dev/null || mktemp -d -t dsd-neo-clang-tidy)
-    trap 'rm -rf "$TIDY_PDB_TEMP_DIR" 2>/dev/null || true' EXIT
-    TIDY_PDB_DIR="$TIDY_PDB_TEMP_DIR"
-  fi
+  # Always analyze against a rewritten database, --all-commands included: the
+  # options clang cannot parse have to come out either way (see GCC_ONLY_ARGS
+  # below), or every Qt translation unit aborts unanalyzed. --all-commands only
+  # changes how many commands per file survive the rewrite, not whether one
+  # happens.
+  TIDY_PDB_TEMP_DIR=$(mktemp -d 2> /dev/null || mktemp -d -t dsd-neo-clang-tidy)
+  trap 'rm -rf "$TIDY_PDB_TEMP_DIR" 2>/dev/null || true' EXIT
+  TIDY_PDB_DIR="$TIDY_PDB_TEMP_DIR"
 
   mapfile -t FILES < <(
     python3 - "$PDB_FILE" "$ROOT_DIR" "$TIDY_PDB_DIR" "$ALL_COMMANDS" "${REQUESTED_FILES[@]}" << 'PY'
@@ -161,6 +165,7 @@ print(
 # with GCC, which is every Qt frontend and Qt test target in this tree.
 # Dropping the flag changes nothing clang-tidy examines: it is a codegen option,
 # and clang-tidy does not generate code.
+# Keep in step with tools/iwyu.sh, which strips the same set.
 GCC_ONLY_ARGS = frozenset({"-mno-direct-extern-access"})
 
 
@@ -259,19 +264,23 @@ if requested_rel:
     selected_files = sorted(p for p in requested_tus if p in entries_by_rel)
 
 
-if out_dir and not all_commands:
+if out_dir:
     out_dir.mkdir(parents=True, exist_ok=True)
     selected = []
     for rel in selected_files:
         cmds = entries_by_rel.get(rel)
         if not cmds:
             continue
-        best = max(cmds, key=lambda e: score_entry(rel, e))
-        selected.append(strip_gcc_only_args(best))
+        if all_commands:
+            selected.extend(strip_gcc_only_args(entry) for entry in cmds)
+        else:
+            best = max(cmds, key=lambda e: score_entry(rel, e))
+            selected.append(strip_gcc_only_args(best))
 
     out_path = out_dir / "compile_commands.json"
     out_path.write_text(json.dumps(selected, indent=2, sort_keys=True) + "\n")
-    print(f"Wrote deduped compile database: {out_path} ({len(selected)} entries)", file=sys.stderr)
+    kind = "stripped" if all_commands else "deduped"
+    print(f"Wrote {kind} compile database: {out_path} ({len(selected)} entries)", file=sys.stderr)
 
 for path in selected_files:
     print(path)

--- a/tools/iwyu-qt6.imp
+++ b/tools/iwyu-qt6.imp
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+#
+# include-what-you-use mapping for Qt 6.
+#
+# IWYU reports the header a symbol is physically declared in. Qt declares almost
+# everything in lowercase implementation headers and exposes it through
+# capitalised class headers, so without a mapping IWYU asks for <qbytearray.h>
+# where Qt's own API is <QByteArray> — advice that would break on the next Qt
+# release, and which is why Qt units were excluded from tools/iwyu.sh before this
+# file existed. Upstream ships qt4.imp and qt5_11.imp only; Qt 6 moved much of
+# the surface into new private headers (qtmetamacros.h, qtypes.h, qminmax.h,
+# qcontainerfwd.h), which is what the Qt 5 mapping misses.
+#
+# Entries are regex ("@" prefix) on the private spelling because IWYU names the
+# same header both bare and module-qualified (qobjectdefs.h and
+# QtCore/qobjectdefs.h) depending on how it was reached.
+#
+# Adding to this file: run tools/iwyu.sh --strict on a Qt translation unit; any
+# lowercase q*.h in its suggestions needs an entry here, mapped to the class or
+# module header Qt documents for that symbol.
+[
+  # Macros and the meta-object system. Q_OBJECT, Q_PROPERTY, Q_SIGNALS, Q_ENUM
+  # and Q_INVOKABLE all live here; QObject is what a reader includes for them.
+  { include: ["@[\"<](.*/)?qtmetamacros\\.h[\">]", private, "<QObject>", public] },
+  { include: ["@[\"<](.*/)?qobjectdefs\\.h[\">]", private, "<QObject>", public] },
+  { include: ["@[\"<](.*/)?qobject\\.h[\">]", private, "<QObject>", public] },
+  { include: ["@[\"<](.*/)?qmetatype\\.h[\">]", private, "<QMetaType>", public] },
+
+  # Global helpers and scalar types.
+  { include: ["@[\"<](.*/)?qtypes\\.h[\">]", private, "<QtTypes>", public] },
+  { include: ["@[\"<](.*/)?qminmax\\.h[\">]", private, "<QtMinMax>", public] },
+  { include: ["@[\"<](.*/)?qnumeric\\.h[\">]", private, "<QtNumeric>", public] },
+  { include: ["@[\"<](.*/)?qcompare\\.h[\">]", private, "<QtCompare>", public] },
+  { include: ["@[\"<](.*/)?qtversionchecks\\.h[\">]", private, "<QtVersionChecks>", public] },
+  # qt_ptr_swap and friends have no class header of their own.
+  { include: ["@[\"<](.*/)?qswap\\.h[\">]", private, "<QtGlobal>", public] },
+  { include: ["@[\"<](.*/)?qtypeinfo\\.h[\">]", private, "<QtGlobal>", public] },
+  # The Qt namespace itself (Qt::ItemDataRole, Qt::CaseInsensitive, ...).
+  { include: ["@[\"<](.*/)?qnamespace\\.h[\">]", private, "<Qt>", public] },
+
+  # Strings and bytes.
+  { include: ["@[\"<](.*/)?qstring\\.h[\">]", private, "<QString>", public] },
+  { include: ["@[\"<](.*/)?qstringview\\.h[\">]", private, "<QStringView>", public] },
+  { include: ["@[\"<](.*/)?qlatin1stringview\\.h[\">]", private, "<QLatin1StringView>", public] },
+  { include: ["@[\"<](.*/)?qchar\\.h[\">]", private, "<QChar>", public] },
+  { include: ["@[\"<](.*/)?qbytearray\\.h[\">]", private, "<QByteArray>", public] },
+  { include: ["@[\"<](.*/)?qbytearrayview\\.h[\">]", private, "<QByteArrayView>", public] },
+  { include: ["@[\"<](.*/)?qstringlist\\.h[\">]", private, "<QStringList>", public] },
+
+  # Containers. qcontainerfwd.h is Qt's own forward-declaration header, so the
+  # aliases declared there need naming individually — mapping the header alone
+  # would send every one of them to <QList> and pull correct <QStringList> and
+  # <QVariantMap> includes out of files that legitimately have them.
+  { symbol: ["QStringList", private, "<QStringList>", public] },
+  { symbol: ["QVariantMap", private, "<QVariantMap>", public] },
+  { symbol: ["QVariantList", private, "<QVariantList>", public] },
+  { symbol: ["QVariantHash", private, "<QVariantHash>", public] },
+  { include: ["@[\"<](.*/)?qcontainerfwd\\.h[\">]", private, "<QList>", public] },
+  { include: ["@[\"<](.*/)?qlist\\.h[\">]", private, "<QList>", public] },
+  { include: ["@[\"<](.*/)?qmap\\.h[\">]", private, "<QMap>", public] },
+  { include: ["@[\"<](.*/)?qhash\\.h[\">]", private, "<QHash>", public] },
+  { include: ["@[\"<](.*/)?qset\\.h[\">]", private, "<QSet>", public] },
+  { include: ["@[\"<](.*/)?qvector\\.h[\">]", private, "<QList>", public] },
+  { include: ["@[\"<](.*/)?qpair\\.h[\">]", private, "<QPair>", public] },
+  { include: ["@[\"<](.*/)?qvariant\\.h[\">]", private, "<QVariant>", public] },
+
+  # Item models.
+  { include: ["@[\"<](.*/)?qabstractitemmodel\\.h[\">]", private, "<QAbstractItemModel>", public] },
+  { include: ["@[\"<](.*/)?qsortfilterproxymodel\\.h[\">]", private, "<QSortFilterProxyModel>", public] },
+
+  # JSON, I/O, time, settings, logging.
+  { include: ["@[\"<](.*/)?qjsonvalue\\.h[\">]", private, "<QJsonValue>", public] },
+  { include: ["@[\"<](.*/)?qjsonobject\\.h[\">]", private, "<QJsonObject>", public] },
+  { include: ["@[\"<](.*/)?qjsonarray\\.h[\">]", private, "<QJsonArray>", public] },
+  { include: ["@[\"<](.*/)?qjsondocument\\.h[\">]", private, "<QJsonDocument>", public] },
+  { include: ["@[\"<](.*/)?qiodevice\\.h[\">]", private, "<QIODevice>", public] },
+  { include: ["@[\"<](.*/)?qiodevicebase\\.h[\">]", private, "<QIODevice>", public] },
+  { include: ["@[\"<](.*/)?qfile\\.h[\">]", private, "<QFile>", public] },
+  { include: ["@[\"<](.*/)?qfiledevice\\.h[\">]", private, "<QFile>", public] },
+  { include: ["@[\"<](.*/)?qdatetime\\.h[\">]", private, "<QDateTime>", public] },
+  { include: ["@[\"<](.*/)?qsettings\\.h[\">]", private, "<QSettings>", public] },
+  { include: ["@[\"<](.*/)?qdebug\\.h[\">]", private, "<QDebug>", public] },
+  { include: ["@[\"<](.*/)?qtimer\\.h[\">]", private, "<QTimer>", public] },
+  { include: ["@[\"<](.*/)?qthreadpool\\.h[\">]", private, "<QThreadPool>", public] },
+  { include: ["@[\"<](.*/)?qrunnable\\.h[\">]", private, "<QRunnable>", public] },
+  { include: ["@[\"<](.*/)?qcoreapplication\\.h[\">]", private, "<QCoreApplication>", public] },
+
+  # Qml and Quick.
+  { include: ["@[\"<](.*/)?qqmlengine\\.h[\">]", private, "<QQmlEngine>", public] },
+  { include: ["@[\"<](.*/)?qqmlcontext\\.h[\">]", private, "<QQmlContext>", public] },
+  { include: ["@[\"<](.*/)?qqmlapplicationengine\\.h[\">]", private, "<QQmlApplicationEngine>", public] },
+  { include: ["@[\"<](.*/)?qquickwindow\\.h[\">]", private, "<QQuickWindow>", public] },
+  { include: ["@[\"<](.*/)?quicktest\\.h[\">]", private, "<QtQuickTest>", public] },
+
+  # Gui.
+  { include: ["@[\"<](.*/)?qguiapplication\\.h[\">]", private, "<QGuiApplication>", public] },
+  { include: ["@[\"<](.*/)?qfontdatabase\\.h[\">]", private, "<QFontDatabase>", public] },
+]

--- a/tools/iwyu-qt6.imp
+++ b/tools/iwyu-qt6.imp
@@ -30,14 +30,17 @@
   # Global helpers and scalar types, all of them to <QtGlobal>.
   #
   # Qt 6.5 broke qglobal.h apart and gave each piece its own capitalised
-  # forwarding header (<QtTypes>, <QtMinMax>, <QtVersionChecks>, ...). Mapping to
-  # those would be the fine-grained answer and it is what IWYU prefers, but it
-  # also silently raises this project's Qt floor to 6.5: on Qt 6.4 and earlier
-  # the split headers do not exist and the include fails to resolve, and nothing
-  # in CI builds against an older Qt to catch it (see the QT_VERSION branch in
-  # call_history_filter.h — older Qt is a case this tree still handles).
-  # <QtGlobal> declares the same symbols on every Qt 6, directly before 6.5 and
-  # by including the split headers after, so it is the portable spelling.
+  # forwarding header (<QtTypes>, <QtMinMax>, <QtVersionChecks>, ...). Those all
+  # exist at this tree's floor — Qt 6.9, the oldest release the Android app is
+  # built against (android/README.md, and the QT_VERSION branch in
+  # call_history_filter.h) — so mapping to them would resolve, and it is the
+  # fine-grained answer IWYU prefers. <QtGlobal> is the deliberate choice
+  # instead: qglobal.h has already been reshuffled once inside Qt 6, and a
+  # header-per-helper mapping re-splits with it, whereas <QtGlobal> is one
+  # spelling that has named this set across every Qt 6 and still does (it
+  # includes the split headers). Going fine-grained is a live option, not a
+  # compatibility break — it costs an include churn across the Qt units and buys
+  # precision on headers that carry a handful of scalars and qMin.
   { include: ["@[\"<](.*/)?qtypes\\.h[\">]", private, "<QtGlobal>", public] },
   { include: ["@[\"<](.*/)?qminmax\\.h[\">]", private, "<QtGlobal>", public] },
   { include: ["@[\"<](.*/)?qnumeric\\.h[\">]", private, "<QtGlobal>", public] },
@@ -45,9 +48,8 @@
   # qt_ptr_swap and friends have no class header of their own.
   { include: ["@[\"<](.*/)?qswap\\.h[\">]", private, "<QtGlobal>", public] },
   { include: ["@[\"<](.*/)?qtypeinfo\\.h[\">]", private, "<QtGlobal>", public] },
-  # Not <QtGlobal>: qglobal.h does not include qcompare.h, and the three-way
-  # comparison helpers it declares are a Qt 6.7 facility either way, so a unit
-  # that needs them is already pinned above the floor the entries above protect.
+  # Not <QtGlobal>: qglobal.h does not include qcompare.h, so <QtCompare> is the
+  # only public header that actually provides the three-way comparison helpers.
   { include: ["@[\"<](.*/)?qcompare\\.h[\">]", private, "<QtCompare>", public] },
   # The Qt namespace itself (Qt::ItemDataRole, Qt::CaseInsensitive, ...).
   { include: ["@[\"<](.*/)?qnamespace\\.h[\">]", private, "<Qt>", public] },
@@ -55,9 +57,9 @@
   # Strings and bytes.
   { include: ["@[\"<](.*/)?qstring\\.h[\">]", private, "<QString>", public] },
   { include: ["@[\"<](.*/)?qstringview\\.h[\">]", private, "<QStringView>", public] },
-  # <QLatin1String>, not <QLatin1StringView>: the class was split out of
-  # qstring.h into its own header after Qt 6.0, so only the older spelling
-  # resolves on every Qt 6 — and it is the spelling this tree constructs.
+  # <QLatin1String>, not <QLatin1StringView>: the two headers are the same class
+  # under its two names, and QLatin1String is the name this tree constructs, so
+  # that is the include a reader can match to the code in front of them.
   { include: ["@[\"<](.*/)?qlatin1stringview\\.h[\">]", private, "<QLatin1String>", public] },
   { include: ["@[\"<](.*/)?qchar\\.h[\">]", private, "<QChar>", public] },
   { include: ["@[\"<](.*/)?qbytearray\\.h[\">]", private, "<QByteArray>", public] },

--- a/tools/iwyu-qt6.imp
+++ b/tools/iwyu-qt6.imp
@@ -27,22 +27,38 @@
   { include: ["@[\"<](.*/)?qobject\\.h[\">]", private, "<QObject>", public] },
   { include: ["@[\"<](.*/)?qmetatype\\.h[\">]", private, "<QMetaType>", public] },
 
-  # Global helpers and scalar types.
-  { include: ["@[\"<](.*/)?qtypes\\.h[\">]", private, "<QtTypes>", public] },
-  { include: ["@[\"<](.*/)?qminmax\\.h[\">]", private, "<QtMinMax>", public] },
-  { include: ["@[\"<](.*/)?qnumeric\\.h[\">]", private, "<QtNumeric>", public] },
-  { include: ["@[\"<](.*/)?qcompare\\.h[\">]", private, "<QtCompare>", public] },
-  { include: ["@[\"<](.*/)?qtversionchecks\\.h[\">]", private, "<QtVersionChecks>", public] },
+  # Global helpers and scalar types, all of them to <QtGlobal>.
+  #
+  # Qt 6.5 broke qglobal.h apart and gave each piece its own capitalised
+  # forwarding header (<QtTypes>, <QtMinMax>, <QtVersionChecks>, ...). Mapping to
+  # those would be the fine-grained answer and it is what IWYU prefers, but it
+  # also silently raises this project's Qt floor to 6.5: on Qt 6.4 and earlier
+  # the split headers do not exist and the include fails to resolve, and nothing
+  # in CI builds against an older Qt to catch it (see the QT_VERSION branch in
+  # call_history_filter.h — older Qt is a case this tree still handles).
+  # <QtGlobal> declares the same symbols on every Qt 6, directly before 6.5 and
+  # by including the split headers after, so it is the portable spelling.
+  { include: ["@[\"<](.*/)?qtypes\\.h[\">]", private, "<QtGlobal>", public] },
+  { include: ["@[\"<](.*/)?qminmax\\.h[\">]", private, "<QtGlobal>", public] },
+  { include: ["@[\"<](.*/)?qnumeric\\.h[\">]", private, "<QtGlobal>", public] },
+  { include: ["@[\"<](.*/)?qtversionchecks\\.h[\">]", private, "<QtGlobal>", public] },
   # qt_ptr_swap and friends have no class header of their own.
   { include: ["@[\"<](.*/)?qswap\\.h[\">]", private, "<QtGlobal>", public] },
   { include: ["@[\"<](.*/)?qtypeinfo\\.h[\">]", private, "<QtGlobal>", public] },
+  # Not <QtGlobal>: qglobal.h does not include qcompare.h, and the three-way
+  # comparison helpers it declares are a Qt 6.7 facility either way, so a unit
+  # that needs them is already pinned above the floor the entries above protect.
+  { include: ["@[\"<](.*/)?qcompare\\.h[\">]", private, "<QtCompare>", public] },
   # The Qt namespace itself (Qt::ItemDataRole, Qt::CaseInsensitive, ...).
   { include: ["@[\"<](.*/)?qnamespace\\.h[\">]", private, "<Qt>", public] },
 
   # Strings and bytes.
   { include: ["@[\"<](.*/)?qstring\\.h[\">]", private, "<QString>", public] },
   { include: ["@[\"<](.*/)?qstringview\\.h[\">]", private, "<QStringView>", public] },
-  { include: ["@[\"<](.*/)?qlatin1stringview\\.h[\">]", private, "<QLatin1StringView>", public] },
+  # <QLatin1String>, not <QLatin1StringView>: the class was split out of
+  # qstring.h into its own header after Qt 6.0, so only the older spelling
+  # resolves on every Qt 6 — and it is the spelling this tree constructs.
+  { include: ["@[\"<](.*/)?qlatin1stringview\\.h[\">]", private, "<QLatin1String>", public] },
   { include: ["@[\"<](.*/)?qchar\\.h[\">]", private, "<QChar>", public] },
   { include: ["@[\"<](.*/)?qbytearray\\.h[\">]", private, "<QByteArray>", public] },
   { include: ["@[\"<](.*/)?qbytearrayview\\.h[\">]", private, "<QByteArrayView>", public] },

--- a/tools/iwyu.sh
+++ b/tools/iwyu.sh
@@ -268,21 +268,15 @@ def compiles_against_qt(entry):
     return any("/QtCore" in t or "/qt6" in t or "/qt5" in t for t in tokens_for_entry(entry))
 
 
-# IWYU ships mapping files for Qt 4 and Qt 5 only, and a mapping is what tells it
-# that QByteArray's public spelling is <QByteArray> rather than the private
-# <qbytearray.h> it actually sees. Qt 6 moved much of the API behind new private
-# headers (qtmetamacros.h, qtypes.h, qcontainerfwd.h) that no shipped mapping
-# covers, so on Qt code IWYU asks for private headers that are not Qt's API and
-# following it would break the build on the next Qt release. Those units are
-# named and skipped rather than analyzed against advice nobody should take.
-# Writing a Qt 6 mapping file would lift this; until then the exclusion is
-# reported on every run so it cannot pass for coverage.
-qt_entries = [(rel, entry) for rel, entry in selected_entries if compiles_against_qt(entry)]
-if qt_entries:
-    selected_entries = [pair for pair in selected_entries if pair not in qt_entries]
-    print(f"Skipping {len(qt_entries)} Qt translation unit(s): IWYU has no Qt 6 mapping file.")
-    for rel, _entry in qt_entries:
-        print(f"  {rel}")
+# IWYU reports the header a symbol is physically declared in, and Qt declares
+# nearly everything in lowercase implementation headers. tools/iwyu-qt6.imp maps
+# those back to the class headers Qt documents; without it every Qt unit is asked
+# to include private headers instead of Qt's API.
+qt_mapping = root / "tools" / "iwyu-qt6.imp"
+qt_units = sum(1 for _rel, entry in selected_entries if compiles_against_qt(entry))
+if qt_units and not qt_mapping.is_file():
+    print(f"WARNING: {qt_units} Qt translation unit(s) will be analyzed without "
+          f"{qt_mapping.name}; expect private-header suggestions.")
 
 if not selected_entries:
     print("No translation units left for IWYU analysis.")
@@ -313,6 +307,8 @@ def run_iwyu(rel, entry):
         compiler_index = 1
     cmd[compiler_index] = "include-what-you-use"
     cmd.append("-fno-color-diagnostics")
+    if qt_mapping.is_file() and compiles_against_qt(entry):
+        cmd.extend(["-Xiwyu", f"--mapping_file={qt_mapping}"])
     if strict:
         cmd.extend(
             [

--- a/tools/iwyu.sh
+++ b/tools/iwyu.sh
@@ -149,17 +149,29 @@ def normalize_file(entry):
     return rel.as_posix(), str(file_path)
 
 
+# Compiler options GCC accepts and clang rejects outright. IWYU is a clang tool
+# driven by the recorded command line, so one of these anywhere in it aborts the
+# translation unit and the file goes unanalyzed. Qt6 puts
+# -mno-direct-extern-access on everything linking Qt when Qt was built with GCC,
+# which is every Qt frontend and Qt test target in this tree. Dropping it changes
+# nothing IWYU examines: it is a codegen option, and IWYU emits no code.
+# Keep in step with tools/clang_tidy.sh, which strips the same set.
+GCC_ONLY_ARGS = frozenset({"-mno-direct-extern-access"})
+
+
 def tokens_for_entry(entry):
     args = entry.get("arguments")
     if args:
-        return list(args)
-    cmd = entry.get("command") or ""
-    if not cmd:
-        return []
-    try:
-        return shlex.split(cmd)
-    except Exception:
-        return cmd.split()
+        tokens = list(args)
+    else:
+        cmd = entry.get("command") or ""
+        if not cmd:
+            return []
+        try:
+            tokens = shlex.split(cmd)
+        except Exception:
+            tokens = cmd.split()
+    return [t for t in tokens if t not in GCC_ONLY_ARGS]
 
 
 def score_entry(entry):
@@ -249,6 +261,32 @@ else:
     for rel in selected_rel:
         entry = max(entries_by_rel[rel], key=score_entry)
         selected_entries.append((rel, entry))
+
+
+def compiles_against_qt(entry):
+    """Whether this translation unit's command line pulls in Qt headers."""
+    return any("/QtCore" in t or "/qt6" in t or "/qt5" in t for t in tokens_for_entry(entry))
+
+
+# IWYU ships mapping files for Qt 4 and Qt 5 only, and a mapping is what tells it
+# that QByteArray's public spelling is <QByteArray> rather than the private
+# <qbytearray.h> it actually sees. Qt 6 moved much of the API behind new private
+# headers (qtmetamacros.h, qtypes.h, qcontainerfwd.h) that no shipped mapping
+# covers, so on Qt code IWYU asks for private headers that are not Qt's API and
+# following it would break the build on the next Qt release. Those units are
+# named and skipped rather than analyzed against advice nobody should take.
+# Writing a Qt 6 mapping file would lift this; until then the exclusion is
+# reported on every run so it cannot pass for coverage.
+qt_entries = [(rel, entry) for rel, entry in selected_entries if compiles_against_qt(entry)]
+if qt_entries:
+    selected_entries = [pair for pair in selected_entries if pair not in qt_entries]
+    print(f"Skipping {len(qt_entries)} Qt translation unit(s): IWYU has no Qt 6 mapping file.")
+    for rel, _entry in qt_entries:
+        print(f"  {rel}")
+
+if not selected_entries:
+    print("No translation units left for IWYU analysis.")
+    raise SystemExit(0)
 
 print(
     f"Running IWYU on {len(selected_entries)} compile command(s) "


### PR DESCRIPTION
## Summary

- The Android call log stopped tracking the latest call. Both call lists are newest-first, and a `ListView` prepend below the top does not move the view, it moves the content: existing rows are held still and the new row lands above the viewport. A list left even slightly off the top never comes back on its own, so every later call arrives out of sight and the reader only sees the older calls they had scrolled to. Nothing drifts while the view sits exactly at the top, which is why it looked intermittent. Measured on `main` with a mock store: three calls arriving while scrolled took the gap from 325 px to 756 px, with nothing on screen saying anything had landed.
- The history log and the monitor's recent-calls pane now re-assert the top when a call lands and the view is at rest within a row of it. Being on the latest call is derived from where the list sits rather than kept as a mode, so nothing can get stuck: one flick back to the top resumes it, and a stray touch, an overscroll bounce or the keyboard resizing the view never ends it. The position is re-asserted only when a call lands, and never mid-movement, so scrolling and flicking are unchanged.
- A "N new calls" capsule was built for the case where the reader is further back, then **removed again**: it cannot appear in the shipped app. While a session is active `Main.qml` hides the tab shell, so the history screen is never on screen while calls land — confirmed on a device, where the bottom bar is replaced by "Stop listening" and even reaching Settings means stopping the session first. With `DSD_ENABLE_QT_UI` off for every non-Android preset there is no desktop frontend to show it either. Making the shell reachable during a session is the change worth having, and the capsule is cheap to restore once it is.
- `Theme.rowHeight` replaces `CallRow`'s hardcoded 58, so the "within one row of the top" slack follows the row it is named after.
- Counted strings are now whole sentences rather than one `%n` plural form. The app installs no `QTranslator`, so an untranslated `%n` substitutes the number but never selects a plural: the filtered empty state read "1 logged call(s) **are** hidden by the search or filters." There are no `%n` forms left in the Qt UI.
- `UI_QT_QML_CALL_LISTS` puts all of the above under CTest via Qt Quick Test, and a new `android-ci` job runs it on the host with the same pinned Qt the APK ships. Three analyzer fixes fell out of adding it — see Tests And Guardrails.
- The monitor gains an **ENC LOCKOUT** reading next to SNR and STREAM: the size of the encrypted-target ledger at the current key epoch, hidden at zero. Found while verifying on a live site — with the default "Skip encrypted calls" on, an almost entirely encrypted system presents as a dead decoder, because the control channel decodes, every grant is declined and no call is ever logged. It reads the ledger rather than counting refusals: a first attempt counted declined grants and read **150** after three minutes on a site that had carried about a dozen transmissions, since a control channel repeats a grant update every few hundred ms while a call is up. The ledger counts targets, and only targets confirmed undecryptable from voice — the evidence standard #306 settled on when it deleted the grant-time lockout notice. Nothing here arms the ledger or writes a history row.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / **none**.
- [x] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests. — none of those are touched; the UI behaviour itself is covered by the new `UI_QT_QML_CALL_LISTS`.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny. — none touched; QML view layer only.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. — none added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` — 508/508 with the Qt frontend off, 512/512 with `-DDSD_ENABLE_QT_UI=ON` (both paths checked, since only the second registers the Qt tests); 11 QML cases inside `UI_QT_QML_CALL_LISTS`
- [x] `tools/preflight_ci.sh` — clean
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes — not applicable
- [x] `tools/cmake_format_check.sh` for CMake changes — run with `--fix`
- [x] `tools/zizmor.sh` for workflow changes — clean, alongside actionlint and shellcheck
- [ ] `tools/osv_scan.sh` for dependency input changes — no dependency changes
- [ ] `tools/check_secret_redaction.sh` and workflow/release pin checks — not security-sensitive

`qmllint` is clean on every touched `.qml` file.

### What the new test covers

`UI_QT_QML_CALL_LISTS` drives the real files from `src/ui/qt/qml` through Qt Quick Test: four cases over the history log — pinned at the top, holding the reader's place while calls land above the viewport, a sub-row offset still counting as the latest, and the hidden-count sentence — plus three over the monitor's recent-calls pane. Positions are set rather than flicked: a flick's momentum and its boundary bounce are timing-dependent, and the behaviour is keyed on where the list came to rest, not on how it got there. Whole run: 0.6 s.

Mutation-checked rather than assumed, and it found a hole in my own tests: deleting the **monitor** pin originally failed nothing, because both monitor cases only ever sat at an exact top, which `ListView` holds without help. Each pane now has the sub-row-offset case — the one measured by hand on the device — so deleting either pin fails exactly one test, and restoring the `%n` plural fails the sentence case.

The screens load by absolute path rather than through the app's qrc, so the test links no frontend library, and the production `CallHistoryFilterModel` is compiled in so the filter under the views is the real one. The store is a stand-in: the shipped one only grows by ingesting a decoder ring, which `UI_QT_CALL_HISTORY_MODEL` already covers. The engine-facing objects are maps carrying every key the screens read, so a screen that grows a new binding fails loudly instead of quietly rendering `undefined`. The headless environment (offscreen platform, software renderer) rides on the CTest registration, so a local `ctest` behaves exactly like CI.

### CI

A new `android-ci` job, `Qt UI tests (host Qt)`, configures the frontend for the host with the pinned `ANDROID_QT_VERSION` and runs `ctest -R '^UI_QT_'`. The arm64 APK job can build the QML but never run it, and the Qt model tests behind `DSD_ENABLE_QT_UI` have never run anywhere in CI — both do now, seven tests in total. Only the frontend's test targets are built (they do not link the decoder), and the job fails if the registration ever stops producing them rather than reporting green on an empty run. It is wired into `publish-apk`'s `needs` (the APK job can package the QML but never run it, and a release is the wrong place to discover a broken screen), and "Qt UI tests (host Qt)" is now a required status check on `main`.

### Verified on a device

Built and run in the API 34 emulator against live RF (host `rtl_tcp`, 769.76875 MHz, SNR 18–24 dB, real trunk-following grants); Settings reported `2.6.1-3-gfaf5ae39`. The pane was dragged 70 px off the top and then left to receive calls, measured anchor-relative because the pane shifts when the engine's message line appears:

| | label→first-name gap | newest row's glyph height |
|---|---|---|
| before the drag | 152 px | 30 px — full |
| right after it | 65 px | 20 px — clipped |
| +2 min, several calls later | 152 px | 30 px — full |

So it was genuinely left off the top, and calls landing pulled it back with the newest fully visible. The empty state read "39 logged calls are hidden by the search or filters." Scope: the fixed build was observed recovering; the pre-fix APK was not built to watch it fail, which is what the mutation run covers instead. One rig note worth keeping: with "Skip encrypted calls" on — the default — every grant on that site logs `grant-blocked-enc-lo` and **nothing reaches the log at all**, which is why the first five minutes looked like a dead decoder.

### Three analyzer fixes this surfaced

- **clang-tidy could not analyze any Qt code.** Qt6 puts `-mno-direct-extern-access` on everything that links Qt when Qt itself was built with GCC. clang rejects the option outright, so every Qt translation unit died with `clang-diagnostic-error` before analysis — including untouched files like `src/ui/qt/qt_ui.cpp`, which fails identically on `main`. `tools/clang_tidy.sh` now drops the flag when it rewrites the compile database; it is a codegen option, and clang-tidy generates no code. With that gone the whole frontend analyzes clean except one real finding, fixed here: `saved_systems_model.cpp` iterated a `QJsonArray` as `const QJsonValue&`, converting each `QJsonValueConstRef` into a temporary per element.
- **IWYU had the same parse failure**, and fixing it exposed a second gap: IWYU ships mappings for Qt 4 and Qt 5 only, and without one for Qt 6 it asks for private headers (`qtmetamacros.h`, `qtypes.h`, `qcontainerfwd.h`) that are not Qt's API. `tools/iwyu-qt6.imp` maps those to the headers Qt documents, so the exclusion is gone rather than documented. The container aliases needed naming as symbols, not through their header: `QStringList` and `QVariantMap` live in `qcontainerfwd.h` next to `QList`, and mapping the header alone sent all of them to `<QList>` while pulling correct `<QStringList>`/`<QVariantMap>` includes out of files that had them right. With the mapping in place the frontend's real include debt is fixed — 18 units gained the headers whose symbols they use and shed three includes plus a forward declaration nothing referenced — and all 18 pass `--strict` with nothing suggested.
- **GCC `-fanalyzer` was failing on the frontend too**, for a third reason, and any Qt C++ change would have walked into it: `dsd_call_observation_data` zeroed its aggregate with `= {0}`, which `-Wmissing-field-initializers` reports field by field when `call_state.h` is compiled as C++ — and it is compiled as both C11 and C++14. It now zeroes through `DSD_MEMSET`, the device `dsd_opts` already uses: warning-free in both languages, and not silently mis-assignable by a field reorder the way a positional initializer would be. C11 has no designated initializers that C++14 also accepts, so spelling the fields out was not available.

All three widen analyzer coverage rather than narrow it, and none suppresses a finding.

## Risk

- Security/dependency impact: none. No new dependencies, no input parsing, no network or file handling.
- CLI/UI behavior impact: Android/Qt frontend only, and confined to the two call lists. Scrolling, flicking and every filter behave as before; what changes is that a list parked at the top keeps the newest call in view, and the history screen gains a "N new calls" capsule while scrolled away. The terminal UI and the decoder are untouched.
- Compatibility or packaging impact: none for the app. The QML resource list is unchanged, and nothing new ships in the APK. The English strings behind the `%n` removal should return to a `%n` form if translations are ever shipped.
- Tooling impact: `tools/clang_tidy.sh` now analyzes Qt translation units that previously aborted, so a future change under `src/ui/qt/` will be linted for real for the first time. Everything there is clean as of this branch.
