### PR TITLE
dmr: surface Reverse Channel commands as event-history rows

### DIFF
--- a/include/dsd-neo/core/state_ext.h
+++ b/include/dsd-neo/core/state_ext.h
@@ -57,6 +57,7 @@ typedef enum DSD_ATTR_PACKED dsd_state_ext_id {
     DSD_STATE_EXT_ENGINE_TRUNK_SCAN = 3,
     DSD_STATE_EXT_CORE_CALL_STATE = 4,
     DSD_STATE_EXT_PROTO_NXDN_TRUNK_DIAG = 24,
+    DSD_STATE_EXT_PROTO_DMR_RC = 25,
 } dsd_state_ext_id;
 
 typedef void (*dsd_state_ext_cleanup_fn)(void*);

--- a/include/dsd-neo/protocol/dmr/dmr.h
+++ b/include/dsd-neo/protocol/dmr/dmr.h
@@ -18,6 +18,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -79,7 +80,7 @@ void dmr_refresh_algids_on_error(dsd_opts* opts, dsd_state* state);
 void dmr_late_entry_mi_fragment(dsd_opts* opts, dsd_state* state, uint8_t vc, uint8_t ambe_fr[4][24],
                                 uint8_t ambe_fr2[4][24], uint8_t ambe_fr3[4][24]);
 void dmr_late_entry_mi(dsd_opts* opts, dsd_state* state);
-void dmr_sbrc(const dsd_opts* opts, dsd_state* state, uint8_t power);
+void dmr_sbrc(dsd_opts* opts, dsd_state* state, uint8_t power);
 
 /* Standalone Reverse Channel burst (ETSI TS 102 361-1 clause 6.4.1). */
 enum {
@@ -91,6 +92,15 @@ enum {
 void dmrRC(dsd_opts* opts, dsd_state* state);
 int dmr_rc_decode_pdu(const uint8_t interleaved_bits[32], uint8_t* out_command, uint32_t* out_hex);
 const char* dmr_rc_command_name(uint8_t rc_command);
+
+/* Surface a validated RC command as a CONTROL event-history row (yellow in the
+ * terminal UI). dedup_key: 0/1 = embedded SB/RC per slot index, 2 = standalone
+ * burst. have_cc/cc: EMB color code when trustworthy. `now` is injected so
+ * tests can cross the repeat-suppression window deterministically. */
+enum { DMR_RC_NOTIFY_KEY_STANDALONE = 2 };
+
+void dmr_rc_notify_command(dsd_opts* opts, dsd_state* state, uint8_t emit_slot, uint8_t dedup_key, uint8_t rc_command,
+                           int have_cc, uint8_t cc, time_t now);
 void dmr_rc_assemble_bits(const int dibits[48], uint8_t emb_bits[16], uint8_t rc_bits[32]);
 size_t dmr_debug_format_rc_burst(char* out, size_t out_size, const int dibits[48]);
 void LFSR64(dsd_state* state);

--- a/src/protocol/dmr/CMakeLists.txt
+++ b/src/protocol/dmr/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(
         dmr_ms.c
         dmr_pdu.c
         dmr_rc.c
+        dmr_rc_notify.c
         dmr_text.c
         dmr_pi.c
         dmr_utils.c

--- a/src/protocol/dmr/dmr_bs.c
+++ b/src/protocol/dmr/dmr_bs.c
@@ -529,7 +529,7 @@ reset_dmr_bs_slot_keystream_counters(dsd_state* state, uint8_t internalslot) {
 }
 
 static void
-run_dmr_bs_slot_vc6_sbrc(const dsd_opts* opts, dsd_state* state, const dmr_bs_ctx* ctx) {
+run_dmr_bs_slot_vc6_sbrc(dsd_opts* opts, dsd_state* state, const dmr_bs_ctx* ctx) {
     if (is_dmr_bs_slot_vc6(ctx)) {
         dmr_sbrc(opts, state, ctx->power);
     }

--- a/src/protocol/dmr/dmr_le.c
+++ b/src/protocol/dmr/dmr_le.c
@@ -22,6 +22,7 @@
 #include <dsd-neo/runtime/colors.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -585,7 +586,7 @@ dmr_sbrc_handle_kirisun_mode(const dsd_opts* opts, dsd_state* state, const dmr_s
 }
 
 static void
-dmr_sbrc_handle_standard_payload(const dsd_opts* opts, dsd_state* state, const dmr_sbrc_data* data, uint8_t sbrc_opcode,
+dmr_sbrc_handle_standard_payload(dsd_opts* opts, dsd_state* state, const dmr_sbrc_data* data, uint8_t sbrc_opcode,
                                  uint8_t alg, uint8_t key, uint8_t txi_delay) {
     if (data->sbrc_hex == 0U && data->crc7_okay == 0U) {
         return;
@@ -593,6 +594,10 @@ dmr_sbrc_handle_standard_payload(const dsd_opts* opts, dsd_state* state, const d
 
     if (data->crc7_okay == 1U) {
         dmr_sbrc_print_rc_command(opts, data->sbrc_hex);
+        /* Attributed to the received slot; the EMB color code is not in scope
+         * here, so the notice carries no CC clause. */
+        dmr_rc_notify_command(opts, state, data->slot_idx, data->slot_idx, (uint8_t)(data->sbrc_hex >> 7),
+                              /*have_cc*/ 0, 0U, time(NULL));
         return;
     }
 
@@ -607,7 +612,7 @@ dmr_sbrc_handle_standard_payload(const dsd_opts* opts, dsd_state* state, const d
 }
 
 static void
-dmr_sbrc_handle_standard_mode(const dsd_opts* opts, dsd_state* state, const dmr_sbrc_data* data, uint8_t sbrc_opcode,
+dmr_sbrc_handle_standard_mode(dsd_opts* opts, dsd_state* state, const dmr_sbrc_data* data, uint8_t sbrc_opcode,
                               uint8_t alg, uint8_t key, uint8_t txi_delay, int kirisun_call) {
     // opts->dmr_le is global; fall back to standard SB/RC parsing for non-Kirisun calls.
     if (!(opts->dmr_le == 1 || (opts->dmr_le == 3 && !kirisun_call))) {
@@ -643,7 +648,7 @@ dmr_sbrc_write_dsp_output(const dsd_opts* opts, const dsd_state* state, uint8_t 
 
 //handle Single Burst (Voice Burst F) or Reverse Channel Signalling
 void
-dmr_sbrc(const dsd_opts* opts, dsd_state* state, uint8_t power) {
+dmr_sbrc(dsd_opts* opts, dsd_state* state, uint8_t power) {
     dmr_sbrc_data data;
     dmr_sbrc_init_data(&data, state, power);
 

--- a/src/protocol/dmr/dmr_rc.c
+++ b/src/protocol/dmr/dmr_rc.c
@@ -205,6 +205,17 @@ dmrRC(dsd_opts* opts, dsd_state* state) {
 
     dmr_rc_print(opts, emb_ok, emb_bits, rc_err, rc_command, rc_hex);
 
+    if (rc_err == DMR_RC_DECODE_OK) {
+        uint8_t cc = 0;
+        if (emb_ok == 1) {
+            cc = (uint8_t)((emb_bits[0] << 3) | (emb_bits[1] << 2) | (emb_bits[2] << 1) | (emb_bits[3] << 0));
+        }
+        /* Slot 0 + sentinel IDs: the event row is a slot-less notice, and the
+         * dedup ext slot is module-private bookkeeping, so the handler's no-op
+         * contract for slot/trunking/call state still holds. */
+        dmr_rc_notify_command(opts, state, 0U, DMR_RC_NOTIFY_KEY_STANDALONE, rc_command, emb_ok, cc, time(NULL));
+    }
+
     if (opts->dmr_debug_burst != 0) {
         char line[192];
         if (dmr_debug_format_rc_burst(line, sizeof(line), dibits) != 0U) {

--- a/src/protocol/dmr/dmr_rc_notify.c
+++ b/src/protocol/dmr/dmr_rc_notify.c
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Event-history notices for decoded DMR Reverse Channel commands.
+ *
+ * Shared by the standalone RC burst handler (dmr_rc.c) and the embedded SB/RC
+ * path (dmr_le.c). Lives in its own translation unit so dmr_le.o does not
+ * inherit the standalone handler's dibit-reader dependency chain.
+ */
+
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <time.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+enum { DMR_RC_NOTIFY_KEYS = 3, DMR_RC_NOTIFY_WINDOW_S = 5 };
+
+/* Per-key repeat suppression for RC event rows. Keys 0/1 are the embedded
+ * SB/RC path per slot index, key 2 the standalone burst; keeping them apart
+ * stops an embedded repeat train from masking a standalone burst and vice
+ * versa. */
+typedef struct {
+    uint8_t last_cmd[DMR_RC_NOTIFY_KEYS];
+    uint8_t valid[DMR_RC_NOTIFY_KEYS];
+    time_t last_time[DMR_RC_NOTIFY_KEYS];
+} dmr_rc_dedup_t;
+
+static dmr_rc_dedup_t*
+dmr_rc_dedup_get_or_create(dsd_state* state) {
+    dmr_rc_dedup_t* dedup = DSD_STATE_EXT_GET_AS(dmr_rc_dedup_t, state, DSD_STATE_EXT_PROTO_DMR_RC);
+    if (dedup != NULL) {
+        return dedup;
+    }
+
+    dedup = (dmr_rc_dedup_t*)calloc(1, sizeof(*dedup));
+    if (dedup == NULL) {
+        return NULL;
+    }
+    if (dsd_state_ext_set(state, DSD_STATE_EXT_PROTO_DMR_RC, dedup, free) != 0) {
+        free(dedup);
+        return NULL;
+    }
+    return dedup;
+}
+
+void
+dmr_rc_notify_command(dsd_opts* opts, dsd_state* state, uint8_t emit_slot, uint8_t dedup_key, uint8_t rc_command,
+                      int have_cc, uint8_t cc, time_t now) {
+    if (opts == NULL || state == NULL || dedup_key >= DMR_RC_NOTIFY_KEYS) {
+        return;
+    }
+
+    /* Reserved commands (6..15) stay stderr-only: the CRC-7 covers just four
+     * data bits, so a corrupted-but-CRC-passing burst is plausible enough to
+     * keep out of the event history. */
+    const char* name = dmr_rc_command_name(rc_command);
+    if (name == NULL) {
+        return;
+    }
+
+    /* An identical command inside the sliding window is a repeat train, not a
+     * new operator event; refreshing the timestamp keeps a continuous train
+     * collapsed to one row. Read-only: suppression never allocates. */
+    dmr_rc_dedup_t* dedup = DSD_STATE_EXT_GET_AS(dmr_rc_dedup_t, state, DSD_STATE_EXT_PROTO_DMR_RC);
+    if (dedup != NULL && dedup->valid[dedup_key] != 0U && dedup->last_cmd[dedup_key] == rc_command
+        && now >= dedup->last_time[dedup_key] && now - dedup->last_time[dedup_key] < DMR_RC_NOTIFY_WINDOW_S) {
+        dedup->last_time[dedup_key] = now;
+        return;
+    }
+
+    char notice[96];
+    if (have_cc != 0) {
+        DSD_SNPRINTF(notice, sizeof(notice), "DMR RC: %s; CC: %02u;", name, cc & 0x0FU);
+    } else {
+        DSD_SNPRINTF(notice, sizeof(notice), "DMR RC: %s;", name);
+    }
+
+    /* RC is signalling, not a call: keep the data-notice beeper quiet. */
+    const int prev_alert = opts->call_alert;
+    opts->call_alert = 0;
+    const dsd_call_observation observation =
+        dsd_call_observation_data(state->lastsynctype, emit_slot, 0xFFFFFFU, 0xFFFFFFU);
+    const int emitted = dsd_event_emit_data_notice_classified_with_gps(opts, state, emit_slot, &observation,
+                                                                       DSD_EVENT_CATEGORY_CONTROL, notice, "");
+    opts->call_alert = prev_alert;
+
+    /* Record only after a successful emit: states without an event history
+     * (the emitter rejects them) never allocate the ext slot. */
+    if (emitted == 0) {
+        dedup = dmr_rc_dedup_get_or_create(state);
+        if (dedup != NULL) {
+            dedup->valid[dedup_key] = 1U;
+            dedup->last_cmd[dedup_key] = rc_command;
+            dedup->last_time[dedup_key] = now;
+        }
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5646,6 +5646,18 @@ target_include_directories(
 target_link_libraries(dsd-neo_test_dmr_rc_burst PRIVATE dsd-neo_proto_dmr)
 add_test(NAME DMR_RC_BURST COMMAND dsd-neo_test_dmr_rc_burst)
 
+# Embedded SB/RC path: validated RC commands emit CONTROL event-history rows
+add_executable(
+    dsd-neo_test_dmr_sbrc_rc_event
+    protocol/dmr/test_dmr_sbrc_rc_event.c
+)
+target_include_directories(
+    dsd-neo_test_dmr_sbrc_rc_event
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(dsd-neo_test_dmr_sbrc_rc_event PRIVATE dsd-neo_proto_dmr)
+add_test(NAME DMR_SBRC_RC_EVENT COMMAND dsd-neo_test_dmr_sbrc_rc_event)
+
 add_executable(
     dsd-neo_test_dmr_dburst_profile
     protocol/dmr/test_dmr_dburst_profile.c

--- a/tests/protocol/dmr/test_dmr_bs_sync_times.c
+++ b/tests/protocol/dmr/test_dmr_bs_sync_times.c
@@ -420,7 +420,7 @@ dmr_late_entry_mi_fragment(dsd_opts* opts, dsd_state* state, uint8_t vc, uint8_t
 }
 
 void
-dmr_sbrc(const dsd_opts* opts, dsd_state* state, uint8_t power) {
+dmr_sbrc(dsd_opts* opts, dsd_state* state, uint8_t power) {
     (void)opts;
     (void)state;
     g_sbrc_calls++;

--- a/tests/protocol/dmr/test_dmr_ms_data.c
+++ b/tests/protocol/dmr/test_dmr_ms_data.c
@@ -315,7 +315,7 @@ dmr_late_entry_mi_fragment(dsd_opts* opts, dsd_state* state, uint8_t vc, uint8_t
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-dmr_sbrc(const dsd_opts* opts, dsd_state* state, uint8_t power) {
+dmr_sbrc(dsd_opts* opts, dsd_state* state, uint8_t power) {
     (void)opts;
     (void)state;
     (void)power;

--- a/tests/protocol/dmr/test_dmr_pi_kirisun.c
+++ b/tests/protocol/dmr/test_dmr_pi_kirisun.c
@@ -7,20 +7,45 @@
 
 #include <assert.h>
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/events.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/fec/block_codes.h>
 #include <dsd-neo/fec/bptc.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
+/* Strong stub: dmr_le.o references the RC notice emitter via dmr_rc_notify.o;
+ * satisfying it here keeps the real dsd_events.o (and its call-state
+ * dependencies, stubbed in this binary) out of the link. The recorded call
+ * count doubles as proof that the RC-command branch ran. */
+static unsigned g_rc_notice_calls;
+static char g_rc_notice_last_text[128];
+
+int
+dsd_event_emit_data_notice_classified_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                               const dsd_call_observation* observation, dsd_event_category category,
+                                               const char* notice, const char* gps) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)observation;
+    (void)category;
+    (void)gps;
+    g_rc_notice_calls++;
+    DSD_SNPRINTF(g_rc_notice_last_text, sizeof(g_rc_notice_last_text), "%s", notice ? notice : "");
+    return 0;
+}
+
 static void
-load_single_burst_value(dsd_state* state, uint8_t slot, uint16_t sb_value) {
+load_sbrc_codeword(dsd_state* state, uint8_t slot, uint16_t sb_value, int odd_parity) {
     static const struct {
         uint16_t value;
         uint8_t codeword[16];
@@ -57,7 +82,7 @@ load_single_burst_value(dsd_state* state, uint8_t slot, uint16_t sb_value) {
 
     for (int i = 0; i < 16; i++) {
         data_matrix[i] = encoded[i];
-        data_matrix[16 + i] = data_matrix[i];
+        data_matrix[16 + i] = (uint8_t)(data_matrix[i] ^ (odd_parity ? 1U : 0U));
     }
 
     for (int i = 0; i < 32; i++) {
@@ -67,6 +92,19 @@ load_single_burst_value(dsd_state* state, uint8_t slot, uint16_t sb_value) {
     for (int i = 0; i < 32; i++) {
         state->dmr_embedded_signalling[slot][5][i + 8] = interleaved[i];
     }
+}
+
+/* SB variant: duplicated (even-parity) second row. */
+static void
+load_single_burst_value(dsd_state* state, uint8_t slot, uint16_t sb_value) {
+    load_sbrc_codeword(state, slot, sb_value, 0);
+}
+
+/* RC variant: complemented (odd-parity) second row, as the RC single-burst
+ * BPTC expects when dmr_sbrc runs with power=1. */
+static void
+load_reverse_channel_value(dsd_state* state, uint8_t slot, uint16_t sb_value) {
+    load_sbrc_codeword(state, slot, sb_value, 1);
 }
 
 static uint16_t
@@ -639,21 +677,31 @@ test_sbrc_reverse_channel_commands(void) {
     static dsd_opts opts;
     static dsd_state state;
 
+    /* A valid RC command must reach the RC-command branch (observed via the
+     * notice stub) and must not be misread as an encryption identifier. */
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
+    g_rc_notice_calls = 0;
+    g_rc_notice_last_text[0] = '\0';
     opts.dmr_le = 1;
     state.currentslot = 0;
-    load_single_burst_value(&state, 0, build_rc_command_value(5U));
+    load_reverse_channel_value(&state, 0, build_rc_command_value(5U));
     dmr_sbrc(&opts, &state, 1);
     assert(state.payload_algid == 0);
+    assert(g_rc_notice_calls == 1U);
+    assert(strcmp(g_rc_notice_last_text, "DMR RC: Cease Transmission Request;") == 0);
+    dsd_state_ext_free_all(&state);
 
+    /* Reserved commands decode but never surface a notice. */
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
+    g_rc_notice_calls = 0;
     opts.dmr_le = 1;
     state.currentslot = 0;
-    load_single_burst_value(&state, 0, build_rc_command_value(6U));
+    load_reverse_channel_value(&state, 0, build_rc_command_value(6U));
     dmr_sbrc(&opts, &state, 1);
     assert(state.payload_algid == 0);
+    assert(g_rc_notice_calls == 0U);
 }
 
 static void

--- a/tests/protocol/dmr/test_dmr_rc_burst.c
+++ b/tests/protocol/dmr/test_dmr_rc_burst.c
@@ -9,10 +9,13 @@
  */
 
 #include <assert.h>
+#include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/events.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/fec/block_codes.h>
 #include <dsd-neo/fec/bptc.h>
@@ -21,6 +24,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -205,6 +209,45 @@ static int g_live_dibits[32];
 static int g_live_count;
 static int g_live_pos;
 
+/* Strong spy for the event emitter: records the notice and keeps the real
+ * core implementation (and its audio/history deps) out of the link. */
+static unsigned g_notice_calls;
+static uint8_t g_notice_last_slot;
+static int g_notice_last_category;
+static uint64_t g_notice_last_src;
+static uint64_t g_notice_last_dst;
+static int g_notice_alert_during;
+static char g_notice_last_text[256];
+static char g_notice_last_gps[64];
+
+int
+dsd_event_emit_data_notice_classified_with_gps(dsd_opts* opts, dsd_state* state, uint8_t slot,
+                                               const dsd_call_observation* observation, dsd_event_category category,
+                                               const char* notice, const char* gps) {
+    (void)state;
+    g_notice_calls++;
+    g_notice_last_slot = slot;
+    g_notice_last_category = (int)category;
+    g_notice_last_src = observation->ota_source_id;
+    g_notice_last_dst = observation->ota_target_id;
+    g_notice_alert_during = opts->call_alert;
+    DSD_SNPRINTF(g_notice_last_text, sizeof(g_notice_last_text), "%s", notice ? notice : "");
+    DSD_SNPRINTF(g_notice_last_gps, sizeof(g_notice_last_gps), "%s", gps ? gps : "");
+    return 0;
+}
+
+static void
+reset_notice_spy(void) {
+    g_notice_calls = 0;
+    g_notice_last_slot = 0xFF;
+    g_notice_last_category = -1;
+    g_notice_last_src = 0;
+    g_notice_last_dst = 0;
+    g_notice_alert_during = -1;
+    g_notice_last_text[0] = '\0';
+    g_notice_last_gps[0] = '\0';
+}
+
 int
 getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
     (void)opts;
@@ -221,10 +264,10 @@ getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
 /* Compose the full 48-dibit RC burst: RC_a(8) EMB_a(4) SYNC(24) EMB_b(4)
  * RC_b(8), splitting the 32 RC bits and 16 EMB bits around the sync. */
 static void
-build_rc_burst_dibits(uint8_t cmd, uint8_t cc, int dibits[48]) {
+build_rc_burst_dibits_mask(uint8_t cmd, uint8_t cc, uint8_t crc_mask, int dibits[48]) {
     uint8_t rc_bits[32];
     uint8_t emb_bits[16];
-    encode_rc_pdu(cmd, 0x7A, rc_bits);
+    encode_rc_pdu(cmd, crc_mask, rc_bits);
     encode_emb(cc, /*pi*/ 0, /*lcss single fragment*/ 0, emb_bits);
 
     for (size_t i = 0; i < 8U; i++) {
@@ -239,6 +282,11 @@ build_rc_burst_dibits(uint8_t cmd, uint8_t cc, int dibits[48]) {
     for (int i = 0; i < 24; i++) {
         dibits[12 + i] = sync[i] - '0';
     }
+}
+
+static void
+build_rc_burst_dibits(uint8_t cmd, uint8_t cc, int dibits[48]) {
+    build_rc_burst_dibits_mask(cmd, cc, 0x7A, dibits);
 }
 
 static void
@@ -299,6 +347,7 @@ run_handler_case(int inverted, uint8_t debug_burst) {
 
     dmrRC(&opts, &state);
     assert(g_live_pos == 12);
+    dsd_state_ext_free_all(&state);
 }
 
 static void
@@ -306,6 +355,119 @@ test_handler_consumes_trailing_dibits(void) {
     run_handler_case(/*inverted*/ 0, /*debug_burst*/ 0);
     run_handler_case(/*inverted*/ 0, /*debug_burst*/ 1);
     run_handler_case(/*inverted*/ 1, /*debug_burst*/ 0);
+}
+
+/* Drive a full burst with the given command/CC/CRC-mask through dmrRC. */
+static void
+drive_rc_burst(dsd_opts* opts, dsd_state* state, int payload_buf[64], uint8_t cmd, uint8_t cc, uint8_t crc_mask) {
+    int dibits[48];
+    build_rc_burst_dibits_mask(cmd, cc, crc_mask, dibits);
+    for (int i = 0; i < 36; i++) {
+        payload_buf[i] = dibits[i];
+    }
+    g_live_count = 12;
+    g_live_pos = 0;
+    for (int i = 0; i < 12; i++) {
+        g_live_dibits[i] = dibits[36 + i];
+    }
+    state->dmr_payload_buf = payload_buf;
+    state->dmr_payload_p = payload_buf + 36;
+    dmrRC(opts, state);
+}
+
+static void
+test_handler_emits_control_event(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int payload_buf[64];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(payload_buf, 0, sizeof(payload_buf));
+    reset_notice_spy();
+
+    /* A validated command surfaces exactly one CONTROL notice on slot 0 with
+     * sentinel IDs and the trusted EMB color code, with the beeper stashed
+     * off for the duration of the emit. */
+    opts.call_alert = 1;
+    drive_rc_burst(&opts, &state, payload_buf, /*cmd*/ 4, /*cc*/ 1, 0x7A);
+    assert(g_notice_calls == 1U);
+    assert(g_notice_last_slot == 0U);
+    assert(g_notice_last_category == (int)DSD_EVENT_CATEGORY_CONTROL);
+    assert(g_notice_last_src == 0xFFFFFFU);
+    assert(g_notice_last_dst == 0xFFFFFFU);
+    assert(strcmp(g_notice_last_text, "DMR RC: Cease Transmission Command; CC: 01;") == 0);
+    assert(strcmp(g_notice_last_gps, "") == 0);
+    assert(g_notice_alert_during == 0);
+    assert(opts.call_alert == 1);
+
+    /* The same burst repeated back-to-back is a repeat train, not a new
+     * operator event: still one row. */
+    drive_rc_burst(&opts, &state, payload_buf, /*cmd*/ 4, /*cc*/ 1, 0x7A);
+    assert(g_notice_calls == 1U);
+
+    dsd_state_ext_free_all(&state);
+}
+
+static void
+test_handler_no_event_on_invalid_or_reserved(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int payload_buf[64];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(payload_buf, 0, sizeof(payload_buf));
+    reset_notice_spy();
+
+    /* CRC failure (wrong mask): no event row. */
+    drive_rc_burst(&opts, &state, payload_buf, /*cmd*/ 4, /*cc*/ 1, /*mask*/ 0x00);
+    assert(g_notice_calls == 0U);
+
+    /* Reserved command (6..15): decodes fine but stays stderr-only. */
+    drive_rc_burst(&opts, &state, payload_buf, /*cmd*/ 6, /*cc*/ 1, 0x7A);
+    assert(g_notice_calls == 0U);
+
+    dsd_state_ext_free_all(&state);
+}
+
+static void
+test_notify_dedup_window(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_notice_spy();
+
+    /* Identical command inside the 5 s sliding window is suppressed and
+     * refreshes the window. */
+    dmr_rc_notify_command(&opts, &state, 0U, 2U, 4U, /*have_cc*/ 1, /*cc*/ 1, (time_t)1000);
+    assert(g_notice_calls == 1U);
+    dmr_rc_notify_command(&opts, &state, 0U, 2U, 4U, 1, 1, (time_t)1004);
+    assert(g_notice_calls == 1U);
+    /* 8 s after the first emit but only 4 s after the refresh: still
+     * suppressed (proves the window slides). */
+    dmr_rc_notify_command(&opts, &state, 0U, 2U, 4U, 1, 1, (time_t)1008);
+    assert(g_notice_calls == 1U);
+    /* 6 s of RC silence: same command is a new event. */
+    dmr_rc_notify_command(&opts, &state, 0U, 2U, 4U, 1, 1, (time_t)1014);
+    assert(g_notice_calls == 2U);
+
+    /* A different command always emits immediately; without a trusted color
+     * code the CC clause is omitted. */
+    dmr_rc_notify_command(&opts, &state, 0U, 2U, 5U, /*have_cc*/ 0, 0U, (time_t)1014);
+    assert(g_notice_calls == 3U);
+    assert(strcmp(g_notice_last_text, "DMR RC: Cease Transmission Request;") == 0);
+
+    /* Dedup keys are independent: the same command on an embedded-slot key
+     * is not suppressed by the standalone key. */
+    dmr_rc_notify_command(&opts, &state, 1U, 0U, 5U, 0, 0U, (time_t)1014);
+    assert(g_notice_calls == 4U);
+    assert(g_notice_last_slot == 1U);
+
+    /* Reserved commands never emit. */
+    dmr_rc_notify_command(&opts, &state, 0U, 2U, 6U, 0, 0U, (time_t)2000);
+    assert(g_notice_calls == 4U);
+
+    dsd_state_ext_free_all(&state);
 }
 
 static void
@@ -345,6 +507,9 @@ main(void) {
     test_rc_pdu_rejects_wrong_crc_mask();
     test_assemble_bits_round_trip();
     test_handler_consumes_trailing_dibits();
+    test_handler_emits_control_event();
+    test_handler_no_event_on_invalid_or_reserved();
+    test_notify_dedup_window();
     test_handler_bails_out_on_short_history();
 
     printf("DMR_RC_BURST: OK\n");

--- a/tests/protocol/dmr/test_dmr_sbrc_rc_event.c
+++ b/tests/protocol/dmr/test_dmr_sbrc_rc_event.c
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Event-emission contract for the embedded SB/RC path: a validated RC command
+// commits exactly one CONTROL row to the received slot's event history, with
+// repeat suppression, and every invalid/gated variant stays stderr-only.
+// Asserts against the real emitter (dsd_events.c is already in this link
+// closure, so a strong spy would collide with it).
+// NOLINTBEGIN(misc-use-internal-linkage)
+
+#include <assert.h>
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/fec/block_codes.h>
+#include <dsd-neo/fec/bptc.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
+#include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+/* Copy of the Hamming(16,11,4) parity-check matrix in src/fec/fec.c; the
+ * encoder is sanity-asserted against the in-tree decoder. */
+static const uint8_t k_hamming_16_11_4_h[5][16] = {
+    {1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0}, {0, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0},
+    {0, 0, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0}, {1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 0},
+    {1, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1},
+};
+
+/* Load an 11-bit SB/RC value into the slot's embedded-signalling cache the way
+ * dmr_sbrc_init_data reads it. odd_parity selects the RC single-burst BPTC
+ * variant (second row = complement); pass 0 for the SB (even) variant. */
+static void
+load_sbrc_value(dsd_state* state, uint8_t slot, uint16_t value, int odd_parity) {
+    uint8_t data_matrix[32];
+    uint8_t interleaved[32];
+
+    for (int i = 0; i < 11; i++) {
+        data_matrix[i] = (uint8_t)((value >> (10 - i)) & 1U);
+    }
+    for (int row = 0; row < 5; row++) {
+        uint8_t p = 0;
+        for (int j = 0; j < 11; j++) {
+            p ^= (uint8_t)(k_hamming_16_11_4_h[row][j] & data_matrix[j]);
+        }
+        data_matrix[11 + row] = p;
+    }
+
+    uint8_t rx[16];
+    uint8_t decoded[11];
+    DSD_MEMCPY(rx, data_matrix, sizeof(rx));
+    assert(Hamming_16_11_4_decode(rx, decoded, 1));
+    for (int i = 0; i < 11; i++) {
+        assert(decoded[i] == ((value >> (10 - i)) & 1U));
+    }
+
+    for (int i = 0; i < 16; i++) {
+        data_matrix[16 + i] = (uint8_t)(data_matrix[i] ^ (odd_parity ? 1U : 0U));
+    }
+
+    for (int i = 0; i < 32; i++) {
+        interleaved[i] = data_matrix[DeInterleaveReverseChannelBptcPlacement[DeInterleaveReverseChannelBptc[i]]];
+    }
+    for (int i = 0; i < 32; i++) {
+        state->dmr_embedded_signalling[slot][5][i + 8] = interleaved[i];
+    }
+}
+
+/* 4-bit RC command + masked CRC-7 -> 11-bit SB/RC value. */
+static uint16_t
+build_rc_command_value(uint8_t rc_value) {
+    uint8_t rc_bits[4];
+    for (int i = 0; i < 4; i++) {
+        rc_bits[i] = (uint8_t)((rc_value >> (3 - i)) & 1U);
+    }
+    const uint8_t masked_crc = (uint8_t)(crc7(rc_bits, 4U) ^ 0x7AU);
+    return (uint16_t)(((uint16_t)(rc_value & 0xFU) << 7U) | masked_crc);
+}
+
+/* TXI opcode + delay + CRC-3 -> 11-bit SB value (even-parity variant). */
+static uint16_t
+build_txi_value(uint8_t opcode, uint8_t delay) {
+    const uint8_t low8 = (uint8_t)(((delay & 0x1FU) << 3U) | (opcode & 0x7U));
+    uint8_t low_bits[8];
+    for (int i = 0; i < 8; i++) {
+        low_bits[i] = (uint8_t)((low8 >> (7 - i)) & 1U);
+    }
+    return (uint16_t)(((uint16_t)crc3(low_bits, 8U) << 8U) | low8);
+}
+
+/* Strong stub: dmr_rc.o rides into this link for dmr_rc_notify_command, and
+ * its standalone-burst reader must not drag the DSP/io symbol chain in. The
+ * embedded path under test never reads dibits. */
+int
+getDibitSoft(dsd_opts* opts, dsd_state* state, dsd_dibit_soft_t* out_soft) {
+    (void)opts;
+    (void)state;
+    if (out_soft != NULL) {
+        out_soft->reliability = 0U;
+    }
+    return 0;
+}
+
+static Event_History_I g_event_history[2];
+
+static void
+reset_fixture(dsd_opts* opts, dsd_state* state) {
+    dsd_state_ext_free_all(state);
+    DSD_MEMSET(opts, 0, sizeof *opts);
+    DSD_MEMSET(state, 0, sizeof *state);
+    DSD_MEMSET(g_event_history, 0, sizeof g_event_history);
+    state->event_history_s = g_event_history;
+    init_event_history(&state->event_history_s[0], 0, 255);
+    init_event_history(&state->event_history_s[1], 0, 255);
+    opts->dmr_le = 1;
+    opts->call_alert = 1;
+}
+
+static void
+test_valid_rc_command_emits_on_received_slot(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_fixture(&opts, &state);
+
+    state.currentslot = 1;
+    load_sbrc_value(&state, 1, build_rc_command_value(5U), /*odd_parity*/ 1);
+    dmr_sbrc(&opts, &state, /*power*/ 1);
+
+    const Event_History* committed = &g_event_history[1].Event_History_Items[1];
+    assert(committed->category == DSD_EVENT_CATEGORY_CONTROL);
+    assert(committed->severity == DSD_EVENT_SEVERITY_INFO);
+    assert(committed->source_id == 0xFFFFFFU);
+    assert(committed->target_id == 0xFFFFFFU);
+    assert(strstr(committed->event_string, "DMR RC: Cease Transmission Request;") != NULL);
+    assert(committed->gps_s[0] == '\0');
+    assert(g_event_history[0].Event_History_Items[1].event_string[0] == '\0');
+    assert(opts.call_alert == 1);
+
+    /* The same command repeated within the window is one repeat train: the
+     * ring must not move again. */
+    const uint64_t revision_after_first = g_event_history[1].revision;
+    dmr_sbrc(&opts, &state, 1);
+    assert(g_event_history[1].revision == revision_after_first);
+
+    /* Each slot has its own dedup key: the same command decoded on the other
+     * slot is still a fresh event, committed to that slot's ring. */
+    state.currentslot = 0;
+    load_sbrc_value(&state, 0, build_rc_command_value(5U), 1);
+    dmr_sbrc(&opts, &state, 1);
+    assert(strstr(g_event_history[0].Event_History_Items[1].event_string, "DMR RC: Cease Transmission Request;")
+           != NULL);
+
+    dsd_state_ext_free_all(&state);
+}
+
+static void
+expect_no_commit(dsd_opts* opts, dsd_state* state, uint16_t value, int odd_parity, uint8_t power) {
+    reset_fixture(opts, state);
+    state->currentslot = 0;
+    const uint64_t revision_before = g_event_history[0].revision;
+    load_sbrc_value(state, 0, value, odd_parity);
+    dmr_sbrc(opts, state, power);
+    assert(g_event_history[0].revision == revision_before);
+    assert(g_event_history[0].Event_History_Items[1].event_string[0] == '\0');
+    dsd_state_ext_free_all(state);
+}
+
+static void
+test_invalid_or_gated_variants_do_not_emit(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    /* Reserved command (6..15): decodes with a valid CRC but stays
+     * stderr-only. */
+    expect_no_commit(&opts, &state, build_rc_command_value(6U), 1, 1);
+
+    /* Corrupted CRC-7. */
+    expect_no_commit(&opts, &state, (uint16_t)(build_rc_command_value(5U) ^ 0x1U), 1, 1);
+
+    /* FEC failure: even-parity rows presented as the RC (odd) variant. */
+    expect_no_commit(&opts, &state, build_rc_command_value(5U), 0, 1);
+
+    /* SB (power=0) TXI payloads are not RC commands. */
+    expect_no_commit(&opts, &state, build_txi_value(3U, 4U), 0, 0);
+
+    /* Late-entry gate off: the standard SB/RC branch never runs. */
+    reset_fixture(&opts, &state);
+    opts.dmr_le = 0;
+    state.currentslot = 0;
+    const uint64_t revision_before = g_event_history[0].revision;
+    load_sbrc_value(&state, 0, build_rc_command_value(5U), 1);
+    dmr_sbrc(&opts, &state, 1);
+    assert(g_event_history[0].revision == revision_before);
+    dsd_state_ext_free_all(&state);
+}
+
+int
+main(void) {
+    InitAllFecFunction();
+
+    test_valid_rc_command_emits_on_received_slot();
+    test_invalid_or_gated_variants_do_not_emit();
+
+    printf("DMR_SBRC_RC_EVENT: OK\n");
+    return 0;
+}
+
+// NOLINTEND(misc-use-internal-linkage)


### PR DESCRIPTION
Requested in discussion #152: decoded Reverse Channel commands ("Cease Transmission Request", power control, etc.) now appear in the ncurses terminal event history as yellow rows, on top of the existing stderr prints.

## What changed

- New `dmr_rc_notify_command()` (`src/protocol/dmr/dmr_rc_notify.c`), shared by both RC decode paths:
  - the standalone RC burst handler (`dmrRC`, PR #287), and
  - the embedded SB/RC path in voice burst F (`dmr_sbrc`).
- Rows are CONTROL-category data notices (rendered yellow, same as the ARS rows from #257/#263), e.g. `DMR RC: Cease Transmission Request; CC: 01;`. The CC clause appears only when the EMB QR(16,7,6) decode succeeded; the embedded path omits it (color code not in scope there).
- Emitted via the `_with_gps` variant so an active voice call's staged pdu/text/GPS on that slot is never consumed by the notice. Sentinel src/tgt IDs — the RC PDU is 4 command bits + CRC-7 and carries no addressing.
- Repeat suppression: identical command within a 5 s sliding window collapses to one row (RC bursts repeat every 30 ms / superframe). Per-key state (embedded slot 0/1, standalone) lives in new state-extension slot `DSD_STATE_EXT_PROTO_DMR_RC = 25`, allocated lazily only after a successful emit.
- Reserved commands (6..15) stay stderr-only: the CRC-7 covers just four data bits, so corrupted-but-passing bursts are plausible enough to keep out of history.
- The data-notice beeper is stashed off around the emit — RC is signalling, not a call.
- `dmr_sbrc` loses its `const dsd_opts*` (the emitter mutates `call_alert`); both production call sites already passed non-const.

## Latent test bug fixed

`test_sbrc_reverse_channel_commands` (test_dmr_pi_kirisun.c) loaded even-parity BPTC rows, but the RC single-burst variant (`power=1`) expects the complemented odd-parity row — so its RC cases always took the FEC-error path and `payload_algid == 0` passed vacuously. The loader now has an RC (odd-parity) variant and the test asserts the RC-command branch actually runs: one notice for a valid command, none for reserved. Verified the old parity fails the new assertions.

## Tests

- `DMR_RC_BURST`: emission contract through the full `dmrRC` handler (category/slot/text/gps, sentinel IDs), beeper stash/restore, dedup sliding window + per-key independence, no emit on CRC failure or reserved commands.
- New `DMR_SBRC_RC_EVENT`: drives `dmr_sbrc` against a real event-history ring — valid command commits to the received slot, repeat dedups, per-slot keys, and no commit for reserved / corrupted CRC-7 / wrong-parity FEC failure / SB (TXI) payloads / `dmr_le=0` gate.
- Full suite: 509/509; RC/kirisun tests also pass under ASan/UBSan; `tools/preflight_ci.sh` clean.

## Notes

- Per ETSI TS 102 361-1 9.3.2, an embedded RC targets the *other* logical channel; rows attribute to the received slot to match the existing stderr attribution (least surprise for anyone watching that call).
- TXI opcode prints (CRC-3 branch) and the kirisun branch remain stderr-only — candidate follow-ups if wanted.
- Standalone RC bursts are MS-sourced inbound signalling, so they only appear when the transmitting radio is within receive range.