### PR TITLE
ci: build a signed Play bundle on main and tags without risking the APK publish

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -313,6 +313,8 @@ jobs:
       signed: ${{ steps.sign.outputs.SIGNED }}
       art_name: ${{ steps.names.outputs.ART_NAME }}
       apk_path: ${{ steps.names.outputs.APK_PATH }}
+      publishable: ${{ steps.names.outputs.PUBLISHABLE }}
+      aab_ok: ${{ steps.aab_outcome.outputs.AAB_OK }}
     env:
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/.vcpkg-archives
       CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -453,7 +455,15 @@ jobs:
         run: |
           set -euxo pipefail
           log="$RUNNER_TEMP/configure-android-app.log"
+          # QT_ANDROID_SIGN_AAB only adds --sign to the aab target's
+          # androiddeployqt invocation; the apk target is driven by
+          # QT_ANDROID_SIGN_APK and keeps signing through apksigner below. The
+          # aab target is outside ALL, so this is inert until the "Build the
+          # AAB" step names that target — which it does on every publishable
+          # run (release tags, pushes to main/master, and workflow_dispatch),
+          # not only on tags.
           cmake --preset android-app -G Ninja \
+            -DQT_ANDROID_SIGN_AAB=ON \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache 2>&1 | tee "$log"
           grep -F "Codec2 available: ON (M17 voice)" "$log"
@@ -487,7 +497,7 @@ jobs:
           fi
           echo "APK_PATH=${apks[0]}" >> "$GITHUB_OUTPUT"
 
-      - name: Prepare artifact naming
+      - name: Prepare artifact naming and the publish gate
         id: names
         shell: bash
         env:
@@ -500,18 +510,37 @@ jobs:
           else
             art="dsd-neo-android-arm64-app-nightly"
           fi
+          # The one definition of "a run that publishes": the upstream repo, on
+          # a release tag or a push/dispatch to main/master. The AAB steps, the
+          # publish-apk job gate, and the aab-status job all read this output
+          # instead of restating the predicate.
+          publishable=false
+          if [ "$GITHUB_REPOSITORY" = 'arancormonk/dsd-neo' ]; then
+            case "$GITHUB_REF" in
+              refs/tags/v*) publishable=true ;;
+              refs/heads/main | refs/heads/master)
+                if [ "$GITHUB_EVENT_NAME" = 'push' ] || [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ]; then
+                  publishable=true
+                fi
+                ;;
+            esac
+          fi
           mkdir -p dist
           {
             echo "APK_PATH=dist/${art}.apk"
             echo "ART_NAME=${art}"
+            echo "PUBLISHABLE=${publishable}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Sign the APK
-        id: sign
+      # One decision, shared by APK signing and the AAB build below: is there
+      # usable signing material? A release tag without it is fatal — a release
+      # must not ship artifacts nobody can install or upload. The decoded
+      # keystore lives in RUNNER_TEMP until the always() cleanup step at the
+      # end of the job.
+      - name: Materialize the signing keystore
+        id: keystore
         shell: bash
         env:
-          BUILT_APK: ${{ steps.apk.outputs.APK_PATH }}
-          OUT_APK: ${{ steps.names.outputs.APK_PATH }}
           IS_TAG: ${{ startsWith(github.ref, 'refs/tags/v') }}
           IS_PR: ${{ github.event_name == 'pull_request' }}
           KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
@@ -522,32 +551,54 @@ jobs:
           set -euo pipefail
           if [ -z "${KEYSTORE_BASE64}" ]; then
             if [ "${IS_TAG}" = 'true' ]; then
-              echo "::error::ANDROID_KEYSTORE_BASE64 is not configured; a release tag cannot ship an unsigned APK" >&2
+              echo "::error::ANDROID_KEYSTORE_BASE64 is not configured; a release tag cannot ship unsigned artifacts" >&2
               exit 1
             fi
             # Pull requests never see the secrets, so only a push that was meant
             # to publish deserves a warning annotation.
             if [ "${IS_PR}" = 'true' ]; then
-              echo "Pull request build: leaving the APK unsigned."
+              echo "Pull request build: no signing material; the APK stays unsigned and no AAB is built."
             else
-              echo "::warning::Android signing secrets are not configured; the APK stays unsigned and is not published"
+              echo "::warning::Android signing secrets are not configured; the APK stays unsigned, no AAB is built, and nothing is published"
             fi
-            cp "${BUILT_APK}" "${OUT_APK}"
-            echo "SIGNED=false" >> "$GITHUB_OUTPUT"
+            echo "AVAILABLE=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           : "${KEYSTORE_PASSWORD:?ANDROID_KEYSTORE_PASSWORD is required alongside ANDROID_KEYSTORE_BASE64}"
           : "${KEY_ALIAS:?ANDROID_KEY_ALIAS is required alongside ANDROID_KEYSTORE_BASE64}"
           : "${KEY_PASSWORD:?ANDROID_KEY_PASSWORD is required alongside ANDROID_KEYSTORE_BASE64}"
           keystore="$RUNNER_TEMP/android-release.jks"
-          trap 'rm -f "$keystore"' EXIT
           printf '%s' "${KEYSTORE_BASE64}" | base64 -d > "$keystore"
+          chmod 600 "$keystore"
+          {
+            echo "AVAILABLE=true"
+            echo "KEYSTORE_PATH=$keystore"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sign the APK
+        id: sign
+        shell: bash
+        env:
+          BUILT_APK: ${{ steps.apk.outputs.APK_PATH }}
+          OUT_APK: ${{ steps.names.outputs.APK_PATH }}
+          KEYSTORE_AVAILABLE: ${{ steps.keystore.outputs.AVAILABLE }}
+          KEYSTORE_PATH: ${{ steps.keystore.outputs.KEYSTORE_PATH }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ "${KEYSTORE_AVAILABLE}" != 'true' ]; then
+            cp "${BUILT_APK}" "${OUT_APK}"
+            echo "SIGNED=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           tools="${ANDROID_SDK_ROOT:?ANDROID_SDK_ROOT is not set}/build-tools/$ANDROID_BUILD_TOOLS_VERSION"
           # androiddeployqt's release output is already 16 KB aligned and
           # apksigner preserves that, so re-running zipalign would only risk
           # undoing it; the alignment checks below run on the signed APK.
           "$tools/apksigner" sign \
-            --ks "$keystore" \
+            --ks "${KEYSTORE_PATH}" \
             --ks-pass env:KEYSTORE_PASSWORD \
             --key-pass env:KEY_PASSWORD \
             --ks-key-alias "${KEY_ALIAS}" \
@@ -690,9 +741,231 @@ jobs:
           subject-path: ${{ steps.names.outputs.APK_PATH }}
           sbom-path: ${{ steps.names.outputs.APK_PATH }}.spdx.json
 
+      # Google Play will not take an APK for a new app, so releases also produce
+      # an Android App Bundle. It is deliberately a workflow artifact and never a
+      # release asset: an AAB cannot be installed, so next to the APK it is only
+      # a trap for anyone who downloads it, and under Play App Signing the
+      # uploaded bundle carries the upload key while Google re-signs what users
+      # actually install - it corresponds to no shipped binary. A maintainer
+      # downloads it and hands it to the Play Console.
+      #
+      # Built on main as well as on tags, so the bundle path is exercised every
+      # merge rather than for the first time on a release. Building consumes no
+      # versionCode - only an upload to a Play track does that. Every AAB step
+      # is continue-on-error so a bundle-only failure cannot fail this job and
+      # take the already-verified APK publish down with it; the aab-status job
+      # turns any such failure into its own red check instead.
+      #
+      # Gated on SIGNED rather than on the keystore directly: an unsigned
+      # bundle is useless - Play rejects it on upload - and the missing-secrets
+      # warning (or the tag-fatal error) was already issued by "Materialize the
+      # signing keystore".
+      - name: Build the AAB
+        id: aab_build
+        if: >-
+          steps.names.outputs.PUBLISHABLE == 'true' &&
+          steps.sign.outputs.SIGNED == 'true'
+        continue-on-error: true
+        shell: bash
+        env:
+          KEYSTORE_PATH: ${{ steps.keystore.outputs.KEYSTORE_PATH }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          # androiddeployqt signs a bundle with jarsigner rather than apksigner,
+          # which cannot sign an AAB at all. The four QT_ANDROID_KEYSTORE_*
+          # variables keep the passwords out of this step's own command lines,
+          # but androiddeployqt still forwards them to jarsigner as
+          # -storepass/-keypass argv, so they are visible in the runner's
+          # process table while jarsigner runs. That is tolerated only because
+          # the runner is ephemeral and single-tenant; do not point verbose
+          # Gradle/androiddeployqt logging at this step, since a mode that
+          # echoes child command lines would put them in the build log.
+          export QT_ANDROID_KEYSTORE_PATH="${KEYSTORE_PATH}"
+          export QT_ANDROID_KEYSTORE_ALIAS="${KEY_ALIAS}"
+          export QT_ANDROID_KEYSTORE_STORE_PASS="${KEYSTORE_PASSWORD}"
+          export QT_ANDROID_KEYSTORE_KEY_PASS="${KEY_PASSWORD}"
+          # Qt's aab target is outside ALL and the android-app build preset pins
+          # its targets to apk, so name it against the build directory. The
+          # native libraries are already built at this point; this only re-runs
+          # androiddeployqt and Gradle.
+          cmake --build build/android-app --target aab -j
+          echo "BUILT=true" >> "$GITHUB_OUTPUT"
+
+      # A step skipped by its own `if` (or by its predecessor failing) reports
+      # empty outputs, so these conditions also cover pull requests, where the
+      # build step never ran.
+      - name: Locate the AAB
+        id: aab
+        if: steps.aab_build.outputs.BUILT == 'true'
+        continue-on-error: true
+        shell: bash
+        env:
+          ART_NAME: ${{ steps.names.outputs.ART_NAME }}
+        run: |
+          set -euo pipefail
+          # Qt's aab target drives Gradle's variant-less `bundle` anchor task,
+          # which builds every variant: the debug bundle and AGP's intermediary
+          # bundles land in the build tree alongside the release bundle, and
+          # jarsigner signs only the release output. Scope the search to the
+          # release outputs directory; the digest check still guards against a
+          # build that leaves two distinct candidates even there.
+          mapfile -t aabs < <(find build/android-app -path '*/build/outputs/bundle/release/*.aab' | sort)
+          if [ "${#aabs[@]}" -eq 0 ]; then
+            echo "No release AAB produced under build/android-app" >&2
+            exit 1
+          fi
+          printf 'Found: %s\n' "${aabs[@]}"
+          mapfile -t digests < <(sha256sum "${aabs[@]}" | awk '{ print $1 }' | sort -u)
+          if [ "${#digests[@]}" -ne 1 ]; then
+            echo "build/android-app contains more than one distinct release AAB" >&2
+            exit 1
+          fi
+          mkdir -p dist
+          cp "${aabs[0]}" "dist/${ART_NAME}.aab"
+          echo "AAB_PATH=dist/${ART_NAME}.aab" >> "$GITHUB_OUTPUT"
+
+      - name: Verify the AAB
+        id: aab_verify
+        if: steps.aab.outputs.AAB_PATH != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          AAB_PATH: ${{ steps.aab.outputs.AAB_PATH }}
+        run: |
+          set -euo pipefail
+          # jarsigner -verify exits 0 on an unsigned jar, so assert on the
+          # message. -strict is deliberately not used: the release key is
+          # self-signed, and -strict turns signerSelfSigned into a nonzero exit.
+          verify_out=$(jarsigner -verify -verbose:summary "$AAB_PATH" 2>&1)
+          printf '%s\n' "$verify_out"
+          if ! printf '%s\n' "$verify_out" | grep -qF 'jar verified.'; then
+            echo "ERROR: the AAB is unsigned; Play rejects it on upload" >&2
+            exit 1
+          fi
+          entries=$(unzip -Z1 "$AAB_PATH")
+          if ! printf '%s\n' "$entries" | grep -qxF 'base/manifest/AndroidManifest.xml'; then
+            echo "ERROR: the AAB has no base module manifest" >&2
+            exit 1
+          fi
+          # Play generates the per-device APKs from these directories, so a
+          # stray ABI would be served to devices the app was never built for.
+          abis=$(printf '%s\n' "$entries" | sed -n 's:^base/lib/\([^/]*\)/.*:\1:p' | sort -u)
+          if [ "$abis" != 'arm64-v8a' ]; then
+            echo "ERROR: unexpected ABIs in the AAB: ${abis:-none}" >&2
+            exit 1
+          fi
+          echo "AAB OK: signed, arm64-v8a only."
+
+      - name: Upload AAB
+        id: aab_upload
+        if: steps.aab.outputs.AAB_PATH != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.names.outputs.ART_NAME }}.aab
+          path: ${{ steps.aab.outputs.AAB_PATH }}
+          # Longer than the APK's 7 days: nothing consumes the bundle
+          # automatically, it is fetched by hand whenever the Play track is
+          # next updated, which is not necessarily release day. A tag bundle
+          # gets the 90-day maximum for that reason (a re-run after expiry
+          # rebuilds with the current toolchain, it does not restore the same
+          # bytes); a nightly is superseded on the next merge and keeps 30.
+          retention-days: ${{ startsWith(github.ref, 'refs/tags/v') && 90 || 30 }}
+
+      - name: Generate AAB SBOM
+        id: aab_sbom
+        if: steps.aab.outputs.AAB_PATH != ''
+        continue-on-error: true
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610
+        with:
+          file: ${{ steps.aab.outputs.AAB_PATH }}
+          format: spdx-json
+          output-file: ${{ steps.aab.outputs.AAB_PATH }}.spdx.json
+          artifact-name: ${{ steps.names.outputs.ART_NAME }}.aab.spdx.json
+          upload-artifact: true
+          upload-release-assets: false
+
+      # The AAB is the artifact that actually reaches users through Play, so a
+      # tag attests it exactly like the sideload APK; a maintainer verifies
+      # with `gh attestation verify` before handing a bundle to the Play
+      # Console (docs/release-verification.md).
+      - name: Attest AAB provenance
+        id: aab_attest
+        if: startsWith(github.ref, 'refs/tags/') && steps.aab.outputs.AAB_PATH != ''
+        continue-on-error: true
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-path: ${{ steps.aab.outputs.AAB_PATH }}
+
+      - name: Attest AAB SBOM
+        id: aab_attest_sbom
+        if: startsWith(github.ref, 'refs/tags/') && steps.aab.outputs.AAB_PATH != ''
+        continue-on-error: true
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-path: ${{ steps.aab.outputs.AAB_PATH }}
+          sbom-path: ${{ steps.aab.outputs.AAB_PATH }}.spdx.json
+
+      # continue-on-error keeps AAB failures from failing this job, so the
+      # signal has to leave through a job output instead; the aab-status job
+      # fails on it. Skipped steps count as ok: an AAB is only owed on
+      # publishable refs with signing material, and the missing-material cases
+      # already warned (nightly) or hard-failed (tag) at the keystore step.
+      - name: Record the AAB outcome
+        id: aab_outcome
+        if: always()
+        shell: bash
+        env:
+          OUTCOMES: >-
+            ${{ steps.aab_build.outcome }}
+            ${{ steps.aab.outcome }}
+            ${{ steps.aab_verify.outcome }}
+            ${{ steps.aab_upload.outcome }}
+            ${{ steps.aab_sbom.outcome }}
+            ${{ steps.aab_attest.outcome }}
+            ${{ steps.aab_attest_sbom.outcome }}
+        run: |
+          set -euo pipefail
+          if printf '%s\n' "${OUTCOMES}" | grep -qw 'failure'; then
+            echo "AAB_OK=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "AAB_OK=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Remove the signing keystore
+        if: always() && steps.keystore.outputs.KEYSTORE_PATH != ''
+        shell: bash
+        env:
+          KEYSTORE_PATH: ${{ steps.keystore.outputs.KEYSTORE_PATH }}
+        run: rm -f "${KEYSTORE_PATH}"
+
       - name: Show ccache stats
         shell: bash
         run: ccache --show-stats
+
+  aab-status:
+    name: AAB status
+    # The AAB steps in build-apk are continue-on-error so a bundle-only failure
+    # cannot block the APK publish; this job is where such a failure surfaces
+    # as its own red check instead of vanishing.
+    needs: [build-apk]
+    runs-on: ubuntu-latest
+    if: needs.build-apk.outputs.publishable == 'true'
+    steps:
+      - name: Fail when the AAB pipeline failed
+        shell: bash
+        env:
+          AAB_OK: ${{ needs.build-apk.outputs.aab_ok }}
+        run: |
+          set -euo pipefail
+          if [ "${AAB_OK}" != 'true' ]; then
+            echo "::error::An AAB build/verify/upload/attest step failed in build-apk; the APK publish is unaffected, but this run produced no uploadable bundle" >&2
+            exit 1
+          fi
+          echo "AAB pipeline OK."
 
   publish-apk:
     name: Publish APK
@@ -703,13 +976,13 @@ jobs:
     needs: [build-apk, qt-ui-tests]
     runs-on: ubuntu-latest
     # An unsigned APK cannot be installed, so a build that could not sign
-    # publishes nothing rather than shipping a broken download.
+    # publishes nothing rather than shipping a broken download. The publishable
+    # predicate (upstream repo + release tag or main/master push/dispatch) is
+    # computed once, in build-apk's "Prepare artifact naming and the publish
+    # gate" step.
     if: >-
-      github.repository == 'arancormonk/dsd-neo' &&
-      needs.build-apk.outputs.signed == 'true' &&
-      (startsWith(github.ref, 'refs/tags/v') ||
-      ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')))
+      needs.build-apk.outputs.publishable == 'true' &&
+      needs.build-apk.outputs.signed == 'true'
     permissions:
       actions: read
       contents: write
@@ -773,10 +1046,10 @@ jobs:
             --repo "${RELEASE_REPOSITORY}" \
             --clobber
 
+      # The job-level gate already restricts this job to publishable refs, so
+      # "not a tag" is all that distinguishes a nightly here.
       - name: Upload APK nightly assets (overwrite)
-        if: >-
-          (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-          (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
         with:
           tag_name: nightly

--- a/android/README.md
+++ b/android/README.md
@@ -144,7 +144,10 @@ pull requests as well as pushes to `main`:
   intact (label `DSD-neo`, a declared icon, a non-placeholder version code and
   the icon/splash/theme resources). The APK is uploaded as a build
   artifact, and on `main` and release tags the `Publish APK` job attaches it to a
-  release (see [Release signing](#release-signing)).
+  release (see [Release signing](#release-signing)). On `main` and release tags
+  the same `build-apk` job also builds and signs the Play bundle — the `Publish
+  APK` job never touches it, and a separate `AAB status` check reports bundle
+  failures (see [Google Play](#google-play-the-app-bundle)).
 - **`linux-ci` / android shape (headless, forced radio pipeline)** — the same
   option set on the host without an NDK, and deliberately without PulseAudio or
   ncurses installed. This is the only place the Android configuration gets test
@@ -233,6 +236,83 @@ release must not ship an APK nobody can install. CI deliberately does not re-run
 `zipalign`: the Gradle output is already 16 KB page aligned and `apksigner`
 preserves that, so it only verifies the alignment (`zipalign -c -P 16 4`) after
 signing.
+
+## Google Play: the app bundle
+
+Play will not accept an APK for a new app, so releases also produce an Android
+App Bundle. Qt's Android macros already define a global `aab` target next to
+`apk`; it sits outside `ALL`, so it has to be named explicitly, and the
+`android-app` build preset pins its targets to `apk`. Point the build at the
+directory instead:
+
+```sh
+export QT_ANDROID_KEYSTORE_PATH=/path/to/dsd-neo-release.jks
+export QT_ANDROID_KEYSTORE_ALIAS="$ANDROID_KEY_ALIAS"
+export QT_ANDROID_KEYSTORE_STORE_PASS=...
+export QT_ANDROID_KEYSTORE_KEY_PASS="$QT_ANDROID_KEYSTORE_STORE_PASS"
+
+cmake --preset android-app -DQT_ANDROID_SIGN_AAB=ON
+cmake --build build/android-app --target aab -j
+find build/android-app -name '*.aab'
+```
+
+`QT_ANDROID_SIGN_AAB` only adds `--sign` to the `aab` target — the APK target
+stays governed by `QT_ANDROID_SIGN_APK` — but building `aab` re-runs
+androiddeployqt with `--sign`, which also apksigner-signs the APK and overwrites
+the build-tree `dsd-neo-app.apk` with the signed copy in passing. Signing
+happens in the build because androiddeployqt signs a bundle with `jarsigner`;
+`apksigner` cannot sign an AAB at all, so the post-hoc recipe above does not
+transfer. The four `QT_ANDROID_KEYSTORE_*` variables keep the passwords out of
+your shell history and off the command line *you* type, but androiddeployqt
+still forwards them to `jarsigner` as `-storepass`/`-keypass` arguments, so they
+are visible in the local process table while the bundle signs.
+
+CI builds the bundle in the same `build-apk` job, reusing the native libraries
+the APK build already produced, and uploads it as the workflow artifact
+`dsd-neo-android-arm64-app-<tag>.aab` (`-nightly` off `main`). Nothing consumes
+it automatically, so retention is sized for hand-fetching: 90 days for a tag
+bundle, 30 for a nightly. Fetch a release bundle within that window — re-running
+the tag workflow after expiry rebuilds against the current toolchain rather than
+restoring the same bytes. The bundle path runs on `main` as well as on tags so
+it is exercised every merge rather than for the first time on a release, and
+every AAB step is `continue-on-error`: a bundle-only failure surfaces through
+the separate `AAB status` check instead of failing `build-apk` and taking the
+APK publish down with it. Building consumes no `versionCode`, only an upload to
+a Play track does. Without the signing secrets a tag fails hard at the shared
+keystore step and a nightly just warns and skips, matching how the APK is
+treated. Every bundle gets an SPDX SBOM artifact, and a tag bundle additionally
+gets GitHub provenance/SBOM attestations — verify with `gh attestation verify`
+before handing it to the Play Console
+(see `docs/release-verification.md`). It is deliberately **not** a release asset:
+an AAB cannot be installed, so beside the APK it only misleads, and under Play
+App Signing the uploaded bundle carries the upload key while Google re-signs what
+users install — it corresponds to no shipped binary. Download it by hand when
+updating a Play track.
+
+Two consequences worth knowing before enrolling in Play App Signing:
+
+- The release keystore becomes the *upload* key. Play installs and GitHub release
+  APKs then have different signatures and cannot upgrade into each other, so a
+  tester on a sideloaded build has to uninstall first.
+- A `versionCode` is consumed permanently the moment a bundle reaches any track
+  and can never be re-uploaded. Whether a nightly bundle is safe to upload
+  depends on when it was built, because the version part of the code moves at
+  the version-bump commit while the distance part counts from the previous tag:
+  - **After a release, before the next version bump** (most nightlies): the code
+    is the last release's round thousand plus the commit distance —
+    `20600042` sits above `v2.6.0` but below `v2.6.1`'s `20601000`, so the next
+    release still outranks it. Uploading one to a closed testing track works
+    and burns nothing the release will need.
+  - **After the version bump, before its tag**: the code is the *upcoming*
+    release's round thousand plus a distance that has not reset — a nightly
+    after the 2.6.1 bump was `20601001`, above `v2.6.1`'s `20601000`. Uploading
+    that bundle to any track permanently burns a code above the release and
+    makes the release unuploadable.
+
+  The safe habit is to upload only release-tag bundles; before uploading a
+  nightly, check its `versionCode` is below the next release's round thousand.
+  A respin is: once `v2.6.0`'s `20600000` is on a track, correcting that
+  release means cutting `v2.6.1`, not rebuilding the tag.
 
 ## USB-OTG: how the descriptor gets to librtlsdr
 

--- a/docs/release-assets-checklist.md
+++ b/docs/release-assets-checklist.md
@@ -53,6 +53,21 @@ resource bundle, so they travel with the binary rather than as a separate file.
         zero (`android-ci` asserts the shape, so this is a spot check that the
         published asset is the one CI built from the tag and not from `main`).
 
+### Android (AAB — workflow artifact, not a release asset)
+
+- [ ] Download the `dsd-neo-android-arm64-app-<tag>.aab` artifact from the tag's
+      `android-ci` run within its 90-day retention window (re-running the
+      workflow after expiry rebuilds against the current toolchain; it does not
+      restore the same bytes).
+  - [ ] `jarsigner -verify -verbose:summary` prints `jar verified.` with the
+        project release (upload) key.
+  - [ ] `gh attestation verify <file>.aab --repo arancormonk/dsd-neo` passes
+        before the bundle goes to the Play Console.
+  - [ ] The bundle came from a release tag, never from a nightly: a nightly
+        built between the version bump and the tag carries a `versionCode`
+        above the release's, and uploading it to any track would burn that code
+        permanently (see `android/README.md`, Google Play section).
+
 ## CI-side sanity
 
 - [ ] Release tags use `vX.Y.Z`, match `project(dsd-neo VERSION X.Y.Z ...)` in `CMakeLists.txt`, and verify with `git tag -v` against one of the trusted keys in `release-keys/` (`arancormonk-desktop-2026.pgp` or `arancormonk-laptop-2026.pgp`).

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -61,7 +61,9 @@ verification remains mandatory even when repository rulesets are enabled.
 Release assets are distributed over GitHub HTTPS. Tag release workflows generate
 SBOMs and GitHub artifact attestations for packaged Linux AppImage, macOS DMG,
 Windows ZIP, and Android APK assets when the corresponding workflow completes
-successfully.
+successfully. The Android App Bundle handed to the Play Console is a workflow
+artifact rather than a release asset, but a tag attests it the same way — verify
+it with `gh attestation verify` (below) before uploading it to a Play track.
 Release publication jobs use `contents: write` only in trusted upstream
 release/nightly paths and publish with the workflow `GITHUB_TOKEN`.
 Packaging workflows also verify release hardening before upload: Linux ELF


### PR DESCRIPTION
Google Play will not take an APK for a new app, so publishable runs of `android-ci` (release tags, pushes to `main`/`master`, and `workflow_dispatch`) now also build the Android App Bundle. Qt's `aab` target sits outside `ALL`, so the `build-apk` job names it explicitly after the APK is already signed, verified, and uploaded, reusing the native libraries that build produced.

## The bundle path cannot take the APK down with it

- Every AAB step is `continue-on-error`; a new `aab-status` job turns any bundle failure into its own red check. A bundle-only failure — transient Gradle trouble, a jarsigner change — can no longer skip the APK publish, on `main` or on a release tag.
- Locating the bundle is scoped to Gradle's `build/outputs/bundle/release/` directory. Qt's `aab` target drives the variant-less `bundle` anchor task, which also leaves debug and intermediary bundles in the build tree, so a whole-tree search would find several distinct `.aab` files on every run. The single-digest check remains as a guard within the release directory.

## Artifact handling

- The AAB is a **workflow artifact only, never a release asset**: it cannot be installed, and under Play App Signing the uploaded bundle carries the upload key while Google re-signs what users install. It never appears on the Releases page; a maintainer fetches it from the tag's workflow run.
- Tag bundles keep the 90-day retention maximum (nothing consumes them automatically, and a re-run after expiry rebuilds against the current toolchain rather than restoring the same bytes); nightlies keep 30.
- The bundle gets an SPDX SBOM on every build and provenance/SBOM attestations on tags, matching the sideload APK — it is the artifact that actually reaches users through Play. `docs/release-verification.md` and the release checklist cover verifying it before a Play upload.

## Deduplication

- One shared **keystore-materialization step** feeds both `apksigner` (APK) and androiddeployqt/`jarsigner` (AAB), replacing two hand-copied secrets ladders; a release tag without signing material still fails hard, once, in one place. The decoded keystore is removed by an `always()` cleanup step.
- One **`PUBLISHABLE` output** computed in `build-apk` replaces three hand-copied ref gates. The AAB copy had silently dropped the `github.repository` clause the publish job carries; all consumers now agree.

## Docs corrected to match reality

- The versionCode section now states the true ordering: a nightly built *after* a release and *before* the next version bump is safely outranked by the next release, but a nightly built *between the version-bump commit and its tag* outranks the upcoming release (`20601001` > `v2.6.1`'s `20601000`, since the distance counts from the previous tag while the version part moves at the bump). Such a bundle must never reach a Play track.
- The claim that the keystore passwords never reach a command line was false one process level down: androiddeployqt forwards them to `jarsigner` as `-storepass`/`-keypass` argv. The comments now say so, and why it is tolerated on an ephemeral single-tenant runner.
- "Inert unless a release tag asks for it" (configure step) and "the same job builds the bundle" (README, pointing at the wrong job) are fixed.

## Testing

- `actionlint` and YAML parse clean; `zizmor` finding set is byte-identical to the pre-change baseline (no new findings).
- `tools/preflight_ci.sh` passes on the changed paths (pre-push hooks ran on push).
- The workflow itself cannot run pre-merge for the `main` path; the first push to `main` with secrets exercises the full bundle pipeline, and a failure there surfaces in `aab-status` without blocking the nightly APK.