### PR TITLE
android: add a spectrum screen that retunes the receiver by touch

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -268,7 +268,7 @@ jobs:
           # the count would fail the release for the act of adding a UI test —
           # and fail it saying only that a grep matched nothing. Registration
           # going backwards, which is what this guards, still fails here.
-          min=7
+          min=9
           registered=$(ctest --preset dev-debug -N -R '^UI_QT_' | sed -n 's/^Total Tests: *//p')
           echo "UI_QT_* tests registered: ${registered:-none} (floor $min)"
           if [ "${registered:-0}" -lt "$min" ]; then
@@ -291,7 +291,8 @@ jobs:
             dsd-neo_test_ui_qt_call_history_merge \
             dsd-neo_test_ui_qt_call_line \
             dsd-neo_test_ui_qt_session_state \
-            dsd-neo_test_ui_qt_spectrum_math
+            dsd-neo_test_ui_qt_spectrum_math \
+            dsd-neo_test_ui_qt_spectrum_model
 
       # The QML test carries its own headless environment (offscreen platform,
       # software renderer) in the CTest registration, so there is nothing to set

--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -276,6 +276,9 @@ jobs:
             exit 1
           fi
 
+      # Every target behind a UI_QT_* test, because the Test step runs them by
+      # name pattern: registering one and forgetting it here fails the job with
+      # "Could not find executable", not with anything about the test.
       - name: Build the Qt UI test targets
         shell: bash
         run: |
@@ -287,7 +290,8 @@ jobs:
             dsd-neo_test_ui_qt_session_args \
             dsd-neo_test_ui_qt_call_history_merge \
             dsd-neo_test_ui_qt_call_line \
-            dsd-neo_test_ui_qt_session_state
+            dsd-neo_test_ui_qt_session_state \
+            dsd-neo_test_ui_qt_spectrum_math
 
       # The QML test carries its own headless environment (offscreen platform,
       # software renderer) in the CTest registration, so there is nothing to set

--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -268,7 +268,7 @@ jobs:
           # the count would fail the release for the act of adding a UI test —
           # and fail it saying only that a grep matched nothing. Registration
           # going backwards, which is what this guards, still fails here.
-          min=9
+          min=10
           registered=$(ctest --preset dev-debug -N -R '^UI_QT_' | sed -n 's/^Total Tests: *//p')
           echo "UI_QT_* tests registered: ${registered:-none} (floor $min)"
           if [ "${registered:-0}" -lt "$min" ]; then
@@ -292,7 +292,8 @@ jobs:
             dsd-neo_test_ui_qt_call_line \
             dsd-neo_test_ui_qt_session_state \
             dsd-neo_test_ui_qt_spectrum_math \
-            dsd-neo_test_ui_qt_spectrum_model
+            dsd-neo_test_ui_qt_spectrum_model \
+            dsd-neo_test_ui_qt_metrics_model
 
       # The QML test carries its own headless environment (offscreen platform,
       # software renderer) in the CTest registration, so there is nothing to set

--- a/include/dsd-neo/app_control/commands.h
+++ b/include/dsd-neo/app_control/commands.h
@@ -162,7 +162,7 @@ enum dsd_app_command_id {
     // Set the modulation outright rather than cycling it. A view showing C4FM and
     // QPSK as two choices has to be able to ask for the one it is not on; a toggle
     // makes that a guess about state that may already have moved.
-    DSD_APP_CMD_MOD_SET = 494, // payload: int32_t (0 = C4FM, 1 = QPSK)
+    DSD_APP_CMD_MOD_SET = 494, // payload: int32_t (0 = C4FM, 1 = QPSK, 2 = GFSK), matching dsd_state::rf_mod
     // Switch which protocols are decoded, mid-session. Payload is a
     // dsdneoUserDecodeMode (<dsd-neo/runtime/config.h>), applied through the same
     // preset helper the CLI and config paths use.

--- a/include/dsd-neo/app_control/commands.h
+++ b/include/dsd-neo/app_control/commands.h
@@ -155,6 +155,18 @@ enum dsd_app_command_id {
     // with taps, the trunking gate is enforced at drain time, and an accepted tune resets
     // the decoder's auto-modulation votes and call state for re-acquisition.
     DSD_APP_CMD_MANUAL_TUNE = 492, // payload: uint32_t hz
+    // Hand the tuner back to the operator: trunking and conventional scanner mode both off,
+    // idempotent. Distinct from TRUNK_TOGGLE/SCANNER_TOGGLE, which cannot express "off" from a
+    // frontend that only sees whether *something* owns the tuner.
+    DSD_APP_CMD_TUNER_RELEASE = 493, // no payload
+    // Set the modulation outright rather than cycling it. A view showing C4FM and
+    // QPSK as two choices has to be able to ask for the one it is not on; a toggle
+    // makes that a guess about state that may already have moved.
+    DSD_APP_CMD_MOD_SET = 494, // payload: int32_t (0 = C4FM, 1 = QPSK)
+    // Switch which protocols are decoded, mid-session. Payload is a
+    // dsdneoUserDecodeMode (<dsd-neo/runtime/config.h>), applied through the same
+    // preset helper the CLI and config paths use.
+    DSD_APP_CMD_DECODE_MODE_SET = 495, // payload: int32_t dsdneoUserDecodeMode
 
     // Rigctl / tuning params
     DSD_APP_CMD_RIGCTL_SET_MOD_BW = 500, // payload: int32_t hz

--- a/include/dsd-neo/app_control/commands.h
+++ b/include/dsd-neo/app_control/commands.h
@@ -167,6 +167,14 @@ enum dsd_app_command_id {
     // dsdneoUserDecodeMode (<dsd-neo/runtime/config.h>), applied through the same
     // preset helper the CLI and config paths use.
     DSD_APP_CMD_DECODE_MODE_SET = 495, // payload: int32_t dsdneoUserDecodeMode
+    // Hand the tuner to trunking, or take it back, from a frontend that knows which
+    // of the two it is asking for. TRUNK_TOGGLE cannot say that: a view offering
+    // "follow this system" as a choice has to be able to ask for the state it is not
+    // in, and a flip makes that a guess about state that may already have moved.
+    // Turning it on clears scanner mode, which is the same exclusion SCANNER_TOGGLE
+    // already applies in the other direction — both cannot own the tuner. Turning it
+    // off is deliberately narrow; TUNER_RELEASE remains the way to clear both at once.
+    DSD_APP_CMD_TRUNK_SET = 496, // payload: int32_t on(0/1)
 
     // Rigctl / tuning params
     DSD_APP_CMD_RIGCTL_SET_MOD_BW = 500, // payload: int32_t hz

--- a/include/dsd-neo/app_control/commands.h
+++ b/include/dsd-neo/app_control/commands.h
@@ -151,6 +151,10 @@ enum dsd_app_command_id {
     DSD_APP_CMD_RTL_SET_BIAS_TEE = 489,    // payload: int32_t on(0/1)
     DSD_APP_CMD_RTLTCP_SET_AUTOTUNE = 490, // payload: int32_t on(0/1)
     DSD_APP_CMD_RTL_SET_AUTO_PPM = 491,    // payload: int32_t on(0/1)
+    // Live retune from a spectrum tap. Separate from RTL_SET_FREQ so taps coalesce only
+    // with taps, the trunking gate is enforced at drain time, and an accepted tune resets
+    // the decoder's auto-modulation votes and call state for re-acquisition.
+    DSD_APP_CMD_MANUAL_TUNE = 492, // payload: uint32_t hz
 
     // Rigctl / tuning params
     DSD_APP_CMD_RIGCTL_SET_MOD_BW = 500, // payload: int32_t hz

--- a/include/dsd-neo/app_control/frontend.h
+++ b/include/dsd-neo/app_control/frontend.h
@@ -57,6 +57,10 @@ typedef struct dsd_frontend_metrics {
     int symbol_rate_hz;
     int symbol_levels;
     int channel_profile;
+    /* Full width in Hz of the channel the demodulator is filtering — twice the
+     * protected edge of channel_profile. 0 when the input is not a radio. The
+     * channel, not the filter: see dsd_channel_lpf_protected_edge_hz(). */
+    int channel_bandwidth_hz;
     uint32_t stream_generation;
     int stream_active;
     dsd_input_level_snapshot input_level;

--- a/include/dsd-neo/app_control/frontend.h
+++ b/include/dsd-neo/app_control/frontend.h
@@ -157,6 +157,31 @@ int dsd_app_frontend_constellation_get(float* out_xy, int max_points);
 int dsd_app_frontend_eye_get(float* out, int max_samples, int* out_sps);
 int dsd_app_frontend_spectrum_get(float* out_db, int max_bins, int* out_rate);
 
+/**
+ * @brief Copy the wideband spectrum covering the whole SDR capture span.
+ *
+ * Unlike dsd_app_frontend_spectrum_get(), which reports the narrow
+ * post-decimation span used for tuner diagnostics, this covers the full
+ * capture bandwidth so a frontend can draw a panorama around the tuned
+ * frequency. Bins are DC-centered and the center/span are published together
+ * with them, so the axis always matches the data.
+ *
+ * Production is off by default: a frontend must call
+ * dsd_app_frontend_wideband_spectrum_set_enabled(1) while its view is open and
+ * 0 when it closes, so the FFT costs nothing the rest of the time.
+ *
+ * @param out_db Destination buffer for spectrum bins (float dB).
+ * @param max_bins Maximum number of bins to write.
+ * @param out_center_freq_hz Optional; receives the tuned center in Hz.
+ * @param out_span_hz Optional; receives the covered span in Hz.
+ * @return Number of bins written; 0 when disabled, unavailable, or on a build
+ *         with no radio backend.
+ */
+int dsd_app_frontend_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz,
+                                           uint32_t* out_span_hz);
+/** @brief Enable or disable wideband spectrum production (off = zero DSP cost). */
+void dsd_app_frontend_wideband_spectrum_set_enabled(int on);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dsd-neo/app_control/frontend.h
+++ b/include/dsd-neo/app_control/frontend.h
@@ -170,15 +170,21 @@ int dsd_app_frontend_spectrum_get(float* out_db, int max_bins, int* out_rate);
  * dsd_app_frontend_wideband_spectrum_set_enabled(1) while its view is open and
  * 0 when it closes, so the FFT costs nothing the rest of the time.
  *
- * @param out_db Destination buffer for spectrum bins (float dB).
- * @param max_bins Maximum number of bins to write.
+ * @param out_db Destination buffer, at least DSD_WIDEBAND_SPECTRUM_BINS floats
+ *               (from <dsd-neo/core/wideband_spectrum.h>).
+ * @param max_bins Capacity of @p out_db in floats. A shorter buffer is refused
+ *                 rather than filled with a prefix of the span.
  * @param out_center_freq_hz Optional; receives the tuned center in Hz.
  * @param out_span_hz Optional; receives the covered span in Hz.
- * @return Number of bins written; 0 when disabled, unavailable, or on a build
- *         with no radio backend.
+ * @param out_frame_serial Optional; receives the frame's serial number, which
+ *                         changes only when a new frame is published. A
+ *                         frontend polling on its own timer needs it to tell a
+ *                         fresh frame from a re-read of the one it already drew.
+ * @return Number of bins written; 0 when disabled, unavailable, too large for
+ *         @p out_db, or on a build with no radio backend.
  */
 int dsd_app_frontend_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz,
-                                           uint32_t* out_span_hz);
+                                           uint32_t* out_span_hz, uint32_t* out_frame_serial);
 /** @brief Enable or disable wideband spectrum production (off = zero DSP cost). */
 void dsd_app_frontend_wideband_spectrum_set_enabled(int on);
 

--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -369,6 +369,34 @@ dsd_opts_has_digital_decode_mode(const dsd_opts* opts) {
            || opts->frame_dstar == 1 || opts->frame_dpmr == 1 || opts->frame_m17 == 1;
 }
 
+/**
+ * @brief The modulation the `mod_*` flags select: 0 C4FM, 1 QPSK, 2 GFSK.
+ *
+ * Same encoding as @c dsd_state::rf_mod and @c DSD_APP_CMD_MOD_SET's payload, so
+ * a control's request and its readback are the same number.
+ *
+ * One copy of the mapping because two readers already need it -- the reading a
+ * segmented control binds to, and the skip test that decides whether a request
+ * is a no-op -- and if those two disagree the control shows one modulation while
+ * the engine drops the tap that would resynchronise them.
+ *
+ * More than one flag set is not a modulation: `-ma` and `demod = auto` turn all
+ * three on to mean "let the hunt choose", and the demodulator starts that on
+ * C4FM. Reporting the first flag found would answer QPSK for a session running
+ * as C4FM.
+ */
+static inline int
+dsd_opts_modulation(const dsd_opts* opts) {
+    if (!opts) {
+        return 0;
+    }
+    const int selected = (opts->mod_c4fm != 0) + (opts->mod_qpsk != 0) + (opts->mod_gfsk != 0);
+    if (selected != 1) {
+        return 0;
+    }
+    return (opts->mod_qpsk != 0) ? 1 : ((opts->mod_gfsk != 0) ? 2 : 0);
+}
+
 /** @brief Return 1 when an enabled 4800-symbol four-level mode uses the 12.5 kHz channel profile. */
 static inline int
 dsd_opts_uses_wide_4800_profile(const dsd_opts* opts) {

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -306,6 +306,18 @@ typedef struct {
     unsigned long long site;  // Site ID provenance
 } p25_iden_entry_t;
 
+// dsd_state is a C aggregate, not a C++ class: it is allocated once and zeroed by
+// initState() before anything reads it, and C code — which is most of its users —
+// has no constructors to write. A C++ TU that includes this header would otherwise
+// report every one of its ~600 members, one finding per field of a struct nobody
+// default-constructs. Scoped to this struct rather than to the file, which is what
+// a --suppress on the command line could only do: the seventeen other types
+// declared here, and every real C++ class in the tree, still get checked.
+//
+// Inert on cppcheck 2.21 — the check does not fire on a struct with no member
+// functions at all — so this is insurance against a version that does, not a live
+// carve-out. Unmatched suppressions are already suppressed tree-wide.
+// cppcheck-suppress-begin uninitMemberVarNoCtor
 struct dsd_state {
     int* dibit_buf;
     int* dibit_buf_p;
@@ -1268,6 +1280,8 @@ struct dsd_state {
     void* state_ext[DSD_STATE_EXT_MAX];
     dsd_state_ext_cleanup_fn state_ext_cleanup[DSD_STATE_EXT_MAX];
 };
+
+// cppcheck-suppress-end uninitMemberVarNoCtor
 
 // NOLINTEND(clang-analyzer-optin.performance.Padding)
 

--- a/include/dsd-neo/core/synctype_ids.h
+++ b/include/dsd-neo/core/synctype_ids.h
@@ -184,6 +184,19 @@ extern "C" {
 /** Check if synctype is EDACS/ProVoice */
 #define DSD_SYNC_IS_EDACS(s)      (DSD_SYNC_IS_PROVOICE(s) || DSD_SYNC_IS_EDACS_ONLY(s))
 
+/**
+ * Check if synctype belongs to a protocol the trunking layer can follow.
+ *
+ * Sync on one of these means a control channel is at least possible here, which
+ * is what a control offering to hand the tuner to trunking needs to know. It is
+ * not a promise that this particular carrier is a control channel — only the
+ * decoded signalling says that — but the protocols left out (D-STAR, M17, YSF,
+ * dPMR) have no trunking to follow at all, so offering it there would be a
+ * control that does nothing.
+ */
+#define DSD_SYNC_IS_TRUNKABLE(s)                                                                                       \
+    (DSD_SYNC_IS_P25(s) || DSD_SYNC_IS_DMR(s) || DSD_SYNC_IS_NXDN(s) || DSD_SYNC_IS_EDACS(s) || DSD_SYNC_IS_X2TDMA(s))
+
 /** Check if synctype is inverted (negative polarity) */
 #define DSD_SYNC_IS_INVERTED(s)                                                                                        \
     ((s) == DSD_SYNC_P25P1_NEG || (s) == DSD_SYNC_X2TDMA_VOICE_NEG || (s) == DSD_SYNC_X2TDMA_DATA_NEG                  \

--- a/include/dsd-neo/core/wideband_spectrum.h
+++ b/include/dsd-neo/core/wideband_spectrum.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Shape of a published wideband spectrum frame.
+ *
+ * The producer lives in io and the consumers are frontends, which are not
+ * allowed to include each other's headers — so without a shared home these
+ * numbers get copied into the FFT, the poll timer and the waterfall history
+ * separately, and a change to one silently mismatches the others. A buffer
+ * sized off a stale copy is the failure that matters: it truncates a frame the
+ * producer still labels with the whole span.
+ */
+#ifndef DSD_NEO_CORE_WIDEBAND_SPECTRUM_H
+#define DSD_NEO_CORE_WIDEBAND_SPECTRUM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Bins in every published wideband spectrum frame.
+ *
+ * Fixed rather than negotiable: at the ~1.536 MHz capture span this is ~1.5 kHz
+ * per bin, finer than any channel plan the decoder handles, and a consumer that
+ * cannot be handed a smaller frame needs no resampling path to get the axis
+ * right. A receiving buffer must hold at least this many floats.
+ */
+#define DSD_WIDEBAND_SPECTRUM_BINS      1024
+
+/**
+ * @brief Interval between published frames, in milliseconds.
+ *
+ * ~15 FPS: enough for a readable waterfall, cheap enough to ride the demod
+ * thread. A consumer polling faster only re-copies a frame the producer has not
+ * replaced yet.
+ */
+#define DSD_WIDEBAND_SPECTRUM_PERIOD_MS 66
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_CORE_WIDEBAND_SPECTRUM_H */

--- a/include/dsd-neo/dsp/demod_pipeline.h
+++ b/include/dsd-neo/dsp/demod_pipeline.h
@@ -105,6 +105,18 @@ float mean_power(const float* samples, int len, int step);
  */
 void full_demod(struct demod_state* d);
 
+/**
+ * Channel edge (Hz) that the channel low-pass protects for a profile.
+ *
+ * The half-width of the nominal channel — 12.5 kHz modes return 6250. This is
+ * the channel, not the filter: DSD_CH_LPF_PROFILE_P25_CQPSK runs a roomier
+ * 7250 Hz cutoff and still protects a 12.5 kHz channel.
+ *
+ * @param profile DSD_CH_LPF_PROFILE_* value.
+ * @return Channel half-width in Hz; the wide/analog edge for unknown profiles.
+ */
+double dsd_channel_lpf_protected_edge_hz(int profile);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -29,6 +29,37 @@ typedef enum {
     DSD_FRAME_SYNC_SPS_PROFILE_COUNT = 5,
 } dsd_frame_sync_sps_profile_index;
 
+/**
+ * @brief Non-zero when a symbol profile's level count admits only GFSK.
+ *
+ * Two-level slicing is frequency-shift keying; there is no two-level C4FM or
+ * QPSK to choose. Stated once because three callers act on it and they have to
+ * act the same way: the SPS hunt normalises @c dsd_state::rf_mod to GFSK on such
+ * a profile, the SNR gate reads the GFSK estimator for it, and the UI's
+ * modulation control has to stop offering the other two -- a control that lets a
+ * two-level session be set to C4FM leaves @c dsd_opts::mod_c4fm saying one thing
+ * while the demodulator the hunt rebuilt does another, and nothing ever
+ * reconciles the pair.
+ */
+static inline int
+dsd_frame_sync_profile_levels_force_gfsk(int levels) {
+    return levels == 2;
+}
+
+/**
+ * @brief The modulation @p requested_rf_mod becomes on a profile with @p levels levels.
+ *
+ * @param levels Slicer level count, 2 or 4.
+ * @param requested_rf_mod Modulation asked for, as @c dsd_state::rf_mod
+ *                         (0 C4FM, 1 QPSK, 2 GFSK). Pass 0 for "no opinion" to
+ *                         get the profile's own default.
+ * @return @p requested_rf_mod on a four-level profile, GFSK on a two-level one.
+ */
+static inline int
+dsd_frame_sync_profile_modulation(int levels, int requested_rf_mod) {
+    return dsd_frame_sync_profile_levels_force_gfsk(levels) ? 2 : requested_rf_mod;
+}
+
 /** @brief NXDN air-interface variant selected by frame-sync profile matching. */
 typedef enum {
     DSD_NXDN_VARIANT_NONE = 0,

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -725,7 +725,9 @@ int rtl_stream_spectrum_get_size(void);
  *                         frame, so a consumer polling on its own clock can tell
  *                         a fresh frame from a re-read of the last one.
  * @return Number of bins written; 0 when disabled, not yet published,
- *         invalidated by a retune, or when @p out_db is too small.
+ *         invalidated by a retune, or when @p out_db is too small. On 0 the
+ *         buffer is left exactly as the caller passed it, so a consumer that
+ *         holds its last frame across a gap is holding the frame it drew.
  */
 int rtl_stream_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz, uint32_t* out_span_hz,
                                      uint32_t* out_frame_serial);

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -707,27 +707,29 @@ int rtl_stream_spectrum_get_size(void);
  * approximately in dBFS.
  *
  * Production is off by default and costs nothing until
- * rtl_stream_wideband_spectrum_set_enabled(1) is called. The center and span
- * are published atomically with the bins, so the axis always matches the data.
+ * rtl_stream_wideband_spectrum_set_enabled(1) is called. The center, span and
+ * serial number are published atomically with the bins, so the axis always
+ * matches the data.
  *
- * @param out_db Destination buffer for spectrum bins (float dB). Must not be NULL.
- * @param max_bins Maximum number of bins to write.
+ * Every frame is exactly DSD_WIDEBAND_SPECTRUM_BINS wide. A buffer shorter than
+ * that is refused rather than filled with a prefix, which would be the low end
+ * of the span carrying a label for the whole of it.
+ *
+ * @param out_db Destination buffer, at least DSD_WIDEBAND_SPECTRUM_BINS floats
+ *               (from <dsd-neo/core/wideband_spectrum.h>). Must not be NULL.
+ * @param max_bins Capacity of @p out_db in floats.
  * @param out_center_freq_hz Optional pointer to receive the tuned center in Hz.
  * @param out_span_hz Optional pointer to receive the covered span in Hz.
- * @return Number of bins written; 0 when disabled, not yet published, or
- *         invalidated by a retune.
+ * @param out_frame_serial Optional pointer to receive the frame's serial number.
+ *                         It changes only when the producer publishes a new
+ *                         frame, so a consumer polling on its own clock can tell
+ *                         a fresh frame from a re-read of the last one.
+ * @return Number of bins written; 0 when disabled, not yet published,
+ *         invalidated by a retune, or when @p out_db is too small.
  */
-int rtl_stream_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz, uint32_t* out_span_hz);
+int rtl_stream_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz, uint32_t* out_span_hz,
+                                     uint32_t* out_frame_serial);
 
-/**
- * @brief Set desired wideband spectrum FFT size (power-of-two, clamped to [256, 2048]).
- *
- * @param n Requested FFT size; rounded up to the next supported power of two.
- * @return The FFT size actually selected.
- */
-int rtl_stream_wideband_spectrum_set_size(int n);
-/** @brief Get current wideband spectrum FFT size. */
-int rtl_stream_wideband_spectrum_get_size(void);
 /** @brief Enable or disable wideband spectrum production (off = zero DSP cost). */
 void rtl_stream_wideband_spectrum_set_enabled(int on);
 /** @brief Return 1 when wideband spectrum production is enabled. */

--- a/include/dsd-neo/io/rtl_stream_c.h
+++ b/include/dsd-neo/io/rtl_stream_c.h
@@ -696,6 +696,43 @@ int rtl_stream_spectrum_set_size(int n);
 /** @brief Get current spectrum FFT size. */
 int rtl_stream_spectrum_get_size(void);
 
+/**
+ * @brief Get a snapshot of the wideband power spectrum across the capture span.
+ *
+ * Unlike rtl_stream_spectrum_get(), which reports the narrow post-decimation
+ * span used for tuner diagnostics, this covers the full SDR capture bandwidth
+ * (typically ~1.536 MHz) so a UI can draw a panorama around the tuned
+ * frequency. Bins are DC-centered: out_db[0] ~ center - span/2, the middle bin
+ * ~ center, and the last ~ center + span/2. Values are smoothed and
+ * approximately in dBFS.
+ *
+ * Production is off by default and costs nothing until
+ * rtl_stream_wideband_spectrum_set_enabled(1) is called. The center and span
+ * are published atomically with the bins, so the axis always matches the data.
+ *
+ * @param out_db Destination buffer for spectrum bins (float dB). Must not be NULL.
+ * @param max_bins Maximum number of bins to write.
+ * @param out_center_freq_hz Optional pointer to receive the tuned center in Hz.
+ * @param out_span_hz Optional pointer to receive the covered span in Hz.
+ * @return Number of bins written; 0 when disabled, not yet published, or
+ *         invalidated by a retune.
+ */
+int rtl_stream_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz, uint32_t* out_span_hz);
+
+/**
+ * @brief Set desired wideband spectrum FFT size (power-of-two, clamped to [256, 2048]).
+ *
+ * @param n Requested FFT size; rounded up to the next supported power of two.
+ * @return The FFT size actually selected.
+ */
+int rtl_stream_wideband_spectrum_set_size(int n);
+/** @brief Get current wideband spectrum FFT size. */
+int rtl_stream_wideband_spectrum_get_size(void);
+/** @brief Enable or disable wideband spectrum production (off = zero DSP cost). */
+void rtl_stream_wideband_spectrum_set_enabled(int on);
+/** @brief Return 1 when wideband spectrum production is enabled. */
+int rtl_stream_wideband_spectrum_enabled(void);
+
 /* Carrier/Costas diagnostics and control */
 /** Return current NCO frequency used for carrier rotation (Costas/FLL), in Hz. */
 double rtl_stream_get_cfo_hz(void);

--- a/include/dsd-neo/runtime/decode_mode.h
+++ b/include/dsd-neo/runtime/decode_mode.h
@@ -15,6 +15,7 @@
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/runtime/config.h>
 
 #ifdef __cplusplus
@@ -68,6 +69,53 @@ int dsd_apply_decode_mode_preset(dsdneoUserDecodeMode mode, dsdDecodePresetProfi
  * @param state Decoder state receiving `samplesPerSymbol` and `symbolCenter`.
  */
 void dsd_apply_decode_mode_symbol_timing(dsdneoUserDecodeMode mode, int effective_input_rate_hz, dsd_state* state);
+
+/**
+ * @brief The symbol profile a decode mode runs on.
+ *
+ * One answer for the three things that have to agree once a mode is live: the
+ * symbol clock the slicer runs at, the number of levels the demodulator slices
+ * to, and the frame-sync SPS profile the hunt searches from. Derived separately
+ * they drift, and a mode ends up on one protocol's symbol clock with another
+ * protocol's hunt profile and a third protocol's channel filter.
+ *
+ * This is the steady-state profile — what the SPS hunt will converge on — which
+ * is not always where @c dsd_apply_decode_mode_symbol_timing() starts a mode off.
+ */
+typedef struct {
+    int symbol_rate_hz;                                 /**< 2400, 4800, 6000 or 9600. */
+    int levels;                                         /**< 2 or 4. */
+    dsd_frame_sync_sps_profile_index sps_profile_index; /**< Hunt profile carrying this mode. */
+} dsd_decode_mode_profile;
+
+/**
+ * @brief Return the symbol profile @p mode decodes on.
+ *
+ * Modes with no profile of their own — AUTO, analog monitor, and any mode set
+ * that spans several symbol rates — answer with 4800/4, which is both the
+ * commonest case and the hunt's own starting profile.
+ *
+ * @param mode Decode mode preset.
+ * @return Symbol rate, level count and frame-sync profile index for @p mode.
+ */
+dsd_decode_mode_profile dsd_decode_mode_profile_for(dsdneoUserDecodeMode mode);
+
+/**
+ * @brief Return the RTL channel filter a symbol profile and modulation need.
+ *
+ * The one copy of this mapping. A modulation the operator picks and one the SPS
+ * hunt lands on have to ask the front end for the same filter, or the two
+ * disagree about what the front end is doing every time the hunt re-runs.
+ *
+ * @param opts Decoder options, consulted for the wide-4800 profile override.
+ * @param symbol_rate_hz Symbol rate in Hz.
+ * @param levels Number of slicer levels (2 or 4).
+ * @param rf_mod Modulation, as @c dsd_state::rf_mod (0 C4FM, 1 QPSK, 2 GFSK).
+ * @return A channel-profile selector. The `RTL_STREAM_CHANNEL_PROFILE_*` and
+ *         `DSD_RTL_STREAM_CHANNEL_PROFILE_*` enumerations share these values, so
+ *         either spelling may be compared against the result.
+ */
+int dsd_rtl_channel_profile_for(const dsd_opts* opts, int symbol_rate_hz, int levels, int rf_mod);
 
 /**
  * @brief Infer a user decode mode from active opts flags.

--- a/semgrep/dsd-neo.yml
+++ b/semgrep/dsd-neo.yml
@@ -335,9 +335,9 @@ rules:
         - /android/third_party/**
         - /src/third_party/**
         - /src/fec/ez.cpp
+        # The project-owned pffft wrapper. The two spectrum producers go through it
+        # and are deliberately not listed here.
         - /src/io/radio/rtl_fft_cache.h
-        - /src/io/radio/rtl_metrics.cpp
-        - /src/io/radio/rtl_wideband_spectrum.cpp
         - /tests/protocol/p25/test_p25_p2_rs28_limits.cpp
     pattern-either:
       - pattern: '#include "src/third_party/..."'

--- a/semgrep/dsd-neo.yml
+++ b/semgrep/dsd-neo.yml
@@ -336,6 +336,7 @@ rules:
         - /src/third_party/**
         - /src/fec/ez.cpp
         - /src/io/radio/rtl_metrics.cpp
+        - /src/io/radio/rtl_wideband_spectrum.cpp
         - /tests/protocol/p25/test_p25_p2_rs28_limits.cpp
     pattern-either:
       - pattern: '#include "src/third_party/..."'

--- a/semgrep/dsd-neo.yml
+++ b/semgrep/dsd-neo.yml
@@ -335,6 +335,7 @@ rules:
         - /android/third_party/**
         - /src/third_party/**
         - /src/fec/ez.cpp
+        - /src/io/radio/rtl_fft_cache.h
         - /src/io/radio/rtl_metrics.cpp
         - /src/io/radio/rtl_wideband_spectrum.cpp
         - /tests/protocol/p25/test_p25_p2_rs28_limits.cpp

--- a/src/app_control/CMakeLists.txt
+++ b/src/app_control/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(
         ui_history.c
         telemetry_hooks_install.c
         menu_services.c
+        symbol_profile.c
         tcp_audio_connect.c
 )
 

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -179,9 +179,13 @@ ui_handle_mod_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_command
      * actually in effect rather than as a boolean, because rf_mod has three values
      * and GFSK (2) is one the DMR and EDACS/ProVoice presets select — a C4FM
      * request from there is a real change and has to apply. */
-    if (state->rf_mod == (int)want) {
+    if (state->rf_mod == (int)want && opts->mod_p25p2_c4fm == 0 && opts->mod_p25p2_profile_lock == 0) {
         return 1;
     }
+    /* The P25p2 helper is the exception to the skip: it holds mod_cli_lock and the
+     * 6000 sym/s profile, and it is entered from a session whose modulation reads
+     * the same as the one being asked for -- so a request that looks idempotent is
+     * the only way out of it from a control that only offers three modulations. */
     ui_apply_modulation(opts, state, (int)want);
     return 1;
 }

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -33,28 +33,60 @@ ui_modulation_demod_rate(const dsd_opts* opts, const dsd_state* state) {
     return demod_rate;
 }
 
-#ifdef USE_RADIO
+/**
+ * @brief The symbol rate the modulation control's choices run at, in Hz.
+ *
+ * The control switches the demodulator inside whatever decode set is enabled, so
+ * the timing has to come from that set rather than from a constant. Everything it
+ * applies to is 4800 symbols/s except ProVoice, which is 9600 — and only when
+ * ProVoice is the mode being decoded. AUTO enables ProVoice alongside the 4800
+ * modes, so the flag on its own says nothing.
+ */
 static int
-ui_rtl_channel_profile(const dsd_opts* opts, int symbol_rate_hz, int cqpsk) {
-    if (cqpsk) {
+ui_modulation_symbol_rate(const dsd_opts* opts) {
+    if (opts->frame_provoice != 1) {
+        return 4800;
+    }
+    const int other_modes = opts->frame_p25p1 == 1 || opts->frame_p25p2 == 1 || opts->frame_dmr == 1
+                            || opts->frame_nxdn48 == 1 || opts->frame_nxdn96 == 1 || opts->frame_ysf == 1
+                            || opts->frame_m17 == 1 || opts->frame_dstar == 1 || opts->frame_x2tdma == 1
+                            || opts->frame_dpmr == 1;
+    return other_modes ? 4800 : 9600;
+}
+
+#ifdef USE_RADIO
+/**
+ * @brief The channel filter that goes with a symbol rate and modulation.
+ *
+ * Deliberately the same mapping the DSP's SPS hunt applies in
+ * rtl_profile_for_sps_profile(): a modulation picked here and one the hunt lands
+ * on must ask the backend for the same filter, or the two disagree about what the
+ * front end is doing every time the hunt re-runs.
+ */
+static int
+ui_rtl_channel_profile(const dsd_opts* opts, int symbol_rate_hz, int mod) {
+    if (symbol_rate_hz == 9600) {
+        return RTL_STREAM_CHANNEL_PROFILE_PROVOICE;
+    }
+    if (mod == 1) {
         return RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
     }
-    if (symbol_rate_hz == 4800 && !dsd_opts_uses_wide_4800_profile(opts)) {
-        return RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+    if (symbol_rate_hz == 6000 || mod == 2 || dsd_opts_uses_wide_4800_profile(opts)) {
+        return RTL_STREAM_CHANNEL_PROFILE_12K5;
     }
-    return RTL_STREAM_CHANNEL_PROFILE_12K5;
+    return RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
 }
 
 static void
-ui_apply_rtl_demod_profile(const dsd_opts* opts, const dsd_state* state, int symbol_rate_hz, int sps) {
+ui_apply_rtl_demod_profile(const dsd_opts* opts, const dsd_state* state, int symbol_rate_hz, int levels, int sps) {
     if (!opts || !state || opts->audio_in_type != AUDIO_IN_RTL || !state->rtl_ctx) {
         return;
     }
-    const int cqpsk = state->rf_mod == 1;
+    const int mod = state->rf_mod;
     /* Queue the whole profile for the demod thread instead of mutating demod
      * state from the UI thread (sps clamp mirrors the old no-override setter). */
-    (void)rtl_stream_request_demod_profile(cqpsk, symbol_rate_hz, 4,
-                                           ui_rtl_channel_profile(opts, symbol_rate_hz, cqpsk), sps < 2 ? 2 : sps, 0);
+    (void)rtl_stream_request_demod_profile(mod == 1, symbol_rate_hz, levels,
+                                           ui_rtl_channel_profile(opts, symbol_rate_hz, mod), sps < 2 ? 2 : sps, 0);
 }
 #endif
 
@@ -87,8 +119,11 @@ ui_handle_invert_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
 }
 
 /**
- * @brief Put the demodulator on C4FM or QPSK, with the timing and RTL profile
- *        that go with it.
+ * @brief Put the demodulator on C4FM, QPSK or GFSK, with the timing and RTL
+ *        profile that go with it.
+ *
+ * @param mod 0 for C4FM, 1 for QPSK, 2 for GFSK — the values @c dsd_state::rf_mod
+ *            already uses, so the caller's request and the readback agree.
  *
  * Shared by the cycle-to-the-other-one hotkey and the pick-this-one command: the
  * SPS recompute, the sps-hunt reset, the P25p2 helper release and the backend
@@ -96,21 +131,23 @@ ui_handle_invert_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
  * how one of them ends up half right.
  */
 static void
-ui_apply_modulation(dsd_opts* opts, dsd_state* state, int want_qpsk) {
+ui_apply_modulation(dsd_opts* opts, dsd_state* state, int mod) {
     const int leaving_p25p2_helper = opts->mod_p25p2_c4fm == 1 || opts->mod_p25p2_profile_lock == 1;
-    const int sps = dsd_opts_compute_sps_rate(opts, 4800, ui_modulation_demod_rate(opts, state));
+    const int symbol_rate = ui_modulation_symbol_rate(opts);
+    const int sps = dsd_opts_compute_sps_rate(opts, symbol_rate, ui_modulation_demod_rate(opts, state));
     opts->mod_p25p2_c4fm = 0;
     opts->mod_p25p2_profile_lock = 0;
-    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state->sps_hunt_idx = (symbol_rate == 9600) ? DSD_FRAME_SYNC_SPS_PROFILE_9600_2 : DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
     state->sps_hunt_counter = 0;
-    opts->mod_c4fm = want_qpsk ? 0 : 1;
-    opts->mod_qpsk = want_qpsk ? 1 : 0;
-    opts->mod_gfsk = 0;
-    state->rf_mod = want_qpsk ? 1 : 0;
+    opts->mod_c4fm = (mod == 0) ? 1 : 0;
+    opts->mod_qpsk = (mod == 1) ? 1 : 0;
+    opts->mod_gfsk = (mod == 2) ? 1 : 0;
+    state->rf_mod = mod;
     state->samplesPerSymbol = sps;
     state->symbolCenter = dsd_opts_symbol_center(sps);
 #ifdef USE_RADIO
-    ui_apply_rtl_demod_profile(opts, state, 4800, sps);
+    /* ProVoice is the two-level one; everything else this control reaches is four. */
+    ui_apply_rtl_demod_profile(opts, state, symbol_rate, (symbol_rate == 9600) ? 2 : 4, sps);
 #endif
     if (leaving_p25p2_helper) {
         /* Release the helper lock only after decoder timing and any RTL backend agree on profile 0. */
@@ -131,17 +168,21 @@ ui_handle_mod_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_command
     if (c->n >= (int)sizeof(int32_t)) {
         DSD_MEMCPY(&want, c->data, sizeof(int32_t));
     }
-    const int want_qpsk = (want != 0);
-    /* Idempotent on purpose: a segmented control re-asserts its own state after a
-     * frame it did not cause, and re-applying the same modulation must not disturb
-     * timing the decoder has already settled on. Tested against the modulation we
-     * are actually on rather than as a boolean, because rf_mod has a third value:
-     * GFSK (2), which the DMR/NXDN/YSF/M17/dPMR/EDACS presets select. Asking for
-     * C4FM from GFSK is a real change and has to apply. */
-    if (want_qpsk ? state->rf_mod == 1 : state->rf_mod == 0) {
+    if (want < 0 || want > 2) {
+        /* A modulation that does not exist. Nothing sane to apply, and guessing at
+         * one would move the demodulator somewhere the caller never asked for. */
         return 1;
     }
-    ui_apply_modulation(opts, state, want_qpsk);
+    /* Idempotent on purpose: a segmented control re-asserts its own state after a
+     * frame it did not cause, and re-applying the same modulation must not disturb
+     * timing the decoder has already settled on. Compared against the modulation
+     * actually in effect rather than as a boolean, because rf_mod has three values
+     * and GFSK (2) is one the DMR and EDACS/ProVoice presets select — a C4FM
+     * request from there is a real change and has to apply. */
+    if (state->rf_mod == (int)want) {
+        return 1;
+    }
+    ui_apply_modulation(opts, state, (int)want);
     return 1;
 }
 
@@ -171,7 +212,7 @@ ui_handle_mod_p2_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
         state->symbolCenter = center;
     }
 #ifdef USE_RADIO
-    ui_apply_rtl_demod_profile(opts, state, 6000, sps);
+    ui_apply_rtl_demod_profile(opts, state, 6000, 4, sps);
 #endif
     /* Lock only after the decoder and any RTL backend share the P25p2 profile. */
     opts->mod_cli_lock = 1;

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -86,26 +86,27 @@ ui_handle_invert_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
     return 1;
 }
 
-static int
-ui_handle_mod_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
-    (void)c;
+/**
+ * @brief Put the demodulator on C4FM or QPSK, with the timing and RTL profile
+ *        that go with it.
+ *
+ * Shared by the cycle-to-the-other-one hotkey and the pick-this-one command: the
+ * SPS recompute, the sps-hunt reset, the P25p2 helper release and the backend
+ * profile request all have to happen together, and having two copies of that is
+ * how one of them ends up half right.
+ */
+static void
+ui_apply_modulation(dsd_opts* opts, dsd_state* state, int want_qpsk) {
     const int leaving_p25p2_helper = opts->mod_p25p2_c4fm == 1 || opts->mod_p25p2_profile_lock == 1;
     const int sps = dsd_opts_compute_sps_rate(opts, 4800, ui_modulation_demod_rate(opts, state));
     opts->mod_p25p2_c4fm = 0;
     opts->mod_p25p2_profile_lock = 0;
     state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
     state->sps_hunt_counter = 0;
-    if (state->rf_mod == 0) {
-        opts->mod_c4fm = 0;
-        opts->mod_qpsk = 1;
-        opts->mod_gfsk = 0;
-        state->rf_mod = 1;
-    } else {
-        opts->mod_c4fm = 1;
-        opts->mod_qpsk = 0;
-        opts->mod_gfsk = 0;
-        state->rf_mod = 0;
-    }
+    opts->mod_c4fm = want_qpsk ? 0 : 1;
+    opts->mod_qpsk = want_qpsk ? 1 : 0;
+    opts->mod_gfsk = 0;
+    state->rf_mod = want_qpsk ? 1 : 0;
     state->samplesPerSymbol = sps;
     state->symbolCenter = dsd_opts_symbol_center(sps);
 #ifdef USE_RADIO
@@ -115,6 +116,32 @@ ui_handle_mod_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_comm
         /* Release the helper lock only after decoder timing and any RTL backend agree on profile 0. */
         opts->mod_cli_lock = 0;
     }
+}
+
+static int
+ui_handle_mod_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
+    (void)c;
+    ui_apply_modulation(opts, state, state->rf_mod == 0 ? 1 : 0);
+    return 1;
+}
+
+static int
+ui_handle_mod_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
+    int32_t want = 0;
+    if (c->n >= (int)sizeof(int32_t)) {
+        DSD_MEMCPY(&want, c->data, sizeof(int32_t));
+    }
+    const int want_qpsk = (want != 0);
+    /* Idempotent on purpose: a segmented control re-asserts its own state after a
+     * frame it did not cause, and re-applying the same modulation must not disturb
+     * timing the decoder has already settled on. Tested against the modulation we
+     * are actually on rather than as a boolean, because rf_mod has a third value:
+     * GFSK (2), which the DMR/NXDN/YSF/M17/dPMR/EDACS presets select. Asking for
+     * C4FM from GFSK is a real change and has to apply. */
+    if (want_qpsk ? state->rf_mod == 1 : state->rf_mod == 0) {
+        return 1;
+    }
+    ui_apply_modulation(opts, state, want_qpsk);
     return 1;
 }
 
@@ -152,9 +179,7 @@ ui_handle_mod_p2_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
 }
 
 const struct dsd_app_command_reg dsd_app_actions_radio[] = {
-    {DSD_APP_CMD_PPM_DELTA, ui_handle_ppm_delta},
-    {DSD_APP_CMD_INVERT_TOGGLE, ui_handle_invert_toggle},
-    {DSD_APP_CMD_MOD_TOGGLE, ui_handle_mod_toggle},
-    {DSD_APP_CMD_MOD_P2_TOGGLE, ui_handle_mod_p2_toggle},
-    {0, NULL},
+    {DSD_APP_CMD_PPM_DELTA, ui_handle_ppm_delta},         {DSD_APP_CMD_INVERT_TOGGLE, ui_handle_invert_toggle},
+    {DSD_APP_CMD_MOD_TOGGLE, ui_handle_mod_toggle},       {DSD_APP_CMD_MOD_SET, ui_handle_mod_set},
+    {DSD_APP_CMD_MOD_P2_TOGGLE, ui_handle_mod_p2_toggle}, {0, NULL},
 };

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -7,6 +7,7 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
@@ -48,6 +49,23 @@ ui_modulation_demod_rate(const dsd_opts* opts, const dsd_state* state) {
 static dsd_decode_mode_profile
 ui_modulation_profile(const dsd_opts* opts) {
     return dsd_decode_mode_profile_for(dsd_infer_decode_mode_preset(opts));
+}
+
+/**
+ * @brief The modulation a request for @p mod actually lands on.
+ *
+ * The control offers three modulations, but the decode set decides how many of
+ * them exist: a two-level profile — EDACS/ProVoice at 9600/2, D-STAR at 4800/2 —
+ * runs GFSK and nothing else. Honouring a C4FM request there would write
+ * @c mod_c4fm and @c rf_mod together only for frame_sync_apply_sps_hunt_profile()
+ * to normalise @c rf_mod straight back to GFSK on the next pass, leaving the two
+ * permanently disagreeing: the control reads C4FM off the flags, the decoder runs
+ * GFSK, and because the two disagree the idempotence check in ui_handle_mod_set()
+ * can never fire, so every tap rebuilds the timing for nothing.
+ */
+static int
+ui_effective_modulation(const dsd_opts* opts, int mod) {
+    return dsd_frame_sync_profile_modulation(ui_modulation_profile(opts).levels, mod);
 }
 
 static int
@@ -95,12 +113,15 @@ ui_apply_modulation(dsd_opts* opts, dsd_state* state, int mod) {
     const int leaving_p25p2_helper = opts->mod_p25p2_c4fm == 1 || opts->mod_p25p2_profile_lock == 1;
     const dsd_decode_mode_profile profile = ui_modulation_profile(opts);
     const int sps = dsd_opts_compute_sps_rate(opts, profile.symbol_rate_hz, ui_modulation_demod_rate(opts, state));
+    /* Through the profile, so the flags and rf_mod written below are a modulation
+       the decode set can actually run and the SPS hunt will not move off. */
+    const int applied = dsd_frame_sync_profile_modulation(profile.levels, mod);
     opts->mod_p25p2_c4fm = 0;
     opts->mod_p25p2_profile_lock = 0;
-    opts->mod_c4fm = (mod == 0) ? 1 : 0;
-    opts->mod_qpsk = (mod == 1) ? 1 : 0;
-    opts->mod_gfsk = (mod == 2) ? 1 : 0;
-    state->rf_mod = mod;
+    opts->mod_c4fm = (applied == 0) ? 1 : 0;
+    opts->mod_qpsk = (applied == 1) ? 1 : 0;
+    opts->mod_gfsk = (applied == 2) ? 1 : 0;
+    state->rf_mod = applied;
     state->samplesPerSymbol = sps;
     state->symbolCenter = dsd_opts_symbol_center(sps);
     /* After rf_mod and the timing, both of which the published profile reads. */
@@ -147,9 +168,16 @@ ui_handle_mod_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_command
      * (MetricsModel::fillDecoderView). Skipping on rf_mod alone therefore drops
      * exactly the tap that would resynchronise them: the control shows C4FM, asking
      * for QPSK on a session the hunt already moved to QPSK does nothing, and the
-     * control snaps back on the next poll and reads as broken. */
-    const int mod_in_effect = (opts->mod_qpsk != 0) ? 1 : ((opts->mod_gfsk != 0) ? 2 : 0);
-    if (state->rf_mod == (int)want && mod_in_effect == (int)want && opts->mod_p25p2_c4fm == 0
+     * control snaps back on the next poll and reads as broken. Through the same
+     * helper that publishes the reading, so the two cannot answer differently.
+     *
+     * Compared against what the request lands on rather than what it asked for:
+     * on a two-level decode set every modulation lands on GFSK, so asking for
+     * C4FM there is already satisfied and rebuilding the timing for it would be
+     * the same pointless churn on every tap. */
+    const int mod_in_effect = dsd_opts_modulation(opts);
+    const int mod_effective = ui_effective_modulation(opts, (int)want);
+    if (state->rf_mod == mod_effective && mod_in_effect == mod_effective && opts->mod_p25p2_c4fm == 0
         && opts->mod_p25p2_profile_lock == 0) {
         return 1;
     }

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -7,11 +7,13 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
-#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
 #include <stdint.h>
 #include <string.h>
 #include "../command_dispatch.h"
+#include "../services.h"
 #include "dsd-neo/app_control/commands.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -34,61 +36,19 @@ ui_modulation_demod_rate(const dsd_opts* opts, const dsd_state* state) {
 }
 
 /**
- * @brief The symbol rate the modulation control's choices run at, in Hz.
+ * @brief The symbol profile the modulation control's choices run at.
  *
  * The control switches the demodulator inside whatever decode set is enabled, so
- * the timing has to come from that set rather than from a constant. Everything it
- * applies to is 4800 symbols/s except ProVoice, which is 9600 — and only when
- * ProVoice is the mode being decoded. AUTO enables ProVoice alongside the 4800
- * modes, so the flag on its own says nothing.
+ * the timing has to come from that set rather than from a constant — and from the
+ * same authority the SPS hunt and the front-end filter read, or a modulation
+ * picked here lands the decoder on one protocol's symbol clock and the hunt on
+ * another's. A mode set that spans several symbol rates (AUTO, or a hand-rolled
+ * combination) answers 4800/4, which is where the hunt starts anyway.
  */
-static int
-ui_modulation_symbol_rate(const dsd_opts* opts) {
-    if (opts->frame_provoice != 1) {
-        return 4800;
-    }
-    const int other_modes = opts->frame_p25p1 == 1 || opts->frame_p25p2 == 1 || opts->frame_dmr == 1
-                            || opts->frame_nxdn48 == 1 || opts->frame_nxdn96 == 1 || opts->frame_ysf == 1
-                            || opts->frame_m17 == 1 || opts->frame_dstar == 1 || opts->frame_x2tdma == 1
-                            || opts->frame_dpmr == 1;
-    return other_modes ? 4800 : 9600;
+static dsd_decode_mode_profile
+ui_modulation_profile(const dsd_opts* opts) {
+    return dsd_decode_mode_profile_for(dsd_infer_decode_mode_preset(opts));
 }
-
-#ifdef USE_RADIO
-/**
- * @brief The channel filter that goes with a symbol rate and modulation.
- *
- * Deliberately the same mapping the DSP's SPS hunt applies in
- * rtl_profile_for_sps_profile(): a modulation picked here and one the hunt lands
- * on must ask the backend for the same filter, or the two disagree about what the
- * front end is doing every time the hunt re-runs.
- */
-static int
-ui_rtl_channel_profile(const dsd_opts* opts, int symbol_rate_hz, int mod) {
-    if (symbol_rate_hz == 9600) {
-        return RTL_STREAM_CHANNEL_PROFILE_PROVOICE;
-    }
-    if (mod == 1) {
-        return RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
-    }
-    if (symbol_rate_hz == 6000 || mod == 2 || dsd_opts_uses_wide_4800_profile(opts)) {
-        return RTL_STREAM_CHANNEL_PROFILE_12K5;
-    }
-    return RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
-}
-
-static void
-ui_apply_rtl_demod_profile(const dsd_opts* opts, const dsd_state* state, int symbol_rate_hz, int levels, int sps) {
-    if (!opts || !state || opts->audio_in_type != AUDIO_IN_RTL || !state->rtl_ctx) {
-        return;
-    }
-    const int mod = state->rf_mod;
-    /* Queue the whole profile for the demod thread instead of mutating demod
-     * state from the UI thread (sps clamp mirrors the old no-override setter). */
-    (void)rtl_stream_request_demod_profile(mod == 1, symbol_rate_hz, levels,
-                                           ui_rtl_channel_profile(opts, symbol_rate_hz, mod), sps < 2 ? 2 : sps, 0);
-}
-#endif
 
 static int
 ui_handle_ppm_delta(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
@@ -133,22 +93,18 @@ ui_handle_invert_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
 static void
 ui_apply_modulation(dsd_opts* opts, dsd_state* state, int mod) {
     const int leaving_p25p2_helper = opts->mod_p25p2_c4fm == 1 || opts->mod_p25p2_profile_lock == 1;
-    const int symbol_rate = ui_modulation_symbol_rate(opts);
-    const int sps = dsd_opts_compute_sps_rate(opts, symbol_rate, ui_modulation_demod_rate(opts, state));
+    const dsd_decode_mode_profile profile = ui_modulation_profile(opts);
+    const int sps = dsd_opts_compute_sps_rate(opts, profile.symbol_rate_hz, ui_modulation_demod_rate(opts, state));
     opts->mod_p25p2_c4fm = 0;
     opts->mod_p25p2_profile_lock = 0;
-    state->sps_hunt_idx = (symbol_rate == 9600) ? DSD_FRAME_SYNC_SPS_PROFILE_9600_2 : DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
-    state->sps_hunt_counter = 0;
     opts->mod_c4fm = (mod == 0) ? 1 : 0;
     opts->mod_qpsk = (mod == 1) ? 1 : 0;
     opts->mod_gfsk = (mod == 2) ? 1 : 0;
     state->rf_mod = mod;
     state->samplesPerSymbol = sps;
     state->symbolCenter = dsd_opts_symbol_center(sps);
-#ifdef USE_RADIO
-    /* ProVoice is the two-level one; everything else this control reaches is four. */
-    ui_apply_rtl_demod_profile(opts, state, symbol_rate, (symbol_rate == 9600) ? 2 : 4, sps);
-#endif
+    /* After rf_mod and the timing, both of which the published profile reads. */
+    svc_publish_symbol_profile(opts, state, profile);
     if (leaving_p25p2_helper) {
         /* Release the helper lock only after decoder timing and any RTL backend agree on profile 0. */
         opts->mod_cli_lock = 0;
@@ -165,9 +121,13 @@ ui_handle_mod_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_comm
 static int
 ui_handle_mod_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     int32_t want = 0;
-    if (c->n >= (int)sizeof(int32_t)) {
-        DSD_MEMCPY(&want, c->data, sizeof(int32_t));
+    if (c->n < (int)sizeof(int32_t)) {
+        /* A truncated payload is not a request for C4FM. Falling through with want
+         * still 0 would force the demodulator, reset the sps hunt and release the
+         * P25p2 helper lock on a command nobody sent. */
+        return 1;
     }
+    DSD_MEMCPY(&want, c->data, sizeof(int32_t));
     if (want < 0 || want > 2) {
         /* A modulation that does not exist. Nothing sane to apply, and guessing at
          * one would move the demodulator somewhere the caller never asked for. */
@@ -178,8 +138,19 @@ ui_handle_mod_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_command
      * timing the decoder has already settled on. Compared against the modulation
      * actually in effect rather than as a boolean, because rf_mod has three values
      * and GFSK (2) is one the DMR and EDACS/ProVoice presets select — a C4FM
-     * request from there is a real change and has to apply. */
-    if (state->rf_mod == (int)want && opts->mod_p25p2_c4fm == 0 && opts->mod_p25p2_profile_lock == 0) {
+     * request from there is a real change and has to apply.
+     *
+     * Both readings have to agree before the request is a no-op. The sps hunt moves
+     * state->rf_mod on its own without touching the mod_* flags
+     * (frame_sync_maybe_force_dmr_gfsk(), frame_sync_accept_p25p2()), while the
+     * reading a segmented control binds to is published from the flags
+     * (MetricsModel::fillDecoderView). Skipping on rf_mod alone therefore drops
+     * exactly the tap that would resynchronise them: the control shows C4FM, asking
+     * for QPSK on a session the hunt already moved to QPSK does nothing, and the
+     * control snaps back on the next poll and reads as broken. */
+    const int mod_in_effect = (opts->mod_qpsk != 0) ? 1 : ((opts->mod_gfsk != 0) ? 2 : 0);
+    if (state->rf_mod == (int)want && mod_in_effect == (int)want && opts->mod_p25p2_c4fm == 0
+        && opts->mod_p25p2_profile_lock == 0) {
         return 1;
     }
     /* The P25p2 helper is the exception to the skip: it holds mod_cli_lock and the
@@ -194,12 +165,11 @@ static int
 ui_handle_mod_p2_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     (void)c;
     // P25P2 TDMA: 6000 sym/s - compute SPS from actual demod rate
-    int sps = dsd_opts_compute_sps_rate(opts, 6000, ui_modulation_demod_rate(opts, state));
+    const dsd_decode_mode_profile profile = dsd_decode_mode_profile_for(DSDCFG_MODE_P25P2);
+    int sps = dsd_opts_compute_sps_rate(opts, profile.symbol_rate_hz, ui_modulation_demod_rate(opts, state));
     int center = dsd_opts_symbol_center(sps);
     opts->mod_p25p2_c4fm = 0;
     opts->mod_p25p2_profile_lock = 1;
-    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
-    state->sps_hunt_counter = 0;
     if (state->rf_mod == 0) {
         opts->mod_c4fm = 0;
         opts->mod_qpsk = 1;
@@ -215,9 +185,7 @@ ui_handle_mod_p2_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
         state->samplesPerSymbol = sps;
         state->symbolCenter = center;
     }
-#ifdef USE_RADIO
-    ui_apply_rtl_demod_profile(opts, state, 6000, 4, sps);
-#endif
+    svc_publish_symbol_profile(opts, state, profile);
     /* Lock only after the decoder and any RTL backend share the P25p2 profile. */
     opts->mod_cli_lock = 1;
     return 1;

--- a/src/app_control/actions/actions_trunk.c
+++ b/src/app_control/actions/actions_trunk.c
@@ -39,8 +39,14 @@ ui_handle_trunk_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_comma
     if (c->n < (int)sizeof(int32_t)) {
         /* A truncated payload is not a request to stop trunking. Falling through
          * with want still 0 would hand the tuner back mid-call on a command nobody
-         * sent, and the session would quietly stop following the system. */
-        return 0;
+         * sent, and the session would quietly stop following the system.
+         *
+         * Handled-and-declined, not unhandled: 0 means "this table does not know
+         * this id", so the drain would keep walking every remaining group with a
+         * command they were never meant to see and finally report it as an unknown
+         * id rather than a bad payload. ui_handle_mod_set() answers the same
+         * condition the same way. */
+        return 1;
     }
     DSD_MEMCPY(&want, c->data, sizeof(int32_t));
     const int on = (want != 0) ? 1 : 0;

--- a/src/app_control/actions/actions_trunk.c
+++ b/src/app_control/actions/actions_trunk.c
@@ -17,6 +17,7 @@
 
 #include "dsd-neo/app_control/commands.h"
 #include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
 static int
@@ -27,6 +28,28 @@ ui_handle_trunk_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_co
         opts->trunk_enable = 0;
     } else {
         opts->trunk_enable = 1;
+    }
+    return 1;
+}
+
+static int
+ui_handle_trunk_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
+    (void)state;
+    int32_t want = 0;
+    if (c->n < (int)sizeof(int32_t)) {
+        /* A truncated payload is not a request to stop trunking. Falling through
+         * with want still 0 would hand the tuner back mid-call on a command nobody
+         * sent, and the session would quietly stop following the system. */
+        return 0;
+    }
+    DSD_MEMCPY(&want, c->data, sizeof(int32_t));
+    const int on = (want != 0) ? 1 : 0;
+    opts->trunk_enable = on;
+    if (on) {
+        // Scanner mode is the other automatic owner of the tuner, and
+        // ui_handle_scanner_toggle clears trunking for the same reason: whichever
+        // one was asked for last is the one driving, not both at once.
+        opts->scanner_mode = 0;
     }
     return 1;
 }
@@ -120,6 +143,7 @@ ui_handle_enc_lockout_clear(dsd_opts* opts, dsd_state* state, const struct dsd_a
 
 const struct dsd_app_command_reg dsd_app_actions_trunk[] = {
     {DSD_APP_CMD_TRUNK_TOGGLE, ui_handle_trunk_toggle},
+    {DSD_APP_CMD_TRUNK_SET, ui_handle_trunk_set},
     {DSD_APP_CMD_SCANNER_TOGGLE, ui_handle_scanner_toggle},
     {DSD_APP_CMD_TRUNK_GROUP_TOGGLE, ui_handle_trunk_group_toggle},
     {DSD_APP_CMD_TG_HOLD_TOGGLE, ui_handle_tg_hold_toggle},

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -1047,6 +1047,14 @@ ui_cmd_handle_manual_tune(dsd_opts* opts, dsd_state* state, const struct dsd_app
         ui_set_toast(state, 3, "Scanner active: tap-to-tune disabled");
         return result;
     }
+    /* The third owner, and the one a release cannot clear (see apply_tuner_release):
+     * dsd_trunk_scan_hook_tick() runs on every engine iteration and steps targets on
+     * its own, so a tap accepted under it is undone within a dwell -- and it is the
+     * owner engine_trunk_tuning_owner_active() actually gates dispatch on. */
+    if (opts->trunk_scan_enabled) {
+        ui_set_toast(state, 3, "Trunk scan active: tap-to-tune disabled");
+        return result;
+    }
     int rc = svc_rtl_set_freq(opts, state, v);
     result = ui_cmd_apply_status_from_tune_rc(rc);
     if (rc == 0 || rc == RTL_STREAM_TUNE_TIMEOUT) {
@@ -2969,10 +2977,26 @@ apply_decode_mode_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_com
     int32_t requested = 0;
     DSD_MEMCPY(&requested, c->data, sizeof requested);
     const dsdneoUserDecodeMode mode = (dsdneoUserDecodeMode)requested;
+    /* The presets also carry an audio layout, but the output stream was opened
+       once at session start with the layout in force then (openAudioOutput()
+       reads pulse_digi_out_channels/pulse_digi_rate_out and the backend fixes
+       them for the life of the stream). Letting a preset change them here would
+       have dsd_play_synthesized_voice() dispatch mono writes into a stereo
+       stream for the rest of the session, so the session's own layout is kept. */
+    const int audio_channels = opts->pulse_digi_out_channels;
+    const int audio_rate = opts->pulse_digi_rate_out;
     if (dsd_apply_decode_mode_preset(mode, DSD_DECODE_PRESET_PROFILE_CLI, opts, state) != 0) {
         ui_set_toast(state, 4, "Decode mode not available");
         return UI_CMD_APPLY_UNSUPPORTED;
     }
+    opts->pulse_digi_out_channels = audio_channels;
+    opts->pulse_digi_rate_out = audio_rate;
+    /* The presets write symbol timing for a 48 kHz input. On an RTL front end the
+       demod output rate is whatever the capture rate decimates to, so the same
+       rescale every other preset caller performs (the CLI at startup, the config
+       reload above) has to happen here too, or the decoder is put on the wrong
+       symbol clock for the protocol it was just told to look for. */
+    dsd_apply_decode_mode_symbol_timing(mode, current_demod_rate(opts, state), state);
     /* The decoder was hunting for a different protocol a moment ago: its
        modulation votes describe frames of the old kind, and any call open on the
        old protocol will never be closed by the new one. */

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -2958,6 +2958,52 @@ apply_tuner_release(dsd_opts* opts, dsd_state* state) {
 }
 
 /**
+ * @brief Answer a decode-mode request that needs no preset run, or decline to.
+ *
+ * Range-checked before the cast, not after. dsdneoUserDecodeMode is a packed enum
+ * -- one byte -- so a value outside it does not stay outside it: 260 casts to 4,
+ * which is DSDCFG_MODE_DMR, and the whole DMR preset would then run for a command
+ * nobody could have meant. The payload is a plain int32 on the wire and
+ * CommandBridge::setDecodeMode() passes it through unvalidated, so this is the only
+ * place the two widths are reconciled.
+ *
+ * Idempotent for the reason ui_handle_mod_set() is: a chip re-asserts its own state
+ * after a frame it did not cause, and DecodeChip taps whether or not it is already
+ * selected. Applying a preset ends both call epochs, drops the auto-modulation
+ * votes and releases the modulation locks -- so re-applying the mode already in
+ * effect would cut a live call and revert an operator's QPSK pick on a tap that
+ * asked for nothing to change. Compared through dsd_infer_decode_mode_preset(),
+ * which is the same reading the control binds to, so the skip and the selection
+ * cannot answer differently.
+ *
+ * AUTO is excluded because there the reading is not an identification: AUTO is that
+ * helper's catch-all for any frame set matching no single preset, so a session with
+ * one protocol switched off answers AUTO without being it, and "listen for
+ * everything" has to stay able to widen such a set back out.
+ *
+ * @param c        Command whose payload is already known to be wide enough.
+ * @param out_mode Receives the requested mode whenever one could be read.
+ * @return The verdict to answer with, its toast already posted, or
+ *         UI_CMD_APPLY_UNHANDLED when @p out_mode is a mode still to apply.
+ */
+static int
+decode_mode_set_early_verdict(const dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c,
+                              dsdneoUserDecodeMode* out_mode) {
+    int32_t requested = 0;
+    DSD_MEMCPY(&requested, c->data, sizeof requested);
+    if (requested < 0 || requested > (int32_t)DSDCFG_MODE_DMR_MONO) {
+        ui_set_toast(state, 4, "Decode mode not available");
+        return UI_CMD_APPLY_UNSUPPORTED;
+    }
+    *out_mode = (dsdneoUserDecodeMode)requested;
+    if (*out_mode != DSDCFG_MODE_AUTO && dsd_infer_decode_mode_preset(opts) == *out_mode) {
+        ui_set_toast(state, 3, "Decoding %s", decode_mode_label(*out_mode));
+        return UI_CMD_APPLY_COMPLETED;
+    }
+    return UI_CMD_APPLY_UNHANDLED;
+}
+
+/**
  * @brief Switch which protocols are decoded, mid-session.
  *
  * Goes through the same preset helper the CLI uses, so a mode chosen here means
@@ -2978,9 +3024,11 @@ apply_decode_mode_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_com
     if (!state || c->n < (int)sizeof(int32_t)) {
         return UI_CMD_APPLY_INVALID_PAYLOAD;
     }
-    int32_t requested = 0;
-    DSD_MEMCPY(&requested, c->data, sizeof requested);
-    const dsdneoUserDecodeMode mode = (dsdneoUserDecodeMode)requested;
+    dsdneoUserDecodeMode mode = DSDCFG_MODE_AUTO;
+    const int early = decode_mode_set_early_verdict(opts, state, c, &mode);
+    if (early != UI_CMD_APPLY_UNHANDLED) {
+        return early;
+    }
     /* The presets also carry an audio layout, but the output stream was opened
        once at session start with the layout in force then (openAudioOutput()
        reads pulse_digi_out_channels/pulse_digi_rate_out and the backend fixes

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -2991,12 +2991,23 @@ apply_decode_mode_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_com
     }
     opts->pulse_digi_out_channels = audio_channels;
     opts->pulse_digi_rate_out = audio_rate;
-    /* The presets write symbol timing for a 48 kHz input. On an RTL front end the
-       demod output rate is whatever the capture rate decimates to, so the same
-       rescale every other preset caller performs (the CLI at startup, the config
-       reload above) has to happen here too, or the decoder is put on the wrong
-       symbol clock for the protocol it was just told to look for. */
-    dsd_apply_decode_mode_symbol_timing(mode, current_demod_rate(opts, state), state);
+    /* The presets write symbol timing for a 48 kHz input, and on an RTL front end
+       the demod output rate is whatever the capture rate decimates to, so the
+       timing has to be recomputed at the live rate or the decoder is put on the
+       wrong symbol clock for the protocol it was just told to look for.
+
+       Taken from the mode's steady-state profile rather than from the preset's
+       starting timing, because the same profile decides the SPS hunt index and
+       the channel filter published just below, and a mode running on one symbol
+       clock with a hunt profile and a filter built for another is exactly what
+       that costs. */
+    const dsd_decode_mode_profile profile = dsd_decode_mode_profile_for(mode);
+    state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, profile.symbol_rate_hz, current_demod_rate(opts, state));
+    state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
+    /* The SPS hunt resumes from wherever the previous mode left it, and its next
+       pass overwrites the timing just computed; the RTL front end likewise keeps
+       the old mode's demodulator family and channel filter until told otherwise. */
+    svc_publish_symbol_profile(opts, state, profile);
     /* The decoder was hunting for a different protocol a moment ago: its
        modulation votes describe frames of the old kind, and any call open on the
        old protocol will never be closed by the new one. */

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -146,6 +146,7 @@ ui_cmd_is_coalescible_setter(int cmd_id) {
         case DSD_APP_CMD_AGAIN_SET:
         case DSD_APP_CMD_INPUT_VOL_SET:
         case DSD_APP_CMD_RTL_SET_FREQ:
+        case DSD_APP_CMD_MANUAL_TUNE:
         case DSD_APP_CMD_RTL_SET_GAIN:
         case DSD_APP_CMD_RTL_SET_PPM:
         case DSD_APP_CMD_RTL_SET_BW:
@@ -1006,6 +1007,52 @@ ui_cmd_handle_rtl_set_freq(dsd_opts* opts, dsd_state* state, const struct dsd_ap
     return result;
 }
 
+/* Defined further down with the manual-tuning helpers; tap-to-tune needs the
+ * same call-state teardown the manual return-to-CC path uses. */
+static void reset_call_tracking(dsd_opts* opts, dsd_state* state, int clear_trunk_vc);
+
+/*
+ * Live retune from a spectrum tap.
+ *
+ * Kept separate from ui_cmd_handle_rtl_set_freq() on purpose. That one is the
+ * settings-menu tune and documents a no-bookkeeping contract; here the tune is
+ * a navigation gesture, so it (a) evaluates the trunking gate at drain time on
+ * the authoritative live opts->trunk_enable rather than trusting the
+ * frontend's affordance, and (b) drops the stale auto-modulation votes and
+ * per-slot call state that would otherwise slow or corrupt re-acquisition in
+ * decode mode "auto".
+ */
+static int
+ui_cmd_handle_manual_tune(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
+    uint32_t v = 0;
+    int result = UI_CMD_APPLY_COMPLETED;
+    if (!state || !ui_cmd_parse_u32_payload(c, &v)) {
+        return result;
+    }
+    if (opts->trunk_enable) {
+        ui_set_toast(state, 3, "Trunking active: tap-to-tune disabled");
+        return result;
+    }
+    int rc = svc_rtl_set_freq(opts, state, v);
+    result = ui_cmd_apply_status_from_tune_rc(rc);
+    if (rc == 0 || rc == RTL_STREAM_TUNE_TIMEOUT) {
+        /* Only after the tune is accepted, matching how trunk_tuning.c and the
+         * manual return-to-CC path order this — never on the failure path. */
+        dsd_frame_sync_reset_mod_state();
+        reset_call_tracking(opts, state, 1);
+        if (rc == 0) {
+            ui_set_toast(state, 3, "Applied: tuned -> %u Hz", v);
+        } else {
+            ui_set_toast(state, 3, "Accepted: tuned -> %u Hz (pending)", v);
+        }
+    } else if (ui_rc_is_not_supported(rc)) {
+        ui_set_toast(state, 3, "Unsupported: frequency control not available on active backend");
+    } else {
+        ui_set_toast(state, 4, "Failed: tune -> %u Hz", v);
+    }
+    return result;
+}
+
 static int
 ui_cmd_handle_rtl_set_gain(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     int32_t v = 0;
@@ -1046,6 +1093,7 @@ static int
 apply_cmd_io_and_import_rtl_b(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     static const struct dsd_app_command_handler_entry k_handlers[] = {
         {DSD_APP_CMD_RTL_SET_FREQ, ui_cmd_handle_rtl_set_freq},
+        {DSD_APP_CMD_MANUAL_TUNE, ui_cmd_handle_manual_tune},
         {DSD_APP_CMD_RTL_SET_GAIN, ui_cmd_handle_rtl_set_gain},
         {DSD_APP_CMD_RTL_SET_PPM, ui_cmd_handle_rtl_set_ppm},
     };
@@ -2317,6 +2365,7 @@ int
 dsd_app_command_set_u32(int cmd_id, uint32_t value) {
     switch (cmd_id) {
         case DSD_APP_CMD_RTL_SET_FREQ:
+        case DSD_APP_CMD_MANUAL_TUNE:
         case DSD_APP_CMD_TG_HOLD_SET:
         case DSD_APP_CMD_KEY_BASIC_SET:
         case DSD_APP_CMD_KEY_SCRAMBLER_SET: return dsd_app_command_submit(cmd_id, &value, sizeof value);
@@ -2435,6 +2484,7 @@ static const struct ui_cmd_payload_min_size_rule k_ui_cmd_payload_min_size_rules
     {DSD_APP_CMD_CALL_ALERT_EVENTS_SET, sizeof(uint8_t)},
     {DSD_APP_CMD_LOCKOUT_SLOT, sizeof(uint8_t)},
     {DSD_APP_CMD_RTL_SET_FREQ, sizeof(uint32_t)},
+    {DSD_APP_CMD_MANUAL_TUNE, sizeof(uint32_t)},
     {DSD_APP_CMD_TG_HOLD_SET, sizeof(uint32_t)},
     {DSD_APP_CMD_KEY_BASIC_SET, sizeof(uint32_t)},
     {DSD_APP_CMD_KEY_SCRAMBLER_SET, sizeof(uint32_t)},

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -1016,11 +1016,11 @@ static void reset_call_tracking(dsd_opts* opts, dsd_state* state, int clear_trun
  *
  * Kept separate from ui_cmd_handle_rtl_set_freq() on purpose. That one is the
  * settings-menu tune and documents a no-bookkeeping contract; here the tune is
- * a navigation gesture, so it (a) evaluates the trunking gate at drain time on
- * the authoritative live opts->trunk_enable rather than trusting the
- * frontend's affordance, and (b) drops the stale auto-modulation votes and
- * per-slot call state that would otherwise slow or corrupt re-acquisition in
- * decode mode "auto".
+ * a navigation gesture, so it (a) evaluates the tuner-ownership gate at drain
+ * time on the authoritative live opts rather than trusting the frontend's
+ * affordance, and (b) drops the stale auto-modulation votes and per-slot call
+ * state that would otherwise slow or corrupt re-acquisition in decode mode
+ * "auto".
  */
 static int
 ui_cmd_handle_manual_tune(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
@@ -1029,8 +1029,17 @@ ui_cmd_handle_manual_tune(dsd_opts* opts, dsd_state* state, const struct dsd_app
     if (!state || !ui_cmd_parse_u32_payload(c, &v)) {
         return result;
     }
+    /* Either automatic controller owns the tuner. Trunking parks on a control
+     * channel; conventional scanner mode steps the channel map on its own once
+     * trunk_hangtime expires (no_carrier_step_scanner_mode_if_needed()), so a
+     * tap accepted under it would be silently undone seconds later — worse than
+     * a refusal, because the toast would have claimed it worked. */
     if (opts->trunk_enable) {
         ui_set_toast(state, 3, "Trunking active: tap-to-tune disabled");
+        return result;
+    }
+    if (opts->scanner_mode) {
+        ui_set_toast(state, 3, "Scanner active: tap-to-tune disabled");
         return result;
     }
     int rc = svc_rtl_set_freq(opts, state, v);

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -139,28 +139,30 @@ static const int k_ui_cmd_string_ids[] = {
     DSD_APP_CMD_M17_USER_DATA_SET,
 };
 
+/* Setters where only the newest value matters, so a queued one may be overwritten
+   in place rather than walked through. A list rather than a switch for the same
+   reason k_ui_cmd_string_ids above is one: each entry costs a branch in a switch,
+   and this set only grows.
+
+   The last four are discrete choices rather than swept values, and are here on a
+   narrower argument: a segmented control taken twice in a second should land on
+   the second answer without the decoder rebuilding timing for the first one on
+   the way. */
+static const int k_ui_cmd_coalescible_setter_ids[] = {
+    DSD_APP_CMD_GAIN_SET,        DSD_APP_CMD_AGAIN_SET,        DSD_APP_CMD_INPUT_VOL_SET, DSD_APP_CMD_RTL_SET_FREQ,
+    DSD_APP_CMD_MANUAL_TUNE,     DSD_APP_CMD_RTL_SET_GAIN,     DSD_APP_CMD_RTL_SET_PPM,   DSD_APP_CMD_RTL_SET_BW,
+    DSD_APP_CMD_RTL_SET_SQL_DB,  DSD_APP_CMD_RTL_SET_VOL_MULT, DSD_APP_CMD_HANGTIME_SET,  DSD_APP_CMD_MOD_SET,
+    DSD_APP_CMD_DECODE_MODE_SET, DSD_APP_CMD_TRUNK_SET,        DSD_APP_CMD_SLOT_PREF_SET,
+};
+
 static int
 ui_cmd_is_coalescible_setter(int cmd_id) {
-    switch (cmd_id) {
-        case DSD_APP_CMD_GAIN_SET:
-        case DSD_APP_CMD_AGAIN_SET:
-        case DSD_APP_CMD_INPUT_VOL_SET:
-        case DSD_APP_CMD_RTL_SET_FREQ:
-        case DSD_APP_CMD_MANUAL_TUNE:
-        case DSD_APP_CMD_RTL_SET_GAIN:
-        case DSD_APP_CMD_RTL_SET_PPM:
-        case DSD_APP_CMD_RTL_SET_BW:
-        case DSD_APP_CMD_RTL_SET_SQL_DB:
-        case DSD_APP_CMD_RTL_SET_VOL_MULT:
-        case DSD_APP_CMD_HANGTIME_SET:
-        /* Discrete choices, but a segmented control taken twice in a second should
-           land on the second answer without the decoder rebuilding timing for the
-           first one on the way. */
-        case DSD_APP_CMD_MOD_SET:
-        case DSD_APP_CMD_DECODE_MODE_SET:
-        case DSD_APP_CMD_SLOT_PREF_SET: return 1;
-        default: return 0;
+    for (size_t i = 0; i < sizeof k_ui_cmd_coalescible_setter_ids / sizeof k_ui_cmd_coalescible_setter_ids[0]; i++) {
+        if (k_ui_cmd_coalescible_setter_ids[i] == cmd_id) {
+            return 1;
+        }
     }
+    return 0;
 }
 
 static int
@@ -2381,6 +2383,7 @@ static const int k_ui_cmd_i32_ids[] = {
     DSD_APP_CMD_INPUT_VOL_SET,
     DSD_APP_CMD_MOD_SET,
     DSD_APP_CMD_DECODE_MODE_SET,
+    DSD_APP_CMD_TRUNK_SET,
 };
 
 static int
@@ -2545,6 +2548,7 @@ static const struct ui_cmd_payload_min_size_rule k_ui_cmd_payload_min_size_rules
     {DSD_APP_CMD_RTL_SET_FREQ, sizeof(uint32_t)},
     {DSD_APP_CMD_MOD_SET, sizeof(int32_t)},
     {DSD_APP_CMD_DECODE_MODE_SET, sizeof(int32_t)},
+    {DSD_APP_CMD_TRUNK_SET, sizeof(int32_t)},
     {DSD_APP_CMD_MANUAL_TUNE, sizeof(uint32_t)},
     {DSD_APP_CMD_TG_HOLD_SET, sizeof(uint32_t)},
     {DSD_APP_CMD_KEY_BASIC_SET, sizeof(uint32_t)},

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -153,6 +153,11 @@ ui_cmd_is_coalescible_setter(int cmd_id) {
         case DSD_APP_CMD_RTL_SET_SQL_DB:
         case DSD_APP_CMD_RTL_SET_VOL_MULT:
         case DSD_APP_CMD_HANGTIME_SET:
+        /* Discrete choices, but a segmented control taken twice in a second should
+           land on the second answer without the decoder rebuilding timing for the
+           first one on the way. */
+        case DSD_APP_CMD_MOD_SET:
+        case DSD_APP_CMD_DECODE_MODE_SET:
         case DSD_APP_CMD_SLOT_PREF_SET: return 1;
         default: return 0;
     }
@@ -1617,6 +1622,28 @@ current_cc_freq(const dsd_state* state) {
     return (state->trunk_cc_freq != 0) ? state->trunk_cc_freq : state->p25_cc_freq;
 }
 
+/** @brief What to call a decode preset in a message the operator reads. */
+static const char*
+decode_mode_label(dsdneoUserDecodeMode mode) {
+    static const struct {
+        dsdneoUserDecodeMode mode;
+        const char* label;
+    } k_labels[] = {
+        {DSDCFG_MODE_AUTO, "everything"}, {DSDCFG_MODE_P25P1, "P25 Phase 1"}, {DSDCFG_MODE_P25P2, "P25 Phase 2"},
+        {DSDCFG_MODE_TDMA, "P25"},        {DSDCFG_MODE_DMR, "DMR"},           {DSDCFG_MODE_DMR_MONO, "DMR"},
+        {DSDCFG_MODE_NXDN48, "NXDN48"},   {DSDCFG_MODE_NXDN96, "NXDN96"},     {DSDCFG_MODE_X2TDMA, "X2-TDMA"},
+        {DSDCFG_MODE_YSF, "YSF"},         {DSDCFG_MODE_DSTAR, "D-STAR"},      {DSDCFG_MODE_EDACS_PV, "EDACS/ProVoice"},
+        {DSDCFG_MODE_DPMR, "dPMR"},       {DSDCFG_MODE_M17, "M17"},           {DSDCFG_MODE_ANALOG, "analog"},
+    };
+
+    for (size_t i = 0; i < sizeof k_labels / sizeof k_labels[0]; i++) {
+        if (k_labels[i].mode == mode) {
+            return k_labels[i].label;
+        }
+    }
+    return "that mode";
+}
+
 static void
 reset_call_tracking(dsd_opts* opts, dsd_state* state, int clear_trunk_vc) {
     const double ended_m = dsd_time_now_monotonic_s();
@@ -2247,6 +2274,7 @@ static const int k_ui_cmd_action_ids[] = {
     DSD_APP_CMD_SLOT_PREF_CYCLE,
     DSD_APP_CMD_TRUNK_TOGGLE,
     DSD_APP_CMD_SCANNER_TOGGLE,
+    DSD_APP_CMD_TUNER_RELEASE,
     DSD_APP_CMD_PAYLOAD_TOGGLE,
     DSD_APP_CMD_P25_GA_TOGGLE,
     DSD_APP_CMD_LPF_TOGGLE,
@@ -2325,12 +2353,26 @@ static const int k_ui_cmd_action_ids[] = {
 };
 
 static const int k_ui_cmd_i32_ids[] = {
-    DSD_APP_CMD_GAIN_DELTA,          DSD_APP_CMD_AGAIN_DELTA,      DSD_APP_CMD_SPEC_SIZE_DELTA,
-    DSD_APP_CMD_PPM_DELTA,           DSD_APP_CMD_GAIN_SET,         DSD_APP_CMD_AGAIN_SET,
-    DSD_APP_CMD_RTL_SET_DEV,         DSD_APP_CMD_RTL_SET_GAIN,     DSD_APP_CMD_RTL_SET_PPM,
-    DSD_APP_CMD_RTL_SET_BW,          DSD_APP_CMD_RTL_SET_VOL_MULT, DSD_APP_CMD_RTL_SET_BIAS_TEE,
-    DSD_APP_CMD_RTLTCP_SET_AUTOTUNE, DSD_APP_CMD_RTL_SET_AUTO_PPM, DSD_APP_CMD_RIGCTL_SET_MOD_BW,
-    DSD_APP_CMD_SLOT_PREF_SET,       DSD_APP_CMD_SLOTS_ONOFF_SET,  DSD_APP_CMD_INPUT_VOL_SET,
+    DSD_APP_CMD_GAIN_DELTA,
+    DSD_APP_CMD_AGAIN_DELTA,
+    DSD_APP_CMD_SPEC_SIZE_DELTA,
+    DSD_APP_CMD_PPM_DELTA,
+    DSD_APP_CMD_GAIN_SET,
+    DSD_APP_CMD_AGAIN_SET,
+    DSD_APP_CMD_RTL_SET_DEV,
+    DSD_APP_CMD_RTL_SET_GAIN,
+    DSD_APP_CMD_RTL_SET_PPM,
+    DSD_APP_CMD_RTL_SET_BW,
+    DSD_APP_CMD_RTL_SET_VOL_MULT,
+    DSD_APP_CMD_RTL_SET_BIAS_TEE,
+    DSD_APP_CMD_RTLTCP_SET_AUTOTUNE,
+    DSD_APP_CMD_RTL_SET_AUTO_PPM,
+    DSD_APP_CMD_RIGCTL_SET_MOD_BW,
+    DSD_APP_CMD_SLOT_PREF_SET,
+    DSD_APP_CMD_SLOTS_ONOFF_SET,
+    DSD_APP_CMD_INPUT_VOL_SET,
+    DSD_APP_CMD_MOD_SET,
+    DSD_APP_CMD_DECODE_MODE_SET,
 };
 
 static int
@@ -2493,6 +2535,8 @@ static const struct ui_cmd_payload_min_size_rule k_ui_cmd_payload_min_size_rules
     {DSD_APP_CMD_CALL_ALERT_EVENTS_SET, sizeof(uint8_t)},
     {DSD_APP_CMD_LOCKOUT_SLOT, sizeof(uint8_t)},
     {DSD_APP_CMD_RTL_SET_FREQ, sizeof(uint32_t)},
+    {DSD_APP_CMD_MOD_SET, sizeof(int32_t)},
+    {DSD_APP_CMD_DECODE_MODE_SET, sizeof(int32_t)},
     {DSD_APP_CMD_MANUAL_TUNE, sizeof(uint32_t)},
     {DSD_APP_CMD_TG_HOLD_SET, sizeof(uint32_t)},
     {DSD_APP_CMD_KEY_BASIC_SET, sizeof(uint32_t)},
@@ -2868,6 +2912,76 @@ apply_cmd_eye_spectrum(dsd_opts* opts, dsd_state* state, const struct dsd_app_co
     return ui_cmd_apply_handler_table(k_handlers, sizeof k_handlers / sizeof k_handlers[0], opts, state, c);
 }
 
+/**
+ * @brief Hand the tuner back to the operator: trunking and scanner mode both off.
+ *
+ * Idempotent. A frontend only learns that *something* owns the tuner, not which,
+ * so TRUNK_TOGGLE/SCANNER_TOGGLE cannot express "off" from there without guessing.
+ *
+ * The call-state teardown is not optional and is not left to a following
+ * MANUAL_TUNE: a release is frequently the whole request -- look around from
+ * where we already are -- and then no tune ever runs it. Left set,
+ * opts->trunk_is_tuned keeps update_dmr_bs_sync_times_if_tuned() stamping sync
+ * times, which in turn suppresses the engine's stale-follow-state cleanup, and it
+ * is also the flag whose zero state lets the decoder learn a control channel.
+ *
+ * No dsd_frame_sync_reset_mod_state() here: nothing retuned, so the modulation
+ * votes still describe the signal actually being received.
+ *
+ * opts->trunk_scan_enabled is a third tuner owner (see
+ * engine_trunk_tuning_owner_active()) and is deliberately untouched: it owns live
+ * scan hooks that clearing a flag would not tear down, and it is only reachable
+ * from a frontend that passes --trunk-scan.
+ */
+static int
+apply_tuner_release(dsd_opts* opts, dsd_state* state) {
+    if (!state) {
+        return UI_CMD_APPLY_COMPLETED;
+    }
+    opts->trunk_enable = 0;
+    opts->scanner_mode = 0;
+    reset_call_tracking(opts, state, 1);
+    ui_set_toast(state, 3, "Automatic tuning stopped");
+    return UI_CMD_APPLY_COMPLETED;
+}
+
+/**
+ * @brief Switch which protocols are decoded, mid-session.
+ *
+ * Goes through the same preset helper the CLI uses, so a mode chosen here means
+ * exactly what the same mode means at startup rather than a second opinion about
+ * which frame_* flags it implies.
+ *
+ * The CLI profile specifically, not the interactive one: only its AUTO re-enables
+ * the whole frame set. The other profiles leave AUTO as a label because they run
+ * against freshly defaulted options where everything is already on -- but this
+ * command runs against options a previous single-protocol choice has already
+ * narrowed, so "listen for everything" has to actually widen them again.
+ *
+ * Every preset also settles the modulation, which is why a panel offering both
+ * reads modulation back from the engine rather than remembering what it asked for.
+ */
+static int
+apply_decode_mode_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
+    if (!state || c->n < (int)sizeof(int32_t)) {
+        return UI_CMD_APPLY_INVALID_PAYLOAD;
+    }
+    int32_t requested = 0;
+    DSD_MEMCPY(&requested, c->data, sizeof requested);
+    const dsdneoUserDecodeMode mode = (dsdneoUserDecodeMode)requested;
+    if (dsd_apply_decode_mode_preset(mode, DSD_DECODE_PRESET_PROFILE_CLI, opts, state) != 0) {
+        ui_set_toast(state, 4, "Decode mode not available");
+        return UI_CMD_APPLY_UNSUPPORTED;
+    }
+    /* The decoder was hunting for a different protocol a moment ago: its
+       modulation votes describe frames of the old kind, and any call open on the
+       old protocol will never be closed by the new one. */
+    dsd_frame_sync_reset_mod_state();
+    reset_call_tracking(opts, state, 1);
+    ui_set_toast(state, 3, "Decoding %s", decode_mode_label(mode));
+    return UI_CMD_APPLY_COMPLETED;
+}
+
 static int
 apply_cmd_trunk_controls(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     switch (c->id) {
@@ -2914,6 +3028,8 @@ apply_cmd_trunk_controls(dsd_opts* opts, dsd_state* state, const struct dsd_app_
             }
             return 1;
         case DSD_APP_CMD_RETURN_CC: return apply_manual_return_to_cc(opts, state);
+        case DSD_APP_CMD_TUNER_RELEASE: return apply_tuner_release(opts, state);
+        case DSD_APP_CMD_DECODE_MODE_SET: return apply_decode_mode_set(opts, state, c);
         case DSD_APP_CMD_SIM_NOCAR:
             if (!state) {
                 return 1;

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -2982,10 +2982,38 @@ apply_decode_mode_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_com
        reads pulse_digi_out_channels/pulse_digi_rate_out and the backend fixes
        them for the life of the stream). Letting a preset change them here would
        have dsd_play_synthesized_voice() dispatch mono writes into a stereo
-       stream for the rest of the session, so the session's own layout is kept. */
+       stream for the rest of the session, so the session's own layout is kept.
+
+       dmr_stereo is deliberately not in this pair, though the presets set it
+       next to them. It selects two-slot decoding, not a stream shape: the DMR
+       playback paths take the channel count separately and mix both slots down
+       when it is 1 (playSynthesizedVoiceSS3/FS3), so a mono session that switches
+       to DMR still hears both slots. Putting it back with the channel count would
+       instead leave a DMR session on dmr_stereo == 0 with dmr_mono == 0, which no
+       preset produces and which dmr_handle_voice() answers by running the MS
+       bootstrap against BS voice and nothing at all against MS voice. */
     const int audio_channels = opts->pulse_digi_out_channels;
     const int audio_rate = opts->pulse_digi_rate_out;
+    /* Released before the preset runs, not after. The presets skip their whole
+       modulation block under mod_cli_lock (decode_mode_apply_dmr() and siblings),
+       so on a session started with `-mq`/`-mg` the new protocol would keep the old
+       modulation -- and svc_publish_symbol_profile() below reads state->rf_mod, so
+       it would then ask the front end for that modulation's demodulator and channel
+       filter at the new protocol's symbol rate, with the lock still on to stop the
+       SPS hunt correcting it. Choosing a protocol here is a fresh answer to what is
+       on this channel and outranks a `-m` flag from session start; this is the same
+       release ui_apply_modulation() performs for the modulation control.
+
+       Restored if the mode turns out to be unsupported, so a refused command
+       changes nothing -- which is the contract the preset helper itself keeps. */
+    const int mod_locks[3] = {opts->mod_cli_lock, opts->mod_p25p2_c4fm, opts->mod_p25p2_profile_lock};
+    opts->mod_p25p2_c4fm = 0;
+    opts->mod_p25p2_profile_lock = 0;
+    opts->mod_cli_lock = 0;
     if (dsd_apply_decode_mode_preset(mode, DSD_DECODE_PRESET_PROFILE_CLI, opts, state) != 0) {
+        opts->mod_cli_lock = mod_locks[0];
+        opts->mod_p25p2_c4fm = mod_locks[1];
+        opts->mod_p25p2_profile_lock = mod_locks[2];
         ui_set_toast(state, 4, "Decode mode not available");
         return UI_CMD_APPLY_UNSUPPORTED;
     }

--- a/src/app_control/frontend.c
+++ b/src/app_control/frontend.c
@@ -60,9 +60,7 @@ frontend_metrics_from_runtime_hooks(dsd_frontend_metrics* out) {
     out->output_rate_hz = dsd_rtl_stream_metrics_hook_output_rate_hz();
     out->output_kind = dsd_rtl_stream_metrics_hook_output_kind();
     (void)dsd_rtl_stream_metrics_hook_symbol_profile(&out->symbol_rate_hz, &out->symbol_levels, &out->channel_profile);
-#ifdef USE_RADIO
     out->channel_bandwidth_hz = (int)(2.0 * dsd_channel_lpf_protected_edge_hz(out->channel_profile));
-#endif
     out->stream_generation = dsd_rtl_stream_metrics_hook_stream_generation();
     out->stream_active = dsd_rtl_stream_metrics_hook_stream_active();
     (void)dsd_rtl_stream_metrics_hook_input_level(&out->input_level);

--- a/src/app_control/frontend.c
+++ b/src/app_control/frontend.c
@@ -60,7 +60,14 @@ frontend_metrics_from_runtime_hooks(dsd_frontend_metrics* out) {
     out->output_rate_hz = dsd_rtl_stream_metrics_hook_output_rate_hz();
     out->output_kind = dsd_rtl_stream_metrics_hook_output_kind();
     (void)dsd_rtl_stream_metrics_hook_symbol_profile(&out->symbol_rate_hz, &out->symbol_levels, &out->channel_profile);
-    out->channel_bandwidth_hz = (int)(2.0 * dsd_channel_lpf_protected_edge_hz(out->channel_profile));
+    /* Only once the front end has actually published a profile. The mirror behind
+     * channel_profile is process-global and reads WIDE until the first publish, so
+     * deriving a width from it unconditionally reports 16 kHz for a session that
+     * has not chosen a channel yet -- and a consumer drawing that shades a channel
+     * band over the waterfall that belongs to nothing. 0 is the documented "there
+     * is nothing to draw". */
+    out->channel_bandwidth_hz =
+        (out->symbol_rate_hz > 0) ? (int)(2.0 * dsd_channel_lpf_protected_edge_hz(out->channel_profile)) : 0;
     out->stream_generation = dsd_rtl_stream_metrics_hook_stream_generation();
     out->stream_active = dsd_rtl_stream_metrics_hook_stream_active();
     (void)dsd_rtl_stream_metrics_hook_input_level(&out->input_level);

--- a/src/app_control/frontend.c
+++ b/src/app_control/frontend.c
@@ -237,3 +237,30 @@ dsd_app_frontend_spectrum_get(float* out_db, int max_bins, int* out_rate) {
     return 0;
 #endif
 }
+
+int
+dsd_app_frontend_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz,
+                                       uint32_t* out_span_hz) {
+#ifdef USE_RADIO
+    return rtl_stream_wideband_spectrum_get(out_db, max_bins, out_center_freq_hz, out_span_hz);
+#else
+    (void)out_db;
+    (void)max_bins;
+    if (out_center_freq_hz) {
+        *out_center_freq_hz = 0;
+    }
+    if (out_span_hz) {
+        *out_span_hz = 0;
+    }
+    return 0;
+#endif
+}
+
+void
+dsd_app_frontend_wideband_spectrum_set_enabled(int on) {
+#ifdef USE_RADIO
+    rtl_stream_wideband_spectrum_set_enabled(on);
+#else
+    (void)on;
+#endif
+}

--- a/src/app_control/frontend.c
+++ b/src/app_control/frontend.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/app_control/snapshot.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/dsp/demod_pipeline.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <stddef.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -59,6 +60,9 @@ frontend_metrics_from_runtime_hooks(dsd_frontend_metrics* out) {
     out->output_rate_hz = dsd_rtl_stream_metrics_hook_output_rate_hz();
     out->output_kind = dsd_rtl_stream_metrics_hook_output_kind();
     (void)dsd_rtl_stream_metrics_hook_symbol_profile(&out->symbol_rate_hz, &out->symbol_levels, &out->channel_profile);
+#ifdef USE_RADIO
+    out->channel_bandwidth_hz = (int)(2.0 * dsd_channel_lpf_protected_edge_hz(out->channel_profile));
+#endif
     out->stream_generation = dsd_rtl_stream_metrics_hook_stream_generation();
     out->stream_active = dsd_rtl_stream_metrics_hook_stream_active();
     (void)dsd_rtl_stream_metrics_hook_input_level(&out->input_level);

--- a/src/app_control/frontend.c
+++ b/src/app_control/frontend.c
@@ -239,10 +239,10 @@ dsd_app_frontend_spectrum_get(float* out_db, int max_bins, int* out_rate) {
 }
 
 int
-dsd_app_frontend_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz,
-                                       uint32_t* out_span_hz) {
+dsd_app_frontend_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz, uint32_t* out_span_hz,
+                                       uint32_t* out_frame_serial) {
 #ifdef USE_RADIO
-    return rtl_stream_wideband_spectrum_get(out_db, max_bins, out_center_freq_hz, out_span_hz);
+    return rtl_stream_wideband_spectrum_get(out_db, max_bins, out_center_freq_hz, out_span_hz, out_frame_serial);
 #else
     (void)out_db;
     (void)max_bins;
@@ -251,6 +251,9 @@ dsd_app_frontend_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* ou
     }
     if (out_span_hz) {
         *out_span_hz = 0;
+    }
+    if (out_frame_serial) {
+        *out_frame_serial = 0;
     }
     return 0;
 #endif

--- a/src/app_control/services.h
+++ b/src/app_control/services.h
@@ -17,6 +17,7 @@
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/runtime/decode_mode.h>
 
 #ifdef USE_RADIO
 #include <stdint.h>
@@ -125,6 +126,24 @@ void svc_toggle_dmr_le(dsd_opts* opts);
 void svc_set_slot_pref(dsd_opts* opts, int pref);
 /** @brief Enable/disable slots using bitmask (bit0=slot1, bit1=slot2). */
 void svc_set_slots_onoff(dsd_opts* opts, int mask);
+
+// Symbol profile
+/**
+ * @brief Make the SPS hunt and the front end agree with the decoder's timing.
+ *
+ * The caller has already put @c samplesPerSymbol / @c symbolCenter on the timing
+ * @p profile calls for; this publishes that decision to everything downstream of
+ * it. The hunt is restarted from the profile's index, because left on the
+ * previous mode's it overwrites the freshly computed timing on its next pass, and
+ * on an RTL front end the demodulator family and channel filter are queued to
+ * match — otherwise the decoder is looking for one protocol through the filter of
+ * another.
+ *
+ * For handlers that change the decoder in place. Ones that retune are already
+ * served by the trunk tuning hook, which stages a profile with the retune, and
+ * a second request from here would fight it.
+ */
+void svc_publish_symbol_profile(const dsd_opts* opts, dsd_state* state, dsd_decode_mode_profile profile);
 
 // Per-protocol inversion toggles
 /** @brief Toggle X2-TDMA symbol inversion. */

--- a/src/app_control/symbol_profile.c
+++ b/src/app_control/symbol_profile.c
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Publishing a decoder symbol profile to the SPS hunt and the front end.
+ *
+ * Its own translation unit rather than part of menu_services.c so that the
+ * hermetic unit tests over a single command-handler source can link it without
+ * dragging in CSV import, rigctl and the P25 watchdog.
+ */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/runtime/decode_mode.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "services.h"
+
+#ifdef USE_RADIO
+#include <dsd-neo/io/rtl_stream_c.h>
+#endif
+
+void
+svc_publish_symbol_profile(const dsd_opts* opts, dsd_state* state, dsd_decode_mode_profile profile) {
+    if (!opts || !state) {
+        return;
+    }
+
+    state->sps_hunt_idx = (int)profile.sps_profile_index;
+    state->sps_hunt_counter = 0;
+
+#ifdef USE_RADIO
+    if (opts->audio_in_type != AUDIO_IN_RTL || !state->rtl_ctx) {
+        return;
+    }
+    /* Queued for the demod thread rather than written into demod state from the
+       caller's thread. The clamp mirrors the no-override setter this replaced. */
+    const int mod = state->rf_mod;
+    const int ted_sps = state->samplesPerSymbol < 2 ? 2 : state->samplesPerSymbol;
+    (void)rtl_stream_request_demod_profile(
+        mod == 1, profile.symbol_rate_hz, profile.levels,
+        dsd_rtl_channel_profile_for(opts, profile.symbol_rate_hz, profile.levels, mod), ted_sps, 0);
+#endif
+}

--- a/src/app_control/symbol_profile.c
+++ b/src/app_control/symbol_profile.c
@@ -36,6 +36,17 @@ svc_publish_symbol_profile(const dsd_opts* opts, dsd_state* state, dsd_decode_mo
     if (opts->audio_in_type != AUDIO_IN_RTL || !state->rtl_ctx) {
         return;
     }
+    /* Analog monitor has no symbol clock and no channel to protect, and the front
+       end already answers that case for itself with DSD_CH_LPF_PROFILE_WIDE
+       (opts_channel_profile_for_rate()). dsd_decode_mode_profile_for() has no
+       entry for it and falls back on 4800/4, so publishing that would ask
+       rtl_stream_set_symbol_profile() for the P25 C4FM filter and narrow the
+       monitor audio to a digital channel's width -- for a command that only chose
+       a mode. Narrower than "no digital decode mode": that is also the shape a
+       modulation change sees before any frame flag is set. */
+    if (opts->analog_only) {
+        return;
+    }
     /* Queued for the demod thread rather than written into demod state from the
        caller's thread. The clamp mirrors the no-override setter this replaced. */
     const int mod = state->rf_mod;

--- a/src/dsp/demod_pipeline.cpp
+++ b/src/dsp/demod_pipeline.cpp
@@ -133,11 +133,19 @@ clamp_float(float value, float lo, float hi) {
 static const int kChannelLpfTaps = 144;
 static const double kChannelLpfTransitionHz = 1200.0;
 static const double kChannelLpfGuardHz = kChannelLpfTransitionHz * 0.5;
-static const double kChannelLpfWideCutoffHz = 8000.0 + kChannelLpfGuardHz;
-static const double kChannelLpf6k25CutoffHz = 3125.0 + kChannelLpfGuardHz;
-static const double kChannelLpf12k5CutoffHz = 6250.0 + kChannelLpfGuardHz;
-static const double kChannelLpfProvoiceCutoffHz = 6250.0 + kChannelLpfGuardHz;
-static const double kChannelLpfP25C4fmCutoffHz = 6250.0 + kChannelLpfGuardHz;
+/* Protected channel edges: the highest frequency each profile's channel LPF is
+ * designed to pass unattenuated. The cutoff constants below are these plus
+ * design guard, and dsd_channel_lpf_protected_edge_hz() reports these — see its
+ * doc comment for why P25 CQPSK reports 6250 while its cutoff is 7250. */
+static const double kChannelEdgeWideHz = 8000.0;
+static const double kChannelEdge6k25Hz = 3125.0;
+static const double kChannelEdge12k5Hz = 6250.0;
+
+static const double kChannelLpfWideCutoffHz = kChannelEdgeWideHz + kChannelLpfGuardHz;
+static const double kChannelLpf6k25CutoffHz = kChannelEdge6k25Hz + kChannelLpfGuardHz;
+static const double kChannelLpf12k5CutoffHz = kChannelEdge12k5Hz + kChannelLpfGuardHz;
+static const double kChannelLpfProvoiceCutoffHz = kChannelEdge12k5Hz + kChannelLpfGuardHz;
+static const double kChannelLpfP25C4fmCutoffHz = kChannelEdge12k5Hz + kChannelLpfGuardHz;
 static const double kChannelLpfP25CqpskCutoffHz = 7250.0;
 /* Fixed fallback filters are 63 taps (designed for 24 kHz). Only used when
  * dynamic filter generation fails; prefer dynamically generated taps. */
@@ -207,6 +215,18 @@ static const float channel_lpf_wide[kChannelLpfFallbackTaps] = {
     0.0f,
     0.0f,
 };
+
+double
+dsd_channel_lpf_protected_edge_hz(int profile) {
+    switch (profile) {
+        case DSD_CH_LPF_PROFILE_6K25: return kChannelEdge6k25Hz;
+        case DSD_CH_LPF_PROFILE_12K5:
+        case DSD_CH_LPF_PROFILE_PROVOICE:
+        case DSD_CH_LPF_PROFILE_P25_C4FM:
+        case DSD_CH_LPF_PROFILE_P25_CQPSK: return kChannelEdge12k5Hz;
+        default: return kChannelEdgeWideHz;
+    }
+}
 
 /* Fixed digital-profile taps (fc≈5 kHz @ 24 kHz, 63 taps). Designed as
    Blackman-windowed sinc and normalized to unity DC gain. */

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -38,6 +38,7 @@
 #include <dsd-neo/platform/atomic_compat.h>
 #include <dsd-neo/runtime/colors.h>
 #include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/exitflag.h>
 #include <dsd-neo/runtime/frame_sync_hooks.h>
 #include <dsd-neo/runtime/shutdown.h>
@@ -142,19 +143,10 @@ rtl_profile_for_sps_profile(const dsd_opts* opts, const dsd_state* state, const 
     if (!profile) {
         return DSD_RTL_STREAM_CHANNEL_PROFILE_WIDE;
     }
-    if (profile->symbol_rate_hz == 2400 || (profile->symbol_rate_hz == 4800 && profile->levels == 2)) {
-        return DSD_RTL_STREAM_CHANNEL_PROFILE_6K25;
-    }
-    if (profile->symbol_rate_hz == 9600) {
-        return DSD_RTL_STREAM_CHANNEL_PROFILE_PROVOICE;
-    }
-    if (state && state->rf_mod == 1) {
-        return DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
-    }
-    if (profile->symbol_rate_hz == 6000 || (state && state->rf_mod == 2) || dsd_opts_uses_wide_4800_profile(opts)) {
-        return DSD_RTL_STREAM_CHANNEL_PROFILE_12K5;
-    }
-    return DSD_RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+    /* Shared with the operator-facing modulation control, which reaches the same
+     * front end by a different route: two copies of this drift, and then the
+     * filter changes under the user every time the hunt re-runs. */
+    return dsd_rtl_channel_profile_for(opts, profile->symbol_rate_hz, profile->levels, state ? state->rf_mod : 0);
 }
 
 #ifdef DSD_NEO_TEST_HOOKS

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -2337,7 +2337,7 @@ frame_sync_window_levels(const dsd_opts* opts, dsd_state* state, frame_sync_runt
 
 static int
 frame_sync_profile_uses_gfsk_exclusively(const dsd_opts* opts, int profile_index) {
-    if (frame_sync_sps_profile_for_index(profile_index)->levels == 2) {
+    if (dsd_frame_sync_profile_levels_force_gfsk(frame_sync_sps_profile_for_index(profile_index)->levels)) {
         return 1;
     }
     if (!opts) {
@@ -2836,6 +2836,11 @@ dsd_frame_sync_test_sps_hunt_profile_levels(int profile_index) {
     return frame_sync_sps_profile_for_index(profile_index)->levels;
 }
 
+int
+dsd_frame_sync_test_sps_hunt_profile_has_candidate(const dsd_opts* opts, int profile_index) {
+    return frame_sync_sps_profile_has_candidate(opts, profile_index);
+}
+
 #endif
 
 static void
@@ -2864,7 +2869,7 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
 
     const frame_sync_sps_profile* profile = frame_sync_sps_profile_for_index(next_idx);
     const int profile_changed = next_idx != state->sps_hunt_idx;
-    const int profile_default_modulation = profile->levels == 2 ? 2 : 0;
+    const int profile_default_modulation = dsd_frame_sync_profile_modulation(profile->levels, 0);
     const int normalize_profile_modulation = !preserve_modulation && !opts->mod_cli_lock
                                              && state->rf_mod != profile_default_modulation
                                              && (profile_changed || profile->levels == 2);

--- a/src/dsp/frame_sync_test_support.h
+++ b/src/dsp/frame_sync_test_support.h
@@ -13,6 +13,7 @@ extern "C" {
 int dsd_frame_sync_test_sps_hunt_profile_count(void);
 int dsd_frame_sync_test_sps_hunt_profile_rate(int profile_index);
 int dsd_frame_sync_test_sps_hunt_profile_levels(int profile_index);
+int dsd_frame_sync_test_sps_hunt_profile_has_candidate(const dsd_opts* opts, int profile_index);
 int dsd_frame_sync_test_history_window(const char* symbols, int symbol_count, int window_length, char* out,
                                        int out_size);
 int dsd_frame_sync_test_try_protocol_matches(dsd_opts* opts, dsd_state* state, const char* symbols, int symbol_count);

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -32,6 +32,7 @@ if(DSD_HAS_RADIO)
             radio/rtl_stream.cpp
             radio/rtl_stream_c.cpp
             radio/rtl_sdr_fm.cpp
+            radio/rtl_wideband_spectrum.cpp
             radio/soapy_profile.cpp
     )
     target_include_directories(

--- a/src/io/radio/rtl_fft_cache.h
+++ b/src/io/radio/rtl_fft_cache.h
@@ -33,9 +33,33 @@ namespace dsd_io {
  * every caller, and destroying one at static-destruction time could race a
  * demod thread that has not been joined yet — the same reason the
  * function-local statics this replaces were also never torn down.
+ *
+ * The transform is a method rather than a setup handed back to the caller, so
+ * this header is the one place in the project that names pffft — which is what
+ * the no-direct-third-party-include rule asks for, and it kept the exception
+ * list from growing a line per spectrum producer.
  */
 class FftSetupCache {
   public:
+    /**
+     * @brief Forward complex transform of @p n points, in place.
+     *
+     * @param n Transform size in complex points.
+     * @param inout 2*n interleaved floats, 16-byte aligned; overwritten with the
+     *              ordered spectrum. Untouched when the size is rejected.
+     * @return false when pffft has no setup for @p n.
+     */
+    bool
+    forward(int n, float* inout) {
+        PFFFT_Setup* setup = get(n);
+        if (setup == nullptr || inout == nullptr) {
+            return false;
+        }
+        pffft_transform_ordered(setup, inout, inout, nullptr, PFFFT_FORWARD);
+        return true;
+    }
+
+  private:
     /** @brief Setup for @p n points, or nullptr when pffft rejects the size. */
     PFFFT_Setup*
     get(int n) {
@@ -54,7 +78,6 @@ class FftSetupCache {
         return m_setup;
     }
 
-  private:
     PFFFT_Setup* m_setup = nullptr;
     int m_n = 0;
 };

--- a/src/io/radio/rtl_fft_cache.h
+++ b/src/io/radio/rtl_fft_cache.h
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Reusable pffft setup and Hann window caches for the radio spectrum taps.
+ *
+ * Both spectrum producers — the narrow post-decimation one in rtl_metrics.cpp
+ * and the wideband one in rtl_wideband_spectrum.cpp — need the same two things
+ * on every block: a pffft setup for their transform size and a Hann window of
+ * that length, neither of which is worth rebuilding per call.
+ *
+ * The caches are objects rather than function-local statics precisely so the
+ * two producers do not share one. They run on the same thread at different
+ * sizes, so a single shared cache would destroy and rebuild the setup on every
+ * alternating call — slower than not caching at all.
+ */
+
+#ifndef DSD_NEO_SRC_IO_RADIO_RTL_FFT_CACHE_H_
+#define DSD_NEO_SRC_IO_RADIO_RTL_FFT_CACHE_H_
+
+#include <cmath>
+#include <pffft.h>
+
+namespace dsd_io {
+
+/**
+ * @brief A pffft complex setup, rebuilt only when the transform size changes.
+ *
+ * Never frees the setup it holds. The instances are file-scope and outlive
+ * every caller, and destroying one at static-destruction time could race a
+ * demod thread that has not been joined yet — the same reason the
+ * function-local statics this replaces were also never torn down.
+ */
+class FftSetupCache {
+  public:
+    /** @brief Setup for @p n points, or nullptr when pffft rejects the size. */
+    PFFFT_Setup*
+    get(int n) {
+        if (m_setup != nullptr && m_n == n) {
+            return m_setup;
+        }
+        if (m_setup != nullptr) {
+            pffft_destroy_setup(m_setup);
+            m_setup = nullptr;
+            m_n = 0;
+        }
+        m_setup = pffft_new_setup(n, PFFFT_COMPLEX);
+        /* Left at 0 on failure so the next call retries rather than handing
+         * back a null setup it thinks is current. */
+        m_n = (m_setup != nullptr) ? n : 0;
+        return m_setup;
+    }
+
+  private:
+    PFFFT_Setup* m_setup = nullptr;
+    int m_n = 0;
+};
+
+/**
+ * @brief A Hann window of up to @p MaxN points, recomputed only on a size change.
+ *
+ * @tparam MaxN Largest window the owner will ask for; longer requests are
+ *              rejected rather than overrunning the buffer.
+ */
+template <int MaxN>
+class HannWindowCache {
+  public:
+    /** @brief Window of @p n points, or nullptr when @p n does not fit. */
+    const float*
+    get(int n) {
+        if (n <= 0 || n > MaxN) {
+            return nullptr;
+        }
+        if (m_n == n) {
+            return m_window;
+        }
+        if (n == 1) {
+            m_window[0] = 1.0f;
+        } else {
+            const float scale = 2.0f * static_cast<float>(M_PI) / static_cast<float>(n - 1);
+            for (int i = 0; i < n; i++) {
+                m_window[i] = 0.5f * (1.0f - cosf(scale * static_cast<float>(i)));
+            }
+        }
+        m_n = n;
+        return m_window;
+    }
+
+  private:
+    alignas(16) float m_window[MaxN] = {};
+    int m_n = 0;
+};
+
+} // namespace dsd_io
+
+#endif /* DSD_NEO_SRC_IO_RADIO_RTL_FFT_CACHE_H_ */

--- a/src/io/radio/rtl_fft_cache.h
+++ b/src/io/radio/rtl_fft_cache.h
@@ -21,7 +21,7 @@
 #ifndef DSD_NEO_SRC_IO_RADIO_RTL_FFT_CACHE_H_
 #define DSD_NEO_SRC_IO_RADIO_RTL_FFT_CACHE_H_
 
-#include <cmath>
+#include <dsd-neo/dsp/firdes.h>
 #include <pffft.h>
 
 namespace dsd_io {
@@ -108,12 +108,16 @@ class HannWindowCache {
             return m_window;
         }
         if (n == 1) {
+            /* dsd_window_build() divides by (ntaps - 1), so the degenerate length
+             * is answered here rather than handed to it. */
             m_window[0] = 1.0f;
         } else {
-            const float scale = 2.0f * static_cast<float>(M_PI) / static_cast<float>(n - 1);
-            for (int i = 0; i < n; i++) {
-                m_window[i] = 0.5f * (1.0f - cosf(scale * static_cast<float>(i)));
-            }
+            /* The project's own window builder, not a third copy of the formula:
+             * every other windowed operation in the tree goes through it, and a
+             * correction made there (periodic vs symmetric, an edge case) has to
+             * reach the spectrum taps too or the two views pick up a different
+             * sidelobe floor than everything else that measures the same signal. */
+            dsd_window_build(DSD_WIN_HANN, n, m_window);
         }
         m_n = n;
         return m_window;

--- a/src/io/radio/rtl_fft_cache.h
+++ b/src/io/radio/rtl_fft_cache.h
@@ -41,6 +41,13 @@ namespace dsd_io {
  */
 class FftSetupCache {
   public:
+    FftSetupCache() = default;
+    /* Owns a raw PFFFT_Setup* that get() destroys on a size change, so a copy would
+     * leave two owners of one setup and the second would destroy freed memory. The
+     * instances are file-scope and never copied; this is what keeps it that way. */
+    FftSetupCache(const FftSetupCache&) = delete;
+    FftSetupCache& operator=(const FftSetupCache&) = delete;
+
     /**
      * @brief Forward complex transform of @p n points, in place.
      *

--- a/src/io/radio/rtl_metrics.cpp
+++ b/src/io/radio/rtl_metrics.cpp
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include "rtl_fft_cache.h"
+#include "rtl_spectrum_kernels.h"
 #include "rtl_stream_shared.hpp"
 
 /* Spectrum capture and carrier diagnostics shared with RTL orchestrator. */
@@ -156,17 +157,9 @@ rtl_metrics_prepare_fft_input(const float* iq_interleaved, int pairs, int N, flo
     frame.take = (pairs >= N) ? N : pairs;
     frame.start = pairs - frame.take;
 
-    double sumI = 0.0;
-    double sumQ = 0.0;
-    for (int n = 0; n < frame.take; n++) {
-        int idx = frame.start + n;
-        sumI += static_cast<double>(iq_interleaved[(size_t)(idx << 1)]);
-        sumQ += static_cast<double>(iq_interleaved[(size_t)(idx << 1) + 1]);
-    }
-    if (frame.take > 0) {
-        frame.meanI = static_cast<float>(sumI / static_cast<double>(frame.take));
-        frame.meanQ = static_cast<float>(sumQ / static_cast<double>(frame.take));
-    }
+    const dsd_io::IqBlockMean mean = dsd_io::iq_block_mean(iq_interleaved, frame.start, frame.take);
+    frame.meanI = mean.i;
+    frame.meanQ = mean.q;
 
     if (frame.take < N) {
         for (int n = 0; n < (N << 1); n++) {
@@ -185,14 +178,10 @@ rtl_metrics_prepare_fft_input(const float* iq_interleaved, int pairs, int N, flo
         frame.take = 0;
         return frame;
     }
-    for (int n = 0; n < frame.take; n++) {
-        int idx = frame.start + n;
-        float I = iq_interleaved[(size_t)(idx << 1)];
-        float Q = iq_interleaved[(size_t)(idx << 1) + 1];
-        float w = hann[n];
-        z[(n << 1)] = w * (I - frame.meanI);
-        z[(n << 1) + 1] = w * (Q - frame.meanQ);
-    }
+    /* The leading frame.take points of an N-point window when the block is
+     * short — a partial window, but the tail of z was zeroed above, so the
+     * transform sees a shorter record rather than a discontinuity. */
+    dsd_io::iq_window_dc_removed(iq_interleaved, frame.start, frame.take, hann, mean, z);
     return frame;
 }
 
@@ -224,21 +213,15 @@ rtl_metrics_phase_cfo_hz(const float* iq_interleaved, const rtl_metrics_fft_fram
     return atan2(acc_im, acc_re) * static_cast<double>(out_rate_hz) / (2.0 * M_PI);
 }
 
+/* Share of each new frame in the smoothed bins. Light, because these feed the
+ * auto-gain spectral gate and a peak search: a decision taken off one noisy
+ * frame is a gain step taken for no reason. */
+static const float kSpecEmaNewWeight = 0.2f;
+
 static void
 rtl_metrics_smooth_spectrum_bins(int N, int out_rate_hz, const float* z) {
-    const float eps = 1e-12f;
     const bool first = (g_spec_ready.load(std::memory_order_relaxed) == 0);
-    for (int k = 0; k < N; k++) {
-        int kk = k + (N >> 1);
-        if (kk >= N) {
-            kk -= N;
-        }
-        float re = z[(kk << 1)];
-        float im = z[(kk << 1) + 1];
-        float mag2 = re * re + im * im;
-        float db = 10.0f * log10f(mag2 + eps);
-        g_spec_db[k] = first ? db : (0.8f * g_spec_db[k] + 0.2f * db);
-    }
+    dsd_io::spectrum_fold_db(z, N, kSpecEmaNewWeight, first, g_spec_db);
     g_spec_rate_hz.store(out_rate_hz, std::memory_order_relaxed);
     g_spec_ready.store(1, std::memory_order_release);
 }

--- a/src/io/radio/rtl_metrics.cpp
+++ b/src/io/radio/rtl_metrics.cpp
@@ -21,6 +21,7 @@
 #include <pffft.h>
 #include <string.h>
 
+#include "rtl_fft_cache.h"
 #include "rtl_stream_shared.hpp"
 
 /* Spectrum capture and carrier diagnostics shared with RTL orchestrator. */
@@ -108,39 +109,11 @@ cqpsk_loop_lock_heuristic(float total_freq_rad, int out_rate_hz) {
     return (freq_stable_blocks >= 2 && ted_lock > 0.25f && costas_err < 0.65f && fll_abs < fll_lock_limit) ? 1 : 0;
 }
 
-static inline PFFFT_Setup*
-pffft_get_cached_setup(int N) {
-    static PFFFT_Setup* setup = nullptr;
-    static int setup_N = 0;
-    if (!setup || setup_N != N) {
-        if (setup) {
-            pffft_destroy_setup(setup);
-            setup = nullptr;
-            setup_N = 0;
-        }
-        setup = pffft_new_setup(N, PFFFT_COMPLEX);
-        setup_N = N;
-    }
-    return setup;
-}
-
-static inline const float*
-rtl_metrics_hann_window(int N) {
-    alignas(16) static float window[kSpecMaxN];
-    static int window_N = 0;
-    if (window_N != N) {
-        if (N <= 1) {
-            window[0] = 1.0f;
-        } else {
-            const float scale = 2.0f * static_cast<float>(M_PI) / static_cast<float>(N - 1);
-            for (int n = 0; n < N; n++) {
-                window[n] = 0.5f * (1.0f - cosf(scale * static_cast<float>(n)));
-            }
-        }
-        window_N = N;
-    }
-    return window;
-}
+/* This tap's own caches. Kept separate from the wideband tap's by construction:
+ * the two analyse different sizes on this same thread, so one shared cache
+ * would rebuild the pffft setup on every alternating call. */
+static dsd_io::FftSetupCache g_spec_fft_setup;
+static dsd_io::HannWindowCache<kSpecMaxN> g_spec_hann;
 
 namespace {
 
@@ -202,7 +175,17 @@ rtl_metrics_prepare_fft_input(const float* iq_interleaved, int pairs, int N, flo
         }
     }
 
-    const float* hann = rtl_metrics_hann_window(N);
+    const float* hann = g_spec_hann.get(N);
+    if (hann == nullptr) {
+        /* N is clamped to [64, kSpecMaxN] upstream, so this is unreachable in
+         * practice. Hand back a silent frame rather than transforming whatever
+         * the buffer happened to hold. */
+        for (int n = 0; n < (N << 1); n++) {
+            z[n] = 0.0f;
+        }
+        frame.take = 0;
+        return frame;
+    }
     for (int n = 0; n < frame.take; n++) {
         int idx = frame.start + n;
         float I = iq_interleaved[(size_t)(idx << 1)];
@@ -385,7 +368,7 @@ rtl_metrics_update_spectrum_from_iq(const float* iq_interleaved, int len_interle
     double phase_cfo_hz = rtl_metrics_phase_cfo_hz(iq_interleaved, frame, out_rate_hz);
     g_resid_cfo_phase_hz.store(phase_cfo_hz, std::memory_order_relaxed);
 
-    PFFFT_Setup* setup = pffft_get_cached_setup(N);
+    PFFFT_Setup* setup = g_spec_fft_setup.get(N);
     if (setup) {
         pffft_transform_ordered(setup, z, z, nullptr, PFFFT_FORWARD);
         rtl_metrics_smooth_spectrum_bins(N, out_rate_hz, z);

--- a/src/io/radio/rtl_metrics.cpp
+++ b/src/io/radio/rtl_metrics.cpp
@@ -18,7 +18,6 @@
 #include <dsd-neo/dsp/ted.h>
 #include <dsd-neo/io/rtl_metrics.h>
 #include <dsd-neo/io/rtl_stream_c.h>
-#include <pffft.h>
 #include <string.h>
 
 #include "rtl_fft_cache.h"
@@ -368,9 +367,7 @@ rtl_metrics_update_spectrum_from_iq(const float* iq_interleaved, int len_interle
     double phase_cfo_hz = rtl_metrics_phase_cfo_hz(iq_interleaved, frame, out_rate_hz);
     g_resid_cfo_phase_hz.store(phase_cfo_hz, std::memory_order_relaxed);
 
-    PFFFT_Setup* setup = g_spec_fft_setup.get(N);
-    if (setup) {
-        pffft_transform_ordered(setup, z, z, nullptr, PFFFT_FORWARD);
+    if (g_spec_fft_setup.forward(N, z)) {
         rtl_metrics_smooth_spectrum_bins(N, out_rate_hz, z);
     }
     rtl_metrics_peak_metrics peak = rtl_metrics_compute_peak_metrics(N);

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -4132,6 +4132,15 @@ rtl_replay_on_retune_event(const dsd_iq_event* event, void* user) {
         (event->capture_center_frequency_hz > UINT32_MAX) ? UINT32_MAX : (uint32_t)event->capture_center_frequency_hz;
     store_dongle_frequency(capture_hz);
     store_dongle_rate(event->sample_rate_hz);
+    /* The two inputs the wideband spectrum tap has, kept together with the move.
+     * demod_feed_wideband_spectrum() reads load_dongle_rate() for the span and
+     * last_applied_freq_hz for the centre, so leaving the centre behind publishes
+     * the new band's bins under the old band's label -- and without the clear the
+     * EMA blends the two bands together first, because the generation the producer
+     * compares against never moved. The RESET sibling below gets both through
+     * drain_output_on_retune() and controller_finalize_reconfigure(). */
+    controller.last_applied_freq_hz.store(center_hz, std::memory_order_release);
+    rtl_wideband_spectrum_clear();
     g_replay_event_last_frequency_hz.store(center_hz, std::memory_order_release);
     g_replay_event_retune_count.fetch_add(1U, std::memory_order_acq_rel);
 }

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -74,6 +74,7 @@
 #include "rtl_replay_device.h"
 #include "rtl_stream_mirrors.hpp"
 #include "rtl_stream_shared.hpp"
+#include "rtl_wideband_spectrum.h"
 #if defined(DSD_NEO_ENABLE_INTERNAL_TEST_HOOKS)
 #include "rtl_stream_test_support.h"
 #endif
@@ -1462,6 +1463,7 @@ drain_output_on_retune(void) {
      * degraded SNR even when the DSP is performing correctly. */
     constellation_ring_clear();
     eye_ring_clear();
+    rtl_wideband_spectrum_clear();
     snr_ema_reset();
 
     if (force_clear || drain_ms == 0) {
@@ -3433,6 +3435,22 @@ demod_prepare_iteration_processing(const struct demod_state* d, const DemodInput
     return 1;
 }
 
+/**
+ * @brief Offer the pre-decimation block to the wideband spectrum tap.
+ *
+ * Must run before full_demod(): its very first step is the half-band cascade
+ * that rebinds d->lowpassed to the narrow demod rate. Here the block is still
+ * interleaved float I/Q at the capture rate, and ingest has already rotated the
+ * fs/4 hardware offset back out, so the FFT is centered on the frequency the
+ * controller last applied. This is a no-op (and costs nothing) unless a UI has
+ * enabled wideband spectrum production.
+ */
+static inline void
+demod_feed_wideband_spectrum(const struct demod_state* d) {
+    rtl_wideband_spectrum_maybe_update(d->lowpassed, d->lp_len, load_dongle_rate(),
+                                       controller.last_applied_freq_hz.load(std::memory_order_acquire));
+}
+
 static DSD_THREAD_RETURN_TYPE
 #if DSD_PLATFORM_WIN_NATIVE
     __stdcall
@@ -3464,6 +3482,7 @@ static DSD_THREAD_RETURN_TYPE
         if (!consumed_fsk_reacquire) {
             (void)rtl_stream_consume_fsk_modem_reset_pending(d);
         }
+        demod_feed_wideband_spectrum(d);
         full_demod(d);
         g_channel_pwr.store(d->channel_pwr, std::memory_order_relaxed);
         rtl_stream_publish_demod_profile_snapshot();

--- a/src/io/radio/rtl_spectrum_kernels.h
+++ b/src/io/radio/rtl_spectrum_kernels.h
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief The per-block arithmetic both radio spectrum taps run.
+ *
+ * Companion to rtl_fft_cache.h: that header holds the state the narrow tap in
+ * rtl_metrics.cpp and the wideband tap in rtl_wideband_spectrum.cpp each keep an
+ * instance of, this one holds the arithmetic they share outright. Both remove
+ * the block's DC before windowing, and both fold the transform into a display
+ * array with the same fftshift and the same dB conversion; only the smoothing
+ * weight and where the result lands differ.
+ *
+ * Worth one copy rather than two because the two taps are read against each
+ * other — the wideband one exists precisely because the narrow one's sizing and
+ * smoothing may not be retuned — so a silent divergence in the bin order or the
+ * dB reference would show up as the two views disagreeing about the same signal,
+ * with nothing in either file to point at.
+ */
+
+#ifndef DSD_NEO_SRC_IO_RADIO_RTL_SPECTRUM_KERNELS_H_
+#define DSD_NEO_SRC_IO_RADIO_RTL_SPECTRUM_KERNELS_H_
+
+#include <cmath>
+#include <stddef.h>
+
+namespace dsd_io {
+
+/** @brief Mean I and Q of a block, the DC offset removed before windowing. */
+struct IqBlockMean {
+    float i = 0.0f;
+    float q = 0.0f;
+};
+
+/**
+ * @brief Mean of @p n complex pairs of @p iq_interleaved starting at @p start.
+ *
+ * Accumulated in double: an RTL front end's DC offset is a large fraction of
+ * full scale, and summing thousands of samples of it in float loses the low
+ * bits of exactly the quantity being measured.
+ *
+ * @return Zero for a non-positive @p n, so a caller that skips the window loop
+ *         subtracts nothing rather than a NaN.
+ */
+inline IqBlockMean
+iq_block_mean(const float* iq_interleaved, int start, int n) {
+    IqBlockMean mean;
+    if (iq_interleaved == nullptr || n <= 0) {
+        return mean;
+    }
+    double sum_i = 0.0;
+    double sum_q = 0.0;
+    for (int k = 0; k < n; k++) {
+        const size_t idx = static_cast<size_t>(start + k) << 1;
+        sum_i += static_cast<double>(iq_interleaved[idx]);
+        sum_q += static_cast<double>(iq_interleaved[idx + 1]);
+    }
+    mean.i = static_cast<float>(sum_i / static_cast<double>(n));
+    mean.q = static_cast<float>(sum_q / static_cast<double>(n));
+    return mean;
+}
+
+/**
+ * @brief Window @p n pairs from @p start into @p z with @p mean removed.
+ *
+ * The mean is subtracted before windowing because the residual DC of an RTL
+ * front end is large enough to bury the middle of a display in a spike that is
+ * not a signal — and, on the narrow tap, to be mistaken for the carrier the peak
+ * search is looking for.
+ *
+ * @param hann Window of at least @p n points. Callers that analyse fewer pairs
+ *             than their transform size pass the leading @p n of a longer
+ *             window, and are expected to have zeroed the tail of @p z.
+ * @param z Destination for 2*@p n interleaved floats.
+ */
+inline void
+iq_window_dc_removed(const float* iq_interleaved, int start, int n, const float* hann, IqBlockMean mean, float* z) {
+    if (iq_interleaved == nullptr || hann == nullptr || z == nullptr) {
+        return;
+    }
+    for (int k = 0; k < n; k++) {
+        const size_t idx = static_cast<size_t>(start + k) << 1;
+        const float w = hann[k];
+        z[static_cast<size_t>(k) << 1] = w * (iq_interleaved[idx] - mean.i);
+        z[(static_cast<size_t>(k) << 1) + 1] = w * (iq_interleaved[idx + 1] - mean.q);
+    }
+}
+
+/**
+ * @brief Fold an ordered transform into @p inout_db as smoothed dB, fftshifted.
+ *
+ * fftshift as it goes: bin 0 becomes center - rate/2 and bin n/2 becomes DC,
+ * which is the order both taps' consumers expect of the arrays they read.
+ *
+ * @param new_weight Share of the new frame in the exponential average, in
+ *                   [0, 1]. Smoothing is what stops a display flickering between
+ *                   frames; the two taps weigh it differently because one feeds
+ *                   a waterfall and the other a gain gate.
+ * @param seed True to write the new frame outright instead of blending. The
+ *             first frame has nothing to blend with, and after a retune the old
+ *             band must not bleed into the new one.
+ * @param inout_db Destination of @p n floats, read as the previous frame unless
+ *                 @p seed is set.
+ */
+inline void
+spectrum_fold_db(const float* z, int n, float new_weight, bool seed, float* inout_db) {
+    if (z == nullptr || inout_db == nullptr) {
+        return;
+    }
+    /* Never zero: a bin with no energy would otherwise be log10(0). */
+    const float eps = 1e-12f;
+    const float old_weight = 1.0f - new_weight;
+    for (int k = 0; k < n; k++) {
+        int kk = k + (n >> 1);
+        if (kk >= n) {
+            kk -= n;
+        }
+        const float re = z[static_cast<size_t>(kk) << 1];
+        const float im = z[(static_cast<size_t>(kk) << 1) + 1];
+        const float db = 10.0f * log10f(re * re + im * im + eps);
+        inout_db[k] = seed ? db : (new_weight * db + old_weight * inout_db[k]);
+    }
+}
+
+} // namespace dsd_io
+
+#endif /* DSD_NEO_SRC_IO_RADIO_RTL_SPECTRUM_KERNELS_H_ */

--- a/src/io/radio/rtl_wideband_spectrum.cpp
+++ b/src/io/radio/rtl_wideband_spectrum.cpp
@@ -7,15 +7,19 @@
  * @file
  * @brief Wideband (capture-rate) spectrum snapshots for the graphical spectrum view.
  *
- * The FFT plumbing here — cached pffft setup, cached Hann window, dB
- * conversion, fftshift, EMA smoothing — deliberately mirrors rtl_metrics.cpp
- * rather than sharing it. That module publishes a *narrow*, post-decimation
- * spectrum at the demod output rate which feeds the supervisory tuner
- * auto-gain gate (`demod_autogain_spectral_gate_ok()`); retuning its size,
- * rate, or smoothing to also serve a UI would regress gain control. This
- * module taps the block before decimation instead, costs nothing until a
- * consumer enables it, and carries the tuned center and span alongside the
- * bins so the consumer can label a frequency axis.
+ * Separate from rtl_metrics.cpp on purpose. That module publishes a *narrow*,
+ * post-decimation spectrum at the demod output rate which feeds the supervisory
+ * tuner auto-gain gate (`demod_autogain_spectral_gate_ok()`); retuning its size,
+ * rate, or smoothing to also serve a UI would regress gain control. This module
+ * taps the block before decimation instead, costs nothing until a consumer
+ * enables it, and carries the tuned center and span alongside the bins so the
+ * consumer can label a frequency axis.
+ *
+ * Only the generic plumbing both need — a cached pffft setup and a cached Hann
+ * window — is shared, through rtl_fft_cache.h, as caches each module owns an
+ * instance of. Sharing the *state* would be wrong: the two run on this same
+ * thread at different sizes, so one cache between them would destroy and
+ * rebuild the setup on every alternating call.
  *
  * Threading: `rtl_wideband_spectrum_maybe_update()` runs on the demod thread
  * and is the only writer. Readers may call `rtl_stream_wideband_spectrum_get()`
@@ -26,30 +30,32 @@
 
 #include <atomic>
 #include <cmath>
+#include <dsd-neo/core/wideband_spectrum.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/timing.h>
 #include <pffft.h>
 #include <stddef.h>
 #include <stdint.h>
 
+#include "rtl_fft_cache.h"
 #include "rtl_wideband_spectrum.h"
 
 namespace {
 
-constexpr int kWbSpecMinN = 256;
-constexpr int kWbSpecMaxN = 2048;
-constexpr int kWbSpecDefaultN = 1024;
-/* ~15 FPS: enough for a readable waterfall, cheap enough to ride the demod thread. */
-constexpr uint64_t kWbSpecMinPeriodNs = 66ULL * 1000ULL * 1000ULL;
-/* Seqlock reads are best-effort: give the writer a few chances, then take what we have. */
+/* One published size, so a consumer's buffer, its frequency axis and the FFT
+ * can never disagree. See <dsd-neo/core/wideband_spectrum.h>. */
+constexpr int kWbSpecN = DSD_WIDEBAND_SPECTRUM_BINS;
+constexpr uint64_t kWbSpecMinPeriodNs = static_cast<uint64_t>(DSD_WIDEBAND_SPECTRUM_PERIOD_MS) * 1000ULL * 1000ULL;
+/* Seqlock reads are best-effort: give the writer a few chances, then give up.
+ * Reporting no frame is safe (the consumer holds its last picture); reporting a
+ * torn one is not. */
 constexpr int kWbSpecReadAttempts = 4;
 
 std::atomic<int> g_wb_enabled{0};
-std::atomic<int> g_wb_n{kWbSpecDefaultN};
 
-/* Bumped by clear()/set_size()/disable. A published frame is only valid while
- * its stamped generation still matches, which invalidates stale frames without
- * needing a second writer on the seqlock below. */
+/* Bumped by clear()/disable. A published frame is only valid while its stamped
+ * generation still matches, which invalidates stale frames without needing a
+ * second writer on the seqlock below. */
 std::atomic<uint32_t> g_wb_clear_gen{0};
 
 /* Published frame. Written only by the demod thread, guarded by g_wb_seq.
@@ -57,87 +63,105 @@ std::atomic<uint32_t> g_wb_clear_gen{0};
  * model as well as in practice; on every supported target these lower to plain
  * loads and stores. */
 std::atomic<uint32_t> g_wb_seq{0}; /* odd => writer in progress */
-std::atomic<float> g_wb_pub_db[kWbSpecMaxN];
+std::atomic<float> g_wb_pub_db[kWbSpecN];
 std::atomic<int> g_wb_pub_n{0};
 std::atomic<uint32_t> g_wb_pub_center_hz{0};
 std::atomic<uint32_t> g_wb_pub_span_hz{0};
 std::atomic<uint32_t> g_wb_pub_gen{0};
+/* Serial number of the published frame. A consumer polls on its own clock, so
+ * without this it cannot tell a new frame from a re-read of the one it already
+ * drew — and a waterfall would scroll duplicate rows. Kept in the payload
+ * rather than inferred from g_wb_seq so frame identity does not depend on how
+ * the lock happens to count. */
+std::atomic<uint32_t> g_wb_pub_serial{0};
+
+#ifdef DSD_NEO_TEST_HOOKS
+/* Makes every read attempt observe a writer landing inside it. A torn read is
+ * otherwise a race no single-threaded test can stage, and "what the reader does
+ * when it never gets a clean copy" is the whole question. */
+std::atomic<int> g_wb_test_tear{0};
+#endif
 
 /* Demod-thread-private state (never touched by readers). */
 uint64_t g_wb_last_publish_ns = 0;
-float g_wb_ema[kWbSpecMaxN];
+float g_wb_ema[kWbSpecN];
 int g_wb_ema_valid = 0;
 uint32_t g_wb_seen_clear_gen = 0;
+uint32_t g_wb_next_serial = 1;
 
-PFFFT_Setup*
-wb_cached_setup(int n) {
-    static PFFFT_Setup* setup = nullptr;
-    static int setup_n = 0;
-    if (!setup || setup_n != n) {
-        if (setup) {
-            pffft_destroy_setup(setup);
-            setup = nullptr;
-            setup_n = 0;
-        }
-        setup = pffft_new_setup(n, PFFFT_COMPLEX);
-        setup_n = setup ? n : 0;
-    }
-    return setup;
-}
-
-const float*
-wb_hann_window(int n) {
-    alignas(16) static float window[kWbSpecMaxN];
-    static int window_n = 0;
-    if (window_n != n) {
-        if (n <= 1) {
-            window[0] = 1.0f;
-        } else {
-            const float scale = 2.0f * static_cast<float>(M_PI) / static_cast<float>(n - 1);
-            for (int i = 0; i < n; i++) {
-                window[i] = 0.5f * (1.0f - cosf(scale * static_cast<float>(i)));
-            }
-        }
-        window_n = n;
-    }
-    return window;
-}
-
-int
-wb_clamp_size(int n) {
-    if (n < kWbSpecMinN) {
-        n = kWbSpecMinN;
-    }
-    if (n > kWbSpecMaxN) {
-        n = kWbSpecMaxN;
-    }
-    int p = kWbSpecMinN;
-    while (p < n) {
-        p <<= 1;
-    }
-    if (p > kWbSpecMaxN) {
-        p = kWbSpecMaxN;
-    }
-    return p;
-}
+dsd_io::FftSetupCache g_wb_fft_setup;
+dsd_io::HannWindowCache<kWbSpecN> g_wb_hann;
 
 void
 wb_bump_clear_gen(void) {
     g_wb_clear_gen.fetch_add(1, std::memory_order_acq_rel);
 }
 
+/**
+ * @brief Window @p n complex pairs starting at @p start into @p z, DC removed.
+ *
+ * The mean is subtracted before windowing because the residual DC of an RTL
+ * front end is large enough to bury the middle of the display in a spike that
+ * is not a signal.
+ */
 void
-wb_publish(const float* db, int n, uint32_t center_hz, uint32_t span_hz, uint32_t gen) {
+wb_window_block(const float* iq_interleaved, int start, int n, const float* hann, float* z) {
+    double sum_i = 0.0;
+    double sum_q = 0.0;
+    for (int k = 0; k < n; k++) {
+        const size_t idx = static_cast<size_t>(start + k) << 1;
+        sum_i += static_cast<double>(iq_interleaved[idx]);
+        sum_q += static_cast<double>(iq_interleaved[idx + 1]);
+    }
+    const float mean_i = static_cast<float>(sum_i / static_cast<double>(n));
+    const float mean_q = static_cast<float>(sum_q / static_cast<double>(n));
+
+    for (int k = 0; k < n; k++) {
+        const size_t idx = static_cast<size_t>(start + k) << 1;
+        const float w = hann[k];
+        z[static_cast<size_t>(k) << 1] = w * (iq_interleaved[idx] - mean_i);
+        z[(static_cast<size_t>(k) << 1) + 1] = w * (iq_interleaved[idx + 1] - mean_q);
+    }
+}
+
+/**
+ * @brief Convert @p z to dB in display order and smooth it into the EMA.
+ *
+ * fftshift as it goes: bin 0 is center - span/2 and bin n/2 is DC, which is the
+ * order the published frame promises. The EMA is what keeps a waterfall from
+ * flickering between frames; it is seeded rather than blended on the first
+ * frame after a clear, so a retune shows the new band immediately.
+ */
+void
+wb_fold_into_ema(const float* z, int n) {
+    const float eps = 1e-12f;
+    const bool seed = (g_wb_ema_valid == 0);
+    for (int k = 0; k < n; k++) {
+        int kk = k + (n >> 1);
+        if (kk >= n) {
+            kk -= n;
+        }
+        const float re = z[static_cast<size_t>(kk) << 1];
+        const float im = z[(static_cast<size_t>(kk) << 1) + 1];
+        const float db = 10.0f * log10f(re * re + im * im + eps);
+        g_wb_ema[k] = seed ? db : (0.6f * db + 0.4f * g_wb_ema[k]);
+    }
+    g_wb_ema_valid = 1;
+}
+
+void
+wb_publish(const float* db, uint32_t center_hz, uint32_t span_hz, uint32_t gen, uint32_t serial) {
     const uint32_t s = g_wb_seq.load(std::memory_order_relaxed);
     g_wb_seq.store(s + 1u, std::memory_order_release); /* odd: writer active */
     std::atomic_thread_fence(std::memory_order_release);
-    for (int i = 0; i < n; i++) {
+    for (int i = 0; i < kWbSpecN; i++) {
         g_wb_pub_db[i].store(db[i], std::memory_order_relaxed);
     }
-    g_wb_pub_n.store(n, std::memory_order_relaxed);
+    g_wb_pub_n.store(kWbSpecN, std::memory_order_relaxed);
     g_wb_pub_center_hz.store(center_hz, std::memory_order_relaxed);
     g_wb_pub_span_hz.store(span_hz, std::memory_order_relaxed);
     g_wb_pub_gen.store(gen, std::memory_order_relaxed);
+    g_wb_pub_serial.store(serial, std::memory_order_relaxed);
     g_wb_seq.store(s + 2u, std::memory_order_release); /* even: frame complete */
 }
 
@@ -146,9 +170,9 @@ wb_publish(const float* db, int n, uint32_t center_hz, uint32_t span_hz, uint32_
 /**
  * @brief Fold one capture-rate I/Q block into the published wideband spectrum.
  *
- * See rtl_wideband_spectrum.h. Skips blocks shorter than the configured FFT
- * size rather than zero-padding them, so the published span always reflects a
- * full analysis window.
+ * See rtl_wideband_spectrum.h. Skips blocks shorter than the FFT size rather
+ * than zero-padding them, so the published span always reflects a full analysis
+ * window.
  */
 void
 rtl_wideband_spectrum_maybe_update(const float* iq_interleaved, int len_interleaved, uint32_t capture_rate_hz,
@@ -165,7 +189,7 @@ rtl_wideband_spectrum_maybe_update(const float* iq_interleaved, int len_interlea
         return;
     }
 
-    const int n = wb_clamp_size(g_wb_n.load(std::memory_order_relaxed));
+    const int n = kWbSpecN;
     const int pairs = len_interleaved >> 1;
     if (pairs < n) {
         return;
@@ -177,51 +201,21 @@ rtl_wideband_spectrum_maybe_update(const float* iq_interleaved, int len_interlea
         g_wb_ema_valid = 0;
     }
 
-    PFFFT_Setup* setup = wb_cached_setup(n);
-    if (!setup) {
+    PFFFT_Setup* setup = g_wb_fft_setup.get(n);
+    const float* hann = g_wb_hann.get(n);
+    if (!setup || !hann) {
         return;
     }
 
     /* Analyse the most recent n pairs of the block. */
-    alignas(16) static float z[2 * kWbSpecMaxN];
-    const int start = pairs - n;
-
-    double sum_i = 0.0;
-    double sum_q = 0.0;
-    for (int k = 0; k < n; k++) {
-        const size_t idx = static_cast<size_t>(start + k) << 1;
-        sum_i += static_cast<double>(iq_interleaved[idx]);
-        sum_q += static_cast<double>(iq_interleaved[idx + 1]);
-    }
-    const float mean_i = static_cast<float>(sum_i / static_cast<double>(n));
-    const float mean_q = static_cast<float>(sum_q / static_cast<double>(n));
-
-    const float* hann = wb_hann_window(n);
-    for (int k = 0; k < n; k++) {
-        const size_t idx = static_cast<size_t>(start + k) << 1;
-        const float w = hann[k];
-        z[static_cast<size_t>(k) << 1] = w * (iq_interleaved[idx] - mean_i);
-        z[(static_cast<size_t>(k) << 1) + 1] = w * (iq_interleaved[idx + 1] - mean_q);
-    }
-
+    alignas(16) static float z[2 * kWbSpecN];
+    wb_window_block(iq_interleaved, pairs - n, n, hann, z);
     pffft_transform_ordered(setup, z, z, nullptr, PFFFT_FORWARD);
+    wb_fold_into_ema(z, n);
 
-    /* fftshift into display order: bin 0 is center - span/2, bin n/2 is DC. */
-    const float eps = 1e-12f;
-    const bool seed = (g_wb_ema_valid == 0);
-    for (int k = 0; k < n; k++) {
-        int kk = k + (n >> 1);
-        if (kk >= n) {
-            kk -= n;
-        }
-        const float re = z[static_cast<size_t>(kk) << 1];
-        const float im = z[(static_cast<size_t>(kk) << 1) + 1];
-        const float db = 10.0f * log10f(re * re + im * im + eps);
-        g_wb_ema[k] = seed ? db : (0.6f * db + 0.4f * g_wb_ema[k]);
-    }
-    g_wb_ema_valid = 1;
-
-    wb_publish(g_wb_ema, n, center_freq_hz, capture_rate_hz, gen);
+    wb_publish(g_wb_ema, center_freq_hz, capture_rate_hz, gen, g_wb_next_serial);
+    /* Serial 0 is "no frame", so skip it on the wrap. */
+    g_wb_next_serial = (g_wb_next_serial == UINT32_MAX) ? 1u : (g_wb_next_serial + 1u);
     g_wb_last_publish_ns = now_ns;
 }
 
@@ -237,7 +231,64 @@ void
 rtl_wideband_spectrum_test_reset_throttle(void) {
     g_wb_last_publish_ns = 0;
 }
+
+/** @brief Make every read attempt tear; see rtl_wideband_spectrum.h. */
+void
+rtl_wideband_spectrum_test_set_tear(int on) {
+    g_wb_test_tear.store(on ? 1 : 0, std::memory_order_relaxed);
+}
 #endif
+
+namespace {
+
+/** @brief Everything published alongside a frame's bins. */
+struct WbFrameHeader {
+    uint32_t center_hz = 0;
+    uint32_t span_hz = 0;
+    uint32_t gen = 0;
+    uint32_t serial = 0;
+    int bins = 0;
+};
+
+/**
+ * @brief Copy the published frame and its header under the seqlock.
+ *
+ * @param out_db Destination for the bins; must hold kWbSpecN floats.
+ * @return true when one publish was captured whole. False means every attempt
+ *         had the writer land inside it — the caller must report no frame
+ *         rather than pass on bins that may straddle two publishes.
+ */
+bool
+wb_read_frame(float* out_db, WbFrameHeader* out) {
+    for (int attempt = 0; attempt < kWbSpecReadAttempts; attempt++) {
+        const uint32_t s1 = g_wb_seq.load(std::memory_order_acquire);
+        if ((s1 & 1u) != 0u) {
+            continue; /* writer mid-frame */
+        }
+        int n = g_wb_pub_n.load(std::memory_order_relaxed);
+        n = (n < 0) ? 0 : ((n > kWbSpecN) ? kWbSpecN : n);
+        for (int i = 0; i < n; i++) {
+            out_db[i] = g_wb_pub_db[i].load(std::memory_order_relaxed);
+        }
+        out->bins = n;
+        out->center_hz = g_wb_pub_center_hz.load(std::memory_order_relaxed);
+        out->span_hz = g_wb_pub_span_hz.load(std::memory_order_relaxed);
+        out->gen = g_wb_pub_gen.load(std::memory_order_relaxed);
+        out->serial = g_wb_pub_serial.load(std::memory_order_relaxed);
+#ifdef DSD_NEO_TEST_HOOKS
+        if (g_wb_test_tear.load(std::memory_order_relaxed) != 0) {
+            g_wb_seq.fetch_add(2u, std::memory_order_release);
+        }
+#endif
+        std::atomic_thread_fence(std::memory_order_acquire);
+        if (g_wb_seq.load(std::memory_order_relaxed) == s1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
 
 /**
  * @brief Copy the latest wideband spectrum frame.
@@ -245,79 +296,42 @@ rtl_wideband_spectrum_test_reset_throttle(void) {
  * See the doc comment on the declaration in <dsd-neo/io/rtl_stream_c.h>.
  */
 extern "C" int
-rtl_stream_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz, uint32_t* out_span_hz) {
-    if (!out_db || max_bins <= 0) {
+rtl_stream_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz, uint32_t* out_span_hz,
+                                 uint32_t* out_frame_serial) {
+    if (!out_db) {
+        return 0;
+    }
+    /* Every frame is the full DSD_WIDEBAND_SPECTRUM_BINS wide. Writing a prefix
+     * of one into a smaller buffer would hand back the low end of the span
+     * labelled as the whole of it, so a short buffer is refused instead. */
+    if (max_bins < kWbSpecN) {
         return 0;
     }
     if (g_wb_enabled.load(std::memory_order_relaxed) == 0) {
         return 0;
     }
 
-    const int cap = (max_bins < kWbSpecMaxN) ? max_bins : kWbSpecMaxN;
-    int copied = 0;
-    uint32_t center_hz = 0;
-    uint32_t span_hz = 0;
-    uint32_t gen = 0;
-    for (int attempt = 0; attempt < kWbSpecReadAttempts; attempt++) {
-        const uint32_t s1 = g_wb_seq.load(std::memory_order_acquire);
-        if ((s1 & 1u) != 0u) {
-            continue; /* writer mid-frame */
-        }
-        int n = g_wb_pub_n.load(std::memory_order_relaxed);
-        if (n > cap) {
-            n = cap;
-        }
-        if (n < 0) {
-            n = 0;
-        }
-        for (int i = 0; i < n; i++) {
-            out_db[i] = g_wb_pub_db[i].load(std::memory_order_relaxed);
-        }
-        center_hz = g_wb_pub_center_hz.load(std::memory_order_relaxed);
-        span_hz = g_wb_pub_span_hz.load(std::memory_order_relaxed);
-        gen = g_wb_pub_gen.load(std::memory_order_relaxed);
-        copied = n;
-        std::atomic_thread_fence(std::memory_order_acquire);
-        if (g_wb_seq.load(std::memory_order_relaxed) == s1) {
-            break;
-        }
-    }
-
-    if (copied <= 0) {
+    WbFrameHeader header;
+    /* A copy the writer ran through is not a frame: its bins may straddle two
+     * publishes, and the axis it came with may belong to either. */
+    if (!wb_read_frame(out_db, &header) || header.bins <= 0) {
         return 0;
     }
-    /* Retune / resize / disable since this frame was published: report no data
-     * rather than mislabelled bins. */
-    if (gen != g_wb_clear_gen.load(std::memory_order_acquire)) {
+    /* Retune / disable since this frame was published: report no data rather
+     * than mislabelled bins. */
+    if (header.gen != g_wb_clear_gen.load(std::memory_order_acquire)) {
         return 0;
     }
     if (out_center_freq_hz) {
-        *out_center_freq_hz = center_hz;
+        *out_center_freq_hz = header.center_hz;
     }
     if (out_span_hz) {
-        *out_span_hz = span_hz;
+        *out_span_hz = header.span_hz;
     }
-    return copied;
-}
-
-/**
- * @brief Set the wideband FFT size.
- *
- * See the doc comment on the declaration in <dsd-neo/io/rtl_stream_c.h>.
- */
-extern "C" int
-rtl_stream_wideband_spectrum_set_size(int n) {
-    const int p = wb_clamp_size(n);
-    if (g_wb_n.exchange(p, std::memory_order_relaxed) != p) {
-        wb_bump_clear_gen();
+    if (out_frame_serial) {
+        *out_frame_serial = header.serial;
     }
-    return p;
-}
-
-/** @brief Get the current wideband FFT size in bins. */
-extern "C" int
-rtl_stream_wideband_spectrum_get_size(void) {
-    return wb_clamp_size(g_wb_n.load(std::memory_order_relaxed));
+    return header.bins;
 }
 
 /** @brief Enable or disable wideband spectrum production. */

--- a/src/io/radio/rtl_wideband_spectrum.cpp
+++ b/src/io/radio/rtl_wideband_spectrum.cpp
@@ -33,7 +33,6 @@
 #include <dsd-neo/core/wideband_spectrum.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/timing.h>
-#include <pffft.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -201,16 +200,17 @@ rtl_wideband_spectrum_maybe_update(const float* iq_interleaved, int len_interlea
         g_wb_ema_valid = 0;
     }
 
-    PFFFT_Setup* setup = g_wb_fft_setup.get(n);
     const float* hann = g_wb_hann.get(n);
-    if (!setup || !hann) {
+    if (!hann) {
         return;
     }
 
     /* Analyse the most recent n pairs of the block. */
     alignas(16) static float z[2 * kWbSpecN];
     wb_window_block(iq_interleaved, pairs - n, n, hann, z);
-    pffft_transform_ordered(setup, z, z, nullptr, PFFFT_FORWARD);
+    if (!g_wb_fft_setup.forward(n, z)) {
+        return;
+    }
     wb_fold_into_ema(z, n);
 
     wb_publish(g_wb_ema, center_freq_hz, capture_rate_hz, gen, g_wb_next_serial);
@@ -311,16 +311,25 @@ rtl_stream_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_cent
         return 0;
     }
 
+    /* Staged, not read straight into the caller's buffer. Every rejection below
+     * returns 0, and a consumer reading that as "no new frame, keep the picture I
+     * have" would then be drawing a picture this function had already scribbled a
+     * torn or stale-generation copy over — against the axis of the frame before
+     * it. The buffer is only touched once the frame is known to be whole. */
+    float staged[kWbSpecN];
     WbFrameHeader header;
     /* A copy the writer ran through is not a frame: its bins may straddle two
      * publishes, and the axis it came with may belong to either. */
-    if (!wb_read_frame(out_db, &header) || header.bins <= 0) {
+    if (!wb_read_frame(staged, &header) || header.bins <= 0) {
         return 0;
     }
     /* Retune / disable since this frame was published: report no data rather
      * than mislabelled bins. */
     if (header.gen != g_wb_clear_gen.load(std::memory_order_acquire)) {
         return 0;
+    }
+    for (int i = 0; i < header.bins; i++) {
+        out_db[i] = staged[i];
     }
     if (out_center_freq_hz) {
         *out_center_freq_hz = header.center_hz;

--- a/src/io/radio/rtl_wideband_spectrum.cpp
+++ b/src/io/radio/rtl_wideband_spectrum.cpp
@@ -29,6 +29,7 @@
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/timing.h>
 #include <pffft.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include "rtl_wideband_spectrum.h"

--- a/src/io/radio/rtl_wideband_spectrum.cpp
+++ b/src/io/radio/rtl_wideband_spectrum.cpp
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Wideband (capture-rate) spectrum snapshots for the graphical spectrum view.
+ *
+ * The FFT plumbing here — cached pffft setup, cached Hann window, dB
+ * conversion, fftshift, EMA smoothing — deliberately mirrors rtl_metrics.cpp
+ * rather than sharing it. That module publishes a *narrow*, post-decimation
+ * spectrum at the demod output rate which feeds the supervisory tuner
+ * auto-gain gate (`demod_autogain_spectral_gate_ok()`); retuning its size,
+ * rate, or smoothing to also serve a UI would regress gain control. This
+ * module taps the block before decimation instead, costs nothing until a
+ * consumer enables it, and carries the tuned center and span alongside the
+ * bins so the consumer can label a frequency axis.
+ *
+ * Threading: `rtl_wideband_spectrum_maybe_update()` runs on the demod thread
+ * and is the only writer. Readers may call `rtl_stream_wideband_spectrum_get()`
+ * from any thread; a seqlock keeps the bins consistent with the center/span
+ * they were captured at, because a torn axis-vs-bins frame is visibly wrong on
+ * a waterfall.
+ */
+
+#include <atomic>
+#include <cmath>
+#include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/platform/timing.h>
+#include <pffft.h>
+#include <stdint.h>
+
+#include "rtl_wideband_spectrum.h"
+
+namespace {
+
+constexpr int kWbSpecMinN = 256;
+constexpr int kWbSpecMaxN = 2048;
+constexpr int kWbSpecDefaultN = 1024;
+/* ~15 FPS: enough for a readable waterfall, cheap enough to ride the demod thread. */
+constexpr uint64_t kWbSpecMinPeriodNs = 66ULL * 1000ULL * 1000ULL;
+/* Seqlock reads are best-effort: give the writer a few chances, then take what we have. */
+constexpr int kWbSpecReadAttempts = 4;
+
+std::atomic<int> g_wb_enabled{0};
+std::atomic<int> g_wb_n{kWbSpecDefaultN};
+
+/* Bumped by clear()/set_size()/disable. A published frame is only valid while
+ * its stamped generation still matches, which invalidates stale frames without
+ * needing a second writer on the seqlock below. */
+std::atomic<uint32_t> g_wb_clear_gen{0};
+
+/* Published frame. Written only by the demod thread, guarded by g_wb_seq.
+ * The payload is relaxed-atomic so the seqlock is race-free by the memory
+ * model as well as in practice; on every supported target these lower to plain
+ * loads and stores. */
+std::atomic<uint32_t> g_wb_seq{0}; /* odd => writer in progress */
+std::atomic<float> g_wb_pub_db[kWbSpecMaxN];
+std::atomic<int> g_wb_pub_n{0};
+std::atomic<uint32_t> g_wb_pub_center_hz{0};
+std::atomic<uint32_t> g_wb_pub_span_hz{0};
+std::atomic<uint32_t> g_wb_pub_gen{0};
+
+/* Demod-thread-private state (never touched by readers). */
+uint64_t g_wb_last_publish_ns = 0;
+float g_wb_ema[kWbSpecMaxN];
+int g_wb_ema_valid = 0;
+uint32_t g_wb_seen_clear_gen = 0;
+
+PFFFT_Setup*
+wb_cached_setup(int n) {
+    static PFFFT_Setup* setup = nullptr;
+    static int setup_n = 0;
+    if (!setup || setup_n != n) {
+        if (setup) {
+            pffft_destroy_setup(setup);
+            setup = nullptr;
+            setup_n = 0;
+        }
+        setup = pffft_new_setup(n, PFFFT_COMPLEX);
+        setup_n = setup ? n : 0;
+    }
+    return setup;
+}
+
+const float*
+wb_hann_window(int n) {
+    alignas(16) static float window[kWbSpecMaxN];
+    static int window_n = 0;
+    if (window_n != n) {
+        if (n <= 1) {
+            window[0] = 1.0f;
+        } else {
+            const float scale = 2.0f * static_cast<float>(M_PI) / static_cast<float>(n - 1);
+            for (int i = 0; i < n; i++) {
+                window[i] = 0.5f * (1.0f - cosf(scale * static_cast<float>(i)));
+            }
+        }
+        window_n = n;
+    }
+    return window;
+}
+
+int
+wb_clamp_size(int n) {
+    if (n < kWbSpecMinN) {
+        n = kWbSpecMinN;
+    }
+    if (n > kWbSpecMaxN) {
+        n = kWbSpecMaxN;
+    }
+    int p = kWbSpecMinN;
+    while (p < n) {
+        p <<= 1;
+    }
+    if (p > kWbSpecMaxN) {
+        p = kWbSpecMaxN;
+    }
+    return p;
+}
+
+void
+wb_bump_clear_gen(void) {
+    g_wb_clear_gen.fetch_add(1, std::memory_order_acq_rel);
+}
+
+void
+wb_publish(const float* db, int n, uint32_t center_hz, uint32_t span_hz, uint32_t gen) {
+    const uint32_t s = g_wb_seq.load(std::memory_order_relaxed);
+    g_wb_seq.store(s + 1u, std::memory_order_release); /* odd: writer active */
+    std::atomic_thread_fence(std::memory_order_release);
+    for (int i = 0; i < n; i++) {
+        g_wb_pub_db[i].store(db[i], std::memory_order_relaxed);
+    }
+    g_wb_pub_n.store(n, std::memory_order_relaxed);
+    g_wb_pub_center_hz.store(center_hz, std::memory_order_relaxed);
+    g_wb_pub_span_hz.store(span_hz, std::memory_order_relaxed);
+    g_wb_pub_gen.store(gen, std::memory_order_relaxed);
+    g_wb_seq.store(s + 2u, std::memory_order_release); /* even: frame complete */
+}
+
+} // namespace
+
+/**
+ * @brief Fold one capture-rate I/Q block into the published wideband spectrum.
+ *
+ * See rtl_wideband_spectrum.h. Skips blocks shorter than the configured FFT
+ * size rather than zero-padding them, so the published span always reflects a
+ * full analysis window.
+ */
+void
+rtl_wideband_spectrum_maybe_update(const float* iq_interleaved, int len_interleaved, uint32_t capture_rate_hz,
+                                   uint32_t center_freq_hz) {
+    if (g_wb_enabled.load(std::memory_order_relaxed) == 0) {
+        return;
+    }
+    if (!iq_interleaved || len_interleaved < 2 || capture_rate_hz == 0) {
+        return;
+    }
+
+    const uint64_t now_ns = dsd_time_monotonic_ns();
+    if (g_wb_last_publish_ns != 0 && (now_ns - g_wb_last_publish_ns) < kWbSpecMinPeriodNs) {
+        return;
+    }
+
+    const int n = wb_clamp_size(g_wb_n.load(std::memory_order_relaxed));
+    const int pairs = len_interleaved >> 1;
+    if (pairs < n) {
+        return;
+    }
+
+    const uint32_t gen = g_wb_clear_gen.load(std::memory_order_acquire);
+    if (gen != g_wb_seen_clear_gen) {
+        g_wb_seen_clear_gen = gen;
+        g_wb_ema_valid = 0;
+    }
+
+    PFFFT_Setup* setup = wb_cached_setup(n);
+    if (!setup) {
+        return;
+    }
+
+    /* Analyse the most recent n pairs of the block. */
+    alignas(16) static float z[2 * kWbSpecMaxN];
+    const int start = pairs - n;
+
+    double sum_i = 0.0;
+    double sum_q = 0.0;
+    for (int k = 0; k < n; k++) {
+        const size_t idx = static_cast<size_t>(start + k) << 1;
+        sum_i += static_cast<double>(iq_interleaved[idx]);
+        sum_q += static_cast<double>(iq_interleaved[idx + 1]);
+    }
+    const float mean_i = static_cast<float>(sum_i / static_cast<double>(n));
+    const float mean_q = static_cast<float>(sum_q / static_cast<double>(n));
+
+    const float* hann = wb_hann_window(n);
+    for (int k = 0; k < n; k++) {
+        const size_t idx = static_cast<size_t>(start + k) << 1;
+        const float w = hann[k];
+        z[static_cast<size_t>(k) << 1] = w * (iq_interleaved[idx] - mean_i);
+        z[(static_cast<size_t>(k) << 1) + 1] = w * (iq_interleaved[idx + 1] - mean_q);
+    }
+
+    pffft_transform_ordered(setup, z, z, nullptr, PFFFT_FORWARD);
+
+    /* fftshift into display order: bin 0 is center - span/2, bin n/2 is DC. */
+    const float eps = 1e-12f;
+    const bool seed = (g_wb_ema_valid == 0);
+    for (int k = 0; k < n; k++) {
+        int kk = k + (n >> 1);
+        if (kk >= n) {
+            kk -= n;
+        }
+        const float re = z[static_cast<size_t>(kk) << 1];
+        const float im = z[(static_cast<size_t>(kk) << 1) + 1];
+        const float db = 10.0f * log10f(re * re + im * im + eps);
+        g_wb_ema[k] = seed ? db : (0.6f * db + 0.4f * g_wb_ema[k]);
+    }
+    g_wb_ema_valid = 1;
+
+    wb_publish(g_wb_ema, n, center_freq_hz, capture_rate_hz, gen);
+    g_wb_last_publish_ns = now_ns;
+}
+
+/** @brief Invalidate the published frame; see rtl_wideband_spectrum.h. */
+void
+rtl_wideband_spectrum_clear(void) {
+    wb_bump_clear_gen();
+}
+
+#ifdef DSD_NEO_TEST_HOOKS
+/** @brief Clear the publish throttle so the next update publishes immediately. */
+void
+rtl_wideband_spectrum_test_reset_throttle(void) {
+    g_wb_last_publish_ns = 0;
+}
+#endif
+
+/**
+ * @brief Copy the latest wideband spectrum frame.
+ *
+ * See the doc comment on the declaration in <dsd-neo/io/rtl_stream_c.h>.
+ */
+extern "C" int
+rtl_stream_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz, uint32_t* out_span_hz) {
+    if (!out_db || max_bins <= 0) {
+        return 0;
+    }
+    if (g_wb_enabled.load(std::memory_order_relaxed) == 0) {
+        return 0;
+    }
+
+    const int cap = (max_bins < kWbSpecMaxN) ? max_bins : kWbSpecMaxN;
+    int copied = 0;
+    uint32_t center_hz = 0;
+    uint32_t span_hz = 0;
+    uint32_t gen = 0;
+    for (int attempt = 0; attempt < kWbSpecReadAttempts; attempt++) {
+        const uint32_t s1 = g_wb_seq.load(std::memory_order_acquire);
+        if ((s1 & 1u) != 0u) {
+            continue; /* writer mid-frame */
+        }
+        int n = g_wb_pub_n.load(std::memory_order_relaxed);
+        if (n > cap) {
+            n = cap;
+        }
+        if (n < 0) {
+            n = 0;
+        }
+        for (int i = 0; i < n; i++) {
+            out_db[i] = g_wb_pub_db[i].load(std::memory_order_relaxed);
+        }
+        center_hz = g_wb_pub_center_hz.load(std::memory_order_relaxed);
+        span_hz = g_wb_pub_span_hz.load(std::memory_order_relaxed);
+        gen = g_wb_pub_gen.load(std::memory_order_relaxed);
+        copied = n;
+        std::atomic_thread_fence(std::memory_order_acquire);
+        if (g_wb_seq.load(std::memory_order_relaxed) == s1) {
+            break;
+        }
+    }
+
+    if (copied <= 0) {
+        return 0;
+    }
+    /* Retune / resize / disable since this frame was published: report no data
+     * rather than mislabelled bins. */
+    if (gen != g_wb_clear_gen.load(std::memory_order_acquire)) {
+        return 0;
+    }
+    if (out_center_freq_hz) {
+        *out_center_freq_hz = center_hz;
+    }
+    if (out_span_hz) {
+        *out_span_hz = span_hz;
+    }
+    return copied;
+}
+
+/**
+ * @brief Set the wideband FFT size.
+ *
+ * See the doc comment on the declaration in <dsd-neo/io/rtl_stream_c.h>.
+ */
+extern "C" int
+rtl_stream_wideband_spectrum_set_size(int n) {
+    const int p = wb_clamp_size(n);
+    if (g_wb_n.exchange(p, std::memory_order_relaxed) != p) {
+        wb_bump_clear_gen();
+    }
+    return p;
+}
+
+/** @brief Get the current wideband FFT size in bins. */
+extern "C" int
+rtl_stream_wideband_spectrum_get_size(void) {
+    return wb_clamp_size(g_wb_n.load(std::memory_order_relaxed));
+}
+
+/** @brief Enable or disable wideband spectrum production. */
+extern "C" void
+rtl_stream_wideband_spectrum_set_enabled(int on) {
+    const int v = on ? 1 : 0;
+    if (g_wb_enabled.exchange(v, std::memory_order_relaxed) != v && v == 0) {
+        /* Drop the frame so a later re-enable never shows pre-close bins. */
+        wb_bump_clear_gen();
+    }
+}
+
+/** @brief Return 1 when wideband spectrum production is enabled. */
+extern "C" int
+rtl_stream_wideband_spectrum_enabled(void) {
+    return g_wb_enabled.load(std::memory_order_relaxed) ? 1 : 0;
+}

--- a/src/io/radio/rtl_wideband_spectrum.cpp
+++ b/src/io/radio/rtl_wideband_spectrum.cpp
@@ -29,14 +29,13 @@
  */
 
 #include <atomic>
-#include <cmath>
 #include <dsd-neo/core/wideband_spectrum.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/timing.h>
-#include <stddef.h>
 #include <stdint.h>
 
 #include "rtl_fft_cache.h"
+#include "rtl_spectrum_kernels.h"
 #include "rtl_wideband_spectrum.h"
 
 namespace {
@@ -96,55 +95,21 @@ wb_bump_clear_gen(void) {
     g_wb_clear_gen.fetch_add(1, std::memory_order_acq_rel);
 }
 
-/**
- * @brief Window @p n complex pairs starting at @p start into @p z, DC removed.
- *
- * The mean is subtracted before windowing because the residual DC of an RTL
- * front end is large enough to bury the middle of the display in a spike that
- * is not a signal.
- */
-void
-wb_window_block(const float* iq_interleaved, int start, int n, const float* hann, float* z) {
-    double sum_i = 0.0;
-    double sum_q = 0.0;
-    for (int k = 0; k < n; k++) {
-        const size_t idx = static_cast<size_t>(start + k) << 1;
-        sum_i += static_cast<double>(iq_interleaved[idx]);
-        sum_q += static_cast<double>(iq_interleaved[idx + 1]);
-    }
-    const float mean_i = static_cast<float>(sum_i / static_cast<double>(n));
-    const float mean_q = static_cast<float>(sum_q / static_cast<double>(n));
-
-    for (int k = 0; k < n; k++) {
-        const size_t idx = static_cast<size_t>(start + k) << 1;
-        const float w = hann[k];
-        z[static_cast<size_t>(k) << 1] = w * (iq_interleaved[idx] - mean_i);
-        z[(static_cast<size_t>(k) << 1) + 1] = w * (iq_interleaved[idx + 1] - mean_q);
-    }
-}
+/* Share of each new frame in the published EMA. Heavier than the narrow tap's,
+ * because a waterfall row is a moment rather than a running estimate: this one
+ * is scrolled away a frame later, and over-smoothing smears a short burst across
+ * rows it was not present in. */
+constexpr float kWbSpecEmaNewWeight = 0.6f;
 
 /**
  * @brief Convert @p z to dB in display order and smooth it into the EMA.
  *
- * fftshift as it goes: bin 0 is center - span/2 and bin n/2 is DC, which is the
- * order the published frame promises. The EMA is what keeps a waterfall from
- * flickering between frames; it is seeded rather than blended on the first
- * frame after a clear, so a retune shows the new band immediately.
+ * Seeded rather than blended on the first frame after a clear, so a retune shows
+ * the new band immediately instead of fading the old one out over several rows.
  */
 void
 wb_fold_into_ema(const float* z, int n) {
-    const float eps = 1e-12f;
-    const bool seed = (g_wb_ema_valid == 0);
-    for (int k = 0; k < n; k++) {
-        int kk = k + (n >> 1);
-        if (kk >= n) {
-            kk -= n;
-        }
-        const float re = z[static_cast<size_t>(kk) << 1];
-        const float im = z[(static_cast<size_t>(kk) << 1) + 1];
-        const float db = 10.0f * log10f(re * re + im * im + eps);
-        g_wb_ema[k] = seed ? db : (0.6f * db + 0.4f * g_wb_ema[k]);
-    }
+    dsd_io::spectrum_fold_db(z, n, kWbSpecEmaNewWeight, g_wb_ema_valid == 0, g_wb_ema);
     g_wb_ema_valid = 1;
 }
 
@@ -207,7 +172,8 @@ rtl_wideband_spectrum_maybe_update(const float* iq_interleaved, int len_interlea
 
     /* Analyse the most recent n pairs of the block. */
     alignas(16) static float z[2 * kWbSpecN];
-    wb_window_block(iq_interleaved, pairs - n, n, hann, z);
+    const int start = pairs - n;
+    dsd_io::iq_window_dc_removed(iq_interleaved, start, n, hann, dsd_io::iq_block_mean(iq_interleaved, start, n), z);
     if (!g_wb_fft_setup.forward(n, z)) {
         return;
     }

--- a/src/io/radio/rtl_wideband_spectrum.h
+++ b/src/io/radio/rtl_wideband_spectrum.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef DSD_NEO_IO_RADIO_RTL_WIDEBAND_SPECTRUM_H
+#define DSD_NEO_IO_RADIO_RTL_WIDEBAND_SPECTRUM_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Fold one capture-rate I/Q block into the published wideband spectrum.
+ *
+ * Called from the demod thread on every block. Returns immediately when no
+ * consumer has enabled the feature, and otherwise publishes at most one frame
+ * per ~66 ms (~15 FPS).
+ *
+ * @param iq_interleaved  Interleaved float I/Q at capture rate.
+ * @param len_interleaved Number of floats (2x the complex pair count).
+ * @param capture_rate_hz Sample rate of the block; becomes the published span.
+ * @param center_freq_hz  Tuned center frequency the block was captured at.
+ */
+void rtl_wideband_spectrum_maybe_update(const float* iq_interleaved, int len_interleaved, uint32_t capture_rate_hz,
+                                        uint32_t center_freq_hz);
+
+/**
+ * @brief Invalidate the published frame (retune, size change, or disable).
+ *
+ * The getter reports "no data" until the demod thread publishes again, so a
+ * consumer never labels post-retune bins with the previous center frequency.
+ */
+void rtl_wideband_spectrum_clear(void);
+
+#ifdef DSD_NEO_TEST_HOOKS
+/** @brief Clear the publish throttle so the next update publishes immediately. */
+void rtl_wideband_spectrum_test_reset_throttle(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_IO_RADIO_RTL_WIDEBAND_SPECTRUM_H */

--- a/src/io/radio/rtl_wideband_spectrum.h
+++ b/src/io/radio/rtl_wideband_spectrum.h
@@ -38,6 +38,16 @@ void rtl_wideband_spectrum_clear(void);
 #ifdef DSD_NEO_TEST_HOOKS
 /** @brief Clear the publish throttle so the next update publishes immediately. */
 void rtl_wideband_spectrum_test_reset_throttle(void);
+
+/**
+ * @brief Make every seqlock read attempt observe a writer landing inside it.
+ *
+ * A torn read is a race between two threads, which no single-threaded test can
+ * stage — and what the reader does when it never gets a clean copy is exactly
+ * what must not regress: reporting no frame is safe, handing back a copy the
+ * writer ran through is not.
+ */
+void rtl_wideband_spectrum_test_set_tear(int on);
 #endif
 
 #ifdef __cplusplus

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -2048,10 +2048,8 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
             break;                                                                                                     \
         }                                                                                                              \
         case 'f': {                                                                                                    \
-            /* Any -f* preset should stop pure analog-monitor mode unless explicitly selecting it. */                  \
-            opts->analog_only = 0;                                                                                     \
-            opts->monitor_input_audio = 0;                                                                             \
-                                                                                                                       \
+            /* Leaving analog-monitor mode is dsd_apply_decode_mode_preset()'s job now,                                \
+               so an unrecognized -f selector no longer half-changes the mode. */                                      \
             const char decode_preset = optarg[0] == 'r' ? 's' : optarg[0];                                             \
             dsdneoUserDecodeMode core_mode = DSDCFG_MODE_UNSET;                                                        \
             if (dsd_decode_mode_from_cli_preset(decode_preset, &core_mode) == 0                                        \

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -2129,9 +2129,16 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                 cli_decode_timing_source = CLI_TIMING_SOURCE_PRESET;                                                   \
             } else if (optarg[0] == 'h') {                                                                             \
                 if (optarg[1] != 0) {                                                                                  \
-                    char abits[2] = {optarg[1], 0};                                                                    \
-                    char fbits[2] = {optarg[2], 0};                                                                    \
-                    char sbits[2] = {optarg[3], 0};                                                                    \
+                    /* Each digit is only read once the one before it proved the                                       \
+                       string reaches that far. `-fh1` is a two-character selector,                                    \
+                       so optarg[3] is a byte past the end of the argv element, and                                    \
+                       whatever it happened to be was parsed into edacs_s_bits. */                                     \
+                    const char afs_a = optarg[1];                                                                      \
+                    const char afs_f = (afs_a != 0) ? optarg[2] : 0;                                                   \
+                    const char afs_s = (afs_f != 0) ? optarg[3] : 0;                                                   \
+                    char abits[2] = {afs_a, 0};                                                                        \
+                    char fbits[2] = {afs_f, 0};                                                                        \
+                    char sbits[2] = {afs_s, 0};                                                                        \
                     state->edacs_a_bits = (int)cli_parse_long_or_default(&abits[0], 10, 0);                            \
                     state->edacs_f_bits = (int)cli_parse_long_or_default(&fbits[0], 10, 0);                            \
                     state->edacs_s_bits = (int)cli_parse_long_or_default(&sbits[0], 10, 0);                            \
@@ -2180,9 +2187,16 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
                 cli_decode_timing_source = CLI_TIMING_SOURCE_PRESET;                                                   \
             } else if (optarg[0] == 'H') {                                                                             \
                 if (optarg[1] != 0) {                                                                                  \
-                    char abits[2] = {optarg[1], 0};                                                                    \
-                    char fbits[2] = {optarg[2], 0};                                                                    \
-                    char sbits[2] = {optarg[3], 0};                                                                    \
+                    /* Each digit is only read once the one before it proved the                                       \
+                       string reaches that far. `-fH1` is a two-character selector,                                    \
+                       so optarg[3] is a byte past the end of the argv element, and                                    \
+                       whatever it happened to be was parsed into edacs_s_bits. */                                     \
+                    const char afs_a = optarg[1];                                                                      \
+                    const char afs_f = (afs_a != 0) ? optarg[2] : 0;                                                   \
+                    const char afs_s = (afs_f != 0) ? optarg[3] : 0;                                                   \
+                    char abits[2] = {afs_a, 0};                                                                        \
+                    char fbits[2] = {afs_f, 0};                                                                        \
+                    char sbits[2] = {afs_s, 0};                                                                        \
                     state->edacs_a_bits = (int)cli_parse_long_or_default(&abits[0], 10, 0);                            \
                     state->edacs_f_bits = (int)cli_parse_long_or_default(&fbits[0], 10, 0);                            \
                     state->edacs_s_bits = (int)cli_parse_long_or_default(&sbits[0], 10, 0);                            \

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -2048,8 +2048,20 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
             break;                                                                                                     \
         }                                                                                                              \
         case 'f': {                                                                                                    \
-            /* Leaving analog-monitor mode is dsd_apply_decode_mode_preset()'s job now,                                \
-               so an unrecognized -f selector no longer half-changes the mode. */                                      \
+            /* Leaving analog-monitor mode is dsd_apply_decode_mode_preset()'s job for every                           \
+               selector that reaches it, so an unrecognized -f selector no longer half-changes                         \
+               the mode. The selectors below are handled by the hand-rolled chain further down                         \
+               and never reach the preset helper, so they have to say it themselves: left set                          \
+               from an earlier -fA, analog_only pins the RTL front end to                                              \
+               DSD_DEMOD_OUTPUT_AUDIO_MONITOR and suppresses the digital output stream, so                             \
+               `-fA -fp` selects ProVoice and then never decodes it. */                                                \
+            const char f_selector = optarg[0];                                                                         \
+            if (f_selector == 'p' || f_selector == 'h' || f_selector == 'H' || f_selector == 'e'                       \
+                || f_selector == 'E' || f_selector == 'Z' || f_selector == 'B' || f_selector == 'P'                    \
+                || f_selector == 'U') {                                                                                \
+                opts->analog_only = 0;                                                                                 \
+                opts->monitor_input_audio = 0;                                                                         \
+            }                                                                                                          \
             const char decode_preset = optarg[0] == 'r' ? 's' : optarg[0];                                             \
             dsdneoUserDecodeMode core_mode = DSDCFG_MODE_UNSET;                                                        \
             if (dsd_decode_mode_from_cli_preset(decode_preset, &core_mode) == 0                                        \

--- a/src/runtime/decode_mode.c
+++ b/src/runtime/decode_mode.c
@@ -5,7 +5,9 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -35,6 +37,60 @@ dsd_decode_mode_from_cli_preset(char preset, dsdneoUserDecodeMode* out_mode) {
     }
 }
 
+dsd_decode_mode_profile
+dsd_decode_mode_profile_for(dsdneoUserDecodeMode mode) {
+    dsd_decode_mode_profile profile = {4800, 4, DSD_FRAME_SYNC_SPS_PROFILE_4800_4};
+
+    switch (mode) {
+        case DSDCFG_MODE_P25P2:
+            profile.symbol_rate_hz = 6000;
+            profile.sps_profile_index = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+            break;
+        case DSDCFG_MODE_NXDN48:
+        case DSDCFG_MODE_DPMR:
+            profile.symbol_rate_hz = 2400;
+            profile.sps_profile_index = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+            break;
+        case DSDCFG_MODE_EDACS_PV:
+            profile.symbol_rate_hz = 9600;
+            profile.levels = 2;
+            profile.sps_profile_index = DSD_FRAME_SYNC_SPS_PROFILE_9600_2;
+            break;
+        /* NXDN96 belongs here and not with NXDN48: 9600 bps over four levels is
+           4800 sym/s. The hunt agrees -- frame_sync_sps_profile_has_candidate()
+           offers NXDN96 only at 4800_4, so a mode put on 2400_4 would search a
+           profile that can never match it. */
+        default: break;
+    }
+
+    return profile;
+}
+
+int
+dsd_rtl_channel_profile_for(const dsd_opts* opts, int symbol_rate_hz, int levels, int rf_mod) {
+    if (symbol_rate_hz == 2400 || (symbol_rate_hz == 4800 && levels == 2)) {
+        return DSD_RTL_STREAM_CHANNEL_PROFILE_6K25;
+    }
+    if (symbol_rate_hz == 9600) {
+        return DSD_RTL_STREAM_CHANNEL_PROFILE_PROVOICE;
+    }
+    if (rf_mod == 1) {
+        return DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
+    }
+    if (symbol_rate_hz == 6000 || rf_mod == 2 || dsd_opts_uses_wide_4800_profile(opts)) {
+        return DSD_RTL_STREAM_CHANNEL_PROFILE_12K5;
+    }
+    return DSD_RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+}
+
+/**
+ * @brief The symbol timing a preset starts a mode off on, at 48 kHz.
+ *
+ * Not the same question as dsd_decode_mode_profile_for(): this is where the
+ * preset puts the slicer before any sync, and NXDN96 has historically started at
+ * 20 (2400 sym/s) even though it decodes at 4800. The hunt corrects it, so the
+ * value is left alone here rather than changed underneath the CLI.
+ */
 static void
 decode_mode_base_symbol_timing(dsdneoUserDecodeMode mode, int* out_sps, int* out_center) {
     int sps = 10;

--- a/src/runtime/decode_mode.c
+++ b/src/runtime/decode_mode.c
@@ -56,6 +56,20 @@ dsd_decode_mode_profile_for(dsdneoUserDecodeMode mode) {
             profile.levels = 2;
             profile.sps_profile_index = DSD_FRAME_SYNC_SPS_PROFILE_9600_2;
             break;
+        case DSDCFG_MODE_DSTAR:
+            /* Two levels, not four. Left on the 4800/4 default the published
+               profile asks the front end for the P25 C4FM filter and parks the
+               hunt on an index frame_sync_sps_profile_has_candidate() never
+               offers a D-STAR-only session -- so it cannot sync until the hunt
+               dwells out and rotates away from what it was just told. */
+            profile.levels = 2;
+            profile.sps_profile_index = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+            break;
+        case DSDCFG_MODE_X2TDMA:
+            /* Carried at 6000_4 alongside P25p2, for the same reason. */
+            profile.symbol_rate_hz = 6000;
+            profile.sps_profile_index = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+            break;
         /* NXDN96 belongs here and not with NXDN48: 9600 bps over four levels is
            4800 sym/s. The hunt agrees -- frame_sync_sps_profile_has_candidate()
            offers NXDN96 only at 4800_4, so a mode put on 2400_4 would search a
@@ -146,14 +160,23 @@ decode_mode_apply_auto(dsdDecodePresetProfile p, dsd_opts* o, dsd_state* s) {
         o->frame_provoice = 1;
         o->frame_ysf = 1;
         o->frame_m17 = 1;
-        o->mod_c4fm = 1;
-        o->mod_qpsk = 0;
-        /* Cleared like every sibling preset does. Applied mid-session (the Qt
-         * radio panel's decode chips), a preset that leaves the previous one's
-         * GFSK flag set publishes mod_c4fm=1 && mod_gfsk=1 -- an opts pair the
-         * demodulator and the UI's modulation readout then disagree about. */
-        o->mod_gfsk = 0;
-        s->rf_mod = 0;
+        /* Cleared together, like every sibling preset does. Applied mid-session
+         * (the Qt radio panel's decode chips), a preset that leaves the previous
+         * one's GFSK flag set publishes mod_c4fm=1 && mod_gfsk=1 -- an opts pair
+         * the demodulator and the UI's modulation readout then disagree about.
+         *
+         * Skipped under mod_cli_lock, as decode_mode_apply_dmr() already does:
+         * the lock means the operator named a modulation on the command line, and
+         * frame_sync_apply_cli_mod_lock() re-derives rf_mod from these flags on
+         * every pass -- so clearing mod_gfsk here would turn `-mg -fa` into a
+         * permanent C4FM lock the SPS hunt is then forbidden to correct. The
+         * mid-session path clears the lock before it applies a preset. */
+        if (!o->mod_cli_lock) {
+            o->mod_c4fm = 1;
+            o->mod_qpsk = 0;
+            o->mod_gfsk = 0;
+            s->rf_mod = 0;
+        }
         o->dmr_stereo = 1;
         o->dmr_mono = 0;
         o->pulse_digi_rate_out = 8000;
@@ -384,12 +407,22 @@ decode_mode_apply_dstar(dsd_opts* o, dsd_state* s) {
     o->dmr_mono = 0;
     s->dmr_stereo = 0;
     /* Set alongside rf_mod, not left to whatever the last preset chose: applied
-     * mid-session, a stale mod_gfsk here contradicts rf_mod and strands the UI's
-     * modulation control on a value the demodulator is not on. */
-    o->mod_c4fm = 1;
-    o->mod_qpsk = 0;
-    o->mod_gfsk = 0;
-    s->rf_mod = 0;
+     * mid-session, a stale flag here contradicts rf_mod and strands the UI's
+     * modulation control on a value the demodulator is not on. Skipped under
+     * mod_cli_lock for the reason decode_mode_apply_auto() spells out: the lock
+     * makes these flags the operator's own answer, and rewriting them pins the
+     * session to a modulation nothing can move it off.
+     *
+     * GFSK, not C4FM: D-STAR is GMSK over two levels, which is what its 4800/2
+     * symbol profile says and what frame_sync_apply_sps_hunt_profile() normalises
+     * rf_mod to the moment the hunt lands on that profile. Naming C4FM here only
+     * put the flags a pass behind the demodulator. */
+    if (!o->mod_cli_lock) {
+        o->mod_c4fm = 0;
+        o->mod_qpsk = 0;
+        o->mod_gfsk = 1;
+        s->rf_mod = 2;
+    }
     DSD_SNPRINTF(o->output_name, sizeof o->output_name, "%s", "DSTAR");
 }
 
@@ -519,11 +552,14 @@ decode_mode_apply_analog(dsd_opts* o, dsd_state* s) {
     s->dmr_stereo = 0;
     o->dmr_mono = 0;
     /* As in the other presets: rf_mod and the mod_* flags are one answer, and
-     * leaving half of it behind makes them disagree on a live session. */
-    o->mod_c4fm = 1;
-    o->mod_qpsk = 0;
-    o->mod_gfsk = 0;
-    s->rf_mod = 0;
+     * leaving half of it behind makes them disagree on a live session -- and, as
+     * there, the operator's own `-m` answer outranks the preset's. */
+    if (!o->mod_cli_lock) {
+        o->mod_c4fm = 1;
+        o->mod_qpsk = 0;
+        o->mod_gfsk = 0;
+        s->rf_mod = 0;
+    }
     o->monitor_input_audio = 1;
     o->analog_only = 1;
     DSD_SNPRINTF(o->output_name, sizeof o->output_name, "%s", "Analog Monitor");
@@ -575,16 +611,27 @@ dsd_apply_decode_mode_preset(dsdneoUserDecodeMode mode, dsdDecodePresetProfile p
     }
 
     /* Analog monitor is a mode like any other, so leaving it is part of choosing a
-       different one. Only the analog preset sets these, and with nothing clearing
-       them dsd_infer_decode_mode_preset() answers ANALOG forever: the CLI becomes
+       different one. With nothing clearing analog_only,
+       dsd_infer_decode_mode_preset() answers ANALOG forever: the CLI becomes
        order-dependent, and every decode chip in the Qt radio panel renders
        unselected because the engine reports a mode none of them carry. The CLI used
        to clear it at its own `-f` case; it belongs to the presets, which is where
        every caller gets it. Applied after the dispatch so an unsupported mode
-       changes nothing at all. */
+       changes nothing at all.
+
+       monitor_input_audio only follows analog_only out. Unlike analog_only --
+       which nothing but this preset and `-fA` ever set -- it is also the `-8`
+       flag and the menu's "Toggle Source Audio Monitor", and this helper runs on
+       every runtime config apply with the mode the session is already in
+       (snapshot_mode_config() always stamps has_mode). Clearing it
+       unconditionally would switch a monitor the operator turned on by hand off
+       again on the next unrelated settings change. analog_only is what marks the
+       analog preset as the one that set it. */
     if (mode != DSDCFG_MODE_ANALOG) {
+        if (opts->analog_only) {
+            opts->monitor_input_audio = 0;
+        }
         opts->analog_only = 0;
-        opts->monitor_input_audio = 0;
     }
     return 0;
 }

--- a/src/runtime/decode_mode.c
+++ b/src/runtime/decode_mode.c
@@ -92,6 +92,11 @@ decode_mode_apply_auto(dsdDecodePresetProfile p, dsd_opts* o, dsd_state* s) {
         o->frame_m17 = 1;
         o->mod_c4fm = 1;
         o->mod_qpsk = 0;
+        /* Cleared like every sibling preset does. Applied mid-session (the Qt
+         * radio panel's decode chips), a preset that leaves the previous one's
+         * GFSK flag set publishes mod_c4fm=1 && mod_gfsk=1 -- an opts pair the
+         * demodulator and the UI's modulation readout then disagree about. */
+        o->mod_gfsk = 0;
         s->rf_mod = 0;
         o->dmr_stereo = 1;
         o->dmr_mono = 0;
@@ -322,6 +327,12 @@ decode_mode_apply_dstar(dsd_opts* o, dsd_state* s) {
     o->dmr_stereo = 0;
     o->dmr_mono = 0;
     s->dmr_stereo = 0;
+    /* Set alongside rf_mod, not left to whatever the last preset chose: applied
+     * mid-session, a stale mod_gfsk here contradicts rf_mod and strands the UI's
+     * modulation control on a value the demodulator is not on. */
+    o->mod_c4fm = 1;
+    o->mod_qpsk = 0;
+    o->mod_gfsk = 0;
     s->rf_mod = 0;
     DSD_SNPRINTF(o->output_name, sizeof o->output_name, "%s", "DSTAR");
 }
@@ -451,6 +462,11 @@ decode_mode_apply_analog(dsd_opts* o, dsd_state* s) {
     o->dmr_stereo = 0;
     s->dmr_stereo = 0;
     o->dmr_mono = 0;
+    /* As in the other presets: rf_mod and the mod_* flags are one answer, and
+     * leaving half of it behind makes them disagree on a live session. */
+    o->mod_c4fm = 1;
+    o->mod_qpsk = 0;
+    o->mod_gfsk = 0;
     s->rf_mod = 0;
     o->monitor_input_audio = 1;
     o->analog_only = 1;
@@ -470,13 +486,8 @@ decode_mode_apply_profiled(dsdneoUserDecodeMode mode, dsdDecodePresetProfile pro
     }
 }
 
-int
-dsd_apply_decode_mode_preset(dsdneoUserDecodeMode mode, dsdDecodePresetProfile profile, dsd_opts* opts,
-                             dsd_state* state) {
-    if (!opts || !state) {
-        return -1;
-    }
-
+static int
+decode_mode_dispatch(dsdneoUserDecodeMode mode, dsdDecodePresetProfile profile, dsd_opts* opts, dsd_state* state) {
     if (decode_mode_apply_profiled(mode, profile, opts, state) == 0) {
         return 0;
     }
@@ -494,6 +505,32 @@ dsd_apply_decode_mode_preset(dsdneoUserDecodeMode mode, dsdDecodePresetProfile p
         case DSDCFG_MODE_ANALOG: decode_mode_apply_analog(opts, state); return 0;
         default: return -1;
     }
+}
+
+int
+dsd_apply_decode_mode_preset(dsdneoUserDecodeMode mode, dsdDecodePresetProfile profile, dsd_opts* opts,
+                             dsd_state* state) {
+    if (!opts || !state) {
+        return -1;
+    }
+
+    if (decode_mode_dispatch(mode, profile, opts, state) != 0) {
+        return -1;
+    }
+
+    /* Analog monitor is a mode like any other, so leaving it is part of choosing a
+       different one. Only the analog preset sets these, and with nothing clearing
+       them dsd_infer_decode_mode_preset() answers ANALOG forever: the CLI becomes
+       order-dependent, and every decode chip in the Qt radio panel renders
+       unselected because the engine reports a mode none of them carry. The CLI used
+       to clear it at its own `-f` case; it belongs to the presets, which is where
+       every caller gets it. Applied after the dispatch so an unsupported mode
+       changes nothing at all. */
+    if (mode != DSDCFG_MODE_ANALOG) {
+        opts->analog_only = 0;
+        opts->monitor_input_audio = 0;
+    }
+    return 0;
 }
 
 dsdneoUserDecodeMode

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -47,12 +47,14 @@ qt_add_resources(
         qml/ExploreSetupScreen.qml
         qml/FilterPill.qml
         qml/FollowLatest.qml
+        qml/FrequencyField.qml
         qml/GradientButton.qml
         qml/HistoryScreen.qml
         qml/HomeScreen.qml
         qml/LevelMeter.qml
         qml/LogoMark.qml
         qml/MicroLabel.qml
+        qml/ModalSheet.qml
         qml/MonitorScreen.qml
         qml/OnboardingScreen.qml
         qml/OutlineButton.qml

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -65,6 +65,7 @@ qt_add_resources(
         qml/SegmentedControl.qml
         qml/SettingsScreen.qml
         qml/SpectrumScreen.qml
+        qml/TunerMarker.qml
         qml/UiPanel.qml
         qml/WizardScreen.qml
         fonts/IBMPlexSans-Regular.ttf

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -22,6 +22,8 @@ target_sources(
         metrics_model.cpp
         qt_ui.cpp
         saved_systems_model.cpp
+        spectrum_model.cpp
+        spectrum_view_item.cpp
         session_args.cpp
         ui_controller.cpp
 )
@@ -58,6 +60,7 @@ qt_add_resources(
         qml/PlexTextField.qml
         qml/SegmentedControl.qml
         qml/SettingsScreen.qml
+        qml/SpectrumScreen.qml
         qml/UiPanel.qml
         qml/WizardScreen.qml
         fonts/IBMPlexSans-Regular.ttf

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -38,6 +38,7 @@ qt_add_resources(
         qml/Theme.qml
         qml/Util.js
         qml/Main.qml
+        qml/BandRail.qml
         qml/BottomNav.qml
         qml/CallRow.qml
         qml/Caret.qml

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -44,6 +44,7 @@ qt_add_resources(
         qml/DashedActionButton.qml
         qml/DecodeChip.qml
         qml/EncTag.qml
+        qml/ExploreSetupScreen.qml
         qml/FilterPill.qml
         qml/FollowLatest.qml
         qml/GradientButton.qml
@@ -58,6 +59,7 @@ qt_add_resources(
         qml/PlayCircle.qml
         qml/PlexSwitch.qml
         qml/PlexTextField.qml
+        qml/RadioSheet.qml
         qml/SegmentedControl.qml
         qml/SettingsScreen.qml
         qml/SpectrumScreen.qml

--- a/src/ui/qt/app_prefs.cpp
+++ b/src/ui/qt/app_prefs.cpp
@@ -33,6 +33,39 @@ constexpr const char kExploreHost[] = "explore/host";
 constexpr const char kExplorePort[] = "explore/port";
 constexpr const char kExploreFreqMhz[] = "explore/freqMhz";
 
+/*
+ * Three preferences are range-checked on the way out. They are checked on the way
+ * in as well, and the setters below compare against what is *stored* rather than
+ * against the checked reading — otherwise an out-of-range write persists (the
+ * getter hides it) and the corrective write that follows looks like a no-op and is
+ * dropped, leaving the file permanently disagreeing with the app.
+ */
+
+/** @brief @p mode if it names an appearance, else the default. */
+int
+sane_appearance(int mode) {
+    return (mode >= AppPrefs::FollowSystem && mode <= AppPrefs::Dark) ? mode : AppPrefs::FollowSystem;
+}
+
+/**
+ * @brief @p type if it is a source that can explore, else empty.
+ *
+ * Only the two tuner sources can explore -- a PCM feed or a file has nothing to
+ * point anywhere -- so anything else reads as "not chosen yet" and sends the user
+ * to the setup sheet rather than starting something that cannot tune. Empty is the
+ * honest default: it is what makes the first tap ask.
+ */
+QString
+sane_explore_source_type(const QString& type) {
+    return (type == QLatin1String("usb") || type == QLatin1String("rtltcp")) ? type : QString();
+}
+
+/** @brief @p port if it is a usable TCP port, else the rtl_tcp default. */
+int
+sane_explore_port(int port) {
+    return (port >= 1 && port <= 65535) ? port : 1234;
+}
+
 } // namespace
 
 AppPrefs::AppPrefs(QObject* parent)
@@ -47,16 +80,16 @@ AppPrefs::~AppPrefs() = default;
 
 int
 AppPrefs::appearance() const {
-    const int mode = m_settings.value(QLatin1String(kAppearance), FollowSystem).toInt();
-    return (mode >= FollowSystem && mode <= Dark) ? mode : FollowSystem;
+    return sane_appearance(m_settings.value(QLatin1String(kAppearance), FollowSystem).toInt());
 }
 
 void
 AppPrefs::setAppearance(int mode) {
-    if (mode == appearance()) {
+    const int next = sane_appearance(mode);
+    if (next == m_settings.value(QLatin1String(kAppearance), FollowSystem).toInt()) {
         return;
     }
-    m_settings.setValue(QLatin1String(kAppearance), mode);
+    m_settings.setValue(QLatin1String(kAppearance), next);
     Q_EMIT appearanceChanged();
 }
 
@@ -205,20 +238,16 @@ AppPrefs::setExtraArgs(const QString& args) {
 
 QString
 AppPrefs::exploreSourceType() const {
-    const QString type = m_settings.value(QLatin1String(kExploreSourceType), QString()).toString();
-    /* Only the two tuner sources can explore -- a PCM feed or a file has nothing to
-     * point anywhere -- so anything else stored here reads as "not chosen yet" and
-     * sends the user to the setup sheet rather than starting something that cannot
-     * tune. Empty is the honest default: it is what makes the first tap ask. */
-    return (type == QLatin1String("usb") || type == QLatin1String("rtltcp")) ? type : QString();
+    return sane_explore_source_type(m_settings.value(QLatin1String(kExploreSourceType), QString()).toString());
 }
 
 void
 AppPrefs::setExploreSourceType(const QString& type) {
-    if (type == exploreSourceType()) {
+    const QString next = sane_explore_source_type(type);
+    if (next == m_settings.value(QLatin1String(kExploreSourceType), QString()).toString()) {
         return;
     }
-    m_settings.setValue(QLatin1String(kExploreSourceType), type);
+    m_settings.setValue(QLatin1String(kExploreSourceType), next);
     Q_EMIT exploreChanged();
 }
 
@@ -238,16 +267,16 @@ AppPrefs::setExploreHost(const QString& host) {
 
 int
 AppPrefs::explorePort() const {
-    const int port = m_settings.value(QLatin1String(kExplorePort), 1234).toInt();
-    return (port >= 1 && port <= 65535) ? port : 1234;
+    return sane_explore_port(m_settings.value(QLatin1String(kExplorePort), 1234).toInt());
 }
 
 void
 AppPrefs::setExplorePort(int port) {
-    if (port == explorePort()) {
+    const int next = sane_explore_port(port);
+    if (next == m_settings.value(QLatin1String(kExplorePort), 1234).toInt()) {
         return;
     }
-    m_settings.setValue(QLatin1String(kExplorePort), port);
+    m_settings.setValue(QLatin1String(kExplorePort), next);
     Q_EMIT exploreChanged();
 }
 

--- a/src/ui/qt/app_prefs.cpp
+++ b/src/ui/qt/app_prefs.cpp
@@ -25,6 +25,13 @@ constexpr const char kPpm[] = "tuner/ppm";
 constexpr const char kBandwidthKhz[] = "tuner/bandwidthKhz";
 constexpr const char kBiasTee[] = "tuner/biasTee";
 constexpr const char kExtraArgs[] = "decode/extraArgs";
+// Where the last explore session was pointed, so the next one resumes there
+// instead of asking again. Not a saved system: exploring has no card, no name and
+// no trunking, and it must not appear in the list of things to listen to.
+constexpr const char kExploreSourceType[] = "explore/sourceType";
+constexpr const char kExploreHost[] = "explore/host";
+constexpr const char kExplorePort[] = "explore/port";
+constexpr const char kExploreFreqMhz[] = "explore/freqMhz";
 
 } // namespace
 
@@ -194,6 +201,71 @@ AppPrefs::setExtraArgs(const QString& args) {
     }
     m_settings.setValue(QLatin1String(kExtraArgs), args);
     Q_EMIT extraArgsChanged();
+}
+
+QString
+AppPrefs::exploreSourceType() const {
+    const QString type = m_settings.value(QLatin1String(kExploreSourceType), QString()).toString();
+    /* Only the two tuner sources can explore -- a PCM feed or a file has nothing to
+     * point anywhere -- so anything else stored here reads as "not chosen yet" and
+     * sends the user to the setup sheet rather than starting something that cannot
+     * tune. Empty is the honest default: it is what makes the first tap ask. */
+    return (type == QLatin1String("usb") || type == QLatin1String("rtltcp")) ? type : QString();
+}
+
+void
+AppPrefs::setExploreSourceType(const QString& type) {
+    if (type == exploreSourceType()) {
+        return;
+    }
+    m_settings.setValue(QLatin1String(kExploreSourceType), type);
+    Q_EMIT exploreChanged();
+}
+
+QString
+AppPrefs::exploreHost() const {
+    return m_settings.value(QLatin1String(kExploreHost), QString()).toString();
+}
+
+void
+AppPrefs::setExploreHost(const QString& host) {
+    if (host == exploreHost()) {
+        return;
+    }
+    m_settings.setValue(QLatin1String(kExploreHost), host);
+    Q_EMIT exploreChanged();
+}
+
+int
+AppPrefs::explorePort() const {
+    const int port = m_settings.value(QLatin1String(kExplorePort), 1234).toInt();
+    return (port >= 1 && port <= 65535) ? port : 1234;
+}
+
+void
+AppPrefs::setExplorePort(int port) {
+    if (port == explorePort()) {
+        return;
+    }
+    m_settings.setValue(QLatin1String(kExplorePort), port);
+    Q_EMIT exploreChanged();
+}
+
+QString
+AppPrefs::exploreFreqMhz() const {
+    /* A string, like every other frequency in this app: the session-args builder and
+     * the card meta both read freqMhz as text, and a number here loses the trailing
+     * digits that tell a user which channel they were on. */
+    return m_settings.value(QLatin1String(kExploreFreqMhz), QString()).toString();
+}
+
+void
+AppPrefs::setExploreFreqMhz(const QString& mhz) {
+    if (mhz == exploreFreqMhz()) {
+        return;
+    }
+    m_settings.setValue(QLatin1String(kExploreFreqMhz), mhz);
+    Q_EMIT exploreChanged();
 }
 
 } // namespace dsd_qt

--- a/src/ui/qt/app_prefs.h
+++ b/src/ui/qt/app_prefs.h
@@ -36,6 +36,13 @@ class AppPrefs : public QObject {
     Q_PROPERTY(int bandwidthKhz READ bandwidthKhz WRITE setBandwidthKhz NOTIFY bandwidthKhzChanged)
     Q_PROPERTY(bool biasTee READ biasTee WRITE setBiasTee NOTIFY biasTeeChanged)
     Q_PROPERTY(QString extraArgs READ extraArgs WRITE setExtraArgs NOTIFY extraArgsChanged)
+    /* Where exploring was left off. One signal for all four: they are written
+     * together as a single "how to start exploring" answer, and nothing binds to
+     * one of them without the rest. */
+    Q_PROPERTY(QString exploreSourceType READ exploreSourceType WRITE setExploreSourceType NOTIFY exploreChanged)
+    Q_PROPERTY(QString exploreHost READ exploreHost WRITE setExploreHost NOTIFY exploreChanged)
+    Q_PROPERTY(int explorePort READ explorePort WRITE setExplorePort NOTIFY exploreChanged)
+    Q_PROPERTY(QString exploreFreqMhz READ exploreFreqMhz WRITE setExploreFreqMhz NOTIFY exploreChanged)
 
   public:
     /** @brief Appearance follows the OS by default; see the settings screen. */
@@ -78,6 +85,21 @@ class AppPrefs : public QObject {
     QString extraArgs() const;
     void setExtraArgs(const QString& args);
 
+    /** @brief "usb" or "rtltcp"; empty until the user has chosen, which is what makes
+     *         the first Explore tap open the setup sheet instead of starting blind. */
+    QString exploreSourceType() const;
+    void setExploreSourceType(const QString& type);
+
+    QString exploreHost() const;
+    void setExploreHost(const QString& host);
+
+    int explorePort() const;
+    void setExplorePort(int port);
+
+    /** @brief Start frequency in MHz, as text; empty until an explore session has run. */
+    QString exploreFreqMhz() const;
+    void setExploreFreqMhz(const QString& mhz);
+
   Q_SIGNALS:
     void appearanceChanged();
     void onboardingDoneChanged();
@@ -90,6 +112,7 @@ class AppPrefs : public QObject {
     void bandwidthKhzChanged();
     void biasTeeChanged();
     void extraArgsChanged();
+    void exploreChanged();
 
   private:
     mutable QSettings m_settings;

--- a/src/ui/qt/command_bridge.cpp
+++ b/src/ui/qt/command_bridge.cpp
@@ -68,6 +68,12 @@ CommandBridge::releaseTuner() const {
 }
 
 bool
+// cppcheck-suppress functionStatic -- Q_INVOKABLE members cannot be static (Qt meta-object)
+CommandBridge::setTrunking(bool on) const {
+    return accepted(dsd_app_command_set_i32(DSD_APP_CMD_TRUNK_SET, on ? 1 : 0));
+}
+
+bool
 CommandBridge::setTunerGain(int gain_db) const {
     return accepted(dsd_app_command_set_i32(DSD_APP_CMD_RTL_SET_GAIN, static_cast<int32_t>(gain_db)));
 }

--- a/src/ui/qt/command_bridge.cpp
+++ b/src/ui/qt/command_bridge.cpp
@@ -5,16 +5,11 @@
 
 #include "command_bridge.h"
 
-#include <QChar>
-#include <QLatin1String>
-#include <QList>
-#include <QStringList>
-#include <Qt>
 #include <dsd-neo/app_control/commands.h>
 #include <dsd-neo/app_control/history.h>
-#include <dsd-neo/runtime/config.h>
-#include <dsd-neo/runtime/decode_mode.h>
 #include <stdint.h>
+
+#include "decode_mode_flag.h"
 
 namespace dsd_qt {
 
@@ -106,21 +101,7 @@ CommandBridge::setDecodeMode(int mode) const {
 int
 // cppcheck-suppress functionStatic -- Q_INVOKABLE members cannot be static (Qt meta-object)
 CommandBridge::decodeModeForFlag(const QString& flag) const {
-    /* The chip's flag is the CLI's own text, so the mapping is the CLI's own
-     * function rather than a second table here that could drift from it. A chip
-     * may carry several flags ("-f1 -mq"); the decode one is whichever is -f. */
-    const QStringList tokens = flag.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-    for (const QString& token : tokens) {
-        if (!token.startsWith(QLatin1String("-f")) || token.size() != 3) {
-            continue;
-        }
-        dsdneoUserDecodeMode mode = DSDCFG_MODE_UNSET;
-        if (dsd_decode_mode_from_cli_preset(token.at(2).toLatin1(), &mode) == 0) {
-            return static_cast<int>(mode);
-        }
-    }
-    /* An empty flag is the engine's own default, which is the auto preset. */
-    return flag.trimmed().isEmpty() ? static_cast<int>(DSDCFG_MODE_AUTO) : -1;
+    return decode_mode_for_flag(flag);
 }
 
 int

--- a/src/ui/qt/command_bridge.cpp
+++ b/src/ui/qt/command_bridge.cpp
@@ -92,7 +92,10 @@ CommandBridge::setPpm(int ppm) const {
 bool
 // cppcheck-suppress functionStatic -- Q_INVOKABLE members cannot be static (Qt meta-object)
 CommandBridge::setModulation(int modulation) const {
-    return accepted(dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, (modulation != 0) ? 1 : 0));
+    if (modulation < 0 || modulation > 2) {
+        return false;
+    }
+    return accepted(dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, static_cast<int32_t>(modulation)));
 }
 
 bool

--- a/src/ui/qt/command_bridge.cpp
+++ b/src/ui/qt/command_bridge.cpp
@@ -55,6 +55,11 @@ CommandBridge::tuneHz(unsigned int hz) const {
 }
 
 bool
+CommandBridge::manualTuneHz(unsigned int hz) const {
+    return accepted(dsd_app_command_set_u32(DSD_APP_CMD_MANUAL_TUNE, static_cast<uint32_t>(hz)));
+}
+
+bool
 CommandBridge::setTunerGain(int gain_db) const {
     return accepted(dsd_app_command_set_i32(DSD_APP_CMD_RTL_SET_GAIN, static_cast<int32_t>(gain_db)));
 }

--- a/src/ui/qt/command_bridge.cpp
+++ b/src/ui/qt/command_bridge.cpp
@@ -5,8 +5,15 @@
 
 #include "command_bridge.h"
 
+#include <QChar>
+#include <QLatin1String>
+#include <QList>
+#include <QStringList>
+#include <Qt>
 #include <dsd-neo/app_control/commands.h>
 #include <dsd-neo/app_control/history.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
 #include <stdint.h>
 
 namespace dsd_qt {
@@ -60,8 +67,57 @@ CommandBridge::manualTuneHz(unsigned int hz) const {
 }
 
 bool
+// cppcheck-suppress functionStatic -- Q_INVOKABLE members cannot be static (Qt meta-object)
+CommandBridge::releaseTuner() const {
+    return accepted(dsd_app_command_action(DSD_APP_CMD_TUNER_RELEASE));
+}
+
+bool
 CommandBridge::setTunerGain(int gain_db) const {
     return accepted(dsd_app_command_set_i32(DSD_APP_CMD_RTL_SET_GAIN, static_cast<int32_t>(gain_db)));
+}
+
+bool
+// cppcheck-suppress functionStatic -- Q_INVOKABLE members cannot be static (Qt meta-object)
+CommandBridge::setSquelchDb(double db) const {
+    return accepted(dsd_app_command_set_double(DSD_APP_CMD_RTL_SET_SQL_DB, db));
+}
+
+bool
+// cppcheck-suppress functionStatic -- Q_INVOKABLE members cannot be static (Qt meta-object)
+CommandBridge::setPpm(int ppm) const {
+    return accepted(dsd_app_command_set_i32(DSD_APP_CMD_RTL_SET_PPM, static_cast<int32_t>(ppm)));
+}
+
+bool
+// cppcheck-suppress functionStatic -- Q_INVOKABLE members cannot be static (Qt meta-object)
+CommandBridge::setModulation(int modulation) const {
+    return accepted(dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, (modulation != 0) ? 1 : 0));
+}
+
+bool
+CommandBridge::setDecodeMode(int mode) const {
+    return accepted(dsd_app_command_set_i32(DSD_APP_CMD_DECODE_MODE_SET, static_cast<int32_t>(mode)));
+}
+
+int
+// cppcheck-suppress functionStatic -- Q_INVOKABLE members cannot be static (Qt meta-object)
+CommandBridge::decodeModeForFlag(const QString& flag) const {
+    /* The chip's flag is the CLI's own text, so the mapping is the CLI's own
+     * function rather than a second table here that could drift from it. A chip
+     * may carry several flags ("-f1 -mq"); the decode one is whichever is -f. */
+    const QStringList tokens = flag.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    for (const QString& token : tokens) {
+        if (!token.startsWith(QLatin1String("-f")) || token.size() != 3) {
+            continue;
+        }
+        dsdneoUserDecodeMode mode = DSDCFG_MODE_UNSET;
+        if (dsd_decode_mode_from_cli_preset(token.at(2).toLatin1(), &mode) == 0) {
+            return static_cast<int>(mode);
+        }
+    }
+    /* An empty flag is the engine's own default, which is the auto preset. */
+    return flag.trimmed().isEmpty() ? static_cast<int>(DSDCFG_MODE_AUTO) : -1;
 }
 
 int

--- a/src/ui/qt/command_bridge.h
+++ b/src/ui/qt/command_bridge.h
@@ -61,6 +61,16 @@ class CommandBridge : public QObject {
      */
     Q_INVOKABLE bool releaseTuner() const;
 
+    /**
+     * @brief Hand the tuner to trunking (@a on true), or stop it following.
+     *
+     * The inverse of releaseTuner() for the one flag a view can name. Turning it
+     * on also clears scanner mode engine-side, since both cannot drive the tuner.
+     * Off is the narrow half — it leaves scanner mode alone, so releaseTuner()
+     * stays the way to ask for the tuner back without knowing what holds it.
+     */
+    Q_INVOKABLE bool setTrunking(bool on) const;
+
     /** @brief Set tuner gain in dB (0 selects automatic gain). */
     Q_INVOKABLE bool setTunerGain(int gain_db) const;
 

--- a/src/ui/qt/command_bridge.h
+++ b/src/ui/qt/command_bridge.h
@@ -71,11 +71,12 @@ class CommandBridge : public QObject {
     Q_INVOKABLE bool setPpm(int ppm) const;
 
     /**
-     * @brief Choose the demodulator: 0 for C4FM, 1 for QPSK.
+     * @brief Choose the demodulator: 0 for C4FM, 1 for QPSK, 2 for GFSK.
      *
-     * A setter, not the hotkey's cycle: a control showing both as choices has to
+     * A setter, not the hotkey's cycle: a control showing them as choices has to
      * be able to ask for the one it is not on without guessing at a state the
-     * engine may have moved since.
+     * engine may have moved since. Anything outside 0..2 is refused here rather
+     * than clamped, so a caller's mistake does not silently land on C4FM.
      */
     Q_INVOKABLE bool setModulation(int modulation) const;
 

--- a/src/ui/qt/command_bridge.h
+++ b/src/ui/qt/command_bridge.h
@@ -15,6 +15,7 @@
 #define DSD_NEO_SRC_UI_QT_COMMAND_BRIDGE_H_
 
 #include <QObject>
+#include <QString>
 
 namespace dsd_qt {
 
@@ -50,8 +51,50 @@ class CommandBridge : public QObject {
      */
     Q_INVOKABLE bool manualTuneHz(unsigned int hz) const;
 
+    /**
+     * @brief Stop trunking and scanner mode from moving the tuner.
+     *
+     * Idempotent, and deliberately not a toggle: a view only learns that
+     * something owns the tuner, never which of the two, so it cannot safely
+     * flip either flag on its own. Also tears down the follow state the trunker
+     * left behind, so the decoder can acquire whatever it is pointed at next.
+     */
+    Q_INVOKABLE bool releaseTuner() const;
+
     /** @brief Set tuner gain in dB (0 selects automatic gain). */
     Q_INVOKABLE bool setTunerGain(int gain_db) const;
+
+    /** @brief Set the RTL power squelch threshold, in dB. */
+    Q_INVOKABLE bool setSquelchDb(double db) const;
+
+    /** @brief Set the dongle's crystal correction, in parts per million. */
+    Q_INVOKABLE bool setPpm(int ppm) const;
+
+    /**
+     * @brief Choose the demodulator: 0 for C4FM, 1 for QPSK.
+     *
+     * A setter, not the hotkey's cycle: a control showing both as choices has to
+     * be able to ask for the one it is not on without guessing at a state the
+     * engine may have moved since.
+     */
+    Q_INVOKABLE bool setModulation(int modulation) const;
+
+    /**
+     * @brief Switch which protocols are decoded, live.
+     *
+     * @param mode A dsdneoUserDecodeMode. Use decodeModeForFlag() to get one from
+     *        the same decode-chip flag a saved system stores, so the mapping from
+     *        flag to preset exists once and is the CLI's own.
+     */
+    Q_INVOKABLE bool setDecodeMode(int mode) const;
+
+    /**
+     * @brief The decode mode a `-f<x>` chip flag selects, or -1 when it selects none.
+     *
+     * "-mq" is a modulation chip, not a decode one, and answers -1: it says how to
+     * demodulate, not what to look for.
+     */
+    Q_INVOKABLE int decodeModeForFlag(const QString& flag) const;
 
     /** @brief Cycle the event-history display mode. */
     Q_INVOKABLE int cycleHistoryMode() const;

--- a/src/ui/qt/command_bridge.h
+++ b/src/ui/qt/command_bridge.h
@@ -40,6 +40,16 @@ class CommandBridge : public QObject {
     /** @brief Retune the radio front end. */
     Q_INVOKABLE bool tuneHz(unsigned int hz) const;
 
+    /**
+     * @brief Retune from a spectrum tap.
+     *
+     * Distinct from tuneHz(): taps coalesce only with taps, the decoder resets
+     * its auto-modulation votes and call state so it re-acquires on the new
+     * frequency, and the engine refuses the tune outright while trunking owns
+     * the tuner.
+     */
+    Q_INVOKABLE bool manualTuneHz(unsigned int hz) const;
+
     /** @brief Set tuner gain in dB (0 selects automatic gain). */
     Q_INVOKABLE bool setTunerGain(int gain_db) const;
 

--- a/src/ui/qt/decode_mode_flag.h
+++ b/src/ui/qt/decode_mode_flag.h
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief The decode-chip flag to preset-enum mapping, shared with the QML tests.
+ *
+ * Header-only and free of every Qt UI type but QString, so the QML test can
+ * compile the real thing rather than keep a second copy of it. A copy is what
+ * this replaces: the test double used to answer with numbers that were not the
+ * enum's, which made the case asserting "the DMR chip sends DMR" pass on a value
+ * DSDCFG_MODE_DMR has never had.
+ */
+
+#ifndef DSD_NEO_SRC_UI_QT_DECODE_MODE_FLAG_H_
+#define DSD_NEO_SRC_UI_QT_DECODE_MODE_FLAG_H_
+
+#include <QChar>
+#include <QLatin1String>
+#include <QList>
+#include <QString>
+#include <QStringList>
+#include <Qt>
+
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
+
+namespace dsd_qt {
+
+/**
+ * @brief The decode preset a chip's CLI flag selects.
+ *
+ * The chip's flag is the CLI's own text, so the mapping is the CLI's own function
+ * rather than a second table here that could drift from it. A chip may carry
+ * several flags ("-f1 -mq"); the decode one is whichever is -f.
+ *
+ * @param flag The chip's flag text; empty means the engine's own default.
+ * @return A `dsdneoUserDecodeMode` value, or -1 when the flag selects no preset.
+ */
+inline int
+decode_mode_for_flag(const QString& flag) {
+    const QStringList tokens = flag.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    for (const QString& token : tokens) {
+        if (!token.startsWith(QLatin1String("-f")) || token.size() != 3) {
+            continue;
+        }
+        dsdneoUserDecodeMode mode = DSDCFG_MODE_UNSET;
+        if (dsd_decode_mode_from_cli_preset(token.at(2).toLatin1(), &mode) == 0) {
+            return static_cast<int>(mode);
+        }
+    }
+    /* An empty flag is the engine's own default, which is the auto preset. */
+    return flag.trimmed().isEmpty() ? static_cast<int>(DSDCFG_MODE_AUTO) : -1;
+}
+
+} // namespace dsd_qt
+
+#endif /* DSD_NEO_SRC_UI_QT_DECODE_MODE_FLAG_H_ */

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -179,12 +179,13 @@ MetricsModel::refresh(const dsd_opts* opts_snapshot, const dsd_state* snapshot) 
     next.carrier_lock = metrics.carrier_lock != 0;
     next.cfo_hz = metrics.cfo_hz;
     next.stream_active = metrics.stream_active != 0;
-    /* Where the front end is pointed, and whether the trunking controller is the
-     * one pointing it. Both come from the same options snapshot as radio_input,
+    /* Where the front end is pointed, and whether something other than the user
+     * is pointing it. Both come from the same options snapshot as radio_input,
      * so a frame never mixes a center from one generation with a gate from
-     * another. */
+     * another. Scanner mode counts alongside trunking: it owns the tuner too,
+     * stepping the channel map once the hangtime expires. */
     next.center_freq_hz = next.radio_input ? static_cast<double>(opts_snapshot->rtlsdr_center_freq) : 0.0;
-    next.trunking_enabled = opts_snapshot->trunk_enable != 0;
+    next.tuner_controlled = (opts_snapshot->trunk_enable != 0) || (opts_snapshot->scanner_mode != 0);
 
     /* Selected by modulation, not by cqpsk_enable: the C4FM estimator reads nothing on
      * a GFSK stream. Nothing reads at all on an input with no demodulator behind it

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -13,7 +13,10 @@
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/enc_lockout.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/runtime/decode_mode.h>
 #include <stdint.h>
 
 #include "call_line.h"
@@ -23,6 +26,15 @@
 namespace dsd_qt {
 
 namespace {
+
+/**
+ * @brief How long a lock keeps reading as locked after the last synced frame.
+ *
+ * Long enough to ride out the gaps between frames a 250 ms poll lands in, short
+ * enough that a decoder which has genuinely stopped finding anything says so
+ * while the reader is still looking at it.
+ */
+constexpr double kSyncHoldSeconds = 3.0;
 
 /**
  * @brief Whether the call reads as encrypted over the air, including DECRYPTABLE.
@@ -55,6 +67,41 @@ slot_enc_text(const dsd_call_snapshot& call) {
         .toUpper();
 }
 
+/**
+ * @brief Whether the epoch carries nothing that could name a transmission.
+ *
+ * The decoder opens one on a frame that synced far enough to be a frame and no
+ * further, which happens routinely on a control channel and on noise while
+ * hunting. Rendered, it becomes a call from talkgroup 0 by nobody — and if a
+ * stale crypto header is still on the slot, an encrypted one. On a session that
+ * has not locked onto anything, that is the screen inventing traffic.
+ */
+bool
+call_has_no_identity(const dsd_call_snapshot& call) {
+    return call.ota_target_id == 0U && call.policy_target_id == 0U && call.target_text[0] == '\0'
+           && call.ota_source_id == 0U && call.source_text[0] == '\0';
+}
+
+/**
+ * @brief The CSV-imported group name staged on the slot's active history row, or empty.
+ *
+ * The staged row's target_id is stamped OTA-then-policy by the event layer, so it
+ * must be compared against the same preference (the caller's resolved tg_id), not
+ * the OTA id alone — a policy-resolved talkgroup would never match otherwise.
+ * Nonzero required: a text-only target's 0 would "match" a stale staged row.
+ */
+QString
+staged_group_name(const dsd_state* snapshot, quint8 slot, qulonglong tg_id) {
+    if (snapshot->event_history_s == nullptr || tg_id == 0) {
+        return QString();
+    }
+    const Event_History* staged = &snapshot->event_history_s[slot].Event_History_Items[0];
+    if (staged->t_name[0] == '\0' || staged->target_id != static_cast<uint32_t>(tg_id)) {
+        return QString();
+    }
+    return QString::fromUtf8(staged->t_name);
+}
+
 } // namespace
 
 /**
@@ -74,6 +121,12 @@ MetricsModel::slotCallView(const dsd_state* snapshot, quint8 slot, double now_m)
         return out;
     }
 
+    /* An epoch with nothing in it is not a transmission anyone can be shown. */
+    if (call_has_no_identity(call)) {
+        out.state = static_cast<int>(kCallLineIdle);
+        return out;
+    }
+
     const QString target = (call.target_text[0] != '\0') ? QString::fromUtf8(call.target_text)
                                                          : QString::number(static_cast<qulonglong>(call.ota_target_id));
     out.tg_text = target;
@@ -84,17 +137,8 @@ MetricsModel::slotCallView(const dsd_state* snapshot, quint8 slot, double now_m)
     out.src_text = (call.source_text[0] != '\0') ? QString::fromUtf8(call.source_text)
                                                  : QString::number(static_cast<qulonglong>(call.ota_source_id));
 
-    out.name = target;
-    if (snapshot->event_history_s != nullptr) {
-        const Event_History* staged = &snapshot->event_history_s[slot].Event_History_Items[0];
-        // The staged row's target_id is stamped OTA-then-policy by the event layer,
-        // so it must be compared against the same preference (out.tg_id), not the
-        // OTA id alone — a policy-resolved talkgroup would never match otherwise.
-        // Nonzero required: a text-only target's 0 would "match" a stale staged row.
-        if (staged->t_name[0] != '\0' && out.tg_id != 0 && staged->target_id == static_cast<uint32_t>(out.tg_id)) {
-            out.name = QString::fromUtf8(staged->t_name);
-        }
-    }
+    const QString staged_name = staged_group_name(snapshot, slot, out.tg_id);
+    out.name = staged_name.isEmpty() ? target : staged_name;
 
     out.enc = call_reads_encrypted(call);
     if (out.enc) {
@@ -148,7 +192,55 @@ MetricsModel::publish(const View& next) {
 void
 MetricsModel::clear() {
     m_messageTimer.stop();
+    /* The latch is per-session state, not part of the published frame: a stopped
+     * session that starts again on the same frequency must not inherit the old
+     * session's answer to "is there anything here". */
+    m_sync_type_here = DSD_SYNC_NONE;
+    m_sync_seen_m = 0.0;
     publish(View());
+}
+
+/**
+ * @brief Fill in what the decoder is doing and what it is set to.
+ *
+ * The settings are read from the options snapshot rather than remembered from the
+ * last command, because a command can be refused and, on Android, the service
+ * that owns them outlives this process.
+ */
+void
+MetricsModel::fillDecoderView(View& next, const dsd_opts* opts_snapshot, const dsd_state* snapshot, double now_m) {
+    next.decode_mode = static_cast<int>(dsd_infer_decode_mode_preset(opts_snapshot));
+
+    /* Held for a moment after the last live sync, rather than latched until
+     * something explicitly clears it.
+     *
+     * A hold is needed at all because sync comes and goes between the 250 ms
+     * polls, so an instantaneous reading flickers. But it has to expire on its
+     * own: the first version cleared the latch on a retune or a decode-mode
+     * change, and any such one-shot reset is a race against whatever the poll
+     * happens to read on that same frame -- observed as the strip still naming
+     * P25 minutes after being told to decode DMR, with no P25 sync in the log at
+     * all. Decay answers the question the reader is actually asking ("is it
+     * locked now") and cannot get stuck on an answer to a question they stopped
+     * asking. lastsynctype is deliberately not consulted: it holds the previous
+     * lock until the engine's no-carrier path gets round to clearing it. */
+    if (snapshot->synctype != DSD_SYNC_NONE) {
+        m_sync_type_here = snapshot->synctype;
+        m_sync_seen_m = now_m;
+    } else if (m_sync_type_here != DSD_SYNC_NONE && (now_m - m_sync_seen_m) > kSyncHoldSeconds) {
+        m_sync_type_here = DSD_SYNC_NONE;
+    }
+    next.synced_here = m_sync_type_here != DSD_SYNC_NONE;
+    if (next.synced_here) {
+        next.sync_label = QString::fromUtf8(dsd_synctype_to_string(m_sync_type_here));
+    }
+    next.modulation = (opts_snapshot->mod_qpsk != 0) ? 1 : 0;
+    next.tuner_gain_db = opts_snapshot->rtl_gain_value;
+    /* rtl_squelch_level is a mean-power threshold, not decibels — the same
+     * conversion the engine's own status line uses. Publishing the raw value
+     * would put "0" on screen for a squelch of -120 dB. */
+    next.squelch_db = pwr_to_dB(opts_snapshot->rtl_squelch_level);
+    next.ppm = opts_snapshot->rtlsdr_ppm_error;
 }
 
 void
@@ -185,7 +277,15 @@ MetricsModel::refresh(const dsd_opts* opts_snapshot, const dsd_state* snapshot) 
      * another. Scanner mode counts alongside trunking: it owns the tuner too,
      * stepping the channel map once the hangtime expires. */
     next.center_freq_hz = next.radio_input ? static_cast<double>(opts_snapshot->rtlsdr_center_freq) : 0.0;
-    next.tuner_controlled = (opts_snapshot->trunk_enable != 0) || (opts_snapshot->scanner_mode != 0);
+    next.trunking_enabled = opts_snapshot->trunk_enable != 0;
+    next.scanner_mode = opts_snapshot->scanner_mode != 0;
+    next.tuner_controlled = next.trunking_enabled || next.scanner_mode;
+
+    /* Sync is latched per tuned frequency rather than sampled. synctype carries the
+     * frame currently being decoded and lastsynctype the one before it; either being
+     * set means the decoder has locked onto something here, and neither survives the
+     * tuner moving on, because the move clears the latch. */
+    fillDecoderView(next, opts_snapshot, snapshot, dsd_time_now_monotonic_s());
 
     /* Selected by modulation, not by cqpsk_enable: the C4FM estimator reads nothing on
      * a GFSK stream. Nothing reads at all on an input with no demodulator behind it

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -282,12 +282,14 @@ MetricsModel::refresh(const dsd_opts* opts_snapshot, const dsd_state* snapshot) 
     next.center_freq_hz = next.radio_input ? static_cast<double>(opts_snapshot->rtlsdr_center_freq) : 0.0;
     next.trunking_enabled = opts_snapshot->trunk_enable != 0;
     next.scanner_mode = opts_snapshot->scanner_mode != 0;
-    next.tuner_controlled = next.trunking_enabled || next.scanner_mode;
+    /* Trunk scan counts as a third owner even though it has no reading of its own:
+     * it steps targets from the engine loop and a release cannot clear it, so an
+     * affordance gated only on the other two offers a tune the scan then undoes. */
+    next.tuner_controlled = next.trunking_enabled || next.scanner_mode || (opts_snapshot->trunk_scan_enabled != 0);
 
-    /* Sync is latched per tuned frequency rather than sampled. synctype carries the
-     * frame currently being decoded and lastsynctype the one before it; either being
-     * set means the decoder has locked onto something here, and neither survives the
-     * tuner moving on, because the move clears the latch. */
+    /* Sync is held for a moment after the last synced frame rather than sampled;
+     * the hold decays on its own rather than being cleared on a retune. See
+     * fillDecoderView(), which documents why a one-shot reset was a race. */
     fillDecoderView(next, opts_snapshot, snapshot, dsd_time_now_monotonic_s());
 
     /* Selected by modulation, not by cqpsk_enable: the C4FM estimator reads nothing on

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -234,7 +234,10 @@ MetricsModel::fillDecoderView(View& next, const dsd_opts* opts_snapshot, const d
     if (next.synced_here) {
         next.sync_label = QString::fromUtf8(dsd_synctype_to_string(m_sync_type_here));
     }
-    next.modulation = (opts_snapshot->mod_qpsk != 0) ? 1 : 0;
+    /* Three states, not two: GFSK is what the DMR and EDACS/ProVoice presets
+     * select, and folding it into C4FM made a control bound to this reading show
+     * C4FM as already-selected on a session that was never on it. */
+    next.modulation = (opts_snapshot->mod_qpsk != 0) ? 1 : ((opts_snapshot->mod_gfsk != 0) ? 2 : 0);
     next.tuner_gain_db = opts_snapshot->rtl_gain_value;
     /* rtl_squelch_level is a mean-power threshold, not decibels — the same
      * conversion the engine's own status line uses. Publishing the raw value

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -252,6 +252,10 @@ MetricsModel::fillDecoderView(View& next, const dsd_opts* opts_snapshot, const d
     if (next.synced_here) {
         next.sync_label = QString::fromUtf8(dsd_synctype_to_string(m_sync_type_here));
     }
+    /* Rides the same decayed reading as synced_here rather than the raw snapshot:
+     * a control offered on one frame of sync and withdrawn on the next would
+     * flicker under the finger. */
+    next.trunkable_sync = next.synced_here && DSD_SYNC_IS_TRUNKABLE(m_sync_type_here);
     /* Three states, not two: GFSK is what the DMR and EDACS/ProVoice presets
      * select, and folding it into C4FM made a control bound to this reading show
      * C4FM as already-selected on a session that was never on it. Through the

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -307,6 +307,7 @@ MetricsModel::refresh(const dsd_opts* opts_snapshot, const dsd_state* snapshot) 
      * another. Scanner mode counts alongside trunking: it owns the tuner too,
      * stepping the channel map once the hangtime expires. */
     next.center_freq_hz = next.radio_input ? static_cast<double>(opts_snapshot->rtlsdr_center_freq) : 0.0;
+    next.channel_bandwidth_hz = next.radio_input ? metrics.channel_bandwidth_hz : 0;
     next.trunking_enabled = opts_snapshot->trunk_enable != 0;
     next.scanner_mode = opts_snapshot->scanner_mode != 0;
     /* Trunk scan counts as a third owner even though it has no reading of its own:

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -75,11 +75,29 @@ slot_enc_text(const dsd_call_snapshot& call) {
  * hunting. Rendered, it becomes a call from talkgroup 0 by nobody — and if a
  * stale crypto header is still on the slot, an encrypted one. On a session that
  * has not locked onto anything, that is the screen inventing traffic.
+ *
+ * The field list mirrors dsd_call_state_snapshot_has_identity() (call_state.c),
+ * route_text included: D-STAR, NXDN and YSF enrich the repeater pair, and a call
+ * whose route decoded before its callsigns is a named transmission the canonical
+ * layer already counts as one. That helper lives behind call_state_internal.h and
+ * a frontend cannot call it, which is why this mirror exists — but a mirror that
+ * drops a field reports idle for calls the rest of the app is showing.
+ *
+ * X2-TDMA and standalone ProVoice are the deliberate exception, matching
+ * dsd_call_state_protocol_voice_is_anonymous(): those modes never parse voice into
+ * a talkgroup or a source at all, so an identity-less voice epoch is the whole
+ * story the protocol has — not a frame that synced and went nowhere. Suppressed,
+ * their transmissions would play audio and log history rows while the panel said
+ * nothing was happening.
  */
 bool
 call_has_no_identity(const dsd_call_snapshot& call) {
+    if (DSD_SYNC_IS_X2TDMA(call.protocol) || DSD_SYNC_IS_PROVOICE(call.protocol)) {
+        return false;
+    }
     return call.ota_target_id == 0U && call.policy_target_id == 0U && call.target_text[0] == '\0'
-           && call.ota_source_id == 0U && call.source_text[0] == '\0';
+           && call.ota_source_id == 0U && call.source_text[0] == '\0' && call.route_text[0][0] == '\0'
+           && call.route_text[1][0] == '\0';
 }
 
 /**
@@ -236,14 +254,19 @@ MetricsModel::fillDecoderView(View& next, const dsd_opts* opts_snapshot, const d
     }
     /* Three states, not two: GFSK is what the DMR and EDACS/ProVoice presets
      * select, and folding it into C4FM made a control bound to this reading show
-     * C4FM as already-selected on a session that was never on it. */
-    next.modulation = (opts_snapshot->mod_qpsk != 0) ? 1 : ((opts_snapshot->mod_gfsk != 0) ? 2 : 0);
-    next.tuner_gain_db = opts_snapshot->rtl_gain_value;
+     * C4FM as already-selected on a session that was never on it. Through the
+     * shared helper so this and ui_handle_mod_set()'s skip test cannot drift. */
+    next.modulation = dsd_opts_modulation(opts_snapshot);
+    /* Gated on radio_input like center_freq_hz above, and for the same reason:
+     * on a WAV, UDP, TCP or symbol-file session these are options the front end
+     * never applied, and publishing them would put three plausible tuner
+     * readings on screen for a session that has no tuner. */
+    next.tuner_gain_db = next.radio_input ? opts_snapshot->rtl_gain_value : 0;
     /* rtl_squelch_level is a mean-power threshold, not decibels — the same
      * conversion the engine's own status line uses. Publishing the raw value
      * would put "0" on screen for a squelch of -120 dB. */
-    next.squelch_db = pwr_to_dB(opts_snapshot->rtl_squelch_level);
-    next.ppm = opts_snapshot->rtlsdr_ppm_error;
+    next.squelch_db = next.radio_input ? pwr_to_dB(opts_snapshot->rtl_squelch_level) : 0.0;
+    next.ppm = next.radio_input ? opts_snapshot->rtlsdr_ppm_error : 0;
 }
 
 void

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -179,6 +179,12 @@ MetricsModel::refresh(const dsd_opts* opts_snapshot, const dsd_state* snapshot) 
     next.carrier_lock = metrics.carrier_lock != 0;
     next.cfo_hz = metrics.cfo_hz;
     next.stream_active = metrics.stream_active != 0;
+    /* Where the front end is pointed, and whether the trunking controller is the
+     * one pointing it. Both come from the same options snapshot as radio_input,
+     * so a frame never mixes a center from one generation with a gate from
+     * another. */
+    next.center_freq_hz = next.radio_input ? static_cast<double>(opts_snapshot->rtlsdr_center_freq) : 0.0;
+    next.trunking_enabled = opts_snapshot->trunk_enable != 0;
 
     /* Selected by modulation, not by cqpsk_enable: the C4FM estimator reads nothing on
      * a GFSK stream. Nothing reads at all on an input with no demodulator behind it

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -39,6 +39,7 @@ class MetricsModel : public QObject {
     Q_PROPERTY(bool radioInput READ radioInput NOTIFY tunerChanged)
     Q_PROPERTY(bool streamActive READ streamActive NOTIFY tunerChanged)
     Q_PROPERTY(double centerFreqHz READ centerFreqHz NOTIFY tunerChanged)
+    Q_PROPERTY(int channelBandwidthHz READ channelBandwidthHz NOTIFY tunerChanged)
     Q_PROPERTY(int slot1CallState READ slot1CallState NOTIFY slot1Changed)
     Q_PROPERTY(int slot2CallState READ slot2CallState NOTIFY slot2Changed)
     Q_PROPERTY(QString slot1CallName READ slot1CallName NOTIFY slot1Changed)
@@ -132,6 +133,19 @@ class MetricsModel : public QObject {
     double
     centerFreqHz() const {
         return m_view.center_freq_hz;
+    }
+
+    /**
+     * @brief Full width in Hz of the channel the demodulator is filtering.
+     *
+     * 12500 for the 12.5 kHz modes, 6250 for the narrow ones, 16000 wide. 0 when
+     * the input is not a radio, or before the demodulator has reported a profile —
+     * which the spectrum screen renders as "width unknown" rather than as zero
+     * width. The channel, not the filter: see dsd_channel_lpf_protected_edge_hz().
+     */
+    int
+    channelBandwidthHz() const {
+        return m_view.channel_bandwidth_hz;
     }
 
     /**
@@ -471,6 +485,7 @@ class MetricsModel : public QObject {
         bool radio_input = false;
         bool stream_active = false;
         double center_freq_hz = 0.0;
+        int channel_bandwidth_hz = 0;
         bool synced_here = false;
         QString sync_label;
         bool trunkable_sync = false;
@@ -497,8 +512,9 @@ class MetricsModel : public QObject {
             return snr_db == other.snr_db && snr_valid == other.snr_valid && carrier_lock == other.carrier_lock
                    && cfo_hz == other.cfo_hz && tuner_gain_text == other.tuner_gain_text
                    && radio_input == other.radio_input && stream_active == other.stream_active
-                   && center_freq_hz == other.center_freq_hz && synced_here == other.synced_here
-                   && sync_label == other.sync_label && trunkable_sync == other.trunkable_sync;
+                   && center_freq_hz == other.center_freq_hz && channel_bandwidth_hz == other.channel_bandwidth_hz
+                   && synced_here == other.synced_here && sync_label == other.sync_label
+                   && trunkable_sync == other.trunkable_sync;
         }
 
         bool

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -38,6 +38,7 @@ class MetricsModel : public QObject {
     Q_PROPERTY(QString tunerGainText READ tunerGainText NOTIFY tunerChanged)
     Q_PROPERTY(bool radioInput READ radioInput NOTIFY tunerChanged)
     Q_PROPERTY(bool streamActive READ streamActive NOTIFY tunerChanged)
+    Q_PROPERTY(double centerFreqHz READ centerFreqHz NOTIFY tunerChanged)
     Q_PROPERTY(int slot1CallState READ slot1CallState NOTIFY slot1Changed)
     Q_PROPERTY(int slot2CallState READ slot2CallState NOTIFY slot2Changed)
     Q_PROPERTY(QString slot1CallName READ slot1CallName NOTIFY slot1Changed)
@@ -57,6 +58,7 @@ class MetricsModel : public QObject {
     Q_PROPERTY(bool audioMuted READ audioMuted NOTIFY controlChanged)
     Q_PROPERTY(qulonglong heldTg READ heldTg NOTIFY controlChanged)
     Q_PROPERTY(int encLockoutCount READ encLockoutCount NOTIFY controlChanged)
+    Q_PROPERTY(bool trunkingEnabled READ trunkingEnabled NOTIFY controlChanged)
     Q_PROPERTY(QString uiMessage READ uiMessage NOTIFY uiMessageChanged)
 
   public:
@@ -106,6 +108,31 @@ class MetricsModel : public QObject {
     bool
     streamActive() const {
         return m_view.stream_active;
+    }
+
+    /**
+     * @brief The frequency the front end is tuned to, in Hz; 0 when there is none.
+     *
+     * A double rather than an integer because QML has no 64-bit integer type, and
+     * every frequency a tuner reaches is exact in a double. Good for a readout and
+     * for deciding what to ask for next — but a spectrum axis must use the center
+     * carried inside the spectrum frame itself, which is the one that provably
+     * matches those bins.
+     */
+    double
+    centerFreqHz() const {
+        return m_view.center_freq_hz;
+    }
+
+    /**
+     * @brief Whether the trunking controller owns the tuner.
+     *
+     * While it does, the engine refuses manual retunes, so a view offering one
+     * should say so rather than present a control that silently does nothing.
+     */
+    bool
+    trunkingEnabled() const {
+        return m_view.trunking_enabled;
     }
 
     /**
@@ -326,9 +353,11 @@ class MetricsModel : public QObject {
         QString tuner_gain_text;
         bool radio_input = false;
         bool stream_active = false;
+        double center_freq_hz = 0.0;
         bool audio_muted = false;
         qulonglong held_tg = 0;
         int enc_lockout_count = 0;
+        bool trunking_enabled = false;
         QString ui_message;
         SlotCall slot_call[2];
 
@@ -340,13 +369,14 @@ class MetricsModel : public QObject {
         tunerEquals(const View& other) const {
             return snr_db == other.snr_db && snr_valid == other.snr_valid && carrier_lock == other.carrier_lock
                    && cfo_hz == other.cfo_hz && tuner_gain_text == other.tuner_gain_text
-                   && radio_input == other.radio_input && stream_active == other.stream_active;
+                   && radio_input == other.radio_input && stream_active == other.stream_active
+                   && center_freq_hz == other.center_freq_hz;
         }
 
         bool
         controlEquals(const View& other) const {
             return audio_muted == other.audio_muted && held_tg == other.held_tg
-                   && enc_lockout_count == other.enc_lockout_count;
+                   && enc_lockout_count == other.enc_lockout_count && trunking_enabled == other.trunking_enabled;
         }
     };
 

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -21,6 +21,7 @@
 #include <QtGlobal>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/synctype_ids.h>
 
 namespace dsd_qt {
 
@@ -553,10 +554,12 @@ class MetricsModel : public QObject {
 
   private:
     View m_view;
-    /* Latched across frames rather than derived from one: frame sync comes and goes
+    /* Held across frames rather than derived from one: frame sync comes and goes
      * between 250 ms polls, so a single sample answers "is it synced right now",
-     * which is not the question. Cleared when the tuner moves; see syncedHere(). */
-    int m_sync_type_here = -1; /* DSD_SYNC_NONE */
+     * which is not the question. The hold decays on its own rather than being
+     * cleared on a retune or a mode change — fillDecoderView() documents why a
+     * one-shot reset was a race. See syncedHere(). */
+    int m_sync_type_here = DSD_SYNC_NONE;
     double m_sync_seen_m = 0.0;
     /* Armed for a live ui_message's expiry stamp, so the message leaves the screen
      * on time even when the idle engine never publishes another frame. */

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -59,6 +59,15 @@ class MetricsModel : public QObject {
     Q_PROPERTY(qulonglong heldTg READ heldTg NOTIFY controlChanged)
     Q_PROPERTY(int encLockoutCount READ encLockoutCount NOTIFY controlChanged)
     Q_PROPERTY(bool tunerControlled READ tunerControlled NOTIFY controlChanged)
+    Q_PROPERTY(bool trunkingEnabled READ trunkingEnabled NOTIFY controlChanged)
+    Q_PROPERTY(bool scannerMode READ scannerMode NOTIFY controlChanged)
+    Q_PROPERTY(bool syncedHere READ syncedHere NOTIFY tunerChanged)
+    Q_PROPERTY(QString syncLabel READ syncLabel NOTIFY tunerChanged)
+    Q_PROPERTY(int decodeMode READ decodeMode NOTIFY controlChanged)
+    Q_PROPERTY(int modulation READ modulation NOTIFY controlChanged)
+    Q_PROPERTY(int tunerGainDb READ tunerGainDb NOTIFY controlChanged)
+    Q_PROPERTY(double squelchDb READ squelchDb NOTIFY controlChanged)
+    Q_PROPERTY(int ppm READ ppm NOTIFY controlChanged)
     Q_PROPERTY(QString uiMessage READ uiMessage NOTIFY uiMessageChanged)
 
   public:
@@ -136,6 +145,96 @@ class MetricsModel : public QObject {
     bool
     tunerControlled() const {
         return m_view.tuner_controlled;
+    }
+
+    /**
+     * @brief Which owner is holding the tuner. For wording a message, never for gating.
+     *
+     * A control that is unavailable is unavailable for either reason, and anything
+     * that gates on one of these alone offers something the other owner then undoes --
+     * that is what tunerControlled() exists to prevent, and it stays the only reading
+     * an affordance may bind to. These two are here so a message can name the reason
+     * rather than say "something".
+     */
+    bool
+    trunkingEnabled() const {
+        return m_view.trunking_enabled;
+    }
+
+    bool
+    scannerMode() const {
+        return m_view.scanner_mode;
+    }
+
+    /**
+     * @brief Whether the decoder currently has frame sync, held briefly.
+     *
+     * Held rather than sampled, because sync drops and returns between the 250 ms
+     * polls and an instantaneous reading flickers; and held rather than latched,
+     * because a lock that outlives the thing that produced it is worse than one
+     * that flickers -- see kSyncHoldSeconds.
+     *
+     * Deliberately not call activity: a control channel carries no calls, and an
+     * accepted retune ends both call slots anyway, so anything watching those
+     * would read its own retune as a find.
+     */
+    bool
+    syncedHere() const {
+        return m_view.synced_here;
+    }
+
+    /**
+     * @brief What the decoder locked onto here — "P25p1", "DMR", … — or empty.
+     *
+     * The protocol, not merely that there is one: on a band being walked, "DMR"
+     * where P25 was expected is the answer to why nothing is being heard, and a
+     * plain lock light would leave that invisible.
+     */
+    const QString&
+    syncLabel() const {
+        return m_view.sync_label;
+    }
+
+    /**
+     * @brief Live front-end and decoder settings, for a panel that can change them.
+     *
+     * Read from the same options snapshot the commands mutate, so a control shows
+     * where the engine actually is rather than what the UI last asked for — the
+     * engine can refuse, and on Android the service outlives this process.
+     *
+     * decodeMode is a dsdneoUserDecodeMode; modulation is 0 for C4FM and 1 for
+     * QPSK, matching DSD_APP_CMD_MOD_SET's payload.
+     */
+    int
+    decodeMode() const {
+        return m_view.decode_mode;
+    }
+
+    int
+    modulation() const {
+        return m_view.modulation;
+    }
+
+    int
+    tunerGainDb() const {
+        return m_view.tuner_gain_db;
+    }
+
+    double
+    squelchDb() const {
+        return m_view.squelch_db;
+    }
+
+    /**
+     * @brief The dongle's crystal correction, in parts per million.
+     *
+     * Adjustable live because a wrong one is not obvious at the point it is
+     * entered: the symptom is a frequency offset the decoder cannot close, which
+     * only shows up once there is a signal to look at.
+     */
+    int
+    ppm() const {
+        return m_view.ppm;
     }
 
     /**
@@ -357,10 +456,19 @@ class MetricsModel : public QObject {
         bool radio_input = false;
         bool stream_active = false;
         double center_freq_hz = 0.0;
+        bool synced_here = false;
+        QString sync_label;
+        int decode_mode = 0;
+        int modulation = 0;
+        int tuner_gain_db = 0;
+        double squelch_db = 0.0;
+        int ppm = 0;
         bool audio_muted = false;
         qulonglong held_tg = 0;
         int enc_lockout_count = 0;
         bool tuner_controlled = false;
+        bool trunking_enabled = false;
+        bool scanner_mode = false;
         QString ui_message;
         SlotCall slot_call[2];
 
@@ -373,13 +481,17 @@ class MetricsModel : public QObject {
             return snr_db == other.snr_db && snr_valid == other.snr_valid && carrier_lock == other.carrier_lock
                    && cfo_hz == other.cfo_hz && tuner_gain_text == other.tuner_gain_text
                    && radio_input == other.radio_input && stream_active == other.stream_active
-                   && center_freq_hz == other.center_freq_hz;
+                   && center_freq_hz == other.center_freq_hz && synced_here == other.synced_here
+                   && sync_label == other.sync_label;
         }
 
         bool
         controlEquals(const View& other) const {
             return audio_muted == other.audio_muted && held_tg == other.held_tg
-                   && enc_lockout_count == other.enc_lockout_count && tuner_controlled == other.tuner_controlled;
+                   && enc_lockout_count == other.enc_lockout_count && tuner_controlled == other.tuner_controlled
+                   && trunking_enabled == other.trunking_enabled && scanner_mode == other.scanner_mode
+                   && decode_mode == other.decode_mode && modulation == other.modulation
+                   && tuner_gain_db == other.tuner_gain_db && squelch_db == other.squelch_db && ppm == other.ppm;
         }
     };
 
@@ -389,7 +501,30 @@ class MetricsModel : public QObject {
     /** @brief Build one slot's structured call identity from the snapshot. */
     static SlotCall slotCallView(const dsd_state* snapshot, quint8 slot, double now_m);
 
+    /** @brief Fill in sync state and the live decoder/front-end settings. */
+    void fillDecoderView(View& next, const dsd_opts* opts_snapshot, const dsd_state* snapshot, double now_m);
+
+  public:
+#ifdef DSD_NEO_TEST_HOOKS
+    /**
+     * @brief Age the sync hold out, as if kSyncHoldSeconds had passed.
+     *
+     * The expiry is the part worth testing and the only part a test cannot reach,
+     * short of sleeping for it in a suite that runs in milliseconds.
+     */
+    void
+    expireSyncForTest() {
+        m_sync_seen_m = 0.0;
+    }
+#endif
+
+  private:
     View m_view;
+    /* Latched across frames rather than derived from one: frame sync comes and goes
+     * between 250 ms polls, so a single sample answers "is it synced right now",
+     * which is not the question. Cleared when the tuner moves; see syncedHere(). */
+    int m_sync_type_here = -1; /* DSD_SYNC_NONE */
+    double m_sync_seen_m = 0.0;
     /* Armed for a live ui_message's expiry stamp, so the message leaves the screen
      * on time even when the idle engine never publishes another frame. */
     QTimer m_messageTimer;

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -63,6 +63,7 @@ class MetricsModel : public QObject {
     Q_PROPERTY(bool scannerMode READ scannerMode NOTIFY controlChanged)
     Q_PROPERTY(bool syncedHere READ syncedHere NOTIFY tunerChanged)
     Q_PROPERTY(QString syncLabel READ syncLabel NOTIFY tunerChanged)
+    Q_PROPERTY(bool trunkableSync READ trunkableSync NOTIFY tunerChanged)
     Q_PROPERTY(int decodeMode READ decodeMode NOTIFY controlChanged)
     Q_PROPERTY(int modulation READ modulation NOTIFY controlChanged)
     Q_PROPERTY(int tunerGainDb READ tunerGainDb NOTIFY controlChanged)
@@ -193,6 +194,20 @@ class MetricsModel : public QObject {
     const QString&
     syncLabel() const {
         return m_view.sync_label;
+    }
+
+    /**
+     * @brief Whether the lock here is on a protocol trunking can follow.
+     *
+     * What a control offering to hand the tuner to trunking needs: on M17 or
+     * D-STAR there is no trunking to hand it to, and on noise there is nothing to
+     * follow yet, so the offer would be a button that does nothing. Sync on a
+     * trunked protocol is the weakest honest claim available here — the signalling
+     * decides whether this carrier is really a control channel.
+     */
+    bool
+    trunkableSync() const {
+        return m_view.trunkable_sync;
     }
 
     /**
@@ -458,6 +473,7 @@ class MetricsModel : public QObject {
         double center_freq_hz = 0.0;
         bool synced_here = false;
         QString sync_label;
+        bool trunkable_sync = false;
         int decode_mode = 0;
         int modulation = 0;
         int tuner_gain_db = 0;
@@ -482,7 +498,7 @@ class MetricsModel : public QObject {
                    && cfo_hz == other.cfo_hz && tuner_gain_text == other.tuner_gain_text
                    && radio_input == other.radio_input && stream_active == other.stream_active
                    && center_freq_hz == other.center_freq_hz && synced_here == other.synced_here
-                   && sync_label == other.sync_label;
+                   && sync_label == other.sync_label && trunkable_sync == other.trunkable_sync;
         }
 
         bool

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -138,10 +138,11 @@ class MetricsModel : public QObject {
     /**
      * @brief Full width in Hz of the channel the demodulator is filtering.
      *
-     * 12500 for the 12.5 kHz modes, 6250 for the narrow ones, 16000 wide. 0 when
-     * the input is not a radio, or before the demodulator has reported a profile —
-     * which the spectrum screen renders as "width unknown" rather than as zero
-     * width. The channel, not the filter: see dsd_channel_lpf_protected_edge_hz().
+     * 12500 for the 12.5 kHz modes, 6250 for the narrow ones, 16000 wide — a
+     * profile the demodulator has not yet narrowed reads as wide, not as zero.
+     * 0 means there is nothing to draw at all: the input is not a radio, or no
+     * metrics frame has been read yet. The channel, not the filter: see
+     * dsd_channel_lpf_protected_edge_hz().
      */
     int
     channelBandwidthHz() const {

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -58,7 +58,7 @@ class MetricsModel : public QObject {
     Q_PROPERTY(bool audioMuted READ audioMuted NOTIFY controlChanged)
     Q_PROPERTY(qulonglong heldTg READ heldTg NOTIFY controlChanged)
     Q_PROPERTY(int encLockoutCount READ encLockoutCount NOTIFY controlChanged)
-    Q_PROPERTY(bool trunkingEnabled READ trunkingEnabled NOTIFY controlChanged)
+    Q_PROPERTY(bool tunerControlled READ tunerControlled NOTIFY controlChanged)
     Q_PROPERTY(QString uiMessage READ uiMessage NOTIFY uiMessageChanged)
 
   public:
@@ -125,14 +125,17 @@ class MetricsModel : public QObject {
     }
 
     /**
-     * @brief Whether the trunking controller owns the tuner.
+     * @brief Whether an automatic controller owns the tuner.
      *
-     * While it does, the engine refuses manual retunes, so a view offering one
-     * should say so rather than present a control that silently does nothing.
+     * True under trunking and under conventional scanner mode alike: both move
+     * the front end on their own, and the engine refuses manual retunes under
+     * either. Deliberately not named for trunking — a view that gated only on
+     * that would offer a control which appears to work and is then undone by
+     * the scanner's next step.
      */
     bool
-    trunkingEnabled() const {
-        return m_view.trunking_enabled;
+    tunerControlled() const {
+        return m_view.tuner_controlled;
     }
 
     /**
@@ -357,7 +360,7 @@ class MetricsModel : public QObject {
         bool audio_muted = false;
         qulonglong held_tg = 0;
         int enc_lockout_count = 0;
-        bool trunking_enabled = false;
+        bool tuner_controlled = false;
         QString ui_message;
         SlotCall slot_call[2];
 
@@ -376,7 +379,7 @@ class MetricsModel : public QObject {
         bool
         controlEquals(const View& other) const {
             return audio_muted == other.audio_muted && held_tg == other.held_tg
-                   && enc_lockout_count == other.enc_lockout_count && trunking_enabled == other.trunking_enabled;
+                   && enc_lockout_count == other.enc_lockout_count && tuner_controlled == other.tuner_controlled;
         }
     };
 

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -202,8 +202,8 @@ class MetricsModel : public QObject {
      * where the engine actually is rather than what the UI last asked for — the
      * engine can refuse, and on Android the service outlives this process.
      *
-     * decodeMode is a dsdneoUserDecodeMode; modulation is 0 for C4FM and 1 for
-     * QPSK, matching DSD_APP_CMD_MOD_SET's payload.
+     * decodeMode is a dsdneoUserDecodeMode; modulation is 0 for C4FM, 1 for QPSK
+     * and 2 for GFSK, matching DSD_APP_CMD_MOD_SET's payload and dsd_state::rf_mod.
      */
     int
     decodeMode() const {

--- a/src/ui/qt/qml/BandRail.qml
+++ b/src/ui/qt/qml/BandRail.qml
@@ -51,10 +51,18 @@ Item {
 
     implicitHeight: 32
 
-    /** Take hold at the current frequency. */
+    /**
+     * Take hold at the frequency the rail is showing.
+     *
+     * displayHz, not tunedHz: while a previous drag's retune is still in flight
+     * the knob and the readout are already on the frequency being waited for, and
+     * seeding from tunedHz would snap both back to where the receiver still is and
+     * compute this drag from a frequency the user has already left — so a nudge to
+     * fine-tune a move undoes it instead.
+     */
     function beginDrag() {
-        rail.dragStartHz = rail.tunedHz
-        rail.pendingHz = rail.tunedHz
+        rail.dragStartHz = rail.displayHz
+        rail.pendingHz = rail.displayHz
         rail.dragging = true
     }
 
@@ -86,8 +94,25 @@ Item {
         if (!cancelled && moved) {
             rail.settleHz = want
             rail.settling = true
+            // Restarted rather than left to the `running` binding: a second drag
+            // released while the first is still settling assigns `settling` the
+            // value it already has, so the binding does not re-evaluate and the
+            // timer would fire on the first drag's deadline — snapping the readout
+            // back to the old frequency with the second retune still in flight.
+            settleTimer.restart()
             rail.tuneRequested(want)
         }
+    }
+
+    /**
+     * The requested tune was refused, so there is nothing to wait for.
+     *
+     * A QML signal handler cannot answer its emitter, so the screen that decides
+     * whether a tune is allowed calls this when it turned one down. Without it the
+     * readout shows a frequency nobody is on for the full settle timeout.
+     */
+    function cancelSettle() {
+        rail.settling = false
     }
 
     // The tune landed: the truth takes over and the knob eases to its real
@@ -98,6 +123,8 @@ Item {
     // hold the preview forever — after this the display falls back to the
     // truth same as it would with no preview at all.
     Timer {
+        id: settleTimer
+
         interval: 1500
         running: rail.settling
         onTriggered: rail.settling = false

--- a/src/ui/qt/qml/BandRail.qml
+++ b/src/ui/qt/qml/BandRail.qml
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import "Util.js" as Util
+
+// Coarse tuning: a local window of band with the receiver in it, dragged.
+//
+// It used to be a readout with a track and a handle, which invited a drag it did
+// not accept, and it was scoped to a hardcoded band the tuner reaches far
+// outside of. Now the window simply travels with the receiver, so there is no
+// boundary to explain — only the tuner's own ends.
+//
+// The arithmetic lives in functions rather than in the DragHandler's body
+// because a handler body cannot be called from a test, and this is where the
+// receiver's frequency is decided.
+Item {
+    id: rail
+
+    property real tunedHz: 0
+    // Full width of the window. One end-to-end drag moves twenty MHz, about
+    // fourteen screenfuls of spectrum — coarse, which is the job; the picture
+    // above does the fine work.
+    property real windowHz: 20.0e6
+
+    signal tuneRequested(double hz)
+
+    property bool dragging: false
+    property real pendingHz: 0
+    property real dragStartHz: 0
+
+    // Clamped in this order so that near a tuner limit the window stops sliding
+    // and the knob moves off centre instead — the alternative is a window that
+    // runs off the end of what the hardware can reach.
+    readonly property real lowHz: {
+        var lo = Math.max(Util.TUNER_LOW_HZ, rail.tunedHz - (rail.windowHz / 2))
+        var hi = Math.min(Util.TUNER_HIGH_HZ, lo + rail.windowHz)
+        return Math.max(Util.TUNER_LOW_HZ, hi - rail.windowHz)
+    }
+    readonly property real highHz: Math.min(Util.TUNER_HIGH_HZ, rail.lowHz + rail.windowHz)
+    readonly property real displayHz: rail.dragging ? rail.pendingHz : rail.tunedHz
+
+    implicitHeight: 32
+
+    /** Take hold at the current frequency. */
+    function beginDrag() {
+        rail.dragStartHz = rail.tunedHz
+        rail.pendingHz = rail.tunedHz
+        rail.dragging = true
+    }
+
+    /**
+     * Move @a dx pixels from where the drag began, across @a trackWidth pixels.
+     *
+     * Relative to the grab, never absolute to the touch: a knob that jumped to
+     * the finger would turn a mis-aimed tap into a twenty-megahertz move. The
+     * window cannot shift underneath this, because it derives from tunedHz and
+     * nothing retunes until release.
+     */
+    function dragBy(dx, trackWidth) {
+        if (!rail.dragging || !(trackWidth > 0))
+            return
+        var want = rail.dragStartHz + ((dx / trackWidth) * (rail.highHz - rail.lowHz))
+        rail.pendingHz = Math.max(Util.TUNER_LOW_HZ, Math.min(Util.TUNER_HIGH_HZ, want))
+    }
+
+    /**
+     * Let go: at most one retune, and only if the finger actually lifted.
+     *
+     * @a cancelled marks a drag that ended some other way. Those few pixels are
+     * not a request to move the receiver.
+     */
+    function endDrag(cancelled) {
+        var want = rail.pendingHz
+        var moved = rail.dragging && Math.round(want) !== Math.round(rail.tunedHz)
+        rail.dragging = false
+        if (!cancelled && moved)
+            rail.tuneRequested(want)
+    }
+
+    Text {
+        id: railLow
+
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        text: Math.round(rail.lowHz / 1.0e6)
+        font.family: Theme.mono
+        font.pixelSize: 10
+        color: Theme.textSubdued
+    }
+
+    Text {
+        id: railHigh
+
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        text: Math.round(rail.highHz / 1.0e6)
+        font.family: Theme.mono
+        font.pixelSize: 10
+        color: Theme.textSubdued
+    }
+
+    Item {
+        id: track
+
+        anchors.left: railLow.right
+        anchors.right: railHigh.left
+        anchors.leftMargin: 8
+        anchors.rightMargin: 8
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            height: 1
+            color: Theme.divider
+        }
+
+        // The app's own knob, from PlexSwitch: round, cyan, with the hairline
+        // light mode needs to keep it off a pale track. Borrowed rather than
+        // invented because the whole defect here was a control that did not look
+        // like one, and this is the shape the app already uses to say so.
+        Rectangle {
+            id: knob
+
+            objectName: "spectrumBandMarker"
+            width: 16
+            height: 16
+            radius: 8
+            anchors.verticalCenter: parent.verticalCenter
+            color: Theme.cyan
+            border.width: Theme.dark ? 0 : 1
+            border.color: Theme.controlBorder
+            x: {
+                var span = rail.highHz - rail.lowHz
+                if (!(span > 0))
+                    return 0
+                var t = (rail.displayHz - rail.lowHz) / span
+                return Math.round(Math.max(0, Math.min(1, t)) * (track.width - width))
+            }
+
+            // Eases back to centre after a retune, which reads as the window
+            // having come along. Off during a drag, where it would only lag the
+            // finger.
+            Behavior on x {
+                enabled: !rail.dragging
+                NumberAnimation { duration: 180; easing.type: Easing.OutCubic }
+            }
+        }
+    }
+
+    DragHandler {
+        target: null
+        xAxis.enabled: true
+        yAxis.enabled: false
+
+        onActiveChanged: {
+            if (active)
+                rail.beginDrag()
+            else
+                rail.endDrag(false)
+        }
+        onActiveTranslationChanged: {
+            if (active)
+                rail.dragBy(activeTranslation.x, track.width)
+        }
+    }
+}

--- a/src/ui/qt/qml/BandRail.qml
+++ b/src/ui/qt/qml/BandRail.qml
@@ -29,6 +29,14 @@ Item {
     property real pendingHz: 0
     property real dragStartHz: 0
 
+    // Held from release until the tuner actually lands on the requested
+    // frequency, so the readout and the knob do not revert to the old
+    // frequency and then jump forward again once the retune completes — which
+    // reads as the drag having been refused. settleHz is the frequency being
+    // waited for; the Timer below gives up on it if it never arrives.
+    property bool settling: false
+    property real settleHz: 0
+
     // Clamped in this order so that near a tuner limit the window stops sliding
     // and the knob moves off centre instead — the alternative is a window that
     // runs off the end of what the hardware can reach.
@@ -38,7 +46,8 @@ Item {
         return Math.max(Util.TUNER_LOW_HZ, hi - rail.windowHz)
     }
     readonly property real highHz: Math.min(Util.TUNER_HIGH_HZ, rail.lowHz + rail.windowHz)
-    readonly property real displayHz: rail.dragging ? rail.pendingHz : rail.tunedHz
+    readonly property real displayHz: rail.dragging ? rail.pendingHz
+                                                    : (rail.settling ? rail.settleHz : rail.tunedHz)
 
     implicitHeight: 32
 
@@ -74,8 +83,24 @@ Item {
         var want = rail.pendingHz
         var moved = rail.dragging && Math.round(want) !== Math.round(rail.tunedHz)
         rail.dragging = false
-        if (!cancelled && moved)
+        if (!cancelled && moved) {
+            rail.settleHz = want
+            rail.settling = true
             rail.tuneRequested(want)
+        }
+    }
+
+    // The tune landed: the truth takes over and the knob eases to its real
+    // position from wherever the preview left it.
+    onTunedHzChanged: rail.settling = false
+
+    // A retune the engine refused, or one that otherwise never lands, must not
+    // hold the preview forever — after this the display falls back to the
+    // truth same as it would with no preview at all.
+    Timer {
+        interval: 1500
+        running: rail.settling
+        onTriggered: rail.settling = false
     }
 
     Text {

--- a/src/ui/qt/qml/ExploreSetupScreen.qml
+++ b/src/ui/qt/qml/ExploreSetupScreen.qml
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import "Util.js" as Util
+
+// Two answers stand between someone and a live band: what the radio is, and
+// where to point it first. Everything else about exploring is decided on the
+// spectrum itself, so this screen asks only those two and gets out of the way.
+//
+// It is not the add-system wizard with steps removed: there is nothing to name,
+// nothing to decode-select (exploring listens for anything), and nothing saved
+// at the end. A session that finds something worth keeping goes to the wizard
+// afterwards, with the answer already filled in.
+Item {
+    id: screen
+
+    objectName: "exploreSetupScreen"
+
+    signal closed()
+    signal start(string sourceType, string host, int port, string freqMhz)
+
+    property string sourceType: "usb"
+    property alias hostText: hostField.text
+    property alias portText: portField.text
+    property alias freqText: freqField.text
+
+    readonly property bool needsHost: sourceType === "rtltcp"
+
+    /** Fill the fields from what the last explore used, or from sane firsts. */
+    function reset(prefSource, prefHost, prefPort, prefFreqMhz) {
+        screen.sourceType = (prefSource === "rtltcp") ? "rtltcp" : "usb"
+        hostField.text = prefHost && prefHost.length > 0 ? prefHost : "192.168.1.10"
+        portField.text = String(prefPort > 0 ? prefPort : 1234)
+        // 800 MHz is where most of the traffic this app decodes lives, so an
+        // unconfigured first run opens on something rather than on dead air.
+        freqField.text = prefFreqMhz && prefFreqMhz.length > 0 ? prefFreqMhz : "855.0000"
+    }
+
+    function portValid() {
+        var p = parseInt(portText, 10)
+        return !isNaN(p) && p >= 1 && p <= 65535
+    }
+
+    function ready() {
+        if (needsHost && (hostText.length === 0 || !portValid()))
+            return false
+        return sessionArgs.freqValid(freqText)
+    }
+
+    function submit() {
+        if (!ready())
+            return
+        screen.start(screen.sourceType, screen.needsHost ? screen.hostText : "",
+                     screen.needsHost ? parseInt(screen.portText, 10) : 0, screen.freqText.trim())
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.bg
+    }
+
+    Item {
+        id: header
+
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.margins: Theme.screenPadding
+        height: 46
+
+        Text {
+            id: back
+
+            objectName: "exploreSetupBack"
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            text: "‹"
+            font.pixelSize: 28
+            color: Theme.textSecondary
+
+            TapHandler {
+                onTapped: screen.closed()
+            }
+        }
+
+        Text {
+            anchors.left: back.right
+            anchors.leftMargin: 14
+            anchors.verticalCenter: parent.verticalCenter
+            text: qsTr("Explore")
+            font.family: Theme.sans
+            font.pixelSize: 22
+            font.weight: Font.Bold
+            font.letterSpacing: -0.22
+            color: Theme.textPrimary
+        }
+    }
+
+    Flickable {
+        anchors.top: header.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: startButton.top
+        anchors.topMargin: 14
+        anchors.bottomMargin: 14
+        contentHeight: content.height
+        clip: true
+
+        Column {
+            id: content
+
+            x: Theme.screenPadding
+            width: parent.width - 2 * Theme.screenPadding
+            spacing: Theme.gap
+
+            Text {
+                width: parent.width
+                text: qsTr("Which radio?")
+                font.family: Theme.sans
+                font.pixelSize: 15
+                font.weight: Font.DemiBold
+                color: Theme.textPrimary
+            }
+
+            // Only the two tuner sources appear. A UDP or TCP audio feed and a
+            // file have no front end to point anywhere, so offering them here
+            // would be offering a session where every control on the next screen
+            // is dead.
+            Flow {
+                width: parent.width
+                spacing: 10
+
+                Repeater {
+                    model: [
+                        { label: qsTr("USB dongle"), key: "usb" },
+                        { label: qsTr("RTL-TCP"), key: "rtltcp" }
+                    ]
+
+                    DecodeChip {
+                        required property var modelData
+
+                        objectName: "exploreSource_" + modelData.key
+                        text: modelData.label
+                        selected: screen.sourceType === modelData.key
+                        onClicked: screen.sourceType = modelData.key
+                    }
+                }
+            }
+
+            Column {
+                width: parent.width
+                visible: screen.needsHost
+                spacing: 10
+
+                Text {
+                    text: qsTr("Host")
+                    font.family: Theme.sans
+                    font.pixelSize: 13
+                    color: Theme.textSecondary
+                }
+
+                PlexTextField {
+                    id: hostField
+
+                    width: parent.width
+                    mono: true
+                    text: "192.168.1.10"
+                    inputMethodHints: Qt.ImhUrlCharactersOnly | Qt.ImhNoAutoUppercase
+                }
+
+                Text {
+                    text: qsTr("Port")
+                    font.family: Theme.sans
+                    font.pixelSize: 13
+                    color: Theme.textSecondary
+                }
+
+                PlexTextField {
+                    id: portField
+
+                    width: parent.width
+                    mono: true
+                    text: "1234"
+                    inputMethodHints: Qt.ImhDigitsOnly
+                    input.validator: IntValidator {
+                        bottom: 1
+                        top: 65535
+                    }
+                }
+            }
+
+            Text {
+                width: parent.width
+                text: qsTr("Start where?")
+                font.family: Theme.sans
+                font.pixelSize: 15
+                font.weight: Font.DemiBold
+                color: Theme.textPrimary
+            }
+
+            UiPanel {
+                width: parent.width
+                height: freqColumn.height + 2 * Theme.cardPadding
+
+                Column {
+                    id: freqColumn
+
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    anchors.margins: Theme.cardPadding
+                    spacing: 8
+
+                    Row {
+                        spacing: 8
+
+                        TextInput {
+                            id: freqField
+
+                            objectName: "exploreStartFrequency"
+                            width: Math.max(implicitWidth, 60)
+                            text: "855.0000"
+                            font.family: Theme.mono
+                            font.pixelSize: 32
+                            font.weight: Font.Medium
+                            color: Theme.textPrimary
+                            inputMethodHints: Qt.ImhFormattedNumbersOnly
+                            // The hint only chooses the soft keyboard; a hardware
+                            // keyboard types anything, and the builder splices this
+                            // straight into the input spec.
+                            validator: RegularExpressionValidator {
+                                regularExpression: /^\d{1,5}(\.\d{0,6})?$/
+                            }
+                            selectionColor: Qt.alpha(Theme.cyan, 0.35)
+                            selectedTextColor: Theme.textPrimary
+                        }
+
+                        Text {
+                            text: "MHz"
+                            anchors.baseline: freqField.baseline
+                            font.family: Theme.mono
+                            font.pixelSize: 15
+                            color: Theme.textSubdued
+                        }
+                    }
+
+                    Rectangle {
+                        width: parent.width
+                        height: 2
+                        color: Theme.cyan
+                    }
+
+                    // For anyone who does not know a local frequency, this is the
+                    // whole answer to "where do I even begin".
+                    Flow {
+                        width: parent.width
+                        spacing: 8
+
+                        Repeater {
+                            model: Util.BANDS
+
+                            FilterPill {
+                                required property var modelData
+
+                                objectName: "exploreBand_" + modelData.label
+                                text: modelData.label
+                                // The caret means "this opens a menu" on the history
+                                // screen; these jump straight to a frequency.
+                                caret: false
+                                active: {
+                                    var hz = parseFloat(screen.freqText) * 1.0e6
+                                    return !isNaN(hz) && hz >= modelData.low && hz < modelData.high
+                                }
+                                onClicked: freqField.text = Util.mhzText(modelData.start)
+                            }
+                        }
+                    }
+
+                    Text {
+                        width: parent.width
+                        text: qsTr("Anywhere is fine — you can move around once the band is on screen.")
+                        font.family: Theme.sans
+                        font.pixelSize: 13
+                        color: Theme.textSubdued
+                        wrapMode: Text.Wrap
+                    }
+                }
+            }
+        }
+    }
+
+    GradientButton {
+        id: startButton
+
+        objectName: "exploreStartButton"
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: Theme.screenPadding
+        anchors.bottomMargin: 22
+        text: qsTr("Start exploring")
+        enabled: screen.ready()
+        onClicked: screen.submit()
+    }
+}

--- a/src/ui/qt/qml/ExploreSetupScreen.qml
+++ b/src/ui/qt/qml/ExploreSetupScreen.qml
@@ -212,43 +212,12 @@ Item {
                     anchors.margins: Theme.cardPadding
                     spacing: 8
 
-                    Row {
-                        spacing: 8
+                    FrequencyField {
+                        id: freqField
 
-                        TextInput {
-                            id: freqField
-
-                            objectName: "exploreStartFrequency"
-                            width: Math.max(implicitWidth, 60)
-                            text: "855.0000"
-                            font.family: Theme.mono
-                            font.pixelSize: 32
-                            font.weight: Font.Medium
-                            color: Theme.textPrimary
-                            inputMethodHints: Qt.ImhFormattedNumbersOnly
-                            // The hint only chooses the soft keyboard; a hardware
-                            // keyboard types anything, and the builder splices this
-                            // straight into the input spec.
-                            validator: RegularExpressionValidator {
-                                regularExpression: /^\d{1,5}(\.\d{0,6})?$/
-                            }
-                            selectionColor: Qt.alpha(Theme.cyan, 0.35)
-                            selectedTextColor: Theme.textPrimary
-                        }
-
-                        Text {
-                            text: "MHz"
-                            anchors.baseline: freqField.baseline
-                            font.family: Theme.mono
-                            font.pixelSize: 15
-                            color: Theme.textSubdued
-                        }
-                    }
-
-                    Rectangle {
                         width: parent.width
-                        height: 2
-                        color: Theme.cyan
+                        fieldObjectName: "exploreStartFrequency"
+                        text: "855.0000"
                     }
 
                     // For anyone who does not know a local frequency, this is the

--- a/src/ui/qt/qml/FrequencyField.qml
+++ b/src/ui/qt/qml/FrequencyField.qml
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+
+// A frequency in MHz, typed: the number, its unit, and the rule for what counts
+// as one.
+//
+// One copy because the rule is the part that matters and it is not obvious from
+// looking at any single field. inputMethodHints only chooses which soft keyboard
+// appears; a hardware keyboard types whatever it likes, and every one of these
+// values is spliced into an input spec or a saved system. The validator is what
+// keeps "851.375M" out of them, so a screen that grew its own field without it
+// would be the one that let a bad frequency through.
+Column {
+    id: root
+
+    /** The text in the field. */
+    property alias text: field.text
+    /** Names the input itself, for tests that address it directly. */
+    property alias fieldObjectName: field.objectName
+    /** Size of the number; the unit stays at its own size beside it. */
+    property int pixelSize: 32
+    /** Whether the text currently satisfies the validator. */
+    readonly property alias acceptableInput: field.acceptableInput
+
+    /** Emitted when the field is committed from the keyboard. */
+    signal accepted
+
+    function forceActiveFocus() {
+        field.forceActiveFocus();
+    }
+
+    spacing: 8
+
+    Row {
+        spacing: 8
+
+        TextInput {
+            id: field
+
+            width: Math.max(implicitWidth, 60)
+            font.family: Theme.mono
+            font.pixelSize: root.pixelSize
+            font.weight: Font.Medium
+            color: Theme.textPrimary
+            inputMethodHints: Qt.ImhFormattedNumbersOnly
+            validator: RegularExpressionValidator {
+                regularExpression: /^\d{1,5}(\.\d{0,6})?$/
+            }
+            selectionColor: Qt.alpha(Theme.cyan, 0.35)
+            selectedTextColor: Theme.textPrimary
+            onAccepted: root.accepted()
+        }
+
+        Text {
+            text: "MHz"
+            anchors.baseline: field.baseline
+            font.family: Theme.mono
+            font.pixelSize: 15
+            color: Theme.textSubdued
+        }
+    }
+
+    Rectangle {
+        width: root.width
+        height: 2
+        color: Theme.cyan
+    }
+}

--- a/src/ui/qt/qml/HomeScreen.qml
+++ b/src/ui/qt/qml/HomeScreen.qml
@@ -13,6 +13,10 @@ Item {
     signal playSystem(int row)
     signal editSystem(int row)
     signal networkSource()
+    // Tap starts exploring with what was used last; long-press changes it. Same
+    // split as a system card, where the face plays and the press manages.
+    signal explore()
+    signal exploreSetup()
 
     // Re-derives "Heard n minutes ago" once a minute so rows do not go stale.
     property int heardTick: 0
@@ -221,6 +225,81 @@ Item {
                 width: parent.width
                 text: qsTr("+ Add a system")
                 onClicked: screen.addSystem()
+            }
+
+            MicroLabel {
+                text: qsTr("Or go looking")
+            }
+
+            // Deliberately not a system card: there is nothing saved here, nothing
+            // named, and nothing to come back to. It is a door, so it carries a
+            // chevron rather than a play button, and its meta line states what the
+            // tap will actually do so that starting is never a surprise.
+            UiPanel {
+                id: exploreCard
+
+                objectName: "exploreCard"
+                width: content.width
+                height: 78
+
+                readonly property string sourceLabel: prefs.exploreSourceType === "rtltcp" ? qsTr("RTL-TCP")
+                                                                                           : qsTr("USB dongle")
+                readonly property bool configured: prefs.exploreSourceType.length > 0
+
+                Column {
+                    anchors.left: parent.left
+                    anchors.right: exploreCaret.left
+                    anchors.leftMargin: Theme.cardPadding
+                    anchors.rightMargin: 12
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: 4
+
+                    Text {
+                        width: parent.width
+                        text: qsTr("Explore the band")
+                        font.family: Theme.sans
+                        font.pixelSize: 17
+                        font.weight: Font.Bold
+                        color: Theme.textPrimary
+                        elide: Text.ElideRight
+                    }
+
+                    Text {
+                        width: parent.width
+                        text: exploreCard.configured
+                              ? qsTr("%1 · from %2 MHz").arg(exploreCard.sourceLabel).arg(prefs.exploreFreqMhz)
+                              : qsTr("Tune around and find what is on the air")
+                        font.family: exploreCard.configured ? Theme.mono : Theme.sans
+                        font.pixelSize: exploreCard.configured ? 12 : 13
+                        color: Theme.textSubdued
+                        elide: Text.ElideRight
+                    }
+                }
+
+                Caret {
+                    id: exploreCaret
+
+                    anchors.right: parent.right
+                    anchors.rightMargin: Theme.cardPadding + 6
+                    anchors.verticalCenter: parent.verticalCenter
+                    // Larger than the default: at the size a filter pill uses it
+                    // reads as a speck against a full-width card, and this is the
+                    // only thing saying the card goes somewhere.
+                    width: 13
+                    height: 9
+                    // Points down at rotation 0; a quarter turn anticlockwise reads
+                    // as forward, matching the "Network or file source ›" affordance.
+                    rotation: -90
+                    color: Theme.cyan
+                }
+
+                TapHandler {
+                    enabled: !mainRoot.transitioning
+                    // Nothing remembered means nothing to start from, so the first
+                    // tap asks rather than guessing at a radio and a frequency.
+                    onTapped: exploreCard.configured ? screen.explore() : screen.exploreSetup()
+                    onLongPressed: screen.exploreSetup()
+                }
             }
 
             Item {

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -345,15 +345,18 @@ Window {
     MonitorScreen {
         id: monitor
 
+        objectName: "monitorScreen"
         anchors.fill: parent
         system: mainRoot.sessionSystem
         opacity: mainRoot.monitorMode ? 1.0 : 0.0
         visible: opacity > 0.0
-        // The wizard now opens over a running session ("Save as a system") and
-        // TapHandlers never take exclusive grabs, so without this a tap on the
-        // wizard's bottom button also lands on "Stop listening", which sits at
-        // exactly the same rect underneath it and ends the session.
-        enabled: opacity > 0.9 && !mainRoot.wizardOpen
+        // The wizard ("Save as a system") and the spectrum both open over a
+        // running session, and TapHandlers never take exclusive grabs, so without
+        // this a tap on the layer above also lands on "Stop listening", which sits
+        // at exactly the same rect underneath both of them and ends the session.
+        // That is what "Explore from here" — the one way out of view-only — did
+        // instead of offering to hand the tuner over.
+        enabled: opacity > 0.9 && !mainRoot.wizardOpen && !mainRoot.spectrumOpen
 
         Behavior on opacity {
             NumberAnimation { duration: 150; easing.type: Easing.OutCubic }

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -30,8 +30,11 @@ Window {
     // asked. Cleared when access is granted (which resumes the pending start
     // below), when the banner is dismissed, or when another system starts.
     property bool awaitingUsbAccess: false
-    // The saved-system row whose start is waiting on that grant.
-    property int pendingUsbRow: -1
+    // The system map whose start is waiting on that grant, and the row it came
+    // from (-1 when it came from nowhere, i.e. an explore session). The map, not
+    // just the row: an explore start has no row to look up again.
+    property var pendingStart: null
+    property int pendingStartRow: -1
     readonly property string usbAccessText:
         awaitingUsbAccess && decoderHost && !decoderHost.localDeviceReady ? decoderHost.localDeviceStatus : ""
     readonly property string failureText: startError.length > 0 ? startError
@@ -39,11 +42,29 @@ Window {
 
     property int currentTab: 0
     property bool wizardOpen: false
+    property bool exploreSetupOpen: false
     // The spectrum view is pushed over the monitor, so it can only be open
     // while a session is; ending one has to take it down with it.
     property bool spectrumOpen: false
     // The saved-system map the running session was started from.
     property var sessionSystem: null
+    // Whether this session is free to be retuned by hand. False for anything
+    // started from a saved system — its card names a frequency, and wandering off
+    // it makes the card a lie and mis-files the calls heard afterwards. Set at
+    // start, and again if the user asks to explore from where they are.
+    property bool exploring: false
+    // Sampled while an explore session runs, not read at the end of one: the
+    // metrics are cleared the moment the session stops, so asking then would
+    // persist a zero and lose the frequency the user had found.
+    property string lastExploreFreqMhz: ""
+
+    Connections {
+        target: metrics
+        function onTunerChanged() {
+            if (mainRoot.exploring && metrics.centerFreqHz > 0)
+                mainRoot.lastExploreFreqMhz = Util.mhzText(metrics.centerFreqHz)
+        }
+    }
 
     // Suppresses a failure banner the user has read. Reset on the next start so a
     // repeat of the same failure is reported again rather than swallowed.
@@ -57,7 +78,8 @@ Window {
     onDismissedFailureChanged: {
         if (dismissedFailure.length > 0) {
             awaitingUsbAccess = false
-            pendingUsbRow = -1
+            mainRoot.pendingStart = null
+            mainRoot.pendingStartRow = -1
         }
     }
 
@@ -70,18 +92,26 @@ Window {
             if (!mainRoot.awaitingUsbAccess || !decoderHost.localDeviceReady)
                 return
             mainRoot.awaitingUsbAccess = false
-            var row = mainRoot.pendingUsbRow
-            mainRoot.pendingUsbRow = -1
-            if (row >= 0)
-                mainRoot.startSystem(row)
+            var sys = mainRoot.pendingStart
+            var row = mainRoot.pendingStartRow
+            mainRoot.pendingStart = null
+            mainRoot.pendingStartRow = -1
+            if (sys)
+                mainRoot.startWithMap(sys, row)
         }
     }
 
     onMonitorModeChanged: {
         // The spectrum layer lives above the monitor; when the session goes so
         // does it, or the next one would open onto a stale panorama.
-        if (!monitorMode)
+        if (!monitorMode) {
+            // Where the exploring got to, so the next one resumes there rather
+            // than back at the start frequency.
+            if (mainRoot.exploring && mainRoot.lastExploreFreqMhz.length > 0)
+                prefs.exploreFreqMhz = mainRoot.lastExploreFreqMhz
+            mainRoot.exploring = false
             mainRoot.spectrumOpen = false
+        }
         if (monitorMode) {
             // The frequency field usually still holds focus; the keyboard would
             // cover the session that just appeared.
@@ -106,6 +136,21 @@ Window {
 
     function startSystem(row) {
         var sys = savedSystems.get(row)
+        if (sys)
+            mainRoot.startWithMap(sys, row)
+    }
+
+    /**
+     * Start a session from a system map.
+     *
+     * @a row is the saved-systems row it came from, or -1 when it came from
+     * nowhere — an explore session is an ordinary session over a map that was
+     * never saved, so everything here except the row bookkeeping is shared. The
+     * alternative, a second start path, would have to re-implement the USB
+     * permission dance below, and would get it wrong on exactly the install
+     * where it matters: a fresh one.
+     */
+    function startWithMap(sys, row) {
         if (!sys || !sys.sourceType)
             return
         if (sys.sourceType === "usb" && decoderHost.localDeviceBrokered && !decoderHost.localDeviceReady) {
@@ -116,14 +161,16 @@ Window {
             mainRoot.dismissedFailure = ""
             mainRoot.startError = ""
             mainRoot.awaitingUsbAccess = true
-            mainRoot.pendingUsbRow = row
+            mainRoot.pendingStart = sys
+            mainRoot.pendingStartRow = row
             decoderHost.requestLocalDeviceAccess()
             return
         }
         mainRoot.dismissedFailure = ""
         mainRoot.startError = ""
         mainRoot.awaitingUsbAccess = false
-        mainRoot.pendingUsbRow = -1
+        mainRoot.pendingStart = null
+        mainRoot.pendingStartRow = -1
         var built = sessionArgs.build(sys)
         if (!built.ok) {
             // The builder refuses for exactly two reasons; blame the field that
@@ -142,6 +189,10 @@ Window {
             return
         }
         mainRoot.sessionSystem = sys
+        // The session's intent, decided here and nowhere else: a system someone
+        // saved is a thing to listen to, and the spectrum watches it. Only a
+        // session with no saved system behind it is free to wander.
+        mainRoot.exploring = (row < 0)
         // The previous session may have committed calls since the last 250 ms
         // tick; ingest them under its own label before the label changes hands,
         // or its tail calls read as the new system's.
@@ -152,12 +203,45 @@ Window {
         savedSystems.touch(row)
     }
 
+    /** Start an explore session from the remembered source and frequency. */
+    function startExploring() {
+        var source = prefs.exploreSourceType
+        if (source !== "usb" && source !== "rtltcp") {
+            // Nothing remembered to start from; ask instead of guessing.
+            mainRoot.exploreSetupOpen = true
+            return
+        }
+        mainRoot.startWithMap(mainRoot.exploreSystem(source, prefs.exploreHost, prefs.explorePort,
+                                                     prefs.exploreFreqMhz), -1)
+    }
+
+    /**
+     * The system map an explore session runs on.
+     *
+     * Deliberately shaped like a saved system so the ordinary start path, the
+     * monitor header and the args builder all work on it unchanged — but with no
+     * decode flag, because exploring should hear whatever it lands on, and with
+     * trunking off, because a trunker would take the tuner straight back.
+     */
+    function exploreSystem(source, host, port, freqMhz) {
+        return {
+            name: qsTr("Exploring"),
+            sourceType: source,
+            host: host,
+            port: port,
+            freqMhz: freqMhz,
+            decodeFlag: "",
+            trunking: false
+        }
+    }
+
     // ---- Tab shell ----
     Item {
         id: shell
 
         anchors.fill: parent
-        opacity: (mainRoot.monitorMode || mainRoot.wizardOpen || !prefs.onboardingDone) ? 0.0 : 1.0
+        opacity: (mainRoot.monitorMode || mainRoot.wizardOpen || mainRoot.exploreSetupOpen
+                  || !prefs.onboardingDone) ? 0.0 : 1.0
         visible: opacity > 0.0
         enabled: opacity > 0.9
 
@@ -184,6 +268,12 @@ Window {
             onEditSystem: function (row) {
                 wizard.openForEdit(row)
                 mainRoot.wizardOpen = true
+            }
+            onExplore: mainRoot.startExploring()
+            onExploreSetup: {
+                exploreSetup.reset(prefs.exploreSourceType, prefs.exploreHost, prefs.explorePort,
+                                   prefs.exploreFreqMhz)
+                mainRoot.exploreSetupOpen = true
             }
         }
 
@@ -214,12 +304,12 @@ Window {
         }
     }
 
-    // ---- Add-system wizard (pushed) ----
-    WizardScreen {
-        id: wizard
+    // ---- Explore setup (pushed; idle only, since it starts a session) ----
+    ExploreSetupScreen {
+        id: exploreSetup
 
         anchors.fill: parent
-        opacity: mainRoot.wizardOpen && !mainRoot.monitorMode ? 1.0 : 0.0
+        opacity: mainRoot.exploreSetupOpen && !mainRoot.monitorMode ? 1.0 : 0.0
         visible: opacity > 0.0
         enabled: opacity > 0.9
 
@@ -227,10 +317,19 @@ Window {
             NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
         }
 
-        onClosed: mainRoot.wizardOpen = false
-        onSaved: function (row) {
-            mainRoot.wizardOpen = false
-            mainRoot.currentTab = 0
+        onClosed: mainRoot.exploreSetupOpen = false
+        onStart: function (sourceType, host, port, freqMhz) {
+            // Remembered before the start, not after: a start that fails is still
+            // the answer the user gave, and asking again would be the app
+            // forgetting what it was just told.
+            prefs.exploreSourceType = sourceType
+            if (host.length > 0)
+                prefs.exploreHost = host
+            if (port > 0)
+                prefs.explorePort = port
+            prefs.exploreFreqMhz = freqMhz
+            mainRoot.exploreSetupOpen = false
+            mainRoot.startWithMap(mainRoot.exploreSystem(sourceType, host, port, freqMhz), -1)
         }
     }
 
@@ -264,9 +363,12 @@ Window {
         anchors.fill: parent
         active: false
         sourceComponent: spectrumScreen
-        opacity: mainRoot.monitorMode && mainRoot.spectrumOpen ? 1.0 : 0.0
+        opacity: mainRoot.monitorMode && mainRoot.spectrumOpen && !mainRoot.wizardOpen ? 1.0 : 0.0
         visible: opacity > 0.0
-        enabled: opacity > 0.9
+        // The wizard can now open over a running session ("Save as a system"), and
+        // TapHandlers never take exclusive grabs — without this, a tap meant for a
+        // wizard field also reaches the spectrum underneath and retunes the radio.
+        enabled: opacity > 0.9 && !mainRoot.wizardOpen
 
         Behavior on opacity {
             NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
@@ -277,7 +379,59 @@ Window {
         id: spectrumScreen
 
         SpectrumScreen {
+            exploring: mainRoot.exploring
+
             onClosed: mainRoot.spectrumOpen = false
+            onExploreFromHere: {
+                // The engine is the authority on who owns the tuner; this only
+                // asks. The pill follows the options snapshot, so it flips a poll
+                // later whether or not the request was honoured.
+                commands.releaseTuner()
+                mainRoot.exploring = true
+                // The session is no longer the saved system it started as: its
+                // frequency is now whatever the user makes it, and the calls it
+                // logs from here on did not come from that system.
+                mainRoot.sessionSystem = mainRoot.exploreSystem(
+                    mainRoot.sessionSystem ? mainRoot.sessionSystem.sourceType : "usb",
+                    mainRoot.sessionSystem ? mainRoot.sessionSystem.host : "",
+                    mainRoot.sessionSystem ? mainRoot.sessionSystem.port : 0,
+                    Util.mhzText(metrics.centerFreqHz))
+                uiController.flushHistory()
+                callHistory.sessionLabel = qsTr("Exploring")
+            }
+            onSaveAsSystem: function (freqHz) {
+                wizard.openForFound(mainRoot.sessionSystem, Util.mhzText(freqHz))
+                mainRoot.wizardOpen = true
+            }
+        }
+    }
+
+    // ---- Add-system wizard (pushed) ----
+    // Declared after the monitor and the spectrum because declaration order is
+    // z-order among siblings: the monitor paints an opaque background, so a
+    // wizard declared before it would be visible, enabled and completely covered.
+    WizardScreen {
+        id: wizard
+
+        anchors.fill: parent
+        opacity: mainRoot.wizardOpen ? 1.0 : 0.0
+        visible: opacity > 0.0
+        enabled: opacity > 0.9
+
+        Behavior on opacity {
+            NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
+        }
+
+        onClosed: {
+            mainRoot.wizardOpen = false
+            // Over a session the monitor comes back underneath; without this it
+            // returns behind the keyboard the name field was still holding.
+            Qt.inputMethod.hide()
+        }
+        onSaved: function (row) {
+            mainRoot.wizardOpen = false
+            mainRoot.currentTab = 0
+            Qt.inputMethod.hide()
         }
     }
 

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -341,7 +341,11 @@ Window {
         system: mainRoot.sessionSystem
         opacity: mainRoot.monitorMode ? 1.0 : 0.0
         visible: opacity > 0.0
-        enabled: opacity > 0.9
+        // The wizard now opens over a running session ("Save as a system") and
+        // TapHandlers never take exclusive grabs, so without this a tap on the
+        // wizard's bottom button also lands on "Stop listening", which sits at
+        // exactly the same rect underneath it and ends the session.
+        enabled: opacity > 0.9 && !mainRoot.wizardOpen
 
         Behavior on opacity {
             NumberAnimation { duration: 150; easing.type: Easing.OutCubic }

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -248,12 +248,22 @@ Window {
             NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
         }
 
-        onOpenSpectrum: mainRoot.spectrumOpen = true
+        onOpenSpectrum: {
+            spectrumLoader.active = true
+            mainRoot.spectrumOpen = true
+        }
     }
 
     // ---- Spectrum (pushed over the monitor) ----
-    SpectrumScreen {
+    // Built on first open, then kept. Its waterfall holds a full-resolution
+    // history image, which is real memory to hand every user who never opens
+    // the view — and rebuilding it on each visit would throw that history away.
+    Loader {
+        id: spectrumLoader
+
         anchors.fill: parent
+        active: false
+        sourceComponent: spectrumScreen
         opacity: mainRoot.monitorMode && mainRoot.spectrumOpen ? 1.0 : 0.0
         visible: opacity > 0.0
         enabled: opacity > 0.9
@@ -261,8 +271,14 @@ Window {
         Behavior on opacity {
             NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
         }
+    }
 
-        onClosed: mainRoot.spectrumOpen = false
+    Component {
+        id: spectrumScreen
+
+        SpectrumScreen {
+            onClosed: mainRoot.spectrumOpen = false
+        }
     }
 
     // ---- First-run onboarding ----

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -326,11 +326,15 @@ Window {
             // Remembered before the start, not after: a start that fails is still
             // the answer the user gave, and asking again would be the app
             // forgetting what it was just told.
+            // All four unconditionally: they are one answer to "how to start
+            // exploring", and startExploring() reads all four back together.
+            // Skipping the empty ones leaves the previous answer's endpoint
+            // behind, so switching rtltcp -> usb keeps the old host and the
+            // setup sheet shows it again as the current setting. An out-of-range
+            // port is corrected by AppPrefs' own sanitiser, not by not writing it.
             prefs.exploreSourceType = sourceType
-            if (host.length > 0)
-                prefs.exploreHost = host
-            if (port > 0)
-                prefs.explorePort = port
+            prefs.exploreHost = host
+            prefs.explorePort = port
             prefs.exploreFreqMhz = freqMhz
             mainRoot.exploreSetupOpen = false
             mainRoot.startWithMap(mainRoot.exploreSystem(sourceType, host, port, freqMhz), -1)
@@ -399,8 +403,16 @@ Window {
                 // Seeded here rather than waiting for the next tuner reading: the
                 // session may never move again, and an empty value would leave the
                 // stop handler with nothing to remember this band by.
-                if (metrics.centerFreqHz > 0)
-                    mainRoot.lastExploreFreqMhz = Util.mhzText(metrics.centerFreqHz)
+                //
+                // Read once and guarded once. A zero reading — no tuner, or the
+                // options snapshot briefly unavailable — is not a frequency, and
+                // Util.mhzText(0) is the string "0.0000", which the session map,
+                // the monitor header and the save-as-system wizard would all then
+                // carry as if it were one. Empty is what monitorMeta() already
+                // knows to leave out.
+                var exploreFreqMhz = metrics.centerFreqHz > 0 ? Util.mhzText(metrics.centerFreqHz) : ""
+                if (exploreFreqMhz.length > 0)
+                    mainRoot.lastExploreFreqMhz = exploreFreqMhz
                 // The session is no longer the saved system it started as: its
                 // frequency is now whatever the user makes it, and the calls it
                 // logs from here on did not come from that system.
@@ -408,7 +420,7 @@ Window {
                     mainRoot.sessionSystem ? mainRoot.sessionSystem.sourceType : "usb",
                     mainRoot.sessionSystem ? mainRoot.sessionSystem.host : "",
                     mainRoot.sessionSystem ? mainRoot.sessionSystem.port : 0,
-                    Util.mhzText(metrics.centerFreqHz))
+                    exploreFreqMhz)
                 uiController.flushHistory()
                 callHistory.sessionLabel = qsTr("Exploring")
             }

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -39,6 +39,9 @@ Window {
 
     property int currentTab: 0
     property bool wizardOpen: false
+    // The spectrum view is pushed over the monitor, so it can only be open
+    // while a session is; ending one has to take it down with it.
+    property bool spectrumOpen: false
     // The saved-system map the running session was started from.
     property var sessionSystem: null
 
@@ -75,6 +78,10 @@ Window {
     }
 
     onMonitorModeChanged: {
+        // The spectrum layer lives above the monitor; when the session goes so
+        // does it, or the next one would open onto a stale panorama.
+        if (!monitorMode)
+            mainRoot.spectrumOpen = false
         if (monitorMode) {
             // The frequency field usually still holds focus; the keyboard would
             // cover the session that just appeared.
@@ -240,6 +247,22 @@ Window {
         Behavior on opacity {
             NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
         }
+
+        onOpenSpectrum: mainRoot.spectrumOpen = true
+    }
+
+    // ---- Spectrum (pushed over the monitor) ----
+    SpectrumScreen {
+        anchors.fill: parent
+        opacity: mainRoot.monitorMode && mainRoot.spectrumOpen ? 1.0 : 0.0
+        visible: opacity > 0.0
+        enabled: opacity > 0.9
+
+        Behavior on opacity {
+            NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
+        }
+
+        onClosed: mainRoot.spectrumOpen = false
     }
 
     // ---- First-run onboarding ----

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -193,6 +193,10 @@ Window {
         // saved is a thing to listen to, and the spectrum watches it. Only a
         // session with no saved system behind it is free to wander.
         mainRoot.exploring = (row < 0)
+        // Belongs to the session that just ended. Carried into this one it would be
+        // written back to prefs on stop as if it were where this exploring got to —
+        // a frequency from two sessions ago, on a session that may never have moved.
+        mainRoot.lastExploreFreqMhz = ""
         // The previous session may have committed calls since the last 250 ms
         // tick; ingest them under its own label before the label changes hands,
         // or its tail calls read as the new system's.
@@ -392,6 +396,11 @@ Window {
                 // later whether or not the request was honoured.
                 commands.releaseTuner()
                 mainRoot.exploring = true
+                // Seeded here rather than waiting for the next tuner reading: the
+                // session may never move again, and an empty value would leave the
+                // stop handler with nothing to remember this band by.
+                if (metrics.centerFreqHz > 0)
+                    mainRoot.lastExploreFreqMhz = Util.mhzText(metrics.centerFreqHz)
                 // The session is no longer the saved system it started as: its
                 // frequency is now whatever the user makes it, and the calls it
                 // logs from here on did not come from that system.

--- a/src/ui/qt/qml/ModalSheet.qml
+++ b/src/ui/qt/qml/ModalSheet.qml
@@ -31,10 +31,6 @@ Rectangle {
         return p.x >= 0 && p.y >= 0 && p.x <= panelItem.width && p.y <= panelItem.height;
     }
 
-    function open() {
-        visible = true;
-    }
-
     anchors.fill: parent
     visible: false
     color: Qt.alpha("#000000", 0.5)

--- a/src/ui/qt/qml/ModalSheet.qml
+++ b/src/ui/qt/qml/ModalSheet.qml
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+
+// A centred panel over a dimmed screen, dismissed by tapping outside it.
+//
+// One copy because the dismissal rule is subtle and had been written out three
+// times: a TapHandler never takes an exclusive grab, so one placed on the panel
+// does not stop the scrim's from firing as well — an unconditional dismiss on
+// the scrim therefore closes the sheet on every press of every control inside
+// it. The scrim has to decide by where the tap landed instead, which is what
+// hitsPanel() is for, and a copy that got it wrong would be one sheet that
+// closes on its own buttons while the others do not.
+Rectangle {
+    id: sheet
+
+    /** Panel contents, laid out top to bottom. */
+    default property alias content: column.data
+    /** Gap between the panel's children. */
+    property alias spacing: column.spacing
+    /** Names the panel item itself, for tests that address it directly. */
+    property alias panelObjectName: panelItem.objectName
+
+    /** Emitted after a tap on the scrim has hidden the sheet. */
+    signal dismissed
+
+    /** Whether a point in this sheet's coordinates lies on the panel. */
+    function hitsPanel(x, y) {
+        var p = sheet.mapToItem(panelItem, x, y);
+        return p.x >= 0 && p.y >= 0 && p.x <= panelItem.width && p.y <= panelItem.height;
+    }
+
+    function open() {
+        visible = true;
+    }
+
+    anchors.fill: parent
+    visible: false
+    color: Qt.alpha("#000000", 0.5)
+
+    TapHandler {
+        onTapped: function (eventPoint) {
+            if (sheet.hitsPanel(eventPoint.position.x, eventPoint.position.y))
+                return;
+            sheet.visible = false;
+            // A sheet dismissed with a field still focused leaves the soft
+            // keyboard standing over the screen it went back to.
+            Qt.inputMethod.hide();
+            sheet.dismissed();
+        }
+    }
+
+    UiPanel {
+        id: panelItem
+
+        anchors.centerIn: parent
+        width: parent.width - 2 * Theme.screenPadding
+        height: column.height + 2 * Theme.cardPadding
+
+        Column {
+            id: column
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Theme.cardPadding
+            spacing: 12
+        }
+    }
+}

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -9,6 +9,9 @@ import "Util.js" as Util
 Item {
     id: screen
 
+    // Raised by the header's spectrum button; Main.qml owns the layer.
+    signal openSpectrum()
+
     // The saved-system map the session was started from (may be null for a
     // network/file quick start).
     property var system: null
@@ -99,7 +102,7 @@ Item {
 
         Column {
             anchors.left: parent.left
-            anchors.right: livePill.left
+            anchors.right: spectrumPill.visible ? spectrumPill.left : livePill.left
             anchors.rightMargin: 12
             anchors.verticalCenter: parent.verticalCenter
             spacing: 3
@@ -122,6 +125,44 @@ Item {
                 font.letterSpacing: 0.8
                 color: Theme.textSubdued
                 elide: Text.ElideRight
+            }
+        }
+
+        // Only an RTL front end has a band around the tuned frequency to show;
+        // a PCM feed or a file has nothing to draw.
+        Rectangle {
+            id: spectrumPill
+
+            objectName: "openSpectrumButton"
+            anchors.right: livePill.left
+            anchors.rightMargin: 8
+            anchors.verticalCenter: parent.verticalCenter
+            visible: metrics.radioInput
+            width: spectrumLabel.implicitWidth + 22
+            height: 30
+            radius: Theme.radiusButton
+            color: spectrumTap.pressed ? Qt.alpha(Theme.cyan, 0.08) : Theme.panel
+            border.width: 1
+            border.color: Theme.panelBorder
+
+            Behavior on color {
+                ColorAnimation { duration: 120 }
+            }
+
+            Text {
+                id: spectrumLabel
+
+                anchors.centerIn: parent
+                text: qsTr("SPECTRUM")
+                font.family: Theme.mono
+                font.pixelSize: 11
+                font.letterSpacing: 1.4
+                color: Theme.textSecondary
+            }
+
+            TapHandler {
+                id: spectrumTap
+                onTapped: screen.openSpectrum()
             }
         }
 

--- a/src/ui/qt/qml/RadioSheet.qml
+++ b/src/ui/qt/qml/RadioSheet.qml
@@ -13,6 +13,14 @@ import "Util.js" as Util
 // Every control reads the engine, not its own last request: a command can be
 // refused, and on Android the service holding these outlives this process, so a
 // panel remembering what it asked for would drift from the radio.
+//
+// With one bounded exception, below: a request that has been sent and not yet
+// answered stands in for the reading while it is outstanding. metrics is a
+// mirror republished every 250 ms, and these commands are coalescible setters —
+// so five taps inside one poll would each read the same stale value, compute the
+// same next one, and merge in the queue into a single step. The pending value
+// expires after requestTtlMs whatever happens, which is how a refused command
+// comes back to what the radio is actually on.
 Rectangle {
     id: sheet
 
@@ -22,42 +30,118 @@ Rectangle {
     visible: false
     color: Qt.alpha("#000000", 0.5)
 
+    // Long enough for several 250 ms polls plus the queue drain — an accepted
+    // request is normally reflected well inside it, and a refused one is not
+    // left standing for long enough to read as accepted.
+    readonly property int requestTtlMs: 1500
+
+    // NaN means "no outstanding request; the engine's reading is the truth".
+    property real pendingGain: NaN
+    property real pendingPpm: NaN
+    property real pendingSquelch: NaN
+
+    // What each control steps from and displays.
+    readonly property int gainDb: isNaN(pendingGain) ? metrics.tunerGainDb : pendingGain
+    readonly property int ppm: isNaN(pendingPpm) ? metrics.ppm : pendingPpm
+    readonly property real squelchDb: isNaN(pendingSquelch) ? metrics.squelchDb : pendingSquelch
+
     // 0 dB is the tuner's automatic gain, not silence — worth saying, because
     // "0" next to a signal that vanished reads as a mistake otherwise.
-    readonly property bool autoGain: metrics.tunerGainDb <= 0
+    readonly property bool autoGain: gainDb <= 0
 
     function open() {
+        // Whatever was outstanding belongs to the last time this was open, and on
+        // Android the service may have been driven from elsewhere since.
+        forgetRequests()
         visible = true
     }
 
-    /** Nudge the tuner gain, staying inside what an R820T actually offers. */
+    /** Drop every outstanding request and go back to reading the engine. */
+    function forgetRequests() {
+        pendingGain = NaN
+        pendingPpm = NaN
+        pendingSquelch = NaN
+        gainTtl.stop()
+        ppmTtl.stop()
+        squelchTtl.stop()
+    }
+
+    /**
+     * Nudge the tuner gain, staying inside what an R820T actually offers.
+     *
+     * A step that lands where the setting already is sends nothing: every
+     * accepted gain command restarts the dongle (svc_rtl_set_gain sets
+     * rtl_needs_restart), which drops audio and the spectrum — too much to spend
+     * on a button press at the end of the range that changes no setting.
+     */
     function stepGain(delta) {
-        var next = metrics.tunerGainDb + delta
+        var next = gainDb + delta
         if (next < 0)
             next = 0
         if (next > 49)
             next = 49
+        if (next === gainDb)
+            return
+        pendingGain = next
+        gainTtl.restart()
         commands.setTunerGain(next)
     }
 
     /** Nudge the crystal correction. Real dongles land within about ±100 ppm. */
     function stepPpm(delta) {
-        var next = metrics.ppm + delta
+        var next = ppm + delta
         if (next < -200)
             next = -200
         if (next > 200)
             next = 200
+        if (next === ppm)
+            return
+        pendingPpm = next
+        ppmTtl.restart()
         commands.setPpm(next)
     }
 
-    /** Nudge the squelch. Coarse steps: this is a threshold, not a measurement. */
+    /**
+     * Nudge the squelch. Coarse steps: this is a threshold, not a measurement.
+     *
+     * The floor is the readback's own: pwr_to_dB() clamps what comes back at
+     * -120 dB, so a step below that submits a value the display can never show
+     * and the button reads as broken while still restating the threshold.
+     */
     function stepSquelch(delta) {
-        var next = metrics.squelchDb + delta
-        if (next < -140)
-            next = -140
+        var next = squelchDb + delta
+        if (next < -120)
+            next = -120
         if (next > 0)
             next = 0
+        // The reading is a float that has been through dB_to_pwr and back, so
+        // "already there" is a tolerance, not an equality.
+        if (Math.abs(next - squelchDb) < 0.001)
+            return
+        pendingSquelch = next
+        squelchTtl.restart()
         commands.setSquelchDb(next)
+    }
+
+    Timer {
+        id: gainTtl
+
+        interval: sheet.requestTtlMs
+        onTriggered: sheet.pendingGain = NaN
+    }
+
+    Timer {
+        id: ppmTtl
+
+        interval: sheet.requestTtlMs
+        onTriggered: sheet.pendingPpm = NaN
+    }
+
+    Timer {
+        id: squelchTtl
+
+        interval: sheet.requestTtlMs
+        onTriggered: sheet.pendingSquelch = NaN
     }
 
     // Tapping the scrim dismisses; tapping the panel must not. A TapHandler on
@@ -122,7 +206,7 @@ Rectangle {
                         anchors.verticalCenter: parent.verticalCenter
                         width: 74
                         horizontalAlignment: Text.AlignRight
-                        text: sheet.autoGain ? qsTr("auto") : metrics.tunerGainDb + " dB"
+                        text: sheet.autoGain ? qsTr("auto") : sheet.gainDb + " dB"
                         font.family: Theme.mono
                         font.pixelSize: 14
                         color: Theme.textPrimary
@@ -170,7 +254,7 @@ Rectangle {
                         anchors.verticalCenter: parent.verticalCenter
                         width: 74
                         horizontalAlignment: Text.AlignRight
-                        text: Math.round(metrics.squelchDb) + " dB"
+                        text: Math.round(sheet.squelchDb) + " dB"
                         font.family: Theme.mono
                         font.pixelSize: 14
                         color: Theme.textPrimary
@@ -222,7 +306,7 @@ Rectangle {
                         anchors.verticalCenter: parent.verticalCenter
                         width: 74
                         horizontalAlignment: Text.AlignRight
-                        text: String(metrics.ppm)
+                        text: String(sheet.ppm)
                         font.family: Theme.mono
                         font.pixelSize: 14
                         color: Theme.textPrimary

--- a/src/ui/qt/qml/RadioSheet.qml
+++ b/src/ui/qt/qml/RadioSheet.qml
@@ -21,14 +21,12 @@ import "Util.js" as Util
 // same next one, and merge in the queue into a single step. The pending value
 // expires after requestTtlMs whatever happens, which is how a refused command
 // comes back to what the radio is actually on.
-Rectangle {
+ModalSheet {
     id: sheet
 
     objectName: "radioSheet"
-
-    anchors.fill: parent
-    visible: false
-    color: Qt.alpha("#000000", 0.5)
+    panelObjectName: "radioSheetPanel"
+    spacing: 14
 
     // Long enough for several 250 ms polls plus the queue drain — an accepted
     // request is normally reflected well inside it, and a refused one is not
@@ -144,263 +142,227 @@ Rectangle {
         onTriggered: sheet.pendingSquelch = NaN
     }
 
-    // Tapping the scrim dismisses; tapping the panel must not. A TapHandler on
-    // the panel cannot express that, because handlers never take exclusive grabs
-    // and both would fire — which closed this panel on every press of every
-    // control inside it. So the scrim decides by where the tap landed.
-    TapHandler {
-        onTapped: function (eventPoint) {
-            if (!sheet.hitsPanel(eventPoint.position.x, eventPoint.position.y))
-                sheet.visible = false
-        }
+    MicroLabel {
+        text: qsTr("Radio")
     }
 
-    /** Whether a point in this sheet's coordinates lies on the panel. */
-    function hitsPanel(x, y) {
-        var p = sheet.mapToItem(panel, x, y)
-        return p.x >= 0 && p.y >= 0 && p.x <= panel.width && p.y <= panel.height
-    }
+    // ---- Gain ----
+    Item {
+        width: parent.width
+        height: 34
 
-    UiPanel {
-        id: panel
-
-        objectName: "radioSheetPanel"
-        anchors.centerIn: parent
-        width: parent.width - 2 * Theme.screenPadding
-        height: column.height + 2 * Theme.cardPadding
-
-        Column {
-            id: column
-
+        Text {
             anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            text: qsTr("Gain")
+            font.family: Theme.sans
+            font.pixelSize: 14
+            color: Theme.textSecondary
+        }
+
+        Row {
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
-            anchors.margins: Theme.cardPadding
-            spacing: 14
+            spacing: 10
 
-            MicroLabel {
-                text: qsTr("Radio")
-            }
-
-            // ---- Gain ----
-            Item {
-                width: parent.width
-                height: 34
-
-                Text {
-                    anchors.left: parent.left
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: qsTr("Gain")
-                    font.family: Theme.sans
-                    font.pixelSize: 14
-                    color: Theme.textSecondary
-                }
-
-                Row {
-                    anchors.right: parent.right
-                    anchors.verticalCenter: parent.verticalCenter
-                    spacing: 10
-
-                    Text {
-                        objectName: "radioGainValue"
-                        anchors.verticalCenter: parent.verticalCenter
-                        width: 74
-                        horizontalAlignment: Text.AlignRight
-                        text: sheet.autoGain ? qsTr("auto") : sheet.gainDb + " dB"
-                        font.family: Theme.mono
-                        font.pixelSize: 14
-                        color: Theme.textPrimary
-                    }
-
-                    OutlineButton {
-                        objectName: "radioGainDown"
-                        width: 44
-                        height: 34
-                        text: "−"
-                        onClicked: sheet.stepGain(-1)
-                    }
-
-                    OutlineButton {
-                        objectName: "radioGainUp"
-                        width: 44
-                        height: 34
-                        text: "+"
-                        onClicked: sheet.stepGain(1)
-                    }
-                }
-            }
-
-            // ---- Squelch ----
-            Item {
-                width: parent.width
-                height: 34
-
-                Text {
-                    anchors.left: parent.left
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: qsTr("Squelch")
-                    font.family: Theme.sans
-                    font.pixelSize: 14
-                    color: Theme.textSecondary
-                }
-
-                Row {
-                    anchors.right: parent.right
-                    anchors.verticalCenter: parent.verticalCenter
-                    spacing: 10
-
-                    Text {
-                        objectName: "radioSquelchValue"
-                        anchors.verticalCenter: parent.verticalCenter
-                        width: 74
-                        horizontalAlignment: Text.AlignRight
-                        text: Math.round(sheet.squelchDb) + " dB"
-                        font.family: Theme.mono
-                        font.pixelSize: 14
-                        color: Theme.textPrimary
-                    }
-
-                    OutlineButton {
-                        objectName: "radioSquelchDown"
-                        width: 44
-                        height: 34
-                        text: "−"
-                        onClicked: sheet.stepSquelch(-5)
-                    }
-
-                    OutlineButton {
-                        objectName: "radioSquelchUp"
-                        width: 44
-                        height: 34
-                        text: "+"
-                        onClicked: sheet.stepSquelch(5)
-                    }
-                }
-            }
-
-            // ---- PPM ----
-            // The dongle's crystal error. Chosen once when the system was added,
-            // by someone who had no way to tell whether it was right: the symptom
-            // is a frequency offset the decoder cannot close, and that only shows
-            // up with a signal on screen. Which is here.
-            Item {
-                width: parent.width
-                height: 34
-
-                Text {
-                    anchors.left: parent.left
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: qsTr("PPM")
-                    font.family: Theme.sans
-                    font.pixelSize: 14
-                    color: Theme.textSecondary
-                }
-
-                Row {
-                    anchors.right: parent.right
-                    anchors.verticalCenter: parent.verticalCenter
-                    spacing: 10
-
-                    Text {
-                        objectName: "radioPpmValue"
-                        anchors.verticalCenter: parent.verticalCenter
-                        width: 74
-                        horizontalAlignment: Text.AlignRight
-                        text: String(sheet.ppm)
-                        font.family: Theme.mono
-                        font.pixelSize: 14
-                        color: Theme.textPrimary
-                    }
-
-                    OutlineButton {
-                        objectName: "radioPpmDown"
-                        width: 44
-                        height: 34
-                        text: "−"
-                        onClicked: sheet.stepPpm(-1)
-                    }
-
-                    OutlineButton {
-                        objectName: "radioPpmUp"
-                        width: 44
-                        height: 34
-                        text: "+"
-                        onClicked: sheet.stepPpm(1)
-                    }
-                }
-            }
-
-            Rectangle {
-                width: parent.width
-                height: 1
-                color: Theme.divider
-            }
-
-            // ---- Modulation ----
-            // Its own control rather than a decode chip, because it answers a
-            // different question: not what to look for, but how the site sends
-            // it. A simulcast P25 system reads as noise on C4FM and never locks,
-            // and that is the single most common reason a real signal decodes
-            // nothing.
             Text {
-                text: qsTr("Modulation")
-                font.family: Theme.sans
+                objectName: "radioGainValue"
+                anchors.verticalCenter: parent.verticalCenter
+                width: 74
+                horizontalAlignment: Text.AlignRight
+                text: sheet.autoGain ? qsTr("auto") : sheet.gainDb + " dB"
+                font.family: Theme.mono
                 font.pixelSize: 14
-                color: Theme.textSecondary
-            }
-
-            // GFSK is the third choice because it is a state the session can
-            // already be in — the DMR and EDACS/ProVoice presets select it — and
-            // a two-entry control could only show it as C4FM, then offer no way
-            // back to it once the user tried something else.
-            SegmentedControl {
-                objectName: "radioModulation"
-                width: parent.width
-                model: [qsTr("C4FM"), qsTr("QPSK / simulcast"), qsTr("GFSK")]
-                currentIndex: metrics.modulation
-                onSelected: function (index) { commands.setModulation(index) }
-            }
-
-            // ---- Decode ----
-            Text {
-                text: qsTr("Listening for")
-                font.family: Theme.sans
-                font.pixelSize: 14
-                color: Theme.textSecondary
-            }
-
-            Flow {
-                width: parent.width
-                spacing: 8
-
-                Repeater {
-                    // The simulcast entry is a modulation choice wearing a decode
-                    // chip's clothes; it has its own control above, so it would
-                    // appear here as a duplicate that changes nothing.
-                    model: Util.DECODE_MODES.filter(function (m) { return m.flag !== "-mq" })
-
-                    DecodeChip {
-                        required property var modelData
-
-                        readonly property int mode: commands.decodeModeForFlag(modelData.flag)
-
-                        objectName: "radioDecode_" + modelData.short
-                        text: modelData.short
-                        selected: mode >= 0 && mode === metrics.decodeMode
-                        onClicked: {
-                            if (mode >= 0)
-                                commands.setDecodeMode(mode)
-                        }
-                    }
-                }
+                color: Theme.textPrimary
             }
 
             OutlineButton {
-                objectName: "radioSheetDone"
-                width: parent.width
-                text: qsTr("Done")
-                onClicked: sheet.visible = false
+                objectName: "radioGainDown"
+                width: 44
+                height: 34
+                text: "−"
+                onClicked: sheet.stepGain(-1)
+            }
+
+            OutlineButton {
+                objectName: "radioGainUp"
+                width: 44
+                height: 34
+                text: "+"
+                onClicked: sheet.stepGain(1)
             }
         }
+    }
+
+    // ---- Squelch ----
+    Item {
+        width: parent.width
+        height: 34
+
+        Text {
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            text: qsTr("Squelch")
+            font.family: Theme.sans
+            font.pixelSize: 14
+            color: Theme.textSecondary
+        }
+
+        Row {
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: 10
+
+            Text {
+                objectName: "radioSquelchValue"
+                anchors.verticalCenter: parent.verticalCenter
+                width: 74
+                horizontalAlignment: Text.AlignRight
+                text: Math.round(sheet.squelchDb) + " dB"
+                font.family: Theme.mono
+                font.pixelSize: 14
+                color: Theme.textPrimary
+            }
+
+            OutlineButton {
+                objectName: "radioSquelchDown"
+                width: 44
+                height: 34
+                text: "−"
+                onClicked: sheet.stepSquelch(-5)
+            }
+
+            OutlineButton {
+                objectName: "radioSquelchUp"
+                width: 44
+                height: 34
+                text: "+"
+                onClicked: sheet.stepSquelch(5)
+            }
+        }
+    }
+
+    // ---- PPM ----
+    // The dongle's crystal error. Chosen once when the system was added,
+    // by someone who had no way to tell whether it was right: the symptom
+    // is a frequency offset the decoder cannot close, and that only shows
+    // up with a signal on screen. Which is here.
+    Item {
+        width: parent.width
+        height: 34
+
+        Text {
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            text: qsTr("PPM")
+            font.family: Theme.sans
+            font.pixelSize: 14
+            color: Theme.textSecondary
+        }
+
+        Row {
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: 10
+
+            Text {
+                objectName: "radioPpmValue"
+                anchors.verticalCenter: parent.verticalCenter
+                width: 74
+                horizontalAlignment: Text.AlignRight
+                text: String(sheet.ppm)
+                font.family: Theme.mono
+                font.pixelSize: 14
+                color: Theme.textPrimary
+            }
+
+            OutlineButton {
+                objectName: "radioPpmDown"
+                width: 44
+                height: 34
+                text: "−"
+                onClicked: sheet.stepPpm(-1)
+            }
+
+            OutlineButton {
+                objectName: "radioPpmUp"
+                width: 44
+                height: 34
+                text: "+"
+                onClicked: sheet.stepPpm(1)
+            }
+        }
+    }
+
+    Rectangle {
+        width: parent.width
+        height: 1
+        color: Theme.divider
+    }
+
+    // ---- Modulation ----
+    // Its own control rather than a decode chip, because it answers a
+    // different question: not what to look for, but how the site sends
+    // it. A simulcast P25 system reads as noise on C4FM and never locks,
+    // and that is the single most common reason a real signal decodes
+    // nothing.
+    Text {
+        text: qsTr("Modulation")
+        font.family: Theme.sans
+        font.pixelSize: 14
+        color: Theme.textSecondary
+    }
+
+    // GFSK is the third choice because it is a state the session can
+    // already be in — the DMR and EDACS/ProVoice presets select it — and
+    // a two-entry control could only show it as C4FM, then offer no way
+    // back to it once the user tried something else.
+    SegmentedControl {
+        objectName: "radioModulation"
+        width: parent.width
+        model: [qsTr("C4FM"), qsTr("QPSK / simulcast"), qsTr("GFSK")]
+        currentIndex: metrics.modulation
+        onSelected: function (index) { commands.setModulation(index) }
+    }
+
+    // ---- Decode ----
+    Text {
+        text: qsTr("Listening for")
+        font.family: Theme.sans
+        font.pixelSize: 14
+        color: Theme.textSecondary
+    }
+
+    Flow {
+        width: parent.width
+        spacing: 8
+
+        Repeater {
+            // The simulcast entry is a modulation choice wearing a decode
+            // chip's clothes; it has its own control above, so it would
+            // appear here as a duplicate that changes nothing.
+            model: Util.DECODE_MODES.filter(function (m) { return m.flag !== "-mq" })
+
+            DecodeChip {
+                required property var modelData
+
+                readonly property int mode: commands.decodeModeForFlag(modelData.flag)
+
+                objectName: "radioDecode_" + modelData.short
+                text: modelData.short
+                selected: mode >= 0 && mode === metrics.decodeMode
+                onClicked: {
+                    if (mode >= 0)
+                        commands.setDecodeMode(mode)
+                }
+            }
+        }
+    }
+
+    OutlineButton {
+        objectName: "radioSheetDone"
+        width: parent.width
+        text: qsTr("Done")
+        onClicked: sheet.visible = false
     }
 }

--- a/src/ui/qt/qml/RadioSheet.qml
+++ b/src/ui/qt/qml/RadioSheet.qml
@@ -265,10 +265,14 @@ Rectangle {
                 color: Theme.textSecondary
             }
 
+            // GFSK is the third choice because it is a state the session can
+            // already be in — the DMR and EDACS/ProVoice presets select it — and
+            // a two-entry control could only show it as C4FM, then offer no way
+            // back to it once the user tried something else.
             SegmentedControl {
                 objectName: "radioModulation"
                 width: parent.width
-                model: [qsTr("C4FM"), qsTr("QPSK / simulcast")]
+                model: [qsTr("C4FM"), qsTr("QPSK / simulcast"), qsTr("GFSK")]
                 currentIndex: metrics.modulation
                 onSelected: function (index) { commands.setModulation(index) }
             }

--- a/src/ui/qt/qml/RadioSheet.qml
+++ b/src/ui/qt/qml/RadioSheet.qml
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import "Util.js" as Util
+
+// The four settings that decide whether a signal on the waterfall turns into
+// audio, put where the waterfall is. Getting them wrong looks identical to
+// nothing being on the air, and until now the only way to change them was to
+// stop, edit the system and start again — which loses the thing you were
+// looking at.
+//
+// Every control reads the engine, not its own last request: a command can be
+// refused, and on Android the service holding these outlives this process, so a
+// panel remembering what it asked for would drift from the radio.
+Rectangle {
+    id: sheet
+
+    objectName: "radioSheet"
+
+    anchors.fill: parent
+    visible: false
+    color: Qt.alpha("#000000", 0.5)
+
+    // 0 dB is the tuner's automatic gain, not silence — worth saying, because
+    // "0" next to a signal that vanished reads as a mistake otherwise.
+    readonly property bool autoGain: metrics.tunerGainDb <= 0
+
+    function open() {
+        visible = true
+    }
+
+    /** Nudge the tuner gain, staying inside what an R820T actually offers. */
+    function stepGain(delta) {
+        var next = metrics.tunerGainDb + delta
+        if (next < 0)
+            next = 0
+        if (next > 49)
+            next = 49
+        commands.setTunerGain(next)
+    }
+
+    /** Nudge the crystal correction. Real dongles land within about ±100 ppm. */
+    function stepPpm(delta) {
+        var next = metrics.ppm + delta
+        if (next < -200)
+            next = -200
+        if (next > 200)
+            next = 200
+        commands.setPpm(next)
+    }
+
+    /** Nudge the squelch. Coarse steps: this is a threshold, not a measurement. */
+    function stepSquelch(delta) {
+        var next = metrics.squelchDb + delta
+        if (next < -140)
+            next = -140
+        if (next > 0)
+            next = 0
+        commands.setSquelchDb(next)
+    }
+
+    // Tapping the scrim dismisses; tapping the panel must not. A TapHandler on
+    // the panel cannot express that, because handlers never take exclusive grabs
+    // and both would fire — which closed this panel on every press of every
+    // control inside it. So the scrim decides by where the tap landed.
+    TapHandler {
+        onTapped: function (eventPoint) {
+            if (!sheet.hitsPanel(eventPoint.position.x, eventPoint.position.y))
+                sheet.visible = false
+        }
+    }
+
+    /** Whether a point in this sheet's coordinates lies on the panel. */
+    function hitsPanel(x, y) {
+        var p = sheet.mapToItem(panel, x, y)
+        return p.x >= 0 && p.y >= 0 && p.x <= panel.width && p.y <= panel.height
+    }
+
+    UiPanel {
+        id: panel
+
+        objectName: "radioSheetPanel"
+        anchors.centerIn: parent
+        width: parent.width - 2 * Theme.screenPadding
+        height: column.height + 2 * Theme.cardPadding
+
+        Column {
+            id: column
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Theme.cardPadding
+            spacing: 14
+
+            MicroLabel {
+                text: qsTr("Radio")
+            }
+
+            // ---- Gain ----
+            Item {
+                width: parent.width
+                height: 34
+
+                Text {
+                    anchors.left: parent.left
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: qsTr("Gain")
+                    font.family: Theme.sans
+                    font.pixelSize: 14
+                    color: Theme.textSecondary
+                }
+
+                Row {
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: 10
+
+                    Text {
+                        objectName: "radioGainValue"
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 74
+                        horizontalAlignment: Text.AlignRight
+                        text: sheet.autoGain ? qsTr("auto") : metrics.tunerGainDb + " dB"
+                        font.family: Theme.mono
+                        font.pixelSize: 14
+                        color: Theme.textPrimary
+                    }
+
+                    OutlineButton {
+                        objectName: "radioGainDown"
+                        width: 44
+                        height: 34
+                        text: "−"
+                        onClicked: sheet.stepGain(-1)
+                    }
+
+                    OutlineButton {
+                        objectName: "radioGainUp"
+                        width: 44
+                        height: 34
+                        text: "+"
+                        onClicked: sheet.stepGain(1)
+                    }
+                }
+            }
+
+            // ---- Squelch ----
+            Item {
+                width: parent.width
+                height: 34
+
+                Text {
+                    anchors.left: parent.left
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: qsTr("Squelch")
+                    font.family: Theme.sans
+                    font.pixelSize: 14
+                    color: Theme.textSecondary
+                }
+
+                Row {
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: 10
+
+                    Text {
+                        objectName: "radioSquelchValue"
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 74
+                        horizontalAlignment: Text.AlignRight
+                        text: Math.round(metrics.squelchDb) + " dB"
+                        font.family: Theme.mono
+                        font.pixelSize: 14
+                        color: Theme.textPrimary
+                    }
+
+                    OutlineButton {
+                        objectName: "radioSquelchDown"
+                        width: 44
+                        height: 34
+                        text: "−"
+                        onClicked: sheet.stepSquelch(-5)
+                    }
+
+                    OutlineButton {
+                        objectName: "radioSquelchUp"
+                        width: 44
+                        height: 34
+                        text: "+"
+                        onClicked: sheet.stepSquelch(5)
+                    }
+                }
+            }
+
+            // ---- PPM ----
+            // The dongle's crystal error. Chosen once when the system was added,
+            // by someone who had no way to tell whether it was right: the symptom
+            // is a frequency offset the decoder cannot close, and that only shows
+            // up with a signal on screen. Which is here.
+            Item {
+                width: parent.width
+                height: 34
+
+                Text {
+                    anchors.left: parent.left
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: qsTr("PPM")
+                    font.family: Theme.sans
+                    font.pixelSize: 14
+                    color: Theme.textSecondary
+                }
+
+                Row {
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: 10
+
+                    Text {
+                        objectName: "radioPpmValue"
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 74
+                        horizontalAlignment: Text.AlignRight
+                        text: String(metrics.ppm)
+                        font.family: Theme.mono
+                        font.pixelSize: 14
+                        color: Theme.textPrimary
+                    }
+
+                    OutlineButton {
+                        objectName: "radioPpmDown"
+                        width: 44
+                        height: 34
+                        text: "−"
+                        onClicked: sheet.stepPpm(-1)
+                    }
+
+                    OutlineButton {
+                        objectName: "radioPpmUp"
+                        width: 44
+                        height: 34
+                        text: "+"
+                        onClicked: sheet.stepPpm(1)
+                    }
+                }
+            }
+
+            Rectangle {
+                width: parent.width
+                height: 1
+                color: Theme.divider
+            }
+
+            // ---- Modulation ----
+            // Its own control rather than a decode chip, because it answers a
+            // different question: not what to look for, but how the site sends
+            // it. A simulcast P25 system reads as noise on C4FM and never locks,
+            // and that is the single most common reason a real signal decodes
+            // nothing.
+            Text {
+                text: qsTr("Modulation")
+                font.family: Theme.sans
+                font.pixelSize: 14
+                color: Theme.textSecondary
+            }
+
+            SegmentedControl {
+                objectName: "radioModulation"
+                width: parent.width
+                model: [qsTr("C4FM"), qsTr("QPSK / simulcast")]
+                currentIndex: metrics.modulation
+                onSelected: function (index) { commands.setModulation(index) }
+            }
+
+            // ---- Decode ----
+            Text {
+                text: qsTr("Listening for")
+                font.family: Theme.sans
+                font.pixelSize: 14
+                color: Theme.textSecondary
+            }
+
+            Flow {
+                width: parent.width
+                spacing: 8
+
+                Repeater {
+                    // The simulcast entry is a modulation choice wearing a decode
+                    // chip's clothes; it has its own control above, so it would
+                    // appear here as a duplicate that changes nothing.
+                    model: Util.DECODE_MODES.filter(function (m) { return m.flag !== "-mq" })
+
+                    DecodeChip {
+                        required property var modelData
+
+                        readonly property int mode: commands.decodeModeForFlag(modelData.flag)
+
+                        objectName: "radioDecode_" + modelData.short
+                        text: modelData.short
+                        selected: mode >= 0 && mode === metrics.decodeMode
+                        onClicked: {
+                            if (mode >= 0)
+                                commands.setDecodeMode(mode)
+                        }
+                    }
+                }
+            }
+
+            OutlineButton {
+                objectName: "radioSheetDone"
+                width: parent.width
+                text: qsTr("Done")
+                onClicked: sheet.visible = false
+            }
+        }
+    }
+}

--- a/src/ui/qt/qml/SpectrumScreen.qml
+++ b/src/ui/qt/qml/SpectrumScreen.qml
@@ -1078,7 +1078,7 @@ Item {
     }
 
     // ---- Go to ----
-    Rectangle {
+    ModalSheet {
         id: goToSheet
 
         objectName: "spectrumGoToSheet"
@@ -1096,116 +1096,58 @@ Item {
             goToSheet.visible = false
             Qt.inputMethod.hide()
             screen.stopSweep()
-            screen.tuneTo(mhz * 1.0e6)
+            // The field's validator accepts up to 99999 MHz and tuneTo() refuses
+            // anything past its own uint bound, so a number this sheet took can
+            // still be turned down. Reported rather than dropped: the sheet
+            // vanishing with the receiver where it was reads as the app ignoring
+            // the entry. Said after the dismissal because the toast sits under
+            // the sheet.
+            if (!screen.tuneTo(mhz * 1.0e6))
+                screen.hint = qsTr("Cannot tune to %1 MHz").arg(Util.mhzText(mhz * 1.0e6))
         }
 
-        /** Whether a point in this sheet's coordinates lies on the panel. */
-        function hitsPanel(x, y) {
-            var p = goToSheet.mapToItem(goToPanel, x, y)
-            return p.x >= 0 && p.y >= 0 && p.x <= goToPanel.width && p.y <= goToPanel.height
+        MicroLabel {
+            text: qsTr("Go to")
         }
 
-        anchors.fill: parent
-        visible: false
-        color: Qt.alpha("#000000", 0.5)
+        FrequencyField {
+            id: goToField
 
-        // Same rule as RadioSheet: handlers never take exclusive grabs, so an
-        // unconditional dismiss here also fires for every control on the panel —
-        // tapping a band pill set the field and closed the sheet in the same
-        // gesture, and tapping the field to place the cursor closed it outright.
-        TapHandler {
-            onTapped: function (eventPoint) {
-                if (goToSheet.hitsPanel(eventPoint.position.x, eventPoint.position.y))
-                    return
-                goToSheet.visible = false
-                Qt.inputMethod.hide()
+            width: parent.width
+            fieldObjectName: "spectrumGoToField"
+            // A shade smaller than the setup screens': this panel also carries
+            // the band pills and the button, over a live waterfall.
+            pixelSize: 30
+            spacing: 12
+            onAccepted: goToSheet.submit()
+        }
+
+        // Typing a frequency and jumping to a band are the same intent at
+        // different precisions, so they share one panel.
+        Flow {
+            width: parent.width
+            spacing: 8
+
+            Repeater {
+                model: Util.BANDS
+
+                FilterPill {
+                    required property var modelData
+
+                    objectName: "spectrumBand_" + modelData.label
+                    text: modelData.label
+                    caret: false
+                    active: screen.band ? screen.band.label === modelData.label : false
+                    onClicked: goToField.text = Util.mhzText(modelData.start)
+                }
             }
         }
 
-        UiPanel {
-            id: goToPanel
-
-            anchors.centerIn: parent
-            width: parent.width - 2 * Theme.screenPadding
-            height: goToColumn.height + 2 * Theme.cardPadding
-
-            Column {
-                id: goToColumn
-
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.margins: Theme.cardPadding
-                spacing: 12
-
-                MicroLabel {
-                    text: qsTr("Go to")
-                }
-
-                Row {
-                    spacing: 8
-
-                    TextInput {
-                        id: goToField
-
-                        objectName: "spectrumGoToField"
-                        width: Math.max(implicitWidth, 60)
-                        font.family: Theme.mono
-                        font.pixelSize: 30
-                        font.weight: Font.Medium
-                        color: Theme.textPrimary
-                        inputMethodHints: Qt.ImhFormattedNumbersOnly
-                        validator: RegularExpressionValidator {
-                            regularExpression: /^\d{1,5}(\.\d{0,6})?$/
-                        }
-                        selectionColor: Qt.alpha(Theme.cyan, 0.35)
-                        selectedTextColor: Theme.textPrimary
-                        onAccepted: goToSheet.submit()
-                    }
-
-                    Text {
-                        text: "MHz"
-                        anchors.baseline: goToField.baseline
-                        font.family: Theme.mono
-                        font.pixelSize: 15
-                        color: Theme.textSubdued
-                    }
-                }
-
-                Rectangle {
-                    width: parent.width
-                    height: 2
-                    color: Theme.cyan
-                }
-
-                // Typing a frequency and jumping to a band are the same intent at
-                // different precisions, so they share one panel.
-                Flow {
-                    width: parent.width
-                    spacing: 8
-
-                    Repeater {
-                        model: Util.BANDS
-
-                        FilterPill {
-                            required property var modelData
-
-                            objectName: "spectrumBand_" + modelData.label
-                            text: modelData.label
-                            caret: false
-                            active: screen.band ? screen.band.label === modelData.label : false
-                            onClicked: goToField.text = Util.mhzText(modelData.start)
-                        }
-                    }
-                }
-
-                OutlineButton {
-                    width: parent.width
-                    objectName: "spectrumGoToConfirm"
-                    text: qsTr("Tune")
-                    onClicked: goToSheet.submit()
-                }
-            }
+        OutlineButton {
+            width: parent.width
+            objectName: "spectrumGoToConfirm"
+            text: qsTr("Tune")
+            onClicked: goToSheet.submit()
         }
     }
 
@@ -1215,85 +1157,48 @@ Item {
     }
 
     // ---- Explore from here, confirmed ----
-    Rectangle {
+    ModalSheet {
         id: confirmExplore
 
         objectName: "spectrumExploreConfirm"
 
-        anchors.fill: parent
-        visible: false
-        color: Qt.alpha("#000000", 0.5)
-
-        /** Whether a point in this sheet's coordinates lies on the panel. */
-        function hitsPanel(x, y) {
-            var p = confirmExplore.mapToItem(confirmPanel, x, y)
-            return p.x >= 0 && p.y >= 0 && p.x <= confirmPanel.width && p.y <= confirmPanel.height
+        Text {
+            width: parent.width
+            text: qsTr("Explore from here?")
+            font.family: Theme.sans
+            font.pixelSize: 17
+            font.weight: Font.Bold
+            color: Theme.textPrimary
+            wrapMode: Text.Wrap
         }
 
-        // Same rule as the other two sheets: handlers never take exclusive grabs, so
-        // an unconditional dismiss here fires for every control on the panel as well.
-        TapHandler {
-            onTapped: function (eventPoint) {
-                if (!confirmExplore.hitsPanel(eventPoint.position.x, eventPoint.position.y))
-                    confirmExplore.visible = false
+        // Names what stops, and — the part people actually worry about —
+        // what does not.
+        Text {
+            width: parent.width
+            text: metrics.scannerMode
+                  ? qsTr("This stops stepping through the channel list for now. The saved system itself is unchanged.")
+                  : qsTr("This stops following calls across channels for now. The saved system itself is unchanged.")
+            font.family: Theme.sans
+            font.pixelSize: 14
+            color: Theme.textSecondary
+            wrapMode: Text.Wrap
+        }
+
+        OutlineButton {
+            objectName: "spectrumExploreConfirmAccept"
+            width: parent.width
+            text: qsTr("Explore from here")
+            onClicked: {
+                confirmExplore.visible = false
+                screen.exploreFromHere()
             }
         }
 
-        UiPanel {
-            id: confirmPanel
-
-            anchors.centerIn: parent
-            width: parent.width - 2 * Theme.screenPadding
-            height: confirmColumn.height + 2 * Theme.cardPadding
-
-            Column {
-                id: confirmColumn
-
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.margins: Theme.cardPadding
-                spacing: 12
-
-                Text {
-                    width: parent.width
-                    text: qsTr("Explore from here?")
-                    font.family: Theme.sans
-                    font.pixelSize: 17
-                    font.weight: Font.Bold
-                    color: Theme.textPrimary
-                    wrapMode: Text.Wrap
-                }
-
-                // Names what stops, and — the part people actually worry about —
-                // what does not.
-                Text {
-                    width: parent.width
-                    text: metrics.scannerMode
-                          ? qsTr("This stops stepping through the channel list for now. The saved system itself is unchanged.")
-                          : qsTr("This stops following calls across channels for now. The saved system itself is unchanged.")
-                    font.family: Theme.sans
-                    font.pixelSize: 14
-                    color: Theme.textSecondary
-                    wrapMode: Text.Wrap
-                }
-
-                OutlineButton {
-                    objectName: "spectrumExploreConfirmAccept"
-                    width: parent.width
-                    text: qsTr("Explore from here")
-                    onClicked: {
-                        confirmExplore.visible = false
-                        screen.exploreFromHere()
-                    }
-                }
-
-                OutlineButton {
-                    width: parent.width
-                    text: qsTr("Cancel")
-                    onClicked: confirmExplore.visible = false
-                }
-            }
+        OutlineButton {
+            width: parent.width
+            text: qsTr("Cancel")
+            onClicked: confirmExplore.visible = false
         }
     }
 }

--- a/src/ui/qt/qml/SpectrumScreen.qml
+++ b/src/ui/qt/qml/SpectrumScreen.qml
@@ -49,9 +49,10 @@ Item {
     // preview; this just reads it, rather than restating the same expression.
     readonly property real readoutHz: bandRail.displayHz
 
-    // Where the tuner can be walked without leaving the part of the spectrum the
-    // user is working in. Null off-band, in which case stepping is unbounded and
-    // the rail shows a local window instead.
+    // Which band the tuner is currently inside, or null off-band. The Go-to
+    // sheet reads this to highlight the matching pill; nextStepHz() reaches the
+    // same answer through its own Util.bandFor() lookup to decide where a step
+    // wraps. Neither the rail nor its window cares about bands at all.
     readonly property var band: Util.bandFor(screen.tunedHz)
 
     // A step overlaps the last one, so a signal sitting on a seam is not missed

--- a/src/ui/qt/qml/SpectrumScreen.qml
+++ b/src/ui/qt/qml/SpectrumScreen.qml
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import DsdNeo
+
+// The band around the tuned frequency, and a way to move to a signal by
+// touching it. Changing frequency otherwise means stopping the session, editing
+// the system and starting again, which is hopeless when what you are doing is
+// hunting for activity.
+//
+// The waterfall is the screen: everything else stays quiet so the eye goes to
+// the one thing that shows where the traffic is.
+Item {
+    id: screen
+
+    objectName: "spectrumScreen"
+
+    signal closed()
+
+    // While the trunking controller owns the tuner the engine refuses manual
+    // retunes, so this is view-only rather than a control that does nothing.
+    readonly property bool viewOnly: metrics ? metrics.trunkingEnabled : false
+    // The frame's own center is what the bins were measured at; the options
+    // reading is only a fallback for the moment before the first frame lands.
+    readonly property real tunedHz: spectrum.hasData ? spectrum.centerFreqHz
+                                                     : (metrics ? metrics.centerFreqHz : 0)
+
+    // Producing frames is what costs battery, so it follows the screen being up
+    // and a session running — not merely the object existing.
+    Binding {
+        target: spectrum
+        property: "active"
+        value: screen.visible && decoderHost.sessionActive
+    }
+
+    // Gesture state and the steps that act on it live here rather than inside
+    // the handlers: a handler body cannot be called from a test, and these are
+    // the parts that decide where the receiver ends up.
+    property real pinchStartZoom: 1.0
+    property real pinchAnchorX: 0.5
+    property real panStartOffsetHz: 0
+
+    /** Zoom to @a activeScale relative to where the pinch began, held at its anchor. */
+    function applyPinch(activeScale) {
+        spectrum.zoomToAnchored(screen.pinchStartZoom * activeScale, screen.pinchAnchorX)
+    }
+
+    /** Pan by @a dx pixels from where the drag began, across @a width pixels of view. */
+    function applyPan(dx, width) {
+        if (width <= 0)
+            return
+        // Dragging right walks the window down the band, as if pulling the
+        // spectrum along under the finger.
+        spectrum.viewOffsetHz = screen.panStartOffsetHz - ((dx / width) * spectrum.viewSpanHz)
+    }
+
+    /** Settle a finished pan: at most one retune, and only if it ran off the edge. */
+    function endPan() {
+        if (!screen.viewOnly && spectrum.edgeOvershootHz !== 0 && spectrum.hasData)
+            commands.manualTuneHz(Math.round(spectrum.centerFreqHz + spectrum.edgeOvershootHz))
+        spectrum.clearOvershoot()
+    }
+
+    // This layer sits above the monitor, which stays visible underneath it.
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.bg
+    }
+
+    // ---- Header ----
+    Item {
+        id: header
+
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.margins: Theme.screenPadding
+        height: 48
+
+        Item {
+            id: backButton
+
+            objectName: "spectrumBack"
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            width: 32
+            height: 32
+
+            Caret {
+                anchors.centerIn: parent
+                // Points down at rotation 0; a quarter turn clockwise reads as back.
+                rotation: 90
+                color: Theme.textPrimary
+            }
+
+            TapHandler {
+                onTapped: screen.closed()
+            }
+        }
+
+        Column {
+            anchors.left: backButton.right
+            anchors.leftMargin: 6
+            anchors.right: statusPill.left
+            anchors.rightMargin: 12
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: 2
+
+            MicroLabel {
+                text: qsTr("Spectrum")
+            }
+
+            Text {
+                objectName: "spectrumCenterReadout"
+                width: parent.width
+                text: screen.tunedHz > 0 ? (screen.tunedHz / 1.0e6).toFixed(4) + " MHz" : "—"
+                font.family: Theme.mono
+                font.pixelSize: 21
+                font.weight: Font.Medium
+                color: Theme.textPrimary
+                elide: Text.ElideRight
+            }
+        }
+
+        Rectangle {
+            id: statusPill
+
+            objectName: "spectrumStatusPill"
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            width: statusLabel.implicitWidth + 22
+            height: 30
+            radius: Theme.radiusButton
+            color: Theme.panel
+            border.width: 1
+            border.color: screen.viewOnly ? Theme.encBorder : Theme.panelBorder
+
+            Text {
+                id: statusLabel
+
+                anchors.centerIn: parent
+                text: screen.viewOnly ? qsTr("VIEW ONLY") : qsTr("TAP TO TUNE")
+                font.family: Theme.mono
+                font.pixelSize: 11
+                font.letterSpacing: 1.4
+                color: screen.viewOnly ? Theme.magenta : Theme.textSecondary
+            }
+        }
+    }
+
+    // ---- Trace, axis, waterfall ----
+    Item {
+        id: body
+
+        objectName: "spectrumTapArea"
+
+        anchors.top: header.bottom
+        anchors.topMargin: Theme.gap
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.leftMargin: Theme.screenPadding
+        anchors.rightMargin: Theme.screenPadding
+        anchors.bottomMargin: Theme.screenPadding
+
+        // Recomputed whenever the window moves. axisTicks() is a call, not a
+        // property, so the window edges are read here to make the dependency
+        // explicit — without them the labels would freeze on the first frame.
+        readonly property var ticks: {
+            var low = spectrum.viewLowHz
+            var high = spectrum.viewHighHz
+            if (!spectrum.hasData || high <= low)
+                return []
+            return spectrum.axisTicks(5)
+        }
+
+        SpectrumTrace {
+            id: trace
+
+            objectName: "spectrumTrace"
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            height: Math.round(parent.height * 0.32)
+
+            model: spectrum
+            lineColor: Theme.cyan
+            areaColor: Qt.alpha(Theme.cyan, 0.14)
+            gridColor: Theme.divider
+        }
+
+        Item {
+            id: axis
+
+            anchors.top: trace.bottom
+            anchors.left: parent.left
+            anchors.right: parent.right
+            height: 18
+
+            // Hairline where the live trace hands over to its own history.
+            Rectangle {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: 1
+                color: Theme.panelBorder
+            }
+
+            Repeater {
+                model: body.ticks
+
+                MicroLabel {
+                    // Anchored by its center on the tick, then nudged so the end
+                    // labels stay inside the panel instead of hanging off it.
+                    x: Math.round(Math.max(0, Math.min(axis.width - implicitWidth,
+                                                       (modelData.xFraction * axis.width) - (implicitWidth / 2))))
+                    y: Math.round((axis.height - implicitHeight) / 2)
+                    text: modelData.label
+                    font.capitalization: Font.MixedCase
+                }
+            }
+        }
+
+        Waterfall {
+            id: waterfall
+
+            objectName: "spectrumWaterfall"
+            anchors.top: axis.bottom
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+
+            model: spectrum
+            // The page color, not the panel: history takes ~16 s to fill, and
+            // a panel-colored fresh waterfall is a bright empty slab in light
+            // mode. Sharing the background makes "nothing heard yet" read as
+            // nothing rather than as a hole.
+            coldColor: Theme.bg
+            midColor: Theme.cyan
+            hotColor: Theme.magenta
+        }
+
+        Text {
+            anchors.centerIn: waterfall
+            visible: !spectrum.hasData
+            text: qsTr("Waiting for signal data…")
+            font.family: Theme.mono
+            font.pixelSize: 12
+            font.letterSpacing: 0.8
+            color: Theme.textSubdued
+        }
+
+        // The engine's answer to the last tap. The monitor shows this too, but it
+        // is underneath this layer — without it here a refused tune (trunking
+        // took the tuner, backend cannot retune) reads as a screen that ignored
+        // the touch.
+        Rectangle {
+            objectName: "spectrumToast"
+
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: Theme.gap
+            visible: metrics.uiMessage.length > 0
+            width: Math.min(parent.width, toastLabel.implicitWidth + 24)
+            height: 30
+            radius: Theme.radiusButton
+            color: Theme.panel
+            border.width: 1
+            border.color: Theme.panelBorder
+
+            Text {
+                id: toastLabel
+
+                anchors.centerIn: parent
+                width: Math.min(parent.width - 24, implicitWidth)
+                text: metrics.uiMessage
+                font.family: Theme.mono
+                font.pixelSize: 12
+                color: Theme.cyan
+                elide: Text.ElideRight
+            }
+        }
+
+        // A fingertip covers several channels, so the tap snaps to the strongest
+        // peak near it. The gate is an affordance only — the engine refuses the
+        // tune on its own if trunking took the tuner in the meantime.
+        TapHandler {
+            enabled: !screen.viewOnly && spectrum.hasData
+            onTapped: function (eventPoint) {
+                var hz = spectrum.tapFrequencyHz(eventPoint.position.x / body.width)
+                if (hz > 0)
+                    commands.manualTuneHz(Math.round(hz))
+            }
+        }
+
+        PinchHandler {
+            id: pinch
+
+            target: null
+            // Wider than the model's 1x-8x so the clamp lives in one place.
+            minimumScale: 0.1
+            maximumScale: 20.0
+
+            onActiveChanged: {
+                if (!active)
+                    return
+                screen.pinchStartZoom = spectrum.zoom
+                screen.pinchAnchorX = body.width > 0 ? (pinch.centroid.position.x / body.width) : 0.5
+            }
+            onActiveScaleChanged: {
+                if (pinch.active)
+                    screen.applyPinch(pinch.activeScale)
+            }
+        }
+
+        DragHandler {
+            id: pan
+
+            target: null
+            xAxis.enabled: true
+            yAxis.enabled: false
+
+            onActiveChanged: {
+                if (active) {
+                    screen.panStartOffsetHz = spectrum.viewOffsetHz
+                    return
+                }
+                // Exactly one retune per gesture, on release. Retuning per drag
+                // frame would block the engine thread for up to 500 ms a time.
+                screen.endPan()
+            }
+            onActiveTranslationChanged: {
+                if (pan.active)
+                    screen.applyPan(pan.activeTranslation.x, body.width)
+            }
+        }
+    }
+}

--- a/src/ui/qt/qml/SpectrumScreen.qml
+++ b/src/ui/qt/qml/SpectrumScreen.qml
@@ -3,29 +3,66 @@
 
 import QtQuick
 import DsdNeo
+import "Util.js" as Util
 
-// The band around the tuned frequency, and a way to move to a signal by
-// touching it. Changing frequency otherwise means stopping the session, editing
-// the system and starting again, which is hopeless when what you are doing is
-// hunting for activity.
+// The band around the tuned frequency. What you can do with it depends on why
+// the session exists.
 //
-// The waterfall is the screen: everything else stays quiet so the eye goes to
-// the one thing that shows where the traffic is.
+// Listening to a saved system, this watches: the card names a frequency, and a
+// touch that quietly moved off it would make the card a lie and would file the
+// calls heard afterwards under a system that was not on the air. Exploring, this
+// *is* the session — tap a signal, step along the band, or let it sweep — and
+// there is nothing to be untrue to.
+//
+// The waterfall is the screen either way: everything else stays quiet so the eye
+// goes to the one thing that shows where the traffic is.
 Item {
     id: screen
 
     objectName: "spectrumScreen"
 
     signal closed()
+    // Asks the session to stop following a system and let the tuner be driven by
+    // hand. Main.qml owns what that costs; this screen only asks.
+    signal exploreFromHere()
+    signal saveAsSystem(double freqHz)
 
-    // While an automatic controller owns the tuner — trunking, or conventional
-    // scanner mode stepping the channel map — the engine refuses manual
-    // retunes, so this is view-only rather than a control that does nothing.
-    readonly property bool viewOnly: metrics ? metrics.tunerControlled : false
+    // Whether this session may be retuned at all. Set from the session's intent,
+    // defaulted to the safe answer so the screen is inert wherever it is loaded
+    // without one.
+    property bool exploring: false
+
+    // Two different refusals, and the difference matters to the user. An
+    // automatic controller holding the tuner is temporary and has a name; a saved
+    // system is a choice they made, and it has a way out.
+    readonly property bool tunerHeld: metrics ? metrics.tunerControlled : false
+    readonly property bool viewOnly: !screen.exploring || screen.tunerHeld
+
     // The frame's own center is what the bins were measured at; the options
     // reading is only a fallback for the moment before the first frame lands.
     readonly property real tunedHz: spectrum.hasData ? spectrum.centerFreqHz
                                                      : (metrics ? metrics.centerFreqHz : 0)
+
+    // Where the tuner can be walked without leaving the part of the spectrum the
+    // user is working in. Null off-band, in which case stepping is unbounded and
+    // the rail shows a local window instead.
+    readonly property var band: Util.bandFor(screen.tunedHz)
+
+    // A step overlaps the last one, so a signal sitting on a seam is not missed
+    // by both screens it straddles.
+    readonly property real stepHz: spectrum.hasData ? spectrum.spanHz * 0.9 : 0
+
+    // Answers this screen has to give itself, which the engine never sends: an
+    // empty band, a sweep that wrapped. Preferred over the engine's own message
+    // so the newer answer wins.
+    property string hint: ""
+
+    // Whether a sheet is over the picture. TapHandlers never take exclusive
+    // grabs, so a tap meant for a control on a sheet also reaches the spectrum
+    // underneath and retunes the radio — the panel closes and the receiver has
+    // moved. Disabling the picture while a sheet is up is what stops that; the
+    // sheets are siblings of it, so they stay live.
+    readonly property bool sheetOpen: radioSheet.visible || goToSheet.visible || confirmExplore.visible
 
     // Producing frames is what costs battery, so it follows the screen being up
     // and a session running — not merely the object existing.
@@ -33,6 +70,16 @@ Item {
         target: spectrum
         property: "active"
         value: screen.visible && decoderHost.sessionActive
+    }
+
+    onVisibleChanged: {
+        if (!visible)
+            screen.stopSweep()
+    }
+
+    onViewOnlyChanged: {
+        if (viewOnly)
+            screen.stopSweep()
     }
 
     // Gesture state and the steps that act on it live here rather than inside
@@ -75,6 +122,124 @@ Item {
         if (!cancelled && !screen.viewOnly && spectrum.edgeOvershootHz !== 0 && spectrum.hasData && wantHz > 0)
             commands.manualTuneHz(Math.round(wantHz))
         spectrum.clearOvershoot()
+    }
+
+    /** Ask for @a hz, if this session is allowed to ask at all. */
+    function tuneTo(hz) {
+        if (screen.viewOnly || !(hz > 0))
+            return false
+        screen.hint = ""
+        commands.manualTuneHz(Math.round(hz))
+        return true
+    }
+
+    /**
+     * Where a step of @a direction (+1 up the band, -1 down) from @a fromHz lands.
+     *
+     * Wraps inside the band it started in rather than running off the end: past
+     * the top of 800 MHz there is nothing this app decodes, and a control that
+     * keeps going teaches the user nothing about where they are. Off-band there
+     * is nothing to wrap against and the walk is unbounded.
+     *
+     * Separate from stepBy() because this is the part worth pinning: the wrap
+     * only happens at a band edge, which is not somewhere a test can drive the
+     * receiver to.
+     */
+    function nextStepHz(fromHz, direction) {
+        if (!(screen.stepHz > 0))
+            return 0
+        var next = fromHz + (direction >= 0 ? screen.stepHz : -screen.stepHz)
+        var band = Util.bandFor(fromHz)
+        if (!band)
+            return next
+        // Half a step in from the far edge, so the first screenful after a wrap
+        // is spectrum rather than half a screen of nothing.
+        if (next >= band.high)
+            return band.low + (screen.stepHz / 2)
+        if (next <= band.low)
+            return band.high - (screen.stepHz / 2)
+        return next
+    }
+
+    /** Walk one screen of spectrum in @a direction (+1 up the band, -1 down). */
+    function stepBy(direction) {
+        if (!spectrum.hasData)
+            return
+        var from = screen.tunedHz
+        var next = screen.nextStepHz(from, direction)
+        if (!(next > 0))
+            return
+        // Moving against the direction asked for can only mean the walk came back
+        // round; say so, or the readout appears to jump for no reason.
+        var wrapped = (direction >= 0) ? (next < from) : (next > from)
+        if (!screen.tuneTo(next))
+            return
+        if (wrapped)
+            screen.hint = qsTr("Wrapped to %1").arg(Util.fmtMhz(next))
+    }
+
+    /** Jump to the next signal above (+1) or below (-1) the current center. */
+    function hopToSignal(direction) {
+        var hz = spectrum.nextPeakHz(direction)
+        if (!(hz > 0)) {
+            screen.hint = qsTr("Nothing else on this screen")
+            return
+        }
+        screen.tuneTo(hz)
+    }
+
+    // ---- Sweep ----
+    // Stepping, repeated, until something is found. It is the same action as the
+    // chevrons either side of it, which is why it lives between them rather than
+    // as a control of its own.
+    property bool sweeping: false
+
+    function startSweep() {
+        if (screen.viewOnly || !spectrum.hasData)
+            return
+        screen.hint = ""
+        // The band is decided once, at the start: wrapping against a boundary the
+        // sweep itself crossed would make it stop somewhere it never chose.
+        screen.sweeping = true
+        sweepTimer.restart()
+    }
+
+    function stopSweep() {
+        if (!screen.sweeping)
+            return
+        screen.sweeping = false
+        sweepTimer.stop()
+    }
+
+    function toggleSweep() {
+        if (screen.sweeping)
+            screen.stopSweep()
+        else
+            screen.startSweep()
+    }
+
+    /** One dwell has elapsed: keep what was found, or move on. */
+    function sweepTick() {
+        if (!screen.sweeping)
+            return
+        if (metrics.syncedHere) {
+            screen.stopSweep()
+            screen.hint = qsTr("Found something at %1").arg(Util.fmtMhz(screen.tunedHz))
+            return
+        }
+        screen.stepBy(1)
+    }
+
+    Timer {
+        id: sweepTimer
+
+        // Long enough for the tuner to settle and the decoder to find sync, and
+        // no shorter: each retune blocks the engine thread for up to half a
+        // second, so a fast sweep spends its time stopping and starting.
+        interval: 2500
+        repeat: true
+        running: screen.sweeping
+        onTriggered: screen.sweepTick()
     }
 
     // This layer sits above the monitor, which stays visible underneath it.
@@ -126,15 +291,33 @@ Item {
                 text: qsTr("Spectrum")
             }
 
-            Text {
-                objectName: "spectrumCenterReadout"
-                width: parent.width
-                text: screen.tunedHz > 0 ? (screen.tunedHz / 1.0e6).toFixed(4) + " MHz" : "—"
-                font.family: Theme.mono
-                font.pixelSize: 21
-                font.weight: Font.Medium
-                color: Theme.textPrimary
-                elide: Text.ElideRight
+            Row {
+                spacing: 6
+
+                Text {
+                    objectName: "spectrumCenterReadout"
+                    // Never elided: this is the frequency the radio is on, and a
+                    // readout that drops a digit is worse than one that is tight.
+                    text: screen.tunedHz > 0 ? Util.fmtMhz(screen.tunedHz) : "—"
+                    font.family: Theme.mono
+                    font.pixelSize: 21
+                    font.weight: Font.Medium
+                    color: Theme.textPrimary
+                }
+
+                // The readout doubles as the way to leave the neighbourhood
+                // entirely. Only marked as a control when it is one.
+                Caret {
+                    anchors.verticalCenter: parent.verticalCenter
+                    visible: !screen.viewOnly
+                    color: Theme.cyan
+                }
+            }
+
+            TapHandler {
+                objectName: "spectrumGoToOpen"
+                enabled: !screen.viewOnly
+                onTapped: goToSheet.open(screen.tunedHz)
             }
         }
 
@@ -149,17 +332,20 @@ Item {
             radius: Theme.radiusButton
             color: Theme.panel
             border.width: 1
-            border.color: screen.viewOnly ? Theme.encBorder : Theme.panelBorder
+            border.color: screen.viewOnly ? Theme.encBorder
+                                          : screen.sweeping ? Theme.cyan : Theme.panelBorder
 
             Text {
                 id: statusLabel
 
                 anchors.centerIn: parent
-                text: screen.viewOnly ? qsTr("VIEW ONLY") : qsTr("TAP TO TUNE")
+                text: screen.viewOnly ? qsTr("VIEW ONLY")
+                                      : screen.sweeping ? qsTr("SWEEPING") : qsTr("TAP TO TUNE")
                 font.family: Theme.mono
                 font.pixelSize: 11
                 font.letterSpacing: 1.4
-                color: screen.viewOnly ? Theme.magenta : Theme.textSecondary
+                color: screen.viewOnly ? Theme.magenta
+                                       : screen.sweeping ? Theme.cyan : Theme.textSecondary
             }
         }
     }
@@ -167,8 +353,6 @@ Item {
     // ---- Trace, axis, waterfall ----
     Item {
         id: body
-
-        objectName: "spectrumTapArea"
 
         anchors.top: header.bottom
         anchors.topMargin: Theme.gap
@@ -178,6 +362,7 @@ Item {
         anchors.leftMargin: Theme.screenPadding
         anchors.rightMargin: Theme.screenPadding
         anchors.bottomMargin: Theme.screenPadding
+        enabled: !screen.sheetOpen
 
         // Most labels the axis will carry. Shared with the Repeater below so the
         // delegate count and the request can never drift apart.
@@ -194,103 +379,641 @@ Item {
             return spectrum.axisTicks(body.maxTicks)
         }
 
-        SpectrumTrace {
-            id: trace
+        // What the decoder is making of all this. The waterfall says where the
+        // energy is and says nothing at all about whether any of it is being
+        // decoded — which, on a band being swept, is the only question. Sync
+        // first because it is the answer; SNR second because it explains a
+        // missing sync; the call last because it is the payoff.
+        Item {
+            id: statusStrip
 
-            objectName: "spectrumTrace"
+            objectName: "spectrumStatusStrip"
             anchors.top: parent.top
             anchors.left: parent.left
             anchors.right: parent.right
-            height: Math.round(parent.height * 0.32)
+            height: 22
 
-            model: spectrum
-            lineColor: Theme.cyan
-            areaColor: Qt.alpha(Theme.cyan, 0.14)
-            gridColor: Theme.divider
-        }
-
-        Item {
-            id: axis
-
-            anchors.top: trace.bottom
-            anchors.left: parent.left
-            anchors.right: parent.right
-            height: 18
-
-            // Hairline where the live trace hands over to its own history.
-            Rectangle {
-                anchors.bottom: parent.bottom
+            Row {
                 anchors.left: parent.left
-                anchors.right: parent.right
-                height: 1
-                color: Theme.panelBorder
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: 14
+
+                Row {
+                    spacing: 6
+
+                    Rectangle {
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: 7
+                        height: 7
+                        radius: 3.5
+                        color: metrics.syncedHere ? Theme.cyan : Theme.textSubdued
+                    }
+
+                    Text {
+                        objectName: "spectrumSyncLabel"
+                        anchors.verticalCenter: parent.verticalCenter
+                        // Named when there is one, because "DMR" where P25 was
+                        // expected is the whole explanation for silence.
+                        text: metrics.syncedHere ? metrics.syncLabel.toUpperCase() : qsTr("NO SYNC")
+                        font.family: Theme.mono
+                        font.pixelSize: 11
+                        font.letterSpacing: 1.0
+                        color: metrics.syncedHere ? Theme.textPrimary : Theme.textSubdued
+                    }
+                }
+
+                Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: metrics.snrValid ? metrics.snrDb.toFixed(1) + " dB" : "— dB"
+                    font.family: Theme.mono
+                    font.pixelSize: 11
+                    color: metrics.snrValid ? Theme.textSecondary : Theme.textSubdued
+                }
+
+                // How far off frequency the decoder is finding the signal. Only
+                // meaningful once something is locked, and only interesting when
+                // it is not ~0 — a standing offset of a few hundred Hz is the
+                // symptom of a PPM correction that does not match this dongle,
+                // which is a thing the panel one tap away can fix.
+                Text {
+                    objectName: "spectrumCfoLabel"
+                    anchors.verticalCenter: parent.verticalCenter
+                    visible: metrics.syncedHere && Math.abs(metrics.cfoHz) >= 50
+                    text: Math.round(metrics.cfoHz) + " Hz"
+                    font.family: Theme.mono
+                    font.pixelSize: 11
+                    // Loud once it is large enough to be why nothing decodes.
+                    color: Math.abs(metrics.cfoHz) >= 500 ? Theme.magenta : Theme.textSecondary
+                }
+
+                Text {
+                    objectName: "spectrumCallLabel"
+                    anchors.verticalCenter: parent.verticalCenter
+                    visible: text.length > 0
+                    // "0" is a call epoch whose target has not decoded yet — which
+                    // a control channel opens routinely. Naming it would put a
+                    // talkgroup on screen that nobody is transmitting on.
+                    text: {
+                        var tg = metrics.slot1CallState === 2 ? metrics.slot1TgText
+                                                              : metrics.slot2CallState === 2 ? metrics.slot2TgText : ""
+                        return tg === "0" ? "" : tg
+                    }
+                    font.family: Theme.mono
+                    font.pixelSize: 11
+                    color: Theme.cyan
+                }
             }
 
-            // A fixed count, not the tick list itself: binding a Repeater to a
-            // freshly built list destroys and recreates every label each time
-            // the viewport moves, which during a drag is fifteen times a
-            // second. The delegates stay put and only their bindings re-evaluate.
-            Repeater {
-                model: body.maxTicks
+            // The settings that decide whether any of the above happens. Here
+            // rather than in the header because the header has no room left, and
+            // here rather than with the tuning controls because a saved system
+            // that is view-only still needs its gain fixed.
+            Rectangle {
+                id: radioButton
 
-                MicroLabel {
-                    required property int index
+                objectName: "spectrumRadioButton"
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                visible: metrics.radioInput
+                width: radioLabel.implicitWidth + 20
+                height: 22
+                radius: Theme.radiusButton
+                color: radioTap.pressed ? Qt.alpha(Theme.cyan, 0.08) : "transparent"
+                border.width: 1
+                border.color: Theme.panelBorder
 
-                    readonly property var tick: index < body.ticks.length ? body.ticks[index] : null
+                Behavior on color {
+                    ColorAnimation { duration: 120 }
+                }
 
-                    visible: tick !== null
-                    // Anchored by its center on the tick, then nudged so the end
-                    // labels stay inside the panel instead of hanging off it.
-                    x: tick ? Math.round(Math.max(0, Math.min(axis.width - implicitWidth,
-                                                              (tick.xFraction * axis.width) - (implicitWidth / 2))))
-                            : 0
-                    y: Math.round((axis.height - implicitHeight) / 2)
-                    text: tick ? tick.label : ""
-                    font.capitalization: Font.MixedCase
+                Text {
+                    id: radioLabel
+
+                    anchors.centerIn: parent
+                    text: qsTr("RADIO")
+                    font.family: Theme.mono
+                    font.pixelSize: 10
+                    font.letterSpacing: 1.2
+                    color: Theme.textSecondary
+                }
+
+                TapHandler {
+                    id: radioTap
+
+                    onTapped: radioSheet.open()
                 }
             }
         }
 
-        Waterfall {
-            id: waterfall
+        // The gesture surface is exactly the picture — trace, axis and waterfall —
+        // and nothing else. The controls below sit outside it, so a tap that
+        // misses a button cannot fall through and retune the radio.
+        Item {
+            id: gestureArea
 
-            objectName: "spectrumWaterfall"
-            anchors.top: axis.bottom
+            objectName: "spectrumTapArea"
+            anchors.top: statusStrip.bottom
+            anchors.topMargin: 4
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: tuning.visible ? tuning.top
+                                           : (exploreButton.visible ? exploreButton.top : parent.bottom)
+            anchors.bottomMargin: (tuning.visible || exploreButton.visible) ? Theme.gap : 0
+
+            SpectrumTrace {
+                id: trace
+
+                objectName: "spectrumTrace"
+                anchors.top: parent.top
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: Math.round(parent.height * 0.32)
+
+                model: spectrum
+                lineColor: Theme.cyan
+                areaColor: Qt.alpha(Theme.cyan, 0.14)
+                gridColor: Theme.divider
+            }
+
+            Item {
+                id: axis
+
+                anchors.top: trace.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: 18
+
+                // Hairline where the live trace hands over to its own history.
+                Rectangle {
+                    anchors.bottom: parent.bottom
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: 1
+                    color: Theme.panelBorder
+                }
+
+                // A fixed count, not the tick list itself: binding a Repeater to a
+                // freshly built list destroys and recreates every label each time
+                // the viewport moves, which during a drag is fifteen times a
+                // second. The delegates stay put and only their bindings re-evaluate.
+                Repeater {
+                    model: body.maxTicks
+
+                    MicroLabel {
+                        required property int index
+
+                        readonly property var tick: index < body.ticks.length ? body.ticks[index] : null
+
+                        visible: tick !== null
+                        // Anchored by its center on the tick, then nudged so the end
+                        // labels stay inside the panel instead of hanging off it.
+                        x: tick ? Math.round(Math.max(0, Math.min(axis.width - implicitWidth,
+                                                                  (tick.xFraction * axis.width) - (implicitWidth / 2))))
+                                : 0
+                        y: Math.round((axis.height - implicitHeight) / 2)
+                        text: tick ? tick.label : ""
+                        font.capitalization: Font.MixedCase
+                    }
+                }
+            }
+
+            Waterfall {
+                id: waterfall
+
+                objectName: "spectrumWaterfall"
+                anchors.top: axis.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+
+                model: spectrum
+                // The page color, not the panel: history takes ~16 s to fill, and
+                // a panel-colored fresh waterfall is a bright empty slab in light
+                // mode. Sharing the background makes "nothing heard yet" read as
+                // nothing rather than as a hole.
+                coldColor: Theme.bg
+                midColor: Theme.cyan
+                hotColor: Theme.magenta
+            }
+
+            Text {
+                anchors.centerIn: waterfall
+                visible: !spectrum.hasData
+                text: qsTr("Waiting for signal data…")
+                font.family: Theme.mono
+                font.pixelSize: 12
+                font.letterSpacing: 0.8
+                color: Theme.textSubdued
+            }
+
+            // A fingertip covers several channels, so the tap snaps to the strongest
+            // peak near it. The gate is an affordance only — the engine refuses the
+            // tune on its own if trunking took the tuner in the meantime.
+            TapHandler {
+                enabled: !screen.viewOnly && spectrum.hasData
+                onTapped: function (eventPoint) {
+                    // Touching the spectrum is taking over; a sweep that carried on
+                    // underneath would move the radio off what was just chosen.
+                    screen.stopSweep()
+                    screen.tuneTo(spectrum.tapFrequencyHz(eventPoint.position.x / gestureArea.width))
+                }
+            }
+
+            PinchHandler {
+                id: pinch
+
+                target: null
+                // Wider than the model's 1x-8x so the clamp lives in one place.
+                minimumScale: 0.1
+                maximumScale: 20.0
+
+                onActiveChanged: {
+                    if (!active)
+                        return
+                    screen.stopSweep()
+                    screen.pinchStartZoom = spectrum.zoom
+                    screen.pinchAnchorX = gestureArea.width > 0 ? (pinch.centroid.position.x / gestureArea.width) : 0.5
+                }
+                onActiveScaleChanged: {
+                    if (pinch.active)
+                        screen.applyPinch(pinch.activeScale)
+                }
+            }
+
+            DragHandler {
+                id: pan
+
+                target: null
+                xAxis.enabled: true
+                yAxis.enabled: false
+
+                onActiveChanged: {
+                    if (active) {
+                        screen.stopSweep()
+                        screen.panStartOffsetHz = spectrum.viewOffsetHz
+                        return
+                    }
+                    // Exactly one retune per gesture, on release. Retuning per drag
+                    // frame would block the engine thread for up to 500 ms a time.
+                    // A pinch stealing the grab deactivates this handler too, and
+                    // that is not a release.
+                    screen.endPan(pinch.active)
+                }
+                onActiveTranslationChanged: {
+                    if (pan.active)
+                        screen.applyPan(pan.activeTranslation.x, gestureArea.width)
+                }
+            }
+        }
+
+        // ---- Tuning controls (exploring only) ----
+        Column {
+            id: tuning
+
+            objectName: "spectrumTuning"
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.bottom: parent.bottom
+            spacing: 8
+            visible: !screen.viewOnly
 
-            model: spectrum
-            // The page color, not the panel: history takes ~16 s to fill, and
-            // a panel-colored fresh waterfall is a bright empty slab in light
-            // mode. Sharing the background makes "nothing heard yet" read as
-            // nothing rather than as a hole.
-            coldColor: Theme.bg
-            midColor: Theme.cyan
-            hotColor: Theme.magenta
+            // Where in the band this screenful sits. A readout, not a control:
+            // band-walking loses your place within a few steps, and during a
+            // sweep this is the part that shows it working.
+            Item {
+                id: rail
+
+                width: parent.width
+                height: 16
+                visible: screen.tunedHz > 0
+
+                // Off-band, a local window rather than the whole tuner range: a
+                // marker that moves by a hair across 24-1766 MHz says nothing.
+                readonly property real lowHz: screen.band ? screen.band.low : screen.tunedHz - 10.0e6
+                readonly property real highHz: screen.band ? screen.band.high : screen.tunedHz + 10.0e6
+
+                Text {
+                    id: railLow
+
+                    anchors.left: parent.left
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: Math.round(rail.lowHz / 1.0e6)
+                    font.family: Theme.mono
+                    font.pixelSize: 10
+                    color: Theme.textSubdued
+                }
+
+                Text {
+                    id: railHigh
+
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: Math.round(rail.highHz / 1.0e6)
+                    font.family: Theme.mono
+                    font.pixelSize: 10
+                    color: Theme.textSubdued
+                }
+
+                Item {
+                    id: railTrack
+
+                    anchors.left: railLow.right
+                    anchors.right: railHigh.left
+                    anchors.leftMargin: 8
+                    anchors.rightMargin: 8
+                    anchors.verticalCenter: parent.verticalCenter
+                    height: parent.height
+
+                    Rectangle {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        height: 1
+                        color: Theme.divider
+                    }
+
+                    Rectangle {
+                        objectName: "spectrumBandMarker"
+                        width: 3
+                        height: 11
+                        radius: 1.5
+                        anchors.verticalCenter: parent.verticalCenter
+                        x: {
+                            var span = rail.highHz - rail.lowHz
+                            if (!(span > 0))
+                                return 0
+                            var t = (screen.tunedHz - rail.lowHz) / span
+                            return Math.round(Math.max(0, Math.min(1, t)) * (railTrack.width - width))
+                        }
+                        color: Theme.cyan
+
+                        Behavior on x {
+                            NumberAnimation { duration: 180; easing.type: Easing.OutCubic }
+                        }
+                    }
+                }
+            }
+
+            Flow {
+                width: parent.width
+                spacing: 10
+
+                // Step, and the same step repeated. Putting the sweep between the
+                // chevrons says what it does without a word of explanation.
+                Rectangle {
+                    id: stepPill
+
+                    width: Math.max(186, stepRow.implicitWidth + 24)
+                    height: 40
+                    radius: Theme.radiusButton
+                    color: Theme.panel
+                    border.width: 1
+                    border.color: screen.sweeping ? Theme.cyan : Theme.controlBorder
+                    opacity: spectrum.hasData ? 1.0 : 0.5
+
+                    Behavior on border.color {
+                        ColorAnimation { duration: 120 }
+                    }
+
+                    Row {
+                        id: stepRow
+
+                        anchors.centerIn: parent
+                        spacing: 0
+
+                        Item {
+                            objectName: "spectrumStepDown"
+                            width: 46
+                            height: 38
+
+                            Caret {
+                                anchors.centerIn: parent
+                                rotation: 90
+                                color: Theme.buttonSecondaryText
+                            }
+
+                            TapHandler {
+                                enabled: spectrum.hasData
+                                onTapped: {
+                                    screen.stopSweep()
+                                    screen.stepBy(-1)
+                                }
+                            }
+                        }
+
+                        Item {
+                            objectName: "spectrumSweepToggle"
+                            width: Math.max(94, sweepLabel.implicitWidth + 26)
+                            height: 38
+
+                            Row {
+                                anchors.centerIn: parent
+                                spacing: 7
+
+                                // A triangle and a square, drawn: the font's own
+                                // play and stop glyphs are missing on the device.
+                                Canvas {
+                                    id: sweepGlyph
+
+                                    width: 10
+                                    height: 10
+                                    anchors.verticalCenter: parent.verticalCenter
+
+                                    onPaint: {
+                                        var ctx = getContext("2d")
+                                        ctx.reset()
+                                        ctx.fillStyle = screen.sweeping ? Theme.cyan : Theme.buttonSecondaryText
+                                        if (screen.sweeping) {
+                                            ctx.fillRect(1, 1, 8, 8)
+                                        } else {
+                                            ctx.beginPath()
+                                            ctx.moveTo(1, 0)
+                                            ctx.lineTo(10, 5)
+                                            ctx.lineTo(1, 10)
+                                            ctx.closePath()
+                                            ctx.fill()
+                                        }
+                                    }
+
+                                    Connections {
+                                        target: screen
+                                        function onSweepingChanged() { sweepGlyph.requestPaint() }
+                                    }
+
+                                    Connections {
+                                        target: Theme
+                                        function onDarkChanged() { sweepGlyph.requestPaint() }
+                                    }
+                                }
+
+                                Text {
+                                    id: sweepLabel
+
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    text: spectrum.hasData ? (screen.stepHz / 1.0e6).toFixed(2) + " MHz" : "—"
+                                    font.family: Theme.mono
+                                    font.pixelSize: 12
+                                    color: screen.sweeping ? Theme.cyan : Theme.buttonSecondaryText
+                                }
+                            }
+
+                            TapHandler {
+                                enabled: spectrum.hasData
+                                onTapped: screen.toggleSweep()
+                            }
+                        }
+
+                        Item {
+                            objectName: "spectrumStepUp"
+                            width: 46
+                            height: 38
+
+                            Caret {
+                                anchors.centerIn: parent
+                                rotation: -90
+                                color: Theme.buttonSecondaryText
+                            }
+
+                            TapHandler {
+                                enabled: spectrum.hasData
+                                onTapped: {
+                                    screen.stopSweep()
+                                    screen.stepBy(1)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // The finer move: to the next carrier actually on screen.
+                Rectangle {
+                    width: 92
+                    height: 40
+                    radius: Theme.radiusButton
+                    color: Theme.panel
+                    border.width: 1
+                    border.color: Theme.controlBorder
+                    opacity: spectrum.hasData ? 1.0 : 0.5
+
+                    Row {
+                        anchors.centerIn: parent
+                        spacing: 0
+
+                        Item {
+                            objectName: "spectrumSignalDown"
+                            width: 46
+                            height: 38
+
+                            Row {
+                                anchors.centerIn: parent
+                                spacing: 3
+
+                                Caret {
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    rotation: 90
+                                    color: Theme.buttonSecondaryText
+                                }
+
+                                Rectangle {
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    width: 2
+                                    height: 12
+                                    color: Theme.cyan
+                                }
+                            }
+
+                            TapHandler {
+                                enabled: spectrum.hasData
+                                onTapped: {
+                                    screen.stopSweep()
+                                    screen.hopToSignal(-1)
+                                }
+                            }
+                        }
+
+                        Item {
+                            objectName: "spectrumSignalUp"
+                            width: 46
+                            height: 38
+
+                            Row {
+                                anchors.centerIn: parent
+                                spacing: 3
+
+                                Rectangle {
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    width: 2
+                                    height: 12
+                                    color: Theme.cyan
+                                }
+
+                                Caret {
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    rotation: -90
+                                    color: Theme.buttonSecondaryText
+                                }
+                            }
+
+                            TapHandler {
+                                enabled: spectrum.hasData
+                                onTapped: {
+                                    screen.stopSweep()
+                                    screen.hopToSignal(1)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                OutlineButton {
+                    objectName: "spectrumSaveSystem"
+                    width: 96
+                    height: 40
+                    text: qsTr("Save")
+                    enabled: screen.tunedHz > 0
+                    onClicked: {
+                        screen.stopSweep()
+                        screen.saveAsSystem(screen.tunedHz)
+                    }
+                }
+            }
         }
 
-        Text {
-            anchors.centerIn: waterfall
-            visible: !spectrum.hasData
-            text: qsTr("Waiting for signal data…")
-            font.family: Theme.mono
-            font.pixelSize: 12
-            font.letterSpacing: 0.8
-            color: Theme.textSubdued
+        // The way out of view-only, when there is one. A saved system is a choice
+        // the user made, so this offers to undo it rather than silently allowing
+        // a touch to do the same thing.
+        OutlineButton {
+            id: exploreButton
+
+            objectName: "spectrumExploreFromHere"
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            visible: screen.viewOnly && decoderHost.sessionActive
+            text: qsTr("Explore from here")
+            onClicked: {
+                // Nothing is holding the tuner, so there is nothing to warn about
+                // and nothing to confirm.
+                if (!screen.tunerHeld)
+                    screen.exploreFromHere()
+                else
+                    confirmExplore.visible = true
+            }
         }
 
-        // The engine's answer to the last tap. The monitor shows this too, but it
-        // is underneath this layer — without it here a refused tune (trunking
-        // took the tuner, backend cannot retune) reads as a screen that ignored
-        // the touch.
+        // The engine's answer to the last tap, or this screen's own. Anchored
+        // above the controls rather than to the bottom of the body, which the
+        // tuning row now occupies.
         Rectangle {
             objectName: "spectrumToast"
 
             anchors.horizontalCenter: parent.horizontalCenter
-            anchors.bottom: parent.bottom
+            anchors.bottom: tuning.visible ? tuning.top : (exploreButton.visible ? exploreButton.top : parent.bottom)
             anchors.bottomMargin: Theme.gap
-            visible: metrics.uiMessage.length > 0
+            // Suppressed while sweeping: every step draws an "Applied" message
+            // with a three-second life, so at this cadence it would never leave
+            // the screen and would read as a fault rather than as progress.
+            visible: !screen.sweeping && toastLabel.text.length > 0
             width: Math.min(parent.width, toastLabel.implicitWidth + 24)
             height: 30
             radius: Theme.radiusButton
@@ -303,67 +1026,214 @@ Item {
 
                 anchors.centerIn: parent
                 width: Math.min(parent.width - 24, implicitWidth)
-                text: metrics.uiMessage
+                // This screen's own answer wins: it is always the newer one, and
+                // the engine has nothing to say about an empty band.
+                text: screen.hint.length > 0 ? screen.hint : metrics.uiMessage
                 font.family: Theme.mono
                 font.pixelSize: 12
                 color: Theme.cyan
                 elide: Text.ElideRight
             }
         }
+    }
 
-        // A fingertip covers several channels, so the tap snaps to the strongest
-        // peak near it. The gate is an affordance only — the engine refuses the
-        // tune on its own if trunking took the tuner in the meantime.
+    // A hint is this screen talking, and it should not outlive the answer it was
+    // about. The engine's own messages carry their own expiry.
+    Timer {
+        interval: 4000
+        running: screen.hint.length > 0
+        onTriggered: screen.hint = ""
+    }
+
+    // ---- Go to ----
+    Rectangle {
+        id: goToSheet
+
+        objectName: "spectrumGoToSheet"
+
+        function open(hz) {
+            goToField.text = Util.mhzText(hz)
+            visible = true
+            goToField.forceActiveFocus()
+        }
+
+        function submit() {
+            var mhz = parseFloat(goToField.text)
+            if (isNaN(mhz) || !(mhz > 0))
+                return
+            goToSheet.visible = false
+            Qt.inputMethod.hide()
+            screen.stopSweep()
+            screen.tuneTo(mhz * 1.0e6)
+        }
+
+        anchors.fill: parent
+        visible: false
+        color: Qt.alpha("#000000", 0.5)
+
         TapHandler {
-            enabled: !screen.viewOnly && spectrum.hasData
-            onTapped: function (eventPoint) {
-                var hz = spectrum.tapFrequencyHz(eventPoint.position.x / body.width)
-                if (hz > 0)
-                    commands.manualTuneHz(Math.round(hz))
+            onTapped: {
+                goToSheet.visible = false
+                Qt.inputMethod.hide()
             }
         }
 
-        PinchHandler {
-            id: pinch
+        UiPanel {
+            anchors.centerIn: parent
+            width: parent.width - 2 * Theme.screenPadding
+            height: goToColumn.height + 2 * Theme.cardPadding
 
-            target: null
-            // Wider than the model's 1x-8x so the clamp lives in one place.
-            minimumScale: 0.1
-            maximumScale: 20.0
+            Column {
+                id: goToColumn
 
-            onActiveChanged: {
-                if (!active)
-                    return
-                screen.pinchStartZoom = spectrum.zoom
-                screen.pinchAnchorX = body.width > 0 ? (pinch.centroid.position.x / body.width) : 0.5
-            }
-            onActiveScaleChanged: {
-                if (pinch.active)
-                    screen.applyPinch(pinch.activeScale)
-            }
-        }
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.margins: Theme.cardPadding
+                spacing: 12
 
-        DragHandler {
-            id: pan
-
-            target: null
-            xAxis.enabled: true
-            yAxis.enabled: false
-
-            onActiveChanged: {
-                if (active) {
-                    screen.panStartOffsetHz = spectrum.viewOffsetHz
-                    return
+                MicroLabel {
+                    text: qsTr("Go to")
                 }
-                // Exactly one retune per gesture, on release. Retuning per drag
-                // frame would block the engine thread for up to 500 ms a time.
-                // A pinch stealing the grab deactivates this handler too, and
-                // that is not a release.
-                screen.endPan(pinch.active)
+
+                Row {
+                    spacing: 8
+
+                    TextInput {
+                        id: goToField
+
+                        objectName: "spectrumGoToField"
+                        width: Math.max(implicitWidth, 60)
+                        font.family: Theme.mono
+                        font.pixelSize: 30
+                        font.weight: Font.Medium
+                        color: Theme.textPrimary
+                        inputMethodHints: Qt.ImhFormattedNumbersOnly
+                        validator: RegularExpressionValidator {
+                            regularExpression: /^\d{1,5}(\.\d{0,6})?$/
+                        }
+                        selectionColor: Qt.alpha(Theme.cyan, 0.35)
+                        selectedTextColor: Theme.textPrimary
+                        onAccepted: goToSheet.submit()
+                    }
+
+                    Text {
+                        text: "MHz"
+                        anchors.baseline: goToField.baseline
+                        font.family: Theme.mono
+                        font.pixelSize: 15
+                        color: Theme.textSubdued
+                    }
+                }
+
+                Rectangle {
+                    width: parent.width
+                    height: 2
+                    color: Theme.cyan
+                }
+
+                // Typing a frequency and jumping to a band are the same intent at
+                // different precisions, so they share one panel.
+                Flow {
+                    width: parent.width
+                    spacing: 8
+
+                    Repeater {
+                        model: Util.BANDS
+
+                        FilterPill {
+                            required property var modelData
+
+                            objectName: "spectrumBand_" + modelData.label
+                            text: modelData.label
+                            caret: false
+                            active: screen.band ? screen.band.label === modelData.label : false
+                            onClicked: goToField.text = Util.mhzText(modelData.start)
+                        }
+                    }
+                }
+
+                OutlineButton {
+                    width: parent.width
+                    objectName: "spectrumGoToConfirm"
+                    text: qsTr("Tune")
+                    onClicked: goToSheet.submit()
+                }
             }
-            onActiveTranslationChanged: {
-                if (pan.active)
-                    screen.applyPan(pan.activeTranslation.x, body.width)
+        }
+    }
+
+    // ---- Radio settings ----
+    RadioSheet {
+        id: radioSheet
+    }
+
+    // ---- Explore from here, confirmed ----
+    Rectangle {
+        id: confirmExplore
+
+        objectName: "spectrumExploreConfirm"
+
+        anchors.fill: parent
+        visible: false
+        color: Qt.alpha("#000000", 0.5)
+
+        TapHandler {
+            onTapped: confirmExplore.visible = false
+        }
+
+        UiPanel {
+            anchors.centerIn: parent
+            width: parent.width - 2 * Theme.screenPadding
+            height: confirmColumn.height + 2 * Theme.cardPadding
+
+            Column {
+                id: confirmColumn
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.margins: Theme.cardPadding
+                spacing: 12
+
+                Text {
+                    width: parent.width
+                    text: qsTr("Explore from here?")
+                    font.family: Theme.sans
+                    font.pixelSize: 17
+                    font.weight: Font.Bold
+                    color: Theme.textPrimary
+                    wrapMode: Text.Wrap
+                }
+
+                // Names what stops, and — the part people actually worry about —
+                // what does not.
+                Text {
+                    width: parent.width
+                    text: metrics.scannerMode
+                          ? qsTr("This stops stepping through the channel list for now. The saved system itself is unchanged.")
+                          : qsTr("This stops following calls across channels for now. The saved system itself is unchanged.")
+                    font.family: Theme.sans
+                    font.pixelSize: 14
+                    color: Theme.textSecondary
+                    wrapMode: Text.Wrap
+                }
+
+                OutlineButton {
+                    objectName: "spectrumExploreConfirmAccept"
+                    width: parent.width
+                    text: qsTr("Explore from here")
+                    onClicked: {
+                        confirmExplore.visible = false
+                        screen.exploreFromHere()
+                    }
+                }
+
+                OutlineButton {
+                    width: parent.width
+                    text: qsTr("Cancel")
+                    onClicked: confirmExplore.visible = false
+                }
             }
         }
     }

--- a/src/ui/qt/qml/SpectrumScreen.qml
+++ b/src/ui/qt/qml/SpectrumScreen.qml
@@ -43,10 +43,11 @@ Item {
     readonly property real tunedHz: spectrum.hasData ? spectrum.centerFreqHz
                                                      : (metrics ? metrics.centerFreqHz : 0)
 
-    // What the big readout shows. While the rail is being dragged that is where
-    // it is heading, not where the receiver still is — it is the number being
-    // steered.
-    readonly property real readoutHz: bandRail.dragging ? bandRail.pendingHz : screen.tunedHz
+    // What the big readout shows. While the rail is being dragged, or waiting for
+    // a drag's retune to land, that is where it is heading, not where the
+    // receiver still is — it is the number being steered. The rail owns that
+    // preview; this just reads it, rather than restating the same expression.
+    readonly property real readoutHz: bandRail.displayHz
 
     // Where the tuner can be walked without leaving the part of the spectrum the
     // user is working in. Null off-band, in which case stepping is unbounded and
@@ -329,8 +330,9 @@ Item {
                     font.pixelSize: 21
                     font.weight: Font.Medium
                     // Cyan while it is a request rather than a fact, the same way
-                    // every other in-flight thing on this screen reads.
-                    color: bandRail.dragging ? Theme.cyan : Theme.textPrimary
+                    // every other in-flight thing on this screen reads — through
+                    // the retune settling, not just through the drag itself.
+                    color: (bandRail.dragging || bandRail.settling) ? Theme.cyan : Theme.textPrimary
                 }
 
                 // The readout doubles as the way to leave the neighbourhood

--- a/src/ui/qt/qml/SpectrumScreen.qml
+++ b/src/ui/qt/qml/SpectrumScreen.qml
@@ -617,6 +617,21 @@ Item {
                 hotColor: Theme.magenta
             }
 
+            // Above trace, axis and waterfall as one continuous column. Correct
+            // over waterfall history only because a retune clears it, so every
+            // visible row shares this frame's center — if that ever changes, so
+            // must this.
+            TunerMarker {
+                objectName: "spectrumTunerMarker"
+                anchors.fill: parent
+                visible: spectrum.hasData
+
+                tunedHz: screen.tunedHz
+                channelBwHz: metrics ? metrics.channelBandwidthHz : 0
+                viewLowHz: spectrum.viewLowHz
+                viewSpanHz: spectrum.viewSpanHz
+            }
+
             Text {
                 anchors.centerIn: waterfall
                 visible: !spectrum.hasData

--- a/src/ui/qt/qml/SpectrumScreen.qml
+++ b/src/ui/qt/qml/SpectrumScreen.qml
@@ -18,9 +18,10 @@ Item {
 
     signal closed()
 
-    // While the trunking controller owns the tuner the engine refuses manual
+    // While an automatic controller owns the tuner — trunking, or conventional
+    // scanner mode stepping the channel map — the engine refuses manual
     // retunes, so this is view-only rather than a control that does nothing.
-    readonly property bool viewOnly: metrics ? metrics.trunkingEnabled : false
+    readonly property bool viewOnly: metrics ? metrics.tunerControlled : false
     // The frame's own center is what the bins were measured at; the options
     // reading is only a fallback for the moment before the first frame lands.
     readonly property real tunedHz: spectrum.hasData ? spectrum.centerFreqHz
@@ -55,10 +56,24 @@ Item {
         spectrum.viewOffsetHz = screen.panStartOffsetHz - ((dx / width) * spectrum.viewSpanHz)
     }
 
-    /** Settle a finished pan: at most one retune, and only if it ran off the edge. */
-    function endPan() {
-        if (!screen.viewOnly && spectrum.edgeOvershootHz !== 0 && spectrum.hasData)
-            commands.manualTuneHz(Math.round(spectrum.centerFreqHz + spectrum.edgeOvershootHz))
+    /**
+     * Settle a finished pan: at most one retune, and only if it ran off the edge.
+     *
+     * @a cancelled marks a drag that ended for a reason other than the finger
+     * lifting — a pinch taking the grab. The few pixels of drift before the
+     * second finger landed are not a request to move the receiver, and at 1x
+     * every drift is overshoot, so acting on it would retune on the way into a
+     * zoom and drop the decode session.
+     *
+     * The retune target is where the viewport was asking to be, not merely how
+     * far past the edge it reached: the granted offset is already carrying the
+     * user toward one end of the span, and tuning to the overshoot alone would
+     * land short and snap the view backwards away from what they dragged to.
+     */
+    function endPan(cancelled) {
+        var wantHz = spectrum.centerFreqHz + spectrum.viewOffsetHz + spectrum.edgeOvershootHz
+        if (!cancelled && !screen.viewOnly && spectrum.edgeOvershootHz !== 0 && spectrum.hasData && wantHz > 0)
+            commands.manualTuneHz(Math.round(wantHz))
         spectrum.clearOvershoot()
     }
 
@@ -164,6 +179,10 @@ Item {
         anchors.rightMargin: Theme.screenPadding
         anchors.bottomMargin: Theme.screenPadding
 
+        // Most labels the axis will carry. Shared with the Repeater below so the
+        // delegate count and the request can never drift apart.
+        readonly property int maxTicks: 5
+
         // Recomputed whenever the window moves. axisTicks() is a call, not a
         // property, so the window edges are read here to make the dependency
         // explicit — without them the labels would freeze on the first frame.
@@ -172,7 +191,7 @@ Item {
             var high = spectrum.viewHighHz
             if (!spectrum.hasData || high <= low)
                 return []
-            return spectrum.axisTicks(5)
+            return spectrum.axisTicks(body.maxTicks)
         }
 
         SpectrumTrace {
@@ -207,16 +226,26 @@ Item {
                 color: Theme.panelBorder
             }
 
+            // A fixed count, not the tick list itself: binding a Repeater to a
+            // freshly built list destroys and recreates every label each time
+            // the viewport moves, which during a drag is fifteen times a
+            // second. The delegates stay put and only their bindings re-evaluate.
             Repeater {
-                model: body.ticks
+                model: body.maxTicks
 
                 MicroLabel {
+                    required property int index
+
+                    readonly property var tick: index < body.ticks.length ? body.ticks[index] : null
+
+                    visible: tick !== null
                     // Anchored by its center on the tick, then nudged so the end
                     // labels stay inside the panel instead of hanging off it.
-                    x: Math.round(Math.max(0, Math.min(axis.width - implicitWidth,
-                                                       (modelData.xFraction * axis.width) - (implicitWidth / 2))))
+                    x: tick ? Math.round(Math.max(0, Math.min(axis.width - implicitWidth,
+                                                              (tick.xFraction * axis.width) - (implicitWidth / 2))))
+                            : 0
                     y: Math.round((axis.height - implicitHeight) / 2)
-                    text: modelData.label
+                    text: tick ? tick.label : ""
                     font.capitalization: Font.MixedCase
                 }
             }
@@ -328,7 +357,9 @@ Item {
                 }
                 // Exactly one retune per gesture, on release. Retuning per drag
                 // frame would block the engine thread for up to 500 ms a time.
-                screen.endPan()
+                // A pinch stealing the grab deactivates this handler too, and
+                // that is not a release.
+                screen.endPan(pinch.active)
             }
             onActiveTranslationChanged: {
                 if (pan.active)

--- a/src/ui/qt/qml/SpectrumScreen.qml
+++ b/src/ui/qt/qml/SpectrumScreen.qml
@@ -997,6 +997,25 @@ Item {
                         screen.saveAsSystem(screen.tunedHz)
                     }
                 }
+
+                // The inverse of "Explore from here": hand the tuner to trunking
+                // and let it follow the system off this control channel. Inside
+                // `tuning`, so !viewOnly is already answered — what is left is
+                // whether there is anything here worth following. No confirm
+                // sheet, unlike the way out: this loses nothing that was not
+                // already the user's next tap, and the moment trunking takes the
+                // tuner the escape appears in its place.
+                OutlineButton {
+                    objectName: "spectrumFollowSystem"
+                    width: 200
+                    height: 40
+                    text: qsTr("Follow this system")
+                    visible: decoderHost.sessionActive && metrics && metrics.trunkableSync
+                    onClicked: {
+                        screen.stopSweep()
+                        commands.setTrunking(true)
+                    }
+                }
             }
         }
 

--- a/src/ui/qt/qml/SpectrumScreen.qml
+++ b/src/ui/qt/qml/SpectrumScreen.qml
@@ -124,9 +124,17 @@ Item {
         spectrum.clearOvershoot()
     }
 
-    /** Ask for @a hz, if this session is allowed to ask at all. */
+    /**
+     * Ask for @a hz, if this session is allowed to ask at all.
+     *
+     * The upper bound is not a tuner limit — the engine owns those and refuses
+     * with its own message. It is the point past which the number stops meaning
+     * itself: manualTuneHz takes a uint, and QML converts a JS number to one by
+     * ECMAScript ToUint32, so 5 GHz typed into "Go to" arrives as 705 MHz and
+     * retunes the receiver somewhere plausible that nobody asked for.
+     */
     function tuneTo(hz) {
-        if (screen.viewOnly || !(hz > 0))
+        if (screen.viewOnly || !(hz > 0) || !(hz < 4294967296))
             return false
         screen.hint = ""
         commands.manualTuneHz(Math.round(hz))
@@ -236,7 +244,13 @@ Item {
         // Long enough for the tuner to settle and the decoder to find sync, and
         // no shorter: each retune blocks the engine thread for up to half a
         // second, so a fast sweep spends its time stopping and starting.
-        interval: 2500
+        //
+        // It must also outlast metrics' sync hold (kSyncHoldSeconds, 3 s in
+        // metrics_model.cpp), which decays rather than clearing on a retune: a
+        // lock the decoder found just before the previous step still reads as
+        // locked for that long, and a shorter dwell stops the sweep on the
+        // frequency it has already moved to and reports that one as the find.
+        interval: 3500
         repeat: true
         running: screen.sweeping
         onTriggered: screen.sweepTick()
@@ -1040,9 +1054,20 @@ Item {
     // A hint is this screen talking, and it should not outlive the answer it was
     // about. The engine's own messages carry their own expiry.
     Timer {
+        id: hintTimer
+
         interval: 4000
         running: screen.hint.length > 0
         onTriggered: screen.hint = ""
+    }
+
+    // Restarted explicitly, because `running` does not change when one hint
+    // replaces another: without this the second hint inherits whatever is left
+    // of the first one's four seconds, and a "Wrapped to ..." followed by
+    // "Nothing else on this screen" flashes the second one for a moment.
+    onHintChanged: {
+        if (screen.hint.length > 0)
+            hintTimer.restart()
     }
 
     // ---- Go to ----
@@ -1067,18 +1092,32 @@ Item {
             screen.tuneTo(mhz * 1.0e6)
         }
 
+        /** Whether a point in this sheet's coordinates lies on the panel. */
+        function hitsPanel(x, y) {
+            var p = goToSheet.mapToItem(goToPanel, x, y)
+            return p.x >= 0 && p.y >= 0 && p.x <= goToPanel.width && p.y <= goToPanel.height
+        }
+
         anchors.fill: parent
         visible: false
         color: Qt.alpha("#000000", 0.5)
 
+        // Same rule as RadioSheet: handlers never take exclusive grabs, so an
+        // unconditional dismiss here also fires for every control on the panel —
+        // tapping a band pill set the field and closed the sheet in the same
+        // gesture, and tapping the field to place the cursor closed it outright.
         TapHandler {
-            onTapped: {
+            onTapped: function (eventPoint) {
+                if (goToSheet.hitsPanel(eventPoint.position.x, eventPoint.position.y))
+                    return
                 goToSheet.visible = false
                 Qt.inputMethod.hide()
             }
         }
 
         UiPanel {
+            id: goToPanel
+
             anchors.centerIn: parent
             width: parent.width - 2 * Theme.screenPadding
             height: goToColumn.height + 2 * Theme.cardPadding

--- a/src/ui/qt/qml/SpectrumScreen.qml
+++ b/src/ui/qt/qml/SpectrumScreen.qml
@@ -43,6 +43,11 @@ Item {
     readonly property real tunedHz: spectrum.hasData ? spectrum.centerFreqHz
                                                      : (metrics ? metrics.centerFreqHz : 0)
 
+    // What the big readout shows. While the rail is being dragged that is where
+    // it is heading, not where the receiver still is — it is the number being
+    // steered.
+    readonly property real readoutHz: bandRail.dragging ? bandRail.pendingHz : screen.tunedHz
+
     // Where the tuner can be walked without leaving the part of the spectrum the
     // user is working in. Null off-band, in which case stepping is unbounded and
     // the rail shows a local window instead.
@@ -319,11 +324,13 @@ Item {
                     objectName: "spectrumCenterReadout"
                     // Never elided: this is the frequency the radio is on, and a
                     // readout that drops a digit is worse than one that is tight.
-                    text: screen.tunedHz > 0 ? Util.fmtMhz(screen.tunedHz) : "—"
+                    text: screen.readoutHz > 0 ? Util.fmtMhz(screen.readoutHz) : "—"
                     font.family: Theme.mono
                     font.pixelSize: 21
                     font.weight: Font.Medium
-                    color: Theme.textPrimary
+                    // Cyan while it is a request rather than a fact, the same way
+                    // every other in-flight thing on this screen reads.
+                    color: bandRail.dragging ? Theme.cyan : Theme.textPrimary
                 }
 
                 // The readout doubles as the way to leave the neighbourhood
@@ -713,81 +720,22 @@ Item {
             spacing: 8
             visible: !screen.viewOnly
 
-            // Where in the band this screenful sits. A readout, not a control:
-            // band-walking loses your place within a few steps, and during a
-            // sweep this is the part that shows it working.
-            Item {
-                id: rail
+            // Where in the neighbourhood this screenful sits, and the way to move
+            // it. A readout until now, which is why it invited a drag it did not
+            // take.
+            BandRail {
+                id: bandRail
 
+                objectName: "spectrumBandRail"
                 width: parent.width
-                height: 16
                 visible: screen.tunedHz > 0
 
-                // Off-band, a local window rather than the whole tuner range: a
-                // marker that moves by a hair across 24-1766 MHz says nothing.
-                readonly property real lowHz: screen.band ? screen.band.low : screen.tunedHz - 10.0e6
-                readonly property real highHz: screen.band ? screen.band.high : screen.tunedHz + 10.0e6
-
-                Text {
-                    id: railLow
-
-                    anchors.left: parent.left
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: Math.round(rail.lowHz / 1.0e6)
-                    font.family: Theme.mono
-                    font.pixelSize: 10
-                    color: Theme.textSubdued
+                tunedHz: screen.tunedHz
+                onDraggingChanged: {
+                    if (dragging)
+                        screen.stopSweep()
                 }
-
-                Text {
-                    id: railHigh
-
-                    anchors.right: parent.right
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: Math.round(rail.highHz / 1.0e6)
-                    font.family: Theme.mono
-                    font.pixelSize: 10
-                    color: Theme.textSubdued
-                }
-
-                Item {
-                    id: railTrack
-
-                    anchors.left: railLow.right
-                    anchors.right: railHigh.left
-                    anchors.leftMargin: 8
-                    anchors.rightMargin: 8
-                    anchors.verticalCenter: parent.verticalCenter
-                    height: parent.height
-
-                    Rectangle {
-                        anchors.left: parent.left
-                        anchors.right: parent.right
-                        anchors.verticalCenter: parent.verticalCenter
-                        height: 1
-                        color: Theme.divider
-                    }
-
-                    Rectangle {
-                        objectName: "spectrumBandMarker"
-                        width: 3
-                        height: 11
-                        radius: 1.5
-                        anchors.verticalCenter: parent.verticalCenter
-                        x: {
-                            var span = rail.highHz - rail.lowHz
-                            if (!(span > 0))
-                                return 0
-                            var t = (screen.tunedHz - rail.lowHz) / span
-                            return Math.round(Math.max(0, Math.min(1, t)) * (railTrack.width - width))
-                        }
-                        color: Theme.cyan
-
-                        Behavior on x {
-                            NumberAnimation { duration: 180; easing.type: Easing.OutCubic }
-                        }
-                    }
-                }
+                onTuneRequested: function (hz) { screen.tuneTo(hz) }
             }
 
             Flow {

--- a/src/ui/qt/qml/SpectrumScreen.qml
+++ b/src/ui/qt/qml/SpectrumScreen.qml
@@ -271,6 +271,13 @@ Item {
         anchors.right: parent.right
         anchors.margins: Theme.screenPadding
         height: 48
+        // Same shield the picture carries, for the same reason: the sheets are
+        // siblings anchored over the whole screen, so their scrim covers this
+        // strip too, and a TapHandler never takes an exclusive grab. Without
+        // this, dismissing a sheet by tapping the scrim over the header also
+        // fires the back caret underneath and closes the whole view — or
+        // re-opens the Go-to sheet and overwrites what was typed into it.
+        enabled: !screen.sheetOpen
 
         Item {
             id: backButton
@@ -1217,11 +1224,24 @@ Item {
         visible: false
         color: Qt.alpha("#000000", 0.5)
 
+        /** Whether a point in this sheet's coordinates lies on the panel. */
+        function hitsPanel(x, y) {
+            var p = confirmExplore.mapToItem(confirmPanel, x, y)
+            return p.x >= 0 && p.y >= 0 && p.x <= confirmPanel.width && p.y <= confirmPanel.height
+        }
+
+        // Same rule as the other two sheets: handlers never take exclusive grabs, so
+        // an unconditional dismiss here fires for every control on the panel as well.
         TapHandler {
-            onTapped: confirmExplore.visible = false
+            onTapped: function (eventPoint) {
+                if (!confirmExplore.hitsPanel(eventPoint.position.x, eventPoint.position.y))
+                    confirmExplore.visible = false
+            }
         }
 
         UiPanel {
+            id: confirmPanel
+
             anchors.centerIn: parent
             width: parent.width - 2 * Theme.screenPadding
             height: confirmColumn.height + 2 * Theme.cardPadding

--- a/src/ui/qt/qml/SpectrumScreen.qml
+++ b/src/ui/qt/qml/SpectrumScreen.qml
@@ -126,8 +126,12 @@ Item {
      */
     function endPan(cancelled) {
         var wantHz = spectrum.centerFreqHz + spectrum.viewOffsetHz + spectrum.edgeOvershootHz
-        if (!cancelled && !screen.viewOnly && spectrum.edgeOvershootHz !== 0 && spectrum.hasData && wantHz > 0)
-            commands.manualTuneHz(Math.round(wantHz))
+        // Through tuneTo() like every other retune on this screen, rather than
+        // straight to the command: it owns the view-only gate, the uint32 bound
+        // its own comment explains, and the stale-hint clear — and a pan is the
+        // one path that had its own half of those written out again.
+        if (!cancelled && spectrum.edgeOvershootHz !== 0 && spectrum.hasData)
+            screen.tuneTo(wantHz)
         spectrum.clearOvershoot()
     }
 
@@ -738,7 +742,15 @@ Item {
                     if (dragging)
                         screen.stopSweep()
                 }
-                onTuneRequested: function (hz) { screen.tuneTo(hz) }
+                // A refused tune has nothing to settle on: the rail holds its
+                // preview until the receiver lands on what it asked for, and
+                // tuneTo() turns the request down outright when something else
+                // owns the tuner — so the header would read a frequency nobody is
+                // on until the rail's own timeout gave up on it.
+                onTuneRequested: function (hz) {
+                    if (!screen.tuneTo(hz))
+                        bandRail.cancelSettle()
+                }
             }
 
             Flow {

--- a/src/ui/qt/qml/TunerMarker.qml
+++ b/src/ui/qt/qml/TunerMarker.qml
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+
+// Where the receiver is, and how much of the band it is actually listening to.
+//
+// Neutral rather than cyan or magenta: the waterfall ramp runs background ->
+// cyan -> magenta, so both accents already mean signal down there, and a
+// coloured marker would read as a strong carrier. Value and form carry it
+// instead — the highest-contrast token in either theme, in a shape no data
+// element has.
+//
+// The cap is a flat square tick on purpose. Anything rounded or raised at the
+// top of a vertical line reads as a grab handle, and this does not move: the way
+// to retune is to tap the spectrum. The band rail's round knob is the thing you
+// drag, and the contrast between the two shapes is doing real work.
+Item {
+    id: marker
+
+    property real tunedHz: 0
+    property real channelBwHz: 0
+    property real viewLowHz: 0
+    property real viewSpanHz: 0
+
+    // Same mapping the trace and the axis labels use (SpectrumTraceItem::paint,
+    // SpectrumModel::axisTicks). Anything else puts the marker off the carrier
+    // it is naming.
+    readonly property real xFraction: viewSpanHz > 0 ? (tunedHz - viewLowHz) / viewSpanHz : -1
+    readonly property real bandWidthFraction: (viewSpanHz > 0 && channelBwHz > 0)
+                                              ? channelBwHz / viewSpanHz : 0
+    readonly property bool onScreen: xFraction >= 0 && xFraction <= 1
+
+    // No handlers anywhere in here: taps, pinches and drags belong to the
+    // gesture area underneath, and an Item that accepted them would make the
+    // spectrum untappable exactly where the receiver is.
+
+    Rectangle {
+        objectName: "spectrumTunerColumn"
+        visible: marker.onScreen && marker.bandWidthFraction > 0
+        // Lit on a dark ground, shaded on a light one. A fixed white wash is
+        // invisible over the light theme's waterfall.
+        color: Qt.alpha(Theme.textPrimary, Theme.dark ? 0.10 : 0.07)
+        y: 0
+        height: parent.height
+        width: Math.max(2, Math.round(marker.bandWidthFraction * parent.width))
+        x: Math.round((marker.xFraction * parent.width) - (width / 2))
+    }
+
+    Rectangle {
+        id: hairline
+
+        visible: marker.onScreen
+        color: Theme.textPrimary
+        width: 1
+        y: 0
+        height: parent.height
+        x: Math.round(marker.xFraction * parent.width)
+    }
+
+    Rectangle {
+        objectName: "spectrumTunerTick"
+        visible: marker.onScreen
+        color: Theme.textPrimary
+        width: 9
+        height: 3
+        y: 0
+        x: Math.round((marker.xFraction * parent.width) - (width / 2))
+    }
+
+    // Off screen the marker is not drawn at all — clamping it to the edge would
+    // sit it on a carrier it is not tuned to. This says which way it went.
+    Caret {
+        objectName: "spectrumTunerEdgeHint"
+        visible: !marker.onScreen && marker.viewSpanHz > 0
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.left: marker.xFraction < 0 ? parent.left : undefined
+        anchors.right: marker.xFraction > 1 ? parent.right : undefined
+        anchors.margins: 2
+        rotation: marker.xFraction < 0 ? 90 : -90
+        color: Theme.textPrimary
+    }
+}

--- a/src/ui/qt/qml/TunerMarker.qml
+++ b/src/ui/qt/qml/TunerMarker.qml
@@ -31,6 +31,15 @@ Item {
                                               ? channelBwHz / viewSpanHz : 0
     readonly property bool onScreen: xFraction >= 0 && xFraction <= 1
 
+    // The one pixel column, hairline and tick are all centred on, so the three
+    // cannot drift apart from each other by a rounding of their own.
+    readonly property real centerX: Math.round(xFraction * width)
+
+    // The picture's own edge, not the marker's: at high zoom near a view edge
+    // the column's outer half would otherwise spill past it into the screen
+    // padding this Item is not clipped by anywhere else.
+    clip: true
+
     // No handlers anywhere in here: taps, pinches and drags belong to the
     // gesture area underneath, and an Item that accepted them would make the
     // spectrum untappable exactly where the receiver is.
@@ -44,18 +53,19 @@ Item {
         y: 0
         height: parent.height
         width: Math.max(2, Math.round(marker.bandWidthFraction * parent.width))
-        x: Math.round((marker.xFraction * parent.width) - (width / 2))
+        x: marker.centerX - (width / 2)
     }
 
     Rectangle {
         id: hairline
 
+        objectName: "spectrumTunerHairline"
         visible: marker.onScreen
         color: Theme.textPrimary
         width: 1
         y: 0
         height: parent.height
-        x: Math.round(marker.xFraction * parent.width)
+        x: marker.centerX - (width / 2)
     }
 
     Rectangle {
@@ -65,7 +75,7 @@ Item {
         width: 9
         height: 3
         y: 0
-        x: Math.round((marker.xFraction * parent.width) - (width / 2))
+        x: marker.centerX - (width / 2)
     }
 
     // Off screen the marker is not drawn at all — clamping it to the edge would

--- a/src/ui/qt/qml/Util.js
+++ b/src/ui/qt/qml/Util.js
@@ -60,6 +60,51 @@ var LEGACY_DECODE_LABELS = {
     "-f1": "P25"
 }
 
+// Where digital voice actually lives, for someone exploring who does not yet know
+// a single local frequency. The same US-centric assumption the decode chips make
+// ("most statewide and county digital systems"); anyone elsewhere types a
+// frequency instead, which is why the catalog is a convenience and not the only
+// way to move.
+//
+// `start` is where a chip drops you: a busy part of the band rather than its
+// bottom edge, so the first screen of waterfall usually has something on it.
+// `low`/`high` also bound the sweep — it wraps inside the band it began in rather
+// than walking off into spectrum nobody asked about.
+var BANDS = [
+    { label: "VHF", low: 136.0e6, high: 174.0e6, start: 154.0e6 },
+    { label: "UHF", low: 380.0e6, high: 470.0e6, start: 453.0e6 },
+    { label: "700", low: 763.0e6, high: 806.0e6, start: 770.0e6 },
+    { label: "800", low: 806.0e6, high: 869.0e6, start: 855.0e6 }
+]
+
+// The band containing hz, or null when tuned outside all of them. Callers fall
+// back to a local window: a rail spanning everything a tuner can reach would move
+// its marker by a hair across a whole band, which tells the reader nothing.
+function bandFor(hz) {
+    for (var i = 0; i < BANDS.length; i++) {
+        if (hz >= BANDS[i].low && hz < BANDS[i].high)
+            return BANDS[i]
+    }
+    return null
+}
+
+// The MHz text for a frequency, without a unit: "769.76875", "851.0125".
+//
+// Five decimals, not four. 12.5 kHz and 6.25 kHz channel plans put real
+// frequencies on the fifth decimal — 769.76875 is a control channel someone is
+// listening to — and four would render it as 769.7687, a frequency the radio is
+// not on. The trailing zero is dropped so the commoner 4-decimal channels do not
+// carry a digit that means nothing.
+function mhzText(hz) {
+    var s = (hz / 1.0e6).toFixed(5)
+    return s.charAt(s.length - 1) === "0" ? s.substring(0, s.length - 1) : s
+}
+
+// The same number with its unit: "769.76875 MHz".
+function fmtMhz(hz) {
+    return mhzText(hz) + " MHz"
+}
+
 function decodeLabel(flag) {
     for (var i = 0; i < DECODE_MODES.length; i++) {
         if (DECODE_MODES[i].flag === flag)

--- a/src/ui/qt/qml/Util.js
+++ b/src/ui/qt/qml/Util.js
@@ -86,9 +86,10 @@ var BANDS = [
 var TUNER_LOW_HZ = 24.0e6
 var TUNER_HIGH_HZ = 1766.0e6
 
-// The band containing hz, or null when tuned outside all of them. Callers fall
-// back to a local window: a rail spanning everything a tuner can reach would move
-// its marker by a hair across a whole band, which tells the reader nothing.
+// The band containing hz, or null when tuned outside all of them. nextStepHz()
+// is the only caller that treats a null result as a fallback, and what it falls
+// back to is unbounded stepping — off-band there is no window to wrap a step
+// against, so it simply keeps going.
 function bandFor(hz) {
     for (var i = 0; i < BANDS.length; i++) {
         if (hz >= BANDS[i].low && hz < BANDS[i].high)

--- a/src/ui/qt/qml/Util.js
+++ b/src/ui/qt/qml/Util.js
@@ -77,6 +77,15 @@ var BANDS = [
     { label: "800", low: 806.0e6, high: 869.0e6, start: 855.0e6 }
 ]
 
+// The tuner's usable range. R820T/R828D — the tuner in essentially every RTL
+// dongle — covers 24-1766 MHz, and RTL over USB or TCP is the only radio this
+// app builds with: both Android presets set DSD_ENABLE_SOAPYSDR=OFF
+// (CMakePresets.json:215,242). Not a hard contract even so — the engine is the
+// authority and refuses an out-of-range tune with its own message. This only
+// stops the rail offering frequencies nothing can reach.
+var TUNER_LOW_HZ = 24.0e6
+var TUNER_HIGH_HZ = 1766.0e6
+
 // The band containing hz, or null when tuned outside all of them. Callers fall
 // back to a local window: a rail spanning everything a tuner can reach would move
 // its marker by a hair across a whole band, which tells the reader nothing.

--- a/src/ui/qt/qml/WizardScreen.qml
+++ b/src/ui/qt/qml/WizardScreen.qml
@@ -449,42 +449,11 @@ Item {
                             color: Theme.textSecondary
                         }
 
-                        Row {
-                            spacing: 8
+                        FrequencyField {
+                            id: freqField
 
-                            TextInput {
-                                id: freqField
-
-                                width: Math.max(implicitWidth, 60)
-                                text: "851.375"
-                                font.family: Theme.mono
-                                font.pixelSize: 32
-                                font.weight: Font.Medium
-                                color: Theme.textPrimary
-                                inputMethodHints: Qt.ImhFormattedNumbersOnly
-                                // The hint only picks the soft keyboard; a hardware
-                                // keyboard types anything. The validator is what keeps
-                                // "851.375M" out of the saved system.
-                                validator: RegularExpressionValidator {
-                                    regularExpression: /^\d{1,5}(\.\d{0,6})?$/
-                                }
-                                selectionColor: Qt.alpha(Theme.cyan, 0.35)
-                                selectedTextColor: Theme.textPrimary
-                            }
-
-                            Text {
-                                text: "MHz"
-                                anchors.baseline: freqField.baseline
-                                font.family: Theme.mono
-                                font.pixelSize: 15
-                                color: Theme.textSubdued
-                            }
-                        }
-
-                        Rectangle {
                             width: parent.width
-                            height: 2
-                            color: Theme.cyan
+                            text: "851.375"
                         }
 
                         Text {

--- a/src/ui/qt/qml/WizardScreen.qml
+++ b/src/ui/qt/qml/WizardScreen.qml
@@ -82,6 +82,34 @@ Item {
         nameField.text = ""
     }
 
+    /**
+     * Open on something found while exploring, with the source and frequency
+     * already answered.
+     *
+     * Opens at step 2 rather than step 3: the source is settled, but what to
+     * decode and whether to follow calls are real questions about the system just
+     * found, and answering them for the user would produce a card that does not
+     * work. @a sys supplies the source; it is the explore session's own map.
+     */
+    function openForFound(sys, freqMhz) {
+        editRow = -1
+        step = 1
+        sourceType = (sys && sys.sourceType === "rtltcp") ? "rtltcp" : "usb"
+        hostField.text = sys && sys.host ? sys.host : defaultHostFor(sourceType)
+        portField.text = sys && sys.port > 0 ? String(sys.port) : defaultPortFor(sourceType)
+        fileField.text = ""
+        freqField.text = freqMhz
+        decodeFlag = ""
+        trunking = true
+        advancedOpen = false
+        gainField.text = ""
+        ppmField.text = ""
+        bwField.text = ""
+        biasTee = -1
+        extraField.text = ""
+        nameField.text = ""
+    }
+
     function openForEdit(row) {
         var sys = savedSystems.get(row)
         editRow = row

--- a/src/ui/qt/qt_ui.cpp
+++ b/src/ui/qt/qt_ui.cpp
@@ -16,6 +16,7 @@
 #include <QStringList>
 #include <QUrl>
 #include <dsd-neo/runtime/git_ver.h>
+#include <qqml.h>
 
 #include "app_prefs.h"
 #include "call_history_filter.h"
@@ -25,6 +26,8 @@
 #include "metrics_model.h"
 #include "saved_systems_model.h"
 #include "session_args.h"
+#include "spectrum_model.h"
+#include "spectrum_view_item.h"
 #include "ui_controller.h"
 
 namespace dsd_qt {
@@ -74,6 +77,7 @@ ui_load(QQmlApplicationEngine& engine, DecoderHost* host) {
     auto* sessionArgs = new SessionArgsBuilder(prefs, &engine);
     auto* systems = new SavedSystemsModel(&engine);
     auto* history = new CallHistoryModel(&engine);
+    auto* spectrum = new SpectrumModel(&engine);
     // Each view that shows the call log owns its filter state: the history tab's
     // search and pills must not silently filter the monitor's recent-calls pane.
     auto* historyView = new CallHistoryFilterModel(&engine);
@@ -89,6 +93,12 @@ ui_load(QQmlApplicationEngine& engine, DecoderHost* host) {
     QObject::connect(prefs, &AppPrefs::keepScreenAwakeChanged, host,
                      [host, prefs]() { host->setKeepScreenAwake(prefs->keepScreenAwake()); });
 
+    /* The trace and waterfall are the only C++ types QML instantiates itself;
+     * everything else it sees is a context property below. They have to be
+     * registered before the engine loads any QML that imports them. */
+    qmlRegisterType<SpectrumTraceItem>("DsdNeo", 1, 0, "SpectrumTrace");
+    qmlRegisterType<WaterfallItem>("DsdNeo", 1, 0, "Waterfall");
+
     QQmlContext* context = engine.rootContext();
     context->setContextProperty(QStringLiteral("decoderHost"), host);
     context->setContextProperty(QStringLiteral("metrics"), metrics);
@@ -100,6 +110,7 @@ ui_load(QQmlApplicationEngine& engine, DecoderHost* host) {
     context->setContextProperty(QStringLiteral("callHistory"), history);
     context->setContextProperty(QStringLiteral("historyView"), historyView);
     context->setContextProperty(QStringLiteral("monitorView"), monitorView);
+    context->setContextProperty(QStringLiteral("spectrum"), spectrum);
     context->setContextProperty(QStringLiteral("sansFontFamily"),
                                 sans_family.isEmpty() ? QStringLiteral("sans-serif") : sans_family);
     context->setContextProperty(QStringLiteral("monoFontFamily"),

--- a/src/ui/qt/spectrum_math.h
+++ b/src/ui/qt/spectrum_math.h
@@ -203,6 +203,93 @@ peak_search_bin(const float* db, int n, int center_bin, int half_width_bins, int
 }
 
 /**
+ * @brief Mean level of a frame — the same floor estimate AutoRange builds on.
+ *
+ * The mean, not the minimum: a spectrum's minimum bin is a noise trough tens of
+ * dB below where the noise actually sits, so a threshold measured from it would
+ * call everything a signal.
+ */
+inline double
+frame_mean_db(const float* db, int n) {
+    double sum = 0.0;
+    for (int i = 0; i < n; i++) {
+        sum += static_cast<double>(db[i]);
+    }
+    return sum / static_cast<double>(n);
+}
+
+/** @brief An inclusive bin range; empty when @c hi is below @c lo. */
+struct BinRange {
+    int lo;
+    int hi;
+};
+
+/**
+ * @brief Where to look for the next signal in @p direction, within the bounds.
+ *
+ * Searching upward starts @p gap_bins above @p from_bin and runs to the top of
+ * the window; downward is the mirror. The gap is what keeps the answer from
+ * being the carrier already tuned, which is invariably the strongest bin around.
+ */
+inline BinRange
+directional_range(int from_bin, int direction, int gap_bins, int bound_lo, int bound_hi) {
+    BinRange range = {bound_lo, bound_hi};
+    if (direction >= 0) {
+        const int start = from_bin + gap_bins;
+        range.lo = (start > bound_lo) ? start : bound_lo;
+    } else {
+        const int end = from_bin - gap_bins;
+        range.hi = (end < bound_hi) ? end : bound_hi;
+    }
+    return range;
+}
+
+/**
+ * @brief Strongest bin beyond @p from_bin in @p direction that stands above the noise.
+ *
+ * The control this backs is "take me to the next signal", so it answers with a bin
+ * or with nothing — never with a fallback. Returning @p from_bin when the band is
+ * empty would make the button retune the radio to where it already is, which reads
+ * as a broken control rather than as an empty band.
+ *
+ * @param direction     +1 searches upward in frequency, -1 downward.
+ * @param min_gap_bins  How far past @p from_bin the search starts. Immediately after
+ *                      tuning to a carrier, that carrier is the strongest bin there
+ *                      is; without a gap, "next" answers with the signal already
+ *                      being listened to.
+ * @param min_excess_db How far above the frame's mean level a bin must sit to count
+ *                      as a signal. The mean is the same floor estimate AutoRange
+ *                      uses, and without a threshold this walks one bin at a time
+ *                      across flat noise.
+ * @param bound_lo,bound_hi Inclusive bin range the answer must lie in, as with
+ *        peak_search_bin(): the answer has to be something the user can see.
+ * @return The bin, or -1 when nothing in range qualifies.
+ */
+inline int
+directional_peak_bin(const float* db, int n, int from_bin, int direction, int min_gap_bins, double min_excess_db,
+                     int bound_lo, int bound_hi) {
+    if (!db || n <= 0) {
+        return -1;
+    }
+    const int lo_bound = (bound_lo < 0) ? 0 : bound_lo;
+    const int hi_bound = (bound_hi > n - 1) ? n - 1 : bound_hi;
+    if (hi_bound < lo_bound) {
+        return -1;
+    }
+    const int gap = (min_gap_bins < 0) ? 0 : min_gap_bins;
+    const BinRange range = directional_range(from_bin, direction, gap, lo_bound, hi_bound);
+    const double threshold = frame_mean_db(db, n) + min_excess_db;
+
+    int best = -1;
+    for (int i = range.lo; i <= range.hi; i++) {
+        if (static_cast<double>(db[i]) >= threshold && (best < 0 || db[i] > db[best])) {
+            best = i;
+        }
+    }
+    return best;
+}
+
+/**
  * @brief Offset that holds the frequency under @p x_fraction still across a zoom.
  *
  * A pinch that moves the signal out from under the fingers reads as broken, so

--- a/src/ui/qt/spectrum_math.h
+++ b/src/ui/qt/spectrum_math.h
@@ -245,6 +245,25 @@ directional_range(int from_bin, int direction, int gap_bins, int bound_lo, int b
 }
 
 /**
+ * @brief Where a directional search should start, given what is on screen.
+ *
+ * The tuned carrier is the natural reference, and @c directional_peak_bin()'s gap
+ * exists to step past it. But the viewport pans independently of the tuner, and
+ * past 2x it can be moved until the tuned bin is not within @p bound_lo ..
+ * @p bound_hi at all. A seed outside its own bounds leaves one of the two
+ * directions with an empty range — a control that reports an empty band while
+ * carriers sit on screen. There is nothing to step past once the tuned carrier is
+ * off screen, so the middle of what is on screen becomes the reference instead.
+ */
+inline int
+directional_seed_bin(int from_bin, int bound_lo, int bound_hi) {
+    if (from_bin >= bound_lo && from_bin <= bound_hi) {
+        return from_bin;
+    }
+    return bound_lo + ((bound_hi - bound_lo) / 2);
+}
+
+/**
  * @brief Strongest bin beyond @p from_bin in @p direction that stands above the noise.
  *
  * The control this backs is "take me to the next signal", so it answers with a bin

--- a/src/ui/qt/spectrum_math.h
+++ b/src/ui/qt/spectrum_math.h
@@ -211,6 +211,13 @@ peak_search_bin(const float* db, int n, int center_bin, int half_width_bins, int
  */
 inline double
 frame_mean_db(const float* db, int n) {
+    /* Guarded like every other entry point here: an empty frame would otherwise
+     * divide by zero, and the NaN that produces makes every `>=` against it false
+     * — so directional_peak_bin() would answer "nothing on this screen" for a
+     * band full of carriers rather than failing where it could be seen. */
+    if (!db || n <= 0) {
+        return 0.0;
+    }
     double sum = 0.0;
     for (int i = 0; i < n; i++) {
         sum += static_cast<double>(db[i]);
@@ -403,7 +410,16 @@ struct AutoRange {
         }
         const double want_min = (sum / static_cast<double>(n)) - 6.0;
         const double want_max = peak + 3.0;
-        if (!seeded) {
+        /* A frame carrying an infinity or a NaN says nothing about where the band
+         * sits, and folding one in is not recoverable: the relaxation below turns
+         * `-inf + inf` into a NaN that every later frame then relaxes towards
+         * itself, so the range stays NaN for the rest of the session and
+         * normalize() answers 0 for every bin — a flat trace over a cold
+         * waterfall, with a live signal on the air. */
+        if (!std::isfinite(want_min) || !std::isfinite(want_max)) {
+            return;
+        }
+        if (!seeded || !std::isfinite(min_db) || !std::isfinite(max_db)) {
             min_db = want_min;
             max_db = want_max;
             seeded = true;
@@ -418,7 +434,9 @@ struct AutoRange {
     double
     span_db() const {
         const double span = max_db - min_db;
-        return (span < 20.0) ? 20.0 : span;
+        /* Negated so a NaN span takes the floor as well: `span < 20.0` is false
+         * for NaN, which would hand a NaN divisor to normalize(). */
+        return !(span >= 20.0) ? 20.0 : span;
     }
 
     /** @brief Where @p db sits in the range, clamped to [0, 1]. */

--- a/src/ui/qt/spectrum_math.h
+++ b/src/ui/qt/spectrum_math.h
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Frequency/bin/viewport arithmetic for the spectrum view.
+ *
+ * Deliberately Qt-free and header-only so the parts that are easy to get
+ * subtly wrong — which bin a tap lands on, where a clamped pan window sits,
+ * whether a pinch keeps the frequency under the fingers still — are testable
+ * without a window, a scene graph, or a running decoder.
+ *
+ * Bin convention matches what the io layer actually publishes: bins are
+ * fftshifted, so bin i of n sits at `center + (i - n/2) * span/n`. Bin n/2 is
+ * DC, i.e. exactly the tuned center. (A tempting alternative is to treat the n
+ * bins as tiles and put bin centers at `(i + 0.5) * span/n`; that is off by
+ * half a bin — 750 Hz at n=1024 over 1.536 MHz — and would bias every
+ * tap-to-tune by that much.)
+ */
+
+#ifndef DSD_NEO_SRC_UI_QT_SPECTRUM_MATH_H_
+#define DSD_NEO_SRC_UI_QT_SPECTRUM_MATH_H_
+
+#include <cmath>
+
+namespace dsd_qt {
+namespace spectrum_math {
+
+/** @brief Lowest and highest zoom the view allows. */
+constexpr double kMinZoom = 1.0;
+constexpr double kMaxZoom = 8.0;
+
+/** @brief Tap snap half-width bounds, in Hz. */
+constexpr double kMinSnapHz = 6000.0;
+constexpr double kMaxSnapHz = 25000.0;
+
+/** @brief Clamp a requested zoom into the supported range. */
+inline double
+clamp_zoom(double zoom) {
+    if (!(zoom > kMinZoom)) { // also catches NaN
+        return kMinZoom;
+    }
+    return (zoom > kMaxZoom) ? kMaxZoom : zoom;
+}
+
+/** @brief Center frequency of bin @p i, in Hz. */
+inline double
+bin_to_freq_hz(double center, double span, int n, int i) {
+    if (n <= 0) {
+        return center;
+    }
+    return center + ((static_cast<double>(i) - (static_cast<double>(n) / 2.0)) * span / static_cast<double>(n));
+}
+
+/** @brief Bin nearest frequency @p f, clamped to [0, n-1]. */
+inline int
+freq_to_bin(double center, double span, int n, double f) {
+    if (n <= 0) {
+        return 0;
+    }
+    if (!(span > 0.0)) {
+        return n / 2;
+    }
+    const double low = center - (span / 2.0);
+    const double raw = std::floor((((f - low) / span) * static_cast<double>(n)) + 0.5);
+    if (!(raw > 0.0)) {
+        return 0;
+    }
+    if (raw > static_cast<double>(n - 1)) {
+        return n - 1;
+    }
+    return static_cast<int>(raw);
+}
+
+/** @brief The visible slice of the capture span. */
+struct ViewWindow {
+    double low_hz = 0.0;
+    double high_hz = 0.0;
+    double span_hz = 0.0;
+};
+
+/**
+ * @brief The window a zoom/pan pair actually shows, kept inside the capture span.
+ *
+ * The requested window is centered on `center + offset_hz` and `span/zoom`
+ * wide. Panning past an edge is not an error — it is how the user asks for a
+ * frequency the hardware is not covering — so the window clamps and the excess
+ * is reported through @p overshoot_hz for the caller to turn into a retune.
+ *
+ * @param overshoot_hz [out] Optional; requested offset minus granted offset,
+ *                     signed, 0 while the window fits.
+ */
+inline ViewWindow
+view_window(double center, double span, double zoom, double offset_hz, double* overshoot_hz) {
+    if (overshoot_hz) {
+        *overshoot_hz = 0.0;
+    }
+    ViewWindow win;
+    if (!(span > 0.0)) {
+        win.low_hz = center;
+        win.high_hz = center;
+        win.span_hz = 0.0;
+        return win;
+    }
+
+    const double view_span = span / clamp_zoom(zoom);
+    const double half = view_span / 2.0;
+    const double min_center = (center - (span / 2.0)) + half;
+    const double max_center = (center + (span / 2.0)) - half;
+
+    double view_center = center + offset_hz;
+    if (min_center >= max_center) {
+        view_center = center; /* fully zoomed out: there is nowhere to pan */
+    } else if (view_center < min_center) {
+        view_center = min_center;
+    } else if (view_center > max_center) {
+        view_center = max_center;
+    }
+
+    if (overshoot_hz) {
+        *overshoot_hz = (center + offset_hz) - view_center;
+    }
+    win.low_hz = view_center - half;
+    win.high_hz = view_center + half;
+    win.span_hz = view_span;
+    return win;
+}
+
+/**
+ * @brief How far either side of a tap to look for the real peak, in Hz.
+ *
+ * Scales with the zoom so a tap means the same thing on screen at every zoom
+ * level, and is capped so a fully zoomed-out tap cannot drag the receiver two
+ * channels away from where the finger landed.
+ */
+inline double
+snap_window_hz(double view_span_hz) {
+    const double raw = view_span_hz / 20.0;
+    if (!(raw > kMinSnapHz)) {
+        return kMinSnapHz;
+    }
+    return (raw > kMaxSnapHz) ? kMaxSnapHz : raw;
+}
+
+/**
+ * @brief Strongest bin within +/-@p half_width_bins of @p center_bin, bounds-clamped.
+ *
+ * The search starts at @p center_bin and only leaves it for a strictly stronger
+ * bin, which is what makes it a snap rather than a magnet: over flat noise
+ * every candidate ties, and a search seeded at the window edge would answer
+ * with that edge — pulling a deliberate tap on a quiet channel tens of kHz away
+ * every time.
+ */
+inline int
+peak_search_bin(const float* db, int n, int center_bin, int half_width_bins) {
+    if (!db || n <= 0) {
+        return 0;
+    }
+    if (center_bin < 0) {
+        center_bin = 0;
+    }
+    if (center_bin > n - 1) {
+        center_bin = n - 1;
+    }
+    if (half_width_bins < 0) {
+        half_width_bins = 0;
+    }
+    int lo = center_bin - half_width_bins;
+    int hi = center_bin + half_width_bins;
+    if (lo < 0) {
+        lo = 0;
+    }
+    if (hi > n - 1) {
+        hi = n - 1;
+    }
+    int best = center_bin;
+    for (int i = lo; i <= hi; i++) {
+        if (db[i] > db[best]) {
+            best = i;
+        }
+    }
+    return best;
+}
+
+/**
+ * @brief Offset that holds the frequency under @p x_fraction still across a zoom.
+ *
+ * A pinch that moves the signal out from under the fingers reads as broken, so
+ * the anchor frequency is measured in the old window and re-placed at the same
+ * screen fraction in the new one. The result is a raw offset — feed it back
+ * through view_window(), which clamps it.
+ */
+inline double
+zoom_anchor_offset_hz(double center, double span, double old_zoom, double old_offset_hz, double new_zoom,
+                      double x_fraction) {
+    const ViewWindow old_win = view_window(center, span, old_zoom, old_offset_hz, nullptr);
+    if (!(old_win.span_hz > 0.0)) {
+        return 0.0;
+    }
+    if (x_fraction < 0.0) {
+        x_fraction = 0.0;
+    }
+    if (x_fraction > 1.0) {
+        x_fraction = 1.0;
+    }
+    const double anchor_hz = old_win.low_hz + (x_fraction * old_win.span_hz);
+    const double new_span = span / clamp_zoom(new_zoom);
+    const double new_center = anchor_hz + ((0.5 - x_fraction) * new_span);
+    return new_center - center;
+}
+
+/**
+ * @brief A 1/2/5x10^k axis step no smaller than `view_span_hz / max_ticks`.
+ *
+ * Round numbers only: an axis labelled 851.0000 / 851.2000 / 851.4000 is
+ * readable at a glance, one labelled 851.0374 / 851.2921 is not. Because the
+ * step rounds up, a window can still contain max_ticks + 1 multiples of it;
+ * the caller caps the list it emits.
+ *
+ * @return The step in Hz, or 0 when there is nothing to label.
+ */
+inline double
+nice_tick_step_hz(double view_span_hz, int max_ticks) {
+    if (!(view_span_hz > 0.0)) {
+        return 0.0;
+    }
+    if (max_ticks < 1) {
+        max_ticks = 1;
+    }
+    const double raw = view_span_hz / static_cast<double>(max_ticks);
+    const double exponent = std::floor(std::log10(raw));
+    const double magnitude = std::pow(10.0, exponent);
+    const double base = raw / magnitude;
+    double nice = 10.0;
+    if (base <= 1.0) {
+        nice = 1.0;
+    } else if (base <= 2.0) {
+        nice = 2.0;
+    } else if (base <= 5.0) {
+        nice = 5.0;
+    }
+    return nice * magnitude;
+}
+
+/**
+ * @brief A display range that follows the signal without flickering.
+ *
+ * Ranging to each frame's own min and max makes the picture breathe on every
+ * update and turns an empty band into amplified noise. This tracks a floor and
+ * a ceiling and relaxes toward the current frame a few percent at a time, so a
+ * transmission appearing is a signal rising into a stable frame rather than the
+ * whole display rescaling around it.
+ *
+ * The floor comes from the mean rather than the minimum: most bins are noise,
+ * so the mean is the noise floor, while a single deep null would drag a
+ * minimum-based floor tens of dB down.
+ */
+struct AutoRange {
+    double min_db = 0.0;
+    double max_db = 0.0;
+    bool seeded = false;
+
+    /** @brief Fold one frame in. */
+    void
+    update(const float* db, int n) {
+        if (!db || n <= 0) {
+            return;
+        }
+        double sum = 0.0;
+        double peak = static_cast<double>(db[0]);
+        for (int i = 0; i < n; i++) {
+            const double v = static_cast<double>(db[i]);
+            sum += v;
+            if (v > peak) {
+                peak = v;
+            }
+        }
+        const double want_min = (sum / static_cast<double>(n)) - 6.0;
+        const double want_max = peak + 3.0;
+        if (!seeded) {
+            min_db = want_min;
+            max_db = want_max;
+            seeded = true;
+            return;
+        }
+        const double relax = 0.05;
+        min_db += relax * (want_min - min_db);
+        max_db += relax * (want_max - max_db);
+    }
+
+    /** @brief Height of the range in dB, floored so it can always be divided by. */
+    double
+    span_db() const {
+        const double span = max_db - min_db;
+        return (span < 20.0) ? 20.0 : span;
+    }
+
+    /** @brief Where @p db sits in the range, clamped to [0, 1]. */
+    double
+    normalize(double db) const {
+        const double t = (db - min_db) / span_db();
+        if (!(t > 0.0)) {
+            return 0.0;
+        }
+        return (t > 1.0) ? 1.0 : t;
+    }
+
+    /** @brief Forget the tracked range (new session, new frequency). */
+    void
+    reset() {
+        min_db = 0.0;
+        max_db = 0.0;
+        seeded = false;
+    }
+};
+
+} // namespace spectrum_math
+} // namespace dsd_qt
+
+#endif /* DSD_NEO_SRC_UI_QT_SPECTRUM_MATH_H_ */

--- a/src/ui/qt/spectrum_math.h
+++ b/src/ui/qt/spectrum_math.h
@@ -152,28 +152,46 @@ snap_window_hz(double view_span_hz) {
  * every candidate ties, and a search seeded at the window edge would answer
  * with that edge — pulling a deliberate tap on a quiet channel tens of kHz away
  * every time.
+ *
+ * @param bound_lo,bound_hi Inclusive bin range the answer must lie in, on top of
+ *        the array bounds. Callers pass the visible window: the snap width is
+ *        derived from the view span, so near an edge it otherwise reaches past
+ *        what is on screen and a tap can land on a stronger carrier the user
+ *        cannot see. Pass 0 and n-1 to search the whole array.
  */
 inline int
-peak_search_bin(const float* db, int n, int center_bin, int half_width_bins) {
+peak_search_bin(const float* db, int n, int center_bin, int half_width_bins, int bound_lo, int bound_hi) {
     if (!db || n <= 0) {
         return 0;
     }
-    if (center_bin < 0) {
-        center_bin = 0;
+    if (bound_lo < 0) {
+        bound_lo = 0;
     }
-    if (center_bin > n - 1) {
-        center_bin = n - 1;
+    if (bound_hi > n - 1) {
+        bound_hi = n - 1;
+    }
+    if (bound_hi < bound_lo) {
+        /* An empty or inverted window would leave nothing to answer with; fall
+         * back to the array rather than inventing a bin. */
+        bound_lo = 0;
+        bound_hi = n - 1;
+    }
+    if (center_bin < bound_lo) {
+        center_bin = bound_lo;
+    }
+    if (center_bin > bound_hi) {
+        center_bin = bound_hi;
     }
     if (half_width_bins < 0) {
         half_width_bins = 0;
     }
     int lo = center_bin - half_width_bins;
     int hi = center_bin + half_width_bins;
-    if (lo < 0) {
-        lo = 0;
+    if (lo < bound_lo) {
+        lo = bound_lo;
     }
-    if (hi > n - 1) {
-        hi = n - 1;
+    if (hi > bound_hi) {
+        hi = bound_hi;
     }
     int best = center_bin;
     for (int i = lo; i <= hi; i++) {

--- a/src/ui/qt/spectrum_model.cpp
+++ b/src/ui/qt/spectrum_model.cpp
@@ -39,6 +39,33 @@ state_is_showing(Qt::ApplicationState state) {
     return state != Qt::ApplicationSuspended && state != Qt::ApplicationHidden;
 }
 
+/**
+ * @brief The visible bin range and the snap width, in bins.
+ *
+ * Shared by the tap and the hop because it is the same rule for both: the answer
+ * has to be on screen, and anything nearer than the snap window is the same
+ * channel a tap would already have reached. Two copies of it would let a tap and
+ * a hop resolve to different carriers on one screen.
+ */
+struct ViewBins {
+    int lo;
+    int hi;
+    int snap;
+};
+
+ViewBins
+view_bins(double center_hz, double span_hz, int bin_count, const spectrum_math::ViewWindow& win) {
+    ViewBins out;
+    out.lo = spectrum_math::freq_to_bin(center_hz, span_hz, bin_count, win.low_hz);
+    out.hi = spectrum_math::freq_to_bin(center_hz, span_hz, bin_count, win.high_hz);
+    const double bin_width_hz = span_hz / static_cast<double>(bin_count);
+    out.snap = static_cast<int>(spectrum_math::snap_window_hz(win.span_hz) / bin_width_hz);
+    if (out.snap < 1) {
+        out.snap = 1;
+    }
+    return out;
+}
+
 } // namespace
 
 SpectrumModel::SpectrumModel(QObject* parent) : QObject(parent), m_bins(kMaxBins, 0.0F) {
@@ -255,18 +282,12 @@ SpectrumModel::tapFrequencyHz(double x_fraction) const {
     const double tapped_hz = win.low_hz + (x_fraction * win.span_hz);
     const int tapped_bin = spectrum_math::freq_to_bin(m_center_hz, m_span_hz, m_bin_count, tapped_hz);
 
-    const double bin_width_hz = m_span_hz / static_cast<double>(m_bin_count);
-    int half_width_bins = static_cast<int>(spectrum_math::snap_window_hz(win.span_hz) / bin_width_hz);
-    if (half_width_bins < 1) {
-        half_width_bins = 1;
-    }
     /* The snap may only answer with something the user can see. Its width comes
      * from the view span, so near an edge it otherwise reaches off screen and a
      * tap lands on a carrier that was never displayed. */
-    const int view_lo_bin = spectrum_math::freq_to_bin(m_center_hz, m_span_hz, m_bin_count, win.low_hz);
-    const int view_hi_bin = spectrum_math::freq_to_bin(m_center_hz, m_span_hz, m_bin_count, win.high_hz);
-    const int peak = spectrum_math::peak_search_bin(m_bins.constData(), m_bin_count, tapped_bin, half_width_bins,
-                                                    view_lo_bin, view_hi_bin);
+    const ViewBins view = view_bins(m_center_hz, m_span_hz, m_bin_count, win);
+    const int peak =
+        spectrum_math::peak_search_bin(m_bins.constData(), m_bin_count, tapped_bin, view.snap, view.lo, view.hi);
     return spectrum_math::bin_to_freq_hz(m_center_hz, m_span_hz, m_bin_count, peak);
 }
 
@@ -278,21 +299,20 @@ SpectrumModel::nextPeakHz(int direction) const {
     const spectrum_math::ViewWindow win = window();
     /* Same rule as the tap: only answer with something on screen. Hopping to a
      * carrier outside the window would move the radio to a signal the user was
-     * never shown and could not have been asking for. */
-    const int view_lo_bin = spectrum_math::freq_to_bin(m_center_hz, m_span_hz, m_bin_count, win.low_hz);
-    const int view_hi_bin = spectrum_math::freq_to_bin(m_center_hz, m_span_hz, m_bin_count, win.high_hz);
+     * never shown and could not have been asking for. The gap is the same snap
+     * window: inside it a tap would have reached the same signal, so anything
+     * nearer than that is not a different channel.
+     *
+     * "Above" and "below" are measured from the tuned carrier while it is on
+     * screen, and from the middle of the view once the pan has taken it off —
+     * see directional_seed_bin(). Both bounds and seed have to come from the same
+     * window or one of the two directions searches nothing. */
+    const ViewBins view = view_bins(m_center_hz, m_span_hz, m_bin_count, win);
     const int center_bin = spectrum_math::freq_to_bin(m_center_hz, m_span_hz, m_bin_count, m_center_hz);
-
-    /* The gap is the snap window: inside it a tap would have reached the same
-     * signal, so anything nearer than that is not a different channel. */
-    const double bin_width_hz = m_span_hz / static_cast<double>(m_bin_count);
-    int gap_bins = static_cast<int>(spectrum_math::snap_window_hz(win.span_hz) / bin_width_hz);
-    if (gap_bins < 1) {
-        gap_bins = 1;
-    }
+    const int seed = spectrum_math::directional_seed_bin(center_bin, view.lo, view.hi);
     const int peak =
-        spectrum_math::directional_peak_bin(m_bins.constData(), m_bin_count, center_bin, (direction >= 0) ? 1 : -1,
-                                            gap_bins, kNextPeakExcessDb, view_lo_bin, view_hi_bin);
+        spectrum_math::directional_peak_bin(m_bins.constData(), m_bin_count, seed, (direction >= 0) ? 1 : -1, view.snap,
+                                            kNextPeakExcessDb, view.lo, view.hi);
     if (peak < 0) {
         return 0.0;
     }

--- a/src/ui/qt/spectrum_model.cpp
+++ b/src/ui/qt/spectrum_model.cpp
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "spectrum_model.h"
+
+#include <QCoreApplication>
+#include <QDebug>
+#include <QGuiApplication>
+#include <QMap>
+#include <QString>
+#include <QVariant>
+#include <QVariantMap>
+#include <Qt>
+#include <cmath>
+#include <stdint.h>
+
+#include <dsd-neo/app_control/frontend.h>
+
+namespace dsd_qt {
+
+namespace {
+
+/* Matches the io layer's publish throttle. Polling faster only re-copies a
+ * frame the demod thread has not replaced yet. */
+constexpr int kPollIntervalMs = 66;
+/* The largest frame the io layer will ever publish. */
+constexpr int kMaxBins = 2048;
+
+bool
+state_is_showing(Qt::ApplicationState state) {
+    return state != Qt::ApplicationSuspended && state != Qt::ApplicationHidden;
+}
+
+} // namespace
+
+SpectrumModel::SpectrumModel(QObject* parent) : QObject(parent), m_bins(kMaxBins, 0.0F) {
+    m_timer.setInterval(kPollIntervalMs);
+    /* Coarse: a waterfall row landing a few ms late is invisible, and the
+     * precise timer would keep a phone's CPU out of its idle states. */
+    m_timer.setTimerType(Qt::CoarseTimer);
+    connect(&m_timer, &QTimer::timeout, this, &SpectrumModel::tick);
+
+    /* A backgrounded app draws nothing, so producing frames for it is pure
+     * battery cost. Qt reports this for the whole application, which is right:
+     * the Android service may still be decoding, but nobody is looking.
+     * Inactive is deliberately still "showing" — it only means unfocused (a
+     * dialog or the notification shade on top), and the view is visible under
+     * it. Only Suspended and Hidden mean nothing is on screen. */
+    if (QGuiApplication* app = qobject_cast<QGuiApplication*>(QCoreApplication::instance())) {
+        m_app_foreground = state_is_showing(app->applicationState());
+        connect(app, &QGuiApplication::applicationStateChanged, this, [this](Qt::ApplicationState state) {
+            m_app_foreground = state_is_showing(state);
+            applyRunState();
+        });
+    }
+}
+
+SpectrumModel::~SpectrumModel() {
+    if (m_running) {
+        dsd_app_frontend_wideband_spectrum_set_enabled(0);
+    }
+}
+
+void
+SpectrumModel::setActive(bool on) {
+    if (m_active == on) {
+        return;
+    }
+    m_active = on;
+    applyRunState();
+    Q_EMIT activeChanged();
+}
+
+void
+SpectrumModel::applyRunState() {
+    const bool run = m_active && m_app_foreground;
+    if (run == m_running) {
+        return;
+    }
+    m_running = run;
+    dsd_app_frontend_wideband_spectrum_set_enabled(run ? 1 : 0);
+    if (run) {
+        m_timer.start();
+        return;
+    }
+    m_timer.stop();
+    /* Reopening the view must not flash the last session's panorama. A gap
+     * *while* running is different — see tick(), which holds the last frame. */
+    invalidateFrame();
+}
+
+void
+SpectrumModel::invalidateFrame() {
+    if (!m_has_data) {
+        return;
+    }
+    m_has_data = false;
+    m_bin_count = 0;
+    m_center_hz = 0.0;
+    m_span_hz = 0.0;
+    m_frame_index++;
+    (void)applyOffset(0.0);
+    Q_EMIT retuned();
+    Q_EMIT frameChanged();
+    Q_EMIT viewChanged();
+}
+
+void
+SpectrumModel::tick() {
+    uint32_t center_hz = 0;
+    uint32_t span_hz = 0;
+    const int n = dsd_app_frontend_wideband_spectrum_get(m_bins.data(), kMaxBins, &center_hz, &span_hz);
+    if (n <= 0) {
+        /* No frame yet, or one was just invalidated by a retune in flight.
+         * Holding the last picture beats flickering to empty and back. */
+        return;
+    }
+
+    /* Exact comparison is right: both sides came from the same uint32 Hz
+     * values, so "different" means the front end actually moved. */
+    const double center = static_cast<double>(center_hz);
+    const double span = static_cast<double>(span_hz);
+    const bool moved = m_has_data && (center != m_center_hz || span != m_span_hz);
+    const bool geometry_changed = (center != m_center_hz) || (span != m_span_hz) || (n != m_bin_count);
+
+    m_center_hz = center;
+    m_span_hz = span;
+    m_bin_count = n;
+    m_has_data = true;
+    m_frame_index++;
+
+    bool view_moved = false;
+    if (moved) {
+        /* Recenter but keep the magnification: the user zoomed in for a reason,
+         * and the thing they tapped is now the middle of the span. */
+        view_moved = applyOffset(0.0);
+        Q_EMIT retuned();
+    } else if (geometry_changed) {
+        /* A span change can put a previously legal offset out of bounds. */
+        view_moved = applyOffset(m_offset_hz);
+    }
+
+    Q_EMIT frameChanged();
+    if (view_moved || geometry_changed) {
+        Q_EMIT viewChanged();
+    }
+}
+
+bool
+SpectrumModel::applyOffset(double hz) {
+    if (!std::isfinite(hz)) {
+        hz = 0.0;
+    }
+    double overshoot = 0.0;
+    (void)spectrum_math::view_window(m_center_hz, m_span_hz, m_zoom, hz, &overshoot);
+    const double granted = hz - overshoot;
+    if (granted == m_offset_hz && overshoot == m_overshoot_hz) {
+        return false;
+    }
+    m_offset_hz = granted;
+    m_overshoot_hz = overshoot;
+    return true;
+}
+
+void
+SpectrumModel::setViewOffsetHz(double hz) {
+    if (applyOffset(hz)) {
+        Q_EMIT viewChanged();
+    }
+}
+
+void
+SpectrumModel::setZoom(double zoom_level) {
+    zoomToAnchored(zoom_level, 0.5);
+}
+
+void
+SpectrumModel::zoomAt(double factor, double x_fraction) {
+    if (!std::isfinite(factor) || !(factor > 0.0)) {
+        return;
+    }
+    zoomToAnchored(m_zoom * factor, x_fraction);
+}
+
+void
+SpectrumModel::zoomToAnchored(double zoom_level, double x_fraction) {
+    if (!std::isfinite(zoom_level)) {
+        return;
+    }
+    const double next = spectrum_math::clamp_zoom(zoom_level);
+    if (next == m_zoom) {
+        return;
+    }
+    const double anchored =
+        spectrum_math::zoom_anchor_offset_hz(m_center_hz, m_span_hz, m_zoom, m_offset_hz, next, x_fraction);
+    m_zoom = next;
+    (void)applyOffset(anchored);
+    Q_EMIT viewChanged();
+}
+
+void
+SpectrumModel::clearOvershoot() {
+    if (m_overshoot_hz == 0.0) {
+        return;
+    }
+    m_overshoot_hz = 0.0;
+    Q_EMIT viewChanged();
+}
+
+void
+SpectrumModel::resetView() {
+    const bool zoom_moved = (m_zoom != spectrum_math::kMinZoom);
+    m_zoom = spectrum_math::kMinZoom;
+    const bool offset_moved = applyOffset(0.0);
+    if (zoom_moved || offset_moved) {
+        Q_EMIT viewChanged();
+    }
+}
+
+double
+SpectrumModel::tapFrequencyHz(double x_fraction) const {
+    if (!m_has_data || m_bin_count <= 0 || !(m_span_hz > 0.0)) {
+        return 0.0;
+    }
+    if (!std::isfinite(x_fraction)) {
+        return 0.0;
+    }
+    if (x_fraction < 0.0) {
+        x_fraction = 0.0;
+    }
+    if (x_fraction > 1.0) {
+        x_fraction = 1.0;
+    }
+
+    const spectrum_math::ViewWindow win = window();
+    const double tapped_hz = win.low_hz + (x_fraction * win.span_hz);
+    const int tapped_bin = spectrum_math::freq_to_bin(m_center_hz, m_span_hz, m_bin_count, tapped_hz);
+
+    const double bin_width_hz = m_span_hz / static_cast<double>(m_bin_count);
+    int half_width_bins = static_cast<int>(spectrum_math::snap_window_hz(win.span_hz) / bin_width_hz);
+    if (half_width_bins < 1) {
+        half_width_bins = 1;
+    }
+    const int peak = spectrum_math::peak_search_bin(m_bins.constData(), m_bin_count, tapped_bin, half_width_bins);
+    return spectrum_math::bin_to_freq_hz(m_center_hz, m_span_hz, m_bin_count, peak);
+}
+
+QVariantList
+SpectrumModel::axisTicks(int max_ticks) const {
+    QVariantList ticks;
+    if (!m_has_data || max_ticks < 1) {
+        return ticks;
+    }
+    const spectrum_math::ViewWindow win = window();
+    if (!(win.span_hz > 0.0)) {
+        return ticks;
+    }
+    const double step = spectrum_math::nice_tick_step_hz(win.span_hz, max_ticks);
+    if (!(step > 0.0)) {
+        return ticks;
+    }
+
+    ticks.reserve(max_ticks);
+    /* Each label is computed from the first one and an integer count rather
+     * than accumulated: at 850 MHz, repeated addition drifts the later labels
+     * off their own grid lines. */
+    const double first = std::ceil(win.low_hz / step) * step;
+    for (int k = 0; k < max_ticks; k++) {
+        const double freq = first + (static_cast<double>(k) * step);
+        if (freq > win.high_hz) {
+            break;
+        }
+        QVariantMap entry;
+        entry[QStringLiteral("freqHz")] = freq;
+        entry[QStringLiteral("xFraction")] = (freq - win.low_hz) / win.span_hz;
+        /* MHz to 4 decimals: 100 Hz resolution reads every channel plan we
+         * decode without turning the axis into a wall of digits. */
+        entry[QStringLiteral("label")] = QString::number(freq / 1.0e6, 'f', 4);
+        ticks.append(entry);
+    }
+    return ticks;
+}
+
+} // namespace dsd_qt

--- a/src/ui/qt/spectrum_model.cpp
+++ b/src/ui/qt/spectrum_model.cpp
@@ -29,6 +29,11 @@ namespace {
 constexpr int kPollIntervalMs = DSD_WIDEBAND_SPECTRUM_PERIOD_MS;
 constexpr int kMaxBins = DSD_WIDEBAND_SPECTRUM_BINS;
 
+/* How far above the frame's mean level a bin has to sit before "next signal" will
+ * move the radio to it. Low enough that a weak but real carrier still counts, high
+ * enough that the control does not walk across noise one bin at a time. */
+constexpr double kNextPeakExcessDb = 8.0;
+
 bool
 state_is_showing(Qt::ApplicationState state) {
     return state != Qt::ApplicationSuspended && state != Qt::ApplicationHidden;
@@ -254,6 +259,35 @@ SpectrumModel::tapFrequencyHz(double x_fraction) const {
     const int view_hi_bin = spectrum_math::freq_to_bin(m_center_hz, m_span_hz, m_bin_count, win.high_hz);
     const int peak = spectrum_math::peak_search_bin(m_bins.constData(), m_bin_count, tapped_bin, half_width_bins,
                                                     view_lo_bin, view_hi_bin);
+    return spectrum_math::bin_to_freq_hz(m_center_hz, m_span_hz, m_bin_count, peak);
+}
+
+double
+SpectrumModel::nextPeakHz(int direction) const {
+    if (!m_has_data || m_bin_count <= 0 || !(m_span_hz > 0.0)) {
+        return 0.0;
+    }
+    const spectrum_math::ViewWindow win = window();
+    /* Same rule as the tap: only answer with something on screen. Hopping to a
+     * carrier outside the window would move the radio to a signal the user was
+     * never shown and could not have been asking for. */
+    const int view_lo_bin = spectrum_math::freq_to_bin(m_center_hz, m_span_hz, m_bin_count, win.low_hz);
+    const int view_hi_bin = spectrum_math::freq_to_bin(m_center_hz, m_span_hz, m_bin_count, win.high_hz);
+    const int center_bin = spectrum_math::freq_to_bin(m_center_hz, m_span_hz, m_bin_count, m_center_hz);
+
+    /* The gap is the snap window: inside it a tap would have reached the same
+     * signal, so anything nearer than that is not a different channel. */
+    const double bin_width_hz = m_span_hz / static_cast<double>(m_bin_count);
+    int gap_bins = static_cast<int>(spectrum_math::snap_window_hz(win.span_hz) / bin_width_hz);
+    if (gap_bins < 1) {
+        gap_bins = 1;
+    }
+    const int peak =
+        spectrum_math::directional_peak_bin(m_bins.constData(), m_bin_count, center_bin, (direction >= 0) ? 1 : -1,
+                                            gap_bins, kNextPeakExcessDb, view_lo_bin, view_hi_bin);
+    if (peak < 0) {
+        return 0.0;
+    }
     return spectrum_math::bin_to_freq_hz(m_center_hz, m_span_hz, m_bin_count, peak);
 }
 

--- a/src/ui/qt/spectrum_model.cpp
+++ b/src/ui/qt/spectrum_model.cpp
@@ -104,12 +104,16 @@ SpectrumModel::invalidateFrame() {
     }
     m_has_data = false;
     m_bin_count = 0;
-    m_center_hz = 0.0;
-    m_span_hz = 0.0;
     m_frame_serial = 0;
     m_frame_index++;
+    /* Deliberately no retuned(): pausing production is not the front end moving,
+     * and a consumer holding history (the waterfall) would throw away minutes of
+     * it every time the app backgrounds or a sheet opens over the view — which is
+     * the very thing keeping the view's Loader alive is meant to prevent. The
+     * center and span are kept for the same reason: tick() compares the next
+     * frame against them, so a retune that happened while paused is still
+     * recognised as one and still clears the history, on the frame that proves it. */
     (void)applyOffset(0.0);
-    Q_EMIT retuned();
     Q_EMIT frameChanged();
     Q_EMIT viewChanged();
 }
@@ -139,13 +143,17 @@ SpectrumModel::tick() {
      * values, so "different" means the front end actually moved. */
     const double center = static_cast<double>(center_hz);
     const double span = static_cast<double>(span_hz);
-    const bool moved = m_has_data && (center != m_center_hz || span != m_span_hz);
+    /* Against the last geometry seen, not against "is there a frame right now":
+     * production stops and starts with the view, and the front end can move while
+     * it is stopped, so the comparison has to survive an invalidation. */
+    const bool moved = m_have_geometry && (center != m_center_hz || span != m_span_hz);
     const bool geometry_changed = (center != m_center_hz) || (span != m_span_hz) || (n != m_bin_count);
 
     m_center_hz = center;
     m_span_hz = span;
     m_bin_count = n;
     m_has_data = true;
+    m_have_geometry = true;
     m_frame_index++;
 
     bool view_moved = false;

--- a/src/ui/qt/spectrum_model.cpp
+++ b/src/ui/qt/spectrum_model.cpp
@@ -26,7 +26,14 @@ namespace {
 /* Both come from the producer's own contract rather than being chosen here: a
  * poll slower than the publish period drops frames, and a buffer shorter than a
  * frame is refused outright. See <dsd-neo/core/wideband_spectrum.h>. */
-constexpr int kPollIntervalMs = DSD_WIDEBAND_SPECTRUM_PERIOD_MS;
+/* Half the publish period, not the whole of it. Polling at exactly the producer's
+ * rate is the boundary case that drops rows: the two clocks free-run, and a
+ * CoarseTimer is allowed to fire late, so a poll that slips past one period
+ * repeatedly finds a frame the producer has already replaced. Polling faster is
+ * cheap — tick() rejects a re-read by serial before doing any work — and it is
+ * what the header's own note ("a consumer polling faster only re-copies a frame
+ * the producer has not replaced yet") describes as the safe direction. */
+constexpr int kPollIntervalMs = DSD_WIDEBAND_SPECTRUM_PERIOD_MS / 2;
 constexpr int kMaxBins = DSD_WIDEBAND_SPECTRUM_BINS;
 
 /* How far above the frame's mean level a bin has to sit before "next signal" will
@@ -58,10 +65,17 @@ view_bins(double center_hz, double span_hz, int bin_count, const spectrum_math::
     ViewBins out;
     out.lo = spectrum_math::freq_to_bin(center_hz, span_hz, bin_count, win.low_hz);
     out.hi = spectrum_math::freq_to_bin(center_hz, span_hz, bin_count, win.high_hz);
-    const double bin_width_hz = span_hz / static_cast<double>(bin_count);
-    out.snap = static_cast<int>(spectrum_math::snap_window_hz(win.span_hz) / bin_width_hz);
-    if (out.snap < 1) {
-        out.snap = 1;
+    out.snap = 1;
+    /* Guarded here rather than only at the call sites, as every helper in
+     * spectrum_math.h is: a zero bin count or span makes the division infinite,
+     * and narrowing an infinity to int is undefined behaviour rather than a large
+     * number the clamp below would catch. */
+    if (bin_count > 0 && span_hz > 0.0) {
+        const double bin_width_hz = span_hz / static_cast<double>(bin_count);
+        const double snap = spectrum_math::snap_window_hz(win.span_hz) / bin_width_hz;
+        if (snap > 1.0) {
+            out.snap = (snap > static_cast<double>(bin_count)) ? bin_count : static_cast<int>(snap);
+        }
     }
     return out;
 }

--- a/src/ui/qt/spectrum_model.cpp
+++ b/src/ui/qt/spectrum_model.cpp
@@ -139,8 +139,16 @@ SpectrumModel::invalidateFrame() {
      * the very thing keeping the view's Loader alive is meant to prevent. The
      * center and span are kept for the same reason: tick() compares the next
      * frame against them, so a retune that happened while paused is still
-     * recognised as one and still clears the history, on the frame that proves it. */
-    (void)applyOffset(0.0);
+     * recognised as one and still clears the history, on the frame that proves it.
+     *
+     * The pan offset is kept with them, and for the same reason: WaterfallItem is
+     * deliberately not gated on hasData() so its retained history stays on screen
+     * across a pause, but it derives its source rect from viewLowHz/viewHighHz --
+     * so zeroing the offset here would slide those minutes of history sideways to
+     * the middle of the span the moment a sheet opened, and leave it there. Only
+     * the overshoot goes: that is an unfinished pan gesture, and there is no
+     * gesture left to finish. */
+    m_overshoot_hz = 0.0;
     Q_EMIT frameChanged();
     Q_EMIT viewChanged();
 }

--- a/src/ui/qt/spectrum_model.cpp
+++ b/src/ui/qt/spectrum_model.cpp
@@ -17,16 +17,17 @@
 #include <stdint.h>
 
 #include <dsd-neo/app_control/frontend.h>
+#include <dsd-neo/core/wideband_spectrum.h>
 
 namespace dsd_qt {
 
 namespace {
 
-/* Matches the io layer's publish throttle. Polling faster only re-copies a
- * frame the demod thread has not replaced yet. */
-constexpr int kPollIntervalMs = 66;
-/* The largest frame the io layer will ever publish. */
-constexpr int kMaxBins = 2048;
+/* Both come from the producer's own contract rather than being chosen here: a
+ * poll slower than the publish period drops frames, and a buffer shorter than a
+ * frame is refused outright. See <dsd-neo/core/wideband_spectrum.h>. */
+constexpr int kPollIntervalMs = DSD_WIDEBAND_SPECTRUM_PERIOD_MS;
+constexpr int kMaxBins = DSD_WIDEBAND_SPECTRUM_BINS;
 
 bool
 state_is_showing(Qt::ApplicationState state) {
@@ -100,6 +101,7 @@ SpectrumModel::invalidateFrame() {
     m_bin_count = 0;
     m_center_hz = 0.0;
     m_span_hz = 0.0;
+    m_frame_serial = 0;
     m_frame_index++;
     (void)applyOffset(0.0);
     Q_EMIT retuned();
@@ -111,12 +113,22 @@ void
 SpectrumModel::tick() {
     uint32_t center_hz = 0;
     uint32_t span_hz = 0;
-    const int n = dsd_app_frontend_wideband_spectrum_get(m_bins.data(), kMaxBins, &center_hz, &span_hz);
+    uint32_t serial = 0;
+    const int n = dsd_app_frontend_wideband_spectrum_get(m_bins.data(), kMaxBins, &center_hz, &span_hz, &serial);
     if (n <= 0) {
         /* No frame yet, or one was just invalidated by a retune in flight.
          * Holding the last picture beats flickering to empty and back. */
         return;
     }
+    /* This timer and the producer's publish period free-run against each other,
+     * so a poll landing on the frame already drawn is routine rather than
+     * exceptional. Announcing it as new would repaint identical pixels and, on
+     * the waterfall, add a duplicate row — history that says a signal lasted
+     * longer than it did. */
+    if (m_has_data && serial == m_frame_serial) {
+        return;
+    }
+    m_frame_serial = serial;
 
     /* Exact comparison is right: both sides came from the same uint32 Hz
      * values, so "different" means the front end actually moved. */
@@ -174,14 +186,6 @@ SpectrumModel::setViewOffsetHz(double hz) {
 void
 SpectrumModel::setZoom(double zoom_level) {
     zoomToAnchored(zoom_level, 0.5);
-}
-
-void
-SpectrumModel::zoomAt(double factor, double x_fraction) {
-    if (!std::isfinite(factor) || !(factor > 0.0)) {
-        return;
-    }
-    zoomToAnchored(m_zoom * factor, x_fraction);
 }
 
 void
@@ -243,7 +247,13 @@ SpectrumModel::tapFrequencyHz(double x_fraction) const {
     if (half_width_bins < 1) {
         half_width_bins = 1;
     }
-    const int peak = spectrum_math::peak_search_bin(m_bins.constData(), m_bin_count, tapped_bin, half_width_bins);
+    /* The snap may only answer with something the user can see. Its width comes
+     * from the view span, so near an edge it otherwise reaches off screen and a
+     * tap lands on a carrier that was never displayed. */
+    const int view_lo_bin = spectrum_math::freq_to_bin(m_center_hz, m_span_hz, m_bin_count, win.low_hz);
+    const int view_hi_bin = spectrum_math::freq_to_bin(m_center_hz, m_span_hz, m_bin_count, win.high_hz);
+    const int peak = spectrum_math::peak_search_bin(m_bins.constData(), m_bin_count, tapped_bin, half_width_bins,
+                                                    view_lo_bin, view_hi_bin);
     return spectrum_math::bin_to_freq_hz(m_center_hz, m_span_hz, m_bin_count, peak);
 }
 

--- a/src/ui/qt/spectrum_model.h
+++ b/src/ui/qt/spectrum_model.h
@@ -228,6 +228,10 @@ class SpectrumModel : public QObject {
     double m_span_hz = 0.0;
     int m_bin_count = 0;
     bool m_has_data = false;
+    /* Whether m_center_hz/m_span_hz describe a frame that was actually received.
+     * Outlives m_has_data on purpose: invalidateFrame() drops the frame but keeps
+     * the geometry, so the next frame can still be recognised as a retune. */
+    bool m_have_geometry = false;
     double m_zoom = spectrum_math::kMinZoom;
     double m_offset_hz = 0.0;
     double m_overshoot_hz = 0.0;

--- a/src/ui/qt/spectrum_model.h
+++ b/src/ui/qt/spectrum_model.h
@@ -142,6 +142,16 @@ class SpectrumModel : public QObject {
      */
     Q_INVOKABLE double tapFrequencyHz(double x_fraction) const;
 
+    /**
+     * @brief Frequency of the next signal above (@p direction >= 0) or below center.
+     *
+     * Only signals that are visible and stand clear of the noise count, and the
+     * one already tuned is skipped. Returns 0 when there is no such signal, which
+     * the caller must check — this control has to do nothing on an empty band
+     * rather than retune to where the radio already is.
+     */
+    Q_INVOKABLE double nextPeakHz(int direction) const;
+
     /** @brief Set the zoom to @p zoom_level, holding @p x_fraction's frequency still. */
     Q_INVOKABLE void zoomToAnchored(double zoom_level, double x_fraction);
 

--- a/src/ui/qt/spectrum_model.h
+++ b/src/ui/qt/spectrum_model.h
@@ -149,6 +149,11 @@ class SpectrumModel : public QObject {
      * one already tuned is skipped. Returns 0 when there is no such signal, which
      * the caller must check — this control has to do nothing on an empty band
      * rather than retune to where the radio already is.
+     *
+     * "Center" is the tuned carrier while it is on screen, and the middle of the
+     * view once the pan has taken it off: only what is visible can be answered
+     * with, so an off-screen reference would leave one direction with nothing to
+     * search. A retune resets the pan, so the two coincide again immediately after.
      */
     Q_INVOKABLE double nextPeakHz(int direction) const;
 

--- a/src/ui/qt/spectrum_model.h
+++ b/src/ui/qt/spectrum_model.h
@@ -142,9 +142,6 @@ class SpectrumModel : public QObject {
      */
     Q_INVOKABLE double tapFrequencyHz(double x_fraction) const;
 
-    /** @brief Multiply the zoom by @p factor, holding @p x_fraction's frequency still. */
-    Q_INVOKABLE void zoomAt(double factor, double x_fraction);
-
     /** @brief Set the zoom to @p zoom_level, holding @p x_fraction's frequency still. */
     Q_INVOKABLE void zoomToAnchored(double zoom_level, double x_fraction);
 
@@ -157,13 +154,32 @@ class SpectrumModel : public QObject {
     /** @brief Return the viewport to the whole span at 1x. */
     Q_INVOKABLE void resetView();
 
+#ifdef DSD_NEO_TEST_HOOKS
+    /**
+     * @brief Poll the producer once, exactly as the timer does.
+     *
+     * Lets a test drive frames in without waiting out the publish period, and
+     * without the arrival order depending on how a run was scheduled.
+     */
+    void
+    testPoll() {
+        tick();
+    }
+#endif
+
     /** @brief The live bin buffer, for the painted items. Only binCount() entries are valid. */
     const QVector<float>&
     bins() const {
         return m_bins;
     }
 
-    /** @brief Increments on every published frame, so a painter can skip repeats. */
+    /**
+     * @brief Increments once per frame actually taken from the producer.
+     *
+     * Not once per poll: the timer here and the producer's publish period
+     * free-run, so a painter needs to know when the picture changed rather than
+     * when it was looked at.
+     */
     quint64
     frameIndex() const {
         return m_frame_index;
@@ -206,6 +222,8 @@ class SpectrumModel : public QObject {
     double m_offset_hz = 0.0;
     double m_overshoot_hz = 0.0;
     quint64 m_frame_index = 0;
+    /* The producer's identity for the frame in m_bins; 0 while there is none. */
+    quint32 m_frame_serial = 0;
     bool m_active = false;
     bool m_app_foreground = true;
     bool m_running = false;

--- a/src/ui/qt/spectrum_model.h
+++ b/src/ui/qt/spectrum_model.h
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Live wideband spectrum frames and viewport state exposed to QML.
+ *
+ * Polls the app-control wideband getter on its own timer rather than riding
+ * the 250 ms UI tick: a waterfall needs frames several times faster than the
+ * status card does, and the getter is an atomic copy that is safe to call from
+ * any thread. It must never touch dsd_app_get_latest_snapshot() /
+ * ..._opts_snapshot(), which are strictly single-consumer and belong to
+ * UiController — everything a spectrum frame needs (bins, center, span) is
+ * published inside the frame itself.
+ *
+ * Production is enabled only while the view is on screen and the app is in the
+ * foreground, so the FFT costs nothing the rest of the time.
+ */
+
+#ifndef DSD_NEO_SRC_UI_QT_SPECTRUM_MODEL_H_
+#define DSD_NEO_SRC_UI_QT_SPECTRUM_MODEL_H_
+
+#include <QList>
+#include <QObject>
+#include <QTimer>
+#include <QVariantList>
+#include <QtGlobal>
+
+#include "spectrum_math.h"
+
+namespace dsd_qt {
+
+class SpectrumModel : public QObject {
+    Q_OBJECT
+
+    /* Two groups, for the same reason MetricsModel splits its signals: a new
+     * frame arrives ~15x a second and must repaint the trace, but it must not
+     * re-lay-out the axis labels or re-evaluate the gesture bindings, which
+     * only move when the viewport does. */
+    Q_PROPERTY(bool active READ active WRITE setActive NOTIFY activeChanged)
+    Q_PROPERTY(bool hasData READ hasData NOTIFY frameChanged)
+    Q_PROPERTY(double centerFreqHz READ centerFreqHz NOTIFY frameChanged)
+    Q_PROPERTY(double spanHz READ spanHz NOTIFY frameChanged)
+    Q_PROPERTY(int binCount READ binCount NOTIFY frameChanged)
+    Q_PROPERTY(double zoom READ zoom WRITE setZoom NOTIFY viewChanged)
+    Q_PROPERTY(double viewOffsetHz READ viewOffsetHz WRITE setViewOffsetHz NOTIFY viewChanged)
+    Q_PROPERTY(double edgeOvershootHz READ edgeOvershootHz NOTIFY viewChanged)
+    Q_PROPERTY(double viewLowHz READ viewLowHz NOTIFY viewChanged)
+    Q_PROPERTY(double viewHighHz READ viewHighHz NOTIFY viewChanged)
+    Q_PROPERTY(double viewSpanHz READ viewSpanHz NOTIFY viewChanged)
+
+  public:
+    explicit SpectrumModel(QObject* parent = nullptr);
+    ~SpectrumModel() override;
+
+    /** @brief Whether frames are being produced and polled. */
+    bool
+    active() const {
+        return m_active;
+    }
+
+    void setActive(bool on);
+
+    /** @brief Whether a frame has been received and not since invalidated. */
+    bool
+    hasData() const {
+        return m_has_data;
+    }
+
+    /** @brief Center of the published frame, in Hz. This is the axis authority. */
+    double
+    centerFreqHz() const {
+        return m_center_hz;
+    }
+
+    /** @brief Width of the published frame, in Hz (the SDR capture bandwidth). */
+    double
+    spanHz() const {
+        return m_span_hz;
+    }
+
+    /** @brief Number of bins in the published frame. */
+    int
+    binCount() const {
+        return m_bin_count;
+    }
+
+    /** @brief Current magnification, 1x (whole span) to 8x. */
+    double
+    zoom() const {
+        return m_zoom;
+    }
+
+    void setZoom(double zoom_level);
+
+    /** @brief Viewport center relative to the frame center, in Hz. Always clamped. */
+    double
+    viewOffsetHz() const {
+        return m_offset_hz;
+    }
+
+    void setViewOffsetHz(double hz);
+
+    /**
+     * @brief How far past the capture edge the last pan asked to go, in Hz.
+     *
+     * Signed, and 0 whenever the request fitted. A gesture that ends with this
+     * non-zero is the user asking for a frequency the hardware is not covering;
+     * the view turns exactly one of those into a retune, on release.
+     */
+    double
+    edgeOvershootHz() const {
+        return m_overshoot_hz;
+    }
+
+    /** @brief Low edge of the visible window, in Hz. */
+    double
+    viewLowHz() const {
+        return window().low_hz;
+    }
+
+    /** @brief High edge of the visible window, in Hz. */
+    double
+    viewHighHz() const {
+        return window().high_hz;
+    }
+
+    /** @brief Width of the visible window, in Hz. */
+    double
+    viewSpanHz() const {
+        return window().span_hz;
+    }
+
+    /**
+     * @brief Frequency a tap at @p x_fraction across the view is asking for.
+     *
+     * Snaps to the strongest bin near the touch, because a fingertip is far
+     * wider than a channel. Returns 0 when there is no frame to read, which the
+     * caller must check before submitting a tune.
+     */
+    Q_INVOKABLE double tapFrequencyHz(double x_fraction) const;
+
+    /** @brief Multiply the zoom by @p factor, holding @p x_fraction's frequency still. */
+    Q_INVOKABLE void zoomAt(double factor, double x_fraction);
+
+    /** @brief Set the zoom to @p zoom_level, holding @p x_fraction's frequency still. */
+    Q_INVOKABLE void zoomToAnchored(double zoom_level, double x_fraction);
+
+    /** @brief Axis labels as {freqHz, xFraction, label} maps, at most @p max_ticks. */
+    Q_INVOKABLE QVariantList axisTicks(int max_ticks) const;
+
+    /** @brief Forget a pending edge overshoot, after acting on it. */
+    Q_INVOKABLE void clearOvershoot();
+
+    /** @brief Return the viewport to the whole span at 1x. */
+    Q_INVOKABLE void resetView();
+
+    /** @brief The live bin buffer, for the painted items. Only binCount() entries are valid. */
+    const QVector<float>&
+    bins() const {
+        return m_bins;
+    }
+
+    /** @brief Increments on every published frame, so a painter can skip repeats. */
+    quint64
+    frameIndex() const {
+        return m_frame_index;
+    }
+
+  Q_SIGNALS:
+    /** @brief A new frame landed, or the frame was invalidated. */
+    void frameChanged();
+    /** @brief The visible window moved (zoom, pan, or a frame geometry change). */
+    void viewChanged();
+    /** @brief Production started or stopped. */
+    void activeChanged();
+    /**
+     * @brief The front end moved to a different frequency.
+     *
+     * Waterfall history is only meaningful at one center, so a consumer holding
+     * history must drop it here.
+     */
+    void retuned();
+
+  private:
+    void tick();
+    void applyRunState();
+    /** @return true when the stored offset or overshoot actually moved. */
+    bool applyOffset(double hz);
+    void invalidateFrame();
+
+    spectrum_math::ViewWindow
+    window() const {
+        return spectrum_math::view_window(m_center_hz, m_span_hz, m_zoom, m_offset_hz, nullptr);
+    }
+
+    QVector<float> m_bins;
+    QTimer m_timer;
+    double m_center_hz = 0.0;
+    double m_span_hz = 0.0;
+    int m_bin_count = 0;
+    bool m_has_data = false;
+    double m_zoom = spectrum_math::kMinZoom;
+    double m_offset_hz = 0.0;
+    double m_overshoot_hz = 0.0;
+    quint64 m_frame_index = 0;
+    bool m_active = false;
+    bool m_app_foreground = true;
+    bool m_running = false;
+};
+
+} // namespace dsd_qt
+
+#endif /* DSD_NEO_SRC_UI_QT_SPECTRUM_MODEL_H_ */

--- a/src/ui/qt/spectrum_view_item.cpp
+++ b/src/ui/qt/spectrum_view_item.cpp
@@ -25,11 +25,51 @@ constexpr int kWaterfallWidth = DSD_WIDEBAND_SPECTRUM_BINS;
 constexpr int kWaterfallRows = 240;
 
 /**
- * @brief Reduce @p count bins starting at @p first into @p out_width columns.
+ * @brief Peak-pick @p count bins down into a narrower @p out_width, for count > out_width.
  *
  * Peak-picking, not averaging: a narrow carrier that lands between two columns
- * must stay visible rather than being averaged into the noise. Mirrors
- * spectrum_resample_columns() in the terminal visualizer.
+ * must stay visible rather than being averaged into the noise.
+ */
+void
+resample_peak_decimate(const float* bins, int first, int count, float* out, int out_width) {
+    for (int x = 0; x < out_width; x++) {
+        int i0 = static_cast<int>((static_cast<long long>(x) * count) / out_width);
+        int i1 = static_cast<int>((static_cast<long long>(x + 1) * count) / out_width);
+        if (i1 <= i0) {
+            i1 = i0 + 1;
+        }
+        if (i1 > count) {
+            i1 = count;
+        }
+        float peak = bins[first + i0];
+        for (int i = i0 + 1; i < i1; i++) {
+            if (bins[first + i] > peak) {
+                peak = bins[first + i];
+            }
+        }
+        out[x] = peak;
+    }
+}
+
+/** @brief Spread @p count bins across a wider @p out_width by repetition, for count < out_width. */
+void
+resample_repeat(const float* bins, int first, int count, float* out, int out_width) {
+    for (int x = 0; x < out_width; x++) {
+        int src = static_cast<int>((static_cast<long long>(x) * count) / out_width);
+        if (src < 0) {
+            src = 0;
+        }
+        if (src > count - 1) {
+            src = count - 1;
+        }
+        out[x] = bins[first + src];
+    }
+}
+
+/**
+ * @brief Reduce @p count bins starting at @p first into @p out_width columns.
+ *
+ * Mirrors spectrum_resample_columns() in the terminal visualizer.
  */
 void
 resample_columns(const float* bins, int first, int count, float* out, int out_width) {
@@ -42,36 +82,20 @@ resample_columns(const float* bins, int first, int count, float* out, int out_wi
         }
         return;
     }
-    if (count >= out_width) {
+    if (count == out_width) {
+        /* The waterfall's own case: every published frame is exactly
+         * DSD_WIDEBAND_SPECTRUM_BINS wide and so is the history image, so the general
+         * paths would spend two 64-bit divisions per column deriving the identity map. */
         for (int x = 0; x < out_width; x++) {
-            int i0 = static_cast<int>((static_cast<long long>(x) * count) / out_width);
-            int i1 = static_cast<int>((static_cast<long long>(x + 1) * count) / out_width);
-            if (i1 <= i0) {
-                i1 = i0 + 1;
-            }
-            if (i1 > count) {
-                i1 = count;
-            }
-            float peak = bins[first + i0];
-            for (int i = i0 + 1; i < i1; i++) {
-                if (bins[first + i] > peak) {
-                    peak = bins[first + i];
-                }
-            }
-            out[x] = peak;
+            out[x] = bins[first + x];
         }
         return;
     }
-    for (int x = 0; x < out_width; x++) {
-        int src = static_cast<int>((static_cast<long long>(x) * count) / out_width);
-        if (src < 0) {
-            src = 0;
-        }
-        if (src > count - 1) {
-            src = count - 1;
-        }
-        out[x] = bins[first + src];
+    if (count > out_width) {
+        resample_peak_decimate(bins, first, count, out, out_width);
+        return;
     }
+    resample_repeat(bins, first, count, out, out_width);
 }
 
 int
@@ -347,14 +371,16 @@ WaterfallItem::onFrame() {
     if (m_have_row && index == m_last_frame_index) {
         return; /* a repaint request, not a new row */
     }
-    m_last_frame_index = index;
-    m_have_row = true;
-
     const int n = m_model->binCount();
     const QVector<float>& bins = m_model->bins();
     if (n <= 0 || bins.size() < n) {
         return;
     }
+    /* Stamped only once the frame is known to be usable, as SpectrumTraceItem does:
+     * claiming it before the check would make a frame this declined to draw look
+     * like one already drawn, and the row would be lost from history for good. */
+    m_last_frame_index = index;
+    m_have_row = true;
     m_range.update(bins.constData(), n);
 
     /* Always full span: that is what lets zoom and pan reach back through
@@ -382,10 +408,16 @@ WaterfallItem::paint(QPainter* painter) {
         return;
     }
 
-    /* Which slice of the full-span rows the viewport is looking at. */
+    /* Which slice of the full-span rows the viewport is looking at.
+     *
+     * Deliberately not gated on hasData(): invalidateFrame() drops the frame but
+     * keeps the center, the span and the viewport, precisely so the history stays
+     * meaningful across a pause. Requiring a live frame here would snap the picture
+     * from the zoomed slice back to 1x every time the app backgrounds or production
+     * stops, and snap it back a frame later. */
     double src_x = 0.0;
     double src_w = kWaterfallWidth;
-    if (m_model && m_model->hasData() && m_model->spanHz() > 0.0) {
+    if (m_model && m_model->spanHz() > 0.0) {
         const double span = m_model->spanHz();
         const double low = m_model->centerFreqHz() - (span / 2.0);
         const double frac_lo = (m_model->viewLowHz() - low) / span;

--- a/src/ui/qt/spectrum_view_item.cpp
+++ b/src/ui/qt/spectrum_view_item.cpp
@@ -234,9 +234,15 @@ SpectrumTraceItem::paint(QPainter* painter) {
     }
 
     /* A model handed over after its first frame has landed announces nothing until
-     * the next one, so seed here rather than draw a flat trace for a frame. */
+     * the next one, so seed here rather than draw a flat trace for a frame. Stamped
+     * with the frame it seeded from, exactly as onFrame() does: left unstamped, the
+     * next viewChanged — the first touch-move of a pan — folds this same frame in a
+     * second time, and the trace's range then runs one relaxation step ahead of the
+     * waterfall's copy of it for the rest of the session. */
     if (!m_range.seeded) {
         m_range.update(bins.constData(), n);
+        m_last_frame_index = m_model->frameIndex();
+        m_have_frame = true;
     }
 
     const double center = m_model->centerFreqHz();
@@ -274,6 +280,7 @@ SpectrumTraceItem::paint(QPainter* painter) {
 
 WaterfallItem::WaterfallItem(QQuickItem* parent)
     : QQuickPaintedItem(parent), m_image(kWaterfallWidth, kWaterfallRows, QImage::Format_RGB32) {
+    rebuildRamp();
     clearHistory();
 }
 
@@ -307,6 +314,7 @@ WaterfallItem::setColdColor(const QColor& color) {
     }
     m_cold_color = color;
     Q_EMIT colorsChanged();
+    rebuildRamp();
     /* Rows already written hold their old palette, and a half-recolored
      * waterfall reads as corruption. */
     clearHistory();
@@ -319,6 +327,7 @@ WaterfallItem::setMidColor(const QColor& color) {
     }
     m_mid_color = color;
     Q_EMIT colorsChanged();
+    rebuildRamp();
     clearHistory();
 }
 
@@ -329,6 +338,7 @@ WaterfallItem::setHotColor(const QColor& color) {
     }
     m_hot_color = color;
     Q_EMIT colorsChanged();
+    rebuildRamp();
     clearHistory();
 }
 
@@ -348,18 +358,36 @@ WaterfallItem::clearHistory() {
     update();
 }
 
+void
+WaterfallItem::rebuildRamp() {
+    for (int i = 0; i < kRampSteps; i++) {
+        const double t = static_cast<double>(i) / static_cast<double>(kRampSteps - 1);
+        if (t <= 0.5) {
+            const double u = t * 2.0;
+            m_ramp[i] = qRgb(lerp_channel(m_cold_color.red(), m_mid_color.red(), u),
+                             lerp_channel(m_cold_color.green(), m_mid_color.green(), u),
+                             lerp_channel(m_cold_color.blue(), m_mid_color.blue(), u));
+            continue;
+        }
+        const double u = (t - 0.5) * 2.0;
+        m_ramp[i] = qRgb(lerp_channel(m_mid_color.red(), m_hot_color.red(), u),
+                         lerp_channel(m_mid_color.green(), m_hot_color.green(), u),
+                         lerp_channel(m_mid_color.blue(), m_hot_color.blue(), u));
+    }
+}
+
 QRgb
 WaterfallItem::rampColor(double t) const {
-    if (t <= 0.5) {
-        const double u = t * 2.0;
-        return qRgb(lerp_channel(m_cold_color.red(), m_mid_color.red(), u),
-                    lerp_channel(m_cold_color.green(), m_mid_color.green(), u),
-                    lerp_channel(m_cold_color.blue(), m_mid_color.blue(), u));
+    /* Clamped rather than trusted: AutoRange::normalize() is the only caller
+     * today and already returns [0, 1], but an out-of-range index here reads
+     * off the end of the table instead of producing a wrong color. */
+    int i = static_cast<int>(std::lround(t * static_cast<double>(kRampSteps - 1)));
+    if (i < 0) {
+        i = 0;
+    } else if (i >= kRampSteps) {
+        i = kRampSteps - 1;
     }
-    const double u = (t - 0.5) * 2.0;
-    return qRgb(lerp_channel(m_mid_color.red(), m_hot_color.red(), u),
-                lerp_channel(m_mid_color.green(), m_hot_color.green(), u),
-                lerp_channel(m_mid_color.blue(), m_hot_color.blue(), u));
+    return m_ramp[i];
 }
 
 void

--- a/src/ui/qt/spectrum_view_item.cpp
+++ b/src/ui/qt/spectrum_view_item.cpp
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "spectrum_view_item.h"
+
+#include <QPainter>
+#include <QPolygonF>
+#include <QRectF>
+#include <Qt>
+#include <cmath>
+#include <qpen.h>
+
+#include "spectrum_model.h"
+
+namespace dsd_qt {
+
+namespace {
+
+/* Waterfall history buffer. The width is the largest frame the io layer
+ * publishes, so a row never loses resolution the display could have shown; the
+ * height is a couple of minutes of history at ~15 FPS. */
+constexpr int kWaterfallWidth = 2048;
+constexpr int kWaterfallRows = 240;
+
+/**
+ * @brief Reduce @p count bins starting at @p first into @p out_width columns.
+ *
+ * Peak-picking, not averaging: a narrow carrier that lands between two columns
+ * must stay visible rather than being averaged into the noise. Mirrors
+ * spectrum_resample_columns() in the terminal visualizer.
+ */
+void
+resample_columns(const float* bins, int first, int count, float* out, int out_width) {
+    if (!bins || !out || out_width <= 0) {
+        return;
+    }
+    if (count <= 0) {
+        for (int x = 0; x < out_width; x++) {
+            out[x] = 0.0F;
+        }
+        return;
+    }
+    if (count >= out_width) {
+        for (int x = 0; x < out_width; x++) {
+            int i0 = static_cast<int>((static_cast<long long>(x) * count) / out_width);
+            int i1 = static_cast<int>((static_cast<long long>(x + 1) * count) / out_width);
+            if (i1 <= i0) {
+                i1 = i0 + 1;
+            }
+            if (i1 > count) {
+                i1 = count;
+            }
+            float peak = bins[first + i0];
+            for (int i = i0 + 1; i < i1; i++) {
+                if (bins[first + i] > peak) {
+                    peak = bins[first + i];
+                }
+            }
+            out[x] = peak;
+        }
+        return;
+    }
+    for (int x = 0; x < out_width; x++) {
+        int src = static_cast<int>((static_cast<long long>(x) * count) / out_width);
+        if (src < 0) {
+            src = 0;
+        }
+        if (src > count - 1) {
+            src = count - 1;
+        }
+        out[x] = bins[first + src];
+    }
+}
+
+int
+lerp_channel(int from, int to, double t) {
+    const double v = static_cast<double>(from) + (t * static_cast<double>(to - from));
+    if (!(v > 0.0)) {
+        return 0;
+    }
+    return (v > 255.0) ? 255 : static_cast<int>(std::lround(v));
+}
+
+} // namespace
+
+// ---------------------------------------------------------------- trace ----
+
+SpectrumTraceItem::SpectrumTraceItem(QQuickItem* parent) : QQuickPaintedItem(parent) {}
+
+SpectrumTraceItem::~SpectrumTraceItem() = default;
+
+void
+SpectrumTraceItem::setModel(SpectrumModel* next) {
+    if (m_model == next) {
+        return;
+    }
+    if (m_model) {
+        disconnect(m_model, nullptr, this, nullptr);
+    }
+    m_model = next;
+    if (m_model) {
+        connect(m_model, &SpectrumModel::frameChanged, this, &SpectrumTraceItem::onFrame);
+        connect(m_model, &SpectrumModel::viewChanged, this, &SpectrumTraceItem::onFrame);
+        connect(m_model, &SpectrumModel::retuned, this, &SpectrumTraceItem::onRetuned);
+    }
+    m_range.reset();
+    Q_EMIT modelChanged();
+    update();
+}
+
+void
+SpectrumTraceItem::setLineColor(const QColor& color) {
+    if (m_line_color == color) {
+        return;
+    }
+    m_line_color = color;
+    Q_EMIT colorsChanged();
+    update();
+}
+
+void
+SpectrumTraceItem::setAreaColor(const QColor& color) {
+    if (m_area_color == color) {
+        return;
+    }
+    m_area_color = color;
+    Q_EMIT colorsChanged();
+    update();
+}
+
+void
+SpectrumTraceItem::setGridColor(const QColor& color) {
+    if (m_grid_color == color) {
+        return;
+    }
+    m_grid_color = color;
+    Q_EMIT colorsChanged();
+    update();
+}
+
+void
+SpectrumTraceItem::onFrame() {
+    update();
+}
+
+void
+SpectrumTraceItem::onRetuned() {
+    /* The new frequency's noise floor has nothing to do with the old one's. */
+    m_range.reset();
+    update();
+}
+
+void
+SpectrumTraceItem::paint(QPainter* painter) {
+    if (!painter) {
+        return;
+    }
+    const int w = static_cast<int>(width());
+    const int h = static_cast<int>(height());
+    if (w <= 1 || h <= 1) {
+        return;
+    }
+
+    painter->setRenderHint(QPainter::Antialiasing, true);
+
+    /* The grid is drawn even with no data, so the panel reads as a chart that is
+     * waiting rather than as a hole in the screen. */
+    if (m_grid_color.alpha() > 0) {
+        QPen grid(m_grid_color);
+        grid.setWidthF(1.0);
+        painter->setPen(grid);
+        for (int i = 1; i < 4; i++) {
+            const double y = (static_cast<double>(h) * i) / 4.0;
+            painter->drawLine(QPointF(0.0, y), QPointF(static_cast<double>(w), y));
+        }
+    }
+
+    if (!m_model || !m_model->hasData()) {
+        return;
+    }
+    const int n = m_model->binCount();
+    const QVector<float>& bins = m_model->bins();
+    if (n <= 0 || bins.size() < n) {
+        return;
+    }
+
+    m_range.update(bins.constData(), n);
+
+    const double center = m_model->centerFreqHz();
+    const double span = m_model->spanHz();
+    const int lo = spectrum_math::freq_to_bin(center, span, n, m_model->viewLowHz());
+    const int hi = spectrum_math::freq_to_bin(center, span, n, m_model->viewHighHz());
+    const int count = (hi >= lo) ? (hi - lo + 1) : 1;
+
+    m_points.resize(w);
+    QVector<float> columns(w);
+    resample_columns(bins.constData(), lo, count, columns.data(), w);
+    for (int x = 0; x < w; x++) {
+        const double t = m_range.normalize(static_cast<double>(columns[x]));
+        m_points[x] = QPointF(static_cast<double>(x), static_cast<double>(h) * (1.0 - t));
+    }
+
+    if (m_area_color.alpha() > 0) {
+        QPolygonF filled;
+        filled.reserve(w + 2);
+        filled.append(QPointF(0.0, static_cast<double>(h)));
+        for (int x = 0; x < w; x++) {
+            filled.append(m_points[x]);
+        }
+        filled.append(QPointF(static_cast<double>(w - 1), static_cast<double>(h)));
+        painter->setPen(Qt::NoPen);
+        painter->setBrush(m_area_color);
+        painter->drawPolygon(filled);
+    }
+
+    QPen line(m_line_color);
+    line.setWidthF(1.5);
+    painter->setBrush(Qt::NoBrush);
+    painter->setPen(line);
+    painter->drawPolyline(m_points.constData(), w);
+}
+
+// ------------------------------------------------------------ waterfall ----
+
+WaterfallItem::WaterfallItem(QQuickItem* parent)
+    : QQuickPaintedItem(parent), m_image(kWaterfallWidth, kWaterfallRows, QImage::Format_RGB32) {
+    clearHistory();
+}
+
+WaterfallItem::~WaterfallItem() = default;
+
+void
+WaterfallItem::setModel(SpectrumModel* next) {
+    if (m_model == next) {
+        return;
+    }
+    if (m_model) {
+        disconnect(m_model, nullptr, this, nullptr);
+    }
+    m_model = next;
+    if (m_model) {
+        connect(m_model, &SpectrumModel::frameChanged, this, &WaterfallItem::onFrame);
+        /* Pan and zoom are a source rectangle, so they need a repaint but not a
+         * new row. */
+        connect(m_model, &SpectrumModel::viewChanged, this, [this]() { update(); });
+        connect(m_model, &SpectrumModel::retuned, this, &WaterfallItem::clearHistory);
+    }
+    m_range.reset();
+    clearHistory();
+    Q_EMIT modelChanged();
+}
+
+void
+WaterfallItem::setColdColor(const QColor& color) {
+    if (m_cold_color == color) {
+        return;
+    }
+    m_cold_color = color;
+    Q_EMIT colorsChanged();
+    /* Rows already written hold their old palette, and a half-recolored
+     * waterfall reads as corruption. */
+    clearHistory();
+}
+
+void
+WaterfallItem::setMidColor(const QColor& color) {
+    if (m_mid_color == color) {
+        return;
+    }
+    m_mid_color = color;
+    Q_EMIT colorsChanged();
+    clearHistory();
+}
+
+void
+WaterfallItem::setHotColor(const QColor& color) {
+    if (m_hot_color == color) {
+        return;
+    }
+    m_hot_color = color;
+    Q_EMIT colorsChanged();
+    clearHistory();
+}
+
+void
+WaterfallItem::clearHistory() {
+    m_image.fill(m_cold_color);
+    /* Rows are written at the cursor and the cursor walks backwards, so the
+     * slice above it is always newest-first. */
+    m_cursor = kWaterfallRows - 1;
+    m_range.reset();
+    m_last_frame_index = m_model ? m_model->frameIndex() : 0;
+    update();
+}
+
+QRgb
+WaterfallItem::rampColor(double t) const {
+    if (t <= 0.5) {
+        const double u = t * 2.0;
+        return qRgb(lerp_channel(m_cold_color.red(), m_mid_color.red(), u),
+                    lerp_channel(m_cold_color.green(), m_mid_color.green(), u),
+                    lerp_channel(m_cold_color.blue(), m_mid_color.blue(), u));
+    }
+    const double u = (t - 0.5) * 2.0;
+    return qRgb(lerp_channel(m_mid_color.red(), m_hot_color.red(), u),
+                lerp_channel(m_mid_color.green(), m_hot_color.green(), u),
+                lerp_channel(m_mid_color.blue(), m_hot_color.blue(), u));
+}
+
+void
+WaterfallItem::onFrame() {
+    if (!m_model || !m_model->hasData()) {
+        return;
+    }
+    const quint64 index = m_model->frameIndex();
+    if (index == m_last_frame_index) {
+        return; /* a repaint request, not a new row */
+    }
+    m_last_frame_index = index;
+
+    const int n = m_model->binCount();
+    const QVector<float>& bins = m_model->bins();
+    if (n <= 0 || bins.size() < n) {
+        return;
+    }
+    m_range.update(bins.constData(), n);
+
+    /* Always full span: that is what lets zoom and pan reach back through
+     * history without invalidating it. */
+    QVector<float> columns(kWaterfallWidth);
+    resample_columns(bins.constData(), 0, n, columns.data(), kWaterfallWidth);
+
+    QRgb* row = reinterpret_cast<QRgb*>(m_image.scanLine(m_cursor));
+    for (int x = 0; x < kWaterfallWidth; x++) {
+        row[x] = rampColor(m_range.normalize(static_cast<double>(columns[x])));
+    }
+    m_cursor = (m_cursor - 1 + kWaterfallRows) % kWaterfallRows;
+    update();
+}
+
+void
+WaterfallItem::paint(QPainter* painter) {
+    if (!painter) {
+        return;
+    }
+    const double w = width();
+    const double h = height();
+    if (!(w > 1.0) || !(h > 1.0)) {
+        return;
+    }
+
+    /* Which slice of the full-span rows the viewport is looking at. */
+    double src_x = 0.0;
+    double src_w = kWaterfallWidth;
+    if (m_model && m_model->hasData() && m_model->spanHz() > 0.0) {
+        const double span = m_model->spanHz();
+        const double low = m_model->centerFreqHz() - (span / 2.0);
+        const double frac_lo = (m_model->viewLowHz() - low) / span;
+        const double frac_hi = (m_model->viewHighHz() - low) / span;
+        src_x = frac_lo * kWaterfallWidth;
+        src_w = (frac_hi - frac_lo) * kWaterfallWidth;
+        if (!(src_w > 0.0)) {
+            src_w = kWaterfallWidth;
+            src_x = 0.0;
+        }
+    }
+
+    /* Two blits because the ring wraps: rows above the cursor are the recent
+     * history, rows below it are the older tail. */
+    const int newest_count = kWaterfallRows - 1 - m_cursor;
+    const int older_count = kWaterfallRows - newest_count;
+    const double newest_h = (h * newest_count) / kWaterfallRows;
+
+    painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
+    if (newest_count > 0) {
+        painter->drawImage(QRectF(0.0, 0.0, w, newest_h), m_image,
+                           QRectF(src_x, static_cast<double>(m_cursor + 1), src_w, static_cast<double>(newest_count)));
+    }
+    if (older_count > 0) {
+        painter->drawImage(QRectF(0.0, newest_h, w, h - newest_h), m_image,
+                           QRectF(src_x, 0.0, src_w, static_cast<double>(older_count)));
+    }
+}
+
+} // namespace dsd_qt

--- a/src/ui/qt/spectrum_view_item.cpp
+++ b/src/ui/qt/spectrum_view_item.cpp
@@ -412,13 +412,22 @@ WaterfallItem::onFrame() {
     m_range.update(bins.constData(), n);
 
     /* Always full span: that is what lets zoom and pan reach back through
-     * history without invalidating it. */
-    m_columns.resize(kWaterfallWidth);
-    resample_columns(bins.constData(), 0, n, m_columns.data(), kWaterfallWidth);
+     * history without invalidating it.
+     *
+     * Read straight out of the frame when it is already that wide, which is every
+     * frame the producer publishes: staging it costs a 4 KB copy and a second pass
+     * over the same values, fifteen times a second, to hand the row loop a pointer
+     * it could have had. The resample stays for the odd frame that is not. */
+    const float* columns = bins.constData();
+    if (n != kWaterfallWidth) {
+        m_columns.resize(kWaterfallWidth);
+        resample_columns(bins.constData(), 0, n, m_columns.data(), kWaterfallWidth);
+        columns = m_columns.constData();
+    }
 
     QRgb* row = reinterpret_cast<QRgb*>(m_image.scanLine(m_cursor));
     for (int x = 0; x < kWaterfallWidth; x++) {
-        row[x] = rampColor(m_range.normalize(static_cast<double>(m_columns[x])));
+        row[x] = rampColor(m_range.normalize(static_cast<double>(columns[x])));
     }
     m_cursor = (m_cursor - 1 + kWaterfallRows) % kWaterfallRows;
     m_rows_written++;

--- a/src/ui/qt/spectrum_view_item.cpp
+++ b/src/ui/qt/spectrum_view_item.cpp
@@ -10,6 +10,7 @@
 #include <QRectF>
 #include <Qt>
 #include <cmath>
+#include <dsd-neo/core/wideband_spectrum.h>
 #include <qpen.h>
 
 #include "spectrum_model.h"
@@ -18,10 +19,10 @@ namespace dsd_qt {
 
 namespace {
 
-/* Waterfall history buffer. The width is the largest frame the io layer
- * publishes, so a row never loses resolution the display could have shown; the
- * height is a couple of minutes of history at ~15 FPS. */
-constexpr int kWaterfallWidth = 2048;
+/* Waterfall history buffer. The width is one published frame, so a row keeps
+ * every bin the producer measured and zoom can reach back into history without
+ * resampling; the height is a couple of minutes at the publish rate. */
+constexpr int kWaterfallWidth = DSD_WIDEBAND_SPECTRUM_BINS;
 constexpr int kWaterfallRows = 240;
 
 /**
@@ -195,10 +196,10 @@ SpectrumTraceItem::paint(QPainter* painter) {
     const int count = (hi >= lo) ? (hi - lo + 1) : 1;
 
     m_points.resize(w);
-    QVector<float> columns(w);
-    resample_columns(bins.constData(), lo, count, columns.data(), w);
+    m_columns.resize(w);
+    resample_columns(bins.constData(), lo, count, m_columns.data(), w);
     for (int x = 0; x < w; x++) {
-        const double t = m_range.normalize(static_cast<double>(columns[x]));
+        const double t = m_range.normalize(static_cast<double>(m_columns[x]));
         m_points[x] = QPointF(static_cast<double>(x), static_cast<double>(h) * (1.0 - t));
     }
 
@@ -291,7 +292,12 @@ WaterfallItem::clearHistory() {
      * slice above it is always newest-first. */
     m_cursor = kWaterfallRows - 1;
     m_range.reset();
-    m_last_frame_index = m_model ? m_model->frameIndex() : 0;
+    /* Deliberately not stamped with the model's current frame index. A retune
+     * bumps that index and only then announces the frame captured at the new
+     * center, so claiming it here would drop the first row after every tune. */
+    m_have_row = false;
+    m_last_frame_index = 0;
+    m_rows_written = 0;
     update();
 }
 
@@ -315,10 +321,11 @@ WaterfallItem::onFrame() {
         return;
     }
     const quint64 index = m_model->frameIndex();
-    if (index == m_last_frame_index) {
+    if (m_have_row && index == m_last_frame_index) {
         return; /* a repaint request, not a new row */
     }
     m_last_frame_index = index;
+    m_have_row = true;
 
     const int n = m_model->binCount();
     const QVector<float>& bins = m_model->bins();
@@ -329,14 +336,15 @@ WaterfallItem::onFrame() {
 
     /* Always full span: that is what lets zoom and pan reach back through
      * history without invalidating it. */
-    QVector<float> columns(kWaterfallWidth);
-    resample_columns(bins.constData(), 0, n, columns.data(), kWaterfallWidth);
+    m_columns.resize(kWaterfallWidth);
+    resample_columns(bins.constData(), 0, n, m_columns.data(), kWaterfallWidth);
 
     QRgb* row = reinterpret_cast<QRgb*>(m_image.scanLine(m_cursor));
     for (int x = 0; x < kWaterfallWidth; x++) {
-        row[x] = rampColor(m_range.normalize(static_cast<double>(columns[x])));
+        row[x] = rampColor(m_range.normalize(static_cast<double>(m_columns[x])));
     }
     m_cursor = (m_cursor - 1 + kWaterfallRows) % kWaterfallRows;
+    m_rows_written++;
     update();
 }
 

--- a/src/ui/qt/spectrum_view_item.cpp
+++ b/src/ui/qt/spectrum_view_item.cpp
@@ -6,7 +6,6 @@
 #include "spectrum_view_item.h"
 
 #include <QPainter>
-#include <QPolygonF>
 #include <QRectF>
 #include <Qt>
 #include <cmath>
@@ -107,6 +106,8 @@ SpectrumTraceItem::setModel(SpectrumModel* next) {
         connect(m_model, &SpectrumModel::retuned, this, &SpectrumTraceItem::onRetuned);
     }
     m_range.reset();
+    m_have_frame = false;
+    m_last_frame_index = 0;
     Q_EMIT modelChanged();
     update();
 }
@@ -143,13 +144,34 @@ SpectrumTraceItem::setGridColor(const QColor& color) {
 
 void
 SpectrumTraceItem::onFrame() {
+    /* Folded here rather than in paint(): the range is an EMA that relaxes a few
+     * percent per call, and this slot also runs on viewChanged, so folding at
+     * paint time would advance it at touch rate during a pan and settle the trace
+     * on a different scale than the waterfall shows for the same bins. */
+    if (m_model != nullptr && m_model->hasData()) {
+        const quint64 index = m_model->frameIndex();
+        if (!m_have_frame || index != m_last_frame_index) {
+            m_last_frame_index = index;
+            const int n = m_model->binCount();
+            const QVector<float>& bins = m_model->bins();
+            if (n > 0 && bins.size() >= n) {
+                m_have_frame = true;
+                m_range.update(bins.constData(), n);
+            }
+        }
+    }
     update();
 }
 
 void
 SpectrumTraceItem::onRetuned() {
-    /* The new frequency's noise floor has nothing to do with the old one's. */
+    /* The new frequency's noise floor has nothing to do with the old one's.
+     * The frame stamp goes with it: a retune bumps the model's index before the
+     * frame captured at the new center is announced, so keeping the stamp would
+     * skip the fold for exactly the frame the new range has to be built from. */
     m_range.reset();
+    m_have_frame = false;
+    m_last_frame_index = 0;
     update();
 }
 
@@ -187,7 +209,11 @@ SpectrumTraceItem::paint(QPainter* painter) {
         return;
     }
 
-    m_range.update(bins.constData(), n);
+    /* A model handed over after its first frame has landed announces nothing until
+     * the next one, so seed here rather than draw a flat trace for a frame. */
+    if (!m_range.seeded) {
+        m_range.update(bins.constData(), n);
+    }
 
     const double center = m_model->centerFreqHz();
     const double span = m_model->spanHz();
@@ -195,32 +221,29 @@ SpectrumTraceItem::paint(QPainter* painter) {
     const int hi = spectrum_math::freq_to_bin(center, span, n, m_model->viewHighHz());
     const int count = (hi >= lo) ? (hi - lo + 1) : 1;
 
-    m_points.resize(w);
+    /* Index 0 and w+1 are the polygon's baseline corners; the trace occupies
+     * 1..w, which is where the polyline is drawn from. */
+    m_points.resize(w + 2);
     m_columns.resize(w);
     resample_columns(bins.constData(), lo, count, m_columns.data(), w);
     for (int x = 0; x < w; x++) {
         const double t = m_range.normalize(static_cast<double>(m_columns[x]));
-        m_points[x] = QPointF(static_cast<double>(x), static_cast<double>(h) * (1.0 - t));
+        m_points[x + 1] = QPointF(static_cast<double>(x), static_cast<double>(h) * (1.0 - t));
     }
+    m_points[0] = QPointF(0.0, static_cast<double>(h));
+    m_points[w + 1] = QPointF(static_cast<double>(w - 1), static_cast<double>(h));
 
     if (m_area_color.alpha() > 0) {
-        QPolygonF filled;
-        filled.reserve(w + 2);
-        filled.append(QPointF(0.0, static_cast<double>(h)));
-        for (int x = 0; x < w; x++) {
-            filled.append(m_points[x]);
-        }
-        filled.append(QPointF(static_cast<double>(w - 1), static_cast<double>(h)));
         painter->setPen(Qt::NoPen);
         painter->setBrush(m_area_color);
-        painter->drawPolygon(filled);
+        painter->drawPolygon(m_points.constData(), w + 2);
     }
 
     QPen line(m_line_color);
     line.setWidthF(1.5);
     painter->setBrush(Qt::NoBrush);
     painter->setPen(line);
-    painter->drawPolyline(m_points.constData(), w);
+    painter->drawPolyline(m_points.constData() + 1, w);
 }
 
 // ------------------------------------------------------------ waterfall ----

--- a/src/ui/qt/spectrum_view_item.h
+++ b/src/ui/qt/spectrum_view_item.h
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief The two drawn halves of the spectrum view: live trace and waterfall.
+ *
+ * QQuickPaintedItem rather than QML Canvas or a scene-graph node. Canvas would
+ * marshal a thousand bins into JavaScript fifteen times a second, which is the
+ * slow path on a phone; a QSGNode would be faster still but is a great deal
+ * more code for a workload that is one image blit and one polyline per frame.
+ * These are the first qmlRegisterType'd items in the tree — every other C++
+ * object QML sees is a context property.
+ *
+ * Colors arrive as properties so the screen can bind them to Theme tokens; no
+ * palette decisions are made here.
+ */
+
+#ifndef DSD_NEO_SRC_UI_QT_SPECTRUM_VIEW_ITEM_H_
+#define DSD_NEO_SRC_UI_QT_SPECTRUM_VIEW_ITEM_H_
+
+#include <QColor>
+#include <QImage>
+#include <QList>
+#include <QObject>
+#include <QPointF>
+#include <QQuickPaintedItem>
+#include <QtGlobal>
+#include <qrgb.h>
+
+#include "spectrum_math.h"
+
+class QQuickItem;
+
+namespace dsd_qt {
+
+class SpectrumModel;
+
+/** @brief The instantaneous spectrum, drawn as a filled trace over a faint grid. */
+class SpectrumTraceItem : public QQuickPaintedItem {
+    Q_OBJECT
+    Q_PROPERTY(dsd_qt::SpectrumModel* model READ model WRITE setModel NOTIFY modelChanged)
+    Q_PROPERTY(QColor lineColor READ lineColor WRITE setLineColor NOTIFY colorsChanged)
+    Q_PROPERTY(QColor areaColor READ areaColor WRITE setAreaColor NOTIFY colorsChanged)
+    Q_PROPERTY(QColor gridColor READ gridColor WRITE setGridColor NOTIFY colorsChanged)
+
+  public:
+    explicit SpectrumTraceItem(QQuickItem* parent = nullptr);
+    ~SpectrumTraceItem() override;
+
+    SpectrumModel*
+    model() const {
+        return m_model;
+    }
+
+    void setModel(SpectrumModel* next);
+
+    QColor
+    lineColor() const {
+        return m_line_color;
+    }
+
+    void setLineColor(const QColor& color);
+
+    QColor
+    areaColor() const {
+        return m_area_color;
+    }
+
+    void setAreaColor(const QColor& color);
+
+    QColor
+    gridColor() const {
+        return m_grid_color;
+    }
+
+    void setGridColor(const QColor& color);
+
+    void paint(QPainter* painter) override;
+
+  Q_SIGNALS:
+    void modelChanged();
+    void colorsChanged();
+
+  private:
+    void onFrame();
+    void onRetuned();
+
+    SpectrumModel* m_model = nullptr;
+    QColor m_line_color = QColor(0x22, 0xDC, 0xF5);
+    QColor m_area_color = QColor(0x22, 0xDC, 0xF5, 0x33);
+    QColor m_grid_color = QColor(0x23, 0x2B, 0x3A);
+    spectrum_math::AutoRange m_range;
+    /* Reused across frames: a polyline this wide would otherwise allocate on
+     * every repaint. */
+    QVector<QPointF> m_points;
+};
+
+/** @brief Scrolling history of the spectrum, newest row at the top. */
+class WaterfallItem : public QQuickPaintedItem {
+    Q_OBJECT
+    Q_PROPERTY(dsd_qt::SpectrumModel* model READ model WRITE setModel NOTIFY modelChanged)
+    Q_PROPERTY(QColor coldColor READ coldColor WRITE setColdColor NOTIFY colorsChanged)
+    Q_PROPERTY(QColor midColor READ midColor WRITE setMidColor NOTIFY colorsChanged)
+    Q_PROPERTY(QColor hotColor READ hotColor WRITE setHotColor NOTIFY colorsChanged)
+
+  public:
+    explicit WaterfallItem(QQuickItem* parent = nullptr);
+    ~WaterfallItem() override;
+
+    SpectrumModel*
+    model() const {
+        return m_model;
+    }
+
+    void setModel(SpectrumModel* next);
+
+    QColor
+    coldColor() const {
+        return m_cold_color;
+    }
+
+    void setColdColor(const QColor& color);
+
+    QColor
+    midColor() const {
+        return m_mid_color;
+    }
+
+    void setMidColor(const QColor& color);
+
+    QColor
+    hotColor() const {
+        return m_hot_color;
+    }
+
+    void setHotColor(const QColor& color);
+
+    void paint(QPainter* painter) override;
+
+  Q_SIGNALS:
+    void modelChanged();
+    void colorsChanged();
+
+  private:
+    void onFrame();
+    void clearHistory();
+    QRgb rampColor(double t) const;
+
+    SpectrumModel* m_model = nullptr;
+    QColor m_cold_color = QColor(0x12, 0x16, 0x1E);
+    QColor m_mid_color = QColor(0x22, 0xDC, 0xF5);
+    QColor m_hot_color = QColor(0xEC, 0x1F, 0xDC);
+    spectrum_math::AutoRange m_range;
+    /* Preallocated once. Rows are always written full-span, so zoom and pan are
+     * a source rectangle at paint time and old rows stay correct under both;
+     * only a retune can invalidate them. */
+    QImage m_image;
+    int m_cursor = 0;
+    quint64 m_last_frame_index = 0;
+};
+
+} // namespace dsd_qt
+
+#endif /* DSD_NEO_SRC_UI_QT_SPECTRUM_VIEW_ITEM_H_ */

--- a/src/ui/qt/spectrum_view_item.h
+++ b/src/ui/qt/spectrum_view_item.h
@@ -94,9 +94,18 @@ class SpectrumTraceItem : public QQuickPaintedItem {
     QColor m_grid_color = QColor(0x23, 0x2B, 0x3A);
     spectrum_math::AutoRange m_range;
     /* Both reused across frames: a polyline and a column set this wide would
-     * otherwise allocate twice on every repaint, fifteen times a second. */
+     * otherwise allocate twice on every repaint, fifteen times a second. The
+     * point buffer carries the filled polygon too — its first and last entries
+     * are the two baseline corners, and the polyline is drawn from the middle —
+     * so the area pass does not build a second one of its own. */
     QVector<QPointF> m_points;
     QVector<float> m_columns;
+    /* Which frame the auto-range last folded in. The fold is stateful (a 5%
+     * relaxation per call), so it has to happen once per frame and not once per
+     * repaint: viewChanged repaints at touch rate during a pan, which would
+     * advance the range four times faster than the waterfall's copy of it. */
+    quint64 m_last_frame_index = 0;
+    bool m_have_frame = false;
 };
 
 /** @brief Scrolling history of the spectrum, newest row at the top. */

--- a/src/ui/qt/spectrum_view_item.h
+++ b/src/ui/qt/spectrum_view_item.h
@@ -93,9 +93,10 @@ class SpectrumTraceItem : public QQuickPaintedItem {
     QColor m_area_color = QColor(0x22, 0xDC, 0xF5, 0x33);
     QColor m_grid_color = QColor(0x23, 0x2B, 0x3A);
     spectrum_math::AutoRange m_range;
-    /* Reused across frames: a polyline this wide would otherwise allocate on
-     * every repaint. */
+    /* Both reused across frames: a polyline and a column set this wide would
+     * otherwise allocate twice on every repaint, fifteen times a second. */
     QVector<QPointF> m_points;
+    QVector<float> m_columns;
 };
 
 /** @brief Scrolling history of the spectrum, newest row at the top. */
@@ -140,6 +141,20 @@ class WaterfallItem : public QQuickPaintedItem {
 
     void paint(QPainter* painter) override;
 
+#ifdef DSD_NEO_TEST_HOOKS
+    /**
+     * @brief Rows written since the last history clear.
+     *
+     * The history is a private image, so this is the only way a test can say
+     * whether a frame became a row or was dropped — which is the difference
+     * between a waterfall and a waterfall missing the moment it retuned.
+     */
+    quint64
+    testRowsWritten() const {
+        return m_rows_written;
+    }
+#endif
+
   Q_SIGNALS:
     void modelChanged();
     void colorsChanged();
@@ -158,8 +173,17 @@ class WaterfallItem : public QQuickPaintedItem {
      * a source rectangle at paint time and old rows stay correct under both;
      * only a retune can invalidate them. */
     QImage m_image;
+    /* One row's worth of columns, reused rather than allocated per frame. */
+    QVector<float> m_columns;
     int m_cursor = 0;
+    /* Which frame the newest row was drawn from, and whether there is one at
+     * all. The flag is what keeps clearHistory() from claiming the frame that
+     * is about to arrive: a retune bumps the model's index before the new frame
+     * is announced, so recording that index here would swallow the first row at
+     * the new center — the one row that is certain to be worth seeing. */
     quint64 m_last_frame_index = 0;
+    bool m_have_row = false;
+    quint64 m_rows_written = 0;
 };
 
 } // namespace dsd_qt

--- a/src/ui/qt/spectrum_view_item.h
+++ b/src/ui/qt/spectrum_view_item.h
@@ -171,12 +171,20 @@ class WaterfallItem : public QQuickPaintedItem {
   private:
     void onFrame();
     void clearHistory();
+    void rebuildRamp();
     QRgb rampColor(double t) const;
 
     SpectrumModel* m_model = nullptr;
     QColor m_cold_color = QColor(0x12, 0x16, 0x1E);
     QColor m_mid_color = QColor(0x22, 0xDC, 0xF5);
     QColor m_hot_color = QColor(0xEC, 0x1F, 0xDC);
+    /* The cold-mid-hot ramp evaluated once per palette change rather than once
+     * per bin. Every row is kWaterfallWidth bins and rows arrive at the frame
+     * rate, so the six-channel interpolation was running tens of thousands of
+     * times a second — on a phone — to produce colors drawn from a set this
+     * small. 256 steps is finer than the 8-bit channels can show. */
+    static constexpr int kRampSteps = 256;
+    QRgb m_ramp[kRampSteps] = {};
     spectrum_math::AutoRange m_range;
     /* Preallocated once. Rows are always written full-span, so zoom and pan are
      * a source rectangle at paint time and old rows stay correct under both;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7453,6 +7453,10 @@ if(DSD_HAS_RADIO)
         dsd-neo_test_io_rtl_wideband_spectrum
         io/test_io_rtl_wideband_spectrum.cpp
         ${PROJECT_SOURCE_DIR}/src/io/radio/rtl_wideband_spectrum.cpp
+        # The Hann window the tap uses comes from the project's own window
+        # builder; firdes.cpp is pure math over <math.h>, so compiling it here
+        # keeps this test standalone rather than linking the whole DSP library.
+        ${PROJECT_SOURCE_DIR}/src/dsp/firdes.cpp
     )
     target_compile_definitions(
         dsd-neo_test_io_rtl_wideband_spectrum

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2103,6 +2103,39 @@ if(DSD_ENABLE_QT_UI)
     set_target_properties(dsd-neo_test_ui_qt_persistence PROPERTIES AUTOMOC ON)
     add_test(NAME UI_QT_PERSISTENCE COMMAND dsd-neo_test_ui_qt_persistence)
 
+    # What MetricsModel makes of a decoder snapshot: the readings screens gate
+    # on. The sync hold in particular -- a lock that outlives the decoder finding
+    # anything reads as "it is working" while nothing is being decoded, which is
+    # exactly what shipped once. The frontend boundary is stubbed in the test so
+    # this stays arithmetic over a snapshot rather than a link against the engine.
+    add_executable(
+        dsd-neo_test_ui_qt_metrics_model
+        ui/test_ui_qt_metrics_model.cpp
+        ${PROJECT_SOURCE_DIR}/src/ui/qt/metrics_model.cpp
+    )
+    target_include_directories(
+        dsd-neo_test_ui_qt_metrics_model
+        PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/qt
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_qt_metrics_model
+        PRIVATE
+            Qt6::Core
+            dsd-neo_core
+            dsd-neo_runtime
+            dsd-neo_feature_codec2
+            ${LIBS}
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_qt_metrics_model
+        PRIVATE QT_NO_KEYWORDS DSD_NEO_TEST_HOOKS
+    )
+    set_target_properties(
+        dsd-neo_test_ui_qt_metrics_model
+        PROPERTIES AUTOMOC ON
+    )
+    add_test(NAME UI_QT_METRICS_MODEL COMMAND dsd-neo_test_ui_qt_metrics_model)
+
     # The call-history model's ring ingest, driven against synthetic event
     # rings: the slot/seq row keying, merge-versus-duplicate decisions, the
     # commit_rev rescan gate, and the relaunch (Activity restart) path.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1318,7 +1318,9 @@ add_executable(
     ${PROJECT_SOURCE_DIR}/src/app_control/actions/actions_radio.c
     ${PROJECT_SOURCE_DIR}/src/app_control/actions/actions_trunk.c
     ${PROJECT_SOURCE_DIR}/src/app_control/actions/actions_logging.c
+    ${PROJECT_SOURCE_DIR}/src/app_control/symbol_profile.c
     ${PROJECT_SOURCE_DIR}/src/core/util/enc_lockout.c
+    ${PROJECT_SOURCE_DIR}/src/runtime/decode_mode.c
     ${PROJECT_SOURCE_DIR}/src/runtime/trunk_scan_hooks.c
 )
 target_include_directories(
@@ -1335,6 +1337,8 @@ add_executable(
     dsd-neo_test_app_control_actions_rtl
     ui/test_ui_radio_actions_rtl.c
     ${PROJECT_SOURCE_DIR}/src/app_control/actions/actions_radio.c
+    ${PROJECT_SOURCE_DIR}/src/app_control/symbol_profile.c
+    ${PROJECT_SOURCE_DIR}/src/runtime/decode_mode.c
 )
 target_compile_definitions(
     dsd-neo_test_app_control_actions_rtl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2061,6 +2061,17 @@ add_test(
     COMMAND dsd-neo_test_ui_qt_call_history_merge
 )
 
+# And for the spectrum viewport arithmetic (spectrum_math.h), also header-only
+# and Qt-free: bin<->frequency mapping, pan clamping and the overshoot that
+# turns into a retune, tap snapping, and the pinch anchor. A sign error in any
+# of these lands the receiver on the wrong channel, which no build catches.
+add_executable(dsd-neo_test_ui_qt_spectrum_math ui/test_ui_qt_spectrum_math.cpp)
+target_include_directories(
+    dsd-neo_test_ui_qt_spectrum_math
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/qt
+)
+add_test(NAME UI_QT_SPECTRUM_MATH COMMAND dsd-neo_test_ui_qt_spectrum_math)
+
 # The persistence layer itself (json_store atomic writes, the saved-systems
 # field-map round trip, AppPrefs defaults) is thin Qt code, so unlike the
 # policy tests above it links Qt and is registered only when the Qt frontend
@@ -2184,11 +2195,18 @@ if(DSD_ENABLE_QT_UI)
         # The header is listed so AUTOMOC processes its Q_OBJECT classes into
         # their own generated translation unit, keeping moc output out of the
         # test's.
+        # The spectrum model and its two painted items are compiled in so the
+        # QML drives the production polling, viewport and tap-snapping; only
+        # the frames behind them are canned (ui/qml_spectrum_stub.cpp supplies
+        # the app-control getter, which keeps this target off the engine).
         add_executable(
             dsd-neo_test_ui_qt_qml
             ui/test_ui_qt_qml_main.cpp
             ui/qml_test_context.h
+            ui/qml_spectrum_stub.cpp
             ${PROJECT_SOURCE_DIR}/src/ui/qt/call_history_filter.cpp
+            ${PROJECT_SOURCE_DIR}/src/ui/qt/spectrum_model.cpp
+            ${PROJECT_SOURCE_DIR}/src/ui/qt/spectrum_view_item.cpp
         )
         target_include_directories(
             dsd-neo_test_ui_qt_qml

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2289,6 +2289,11 @@ if(DSD_ENABLE_QT_UI)
             ${PROJECT_SOURCE_DIR}/src/ui/qt/call_history_filter.cpp
             ${PROJECT_SOURCE_DIR}/src/ui/qt/spectrum_model.cpp
             ${PROJECT_SOURCE_DIR}/src/ui/qt/spectrum_view_item.cpp
+            # The decode-chip flag mapping (src/ui/qt/decode_mode_flag.h) is the
+            # production one, so the preset a chip sends is really under test. It
+            # needs the CLI mapping behind it, and that translation unit is
+            # header-only apart from vsnprintf -- it links nothing else in.
+            ${PROJECT_SOURCE_DIR}/src/runtime/decode_mode.c
         )
         target_include_directories(
             dsd-neo_test_ui_qt_qml

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -494,6 +494,12 @@ dsd_neo_add_public_header_smoke_test(
   dsd-neo/core/talkgroup_policy.h
   C
 )
+dsd_neo_add_public_header_smoke_test(
+  dsd-neo_test_headers_public_core_wideband_spectrum
+  HEADERS_PUBLIC_CORE_WIDEBAND_SPECTRUM
+  dsd-neo/core/wideband_spectrum.h
+  C
+)
 
 dsd_neo_add_public_header_smoke_test(
   dsd-neo_test_headers_public_dsp_sync_hamming
@@ -2147,6 +2153,49 @@ if(DSD_ENABLE_QT_UI)
     )
     set_target_properties(dsd-neo_test_ui_qt_session_args PROPERTIES AUTOMOC ON)
     add_test(NAME UI_QT_SESSION_ARGS COMMAND dsd-neo_test_ui_qt_session_args)
+
+    # What the spectrum model does with the frames a producer hands it, and what
+    # the waterfall does with the model: the frame-identity check that keeps a
+    # re-read of an unreplaced frame from scrolling a duplicate row, the history
+    # clear that must not swallow the first frame at a new center, and the tap
+    # snap staying inside the visible window. Only the app-control getter is
+    # stubbed, so the polling and viewport under test are the production ones.
+    # DSD_NEO_TEST_HOOKS exposes the single-poll entry point and the row count;
+    # without them this would have to sleep through publish periods and guess.
+    add_executable(
+        dsd-neo_test_ui_qt_spectrum_model
+        ui/test_ui_qt_spectrum_model.cpp
+        ${PROJECT_SOURCE_DIR}/src/ui/qt/spectrum_model.cpp
+        ${PROJECT_SOURCE_DIR}/src/ui/qt/spectrum_view_item.cpp
+    )
+    target_include_directories(
+        dsd-neo_test_ui_qt_spectrum_model
+        PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/qt
+    )
+    find_package(Qt6 REQUIRED COMPONENTS Gui Quick)
+    target_link_libraries(
+        dsd-neo_test_ui_qt_spectrum_model
+        PRIVATE Qt6::Gui Qt6::Quick
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_qt_spectrum_model
+        PRIVATE QT_NO_KEYWORDS DSD_NEO_TEST_HOOKS
+    )
+    set_target_properties(
+        dsd-neo_test_ui_qt_spectrum_model
+        PROPERTIES AUTOMOC ON
+    )
+    add_test(
+        NAME UI_QT_SPECTRUM_MODEL
+        COMMAND dsd-neo_test_ui_qt_spectrum_model
+    )
+    # A QQuickItem needs an application object, and a CI runner has no display.
+    set_tests_properties(
+        UI_QT_SPECTRUM_MODEL
+        PROPERTIES
+            ENVIRONMENT
+                "QT_QPA_PLATFORM=offscreen;QT_QUICK_BACKEND=software;QT_FORCE_STDERR_LOGGING=1"
+    )
 
     # The QML screens themselves, driven by Qt Quick Test: the call lists keep
     # the latest call in view while the reader is parked at the top, hold their

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7341,6 +7341,28 @@ if(DSD_HAS_RADIO)
     add_test(NAME IO_RTL_DEMOD_CONFIG COMMAND dsd-neo_test_io_rtl_demod_config)
 
     add_executable(
+        dsd-neo_test_io_rtl_wideband_spectrum
+        io/test_io_rtl_wideband_spectrum.cpp
+        ${PROJECT_SOURCE_DIR}/src/io/radio/rtl_wideband_spectrum.cpp
+    )
+    target_compile_definitions(
+        dsd-neo_test_io_rtl_wideband_spectrum
+        PRIVATE DSD_NEO_TEST_HOOKS
+    )
+    target_include_directories(
+        dsd-neo_test_io_rtl_wideband_spectrum
+        PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/io/radio
+    )
+    target_link_libraries(
+        dsd-neo_test_io_rtl_wideband_spectrum
+        PRIVATE dsd-neo_pffft dsd-neo_platform
+    )
+    add_test(
+        NAME IO_RTL_WIDEBAND_SPECTRUM
+        COMMAND dsd-neo_test_io_rtl_wideband_spectrum
+    )
+
+    add_executable(
         dsd-neo_test_io_rtl_ppm_request
         io/test_io_rtl_ppm_request.cpp
     )

--- a/tests/dsp/test_dsp_demod_misc.cpp
+++ b/tests/dsp/test_dsp_demod_misc.cpp
@@ -92,6 +92,44 @@ check_channel_lpf_protected_edges(demod_state* s) {
     return 0;
 }
 
+/*
+ * The channel, not the filter.
+ *
+ * P25 CQPSK runs a deliberately roomier 7250 Hz cutoff than the other 12.5 kHz
+ * profiles, but the channel it protects is still 12.5 kHz. Reporting the cutoff
+ * would widen the spectrum screen's channel column by 2 kHz the moment the
+ * modulation flipped C4FM->CQPSK on the same system, which reads as the receiver
+ * changing its mind about what it is listening to.
+ */
+static int
+test_channel_lpf_protected_edge(void) {
+    const float tol = 0.5f;
+
+    struct {
+        int profile;
+        float want;
+    } cases[] = {
+        {DSD_CH_LPF_PROFILE_WIDE, 8000.0f},
+        {DSD_CH_LPF_PROFILE_6K25, 3125.0f},
+        {DSD_CH_LPF_PROFILE_12K5, 6250.0f},
+        {DSD_CH_LPF_PROFILE_PROVOICE, 6250.0f},
+        {DSD_CH_LPF_PROFILE_P25_C4FM, 6250.0f},
+        {DSD_CH_LPF_PROFILE_P25_CQPSK, 6250.0f},
+        /* An id from a newer build must fall back, not widen unpredictably. */
+        {99, 8000.0f},
+    };
+
+    for (unsigned i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        float got = (float)dsd_channel_lpf_protected_edge_hz(cases[i].profile);
+        if (!approx_eq(got, cases[i].want, tol)) {
+            DSD_FPRINTF(stderr, "protected_edge(%d): got %f want %f\n", cases[i].profile, (double)got,
+                        (double)cases[i].want);
+            return 0;
+        }
+    }
+    return 1;
+}
+
 int
 main(void) {
     demod_state* s = (demod_state*)malloc(sizeof(demod_state));
@@ -99,6 +137,11 @@ main(void) {
         return 1;
     }
     DSD_MEMSET(s, 0, sizeof(*s));
+
+    if (!test_channel_lpf_protected_edge()) {
+        free(s);
+        return 1;
+    }
 
     // deemph_filter: step response
     {

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -1123,6 +1123,32 @@ test_decode_mode_profiles_agree_with_the_sps_hunt_table(void) {
         assert(index >= 0 && index < dsd_frame_sync_test_sps_hunt_profile_count());
         assert(profile.symbol_rate_hz == dsd_frame_sync_test_sps_hunt_profile_rate(index));
         assert(profile.levels == dsd_frame_sync_test_sps_hunt_profile_levels(index));
+
+        /* Checked against what the preset actually writes, because that is what
+         * the hunt and the UI both read back. */
+        static dsd_opts opts;
+        static dsd_state state;
+        reset(&opts, &state);
+        assert(dsd_apply_decode_mode_preset(modes[i], DSD_DECODE_PRESET_PROFILE_CLI, &opts, &state) == 0);
+
+        /* The half the rate/levels comparison cannot see: an index whose row
+         * happens to carry the right numbers is still useless if the hunt never
+         * offers it to this mode's frame set. Analog is the one mode with no
+         * frame set at all and so no candidate anywhere. */
+        if (modes[i] != DSDCFG_MODE_ANALOG) {
+            assert(dsd_frame_sync_test_sps_hunt_profile_has_candidate(&opts, index) == 1);
+        }
+
+        /* The modulation half of the same agreement. A two-level profile runs
+         * GFSK and nothing else, so a preset naming C4FM or QPSK on one is
+         * already a pass behind the demodulator: frame_sync_apply_sps_hunt_profile()
+         * normalises rf_mod to GFSK the moment the hunt lands there and never
+         * touches opts->mod_*, which is what the UI's modulation control binds
+         * to -- and nothing afterwards reconciles the pair. Both readings are
+         * asserted because they are separately reachable and it is exactly their
+         * disagreement that is the defect. */
+        assert(state.rf_mod == dsd_frame_sync_profile_modulation(profile.levels, state.rf_mod));
+        assert(dsd_opts_modulation(&opts) == state.rf_mod);
     }
 
     /* The two NXDN variants are the pair this is most likely to be got wrong on:

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -17,6 +17,7 @@
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/platform/sockets.h>
 #include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/frame_sync_hooks.h>
 #ifdef USE_RADIO
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
@@ -1098,6 +1099,38 @@ test_rtl_symbol_profile_selection(void) {
     assert(dsd_frame_sync_test_rtl_profile_for_sps_index(&opts, &state, 1) == DSD_RTL_STREAM_CHANNEL_PROFILE_6K25);
 }
 
+/*
+ * The decode-mode layer and the SPS hunt each name a symbol rate and a level
+ * count, and the two have to be the same numbers: the mode picks the profile the
+ * hunt then searches from, so a mode claiming 2400/4 while its chosen index means
+ * 4800/4 puts the decoder on one symbol clock and the hunt on another.
+ *
+ * The index also has to be one that can match the mode at all —
+ * frame_sync_sps_profile_has_candidate() offers each profile only to the modes it
+ * carries, so a mode pointed at a profile that never accepts it hunts forever.
+ */
+static void
+test_decode_mode_profiles_agree_with_the_sps_hunt_table(void) {
+    static const dsdneoUserDecodeMode modes[] = {
+        DSDCFG_MODE_AUTO, DSDCFG_MODE_DSTAR,    DSDCFG_MODE_X2TDMA,   DSDCFG_MODE_P25P1,  DSDCFG_MODE_P25P2,
+        DSDCFG_MODE_DMR,  DSDCFG_MODE_DMR_MONO, DSDCFG_MODE_NXDN48,   DSDCFG_MODE_NXDN96, DSDCFG_MODE_DPMR,
+        DSDCFG_MODE_YSF,  DSDCFG_MODE_M17,      DSDCFG_MODE_EDACS_PV, DSDCFG_MODE_TDMA,   DSDCFG_MODE_ANALOG,
+    };
+
+    for (unsigned i = 0; i < sizeof modes / sizeof modes[0]; i++) {
+        const dsd_decode_mode_profile profile = dsd_decode_mode_profile_for(modes[i]);
+        const int index = (int)profile.sps_profile_index;
+        assert(index >= 0 && index < dsd_frame_sync_test_sps_hunt_profile_count());
+        assert(profile.symbol_rate_hz == dsd_frame_sync_test_sps_hunt_profile_rate(index));
+        assert(profile.levels == dsd_frame_sync_test_sps_hunt_profile_levels(index));
+    }
+
+    /* The two NXDN variants are the pair this is most likely to be got wrong on:
+     * they share a preset symbol timing but not a symbol rate. */
+    assert(dsd_decode_mode_profile_for(DSDCFG_MODE_NXDN48).symbol_rate_hz == 2400);
+    assert(dsd_decode_mode_profile_for(DSDCFG_MODE_NXDN96).symbol_rate_hz == 4800);
+}
+
 static void
 test_rtl_p25p2_timing_reconciliation_preserves_cqpsk(void) {
     static dsd_opts opts;
@@ -1630,6 +1663,7 @@ main(void) {
     test_hamming_helpers_find_best_patterns();
 #ifdef USE_RADIO
     test_rtl_symbol_profile_selection();
+    test_decode_mode_profiles_agree_with_the_sps_hunt_table();
     test_rtl_p25p2_timing_reconciliation_preserves_cqpsk();
     test_unlocked_rtl_p25p2_sync_switches_demod_family();
     test_rtl_sps_profiles_apply_and_lock_on_sync();

--- a/tests/io/test_io_rtl_wideband_spectrum.cpp
+++ b/tests/io/test_io_rtl_wideband_spectrum.cpp
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Regression test: the wideband spectrum tap must stay silent until enabled,
+ * clamp its FFT size, publish fftshifted bins whose argmax lands where the
+ * injected tone actually is, throttle its publish rate, and drop the frame on
+ * clear() so a consumer never labels bins with a stale center frequency.
+ */
+
+// LLVM 22/GCC 16 misclassifies these runtime test oracles as compile-time assertions.
+// NOLINTBEGIN(cert-dcl03-c,misc-static-assert)
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include <dsd-neo/io/rtl_stream_c.h>
+
+#include "rtl_wideband_spectrum.h"
+
+namespace {
+
+constexpr uint32_t kCaptureRateHz = 1536000;
+constexpr uint32_t kCenterHz = 851000000;
+constexpr double kToneOffsetHz = 200000.0;
+constexpr int kPairs = 4096;
+
+/* Interleaved float I/Q carrying a single complex tone at `offset_hz`. */
+std::vector<float>
+make_tone(double offset_hz, uint32_t rate_hz, int pairs) {
+    std::vector<float> iq(static_cast<size_t>(pairs) * 2);
+    const double w = 2.0 * M_PI * offset_hz / static_cast<double>(rate_hz);
+    for (int n = 0; n < pairs; n++) {
+        iq[static_cast<size_t>(n) * 2] = static_cast<float>(cos(w * n));
+        iq[static_cast<size_t>(n) * 2 + 1] = static_cast<float>(sin(w * n));
+    }
+    return iq;
+}
+
+int
+argmax_bin(const float* db, int n) {
+    int best = 0;
+    for (int i = 1; i < n; i++) {
+        if (db[i] > db[best]) {
+            best = i;
+        }
+    }
+    return best;
+}
+
+/* Force the next update past the throttle and feed one block. */
+void
+publish_block(const std::vector<float>& iq, uint32_t center_hz) {
+    rtl_wideband_spectrum_test_reset_throttle();
+    rtl_wideband_spectrum_maybe_update(iq.data(), static_cast<int>(iq.size()), kCaptureRateHz, center_hz);
+}
+
+void
+test_size_clamping(void) {
+    assert(rtl_stream_wideband_spectrum_set_size(100) == 256);
+    assert(rtl_stream_wideband_spectrum_get_size() == 256);
+    assert(rtl_stream_wideband_spectrum_set_size(3000) == 2048);
+    assert(rtl_stream_wideband_spectrum_get_size() == 2048);
+    assert(rtl_stream_wideband_spectrum_set_size(500) == 512);
+    assert(rtl_stream_wideband_spectrum_get_size() == 512);
+    assert(rtl_stream_wideband_spectrum_set_size(1024) == 1024);
+}
+
+void
+test_disabled_publishes_nothing(void) {
+    assert(rtl_stream_wideband_spectrum_enabled() == 0);
+
+    const std::vector<float> iq = make_tone(kToneOffsetHz, kCaptureRateHz, kPairs);
+    publish_block(iq, kCenterHz);
+
+    std::vector<float> bins(2048, 0.0f);
+    uint32_t center = 0;
+    uint32_t span = 0;
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) == 0);
+}
+
+void
+test_tone_orientation(void) {
+    rtl_stream_wideband_spectrum_set_enabled(1);
+    assert(rtl_stream_wideband_spectrum_enabled() == 1);
+
+    const int n = rtl_stream_wideband_spectrum_get_size();
+    assert(n == 1024);
+
+    const std::vector<float> iq = make_tone(kToneOffsetHz, kCaptureRateHz, kPairs);
+    publish_block(iq, kCenterHz);
+
+    std::vector<float> bins(2048, 0.0f);
+    uint32_t center = 0;
+    uint32_t span = 0;
+    const int got = rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span);
+    assert(got == n);
+    assert(center == kCenterHz);
+    assert(span == kCaptureRateHz);
+
+    /* Bins are fftshifted: index n/2 is DC, so a +200 kHz tone must sit above it. */
+    const int expected = (n / 2) + static_cast<int>(lrint(kToneOffsetHz / kCaptureRateHz * n));
+    const int peak = argmax_bin(bins.data(), got);
+    assert(peak >= expected - 1 && peak <= expected + 1);
+
+    /* The peak must actually stand out from the noise floor, not just win a tie. */
+    const int far = (n / 4);
+    assert(bins[static_cast<size_t>(peak)] - bins[static_cast<size_t>(far)] > 20.0f);
+}
+
+void
+test_publish_throttle(void) {
+    const std::vector<float> iq = make_tone(kToneOffsetHz, kCaptureRateHz, kPairs);
+    const uint32_t moved_hz = kCenterHz + 1000000u;
+
+    /* Without a throttle reset the block is dropped: the frame keeps its center. */
+    rtl_wideband_spectrum_maybe_update(iq.data(), static_cast<int>(iq.size()), kCaptureRateHz, moved_hz);
+
+    std::vector<float> bins(2048, 0.0f);
+    uint32_t center = 0;
+    uint32_t span = 0;
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) > 0);
+    assert(center == kCenterHz);
+
+    /* Once the throttle is cleared the same block publishes. */
+    publish_block(iq, moved_hz);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) > 0);
+    assert(center == moved_hz);
+}
+
+void
+test_clear_invalidates_frame(void) {
+    std::vector<float> bins(2048, 0.0f);
+    uint32_t center = 0;
+    uint32_t span = 0;
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) > 0);
+
+    rtl_wideband_spectrum_clear();
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) == 0);
+
+    /* ...and stays empty until the demod thread publishes again. */
+    const std::vector<float> iq = make_tone(kToneOffsetHz, kCaptureRateHz, kPairs);
+    publish_block(iq, kCenterHz);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) > 0);
+    assert(center == kCenterHz);
+}
+
+void
+test_short_block_is_skipped(void) {
+    /* Fewer complex pairs than the FFT size must not publish a padded frame. */
+    rtl_wideband_spectrum_clear();
+    const std::vector<float> iq = make_tone(kToneOffsetHz, kCaptureRateHz, 128);
+    publish_block(iq, kCenterHz);
+
+    std::vector<float> bins(2048, 0.0f);
+    uint32_t center = 0;
+    uint32_t span = 0;
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) == 0);
+}
+
+void
+test_disable_drops_frame(void) {
+    const std::vector<float> iq = make_tone(kToneOffsetHz, kCaptureRateHz, kPairs);
+    publish_block(iq, kCenterHz);
+
+    std::vector<float> bins(2048, 0.0f);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), nullptr, nullptr) > 0);
+
+    rtl_stream_wideband_spectrum_set_enabled(0);
+    assert(rtl_stream_wideband_spectrum_enabled() == 0);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), nullptr, nullptr) == 0);
+
+    /* Re-enabling must not resurrect the pre-close frame. */
+    rtl_stream_wideband_spectrum_set_enabled(1);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), nullptr, nullptr) == 0);
+    rtl_stream_wideband_spectrum_set_enabled(0);
+}
+
+void
+test_max_bins_truncation(void) {
+    rtl_stream_wideband_spectrum_set_enabled(1);
+    const std::vector<float> iq = make_tone(kToneOffsetHz, kCaptureRateHz, kPairs);
+    publish_block(iq, kCenterHz);
+
+    std::vector<float> bins(64, 0.0f);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), 64, nullptr, nullptr) == 64);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), 0, nullptr, nullptr) == 0);
+    assert(rtl_stream_wideband_spectrum_get(nullptr, 64, nullptr, nullptr) == 0);
+    rtl_stream_wideband_spectrum_set_enabled(0);
+}
+
+} // namespace
+
+int
+main(void) {
+    test_size_clamping();
+    test_disabled_publishes_nothing();
+    test_tone_orientation();
+    test_publish_throttle();
+    test_clear_invalidates_frame();
+    test_short_block_is_skipped();
+    test_disable_drops_frame();
+    test_max_bins_truncation();
+    (void)fprintf(stdout, "IO_RTL_WIDEBAND_SPECTRUM: ok\n");
+    return 0;
+}
+
+// NOLINTEND(cert-dcl03-c,misc-static-assert)

--- a/tests/io/test_io_rtl_wideband_spectrum.cpp
+++ b/tests/io/test_io_rtl_wideband_spectrum.cpp
@@ -243,9 +243,14 @@ test_a_torn_read_is_not_a_frame(void) {
     assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span, nullptr) > 0);
 
     /* Every attempt tears, so the read never gets a clean copy of anything. */
+    const std::vector<float> held = bins;
     rtl_wideband_spectrum_test_set_tear(1);
     assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span, nullptr) == 0);
     rtl_wideband_spectrum_test_set_tear(0);
+    /* "No frame" has to mean the caller's buffer is untouched. The consumer holds
+     * its last picture across a gap, so a rejected read that had already written
+     * over it would leave torn bins on screen under the previous frame's axis. */
+    assert(bins == held);
 
     /* ...and an untorn read still works afterwards. */
     publish_block(iq, kCenterHz);

--- a/tests/io/test_io_rtl_wideband_spectrum.cpp
+++ b/tests/io/test_io_rtl_wideband_spectrum.cpp
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include <vector>
 
+#include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 
 #include "rtl_wideband_spectrum.h"
@@ -202,7 +203,7 @@ main(void) {
     test_short_block_is_skipped();
     test_disable_drops_frame();
     test_max_bins_truncation();
-    (void)fprintf(stdout, "IO_RTL_WIDEBAND_SPECTRUM: ok\n");
+    (void)DSD_FPRINTF(stdout, "IO_RTL_WIDEBAND_SPECTRUM: ok\n");
     return 0;
 }
 

--- a/tests/io/test_io_rtl_wideband_spectrum.cpp
+++ b/tests/io/test_io_rtl_wideband_spectrum.cpp
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 /*
  * Regression test: the wideband spectrum tap must stay silent until enabled,
- * clamp its FFT size, publish fftshifted bins whose argmax lands where the
- * injected tone actually is, throttle its publish rate, and drop the frame on
- * clear() so a consumer never labels bins with a stale center frequency.
+ * publish fftshifted bins whose argmax lands where the injected tone actually
+ * is, throttle its publish rate, drop the frame on clear() so a consumer never
+ * labels bins with a stale center frequency, refuse a buffer too short to hold
+ * a whole frame, and serialise frames so a consumer can tell a new one from a
+ * re-read.
  */
 
 // LLVM 22/GCC 16 misclassifies these runtime test oracles as compile-time assertions.
@@ -16,6 +18,7 @@
 #include <vector>
 
 #include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/wideband_spectrum.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 
 #include "rtl_wideband_spectrum.h"
@@ -58,17 +61,6 @@ publish_block(const std::vector<float>& iq, uint32_t center_hz) {
 }
 
 void
-test_size_clamping(void) {
-    assert(rtl_stream_wideband_spectrum_set_size(100) == 256);
-    assert(rtl_stream_wideband_spectrum_get_size() == 256);
-    assert(rtl_stream_wideband_spectrum_set_size(3000) == 2048);
-    assert(rtl_stream_wideband_spectrum_get_size() == 2048);
-    assert(rtl_stream_wideband_spectrum_set_size(500) == 512);
-    assert(rtl_stream_wideband_spectrum_get_size() == 512);
-    assert(rtl_stream_wideband_spectrum_set_size(1024) == 1024);
-}
-
-void
 test_disabled_publishes_nothing(void) {
     assert(rtl_stream_wideband_spectrum_enabled() == 0);
 
@@ -78,7 +70,7 @@ test_disabled_publishes_nothing(void) {
     std::vector<float> bins(2048, 0.0f);
     uint32_t center = 0;
     uint32_t span = 0;
-    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) == 0);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span, nullptr) == 0);
 }
 
 void
@@ -86,8 +78,7 @@ test_tone_orientation(void) {
     rtl_stream_wideband_spectrum_set_enabled(1);
     assert(rtl_stream_wideband_spectrum_enabled() == 1);
 
-    const int n = rtl_stream_wideband_spectrum_get_size();
-    assert(n == 1024);
+    const int n = DSD_WIDEBAND_SPECTRUM_BINS;
 
     const std::vector<float> iq = make_tone(kToneOffsetHz, kCaptureRateHz, kPairs);
     publish_block(iq, kCenterHz);
@@ -95,7 +86,8 @@ test_tone_orientation(void) {
     std::vector<float> bins(2048, 0.0f);
     uint32_t center = 0;
     uint32_t span = 0;
-    const int got = rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span);
+    const int got =
+        rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span, nullptr);
     assert(got == n);
     assert(center == kCenterHz);
     assert(span == kCaptureRateHz);
@@ -121,12 +113,12 @@ test_publish_throttle(void) {
     std::vector<float> bins(2048, 0.0f);
     uint32_t center = 0;
     uint32_t span = 0;
-    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) > 0);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span, nullptr) > 0);
     assert(center == kCenterHz);
 
     /* Once the throttle is cleared the same block publishes. */
     publish_block(iq, moved_hz);
-    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) > 0);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span, nullptr) > 0);
     assert(center == moved_hz);
 }
 
@@ -135,15 +127,15 @@ test_clear_invalidates_frame(void) {
     std::vector<float> bins(2048, 0.0f);
     uint32_t center = 0;
     uint32_t span = 0;
-    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) > 0);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span, nullptr) > 0);
 
     rtl_wideband_spectrum_clear();
-    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) == 0);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span, nullptr) == 0);
 
     /* ...and stays empty until the demod thread publishes again. */
     const std::vector<float> iq = make_tone(kToneOffsetHz, kCaptureRateHz, kPairs);
     publish_block(iq, kCenterHz);
-    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) > 0);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span, nullptr) > 0);
     assert(center == kCenterHz);
 }
 
@@ -157,7 +149,7 @@ test_short_block_is_skipped(void) {
     std::vector<float> bins(2048, 0.0f);
     uint32_t center = 0;
     uint32_t span = 0;
-    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span) == 0);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span, nullptr) == 0);
 }
 
 void
@@ -166,28 +158,99 @@ test_disable_drops_frame(void) {
     publish_block(iq, kCenterHz);
 
     std::vector<float> bins(2048, 0.0f);
-    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), nullptr, nullptr) > 0);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), nullptr, nullptr, nullptr) > 0);
 
     rtl_stream_wideband_spectrum_set_enabled(0);
     assert(rtl_stream_wideband_spectrum_enabled() == 0);
-    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), nullptr, nullptr) == 0);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), nullptr, nullptr, nullptr)
+           == 0);
 
     /* Re-enabling must not resurrect the pre-close frame. */
     rtl_stream_wideband_spectrum_set_enabled(1);
-    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), nullptr, nullptr) == 0);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), nullptr, nullptr, nullptr)
+           == 0);
     rtl_stream_wideband_spectrum_set_enabled(0);
 }
 
+/*
+ * A frame is all of the span or none of it. Filling a short buffer with the
+ * bins that fit would hand back the low end of the capture carrying a center
+ * and span that describe the whole of it — an axis wrong by up to a quarter of
+ * the span, on data that looks perfectly plausible.
+ */
 void
-test_max_bins_truncation(void) {
+test_a_short_buffer_is_refused(void) {
     rtl_stream_wideband_spectrum_set_enabled(1);
     const std::vector<float> iq = make_tone(kToneOffsetHz, kCaptureRateHz, kPairs);
     publish_block(iq, kCenterHz);
 
-    std::vector<float> bins(64, 0.0f);
-    assert(rtl_stream_wideband_spectrum_get(bins.data(), 64, nullptr, nullptr) == 64);
-    assert(rtl_stream_wideband_spectrum_get(bins.data(), 0, nullptr, nullptr) == 0);
-    assert(rtl_stream_wideband_spectrum_get(nullptr, 64, nullptr, nullptr) == 0);
+    std::vector<float> bins(DSD_WIDEBAND_SPECTRUM_BINS, 0.0f);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), DSD_WIDEBAND_SPECTRUM_BINS, nullptr, nullptr, nullptr)
+           == DSD_WIDEBAND_SPECTRUM_BINS);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), DSD_WIDEBAND_SPECTRUM_BINS - 1, nullptr, nullptr, nullptr)
+           == 0);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), 64, nullptr, nullptr, nullptr) == 0);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), 0, nullptr, nullptr, nullptr) == 0);
+    assert(rtl_stream_wideband_spectrum_get(nullptr, DSD_WIDEBAND_SPECTRUM_BINS, nullptr, nullptr, nullptr) == 0);
+    rtl_stream_wideband_spectrum_set_enabled(0);
+}
+
+/*
+ * The serial is what lets a consumer polling on its own clock tell a new frame
+ * from a re-read of the one it already drew. Without it a waterfall scrolls a
+ * duplicate row every time the poll wins the race against the publish period.
+ */
+void
+test_the_serial_marks_new_frames_only(void) {
+    rtl_stream_wideband_spectrum_set_enabled(1);
+    const std::vector<float> iq = make_tone(kToneOffsetHz, kCaptureRateHz, kPairs);
+    publish_block(iq, kCenterHz);
+
+    std::vector<float> bins(DSD_WIDEBAND_SPECTRUM_BINS, 0.0f);
+    uint32_t first = 0;
+    uint32_t again = 0;
+    uint32_t next = 0;
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), nullptr, nullptr, &first) > 0);
+    assert(first != 0U);
+
+    /* Re-reading the same published frame must report the same serial... */
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), nullptr, nullptr, &again) > 0);
+    assert(again == first);
+
+    /* ...and a block the throttle lets through must move it on. */
+    publish_block(iq, kCenterHz);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), nullptr, nullptr, &next) > 0);
+    assert(next != first);
+
+    rtl_stream_wideband_spectrum_set_enabled(0);
+}
+
+/*
+ * A copy the writer ran through is not a frame: its bins may straddle two
+ * publishes and the center it came with may belong to either. The consumer
+ * holds its last picture when there is nothing new, so reporting no frame costs
+ * a repaint; reporting a torn one puts a mislabelled row in the history.
+ */
+void
+test_a_torn_read_is_not_a_frame(void) {
+    rtl_stream_wideband_spectrum_set_enabled(1);
+    const std::vector<float> iq = make_tone(kToneOffsetHz, kCaptureRateHz, kPairs);
+    publish_block(iq, kCenterHz);
+
+    std::vector<float> bins(DSD_WIDEBAND_SPECTRUM_BINS, 0.0f);
+    uint32_t center = 0;
+    uint32_t span = 0;
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span, nullptr) > 0);
+
+    /* Every attempt tears, so the read never gets a clean copy of anything. */
+    rtl_wideband_spectrum_test_set_tear(1);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span, nullptr) == 0);
+    rtl_wideband_spectrum_test_set_tear(0);
+
+    /* ...and an untorn read still works afterwards. */
+    publish_block(iq, kCenterHz);
+    assert(rtl_stream_wideband_spectrum_get(bins.data(), static_cast<int>(bins.size()), &center, &span, nullptr) > 0);
+    assert(center == kCenterHz);
     rtl_stream_wideband_spectrum_set_enabled(0);
 }
 
@@ -195,14 +258,15 @@ test_max_bins_truncation(void) {
 
 int
 main(void) {
-    test_size_clamping();
     test_disabled_publishes_nothing();
     test_tone_orientation();
     test_publish_throttle();
     test_clear_invalidates_frame();
     test_short_block_is_skipped();
     test_disable_drops_frame();
-    test_max_bins_truncation();
+    test_a_short_buffer_is_refused();
+    test_the_serial_marks_new_frames_only();
+    test_a_torn_read_is_not_a_frame();
     (void)DSD_FPRINTF(stdout, "IO_RTL_WIDEBAND_SPECTRUM: ok\n");
     return 0;
 }

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -5168,6 +5168,89 @@ test_f_edacs_presets_match_reference_modes(void) {
     return test_rc;
 }
 
+/*
+ * -fA followed by a selector the preset helper never sees.
+ *
+ * The EDACS/ProVoice and M17 selectors are handled by the `-f` case's own chain and
+ * never reach dsd_apply_decode_mode_preset(), so leaving analog-monitor mode is
+ * theirs to do. Left set, opts->analog_only pins the RTL front end to
+ * DSD_DEMOD_OUTPUT_AUDIO_MONITOR (rtl_demod_config.cpp) and suppresses the digital
+ * output stream (dsd_audio.c), so the selector names a protocol that then never
+ * decodes.
+ */
+static int
+test_f_manual_selectors_leave_analog_monitor(void) {
+    static const char* const selectors[] = {"-fp", "-fh", "-fH", "-fe", "-fE", "-fZ", "-fB", "-fP", "-fU"};
+
+    int test_rc = 0;
+    for (size_t i = 0; i < sizeof(selectors) / sizeof(selectors[0]); i++) {
+        dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+        dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+        if (!opts || !state) {
+            free(opts);
+            free(state);
+            DSD_FPRINTF(stderr, "out of memory\n");
+            return 1;
+        }
+
+        initOpts(opts);
+        initState(state);
+
+        char arg0[] = "dsd-neo";
+        char arg1[] = "-fA";
+        char arg2[16] = {0};
+        DSD_SNPRINTF(arg2, sizeof arg2, "%s", selectors[i]);
+        char* argv[] = {arg0, arg1, arg2, NULL};
+
+        int argc_effective = 0;
+        int exit_rc = -1;
+        int rc = dsd_parse_args(3, argv, opts, state, &argc_effective, &exit_rc);
+        if (rc != DSD_PARSE_CONTINUE) {
+            DSD_FPRINTF(stderr, "expected -fA %s rc=%d, got %d (exit_rc=%d)\n", selectors[i], DSD_PARSE_CONTINUE, rc,
+                        exit_rc);
+            test_rc = 1;
+        }
+        if (opts->analog_only != 0 || opts->monitor_input_audio != 0) {
+            DSD_FPRINTF(stderr, "-fA %s left analog monitor on (analog_only=%d monitor_input_audio=%d)\n", selectors[i],
+                        opts->analog_only, opts->monitor_input_audio);
+            test_rc = 1;
+        }
+
+        freeState(state);
+        free(opts);
+        free(state);
+    }
+
+    /* An -f selector no branch handles still changes nothing at all. */
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+    initOpts(opts);
+    initState(state);
+    char arg0[] = "dsd-neo";
+    char arg1[] = "-fA";
+    char arg2[] = "-fQ";
+    char* argv[] = {arg0, arg1, arg2, NULL};
+    int argc_effective = 0;
+    int exit_rc = -1;
+    (void)dsd_parse_args(3, argv, opts, state, &argc_effective, &exit_rc);
+    if (opts->analog_only != 1 || opts->monitor_input_audio != 1) {
+        DSD_FPRINTF(stderr, "an unrecognized -f selector half-left analog monitor (analog_only=%d monitor=%d)\n",
+                    opts->analog_only, opts->monitor_input_audio);
+        test_rc = 1;
+    }
+    freeState(state);
+    free(opts);
+    free(state);
+
+    return test_rc;
+}
+
 static int
 test_f_fr_restores_single_slot_mono_preset(void) {
     static const struct {
@@ -6515,6 +6598,7 @@ main(void) {
     rc |= test_f_ysf_preset_applies_cli_profile();
     rc |= test_f_dpmr_and_m17_presets_match_documented_letters();
     rc |= test_f_edacs_presets_match_reference_modes();
+    rc |= test_f_manual_selectors_leave_analog_monitor();
     rc |= test_f_fr_restores_single_slot_mono_preset();
     rc |= test_f_dmr_preset_selects_gfsk();
     rc |= test_mg_before_f_dmr_keeps_gfsk_lock();

--- a/tests/runtime/test_runtime_decode_mode.c
+++ b/tests/runtime/test_runtime_decode_mode.c
@@ -299,7 +299,11 @@ test_remaining_preset_modes(void) {
         {DSDCFG_MODE_P25P1, DSD_DECODE_PRESET_PROFILE_CLI, "P25p1", 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
         {DSDCFG_MODE_NXDN96, DSD_DECODE_PRESET_PROFILE_INTERACTIVE, "NXDN96", 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 20, 9, 0,
          1},
-        {DSDCFG_MODE_DSTAR, DSD_DECODE_PRESET_PROFILE_CLI, "DSTAR", 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+        /* GFSK, like the other two-level mode below it: D-STAR is GMSK, its symbol
+           profile is 4800/2, and frame_sync_apply_sps_hunt_profile() normalises
+           rf_mod to GFSK the moment the hunt reaches that profile. C4FM here only
+           left the preset a pass behind the demodulator. */
+        {DSDCFG_MODE_DSTAR, DSD_DECODE_PRESET_PROFILE_CLI, "DSTAR", 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1},
         {DSDCFG_MODE_EDACS_PV, DSD_DECODE_PRESET_PROFILE_CLI, "EDACS/PV", 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 5, 2, 2, 1},
         {DSDCFG_MODE_DPMR, DSD_DECODE_PRESET_PROFILE_CLI, "dPMR", 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 20, 9, 0, 1},
         {DSDCFG_MODE_M17, DSD_DECODE_PRESET_PROFILE_CLI, "M17", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1},

--- a/tests/runtime/test_runtime_decode_mode.c
+++ b/tests/runtime/test_runtime_decode_mode.c
@@ -484,6 +484,61 @@ test_symbol_timing_and_inference(void) {
     return 0;
 }
 
+/*
+ * Analog monitor has to be a mode you can leave. Nothing but the analog preset
+ * sets analog_only/monitor_input_audio, so if the other presets do not clear them
+ * dsd_infer_decode_mode_preset() keeps answering ANALOG -- which is what makes
+ * every decode chip in the Qt radio panel render unselected after one visit.
+ */
+static int
+test_analog_monitor_is_not_a_one_way_door(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&state, 0, sizeof state);
+
+    if (dsd_apply_decode_mode_preset(DSDCFG_MODE_ANALOG, DSD_DECODE_PRESET_PROFILE_CLI, &opts, &state) != 0
+        || opts.analog_only != 1 || opts.monitor_input_audio != 1) {
+        DSD_FPRINTF(stderr, "analog preset should select analog monitor\n");
+        return 1;
+    }
+    if (dsd_infer_decode_mode_preset(&opts) != DSDCFG_MODE_ANALOG) {
+        DSD_FPRINTF(stderr, "analog preset should read back as analog\n");
+        return 1;
+    }
+
+    if (dsd_apply_decode_mode_preset(DSDCFG_MODE_DMR, DSD_DECODE_PRESET_PROFILE_CLI, &opts, &state) != 0
+        || opts.analog_only != 0 || opts.monitor_input_audio != 0) {
+        DSD_FPRINTF(stderr, "a later preset should leave analog monitor\n");
+        return 1;
+    }
+    if (dsd_infer_decode_mode_preset(&opts) != DSDCFG_MODE_DMR) {
+        DSD_FPRINTF(stderr, "a later preset should read back as itself\n");
+        return 1;
+    }
+
+    /* The profiled presets go through a different arm of the dispatch. */
+    if (dsd_apply_decode_mode_preset(DSDCFG_MODE_ANALOG, DSD_DECODE_PRESET_PROFILE_CLI, &opts, &state) != 0
+        || dsd_apply_decode_mode_preset(DSDCFG_MODE_AUTO, DSD_DECODE_PRESET_PROFILE_CLI, &opts, &state) != 0
+        || opts.analog_only != 0 || opts.monitor_input_audio != 0) {
+        DSD_FPRINTF(stderr, "the auto preset should leave analog monitor\n");
+        return 1;
+    }
+
+    /* A mode the presets do not implement must change nothing, analog included. */
+    if (dsd_apply_decode_mode_preset(DSDCFG_MODE_ANALOG, DSD_DECODE_PRESET_PROFILE_CLI, &opts, &state) != 0) {
+        DSD_FPRINTF(stderr, "analog preset reapply failed\n");
+        return 1;
+    }
+    if (dsd_apply_decode_mode_preset(DSDCFG_MODE_UNSET, DSD_DECODE_PRESET_PROFILE_CLI, &opts, &state) != -1
+        || opts.analog_only != 1 || opts.monitor_input_audio != 1) {
+        DSD_FPRINTF(stderr, "a rejected mode should not half-leave analog monitor\n");
+        return 1;
+    }
+
+    return 0;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -496,6 +551,7 @@ main(void) {
     rc |= test_cli_preset_mapping_and_guards();
     rc |= test_remaining_preset_modes();
     rc |= test_symbol_timing_and_inference();
+    rc |= test_analog_monitor_is_not_a_one_way_door();
     return rc;
 }
 

--- a/tests/ui/qml/tst_context_fixture.qml
+++ b/tests/ui/qml/tst_context_fixture.qml
@@ -16,7 +16,8 @@ TestCase {
         // The screens the other cases load, plus Theme.qml: the screens pull it
         // in as a singleton and it reads prefs itself.
         var missing = testContext.missingContextKeys(
-            ["HistoryScreen.qml", "MonitorScreen.qml", "SpectrumScreen.qml", "Theme.qml"])
+            ["HistoryScreen.qml", "MonitorScreen.qml", "SpectrumScreen.qml", "ExploreSetupScreen.qml", "RadioSheet.qml",
+             "Theme.qml"])
 
         compare(missing.length, 0,
                 "read by the screens, missing from the fixture: " + missing.join(", "))

--- a/tests/ui/qml/tst_context_fixture.qml
+++ b/tests/ui/qml/tst_context_fixture.qml
@@ -13,9 +13,10 @@ TestCase {
     name: "QmlContextFixtureIsComplete"
 
     function test_01_the_fixture_carries_every_reading_the_screens_read() {
-        // The two screens the other cases load, plus Theme.qml: the screens pull
-        // it in as a singleton and it reads prefs itself.
-        var missing = testContext.missingContextKeys(["HistoryScreen.qml", "MonitorScreen.qml", "Theme.qml"])
+        // The screens the other cases load, plus Theme.qml: the screens pull it
+        // in as a singleton and it reads prefs itself.
+        var missing = testContext.missingContextKeys(
+            ["HistoryScreen.qml", "MonitorScreen.qml", "SpectrumScreen.qml", "Theme.qml"])
 
         compare(missing.length, 0,
                 "read by the screens, missing from the fixture: " + missing.join(", "))

--- a/tests/ui/qml/tst_main_overlay_layering.qml
+++ b/tests/ui/qml/tst_main_overlay_layering.qml
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import QtTest
+
+// The layers over a running session — the wizard, and the spectrum — cover the
+// monitor completely, and both carry a full-width button along the bottom. So
+// does the monitor: "Stop listening" sits at the same rect underneath them.
+//
+// TapHandlers never take exclusive grabs, so covering the monitor is not enough
+// to stop a tap reaching it; only `enabled` does that. Without it one tap on the
+// layer above runs both handlers, and the button the user actually pressed
+// finishes by ending the session. That shipped: "Explore from here" — the one
+// way out of a view-only spectrum — stopped the session instead of offering to
+// hand the tuner over.
+//
+// This asserts the guard, not the geometry: the rects are free to move apart,
+// but nothing underneath an opaque layer should be taking taps regardless.
+Item {
+    id: root
+
+    width: 420
+    height: 900
+
+    Loader {
+        id: appLoader
+
+        anchors.fill: parent
+        source: uiDir + "/Main.qml"
+    }
+
+    TestCase {
+        id: tc
+
+        name: "MainOverlayLayering"
+        when: windowShown
+
+        property var app: null
+        property var monitor: null
+
+        function initTestCase() {
+            tc.app = appLoader.item
+            verify(tc.app !== null, "Main.qml failed to load")
+            tc.monitor = findChild(tc.app, "monitorScreen")
+            verify(tc.monitor !== null, "the monitor screen is missing")
+        }
+
+        function init() {
+            tc.app.spectrumOpen = false
+            tc.app.wizardOpen = false
+        }
+
+        // The baseline the other cases are measured against: with a live session
+        // and nothing over it, the monitor is the screen and takes its own taps.
+        function test_01_the_monitor_takes_taps_when_it_is_the_top_layer() {
+            tryVerify(function () { return tc.monitor.enabled },
+                      2000, "the monitor was inert with nothing covering it")
+        }
+
+        function test_02_the_spectrum_stops_taps_reaching_the_monitor() {
+            tc.app.spectrumOpen = true
+            tryVerify(function () { return !tc.monitor.enabled },
+                      2000, "a tap on the spectrum also reaches the monitor underneath")
+
+            // And closing it hands the screen back, or the monitor would be dead
+            // to touch for the rest of the session.
+            tc.app.spectrumOpen = false
+            tryVerify(function () { return tc.monitor.enabled },
+                      2000, "the monitor stayed inert after the spectrum closed")
+        }
+
+        function test_03_the_wizard_stops_taps_reaching_the_monitor() {
+            tc.app.wizardOpen = true
+            tryVerify(function () { return !tc.monitor.enabled },
+                      2000, "a tap on the wizard also reaches the monitor underneath")
+
+            tc.app.wizardOpen = false
+            tryVerify(function () { return tc.monitor.enabled },
+                      2000, "the monitor stayed inert after the wizard closed")
+        }
+
+        // The wizard opens over the spectrum ("Save as a system"), so both are up
+        // at once. Whichever closes first must not re-arm the monitor while the
+        // other is still covering it.
+        function test_04_closing_one_layer_leaves_the_other_still_covering() {
+            tc.app.spectrumOpen = true
+            tc.app.wizardOpen = true
+            tryVerify(function () { return !tc.monitor.enabled }, 2000)
+
+            tc.app.wizardOpen = false
+            tryVerify(function () { return !tc.monitor.enabled },
+                      2000, "closing the wizard re-armed the monitor under the spectrum")
+
+            tc.app.spectrumOpen = false
+            tryVerify(function () { return tc.monitor.enabled }, 2000)
+        }
+    }
+}

--- a/tests/ui/qml/tst_spectrum_screen.qml
+++ b/tests/ui/qml/tst_spectrum_screen.qml
@@ -37,7 +37,7 @@ Item {
 
         function init() {
             testContext.resetCommands()
-            testContext.setMetric("trunkingEnabled", false)
+            testContext.setMetric("tunerControlled",false)
             // The screen switches production on for itself; wait for the first frame.
             tryVerify(function () { return spectrum.hasData }, 5000,
                       "no spectrum frame arrived")
@@ -87,9 +87,11 @@ Item {
         }
 
         // The engine refuses the tune anyway, but a control that silently does
-        // nothing is worse than one that is visibly unavailable.
+        // nothing is worse than one that is visibly unavailable. True under
+        // trunking and under conventional scanner mode alike — both own the
+        // tuner, and the screen is told only that something does.
         function test_03_trunking_makes_the_screen_view_only() {
-            testContext.setMetric("trunkingEnabled", true)
+            testContext.setMetric("tunerControlled",true)
             var pill = findChild(screenLoader.item, "spectrumStatusPill")
             verify(pill !== null, "the status pill is missing")
             tryVerify(function () { return screenLoader.item.viewOnly })
@@ -99,7 +101,7 @@ Item {
             tc.wait(50)
             compare(testContext.manualTuneCalls(), 0)
 
-            testContext.setMetric("trunkingEnabled", false)
+            testContext.setMetric("tunerControlled",false)
             tryVerify(function () { return !screenLoader.item.viewOnly })
         }
 
@@ -173,7 +175,7 @@ Item {
             for (var i = 1; i <= 5; i++)
                 screen.applyPan(-i * 4, 400)
             verify(spectrum.edgeOvershootHz === 0, "an interior drag reported overshoot")
-            screen.endPan()
+            screen.endPan(false)
             compare(testContext.manualTuneCalls(), 0)
 
             // Off the edge: still no retune until the finger lifts.
@@ -183,8 +185,51 @@ Item {
             verify(spectrum.edgeOvershootHz > 0, "a drag off the edge reported no overshoot")
             compare(testContext.manualTuneCalls(), 0)
 
-            screen.endPan()
+            screen.endPan(false)
             compare(testContext.manualTuneCalls(), 1)
+            compare(spectrum.edgeOvershootHz, 0)
+            spectrum.resetView()
+        }
+
+        // The retune has to land where the finger was heading. Zoomed in, the
+        // viewport is already carried toward one end of the span before it runs
+        // out of capture, so tuning to the overshoot alone would land short and
+        // snap the view backwards, away from the band being dragged toward.
+        function test_08b_an_edge_drag_tunes_to_where_the_view_was_asking_to_be() {
+            var screen = screenLoader.item
+            spectrum.resetView()
+            spectrum.zoom = 4.0
+            screen.panStartOffsetHz = spectrum.viewOffsetHz
+
+            screen.applyPan(-2000, 400)
+            var granted = spectrum.viewOffsetHz
+            var overshoot = spectrum.edgeOvershootHz
+            verify(granted > 0, "the drag was fully absorbed by the overshoot")
+            verify(overshoot > 0, "the drag never reached the edge")
+
+            screen.endPan(false)
+            compare(testContext.manualTuneCalls(), 1)
+            var want = spectrum.centerFreqHz + granted + overshoot
+            verify(Math.abs(testContext.lastManualTuneHz() - want) <= 1,
+                   "tuned to " + testContext.lastManualTuneHz() + " but the view was asking for " + want)
+            spectrum.resetView()
+        }
+
+        // A pinch takes the drag handler's grab, which deactivates it exactly as
+        // a release does. The drift before the second finger landed is not a
+        // request to move the receiver — and at 1x every drift is overshoot, so
+        // acting on it would retune on the way into every zoom.
+        function test_08c_a_pinch_stealing_the_drag_never_retunes() {
+            var screen = screenLoader.item
+            spectrum.resetView()
+            screen.panStartOffsetHz = spectrum.viewOffsetHz
+
+            // A few pixels of drift at 1x, where there is nowhere to pan.
+            screen.applyPan(-20, 400)
+            verify(spectrum.edgeOvershootHz !== 0, "a 1x drag reported no overshoot")
+
+            screen.endPan(true)
+            compare(testContext.manualTuneCalls(), 0)
             compare(spectrum.edgeOvershootHz, 0)
             spectrum.resetView()
         }

--- a/tests/ui/qml/tst_spectrum_screen.qml
+++ b/tests/ui/qml/tst_spectrum_screen.qml
@@ -183,6 +183,47 @@ Item {
             screen.exploring = true
         }
 
+        // The way *into* view-only, and the inverse of the two cases above: having
+        // found a control channel by hand, hand the tuner to trunking and let it
+        // follow the system from there. Offered only where trunking has something
+        // to follow — a lock on M17 is still a lock, and a button that does
+        // nothing teaches the user that the app is broken.
+        function test_03f_follow_this_system_hands_the_tuner_to_trunking() {
+            var screen = screenLoader.item
+            var button = findChild(screen, "spectrumFollowSystem")
+            verify(button !== null, "the follow-this-system button is missing")
+
+            // Exploring, but parked on noise: nothing to follow yet.
+            screen.exploring = true
+            testContext.setMetric("trunkableSync",false)
+            tryVerify(function () { return !button.visible },
+                      2000, "trunking was offered with nothing to follow")
+
+            // A lock on a trunked protocol is what makes the offer real.
+            testContext.setMetric("trunkableSync",true)
+            tryVerify(function () { return button.visible },
+                      2000, "a control channel did not bring up the offer")
+
+            button.clicked()
+            compare(testContext.setTrunkingCalls(), 1)
+            compare(testContext.lastSetTrunking(), true, "the button asked to stop trunking")
+
+            // And it is gone the moment there is nothing left to ask for: on a
+            // saved system the tuner was never the user's to give, and once
+            // trunking holds it the escape hatch is the only thing left to offer.
+            screen.exploring = false
+            tryVerify(function () { return !button.visible },
+                      2000, "a saved-system session offered to start trunking")
+
+            screen.exploring = true
+            testContext.setMetric("tunerControlled",true)
+            tryVerify(function () { return !button.visible },
+                      2000, "trunking was offered while something already held the tuner")
+
+            testContext.setMetric("tunerControlled",false)
+            testContext.setMetric("trunkableSync",false)
+        }
+
         // The monitor's copy of this line is underneath this layer, so a refused
         // tune would otherwise be silent here.
         function test_03b_the_engine_answer_is_visible_on_this_screen() {

--- a/tests/ui/qml/tst_spectrum_screen.qml
+++ b/tests/ui/qml/tst_spectrum_screen.qml
@@ -762,5 +762,77 @@ Item {
                    "the axis did not change with the zoom")
             spectrum.resetView()
         }
+
+        // Where the receiver is, on a picture whose whole point is showing where
+        // signals are. The frame's center bin IS the tuned frequency, so at 1x
+        // this sits mid-screen and only moves once the view is panned or zoomed.
+        function test_22_the_marker_sits_where_the_receiver_is() {
+            var marker = findChild(screenLoader.item, "spectrumTunerMarker")
+            verify(marker !== null, "the tuner marker is missing")
+            verify(marker.onScreen, "the marker is off screen at rest")
+            verify(Math.abs(marker.xFraction - 0.5) < 0.01,
+                   "at rest the marker is at " + marker.xFraction + ", not mid-screen")
+
+            // Pan the viewport and the marker must travel with the spectrum.
+            spectrum.zoom = 4.0
+            spectrum.viewOffsetHz = spectrum.spanHz * 0.1
+            var want = (spectrum.centerFreqHz - spectrum.viewLowHz) / spectrum.viewSpanHz
+            verify(Math.abs(marker.xFraction - want) < 0.001,
+                   "panned, the marker is at " + marker.xFraction + " not " + want)
+            spectrum.resetView()
+        }
+
+        // The column is the channel the demodulator is filtering, so it has to be
+        // that wide against the view — not a fixed number of pixels that would lie
+        // at every zoom but one.
+        function test_23_the_channel_column_is_as_wide_as_the_channel() {
+            var marker = findChild(screenLoader.item, "spectrumTunerMarker")
+            testContext.setMetric("channelBandwidthHz", 12500)
+            var want = 12500 / spectrum.viewSpanHz
+            verify(Math.abs(marker.bandWidthFraction - want) < 1e-6,
+                   "column is " + marker.bandWidthFraction + " of the view, want " + want)
+
+            // Zoomed 4x the same channel covers four times the screen.
+            spectrum.zoom = 4.0
+            want = 12500 / spectrum.viewSpanHz
+            verify(Math.abs(marker.bandWidthFraction - want) < 1e-6, "the column ignored the zoom")
+            spectrum.resetView()
+        }
+
+        // Before the demodulator reports a profile there is no honest width to
+        // draw. The line still says where the receiver is; the column says nothing
+        // rather than claiming zero width.
+        function test_24_an_unknown_channel_width_draws_no_column() {
+            var marker = findChild(screenLoader.item, "spectrumTunerMarker")
+            testContext.setMetric("channelBandwidthHz", 0)
+            compare(marker.bandWidthFraction, 0)
+            verify(marker.onScreen, "the marker vanished with the column")
+            testContext.setMetric("channelBandwidthHz", 12500)
+        }
+
+        // Zoomed in and panned to the far edge, the receiver is genuinely not on
+        // screen. Drawing the marker clamped to the edge would put it on a carrier
+        // it is not tuned to, so it hides and an edge hint points the way back.
+        function test_25_the_marker_hides_when_the_receiver_is_off_screen() {
+            var marker = findChild(screenLoader.item, "spectrumTunerMarker")
+            spectrum.zoom = 8.0
+            spectrum.viewOffsetHz = spectrum.spanHz
+            verify(!marker.onScreen, "the marker claims to be on screen at the far edge")
+            var hint = findChild(screenLoader.item, "spectrumTunerEdgeHint")
+            verify(hint !== null && hint.visible, "nothing points back toward the receiver")
+            spectrum.resetView()
+            verify(marker.onScreen, "the marker did not come back")
+        }
+
+        // Locked to a saved system, or with trunking holding the tuner, is
+        // exactly when "what am I on?" matters most — so the marker belongs to
+        // the picture, not to the tuning controls that disappear in view-only.
+        function test_25b_the_marker_survives_view_only() {
+            var marker = findChild(screenLoader.item, "spectrumTunerMarker")
+            testContext.setMetric("tunerControlled", true)
+            verify(screenLoader.item.viewOnly, "the screen did not go view-only")
+            verify(marker.visible && marker.onScreen, "the marker vanished in view-only")
+            testContext.setMetric("tunerControlled", false)
+        }
     }
 }

--- a/tests/ui/qml/tst_spectrum_screen.qml
+++ b/tests/ui/qml/tst_spectrum_screen.qml
@@ -901,13 +901,35 @@ Item {
             var rail = findChild(screenLoader.item, "spectrumBandRail")
             rail.beginDrag()
             rail.dragBy(-100000, 400)
-            verify(rail.pendingHz >= 24.0e6 - 1, "the rail went below the tuner's low end")
+            verify(Math.abs(rail.pendingHz - 24.0e6) <= 1,
+                   "a huge drag down landed at " + rail.pendingHz + ", not the tuner's low limit")
             rail.endDrag(true)
 
             rail.beginDrag()
             rail.dragBy(100000, 400)
-            verify(rail.pendingHz <= 1766.0e6 + 1, "the rail went above the tuner's high end")
+            verify(Math.abs(rail.pendingHz - 1766.0e6) <= 1,
+                   "a huge drag up landed at " + rail.pendingHz + ", not the tuner's high limit")
             rail.endDrag(true)
+        }
+
+        // Near a tuner limit the window stops sliding and the knob moves off centre
+        // instead — the alternative is a window running off the end of what the
+        // hardware can reach, with the receiver still nominally in the middle of it.
+        function test_30b_the_window_stops_at_the_tuner_ends_and_the_knob_moves() {
+            var rail = findChild(screenLoader.item, "spectrumBandRail")
+            var was = rail.tunedHz
+
+            rail.tunedHz = 30.0e6
+            verify(Math.abs(rail.lowHz - 24.0e6) <= 1, "the window ran below the tuner's low end")
+            verify(Math.abs((rail.highHz - rail.lowHz) - rail.windowHz) <= 1,
+                   "the window narrowed instead of sliding")
+
+            rail.tunedHz = 1760.0e6
+            verify(Math.abs(rail.highHz - 1766.0e6) <= 1, "the window ran above the tuner's high end")
+            verify(Math.abs((rail.highHz - rail.lowHz) - rail.windowHz) <= 1,
+                   "the window narrowed instead of sliding")
+
+            rail.tunedHz = was
         }
 
         // Touching the rail is taking over, exactly like touching the spectrum.

--- a/tests/ui/qml/tst_spectrum_screen.qml
+++ b/tests/ui/qml/tst_spectrum_screen.qml
@@ -942,5 +942,53 @@ Item {
             verify(!screen.sweeping, "the sweep survived a rail grab")
             rail.endDrag(true)
         }
+
+        // The handler itself, not just the arithmetic behind it. Every other rail case
+        // calls the drag functions directly, so deleting the DragHandler would leave
+        // them all green — and a rail that looks draggable and is not is precisely the
+        // defect this control was built to remove.
+        function test_33_the_rail_handler_is_actually_wired() {
+            var rail = findChild(screenLoader.item, "spectrumBandRail")
+            mouseDrag(rail, rail.width * 0.5, rail.height / 2, rail.width * 0.25, 0)
+            tryVerify(function () { return testContext.manualTuneCalls() === 1 }, 5000,
+                      "dragging the rail itself never asked for a tune")
+        }
+
+        // The number being steered must not snap back to the old frequency the instant
+        // the finger lifts. A retune blocks the engine up to 500 ms, and a readout that
+        // reverts and then re-applies reads as the drag having been refused.
+        //
+        // The final assignment below sets rail.tunedHz directly, which detaches its
+        // binding to screen.tunedHz for the rest of the run (a known trap already in
+        // play by test_30b above) — and unlike test_30b, this does not restore the
+        // original value afterward, so it leaves the rail off by the drag amount for
+        // anything that runs later. Kept last in the file so nothing added below it
+        // casually assumes the binding still lives.
+        //
+        // That said, "last in the file" is not "last to run": TestCase sorts its
+        // test_* functions in ascending alphabetical order of their name rather than
+        // file order (TestCase.qml documents this), and "test_32" sorts and runs
+        // before "test_33" regardless of which is written first. test_33 tolerates
+        // running afterward on purpose — it only asserts that dragging the handle asks
+        // for one tune and never reads rail.tunedHz, so the value this test leaves
+        // behind does not reach it.
+        function test_32_the_preview_holds_through_the_release() {
+            var rail = findChild(screenLoader.item, "spectrumBandRail")
+            var readout = findChild(screenLoader.item, "spectrumCenterReadout")
+            rail.beginDrag()
+            rail.dragBy(120, 400)
+            var want = rail.pendingHz
+            rail.endDrag(false)
+
+            verify(rail.settling, "the rail stopped previewing the moment the drag ended")
+            verify(Math.abs(rail.displayHz - want) <= 1,
+                   "after release the rail shows " + rail.displayHz + ", not the requested " + want)
+            verify(readout.text.indexOf((want / 1.0e6).toFixed(2)) === 0,
+                   "the readout reverted to " + readout.text + " before the tune landed")
+
+            // The tuner arriving is what ends the preview.
+            rail.tunedHz = want
+            verify(!rail.settling, "the preview outlived the tune landing")
+        }
     }
 }

--- a/tests/ui/qml/tst_spectrum_screen.qml
+++ b/tests/ui/qml/tst_spectrum_screen.qml
@@ -834,5 +834,91 @@ Item {
             verify(marker.visible && marker.onScreen, "the marker vanished in view-only")
             testContext.setMetric("tunerControlled", false)
         }
+
+        // The rail looked like a slider and was not one — you could not drag it,
+        // and it clamped to a band the tuner reaches far outside of. It is now a
+        // coarse tuner over a local window, and the ONLY hard stops are the
+        // tuner's own.
+        function test_26_the_rail_window_follows_the_receiver() {
+            var rail = findChild(screenLoader.item, "spectrumBandRail")
+            verify(rail !== null, "the band rail is missing")
+            verify(Math.abs(rail.lowHz - (rail.tunedHz - rail.windowHz / 2)) < 1,
+                   "the window is not centred on the receiver")
+            verify(Math.abs((rail.highHz - rail.lowHz) - rail.windowHz) < 1,
+                   "the window is not one window wide")
+        }
+
+        // One retune, on release. A tune per drag frame would block the engine
+        // thread up to 500 ms each time.
+        function test_27_a_rail_drag_retunes_once_on_release() {
+            var rail = findChild(screenLoader.item, "spectrumBandRail")
+            var from = rail.tunedHz
+
+            rail.beginDrag()
+            for (var i = 1; i <= 5; i++)
+                rail.dragBy(i * 20, 400)
+            compare(testContext.manualTuneCalls(), 0)
+
+            var want = rail.pendingHz
+            verify(want > from, "dragging right did not walk up the band")
+            rail.endDrag(false)
+            compare(testContext.manualTuneCalls(), 1)
+            verify(Math.abs(testContext.lastManualTuneHz() - want) <= 1,
+                   "tuned to " + testContext.lastManualTuneHz() + " but the rail asked for " + want)
+        }
+
+        // The big mono readout is the number being steered, so it has to show the
+        // pending frequency — and show that it is pending.
+        function test_28_the_readout_previews_the_pending_frequency() {
+            var rail = findChild(screenLoader.item, "spectrumBandRail")
+            var readout = findChild(screenLoader.item, "spectrumCenterReadout")
+            var atRest = readout.text
+
+            rail.beginDrag()
+            rail.dragBy(120, 400)
+            verify(readout.text !== atRest, "the readout ignored the drag")
+            verify(readout.text.indexOf((rail.pendingHz / 1.0e6).toFixed(2)) === 0,
+                   "the readout shows " + readout.text + " not the pending " + rail.pendingHz)
+            compare(testContext.manualTuneCalls(), 0)
+
+            rail.endDrag(false)
+            verify(!rail.dragging, "the rail is still dragging after release")
+        }
+
+        // A drag that ended for any reason other than the finger lifting is not a
+        // request to move the receiver.
+        function test_29_a_cancelled_rail_drag_never_retunes() {
+            var rail = findChild(screenLoader.item, "spectrumBandRail")
+            rail.beginDrag()
+            rail.dragBy(200, 400)
+            rail.endDrag(true)
+            compare(testContext.manualTuneCalls(), 0)
+        }
+
+        // The tuner's own limits are the only wall. Dragging past one stops there
+        // rather than offering a frequency nothing can reach.
+        function test_30_the_rail_clamps_at_the_tuner_limits() {
+            var rail = findChild(screenLoader.item, "spectrumBandRail")
+            rail.beginDrag()
+            rail.dragBy(-100000, 400)
+            verify(rail.pendingHz >= 24.0e6 - 1, "the rail went below the tuner's low end")
+            rail.endDrag(true)
+
+            rail.beginDrag()
+            rail.dragBy(100000, 400)
+            verify(rail.pendingHz <= 1766.0e6 + 1, "the rail went above the tuner's high end")
+            rail.endDrag(true)
+        }
+
+        // Touching the rail is taking over, exactly like touching the spectrum.
+        function test_31_grabbing_the_rail_stops_a_sweep() {
+            var screen = screenLoader.item
+            var rail = findChild(screen, "spectrumBandRail")
+            screen.startSweep()
+            verify(screen.sweeping, "the sweep did not start")
+            rail.beginDrag()
+            verify(!screen.sweeping, "the sweep survived a rail grab")
+            rail.endDrag(true)
+        }
     }
 }

--- a/tests/ui/qml/tst_spectrum_screen.qml
+++ b/tests/ui/qml/tst_spectrum_screen.qml
@@ -835,6 +835,19 @@ Item {
             testContext.setMetric("tunerControlled", false)
         }
 
+        // The fractions are covered; the pixels are not. Dropping the centring term
+        // would leave every other marker case green while the column sat half its own
+        // width off the carrier it is naming.
+        function test_25c_the_column_is_centred_on_the_hairline() {
+            var marker = findChild(screenLoader.item, "spectrumTunerMarker")
+            var column = findChild(screenLoader.item, "spectrumTunerColumn")
+            var hairline = findChild(screenLoader.item, "spectrumTunerHairline")
+            verify(column !== null && hairline !== null, "the marker's parts are missing")
+            verify(Math.abs((column.x + column.width / 2) - (hairline.x + hairline.width / 2)) <= 1,
+                   "the column centre is at " + (column.x + column.width / 2)
+                   + " but the hairline is at " + (hairline.x + hairline.width / 2))
+        }
+
         // The rail looked like a slider and was not one — you could not drag it,
         // and it clamped to a band the tuner reaches far outside of. It is now a
         // coarse tuner over a local window, and the ONLY hard stops are the

--- a/tests/ui/qml/tst_spectrum_screen.qml
+++ b/tests/ui/qml/tst_spectrum_screen.qml
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import QtTest
+
+// Tap-to-tune is the one thing on this screen that moves hardware, and the two
+// ways it can be wrong are both invisible to a C++ model test: a tap could map
+// to the wrong frequency, or the trunking gate could be bound to something that
+// never goes false. Both live in binding expressions and handler wiring.
+Item {
+    id: root
+
+    width: 420
+    height: 900
+
+    Loader {
+        id: screenLoader
+
+        anchors.fill: parent
+        source: uiDir + "/SpectrumScreen.qml"
+    }
+
+    TestCase {
+        id: tc
+
+        name: "SpectrumScreenTapToTune"
+        when: windowShown
+
+        property var area: null
+
+        function initTestCase() {
+            verify(screenLoader.item !== null, "SpectrumScreen.qml failed to load")
+            tc.area = findChild(screenLoader.item, "spectrumTapArea")
+            verify(tc.area !== null, "the gesture area is missing")
+        }
+
+        function init() {
+            testContext.resetCommands()
+            testContext.setMetric("trunkingEnabled", false)
+            // The screen switches production on for itself; wait for the first frame.
+            tryVerify(function () { return spectrum.hasData }, 5000,
+                      "no spectrum frame arrived")
+            spectrum.resetView()
+        }
+
+        // x of a frequency in the current view, in the gesture area's coordinates.
+        function xOf(hz) {
+            return ((hz - spectrum.viewLowHz) / spectrum.viewSpanHz) * tc.area.width
+        }
+
+        function test_01_the_screen_reads_the_tuned_frequency() {
+            var readout = findChild(screenLoader.item, "spectrumCenterReadout")
+            verify(readout !== null, "the frequency readout is missing")
+            compare(readout.text, (spectrum.centerFreqHz / 1.0e6).toFixed(4) + " MHz")
+        }
+
+        // A fingertip is far wider than a channel, so a tap that lands near a
+        // signal has to mean that signal. 18 kHz off is well inside the 25 kHz
+        // snap window at 1x, and far enough out that a tap taken literally would
+        // land a dozen bins away.
+        function test_02_a_tap_beside_a_signal_snaps_onto_it() {
+            var peak = testContext.spectrumPeakHz()
+            mouseClick(tc.area, tc.xOf(peak - 18000), tc.area.height * 0.75)
+
+            tryVerify(function () { return testContext.manualTuneCalls() === 1 }, 5000,
+                      "the tap did not ask for a tune")
+            var asked = testContext.lastManualTuneHz()
+            // One bin of slack (1.5 kHz at this span) and no more.
+            verify(Math.abs(asked - peak) <= 1500,
+                   "tuned to " + asked + " but the peak is at " + peak)
+        }
+
+        // ...and the snap is a window, not a magnet. A tap on empty spectrum
+        // must tune where the finger went down, or a deliberate move to a quiet
+        // channel would be dragged back to whatever was loudest nearby.
+        function test_02b_a_tap_far_from_a_signal_stays_where_it_landed() {
+            var peak = testContext.spectrumPeakHz()
+            var quiet = peak - 200000
+            mouseClick(tc.area, tc.xOf(quiet), tc.area.height * 0.75)
+
+            tryVerify(function () { return testContext.manualTuneCalls() === 1 }, 5000,
+                      "the tap did not ask for a tune")
+            var asked = testContext.lastManualTuneHz()
+            verify(Math.abs(asked - quiet) <= 4000,
+                   "tuned to " + asked + " but the tap was at " + quiet)
+        }
+
+        // The engine refuses the tune anyway, but a control that silently does
+        // nothing is worse than one that is visibly unavailable.
+        function test_03_trunking_makes_the_screen_view_only() {
+            testContext.setMetric("trunkingEnabled", true)
+            var pill = findChild(screenLoader.item, "spectrumStatusPill")
+            verify(pill !== null, "the status pill is missing")
+            tryVerify(function () { return screenLoader.item.viewOnly })
+
+            mouseClick(tc.area, tc.xOf(testContext.spectrumPeakHz()), tc.area.height * 0.75)
+            // Asserting an absence, so give the handler the passes it would need.
+            tc.wait(50)
+            compare(testContext.manualTuneCalls(), 0)
+
+            testContext.setMetric("trunkingEnabled", false)
+            tryVerify(function () { return !screenLoader.item.viewOnly })
+        }
+
+        // The monitor's copy of this line is underneath this layer, so a refused
+        // tune would otherwise be silent here.
+        function test_03b_the_engine_answer_is_visible_on_this_screen() {
+            var toast = findChild(screenLoader.item, "spectrumToast")
+            verify(toast !== null, "the engine-message line is missing")
+
+            testContext.setMetric("uiMessage", "")
+            tryVerify(function () { return !toast.visible })
+
+            testContext.setMetric("uiMessage", "Trunking active: tap-to-tune disabled")
+            tryVerify(function () { return toast.visible })
+
+            testContext.setMetric("uiMessage", "")
+            tryVerify(function () { return !toast.visible })
+        }
+
+        // Panning inside the span is free; only a pan that ran out of capture
+        // bandwidth asks the hardware to move, and only once, on release.
+        function test_04_panning_inside_the_span_never_retunes() {
+            spectrum.zoom = 4.0
+            spectrum.viewOffsetHz = 100000
+            compare(spectrum.edgeOvershootHz, 0)
+            tc.wait(50)
+            compare(testContext.manualTuneCalls(), 0)
+        }
+
+        function test_05_panning_past_the_edge_reports_the_overshoot() {
+            spectrum.zoom = 1.0
+            spectrum.viewOffsetHz = 400000
+            // Fully zoomed out there is nowhere to go, so all of it is overshoot.
+            verify(spectrum.edgeOvershootHz > 0)
+            spectrum.clearOvershoot()
+            compare(spectrum.edgeOvershootHz, 0)
+        }
+
+        // A pinch that moves the signal out from under the fingers reads as
+        // broken, so the anchor frequency has to survive the zoom.
+        function test_07_a_pinch_zooms_around_its_anchor() {
+            var screen = screenLoader.item
+            spectrum.resetView()
+            screen.pinchStartZoom = spectrum.zoom
+            screen.pinchAnchorX = 0.25
+            var anchorHz = spectrum.viewLowHz + (0.25 * spectrum.viewSpanHz)
+
+            screen.applyPinch(4.0)
+
+            compare(spectrum.zoom, 4.0)
+            var afterHz = spectrum.viewLowHz + (0.25 * spectrum.viewSpanHz)
+            verify(Math.abs(afterHz - anchorHz) < 1.0,
+                   "the anchor moved from " + anchorHz + " to " + afterHz)
+
+            // And the model owns the limit, whatever the fingers ask for.
+            screen.applyPinch(100.0)
+            compare(spectrum.zoom, 8.0)
+            screen.applyPinch(0.001)
+            compare(spectrum.zoom, 1.0)
+            spectrum.resetView()
+        }
+
+        // A drag is free while it stays inside the capture span, and asks for
+        // exactly one retune when it runs off the edge — on release, not per frame.
+        function test_08_a_drag_retunes_once_and_only_off_the_edge() {
+            var screen = screenLoader.item
+            spectrum.zoom = 4.0
+            screen.panStartOffsetHz = spectrum.viewOffsetHz
+
+            // Well inside the span: many drag frames, no retune.
+            for (var i = 1; i <= 5; i++)
+                screen.applyPan(-i * 4, 400)
+            verify(spectrum.edgeOvershootHz === 0, "an interior drag reported overshoot")
+            screen.endPan()
+            compare(testContext.manualTuneCalls(), 0)
+
+            // Off the edge: still no retune until the finger lifts.
+            screen.panStartOffsetHz = spectrum.viewOffsetHz
+            for (var j = 1; j <= 5; j++)
+                screen.applyPan(-j * 400, 400)
+            verify(spectrum.edgeOvershootHz > 0, "a drag off the edge reported no overshoot")
+            compare(testContext.manualTuneCalls(), 0)
+
+            screen.endPan()
+            compare(testContext.manualTuneCalls(), 1)
+            compare(spectrum.edgeOvershootHz, 0)
+            spectrum.resetView()
+        }
+
+        // The axis has to follow the viewport, not freeze on the first frame.
+        function test_06_the_axis_labels_follow_the_zoom() {
+            spectrum.resetView()
+            var wide = spectrum.axisTicks(5)
+            verify(wide.length > 0, "no axis labels at 1x")
+
+            spectrum.zoom = 8.0
+            var tight = spectrum.axisTicks(5)
+            verify(tight.length > 0, "no axis labels at 8x")
+            // A narrower window means finer steps between labels.
+            verify(tight[0].freqHz !== wide[0].freqHz || tight.length !== wide.length,
+                   "the axis did not change with the zoom")
+            spectrum.resetView()
+        }
+    }
+}

--- a/tests/ui/qml/tst_spectrum_screen.qml
+++ b/tests/ui/qml/tst_spectrum_screen.qml
@@ -555,8 +555,9 @@ Item {
             verify(!panel.visible)
         }
 
-        // Each control asks the engine for an absolute value derived from what the
-        // engine currently reports — never from what this panel last asked for.
+        // Each control asks the engine for an absolute value. It derives that value
+        // from what the engine reports, except while one of its own requests is
+        // still outstanding — which it must, or taps inside one poll are lost.
         function test_19_the_radio_panel_changes_the_radio() {
             var screen = screenLoader.item
             var panel = findChild(screen, "radioSheet")
@@ -566,19 +567,44 @@ Item {
             tryVerify(function () { return metrics.tunerGainDb === 30 })
             findChild(screen, "radioGainUp").clicked()
             compare(testContext.lastGainDb(), 31)
+
+            // Taps land faster than the 250 ms mirror is republished, and the
+            // command is a coalescible setter: stepping from the reading would have
+            // every tap inside one poll ask for the same value, and the queue would
+            // merge them into one. Five taps have to be five steps.
+            for (var i = 0; i < 4; i++)
+                findChild(screen, "radioGainUp").clicked()
+            compare(testContext.lastGainDb(), 35)
+            compare(findChild(screen, "radioGainValue").text, "35 dB")
+
+            // And down from what was asked for, not from the stale reading.
             findChild(screen, "radioGainDown").clicked()
-            compare(testContext.lastGainDb(), 29)
+            compare(testContext.lastGainDb(), 34)
+
+            // The request only stands in for the reading while it is outstanding: a
+            // command can be refused, and the panel must not go on showing a gain
+            // the radio never took.
+            panel.forgetRequests()
+            compare(findChild(screen, "radioGainValue").text, "30 dB")
 
             // Clamped to what the tuner actually offers, so the panel cannot ask
-            // for a gain the backend will only refuse.
+            // for a gain the backend will only refuse — and a step that changes no
+            // setting is not sent at all, because every accepted gain command
+            // restarts the dongle and drops the audio and the spectrum with it.
             testContext.setMetric("tunerGainDb",49)
             tryVerify(function () { return metrics.tunerGainDb === 49 })
+            panel.forgetRequests()
+            var atCeiling = testContext.gainCalls()
             findChild(screen, "radioGainUp").clicked()
-            compare(testContext.lastGainDb(), 49)
+            compare(testContext.gainCalls(), atCeiling,
+                    "a step at the ceiling restarted the dongle to change nothing")
             testContext.setMetric("tunerGainDb",0)
             tryVerify(function () { return metrics.tunerGainDb === 0 })
+            panel.forgetRequests()
+            var atFloor = testContext.gainCalls()
             findChild(screen, "radioGainDown").clicked()
-            compare(testContext.lastGainDb(), 0)
+            compare(testContext.gainCalls(), atFloor,
+                    "a step at the floor restarted the dongle to change nothing")
 
             findChild(screen, "radioSquelchUp").clicked()
             verify(Math.abs(testContext.lastSquelchDb() - (-115)) < 0.001)
@@ -586,6 +612,9 @@ Item {
             // PPM is chosen once, by someone with no way to tell if it was right.
             findChild(screen, "radioPpmUp").clicked()
             compare(testContext.lastPpm(), 1)
+            findChild(screen, "radioPpmDown").clicked()
+            compare(testContext.lastPpm(), 0)
+            panel.forgetRequests()
             findChild(screen, "radioPpmDown").clicked()
             compare(testContext.lastPpm(), -1)
 
@@ -636,7 +665,10 @@ Item {
             var dmr = findChild(screen, "radioDecode_DMR")
             verify(dmr !== null, "the DMR chip is missing")
             dmr.clicked()
-            compare(testContext.lastDecodeMode(), 5)
+            // DSDCFG_MODE_DMR. The mapping behind this is the production one, so
+            // the number is the enum's own — if it ever renumbers, this fails and
+            // someone has to look at what else reads it.
+            compare(testContext.lastDecodeMode(), 4)
 
             // Selection reads the engine, not the tap: the fixture reports auto,
             // so Auto is the chip that shows as chosen.

--- a/tests/ui/qml/tst_spectrum_screen.qml
+++ b/tests/ui/qml/tst_spectrum_screen.qml
@@ -596,6 +596,19 @@ Item {
             findChild(screen, "radioModulation").selected(0)
             compare(testContext.lastModulation(), 0)
 
+            // GFSK is a state the session arrives in on its own — the DMR and
+            // EDACS/ProVoice presets select it — so it has to be offered as a
+            // choice too, or the first press above is a one-way door out of it.
+            compare(findChild(screen, "radioModulation").model.length, 3)
+            findChild(screen, "radioModulation").selected(2)
+            compare(testContext.lastModulation(), 2)
+
+            // And it has to read back as itself rather than as C4FM, or the
+            // control claims a modulation the decoder is not on.
+            testContext.setMetric("modulation", 2)
+            compare(findChild(screen, "radioModulation").currentIndex, 2)
+            testContext.setMetric("modulation", 0)
+
             // Every one of those presses has to leave the panel open. The scrim
             // dismisses on a tap, and a handler on the panel cannot stop that —
             // handlers never take exclusive grabs — so the scrim has to decide by

--- a/tests/ui/qml/tst_spectrum_screen.qml
+++ b/tests/ui/qml/tst_spectrum_screen.qml
@@ -38,6 +38,13 @@ Item {
         function init() {
             testContext.resetCommands()
             testContext.setMetric("tunerControlled",false)
+            testContext.setMetric("trunkingEnabled",false)
+            testContext.setMetric("scannerMode",false)
+            testContext.setMetric("syncedHere",false)
+            // Most cases are about what exploring can do; the screen defaults to
+            // the other intent, where none of it is available.
+            screenLoader.item.exploring = true
+            screenLoader.item.hint = ""
             // The screen switches production on for itself; wait for the first frame.
             tryVerify(function () { return spectrum.hasData }, 5000,
                       "no spectrum frame arrived")
@@ -103,6 +110,77 @@ Item {
 
             testContext.setMetric("tunerControlled",false)
             tryVerify(function () { return !screenLoader.item.viewOnly })
+        }
+
+        // The other reason, and the one this screen decides for itself: a session
+        // started from a saved system is a session about that system. Nothing owns
+        // the tuner and the engine would accept the tune — the refusal is the
+        // product's, so nothing but this binding enforces it.
+        function test_03c_a_saved_system_session_is_view_only_with_nothing_holding_the_tuner() {
+            var screen = screenLoader.item
+            screen.exploring = false
+            verify(screen.viewOnly, "a saved-system session offered tap-to-tune")
+            verify(!screen.tunerHeld, "the fixture was not left with a free tuner")
+
+            mouseClick(tc.area, tc.xOf(testContext.spectrumPeakHz()), tc.area.height * 0.75)
+            tc.wait(50)
+            compare(testContext.manualTuneCalls(), 0)
+
+            // And the controls that only make sense while exploring are not there.
+            var tuning = findChild(screen, "spectrumTuning")
+            verify(tuning !== null, "the tuning row is missing entirely")
+            verify(!tuning.visible, "a saved-system session showed the tuning controls")
+
+            screen.exploring = true
+            verify(!screen.viewOnly)
+            tryVerify(function () { return tuning.visible })
+        }
+
+        // The way out of view-only. Nothing is holding the tuner here, so there is
+        // nothing to warn about and the ask goes straight through.
+        function test_03d_explore_from_here_asks_for_the_tuner() {
+            var screen = screenLoader.item
+            screen.exploring = false
+            var button = findChild(screen, "spectrumExploreFromHere")
+            verify(button !== null, "the explore-from-here button is missing")
+            tryVerify(function () { return button.visible })
+
+            var asked = 0
+            screen.exploreFromHere.connect(function () { asked++ })
+            button.clicked()
+
+            compare(testContext.releaseTunerCalls(), 0, "nothing held the tuner; nothing to release")
+            compare(asked, 1)
+            screen.exploring = true
+        }
+
+        // With a controller holding the tuner, taking it costs something the user
+        // did not ask for — following calls across channels stops — so it is named
+        // and confirmed rather than done on the tap.
+        function test_03e_taking_the_tuner_from_a_controller_is_confirmed_first() {
+            var screen = screenLoader.item
+            screen.exploring = false
+            testContext.setMetric("tunerControlled",true)
+            testContext.setMetric("trunkingEnabled",true)
+            tryVerify(function () { return screen.tunerHeld })
+
+            var asked = 0
+            screen.exploreFromHere.connect(function () { asked++ })
+
+            var button = findChild(screen, "spectrumExploreFromHere")
+            button.clicked()
+            var sheet = findChild(screen, "spectrumExploreConfirm")
+            verify(sheet !== null, "the confirm sheet is missing")
+            tryVerify(function () { return sheet.visible }, 2000, "the tap did not ask first")
+            compare(asked, 0, "the tuner was taken before the user confirmed")
+
+            findChild(screen, "spectrumExploreConfirmAccept").clicked()
+            tryVerify(function () { return !sheet.visible })
+            compare(asked, 1)
+
+            testContext.setMetric("tunerControlled",false)
+            testContext.setMetric("trunkingEnabled",false)
+            screen.exploring = true
         }
 
         // The monitor's copy of this line is underneath this layer, so a refused
@@ -232,6 +310,356 @@ Item {
             compare(testContext.manualTuneCalls(), 0)
             compare(spectrum.edgeOvershootHz, 0)
             spectrum.resetView()
+        }
+
+        // Tapping only reaches what is already on screen. Getting anywhere else
+        // means walking the band, and a step that did not overlap would hide a
+        // signal sitting on the seam from both screens it straddles.
+        function test_09_a_step_moves_one_overlapping_screenful() {
+            var screen = screenLoader.item
+            var from = spectrum.centerFreqHz
+
+            screen.stepBy(1)
+            compare(testContext.manualTuneCalls(), 1)
+            var up = testContext.lastManualTuneHz()
+            verify(up > from, "stepping up went down")
+            verify(Math.abs((up - from) - (spectrum.spanHz * 0.9)) <= 1,
+                   "stepped " + (up - from) + " Hz, not one overlapping span")
+
+            testContext.resetCommands()
+            screen.stepBy(-1)
+            compare(testContext.manualTuneCalls(), 1)
+            verify(Math.abs((from - testContext.lastManualTuneHz()) - (spectrum.spanHz * 0.9)) <= 1)
+        }
+
+        // Walking off the top of a band leads into spectrum this app decodes
+        // nothing in, so the walk comes back round instead. The receiver cannot be
+        // driven to a band edge from here, which is exactly why the arithmetic is
+        // its own function.
+        function test_10_stepping_wraps_inside_the_band() {
+            var screen = screenLoader.item
+            var band = screen.band
+            verify(band !== null, "the fixture centre is outside every known band")
+            var step = spectrum.spanHz * 0.9
+
+            // Mid-band, a step is just a step.
+            var mid = (band.low + band.high) / 2
+            verify(Math.abs(screen.nextStepHz(mid, 1) - (mid + step)) <= 1)
+            verify(Math.abs(screen.nextStepHz(mid, -1) - (mid - step)) <= 1)
+
+            // At the top, it comes back to the bottom — and lands inside the band
+            // rather than exactly on its edge, so the first screenful is spectrum.
+            var top = screen.nextStepHz(band.high - (step / 2), 1)
+            verify(top < band.high, "stepped past the top of the band to " + top)
+            verify(top > band.low, "wrapped onto the very edge of the band")
+            verify(top < mid, "the wrap did not come back round")
+
+            var bottom = screen.nextStepHz(band.low + (step / 2), -1)
+            verify(bottom > band.low, "stepped below the bottom of the band to " + bottom)
+            verify(bottom < band.high)
+            verify(bottom > mid, "the downward wrap did not come back round")
+
+            // Off-band — 250 MHz is in none of them — there is nothing to wrap
+            // against, and a walk that snapped into some other band would move the
+            // radio somewhere it was never pointed.
+            var away = 250.0e6
+            verify(Math.abs(screen.nextStepHz(away, 1) - (away + step)) <= 1)
+            verify(Math.abs(screen.nextStepHz(away, -1) - (away - step)) <= 1)
+        }
+
+        // The sweep is stepping repeated until something is found; the finding is
+        // the whole point, so it has to stop on it rather than walk past.
+        function test_11_a_sweep_steps_until_the_decoder_finds_something() {
+            var screen = screenLoader.item
+            screen.startSweep()
+            verify(screen.sweeping, "the sweep did not start")
+
+            screen.sweepTick()
+            compare(testContext.manualTuneCalls(), 1, "a dwell with nothing found did not move on")
+            verify(screen.sweeping)
+
+            testContext.setMetric("syncedHere",true)
+            tryVerify(function () { return metrics.syncedHere })
+            screen.sweepTick()
+            verify(!screen.sweeping, "the sweep walked past a signal")
+            compare(testContext.manualTuneCalls(), 1, "the sweep moved off what it found")
+            verify(screen.hint.length > 0, "the sweep stopped without saying why")
+
+            testContext.setMetric("syncedHere",false)
+        }
+
+        // Touching the spectrum is taking over. A sweep still running underneath
+        // would move the radio off whatever was just chosen, seconds later.
+        function test_12_touching_the_spectrum_stops_a_sweep() {
+            var screen = screenLoader.item
+            screen.startSweep()
+            verify(screen.sweeping)
+
+            mouseClick(tc.area, tc.xOf(testContext.spectrumPeakHz()), tc.area.height * 0.75)
+            tryVerify(function () { return !screen.sweeping }, 2000, "the sweep survived a tap")
+
+            // As does losing the right to tune at all.
+            screen.startSweep()
+            verify(screen.sweeping)
+            testContext.setMetric("tunerControlled",true)
+            tryVerify(function () { return !screen.sweeping }, 2000,
+                      "the sweep survived the tuner being taken")
+            testContext.setMetric("tunerControlled",false)
+        }
+
+        // Hopping to the next carrier, and — the part that is easy to get wrong —
+        // doing nothing at all when there is not one.
+        function test_13_the_signal_hop_lands_on_a_carrier_or_says_it_cannot() {
+            var screen = screenLoader.item
+            var peak = testContext.spectrumPeakHz()
+            var direction = peak > spectrum.centerFreqHz ? 1 : -1
+
+            screen.hopToSignal(direction)
+            compare(testContext.manualTuneCalls(), 1, "the hop asked for nothing")
+            verify(Math.abs(testContext.lastManualTuneHz() - peak) <= 4000,
+                   "hopped to " + testContext.lastManualTuneHz() + " but the peak is at " + peak)
+
+            // The other way there is only noise, and a hop that fell back to the
+            // current centre would retune the radio to where it already is.
+            testContext.resetCommands()
+            screen.hopToSignal(-direction)
+            compare(testContext.manualTuneCalls(), 0, "an empty band still moved the radio")
+            verify(screen.hint.length > 0, "an empty band said nothing")
+        }
+
+        // Typing a frequency is how someone leaves the neighbourhood entirely.
+        function test_14_go_to_tunes_to_a_typed_frequency() {
+            var screen = screenLoader.item
+            var sheet = findChild(screen, "spectrumGoToSheet")
+            verify(sheet !== null, "the go-to sheet is missing")
+
+            sheet.open(spectrum.centerFreqHz)
+            verify(sheet.visible)
+
+            findChild(screen, "spectrumGoToField").text = "154.0000"
+            findChild(screen, "spectrumGoToConfirm").clicked()
+
+            verify(!sheet.visible, "the sheet stayed open after tuning")
+            compare(testContext.manualTuneCalls(), 1)
+            compare(testContext.lastManualTuneHz(), 154000000)
+        }
+
+        // The engine reports every step of a sweep with a three-second message; at
+        // this cadence the line would never clear and would read as a fault.
+        function test_15_the_engine_message_is_hidden_while_sweeping() {
+            var screen = screenLoader.item
+            var toast = findChild(screen, "spectrumToast")
+            testContext.setMetric("uiMessage", "Applied: tuned -> 851000000 Hz")
+            tryVerify(function () { return toast.visible })
+
+            screen.startSweep()
+            tryVerify(function () { return !toast.visible }, 2000,
+                      "the per-step message stayed up through the sweep")
+
+            screen.stopSweep()
+            testContext.setMetric("uiMessage", "")
+        }
+
+        // A waterfall shows where energy is and says nothing about whether any of
+        // it is being decoded. On a band being swept that is the only question,
+        // and "which protocol" is the answer to why a real signal is silent.
+        function test_16_the_strip_says_whether_the_decoder_is_locked() {
+            var screen = screenLoader.item
+            var label = findChild(screen, "spectrumSyncLabel")
+            verify(label !== null, "the sync label is missing")
+
+            testContext.setMetric("syncedHere",false)
+            tryVerify(function () { return label.text === "NO SYNC" },
+                      2000, "an unlocked decoder did not say so")
+
+            testContext.setMetric("syncLabel","DMR")
+            testContext.setMetric("syncedHere",true)
+            tryVerify(function () { return label.text === "DMR" },
+                      2000, "a locked decoder did not name what it locked to")
+
+            testContext.setMetric("syncedHere",false)
+            testContext.setMetric("syncLabel","")
+        }
+
+        // A call in progress is the payoff, and it belongs next to the lock that
+        // produced it rather than on a screen the user has to leave this one for.
+        function test_17_the_strip_shows_a_call_in_progress() {
+            var screen = screenLoader.item
+            var call = findChild(screen, "spectrumCallLabel")
+            verify(call !== null, "the call label is missing")
+            verify(!call.visible, "an idle screen showed a call")
+
+            testContext.setMetric("slot1TgText","1201")
+            testContext.setMetric("slot1CallState",2)
+            tryVerify(function () { return call.visible && call.text === "1201" },
+                      2000, "an active call did not reach the strip")
+
+            // A control channel opens call epochs whose target has not decoded
+            // yet. Rendering that as talkgroup 0 would name a transmission
+            // nobody is making.
+            testContext.setMetric("slot1TgText","0")
+            tryVerify(function () { return !call.visible }, 2000,
+                      "an unidentified call was shown as talkgroup 0")
+
+            testContext.setMetric("slot1CallState",0)
+            testContext.setMetric("slot1TgText","")
+            tryVerify(function () { return !call.visible })
+        }
+
+        // A standing frequency offset is the symptom of a PPM correction that does
+        // not match this dongle — the one setting nobody can verify when they type
+        // it. Shown only once something is locked, because before that it is noise.
+        function test_17b_the_strip_shows_a_frequency_offset_worth_acting_on() {
+            var screen = screenLoader.item
+            var cfo = findChild(screen, "spectrumCfoLabel")
+            verify(cfo !== null, "the offset label is missing")
+
+            testContext.setMetric("syncedHere",false)
+            testContext.setMetric("cfoHz",900.0)
+            tryVerify(function () { return !cfo.visible }, 2000,
+                      "an offset was shown with nothing locked")
+
+            testContext.setMetric("syncedHere",true)
+            tryVerify(function () { return cfo.visible && cfo.text === "900 Hz" }, 2000,
+                      "a large offset was not shown")
+
+            // A few Hz is normal and is not worth a reading.
+            testContext.setMetric("cfoHz",4.0)
+            tryVerify(function () { return !cfo.visible }, 2000,
+                      "a negligible offset was still reported")
+
+            testContext.setMetric("cfoHz",0.0)
+            testContext.setMetric("syncedHere",false)
+        }
+
+        // Gain, squelch, modulation and decode are what decide whether a signal
+        // on the waterfall becomes audio. Reaching them used to mean stopping the
+        // session, so the panel is available even where tuning is not.
+        function test_18_the_radio_panel_opens_in_both_intents() {
+            var screen = screenLoader.item
+            var button = findChild(screen, "spectrumRadioButton")
+            var panel = findChild(screen, "radioSheet")
+            verify(button !== null, "the radio button is missing")
+            verify(panel !== null, "the radio panel is missing")
+
+            screen.exploring = false
+            tryVerify(function () { return screen.viewOnly })
+            verify(button.visible, "a view-only session hid the radio settings")
+
+            screen.exploring = true
+            verify(button.visible)
+            verify(!panel.visible)
+            panel.open()
+            verify(panel.visible)
+            findChild(screen, "radioSheetDone").clicked()
+            verify(!panel.visible)
+        }
+
+        // Each control asks the engine for an absolute value derived from what the
+        // engine currently reports — never from what this panel last asked for.
+        function test_19_the_radio_panel_changes_the_radio() {
+            var screen = screenLoader.item
+            var panel = findChild(screen, "radioSheet")
+            panel.open()
+
+            testContext.setMetric("tunerGainDb",30)
+            tryVerify(function () { return metrics.tunerGainDb === 30 })
+            findChild(screen, "radioGainUp").clicked()
+            compare(testContext.lastGainDb(), 31)
+            findChild(screen, "radioGainDown").clicked()
+            compare(testContext.lastGainDb(), 29)
+
+            // Clamped to what the tuner actually offers, so the panel cannot ask
+            // for a gain the backend will only refuse.
+            testContext.setMetric("tunerGainDb",49)
+            tryVerify(function () { return metrics.tunerGainDb === 49 })
+            findChild(screen, "radioGainUp").clicked()
+            compare(testContext.lastGainDb(), 49)
+            testContext.setMetric("tunerGainDb",0)
+            tryVerify(function () { return metrics.tunerGainDb === 0 })
+            findChild(screen, "radioGainDown").clicked()
+            compare(testContext.lastGainDb(), 0)
+
+            findChild(screen, "radioSquelchUp").clicked()
+            verify(Math.abs(testContext.lastSquelchDb() - (-115)) < 0.001)
+
+            // PPM is chosen once, by someone with no way to tell if it was right.
+            findChild(screen, "radioPpmUp").clicked()
+            compare(testContext.lastPpm(), 1)
+            findChild(screen, "radioPpmDown").clicked()
+            compare(testContext.lastPpm(), -1)
+
+            // QPSK is the simulcast answer, and picking it must ask for that state
+            // rather than for "the other one".
+            findChild(screen, "radioModulation").selected(1)
+            compare(testContext.lastModulation(), 1)
+            findChild(screen, "radioModulation").selected(0)
+            compare(testContext.lastModulation(), 0)
+
+            // Every one of those presses has to leave the panel open. The scrim
+            // dismisses on a tap, and a handler on the panel cannot stop that —
+            // handlers never take exclusive grabs — so the scrim has to decide by
+            // where the tap landed, or the panel closes on its own first button.
+            verify(panel.visible, "the panel closed while its controls were used")
+            verify(panel.hitsPanel(root.width / 2, root.height / 2),
+                   "the panel does not claim its own centre")
+            verify(!panel.hitsPanel(root.width / 2, 4),
+                   "the panel claimed the scrim above it")
+
+            panel.visible = false
+            testContext.setMetric("tunerGainDb",30)
+        }
+
+        // The chips must send the preset the flag means, and the modulation chip
+        // must not appear among them at all — it changes nothing here.
+        function test_20_the_decode_chips_send_a_preset() {
+            var screen = screenLoader.item
+            var panel = findChild(screen, "radioSheet")
+            panel.open()
+
+            verify(findChild(screen, "radioDecode_P25 LSM") === null,
+                   "the simulcast modulation chip appeared as a decode choice")
+
+            var dmr = findChild(screen, "radioDecode_DMR")
+            verify(dmr !== null, "the DMR chip is missing")
+            dmr.clicked()
+            compare(testContext.lastDecodeMode(), 5)
+
+            // Selection reads the engine, not the tap: the fixture reports auto,
+            // so Auto is the chip that shows as chosen.
+            var auto = findChild(screen, "radioDecode_Auto")
+            verify(auto !== null, "the auto chip is missing")
+            verify(auto.selected, "the panel did not show the engine's own mode")
+            verify(!dmr.selected, "a tapped chip showed as chosen before the engine agreed")
+
+            panel.visible = false
+        }
+
+        // TapHandlers never take exclusive grabs, so a tap on a sheet also lands
+        // on the spectrum behind it. Left alone, every press of a button on the
+        // radio panel also retunes the receiver — the panel closes and the radio
+        // has moved somewhere nobody asked for.
+        function test_21_a_tap_on_a_sheet_never_reaches_the_spectrum() {
+            var screen = screenLoader.item
+            var sheets = [findChild(screen, "radioSheet"),
+                          findChild(screen, "spectrumGoToSheet"),
+                          findChild(screen, "spectrumExploreConfirm")]
+
+            for (var i = 0; i < sheets.length; i++) {
+                verify(sheets[i] !== null, "a sheet is missing")
+                testContext.resetCommands()
+                sheets[i].visible = true
+                verify(screen.sheetOpen, "an open sheet did not shield the spectrum")
+
+                // Straight through the middle of the panel, where its own controls are.
+                mouseClick(tc.area, tc.xOf(testContext.spectrumPeakHz()), tc.area.height * 0.5)
+                tc.wait(50)
+                compare(testContext.manualTuneCalls(), 0,
+                        "a tap on a sheet retuned the receiver behind it")
+
+                sheets[i].visible = false
+            }
+            verify(!screen.sheetOpen)
         }
 
         // The axis has to follow the viewport, not freeze on the first frame.

--- a/tests/ui/qml/tst_spectrum_screen.qml
+++ b/tests/ui/qml/tst_spectrum_screen.qml
@@ -898,6 +898,47 @@ Item {
             verify(!rail.dragging, "the rail is still dragging after release")
         }
 
+        // A second drag started while the first one's retune is still in flight has
+        // to carry on from the frequency the rail is showing. Seeded from tunedHz
+        // instead, the knob snaps back to where the receiver still is and the nudge
+        // is measured from a frequency the user has already left — so fine-tuning a
+        // move undoes it.
+        function test_28b_a_drag_during_a_settle_continues_from_the_preview() {
+            var rail = findChild(screenLoader.item, "spectrumBandRail")
+            var before = rail.tunedHz
+
+            rail.beginDrag()
+            rail.dragBy(120, 400)
+            var firstWant = rail.pendingHz
+            rail.endDrag(false)
+            verify(rail.settling, "the rail did not hold the preview through the retune")
+            compare(rail.settleHz, firstWant)
+
+            // The engine has not landed yet: tunedHz is still the old frequency.
+            compare(rail.tunedHz, before)
+            rail.beginDrag()
+            compare(rail.dragStartHz, firstWant)
+            compare(rail.pendingHz, firstWant)
+            rail.dragBy(40, 400)
+            verify(rail.pendingHz > firstWant,
+                   "the second drag went to " + rail.pendingHz + ", behind the first at " + firstWant)
+            rail.endDrag(true)
+        }
+
+        // A tune the screen turned down leaves nothing to wait for, so the preview
+        // must not sit on a frequency nobody is on until the timeout gives up.
+        function test_28c_a_refused_tune_drops_the_preview() {
+            var rail = findChild(screenLoader.item, "spectrumBandRail")
+            rail.beginDrag()
+            rail.dragBy(120, 400)
+            rail.endDrag(false)
+            verify(rail.settling, "the accepted tune did not hold the preview")
+
+            rail.cancelSettle()
+            verify(!rail.settling, "the refused tune kept the preview")
+            compare(rail.displayHz, rail.tunedHz)
+        }
+
         // A drag that ended for any reason other than the finger lifting is not a
         // request to move the receiver.
         function test_29_a_cancelled_rail_drag_never_retunes() {

--- a/tests/ui/qml_spectrum_stub.cpp
+++ b/tests/ui/qml_spectrum_stub.cpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Canned wideband spectrum for the QML suite.
+ *
+ * UI_QT_QML_CALL_LISTS links Qt and the two spectrum classes but no engine, so
+ * the app-control boundary those classes call is supplied here: a flat noise
+ * floor with one unmistakable peak, gated on the enable flag exactly as the
+ * real getter is, so the view's start/stop behaviour is under test too.
+ */
+
+#include <stdint.h>
+
+#include <dsd-neo/app_control/frontend.h>
+
+#include "qml_spectrum_stub.h"
+
+using namespace dsd_neo_qml_stub;
+
+namespace {
+
+int g_enabled = 0;
+
+} // namespace
+
+extern "C" int
+dsd_app_frontend_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz,
+                                       uint32_t* out_span_hz) {
+    if (!out_db || max_bins <= 0 || g_enabled == 0) {
+        return 0;
+    }
+    const int n = (max_bins < kSpectrumBins) ? max_bins : kSpectrumBins;
+    for (int i = 0; i < n; i++) {
+        out_db[i] = -80.0F;
+    }
+    /* A three-bin peak, so a snap search that is off by one still finds it and a
+     * search that ignores the window entirely still fails. */
+    for (int i = kSpectrumPeakBin - 1; i <= kSpectrumPeakBin + 1; i++) {
+        if (i >= 0 && i < n) {
+            out_db[i] = (i == kSpectrumPeakBin) ? -18.0F : -30.0F;
+        }
+    }
+    if (out_center_freq_hz) {
+        *out_center_freq_hz = kSpectrumCenterHz;
+    }
+    if (out_span_hz) {
+        *out_span_hz = kSpectrumSpanHz;
+    }
+    return n;
+}
+
+extern "C" void
+dsd_app_frontend_wideband_spectrum_set_enabled(int on) {
+    g_enabled = on ? 1 : 0;
+}

--- a/tests/ui/qml_spectrum_stub.cpp
+++ b/tests/ui/qml_spectrum_stub.cpp
@@ -24,16 +24,19 @@ using namespace dsd_neo_qml_stub;
 namespace {
 
 int g_enabled = 0;
+/* A fresh frame on every poll, which is what a producer running faster than the
+ * view does. Serial 0 means "nothing published", so it is skipped. */
+uint32_t g_serial = 0;
 
 } // namespace
 
 extern "C" int
-dsd_app_frontend_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz,
-                                       uint32_t* out_span_hz) {
-    if (!out_db || max_bins <= 0 || g_enabled == 0) {
+dsd_app_frontend_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz, uint32_t* out_span_hz,
+                                       uint32_t* out_frame_serial) {
+    if (!out_db || max_bins < kSpectrumBins || g_enabled == 0) {
         return 0;
     }
-    const int n = (max_bins < kSpectrumBins) ? max_bins : kSpectrumBins;
+    const int n = kSpectrumBins;
     for (int i = 0; i < n; i++) {
         out_db[i] = -80.0F;
     }
@@ -49,6 +52,10 @@ dsd_app_frontend_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* ou
     }
     if (out_span_hz) {
         *out_span_hz = kSpectrumSpanHz;
+    }
+    if (out_frame_serial) {
+        g_serial++;
+        *out_frame_serial = g_serial;
     }
     return n;
 }

--- a/tests/ui/qml_spectrum_stub.h
+++ b/tests/ui/qml_spectrum_stub.h
@@ -16,9 +16,14 @@
 #ifndef DSD_NEO_TESTS_UI_QML_SPECTRUM_STUB_H_
 #define DSD_NEO_TESTS_UI_QML_SPECTRUM_STUB_H_
 
+#include <dsd-neo/core/wideband_spectrum.h>
+
 namespace dsd_neo_qml_stub {
 
-constexpr int kSpectrumBins = 1024;
+/* The published width, not a number of its own: the consumer refuses a frame
+ * that is not exactly this wide, so a fixture that drifted from it would fail
+ * as "no frames arrived" rather than as a mismatch. */
+constexpr int kSpectrumBins = DSD_WIDEBAND_SPECTRUM_BINS;
 constexpr unsigned int kSpectrumCenterHz = 851000000U;
 constexpr unsigned int kSpectrumSpanHz = 1536000U;
 /* Well away from DC, so a tap landing on it cannot be confused with a tap that

--- a/tests/ui/qml_spectrum_stub.h
+++ b/tests/ui/qml_spectrum_stub.h
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Shape of the canned wideband spectrum the QML tests run against.
+ *
+ * The QML suite deliberately links no engine, so the app-control wideband
+ * getter is stubbed (qml_spectrum_stub.cpp). These constants describe the frame
+ * it hands back, so a test can compute where the peak should be rather than
+ * hard-coding a frequency that would drift if the fixture changed.
+ */
+
+#ifndef DSD_NEO_TESTS_UI_QML_SPECTRUM_STUB_H_
+#define DSD_NEO_TESTS_UI_QML_SPECTRUM_STUB_H_
+
+namespace dsd_neo_qml_stub {
+
+constexpr int kSpectrumBins = 1024;
+constexpr unsigned int kSpectrumCenterHz = 851000000U;
+constexpr unsigned int kSpectrumSpanHz = 1536000U;
+/* Well away from DC, so a tap landing on it cannot be confused with a tap that
+ * simply did nothing and left the view centered. */
+constexpr int kSpectrumPeakBin = 700;
+
+/** @brief Frequency of the stub's peak bin, using the published bin convention. */
+constexpr double
+spectrum_peak_hz() {
+    return static_cast<double>(kSpectrumCenterHz)
+           + ((static_cast<double>(kSpectrumPeakBin) - (kSpectrumBins / 2.0)) * static_cast<double>(kSpectrumSpanHz)
+              / static_cast<double>(kSpectrumBins));
+}
+
+} // namespace dsd_neo_qml_stub
+
+#endif /* DSD_NEO_TESTS_UI_QML_SPECTRUM_STUB_H_ */

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -119,6 +119,13 @@ class CommandRecorder : public QObject {
     }
 
     Q_INVOKABLE bool
+    setTrunking(bool on) {
+        m_set_trunking_calls++;
+        m_last_set_trunking = on;
+        return true;
+    }
+
+    Q_INVOKABLE bool
     setTunerGain(int gain_db) {
         m_last_gain_db = gain_db;
         m_gain_calls++;
@@ -168,6 +175,8 @@ class CommandRecorder : public QObject {
         m_manual_tune_calls = 0;
         m_last_manual_tune_hz = 0U;
         m_release_tuner_calls = 0;
+        m_set_trunking_calls = 0;
+        m_last_set_trunking = false;
         m_gain_calls = 0;
         m_last_gain_db = -1;
         m_last_squelch_db = 0.0;
@@ -216,6 +225,16 @@ class CommandRecorder : public QObject {
         return m_release_tuner_calls;
     }
 
+    int
+    setTrunkingCalls() const {
+        return m_set_trunking_calls;
+    }
+
+    bool
+    lastSetTrunking() const {
+        return m_last_set_trunking;
+    }
+
     /** @brief The recorded frequency, widened for QML's arithmetic. */
     double
     lastManualTuneHz() const {
@@ -226,6 +245,8 @@ class CommandRecorder : public QObject {
     int m_manual_tune_calls = 0;
     unsigned int m_last_manual_tune_hz = 0U;
     int m_release_tuner_calls = 0;
+    int m_set_trunking_calls = 0;
+    bool m_last_set_trunking = false;
     int m_gain_calls = 0;
     int m_last_gain_db = -1;
     double m_last_squelch_db = 0.0;
@@ -464,6 +485,18 @@ class Setup : public QObject {
         return (m_commands != nullptr) ? m_commands->releaseTunerCalls() : -1;
     }
 
+    /** @brief How many times the screens have asked to hand the tuner to trunking. */
+    Q_INVOKABLE int
+    setTrunkingCalls() const {
+        return (m_commands != nullptr) ? m_commands->setTrunkingCalls() : -1;
+    }
+
+    /** @brief Which way the most recent trunking request went. */
+    Q_INVOKABLE bool
+    lastSetTrunking() const {
+        return (m_commands != nullptr) ? m_commands->lastSetTrunking() : false;
+    }
+
     /** @brief What the radio panel last asked the engine for. */
     Q_INVOKABLE int
     gainCalls() const {
@@ -616,6 +649,7 @@ class Setup : public QObject {
         // at rest, which is what lets a sweep keep stepping until a case says so.
         metrics[QStringLiteral("syncedHere")] = false;
         metrics[QStringLiteral("syncLabel")] = QString();
+        metrics[QStringLiteral("trunkableSync")] = false;
         // What the radio panel shows and changes. DSDCFG_MODE_AUTO is 1.
         metrics[QStringLiteral("decodeMode")] = 1;
         metrics[QStringLiteral("modulation")] = 0;

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -110,8 +110,56 @@ class CommandRecorder : public QObject {
     }
 
     Q_INVOKABLE bool
-    setTunerGain(int) {
+    releaseTuner() {
+        m_release_tuner_calls++;
         return true;
+    }
+
+    Q_INVOKABLE bool
+    setTunerGain(int gain_db) {
+        m_last_gain_db = gain_db;
+        m_gain_calls++;
+        return true;
+    }
+
+    Q_INVOKABLE bool
+    setSquelchDb(double db) {
+        m_last_squelch_db = db;
+        return true;
+    }
+
+    Q_INVOKABLE bool
+    setPpm(int ppm) {
+        m_last_ppm = ppm;
+        return true;
+    }
+
+    Q_INVOKABLE bool
+    setModulation(int modulation) {
+        m_last_modulation = modulation;
+        return true;
+    }
+
+    Q_INVOKABLE bool
+    setDecodeMode(int mode) {
+        m_last_decode_mode = mode;
+        return true;
+    }
+
+    /* The production mapping is CLI-flag to preset enum; the double only has to
+     * be consistent with itself and with the fixture's decodeMode of 1 (auto). */
+    Q_INVOKABLE int
+    decodeModeForFlag(const QString& flag) {
+        if (flag.trimmed().isEmpty()) {
+            return 1; /* DSDCFG_MODE_AUTO */
+        }
+        if (flag == QLatin1String("-mq")) {
+            return -1; /* a modulation chip, not a decode one */
+        }
+        if (flag == QLatin1String("-fs")) {
+            return 5; /* DSDCFG_MODE_DMR */
+        }
+        return 13; /* DSDCFG_MODE_TDMA, standing in for the rest */
     }
 
     Q_INVOKABLE int
@@ -125,11 +173,53 @@ class CommandRecorder : public QObject {
         m_last_manual_tune_hz = 0U;
         m_tune_calls = 0;
         m_last_tune_hz = 0U;
+        m_release_tuner_calls = 0;
+        m_gain_calls = 0;
+        m_last_gain_db = -1;
+        m_last_squelch_db = 0.0;
+        m_last_modulation = -1;
+        m_last_decode_mode = -1;
+        m_last_ppm = 9999;
+    }
+
+    int
+    gainCalls() const {
+        return m_gain_calls;
+    }
+
+    int
+    lastGainDb() const {
+        return m_last_gain_db;
+    }
+
+    double
+    lastSquelchDb() const {
+        return m_last_squelch_db;
+    }
+
+    int
+    lastModulation() const {
+        return m_last_modulation;
+    }
+
+    int
+    lastDecodeMode() const {
+        return m_last_decode_mode;
+    }
+
+    int
+    lastPpm() const {
+        return m_last_ppm;
     }
 
     int
     manualTuneCalls() const {
         return m_manual_tune_calls;
+    }
+
+    int
+    releaseTunerCalls() const {
+        return m_release_tuner_calls;
     }
 
     /** @brief The recorded frequency, widened for QML's arithmetic. */
@@ -143,6 +233,13 @@ class CommandRecorder : public QObject {
     unsigned int m_last_manual_tune_hz = 0U;
     int m_tune_calls = 0;
     unsigned int m_last_tune_hz = 0U;
+    int m_release_tuner_calls = 0;
+    int m_gain_calls = 0;
+    int m_last_gain_db = -1;
+    double m_last_squelch_db = 0.0;
+    int m_last_modulation = -1;
+    int m_last_decode_mode = -1;
+    int m_last_ppm = 9999;
 };
 
 /**
@@ -369,6 +466,43 @@ class Setup : public QObject {
         return (m_commands != nullptr) ? m_commands->lastManualTuneHz() : 0.0;
     }
 
+    /** @brief How many times the screens have asked to be given the tuner. */
+    Q_INVOKABLE int
+    releaseTunerCalls() const {
+        return (m_commands != nullptr) ? m_commands->releaseTunerCalls() : -1;
+    }
+
+    /** @brief What the radio panel last asked the engine for. */
+    Q_INVOKABLE int
+    gainCalls() const {
+        return (m_commands != nullptr) ? m_commands->gainCalls() : -1;
+    }
+
+    Q_INVOKABLE int
+    lastGainDb() const {
+        return (m_commands != nullptr) ? m_commands->lastGainDb() : -1;
+    }
+
+    Q_INVOKABLE double
+    lastSquelchDb() const {
+        return (m_commands != nullptr) ? m_commands->lastSquelchDb() : 0.0;
+    }
+
+    Q_INVOKABLE int
+    lastModulation() const {
+        return (m_commands != nullptr) ? m_commands->lastModulation() : -1;
+    }
+
+    Q_INVOKABLE int
+    lastDecodeMode() const {
+        return (m_commands != nullptr) ? m_commands->lastDecodeMode() : -1;
+    }
+
+    Q_INVOKABLE int
+    lastPpm() const {
+        return (m_commands != nullptr) ? m_commands->lastPpm() : 9999;
+    }
+
     Q_INVOKABLE QStringList
     missingContextKeys(const QStringList& qmlFiles) const {
         const QHash<QString, QVariantMap> maps = {{QStringLiteral("metrics"), m_metrics},
@@ -480,9 +614,22 @@ class Setup : public QObject {
         }
         // Targets the encrypted lockout is skipping; 0 is the at-rest value.
         metrics[QStringLiteral("encLockoutCount")] = 0;
-        // Whether an automatic controller owns the tuner, and where it points.
+        // Whether an automatic controller owns the tuner, which one, and where it
+        // points. The two named owners word a message; tunerControlled is the gate.
         metrics[QStringLiteral("tunerControlled")] = false;
+        metrics[QStringLiteral("trunkingEnabled")] = false;
+        metrics[QStringLiteral("scannerMode")] = false;
         metrics[QStringLiteral("centerFreqHz")] = static_cast<double>(dsd_neo_qml_stub::kSpectrumCenterHz);
+        // Whether the decoder has found anything since the tuner last moved. False
+        // at rest, which is what lets a sweep keep stepping until a case says so.
+        metrics[QStringLiteral("syncedHere")] = false;
+        metrics[QStringLiteral("syncLabel")] = QString();
+        // What the radio panel shows and changes. DSDCFG_MODE_AUTO is 1.
+        metrics[QStringLiteral("decodeMode")] = 1;
+        metrics[QStringLiteral("modulation")] = 0;
+        metrics[QStringLiteral("tunerGainDb")] = 30;
+        metrics[QStringLiteral("squelchDb")] = -120.0;
+        metrics[QStringLiteral("ppm")] = 0;
         m_metrics = metrics;
         m_engine = engine;
         ctx->setContextProperty(QStringLiteral("metrics"), metrics);

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -50,6 +50,7 @@
 
 #include "call_history_filter.h"
 #include "call_history_model.h"
+#include "decode_mode_flag.h"
 #include "qml_spectrum_stub.h"
 #include "spectrum_model.h"
 #include "spectrum_view_item.h"
@@ -146,20 +147,13 @@ class CommandRecorder : public QObject {
         return true;
     }
 
-    /* The production mapping is CLI-flag to preset enum; the double only has to
-     * be consistent with itself and with the fixture's decodeMode of 1 (auto). */
+    /* The production mapping itself, not a stand-in for it. It used to be a
+     * stand-in answering numbers no dsdneoUserDecodeMode has -- 5 for DMR (which
+     * is 4) and 13 for "the rest" (which is ANALOG) -- so the case asserting that
+     * the DMR chip sends DMR was really asserting the double's own arithmetic. */
     Q_INVOKABLE int
     decodeModeForFlag(const QString& flag) {
-        if (flag.trimmed().isEmpty()) {
-            return 1; /* DSDCFG_MODE_AUTO */
-        }
-        if (flag == QLatin1String("-mq")) {
-            return -1; /* a modulation chip, not a decode one */
-        }
-        if (flag == QLatin1String("-fs")) {
-            return 5; /* DSDCFG_MODE_DMR */
-        }
-        return 13; /* DSDCFG_MODE_TDMA, standing in for the rest */
+        return dsd_qt::decode_mode_for_flag(flag);
     }
 
     Q_INVOKABLE int

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -83,10 +83,12 @@ class CommandRecorder : public QObject {
         return true;
     }
 
+    /* Accepted and discarded: nothing under test asserts on the settings-menu
+     * tune, only on the spectrum's manualTuneHz(). Counting it would be state no
+     * assertion can ever fail on. */
     Q_INVOKABLE bool
     tuneHz(unsigned int hz) {
-        m_tune_calls++;
-        m_last_tune_hz = hz;
+        Q_UNUSED(hz)
         return true;
     }
 
@@ -165,8 +167,6 @@ class CommandRecorder : public QObject {
     reset() {
         m_manual_tune_calls = 0;
         m_last_manual_tune_hz = 0U;
-        m_tune_calls = 0;
-        m_last_tune_hz = 0U;
         m_release_tuner_calls = 0;
         m_gain_calls = 0;
         m_last_gain_db = -1;
@@ -225,8 +225,6 @@ class CommandRecorder : public QObject {
   private:
     int m_manual_tune_calls = 0;
     unsigned int m_last_manual_tune_hz = 0U;
-    int m_tune_calls = 0;
-    unsigned int m_last_tune_hz = 0U;
     int m_release_tuner_calls = 0;
     int m_gain_calls = 0;
     int m_last_gain_db = -1;

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -645,6 +645,8 @@ class Setup : public QObject {
         metrics[QStringLiteral("trunkingEnabled")] = false;
         metrics[QStringLiteral("scannerMode")] = false;
         metrics[QStringLiteral("centerFreqHz")] = static_cast<double>(dsd_neo_qml_stub::kSpectrumCenterHz);
+        // Width of the channel being demodulated; 12.5 kHz is the P25/DMR case.
+        metrics[QStringLiteral("channelBandwidthHz")] = 12500;
         // Whether the decoder has found anything since the tuner last moved. False
         // at rest, which is what lets a sweep keep stepping until a case says so.
         metrics[QStringLiteral("syncedHere")] = false;

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -64,20 +64,26 @@ using dsd_qt::CallHistoryModel;
  * command surface has to be observable. It carries every method the screens
  * call — an unimplemented one would only fail when some future case triggered
  * it, which is exactly the kind of gap this suite exists to close.
+ *
+ * The tune parameters are `unsigned int` because CommandBridge's are: QML hands
+ * these methods a JavaScript number, and taking a double here would quietly
+ * accept a fractional, negative or out-of-range frequency that production
+ * truncates or wraps on its way to the tuner. Recording what production would
+ * actually submit is the point.
  */
 class CommandRecorder : public QObject {
     Q_OBJECT
 
   public:
     Q_INVOKABLE bool
-    manualTuneHz(double hz) {
+    manualTuneHz(unsigned int hz) {
         m_manual_tune_calls++;
         m_last_manual_tune_hz = hz;
         return true;
     }
 
     Q_INVOKABLE bool
-    tuneHz(double hz) {
+    tuneHz(unsigned int hz) {
         m_tune_calls++;
         m_last_tune_hz = hz;
         return true;
@@ -116,9 +122,9 @@ class CommandRecorder : public QObject {
     void
     reset() {
         m_manual_tune_calls = 0;
-        m_last_manual_tune_hz = 0.0;
+        m_last_manual_tune_hz = 0U;
         m_tune_calls = 0;
-        m_last_tune_hz = 0.0;
+        m_last_tune_hz = 0U;
     }
 
     int
@@ -126,16 +132,17 @@ class CommandRecorder : public QObject {
         return m_manual_tune_calls;
     }
 
+    /** @brief The recorded frequency, widened for QML's arithmetic. */
     double
     lastManualTuneHz() const {
-        return m_last_manual_tune_hz;
+        return static_cast<double>(m_last_manual_tune_hz);
     }
 
   private:
     int m_manual_tune_calls = 0;
-    double m_last_manual_tune_hz = 0.0;
+    unsigned int m_last_manual_tune_hz = 0U;
     int m_tune_calls = 0;
-    double m_last_tune_hz = 0.0;
+    unsigned int m_last_tune_hz = 0U;
 };
 
 /**
@@ -473,8 +480,8 @@ class Setup : public QObject {
         }
         // Targets the encrypted lockout is skipping; 0 is the at-rest value.
         metrics[QStringLiteral("encLockoutCount")] = 0;
-        // Whether the trunking controller owns the tuner, and where it points.
-        metrics[QStringLiteral("trunkingEnabled")] = false;
+        // Whether an automatic controller owns the tuner, and where it points.
+        metrics[QStringLiteral("tunerControlled")] = false;
         metrics[QStringLiteral("centerFreqHz")] = static_cast<double>(dsd_neo_qml_stub::kSpectrumCenterHz);
         m_metrics = metrics;
         m_engine = engine;

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -50,9 +50,93 @@
 
 #include "call_history_filter.h"
 #include "call_history_model.h"
+#include "qml_spectrum_stub.h"
+#include "spectrum_model.h"
+#include "spectrum_view_item.h"
 
 using dsd_qt::CallHistoryFilterModel;
 using dsd_qt::CallHistoryModel;
+
+/**
+ * @brief Stand-in for CommandBridge that records instead of submitting.
+ *
+ * The whole point of a tap-to-tune test is what the screen asks for, so the
+ * command surface has to be observable. It carries every method the screens
+ * call — an unimplemented one would only fail when some future case triggered
+ * it, which is exactly the kind of gap this suite exists to close.
+ */
+class CommandRecorder : public QObject {
+    Q_OBJECT
+
+  public:
+    Q_INVOKABLE bool
+    manualTuneHz(double hz) {
+        m_manual_tune_calls++;
+        m_last_manual_tune_hz = hz;
+        return true;
+    }
+
+    Q_INVOKABLE bool
+    tuneHz(double hz) {
+        m_tune_calls++;
+        m_last_tune_hz = hz;
+        return true;
+    }
+
+    Q_INVOKABLE bool
+    toggleMute() {
+        return true;
+    }
+
+    Q_INVOKABLE bool
+    holdTalkgroup(double) {
+        return true;
+    }
+
+    Q_INVOKABLE bool
+    lockoutSlot(int) {
+        return true;
+    }
+
+    Q_INVOKABLE bool
+    clearEncLockouts() {
+        return true;
+    }
+
+    Q_INVOKABLE bool
+    setTunerGain(int) {
+        return true;
+    }
+
+    Q_INVOKABLE int
+    cycleHistoryMode() {
+        return 0;
+    }
+
+    void
+    reset() {
+        m_manual_tune_calls = 0;
+        m_last_manual_tune_hz = 0.0;
+        m_tune_calls = 0;
+        m_last_tune_hz = 0.0;
+    }
+
+    int
+    manualTuneCalls() const {
+        return m_manual_tune_calls;
+    }
+
+    double
+    lastManualTuneHz() const {
+        return m_last_manual_tune_hz;
+    }
+
+  private:
+    int m_manual_tune_calls = 0;
+    double m_last_manual_tune_hz = 0.0;
+    int m_tune_calls = 0;
+    double m_last_tune_hz = 0.0;
+};
 
 /**
  * @brief Newest-first call log the tests drive directly.
@@ -252,6 +336,32 @@ class Setup : public QObject {
      *
      * @param qmlFiles File names under src/ui/qt/qml, as the tests load them.
      */
+    /** @brief Frequency of the canned spectrum's peak, so a case need not hard-code it. */
+    Q_INVOKABLE double
+    spectrumPeakHz() const {
+        return dsd_neo_qml_stub::spectrum_peak_hz();
+    }
+
+    /** @brief Forget every recorded command. */
+    Q_INVOKABLE void
+    resetCommands() {
+        if (m_commands != nullptr) {
+            m_commands->reset();
+        }
+    }
+
+    /** @brief How many manual tunes the screens have asked for. */
+    Q_INVOKABLE int
+    manualTuneCalls() const {
+        return (m_commands != nullptr) ? m_commands->manualTuneCalls() : -1;
+    }
+
+    /** @brief The frequency of the most recent manual tune request. */
+    Q_INVOKABLE double
+    lastManualTuneHz() const {
+        return (m_commands != nullptr) ? m_commands->lastManualTuneHz() : 0.0;
+    }
+
     Q_INVOKABLE QStringList
     missingContextKeys(const QStringList& qmlFiles) const {
         const QHash<QString, QVariantMap> maps = {{QStringLiteral("metrics"), m_metrics},
@@ -307,6 +417,12 @@ class Setup : public QObject {
 
     void
     qmlEngineAvailable(QQmlEngine* engine) {
+        /* The spectrum's trace and waterfall are the only C++ types the QML
+         * instantiates itself, so they need the same registration ui_load()
+         * does before anything importing them is parsed. */
+        qmlRegisterType<dsd_qt::SpectrumTraceItem>("DsdNeo", 1, 0, "SpectrumTrace");
+        qmlRegisterType<dsd_qt::WaterfallItem>("DsdNeo", 1, 0, "Waterfall");
+
         auto* store = new CallLogStore();
         auto* historyView = new CallHistoryFilterModel(engine);
         historyView->setSourceModel(store);
@@ -357,6 +473,9 @@ class Setup : public QObject {
         }
         // Targets the encrypted lockout is skipping; 0 is the at-rest value.
         metrics[QStringLiteral("encLockoutCount")] = 0;
+        // Whether the trunking controller owns the tuner, and where it points.
+        metrics[QStringLiteral("trunkingEnabled")] = false;
+        metrics[QStringLiteral("centerFreqHz")] = static_cast<double>(dsd_neo_qml_stub::kSpectrumCenterHz);
         m_metrics = metrics;
         m_engine = engine;
         ctx->setContextProperty(QStringLiteral("metrics"), metrics);
@@ -366,9 +485,21 @@ class Setup : public QObject {
         host[QStringLiteral("running")] = false;
         host[QStringLiteral("transitioning")] = false;
         host[QStringLiteral("statusText")] = QStringLiteral("idle");
+        /* The spectrum view gates production on a live session, so the fixture
+         * has to claim one or its frames would never start. */
+        host[QStringLiteral("sessionActive")] = true;
         m_host = host;
         ctx->setContextProperty(QStringLiteral("decoderHost"), host);
-        ctx->setContextProperty(QStringLiteral("commands"), QVariantMap());
+
+        /* The real SpectrumModel over the canned getter in qml_spectrum_stub.cpp:
+         * the polling, viewport and tap-snapping under test are the production
+         * ones, only the frames are synthetic. */
+        m_spectrum = new dsd_qt::SpectrumModel(engine);
+        ctx->setContextProperty(QStringLiteral("spectrum"), m_spectrum);
+
+        m_commands = new CommandRecorder();
+        m_commands->setParent(engine);
+        ctx->setContextProperty(QStringLiteral("commands"), m_commands);
     }
 
   private:
@@ -376,6 +507,8 @@ class Setup : public QObject {
     QVariantMap m_prefs;
     QVariantMap m_host;
     QQmlEngine* m_engine = nullptr;
+    dsd_qt::SpectrumModel* m_spectrum = nullptr;
+    CommandRecorder* m_commands = nullptr;
 };
 
 #endif /* DSD_NEO_TESTS_UI_QML_TEST_CONTEXT_H_ */

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1524,6 +1524,65 @@ test_modulation_and_decode_mode_setters(void) {
     return rc;
 }
 
+/*
+ * TRUNK_SET is the half of tuner ownership a view can name. TUNER_RELEASE clears
+ * both owners without knowing which held it; this one says "trunking, on" or
+ * "trunking, off" from a frontend that does know, which is what a control
+ * offering trunking as a choice needs and what TRUNK_TOGGLE cannot express.
+ */
+static int
+test_trunk_set(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+
+    init_test_context(&opts, &state);
+    opts.trunk_enable = 0;
+    opts.scanner_mode = 0;
+
+    rc |=
+        expect_int("trunk on queued", dsd_app_command_set_i32(DSD_APP_CMD_TRUNK_SET, 1), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("trunk on drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("trunk on enables trunking", opts.trunk_enable, 1);
+
+    /* Asking for it again is not a flip. This is the whole reason the command
+     * exists: TRUNK_TOGGLE here would hand the tuner straight back. */
+    rc |= expect_int("repeat trunk on queued", dsd_app_command_set_i32(DSD_APP_CMD_TRUNK_SET, 1),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("repeat trunk on drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("repeat trunk on stays on", opts.trunk_enable, 1);
+
+    rc |= expect_int("trunk off queued", dsd_app_command_set_i32(DSD_APP_CMD_TRUNK_SET, 0),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("trunk off drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("trunk off disables trunking", opts.trunk_enable, 0);
+
+    /* Scanner mode is the other automatic owner, and SCANNER_TOGGLE already
+     * clears trunking on the way in. Without the same exclusion here, asking for
+     * trunking from a scanning session would leave two owners driving the tuner. */
+    opts.scanner_mode = 1;
+    rc |= expect_int("trunk on over scanner queued", dsd_app_command_set_i32(DSD_APP_CMD_TRUNK_SET, 1),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("trunk on over scanner drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("trunk on enables trunking over scanner", opts.trunk_enable, 1);
+    rc |= expect_int("trunk on clears scanner mode", opts.scanner_mode, 0);
+
+    /* Turning it off is the narrow half: TUNER_RELEASE stays the way to clear
+     * both, so this must not reach into scanner mode on the way out. */
+    opts.scanner_mode = 1;
+    rc |= expect_int("trunk off over scanner queued", dsd_app_command_set_i32(DSD_APP_CMD_TRUNK_SET, 0),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("trunk off over scanner drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("trunk off leaves scanner mode alone", opts.scanner_mode, 1);
+
+    /* Carries a payload, so the payload-less action API must refuse it — a bare
+     * action submit would arrive with no bytes and read as "stop trunking". */
+    rc |= expect_int("trunk set rejects an action submit", dsd_app_command_action(DSD_APP_CMD_TRUNK_SET),
+                     DSD_APP_COMMAND_SUBMIT_REJECTED);
+    freeState(&state);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -1536,6 +1595,7 @@ main(void) {
     rc |= test_io_and_state_commands();
     rc |= test_compact_visualizer_toast();
     rc |= test_modulation_and_decode_mode_setters();
+    rc |= test_trunk_set();
 #ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
     rc |= test_manual_tune_commands_commit_only_after_acceptance();
     rc |= test_manual_tune_trunking_gate_and_reacquisition();

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -362,6 +362,45 @@ test_command_api(void) {
     return rc;
 }
 
+/*
+ * Spectrum tap-to-tune shares the queue with the settings tune but must never
+ * share a coalescing slot with it: a tap storm has to collapse onto its own
+ * newest target while a pending settings tune still lands.
+ *
+ * Trunking is left on here so draining cannot reach the tuner; the gate itself
+ * is asserted against the wrapped tune stub further down.
+ */
+static int
+test_manual_tune_queue_semantics(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    init_test_context(&opts, &state);
+    opts.trunk_enable = 1;
+
+    rc |= expect_int("manual tune rejects i32", dsd_app_command_set_i32(DSD_APP_CMD_MANUAL_TUNE, 1), -1);
+    rc |= expect_int("manual tune u32 posts", dsd_app_command_set_u32(DSD_APP_CMD_MANUAL_TUNE, 3000000000U),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("tap storm coalesces onto the newest target",
+                     dsd_app_command_set_u32(DSD_APP_CMD_MANUAL_TUNE, 851000000U), DSD_APP_COMMAND_SUBMIT_COALESCED);
+    rc |= expect_int("a settings tune never absorbs a tap",
+                     dsd_app_command_set_u32(DSD_APP_CMD_RTL_SET_FREQ, 852000000U), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("a tap never absorbs a settings tune",
+                     dsd_app_command_set_u32(DSD_APP_CMD_MANUAL_TUNE, 853000000U), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("distinct tune entries drain", dsd_app_drain_cmds(&opts, &state), 3);
+
+    /* An undersized payload is consumed but must reach no handler at all — with
+     * trunking on, even the refusal toast would prove it got that far. */
+    state.ui_msg[0] = '\0';
+    uint8_t short_payload = 0xFFU;
+    dsd_app_command_submit(DSD_APP_CMD_MANUAL_TUNE, &short_payload, sizeof(short_payload));
+    rc |= expect_int("short manual tune payload drains", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_str("short manual tune payload is ignored", state.ui_msg, "");
+
+    freeState(&state);
+    return rc;
+}
+
 static int
 test_setter_coalescing_preserves_fifo_boundaries(void) {
     int rc = 0;
@@ -1049,12 +1088,83 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
     return rc;
 }
+
+/*
+ * Tap-to-tune is gated on the live trunk_enable at drain time, not on the
+ * frontend hiding the affordance, and an accepted tap tears down call state so
+ * the decoder re-acquires on the new frequency instead of aging out.
+ */
+static int
+test_manual_tune_trunking_gate_and_reacquisition(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+
+    init_test_context(&opts, &state);
+    seed_active_p25_voice(&opts, &state, 851000000L, 852000000L, 1201);
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    rc |= expect_int("manual tune under trunking queued", dsd_app_command_set_u32(DSD_APP_CMD_MANUAL_TUNE, 853125000U),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("manual tune under trunking drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("manual tune under trunking never reaches the tuner", g_io_control_tune_calls, 0);
+    rc |= expect_contains("manual tune under trunking explains itself", state.ui_msg, "Trunking active");
+    rc |= expect_int("manual tune under trunking leaves the trunker tuned", opts.trunk_is_tuned, 1);
+    rc |= expect_true("manual tune under trunking leaves the VC", state.p25_vc_freq[0] == 852000000L);
+    freeState(&state);
+
+    init_test_context(&opts, &state);
+    seed_active_p25_voice(&opts, &state, 851000000L, 852000000L, 1201);
+    rc |= seed_active_canonical_calls(&opts, &state, 852000000L, 1201);
+    opts.trunk_enable = 0;
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    rc |= expect_int("manual tune queued", dsd_app_command_set_u32(DSD_APP_CMD_MANUAL_TUNE, 853125000U),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("manual tune drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("manual tune reaches the tuner once", g_io_control_tune_calls, 1);
+    rc |= expect_true("manual tune targets the tapped frequency", g_io_control_tune_freq == 853125000L);
+    rc |= expect_contains("manual tune reports applied", state.ui_msg, "Applied: tuned -> 853125000 Hz");
+    rc |= expect_call_phase("manual tune ends canonical slot 1", &state, 0U, DSD_CALL_PHASE_ENDED);
+    rc |= expect_call_phase("manual tune ends canonical slot 2", &state, 1U, DSD_CALL_PHASE_ENDED);
+    rc |= expect_int("manual tune clears trunk tuned", opts.trunk_is_tuned, 0);
+    rc |= expect_true("manual tune clears the VC", state.p25_vc_freq[0] == 0L);
+    freeState(&state);
+
+    /* A tune the backend only accepted (no hardware confirmation yet) still has
+     * to reset for re-acquisition — the same rule ui_cmd_apply_status_from_tune_rc
+     * encodes for RTL_SET_FREQ. */
+    init_test_context(&opts, &state);
+    seed_active_canonical_calls(&opts, &state, 852000000L, 1301);
+    opts.trunk_enable = 0;
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_TIMEOUT);
+    rc |= expect_int("pending manual tune queued", dsd_app_command_set_u32(DSD_APP_CMD_MANUAL_TUNE, 854000000U),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("pending manual tune drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_contains("pending manual tune reports pending", state.ui_msg, "(pending)");
+    rc |= expect_call_phase("pending manual tune still ends slot 1", &state, 0U, DSD_CALL_PHASE_ENDED);
+    freeState(&state);
+
+    /* A refused tune must leave call state alone. */
+    init_test_context(&opts, &state);
+    seed_active_canonical_calls(&opts, &state, 852000000L, 1401);
+    opts.trunk_enable = 0;
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_FAILED);
+    rc |= expect_int("failed manual tune queued", dsd_app_command_set_u32(DSD_APP_CMD_MANUAL_TUNE, 855000000U),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("failed manual tune drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_contains("failed manual tune reports failure", state.ui_msg, "Failed: tune -> 855000000 Hz");
+    rc |= expect_call_phase("failed manual tune keeps slot 1 active", &state, 0U, DSD_CALL_PHASE_ACTIVE);
+    freeState(&state);
+
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    return rc;
+}
 #endif
 
 int
 main(void) {
     int rc = 0;
     rc |= test_command_api();
+    rc |= test_manual_tune_queue_semantics();
     rc |= test_setter_coalescing_preserves_fifo_boundaries();
     rc |= test_visibility_and_queue_overflow();
     rc |= test_key_and_runtime_state_commands();
@@ -1063,6 +1173,7 @@ main(void) {
     rc |= test_compact_visualizer_toast();
 #ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
     rc |= test_manual_tune_commands_commit_only_after_acceptance();
+    rc |= test_manual_tune_trunking_gate_and_reacquisition();
 #endif
     if (rc == 0) {
         printf("DSD_APP_CMD_QUEUE: OK\n");

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1352,7 +1352,11 @@ test_modulation_and_decode_mode_setters(void) {
 
     /* Timing comes from the decode set, not from a constant. ProVoice is the one
      * mode this control reaches that is not 4800 symbols/s, and applying a
-     * modulation at 4800 on a 9600-baud signal is a decoder that stops decoding. */
+     * modulation at 4800 on a 9600-baud signal is a decoder that stops decoding.
+     *
+     * Started from C4FM so the request below is a real change: ProVoice runs on a
+     * two-level profile, where every request lands on GFSK, so one made from GFSK
+     * is already satisfied. */
     init_test_context(&opts, &state);
     opts.frame_provoice = 1;
     opts.frame_p25p1 = 0;
@@ -1365,16 +1369,53 @@ test_modulation_and_decode_mode_setters(void) {
     opts.frame_dstar = 0;
     opts.frame_x2tdma = 0;
     opts.frame_dpmr = 0;
-    opts.mod_c4fm = 0;
+    opts.mod_c4fm = 1;
     opts.mod_qpsk = 0;
-    opts.mod_gfsk = 1;
-    state.rf_mod = 2;
-    rc |= expect_int("provoice c4fm queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 0),
+    opts.mod_gfsk = 0;
+    state.rf_mod = 0;
+    rc |= expect_int("provoice gfsk queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 2),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
-    rc |= expect_int("provoice c4fm drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("provoice gfsk drained", dsd_app_drain_cmds(&opts, &state), 1);
     /* 48 kHz / 9600 = 5, the value the EDACS/ProVoice preset itself installs. */
     rc |= expect_int("provoice keeps its 9600 timing", state.samplesPerSymbol, 5);
     rc |= expect_int("provoice hunts on the 9600 profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_9600_2);
+    freeState(&state);
+
+    /* Two-level decode sets have one modulation. Asking for C4FM on ProVoice used
+     * to be honoured in opts->mod_* and then undone in state->rf_mod alone, by
+     * frame_sync_apply_sps_hunt_profile() normalising the 9600/2 profile back to
+     * GFSK — leaving the control reading C4FM off flags the demodulator had
+     * already contradicted, with no tap able to resynchronise them because the two
+     * disagreeing is exactly what the idempotency guard tests. */
+    init_test_context(&opts, &state);
+    opts.frame_provoice = 1;
+    opts.frame_p25p1 = 0;
+    opts.frame_p25p2 = 0;
+    opts.frame_dmr = 0;
+    opts.frame_nxdn48 = 0;
+    opts.frame_nxdn96 = 0;
+    opts.frame_ysf = 0;
+    opts.frame_m17 = 0;
+    opts.frame_dstar = 0;
+    opts.frame_x2tdma = 0;
+    opts.frame_dpmr = 0;
+    opts.mod_c4fm = 1;
+    opts.mod_qpsk = 0;
+    opts.mod_gfsk = 0;
+    state.rf_mod = 0;
+    rc |= expect_int("provoice c4fm queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 0),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("provoice c4fm drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("provoice c4fm lands on gfsk", state.rf_mod, 2);
+    rc |= expect_int("provoice c4fm sets the gfsk flag", opts.mod_gfsk, 1);
+    rc |= expect_int("provoice c4fm clears the c4fm flag", opts.mod_c4fm, 0);
+    /* And having landed there, it stays: the two readings now agree, so the guard
+     * fires and the timing is not rebuilt on every repeat of the same tap. */
+    state.samplesPerSymbol = 12345;
+    rc |= expect_int("provoice repeat c4fm queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 0),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("provoice repeat c4fm drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("provoice repeat c4fm changes nothing", state.samplesPerSymbol, 12345);
     freeState(&state);
 
     /* AUTO enables ProVoice next to the 4800 modes, so its flag alone must not
@@ -1438,6 +1479,29 @@ test_modulation_and_decode_mode_setters(void) {
     rc |= expect_int("nxdn48 selects the 2400 hunt profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_2400_4);
     rc |= expect_int("nxdn48 restarts the hunt dwell", state.sps_hunt_counter, 0);
     rc |= expect_int("nxdn48 installs 2400 timing", state.samplesPerSymbol, 20);
+    freeState(&state);
+
+    /* The session's stream shape survives a mode change, because the backend fixed
+     * it when the stream was opened. dmr_stereo is not part of that shape and must
+     * not be dragged along with it: it selects two-slot decoding, and the DMR
+     * playback paths mix the two slots down themselves when the stream is mono
+     * (playSynthesizedVoiceSS3/FS3). Held to dmr_stereo == 1 here because the
+     * alternative pairs it with dmr_mono == 0, which no preset produces and which
+     * dmr_handle_voice() has no branch for on MS voice. */
+    init_test_context(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dmr = 0;
+    opts.pulse_digi_out_channels = 1;
+    opts.pulse_digi_rate_out = 8000;
+    opts.dmr_stereo = 0;
+    rc |= expect_int("mono dmr mode queued",
+                     dsd_app_command_set_i32(DSD_APP_CMD_DECODE_MODE_SET, (int32_t)DSDCFG_MODE_DMR),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("mono dmr mode drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("mono session keeps its one channel", opts.pulse_digi_out_channels, 1);
+    rc |= expect_int("mono session keeps its rate", opts.pulse_digi_rate_out, 8000);
+    rc |= expect_int("dmr still decodes both slots", opts.dmr_stereo, 1);
+    rc |= expect_int("and not as dmr mono", opts.dmr_mono, 0);
     freeState(&state);
 
     /* Back to auto re-enables the set the engine starts with. */

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -28,6 +28,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/runtime/config.h"
 
 #ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
 static int g_io_control_tune_result = RTL_STREAM_TUNE_OK;
@@ -1174,7 +1175,189 @@ test_manual_tune_trunking_gate_and_reacquisition(void) {
     reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
     return rc;
 }
+
+/*
+ * Releasing the tuner is how a frontend says "stop moving this on your own"
+ * without knowing which of the two owners is active — so it has to be an
+ * unconditional clear of both, safe to repeat, and it has to leave behind a
+ * decoder that can be tuned by hand.
+ */
+static int
+test_tuner_release(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+
+    /* Trunking: the flags go down and the follow state goes with them. Leaving
+     * trunk_is_tuned or the VC set would keep the DMR sync-time stamping alive
+     * and block the decoder from ever learning a new control channel. */
+    init_test_context(&opts, &state);
+    seed_active_p25_voice(&opts, &state, 851000000L, 852000000L, 1201);
+    rc |= seed_active_canonical_calls(&opts, &state, 852000000L, 1201);
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    rc |=
+        expect_int("release queued", dsd_app_command_action(DSD_APP_CMD_TUNER_RELEASE), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("release drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("release clears trunking", opts.trunk_enable, 0);
+    rc |= expect_int("release clears the scanner", opts.scanner_mode, 0);
+    rc |= expect_int("release clears trunk tuned", opts.trunk_is_tuned, 0);
+    rc |= expect_true("release clears the VC", state.p25_vc_freq[0] == 0L && state.trunk_vc_freq[0] == 0L);
+    rc |= expect_call_phase("release ends canonical slot 1", &state, 0U, DSD_CALL_PHASE_ENDED);
+    rc |= expect_call_phase("release ends canonical slot 2", &state, 1U, DSD_CALL_PHASE_ENDED);
+    rc |= expect_contains("release explains itself", state.ui_msg, "Automatic tuning stopped");
+    rc |= expect_int("release never touches the tuner itself", g_io_control_tune_calls, 0);
+
+    /* And it is the whole point that a tap now works where it was refused. */
+    rc |= expect_int("tune after release queued", dsd_app_command_set_u32(DSD_APP_CMD_MANUAL_TUNE, 853125000U),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("tune after release drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("tune after release reaches the tuner", g_io_control_tune_calls, 1);
+    rc |= expect_contains("tune after release reports applied", state.ui_msg, "Applied: tuned -> 853125000 Hz");
+    freeState(&state);
+
+    /* Conventional scanner mode is the other owner, and a frontend cannot tell
+     * the two apart — one release has to cover both, including both at once. */
+    init_test_context(&opts, &state);
+    seed_active_p25_voice(&opts, &state, 851000000L, 852000000L, 1201);
+    opts.scanner_mode = 1;
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    rc |= expect_int("release under both queued", dsd_app_command_action(DSD_APP_CMD_TUNER_RELEASE),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("release under both drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("release under both clears trunking", opts.trunk_enable, 0);
+    rc |= expect_int("release under both clears the scanner", opts.scanner_mode, 0);
+
+    /* Repeating it is a no-op, not a toggle back on: the frontend re-sends this
+     * whenever it re-enters explore mode and cannot know the current state. */
+    rc |= expect_int("second release queued", dsd_app_command_action(DSD_APP_CMD_TUNER_RELEASE),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("second release drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("second release leaves trunking off", opts.trunk_enable, 0);
+    rc |= expect_int("second release leaves the scanner off", opts.scanner_mode, 0);
+    freeState(&state);
+
+    /* It carries no payload, so the setter APIs must not accept it — that is
+     * what keeps the action-id list and the payload rules from drifting. */
+    rc |= expect_int("release rejects a u32 payload", dsd_app_command_set_u32(DSD_APP_CMD_TUNER_RELEASE, 1U),
+                     DSD_APP_COMMAND_SUBMIT_REJECTED);
+    rc |= expect_int("release rejects an i32 payload", dsd_app_command_set_i32(DSD_APP_CMD_TUNER_RELEASE, 1),
+                     DSD_APP_COMMAND_SUBMIT_REJECTED);
+
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    return rc;
+}
 #endif
+
+/*
+ * Modulation and decode mode as setters rather than toggles. A panel showing
+ * both choices has to be able to ask for the one it is not on, and re-asserting
+ * the state it is already on must cost nothing — a segmented control re-sends
+ * itself whenever the engine publishes a frame it did not cause.
+ */
+static int
+test_modulation_and_decode_mode_setters(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+
+    init_test_context(&opts, &state);
+    opts.mod_c4fm = 1;
+    opts.mod_qpsk = 0;
+    state.rf_mod = 0;
+
+    rc |= expect_int("qpsk queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 1), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("qpsk drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("qpsk selected", opts.mod_qpsk, 1);
+    rc |= expect_int("qpsk clears c4fm", opts.mod_c4fm, 0);
+    rc |= expect_int("qpsk moves rf_mod", state.rf_mod, 1);
+
+    /* Asking again for what it is already on leaves the timing the decoder has
+     * settled on alone. Observable through samplesPerSymbol, which the apply
+     * path rewrites. */
+    state.samplesPerSymbol = 12345;
+    rc |= expect_int("repeat qpsk queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 1),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("repeat qpsk drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("repeat qpsk changes nothing", state.samplesPerSymbol, 12345);
+
+    rc |= expect_int("c4fm queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 0), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("c4fm drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("c4fm selected", opts.mod_c4fm, 1);
+    rc |= expect_int("c4fm clears qpsk", opts.mod_qpsk, 0);
+    rc |= expect_int("c4fm moves rf_mod", state.rf_mod, 0);
+    rc |= expect_true("c4fm rebuilds timing", state.samplesPerSymbol != 12345);
+    freeState(&state);
+
+    /* GFSK is the third rf_mod value, and the one the DMR/NXDN/YSF/M17/dPMR and
+     * EDACS presets leave behind. Asking for C4FM from there is a real change, so
+     * the idempotency guard must not swallow it. */
+    init_test_context(&opts, &state);
+    opts.mod_c4fm = 0;
+    opts.mod_qpsk = 0;
+    opts.mod_gfsk = 1;
+    state.rf_mod = 2;
+    state.samplesPerSymbol = 12345;
+    rc |= expect_int("c4fm from gfsk queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 0),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("c4fm from gfsk drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("c4fm from gfsk selected", opts.mod_c4fm, 1);
+    rc |= expect_int("c4fm from gfsk clears gfsk", opts.mod_gfsk, 0);
+    rc |= expect_int("c4fm from gfsk moves rf_mod", state.rf_mod, 0);
+    rc |= expect_true("c4fm from gfsk rebuilds timing", state.samplesPerSymbol != 12345);
+
+    /* And the other segment from the same starting point. */
+    opts.mod_c4fm = 0;
+    opts.mod_qpsk = 0;
+    opts.mod_gfsk = 1;
+    state.rf_mod = 2;
+    state.samplesPerSymbol = 12345;
+    rc |= expect_int("qpsk from gfsk queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 1),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("qpsk from gfsk drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("qpsk from gfsk selected", opts.mod_qpsk, 1);
+    rc |= expect_int("qpsk from gfsk clears gfsk", opts.mod_gfsk, 0);
+    rc |= expect_int("qpsk from gfsk moves rf_mod", state.rf_mod, 1);
+    freeState(&state);
+
+    /* Decode mode goes through the same preset helper the CLI uses, so a mode
+     * chosen here means what it means at startup. DMR must leave P25 off. */
+    init_test_context(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_dmr = 0;
+    rc |= seed_active_canonical_calls(&opts, &state, 852000000L, 1501);
+    rc |= expect_int("dmr mode queued", dsd_app_command_set_i32(DSD_APP_CMD_DECODE_MODE_SET, (int32_t)DSDCFG_MODE_DMR),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("dmr mode drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("dmr enabled", opts.frame_dmr, 1);
+    rc |= expect_int("p25p1 disabled", opts.frame_p25p1, 0);
+    rc |= expect_int("p25p2 disabled", opts.frame_p25p2, 0);
+    rc |= expect_contains("decode mode explains itself", state.ui_msg, "DMR");
+    /* A call open on the protocol we just stopped decoding would never be closed
+     * by the one we started, so it has to end here. */
+    rc |= expect_call_phase("decode change ends slot 1", &state, 0U, DSD_CALL_PHASE_ENDED);
+    rc |= expect_call_phase("decode change ends slot 2", &state, 1U, DSD_CALL_PHASE_ENDED);
+    freeState(&state);
+
+    /* Back to auto re-enables the set the engine starts with. */
+    init_test_context(&opts, &state);
+    opts.frame_dmr = 1;
+    opts.frame_p25p1 = 0;
+    rc |=
+        expect_int("auto mode queued", dsd_app_command_set_i32(DSD_APP_CMD_DECODE_MODE_SET, (int32_t)DSDCFG_MODE_AUTO),
+                   DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("auto mode drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("auto re-enables p25", opts.frame_p25p1, 1);
+    rc |= expect_int("auto keeps dmr", opts.frame_dmr, 1);
+
+    /* Both carry a payload, so the payload-less action API must refuse them. */
+    rc |= expect_int("mod set rejects an action submit", dsd_app_command_action(DSD_APP_CMD_MOD_SET),
+                     DSD_APP_COMMAND_SUBMIT_REJECTED);
+    rc |= expect_int("decode mode rejects an action submit", dsd_app_command_action(DSD_APP_CMD_DECODE_MODE_SET),
+                     DSD_APP_COMMAND_SUBMIT_REJECTED);
+    freeState(&state);
+    return rc;
+}
 
 int
 main(void) {
@@ -1187,9 +1370,11 @@ main(void) {
     rc |= test_file_network_and_import_commands();
     rc |= test_io_and_state_commands();
     rc |= test_compact_visualizer_toast();
+    rc |= test_modulation_and_decode_mode_setters();
 #ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
     rc |= test_manual_tune_commands_commit_only_after_acceptance();
     rc |= test_manual_tune_trunking_gate_and_reacquisition();
+    rc |= test_tuner_release();
 #endif
     if (rc == 0) {
         printf("DSD_APP_CMD_QUEUE: OK\n");

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1399,6 +1399,10 @@ test_modulation_and_decode_mode_setters(void) {
     opts.frame_p25p1 = 1;
     opts.frame_p25p2 = 1;
     opts.frame_dmr = 0;
+    /* Mid-session the hunt is wherever the previous mode left it — here the P25p2
+     * 6000 profile, part-way through its dwell. */
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+    state.sps_hunt_counter = 11;
     rc |= seed_active_canonical_calls(&opts, &state, 852000000L, 1501);
     rc |= expect_int("dmr mode queued", dsd_app_command_set_i32(DSD_APP_CMD_DECODE_MODE_SET, (int32_t)DSDCFG_MODE_DMR),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
@@ -1407,10 +1411,33 @@ test_modulation_and_decode_mode_setters(void) {
     rc |= expect_int("p25p1 disabled", opts.frame_p25p1, 0);
     rc |= expect_int("p25p2 disabled", opts.frame_p25p2, 0);
     rc |= expect_contains("decode mode explains itself", state.ui_msg, "DMR");
+    /* Left on the old mode's profile the hunt overwrites the timing installed
+     * here on its very next pass, and the new mode never gets a chance. */
+    rc |= expect_int("dmr mode selects the 4800 hunt profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    rc |= expect_int("dmr mode restarts the hunt dwell", state.sps_hunt_counter, 0);
+    rc |= expect_int("dmr mode installs 4800 timing", state.samplesPerSymbol, 10);
     /* A call open on the protocol we just stopped decoding would never be closed
      * by the one we started, so it has to end here. */
     rc |= expect_call_phase("decode change ends slot 1", &state, 0U, DSD_CALL_PHASE_ENDED);
     rc |= expect_call_phase("decode change ends slot 2", &state, 1U, DSD_CALL_PHASE_ENDED);
+    freeState(&state);
+
+    /* A mode on a different symbol rate has to carry the hunt with it: NXDN48 is
+     * 2400 sym/s, and a decoder left on the 4800 profile is looking for it at
+     * twice the symbol clock through a 12.5 kHz filter. */
+    init_test_context(&opts, &state);
+    opts.frame_dmr = 1;
+    opts.frame_p25p1 = 0;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.sps_hunt_counter = 5;
+    rc |= expect_int("nxdn48 mode queued",
+                     dsd_app_command_set_i32(DSD_APP_CMD_DECODE_MODE_SET, (int32_t)DSDCFG_MODE_NXDN48),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("nxdn48 mode drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("nxdn48 enabled", opts.frame_nxdn48, 1);
+    rc |= expect_int("nxdn48 selects the 2400 hunt profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_2400_4);
+    rc |= expect_int("nxdn48 restarts the hunt dwell", state.sps_hunt_counter, 0);
+    rc |= expect_int("nxdn48 installs 2400 timing", state.samplesPerSymbol, 20);
     freeState(&state);
 
     /* Back to auto re-enables the set the engine starts with. */

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1288,9 +1288,9 @@ test_modulation_and_decode_mode_setters(void) {
     rc |= expect_true("c4fm rebuilds timing", state.samplesPerSymbol != 12345);
     freeState(&state);
 
-    /* GFSK is the third rf_mod value, and the one the DMR/NXDN/YSF/M17/dPMR and
-     * EDACS presets leave behind. Asking for C4FM from there is a real change, so
-     * the idempotency guard must not swallow it. */
+    /* GFSK is the third rf_mod value, and the one the DMR and EDACS/ProVoice
+     * presets leave behind. Asking for C4FM from there is a real change, so the
+     * idempotency guard must not swallow it. */
     init_test_context(&opts, &state);
     opts.mod_c4fm = 0;
     opts.mod_qpsk = 0;
@@ -1317,6 +1317,80 @@ test_modulation_and_decode_mode_setters(void) {
     rc |= expect_int("qpsk from gfsk selected", opts.mod_qpsk, 1);
     rc |= expect_int("qpsk from gfsk clears gfsk", opts.mod_gfsk, 0);
     rc |= expect_int("qpsk from gfsk moves rf_mod", state.rf_mod, 1);
+
+    /* And back to GFSK, which is why it is a choice and not just a reading: the
+     * preset that selected it is not re-run by the modulation control, so without
+     * this the first tap on any other segment is a one-way door. */
+    state.samplesPerSymbol = 12345;
+    rc |= expect_int("gfsk queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 2), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("gfsk drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("gfsk selected", opts.mod_gfsk, 1);
+    rc |= expect_int("gfsk clears c4fm", opts.mod_c4fm, 0);
+    rc |= expect_int("gfsk clears qpsk", opts.mod_qpsk, 0);
+    rc |= expect_int("gfsk moves rf_mod", state.rf_mod, 2);
+    rc |= expect_true("gfsk rebuilds timing", state.samplesPerSymbol != 12345);
+
+    /* Idempotent on its own value too, same as the other two. */
+    state.samplesPerSymbol = 12345;
+    rc |= expect_int("repeat gfsk queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 2),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("repeat gfsk drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("repeat gfsk changes nothing", state.samplesPerSymbol, 12345);
+
+    /* A modulation that does not exist is refused rather than clamped: clamping
+     * would land the demodulator on C4FM, which nobody asked for. */
+    rc |= expect_int("out of range queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 3),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("out of range drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("out of range leaves modulation alone", state.rf_mod, 2);
+    rc |= expect_int("out of range leaves timing alone", state.samplesPerSymbol, 12345);
+    rc |=
+        expect_int("negative queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, -1), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("negative drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("negative leaves modulation alone", state.rf_mod, 2);
+    freeState(&state);
+
+    /* Timing comes from the decode set, not from a constant. ProVoice is the one
+     * mode this control reaches that is not 4800 symbols/s, and applying a
+     * modulation at 4800 on a 9600-baud signal is a decoder that stops decoding. */
+    init_test_context(&opts, &state);
+    opts.frame_provoice = 1;
+    opts.frame_p25p1 = 0;
+    opts.frame_p25p2 = 0;
+    opts.frame_dmr = 0;
+    opts.frame_nxdn48 = 0;
+    opts.frame_nxdn96 = 0;
+    opts.frame_ysf = 0;
+    opts.frame_m17 = 0;
+    opts.frame_dstar = 0;
+    opts.frame_x2tdma = 0;
+    opts.frame_dpmr = 0;
+    opts.mod_c4fm = 0;
+    opts.mod_qpsk = 0;
+    opts.mod_gfsk = 1;
+    state.rf_mod = 2;
+    rc |= expect_int("provoice c4fm queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 0),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("provoice c4fm drained", dsd_app_drain_cmds(&opts, &state), 1);
+    /* 48 kHz / 9600 = 5, the value the EDACS/ProVoice preset itself installs. */
+    rc |= expect_int("provoice keeps its 9600 timing", state.samplesPerSymbol, 5);
+    rc |= expect_int("provoice hunts on the 9600 profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_9600_2);
+    freeState(&state);
+
+    /* AUTO enables ProVoice next to the 4800 modes, so its flag alone must not
+     * drag everything else to 9600. */
+    init_test_context(&opts, &state);
+    opts.frame_provoice = 1;
+    opts.frame_p25p1 = 1;
+    opts.mod_c4fm = 1;
+    opts.mod_qpsk = 0;
+    opts.mod_gfsk = 0;
+    state.rf_mod = 0;
+    rc |=
+        expect_int("auto qpsk queued", dsd_app_command_set_i32(DSD_APP_CMD_MOD_SET, 1), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("auto qpsk drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("auto stays on 4800 timing", state.samplesPerSymbol, 10);
+    rc |= expect_int("auto hunts on the 4800 profile", state.sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
     freeState(&state);
 
     /* Decode mode goes through the same preset helper the CLI uses, so a mode

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1090,9 +1090,9 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
 }
 
 /*
- * Tap-to-tune is gated on the live trunk_enable at drain time, not on the
- * frontend hiding the affordance, and an accepted tap tears down call state so
- * the decoder re-acquires on the new frequency instead of aging out.
+ * Tap-to-tune is gated on the live options at drain time, not on the frontend
+ * hiding the affordance, and an accepted tap tears down call state so the
+ * decoder re-acquires on the new frequency instead of aging out.
  */
 static int
 test_manual_tune_trunking_gate_and_reacquisition(void) {
@@ -1110,6 +1110,22 @@ test_manual_tune_trunking_gate_and_reacquisition(void) {
     rc |= expect_contains("manual tune under trunking explains itself", state.ui_msg, "Trunking active");
     rc |= expect_int("manual tune under trunking leaves the trunker tuned", opts.trunk_is_tuned, 1);
     rc |= expect_true("manual tune under trunking leaves the VC", state.p25_vc_freq[0] == 852000000L);
+    freeState(&state);
+
+    /* Conventional scanner mode owns the tuner too: it steps the channel map on
+     * its own once the hangtime expires, so a tap accepted here would be undone
+     * a few seconds later, after a toast claiming it had worked. */
+    init_test_context(&opts, &state);
+    seed_active_p25_voice(&opts, &state, 851000000L, 852000000L, 1201);
+    opts.trunk_enable = 0;
+    opts.scanner_mode = 1;
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    rc |= expect_int("manual tune under the scanner queued",
+                     dsd_app_command_set_u32(DSD_APP_CMD_MANUAL_TUNE, 853125000U), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("manual tune under the scanner drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("manual tune under the scanner never reaches the tuner", g_io_control_tune_calls, 0);
+    rc |= expect_contains("manual tune under the scanner explains itself", state.ui_msg, "Scanner active");
+    opts.scanner_mode = 0;
     freeState(&state);
 
     init_test_context(&opts, &state);

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1504,6 +1504,52 @@ test_modulation_and_decode_mode_setters(void) {
     rc |= expect_int("and not as dmr mono", opts.dmr_mono, 0);
     freeState(&state);
 
+    /* Asking for the mode already in effect must change nothing at all. DecodeChip
+     * taps whether or not it is already selected, so a stray tap on the lit chip
+     * would otherwise run the whole teardown above: it would end a live call and
+     * put the modulation back to the preset's, discarding the operator's own pick.
+     * ui_handle_mod_set() has held this contract since it was written; this is the
+     * same one for the decode chips beside it. */
+    init_test_context(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_dmr = 0;
+    rc |= expect_int("first dmr mode queued",
+                     dsd_app_command_set_i32(DSD_APP_CMD_DECODE_MODE_SET, (int32_t)DSDCFG_MODE_DMR),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("first dmr mode drained", dsd_app_drain_cmds(&opts, &state), 1);
+    /* The session is on DMR now. The operator picks QPSK and a call opens. */
+    opts.mod_c4fm = 0;
+    opts.mod_qpsk = 1;
+    opts.mod_gfsk = 0;
+    state.rf_mod = 1;
+    state.sps_hunt_counter = 7;
+    rc |= seed_active_canonical_calls(&opts, &state, 852000000L, 1502);
+    rc |= expect_int("repeat dmr mode queued",
+                     dsd_app_command_set_i32(DSD_APP_CMD_DECODE_MODE_SET, (int32_t)DSDCFG_MODE_DMR),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("repeat dmr mode drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("repeat keeps the operator's modulation", opts.mod_qpsk, 1);
+    rc |= expect_int("repeat leaves the hunt dwell alone", state.sps_hunt_counter, 7);
+    rc |= expect_call_phase("repeat leaves slot 1 active", &state, 0U, DSD_CALL_PHASE_ACTIVE);
+    rc |= expect_call_phase("repeat leaves slot 2 active", &state, 1U, DSD_CALL_PHASE_ACTIVE);
+    rc |= expect_contains("repeat still names the mode", state.ui_msg, "DMR");
+    freeState(&state);
+
+    /* The payload travels as a plain int32 but dsdneoUserDecodeMode is packed to a
+     * byte, so an out-of-range value does not stay out of range: 260 casts to 4,
+     * which is DSDCFG_MODE_DMR, and the DMR preset would run for a command nobody
+     * could have meant. */
+    init_test_context(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dmr = 0;
+    rc |= expect_int("out-of-range mode queued", dsd_app_command_set_i32(DSD_APP_CMD_DECODE_MODE_SET, 260),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("out-of-range mode drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("out-of-range mode does not alias onto dmr", opts.frame_dmr, 0);
+    rc |= expect_int("out-of-range mode leaves p25 alone", opts.frame_p25p1, 1);
+    freeState(&state);
+
     /* Back to auto re-enables the set the engine starts with. */
     init_test_context(&opts, &state);
     opts.frame_dmr = 1;

--- a/tests/ui/test_ui_frontend_metrics.c
+++ b/tests/ui/test_ui_frontend_metrics.c
@@ -355,14 +355,16 @@ test_visualizer_getters_without_radio(void) {
     assert(dsd_app_frontend_spectrum_get(bins, 4, &rate) == 0);
     assert(rate == 0);
 
-    assert(dsd_app_frontend_wideband_spectrum_get(bins, 4, &center, &span) == 0);
+    uint32_t serial = 99U;
+    assert(dsd_app_frontend_wideband_spectrum_get(bins, 4, &center, &span, &serial) == 0);
     assert(center == 0U);
     assert(span == 0U);
-    assert(dsd_app_frontend_wideband_spectrum_get(NULL, 0, NULL, NULL) == 0);
+    assert(serial == 0U);
+    assert(dsd_app_frontend_wideband_spectrum_get(NULL, 0, NULL, NULL, NULL) == 0);
 
     /* Toggling production must stay harmless with no stream behind it. */
     dsd_app_frontend_wideband_spectrum_set_enabled(1);
-    assert(dsd_app_frontend_wideband_spectrum_get(bins, 4, NULL, NULL) == 0);
+    assert(dsd_app_frontend_wideband_spectrum_get(bins, 4, NULL, NULL, NULL) == 0);
     dsd_app_frontend_wideband_spectrum_set_enabled(0);
 }
 

--- a/tests/ui/test_ui_frontend_metrics.c
+++ b/tests/ui/test_ui_frontend_metrics.c
@@ -333,11 +333,44 @@ test_metrics_ignore_stream_hooks_off_radio(void) {
     dsd_rtl_stream_metrics_hooks_set(NULL);
 }
 
+/*
+ * Visualizer accessors on a build with no radio backend.
+ *
+ * This target compiles frontend.c without USE_RADIO, so every accessor takes
+ * its stub branch. A frontend that renders whatever comes back needs a zero
+ * count and defined out-params from that branch, not an uninitialised axis.
+ */
+static void
+test_visualizer_getters_without_radio(void) {
+    float bins[8];
+    int rate = 1234;
+    int sps = 7;
+    uint32_t center = 99U;
+    uint32_t span = 99U;
+
+    assert(dsd_app_frontend_constellation_get(bins, 4) == 0);
+    assert(dsd_app_frontend_eye_get(bins, 4, &sps) == 0);
+    assert(sps == 0);
+    assert(dsd_app_frontend_spectrum_get(bins, 4, &rate) == 0);
+    assert(rate == 0);
+
+    assert(dsd_app_frontend_wideband_spectrum_get(bins, 4, &center, &span) == 0);
+    assert(center == 0U);
+    assert(span == 0U);
+    assert(dsd_app_frontend_wideband_spectrum_get(NULL, 0, NULL, NULL) == 0);
+
+    /* Toggling production must stay harmless with no stream behind it. */
+    dsd_app_frontend_wideband_spectrum_set_enabled(1);
+    assert(dsd_app_frontend_wideband_spectrum_get(bins, 4, NULL, NULL) == 0);
+    dsd_app_frontend_wideband_spectrum_set_enabled(0);
+}
+
 int
 main(void) {
     test_metrics_for_snapshot_does_not_consume();
     test_metrics_fallback_and_runtime_hooks();
     test_metrics_ignore_stream_hooks_off_radio();
+    test_visualizer_getters_without_radio();
     printf("UI_FRONTEND_METRICS: OK\n");
     return 0;
 }

--- a/tests/ui/test_ui_frontend_metrics.c
+++ b/tests/ui/test_ui_frontend_metrics.c
@@ -4,6 +4,7 @@
  */
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #include <dsd-neo/app_control/frontend.h>

--- a/tests/ui/test_ui_frontend_metrics.c
+++ b/tests/ui/test_ui_frontend_metrics.c
@@ -90,6 +90,26 @@ hook_symbol_profile(int* out_symbol_rate_hz, int* out_levels, int* out_channel_p
     return 0;
 }
 
+/*
+ * The shape a radio session has before the front end has published a profile:
+ * the mirror behind channel_profile is process-global and reads WIDE until then,
+ * so a width derived from it unconditionally would report 16 kHz for a channel
+ * nothing has chosen yet -- and carry the previous session's width into the next.
+ */
+static int
+hook_symbol_profile_unpublished(int* out_symbol_rate_hz, int* out_levels, int* out_channel_profile) {
+    if (out_symbol_rate_hz) {
+        *out_symbol_rate_hz = 0;
+    }
+    if (out_levels) {
+        *out_levels = 0;
+    }
+    if (out_channel_profile) {
+        *out_channel_profile = 0; /* DSD_CH_LPF_PROFILE_WIDE */
+    }
+    return 0;
+}
+
 static int
 hook_cqpsk_status(int* out_cqpsk_enable, int* out_cqpsk_timing_active) {
     if (out_cqpsk_enable) {
@@ -196,6 +216,19 @@ test_metrics_fallback_and_runtime_hooks(void) {
     assert(g_snr_c4fm_eye_calls == 0);
     assert(g_snr_gfsk_eye_calls == 0);
     assert(g_snr_qpsk_const_calls == 0);
+
+    /* No profile published yet: the width has to say "nothing to draw" rather than
+     * the WIDE fallback's 16 kHz, or a consumer shades a channel band over a
+     * session that has not chosen a channel. */
+    hooks.symbol_profile = hook_symbol_profile_unpublished;
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+    assert(dsd_app_frontend_get_metrics(&metrics) == 0);
+    assert(metrics.symbol_rate_hz == 0);
+    assert(metrics.channel_bandwidth_hz == 0);
+    hooks.symbol_profile = hook_symbol_profile;
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+    assert(dsd_app_frontend_get_metrics(&metrics) == 0);
+    assert(metrics.channel_bandwidth_hz == 12500);
 
     assert(dsd_app_frontend_get_metrics_with_snr_fallbacks(&metrics, DSD_FRONTEND_SNR_FALLBACK_ALL) == 0);
     assert(metrics.snr_c4fm_db == 23.5);

--- a/tests/ui/test_ui_frontend_metrics.c
+++ b/tests/ui/test_ui_frontend_metrics.c
@@ -39,6 +39,20 @@ dsd_app_get_latest_snapshot(void) {
     return g_latest_state;
 }
 
+/* Forward declaration for the stub defined below. */
+double dsd_channel_lpf_protected_edge_hz(int profile);
+
+/* The real one lives in dsd-neo_dsp, which this target deliberately does not
+ * link: dsp carries dsd-neo_feature_radio PUBLIC, and that would define
+ * USE_RADIO and turn this no-radio stub test into a radio build. Task 1's
+ * DSP_DEMOD_MISC pins the real per-profile values; what needs pinning HERE is
+ * that frontend.c publishes the full width rather than the half-width. */
+double
+dsd_channel_lpf_protected_edge_hz(int profile) {
+    (void)profile;
+    return 6250.0; /* the 12.5 kHz channel half-width */
+}
+
 static void
 fill_metric_inputs(dsd_opts* opts, dsd_state* state) {
     DSD_MEMSET(opts, 0, sizeof(*opts));
@@ -167,6 +181,7 @@ test_metrics_fallback_and_runtime_hooks(void) {
     assert(metrics.symbol_rate_hz == 4800);
     assert(metrics.symbol_levels == 4);
     assert(metrics.channel_profile == 5);
+    assert(metrics.channel_bandwidth_hz == 12500);
     assert(metrics.cqpsk_enable == 1);
     assert(metrics.cqpsk_timing_active == 1);
     assert(metrics.snr_c4fm_db == 23.5);

--- a/tests/ui/test_ui_frontend_metrics.c
+++ b/tests/ui/test_ui_frontend_metrics.c
@@ -39,8 +39,11 @@ dsd_app_get_latest_snapshot(void) {
     return g_latest_state;
 }
 
-/* Forward declaration for the stub defined below. */
-double dsd_channel_lpf_protected_edge_hz(int profile);
+/* Forward declaration for the stub defined below. External (non-static) linkage
+ * is required here: frontend.c is compiled and linked into this same test
+ * binary and calls this symbol expecting another translation unit to define
+ * it, which is exactly what this file does. */
+double dsd_channel_lpf_protected_edge_hz(int profile); // NOLINT(misc-use-internal-linkage)
 
 /* The real one lives in dsd-neo_dsp, which this target deliberately does not
  * link: dsp carries dsd-neo_feature_radio PUBLIC, and that would define

--- a/tests/ui/test_ui_frontend_metrics.c
+++ b/tests/ui/test_ui_frontend_metrics.c
@@ -335,6 +335,25 @@ test_metrics_ignore_stream_hooks_off_radio(void) {
 }
 
 /*
+ * A new metrics field has to be zero on an input with no demodulator behind it.
+ * frontend_metrics_defaults() memsets the struct, so this is really a guard
+ * against someone later filling the field ahead of the radio check.
+ */
+static void
+test_channel_bandwidth_is_zero_off_radio(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    dsd_frontend_metrics metrics;
+    fill_metric_inputs(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_PULSE;
+
+    /* Poison, so a field left unwritten is visible rather than accidentally right. */
+    metrics.channel_bandwidth_hz = 12500;
+    assert(dsd_app_frontend_get_metrics_for_snapshot(&opts, &state, &metrics, 0) == 0);
+    assert(metrics.channel_bandwidth_hz == 0);
+}
+
+/*
  * Visualizer accessors on a build with no radio backend.
  *
  * This target compiles frontend.c without USE_RADIO, so every accessor takes
@@ -373,6 +392,7 @@ main(void) {
     test_metrics_for_snapshot_does_not_consume();
     test_metrics_fallback_and_runtime_hooks();
     test_metrics_ignore_stream_hooks_off_radio();
+    test_channel_bandwidth_is_zero_off_radio();
     test_visualizer_getters_without_radio();
     printf("UI_FRONTEND_METRICS: OK\n");
     return 0;

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -252,6 +252,23 @@ main(int argc, char** argv) {
         opts.audio_in_type = AUDIO_IN_RTL;
     }
 
+    /* The width must move on its own. Every other tuner reading is holding still
+     * here, so if channel_bandwidth_hz were missing from tunerEquals() the frame
+     * would compare equal, publish() would skip the whole View, and this second
+     * reading would still be the first one. */
+    {
+        opts.audio_in_type = AUDIO_IN_RTL;
+        g_stub_channel_bandwidth_hz = 12500;
+        model.refresh(&opts, &state);
+        expect("width reads the first frame", model.channelBandwidthHz() == 12500);
+
+        g_stub_channel_bandwidth_hz = 6250;
+        model.refresh(&opts, &state);
+        expect("width alone moves the tuner group", model.channelBandwidthHz() == 6250);
+
+        g_stub_channel_bandwidth_hz = 0;
+    }
+
     if (g_failures != 0) {
         DSD_FPRINTF(stderr, "%d failure(s)\n", g_failures);
         return 1;

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -33,6 +33,10 @@ namespace {
 
 int g_failures = 0;
 
+/* What the stubbed frontend reports for the channel width. Per-case, because
+ * every other case wants the at-rest 0. */
+static int g_stub_channel_bandwidth_hz = 0;
+
 void
 expect(const char* what, bool ok) {
     if (!ok) {
@@ -57,6 +61,7 @@ dsd_app_frontend_get_metrics_for_snapshot(const dsd_opts* opts, const dsd_state*
         return -1;
     }
     *out = dsd_frontend_metrics{};
+    out->channel_bandwidth_hz = g_stub_channel_bandwidth_hz;
     return 0;
 }
 
@@ -229,6 +234,23 @@ main(int argc, char** argv) {
     model.clear();
     expect("a cleared model reports no lock", !model.syncedHere());
     expect("a cleared model reports no tuner", !model.radioInput());
+
+    /* The channel width rides the tuner group: it moves when the decoder changes
+     * profile, not when the user changes a setting. It is also gated on a radio
+     * input, like every other tuner reading. */
+    {
+        g_stub_channel_bandwidth_hz = 12500;
+        opts.audio_in_type = AUDIO_IN_RTL;
+        model.refresh(&opts, &state);
+        expect("channel bandwidth reaches the model", model.channelBandwidthHz() == 12500);
+
+        opts.audio_in_type = AUDIO_IN_PULSE;
+        model.refresh(&opts, &state);
+        expect("channel bandwidth is zero off a radio", model.channelBandwidthHz() == 0);
+
+        g_stub_channel_bandwidth_hz = 0;
+        opts.audio_in_type = AUDIO_IN_RTL;
+    }
 
     if (g_failures != 0) {
         DSD_FPRINTF(stderr, "%d failure(s)\n", g_failures);

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -115,6 +115,45 @@ main(int argc, char** argv) {
     expect("a decoder that stopped finding anything stops reading as locked", !model.syncedHere());
     expect("an expired lock names nothing", model.syncLabel().isEmpty());
 
+    /* Whether trunking has anything to follow here. A control offering to hand
+     * the tuner over needs the protocol, not merely a lock: on M17 there is no
+     * trunking to hand it to, and on nothing at all there is nothing to follow. */
+    expect("no lock is not something to follow", !model.trunkableSync());
+
+    state.synctype = DSD_SYNC_P25P1_POS;
+    model.refresh(&opts, &state);
+    expect("P25p1 is something trunking can follow", model.trunkableSync());
+
+    model.expireSyncForTest();
+    state.synctype = DSD_SYNC_DMR_BS_DATA_POS;
+    model.refresh(&opts, &state);
+    expect("DMR is something trunking can follow", model.trunkableSync());
+
+    model.expireSyncForTest();
+    state.synctype = DSD_SYNC_M17_STR_POS;
+    model.refresh(&opts, &state);
+    expect("M17 locks without giving trunking anything to follow", !model.trunkableSync());
+    expect("M17 still reads as locked", model.syncedHere());
+
+    model.expireSyncForTest();
+    state.synctype = DSD_SYNC_DSTAR_VOICE_POS;
+    model.refresh(&opts, &state);
+    expect("D-STAR locks without giving trunking anything to follow", !model.trunkableSync());
+
+    /* Rides the decayed lock, not the raw frame: a control that vanished on the
+     * one unsynced poll between two synced ones would flicker under the finger. */
+    model.expireSyncForTest();
+    state.synctype = DSD_SYNC_P25P2_POS;
+    model.refresh(&opts, &state);
+    state.synctype = DSD_SYNC_NONE;
+    model.refresh(&opts, &state);
+    expect("one unsynced poll does not withdraw the offer", model.trunkableSync());
+
+    model.expireSyncForTest();
+    state.synctype = DSD_SYNC_NONE;
+    model.refresh(&opts, &state);
+    expect("an expired lock withdraws the offer", !model.trunkableSync());
+
     /* The panel's own readings come from the options, not from what anything
      * asked for. Squelch is stored as mean power and must reach QML as decibels,
      * or a -120 dB threshold renders as 0. */

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ *
+ * Regression test: what MetricsModel makes of a decoder snapshot.
+ *
+ * The readings a screen gates on are derived here, and getting them wrong is
+ * invisible in a screenshot: a lock light that stays lit after the decoder has
+ * been told to look for something else reads as "it is working" while nothing is
+ * being decoded at all. That one shipped — a one-shot latch reset raced whatever
+ * the poll happened to read on the same frame — which is what these cases pin.
+ */
+
+#include <QCoreApplication>
+#include <QString>
+#include <cmath>
+#include <stdio.h>
+
+#include <dsd-neo/app_control/frontend.h>
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/init.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/power.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "metrics_model.h"
+
+namespace {
+
+int g_failures = 0;
+
+void
+expect(const char* what, bool ok) {
+    if (!ok) {
+        DSD_FPRINTF(stderr, "FAIL: %s\n", what);
+        g_failures++;
+    }
+}
+
+} // namespace
+
+/*
+ * The frontend boundary, stubbed. Linking the real one would drag in the engine
+ * and the radio backends for a test about arithmetic over a snapshot.
+ */
+extern "C" int
+dsd_app_frontend_get_metrics_for_snapshot(const dsd_opts* opts, const dsd_state* state, dsd_frontend_metrics* out,
+                                          unsigned int snr_fallbacks) {
+    (void)opts;
+    (void)state;
+    (void)snr_fallbacks;
+    if (out == nullptr) {
+        return -1;
+    }
+    *out = dsd_frontend_metrics{};
+    return 0;
+}
+
+extern "C" dsd_frontend_snr_readout
+dsd_app_frontend_snr_for_mod(const dsd_frontend_metrics* metrics, int rf_mod) {
+    (void)metrics;
+    (void)rf_mod;
+    dsd_frontend_snr_readout out{};
+    out.valid = 0;
+    out.snr_db = 0.0;
+    return out;
+}
+
+int
+main(int argc, char** argv) {
+    QCoreApplication app(argc, argv);
+
+    static dsd_opts opts;
+    static dsd_state state;
+    initOpts(&opts);
+    initState(&state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.rtlsdr_center_freq = 769768750;
+    opts.rtl_gain_value = 30;
+    opts.rtl_squelch_level = dB_to_pwr(-120.0);
+    opts.mod_c4fm = 1;
+    opts.mod_qpsk = 0;
+
+    dsd_qt::MetricsModel model;
+
+    /* Nothing has synced: the strip must say so rather than default to a lock. */
+    state.synctype = DSD_SYNC_NONE;
+    state.lastsynctype = DSD_SYNC_NONE;
+    model.refresh(&opts, &state);
+    expect("an unsynced decoder does not read as locked", !model.syncedHere());
+    expect("an unsynced decoder names nothing", model.syncLabel().isEmpty());
+
+    /* A live sync latches, and names what it locked to. */
+    state.synctype = DSD_SYNC_P25P1_POS;
+    model.refresh(&opts, &state);
+    expect("a live sync reads as locked", model.syncedHere());
+    expect("a live sync names the protocol", model.syncLabel().contains(QStringLiteral("P25")));
+
+    /* Sync comes and goes between polls, so a single unsynced frame must not
+     * drop the lock — that is what the hold is for. */
+    state.synctype = DSD_SYNC_NONE;
+    model.refresh(&opts, &state);
+    expect("one unsynced poll does not drop the lock", model.syncedHere());
+
+    /* But the hold expires. Nothing clears it explicitly: a decoder told to look
+     * for another protocol simply stops finding this one, and the reading has to
+     * follow that on its own. This is the case the shipped bug failed. */
+    model.expireSyncForTest();
+    state.synctype = DSD_SYNC_NONE;
+    model.refresh(&opts, &state);
+    expect("a decoder that stopped finding anything stops reading as locked", !model.syncedHere());
+    expect("an expired lock names nothing", model.syncLabel().isEmpty());
+
+    /* The panel's own readings come from the options, not from what anything
+     * asked for. Squelch is stored as mean power and must reach QML as decibels,
+     * or a -120 dB threshold renders as 0. */
+    expect("gain is reported", model.tunerGainDb() == 30);
+    expect("squelch is reported in dB", std::fabs(model.squelchDb() - (-120.0)) < 0.5);
+    expect("c4fm reads as modulation 0", model.modulation() == 0);
+
+    opts.mod_qpsk = 1;
+    opts.mod_c4fm = 0;
+    model.refresh(&opts, &state);
+    expect("qpsk reads as modulation 1", model.modulation() == 1);
+
+    /* Tuner ownership: the gate is the OR, and the two named owners exist only to
+     * word a message. All three have to agree. */
+    opts.trunk_enable = 1;
+    model.refresh(&opts, &state);
+    expect("trunking owns the tuner", model.tunerControlled() && model.trunkingEnabled());
+    expect("trunking is not the scanner", !model.scannerMode());
+    opts.trunk_enable = 0;
+    opts.scanner_mode = 1;
+    model.refresh(&opts, &state);
+    expect("the scanner owns the tuner too", model.tunerControlled() && model.scannerMode());
+    expect("the scanner is not trunking", !model.trunkingEnabled());
+    opts.scanner_mode = 0;
+
+    /* An epoch the decoder opened on a frame that synced and went no further has
+     * nothing in it. Rendered, it becomes a call from talkgroup 0 by nobody —
+     * and, with a stale crypto header on the slot, an encrypted one. A session
+     * that has not locked onto anything must not appear to be hearing traffic. */
+    {
+        dsd_call_observation empty = {};
+        empty.protocol = DSD_SYNC_P25P1_POS;
+        empty.slot = 0U;
+        empty.kind = DSD_CALL_KIND_GROUP_VOICE;
+        empty.observed_m = 1.0;
+        expect("an identity-less epoch opens", dsd_call_state_observe(&state, &empty, DSD_CALL_BOUNDARY_BEGIN) == 1);
+        state.payload_algid = 0x84; /* the stale header that made it read as ENC */
+        model.refresh(&opts, &state);
+        expect("an identity-less call is not presented as active", model.slot1CallState() != 2);
+        expect("an identity-less call names no talkgroup", model.slot1TgText().isEmpty());
+        expect("an identity-less call is not reported encrypted", !model.slot1CallEnc());
+
+        /* The same epoch with a talkgroup on it is a real transmission. */
+        dsd_call_observation named = empty;
+        named.ota_target_id = 1201U;
+        named.ota_source_id = 4242U;
+        named.observed_m = 2.0;
+        (void)dsd_call_state_observe(&state, &named, DSD_CALL_BOUNDARY_BEGIN);
+        model.refresh(&opts, &state);
+        expect("a call with a talkgroup is presented", model.slot1CallState() == 2);
+        expect("a call with a talkgroup names it", model.slot1TgText() == QStringLiteral("1201"));
+        (void)dsd_call_state_end(&state, 0U, 3.0);
+    }
+
+    /* A stopped session must not leave its answers behind for the next one. */
+    state.synctype = DSD_SYNC_P25P1_POS;
+    model.refresh(&opts, &state);
+    expect("locked again before the stop", model.syncedHere());
+    model.clear();
+    expect("a cleared model reports no lock", !model.syncedHere());
+    expect("a cleared model reports no tuner", !model.radioInput());
+
+    if (g_failures != 0) {
+        DSD_FPRINTF(stderr, "%d failure(s)\n", g_failures);
+        return 1;
+    }
+    DSD_FPRINTF(stderr, "OK\n");
+    return 0;
+}

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -127,6 +127,20 @@ main(int argc, char** argv) {
     model.refresh(&opts, &state);
     expect("qpsk reads as modulation 1", model.modulation() == 1);
 
+    /* GFSK is a third state, not an absence of QPSK. Reported as C4FM, it made a
+     * control bound to this reading show C4FM as already-selected on a DMR or
+     * EDACS/ProVoice session that had never been on it. */
+    opts.mod_qpsk = 0;
+    opts.mod_c4fm = 0;
+    opts.mod_gfsk = 1;
+    model.refresh(&opts, &state);
+    expect("gfsk reads as modulation 2", model.modulation() == 2);
+
+    opts.mod_gfsk = 0;
+    opts.mod_c4fm = 1;
+    model.refresh(&opts, &state);
+    expect("c4fm reads as modulation 0 again", model.modulation() == 0);
+
     /* Tuner ownership: the gate is the OR, and the two named owners exist only to
      * word a message. All three have to agree. */
     opts.trunk_enable = 1;

--- a/tests/ui/test_ui_qt_persistence.cpp
+++ b/tests/ui/test_ui_qt_persistence.cpp
@@ -204,21 +204,44 @@ test_app_prefs(void) {
         expect("ppm defaults to 0", prefs.ppm() == 0);
         expect("bandwidth defaults to 48 kHz", prefs.bandwidthKhz() == 48);
         expect("extra args default empty", prefs.extraArgs().isEmpty());
+        /* Empty is what makes the first Explore tap ask where to point the radio
+         * instead of starting on a guess. */
+        expect("explore source starts unchosen", prefs.exploreSourceType().isEmpty());
+        expect("explore frequency starts unchosen", prefs.exploreFreqMhz().isEmpty());
+        expect("explore port defaults to rtl_tcp's", prefs.explorePort() == 1234);
 
         /* The getter validates: an out-of-range stored mode must read as the
          * default, not drive a switch statement off the end. */
         prefs.setAppearance(9);
         expect("out-of-range appearance reads as default", prefs.appearance() == AppPrefs::FollowSystem);
 
+        /* Same discipline for the explore source. Only a tuner can be explored, so
+         * a stored "udp" is not a source to start on — it reads as unchosen and
+         * sends the user back to the setup sheet. */
+        prefs.setExploreSourceType(QStringLiteral("udp"));
+        expect("a non-tuner explore source reads as unchosen", prefs.exploreSourceType().isEmpty());
+        prefs.setExplorePort(70000);
+        expect("an out-of-range explore port reads as the default", prefs.explorePort() == 1234);
+
         prefs.setGainDb(42);
         prefs.setExtraArgs(QStringLiteral("--enc-lockout"));
         prefs.setOnboardingDone(true);
+        prefs.setExploreSourceType(QStringLiteral("rtltcp"));
+        prefs.setExploreHost(QStringLiteral("10.0.2.2"));
+        prefs.setExplorePort(1234);
+        /* Text, not a number: the trailing zeros say which channel this was. */
+        prefs.setExploreFreqMhz(QStringLiteral("769.76875"));
     }
 
     AppPrefs reloaded;
     expect("gain persists across instances", reloaded.gainDb() == 42);
     expect("extra args persist across instances", reloaded.extraArgs() == QStringLiteral("--enc-lockout"));
     expect("onboarding flag persists", reloaded.onboardingDone());
+    expect("explore source persists", reloaded.exploreSourceType() == QStringLiteral("rtltcp"));
+    expect("explore host persists", reloaded.exploreHost() == QStringLiteral("10.0.2.2"));
+    expect("explore port persists", reloaded.explorePort() == 1234);
+    expect("explore frequency persists with its digits intact",
+           reloaded.exploreFreqMhz() == QStringLiteral("769.76875"));
 }
 
 } // namespace

--- a/tests/ui/test_ui_qt_session_args.cpp
+++ b/tests/ui/test_ui_qt_session_args.cpp
@@ -69,6 +69,49 @@ test_freq_validation(void) {
            session_args_build(sys, SessionArgPrefs(), &error).isEmpty() && error == SessionArgsError::Frequency);
 }
 
+/*
+ * An explore session is an ordinary session over a map that was never saved, so
+ * the only thing keeping it honest is the shape of that map. Two properties are
+ * load-bearing and neither is visible anywhere else: no -T, because a trunker
+ * would take the tuner straight back from the user who came here to drive it,
+ * and no decode flag, because the point is to hear whatever it lands on.
+ */
+void
+test_explore_system(void) {
+    QVariantMap sys;
+    sys.insert(QStringLiteral("name"), QStringLiteral("Exploring"));
+    sys.insert(QStringLiteral("sourceType"), QStringLiteral("usb"));
+    sys.insert(QStringLiteral("host"), QString());
+    sys.insert(QStringLiteral("port"), 0);
+    sys.insert(QStringLiteral("freqMhz"), QStringLiteral("855.0000"));
+    sys.insert(QStringLiteral("decodeFlag"), QString());
+    sys.insert(QStringLiteral("trunking"), false);
+
+    SessionArgsError error = SessionArgsError::None;
+    const QStringList args = session_args_build(sys, SessionArgPrefs(), &error);
+    expect("an explore map builds", error == SessionArgsError::None);
+    expect("explore tunes where it was told", input_spec(args) == QStringLiteral("rtl:0:855.0000M:30:0:48:0:2"));
+    expect("explore never follows calls across channels", !args.contains(QStringLiteral("-T")));
+    expect("explore leaves the decoder to work it out", !args.contains(QStringLiteral("-f1"))
+                                                            && !args.contains(QStringLiteral("-fs"))
+                                                            && !args.contains(QStringLiteral("-ft")));
+
+    // Over rtl_tcp it is the same session with a different front end.
+    sys.insert(QStringLiteral("sourceType"), QStringLiteral("rtltcp"));
+    sys.insert(QStringLiteral("host"), QStringLiteral("10.0.2.2"));
+    sys.insert(QStringLiteral("port"), 1234);
+    const QStringList remote = session_args_build(sys, SessionArgPrefs(), &error);
+    expect("explore builds over rtl_tcp", error == SessionArgsError::None);
+    expect("explore reaches the remote tuner",
+           input_spec(remote) == QStringLiteral("rtltcp:10.0.2.2:1234:855.0000M:30:0:48:0:2"));
+
+    // A frequency that never made it into the prefs must be refused here, the
+    // same as a saved system's would be, rather than starting a mistuned session.
+    sys.insert(QStringLiteral("freqMhz"), QString());
+    expect("an explore map with no frequency is refused",
+           session_args_build(sys, SessionArgPrefs(), &error).isEmpty() && error == SessionArgsError::Frequency);
+}
+
 void
 test_defaults_and_overrides(void) {
     SessionArgsError error = SessionArgsError::None;
@@ -195,6 +238,7 @@ main(void) {
     test_ppm_shapes();
     test_bias_tee_tristate();
     test_network_and_file_sources();
+    test_explore_system();
     if (g_failures != 0) {
         DSD_FPRINTF(stderr, "%d failure(s)\n", g_failures);
         return 1;

--- a/tests/ui/test_ui_qt_spectrum_math.cpp
+++ b/tests/ui/test_ui_qt_spectrum_math.cpp
@@ -126,33 +126,60 @@ test_peak_search(void) {
     db[10] = -20.0F; /* near peak */
     db[40] = -5.0F;  /* stronger, but far away */
 
-    assert(sm::peak_search_bin(db.data(), 64, 12, 5) == 10);
+    assert(sm::peak_search_bin(db.data(), 64, 12, 5, 0, 63) == 10);
     /* A stronger peak outside the window must not win. */
-    assert(sm::peak_search_bin(db.data(), 64, 12, 5) != 40);
+    assert(sm::peak_search_bin(db.data(), 64, 12, 5, 0, 63) != 40);
     /* Widen far enough and it does. */
-    assert(sm::peak_search_bin(db.data(), 64, 12, 40) == 40);
+    assert(sm::peak_search_bin(db.data(), 64, 12, 40, 0, 63) == 40);
 
     /* Over flat noise nothing is stronger than anything else, and the answer
      * must be where the tap landed. Seeding the search at the window edge would
      * silently drag every tap on a quiet channel to that edge. */
     const std::vector<float> flat(64, -90.0F);
-    assert(sm::peak_search_bin(flat.data(), 64, 30, 16) == 30);
-    assert(sm::peak_search_bin(flat.data(), 64, 0, 16) == 0);
-    assert(sm::peak_search_bin(flat.data(), 64, 63, 16) == 63);
+    assert(sm::peak_search_bin(flat.data(), 64, 30, 16, 0, 63) == 30);
+    assert(sm::peak_search_bin(flat.data(), 64, 0, 16, 0, 63) == 0);
+    assert(sm::peak_search_bin(flat.data(), 64, 63, 16, 0, 63) == 63);
 
     /* Windows clip at the array edges rather than reading past them. */
     db[0] = -1.0F;
-    assert(sm::peak_search_bin(db.data(), 64, 1, 10) == 0);
+    assert(sm::peak_search_bin(db.data(), 64, 1, 10, 0, 63) == 0);
     db[63] = -1.0F;
-    assert(sm::peak_search_bin(db.data(), 64, 62, 10) == 63);
+    assert(sm::peak_search_bin(db.data(), 64, 62, 10, 0, 63) == 63);
 
     /* A center outside the array is clamped in. */
-    assert(sm::peak_search_bin(db.data(), 64, -5, 0) == 0);
-    assert(sm::peak_search_bin(db.data(), 64, 900, 0) == 63);
+    assert(sm::peak_search_bin(db.data(), 64, -5, 0, 0, 63) == 0);
+    assert(sm::peak_search_bin(db.data(), 64, 900, 0, 0, 63) == 63);
 
     /* Defensive: no data, no crash. */
-    assert(sm::peak_search_bin(nullptr, 64, 3, 2) == 0);
-    assert(sm::peak_search_bin(db.data(), 0, 3, 2) == 0);
+    assert(sm::peak_search_bin(nullptr, 64, 3, 2, 0, 63) == 0);
+    assert(sm::peak_search_bin(db.data(), 0, 3, 2, 0, 63) == 0);
+}
+
+/*
+ * The snap width comes from the view span, so near an edge it reaches past what
+ * is on screen. Answering with a carrier the user cannot see reads as a tap
+ * that landed somewhere random, so the search is bounded by the window too.
+ */
+void
+test_peak_search_stays_inside_the_window(void) {
+    std::vector<float> db(64, -90.0F);
+    db[30] = -5.0F; /* strong, but outside the window below */
+
+    /* A tap at bin 20 with the window ending at 24: the search may reach 25-30
+     * by half-width alone, and must not. */
+    assert(sm::peak_search_bin(db.data(), 64, 20, 10, 8, 24) == 20);
+    /* The same tap with the window opened up does find it. */
+    assert(sm::peak_search_bin(db.data(), 64, 20, 10, 8, 40) == 30);
+
+    /* A tap outside the window is pulled to the nearest edge of it, not to the
+     * nearest edge of the array. */
+    assert(sm::peak_search_bin(db.data(), 64, 2, 0, 8, 24) == 8);
+    assert(sm::peak_search_bin(db.data(), 64, 60, 0, 8, 24) == 24);
+
+    /* Bounds wider than the array clip to it; an empty or inverted window falls
+     * back to the whole array rather than answering with a bin outside it. */
+    assert(sm::peak_search_bin(db.data(), 64, 30, 0, -5, 900) == 30);
+    assert(sm::peak_search_bin(db.data(), 64, 20, 40, 40, 8) == 30);
 }
 
 /* The frequency shown at x_fraction, after clamping. */
@@ -233,6 +260,7 @@ main(void) {
     test_view_window_clamping();
     test_snap_window();
     test_peak_search();
+    test_peak_search_stays_inside_the_window();
     test_zoom_anchor();
     test_nice_tick_step();
     (void)DSD_FPRINTF(stdout, "UI_QT_SPECTRUM_MATH: ok\n");

--- a/tests/ui/test_ui_qt_spectrum_math.cpp
+++ b/tests/ui/test_ui_qt_spectrum_math.cpp
@@ -182,6 +182,60 @@ test_peak_search_stays_inside_the_window(void) {
     assert(sm::peak_search_bin(db.data(), 64, 20, 40, 40, 8) == 30);
 }
 
+/*
+ * "Next signal" is a different question from the tap's snap: it must skip what is
+ * already tuned, must refuse to answer at all on an empty band, and must not treat
+ * noise as a find. Each of those failing looks like a dead button or a radio that
+ * wanders off on its own.
+ */
+void
+test_directional_peak(void) {
+    std::vector<float> db(64, -90.0F);
+    db[32] = -10.0F; /* the signal already tuned, at center */
+    db[44] = -30.0F; /* a weaker one above */
+    db[16] = -20.0F; /* a stronger one below */
+
+    /* Upward finds the one above, not the one under the cursor. */
+    assert(sm::directional_peak_bin(db.data(), 64, 32, 1, 4, 8.0, 0, 63) == 44);
+    /* Downward finds the one below, even though it is not the strongest overall. */
+    assert(sm::directional_peak_bin(db.data(), 64, 32, -1, 4, 8.0, 0, 63) == 16);
+
+    /* The gap is what keeps the answer from being the signal already tuned. A
+     * gap of zero lets bin 32 itself win, which is the bug the gap exists for. */
+    assert(sm::directional_peak_bin(db.data(), 64, 32, 1, 0, 8.0, 0, 63) == 32);
+
+    /* Strongest wins among several above, not merely the first one reached. */
+    db[50] = -15.0F;
+    assert(sm::directional_peak_bin(db.data(), 64, 32, 1, 4, 8.0, 0, 63) == 50);
+
+    /* Bounded by the visible window like the tap is: a carrier off screen was
+     * never offered to the user and must not be answered with. */
+    assert(sm::directional_peak_bin(db.data(), 64, 32, 1, 4, 8.0, 0, 47) == 44);
+
+    /* An empty band answers with nothing rather than with where we already are —
+     * otherwise the control retunes the radio to its own frequency. */
+    const std::vector<float> flat(64, -90.0F);
+    assert(sm::directional_peak_bin(flat.data(), 64, 32, 1, 4, 8.0, 0, 63) < 0);
+    assert(sm::directional_peak_bin(flat.data(), 64, 32, -1, 4, 8.0, 0, 63) < 0);
+
+    /* Noise that is merely a little above the mean is not a signal. */
+    std::vector<float> noisy(64, -90.0F);
+    noisy[40] = -87.0F;
+    assert(sm::directional_peak_bin(noisy.data(), 64, 32, 1, 4, 8.0, 0, 63) < 0);
+    noisy[40] = -60.0F;
+    assert(sm::directional_peak_bin(noisy.data(), 64, 32, 1, 4, 8.0, 0, 63) == 40);
+
+    /* Nothing left in the search direction. */
+    assert(sm::directional_peak_bin(db.data(), 64, 63, 1, 4, 8.0, 0, 63) < 0);
+    assert(sm::directional_peak_bin(db.data(), 64, 0, -1, 4, 8.0, 0, 63) < 0);
+
+    /* Defensive: no data, no crash, and an inverted window answers with nothing
+     * rather than falling back to the whole array. */
+    assert(sm::directional_peak_bin(nullptr, 64, 32, 1, 4, 8.0, 0, 63) < 0);
+    assert(sm::directional_peak_bin(db.data(), 0, 32, 1, 4, 8.0, 0, 63) < 0);
+    assert(sm::directional_peak_bin(db.data(), 64, 32, 1, 4, 8.0, 40, 8) < 0);
+}
+
 /* The frequency shown at x_fraction, after clamping. */
 double
 freq_at(double zoom, double offset, double x_fraction) {
@@ -261,6 +315,7 @@ main(void) {
     test_snap_window();
     test_peak_search();
     test_peak_search_stays_inside_the_window();
+    test_directional_peak();
     test_zoom_anchor();
     test_nice_tick_step();
     (void)DSD_FPRINTF(stdout, "UI_QT_SPECTRUM_MATH: ok\n");

--- a/tests/ui/test_ui_qt_spectrum_math.cpp
+++ b/tests/ui/test_ui_qt_spectrum_math.cpp
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdio>
+#include <limits>
 #include <vector>
 
 #include <dsd-neo/core/safe_api.h>
@@ -328,6 +329,66 @@ test_nice_tick_step(void) {
     assert(sm::nice_tick_step_hz(kSpan, 0) > 0.0);
 }
 
+/*
+ * A single non-finite bin must not take the display out for the rest of the
+ * session. The range is an EMA, so folding in an infinity once makes the very
+ * next relaxation `-inf + inf` -- a NaN that every later frame then relaxes
+ * towards itself. Nothing resets it short of a retune, and because every
+ * comparison against NaN is false the 20 dB floor in span_db() would not catch
+ * it either: normalize() would answer 0 for every bin, which is a flat trace over
+ * a cold waterfall with a live signal on the air.
+ */
+void
+test_auto_range_survives_a_bad_frame(void) {
+    std::vector<float> healthy(64, -60.0F);
+    healthy[32] = -20.0F;
+
+    sm::AutoRange range;
+    range.update(healthy.data(), 64);
+    assert(range.seeded);
+    const double seeded_span = range.span_db();
+    assert(std::isfinite(seeded_span));
+
+    std::vector<float> poisoned(64, -60.0F);
+    poisoned[7] = std::numeric_limits<float>::infinity();
+    range.update(poisoned.data(), 64);
+    assert(std::isfinite(range.min_db) && std::isfinite(range.max_db));
+    assert(near(range.span_db(), seeded_span, 1e-9));
+
+    /* And it keeps tracking healthy frames afterwards. */
+    for (int i = 0; i < 8; i++) {
+        range.update(healthy.data(), 64);
+    }
+    assert(std::isfinite(range.span_db()));
+    assert(range.normalize(-20.0) > range.normalize(-60.0));
+
+    /* A NaN reaching min/max some other way still cannot make span_db() NaN:
+     * `span < 20.0` is false for NaN, so the floor has to be written negated. */
+    sm::AutoRange poisoned_range;
+    poisoned_range.min_db = std::numeric_limits<double>::quiet_NaN();
+    poisoned_range.max_db = std::numeric_limits<double>::quiet_NaN();
+    poisoned_range.seeded = true;
+    assert(near(poisoned_range.span_db(), 20.0, 1e-9));
+    /* And it re-seeds from the next good frame rather than relaxing towards NaN. */
+    poisoned_range.update(healthy.data(), 64);
+    assert(std::isfinite(poisoned_range.min_db) && std::isfinite(poisoned_range.max_db));
+}
+
+/*
+ * frame_mean_db() is the noise-floor estimate directional_peak_bin() thresholds
+ * on. An empty frame divided by zero would make that threshold NaN, and since
+ * every `>=` against NaN is false the "next signal" control would answer "nothing
+ * on this screen" for a band full of carriers -- silently, and nowhere near the
+ * line that caused it.
+ */
+void
+test_frame_mean_guards_an_empty_frame(void) {
+    const std::vector<float> db(8, -70.0F);
+    assert(near(sm::frame_mean_db(db.data(), 8), -70.0, 1e-9));
+    assert(std::isfinite(sm::frame_mean_db(db.data(), 0)));
+    assert(std::isfinite(sm::frame_mean_db(nullptr, 8)));
+}
+
 } // namespace
 
 int
@@ -341,6 +402,8 @@ main(void) {
     test_directional_seed();
     test_zoom_anchor();
     test_nice_tick_step();
+    test_auto_range_survives_a_bad_frame();
+    test_frame_mean_guards_an_empty_frame();
     (void)DSD_FPRINTF(stdout, "UI_QT_SPECTRUM_MATH: ok\n");
     return 0;
 }

--- a/tests/ui/test_ui_qt_spectrum_math.cpp
+++ b/tests/ui/test_ui_qt_spectrum_math.cpp
@@ -236,6 +236,28 @@ test_directional_peak(void) {
     assert(sm::directional_peak_bin(db.data(), 64, 32, 1, 4, 8.0, 40, 8) < 0);
 }
 
+void
+test_directional_seed(void) {
+    /* On screen the tuned carrier is the reference, edges included — that is what
+     * makes the gap step past the signal already being listened to. */
+    assert(sm::directional_seed_bin(32, 0, 63) == 32);
+    assert(sm::directional_seed_bin(0, 0, 63) == 0);
+    assert(sm::directional_seed_bin(63, 0, 63) == 63);
+
+    /* Panned clear of it, the middle of what is on screen takes over. Seeding at
+     * the bound instead would leave the opposite direction with an empty range,
+     * which is the dead control this exists to prevent. */
+    assert(sm::directional_seed_bin(32, 40, 63) == 51);
+    assert(sm::directional_seed_bin(32, 0, 20) == 10);
+
+    /* One bin either side of the window is already off it. */
+    assert(sm::directional_seed_bin(39, 40, 63) == 51);
+    assert(sm::directional_seed_bin(64, 40, 63) == 51);
+
+    /* A one-bin window is its own middle. */
+    assert(sm::directional_seed_bin(0, 7, 7) == 7);
+}
+
 /* The frequency shown at x_fraction, after clamping. */
 double
 freq_at(double zoom, double offset, double x_fraction) {
@@ -316,6 +338,7 @@ main(void) {
     test_peak_search();
     test_peak_search_stays_inside_the_window();
     test_directional_peak();
+    test_directional_seed();
     test_zoom_anchor();
     test_nice_tick_step();
     (void)DSD_FPRINTF(stdout, "UI_QT_SPECTRUM_MATH: ok\n");

--- a/tests/ui/test_ui_qt_spectrum_math.cpp
+++ b/tests/ui/test_ui_qt_spectrum_math.cpp
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Regression test: the spectrum viewport arithmetic (spectrum_math.h).
+ *
+ * These are the parts of a spectrum view that are wrong in ways nobody notices
+ * until the receiver lands on the wrong channel: which bin a tap maps to, where
+ * a clamped pan actually sits and how much of the pan was refused, and whether
+ * a pinch keeps the signal under the fingers.
+ */
+
+// LLVM 22/GCC 16 misclassifies these runtime test oracles as compile-time assertions.
+// NOLINTBEGIN(cert-dcl03-c,misc-static-assert)
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+#include <dsd-neo/core/safe_api.h>
+
+#include "spectrum_math.h"
+
+namespace sm = dsd_qt::spectrum_math;
+
+namespace {
+
+constexpr double kCenter = 851000000.0;
+constexpr double kSpan = 1536000.0;
+constexpr int kBins = 1024;
+/* A millihertz. Absurdly strict for a radio, but loose enough that double
+ * rounding on absolute frequencies near 851 MHz is not mistaken for a bug. */
+constexpr double kTolHz = 1.0e-3;
+
+bool
+near(double got, double want, double tol) {
+    return std::fabs(got - want) <= tol;
+}
+
+void
+test_bin_freq_round_trip(void) {
+    /* Bin n/2 is DC: exactly the tuned center, not half a bin off it. */
+    assert(near(sm::bin_to_freq_hz(kCenter, kSpan, kBins, kBins / 2), kCenter, kTolHz));
+    assert(near(sm::bin_to_freq_hz(kCenter, kSpan, kBins, 0), kCenter - (kSpan / 2.0), kTolHz));
+    assert(
+        near(sm::bin_to_freq_hz(kCenter, kSpan, kBins, kBins - 1), kCenter + (kSpan / 2.0) - (kSpan / kBins), kTolHz));
+
+    for (int i = 0; i < kBins; i++) {
+        const double f = sm::bin_to_freq_hz(kCenter, kSpan, kBins, i);
+        assert(sm::freq_to_bin(kCenter, kSpan, kBins, f) == i);
+    }
+
+    /* Off the ends clamps rather than wrapping or indexing out of range. */
+    assert(sm::freq_to_bin(kCenter, kSpan, kBins, kCenter - kSpan) == 0);
+    assert(sm::freq_to_bin(kCenter, kSpan, kBins, kCenter + kSpan) == kBins - 1);
+
+    /* A +200 kHz tone lands where the io-layer orientation test says it does. */
+    const int tone = sm::freq_to_bin(kCenter, kSpan, kBins, kCenter + 200000.0);
+    const int expected = (kBins / 2) + static_cast<int>(std::lround(200000.0 / kSpan * kBins));
+    assert(tone == expected);
+
+    /* Degenerate inputs do not divide by zero. */
+    assert(near(sm::bin_to_freq_hz(kCenter, kSpan, 0, 3), kCenter, kTolHz));
+    assert(sm::freq_to_bin(kCenter, 0.0, kBins, kCenter) == kBins / 2);
+}
+
+void
+test_view_window_clamping(void) {
+    double overshoot = -1.0;
+
+    /* Fully zoomed out there is nowhere to pan: any offset is refused whole. */
+    sm::ViewWindow win = sm::view_window(kCenter, kSpan, 1.0, 0.0, &overshoot);
+    assert(near(win.span_hz, kSpan, kTolHz));
+    assert(near(win.low_hz, kCenter - (kSpan / 2.0), kTolHz));
+    assert(near(overshoot, 0.0, kTolHz));
+
+    sm::view_window(kCenter, kSpan, 1.0, 100000.0, &overshoot);
+    assert(near(overshoot, 100000.0, kTolHz));
+
+    /* At 4x the window is a quarter wide and can travel 3/8 of the span each way. */
+    const double quarter = kSpan / 4.0;
+    const double reach = (kSpan / 2.0) - (quarter / 2.0);
+    win = sm::view_window(kCenter, kSpan, 4.0, 0.0, &overshoot);
+    assert(near(win.span_hz, quarter, kTolHz));
+    assert(near(overshoot, 0.0, kTolHz));
+
+    win = sm::view_window(kCenter, kSpan, 4.0, reach, &overshoot);
+    assert(near(win.high_hz, kCenter + (kSpan / 2.0), kTolHz));
+    assert(near(overshoot, 0.0, kTolHz));
+
+    /* Past the top edge: clamped, and the excess is reported positive. */
+    win = sm::view_window(kCenter, kSpan, 4.0, reach + 50000.0, &overshoot);
+    assert(near(win.high_hz, kCenter + (kSpan / 2.0), kTolHz));
+    assert(near(overshoot, 50000.0, kTolHz));
+
+    /* Past the bottom edge: negative. */
+    win = sm::view_window(kCenter, kSpan, 4.0, -reach - 50000.0, &overshoot);
+    assert(near(win.low_hz, kCenter - (kSpan / 2.0), kTolHz));
+    assert(near(overshoot, -50000.0, kTolHz));
+
+    /* Out-of-range zoom is clamped, not honoured. */
+    win = sm::view_window(kCenter, kSpan, 100.0, 0.0, &overshoot);
+    assert(near(win.span_hz, kSpan / sm::kMaxZoom, kTolHz));
+    win = sm::view_window(kCenter, kSpan, 0.1, 0.0, &overshoot);
+    assert(near(win.span_hz, kSpan, kTolHz));
+
+    /* No span, no window — and no NaN. */
+    win = sm::view_window(kCenter, 0.0, 4.0, 1000.0, &overshoot);
+    assert(near(win.span_hz, 0.0, kTolHz));
+    assert(near(overshoot, 0.0, kTolHz));
+}
+
+void
+test_snap_window(void) {
+    /* Zoomed all the way out the snap is capped, or a tap near one channel
+     * could drag the receiver to another. */
+    assert(near(sm::snap_window_hz(kSpan), 25000.0, kTolHz));
+    /* 8x of that span: 192 kHz / 20. */
+    assert(near(sm::snap_window_hz(kSpan / 8.0), 9600.0, kTolHz));
+    /* And a floor, so a deep zoom still tolerates a fat fingertip. */
+    assert(near(sm::snap_window_hz(1000.0), 6000.0, kTolHz));
+}
+
+void
+test_peak_search(void) {
+    std::vector<float> db(64, -90.0F);
+    db[10] = -20.0F; /* near peak */
+    db[40] = -5.0F;  /* stronger, but far away */
+
+    assert(sm::peak_search_bin(db.data(), 64, 12, 5) == 10);
+    /* A stronger peak outside the window must not win. */
+    assert(sm::peak_search_bin(db.data(), 64, 12, 5) != 40);
+    /* Widen far enough and it does. */
+    assert(sm::peak_search_bin(db.data(), 64, 12, 40) == 40);
+
+    /* Over flat noise nothing is stronger than anything else, and the answer
+     * must be where the tap landed. Seeding the search at the window edge would
+     * silently drag every tap on a quiet channel to that edge. */
+    const std::vector<float> flat(64, -90.0F);
+    assert(sm::peak_search_bin(flat.data(), 64, 30, 16) == 30);
+    assert(sm::peak_search_bin(flat.data(), 64, 0, 16) == 0);
+    assert(sm::peak_search_bin(flat.data(), 64, 63, 16) == 63);
+
+    /* Windows clip at the array edges rather than reading past them. */
+    db[0] = -1.0F;
+    assert(sm::peak_search_bin(db.data(), 64, 1, 10) == 0);
+    db[63] = -1.0F;
+    assert(sm::peak_search_bin(db.data(), 64, 62, 10) == 63);
+
+    /* A center outside the array is clamped in. */
+    assert(sm::peak_search_bin(db.data(), 64, -5, 0) == 0);
+    assert(sm::peak_search_bin(db.data(), 64, 900, 0) == 63);
+
+    /* Defensive: no data, no crash. */
+    assert(sm::peak_search_bin(nullptr, 64, 3, 2) == 0);
+    assert(sm::peak_search_bin(db.data(), 0, 3, 2) == 0);
+}
+
+/* The frequency shown at x_fraction, after clamping. */
+double
+freq_at(double zoom, double offset, double x_fraction) {
+    const sm::ViewWindow win = sm::view_window(kCenter, kSpan, zoom, offset, nullptr);
+    return win.low_hz + (x_fraction * win.span_hz);
+}
+
+void
+test_zoom_anchor(void) {
+    const double fractions[] = {0.0, 0.25, 0.5, 0.75, 1.0};
+    const double zooms[] = {1.0, 2.0, 4.0, 8.0};
+    for (double x : fractions) {
+        for (double from : zooms) {
+            for (double to : zooms) {
+                /* Start from a pan that is legal at `from`. */
+                const double offset = (from > 1.0) ? ((kSpan / 2.0) - (kSpan / from / 2.0)) * 0.5 : 0.0;
+                const double before = freq_at(from, offset, x);
+                const double next = sm::zoom_anchor_offset_hz(kCenter, kSpan, from, offset, to, x);
+                const double after = freq_at(to, next, x);
+
+                if (to >= from) {
+                    /* Zooming in only ever shrinks the window, so the anchor is
+                     * always reachable and must be held exactly. */
+                    assert(near(after, before, kTolHz));
+                    continue;
+                }
+                /* Zooming out can ask for a window wider than the space left on
+                 * one side. Then the anchor cannot be held — but the only
+                 * acceptable reason is that the window is flush against a
+                 * capture edge, never an arbitrary drift. */
+                const sm::ViewWindow win = sm::view_window(kCenter, kSpan, to, next, nullptr);
+                const bool flush = near(win.low_hz, kCenter - (kSpan / 2.0), kTolHz)
+                                   || near(win.high_hz, kCenter + (kSpan / 2.0), kTolHz);
+                assert(near(after, before, kTolHz) || flush);
+            }
+        }
+    }
+
+    /* Zooming in at an anchor away from the middle really does hold it exact. */
+    const double before = freq_at(1.0, 0.0, 0.25);
+    const double next = sm::zoom_anchor_offset_hz(kCenter, kSpan, 1.0, 0.0, 4.0, 0.25);
+    assert(near(freq_at(4.0, next, 0.25), before, kTolHz));
+
+    /* Zooming out from the middle has room on both sides, so it is exact too. */
+    const double mid_before = freq_at(8.0, 0.0, 0.75);
+    const double mid_next = sm::zoom_anchor_offset_hz(kCenter, kSpan, 8.0, 0.0, 2.0, 0.75);
+    assert(near(freq_at(2.0, mid_next, 0.75), mid_before, kTolHz));
+}
+
+void
+test_nice_tick_step(void) {
+    /* Every step is 1, 2 or 5 times a power of ten... */
+    const double spans[] = {kSpan, kSpan / 2.0, kSpan / 8.0, 12500.0, 137.0, 4.2e6};
+    for (double span : spans) {
+        for (int max_ticks = 1; max_ticks <= 8; max_ticks++) {
+            const double step = sm::nice_tick_step_hz(span, max_ticks);
+            assert(step > 0.0);
+            /* ...and never finer than the requested density. */
+            assert(step >= (span / max_ticks) * (1.0 - 1e-9));
+            const double mantissa = step / std::pow(10.0, std::floor(std::log10(step)));
+            assert(near(mantissa, 1.0, 1e-9) || near(mantissa, 2.0, 1e-9) || near(mantissa, 5.0, 1e-9));
+            /* Rounding up bounds the label count at max_ticks + 1. */
+            assert(std::floor(span / step) + 1.0 <= max_ticks + 1);
+        }
+    }
+
+    assert(near(sm::nice_tick_step_hz(0.0, 5), 0.0, kTolHz));
+    assert(sm::nice_tick_step_hz(kSpan, 0) > 0.0);
+}
+
+} // namespace
+
+int
+main(void) {
+    test_bin_freq_round_trip();
+    test_view_window_clamping();
+    test_snap_window();
+    test_peak_search();
+    test_zoom_anchor();
+    test_nice_tick_step();
+    (void)DSD_FPRINTF(stdout, "UI_QT_SPECTRUM_MATH: ok\n");
+    return 0;
+}
+
+// NOLINTEND(cert-dcl03-c,misc-static-assert)

--- a/tests/ui/test_ui_qt_spectrum_model.cpp
+++ b/tests/ui/test_ui_qt_spectrum_model.cpp
@@ -17,7 +17,9 @@
  *  - the first frame captured at a new center must survive the history clear
  *    that the retune triggers, because it is the one row that is certain to be
  *    worth seeing;
- *  - a tap must never resolve to a frequency outside the visible window.
+ *  - a tap must never resolve to a frequency outside the visible window, and a
+ *    hop must still find the carriers inside it once the view has been panned
+ *    clear of the tuned center.
  *
  * The producer is stubbed here rather than mocked through the engine: the model
  * only ever sees the app-control getter, so supplying that is the whole of it.
@@ -30,6 +32,7 @@
 #include <QObject>
 #include <QtGlobal>
 #include <cassert>
+#include <cmath>
 #include <cstdint>
 #include <stdio.h>
 
@@ -222,6 +225,51 @@ test_a_tap_never_snaps_outside_the_visible_window(void) {
 }
 
 /*
+ * The hop is bounded by the visible window but takes its reference from the
+ * tuned center, and past 2x the window can be panned until that center is not
+ * inside it at all. Seeded outside its own bounds, one of the two directions
+ * searches an empty range: the control reports an empty band with carriers
+ * plainly on screen, and stays that way until the view is reset.
+ */
+void
+test_a_hop_still_works_when_the_view_is_panned_off_center(void) {
+    /* Two carriers in the top of the capture, either side of where the panned
+     * window's middle lands. The lower one is the stronger of the two, so an
+     * upward hop that searched the whole window would answer with it. */
+    const int lower_bin = 940;
+    const int upper_bin = 980;
+    seed_bins(lower_bin);
+    g_bins[lower_bin] = -15.0F;
+    g_bins[upper_bin] = -20.0F;
+    g_serial = 0;
+    dsd_qt::SpectrumModel model;
+
+    model.setActive(true);
+    publish(kCenterHz);
+    model.testPoll();
+    assert(model.hasData());
+
+    /* Past 2x the maximum pan clears the center bin entirely; the offset is
+     * deliberately over-large and left to the model's own clamp. */
+    model.setZoom(8.0);
+    model.setViewOffsetHz(static_cast<double>(kSpanHz));
+    assert(model.viewLowHz() > static_cast<double>(kCenterHz));
+
+    const double bin_width = static_cast<double>(kSpanHz) / static_cast<double>(kBins);
+    const double lower_hz =
+        static_cast<double>(kCenterHz) + ((static_cast<double>(lower_bin) - (kBins / 2.0)) * bin_width);
+    const double upper_hz =
+        static_cast<double>(kCenterHz) + ((static_cast<double>(upper_bin) - (kBins / 2.0)) * bin_width);
+    assert(lower_hz > model.viewLowHz() && upper_hz < model.viewHighHz());
+
+    /* Both carriers are on screen, so both directions have an answer to give. */
+    assert(std::fabs(model.nextPeakHz(1) - upper_hz) < (bin_width / 2.0));
+    assert(std::fabs(model.nextPeakHz(-1) - lower_hz) < (bin_width / 2.0));
+
+    model.setActive(false);
+}
+
+/*
  * Production follows the view, so a closed view costs no FFT at all, and a
  * reopened one never shows the frame the last session left behind.
  */
@@ -255,6 +303,7 @@ main(int argc, char** argv) {
     test_a_repeated_frame_is_not_a_new_frame();
     test_the_first_frame_after_a_retune_becomes_a_row();
     test_a_tap_never_snaps_outside_the_visible_window();
+    test_a_hop_still_works_when_the_view_is_panned_off_center();
     test_production_follows_the_view();
 
     assert(g_get_calls > 0);

--- a/tests/ui/test_ui_qt_spectrum_model.cpp
+++ b/tests/ui/test_ui_qt_spectrum_model.cpp
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Regression test: what the spectrum model does with the frames it is handed,
+ * and what the waterfall does with the model.
+ *
+ * The viewport arithmetic itself is UI_QT_SPECTRUM_MATH's job. What lives here
+ * is the part that only shows up once a producer and a poll timer are running
+ * against each other on separate clocks:
+ *
+ *  - a poll that re-reads the frame already on screen must not be announced as
+ *    a new one, or the waterfall scrolls duplicate rows and reports a signal as
+ *    lasting longer than it did;
+ *  - the first frame captured at a new center must survive the history clear
+ *    that the retune triggers, because it is the one row that is certain to be
+ *    worth seeing;
+ *  - a tap must never resolve to a frequency outside the visible window.
+ *
+ * The producer is stubbed here rather than mocked through the engine: the model
+ * only ever sees the app-control getter, so supplying that is the whole of it.
+ */
+
+// LLVM 22/GCC 16 misclassifies these runtime test oracles as compile-time assertions.
+// NOLINTBEGIN(cert-dcl03-c,misc-static-assert)
+
+#include <QGuiApplication>
+#include <QObject>
+#include <QtGlobal>
+#include <cassert>
+#include <cstdint>
+#include <stdio.h>
+
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/wideband_spectrum.h>
+
+#include "spectrum_model.h"
+#include "spectrum_view_item.h"
+
+namespace {
+
+/* ------------------------------------------------------------- producer ---- */
+
+constexpr int kBins = DSD_WIDEBAND_SPECTRUM_BINS;
+constexpr uint32_t kCenterHz = 851000000U;
+constexpr uint32_t kSpanHz = 1536000U;
+
+float g_bins[kBins];
+uint32_t g_center_hz = kCenterHz;
+uint32_t g_span_hz = kSpanHz;
+uint32_t g_serial = 0;
+int g_enabled = 0;
+int g_get_calls = 0;
+
+/** @brief Flat noise with one strong bin, as a real capture with one carrier. */
+void
+seed_bins(int peak_bin) {
+    for (int i = 0; i < kBins; i++) {
+        g_bins[i] = -80.0F;
+    }
+    if (peak_bin >= 0 && peak_bin < kBins) {
+        g_bins[peak_bin] = -20.0F;
+    }
+}
+
+/** @brief Publish a frame, as the demod thread would. */
+void
+publish(uint32_t center_hz) {
+    g_center_hz = center_hz;
+    g_serial++;
+}
+
+} // namespace
+
+extern "C" int
+dsd_app_frontend_wideband_spectrum_get(float* out_db, int max_bins, uint32_t* out_center_freq_hz, uint32_t* out_span_hz,
+                                       uint32_t* out_frame_serial) {
+    g_get_calls++;
+    if (!out_db || max_bins < kBins || g_enabled == 0 || g_serial == 0) {
+        return 0;
+    }
+    for (int i = 0; i < kBins; i++) {
+        out_db[i] = g_bins[i];
+    }
+    if (out_center_freq_hz) {
+        *out_center_freq_hz = g_center_hz;
+    }
+    if (out_span_hz) {
+        *out_span_hz = g_span_hz;
+    }
+    if (out_frame_serial) {
+        *out_frame_serial = g_serial;
+    }
+    return kBins;
+}
+
+extern "C" void
+dsd_app_frontend_wideband_spectrum_set_enabled(int on) {
+    g_enabled = on ? 1 : 0;
+}
+
+namespace {
+
+/* ---------------------------------------------------------------- cases ---- */
+
+/*
+ * The poll timer and the publish period free-run, so most polls land on a frame
+ * that is already drawn. Announcing one as new is what fills the waterfall with
+ * rows nothing happened in.
+ */
+void
+test_a_repeated_frame_is_not_a_new_frame(void) {
+    seed_bins(kBins / 2);
+    g_serial = 0;
+    dsd_qt::SpectrumModel model;
+    /* A plain counter rather than QSignalSpy: that lives in Qt's testlib, which
+     * distributions package separately, and nothing else here needs it. */
+    int frames = 0;
+    QObject::connect(&model, &dsd_qt::SpectrumModel::frameChanged, &model, [&frames]() { frames++; });
+
+    model.setActive(true);
+    publish(kCenterHz);
+
+    model.testPoll();
+    assert(model.hasData());
+    const quint64 first = model.frameIndex();
+    assert(frames == 1);
+
+    /* Three more polls, no new publish: the producer has not replaced the frame. */
+    model.testPoll();
+    model.testPoll();
+    model.testPoll();
+    assert(model.frameIndex() == first);
+    assert(frames == 1);
+
+    /* ...and a fresh publish is announced again. */
+    publish(kCenterHz);
+    model.testPoll();
+    assert(model.frameIndex() == first + 1);
+    assert(frames == 2);
+
+    model.setActive(false);
+}
+
+/*
+ * A retune clears the waterfall's history, which is right — rows measured at
+ * the old center mean nothing at the new one. The frame that arrives *with* the
+ * retune was captured at the new center, so it must still become a row.
+ */
+void
+test_the_first_frame_after_a_retune_becomes_a_row(void) {
+    seed_bins(kBins / 2);
+    g_serial = 0;
+    dsd_qt::SpectrumModel model;
+    dsd_qt::WaterfallItem waterfall;
+    waterfall.setModel(&model);
+    int retunes = 0;
+    QObject::connect(&model, &dsd_qt::SpectrumModel::retuned, &model, [&retunes]() { retunes++; });
+
+    model.setActive(true);
+    publish(kCenterHz);
+    model.testPoll();
+    assert(waterfall.testRowsWritten() == 1);
+
+    publish(kCenterHz);
+    model.testPoll();
+    assert(waterfall.testRowsWritten() == 2);
+
+    /* The tap lands, the front end moves, and the next frame is at the new
+     * center. History resets to nothing — and then immediately takes that
+     * frame, rather than skipping it as already seen. */
+    publish(kCenterHz + 1000000U);
+    model.testPoll();
+    assert(retunes == 1);
+    assert(waterfall.testRowsWritten() == 1);
+
+    publish(kCenterHz + 1000000U);
+    model.testPoll();
+    assert(waterfall.testRowsWritten() == 2);
+
+    model.setActive(false);
+}
+
+/*
+ * The snap width is derived from the view span, so at high zoom it reaches
+ * further than the screen does. A tap must never answer with a carrier the user
+ * cannot see — that reads as a tap that landed somewhere random.
+ */
+void
+test_a_tap_never_snaps_outside_the_visible_window(void) {
+    /* One loud bin near the top of the capture, quiet everywhere else. */
+    const int loud_bin = kBins - 8;
+    seed_bins(loud_bin);
+    g_serial = 0;
+    dsd_qt::SpectrumModel model;
+
+    model.setActive(true);
+    publish(kCenterHz);
+    model.testPoll();
+    assert(model.hasData());
+
+    /* Zoom in and pan so the loud bin sits just past the right-hand edge. */
+    model.setZoom(8.0);
+    const double bin_width = static_cast<double>(kSpanHz) / static_cast<double>(kBins);
+    const double loud_hz =
+        static_cast<double>(kCenterHz) + ((static_cast<double>(loud_bin) - (kBins / 2.0)) * bin_width);
+    const double view_span = static_cast<double>(kSpanHz) / 8.0;
+    /* Put the window's high edge a few bins below the carrier. */
+    model.setViewOffsetHz((loud_hz - (4.0 * bin_width)) - (view_span / 2.0) - static_cast<double>(kCenterHz));
+
+    const double high = model.viewHighHz();
+    const double low = model.viewLowHz();
+    assert(loud_hz > high); /* the carrier really is off screen */
+
+    /* A tap on the right-hand edge, where the unbounded search would reach it. */
+    const double tapped = model.tapFrequencyHz(1.0);
+    assert(tapped >= low && tapped <= high);
+
+    model.setActive(false);
+}
+
+/*
+ * Production follows the view, so a closed view costs no FFT at all, and a
+ * reopened one never shows the frame the last session left behind.
+ */
+void
+test_production_follows_the_view(void) {
+    seed_bins(kBins / 2);
+    g_serial = 0;
+    dsd_qt::SpectrumModel model;
+
+    assert(g_enabled == 0);
+    model.setActive(true);
+    assert(g_enabled == 1);
+    publish(kCenterHz);
+    model.testPoll();
+    assert(model.hasData());
+
+    model.setActive(false);
+    assert(g_enabled == 0);
+    assert(!model.hasData());
+    assert(model.binCount() == 0);
+}
+
+} // namespace
+
+int
+main(int argc, char** argv) {
+    /* The waterfall is a QQuickItem, so it needs an application object; the
+     * offscreen platform comes from the CTest registration. */
+    QGuiApplication app(argc, argv);
+
+    test_a_repeated_frame_is_not_a_new_frame();
+    test_the_first_frame_after_a_retune_becomes_a_row();
+    test_a_tap_never_snaps_outside_the_visible_window();
+    test_production_follows_the_view();
+
+    assert(g_get_calls > 0);
+    (void)DSD_FPRINTF(stdout, "UI_QT_SPECTRUM_MODEL: ok\n");
+    return 0;
+}
+
+// NOLINTEND(cert-dcl03-c,misc-static-assert)

--- a/tests/ui/test_ui_radio_actions_rtl.c
+++ b/tests/ui/test_ui_radio_actions_rtl.c
@@ -170,6 +170,101 @@ test_generic_toggle_restores_rtl_after_p25p2_helper(void) {
     return rc;
 }
 
+/* One decode mode enabled, as a single-protocol session has it. */
+static void
+enable_nxdn48(dsd_opts* o) {
+    o->frame_nxdn48 = 1;
+}
+
+static void
+enable_nxdn96(dsd_opts* o) {
+    o->frame_nxdn96 = 1;
+}
+
+static void
+enable_dpmr(dsd_opts* o) {
+    o->frame_dpmr = 1;
+}
+
+static void
+enable_p25p2(dsd_opts* o) {
+    o->frame_p25p2 = 1;
+}
+
+static void
+enable_provoice(dsd_opts* o) {
+    o->frame_provoice = 1;
+}
+
+/*
+ * The symbol rate the modulation control applies comes from the mode being
+ * decoded. NXDN48 and dPMR run at 2400 sym/s in a 6.25 kHz channel and NXDN96 at
+ * 4800 in 12.5 kHz despite both NXDN variants sharing a preset sps; deriving the
+ * rate from the frame flags by hand got the 2400 modes wrong and asked the front
+ * end for a filter the DSP's own hunt disagreed with, which is what makes the
+ * filter flip every time the hunt re-runs.
+ */
+static int
+test_mod_set_takes_symbol_profile_from_the_decoded_mode(void) {
+    static const struct {
+        const char* tag;
+        void (*enable)(dsd_opts*);
+        int rate;
+        int levels;
+        int channel_profile;
+        int ted_sps;
+        int hunt_idx;
+    } cases[] = {
+        {"nxdn48", enable_nxdn48, 2400, 4, RTL_STREAM_CHANNEL_PROFILE_6K25, 20, DSD_FRAME_SYNC_SPS_PROFILE_2400_4},
+        {"dpmr", enable_dpmr, 2400, 4, RTL_STREAM_CHANNEL_PROFILE_6K25, 20, DSD_FRAME_SYNC_SPS_PROFILE_2400_4},
+        /* 4800 like P25p1, but a 12.5 kHz channel — dsd_opts_uses_wide_4800_profile(). */
+        {"nxdn96", enable_nxdn96, 4800, 4, RTL_STREAM_CHANNEL_PROFILE_12K5, 10, DSD_FRAME_SYNC_SPS_PROFILE_4800_4},
+        {"p25p2", enable_p25p2, 6000, 4, RTL_STREAM_CHANNEL_PROFILE_12K5, 8, DSD_FRAME_SYNC_SPS_PROFILE_6000_4},
+        {"provoice", enable_provoice, 9600, 2, RTL_STREAM_CHANNEL_PROFILE_PROVOICE, 5,
+         DSD_FRAME_SYNC_SPS_PROFILE_9600_2},
+    };
+
+    int rc = 0;
+    for (unsigned i = 0; i < sizeof cases / sizeof cases[0]; i++) {
+        static dsd_opts opts;
+        static dsd_state state;
+        struct dsd_app_command cmd;
+        DSD_MEMSET(&opts, 0, sizeof(opts));
+        DSD_MEMSET(&state, 0, sizeof(state));
+        DSD_MEMSET(&cmd, 0, sizeof(cmd));
+
+        opts.audio_in_type = AUDIO_IN_RTL;
+        state.rtl_ctx = (RtlSdrContext*)&state;
+        cases[i].enable(&opts);
+        /* Start on QPSK so the C4FM request below is a real change rather than
+         * the no-op a control re-asserting its own state produces. */
+        opts.mod_qpsk = 1;
+        state.rf_mod = 1;
+        /* Deliberately the wrong profile to begin with: leaving it alone is the
+         * bug, so the assertion has to be able to tell "set" from "untouched". */
+        state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+        state.sps_hunt_counter = 7;
+
+        const int32_t want_c4fm = 0;
+        cmd.id = DSD_APP_CMD_MOD_SET;
+        cmd.n = (int)sizeof want_c4fm;
+        DSD_MEMCPY(cmd.data, &want_c4fm, sizeof want_c4fm);
+        reset_profile_capture(&opts);
+
+        rc |= expect_int(cases[i].tag, dispatch_one(&opts, &state, &cmd), 1);
+        rc |= expect_int(cases[i].tag, g_request_calls, 1);
+        rc |= expect_int(cases[i].tag, g_request_rate, cases[i].rate);
+        rc |= expect_int(cases[i].tag, g_request_levels, cases[i].levels);
+        rc |= expect_int(cases[i].tag, g_request_channel_profile, cases[i].channel_profile);
+        rc |= expect_int(cases[i].tag, g_request_ted_sps, cases[i].ted_sps);
+        rc |= expect_int(cases[i].tag, g_request_cqpsk, 0);
+        rc |= expect_int(cases[i].tag, state.samplesPerSymbol, cases[i].ted_sps);
+        rc |= expect_int(cases[i].tag, state.sps_hunt_idx, cases[i].hunt_idx);
+        rc |= expect_int(cases[i].tag, state.sps_hunt_counter, 0);
+    }
+    return rc;
+}
+
 static int
 test_p25p2_toggle_ignores_non_rtl_input(void) {
     int rc = 0;
@@ -196,6 +291,7 @@ main(void) {
     int rc = 0;
     rc |= test_p25p2_toggle_applies_rtl_profile_before_lock();
     rc |= test_generic_toggle_restores_rtl_after_p25p2_helper();
+    rc |= test_mod_set_takes_symbol_profile_from_the_decoded_mode();
     rc |= test_p25p2_toggle_ignores_non_rtl_input();
     if (rc == 0) {
         DSD_FPRINTF(stderr, "APP CONTROL RTL ACTION TESTS PASSED\n");

--- a/tools/cppcheck.sh
+++ b/tools/cppcheck.sh
@@ -159,15 +159,10 @@ CPPCHECK_ARGS+=(
   --suppress='*:*/src/third_party/*'
   --suppress='*:android/third_party/*'
   --suppress='*:*/android/third_party/*'
-  # dsd_state is a C aggregate, not a C++ class: it is allocated once and zeroed
-  # by initState()/initOpts() before anything reads it, and C code — which is
-  # most of its users — has no constructors to write. Analysing a C++ TU that
-  # includes it reports every one of its ~600 members as "no initializer", which
-  # is one finding per field of a struct nobody default-constructs. Scoped to
-  # this header and this check only; the same check still applies to every real
-  # C++ class in the tree.
-  --suppress='uninitMemberVarNoCtor:include/dsd-neo/core/state.h'
-  --suppress='uninitMemberVarNoCtor:*/dsd-neo/core/state.h'
+  # uninitMemberVarNoCtor on dsd_state is suppressed at the struct itself, with a
+  # cppcheck-suppress-begin/end pair in include/dsd-neo/core/state.h: a suppression
+  # here would have to name the file, and that covers the seventeen other types
+  # declared in it as well.
   -i src/third_party
   -i android/third_party
 )

--- a/tools/cppcheck.sh
+++ b/tools/cppcheck.sh
@@ -159,6 +159,15 @@ CPPCHECK_ARGS+=(
   --suppress='*:*/src/third_party/*'
   --suppress='*:android/third_party/*'
   --suppress='*:*/android/third_party/*'
+  # dsd_state is a C aggregate, not a C++ class: it is allocated once and zeroed
+  # by initState()/initOpts() before anything reads it, and C code — which is
+  # most of its users — has no constructors to write. Analysing a C++ TU that
+  # includes it reports every one of its ~600 members as "no initializer", which
+  # is one finding per field of a struct nobody default-constructs. Scoped to
+  # this header and this check only; the same check still applies to every real
+  # C++ class in the tree.
+  --suppress='uninitMemberVarNoCtor:include/dsd-neo/core/state.h'
+  --suppress='uninitMemberVarNoCtor:*/dsd-neo/core/state.h'
   -i src/third_party
   -i android/third_party
 )


### PR DESCRIPTION
Changing frequency in the Android app today means stop → edit the system → start again, which is hopeless when what you are actually doing is hunting for activity. This adds a Spectrum screen: a live trace over a scrolling waterfall covering the whole SDR capture span, and a tap that moves the receiver to the signal under your finger without dropping the session.

Works the same for USB RTL-SDR and rtl_tcp — both feed one `input_ring`, so there is one code path from the tap onward.

## io: a wideband spectrum, separate from the narrow one

`src/io/radio/rtl_wideband_spectrum.{h,cpp}` taps `d->lowpassed` in `demod_thread_fn()` **before** `full_demod()`, whose first step is the half-band cascade — so the block is still interleaved float I/Q at capture rate (~1.536 MHz), roughly 32 channels wide instead of one.

The existing `rtl_metrics.cpp` spectrum stays untouched: it is post-decimation, and it feeds the supervisory tuner auto-gain gate (`demod_autogain_spectral_gate_ok()`), so retuning its size/rate/smoothing to also serve a UI would regress gain control. The new module mirrors its FFT plumbing (cached pffft setup, Hann window, dB, fftshift, EMA) rather than sharing it, with a comment saying why.

- **Off by default.** `rtl_stream_wideband_spectrum_set_enabled()` gates the whole thing; `maybe_update()` returns on an atomic load, so it costs nothing while no view is open. Measured on device: 5× less CPU with the screen closed.
- **Seqlock publish.** Bins, center and span go out together — a waterfall labelled with a torn axis is visibly wrong. The payload is relaxed-atomic so the seqlock is race-free by the memory model, not just in practice.
- **Retunes invalidate via a generation counter**, not a write into the published frame: `rtl_wideband_spectrum_clear()` is called from `drain_output_on_retune()` on the *controller* thread while the demod thread is the seqlock writer, and two writers on one seqlock is a real race. `set_size()` and disabling bump it too.
- Blocks shorter than the FFT size are skipped rather than zero-padded, so a published frame's resolution always matches its advertised span.

Two details worth recording, both verified rather than assumed:

- The capture rate comes from `load_dongle_rate()`, not `rate_in << downsample_passes` — `optimal_settings()` may override the computed rate with the device's nearest supported one.
- `controller.last_applied_freq_hz` is the **user-visible center**, not capture terms, and ingest already rotates the fs/4 offset back out (`rtl_device.cpp`, the `j^n` sequence). So no inverse transform is needed. Confirmed on hardware: the control channel we are locked to renders exactly at the center of the span.

## app_control: `DSD_APP_CMD_MANUAL_TUNE`

Deliberately not a reuse of `DSD_APP_CMD_RTL_SET_FREQ` (483), which is the settings-menu tune with a documented no-bookkeeping contract. A separate id (492) buys three things:

- its own coalescing class, so a burst of taps collapses onto the latest tap and never merges with a pending settings tune;
- the trunking gate evaluated at drain time on the live `opts->trunk_enable`, rather than trusting the frontend to have hidden the control;
- a home for the decode-auto re-acquisition resets — `dsd_frame_sync_reset_mod_state()` + `reset_call_tracking()`, only after an accepted tune (`0` or `TUNE_TIMEOUT`), matching how `trunk_tuning.c` orders this. Without them the stale modulation votes and per-slot call state slow or corrupt re-acquisition.

Plus `dsd_app_frontend_wideband_spectrum_get/_set_enabled` on the frontend boundary, with the usual `USE_RADIO`/stub arrangement.

## Qt/QML: the screen

- `spectrum_math.h` — Qt-free, header-only: bin↔frequency, viewport clamping and the overshoot that becomes a retune, the tap snap window, the pinch anchor, axis tick steps, and the slowly-relaxing display range. All the arithmetic that is wrong in ways nobody notices until the receiver lands on the wrong channel.
- `SpectrumModel` — polls the wideband getter on its own ~15 FPS timer rather than riding the 250 ms UI tick, which a waterfall would starve on. It never touches `dsd_app_get_latest_snapshot()` / `..._opts_snapshot()` (strictly single-consumer, owned by `UiController`); everything a frame needs is published inside the frame. Production follows the view being up **and** the app being on screen.
- `SpectrumTraceItem` / `WaterfallItem` — `QQuickPaintedItem`, the first `qmlRegisterType`'d types here. A QML `Canvas` would marshal a thousand bins through JavaScript fifteen times a second, which is the slow path on a phone. Waterfall rows are always written full-span into a preallocated ring, so zoom and pan are a source rectangle at paint time and history stays correct under both; only a retune invalidates it.
- `SpectrumScreen.qml` — opened from a header pill on MonitorScreen (`visible: metrics.radioInput`), as a new cross-fade layer above it. Tap snaps to the strongest peak near the touch; pinch 1×–8× holds the frequency under the fingers; panning past the capture edge retunes **once, on release** — never per drag frame, since each tune blocks the engine thread for up to 500 ms. While trunking owns the tuner the screen is view-only with a magenta pill.
- `MetricsModel` gained `centerFreqHz` and `trunkingEnabled`; nothing in the Qt tree read `trunk_enable` or `rtlsdr_center_freq` before this.

## A bug the new tests found

`peak_search_bin()` seeded its search at the low edge of the snap window. Over flat noise every candidate ties, so a deliberate tap on a *quiet* channel was dragged ~25 kHz down, every time. It now starts at the tap and only leaves for a strictly stronger bin. Pinned by a unit case and a QML case.

## Tests

- `IO_RTL_WIDEBAND_SPECTRUM` — size clamping, silent-until-enabled, fftshift orientation against a synthetic +200 kHz tone (this is what pins bin 0 = center − span/2), publish throttling, clear/disable invalidation, short-block skip, `max_bins` truncation. Compiles the module directly into the target, so it needs no RTL libs.
- `UI_QT_SPECTRUM_MATH` — bin↔frequency round trips, pan clamping and overshoot sign at both edges, snap-window endpoints, peak-search bounds discipline including the flat-noise case above, pinch anchor invariance, tick-step niceness. Registered outside the `DSD_ENABLE_QT_UI` gate since the header is Qt-free.
- `APP_COMMAND_QUEUE` — MANUAL_TUNE typed accept/reject, tap-storm coalescing, no cross-coalescing with `RTL_SET_FREQ` in either direction, undersized payload reaching no handler; and under the existing `--wrap=io_control_set_freq` seam: trunking ⇒ zero tune calls plus the refusal toast, trunking off ⇒ one tune at the tapped frequency with both call slots ENDED, `TUNE_TIMEOUT` still resets, `TUNE_FAILED` leaves call state alone.
- `UI_QT_QML_CALL_LISTS` — eleven new cases in `tst_spectrum_screen.qml`. The suite now compiles the production `SpectrumModel` and both painted items against a canned app-control getter, so the polling, viewport and snapping under test are the real ones and only the frames are synthetic. Gesture bodies were lifted out of the handlers into named functions (`applyPinch`/`applyPan`/`endPan`) precisely so they could be called from a test.
- `APP_CONTROL_FRONTEND_METRICS` — that target compiles `frontend.c` without `USE_RADIO`, so it now also pins that all four visualizer getters return 0 and zero their out-params on a no-radio build. Nothing covered that before.
- Full suite 515/515; `tools/preflight_ci.sh` clean.

## Verified on hardware

Emulator + host `rtl_tcp`, live P25 site at 769.76875 MHz, SNR ~20 dB:

- Trace and waterfall render live RF; the locked control channel sits at the center of the span.
- Tap → "Applied: tuned -> …" and the receiver moves (769.7687 → 770.4182 MHz onto a carrier at the right of the span, which then appears centered), waterfall clears, axis relabels, session keeps running.
- Drag past the edge → exactly one retune (769.9592 → 770.7363 MHz for a half-screen drag).
- Trunking on → view-only, taps do nothing.
- CPU 1375 → 272 jiffies/10 s when the screen is closed.

Both themes checked; the waterfall's cold color is `Theme.bg` rather than `Theme.panel` because history takes ~16 s to fill and a panel-colored fresh waterfall is a bright empty slab in light mode.

## Notes

- On a trunked system the waterfall clears on every trunk retune — history at another center is meaningless — so it only accumulates a second or two at a time there. Untrunked it fills the full window.
- Pinch was not driven as a real two-finger gesture (`adb shell input` has no multi-touch). Its body is covered by calling `applyPinch()` directly and its Qt property names checked against the 6.11 headers, but the gesture itself deserves a manual pass.
- USB-OTG RTL-SDR is untested here; everything was driven over rtl_tcp.
- `src/io/radio/rtl_wideband_spectrum.cpp` had to be added to the `no-direct-third-party-include` exclude list in `semgrep/dsd-neo.yml`, alongside `rtl_metrics.cpp`, since it includes `<pffft.h>`.
