### PR TITLE
feat(android): tap the notification to return, and show live call status

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,14 +213,17 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
         # sequence counter. GCC raises the diagnostic from inside libstdc++'s <atomic>,
         # where no pragma at our call site reaches it, so with -Werror it makes the whole
         # preset unbuildable. CI runs this preset under clang, which has no such warning,
-        # which is why it only bites locally. Narrowed to GCC: clang rejects unknown
-        # -Wno-* under -Werror.
-        if(
-            CMAKE_C_COMPILER_ID STREQUAL "GNU"
-            AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+        # which is why it only bites locally.
+        #
+        # Per-language, not per-configuration: the diagnostic comes out of libstdc++, so
+        # it is C++-only, and testing both compiler ids meant a mixed CC=clang CXX=g++
+        # tree withheld the flag from the very TU that needs it and stayed unbuildable.
+        # The genex also keeps clang from ever seeing -Wno-tsan, which it rejects as an
+        # unknown warning option under -Werror.
+        list(
+            APPEND _dsd_san_cflags
+            $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:GNU>>:-Wno-tsan>
         )
-            list(APPEND _dsd_san_cflags -Wno-tsan)
-        endif()
     endif()
 
     if(_dsd_san_cflags)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,21 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
     if(DSD_ENABLE_TSAN)
         list(APPEND _dsd_san_cflags -fsanitize=thread -fno-omit-frame-pointer)
         list(APPEND _dsd_san_ldflags -fsanitize=thread)
+        # GCC's -Wtsan reports that ThreadSanitizer cannot model atomic_thread_fence.
+        # That is a statement about the sanitizer's coverage, not a defect: the wideband
+        # spectrum publisher (src/io/radio/rtl_wideband_spectrum.cpp) is a seqlock, and a
+        # seqlock needs standalone release/acquire fences to order its payload against the
+        # sequence counter. GCC raises the diagnostic from inside libstdc++'s <atomic>,
+        # where no pragma at our call site reaches it, so with -Werror it makes the whole
+        # preset unbuildable. CI runs this preset under clang, which has no such warning,
+        # which is why it only bites locally. Narrowed to GCC: clang rejects unknown
+        # -Wno-* under -Werror.
+        if(
+            CMAKE_C_COMPILER_ID STREQUAL "GNU"
+            AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+        )
+            list(APPEND _dsd_san_cflags -Wno-tsan)
+        endif()
     endif()
 
     if(_dsd_san_cflags)

--- a/android/README.md
+++ b/android/README.md
@@ -4,8 +4,9 @@
 
 An arm64-v8a app: a Qt Quick UI (shared with the future desktop GUI, `src/ui/qt/`),
 a foreground service that owns the decoder, and a small JNI surface between them.
-The engine is linked into the app process as native code — there is no data path
-across JNI, only lifecycle and platform glue.
+The engine is linked into the app process as native code, so JNI carries only
+lifecycle, platform glue, and one read-only status record (the scanner readout the
+service renders into its notification).
 
 Supported inputs: a directly attached RTL-SDR over USB-OTG, `rtl_tcp`, UDP PCM,
 TCP PCM, and local files.

--- a/android/decoder_host_android.cpp
+++ b/android/decoder_host_android.cpp
@@ -8,7 +8,10 @@
 #include <QCoreApplication>
 #include <QJniEnvironment>
 #include <QJniObject>
+#include <QMetaObject>
 #include <QVariant>
+
+#include <jni.h>
 
 #include "dsdneo_jni.h"
 
@@ -303,3 +306,54 @@ DecoderHostAndroid::setLocalDeviceState(bool ready, const QString& text) {
 }
 
 } // namespace dsd_android
+
+extern "C" {
+
+/**
+ * @brief Asks the Qt event loop to quit, so main() can return.
+ *
+ * Called from DsdNeoActivity.onDestroy() before Qt's own teardown runs, and it has to
+ * be: QtActivityBase.onDestroy() calls QtNative.terminateQtNativeApplication(), which
+ * waits on a semaphore that is only posted once main() has returned — but the quit that
+ * would make it return is raised by Qt only when the Android event dispatcher is already
+ * stopped:
+ *
+ *     if (QAndroidEventDispatcherStopper::instance()->stopped()) {
+ *         QAndroidEventDispatcherStopper::instance()->startAll();
+ *         QCoreApplication::quit();
+ *         ...
+ *     }
+ *     if (startQtAndroidPluginCalled.loadAcquire())
+ *         sem_wait(&m_terminateSemaphore);
+ *
+ * With the dispatcher still running — which is the state a swipe out of recents leaves
+ * behind — no quit is sent and the wait never ends. Without a foreground service the
+ * process is an empty-process kill candidate and Android reaps it before anyone notices;
+ * with the decoder's service up the process is retained, so the block persists and every
+ * later main-thread delivery, the service's own included, times out into an ANR.
+ *
+ * Safe before Qt exists — the Activity can be destroyed after a failed start, when there
+ * is no QCoreApplication instance to end.
+ */
+JNIEXPORT void JNICALL
+Java_io_github_arancormonk_dsdneo_DsdNative_nativeQuitUi(JNIEnv* env, jclass clazz) {
+    (void)env;
+    (void)clazz;
+
+    QCoreApplication* app = QCoreApplication::instance();
+    if (app == nullptr) {
+        return;
+    }
+    /* exit(), not quit(). Since Qt 6, quit() first asks every top-level window to close
+     * and abandons the quit if any of them refuses -- and Main.qml's onClosing refuses
+     * every time, because that handler is what turns a window close into
+     * moveToBackground() so a decode session survives the user leaving the app. Calling
+     * quit() here therefore did nothing at all: the handler declined, the loop carried on
+     * and the teardown went on waiting. exit() leaves the event loop directly, without
+     * consulting windows, which is what a teardown that cannot be declined needs.
+     *
+     * Queued so the loop unwinds on its own thread; this runs on the Android main thread. */
+    QMetaObject::invokeMethod(app, []() { QCoreApplication::exit(0); }, Qt::QueuedConnection);
+}
+
+} // extern "C"

--- a/android/dsdneo_jni.cpp
+++ b/android/dsdneo_jni.cpp
@@ -7,9 +7,10 @@
  * @file
  * @brief JNI lifecycle surface for the Android app: init/configure/run/stop/destroy.
  *
- * There is no data path here. The Qt UI links the engine in-process and reads
- * app-control directly; JNI only carries what has to cross into Java: the engine
- * lifetime (owned by the foreground service) and platform glue.
+ * The Qt UI links the engine in-process and reads app-control directly, so JNI carries
+ * only what has to cross into Java: lifecycle, platform glue, and one read-only status
+ * record -- the scanner readout the foreground service renders into its notification,
+ * which it needs with no Qt in the picture. No audio, symbols or I/Q cross here.
  *
  * One engine instance per process (ground rule 4), guarded by a single mutex.
  * Nothing throws across JNI — every entry point returns a status code.

--- a/android/dsdneo_jni.cpp
+++ b/android/dsdneo_jni.cpp
@@ -31,6 +31,7 @@
 #include <unistd.h>
 
 #include <dsd-neo/app_control/frontend_runtime.h>
+#include <dsd-neo/app_control/notification_status.h>
 #include <dsd-neo/core/init.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
@@ -546,6 +547,28 @@ Java_io_github_arancormonk_dsdneo_DsdNative_nativeIsUsbFdInUse(JNIEnv* env, jcla
     /* No radio pipeline, so nothing can have taken the descriptor. */
     return JNI_FALSE;
 #endif
+}
+
+JNIEXPORT jstring JNICALL
+Java_io_github_arancormonk_dsdneo_DsdNative_nativeNotificationStatus(JNIEnv* env, jclass clazz) {
+    (void)clazz;
+
+    /* Deliberately lock-free with respect to g_lock. This is polled from the service's
+     * main thread once a second, and the publisher behind it takes only its own short
+     * mutex -- taking g_lock here would put a UI-thread poll behind nativeConfigure's
+     * whole bootstrap. */
+    char record[DSD_APP_NOTIFICATION_RECORD_SIZE];
+    if (dsd_app_notification_encode(record, sizeof(record)) == 0) {
+        return nullptr;
+    }
+    jstring result = env->NewStringUTF(record);
+    if (result == nullptr) {
+        /* Allocation failure leaves a pending OutOfMemoryError: returning null with it
+         * still pending would throw into the service's poll loop instead of handing back
+         * a value, so absorb it here and let this poll look like "nothing published". */
+        clear_pending_exception(env);
+    }
+    return result;
 }
 
 } // extern "C"

--- a/android/package/AndroidManifest.xml
+++ b/android/package/AndroidManifest.xml
@@ -39,8 +39,18 @@
         android:allowBackup="false"
         android:fullBackupOnly="false">
 
+        <!-- QtActivity plus one override: it raises the Qt quit that Qt's own teardown
+             waits for but does not send. See DsdNeoActivity. -->
+        <!-- The launcher activity has to be exported: it carries the MAIN/LAUNCHER filter
+             and the USB_DEVICE_ATTACHED filter, and both are delivered by the system from
+             outside the app. It reads nothing from the intent beyond what Qt takes for its
+             own startup, so there is no control plane behind it to reach. Suppressed on
+             this element and this rule only, rather than excluding the manifest from the
+             scan. The finding predates DsdNeoActivity — it fires on the stock QtActivity
+             declaration too — and only surfaces when a change touches this file. -->
+        <!-- nosemgrep: java.android.security.exported_activity.exported_activity -->
         <activity
-            android:name="org.qtproject.qt.android.bindings.QtActivity"
+            android:name="io.github.arancormonk.dsdneo.DsdNeoActivity"
             android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
             android:label="-- %%INSERT_APP_NAME%% --"
             android:launchMode="singleTop"

--- a/android/package/res/values/strings.xml
+++ b/android/package/res/values/strings.xml
@@ -7,6 +7,18 @@
     <string name="decoder_starting">Starting…</string>
     <string name="decoder_running">Decoding</string>
     <string name="decoder_stopping">Stopping…</string>
+    <string name="decoder_listening">Listening</string>
+    <!-- Quoted because aapt2 strips leading and trailing whitespace from a string
+         resource: written bare, this compiles to "·" and the notification body runs
+         together as "Encrypted·Unit 1234". The quotes are the delimiter, not content. -->
+    <string name="notif_separator">" · "</string>
+    <string name="notif_unit">Unit %1$s</string>
+    <string name="notif_encrypted">Encrypted</string>
+    <string name="notif_alg">ALG %1$s</string>
+    <string name="notif_kid">KID %1$s</string>
+    <string name="notif_control_freq">Control %1$s</string>
+    <string name="notif_freq_mhz">%.06f MHz</string>
+    <string name="notif_slot">Slot %1$d</string>
     <!-- Shown in the app when a start dies before the engine ever runs. The code is
          carried through because the underlying reason only exists in logcat. -->
     <string name="error_init_failed">The decoder could not be initialised (code %1$d).</string>

--- a/android/package/src/io/github/arancormonk/dsdneo/DecoderService.kt
+++ b/android/package/src/io/github/arancormonk/dsdneo/DecoderService.kt
@@ -68,12 +68,16 @@ class DecoderService : Service() {
         }
 
         // Here rather than in startDecoding(), so it keys off "this instance is fronting a
-        // live engine" instead of "this instance started it". joinEngineThread() leaves a
-        // timed-out engine RUNNING on purpose, and the replacement service's START is then
-        // rejected as a duplicate before it ever reaches startDecoding()'s tail — but its
-        // notification is the only surface the user has, so it still has to track the call.
-        // startStatusPolling() removes any queued tick first, so arriving here twice for
-        // one session cannot leave two loops running.
+        // live engine" instead of "this instance started it": a duplicate START that
+        // startDecoding() rejects still has to leave the notification tracking the call it
+        // is already fronting. startStatusPolling() removes any queued tick first, so
+        // arriving here twice for one session cannot leave two loops running.
+        //
+        // RUNNING and not merely "not IDLE": STOPPING means nativeStop() has been called,
+        // which is the state a timed-out joinEngineThread() leaves behind (onDestroy runs
+        // stopDecoding() before the join, so the engine is always on its way out by then).
+        // A replacement instance created in that window is fronting a session that is
+        // shutting down, and "Stopping…" is what its notification should say.
         if (synchronized(lock) { state } == State.RUNNING) {
             startStatusPolling()
         }
@@ -189,7 +193,9 @@ class DecoderService : Service() {
             state = State.IDLE
             lastError = userMessage
         }
-        stopStatusPolling()
+        // No stopStatusPolling() here: stopForegroundCompat() does it first thing, and it
+        // has to, because stopIfIdle() reaches it by a path that does not come through
+        // here. Two calls would only make it ambiguous which one is load-bearing.
         stopForegroundCompat()
         stopSelfLatest()
     }
@@ -304,7 +310,7 @@ class DecoderService : Service() {
      * the top of onStartCommand.
      */
     private fun buildNotification(text: String): Notification {
-        val status = DecoderStatus.parse(lastStatusRecord)
+        val status = lastStatus
         val lead = status?.leadSlot
 
         val builder = Notification.Builder(this, CHANNEL_ID)
@@ -356,15 +362,25 @@ class DecoderService : Service() {
                 else -> getString(R.string.decoder_listening)
             }
         )
+        // Resolved once and handed to both renderers: each would otherwise take the
+        // Resources lock for the same two strings, and they must not disagree.
+        val frequency = frequencyPart(status, lead)
+
         // Back to the phase wording when the status has nothing to say. The record's two
         // halves are published by separate calls, so a poll can catch a status whose call
         // and frequency are both still empty, and a blank second line reads as a bug.
-        builder.setContentText(bodyText(status, lead).ifEmpty { text })
+        val body = bodyText(lead, frequency)
+        builder.setContentText(body.ifEmpty { text })
 
-        if (status.slots.any { it.hasContent }) {
-            // Only when there is something to expand into: a BigTextStyle whose text is
-            // just the collapsed line again turns the expand chevron into a lie.
-            builder.setStyle(Notification.BigTextStyle().bigText(expandedText(status, lead)))
+        // Gated on the expanded text itself, not on "some slot has content": a slot whose
+        // name and source are both the encoder's "0" sentinel — X2-TDMA and standalone
+        // ProVoice, which call_view.c deliberately lets through with no identity —
+        // contributes no row at all, so the guard would pass with nothing to show. An
+        // empty big text, or one that just repeats the collapsed line, turns the expand
+        // chevron into a lie.
+        val expanded = expandedText(status, frequency)
+        if (expanded.isNotEmpty() && expanded != body) {
+            builder.setStyle(Notification.BigTextStyle().bigText(expanded))
         }
         return builder.build()
     }
@@ -396,9 +412,6 @@ class DecoderService : Service() {
      * retune moves the centre out from under the call.
      */
     private fun frequencyPart(status: DecoderStatus, lead: SlotCall?): String? {
-        if (!status.radioInput) {
-            return null
-        }
         // hasContent, not LINE_ACTIVE: the lead slot stays ENDED for the hold that follows
         // every transmission, and trunkTuned is still set for as much of it as the trunk
         // state machine takes to hand the tuner back. Testing for ACTIVE alone made the
@@ -411,29 +424,51 @@ class DecoderService : Service() {
         if (status.trunking) {
             freqText(status.ccFreqHz)?.let { return getString(R.string.notif_control_freq, it) }
         }
-        return freqText(status.centerFreqHz)
+        // Only the tuner centre is gated on the input being a radio, and only the tuner
+        // centre should be: the publisher already zeroes it for every other input, whereas
+        // the voice and control channels above are decoded off the air and are just as
+        // true on a rigctl-tuned trunked session fed over UDP, TCP or from a file. Gating
+        // the whole chain here left those sessions with no frequency line at all.
+        return if (status.radioInput) freqText(status.centerFreqHz) else null
+    }
+
+    /**
+     * `Encrypted`, plus `ALG xx` / `KID xxxx` once a crypto header has decoded.
+     *
+     * One helper for both renderers: written out twice, the expanded view had only the
+     * bare `Encrypted` while the collapsed line carried the algorithm — so pulling the
+     * notification open *removed* the one thing that tells AES from RC4 at a glance,
+     * which is the whole reason the Qt panel formats it.
+     *
+     * algid 0 is "encrypted, but no crypto header decoded yet"; the ENC word alone is the
+     * whole of what is known. Same rule the Qt panel applies.
+     */
+    private fun cryptoParts(call: SlotCall?): List<String> {
+        if (call == null || !call.enc) {
+            return emptyList()
+        }
+        if (call.algid == 0) {
+            return listOf(getString(R.string.notif_encrypted))
+        }
+        return listOf(
+            getString(R.string.notif_encrypted),
+            getString(R.string.notif_alg, "%02X".format(call.algid)),
+            getString(R.string.notif_kid, "%04X".format(call.kid))
+        )
     }
 
     /**
      * Parts in priority order, because Android truncates the tail: why there is no audio
      * first, who is talking second, where third.
      */
-    private fun bodyText(status: DecoderStatus, lead: SlotCall?): String {
+    private fun bodyText(lead: SlotCall?, frequency: String?): String {
         val parts = mutableListOf<String>()
-        if (lead != null && lead.enc) {
-            parts += getString(R.string.notif_encrypted)
-            // algid 0 is "encrypted, but no crypto header decoded yet"; the ENC word
-            // alone is the whole of what is known. Same rule the Qt panel applies.
-            if (lead.algid != 0) {
-                parts += getString(R.string.notif_alg, "%02X".format(lead.algid))
-                parts += getString(R.string.notif_kid, "%04X".format(lead.kid))
-            }
-        }
+        parts += cryptoParts(lead)
         // "0" is what the encoder writes for a source that never decoded, not a unit.
         if (lead != null && lead.srcText.isNotEmpty() && lead.srcText != "0") {
             parts += getString(R.string.notif_unit, lead.srcText)
         }
-        frequencyPart(status, lead)?.let { parts += it }
+        frequency?.let { parts += it }
         return parts.joinToString(separator)
     }
 
@@ -441,7 +476,7 @@ class DecoderService : Service() {
      * One row per slot with content, plus the frequency. Prose, not columns: notification
      * body text is proportional, so an aligned table would ragged out.
      */
-    private fun expandedText(status: DecoderStatus, lead: SlotCall?): String {
+    private fun expandedText(status: DecoderStatus, frequency: String?): String {
         val occupied = status.slots.count { it.hasContent }
         val rows = mutableListOf<String>()
         status.slots.forEachIndexed { index, call ->
@@ -464,14 +499,12 @@ class DecoderService : Service() {
             if (call.srcText.isNotEmpty() && call.srcText != "0") {
                 parts += getString(R.string.notif_unit, call.srcText)
             }
-            if (call.enc) {
-                parts += getString(R.string.notif_encrypted)
-            }
+            parts += cryptoParts(call)
             if (parts.isNotEmpty()) {
                 rows += parts.joinToString(separator)
             }
         }
-        frequencyPart(status, lead)?.let { rows += it }
+        frequency?.let { rows += it }
         return rows.joinToString("\n")
     }
 
@@ -502,6 +535,16 @@ class DecoderService : Service() {
     private var lastStatusRecord: String? = null
 
     /**
+     * [lastStatusRecord] parsed, and the only input [buildNotification] renders.
+     *
+     * Parsed once where the record changes rather than once per notification build: a
+     * build happens on every phase update too, and re-splitting 27 fields to render the
+     * same status again is work for nothing. Kept in step with [lastStatusRecord] — both
+     * are written together and cleared together.
+     */
+    private var lastStatus: DecoderStatus? = null
+
+    /**
      * Re-reads the published status once a second, re-posting only on a change.
      *
      * Re-posts itself from the tail and only while RUNNING, so the loop unwinds on its
@@ -520,6 +563,7 @@ class DecoderService : Service() {
                 // still counting up, until Android gets round to destroying the service.
                 if (lastStatusRecord != null) {
                     lastStatusRecord = null
+                    lastStatus = null
                     // Not currentStatusText(): it maps IDLE to "Starting…" for the
                     // promotion at the top of onStartCommand, where IDLE means a start is
                     // about to happen. Here it means the run just ended and stopSelf has
@@ -541,6 +585,14 @@ class DecoderService : Service() {
             }
             if (record != lastStatusRecord) {
                 lastStatusRecord = record
+                lastStatus = DecoderStatus.parse(record)
+                if (record != null && lastStatus == null) {
+                    // A record this build cannot read — a field added on one side of JNI
+                    // without the other, or a version it does not know. Silent otherwise:
+                    // the notification would render the phase wording for the rest of the
+                    // session with nothing on either side saying why.
+                    Log.w(TAG, "unreadable status record; notification limited to phase text")
+                }
                 // Only when the record itself changed, which on a quiet channel is
                 // almost never. A live call does re-render each second — its elapsed_ms
                 // advances — but setOnlyAlertOnce keeps every one of those silent.
@@ -567,6 +619,7 @@ class DecoderService : Service() {
     private fun stopStatusPolling() {
         statusHandler.removeCallbacks(statusPoll)
         lastStatusRecord = null
+        lastStatus = null
     }
 
     private fun stopForegroundCompat() {

--- a/android/package/src/io/github/arancormonk/dsdneo/DecoderService.kt
+++ b/android/package/src/io/github/arancormonk/dsdneo/DecoderService.kt
@@ -246,6 +246,44 @@ class DecoderService : Service() {
     }
 
     /**
+     * The stop action's PendingIntent, built once for this service instance.
+     *
+     * [buildNotification] runs on every status poll — once a second for the length of
+     * every call — and each PendingIntent.getService/getActivity is a binder round trip
+     * on the main thread. A PendingIntent is a process-lifetime token and this one's
+     * identity (request code, target, action) never varies, so building it once costs
+     * nothing in freshness.
+     *
+     * On the instance and not in the companion object, unlike [state] and [engineThread]:
+     * a PendingIntent built from `this` holds the Context, and a companion field would
+     * keep a destroyed service alive for the life of the process.
+     */
+    private val stopPendingIntent: PendingIntent by lazy {
+        val stopIntent = Intent(this, DecoderService::class.java).setAction(ACTION_STOP)
+        PendingIntent.getService(
+            this, REQUEST_STOP, stopIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+    }
+
+    /**
+     * The tap target, built once alongside [stopPendingIntent].
+     *
+     * The launcher's own intent, not an explicit QtActivity component: ACTION_MAIN +
+     * CATEGORY_LAUNCHER + NEW_TASK is what resumes an existing task, whereas an explicit
+     * component can start a second Activity instance and with it a second Qt main(). Null
+     * only if no launcher activity resolves, in which case the body stays inert rather
+     * than taking the service down — and a package cannot gain or lose its launcher
+     * activity without the process being killed, so resolving once is enough.
+     */
+    private val openPendingIntent: PendingIntent? by lazy {
+        packageManager.getLaunchIntentForPackage(packageName)?.let { launch ->
+            PendingIntent.getActivity(
+                this, REQUEST_OPEN, launch, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+        }
+    }
+
+    /**
      * Renders the notification from the last polled status, falling back to [text].
      *
      * [text] is the phase wording — "Starting…", "Decoding" — and is what shows before
@@ -253,22 +291,6 @@ class DecoderService : Service() {
      * the top of onStartCommand.
      */
     private fun buildNotification(text: String): Notification {
-        val stopIntent = Intent(this, DecoderService::class.java).setAction(ACTION_STOP)
-        val stopPending = PendingIntent.getService(
-            this, REQUEST_STOP, stopIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-        )
-
-        // The launcher's own intent, not an explicit QtActivity component: ACTION_MAIN +
-        // CATEGORY_LAUNCHER + NEW_TASK is what resumes an existing task, whereas an
-        // explicit component can start a second Activity instance and with it a second Qt
-        // main(). Null only if no launcher activity resolves, in which case the body stays
-        // inert rather than taking the service down.
-        val openPending = packageManager.getLaunchIntentForPackage(packageName)?.let { launch ->
-            PendingIntent.getActivity(
-                this, REQUEST_OPEN, launch, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-            )
-        }
-
         val status = DecoderStatus.parse(lastStatusRecord)
         val lead = status?.leadSlot
 
@@ -277,11 +299,11 @@ class DecoderService : Service() {
             .setOngoing(true)
             // Updates must never re-alert: this posts again on every call boundary.
             .setOnlyAlertOnce(true)
-            .addAction(Notification.Action.Builder(null, getString(R.string.action_stop), stopPending).build())
+            .addAction(Notification.Action.Builder(null, getString(R.string.action_stop), stopPendingIntent).build())
 
         // No setAutoCancel: this is an ongoing foreground-service notification and must
         // survive the tap that opens the app.
-        openPending?.let { builder.setContentIntent(it) }
+        openPendingIntent?.let { builder.setContentIntent(it) }
 
         if (status == null) {
             return builder.setContentTitle(getString(R.string.app_name))

--- a/android/package/src/io/github/arancormonk/dsdneo/DecoderService.kt
+++ b/android/package/src/io/github/arancormonk/dsdneo/DecoderService.kt
@@ -14,7 +14,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import android.os.PowerManager
 import android.util.Log
 
@@ -69,6 +71,10 @@ class DecoderService : Service() {
     }
 
     override fun onDestroy() {
+        // First, and on the same thread the poll runs on: once removeCallbacks() has
+        // returned here, no pending tick can still fire and post a notification behind a
+        // service that is on its way out.
+        stopStatusPolling()
         stopDecoding()
         val stopped = joinEngineThread()
         if (stopped && initialized) {
@@ -155,6 +161,7 @@ class DecoderService : Service() {
         }
         updateNotification(getString(R.string.decoder_running))
         thread.start()
+        startStatusPolling()
     }
 
     /**
@@ -169,6 +176,7 @@ class DecoderService : Service() {
             state = State.IDLE
             lastError = userMessage
         }
+        stopStatusPolling()
         stopForegroundCompat()
         stopSelfLatest()
     }
@@ -185,6 +193,11 @@ class DecoderService : Service() {
         if (!shouldStop) {
             return
         }
+        // Drops the cached record with it, which is what makes the update below visible:
+        // the phase text is only rendered when no status is cached, so leaving the last
+        // polled call in place would answer the user's stop with a call line and a
+        // chronometer still counting up.
+        stopStatusPolling()
         updateNotification(getString(R.string.decoder_stopping))
         DsdNative.nativeStop()
     }
@@ -232,19 +245,149 @@ class DecoderService : Service() {
         getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
     }
 
+    /**
+     * Renders the notification from the last polled status, falling back to [text].
+     *
+     * [text] is the phase wording — "Starting…", "Decoding" — and is what shows before
+     * the engine has published anything, which includes the unconditional promotion at
+     * the top of onStartCommand.
+     */
     private fun buildNotification(text: String): Notification {
         val stopIntent = Intent(this, DecoderService::class.java).setAction(ACTION_STOP)
         val stopPending = PendingIntent.getService(
-            this, 0, stopIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            this, REQUEST_STOP, stopIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 
-        return Notification.Builder(this, CHANNEL_ID)
-            .setContentTitle(getString(R.string.app_name))
-            .setContentText(text)
+        // The launcher's own intent, not an explicit QtActivity component: ACTION_MAIN +
+        // CATEGORY_LAUNCHER + NEW_TASK is what resumes an existing task, whereas an
+        // explicit component can start a second Activity instance and with it a second Qt
+        // main(). Null only if no launcher activity resolves, in which case the body stays
+        // inert rather than taking the service down.
+        val openPending = packageManager.getLaunchIntentForPackage(packageName)?.let { launch ->
+            PendingIntent.getActivity(
+                this, REQUEST_OPEN, launch, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            )
+        }
+
+        val status = DecoderStatus.parse(lastStatusRecord)
+        val lead = status?.leadSlot
+
+        val builder = Notification.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_stat_dsdneo)
             .setOngoing(true)
+            // Updates must never re-alert: this posts again on every call boundary.
+            .setOnlyAlertOnce(true)
             .addAction(Notification.Action.Builder(null, getString(R.string.action_stop), stopPending).build())
-            .build()
+
+        // No setAutoCancel: this is an ongoing foreground-service notification and must
+        // survive the tap that opens the app.
+        openPending?.let { builder.setContentIntent(it) }
+
+        if (status == null) {
+            return builder.setContentTitle(getString(R.string.app_name))
+                .setContentText(text)
+                .setShowWhen(false)
+                .build()
+        }
+
+        if (status.protocol.isNotEmpty()) {
+            builder.setSubText(status.protocol)
+        }
+
+        if (lead != null && lead.state == DecoderStatus.LINE_ACTIVE) {
+            builder.setWhen(System.currentTimeMillis() - lead.elapsedMs)
+                .setShowWhen(true)
+                .setUsesChronometer(true)
+        } else {
+            // A Notification chronometer always counts, so an ended call cannot hold it
+            // at its final duration. Hiding it is the honest option; the call's identity
+            // stays for the 3s hold so a late glance still reads who it was.
+            builder.setShowWhen(false).setUsesChronometer(false)
+        }
+
+        builder.setContentTitle(if (lead != null) lead.name else getString(R.string.decoder_listening))
+        // Back to the phase wording when the status has nothing to say. The record's two
+        // halves are published by separate calls, so a poll can catch a status whose call
+        // and frequency are both still empty, and a blank second line reads as a bug.
+        builder.setContentText(bodyText(status, lead).ifEmpty { text })
+
+        if (status.slots.any { it.hasContent }) {
+            // Only when there is something to expand into: a BigTextStyle whose text is
+            // just the collapsed line again turns the expand chevron into a lie.
+            builder.setStyle(Notification.BigTextStyle().bigText(expandedText(status)))
+        }
+        return builder.build()
+    }
+
+    private fun sep() = getString(R.string.notif_separator)
+
+    /** `851.012500 MHz`, or null when there is no frequency to show. */
+    private fun freqText(hz: Long): String? =
+        if (hz <= 0L) null else getString(R.string.notif_freq_mhz, hz / 1_000_000.0)
+
+    /**
+     * The frequency line, by first-match precedence.
+     *
+     * The tuner centre is never a stand-in for the voice channel: on a trunked system a
+     * retune moves the centre out from under the call.
+     */
+    private fun frequencyPart(status: DecoderStatus, lead: SlotCall?): String? {
+        if (!status.radioInput) {
+            return null
+        }
+        if (lead?.state == DecoderStatus.LINE_ACTIVE && status.trunking && status.trunkTuned) {
+            freqText(status.vcFreqHz)?.let { return it }
+        }
+        if (status.trunking) {
+            freqText(status.ccFreqHz)?.let { return getString(R.string.notif_control_freq, it) }
+        }
+        return freqText(status.centerFreqHz)
+    }
+
+    /**
+     * Parts in priority order, because Android truncates the tail: why there is no audio
+     * first, who is talking second, where third.
+     */
+    private fun bodyText(status: DecoderStatus, lead: SlotCall?): String {
+        val parts = mutableListOf<String>()
+        if (lead != null && lead.enc) {
+            parts += getString(R.string.notif_encrypted)
+            // algid 0 is "encrypted, but no crypto header decoded yet"; the ENC word
+            // alone is the whole of what is known. Same rule the Qt panel applies.
+            if (lead.algid != 0) {
+                parts += getString(R.string.notif_alg, "%02X".format(lead.algid))
+                parts += getString(R.string.notif_kid, "%04X".format(lead.kid))
+            }
+        }
+        // "0" is what the encoder writes for a source that never decoded, not a unit.
+        if (lead != null && lead.srcText.isNotEmpty() && lead.srcText != "0") {
+            parts += getString(R.string.notif_unit, lead.srcText)
+        }
+        frequencyPart(status, lead)?.let { parts += it }
+        return parts.joinToString(sep())
+    }
+
+    /**
+     * One row per slot with content, plus the frequency. Prose, not columns: notification
+     * body text is proportional, so an aligned table would ragged out.
+     */
+    private fun expandedText(status: DecoderStatus): String {
+        val rows = mutableListOf<String>()
+        status.slots.forEachIndexed { index, call ->
+            if (!call.hasContent) {
+                return@forEachIndexed
+            }
+            val parts = mutableListOf(getString(R.string.notif_slot, index + 1), call.name)
+            if (call.srcText.isNotEmpty() && call.srcText != "0") {
+                parts += getString(R.string.notif_unit, call.srcText)
+            }
+            if (call.enc) {
+                parts += getString(R.string.notif_encrypted)
+            }
+            rows += parts.joinToString(sep())
+        }
+        frequencyPart(status, status.leadSlot)?.let { rows += it }
+        return rows.joinToString("\n")
     }
 
     private fun startForegroundNotification(text: String) {
@@ -259,6 +402,71 @@ class DecoderService : Service() {
 
     private fun updateNotification(text: String) {
         getSystemService(NotificationManager::class.java).notify(NOTIFICATION_ID, buildNotification(text))
+    }
+
+    private val statusHandler = Handler(Looper.getMainLooper())
+
+    /**
+     * The record [statusPoll] read last, and the only input [buildNotification] renders.
+     *
+     * On the instance rather than in the companion, unlike [state] and [engineThread]:
+     * this is a rendering cache, not lifecycle state. A service instance that replaces
+     * one destroyed mid-run should render its own first poll rather than inherit a
+     * predecessor's record and skip it as unchanged.
+     */
+    private var lastStatusRecord: String? = null
+
+    /**
+     * Re-reads the published status once a second, re-posting only on a change.
+     *
+     * Re-posts itself from the tail and only while RUNNING, so the loop unwinds on its
+     * own the moment a session ends or a stop lands — there is no timer left pointing at
+     * a service that has been told to go away.
+     */
+    private val statusPoll = object : Runnable {
+        override fun run() {
+            if (synchronized(lock) { state } != State.RUNNING) {
+                return
+            }
+            val record = try {
+                DsdNative.nativeNotificationStatus()
+            } catch (e: UnsatisfiedLinkError) {
+                // A native method with nothing bound behind it never acquires an
+                // implementation later in the same process, so this drops the loop
+                // instead of re-posting: retrying would only log the same failure every
+                // second for the rest of the session. The notification keeps whatever it
+                // last rendered.
+                Log.e(TAG, "status accessor unavailable; stopping status polling", e)
+                return
+            }
+            if (record != lastStatusRecord) {
+                lastStatusRecord = record
+                // Only when the record itself changed, which on a quiet channel is
+                // almost never. A live call does re-render each second — its elapsed_ms
+                // advances — but setOnlyAlertOnce keeps every one of those silent.
+                updateNotification(currentStatusText())
+            }
+            statusHandler.postDelayed(this, STATUS_POLL_MS)
+        }
+    }
+
+    private fun startStatusPolling() {
+        // removeCallbacks first so a restart cannot leave two loops posting each other.
+        statusHandler.removeCallbacks(statusPoll)
+        statusHandler.post(statusPoll)
+    }
+
+    /**
+     * Stops the loop and forgets the cached record, so the notification falls back to the
+     * phase wording rather than freezing on the last call it saw.
+     *
+     * Safe against a tick that is already queued: the poll runs on the main looper, and
+     * every caller of this is on the main thread too, so removeCallbacks() cannot race
+     * one that is halfway through.
+     */
+    private fun stopStatusPolling() {
+        statusHandler.removeCallbacks(statusPoll)
+        lastStatusRecord = null
     }
 
     private fun stopForegroundCompat() {
@@ -320,6 +528,24 @@ class DecoderService : Service() {
          * tidy join is the wrong way round.
          */
         private const val ENGINE_JOIN_TIMEOUT_MS = 1000L
+
+        /**
+         * How often the service re-reads the published status.
+         *
+         * A second is well under the shortest transmission worth showing and well over
+         * the cost of the read, which is one short mutex and a string copy. Faster would
+         * only buy sub-second precision on a chronometer that shows whole seconds.
+         */
+        private const val STATUS_POLL_MS = 1000L
+
+        /**
+         * Request codes for the two pending intents.
+         *
+         * Distinct so FLAG_UPDATE_CURRENT can never have one rewrite the other: the
+         * request code is part of a PendingIntent's identity, the extras are not.
+         */
+        private const val REQUEST_STOP = 0
+        private const val REQUEST_OPEN = 1
 
         const val ACTION_START = "io.github.arancormonk.dsdneo.action.START"
         const val ACTION_STOP = "io.github.arancormonk.dsdneo.action.STOP"

--- a/android/package/src/io/github/arancormonk/dsdneo/DecoderService.kt
+++ b/android/package/src/io/github/arancormonk/dsdneo/DecoderService.kt
@@ -19,6 +19,7 @@ import android.os.IBinder
 import android.os.Looper
 import android.os.PowerManager
 import android.util.Log
+import java.util.Locale
 
 /**
  * Foreground service that owns the decoder.
@@ -65,6 +66,18 @@ class DecoderService : Service() {
                 stopIfIdle()
             }
         }
+
+        // Here rather than in startDecoding(), so it keys off "this instance is fronting a
+        // live engine" instead of "this instance started it". joinEngineThread() leaves a
+        // timed-out engine RUNNING on purpose, and the replacement service's START is then
+        // rejected as a duplicate before it ever reaches startDecoding()'s tail — but its
+        // notification is the only surface the user has, so it still has to track the call.
+        // startStatusPolling() removes any queued tick first, so arriving here twice for
+        // one session cannot leave two loops running.
+        if (synchronized(lock) { state } == State.RUNNING) {
+            startStatusPolling()
+        }
+
         // A dead process stays dead until the user relaunches: restarting the engine
         // without its configuration would be worse than not restarting at all.
         return START_NOT_STICKY
@@ -161,7 +174,7 @@ class DecoderService : Service() {
         }
         updateNotification(getString(R.string.decoder_running))
         thread.start()
-        startStatusPolling()
+        // Polling is armed by onStartCommand() once the state settles; see the note there.
     }
 
     /**
@@ -327,7 +340,22 @@ class DecoderService : Service() {
             builder.setShowWhen(false).setUsesChronometer(false)
         }
 
-        builder.setContentTitle(if (lead != null) lead.name else getString(R.string.decoder_listening))
+        // "0" is the encoder's not-decoded sentinel, the same one srcText is filtered for
+        // in bodyText() -- X2-TDMA and standalone ProVoice never parse a talkgroup at all
+        // and their calls arrive carrying it, and a policy-resolved target with no CSV
+        // alias does too. Empty is the other unrenderable case: the record's charset
+        // filter drops a multi-byte sequence the field ended part-way through, which can
+        // take the whole name with it. Either way there is a transmission, it just has no
+        // name, so the phase wording is the honest headline -- "Listening" would say the
+        // opposite of what is happening.
+        val leadName = lead?.name?.takeIf { it.isNotEmpty() && it != "0" }
+        builder.setContentTitle(
+            when {
+                leadName != null -> leadName
+                lead != null -> text
+                else -> getString(R.string.decoder_listening)
+            }
+        )
         // Back to the phase wording when the status has nothing to say. The record's two
         // halves are published by separate calls, so a poll can catch a status whose call
         // and frequency are both still empty, and a blank second line reads as a bug.
@@ -336,16 +364,30 @@ class DecoderService : Service() {
         if (status.slots.any { it.hasContent }) {
             // Only when there is something to expand into: a BigTextStyle whose text is
             // just the collapsed line again turns the expand chevron into a lie.
-            builder.setStyle(Notification.BigTextStyle().bigText(expandedText(status)))
+            builder.setStyle(Notification.BigTextStyle().bigText(expandedText(status, lead)))
         }
         return builder.build()
     }
 
-    private fun sep() = getString(R.string.notif_separator)
+    /**
+     * Resolved once: it is a constant for the life of the process, and [expandedText]
+     * would otherwise take the Resources lock once per rendered row.
+     */
+    private val separator: String by lazy(LazyThreadSafetyMode.NONE) { getString(R.string.notif_separator) }
 
-    /** `851.012500 MHz`, or null when there is no frequency to show. */
+    /**
+     * `851.012500 MHz`, or null when there is no frequency to show.
+     *
+     * Formatted against Locale.ROOT, not the resource configuration's locale, which is
+     * what `getString(id, args)` would use: Java's `%f` localises both the decimal
+     * separator and the zero digit, so a device set to German would render
+     * `851,012500 MHz` and one set to Arabic with native digits would render the number in
+     * Arabic-Indic numerals beside English words. Every other frequency readout in the
+     * project is C-locale `%.06lf`, and a frequency is a machine value the user reads back
+     * into a config file.
+     */
     private fun freqText(hz: Long): String? =
-        if (hz <= 0L) null else getString(R.string.notif_freq_mhz, hz / 1_000_000.0)
+        if (hz <= 0L) null else String.format(Locale.ROOT, getString(R.string.notif_freq_mhz), hz / 1_000_000.0)
 
     /**
      * The frequency line, by first-match precedence.
@@ -357,7 +399,13 @@ class DecoderService : Service() {
         if (!status.radioInput) {
             return null
         }
-        if (lead?.state == DecoderStatus.LINE_ACTIVE && status.trunking && status.trunkTuned) {
+        // hasContent, not LINE_ACTIVE: the lead slot stays ENDED for the hold that follows
+        // every transmission, and trunkTuned is still set for as much of it as the trunk
+        // state machine takes to hand the tuner back. Testing for ACTIVE alone made the
+        // body fall through to the branch below and label the control channel as where the
+        // receiver was, for three seconds after every call, while it was still parked on
+        // the voice channel.
+        if (lead != null && lead.hasContent && status.trunking && status.trunkTuned) {
             freqText(status.vcFreqHz)?.let { return it }
         }
         if (status.trunking) {
@@ -386,29 +434,44 @@ class DecoderService : Service() {
             parts += getString(R.string.notif_unit, lead.srcText)
         }
         frequencyPart(status, lead)?.let { parts += it }
-        return parts.joinToString(sep())
+        return parts.joinToString(separator)
     }
 
     /**
      * One row per slot with content, plus the frequency. Prose, not columns: notification
      * body text is proportional, so an aligned table would ragged out.
      */
-    private fun expandedText(status: DecoderStatus): String {
+    private fun expandedText(status: DecoderStatus, lead: SlotCall?): String {
+        val occupied = status.slots.count { it.hasContent }
         val rows = mutableListOf<String>()
         status.slots.forEachIndexed { index, call ->
             if (!call.hasContent) {
                 return@forEachIndexed
             }
-            val parts = mutableListOf(getString(R.string.notif_slot, index + 1), call.name)
+            val parts = mutableListOf<String>()
+            // Only when the number tells the reader something. Slot 1 is the only slot
+            // P25 Phase 1, D-STAR, M17, YSF, NXDN, dPMR, EDACS and ProVoice ever fill, and
+            // labelling their single row "Slot 1" invents a TDMA concept those modes do
+            // not have.
+            if (occupied > 1) {
+                parts += getString(R.string.notif_slot, index + 1)
+            }
+            // Same two unrenderable cases the content title guards against; a bare "0" or
+            // an empty name would otherwise leave a row that is nothing but a separator.
+            if (call.name.isNotEmpty() && call.name != "0") {
+                parts += call.name
+            }
             if (call.srcText.isNotEmpty() && call.srcText != "0") {
                 parts += getString(R.string.notif_unit, call.srcText)
             }
             if (call.enc) {
                 parts += getString(R.string.notif_encrypted)
             }
-            rows += parts.joinToString(sep())
+            if (parts.isNotEmpty()) {
+                rows += parts.joinToString(separator)
+            }
         }
-        frequencyPart(status, status.leadSlot)?.let { rows += it }
+        frequencyPart(status, lead)?.let { rows += it }
         return rows.joinToString("\n")
     }
 
@@ -448,6 +511,21 @@ class DecoderService : Service() {
     private val statusPoll = object : Runnable {
         override fun run() {
             if (synchronized(lock) { state } != State.RUNNING) {
+                // Also where a session that ended by itself gets its call line taken down.
+                // Every deliberate teardown calls stopStatusPolling() first, but the engine
+                // thread drops the state to IDLE from its own thread when nativeRun returns
+                // — end of a file, a dropped rtl_tcp connection, a decode error — and
+                // cannot touch the main-thread cache. Left in place, the last polled record
+                // keeps the finished transmission on the notification with its chronometer
+                // still counting up, until Android gets round to destroying the service.
+                if (lastStatusRecord != null) {
+                    lastStatusRecord = null
+                    // Not currentStatusText(): it maps IDLE to "Starting…" for the
+                    // promotion at the top of onStartCommand, where IDLE means a start is
+                    // about to happen. Here it means the run just ended and stopSelf has
+                    // been called, so the service really is on its way down.
+                    updateNotification(getString(R.string.decoder_stopping))
+                }
                 return
             }
             val record = try {
@@ -492,6 +570,10 @@ class DecoderService : Service() {
     }
 
     private fun stopForegroundCompat() {
+        // Before dropping the notification, not after: once it is gone a queued tick that
+        // re-posted would put an ongoing notification back with no foreground service
+        // behind it, and nothing left alive to take it down again.
+        stopStatusPolling()
         stopForeground(STOP_FOREGROUND_REMOVE)
     }
 

--- a/android/package/src/io/github/arancormonk/dsdneo/DecoderStatus.kt
+++ b/android/package/src/io/github/arancormonk/dsdneo/DecoderStatus.kt
@@ -36,17 +36,18 @@ data class DecoderStatus(
     val vcFreqHz: Long,
     val centerFreqHz: Long,
     val slots: List<SlotCall>,
+    val leadSlotIndex: Int,
 ) {
-    /** The slot whose call should headline, or null when nothing is on the air. */
+    /**
+     * The slot whose call should headline, or null when nothing is on the air.
+     *
+     * The choice is made natively by dsd_app_lead_slot() and carried on the wire rather
+     * than recomputed here. Deciding it a second time in Kotlin is how this surface and
+     * the Qt hero panel came to headline different slots from the same record on a TDMA
+     * system with both slots up.
+     */
     val leadSlot: SlotCall?
-        get() = slots.filter { it.hasContent }
-            .minWithOrNull(
-                // Active outranks merely ended. Among equals the smallest elapsed time is
-                // the most recently started, which is the transmission the user just heard
-                // begin -- so a plain ascending compare on elapsedMs is the tie-break.
-                compareByDescending<SlotCall> { it.state == LINE_ACTIVE }
-                    .thenBy { it.elapsedMs },
-            )
+        get() = slots.getOrNull(leadSlotIndex)?.takeIf { it.hasContent }
 
     companion object {
         const val LINE_NONE = 0
@@ -55,7 +56,7 @@ data class DecoderStatus(
         const val LINE_ENDED = 3
 
         private const val VERSION = "v1"
-        private const val HEADER_FIELDS = 8
+        private const val HEADER_FIELDS = 9
         private const val SLOT_FIELDS = 9
         private const val SLOT_COUNT = 2
         private const val TOTAL_FIELDS = HEADER_FIELDS + SLOT_FIELDS * SLOT_COUNT
@@ -88,6 +89,9 @@ data class DecoderStatus(
                     ccFreqHz = f[5].toLong(),
                     vcFreqHz = f[6].toLong(),
                     centerFreqHz = f[7].toLong(),
+                    // -1 when no slot has anything to show; getOrNull() in leadSlot turns
+                    // that (and any out-of-range value) back into "nothing on the air".
+                    leadSlotIndex = f[8].toInt(),
                     slots = (0 until SLOT_COUNT).map { slot ->
                         val b = HEADER_FIELDS + slot * SLOT_FIELDS
                         SlotCall(

--- a/android/package/src/io/github/arancormonk/dsdneo/DecoderStatus.kt
+++ b/android/package/src/io/github/arancormonk/dsdneo/DecoderStatus.kt
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+package io.github.arancormonk.dsdneo
+
+/** One slot's call identity, mirroring `dsd_app_slot_call`. */
+data class SlotCall(
+    val state: Int,
+    val name: String,
+    val tgText: String,
+    val srcText: String,
+    val tgId: ULong,
+    val enc: Boolean,
+    val algid: Int,
+    val kid: Int,
+    val elapsedMs: Long,
+) {
+    val hasContent: Boolean
+        get() = state == DecoderStatus.LINE_ACTIVE || state == DecoderStatus.LINE_ENDED
+}
+
+/**
+ * The decoder's status as the notification needs it.
+ *
+ * Parsed from one record rather than assembled from several calls, so every field
+ * describes the same moment.
+ */
+data class DecoderStatus(
+    val protocol: String,
+    val radioInput: Boolean,
+    val trunking: Boolean,
+    val trunkTuned: Boolean,
+    val ccFreqHz: Long,
+    val vcFreqHz: Long,
+    val centerFreqHz: Long,
+    val slots: List<SlotCall>,
+) {
+    /** The slot whose call should headline, or null when nothing is on the air. */
+    val leadSlot: SlotCall?
+        get() = slots.filter { it.hasContent }
+            .minWithOrNull(
+                // Active outranks merely ended. Among equals the smallest elapsed time is
+                // the most recently started, which is the transmission the user just heard
+                // begin -- so a plain ascending compare on elapsedMs is the tie-break.
+                compareByDescending<SlotCall> { it.state == LINE_ACTIVE }
+                    .thenBy { it.elapsedMs },
+            )
+
+    companion object {
+        const val LINE_NONE = 0
+        const val LINE_IDLE = 1
+        const val LINE_ACTIVE = 2
+        const val LINE_ENDED = 3
+
+        private const val VERSION = "v1"
+        private const val HEADER_FIELDS = 8
+        private const val SLOT_FIELDS = 9
+        private const val SLOT_COUNT = 2
+        private const val TOTAL_FIELDS = HEADER_FIELDS + SLOT_FIELDS * SLOT_COUNT
+
+        /**
+         * @return the parsed status, or null when [record] is absent, a version this build
+         *   does not know, or the wrong shape. A caller that gets null renders the plain
+         *   phase text rather than a half-read status.
+         */
+        @JvmStatic
+        fun parse(record: String?): DecoderStatus? {
+            if (record.isNullOrEmpty()) {
+                return null
+            }
+            // Kotlin's Char-delimited split, unlike Java's regex-based String.split, never
+            // drops trailing empty strings -- the default limit (0, meaning unbounded)
+            // already keeps the empty name/tgText/srcText a quiet slot produces. (A
+            // negative limit is not "unbounded" here; split() throws IllegalArgumentException
+            // for one, so this must stay 0/default rather than the -1 a Java habit suggests.)
+            val f = record.split('\t')
+            if (f.size != TOTAL_FIELDS || f[0] != VERSION) {
+                return null
+            }
+            return try {
+                DecoderStatus(
+                    protocol = f[1],
+                    radioInput = f[2] == "1",
+                    trunking = f[3] == "1",
+                    trunkTuned = f[4] == "1",
+                    ccFreqHz = f[5].toLong(),
+                    vcFreqHz = f[6].toLong(),
+                    centerFreqHz = f[7].toLong(),
+                    slots = (0 until SLOT_COUNT).map { slot ->
+                        val b = HEADER_FIELDS + slot * SLOT_FIELDS
+                        SlotCall(
+                            state = f[b].toInt(),
+                            name = f[b + 1],
+                            tgText = f[b + 2],
+                            srcText = f[b + 3],
+                            // tg_id is uint64_t on the wire (0..2^64-1), a range Long cannot
+                            // fully cover; ULong covers it exactly. A bad or oversized string
+                            // still throws NumberFormatException here (confirmed empirically,
+                            // not assumed toULong() behaves like toLong()), so the catch below
+                            // still applies -- this only changes behavior for the values above
+                            // Long.MAX_VALUE that toLong() could never have represented anyway.
+                            tgId = f[b + 4].toULong(),
+                            enc = f[b + 5] == "1",
+                            algid = f[b + 6].toInt(),
+                            kid = f[b + 7].toInt(),
+                            elapsedMs = f[b + 8].toLong(),
+                        )
+                    },
+                )
+            } catch (e: NumberFormatException) {
+                // A malformed record is a bug on the native side, not something to render.
+                null
+            }
+        }
+    }
+}

--- a/android/package/src/io/github/arancormonk/dsdneo/DsdNative.kt
+++ b/android/package/src/io/github/arancormonk/dsdneo/DsdNative.kt
@@ -65,4 +65,18 @@ object DsdNative {
      * produce a status describing two different moments.
      */
     external fun nativeNotificationStatus(): String?
+
+    /**
+     * Asks the Qt event loop to quit so its `main()` returns.
+     *
+     * Qt's own teardown waits for that to happen but only raises the quit when the
+     * Android event dispatcher is already stopped, which it is not when the task is
+     * swiped out of recents — so without this the wait never ends. Called from
+     * [DsdNeoActivity.onDestroy]; see the JNI side in `android/decoder_host_android.cpp`
+     * for the full account.
+     *
+     * A no-op when no QCoreApplication exists yet, so it is safe on an Activity torn
+     * down before Qt finished starting.
+     */
+    external fun nativeQuitUi()
 }

--- a/android/package/src/io/github/arancormonk/dsdneo/DsdNative.kt
+++ b/android/package/src/io/github/arancormonk/dsdneo/DsdNative.kt
@@ -55,4 +55,14 @@ object DsdNative {
      * it to clear before releasing.
      */
     external fun nativeIsUsbFdInUse(): Boolean
+
+    /**
+     * The decoder's current status as one versioned, tab-separated record, or null when
+     * nothing has been published yet.
+     *
+     * One call rather than a field at a time: the service polls this off the decode
+     * thread, and reading fields separately would let a publish land between them and
+     * produce a status describing two different moments.
+     */
+    external fun nativeNotificationStatus(): String?
 }

--- a/android/package/src/io/github/arancormonk/dsdneo/DsdNeoActivity.kt
+++ b/android/package/src/io/github/arancormonk/dsdneo/DsdNeoActivity.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+package io.github.arancormonk.dsdneo
+
+import android.content.Intent
+import org.qtproject.qt.android.bindings.QtActivity
+
+/**
+ * The app's Activity, which is stock [QtActivity] plus one thing it has to do on the way
+ * out.
+ *
+ * `QtActivityBase.onDestroy()` calls `QtNative.terminateQtNativeApplication()`, which
+ * blocks until Qt's `main()` returns, and only then `System.exit(0)`. Left alone, `main()`
+ * never returns here and that block is permanent. Two things have to line up wrong for
+ * that, and both do:
+ *
+ * 1. Qt's own teardown raises the quit that would end `main()` only when its Android event
+ *    dispatcher is *already stopped*; when the dispatcher is still running — the state a
+ *    swipe out of recents leaves behind — it sends no quit and waits anyway.
+ * 2. Raising the quit by hand is not enough either. Since Qt 6, `QCoreApplication::quit()`
+ *    asks every top-level window to close first and abandons the quit if any refuses, and
+ *    `Main.qml`'s `onClosing` always refuses: declining the close is how a window dismissal
+ *    becomes `moveToBackground()` so a decode session survives the user leaving the app.
+ *
+ * So [DsdNative.nativeQuitUi] uses `exit()`, which leaves the event loop without consulting
+ * windows. See the JNI side in `android/decoder_host_android.cpp`.
+ *
+ * The deadlock is invisible in a plain Qt app: with nothing holding the process up, Android
+ * reaps it as an empty process and the hang goes unnoticed. This app keeps a foreground
+ * service for the decoder, so the process is retained, the block persists, and everything
+ * queued behind the main thread — the service's own callbacks included — times out into
+ * "DSD-neo isn't responding".
+ */
+class DsdNeoActivity : QtActivity() {
+
+    override fun onDestroy() {
+        // Not on a configuration change: those destroy and immediately recreate the
+        // Activity, and Qt keeps the process across them (it skips its own teardown for
+        // exactly this case). Quitting there would take the UI down on a rotation.
+        if (!isChangingConfigurations) {
+            // Signalled directly rather than through DecoderService.stopDecoder(): that
+            // posts an intent, and intents are delivered on this very thread, which is
+            // about to block inside super.onDestroy() and then never come back — the stop
+            // would sit in the queue until System.exit(0) threw it away. nativeStop() only
+            // raises the engine's stop flag, so it is safe to call from here.
+            //
+            // Best effort, not a guarantee: nothing waits for the engine to finish
+            // unwinding, because the only thread that could wait is the one whose blocking
+            // this override exists to prevent. It buys the decode loop a chance to close
+            // its files before the process goes.
+            DsdNative.nativeStop()
+
+            // Withdraws the service's outstanding start request, and it has to happen
+            // before the process goes. The engine thread is what normally calls stopSelf(),
+            // once nativeRun() returns — but Qt's teardown ends in System.exit(0) and will
+            // not wait for that. A process that dies with a start request still standing is
+            // a *crashed* service to ActivityManager, which duly restarts it:
+            //
+            //   Process ... has died: fg +50 FGS
+            //   Scheduling restart of crashed service .DecoderService for start-requested
+            //   Start proc ... for service {.DecoderService}
+            //
+            // — a decoder respawned with no UI and no way to have asked for it, holding a
+            // notification the user just swiped away. stopService() is an ActivityManager
+            // call rather than a queued callback, so it lands even though this thread is
+            // about to block.
+            stopService(Intent(this, DecoderService::class.java))
+
+            DsdNative.nativeQuitUi()
+        }
+        super.onDestroy()
+    }
+}

--- a/include/dsd-neo/app_control/call_view.h
+++ b/include/dsd-neo/app_control/call_view.h
@@ -43,6 +43,20 @@ enum {
  */
 #define DSD_APP_CALL_LINE_ENDED_HOLD_S 3.0
 
+enum {
+    /**
+     * @brief Size of @ref dsd_app_slot_call::name.
+     *
+     * Its own constant rather than DSD_CALL_IDENTITY_TEXT_SIZE, because the two fields
+     * are copied from differently sized sources: @c name comes from a CSV import, held
+     * in @c Event_History::t_name as a @c char[200], while @c tg_text and @c src_text
+     * come from the canonical call state's @c char[DSD_CALL_IDENTITY_TEXT_SIZE] fields.
+     * Sizing @c name like the other two silently cut a long talkgroup alias down to 63
+     * characters on its way to the hero panel.
+     */
+    DSD_APP_CALL_NAME_SIZE = 200,
+};
+
 /**
  * @brief Display-ready identity for one slot.
  *
@@ -52,7 +66,7 @@ enum {
 typedef struct {
     int state; /**< One of the DSD_APP_CALL_LINE_* values. */
     /** CSV-imported group name when one is staged for this talkgroup, else @c tg_text. */
-    char name[DSD_CALL_IDENTITY_TEXT_SIZE];
+    char name[DSD_APP_CALL_NAME_SIZE];
     char tg_text[DSD_CALL_IDENTITY_TEXT_SIZE];
     char src_text[DSD_CALL_IDENTITY_TEXT_SIZE];
     uint64_t tg_id;      /**< OTA target when one decoded, else the policy-resolved id. */

--- a/include/dsd-neo/app_control/call_view.h
+++ b/include/dsd-neo/app_control/call_view.h
@@ -47,6 +47,20 @@ enum {
  */
 #define DSD_APP_CALL_LINE_ENDED_HOLD_S ((double)DSD_RECENT_ACTIVITY_TTL_MS / 1000.0)
 
+/**
+ * @brief Seconds a sync label survives a frame that found none.
+ *
+ * getFrameSync() re-stamps @c state->synctype every engine iteration and answers NONE
+ * whenever the current search window found nothing, which on a control channel is most of
+ * them. Sampled raw, the protocol label blinks on and off between polls.
+ *
+ * Shared for the same reason the ended hold is: the Qt panel and the Android notification
+ * both decay this field, and a second literal is a promise the compiler cannot keep --
+ * retuning one would leave the two surfaces disagreeing about when a session stops
+ * reading as locked.
+ */
+#define DSD_APP_SYNC_HOLD_S            3.0
+
 enum {
     /**
      * @brief Size of @ref dsd_app_slot_call::name.

--- a/include/dsd-neo/app_control/call_view.h
+++ b/include/dsd-neo/app_control/call_view.h
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Frontend-neutral decisions about what a per-slot call line should say.
+ *
+ * The canonical call state keeps an ended epoch on the slot indefinitely -- the
+ * reacquisition window, the terminator heal and the history layer all read it after
+ * the transmission is over, and nothing ages it out. A status surface wants the
+ * opposite: it is about what is on the air now, so it has to decide for itself when a
+ * retained epoch stops being news. This is that decision, shared so the terminal, the
+ * Qt panel and the Android notification cannot drift apart.
+ */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_CALL_VIEW_H_
+#define DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_CALL_VIEW_H_
+
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief What a slot line is reporting. */
+enum {
+    DSD_APP_CALL_LINE_NONE = 0, /**< Nothing has ever been observed on this slot. */
+    DSD_APP_CALL_LINE_IDLE,     /**< Quiet: never active, or ended long enough ago. */
+    DSD_APP_CALL_LINE_ACTIVE,   /**< A call epoch is open. */
+    DSD_APP_CALL_LINE_ENDED,    /**< A call ended within the hold window. */
+};
+
+/**
+ * @brief Seconds an ended epoch stays on the slot line before it reads as idle.
+ *
+ * Long enough to catch the end of a call glanced at a moment late, short enough that a
+ * quiet channel does not keep advertising a transmission that finished minutes ago.
+ * Matches DSD_RECENT_ACTIVITY_TTL_MS so the decay windows in the UI agree.
+ */
+#define DSD_APP_CALL_LINE_ENDED_HOLD_S 3.0
+
+/**
+ * @brief Display-ready identity for one slot.
+ *
+ * Crypto is carried as @c algid / @c kid rather than as formatted text: each frontend
+ * words it differently, and a formatted string here would force one wording on all.
+ */
+typedef struct {
+    int state; /**< One of the DSD_APP_CALL_LINE_* values. */
+    /** CSV-imported group name when one is staged for this talkgroup, else @c tg_text. */
+    char name[DSD_CALL_IDENTITY_TEXT_SIZE];
+    char tg_text[DSD_CALL_IDENTITY_TEXT_SIZE];
+    char src_text[DSD_CALL_IDENTITY_TEXT_SIZE];
+    uint64_t tg_id;      /**< OTA target when one decoded, else the policy-resolved id. */
+    uint32_t elapsed_ms; /**< Since the epoch started; frozen at the end for ENDED. */
+    uint16_t kid;
+    uint8_t algid;
+    uint8_t enc; /**< Non-zero when the call reads as encrypted over the air. */
+} dsd_app_slot_call;
+
+/**
+ * @brief Fold a call-state lookup into what the line should show.
+ *
+ * @param lookup Result of dsd_call_state_get(); <= 0 means no epoch on the slot.
+ * @param call   The snapshot it filled in. Only read when @p lookup is positive.
+ * @param now_m  Monotonic seconds, the clock call_state stamps @c ended_m from.
+ * @param hold_s How long an ended epoch is held; see @ref DSD_APP_CALL_LINE_ENDED_HOLD_S.
+ *
+ * A negative age -- an end stamped a hair ahead of the poll -- counts as fresh rather
+ * than as an expiry, which is what the comparison would say for age zero too.
+ */
+int dsd_app_call_line_state(int lookup, const dsd_call_snapshot* call, double now_m, double hold_s);
+
+/**
+ * @brief Fill @p out with the display-ready identity for @p slot.
+ *
+ * Zeroes @p out first, so a slot with nothing on it yields DSD_APP_CALL_LINE_NONE and
+ * empty text. Safe with a NULL @p state; a NULL @p out is a no-op.
+ */
+void dsd_app_slot_call_view(const dsd_state* state, uint8_t slot, double now_m, dsd_app_slot_call* out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_CALL_VIEW_H_ */

--- a/include/dsd-neo/app_control/call_view.h
+++ b/include/dsd-neo/app_control/call_view.h
@@ -39,9 +39,13 @@ enum {
  *
  * Long enough to catch the end of a call glanced at a moment late, short enough that a
  * quiet channel does not keep advertising a transmission that finished minutes ago.
- * Matches DSD_RECENT_ACTIVITY_TTL_MS so the decay windows in the UI agree.
+ *
+ * Derived from DSD_RECENT_ACTIVITY_TTL_MS rather than restated as its own literal: the
+ * two decay windows have to agree, and a second literal is a promise the compiler cannot
+ * keep -- retuning the recent-activity TTL would silently leave the slot line holding an
+ * ended call past the point the frequency behind it expired.
  */
-#define DSD_APP_CALL_LINE_ENDED_HOLD_S 3.0
+#define DSD_APP_CALL_LINE_ENDED_HOLD_S ((double)DSD_RECENT_ACTIVITY_TTL_MS / 1000.0)
 
 enum {
     /**
@@ -96,6 +100,28 @@ int dsd_app_call_line_state(int lookup, const dsd_call_snapshot* call, double no
  * empty text. Safe with a NULL @p state; a NULL @p out is a no-op.
  */
 void dsd_app_slot_call_view(const dsd_state* state, uint8_t slot, double now_m, dsd_app_slot_call* out);
+
+/**
+ * @brief Which slot's call should headline a surface with room for only one.
+ *
+ * The Qt hero panel and the Android notification each show a single call and each has
+ * to answer this. Stated once per frontend it is a rule that drifts -- and it did: two
+ * surfaces reading the same record named different units on a TDMA system with both
+ * slots up, which is routine on DMR and P25 Phase 2.
+ *
+ * An open epoch outranks a merely-ended one. Between two of equal rank the lower slot
+ * wins: a fixed order, so the headline does not swap between two simultaneous
+ * transmissions as their relative timings shift.
+ *
+ * Takes the line states rather than the whole views because that is all the rule reads,
+ * and the Qt model keeps its slots in a QML-facing struct of its own.
+ *
+ * @param line_states Array of @p count DSD_APP_CALL_LINE_* values, indexed by slot.
+ * @param count       Number of entries in @p line_states.
+ * @return Index of the headline slot, or -1 when no slot has anything to show and when
+ *         @p line_states is NULL.
+ */
+int dsd_app_lead_slot(const int* line_states, unsigned count);
 
 /**
  * @brief The voice-channel frequency in Hz, or 0 when none resolves.

--- a/include/dsd-neo/app_control/call_view.h
+++ b/include/dsd-neo/app_control/call_view.h
@@ -83,6 +83,26 @@ int dsd_app_call_line_state(int lookup, const dsd_call_snapshot* call, double no
  */
 void dsd_app_slot_call_view(const dsd_state* state, uint8_t slot, double now_m, dsd_app_slot_call* out);
 
+/**
+ * @brief The voice-channel frequency in Hz, or 0 when none resolves.
+ *
+ * Four sources in precedence order: an active P25 call epoch carrying its own frequency,
+ * then @c trunk_vc_freq[0], then @c p25_vc_freq[0], then the newest live recent-activity
+ * entry -- either its own frequency or a "Ch:" token resolved through @c trunk_chan_map.
+ *
+ * The tuner centre is deliberately not in this chain. On a trunked system a retune moves
+ * the centre out from under the call, so it is not a proxy for the voice channel.
+ */
+long int dsd_app_vc_freq(const dsd_state* state);
+
+/**
+ * @brief The control-channel frequency in Hz, or 0 when none is known.
+ *
+ * A different value from @ref dsd_app_vc_freq: on a tuned trunked system the decoder is
+ * sitting on the voice channel while the control channel is where it will return.
+ */
+long int dsd_app_cc_freq(const dsd_state* state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dsd-neo/app_control/notification_status.h
+++ b/include/dsd-neo/app_control/notification_status.h
@@ -70,8 +70,16 @@ int dsd_app_notification_get(dsd_app_notification_status* out);
 double dsd_app_notification_test_now_m(void);
 
 enum {
-    /** Comfortably larger than any record the encoder produces. */
-    DSD_APP_NOTIFICATION_RECORD_SIZE = 1024,
+    /**
+     * @brief Comfortably larger than any record the encoder produces.
+     *
+     * The worst case is roughly 875 bytes: the fixed header, plus two slots each
+     * carrying a full-length @c name (@ref DSD_APP_CALL_NAME_SIZE), @c tg_text and
+     * @c src_text alongside their numeric fields. Rounded well past that, because a
+     * record that outgrows this buffer is not truncated -- it is dropped, and the
+     * notification would silently stop updating.
+     */
+    DSD_APP_NOTIFICATION_RECORD_SIZE = 2048,
 };
 
 /**

--- a/include/dsd-neo/app_control/notification_status.h
+++ b/include/dsd-neo/app_control/notification_status.h
@@ -66,6 +66,18 @@ void dsd_app_notification_publish_opts(const dsd_opts* opts);
  */
 int dsd_app_notification_get(dsd_app_notification_status* out);
 
+/**
+ * @brief Forget everything published, so the next get() reports nothing again.
+ *
+ * The published record is a module static and outlives the session that filled it. The
+ * Android service starts its status poll before the engine reaches
+ * dsd_app_frontend_runtime_start(), so without this a second session's first poll would
+ * render the previous session's last call for as long as a poll interval.
+ *
+ * Called from dsd_app_frontend_runtime_stop(). Safe from any thread.
+ */
+void dsd_app_notification_reset(void);
+
 /** @brief The monotonic clock the publisher stamps call ages from; for tests. */
 double dsd_app_notification_test_now_m(void);
 

--- a/include/dsd-neo/app_control/notification_status.h
+++ b/include/dsd-neo/app_control/notification_status.h
@@ -48,19 +48,40 @@ typedef struct {
     uint8_t trunking;       /**< opts->trunk_enable. */
     uint8_t trunk_tuned;    /**< opts->trunk_is_tuned. */
     dsd_app_slot_call slots[DSD_CALL_STATE_SLOT_COUNT];
+    /**
+     * @brief Index into @c slots of the call that should headline, or -1 for none.
+     *
+     * Carried rather than left to the reader: the notification has room for one call and
+     * so does the Qt hero panel, and a reader deciding for itself is how the two came to
+     * name different units at the same instant. See dsd_app_lead_slot().
+     */
+    int8_t lead_slot;
 } dsd_app_notification_status;
 
-/** @brief Publish the state-derived half. Called on the decode thread. */
+/**
+ * @brief Publish the state-derived half. Called on the decode thread.
+ *
+ * A no-op until something has called dsd_app_notification_get() at least once. Deriving
+ * the record is not free -- the voice-channel chain copies the recent-activity snapshot
+ * under the canonical call-state lock -- and these publishers hang off the telemetry
+ * hook, which fires at protocol frame rate on the decode thread of every frontend. Only
+ * the Android service reads the record, so a run with no reader pays one atomic load.
+ */
 void dsd_app_notification_publish_state(const dsd_state* state);
 
-/** @brief Publish the options-derived half. Called on the decode thread. */
+/** @brief Publish the options-derived half. Called on the decode thread. Same gate. */
 void dsd_app_notification_publish_opts(const dsd_opts* opts);
 
 /**
  * @brief Copy the latest status out.
  *
  * Safe from any thread, and from any number of them concurrently -- unlike the snapshot
- * accessors. Zeroes @p out when nothing has been published yet.
+ * accessors. Zeroes @p out when nothing has been published yet, except for @c lead_slot,
+ * which is left at its -1 "no slot" sentinel rather than at a zero that names slot 0.
+ *
+ * Also arms the publishers, which stay dormant until a reader has asked once. The first
+ * call therefore reports nothing on a session that is already decoding; the next one, a
+ * poll interval later, has a record.
  *
  * @return 1 when @p out holds a published status, 0 otherwise.
  */
@@ -77,9 +98,6 @@ int dsd_app_notification_get(dsd_app_notification_status* out);
  * Called from dsd_app_frontend_runtime_stop(). Safe from any thread.
  */
 void dsd_app_notification_reset(void);
-
-/** @brief The monotonic clock the publisher stamps call ages from; for tests. */
-double dsd_app_notification_test_now_m(void);
 
 enum {
     /**

--- a/include/dsd-neo/app_control/notification_status.h
+++ b/include/dsd-neo/app_control/notification_status.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Compact decoder status for surfaces outside the single-consumer snapshot.
+ *
+ * The snapshot accessors in @ref snapshot.h are single-consumer: exactly one thread may
+ * call them, and on Android that thread is Qt's. The foreground service needs the same
+ * facts with no Qt in the picture -- Android can destroy the Activity while the engine
+ * keeps decoding, which is precisely when the notification is the only visible surface.
+ *
+ * So this is a second, far smaller publication: a fixed-size POD copied out under a short
+ * mutex, safe to read from any thread and any number of them. It is fed by the telemetry
+ * hooks, which run on the decode thread for the whole session (see
+ * dsd_app_frontend_runtime_start()), so it keeps updating with no frontend attached.
+ */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_NOTIFICATION_STATUS_H_
+#define DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_NOTIFICATION_STATUS_H_
+
+#include <dsd-neo/app_control/call_view.h>
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    /** Longest label dsd_synctype_to_string() returns, plus room and a NUL. */
+    DSD_APP_NOTIFICATION_PROTOCOL_SIZE = 24,
+};
+
+typedef struct {
+    uint64_t revision; /**< Advances on every publish; 0 before the first. */
+    /** dsd_synctype_to_string() for the current sync, or "" when NONE/UNKNOWN. */
+    char protocol[DSD_APP_NOTIFICATION_PROTOCOL_SIZE];
+    int64_t vc_freq_hz;     /**< Voice channel; 0 when none resolves. */
+    int64_t cc_freq_hz;     /**< Control channel; 0 when none is known. */
+    int64_t center_freq_hz; /**< Tuner centre; 0 unless the input is a radio. */
+    uint8_t radio_input;    /**< Non-zero for RTL-family input only. */
+    uint8_t trunking;       /**< opts->trunk_enable. */
+    uint8_t trunk_tuned;    /**< opts->trunk_is_tuned. */
+    dsd_app_slot_call slots[DSD_CALL_STATE_SLOT_COUNT];
+} dsd_app_notification_status;
+
+/** @brief Publish the state-derived half. Called on the decode thread. */
+void dsd_app_notification_publish_state(const dsd_state* state);
+
+/** @brief Publish the options-derived half. Called on the decode thread. */
+void dsd_app_notification_publish_opts(const dsd_opts* opts);
+
+/**
+ * @brief Copy the latest status out.
+ *
+ * Safe from any thread, and from any number of them concurrently -- unlike the snapshot
+ * accessors. Zeroes @p out when nothing has been published yet.
+ *
+ * @return 1 when @p out holds a published status, 0 otherwise.
+ */
+int dsd_app_notification_get(dsd_app_notification_status* out);
+
+/** @brief The monotonic clock the publisher stamps call ages from; for tests. */
+double dsd_app_notification_test_now_m(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_NOTIFICATION_STATUS_H_ */

--- a/include/dsd-neo/app_control/notification_status.h
+++ b/include/dsd-neo/app_control/notification_status.h
@@ -25,6 +25,7 @@
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -67,6 +68,24 @@ int dsd_app_notification_get(dsd_app_notification_status* out);
 
 /** @brief The monotonic clock the publisher stamps call ages from; for tests. */
 double dsd_app_notification_test_now_m(void);
+
+enum {
+    /** Comfortably larger than any record the encoder produces. */
+    DSD_APP_NOTIFICATION_RECORD_SIZE = 1024,
+};
+
+/**
+ * @brief Encode the latest status as one versioned, tab-separated record.
+ *
+ * One record per call so a reader cannot tear its view across fields. Text fields have
+ * control characters replaced with spaces: they arrive from CSV imports and off the air,
+ * and an embedded tab would invent a field and desynchronise everything after it.
+ *
+ * @return Characters written excluding the NUL, or 0 when nothing is published, @p out is
+ *         NULL, or @p out_size cannot hold the whole record. Never truncates -- a partial
+ *         record is one a reader would happily parse as a shorter one.
+ */
+size_t dsd_app_notification_encode(char* out, size_t out_size);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -620,6 +620,28 @@ dsd_opts_input_upsample_factor(const dsd_opts* opts) {
 }
 
 /**
+ * @brief Return 1 when a tuner sits behind this session, 0 otherwise.
+ *
+ * The question every surface that renders a tuner reading has to ask first. On a WAV,
+ * stdin, UDP, TCP or symbol-file session the centre frequency, gain, squelch and PPM are
+ * options the front end never applied, and rendering them puts plausible readings on
+ * screen for a run that has no radio; the RTL stream state is process-global and outlives
+ * its session, so the readings themselves cannot be trusted to say so. The input type is
+ * re-parsed per session and can, which is why it is the authority.
+ *
+ * One predicate rather than an open-coded comparison per call site: the moment a second
+ * RTL-family input type appears, whichever site is updated first would otherwise start
+ * disagreeing with the others about whether the same session has a tuner.
+ *
+ * @param opts Decoder options containing the configured input source.
+ * @return 1 for RTL-family input, 0 for everything else and for NULL.
+ */
+static inline int
+dsd_opts_input_is_radio(const dsd_opts* opts) {
+    return (opts != NULL && opts->audio_in_type == AUDIO_IN_RTL) ? 1 : 0;
+}
+
+/**
  * @brief Return the effective PCM rate seen by non-RTL PCM decode paths.
  *
  * @param opts Decoder options containing the configured PCM input sample rate.

--- a/src/app_control/CMakeLists.txt
+++ b/src/app_control/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(
         actions/actions_trunk.c
         actions/actions_logging.c
         app_command_queue.c
+        call_view.c
         frontend.c
         frontend_snr.c
         ui_snapshot.c

--- a/src/app_control/CMakeLists.txt
+++ b/src/app_control/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(
         call_view.c
         frontend.c
         frontend_snr.c
+        notification_status.c
         ui_snapshot.c
         ui_opts_snapshot.c
         ui_history.c

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -5,6 +5,7 @@
 
 /* Frontend → decoder app-command queue (bounded). */
 
+#include <dsd-neo/app_control/call_view.h>
 #include <dsd-neo/app_control/commands.h>
 #include <dsd-neo/app_control/history.h>
 #include <dsd-neo/core/audio.h>
@@ -1627,9 +1628,11 @@ apply_cmd_dsp(const struct dsd_app_command* c) {
 }
 #endif
 
+/* Through the shared chain rather than a fourth copy of the same ternary: the retune and
+   tune commands here have to name the control channel the status surfaces name. */
 static long
 current_cc_freq(const dsd_state* state) {
-    return (state->trunk_cc_freq != 0) ? state->trunk_cc_freq : state->p25_cc_freq;
+    return dsd_app_cc_freq(state);
 }
 
 /** @brief What to call a decode preset in a message the operator reads. */

--- a/src/app_control/call_view.c
+++ b/src/app_control/call_view.c
@@ -5,11 +5,14 @@
 
 #include <dsd-neo/app_control/call_view.h>
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 
 /**
  * @brief Whether the call reads as encrypted over the air, including DECRYPTABLE.
@@ -148,4 +151,123 @@ dsd_app_slot_call_view(const dsd_state* state, uint8_t slot, double now_m, dsd_a
     const double ref_m = (line == DSD_APP_CALL_LINE_ENDED) ? call.ended_m : now_m;
     const double elapsed = ref_m - call.started_m;
     out->elapsed_ms = (elapsed > 0.0) ? (uint32_t)(elapsed * 1000.0) : 0U;
+}
+
+static int
+app_is_p25_synctype(int synctype) {
+    return DSD_SYNC_IS_P25P1(synctype) || DSD_SYNC_IS_P25P2(synctype);
+}
+
+static long int
+app_canonical_active_p25_freq(const dsd_call_state_snapshot* calls) {
+    for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
+        const dsd_call_snapshot* call = &calls->slots[slot];
+        if (call->phase == DSD_CALL_PHASE_ACTIVE && app_is_p25_synctype(call->protocol) && call->frequency_hz > 0) {
+            return (long int)call->frequency_hz;
+        }
+    }
+    return 0;
+}
+
+static int
+app_extract_channel_token(const char* channel_str, char* tok, size_t tok_len) {
+    const char* p = strstr(channel_str, "Ch:");
+    if (!p || tok_len == 0) {
+        return 0;
+    }
+    p += 3;
+    while (*p == ' ') {
+        p++;
+    }
+    size_t t = 0;
+    while (*p && t + 1 < tok_len) {
+        char c = *p;
+        int is_hex = (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+        if (!is_hex) {
+            break;
+        }
+        tok[t++] = c;
+        p++;
+    }
+    tok[t] = '\0';
+    return t > 0;
+}
+
+static long int
+app_lookup_trunk_chan_map(const dsd_state* state, const char* tok) {
+    char* endp = NULL;
+    long ch_hex = strtol(tok, &endp, 16);
+    if (endp && *endp == '\0' && ch_hex > 0 && ch_hex < 65535) {
+        long int freq = state->trunk_chan_map[ch_hex];
+        if (freq != 0) {
+            return freq;
+        }
+    }
+    long ch_dec = strtol(tok, &endp, 10);
+    if (endp && *endp == '\0' && ch_dec > 0 && ch_dec < 65535) {
+        return state->trunk_chan_map[ch_dec];
+    }
+    return 0;
+}
+
+static long int
+app_recent_activity_vc_freq(const dsd_state* state) {
+    dsd_recent_activity_snapshot recent;
+    if (dsd_recent_activity_copy_snapshot(state, &recent) <= 0) {
+        return 0;
+    }
+    const uint64_t now_ms = (uint64_t)(dsd_time_now_monotonic_s() * 1000.0);
+    for (int i = 0; i < DSD_RECENT_ACTIVITY_COUNT; i++) {
+        const dsd_recent_activity_entry* entry = &recent.entries[i];
+        if (entry->updated_m_ms != 0U && now_ms >= entry->updated_m_ms
+            && now_ms - entry->updated_m_ms > DSD_RECENT_ACTIVITY_TTL_MS) {
+            continue;
+        }
+        if (entry->observation.frequency_hz > 0) {
+            return (long int)entry->observation.frequency_hz;
+        }
+        const char* activity = entry->notice;
+        if (!activity || activity[0] == '\0') {
+            continue;
+        }
+        char channel[8] = {0};
+        if (!app_extract_channel_token(activity, channel, sizeof(channel))) {
+            continue;
+        }
+        const long int frequency = app_lookup_trunk_chan_map(state, channel);
+        if (frequency != 0) {
+            return frequency;
+        }
+    }
+    return 0;
+}
+
+long int
+dsd_app_vc_freq(const dsd_state* state) {
+    if (!state) {
+        return 0;
+    }
+    dsd_call_state_snapshot calls;
+    const int has_canonical = dsd_call_state_copy_snapshot(state, &calls) > 0;
+    if (has_canonical) {
+        const long int canonical_frequency = app_canonical_active_p25_freq(&calls);
+        if (canonical_frequency != 0) {
+            return canonical_frequency;
+        }
+    }
+    if (state->trunk_vc_freq[0] != 0) {
+        return state->trunk_vc_freq[0];
+    }
+    if (state->p25_vc_freq[0] != 0) {
+        return state->p25_vc_freq[0];
+    }
+    return app_recent_activity_vc_freq(state);
+}
+
+long int
+dsd_app_cc_freq(const dsd_state* state) {
+    if (!state) {
+        return 0;
+    }
+    return (state->trunk_cc_freq != 0) ? state->trunk_cc_freq : state->p25_cc_freq;
 }

--- a/src/app_control/call_view.c
+++ b/src/app_control/call_view.c
@@ -10,8 +10,17 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* The one field whose width is copied rather than shared: dsd_app_slot_call::name is
+   sized to hold a CSV-imported group name whole, and the source is a bare char[200] with
+   no constant of its own. Widening t_name without widening this would silently
+   re-introduce the truncation DSD_APP_CALL_NAME_SIZE exists to prevent, in the Qt hero
+   panel and the Android notification alike, with nothing failing. */
+_Static_assert(sizeof(((Event_History*)0)->t_name) == DSD_APP_CALL_NAME_SIZE,
+               "dsd_app_slot_call::name must match Event_History::t_name");
 
 /**
  * @brief Whether the call reads as encrypted over the air, including DECRYPTABLE.
@@ -149,19 +158,39 @@ dsd_app_slot_call_view(const dsd_state* state, uint8_t slot, double now_m, dsd_a
 
     const double ref_m = (line == DSD_APP_CALL_LINE_ENDED) ? call.ended_m : now_m;
     const double elapsed = ref_m - call.started_m;
-    out->elapsed_ms = (elapsed > 0.0) ? (uint32_t)(elapsed * 1000.0) : 0U;
+    const double elapsed_ms = (elapsed > 0.0) ? (elapsed * 1000.0) : 0.0;
+    /* Saturating rather than a bare cast: converting a double whose value does not fit
+       the destination is undefined behavior, not a wrap (C11 6.3.1.4), and UBSan's
+       float-cast-overflow traps it. An ACTIVE epoch is held open by sync alone -- nothing
+       ages one out -- so 49.7 days is reachable in principle on a long-lived session. */
+    out->elapsed_ms = (elapsed_ms >= (double)UINT32_MAX) ? UINT32_MAX : (uint32_t)elapsed_ms;
 }
 
-static int
-app_is_p25_synctype(int synctype) {
-    return DSD_SYNC_IS_P25P1(synctype) || DSD_SYNC_IS_P25P2(synctype);
+int
+dsd_app_lead_slot(const int* line_states, unsigned count) {
+    if (line_states == NULL) {
+        return -1;
+    }
+    /* Two passes rather than one ranked comparison: the first slot found ACTIVE wins
+       outright, so an ended call on a lower slot never outranks a live one above it. */
+    for (unsigned slot = 0; slot < count; slot++) {
+        if (line_states[slot] == DSD_APP_CALL_LINE_ACTIVE) {
+            return (int)slot;
+        }
+    }
+    for (unsigned slot = 0; slot < count; slot++) {
+        if (line_states[slot] == DSD_APP_CALL_LINE_ENDED) {
+            return (int)slot;
+        }
+    }
+    return -1;
 }
 
 static long int
 app_canonical_active_p25_freq(const dsd_call_state_snapshot* calls) {
     for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
         const dsd_call_snapshot* call = &calls->slots[slot];
-        if (call->phase == DSD_CALL_PHASE_ACTIVE && app_is_p25_synctype(call->protocol) && call->frequency_hz > 0) {
+        if (call->phase == DSD_CALL_PHASE_ACTIVE && DSD_SYNC_IS_P25(call->protocol) && call->frequency_hz > 0) {
             return (long int)call->frequency_hz;
         }
     }

--- a/src/app_control/call_view.c
+++ b/src/app_control/call_view.c
@@ -6,11 +6,10 @@
 #include <dsd-neo/app_control/call_view.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dsd_time.h>
-#include <dsd-neo/core/events.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/core/synctype_ids.h>
-#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/app_control/call_view.c
+++ b/src/app_control/call_view.c
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/app_control/call_view.h>
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <stddef.h>
+
+/**
+ * @brief Whether the call reads as encrypted over the air, including DECRYPTABLE.
+ *
+ * Same definition the event ring stamps on history rows, so the live view and the call
+ * log agree on which transmissions were encrypted. Disagreeing would let a decrypted
+ * call play clear in one surface and hide under the log's ENC filter in another.
+ */
+static int
+call_reads_encrypted(const dsd_call_snapshot* call) {
+    return call->crypto == DSD_CALL_CRYPTO_ENCRYPTED || call->crypto == DSD_CALL_CRYPTO_ENCRYPTED_PENDING
+           || call->crypto == DSD_CALL_CRYPTO_DECRYPTABLE;
+}
+
+/**
+ * @brief Whether the epoch carries nothing that could name a transmission.
+ *
+ * The decoder opens one on a frame that synced far enough to be a frame and no further,
+ * which happens routinely on a control channel and on noise while hunting. Rendered, it
+ * becomes a call from talkgroup 0 by nobody -- and if a stale crypto header is still on
+ * the slot, an encrypted one.
+ *
+ * The field list mirrors dsd_call_state_snapshot_has_identity() (call_state.c),
+ * route_text included: D-STAR, NXDN and YSF enrich the repeater pair, and a call whose
+ * route decoded before its callsigns is a named transmission the canonical layer already
+ * counts as one. That helper lives behind call_state_internal.h and cannot be called from
+ * here, which is why this mirror exists -- but a mirror that drops a field reports idle
+ * for calls the rest of the app is showing.
+ *
+ * X2-TDMA and standalone ProVoice are the deliberate exception, matching
+ * dsd_call_state_protocol_voice_is_anonymous(): those modes never parse voice into a
+ * talkgroup or a source at all, so an identity-less voice epoch is the whole story the
+ * protocol has. Suppressed, their transmissions would play audio and log history rows
+ * while every status surface said nothing was happening.
+ */
+static int
+call_has_no_identity(const dsd_call_snapshot* call) {
+    if (DSD_SYNC_IS_X2TDMA(call->protocol) || DSD_SYNC_IS_PROVOICE(call->protocol)) {
+        return 0;
+    }
+    return call->ota_target_id == 0U && call->policy_target_id == 0U && call->target_text[0] == '\0'
+           && call->ota_source_id == 0U && call->source_text[0] == '\0' && call->route_text[0][0] == '\0'
+           && call->route_text[1][0] == '\0';
+}
+
+/**
+ * @brief Copy the CSV-imported group name staged on the slot's active history row.
+ *
+ * The staged row's target_id is stamped OTA-then-policy by the event layer, so it must be
+ * compared against the same preference (the caller's resolved @p tg_id), not the OTA id
+ * alone -- a policy-resolved talkgroup would never match otherwise. Nonzero required: a
+ * text-only target's 0 would "match" a stale staged row.
+ *
+ * @return Non-zero when a name was written.
+ */
+static int
+staged_group_name(const dsd_state* state, uint8_t slot, uint64_t tg_id, char* out, size_t out_size) {
+    if (state->event_history_s == NULL || tg_id == 0U) {
+        return 0;
+    }
+    const Event_History* staged = &state->event_history_s[slot].Event_History_Items[0];
+    if (staged->t_name[0] == '\0' || staged->target_id != (uint32_t)tg_id) {
+        return 0;
+    }
+    DSD_SNPRINTF(out, out_size, "%s", staged->t_name);
+    return 1;
+}
+
+int
+dsd_app_call_line_state(int lookup, const dsd_call_snapshot* call, double now_m, double hold_s) {
+    if (lookup <= 0 || call == NULL) {
+        return DSD_APP_CALL_LINE_NONE;
+    }
+    if (call->phase == DSD_CALL_PHASE_ACTIVE) {
+        return DSD_APP_CALL_LINE_ACTIVE;
+    }
+    if (call->phase != DSD_CALL_PHASE_ENDED) {
+        return DSD_APP_CALL_LINE_IDLE;
+    }
+    return ((now_m - call->ended_m) < hold_s) ? DSD_APP_CALL_LINE_ENDED : DSD_APP_CALL_LINE_IDLE;
+}
+
+void
+dsd_app_slot_call_view(const dsd_state* state, uint8_t slot, double now_m, dsd_app_slot_call* out) {
+    if (out == NULL) {
+        return;
+    }
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->state = DSD_APP_CALL_LINE_NONE;
+    if (state == NULL) {
+        return;
+    }
+
+    dsd_call_snapshot call;
+    DSD_MEMSET(&call, 0, sizeof(call));
+    const int line =
+        dsd_app_call_line_state(dsd_call_state_get(state, slot, &call), &call, now_m, DSD_APP_CALL_LINE_ENDED_HOLD_S);
+    out->state = line;
+    if (line != DSD_APP_CALL_LINE_ACTIVE && line != DSD_APP_CALL_LINE_ENDED) {
+        return;
+    }
+
+    /* An epoch with nothing in it is not a transmission anyone can be shown. */
+    if (call_has_no_identity(&call)) {
+        out->state = DSD_APP_CALL_LINE_IDLE;
+        return;
+    }
+
+    if (call.target_text[0] != '\0') {
+        DSD_SNPRINTF(out->tg_text, sizeof(out->tg_text), "%s", call.target_text);
+    } else {
+        DSD_SNPRINTF(out->tg_text, sizeof(out->tg_text), "%llu", (unsigned long long)call.ota_target_id);
+    }
+    /* Same preference order the event layer uses: the OTA id when one decoded, the
+       policy-resolved id otherwise. Text-only targets stay 0. */
+    out->tg_id = (call.ota_target_id != 0U) ? call.ota_target_id : call.policy_target_id;
+
+    if (call.source_text[0] != '\0') {
+        DSD_SNPRINTF(out->src_text, sizeof(out->src_text), "%s", call.source_text);
+    } else {
+        DSD_SNPRINTF(out->src_text, sizeof(out->src_text), "%llu", (unsigned long long)call.ota_source_id);
+    }
+
+    /* The staged row outlives a call by design and must not caption the next one, which
+       is what the target_id comparison inside staged_group_name() guards. */
+    if (!staged_group_name(state, slot, out->tg_id, out->name, sizeof(out->name))) {
+        DSD_SNPRINTF(out->name, sizeof(out->name), "%s", out->tg_text);
+    }
+
+    out->enc = call_reads_encrypted(&call) ? 1U : 0U;
+    if (out->enc) {
+        out->algid = call.algid;
+        out->kid = call.kid;
+    }
+
+    const double ref_m = (line == DSD_APP_CALL_LINE_ENDED) ? call.ended_m : now_m;
+    const double elapsed = ref_m - call.started_m;
+    out->elapsed_ms = (elapsed > 0.0) ? (uint32_t)(elapsed * 1000.0) : 0U;
+}

--- a/src/app_control/frontend.c
+++ b/src/app_control/frontend.c
@@ -49,10 +49,13 @@ frontend_snr_value_is_valid(double snr_db) {
  * with no demodulator behind it had measured them. The input type is what says
  * whether any of it applies; it is re-parsed per session, so it cannot go stale
  * the way the stream globals do.
+ *
+ * Shared with the notification publisher through <dsd-neo/core/opts.h> so the two
+ * cannot come to disagree about whether a session has a tuner behind it.
  */
 static int
 frontend_input_is_radio(const dsd_opts* opts) {
-    return opts != NULL && opts->audio_in_type == AUDIO_IN_RTL;
+    return dsd_opts_input_is_radio(opts);
 }
 
 static void

--- a/src/app_control/notification_status.c
+++ b/src/app_control/notification_status.c
@@ -132,6 +132,15 @@ dsd_app_notification_get(dsd_app_notification_status* out) {
     return have;
 }
 
+void
+dsd_app_notification_reset(void) {
+    ensure_mu_init();
+    dsd_mutex_lock(&g_mu);
+    DSD_MEMSET(&g_status, 0, sizeof(g_status));
+    g_have = 0;
+    dsd_mutex_unlock(&g_mu);
+}
+
 /**
  * @brief Split a UTF-8 lead byte into its continuation count and leading bits.
  *

--- a/src/app_control/notification_status.c
+++ b/src/app_control/notification_status.c
@@ -133,19 +133,153 @@ dsd_app_notification_get(dsd_app_notification_status* out) {
 }
 
 /**
- * @brief Copy @p in into @p out with control characters folded to spaces.
+ * @brief Split a UTF-8 lead byte into its continuation count and leading bits.
+ *
+ * @param cp Receives the code-point bits the lead byte carries. Untouched on failure.
+ * @return How many continuation bytes must follow (0 for ASCII), or -1 when @p lead
+ *         cannot begin a sequence at all: 0x80..0xBF is a continuation byte with
+ *         nothing leading it, and 0xF8..0xFF leads a length UTF-8 has not had since it
+ *         was capped at four bytes.
+ */
+static int
+utf8_lead_bits(unsigned char lead, uint32_t* cp) {
+    if (lead < 0x80U) {
+        *cp = lead;
+        return 0;
+    }
+    if ((lead & 0xE0U) == 0xC0U) {
+        *cp = (uint32_t)(lead & 0x1FU);
+        return 1;
+    }
+    if ((lead & 0xF0U) == 0xE0U) {
+        *cp = (uint32_t)(lead & 0x0FU);
+        return 2;
+    }
+    if ((lead & 0xF8U) == 0xF0U) {
+        *cp = (uint32_t)(lead & 0x07U);
+        return 3;
+    }
+    return -1;
+}
+
+/** @brief Lowest code point encodable with @p trailing continuation bytes. */
+static uint32_t
+utf8_min_code_point(int trailing) {
+    if (trailing == 1) {
+        return 0x80U;
+    }
+    if (trailing == 2) {
+        return 0x800U;
+    }
+    return 0x10000U;
+}
+
+/**
+ * @brief Whether @p cp is a code point UTF-8 may encode with @p trailing bytes.
+ *
+ * Rejects surrogates and anything past U+10FFFF, plus overlong forms -- a code point
+ * that fits in fewer bytes must use them.
+ */
+static int
+utf8_code_point_is_valid(uint32_t cp, int trailing) {
+    if (cp > 0x10FFFFU) {
+        return 0;
+    }
+    if (cp >= 0xD800U && cp <= 0xDFFFU) {
+        return 0;
+    }
+    return cp >= utf8_min_code_point(trailing);
+}
+
+/**
+ * @brief Classify the UTF-8 sequence starting at @p in.
+ *
+ * Stricter than the modified-UTF-8 decoder on the other side of JNI: overlong forms,
+ * surrogate code points and anything past U+10FFFF are rejected here even though ART's
+ * CheckJNI would let them by. An overlong is the classic way to smuggle a tab or a NUL
+ * past a byte-wise filter, and rejecting more than the consumer does can only ever
+ * produce input it still accepts.
+ *
+ * @return The sequence length in bytes (1..4) when @p in starts a complete, well-formed,
+ *         minimally-encoded sequence; 0 when the byte at @p in cannot be part of one;
+ *         -1 when a well-formed sequence starts but the string ends inside it.
+ */
+static int
+utf8_sequence_len(const unsigned char* in) {
+    uint32_t cp = 0U;
+    const int trailing = utf8_lead_bits(in[0], &cp);
+    if (trailing < 0) {
+        return 0;
+    }
+    if (trailing == 0) {
+        return 1;
+    }
+
+    for (int k = 1; k <= trailing; k++) {
+        const unsigned char c = in[k];
+        if (c == '\0') {
+            return -1; /* The field ends inside the sequence. */
+        }
+        if ((c & 0xC0U) != 0x80U) {
+            return 0;
+        }
+        cp = (cp << 6) | (uint32_t)(c & 0x3FU);
+    }
+
+    return utf8_code_point_is_valid(cp, trailing) ? trailing + 1 : 0;
+}
+
+/**
+ * @brief Copy @p in into @p out, folded to control-free, well-formed UTF-8.
  *
  * Tabs separate fields and a newline would end the record, so neither may survive from
- * text the app did not author.
+ * text the app did not author; C0 controls and DEL become spaces.
+ *
+ * The charset half matters just as much, and for a different consumer: this record is
+ * handed to JNI's NewStringUTF(), which requires modified UTF-8 and aborts the process
+ * under CheckJNI when it does not get it. Nothing upstream filters for charset --
+ * D-STAR and YSF callsigns are raw decoded octets off the air, and CSV names are
+ * imported unvalidated -- so every byte that is not part of a well-formed sequence
+ * becomes a '?' here. A sequence the field ends part-way through is dropped rather than
+ * emitted, which is also what keeps a byte-count truncation upstream from leaving a
+ * split sequence behind.
+ *
+ * A multi-byte sequence is written whole or not at all, so the output can be shorter
+ * than @p out_size - 1 even with input left over.
  */
 static void
 sanitize_field(char* out, size_t out_size, const char* in) {
-    size_t i = 0;
-    for (; in[i] != '\0' && i + 1 < out_size; i++) {
-        const unsigned char c = (unsigned char)in[i];
-        out[i] = (c < 0x20U || c == 0x7FU) ? ' ' : in[i];
+    if (out_size == 0) {
+        return;
     }
-    out[i] = '\0';
+
+    size_t used = 0;
+    size_t i = 0;
+    while (in[i] != '\0' && used + 1U < out_size) {
+        const int len = utf8_sequence_len((const unsigned char*)in + i);
+        if (len < 0) {
+            break; /* Trailing incomplete sequence: drop it. */
+        }
+        if (len == 0) {
+            out[used++] = '?';
+            i++;
+            continue;
+        }
+        if (len == 1) {
+            const unsigned char c = (unsigned char)in[i];
+            out[used++] = (c < 0x20U || c == 0x7FU) ? ' ' : in[i];
+            i++;
+            continue;
+        }
+        if (used + (size_t)len + 1U > out_size) {
+            break; /* Splitting it here would emit the truncation this guards against. */
+        }
+        for (int k = 0; k < len; k++) {
+            out[used++] = in[i + (size_t)k];
+        }
+        i += (size_t)len;
+    }
+    out[used] = '\0';
 }
 
 size_t
@@ -179,7 +313,7 @@ dsd_app_notification_encode(char* out, size_t out_size) {
 
     for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
         const dsd_app_slot_call* call = &status.slots[slot];
-        char name[DSD_CALL_IDENTITY_TEXT_SIZE];
+        char name[DSD_APP_CALL_NAME_SIZE];
         char tg[DSD_CALL_IDENTITY_TEXT_SIZE];
         char src[DSD_CALL_IDENTITY_TEXT_SIZE];
         sanitize_field(name, sizeof(name), call->name);

--- a/src/app_control/notification_status.c
+++ b/src/app_control/notification_status.c
@@ -15,6 +15,7 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/platform/atomic_compat.h>
 #include <dsd-neo/platform/threading.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -130,4 +131,75 @@ dsd_app_notification_get(dsd_app_notification_status* out) {
     }
     dsd_mutex_unlock(&g_mu);
     return have;
+}
+
+/**
+ * @brief Copy @p in into @p out with control characters folded to spaces.
+ *
+ * Tabs separate fields and a newline would end the record, so neither may survive from
+ * text the app did not author.
+ */
+static void
+sanitize_field(char* out, size_t out_size, const char* in) {
+    size_t i = 0;
+    for (; in[i] != '\0' && i + 1 < out_size; i++) {
+        const unsigned char c = (unsigned char)in[i];
+        out[i] = (c < 0x20U || c == 0x7FU) ? ' ' : in[i];
+    }
+    out[i] = '\0';
+}
+
+size_t
+dsd_app_notification_encode(char* out, size_t out_size) {
+    if (out == NULL || out_size == 0) {
+        return 0;
+    }
+
+    dsd_app_notification_status status;
+    if (!dsd_app_notification_get(&status)) {
+        return 0;
+    }
+
+    char protocol[DSD_APP_NOTIFICATION_PROTOCOL_SIZE];
+    sanitize_field(protocol, sizeof(protocol), status.protocol);
+
+    /* scratch is built up front and only copied into *out once it is known to hold the
+       whole record: a reader must never be handed a prefix it could parse as a complete,
+       shorter record. */
+    char scratch[DSD_APP_NOTIFICATION_RECORD_SIZE];
+    int used =
+        DSD_SNPRINTF(scratch, sizeof(scratch), "v1\t%s\t%u\t%u\t%u\t%lld\t%lld\t%lld", protocol,
+                     (unsigned)status.radio_input, (unsigned)status.trunking, (unsigned)status.trunk_tuned,
+                     (long long)status.cc_freq_hz, (long long)status.vc_freq_hz, (long long)status.center_freq_hz);
+    /* DSD_SNPRINTF forwards to vsnprintf: a negative return is an encoding error, and a
+       return >= the buffer size means the formatted record was truncated. Either way,
+       there is no whole record to hand back. */
+    if (used < 0 || (size_t)used >= sizeof(scratch)) {
+        return 0;
+    }
+
+    for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
+        const dsd_app_slot_call* call = &status.slots[slot];
+        char name[DSD_CALL_IDENTITY_TEXT_SIZE];
+        char tg[DSD_CALL_IDENTITY_TEXT_SIZE];
+        char src[DSD_CALL_IDENTITY_TEXT_SIZE];
+        sanitize_field(name, sizeof(name), call->name);
+        sanitize_field(tg, sizeof(tg), call->tg_text);
+        sanitize_field(src, sizeof(src), call->src_text);
+
+        const int added =
+            DSD_SNPRINTF(scratch + used, sizeof(scratch) - (size_t)used, "\t%d\t%s\t%s\t%s\t%llu\t%u\t%u\t%u\t%u",
+                         call->state, name, tg, src, (unsigned long long)call->tg_id, (unsigned)call->enc,
+                         (unsigned)call->algid, (unsigned)call->kid, (unsigned)call->elapsed_ms);
+        if (added < 0 || (size_t)added >= sizeof(scratch) - (size_t)used) {
+            return 0;
+        }
+        used += added;
+    }
+
+    if ((size_t)used + 1U > out_size) {
+        return 0;
+    }
+    DSD_MEMCPY(out, scratch, (size_t)used + 1U);
+    return (size_t)used;
 }

--- a/src/app_control/notification_status.c
+++ b/src/app_control/notification_status.c
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/app_control/call_view.h>
+#include <dsd-neo/app_control/notification_status.h>
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/platform/atomic_compat.h>
+#include <dsd-neo/platform/threading.h>
+#include <stdint.h>
+#include <string.h>
+
+static dsd_app_notification_status g_status;
+static int g_have = 0;
+static dsd_mutex_t g_mu;
+static atomic_int g_mu_state = 0; /* 0=uninit, 1=initing, 2=init */
+
+/* Same lazy-init shape as ui_snapshot.c's and ui_opts_snapshot.c's ensure_mu_init():
+   the publisher can be reached before any explicit setup, and app-control has no start
+   hook that is guaranteed to run first. The loser of the first-call race must wait --
+   taking a mutex another thread has not finished initializing is undefined behavior. */
+static void
+ensure_mu_init(void) {
+    if (atomic_load(&g_mu_state) == 2) {
+        return;
+    }
+    int expected = 0;
+    if (atomic_compare_exchange_strong(&g_mu_state, &expected, 1)) {
+        (void)dsd_mutex_init(&g_mu);
+        atomic_store(&g_mu_state, 2);
+        return;
+    }
+    while (atomic_load(&g_mu_state) != 2) {
+        dsd_thread_yield();
+    }
+}
+
+double
+dsd_app_notification_test_now_m(void) {
+    return dsd_time_now_monotonic_s();
+}
+
+void
+dsd_app_notification_publish_state(const dsd_state* state) {
+    if (state == NULL) {
+        return;
+    }
+
+    /* Everything below reads the live state, so do it before taking the lock: the
+       decode thread must never wait on a JNI poll, and a poll must never see a
+       half-written record. */
+    dsd_app_slot_call slots[DSD_CALL_STATE_SLOT_COUNT];
+    const double now_m = dsd_time_now_monotonic_s();
+    /* int, not uint8_t: DSD_CALL_STATE_SLOT_COUNT is an int-typed enum constant, and
+       comparing a narrower loop variable against it is what
+       bugprone-too-small-loop-variable flags -- matches the loop shape already used
+       for this same constant in call_view.c's app_canonical_active_p25_freq(). */
+    for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
+        dsd_app_slot_call_view(state, (uint8_t)slot, now_m, &slots[slot]);
+    }
+    const long int vc = dsd_app_vc_freq(state);
+    const long int cc = dsd_app_cc_freq(state);
+
+    /* Zeroed rather than just NUL-terminated at [0]: the whole buffer is copied into
+       the published record below, and a partial DSD_SNPRINTF() only overwrites the
+       label plus its NUL, leaving stack garbage past it otherwise. */
+    char protocol[DSD_APP_NOTIFICATION_PROTOCOL_SIZE];
+    DSD_MEMSET(protocol, 0, sizeof(protocol));
+    const char* label = dsd_synctype_to_string(state->synctype);
+    /* NONE means not synced and UNKNOWN means synced to something unnameable. Neither is
+       worth a label, and an empty one is what distinguishes an unsynced session. */
+    if (label != NULL && strcmp(label, "NONE") != 0 && strcmp(label, "UNKNOWN") != 0) {
+        DSD_SNPRINTF(protocol, sizeof(protocol), "%s", label);
+    }
+
+    ensure_mu_init();
+    dsd_mutex_lock(&g_mu);
+    DSD_MEMCPY(g_status.slots, slots, sizeof(slots));
+    DSD_MEMCPY(g_status.protocol, protocol, sizeof(protocol));
+    g_status.vc_freq_hz = (int64_t)vc;
+    g_status.cc_freq_hz = (int64_t)cc;
+    g_status.revision++;
+    g_have = 1;
+    dsd_mutex_unlock(&g_mu);
+}
+
+void
+dsd_app_notification_publish_opts(const dsd_opts* opts) {
+    if (opts == NULL) {
+        return;
+    }
+
+    /* Gated on RTL-family input for the same reason the Qt metrics are: on a WAV, UDP,
+       TCP or symbol-file session the tuner readings are options the front end never
+       applied, and publishing them would put a plausible frequency on a run with no
+       tuner. Frontends omit the row rather than render a zero. */
+    const int radio = (opts->audio_in_type == AUDIO_IN_RTL);
+
+    ensure_mu_init();
+    dsd_mutex_lock(&g_mu);
+    g_status.radio_input = radio ? 1U : 0U;
+    g_status.trunking = (opts->trunk_enable == 1) ? 1U : 0U;
+    g_status.trunk_tuned = (opts->trunk_is_tuned == 1) ? 1U : 0U;
+    g_status.center_freq_hz = radio ? (int64_t)opts->rtlsdr_center_freq : 0;
+    g_status.revision++;
+    g_have = 1;
+    dsd_mutex_unlock(&g_mu);
+}
+
+int
+dsd_app_notification_get(dsd_app_notification_status* out) {
+    if (out == NULL) {
+        return 0;
+    }
+    ensure_mu_init();
+    dsd_mutex_lock(&g_mu);
+    const int have = g_have;
+    if (have) {
+        DSD_MEMCPY(out, &g_status, sizeof(*out));
+    } else {
+        DSD_MEMSET(out, 0, sizeof(*out));
+    }
+    dsd_mutex_unlock(&g_mu);
+    return have;
+}

--- a/src/app_control/notification_status.c
+++ b/src/app_control/notification_status.c
@@ -23,6 +23,24 @@ static int g_have = 0;
 static dsd_mutex_t g_mu;
 static atomic_int g_mu_state = 0; /* 0=uninit, 1=initing, 2=init */
 
+/* Armed by the first read; see dsd_app_notification_get(). The publishers hang off the
+   telemetry hook, which runs on the decode thread at protocol frame rate -- unthrottled
+   at the DMR/P25p2/D-STAR/M17/EDACS sites, so tens of times a second -- and deriving the
+   record is not cheap: dsd_app_vc_freq() alone copies the whole recent-activity snapshot
+   under the canonical call-state lock whenever no voice frequency is cached, which is
+   every publish of a conventional or not-yet-tuned session. The only reader in the tree
+   is the Android service's 1 Hz poll, so a desktop run must not pay for any of it. */
+static atomic_int g_wanted = 0;
+
+/* Seconds a sync label survives a frame that found none. Matches the hold the Qt panel
+   applies to the same field (kSyncHoldSeconds in src/ui/qt/metrics_model.cpp), so the
+   two surfaces agree on when a session stops reading as locked. Guarded by g_mu with the
+   record itself, because dsd_app_notification_reset() clears them together and can be
+   called from a thread other than the publisher's. */
+#define NOTIFICATION_SYNC_HOLD_S 3.0
+static int g_sync_type = DSD_SYNC_NONE;
+static double g_sync_seen_m = 0.0;
+
 /* Same lazy-init shape as ui_snapshot.c's and ui_opts_snapshot.c's ensure_mu_init():
    the publisher can be reached before any explicit setup, and app-control has no start
    hook that is guaranteed to run first. The loser of the first-call race must wait --
@@ -43,14 +61,9 @@ ensure_mu_init(void) {
     }
 }
 
-double
-dsd_app_notification_test_now_m(void) {
-    return dsd_time_now_monotonic_s();
-}
-
 void
 dsd_app_notification_publish_state(const dsd_state* state) {
-    if (state == NULL) {
+    if (state == NULL || atomic_load(&g_wanted) == 0) {
         return;
     }
 
@@ -66,25 +79,50 @@ dsd_app_notification_publish_state(const dsd_state* state) {
     for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
         dsd_app_slot_call_view(state, (uint8_t)slot, now_m, &slots[slot]);
     }
+    int line_states[DSD_CALL_STATE_SLOT_COUNT];
+    for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
+        line_states[slot] = slots[slot].state;
+    }
+    const int8_t lead = (int8_t)dsd_app_lead_slot(line_states, (unsigned)DSD_CALL_STATE_SLOT_COUNT);
+
     const long int vc = dsd_app_vc_freq(state);
     const long int cc = dsd_app_cc_freq(state);
+
+    const int synctype = state->synctype;
+
+    ensure_mu_init();
+    dsd_mutex_lock(&g_mu);
+    /* Held rather than sampled, the same way the Qt panel holds it and for the same
+       reason: getFrameSync() re-stamps state->synctype every engine iteration and answers
+       NONE whenever the current search window found nothing, which on a control channel
+       is most of them. Published raw, the label blinks on and off between polls -- and
+       because that changes the encoded record, the service re-posts the notification at
+       the full poll rate on a channel carrying no traffic at all. */
+    if (synctype != DSD_SYNC_NONE) {
+        g_sync_type = synctype;
+        g_sync_seen_m = now_m;
+    } else if (g_sync_type != DSD_SYNC_NONE && (now_m - g_sync_seen_m) > NOTIFICATION_SYNC_HOLD_S) {
+        g_sync_type = DSD_SYNC_NONE;
+    }
 
     /* Zeroed rather than just NUL-terminated at [0]: the whole buffer is copied into
        the published record below, and a partial DSD_SNPRINTF() only overwrites the
        label plus its NUL, leaving stack garbage past it otherwise. */
     char protocol[DSD_APP_NOTIFICATION_PROTOCOL_SIZE];
     DSD_MEMSET(protocol, 0, sizeof(protocol));
-    const char* label = dsd_synctype_to_string(state->synctype);
-    /* NONE means not synced and UNKNOWN means synced to something unnameable. Neither is
-       worth a label, and an empty one is what distinguishes an unsynced session. */
-    if (label != NULL && strcmp(label, "NONE") != 0 && strcmp(label, "UNKNOWN") != 0) {
+    /* Not synced is asked of the sync id, not of its rendered label: round-tripping the
+       question through display text would couple this filter to the wording of the table
+       in synctype.c, where renaming a label is a display-only change nobody would expect
+       to reach app-control. UNKNOWN has no sentinel of its own -- it is what the table
+       returns for an id it does not map -- so that half still has to be a string test. */
+    const char* label = (g_sync_type != DSD_SYNC_NONE) ? dsd_synctype_to_string(g_sync_type) : NULL;
+    if (label != NULL && strcmp(label, "UNKNOWN") != 0) {
         DSD_SNPRINTF(protocol, sizeof(protocol), "%s", label);
     }
 
-    ensure_mu_init();
-    dsd_mutex_lock(&g_mu);
     DSD_MEMCPY(g_status.slots, slots, sizeof(slots));
     DSD_MEMCPY(g_status.protocol, protocol, sizeof(protocol));
+    g_status.lead_slot = lead;
     g_status.vc_freq_hz = (int64_t)vc;
     g_status.cc_freq_hz = (int64_t)cc;
     g_status.revision++;
@@ -94,15 +132,17 @@ dsd_app_notification_publish_state(const dsd_state* state) {
 
 void
 dsd_app_notification_publish_opts(const dsd_opts* opts) {
-    if (opts == NULL) {
+    if (opts == NULL || atomic_load(&g_wanted) == 0) {
         return;
     }
 
     /* Gated on RTL-family input for the same reason the Qt metrics are: on a WAV, UDP,
        TCP or symbol-file session the tuner readings are options the front end never
        applied, and publishing them would put a plausible frequency on a run with no
-       tuner. Frontends omit the row rather than render a zero. */
-    const int radio = (opts->audio_in_type == AUDIO_IN_RTL);
+       tuner. Frontends omit the row rather than render a zero. Through the shared
+       predicate so this and dsd_app_frontend_get_metrics() cannot come to disagree about
+       whether a session has a tuner behind it. */
+    const int radio = dsd_opts_input_is_radio(opts);
 
     ensure_mu_init();
     dsd_mutex_lock(&g_mu);
@@ -120,6 +160,9 @@ dsd_app_notification_get(dsd_app_notification_status* out) {
     if (out == NULL) {
         return 0;
     }
+    /* Arms the publishers; see g_wanted. Sticky for the life of the process rather than
+       per session, so a host that has polled once keeps a live record across restarts. */
+    atomic_store(&g_wanted, 1);
     ensure_mu_init();
     dsd_mutex_lock(&g_mu);
     const int have = g_have;
@@ -127,6 +170,10 @@ dsd_app_notification_get(dsd_app_notification_status* out) {
         DSD_MEMCPY(out, &g_status, sizeof(*out));
     } else {
         DSD_MEMSET(out, 0, sizeof(*out));
+        /* Not left at the zero the memset wrote: 0 is a valid slot index, so a caller
+           rendering straight from the struct would headline slot 0 on a session that has
+           published nothing at all. -1 is the "no slot" sentinel. */
+        out->lead_slot = -1;
     }
     dsd_mutex_unlock(&g_mu);
     return have;
@@ -137,6 +184,10 @@ dsd_app_notification_reset(void) {
     ensure_mu_init();
     dsd_mutex_lock(&g_mu);
     DSD_MEMSET(&g_status, 0, sizeof(g_status));
+    /* The sync hold goes with the record: carried across, it would let the next session's
+       first frames publish the previous one's protocol label. */
+    g_sync_type = DSD_SYNC_NONE;
+    g_sync_seen_m = 0.0;
     g_have = 0;
     dsd_mutex_unlock(&g_mu);
 }
@@ -309,10 +360,10 @@ dsd_app_notification_encode(char* out, size_t out_size) {
        whole record: a reader must never be handed a prefix it could parse as a complete,
        shorter record. */
     char scratch[DSD_APP_NOTIFICATION_RECORD_SIZE];
-    int used =
-        DSD_SNPRINTF(scratch, sizeof(scratch), "v1\t%s\t%u\t%u\t%u\t%lld\t%lld\t%lld", protocol,
-                     (unsigned)status.radio_input, (unsigned)status.trunking, (unsigned)status.trunk_tuned,
-                     (long long)status.cc_freq_hz, (long long)status.vc_freq_hz, (long long)status.center_freq_hz);
+    int used = DSD_SNPRINTF(scratch, sizeof(scratch), "v1\t%s\t%u\t%u\t%u\t%lld\t%lld\t%lld\t%d", protocol,
+                            (unsigned)status.radio_input, (unsigned)status.trunking, (unsigned)status.trunk_tuned,
+                            (long long)status.cc_freq_hz, (long long)status.vc_freq_hz,
+                            (long long)status.center_freq_hz, (int)status.lead_slot);
     /* DSD_SNPRINTF forwards to vsnprintf: a negative return is an encoding error, and a
        return >= the buffer size means the formatted record was truncated. Either way,
        there is no whole record to hand back. */

--- a/src/app_control/notification_status.c
+++ b/src/app_control/notification_status.c
@@ -18,7 +18,12 @@
 #include <stdint.h>
 #include <string.h>
 
-static dsd_app_notification_status g_status;
+/* lead_slot starts at, and is reset to, the -1 "no slot" sentinel rather than the zero a
+   plain static initializer or a memset would leave: 0 names slot 0. The two halves of the
+   record are published separately, so an opts-only publish flips g_have with the slot
+   fields still untouched, and a reader that trusts the header's "or -1 for none" would
+   headline slot 0 on a session with nothing on the air. */
+static dsd_app_notification_status g_status = {.lead_slot = -1};
 static int g_have = 0;
 static dsd_mutex_t g_mu;
 static atomic_int g_mu_state = 0; /* 0=uninit, 1=initing, 2=init */
@@ -32,12 +37,10 @@ static atomic_int g_mu_state = 0; /* 0=uninit, 1=initing, 2=init */
    is the Android service's 1 Hz poll, so a desktop run must not pay for any of it. */
 static atomic_int g_wanted = 0;
 
-/* Seconds a sync label survives a frame that found none. Matches the hold the Qt panel
-   applies to the same field (kSyncHoldSeconds in src/ui/qt/metrics_model.cpp), so the
-   two surfaces agree on when a session stops reading as locked. Guarded by g_mu with the
-   record itself, because dsd_app_notification_reset() clears them together and can be
-   called from a thread other than the publisher's. */
-#define NOTIFICATION_SYNC_HOLD_S 3.0
+/* The sync-hold decay, sharing DSD_APP_SYNC_HOLD_S with the Qt panel so the two surfaces
+   cannot come to disagree about when a session stops reading as locked. Guarded by g_mu
+   with the record itself, because dsd_app_notification_reset() clears them together and
+   can be called from a thread other than the publisher's. */
 static int g_sync_type = DSD_SYNC_NONE;
 static double g_sync_seen_m = 0.0;
 
@@ -71,6 +74,7 @@ dsd_app_notification_publish_state(const dsd_state* state) {
        decode thread must never wait on a JNI poll, and a poll must never see a
        half-written record. */
     dsd_app_slot_call slots[DSD_CALL_STATE_SLOT_COUNT];
+    int line_states[DSD_CALL_STATE_SLOT_COUNT];
     const double now_m = dsd_time_now_monotonic_s();
     /* int, not uint8_t: DSD_CALL_STATE_SLOT_COUNT is an int-typed enum constant, and
        comparing a narrower loop variable against it is what
@@ -78,9 +82,6 @@ dsd_app_notification_publish_state(const dsd_state* state) {
        for this same constant in call_view.c's app_canonical_active_p25_freq(). */
     for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
         dsd_app_slot_call_view(state, (uint8_t)slot, now_m, &slots[slot]);
-    }
-    int line_states[DSD_CALL_STATE_SLOT_COUNT];
-    for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
         line_states[slot] = slots[slot].state;
     }
     const int8_t lead = (int8_t)dsd_app_lead_slot(line_states, (unsigned)DSD_CALL_STATE_SLOT_COUNT);
@@ -101,7 +102,7 @@ dsd_app_notification_publish_state(const dsd_state* state) {
     if (synctype != DSD_SYNC_NONE) {
         g_sync_type = synctype;
         g_sync_seen_m = now_m;
-    } else if (g_sync_type != DSD_SYNC_NONE && (now_m - g_sync_seen_m) > NOTIFICATION_SYNC_HOLD_S) {
+    } else if (g_sync_type != DSD_SYNC_NONE && (now_m - g_sync_seen_m) > DSD_APP_SYNC_HOLD_S) {
         g_sync_type = DSD_SYNC_NONE;
     }
 
@@ -184,6 +185,8 @@ dsd_app_notification_reset(void) {
     ensure_mu_init();
     dsd_mutex_lock(&g_mu);
     DSD_MEMSET(&g_status, 0, sizeof(g_status));
+    /* Back to the sentinel the memset just overwrote; see the declaration. */
+    g_status.lead_slot = -1;
     /* The sync hold goes with the record: carried across, it would let the next session's
        first frames publish the previous one's protocol label. */
     g_sync_type = DSD_SYNC_NONE;

--- a/src/app_control/notification_status.c
+++ b/src/app_control/notification_status.c
@@ -15,7 +15,6 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/platform/atomic_compat.h>
 #include <dsd-neo/platform/threading.h>
-#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 

--- a/src/app_control/telemetry_hooks_install.c
+++ b/src/app_control/telemetry_hooks_install.c
@@ -4,6 +4,7 @@
  */
 
 #include <dsd-neo/app_control/frontend_runtime.h>
+#include <dsd-neo/app_control/notification_status.h>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/platform/atomic_compat.h>
@@ -56,4 +57,9 @@ void
 dsd_app_frontend_runtime_stop(void) {
     dsd_runtime_set_control_pump(NULL);
     dsd_telemetry_hooks_set((dsd_telemetry_hooks){0});
+    /* Clearing the hooks stops the feed but leaves the last record behind, and that
+       record is a module static that outlives the session. On Android the service starts
+       polling before the next session reaches dsd_app_frontend_runtime_start(), so a
+       stale record would caption the new run with the old one's last call. */
+    dsd_app_notification_reset();
 }

--- a/src/app_control/ui_opts_snapshot.c
+++ b/src/app_control/ui_opts_snapshot.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+#include <dsd-neo/app_control/notification_status.h>
 #include <dsd-neo/app_control/snapshot.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/platform/atomic_compat.h>
@@ -50,6 +51,10 @@ dsd_app_telemetry_publish_opts_snapshot(const dsd_opts* opts) {
     g_pub_opts_seq++;
     g_have_opts = 1;
     dsd_mutex_unlock(&g_opts_mu);
+    /* Outside this module's lock on purpose, matching ui_snapshot.c: the notification
+       publisher takes its own, and nesting the two would put a lock-order edge between
+       the snapshot path and a JNI poll. */
+    dsd_app_notification_publish_opts(opts);
 }
 
 const dsd_opts*

--- a/src/app_control/ui_snapshot.c
+++ b/src/app_control/ui_snapshot.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+#include <dsd-neo/app_control/notification_status.h>
 #include <dsd-neo/app_control/snapshot.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/state.h>
@@ -198,6 +199,10 @@ dsd_app_telemetry_publish_snapshot(const dsd_state* state) {
     g_have = 1;
     g_pub_seq++;
     dsd_mutex_unlock(&g_mu);
+    /* Outside this module's lock on purpose: the notification publisher takes its own,
+       and nesting the two would put a lock-order edge between the snapshot path and a
+       JNI poll. */
+    dsd_app_notification_publish_state(state);
 }
 
 const dsd_state*

--- a/src/ui/qt/call_line.h
+++ b/src/ui/qt/call_line.h
@@ -5,64 +5,46 @@
 
 /**
  * @file
- * @brief Decides what a per-slot call line should say, independent of Qt.
+ * @brief Qt-facing names for the shared per-slot call line decision.
  *
  * The canonical call state keeps an ended epoch on the slot indefinitely -- the
  * reacquisition window, the terminator heal and the history layer all read it after the
  * transmission is over, and nothing ages it out (see dsd_call_state_end_ex()). A status
  * panel wants the opposite: it is about what is on the air now, so it has to decide for
- * itself when a retained epoch stops being news. This is that decision, kept free of Qt
- * so the host test can drive it directly.
+ * itself when a retained epoch stops being news. That decision now lives in
+ * <dsd-neo/app_control/call_view.h>, shared with the terminal and the Android
+ * notification; this header only binds it to the CallLineState names and values this
+ * panel (and its tests) already depend on.
  */
 
 #ifndef DSD_NEO_SRC_UI_QT_CALL_LINE_H_
 #define DSD_NEO_SRC_UI_QT_CALL_LINE_H_
 
+#include <dsd-neo/app_control/call_view.h>
 #include <dsd-neo/core/call_state.h>
 
 namespace dsd_qt {
 
-/**
- * @brief Seconds an ended epoch stays on the slot line before it reads as idle.
- *
- * Long enough to catch the end of a call glanced at a moment late, short enough that a
- * quiet channel does not keep advertising a transmission that finished minutes ago.
- * Matches DSD_RECENT_ACTIVITY_TTL_MS so the two decay windows in the UI agree.
- */
-constexpr double kCallLineEndedHoldS = 3.0;
+/** @brief Seconds an ended epoch stays on the slot line before it reads as idle. */
+constexpr double kCallLineEndedHoldS = DSD_APP_CALL_LINE_ENDED_HOLD_S;
 
-/** @brief What a slot line is reporting. */
+/** @brief What a slot line is reporting. Values match the app-control enum. */
 enum CallLineState {
-    kCallLineNone = 0, /**< Nothing has ever been observed on this slot. */
-    kCallLineIdle,     /**< The slot is quiet: never active, or ended long enough ago. */
-    kCallLineActive,   /**< A call epoch is open. */
-    kCallLineEnded,    /**< A call ended within the hold window. */
+    kCallLineNone = DSD_APP_CALL_LINE_NONE,
+    kCallLineIdle = DSD_APP_CALL_LINE_IDLE,
+    kCallLineActive = DSD_APP_CALL_LINE_ACTIVE,
+    kCallLineEnded = DSD_APP_CALL_LINE_ENDED,
 };
 
 /**
  * @brief Fold a call-state lookup into what the line should show.
  *
- * @param lookup       Result of dsd_call_state_get(); <= 0 means no epoch on the slot.
- * @param call         The snapshot it filled in. Only read when @p lookup is positive.
- * @param now_m        Monotonic seconds, the same clock call_state_observed_m() stamps
- *                     @c ended_m from.
- * @param hold_s       How long an ended epoch is held; see @ref kCallLineEndedHoldS.
- *
- * A negative age -- an end stamped a hair ahead of the poll -- counts as fresh rather
- * than as an expiry, which is the same thing the comparison would say for age zero.
+ * Delegates to app-control so the terminal, this panel and the Android notification
+ * cannot drift apart on when a retained epoch stops being news.
  */
 inline CallLineState
 call_line_state(int lookup, const dsd_call_snapshot& call, double now_m, double hold_s = kCallLineEndedHoldS) {
-    if (lookup <= 0) {
-        return kCallLineNone;
-    }
-    if (call.phase == DSD_CALL_PHASE_ACTIVE) {
-        return kCallLineActive;
-    }
-    if (call.phase != DSD_CALL_PHASE_ENDED) {
-        return kCallLineIdle;
-    }
-    return ((now_m - call.ended_m) < hold_s) ? kCallLineEnded : kCallLineIdle;
+    return static_cast<CallLineState>(dsd_app_call_line_state(lookup, &call, now_m, hold_s));
 }
 
 } // namespace dsd_qt

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -32,8 +32,11 @@ namespace {
  * Long enough to ride out the gaps between frames a 250 ms poll lands in, short
  * enough that a decoder which has genuinely stopped finding anything says so
  * while the reader is still looking at it.
+ *
+ * Shared with the Android notification through app-control, so the two surfaces cannot
+ * drift apart on when a session stops reading as locked.
  */
-constexpr double kSyncHoldSeconds = 3.0;
+constexpr double kSyncHoldSeconds = DSD_APP_SYNC_HOLD_S;
 
 /**
  * @brief "ALG 84 · KID 0001" when the crypto header decoded, else empty.
@@ -215,7 +218,7 @@ MetricsModel::refresh(const dsd_opts* opts_snapshot, const dsd_state* snapshot) 
     /* Drives whether the tuner-facing rows are shown at all. Taken from the options
      * the running session was configured with, which is the same authority the
      * metrics fetch above uses to decide whether any of them mean anything. */
-    next.radio_input = opts_snapshot->audio_in_type == AUDIO_IN_RTL;
+    next.radio_input = dsd_opts_input_is_radio(opts_snapshot) != 0;
 
     next.carrier_lock = metrics.carrier_lock != 0;
     next.cfo_hz = metrics.cfo_hz;

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -8,8 +8,8 @@
 #include <QChar>
 #include <QDateTime>
 #include <QtGlobal>
+#include <dsd-neo/app_control/call_view.h>
 #include <dsd-neo/app_control/frontend.h>
-#include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/enc_lockout.h>
 #include <dsd-neo/core/opts.h>
@@ -19,7 +19,6 @@
 #include <dsd-neo/runtime/decode_mode.h>
 #include <stdint.h>
 
-#include "call_line.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 
@@ -37,87 +36,20 @@ namespace {
 constexpr double kSyncHoldSeconds = 3.0;
 
 /**
- * @brief Whether the call reads as encrypted over the air, including DECRYPTABLE.
- *
- * Same definition the event ring stamps on history rows (and the terminal UI
- * renders): the live view and the call log must agree on which transmissions
- * were encrypted, or a decrypted call plays clear here and then hides under
- * the log's ENC filter.
- */
-bool
-call_reads_encrypted(const dsd_call_snapshot& call) {
-    return call.crypto == DSD_CALL_CRYPTO_ENCRYPTED || call.crypto == DSD_CALL_CRYPTO_ENCRYPTED_PENDING
-           || call.crypto == DSD_CALL_CRYPTO_DECRYPTABLE;
-}
-
-/**
  * @brief "ALG 84 · KID 0001" when the crypto header decoded, else empty.
  *
- * What the terminal UI's slot line showed, so AES and RC4 traffic read
- * differently at a glance; the ENC tag alone covers "encrypted, alg unknown".
+ * What the terminal UI's slot line showed, so AES and RC4 traffic read differently at a
+ * glance; the ENC tag alone covers "encrypted, alg unknown".
  */
 QString
-slot_enc_text(const dsd_call_snapshot& call) {
-    if (call.algid == 0U) {
+slot_enc_text(quint8 algid, quint16 kid) {
+    if (algid == 0U) {
         return QString();
     }
     return QStringLiteral("ALG %1 · KID %2")
-        .arg(call.algid, 2, 16, QLatin1Char('0'))
-        .arg(call.kid, 4, 16, QLatin1Char('0'))
+        .arg(algid, 2, 16, QLatin1Char('0'))
+        .arg(kid, 4, 16, QLatin1Char('0'))
         .toUpper();
-}
-
-/**
- * @brief Whether the epoch carries nothing that could name a transmission.
- *
- * The decoder opens one on a frame that synced far enough to be a frame and no
- * further, which happens routinely on a control channel and on noise while
- * hunting. Rendered, it becomes a call from talkgroup 0 by nobody — and if a
- * stale crypto header is still on the slot, an encrypted one. On a session that
- * has not locked onto anything, that is the screen inventing traffic.
- *
- * The field list mirrors dsd_call_state_snapshot_has_identity() (call_state.c),
- * route_text included: D-STAR, NXDN and YSF enrich the repeater pair, and a call
- * whose route decoded before its callsigns is a named transmission the canonical
- * layer already counts as one. That helper lives behind call_state_internal.h and
- * a frontend cannot call it, which is why this mirror exists — but a mirror that
- * drops a field reports idle for calls the rest of the app is showing.
- *
- * X2-TDMA and standalone ProVoice are the deliberate exception, matching
- * dsd_call_state_protocol_voice_is_anonymous(): those modes never parse voice into
- * a talkgroup or a source at all, so an identity-less voice epoch is the whole
- * story the protocol has — not a frame that synced and went nowhere. Suppressed,
- * their transmissions would play audio and log history rows while the panel said
- * nothing was happening.
- */
-bool
-call_has_no_identity(const dsd_call_snapshot& call) {
-    if (DSD_SYNC_IS_X2TDMA(call.protocol) || DSD_SYNC_IS_PROVOICE(call.protocol)) {
-        return false;
-    }
-    return call.ota_target_id == 0U && call.policy_target_id == 0U && call.target_text[0] == '\0'
-           && call.ota_source_id == 0U && call.source_text[0] == '\0' && call.route_text[0][0] == '\0'
-           && call.route_text[1][0] == '\0';
-}
-
-/**
- * @brief The CSV-imported group name staged on the slot's active history row, or empty.
- *
- * The staged row's target_id is stamped OTA-then-policy by the event layer, so it
- * must be compared against the same preference (the caller's resolved tg_id), not
- * the OTA id alone — a policy-resolved talkgroup would never match otherwise.
- * Nonzero required: a text-only target's 0 would "match" a stale staged row.
- */
-QString
-staged_group_name(const dsd_state* snapshot, quint8 slot, qulonglong tg_id) {
-    if (snapshot->event_history_s == nullptr || tg_id == 0) {
-        return QString();
-    }
-    const Event_History* staged = &snapshot->event_history_s[slot].Event_History_Items[0];
-    if (staged->t_name[0] == '\0' || staged->target_id != static_cast<uint32_t>(tg_id)) {
-        return QString();
-    }
-    return QString::fromUtf8(staged->t_name);
 }
 
 } // namespace
@@ -125,46 +57,30 @@ staged_group_name(const dsd_state* snapshot, quint8 slot, qulonglong tg_id) {
 /**
  * @brief Structured identity for one slot, display-ready for the hero panel.
  *
- * The friendly name prefers the CSV-imported group name staged on the slot's active
- * history row, but only when that row is about the same talkgroup — the staged row
- * outlives a call by design and must not caption the next one.
+ * Thin adapter over the shared app-control view: it owns the ended-hold decay, the
+ * identity-less-epoch suppression and the staged CSV group name lookup, so the
+ * terminal, this panel and the Android notification cannot drift apart on any of them.
  */
 MetricsModel::SlotCall
 MetricsModel::slotCallView(const dsd_state* snapshot, quint8 slot, double now_m) {
     MetricsModel::SlotCall out;
-    dsd_call_snapshot call = {};
-    const CallLineState line = call_line_state(dsd_call_state_get(snapshot, slot, &call), call, now_m);
-    out.state = static_cast<int>(line);
-    if (line != kCallLineActive && line != kCallLineEnded) {
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(snapshot, slot, now_m, &view);
+
+    out.state = view.state;
+    if (view.state != DSD_APP_CALL_LINE_ACTIVE && view.state != DSD_APP_CALL_LINE_ENDED) {
         return out;
     }
 
-    /* An epoch with nothing in it is not a transmission anyone can be shown. */
-    if (call_has_no_identity(call)) {
-        out.state = static_cast<int>(kCallLineIdle);
-        return out;
-    }
-
-    const QString target = (call.target_text[0] != '\0') ? QString::fromUtf8(call.target_text)
-                                                         : QString::number(static_cast<qulonglong>(call.ota_target_id));
-    out.tg_text = target;
-    // Same preference order the event layer uses: the OTA id when one decoded,
-    // the policy-resolved id otherwise. Text-only targets stay 0.
-    out.tg_id = (call.ota_target_id != 0U) ? static_cast<qulonglong>(call.ota_target_id)
-                                           : static_cast<qulonglong>(call.policy_target_id);
-    out.src_text = (call.source_text[0] != '\0') ? QString::fromUtf8(call.source_text)
-                                                 : QString::number(static_cast<qulonglong>(call.ota_source_id));
-
-    const QString staged_name = staged_group_name(snapshot, slot, out.tg_id);
-    out.name = staged_name.isEmpty() ? target : staged_name;
-
-    out.enc = call_reads_encrypted(call);
+    out.tg_text = QString::fromUtf8(view.tg_text);
+    out.tg_id = static_cast<qulonglong>(view.tg_id);
+    out.src_text = QString::fromUtf8(view.src_text);
+    out.name = QString::fromUtf8(view.name);
+    out.enc = view.enc != 0U;
     if (out.enc) {
-        out.enc_text = slot_enc_text(call);
+        out.enc_text = slot_enc_text(view.algid, view.kid);
     }
-    const double ref_m = (line == kCallLineEnded) ? call.ended_m : now_m;
-    const double elapsed = ref_m - call.started_m;
-    out.seconds = (elapsed > 0.0) ? static_cast<int>(elapsed) : 0;
+    out.seconds = static_cast<int>(view.elapsed_ms / 1000U);
     return out;
 }
 

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -115,6 +115,9 @@ MetricsModel::publish(const View& next) {
     if (slot2Moved) {
         Q_EMIT slot2Changed();
     }
+    if (slot1Moved || slot2Moved) {
+        Q_EMIT leadSlotChanged();
+    }
     if (controlMoved) {
         Q_EMIT controlChanged();
     }

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -19,6 +19,7 @@
 #include <QString>
 #include <QTimer>
 #include <QtGlobal>
+#include <dsd-neo/app_control/call_view.h>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/core/synctype_ids.h>
@@ -57,6 +58,9 @@ class MetricsModel : public QObject {
     Q_PROPERTY(QString slot2EncText READ slot2EncText NOTIFY slot2Changed)
     Q_PROPERTY(int slot1CallSeconds READ slot1CallSeconds NOTIFY slot1Changed)
     Q_PROPERTY(int slot2CallSeconds READ slot2CallSeconds NOTIFY slot2Changed)
+    /* Its own signal rather than slot1Changed: it reads both slots, and Q_PROPERTY takes
+       only one NOTIFY -- bound to either slot alone it would go stale when the other moved. */
+    Q_PROPERTY(int leadSlot READ leadSlot NOTIFY leadSlotChanged)
     Q_PROPERTY(bool audioMuted READ audioMuted NOTIFY controlChanged)
     Q_PROPERTY(qulonglong heldTg READ heldTg NOTIFY controlChanged)
     Q_PROPERTY(int encLockoutCount READ encLockoutCount NOTIFY controlChanged)
@@ -284,6 +288,19 @@ class MetricsModel : public QObject {
         return m_view.slot_call[1].state;
     }
 
+    /**
+     * @brief Which slot the hero should show: 1, 2, or 0 when nothing is on the air.
+     *
+     * One-based to match the slotN* properties QML reads it against, so 0 falls out as
+     * "neither". The rule itself lives in dsd_app_lead_slot() and is shared with the
+     * Android notification, which has the same one-call-at-a-time problem.
+     */
+    int
+    leadSlot() const {
+        const int states[2] = {m_view.slot_call[0].state, m_view.slot_call[1].state};
+        return dsd_app_lead_slot(states, 2U) + 1;
+    }
+
     const QString&
     slot1CallName() const {
         return m_view.slot_call[0].name;
@@ -443,6 +460,7 @@ class MetricsModel : public QObject {
     void tunerChanged();
     void slot1Changed();
     void slot2Changed();
+    void leadSlotChanged();
     void controlChanged();
     void uiMessageChanged();
 

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -297,8 +297,11 @@ class MetricsModel : public QObject {
      */
     int
     leadSlot() const {
-        const int states[2] = {m_view.slot_call[0].state, m_view.slot_call[1].state};
-        return dsd_app_lead_slot(states, 2U) + 1;
+        int states[DSD_CALL_STATE_SLOT_COUNT];
+        for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
+            states[slot] = m_view.slot_call[slot].state;
+        }
+        return dsd_app_lead_slot(states, static_cast<unsigned>(DSD_CALL_STATE_SLOT_COUNT)) + 1;
     }
 
     const QString&
@@ -521,7 +524,10 @@ class MetricsModel : public QObject {
         bool trunking_enabled = false;
         bool scanner_mode = false;
         QString ui_message;
-        SlotCall slot_call[2];
+        /* Sized from the canonical constant rather than a literal 2: leadSlot() ranks the
+         * whole array through dsd_app_lead_slot(), so the two must agree or the ranking
+         * would read past the end the day a third slot appears. */
+        SlotCall slot_call[DSD_CALL_STATE_SLOT_COUNT];
 
         /* Exact comparison is right for the two doubles: they are carried through
          * unmodified from the metrics boundary, so "unchanged" means the identical

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -22,20 +22,10 @@ Item {
                                        : callHistory.sessionLabel.length > 0 ? callHistory.sessionLabel
                                                                              : qsTr("Listening")
 
-    // Which slot the hero shows: an active call wins, then a recently ended one.
-    readonly property int heroSlot: {
-        if (!metrics)
-            return 0
-        if (metrics.slot1CallState === 2)
-            return 1
-        if (metrics.slot2CallState === 2)
-            return 2
-        if (metrics.slot1CallState === 3)
-            return 1
-        if (metrics.slot2CallState === 3)
-            return 2
-        return 0
-    }
+    // Which slot the hero shows: an active call wins, then a recently ended one, and
+    // between equals the lower slot. Decided by dsd_app_lead_slot() rather than here, so
+    // this panel and the Android notification cannot headline different slots.
+    readonly property int heroSlot: metrics ? metrics.leadSlot : 0
     readonly property bool heroActive: heroSlot === 1 ? metrics.slot1CallState === 2
                                                       : heroSlot === 2 ? metrics.slot2CallState === 2 : false
     readonly property string heroName: heroSlot === 1 ? metrics.slot1CallName

--- a/src/ui/terminal/ncurses_p25_display.c
+++ b/src/ui/terminal/ncurses_p25_display.c
@@ -8,8 +8,8 @@
  */
 
 #include <curses.h>
+#include <dsd-neo/app_control/call_view.h>
 #include <dsd-neo/app_control/frontend.h>
-#include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
@@ -233,47 +233,6 @@ ui_p25_print_iden_line(int id, const p25_iden_entry_t* entry, int has_other_clas
     }
     addch('\n');
     attr_set(saved_attrs, saved_pair, NULL);
-}
-
-static int
-ui_extract_channel_token(const char* channel_str, char* tok, size_t tok_len) {
-    const char* p = strstr(channel_str, "Ch:");
-    if (!p || tok_len == 0) {
-        return 0;
-    }
-    p += 3;
-    while (*p == ' ') {
-        p++;
-    }
-    size_t t = 0;
-    while (*p && t + 1 < tok_len) {
-        char c = *p;
-        int is_hex = (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
-        if (!is_hex) {
-            break;
-        }
-        tok[t++] = c;
-        p++;
-    }
-    tok[t] = '\0';
-    return t > 0;
-}
-
-static long int
-ui_lookup_trunk_chan_map(const dsd_state* state, const char* tok) {
-    char* endp = NULL;
-    long ch_hex = strtol(tok, &endp, 16);
-    if (endp && *endp == '\0' && ch_hex > 0 && ch_hex < 65535) {
-        long int freq = state->trunk_chan_map[ch_hex];
-        if (freq != 0) {
-            return freq;
-        }
-    }
-    long ch_dec = strtol(tok, &endp, 10);
-    if (endp && *endp == '\0' && ch_dec > 0 && ch_dec < 65535) {
-        return state->trunk_chan_map[ch_dec];
-    }
-    return 0;
 }
 
 static int
@@ -1230,67 +1189,9 @@ ui_print_p25_iden_plan(const dsd_opts* opts, const dsd_state* state) {
     }
 }
 
-static long int
-ui_canonical_active_p25_freq(const dsd_call_state_snapshot* calls) {
-    for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
-        const dsd_call_snapshot* call = &calls->slots[slot];
-        if (call->phase == DSD_CALL_PHASE_ACTIVE && ui_is_p25_synctype(call->protocol) && call->frequency_hz > 0) {
-            return (long int)call->frequency_hz;
-        }
-    }
-    return 0;
-}
-
-static long int
-ui_recent_activity_vc_freq(const dsd_state* state) {
-    dsd_recent_activity_snapshot recent;
-    if (dsd_recent_activity_copy_snapshot(state, &recent) <= 0) {
-        return 0;
-    }
-    const uint64_t now_ms = (uint64_t)(dsd_time_now_monotonic_s() * 1000.0);
-    for (int i = 0; i < 31; i++) {
-        const dsd_recent_activity_entry* entry = &recent.entries[i];
-        if (entry->updated_m_ms != 0U && now_ms >= entry->updated_m_ms
-            && now_ms - entry->updated_m_ms > DSD_RECENT_ACTIVITY_TTL_MS) {
-            continue;
-        }
-        if (entry->observation.frequency_hz > 0) {
-            return (long int)entry->observation.frequency_hz;
-        }
-        const char* activity = entry->notice;
-        if (!activity || activity[0] == '\0') {
-            continue;
-        }
-        char channel[8] = {0};
-        if (!ui_extract_channel_token(activity, channel, sizeof(channel))) {
-            continue;
-        }
-        const long int frequency = ui_lookup_trunk_chan_map(state, channel);
-        if (frequency != 0) {
-            return frequency;
-        }
-    }
-    return 0;
-}
-
 long int
 ui_guess_active_vc_freq(const dsd_state* state) {
-    if (!state) {
-        return 0;
-    }
-    dsd_call_state_snapshot calls;
-    const int has_canonical = dsd_call_state_copy_snapshot(state, &calls) > 0;
-    if (has_canonical) {
-        const long int canonical_frequency = ui_canonical_active_p25_freq(&calls);
-        if (canonical_frequency != 0) {
-            return canonical_frequency;
-        }
-    }
-    if (state->trunk_vc_freq[0] != 0) {
-        return state->trunk_vc_freq[0];
-    }
-    if (state->p25_vc_freq[0] != 0) {
-        return state->p25_vc_freq[0];
-    }
-    return ui_recent_activity_vc_freq(state);
+    /* The chain lives in app-control so the terminal, the Qt panel and the Android
+       notification cannot disagree about which frequency a call is on. */
+    return dsd_app_vc_freq(state);
 }

--- a/src/ui/terminal/ncurses_p25_display.c
+++ b/src/ui/terminal/ncurses_p25_display.c
@@ -612,7 +612,7 @@ ui_print_p25_sm_overview(const dsd_state* state) {
 
 static int
 ui_print_p25_cc_vc_metric(const dsd_state* state) {
-    long cc = (state->trunk_cc_freq != 0) ? state->trunk_cc_freq : state->p25_cc_freq;
+    long cc = dsd_app_cc_freq(state);
     long vc = ui_guess_active_vc_freq(state);
     char cc_buf[48];
     char vc_buf[48];

--- a/src/ui/terminal/ncurses_p25_display.c
+++ b/src/ui/terminal/ncurses_p25_display.c
@@ -24,7 +24,6 @@
 #include <dsd-neo/ui/ncurses_internal.h>
 #include <dsd-neo/ui/ncurses_p25_display.h>
 #include <dsd-neo/ui/ui_prims.h>
-#include <stdint.h>
 #include <string.h>
 #include <time.h>
 #include "dsd-neo/core/opts_fwd.h"

--- a/src/ui/terminal/ncurses_p25_display.c
+++ b/src/ui/terminal/ncurses_p25_display.c
@@ -25,7 +25,6 @@
 #include <dsd-neo/ui/ncurses_p25_display.h>
 #include <dsd-neo/ui/ui_prims.h>
 #include <stdint.h>
-#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include "dsd-neo/core/opts_fwd.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1520,6 +1520,26 @@ target_link_libraries(
 )
 add_test(NAME APP_CONTROL_CALL_VIEW COMMAND dsd-neo_test_app_control_call_view)
 
+add_executable(
+    dsd-neo_test_app_control_notification_status
+    ui/test_app_control_notification_status.c
+    ${PROJECT_SOURCE_DIR}/src/app_control/notification_status.c
+    ${PROJECT_SOURCE_DIR}/src/app_control/call_view.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/synctype.c
+)
+target_include_directories(
+    dsd-neo_test_app_control_notification_status
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/app_control
+)
+target_link_libraries(
+    dsd-neo_test_app_control_notification_status
+    PRIVATE dsd-neo_test_call_state_support dsd-neo_platform
+)
+add_test(
+    NAME APP_CONTROL_NOTIFICATION_STATUS
+    COMMAND dsd-neo_test_app_control_notification_status
+)
+
 if(DSD_ENABLE_TERMINAL_UI)
     add_executable(
         dsd-neo_test_ui_ncurses_trunk_display_helpers
@@ -2403,6 +2423,9 @@ add_executable(
     ui/test_ui_snapshot_event_history.c
     ${PROJECT_SOURCE_DIR}/src/core/util/talkgroup_policy.c
     ${PROJECT_SOURCE_DIR}/src/core/util/enc_lockout.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/synctype.c
+    ${PROJECT_SOURCE_DIR}/src/app_control/call_view.c
+    ${PROJECT_SOURCE_DIR}/src/app_control/notification_status.c
     ${PROJECT_SOURCE_DIR}/src/app_control/ui_snapshot.c
     ${PROJECT_SOURCE_DIR}/src/runtime/trunk_cc_candidates.c
     ${PROJECT_SOURCE_DIR}/tests/test_support/csv_import_stub.c
@@ -2428,6 +2451,9 @@ add_executable(
     dsd-neo_test_app_control_opts_snapshot
     ui/test_ui_opts_snapshot.c
     ${PROJECT_SOURCE_DIR}/src/app_control/ui_opts_snapshot.c
+    ${PROJECT_SOURCE_DIR}/src/app_control/call_view.c
+    ${PROJECT_SOURCE_DIR}/src/app_control/notification_status.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/synctype.c
 )
 target_include_directories(
     dsd-neo_test_app_control_opts_snapshot
@@ -2435,7 +2461,7 @@ target_include_directories(
 )
 target_link_libraries(
     dsd-neo_test_app_control_opts_snapshot
-    PRIVATE dsd-neo_platform
+    PRIVATE dsd-neo_test_call_state_support dsd-neo_platform
 )
 add_test(
     NAME APP_CONTROL_OPTS_SNAPSHOT

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1544,6 +1544,7 @@ if(DSD_ENABLE_TERMINAL_UI)
     add_executable(
         dsd-neo_test_ui_ncurses_p25_display_helpers
         ui/test_ui_ncurses_p25_display_helpers.c
+        ${PROJECT_SOURCE_DIR}/src/app_control/call_view.c
     )
     target_compile_definitions(
         dsd-neo_test_ui_ncurses_p25_display_helpers

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -416,6 +416,12 @@ dsd_neo_add_public_header_smoke_test(
 )
 
 dsd_neo_add_public_header_smoke_test(
+  dsd-neo_test_headers_public_app_control_call_view
+  HEADERS_PUBLIC_APP_CONTROL_CALL_VIEW
+  dsd-neo/app_control/call_view.h
+  C
+)
+dsd_neo_add_public_header_smoke_test(
   dsd-neo_test_headers_public_app_control_commands
   HEADERS_PUBLIC_APP_CONTROL_COMMANDS
   dsd-neo/app_control/commands.h
@@ -438,6 +444,21 @@ dsd_neo_add_public_header_smoke_test(
   HEADERS_PUBLIC_APP_CONTROL_HISTORY
   dsd-neo/app_control/history.h
   C
+)
+dsd_neo_add_public_header_smoke_test(
+  dsd-neo_test_headers_public_app_control_notification_status
+  HEADERS_PUBLIC_APP_CONTROL_NOTIFICATION_STATUS
+  dsd-neo/app_control/notification_status.h
+  C
+)
+# Also as C++: the only consumer of this header anywhere is android/dsdneo_jni.cpp, which
+# no Linux/macOS/Windows CI job ever compiles, so nothing else would catch it losing its
+# extern "C" guard or a transitively-needed include.
+dsd_neo_add_public_header_smoke_test(
+  dsd-neo_test_headers_public_app_control_notification_status_cxx
+  HEADERS_PUBLIC_APP_CONTROL_NOTIFICATION_STATUS_CXX
+  dsd-neo/app_control/notification_status.h
+  CXX
 )
 dsd_neo_add_public_header_smoke_test(
   dsd-neo_test_headers_public_app_control_snapshot

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2061,12 +2061,22 @@ target_include_directories(
 )
 add_test(NAME UI_QT_SESSION_STATE COMMAND dsd-neo_test_ui_qt_session_state)
 
-# Same arrangement for the slot-line decay: header-only and free of Qt so the hold
-# window can be tested without an Android build.
-add_executable(dsd-neo_test_ui_qt_call_line ui/test_ui_qt_call_line.cpp)
+# Same arrangement for the slot-line decay: free of Qt so the hold window can be tested
+# without an Android build. call_line.h now delegates to app_control's call_view, so
+# this links the same call_view.c the app_control test below compiles, plus the
+# lightweight call-state support lib it calls into.
+add_executable(
+    dsd-neo_test_ui_qt_call_line
+    ui/test_ui_qt_call_line.cpp
+    ${PROJECT_SOURCE_DIR}/src/app_control/call_view.c
+)
 target_include_directories(
     dsd-neo_test_ui_qt_call_line
     PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/qt
+)
+target_link_libraries(
+    dsd-neo_test_ui_qt_call_line
+    PRIVATE dsd-neo_test_call_state_support
 )
 add_test(NAME UI_QT_CALL_LINE COMMAND dsd-neo_test_ui_qt_call_line)
 
@@ -2127,10 +2137,14 @@ if(DSD_ENABLE_QT_UI)
     # anything reads as "it is working" while nothing is being decoded, which is
     # exactly what shipped once. The frontend boundary is stubbed in the test so
     # this stays arithmetic over a snapshot rather than a link against the engine.
+    # slotCallView() now delegates to app_control's call_view, so call_view.c is
+    # compiled in too; it needs nothing beyond dsd_call_state_get(), which
+    # dsd-neo_core (below) already provides.
     add_executable(
         dsd-neo_test_ui_qt_metrics_model
         ui/test_ui_qt_metrics_model.cpp
         ${PROJECT_SOURCE_DIR}/src/ui/qt/metrics_model.cpp
+        ${PROJECT_SOURCE_DIR}/src/app_control/call_view.c
     )
     target_include_directories(
         dsd-neo_test_ui_qt_metrics_model

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1505,6 +1505,21 @@ add_test(
     COMMAND dsd-neo_test_app_control_telemetry_hooks_install
 )
 
+add_executable(
+    dsd-neo_test_app_control_call_view
+    ui/test_app_control_call_view.c
+    ${PROJECT_SOURCE_DIR}/src/app_control/call_view.c
+)
+target_include_directories(
+    dsd-neo_test_app_control_call_view
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/app_control
+)
+target_link_libraries(
+    dsd-neo_test_app_control_call_view
+    PRIVATE dsd-neo_test_call_state_support
+)
+add_test(NAME APP_CONTROL_CALL_VIEW COMMAND dsd-neo_test_app_control_call_view)
+
 if(DSD_ENABLE_TERMINAL_UI)
     add_executable(
         dsd-neo_test_ui_ncurses_trunk_display_helpers

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -637,6 +637,10 @@ class Setup : public QObject {
             metrics[p + QStringLiteral("EncText")] = QString();
             metrics[p + QStringLiteral("TgId")] = 0;
         }
+        // Which slot the hero headlines, one-based, 0 for neither. Derived natively by
+        // dsd_app_lead_slot() in the real model; here it is a plain reading a case sets
+        // alongside the slotNCallState it is meant to agree with.
+        metrics[QStringLiteral("leadSlot")] = 0;
         // Targets the encrypted lockout is skipping; 0 is the at-rest value.
         metrics[QStringLiteral("encLockoutCount")] = 0;
         // Whether an automatic controller owns the tuner, which one, and where it

--- a/tests/ui/test_app_control_call_view.c
+++ b/tests/ui/test_app_control_call_view.c
@@ -33,6 +33,30 @@ observe_group_call(dsd_state* state, uint8_t slot, uint64_t target, uint64_t sou
     assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
 }
 
+/* Like make_state(), but also attaches a two-slot event history array so
+   staged_group_name() has something to read instead of always taking its
+   NULL-history early return. */
+static dsd_state*
+make_state_with_history(Event_History_I** history_out) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    assert(state != NULL);
+    assert(dsd_call_state_ensure(state) > 0);
+    Event_History_I* history = (Event_History_I*)calloc(DSD_CALL_STATE_SLOT_COUNT, sizeof(Event_History_I));
+    assert(history != NULL);
+    state->event_history_s = history;
+    *history_out = history;
+    return state;
+}
+
+/* Stage a CSV-imported group name on the slot's active (index 0) history row,
+   the same row staged_group_name() reads. */
+static void
+stage_group_name(Event_History_I* history, uint8_t slot, uint32_t target_id, const char* name) {
+    Event_History* item = &history[slot].Event_History_Items[0];
+    item->target_id = target_id;
+    DSD_SNPRINTF(item->t_name, sizeof(item->t_name), "%s", name);
+}
+
 static void
 test_idle_slot_reports_none(void) {
     dsd_state* state = make_state();
@@ -58,6 +82,63 @@ test_active_call_reports_identity(void) {
     assert(view.tg_id == 51023U);
     assert(view.enc == 0U);
     assert(view.elapsed_ms >= 1900U && view.elapsed_ms <= 2100U);
+    free(state);
+}
+
+static void
+test_tg_id_falls_back_to_policy_target_id(void) {
+    dsd_state* state = make_state();
+    dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 0U, 0U, 0U);
+    observation.kind = DSD_CALL_KIND_GROUP_VOICE;
+    observation.policy_target_id = 654321U;
+    observation.observed_m = 10.0;
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 10.5, &view);
+    assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
+    /* No OTA target ever decoded, so tg_id falls back to the policy-resolved id
+       instead of staying 0. */
+    assert(view.tg_id == 654321U);
+    /* tg_text still falls back to the (zero) OTA numeric id: policy resolution
+       feeds tg_id/name lookups, not the OTA display text. */
+    assert(strcmp(view.tg_text, "0") == 0);
+    free(state);
+}
+
+static void
+test_target_text_used_verbatim(void) {
+    dsd_state* state = make_state();
+    observe_group_call(state, 0U, 0U, 0U, 10.0);
+
+    dsd_call_snapshot snapshot;
+    assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
+    assert(dsd_call_state_enrich_text(state, 0U, snapshot.epoch, NULL, "DISPATCH-1", NULL, NULL, 10.05) == 1);
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 12.0, &view);
+    /* Text identity alone -- no numeric target ever decoded -- is enough to
+       keep the call from reading idle, and is used verbatim over the (zero)
+       numeric fallback. */
+    assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
+    assert(strcmp(view.tg_text, "DISPATCH-1") == 0);
+    assert(strcmp(view.name, "DISPATCH-1") == 0);
+    free(state);
+}
+
+static void
+test_source_text_used_verbatim(void) {
+    dsd_state* state = make_state();
+    observe_group_call(state, 0U, 0U, 0U, 10.0);
+
+    dsd_call_snapshot snapshot;
+    assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
+    assert(dsd_call_state_enrich_text(state, 0U, snapshot.epoch, "N0CALL", NULL, NULL, NULL, 10.05) == 1);
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 12.0, &view);
+    assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
+    assert(strcmp(view.src_text, "N0CALL") == 0);
     free(state);
 }
 
@@ -88,6 +169,44 @@ test_identityless_epoch_reads_idle(void) {
     dsd_app_slot_call view;
     dsd_app_slot_call_view(state, 0U, 10.5, &view);
     assert(view.state == DSD_APP_CALL_LINE_IDLE);
+    free(state);
+}
+
+static void
+test_route_text_leg0_confers_identity(void) {
+    dsd_state* state = make_state();
+    /* Same identity-less baseline as test_identityless_epoch_reads_idle(): no
+       numeric ids, no source/target text. Without the enrichment below this
+       reads idle. */
+    observe_group_call(state, 0U, 0U, 0U, 10.0);
+
+    dsd_call_snapshot snapshot;
+    assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
+    /* D-STAR/NXDN/YSF can decode the first repeater leg before either callsign;
+       that alone must count as a named transmission, matching
+       dsd_call_state_snapshot_has_identity(). */
+    assert(dsd_call_state_enrich_text(state, 0U, snapshot.epoch, NULL, NULL, "RPT1 GATEWAY", NULL, 10.05) == 1);
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 10.5, &view);
+    assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
+    free(state);
+}
+
+static void
+test_route_text_leg1_confers_identity(void) {
+    dsd_state* state = make_state();
+    observe_group_call(state, 0U, 0U, 0U, 10.0);
+
+    dsd_call_snapshot snapshot;
+    assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
+    /* Same as leg0, but only the second repeater leg decoded. Either leg alone
+       must be enough -- call_has_no_identity() ANDs both being empty. */
+    assert(dsd_call_state_enrich_text(state, 0U, snapshot.epoch, NULL, NULL, NULL, "RPT2 GATEWAY", 10.05) == 1);
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 10.5, &view);
+    assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
     free(state);
 }
 
@@ -128,6 +247,99 @@ test_encrypted_call_carries_alg_and_kid(void) {
     free(state);
 }
 
+/* call_reads_encrypted() treats ENCRYPTED, ENCRYPTED_PENDING and DECRYPTABLE as
+   equally "encrypted over the air" -- the same three-way definition the event
+   ring stamps on history rows. Exercised for all three so a regression that
+   narrows the check to plain ENCRYPTED fails here. */
+static void
+test_crypto_classification_reads_encrypted(dsd_call_crypto_state classification) {
+    dsd_state* state = make_state();
+    observe_group_call(state, 0U, 51023U, 1234567U, 10.0);
+
+    dsd_call_crypto_update crypto;
+    DSD_MEMSET(&crypto, 0, sizeof(crypto));
+    crypto.classification = classification;
+    crypto.algid = 0xAAU;
+    crypto.kid = 0x2222U;
+    crypto.observed_m = 10.1;
+    assert(dsd_call_state_update_crypto(state, 0U, &crypto) > 0);
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 11.0, &view);
+    assert(view.enc == 1U);
+    assert(view.algid == 0xAAU);
+    assert(view.kid == 0x2222U);
+    free(state);
+}
+
+static void
+test_staged_group_name_used_when_target_matches(void) {
+    Event_History_I* history = NULL;
+    dsd_state* state = make_state_with_history(&history);
+    observe_group_call(state, 0U, 51023U, 1234567U, 10.0);
+    stage_group_name(history, 0U, 51023U, "Metro Fire Dispatch");
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 12.0, &view);
+    assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
+    assert(strcmp(view.name, "Metro Fire Dispatch") == 0);
+    /* The staged name replaces the display name; it does not touch tg_text. */
+    assert(strcmp(view.tg_text, "51023") == 0);
+    free(history);
+    free(state);
+}
+
+static void
+test_staged_group_name_ignored_for_other_talkgroup(void) {
+    Event_History_I* history = NULL;
+    dsd_state* state = make_state_with_history(&history);
+    observe_group_call(state, 0U, 51023U, 1234567U, 10.0);
+    /* Staged row describes a previous call on a different talkgroup and must
+       not caption this one -- the guarantee staged_group_name()'s doc comment
+       makes, and the most valuable case here: a broken target_id comparison
+       would let a stale name bleed into the next call. */
+    stage_group_name(history, 0U, 99999U, "Old Talkgroup");
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 12.0, &view);
+    assert(strcmp(view.name, "51023") == 0);
+    free(history);
+    free(state);
+}
+
+static void
+test_staged_group_name_ignored_when_empty(void) {
+    Event_History_I* history = NULL;
+    dsd_state* state = make_state_with_history(&history);
+    observe_group_call(state, 0U, 51023U, 1234567U, 10.0);
+    /* target_id matches, but the row's t_name was never populated (no CSV
+       import staged one). */
+    history[0].Event_History_Items[0].target_id = 51023U;
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 12.0, &view);
+    assert(strcmp(view.name, "51023") == 0);
+    free(history);
+    free(state);
+}
+
+static void
+test_staged_group_name_respects_slot(void) {
+    Event_History_I* history = NULL;
+    dsd_state* state = make_state_with_history(&history);
+    observe_group_call(state, 0U, 51023U, 1234567U, 10.0);
+    /* Same talkgroup id staged on the *other* slot must not caption slot 0:
+       a regression that dropped the slot index from staged_group_name()'s
+       lookup would pass every other test in this file. */
+    stage_group_name(history, 1U, 51023U, "Wrong Slot");
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 12.0, &view);
+    assert(strcmp(view.name, "51023") == 0);
+    free(history);
+    free(state);
+}
+
 static void
 test_call_line_state_boundaries(void) {
     dsd_call_snapshot call;
@@ -145,6 +357,10 @@ test_call_line_state_boundaries(void) {
     call.phase = DSD_CALL_PHASE_ENDED;
     call.ended_m = 10.0;
     assert(dsd_app_call_line_state(1, &call, 12.0, 3.0) == DSD_APP_CALL_LINE_ENDED);
+    /* Exactly at hold_s the comparison is strict less-than, not less-or-equal,
+       so equality already reads idle rather than getting one extra tick of
+       grace. */
+    assert(dsd_app_call_line_state(1, &call, 13.0, 3.0) == DSD_APP_CALL_LINE_IDLE);
     assert(dsd_app_call_line_state(1, &call, 14.0, 3.0) == DSD_APP_CALL_LINE_IDLE);
     /* An end stamped a hair ahead of the poll counts as fresh, not as an expiry. */
     assert(dsd_app_call_line_state(1, &call, 9.9, 3.0) == DSD_APP_CALL_LINE_ENDED);
@@ -162,10 +378,21 @@ int
 main(void) {
     test_idle_slot_reports_none();
     test_active_call_reports_identity();
+    test_tg_id_falls_back_to_policy_target_id();
+    test_target_text_used_verbatim();
+    test_source_text_used_verbatim();
     test_ended_call_holds_then_expires();
     test_identityless_epoch_reads_idle();
+    test_route_text_leg0_confers_identity();
+    test_route_text_leg1_confers_identity();
     test_x2tdma_identityless_epoch_still_shows();
     test_encrypted_call_carries_alg_and_kid();
+    test_crypto_classification_reads_encrypted(DSD_CALL_CRYPTO_ENCRYPTED_PENDING);
+    test_crypto_classification_reads_encrypted(DSD_CALL_CRYPTO_DECRYPTABLE);
+    test_staged_group_name_used_when_target_matches();
+    test_staged_group_name_ignored_for_other_talkgroup();
+    test_staged_group_name_ignored_when_empty();
+    test_staged_group_name_respects_slot();
     test_call_line_state_boundaries();
     test_null_arguments_are_safe();
     printf("APP_CONTROL_CALL_VIEW ok\n");

--- a/tests/ui/test_app_control_call_view.c
+++ b/tests/ui/test_app_control_call_view.c
@@ -374,6 +374,23 @@ test_null_arguments_are_safe(void) {
     dsd_app_slot_call_view(NULL, 0U, 10.0, NULL);
 }
 
+static void
+test_seconds_truncation_matches_qt_adapter(void) {
+    /* Qt renders whole seconds as (int)(elapsed_ms / 1000). Pin the boundaries so the
+       adapter's integer division cannot drift from the old (int)elapsed_seconds. */
+    dsd_state* state = make_state();
+    observe_group_call(state, 0U, 51023U, 1234567U, 10.0);
+
+    dsd_app_slot_call just_under;
+    dsd_app_slot_call_view(state, 0U, 12.999, &just_under);
+    assert(just_under.elapsed_ms / 1000U == 2U);
+
+    dsd_app_slot_call just_over;
+    dsd_app_slot_call_view(state, 0U, 13.001, &just_over);
+    assert(just_over.elapsed_ms / 1000U == 3U);
+    free(state);
+}
+
 int
 main(void) {
     test_idle_slot_reports_none();
@@ -395,6 +412,7 @@ main(void) {
     test_staged_group_name_respects_slot();
     test_call_line_state_boundaries();
     test_null_arguments_are_safe();
+    test_seconds_truncation_matches_qt_adapter();
     printf("APP_CONTROL_CALL_VIEW ok\n");
     return 0;
 }

--- a/tests/ui/test_app_control_call_view.c
+++ b/tests/ui/test_app_control_call_view.c
@@ -391,6 +391,55 @@ test_seconds_truncation_matches_qt_adapter(void) {
     free(state);
 }
 
+static void
+test_vc_freq_prefers_canonical_active_p25_call(void) {
+    dsd_state* state = make_state();
+    state->trunk_vc_freq[0] = 852012500L;
+
+    dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 0U, 1234567U, 51023U);
+    observation.kind = DSD_CALL_KIND_GROUP_VOICE;
+    observation.frequency_hz = 851012500;
+    observation.observed_m = 10.0;
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
+
+    /* Step 1 of the chain wins over the trunk_vc_freq fallback. */
+    assert(dsd_app_vc_freq(state) == 851012500L);
+    free(state);
+}
+
+static void
+test_vc_freq_falls_back_through_the_chain(void) {
+    dsd_state* state = make_state();
+    assert(dsd_app_vc_freq(state) == 0L);
+
+    state->p25_vc_freq[0] = 853012500L;
+    assert(dsd_app_vc_freq(state) == 853012500L);
+
+    /* trunk_vc_freq outranks p25_vc_freq. */
+    state->trunk_vc_freq[0] = 852012500L;
+    assert(dsd_app_vc_freq(state) == 852012500L);
+    free(state);
+}
+
+static void
+test_cc_freq_prefers_trunk_over_p25(void) {
+    dsd_state* state = make_state();
+    assert(dsd_app_cc_freq(state) == 0L);
+
+    state->p25_cc_freq = 851512500L;
+    assert(dsd_app_cc_freq(state) == 851512500L);
+
+    state->trunk_cc_freq = 851612500L;
+    assert(dsd_app_cc_freq(state) == 851612500L);
+    free(state);
+}
+
+static void
+test_freq_helpers_are_null_safe(void) {
+    assert(dsd_app_vc_freq(NULL) == 0L);
+    assert(dsd_app_cc_freq(NULL) == 0L);
+}
+
 int
 main(void) {
     test_idle_slot_reports_none();
@@ -413,6 +462,10 @@ main(void) {
     test_call_line_state_boundaries();
     test_null_arguments_are_safe();
     test_seconds_truncation_matches_qt_adapter();
+    test_vc_freq_prefers_canonical_active_p25_call();
+    test_vc_freq_falls_back_through_the_chain();
+    test_cc_freq_prefers_trunk_over_p25();
+    test_freq_helpers_are_null_safe();
     printf("APP_CONTROL_CALL_VIEW ok\n");
     return 0;
 }

--- a/tests/ui/test_app_control_call_view.c
+++ b/tests/ui/test_app_control_call_view.c
@@ -342,6 +342,35 @@ test_staged_group_name_respects_slot(void) {
     free(state);
 }
 
+/* The CSV group name is the only field here whose source is wider than the canonical
+   call state's identity text: Event_History::t_name is a char[200], while target_text
+   and source_text are char[DSD_CALL_IDENTITY_TEXT_SIZE]. Sizing name like the latter
+   two truncated long aliases -- the Qt monitor's heroName -- at 63 characters, and no
+   test noticed because every other staged-name case here uses a short name. */
+static void
+test_staged_group_name_longer_than_identity_text_survives(void) {
+    Event_History_I* history = NULL;
+    dsd_state* state = make_state_with_history(&history);
+    observe_group_call(state, 0U, 51023U, 1234567U, 10.0);
+
+    /* 199 characters: exactly what t_name can hold, and what a CSV import can stage. */
+    char alias[200];
+    DSD_MEMSET(alias, 'A', sizeof(alias) - 1U);
+    alias[sizeof(alias) - 1U] = '\0';
+    /* Distinct tail, so a truncation cannot pass by matching a prefix. */
+    DSD_MEMCPY(alias + 190, "TAILEND", 7U);
+    stage_group_name(history, 0U, 51023U, alias);
+    assert(strlen(history[0].Event_History_Items[0].t_name) == 199U);
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 12.0, &view);
+    assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
+    assert(strlen(view.name) == 199U);
+    assert(strcmp(view.name, alias) == 0);
+    free(history);
+    free(state);
+}
+
 static void
 test_call_line_state_boundaries(void) {
     dsd_call_snapshot call;
@@ -461,6 +490,7 @@ main(void) {
     test_staged_group_name_ignored_for_other_talkgroup();
     test_staged_group_name_ignored_when_empty();
     test_staged_group_name_respects_slot();
+    test_staged_group_name_longer_than_identity_text_survives();
     test_call_line_state_boundaries();
     test_null_arguments_are_safe();
     test_seconds_truncation_matches_qt_adapter();

--- a/tests/ui/test_app_control_call_view.c
+++ b/tests/ui/test_app_control_call_view.c
@@ -241,6 +241,45 @@ test_x2tdma_identityless_epoch_still_shows(void) {
     destroy_state(state);
 }
 
+/* The other half of call_has_no_identity()'s protocol exception. Only the X2-TDMA arm was
+   covered, so deleting DSD_SYNC_IS_PROVOICE() from that test left the whole suite green
+   while every standalone ProVoice transmission read IDLE on the terminal, the Qt hero
+   panel and the Android notification at once -- with audio playing and history rows being
+   written the whole time. */
+static void
+test_provoice_identityless_epoch_still_shows(void) {
+    dsd_state* state = make_state();
+    dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_PROVOICE_POS, 0U, 0U, 0U);
+    observation.kind = DSD_CALL_KIND_VOICE;
+    observation.observed_m = 10.0;
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 10.5, &view);
+    assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
+    destroy_state(state);
+}
+
+/* A numeric source and nothing else is identity enough. Every other case here gives the
+   call a target as well, so the ota_source_id conjunct in call_has_no_identity() was
+   unpinned: dropping it suppressed unit-to-unit traffic -- NXDN, dPMR and DMR private
+   calls, where the source routinely decodes before any target does -- on all three
+   surfaces, with nothing failing. */
+static void
+test_source_id_alone_confers_identity(void) {
+    dsd_state* state = make_state();
+    dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_NXDN_POS, 0U, 4242U, 0U);
+    observation.kind = DSD_CALL_KIND_PRIVATE_VOICE;
+    observation.observed_m = 10.0;
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 10.5, &view);
+    assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
+    assert(strcmp(view.src_text, "4242") == 0);
+    destroy_state(state);
+}
+
 static void
 test_encrypted_call_carries_alg_and_kid(void) {
     dsd_state* state = make_state();
@@ -520,6 +559,8 @@ main(void) {
     test_route_text_leg0_confers_identity();
     test_route_text_leg1_confers_identity();
     test_x2tdma_identityless_epoch_still_shows();
+    test_provoice_identityless_epoch_still_shows();
+    test_source_id_alone_confers_identity();
     test_encrypted_call_carries_alg_and_kid();
     test_crypto_classification_reads_encrypted(DSD_CALL_CRYPTO_ENCRYPTED_PENDING);
     test_crypto_classification_reads_encrypted(DSD_CALL_CRYPTO_DECRYPTABLE);

--- a/tests/ui/test_app_control_call_view.c
+++ b/tests/ui/test_app_control_call_view.c
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Shared slot-call display decision, independent of any frontend.
+ */
+
+#include <assert.h>
+#include <dsd-neo/app_control/call_view.h>
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static dsd_state*
+make_state(void) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    assert(state != NULL);
+    assert(dsd_call_state_ensure(state) > 0);
+    return state;
+}
+
+static void
+observe_group_call(dsd_state* state, uint8_t slot, uint64_t target, uint64_t source, double now_m) {
+    dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, slot, source, target);
+    observation.kind = DSD_CALL_KIND_GROUP_VOICE;
+    observation.observed_m = now_m;
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
+}
+
+static void
+test_idle_slot_reports_none(void) {
+    dsd_state* state = make_state();
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 10.0, &view);
+    assert(view.state == DSD_APP_CALL_LINE_NONE);
+    assert(view.tg_text[0] == '\0');
+    free(state);
+}
+
+static void
+test_active_call_reports_identity(void) {
+    dsd_state* state = make_state();
+    observe_group_call(state, 0U, 51023U, 1234567U, 10.0);
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 12.0, &view);
+    assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
+    assert(strcmp(view.tg_text, "51023") == 0);
+    assert(strcmp(view.src_text, "1234567") == 0);
+    /* No CSV group name staged, so the name falls back to the talkgroup text. */
+    assert(strcmp(view.name, "51023") == 0);
+    assert(view.tg_id == 51023U);
+    assert(view.enc == 0U);
+    assert(view.elapsed_ms >= 1900U && view.elapsed_ms <= 2100U);
+    free(state);
+}
+
+static void
+test_ended_call_holds_then_expires(void) {
+    dsd_state* state = make_state();
+    observe_group_call(state, 0U, 51023U, 1234567U, 10.0);
+    assert(dsd_call_state_end_ex(state, 0U, 12.0, DSD_CALL_END_TERMINATOR) > 0);
+
+    dsd_app_slot_call held;
+    dsd_app_slot_call_view(state, 0U, 13.0, &held);
+    assert(held.state == DSD_APP_CALL_LINE_ENDED);
+    /* Elapsed freezes at the end, it does not keep counting. */
+    assert(held.elapsed_ms >= 1900U && held.elapsed_ms <= 2100U);
+
+    dsd_app_slot_call expired;
+    dsd_app_slot_call_view(state, 0U, 12.0 + DSD_APP_CALL_LINE_ENDED_HOLD_S + 0.5, &expired);
+    assert(expired.state == DSD_APP_CALL_LINE_IDLE);
+    free(state);
+}
+
+static void
+test_identityless_epoch_reads_idle(void) {
+    dsd_state* state = make_state();
+    /* A frame that synced far enough to be a frame and no further. */
+    observe_group_call(state, 0U, 0U, 0U, 10.0);
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 10.5, &view);
+    assert(view.state == DSD_APP_CALL_LINE_IDLE);
+    free(state);
+}
+
+static void
+test_x2tdma_identityless_epoch_still_shows(void) {
+    dsd_state* state = make_state();
+    dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_X2TDMA_VOICE_POS, 0U, 0U, 0U);
+    observation.kind = DSD_CALL_KIND_VOICE;
+    observation.observed_m = 10.0;
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 10.5, &view);
+    /* X2-TDMA never parses voice into a talkgroup, so an identity-less epoch is
+       the whole story the protocol has. Suppressing it would hide real traffic. */
+    assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
+    free(state);
+}
+
+static void
+test_encrypted_call_carries_alg_and_kid(void) {
+    dsd_state* state = make_state();
+    observe_group_call(state, 0U, 51023U, 1234567U, 10.0);
+
+    dsd_call_crypto_update crypto;
+    DSD_MEMSET(&crypto, 0, sizeof(crypto));
+    crypto.classification = DSD_CALL_CRYPTO_ENCRYPTED;
+    crypto.algid = 0x84U;
+    crypto.kid = 0x0101U;
+    crypto.observed_m = 10.1;
+    assert(dsd_call_state_update_crypto(state, 0U, &crypto) > 0);
+
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(state, 0U, 11.0, &view);
+    assert(view.enc == 1U);
+    assert(view.algid == 0x84U);
+    assert(view.kid == 0x0101U);
+    free(state);
+}
+
+static void
+test_call_line_state_boundaries(void) {
+    dsd_call_snapshot call;
+    DSD_MEMSET(&call, 0, sizeof(call));
+
+    /* A non-positive lookup means no epoch on the slot at all. */
+    assert(dsd_app_call_line_state(0, &call, 10.0, 3.0) == DSD_APP_CALL_LINE_NONE);
+
+    call.phase = DSD_CALL_PHASE_ACTIVE;
+    assert(dsd_app_call_line_state(1, &call, 10.0, 3.0) == DSD_APP_CALL_LINE_ACTIVE);
+
+    call.phase = DSD_CALL_PHASE_IDLE;
+    assert(dsd_app_call_line_state(1, &call, 10.0, 3.0) == DSD_APP_CALL_LINE_IDLE);
+
+    call.phase = DSD_CALL_PHASE_ENDED;
+    call.ended_m = 10.0;
+    assert(dsd_app_call_line_state(1, &call, 12.0, 3.0) == DSD_APP_CALL_LINE_ENDED);
+    assert(dsd_app_call_line_state(1, &call, 14.0, 3.0) == DSD_APP_CALL_LINE_IDLE);
+    /* An end stamped a hair ahead of the poll counts as fresh, not as an expiry. */
+    assert(dsd_app_call_line_state(1, &call, 9.9, 3.0) == DSD_APP_CALL_LINE_ENDED);
+}
+
+static void
+test_null_arguments_are_safe(void) {
+    dsd_app_slot_call view;
+    dsd_app_slot_call_view(NULL, 0U, 10.0, &view);
+    assert(view.state == DSD_APP_CALL_LINE_NONE);
+    dsd_app_slot_call_view(NULL, 0U, 10.0, NULL);
+}
+
+int
+main(void) {
+    test_idle_slot_reports_none();
+    test_active_call_reports_identity();
+    test_ended_call_holds_then_expires();
+    test_identityless_epoch_reads_idle();
+    test_x2tdma_identityless_epoch_still_shows();
+    test_encrypted_call_carries_alg_and_kid();
+    test_call_line_state_boundaries();
+    test_null_arguments_are_safe();
+    printf("APP_CONTROL_CALL_VIEW ok\n");
+    return 0;
+}

--- a/tests/ui/test_app_control_call_view.c
+++ b/tests/ui/test_app_control_call_view.c
@@ -12,6 +12,7 @@
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <stdint.h>
@@ -25,6 +26,18 @@ make_state(void) {
     assert(state != NULL);
     assert(dsd_call_state_ensure(state) > 0);
     return state;
+}
+
+/* Counterpart to make_state(): dsd_call_state_ensure() hangs a ~17 KB call-state
+   block off the extension table, so freeing the dsd_state alone leaks it. */
+static void
+destroy_state(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    dsd_state_ext_free_all(state);
+    free(state->event_history_s);
+    free(state);
 }
 
 static void
@@ -66,7 +79,7 @@ test_idle_slot_reports_none(void) {
     dsd_app_slot_call_view(state, 0U, 10.0, &view);
     assert(view.state == DSD_APP_CALL_LINE_NONE);
     assert(view.tg_text[0] == '\0');
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -84,7 +97,7 @@ test_active_call_reports_identity(void) {
     assert(view.tg_id == 51023U);
     assert(view.enc == 0U);
     assert(view.elapsed_ms >= 1900U && view.elapsed_ms <= 2100U);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -105,7 +118,7 @@ test_tg_id_falls_back_to_policy_target_id(void) {
     /* tg_text still falls back to the (zero) OTA numeric id: policy resolution
        feeds tg_id/name lookups, not the OTA display text. */
     assert(strcmp(view.tg_text, "0") == 0);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -125,7 +138,7 @@ test_target_text_used_verbatim(void) {
     assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
     assert(strcmp(view.tg_text, "DISPATCH-1") == 0);
     assert(strcmp(view.name, "DISPATCH-1") == 0);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -141,7 +154,7 @@ test_source_text_used_verbatim(void) {
     dsd_app_slot_call_view(state, 0U, 12.0, &view);
     assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
     assert(strcmp(view.src_text, "N0CALL") == 0);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -159,7 +172,7 @@ test_ended_call_holds_then_expires(void) {
     dsd_app_slot_call expired;
     dsd_app_slot_call_view(state, 0U, 12.0 + DSD_APP_CALL_LINE_ENDED_HOLD_S + 0.5, &expired);
     assert(expired.state == DSD_APP_CALL_LINE_IDLE);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -171,7 +184,7 @@ test_identityless_epoch_reads_idle(void) {
     dsd_app_slot_call view;
     dsd_app_slot_call_view(state, 0U, 10.5, &view);
     assert(view.state == DSD_APP_CALL_LINE_IDLE);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -192,7 +205,7 @@ test_route_text_leg0_confers_identity(void) {
     dsd_app_slot_call view;
     dsd_app_slot_call_view(state, 0U, 10.5, &view);
     assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -209,7 +222,7 @@ test_route_text_leg1_confers_identity(void) {
     dsd_app_slot_call view;
     dsd_app_slot_call_view(state, 0U, 10.5, &view);
     assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -225,7 +238,7 @@ test_x2tdma_identityless_epoch_still_shows(void) {
     /* X2-TDMA never parses voice into a talkgroup, so an identity-less epoch is
        the whole story the protocol has. Suppressing it would hide real traffic. */
     assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -246,7 +259,7 @@ test_encrypted_call_carries_alg_and_kid(void) {
     assert(view.enc == 1U);
     assert(view.algid == 0x84U);
     assert(view.kid == 0x0101U);
-    free(state);
+    destroy_state(state);
 }
 
 /* call_reads_encrypted() treats ENCRYPTED, ENCRYPTED_PENDING and DECRYPTABLE as
@@ -271,7 +284,7 @@ test_crypto_classification_reads_encrypted(dsd_call_crypto_state classification)
     assert(view.enc == 1U);
     assert(view.algid == 0xAAU);
     assert(view.kid == 0x2222U);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -287,8 +300,7 @@ test_staged_group_name_used_when_target_matches(void) {
     assert(strcmp(view.name, "Metro Fire Dispatch") == 0);
     /* The staged name replaces the display name; it does not touch tg_text. */
     assert(strcmp(view.tg_text, "51023") == 0);
-    free(history);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -305,8 +317,7 @@ test_staged_group_name_ignored_for_other_talkgroup(void) {
     dsd_app_slot_call view;
     dsd_app_slot_call_view(state, 0U, 12.0, &view);
     assert(strcmp(view.name, "51023") == 0);
-    free(history);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -321,8 +332,7 @@ test_staged_group_name_ignored_when_empty(void) {
     dsd_app_slot_call view;
     dsd_app_slot_call_view(state, 0U, 12.0, &view);
     assert(strcmp(view.name, "51023") == 0);
-    free(history);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -338,8 +348,7 @@ test_staged_group_name_respects_slot(void) {
     dsd_app_slot_call view;
     dsd_app_slot_call_view(state, 0U, 12.0, &view);
     assert(strcmp(view.name, "51023") == 0);
-    free(history);
-    free(state);
+    destroy_state(state);
 }
 
 /* The CSV group name is the only field here whose source is wider than the canonical
@@ -367,8 +376,7 @@ test_staged_group_name_longer_than_identity_text_survives(void) {
     assert(view.state == DSD_APP_CALL_LINE_ACTIVE);
     assert(strlen(view.name) == 199U);
     assert(strcmp(view.name, alias) == 0);
-    free(history);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -419,7 +427,7 @@ test_seconds_truncation_matches_qt_adapter(void) {
     dsd_app_slot_call just_over;
     dsd_app_slot_call_view(state, 0U, 13.001, &just_over);
     assert(just_over.elapsed_ms / 1000U == 3U);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -435,7 +443,7 @@ test_vc_freq_prefers_canonical_active_p25_call(void) {
 
     /* Step 1 of the chain wins over the trunk_vc_freq fallback. */
     assert(dsd_app_vc_freq(state) == 851012500L);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -449,7 +457,7 @@ test_vc_freq_falls_back_through_the_chain(void) {
     /* trunk_vc_freq outranks p25_vc_freq. */
     state->trunk_vc_freq[0] = 852012500L;
     assert(dsd_app_vc_freq(state) == 852012500L);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -462,13 +470,42 @@ test_cc_freq_prefers_trunk_over_p25(void) {
 
     state->trunk_cc_freq = 851612500L;
     assert(dsd_app_cc_freq(state) == 851612500L);
-    free(state);
+    destroy_state(state);
 }
 
 static void
 test_freq_helpers_are_null_safe(void) {
     assert(dsd_app_vc_freq(NULL) == 0L);
     assert(dsd_app_cc_freq(NULL) == 0L);
+}
+
+/* The headline rule the Qt hero panel and the Android notification share. Both once
+   answered this for themselves and disagreed: on a TDMA system with both slots up the
+   panel headlined slot 1 while the notification headlined whichever call started later,
+   so the same record named different units on the two surfaces. */
+static void
+test_lead_slot_prefers_active_then_lower_slot(void) {
+    const int none[2] = {DSD_APP_CALL_LINE_NONE, DSD_APP_CALL_LINE_IDLE};
+    assert(dsd_app_lead_slot(none, 2U) == -1);
+
+    const int second_only[2] = {DSD_APP_CALL_LINE_IDLE, DSD_APP_CALL_LINE_ACTIVE};
+    assert(dsd_app_lead_slot(second_only, 2U) == 1);
+
+    /* An open epoch outranks a merely-ended one even on the higher slot: the ended hold
+       keeps slot 0 renderable for seconds after its call finished, and headlining it
+       would bury the transmission actually on the air. */
+    const int ended_over_active[2] = {DSD_APP_CALL_LINE_ENDED, DSD_APP_CALL_LINE_ACTIVE};
+    assert(dsd_app_lead_slot(ended_over_active, 2U) == 1);
+
+    /* Equal rank falls to the lower slot, in both directions, so the headline does not
+       swap between two simultaneous transmissions as their relative timings shift. */
+    const int both_active[2] = {DSD_APP_CALL_LINE_ACTIVE, DSD_APP_CALL_LINE_ACTIVE};
+    assert(dsd_app_lead_slot(both_active, 2U) == 0);
+    const int both_ended[2] = {DSD_APP_CALL_LINE_ENDED, DSD_APP_CALL_LINE_ENDED};
+    assert(dsd_app_lead_slot(both_ended, 2U) == 0);
+
+    assert(dsd_app_lead_slot(NULL, 2U) == -1);
+    assert(dsd_app_lead_slot(both_active, 0U) == -1);
 }
 
 int
@@ -498,6 +535,7 @@ main(void) {
     test_vc_freq_falls_back_through_the_chain();
     test_cc_freq_prefers_trunk_over_p25();
     test_freq_helpers_are_null_safe();
+    test_lead_slot_prefers_active_then_lower_slot();
     printf("APP_CONTROL_CALL_VIEW ok\n");
     return 0;
 }

--- a/tests/ui/test_app_control_call_view.c
+++ b/tests/ui/test_app_control_call_view.c
@@ -12,7 +12,9 @@
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/ui/test_app_control_notification_status.c
+++ b/tests/ui/test_app_control_notification_status.c
@@ -11,16 +11,29 @@
 #include <dsd-neo/app_control/call_view.h>
 #include <dsd-neo/app_control/notification_status.h>
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/platform/threading.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* The record's shape, spelled out rather than left as a bare total: DecoderStatus.kt
+   mirrors it as HEADER_FIELDS/SLOT_FIELDS, and a field added on one side without the
+   other makes parse() return null for every record -- at which point the notification
+   silently stops updating, with nothing logged on either side of JNI. Split the same way
+   the Kotlin constants are so the two read as the same statement. */
+enum {
+    NOTIFICATION_HEADER_FIELDS = 9, /**< version, protocol, 3 flags, 3 frequencies, lead slot. */
+    NOTIFICATION_SLOT_FIELDS = 9,   /**< state, name, tg, src, tg_id, enc, algid, kid, elapsed. */
+    NOTIFICATION_TOTAL_FIELDS = NOTIFICATION_HEADER_FIELDS + NOTIFICATION_SLOT_FIELDS * DSD_CALL_STATE_SLOT_COUNT,
+};
 
 static dsd_state*
 make_state(void) {
@@ -29,6 +42,18 @@ make_state(void) {
     assert(dsd_call_state_ensure(state) > 0);
     state->synctype = DSD_SYNC_NONE;
     return state;
+}
+
+/* Counterpart to make_state(): dsd_call_state_ensure() hangs a ~17 KB call-state
+   block off the extension table, so freeing the dsd_state alone leaks it. */
+static void
+destroy_state(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    dsd_state_ext_free_all(state);
+    free(state->event_history_s);
+    free(state);
 }
 
 /* MUST run first in main(): it is the only point at which nothing has been published
@@ -48,6 +73,10 @@ test_get_before_any_publish_reports_nothing(void) {
     assert(status.center_freq_hz == 0);
     assert(status.slots[0].state == DSD_APP_CALL_LINE_NONE);
     assert(status.slots[1].state == DSD_APP_CALL_LINE_NONE);
+    /* The one field that is not simply zeroed: 0 is a real slot index, so a caller
+       rendering straight from the struct would headline slot 0 on a process that has
+       published nothing at all. */
+    assert(status.lead_slot == -1);
 }
 
 static void
@@ -58,7 +87,7 @@ test_publish_state_carries_protocol_and_call(void) {
     dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 0U, 1234567U, 51023U);
     observation.kind = DSD_CALL_KIND_GROUP_VOICE;
     observation.frequency_hz = 851012500;
-    observation.observed_m = dsd_app_notification_test_now_m();
+    observation.observed_m = dsd_time_now_monotonic_s();
     assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
 
     dsd_app_notification_publish_state(state);
@@ -69,13 +98,18 @@ test_publish_state_carries_protocol_and_call(void) {
     assert(status.vc_freq_hz == 851012500);
     assert(status.slots[0].state == DSD_APP_CALL_LINE_ACTIVE);
     assert(strcmp(status.slots[0].tg_text, "51023") == 0);
-    free(state);
+    destroy_state(state);
 }
 
 static void
 test_unsynced_publishes_empty_protocol(void) {
     dsd_state* state = make_state();
     state->synctype = DSD_SYNC_NONE;
+    /* The label is held for a few seconds after the last frame that carried one, so a
+       session that has never synced has to start from a cleared hold rather than from
+       whatever the test above left behind -- which, in a suite that runs in
+       microseconds, is still inside the window. */
+    dsd_app_notification_reset();
     dsd_app_notification_publish_state(state);
 
     dsd_app_notification_status status;
@@ -83,7 +117,28 @@ test_unsynced_publishes_empty_protocol(void) {
     /* NONE and UNKNOWN are not labels worth showing; an empty string is what tells an
        unsynced session from a locked one. */
     assert(status.protocol[0] == '\0');
-    free(state);
+    destroy_state(state);
+}
+
+/* The hold itself: a frame that finds no sync must not blank a label the frame before it
+   published. getFrameSync() answers NONE on most iterations of a hunt, so publishing the
+   instantaneous value made the label blink -- and, because the record changed each time,
+   made the Android service re-post its notification once a second on a silent channel. */
+static void
+test_sync_label_is_held_across_a_frame_with_no_sync(void) {
+    dsd_state* state = make_state();
+    dsd_app_notification_reset();
+
+    state->synctype = DSD_SYNC_P25P2_POS;
+    dsd_app_notification_publish_state(state);
+
+    state->synctype = DSD_SYNC_NONE;
+    dsd_app_notification_publish_state(state);
+
+    dsd_app_notification_status status;
+    assert(dsd_app_notification_get(&status) == 1);
+    assert(strcmp(status.protocol, "P25p2") == 0);
+    destroy_state(state);
 }
 
 static void
@@ -136,7 +191,55 @@ test_revision_advances_on_each_publish(void) {
     dsd_app_notification_status second;
     assert(dsd_app_notification_get(&second) == 1);
     assert(second.revision > first.revision);
-    free(state);
+    destroy_state(state);
+}
+
+/* The headline choice rides the wire rather than being remade by the reader. DecoderStatus.kt
+   used to pick for itself and picked differently from the Qt hero panel, so the shade and
+   the app named different units at the same instant on a two-slot system. */
+static void
+test_lead_slot_is_published_and_survives_encoding(void) {
+    dsd_state* state = make_state();
+    dsd_app_notification_reset();
+
+    dsd_app_notification_status status;
+    dsd_app_notification_publish_state(state);
+    assert(dsd_app_notification_get(&status) == 1);
+    /* -1, not 0: 0 is a real slot index, and a reader rendering straight from the struct
+       would headline slot 0 on a session with nothing on the air. */
+    assert(status.lead_slot == -1);
+
+    /* Slot 1 alone: the lead is the slot with the call, not simply the lowest one. */
+    dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 1U, 1234567U, 51023U);
+    observation.kind = DSD_CALL_KIND_GROUP_VOICE;
+    observation.observed_m = dsd_time_now_monotonic_s();
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    dsd_app_notification_publish_state(state);
+    assert(dsd_app_notification_get(&status) == 1);
+    assert(status.lead_slot == 1);
+
+    /* Both up: the lower slot takes the headline, matching MonitorScreen.qml's hero. */
+    dsd_call_observation other = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 0U, 7654321U, 51024U);
+    other.kind = DSD_CALL_KIND_GROUP_VOICE;
+    other.observed_m = dsd_time_now_monotonic_s();
+    assert(dsd_call_state_observe(state, &other, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    dsd_app_notification_publish_state(state);
+    assert(dsd_app_notification_get(&status) == 1);
+    assert(status.lead_slot == 0);
+
+    /* And it reaches the reader: the field sits at the end of the header, ahead of the
+       first slot's state. */
+    char record[DSD_APP_NOTIFICATION_RECORD_SIZE];
+    assert(dsd_app_notification_encode(record, sizeof(record)) > 0);
+    const char* eighth = record;
+    for (int field = 0; field < NOTIFICATION_HEADER_FIELDS - 1; field++) {
+        eighth = strchr(eighth, '\t');
+        assert(eighth != NULL);
+        eighth++;
+    }
+    assert(eighth[0] == '0' && eighth[1] == '\t');
+
+    destroy_state(state);
 }
 
 static void
@@ -179,10 +282,10 @@ test_encode_has_version_and_field_count(void) {
     const size_t written = dsd_app_notification_encode(record, sizeof(record));
     assert(written > 0);
     assert(strncmp(record, "v1\t", 3) == 0);
-    assert(count_fields(record) == 26);
+    assert(count_fields(record) == (size_t)NOTIFICATION_TOTAL_FIELDS);
     /* One line: a newline would break the reader's single-record assumption. */
     assert(strchr(record, '\n') == NULL);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -192,7 +295,7 @@ test_encode_sanitises_control_characters(void) {
 
     dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 0U, 1234567U, 51023U);
     observation.kind = DSD_CALL_KIND_GROUP_VOICE;
-    observation.observed_m = dsd_app_notification_test_now_m();
+    observation.observed_m = dsd_time_now_monotonic_s();
     DSD_SNPRINTF(observation.target_text, sizeof(observation.target_text), "Metro\tFire\nDispatch");
     assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
     dsd_app_notification_publish_state(state);
@@ -201,9 +304,9 @@ test_encode_sanitises_control_characters(void) {
     assert(dsd_app_notification_encode(record, sizeof(record)) > 0);
     /* Text arrives from CSV imports and off the air; an embedded tab would invent a
        field and desynchronise every field after it. */
-    assert(count_fields(record) == 26);
+    assert(count_fields(record) == (size_t)NOTIFICATION_TOTAL_FIELDS);
     assert(strstr(record, "Metro Fire Dispatch") != NULL);
-    free(state);
+    destroy_state(state);
 }
 
 /* Publishes one call whose target text is @p target verbatim, then encodes it into
@@ -216,13 +319,13 @@ encode_with_target_text(const char* target, char* record, size_t record_size) {
 
     dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 0U, 1234567U, 51023U);
     observation.kind = DSD_CALL_KIND_GROUP_VOICE;
-    observation.observed_m = dsd_app_notification_test_now_m();
+    observation.observed_m = dsd_time_now_monotonic_s();
     DSD_SNPRINTF(observation.target_text, sizeof(observation.target_text), "%s", target);
     assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
     dsd_app_notification_publish_state(state);
 
     assert(dsd_app_notification_encode(record, record_size) > 0);
-    free(state);
+    destroy_state(state);
 }
 
 /* The record is handed straight to JNI's NewStringUTF(), which requires modified UTF-8
@@ -291,7 +394,7 @@ test_encode_round_trips_a_long_group_name(void) {
 
     dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 0U, 1234567U, 51023U);
     observation.kind = DSD_CALL_KIND_GROUP_VOICE;
-    observation.observed_m = dsd_app_notification_test_now_m();
+    observation.observed_m = dsd_time_now_monotonic_s();
     assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
 
     /* 199 characters, with a distinct tail so a truncation cannot pass on a prefix
@@ -318,10 +421,9 @@ test_encode_round_trips_a_long_group_name(void) {
     DSD_SNPRINTF(expected, sizeof(expected), "\t%s\t", alias);
     assert(strstr(record, expected) != NULL);
     /* The record must still fit, which is the other half of the fix. */
-    assert(count_fields(record) == 26);
+    assert(count_fields(record) == (size_t)NOTIFICATION_TOTAL_FIELDS);
 
-    free(history);
-    free(state);
+    destroy_state(state);
 }
 
 static void
@@ -333,7 +435,7 @@ test_encode_rejects_a_short_buffer(void) {
     /* Truncation would hand the reader a record it could parse as a shorter one. */
     assert(dsd_app_notification_encode(tiny, sizeof(tiny)) == 0);
     assert(dsd_app_notification_encode(NULL, 0) == 0);
-    free(state);
+    destroy_state(state);
 }
 
 /* A field-count check cannot catch two same-typed fields swapped (say, algid and kid,
@@ -376,7 +478,7 @@ test_encode_matches_expected_record_field_order(void) {
     dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 0U, 7654321U, 51023U);
     observation.kind = DSD_CALL_KIND_GROUP_VOICE;
     observation.frequency_hz = 851012500;
-    observation.observed_m = dsd_app_notification_test_now_m();
+    observation.observed_m = dsd_time_now_monotonic_s();
     assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
 
     /* Staged on the same talkgroup id the observation above carries, so
@@ -391,7 +493,7 @@ test_encode_matches_expected_record_field_order(void) {
     crypto.classification = DSD_CALL_CRYPTO_ENCRYPTED;
     crypto.algid = 0xAAU;
     crypto.kid = 0x1234U;
-    crypto.observed_m = dsd_app_notification_test_now_m();
+    crypto.observed_m = dsd_time_now_monotonic_s();
     assert(dsd_call_state_update_crypto(state, 0U, &crypto) > 0);
 
     dsd_app_notification_publish_state(state);
@@ -407,10 +509,10 @@ test_encode_matches_expected_record_field_order(void) {
     char expected[DSD_APP_NOTIFICATION_RECORD_SIZE];
     const int n =
         DSD_SNPRINTF(expected, sizeof(expected),
-                     "v1\t%s\t%u\t%u\t%u\t%lld\t%lld\t%lld"
+                     "v1\t%s\t%u\t%u\t%u\t%lld\t%lld\t%lld\t%d"
                      "\t%d\t%s\t%s\t%s\t%llu\t%u\t%u\t%u\t%u"
                      "\t%d\t%s\t%s\t%s\t%llu\t%u\t%u\t%u\t%u",
-                     "P25p2", 1U, 0U, 1U, 851006250LL, 851012500LL, 851500000LL, DSD_APP_CALL_LINE_ACTIVE,
+                     "P25p2", 1U, 0U, 1U, 851006250LL, 851012500LL, 851500000LL, 0, DSD_APP_CALL_LINE_ACTIVE,
                      "Riverside Fire", "51023", "7654321", 51023ULL, 1U, 0xAAU, 0x1234U,
                      (unsigned)status.slots[0].elapsed_ms, DSD_APP_CALL_LINE_NONE, "", "", "", 0ULL, 0U, 0U, 0U, 0U);
     assert(n > 0 && (size_t)n < sizeof(expected));
@@ -419,8 +521,7 @@ test_encode_matches_expected_record_field_order(void) {
     assert(dsd_app_notification_encode(record, sizeof(record)) > 0);
     assert(strcmp(record, expected) == 0);
 
-    free(history);
-    free(state);
+    destroy_state(state);
 }
 
 /* Below: the multi-consumer property itself. Every test above drives publish and get
@@ -538,7 +639,7 @@ test_concurrent_publish_and_get_never_tears(void) {
        only ever seen the pre-seeded value before the writer got scheduled. */
     assert(reader_ctx_a.matches > 0);
     assert(reader_ctx_b.matches > 0);
-    free(state);
+    destroy_state(state);
 }
 
 /* MUST run last in main(): it puts the module back to its never-published state, which
@@ -571,7 +672,7 @@ test_reset_forgets_the_published_status(void) {
     /* And the encoder, the only thing the service actually reads, has nothing to give. */
     char record[DSD_APP_NOTIFICATION_RECORD_SIZE];
     assert(dsd_app_notification_encode(record, sizeof(record)) == 0);
-    free(state);
+    destroy_state(state);
 }
 
 int
@@ -579,10 +680,12 @@ main(void) {
     test_get_before_any_publish_reports_nothing();
     test_publish_state_carries_protocol_and_call();
     test_unsynced_publishes_empty_protocol();
+    test_sync_label_is_held_across_a_frame_with_no_sync();
     test_publish_opts_carries_radio_and_trunking();
     test_non_radio_input_reports_no_centre();
     test_revision_advances_on_each_publish();
     test_null_arguments_are_safe();
+    test_lead_slot_is_published_and_survives_encoding();
     test_encode_has_version_and_field_count();
     test_encode_sanitises_control_characters();
     test_encode_replaces_a_lone_continuation_byte();

--- a/tests/ui/test_app_control_notification_status.c
+++ b/tests/ui/test_app_control_notification_status.c
@@ -146,6 +146,127 @@ test_null_arguments_are_safe(void) {
     assert(dsd_app_notification_get(NULL) == 0);
 }
 
+static size_t
+count_fields(const char* record) {
+    size_t fields = 1;
+    for (const char* p = record; *p != '\0'; p++) {
+        if (*p == '\t') {
+            fields++;
+        }
+    }
+    return fields;
+}
+
+static void
+test_encode_has_version_and_field_count(void) {
+    dsd_state* state = make_state();
+    state->synctype = DSD_SYNC_P25P2_POS;
+    dsd_app_notification_publish_state(state);
+
+    char record[1024];
+    const size_t written = dsd_app_notification_encode(record, sizeof(record));
+    assert(written > 0);
+    assert(strncmp(record, "v1\t", 3) == 0);
+    assert(count_fields(record) == 26);
+    /* One line: a newline would break the reader's single-record assumption. */
+    assert(strchr(record, '\n') == NULL);
+    free(state);
+}
+
+static void
+test_encode_sanitises_control_characters(void) {
+    dsd_state* state = make_state();
+    state->synctype = DSD_SYNC_P25P2_POS;
+
+    dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 0U, 1234567U, 51023U);
+    observation.kind = DSD_CALL_KIND_GROUP_VOICE;
+    observation.observed_m = dsd_app_notification_test_now_m();
+    DSD_SNPRINTF(observation.target_text, sizeof(observation.target_text), "Metro\tFire\nDispatch");
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    dsd_app_notification_publish_state(state);
+
+    char record[1024];
+    assert(dsd_app_notification_encode(record, sizeof(record)) > 0);
+    /* Text arrives from CSV imports and off the air; an embedded tab would invent a
+       field and desynchronise every field after it. */
+    assert(count_fields(record) == 26);
+    assert(strstr(record, "Metro Fire Dispatch") != NULL);
+    free(state);
+}
+
+static void
+test_encode_rejects_a_short_buffer(void) {
+    dsd_state* state = make_state();
+    dsd_app_notification_publish_state(state);
+
+    char tiny[8];
+    /* Truncation would hand the reader a record it could parse as a shorter one. */
+    assert(dsd_app_notification_encode(tiny, sizeof(tiny)) == 0);
+    assert(dsd_app_notification_encode(NULL, 0) == 0);
+    free(state);
+}
+
+/* A field-count check cannot catch two adjacent same-typed fields swapped (say, algid
+   and kid, or cc_freq_hz and vc_freq_hz) -- only a comparison against an independently
+   built expected record can. Every field below except elapsed_ms is a deterministic
+   function of the inputs set here; elapsed_ms is wall-clock-derived (time since the
+   call epoch opened), so it is read back from the published status rather than
+   guessed, to keep the comparison from flaking. */
+static void
+test_encode_matches_expected_record_field_order(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    assert(opts != NULL);
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 0;
+    opts->rtlsdr_center_freq = 851500000U;
+    dsd_app_notification_publish_opts(opts);
+    free(opts);
+
+    dsd_state* state = make_state();
+    state->synctype = DSD_SYNC_P25P2_POS;
+    state->trunk_cc_freq = 851006250L;
+
+    dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 0U, 7654321U, 51023U);
+    observation.kind = DSD_CALL_KIND_GROUP_VOICE;
+    observation.frequency_hz = 851012500;
+    observation.observed_m = dsd_app_notification_test_now_m();
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
+
+    dsd_call_crypto_update crypto;
+    DSD_MEMSET(&crypto, 0, sizeof(crypto));
+    crypto.classification = DSD_CALL_CRYPTO_ENCRYPTED;
+    crypto.algid = 0xAAU;
+    crypto.kid = 0x1234U;
+    crypto.observed_m = dsd_app_notification_test_now_m();
+    assert(dsd_call_state_update_crypto(state, 0U, &crypto) > 0);
+
+    dsd_app_notification_publish_state(state);
+
+    dsd_app_notification_status status;
+    assert(dsd_app_notification_get(&status) == 1);
+    assert(status.slots[0].enc == 1U);
+    assert(status.slots[0].algid == 0xAAU);
+    assert(status.slots[0].kid == 0x1234U);
+
+    char expected[DSD_APP_NOTIFICATION_RECORD_SIZE];
+    const int n =
+        DSD_SNPRINTF(expected, sizeof(expected),
+                     "v1\t%s\t%u\t%u\t%u\t%lld\t%lld\t%lld"
+                     "\t%d\t%s\t%s\t%s\t%llu\t%u\t%u\t%u\t%u"
+                     "\t%d\t%s\t%s\t%s\t%llu\t%u\t%u\t%u\t%u",
+                     "P25p2", 1U, 1U, 0U, 851006250LL, 851012500LL, 851500000LL, DSD_APP_CALL_LINE_ACTIVE, "51023",
+                     "51023", "7654321", 51023ULL, 1U, 0xAAU, 0x1234U, (unsigned)status.slots[0].elapsed_ms,
+                     DSD_APP_CALL_LINE_NONE, "", "", "", 0ULL, 0U, 0U, 0U, 0U);
+    assert(n > 0 && (size_t)n < sizeof(expected));
+
+    char record[DSD_APP_NOTIFICATION_RECORD_SIZE];
+    assert(dsd_app_notification_encode(record, sizeof(record)) > 0);
+    assert(strcmp(record, expected) == 0);
+
+    free(state);
+}
+
 /* Below: the multi-consumer property itself. Every test above drives publish and get
    from a single thread, which can never race itself. The publisher's entire reason to
    exist is that dsd_app_notification_get() is safe to call from any thread, and from
@@ -273,6 +394,10 @@ main(void) {
     test_non_radio_input_reports_no_centre();
     test_revision_advances_on_each_publish();
     test_null_arguments_are_safe();
+    test_encode_has_version_and_field_count();
+    test_encode_sanitises_control_characters();
+    test_encode_rejects_a_short_buffer();
+    test_encode_matches_expected_record_field_order();
     test_concurrent_publish_and_get_never_tears();
     printf("APP_CONTROL_NOTIFICATION_STATUS ok\n");
     return 0;

--- a/tests/ui/test_app_control_notification_status.c
+++ b/tests/ui/test_app_control_notification_status.c
@@ -179,6 +179,35 @@ test_non_radio_input_reports_no_centre(void) {
     free(opts);
 }
 
+/* The record's two halves are published by separate calls, and the opts half is the one
+   that runs first -- dsd_telemetry_publish_both_and_redraw() publishes opts, then the whole
+   snapshot body, then state. So there is a window at the start of every session in which
+   g_have is already set while no slot has been written, and the sentinel has to survive it:
+   a reader following the header's "or -1 for none" and indexing slots[lead_slot] would
+   otherwise headline slot 0 on a session with nothing on the air. */
+static void
+test_opts_only_publish_keeps_the_no_slot_sentinel(void) {
+    dsd_app_notification_reset();
+
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    assert(opts != NULL);
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->rtlsdr_center_freq = 851012500U;
+    dsd_app_notification_publish_opts(opts);
+    free(opts);
+
+    dsd_app_notification_status status;
+    assert(dsd_app_notification_get(&status) == 1);
+    assert(status.slots[0].state == DSD_APP_CALL_LINE_NONE);
+    assert(status.slots[1].state == DSD_APP_CALL_LINE_NONE);
+    assert(status.lead_slot == -1);
+
+    /* And through the encoder, which passes lead_slot out verbatim. */
+    char record[DSD_APP_NOTIFICATION_RECORD_SIZE];
+    assert(dsd_app_notification_encode(record, sizeof(record)) > 0);
+    assert(strstr(record, "\t-1\t") != NULL);
+}
+
 static void
 test_revision_advances_on_each_publish(void) {
     dsd_state* state = make_state();
@@ -675,14 +704,30 @@ test_reset_forgets_the_published_status(void) {
     destroy_state(state);
 }
 
+/* Both publishers early-return until a reader has asked once (g_wanted, notification_status.c).
+   Every publish below therefore depends on a get() having happened first -- which today is
+   incidental, because test_get_before_any_publish_reports_nothing() happens to run first.
+   Stated here instead so the dependency does not ride on call order: reordering main() would
+   otherwise turn the new first test's publish into a silent no-op and surface as an assertion
+   about the getter, pointing nowhere near the cause. */
+static void
+arm_publishers(void) {
+    dsd_app_notification_status probe;
+    /* Deliberately before test_get_before_any_publish_reports_nothing(): arming is all this
+       does, and get() reports nothing until something is actually published. */
+    (void)dsd_app_notification_get(&probe);
+}
+
 int
 main(void) {
+    arm_publishers();
     test_get_before_any_publish_reports_nothing();
     test_publish_state_carries_protocol_and_call();
     test_unsynced_publishes_empty_protocol();
     test_sync_label_is_held_across_a_frame_with_no_sync();
     test_publish_opts_carries_radio_and_trunking();
     test_non_radio_input_reports_no_centre();
+    test_opts_only_publish_keeps_the_no_slot_sentinel();
     test_revision_advances_on_each_publish();
     test_null_arguments_are_safe();
     test_lead_slot_is_published_and_survives_encoding();

--- a/tests/ui/test_app_control_notification_status.c
+++ b/tests/ui/test_app_control_notification_status.c
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Publisher for the Android notification's scanner readout.
+ */
+
+#include <assert.h>
+#include <dsd-neo/app_control/call_view.h>
+#include <dsd-neo/app_control/notification_status.h>
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/platform/threading.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static dsd_state*
+make_state(void) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    assert(state != NULL);
+    assert(dsd_call_state_ensure(state) > 0);
+    state->synctype = DSD_SYNC_NONE;
+    return state;
+}
+
+/* MUST run first in main(): it is the only point at which nothing has been published
+   into this process yet. Moving it later makes it assert the opposite of its name. */
+static void
+test_get_before_any_publish_reports_nothing(void) {
+    dsd_app_notification_status status;
+    /* Poisoned first, so "zeroed" is a claim about the callee rather than about calloc. */
+    DSD_MEMSET(&status, 0xAB, sizeof(status));
+
+    assert(dsd_app_notification_get(&status) == 0);
+    /* Zeroed even when there is nothing to report, so a caller can render from it
+       without checking the return value first. */
+    assert(status.revision == 0U);
+    assert(status.protocol[0] == '\0');
+    assert(status.radio_input == 0U);
+    assert(status.center_freq_hz == 0);
+    assert(status.slots[0].state == DSD_APP_CALL_LINE_NONE);
+    assert(status.slots[1].state == DSD_APP_CALL_LINE_NONE);
+}
+
+static void
+test_publish_state_carries_protocol_and_call(void) {
+    dsd_state* state = make_state();
+    state->synctype = DSD_SYNC_P25P2_POS;
+
+    dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 0U, 1234567U, 51023U);
+    observation.kind = DSD_CALL_KIND_GROUP_VOICE;
+    observation.frequency_hz = 851012500;
+    observation.observed_m = dsd_app_notification_test_now_m();
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
+
+    dsd_app_notification_publish_state(state);
+
+    dsd_app_notification_status status;
+    assert(dsd_app_notification_get(&status) == 1);
+    assert(strcmp(status.protocol, "P25p2") == 0);
+    assert(status.vc_freq_hz == 851012500);
+    assert(status.slots[0].state == DSD_APP_CALL_LINE_ACTIVE);
+    assert(strcmp(status.slots[0].tg_text, "51023") == 0);
+    free(state);
+}
+
+static void
+test_unsynced_publishes_empty_protocol(void) {
+    dsd_state* state = make_state();
+    state->synctype = DSD_SYNC_NONE;
+    dsd_app_notification_publish_state(state);
+
+    dsd_app_notification_status status;
+    assert(dsd_app_notification_get(&status) == 1);
+    /* NONE and UNKNOWN are not labels worth showing; an empty string is what tells an
+       unsynced session from a locked one. */
+    assert(status.protocol[0] == '\0');
+    free(state);
+}
+
+static void
+test_publish_opts_carries_radio_and_trunking(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    assert(opts != NULL);
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    opts->rtlsdr_center_freq = 851012500U;
+
+    dsd_app_notification_publish_opts(opts);
+
+    dsd_app_notification_status status;
+    assert(dsd_app_notification_get(&status) == 1);
+    assert(status.radio_input == 1U);
+    assert(status.trunking == 1U);
+    assert(status.trunk_tuned == 1U);
+    assert(status.center_freq_hz == 851012500);
+    free(opts);
+}
+
+static void
+test_non_radio_input_reports_no_centre(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    assert(opts != NULL);
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->rtlsdr_center_freq = 851012500U;
+
+    dsd_app_notification_publish_opts(opts);
+
+    dsd_app_notification_status status;
+    assert(dsd_app_notification_get(&status) == 1);
+    /* A WAV session has no tuner; publishing the centre would put a plausible reading
+       on screen for a run that never had one. */
+    assert(status.radio_input == 0U);
+    assert(status.center_freq_hz == 0);
+    free(opts);
+}
+
+static void
+test_revision_advances_on_each_publish(void) {
+    dsd_state* state = make_state();
+    dsd_app_notification_publish_state(state);
+
+    dsd_app_notification_status first;
+    assert(dsd_app_notification_get(&first) == 1);
+
+    dsd_app_notification_publish_state(state);
+    dsd_app_notification_status second;
+    assert(dsd_app_notification_get(&second) == 1);
+    assert(second.revision > first.revision);
+    free(state);
+}
+
+static void
+test_null_arguments_are_safe(void) {
+    dsd_app_notification_publish_state(NULL);
+    dsd_app_notification_publish_opts(NULL);
+    assert(dsd_app_notification_get(NULL) == 0);
+}
+
+/* Below: the multi-consumer property itself. Every test above drives publish and get
+   from a single thread, which can never race itself. The publisher's entire reason to
+   exist is that dsd_app_notification_get() is safe to call from any thread, and from
+   several at once, concurrently with the decode thread publishing. This is the test
+   that gives the TSan run something to say no to. */
+
+#define NOTIFICATION_RACE_WRITER_ITERATIONS 4000
+#define NOTIFICATION_RACE_READER_ITERATIONS 8000
+#define NOTIFICATION_RACE_FREQ_P25P2        851000000L
+#define NOTIFICATION_RACE_FREQ_DMR          852000000L
+
+typedef struct {
+    dsd_state* state;
+} notification_race_writer_ctx;
+
+typedef struct {
+    int mismatches; /* Any observed (protocol, freq) pair outside the two published ones. */
+    int matches;    /* How many gets actually landed on one of the two profiles below. */
+} notification_race_reader_ctx;
+
+static DSD_THREAD_RETURN_TYPE
+notification_race_writer(void* arg) {
+    notification_race_writer_ctx* ctx = (notification_race_writer_ctx*)arg;
+    for (int i = 0; i < NOTIFICATION_RACE_WRITER_ITERATIONS; i++) {
+        /* Two distinct, fully-formed profiles. protocol and vc_freq_hz are written
+           together under dsd_app_notification_publish_state()'s single critical
+           section, so any observer must see one whole profile or the other -- never a
+           protocol string from one paired with a frequency from the other. */
+        if ((i & 1) == 0) {
+            ctx->state->synctype = DSD_SYNC_P25P2_POS;
+            ctx->state->trunk_vc_freq[0] = NOTIFICATION_RACE_FREQ_P25P2;
+        } else {
+            ctx->state->synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+            ctx->state->trunk_vc_freq[0] = NOTIFICATION_RACE_FREQ_DMR;
+        }
+        dsd_app_notification_publish_state(ctx->state);
+    }
+    DSD_THREAD_RETURN;
+}
+
+static DSD_THREAD_RETURN_TYPE
+notification_race_reader(void* arg) {
+    notification_race_reader_ctx* ctx = (notification_race_reader_ctx*)arg;
+    for (int i = 0; i < NOTIFICATION_RACE_READER_ITERATIONS; i++) {
+        dsd_app_notification_status status;
+        /* Poisoned so a get() that forgot to fill a field would show up as garbage
+           rather than as a zero that might accidentally match nothing and pass anyway. */
+        DSD_MEMSET(&status, 0x7E, sizeof(status));
+        if (dsd_app_notification_get(&status) == 0) {
+            continue; /* Should not happen once the writer has seeded, but stay safe. */
+        }
+        const int is_p25 = strcmp(status.protocol, "P25p2") == 0;
+        const int is_dmr = strcmp(status.protocol, "DMR") == 0;
+        /* test_concurrent_publish_and_get_never_tears() seeds g_status with the P25p2
+           profile synchronously before any thread is created, and dsd_thread_create()'s
+           happens-before guarantee means no reader here can observe anything older than
+           that seed. From then on the writer only ever publishes the P25p2 or DMR
+           profile, so every get() from here to the end of the race must land on one of
+           the two -- an empty string, a third protocol, or a truncated/corrupted one can
+           only mean bytes from two different publishes were observed in one record. */
+        if (!is_p25 && !is_dmr) {
+            ctx->mismatches++;
+            continue;
+        }
+        ctx->matches++;
+        if (is_p25 && status.vc_freq_hz != NOTIFICATION_RACE_FREQ_P25P2) {
+            ctx->mismatches++;
+        }
+        if (is_dmr && status.vc_freq_hz != NOTIFICATION_RACE_FREQ_DMR) {
+            ctx->mismatches++;
+        }
+    }
+    DSD_THREAD_RETURN;
+}
+
+static void
+test_concurrent_publish_and_get_never_tears(void) {
+    dsd_state* state = make_state();
+    /* Seed with one of the two profiles before spawning anything: otherwise the very
+       first gets could legitimately observe whatever an earlier test in this process
+       last published (some other protocol label entirely) and this test would have no
+       way to tell that apart from a real torn read. */
+    state->synctype = DSD_SYNC_P25P2_POS;
+    state->trunk_vc_freq[0] = NOTIFICATION_RACE_FREQ_P25P2;
+    dsd_app_notification_publish_state(state);
+
+    notification_race_writer_ctx writer_ctx;
+    writer_ctx.state = state;
+    notification_race_reader_ctx reader_ctx_a;
+    reader_ctx_a.mismatches = 0;
+    reader_ctx_a.matches = 0;
+    notification_race_reader_ctx reader_ctx_b;
+    reader_ctx_b.mismatches = 0;
+    reader_ctx_b.matches = 0;
+
+    dsd_thread_t writer;
+    dsd_thread_t reader_a;
+    dsd_thread_t reader_b;
+    /* One writer, matching the documented contract (the decode thread is the only
+       publisher); two readers, to exercise "any number of them concurrently" rather
+       than just a single second thread. */
+    assert(dsd_thread_create(&writer, notification_race_writer, &writer_ctx) == 0);
+    assert(dsd_thread_create(&reader_a, notification_race_reader, &reader_ctx_a) == 0);
+    assert(dsd_thread_create(&reader_b, notification_race_reader, &reader_ctx_b) == 0);
+
+    assert(dsd_thread_join(writer) == 0);
+    assert(dsd_thread_join(reader_a) == 0);
+    assert(dsd_thread_join(reader_b) == 0);
+
+    assert(reader_ctx_a.mismatches == 0);
+    assert(reader_ctx_b.mismatches == 0);
+    /* Not vacuous: both readers must have actually landed inside the race window, not
+       only ever seen the pre-seeded value before the writer got scheduled. */
+    assert(reader_ctx_a.matches > 0);
+    assert(reader_ctx_b.matches > 0);
+    free(state);
+}
+
+int
+main(void) {
+    test_get_before_any_publish_reports_nothing();
+    test_publish_state_carries_protocol_and_call();
+    test_unsynced_publishes_empty_protocol();
+    test_publish_opts_carries_radio_and_trunking();
+    test_non_radio_input_reports_no_centre();
+    test_revision_advances_on_each_publish();
+    test_null_arguments_are_safe();
+    test_concurrent_publish_and_get_never_tears();
+    printf("APP_CONTROL_NOTIFICATION_STATUS ok\n");
+    return 0;
+}

--- a/tests/ui/test_app_control_notification_status.c
+++ b/tests/ui/test_app_control_notification_status.c
@@ -206,24 +206,40 @@ test_encode_rejects_a_short_buffer(void) {
     free(state);
 }
 
-/* A field-count check cannot catch two adjacent same-typed fields swapped (say, algid
-   and kid, or cc_freq_hz and vc_freq_hz) -- only a comparison against an independently
-   built expected record can. Every field below except elapsed_ms is a deterministic
-   function of the inputs set here; elapsed_ms is wall-clock-derived (time since the
-   call epoch opened), so it is read back from the published status rather than
-   guessed, to keep the comparison from flaking. */
+/* A field-count check cannot catch two same-typed fields swapped (say, algid and kid,
+   or cc_freq_hz and vc_freq_hz) -- only a comparison against an independently built
+   expected record can, and only if the two fields actually hold different values.
+   Every *adjacent* same-typed pair below is deliberately given different values, so a
+   transposition of neighboring encoder arguments -- the shape a copy/paste or
+   reordering slip actually takes -- changes the string:
+    - radio_input=1, trunking=0, trunk_tuned=1: neighbors differ (1,0) and (0,1).
+      radio_input and trunk_tuned do land on the same value, but they are not
+      neighbors -- trunking sits between them -- and with only two possible values for
+      three boolean flags, some pair has to repeat.
+    - name and tg_text differ because a CSV-imported group name is staged on the slot's
+      history row below; without one, dsd_app_slot_call_view() (call_view.c) makes name
+      fall back to tg_text verbatim, which would make that swap invisible.
+   Every field except elapsed_ms is otherwise a deterministic function of the inputs set
+   here; elapsed_ms is wall-clock-derived (time since the call epoch opened), so it is
+   read back from the published status rather than guessed, to keep the comparison from
+   flaking. */
 static void
 test_encode_matches_expected_record_field_order(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
     assert(opts != NULL);
     opts->audio_in_type = AUDIO_IN_RTL;
-    opts->trunk_enable = 1;
-    opts->trunk_is_tuned = 0;
+    opts->trunk_enable = 0;
+    opts->trunk_is_tuned = 1;
     opts->rtlsdr_center_freq = 851500000U;
     dsd_app_notification_publish_opts(opts);
     free(opts);
 
     dsd_state* state = make_state();
+    /* Attaches a staged history row purely so the CSV-group-name lookup below has
+       something to read; see dsd_app_slot_call_view()'s staged_group_name(). */
+    Event_History_I* history = (Event_History_I*)calloc(DSD_CALL_STATE_SLOT_COUNT, sizeof(Event_History_I));
+    assert(history != NULL);
+    state->event_history_s = history;
     state->synctype = DSD_SYNC_P25P2_POS;
     state->trunk_cc_freq = 851006250L;
 
@@ -232,6 +248,13 @@ test_encode_matches_expected_record_field_order(void) {
     observation.frequency_hz = 851012500;
     observation.observed_m = dsd_app_notification_test_now_m();
     assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
+
+    /* Staged on the same talkgroup id the observation above carries, so
+       staged_group_name() actually uses it for slot 0's name instead of falling back
+       to tg_text. */
+    history[0].Event_History_Items[0].target_id = 51023U;
+    DSD_SNPRINTF(history[0].Event_History_Items[0].t_name, sizeof(history[0].Event_History_Items[0].t_name), "%s",
+                 "Riverside Fire");
 
     dsd_call_crypto_update crypto;
     DSD_MEMSET(&crypto, 0, sizeof(crypto));
@@ -248,6 +271,8 @@ test_encode_matches_expected_record_field_order(void) {
     assert(status.slots[0].enc == 1U);
     assert(status.slots[0].algid == 0xAAU);
     assert(status.slots[0].kid == 0x1234U);
+    assert(strcmp(status.slots[0].name, "Riverside Fire") == 0);
+    assert(strcmp(status.slots[0].tg_text, "51023") == 0);
 
     char expected[DSD_APP_NOTIFICATION_RECORD_SIZE];
     const int n =
@@ -255,15 +280,16 @@ test_encode_matches_expected_record_field_order(void) {
                      "v1\t%s\t%u\t%u\t%u\t%lld\t%lld\t%lld"
                      "\t%d\t%s\t%s\t%s\t%llu\t%u\t%u\t%u\t%u"
                      "\t%d\t%s\t%s\t%s\t%llu\t%u\t%u\t%u\t%u",
-                     "P25p2", 1U, 1U, 0U, 851006250LL, 851012500LL, 851500000LL, DSD_APP_CALL_LINE_ACTIVE, "51023",
-                     "51023", "7654321", 51023ULL, 1U, 0xAAU, 0x1234U, (unsigned)status.slots[0].elapsed_ms,
-                     DSD_APP_CALL_LINE_NONE, "", "", "", 0ULL, 0U, 0U, 0U, 0U);
+                     "P25p2", 1U, 0U, 1U, 851006250LL, 851012500LL, 851500000LL, DSD_APP_CALL_LINE_ACTIVE,
+                     "Riverside Fire", "51023", "7654321", 51023ULL, 1U, 0xAAU, 0x1234U,
+                     (unsigned)status.slots[0].elapsed_ms, DSD_APP_CALL_LINE_NONE, "", "", "", 0ULL, 0U, 0U, 0U, 0U);
     assert(n > 0 && (size_t)n < sizeof(expected));
 
     char record[DSD_APP_NOTIFICATION_RECORD_SIZE];
     assert(dsd_app_notification_encode(record, sizeof(record)) > 0);
     assert(strcmp(record, expected) == 0);
 
+    free(history);
     free(state);
 }
 

--- a/tests/ui/test_app_control_notification_status.c
+++ b/tests/ui/test_app_control_notification_status.c
@@ -146,6 +146,18 @@ test_null_arguments_are_safe(void) {
     assert(dsd_app_notification_get(NULL) == 0);
 }
 
+/* Byte-exact rather than strchr(): strchr() takes an int and converts it to char, so a
+   high byte written as a literal reads differently depending on whether char is signed. */
+static int
+record_has_byte(const char* record, unsigned char byte) {
+    for (const char* p = record; *p != '\0'; p++) {
+        if ((unsigned char)*p == byte) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static size_t
 count_fields(const char* record) {
     size_t fields = 1;
@@ -191,6 +203,124 @@ test_encode_sanitises_control_characters(void) {
        field and desynchronise every field after it. */
     assert(count_fields(record) == 26);
     assert(strstr(record, "Metro Fire Dispatch") != NULL);
+    free(state);
+}
+
+/* Publishes one call whose target text is @p target verbatim, then encodes it into
+   @p record. Callsigns arrive off the air as raw decoded octets and CSV names arrive
+   unvalidated, so this is the shape every charset case below takes. */
+static void
+encode_with_target_text(const char* target, char* record, size_t record_size) {
+    dsd_state* state = make_state();
+    state->synctype = DSD_SYNC_P25P2_POS;
+
+    dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 0U, 1234567U, 51023U);
+    observation.kind = DSD_CALL_KIND_GROUP_VOICE;
+    observation.observed_m = dsd_app_notification_test_now_m();
+    DSD_SNPRINTF(observation.target_text, sizeof(observation.target_text), "%s", target);
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
+    dsd_app_notification_publish_state(state);
+
+    assert(dsd_app_notification_encode(record, record_size) > 0);
+    free(state);
+}
+
+/* The record is handed straight to JNI's NewStringUTF(), which requires modified UTF-8
+   and aborts the process under CheckJNI when it does not get it. Nothing upstream
+   filters for charset: D-STAR and YSF callsigns are raw decoded octets off the air, so
+   any byte value at all can reach here. */
+static void
+test_encode_replaces_a_lone_continuation_byte(void) {
+    char record[DSD_APP_NOTIFICATION_RECORD_SIZE];
+    /* 0x9F with no lead byte in front of it: not part of any sequence. */
+    encode_with_target_text("KD\x9F"
+                            "ABC",
+                            record, sizeof(record));
+    assert(strstr(record, "KD?ABC") != NULL);
+    assert(!record_has_byte(record, 0x9FU));
+}
+
+static void
+test_encode_drops_a_truncated_trailing_sequence(void) {
+    char record[DSD_APP_NOTIFICATION_RECORD_SIZE];
+    /* U+20AC is E2 82 AC; the field ends one byte short of it. Emitting the stump would
+       hand NewStringUTF() a lead byte with a missing continuation -- the exact shape
+       CheckJNI aborts on -- and a '?' per byte would invent characters the sender never
+       sent. */
+    encode_with_target_text("NET\xE2\x82", record, sizeof(record));
+    assert(strstr(record, "\tNET\t") != NULL);
+    assert(!record_has_byte(record, 0xE2U));
+    assert(!record_has_byte(record, 0x82U));
+}
+
+static void
+test_encode_replaces_an_overlong_encoding(void) {
+    char record[DSD_APP_NOTIFICATION_RECORD_SIZE];
+    /* C0 AF is a non-minimal encoding of '/'. Decoders that accept it are how a filter
+       that only looks at single bytes gets walked past, so both bytes are rejected. */
+    encode_with_target_text("A\xC0\xAF"
+                            "B",
+                            record, sizeof(record));
+    assert(strstr(record, "A??B") != NULL);
+    assert(!record_has_byte(record, 0xC0U));
+    assert(!record_has_byte(record, 0xAFU));
+}
+
+static void
+test_encode_keeps_valid_multibyte_text(void) {
+    char record[DSD_APP_NOTIFICATION_RECORD_SIZE];
+    /* Two-byte (U+00C7), three-byte (U+20AC) and four-byte (U+1F525) sequences, all
+       well-formed: the filter must pass them through byte for byte. A charset check
+       that rejected everything above 0x7F would be just as wrong as no check at all. */
+    encode_with_target_text("A\xC3\x87 \xE2\x82\xAC \xF0\x9F\x94\xA5", record, sizeof(record));
+    assert(strstr(record, "A\xC3\x87 \xE2\x82\xAC \xF0\x9F\x94\xA5") != NULL);
+    assert(strchr(record, '?') == NULL);
+}
+
+/* Event_History::t_name is a char[200] and dsd_app_slot_call::name must match it: it is
+   the Qt monitor's heroName, which returned the alias unbounded before it moved behind
+   app-control. Sizing it like tg_text/src_text (char[64], and correctly so, since those
+   come from the canonical call state) cut every CSV alias at 63 characters. */
+static void
+test_encode_round_trips_a_long_group_name(void) {
+    dsd_state* state = make_state();
+    Event_History_I* history = (Event_History_I*)calloc(DSD_CALL_STATE_SLOT_COUNT, sizeof(Event_History_I));
+    assert(history != NULL);
+    state->event_history_s = history;
+    state->synctype = DSD_SYNC_P25P2_POS;
+
+    dsd_call_observation observation = dsd_call_observation_data(DSD_SYNC_P25P2_POS, 0U, 1234567U, 51023U);
+    observation.kind = DSD_CALL_KIND_GROUP_VOICE;
+    observation.observed_m = dsd_app_notification_test_now_m();
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0);
+
+    /* 199 characters, with a distinct tail so a truncation cannot pass on a prefix
+       match, and comfortably past the 63 the old sizing allowed. */
+    char alias[200];
+    DSD_MEMSET(alias, 'A', sizeof(alias) - 1U);
+    alias[sizeof(alias) - 1U] = '\0';
+    DSD_MEMCPY(alias + 190, "TAILEND", 7U);
+    history[0].Event_History_Items[0].target_id = 51023U;
+    DSD_SNPRINTF(history[0].Event_History_Items[0].t_name, sizeof(history[0].Event_History_Items[0].t_name), "%s",
+                 alias);
+
+    dsd_app_notification_publish_state(state);
+
+    dsd_app_notification_status status;
+    assert(dsd_app_notification_get(&status) == 1);
+    assert(strcmp(status.slots[0].name, alias) == 0);
+
+    char record[DSD_APP_NOTIFICATION_RECORD_SIZE];
+    assert(dsd_app_notification_encode(record, sizeof(record)) > 0);
+    /* Tab-delimited on both sides: a truncated alias would still match a bare strstr
+       of its prefix. */
+    char expected[sizeof(alias) + 2U];
+    DSD_SNPRINTF(expected, sizeof(expected), "\t%s\t", alias);
+    assert(strstr(record, expected) != NULL);
+    /* The record must still fit, which is the other half of the fix. */
+    assert(count_fields(record) == 26);
+
+    free(history);
     free(state);
 }
 
@@ -422,6 +552,11 @@ main(void) {
     test_null_arguments_are_safe();
     test_encode_has_version_and_field_count();
     test_encode_sanitises_control_characters();
+    test_encode_replaces_a_lone_continuation_byte();
+    test_encode_drops_a_truncated_trailing_sequence();
+    test_encode_replaces_an_overlong_encoding();
+    test_encode_keeps_valid_multibyte_text();
+    test_encode_round_trips_a_long_group_name();
     test_encode_rejects_a_short_buffer();
     test_encode_matches_expected_record_field_order();
     test_concurrent_publish_and_get_never_tears();

--- a/tests/ui/test_app_control_notification_status.c
+++ b/tests/ui/test_app_control_notification_status.c
@@ -541,6 +541,39 @@ test_concurrent_publish_and_get_never_tears(void) {
     free(state);
 }
 
+/* MUST run last in main(): it puts the module back to its never-published state, which
+   is the one condition every other test here needs not to be in. */
+static void
+test_reset_forgets_the_published_status(void) {
+    dsd_state* state = make_state();
+    state->synctype = DSD_SYNC_P25P2_POS;
+    state->trunk_vc_freq[0] = 851012500L;
+    dsd_app_notification_publish_state(state);
+
+    dsd_app_notification_status before;
+    assert(dsd_app_notification_get(&before) == 1);
+    assert(before.protocol[0] != '\0');
+
+    dsd_app_notification_reset();
+
+    dsd_app_notification_status after;
+    /* Poisoned, so "zeroed" is a claim about the callee. */
+    DSD_MEMSET(&after, 0xAB, sizeof(after));
+    /* Back to reporting nothing, not merely to a stale record with a fresh revision:
+       the record is a module static that outlives its session, and the Android service
+       polls it before the next session has published anything. */
+    assert(dsd_app_notification_get(&after) == 0);
+    assert(after.revision == 0U);
+    assert(after.protocol[0] == '\0');
+    assert(after.vc_freq_hz == 0);
+    assert(after.slots[0].state == DSD_APP_CALL_LINE_NONE);
+
+    /* And the encoder, the only thing the service actually reads, has nothing to give. */
+    char record[DSD_APP_NOTIFICATION_RECORD_SIZE];
+    assert(dsd_app_notification_encode(record, sizeof(record)) == 0);
+    free(state);
+}
+
 int
 main(void) {
     test_get_before_any_publish_reports_nothing();
@@ -560,6 +593,7 @@ main(void) {
     test_encode_rejects_a_short_buffer();
     test_encode_matches_expected_record_field_order();
     test_concurrent_publish_and_get_never_tears();
+    test_reset_forgets_the_published_status();
     printf("APP_CONTROL_NOTIFICATION_STATUS ok\n");
     return 0;
 }

--- a/tests/ui/test_ui_opts_snapshot.c
+++ b/tests/ui/test_ui_opts_snapshot.c
@@ -12,6 +12,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/safe_api.h>
 
+#include <dsd-neo/app_control/notification_status.h>
 #include <dsd-neo/app_control/snapshot.h>
 #include "snapshot_internal.h"
 
@@ -69,11 +70,38 @@ test_republish_updates_stable_consumer_copy(void) {
     assert(second->udp_portno == 7355);
 }
 
+/* This publisher also feeds the notification record, which the Android foreground service
+   reads with no Qt in the picture. That fan-out lives at the tail of
+   dsd_app_telemetry_publish_opts_snapshot() and had no coverage anywhere: deleting the
+   call left the whole suite green while the notification went permanently blank. */
+static void
+test_publish_also_feeds_the_notification_record(void) {
+    static dsd_opts opts;
+
+    /* The notification publishers stay dormant until a reader has asked once, so arm them
+       before publishing or the fan-out below is a no-op for a reason that has nothing to
+       do with the wiring under test. */
+    dsd_app_notification_status status;
+    (void)dsd_app_notification_get(&status);
+
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.trunk_enable = 1;
+    opts.rtlsdr_center_freq = 851012500U;
+    dsd_app_telemetry_publish_opts_snapshot(&opts);
+
+    assert(dsd_app_notification_get(&status) == 1);
+    assert(status.radio_input == 1U);
+    assert(status.trunking == 1U);
+    assert(status.center_freq_hz == 851012500);
+}
+
 int
 main(void) {
     test_initial_snapshot_is_absent();
     test_publish_copies_latest_options();
     test_republish_updates_stable_consumer_copy();
+    test_publish_also_feeds_the_notification_record();
     printf("UI_OPTS_SNAPSHOT: OK\n");
     return 0;
 }

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -224,8 +224,35 @@ main(int argc, char** argv) {
         model.refresh(&opts, &state);
         expect("a call with a talkgroup is presented", model.slot1CallState() == 2);
         expect("a call with a talkgroup names it", model.slot1TgText() == QStringLiteral("1201"));
+
+        /* leadSlot is what MonitorScreen.qml binds heroSlot to, and it is one-based so 0
+         * falls out as "neither" — the rebasing of dsd_app_lead_slot()'s -1 happens here
+         * and nowhere else. An off-by-one hides the hero panel or headlines the wrong
+         * slot, which no C test of dsd_app_lead_slot() and no QML case can see. */
+        expect("the only live call headlines", model.leadSlot() == 1);
+
+        /* Slot 2 live as well: an open epoch on the lower slot still outranks it. */
+        dsd_call_observation other = named;
+        other.slot = 1U;
+        other.ota_target_id = 1202U;
+        other.observed_m = 2.5;
+        (void)dsd_call_state_observe(&state, &other, DSD_CALL_BOUNDARY_BEGIN);
+        model.refresh(&opts, &state);
+        expect("slot 2 is live too", model.slot2CallState() == 2);
+        expect("between two live calls the lower slot headlines", model.leadSlot() == 1);
+
+        /* With slot 1 ended and slot 2 still open, the open epoch wins outright — the
+         * rule that made two surfaces name different units before it was shared. */
         (void)dsd_call_state_end(&state, 0U, 3.0);
+        model.refresh(&opts, &state);
+        expect("an open call outranks an ended one on a lower slot", model.leadSlot() == 2);
+
+        (void)dsd_call_state_end(&state, 1U, 3.5);
     }
+
+    /* Nothing on the air: one-based leadSlot answers 0 rather than naming slot 1. */
+    model.clear();
+    expect("a cleared model headlines no slot", model.leadSlot() == 0);
 
     /* A stopped session must not leave its answers behind for the next one. */
     state.synctype = DSD_SYNC_P25P1_POS;

--- a/tests/ui/test_ui_snapshot_event_history.c
+++ b/tests/ui/test_ui_snapshot_event_history.c
@@ -4,12 +4,14 @@
  */
 
 #include <assert.h>
+#include <dsd-neo/app_control/notification_status.h>
 #include <dsd-neo/app_control/snapshot.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/input_level.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <stdint.h>
@@ -298,6 +300,20 @@ main(void) {
     assert(dsd_tg_policy_lookup_id(snap, 7777U, &lookup) == 0);
     assert(lookup.match == DSD_TG_POLICY_MATCH_EXACT);
     assert(strcmp(lookup.entry.name, "POLICY-ONLY") == 0);
+
+    /* This publisher also feeds the notification record the Android foreground service
+       reads with no Qt in the picture. The fan-out sits at the tail of
+       dsd_app_telemetry_publish_snapshot() and had no coverage anywhere: deleting the call
+       left the whole suite green while the notification went permanently blank. The
+       publishers stay dormant until a reader has asked once, so arm them first. */
+    dsd_app_notification_status notification;
+    (void)dsd_app_notification_get(&notification);
+    state->synctype = DSD_SYNC_P25P2_POS;
+    state->trunk_cc_freq = 851006250L;
+    dsd_app_telemetry_publish_snapshot(state);
+    assert(dsd_app_notification_get(&notification) == 1);
+    assert(strcmp(notification.protocol, "P25p2") == 0);
+    assert(notification.cc_freq_hz == 851006250);
 
     puts("UI_SNAPSHOT_EVENT_HISTORY: OK");
     dsd_state_ext_free_all(state);

--- a/tests/ui/test_ui_telemetry_hooks_install.c
+++ b/tests/ui/test_ui_telemetry_hooks_install.c
@@ -5,6 +5,7 @@
 
 #include <assert.h>
 #include <dsd-neo/app_control/frontend_runtime.h>
+#include <dsd-neo/app_control/notification_status.h>
 #include <dsd-neo/runtime/control_pump.h>
 #include <dsd-neo/runtime/telemetry.h>
 #include <stddef.h>
@@ -17,6 +18,12 @@
 static dsd_telemetry_hooks g_hooks;
 static int g_snapshot_calls;
 static int g_opts_snapshot_calls;
+static int g_notification_resets;
+
+void
+dsd_app_notification_reset(void) { // NOLINT(misc-use-internal-linkage)
+    g_notification_resets++;
+}
 
 void
 dsd_telemetry_hooks_set(dsd_telemetry_hooks hooks) { // NOLINT(misc-use-internal-linkage)
@@ -69,5 +76,16 @@ main(void) {
 
     dsd_app_install_telemetry_hooks();
     assert(g_hooks.request_redraw == dsd_app_request_redraw);
+
+    /* Stopping must drop the published status with the hooks. It is a module static
+       that outlives the session, and the Android service polls it again before the next
+       session has published anything -- a stale record would caption the new run with
+       the previous one's last call. */
+    assert(g_notification_resets == 0);
+    dsd_app_frontend_runtime_stop();
+    assert(g_notification_resets == 1);
+    assert(g_hooks.publish_snapshot == NULL);
+    assert(g_hooks.publish_opts_snapshot == NULL);
+    assert(g_hooks.request_redraw == NULL);
     return 0;
 }


### PR DESCRIPTION
## Summary

- Tapping the Android foreground-service notification now returns you to the running app. `buildNotification()` never set a `contentIntent`, which is why the `Stop` action worked and tapping the body did nothing. It now carries a launcher-style `PendingIntent` from `getLaunchIntentForPackage()` rather than an explicit `QtActivity` component, so Android brings the existing task forward instead of risking a second Activity and a second Qt `main()`.
- The notification's static "Decoding" text becomes a live scanner readout: protocol as subtext, talkgroup (CSV alias when known) as title, unit and frequency below, a chronometer for active calls, and a `BigTextStyle` pull-down showing both TDMA slots. It keeps updating after Android destroys the Activity, because the feed is a multi-consumer publisher fed by the telemetry hooks that already run on the decode thread for the whole session — not anything Qt owns.
- Two display rules moved down into `app_control` so all three frontends share one implementation: the per-slot call-line decision (from `MetricsModel::slotCallView()`) and the four-step voice-channel frequency chain (from `ui_guess_active_vc_freq()`). Both are pure refactors; the terminal and Qt keep thin wrappers.

**Why a second publication rather than the existing snapshot layer.** `include/dsd-neo/app_control/snapshot.h` is explicitly single-consumer — one shared consume buffer, one reader thread, which on Android is Qt's. A second consumer would mean a second deep copy of `dsd_state` (event history, channel maps, CC candidates) on every poll to move six fields. Instead `notification_status` publishes a small POD behind its own short leaf mutex, safe from any thread and any number of them.

New public API: `include/dsd-neo/app_control/call_view.h`, `include/dsd-neo/app_control/notification_status.h`.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human. — **not yet; this PR is the request for that review.** Nine manual on-device steps are also outstanding (see Risk).
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented. — solo-maintainer exception. Extra guardrails applied: every task gated on an independent review, plus a whole-branch review and a scoped re-review of the fix wave. New assertions were mutation-tested (the defect reintroduced, the test confirmed to fail, then reverted byte-for-byte).
- [x] High-risk areas touched are marked: **parser** (new tab-separated wire format parsed positionally in Kotlin), **network/radio input** (identity text originating off the air reaches `NewStringUTF`), **runtime/IO** (a new publisher on the decode thread). Not security/workflow/release/crypto/dependency.
- [ ] Outside review was requested when available, or unavailability is documented. — not requested.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests. — `APP_CONTROL_CALL_VIEW` and `APP_CONTROL_NOTIFICATION_STATUS` added; existing `UI_QT_CALL_LINE`, `UI_QT_METRICS_MODEL` and `UI_NCURSES_P25_DISPLAY_HELPERS` are the regression gates for the two extractions and pass unchanged.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny. — the publisher's lock discipline was verified as a strict leaf (nothing acquired while held), and the tearing test was confirmed to fail 40/40 with the lock removed.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. — none added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification. — semgrep `--strict` clean, 0 findings.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j` — 0 warnings under `-Werror`
- [x] `ctest --preset dev-debug --output-on-failure` — 514/514
- [x] `tools/preflight_ci.sh` — rc=0
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes — **not run.** `scan-build` was not exercised; preflight's optional scan-build step was skipped.
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes — N/A, no workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes — N/A, no dependency changes
- [ ] secret-redaction / workflow-pin / vcpkg-overlay-pin checks — N/A, no security-sensitive workflow or release changes

Additional verification beyond the template, because `dev-debug` sets `DSD_ENABLE_QT_UI=OFF` and this branch changes Qt code that build never compiles:

- Qt built separately with `-DDSD_ENABLE_QT_UI=ON` (Qt 6.11.1): 0 warnings, `UI_QT_METRICS_MODEL` passes.
- The wire format was exercised end to end — real `dsd_app_notification_encode()` output fed through the real Kotlin `DecoderStatus.parse()`, covering a 199-char CSV alias, emoji, an embedded tab, an overlong tab, a lone continuation byte, a truncated sequence and a CESU-8 pair.
- Kotlin type-checked against `android-36` with a real `aapt2`-generated `R`; both new test binaries pass under ASan+UBSan; the touched C files cross-compile clean under the Android NDK for arm64/API 29.

## Risk

- **Security/dependency impact:** one hazard found and closed. `sanitize_field()` previously passed bytes `0x80–0xFF` straight to `env->NewStringUTF()`, which requires *modified* UTF-8. That is reachable from received RF — D-STAR radio-header and slow-data callsigns and YSF DCH callsigns write raw decoded octets into the identity fields with no charset filter — and malformed input aborts the process under CheckJNI. Separately, the overlong sequence `C0 89` decodes to a real TAB on the Java side, which was a live field-injection channel into the tab-separated parser. Both are closed by UTF-8 validation at the single choke point. Known and accepted: well-formed 4-byte sequences pass through, which is a deviation from modified UTF-8's letter, but ART decodes them into a surrogate pair on every supported version (minSdk 29) and rejecting them would turn an emoji in a CSV alias into four `?` for no safety gain. No dependency changes.

- **CLI/UI behavior impact:** the two extractions touch shipped frontends and deserve the closest look. One real regression was found and fixed during review: `dsd_app_slot_call.name` was 64 bytes while its source `Event_History.t_name` is 200, silently truncating CSV talkgroup aliases from 199 to 63 characters in the QML `heroName`. Now `DSD_APP_CALL_NAME_SIZE = 200` with a round-trip test. `CallLineState`'s numeric values are load-bearing across the QML boundary (`MonitorScreen.qml` compares `slotNCallState === 2` / `=== 3`) and are preserved. The terminal's voice-channel chain moved verbatim; `UI_NCURSES_P25_DISPLAY_HELPERS` already pinned all four steps and passes unchanged.

- **Compatibility or packaging impact:** none to packaging. One known-Minor behaviour: `elapsed_ms` is inside the wire record and advances on every publish, so the notification's change-gate does not suppress updates during an active call — `notify()` fires once a second and the chronometer base is re-anchored each time. Analysis bounds the visible artifact to at most a repeated second (never wrong, never backwards, never drifting), and the rate stays under AOSP's 5/s enqueue limit with `setOnlyAlertOnce(true)`. The fix is written down if a device shows otherwise; widening the gate to ignore `elapsed_ms` is **not** the fix, since a call starting and ending between two polls would leave the chronometer counting from the old start.

- **Outstanding, and the reason this is not merge-ready on CI alone:** nine manual on-device steps. Seven cover tap-to-return from both a live and a destroyed Activity, live traffic tracking, the two-slot expand, Stop, a three-minute call, and a WAV session showing no frequency row. Two more were added by review and matter most: a start → stop → start cycle in one process (validates `dsd_app_notification_reset()`), and an encrypted or D-STAR/YSF call on a **debuggable** build so CheckJNI is active (validates the UTF-8 work). The existing traffic step never exercises the ENC / ALG / KID rendering path.
