### PR TITLE
fix(ci): teach cppcheck the JNI macros, and scan android/ on PRs

### DIFF
--- a/tools/ci_changed_files.sh
+++ b/tools/ci_changed_files.sh
@@ -257,10 +257,14 @@ if [[ $EXPAND_HEADERS -eq 1 && ${#changed_headers[@]} -gt 0 ]]; then
   fi
 fi
 
+# Keep in step with the target list in tools/cppcheck.sh (src/, include/, android/),
+# so a PR is checked over the same tree the push build scans. Leaving android/ out
+# here meant a finding in the JNI and host glue only ever surfaced on main, after
+# the merge. The vendored subtree under android/ was already dropped above.
 cppcheck_sources=()
 for p in "${analysis_tus[@]}"; do
   case "$p" in
-    src/*) cppcheck_sources+=("$p") ;;
+    src/* | include/* | android/*) cppcheck_sources+=("$p") ;;
   esac
 done
 

--- a/tools/cppcheck.sh
+++ b/tools/cppcheck.sh
@@ -92,6 +92,13 @@ CPPCHECK_ARGS=(
   "-DQ_SLOTS="
   "-DQ_INVOKABLE="
   "-DQ_EMIT="
+  # The NDK's jni.h is not on the include path here, so JNIEXPORT/JNICALL would
+  # otherwise stay unknown identifiers and be parsed as part of the return type --
+  # which makes a `JNIEXPORT void JNICALL` entry point look non-void and every bare
+  # `return;` in it a missingReturn. Empty is what jni.h expands JNICALL to, and
+  # JNIEXPORT's visibility attribute has no bearing on analysis.
+  "-DJNIEXPORT="
+  "-DJNICALL="
   --cppcheck-build-dir="$CPPCHECK_BUILD_DIR"
   --inline-suppr
   -I include
@@ -125,6 +132,9 @@ if [[ $STRICT -eq 1 ]]; then
     "-DQ_SLOTS="
     "-DQ_INVOKABLE="
     "-DQ_EMIT="
+    # See the note on the non-strict argument list above.
+    "-DJNIEXPORT="
+    "-DJNICALL="
     --cppcheck-build-dir="$CPPCHECK_BUILD_DIR"
     --inline-suppr
     -I include


### PR DESCRIPTION
## What broke

The push build of 45513101 failed the `linux-ci / cppcheck` job:

```
android/decoder_host_android.cpp:346: error: Found an exit path from function with non-void return type that has missing return statement [missingReturn]
```

## Root cause

`nativeQuitUi()` is the first `JNIEXPORT void JNICALL` function in the tree. cppcheck runs without the NDK's `jni.h` on its include path, so `JNIEXPORT` and `JNICALL` stay unknown identifiers and get parsed as part of the return type — the function then reads as non-void, and its early `return;` as a missing return.

Minimal repro against the same cppcheck (2.21.1):

```cpp
JNIEXPORT void JNICALL
f1(int* p) { if (p == nullptr) { return; } *p = 1; }   // missingReturn

void
f2(int* p) { if (p == nullptr) { return; } *p = 1; }   // clean
```

The nine JNI functions already in `dsdneo_jni.cpp` all return `jint`/`jboolean`/`jstring`, so none of them ever took that path — this only became reachable when a `void` entry point was added.

## Why the PR that introduced it was green

`tools/ci_changed_files.sh` narrowed the PR cppcheck file list to `src/*`, while the push job scans `src/`, `include/` and `android/`. Everything under `android/` was structurally invisible to cppcheck until after the merge.

## The fix

- `tools/cppcheck.sh`: add `-DJNIEXPORT=` / `-DJNICALL=` to both argument lists, alongside the Qt macros the script already neutralizes the same way. Empty is what `jni.h` expands `JNICALL` to, and `JNIEXPORT`'s visibility attribute has no bearing on analysis.
- `tools/ci_changed_files.sh`: widen the cppcheck filter to `src/* | include/* | android/*` so a PR is checked over the same tree the push build scans. (The vendored `android/third_party` subtree is already dropped upstream in the same script, and `tools/cppcheck.sh` filters it again.)

No production code changes — the reported code is correct, the analyzer configuration was not.

## Verification

- Reproduced the exact CI error locally on `android/decoder_host_android.cpp`, then confirmed it is gone with the fix.
- Full-tree `tools/cppcheck.sh --strict` passes.
- `tools/preflight_ci.sh` exits 0 (semgrep, shell lint, lizard).
- Replayed the offending commit through the fixed `ci_changed_files.sh`: `android/decoder_host_android.cpp` and `android/dsdneo_jni.cpp` now appear in `cppcheck_sources.txt`, so this would have been caught pre-merge.

No regression test is added: the failure is in CI tooling configuration rather than shipped code, the repo has no harness for `tools/*.sh`, and the `cppcheck` job over `android/` is itself the coverage — which is the gap this PR closes.