### PR TITLE
android: keep the Qt UI inside the edge-to-edge safe area

### DIFF
--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -239,11 +239,30 @@ Window {
         }
     }
 
+    // ---- Safe area ----
+    // From Android 15 (targetSdk 35+) the window is edge-to-edge: the status
+    // bar and gesture-nav bar are transparent overlays on the window, whose
+    // color paints the full bleed behind them. Every UI layer anchors to this
+    // item rather than the window, which keeps content out from under the
+    // bars. On desktop the margins are zero and this is the whole window.
+    // Bound to the window's margins, not this item's own: positioning an item
+    // by its own safe area is a binding loop.
+    Item {
+        id: safeArea
+
+        objectName: "safeArea"
+        anchors.fill: parent
+        anchors.topMargin: mainRoot.SafeArea.margins.top
+        anchors.leftMargin: mainRoot.SafeArea.margins.left
+        anchors.rightMargin: mainRoot.SafeArea.margins.right
+        anchors.bottomMargin: mainRoot.SafeArea.margins.bottom
+    }
+
     // ---- Tab shell ----
     Item {
         id: shell
 
-        anchors.fill: parent
+        anchors.fill: safeArea
         opacity: (mainRoot.monitorMode || mainRoot.wizardOpen || mainRoot.exploreSetupOpen
                   || !prefs.onboardingDone) ? 0.0 : 1.0
         visible: opacity > 0.0
@@ -312,7 +331,7 @@ Window {
     ExploreSetupScreen {
         id: exploreSetup
 
-        anchors.fill: parent
+        anchors.fill: safeArea
         opacity: mainRoot.exploreSetupOpen && !mainRoot.monitorMode ? 1.0 : 0.0
         visible: opacity > 0.0
         enabled: opacity > 0.9
@@ -346,7 +365,7 @@ Window {
         id: monitor
 
         objectName: "monitorScreen"
-        anchors.fill: parent
+        anchors.fill: safeArea
         system: mainRoot.sessionSystem
         opacity: mainRoot.monitorMode ? 1.0 : 0.0
         visible: opacity > 0.0
@@ -375,7 +394,7 @@ Window {
     Loader {
         id: spectrumLoader
 
-        anchors.fill: parent
+        anchors.fill: safeArea
         active: false
         sourceComponent: spectrumScreen
         opacity: mainRoot.monitorMode && mainRoot.spectrumOpen && !mainRoot.wizardOpen ? 1.0 : 0.0
@@ -441,7 +460,7 @@ Window {
     WizardScreen {
         id: wizard
 
-        anchors.fill: parent
+        anchors.fill: safeArea
         opacity: mainRoot.wizardOpen ? 1.0 : 0.0
         visible: opacity > 0.0
         enabled: opacity > 0.9
@@ -465,7 +484,7 @@ Window {
 
     // ---- First-run onboarding ----
     OnboardingScreen {
-        anchors.fill: parent
+        anchors.fill: safeArea
         opacity: !prefs.onboardingDone && !mainRoot.monitorMode ? 1.0 : 0.0
         visible: opacity > 0.0
         enabled: opacity > 0.9

--- a/tests/ui/qml/tst_main_safe_area.qml
+++ b/tests/ui/qml/tst_main_safe_area.qml
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import QtTest
+
+// From Android 15 the app window is edge-to-edge: the status and navigation
+// bars are transparent overlays over the window, and keeping content out from
+// under them is the app's job. The insets reach QML as SafeArea margins, and
+// every full-window layer in Main.qml is expected to stay inside them.
+//
+// Offscreen there are no system bars, so the platform margins are zero and a
+// UI that ignored them would pass by accident. SafeArea's writable
+// additionalMargins feed the same sum the platform insets do, which makes the
+// enforcement testable: raise the margins, and the layers must move.
+Item {
+    id: root
+
+    width: 420
+    height: 900
+
+    Loader {
+        id: appLoader
+
+        anchors.fill: parent
+        source: uiDir + "/Main.qml"
+    }
+
+    TestCase {
+        id: tc
+
+        name: "MainSafeArea"
+        when: windowShown
+
+        property var app: null
+
+        function initTestCase() {
+            tc.app = appLoader.item
+            verify(tc.app !== null, "Main.qml failed to load")
+        }
+
+        function test_the_ui_stays_inside_the_safe_area() {
+            tc.app.SafeArea.additionalMargins.top = 48
+            tc.app.SafeArea.additionalMargins.left = 12
+            tc.app.SafeArea.additionalMargins.right = 16
+            tc.app.SafeArea.additionalMargins.bottom = 32
+
+            // The window's margins are the sum of the platform insets (zero
+            // offscreen) and the additional margins; if this read-back fails,
+            // the simulated insets never took, not the layout under test.
+            tryVerify(function () { return tc.app.SafeArea.margins.top === 48 },
+                      2000, "additional safe-area margins did not register")
+
+            // The container every UI layer anchors to.
+            var safe = findChild(tc.app, "safeArea")
+            verify(safe !== null, "Main.qml has no safe-area container")
+            tryCompare(safe, "y", 48)
+            compare(safe.x, 12)
+            compare(safe.width, tc.app.width - 12 - 16)
+            compare(safe.height, tc.app.height - 48 - 32)
+
+            // And one full-window layer as a user-visible sample of the rest.
+            var monitor = findChild(tc.app, "monitorScreen")
+            verify(monitor !== null, "the monitor screen is missing")
+            tryCompare(monitor, "y", 48)
+            compare(monitor.height, tc.app.height - 48 - 32)
+        }
+    }
+}


### PR DESCRIPTION
## What

From Android 15, apps targeting SDK 35+ display edge-to-edge: the status bar and gesture-nav bar become transparent overlays and the app must keep its content out from under them. We target SDK 36, and the QML shell anchored every full-window layer to the window edges — so on Android 15/16 the screen headers sat under the status bar and `BottomNav` collided with the gesture area. This is what the Play Console advisory (*"Edge-to-edge may not display for all users"*, [Android 15 behavior change](https://developer.android.com/about/versions/15/behavior-changes-15#edge-to-edge)) flags.

`Main.qml` gains a `safeArea` container inset by the window's `SafeArea` margins (Qt ≥ 6.9 attached type; bound to the **window's** margins, since positioning an item by its own safe area is a documented binding loop). All six full-window layers — tab shell, explore setup, monitor, spectrum, wizard, onboarding — anchor to it. The window color still paints the full bleed behind the transparent bars; on desktop the margins are zero, so nothing moves.

No Kotlin/manifest changes needed: Qt 6.11's `QtWindow` already forwards WindowInsets to QML, and `enableEdgeToEdge()` from the advisory is AndroidX-View-app advice that doesn't apply to Qt.

## Tests

New `tst_main_safe_area.qml` in the `UI_QT_QML_CALL_LISTS` suite. Offscreen platforms report zero insets, so a UI that ignored them would pass by accident — the test simulates insets through `SafeArea.additionalMargins` (which feeds the same margin sum as platform insets) and asserts the container and the monitor layer take exactly the inset geometry. Written first and watched fail (`Main.qml has no safe-area container`) before the fix.

All 10 `UI_QT_*` tests pass in a `-DDSD_ENABLE_QT_UI=ON` build; `tools/preflight_ci.sh` clean.

## Verified on an Android 16 emulator (API 36, arm64 APK via NDK translation)

- Portrait + gesture nav, light theme: header clear of the status bar, `BottomNav` clear of the gesture pill
- Landscape gesture nav, and landscape 3-button nav (opaque side bar → horizontal insets)
- Dark theme: fully seamless (`Theme.bg` everywhere)

Known cosmetic follow-up, light theme only: the gesture strip below `BottomNav` shows `Theme.bg` while the bar itself is `Theme.panel`; if it grates on device, `BottomNav` can extend its background to the physical edge and pad by `SafeArea.margins.bottom`.