### PR TITLE
fix(android): store native libs uncompressed so Play ships delta updates

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -614,7 +614,7 @@ jobs:
           "$tools/zipalign" -c -P 16 4 "${OUT_APK}"
           echo "SIGNED=true" >> "$GITHUB_OUTPUT"
 
-      - name: Verify every packaged library is arm64 with 16 KB page alignment
+      - name: Verify every packaged library is arm64, 16 KB aligned, and stored uncompressed
         shell: bash
         env:
           APK_PATH: ${{ steps.names.outputs.APK_PATH }}
@@ -639,6 +639,16 @@ jobs:
             echo "APK contains ABIs other than arm64-v8a" >&2
             exit 1
           fi
+          # Stored (uncompressed) libraries are what lets Google Play delta-patch
+          # updates; Qt's stock Gradle template compresses them by mistake, which
+          # android/package/build.gradle overrides. Deflated entries here mean the
+          # override stopped being applied and every Play update ships near-full-size.
+          if ! unzip -v "$APK_PATH" 'lib/*.so' \
+            | awk '$8 ~ /^lib\// && $2 != "Stored" {print "compressed: " $8; bad = 1} END {exit bad}'; then
+            echo "APK compresses native libraries; Play delta updates would ship near-full downloads" >&2
+            exit 1
+          fi
+          echo "All packaged libraries are stored uncompressed"
 
       - name: Verify the APK carries the required license files
         shell: bash

--- a/android/package/build.gradle
+++ b/android/package/build.gradle
@@ -1,0 +1,111 @@
+// Copyright (C) The Qt Company Ltd.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Vendored from Qt 6.11.1's androiddeployqt template
+// (<Qt>/android_arm64_v8a/src/android/templates/build.gradle) with one fix, marked
+// DSD-NEO below. Files in QT_ANDROID_PACKAGE_SOURCE_DIR override the Qt template, so
+// this copy is what Gradle actually runs. Re-diff against the Qt template when the
+// pinned Qt version changes.
+//
+// The fix: gradle.properties values are Strings, and Qt's template assigns
+// `useLegacyPackaging = legacyPackaging` directly. Groovy coerces the non-empty
+// String "false" to boolean true, so legacy jniLibs packaging (compressed .so
+// entries, android:extractNativeLibs="true") was always on. Compressed native libs
+// defeat Google Play's delta patching — every update re-downloaded the full app —
+// and get extracted to a second on-disk copy at install. `.toBoolean()` restores
+// the intended value.
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        //noinspection AndroidGradlePluginVersion
+        classpath 'com.android.tools.build:gradle:9.0.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.0"
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+apply plugin: qtGradlePluginType
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
+    //noinspection GradleDependency
+    implementation 'androidx.core:core:1.17.0'
+}
+
+android {
+    /*******************************************************
+     * The following variables:
+     * - androidBuildToolsVersion,
+     * - androidCompileSdkVersion
+     * - qtAndroidDir - holds the path to qt android files
+     *                   needed to build any Qt application
+     *                   on Android.
+     * - qtGradlePluginType - whether to build an app or a library
+     *
+     * are defined in gradle.properties file. This file is
+     * updated by QtCreator and androiddeployqt tools.
+     * Changing them manually might break the compilation!
+     *******************************************************/
+
+    namespace = androidPackageName
+    compileSdkVersion androidCompileSdkVersion
+    buildToolsVersion androidBuildToolsVersion
+    ndkVersion = androidNdkVersion
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = [qtAndroidDir + '/src', 'src', 'java']
+            kotlin.srcDirs = [qtAndroidDir + '/src', 'src', 'kotlin']
+            aidl.srcDirs = [qtAndroidDir + '/src', 'src', 'aidl']
+            res.srcDirs = [qtAndroidDir + '/res', 'res']
+            resources.srcDirs = ['resources']
+            renderscript.srcDirs = ['src']
+            assets.srcDirs = ['assets']
+            jniLibs.srcDirs = ['libs']
+       }
+    }
+
+    tasks.withType(JavaCompile) {
+        options.incremental = true
+        options.compilerArgs += ['-Xlint:all']
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    lintOptions {
+        abortOnError = false
+    }
+
+    aaptOptions {
+        // Do not compress Qt binary resources file
+        noCompress 'rcc'
+    }
+
+    packagingOptions {
+        jniLibs {
+            // DSD-NEO: Qt's template assigns the raw String property, which Groovy
+            // coerces to true regardless of its value. See header comment.
+            useLegacyPackaging = legacyPackaging.toBoolean()
+        }
+    }
+
+    defaultConfig {
+        resConfig "en"
+        minSdkVersion qtMinSdkVersion
+        targetSdkVersion qtTargetSdkVersion
+        ndk.abiFilters = qtTargetAbiList.split(",")
+    }
+}


### PR DESCRIPTION
## Problem

Every Google Play update re-downloads close to the full app size, even though releases are highly delta-friendly: file-by-file comparison of the v2.6.0 and v2.6.1 release APKs shows **63.7 MB byte-identical, only ~11.6 MB changed** (just `libdsd-neo-app.so`; Qt is pinned so its libs are stable).

## Root cause

Qt 6.11.1's androiddeployqt `build.gradle` template assigns the `legacyPackaging` Gradle property (always a String) straight to `jniLibs.useLegacyPackaging`. Groovy coerces the non-empty string `"false"` to `true`, so legacy jniLibs packaging was silently always on:

- every `.so` shipped DEFLATE-compressed (`Defl:N` for all 79 lib entries in the released APK),
- the merged manifest carried `android:extractNativeLibs="true"` (confirmed with `aapt dump xmltree` on the v2.6.1 release APK),
- the AAB's bundle config disabled `uncompressNativeLibraries`.

Compressed native libs are the canonical Play delta-killer — bsdiff can't patch through compression — and they also get extracted to a second on-disk copy at install, roughly doubling the app's footprint.

## Fix

Vendor the template into `android/package/build.gradle` (staged as `QT_ANDROID_PACKAGE_SOURCE_DIR`, so it overrides Qt's copy) with the one-line fix: `useLegacyPackaging = legacyPackaging.toBoolean()`. The header documents provenance and says to re-diff against the Qt template when the pinned Qt version changes.

## Verification (local `android-app` build)

- APK: all 79 `lib/arm64-v8a/*.so` entries **Stored**, manifest `extractNativeLibs` = `0x0` (false)
- AAB: `BundleConfig.pb` decodes to `uncompress_native_libraries { enabled: true }` with 16 KB alignment

## Regression guard

The android-ci packaged-library step (which already unpacks the signed APK for alignment/ABI checks) now also fails on any Deflated `lib/` entry, so a future Qt upgrade replacing the vendored template can't silently regress this. The check was validated both ways locally: passes on the fixed APK, fails on the released v2.6.1 APK.

## Expectations after shipping

- The **first** Play update is still near-full-size (the installed base has compressed libs, so everything changes once).
- Updates after that shrink to the delta of what actually changed — a few MB for a typical release.
- On-device app size drops by roughly the native-lib payload (~60 MB) since libs are mmap'd from the APK instead of extracted.
- Fresh-install download size is unaffected (Play compresses transport regardless).

Worth reporting the template bug upstream to Qt.