### PR TITLE
fix(android): compress the sideload APK's native libs, keep the AAB Play-shaped

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -614,7 +614,7 @@ jobs:
           "$tools/zipalign" -c -P 16 4 "${OUT_APK}"
           echo "SIGNED=true" >> "$GITHUB_OUTPUT"
 
-      - name: Verify every packaged library is arm64, 16 KB aligned, and stored uncompressed
+      - name: Verify every packaged library is arm64, 16 KB aligned, and compressed for sideload
         shell: bash
         env:
           APK_PATH: ${{ steps.names.outputs.APK_PATH }}
@@ -639,16 +639,28 @@ jobs:
             echo "APK contains ABIs other than arm64-v8a" >&2
             exit 1
           fi
-          # Stored (uncompressed) libraries are what lets Google Play delta-patch
-          # updates; Qt's stock Gradle template compresses them by mistake, which
-          # android/package/build.gradle overrides. Deflated entries here mean the
-          # override stopped being applied and every Play update ships near-full-size.
+          # The sideload APK compresses its native libs (legacy jniLibs
+          # packaging) so the GitHub release download stays roughly half the
+          # size; only the Play AAB stores them uncompressed for delta
+          # patching. android/package/build.gradle branches on the Gradle
+          # invocation. A Stored entry here means that branch regressed and the
+          # sideload download doubled.
           if ! unzip -v "$APK_PATH" 'lib/*.so' \
-            | awk '$8 ~ /^lib\// && $2 != "Stored" {print "compressed: " $8; bad = 1} END {exit bad}'; then
-            echo "APK compresses native libraries; Play delta updates would ship near-full downloads" >&2
+            | awk '$8 ~ /^lib\// && $2 !~ /^Defl/ {print "not compressed: " $8; bad = 1} END {exit bad}'; then
+            echo "APK stores native libraries uncompressed; the sideload download doubles" >&2
             exit 1
           fi
-          echo "All packaged libraries are stored uncompressed"
+          # Compressed libs require install-time extraction: the platform
+          # cannot load them straight from the APK, so legacy packaging has AGP
+          # write extractNativeLibs=true into the merged manifest. Anything
+          # else here means the manifest and the lib entries disagree.
+          aapt2="${ANDROID_SDK_ROOT:?ANDROID_SDK_ROOT is not set}/build-tools/$ANDROID_BUILD_TOOLS_VERSION/aapt2"
+          if ! "$aapt2" dump xmltree "$APK_PATH" --file AndroidManifest.xml \
+            | grep -q 'extractNativeLibs([x0-9a-f]*)=true'; then
+            echo "APK manifest does not set extractNativeLibs=true while its libs are compressed" >&2
+            exit 1
+          fi
+          echo "All packaged libraries are compressed; the platform extracts them at install"
 
       - name: Verify the APK carries the required license files
         shell: bash
@@ -776,6 +788,11 @@ jobs:
       # bundle is useless - Play rejects it on upload - and the missing-secrets
       # warning (or the tag-fatal error) was already issued by "Materialize the
       # signing keystore".
+      #
+      # Must run after "Sign the APK": this step's Gradle invocation repackages
+      # the build-tree dsd-neo-app.apk with the bundle's Play-shaped packaging
+      # (uncompressed libs, extractNativeLibs=false), so the sideload APK has to
+      # be signed and copied to dist/ first.
       - name: Build the AAB
         id: aab_build
         if: >-
@@ -873,7 +890,17 @@ jobs:
             echo "ERROR: unexpected ABIs in the AAB: ${abis:-none}" >&2
             exit 1
           fi
-          echo "AAB OK: signed, arm64-v8a only."
+          # The Play-side invariant the sideload APK deliberately no longer
+          # carries: the bundle must keep extractNativeLibs=false so Play-served
+          # APKs store libs uncompressed and delta updates stay small. The base
+          # manifest is proto-encoded; the attribute value is the
+          # length-prefixed string "false", hence the \x1a\x05 bytes.
+          if ! unzip -p "$AAB_PATH" base/manifest/AndroidManifest.xml \
+            | grep -aqF $'extractNativeLibs\x1a\x05false'; then
+            echo "ERROR: the AAB base manifest does not set extractNativeLibs=false; Play updates would ship near-full downloads" >&2
+            exit 1
+          fi
+          echo "AAB OK: signed, arm64-v8a only, extractNativeLibs=false."
 
       - name: Upload AAB
         id: aab_upload

--- a/android/README.md
+++ b/android/README.md
@@ -65,7 +65,12 @@ unsigned; see [Release signing](#release-signing) for signing and installing it.
 
 CMake is the outer build: vcpkg chainloads Qt's `qt.toolchain.cmake`, which
 chainloads the NDK toolchain, and androiddeployqt generates and drives the Gradle
-project from `android/package/`.
+project from `android/package/`. `android/package/build.gradle` is a vendored
+copy of Qt's androiddeployqt template — files in `QT_ANDROID_PACKAGE_SOURCE_DIR`
+override the Qt template — carrying the per-artifact native-library packaging
+described under [Google Play](#google-play-the-app-bundle); re-diff it against
+`<Qt>/android_arm64_v8a/src/android/templates/build.gradle` whenever the pinned
+Qt version changes.
 
 androiddeployqt is pointed at a staged copy of that directory
 (`build/android-app/android/package`) rather than the source tree, because it
@@ -141,9 +146,11 @@ pull requests as well as pushes to `main`:
 - **`android-ci` / APK (Qt Quick app)** — builds the `android-app` preset through
   androiddeployqt, signs the APK, then unpacks it and asserts the same alignment
   for every packaged `.so` (ours and Qt's), that `arm64-v8a` is the only ABI
-  inside, that the license files are present, and that the launcher identity is
-  intact (label `DSD-neo`, a declared icon, a non-placeholder version code and
-  the icon/splash/theme resources). The APK is uploaded as a build
+  inside, that every `.so` is Deflate-compressed with the manifest extracting at
+  install (the AAB check asserts the inverse for Play — see
+  [Google Play](#google-play-the-app-bundle)), that the license files are
+  present, and that the launcher identity is intact (label `DSD-neo`, a declared
+  icon, a non-placeholder version code and the icon/splash/theme resources). The APK is uploaded as a build
   artifact, and on `main` and release tags the `Publish APK` job attaches it to a
   release (see [Release signing](#release-signing)). On `main` and release tags
   the same `build-apk` job also builds and signs the Play bundle — the `Publish
@@ -260,7 +267,18 @@ find build/android-app -name '*.aab'
 `QT_ANDROID_SIGN_AAB` only adds `--sign` to the `aab` target — the APK target
 stays governed by `QT_ANDROID_SIGN_APK` — but building `aab` re-runs
 androiddeployqt with `--sign`, which also apksigner-signs the APK and overwrites
-the build-tree `dsd-neo-app.apk` with the signed copy in passing. Signing
+the build-tree `dsd-neo-app.apk` with the signed copy in passing. That overwrite
+is also *Play-shaped*: the bundle invocation packages the in-passing APK with
+uncompressed libraries and `extractNativeLibs=false` (see
+[Native libraries](#native-libraries-sideload-apk-vs-play-bundle)), roughly
+doubling it. A plain rebuild of the apk target will not undo this — the aab
+build changes no inputs the apk target's depfile tracks, so it is a no-op.
+Delete the build-tree APK first to force androiddeployqt to re-run:
+
+```sh
+rm build/android-app/android/android-build/dsd-neo-app.apk
+cmake --build --preset android-app -j
+``` Signing
 happens in the build because androiddeployqt signs a bundle with `jarsigner`;
 `apksigner` cannot sign an AAB at all, so the post-hoc recipe above does not
 transfer. The four `QT_ANDROID_KEYSTORE_*` variables keep the passwords out of
@@ -289,6 +307,26 @@ an AAB cannot be installed, so beside the APK it only misleads, and under Play
 App Signing the uploaded bundle carries the upload key while Google re-signs what
 users install — it corresponds to no shipped binary. Download it by hand when
 updating a Play track.
+
+### Native libraries: sideload APK vs Play bundle
+
+The app's 79 `.so` files (the monolithic app library plus Qt) total ~67 MiB
+uncompressed, so how they are packaged dominates artifact size, and the two
+artifacts deliberately differ. The bundle keeps them stored uncompressed
+(`extractNativeLibs=false`): Play's delta patching diffs the raw ELF bytes, so
+updates download only what changed, and the installed app loads the libraries
+straight out of the APK with no second on-disk copy. The sideload APK instead
+uses legacy packaging — Deflate-compressed entries with
+`android:extractNativeLibs="true"` — which roughly halves the GitHub release
+download (~77 MB → ~31 MB) at the cost of the platform extracting the ~67 MB of
+libraries at install. Sideload updates are full downloads either way, so
+download size wins there; Play installs never pay the extraction cost.
+
+The switch lives in the vendored `android/package/build.gradle`, keyed on the
+Gradle invocation androiddeployqt hardcodes: `assembleRelease` (the apk target)
+gets legacy packaging, `assembleRelease bundle` (the aab target) honors the
+non-legacy default. CI asserts both sides — every `.so` in the published APK is
+compressed, and the AAB's base manifest keeps `extractNativeLibs=false`.
 
 Two consequences worth knowing before enrolling in Play App Signing:
 

--- a/android/package/build.gradle
+++ b/android/package/build.gradle
@@ -2,18 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // Vendored from Qt 6.11.1's androiddeployqt template
-// (<Qt>/android_arm64_v8a/src/android/templates/build.gradle) with one fix, marked
+// (<Qt>/android_arm64_v8a/src/android/templates/build.gradle) with one change, marked
 // DSD-NEO below. Files in QT_ANDROID_PACKAGE_SOURCE_DIR override the Qt template, so
 // this copy is what Gradle actually runs. Re-diff against the Qt template when the
 // pinned Qt version changes.
 //
-// The fix: gradle.properties values are Strings, and Qt's template assigns
-// `useLegacyPackaging = legacyPackaging` directly. Groovy coerces the non-empty
-// String "false" to boolean true, so legacy jniLibs packaging (compressed .so
-// entries, android:extractNativeLibs="true") was always on. Compressed native libs
-// defeat Google Play's delta patching — every update re-downloaded the full app —
-// and get extracted to a second on-disk copy at install. `.toBoolean()` restores
-// the intended value.
+// The change (jniLibs.useLegacyPackaging): gradle.properties values are Strings, and
+// Qt's template assigns `useLegacyPackaging = legacyPackaging` directly. Groovy
+// coerces the non-empty String "false" to boolean true, so legacy jniLibs packaging
+// (compressed .so entries, android:extractNativeLibs="true") was always on. Rather
+// than only restoring the intended value with `.toBoolean()`, the vendored copy picks
+// the packaging per artifact: the Play bundle stores .so files uncompressed
+// (extractNativeLibs=false) so Play can delta-patch updates, while the sideload APK
+// compresses them (legacy packaging, install-time extraction) so the GitHub release
+// download stays around half the size. android-ci asserts both sides; see the
+// packaging notes in android/README.md.
 
 buildscript {
     repositories {
@@ -96,9 +99,21 @@ android {
 
     packagingOptions {
         jniLibs {
-            // DSD-NEO: Qt's template assigns the raw String property, which Groovy
-            // coerces to true regardless of its value. See header comment.
-            useLegacyPackaging = legacyPackaging.toBoolean()
+            // DSD-NEO: split packaging by artifact. androiddeployqt hardcodes the
+            // Gradle invocation: "assembleRelease" for the apk target and
+            // "assembleRelease bundle" for the aab target, so the requested task
+            // names are the only per-artifact signal this file sees.
+            //
+            // Bundle builds honor legacyPackaging (a String; Qt's template forgets
+            // .toBoolean(), see header) — false by default, so the AAB keeps
+            // extractNativeLibs=false and Play ships delta updates. Every other
+            // build (the sideload/dev APK) forces legacy packaging: compressed
+            // .so entries and install-time extraction, which roughly halves the
+            // GitHub release download.
+            def bundleBuild = gradle.startParameter.taskNames.any {
+                it.tokenize(':').last().startsWith('bundle')
+            }
+            useLegacyPackaging = bundleBuild ? legacyPackaging.toBoolean() : true
         }
     }
 


### PR DESCRIPTION
## Problem

#326 stored native libs uncompressed in every artifact so Play could delta-patch updates — but that also doubled the sideload APK on GitHub releases (~31 MB → ~77 MB; the 79 `.so` files total ~67 MiB uncompressed).

## Fix

androiddeployqt hardcodes the Gradle invocation — `assembleRelease` for the apk target, `assembleRelease bundle` for the aab target — so the vendored `android/package/build.gradle` now picks the jniLibs packaging per artifact:

- **Play bundle**: `useLegacyPackaging=false` — libs stored uncompressed, `extractNativeLibs=false`, Play delta updates stay small (unchanged from #326).
- **Sideload/dev APK**: legacy packaging forced — Deflate-compressed libs, install-time extraction — restoring the pre-#326 ~31 MB download.

## CI

Both sides are now asserted:
- The APK guard flips: every packaged `.so` must be Deflate-compressed, and the binary manifest must carry `extractNativeLibs=true`.
- The AAB verify step gains the inverse check: the base proto manifest must keep `extractNativeLibs=false` (byte-level grep, no new tooling).
- The `zipalign -c -P 16 4` check is untouched — `-P 16` only applies to uncompressed `.so` entries — and the sign-APK-before-build-AAB ordering is now commented, since the aab invocation repackages the build-tree APK Play-shaped in passing.

## Docs

`android/README.md` documents the vendored Gradle template, the packaging split and its trade-off (sideloaders download ~31 MB but the platform extracts ~67 MB at install — same as before #326), and the caveat that a plain apk rebuild after an aab build is a depfile no-op: delete the build-tree APK to force a repackage.

## Verified locally

- APK: 31,251,816 B (was 76,622,976), all 79 libs `Defl:N`, manifest `extractNativeLibs=true`, zipalign passes.
- AAB: 34,284,215 B, `extractNativeLibs=false` intact in the base proto manifest.
- Round-trip: aab build overwrites the APK Play-shaped; `rm` + apk rebuild restores the sideload shape.
- `tools/preflight_ci.sh` clean.