### PR TITLE
build: release 2.7.0, and keep the WAV stub handle one declaration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(dsd-neo VERSION 2.6.1 LANGUAGES C CXX)
+project(dsd-neo VERSION 2.7.0 LANGUAGES C CXX)
 if(POLICY CMP0083)
     cmake_policy(SET CMP0083 NEW)
 endif()

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -128,7 +128,13 @@ canonical_snapshot_reader(void* arg) {
 static int g_open_wav_count;
 static int g_close_wav_count;
 static int g_close_wav_export_count;
-static SNDFILE* g_open_wav_result;
+// Held as void* rather than SNDFILE*: this file is compiled twice, once against the real
+// <sndfile.h> and once against the alt-tag stub header (CORE_CALL_ALERT_HISTORY_SNDFILE_ALT_TAG),
+// so a SNDFILE*-typed static is two differently-typed declarations sharing one source location.
+// Whole-program analyzers that merge the two translation units then see one of the pair with no
+// reads at all and report it as dead (CodeQL cpp/unused-static-variable). A type that is identical
+// in both builds keeps the stub's handle a single declaration.
+static void* g_open_wav_result;
 static double g_observed_m;
 
 SNDFILE*
@@ -139,7 +145,7 @@ open_wav_file(char* dir, char* temp_filename, size_t temp_filename_size, uint16_
     UNUSED(sample_rate);
     UNUSED(ext);
     g_open_wav_count++;
-    return g_open_wav_result;
+    return (SNDFILE*)g_open_wav_result;
 }
 
 SNDFILE*
@@ -2315,7 +2321,7 @@ test_reacquired_transmission_commits_one_row(void) {
     reset_fixture(&opts, &state, event_history);
     opts.call_alert_events = DSD_CALL_ALERT_EVENT_VOICE_START | DSD_CALL_ALERT_EVENT_VOICE_END;
     opts.wav_out_f = (SNDFILE*)&wav_sentinel;
-    g_open_wav_result = (SNDFILE*)&wav_sentinel;
+    g_open_wav_result = &wav_sentinel;
 
     for (int pass = 0; pass < 3; pass++) {
         if (pass == 0) {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "dsd-neo",
-  "version-string": "2.6.1",
+  "version-string": "2.7.0",
   "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
   "description": "Digital Speech Decoder: DSD-neo",
   "homepage": "https://github.com/arancormonk/dsd-neo",


### PR DESCRIPTION
Closes the open CodeQL alert [#1773](https://github.com/arancormonk/dsd-neo/security/code-scanning/1773) (`cpp/unused-static-variable`) and moves the version metadata to 2.7.0.

## The alert

CodeQL reported `g_open_wav_result` in `tests/core/test_core_call_alert_history.c` as never read — on a variable that is written in `reset_fixture()` and in `test_reacquired_transmission_commits_one_row()`, and read by the `open_wav_file()` stub.

The cause is that this file is compiled **twice**: once against the real `<sndfile.h>` (`SNDFILE` = `struct sf_private_tag`) and once against the alt-tag stub header that `CORE_CALL_ALERT_HISTORY_SNDFILE_ALT_TAG` generates (`SNDFILE` = `struct SNDFILE_tag`). A `SNDFILE*`-typed file-scope static is therefore two differently-typed declarations sharing one source location, and when the two translation units are merged the single read binds to only one of the pair. The other has no reads at all and reports as dead. It is the only file-scope static in that file whose type varies between the two builds, which is why it is the only one flagged.

## The fix

Hold the stub's handle as `void*` — identical in both builds, so it stays one declaration and the read binds where it belongs. The cast moves to the `return`, which is where the alt-tag target was already exercising `SNDFILE*` compatibility. No behavior change; the stub returns the same pointer it always did.

## Version bump

`CMakeLists.txt` and `vcpkg.json` to 2.7.0. The Android `versionCode` derives from `PROJECT_VERSION` (`android/CMakeLists.txt`), so those two files are the whole bump — same shape as the 2.6.0 and 2.5.1 bumps.

## Verification

- `ctest --preset dev-debug` — 517/517 pass, including `CORE_CALL_ALERT_HISTORY` and `CORE_CALL_ALERT_HISTORY_SNDFILE_ALT_TAG`.
- `tools/preflight_ci.sh` — clean.