### PR TITLE
fix(p25): release the shared TDMA VC one hangtime after the clear call ends under encryption lockout

### DIFF
--- a/include/dsd-neo/core/enc_lockout.h
+++ b/include/dsd-neo/core/enc_lockout.h
@@ -15,7 +15,12 @@
  *
  * Release paths, in decreasing strength:
  *  - explicit clear evidence (clear service options, regroup clear-key
- *    override, or a call that resolves decryptable) removes the entry;
+ *    override, or a call that resolves decryptable) removes the entry. This
+ *    store honours every such request; a protocol may still rate-limit how
+ *    often it believes the weakest form of that evidence -- P25 spaces out
+ *    re-admissions driven by a bare grant service bit, because sites whose
+ *    grant bits do not track encryption repeat one per second for the life of
+ *    the encrypted call;
  *  - new key material bumps the global key epoch instead of dropping
  *    entries: a stale-epoch entry stops blocking, the next grant runs one
  *    silent classification probe, and the outcome either re-locks the entry

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -139,9 +139,16 @@ typedef struct {
  * ============================================================================ */
 
 typedef struct {
-    double last_active_m;    // Monotonic timestamp of last activity (PTT/ACTIVE/voice)
-    double last_start_m;     // Monotonic timestamp of the last PTT/ACTIVE call-epoch boundary
-    double last_stop_m;      // Monotonic timestamp when the last followed epoch transitioned inactive
+    double last_active_m; // Monotonic timestamp of last activity (PTT/ACTIVE/voice)
+    double last_start_m;  // Monotonic timestamp of the last PTT/ACTIVE call-epoch boundary
+    double last_stop_m;   // Monotonic timestamp when the last followed epoch transitioned inactive
+    // Monotonic timestamp this slot last carried traffic the SM was following,
+    // 0 when it has carried none on the current carrier. The hangtime deadline
+    // is derived from these two per-slot stamps rather than armed
+    // (p25_sm_hangtime_started_m), so signaling the SM is not following -- a
+    // locked-out slot's MAC repeats, an encryption-lockout reprobe assignment
+    // -- can neither restart nor erase the countdown by construction.
+    double last_followed_m;
     int voice_active;        // 1 if voice is currently active on this slot
     int algid;               // Current algorithm ID for this slot
     int keyid;               // Current key ID for this slot
@@ -157,6 +164,10 @@ typedef struct {
     int data_call;           // 1 for data grant, 0 for voice
     int svc_bits;            // Service options, or P25_SM_SVC_UNKNOWN when absent
     int enc_override_clear;  // 1 when regroup KEY=0 supplied the current clear classification
+    int enc_lockout_reprobe; // 1 when this assignment was re-admitted from the encryption-lockout
+                             // ledger by a clear-claiming grant. The SM has no positive evidence
+                             // for it, so it may acquire but may not outlive the hangtime the last
+                             // followed transmission set.
     double last_grant_m;     // Monotonic timestamp of last accepted grant for this slot
     double crypto_attempt_m; // Monotonic start of the current crypto classification attempt
     double last_end_m;       // Monotonic timestamp of the last accepted MAC_END_PTT
@@ -244,9 +255,10 @@ typedef struct {
     p25_sm_enc_reprobe_memo_t enc_reprobes[P25_SM_ENC_REPROBE_MEMO_MAX];
 
     // Timing
-    double t_tune_m;             // Monotonic time of last VC tune
-    double t_voice_m;            // Monotonic time of last voice activity
-    double t_hangtime_m;         // Monotonic time hangtime started
+    double t_tune_m;  // Monotonic time of last VC tune
+    double t_voice_m; // Monotonic time of last voice activity
+    // The hangtime countdown has no field: it is derived from the per-slot
+    // last_followed_m stamps by p25_sm_hangtime_started_m().
     double t_cc_sync_m;          // Monotonic time of last CC sync
     double t_cc_tune_m;          // Monotonic time of last CC tune awaiting decode
     double t_cc_reacquire_m;     // Monotonic time a soft CQPSK reacquire was queued
@@ -398,6 +410,21 @@ const char* p25_sm_state_name(p25_sm_state_e state);
  * @return Pointer to global state machine context.
  */
 p25_sm_ctx_t* p25_sm_get_ctx(void);
+
+/**
+ * @brief When the tuned carrier's hangtime countdown started, or 0 when none runs.
+ *
+ * Derived, never armed: the most recent moment any slot carried traffic the SM
+ * was following, and 0 while a slot still is. Because only followed traffic
+ * writes p25_sm_slot_ctx_t.last_followed_m, no amount of signaling from a
+ * locked-out slot -- suppressed voice starts, ESS repeats, clear-claiming grant
+ * updates -- can restart or cancel the countdown.
+ *
+ * @param ctx State machine context (may be NULL).
+ * @return Monotonic start of the countdown, or 0.0 when the carrier is not in
+ *         hangtime.
+ */
+double p25_sm_hangtime_started_m(const p25_sm_ctx_t* ctx);
 
 /**
  * @brief Trigger explicit release and return to CC.

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -197,8 +197,13 @@ typedef struct {
     int valid;           // 1 while matching ambiguous CC updates remain quarantined
 } p25_sm_recent_call_end_t;
 
-/** Targets tracked for the encryption-lockout reprobe backoff. */
-enum { P25_SM_ENC_REPROBE_MEMO_MAX = 4 };
+/**
+ * Targets tracked for the encryption-lockout reprobe backoff. Sized so that a
+ * busy site's set of concurrently locked-out talkgroups fits: a live cooldown
+ * is never evicted to make room, so a table too small to hold them would hand
+ * the overflow targets no backoff at all.
+ */
+enum { P25_SM_ENC_REPROBE_MEMO_MAX = 16 };
 
 /**
  * One target re-admitted from the encryption-lockout ledger because a grant

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -186,6 +186,21 @@ typedef struct {
     int valid;           // 1 while matching ambiguous CC updates remain quarantined
 } p25_sm_recent_call_end_t;
 
+/** Targets tracked for the encryption-lockout reprobe backoff. */
+enum { P25_SM_ENC_REPROBE_MEMO_MAX = 4 };
+
+/**
+ * One target re-admitted from the encryption-lockout ledger because a grant
+ * claimed clear service options. The ledger entry is consumed by that
+ * admission, so without this record every repeat of the same grant update
+ * looks like the first one.
+ */
+typedef struct {
+    double admitted_m; // Monotonic timestamp of the re-admission, 0 when unused
+    uint32_t target;   // OTA talkgroup for group calls, destination RID for private calls
+    uint8_t is_group;  // 1 for group/SG target, 0 for private destination
+} p25_sm_enc_reprobe_memo_t;
+
 /* ============================================================================
  * State Machine Context
  * ============================================================================ */
@@ -220,6 +235,13 @@ typedef struct {
 
     // Per-slot activity (index 0 = left/P1, index 1 = right)
     p25_sm_slot_ctx_t slots[2];
+
+    // Targets recently re-admitted from the encryption-lockout ledger by a
+    // clear-claiming grant. Survives the carrier release the failed reprobe
+    // ends in, which is the whole point: the ledger entry the reprobe consumed
+    // is gone by then, so nothing else can tell the site's next identical grant
+    // update apart from the first one.
+    p25_sm_enc_reprobe_memo_t enc_reprobes[P25_SM_ENC_REPROBE_MEMO_MAX];
 
     // Timing
     double t_tune_m;             // Monotonic time of last VC tune

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -944,23 +944,170 @@ p25_grant_patch_clear_key(const dsd_state* state, const p25_grant_eval_ctx_t* ev
     return (p25_patch_tg_key_is_clear(state, eval_ctx->tg) || p25_patch_sg_key_is_clear(state, eval_ctx->tg)) ? 1 : 0;
 }
 
+// Minimum spacing between two ledger re-admissions of the same target on
+// clear-claiming grants. A site whose grant service bits do not track
+// encryption repeats such an update about once a second for the life of the
+// encrypted call, and each one released the ledger entry and re-admitted the
+// call; with the carrier now released one hangtime after the last followed
+// traffic, that became a tune/classify/release cycle per update. One reprobe
+// per window keeps the designed recovery -- a talkgroup that stopped
+// encrypting still tunes on its very next grant -- without letting a talkgroup
+// that did not stop buy a retune per update.
+#define P25_ENC_REPROBE_COOLDOWN_S 10.0
+
+static p25_sm_enc_reprobe_memo_t*
+p25_grant_enc_reprobe_slot(p25_sm_ctx_t* ctx, uint32_t target, int is_group, double now_m) {
+    p25_sm_enc_reprobe_memo_t* oldest = NULL;
+    if (!ctx) {
+        return NULL;
+    }
+    for (int i = 0; i < P25_SM_ENC_REPROBE_MEMO_MAX; i++) {
+        p25_sm_enc_reprobe_memo_t* memo = &ctx->enc_reprobes[i];
+        if (memo->admitted_m > 0.0 && memo->target == target && memo->is_group == (uint8_t)(is_group ? 1 : 0)) {
+            return memo;
+        }
+        if (memo->admitted_m <= 0.0 || now_m - memo->admitted_m >= P25_ENC_REPROBE_COOLDOWN_S) {
+            // Free or expired: reuse the least recently admitted of those.
+            if (!oldest || memo->admitted_m < oldest->admitted_m) {
+                oldest = memo;
+            }
+        }
+    }
+    if (oldest) {
+        return oldest;
+    }
+    // Every slot holds a live cooldown. Evict the oldest so a burst of distinct
+    // targets cannot pin the table and disable the backoff for a new one.
+    oldest = &ctx->enc_reprobes[0];
+    for (int i = 1; i < P25_SM_ENC_REPROBE_MEMO_MAX; i++) {
+        if (ctx->enc_reprobes[i].admitted_m < oldest->admitted_m) {
+            oldest = &ctx->enc_reprobes[i];
+        }
+    }
+    return oldest;
+}
+
+static int
+p25_grant_enc_reprobe_in_cooldown(const p25_sm_ctx_t* ctx, uint32_t target, int is_group, double now_m) {
+    if (!ctx) {
+        return 0;
+    }
+    for (int i = 0; i < P25_SM_ENC_REPROBE_MEMO_MAX; i++) {
+        const p25_sm_enc_reprobe_memo_t* memo = &ctx->enc_reprobes[i];
+        if (memo->admitted_m <= 0.0 || memo->target != target || memo->is_group != (uint8_t)(is_group ? 1 : 0)) {
+            continue;
+        }
+        return (now_m >= memo->admitted_m && (now_m - memo->admitted_m) < P25_ENC_REPROBE_COOLDOWN_S) ? 1 : 0;
+    }
+    return 0;
+}
+
+// Drop the backoff for a target whose voice actually classified clear or
+// decryptable: the grant bit was right, so a later re-lock owes a fresh probe
+// rather than serving out a cooldown earned by a different call.
 static void
-p25_grant_release_enc_lockout_if_clear(dsd_state* state, p25_grant_eval_ctx_t* eval_ctx) {
-    if (!state || !eval_ctx || !p25_grant_is_voice_call(eval_ctx) || eval_ctx->tg <= 0) {
+p25_grant_enc_reprobe_forget(p25_sm_ctx_t* ctx, uint32_t target, int is_group) {
+    if (!ctx) {
         return;
     }
-    // Explicit clear service options, the regroup clear-key override, or an
-    // active patch clear key release a locked target before policy evaluates,
-    // so a talkgroup that stopped encrypting tunes again immediately. The
-    // release is recorded on the eval context: the ledger armed from
-    // corroborated undecryptable voice, while this admission rests on one
-    // uncorroborated grant bit, so downstream timing treats the call as a
-    // reprobe rather than followed traffic until its voice classifies.
-    if ((eval_ctx->svc_valid && !eval_ctx->encrypted_call) || eval_ctx->enc_override_clear
-        || p25_grant_patch_clear_key(state, eval_ctx)) {
-        if (dsd_enc_lockout_release(state, (uint32_t)eval_ctx->tg, !eval_ctx->is_indiv)) {
-            eval_ctx->enc_lockout_reprobe = 1;
+    for (int i = 0; i < P25_SM_ENC_REPROBE_MEMO_MAX; i++) {
+        p25_sm_enc_reprobe_memo_t* memo = &ctx->enc_reprobes[i];
+        if (memo->admitted_m > 0.0 && memo->target == target && memo->is_group == (uint8_t)(is_group ? 1 : 0)) {
+            DSD_MEMSET(memo, 0, sizeof(*memo));
+            return;
         }
+    }
+}
+
+static void
+p25_grant_enc_reprobe_record(p25_sm_ctx_t* ctx, uint32_t target, int is_group, double now_m) {
+    p25_sm_enc_reprobe_memo_t* memo = p25_grant_enc_reprobe_slot(ctx, target, is_group, now_m);
+    if (!memo) {
+        return;
+    }
+    memo->target = target;
+    memo->is_group = (uint8_t)(is_group ? 1 : 0);
+    memo->admitted_m = now_m;
+}
+
+typedef enum {
+    P25_ENC_RELEASE_NONE = 0,
+    // The regroup clear-key override or an active patch clear key. p25_lcw.c
+    // treats the same evidence as authoritative enough to reopen the Phase 1
+    // audio gate immediately, so the call is followed traffic from its first
+    // voice frame and owes no reprobe.
+    P25_ENC_RELEASE_CORROBORATED,
+    // Explicit clear service options: one uncorroborated grant bit against a
+    // ledger armed from confirmed undecryptable voice.
+    P25_ENC_RELEASE_GRANT_BIT,
+} p25_enc_release_evidence_e;
+
+static p25_enc_release_evidence_e
+p25_grant_enc_release_evidence(const dsd_state* state, const p25_grant_eval_ctx_t* eval_ctx) {
+    if (eval_ctx->enc_override_clear || p25_grant_patch_clear_key(state, eval_ctx)) {
+        return P25_ENC_RELEASE_CORROBORATED;
+    }
+    return (eval_ctx->svc_valid && !eval_ctx->encrypted_call) ? P25_ENC_RELEASE_GRANT_BIT : P25_ENC_RELEASE_NONE;
+}
+
+static void
+p25_grant_release_enc_lockout_on_grant_bit(const dsd_opts* opts, dsd_state* state, p25_grant_eval_ctx_t* eval_ctx,
+                                           uint32_t target, int is_group) {
+    if (!dsd_enc_lockout_is_blocked(opts, state, target, is_group)) {
+        // Nothing was blocking -- no entry, or a stale-epoch entry after new key
+        // material. The grant is admitted either way, so drop any residue but do
+        // not treat the call as a reprobe.
+        (void)dsd_enc_lockout_release(state, target, is_group);
+        return;
+    }
+    // The target re-locked after its last re-admission on this same evidence,
+    // so the grant bit has already been shown wrong once. Let the cooldown run
+    // rather than spending another tune on it.
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    const double now_m = dsd_time_now_monotonic_s();
+    if (p25_grant_enc_reprobe_in_cooldown(ctx, target, is_group, now_m)) {
+        p25_sm_diagf((dsd_opts*)opts, state, NULL, "enc_lockout_reprobe_declined", "kind=%s target=%u reason=cooldown",
+                     is_group ? "group" : "private", target);
+        return;
+    }
+    if (dsd_enc_lockout_release(state, target, is_group)) {
+        // The ledger armed from corroborated undecryptable voice, while this
+        // admission rests on one grant bit, so downstream timing treats the call
+        // as a reprobe rather than followed traffic until its voice classifies.
+        eval_ctx->enc_lockout_reprobe = 1;
+        p25_grant_enc_reprobe_record(ctx, target, is_group, now_m);
+    }
+}
+
+// Release a locked target before policy evaluates, so a talkgroup that stopped
+// encrypting tunes again immediately. @p commit marks an assignment actually
+// being processed: the policy-only and voice-start evaluations share this
+// helper and would otherwise consume the one-shot ledger release on the weak
+// evidence without carrying the reprobe marking into grant timing.
+static void
+p25_grant_release_enc_lockout_if_clear(const dsd_opts* opts, dsd_state* state, p25_grant_eval_ctx_t* eval_ctx,
+                                       int commit) {
+    if (!opts || !state || !eval_ctx || !p25_grant_is_voice_call(eval_ctx) || eval_ctx->tg <= 0) {
+        return;
+    }
+    // In follow mode the ledger is suspended, not erased: entries survive a
+    // temporary toggle to following encrypted calls without owing a fresh
+    // probe. handle_enc's sibling release is gated the same way.
+    if (opts->trunk_tune_enc_calls != 0) {
+        return;
+    }
+    const int is_group = !eval_ctx->is_indiv;
+    const uint32_t target = (uint32_t)eval_ctx->tg;
+
+    switch (p25_grant_enc_release_evidence(state, eval_ctx)) {
+        case P25_ENC_RELEASE_CORROBORATED: (void)dsd_enc_lockout_release(state, target, is_group); break;
+        case P25_ENC_RELEASE_GRANT_BIT:
+            if (commit) {
+                p25_grant_release_enc_lockout_on_grant_bit(opts, state, eval_ctx, target, is_group);
+            }
+            break;
+        case P25_ENC_RELEASE_NONE:
+        default: break;
     }
 }
 
@@ -1078,11 +1225,22 @@ p25_grant_track_src_tg(dsd_state* state, const p25_sm_event_t* ev, const p25_gra
     }
 }
 
+// @p commit distinguishes an assignment actually being processed from the
+// policy-only and voice-start re-evaluations that share this path: only the
+// former may spend the one-shot encryption-lockout ledger release, whose
+// outcome it carries into grant timing through @p out_eval_ctx.
 static int
 grant_allowed(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, dsd_tg_policy_decision* out_decision,
-              p25_grant_eval_ctx_t* out_eval_ctx) {
+              p25_grant_eval_ctx_t* out_eval_ctx, int commit) {
     p25_grant_eval_ctx_t eval_ctx;
     dsd_tg_policy_decision decision;
+    // Filled before every return: the context carries enc_lockout_reprobe into
+    // tuning and timing decisions, so a caller must never read stack residue
+    // off a rejected grant.
+    DSD_MEMSET(&eval_ctx, 0, sizeof(eval_ctx));
+    if (out_eval_ctx) {
+        *out_eval_ctx = eval_ctx;
+    }
     if (!opts || !state || !ev) {
         return 0;
     }
@@ -1090,7 +1248,10 @@ grant_allowed(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, dsd_tg
     eval_ctx = p25_grant_eval_ctx_from_event(ev);
     p25_grant_apply_clear_override(opts, state, &eval_ctx);
     p25_grant_apply_crypto_probe(opts, &eval_ctx);
-    p25_grant_release_enc_lockout_if_clear(state, &eval_ctx);
+    p25_grant_release_enc_lockout_if_clear(opts, state, &eval_ctx, commit);
+    if (out_eval_ctx) {
+        *out_eval_ctx = eval_ctx;
+    }
     if (p25_grant_eval_policy(opts, state, ev, &eval_ctx, &decision) != 0) {
         return 0;
     }
@@ -1578,6 +1739,38 @@ p25_grant_commit_decoder_tune(dsd_opts* opts, dsd_state* state, long freq) {
     state->p25_last_vc_tune_time_m = now_m;
 }
 
+/*
+ * The hangtime countdown is one channel-wide deadline: release this carrier one
+ * hangtime after the last *followed* traffic on it. Every write goes through
+ * these two helpers so the rule is stated in one place --
+ *
+ *   arm    -- followed traffic stopped: an END, or a slot leaving followed
+ *             activity. Signaling that the SM is not following (a
+ *             classification-suppressed voice start, a locked-out slot's
+ *             MAC_PTT/MAC_ACTIVE repeats, a reprobe assignment) must neither
+ *             arm nor restart it.
+ *   cancel -- followed traffic resumed on the carrier, or the carrier is gone.
+ *
+ * -- and a new call site has to pick one instead of inventing a third rule.
+ * The deadline itself is read in exactly one place,
+ * p25_sm_tick_tuned_check_hangtime().
+ */
+static void
+p25_sm_arm_hangtime(p25_sm_ctx_t* ctx, double at_m) {
+    if (!ctx || at_m <= 0.0) {
+        return;
+    }
+    ctx->t_hangtime_m = at_m;
+}
+
+static void
+p25_sm_cancel_hangtime(p25_sm_ctx_t* ctx) {
+    if (!ctx) {
+        return;
+    }
+    ctx->t_hangtime_m = 0.0;
+}
+
 static void
 p25_grant_initialize_timing(p25_sm_ctx_t* ctx, dsd_state* state, double now_m, int reused_carrier, int data_call,
                             int enc_lockout_reprobe) {
@@ -1585,18 +1778,27 @@ p25_grant_initialize_timing(p25_sm_ctx_t* ctx, dsd_state* state, double now_m, i
     // physical retune is needed. Do not let the preceding transmission's hang
     // or activity state suppress the grant timeout for a retained carrier.
     const double hangtime_armed_m = ctx->t_hangtime_m;
+    const int keep_hangtime = enc_lockout_reprobe && reused_carrier && hangtime_armed_m > 0.0;
     ctx->t_tune_m = now_m;
     ctx->t_voice_m = 0.0;
-    ctx->t_hangtime_m = 0.0;
     ctx->vc_activity_seen = 0;
-    if (enc_lockout_reprobe && reused_carrier && hangtime_armed_m > 0.0) {
+    if (keep_hangtime) {
         // A locked-out target re-admitted on the retained carrier by a
         // clear-claiming grant is a reprobe, not followed traffic: the site
         // repeats such grant updates for the life of the encrypted call, and
         // letting each one restart the countdown held the channel until the
         // encrypted call ended. Keep the armed countdown; a reprobe whose
-        // voice really classifies clear clears it on that voice start.
-        ctx->t_hangtime_m = hangtime_armed_m;
+        // voice really classifies clear cancels it on that voice start.
+        //
+        // The reprobe's acquisition window is therefore whichever deadline
+        // comes first: p25_sm_tick_tuned() keeps running the grant timeout
+        // alongside the countdown, so the reprobe cannot outlive the hangtime
+        // the last followed transmission set, and a reprobe whose voice never
+        // arrives still gives the carrier up after grant_timeout_s rather than
+        // riding out a long configured hangtime.
+        p25_sm_arm_hangtime(ctx, hangtime_armed_m);
+    } else {
+        p25_sm_cancel_hangtime(ctx);
     }
     if (reused_carrier) {
         p25_grant_refresh_reused_carrier_watchdogs(state, now_m);
@@ -2154,7 +2356,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     DSD_MEMSET(&eval_ctx, 0, sizeof(eval_ctx));
 
     // Check grant policy
-    if (!grant_allowed(opts, state, ev, &decision, &eval_ctx)) {
+    if (!grant_allowed(opts, state, ev, &decision, &eval_ctx, 1)) {
         return;
     }
 
@@ -2226,7 +2428,7 @@ p25_sm_apply_group_grant_policy(dsd_opts* opts, dsd_state* state, int channel, i
 
     p25_sm_event_t ev = p25_sm_ev_group_grant(channel, 0, tg, src, svc_bits);
     dsd_tg_policy_decision decision;
-    if (grant_allowed(opts, state, &ev, &decision, NULL)) {
+    if (grant_allowed(opts, state, &ev, &decision, NULL, 0)) {
         p25_sm_diagf(opts, state, NULL, "grant_policy_only", "ch=0x%04X tg=%d src=%d svc=0x%02X policy_tg=%u",
                      channel & 0xFFFF, tg, src, svc_bits & 0xFF, decision.target_id);
     }
@@ -3251,7 +3453,8 @@ p25_voice_start_apply_identity(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* sta
 
     dsd_tg_policy_decision decision;
     p25_grant_eval_ctx_t eval_ctx;
-    if (!grant_allowed(opts, state, &call_ev, &decision, &eval_ctx)) {
+    DSD_MEMSET(&eval_ctx, 0, sizeof(eval_ctx));
+    if (!grant_allowed(opts, state, &call_ev, &decision, &eval_ctx, 0)) {
         p25_call_end_slot(opts, state, slot, now_m);
         p25_voice_close_slot_media(ctx, opts, state, slot);
         p25_voice_clear_slot_grant(ctx, state, slot);
@@ -3308,30 +3511,48 @@ static int
 p25_voice_start_wait_for_classification(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, const char* why,
                                         double now_m) {
     const int identity_pending = state && !ctx->vc_is_tdma && slot == 0 && state->p25_p1_identity_pending;
-    if (!identity_pending && !p25_voice_start_crypto_suppressed(opts, state, slot)) {
+    const int crypto_suppressed = p25_voice_start_crypto_suppressed(opts, state, slot);
+    if (!identity_pending && !crypto_suppressed) {
         return 0;
     }
 
     // The lockout policy may have been enabled after follow mode marked this
     // blocked slot active. Clear that stale activity before ignoring subsequent
-    // voice indications so the tuned timer can release it. A suppressed voice
-    // start is not followed traffic, though: the locked-out slot repeats
-    // MAC_PTT/MAC_ACTIVE for the life of its transmission, and restarting an
-    // already-armed countdown on every repeat held the channel until the
-    // encrypted call ended. Only the transition out of followed activity (or a
-    // slot with no countdown at all) may arm it; an armed countdown keeps
-    // running so the hangtime tick can release the emptied channel.
-    const int was_active = ctx->t_voice_m > 0.0;
-    const double inactive_since_m = was_active ? ctx->t_voice_m : now_m;
+    // voice indications so the tuned timer can release it.
+    //
+    // A lockout-suppressed voice start is not followed traffic, though: the
+    // locked-out slot repeats MAC_PTT/MAC_ACTIVE for the life of its
+    // transmission, and restarting an already-armed countdown on every repeat
+    // held the channel until the encrypted call ended. For that reason only the
+    // transition out of followed activity on this slot (or a carrier with no
+    // countdown at all) may arm it. A Phase 1 identity wait is the opposite
+    // case -- a followed call whose LCW identity has not decoded yet, with no
+    // repeat loop behind it -- and keeps re-arming as before, or an over that
+    // keys up late in the window is released while its voice is on the air.
+    //
+    // "Followed activity" is read per slot, not off the channel-wide t_voice_m:
+    // the tick re-stamps that to now on every pass while *either* slot is
+    // voice_active, so on a busy TDMA carrier the locked-out slot's own repeats
+    // would each look like a transition and restart the countdown. For the same
+    // reason the countdown stays unarmed while the companion is still followed
+    // -- its END owns arming it.
+    const int was_active = ctx->slots[slot].voice_active;
+    const int companion_followed = ctx->vc_is_tdma && ctx->slots[slot ^ 1].voice_active;
+    const double inactive_since_m =
+        (was_active && ctx->slots[slot].last_active_m > 0.0) ? ctx->slots[slot].last_active_m : now_m;
     ctx->slots[slot].voice_active = 0;
     ctx->slots[slot].last_active_m = 0.0;
     ctx->t_voice_m = 0.0;
     if (state->p25_crypto_state[slot] == DSD_P25_CRYPTO_ENCRYPTED_PENDING) {
+        // Classification owns the wait: p25_sm_tick_tuned() holds the hangtime
+        // release off while this budget runs, so a call that resolves clear is
+        // not torn down mid-classification, and p25_sm_tick_crypto_
+        // classification() releases the carrier when the budget lapses.
         if (ctx->slots[slot].crypto_attempt_m <= 0.0) {
             ctx->slots[slot].crypto_attempt_m = now_m;
         }
-    } else if (was_active || ctx->t_hangtime_m <= 0.0) {
-        ctx->t_hangtime_m = inactive_since_m;
+    } else if (!companion_followed && (!crypto_suppressed || was_active || ctx->t_hangtime_m <= 0.0)) {
+        p25_sm_arm_hangtime(ctx, inactive_since_m);
     }
     p25_sm_diagf(opts, state, ctx, "voice_classification_wait", "kind=%s slot=%d crypto_state=%d identity_pending=%d",
                  why, slot, (int)state->p25_crypto_state[slot], identity_pending);
@@ -3442,7 +3663,7 @@ handle_voice_start(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p2
         dsd_event_sync_slot(opts, state, (uint8_t)s);
         return 1;
     }
-    ctx->t_hangtime_m = 0.0;
+    p25_sm_cancel_hangtime(ctx);
 
     // Update slot activity
     ctx->slots[s].voice_active = 1;
@@ -3722,7 +3943,7 @@ handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, 
     const int other_active = p25_voice_end_diag_other_active(ctx, state, s);
     if (!other_active) {
         ctx->t_voice_m = 0.0;
-        ctx->t_hangtime_m = now_m;
+        p25_sm_arm_hangtime(ctx, now_m);
     }
     if (arm_stale_regrant_guard) {
         (void)p25_stale_regrant_guard_arm(ctx, opts, state, s);
@@ -3798,9 +4019,15 @@ p25_facch_has_newer_grant(const p25_sm_ctx_t* ctx, double first_end_m) {
 // later. The suppression stamp refreshes on every FEC-accepted ESS repeat
 // (via p25_sm_note_enc_suppressed) for as long as that call keeps
 // transmitting, so a stamp fresh within the effective hangtime means
-// "occupied right now" while surviving ESS decode stalls; once the repeats
-// stop, the stamp ages out and the hangtime-expiry tick still owns the
-// release of a genuinely emptied channel.
+// "occupied right now" while surviving ESS decode stalls.
+//
+// What the hold buys is the hangtime window, not an indefinite stay: the
+// hangtime-expiry tick owns the release either way, and it now fires one
+// hangtime after the last *followed* traffic whether or not the locked-out call
+// is still transmitting. Declining the fast release here is what leaves that
+// window open, so the ended conversation's next over can still be re-granted on
+// this same channel instead of the carrier closing the instant the double END
+// lands.
 static int
 p25_facch_companion_enc_suppressed(const p25_sm_ctx_t* ctx, const dsd_state* state, int slot, double now_m) {
     if (!ctx->vc_is_tdma) {
@@ -4113,7 +4340,7 @@ p25_enc_lockout_release_or_hold(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* st
             // transitions to revisit the release. Backdate the countdown to
             // the companion's real stop so the hangtime tick still owns
             // releasing the channel if the companion never resumes.
-            ctx->t_hangtime_m = ctx->slots[other].last_stop_m;
+            p25_sm_arm_hangtime(ctx, ctx->slots[other].last_stop_m);
         }
         p25_sm_diagf(opts, state, ctx, "enc_lockout_hangtime_hold", "slot=%d other=%d gap=%.3f", slot, other,
                      now_m - ctx->slots[other].last_stop_m);
@@ -4157,6 +4384,7 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
             const int rel_target = p25_enc_lockout_target(&ctx->slots[slot], tg, &rel_is_group);
             if (rel_target > 0) {
                 (void)dsd_enc_lockout_release(state, (uint32_t)rel_target, rel_is_group);
+                p25_grant_enc_reprobe_forget(ctx, (uint32_t)rel_target, rel_is_group);
             }
         }
         p25_call_publish_crypto(opts, state, slot, dsd_time_now_monotonic_s());
@@ -4272,7 +4500,7 @@ p25_release_clear_context(p25_sm_ctx_t* ctx) {
     ctx->vc_stale_regrant_probe_slot = -1;
     ctx->t_tune_m = 0.0;
     ctx->t_voice_m = 0.0;
-    ctx->t_hangtime_m = 0.0;
+    p25_sm_cancel_hangtime(ctx);
     ctx->vc_activity_seen = 0;
     p25_sm_reset_vc_reacquire_tracking(ctx);
     ctx->release_count++;
@@ -5403,6 +5631,34 @@ p25_sm_crypto_slot_expired(const p25_sm_ctx_t* ctx, const dsd_state* state, int 
     return started_m > 0.0 && (now_m - started_m) >= grant_timeout;
 }
 
+// Whether any slot is still inside its crypto-classification budget. Such a
+// slot owns the release: the call may yet resolve clear and become followed
+// traffic, and p25_sm_tick_crypto_classification() releases the carrier the
+// moment the budget lapses. The hangtime countdown keeps running underneath and
+// takes over then, so a call whose companion armed the countdown is not torn
+// down mid-classification with the countdown's remainder as its whole budget.
+static int
+p25_sm_crypto_classification_in_flight(const p25_sm_ctx_t* ctx, const dsd_state* state, double now_m,
+                                       double grant_timeout) {
+    if (!ctx || !state || grant_timeout <= 0.0) {
+        return 0;
+    }
+    const int slot_count = ctx->vc_is_tdma ? 2 : 1;
+    for (int slot = 0; slot < slot_count; slot++) {
+        if (ctx->slots[slot].data_call || state->p25_crypto_state[slot] != DSD_P25_CRYPTO_ENCRYPTED_PENDING) {
+            continue;
+        }
+        if (ctx->vc_is_tdma && !ctx->slots[slot].grant_active) {
+            continue;
+        }
+        const double started_m = ctx->slots[slot].crypto_attempt_m;
+        if (started_m > 0.0 && now_m >= started_m && (now_m - started_m) < grant_timeout) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static int
 p25_sm_block_expired_crypto_slot(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot) {
     if (!ctx->vc_is_tdma && slot == 0 && state->p25_p1_crypto_conflict.active) {
@@ -5460,7 +5716,7 @@ p25_sm_recover_expired_followed_p1_conflict(p25_sm_ctx_t* ctx, dsd_opts* opts, d
         ctx->slots[0].voice_active = 1;
         ctx->slots[0].last_active_m = now_m;
         ctx->t_voice_m = now_m;
-        ctx->t_hangtime_m = 0.0;
+        p25_sm_cancel_hangtime(ctx);
     }
     p25_sm_diagf(opts, state, ctx, "crypto_conflict_timeout",
                  "slot=0 algid=0x%02X keyid=0x%04X freq=%ld tg=%d action=resume-clear", algid, keyid, ctx->vc_freq_hz,
@@ -5524,7 +5780,19 @@ p25_sm_tick_tuned(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double no
     }
     if (ctx->t_hangtime_m > 0.0) {
         p25_sm_update_ui_mode(ctx, state);
-        p25_sm_tick_tuned_check_hangtime(ctx, opts, state, now_m, hangtime);
+        if (!p25_sm_crypto_classification_in_flight(ctx, state, now_m, grant_timeout)) {
+            p25_sm_tick_tuned_check_hangtime(ctx, opts, state, now_m, hangtime);
+        }
+        // An armed countdown no longer means "nothing is being acquired": a
+        // lockout reprobe admitted on the retained carrier keeps it running
+        // (p25_grant_initialize_timing). Its acquisition window is whichever
+        // deadline comes first, so the grant timeout still has to run here or a
+        // grant whose voice never arrives rides out the whole hangtime instead.
+        if (ctx->state == P25_SM_TUNED
+            && (!ctx->vc_activity_seen || p25_sm_has_pending_voice_grant(ctx, state)
+                || p25_sm_has_pending_data_grant(ctx))) {
+            p25_sm_tick_tuned_wait_voice(ctx, opts, state, now_m, grant_timeout);
+        }
         return;
     }
     p25_sm_update_ui_mode(ctx, state);

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -62,6 +62,8 @@ static void p25_voice_release_or_preserve_companion(p25_sm_ctx_t* ctx, dsd_opts*
 static void handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev);
 static void handle_crypto_pending(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev);
 static double p25_sm_effective_hangtime(const dsd_state* state, double hangtime);
+static int p25_sm_crypto_classification_in_flight(const p25_sm_ctx_t* ctx, const dsd_state* state, double now_m,
+                                                  double grant_timeout);
 
 typedef enum {
     // Positive per-transmission evidence: MAC_PTT / MAC_ACTIVE or an
@@ -1601,6 +1603,11 @@ p25_grant_clear_one_slot_state(p25_sm_ctx_t* ctx, int slot) {
     ctx->slots[slot].data_call = 0;
     ctx->slots[slot].svc_bits = P25_SM_SVC_UNKNOWN;
     ctx->slots[slot].enc_override_clear = 0;
+    ctx->slots[slot].enc_lockout_reprobe = 0;
+    // The slot's followed history goes with the slot: a new assignment taking
+    // it over is the "cancel" the countdown used to need, and clearing every
+    // slot on a physical retune is the release-time reset.
+    ctx->slots[slot].last_followed_m = 0.0;
     ctx->slots[slot].last_grant_m = 0.0;
     ctx->slots[slot].crypto_attempt_m = 0.0;
     ctx->slots[slot].last_end_m = 0.0;
@@ -1699,6 +1706,7 @@ p25_grant_store_slot_context(p25_sm_ctx_t* ctx, const p25_sm_event_t* ev, long f
     slot_ctx->data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
     slot_ctx->svc_bits = ev->svc_bits;
     slot_ctx->enc_override_clear = (eval_ctx && eval_ctx->enc_override_clear) ? 1 : 0;
+    slot_ctx->enc_lockout_reprobe = (eval_ctx && eval_ctx->enc_lockout_reprobe) ? 1 : 0;
     slot_ctx->last_grant_m = now_m;
     slot_ctx->tg = target_id;
 }
@@ -1740,66 +1748,55 @@ p25_grant_commit_decoder_tune(dsd_opts* opts, dsd_state* state, long freq) {
 }
 
 /*
- * The hangtime countdown is one channel-wide deadline: release this carrier one
- * hangtime after the last *followed* traffic on it. Every write goes through
- * these two helpers so the rule is stated in one place --
- *
- *   arm    -- followed traffic stopped: an END, or a slot leaving followed
- *             activity. Signaling that the SM is not following (a
- *             classification-suppressed voice start, a locked-out slot's
- *             MAC_PTT/MAC_ACTIVE repeats, a reprobe assignment) must neither
- *             arm nor restart it.
- *   cancel -- followed traffic resumed on the carrier, or the carrier is gone.
- *
- * -- and a new call site has to pick one instead of inventing a third rule.
- * The deadline itself is read in exactly one place,
- * p25_sm_tick_tuned_check_hangtime().
+ * The hangtime countdown is one channel-wide deadline -- release this carrier
+ * one hangtime after the last *followed* traffic on it -- but it is not a
+ * channel-wide variable anybody arms. It is derived here from the per-slot
+ * last_followed_m stamps, which are written only where followed traffic exists
+ * or ends. That is what makes the rule enforceable rather than merely agreed:
+ * a locked-out slot's MAC repeats, its ESS repeats, and the clear-claiming
+ * grant updates that re-admit it never touch those stamps, so no amount of
+ * signaling the SM is not following can restart or cancel the countdown, and a
+ * new call site cannot get the rule wrong without first writing a stamp whose
+ * name says what it means.
  */
-static void
-p25_sm_arm_hangtime(p25_sm_ctx_t* ctx, double at_m) {
-    if (!ctx || at_m <= 0.0) {
-        return;
-    }
-    ctx->t_hangtime_m = at_m;
-}
-
-static void
-p25_sm_cancel_hangtime(p25_sm_ctx_t* ctx) {
+double
+p25_sm_hangtime_started_m(const p25_sm_ctx_t* ctx) {
     if (!ctx) {
+        return 0.0;
+    }
+    const int slot_count = ctx->vc_is_tdma ? 2 : 1;
+    double started_m = 0.0;
+    for (int slot = 0; slot < slot_count; slot++) {
+        if (ctx->slots[slot].voice_active) {
+            // Followed traffic is on the air: no countdown is running.
+            return 0.0;
+        }
+        if (ctx->slots[slot].last_followed_m > started_m) {
+            started_m = ctx->slots[slot].last_followed_m;
+        }
+    }
+    return started_m;
+}
+
+// Stamp the moment this slot stopped carrying traffic the SM was following.
+// The only writer of the hangtime countdown's origin; callers that are not
+// looking at followed traffic must not call it.
+static void
+p25_sm_note_followed_until(p25_sm_ctx_t* ctx, int slot, double until_m) {
+    if (!ctx || slot < 0 || slot > 1 || until_m <= 0.0) {
         return;
     }
-    ctx->t_hangtime_m = 0.0;
+    ctx->slots[slot].last_followed_m = until_m;
 }
 
 static void
-p25_grant_initialize_timing(p25_sm_ctx_t* ctx, dsd_state* state, double now_m, int reused_carrier, int data_call,
-                            int enc_lockout_reprobe) {
+p25_grant_initialize_timing(p25_sm_ctx_t* ctx, dsd_state* state, double now_m, int reused_carrier, int data_call) {
     // Every accepted assignment owns a fresh acquisition window, even when no
     // physical retune is needed. Do not let the preceding transmission's hang
     // or activity state suppress the grant timeout for a retained carrier.
-    const double hangtime_armed_m = ctx->t_hangtime_m;
-    const int keep_hangtime = enc_lockout_reprobe && reused_carrier && hangtime_armed_m > 0.0;
     ctx->t_tune_m = now_m;
     ctx->t_voice_m = 0.0;
     ctx->vc_activity_seen = 0;
-    if (keep_hangtime) {
-        // A locked-out target re-admitted on the retained carrier by a
-        // clear-claiming grant is a reprobe, not followed traffic: the site
-        // repeats such grant updates for the life of the encrypted call, and
-        // letting each one restart the countdown held the channel until the
-        // encrypted call ended. Keep the armed countdown; a reprobe whose
-        // voice really classifies clear cancels it on that voice start.
-        //
-        // The reprobe's acquisition window is therefore whichever deadline
-        // comes first: p25_sm_tick_tuned() keeps running the grant timeout
-        // alongside the countdown, so the reprobe cannot outlive the hangtime
-        // the last followed transmission set, and a reprobe whose voice never
-        // arrives still gives the carrier up after grant_timeout_s rather than
-        // riding out a long configured hangtime.
-        p25_sm_arm_hangtime(ctx, hangtime_armed_m);
-    } else {
-        p25_sm_cancel_hangtime(ctx);
-    }
     if (reused_carrier) {
         p25_grant_refresh_reused_carrier_watchdogs(state, now_m);
     } else {
@@ -1850,8 +1847,7 @@ p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_eve
     }
     const int data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
     ctx->vc_data_call = data_call;
-    p25_grant_initialize_timing(ctx, state, now_m, reused_carrier, data_call,
-                                eval_ctx ? eval_ctx->enc_lockout_reprobe : 0);
+    p25_grant_initialize_timing(ctx, state, now_m, reused_carrier, data_call);
     const int logical_slot = p25_grant_logical_slot(ctx, slot);
     p25_grant_store_slot_context(ctx, ev, freq, target_id, eval_ctx, logical_slot, now_m);
     if (state) {
@@ -2332,6 +2328,29 @@ p25_grant_blocked_by_pending_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* st
     return 1;
 }
 
+// Take the slot(s) over for an accepted assignment. Clearing a slot's state is
+// what resets its followed history -- the "cancel" the hangtime countdown used
+// to be given explicitly -- so a lockout reprobe, which is not followed traffic,
+// keeps its stamp. The site repeats a clear-claiming grant update for the life
+// of the encrypted call, and letting each one pass for followed traffic having
+// resumed held the carrier until that call ended.
+static void
+p25_grant_claim_slots(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_event_t* ev, const p25_grant_route_ctx_t* grant,
+                      const p25_grant_eval_ctx_t* eval_ctx) {
+    const int slot = grant->logical_slot;
+    const double keep_followed_m = (eval_ctx->enc_lockout_reprobe && grant->reused_carrier && slot >= 0 && slot <= 1)
+                                       ? ctx->slots[slot].last_followed_m
+                                       : 0.0;
+    if (grant->clear_policy_slot_only) {
+        p25_grant_clear_one_slot_state(ctx, slot);
+    } else {
+        p25_grant_clear_slot_state(ctx);
+    }
+    p25_grant_store_vc_context(ctx, state, ev, grant->freq, grant->target_id, eval_ctx, grant->now_m, grant->slot,
+                               grant->reused_carrier);
+    p25_sm_note_followed_until(ctx, slot, keep_followed_m);
+}
+
 static void
 p25_grant_start_stale_regrant_probe(p25_sm_ctx_t* ctx, const p25_grant_route_ctx_t* grant) {
     if (!ctx || !grant) {
@@ -2394,13 +2413,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     p25_sm_cancel_pending_cc_acquisition(ctx);
     p25_grant_clear_moved_target_slots(ctx, opts, state, grant.slot, ev, grant.target_id, grant.freq,
                                        eval_ctx.data_call);
-    if (grant.clear_policy_slot_only) {
-        p25_grant_clear_one_slot_state(ctx, grant.logical_slot);
-    } else {
-        p25_grant_clear_slot_state(ctx);
-    }
-    p25_grant_store_vc_context(ctx, state, ev, grant.freq, grant.target_id, &eval_ctx, grant.now_m, grant.slot,
-                               grant.reused_carrier);
+    p25_grant_claim_slots(ctx, state, ev, &grant, &eval_ctx);
     p25_grant_start_stale_regrant_probe(ctx, &grant);
     if (!grant.reused_carrier) {
         ctx->tune_count++;
@@ -3520,25 +3533,21 @@ p25_voice_start_wait_for_classification(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
     // blocked slot active. Clear that stale activity before ignoring subsequent
     // voice indications so the tuned timer can release it.
     //
-    // A lockout-suppressed voice start is not followed traffic, though: the
-    // locked-out slot repeats MAC_PTT/MAC_ACTIVE for the life of its
-    // transmission, and restarting an already-armed countdown on every repeat
-    // held the channel until the encrypted call ended. For that reason only the
-    // transition out of followed activity on this slot (or a carrier with no
-    // countdown at all) may arm it. A Phase 1 identity wait is the opposite
-    // case -- a followed call whose LCW identity has not decoded yet, with no
-    // repeat loop behind it -- and keeps re-arming as before, or an over that
-    // keys up late in the window is released while its voice is on the air.
+    // Only two of the starts that land here were followed traffic, and only
+    // those two move this slot's followed stamp:
     //
-    // "Followed activity" is read per slot, not off the channel-wide t_voice_m:
-    // the tick re-stamps that to now on every pass while *either* slot is
-    // voice_active, so on a busy TDMA carrier the locked-out slot's own repeats
-    // would each look like a transition and restart the countdown. For the same
-    // reason the countdown stays unarmed while the companion is still followed
-    // -- its END owns arming it.
+    //   - a slot that *was* active: lockout just took a call the SM had been
+    //     following, so its followed history ends where that activity did;
+    //   - a Phase 1 identity wait: a followed call whose LCW identity has not
+    //     decoded yet. It keeps the stamp current, or an over that keys up late
+    //     in the window is released while its voice is on the air.
+    //
+    // Everything else here is a locked-out slot repeating MAC_PTT/MAC_ACTIVE
+    // for the life of a transmission the SM is not following. Those repeats
+    // leave the stamp alone, so they can neither restart the countdown nor
+    // start one -- no guard needed, because they write nothing.
     const int was_active = ctx->slots[slot].voice_active;
-    const int companion_followed = ctx->vc_is_tdma && ctx->slots[slot ^ 1].voice_active;
-    const double inactive_since_m =
+    const double followed_until_m =
         (was_active && ctx->slots[slot].last_active_m > 0.0) ? ctx->slots[slot].last_active_m : now_m;
     ctx->slots[slot].voice_active = 0;
     ctx->slots[slot].last_active_m = 0.0;
@@ -3551,8 +3560,8 @@ p25_voice_start_wait_for_classification(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
         if (ctx->slots[slot].crypto_attempt_m <= 0.0) {
             ctx->slots[slot].crypto_attempt_m = now_m;
         }
-    } else if (!companion_followed && (!crypto_suppressed || was_active || ctx->t_hangtime_m <= 0.0)) {
-        p25_sm_arm_hangtime(ctx, inactive_since_m);
+    } else if (was_active || identity_pending) {
+        p25_sm_note_followed_until(ctx, slot, followed_until_m);
     }
     p25_sm_diagf(opts, state, ctx, "voice_classification_wait", "kind=%s slot=%d crypto_state=%d identity_pending=%d",
                  why, slot, (int)state->p25_crypto_state[slot], identity_pending);
@@ -3655,17 +3664,14 @@ handle_voice_start(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p2
 
     ctx->vc_activity_seen = 1;
 
-    // Classification-suppressed voice starts must not cancel a running
-    // hangtime countdown -- p25_voice_start_wait_for_classification decides
-    // what a suppressed slot may do to it. Only a followed voice start below
-    // cancels the countdown.
     if (p25_voice_start_wait_for_classification(ctx, opts, state, s, why, now_m)) {
         dsd_event_sync_slot(opts, state, (uint8_t)s);
         return 1;
     }
-    p25_sm_cancel_hangtime(ctx);
 
-    // Update slot activity
+    // Update slot activity. Marking the slot active is what stops the hangtime
+    // countdown: a classification-suppressed start never reaches here, so it
+    // cannot stop one it is not entitled to.
     ctx->slots[s].voice_active = 1;
     ctx->slots[s].last_active_m = now_m;
     (void)dsd_call_state_update_media(state, (uint8_t)s, 1, now_m);
@@ -3939,11 +3945,14 @@ handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, 
         state->p25_p1_identity_epoch_started = 0;
     }
     ctx->slots[s].last_stop_m = now_m;
+    // This slot followed traffic right up to now. Recorded unconditionally: it
+    // is an observation, not a decision about the carrier, and a companion that
+    // is still busy keeps the countdown from running on its own.
+    p25_sm_note_followed_until(ctx, s, now_m);
     ctx->vc_activity_seen = 1;
     const int other_active = p25_voice_end_diag_other_active(ctx, state, s);
     if (!other_active) {
         ctx->t_voice_m = 0.0;
-        p25_sm_arm_hangtime(ctx, now_m);
     }
     if (arm_stale_regrant_guard) {
         (void)p25_stale_regrant_guard_arm(ctx, opts, state, s);
@@ -3957,7 +3966,7 @@ handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, 
     if (!other_active) {
         p25_sm_diagf(opts, state, ctx, "traffic_hang",
                      "phase=%s freq=%ld slot=%d tg=%d src=%d reason=%s started_m=%.3f", p25_voice_phase_name(ctx),
-                     ctx->vc_freq_hz, s, ended_tg, ended_src, why, ctx->t_hangtime_m);
+                     ctx->vc_freq_hz, s, ended_tg, ended_src, why, p25_sm_hangtime_started_m(ctx));
     }
     p25_sm_update_ui_mode(ctx, state);
     return 1;
@@ -4333,15 +4342,6 @@ p25_enc_lockout_release_or_hold(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* st
     const double now_m = dsd_time_now_monotonic_s();
     if (ctx->vc_is_tdma && !p25_voice_other_slot_active(ctx, state, other)
         && p25_voice_companion_gap_within_hangtime(ctx, state, other, now_m)) {
-        if (ctx->t_hangtime_m <= 0.0) {
-            // The companion's END may not have armed the countdown -- this
-            // slot's reprobe assignment read as pending activity there -- and
-            // the locked-out transmission produces no further classification
-            // transitions to revisit the release. Backdate the countdown to
-            // the companion's real stop so the hangtime tick still owns
-            // releasing the channel if the companion never resumes.
-            p25_sm_arm_hangtime(ctx, ctx->slots[other].last_stop_m);
-        }
         p25_sm_diagf(opts, state, ctx, "enc_lockout_hangtime_hold", "slot=%d other=%d gap=%.3f", slot, other,
                      now_m - ctx->slots[other].last_stop_m);
         sm_log(opts, state, "enc-lockout-hangtime-hold");
@@ -4500,7 +4500,6 @@ p25_release_clear_context(p25_sm_ctx_t* ctx) {
     ctx->vc_stale_regrant_probe_slot = -1;
     ctx->t_tune_m = 0.0;
     ctx->t_voice_m = 0.0;
-    p25_sm_cancel_hangtime(ctx);
     ctx->vc_activity_seen = 0;
     p25_sm_reset_vc_reacquire_tracking(ctx);
     ctx->release_count++;
@@ -5304,27 +5303,69 @@ p25_sm_effective_hangtime(const dsd_state* state, double hangtime) {
     return hangtime;
 }
 
-static void
-p25_sm_tick_tuned_check_hangtime(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m, double hangtime) {
-    double dt_hang = 0.0;
-    double effective_hangtime = 0.0;
-    if (!ctx || ctx->t_hangtime_m <= 0.0) {
-        return;
+// An accepted assignment the SM has positive reason to follow keeps the carrier
+// until its acquisition window closes: the hangtime deadline bridges a
+// conversation's talker gaps, it does not cut short a call the site has already
+// granted on the other slot. An encryption-lockout reprobe is the exception --
+// it rests on one grant bit the ledger contradicts, so it may acquire but not
+// outlive the countdown the last followed transmission left running.
+static int
+p25_sm_followable_assignment_acquiring(const p25_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state,
+                                       double now_m, double grant_timeout) {
+    if (!ctx || grant_timeout <= 0.0) {
+        return 0;
     }
-    dt_hang = now_m - ctx->t_hangtime_m;
-    effective_hangtime = p25_sm_effective_hangtime(state, hangtime);
-    if (dt_hang >= effective_hangtime) {
-        int slot = ctx->vc_is_tdma && state ? state->p25_p2_active_slot : 0;
-        if (slot < 0 || slot > 1) {
-            slot = 0;
+    const int slot_count = ctx->vc_is_tdma ? 2 : 1;
+    for (int slot = 0; slot < slot_count; slot++) {
+        const p25_sm_slot_ctx_t* slot_ctx = &ctx->slots[slot];
+        const int pending = slot_ctx->data_call ? (slot_ctx->grant_active && ctx->vc_is_tdma)
+                                                : p25_sm_slot_waiting_for_voice(ctx, state, slot);
+        // An assignment whose voice encryption lockout is refusing to follow is
+        // not one the SM is waiting on, however live it looks: its transmission
+        // may outlast several hangtimes and the carrier would never come back.
+        if (slot_ctx->enc_lockout_reprobe || !pending || p25_voice_start_crypto_suppressed(opts, state, slot)) {
+            continue;
         }
-        p25_sm_diagf(opts, state, ctx, "hang_expired",
-                     "phase=%s freq=%ld slot=%d tg=%d src=%d reason=inactivity elapsed=%.3f hangtime=%.3f",
-                     p25_voice_phase_name(ctx), ctx->vc_freq_hz, slot, ctx->slots[slot].target_id,
-                     ctx->slots[slot].src > 0 ? ctx->slots[slot].src : ctx->slots[slot].last_end_src, dt_hang,
-                     effective_hangtime);
-        do_release(ctx, opts, state, "hangtime-expired", 0);
+        double started_m = ctx->slots[slot].last_grant_m;
+        if (ctx->t_tune_m > started_m) {
+            started_m = ctx->t_tune_m;
+        }
+        if (started_m > 0.0 && now_m >= started_m && (now_m - started_m) < grant_timeout) {
+            return 1;
+        }
     }
+    return 0;
+}
+
+static int
+p25_sm_tick_tuned_check_hangtime(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m, double hangtime,
+                                 double grant_timeout) {
+    const double started_m = p25_sm_hangtime_started_m(ctx);
+    if (started_m <= 0.0 || now_m < started_m) {
+        return 0;
+    }
+    const double dt_hang = now_m - started_m;
+    const double effective_hangtime = p25_sm_effective_hangtime(state, hangtime);
+    if (dt_hang < effective_hangtime) {
+        return 0;
+    }
+    // A crypto classification still inside its budget owns the release instead:
+    // the call may yet resolve clear and become followed traffic, and
+    // p25_sm_tick_crypto_classification() gives the carrier up when it lapses.
+    if (p25_sm_crypto_classification_in_flight(ctx, state, now_m, grant_timeout)
+        || p25_sm_followable_assignment_acquiring(ctx, opts, state, now_m, grant_timeout)) {
+        return 0;
+    }
+    int slot = ctx->vc_is_tdma && state ? state->p25_p2_active_slot : 0;
+    if (slot < 0 || slot > 1) {
+        slot = 0;
+    }
+    p25_sm_diagf(opts, state, ctx, "hang_expired",
+                 "phase=%s freq=%ld slot=%d tg=%d src=%d reason=inactivity elapsed=%.3f hangtime=%.3f",
+                 p25_voice_phase_name(ctx), ctx->vc_freq_hz, slot, ctx->slots[slot].target_id,
+                 ctx->slots[slot].src > 0 ? ctx->slots[slot].src : ctx->slots[slot].last_end_src, dt_hang,
+                 effective_hangtime);
+    return do_release(ctx, opts, state, "hangtime-expired", 0);
 }
 
 #ifdef USE_RADIO
@@ -5716,7 +5757,6 @@ p25_sm_recover_expired_followed_p1_conflict(p25_sm_ctx_t* ctx, dsd_opts* opts, d
         ctx->slots[0].voice_active = 1;
         ctx->slots[0].last_active_m = now_m;
         ctx->t_voice_m = now_m;
-        p25_sm_cancel_hangtime(ctx);
     }
     p25_sm_diagf(opts, state, ctx, "crypto_conflict_timeout",
                  "slot=0 algid=0x%02X keyid=0x%04X freq=%ld tg=%d action=resume-clear", algid, keyid, ctx->vc_freq_hz,
@@ -5778,24 +5818,14 @@ p25_sm_tick_tuned(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double no
         p25_sm_update_ui_mode(ctx, state);
         return;
     }
-    if (ctx->t_hangtime_m > 0.0) {
-        p25_sm_update_ui_mode(ctx, state);
-        if (!p25_sm_crypto_classification_in_flight(ctx, state, now_m, grant_timeout)) {
-            p25_sm_tick_tuned_check_hangtime(ctx, opts, state, now_m, hangtime);
-        }
-        // An armed countdown no longer means "nothing is being acquired": a
-        // lockout reprobe admitted on the retained carrier keeps it running
-        // (p25_grant_initialize_timing). Its acquisition window is whichever
-        // deadline comes first, so the grant timeout still has to run here or a
-        // grant whose voice never arrives rides out the whole hangtime instead.
-        if (ctx->state == P25_SM_TUNED
-            && (!ctx->vc_activity_seen || p25_sm_has_pending_voice_grant(ctx, state)
-                || p25_sm_has_pending_data_grant(ctx))) {
-            p25_sm_tick_tuned_wait_voice(ctx, opts, state, now_m, grant_timeout);
-        }
+    p25_sm_update_ui_mode(ctx, state);
+    // Two deadlines, both always live. The hangtime countdown is derived, so
+    // there is no longer an "armed" state that could hide the acquisition
+    // watchdog from a carrier that is in hangtime and acquiring at once -- which
+    // is exactly what a lockout reprobe on a retained carrier looks like.
+    if (p25_sm_tick_tuned_check_hangtime(ctx, opts, state, now_m, hangtime, grant_timeout)) {
         return;
     }
-    p25_sm_update_ui_mode(ctx, state);
     if (!ctx->vc_activity_seen || p25_sm_has_pending_voice_grant(ctx, state) || p25_sm_has_pending_data_grant(ctx)) {
         p25_sm_tick_tuned_wait_voice(ctx, opts, state, now_m, grant_timeout);
     }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -3973,6 +3973,22 @@ p25_voice_end_clear_policy_route(const p25_sm_ctx_t* ctx, dsd_state* state, int 
     (void)dsd_tg_policy_clear_active_call(state, ctx->vc_is_tdma ? slot : -1);
 }
 
+// A suppressed companion's transmission announces its own end here: the
+// explicit MAC END still decodes after lockout erased the assignment, so it
+// arrives only to be rejected as no-assignment. Terminate the suppression
+// stamp anyway -- whatever identity the END names, it ends the transmission
+// occupying this slot -- or the FACCH double-END fast release stays held
+// against a companion that already stopped transmitting, for up to one
+// hangtime of stamp aging. A new encrypted over re-creates the stamp through
+// the full lockout action.
+static void
+p25_voice_end_terminate_enc_suppression(p25_sm_ctx_t* ctx, int slot, int is_explicit_end) {
+    if (!is_explicit_end || ctx->slots[slot].last_enc_suppress_m <= 0.0) {
+        return;
+    }
+    ctx->slots[slot].last_enc_suppress_m = 0.0;
+}
+
 // `end_reason` records what the triggering event actually said about the air:
 // DSD_CALL_END_TERMINATOR for over-the-air end signaling (a MAC_END_PTT, a Phase 1 TDU), so the
 // event layer can keep an audible epoch whose call identity never decoded, and
@@ -3991,6 +4007,7 @@ handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, 
     }
 
     int s = (slot >= 0 && slot <= 1) ? slot : 0;
+    p25_voice_end_terminate_enc_suppression(ctx, s, is_explicit_end);
     const char* reject_reason =
         p25_voice_end_event_reject_reason(ctx, state, s, is_explicit_end, arm_stale_regrant_guard, ev);
     if (reject_reason) {

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -957,72 +957,85 @@ p25_grant_patch_clear_key(const dsd_state* state, const p25_grant_eval_ctx_t* ev
 // that did not stop buy a retune per update.
 #define P25_ENC_REPROBE_COOLDOWN_S 10.0
 
+// The one place the memo key is spelled out, so widening it later cannot leave
+// a lookup behind. Returns an index rather than a pointer so const and mutable
+// callers can share it without laundering constness.
+static int
+p25_grant_enc_reprobe_index(const p25_sm_ctx_t* ctx, uint32_t target, int is_group) {
+    if (!ctx) {
+        return -1;
+    }
+    for (int i = 0; i < P25_SM_ENC_REPROBE_MEMO_MAX; i++) {
+        const p25_sm_enc_reprobe_memo_t* memo = &ctx->enc_reprobes[i];
+        if (memo->admitted_m > 0.0 && memo->target == target && memo->is_group == (uint8_t)(is_group ? 1 : 0)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+static int
+p25_grant_enc_reprobe_memo_expired(const p25_sm_enc_reprobe_memo_t* memo, double now_m) {
+    // A stamp in the future (a replayed or non-monotonic clock) counts as live:
+    // failing closed costs one delayed reprobe, failing open costs the retune
+    // loop the cooldown exists to damp.
+    return (memo->admitted_m <= 0.0)
+           || (now_m >= memo->admitted_m && (now_m - memo->admitted_m) >= P25_ENC_REPROBE_COOLDOWN_S);
+}
+
 static p25_sm_enc_reprobe_memo_t*
 p25_grant_enc_reprobe_slot(p25_sm_ctx_t* ctx, uint32_t target, int is_group, double now_m) {
-    p25_sm_enc_reprobe_memo_t* oldest = NULL;
+    const int found = p25_grant_enc_reprobe_index(ctx, target, is_group);
     if (!ctx) {
         return NULL;
     }
+    if (found >= 0) {
+        return &ctx->enc_reprobes[found];
+    }
+    p25_sm_enc_reprobe_memo_t* victim = NULL;
     for (int i = 0; i < P25_SM_ENC_REPROBE_MEMO_MAX; i++) {
         p25_sm_enc_reprobe_memo_t* memo = &ctx->enc_reprobes[i];
-        if (memo->admitted_m > 0.0 && memo->target == target && memo->is_group == (uint8_t)(is_group ? 1 : 0)) {
-            return memo;
+        if (!p25_grant_enc_reprobe_memo_expired(memo, now_m)) {
+            continue;
         }
-        if (memo->admitted_m <= 0.0 || now_m - memo->admitted_m >= P25_ENC_REPROBE_COOLDOWN_S) {
-            // Free or expired: reuse the least recently admitted of those.
-            if (!oldest || memo->admitted_m < oldest->admitted_m) {
-                oldest = memo;
-            }
+        // Free or expired: reuse the least recently admitted of those.
+        if (!victim || memo->admitted_m < victim->admitted_m) {
+            victim = memo;
         }
     }
-    if (oldest) {
-        return oldest;
-    }
-    // Every slot holds a live cooldown. Evict the oldest so a burst of distinct
-    // targets cannot pin the table and disable the backoff for a new one.
-    oldest = &ctx->enc_reprobes[0];
-    for (int i = 1; i < P25_SM_ENC_REPROBE_MEMO_MAX; i++) {
-        if (ctx->enc_reprobes[i].admitted_m < oldest->admitted_m) {
-            oldest = &ctx->enc_reprobes[i];
-        }
-    }
-    return oldest;
+    // When every entry holds a live cooldown there is no room. Recording
+    // nothing costs this target its backoff; evicting a live entry would cost
+    // some *other* target the backoff it already earned, which is how a busy
+    // site's targets round-robin the table and disable the damping for all of
+    // them.
+    return victim;
 }
 
 static int
 p25_grant_enc_reprobe_in_cooldown(const p25_sm_ctx_t* ctx, uint32_t target, int is_group, double now_m) {
-    if (!ctx) {
-        return 0;
-    }
-    for (int i = 0; i < P25_SM_ENC_REPROBE_MEMO_MAX; i++) {
-        const p25_sm_enc_reprobe_memo_t* memo = &ctx->enc_reprobes[i];
-        if (memo->admitted_m <= 0.0 || memo->target != target || memo->is_group != (uint8_t)(is_group ? 1 : 0)) {
-            continue;
-        }
-        return (now_m >= memo->admitted_m && (now_m - memo->admitted_m) < P25_ENC_REPROBE_COOLDOWN_S) ? 1 : 0;
-    }
-    return 0;
+    const int found = p25_grant_enc_reprobe_index(ctx, target, is_group);
+    return (found >= 0 && !p25_grant_enc_reprobe_memo_expired(&ctx->enc_reprobes[found], now_m)) ? 1 : 0;
 }
 
 // Drop the backoff for a target whose voice actually classified clear or
-// decryptable: the grant bit was right, so a later re-lock owes a fresh probe
-// rather than serving out a cooldown earned by a different call.
+// decryptable, or whose ledger entry went away on stronger evidence: the
+// cooldown was earned against a claim that is no longer standing, so a later
+// re-lock owes a fresh probe rather than serving out someone else's window.
 static void
 p25_grant_enc_reprobe_forget(p25_sm_ctx_t* ctx, uint32_t target, int is_group) {
-    if (!ctx) {
-        return;
-    }
-    for (int i = 0; i < P25_SM_ENC_REPROBE_MEMO_MAX; i++) {
-        p25_sm_enc_reprobe_memo_t* memo = &ctx->enc_reprobes[i];
-        if (memo->admitted_m > 0.0 && memo->target == target && memo->is_group == (uint8_t)(is_group ? 1 : 0)) {
-            DSD_MEMSET(memo, 0, sizeof(*memo));
-            return;
-        }
+    const int found = p25_grant_enc_reprobe_index(ctx, target, is_group);
+    if (found >= 0) {
+        DSD_MEMSET(&ctx->enc_reprobes[found], 0, sizeof(ctx->enc_reprobes[found]));
     }
 }
 
 static void
 p25_grant_enc_reprobe_record(p25_sm_ctx_t* ctx, uint32_t target, int is_group, double now_m) {
+    if (now_m <= 0.0) {
+        // 0 is the "unused" sentinel, so a memo stamped there could never be
+        // read back. Skip rather than write one the lookups must ignore.
+        return;
+    }
     p25_sm_enc_reprobe_memo_t* memo = p25_grant_enc_reprobe_slot(ctx, target, is_group, now_m);
     if (!memo) {
         return;
@@ -1053,19 +1066,21 @@ p25_grant_enc_release_evidence(const dsd_state* state, const p25_grant_eval_ctx_
 }
 
 static void
-p25_grant_release_enc_lockout_on_grant_bit(const dsd_opts* opts, dsd_state* state, p25_grant_eval_ctx_t* eval_ctx,
-                                           uint32_t target, int is_group) {
+p25_grant_release_enc_lockout_on_grant_bit(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state,
+                                           p25_grant_eval_ctx_t* eval_ctx, uint32_t target, int is_group) {
     if (!dsd_enc_lockout_is_blocked(opts, state, target, is_group)) {
         // Nothing was blocking -- no entry, or a stale-epoch entry after new key
         // material. The grant is admitted either way, so drop any residue but do
-        // not treat the call as a reprobe.
+        // not treat the call as a reprobe. The backoff goes with the entry it
+        // was earned against, or a target that just had new key material loaded
+        // serves out a cooldown from before the change.
         (void)dsd_enc_lockout_release(state, target, is_group);
+        p25_grant_enc_reprobe_forget(ctx, target, is_group);
         return;
     }
     // The target re-locked after its last re-admission on this same evidence,
     // so the grant bit has already been shown wrong once. Let the cooldown run
     // rather than spending another tune on it.
-    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
     const double now_m = dsd_time_now_monotonic_s();
     if (p25_grant_enc_reprobe_in_cooldown(ctx, target, is_group, now_m)) {
         p25_sm_diagf((dsd_opts*)opts, state, NULL, "enc_lockout_reprobe_declined", "kind=%s target=%u reason=cooldown",
@@ -1076,9 +1091,21 @@ p25_grant_release_enc_lockout_on_grant_bit(const dsd_opts* opts, dsd_state* stat
         // The ledger armed from corroborated undecryptable voice, while this
         // admission rests on one grant bit, so downstream timing treats the call
         // as a reprobe rather than followed traffic until its voice classifies.
+        // The cooldown is *not* recorded here: handle_grant still has six ways
+        // to reject this assignment, and a window that prices a probe must not
+        // be spent on one that never ran. p25_grant_note_enc_reprobe_admitted()
+        // records it where the slot is actually taken over.
         eval_ctx->enc_lockout_reprobe = 1;
-        p25_grant_enc_reprobe_record(ctx, target, is_group, now_m);
     }
+}
+
+// Charge the backoff for a re-admission that actually claimed the carrier.
+static void
+p25_grant_note_enc_reprobe_admitted(p25_sm_ctx_t* ctx, const p25_grant_eval_ctx_t* eval_ctx, double now_m) {
+    if (!eval_ctx || !eval_ctx->enc_lockout_reprobe || eval_ctx->tg <= 0) {
+        return;
+    }
+    p25_grant_enc_reprobe_record(ctx, (uint32_t)eval_ctx->tg, !eval_ctx->is_indiv, now_m);
 }
 
 // Release a locked target before policy evaluates, so a talkgroup that stopped
@@ -1087,8 +1114,8 @@ p25_grant_release_enc_lockout_on_grant_bit(const dsd_opts* opts, dsd_state* stat
 // helper and would otherwise consume the one-shot ledger release on the weak
 // evidence without carrying the reprobe marking into grant timing.
 static void
-p25_grant_release_enc_lockout_if_clear(const dsd_opts* opts, dsd_state* state, p25_grant_eval_ctx_t* eval_ctx,
-                                       int commit) {
+p25_grant_release_enc_lockout_if_clear(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state,
+                                       p25_grant_eval_ctx_t* eval_ctx, int commit) {
     if (!opts || !state || !eval_ctx || !p25_grant_is_voice_call(eval_ctx) || eval_ctx->tg <= 0) {
         return;
     }
@@ -1102,10 +1129,15 @@ p25_grant_release_enc_lockout_if_clear(const dsd_opts* opts, dsd_state* state, p
     const uint32_t target = (uint32_t)eval_ctx->tg;
 
     switch (p25_grant_enc_release_evidence(state, eval_ctx)) {
-        case P25_ENC_RELEASE_CORROBORATED: (void)dsd_enc_lockout_release(state, target, is_group); break;
+        case P25_ENC_RELEASE_CORROBORATED:
+            // Stronger evidence than the grant bit the backoff was earned
+            // against, so it retires that backoff along with the entry.
+            (void)dsd_enc_lockout_release(state, target, is_group);
+            p25_grant_enc_reprobe_forget(ctx, target, is_group);
+            break;
         case P25_ENC_RELEASE_GRANT_BIT:
             if (commit) {
-                p25_grant_release_enc_lockout_on_grant_bit(opts, state, eval_ctx, target, is_group);
+                p25_grant_release_enc_lockout_on_grant_bit(ctx, opts, state, eval_ctx, target, is_group);
             }
             break;
         case P25_ENC_RELEASE_NONE:
@@ -1232,16 +1264,15 @@ p25_grant_track_src_tg(dsd_state* state, const p25_sm_event_t* ev, const p25_gra
 // former may spend the one-shot encryption-lockout ledger release, whose
 // outcome it carries into grant timing through @p out_eval_ctx.
 static int
-grant_allowed(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, dsd_tg_policy_decision* out_decision,
-              p25_grant_eval_ctx_t* out_eval_ctx, int commit) {
+grant_allowed(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev,
+              dsd_tg_policy_decision* out_decision, p25_grant_eval_ctx_t* out_eval_ctx, int commit) {
     p25_grant_eval_ctx_t eval_ctx;
     dsd_tg_policy_decision decision;
     // Filled before every return: the context carries enc_lockout_reprobe into
     // tuning and timing decisions, so a caller must never read stack residue
     // off a rejected grant.
-    DSD_MEMSET(&eval_ctx, 0, sizeof(eval_ctx));
     if (out_eval_ctx) {
-        *out_eval_ctx = eval_ctx;
+        DSD_MEMSET(out_eval_ctx, 0, sizeof(*out_eval_ctx));
     }
     if (!opts || !state || !ev) {
         return 0;
@@ -1250,7 +1281,9 @@ grant_allowed(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, dsd_tg
     eval_ctx = p25_grant_eval_ctx_from_event(ev);
     p25_grant_apply_clear_override(opts, state, &eval_ctx);
     p25_grant_apply_crypto_probe(opts, &eval_ctx);
-    p25_grant_release_enc_lockout_if_clear(opts, state, &eval_ctx, commit);
+    p25_grant_release_enc_lockout_if_clear(ctx, opts, state, &eval_ctx, commit);
+    // Nothing below mutates eval_ctx, so this single copy covers every return
+    // that follows.
     if (out_eval_ctx) {
         *out_eval_ctx = eval_ctx;
     }
@@ -1262,9 +1295,6 @@ grant_allowed(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, dsd_tg
         if (out_decision) {
             *out_decision = decision;
         }
-        if (out_eval_ctx) {
-            *out_eval_ctx = eval_ctx;
-        }
         return 0;
     }
 
@@ -1275,9 +1305,6 @@ grant_allowed(dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev, dsd_tg
 
     if (out_decision) {
         *out_decision = decision;
-    }
-    if (out_eval_ctx) {
-        *out_eval_ctx = eval_ctx;
     }
     return 1;
 }
@@ -1604,10 +1631,12 @@ p25_grant_clear_one_slot_state(p25_sm_ctx_t* ctx, int slot) {
     ctx->slots[slot].svc_bits = P25_SM_SVC_UNKNOWN;
     ctx->slots[slot].enc_override_clear = 0;
     ctx->slots[slot].enc_lockout_reprobe = 0;
-    // The slot's followed history goes with the slot: a new assignment taking
-    // it over is the "cancel" the countdown used to need, and clearing every
-    // slot on a physical retune is the release-time reset.
-    ctx->slots[slot].last_followed_m = 0.0;
+    // last_followed_m is deliberately NOT cleared here. It is carrier history,
+    // not assignment state, and this helper also runs for slots that are merely
+    // being vacated (p25_grant_clear_moved_target_slots) -- wiping the countdown
+    // origin as a side effect of tidying an unrelated slot is how the deadline
+    // silently disappears. The two places that really do end that history reset
+    // it by name: p25_grant_claim_slots() and p25_sm_clear_followed_history().
     ctx->slots[slot].last_grant_m = 0.0;
     ctx->slots[slot].crypto_attempt_m = 0.0;
     ctx->slots[slot].last_end_m = 0.0;
@@ -1787,6 +1816,18 @@ p25_sm_note_followed_until(p25_sm_ctx_t* ctx, int slot, double until_m) {
         return;
     }
     ctx->slots[slot].last_followed_m = until_m;
+}
+
+// Forget that this carrier ever carried followed traffic. The countdown's only
+// eraser: a physical retune lands on a different carrier, and a release ends
+// the one the history described.
+static void
+p25_sm_clear_followed_history(p25_sm_ctx_t* ctx) {
+    if (!ctx) {
+        return;
+    }
+    ctx->slots[0].last_followed_m = 0.0;
+    ctx->slots[1].last_followed_m = 0.0;
 }
 
 static void
@@ -2149,6 +2190,14 @@ p25_grant_handle_duplicate(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* s
 
     p25_grant_refresh_duplicate_slot(ctx, state, route, now_m, data_call);
     p25_grant_refresh_duplicate_crypto(ctx, state, ev, route, eval_ctx, data_call, now_m);
+    // A duplicate can still be the update that spent the ledger release, and
+    // this path never reaches p25_grant_store_slot_context(). Carry the marking
+    // in -- only ever setting it, so an ordinary repeat of an already-marked
+    // assignment cannot launder it away.
+    if (eval_ctx && eval_ctx->enc_lockout_reprobe && route->slot >= 0 && route->slot <= 1) {
+        ctx->slots[route->slot].enc_lockout_reprobe = 1;
+    }
+    p25_grant_note_enc_reprobe_admitted(ctx, eval_ctx, now_m);
     const int call_slot = p25_grant_logical_slot(ctx, route->slot);
     if (!data_call && call_slot >= 0 && call_slot <= 1 && ctx->slots[call_slot].voice_active) {
         p25_call_publish_observation(ctx, opts, state, call_slot, 0, 0, 0, P25_CALL_OBS_ASSIGNMENT_REPEAT, now_m);
@@ -2338,17 +2387,25 @@ static void
 p25_grant_claim_slots(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_event_t* ev, const p25_grant_route_ctx_t* grant,
                       const p25_grant_eval_ctx_t* eval_ctx) {
     const int slot = grant->logical_slot;
-    const double keep_followed_m = (eval_ctx->enc_lockout_reprobe && grant->reused_carrier && slot >= 0 && slot <= 1)
-                                       ? ctx->slots[slot].last_followed_m
-                                       : 0.0;
     if (grant->clear_policy_slot_only) {
         p25_grant_clear_one_slot_state(ctx, slot);
+        // Taking the slot over is the cancel the countdown used to be given
+        // explicitly -- but only for an assignment the SM has reason to follow.
+        // A lockout reprobe is not followed traffic, and the site repeats its
+        // clear-claiming grant update for the life of the encrypted call, so
+        // letting each one pass for followed traffic having resumed held the
+        // carrier until that call ended.
+        if (!eval_ctx->enc_lockout_reprobe && slot >= 0 && slot <= 1) {
+            ctx->slots[slot].last_followed_m = 0.0;
+        }
     } else {
+        // A physical retune: the followed history described the carrier being
+        // left behind.
         p25_grant_clear_slot_state(ctx);
+        p25_sm_clear_followed_history(ctx);
     }
     p25_grant_store_vc_context(ctx, state, ev, grant->freq, grant->target_id, eval_ctx, grant->now_m, grant->slot,
                                grant->reused_carrier);
-    p25_sm_note_followed_until(ctx, slot, keep_followed_m);
 }
 
 static void
@@ -2372,10 +2429,9 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     if (!ctx || !ev || !opts || !state) {
         return;
     }
-    DSD_MEMSET(&eval_ctx, 0, sizeof(eval_ctx));
 
     // Check grant policy
-    if (!grant_allowed(opts, state, ev, &decision, &eval_ctx, 1)) {
+    if (!grant_allowed(ctx, opts, state, ev, &decision, &eval_ctx, 1)) {
         return;
     }
 
@@ -2414,6 +2470,7 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     p25_grant_clear_moved_target_slots(ctx, opts, state, grant.slot, ev, grant.target_id, grant.freq,
                                        eval_ctx.data_call);
     p25_grant_claim_slots(ctx, state, ev, &grant, &eval_ctx);
+    p25_grant_note_enc_reprobe_admitted(ctx, &eval_ctx, grant.now_m);
     p25_grant_start_stale_regrant_probe(ctx, &grant);
     if (!grant.reused_carrier) {
         ctx->tune_count++;
@@ -2441,7 +2498,7 @@ p25_sm_apply_group_grant_policy(dsd_opts* opts, dsd_state* state, int channel, i
 
     p25_sm_event_t ev = p25_sm_ev_group_grant(channel, 0, tg, src, svc_bits);
     dsd_tg_policy_decision decision;
-    if (grant_allowed(opts, state, &ev, &decision, NULL, 0)) {
+    if (grant_allowed(p25_sm_get_ctx(), opts, state, &ev, &decision, NULL, 0)) {
         p25_sm_diagf(opts, state, NULL, "grant_policy_only", "ch=0x%04X tg=%d src=%d svc=0x%02X policy_tg=%u",
                      channel & 0xFFFF, tg, src, svc_bits & 0xFF, decision.target_id);
     }
@@ -3374,6 +3431,17 @@ p25_voice_start_update_crypto(p25_sm_ctx_t* ctx, dsd_state* state, int slot, int
     }
 }
 
+// A slot that changes hands drops any reprobe marking: it belonged to the
+// identity being replaced, and leaving it on would deny the new call the
+// acquisition deferral it never had reason to lose.
+static void
+p25_voice_start_clear_stale_reprobe(p25_sm_slot_ctx_t* slot_ctx, const p25_sm_event_t* call_ev, int target_id) {
+    const int is_group = call_ev->is_group ? 1 : 0;
+    if (slot_ctx->target_id != target_id || slot_ctx->is_group != is_group) {
+        slot_ctx->enc_lockout_reprobe = 0;
+    }
+}
+
 static void
 p25_voice_start_commit_identity(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot,
                                 const p25_sm_event_t* call_ev, const dsd_tg_policy_decision* decision,
@@ -3397,6 +3465,7 @@ p25_voice_start_commit_identity(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* st
     const int target_id = p25_grant_target_id(call_ev, decision);
     dsd_tg_policy_call_route route;
     p25_grant_fill_route(&route, call_ev, slot_ctx->freq_hz, ctx->vc_is_tdma ? slot : -1, 0, target_id);
+    p25_voice_start_clear_stale_reprobe(slot_ctx, call_ev, target_id);
     slot_ctx->target_id = target_id;
     slot_ctx->ota_tg = call_ev->is_group ? call_ev->tg : 0;
     slot_ctx->dst = call_ev->is_group ? 0 : call_ev->dst;
@@ -3466,8 +3535,7 @@ p25_voice_start_apply_identity(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* sta
 
     dsd_tg_policy_decision decision;
     p25_grant_eval_ctx_t eval_ctx;
-    DSD_MEMSET(&eval_ctx, 0, sizeof(eval_ctx));
-    if (!grant_allowed(opts, state, &call_ev, &decision, &eval_ctx, 0)) {
+    if (!grant_allowed(ctx, opts, state, &call_ev, &decision, &eval_ctx, 0)) {
         p25_call_end_slot(opts, state, slot, now_m);
         p25_voice_close_slot_media(ctx, opts, state, slot);
         p25_voice_clear_slot_grant(ctx, state, slot);
@@ -3562,6 +3630,17 @@ p25_voice_start_wait_for_classification(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
         }
     } else if (was_active || identity_pending) {
         p25_sm_note_followed_until(ctx, slot, followed_until_m);
+    } else if (!ctx->slots[0].voice_active && !ctx->slots[1].voice_active && p25_sm_hangtime_started_m(ctx) <= 0.0) {
+        // Not followed traffic, so it may not move a countdown that is already
+        // running -- and with no slot active, started_m <= 0 means no slot has
+        // ever carried followed traffic on this carrier. Without a stamp here
+        // that carrier has no release deadline at all: the FDMA fall-through in
+        // p25_sm_tick_tuned() is inert (p25_sm_has_pending_voice_grant() and
+        // p25_sm_has_pending_data_grant() are TDMA-only) and vc_activity_seen
+        // is already set. main armed the countdown unconditionally here; start
+        // one exactly once, so the repeats that follow find it running and
+        // leave it alone.
+        p25_sm_note_followed_until(ctx, slot, now_m);
     }
     p25_sm_diagf(opts, state, ctx, "voice_classification_wait", "kind=%s slot=%d crypto_state=%d identity_pending=%d",
                  why, slot, (int)state->p25_crypto_state[slot], identity_pending);
@@ -3945,10 +4024,17 @@ handle_voice_end(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot, 
         state->p25_p1_identity_epoch_started = 0;
     }
     ctx->slots[s].last_stop_m = now_m;
-    // This slot followed traffic right up to now. Recorded unconditionally: it
-    // is an observation, not a decision about the carrier, and a companion that
-    // is still busy keeps the countdown from running on its own.
-    p25_sm_note_followed_until(ctx, s, now_m);
+    // This slot followed traffic right up to now: an observation, not a
+    // decision about the carrier, and a companion that is still busy keeps the
+    // countdown from running on its own. The one assignment that is not
+    // followed traffic is an encryption-lockout reprobe whose voice has not
+    // classified yet -- the site's END for the call the ledger says is
+    // encrypted must not restart the countdown any more than its grant repeats
+    // may. handle_enc clears the marking the moment that voice proves the grant
+    // bit right, so a reprobe that really did resolve clear still stamps here.
+    if (!ctx->slots[s].enc_lockout_reprobe) {
+        p25_sm_note_followed_until(ctx, s, now_m);
+    }
     ctx->vc_activity_seen = 1;
     const int other_active = p25_voice_end_diag_other_active(ctx, state, s);
     if (!other_active) {
@@ -4386,6 +4472,11 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
                 (void)dsd_enc_lockout_release(state, (uint32_t)rel_target, rel_is_group);
                 p25_grant_enc_reprobe_forget(ctx, (uint32_t)rel_target, rel_is_group);
             }
+            // The voice settled the question this assignment was admitted to
+            // ask: the grant bit was right. Stop treating it as evidence-free,
+            // or a verified-clear call stays excluded from the acquisition
+            // deferral for the rest of its assignment.
+            ctx->slots[slot].enc_lockout_reprobe = 0;
         }
         p25_call_publish_crypto(opts, state, slot, dsd_time_now_monotonic_s());
         dsd_event_sync_slot(opts, state, (uint8_t)slot);
@@ -4411,7 +4502,16 @@ handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_eve
     state->p25_p2_audio_allowed[slot] = 0;
 
     // Clear voice activity indicator to prevent audio routing logic from
-    // treating this locked-out slot as having active voice
+    // treating this locked-out slot as having active voice. Lockout just took a
+    // call the SM had been following, so -- exactly as in
+    // p25_voice_start_wait_for_classification() -- its followed history ends
+    // where that activity did, or the countdown falls back to a stale stamp
+    // from an earlier transmission and expires the moment the hold is granted.
+    if (ctx->slots[slot].voice_active) {
+        p25_sm_note_followed_until(ctx, slot,
+                                   ctx->slots[slot].last_active_m > 0.0 ? ctx->slots[slot].last_active_m
+                                                                        : dsd_time_now_monotonic_s());
+    }
     ctx->slots[slot].voice_active = 0;
     p25_voice_clear_slot_grant(ctx, state, slot);
     p25_voice_clear_slot_burst(state, slot);
@@ -4491,6 +4591,7 @@ p25_release_return_to_cc_accepted(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
 static void
 p25_release_clear_context(p25_sm_ctx_t* ctx) {
     p25_grant_clear_slot_state(ctx);
+    p25_sm_clear_followed_history(ctx);
     ctx->vc_freq_hz = 0;
     ctx->vc_channel = 0;
     ctx->vc_tg = 0;
@@ -4668,8 +4769,16 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
         p25_release_clear_context(ctx);
         const uint32_t release_count = ctx->release_count;
         const uint32_t cc_return_count = ctx->cc_return_count;
+        // The reprobe backoff is session state, like the counters below: it
+        // exists precisely to outlive the carrier release a failed reprobe ends
+        // in, because the ledger entry it consumed is already gone. Wiping it
+        // here would hand every locked-out target a free reprobe on the site's
+        // next grant repeat.
+        p25_sm_enc_reprobe_memo_t enc_reprobes[P25_SM_ENC_REPROBE_MEMO_MAX];
+        DSD_MEMCPY(enc_reprobes, ctx->enc_reprobes, sizeof(enc_reprobes));
         p25_release_clear_decoder_state(opts, state);
         p25_sm_init_ctx(ctx, opts, state);
+        DSD_MEMCPY(ctx->enc_reprobes, enc_reprobes, sizeof(ctx->enc_reprobes));
         ctx->tune_count = tune_count;
         ctx->release_count = release_count;
         ctx->grant_count = grant_count;
@@ -5326,10 +5435,12 @@ p25_sm_followable_assignment_acquiring(const p25_sm_ctx_t* ctx, const dsd_opts* 
         if (slot_ctx->enc_lockout_reprobe || !pending || p25_voice_start_crypto_suppressed(opts, state, slot)) {
             continue;
         }
-        double started_m = ctx->slots[slot].last_grant_m;
-        if (ctx->t_tune_m > started_m) {
-            started_m = ctx->t_tune_m;
-        }
+        // This slot's own acquisition window, never the channel-wide tune
+        // stamp: t_tune_m is refreshed by every accepted assignment, including
+        // the reprobe this loop deliberately skips, so flooring on it would let
+        // a reprobe re-open some other slot's expired window once per repeat
+        // and hold the carrier for the life of the encrypted call.
+        const double started_m = slot_ctx->last_grant_m > 0.0 ? slot_ctx->last_grant_m : ctx->t_tune_m;
         if (started_m > 0.0 && now_m >= started_m && (now_m - started_m) < grant_timeout) {
             return 1;
         }
@@ -5365,7 +5476,14 @@ p25_sm_tick_tuned_check_hangtime(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
                  p25_voice_phase_name(ctx), ctx->vc_freq_hz, slot, ctx->slots[slot].target_id,
                  ctx->slots[slot].src > 0 ? ctx->slots[slot].src : ctx->slots[slot].last_end_src, dt_hang,
                  effective_hangtime);
-    return do_release(ctx, opts, state, "hangtime-expired", 0);
+    // The deadline fired and this tick belongs to it, whatever the release
+    // came back with. do_release() returns 0 when another thread already holds
+    // the release lock, and when the tuner defers or refuses the CC return --
+    // and that path latches state->p25_sm_force_release so the next tick
+    // retries. Reporting "not handled" would instead let this same tick fall
+    // through and issue a second, differently-labelled release on top of it.
+    (void)do_release(ctx, opts, state, "hangtime-expired", 0);
+    return 1;
 }
 
 #ifdef USE_RADIO
@@ -6307,6 +6425,14 @@ p25_sm_emit_mac_release(dsd_opts* opts, dsd_state* state, int slot, double obser
 
     const double ended_m = observed_m > 0.0 ? observed_m : dsd_time_now_monotonic_s();
     p25_ptt_marker_invalidate(ctx, slot);
+    // A MAC_RELEASE ends a transmission the SM was following just as a
+    // MAC_END_PTT does, so it owes the countdown the same stamp. Without it the
+    // derived origin falls back to whatever an earlier over left behind and the
+    // carrier is dropped the instant this one stops, with no hangtime at all.
+    if (ctx->slots[slot].voice_active) {
+        p25_sm_note_followed_until(ctx, slot,
+                                   ctx->slots[slot].last_active_m > 0.0 ? ctx->slots[slot].last_active_m : ended_m);
+    }
     ctx->slots[slot].voice_active = 0;
     ctx->slots[slot].last_active_m = 0.0;
     ctx->slots[slot].last_stop_m = ended_m;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -858,6 +858,7 @@ typedef struct {
     int encrypted_call;
     int enc_override_clear;
     int probe_call;
+    int enc_lockout_reprobe;
     int is_indiv;
     int tg;
 } p25_grant_eval_ctx_t;
@@ -944,16 +945,22 @@ p25_grant_patch_clear_key(const dsd_state* state, const p25_grant_eval_ctx_t* ev
 }
 
 static void
-p25_grant_release_enc_lockout_if_clear(dsd_state* state, const p25_grant_eval_ctx_t* eval_ctx) {
+p25_grant_release_enc_lockout_if_clear(dsd_state* state, p25_grant_eval_ctx_t* eval_ctx) {
     if (!state || !eval_ctx || !p25_grant_is_voice_call(eval_ctx) || eval_ctx->tg <= 0) {
         return;
     }
     // Explicit clear service options, the regroup clear-key override, or an
     // active patch clear key release a locked target before policy evaluates,
-    // so a talkgroup that stopped encrypting tunes again immediately.
+    // so a talkgroup that stopped encrypting tunes again immediately. The
+    // release is recorded on the eval context: the ledger armed from
+    // corroborated undecryptable voice, while this admission rests on one
+    // uncorroborated grant bit, so downstream timing treats the call as a
+    // reprobe rather than followed traffic until its voice classifies.
     if ((eval_ctx->svc_valid && !eval_ctx->encrypted_call) || eval_ctx->enc_override_clear
         || p25_grant_patch_clear_key(state, eval_ctx)) {
-        (void)dsd_enc_lockout_release(state, (uint32_t)eval_ctx->tg, !eval_ctx->is_indiv);
+        if (dsd_enc_lockout_release(state, (uint32_t)eval_ctx->tg, !eval_ctx->is_indiv)) {
+            eval_ctx->enc_lockout_reprobe = 1;
+        }
     }
 }
 
@@ -1572,14 +1579,25 @@ p25_grant_commit_decoder_tune(dsd_opts* opts, dsd_state* state, long freq) {
 }
 
 static void
-p25_grant_initialize_timing(p25_sm_ctx_t* ctx, dsd_state* state, double now_m, int reused_carrier, int data_call) {
+p25_grant_initialize_timing(p25_sm_ctx_t* ctx, dsd_state* state, double now_m, int reused_carrier, int data_call,
+                            int enc_lockout_reprobe) {
     // Every accepted assignment owns a fresh acquisition window, even when no
     // physical retune is needed. Do not let the preceding transmission's hang
     // or activity state suppress the grant timeout for a retained carrier.
+    const double hangtime_armed_m = ctx->t_hangtime_m;
     ctx->t_tune_m = now_m;
     ctx->t_voice_m = 0.0;
     ctx->t_hangtime_m = 0.0;
     ctx->vc_activity_seen = 0;
+    if (enc_lockout_reprobe && reused_carrier && hangtime_armed_m > 0.0) {
+        // A locked-out target re-admitted on the retained carrier by a
+        // clear-claiming grant is a reprobe, not followed traffic: the site
+        // repeats such grant updates for the life of the encrypted call, and
+        // letting each one restart the countdown held the channel until the
+        // encrypted call ended. Keep the armed countdown; a reprobe whose
+        // voice really classifies clear clears it on that voice start.
+        ctx->t_hangtime_m = hangtime_armed_m;
+    }
     if (reused_carrier) {
         p25_grant_refresh_reused_carrier_watchdogs(state, now_m);
     } else {
@@ -1630,7 +1648,8 @@ p25_grant_store_vc_context(p25_sm_ctx_t* ctx, dsd_state* state, const p25_sm_eve
     }
     const int data_call = (eval_ctx && eval_ctx->data_call) ? 1 : 0;
     ctx->vc_data_call = data_call;
-    p25_grant_initialize_timing(ctx, state, now_m, reused_carrier, data_call);
+    p25_grant_initialize_timing(ctx, state, now_m, reused_carrier, data_call,
+                                eval_ctx ? eval_ctx->enc_lockout_reprobe : 0);
     const int logical_slot = p25_grant_logical_slot(ctx, slot);
     p25_grant_store_slot_context(ctx, ev, freq, target_id, eval_ctx, logical_slot, now_m);
     if (state) {
@@ -3295,8 +3314,15 @@ p25_voice_start_wait_for_classification(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
 
     // The lockout policy may have been enabled after follow mode marked this
     // blocked slot active. Clear that stale activity before ignoring subsequent
-    // voice indications so the tuned timer can release it.
-    const double inactive_since_m = ctx->t_voice_m > 0.0 ? ctx->t_voice_m : now_m;
+    // voice indications so the tuned timer can release it. A suppressed voice
+    // start is not followed traffic, though: the locked-out slot repeats
+    // MAC_PTT/MAC_ACTIVE for the life of its transmission, and restarting an
+    // already-armed countdown on every repeat held the channel until the
+    // encrypted call ended. Only the transition out of followed activity (or a
+    // slot with no countdown at all) may arm it; an armed countdown keeps
+    // running so the hangtime tick can release the emptied channel.
+    const int was_active = ctx->t_voice_m > 0.0;
+    const double inactive_since_m = was_active ? ctx->t_voice_m : now_m;
     ctx->slots[slot].voice_active = 0;
     ctx->slots[slot].last_active_m = 0.0;
     ctx->t_voice_m = 0.0;
@@ -3304,7 +3330,7 @@ p25_voice_start_wait_for_classification(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
         if (ctx->slots[slot].crypto_attempt_m <= 0.0) {
             ctx->slots[slot].crypto_attempt_m = now_m;
         }
-    } else {
+    } else if (was_active || ctx->t_hangtime_m <= 0.0) {
         ctx->t_hangtime_m = inactive_since_m;
     }
     p25_sm_diagf(opts, state, ctx, "voice_classification_wait", "kind=%s slot=%d crypto_state=%d identity_pending=%d",
@@ -3407,12 +3433,16 @@ handle_voice_start(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p2
     p25_sm_note_vc_decode_activity(ctx, opts, state, why, s, now_m);
 
     ctx->vc_activity_seen = 1;
-    ctx->t_hangtime_m = 0.0;
 
+    // Classification-suppressed voice starts must not cancel a running
+    // hangtime countdown -- p25_voice_start_wait_for_classification decides
+    // what a suppressed slot may do to it. Only a followed voice start below
+    // cancels the countdown.
     if (p25_voice_start_wait_for_classification(ctx, opts, state, s, why, now_m)) {
         dsd_event_sync_slot(opts, state, (uint8_t)s);
         return 1;
     }
+    ctx->t_hangtime_m = 0.0;
 
     // Update slot activity
     ctx->slots[s].voice_active = 1;
@@ -4076,6 +4106,15 @@ p25_enc_lockout_release_or_hold(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* st
     const double now_m = dsd_time_now_monotonic_s();
     if (ctx->vc_is_tdma && !p25_voice_other_slot_active(ctx, state, other)
         && p25_voice_companion_gap_within_hangtime(ctx, state, other, now_m)) {
+        if (ctx->t_hangtime_m <= 0.0) {
+            // The companion's END may not have armed the countdown -- this
+            // slot's reprobe assignment read as pending activity there -- and
+            // the locked-out transmission produces no further classification
+            // transitions to revisit the release. Backdate the countdown to
+            // the companion's real stop so the hangtime tick still owns
+            // releasing the channel if the companion never resumes.
+            ctx->t_hangtime_m = ctx->slots[other].last_stop_m;
+        }
         p25_sm_diagf(opts, state, ctx, "enc_lockout_hangtime_hold", "slot=%d other=%d gap=%.3f", slot, other,
                      now_m - ctx->slots[other].last_stop_m);
         sm_log(opts, state, "enc-lockout-hangtime-hold");

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -903,7 +903,7 @@ p25_sm_note_encrypted_call_typed(dsd_opts* opts, dsd_state* state, int target, i
     }
 
     if (dsd_enc_lockout_note(state, (uint32_t)target, is_group, algid, keyid)) {
-        p25_sm_diagf(opts, state, NULL, "enc_lockout_arm", "kind=%s target=%d algid=0x%02X keyid=0x%04X",
+        p25_sm_diagf(opts, state, p25_sm_get_ctx(), "enc_lockout_arm", "kind=%s target=%d algid=0x%02X keyid=0x%04X",
                      is_group ? "group" : "private", target, algid & 0xFF, keyid & 0xFFFF);
         sm_log(opts, state, "enc-lockout-arm");
     }
@@ -1083,7 +1083,7 @@ p25_grant_release_enc_lockout_on_grant_bit(p25_sm_ctx_t* ctx, const dsd_opts* op
     // rather than spending another tune on it.
     const double now_m = dsd_time_now_monotonic_s();
     if (p25_grant_enc_reprobe_in_cooldown(ctx, target, is_group, now_m)) {
-        p25_sm_diagf((dsd_opts*)opts, state, NULL, "enc_lockout_reprobe_declined", "kind=%s target=%u reason=cooldown",
+        p25_sm_diagf((dsd_opts*)opts, state, ctx, "enc_lockout_reprobe_declined", "kind=%s target=%u reason=cooldown",
                      is_group ? "group" : "private", target);
         return;
     }
@@ -1234,12 +1234,12 @@ p25_grant_eval_policy(const dsd_opts* opts, const dsd_state* state, const p25_sm
 // it were ever revived a slot-1 target would write its lockout notice over
 // whatever unrelated call slot 0 was carrying.
 static int
-p25_grant_handle_policy_block(dsd_opts* opts, dsd_state* state, const p25_grant_eval_ctx_t* eval_ctx,
-                              const dsd_tg_policy_decision* decision) {
+p25_grant_handle_policy_block(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state,
+                              const p25_grant_eval_ctx_t* eval_ctx, const dsd_tg_policy_decision* decision) {
     if (!opts || !state || !eval_ctx || !decision || decision->tune_allowed) {
         return 0;
     }
-    p25_sm_diagf((dsd_opts*)opts, state, NULL, "grant_block",
+    p25_sm_diagf((dsd_opts*)opts, state, ctx, "grant_block",
                  "reason=%s tg=%d policy_tg=%u svc=0x%02X data=%d enc=%d indiv=%d block=0x%08X",
                  grant_block_log_tag(eval_ctx->is_indiv, decision->block_reasons), eval_ctx->tg, decision->target_id,
                  eval_ctx->svc, eval_ctx->data_call, eval_ctx->encrypted_call, eval_ctx->is_indiv,
@@ -1291,7 +1291,7 @@ grant_allowed(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_
         return 0;
     }
 
-    if (p25_grant_handle_policy_block(opts, state, &eval_ctx, &decision)) {
+    if (p25_grant_handle_policy_block(ctx, opts, state, &eval_ctx, &decision)) {
         if (out_decision) {
             *out_decision = decision;
         }
@@ -2498,8 +2498,9 @@ p25_sm_apply_group_grant_policy(dsd_opts* opts, dsd_state* state, int channel, i
 
     p25_sm_event_t ev = p25_sm_ev_group_grant(channel, 0, tg, src, svc_bits);
     dsd_tg_policy_decision decision;
-    if (grant_allowed(p25_sm_get_ctx(), opts, state, &ev, &decision, NULL, 0)) {
-        p25_sm_diagf(opts, state, NULL, "grant_policy_only", "ch=0x%04X tg=%d src=%d svc=0x%02X policy_tg=%u",
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    if (grant_allowed(ctx, opts, state, &ev, &decision, NULL, 0)) {
+        p25_sm_diagf(opts, state, ctx, "grant_policy_only", "ch=0x%04X tg=%d src=%d svc=0x%02X policy_tg=%u",
                      channel & 0xFFFF, tg, src, svc_bits & 0xFF, decision.target_id);
     }
 }
@@ -4633,6 +4634,10 @@ p25_release_clear_decoder_state(dsd_opts* opts, dsd_state* state) {
         p25_crypto_reset_slot(state, 0);
         p25_crypto_reset_slot(state, 1);
         state->p25_sm_release_count++;
+        // Mirror of ctx->cc_return_count for readers without the ctx (UI, NULL-ctx
+        // diag lines); p25_release_clear_context() bumps the ctx side on the same
+        // two release paths that call this helper.
+        state->p25_sm_cc_return_count++;
     }
     if (opts) {
         opts->trunk_is_tuned = 0;
@@ -4755,6 +4760,10 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
     // nearly the same time (e.g., explicit call termination + watchdog tick).
     int expected = 0;
     if (!atomic_compare_exchange_strong(&g_p25_sm_release_lock, &expected, 1)) {
+        // The trace must show the lost race: the winner logs its own release
+        // under its own reason, and without this line a deadline that fired
+        // here is indistinguishable from one that never fired.
+        p25_sm_diagf(opts, state, ctx, "release_contended", "reason=%s", reason ? reason : "none");
         return 0;
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5188,6 +5188,25 @@ add_test(
     COMMAND dsd-neo_test_p25_p2_enc_lockout_hangtime_release
 )
 
+# Who may arm, restart, or cancel the hangtime countdown: P1 identity waits,
+# followed voice starts, crypto classification budgets, and lockout reprobes
+add_executable(
+    dsd-neo_test_p25_hangtime_arm_rules
+    protocol/p25/test_p25_hangtime_arm_rules.c
+)
+target_include_directories(
+    dsd-neo_test_p25_hangtime_arm_rules
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_p25_hangtime_arm_rules
+    PRIVATE dsd-neo_proto_p25
+)
+add_test(
+    NAME P25_HANGTIME_ARM_RULES
+    COMMAND dsd-neo_test_p25_hangtime_arm_rules
+)
+
 # P25p2 ACTIVE-observed transmissions: the first-seen MAC_PTT folds into the
 # ACTIVE-begun canonical epoch instead of force-minting a duplicate event row
 add_executable(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5169,6 +5169,25 @@ add_test(
     COMMAND dsd-neo_test_p25_p2_hangtime_events
 )
 
+# Enc lockout on a TDMA VC: the locked-out slot's MAC repeats must not restart
+# the hangtime countdown armed by the clear companion call's END
+add_executable(
+    dsd-neo_test_p25_p2_enc_lockout_hangtime_release
+    protocol/p25/test_p25_p2_enc_lockout_hangtime_release.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p2_enc_lockout_hangtime_release
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_p25_p2_enc_lockout_hangtime_release
+    PRIVATE dsd-neo_proto_p25
+)
+add_test(
+    NAME P25_P2_ENC_LOCKOUT_HANGTIME_RELEASE
+    COMMAND dsd-neo_test_p25_p2_enc_lockout_hangtime_release
+)
+
 # P25p2 ACTIVE-observed transmissions: the first-seen MAC_PTT folds into the
 # ACTIVE-begun canonical epoch instead of force-minting a duplicate event row
 add_executable(

--- a/tests/protocol/p25/test_p25_hangtime_arm_rules.c
+++ b/tests/protocol/p25/test_p25_hangtime_arm_rules.c
@@ -666,6 +666,49 @@ test_patch_clear_key_release_is_not_a_reprobe(void) {
     return rc;
 }
 
+/*
+ * A MAC_RELEASE ends a followed transmission just as a MAC_END_PTT does, so it
+ * owes the countdown the same stamp. Without one the derived origin falls back
+ * to whatever an earlier over left behind, and the carrier is dropped the
+ * instant this one stops -- with no hangtime at all, and a "hang_expired"
+ * elapsed reading of however long the two overs together ran.
+ */
+static int
+test_mac_release_stamps_the_countdown(void) {
+    int rc = 0;
+    reset_test_state(2.0f, /*tune_enc_calls*/ 0);
+    start_tuned_tdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+
+    /* Over 1 ends with an explicit END, stamping the countdown. */
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, 0, CLEAR_TG);
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
+    rc |= expect("over 1 END starts the countdown", p25_sm_hangtime_started_m(ctx) > 0.0);
+
+    /* Age over 1 out entirely -- including the retention-tail stamps that
+     * suppress a same-identity repeat -- so a fallback to its followed stamp
+     * would be long expired. Then run over 2 on the same slot with the next
+     * talker and end it with MAC_RELEASE. */
+    ctx->slots[0].last_followed_m -= 20.0;
+    ctx->slots[0].last_stop_m -= 20.0;
+    ctx->slots[0].last_end_m -= 20.0;
+    ctx->slots[0].facch_end_m = 0.0;
+    p25_crypto_reset_slot(&g_state, 0);
+    (void)p25_sm_emit_active_call(&g_opts, &g_state, 0, CLEAR_TG, 0, CLEAR_SRC + 7, 1, 0);
+    rc |= expect("over 2 is followed", ctx->slots[0].voice_active == 1);
+    rc |= expect("followed voice suspends the countdown", p25_sm_hangtime_started_m(ctx) <= 0.0);
+
+    p25_sm_emit_mac_release(&g_opts, &g_state, 0, dsd_time_now_monotonic_s());
+    const double started_m = p25_sm_hangtime_started_m(ctx);
+    rc |= expect("MAC_RELEASE starts the countdown from its own end, not over 1's",
+                 started_m > 0.0 && (dsd_time_now_monotonic_s() - started_m) < (double)g_opts.trunk_hangtime);
+
+    p25_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect("MAC_RELEASE leaves the hangtime bridge intact", g_opts.trunk_is_tuned == 1);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -682,6 +725,7 @@ main(void) {
     rc |= test_stale_epoch_entry_is_not_a_reprobe();
     rc |= test_policy_only_evaluation_does_not_spend_the_ledger();
     rc |= test_patch_clear_key_release_is_not_a_reprobe();
+    rc |= test_mac_release_stamps_the_countdown();
     dsd_state_ext_free_all(&g_state);
 
     if (rc == 0) {

--- a/tests/protocol/p25/test_p25_hangtime_arm_rules.c
+++ b/tests/protocol/p25/test_p25_hangtime_arm_rules.c
@@ -163,6 +163,17 @@ resolve_enc_blocked(void) {
  * Encryption lockout is disabled here on purpose -- this path is reached in
  * plain follow mode, outside the lockout rules entirely.
  */
+/*
+ * Force the derived hangtime countdown to have started at @p started_m. The
+ * deadline is the most recent moment any slot carried followed traffic, so one
+ * slot carries the forced value and the other is cleared.
+ */
+static void
+set_hangtime_started(p25_sm_ctx_t* ctx, double started_m) {
+    ctx->slots[0].last_followed_m = started_m;
+    ctx->slots[1].last_followed_m = 0.0;
+}
+
 static int
 test_p1_identity_wait_rearms_hangtime(void) {
     int rc = 0;
@@ -173,21 +184,21 @@ test_p1_identity_wait_rearms_hangtime(void) {
 
     transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
     rc |= expect("identity-bearing start is followed traffic",
-                 ctx->slots[0].voice_active == 1 && ctx->t_hangtime_m <= 0.0);
+                 ctx->slots[0].voice_active == 1 && p25_sm_hangtime_started_m(ctx) <= 0.0);
 
     /* The TDU ends the over: the countdown arms and the next epoch owes an
      * identity before its audio may open. */
     p25_sm_emit_tdu(&g_opts, &g_state);
-    rc |= expect("tdu arms hangtime", ctx->t_hangtime_m > 0.0);
+    rc |= expect("tdu arms hangtime", p25_sm_hangtime_started_m(ctx) > 0.0);
     rc |= expect("tdu marks p1 identity pending", g_state.p25_p1_identity_pending == 1);
 
     /* Most of the window has gone by when the next over keys up, and its first
      * voice frames carry no decoded identity yet. */
     const double stale_m = dsd_time_now_monotonic_s() - ((double)g_opts.trunk_hangtime - 0.1);
-    ctx->t_hangtime_m = stale_m;
+    set_hangtime_started(ctx, stale_m);
     p25_sm_event_t identity_less = p25_sm_ev_active(0);
     p25_sm_event(ctx, &g_opts, &g_state, &identity_less);
-    rc |= expect("identity wait re-arms hangtime", ctx->t_hangtime_m > stale_m + 0.05);
+    rc |= expect("identity wait re-arms hangtime", p25_sm_hangtime_started_m(ctx) > stale_m + 0.05);
 
     p25_sm_tick_ctx(ctx, &g_opts, &g_state);
     rc |= expect("identity wait keeps the carrier", g_opts.trunk_is_tuned == 1);
@@ -207,10 +218,10 @@ test_followed_voice_start_cancels_hangtime(void) {
 
     transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
     p25_sm_emit_tdu(&g_opts, &g_state);
-    rc |= expect("tdu arms hangtime", ctx->t_hangtime_m > 0.0);
+    rc |= expect("tdu arms hangtime", p25_sm_hangtime_started_m(ctx) > 0.0);
 
     transmit(0, CLEAR_TG, CLEAR_SRC, 0x33U);
-    rc |= expect("followed voice start cancels hangtime", ctx->t_hangtime_m <= 0.0);
+    rc |= expect("followed voice start cancels hangtime", p25_sm_hangtime_started_m(ctx) <= 0.0);
     rc |= expect("followed voice start marks the slot active", ctx->slots[0].voice_active == 1);
     return rc;
 }
@@ -253,7 +264,7 @@ test_locked_out_repeats_do_not_arm_beside_a_live_companion(void) {
 
     for (int repeat = 0; repeat < 3; repeat++) {
         (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, 0x40);
-        rc |= expect("locked-out repeat leaves the countdown unarmed", ctx->t_hangtime_m <= 0.0);
+        rc |= expect("locked-out repeat leaves the countdown unarmed", p25_sm_hangtime_started_m(ctx) <= 0.0);
         rc |= expect("locked-out repeat leaves the companion alone", ctx->slots[0].voice_active == 1);
     }
     return rc;
@@ -278,7 +289,7 @@ test_pending_classification_outranks_hangtime(void) {
     (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, 0, CLEAR_TG);
     (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
     p25_crypto_reset_slot(&g_state, 0);
-    rc |= expect("clear END arms hangtime", ctx->t_hangtime_m > 0.0);
+    rc |= expect("clear END arms hangtime", p25_sm_hangtime_started_m(ctx) > 0.0);
 
     /* The companion slot is granted with no service options, which under
      * lockout is admitted as one silent classification probe. */
@@ -291,16 +302,16 @@ test_pending_classification_outranks_hangtime(void) {
      * start the SM is not following is what let the site's repeats hold the
      * carrier for the life of the encrypted call. */
     const double armed_m = dsd_time_now_monotonic_s() - 0.25;
-    ctx->t_hangtime_m = armed_m;
+    set_hangtime_started(ctx, armed_m);
     for (int repeat = 0; repeat < 3; repeat++) {
         (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, P25_SM_SVC_UNKNOWN);
         rc |= expect("pending MAC start keeps slot inactive", ctx->slots[1].voice_active == 0);
         rc |= expect("pending MAC start neither cancels nor restarts the countdown",
-                     fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
+                     fabs(p25_sm_hangtime_started_m(ctx) - armed_m) <= 1.0e-9);
     }
 
     /* The hangtime elapses while the classification budget still runs. */
-    ctx->t_hangtime_m = dsd_time_now_monotonic_s() - ((double)g_opts.trunk_hangtime + 0.5);
+    set_hangtime_started(ctx, dsd_time_now_monotonic_s() - ((double)g_opts.trunk_hangtime + 0.5));
     p25_sm_tick_ctx(ctx, &g_opts, &g_state);
     rc |= expect("classification in flight holds the carrier", g_opts.trunk_is_tuned == 1);
 
@@ -328,6 +339,12 @@ test_lockout_enabled_mid_call_arms_once(void) {
     start_tuned_tdma();
     p25_sm_ctx_t* ctx = p25_sm_get_ctx();
 
+    /* Slot 0's own call runs and ends, so the carrier carries no assignment
+       still waiting for its first voice -- one of those outranks the countdown
+       until its acquisition window closes, which is a different rule. */
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
+
     /* Follow mode accepts the encrypted call and keeps its assignment. */
     grant_slot1(ENC_TG, ENC_SRC, 0x40);
     transmit(1, ENC_TG, ENC_SRC, 0x22U);
@@ -336,7 +353,7 @@ test_lockout_enabled_mid_call_arms_once(void) {
     rc |= expect("follow mode keeps the assignment", ctx->slots[1].grant_active == 1);
     (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, 0x40);
     rc |= expect("follow mode marks the slot active", ctx->slots[1].voice_active == 1);
-    rc |= expect("followed start cancels any countdown", ctx->t_hangtime_m <= 0.0);
+    rc |= expect("followed start cancels any countdown", p25_sm_hangtime_started_m(ctx) <= 0.0);
 
     /* The user turns encryption lockout on while the call is up. */
     g_opts.trunk_tune_enc_calls = 0;
@@ -344,18 +361,19 @@ test_lockout_enabled_mid_call_arms_once(void) {
     /* The next repeat is suppressed, and clearing the now-stale activity arms
      * the countdown so the tuned timer can release the carrier. */
     (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, 0x40);
-    const double armed_m = ctx->t_hangtime_m;
+    const double armed_m = p25_sm_hangtime_started_m(ctx);
     rc |= expect("suppressing stale activity arms the countdown", armed_m > 0.0);
     rc |= expect("suppressed start clears the stale activity", ctx->slots[1].voice_active == 0);
 
     /* Every repeat after it is just the same transmission still going. */
     for (int repeat = 0; repeat < 3; repeat++) {
         (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, 0x40);
-        rc |= expect("suppressed repeat does not restart the countdown", fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
+        rc |= expect("suppressed repeat does not restart the countdown",
+                     fabs(p25_sm_hangtime_started_m(ctx) - armed_m) <= 1.0e-9);
     }
 
     /* So the deadline actually arrives. */
-    ctx->t_hangtime_m = dsd_time_now_monotonic_s() - ((double)g_opts.trunk_hangtime + 0.5);
+    set_hangtime_started(ctx, dsd_time_now_monotonic_s() - ((double)g_opts.trunk_hangtime + 0.5));
     p25_sm_tick_ctx(ctx, &g_opts, &g_state);
     rc |= expect("countdown releases the carrier", g_opts.trunk_is_tuned == 0);
     return rc;
@@ -385,12 +403,13 @@ test_reprobe_still_answers_to_grant_timeout(void) {
 
     (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
     p25_crypto_reset_slot(&g_state, 0);
-    const double armed_m = ctx->t_hangtime_m;
+    const double armed_m = p25_sm_hangtime_started_m(ctx);
     rc |= expect("clear END arms hangtime", armed_m > 0.0);
 
     grant_slot1(ENC_TG, ENC_SRC, 0x00);
-    rc |= expect("clear-claiming grant re-admits the reprobe", ctx->slots[1].grant_active == 1);
-    rc |= expect("reprobe preserves the armed countdown", fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
+    rc |= expect("clear-claiming grant re-admits the reprobe",
+                 ctx->slots[1].grant_active == 1 && ctx->slots[1].enc_lockout_reprobe == 1);
+    rc |= expect("reprobe preserves the armed countdown", fabs(p25_sm_hangtime_started_m(ctx) - armed_m) <= 1.0e-9);
 
     /* No voice follows. The 30s hangtime is nowhere near expiring, so only the
      * grant timeout can end this. */
@@ -398,9 +417,79 @@ test_reprobe_still_answers_to_grant_timeout(void) {
     ctx->t_tune_m = timed_out_m;
     ctx->slots[1].last_grant_m = timed_out_m;
     rc |= expect("hangtime is nowhere near expiry",
-                 (dsd_time_now_monotonic_s() - ctx->t_hangtime_m) < (double)g_opts.trunk_hangtime);
+                 (dsd_time_now_monotonic_s() - p25_sm_hangtime_started_m(ctx)) < (double)g_opts.trunk_hangtime);
     p25_sm_tick_ctx(ctx, &g_opts, &g_state);
     rc |= expect("reprobe without voice gives the carrier up", g_opts.trunk_is_tuned == 0);
+    return rc;
+}
+
+/*
+ * A reprobe may acquire, but it may not extend the carrier's stay: it rests on
+ * one grant bit the ledger contradicts, so unlike an assignment the SM has
+ * reason to follow it does not outrank the countdown the last followed
+ * transmission left running.
+ */
+static int
+test_reprobe_does_not_outrank_the_countdown(void) {
+    int rc = 0;
+    reset_test_state(2.0f, /*tune_enc_calls*/ 0);
+    start_tuned_tdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, 0, CLEAR_TG);
+    p25_sm_note_encrypted_call_typed(&g_opts, &g_state, ENC_TG, 1, ENC_ALGID, ENC_KEYID);
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
+    p25_crypto_reset_slot(&g_state, 0);
+    rc |= expect("clear END starts the countdown", p25_sm_hangtime_started_m(ctx) > 0.0);
+
+    /* The reprobe is admitted on the retained carrier and its voice never
+       arrives, so its acquisition window is still wide open below. */
+    grant_slot1(ENC_TG, ENC_SRC, 0x00);
+    rc |= expect("clear-claiming grant re-admits the reprobe",
+                 ctx->slots[1].grant_active == 1 && ctx->slots[1].enc_lockout_reprobe == 1);
+
+    /* Age the countdown out while every acquisition stamp stays fresh: only the
+       reprobe's own window could still be holding the carrier. */
+    ctx->slots[0].last_followed_m = dsd_time_now_monotonic_s() - ((double)g_opts.trunk_hangtime + 0.5);
+    rc |= expect("reprobe acquisition window is still open",
+                 (dsd_time_now_monotonic_s() - ctx->slots[1].last_grant_m) < ctx->config.grant_timeout_s);
+    p25_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect("reprobe does not hold the carrier past the hangtime", g_opts.trunk_is_tuned == 0);
+    return rc;
+}
+
+/*
+ * The same rule when the reprobe lands on the very slot whose transmission
+ * started the countdown -- a single-carrier re-grant, or a TDMA site reusing
+ * the slot the clear conversation just left. Taking the slot over is what
+ * clears its followed history for every other assignment; a reprobe is not
+ * followed traffic, so it must leave that history where it is.
+ */
+static int
+test_reprobe_on_the_countdown_slot_keeps_it(void) {
+    int rc = 0;
+    reset_test_state(2.0f, /*tune_enc_calls*/ 0);
+    start_tuned_tdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+
+    /* The clear conversation runs on the companion slot and ends there. */
+    grant_slot1(CLEAR_TG, CLEAR_SRC, 0x00);
+    transmit(1, CLEAR_TG, CLEAR_SRC, 0x11U);
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, 0, CLEAR_TG);
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 1, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
+    p25_crypto_reset_slot(&g_state, 1);
+    const double armed_m = p25_sm_hangtime_started_m(ctx);
+    rc |= expect("clear END starts the countdown on slot 1",
+                 armed_m > 0.0 && fabs(armed_m - ctx->slots[1].last_followed_m) <= 1.0e-9);
+
+    /* The locked-out target is then granted that same slot on a clear claim. */
+    p25_sm_note_encrypted_call_typed(&g_opts, &g_state, ENC_TG, 1, ENC_ALGID, ENC_KEYID);
+    grant_slot1(ENC_TG, ENC_SRC, 0x00);
+    rc |= expect("reprobe takes the countdown's own slot",
+                 ctx->slots[1].grant_active == 1 && ctx->slots[1].enc_lockout_reprobe == 1);
+    rc |= expect("reprobe leaves the countdown where the clear END put it",
+                 fabs(p25_sm_hangtime_started_m(ctx) - armed_m) <= 1.0e-9);
     return rc;
 }
 
@@ -505,11 +594,11 @@ test_stale_epoch_entry_is_not_a_reprobe(void) {
 
     (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
     p25_crypto_reset_slot(&g_state, 0);
-    rc |= expect("clear END arms hangtime", ctx->t_hangtime_m > 0.0);
+    rc |= expect("clear END arms hangtime", p25_sm_hangtime_started_m(ctx) > 0.0);
 
     grant_slot1(ENC_TG, ENC_SRC, 0x00);
     rc |= expect("stale-epoch target is admitted", ctx->slots[1].grant_active == 1);
-    rc |= expect("nothing was blocking, so nothing is a reprobe", ctx->t_hangtime_m <= 0.0);
+    rc |= expect("nothing was blocking, so nothing is a reprobe", ctx->slots[1].enc_lockout_reprobe == 0);
     return rc;
 }
 
@@ -557,7 +646,7 @@ test_patch_clear_key_release_is_not_a_reprobe(void) {
 
     (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
     p25_crypto_reset_slot(&g_state, 0);
-    rc |= expect("clear END arms hangtime", ctx->t_hangtime_m > 0.0);
+    rc |= expect("clear END arms hangtime", p25_sm_hangtime_started_m(ctx) > 0.0);
 
     /* The regroup announces an explicitly clear key for the target, and the
      * grant still claims encryption. */
@@ -566,7 +655,7 @@ test_patch_clear_key_release_is_not_a_reprobe(void) {
     rc |= expect("patch clear key admits the call", ctx->slots[1].grant_active == 1);
     rc |= expect("patch clear key releases the ledger entry",
                  dsd_enc_lockout_lookup(&g_state, (uint32_t)ENC_TG, 1, NULL) == 0);
-    rc |= expect("patch clear key is followed traffic, not a reprobe", ctx->t_hangtime_m <= 0.0);
+    rc |= expect("patch clear key is followed traffic, not a reprobe", ctx->slots[1].enc_lockout_reprobe == 0);
 
     /* And it is not spending a reprobe, so a re-lock does not lock it out of
      * its next grant. */
@@ -586,6 +675,8 @@ main(void) {
     rc |= test_lockout_enabled_mid_call_arms_once();
     rc |= test_pending_classification_outranks_hangtime();
     rc |= test_reprobe_still_answers_to_grant_timeout();
+    rc |= test_reprobe_does_not_outrank_the_countdown();
+    rc |= test_reprobe_on_the_countdown_slot_keeps_it();
     rc |= test_failed_reprobe_is_not_repeated_per_grant_update();
     rc |= test_follow_mode_does_not_erase_the_ledger();
     rc |= test_stale_epoch_entry_is_not_a_reprobe();

--- a/tests/protocol/p25/test_p25_hangtime_arm_rules.c
+++ b/tests/protocol/p25/test_p25_hangtime_arm_rules.c
@@ -1,0 +1,600 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Who may arm, restart, or cancel the P25 hangtime countdown.
+ *
+ * The countdown is one channel-wide deadline -- release this carrier one
+ * hangtime after the last *followed* traffic on it -- and several unrelated
+ * paths write it. These cases pin the ones that are easy to get backwards:
+ *
+ *  - a Phase 1 identity wait is followed traffic and keeps re-arming, so an
+ *    over that keys up late in the window is not cut off mid-voice;
+ *  - a followed voice start cancels it, a lockout-suppressed one does not;
+ *  - an encryption classification still in flight owns the release, so the
+ *    countdown does not tear a call down before it can resolve clear;
+ *  - a lockout reprobe keeps the countdown but still answers to the grant
+ *    timeout, so it can neither be released instantly nor ride out a long
+ *    configured hangtime;
+ *  - a target re-admitted on a clear-claiming grant that re-locks does not get
+ *    another re-admission per grant update, while corroborated clear key
+ *    material is not penalized at all.
+ */
+
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/enc_lockout.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/protocol/p25/p25_crypto.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "../../../src/protocol/p25/p25_trunk_sm_internal.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#define CLEAR_TG      40601
+#define CLEAR_SRC     600205
+#define ENC_TG        40699
+#define ENC_SRC       600299
+#define ENC_ALGID     0x84
+#define ENC_KEYID     0x1234
+#define TDMA_VC_FREQ  851500000L
+#define FDMA_VC_FREQ  852500000L
+#define TDMA_CH_SLOT0 0x1234
+#define TDMA_CH_SLOT1 0x1235
+#define FDMA_CH       0x100A
+
+static dsd_opts g_opts;
+static dsd_state g_state;
+
+static int
+expect(const char* tag, int cond) {
+    if (!cond) {
+        DSD_FPRINTF(stderr, "FAIL: %s\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static dsd_trunk_tune_result
+test_tune_request(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps, uint64_t request_id) {
+    (void)opts;
+    (void)state;
+    (void)ted_sps;
+    (void)request_id;
+    return freq > 0 ? DSD_TRUNK_TUNE_RESULT_OK : DSD_TRUNK_TUNE_RESULT_FAILED;
+}
+
+static dsd_trunk_tune_result
+test_return_request(dsd_opts* opts, dsd_state* state, uint64_t request_id) {
+    (void)opts;
+    (void)state;
+    (void)request_id;
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static void
+reset_test_state(float hangtime_s, int tune_enc_calls) {
+    dsd_state_ext_free_all(&g_state);
+    DSD_MEMSET(&g_opts, 0, sizeof(g_opts));
+    DSD_MEMSET(&g_state, 0, sizeof(g_state));
+    g_opts.trunk_enable = 1;
+    g_opts.trunk_hangtime = hangtime_s;
+    g_opts.trunk_tune_group_calls = 1;
+    g_opts.trunk_tune_private_calls = 1;
+    g_opts.trunk_tune_enc_calls = tune_enc_calls;
+    g_state.p25_cc_freq = 851000000;
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
+        .tune_to_freq_request = test_tune_request,
+        .tune_to_cc_request = test_tune_request,
+        .return_to_cc_request = test_return_request,
+    });
+}
+
+static void
+start_tuned_tdma(void) {
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    g_state.lastsynctype = DSD_SYNC_P25P2_POS;
+    g_state.synctype = DSD_SYNC_P25P2_POS;
+    g_state.trunk_chan_map[TDMA_CH_SLOT0] = TDMA_VC_FREQ;
+    g_state.trunk_chan_map[TDMA_CH_SLOT1] = TDMA_VC_FREQ;
+    g_state.p25_chan_tdma_explicit[1] = 2;
+    p25_sm_init_ctx(ctx, &g_opts, &g_state);
+    g_opts.trunk_is_tuned = 1;
+    p25_sm_event_t grant = p25_sm_ev_group_grant(TDMA_CH_SLOT0, TDMA_VC_FREQ, CLEAR_TG, CLEAR_SRC, 0);
+    p25_sm_event(ctx, &g_opts, &g_state, &grant);
+}
+
+static void
+start_tuned_fdma(void) {
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    g_state.lastsynctype = DSD_SYNC_P25P1_POS;
+    g_state.synctype = DSD_SYNC_P25P1_POS;
+    g_state.trunk_chan_map[FDMA_CH] = FDMA_VC_FREQ;
+    p25_sm_init_ctx(ctx, &g_opts, &g_state);
+    g_opts.trunk_is_tuned = 1;
+    p25_sm_event_t grant = p25_sm_ev_group_grant(FDMA_CH, FDMA_VC_FREQ, CLEAR_TG, CLEAR_SRC, 0);
+    p25_sm_event(ctx, &g_opts, &g_state, &grant);
+}
+
+static void
+grant_slot1(int tg, int src, int svc_bits) {
+    p25_sm_event_t grant = p25_sm_ev_group_grant(TDMA_CH_SLOT1, TDMA_VC_FREQ, tg, src, svc_bits);
+    p25_sm_event(p25_sm_get_ctx(), &g_opts, &g_state, &grant);
+}
+
+static void
+grant_slot1_update(int tg, int src, int svc_bits) {
+    p25_sm_event_t grant = p25_sm_ev_group_grant_update(TDMA_CH_SLOT1, TDMA_VC_FREQ, tg, src, svc_bits);
+    p25_sm_event(p25_sm_get_ctx(), &g_opts, &g_state, &grant);
+}
+
+static void
+transmit(int slot, int tg, int source, uint8_t signature_fill) {
+    uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES];
+    DSD_MEMSET(signature, signature_fill, sizeof(signature));
+    (void)p25_sm_emit_ptt_call_metadata(&g_opts, &g_state, slot, tg, 0, source, 1, P25_SM_SVC_UNKNOWN, signature,
+                                        dsd_time_now_monotonic_s(), 0);
+}
+
+static void
+resolve_enc_blocked(void) {
+    /* A non-clear tuple contradicting clear service context quarantines as
+     * pending on first sight; the FEC-accepted repeat completes it. */
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 1, ENC_ALGID, ENC_KEYID, 0, ENC_TG);
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 1, ENC_ALGID, ENC_KEYID, 0, ENC_TG);
+}
+
+/*
+ * A Phase 1 voice start whose LCW identity has not decoded yet is a followed
+ * call waiting on its identity, not lockout-suppressed signaling: it has no
+ * repeat loop behind it, and the TDU that armed the countdown set the pending
+ * flag in the same breath. It must keep re-arming, or an over that keys up
+ * near the end of the window is released while its voice is on the air.
+ *
+ * Encryption lockout is disabled here on purpose -- this path is reached in
+ * plain follow mode, outside the lockout rules entirely.
+ */
+static int
+test_p1_identity_wait_rearms_hangtime(void) {
+    int rc = 0;
+    reset_test_state(2.0f, /*tune_enc_calls*/ 1);
+    start_tuned_fdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    rc |= expect("fdma grant tunes single carrier", g_opts.trunk_is_tuned == 1 && ctx->vc_is_tdma == 0);
+
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
+    rc |= expect("identity-bearing start is followed traffic",
+                 ctx->slots[0].voice_active == 1 && ctx->t_hangtime_m <= 0.0);
+
+    /* The TDU ends the over: the countdown arms and the next epoch owes an
+     * identity before its audio may open. */
+    p25_sm_emit_tdu(&g_opts, &g_state);
+    rc |= expect("tdu arms hangtime", ctx->t_hangtime_m > 0.0);
+    rc |= expect("tdu marks p1 identity pending", g_state.p25_p1_identity_pending == 1);
+
+    /* Most of the window has gone by when the next over keys up, and its first
+     * voice frames carry no decoded identity yet. */
+    const double stale_m = dsd_time_now_monotonic_s() - ((double)g_opts.trunk_hangtime - 0.1);
+    ctx->t_hangtime_m = stale_m;
+    p25_sm_event_t identity_less = p25_sm_ev_active(0);
+    p25_sm_event(ctx, &g_opts, &g_state, &identity_less);
+    rc |= expect("identity wait re-arms hangtime", ctx->t_hangtime_m > stale_m + 0.05);
+
+    p25_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect("identity wait keeps the carrier", g_opts.trunk_is_tuned == 1);
+    return rc;
+}
+
+/*
+ * The other side of the same branch: once the identity decodes, the start is
+ * ordinary followed traffic and cancels the countdown outright.
+ */
+static int
+test_followed_voice_start_cancels_hangtime(void) {
+    int rc = 0;
+    reset_test_state(2.0f, /*tune_enc_calls*/ 1);
+    start_tuned_fdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
+    p25_sm_emit_tdu(&g_opts, &g_state);
+    rc |= expect("tdu arms hangtime", ctx->t_hangtime_m > 0.0);
+
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x33U);
+    rc |= expect("followed voice start cancels hangtime", ctx->t_hangtime_m <= 0.0);
+    rc |= expect("followed voice start marks the slot active", ctx->slots[0].voice_active == 1);
+    return rc;
+}
+
+/*
+ * Followed activity is a per-slot fact. The tick re-stamps the channel-wide
+ * t_voice_m to now on every pass while *either* slot is voice_active, so on a
+ * busy TDMA carrier a locked-out slot's own repeats each looked like a slot
+ * leaving followed activity -- arming a countdown while the companion is still
+ * talking, and pushing the release past one hangtime after the last followed
+ * traffic.
+ */
+static int
+test_locked_out_repeats_do_not_arm_beside_a_live_companion(void) {
+    int rc = 0;
+    /* Follow mode first, so the encrypted call keeps its assignment and its
+     * suppressed voice starts still reach the timing rules once lockout is on. */
+    reset_test_state(2.0f, /*tune_enc_calls*/ 1);
+    start_tuned_tdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+
+    grant_slot1(ENC_TG, ENC_SRC, 0x40);
+    transmit(1, ENC_TG, ENC_SRC, 0x22U);
+    resolve_enc_blocked();
+    (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, 0x40);
+    rc |= expect("follow mode keeps the encrypted assignment", ctx->slots[1].grant_active == 1);
+    rc |= expect("follow mode marks the encrypted slot active", ctx->slots[1].voice_active == 1);
+
+    /* Slot 0 carries a followed clear call and stays up throughout. */
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, 0, CLEAR_TG);
+    rc |= expect("clear companion is active", ctx->slots[0].voice_active == 1);
+
+    /* Lockout goes on mid-call. The tick keeps advancing the channel-wide voice
+     * clock because slot 0 is live, so reading followed activity off it would
+     * make every suppressed slot-1 repeat look like a transition. */
+    g_opts.trunk_tune_enc_calls = 0;
+    p25_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect("live companion advances the channel voice clock", ctx->t_voice_m > 0.0);
+
+    for (int repeat = 0; repeat < 3; repeat++) {
+        (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, 0x40);
+        rc |= expect("locked-out repeat leaves the countdown unarmed", ctx->t_hangtime_m <= 0.0);
+        rc |= expect("locked-out repeat leaves the companion alone", ctx->slots[0].voice_active == 1);
+    }
+    return rc;
+}
+
+/*
+ * A crypto classification still inside its budget owns the release. The
+ * countdown the companion's END armed keeps running underneath it, but it may
+ * not tear the pending call down first: the call may yet resolve clear, and
+ * shrinking its budget to whatever is left of the hangtime drops legitimate
+ * overs mid-classification.
+ */
+static int
+test_pending_classification_outranks_hangtime(void) {
+    int rc = 0;
+    reset_test_state(2.0f, /*tune_enc_calls*/ 0);
+    start_tuned_tdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+
+    /* Followed clear call on slot 0, then its END arms the countdown. */
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, 0, CLEAR_TG);
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
+    p25_crypto_reset_slot(&g_state, 0);
+    rc |= expect("clear END arms hangtime", ctx->t_hangtime_m > 0.0);
+
+    /* The companion slot is granted with no service options, which under
+     * lockout is admitted as one silent classification probe. */
+    grant_slot1(ENC_TG, ENC_SRC, P25_SM_SVC_UNKNOWN);
+    rc |= expect("probe grant assigns companion slot", ctx->slots[1].grant_active == 1);
+    rc |= expect("probe slot classifies pending", g_state.p25_crypto_state[1] == DSD_P25_CRYPTO_ENCRYPTED_PENDING
+                                                      && ctx->slots[1].crypto_attempt_m > 0.0);
+    /* Its suppressed voice start leaves the classification deadline in charge
+     * and, just as importantly, leaves the countdown alone: cancelling it on a
+     * start the SM is not following is what let the site's repeats hold the
+     * carrier for the life of the encrypted call. */
+    const double armed_m = dsd_time_now_monotonic_s() - 0.25;
+    ctx->t_hangtime_m = armed_m;
+    for (int repeat = 0; repeat < 3; repeat++) {
+        (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, P25_SM_SVC_UNKNOWN);
+        rc |= expect("pending MAC start keeps slot inactive", ctx->slots[1].voice_active == 0);
+        rc |= expect("pending MAC start neither cancels nor restarts the countdown",
+                     fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
+    }
+
+    /* The hangtime elapses while the classification budget still runs. */
+    ctx->t_hangtime_m = dsd_time_now_monotonic_s() - ((double)g_opts.trunk_hangtime + 0.5);
+    p25_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect("classification in flight holds the carrier", g_opts.trunk_is_tuned == 1);
+
+    /* Once the budget lapses the carrier goes back, so nothing is held open. */
+    ctx->slots[1].crypto_attempt_m = dsd_time_now_monotonic_s() - (ctx->config.grant_timeout_s + 0.5);
+    ctx->t_tune_m = ctx->slots[1].crypto_attempt_m;
+    ctx->slots[1].last_grant_m = ctx->slots[1].crypto_attempt_m;
+    p25_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect("lapsed classification releases the carrier", g_opts.trunk_is_tuned == 0);
+    return rc;
+}
+
+/*
+ * Enabling encryption lockout mid-call is the one way a BLOCKED slot keeps its
+ * assignment: follow mode already classified and accepted the call, so nothing
+ * tore it down. Its voice starts are suppressed from that moment on, and they
+ * keep arriving for the whole transmission. The first one is a real transition
+ * out of followed activity and arms the countdown; every repeat after it must
+ * leave that countdown where it is, or the deadline never arrives.
+ */
+static int
+test_lockout_enabled_mid_call_arms_once(void) {
+    int rc = 0;
+    reset_test_state(2.0f, /*tune_enc_calls*/ 1);
+    start_tuned_tdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+
+    /* Follow mode accepts the encrypted call and keeps its assignment. */
+    grant_slot1(ENC_TG, ENC_SRC, 0x40);
+    transmit(1, ENC_TG, ENC_SRC, 0x22U);
+    resolve_enc_blocked();
+    rc |= expect("follow mode classifies BLOCKED", g_state.p25_crypto_state[1] == DSD_P25_CRYPTO_BLOCKED);
+    rc |= expect("follow mode keeps the assignment", ctx->slots[1].grant_active == 1);
+    (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, 0x40);
+    rc |= expect("follow mode marks the slot active", ctx->slots[1].voice_active == 1);
+    rc |= expect("followed start cancels any countdown", ctx->t_hangtime_m <= 0.0);
+
+    /* The user turns encryption lockout on while the call is up. */
+    g_opts.trunk_tune_enc_calls = 0;
+
+    /* The next repeat is suppressed, and clearing the now-stale activity arms
+     * the countdown so the tuned timer can release the carrier. */
+    (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, 0x40);
+    const double armed_m = ctx->t_hangtime_m;
+    rc |= expect("suppressing stale activity arms the countdown", armed_m > 0.0);
+    rc |= expect("suppressed start clears the stale activity", ctx->slots[1].voice_active == 0);
+
+    /* Every repeat after it is just the same transmission still going. */
+    for (int repeat = 0; repeat < 3; repeat++) {
+        (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, 0x40);
+        rc |= expect("suppressed repeat does not restart the countdown", fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
+    }
+
+    /* So the deadline actually arrives. */
+    ctx->t_hangtime_m = dsd_time_now_monotonic_s() - ((double)g_opts.trunk_hangtime + 0.5);
+    p25_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect("countdown releases the carrier", g_opts.trunk_is_tuned == 0);
+    return rc;
+}
+
+/*
+ * A lockout reprobe re-admitted on the retained carrier keeps the armed
+ * countdown, so it cannot extend the channel hold. Its acquisition window is
+ * therefore whichever deadline comes first, and the grant timeout still has to
+ * run: with a long configured hangtime, a reprobe whose voice never arrives
+ * would otherwise hold the carrier for the whole hangtime instead of giving it
+ * up after grant_timeout_s.
+ */
+static int
+test_reprobe_still_answers_to_grant_timeout(void) {
+    int rc = 0;
+    reset_test_state(30.0f, /*tune_enc_calls*/ 0);
+    start_tuned_tdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, 0, CLEAR_TG);
+    grant_slot1(ENC_TG, ENC_SRC, 0x40);
+    transmit(1, ENC_TG, ENC_SRC, 0x22U);
+    resolve_enc_blocked();
+    rc |= expect("enc slot classifies BLOCKED", g_state.p25_crypto_state[1] == DSD_P25_CRYPTO_BLOCKED);
+
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
+    p25_crypto_reset_slot(&g_state, 0);
+    const double armed_m = ctx->t_hangtime_m;
+    rc |= expect("clear END arms hangtime", armed_m > 0.0);
+
+    grant_slot1(ENC_TG, ENC_SRC, 0x00);
+    rc |= expect("clear-claiming grant re-admits the reprobe", ctx->slots[1].grant_active == 1);
+    rc |= expect("reprobe preserves the armed countdown", fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
+
+    /* No voice follows. The 30s hangtime is nowhere near expiring, so only the
+     * grant timeout can end this. */
+    const double timed_out_m = dsd_time_now_monotonic_s() - (ctx->config.grant_timeout_s + 0.5);
+    ctx->t_tune_m = timed_out_m;
+    ctx->slots[1].last_grant_m = timed_out_m;
+    rc |= expect("hangtime is nowhere near expiry",
+                 (dsd_time_now_monotonic_s() - ctx->t_hangtime_m) < (double)g_opts.trunk_hangtime);
+    p25_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect("reprobe without voice gives the carrier up", g_opts.trunk_is_tuned == 0);
+    return rc;
+}
+
+/*
+ * The site repeats a clear-claiming grant update for the life of the encrypted
+ * call it is wrong about. The first one buys a reprobe -- that is the designed
+ * recovery for a talkgroup that stopped encrypting -- but once that reprobe
+ * re-locks, the next identical update must not buy another. The ledger entry
+ * the reprobe consumed is gone by then, so the backoff is what tells the two
+ * apart, and without it the carrier cycles tune/classify/release once per
+ * update.
+ */
+static int
+test_failed_reprobe_is_not_repeated_per_grant_update(void) {
+    int rc = 0;
+    reset_test_state(2.0f, /*tune_enc_calls*/ 0);
+    start_tuned_tdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, 0, CLEAR_TG);
+    grant_slot1(ENC_TG, ENC_SRC, 0x40);
+    transmit(1, ENC_TG, ENC_SRC, 0x22U);
+    resolve_enc_blocked();
+    rc |= expect("enc target locks out", dsd_enc_lockout_lookup(&g_state, (uint32_t)ENC_TG, 1, NULL) == 1);
+
+    /* First clear-claiming update: admitted, and the ledger entry is spent. */
+    grant_slot1(ENC_TG, ENC_SRC, 0x00);
+    rc |= expect("first clear-claiming update re-admits the target", ctx->slots[1].grant_active == 1);
+    rc |= expect("first re-admission consumes the ledger entry",
+                 dsd_enc_lockout_lookup(&g_state, (uint32_t)ENC_TG, 1, NULL) == 0);
+
+    /* The reprobe's own voice re-locks it: the grant bit was wrong. */
+    resolve_enc_blocked();
+    rc |=
+        expect("failed reprobe re-locks the target", dsd_enc_lockout_lookup(&g_state, (uint32_t)ENC_TG, 1, NULL) == 1);
+    rc |= expect("failed reprobe drops the assignment", ctx->slots[1].grant_active == 0);
+
+    /* The site repeats the same claim a moment later, first as another
+     * assignment and then as the grant update the control channel actually
+     * favours -- the provenance the reported stall was driven by. */
+    grant_slot1(ENC_TG, ENC_SRC, 0x00);
+    rc |= expect("repeat assignment does not re-admit the target", ctx->slots[1].grant_active == 0);
+    rc |= expect("repeat assignment leaves the ledger entry armed",
+                 dsd_enc_lockout_lookup(&g_state, (uint32_t)ENC_TG, 1, NULL) == 1);
+
+    grant_slot1_update(ENC_TG, ENC_SRC, 0x00);
+    rc |= expect("repeat grant update does not re-admit the target", ctx->slots[1].grant_active == 0);
+    rc |= expect("repeat grant update leaves the ledger entry armed",
+                 dsd_enc_lockout_lookup(&g_state, (uint32_t)ENC_TG, 1, NULL) == 1);
+    return rc;
+}
+
+/*
+ * In follow mode the ledger is suspended, not erased: entries survive a
+ * temporary toggle to following encrypted calls without owing a fresh probe.
+ * A clear-claiming grant arriving during that window must not quietly erase
+ * one, or turning lockout back on starts from an empty ledger. handle_enc's
+ * sibling release is gated the same way.
+ */
+static int
+test_follow_mode_does_not_erase_the_ledger(void) {
+    int rc = 0;
+    reset_test_state(2.0f, /*tune_enc_calls*/ 0);
+    start_tuned_tdma();
+
+    /* Armed while lockout was on; the user then switched to following. */
+    p25_sm_note_encrypted_call_typed(&g_opts, &g_state, ENC_TG, 1, ENC_ALGID, ENC_KEYID);
+    rc |= expect("seeded entry is present", dsd_enc_lockout_lookup(&g_state, (uint32_t)ENC_TG, 1, NULL) == 1);
+    g_opts.trunk_tune_enc_calls = 1;
+
+    grant_slot1(ENC_TG, ENC_SRC, 0x00);
+    rc |= expect("follow mode admits the call", p25_sm_get_ctx()->slots[1].grant_active == 1);
+    rc |= expect("follow mode leaves the ledger entry alone",
+                 dsd_enc_lockout_lookup(&g_state, (uint32_t)ENC_TG, 1, NULL) == 1);
+    return rc;
+}
+
+/*
+ * The reprobe penalty answers "was this target blocking?", which is not what
+ * "did the ledger have an entry?" answers. New key material leaves entries
+ * behind at a stale epoch: they no longer block anything, so a grant for one is
+ * admitted on its own merits and is ordinary followed traffic -- charging it the
+ * reprobe penalty releases a call the user can now decrypt one hangtime early.
+ */
+static int
+test_stale_epoch_entry_is_not_a_reprobe(void) {
+    int rc = 0;
+    reset_test_state(2.0f, /*tune_enc_calls*/ 0);
+    start_tuned_tdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, 0, CLEAR_TG);
+    p25_sm_note_encrypted_call_typed(&g_opts, &g_state, ENC_TG, 1, ENC_ALGID, ENC_KEYID);
+
+    /* The user loads key material: the entry survives but stops blocking. */
+    dsd_enc_lockout_bump_key_epoch(&g_state);
+    rc |= expect("key change leaves the entry stale",
+                 dsd_enc_lockout_lookup(&g_state, (uint32_t)ENC_TG, 1, NULL) == 1
+                     && dsd_enc_lockout_entry_active(&g_state, (uint32_t)ENC_TG, 1) == 0);
+
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
+    p25_crypto_reset_slot(&g_state, 0);
+    rc |= expect("clear END arms hangtime", ctx->t_hangtime_m > 0.0);
+
+    grant_slot1(ENC_TG, ENC_SRC, 0x00);
+    rc |= expect("stale-epoch target is admitted", ctx->slots[1].grant_active == 1);
+    rc |= expect("nothing was blocking, so nothing is a reprobe", ctx->t_hangtime_m <= 0.0);
+    return rc;
+}
+
+/*
+ * Releasing the ledger on a clear-claiming grant is a one-shot: the entry is
+ * gone afterwards, and with it any way to tell that the call was ever locked
+ * out. Only the path that goes on to process the assignment may spend it. The
+ * policy-only evaluation -- which runs on every Phase 1 MBT group grant while
+ * the SM is already tuned -- would otherwise consume the release and drop the
+ * reprobe marking on the floor.
+ */
+static int
+test_policy_only_evaluation_does_not_spend_the_ledger(void) {
+    int rc = 0;
+    reset_test_state(2.0f, /*tune_enc_calls*/ 0);
+    start_tuned_tdma();
+
+    p25_sm_note_encrypted_call_typed(&g_opts, &g_state, ENC_TG, 1, ENC_ALGID, ENC_KEYID);
+    rc |= expect("enc target locks out", dsd_enc_lockout_entry_active(&g_state, (uint32_t)ENC_TG, 1) == 1);
+
+    p25_sm_apply_group_grant_policy(&g_opts, &g_state, TDMA_CH_SLOT1, 0x00, ENC_TG, ENC_SRC);
+    rc |= expect("policy-only evaluation leaves the ledger entry armed",
+                 dsd_enc_lockout_entry_active(&g_state, (uint32_t)ENC_TG, 1) == 1);
+    return rc;
+}
+
+/*
+ * Corroborated key material is not the same evidence. An active patch clear key
+ * is what p25_lcw.c already trusts to reopen the Phase 1 audio gate, so a grant
+ * carrying it releases the ledger on any path, owes no reprobe penalty -- the
+ * call is followed traffic from its first frame, and cancels the countdown like
+ * one -- and never serves the reprobe backoff.
+ */
+static int
+test_patch_clear_key_release_is_not_a_reprobe(void) {
+    int rc = 0;
+    reset_test_state(2.0f, /*tune_enc_calls*/ 0);
+    start_tuned_tdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, 0, CLEAR_TG);
+    p25_sm_note_encrypted_call_typed(&g_opts, &g_state, ENC_TG, 1, ENC_ALGID, ENC_KEYID);
+    rc |= expect("enc target locks out", dsd_enc_lockout_lookup(&g_state, (uint32_t)ENC_TG, 1, NULL) == 1);
+
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
+    p25_crypto_reset_slot(&g_state, 0);
+    rc |= expect("clear END arms hangtime", ctx->t_hangtime_m > 0.0);
+
+    /* The regroup announces an explicitly clear key for the target, and the
+     * grant still claims encryption. */
+    p25_patch_set_kas(&g_state, ENC_TG, /*key*/ 0, /*alg*/ ENC_ALGID, /*ssn*/ 1);
+    grant_slot1(ENC_TG, ENC_SRC, 0x40);
+    rc |= expect("patch clear key admits the call", ctx->slots[1].grant_active == 1);
+    rc |= expect("patch clear key releases the ledger entry",
+                 dsd_enc_lockout_lookup(&g_state, (uint32_t)ENC_TG, 1, NULL) == 0);
+    rc |= expect("patch clear key is followed traffic, not a reprobe", ctx->t_hangtime_m <= 0.0);
+
+    /* And it is not spending a reprobe, so a re-lock does not lock it out of
+     * its next grant. */
+    p25_sm_note_encrypted_call_typed(&g_opts, &g_state, ENC_TG, 1, ENC_ALGID, ENC_KEYID);
+    grant_slot1(ENC_TG, ENC_SRC, 0x40);
+    rc |= expect("patch clear key is never held off by the reprobe backoff",
+                 dsd_enc_lockout_lookup(&g_state, (uint32_t)ENC_TG, 1, NULL) == 0);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_p1_identity_wait_rearms_hangtime();
+    rc |= test_followed_voice_start_cancels_hangtime();
+    rc |= test_locked_out_repeats_do_not_arm_beside_a_live_companion();
+    rc |= test_lockout_enabled_mid_call_arms_once();
+    rc |= test_pending_classification_outranks_hangtime();
+    rc |= test_reprobe_still_answers_to_grant_timeout();
+    rc |= test_failed_reprobe_is_not_repeated_per_grant_update();
+    rc |= test_follow_mode_does_not_erase_the_ledger();
+    rc |= test_stale_epoch_entry_is_not_a_reprobe();
+    rc |= test_policy_only_evaluation_does_not_spend_the_ledger();
+    rc |= test_patch_clear_key_release_is_not_a_reprobe();
+    dsd_state_ext_free_all(&g_state);
+
+    if (rc == 0) {
+        DSD_FPRINTF(stderr, "P25 HANGTIME ARM RULES: OK\n");
+    }
+    return rc;
+}

--- a/tests/protocol/p25/test_p25_p1_tdulc.c
+++ b/tests/protocol/p25/test_p25_p1_tdulc.c
@@ -384,7 +384,7 @@ test_voice_user_metadata_does_not_restart_call(void) {
         DSD_SNPRINTF(label, sizeof(label), "%s remains inactive", cases[i].name);
         rc |= expect_eq_int(label, ctx->slots[0].voice_active, 0);
         DSD_SNPRINTF(label, sizeof(label), "%s preserves hang timer", cases[i].name);
-        rc |= expect_true(label, ctx->t_hangtime_m > 0.0);
+        rc |= expect_true(label, p25_sm_hangtime_started_m(ctx) > 0.0);
         dsd_state_ext_free_all(&state);
     }
     return rc;

--- a/tests/protocol/p25/test_p25_p1_trunk_sm.c
+++ b/tests/protocol/p25/test_p25_p1_trunk_sm.c
@@ -95,6 +95,7 @@ main(int argc, char** argv) {
     p25_sm_init_ctx(p25_sm_get_ctx(), &opts, &state);
     rc |= expect_eq("init tune_count", state.p25_sm_tune_count, 0);
     rc |= expect_eq("init release_count", state.p25_sm_release_count, 0);
+    rc |= expect_eq("init cc_return_count", state.p25_sm_cc_return_count, 0);
 
     // Validated current-site updates supply two CC candidates.
     long cc_candidates[3] = {851012500, 851537500, 0};
@@ -152,6 +153,7 @@ main(int argc, char** argv) {
     state.dmrburstR = 24;
     p25_sm_release(p25_sm_get_ctx(), &opts, &state, "explicit-release");
     rc |= expect_eq("release_count", state.p25_sm_release_count, 1);
+    rc |= expect_eq("cc_return_count", state.p25_sm_cc_return_count, 1);
 
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
     return rc;

--- a/tests/protocol/p25/test_p25_p2_enc_lockout_hangtime_release.c
+++ b/tests/protocol/p25/test_p25_p2_enc_lockout_hangtime_release.c
@@ -139,23 +139,18 @@ restamp_companion_stop_now(int slot) {
 }
 
 /*
- * Age out only the hangtime countdown and the stamps that keep the locked-out
- * slot looking occupied. t_tune_m and crypto_attempt_m stay fresh on purpose:
- * the grant timeout and the crypto-classification timeout can then not fire, so
- * a release observed after this can only have come from the hangtime tick the
- * test names.
+ * Age out only the derived hangtime countdown -- the per-slot record of when
+ * each slot last carried followed traffic. Every other stamp stays where it is
+ * on purpose: the grant timeout and the crypto-classification timeout can then
+ * not fire, so a release observed after this can only have come from the
+ * hangtime tick the test names.
  */
 static void
 expire_hangtime_only(void) {
     p25_sm_ctx_t* ctx = p25_sm_get_ctx();
     const double by_s = (double)g_opts.trunk_hangtime + 0.5;
-    ctx->t_hangtime_m = backdate(ctx->t_hangtime_m, by_s);
-    ctx->t_voice_m = backdate(ctx->t_voice_m, by_s);
-    ctx->slots[0].last_stop_m = backdate(ctx->slots[0].last_stop_m, by_s);
-    ctx->slots[0].last_end_m = backdate(ctx->slots[0].last_end_m, by_s);
-    ctx->slots[1].last_stop_m = backdate(ctx->slots[1].last_stop_m, by_s);
-    ctx->slots[1].last_grant_m = backdate(ctx->slots[1].last_grant_m, by_s);
-    ctx->slots[1].last_enc_suppress_m = backdate(ctx->slots[1].last_enc_suppress_m, by_s);
+    ctx->slots[0].last_followed_m = backdate(ctx->slots[0].last_followed_m, by_s);
+    ctx->slots[1].last_followed_m = backdate(ctx->slots[1].last_followed_m, by_s);
 }
 
 /*
@@ -191,7 +186,7 @@ test_enc_signaling_does_not_starve_hangtime_release(void) {
      * countdown arms. */
     (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
     p25_crypto_reset_slot(&g_state, 0);
-    const double armed_m = ctx->t_hangtime_m;
+    const double armed_m = p25_sm_hangtime_started_m(ctx);
     rc |= expect("clear END arms hangtime", armed_m > 0.0);
 
     /* The site's next grant update for the still-transmitting encrypted call
@@ -200,7 +195,7 @@ test_enc_signaling_does_not_starve_hangtime_release(void) {
      * it must not erase the armed countdown. */
     grant_companion(ENC_TG, ENC_SRC, 0x00);
     rc |= expect("clear-claiming grant update re-admits probe", ctx->slots[1].grant_active == 1);
-    rc |= expect("probe re-grant preserves armed hangtime", fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
+    rc |= expect("probe re-grant preserves armed hangtime", fabs(p25_sm_hangtime_started_m(ctx) - armed_m) <= 1.0e-9);
 
     /* The re-admitted probe's ESS contradicts the grant's clear claim right
      * away: the slot classifies BLOCKED, the lockout re-arms, and the
@@ -210,7 +205,7 @@ test_enc_signaling_does_not_starve_hangtime_release(void) {
     (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 1, ENC_ALGID, ENC_KEYID, 0, ENC_TG);
     rc |= expect("probe re-classifies BLOCKED", g_state.p25_crypto_state[1] == DSD_P25_CRYPTO_BLOCKED);
     rc |= expect("enc re-lock holds within companion gap", g_opts.trunk_is_tuned == 1);
-    rc |= expect("enc re-lock leaves hangtime armed", fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
+    rc |= expect("enc re-lock leaves hangtime armed", fabs(p25_sm_hangtime_started_m(ctx) - armed_m) <= 1.0e-9);
 
     /* The re-lock tore the assignment down with the rest of the slot, so the
      * locked-out call's remaining MAC repeats are dropped before they reach any
@@ -218,7 +213,8 @@ test_enc_signaling_does_not_starve_hangtime_release(void) {
     for (int repeat = 0; repeat < 3; repeat++) {
         (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, 0x40);
         rc |= expect("post-lockout MAC repeat keeps slot inactive", ctx->slots[1].voice_active == 0);
-        rc |= expect("post-lockout MAC repeat preserves armed hangtime", fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
+        rc |= expect("post-lockout MAC repeat preserves armed hangtime",
+                     fabs(p25_sm_hangtime_started_m(ctx) - armed_m) <= 1.0e-9);
     }
 
     /* Hangtime elapses while the encrypted transmission continues and its ESS
@@ -260,19 +256,21 @@ test_enc_relock_hold_arms_hangtime_for_ended_companion(void) {
     (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
     p25_crypto_reset_slot(&g_state, 0);
 
+    /* The countdown is not something the END had to remember to arm: it is
+       derived from slot 0's own record of following traffic until it stopped,
+       so the phase alignment that used to leave it unarmed cannot arise. */
+    rc |= expect("clear END starts the countdown from its own stop",
+                 fabs(p25_sm_hangtime_started_m(ctx) - ctx->slots[0].last_followed_m) <= 1.0e-9
+                     && ctx->slots[0].last_followed_m > 0.0);
+
     /* The probe's ESS classifies BLOCKED again; the re-lock holds for the
-     * companion's unexpired gap and must arm the countdown from the
-     * companion's stop, because no further transition will revisit it.
-     *
-     * The anchor is the assertion: arming from now instead would give the
-     * locked-out call a full extra hangtime on every re-lock, which is the
-     * failure this arm exists to avoid. */
+     * companion's unexpired gap and must leave that countdown running. */
     restamp_companion_stop_now(0);
-    rc |= expect("clear END left the countdown unarmed", ctx->t_hangtime_m <= 0.0);
+    const double armed_m = p25_sm_hangtime_started_m(ctx);
     resolve_enc_blocked();
     rc |= expect("enc re-lock holds within companion gap", g_opts.trunk_is_tuned == 1);
-    rc |= expect("enc re-lock arms hangtime from companion stop",
-                 ctx->t_hangtime_m > 0.0 && fabs(ctx->t_hangtime_m - ctx->slots[0].last_stop_m) <= 1.0e-9);
+    rc |= expect("enc re-lock leaves the countdown where the clear END put it",
+                 fabs(p25_sm_hangtime_started_m(ctx) - armed_m) <= 1.0e-9);
 
     /* Hangtime elapses with the encrypted transmission still up and its ESS
      * quiet; the tick must release the channel. */

--- a/tests/protocol/p25/test_p25_p2_enc_lockout_hangtime_release.c
+++ b/tests/protocol/p25/test_p25_p2_enc_lockout_hangtime_release.c
@@ -14,7 +14,6 @@
  * followed call ended.
  */
 
-#include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
@@ -128,6 +127,38 @@ backdate(double stamp_m, double by_s) {
 }
 
 /*
+ * Re-stamp the clear companion's stop to now. The re-lock's stay-or-release
+ * action compares that stamp against the configured hangtime with the real
+ * clock, so without this the "holds within companion gap" assertions would
+ * depend on the test itself running in under trunk_hangtime seconds -- which a
+ * parallel ctest, a sanitizer build, or a throttled container need not.
+ */
+static void
+restamp_companion_stop_now(int slot) {
+    p25_sm_get_ctx()->slots[slot].last_stop_m = dsd_time_now_monotonic_s();
+}
+
+/*
+ * Age out only the hangtime countdown and the stamps that keep the locked-out
+ * slot looking occupied. t_tune_m and crypto_attempt_m stay fresh on purpose:
+ * the grant timeout and the crypto-classification timeout can then not fire, so
+ * a release observed after this can only have come from the hangtime tick the
+ * test names.
+ */
+static void
+expire_hangtime_only(void) {
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    const double by_s = (double)g_opts.trunk_hangtime + 0.5;
+    ctx->t_hangtime_m = backdate(ctx->t_hangtime_m, by_s);
+    ctx->t_voice_m = backdate(ctx->t_voice_m, by_s);
+    ctx->slots[0].last_stop_m = backdate(ctx->slots[0].last_stop_m, by_s);
+    ctx->slots[0].last_end_m = backdate(ctx->slots[0].last_end_m, by_s);
+    ctx->slots[1].last_stop_m = backdate(ctx->slots[1].last_stop_m, by_s);
+    ctx->slots[1].last_grant_m = backdate(ctx->slots[1].last_grant_m, by_s);
+    ctx->slots[1].last_enc_suppress_m = backdate(ctx->slots[1].last_enc_suppress_m, by_s);
+}
+
+/*
  * Slot 0 follows a clear call while slot 1 carries a locked-out encrypted
  * transmission that outlives it. After the clear END arms the hangtime
  * countdown, the locked-out call's continuing signaling -- a clear-claiming
@@ -171,35 +202,29 @@ test_enc_signaling_does_not_starve_hangtime_release(void) {
     rc |= expect("clear-claiming grant update re-admits probe", ctx->slots[1].grant_active == 1);
     rc |= expect("probe re-grant preserves armed hangtime", fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
 
-    /* The probe's first contradicting ESS tuple quarantines as pending; the
-     * suppressed MAC voice start that follows must also leave the countdown
-     * running. */
+    /* The re-admitted probe's ESS contradicts the grant's clear claim right
+     * away: the slot classifies BLOCKED, the lockout re-arms, and the
+     * stay-or-release action holds for the companion's unexpired gap -- with
+     * the countdown still armed and still anchored where the clear END put it. */
+    restamp_companion_stop_now(0);
     (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 1, ENC_ALGID, ENC_KEYID, 0, ENC_TG);
-    (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, 0x40);
-    rc |= expect("suppressed MAC start keeps slot inactive", ctx->slots[1].voice_active == 0);
-    rc |= expect("suppressed MAC start preserves armed hangtime", fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
-
-    /* The repeat tuple completes the classification: BLOCKED again, lockout
-     * re-arms, and the stay-or-release action holds for the companion's
-     * unexpired gap -- with the countdown still armed. */
-    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 1, ENC_ALGID, ENC_KEYID, 0, ENC_TG);
+    rc |= expect("probe re-classifies BLOCKED", g_state.p25_crypto_state[1] == DSD_P25_CRYPTO_BLOCKED);
     rc |= expect("enc re-lock holds within companion gap", g_opts.trunk_is_tuned == 1);
-    rc |= expect("enc re-lock leaves hangtime armed", ctx->t_hangtime_m > 0.0);
+    rc |= expect("enc re-lock leaves hangtime armed", fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
+
+    /* The re-lock tore the assignment down with the rest of the slot, so the
+     * locked-out call's remaining MAC repeats are dropped before they reach any
+     * timing at all -- and the countdown keeps running toward its deadline. */
+    for (int repeat = 0; repeat < 3; repeat++) {
+        (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, 0x40);
+        rc |= expect("post-lockout MAC repeat keeps slot inactive", ctx->slots[1].voice_active == 0);
+        rc |= expect("post-lockout MAC repeat preserves armed hangtime", fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
+    }
 
     /* Hangtime elapses while the encrypted transmission continues and its ESS
      * stops decoding (no further classification transitions). Only the tick
      * can release the channel now. */
-    const double by_s = (double)g_opts.trunk_hangtime + 0.5;
-    ctx->t_hangtime_m = backdate(ctx->t_hangtime_m, by_s);
-    ctx->t_tune_m = backdate(ctx->t_tune_m, by_s);
-    ctx->t_voice_m = backdate(ctx->t_voice_m, by_s);
-    ctx->slots[0].last_stop_m = backdate(ctx->slots[0].last_stop_m, by_s);
-    ctx->slots[0].last_end_m = backdate(ctx->slots[0].last_end_m, by_s);
-    ctx->slots[1].last_stop_m = backdate(ctx->slots[1].last_stop_m, by_s);
-    ctx->slots[1].last_grant_m = backdate(ctx->slots[1].last_grant_m, by_s);
-    ctx->slots[1].last_enc_suppress_m = backdate(ctx->slots[1].last_enc_suppress_m, by_s);
-    ctx->slots[1].crypto_attempt_m = backdate(ctx->slots[1].crypto_attempt_m, by_s);
-
+    expire_hangtime_only();
     p25_sm_tick_ctx(ctx, &g_opts, &g_state);
     rc |= expect("hangtime expiry releases channel", g_opts.trunk_is_tuned == 0);
     return rc;
@@ -237,24 +262,21 @@ test_enc_relock_hold_arms_hangtime_for_ended_companion(void) {
 
     /* The probe's ESS classifies BLOCKED again; the re-lock holds for the
      * companion's unexpired gap and must arm the countdown from the
-     * companion's stop, because no further transition will revisit it. */
+     * companion's stop, because no further transition will revisit it.
+     *
+     * The anchor is the assertion: arming from now instead would give the
+     * locked-out call a full extra hangtime on every re-lock, which is the
+     * failure this arm exists to avoid. */
+    restamp_companion_stop_now(0);
+    rc |= expect("clear END left the countdown unarmed", ctx->t_hangtime_m <= 0.0);
     resolve_enc_blocked();
     rc |= expect("enc re-lock holds within companion gap", g_opts.trunk_is_tuned == 1);
-    rc |= expect("enc re-lock arms hangtime from companion stop", ctx->t_hangtime_m > 0.0);
+    rc |= expect("enc re-lock arms hangtime from companion stop",
+                 ctx->t_hangtime_m > 0.0 && fabs(ctx->t_hangtime_m - ctx->slots[0].last_stop_m) <= 1.0e-9);
 
     /* Hangtime elapses with the encrypted transmission still up and its ESS
      * quiet; the tick must release the channel. */
-    const double by_s = (double)g_opts.trunk_hangtime + 0.5;
-    ctx->t_hangtime_m = backdate(ctx->t_hangtime_m, by_s);
-    ctx->t_tune_m = backdate(ctx->t_tune_m, by_s);
-    ctx->t_voice_m = backdate(ctx->t_voice_m, by_s);
-    ctx->slots[0].last_stop_m = backdate(ctx->slots[0].last_stop_m, by_s);
-    ctx->slots[0].last_end_m = backdate(ctx->slots[0].last_end_m, by_s);
-    ctx->slots[1].last_stop_m = backdate(ctx->slots[1].last_stop_m, by_s);
-    ctx->slots[1].last_grant_m = backdate(ctx->slots[1].last_grant_m, by_s);
-    ctx->slots[1].last_enc_suppress_m = backdate(ctx->slots[1].last_enc_suppress_m, by_s);
-    ctx->slots[1].crypto_attempt_m = backdate(ctx->slots[1].crypto_attempt_m, by_s);
-
+    expire_hangtime_only();
     p25_sm_tick_ctx(ctx, &g_opts, &g_state);
     rc |= expect("hangtime expiry releases channel after re-lock", g_opts.trunk_is_tuned == 0);
     return rc;

--- a/tests/protocol/p25/test_p25_p2_enc_lockout_hangtime_release.c
+++ b/tests/protocol/p25/test_p25_p2_enc_lockout_hangtime_release.c
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Encryption lockout on a TDMA voice channel shared with a followed clear
+ * call: the locked-out call keeps signaling for its whole transmission --
+ * clear-claiming grant updates that re-admit it as a probe, suppressed MAC
+ * voice starts, ESS repeats. None of that is followed traffic, so none of it
+ * may reset or disable the hangtime countdown armed when the clear companion
+ * ended; otherwise the channel only releases once the encrypted call stops,
+ * instead of returning to the control channel one hangtime after the last
+ * followed call ended.
+ */
+
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/protocol/p25/p25_crypto.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "../../../src/protocol/p25/p25_trunk_sm_internal.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#define CLEAR_TG  40601
+#define CLEAR_SRC 600205
+#define ENC_TG    40699
+#define ENC_SRC   600299
+#define ENC_ALGID 0x84
+#define ENC_KEYID 0x1234
+#define VC_FREQ   851500000L
+
+static dsd_opts g_opts;
+static dsd_state g_state;
+
+static int
+expect(const char* tag, int cond) {
+    if (!cond) {
+        DSD_FPRINTF(stderr, "FAIL: %s\n", tag);
+        return 1;
+    }
+    return 0;
+}
+
+static dsd_trunk_tune_result
+test_tune_request(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps, uint64_t request_id) {
+    (void)opts;
+    (void)state;
+    (void)ted_sps;
+    (void)request_id;
+    return freq > 0 ? DSD_TRUNK_TUNE_RESULT_OK : DSD_TRUNK_TUNE_RESULT_FAILED;
+}
+
+static dsd_trunk_tune_result
+test_return_request(dsd_opts* opts, dsd_state* state, uint64_t request_id) {
+    (void)opts;
+    (void)state;
+    (void)request_id;
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static void
+reset_test_state(void) {
+    dsd_state_ext_free_all(&g_state);
+    DSD_MEMSET(&g_opts, 0, sizeof(g_opts));
+    DSD_MEMSET(&g_state, 0, sizeof(g_state));
+    g_opts.trunk_enable = 1;
+    g_opts.trunk_hangtime = 2.0f;
+    g_opts.trunk_tune_group_calls = 1;
+    g_opts.trunk_tune_private_calls = 1;
+    g_opts.trunk_tune_enc_calls = 0; /* encryption lockout enabled */
+    g_state.p25_cc_freq = 851000000;
+    g_state.lastsynctype = DSD_SYNC_P25P2_POS;
+    g_state.synctype = DSD_SYNC_P25P2_POS;
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
+        .tune_to_freq_request = test_tune_request,
+        .tune_to_cc_request = test_tune_request,
+        .return_to_cc_request = test_return_request,
+    });
+}
+
+static void
+start_tuned_tdma(void) {
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    g_state.trunk_chan_map[0x1234] = VC_FREQ;
+    g_state.trunk_chan_map[0x1235] = VC_FREQ;
+    g_state.p25_chan_tdma_explicit[1] = 2;
+    p25_sm_init_ctx(ctx, &g_opts, &g_state);
+    g_opts.trunk_is_tuned = 1;
+    p25_sm_event_t grant = p25_sm_ev_group_grant(0x1234, VC_FREQ, CLEAR_TG, CLEAR_SRC, 0);
+    p25_sm_event(ctx, &g_opts, &g_state, &grant);
+}
+
+static void
+grant_companion(int tg, int src, int svc_bits) {
+    p25_sm_event_t grant = p25_sm_ev_group_grant(0x1235, VC_FREQ, tg, src, svc_bits);
+    p25_sm_event(p25_sm_get_ctx(), &g_opts, &g_state, &grant);
+}
+
+static void
+transmit(int slot, int tg, int source, uint8_t signature_fill) {
+    uint8_t signature[P25_SM_PTT_SIGNATURE_BYTES];
+    DSD_MEMSET(signature, signature_fill, sizeof(signature));
+    (void)p25_sm_emit_ptt_call_metadata(&g_opts, &g_state, slot, tg, 0, source, 1, P25_SM_SVC_UNKNOWN, signature,
+                                        dsd_time_now_monotonic_s(), 0);
+}
+
+static void
+resolve_enc_blocked(void) {
+    /* A non-clear tuple contradicting clear service context quarantines as
+     * pending on first sight; the FEC-accepted repeat completes it. */
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 1, ENC_ALGID, ENC_KEYID, 0, ENC_TG);
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 1, ENC_ALGID, ENC_KEYID, 0, ENC_TG);
+}
+
+static double
+backdate(double stamp_m, double by_s) {
+    return stamp_m > 0.0 ? stamp_m - by_s : stamp_m;
+}
+
+/*
+ * Slot 0 follows a clear call while slot 1 carries a locked-out encrypted
+ * transmission that outlives it. After the clear END arms the hangtime
+ * countdown, the locked-out call's continuing signaling -- a clear-claiming
+ * grant update that re-admits it as a probe, plus suppressed MAC voice starts
+ * -- must leave the countdown running so the tick can release the channel
+ * mid-transmission once the hangtime elapses.
+ */
+static int
+test_enc_signaling_does_not_starve_hangtime_release(void) {
+    int rc = 0;
+    reset_test_state();
+    start_tuned_tdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+
+    /* Followed clear call on slot 0. */
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, 0, CLEAR_TG);
+
+    /* Encrypted call granted on the companion slot of the same carrier; its
+     * ESS classifies BLOCKED and the target locks out. */
+    grant_companion(ENC_TG, ENC_SRC, 0x40);
+    rc |= expect("enc grant assigns companion slot", ctx->slots[1].grant_active == 1);
+    transmit(1, ENC_TG, ENC_SRC, 0x22U);
+    resolve_enc_blocked();
+    rc |= expect("enc slot classifies BLOCKED", g_state.p25_crypto_state[1] == DSD_P25_CRYPTO_BLOCKED);
+    rc |= expect("lockout suppression stamped", ctx->slots[1].last_enc_suppress_m > 0.0);
+    rc |= expect("clear companion holds channel", g_opts.trunk_is_tuned == 1);
+
+    /* Clear call ends; the locked-out slot holds no grant, so the hangtime
+     * countdown arms. */
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
+    p25_crypto_reset_slot(&g_state, 0);
+    const double armed_m = ctx->t_hangtime_m;
+    rc |= expect("clear END arms hangtime", armed_m > 0.0);
+
+    /* The site's next grant update for the still-transmitting encrypted call
+     * claims clear service options, which releases the lockout ledger entry
+     * and re-admits the call as a probe. The probe may hold the channel, but
+     * it must not erase the armed countdown. */
+    grant_companion(ENC_TG, ENC_SRC, 0x00);
+    rc |= expect("clear-claiming grant update re-admits probe", ctx->slots[1].grant_active == 1);
+    rc |= expect("probe re-grant preserves armed hangtime", fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
+
+    /* The probe's first contradicting ESS tuple quarantines as pending; the
+     * suppressed MAC voice start that follows must also leave the countdown
+     * running. */
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 1, ENC_ALGID, ENC_KEYID, 0, ENC_TG);
+    (void)p25_sm_emit_active_call(&g_opts, &g_state, 1, ENC_TG, 0, ENC_SRC, 1, 0x40);
+    rc |= expect("suppressed MAC start keeps slot inactive", ctx->slots[1].voice_active == 0);
+    rc |= expect("suppressed MAC start preserves armed hangtime", fabs(ctx->t_hangtime_m - armed_m) <= 1.0e-9);
+
+    /* The repeat tuple completes the classification: BLOCKED again, lockout
+     * re-arms, and the stay-or-release action holds for the companion's
+     * unexpired gap -- with the countdown still armed. */
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 1, ENC_ALGID, ENC_KEYID, 0, ENC_TG);
+    rc |= expect("enc re-lock holds within companion gap", g_opts.trunk_is_tuned == 1);
+    rc |= expect("enc re-lock leaves hangtime armed", ctx->t_hangtime_m > 0.0);
+
+    /* Hangtime elapses while the encrypted transmission continues and its ESS
+     * stops decoding (no further classification transitions). Only the tick
+     * can release the channel now. */
+    const double by_s = (double)g_opts.trunk_hangtime + 0.5;
+    ctx->t_hangtime_m = backdate(ctx->t_hangtime_m, by_s);
+    ctx->t_tune_m = backdate(ctx->t_tune_m, by_s);
+    ctx->t_voice_m = backdate(ctx->t_voice_m, by_s);
+    ctx->slots[0].last_stop_m = backdate(ctx->slots[0].last_stop_m, by_s);
+    ctx->slots[0].last_end_m = backdate(ctx->slots[0].last_end_m, by_s);
+    ctx->slots[1].last_stop_m = backdate(ctx->slots[1].last_stop_m, by_s);
+    ctx->slots[1].last_grant_m = backdate(ctx->slots[1].last_grant_m, by_s);
+    ctx->slots[1].last_enc_suppress_m = backdate(ctx->slots[1].last_enc_suppress_m, by_s);
+    ctx->slots[1].crypto_attempt_m = backdate(ctx->slots[1].crypto_attempt_m, by_s);
+
+    p25_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect("hangtime expiry releases channel", g_opts.trunk_is_tuned == 0);
+    return rc;
+}
+
+/*
+ * Same channel, worse phase alignment: the clear-claiming grant update lands
+ * before the clear call ends, so the clear END reads the reprobe assignment as
+ * pending companion activity and never arms the countdown. The re-lock's hold
+ * must arm it from the companion's real stop time so the tick can still
+ * release the channel once the gap outlives the hangtime.
+ */
+static int
+test_enc_relock_hold_arms_hangtime_for_ended_companion(void) {
+    int rc = 0;
+    reset_test_state();
+    start_tuned_tdma();
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+
+    /* Followed clear call on slot 0; locked-out encrypted call on slot 1. */
+    transmit(0, CLEAR_TG, CLEAR_SRC, 0x11U);
+    (void)p25_crypto_resolve(&g_opts, &g_state, DSD_P25_CRYPTO_PHASE2, 0, 0x80, 0, 0, CLEAR_TG);
+    grant_companion(ENC_TG, ENC_SRC, 0x40);
+    transmit(1, ENC_TG, ENC_SRC, 0x22U);
+    resolve_enc_blocked();
+    rc |= expect("enc slot classifies BLOCKED", g_state.p25_crypto_state[1] == DSD_P25_CRYPTO_BLOCKED);
+
+    /* The clear-claiming grant update re-admits the probe while the clear
+     * call is still up; the clear call then ends with that assignment
+     * pending, so the END cannot arm the countdown. */
+    grant_companion(ENC_TG, ENC_SRC, 0x00);
+    rc |= expect("clear-claiming grant update re-admits probe", ctx->slots[1].grant_active == 1);
+    (void)p25_sm_emit_end_call_at(&g_opts, &g_state, 0, CLEAR_TG, CLEAR_SRC, dsd_time_now_monotonic_s());
+    p25_crypto_reset_slot(&g_state, 0);
+
+    /* The probe's ESS classifies BLOCKED again; the re-lock holds for the
+     * companion's unexpired gap and must arm the countdown from the
+     * companion's stop, because no further transition will revisit it. */
+    resolve_enc_blocked();
+    rc |= expect("enc re-lock holds within companion gap", g_opts.trunk_is_tuned == 1);
+    rc |= expect("enc re-lock arms hangtime from companion stop", ctx->t_hangtime_m > 0.0);
+
+    /* Hangtime elapses with the encrypted transmission still up and its ESS
+     * quiet; the tick must release the channel. */
+    const double by_s = (double)g_opts.trunk_hangtime + 0.5;
+    ctx->t_hangtime_m = backdate(ctx->t_hangtime_m, by_s);
+    ctx->t_tune_m = backdate(ctx->t_tune_m, by_s);
+    ctx->t_voice_m = backdate(ctx->t_voice_m, by_s);
+    ctx->slots[0].last_stop_m = backdate(ctx->slots[0].last_stop_m, by_s);
+    ctx->slots[0].last_end_m = backdate(ctx->slots[0].last_end_m, by_s);
+    ctx->slots[1].last_stop_m = backdate(ctx->slots[1].last_stop_m, by_s);
+    ctx->slots[1].last_grant_m = backdate(ctx->slots[1].last_grant_m, by_s);
+    ctx->slots[1].last_enc_suppress_m = backdate(ctx->slots[1].last_enc_suppress_m, by_s);
+    ctx->slots[1].crypto_attempt_m = backdate(ctx->slots[1].crypto_attempt_m, by_s);
+
+    p25_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect("hangtime expiry releases channel after re-lock", g_opts.trunk_is_tuned == 0);
+    return rc;
+}
+
+int
+main(void) {
+    int rc = 0;
+    rc |= test_enc_signaling_does_not_starve_hangtime_release();
+    rc |= test_enc_relock_hold_arms_hangtime_for_ended_companion();
+    dsd_state_ext_free_all(&g_state);
+
+    if (rc == 0) {
+        DSD_FPRINTF(stderr, "P25 P2 ENC LOCKOUT HANGTIME RELEASE: OK\n");
+    }
+    return rc;
+}

--- a/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
+++ b/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
@@ -557,6 +557,17 @@ test_facch_double_end_holds_channel_while_companion_enc_suppressed(void) {
 // lockout action, so it never revisits stay-or-release -- even when the
 // companion's gap has outlived the hangtime. Releasing that emptied channel is
 // the hangtime tick's job.
+/*
+ * Force the derived hangtime countdown to have started at @p started_m. The
+ * deadline is the most recent moment any slot carried followed traffic, so one
+ * slot carries the forced value and the other is cleared.
+ */
+static void
+set_hangtime_started(p25_sm_ctx_t* ctx, double started_m) {
+    ctx->slots[0].last_followed_m = started_m;
+    ctx->slots[1].last_followed_m = 0.0;
+}
+
 static int
 test_enc_blocked_repeat_edge_triggered_tick_owns_release(void) {
     static dsd_opts opts;
@@ -605,7 +616,7 @@ test_enc_blocked_repeat_edge_triggered_tick_owns_release(void) {
     ctx->slots[0].last_start_m = past_stop_m - 1.0;
     ctx->slots[0].last_grant_m = past_stop_m - 1.0;
     ctx->slots[0].last_stop_m = past_stop_m;
-    ctx->t_hangtime_m = past_stop_m;
+    set_hangtime_started(ctx, past_stop_m);
 
     // Pre-fix, this repeat re-ran the lockout action and released the channel
     // itself. Edge-triggered, it only refreshes the stamp.

--- a/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
+++ b/tests/protocol/p25/test_p25_p2_frame_lockout_sm.c
@@ -551,6 +551,67 @@ test_facch_double_end_holds_channel_while_companion_enc_suppressed(void) {
     return rc;
 }
 
+// The suppression stamp reads "occupied right now" from ESS repeats alone, but
+// the locked-out call also announces its own end: its MAC_END_PTT still decodes
+// and reaches the SM, where the missing assignment gets it discarded. That
+// observed END must terminate the stamp -- otherwise a clear call ending within
+// one hangtime of the encrypted call loses its double-END fast release to a
+// companion that is no longer transmitting, and the CC return waits out the
+// full hangtime instead.
+static int
+test_facch_double_end_releases_after_companion_end_observed(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    setup_tuned_tdma(&opts, &state, &ctx);
+    ctx->config.hangtime_s = 2.0;
+    state.event_history_s = calloc(2, sizeof(Event_History_I));
+    if (state.event_history_s == NULL) {
+        return 1;
+    }
+    for (int i = 0; i < 2; i++) {
+        init_event_history(&state.event_history_s[i], 0, 255);
+    }
+    g_return_to_cc_called = 0;
+
+    int rc = 0;
+
+    // Clear transmission decoding on slot 0.
+    state.p25_crypto_state[0] = DSD_P25_CRYPTO_CLEAR;
+    rc |= expect_eq("clear voice start accepted", p25_sm_emit_active_call(&opts, &state, 0, 1234, 0, 42, 1, 0x00), 1);
+    state.p25_p2_audio_allowed[0] = 1;
+
+    // Slot 1 carries the locked-out encrypted call; the lockout action leaves
+    // only the suppression stamp behind.
+    (void)p25_crypto_resolve(&opts, &state, DSD_P25_CRYPTO_PHASE2, 1, 0x84, 0x2710, 0x1111222233334444ULL, 5678);
+    rc |= expect_eq("companion suppressed: stamp recorded", ctx->slots[1].last_enc_suppress_m > 0.0, 1);
+
+    // The locked-out call un-keys: its MAC_END_PTT decodes on slot 1 even
+    // though lockout erased the assignment it would have applied to. The
+    // active clear call still holds the channel.
+    const double enc_end_m = dsd_time_now_monotonic_s();
+    (void)p25_sm_emit_facch_end_call_at(&opts, &state, 1, 5678, 0xFFFFFF, enc_end_m);
+    rc |= expect_eq("companion end observed: still tuned", ctx->state == P25_SM_TUNED, 1);
+    rc |= expect_eq("companion end observed: no cc return", g_return_to_cc_called, 0);
+    rc |= expect_eq("companion end observed: stamp terminated", ctx->slots[1].last_enc_suppress_m <= 0.0, 1);
+
+    // The clear talker un-keys half a second later -- well inside what stamp
+    // aging alone would still call occupied -- and the END repeat lands 0.2 s
+    // after that. With both transmissions over, the fast release must fire
+    // promptly instead of waiting out the hangtime.
+    const double end_m = enc_end_m + 0.5;
+    rc |= expect_eq("first facch end applied", p25_sm_emit_facch_end_call_at(&opts, &state, 0, 1234, 42, end_m),
+                    P25_SM_END_APPLIED);
+    state.p25_p2_audio_allowed[0] = 0;
+    (void)p25_sm_emit_facch_end_call_at(&opts, &state, 0, 1234, 42, end_m + 0.2);
+    rc |= expect_eq("double end after companion end: released to cc", g_return_to_cc_called, 1);
+
+    dsd_state_ext_free_all(&state);
+    free(state.event_history_s);
+    state.event_history_s = NULL;
+    return rc;
+}
+
 // The crypto layer edge-triggers the ENC event on the classification
 // transition: a FEC-accepted ESS repeat of an already-BLOCKED Phase 2 slot
 // under lockout refreshes the suppression stamp instead of re-running the full
@@ -760,6 +821,7 @@ main(void) {
     rc |= test_enc_repeat_holds_channel_through_companion_hangtime();
     rc |= test_enc_lockout_idle_companion_still_releases();
     rc |= test_facch_double_end_holds_channel_while_companion_enc_suppressed();
+    rc |= test_facch_double_end_releases_after_companion_end_observed();
     rc |= test_enc_blocked_repeat_edge_triggered_tick_owns_release();
     rc |= test_enc_key_identity_change_reemits_lockout();
     rc |= test_companion_voice_burst_preserves_clear_superframe();

--- a/tests/protocol/p25/test_p25_p2_hangtime_events.c
+++ b/tests/protocol/p25/test_p25_p2_hangtime_events.c
@@ -144,7 +144,7 @@ test_same_identity_mac_active_reopens_call(void) {
     rc |= expect("same-source ACTIVE reopens call", slot0_matches(DSD_CALL_PHASE_ACTIVE, TEST_TG, TEST_SRC));
     rc |= expect("same-source ACTIVE starts epoch", slot0_epoch() != ended_epoch);
     rc |= expect("same-source ACTIVE remains clear", g_state.p25_crypto_state[0] == DSD_P25_CRYPTO_CLEAR);
-    rc |= expect("same-source ACTIVE clears hangtime", fabs(p25_sm_get_ctx()->t_hangtime_m) <= 1.0e-9);
+    rc |= expect("same-source ACTIVE clears hangtime", fabs(p25_sm_hangtime_started_m(p25_sm_get_ctx())) <= 1.0e-9);
     return rc;
 }
 

--- a/tests/protocol/p25/test_p25_reassignment.c
+++ b/tests/protocol/p25/test_p25_reassignment.c
@@ -228,7 +228,7 @@ test_followup_reuses_retained_carrier(void) {
     p25_sm_event(&ctx, &opts, &state, &followup);
     rc |= expect_true("followup reopened without tune",
                       g_tune_calls == 1 && g_return_calls == 0 && ctx.slots[0].voice_active == 1
-                          && ctx.slots[0].src == 5402 && p25_sm_hangtime_started_m(&ctx) == 0.0);
+                          && ctx.slots[0].src == 5402 && p25_sm_hangtime_started_m(&ctx) <= 0.0);
     dsd_state_ext_free_all(&state);
     return rc;
 }
@@ -264,7 +264,7 @@ test_same_carrier_assignment_restarts_wait_window(void) {
 
     p25_sm_event(&ctx, &opts, &state, &grant);
     rc |= expect_true("same-carrier assignment restarted acquisition",
-                      ctx.state == P25_SM_TUNED && p25_sm_hangtime_started_m(&ctx) == 0.0 && ctx.vc_activity_seen == 0
+                      ctx.state == P25_SM_TUNED && p25_sm_hangtime_started_m(&ctx) <= 0.0 && ctx.vc_activity_seen == 0
                           && ctx.t_tune_m > previous_tune_m && ctx.slots[0].last_end_m == 0.0 && g_tune_calls == 1);
     p25_sm_tick_ctx(&ctx, &opts, &state);
     rc |= expect_true("fresh same-carrier assignment survived immediate tick", g_return_calls == 0);

--- a/tests/protocol/p25/test_p25_reassignment.c
+++ b/tests/protocol/p25/test_p25_reassignment.c
@@ -224,13 +224,24 @@ test_followup_reuses_retained_carrier(void) {
     p25_sm_event_t end = p25_sm_ev_end_call_at(0, 4401, 5401, dsd_time_now_monotonic_s());
     p25_sm_event(&ctx, &opts, &state, &end);
     rc |= expect_true("transmission end retained carrier",
-                      ctx.state == P25_SM_TUNED && ctx.t_hangtime_m > 0.0 && g_return_calls == 0);
+                      ctx.state == P25_SM_TUNED && p25_sm_hangtime_started_m(&ctx) > 0.0 && g_return_calls == 0);
     p25_sm_event(&ctx, &opts, &state, &followup);
-    rc |= expect_true("followup reopened without tune", g_tune_calls == 1 && g_return_calls == 0
-                                                            && ctx.slots[0].voice_active == 1
-                                                            && ctx.slots[0].src == 5402 && ctx.t_hangtime_m == 0.0);
+    rc |= expect_true("followup reopened without tune",
+                      g_tune_calls == 1 && g_return_calls == 0 && ctx.slots[0].voice_active == 1
+                          && ctx.slots[0].src == 5402 && p25_sm_hangtime_started_m(&ctx) == 0.0);
     dsd_state_ext_free_all(&state);
     return rc;
+}
+
+/*
+ * Force the derived hangtime countdown to have started at @p started_m. The
+ * deadline is the most recent moment any slot carried followed traffic, so one
+ * slot carries the forced value and the other is cleared.
+ */
+static void
+set_hangtime_started(p25_sm_ctx_t* ctx, double started_m) {
+    ctx->slots[0].last_followed_m = started_m;
+    ctx->slots[1].last_followed_m = 0.0;
 }
 
 static int
@@ -248,12 +259,12 @@ test_same_carrier_assignment_restarts_wait_window(void) {
     p25_sm_event(&ctx, &opts, &state, &ptt);
     p25_sm_event_t end = p25_sm_ev_end_call_at(0, 4451, 5451, dsd_time_now_monotonic_s());
     p25_sm_event(&ctx, &opts, &state, &end);
-    ctx.t_hangtime_m = dsd_time_now_monotonic_s() - ctx.config.hangtime_s + 0.01;
+    set_hangtime_started(&ctx, dsd_time_now_monotonic_s() - ctx.config.hangtime_s + 0.01);
     const double previous_tune_m = ctx.t_tune_m;
 
     p25_sm_event(&ctx, &opts, &state, &grant);
     rc |= expect_true("same-carrier assignment restarted acquisition",
-                      ctx.state == P25_SM_TUNED && ctx.t_hangtime_m == 0.0 && ctx.vc_activity_seen == 0
+                      ctx.state == P25_SM_TUNED && p25_sm_hangtime_started_m(&ctx) == 0.0 && ctx.vc_activity_seen == 0
                           && ctx.t_tune_m > previous_tune_m && ctx.slots[0].last_end_m == 0.0 && g_tune_calls == 1);
     p25_sm_tick_ctx(&ctx, &opts, &state);
     rc |= expect_true("fresh same-carrier assignment survived immediate tick", g_return_calls == 0);
@@ -325,7 +336,7 @@ test_p1_source_less_update_validation(void) {
     p25_sm_event(&ctx, &opts, &state, &ptt);
     p25_sm_event_t end = p25_sm_ev_end_call_at(0, 4701, 5701, dsd_time_now_monotonic_s());
     p25_sm_event(&ctx, &opts, &state, &end);
-    ctx.t_hangtime_m = dsd_time_now_monotonic_s() - 3.0;
+    set_hangtime_started(&ctx, dsd_time_now_monotonic_s() - 3.0);
     p25_sm_tick_ctx(&ctx, &opts, &state);
     note_cc_reacquired(&ctx, &state);
 
@@ -371,7 +382,7 @@ test_p1_tdu_preserves_identified_end_source(void) {
     p25_sm_event_t end = p25_sm_ev_end_call_at(0, 4751, 5751, dsd_time_now_monotonic_s());
     p25_sm_event(&ctx, &opts, &state, &end);
     const double guard_end_m = ctx.recent_call_ends[0].end_m;
-    const double hang_started_m = ctx.t_hangtime_m;
+    const double hang_started_m = p25_sm_hangtime_started_m(&ctx);
     const double time_epsilon_s = 1.0e-9;
 
     p25_sm_event_t tdu = p25_sm_ev_tdu();
@@ -380,9 +391,9 @@ test_p1_tdu_preserves_identified_end_source(void) {
                       ctx.slots[0].last_end_tg == 4751 && ctx.slots[0].last_end_src == 5751
                           && ctx.recent_call_ends[0].src == 5751
                           && fabs(ctx.recent_call_ends[0].end_m - guard_end_m) <= time_epsilon_s
-                          && fabs(ctx.t_hangtime_m - hang_started_m) <= time_epsilon_s);
+                          && fabs(p25_sm_hangtime_started_m(&ctx) - hang_started_m) <= time_epsilon_s);
 
-    ctx.t_hangtime_m = dsd_time_now_monotonic_s() - 3.0;
+    set_hangtime_started(&ctx, dsd_time_now_monotonic_s() - 3.0);
     p25_sm_tick_ctx(&ctx, &opts, &state);
     note_cc_reacquired(&ctx, &state);
     p25_sm_event_t update = p25_sm_ev_group_grant_update(channel, freq, 4751, 5752, P25_SM_SVC_UNKNOWN);
@@ -409,7 +420,7 @@ test_failed_validation_probe_does_not_loop(void) {
     p25_sm_event(&ctx, &opts, &state, &ptt);
     p25_sm_event_t end = p25_sm_ev_end_call_at(0, 4501, 5501, dsd_time_now_monotonic_s());
     p25_sm_event(&ctx, &opts, &state, &end);
-    ctx.t_hangtime_m = dsd_time_now_monotonic_s() - 3.0;
+    set_hangtime_started(&ctx, dsd_time_now_monotonic_s() - 3.0);
     p25_sm_tick_ctx(&ctx, &opts, &state);
     note_cc_reacquired(&ctx, &state);
 

--- a/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
+++ b/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
@@ -357,14 +357,25 @@ matrix_send_initial_grant(matrix_fixture* fixture, const matrix_mode_case* mode,
     return rc;
 }
 
+/*
+ * Force the derived hangtime countdown to have started at @p started_m. The
+ * deadline is the most recent moment any slot carried followed traffic, so one
+ * slot carries the forced value and the other is cleared.
+ */
+static void
+set_hangtime_started(p25_sm_ctx_t* ctx, double started_m) {
+    ctx->slots[0].last_followed_m = started_m;
+    ctx->slots[1].last_followed_m = 0.0;
+}
+
 static void
 matrix_age_tuned_timers(matrix_fixture* fixture) {
     double now_m = dsd_time_now_monotonic_s();
     double stale_m = now_m - 1.0;
     fixture->ctx.t_tune_m = stale_m;
     fixture->ctx.t_voice_m = stale_m;
-    if (fixture->ctx.t_hangtime_m > 0.0) {
-        fixture->ctx.t_hangtime_m = stale_m;
+    if (p25_sm_hangtime_started_m(&fixture->ctx) > 0.0) {
+        set_hangtime_started(&fixture->ctx, stale_m);
     }
     fixture->state->last_vc_sync_time = time(NULL) - 1;
     fixture->state->last_vc_sync_time_m = stale_m;

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -174,9 +174,20 @@ canonical_call_begin_p1(uint64_t target, uint64_t source, uint16_t service_optio
     return dsd_call_state_observe(&g_state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0;
 }
 
+/*
+ * Force the derived hangtime countdown to have started at @p started_m. The
+ * deadline is the most recent moment any slot carried followed traffic, so one
+ * slot carries the forced value and the other is cleared.
+ */
+static void
+set_hangtime_started(p25_sm_ctx_t* ctx, double started_m) {
+    ctx->slots[0].last_followed_m = started_m;
+    ctx->slots[1].last_followed_m = 0.0;
+}
+
 static void
 expire_traffic_hang(p25_sm_ctx_t* ctx) {
-    ctx->t_hangtime_m = dsd_time_now_monotonic_s() - ctx->config.hangtime_s - 0.1;
+    set_hangtime_started(ctx, dsd_time_now_monotonic_s() - ctx->config.hangtime_s - 0.1);
     p25_sm_tick_ctx(ctx, &g_opts, &g_state);
 }
 
@@ -324,7 +335,7 @@ test_private_ptt_preserves_grant_identity(void) {
     ev = p25_sm_ev_end_call_at(0, 0x4567, 0x010203, ctx.slots[0].last_start_m + 0.001);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
     if (ctx.slots[0].voice_active || !ctx.slots[0].grant_active || ctx.slots[0].last_end_m <= 0.0
-        || ctx.t_hangtime_m <= 0.0) {
+        || p25_sm_hangtime_started_m(&ctx) <= 0.0) {
         DSD_FPRINTF(stderr, "FAIL: Private END treated the MAC group field as the destination identity\n");
         return 1;
     }
@@ -923,7 +934,7 @@ test_pending_crypto_uses_classification_deadline(void) {
     ev = p25_sm_ev_ptt_call(0, 1000, 0, 123, 1, P25_SM_SVC_UNKNOWN);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
     if (g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_ENCRYPTED_PENDING || ctx.slots[0].voice_active
-        || ctx.slots[0].crypto_attempt_m <= 0.0 || ctx.t_hangtime_m > 0.0) {
+        || ctx.slots[0].crypto_attempt_m <= 0.0 || p25_sm_hangtime_started_m(&ctx) > 0.0) {
         DSD_FPRINTF(stderr, "FAIL: Pending crypto did not retain its classification-only deadline\n");
         return 1;
     }
@@ -1786,7 +1797,7 @@ test_end_clears_voice(void) {
     ev = p25_sm_ev_end(0);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
 
-    if (ctx.state != P25_SM_TUNED || ctx.t_hangtime_m <= 0.0 || !ctx.slots[0].grant_active) {
+    if (ctx.state != P25_SM_TUNED || p25_sm_hangtime_started_m(&ctx) <= 0.0 || !ctx.slots[0].grant_active) {
         DSD_FPRINTF(stderr, "FAIL: Expected retained TUNED allocation after END, got %s\n",
                     p25_sm_state_name(ctx.state));
         return 1;
@@ -1822,7 +1833,7 @@ test_tdma_boundaries_only_hang_after_last_assigned_voice(void) {
 
     ev = p25_sm_ev_idle(1);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
-    if (ctx.vc_activity_seen || ctx.t_hangtime_m > 0.0 || !ctx.slots[0].grant_active) {
+    if (ctx.vc_activity_seen || p25_sm_hangtime_started_m(&ctx) > 0.0 || !ctx.slots[0].grant_active) {
         DSD_FPRINTF(stderr, "FAIL: Unassigned companion IDLE manufactured traffic activity or hang\n");
         return 1;
     }
@@ -1852,14 +1863,14 @@ test_tdma_boundaries_only_hang_after_last_assigned_voice(void) {
 
     ev = p25_sm_ev_hangtime(1);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
-    if (!ctx.slots[0].voice_active || ctx.slots[1].voice_active || ctx.t_hangtime_m > 0.0) {
+    if (!ctx.slots[0].voice_active || ctx.slots[1].voice_active || p25_sm_hangtime_started_m(&ctx) > 0.0) {
         DSD_FPRINTF(stderr, "FAIL: Ending one assigned slot armed hang while its companion remained active\n");
         return 1;
     }
 
     ev = p25_sm_ev_end(0);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
-    if (ctx.t_hangtime_m <= 0.0 || g_return_requests != 0) {
+    if (p25_sm_hangtime_started_m(&ctx) <= 0.0 || g_return_requests != 0) {
         DSD_FPRINTF(stderr, "FAIL: Last assigned voice transition did not arm traffic hang\n");
         return 1;
     }
@@ -1892,7 +1903,7 @@ test_tdma_idle_ends_voice_with_newer_grant(void) {
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
     if (ctx.slots[0].voice_active || !ctx.slots[0].grant_active || ctx.slots[0].target_id != 1000
         || ctx.slots[0].src != 123 || fabs(ctx.slots[0].last_grant_m - newer_grant_m) > 1.0e-9
-        || ctx.t_hangtime_m <= 0.0 || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_CLEAR
+        || p25_sm_hangtime_started_m(&ctx) <= 0.0 || g_state.p25_crypto_state[0] != DSD_P25_CRYPTO_CLEAR
         || g_state.p25_p2_audio_allowed[0]) {
         DSD_FPRINTF(stderr, "FAIL: TDMA IDLE did not end voice while preserving its newer grant\n");
         return 1;
@@ -1998,12 +2009,13 @@ test_unassigned_companion_start_is_rejected(void) {
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
     ev = p25_sm_ev_end(0);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
-    const double hang_started_m = ctx.t_hangtime_m;
+    const double hang_started_m = p25_sm_hangtime_started_m(&ctx);
 
     ev = p25_sm_ev_active_call(1, 2000, 0, 456, 1, 0);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
-    if (ctx.slots[1].voice_active || fabs(ctx.t_hangtime_m - hang_started_m) > 1.0e-9 || ctx.state != P25_SM_TUNED
-        || g_return_requests != 0 || !g_state.p25_p2_media_rejected[1] || g_state.p25_p2_audio_allowed[1] != 0) {
+    if (ctx.slots[1].voice_active || fabs(p25_sm_hangtime_started_m(&ctx) - hang_started_m) > 1.0e-9
+        || ctx.state != P25_SM_TUNED || g_return_requests != 0 || !g_state.p25_p2_media_rejected[1]
+        || g_state.p25_p2_audio_allowed[1] != 0) {
         DSD_FPRINTF(stderr, "FAIL: Unassigned companion ACTIVE bypassed routing policy or canceled hang\n");
         return 1;
     }
@@ -2138,7 +2150,7 @@ test_tdma_partial_end_stays_tuned(void) {
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
 
     // Both transmissions have ended, but the physical allocation remains.
-    if (ctx.state != P25_SM_TUNED || ctx.t_hangtime_m <= 0.0 || g_return_requests != 0) {
+    if (ctx.state != P25_SM_TUNED || p25_sm_hangtime_started_m(&ctx) <= 0.0 || g_return_requests != 0) {
         DSD_FPRINTF(stderr, "FAIL: Expected retained TDMA carrier after both ENDs, got %s\n",
                     p25_sm_state_name(ctx.state));
         return 1;
@@ -2191,8 +2203,11 @@ test_tdma_pending_other_slot_blocks_release(void) {
         DSD_FPRINTF(stderr, "FAIL: END discarded a retained slot assignment\n");
         return 1;
     }
-    if (ctx.t_hangtime_m > 0.0) {
-        DSD_FPRINTF(stderr, "FAIL: Pending companion grant was placed on the shorter traffic hang timer\n");
+    /* The countdown runs -- slot 0's END is a fact about slot 0 -- but a
+       companion assignment the SM has reason to follow outranks it until its
+       own acquisition window closes, which the two ticks below pin. */
+    if (p25_sm_hangtime_started_m(&ctx) <= 0.0) {
+        DSD_FPRINTF(stderr, "FAIL: Expected the ended slot to start the hangtime countdown\n");
         return 1;
     }
 
@@ -2228,8 +2243,8 @@ test_tdma_pending_other_slot_blocks_release(void) {
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
     ev = p25_sm_ev_end(0);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
-    if (ctx.t_hangtime_m > 0.0 || !ctx.slots[1].grant_active || !ctx.slots[1].data_call) {
-        DSD_FPRINTF(stderr, "FAIL: Pending data companion was placed on the traffic hang timer\n");
+    if (p25_sm_hangtime_started_m(&ctx) <= 0.0 || !ctx.slots[1].grant_active || !ctx.slots[1].data_call) {
+        DSD_FPRINTF(stderr, "FAIL: Expected the ended slot to start the countdown beside the data grant\n");
         return 1;
     }
     acquisition_m = dsd_time_now_monotonic_s() - ctx.config.hangtime_s - 0.1;
@@ -2287,7 +2302,7 @@ test_tdma_enc_lockout_slot_does_not_block_release(void) {
 
     ev = p25_sm_ev_end(0);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
-    if (ctx.state != P25_SM_TUNED || ctx.t_hangtime_m <= 0.0 || g_return_requests != 0) {
+    if (ctx.state != P25_SM_TUNED || p25_sm_hangtime_started_m(&ctx) <= 0.0 || g_return_requests != 0) {
         DSD_FPRINTF(stderr, "FAIL: Expected hang retention after clear slot END with encrypted slot muted, got %s\n",
                     p25_sm_state_name(ctx.state));
         return 1;
@@ -2344,7 +2359,8 @@ test_tdma_single_slot_end_retains_carrier(void) {
     ev = p25_sm_ev_end(0);
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
 
-    if (ctx.state != P25_SM_TUNED || ctx.t_hangtime_m <= 0.0 || !ctx.slots[0].grant_active || g_return_requests != 0) {
+    if (ctx.state != P25_SM_TUNED || p25_sm_hangtime_started_m(&ctx) <= 0.0 || !ctx.slots[0].grant_active
+        || g_return_requests != 0) {
         DSD_FPRINTF(stderr, "FAIL: Expected retained carrier after END on single-slot TDMA call, got %s\n",
                     p25_sm_state_name(ctx.state));
         return 1;
@@ -2753,7 +2769,7 @@ test_inband_policy_reject_releases_after_companion_ended(void) {
     ev = p25_sm_ev_end_call_at(1, 2000, 202, dsd_time_now_monotonic_s());
     p25_sm_event(&ctx, &g_opts, &g_state, &ev);
     if (ctx.state != P25_SM_TUNED || ctx.slots[1].voice_active || !ctx.slots[1].grant_active
-        || ctx.t_hangtime_m > 0.0) {
+        || p25_sm_hangtime_started_m(&ctx) > 0.0) {
         DSD_FPRINTF(stderr, "FAIL: Companion END did not leave the active slot in control of the carrier\n");
         return 1;
     }


### PR DESCRIPTION
## Problem

With encryption lockout enabled and a locked-out encrypted call sharing the TDMA voice channel with a followed clear call, the channel stayed tuned after the clear call ended — for as long as the encrypted call kept transmitting — instead of returning to the control channel one hangtime after the last followed transmission.

The stall is a feedback loop driven by the site's grant updates for the still-running encrypted call. A grant update claiming clear service options releases the target's lockout ledger entry (the designed recovery path for a talkgroup that stopped encrypting) and re-admits the call as a probe. On systems whose grant service bits do not track encryption, that happens about once a second for the life of the call, and each iteration erased the countdown the clear call's END had armed:

- each re-admitted grant zeroed `t_hangtime_m` in `p25_grant_initialize_timing()`;
- the suppressed slot's `MAC_PTT`/`MAC_ACTIVE` repeats then cancelled and re-armed the countdown at `now` on every repeat (the re-arm behavior #308 documented);
- and when the reprobe assignment was pending at the moment the clear call ended, the END read the companion as active and never armed the countdown at all — leaving the re-lock's `enc_lockout_hangtime_hold` with no timer and, with the encrypted ESS quiet, no release path until the encrypted call's grants stopped.

## Root cause, restated as a design problem

`t_hangtime_m` was one channel-wide scalar for a two-slot carrier: read in one place, written from eight, by paths owned by different slots and subsystems. Whether the countdown was running encoded a decision — *"followed traffic stopped and nothing else holds this carrier"* — that each writer had to re-derive for itself, and each stated the rule in its own words. Getting one of them wrong is invisible: the suite stays green, because nothing consults a rule a call site never reads.

The first commit here fixed the three loop paths by adding guards. The rest of the branch replaces the scalar with a fact that cannot be gotten wrong.

## Fix

**A per-slot fact and one reader.** `p25_sm_slot_ctx_t.last_followed_m` records when a slot last carried traffic the SM was following. `p25_sm_hangtime_started_m()` derives the deadline from those stamps: the most recent of them, and none while a slot is still followed-active. Nothing a locked-out slot signals — suppressed voice starts, ESS repeats, clear-claiming grant updates — writes a stamp, so by construction none of it can restart or cancel the countdown. The three separately worded guards are gone, not reworded:

- `p25_voice_start_wait_for_classification()` no longer asks whether the companion is followed, whether the start was crypto-suppressed, or whether a countdown is already armed. It stamps for the starts that were followed traffic and writes nothing for the rest.
- `handle_voice_start()`/`handle_voice_end()` no longer cancel or arm. Marking the slot active stops the countdown; the END records where following stopped.
- `p25_grant_initialize_timing()` no longer takes the reprobe flag. Taking a slot over resets its followed history, which is what gives an accepted assignment its fresh acquisition window; a reprobe keeps the stamp, because it is not followed traffic resuming.

**Both deadlines always live.** Deriving the countdown breaks a coupling the old model relied on — an armed countdown implied no followable assignment was pending, because the arm sites declined in that case. `p25_sm_tick_tuned()` now states the release rule outright: the hangtime release defers to an assignment the SM has reason to follow until that slot's own acquisition window closes, and to a crypto classification still inside its budget. A lockout reprobe is neither, so it can acquire but cannot outlive the countdown the last followed transmission left running. `p25_sm_followable_assignment_acquiring()` measures each slot's window from its own `last_grant_m` rather than the channel-wide `t_tune_m` that every accepted assignment — reprobe included — refreshes.

**A backoff on the weak evidence.** `p25_grant_release_enc_lockout_if_clear()` previously treated `dsd_enc_lockout_release()` returning "entry found" as "this target was blocking", which it is not — entries survive a key-epoch bump without blocking, and the ledger is inert in follow mode. The three release conditions are now split by evidence strength: corroborated key material (regroup clear-key override, patch clear key) releases unconditionally and owes no reprobe; a bare grant service bit marks a reprobe only when the target was actually blocked, and only on the assignment path (the policy-only and voice-start re-evaluations were silently consuming the one-shot release). Re-admissions of the same target are then spaced out by a per-target memo: the first clear-claiming grant still probes immediately — the designed recovery — but a reprobe that re-locks does not buy another for a cooldown, and a call whose voice classifies clear clears the record so a real recovery is never delayed.

**Diagnostics.** `enc_lockout_arm`, `grant_block`, and `grant_policy_only` logged with a NULL ctx, printing `state=unknown` and counters that disagreed with the surrounding lines; each now carries the real context (`cc_seed` keeps NULL deliberately — it fires before the SM is engaged). `state->p25_sm_cc_return_count` was never incremented anywhere, so the diag fallback, the ncurses SM panel, and `p25_sm_ui.c` have always shown 0; it now mirrors the ctx-side counter. And `do_release()` losing the release-lock CAS returned silently, making a deadline that fired and lost a race indistinguishable from one that never fired — it now emits `release_contended` with the caller's reason.

## Behavior change

Behavior is unchanged except where the shared scalar was losing information: a new assignment on one slot no longer discards the other slot's bridging window, which only differs when the configured hangtime outruns the grant timeout. The #308 protections are intact — the clear conversation's talker gaps still bridge, and the pre-existing hold tests still pass.

## Tests

- **`P25_P2_ENC_LOCKOUT_HANGTIME_RELEASE`** (new) — the full grant-update loop must leave the countdown running through the reprobe re-grant, the suppressed MAC start, and the re-lock, and the tick must release once the hangtime elapses; the never-armed phase alignment must be rescued by the re-lock hold. Confirmed failing against the pre-fix code.
- **`P25_HANGTIME_ARM_RULES`** (new) — covers the arming rules directly, including the two reprobe rules on the companion slot (a reprobe does not outrank the countdown; a reprobe landing on the countdown's own slot does not reset it). All ten rules are mutation-checked: reverting any one guard fails at least one assertion.
- **`P25_P1_TRUNK_SM`** gains the cc-return mirror assertion at init and across the grant/release cycle; it fails against the pre-fix code.
- `test_mac_release_stamps_the_countdown` covers the `MAC_RELEASE` stamping hole.
- Two tests asserted the old model directly and now assert the rule instead — that a pending companion is what keeps the carrier, rather than the countdown having been withheld. Two float `==` comparisons in `test_p25_reassignment.c` were replaced.

## Verification

- `cmake --build --preset dev-debug -j` — clean.
- `ctest --preset dev-debug` — **519/519 pass** (103/103 in the `P25*` subset).
- `tools/preflight_ci.sh` — clean.

## Risk

- **Security/dependency impact:** none. No new dependencies, no parser or network-input changes. The encryption-lockout ledger's API is unchanged; only P25's rate of *requesting* releases on the weakest evidence changed, which `include/dsd-neo/core/enc_lockout.h` now documents.
- **CLI/UI behavior impact:** the ncurses SM panel's `cc_returns` counter shows a real value instead of a hardcoded 0. Two new diag stream events (`release_contended`, `enc_lockout_reprobe_declined`); several existing ones stop printing `state=unknown`. No flags or config changed.
- **Compatibility or packaging impact:** none. `p25_sm_ctx_t` grows a 16-entry memo table and a per-slot `double`; the struct is internal.
