### PR TITLE
fix(p25): defer Phase 2 TDMA grants until the descrambler seed is known

### DIFF
--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2346,6 +2346,36 @@ p25_grant_prepare_route(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, con
     return 1;
 }
 
+// The TDMA burst descrambler is seeded from WACN/SYSID/NAC, so a Phase 2 voice
+// channel tuned before the Network Status Broadcast has been decoded cannot be
+// descrambled -- the tune just burns the grant-voice timeout. 0 and the
+// all-ones broadcast placeholders are the "not yet known" values.
+static int
+p25_grant_tdma_site_known(const dsd_state* state) {
+    return state->p2_wacn != 0 && state->p2_sysid != 0 && state->p2_cc != 0 && state->p2_wacn != 0xFFFFF
+           && state->p2_sysid != 0xFFF && state->p2_cc != 0xFFF;
+}
+
+// Defer TDMA grants until the site identity needed to seed the descrambler is
+// known. Runs before anything is released or retuned, so a deferred grant
+// leaves the receiver parked on the CC; grants repeat there, and NET_STS_BCST
+// cycles every few seconds, so the deferral self-resolves.
+static int
+p25_grant_deferred_for_tdma_site(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev,
+                                 const p25_grant_route_ctx_t* grant) {
+    if (!ctx || !state || !ev || !grant) {
+        return 0;
+    }
+    if (!is_tdma_channel(state, ev->channel) || p25_grant_tdma_site_known(state)) {
+        return 0;
+    }
+    p25_sm_diagf(opts, state, ctx, "grant_tdma_site_defer",
+                 "ch=0x%04X freq=%ld slot=%d target=%d wacn=0x%05llX sysid=0x%03llX nac=0x%03llX", ev->channel & 0xFFFF,
+                 grant->freq, grant->slot, grant->target_id, state->p2_wacn, state->p2_sysid, state->p2_cc);
+    sm_log(opts, state, "grant-tdma-site-defer");
+    return 1;
+}
+
 static int
 p25_grant_blocked_by_pending_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev,
                                 const p25_grant_route_ctx_t* grant) {
@@ -2436,6 +2466,9 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     }
 
     if (!p25_grant_prepare_route(ctx, opts, state, ev, &decision, &eval_ctx, &grant)) {
+        return;
+    }
+    if (p25_grant_deferred_for_tdma_site(ctx, opts, state, ev, &grant)) {
         return;
     }
     if (p25_grant_blocked_by_pending_cc(ctx, opts, state, ev, &grant)) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6536,6 +6536,24 @@ target_include_directories(
 target_link_libraries(dsd-neo_test_p25_sm_core PRIVATE dsd-neo_proto_p25)
 add_test(NAME P25_SM_CORE COMMAND dsd-neo_test_p25_sm_core)
 
+# P25 SM Phase 2 grant gating on decoded WACN/SYSID/NAC
+add_executable(
+    dsd-neo_test_p25_p2_grant_site_gate
+    protocol/p25/test_p25_p2_grant_site_gate.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p2_grant_site_gate
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_p25_p2_grant_site_gate
+    PRIVATE dsd-neo_proto_p25
+)
+add_test(
+    NAME P25_P2_GRANT_SITE_GATE
+    COMMAND dsd-neo_test_p25_p2_grant_site_gate
+)
+
 # P25 SM diagnostic log records
 add_executable(dsd-neo_test_p25_sm_diag_log protocol/p25/test_p25_sm_diag_log.c)
 target_include_directories(

--- a/tests/protocol/p25/test_p25_grant_policy.c
+++ b/tests/protocol/p25/test_p25_grant_policy.c
@@ -124,6 +124,11 @@ seed_tdma_iden(dsd_state* st, int id) {
     st->p25_iden_tdma[id].trust = 2;
     st->p25_iden_tdma[id].populated = 1;
     st->p25_chan_tdma_explicit[id] = 2;
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    st->p2_wacn = 0xBEE00;
+    st->p2_sysid = 0x1A2;
+    st->p2_cc = 0x293;
 }
 
 static int

--- a/tests/protocol/p25/test_p25_hangtime_arm_rules.c
+++ b/tests/protocol/p25/test_p25_hangtime_arm_rules.c
@@ -107,6 +107,11 @@ start_tuned_tdma(void) {
     g_state.trunk_chan_map[TDMA_CH_SLOT0] = TDMA_VC_FREQ;
     g_state.trunk_chan_map[TDMA_CH_SLOT1] = TDMA_VC_FREQ;
     g_state.p25_chan_tdma_explicit[1] = 2;
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    g_state.p2_wacn = 0xBEE00;
+    g_state.p2_sysid = 0x1A2;
+    g_state.p2_cc = 0x293;
     p25_sm_init_ctx(ctx, &g_opts, &g_state);
     g_opts.trunk_is_tuned = 1;
     p25_sm_event_t grant = p25_sm_ev_group_grant(TDMA_CH_SLOT0, TDMA_VC_FREQ, CLEAR_TG, CLEAR_SRC, 0);

--- a/tests/protocol/p25/test_p25_mbt_decode.c
+++ b/tests/protocol/p25/test_p25_mbt_decode.c
@@ -166,6 +166,11 @@ seed_tdma_iden(dsd_state* state, int iden) {
     state->p25_iden_tdma[iden].trust = 2;
     state->p25_iden_tdma[iden].populated = 1;
     state->p25_chan_tdma_explicit[iden] = 2;
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    state->p2_wacn = 0xBEE00;
+    state->p2_sysid = 0x1A2;
+    state->p2_cc = 0x293;
 }
 
 static void

--- a/tests/protocol/p25/test_p25_p1_trunk_sm.c
+++ b/tests/protocol/p25/test_p25_p1_trunk_sm.c
@@ -128,6 +128,7 @@ main(int argc, char** argv) {
     state.p25_iden_tdma[iden].trust = 2;
     state.p25_iden_tdma[iden].populated = 1;
     state.p25_chan_tdma_explicit[iden] = 2; // TDMA known
+    state.p2_cc = 0x293;                    // NAC completes the TDMA descrambler seed
     int channel = (iden << 12) | 0x0001;    // low bit = 1 → slot 1
     int svc = 0;                            // service bits not used here
     int tg = 1234;

--- a/tests/protocol/p25/test_p25_p2_active_ptt_epoch.c
+++ b/tests/protocol/p25/test_p25_p2_active_ptt_epoch.c
@@ -151,6 +151,11 @@ tune_grant(int svc) {
     p25_sm_ctx_t* ctx = p25_sm_get_ctx();
     g_state.trunk_chan_map[0x1234] = 851500000;
     g_state.p25_chan_tdma_explicit[1] = 2;
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    g_state.p2_wacn = 0xBEE00;
+    g_state.p2_sysid = 0x1A2;
+    g_state.p2_cc = 0x293;
     g_opts.trunk_is_tuned = 1;
     p25_sm_event_t grant = p25_sm_ev_group_grant(0x1234, 851500000, TEST_TG, TEST_SRC, svc);
     p25_sm_event(ctx, &g_opts, &g_state, &grant);

--- a/tests/protocol/p25/test_p25_p2_enc_lockout_hangtime_release.c
+++ b/tests/protocol/p25/test_p25_p2_enc_lockout_hangtime_release.c
@@ -93,6 +93,11 @@ start_tuned_tdma(void) {
     g_state.trunk_chan_map[0x1234] = VC_FREQ;
     g_state.trunk_chan_map[0x1235] = VC_FREQ;
     g_state.p25_chan_tdma_explicit[1] = 2;
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    g_state.p2_wacn = 0xBEE00;
+    g_state.p2_sysid = 0x1A2;
+    g_state.p2_cc = 0x293;
     p25_sm_init_ctx(ctx, &g_opts, &g_state);
     g_opts.trunk_is_tuned = 1;
     p25_sm_event_t grant = p25_sm_ev_group_grant(0x1234, VC_FREQ, CLEAR_TG, CLEAR_SRC, 0);

--- a/tests/protocol/p25/test_p25_p2_grant_site_gate.c
+++ b/tests/protocol/p25/test_p25_p2_grant_site_gate.c
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/* A Phase 2 TDMA voice channel cannot be descrambled until WACN/SYSID/NAC are
+ * known, so the trunk SM must defer TDMA grants until those are valid instead
+ * of burning the grant-voice timeout on an undecodable carrier. FDMA grants
+ * carry no such dependency and must tune regardless. */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+static int g_tune_to_freq_calls = 0;
+static long g_last_tuned_vc = 0;
+
+static dsd_trunk_tune_result
+tune_to_freq_stub(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps, uint64_t request_id) {
+    (void)request_id;
+    (void)ted_sps;
+    g_tune_to_freq_calls++;
+    g_last_tuned_vc = freq;
+    if (opts) {
+        opts->trunk_is_tuned = 1;
+    }
+    if (state) {
+        state->p25_vc_freq[0] = state->p25_vc_freq[1] = freq;
+        state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = freq;
+    }
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static void
+install_hooks(void) {
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_freq_request = tune_to_freq_stub;
+    dsd_trunk_tuning_hooks_set(hooks);
+}
+
+static void
+init_case(dsd_opts* o, dsd_state* s) {
+    DSD_MEMSET(o, 0, sizeof(*o));
+    DSD_MEMSET(s, 0, sizeof(*s));
+    o->trunk_enable = 1;
+    o->trunk_tune_group_calls = 1;
+    s->p25_cc_freq = 851000000;
+    s->trunk_cc_freq = 851000000;
+}
+
+static void
+setup_tdma_iden(dsd_state* s, int id) {
+    s->p25_chan_iden = id;
+    s->p25_iden_tdma[id].base_freq = 851000000 / 5;
+    s->p25_iden_tdma[id].chan_type = 3;
+    s->p25_iden_tdma[id].chan_spac = 100;
+    s->p25_iden_tdma[id].trust = 2;
+    s->p25_iden_tdma[id].populated = 1;
+    s->p25_chan_tdma_explicit[id] = 2;
+}
+
+static void
+setup_fdma_iden(dsd_state* s, int id) {
+    s->p25_chan_iden = id;
+    s->p25_iden_fdma[id].base_freq = 851000000 / 5;
+    s->p25_iden_fdma[id].chan_type = 1;
+    s->p25_iden_fdma[id].chan_spac = 100;
+    s->p25_iden_fdma[id].trust = 2;
+    s->p25_iden_fdma[id].populated = 1;
+    s->p25_chan_tdma_explicit[id] = 1;
+}
+
+static void
+seed_valid_site(dsd_state* s) {
+    s->p2_wacn = 0xBEE00;
+    s->p2_sysid = 0x1A2;
+    s->p2_cc = 0x293;
+}
+
+static p25_sm_event_t
+group_grant_event(int channel) {
+    p25_sm_event_t ev;
+    DSD_MEMSET(&ev, 0, sizeof(ev));
+    ev.type = P25_SM_EV_GRANT;
+    ev.channel = channel;
+    ev.tg = 1234;
+    ev.src = 42;
+    ev.is_group = 1;
+    return ev;
+}
+
+int
+main(void) {
+    install_hooks();
+
+    const int id = 1;
+    const int tdma_ch = (id << 12) | 0x000A;
+    const int fdma_ch = (id << 12) | 0x000A;
+
+    // 1) TDMA grant before WACN/SYSID/NAC are known: deferred, nothing tuned.
+    static dsd_opts o1;
+    static dsd_state s1;
+    init_case(&o1, &s1);
+    setup_tdma_iden(&s1, id);
+    p25_sm_ctx_t ctx1;
+    p25_sm_init_ctx(&ctx1, &o1, &s1);
+    p25_sm_event_t ev = group_grant_event(tdma_ch);
+    g_tune_to_freq_calls = 0;
+    p25_sm_event(&ctx1, &o1, &s1, &ev);
+    assert(g_tune_to_freq_calls == 0);
+    assert(o1.trunk_is_tuned == 0);
+    assert(s1.p25_vc_freq[0] == 0);
+    assert(ctx1.state != P25_SM_TUNED);
+    assert(s1.p25_sm_tune_count == 0);
+
+    // 2) Same grant after the site identity is decoded: tunes normally.
+    seed_valid_site(&s1);
+    p25_sm_event(&ctx1, &o1, &s1, &ev);
+    assert(g_tune_to_freq_calls == 1);
+    assert(o1.trunk_is_tuned == 1);
+    assert(ctx1.state == P25_SM_TUNED);
+
+    // 3) Placeholder site identity (all-ones broadcast values) is not valid:
+    //    still deferred.
+    static dsd_opts o2;
+    static dsd_state s2;
+    init_case(&o2, &s2);
+    setup_tdma_iden(&s2, id);
+    s2.p2_wacn = 0xFFFFF;
+    s2.p2_sysid = 0xFFF;
+    s2.p2_cc = 0xFFF;
+    p25_sm_ctx_t ctx2;
+    p25_sm_init_ctx(&ctx2, &o2, &s2);
+    g_tune_to_freq_calls = 0;
+    p25_sm_event(&ctx2, &o2, &s2, &ev);
+    assert(g_tune_to_freq_calls == 0);
+    assert(ctx2.state != P25_SM_TUNED);
+
+    // 4) FDMA grant with an unknown site identity: no descrambler dependency,
+    //    tunes immediately.
+    static dsd_opts o3;
+    static dsd_state s3;
+    init_case(&o3, &s3);
+    setup_fdma_iden(&s3, id);
+    p25_sm_ctx_t ctx3;
+    p25_sm_init_ctx(&ctx3, &o3, &s3);
+    p25_sm_event_t ev_fdma = group_grant_event(fdma_ch);
+    g_tune_to_freq_calls = 0;
+    p25_sm_event(&ctx3, &o3, &s3, &ev_fdma);
+    assert(g_tune_to_freq_calls == 1);
+    assert(ctx3.state == P25_SM_TUNED);
+
+    return 0;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/protocol/p25/test_p25_p2_hangtime_events.c
+++ b/tests/protocol/p25/test_p25_p2_hangtime_events.c
@@ -100,6 +100,11 @@ start_tuned_tdma_src(int grant_src) {
     p25_sm_ctx_t* ctx = p25_sm_get_ctx();
     g_state.trunk_chan_map[0x1234] = 851500000;
     g_state.p25_chan_tdma_explicit[1] = 2;
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    g_state.p2_wacn = 0xBEE00;
+    g_state.p2_sysid = 0x1A2;
+    g_state.p2_cc = 0x293;
     p25_sm_init_ctx(ctx, &g_opts, &g_state);
     g_opts.trunk_is_tuned = 1;
     p25_sm_event_t grant = p25_sm_ev_group_grant(0x1234, 851500000, TEST_TG, grant_src, 0);

--- a/tests/protocol/p25/test_p25_p2_release_partial_audio.c
+++ b/tests/protocol/p25/test_p25_p2_release_partial_audio.c
@@ -183,6 +183,11 @@ main(void) {
     st.p25_iden_tdma[id].trust = 2;
     st.p25_iden_tdma[id].populated = 1;
     st.p25_chan_tdma_explicit[id] = 2; // TDMA known
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    st.p2_wacn = 0xBEE00;
+    st.p2_sysid = 0x1A2;
+    st.p2_cc = 0x293;
     st.event_history_s = event_history;
 
     p25_sm_init_ctx(p25_sm_get_ctx(), &opts, &st);

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -253,6 +253,11 @@ seed_tdma_iden(dsd_state* state, int iden, int type, long base, int spac) {
     state->p25_iden_tdma[iden].trust = 2;
     state->p25_iden_tdma[iden].populated = 1;
     state->p25_chan_tdma_explicit[iden] = 2;
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    state->p2_wacn = 0xBEE00;
+    state->p2_sysid = 0x1A2;
+    state->p2_cc = 0x293;
 }
 
 static int

--- a/tests/protocol/p25/test_p25_reassignment.c
+++ b/tests/protocol/p25/test_p25_reassignment.c
@@ -87,6 +87,11 @@ init_case(dsd_opts* opts, dsd_state* state, p25_sm_ctx_t* ctx) {
     state->p25_iden_tdma[id].trust = 2;
     state->p25_iden_tdma[id].populated = 1;
     state->p25_chan_tdma_explicit[id] = 2;
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    state->p2_wacn = 0xBEE00;
+    state->p2_sysid = 0x1A2;
+    state->p2_cc = 0x293;
     p25_sm_init_ctx(ctx, opts, state);
     g_tune_calls = 0;
     g_return_calls = 0;

--- a/tests/protocol/p25/test_p25_sm_core.c
+++ b/tests/protocol/p25/test_p25_sm_core.c
@@ -259,6 +259,11 @@ setup_tdma_iden(dsd_state* s, int id) {
     s->p25_iden_tdma[id].trust = 2;
     s->p25_iden_tdma[id].populated = 1;
     s->p25_chan_tdma_explicit[id] = 2;
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    s->p2_wacn = 0xBEE00;
+    s->p2_sysid = 0x1A2;
+    s->p2_cc = 0x293;
 }
 
 static void
@@ -2130,6 +2135,9 @@ main(void) {
     s19.p25_iden_fdma[id9].trust = 2;
     s19.p25_iden_fdma[id9].populated = 1;
     s19.p25_chan_tdma_explicit[id9] = 2;
+    s19.p2_wacn = 0xBEE00; // TDMA grants need the decoded descrambler seed
+    s19.p2_sysid = 0x1A2;
+    s19.p2_cc = 0x293;
     s19.p25_vc_cqpsk_pref = -1;
     (void)dsd_unsetenv("DSD_NEO_CQPSK");
     dsd_neo_config_init();
@@ -2178,6 +2186,9 @@ main(void) {
     s20.p25_iden_fdma[id9].trust = 2;
     s20.p25_iden_fdma[id9].populated = 1;
     s20.p25_chan_tdma_explicit[id9] = 2;
+    s20.p2_wacn = 0xBEE00; // TDMA grants need the decoded descrambler seed
+    s20.p2_sysid = 0x1A2;
+    s20.p2_cc = 0x293;
     s20.p25_vc_cqpsk_pref = -1;
     (void)dsd_unsetenv("DSD_NEO_CQPSK");
     dsd_neo_config_init();

--- a/tests/protocol/p25/test_p25_sm_diag_log.c
+++ b/tests/protocol/p25/test_p25_sm_diag_log.c
@@ -153,6 +153,11 @@ seed_tdma_iden(dsd_state* state, int iden) {
     state->p25_iden_tdma[iden].trust = 2;
     state->p25_iden_tdma[iden].populated = 1;
     state->p25_chan_tdma_explicit[iden] = 2;
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    state->p2_wacn = 0xBEE00;
+    state->p2_sysid = 0x1A2;
+    state->p2_cc = 0x293;
 }
 
 static int

--- a/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
+++ b/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
@@ -291,6 +291,10 @@ matrix_setup_fixture(matrix_fixture* fixture, const matrix_mode_case* mode) {
     fixture->state->p25_last_cc_msg_time_m = now_m;
     fixture->state->nac = 0x293;
     fixture->state->p2_cc = 0x293;
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    fixture->state->p2_wacn = 0xBEE00;
+    fixture->state->p2_sysid = 0x1A2;
     fixture->state->synctype = mode->synctype;
     fixture->state->lastsynctype = mode->synctype;
     fixture->state->p25_cc_is_tdma = mode->cc_is_tdma;

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -71,6 +71,11 @@ reset_test_state(void) {
     g_opts.trunk_tune_group_calls = 1;
     g_opts.verbose = 0;
     g_state.p25_cc_freq = 851000000; // Fake CC freq
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    g_state.p2_wacn = 0xBEE00;
+    g_state.p2_sysid = 0x1A2;
+    g_state.p2_cc = 0x293;
 }
 
 static int

--- a/tests/protocol/p25/test_p25_trunk_sm_timing.c
+++ b/tests/protocol/p25/test_p25_trunk_sm_timing.c
@@ -84,6 +84,12 @@ setup_tdma_grant(dsd_state* st, int* out_channel) {
     st->p25_iden_tdma[id_t].populated = 1;
     st->p25_chan_tdma_explicit[id_t] = 2; // TDMA known
 
+    // The SM defers TDMA grants until the descrambler seed (WACN/SYSID/NAC)
+    // has been decoded from the control channel.
+    st->p2_wacn = 0xBEE00;
+    st->p2_sysid = 0x1A2;
+    st->p2_cc = 0x293;
+
     // Odd channel low bit -> slot 1
     *out_channel = (id_t << 12) | 0x0001;
 }


### PR DESCRIPTION
## Summary

The TDMA burst descrambler is seeded from WACN/SYSID/NAC, but the trunk SM tuned Phase 2 voice grants without checking that those have been decoded yet. A grant received during initial CC acquisition, before the Network Status Broadcast, tuned a voice channel that could not be descrambled and burned the grant-voice timeout (default 3 s) before recovering to the control channel; on a busy Phase 2 system the first seconds after site lock could thrash this way repeatedly.

This gates TDMA grants in `handle_grant()` **before anything is released or retuned**: an undecodable grant is simply deferred, leaving the receiver parked on the CC where grants repeat and NET_STS_BCST cycles every few seconds, so the deferral self-resolves. Because the gate sits in the SM, it covers every grant source (TSBK, MBT, MAC VPDU, LCW). FDMA grants are unaffected, and a decoded (or user-seeded via `-X`/menu) site identity passes the gate unchanged. The validity predicate mirrors the one the Phase 2 frame decoder already uses (0 and the all-ones broadcast placeholders mean "not yet known").

A `grant_tdma_site_defer` diag record and `grant-tdma-site-defer` SM log entry make the deferral observable.

## Testing

- New `P25_P2_GRANT_SITE_GATE` regression test (watched fail before the gate landed): TDMA grant with unknown site identity is deferred; the same grant tunes once WACN/SYSID/NAC are known; placeholder (all-ones) identity still defers; FDMA grants tune regardless.
- Existing SM tests that issue TDMA grants now seed the site identity in their fixtures, matching a receiver that is actually decoding the CC.
- Full suite: 520/520 pass (`dev-debug`), including the `iq-decode` regressions; `tools/preflight_ci.sh` clean.