### PR TITLE
p25: render the FEC telemetry the decoder was already counting, drop the dead knobs

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -890,20 +890,6 @@ struct dsd_state {
     // Monotonic confirmation ticket handed to each armed/refreshed entry; the
     // eviction LRU orders on this rather than on one-second wall clock.
     uint64_t enc_lockout_seq;
-    // Cached P25 SM tunables (seconds), resolved once at p25_sm_init_ctx()
-    double p25_cfg_vc_grace_s;
-    double p25_cfg_grant_voice_to_s;
-    double p25_cfg_min_follow_dwell_s;
-    double p25_cfg_mac_hold_s;
-    double p25_cfg_cc_grace_s;
-    double p25_cfg_ring_hold_s;        // seconds to honor audio ring after recent MAC
-    double p25_cfg_force_rel_extra_s;  // safety-net extra seconds beyond hang
-    double p25_cfg_force_rel_margin_s; // safety-net hard margin seconds beyond extra
-    double p25_cfg_tail_ms;            // P2 tail wait in ms before early release
-    double p25_cfg_p1_tail_ms;         // P1 tail wait in ms before early release
-    double p25_cfg_p1_err_hold_pct;    // P1 elevated-error threshold percentage
-    double p25_cfg_p1_err_hold_s;      // P1 elevated-error additional hold seconds
-
     // P25 Phase 1 control/data channel FEC/CRC telemetry (for BER display)
     // NOTE: This does not reflect IMBE voice quality. Voice frames have their own
     // Golay/Hamming/RS protection and IMBE ECC; see P1 Voice metrics and
@@ -1073,12 +1059,8 @@ struct dsd_state {
 
     //dmr trunking stuff
     int dmr_rest_channel;
-    int dmr_mfid; //just when 'fid' is used as a manufacturer ID and not a feature set id
-    int dmr_vc_lcn;
-    int dmr_vc_lsn;
-    int dmr_tuned_lcn;
-    uint16_t dmr_cc_lpcn; //dmr t3 logical physical channel number
-    uint32_t tg_hold;     //single TG to hold on when enabled
+    int dmr_mfid;     //just when 'fid' is used as a manufacturer ID and not a feature set id
+    uint32_t tg_hold; //single TG to hold on when enabled
 
     //edacs
     int ea_mode;

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -942,7 +942,6 @@ init_state_nxdn_and_dmr_defaults(dsd_state* state) {
     //dmr trunking/ncurses stuff
     state->dmr_rest_channel = -1; //init on -1
     state->dmr_mfid = -1;         //
-    state->dmr_cc_lpcn = 0;
     state->tg_hold = 0;
 
     //new nxdn stuff

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -682,7 +682,13 @@ dmr_flco_publish_voice(dmr_flco_ctx* ctx) {
         .ota_target_id = ctx->target,
         .policy_target_id = ctx->target,
         .ota_source_id = ctx->source,
-        .channel = (uint32_t)(ctx->state->dmr_vc_lsn > 0 ? ctx->state->dmr_vc_lsn : ctx->state->dmr_vc_lcn),
+        /*
+         * No channel: the embedded LC carries none. The DMR trunk SM owns this
+         * field and publishes the tuned LPCN from the grant that sent us here
+         * (handle_voice_sync() in dmr_trunk_sm.c), and dsd_call_state_observe()
+         * leaves a previously observed channel alone when an observation omits
+         * one, so saying nothing here is what preserves the SM's value.
+         */
         .frequency_hz = ctx->state->trunk_vc_freq[ctx->slot],
         .service_options = ctx->so,
         .emergency = (uint8_t)((ctx->so & 0x80U) != 0U),

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -1138,11 +1138,8 @@ p25p2_ess_decode(dsd_state* state) {
 }
 
 static double
-p25p2_frame_mac_hold_s(const dsd_state* state, double fallback) {
+p25p2_frame_mac_hold_s(double fallback) {
     const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
-    if (state->p25_cfg_mac_hold_s > 0.0) {
-        return state->p25_cfg_mac_hold_s;
-    }
     if (cfg && cfg->p25_mac_hold_is_set) {
         return cfg->p25_mac_hold_s;
     }
@@ -1150,11 +1147,8 @@ p25p2_frame_mac_hold_s(const dsd_state* state, double fallback) {
 }
 
 static double
-p25p2_frame_vc_grace_s(const dsd_state* state, double fallback) {
+p25p2_frame_vc_grace_s(double fallback) {
     const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
-    if (state->p25_cfg_vc_grace_s > 0.0) {
-        return state->p25_cfg_vc_grace_s;
-    }
     if (cfg && cfg->p25_vc_grace_is_set) {
         return cfg->p25_vc_grace_s;
     }
@@ -1540,13 +1534,13 @@ p25p2_duid_compute_pending_release(dsd_opts* opts, dsd_state* state, time_t now)
         return 0;
     }
 
-    double vc_grace = p25p2_frame_vc_grace_s(state, 0.75);
+    double vc_grace = p25p2_frame_vc_grace_s(0.75);
     double dt_since_tune = (state->p25_last_vc_tune_time != 0) ? (double)(now - state->p25_last_vc_tune_time) : 1e9;
     if (dt_since_tune < vc_grace) {
         return 0;
     }
 
-    double mac_hold = p25p2_frame_mac_hold_s(state, 0.75);
+    double mac_hold = p25p2_frame_mac_hold_s(0.75);
     int left_mac_active = (state->p25_p2_last_mac_active_m[0] > 0.0)
                           && (dsd_time_now_monotonic_s() - state->p25_p2_last_mac_active_m[0]) <= mac_hold;
     int right_mac_active = (state->p25_p2_last_mac_active_m[1] > 0.0)
@@ -1720,7 +1714,7 @@ p25p2_duid_fallback_release(dsd_opts* opts, dsd_state* state) {
     int no_recent_voice = (state->last_vc_sync_time != 0) && ((now2 - state->last_vc_sync_time) > opts->trunk_hangtime);
     int both_slots_idle = (state->p25_p2_audio_allowed[0] == 0 && state->p25_p2_audio_allowed[1] == 0);
     double dt_since_tune = (state->p25_last_vc_tune_time != 0) ? (double)(now2 - state->p25_last_vc_tune_time) : 1e9;
-    double vc_grace = p25p2_frame_vc_grace_s(state, 0.75);
+    double vc_grace = p25p2_frame_vc_grace_s(0.75);
     if (no_recent_voice && both_slots_idle && dt_since_tune >= vc_grace) {
         state->p25_sm_force_release = 1;
         p25p2_teardown_call(opts, state);

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -905,11 +905,8 @@ p25p2_vpdu_gate_slot_audio(dsd_state* state, int slot) {
 }
 
 static double
-p25p2_vpdu_cfg_mac_hold_s(const dsd_state* state, double fallback) {
+p25p2_vpdu_cfg_mac_hold_s(double fallback) {
     const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
-    if (state && state->p25_cfg_mac_hold_s > 0.0) {
-        return state->p25_cfg_mac_hold_s;
-    }
     if (cfg && cfg->p25_mac_hold_is_set) {
         return cfg->p25_mac_hold_s;
     }
@@ -926,11 +923,8 @@ p25p2_vpdu_cfg_voice_hold_s(double fallback) {
 }
 
 static double
-p25p2_vpdu_cfg_vc_grace_s(const dsd_state* state, double fallback) {
+p25p2_vpdu_cfg_vc_grace_s(double fallback) {
     const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
-    if (state->p25_cfg_vc_grace_s > 0.0) {
-        return state->p25_cfg_vc_grace_s;
-    }
     if (cfg && cfg->p25_vc_grace_is_set) {
         return cfg->p25_vc_grace_s;
     }
@@ -971,7 +965,7 @@ p25p2_vpdu_other_slot_audio_with_history(const dsd_state* state, int slot, doubl
 
 static int
 p25p2_vpdu_force_release_after_grace(dsd_opts* opts, dsd_state* state) {
-    double vc_grace = p25p2_vpdu_cfg_vc_grace_s(state, 0.75);
+    double vc_grace = p25p2_vpdu_cfg_vc_grace_s(0.75);
     double nowm = dsd_time_now_monotonic_s();
     double dt_since_tune = (state->p25_last_vc_tune_time_m > 0.0) ? (nowm - state->p25_last_vc_tune_time_m) : 1e9;
     if (dt_since_tune < vc_grace) {
@@ -3437,7 +3431,7 @@ p25p2_vpdu_iter_block_44(p25p2_vpdu_ctx* ctx) {
         int resr2 = MAC[6 + len_a] >> 4;
         int cc = ((MAC[6 + len_a] & 0xF) << 8) | MAC[7 + len_a];
         int eslot = slot;
-        double mac_hold = p25p2_vpdu_cfg_mac_hold_s(state, 0.75);
+        double mac_hold = p25p2_vpdu_cfg_mac_hold_s(0.75);
         double voice_hold = p25p2_vpdu_cfg_voice_hold_s(0.75);
         int other_audio = 0;
         uint8_t released_slot = (uint8_t)(eslot & 1);

--- a/src/ui/terminal/ncurses_p25_display.c
+++ b/src/ui/terminal/ncurses_p25_display.c
@@ -450,6 +450,78 @@ ui_print_p1_header_metric(const dsd_state* state, int is_p25p1) {
     return 1;
 }
 
+/*
+ * Soft-decision rescues: frames the hard-decision decoders would have dropped.
+ * Zero is the healthy case and says nothing, so the row appears only once the
+ * soft path has actually saved something.
+ */
+static int
+ui_print_p1_soft_fec_metric(const dsd_state* state, int is_p25p1) {
+    if (!is_p25p1) {
+        return 0;
+    }
+    unsigned int any = state->p25_p1_soft_hamming_ok | state->p25_p1_soft_golay_ok | state->p25_p1_soft_rs_ok
+                       | state->p25_p1_soft_combined_ok;
+    if (any == 0) {
+        return 0;
+    }
+    printw("| P1 Soft FEC: Ham %u Golay %u RS %u Comb %u\n", state->p25_p1_soft_hamming_ok, state->p25_p1_soft_golay_ok,
+           state->p25_p1_soft_rs_ok, state->p25_p1_soft_combined_ok);
+    return 1;
+}
+
+/*
+ * NID BCH health. Parity overrides are reported apart from corrections because
+ * they are accepted final-parity mismatches, not corrected symbol errors.
+ */
+static int
+ui_print_p1_nid_metric(const dsd_state* state, int is_p25p1) {
+    if (!is_p25p1) {
+        return 0;
+    }
+    unsigned int any = state->nid_corrections_total | state->nid_failures_total | state->nid_parity_overrides;
+    if (any == 0) {
+        return 0;
+    }
+    printw("| P1 NID: corr %u fail %u parity %u\n", state->nid_corrections_total, state->nid_failures_total,
+           state->nid_parity_overrides);
+    return 1;
+}
+
+/*
+ * What the vocoder did with each accepted IMBE frame, which the FEC and BER rows
+ * above do not answer: a corrected frame was heard, a concealed one was not.
+ *
+ * Tagged "session" because, unlike every other row in this panel, these counters
+ * survive retune and no-carrier -- they are never reset for the life of the run.
+ */
+static int
+ui_print_p1_voice_frame_metric(const dsd_state* state, int is_p25p1) {
+    if (!is_p25p1 || state->p25_p1_accepted_frames == 0U) {
+        return 0;
+    }
+    printw("| P1 Frames (session): acc %llu (cln %llu cor %llu cnc %llu) fix %llu\n",
+           (unsigned long long)state->p25_p1_accepted_frames, (unsigned long long)state->p25_p1_clean_frames,
+           (unsigned long long)state->p25_p1_corrected_frames, (unsigned long long)state->p25_p1_concealed_frames,
+           (unsigned long long)state->p25_p1_accepted_corrections);
+    return 1;
+}
+
+/*
+ * Tail-erasure suppression is rare enough to earn its own row only when it has
+ * fired; folding it into the frame row above would pad every line for a case
+ * most runs never hit.
+ */
+static int
+ui_print_p1_tail_erasure_metric(const dsd_state* state, int is_p25p1) {
+    if (!is_p25p1 || state->p25_p1_suppressed_tail_frames == 0U) {
+        return 0;
+    }
+    printw("| P1 Tail (session): supp %llu excl %llu\n", (unsigned long long)state->p25_p1_suppressed_tail_frames,
+           (unsigned long long)state->p25_p1_excluded_tail_corrections);
+    return 1;
+}
+
 static int
 ui_print_p1_voice_percentile_metric(const dsd_state* state) {
     int n = state->p25_p1_voice_err_hist_len;
@@ -475,8 +547,12 @@ ui_print_p25_core_metrics(const dsd_state* state, int is_p25p1, int is_p25p2) {
     lines += ui_print_p1_voice_err_metric(state);
     lines += ui_print_p1_cc_fec_metric(state);
     lines += ui_print_p1_voice_fec_metric(state, is_p25p1);
+    lines += ui_print_p1_soft_fec_metric(state, is_p25p1);
+    lines += ui_print_p1_nid_metric(state, is_p25p1);
     lines += ui_print_p1_header_metric(state, is_p25p1);
     lines += ui_print_p1_voice_percentile_metric(state);
+    lines += ui_print_p1_voice_frame_metric(state, is_p25p1);
+    lines += ui_print_p1_tail_erasure_metric(state, is_p25p1);
     return lines;
 }
 
@@ -552,6 +628,22 @@ ui_print_p2_rs_metric(const dsd_state* state) {
     return lines;
 }
 
+/*
+ * Soft-decision recoveries on the Phase 2 side, counted where hard-decision RS
+ * would have failed. Max depth is the deepest erasure set the soft ESS decoder
+ * had to reach for, so it says how hard the channel is working the decoder.
+ */
+static int
+ui_print_p2_soft_fec_metric(const dsd_state* state) {
+    unsigned int any = state->p25_p2_soft_erasure_ok | state->p25_p2_soft_ess_ok;
+    if (any == 0) {
+        return 0;
+    }
+    printw("| P2 Soft FEC: erasure %u ESS %u (max depth %u)\n", state->p25_p2_soft_erasure_ok,
+           state->p25_p2_soft_ess_ok, state->p25_p2_soft_ess_max_depth);
+    return 1;
+}
+
 static int
 ui_print_p25p2_metrics(const dsd_opts* opts, const dsd_state* state, int is_p25p1, int is_p25p2) {
     if (!is_p25p2 && !(is_p25p1 && opts && opts->trunk_enable == 1)) {
@@ -561,6 +653,7 @@ ui_print_p25p2_metrics(const dsd_opts* opts, const dsd_state* state, int is_p25p
     lines += ui_print_p2_voice_avg_metric(state);
     lines += ui_print_p2_voice_percentile_metric(state);
     lines += ui_print_p2_rs_metric(state);
+    lines += ui_print_p2_soft_fec_metric(state);
     return lines;
 }
 

--- a/tests/protocol/p25/test_p25_p2_reliability.c
+++ b/tests/protocol/p25/test_p25_p2_reliability.c
@@ -401,6 +401,23 @@ set_p25p2_threshold(int threshold) {
     dsd_neo_config_init();
 }
 
+/*
+ * VC grace is resolved from the runtime config only. `seconds` must sit inside
+ * the config's own accepted range (0..10 s) or the knob reads as unset and the
+ * decoder falls back to its 0.75 s default, which would make a test silently
+ * measure the default instead of the value it asked for. Pass NULL to clear it
+ * again so the setting cannot leak into a later case.
+ */
+static void
+set_p25_vc_grace(const char* seconds) {
+    if (seconds) {
+        dsd_setenv("DSD_NEO_P25_VC_GRACE", seconds, 1);
+    } else {
+        (void)dsd_unsetenv("DSD_NEO_P25_VC_GRACE");
+    }
+    dsd_neo_config_init();
+}
+
 static void
 reset_ess_stubs(void) {
     g_ess_hard_rc = 0;
@@ -1244,10 +1261,17 @@ test_duid_lcch_release_defers_during_vc_grace(void) {
     opts.trunk_hangtime = 1;
     state.currentslot = 0;
     state.last_vc_sync_time = now - 10;
-    state.p25_last_vc_tune_time = now;
-    state.p25_cfg_vc_grace_s = 60.0;
+    /*
+     * Tuned 5 s ago against a 10 s grace. The offset is deliberately larger than
+     * the 0.75 s built-in default: tuning "now" would defer the release under
+     * any grace at all, so the case would pass even if the configured value
+     * never reached the decoder, which is exactly the bug this wiring can have.
+     */
+    state.p25_last_vc_tune_time = now - 5;
+    set_p25_vc_grace("10.0");
 
     p25p2_process_duid(&opts, &state);
+    set_p25_vc_grace(NULL);
 
     int rc = 0;
     rc |= expect_int("grace release force", state.p25_sm_force_release, 0);
@@ -1282,13 +1306,16 @@ test_duid_lcch_release_tears_down_after_vc_grace(void) {
     state.currentslot = 0;
     state.last_vc_sync_time = now - 10;
     state.p25_last_vc_tune_time = now - 10;
-    state.p25_cfg_vc_grace_s = 0.25;
     seed_teardown_dirty_state(&state);
     state.last_vc_sync_time = now - 10;
     state.p25_last_vc_tune_time = now - 10;
-    state.p25_cfg_vc_grace_s = 0.25;
+    /* Tuned 10 s ago, so a 0.25 s grace has long expired. Set after
+     * seed_teardown_dirty_state() only for symmetry with the case above; the
+     * grace now lives in the runtime config, which that helper does not touch. */
+    set_p25_vc_grace("0.25");
 
     p25p2_process_duid(&opts, &state);
+    set_p25_vc_grace(NULL);
 
     int rc = 0;
     rc |= expect_int("post-grace release consumed", state.p25_sm_force_release, 0);

--- a/tests/ui/test_ui_ncurses_p25_display_helpers.c
+++ b/tests/ui/test_ui_ncurses_p25_display_helpers.c
@@ -720,6 +720,79 @@ run_p2_gate_helper_cases(void) {
     return 0;
 }
 
+/*
+ * These four rows report counters that the decode path has always maintained but
+ * that nothing rendered. Each is gated on its own family being non-zero, so the
+ * zero case -- a clean signal, or a run that never decoded P25 -- must stay
+ * silent rather than print a row of zeros.
+ */
+static int
+run_soft_fec_and_nid_display_cases(void) {
+    static dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    /* Nothing decoded yet: every new row stays silent. */
+    reset_printw_capture();
+    assert(ui_print_p1_soft_fec_metric(&state, 1) == 0);
+    assert(ui_print_p1_nid_metric(&state, 1) == 0);
+    assert(ui_print_p1_voice_frame_metric(&state, 1) == 0);
+    assert(ui_print_p1_tail_erasure_metric(&state, 1) == 0);
+    assert(ui_print_p2_soft_fec_metric(&state) == 0);
+    assert(g_printw_capture[0] == '\0');
+
+    state.p25_p1_soft_hamming_ok = 3U;
+    state.p25_p1_soft_golay_ok = 5U;
+    state.p25_p1_soft_rs_ok = 7U;
+    state.p25_p1_soft_combined_ok = 9U;
+    reset_printw_capture();
+    assert(ui_print_p1_soft_fec_metric(&state, 1) == 1);
+    assert_capture_contains("| P1 Soft FEC: Ham 3 Golay 5 RS 7 Comb 9");
+    assert_capture_lines_fit(g_test_cols);
+
+    /* Not P25 Phase 1 right now: the row belongs to the P1 section only. */
+    reset_printw_capture();
+    assert(ui_print_p1_soft_fec_metric(&state, 0) == 0);
+    assert(g_printw_capture[0] == '\0');
+
+    state.nid_corrections_total = 11U;
+    state.nid_failures_total = 2U;
+    state.nid_parity_overrides = 1U;
+    reset_printw_capture();
+    assert(ui_print_p1_nid_metric(&state, 1) == 1);
+    assert_capture_contains("| P1 NID: corr 11 fail 2 parity 1");
+    assert_capture_lines_fit(g_test_cols);
+
+    state.p25_p1_accepted_frames = 4000U;
+    state.p25_p1_clean_frames = 3800U;
+    state.p25_p1_corrected_frames = 150U;
+    state.p25_p1_concealed_frames = 50U;
+    state.p25_p1_accepted_corrections = 900U;
+    reset_printw_capture();
+    assert(ui_print_p1_voice_frame_metric(&state, 1) == 1);
+    assert_capture_contains("| P1 Frames (session): acc 4000 (cln 3800 cor 150 cnc 50) fix 900");
+    assert_capture_lines_fit(g_test_cols);
+
+    /* Tail suppression is rare, so it earns a row only once it has fired. */
+    reset_printw_capture();
+    assert(ui_print_p1_tail_erasure_metric(&state, 1) == 0);
+    state.p25_p1_suppressed_tail_frames = 6U;
+    state.p25_p1_excluded_tail_corrections = 72U;
+    reset_printw_capture();
+    assert(ui_print_p1_tail_erasure_metric(&state, 1) == 1);
+    assert_capture_contains("| P1 Tail (session): supp 6 excl 72");
+    assert_capture_lines_fit(g_test_cols);
+
+    state.p25_p2_soft_erasure_ok = 12U;
+    state.p25_p2_soft_ess_ok = 4U;
+    state.p25_p2_soft_ess_max_depth = 5U;
+    reset_printw_capture();
+    assert(ui_print_p2_soft_fec_metric(&state) == 1);
+    assert_capture_contains("| P2 Soft FEC: erasure 12 ESS 4 (max depth 5)");
+    assert_capture_lines_fit(g_test_cols);
+
+    return 0;
+}
+
 int
 main(void) {
     run_iden_match_cases();
@@ -732,6 +805,7 @@ main(void) {
     run_p25_frequency_display_cases();
     run_service_metric_display_cases();
     run_p2_gate_helper_cases();
+    run_soft_fec_and_nid_display_cases();
     printf("UI_NCURSES_P25_DISPLAY_HELPERS: OK\n");
     return 0;
 }


### PR DESCRIPTION
Sixteen counters were incremented on the P25 decode path and read by nothing --
no panel row, no log line, no test. They are the answer to "is soft decision
actually saving my frames", and they were invisible.

The P25 metrics panel gains four rows for them. Each is gated on its own family
being non-zero, matching every other row there, so a clean signal or a run that
never decoded P25 prints nothing extra:

  P1 Soft FEC          Ham/Golay/RS/Comb rescues, where hard decoding failed
  P1 NID               BCH corrections, failures, accepted parity overrides
  P1 Frames (session)  accepted, and clean/corrected/concealed within it
  P1 Tail (session)    tail-erasure suppression, only once it has fired
  P2 Soft FEC          erasure and ESS recoveries, plus max erasure depth

The two "session" rows are tagged as such because, unlike everything else in
that panel, those counters survive retune and no-carrier.

Nothing is printed at exit: a summary there would be zeros for every non-P25
run, and the panel is where the rest of this telemetry already lives.

The twelve p25_cfg_* fields go the other way. state.h documented them as
"cached P25 SM tunables, resolved once at p25_sm_init_ctx()", but that function
never assigned any of them and neither did anything else. Ten were never read.
The two that were, p25_cfg_mac_hold_s and p25_cfg_vc_grace_s, gated first-tier
overrides at four sites that could not fire, so the runtime-config tier below
them always won. Caching was also the wrong shape to begin with: VC grace is
runtime-mutable from the terminal menu, so a value resolved once at init would
have gone stale. Behaviour is unchanged -- the dead tier is simply removed.

P25_P2_RELIABILITY drove VC grace by writing state->p25_cfg_vc_grace_s, which
means it drove the dead tier; it now sets DSD_NEO_P25_VC_GRACE and re-reads the
config, and clears it again so the value cannot leak into a later case. Test 29
tuned "now", so it passed under any grace at all, configured or defaulted --
it now tunes 5 s back against a 10 s grace, which fails against the 0.75 s
default. Verified by neutering the helper: test 29 fails, and the new panel
assertions fail against a mutated row.

Also drops four DMR fields that were never written anywhere in the project's
history: dmr_vc_lcn, dmr_vc_lsn, dmr_tuned_lcn, dmr_cc_lpcn. The first two fed
.channel in the FLCO voice observation, which therefore always published 0.
That was inert rather than harmful -- dsd_call_state_observe() ignores a zero
channel -- and the DMR trunk SM already publishes the real LPCN, so the field
is dropped with a comment recording who owns it.

ctest --preset dev-debug: 523/523 pass. tools/preflight_ci.sh clean.

Signed-off-by: arancormonk <180709949+arancormonk@users.noreply.github.com>